### PR TITLE
Make prompt preparation deterministic

### DIFF
--- a/dataset_builder/humaneval_to_d.py
+++ b/dataset_builder/humaneval_to_d.py
@@ -68,7 +68,7 @@ class Translator:
             arg_list = ", ".join(arg_names_and_types)
             return_type = self.translate_type(returns)
             self.func_type.append((return_type, ""))
-            libraries = "\n".join([f"import {lib};" for lib in self.require_libs])
+            libraries = "\n".join([f"import {lib};" for lib in sorted(self.require_libs)])
 
             return f"{libraries}\n{dlang_desc}{return_type} {name}({arg_list}) \n"
         except Exception as err:

--- a/dataset_builder/prepare_prompts_json.py
+++ b/dataset_builder/prepare_prompts_json.py
@@ -71,7 +71,7 @@ def main():
         sys.exit(1)
 
     results = [ ]
-    for original in list_originals(args.originals).values():
+    for original in sorted(list_originals(args.originals).values()):
         original_name = original.name.split(".")[0]
         print(f"Processing {original_name}...")
 

--- a/prompts/humaneval-cpp-keep.json
+++ b/prompts/humaneval-cpp-keep.json
@@ -1,1008 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nbool iscube(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nbool has_close_elements(std::vector<float> numbers, float threshold) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nstd::string encode(std::string message) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nlong solution(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nstd::string string_sequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nlong minSubArraySum(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nlong is_bored(std::string S) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nstd::vector<long> get_odd_collatz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nbool below_threshold(std::vector<long> l, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nbool any_int(float x, float y, float z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nlong x_or_y(long n, long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nbool triples_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nbool is_happy(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nstd::string file_name_check(std::string file_name) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nstd::map<std::string,long> histogram(std::string test) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nbool simplify(std::string x, std::string n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nstd::tuple<std::string, bool> reverse_delete(std::string s, std::string c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = reverse_delete;\n    assert(candidate((\"abcde\"), (\"ae\")) == (std::make_tuple(\"bcd\", false)));\n    assert(candidate((\"abcdef\"), (\"b\")) == (std::make_tuple(\"acdef\", false)));\n    assert(candidate((\"abcdedcba\"), (\"ab\")) == (std::make_tuple(\"cdedc\", true)));\n    assert(candidate((\"dwik\"), (\"w\")) == (std::make_tuple(\"dik\", false)));\n    assert(candidate((\"a\"), (\"a\")) == (std::make_tuple(\"\", true)));\n    assert(candidate((\"abcdedcba\"), (\"\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"abcdedcba\"), (\"v\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"vabba\"), (\"v\")) == (std::make_tuple(\"abba\", true)));\n    assert(candidate((\"mamma\"), (\"mia\")) == (std::make_tuple(\"\", true)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nlong skjkasdkd(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nstd::vector<std::string> all_prefixes(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nlong digits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nlong string_length(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nlong fibfib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nstd::vector<std::string> words_string(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nbool monotonic(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nstd::string fix_spaces(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nbool cycpattern_check(std::string a, std::string b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfloat truncate_number(float number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nstd::vector<long> parse_music(std::string music_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nstd::string remove_vowels(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nstd::vector<long> sort_third(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nstd::vector<long> count_up_to(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nlong max_element(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfloat triangle_area(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nstd::vector<long> unique(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nlong smallest_change(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nstd::vector<long> f(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nstd::string match_parens(std::vector<std::string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nbool is_equal_to_sum_even(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nlong largest_prime_factor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nstd::string encrypt(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nlong how_many_times(std::string string, std::string substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nstd::string solve(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nstd::vector<long> sort_even(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)-10, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)5, (long)0, (long)9, (long)1, (long)123})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)-12, (long)4, (long)23, (long)2, (long)3, (long)11, (long)12, (long)-10}))) == (std::vector<long>({(long)-12, (long)8, (long)3, (long)4, (long)5, (long)2, (long)12, (long)11, (long)23, (long)-10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nbool below_zero(std::vector<long> operations) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nbool same_chars(std::string s0, std::string s1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = same_chars;\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(candidate((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(candidate((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(candidate((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(candidate((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(candidate((\"aabb\"), (\"aaccc\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nlong count_upper(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nstd::vector<std::string> select_words(std::string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nstd::string find_max(std::vector<std::string> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nlong sum_squares(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nlong add(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nlong multiply(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nstd::vector<long> tri(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nbool is_simple_power(long x, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = has_close_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1012,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nstd::vector<long> make_a_pile(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = make_a_pile;\n    assert(candidate((3)) == (std::vector<long>({(long)3, (long)5, (long)7})));\n    assert(candidate((4)) == (std::vector<long>({(long)4, (long)6, (long)8, (long)10})));\n    assert(candidate((5)) == (std::vector<long>({(long)5, (long)7, (long)9, (long)11, (long)13})));\n    assert(candidate((6)) == (std::vector<long>({(long)6, (long)8, (long)10, (long)12, (long)14, (long)16})));\n    assert(candidate((8)) == (std::vector<long>({(long)8, (long)10, (long)12, (long)14, (long)16, (long)18, (long)20, (long)22})));\n}\n",
     "stop_tokens": [
@@ -1020,865 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nlong add(long x, long y) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nstd::vector<std::string> words_string(std::string s) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nstd::string decimal_to_binary(long decimal) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nbool is_palindrome(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nlong greatest_common_divisor(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nstd::vector<long> factorize(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nstd::string circular_shift(long x, long shift) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nstd::string get_closest_vowel(std::string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nstd::string sort_numbers(std::string numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nstd::string flip_case(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nlong can_arrange(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nbool is_nested(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nlong sum_to_n(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nstd::string concatenate(std::vector<std::string> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nlong sum_squares(std::vector<float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nstd::vector<long> sort_array(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6}))) == (std::vector<long>({(long)-4, (long)-2, (long)-6, (long)-5, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)77, (long)4, (long)5, (long)3, (long)5, (long)7, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)4, (long)4, (long)3, (long)3, (long)5, (long)5, (long)5, (long)7, (long)77})));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)44, (long)12, (long)32, (long)5}))) == (std::vector<long>({(long)32, (long)3, (long)5, (long)6, (long)12, (long)44})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nbool is_sorted(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nstd::tuple<long, long> even_odd_count(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nstd::vector<long> derivative(std::vector<long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nstd::string anti_shuffle(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nstd::string make_palindrome(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nstd::string change_base(long x, long base) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nbool prime_length(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nlong search(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nbool right_angle_triangle(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nlong fizz_buzz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nstd::vector<long> sort_array(std::vector<long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nlong vowels_count(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nstd::optional<std::string> string_to_md5(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nbool is_prime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nlong hex_key(std::string num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfloat median(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nlong specialFilter(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = specialFilter;\n    assert(candidate((std::vector<long>({(long)5, (long)-2, (long)1, (long)-5}))) == (0));\n    assert(candidate((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15}))) == (1));\n    assert(candidate((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109}))) == (2));\n    assert(candidate((std::vector<long>({(long)43, (long)-12, (long)93, (long)125, (long)121, (long)109}))) == (4));\n    assert(candidate((std::vector<long>({(long)71, (long)-2, (long)-33, (long)75, (long)21, (long)19}))) == (3));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>())) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nlong modp(long n, long p) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nlong prime_fib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nbool valid_date(std::string date) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nlong count_nums(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nlong digitSum(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfloat triangle_area(long a, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nlong fib4(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nstd::string string_xor(std::string a, std::string b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nbool has_close_elements(std::vector<float> numbers, float threshold) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = has_close_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nlong fruit_distribution(std::string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nlong largest_divisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nstd::string int_to_mini_roman(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nbool correct_bracketing(std::string brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nbool correct_bracketing(std::string brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"<>\")) == (true));\n    assert(candidate((\"<<><>>\")) == (true));\n    assert(candidate((\"<><><<><>><>\")) == (true));\n    assert(candidate((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(candidate((\"<<<><>>>>\")) == (false));\n    assert(candidate((\"><<>\")) == (false));\n    assert(candidate((\"<\")) == (false));\n    assert(candidate((\"<<<<\")) == (false));\n    assert(candidate((\">\")) == (false));\n    assert(candidate((\"<<>\")) == (false));\n    assert(candidate((\"<><><<><>><>><<>\")) == (false));\n    assert(candidate((\"<><><<><>><>>><>\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nlong fib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nstd::vector<long> incr_list(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nstd::vector<long> get_positive(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,7 +40,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// choose_num(12, 15) = 14\n// choose_num(13, 12) = -1\nlong choose_num(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
     "stop_tokens": [
@@ -1896,13 +48,793 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nstd::vector<long> f(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nlong count_nums(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nstd::string make_palindrome(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nstd::map<std::string,long> histogram(std::string test) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nstd::tuple<std::string, bool> reverse_delete(std::string s, std::string c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = reverse_delete;\n    assert(candidate((\"abcde\"), (\"ae\")) == (std::make_tuple(\"bcd\", false)));\n    assert(candidate((\"abcdef\"), (\"b\")) == (std::make_tuple(\"acdef\", false)));\n    assert(candidate((\"abcdedcba\"), (\"ab\")) == (std::make_tuple(\"cdedc\", true)));\n    assert(candidate((\"dwik\"), (\"w\")) == (std::make_tuple(\"dik\", false)));\n    assert(candidate((\"a\"), (\"a\")) == (std::make_tuple(\"\", true)));\n    assert(candidate((\"abcdedcba\"), (\"\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"abcdedcba\"), (\"v\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"vabba\"), (\"v\")) == (std::make_tuple(\"abba\", true)));\n    assert(candidate((\"mamma\"), (\"mia\")) == (std::make_tuple(\"\", true)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nlong minSubArraySum(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nstd::vector<long> sort_array(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6}))) == (std::vector<long>({(long)-4, (long)-2, (long)-6, (long)-5, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)77, (long)4, (long)5, (long)3, (long)5, (long)7, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)4, (long)4, (long)3, (long)3, (long)5, (long)5, (long)5, (long)7, (long)77})));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)44, (long)12, (long)32, (long)5}))) == (std::vector<long>({(long)32, (long)3, (long)5, (long)6, (long)12, (long)44})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nstd::vector<std::string> select_words(std::string s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nstd::string get_closest_vowel(std::string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nstd::string match_parens(std::vector<std::string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nstd::string string_xor(std::string a, std::string b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nlong solution(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nstd::vector<long> get_odd_collatz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nbool valid_date(std::string date) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nbool is_sorted(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nstd::vector<long> tri(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nlong digits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nbool is_nested(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nlong sum_squares(std::vector<float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nlong can_arrange(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nbool is_equal_to_sum_even(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nlong greatest_common_divisor(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nstd::string fix_spaces(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nstd::string file_name_check(std::string file_name) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nlong sum_squares(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nbool simplify(std::string x, std::string n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nlong specialFilter(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = specialFilter;\n    assert(candidate((std::vector<long>({(long)5, (long)-2, (long)1, (long)-5}))) == (0));\n    assert(candidate((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15}))) == (1));\n    assert(candidate((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109}))) == (2));\n    assert(candidate((std::vector<long>({(long)43, (long)-12, (long)93, (long)125, (long)121, (long)109}))) == (4));\n    assert(candidate((std::vector<long>({(long)71, (long)-2, (long)-33, (long)75, (long)21, (long)19}))) == (3));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>())) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nstd::vector<std::string> all_prefixes(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nlong x_or_y(long n, long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nstd::tuple<long, long> even_odd_count(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nstd::string int_to_mini_roman(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nstd::string find_max(std::vector<std::string> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nstd::string string_sequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nstd::string solve(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1912,7 +844,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// generate_integers(2, 8) => [2, 4, 6, 8]\n// generate_integers(8, 2) => [2, 4, 6, 8]\n// generate_integers(10, 14) => []\nstd::vector<long> generate_integers(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = generate_integers;\n    assert(candidate((2), (10)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((10), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((132), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((17), (89)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
@@ -1924,9 +856,1077 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters('xyzXYZ')\n// 3\n// >>> count_distinct_characters('Jerry')\n// 4\nlong count_distinct_characters(std::string string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nstd::vector<long> parse_music(std::string music_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nlong how_many_times(std::string string, std::string substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nstd::string sort_numbers(std::string numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nlong string_length(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nlong largest_divisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nstd::vector<long> factorize(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nstd::string flip_case(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfloat truncate_number(float number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nbool is_prime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nstd::vector<long> unique(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nlong max_element(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nlong fizz_buzz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nstd::vector<long> sort_even(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)-10, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)5, (long)0, (long)9, (long)1, (long)123})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)-12, (long)4, (long)23, (long)2, (long)3, (long)11, (long)12, (long)-10}))) == (std::vector<long>({(long)-12, (long)8, (long)3, (long)4, (long)5, (long)2, (long)12, (long)11, (long)23, (long)-10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nlong prime_fib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nbool below_zero(std::vector<long> operations) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nbool triples_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nstd::vector<long> incr_list(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nstd::string change_base(long x, long base) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfloat triangle_area(long a, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nlong fib4(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfloat median(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nbool is_palindrome(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nlong modp(long n, long p) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nstd::string remove_vowels(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nlong add(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nbool same_chars(std::string s0, std::string s1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = same_chars;\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(candidate((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(candidate((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(candidate((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(candidate((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(candidate((\"aabb\"), (\"aaccc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nlong fib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nbool correct_bracketing(std::string brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"<>\")) == (true));\n    assert(candidate((\"<<><>>\")) == (true));\n    assert(candidate((\"<><><<><>><>\")) == (true));\n    assert(candidate((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(candidate((\"<<<><>>>>\")) == (false));\n    assert(candidate((\"><<>\")) == (false));\n    assert(candidate((\"<\")) == (false));\n    assert(candidate((\"<<<<\")) == (false));\n    assert(candidate((\">\")) == (false));\n    assert(candidate((\"<<>\")) == (false));\n    assert(candidate((\"<><><<><>><>><<>\")) == (false));\n    assert(candidate((\"<><><<><>><>>><>\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nbool monotonic(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nlong largest_prime_factor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nlong sum_to_n(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nbool correct_bracketing(std::string brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nstd::vector<long> derivative(std::vector<long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nlong fibfib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nlong vowels_count(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nstd::string circular_shift(long x, long shift) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nlong digitSum(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nlong fruit_distribution(std::string s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nlong search(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfloat triangle_area(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nlong smallest_change(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nbool is_simple_power(long x, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nbool iscube(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nlong hex_key(std::string num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nstd::string decimal_to_binary(long decimal) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nbool is_happy(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nbool prime_length(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nlong add(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nstd::string anti_shuffle(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nstd::vector<long> sort_array(std::vector<long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nstd::string encrypt(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nlong is_bored(std::string S) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nbool any_int(float x, float y, float z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nstd::string encode(std::string message) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nlong skjkasdkd(std::vector<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nstd::vector<long> count_up_to(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nlong multiply(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nlong count_upper(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-cpp-remove.json
+++ b/prompts/humaneval-cpp-remove.json
@@ -1,1368 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\nlong string_length(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nstd::string encrypt(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nlong add(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nstd::string fix_spaces(std::string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nlong fibfib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nstd::vector<long> parse_music(std::string music_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nstd::string decimal_to_binary(long decimal) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\nstd::vector<std::string> all_prefixes(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\nlong add(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nstd::string flip_case(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nstd::vector<long> factorize(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nstd::vector<long> count_up_to(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\nstd::vector<long> unique(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\nlong max_element(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nbool is_nested(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nUnion_std_string_long rounded_avg(long n, long m) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nbool is_equal_to_sum_even(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nstd::vector<long> derivative(std::vector<long> xs) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nbool is_sorted(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nstd::string solve(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nstd::vector<long> tri(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nlong fizz_buzz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nlong count_upper(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\nlong largest_divisor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nstd::vector<long> sort_array(std::vector<long> array) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nstd::vector<long> f(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nbool iscube(long a) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nstd::string encode(std::string message) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nlong is_bored(std::string S) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfloat triangle_area(long a, long b, long c) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nlong digits(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nstd::vector<std::string> words_string(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nlong how_many_times(std::string string, std::string substring) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\nstd::string remove_vowels(std::string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nbool is_simple_power(long x, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nlong prime_fib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\nbool has_close_elements(std::vector<float> numbers, float threshold) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = has_close_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nstd::string make_palindrome(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nstd::string string_xor(std::string a, std::string b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nlong fib4(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nstd::vector<std::string> select_words(std::string s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\nlong fib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nstd::string match_parens(std::vector<std::string> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nbool any_int(float x, float y, float z) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfloat truncate_number(float number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\nstd::vector<long> incr_list(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nlong x_or_y(long n, long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\nlong modp(long n, long p) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nstd::tuple<long, long> even_odd_count(long num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nbool is_happy(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlong largest_prime_factor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nlong digitSum(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nlong solution(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\nfloat median(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nbool prime_length(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nlong smallest_change(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nlong sum_squares(std::vector<float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nstd::string file_name_check(std::string file_name) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nbool triples_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nbool valid_date(std::string date) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nlong count_nums(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nstd::string anti_shuffle(std::string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\nbool is_palindrome(std::string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nstd::string get_closest_vowel(std::string word) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\nbool is_prime(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nbool simplify(std::string x, std::string n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nlong hex_key(std::string num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nstd::map<std::string,long> histogram(std::string test) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nstd::vector<long> get_odd_collatz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nlong can_arrange(std::vector<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nstd::string sort_numbers(std::string numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nstd::string circular_shift(long x, long shift) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nlong sum_squares(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nlong skjkasdkd(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nlong choose_num(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nlong count_distinct_characters(std::string string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1372,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\nstd::vector<long> make_a_pile(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = make_a_pile;\n    assert(candidate((3)) == (std::vector<long>({(long)3, (long)5, (long)7})));\n    assert(candidate((4)) == (std::vector<long>({(long)4, (long)6, (long)8, (long)10})));\n    assert(candidate((5)) == (std::vector<long>({(long)5, (long)7, (long)9, (long)11, (long)13})));\n    assert(candidate((6)) == (std::vector<long>({(long)6, (long)8, (long)10, (long)12, (long)14, (long)16})));\n    assert(candidate((8)) == (std::vector<long>({(long)8, (long)10, (long)12, (long)14, (long)16, (long)18, (long)20, (long)22})));\n}\n",
     "stop_tokens": [
@@ -1380,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nstd::vector<std::string> words_string(std::string s) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nlong minSubArraySum(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nlong choose_num(long x, long y) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nstd::string string_sequence(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nUnion_std_string_long rounded_avg(long n, long m) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\nbool monotonic(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nstd::vector<long> f(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nlong count_nums(std::vector<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nstd::string make_palindrome(std::string string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\nfloat triangle_area(long a, long h) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nstd::map<std::string,long> histogram(std::string test) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nlong multiply(long a, long b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nstd::string int_to_mini_roman(long number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nlong fruit_distribution(std::string s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1588,7 +172,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\nstd::tuple<std::string, bool> reverse_delete(std::string s, std::string c) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = reverse_delete;\n    assert(candidate((\"abcde\"), (\"ae\")) == (std::make_tuple(\"bcd\", false)));\n    assert(candidate((\"abcdef\"), (\"b\")) == (std::make_tuple(\"acdef\", false)));\n    assert(candidate((\"abcdedcba\"), (\"ab\")) == (std::make_tuple(\"cdedc\", true)));\n    assert(candidate((\"dwik\"), (\"w\")) == (std::make_tuple(\"dik\", false)));\n    assert(candidate((\"a\"), (\"a\")) == (std::make_tuple(\"\", true)));\n    assert(candidate((\"abcdedcba\"), (\"\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"abcdedcba\"), (\"v\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"vabba\"), (\"v\")) == (std::make_tuple(\"abba\", true)));\n    assert(candidate((\"mamma\"), (\"mia\")) == (std::make_tuple(\"\", true)));\n}\n",
     "stop_tokens": [
@@ -1596,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\nlong greatest_common_divisor(long a, long b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nlong minSubArraySum(std::vector<long> nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +220,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\nstd::vector<long> sort_array(std::vector<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6}))) == (std::vector<long>({(long)-4, (long)-2, (long)-6, (long)-5, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)77, (long)4, (long)5, (long)3, (long)5, (long)7, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)4, (long)4, (long)3, (long)3, (long)5, (long)5, (long)5, (long)7, (long)77})));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)44, (long)12, (long)32, (long)5}))) == (std::vector<long>({(long)32, (long)3, (long)5, (long)6, (long)12, (long)44})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n}\n",
     "stop_tokens": [
@@ -1632,133 +228,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nstd::vector<std::string> select_words(std::string s, long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nstd::string get_closest_vowel(std::string word) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nstd::string match_parens(std::vector<std::string> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nstd::string string_xor(std::string a, std::string b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nlong vowels_count(std::string s) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nstd::string find_max(std::vector<std::string> words) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nlong solution(std::vector<long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nstd::string change_base(long x, long base) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nstd::vector<long> get_odd_collatz(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nbool valid_date(std::string date) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nbool is_sorted(std::vector<long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nstd::vector<long> tri(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nlong digits(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nbool is_nested(std::string string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nlong sum_squares(std::vector<float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nlong can_arrange(std::vector<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nbool is_equal_to_sum_even(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\nlong greatest_common_divisor(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nstd::string fix_spaces(std::string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nstd::string file_name_check(std::string file_name) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nlong sum_squares(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nbool simplify(std::string x, std::string n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +616,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\nlong specialFilter(std::vector<long> nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = specialFilter;\n    assert(candidate((std::vector<long>({(long)5, (long)-2, (long)1, (long)-5}))) == (0));\n    assert(candidate((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15}))) == (1));\n    assert(candidate((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109}))) == (2));\n    assert(candidate((std::vector<long>({(long)43, (long)-12, (long)93, (long)125, (long)121, (long)109}))) == (4));\n    assert(candidate((std::vector<long>({(long)71, (long)-2, (long)-33, (long)75, (long)21, (long)19}))) == (3));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>())) == (0));\n}\n",
     "stop_tokens": [
@@ -1776,25 +624,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\nlong sum_to_n(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\nstd::vector<std::string> all_prefixes(std::string string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nlong x_or_y(long n, long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nstd::tuple<long, long> even_odd_count(long num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nstd::string int_to_mini_roman(long number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nstd::string find_max(std::vector<std::string> words) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nstd::string string_sequence(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nstd::string solve(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +832,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\nstd::vector<long> generate_integers(long a, long b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = generate_integers;\n    assert(candidate((2), (10)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((10), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((132), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((17), (89)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
@@ -1812,49 +840,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nlong count_distinct_characters(std::string string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nbool below_zero(std::vector<long> operations) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nstd::vector<long> parse_music(std::string music_string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nlong search(std::vector<long> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nlong how_many_times(std::string string, std::string substring) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nbool correct_bracketing(std::string brackets) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nstd::string sort_numbers(std::string numbers) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\nlong string_length(std::string string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\nlong largest_divisor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nstd::vector<long> factorize(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nstd::string flip_case(std::string string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfloat truncate_number(float number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\nbool is_prime(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\nstd::vector<long> unique(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\nlong max_element(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nlong fizz_buzz(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1108,189 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\nstd::vector<long> sort_even(std::vector<long> l) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = sort_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)-10, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)5, (long)0, (long)9, (long)1, (long)123})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)-12, (long)4, (long)23, (long)2, (long)3, (long)11, (long)12, (long)-10}))) == (std::vector<long>({(long)-12, (long)8, (long)3, (long)4, (long)5, (long)2, (long)12, (long)11, (long)23, (long)-10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nlong prime_fib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nbool below_zero(std::vector<long> operations) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nbool triples_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\nstd::vector<long> incr_list(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nstd::string change_base(long x, long base) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\nfloat triangle_area(long a, long h) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nlong fib4(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\nfloat median(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\nbool is_palindrome(std::string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\nlong modp(long n, long p) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\nstd::string remove_vowels(std::string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\nlong add(long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if two words have the same characters.\nbool same_chars(std::string s0, std::string s1) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = same_chars;\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(candidate((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(candidate((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(candidate((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(candidate((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(candidate((\"aabb\"), (\"aaccc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\nlong fib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\nbool correct_bracketing(std::string brackets) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"<>\")) == (true));\n    assert(candidate((\"<<><>>\")) == (true));\n    assert(candidate((\"<><><<><>><>\")) == (true));\n    assert(candidate((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(candidate((\"<<<><>>>>\")) == (false));\n    assert(candidate((\"><<>\")) == (false));\n    assert(candidate((\"<\")) == (false));\n    assert(candidate((\"<<<<\")) == (false));\n    assert(candidate((\">\")) == (false));\n    assert(candidate((\"<<>\")) == (false));\n    assert(candidate((\"<><><<><>><>><<>\")) == (false));\n    assert(candidate((\"<><><<><>><>>><>\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\nbool monotonic(std::vector<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlong largest_prime_factor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\nlong sum_to_n(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nbool correct_bracketing(std::string brackets) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nstd::vector<long> derivative(std::vector<long> xs) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nlong fibfib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nlong vowels_count(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nstd::string circular_shift(long x, long shift) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nlong digitSum(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nlong fruit_distribution(std::string s, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nlong search(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfloat triangle_area(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nlong smallest_change(std::vector<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nbool is_simple_power(long x, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nbool iscube(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nlong hex_key(std::string num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nstd::string decimal_to_binary(long decimal) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nbool is_happy(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nbool prime_length(std::string string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nlong add(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nstd::string anti_shuffle(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nstd::vector<long> sort_array(std::vector<long> array) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nstd::string encrypt(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nlong is_bored(std::string S) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nbool any_int(float x, float y, float z) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nstd::string encode(std::string message) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nlong skjkasdkd(std::vector<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nstd::vector<long> count_up_to(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nlong multiply(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nlong count_upper(std::string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-cpp-reworded.json
+++ b/prompts/humaneval-cpp-reworded.json
@@ -1,1404 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> string_length((\"\"))\n// (0)\n// >>> string_length((\"abc\"))\n// (3)\nlong string_length(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt((\"hi\"))\n// (\"lm\")\n// >>> encrypt((\"asdfghjkl\"))\n// (\"ewhjklnop\")\n// >>> encrypt((\"gf\"))\n// (\"kj\")\n// >>> encrypt((\"et\"))\n// (\"ix\")\nstd::string encrypt(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a map, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given map is empty.\n// Examples:\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"b\", \"banana\"}})))\n// (true)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {8, \"banana\"}, {\"a\", \"apple\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})))\n// (true)\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add((std::vector<long>({(long)4, (long)2, (long)6, (long)7})))\n// (2)\nlong add(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces((\" Example\"))\n// (\"Example\")\n// >>> fix_spaces((\" Example 1\"))\n// (\"Example_1\")\n// >>> fix_spaces((\" Example 2\"))\n// (\"_Example_2\")\n// >>> fix_spaces((\" Example 3\"))\n// (\"_Example-3\")\nstd::string fix_spaces(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib((1))\n// (0)\n// >>> fibfib((5))\n// (4)\n// >>> fibfib((8))\n// (24)\nlong fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of numbers, return the sum of squares of the numbers\n// in the vector that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference((std::vector<float>({(long)1, (long)3, (long)2, (long)0})))\n// (10)\n// >>> double_the_difference((std::vector<float>({(long)-1, (long)-2, (long)0})))\n// (0)\n// >>> double_the_difference((std::vector<float>({(long)9, (long)-2})))\n// (81)\n// >>> double_the_difference((std::vector<float>({(long)0})))\n// (0)\n// If the input vector is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given vector of any cppthon values only for integers\n// >>> filter_integers((std::vector<std::any>({(std::string)\"a\", (std::string)3.14f, (std::string)5})))\n// (std::vector<long>({(long)5}))\n// >>> filter_integers((std::vector<std::any>({1, 2, 3, \"abc\", std::map<long,long>(), std::vector<long>()})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return vector of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music((\"o o| .| o| o| .| .| .| .| o o\"))\n// (std::vector<long>({(long)4, (long)2, (long)1, (long)2, (long)2, (long)1, (long)1, (long)1, (long)1, (long)4, (long)4}))\nstd::vector<long> parse_music(std::string music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary((15))\n// (\"db1111db\")\n// >>> decimal_to_binary((32))\n// (\"db100000db\")\nstd::string decimal_to_binary(long decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector of all prefixes from shortest to longest of the input string\n// >>> all_prefixes((\"abc\"))\n// (std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))\nstd::vector<std::string> all_prefixes(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add((2), (3))\n// (5)\n// >>> add((5), (7))\n// (12)\nlong add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return a vector of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat((5), (6), (10))\n// (std::vector<long>({(long)11, (long)4}))\n// >>> eat((4), (8), (9))\n// (std::vector<long>({(long)12, (long)1}))\n// >>> eat((1), (10), (10))\n// (std::vector<long>({(long)11, (long)0}))\n// >>> eat((2), (11), (5))\n// (std::vector<long>({(long)7, (long)0}))\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1))\n// (6)\n// Example 2:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2))\n// (5)\n// Example 3:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5))\n// (0)\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two vectors operator, and operand. The first vector has basic algebra operations, and \n// the second vector is a vector of integers. Use the two given vectors to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// vector = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator vector is equal to the length of operand vector minus one.\n// Operand is a vector of of non-negative integers.\n// Operator vector has at least one operator, and operand vector has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case((\"Hello\"))\n// (\"hELLO\")\nstd::string flip_case(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting vector, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3})))\n// (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"}))\n// If the vector is empty, return an empty vector:\n// >>> by_length((std::vector<long>()))\n// (std::vector<std::string>())\n// If the vector has any strange number ignore it:\n// >>> by_length((std::vector<long>({(long)1, (long)-1, (long)55})))\n// (std::vector<std::string>({(std::string)\"One\"}))\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize((8))\n// (std::vector<long>({(long)2, (long)2, (long)2}))\n// >>> factorize((25))\n// (std::vector<long>({(long)5, (long)5}))\n// >>> factorize((70))\n// (std::vector<long>({(long)2, (long)5, (long)7}))\nstd::vector<long> factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns a vector of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to((5))\n// (std::vector<long>({(long)2, (long)3}))\n// >>> count_up_to((11))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7}))\n// >>> count_up_to((0))\n// (std::vector<long>())\n// >>> count_up_to((20))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19}))\n// >>> count_up_to((1))\n// (std::vector<long>())\n// >>> count_up_to((18))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17}))\nstd::vector<long> count_up_to(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a vector\n// >>> unique((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123}))\nstd::vector<long> unique(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two vectors of strings and returns the vector that has \n// total number of chars in the all strings of the vector less than the other vector.\n// if the two vectors have the same number of chars, return the first vector.\n// Examples\n// >>> total_match((std::vector<std::string>()), (std::vector<std::string>()))\n// (std::vector<std::string>())\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"})))\n// (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"})))\n// (std::vector<std::string>({(std::string)\"4\"}))\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the vector.\n// >>> max_element((std::vector<long>({(long)1, (long)2, (long)3})))\n// (3)\n// >>> max_element((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (123)\nlong max_element(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested((\"[[]]\"))\n// (true)\n// >>> is_nested((\"[]]]]]]][[[[[]\"))\n// (false)\n// >>> is_nested((\"[][]\"))\n// (false)\n// >>> is_nested((\"[]\"))\n// (false)\n// >>> is_nested((\"[[][]]\"))\n// (true)\n// >>> is_nested((\"[[]][[\"))\n// (true)\nbool is_nested(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg((1), (5))\n// \"0b11\"\n// >>> rounded_avg((7), (5))\n// -1\n// >>> rounded_avg((10), (20))\n// \"0b1111\"\n// >>> rounded_avg((20), (33))\n// \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of strings, where each string consists of only digits, return a vector.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count((std::vector<std::string>({(std::string)\"1234567\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n// >>> odd_count((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the vector will be randomly ordered. Your task is to determine if\n// it is possible to get a vector sorted in non-decreasing order by performing \n// the following operation on the given vector:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the vector by one\n// position in the right direction. The last element of the vector will be moved to\n// the starting position in the vector i.e. 0th index. \n// If it is possible to obtain the sorted vector by performing the above operation\n// then return true else return false.\n// If the given vector is empty then return true.\n// Note: The given vector is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2})))\n// (true)\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given vector.\n// >>> move_one_ball((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2})))\n// (false)\n// Explanation:It is not possible to get non-decreasing order for the given\n// vector by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome((3))\n// (std::make_tuple(1, 2))\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome((12))\n// (std::make_tuple(4, 6))\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even((4))\n// (false)\n// >>> is_equal_to_sum_even((6))\n// (false)\n// >>> is_equal_to_sum_even((8))\n// (true)\nbool is_equal_to_sum_even(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (std::vector<long>({(long)1, (long)4, (long)12, (long)20}))\n// >>> derivative((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)6}))\nstd::vector<long> derivative(std::vector<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of numbers, return whether or not they are sorted\n// in ascending order. If vector has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted((std::vector<long>({(long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4})))\n// (false)\nbool is_sorted(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve((\"1234\"))\n// (\"4321\")\n// >>> solve((\"ab\"))\n// (\"AB\")\n// >>> solve((\"#a@C\"))\n// (\"#A@c\")\nstd::string solve(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a vector of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri((3))\n// (std::vector<long>({(long)1, (long)3, (long)2, (long)8}))\nstd::vector<long> tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz((50))\n// (0)\n// >>> fizz_buzz((78))\n// (2)\n// >>> fizz_buzz((79))\n// (3)\nlong fizz_buzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input vector of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_prefix((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bcd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve((1000))\n// (\"1\")\n// >>> solve((150))\n// (\"110\")\n// >>> solve((147))\n// (\"1100\")\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered vectors of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered vector of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3))\n// (std::vector<long>({(long)1, (long)2, (long)1}))\n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1))\n// (std::vector<long>({(long)1}))\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper((\"aBCdEf\"))\n// (1)\n// >>> count_upper((\"abcdefg\"))\n// (0)\n// >>> count_upper((\"dBBE\"))\n// (0)\nlong count_upper(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector arr of integers and a positive integer k, return a sorted vector \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum((std::vector<long>({(long)-3, (long)-4, (long)5})), (3))\n// (std::vector<long>({(long)-4, (long)-3, (long)5}))\n// Example 2:\n// >>> maximum((std::vector<long>({(long)4, (long)-4, (long)4})), (2))\n// (std::vector<long>({(long)4, (long)4}))\n// Example 3:\n// >>> maximum((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1))\n// (std::vector<long>({(long)2}))\n// Note:\n// 1. The length of the vector will be in the range of [1, 1000].\n// 2. The elements in the vector will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor((15))\n// (5)\nlong largest_divisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of non-negative integers, return a cocpp of the given vector after sorting,\n// you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given vector.\n// Examples:\n// >>> sort_array((std::vector<long>()))\n// (std::vector<long>())\n// >>> sort_array((std::vector<long>({(long)5})))\n// (std::vector<long>({(long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6})))\n// (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0}))\nstd::vector<long> sort_array(std::vector<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f((5))\n// (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15}))\nstd::vector<long> f(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube((1))\n// (true)\n// >>> iscube((2))\n// (false)\n// >>> iscube((-1))\n// (true)\n// >>> iscube((64))\n// (true)\n// >>> iscube((0))\n// (true)\n// >>> iscube((180))\n// (false)\nbool iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode((\"test\"))\n// (\"TGST\")\n// >>> encode((\"This is a message\"))\n// (\"tHKS KS C MGSSCGG\")\nstd::string encode(std::string message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored((\"Hello world\"))\n// (0)\n// >>> is_bored((\"The sky is blue. The sun is shining. I love this weather\"))\n// (1)\nlong is_bored(std::string S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a vector of integers as an input.\n// it returns true if there are two distinct elements in the vector that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7})))\n// (true)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area((3), (4), (5))\n// (6.0f)\n// >>> triangle_area((1), (2), (10))\n// (float(-1))\nfloat triangle_area(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf((\"Jupiter\"), (\"Neptune\"))\n// (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"}))\n// >>> bf((\"Earth\"), (\"Mercury\"))\n// (std::vector<std::string>(\"Venus\"))\n// >>> bf((\"Mercury\"), (\"Uranus\"))\n// (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"}))\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits((1))\n// (1)\n// >>> digits((4))\n// (0)\n// >>> digits((235))\n// (15)\nlong digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return a vector of the words.\n// For example:\n// >>> words_string((\"Hi, my name is John\"))\n// (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"}))\n// >>> words_string((\"One, two, three, four, five, six\"))\n// (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"}))\nstd::vector<std::string> words_string(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times((\"\"), (\"a\"))\n// (0)\n// >>> how_many_times((\"aaa\"), (\"a\"))\n// (3)\n// >>> how_many_times((\"aaaa\"), (\"aa\"))\n// (3)\nlong how_many_times(std::string string, std::string substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5f)\n// 2.5f\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// std::nullopt\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels((\"\"))\n// (\"\")\n// >>> remove_vowels((\"abcdef\"))\n// (\"bcdf\")\n// >>> remove_vowels((\"aaaaa\"))\n// (\"\")\n// >>> remove_vowels((\"aaBAA\"))\n// (\"B\")\n// >>> remove_vowels((\"zbcd\"))\n// (\"zbcd\")\nstd::string remove_vowels(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given vector of integers, return vector in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)3}))\n// >>> strange_sort_list((std::vector<long>({(long)5, (long)5, (long)5, (long)5})))\n// (std::vector<long>({(long)5, (long)5, (long)5, (long)5}))\n// >>> strange_sort_list((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n// (std::make_tuple(2.0f, 2.2f))\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n// (std::make_tuple(2.0f, 2.0f))\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power((1), (4))\n// (true)\n// >>> is_simple_power((2), (2))\n// (true)\n// >>> is_simple_power((8), (2))\n// (true)\n// >>> is_simple_power((3), (2))\n// (false)\n// >>> is_simple_power((3), (1))\n// (false)\n// >>> is_simple_power((5), (3))\n// (false)\nbool is_simple_power(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib((1))\n// (2)\n// >>> prime_fib((2))\n// (3)\n// >>> prime_fib((3))\n// (5)\n// >>> prime_fib((4))\n// (13)\n// >>> prime_fib((5))\n// (89)\nlong prime_fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given vector of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original vector.\n// For example:\n// >>> order_by_points((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12})))\n// (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11}))\n// >>> order_by_points((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if in given vector of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})), (0.5f))\n// (false)\n// >>> has_close_elements((std::vector<float>({(float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.3f))\n// (true)\nbool has_close_elements(std::vector<float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = has_close_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome((\"\"))\n// (\"\")\n// >>> make_palindrome((\"cat\"))\n// (\"catac\")\n// >>> make_palindrome((\"cata\"))\n// (\"catac\")\nstd::string make_palindrome(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor((\"010\"), (\"110\"))\n// (\"100\")\nstd::string string_xor(std::string a, std::string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial((4))\n// (288)\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4))\n// (24)\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4((5))\n// (4)\n// >>> fib4((6))\n// (8)\n// >>> fib4((7))\n// (14)\nlong fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of positive integers x. return a sorted vector of all \n// elements that hasn't any even digit.\n// Note: Returned vector should be sorted in increasing order.\n// For example:\n// >>> unique_digits((std::vector<long>({(long)15, (long)33, (long)1422, (long)1})))\n// (std::vector<long>({(long)1, (long)15, (long)33}))\n// >>> unique_digits((std::vector<long>({(long)152, (long)323, (long)1422, (long)10})))\n// (std::vector<long>())\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a vector of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty vector.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words((\"Mary had a little lamb\"), (4))\n// (std::vector<std::string>({(std::string)\"little\"}))\n// >>> select_words((\"Mary had a little lamb\"), (3))\n// (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"}))\n// >>> select_words((\"simple white space\"), (2))\n// (std::vector<std::string>())\n// >>> select_words((\"Hello world\"), (4))\n// (std::vector<std::string>({(std::string)\"world\"}))\n// >>> select_words((\"Uncle sam\"), (3))\n// (std::vector<std::string>({(std::string)\"Uncle\"}))\nstd::vector<std::string> select_words(std::string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly((std::vector<long>({(long)1, (long)2})), (5))\n// (false)\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (1))\n// (false)\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (9))\n// (true)\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly((std::vector<long>({(long)3})), (5))\n// (true)\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib((10))\n// (55)\n// >>> fib((1))\n// (1)\n// >>> fib((8))\n// (21)\nlong fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a vector of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the vector.\n// For example, if you are given \"Slices\" as the class and a vector of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension((\"my_class\"), (std::vector<std::string>({(std::string)\"AA\", (std::string)\"Be\", (std::string)\"CC\"})))\n// (\"my_class.AA\")\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"})))\n// (\"Yes\")\n// >>> match_parens((std::vector<std::string>({(std::string)\")\", (std::string)\")\"})))\n// (\"No\")\nstd::string match_parens(std::vector<std::string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the vector.\n// Return None if there is no such element.\n// >>> next_smallest((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// 2\n// >>> next_smallest((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2})))\n// 2\n// >>> next_smallest((std::vector<long>()))\n// std::nullopt\n// >>> next_smallest((std::vector<long>({(long)1, (long)1})))\n// std::nullopt\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int((float(5)), (float(2)), (float(7)))\n// (true)\n// >>> any_int((float(3)), (float(2)), (float(2)))\n// (false)\n// >>> any_int((float(3)), (float(-2)), (float(1)))\n// (true)\n// >>> any_int((3.6f), (-2.2f), (float(2)))\n// (false)\nbool any_int(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number((3.5f))\n// (0.5f)\nfloat truncate_number(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector with elements incremented by 1.\n// >>> incr_list((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)3, (long)4}))\n// >>> incr_list((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)6, (long)4, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124}))\nstd::vector<long> incr_list(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y((7), (34), (12))\n// (34)\n// >>> x_or_y((15), (8), (5))\n// (5)\nlong x_or_y(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp((3), (5))\n// (3)\n// >>> modp((1101), (101))\n// (2)\n// >>> modp((0), (101))\n// (1)\n// >>> modp((3), (11))\n// (8)\n// >>> modp((100), (101))\n// (1)\nlong modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count((-12))\n// (std::make_tuple(1, 1))\n// >>> even_odd_count((123))\n// (std::make_tuple(1, 2))\nstd::tuple<long, long> even_odd_count(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is hapcpp or not.\n// A string is hapcpp if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy((\"a\"))\n// (false)\n// >>> is_happy((\"aa\"))\n// (false)\n// >>> is_happy((\"abcd\"))\n// (true)\n// >>> is_happy((\"aabb\"))\n// (false)\n// >>> is_happy((\"adb\"))\n// (true)\n// >>> is_happy((\"xyy\"))\n// (false)\nbool is_happy(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor((13195))\n// (29)\n// >>> largest_prime_factor((2048))\n// (2)\nlong largest_prime_factor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum((\"\"))\n// (0)\n// >>> digitSum((\"abAB\"))\n// (131)\n// >>> digitSum((\"abcCd\"))\n// (67)\n// >>> digitSum((\"helloE\"))\n// (69)\n// >>> digitSum((\"woArBld\"))\n// (131)\n// >>> digitSum((\"aAaaaXa\"))\n// (153)\nlong digitSum(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n// (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution((std::vector<long>({(long)5, (long)8, (long)7, (long)1})))\n// (12)\n// >>> solution((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3})))\n// (9)\n// >>> solution((std::vector<long>({(long)30, (long)13, (long)24, (long)321})))\n// (0)\nlong solution(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given a vector representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a vector, [ smalest_value, its index ],\n// If there are no even values or the given vector is empty, return [].\n// Example 1:\n// >>> pluck((std::vector<long>({(long)4, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck((std::vector<long>()))\n// (std::vector<long>())\n// Example 4:\n// >>> pluck((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2})))\n// (std::vector<long>({(long)0, (long)1}))\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer vector a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples((5))\n// (1)\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two vectors of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a vector of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (\"YES\")\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4})))\n// (\"NO\")\n// It is assumed that the input vectors will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the vector l.\n// >>> median((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (float(3))\n// >>> median((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20})))\n// (15.0f)\nfloat median(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length((\"Hello\"))\n// (true)\n// >>> prime_length((\"abcdcba\"))\n// (true)\n// >>> prime_length((\"kittens\"))\n// (true)\n// >>> prime_length((\"orange\"))\n// (false)\nbool prime_length(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector arr of integers, find the minimum number of elements that\n// need to be changed to make the vector palindromic. A palindromic vector is a vector that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6})))\n// (4)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2})))\n// (1)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1})))\n// (0)\nlong smallest_change(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of numbers.\n// You need to return the sum of squared numbers in the given vector,\n// round each element in the vector to the upper int(Ceiling) first.\n// Examples:\n// >>> lst((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})))\n// (14)\n// >>> lst((std::vector<float>({(float)1.0f, (float)4.0f, (float)9.0f})))\n// (98)\n// >>> lst((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n// (84)\n// >>> lst((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f})))\n// (29)\n// >>> lst((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f})))\n// (6)\nlong sum_squares(std::vector<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check((\"example.txt\"))\n// (\"Yes\")\n// >>> file_name_check((\"1example.dll\"))\n// (\"No\")\nstd::string file_name_check(std::string file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a vector of integers as an input.\n// it returns true if there are three distinct elements in the vector that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool triples_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection((std::make_tuple(1, 2)), (std::make_tuple(2, 3)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-1, 1)), (std::make_tuple(0, 4)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5)))\n// (\"YES\")\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the vector of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups((\"( ) (( )) (( )( ))\"))\n// (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"}))\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two vectors of scores and guesses of equal length, where each index shows a match. \n// Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2})))\n// (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3}))\n// >>> compare((std::vector<long>({(long)0, (long)5, (long)0, (long)0, (long)0, (long)4})), (std::vector<long>({(long)4, (long)1, (long)1, (long)0, (long)0, (long)-2})))\n// (std::vector<long>({(long)4, (long)4, (long)1, (long)0, (long)0, (long)6}))\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter((\"apple pie\"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"apple pi e\"))\n// (true)\n// >>> check_if_last_char_is_a_letter((\"apple pi e \"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"\"))\n// (false)\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date((\"03-11-2000\"))\n// (true)\n// >>> valid_date((\"15-01-2012\"))\n// (false)\n// >>> valid_date((\"04-0-2040\"))\n// (false)\n// >>> valid_date((\"06-04-2020\"))\n// (true)\n// >>> valid_date((\"06/04/2020\"))\n// (false)\nbool valid_date(std::string date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes a vector of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums((std::vector<long>()))\n// (0)\n// >>> count_nums((std::vector<long>({(long)-1, (long)11, (long)-11})))\n// (1)\n// >>> count_nums((std::vector<long>({(long)1, (long)1, (long)2})))\n// (3)\nlong count_nums(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle((\"Hi\"))\n// (\"Hi\")\n// >>> anti_shuffle((\"hello\"))\n// (\"ehllo\")\n// >>> anti_shuffle((\"Hello World!!!\"))\n// (\"Hello !!!Wdlor\")\nstd::string anti_shuffle(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome((\"\"))\n// (true)\n// >>> is_palindrome((\"aba\"))\n// (true)\n// >>> is_palindrome((\"aaaaa\"))\n// (true)\n// >>> is_palindrome((\"zbcd\"))\n// (false)\nbool is_palindrome(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel((\"yogurt\"))\n// (\"u\")\n// >>> get_closest_vowel((\"FULL\"))\n// (\"U\")\n// >>> get_closest_vowel((\"quick\"))\n// (\"\")\n// >>> get_closest_vowel((\"ab\"))\n// (\"\")\nstd::string get_closest_vowel(std::string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime((6))\n// (false)\n// >>> is_prime((101))\n// (true)\n// >>> is_prime((11))\n// (true)\n// >>> is_prime((13441))\n// (true)\n// >>> is_prime((61))\n// (true)\n// >>> is_prime((4))\n// (false)\n// >>> is_prime((1))\n// (false)\nbool is_prime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify((\"1/5\"), (\"5/1\"))\n// (true)\n// >>> simplify((\"1/6\"), (\"2/1\"))\n// (false)\n// >>> simplify((\"7/10\"), (\"10/2\"))\n// (false)\nbool simplify(std::string x, std::string n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key((\"AB\"))\n// (1)\n// >>> hex_key((\"1077E\"))\n// (2)\n// >>> hex_key((\"ABED1A33\"))\n// (4)\n// >>> hex_key((\"123456789ABCDEF0\"))\n// (6)\n// >>> hex_key((\"2020\"))\n// (2)\nlong hex_key(std::string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence((\"This is a test\"))\n// (\"is\")\n// Example 2:\n// >>> words_in_sentence((\"lets go for swimming\"))\n// (\"go for\")\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a map\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram((\"a b c\"))\n// (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}}))\n// >>> histogram((\"a b b a\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"a b c a b\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"b b b b a\"))\n// (std::map<std::string,long>({{\"b\", 4}}))\n// >>> histogram((\"\"))\n// (std::map<std::string,long>())\nstd::map<std::string,long> histogram(std::string test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested vectors,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the vector,\n// and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)}))\n// >>> get_row((std::vector<std::vector<long>>()), (1))\n// (std::vector<std::tuple<long, long>>())\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)}))\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned vector sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz((5))\n// (std::vector<long>({(long)1, (long)5}))\nstd::vector<long> get_odd_collatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given vector will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})))\n// (3)\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)3})))\n// (-1)\nlong can_arrange(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers((\"three one five\"))\n// (\"one three five\")\nstd::string sort_numbers(std::string numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift((12), (1))\n// (\"21\")\n// >>> circular_shift((12), (2))\n// (\"12\")\nstd::string circular_shift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// (long({(long)1, (long)2, (long)3}))\n// >>> lst\n// (long())\n// >>> lst\n// (long({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))\nlong sum_squares(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3})))\n// (10)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1})))\n// (25)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3})))\n// (13)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6})))\n// (11)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21})))\n// (3)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7})))\n// (7)\nlong skjkasdkd(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product((std::vector<long>()))\n// (std::make_tuple(0, 1))\n// >>> sum_product((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::make_tuple(10, 24))\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num((12), (15))\n// (14)\n// >>> choose_num((13), (12))\n// (-1)\nlong choose_num(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a vector.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1))\n// >>> largest_smallest_integers((std::vector<long>()))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\n// >>> largest_smallest_integers((std::vector<long>({(long)0})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters((\"xyzXYZ\"))\n// (3)\n// >>> count_distinct_characters((\"Jerry\"))\n// (4)\nlong count_distinct_characters(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1408,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a vector, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile((3))\n// (std::vector<long>({(long)3, (long)5, (long)7}))\nstd::vector<long> make_a_pile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = make_a_pile;\n    assert(candidate((3)) == (std::vector<long>({(long)3, (long)5, (long)7})));\n    assert(candidate((4)) == (std::vector<long>({(long)4, (long)6, (long)8, (long)10})));\n    assert(candidate((5)) == (std::vector<long>({(long)5, (long)7, (long)9, (long)11, (long)13})));\n    assert(candidate((6)) == (std::vector<long>({(long)6, (long)8, (long)10, (long)12, (long)14, (long)16})));\n    assert(candidate((8)) == (std::vector<long>({(long)8, (long)10, (long)12, (long)14, (long)16, (long)18, (long)20, (long)22})));\n}\n",
     "stop_tokens": [
@@ -1416,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the vector, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs((std::vector<long>({(long)1, (long)2, (long)2, (long)-4})))\n// 9\n// >>> prod_signs((std::vector<long>({(long)0, (long)1})))\n// 0\n// >>> prod_signs((std::vector<long>()))\n// std::nullopt\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return a vector of the words.\n// For example:\n// >>> words_string((\"Hi, my name is John\"))\n// (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"}))\n// >>> words_string((\"One, two, three, four, five, six\"))\n// (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"}))\nstd::vector<std::string> words_string(std::string s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n// of nums.\n// Example\n// >>> minSubArraySum((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4})))\n// (1)\n// >>> minSubArraySum((std::vector<long>({(long)-1, (long)-2, (long)-3})))\n// (-6)\nlong minSubArraySum(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num((12), (15))\n// (14)\n// >>> choose_num((13), (12))\n// (-1)\nlong choose_num(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence((0))\n// (\"0\")\n// >>> string_sequence((5))\n// (\"0 1 2 3 4 5\")\nstd::string string_sequence(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg((1), (5))\n// \"0b11\"\n// >>> rounded_avg((7), (5))\n// -1\n// >>> rounded_avg((10), (20))\n// \"0b1111\"\n// >>> rounded_avg((20), (33))\n// \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check((\"abcd\"), (\"abd\"))\n// (false)\n// >>> cycpattern_check((\"hello\"), (\"ell\"))\n// (true)\n// >>> cycpattern_check((\"whassup\"), (\"psus\"))\n// (false)\n// >>> cycpattern_check((\"abab\"), (\"baa\"))\n// (true)\n// >>> cycpattern_check((\"efef\"), (\"eeff\"))\n// (false)\n// >>> cycpattern_check((\"himenss\"), (\"simen\"))\n// (true)\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of positive integers x. return a sorted vector of all \n// elements that hasn't any even digit.\n// Note: Returned vector should be sorted in increasing order.\n// For example:\n// >>> unique_digits((std::vector<long>({(long)15, (long)33, (long)1422, (long)1})))\n// (std::vector<long>({(long)1, (long)15, (long)33}))\n// >>> unique_digits((std::vector<long>({(long)152, (long)323, (long)1422, (long)10})))\n// (std::vector<long>())\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true is vector elements are monotonically increasing or decreasing.\n// >>> monotonic((std::vector<long>({(long)1, (long)2, (long)4, (long)20})))\n// (true)\n// >>> monotonic((std::vector<long>({(long)1, (long)20, (long)4, (long)10})))\n// (false)\n// >>> monotonic((std::vector<long>({(long)4, (long)1, (long)0, (long)-10})))\n// (true)\nbool monotonic(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting vector, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3})))\n// (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"}))\n// If the vector is empty, return an empty vector:\n// >>> by_length((std::vector<long>()))\n// (std::vector<std::string>())\n// If the vector has any strange number ignore it:\n// >>> by_length((std::vector<long>({(long)1, (long)-1, (long)55})))\n// (std::vector<std::string>({(std::string)\"One\"}))\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of vector of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input vector is empty.\n// >>> longest((std::vector<std::string>()))\n// std::nullopt\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// \"a\"\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"bb\", (std::string)\"ccc\"})))\n// \"ccc\"\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f((5))\n// (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15}))\nstd::vector<long> f(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if all numbers in the vector l are below threshold t.\n// >>> below_threshold((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100))\n// (true)\n// >>> below_threshold((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5))\n// (false)\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome((3))\n// (std::make_tuple(1, 2))\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome((12))\n// (std::make_tuple(4, 6))\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime((30))\n// (true)\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes a vector of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums((std::vector<long>()))\n// (0)\n// >>> count_nums((std::vector<long>({(long)-1, (long)11, (long)-11})))\n// (1)\n// >>> count_nums((std::vector<long>({(long)1, (long)1, (long)2})))\n// (3)\nlong count_nums(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the vector.\n// >>> get_positive((std::vector<long>({(long)-1, (long)2, (long)-4, (long)5, (long)6})))\n// (std::vector<long>({(long)2, (long)5, (long)6}))\n// >>> get_positive((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)9, (long)123, (long)1}))\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the vector will be randomly ordered. Your task is to determine if\n// it is possible to get a vector sorted in non-decreasing order by performing \n// the following operation on the given vector:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the vector by one\n// position in the right direction. The last element of the vector will be moved to\n// the starting position in the vector i.e. 0th index. \n// If it is possible to obtain the sorted vector by performing the above operation\n// then return true else return false.\n// If the given vector is empty then return true.\n// Note: The given vector is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2})))\n// (true)\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given vector.\n// >>> move_one_ball((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2})))\n// (false)\n// Explanation:It is not possible to get non-decreasing order for the given\n// vector by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a vector l and returns a vector l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_third((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2})))\n// (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5}))\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome((\"\"))\n// (\"\")\n// >>> make_palindrome((\"cat\"))\n// (\"catac\")\n// >>> make_palindrome((\"cata\"))\n// (\"catac\")\nstd::string make_palindrome(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens((\"(()()) ((())) () ((())()())\"))\n// (std::vector<long>({(long)2, (long)3, (long)1, (long)3}))\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two vectors of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a vector of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (\"YES\")\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4})))\n// (\"NO\")\n// It is assumed that the input vectors will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area((5), (3))\n// (7.5f)\nfloat triangle_area(long a, long h) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a map\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram((\"a b c\"))\n// (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}}))\n// >>> histogram((\"a b b a\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"a b c a b\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"b b b b a\"))\n// (std::map<std::string,long>({{\"b\", 4}}))\n// >>> histogram((\"\"))\n// (std::map<std::string,long>())\nstd::map<std::string,long> histogram(std::string test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply((148), (412))\n// (16)\n// >>> multiply((19), (28))\n// (72)\n// >>> multiply((2020), (1851))\n// (0)\n// >>> multiply((14), (-15))\n// (20)\nlong multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given vector of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n// (1.0f)\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two vectors.\n// >>> common((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121})))\n// (std::vector<long>({(long)1, (long)5, (long)653}))\n// >>> common((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2})))\n// (std::vector<long>({(long)2, (long)3}))\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman((19))\n// (\"xix\")\n// >>> int_to_mini_roman((152))\n// (\"clii\")\n// >>> int_to_mini_roman((426))\n// (\"cdxxvi\")\nstd::string int_to_mini_roman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution((\"5 apples and 6 oranges\"), (19))\n// (8)\n// >>> fruit_distribution((\"0 apples and 1 oranges\"), (3))\n// (2)\n// >>> fruit_distribution((\"2 apples and 3 oranges\"), (100))\n// (95)\n// >>> fruit_distribution((\"100 apples and 1 oranges\"), (120))\n// (19)\nlong fruit_distribution(std::string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +172,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and true/false for the check.\n// Example\n// >>> reverse_delete((\"abcde\"), (\"ae\"))\n// (std::make_tuple(\"bcd\", false))\n// >>> reverse_delete((\"abcdef\"), (\"b\"))\n// (std::make_tuple(\"acdef\", false))\n// >>> reverse_delete((\"abcdedcba\"), (\"ab\"))\n// (std::make_tuple(\"cdedc\", true))\nstd::tuple<std::string, bool> reverse_delete(std::string s, std::string c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = reverse_delete;\n    assert(candidate((\"abcde\"), (\"ae\")) == (std::make_tuple(\"bcd\", false)));\n    assert(candidate((\"abcdef\"), (\"b\")) == (std::make_tuple(\"acdef\", false)));\n    assert(candidate((\"abcdedcba\"), (\"ab\")) == (std::make_tuple(\"cdedc\", true)));\n    assert(candidate((\"dwik\"), (\"w\")) == (std::make_tuple(\"dik\", false)));\n    assert(candidate((\"a\"), (\"a\")) == (std::make_tuple(\"\", true)));\n    assert(candidate((\"abcdedcba\"), (\"\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"abcdedcba\"), (\"v\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"vabba\"), (\"v\")) == (std::make_tuple(\"abba\", true)));\n    assert(candidate((\"mamma\"), (\"mia\")) == (std::make_tuple(\"\", true)));\n}\n",
     "stop_tokens": [
@@ -1632,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor((3), (5))\n// (1)\n// >>> greatest_common_divisor((25), (15))\n// (5)\nlong greatest_common_divisor(long a, long b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of strings, where each string consists of only digits, return a vector.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count((std::vector<std::string>({(std::string)\"1234567\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n// >>> odd_count((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a vector of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words((\"Hello world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"Hello,world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"abcdef\"))\n// 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n// of nums.\n// Example\n// >>> minSubArraySum((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4})))\n// (1)\n// >>> minSubArraySum((std::vector<long>({(long)-1, (long)-2, (long)-3})))\n// (-6)\nlong minSubArraySum(std::vector<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1))\n// (6)\n// Example 2:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2))\n// (5)\n// Example 3:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5))\n// (0)\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1660,7 +220,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this Kata, you have to sort a vector of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6})))\n// (std::vector<long>({(long)-6, (long)-5, (long)-4, (long)-3, (long)-2}))\n// >>> sort_array((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4}))\nstd::vector<long> sort_array(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6}))) == (std::vector<long>({(long)-4, (long)-2, (long)-6, (long)-5, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)77, (long)4, (long)5, (long)3, (long)5, (long)7, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)4, (long)4, (long)3, (long)3, (long)5, (long)5, (long)5, (long)7, (long)77})));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)44, (long)12, (long)32, (long)5}))) == (std::vector<long>({(long)32, (long)3, (long)5, (long)6, (long)12, (long)44})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n}\n",
     "stop_tokens": [
@@ -1668,133 +228,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate vector of strings into a single string\n// >>> concatenate((std::vector<std::string>()))\n// (\"\")\n// >>> concatenate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// (\"abc\")\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a vector of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty vector.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words((\"Mary had a little lamb\"), (4))\n// (std::vector<std::string>({(std::string)\"little\"}))\n// >>> select_words((\"Mary had a little lamb\"), (3))\n// (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"}))\n// >>> select_words((\"simple white space\"), (2))\n// (std::vector<std::string>())\n// >>> select_words((\"Hello world\"), (4))\n// (std::vector<std::string>({(std::string)\"world\"}))\n// >>> select_words((\"Uncle sam\"), (3))\n// (std::vector<std::string>({(std::string)\"Uncle\"}))\nstd::vector<std::string> select_words(std::string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a vector of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted vector with a sorted order,\n// The vector is always a vector of strings and never a vector of numbers,\n// and it may contain duplicates.\n// The order of the vector should be ascending by length of each word, and you\n// should return the vector sorted by that rule.\n// If two words have the same length, sort the vector alphabetically.\n// The function should return a vector of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"})))\n// (std::vector<std::string>({(std::string)\"aa\"}))\n// >>> list_sort((std::vector<std::string>({(std::string)\"ab\", (std::string)\"a\", (std::string)\"aaa\", (std::string)\"cd\"})))\n// (std::vector<std::string>({(std::string)\"ab\", (std::string)\"cd\"}))\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel((\"yogurt\"))\n// (\"u\")\n// >>> get_closest_vowel((\"FULL\"))\n// (\"U\")\n// >>> get_closest_vowel((\"quick\"))\n// (\"\")\n// >>> get_closest_vowel((\"ab\"))\n// (\"\")\nstd::string get_closest_vowel(std::string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input vector of strings only for ones that contain given substring\n// >>> filter_by_substring((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_substring((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"})))\n// (\"Yes\")\n// >>> match_parens((std::vector<std::string>({(std::string)\")\", (std::string)\")\"})))\n// (\"No\")\nstd::string match_parens(std::vector<std::string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer((\"10\"))\n// (10)\n// >>> closest_integer((\"15.3\"))\n// (15)\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor((\"010\"), (\"110\"))\n// (\"100\")\nstd::string string_xor(std::string a, std::string b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count((\"abcde\"))\n// (2)\n// >>> vowels_count((\"ACEDY\"))\n// (3)\nlong vowels_count(std::string s) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector arr of integers and a positive integer k, return a sorted vector \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum((std::vector<long>({(long)-3, (long)-4, (long)5})), (3))\n// (std::vector<long>({(long)-4, (long)-3, (long)5}))\n// Example 2:\n// >>> maximum((std::vector<long>({(long)4, (long)-4, (long)4})), (2))\n// (std::vector<long>({(long)4, (long)4}))\n// Example 3:\n// >>> maximum((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1))\n// (std::vector<long>({(long)2}))\n// Note:\n// 1. The length of the vector will be in the range of [1, 1000].\n// 2. The elements in the vector will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a vector of strings.\n// The vector contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"})))\n// (\"string\")\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"})))\n// (\"enam\")\n// >>> find_max((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"})))\n// (\"aaaaaaa\")\nstd::string find_max(std::vector<std::string> words) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution((std::vector<long>({(long)5, (long)8, (long)7, (long)1})))\n// (12)\n// >>> solution((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3})))\n// (9)\n// >>> solution((std::vector<long>({(long)30, (long)13, (long)24, (long)321})))\n// (0)\nlong solution(std::vector<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5((\"Hello world\"))\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4))\n// (24)\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base((8), (3))\n// (\"22\")\n// >>> change_base((8), (2))\n// (\"1000\")\n// >>> change_base((7), (2))\n// (\"111\")\nstd::string change_base(long x, long base) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned vector sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz((5))\n// (std::vector<long>({(long)1, (long)5}))\nstd::vector<long> get_odd_collatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle((3), (4), (5))\n// (true)\n// >>> right_angle_triangle((1), (2), (3))\n// (false)\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date((\"03-11-2000\"))\n// (true)\n// >>> valid_date((\"15-01-2012\"))\n// (false)\n// >>> valid_date((\"04-0-2040\"))\n// (false)\n// >>> valid_date((\"06-04-2020\"))\n// (true)\n// >>> valid_date((\"06/04/2020\"))\n// (false)\nbool valid_date(std::string date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a vector of GPAs for some students and you have to write \n// a function that can output a vector of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f})))\n// (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"}))\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a vector of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words((\"Hello world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"Hello,world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"abcdef\"))\n// 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n// >>> intersperse((std::vector<long>()), (4))\n// (std::vector<long>())\n// >>> intersperse((std::vector<long>({(long)1, (long)2, (long)3})), (4))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)4, (long)3}))\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of numbers, return whether or not they are sorted\n// in ascending order. If vector has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted((std::vector<long>({(long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4})))\n// (false)\nbool is_sorted(std::vector<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection((std::make_tuple(1, 2)), (std::make_tuple(2, 3)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-1, 1)), (std::make_tuple(0, 4)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5)))\n// (\"YES\")\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the vector, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs((std::vector<long>({(long)1, (long)2, (long)2, (long)-4})))\n// 9\n// >>> prod_signs((std::vector<long>({(long)0, (long)1})))\n// 0\n// >>> prod_signs((std::vector<long>()))\n// std::nullopt\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered vectors of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered vector of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3))\n// (std::vector<long>({(long)1, (long)2, (long)1}))\n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1))\n// (std::vector<long>({(long)1}))\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of vector of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input vector is empty.\n// >>> longest((std::vector<std::string>()))\n// std::nullopt\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// \"a\"\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"bb\", (std::string)\"ccc\"})))\n// \"ccc\"\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a vector of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri((3))\n// (std::vector<long>({(long)1, (long)3, (long)2, (long)8}))\nstd::vector<long> tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits((1))\n// (1)\n// >>> digits((4))\n// (0)\n// >>> digits((235))\n// (15)\nlong digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested((\"[[]]\"))\n// (true)\n// >>> is_nested((\"[]]]]]]][[[[[]\"))\n// (false)\n// >>> is_nested((\"[][]\"))\n// (false)\n// >>> is_nested((\"[]\"))\n// (false)\n// >>> is_nested((\"[[][]]\"))\n// (true)\n// >>> is_nested((\"[[]][[\"))\n// (true)\nbool is_nested(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of numbers.\n// You need to return the sum of squared numbers in the given vector,\n// round each element in the vector to the upper int(Ceiling) first.\n// Examples:\n// >>> lst((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})))\n// (14)\n// >>> lst((std::vector<float>({(float)1.0f, (float)4.0f, (float)9.0f})))\n// (98)\n// >>> lst((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n// (84)\n// >>> lst((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f})))\n// (29)\n// >>> lst((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f})))\n// (6)\nlong sum_squares(std::vector<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter((\"apple pie\"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"apple pi e\"))\n// (true)\n// >>> check_if_last_char_is_a_letter((\"apple pi e \"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"\"))\n// (false)\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given vector will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})))\n// (3)\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)3})))\n// (-1)\nlong can_arrange(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a vector.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1))\n// >>> largest_smallest_integers((std::vector<long>()))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\n// >>> largest_smallest_integers((std::vector<long>({(long)0})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5f)\n// 2.5f\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// std::nullopt\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even((4))\n// (false)\n// >>> is_equal_to_sum_even((6))\n// (false)\n// >>> is_equal_to_sum_even((8))\n// (true)\nbool is_equal_to_sum_even(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial((4))\n// (288)\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor((3), (5))\n// (1)\n// >>> greatest_common_divisor((25), (15))\n// (5)\nlong greatest_common_divisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces((\" Example\"))\n// (\"Example\")\n// >>> fix_spaces((\" Example 1\"))\n// (\"Example_1\")\n// >>> fix_spaces((\" Example 2\"))\n// (\"_Example_2\")\n// >>> fix_spaces((\" Example 3\"))\n// (\"_Example-3\")\nstd::string fix_spaces(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check((\"example.txt\"))\n// (\"Yes\")\n// >>> file_name_check((\"1example.dll\"))\n// (\"No\")\nstd::string file_name_check(std::string file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// (long({(long)1, (long)2, (long)3}))\n// >>> lst\n// (long())\n// >>> lst\n// (long({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))\nlong sum_squares(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence((\"This is a test\"))\n// (\"is\")\n// Example 2:\n// >>> words_in_sentence((\"lets go for swimming\"))\n// (\"go for\")\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify((\"1/5\"), (\"5/1\"))\n// (true)\n// >>> simplify((\"1/6\"), (\"2/1\"))\n// (false)\n// >>> simplify((\"7/10\"), (\"10/2\"))\n// (false)\nbool simplify(std::string x, std::string n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given vector of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original vector.\n// For example:\n// >>> order_by_points((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12})))\n// (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11}))\n// >>> order_by_points((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +616,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a vector of numbers as input and returns \n// the number of elements in the vector that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15})))\n// (1)\n// >>> specialFilter((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109})))\n// (2)\nlong specialFilter(std::vector<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = specialFilter;\n    assert(candidate((std::vector<long>({(long)5, (long)-2, (long)1, (long)-5}))) == (0));\n    assert(candidate((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15}))) == (1));\n    assert(candidate((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109}))) == (2));\n    assert(candidate((std::vector<long>({(long)43, (long)-12, (long)93, (long)125, (long)121, (long)109}))) == (4));\n    assert(candidate((std::vector<long>({(long)71, (long)-2, (long)-33, (long)75, (long)21, (long)19}))) == (3));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>())) == (0));\n}\n",
     "stop_tokens": [
@@ -1812,25 +624,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n((30))\n// (465)\n// >>> sum_to_n((100))\n// (5050)\n// >>> sum_to_n((5))\n// (15)\n// >>> sum_to_n((10))\n// (55)\n// >>> sum_to_n((1))\n// (1)\nlong sum_to_n(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer vector a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples((5))\n// (1)\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a vector of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4})))\n// (std::vector<long>({(long)1, (long)3, (long)4}))\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf((\"Jupiter\"), (\"Neptune\"))\n// (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"}))\n// >>> bf((\"Earth\"), (\"Mercury\"))\n// (std::vector<std::string>(\"Venus\"))\n// >>> bf((\"Mercury\"), (\"Uranus\"))\n// (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"}))\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a vector of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted vector with a sorted order,\n// The vector is always a vector of strings and never a vector of numbers,\n// and it may contain duplicates.\n// The order of the vector should be ascending by length of each word, and you\n// should return the vector sorted by that rule.\n// If two words have the same length, sort the vector alphabetically.\n// The function should return a vector of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"})))\n// (std::vector<std::string>({(std::string)\"aa\"}))\n// >>> list_sort((std::vector<std::string>({(std::string)\"ab\", (std::string)\"a\", (std::string)\"aaa\", (std::string)\"cd\"})))\n// (std::vector<std::string>({(std::string)\"ab\", (std::string)\"cd\"}))\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector of all prefixes from shortest to longest of the input string\n// >>> all_prefixes((\"abc\"))\n// (std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))\nstd::vector<std::string> all_prefixes(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y((7), (34), (12))\n// (34)\n// >>> x_or_y((15), (8), (5))\n// (5)\nlong x_or_y(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of numbers, return the sum of squares of the numbers\n// in the vector that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference((std::vector<float>({(long)1, (long)3, (long)2, (long)0})))\n// (10)\n// >>> double_the_difference((std::vector<float>({(long)-1, (long)-2, (long)0})))\n// (0)\n// >>> double_the_difference((std::vector<float>({(long)9, (long)-2})))\n// (81)\n// >>> double_the_difference((std::vector<float>({(long)0})))\n// (0)\n// If the input vector is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two vectors of scores and guesses of equal length, where each index shows a match. \n// Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2})))\n// (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3}))\n// >>> compare((std::vector<long>({(long)0, (long)5, (long)0, (long)0, (long)0, (long)4})), (std::vector<long>({(long)4, (long)1, (long)1, (long)0, (long)0, (long)-2})))\n// (std::vector<long>({(long)4, (long)4, (long)1, (long)0, (long)0, (long)6}))\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a vector of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the vector.\n// For example, if you are given \"Slices\" as the class and a vector of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension((\"my_class\"), (std::vector<std::string>({(std::string)\"AA\", (std::string)\"Be\", (std::string)\"CC\"})))\n// (\"my_class.AA\")\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check((\"abcd\"), (\"abd\"))\n// (false)\n// >>> cycpattern_check((\"hello\"), (\"ell\"))\n// (true)\n// >>> cycpattern_check((\"whassup\"), (\"psus\"))\n// (false)\n// >>> cycpattern_check((\"abab\"), (\"baa\"))\n// (true)\n// >>> cycpattern_check((\"efef\"), (\"eeff\"))\n// (false)\n// >>> cycpattern_check((\"himenss\"), (\"simen\"))\n// (true)\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count((-12))\n// (std::make_tuple(1, 1))\n// >>> even_odd_count((123))\n// (std::make_tuple(1, 2))\nstd::tuple<long, long> even_odd_count(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman((19))\n// (\"xix\")\n// >>> int_to_mini_roman((152))\n// (\"clii\")\n// >>> int_to_mini_roman((426))\n// (\"cdxxvi\")\nstd::string int_to_mini_roman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle((3), (4), (5))\n// (true)\n// >>> right_angle_triangle((1), (2), (3))\n// (false)\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a vector of strings.\n// The vector contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"})))\n// (\"string\")\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"})))\n// (\"enam\")\n// >>> find_max((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"})))\n// (\"aaaaaaa\")\nstd::string find_max(std::vector<std::string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return a vector of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat((5), (6), (10))\n// (std::vector<long>({(long)11, (long)4}))\n// >>> eat((4), (8), (9))\n// (std::vector<long>({(long)12, (long)1}))\n// >>> eat((1), (10), (10))\n// (std::vector<long>({(long)11, (long)0}))\n// >>> eat((2), (11), (5))\n// (std::vector<long>({(long)7, (long)0}))\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence((0))\n// (\"0\")\n// >>> string_sequence((5))\n// (\"0 1 2 3 4 5\")\nstd::string string_sequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two vectors operator, and operand. The first vector has basic algebra operations, and \n// the second vector is a vector of integers. Use the two given vectors to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// vector = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator vector is equal to the length of operand vector minus one.\n// Operand is a vector of of non-negative integers.\n// Operator vector has at least one operator, and operand vector has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve((\"1234\"))\n// (\"4321\")\n// >>> solve((\"ab\"))\n// (\"AB\")\n// >>> solve((\"#a@C\"))\n// (\"#A@c\")\nstd::string solve(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5((\"Hello world\"))\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1840,7 +844,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers((2), (8))\n// (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))\n// >>> generate_integers((8), (2))\n// (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))\n// >>> generate_integers((10), (14))\n// (std::vector<long>())\nstd::vector<long> generate_integers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = generate_integers;\n    assert(candidate((2), (10)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((10), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((132), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((17), (89)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
@@ -1848,49 +852,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given vector of integers, generate a vector of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)2})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4}))\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters((\"xyzXYZ\"))\n// (3)\n// >>> count_distinct_characters((\"Jerry\"))\n// (4)\nlong count_distinct_characters(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a vector of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)3})))\n// (false)\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)-4, (long)5})))\n// (true)\nbool below_zero(std::vector<long> operations) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return vector of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music((\"o o| .| o| o| .| .| .| .| o o\"))\n// (std::vector<long>({(long)4, (long)2, (long)1, (long)2, (long)2, (long)1, (long)1, (long)1, (long)1, (long)4, (long)4}))\nstd::vector<long> parse_music(std::string music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the vector.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search((std::vector<long>({(long)4, (long)1, (long)2, (long)2, (long)3, (long)1})))\n// (2)\n// >>> search((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4, (long)4})))\n// (3)\n// >>> search((std::vector<long>({(long)5, (long)5, (long)4, (long)4, (long)4})))\n// (-1)\nlong search(std::vector<long> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times((\"\"), (\"a\"))\n// (0)\n// >>> how_many_times((\"aaa\"), (\"a\"))\n// (3)\n// >>> how_many_times((\"aaaa\"), (\"aa\"))\n// (3)\nlong how_many_times(std::string string, std::string substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"(\"))\n// (false)\n// >>> correct_bracketing((\"()\"))\n// (true)\n// >>> correct_bracketing((\"(()())\"))\n// (true)\n// >>> correct_bracketing((\")(()\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers((\"three one five\"))\n// (\"one three five\")\nstd::string sort_numbers(std::string numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the vector of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups((\"( ) (( )) (( )( ))\"))\n// (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"}))\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n// (std::make_tuple(2.0f, 2.2f))\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n// (std::make_tuple(2.0f, 2.0f))\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n// (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given vector of any cppthon values only for integers\n// >>> filter_integers((std::vector<std::any>({(std::string)\"a\", (std::string)3.14f, (std::string)5})))\n// (std::vector<long>({(long)5}))\n// >>> filter_integers((std::vector<std::any>({1, 2, 3, \"abc\", std::map<long,long>(), std::vector<long>()})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> string_length((\"\"))\n// (0)\n// >>> string_length((\"abc\"))\n// (3)\nlong string_length(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor((15))\n// (5)\nlong largest_divisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize((8))\n// (std::vector<long>({(long)2, (long)2, (long)2}))\n// >>> factorize((25))\n// (std::vector<long>({(long)5, (long)5}))\n// >>> factorize((70))\n// (std::vector<long>({(long)2, (long)5, (long)7}))\nstd::vector<long> factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a vector of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4})))\n// (std::vector<long>({(long)1, (long)3, (long)4}))\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case((\"Hello\"))\n// (\"hELLO\")\nstd::string flip_case(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate vector of strings into a single string\n// >>> concatenate((std::vector<std::string>()))\n// (\"\")\n// >>> concatenate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// (\"abc\")\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input vector of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_prefix((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bcd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number((3.5f))\n// (0.5f)\nfloat truncate_number(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the vector.\n// >>> get_positive((std::vector<long>({(long)-1, (long)2, (long)-4, (long)5, (long)6})))\n// (std::vector<long>({(long)2, (long)5, (long)6}))\n// >>> get_positive((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)9, (long)123, (long)1}))\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime((6))\n// (false)\n// >>> is_prime((101))\n// (true)\n// >>> is_prime((11))\n// (true)\n// >>> is_prime((13441))\n// (true)\n// >>> is_prime((61))\n// (true)\n// >>> is_prime((4))\n// (false)\n// >>> is_prime((1))\n// (false)\nbool is_prime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a vector l and returns a vector l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_third((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2})))\n// (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5}))\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a vector\n// >>> unique((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123}))\nstd::vector<long> unique(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the vector.\n// >>> max_element((std::vector<long>({(long)1, (long)2, (long)3})))\n// (3)\n// >>> max_element((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (123)\nlong max_element(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz((50))\n// (0)\n// >>> fizz_buzz((78))\n// (2)\n// >>> fizz_buzz((79))\n// (3)\nlong fizz_buzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1900,9 +1120,201 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a vector l and returns a vector l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_even((std::vector<long>({(long)5, (long)6, (long)3, (long)4})))\n// (std::vector<long>({(long)3, (long)6, (long)5, (long)4}))\nstd::vector<long> sort_even(std::vector<long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = sort_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)-10, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)5, (long)0, (long)9, (long)1, (long)123})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)-12, (long)4, (long)23, (long)2, (long)3, (long)11, (long)12, (long)-10}))) == (std::vector<long>({(long)-12, (long)8, (long)3, (long)4, (long)5, (long)2, (long)12, (long)11, (long)23, (long)-10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib((1))\n// (2)\n// >>> prime_fib((2))\n// (3)\n// >>> prime_fib((3))\n// (5)\n// >>> prime_fib((4))\n// (13)\n// >>> prime_fib((5))\n// (89)\nlong prime_fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a vector of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)3})))\n// (false)\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)-4, (long)5})))\n// (true)\nbool below_zero(std::vector<long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a vector of integers as an input.\n// it returns true if there are three distinct elements in the vector that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool triples_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return vector with elements incremented by 1.\n// >>> incr_list((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)3, (long)4}))\n// >>> incr_list((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)6, (long)4, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124}))\nstd::vector<long> incr_list(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a vector of integers as an input.\n// it returns true if there are two distinct elements in the vector that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7})))\n// (true)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base((8), (3))\n// (\"22\")\n// >>> change_base((8), (2))\n// (\"1000\")\n// >>> change_base((7), (2))\n// (\"111\")\nstd::string change_base(long x, long base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area((5), (3))\n// (7.5f)\nfloat triangle_area(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4((5))\n// (4)\n// >>> fib4((6))\n// (8)\n// >>> fib4((7))\n// (14)\nlong fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the vector l.\n// >>> median((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (float(3))\n// >>> median((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20})))\n// (15.0f)\nfloat median(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome((\"\"))\n// (true)\n// >>> is_palindrome((\"aba\"))\n// (true)\n// >>> is_palindrome((\"aaaaa\"))\n// (true)\n// >>> is_palindrome((\"zbcd\"))\n// (false)\nbool is_palindrome(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp((3), (5))\n// (3)\n// >>> modp((1101), (101))\n// (2)\n// >>> modp((0), (101))\n// (1)\n// >>> modp((3), (11))\n// (8)\n// >>> modp((100), (101))\n// (1)\nlong modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given vector of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n// (1.0f)\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels((\"\"))\n// (\"\")\n// >>> remove_vowels((\"abcdef\"))\n// (\"bcdf\")\n// >>> remove_vowels((\"aaaaa\"))\n// (\"\")\n// >>> remove_vowels((\"aaBAA\"))\n// (\"B\")\n// >>> remove_vowels((\"zbcd\"))\n// (\"zbcd\")\nstd::string remove_vowels(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if all numbers in the vector l are below threshold t.\n// >>> below_threshold((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100))\n// (true)\n// >>> below_threshold((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5))\n// (false)\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add((2), (3))\n// (5)\n// >>> add((5), (7))\n// (12)\nlong add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1912,9 +1324,21 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if two words have the same characters.\n// >>> same_chars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n// (true)\n// >>> same_chars((\"abcd\"), (\"dddddddabc\"))\n// (true)\n// >>> same_chars((\"dddddddabc\"), (\"abcd\"))\n// (true)\n// >>> same_chars((\"eabcd\"), (\"dddddddabc\"))\n// (false)\n// >>> same_chars((\"abcd\"), (\"dddddddabce\"))\n// (false)\n// >>> same_chars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n// (false)\nbool same_chars(std::string s0, std::string s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = same_chars;\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(candidate((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(candidate((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(candidate((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(candidate((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(candidate((\"aabb\"), (\"aaccc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib((10))\n// (55)\n// >>> fib((1))\n// (1)\n// >>> fib((8))\n// (21)\nlong fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1924,9 +1348,585 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"<\" and \">\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"<\"))\n// (false)\n// >>> correct_bracketing((\"<>\"))\n// (true)\n// >>> correct_bracketing((\"<<><>>\"))\n// (true)\n// >>> correct_bracketing((\"><<>\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"<>\")) == (true));\n    assert(candidate((\"<<><>>\")) == (true));\n    assert(candidate((\"<><><<><>><>\")) == (true));\n    assert(candidate((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(candidate((\"<<<><>>>>\")) == (false));\n    assert(candidate((\"><<>\")) == (false));\n    assert(candidate((\"<\")) == (false));\n    assert(candidate((\"<<<<\")) == (false));\n    assert(candidate((\">\")) == (false));\n    assert(candidate((\"<<>\")) == (false));\n    assert(candidate((\"<><><<><>><>><<>\")) == (false));\n    assert(candidate((\"<><><<><>><>>><>\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true is vector elements are monotonically increasing or decreasing.\n// >>> monotonic((std::vector<long>({(long)1, (long)2, (long)4, (long)20})))\n// (true)\n// >>> monotonic((std::vector<long>({(long)1, (long)20, (long)4, (long)10})))\n// (false)\n// >>> monotonic((std::vector<long>({(long)4, (long)1, (long)0, (long)-10})))\n// (true)\nbool monotonic(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two vectors.\n// >>> common((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121})))\n// (std::vector<long>({(long)1, (long)5, (long)653}))\n// >>> common((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2})))\n// (std::vector<long>({(long)2, (long)3}))\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor((13195))\n// (29)\n// >>> largest_prime_factor((2048))\n// (2)\nlong largest_prime_factor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n// >>> intersperse((std::vector<long>()), (4))\n// (std::vector<long>())\n// >>> intersperse((std::vector<long>({(long)1, (long)2, (long)3})), (4))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)4, (long)3}))\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n((30))\n// (465)\n// >>> sum_to_n((100))\n// (5050)\n// >>> sum_to_n((5))\n// (15)\n// >>> sum_to_n((10))\n// (55)\n// >>> sum_to_n((1))\n// (1)\nlong sum_to_n(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"(\"))\n// (false)\n// >>> correct_bracketing((\"()\"))\n// (true)\n// >>> correct_bracketing((\"(()())\"))\n// (true)\n// >>> correct_bracketing((\")(()\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (std::vector<long>({(long)1, (long)4, (long)12, (long)20}))\n// >>> derivative((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)6}))\nstd::vector<long> derivative(std::vector<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib((1))\n// (0)\n// >>> fibfib((5))\n// (4)\n// >>> fibfib((8))\n// (24)\nlong fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count((\"abcde\"))\n// (2)\n// >>> vowels_count((\"ACEDY\"))\n// (3)\nlong vowels_count(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift((12), (1))\n// (\"21\")\n// >>> circular_shift((12), (2))\n// (\"12\")\nstd::string circular_shift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum((\"\"))\n// (0)\n// >>> digitSum((\"abAB\"))\n// (131)\n// >>> digitSum((\"abcCd\"))\n// (67)\n// >>> digitSum((\"helloE\"))\n// (69)\n// >>> digitSum((\"woArBld\"))\n// (131)\n// >>> digitSum((\"aAaaaXa\"))\n// (153)\nlong digitSum(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution((\"5 apples and 6 oranges\"), (19))\n// (8)\n// >>> fruit_distribution((\"0 apples and 1 oranges\"), (3))\n// (2)\n// >>> fruit_distribution((\"2 apples and 3 oranges\"), (100))\n// (95)\n// >>> fruit_distribution((\"100 apples and 1 oranges\"), (120))\n// (19)\nlong fruit_distribution(std::string s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given a vector representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a vector, [ smalest_value, its index ],\n// If there are no even values or the given vector is empty, return [].\n// Example 1:\n// >>> pluck((std::vector<long>({(long)4, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck((std::vector<long>()))\n// (std::vector<long>())\n// Example 4:\n// >>> pluck((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2})))\n// (std::vector<long>({(long)0, (long)1}))\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the vector.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search((std::vector<long>({(long)4, (long)1, (long)2, (long)2, (long)3, (long)1})))\n// (2)\n// >>> search((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4, (long)4})))\n// (3)\n// >>> search((std::vector<long>({(long)5, (long)5, (long)4, (long)4, (long)4})))\n// (-1)\nlong search(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens((\"(()()) ((())) () ((())()())\"))\n// (std::vector<long>({(long)2, (long)3, (long)1, (long)3}))\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given vector of integers, return vector in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)3}))\n// >>> strange_sort_list((std::vector<long>({(long)5, (long)5, (long)5, (long)5})))\n// (std::vector<long>({(long)5, (long)5, (long)5, (long)5}))\n// >>> strange_sort_list((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area((3), (4), (5))\n// (6.0f)\n// >>> triangle_area((1), (2), (10))\n// (float(-1))\nfloat triangle_area(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly((std::vector<long>({(long)1, (long)2})), (5))\n// (false)\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (1))\n// (false)\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (9))\n// (true)\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly((std::vector<long>({(long)3})), (5))\n// (true)\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector arr of integers, find the minimum number of elements that\n// need to be changed to make the vector palindromic. A palindromic vector is a vector that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6})))\n// (4)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2})))\n// (1)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1})))\n// (0)\nlong smallest_change(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two vectors of strings and returns the vector that has \n// total number of chars in the all strings of the vector less than the other vector.\n// if the two vectors have the same number of chars, return the first vector.\n// Examples\n// >>> total_match((std::vector<std::string>()), (std::vector<std::string>()))\n// (std::vector<std::string>())\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"})))\n// (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"})))\n// (std::vector<std::string>({(std::string)\"4\"}))\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime((30))\n// (true)\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power((1), (4))\n// (true)\n// >>> is_simple_power((2), (2))\n// (true)\n// >>> is_simple_power((8), (2))\n// (true)\n// >>> is_simple_power((3), (2))\n// (false)\n// >>> is_simple_power((3), (1))\n// (false)\n// >>> is_simple_power((5), (3))\n// (false)\nbool is_simple_power(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube((1))\n// (true)\n// >>> iscube((2))\n// (false)\n// >>> iscube((-1))\n// (true)\n// >>> iscube((64))\n// (true)\n// >>> iscube((0))\n// (true)\n// >>> iscube((180))\n// (false)\nbool iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key((\"AB\"))\n// (1)\n// >>> hex_key((\"1077E\"))\n// (2)\n// >>> hex_key((\"ABED1A33\"))\n// (4)\n// >>> hex_key((\"123456789ABCDEF0\"))\n// (6)\n// >>> hex_key((\"2020\"))\n// (2)\nlong hex_key(std::string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary((15))\n// (\"db1111db\")\n// >>> decimal_to_binary((32))\n// (\"db100000db\")\nstd::string decimal_to_binary(long decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input vector of strings only for ones that contain given substring\n// >>> filter_by_substring((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_substring((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is hapcpp or not.\n// A string is hapcpp if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy((\"a\"))\n// (false)\n// >>> is_happy((\"aa\"))\n// (false)\n// >>> is_happy((\"abcd\"))\n// (true)\n// >>> is_happy((\"aabb\"))\n// (false)\n// >>> is_happy((\"adb\"))\n// (true)\n// >>> is_happy((\"xyy\"))\n// (false)\nbool is_happy(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a vector of GPAs for some students and you have to write \n// a function that can output a vector of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f})))\n// (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"}))\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length((\"Hello\"))\n// (true)\n// >>> prime_length((\"abcdcba\"))\n// (true)\n// >>> prime_length((\"kittens\"))\n// (true)\n// >>> prime_length((\"orange\"))\n// (false)\nbool prime_length(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve((1000))\n// (\"1\")\n// >>> solve((150))\n// (\"110\")\n// >>> solve((147))\n// (\"1100\")\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add((std::vector<long>({(long)4, (long)2, (long)6, (long)7})))\n// (2)\nlong add(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle((\"Hi\"))\n// (\"Hi\")\n// >>> anti_shuffle((\"hello\"))\n// (\"ehllo\")\n// >>> anti_shuffle((\"Hello World!!!\"))\n// (\"Hello !!!Wdlor\")\nstd::string anti_shuffle(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested vectors,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the vector,\n// and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)}))\n// >>> get_row((std::vector<std::vector<long>>()), (1))\n// (std::vector<std::tuple<long, long>>())\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)}))\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of non-negative integers, return a cocpp of the given vector after sorting,\n// you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given vector.\n// Examples:\n// >>> sort_array((std::vector<long>()))\n// (std::vector<long>())\n// >>> sort_array((std::vector<long>({(long)5})))\n// (std::vector<long>({(long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6})))\n// (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0}))\nstd::vector<long> sort_array(std::vector<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt((\"hi\"))\n// (\"lm\")\n// >>> encrypt((\"asdfghjkl\"))\n// (\"ewhjklnop\")\n// >>> encrypt((\"gf\"))\n// (\"kj\")\n// >>> encrypt((\"et\"))\n// (\"ix\")\nstd::string encrypt(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product((std::vector<long>()))\n// (std::make_tuple(0, 1))\n// >>> sum_product((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::make_tuple(10, 24))\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the vector.\n// Return None if there is no such element.\n// >>> next_smallest((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// 2\n// >>> next_smallest((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2})))\n// 2\n// >>> next_smallest((std::vector<long>()))\n// std::nullopt\n// >>> next_smallest((std::vector<long>({(long)1, (long)1})))\n// std::nullopt\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored((\"Hello world\"))\n// (0)\n// >>> is_bored((\"The sky is blue. The sun is shining. I love this weather\"))\n// (1)\nlong is_bored(std::string S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int((float(5)), (float(2)), (float(7)))\n// (true)\n// >>> any_int((float(3)), (float(2)), (float(2)))\n// (false)\n// >>> any_int((float(3)), (float(-2)), (float(1)))\n// (true)\n// >>> any_int((3.6f), (-2.2f), (float(2)))\n// (false)\nbool any_int(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode((\"test\"))\n// (\"TGST\")\n// >>> encode((\"This is a message\"))\n// (\"tHKS KS C MGSSCGG\")\nstd::string encode(std::string message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a vector of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3})))\n// (10)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1})))\n// (25)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3})))\n// (13)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6})))\n// (11)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21})))\n// (3)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7})))\n// (7)\nlong skjkasdkd(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a map, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given map is empty.\n// Examples:\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"b\", \"banana\"}})))\n// (true)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {8, \"banana\"}, {\"a\", \"apple\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})))\n// (true)\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns a vector of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to((5))\n// (std::vector<long>({(long)2, (long)3}))\n// >>> count_up_to((11))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7}))\n// >>> count_up_to((0))\n// (std::vector<long>())\n// >>> count_up_to((20))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19}))\n// >>> count_up_to((1))\n// (std::vector<long>())\n// >>> count_up_to((18))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17}))\nstd::vector<long> count_up_to(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply((148), (412))\n// (16)\n// >>> multiply((19), (28))\n// (72)\n// >>> multiply((2020), (1851))\n// (0)\n// >>> multiply((14), (-15))\n// (20)\nlong multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper((\"aBCdEf\"))\n// (1)\n// >>> count_upper((\"abcdefg\"))\n// (0)\n// >>> count_upper((\"dBBE\"))\n// (0)\nlong count_upper(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer((\"10\"))\n// (10)\n// >>> closest_integer((\"15.3\"))\n// (15)\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given vector of integers, generate a vector of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)2})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4}))\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-cpp-transform.json
+++ b/prompts/humaneval-cpp-transform.json
@@ -1,1404 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> string_length((\"\"))\n// (0)\n// >>> string_length((\"abc\"))\n// (3)\nlong string_length(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt((\"hi\"))\n// (\"lm\")\n// >>> encrypt((\"asdfghjkl\"))\n// (\"ewhjklnop\")\n// >>> encrypt((\"gf\"))\n// (\"kj\")\n// >>> encrypt((\"et\"))\n// (\"ix\")\nstd::string encrypt(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"b\", \"banana\"}})))\n// (true)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {8, \"banana\"}, {\"a\", \"apple\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})))\n// (true)\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add((std::vector<long>({(long)4, (long)2, (long)6, (long)7})))\n// (2)\nlong add(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces((\" Example\"))\n// (\"Example\")\n// >>> fix_spaces((\" Example 1\"))\n// (\"Example_1\")\n// >>> fix_spaces((\" Example 2\"))\n// (\"_Example_2\")\n// >>> fix_spaces((\" Example 3\"))\n// (\"_Example-3\")\nstd::string fix_spaces(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib((1))\n// (0)\n// >>> fibfib((5))\n// (4)\n// >>> fibfib((8))\n// (24)\nlong fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference((std::vector<float>({(long)1, (long)3, (long)2, (long)0})))\n// (10)\n// >>> double_the_difference((std::vector<float>({(long)-1, (long)-2, (long)0})))\n// (0)\n// >>> double_the_difference((std::vector<float>({(long)9, (long)-2})))\n// (81)\n// >>> double_the_difference((std::vector<float>({(long)0})))\n// (0)\n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\n// >>> filter_integers((std::vector<std::any>({(std::string)\"a\", (std::string)3.14f, (std::string)5})))\n// (std::vector<long>({(long)5}))\n// >>> filter_integers((std::vector<std::any>({1, 2, 3, \"abc\", std::map<long,long>(), std::vector<long>()})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music((\"o o| .| o| o| .| .| .| .| o o\"))\n// (std::vector<long>({(long)4, (long)2, (long)1, (long)2, (long)2, (long)1, (long)1, (long)1, (long)1, (long)4, (long)4}))\nstd::vector<long> parse_music(std::string music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary((15))\n// (\"db1111db\")\n// >>> decimal_to_binary((32))\n// (\"db100000db\")\nstd::string decimal_to_binary(long decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes((\"abc\"))\n// (std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))\nstd::vector<std::string> all_prefixes(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add((2), (3))\n// (5)\n// >>> add((5), (7))\n// (12)\nlong add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat((5), (6), (10))\n// (std::vector<long>({(long)11, (long)4}))\n// >>> eat((4), (8), (9))\n// (std::vector<long>({(long)12, (long)1}))\n// >>> eat((1), (10), (10))\n// (std::vector<long>({(long)11, (long)0}))\n// >>> eat((2), (11), (5))\n// (std::vector<long>({(long)7, (long)0}))\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1))\n// (6)\n// Example 2:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2))\n// (5)\n// Example 3:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5))\n// (0)\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case((\"Hello\"))\n// (\"hELLO\")\nstd::string flip_case(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3})))\n// (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"}))\n// If the array is empty, return an empty array:\n// >>> by_length((std::vector<long>()))\n// (std::vector<std::string>())\n// If the array has any strange number ignore it:\n// >>> by_length((std::vector<long>({(long)1, (long)-1, (long)55})))\n// (std::vector<std::string>({(std::string)\"One\"}))\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize((8))\n// (std::vector<long>({(long)2, (long)2, (long)2}))\n// >>> factorize((25))\n// (std::vector<long>({(long)5, (long)5}))\n// >>> factorize((70))\n// (std::vector<long>({(long)2, (long)5, (long)7}))\nstd::vector<long> factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to((5))\n// (std::vector<long>({(long)2, (long)3}))\n// >>> count_up_to((11))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7}))\n// >>> count_up_to((0))\n// (std::vector<long>())\n// >>> count_up_to((20))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19}))\n// >>> count_up_to((1))\n// (std::vector<long>())\n// >>> count_up_to((18))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17}))\nstd::vector<long> count_up_to(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\n// >>> unique((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123}))\nstd::vector<long> unique(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match((std::vector<std::string>()), (std::vector<std::string>()))\n// (std::vector<std::string>())\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"})))\n// (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"})))\n// (std::vector<std::string>({(std::string)\"4\"}))\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\n// >>> max_element((std::vector<long>({(long)1, (long)2, (long)3})))\n// (3)\n// >>> max_element((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (123)\nlong max_element(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested((\"[[]]\"))\n// (true)\n// >>> is_nested((\"[]]]]]]][[[[[]\"))\n// (false)\n// >>> is_nested((\"[][]\"))\n// (false)\n// >>> is_nested((\"[]\"))\n// (false)\n// >>> is_nested((\"[[][]]\"))\n// (true)\n// >>> is_nested((\"[[]][[\"))\n// (true)\nbool is_nested(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg((1), (5))\n// \"0b11\"\n// >>> rounded_avg((7), (5))\n// -1\n// >>> rounded_avg((10), (20))\n// \"0b1111\"\n// >>> rounded_avg((20), (33))\n// \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count((std::vector<std::string>({(std::string)\"1234567\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n// >>> odd_count((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2})))\n// (true)\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2})))\n// (false)\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome((3))\n// (std::make_tuple(1, 2))\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome((12))\n// (std::make_tuple(4, 6))\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even((4))\n// (false)\n// >>> is_equal_to_sum_even((6))\n// (false)\n// >>> is_equal_to_sum_even((8))\n// (true)\nbool is_equal_to_sum_even(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (std::vector<long>({(long)1, (long)4, (long)12, (long)20}))\n// >>> derivative((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)6}))\nstd::vector<long> derivative(std::vector<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted((std::vector<long>({(long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4})))\n// (false)\nbool is_sorted(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve((\"1234\"))\n// (\"4321\")\n// >>> solve((\"ab\"))\n// (\"AB\")\n// >>> solve((\"#a@C\"))\n// (\"#A@c\")\nstd::string solve(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri((3))\n// (std::vector<long>({(long)1, (long)3, (long)2, (long)8}))\nstd::vector<long> tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz((50))\n// (0)\n// >>> fizz_buzz((78))\n// (2)\n// >>> fizz_buzz((79))\n// (3)\nlong fizz_buzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_prefix((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bcd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve((1000))\n// (\"1\")\n// >>> solve((150))\n// (\"110\")\n// >>> solve((147))\n// (\"1100\")\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3))\n// (std::vector<long>({(long)1, (long)2, (long)1}))\n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1))\n// (std::vector<long>({(long)1}))\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper((\"aBCdEf\"))\n// (1)\n// >>> count_upper((\"abcdefg\"))\n// (0)\n// >>> count_upper((\"dBBE\"))\n// (0)\nlong count_upper(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum((std::vector<long>({(long)-3, (long)-4, (long)5})), (3))\n// (std::vector<long>({(long)-4, (long)-3, (long)5}))\n// Example 2:\n// >>> maximum((std::vector<long>({(long)4, (long)-4, (long)4})), (2))\n// (std::vector<long>({(long)4, (long)4}))\n// Example 3:\n// >>> maximum((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1))\n// (std::vector<long>({(long)2}))\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor((15))\n// (5)\nlong largest_divisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array((std::vector<long>()))\n// (std::vector<long>())\n// >>> sort_array((std::vector<long>({(long)5})))\n// (std::vector<long>({(long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6})))\n// (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0}))\nstd::vector<long> sort_array(std::vector<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f((5))\n// (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15}))\nstd::vector<long> f(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube((1))\n// (true)\n// >>> iscube((2))\n// (false)\n// >>> iscube((-1))\n// (true)\n// >>> iscube((64))\n// (true)\n// >>> iscube((0))\n// (true)\n// >>> iscube((180))\n// (false)\nbool iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode((\"test\"))\n// (\"TGST\")\n// >>> encode((\"This is a message\"))\n// (\"tHKS KS C MGSSCGG\")\nstd::string encode(std::string message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored((\"Hello world\"))\n// (0)\n// >>> is_bored((\"The sky is blue. The sun is shining. I love this weather\"))\n// (1)\nlong is_bored(std::string S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7})))\n// (true)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area((3), (4), (5))\n// (6.0f)\n// >>> triangle_area((1), (2), (10))\n// (float(-1))\nfloat triangle_area(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf((\"Jupiter\"), (\"Neptune\"))\n// (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"}))\n// >>> bf((\"Earth\"), (\"Mercury\"))\n// (std::vector<std::string>(\"Venus\"))\n// >>> bf((\"Mercury\"), (\"Uranus\"))\n// (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"}))\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits((1))\n// (1)\n// >>> digits((4))\n// (0)\n// >>> digits((235))\n// (15)\nlong digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string((\"Hi, my name is John\"))\n// (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"}))\n// >>> words_string((\"One, two, three, four, five, six\"))\n// (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"}))\nstd::vector<std::string> words_string(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times((\"\"), (\"a\"))\n// (0)\n// >>> how_many_times((\"aaa\"), (\"a\"))\n// (3)\n// >>> how_many_times((\"aaaa\"), (\"aa\"))\n// (3)\nlong how_many_times(std::string string, std::string substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5f)\n// 2.5f\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// std::nullopt\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels((\"\"))\n// (\"\")\n// >>> remove_vowels((\"abcdef\"))\n// (\"bcdf\")\n// >>> remove_vowels((\"aaaaa\"))\n// (\"\")\n// >>> remove_vowels((\"aaBAA\"))\n// (\"B\")\n// >>> remove_vowels((\"zbcd\"))\n// (\"zbcd\")\nstd::string remove_vowels(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)3}))\n// >>> strange_sort_list((std::vector<long>({(long)5, (long)5, (long)5, (long)5})))\n// (std::vector<long>({(long)5, (long)5, (long)5, (long)5}))\n// >>> strange_sort_list((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n// (std::make_tuple(2.0f, 2.2f))\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n// (std::make_tuple(2.0f, 2.0f))\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power((1), (4))\n// (true)\n// >>> is_simple_power((2), (2))\n// (true)\n// >>> is_simple_power((8), (2))\n// (true)\n// >>> is_simple_power((3), (2))\n// (false)\n// >>> is_simple_power((3), (1))\n// (false)\n// >>> is_simple_power((5), (3))\n// (false)\nbool is_simple_power(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib((1))\n// (2)\n// >>> prime_fib((2))\n// (3)\n// >>> prime_fib((3))\n// (5)\n// >>> prime_fib((4))\n// (13)\n// >>> prime_fib((5))\n// (89)\nlong prime_fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12})))\n// (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11}))\n// >>> order_by_points((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})), (0.5f))\n// (false)\n// >>> has_close_elements((std::vector<float>({(float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.3f))\n// (true)\nbool has_close_elements(std::vector<float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = has_close_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome((\"\"))\n// (\"\")\n// >>> make_palindrome((\"cat\"))\n// (\"catac\")\n// >>> make_palindrome((\"cata\"))\n// (\"catac\")\nstd::string make_palindrome(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor((\"010\"), (\"110\"))\n// (\"100\")\nstd::string string_xor(std::string a, std::string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial((4))\n// (288)\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4))\n// (24)\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4((5))\n// (4)\n// >>> fib4((6))\n// (8)\n// >>> fib4((7))\n// (14)\nlong fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits((std::vector<long>({(long)15, (long)33, (long)1422, (long)1})))\n// (std::vector<long>({(long)1, (long)15, (long)33}))\n// >>> unique_digits((std::vector<long>({(long)152, (long)323, (long)1422, (long)10})))\n// (std::vector<long>())\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words((\"Mary had a little lamb\"), (4))\n// (std::vector<std::string>({(std::string)\"little\"}))\n// >>> select_words((\"Mary had a little lamb\"), (3))\n// (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"}))\n// >>> select_words((\"simple white space\"), (2))\n// (std::vector<std::string>())\n// >>> select_words((\"Hello world\"), (4))\n// (std::vector<std::string>({(std::string)\"world\"}))\n// >>> select_words((\"Uncle sam\"), (3))\n// (std::vector<std::string>({(std::string)\"Uncle\"}))\nstd::vector<std::string> select_words(std::string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly((std::vector<long>({(long)1, (long)2})), (5))\n// (false)\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (1))\n// (false)\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (9))\n// (true)\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly((std::vector<long>({(long)3})), (5))\n// (true)\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib((10))\n// (55)\n// >>> fib((1))\n// (1)\n// >>> fib((8))\n// (21)\nlong fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension((\"my_class\"), (std::vector<std::string>({(std::string)\"AA\", (std::string)\"Be\", (std::string)\"CC\"})))\n// (\"my_class.AA\")\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"})))\n// (\"Yes\")\n// >>> match_parens((std::vector<std::string>({(std::string)\")\", (std::string)\")\"})))\n// (\"No\")\nstd::string match_parens(std::vector<std::string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// 2\n// >>> next_smallest((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2})))\n// 2\n// >>> next_smallest((std::vector<long>()))\n// std::nullopt\n// >>> next_smallest((std::vector<long>({(long)1, (long)1})))\n// std::nullopt\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int((float(5)), (float(2)), (float(7)))\n// (true)\n// >>> any_int((float(3)), (float(2)), (float(2)))\n// (false)\n// >>> any_int((float(3)), (float(-2)), (float(1)))\n// (true)\n// >>> any_int((3.6f), (-2.2f), (float(2)))\n// (false)\nbool any_int(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number((3.5f))\n// (0.5f)\nfloat truncate_number(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\n// >>> incr_list((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)3, (long)4}))\n// >>> incr_list((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)6, (long)4, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124}))\nstd::vector<long> incr_list(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y((7), (34), (12))\n// (34)\n// >>> x_or_y((15), (8), (5))\n// (5)\nlong x_or_y(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp((3), (5))\n// (3)\n// >>> modp((1101), (101))\n// (2)\n// >>> modp((0), (101))\n// (1)\n// >>> modp((3), (11))\n// (8)\n// >>> modp((100), (101))\n// (1)\nlong modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count((-12))\n// (std::make_tuple(1, 1))\n// >>> even_odd_count((123))\n// (std::make_tuple(1, 2))\nstd::tuple<long, long> even_odd_count(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy((\"a\"))\n// (false)\n// >>> is_happy((\"aa\"))\n// (false)\n// >>> is_happy((\"abcd\"))\n// (true)\n// >>> is_happy((\"aabb\"))\n// (false)\n// >>> is_happy((\"adb\"))\n// (true)\n// >>> is_happy((\"xyy\"))\n// (false)\nbool is_happy(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor((13195))\n// (29)\n// >>> largest_prime_factor((2048))\n// (2)\nlong largest_prime_factor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum((\"\"))\n// (0)\n// >>> digitSum((\"abAB\"))\n// (131)\n// >>> digitSum((\"abcCd\"))\n// (67)\n// >>> digitSum((\"helloE\"))\n// (69)\n// >>> digitSum((\"woArBld\"))\n// (131)\n// >>> digitSum((\"aAaaaXa\"))\n// (153)\nlong digitSum(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n// (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution((std::vector<long>({(long)5, (long)8, (long)7, (long)1})))\n// (12)\n// >>> solution((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3})))\n// (9)\n// >>> solution((std::vector<long>({(long)30, (long)13, (long)24, (long)321})))\n// (0)\nlong solution(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck((std::vector<long>({(long)4, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck((std::vector<long>()))\n// (std::vector<long>())\n// Example 4:\n// >>> pluck((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2})))\n// (std::vector<long>({(long)0, (long)1}))\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples((5))\n// (1)\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (\"YES\")\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4})))\n// (\"NO\")\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\n// >>> median((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (float(3))\n// >>> median((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20})))\n// (15.0f)\nfloat median(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length((\"Hello\"))\n// (true)\n// >>> prime_length((\"abcdcba\"))\n// (true)\n// >>> prime_length((\"kittens\"))\n// (true)\n// >>> prime_length((\"orange\"))\n// (false)\nbool prime_length(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6})))\n// (4)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2})))\n// (1)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1})))\n// (0)\nlong smallest_change(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})))\n// (14)\n// >>> lst((std::vector<float>({(float)1.0f, (float)4.0f, (float)9.0f})))\n// (98)\n// >>> lst((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n// (84)\n// >>> lst((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f})))\n// (29)\n// >>> lst((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f})))\n// (6)\nlong sum_squares(std::vector<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check((\"example.txt\"))\n// (\"Yes\")\n// >>> file_name_check((\"1example.dll\"))\n// (\"No\")\nstd::string file_name_check(std::string file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool triples_sum_to_zero(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection((std::make_tuple(1, 2)), (std::make_tuple(2, 3)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-1, 1)), (std::make_tuple(0, 4)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5)))\n// (\"YES\")\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups((\"( ) (( )) (( )( ))\"))\n// (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"}))\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2})))\n// (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3}))\n// >>> compare((std::vector<long>({(long)0, (long)5, (long)0, (long)0, (long)0, (long)4})), (std::vector<long>({(long)4, (long)1, (long)1, (long)0, (long)0, (long)-2})))\n// (std::vector<long>({(long)4, (long)4, (long)1, (long)0, (long)0, (long)6}))\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter((\"apple pie\"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"apple pi e\"))\n// (true)\n// >>> check_if_last_char_is_a_letter((\"apple pi e \"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"\"))\n// (false)\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date((\"03-11-2000\"))\n// (true)\n// >>> valid_date((\"15-01-2012\"))\n// (false)\n// >>> valid_date((\"04-0-2040\"))\n// (false)\n// >>> valid_date((\"06-04-2020\"))\n// (true)\n// >>> valid_date((\"06/04/2020\"))\n// (false)\nbool valid_date(std::string date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums((std::vector<long>()))\n// (0)\n// >>> count_nums((std::vector<long>({(long)-1, (long)11, (long)-11})))\n// (1)\n// >>> count_nums((std::vector<long>({(long)1, (long)1, (long)2})))\n// (3)\nlong count_nums(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle((\"Hi\"))\n// (\"Hi\")\n// >>> anti_shuffle((\"hello\"))\n// (\"ehllo\")\n// >>> anti_shuffle((\"Hello World!!!\"))\n// (\"Hello !!!Wdlor\")\nstd::string anti_shuffle(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome((\"\"))\n// (true)\n// >>> is_palindrome((\"aba\"))\n// (true)\n// >>> is_palindrome((\"aaaaa\"))\n// (true)\n// >>> is_palindrome((\"zbcd\"))\n// (false)\nbool is_palindrome(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel((\"yogurt\"))\n// (\"u\")\n// >>> get_closest_vowel((\"FULL\"))\n// (\"U\")\n// >>> get_closest_vowel((\"quick\"))\n// (\"\")\n// >>> get_closest_vowel((\"ab\"))\n// (\"\")\nstd::string get_closest_vowel(std::string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime((6))\n// (false)\n// >>> is_prime((101))\n// (true)\n// >>> is_prime((11))\n// (true)\n// >>> is_prime((13441))\n// (true)\n// >>> is_prime((61))\n// (true)\n// >>> is_prime((4))\n// (false)\n// >>> is_prime((1))\n// (false)\nbool is_prime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify((\"1/5\"), (\"5/1\"))\n// (true)\n// >>> simplify((\"1/6\"), (\"2/1\"))\n// (false)\n// >>> simplify((\"7/10\"), (\"10/2\"))\n// (false)\nbool simplify(std::string x, std::string n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key((\"AB\"))\n// (1)\n// >>> hex_key((\"1077E\"))\n// (2)\n// >>> hex_key((\"ABED1A33\"))\n// (4)\n// >>> hex_key((\"123456789ABCDEF0\"))\n// (6)\n// >>> hex_key((\"2020\"))\n// (2)\nlong hex_key(std::string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence((\"This is a test\"))\n// (\"is\")\n// Example 2:\n// >>> words_in_sentence((\"lets go for swimming\"))\n// (\"go for\")\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram((\"a b c\"))\n// (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}}))\n// >>> histogram((\"a b b a\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"a b c a b\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"b b b b a\"))\n// (std::map<std::string,long>({{\"b\", 4}}))\n// >>> histogram((\"\"))\n// (std::map<std::string,long>())\nstd::map<std::string,long> histogram(std::string test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)}))\n// >>> get_row((std::vector<std::vector<long>>()), (1))\n// (std::vector<std::tuple<long, long>>())\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)}))\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz((5))\n// (std::vector<long>({(long)1, (long)5}))\nstd::vector<long> get_odd_collatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})))\n// (3)\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)3})))\n// (-1)\nlong can_arrange(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers((\"three one five\"))\n// (\"one three five\")\nstd::string sort_numbers(std::string numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift((12), (1))\n// (\"21\")\n// >>> circular_shift((12), (2))\n// (\"12\")\nstd::string circular_shift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// (long({(long)1, (long)2, (long)3}))\n// >>> lst\n// (long())\n// >>> lst\n// (long({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))\nlong sum_squares(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3})))\n// (10)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1})))\n// (25)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3})))\n// (13)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6})))\n// (11)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21})))\n// (3)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7})))\n// (7)\nlong skjkasdkd(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product((std::vector<long>()))\n// (std::make_tuple(0, 1))\n// >>> sum_product((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::make_tuple(10, 24))\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num((12), (15))\n// (14)\n// >>> choose_num((13), (12))\n// (-1)\nlong choose_num(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1))\n// >>> largest_smallest_integers((std::vector<long>()))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\n// >>> largest_smallest_integers((std::vector<long>({(long)0})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters((\"xyzXYZ\"))\n// (3)\n// >>> count_distinct_characters((\"Jerry\"))\n// (4)\nlong count_distinct_characters(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1408,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile((3))\n// (std::vector<long>({(long)3, (long)5, (long)7}))\nstd::vector<long> make_a_pile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = make_a_pile;\n    assert(candidate((3)) == (std::vector<long>({(long)3, (long)5, (long)7})));\n    assert(candidate((4)) == (std::vector<long>({(long)4, (long)6, (long)8, (long)10})));\n    assert(candidate((5)) == (std::vector<long>({(long)5, (long)7, (long)9, (long)11, (long)13})));\n    assert(candidate((6)) == (std::vector<long>({(long)6, (long)8, (long)10, (long)12, (long)14, (long)16})));\n    assert(candidate((8)) == (std::vector<long>({(long)8, (long)10, (long)12, (long)14, (long)16, (long)18, (long)20, (long)22})));\n}\n",
     "stop_tokens": [
@@ -1416,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs((std::vector<long>({(long)1, (long)2, (long)2, (long)-4})))\n// 9\n// >>> prod_signs((std::vector<long>({(long)0, (long)1})))\n// 0\n// >>> prod_signs((std::vector<long>()))\n// std::nullopt\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string((\"Hi, my name is John\"))\n// (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"}))\n// >>> words_string((\"One, two, three, four, five, six\"))\n// (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"}))\nstd::vector<std::string> words_string(std::string s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = words_string;\n    assert(candidate((\"Hi, my name is John\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\", (std::string)\"is\", (std::string)\"John\"})));\n    assert(candidate((\"One, two, three, four, five, six\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"Hi, my name\")) == (std::vector<std::string>({(std::string)\"Hi\", (std::string)\"my\", (std::string)\"name\"})));\n    assert(candidate((\"One,, two, three, four, five, six,\")) == (std::vector<std::string>({(std::string)\"One\", (std::string)\"two\", (std::string)\"three\", (std::string)\"four\", (std::string)\"five\", (std::string)\"six\"})));\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"ahmed     , gamal\")) == (std::vector<std::string>({(std::string)\"ahmed\", (std::string)\"gamal\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4})))\n// (1)\n// >>> minSubArraySum((std::vector<long>({(long)-1, (long)-2, (long)-3})))\n// (-6)\nlong minSubArraySum(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num((12), (15))\n// (14)\n// >>> choose_num((13), (12))\n// (-1)\nlong choose_num(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = choose_num;\n    assert(candidate((12), (15)) == (14));\n    assert(candidate((13), (12)) == (-1));\n    assert(candidate((33), (12354)) == (12354));\n    assert(candidate((5234), (5233)) == (-1));\n    assert(candidate((6), (29)) == (28));\n    assert(candidate((27), (10)) == (-1));\n    assert(candidate((7), (7)) == (-1));\n    assert(candidate((546), (546)) == (546));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence((0))\n// (\"0\")\n// >>> string_sequence((5))\n// (\"0 1 2 3 4 5\")\nstd::string string_sequence(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg((1), (5))\n// \"0b11\"\n// >>> rounded_avg((7), (5))\n// -1\n// >>> rounded_avg((10), (20))\n// \"0b1111\"\n// >>> rounded_avg((20), (33))\n// \"0b11010\"\nUnion_std_string_long rounded_avg(long n, long m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = rounded_avg;\n    assert(candidate((1), (5)) == \"0b11\");\n    assert(candidate((7), (13)) == \"0b1010\");\n    assert(candidate((964), (977)) == \"0b1111001010\");\n    assert(candidate((996), (997)) == \"0b1111100100\");\n    assert(candidate((560), (851)) == \"0b1011000010\");\n    assert(candidate((185), (546)) == \"0b101101110\");\n    assert(candidate((362), (496)) == \"0b110101101\");\n    assert(candidate((350), (902)) == \"0b1001110010\");\n    assert(candidate((197), (233)) == \"0b11010111\");\n    assert(candidate((7), (5)) == -1);\n    assert(candidate((5), (1)) == -1);\n    assert(candidate((5), (5)) == \"0b101\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check((\"abcd\"), (\"abd\"))\n// (false)\n// >>> cycpattern_check((\"hello\"), (\"ell\"))\n// (true)\n// >>> cycpattern_check((\"whassup\"), (\"psus\"))\n// (false)\n// >>> cycpattern_check((\"abab\"), (\"baa\"))\n// (true)\n// >>> cycpattern_check((\"efef\"), (\"eeff\"))\n// (false)\n// >>> cycpattern_check((\"himenss\"), (\"simen\"))\n// (true)\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits((std::vector<long>({(long)15, (long)33, (long)1422, (long)1})))\n// (std::vector<long>({(long)1, (long)15, (long)33}))\n// >>> unique_digits((std::vector<long>({(long)152, (long)323, (long)1422, (long)10})))\n// (std::vector<long>())\nstd::vector<long> unique_digits(std::vector<long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = unique_digits;\n    assert(candidate((std::vector<long>({(long)15, (long)33, (long)1422, (long)1}))) == (std::vector<long>({(long)1, (long)15, (long)33})));\n    assert(candidate((std::vector<long>({(long)152, (long)323, (long)1422, (long)10}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)12345, (long)2033, (long)111, (long)151}))) == (std::vector<long>({(long)111, (long)151})));\n    assert(candidate((std::vector<long>({(long)135, (long)103, (long)31}))) == (std::vector<long>({(long)31, (long)135})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic((std::vector<long>({(long)1, (long)2, (long)4, (long)20})))\n// (true)\n// >>> monotonic((std::vector<long>({(long)1, (long)20, (long)4, (long)10})))\n// (false)\n// >>> monotonic((std::vector<long>({(long)4, (long)1, (long)0, (long)-10})))\n// (true)\nbool monotonic(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3})))\n// (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"}))\n// If the array is empty, return an empty array:\n// >>> by_length((std::vector<long>()))\n// (std::vector<std::string>())\n// If the array has any strange number ignore it:\n// >>> by_length((std::vector<long>({(long)1, (long)-1, (long)55})))\n// (std::vector<std::string>({(std::string)\"One\"}))\nstd::vector<std::string> by_length(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = by_length;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)1, (long)4, (long)5, (long)8, (long)2, (long)3}))) == (std::vector<std::string>({(std::string)\"Eight\", (std::string)\"Five\", (std::string)\"Four\", (std::string)\"Three\", (std::string)\"Two\", (std::string)\"Two\", (std::string)\"One\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)55}))) == (std::vector<std::string>({(std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)3, (long)2}))) == (std::vector<std::string>({(std::string)\"Three\", (std::string)\"Two\", (std::string)\"One\"})));\n    assert(candidate((std::vector<long>({(long)9, (long)4, (long)8}))) == (std::vector<std::string>({(std::string)\"Nine\", (std::string)\"Eight\", (std::string)\"Four\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest((std::vector<std::string>()))\n// std::nullopt\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// \"a\"\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"bb\", (std::string)\"ccc\"})))\n// \"ccc\"\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f((5))\n// (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15}))\nstd::vector<long> f(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = f;\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)2, (long)6, (long)24, (long)15, (long)720, (long)28})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)2, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100))\n// (true)\n// >>> below_threshold((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5))\n// (false)\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome((3))\n// (std::make_tuple(1, 2))\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome((12))\n// (std::make_tuple(4, 6))\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nstd::tuple<long, long> even_odd_palindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_palindrome;\n    assert(candidate((123)) == (std::make_tuple(8, 13)));\n    assert(candidate((12)) == (std::make_tuple(4, 6)));\n    assert(candidate((3)) == (std::make_tuple(1, 2)));\n    assert(candidate((63)) == (std::make_tuple(6, 8)));\n    assert(candidate((25)) == (std::make_tuple(5, 6)));\n    assert(candidate((19)) == (std::make_tuple(4, 6)));\n    assert(candidate((9)) == (std::make_tuple(4, 5)));\n    assert(candidate((1)) == (std::make_tuple(0, 1)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime((30))\n// (true)\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums((std::vector<long>()))\n// (0)\n// >>> count_nums((std::vector<long>({(long)-1, (long)11, (long)-11})))\n// (1)\n// >>> count_nums((std::vector<long>({(long)1, (long)1, (long)2})))\n// (3)\nlong count_nums(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_nums;\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)-2, (long)3, (long)4, (long)5}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)9, (long)-6, (long)0, (long)1, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)100, (long)98, (long)-7, (long)1, (long)-1}))) == (4));\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)34, (long)-45, (long)-56, (long)0}))) == (5));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\n// >>> get_positive((std::vector<long>({(long)-1, (long)2, (long)-4, (long)5, (long)6})))\n// (std::vector<long>({(long)2, (long)5, (long)6}))\n// >>> get_positive((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)9, (long)123, (long)1}))\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2})))\n// (true)\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2})))\n// (false)\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nbool move_one_ball(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = move_one_ball;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)10, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)4, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_third((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2})))\n// (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5}))\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome((\"\"))\n// (\"\")\n// >>> make_palindrome((\"cat\"))\n// (\"catac\")\n// >>> make_palindrome((\"cata\"))\n// (\"catac\")\nstd::string make_palindrome(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = make_palindrome;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"x\")) == (\"x\"));\n    assert(candidate((\"xyz\")) == (\"xyzyx\"));\n    assert(candidate((\"xyx\")) == (\"xyx\"));\n    assert(candidate((\"jerry\")) == (\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens((\"(()()) ((())) () ((())()())\"))\n// (std::vector<long>({(long)2, (long)3, (long)1, (long)3}))\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (\"YES\")\n// >>> exchange((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4})))\n// (\"NO\")\n// It is assumed that the input lists will be non-empty.\nstd::string exchange(std::vector<long> lst1, std::vector<long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = exchange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)1, (long)5, (long)3, (long)4}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)2, (long)1, (long)4, (long)3}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)4}))) == (\"YES\"));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)3})), (std::vector<long>({(long)2, (long)6, (long)3}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)6, (long)1, (long)8, (long)9})), (std::vector<long>({(long)3, (long)5, (long)5, (long)1, (long)1, (long)1}))) == (\"NO\"));\n    assert(candidate((std::vector<long>({(long)100, (long)200})), (std::vector<long>({(long)200, (long)200}))) == (\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area((5), (3))\n// (7.5f)\nfloat triangle_area(long a, long h) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram((\"a b c\"))\n// (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}}))\n// >>> histogram((\"a b b a\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"a b c a b\"))\n// (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}}))\n// >>> histogram((\"b b b b a\"))\n// (std::map<std::string,long>({{\"b\", 4}}))\n// >>> histogram((\"\"))\n// (std::map<std::string,long>())\nstd::map<std::string,long> histogram(std::string test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply((148), (412))\n// (16)\n// >>> multiply((19), (28))\n// (72)\n// >>> multiply((2020), (1851))\n// (0)\n// >>> multiply((14), (-15))\n// (20)\nlong multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n// (1.0f)\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\n// >>> common((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121})))\n// (std::vector<long>({(long)1, (long)5, (long)653}))\n// >>> common((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2})))\n// (std::vector<long>({(long)2, (long)3}))\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman((19))\n// (\"xix\")\n// >>> int_to_mini_roman((152))\n// (\"clii\")\n// >>> int_to_mini_roman((426))\n// (\"cdxxvi\")\nstd::string int_to_mini_roman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution((\"5 apples and 6 oranges\"), (19))\n// (8)\n// >>> fruit_distribution((\"0 apples and 1 oranges\"), (3))\n// (2)\n// >>> fruit_distribution((\"2 apples and 3 oranges\"), (100))\n// (95)\n// >>> fruit_distribution((\"100 apples and 1 oranges\"), (120))\n// (19)\nlong fruit_distribution(std::string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = histogram;\n    assert(candidate((\"a b b a\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c a b\")) == (std::map<std::string,long>({{\"a\", 2}, {\"b\", 2}})));\n    assert(candidate((\"a b c d g\")) == (std::map<std::string,long>({{\"a\", 1}, {\"b\", 1}, {\"c\", 1}, {\"d\", 1}, {\"g\", 1}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"b b b b a\")) == (std::map<std::string,long>({{\"b\", 4}})));\n    assert(candidate((\"r t g\")) == (std::map<std::string,long>({{\"r\", 1}, {\"t\", 1}, {\"g\", 1}})));\n    assert(candidate((\"\")) == (std::map<std::string,long>()));\n    assert(candidate((\"a\")) == (std::map<std::string,long>({{\"a\", 1}})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +172,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// >>> reverse_delete((\"abcde\"), (\"ae\"))\n// (std::make_tuple(\"bcd\", false))\n// >>> reverse_delete((\"abcdef\"), (\"b\"))\n// (std::make_tuple(\"acdef\", false))\n// >>> reverse_delete((\"abcdedcba\"), (\"ab\"))\n// (std::make_tuple(\"cdedc\", true))\nstd::tuple<std::string, bool> reverse_delete(std::string s, std::string c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = reverse_delete;\n    assert(candidate((\"abcde\"), (\"ae\")) == (std::make_tuple(\"bcd\", false)));\n    assert(candidate((\"abcdef\"), (\"b\")) == (std::make_tuple(\"acdef\", false)));\n    assert(candidate((\"abcdedcba\"), (\"ab\")) == (std::make_tuple(\"cdedc\", true)));\n    assert(candidate((\"dwik\"), (\"w\")) == (std::make_tuple(\"dik\", false)));\n    assert(candidate((\"a\"), (\"a\")) == (std::make_tuple(\"\", true)));\n    assert(candidate((\"abcdedcba\"), (\"\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"abcdedcba\"), (\"v\")) == (std::make_tuple(\"abcdedcba\", true)));\n    assert(candidate((\"vabba\"), (\"v\")) == (std::make_tuple(\"abba\", true)));\n    assert(candidate((\"mamma\"), (\"mia\")) == (std::make_tuple(\"\", true)));\n}\n",
     "stop_tokens": [
@@ -1632,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor((3), (5))\n// (1)\n// >>> greatest_common_divisor((25), (15))\n// (5)\nlong greatest_common_divisor(long a, long b) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count((std::vector<std::string>({(std::string)\"1234567\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n// >>> odd_count((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"})))\n// (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\nstd::vector<std::string> odd_count(std::vector<std::string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = odd_count;\n    assert(candidate((std::vector<std::string>({(std::string)\"1234567\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"3\", (std::string)\"11111111\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (std::string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"271\", (std::string)\"137\", (std::string)\"314\"}))) == (std::vector<std::string>({(std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (std::string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (std::string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words((\"Hello world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"Hello,world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"abcdef\"))\n// 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4})))\n// (1)\n// >>> minSubArraySum((std::vector<long>({(long)-1, (long)-2, (long)-3})))\n// (-6)\nlong minSubArraySum(std::vector<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = minSubArraySum;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)1, (long)2, (long)4}))) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (-6));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)2, (long)-10}))) == (-14));\n    assert(candidate((std::vector<long>({(long)-9999999999999999}))) == (-9999999999999999));\n    assert(candidate((std::vector<long>({(long)0, (long)10, (long)20, (long)1000000}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)100, (long)-1, (long)-2, (long)-3, (long)10, (long)-5}))) == (-6));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)13, (long)8, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)100, (long)-33, (long)32, (long)-1, (long)0, (long)-2}))) == (-33));\n    assert(candidate((std::vector<long>({(long)-10}))) == (-10));\n    assert(candidate((std::vector<long>({(long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)1, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1))\n// (6)\n// Example 2:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2))\n// (5)\n// Example 3:\n// >>> max_fill((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5))\n// (0)\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nlong max_fill(std::vector<std::vector<long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_fill;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (1)) == (6));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)1, (long)1, (long)1})})), (2)) == (5));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)0, (long)0, (long)0})})), (5)) == (0));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (2)) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1, (long)1})})), (9)) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1660,7 +220,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6})))\n// (std::vector<long>({(long)-6, (long)-5, (long)-4, (long)-3, (long)-2}))\n// >>> sort_array((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4}))\nstd::vector<long> sort_array(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)-4, (long)-5, (long)-6}))) == (std::vector<long>({(long)-4, (long)-2, (long)-6, (long)-5, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)77, (long)4, (long)5, (long)3, (long)5, (long)7, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)4, (long)4, (long)3, (long)3, (long)5, (long)5, (long)5, (long)7, (long)77})));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)44, (long)12, (long)32, (long)5}))) == (std::vector<long>({(long)32, (long)3, (long)5, (long)6, (long)12, (long)44})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32}))) == (std::vector<long>({(long)2, (long)4, (long)8, (long)16, (long)32})));\n}\n",
     "stop_tokens": [
@@ -1668,133 +228,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\n// >>> concatenate((std::vector<std::string>()))\n// (\"\")\n// >>> concatenate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// (\"abc\")\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words((\"Mary had a little lamb\"), (4))\n// (std::vector<std::string>({(std::string)\"little\"}))\n// >>> select_words((\"Mary had a little lamb\"), (3))\n// (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"}))\n// >>> select_words((\"simple white space\"), (2))\n// (std::vector<std::string>())\n// >>> select_words((\"Hello world\"), (4))\n// (std::vector<std::string>({(std::string)\"world\"}))\n// >>> select_words((\"Uncle sam\"), (3))\n// (std::vector<std::string>({(std::string)\"Uncle\"}))\nstd::vector<std::string> select_words(std::string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = select_words;\n    assert(candidate((\"Mary had a little lamb\"), (4)) == (std::vector<std::string>({(std::string)\"little\"})));\n    assert(candidate((\"Mary had a little lamb\"), (3)) == (std::vector<std::string>({(std::string)\"Mary\", (std::string)\"lamb\"})));\n    assert(candidate((\"simple white space\"), (2)) == (std::vector<std::string>()));\n    assert(candidate((\"Hello world\"), (4)) == (std::vector<std::string>({(std::string)\"world\"})));\n    assert(candidate((\"Uncle sam\"), (3)) == (std::vector<std::string>({(std::string)\"Uncle\"})));\n    assert(candidate((\"\"), (4)) == (std::vector<std::string>()));\n    assert(candidate((\"a b c d e f\"), (1)) == (std::vector<std::string>({(std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"f\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"})))\n// (std::vector<std::string>({(std::string)\"aa\"}))\n// >>> list_sort((std::vector<std::string>({(std::string)\"ab\", (std::string)\"a\", (std::string)\"aaa\", (std::string)\"cd\"})))\n// (std::vector<std::string>({(std::string)\"ab\", (std::string)\"cd\"}))\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel((\"yogurt\"))\n// (\"u\")\n// >>> get_closest_vowel((\"FULL\"))\n// (\"U\")\n// >>> get_closest_vowel((\"quick\"))\n// (\"\")\n// >>> get_closest_vowel((\"ab\"))\n// (\"\")\nstd::string get_closest_vowel(std::string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_closest_vowel;\n    assert(candidate((\"yogurt\")) == (\"u\"));\n    assert(candidate((\"full\")) == (\"u\"));\n    assert(candidate((\"easy\")) == (\"\"));\n    assert(candidate((\"eAsy\")) == (\"\"));\n    assert(candidate((\"ali\")) == (\"\"));\n    assert(candidate((\"bad\")) == (\"a\"));\n    assert(candidate((\"most\")) == (\"o\"));\n    assert(candidate((\"ab\")) == (\"\"));\n    assert(candidate((\"ba\")) == (\"\"));\n    assert(candidate((\"quick\")) == (\"\"));\n    assert(candidate((\"anime\")) == (\"i\"));\n    assert(candidate((\"Asia\")) == (\"\"));\n    assert(candidate((\"Above\")) == (\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_substring((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"})))\n// (\"Yes\")\n// >>> match_parens((std::vector<std::string>({(std::string)\")\", (std::string)\")\"})))\n// (\"No\")\nstd::string match_parens(std::vector<std::string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = match_parens;\n    assert(candidate((std::vector<std::string>({(std::string)\"()(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\")\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(())\", (std::string)\"())())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")())\", (std::string)\"(()()(\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(())))\", (std::string)\"(()())((\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"()\", (std::string)\"())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(()(\", (std::string)\"()))()\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"((((\", (std::string)\"((())\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(()\", (std::string)\"(()(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")(\", (std::string)\")(\"}))) == (\"No\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"(\", (std::string)\")\"}))) == (\"Yes\"));\n    assert(candidate((std::vector<std::string>({(std::string)\")\", (std::string)\"(\"}))) == (\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer((\"10\"))\n// (10)\n// >>> closest_integer((\"15.3\"))\n// (15)\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor((\"010\"), (\"110\"))\n// (\"100\")\nstd::string string_xor(std::string a, std::string b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = string_xor;\n    assert(candidate((\"111000\"), (\"101010\")) == (\"010010\"));\n    assert(candidate((\"1\"), (\"1\")) == (\"0\"));\n    assert(candidate((\"0101\"), (\"0000\")) == (\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count((\"abcde\"))\n// (2)\n// >>> vowels_count((\"ACEDY\"))\n// (3)\nlong vowels_count(std::string s) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum((std::vector<long>({(long)-3, (long)-4, (long)5})), (3))\n// (std::vector<long>({(long)-4, (long)-3, (long)5}))\n// Example 2:\n// >>> maximum((std::vector<long>({(long)4, (long)-4, (long)4})), (2))\n// (std::vector<long>({(long)4, (long)4}))\n// Example 3:\n// >>> maximum((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1))\n// (std::vector<long>({(long)2}))\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nstd::vector<long> maximum(std::vector<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5})), (3)) == (std::vector<long>({(long)-4, (long)-3, (long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4, (long)4})), (2)) == (std::vector<long>({(long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-3, (long)2, (long)1, (long)2, (long)-1, (long)-2, (long)1})), (1)) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)123, (long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (3)) == (std::vector<long>({(long)2, (long)20, (long)123})));\n    assert(candidate((std::vector<long>({(long)-123, (long)20, (long)0, (long)1, (long)2, (long)-3})), (4)) == (std::vector<long>({(long)0, (long)1, (long)2, (long)20})));\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)0, (long)3, (long)-13, (long)-8, (long)0})), (7)) == (std::vector<long>({(long)-13, (long)-8, (long)0, (long)0, (long)3, (long)5, (long)15})));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)2, (long)5, (long)3, (long)-10})), (2)) == (std::vector<long>({(long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)5, (long)-7})), (1)) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)4, (long)-4})), (2)) == (std::vector<long>({(long)-4, (long)4})));\n    assert(candidate((std::vector<long>({(long)-10, (long)10})), (2)) == (std::vector<long>({(long)-10, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-23, (long)243, (long)-400, (long)0})), (0)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"})))\n// (\"string\")\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"})))\n// (\"enam\")\n// >>> find_max((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"})))\n// (\"aaaaaaa\")\nstd::string find_max(std::vector<std::string> words) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution((std::vector<long>({(long)5, (long)8, (long)7, (long)1})))\n// (12)\n// >>> solution((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3})))\n// (9)\n// >>> solution((std::vector<long>({(long)30, (long)13, (long)24, (long)321})))\n// (0)\nlong solution(std::vector<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = solution;\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)7, (long)1}))) == (12));\n    assert(candidate((std::vector<long>({(long)3, (long)3, (long)3, (long)3, (long)3}))) == (9));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)24, (long)321}))) == (0));\n    assert(candidate((std::vector<long>({(long)5, (long)9}))) == (5));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8}))) == (0));\n    assert(candidate((std::vector<long>({(long)30, (long)13, (long)23, (long)32}))) == (23));\n    assert(candidate((std::vector<long>({(long)3, (long)13, (long)2, (long)9}))) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5((\"Hello world\"))\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4))\n// (24)\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nlong add_elements(std::vector<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = add_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)41, (long)57, (long)76, (long)87, (long)88, (long)99})), (3)) == (-4));\n    assert(candidate((std::vector<long>({(long)111, (long)121, (long)3, (long)4000, (long)5, (long)6})), (2)) == (0));\n    assert(candidate((std::vector<long>({(long)11, (long)21, (long)3, (long)90, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (125));\n    assert(candidate((std::vector<long>({(long)111, (long)21, (long)3, (long)4000, (long)5, (long)6, (long)7, (long)8, (long)9})), (4)) == (24));\n    assert(candidate((std::vector<long>({(long)1})), (1)) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base((8), (3))\n// (\"22\")\n// >>> change_base((8), (2))\n// (\"1000\")\n// >>> change_base((7), (2))\n// (\"111\")\nstd::string change_base(long x, long base) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz((5))\n// (std::vector<long>({(long)1, (long)5}))\nstd::vector<long> get_odd_collatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_odd_collatz;\n    assert(candidate((14)) == (std::vector<long>({(long)1, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)5})));\n    assert(candidate((12)) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((1)) == (std::vector<long>({(long)1})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle((3), (4), (5))\n// (true)\n// >>> right_angle_triangle((1), (2), (3))\n// (false)\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date((\"03-11-2000\"))\n// (true)\n// >>> valid_date((\"15-01-2012\"))\n// (false)\n// >>> valid_date((\"04-0-2040\"))\n// (false)\n// >>> valid_date((\"06-04-2020\"))\n// (true)\n// >>> valid_date((\"06/04/2020\"))\n// (false)\nbool valid_date(std::string date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = valid_date;\n    assert(candidate((\"03-11-2000\")) == (true));\n    assert(candidate((\"15-01-2012\")) == (false));\n    assert(candidate((\"04-0-2040\")) == (false));\n    assert(candidate((\"06-04-2020\")) == (true));\n    assert(candidate((\"01-01-2007\")) == (true));\n    assert(candidate((\"03-32-2011\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"04-31-3000\")) == (false));\n    assert(candidate((\"06-06-2005\")) == (true));\n    assert(candidate((\"21-31-2000\")) == (false));\n    assert(candidate((\"04-12-2003\")) == (true));\n    assert(candidate((\"04122003\")) == (false));\n    assert(candidate((\"20030412\")) == (false));\n    assert(candidate((\"2003-04\")) == (false));\n    assert(candidate((\"2003-04-12\")) == (false));\n    assert(candidate((\"04-2003\")) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f})))\n// (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"}))\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_string__long{\n    std::vector<std::string> f0;\n    long f1;    Union_std_vector_std_string__long(std::vector<std::string> _f0) : f0(_f0) {}\n    Union_std_vector_std_string__long(long _f1) : f1(_f1) {}\n    ~Union_std_vector_std_string__long() {}\n    bool operator==(std::vector<std::string> f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words((\"Hello world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"Hello,world!\"))\n// std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"})\n// >>> split_words((\"abcdef\"))\n// 3\nUnion_std_vector_std_string__long split_words(std::string txt) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = split_words;\n    assert(candidate((\"Hello world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello,world!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world!\"}));\n    assert(candidate((\"Hello world,!\")) == std::vector<std::string>({(std::string)\"Hello\", (std::string)\"world,!\"}));\n    assert(candidate((\"Hello,Hello,world !\")) == std::vector<std::string>({(std::string)\"Hello,Hello,world\", (std::string)\"!\"}));\n    assert(candidate((\"abcdef\")) == 3);\n    assert(candidate((\"aaabb\")) == 2);\n    assert(candidate((\"aaaBb\")) == 1);\n    assert(candidate((\"\")) == 0);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse((std::vector<long>()), (4))\n// (std::vector<long>())\n// >>> intersperse((std::vector<long>({(long)1, (long)2, (long)3})), (4))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)4, (long)3}))\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted((std::vector<long>({(long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7})))\n// (false)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4})))\n// (true)\n// >>> is_sorted((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4})))\n// (false)\nbool is_sorted(std::vector<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = is_sorted;\n    assert(candidate((std::vector<long>({(long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)7}))) == (false));\n    assert(candidate((std::vector<long>())) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)2, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection((std::make_tuple(1, 2)), (std::make_tuple(2, 3)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-1, 1)), (std::make_tuple(0, 4)))\n// (\"NO\")\n// >>> intersection((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5)))\n// (\"YES\")\nstd::string intersection(std::tuple<long, long> interval1, std::tuple<long, long> interval2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersection;\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(2, 3))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-1, 1)), (std::make_tuple(0, 4))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-3, -1)), (std::make_tuple(-5, 5))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-2, 2)), (std::make_tuple(-4, 0))) == (\"YES\"));\n    assert(candidate((std::make_tuple(-11, 2)), (std::make_tuple(-1, -1))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(3, 5))) == (\"NO\"));\n    assert(candidate((std::make_tuple(1, 2)), (std::make_tuple(1, 2))) == (\"NO\"));\n    assert(candidate((std::make_tuple(-2, -2)), (std::make_tuple(-3, -2))) == (\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs((std::vector<long>({(long)1, (long)2, (long)2, (long)-4})))\n// 9\n// >>> prod_signs((std::vector<long>({(long)0, (long)1})))\n// 0\n// >>> prod_signs((std::vector<long>()))\n// std::nullopt\nstd::optional<long> prod_signs(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prod_signs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)-4}))) == -9);\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == 0);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)-1, (long)1}))) == -10);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)2, (long)-1, (long)-1, (long)9}))) == 20);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)-1, (long)1}))) == 4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)1}))) == -4);\n    assert(candidate((std::vector<long>({(long)-1, (long)1, (long)1, (long)0}))) == 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3))\n// (std::vector<long>({(long)1, (long)2, (long)1}))\n// >>> minPath((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1))\n// (std::vector<long>({(long)1}))\nstd::vector<long> minPath(std::vector<std::vector<long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = minPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})})), (3)) == (std::vector<long>({(long)1, (long)2, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)9, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)2})})), (1)) == (std::vector<long>({(long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15, (long)16})})), (4)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)10}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)12, (long)1}), (std::vector<long>)std::vector<long>({(long)3, (long)16, (long)11, (long)15}), (std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2})})), (7)) == (std::vector<long>({(long)1, (long)10, (long)1, (long)10, (long)1, (long)10, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)14, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)13, (long)15}), (std::vector<long>)std::vector<long>({(long)5, (long)7, (long)1, (long)12}), (std::vector<long>)std::vector<long>({(long)3, (long)10, (long)11, (long)16})})), (5)) == (std::vector<long>({(long)1, (long)7, (long)1, (long)7, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1})})), (9)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)12, (long)13, (long)10, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)3, (long)15, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)16, (long)14, (long)4}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)7, (long)2})})), (12)) == (std::vector<long>({(long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6, (long)1, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)8, (long)9})})), (8)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)1, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)7, (long)4})})), (8)) == (std::vector<long>({(long)1, (long)5, (long)1, (long)5, (long)1, (long)5, (long)1, (long)5})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})})), (10)) == (std::vector<long>({(long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2, (long)1, (long)2})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)2})})), (10)) == (std::vector<long>({(long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3, (long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest((std::vector<std::string>()))\n// std::nullopt\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// \"a\"\n// >>> longest((std::vector<std::string>({(std::string)\"a\", (std::string)\"bb\", (std::string)\"ccc\"})))\n// \"ccc\"\nstd::optional<std::string> longest(std::vector<std::string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = longest;\n    assert(candidate((std::vector<std::string>())) == std::nullopt);\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == \"x\");\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"yyy\", (std::string)\"zzzz\", (std::string)\"www\", (std::string)\"kkkk\", (std::string)\"abc\"}))) == \"zzzz\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri((3))\n// (std::vector<long>({(long)1, (long)3, (long)2, (long)8}))\nstd::vector<long> tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tri;\n    assert(candidate((3)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8})));\n    assert(candidate((4)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3})));\n    assert(candidate((5)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15})));\n    assert(candidate((6)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4})));\n    assert(candidate((7)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24})));\n    assert(candidate((8)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5})));\n    assert(candidate((9)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35})));\n    assert(candidate((20)) == (std::vector<long>({(long)1, (long)3, (long)2, (long)8, (long)3, (long)15, (long)4, (long)24, (long)5, (long)35, (long)6, (long)48, (long)7, (long)63, (long)8, (long)80, (long)9, (long)99, (long)10, (long)120, (long)11})));\n    assert(candidate((0)) == (std::vector<long>({(long)1})));\n    assert(candidate((1)) == (std::vector<long>({(long)1, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits((1))\n// (1)\n// >>> digits((4))\n// (0)\n// >>> digits((235))\n// (15)\nlong digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digits;\n    assert(candidate((5)) == (5));\n    assert(candidate((54)) == (5));\n    assert(candidate((120)) == (1));\n    assert(candidate((5014)) == (5));\n    assert(candidate((98765)) == (315));\n    assert(candidate((5576543)) == (2625));\n    assert(candidate((2468)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested((\"[[]]\"))\n// (true)\n// >>> is_nested((\"[]]]]]]][[[[[]\"))\n// (false)\n// >>> is_nested((\"[][]\"))\n// (false)\n// >>> is_nested((\"[]\"))\n// (false)\n// >>> is_nested((\"[[][]]\"))\n// (true)\n// >>> is_nested((\"[[]][[\"))\n// (true)\nbool is_nested(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_nested;\n    assert(candidate((\"[[]]\")) == (true));\n    assert(candidate((\"[]]]]]]][[[[[]\")) == (false));\n    assert(candidate((\"[][]\")) == (false));\n    assert(candidate((\"[]\")) == (false));\n    assert(candidate((\"[[[[]]]]\")) == (true));\n    assert(candidate((\"[]]]]]]]]]]\")) == (false));\n    assert(candidate((\"[][][[]]\")) == (true));\n    assert(candidate((\"[[]\")) == (false));\n    assert(candidate((\"[]]\")) == (false));\n    assert(candidate((\"[[]][[\")) == (true));\n    assert(candidate((\"[[][]]\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"[[[[[[[[\")) == (false));\n    assert(candidate((\"]]]]]]]]\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f})))\n// (14)\n// >>> lst((std::vector<float>({(float)1.0f, (float)4.0f, (float)9.0f})))\n// (98)\n// >>> lst((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n// (84)\n// >>> lst((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f})))\n// (29)\n// >>> lst((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f})))\n// (6)\nlong sum_squares(std::vector<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f}))) == (14));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84));\n    assert(candidate((std::vector<float>({(float)1.4f, (float)4.2f, (float)0.0f}))) == (29));\n    assert(candidate((std::vector<float>({(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230));\n    assert(candidate((std::vector<float>({(float)10000.0f, (float)10000.0f}))) == (200000000));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75));\n    assert(candidate((std::vector<float>({(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f}))) == (1));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter((\"apple pie\"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"apple pi e\"))\n// (true)\n// >>> check_if_last_char_is_a_letter((\"apple pi e \"))\n// (false)\n// >>> check_if_last_char_is_a_letter((\"\"))\n// (false)\nbool check_if_last_char_is_a_letter(std::string txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_if_last_char_is_a_letter;\n    assert(candidate((\"apple\")) == (false));\n    assert(candidate((\"apple pi e\")) == (true));\n    assert(candidate((\"eeeee\")) == (false));\n    assert(candidate((\"A\")) == (true));\n    assert(candidate((\"Pumpkin pie \")) == (false));\n    assert(candidate((\"Pumpkin pie 1\")) == (false));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"eeeee e \")) == (false));\n    assert(candidate((\"apple pie\")) == (false));\n    assert(candidate((\"apple pi e \")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5})))\n// (3)\n// >>> can_arrange((std::vector<long>({(long)1, (long)2, (long)3})))\n// (-1)\nlong can_arrange(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = can_arrange;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)3, (long)5}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5}))) == (-1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)4, (long)8, (long)5, (long)7, (long)3}))) == (4));\n    assert(candidate((std::vector<long>())) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1))\n// >>> largest_smallest_integers((std::vector<long>()))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\n// >>> largest_smallest_integers((std::vector<long>({(long)0})))\n// std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt))\nstd::tuple<std::optional<long>, std::optional<long>> largest_smallest_integers(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_smallest_integers;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3, (long)5, (long)7, (long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(1)));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2, (long)4, (long)5, (long)6, (long)-2}))) == std::make_tuple(-2, 1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)3, (long)6, (long)2, (long)7, (long)-7}))) == std::make_tuple(-7, 2));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)8, (long)4, (long)9, (long)2, (long)5, (long)-9}))) == std::make_tuple(-9, 2));\n    assert(candidate((std::vector<long>())) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)0}))) == std::make_tuple(std::optional<long>(std::nullopt), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)-5, (long)-6, (long)0}))) == std::make_tuple(std::optional<long>(-1), std::optional<long>(std::nullopt)));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)1}))) == std::make_tuple(-3, 1));\n    assert(candidate((std::vector<long>({(long)-6, (long)-4, (long)-4, (long)-3, (long)-100, (long)1}))) == std::make_tuple(-3, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float_std_string{\n    long f0;\n    float f1;\n    std::string f2;    Union_long_float_std_string(long _f0) : f0(_f0) {}\n    Union_long_float_std_string(float _f1) : f1(_f1) {}\n    Union_long_float_std_string(std::string _f2) : f2(_f2) {}\n    ~Union_long_float_std_string() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }\n};\nunion Union_long_float_std_string_std_nullopt{\n    long f0;\n    float f1;\n    std::string f2;\n    std::nullopt f3;    Union_long_float_std_string_std_nullopt(long _f0) : f0(_f0) {}\n    Union_long_float_std_string_std_nullopt(float _f1) : f1(_f1) {}\n    Union_long_float_std_string_std_nullopt(std::string _f2) : f2(_f2) {}\n    Union_long_float_std_string_std_nullopt(std::nullopt _f3) : f3(_f3) {}\n    ~Union_long_float_std_string_std_nullopt() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }    bool operator==(std::string f) {\n        return f2 == f ;\n    }    bool operator==(std::nullopt f) {\n        return f3 == f ;\n    }\n};\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5f)\n// 2.5f\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// std::nullopt\nUnion_long_float_std_string_std_nullopt compare_one(Union_long_float_std_string a, Union_long_float_std_string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare_one;\n    assert(candidate(1, 2) == 2);\n    assert(candidate(1, 2.5f) == 2.5f);\n    assert(candidate(2, 3) == 3);\n    assert(candidate(5, 6) == 6);\n    assert(candidate(1, \"2,3\") == \"2,3\");\n    assert(candidate(\"5,1\", \"6\") == \"6\");\n    assert(candidate(\"1\", \"2\") == \"2\");\n    assert(candidate(\"1\", 1) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even((4))\n// (false)\n// >>> is_equal_to_sum_even((6))\n// (false)\n// >>> is_equal_to_sum_even((8))\n// (true)\nbool is_equal_to_sum_even(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_equal_to_sum_even;\n    assert(candidate((4)) == (false));\n    assert(candidate((6)) == (false));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (true));\n    assert(candidate((11)) == (false));\n    assert(candidate((12)) == (true));\n    assert(candidate((13)) == (false));\n    assert(candidate((16)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial((4))\n// (288)\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nlong special_factorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = special_factorial;\n    assert(candidate((4)) == (288));\n    assert(candidate((5)) == (34560));\n    assert(candidate((7)) == (125411328000));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor((3), (5))\n// (1)\n// >>> greatest_common_divisor((25), (15))\n// (5)\nlong greatest_common_divisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = greatest_common_divisor;\n    assert(candidate((3), (7)) == (1));\n    assert(candidate((10), (15)) == (5));\n    assert(candidate((49), (14)) == (7));\n    assert(candidate((144), (60)) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces((\" Example\"))\n// (\"Example\")\n// >>> fix_spaces((\" Example 1\"))\n// (\"Example_1\")\n// >>> fix_spaces((\" Example 2\"))\n// (\"_Example_2\")\n// >>> fix_spaces((\" Example 3\"))\n// (\"_Example-3\")\nstd::string fix_spaces(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fix_spaces;\n    assert(candidate((\"Example\")) == (\"Example\"));\n    assert(candidate((\"Mudasir Hanif \")) == (\"Mudasir_Hanif_\"));\n    assert(candidate((\"Yellow Yellow  Dirty  Fellow\")) == (\"Yellow_Yellow__Dirty__Fellow\"));\n    assert(candidate((\"Exa   mple\")) == (\"Exa-mple\"));\n    assert(candidate((\"   Exa 1 2 2 mple\")) == (\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check((\"example.txt\"))\n// (\"Yes\")\n// >>> file_name_check((\"1example.dll\"))\n// (\"No\")\nstd::string file_name_check(std::string file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = file_name_check;\n    assert(candidate((\"example.txt\")) == (\"Yes\"));\n    assert(candidate((\"1example.dll\")) == (\"No\"));\n    assert(candidate((\"s1sdf3.asd\")) == (\"No\"));\n    assert(candidate((\"K.dll\")) == (\"Yes\"));\n    assert(candidate((\"MY16FILE3.exe\")) == (\"Yes\"));\n    assert(candidate((\"His12FILE94.exe\")) == (\"No\"));\n    assert(candidate((\"_Y.txt\")) == (\"No\"));\n    assert(candidate((\"?aREYA.exe\")) == (\"No\"));\n    assert(candidate((\"/this_is_valid.dll\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.wow\")) == (\"No\"));\n    assert(candidate((\"this_is_valid.txt\")) == (\"Yes\"));\n    assert(candidate((\"this_is_valid.txtexe\")) == (\"No\"));\n    assert(candidate((\"#this2_i4s_5valid.ten\")) == (\"No\"));\n    assert(candidate((\"@this1_is6_valid.exe\")) == (\"No\"));\n    assert(candidate((\"this_is_12valid.6exe4.txt\")) == (\"No\"));\n    assert(candidate((\"all.exe.txt\")) == (\"No\"));\n    assert(candidate((\"I563_No.exe\")) == (\"Yes\"));\n    assert(candidate((\"Is3youfault.txt\")) == (\"Yes\"));\n    assert(candidate((\"no_one#knows.dll\")) == (\"Yes\"));\n    assert(candidate((\"1I563_Yes3.exe\")) == (\"No\"));\n    assert(candidate((\"I563_Yes3.txtt\")) == (\"No\"));\n    assert(candidate((\"final..txt\")) == (\"No\"));\n    assert(candidate((\"final132\")) == (\"No\"));\n    assert(candidate((\"_f4indsartal132.\")) == (\"No\"));\n    assert(candidate((\".txt\")) == (\"No\"));\n    assert(candidate((\"s.\")) == (\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// (long({(long)1, (long)2, (long)3}))\n// >>> lst\n// (long())\n// >>> lst\n// (long({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))\nlong sum_squares(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_squares;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)9}))) == (14));\n    assert(candidate((std::vector<long>())) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1, (long)1}))) == (9));\n    assert(candidate((std::vector<long>({(long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1, (long)-1}))) == (-3));\n    assert(candidate((std::vector<long>({(long)0}))) == (0));\n    assert(candidate((std::vector<long>({(long)-1, (long)-5, (long)2, (long)-1, (long)-5}))) == (-126));\n    assert(candidate((std::vector<long>({(long)-56, (long)-99, (long)1, (long)0, (long)-2}))) == (3030));\n    assert(candidate((std::vector<long>({(long)-1, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)0, (long)-1}))) == (0));\n    assert(candidate((std::vector<long>({(long)-16, (long)-9, (long)-2, (long)36, (long)36, (long)26, (long)-20, (long)25, (long)-40, (long)20, (long)-4, (long)12, (long)-26, (long)35, (long)37}))) == (-14196));\n    assert(candidate((std::vector<long>({(long)-1, (long)-3, (long)17, (long)-1, (long)-15, (long)13, (long)-1, (long)14, (long)-14, (long)-12, (long)-5, (long)14, (long)-14, (long)6, (long)13, (long)11, (long)16, (long)16, (long)4, (long)10}))) == (-1448));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence((\"This is a test\"))\n// (\"is\")\n// Example 2:\n// >>> words_in_sentence((\"lets go for swimming\"))\n// (\"go for\")\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nstd::string words_in_sentence(std::string sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = words_in_sentence;\n    assert(candidate((\"This is a test\")) == (\"is\"));\n    assert(candidate((\"lets go for swimming\")) == (\"go for\"));\n    assert(candidate((\"there is no place available here\")) == (\"there is no place\"));\n    assert(candidate((\"Hi I am Hussein\")) == (\"Hi am Hussein\"));\n    assert(candidate((\"go for it\")) == (\"go for it\"));\n    assert(candidate((\"here\")) == (\"\"));\n    assert(candidate((\"here is\")) == (\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify((\"1/5\"), (\"5/1\"))\n// (true)\n// >>> simplify((\"1/6\"), (\"2/1\"))\n// (false)\n// >>> simplify((\"7/10\"), (\"10/2\"))\n// (false)\nbool simplify(std::string x, std::string n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = simplify;\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/6\"), (\"2/1\")) == (false));\n    assert(candidate((\"5/1\"), (\"3/1\")) == (true));\n    assert(candidate((\"7/10\"), (\"10/2\")) == (false));\n    assert(candidate((\"2/10\"), (\"50/10\")) == (true));\n    assert(candidate((\"7/2\"), (\"4/2\")) == (true));\n    assert(candidate((\"11/6\"), (\"6/1\")) == (true));\n    assert(candidate((\"2/3\"), (\"5/2\")) == (false));\n    assert(candidate((\"5/2\"), (\"3/5\")) == (false));\n    assert(candidate((\"2/4\"), (\"8/4\")) == (true));\n    assert(candidate((\"2/4\"), (\"4/2\")) == (true));\n    assert(candidate((\"1/5\"), (\"5/1\")) == (true));\n    assert(candidate((\"1/5\"), (\"1/5\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12})))\n// (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11}))\n// >>> order_by_points((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> order_by_points(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = order_by_points;\n    assert(candidate((std::vector<long>({(long)1, (long)11, (long)-1, (long)-11, (long)-12}))) == (std::vector<long>({(long)-1, (long)-11, (long)1, (long)-12, (long)11})));\n    assert(candidate((std::vector<long>({(long)1234, (long)423, (long)463, (long)145, (long)2, (long)423, (long)423, (long)53, (long)6, (long)37, (long)3457, (long)3, (long)56, (long)0, (long)46}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)6, (long)53, (long)423, (long)423, (long)423, (long)1234, (long)145, (long)37, (long)46, (long)56, (long)463, (long)3457})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)-11, (long)-32, (long)43, (long)54, (long)-98, (long)2, (long)-3}))) == (std::vector<long>({(long)-3, (long)-32, (long)-98, (long)-11, (long)1, (long)2, (long)43, (long)54})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11}))) == (std::vector<long>({(long)1, (long)10, (long)2, (long)11, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)0, (long)6, (long)6, (long)-76, (long)-21, (long)23, (long)4}))) == (std::vector<long>({(long)-76, (long)-21, (long)0, (long)4, (long)23, (long)6, (long)6})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +616,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15})))\n// (1)\n// >>> specialFilter((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109})))\n// (2)\nlong specialFilter(std::vector<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = specialFilter;\n    assert(candidate((std::vector<long>({(long)5, (long)-2, (long)1, (long)-5}))) == (0));\n    assert(candidate((std::vector<long>({(long)15, (long)-73, (long)14, (long)-15}))) == (1));\n    assert(candidate((std::vector<long>({(long)33, (long)-2, (long)-3, (long)45, (long)21, (long)109}))) == (2));\n    assert(candidate((std::vector<long>({(long)43, (long)-12, (long)93, (long)125, (long)121, (long)109}))) == (4));\n    assert(candidate((std::vector<long>({(long)71, (long)-2, (long)-33, (long)75, (long)21, (long)19}))) == (3));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>())) == (0));\n}\n",
     "stop_tokens": [
@@ -1812,25 +624,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n((30))\n// (465)\n// >>> sum_to_n((100))\n// (5050)\n// >>> sum_to_n((5))\n// (15)\n// >>> sum_to_n((10))\n// (55)\n// >>> sum_to_n((1))\n// (1)\nlong sum_to_n(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples((5))\n// (1)\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nlong get_max_triples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = get_max_triples;\n    assert(candidate((5)) == (1));\n    assert(candidate((6)) == (4));\n    assert(candidate((10)) == (36));\n    assert(candidate((100)) == (53361));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4})))\n// (std::vector<long>({(long)1, (long)3, (long)4}))\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf((\"Jupiter\"), (\"Neptune\"))\n// (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"}))\n// >>> bf((\"Earth\"), (\"Mercury\"))\n// (std::vector<std::string>(\"Venus\"))\n// >>> bf((\"Mercury\"), (\"Uranus\"))\n// (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"}))\nstd::vector<std::string> bf(std::string planet1, std::string planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = bf;\n    assert(candidate((\"Jupiter\"), (\"Neptune\")) == (std::vector<std::string>({(std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Mercury\")) == (std::vector<std::string>({(std::string)\"Venus\"})));\n    assert(candidate((\"Mercury\"), (\"Uranus\")) == (std::vector<std::string>({(std::string)\"Venus\", (std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\"})));\n    assert(candidate((\"Neptune\"), (\"Venus\")) == (std::vector<std::string>({(std::string)\"Earth\", (std::string)\"Mars\", (std::string)\"Jupiter\", (std::string)\"Saturn\", (std::string)\"Uranus\"})));\n    assert(candidate((\"Earth\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Mars\"), (\"Earth\")) == (std::vector<std::string>()));\n    assert(candidate((\"Jupiter\"), (\"Makemake\")) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"})))\n// (std::vector<std::string>({(std::string)\"aa\"}))\n// >>> list_sort((std::vector<std::string>({(std::string)\"ab\", (std::string)\"a\", (std::string)\"aaa\", (std::string)\"cd\"})))\n// (std::vector<std::string>({(std::string)\"ab\", (std::string)\"cd\"}))\nstd::vector<std::string> sorted_list_sum(std::vector<std::string> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sorted_list_sum;\n    assert(candidate((std::vector<std::string>({(std::string)\"aa\", (std::string)\"a\", (std::string)\"aaa\"}))) == (std::vector<std::string>({(std::string)\"aa\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"school\", (std::string)\"AI\", (std::string)\"asdf\", (std::string)\"b\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"asdf\", (std::string)\"school\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"b\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"d\", (std::string)\"dcba\", (std::string)\"abcd\", (std::string)\"a\"}))) == (std::vector<std::string>({(std::string)\"abcd\", (std::string)\"dcba\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"}))) == (std::vector<std::string>({(std::string)\"AI\", (std::string)\"ai\", (std::string)\"au\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\", (std::string)\"c\", (std::string)\"c\", (std::string)\"a\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaa\", (std::string)\"bbbb\", (std::string)\"dd\", (std::string)\"cc\"}))) == (std::vector<std::string>({(std::string)\"cc\", (std::string)\"dd\", (std::string)\"aaaa\", (std::string)\"bbbb\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes((\"abc\"))\n// (std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))\nstd::vector<std::string> all_prefixes(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_prefixes;\n    assert(candidate((\"\")) == (std::vector<std::string>()));\n    assert(candidate((\"asdfgh\")) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"as\", (std::string)\"asd\", (std::string)\"asdf\", (std::string)\"asdfg\", (std::string)\"asdfgh\"})));\n    assert(candidate((\"WWW\")) == (std::vector<std::string>({(std::string)\"W\", (std::string)\"WW\", (std::string)\"WWW\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y((7), (34), (12))\n// (34)\n// >>> x_or_y((15), (8), (5))\n// (5)\nlong x_or_y(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = x_or_y;\n    assert(candidate((7), (34), (12)) == (34));\n    assert(candidate((15), (8), (5)) == (5));\n    assert(candidate((3), (33), (5212)) == (33));\n    assert(candidate((1259), (3), (52)) == (3));\n    assert(candidate((7919), (-1), (12)) == (-1));\n    assert(candidate((3609), (1245), (583)) == (583));\n    assert(candidate((91), (56), (129)) == (129));\n    assert(candidate((6), (34), (1234)) == (1234));\n    assert(candidate((1), (2), (0)) == (0));\n    assert(candidate((2), (2), (0)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference((std::vector<float>({(long)1, (long)3, (long)2, (long)0})))\n// (10)\n// >>> double_the_difference((std::vector<float>({(long)-1, (long)-2, (long)0})))\n// (0)\n// >>> double_the_difference((std::vector<float>({(long)9, (long)-2})))\n// (81)\n// >>> double_the_difference((std::vector<float>({(long)0})))\n// (0)\n// If the input list is empty, return 0.\nlong double_the_difference(std::vector<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = double_the_difference;\n    assert(candidate((std::vector<float>())) == (0));\n    assert(candidate((std::vector<float>({(float)5.0f, (float)4.0f}))) == (25));\n    assert(candidate((std::vector<float>({(float)0.1f, (float)0.2f, (float)0.3f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0));\n    assert(candidate((std::vector<float>({(float)0.2f, (float)3.0f, (float)5.0f}))) == (34));\n    assert(candidate((std::vector<float>({(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2})))\n// (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3}))\n// >>> compare((std::vector<long>({(long)0, (long)5, (long)0, (long)0, (long)0, (long)4})), (std::vector<long>({(long)4, (long)1, (long)1, (long)0, (long)0, (long)-2})))\n// (std::vector<long>({(long)4, (long)4, (long)1, (long)0, (long)0, (long)6}))\nstd::vector<long> compare(std::vector<long> game, std::vector<long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = compare;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})), (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)-2}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)3, (long)3})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})), (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0}))) == (std::vector<long>({(long)0, (long)0, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)-1, (long)-2, (long)-3}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5})), (std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)2, (long)0, (long)0, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension((\"my_class\"), (std::vector<std::string>({(std::string)\"AA\", (std::string)\"Be\", (std::string)\"CC\"})))\n// (\"my_class.AA\")\nstd::string Strongest_Extension(std::string class_name, std::vector<std::string> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Strongest_Extension;\n    assert(candidate((\"Watashi\"), (std::vector<std::string>({(std::string)\"tEN\", (std::string)\"niNE\", (std::string)\"eIGHt8OKe\"}))) == (\"Watashi.eIGHt8OKe\"));\n    assert(candidate((\"Boku123\"), (std::vector<std::string>({(std::string)\"nani\", (std::string)\"NazeDa\", (std::string)\"YEs.WeCaNe\", (std::string)\"32145tggg\"}))) == (\"Boku123.YEs.WeCaNe\"));\n    assert(candidate((\"__YESIMHERE\"), (std::vector<std::string>({(std::string)\"t\", (std::string)\"eMptY\", (std::string)\"nothing\", (std::string)\"zeR00\", (std::string)\"NuLl__\", (std::string)\"123NoooneB321\"}))) == (\"__YESIMHERE.NuLl__\"));\n    assert(candidate((\"K\"), (std::vector<std::string>({(std::string)\"Ta\", (std::string)\"TAR\", (std::string)\"t234An\", (std::string)\"cosSo\"}))) == (\"K.TAR\"));\n    assert(candidate((\"__HAHA\"), (std::vector<std::string>({(std::string)\"Tab\", (std::string)\"123\", (std::string)\"781345\", (std::string)\"-_-\"}))) == (\"__HAHA.123\"));\n    assert(candidate((\"YameRore\"), (std::vector<std::string>({(std::string)\"HhAas\", (std::string)\"okIWILL123\", (std::string)\"WorkOut\", (std::string)\"Fails\", (std::string)\"-_-\"}))) == (\"YameRore.okIWILL123\"));\n    assert(candidate((\"finNNalLLly\"), (std::vector<std::string>({(std::string)\"Die\", (std::string)\"NowW\", (std::string)\"Wow\", (std::string)\"WoW\"}))) == (\"finNNalLLly.WoW\"));\n    assert(candidate((\"_\"), (std::vector<std::string>({(std::string)\"Bb\", (std::string)\"91245\"}))) == (\"_.Bb\"));\n    assert(candidate((\"Sp\"), (std::vector<std::string>({(std::string)\"671235\", (std::string)\"Bb\"}))) == (\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check((\"abcd\"), (\"abd\"))\n// (false)\n// >>> cycpattern_check((\"hello\"), (\"ell\"))\n// (true)\n// >>> cycpattern_check((\"whassup\"), (\"psus\"))\n// (false)\n// >>> cycpattern_check((\"abab\"), (\"baa\"))\n// (true)\n// >>> cycpattern_check((\"efef\"), (\"eeff\"))\n// (false)\n// >>> cycpattern_check((\"himenss\"), (\"simen\"))\n// (true)\nbool cycpattern_check(std::string a, std::string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cycpattern_check;\n    assert(candidate((\"xyzw\"), (\"xyw\")) == (false));\n    assert(candidate((\"yello\"), (\"ell\")) == (true));\n    assert(candidate((\"whattup\"), (\"ptut\")) == (false));\n    assert(candidate((\"efef\"), (\"fee\")) == (true));\n    assert(candidate((\"abab\"), (\"aabb\")) == (false));\n    assert(candidate((\"winemtt\"), (\"tinem\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count((-12))\n// (std::make_tuple(1, 1))\n// >>> even_odd_count((123))\n// (std::make_tuple(1, 2))\nstd::tuple<long, long> even_odd_count(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_odd_count;\n    assert(candidate((7)) == (std::make_tuple(0, 1)));\n    assert(candidate((-78)) == (std::make_tuple(1, 1)));\n    assert(candidate((3452)) == (std::make_tuple(2, 2)));\n    assert(candidate((346211)) == (std::make_tuple(3, 3)));\n    assert(candidate((-345821)) == (std::make_tuple(3, 3)));\n    assert(candidate((-2)) == (std::make_tuple(1, 0)));\n    assert(candidate((-45347)) == (std::make_tuple(2, 3)));\n    assert(candidate((0)) == (std::make_tuple(1, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman((19))\n// (\"xix\")\n// >>> int_to_mini_roman((152))\n// (\"clii\")\n// >>> int_to_mini_roman((426))\n// (\"cdxxvi\")\nstd::string int_to_mini_roman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = int_to_mini_roman;\n    assert(candidate((19)) == (\"xix\"));\n    assert(candidate((152)) == (\"clii\"));\n    assert(candidate((251)) == (\"ccli\"));\n    assert(candidate((426)) == (\"cdxxvi\"));\n    assert(candidate((500)) == (\"d\"));\n    assert(candidate((1)) == (\"i\"));\n    assert(candidate((4)) == (\"iv\"));\n    assert(candidate((43)) == (\"xliii\"));\n    assert(candidate((90)) == (\"xc\"));\n    assert(candidate((94)) == (\"xciv\"));\n    assert(candidate((532)) == (\"dxxxii\"));\n    assert(candidate((900)) == (\"cm\"));\n    assert(candidate((994)) == (\"cmxciv\"));\n    assert(candidate((1000)) == (\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle((3), (4), (5))\n// (true)\n// >>> right_angle_triangle((1), (2), (3))\n// (false)\nbool right_angle_triangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = right_angle_triangle;\n    assert(candidate((3), (4), (5)) == (true));\n    assert(candidate((1), (2), (3)) == (false));\n    assert(candidate((10), (6), (8)) == (true));\n    assert(candidate((2), (2), (2)) == (false));\n    assert(candidate((7), (24), (25)) == (true));\n    assert(candidate((10), (5), (7)) == (false));\n    assert(candidate((5), (12), (13)) == (true));\n    assert(candidate((15), (8), (17)) == (true));\n    assert(candidate((48), (55), (73)) == (true));\n    assert(candidate((1), (1), (1)) == (false));\n    assert(candidate((2), (2), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"})))\n// (\"string\")\n// >>> find_max((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"})))\n// (\"enam\")\n// >>> find_max((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"})))\n// (\"aaaaaaa\")\nstd::string find_max(std::vector<std::string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_max;\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"of\", (std::string)\"string\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"name\", (std::string)\"enam\", (std::string)\"game\"}))) == (\"enam\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"aaaaaaa\", (std::string)\"bb\", (std::string)\"cc\"}))) == (\"aaaaaaa\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"cba\"}))) == (\"abc\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"this\", (std::string)\"game\", (std::string)\"of\", (std::string)\"footbott\"}))) == (\"footbott\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"gonna\", (std::string)\"rock\"}))) == (\"gonna\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"we\", (std::string)\"are\", (std::string)\"a\", (std::string)\"mad\", (std::string)\"nation\"}))) == (\"nation\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\", (std::string)\"is\", (std::string)\"a\", (std::string)\"prrk\"}))) == (\"this\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"b\"}))) == (\"b\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"play\", (std::string)\"play\", (std::string)\"play\"}))) == (\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat((5), (6), (10))\n// (std::vector<long>({(long)11, (long)4}))\n// >>> eat((4), (8), (9))\n// (std::vector<long>({(long)12, (long)1}))\n// >>> eat((1), (10), (10))\n// (std::vector<long>({(long)11, (long)0}))\n// >>> eat((2), (11), (5))\n// (std::vector<long>({(long)7, (long)0}))\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nstd::vector<long> eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = eat;\n    assert(candidate((5), (6), (10)) == (std::vector<long>({(long)11, (long)4})));\n    assert(candidate((4), (8), (9)) == (std::vector<long>({(long)12, (long)1})));\n    assert(candidate((1), (10), (10)) == (std::vector<long>({(long)11, (long)0})));\n    assert(candidate((2), (11), (5)) == (std::vector<long>({(long)7, (long)0})));\n    assert(candidate((4), (5), (7)) == (std::vector<long>({(long)9, (long)2})));\n    assert(candidate((4), (5), (1)) == (std::vector<long>({(long)5, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence((0))\n// (\"0\")\n// >>> string_sequence((5))\n// (\"0 1 2 3 4 5\")\nstd::string string_sequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_sequence;\n    assert(candidate((0)) == (\"0\"));\n    assert(candidate((3)) == (\"0 1 2 3\"));\n    assert(candidate((10)) == (\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nlong do_algebra(std::vector<std::string> op, std::vector<long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = do_algebra;\n    assert(candidate((std::vector<std::string>({(std::string)\"**\", (std::string)\"*\", (std::string)\"+\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (37));\n    assert(candidate((std::vector<std::string>({(std::string)\"+\", (std::string)\"*\", (std::string)\"-\"})), (std::vector<long>({(long)2, (long)3, (long)4, (long)5}))) == (9));\n    assert(candidate((std::vector<std::string>({(std::string)\"//\", (std::string)\"*\"})), (std::vector<long>({(long)7, (long)3, (long)4}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve((\"1234\"))\n// (\"4321\")\n// >>> solve((\"ab\"))\n// (\"AB\")\n// >>> solve((\"#a@C\"))\n// (\"#A@c\")\nstd::string solve(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((\"AsDf\")) == (\"aSdF\"));\n    assert(candidate((\"1234\")) == (\"4321\"));\n    assert(candidate((\"ab\")) == (\"AB\"));\n    assert(candidate((\"#a@C\")) == (\"#A@c\"));\n    assert(candidate((\"#AsdfW^45\")) == (\"#aSDFw^45\"));\n    assert(candidate((\"#6@2\")) == (\"2@6#\"));\n    assert(candidate((\"#$a^D\")) == (\"#$A^d\"));\n    assert(candidate((\"#ccc\")) == (\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5((\"Hello world\"))\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nstd::optional<std::string> string_to_md5(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_to_md5;\n    assert(candidate((\"Hello world\")) == \"3e25960a79dbc69b674cd4ec67a72c62\");\n    assert(candidate((\"\")) == std::nullopt);\n    assert(candidate((\"A B C\")) == \"0ef78513b0cb8cef12743f5aeb35f888\");\n    assert(candidate((\"password\")) == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1840,7 +844,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers((2), (8))\n// (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))\n// >>> generate_integers((8), (2))\n// (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))\n// >>> generate_integers((10), (14))\n// (std::vector<long>())\nstd::vector<long> generate_integers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = generate_integers;\n    assert(candidate((2), (10)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((10), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((132), (2)) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((17), (89)) == (std::vector<long>()));\n}\n",
     "stop_tokens": [
@@ -1848,49 +852,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)2})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4}))\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters((\"xyzXYZ\"))\n// (3)\n// >>> count_distinct_characters((\"Jerry\"))\n// (4)\nlong count_distinct_characters(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count_distinct_characters;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abcde\")) == (5));\n    assert(candidate((\"abcdecadeCADE\")) == (5));\n    assert(candidate((\"aaaaAAAAaaaa\")) == (1));\n    assert(candidate((\"Jerry jERRY JeRRRY\")) == (5));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)3})))\n// (false)\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)-4, (long)5})))\n// (true)\nbool below_zero(std::vector<long> operations) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music((\"o o| .| o| o| .| .| .| .| o o\"))\n// (std::vector<long>({(long)4, (long)2, (long)1, (long)2, (long)2, (long)1, (long)1, (long)1, (long)1, (long)4, (long)4}))\nstd::vector<long> parse_music(std::string music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = parse_music;\n    assert(candidate((\"\")) == (std::vector<long>()));\n    assert(candidate((\"o o o o\")) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\".| .| .| .|\")) == (std::vector<long>({(long)1, (long)1, (long)1, (long)1})));\n    assert(candidate((\"o| o| .| .| o o o o\")) == (std::vector<long>({(long)2, (long)2, (long)1, (long)1, (long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((\"o| .| o| .| o o| o o|\")) == (std::vector<long>({(long)2, (long)1, (long)2, (long)1, (long)4, (long)2, (long)4, (long)2})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search((std::vector<long>({(long)4, (long)1, (long)2, (long)2, (long)3, (long)1})))\n// (2)\n// >>> search((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4, (long)4})))\n// (3)\n// >>> search((std::vector<long>({(long)5, (long)5, (long)4, (long)4, (long)4})))\n// (-1)\nlong search(std::vector<long> lst) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times((\"\"), (\"a\"))\n// (0)\n// >>> how_many_times((\"aaa\"), (\"a\"))\n// (3)\n// >>> how_many_times((\"aaaa\"), (\"aa\"))\n// (3)\nlong how_many_times(std::string string, std::string substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = how_many_times;\n    assert(candidate((\"\"), (\"x\")) == (0));\n    assert(candidate((\"xyxyxyx\"), (\"x\")) == (4));\n    assert(candidate((\"cacacacac\"), (\"cac\")) == (4));\n    assert(candidate((\"john doe\"), (\"john\")) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"(\"))\n// (false)\n// >>> correct_bracketing((\"()\"))\n// (true)\n// >>> correct_bracketing((\"(()())\"))\n// (true)\n// >>> correct_bracketing((\")(()\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers((\"three one five\"))\n// (\"one three five\")\nstd::string sort_numbers(std::string numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_numbers;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"three\")) == (\"three\"));\n    assert(candidate((\"three five nine\")) == (\"three five nine\"));\n    assert(candidate((\"five zero four seven nine eight\")) == (\"zero four five seven eight nine\"));\n    assert(candidate((\"six five four three two one zero\")) == (\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups((\"( ) (( )) (( )( ))\"))\n// (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"}))\nstd::vector<std::string> separate_paren_groups(std::string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = separate_paren_groups;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<std::string>({(std::string)\"(()())\", (std::string)\"((()))\", (std::string)\"()\", (std::string)\"((())()())\"})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"((()))\", (std::string)\"(((())))\"})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<std::string>({(std::string)\"(()(())((())))\"})));\n    assert(candidate((\"( ) (( )) (( )( ))\")) == (std::vector<std::string>({(std::string)\"()\", (std::string)\"(())\", (std::string)\"(()())\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n// (std::make_tuple(2.0f, 2.2f))\n// >>> find_closest_elements((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n// (std::make_tuple(2.0f, 2.0f))\nstd::tuple<float, float> find_closest_elements(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_closest_elements;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(3.9f, 4.0f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))) == (std::make_tuple(5.0f, 5.9f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))) == (std::make_tuple(2.0f, 2.2f)));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))) == (std::make_tuple(2.0f, 2.0f)));\n    assert(candidate((std::vector<float>({(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))) == (std::make_tuple(2.2f, 3.1f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n// (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\nstd::vector<float> rescale_to_unit(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rescale_to_unit;\n    assert(candidate((std::vector<float>({(float)2.0f, (float)49.9f}))) == (std::vector<float>({(float)0.0f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)100.0f, (float)49.9f}))) == (std::vector<float>({(float)1.0f, (float)0.0f})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (std::vector<float>({(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f})));\n    assert(candidate((std::vector<float>({(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n    assert(candidate((std::vector<float>({(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))) == (std::vector<float>({(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter given list of any python values only for integers\n// >>> filter_integers((std::vector<std::any>({(std::string)\"a\", (std::string)3.14f, (std::string)5})))\n// (std::vector<long>({(long)5}))\n// >>> filter_integers((std::vector<std::any>({1, 2, 3, \"abc\", std::map<long,long>(), std::vector<long>()})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\nstd::vector<long> filter_integers(std::vector<std::any> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_integers;\n    assert(candidate((std::vector<std::any>())) == (std::vector<long>()));\n    assert(candidate((std::vector<std::any>({4, std::map<long,long>(), std::vector<long>(), 23.2f, 9, \"adasd\"}))) == (std::vector<long>({(long)4, (long)9})));\n    assert(candidate((std::vector<std::any>({3, \"c\", 3, 3, \"a\", \"b\"}))) == (std::vector<long>({(long)3, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return length of given string\n// >>> string_length((\"\"))\n// (0)\n// >>> string_length((\"abc\"))\n// (3)\nlong string_length(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_length;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"x\")) == (1));\n    assert(candidate((\"asdasnakj\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor((15))\n// (5)\nlong largest_divisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_divisor;\n    assert(candidate((3)) == (1));\n    assert(candidate((7)) == (1));\n    assert(candidate((10)) == (5));\n    assert(candidate((100)) == (50));\n    assert(candidate((49)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize((8))\n// (std::vector<long>({(long)2, (long)2, (long)2}))\n// >>> factorize((25))\n// (std::vector<long>({(long)5, (long)5}))\n// >>> factorize((70))\n// (std::vector<long>({(long)2, (long)5, (long)7}))\nstd::vector<long> factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = factorize;\n    assert(candidate((2)) == (std::vector<long>({(long)2})));\n    assert(candidate((4)) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((8)) == (std::vector<long>({(long)2, (long)2, (long)2})));\n    assert(candidate((57)) == (std::vector<long>({(long)3, (long)19})));\n    assert(candidate((3249)) == (std::vector<long>({(long)3, (long)3, (long)19, (long)19})));\n    assert(candidate((185193)) == (std::vector<long>({(long)3, (long)3, (long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((20577)) == (std::vector<long>({(long)3, (long)19, (long)19, (long)19})));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4})))\n// (std::vector<long>({(long)1, (long)3, (long)4}))\nstd::vector<long> remove_duplicates(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_duplicates;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)3, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case((\"Hello\"))\n// (\"hELLO\")\nstd::string flip_case(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = flip_case;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hello!\")) == (\"hELLO!\"));\n    assert(candidate((\"These violent delights have violent ends\")) == (\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Concatenate list of strings into a single string\n// >>> concatenate((std::vector<std::string>()))\n// (\"\")\n// >>> concatenate((std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})))\n// (\"abc\")\nstd::string concatenate(std::vector<std::string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = concatenate;\n    assert(candidate((std::vector<std::string>())) == (\"\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}))) == (\"xyz\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\", (std::string)\"w\", (std::string)\"k\"}))) == (\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_prefix((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bcd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_prefix(std::vector<std::string> strings, std::string prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_prefix;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number((3.5f))\n// (0.5f)\nfloat truncate_number(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = truncate_number;\n    assert(candidate((3.5f)) == (0.5f));\n    assert(candidate((1.25f)) == (0.25f));\n    assert(candidate((123.0f)) == (0.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return only positive numbers in the list.\n// >>> get_positive((std::vector<long>({(long)-1, (long)2, (long)-4, (long)5, (long)6})))\n// (std::vector<long>({(long)2, (long)5, (long)6}))\n// >>> get_positive((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)9, (long)123, (long)1}))\nstd::vector<long> get_positive(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_positive;\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)5, (long)3, (long)2, (long)3, (long)3, (long)9, (long)123, (long)1})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2}))) == (std::vector<long>()));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime((6))\n// (false)\n// >>> is_prime((101))\n// (true)\n// >>> is_prime((11))\n// (true)\n// >>> is_prime((13441))\n// (true)\n// >>> is_prime((61))\n// (true)\n// >>> is_prime((4))\n// (false)\n// >>> is_prime((1))\n// (false)\nbool is_prime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_prime;\n    assert(candidate((6)) == (false));\n    assert(candidate((101)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((13441)) == (true));\n    assert(candidate((61)) == (true));\n    assert(candidate((4)) == (false));\n    assert(candidate((1)) == (false));\n    assert(candidate((5)) == (true));\n    assert(candidate((11)) == (true));\n    assert(candidate((17)) == (true));\n    assert(candidate((85)) == (false));\n    assert(candidate((77)) == (false));\n    assert(candidate((255379)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_third((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2})))\n// (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5}))\nstd::vector<long> sort_third(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_third;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)3, (long)4, (long)6, (long)9, (long)2}))) == (std::vector<long>({(long)2, (long)8, (long)3, (long)4, (long)6, (long)9, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)9, (long)4, (long)8, (long)3, (long)2}))) == (std::vector<long>({(long)2, (long)6, (long)9, (long)4, (long)8, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)4, (long)8, (long)9, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)6, (long)3, (long)4, (long)8, (long)9, (long)5, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique elements in a list\n// >>> unique((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123}))\nstd::vector<long> unique(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique;\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)0, (long)2, (long)3, (long)5, (long)9, (long)123})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return maximum element in the list.\n// >>> max_element((std::vector<long>({(long)1, (long)2, (long)3})))\n// (3)\n// >>> max_element((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10})))\n// (123)\nlong max_element(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)124, (long)1, (long)-10}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz((50))\n// (0)\n// >>> fizz_buzz((78))\n// (2)\n// >>> fizz_buzz((79))\n// (3)\nlong fizz_buzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fizz_buzz;\n    assert(candidate((50)) == (0));\n    assert(candidate((78)) == (2));\n    assert(candidate((79)) == (3));\n    assert(candidate((100)) == (3));\n    assert(candidate((200)) == (6));\n    assert(candidate((4000)) == (192));\n    assert(candidate((10000)) == (639));\n    assert(candidate((100000)) == (8026));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1900,9 +1120,201 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)1, (long)2, (long)3}))\n// >>> sort_even((std::vector<long>({(long)5, (long)6, (long)3, (long)4})))\n// (std::vector<long>({(long)3, (long)6, (long)5, (long)4}))\nstd::vector<long> sort_even(std::vector<long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = sort_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)9, (long)0, (long)123, (long)1, (long)-10}))) == (std::vector<long>({(long)-10, (long)3, (long)-5, (long)2, (long)-3, (long)3, (long)5, (long)0, (long)9, (long)1, (long)123})));\n    assert(candidate((std::vector<long>({(long)5, (long)8, (long)-12, (long)4, (long)23, (long)2, (long)3, (long)11, (long)12, (long)-10}))) == (std::vector<long>({(long)-12, (long)8, (long)3, (long)4, (long)5, (long)2, (long)12, (long)11, (long)23, (long)-10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib((1))\n// (2)\n// >>> prime_fib((2))\n// (3)\n// >>> prime_fib((3))\n// (5)\n// >>> prime_fib((4))\n// (13)\n// >>> prime_fib((5))\n// (89)\nlong prime_fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_fib;\n    assert(candidate((1)) == (2));\n    assert(candidate((2)) == (3));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (13));\n    assert(candidate((5)) == (89));\n    assert(candidate((6)) == (233));\n    assert(candidate((7)) == (1597));\n    assert(candidate((8)) == (28657));\n    assert(candidate((9)) == (514229));\n    assert(candidate((10)) == (433494437));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)3})))\n// (false)\n// >>> below_zero((std::vector<long>({(long)1, (long)2, (long)-4, (long)5})))\n// (true)\nbool below_zero(std::vector<long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_zero;\n    assert(candidate((std::vector<long>())) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-3, (long)1, (long)2, (long)-3}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)-4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)-1, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)2, (long)-2, (long)5, (long)-5, (long)4, (long)-4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> triples_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7})))\n// (true)\n// >>> triples_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool triples_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triples_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)9, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)-100}))) == (false));\n    assert(candidate((std::vector<long>({(long)100, (long)3, (long)5, (long)-100}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nlong car_race_collision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = car_race_collision;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (9));\n    assert(candidate((4)) == (16));\n    assert(candidate((8)) == (64));\n    assert(candidate((10)) == (100));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return list with elements incremented by 1.\n// >>> incr_list((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)3, (long)4}))\n// >>> incr_list((std::vector<long>({(long)5, (long)3, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123})))\n// (std::vector<long>({(long)6, (long)4, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124}))\nstd::vector<long> incr_list(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = incr_list;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)3, (long)2})));\n    assert(candidate((std::vector<long>({(long)5, (long)2, (long)5, (long)2, (long)3, (long)3, (long)9, (long)0, (long)123}))) == (std::vector<long>({(long)6, (long)3, (long)6, (long)3, (long)4, (long)4, (long)10, (long)1, (long)124})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)5, (long)0})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)3, (long)-2, (long)1})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1, (long)2, (long)3, (long)7})))\n// (false)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7})))\n// (true)\n// >>> pairs_sum_to_zero((std::vector<long>({(long)1})))\n// (false)\nbool pairs_sum_to_zero(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pairs_sum_to_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)0}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)-2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-5, (long)3, (long)5, (long)7}))) == (true));\n    assert(candidate((std::vector<long>({(long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)30}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)3, (long)2, (long)31}))) == (true));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)30}))) == (false));\n    assert(candidate((std::vector<long>({(long)-3, (long)9, (long)-1, (long)4, (long)2, (long)31}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base((8), (3))\n// (\"22\")\n// >>> change_base((8), (2))\n// (\"1000\")\n// >>> change_base((7), (2))\n// (\"111\")\nstd::string change_base(long x, long base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = change_base;\n    assert(candidate((8), (3)) == (\"22\"));\n    assert(candidate((9), (3)) == (\"100\"));\n    assert(candidate((234), (2)) == (\"11101010\"));\n    assert(candidate((16), (2)) == (\"10000\"));\n    assert(candidate((8), (2)) == (\"1000\"));\n    assert(candidate((7), (2)) == (\"111\"));\n    assert(candidate((2), (3)) == (\"2\"));\n    assert(candidate((3), (4)) == (\"3\"));\n    assert(candidate((4), (5)) == (\"4\"));\n    assert(candidate((5), (6)) == (\"5\"));\n    assert(candidate((6), (7)) == (\"6\"));\n    assert(candidate((7), (8)) == (\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area((5), (3))\n// (7.5f)\nfloat triangle_area(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((5), (3)) == (7.5f));\n    assert(candidate((2), (2)) == (2.0f));\n    assert(candidate((10), (8)) == (40.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4((5))\n// (4)\n// >>> fib4((6))\n// (8)\n// >>> fib4((7))\n// (14)\nlong fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib4;\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (28));\n    assert(candidate((10)) == (104));\n    assert(candidate((12)) == (386));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return median of elements in the list l.\n// >>> median((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (float(3))\n// >>> median((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20})))\n// (15.0f)\nfloat median(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = median;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (float(3)));\n    assert(candidate((std::vector<long>({(long)-10, (long)4, (long)6, (long)1000, (long)10, (long)20}))) == (8.0f));\n    assert(candidate((std::vector<long>({(long)5}))) == (float(5)));\n    assert(candidate((std::vector<long>({(long)6, (long)5}))) == (5.5f));\n    assert(candidate((std::vector<long>({(long)8, (long)1, (long)3, (long)9, (long)9, (long)2, (long)7}))) == (float(7)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Checks if given string is a palindrome\n// >>> is_palindrome((\"\"))\n// (true)\n// >>> is_palindrome((\"aba\"))\n// (true)\n// >>> is_palindrome((\"aaaaa\"))\n// (true)\n// >>> is_palindrome((\"zbcd\"))\n// (false)\nbool is_palindrome(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_palindrome;\n    assert(candidate((\"\")) == (true));\n    assert(candidate((\"aba\")) == (true));\n    assert(candidate((\"aaaaa\")) == (true));\n    assert(candidate((\"zbcd\")) == (false));\n    assert(candidate((\"xywyx\")) == (true));\n    assert(candidate((\"xywyz\")) == (false));\n    assert(candidate((\"xywzx\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp((3), (5))\n// (3)\n// >>> modp((1101), (101))\n// (2)\n// >>> modp((0), (101))\n// (1)\n// >>> modp((3), (11))\n// (8)\n// >>> modp((100), (101))\n// (1)\nlong modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = modp;\n    assert(candidate((3), (5)) == (3));\n    assert(candidate((1101), (101)) == (2));\n    assert(candidate((0), (101)) == (1));\n    assert(candidate((3), (11)) == (8));\n    assert(candidate((100), (101)) == (1));\n    assert(candidate((30), (5)) == (4));\n    assert(candidate((31), (5)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n// (1.0f)\nfloat mean_absolute_deviation(std::vector<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = mean_absolute_deviation;\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f}))) == (0.5f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels((\"\"))\n// (\"\")\n// >>> remove_vowels((\"abcdef\"))\n// (\"bcdf\")\n// >>> remove_vowels((\"aaaaa\"))\n// (\"\")\n// >>> remove_vowels((\"aaBAA\"))\n// (\"B\")\n// >>> remove_vowels((\"zbcd\"))\n// (\"zbcd\")\nstd::string remove_vowels(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_vowels;\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"abcdef\\nghijklm\")) == (\"bcdf\\nghjklm\"));\n    assert(candidate((\"fedcba\")) == (\"fdcb\"));\n    assert(candidate((\"eeeee\")) == (\"\"));\n    assert(candidate((\"acBAA\")) == (\"cB\"));\n    assert(candidate((\"EcBOO\")) == (\"cB\"));\n    assert(candidate((\"ybcd\")) == (\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100))\n// (true)\n// >>> below_threshold((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5))\n// (false)\nbool below_threshold(std::vector<long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = below_threshold;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10})), (100)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (21)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10})), (22)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (11)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)8, (long)4, (long)10})), (10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Add two numbers x and y\n// >>> add((2), (3))\n// (5)\n// >>> add((5), (7))\n// (12)\nlong add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((0), (1)) == (1));\n    assert(candidate((1), (0)) == (1));\n    assert(candidate((2), (3)) == (5));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (5)) == (12));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1912,9 +1324,21 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Check if two words have the same characters.\n// >>> same_chars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n// (true)\n// >>> same_chars((\"abcd\"), (\"dddddddabc\"))\n// (true)\n// >>> same_chars((\"dddddddabc\"), (\"abcd\"))\n// (true)\n// >>> same_chars((\"eabcd\"), (\"dddddddabc\"))\n// (false)\n// >>> same_chars((\"abcd\"), (\"dddddddabce\"))\n// (false)\n// >>> same_chars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n// (false)\nbool same_chars(std::string s0, std::string s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = same_chars;\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(candidate((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(candidate((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(candidate((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(candidate((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(candidate((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(candidate((\"aabb\"), (\"aaccc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return n-th Fibonacci number.\n// >>> fib((10))\n// (55)\n// >>> fib((1))\n// (1)\n// >>> fib((8))\n// (21)\nlong fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fib;\n    assert(candidate((10)) == (55));\n    assert(candidate((1)) == (1));\n    assert(candidate((8)) == (21));\n    assert(candidate((11)) == (89));\n    assert(candidate((12)) == (144));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1924,9 +1348,585 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"<\"))\n// (false)\n// >>> correct_bracketing((\"<>\"))\n// (true)\n// >>> correct_bracketing((\"<<><>>\"))\n// (true)\n// >>> correct_bracketing((\"><<>\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"<>\")) == (true));\n    assert(candidate((\"<<><>>\")) == (true));\n    assert(candidate((\"<><><<><>><>\")) == (true));\n    assert(candidate((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(candidate((\"<<<><>>>>\")) == (false));\n    assert(candidate((\"><<>\")) == (false));\n    assert(candidate((\"<\")) == (false));\n    assert(candidate((\"<<<<\")) == (false));\n    assert(candidate((\">\")) == (false));\n    assert(candidate((\"<<>\")) == (false));\n    assert(candidate((\"<><><<><>><>><<>\")) == (false));\n    assert(candidate((\"<><><<><>><>>><>\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic((std::vector<long>({(long)1, (long)2, (long)4, (long)20})))\n// (true)\n// >>> monotonic((std::vector<long>({(long)1, (long)20, (long)4, (long)10})))\n// (false)\n// >>> monotonic((std::vector<long>({(long)4, (long)1, (long)0, (long)-10})))\n// (true)\nbool monotonic(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = monotonic;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)10}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)20}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)4, (long)10}))) == (false));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)0, (long)-10}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)1, (long)0}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)5, (long)60}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)60}))) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)9, (long)9, (long)9}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return sorted unique common elements for two lists.\n// >>> common((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121})))\n// (std::vector<long>({(long)1, (long)5, (long)653}))\n// >>> common((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2})))\n// (std::vector<long>({(long)2, (long)3}))\nstd::vector<long> common(std::vector<long> l1, std::vector<long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = common;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)34, (long)653, (long)2, (long)5})), (std::vector<long>({(long)5, (long)7, (long)1, (long)5, (long)9, (long)653, (long)121}))) == (std::vector<long>({(long)1, (long)5, (long)653})));\n    assert(candidate((std::vector<long>({(long)5, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2}))) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>({(long)3, (long)2, (long)4}))) == (std::vector<long>({(long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)8})), (std::vector<long>())) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor((13195))\n// (29)\n// >>> largest_prime_factor((2048))\n// (2)\nlong largest_prime_factor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_prime_factor;\n    assert(candidate((15)) == (5));\n    assert(candidate((27)) == (3));\n    assert(candidate((63)) == (7));\n    assert(candidate((330)) == (11));\n    assert(candidate((13195)) == (29));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse((std::vector<long>()), (4))\n// (std::vector<long>())\n// >>> intersperse((std::vector<long>({(long)1, (long)2, (long)3})), (4))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)4, (long)3}))\nstd::vector<long> intersperse(std::vector<long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersperse;\n    assert(candidate((std::vector<long>()), (7)) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)3, (long)2})), (8)) == (std::vector<long>({(long)5, (long)8, (long)6, (long)8, (long)3, (long)8, (long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)2, (long)2})), (2)) == (std::vector<long>({(long)2, (long)2, (long)2, (long)2, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n((30))\n// (465)\n// >>> sum_to_n((100))\n// (5050)\n// >>> sum_to_n((5))\n// (15)\n// >>> sum_to_n((10))\n// (55)\n// >>> sum_to_n((1))\n// (1)\nlong sum_to_n(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_to_n;\n    assert(candidate((1)) == (1));\n    assert(candidate((6)) == (21));\n    assert(candidate((11)) == (66));\n    assert(candidate((30)) == (465));\n    assert(candidate((100)) == (5050));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing((\"(\"))\n// (false)\n// >>> correct_bracketing((\"()\"))\n// (true)\n// >>> correct_bracketing((\"(()())\"))\n// (true)\n// >>> correct_bracketing((\")(()\"))\n// (false)\nbool correct_bracketing(std::string brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = correct_bracketing;\n    assert(candidate((\"()\")) == (true));\n    assert(candidate((\"(()())\")) == (true));\n    assert(candidate((\"()()(()())()\")) == (true));\n    assert(candidate((\"()()((()()())())(()()(()))\")) == (true));\n    assert(candidate((\"((()())))\")) == (false));\n    assert(candidate((\")(()\")) == (false));\n    assert(candidate((\"(\")) == (false));\n    assert(candidate((\"((((\")) == (false));\n    assert(candidate((\")\")) == (false));\n    assert(candidate((\"(()\")) == (false));\n    assert(candidate((\"()()(()())())(()\")) == (false));\n    assert(candidate((\"()()(()())()))()\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5})))\n// (std::vector<long>({(long)1, (long)4, (long)12, (long)20}))\n// >>> derivative((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)6}))\nstd::vector<long> derivative(std::vector<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = derivative;\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)12, (long)20})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)6})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (std::vector<long>({(long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1, (long)0, (long)4}))) == (std::vector<long>({(long)2, (long)2, (long)0, (long)16})));\n    assert(candidate((std::vector<long>({(long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib((1))\n// (0)\n// >>> fibfib((5))\n// (4)\n// >>> fibfib((8))\n// (24)\nlong fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fibfib;\n    assert(candidate((2)) == (1));\n    assert(candidate((1)) == (0));\n    assert(candidate((5)) == (4));\n    assert(candidate((8)) == (24));\n    assert(candidate((10)) == (81));\n    assert(candidate((12)) == (274));\n    assert(candidate((14)) == (927));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count((\"abcde\"))\n// (2)\n// >>> vowels_count((\"ACEDY\"))\n// (3)\nlong vowels_count(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = vowels_count;\n    assert(candidate((\"abcde\")) == (2));\n    assert(candidate((\"Alone\")) == (3));\n    assert(candidate((\"key\")) == (2));\n    assert(candidate((\"bye\")) == (1));\n    assert(candidate((\"keY\")) == (2));\n    assert(candidate((\"bYe\")) == (1));\n    assert(candidate((\"ACEDY\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift((12), (1))\n// (\"21\")\n// >>> circular_shift((12), (2))\n// (\"12\")\nstd::string circular_shift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = circular_shift;\n    assert(candidate((100), (2)) == (\"001\"));\n    assert(candidate((12), (2)) == (\"12\"));\n    assert(candidate((97), (8)) == (\"79\"));\n    assert(candidate((12), (1)) == (\"21\"));\n    assert(candidate((11), (101)) == (\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum((\"\"))\n// (0)\n// >>> digitSum((\"abAB\"))\n// (131)\n// >>> digitSum((\"abcCd\"))\n// (67)\n// >>> digitSum((\"helloE\"))\n// (69)\n// >>> digitSum((\"woArBld\"))\n// (131)\n// >>> digitSum((\"aAaaaXa\"))\n// (153)\nlong digitSum(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digitSum;\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"abAB\")) == (131));\n    assert(candidate((\"abcCd\")) == (67));\n    assert(candidate((\"helloE\")) == (69));\n    assert(candidate((\"woArBld\")) == (131));\n    assert(candidate((\"aAaaaXa\")) == (153));\n    assert(candidate((\" How are yOu?\")) == (151));\n    assert(candidate((\"You arE Very Smart\")) == (327));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution((\"5 apples and 6 oranges\"), (19))\n// (8)\n// >>> fruit_distribution((\"0 apples and 1 oranges\"), (3))\n// (2)\n// >>> fruit_distribution((\"2 apples and 3 oranges\"), (100))\n// (95)\n// >>> fruit_distribution((\"100 apples and 1 oranges\"), (120))\n// (19)\nlong fruit_distribution(std::string s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = fruit_distribution;\n    assert(candidate((\"5 apples and 6 oranges\"), (19)) == (8));\n    assert(candidate((\"5 apples and 6 oranges\"), (21)) == (10));\n    assert(candidate((\"0 apples and 1 oranges\"), (3)) == (2));\n    assert(candidate((\"1 apples and 0 oranges\"), (3)) == (2));\n    assert(candidate((\"2 apples and 3 oranges\"), (100)) == (95));\n    assert(candidate((\"2 apples and 3 oranges\"), (5)) == (0));\n    assert(candidate((\"1 apples and 100 oranges\"), (120)) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck((std::vector<long>({(long)4, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck((std::vector<long>({(long)1, (long)2, (long)3})))\n// (std::vector<long>({(long)2, (long)1}))\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck((std::vector<long>()))\n// (std::vector<long>())\n// Example 4:\n// >>> pluck((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2})))\n// (std::vector<long>({(long)0, (long)1}))\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nstd::vector<long> pluck(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pluck;\n    assert(candidate((std::vector<long>({(long)4, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2, (long)1})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5, (long)0, (long)3, (long)0, (long)4, (long)2}))) == (std::vector<long>({(long)0, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)0, (long)5, (long)3}))) == (std::vector<long>({(long)0, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)8, (long)4, (long)8}))) == (std::vector<long>({(long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)6, (long)7, (long)1}))) == (std::vector<long>({(long)6, (long)1})));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)7, (long)1}))) == (std::vector<long>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search((std::vector<long>({(long)4, (long)1, (long)2, (long)2, (long)3, (long)1})))\n// (2)\n// >>> search((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4, (long)4})))\n// (3)\n// >>> search((std::vector<long>({(long)5, (long)5, (long)4, (long)4, (long)4})))\n// (-1)\nlong search(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)4, (long)1, (long)4, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)3, (long)3}))) == (-1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)3, (long)2, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)7, (long)8, (long)8, (long)4, (long)8, (long)7, (long)3, (long)9, (long)6, (long)5, (long)10, (long)4, (long)3, (long)6, (long)7, (long)1, (long)7, (long)4, (long)10, (long)8, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)8, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)1, (long)8, (long)8, (long)10, (long)5, (long)8, (long)5, (long)3, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)3, (long)6, (long)5, (long)6, (long)4}))) == (-1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)6, (long)7, (long)1, (long)4, (long)7, (long)1, (long)8, (long)8, (long)9, (long)8, (long)10, (long)10, (long)8, (long)4, (long)10, (long)4, (long)10, (long)1, (long)2, (long)9, (long)5, (long)7, (long)9}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)9, (long)10, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)6, (long)9, (long)7, (long)5, (long)8, (long)7, (long)5, (long)3, (long)7, (long)5, (long)10, (long)10, (long)3, (long)6, (long)10, (long)2, (long)8, (long)6, (long)5, (long)4, (long)9, (long)5, (long)3, (long)10}))) == (5));\n    assert(candidate((std::vector<long>({(long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)8, (long)10, (long)6, (long)4, (long)3, (long)5, (long)8, (long)2, (long)4, (long)2, (long)8, (long)4, (long)6, (long)10, (long)4, (long)2, (long)1, (long)10, (long)2, (long)1, (long)1, (long)5}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)8, (long)2, (long)10, (long)5, (long)1, (long)2, (long)9, (long)5, (long)5, (long)6, (long)3, (long)8, (long)6, (long)4, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)6, (long)10, (long)1, (long)6, (long)9, (long)10, (long)8, (long)6, (long)8, (long)7, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)4, (long)1, (long)5, (long)1, (long)5, (long)2, (long)5, (long)7, (long)7, (long)7, (long)3, (long)10, (long)1, (long)5, (long)4, (long)2, (long)8, (long)4, (long)1, (long)9, (long)10, (long)7, (long)10, (long)2, (long)8, (long)10, (long)9, (long)4}))) == (4));\n    assert(candidate((std::vector<long>({(long)2, (long)6, (long)4, (long)2, (long)8, (long)7, (long)5, (long)6, (long)4, (long)10, (long)4, (long)6, (long)3, (long)7, (long)8, (long)8, (long)3, (long)1, (long)4, (long)2, (long)2, (long)10, (long)7}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)6, (long)10, (long)2, (long)6, (long)10, (long)2, (long)7, (long)8, (long)10, (long)3, (long)8, (long)2, (long)6, (long)2, (long)3, (long)1}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)3, (long)9, (long)5, (long)6, (long)3, (long)2, (long)8, (long)5, (long)6, (long)10, (long)10, (long)6, (long)8, (long)4, (long)10, (long)7, (long)7, (long)10, (long)8}))) == (-1));\n    assert(candidate((std::vector<long>({(long)10}))) == (-1));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)7, (long)2, (long)4, (long)7, (long)2, (long)10, (long)9, (long)7, (long)5, (long)7, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)10, (long)2, (long)1, (long)1, (long)10, (long)3, (long)6, (long)1, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)7, (long)9, (long)9, (long)9, (long)3, (long)4, (long)1, (long)5, (long)9, (long)1, (long)2, (long)1, (long)1, (long)10, (long)7, (long)5, (long)6, (long)7, (long)6, (long)7, (long)7, (long)6}))) == (1));\n    assert(candidate((std::vector<long>({(long)3, (long)10, (long)10, (long)9, (long)2}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens((\"(()()) ((())) () ((())()())\"))\n// (std::vector<long>({(long)2, (long)3, (long)1, (long)3}))\nstd::vector<long> parse_nested_parens(std::string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = parse_nested_parens;\n    assert(candidate((\"(()()) ((())) () ((())()())\")) == (std::vector<long>({(long)2, (long)3, (long)1, (long)3})));\n    assert(candidate((\"() (()) ((())) (((())))\")) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((\"(()(())((())))\")) == (std::vector<long>({(long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::vector<long>({(long)1, (long)4, (long)2, (long)3}))\n// >>> strange_sort_list((std::vector<long>({(long)5, (long)5, (long)5, (long)5})))\n// (std::vector<long>({(long)5, (long)5, (long)5, (long)5}))\n// >>> strange_sort_list((std::vector<long>()))\n// (std::vector<long>())\nstd::vector<long> strange_sort_list(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = strange_sort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)4, (long)2, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == (std::vector<long>({(long)5, (long)9, (long)6, (long)8, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)2, (long)4, (long)3})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)1, (long)9, (long)5, (long)8, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)5, (long)5, (long)5, (long)5}))) == (std::vector<long>({(long)5, (long)5, (long)5, (long)5})));\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8}))) == (std::vector<long>({(long)1, (long)8, (long)2, (long)7, (long)3, (long)6, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)0, (long)2, (long)2, (long)2, (long)5, (long)5, (long)-5, (long)-5}))) == (std::vector<long>({(long)-5, (long)5, (long)-5, (long)5, (long)0, (long)2, (long)2, (long)2})));\n    assert(candidate((std::vector<long>({(long)111111}))) == (std::vector<long>({(long)111111})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area((3), (4), (5))\n// (6.0f)\n// >>> triangle_area((1), (2), (10))\n// (float(-1))\nfloat triangle_area(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((3), (4), (5)) == (6.0f));\n    assert(candidate((1), (2), (10)) == (float(-1)));\n    assert(candidate((4), (8), (5)) == (8.18f));\n    assert(candidate((2), (2), (2)) == (1.73f));\n    assert(candidate((1), (2), (3)) == (float(-1)));\n    assert(candidate((10), (5), (7)) == (16.25f));\n    assert(candidate((2), (6), (3)) == (float(-1)));\n    assert(candidate((1), (1), (1)) == (0.43f));\n    assert(candidate((2), (2), (10)) == (float(-1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly((std::vector<long>({(long)1, (long)2})), (5))\n// (false)\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (1))\n// (false)\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly((std::vector<long>({(long)3, (long)2, (long)3})), (9))\n// (true)\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly((std::vector<long>({(long)3})), (5))\n// (true)\n// # 3 is less than the maximum possible weight, and it's balanced.\nbool will_it_fly(std::vector<long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = will_it_fly;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (9)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (5)) == (false));\n    assert(candidate((std::vector<long>({(long)3})), (5)) == (true));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3})), (1)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (6)) == (false));\n    assert(candidate((std::vector<long>({(long)5})), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6})))\n// (4)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2})))\n// (1)\n// >>> smallest_change((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1})))\n// (0)\nlong smallest_change(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = smallest_change;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)4, (long)7, (long)9, (long)6}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)4, (long)2}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)3, (long)1, (long)1, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1}))) == (0));\n    assert(candidate((std::vector<long>({(long)0, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match((std::vector<std::string>()), (std::vector<std::string>()))\n// (std::vector<std::string>())\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"})))\n// (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})))\n// (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))\n// >>> total_match((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"})))\n// (std::vector<std::string>({(std::string)\"4\"}))\nstd::vector<std::string> total_match(std::vector<std::string> lst1, std::vector<std::string> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = total_match;\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>())) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hi\", (std::string)\"hi\", (std::string)\"admin\", (std::string)\"project\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"4\"})), (std::vector<std::string>({(std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"5\"}))) == (std::vector<std::string>({(std::string)\"4\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"Hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"}))) == (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hi\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})), (std::vector<std::string>({(std::string)\"hI\", (std::string)\"hi\", (std::string)\"hii\"}))) == (std::vector<std::string>({(std::string)\"hi\", (std::string)\"admin\"})));\n    assert(candidate((std::vector<std::string>()), (std::vector<std::string>({(std::string)\"this\"}))) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"this\"})), (std::vector<std::string>())) == (std::vector<std::string>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime((30))\n// (true)\n// 30 = 2 * 3 * 5\nbool is_multiply_prime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_multiply_prime;\n    assert(candidate((5)) == (false));\n    assert(candidate((30)) == (true));\n    assert(candidate((8)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((125)) == (true));\n    assert(candidate((105)) == (true));\n    assert(candidate((126)) == (false));\n    assert(candidate((729)) == (false));\n    assert(candidate((891)) == (false));\n    assert(candidate((1001)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power((1), (4))\n// (true)\n// >>> is_simple_power((2), (2))\n// (true)\n// >>> is_simple_power((8), (2))\n// (true)\n// >>> is_simple_power((3), (2))\n// (false)\n// >>> is_simple_power((3), (1))\n// (false)\n// >>> is_simple_power((5), (3))\n// (false)\nbool is_simple_power(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_simple_power;\n    assert(candidate((16), (2)) == (true));\n    assert(candidate((143214), (16)) == (false));\n    assert(candidate((4), (2)) == (true));\n    assert(candidate((9), (3)) == (true));\n    assert(candidate((16), (4)) == (true));\n    assert(candidate((24), (2)) == (false));\n    assert(candidate((128), (4)) == (false));\n    assert(candidate((12), (6)) == (false));\n    assert(candidate((1), (1)) == (true));\n    assert(candidate((1), (12)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube((1))\n// (true)\n// >>> iscube((2))\n// (false)\n// >>> iscube((-1))\n// (true)\n// >>> iscube((64))\n// (true)\n// >>> iscube((0))\n// (true)\n// >>> iscube((180))\n// (false)\nbool iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = iscube;\n    assert(candidate((1)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((-1)) == (true));\n    assert(candidate((64)) == (true));\n    assert(candidate((180)) == (false));\n    assert(candidate((1000)) == (true));\n    assert(candidate((0)) == (true));\n    assert(candidate((1729)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key((\"AB\"))\n// (1)\n// >>> hex_key((\"1077E\"))\n// (2)\n// >>> hex_key((\"ABED1A33\"))\n// (4)\n// >>> hex_key((\"123456789ABCDEF0\"))\n// (6)\n// >>> hex_key((\"2020\"))\n// (2)\nlong hex_key(std::string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = hex_key;\n    assert(candidate((\"AB\")) == (1));\n    assert(candidate((\"1077E\")) == (2));\n    assert(candidate((\"ABED1A33\")) == (4));\n    assert(candidate((\"2020\")) == (2));\n    assert(candidate((\"123456789ABCDEF0\")) == (6));\n    assert(candidate((\"112233445566778899AABBCCDDEEFF00\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary((15))\n// (\"db1111db\")\n// >>> decimal_to_binary((32))\n// (\"db100000db\")\nstd::string decimal_to_binary(long decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((0)) == (\"db0db\"));\n    assert(candidate((32)) == (\"db100000db\"));\n    assert(candidate((103)) == (\"db1100111db\"));\n    assert(candidate((15)) == (\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring((std::vector<std::string>()), (\"a\"))\n// (std::vector<std::string>())\n// >>> filter_by_substring((std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"cde\", (std::string)\"array\"})), (\"a\"))\n// (std::vector<std::string>({(std::string)\"abc\", (std::string)\"bacd\", (std::string)\"array\"}))\nstd::vector<std::string> filter_by_substring(std::vector<std::string> strings, std::string substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_by_substring;\n    assert(candidate((std::vector<std::string>()), (\"john\")) == (std::vector<std::string>()));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"xxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xxx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"xxx\", (std::string)\"asd\", (std::string)\"aaaxxy\", (std::string)\"john doe\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})), (\"xx\")) == (std::vector<std::string>({(std::string)\"xxx\", (std::string)\"aaaxxy\", (std::string)\"xxxAAA\", (std::string)\"xxx\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"grunt\", (std::string)\"trumpet\", (std::string)\"prune\", (std::string)\"gruesome\"})), (\"run\")) == (std::vector<std::string>({(std::string)\"grunt\", (std::string)\"prune\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy((\"a\"))\n// (false)\n// >>> is_happy((\"aa\"))\n// (false)\n// >>> is_happy((\"abcd\"))\n// (true)\n// >>> is_happy((\"aabb\"))\n// (false)\n// >>> is_happy((\"adb\"))\n// (true)\n// >>> is_happy((\"xyy\"))\n// (false)\nbool is_happy(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_happy;\n    assert(candidate((\"a\")) == (false));\n    assert(candidate((\"aa\")) == (false));\n    assert(candidate((\"abcd\")) == (true));\n    assert(candidate((\"aabb\")) == (false));\n    assert(candidate((\"adb\")) == (true));\n    assert(candidate((\"xyy\")) == (false));\n    assert(candidate((\"iopaxpoi\")) == (true));\n    assert(candidate((\"iopaxioi\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f})))\n// (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"}))\nstd::vector<std::string> numerical_letter_grade(std::vector<float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = numerical_letter_grade;\n    assert(candidate((std::vector<float>({(float)4.0f, (float)3, (float)1.7f, (float)2, (float)3.5f}))) == (std::vector<std::string>({(std::string)\"A+\", (std::string)\"B\", (std::string)\"C-\", (std::string)\"C\", (std::string)\"A-\"})));\n    assert(candidate((std::vector<float>({(float)1.2f}))) == (std::vector<std::string>({(std::string)\"D+\"})));\n    assert(candidate((std::vector<float>({(float)0.5f}))) == (std::vector<std::string>({(std::string)\"D-\"})));\n    assert(candidate((std::vector<float>({(float)0.0f}))) == (std::vector<std::string>({(std::string)\"E\"})));\n    assert(candidate((std::vector<float>({(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))) == (std::vector<std::string>({(std::string)\"D\", (std::string)\"D-\", (std::string)\"C-\", (std::string)\"B\", (std::string)\"B+\"})));\n    assert(candidate((std::vector<float>({(float)0.0f, (float)0.7f}))) == (std::vector<std::string>({(std::string)\"E\", (std::string)\"D-\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length((\"Hello\"))\n// (true)\n// >>> prime_length((\"abcdcba\"))\n// (true)\n// >>> prime_length((\"kittens\"))\n// (true)\n// >>> prime_length((\"orange\"))\n// (false)\nbool prime_length(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_length;\n    assert(candidate((\"Hello\")) == (true));\n    assert(candidate((\"abcdcba\")) == (true));\n    assert(candidate((\"kittens\")) == (true));\n    assert(candidate((\"orange\")) == (false));\n    assert(candidate((\"wow\")) == (true));\n    assert(candidate((\"world\")) == (true));\n    assert(candidate((\"MadaM\")) == (true));\n    assert(candidate((\"Wow\")) == (true));\n    assert(candidate((\"\")) == (false));\n    assert(candidate((\"HI\")) == (true));\n    assert(candidate((\"go\")) == (true));\n    assert(candidate((\"gogo\")) == (false));\n    assert(candidate((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(candidate((\"Madam\")) == (true));\n    assert(candidate((\"M\")) == (false));\n    assert(candidate((\"0\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nlong starts_one_ends(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = starts_one_ends;\n    assert(candidate((1)) == (1));\n    assert(candidate((2)) == (18));\n    assert(candidate((3)) == (180));\n    assert(candidate((4)) == (1800));\n    assert(candidate((5)) == (18000));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve((1000))\n// (\"1\")\n// >>> solve((150))\n// (\"110\")\n// >>> solve((147))\n// (\"1100\")\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nstd::string solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = solve;\n    assert(candidate((1000)) == (\"1\"));\n    assert(candidate((150)) == (\"110\"));\n    assert(candidate((147)) == (\"1100\"));\n    assert(candidate((333)) == (\"1001\"));\n    assert(candidate((963)) == (\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add((std::vector<long>({(long)4, (long)2, (long)6, (long)7})))\n// (2)\nlong add(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add;\n    assert(candidate((std::vector<long>({(long)4, (long)88}))) == (88));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)2, (long)122}))) == (122));\n    assert(candidate((std::vector<long>({(long)4, (long)0, (long)6, (long)7}))) == (0));\n    assert(candidate((std::vector<long>({(long)4, (long)4, (long)6, (long)8}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle((\"Hi\"))\n// (\"Hi\")\n// >>> anti_shuffle((\"hello\"))\n// (\"ehllo\")\n// >>> anti_shuffle((\"Hello World!!!\"))\n// (\"Hello !!!Wdlor\")\nstd::string anti_shuffle(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = anti_shuffle;\n    assert(candidate((\"Hi\")) == (\"Hi\"));\n    assert(candidate((\"hello\")) == (\"ehllo\"));\n    assert(candidate((\"number\")) == (\"bemnru\"));\n    assert(candidate((\"abcd\")) == (\"abcd\"));\n    assert(candidate((\"Hello World!!!\")) == (\"Hello !!!Wdlor\"));\n    assert(candidate((\"\")) == (\"\"));\n    assert(candidate((\"Hi. My name is Mister Robot. How are you?\")) == (\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)}))\n// >>> get_row((std::vector<std::vector<long>>()), (1))\n// (std::vector<std::tuple<long, long>>())\n// >>> get_row((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3))\n// (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)}))\nstd::vector<std::tuple<long, long>> get_row(std::vector<std::vector<long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_row;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 4), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(2, 0)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})})), (2)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 1), (std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(4, 1), (std::tuple<long, long>)std::make_tuple(5, 1)})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)1, (long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)1})})), (1)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(0, 0), (std::tuple<long, long>)std::make_tuple(1, 0), (std::tuple<long, long>)std::make_tuple(2, 1), (std::tuple<long, long>)std::make_tuple(2, 0), (std::tuple<long, long>)std::make_tuple(3, 2), (std::tuple<long, long>)std::make_tuple(3, 0), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(4, 0), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(5, 0), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 0)})));\n    assert(candidate((std::vector<std::vector<long>>()), (1)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1})})), (2)) == (std::vector<std::tuple<long, long>>()));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>(), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})), (3)) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 2)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array((std::vector<long>()))\n// (std::vector<long>())\n// >>> sort_array((std::vector<long>({(long)5})))\n// (std::vector<long>({(long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5})))\n// (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5}))\n// >>> sort_array((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6})))\n// (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0}))\nstd::vector<long> sort_array(std::vector<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_array;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)5}))) == (std::vector<long>({(long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)0, (long)1, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4, (long)3, (long)2, (long)1, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)1}))) == (std::vector<long>({(long)1, (long)2})));\n    assert(candidate((std::vector<long>({(long)15, (long)42, (long)87, (long)32, (long)11, (long)0}))) == (std::vector<long>({(long)0, (long)11, (long)15, (long)32, (long)42, (long)87})));\n    assert(candidate((std::vector<long>({(long)21, (long)14, (long)23, (long)11}))) == (std::vector<long>({(long)23, (long)21, (long)14, (long)11})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt((\"hi\"))\n// (\"lm\")\n// >>> encrypt((\"asdfghjkl\"))\n// (\"ewhjklnop\")\n// >>> encrypt((\"gf\"))\n// (\"kj\")\n// >>> encrypt((\"et\"))\n// (\"ix\")\nstd::string encrypt(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encrypt;\n    assert(candidate((\"hi\")) == (\"lm\"));\n    assert(candidate((\"asdfghjkl\")) == (\"ewhjklnop\"));\n    assert(candidate((\"gf\")) == (\"kj\"));\n    assert(candidate((\"et\")) == (\"ix\"));\n    assert(candidate((\"faewfawefaewg\")) == (\"jeiajeaijeiak\"));\n    assert(candidate((\"hellomyfriend\")) == (\"lippsqcjvmirh\"));\n    assert(candidate((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")) == (\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert(candidate((\"a\")) == (\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product((std::vector<long>()))\n// (std::make_tuple(0, 1))\n// >>> sum_product((std::vector<long>({(long)1, (long)2, (long)3, (long)4})))\n// (std::make_tuple(10, 24))\nstd::tuple<long, long> sum_product(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_product;\n    assert(candidate((std::vector<long>())) == (std::make_tuple(0, 1)));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (std::make_tuple(3, 1)));\n    assert(candidate((std::vector<long>({(long)100, (long)0}))) == (std::make_tuple(100, 0)));\n    assert(candidate((std::vector<long>({(long)3, (long)5, (long)7}))) == (std::make_tuple(15, 105)));\n    assert(candidate((std::vector<long>({(long)10}))) == (std::make_tuple(10, 10)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})))\n// 2\n// >>> next_smallest((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2})))\n// 2\n// >>> next_smallest((std::vector<long>()))\n// std::nullopt\n// >>> next_smallest((std::vector<long>({(long)1, (long)1})))\n// std::nullopt\nstd::optional<long> next_smallest(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = next_smallest;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == 2);\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)4, (long)3, (long)2}))) == 2);\n    assert(candidate((std::vector<long>())) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1, (long)0}))) == 1);\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == std::nullopt);\n    assert(candidate((std::vector<long>({(long)-35, (long)34, (long)12, (long)-45}))) == -35);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored((\"Hello world\"))\n// (0)\n// >>> is_bored((\"The sky is blue. The sun is shining. I love this weather\"))\n// (1)\nlong is_bored(std::string S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_bored;\n    assert(candidate((\"Hello world\")) == (0));\n    assert(candidate((\"Is the sky blue?\")) == (0));\n    assert(candidate((\"I love It !\")) == (1));\n    assert(candidate((\"bIt\")) == (0));\n    assert(candidate((\"I feel good today. I will be productive. will kill It\")) == (2));\n    assert(candidate((\"You and I are going for a walk\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int((float(5)), (float(2)), (float(7)))\n// (true)\n// >>> any_int((float(3)), (float(2)), (float(2)))\n// (false)\n// >>> any_int((float(3)), (float(-2)), (float(1)))\n// (true)\n// >>> any_int((3.6f), (-2.2f), (float(2)))\n// (false)\nbool any_int(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = any_int;\n    assert(candidate((float(2)), (float(3)), (float(1))) == (true));\n    assert(candidate((2.5f), (float(2)), (float(3))) == (false));\n    assert(candidate((1.5f), (float(5)), (3.5f)) == (false));\n    assert(candidate((float(2)), (float(6)), (float(2))) == (false));\n    assert(candidate((float(4)), (float(2)), (float(2))) == (true));\n    assert(candidate((2.2f), (2.2f), (2.2f)) == (false));\n    assert(candidate((float(-4)), (float(6)), (float(2))) == (true));\n    assert(candidate((float(2)), (float(1)), (float(1))) == (true));\n    assert(candidate((float(3)), (float(4)), (float(7))) == (true));\n    assert(candidate((3.0f), (float(4)), (float(7))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode((\"test\"))\n// (\"TGST\")\n// >>> encode((\"This is a message\"))\n// (\"tHKS KS C MGSSCGG\")\nstd::string encode(std::string message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = encode;\n    assert(candidate((\"TEST\")) == (\"tgst\"));\n    assert(candidate((\"Mudasir\")) == (\"mWDCSKR\"));\n    assert(candidate((\"YES\")) == (\"ygs\"));\n    assert(candidate((\"This is a message\")) == (\"tHKS KS C MGSSCGG\"));\n    assert(candidate((\"I DoNt KnOw WhAt tO WrItE\")) == (\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3})))\n// (10)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1})))\n// (25)\n// >>> skjkasdkd((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3})))\n// (13)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6})))\n// (11)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21})))\n// (3)\n// >>> skjkasdkd((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7})))\n// (7)\nlong skjkasdkd(std::vector<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = skjkasdkd;\n    assert(candidate((std::vector<long>({(long)0, (long)3, (long)2, (long)1, (long)3, (long)5, (long)7, (long)4, (long)5, (long)5, (long)5, (long)2, (long)181, (long)32, (long)4, (long)32, (long)3, (long)2, (long)32, (long)324, (long)4, (long)3}))) == (10));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)1, (long)8, (long)2, (long)4597, (long)2, (long)1, (long)3, (long)40, (long)1, (long)2, (long)1, (long)2, (long)4, (long)2, (long)5, (long)1}))) == (25));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)1, (long)32, (long)5107, (long)34, (long)83278, (long)109, (long)163, (long)23, (long)2323, (long)32, (long)30, (long)1, (long)9, (long)3}))) == (13));\n    assert(candidate((std::vector<long>({(long)0, (long)724, (long)32, (long)71, (long)99, (long)32, (long)6, (long)0, (long)5, (long)91, (long)83, (long)0, (long)5, (long)6}))) == (11));\n    assert(candidate((std::vector<long>({(long)0, (long)81, (long)12, (long)3, (long)1, (long)21}))) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)8, (long)1, (long)2, (long)1, (long)7}))) == (7));\n    assert(candidate((std::vector<long>({(long)8191}))) == (19));\n    assert(candidate((std::vector<long>({(long)8191, (long)123456, (long)127, (long)7}))) == (19));\n    assert(candidate((std::vector<long>({(long)127, (long)97, (long)8192}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"b\", \"banana\"}})))\n// (true)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"a\", \"apple\"}, {8, \"banana\"}, {\"a\", \"apple\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})))\n// (false)\n// >>> check_dict_case((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})))\n// (true)\nbool check_dict_case(std::map<std::string,std::string> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_dict_case;\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"b\", \"banana\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))) == (false));\n    assert(candidate((std::map<std::string,std::string>({{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>({{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}}))) == (true));\n    assert(candidate((std::map<std::string,std::string>())) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to((5))\n// (std::vector<long>({(long)2, (long)3}))\n// >>> count_up_to((11))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7}))\n// >>> count_up_to((0))\n// (std::vector<long>())\n// >>> count_up_to((20))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19}))\n// >>> count_up_to((1))\n// (std::vector<long>())\n// >>> count_up_to((18))\n// (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17}))\nstd::vector<long> count_up_to(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_up_to;\n    assert(candidate((5)) == (std::vector<long>({(long)2, (long)3})));\n    assert(candidate((6)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((7)) == (std::vector<long>({(long)2, (long)3, (long)5})));\n    assert(candidate((10)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((0)) == (std::vector<long>()));\n    assert(candidate((22)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19})));\n    assert(candidate((1)) == (std::vector<long>()));\n    assert(candidate((18)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17})));\n    assert(candidate((47)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43})));\n    assert(candidate((101)) == (std::vector<long>({(long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)19, (long)23, (long)29, (long)31, (long)37, (long)41, (long)43, (long)47, (long)53, (long)59, (long)61, (long)67, (long)71, (long)73, (long)79, (long)83, (long)89, (long)97})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply((148), (412))\n// (16)\n// >>> multiply((19), (28))\n// (72)\n// >>> multiply((2020), (1851))\n// (0)\n// >>> multiply((14), (-15))\n// (20)\nlong multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = multiply;\n    assert(candidate((148), (412)) == (16));\n    assert(candidate((19), (28)) == (72));\n    assert(candidate((2020), (1851)) == (0));\n    assert(candidate((14), (-15)) == (20));\n    assert(candidate((76), (67)) == (42));\n    assert(candidate((17), (27)) == (49));\n    assert(candidate((0), (1)) == (0));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper((\"aBCdEf\"))\n// (1)\n// >>> count_upper((\"abcdefg\"))\n// (0)\n// >>> count_upper((\"dBBE\"))\n// (0)\nlong count_upper(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_upper;\n    assert(candidate((\"aBCdEf\")) == (1));\n    assert(candidate((\"abcdefg\")) == (0));\n    assert(candidate((\"dBBE\")) == (0));\n    assert(candidate((\"B\")) == (0));\n    assert(candidate((\"U\")) == (1));\n    assert(candidate((\"\")) == (0));\n    assert(candidate((\"EEEE\")) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer((\"10\"))\n// (10)\n// >>> closest_integer((\"15.3\"))\n// (15)\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nlong closest_integer(std::string value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = closest_integer;\n    assert(candidate((\"10\")) == (10));\n    assert(candidate((\"14.5\")) == (15));\n    assert(candidate((\"-15.5\")) == (-16));\n    assert(candidate((\"15.3\")) == (15));\n    assert(candidate((\"0\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)2})))\n// (std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)4, (long)4}))\nstd::vector<long> rolling_max(std::vector<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rolling_max;\n    assert(candidate((std::vector<long>())) == (std::vector<long>()));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)1}))) == (std::vector<long>({(long)4, (long)4, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)3, (long)100, (long)3}))) == (std::vector<long>({(long)3, (long)3, (long)3, (long)100, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-cs-keep.json
+++ b/prompts/humaneval-cs-keep.json
@@ -1,984 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    public static bool Iscube(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    public static bool HasCloseElements(List<float> numbers, float threshold) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    public static string Encode(string message) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    public static long Solution(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    public static string StringSequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    public static long Minsubarraysum(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    public static long IsBored(string S) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static List<long> GetOddCollatz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    public static bool BelowThreshold(List<long> l, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    public static bool AnyInt(float x, float y, float z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    public static long XOrY(long n, long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    public static bool TriplesSumToZero(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    public static bool IsHappy(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    public static string FileNameCheck(string file_name) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    public static Dictionary<string,long> Histogram(string test) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    public static bool Simplify(string x, string n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    public static Tuple<string, bool> ReverseDelete(string s, string c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseDelete((\"abcde\"), (\"ae\")).Equals((Tuple.Create(\"bcd\", false))));\n    Debug.Assert(ReverseDelete((\"abcdef\"), (\"b\")).Equals((Tuple.Create(\"acdef\", false))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"ab\")).Equals((Tuple.Create(\"cdedc\", true))));\n    Debug.Assert(ReverseDelete((\"dwik\"), (\"w\")).Equals((Tuple.Create(\"dik\", false))));\n    Debug.Assert(ReverseDelete((\"a\"), (\"a\")).Equals((Tuple.Create(\"\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"v\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"vabba\"), (\"v\")).Equals((Tuple.Create(\"abba\", true))));\n    Debug.Assert(ReverseDelete((\"mamma\"), (\"mia\")).Equals((Tuple.Create(\"\", true))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    public static long Skjkasdkd(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    public static List<string> AllPrefixes(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    public static long Digits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    public static long Strlen(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    public static long Fibfib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    public static List<string> WordsString(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    public static bool Monotonic(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    public static string FixSpaces(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    public static bool CycpatternCheck(string a, string b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    public static float TruncateNumber(float number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    public static List<long> ParseMusic(string music_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    public static string RemoveVowels(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    public static List<long> SortThird(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    public static List<long> CountUpTo(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    public static long MaxElement(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    public static List<string> SortedListSum(List<string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    public static float TriangleArea(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    public static List<long> Unique(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    public static long SmallestChange(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    public static List<long> UniqueDigits(List<long> x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    public static List<long> F(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    public static string MatchParens(List<string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    public static bool IsEqualToSumEven(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    public static long LargestPrimeFactor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    public static string Encrypt(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    public static long HowManyTimes(string str, string substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    public static string Solve(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    public static List<long> SortEven(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-10L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)5L, (long)0L, (long)9L, (long)1L, (long)123L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)8L, (long)-12L, (long)4L, (long)23L, (long)2L, (long)3L, (long)11L, (long)12L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-12L, (long)8L, (long)3L, (long)4L, (long)5L, (long)2L, (long)12L, (long)11L, (long)23L, (long)-10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    public static bool BelowZero(List<long> operations) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    public static bool SameChars(string s0, string s1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    Debug.Assert(SameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    Debug.Assert(SameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    Debug.Assert(SameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    public static long CountUpper(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    public static List<long> RollingMax(List<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    public static List<string> SelectWords(string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    public static string FindMax(List<string> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    public static long SumSquares(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    public static long Add(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    public static long Multiply(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    public static List<long> Tri(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    public static bool IsSimplePower(long x, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -988,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> make_a_pile(3)\n    // [3, 5, 7]\n    public static List<long> MakeAPile(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakeAPile((3L)).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(MakeAPile((4L)).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(MakeAPile((5L)).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)11L, (long)13L}))));\n    Debug.Assert(MakeAPile((6L)).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L}))));\n    Debug.Assert(MakeAPile((8L)).Equals((new List<long>(new long[]{(long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)18L, (long)20L, (long)22L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -996,853 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    public static long Add(long x, long y) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    public static List<string> WordsString(string s) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    public static string DecimalToBinary(long decimalNum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    public static bool IsPalindrome(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    public static long GreatestCommonDivisor(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    public static List<long> Factorize(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    public static string CircularShift(long x, long shift) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    public static string GetClosestVowel(string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    public static string SortNumbers(string numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    public static string FlipCase(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    public static long CanArrange(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    public static bool IsNested(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    public static List<string> ByLength(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    public static long SumToN(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    public static List<string> OddCount(List<string> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    public static string Concatenate(List<string> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    public static long SumSquares(List<float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    public static List<long> SortArray(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-4L, (long)-2L, (long)-6L, (long)-5L, (long)-3L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)5L, (long)77L, (long)4L, (long)5L, (long)3L, (long)5L, (long)7L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)4L, (long)4L, (long)3L, (long)3L, (long)5L, (long)5L, (long)5L, (long)7L, (long)77L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)3L, (long)6L, (long)44L, (long)12L, (long)32L, (long)5L}))).Equals((new List<long>(new long[]{(long)32L, (long)3L, (long)5L, (long)6L, (long)12L, (long)44L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    public static string Longest(List<string> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    public static bool IsSorted(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    public static List<long> Derivative(List<long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    public static string AntiShuffle(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    public static string MakePalindrome(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    public static string ChangeBase(long x, long numBase) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    public static bool PrimeLength(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    public static long Search(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    public static long FizzBuzz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    public static List<long> ParseNestedParens(string paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    public static List<long> SortArray(List<long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    public static long VowelsCount(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    public static string StringToMd5(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    public static bool IsPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    public static List<string> Bf(string planet1, string planet2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    public static long HexKey(string num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    public static float Median(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    public static long Specialfilter(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)5L, (long)-2L, (long)1L, (long)-5L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L}))) == (1L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L}))) == (2L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)43L, (long)-12L, (long)93L, (long)125L, (long)121L, (long)109L}))) == (4L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)71L, (long)-2L, (long)-33L, (long)75L, (long)21L, (long)19L}))) == (3L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>())) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    public static long Modp(long n, long p) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    public static bool PairsSumToZero(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    public static List<long> StrangeSortList(List<long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    public static long PrimeFib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    public static bool ValidDate(string date) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    public static long CountNums(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    public static List<long> FilterIntegers(List<object> values) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    public static long Digitsum(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    public static List<long> OrderByPoints(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    public static float TriangleArea(long a, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    public static long Fib4(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    public static string StringXor(string a, string b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    public static bool HasCloseElements(List<float> numbers, float threshold) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    public static long FruitDistribution(string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    public static long LargestDivisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    public static string IntToMiniRoman(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    public static bool CorrectBracketing(string brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    public static bool CorrectBracketing(string brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"<>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<><>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<<><>>>>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<<<\")) == (false));\n    Debug.Assert(CorrectBracketing((\">\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    public static long Fib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    public static List<long> IncrList(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    public static List<long> GetPositive(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1852,7 +40,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // choose_num(12, 15) = 14\n    // choose_num(13, 12) = -1\n    public static long ChooseNum(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1860,13 +48,757 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_104_unique_digits",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    public static List<long> UniqueDigits(List<long> x) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    public static List<string> ByLength(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    public static List<long> F(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    public static long CountNums(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    public static string MakePalindrome(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    public static Dictionary<string,long> Histogram(string test) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    public static Tuple<string, bool> ReverseDelete(string s, string c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseDelete((\"abcde\"), (\"ae\")).Equals((Tuple.Create(\"bcd\", false))));\n    Debug.Assert(ReverseDelete((\"abcdef\"), (\"b\")).Equals((Tuple.Create(\"acdef\", false))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"ab\")).Equals((Tuple.Create(\"cdedc\", true))));\n    Debug.Assert(ReverseDelete((\"dwik\"), (\"w\")).Equals((Tuple.Create(\"dik\", false))));\n    Debug.Assert(ReverseDelete((\"a\"), (\"a\")).Equals((Tuple.Create(\"\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"v\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"vabba\"), (\"v\")).Equals((Tuple.Create(\"abba\", true))));\n    Debug.Assert(ReverseDelete((\"mamma\"), (\"mia\")).Equals((Tuple.Create(\"\", true))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    public static List<string> OddCount(List<string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    public static List<long> SortArray(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-4L, (long)-2L, (long)-6L, (long)-5L, (long)-3L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)5L, (long)77L, (long)4L, (long)5L, (long)3L, (long)5L, (long)7L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)4L, (long)4L, (long)3L, (long)3L, (long)5L, (long)5L, (long)5L, (long)7L, (long)77L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)3L, (long)6L, (long)44L, (long)12L, (long)32L, (long)5L}))).Equals((new List<long>(new long[]{(long)32L, (long)3L, (long)5L, (long)6L, (long)12L, (long)44L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    public static List<string> SelectWords(string s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    public static string GetClosestVowel(string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    public static string MatchParens(List<string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    public static string StringXor(string a, string b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    public static long Solution(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static List<long> GetOddCollatz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    public static bool ValidDate(string date) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    public static bool IsSorted(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    public static string Longest(List<string> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    public static List<long> Tri(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    public static long Digits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    public static bool IsNested(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    public static long SumSquares(List<float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    public static long CanArrange(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    public static bool IsEqualToSumEven(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    public static string FixSpaces(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    public static string FileNameCheck(string file_name) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    public static long SumSquares(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    public static bool Simplify(string x, string n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    public static List<long> OrderByPoints(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    public static long Specialfilter(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)5L, (long)-2L, (long)1L, (long)-5L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L}))) == (1L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L}))) == (2L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)43L, (long)-12L, (long)93L, (long)125L, (long)121L, (long)109L}))) == (4L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)71L, (long)-2L, (long)-33L, (long)75L, (long)21L, (long)19L}))) == (3L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>())) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    public static List<string> Bf(string planet1, string planet2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    public static List<string> AllPrefixes(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    public static long XOrY(long n, long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    public static string IntToMiniRoman(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    public static string FindMax(List<string> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    public static string StringSequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    public static string Solve(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    public static string StringToMd5(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,7 +808,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // generate_integers(2, 8) => [2, 4, 6, 8]\n    // generate_integers(8, 2) => [2, 4, 6, 8]\n    // generate_integers(10, 14) => []\n    public static List<long> GenerateIntegers(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GenerateIntegers((2L), (10L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((10L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((132L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((17L), (89L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1888,9 +820,1077 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> count_distinct_characters('xyzXYZ')\n    // 3\n    // >>> count_distinct_characters('Jerry')\n    // 4\n    public static long CountDistinctCharacters(string str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    public static List<long> ParseMusic(string music_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    public static long HowManyTimes(string str, string substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    public static string SortNumbers(string numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    public static List<long> FilterIntegers(List<object> values) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    public static long Strlen(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    public static long LargestDivisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    public static List<long> Factorize(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    public static string FlipCase(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    public static string Concatenate(List<string> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    public static float TruncateNumber(float number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    public static List<long> GetPositive(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    public static bool IsPrime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    public static List<long> SortThird(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    public static List<long> Unique(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    public static long MaxElement(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    public static long FizzBuzz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    public static List<long> SortEven(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-10L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)5L, (long)0L, (long)9L, (long)1L, (long)123L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)8L, (long)-12L, (long)4L, (long)23L, (long)2L, (long)3L, (long)11L, (long)12L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-12L, (long)8L, (long)3L, (long)4L, (long)5L, (long)2L, (long)12L, (long)11L, (long)23L, (long)-10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    public static long PrimeFib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    public static bool BelowZero(List<long> operations) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    public static bool TriplesSumToZero(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    public static List<long> IncrList(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    public static bool PairsSumToZero(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    public static string ChangeBase(long x, long numBase) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    public static float TriangleArea(long a, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    public static long Fib4(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    public static float Median(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    public static bool IsPalindrome(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    public static long Modp(long n, long p) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    public static string RemoveVowels(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    public static long Add(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    public static bool SameChars(string s0, string s1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    Debug.Assert(SameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    Debug.Assert(SameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    Debug.Assert(SameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    public static long Fib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    public static bool CorrectBracketing(string brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"<>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<><>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<<><>>>>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<<<\")) == (false));\n    Debug.Assert(CorrectBracketing((\">\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    public static bool Monotonic(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    public static long LargestPrimeFactor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    public static long SumToN(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    public static bool CorrectBracketing(string brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    public static List<long> Derivative(List<long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    public static long Fibfib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    public static long VowelsCount(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    public static string CircularShift(long x, long shift) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    public static long Digitsum(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    public static long FruitDistribution(string s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    public static long Search(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    public static List<long> StrangeSortList(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    public static float TriangleArea(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    public static long SmallestChange(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    public static bool IsSimplePower(long x, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    public static bool Iscube(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    public static long HexKey(string num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    public static string DecimalToBinary(long decimalNum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    public static bool IsHappy(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    public static bool PrimeLength(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    public static long Add(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    public static string AntiShuffle(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    public static List<long> SortArray(List<long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    public static string Encrypt(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    public static long IsBored(string S) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    public static bool AnyInt(float x, float y, float z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    public static string Encode(string message) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    public static long Skjkasdkd(List<long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    public static List<long> CountUpTo(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    public static long Multiply(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    public static long CountUpper(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-cs-remove.json
+++ b/prompts/humaneval-cs-remove.json
@@ -1,1344 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    public static long Strlen(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    public static string Encrypt(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    public static long Add(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    public static string FixSpaces(string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    public static long Fibfib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    public static List<long> FilterIntegers(List<object> values) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    public static List<long> ParseMusic(string music_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    public static string DecimalToBinary(long decimalNum) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    public static List<string> AllPrefixes(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    public static long Add(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    public static string FlipCase(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    public static List<string> ByLength(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    public static List<long> Factorize(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    public static List<long> CountUpTo(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    public static List<long> Unique(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    public static long MaxElement(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    public static bool IsNested(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    public static List<string> OddCount(List<string> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    public static bool IsEqualToSumEven(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    public static List<long> Derivative(List<long> xs) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    public static bool IsSorted(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    public static string Solve(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    public static List<long> Tri(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    public static long FizzBuzz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    public static long CountUpper(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    public static long LargestDivisor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    public static List<long> SortArray(List<long> array) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    public static List<long> F(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    public static bool Iscube(long a) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    public static string Encode(string message) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    public static long IsBored(string S) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static bool PairsSumToZero(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    public static float TriangleArea(long a, long b, long c) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    public static List<string> Bf(string planet1, string planet2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    public static long Digits(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    public static List<string> WordsString(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    public static long HowManyTimes(string str, string substring) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    public static string RemoveVowels(string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    public static List<long> StrangeSortList(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    public static bool IsSimplePower(long x, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    public static long PrimeFib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    public static List<long> OrderByPoints(List<long> nums) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    public static bool HasCloseElements(List<float> numbers, float threshold) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    public static string MakePalindrome(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    public static string StringXor(string a, string b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    public static long Fib4(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    public static List<long> UniqueDigits(List<long> x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    public static List<string> SelectWords(string s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    public static long Fib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    public static string MatchParens(List<string> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    public static bool AnyInt(float x, float y, float z) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    public static float TruncateNumber(float number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    public static List<long> IncrList(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    public static long XOrY(long n, long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    public static long Modp(long n, long p) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    public static bool IsHappy(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    public static long LargestPrimeFactor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    public static long Digitsum(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    public static long Solution(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    public static float Median(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    public static bool PrimeLength(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    public static long SmallestChange(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    public static long SumSquares(List<float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    public static string FileNameCheck(string file_name) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static bool TriplesSumToZero(List<long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    public static bool ValidDate(string date) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    public static long CountNums(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    public static string AntiShuffle(string s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    public static bool IsPalindrome(string text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    public static string GetClosestVowel(string word) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    public static bool IsPrime(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    public static bool Simplify(string x, string n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    public static long HexKey(string num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    public static Dictionary<string,long> Histogram(string test) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static List<long> GetOddCollatz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    public static long CanArrange(List<long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    public static string SortNumbers(string numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    public static string CircularShift(long x, long shift) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    public static long SumSquares(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    public static long Skjkasdkd(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    public static long ChooseNum(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    public static long CountDistinctCharacters(string str) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1348,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    public static List<long> MakeAPile(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakeAPile((3L)).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(MakeAPile((4L)).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(MakeAPile((5L)).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)11L, (long)13L}))));\n    Debug.Assert(MakeAPile((6L)).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L}))));\n    Debug.Assert(MakeAPile((8L)).Equals((new List<long>(new long[]{(long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)18L, (long)20L, (long)22L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1356,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    public static List<string> WordsString(string s) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    public static long ChooseNum(long x, long y) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    public static string StringSequence(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    public static List<long> UniqueDigits(List<long> x) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    public static List<string> ByLength(List<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    public static bool Monotonic(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    public static List<long> F(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    public static string Longest(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    public static long CountNums(List<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    public static List<long> GetPositive(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    public static string MakePalindrome(string str) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    public static List<long> SortThird(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    public static Dictionary<string,long> Histogram(string test) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    public static float TriangleArea(long a, long h) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    public static long Multiply(long a, long b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    public static string IntToMiniRoman(long number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    public static long FruitDistribution(string s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1564,7 +160,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    public static Tuple<string, bool> ReverseDelete(string s, string c) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseDelete((\"abcde\"), (\"ae\")).Equals((Tuple.Create(\"bcd\", false))));\n    Debug.Assert(ReverseDelete((\"abcdef\"), (\"b\")).Equals((Tuple.Create(\"acdef\", false))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"ab\")).Equals((Tuple.Create(\"cdedc\", true))));\n    Debug.Assert(ReverseDelete((\"dwik\"), (\"w\")).Equals((Tuple.Create(\"dik\", false))));\n    Debug.Assert(ReverseDelete((\"a\"), (\"a\")).Equals((Tuple.Create(\"\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"v\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"vabba\"), (\"v\")).Equals((Tuple.Create(\"abba\", true))));\n    Debug.Assert(ReverseDelete((\"mamma\"), (\"mia\")).Equals((Tuple.Create(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1572,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    public static List<string> OddCount(List<string> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1588,7 +208,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    public static List<long> SortArray(List<long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-4L, (long)-2L, (long)-6L, (long)-5L, (long)-3L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)5L, (long)77L, (long)4L, (long)5L, (long)3L, (long)5L, (long)7L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)4L, (long)4L, (long)3L, (long)3L, (long)5L, (long)5L, (long)5L, (long)7L, (long)77L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)3L, (long)6L, (long)44L, (long)12L, (long)32L, (long)5L}))).Equals((new List<long>(new long[]{(long)32L, (long)3L, (long)5L, (long)6L, (long)12L, (long)44L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1596,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    public static string Concatenate(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    public static List<string> SelectWords(string s, long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    public static string GetClosestVowel(string word) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    public static string MatchParens(List<string> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    public static string StringXor(string a, string b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    public static long VowelsCount(string s) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    public static string FindMax(List<string> words) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    public static long Solution(List<long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    public static string StringToMd5(string text) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    public static string ChangeBase(long x, long numBase) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static List<long> GetOddCollatz(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    public static bool ValidDate(string date) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    public static bool IsSorted(List<long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    public static string Longest(List<string> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    public static List<long> Tri(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    public static long Digits(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    public static bool IsNested(string str) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    public static long SumSquares(List<float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    public static long CanArrange(List<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    public static bool IsEqualToSumEven(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    public static string FixSpaces(string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    public static string FileNameCheck(string file_name) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    public static long SumSquares(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    public static bool Simplify(string x, string n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    public static List<long> OrderByPoints(List<long> nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1732,7 +580,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    public static long Specialfilter(List<long> nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)5L, (long)-2L, (long)1L, (long)-5L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L}))) == (1L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L}))) == (2L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)43L, (long)-12L, (long)93L, (long)125L, (long)121L, (long)109L}))) == (4L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)71L, (long)-2L, (long)-33L, (long)75L, (long)21L, (long)19L}))) == (3L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>())) == (0L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1740,25 +588,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    public static long SumToN(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    public static List<string> Bf(string planet1, string planet2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    public static List<string> AllPrefixes(string str) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    public static long XOrY(long n, long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    public static string IntToMiniRoman(long number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    public static string FindMax(List<string> words) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    public static string StringSequence(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    public static string Solve(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    public static string StringToMd5(string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +796,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    public static List<long> GenerateIntegers(long a, long b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GenerateIntegers((2L), (10L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((10L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((132L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((17L), (89L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,49 +804,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    public static long CountDistinctCharacters(string str) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    public static bool BelowZero(List<long> operations) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    public static List<long> ParseMusic(string music_string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    public static long Search(List<long> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    public static long HowManyTimes(string str, string substring) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static bool CorrectBracketing(string brackets) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    public static string SortNumbers(string numbers) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    public static List<long> FilterIntegers(List<object> values) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    public static long Strlen(string str) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    public static long LargestDivisor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    public static List<long> Factorize(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    public static string FlipCase(string str) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    public static string Concatenate(List<string> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    public static float TruncateNumber(float number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    public static List<long> GetPositive(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    public static bool IsPrime(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    public static List<long> SortThird(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    public static List<long> Unique(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    public static long MaxElement(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    public static long FizzBuzz(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1828,9 +1072,189 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    public static List<long> SortEven(List<long> l) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-10L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)5L, (long)0L, (long)9L, (long)1L, (long)123L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)8L, (long)-12L, (long)4L, (long)23L, (long)2L, (long)3L, (long)11L, (long)12L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-12L, (long)8L, (long)3L, (long)4L, (long)5L, (long)2L, (long)12L, (long)11L, (long)23L, (long)-10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    public static long PrimeFib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    public static bool BelowZero(List<long> operations) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static bool TriplesSumToZero(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    public static List<long> IncrList(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static bool PairsSumToZero(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    public static string ChangeBase(long x, long numBase) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    public static float TriangleArea(long a, long h) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    public static long Fib4(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    public static float Median(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    public static bool IsPalindrome(string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    public static long Modp(long n, long p) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    public static string RemoveVowels(string text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    public static long Add(long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1840,9 +1264,21 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if two words have the same characters.\n    public static bool SameChars(string s0, string s1) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    Debug.Assert(SameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    Debug.Assert(SameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    Debug.Assert(SameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    public static long Fib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1852,9 +1288,573 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static bool CorrectBracketing(string brackets) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"<>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<><>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<<><>>>>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<<<\")) == (false));\n    Debug.Assert(CorrectBracketing((\">\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    public static bool Monotonic(List<long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    public static long LargestPrimeFactor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    public static long SumToN(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static bool CorrectBracketing(string brackets) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    public static List<long> Derivative(List<long> xs) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    public static long Fibfib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    public static long VowelsCount(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    public static string CircularShift(long x, long shift) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    public static long Digitsum(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    public static long FruitDistribution(string s, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    public static long Search(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    public static List<long> StrangeSortList(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    public static float TriangleArea(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    public static long SmallestChange(List<long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    public static bool IsSimplePower(long x, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    public static bool Iscube(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    public static long HexKey(string num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    public static string DecimalToBinary(long decimalNum) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    public static bool IsHappy(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    public static bool PrimeLength(string str) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    public static long Add(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    public static string AntiShuffle(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    public static List<long> SortArray(List<long> array) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    public static string Encrypt(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    public static long IsBored(string S) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    public static bool AnyInt(float x, float y, float z) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    public static string Encode(string message) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    public static long Skjkasdkd(List<long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    public static List<long> CountUpTo(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    public static long Multiply(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    public static long CountUpper(string s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-cs-reworded.json
+++ b/prompts/humaneval-cs-reworded.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> StringLength((\"\"))\n    // (0L)\n    // >>> StringLength((\"abc\"))\n    // (3L)\n    public static long Strlen(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> Encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> Encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> Encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> Encrypt((\"et\"))\n    // (\"ix\")\n    public static string Encrypt(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given dictionary is empty.\n    // Examples:\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"b\", \"banana\"}}))\n    // (true)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {8L, \"banana\"}, {\"a\", \"apple\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))\n    // (true)\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> Add((new List<long>(new long[]{(long)4L, (long)2L, (long)6L, (long)7L})))\n    // (2L)\n    public static long Add(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> FixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> FixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> FixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> FixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static string FixSpaces(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> Fibfib((1L))\n    // (0L)\n    // >>> Fibfib((5L))\n    // (4L)\n    // >>> Fibfib((8L))\n    // (24L)\n    public static long Fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)1L, (long)3L, (long)2L, (long)0L})))\n    // (10L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)-1L, (long)-2L, (long)0L})))\n    // (0L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)9L, (long)-2L})))\n    // (81L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)0L})))\n    // (0L)\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any csthon values only for integers\n    // >>> FilterIntegers((new List<object>(new string[]{(string)\"a\", (string)3.14f, (string)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> FilterIntegers((new List<object>(new object[]{1L, 2L, 3L, \"abc\", new List<object>()})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    public static List<long> FilterIntegers(List<object> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> ParseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new List<long>(new long[]{(long)4L, (long)2L, (long)1L, (long)2L, (long)2L, (long)1L, (long)1L, (long)1L, (long)1L, (long)4L, (long)4L}))\n    public static List<long> ParseMusic(string music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> DecimalToBinary((15L))\n    // (\"db1111db\")\n    // >>> DecimalToBinary((32L))\n    // (\"db100000db\")\n    public static string DecimalToBinary(long decimalNum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> AllPrefixes((\"abc\"))\n    // (new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))\n    public static List<string> AllPrefixes(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> Add((2L), (3L))\n    // (5L)\n    // >>> Add((5L), (7L))\n    // (12L)\n    public static long Add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return a list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> Eat((5L), (6L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)4L}))\n    // >>> Eat((4L), (8L), (9L))\n    // (new List<long>(new long[]{(long)12L, (long)1L}))\n    // >>> Eat((1L), (10L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)0L}))\n    // >>> Eat((2L), (11L), (5L))\n    // (new List<long>(new long[]{(long)7L, (long)0L}))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L))\n    // (6L)\n    // Example 2:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L))\n    // (5L)\n    // Example 3:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L))\n    // (0L)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> FlipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static string FlipCase(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L})))\n    // (new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))\n    // If the list is empty, return an empty list:\n    // >>> ByLength((new List<long>()))\n    // (new List<string>())\n    // If the list has any strange number ignore it:\n    // >>> ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L})))\n    // (new List<string>(new string[]{(string)\"One\"}))\n    public static List<string> ByLength(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> Factorize((8L))\n    // (new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))\n    // >>> Factorize((25L))\n    // (new List<long>(new long[]{(long)5L, (long)5L}))\n    // >>> Factorize((70L))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)7L}))\n    public static List<long> Factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns a list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> CountUpTo((5L))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    // >>> CountUpTo((11L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))\n    // >>> CountUpTo((0L))\n    // (new List<long>())\n    // >>> CountUpTo((20L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))\n    // >>> CountUpTo((1L))\n    // (new List<long>())\n    // >>> CountUpTo((18L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))\n    public static List<long> CountUpTo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))\n    public static List<long> Unique(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> TotalMatch((new List<string>()), (new List<string>()))\n    // (new List<string>())\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"})))\n    // (new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"})))\n    // (new List<string>(new string[]{(string)\"4\"}))\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (3L)\n    // >>> MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (123L)\n    public static long MaxElement(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> IsNested((\"[[]]\"))\n    // (true)\n    // >>> IsNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> IsNested((\"[][]\"))\n    // (false)\n    // >>> IsNested((\"[]\"))\n    // (false)\n    // >>> IsNested((\"[[][]]\"))\n    // (true)\n    // >>> IsNested((\"[[]][[\"))\n    // (true)\n    public static bool IsNested(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> OddCount((new List<string>(new string[]{(string)\"1234567\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n    // >>> OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\n    public static List<string> OddCount(List<string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the list will be randomly ordered. Your task is to determine if\n    // it is possible to get a list sorted in non-decreasing order by performing \n    // the following operation on the given list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the list by one\n    // position in the right direction. The last element of the list will be moved to\n    // the starting position in the list i.e. 0th index. \n    // If it is possible to obtain the sorted list by performing the above operation\n    // then return true else return false.\n    // If the given list is empty then return true.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L})))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given list.\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L})))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // list by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> EvenOddPalindrome((3L))\n    // (Tuple.Create(1L, 2L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> EvenOddPalindrome((12L))\n    // (Tuple.Create(4L, 6L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> IsEqualToSumEven((4L))\n    // (false)\n    // >>> IsEqualToSumEven((6L))\n    // (false)\n    // >>> IsEqualToSumEven((8L))\n    // (true)\n    public static bool IsEqualToSumEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))\n    // >>> Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L}))\n    public static List<long> Derivative(List<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> IsSorted((new List<long>(new long[]{(long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L})))\n    // (false)\n    public static bool IsSorted(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> Solve((\"1234\"))\n    // (\"4321\")\n    // >>> Solve((\"ab\"))\n    // (\"AB\")\n    // >>> Solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static string Solve(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> Tri((3L))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))\n    public static List<long> Tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> FizzBuzz((50L))\n    // (0L)\n    // >>> FizzBuzz((78L))\n    // (2L)\n    // >>> FizzBuzz((79L))\n    // (3L)\n    public static long FizzBuzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> FilterByPrefix((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterByPrefix((new List<string>(new string[]{(string)\"abc\", (string)\"bcd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"array\"}))\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> Solve((1000L))\n    // (\"1\")\n    // >>> Solve((150L))\n    // (\"110\")\n    // >>> Solve((147L))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))\n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L))\n    // (new List<long>(new long[]{(long)1L}))\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> CountUpper((\"aBCdEf\"))\n    // (1L)\n    // >>> CountUpper((\"abcdefg\"))\n    // (0L)\n    // >>> CountUpper((\"dBBE\"))\n    // (0L)\n    public static long CountUpper(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L))\n    // (new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))\n    // Example 2:\n    // >>> Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L))\n    // (new List<long>(new long[]{(long)4L, (long)4L}))\n    // Example 3:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L))\n    // (new List<long>(new long[]{(long)2L}))\n    // Note:\n    // 1. The length of the list will be in the range of [1, 1000].\n    // 2. The elements in the list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> LargestDivisor((15L))\n    // (5L)\n    public static long LargestDivisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of non-negative integers, return a cocs of the given list after sorting,\n    // you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given list.\n    // Examples:\n    // >>> SortArray((new List<long>()))\n    // (new List<long>())\n    // >>> SortArray((new List<long>(new long[]{(long)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))\n    public static List<long> SortArray(List<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> F((5L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))\n    public static List<long> F(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> Iscube((1L))\n    // (true)\n    // >>> Iscube((2L))\n    // (false)\n    // >>> Iscube((-1L))\n    // (true)\n    // >>> Iscube((64L))\n    // (true)\n    // >>> Iscube((0L))\n    // (true)\n    // >>> Iscube((180L))\n    // (false)\n    public static bool Iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> Encode((\"test\"))\n    // (\"TGST\")\n    // >>> Encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static string Encode(string message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> IsBored((\"Hello world\"))\n    // (0L)\n    // >>> IsBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1L)\n    public static long IsBored(string S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are two distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L})))\n    // (true)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool PairsSumToZero(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> TriangleArea((3L), (4L), (5L))\n    // (6.0f)\n    // >>> TriangleArea((1L), (2L), (10L))\n    // (float)-1L\n    public static float TriangleArea(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> Bf((\"Jupiter\"), (\"Neptune\"))\n    // (new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))\n    // >>> Bf((\"Earth\"), (\"Mercury\"))\n    // (List<string>(\"Venus\"))\n    // >>> Bf((\"Mercury\"), (\"Uranus\"))\n    // (new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))\n    public static List<string> Bf(string planet1, string planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> Digits((1L))\n    // (1L)\n    // >>> Digits((4L))\n    // (0L)\n    // >>> Digits((235L))\n    // (15L)\n    public static long Digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return a list of the words.\n    // For example:\n    // >>> WordsString((\"Hi, my name is John\"))\n    // (new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))\n    // >>> WordsString((\"One, two, three, four, five, six\"))\n    // (new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))\n    public static List<string> WordsString(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> HowManyTimes((\"\"), (\"a\"))\n    // (0L)\n    // >>> HowManyTimes((\"aaa\"), (\"a\"))\n    // (3L)\n    // >>> HowManyTimes((\"aaaa\"), (\"aa\"))\n    // (3L)\n    public static long HowManyTimes(string str, string substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> RemoveVowels((\"\"))\n    // (\"\")\n    // >>> RemoveVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> RemoveVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> RemoveVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> RemoveVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static string RemoveVowels(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))\n    // >>> StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L})))\n    // (new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))\n    // >>> StrangeSortList((new List<long>()))\n    // (new List<long>())\n    public static List<long> StrangeSortList(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n    // (Tuple.Create(2.0f, 2.2f))\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n    // (Tuple.Create(2.0f, 2.0f))\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> IsSimplePower((1L), (4L))\n    // (true)\n    // >>> IsSimplePower((2L), (2L))\n    // (true)\n    // >>> IsSimplePower((8L), (2L))\n    // (true)\n    // >>> IsSimplePower((3L), (2L))\n    // (false)\n    // >>> IsSimplePower((3L), (1L))\n    // (false)\n    // >>> IsSimplePower((5L), (3L))\n    // (false)\n    public static bool IsSimplePower(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> PrimeFib((1L))\n    // (2L)\n    // >>> PrimeFib((2L))\n    // (3L)\n    // >>> PrimeFib((3L))\n    // (5L)\n    // >>> PrimeFib((4L))\n    // (13L)\n    // >>> PrimeFib((5L))\n    // (89L)\n    public static long PrimeFib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L})))\n    // (new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))\n    // >>> OrderByPoints((new List<long>()))\n    // (new List<long>())\n    public static List<long> OrderByPoints(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})), (0.5f))\n    // (false)\n    // >>> HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.3f))\n    // (true)\n    public static bool HasCloseElements(List<float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> MakePalindrome((\"\"))\n    // (\"\")\n    // >>> MakePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> MakePalindrome((\"cata\"))\n    // (\"catac\")\n    public static string MakePalindrome(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> StringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static string StringXor(string a, string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> SpecialFactorial((4L))\n    // (288L)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L))\n    // (24L)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> Fib4((5L))\n    // (4L)\n    // >>> Fib4((6L))\n    // (8L)\n    // >>> Fib4((7L))\n    // (14L)\n    public static long Fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L})))\n    // (new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))\n    // >>> UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L})))\n    // (new List<long>())\n    public static List<long> UniqueDigits(List<long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> SelectWords((\"Mary had a little lamb\"), (4L))\n    // (new List<string>(new string[]{(string)\"little\"}))\n    // >>> SelectWords((\"Mary had a little lamb\"), (3L))\n    // (new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))\n    // >>> SelectWords((\"simple white space\"), (2L))\n    // (new List<string>())\n    // >>> SelectWords((\"Hello world\"), (4L))\n    // (new List<string>(new string[]{(string)\"world\"}))\n    // >>> SelectWords((\"Uncle sam\"), (3L))\n    // (new List<string>(new string[]{(string)\"Uncle\"}))\n    public static List<string> SelectWords(string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L})), (5L))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> Fib((10L))\n    // (55L)\n    // >>> Fib((1L))\n    // (1L)\n    // >>> Fib((8L))\n    // (21L)\n    public static long Fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new List<string>(new string[]{(string)\"AA\", (string)\"Be\", (string)\"CC\"})))\n    // (\"my_class.AA\")\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"})))\n    // (\"Yes\")\n    // >>> MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"})))\n    // (\"No\")\n    public static string MatchParens(List<string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return null if there is no such element.\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // 2L\n    // >>> NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L})))\n    // 2L\n    // >>> NextSmallest((new List<long>()))\n    // null\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)1L})))\n    // null\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> AnyInt((float)5L, (float)2L, (float)7L)\n    // (true)\n    // >>> AnyInt((float)3L, (float)2L, (float)2L)\n    // (false)\n    // >>> AnyInt((float)3L, (float)-2L, (float)1L)\n    // (true)\n    // >>> AnyInt((3.6f), (-2.2f), (float)2L)\n    // (false)\n    public static bool AnyInt(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> TruncateNumber((3.5f))\n    // (0.5f)\n    public static float TruncateNumber(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> IncrList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))\n    // >>> IncrList((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)6L, (long)4L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))\n    public static List<long> IncrList(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> XOrY((7L), (34L), (12L))\n    // (34L)\n    // >>> XOrY((15L), (8L), (5L))\n    // (5L)\n    public static long XOrY(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> Modp((3L), (5L))\n    // (3L)\n    // >>> Modp((1101L), (101L))\n    // (2L)\n    // >>> Modp((0L), (101L))\n    // (1L)\n    // >>> Modp((3L), (11L))\n    // (8L)\n    // >>> Modp((100L), (101L))\n    // (1L)\n    public static long Modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> EvenOddCount((-12L))\n    // (Tuple.Create(1L, 1L))\n    // >>> EvenOddCount((123L))\n    // (Tuple.Create(1L, 2L))\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapcs or not.\n    // A string is hapcs if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> IsHappy((\"a\"))\n    // (false)\n    // >>> IsHappy((\"aa\"))\n    // (false)\n    // >>> IsHappy((\"abcd\"))\n    // (true)\n    // >>> IsHappy((\"aabb\"))\n    // (false)\n    // >>> IsHappy((\"adb\"))\n    // (true)\n    // >>> IsHappy((\"xyy\"))\n    // (false)\n    public static bool IsHappy(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> LargestPrimeFactor((13195L))\n    // (29L)\n    // >>> LargestPrimeFactor((2048L))\n    // (2L)\n    public static long LargestPrimeFactor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> Digitsum((\"\"))\n    // (0L)\n    // >>> Digitsum((\"abAB\"))\n    // (131L)\n    // >>> Digitsum((\"abcCd\"))\n    // (67L)\n    // >>> Digitsum((\"helloE\"))\n    // (69L)\n    // >>> Digitsum((\"woArBld\"))\n    // (131L)\n    // >>> Digitsum((\"aAaaaXa\"))\n    // (153L)\n    public static long Digitsum(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n    // (new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L})))\n    // (12L)\n    // >>> Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L})))\n    // (9L)\n    // >>> Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L})))\n    // (0L)\n    public static long Solution(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given a list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given list is empty, return [].\n    // Example 1:\n    // >>> Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> Pluck((new List<long>()))\n    // (new List<long>())\n    // Example 4:\n    // >>> Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L}))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> GetMaxTriples((5L))\n    // (1L)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (\"YES\")\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L})))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (float)3L\n    // >>> Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L})))\n    // (15.0f)\n    public static float Median(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> PrimeLength((\"Hello\"))\n    // (true)\n    // >>> PrimeLength((\"abcdcba\"))\n    // (true)\n    // >>> PrimeLength((\"kittens\"))\n    // (true)\n    // >>> PrimeLength((\"orange\"))\n    // (false)\n    public static bool PrimeLength(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list arr of integers, find the minimum number of elements that\n    // need to be changed to make the list palindromic. A palindromic list is a list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L})))\n    // (4L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L})))\n    // (1L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L})))\n    // (0L)\n    public static long SmallestChange(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})))\n    // (14L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)4.0f, (float)9.0f})))\n    // (98L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n    // (84L)\n    // >>> Lst((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f})))\n    // (29L)\n    // >>> Lst((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f})))\n    // (6L)\n    public static long SumSquares(List<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> FileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> FileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static string FileNameCheck(string file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are three distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool TriplesSumToZero(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L)))\n    // (\"YES\")\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> SeparateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two lists of scores and guesses of equal length, where each index shows a match. \n    // Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L})))\n    // (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))\n    // >>> Compare((new List<long>(new long[]{(long)0L, (long)5L, (long)0L, (long)0L, (long)0L, (long)4L})), (new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L, (long)0L, (long)-2L})))\n    // (new List<long>(new long[]{(long)4L, (long)4L, (long)1L, (long)0L, (long)0L, (long)6L}))\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> CheckIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"\"))\n    // (false)\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> ValidDate((\"03-11-2000\"))\n    // (true)\n    // >>> ValidDate((\"15-01-2012\"))\n    // (false)\n    // >>> ValidDate((\"04-0-2040\"))\n    // (false)\n    // >>> ValidDate((\"06-04-2020\"))\n    // (true)\n    // >>> ValidDate((\"06/04/2020\"))\n    // (false)\n    public static bool ValidDate(string date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes a list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> CountNums((new List<long>()))\n    // (0L)\n    // >>> CountNums((new List<long>(new long[]{(long)-1L, (long)11L, (long)-11L})))\n    // (1L)\n    // >>> CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L})))\n    // (3L)\n    public static long CountNums(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> AntiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> AntiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> AntiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static string AntiShuffle(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> IsPalindrome((\"\"))\n    // (true)\n    // >>> IsPalindrome((\"aba\"))\n    // (true)\n    // >>> IsPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> IsPalindrome((\"zbcd\"))\n    // (false)\n    public static bool IsPalindrome(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> GetClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> GetClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> GetClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> GetClosestVowel((\"ab\"))\n    // (\"\")\n    public static string GetClosestVowel(string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> IsPrime((6L))\n    // (false)\n    // >>> IsPrime((101L))\n    // (true)\n    // >>> IsPrime((11L))\n    // (true)\n    // >>> IsPrime((13441L))\n    // (true)\n    // >>> IsPrime((61L))\n    // (true)\n    // >>> IsPrime((4L))\n    // (false)\n    // >>> IsPrime((1L))\n    // (false)\n    public static bool IsPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> Simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> Simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> Simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static bool Simplify(string x, string n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> HexKey((\"AB\"))\n    // (1L)\n    // >>> HexKey((\"1077E\"))\n    // (2L)\n    // >>> HexKey((\"ABED1A33\"))\n    // (4L)\n    // >>> HexKey((\"123456789ABCDEF0\"))\n    // (6L)\n    // >>> HexKey((\"2020\"))\n    // (2L)\n    public static long HexKey(string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> WordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> WordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> Histogram((\"a b c\"))\n    // (new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}})\n    // >>> Histogram((\"a b b a\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"a b c a b\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"b b b b a\"))\n    // (new Dictionary<string,long>(){{\"b\", 4L}})\n    // >>> Histogram((\"\"))\n    // (new Dictionary<string,long>())\n    public static Dictionary<string,long> Histogram(string test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))\n    // >>> GetRow((new List<List<long>>()), (1L))\n    // (new List<Tuple<long, long>>())\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> GetOddCollatz((5L))\n    // (new List<long>(new long[]{(long)1L, (long)5L}))\n    public static List<long> GetOddCollatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L})))\n    // (3L)\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (-1L)\n    public static long CanArrange(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> SortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static string SortNumbers(string numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> CircularShift((12L), (1L))\n    // (\"21\")\n    // >>> CircularShift((12L), (2L))\n    // (\"12\")\n    public static string CircularShift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})\n    // >>> lst\n    // (long)new List<long>()\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L})\n    public static long SumSquares(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L})))\n    // (10L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L})))\n    // (25L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L})))\n    // (13L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L})))\n    // (11L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L})))\n    // (3L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L})))\n    // (7L)\n    public static long Skjkasdkd(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> SumProduct((new List<long>()))\n    // (Tuple.Create(0L, 1L))\n    // >>> SumProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (Tuple.Create(10L, 24L))\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> ChooseNum((12L), (15L))\n    // (14L)\n    // >>> ChooseNum((13L), (12L))\n    // (-1L)\n    public static long ChooseNum(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as null.\n    // Examples:\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L})))\n    // Tuple.Create((Nullable<long>)null, 1L)\n    // >>> LargestSmallestIntegers((new List<long>()))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)0L})))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> CountDistinctCharacters((\"xyzXYZ\"))\n    // (3L)\n    // >>> CountDistinctCharacters((\"Jerry\"))\n    // (4L)\n    public static long CountDistinctCharacters(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1384,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> MakeAPile((3L))\n    // (new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))\n    public static List<long> MakeAPile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakeAPile((3L)).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(MakeAPile((4L)).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(MakeAPile((5L)).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)11L, (long)13L}))));\n    Debug.Assert(MakeAPile((6L)).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L}))));\n    Debug.Assert(MakeAPile((8L)).Equals((new List<long>(new long[]{(long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)18L, (long)20L, (long)22L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1392,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the list, represented by 1, -1 or 0.\n    // Note: return null for empty arr.\n    // Example:\n    // >>> ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L})))\n    // 9L\n    // >>> ProdSigns((new List<long>(new long[]{(long)0L, (long)1L})))\n    // 0L\n    // >>> ProdSigns((new List<long>()))\n    // null\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return a list of the words.\n    // For example:\n    // >>> WordsString((\"Hi, my name is John\"))\n    // (new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))\n    // >>> WordsString((\"One, two, three, four, five, six\"))\n    // (new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))\n    public static List<string> WordsString(string s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of integers nums, find the minimum sum of any non-empty sub-list\n    // of nums.\n    // Example\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L})))\n    // (1L)\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})))\n    // (-6L)\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> ChooseNum((12L), (15L))\n    // (14L)\n    // >>> ChooseNum((13L), (12L))\n    // (-1L)\n    public static long ChooseNum(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> StringSequence((0L))\n    // (\"0\")\n    // >>> StringSequence((5L))\n    // (\"0 1 2 3 4 5\")\n    public static string StringSequence(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L})))\n    // (new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))\n    // >>> UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L})))\n    // (new List<long>())\n    public static List<long> UniqueDigits(List<long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> CycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> CycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> CycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> CycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> CycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> CycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L})))\n    // (new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))\n    // If the list is empty, return an empty list:\n    // >>> ByLength((new List<long>()))\n    // (new List<string>())\n    // If the list has any strange number ignore it:\n    // >>> ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L})))\n    // (new List<string>(new string[]{(string)\"One\"}))\n    public static List<string> ByLength(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true is list elements are monotonically increasing or decreasing.\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L})))\n    // (true)\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})))\n    // (false)\n    // >>> Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L})))\n    // (true)\n    public static bool Monotonic(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> F((5L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))\n    public static List<long> F(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return null in case the input list is empty.\n    // >>> Longest((new List<string>()))\n    // null\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"a\")\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"bb\", (string)\"ccc\"})))\n    // (\"ccc\")\n    public static string Longest(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> EvenOddPalindrome((3L))\n    // (Tuple.Create(1L, 2L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> EvenOddPalindrome((12L))\n    // (Tuple.Create(4L, 6L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if all numbers in the list l are below threshold t.\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L))\n    // (true)\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L))\n    // (false)\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes a list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> CountNums((new List<long>()))\n    // (0L)\n    // >>> CountNums((new List<long>(new long[]{(long)-1L, (long)11L, (long)-11L})))\n    // (1L)\n    // >>> CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L})))\n    // (3L)\n    public static long CountNums(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> IsMultiplyPrime((30L))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the list will be randomly ordered. Your task is to determine if\n    // it is possible to get a list sorted in non-decreasing order by performing \n    // the following operation on the given list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the list by one\n    // position in the right direction. The last element of the list will be moved to\n    // the starting position in the list i.e. 0th index. \n    // If it is possible to obtain the sorted list by performing the above operation\n    // then return true else return false.\n    // If the given list is empty then return true.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L})))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given list.\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L})))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // list by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> GetPositive((new List<long>(new long[]{(long)-1L, (long)2L, (long)-4L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)6L}))\n    // >>> GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)9L, (long)123L, (long)1L}))\n    public static List<long> GetPositive(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> MakePalindrome((\"\"))\n    // (\"\")\n    // >>> MakePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> MakePalindrome((\"cata\"))\n    // (\"catac\")\n    public static string MakePalindrome(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> SortThird((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))\n    public static List<long> SortThird(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (\"YES\")\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L})))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> ParseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> Histogram((\"a b c\"))\n    // (new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}})\n    // >>> Histogram((\"a b b a\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"a b c a b\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"b b b b a\"))\n    // (new Dictionary<string,long>(){{\"b\", 4L}})\n    // >>> Histogram((\"\"))\n    // (new Dictionary<string,long>())\n    public static Dictionary<string,long> Histogram(string test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> TriangleArea((5L), (3L))\n    // (7.5f)\n    public static float TriangleArea(long a, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> Multiply((148L), (412L))\n    // (16L)\n    // >>> Multiply((19L), (28L))\n    // (72L)\n    // >>> Multiply((2020L), (1851L))\n    // (0L)\n    // >>> Multiply((14L), (-15L))\n    // (20L)\n    public static long Multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n    // (1.0f)\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L})))\n    // (new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))\n    // >>> Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> IntToMiniRoman((19L))\n    // (\"xix\")\n    // >>> IntToMiniRoman((152L))\n    // (\"clii\")\n    // >>> IntToMiniRoman((426L))\n    // (\"cdxxvi\")\n    public static string IntToMiniRoman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> FruitDistribution((\"5 apples and 6 oranges\"), (19L))\n    // (8L)\n    // >>> FruitDistribution((\"0 apples and 1 oranges\"), (3L))\n    // (2L)\n    // >>> FruitDistribution((\"2 apples and 3 oranges\"), (100L))\n    // (95L)\n    // >>> FruitDistribution((\"100 apples and 1 oranges\"), (120L))\n    // (19L)\n    public static long FruitDistribution(string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1600,7 +160,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and true/false for the check.\n    // Example\n    // >>> ReverseDelete((\"abcde\"), (\"ae\"))\n    // (Tuple.Create(\"bcd\", false))\n    // >>> ReverseDelete((\"abcdef\"), (\"b\"))\n    // (Tuple.Create(\"acdef\", false))\n    // >>> ReverseDelete((\"abcdedcba\"), (\"ab\"))\n    // (Tuple.Create(\"cdedc\", true))\n    public static Tuple<string, bool> ReverseDelete(string s, string c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseDelete((\"abcde\"), (\"ae\")).Equals((Tuple.Create(\"bcd\", false))));\n    Debug.Assert(ReverseDelete((\"abcdef\"), (\"b\")).Equals((Tuple.Create(\"acdef\", false))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"ab\")).Equals((Tuple.Create(\"cdedc\", true))));\n    Debug.Assert(ReverseDelete((\"dwik\"), (\"w\")).Equals((Tuple.Create(\"dik\", false))));\n    Debug.Assert(ReverseDelete((\"a\"), (\"a\")).Equals((Tuple.Create(\"\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"v\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"vabba\"), (\"v\")).Equals((Tuple.Create(\"abba\", true))));\n    Debug.Assert(ReverseDelete((\"mamma\"), (\"mia\")).Equals((Tuple.Create(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1608,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> GreatestCommonDivisor((3L), (5L))\n    // (1L)\n    // >>> GreatestCommonDivisor((25L), (15L))\n    // (5L)\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> OddCount((new List<string>(new string[]{(string)\"1234567\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n    // >>> OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\n    public static List<string> OddCount(List<string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of integers nums, find the minimum sum of any non-empty sub-list\n    // of nums.\n    // Example\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L})))\n    // (1L)\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})))\n    // (-6L)\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L))\n    // (6L)\n    // Example 2:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L))\n    // (5L)\n    // Example 3:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L))\n    // (0L)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1624,7 +208,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this Kata, you have to sort a list of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L})))\n    // (new List<long>(new long[]{(long)-6L, (long)-5L, (long)-4L, (long)-3L, (long)-2L}))\n    // >>> SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L}))\n    public static List<long> SortArray(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-4L, (long)-2L, (long)-6L, (long)-5L, (long)-3L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)5L, (long)77L, (long)4L, (long)5L, (long)3L, (long)5L, (long)7L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)4L, (long)4L, (long)3L, (long)3L, (long)5L, (long)5L, (long)5L, (long)7L, (long)77L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)3L, (long)6L, (long)44L, (long)12L, (long)32L, (long)5L}))).Equals((new List<long>(new long[]{(long)32L, (long)3L, (long)5L, (long)6L, (long)12L, (long)44L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1632,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> Concatenate((new List<string>()))\n    // (\"\")\n    // >>> Concatenate((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"abc\")\n    public static string Concatenate(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> SelectWords((\"Mary had a little lamb\"), (4L))\n    // (new List<string>(new string[]{(string)\"little\"}))\n    // >>> SelectWords((\"Mary had a little lamb\"), (3L))\n    // (new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))\n    // >>> SelectWords((\"simple white space\"), (2L))\n    // (new List<string>())\n    // >>> SelectWords((\"Hello world\"), (4L))\n    // (new List<string>(new string[]{(string)\"world\"}))\n    // >>> SelectWords((\"Uncle sam\"), (3L))\n    // (new List<string>(new string[]{(string)\"Uncle\"}))\n    public static List<string> SelectWords(string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never a list of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> ListSort((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"})))\n    // (new List<string>(new string[]{(string)\"aa\"}))\n    // >>> ListSort((new List<string>(new string[]{(string)\"ab\", (string)\"a\", (string)\"aaa\", (string)\"cd\"})))\n    // (new List<string>(new string[]{(string)\"ab\", (string)\"cd\"}))\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> GetClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> GetClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> GetClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> GetClosestVowel((\"ab\"))\n    // (\"\")\n    public static string GetClosestVowel(string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> FilterBySubstring((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterBySubstring((new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"array\"}))\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"})))\n    // (\"Yes\")\n    // >>> MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"})))\n    // (\"No\")\n    public static string MatchParens(List<string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> ClosestInteger((\"10\"))\n    // (10L)\n    // >>> ClosestInteger((\"15.3\"))\n    // (15L)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> StringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static string StringXor(string a, string b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> VowelsCount((\"abcde\"))\n    // (2L)\n    // >>> VowelsCount((\"ACEDY\"))\n    // (3L)\n    public static long VowelsCount(string s) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L))\n    // (new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))\n    // Example 2:\n    // >>> Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L))\n    // (new List<long>(new long[]{(long)4L, (long)4L}))\n    // Example 3:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L))\n    // (new List<long>(new long[]{(long)2L}))\n    // Note:\n    // 1. The length of the list will be in the range of [1, 1000].\n    // 2. The elements in the list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"})))\n    // (\"string\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"})))\n    // (\"enam\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"})))\n    // (\"aaaaaaa\")\n    public static string FindMax(List<string> words) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L})))\n    // (12L)\n    // >>> Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L})))\n    // (9L)\n    // >>> Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L})))\n    // (0L)\n    public static long Solution(List<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return null.\n    // >>> StringToMd5((\"Hello world\"))\n    // (\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static string StringToMd5(string text) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L))\n    // (24L)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> ChangeBase((8L), (3L))\n    // (\"22\")\n    // >>> ChangeBase((8L), (2L))\n    // (\"1000\")\n    // >>> ChangeBase((7L), (2L))\n    // (\"111\")\n    public static string ChangeBase(long x, long numBase) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> GetOddCollatz((5L))\n    // (new List<long>(new long[]{(long)1L, (long)5L}))\n    public static List<long> GetOddCollatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> RightAngleTriangle((3L), (4L), (5L))\n    // (true)\n    // >>> RightAngleTriangle((1L), (2L), (3L))\n    // (false)\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> ValidDate((\"03-11-2000\"))\n    // (true)\n    // >>> ValidDate((\"15-01-2012\"))\n    // (false)\n    // >>> ValidDate((\"04-0-2040\"))\n    // (false)\n    // >>> ValidDate((\"06-04-2020\"))\n    // (true)\n    // >>> ValidDate((\"06/04/2020\"))\n    // (false)\n    public static bool ValidDate(string date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> GradeEquation((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f})))\n    // (new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> IsSorted((new List<long>(new long[]{(long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L})))\n    // (false)\n    public static bool IsSorted(List<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> Intersperse((new List<long>()), (4L))\n    // (new List<long>())\n    // >>> Intersperse((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)4L, (long)3L}))\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L)))\n    // (\"YES\")\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the list, represented by 1, -1 or 0.\n    // Note: return null for empty arr.\n    // Example:\n    // >>> ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L})))\n    // 9L\n    // >>> ProdSigns((new List<long>(new long[]{(long)0L, (long)1L})))\n    // 0L\n    // >>> ProdSigns((new List<long>()))\n    // null\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))\n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L))\n    // (new List<long>(new long[]{(long)1L}))\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return null in case the input list is empty.\n    // >>> Longest((new List<string>()))\n    // null\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"a\")\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"bb\", (string)\"ccc\"})))\n    // (\"ccc\")\n    public static string Longest(List<string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> Tri((3L))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))\n    public static List<long> Tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> Digits((1L))\n    // (1L)\n    // >>> Digits((4L))\n    // (0L)\n    // >>> Digits((235L))\n    // (15L)\n    public static long Digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> IsNested((\"[[]]\"))\n    // (true)\n    // >>> IsNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> IsNested((\"[][]\"))\n    // (false)\n    // >>> IsNested((\"[]\"))\n    // (false)\n    // >>> IsNested((\"[[][]]\"))\n    // (true)\n    // >>> IsNested((\"[[]][[\"))\n    // (true)\n    public static bool IsNested(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})))\n    // (14L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)4.0f, (float)9.0f})))\n    // (98L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n    // (84L)\n    // >>> Lst((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f})))\n    // (29L)\n    // >>> Lst((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f})))\n    // (6L)\n    public static long SumSquares(List<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> CheckIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"\"))\n    // (false)\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L})))\n    // (3L)\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (-1L)\n    public static long CanArrange(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as null.\n    // Examples:\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L})))\n    // Tuple.Create((Nullable<long>)null, 1L)\n    // >>> LargestSmallestIntegers((new List<long>()))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)0L})))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> IsEqualToSumEven((4L))\n    // (false)\n    // >>> IsEqualToSumEven((6L))\n    // (false)\n    // >>> IsEqualToSumEven((8L))\n    // (true)\n    public static bool IsEqualToSumEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> SpecialFactorial((4L))\n    // (288L)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> GreatestCommonDivisor((3L), (5L))\n    // (1L)\n    // >>> GreatestCommonDivisor((25L), (15L))\n    // (5L)\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> FixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> FixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> FixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> FixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static string FixSpaces(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> FileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> FileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static string FileNameCheck(string file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})\n    // >>> lst\n    // (long)new List<long>()\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L})\n    public static long SumSquares(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> WordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> WordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> Simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> Simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> Simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static bool Simplify(string x, string n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L})))\n    // (new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))\n    // >>> OrderByPoints((new List<long>()))\n    // (new List<long>())\n    public static List<long> OrderByPoints(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +580,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a list of numbers as input and returns \n    // the number of elements in the list that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L})))\n    // (1L)\n    // >>> Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L})))\n    // (2L)\n    public static long Specialfilter(List<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)5L, (long)-2L, (long)1L, (long)-5L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L}))) == (1L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L}))) == (2L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)43L, (long)-12L, (long)93L, (long)125L, (long)121L, (long)109L}))) == (4L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)71L, (long)-2L, (long)-33L, (long)75L, (long)21L, (long)19L}))) == (3L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>())) == (0L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,25 +588,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> SumToN((30L))\n    // (465L)\n    // >>> SumToN((100L))\n    // (5050L)\n    // >>> SumToN((5L))\n    // (15L)\n    // >>> SumToN((10L))\n    // (55L)\n    // >>> SumToN((1L))\n    // (1L)\n    public static long SumToN(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> GetMaxTriples((5L))\n    // (1L)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)4L}))\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> Bf((\"Jupiter\"), (\"Neptune\"))\n    // (new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))\n    // >>> Bf((\"Earth\"), (\"Mercury\"))\n    // (List<string>(\"Venus\"))\n    // >>> Bf((\"Mercury\"), (\"Uranus\"))\n    // (new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))\n    public static List<string> Bf(string planet1, string planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never a list of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> ListSort((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"})))\n    // (new List<string>(new string[]{(string)\"aa\"}))\n    // >>> ListSort((new List<string>(new string[]{(string)\"ab\", (string)\"a\", (string)\"aaa\", (string)\"cd\"})))\n    // (new List<string>(new string[]{(string)\"ab\", (string)\"cd\"}))\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> AllPrefixes((\"abc\"))\n    // (new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))\n    public static List<string> AllPrefixes(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> XOrY((7L), (34L), (12L))\n    // (34L)\n    // >>> XOrY((15L), (8L), (5L))\n    // (5L)\n    public static long XOrY(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)1L, (long)3L, (long)2L, (long)0L})))\n    // (10L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)-1L, (long)-2L, (long)0L})))\n    // (0L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)9L, (long)-2L})))\n    // (81L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)0L})))\n    // (0L)\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two lists of scores and guesses of equal length, where each index shows a match. \n    // Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L})))\n    // (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))\n    // >>> Compare((new List<long>(new long[]{(long)0L, (long)5L, (long)0L, (long)0L, (long)0L, (long)4L})), (new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L, (long)0L, (long)-2L})))\n    // (new List<long>(new long[]{(long)4L, (long)4L, (long)1L, (long)0L, (long)0L, (long)6L}))\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new List<string>(new string[]{(string)\"AA\", (string)\"Be\", (string)\"CC\"})))\n    // (\"my_class.AA\")\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> CycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> CycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> CycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> CycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> CycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> CycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> EvenOddCount((-12L))\n    // (Tuple.Create(1L, 1L))\n    // >>> EvenOddCount((123L))\n    // (Tuple.Create(1L, 2L))\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> IntToMiniRoman((19L))\n    // (\"xix\")\n    // >>> IntToMiniRoman((152L))\n    // (\"clii\")\n    // >>> IntToMiniRoman((426L))\n    // (\"cdxxvi\")\n    public static string IntToMiniRoman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> RightAngleTriangle((3L), (4L), (5L))\n    // (true)\n    // >>> RightAngleTriangle((1L), (2L), (3L))\n    // (false)\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"})))\n    // (\"string\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"})))\n    // (\"enam\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"})))\n    // (\"aaaaaaa\")\n    public static string FindMax(List<string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return a list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> Eat((5L), (6L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)4L}))\n    // >>> Eat((4L), (8L), (9L))\n    // (new List<long>(new long[]{(long)12L, (long)1L}))\n    // >>> Eat((1L), (10L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)0L}))\n    // >>> Eat((2L), (11L), (5L))\n    // (new List<long>(new long[]{(long)7L, (long)0L}))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> StringSequence((0L))\n    // (\"0\")\n    // >>> StringSequence((5L))\n    // (\"0 1 2 3 4 5\")\n    public static string StringSequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> Solve((\"1234\"))\n    // (\"4321\")\n    // >>> Solve((\"ab\"))\n    // (\"AB\")\n    // >>> Solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static string Solve(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return null.\n    // >>> StringToMd5((\"Hello world\"))\n    // (\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static string StringToMd5(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1804,7 +808,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> GenerateIntegers((2L), (8L))\n    // (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))\n    // >>> GenerateIntegers((8L), (2L))\n    // (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))\n    // >>> GenerateIntegers((10L), (14L))\n    // (new List<long>())\n    public static List<long> GenerateIntegers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GenerateIntegers((2L), (10L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((10L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((132L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((17L), (89L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1812,49 +816,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L}))\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> CountDistinctCharacters((\"xyzXYZ\"))\n    // (3L)\n    // >>> CountDistinctCharacters((\"Jerry\"))\n    // (4L)\n    public static long CountDistinctCharacters(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (false)\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L})))\n    // (true)\n    public static bool BelowZero(List<long> operations) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> ParseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new List<long>(new long[]{(long)4L, (long)2L, (long)1L, (long)2L, (long)2L, (long)1L, (long)1L, (long)1L, (long)1L, (long)4L, (long)4L}))\n    public static List<long> ParseMusic(string music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> Search((new List<long>(new long[]{(long)4L, (long)1L, (long)2L, (long)2L, (long)3L, (long)1L})))\n    // (2L)\n    // >>> Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L, (long)4L})))\n    // (3L)\n    // >>> Search((new List<long>(new long[]{(long)5L, (long)5L, (long)4L, (long)4L, (long)4L})))\n    // (-1L)\n    public static long Search(List<long> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> HowManyTimes((\"\"), (\"a\"))\n    // (0L)\n    // >>> HowManyTimes((\"aaa\"), (\"a\"))\n    // (3L)\n    // >>> HowManyTimes((\"aaaa\"), (\"aa\"))\n    // (3L)\n    public static long HowManyTimes(string str, string substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"(\"))\n    // (false)\n    // >>> CorrectBracketing((\"()\"))\n    // (true)\n    // >>> CorrectBracketing((\"(()())\"))\n    // (true)\n    // >>> CorrectBracketing((\")(()\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> SortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static string SortNumbers(string numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> SeparateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n    // (Tuple.Create(2.0f, 2.2f))\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n    // (Tuple.Create(2.0f, 2.0f))\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n    // (new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any csthon values only for integers\n    // >>> FilterIntegers((new List<object>(new string[]{(string)\"a\", (string)3.14f, (string)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> FilterIntegers((new List<object>(new object[]{1L, 2L, 3L, \"abc\", new List<object>()})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    public static List<long> FilterIntegers(List<object> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> StringLength((\"\"))\n    // (0L)\n    // >>> StringLength((\"abc\"))\n    // (3L)\n    public static long Strlen(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> LargestDivisor((15L))\n    // (5L)\n    public static long LargestDivisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> Factorize((8L))\n    // (new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))\n    // >>> Factorize((25L))\n    // (new List<long>(new long[]{(long)5L, (long)5L}))\n    // >>> Factorize((70L))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)7L}))\n    public static List<long> Factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)4L}))\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> FlipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static string FlipCase(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> Concatenate((new List<string>()))\n    // (\"\")\n    // >>> Concatenate((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"abc\")\n    public static string Concatenate(List<string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> FilterByPrefix((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterByPrefix((new List<string>(new string[]{(string)\"abc\", (string)\"bcd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"array\"}))\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> TruncateNumber((3.5f))\n    // (0.5f)\n    public static float TruncateNumber(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> GetPositive((new List<long>(new long[]{(long)-1L, (long)2L, (long)-4L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)6L}))\n    // >>> GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)9L, (long)123L, (long)1L}))\n    public static List<long> GetPositive(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> IsPrime((6L))\n    // (false)\n    // >>> IsPrime((101L))\n    // (true)\n    // >>> IsPrime((11L))\n    // (true)\n    // >>> IsPrime((13441L))\n    // (true)\n    // >>> IsPrime((61L))\n    // (true)\n    // >>> IsPrime((4L))\n    // (false)\n    // >>> IsPrime((1L))\n    // (false)\n    public static bool IsPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> SortThird((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))\n    public static List<long> SortThird(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))\n    public static List<long> Unique(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (3L)\n    // >>> MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (123L)\n    public static long MaxElement(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> FizzBuzz((50L))\n    // (0L)\n    // >>> FizzBuzz((78L))\n    // (2L)\n    // >>> FizzBuzz((79L))\n    // (3L)\n    public static long FizzBuzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1864,9 +1084,201 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortEven((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)3L, (long)6L, (long)5L, (long)4L}))\n    public static List<long> SortEven(List<long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-10L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)5L, (long)0L, (long)9L, (long)1L, (long)123L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)8L, (long)-12L, (long)4L, (long)23L, (long)2L, (long)3L, (long)11L, (long)12L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-12L, (long)8L, (long)3L, (long)4L, (long)5L, (long)2L, (long)12L, (long)11L, (long)23L, (long)-10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> PrimeFib((1L))\n    // (2L)\n    // >>> PrimeFib((2L))\n    // (3L)\n    // >>> PrimeFib((3L))\n    // (5L)\n    // >>> PrimeFib((4L))\n    // (13L)\n    // >>> PrimeFib((5L))\n    // (89L)\n    public static long PrimeFib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (false)\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L})))\n    // (true)\n    public static bool BelowZero(List<long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are three distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool TriplesSumToZero(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> IncrList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))\n    // >>> IncrList((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)6L, (long)4L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))\n    public static List<long> IncrList(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are two distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L})))\n    // (true)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool PairsSumToZero(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> ChangeBase((8L), (3L))\n    // (\"22\")\n    // >>> ChangeBase((8L), (2L))\n    // (\"1000\")\n    // >>> ChangeBase((7L), (2L))\n    // (\"111\")\n    public static string ChangeBase(long x, long numBase) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> TriangleArea((5L), (3L))\n    // (7.5f)\n    public static float TriangleArea(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> Fib4((5L))\n    // (4L)\n    // >>> Fib4((6L))\n    // (8L)\n    // >>> Fib4((7L))\n    // (14L)\n    public static long Fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (float)3L\n    // >>> Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L})))\n    // (15.0f)\n    public static float Median(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> IsPalindrome((\"\"))\n    // (true)\n    // >>> IsPalindrome((\"aba\"))\n    // (true)\n    // >>> IsPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> IsPalindrome((\"zbcd\"))\n    // (false)\n    public static bool IsPalindrome(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> Modp((3L), (5L))\n    // (3L)\n    // >>> Modp((1101L), (101L))\n    // (2L)\n    // >>> Modp((0L), (101L))\n    // (1L)\n    // >>> Modp((3L), (11L))\n    // (8L)\n    // >>> Modp((100L), (101L))\n    // (1L)\n    public static long Modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n    // (1.0f)\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> RemoveVowels((\"\"))\n    // (\"\")\n    // >>> RemoveVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> RemoveVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> RemoveVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> RemoveVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static string RemoveVowels(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if all numbers in the list l are below threshold t.\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L))\n    // (true)\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L))\n    // (false)\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> Add((2L), (3L))\n    // (5L)\n    // >>> Add((5L), (7L))\n    // (12L)\n    public static long Add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,9 +1288,21 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> SameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> SameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> SameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> SameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    public static bool SameChars(string s0, string s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    Debug.Assert(SameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    Debug.Assert(SameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    Debug.Assert(SameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> Fib((10L))\n    // (55L)\n    // >>> Fib((1L))\n    // (1L)\n    // >>> Fib((8L))\n    // (21L)\n    public static long Fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1312,585 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"<\"))\n    // (false)\n    // >>> CorrectBracketing((\"<>\"))\n    // (true)\n    // >>> CorrectBracketing((\"<<><>>\"))\n    // (true)\n    // >>> CorrectBracketing((\"><<>\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"<>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<><>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<<><>>>>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<<<\")) == (false));\n    Debug.Assert(CorrectBracketing((\">\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true is list elements are monotonically increasing or decreasing.\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L})))\n    // (true)\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})))\n    // (false)\n    // >>> Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L})))\n    // (true)\n    public static bool Monotonic(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L})))\n    // (new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))\n    // >>> Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> LargestPrimeFactor((13195L))\n    // (29L)\n    // >>> LargestPrimeFactor((2048L))\n    // (2L)\n    public static long LargestPrimeFactor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> Intersperse((new List<long>()), (4L))\n    // (new List<long>())\n    // >>> Intersperse((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)4L, (long)3L}))\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> SumToN((30L))\n    // (465L)\n    // >>> SumToN((100L))\n    // (5050L)\n    // >>> SumToN((5L))\n    // (15L)\n    // >>> SumToN((10L))\n    // (55L)\n    // >>> SumToN((1L))\n    // (1L)\n    public static long SumToN(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"(\"))\n    // (false)\n    // >>> CorrectBracketing((\"()\"))\n    // (true)\n    // >>> CorrectBracketing((\"(()())\"))\n    // (true)\n    // >>> CorrectBracketing((\")(()\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))\n    // >>> Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L}))\n    public static List<long> Derivative(List<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> Fibfib((1L))\n    // (0L)\n    // >>> Fibfib((5L))\n    // (4L)\n    // >>> Fibfib((8L))\n    // (24L)\n    public static long Fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> VowelsCount((\"abcde\"))\n    // (2L)\n    // >>> VowelsCount((\"ACEDY\"))\n    // (3L)\n    public static long VowelsCount(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> CircularShift((12L), (1L))\n    // (\"21\")\n    // >>> CircularShift((12L), (2L))\n    // (\"12\")\n    public static string CircularShift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> Digitsum((\"\"))\n    // (0L)\n    // >>> Digitsum((\"abAB\"))\n    // (131L)\n    // >>> Digitsum((\"abcCd\"))\n    // (67L)\n    // >>> Digitsum((\"helloE\"))\n    // (69L)\n    // >>> Digitsum((\"woArBld\"))\n    // (131L)\n    // >>> Digitsum((\"aAaaaXa\"))\n    // (153L)\n    public static long Digitsum(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> FruitDistribution((\"5 apples and 6 oranges\"), (19L))\n    // (8L)\n    // >>> FruitDistribution((\"0 apples and 1 oranges\"), (3L))\n    // (2L)\n    // >>> FruitDistribution((\"2 apples and 3 oranges\"), (100L))\n    // (95L)\n    // >>> FruitDistribution((\"100 apples and 1 oranges\"), (120L))\n    // (19L)\n    public static long FruitDistribution(string s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given a list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given list is empty, return [].\n    // Example 1:\n    // >>> Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> Pluck((new List<long>()))\n    // (new List<long>())\n    // Example 4:\n    // >>> Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L}))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> Search((new List<long>(new long[]{(long)4L, (long)1L, (long)2L, (long)2L, (long)3L, (long)1L})))\n    // (2L)\n    // >>> Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L, (long)4L})))\n    // (3L)\n    // >>> Search((new List<long>(new long[]{(long)5L, (long)5L, (long)4L, (long)4L, (long)4L})))\n    // (-1L)\n    public static long Search(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> ParseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))\n    // >>> StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L})))\n    // (new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))\n    // >>> StrangeSortList((new List<long>()))\n    // (new List<long>())\n    public static List<long> StrangeSortList(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> TriangleArea((3L), (4L), (5L))\n    // (6.0f)\n    // >>> TriangleArea((1L), (2L), (10L))\n    // (float)-1L\n    public static float TriangleArea(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L})), (5L))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list arr of integers, find the minimum number of elements that\n    // need to be changed to make the list palindromic. A palindromic list is a list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L})))\n    // (4L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L})))\n    // (1L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L})))\n    // (0L)\n    public static long SmallestChange(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> TotalMatch((new List<string>()), (new List<string>()))\n    // (new List<string>())\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"})))\n    // (new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"})))\n    // (new List<string>(new string[]{(string)\"4\"}))\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> IsMultiplyPrime((30L))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> IsSimplePower((1L), (4L))\n    // (true)\n    // >>> IsSimplePower((2L), (2L))\n    // (true)\n    // >>> IsSimplePower((8L), (2L))\n    // (true)\n    // >>> IsSimplePower((3L), (2L))\n    // (false)\n    // >>> IsSimplePower((3L), (1L))\n    // (false)\n    // >>> IsSimplePower((5L), (3L))\n    // (false)\n    public static bool IsSimplePower(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> Iscube((1L))\n    // (true)\n    // >>> Iscube((2L))\n    // (false)\n    // >>> Iscube((-1L))\n    // (true)\n    // >>> Iscube((64L))\n    // (true)\n    // >>> Iscube((0L))\n    // (true)\n    // >>> Iscube((180L))\n    // (false)\n    public static bool Iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> HexKey((\"AB\"))\n    // (1L)\n    // >>> HexKey((\"1077E\"))\n    // (2L)\n    // >>> HexKey((\"ABED1A33\"))\n    // (4L)\n    // >>> HexKey((\"123456789ABCDEF0\"))\n    // (6L)\n    // >>> HexKey((\"2020\"))\n    // (2L)\n    public static long HexKey(string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> DecimalToBinary((15L))\n    // (\"db1111db\")\n    // >>> DecimalToBinary((32L))\n    // (\"db100000db\")\n    public static string DecimalToBinary(long decimalNum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> FilterBySubstring((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterBySubstring((new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"array\"}))\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapcs or not.\n    // A string is hapcs if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> IsHappy((\"a\"))\n    // (false)\n    // >>> IsHappy((\"aa\"))\n    // (false)\n    // >>> IsHappy((\"abcd\"))\n    // (true)\n    // >>> IsHappy((\"aabb\"))\n    // (false)\n    // >>> IsHappy((\"adb\"))\n    // (true)\n    // >>> IsHappy((\"xyy\"))\n    // (false)\n    public static bool IsHappy(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> GradeEquation((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f})))\n    // (new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> PrimeLength((\"Hello\"))\n    // (true)\n    // >>> PrimeLength((\"abcdcba\"))\n    // (true)\n    // >>> PrimeLength((\"kittens\"))\n    // (true)\n    // >>> PrimeLength((\"orange\"))\n    // (false)\n    public static bool PrimeLength(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> Solve((1000L))\n    // (\"1\")\n    // >>> Solve((150L))\n    // (\"110\")\n    // >>> Solve((147L))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> Add((new List<long>(new long[]{(long)4L, (long)2L, (long)6L, (long)7L})))\n    // (2L)\n    public static long Add(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> AntiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> AntiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> AntiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static string AntiShuffle(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))\n    // >>> GetRow((new List<List<long>>()), (1L))\n    // (new List<Tuple<long, long>>())\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of non-negative integers, return a cocs of the given list after sorting,\n    // you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given list.\n    // Examples:\n    // >>> SortArray((new List<long>()))\n    // (new List<long>())\n    // >>> SortArray((new List<long>(new long[]{(long)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))\n    public static List<long> SortArray(List<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> Encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> Encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> Encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> Encrypt((\"et\"))\n    // (\"ix\")\n    public static string Encrypt(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> SumProduct((new List<long>()))\n    // (Tuple.Create(0L, 1L))\n    // >>> SumProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (Tuple.Create(10L, 24L))\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return null if there is no such element.\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // 2L\n    // >>> NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L})))\n    // 2L\n    // >>> NextSmallest((new List<long>()))\n    // null\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)1L})))\n    // null\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> IsBored((\"Hello world\"))\n    // (0L)\n    // >>> IsBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1L)\n    public static long IsBored(string S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> AnyInt((float)5L, (float)2L, (float)7L)\n    // (true)\n    // >>> AnyInt((float)3L, (float)2L, (float)2L)\n    // (false)\n    // >>> AnyInt((float)3L, (float)-2L, (float)1L)\n    // (true)\n    // >>> AnyInt((3.6f), (-2.2f), (float)2L)\n    // (false)\n    public static bool AnyInt(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> Encode((\"test\"))\n    // (\"TGST\")\n    // >>> Encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static string Encode(string message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L})))\n    // (10L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L})))\n    // (25L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L})))\n    // (13L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L})))\n    // (11L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L})))\n    // (3L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L})))\n    // (7L)\n    public static long Skjkasdkd(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given dictionary is empty.\n    // Examples:\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"b\", \"banana\"}}))\n    // (true)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {8L, \"banana\"}, {\"a\", \"apple\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))\n    // (true)\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns a list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> CountUpTo((5L))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    // >>> CountUpTo((11L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))\n    // >>> CountUpTo((0L))\n    // (new List<long>())\n    // >>> CountUpTo((20L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))\n    // >>> CountUpTo((1L))\n    // (new List<long>())\n    // >>> CountUpTo((18L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))\n    public static List<long> CountUpTo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> Multiply((148L), (412L))\n    // (16L)\n    // >>> Multiply((19L), (28L))\n    // (72L)\n    // >>> Multiply((2020L), (1851L))\n    // (0L)\n    // >>> Multiply((14L), (-15L))\n    // (20L)\n    public static long Multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> CountUpper((\"aBCdEf\"))\n    // (1L)\n    // >>> CountUpper((\"abcdefg\"))\n    // (0L)\n    // >>> CountUpper((\"dBBE\"))\n    // (0L)\n    public static long CountUpper(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> ClosestInteger((\"10\"))\n    // (10L)\n    // >>> ClosestInteger((\"15.3\"))\n    // (15L)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L}))\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-cs-transform.json
+++ b/prompts/humaneval-cs-transform.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> StringLength((\"\"))\n    // (0L)\n    // >>> StringLength((\"abc\"))\n    // (3L)\n    public static long Strlen(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> Encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> Encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> Encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> Encrypt((\"et\"))\n    // (\"ix\")\n    public static string Encrypt(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"b\", \"banana\"}}))\n    // (true)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {8L, \"banana\"}, {\"a\", \"apple\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))\n    // (true)\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> Add((new List<long>(new long[]{(long)4L, (long)2L, (long)6L, (long)7L})))\n    // (2L)\n    public static long Add(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> FixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> FixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> FixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> FixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static string FixSpaces(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> Fibfib((1L))\n    // (0L)\n    // >>> Fibfib((5L))\n    // (4L)\n    // >>> Fibfib((8L))\n    // (24L)\n    public static long Fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)1L, (long)3L, (long)2L, (long)0L})))\n    // (10L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)-1L, (long)-2L, (long)0L})))\n    // (0L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)9L, (long)-2L})))\n    // (81L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)0L})))\n    // (0L)\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> FilterIntegers((new List<object>(new string[]{(string)\"a\", (string)3.14f, (string)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> FilterIntegers((new List<object>(new object[]{1L, 2L, 3L, \"abc\", new List<object>()})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    public static List<long> FilterIntegers(List<object> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> ParseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new List<long>(new long[]{(long)4L, (long)2L, (long)1L, (long)2L, (long)2L, (long)1L, (long)1L, (long)1L, (long)1L, (long)4L, (long)4L}))\n    public static List<long> ParseMusic(string music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> DecimalToBinary((15L))\n    // (\"db1111db\")\n    // >>> DecimalToBinary((32L))\n    // (\"db100000db\")\n    public static string DecimalToBinary(long decimalNum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> AllPrefixes((\"abc\"))\n    // (new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))\n    public static List<string> AllPrefixes(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> Add((2L), (3L))\n    // (5L)\n    // >>> Add((5L), (7L))\n    // (12L)\n    public static long Add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> Eat((5L), (6L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)4L}))\n    // >>> Eat((4L), (8L), (9L))\n    // (new List<long>(new long[]{(long)12L, (long)1L}))\n    // >>> Eat((1L), (10L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)0L}))\n    // >>> Eat((2L), (11L), (5L))\n    // (new List<long>(new long[]{(long)7L, (long)0L}))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L))\n    // (6L)\n    // Example 2:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L))\n    // (5L)\n    // Example 3:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L))\n    // (0L)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> FlipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static string FlipCase(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L})))\n    // (new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))\n    // If the array is empty, return an empty array:\n    // >>> ByLength((new List<long>()))\n    // (new List<string>())\n    // If the array has any strange number ignore it:\n    // >>> ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L})))\n    // (new List<string>(new string[]{(string)\"One\"}))\n    public static List<string> ByLength(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> Factorize((8L))\n    // (new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))\n    // >>> Factorize((25L))\n    // (new List<long>(new long[]{(long)5L, (long)5L}))\n    // >>> Factorize((70L))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)7L}))\n    public static List<long> Factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> CountUpTo((5L))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    // >>> CountUpTo((11L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))\n    // >>> CountUpTo((0L))\n    // (new List<long>())\n    // >>> CountUpTo((20L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))\n    // >>> CountUpTo((1L))\n    // (new List<long>())\n    // >>> CountUpTo((18L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))\n    public static List<long> CountUpTo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))\n    public static List<long> Unique(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> TotalMatch((new List<string>()), (new List<string>()))\n    // (new List<string>())\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"})))\n    // (new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"})))\n    // (new List<string>(new string[]{(string)\"4\"}))\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (3L)\n    // >>> MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (123L)\n    public static long MaxElement(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> IsNested((\"[[]]\"))\n    // (true)\n    // >>> IsNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> IsNested((\"[][]\"))\n    // (false)\n    // >>> IsNested((\"[]\"))\n    // (false)\n    // >>> IsNested((\"[[][]]\"))\n    // (true)\n    // >>> IsNested((\"[[]][[\"))\n    // (true)\n    public static bool IsNested(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> OddCount((new List<string>(new string[]{(string)\"1234567\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n    // >>> OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\n    public static List<string> OddCount(List<string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L})))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L})))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> EvenOddPalindrome((3L))\n    // (Tuple.Create(1L, 2L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> EvenOddPalindrome((12L))\n    // (Tuple.Create(4L, 6L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> IsEqualToSumEven((4L))\n    // (false)\n    // >>> IsEqualToSumEven((6L))\n    // (false)\n    // >>> IsEqualToSumEven((8L))\n    // (true)\n    public static bool IsEqualToSumEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))\n    // >>> Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L}))\n    public static List<long> Derivative(List<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> IsSorted((new List<long>(new long[]{(long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L})))\n    // (false)\n    public static bool IsSorted(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> Solve((\"1234\"))\n    // (\"4321\")\n    // >>> Solve((\"ab\"))\n    // (\"AB\")\n    // >>> Solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static string Solve(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> Tri((3L))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))\n    public static List<long> Tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> FizzBuzz((50L))\n    // (0L)\n    // >>> FizzBuzz((78L))\n    // (2L)\n    // >>> FizzBuzz((79L))\n    // (3L)\n    public static long FizzBuzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> FilterByPrefix((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterByPrefix((new List<string>(new string[]{(string)\"abc\", (string)\"bcd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"array\"}))\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> Solve((1000L))\n    // (\"1\")\n    // >>> Solve((150L))\n    // (\"110\")\n    // >>> Solve((147L))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))\n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L))\n    // (new List<long>(new long[]{(long)1L}))\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> CountUpper((\"aBCdEf\"))\n    // (1L)\n    // >>> CountUpper((\"abcdefg\"))\n    // (0L)\n    // >>> CountUpper((\"dBBE\"))\n    // (0L)\n    public static long CountUpper(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L))\n    // (new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))\n    // Example 2:\n    // >>> Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L))\n    // (new List<long>(new long[]{(long)4L, (long)4L}))\n    // Example 3:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L))\n    // (new List<long>(new long[]{(long)2L}))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> LargestDivisor((15L))\n    // (5L)\n    public static long LargestDivisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> SortArray((new List<long>()))\n    // (new List<long>())\n    // >>> SortArray((new List<long>(new long[]{(long)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))\n    public static List<long> SortArray(List<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> F((5L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))\n    public static List<long> F(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> Iscube((1L))\n    // (true)\n    // >>> Iscube((2L))\n    // (false)\n    // >>> Iscube((-1L))\n    // (true)\n    // >>> Iscube((64L))\n    // (true)\n    // >>> Iscube((0L))\n    // (true)\n    // >>> Iscube((180L))\n    // (false)\n    public static bool Iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> Encode((\"test\"))\n    // (\"TGST\")\n    // >>> Encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static string Encode(string message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> IsBored((\"Hello world\"))\n    // (0L)\n    // >>> IsBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1L)\n    public static long IsBored(string S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L})))\n    // (true)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool PairsSumToZero(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> TriangleArea((3L), (4L), (5L))\n    // (6.0f)\n    // >>> TriangleArea((1L), (2L), (10L))\n    // (float)-1L\n    public static float TriangleArea(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> Bf((\"Jupiter\"), (\"Neptune\"))\n    // (new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))\n    // >>> Bf((\"Earth\"), (\"Mercury\"))\n    // (List<string>(\"Venus\"))\n    // >>> Bf((\"Mercury\"), (\"Uranus\"))\n    // (new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))\n    public static List<string> Bf(string planet1, string planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> Digits((1L))\n    // (1L)\n    // >>> Digits((4L))\n    // (0L)\n    // >>> Digits((235L))\n    // (15L)\n    public static long Digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> WordsString((\"Hi, my name is John\"))\n    // (new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))\n    // >>> WordsString((\"One, two, three, four, five, six\"))\n    // (new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))\n    public static List<string> WordsString(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> HowManyTimes((\"\"), (\"a\"))\n    // (0L)\n    // >>> HowManyTimes((\"aaa\"), (\"a\"))\n    // (3L)\n    // >>> HowManyTimes((\"aaaa\"), (\"aa\"))\n    // (3L)\n    public static long HowManyTimes(string str, string substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> RemoveVowels((\"\"))\n    // (\"\")\n    // >>> RemoveVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> RemoveVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> RemoveVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> RemoveVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static string RemoveVowels(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))\n    // >>> StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L})))\n    // (new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))\n    // >>> StrangeSortList((new List<long>()))\n    // (new List<long>())\n    public static List<long> StrangeSortList(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n    // (Tuple.Create(2.0f, 2.2f))\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n    // (Tuple.Create(2.0f, 2.0f))\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> IsSimplePower((1L), (4L))\n    // (true)\n    // >>> IsSimplePower((2L), (2L))\n    // (true)\n    // >>> IsSimplePower((8L), (2L))\n    // (true)\n    // >>> IsSimplePower((3L), (2L))\n    // (false)\n    // >>> IsSimplePower((3L), (1L))\n    // (false)\n    // >>> IsSimplePower((5L), (3L))\n    // (false)\n    public static bool IsSimplePower(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> PrimeFib((1L))\n    // (2L)\n    // >>> PrimeFib((2L))\n    // (3L)\n    // >>> PrimeFib((3L))\n    // (5L)\n    // >>> PrimeFib((4L))\n    // (13L)\n    // >>> PrimeFib((5L))\n    // (89L)\n    public static long PrimeFib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L})))\n    // (new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))\n    // >>> OrderByPoints((new List<long>()))\n    // (new List<long>())\n    public static List<long> OrderByPoints(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})), (0.5f))\n    // (false)\n    // >>> HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.3f))\n    // (true)\n    public static bool HasCloseElements(List<float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.3f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f})), (0.05f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.95f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f})), (0.8f)) == (false));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})), (0.1f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (1.0f)) == (true));\n    Debug.Assert(HasCloseElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f})), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> MakePalindrome((\"\"))\n    // (\"\")\n    // >>> MakePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> MakePalindrome((\"cata\"))\n    // (\"catac\")\n    public static string MakePalindrome(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> StringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static string StringXor(string a, string b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> SpecialFactorial((4L))\n    // (288L)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L))\n    // (24L)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> Fib4((5L))\n    // (4L)\n    // >>> Fib4((6L))\n    // (8L)\n    // >>> Fib4((7L))\n    // (14L)\n    public static long Fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L})))\n    // (new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))\n    // >>> UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L})))\n    // (new List<long>())\n    public static List<long> UniqueDigits(List<long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> SelectWords((\"Mary had a little lamb\"), (4L))\n    // (new List<string>(new string[]{(string)\"little\"}))\n    // >>> SelectWords((\"Mary had a little lamb\"), (3L))\n    // (new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))\n    // >>> SelectWords((\"simple white space\"), (2L))\n    // (new List<string>())\n    // >>> SelectWords((\"Hello world\"), (4L))\n    // (new List<string>(new string[]{(string)\"world\"}))\n    // >>> SelectWords((\"Uncle sam\"), (3L))\n    // (new List<string>(new string[]{(string)\"Uncle\"}))\n    public static List<string> SelectWords(string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L})), (5L))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> Fib((10L))\n    // (55L)\n    // >>> Fib((1L))\n    // (1L)\n    // >>> Fib((8L))\n    // (21L)\n    public static long Fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new List<string>(new string[]{(string)\"AA\", (string)\"Be\", (string)\"CC\"})))\n    // (\"my_class.AA\")\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"})))\n    // (\"Yes\")\n    // >>> MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"})))\n    // (\"No\")\n    public static string MatchParens(List<string> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // 2L\n    // >>> NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L})))\n    // 2L\n    // >>> NextSmallest((new List<long>()))\n    // null\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)1L})))\n    // null\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> AnyInt((float)5L, (float)2L, (float)7L)\n    // (true)\n    // >>> AnyInt((float)3L, (float)2L, (float)2L)\n    // (false)\n    // >>> AnyInt((float)3L, (float)-2L, (float)1L)\n    // (true)\n    // >>> AnyInt((3.6f), (-2.2f), (float)2L)\n    // (false)\n    public static bool AnyInt(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> TruncateNumber((3.5f))\n    // (0.5f)\n    public static float TruncateNumber(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> IncrList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))\n    // >>> IncrList((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)6L, (long)4L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))\n    public static List<long> IncrList(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> XOrY((7L), (34L), (12L))\n    // (34L)\n    // >>> XOrY((15L), (8L), (5L))\n    // (5L)\n    public static long XOrY(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> Modp((3L), (5L))\n    // (3L)\n    // >>> Modp((1101L), (101L))\n    // (2L)\n    // >>> Modp((0L), (101L))\n    // (1L)\n    // >>> Modp((3L), (11L))\n    // (8L)\n    // >>> Modp((100L), (101L))\n    // (1L)\n    public static long Modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> EvenOddCount((-12L))\n    // (Tuple.Create(1L, 1L))\n    // >>> EvenOddCount((123L))\n    // (Tuple.Create(1L, 2L))\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> IsHappy((\"a\"))\n    // (false)\n    // >>> IsHappy((\"aa\"))\n    // (false)\n    // >>> IsHappy((\"abcd\"))\n    // (true)\n    // >>> IsHappy((\"aabb\"))\n    // (false)\n    // >>> IsHappy((\"adb\"))\n    // (true)\n    // >>> IsHappy((\"xyy\"))\n    // (false)\n    public static bool IsHappy(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> LargestPrimeFactor((13195L))\n    // (29L)\n    // >>> LargestPrimeFactor((2048L))\n    // (2L)\n    public static long LargestPrimeFactor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> Digitsum((\"\"))\n    // (0L)\n    // >>> Digitsum((\"abAB\"))\n    // (131L)\n    // >>> Digitsum((\"abcCd\"))\n    // (67L)\n    // >>> Digitsum((\"helloE\"))\n    // (69L)\n    // >>> Digitsum((\"woArBld\"))\n    // (131L)\n    // >>> Digitsum((\"aAaaaXa\"))\n    // (153L)\n    public static long Digitsum(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n    // (new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L})))\n    // (12L)\n    // >>> Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L})))\n    // (9L)\n    // >>> Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L})))\n    // (0L)\n    public static long Solution(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> Pluck((new List<long>()))\n    // (new List<long>())\n    // Example 4:\n    // >>> Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L}))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> GetMaxTriples((5L))\n    // (1L)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (\"YES\")\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L})))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (float)3L\n    // >>> Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L})))\n    // (15.0f)\n    public static float Median(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> PrimeLength((\"Hello\"))\n    // (true)\n    // >>> PrimeLength((\"abcdcba\"))\n    // (true)\n    // >>> PrimeLength((\"kittens\"))\n    // (true)\n    // >>> PrimeLength((\"orange\"))\n    // (false)\n    public static bool PrimeLength(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L})))\n    // (4L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L})))\n    // (1L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L})))\n    // (0L)\n    public static long SmallestChange(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})))\n    // (14L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)4.0f, (float)9.0f})))\n    // (98L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n    // (84L)\n    // >>> Lst((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f})))\n    // (29L)\n    // >>> Lst((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f})))\n    // (6L)\n    public static long SumSquares(List<float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> FileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> FileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static string FileNameCheck(string file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool TriplesSumToZero(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L)))\n    // (\"YES\")\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> SeparateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L})))\n    // (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))\n    // >>> Compare((new List<long>(new long[]{(long)0L, (long)5L, (long)0L, (long)0L, (long)0L, (long)4L})), (new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L, (long)0L, (long)-2L})))\n    // (new List<long>(new long[]{(long)4L, (long)4L, (long)1L, (long)0L, (long)0L, (long)6L}))\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> CheckIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"\"))\n    // (false)\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> ValidDate((\"03-11-2000\"))\n    // (true)\n    // >>> ValidDate((\"15-01-2012\"))\n    // (false)\n    // >>> ValidDate((\"04-0-2040\"))\n    // (false)\n    // >>> ValidDate((\"06-04-2020\"))\n    // (true)\n    // >>> ValidDate((\"06/04/2020\"))\n    // (false)\n    public static bool ValidDate(string date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> CountNums((new List<long>()))\n    // (0L)\n    // >>> CountNums((new List<long>(new long[]{(long)-1L, (long)11L, (long)-11L})))\n    // (1L)\n    // >>> CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L})))\n    // (3L)\n    public static long CountNums(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> AntiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> AntiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> AntiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static string AntiShuffle(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> IsPalindrome((\"\"))\n    // (true)\n    // >>> IsPalindrome((\"aba\"))\n    // (true)\n    // >>> IsPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> IsPalindrome((\"zbcd\"))\n    // (false)\n    public static bool IsPalindrome(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> GetClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> GetClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> GetClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> GetClosestVowel((\"ab\"))\n    // (\"\")\n    public static string GetClosestVowel(string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> IsPrime((6L))\n    // (false)\n    // >>> IsPrime((101L))\n    // (true)\n    // >>> IsPrime((11L))\n    // (true)\n    // >>> IsPrime((13441L))\n    // (true)\n    // >>> IsPrime((61L))\n    // (true)\n    // >>> IsPrime((4L))\n    // (false)\n    // >>> IsPrime((1L))\n    // (false)\n    public static bool IsPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> Simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> Simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> Simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static bool Simplify(string x, string n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> HexKey((\"AB\"))\n    // (1L)\n    // >>> HexKey((\"1077E\"))\n    // (2L)\n    // >>> HexKey((\"ABED1A33\"))\n    // (4L)\n    // >>> HexKey((\"123456789ABCDEF0\"))\n    // (6L)\n    // >>> HexKey((\"2020\"))\n    // (2L)\n    public static long HexKey(string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> WordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> WordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> Histogram((\"a b c\"))\n    // (new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}})\n    // >>> Histogram((\"a b b a\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"a b c a b\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"b b b b a\"))\n    // (new Dictionary<string,long>(){{\"b\", 4L}})\n    // >>> Histogram((\"\"))\n    // (new Dictionary<string,long>())\n    public static Dictionary<string,long> Histogram(string test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))\n    // >>> GetRow((new List<List<long>>()), (1L))\n    // (new List<Tuple<long, long>>())\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> GetOddCollatz((5L))\n    // (new List<long>(new long[]{(long)1L, (long)5L}))\n    public static List<long> GetOddCollatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L})))\n    // (3L)\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (-1L)\n    public static long CanArrange(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> SortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static string SortNumbers(string numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> CircularShift((12L), (1L))\n    // (\"21\")\n    // >>> CircularShift((12L), (2L))\n    // (\"12\")\n    public static string CircularShift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})\n    // >>> lst\n    // (long)new List<long>()\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L})\n    public static long SumSquares(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L})))\n    // (10L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L})))\n    // (25L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L})))\n    // (13L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L})))\n    // (11L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L})))\n    // (3L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L})))\n    // (7L)\n    public static long Skjkasdkd(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> SumProduct((new List<long>()))\n    // (Tuple.Create(0L, 1L))\n    // >>> SumProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (Tuple.Create(10L, 24L))\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> ChooseNum((12L), (15L))\n    // (14L)\n    // >>> ChooseNum((13L), (12L))\n    // (-1L)\n    public static long ChooseNum(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L})))\n    // Tuple.Create((Nullable<long>)null, 1L)\n    // >>> LargestSmallestIntegers((new List<long>()))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)0L})))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> CountDistinctCharacters((\"xyzXYZ\"))\n    // (3L)\n    // >>> CountDistinctCharacters((\"Jerry\"))\n    // (4L)\n    public static long CountDistinctCharacters(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1384,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> MakeAPile((3L))\n    // (new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))\n    public static List<long> MakeAPile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakeAPile((3L)).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(MakeAPile((4L)).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(MakeAPile((5L)).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)11L, (long)13L}))));\n    Debug.Assert(MakeAPile((6L)).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L}))));\n    Debug.Assert(MakeAPile((8L)).Equals((new List<long>(new long[]{(long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)18L, (long)20L, (long)22L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1392,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L})))\n    // 9L\n    // >>> ProdSigns((new List<long>(new long[]{(long)0L, (long)1L})))\n    // 0L\n    // >>> ProdSigns((new List<long>()))\n    // null\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> WordsString((\"Hi, my name is John\"))\n    // (new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))\n    // >>> WordsString((\"One, two, three, four, five, six\"))\n    // (new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))\n    public static List<string> WordsString(string s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsString((\"Hi, my name is John\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\", (string)\"is\", (string)\"John\"}))));\n    Debug.Assert(WordsString((\"One, two, three, four, five, six\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"Hi, my name\")).Equals((new List<string>(new string[]{(string)\"Hi\", (string)\"my\", (string)\"name\"}))));\n    Debug.Assert(WordsString((\"One,, two, three, four, five, six,\")).Equals((new List<string>(new string[]{(string)\"One\", (string)\"two\", (string)\"three\", (string)\"four\", (string)\"five\", (string)\"six\"}))));\n    Debug.Assert(WordsString((\"\")).Equals((new List<string>())));\n    Debug.Assert(WordsString((\"ahmed     , gamal\")).Equals((new List<string>(new string[]{(string)\"ahmed\", (string)\"gamal\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L})))\n    // (1L)\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})))\n    // (-6L)\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> ChooseNum((12L), (15L))\n    // (14L)\n    // >>> ChooseNum((13L), (12L))\n    // (-1L)\n    public static long ChooseNum(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChooseNum((12L), (15L)) == (14L));\n    Debug.Assert(ChooseNum((13L), (12L)) == (-1L));\n    Debug.Assert(ChooseNum((33L), (12354L)) == (12354L));\n    Debug.Assert(ChooseNum((5234L), (5233L)) == (-1L));\n    Debug.Assert(ChooseNum((6L), (29L)) == (28L));\n    Debug.Assert(ChooseNum((27L), (10L)) == (-1L));\n    Debug.Assert(ChooseNum((7L), (7L)) == (-1L));\n    Debug.Assert(ChooseNum((546L), (546L)) == (546L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> StringSequence((0L))\n    // (\"0\")\n    // >>> StringSequence((5L))\n    // (\"0 1 2 3 4 5\")\n    public static string StringSequence(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L})))\n    // (new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))\n    // >>> UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L})))\n    // (new List<long>())\n    public static List<long> UniqueDigits(List<long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)15L, (long)33L, (long)1422L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)15L, (long)33L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)152L, (long)323L, (long)1422L, (long)10L}))).Equals((new List<long>())));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)12345L, (long)2033L, (long)111L, (long)151L}))).Equals((new List<long>(new long[]{(long)111L, (long)151L}))));\n    Debug.Assert(UniqueDigits((new List<long>(new long[]{(long)135L, (long)103L, (long)31L}))).Equals((new List<long>(new long[]{(long)31L, (long)135L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> CycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> CycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> CycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> CycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> CycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> CycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L})))\n    // (new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))\n    // If the array is empty, return an empty array:\n    // >>> ByLength((new List<long>()))\n    // (new List<string>())\n    // If the array has any strange number ignore it:\n    // >>> ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L})))\n    // (new List<string>(new string[]{(string)\"One\"}))\n    public static List<string> ByLength(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)2L, (long)1L, (long)1L, (long)4L, (long)5L, (long)8L, (long)2L, (long)3L}))).Equals((new List<string>(new string[]{(string)\"Eight\", (string)\"Five\", (string)\"Four\", (string)\"Three\", (string)\"Two\", (string)\"Two\", (string)\"One\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>())).Equals((new List<string>())));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)55L}))).Equals((new List<string>(new string[]{(string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)1L, (long)-1L, (long)3L, (long)2L}))).Equals((new List<string>(new string[]{(string)\"Three\", (string)\"Two\", (string)\"One\"}))));\n    Debug.Assert(ByLength((new List<long>(new long[]{(long)9L, (long)4L, (long)8L}))).Equals((new List<string>(new string[]{(string)\"Nine\", (string)\"Eight\", (string)\"Four\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L})))\n    // (true)\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})))\n    // (false)\n    // >>> Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L})))\n    // (true)\n    public static bool Monotonic(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> F((5L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))\n    public static List<long> F(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(F((5L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L}))));\n    Debug.Assert(F((7L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L, (long)24L, (long)15L, (long)720L, (long)28L}))));\n    Debug.Assert(F((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(F((3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> Longest((new List<string>()))\n    // null\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"a\")\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"bb\", (string)\"ccc\"})))\n    // (\"ccc\")\n    public static string Longest(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> EvenOddPalindrome((3L))\n    // (Tuple.Create(1L, 2L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> EvenOddPalindrome((12L))\n    // (Tuple.Create(4L, 6L))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Tuple<long, long> EvenOddPalindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddPalindrome((123L)).Equals((Tuple.Create(8L, 13L))));\n    Debug.Assert(EvenOddPalindrome((12L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((3L)).Equals((Tuple.Create(1L, 2L))));\n    Debug.Assert(EvenOddPalindrome((63L)).Equals((Tuple.Create(6L, 8L))));\n    Debug.Assert(EvenOddPalindrome((25L)).Equals((Tuple.Create(5L, 6L))));\n    Debug.Assert(EvenOddPalindrome((19L)).Equals((Tuple.Create(4L, 6L))));\n    Debug.Assert(EvenOddPalindrome((9L)).Equals((Tuple.Create(4L, 5L))));\n    Debug.Assert(EvenOddPalindrome((1L)).Equals((Tuple.Create(0L, 1L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L))\n    // (true)\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L))\n    // (false)\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> CountNums((new List<long>()))\n    // (0L)\n    // >>> CountNums((new List<long>(new long[]{(long)-1L, (long)11L, (long)-11L})))\n    // (1L)\n    // >>> CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L})))\n    // (3L)\n    public static long CountNums(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNums((new List<long>())) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)-1L, (long)-2L, (long)0L}))) == (0L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)-2L, (long)3L, (long)4L, (long)5L}))) == (6L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)6L, (long)9L, (long)-6L, (long)0L, (long)1L, (long)5L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L, (long)100L, (long)98L, (long)-7L, (long)1L, (long)-1L}))) == (4L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)12L, (long)23L, (long)34L, (long)-45L, (long)-56L, (long)0L}))) == (5L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    Debug.Assert(CountNums((new List<long>(new long[]{(long)1L}))) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> IsMultiplyPrime((30L))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L})))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L})))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static bool MoveOneBall(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)10L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)4L, (long)3L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>(new long[]{(long)3L, (long)5L, (long)4L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(MoveOneBall((new List<long>())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> GetPositive((new List<long>(new long[]{(long)-1L, (long)2L, (long)-4L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)6L}))\n    // >>> GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)9L, (long)123L, (long)1L}))\n    public static List<long> GetPositive(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> MakePalindrome((\"\"))\n    // (\"\")\n    // >>> MakePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> MakePalindrome((\"cata\"))\n    // (\"catac\")\n    public static string MakePalindrome(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MakePalindrome((\"\")).Equals((\"\")));\n    Debug.Assert(MakePalindrome((\"x\")).Equals((\"x\")));\n    Debug.Assert(MakePalindrome((\"xyz\")).Equals((\"xyzyx\")));\n    Debug.Assert(MakePalindrome((\"xyx\")).Equals((\"xyx\")));\n    Debug.Assert(MakePalindrome((\"jerry\")).Equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> SortThird((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))\n    public static List<long> SortThird(List<long> l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (\"YES\")\n    // >>> Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L})))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static string Exchange(List<long> lst1, List<long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)4L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)4L}))).Equals((\"YES\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)5L, (long)7L, (long)3L})), (new List<long>(new long[]{(long)2L, (long)6L, (long)3L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)3L, (long)2L, (long)6L, (long)1L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)5L, (long)1L, (long)1L, (long)1L}))).Equals((\"NO\")));\n    Debug.Assert(Exchange((new List<long>(new long[]{(long)100L, (long)200L})), (new List<long>(new long[]{(long)200L, (long)200L}))).Equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> ParseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> Histogram((\"a b c\"))\n    // (new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}})\n    // >>> Histogram((\"a b b a\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"a b c a b\"))\n    // (new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})\n    // >>> Histogram((\"b b b b a\"))\n    // (new Dictionary<string,long>(){{\"b\", 4L}})\n    // >>> Histogram((\"\"))\n    // (new Dictionary<string,long>())\n    public static Dictionary<string,long> Histogram(string test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> TriangleArea((5L), (3L))\n    // (7.5f)\n    public static float TriangleArea(long a, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> Multiply((148L), (412L))\n    // (16L)\n    // >>> Multiply((19L), (28L))\n    // (72L)\n    // >>> Multiply((2020L), (1851L))\n    // (0L)\n    // >>> Multiply((14L), (-15L))\n    // (20L)\n    public static long Multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n    // (1.0f)\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L})))\n    // (new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))\n    // >>> Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> IntToMiniRoman((19L))\n    // (\"xix\")\n    // >>> IntToMiniRoman((152L))\n    // (\"clii\")\n    // >>> IntToMiniRoman((426L))\n    // (\"cdxxvi\")\n    public static string IntToMiniRoman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> FruitDistribution((\"5 apples and 6 oranges\"), (19L))\n    // (8L)\n    // >>> FruitDistribution((\"0 apples and 1 oranges\"), (3L))\n    // (2L)\n    // >>> FruitDistribution((\"2 apples and 3 oranges\"), (100L))\n    // (95L)\n    // >>> FruitDistribution((\"100 apples and 1 oranges\"), (120L))\n    // (19L)\n    public static long FruitDistribution(string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Histogram((\"a b b a\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c a b\")).Equals((new Dictionary<string,long>(){{\"a\", 2L}, {\"b\", 2L}})));\n    Debug.Assert(Histogram((\"a b c d g\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}, {\"b\", 1L}, {\"c\", 1L}, {\"d\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"b b b b a\")).Equals((new Dictionary<string,long>(){{\"b\", 4L}})));\n    Debug.Assert(Histogram((\"r t g\")).Equals((new Dictionary<string,long>(){{\"r\", 1L}, {\"t\", 1L}, {\"g\", 1L}})));\n    Debug.Assert(Histogram((\"\")).Equals((new Dictionary<string,long>())));\n    Debug.Assert(Histogram((\"a\")).Equals((new Dictionary<string,long>(){{\"a\", 1L}})));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1600,7 +160,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // >>> ReverseDelete((\"abcde\"), (\"ae\"))\n    // (Tuple.Create(\"bcd\", false))\n    // >>> ReverseDelete((\"abcdef\"), (\"b\"))\n    // (Tuple.Create(\"acdef\", false))\n    // >>> ReverseDelete((\"abcdedcba\"), (\"ab\"))\n    // (Tuple.Create(\"cdedc\", true))\n    public static Tuple<string, bool> ReverseDelete(string s, string c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseDelete((\"abcde\"), (\"ae\")).Equals((Tuple.Create(\"bcd\", false))));\n    Debug.Assert(ReverseDelete((\"abcdef\"), (\"b\")).Equals((Tuple.Create(\"acdef\", false))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"ab\")).Equals((Tuple.Create(\"cdedc\", true))));\n    Debug.Assert(ReverseDelete((\"dwik\"), (\"w\")).Equals((Tuple.Create(\"dik\", false))));\n    Debug.Assert(ReverseDelete((\"a\"), (\"a\")).Equals((Tuple.Create(\"\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"abcdedcba\"), (\"v\")).Equals((Tuple.Create(\"abcdedcba\", true))));\n    Debug.Assert(ReverseDelete((\"vabba\"), (\"v\")).Equals((Tuple.Create(\"abba\", true))));\n    Debug.Assert(ReverseDelete((\"mamma\"), (\"mia\")).Equals((Tuple.Create(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1608,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> GreatestCommonDivisor((3L), (5L))\n    // (1L)\n    // >>> GreatestCommonDivisor((25L), (15L))\n    // (5L)\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> OddCount((new List<string>(new string[]{(string)\"1234567\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))\n    // >>> OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"})))\n    // (new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))\n    public static List<string> OddCount(List<string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"1234567\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"3\", (string)\"11111111\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (string)\"the number of odd elements 8n the str8ng 8 of the 8nput.\"}))));\n    Debug.Assert(OddCount((new List<string>(new string[]{(string)\"271\", (string)\"137\", (string)\"314\"}))).Equals((new List<string>(new string[]{(string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (string)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (string)\"the number of odd elements 2n the str2ng 2 of the 2nput.\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L})))\n    // (1L)\n    // >>> Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})))\n    // (-6L)\n    public static long Minsubarraysum(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L, (long)2L, (long)4L}))) == (1L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)2L, (long)-10L}))) == (-14L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-9999999999999999L}))) == (-9999999999999999L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)0L, (long)10L, (long)20L, (long)1000000L}))) == (0L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-1L, (long)-2L, (long)-3L, (long)10L, (long)-5L}))) == (-6L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)10L, (long)11L, (long)13L, (long)8L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)100L, (long)-33L, (long)32L, (long)-1L, (long)0L, (long)-2L}))) == (-33L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)-10L}))) == (-10L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)7L}))) == (7L));\n    Debug.Assert(Minsubarraysum((new List<long>(new long[]{(long)1L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L))\n    // (6L)\n    // Example 2:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L))\n    // (5L)\n    // Example 3:\n    // >>> MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L))\n    // (0L)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long MaxFill(List<List<long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (1L)) == (6L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)1L})})), (2L)) == (5L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)0L, (long)0L, (long)0L})})), (5L)) == (0L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (2L)) == (4L));\n    Debug.Assert(MaxFill((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})})), (9L)) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1624,7 +208,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L})))\n    // (new List<long>(new long[]{(long)-6L, (long)-5L, (long)-4L, (long)-3L, (long)-2L}))\n    // >>> SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L}))\n    public static List<long> SortArray(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)-2L, (long)-3L, (long)-4L, (long)-5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-4L, (long)-2L, (long)-6L, (long)-5L, (long)-3L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)5L, (long)77L, (long)4L, (long)5L, (long)3L, (long)5L, (long)7L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)4L, (long)4L, (long)3L, (long)3L, (long)5L, (long)5L, (long)5L, (long)7L, (long)77L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)3L, (long)6L, (long)44L, (long)12L, (long)32L, (long)5L}))).Equals((new List<long>(new long[]{(long)32L, (long)3L, (long)5L, (long)6L, (long)12L, (long)44L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)16L, (long)32L}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1632,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> Concatenate((new List<string>()))\n    // (\"\")\n    // >>> Concatenate((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"abc\")\n    public static string Concatenate(List<string> strings) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> SelectWords((\"Mary had a little lamb\"), (4L))\n    // (new List<string>(new string[]{(string)\"little\"}))\n    // >>> SelectWords((\"Mary had a little lamb\"), (3L))\n    // (new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))\n    // >>> SelectWords((\"simple white space\"), (2L))\n    // (new List<string>())\n    // >>> SelectWords((\"Hello world\"), (4L))\n    // (new List<string>(new string[]{(string)\"world\"}))\n    // >>> SelectWords((\"Uncle sam\"), (3L))\n    // (new List<string>(new string[]{(string)\"Uncle\"}))\n    public static List<string> SelectWords(string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (4L)).Equals((new List<string>(new string[]{(string)\"little\"}))));\n    Debug.Assert(SelectWords((\"Mary had a little lamb\"), (3L)).Equals((new List<string>(new string[]{(string)\"Mary\", (string)\"lamb\"}))));\n    Debug.Assert(SelectWords((\"simple white space\"), (2L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"Hello world\"), (4L)).Equals((new List<string>(new string[]{(string)\"world\"}))));\n    Debug.Assert(SelectWords((\"Uncle sam\"), (3L)).Equals((new List<string>(new string[]{(string)\"Uncle\"}))));\n    Debug.Assert(SelectWords((\"\"), (4L)).Equals((new List<string>())));\n    Debug.Assert(SelectWords((\"a b c d e f\"), (1L)).Equals((new List<string>(new string[]{(string)\"b\", (string)\"c\", (string)\"d\", (string)\"f\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> ListSort((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"})))\n    // (new List<string>(new string[]{(string)\"aa\"}))\n    // >>> ListSort((new List<string>(new string[]{(string)\"ab\", (string)\"a\", (string)\"aaa\", (string)\"cd\"})))\n    // (new List<string>(new string[]{(string)\"ab\", (string)\"cd\"}))\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> GetClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> GetClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> GetClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> GetClosestVowel((\"ab\"))\n    // (\"\")\n    public static string GetClosestVowel(string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetClosestVowel((\"yogurt\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"full\")).Equals((\"u\")));\n    Debug.Assert(GetClosestVowel((\"easy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"eAsy\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ali\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"bad\")).Equals((\"a\")));\n    Debug.Assert(GetClosestVowel((\"most\")).Equals((\"o\")));\n    Debug.Assert(GetClosestVowel((\"ab\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"ba\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"quick\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"anime\")).Equals((\"i\")));\n    Debug.Assert(GetClosestVowel((\"Asia\")).Equals((\"\")));\n    Debug.Assert(GetClosestVowel((\"Above\")).Equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> FilterBySubstring((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterBySubstring((new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"array\"}))\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"})))\n    // (\"Yes\")\n    // >>> MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"})))\n    // (\"No\")\n    public static string MatchParens(List<string> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\")\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(())\", (string)\"())())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")())\", (string)\"(()()(\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(())))\", (string)\"(()())((\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"()\", (string)\"())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(()(\", (string)\"()))()\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"((((\", (string)\"((())\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(()\", (string)\"(()(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")(\", (string)\")(\"}))).Equals((\"No\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\"(\", (string)\")\"}))).Equals((\"Yes\")));\n    Debug.Assert(MatchParens((new List<string>(new string[]{(string)\")\", (string)\"(\"}))).Equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> ClosestInteger((\"10\"))\n    // (10L)\n    // >>> ClosestInteger((\"15.3\"))\n    // (15L)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> StringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static string StringXor(string a, string b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringXor((\"111000\"), (\"101010\")).Equals((\"010010\")));\n    Debug.Assert(StringXor((\"1\"), (\"1\")).Equals((\"0\")));\n    Debug.Assert(StringXor((\"0101\"), (\"0000\")).Equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> VowelsCount((\"abcde\"))\n    // (2L)\n    // >>> VowelsCount((\"ACEDY\"))\n    // (3L)\n    public static long VowelsCount(string s) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L))\n    // (new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))\n    // Example 2:\n    // >>> Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L))\n    // (new List<long>(new long[]{(long)4L, (long)4L}))\n    // Example 3:\n    // >>> Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L))\n    // (new List<long>(new long[]{(long)2L}))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static List<long> Maximum(List<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)-4L, (long)-3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L, (long)4L})), (2L)).Equals((new List<long>(new long[]{(long)4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-3L, (long)2L, (long)1L, (long)2L, (long)-1L, (long)-2L, (long)1L})), (1L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)123L, (long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (3L)).Equals((new List<long>(new long[]{(long)2L, (long)20L, (long)123L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-123L, (long)20L, (long)0L, (long)1L, (long)2L, (long)-3L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)20L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)5L, (long)15L, (long)0L, (long)3L, (long)-13L, (long)-8L, (long)0L})), (7L)).Equals((new List<long>(new long[]{(long)-13L, (long)-8L, (long)0L, (long)0L, (long)3L, (long)5L, (long)15L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-1L, (long)0L, (long)2L, (long)5L, (long)3L, (long)-10L})), (2L)).Equals((new List<long>(new long[]{(long)3L, (long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)0L, (long)5L, (long)-7L})), (1L)).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)4L, (long)-4L})), (2L)).Equals((new List<long>(new long[]{(long)-4L, (long)4L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)-10L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)-10L, (long)10L}))));\n    Debug.Assert(Maximum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-23L, (long)243L, (long)-400L, (long)0L})), (0L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"})))\n    // (\"string\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"})))\n    // (\"enam\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"})))\n    // (\"aaaaaaa\")\n    public static string FindMax(List<string> words) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L})))\n    // (12L)\n    // >>> Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L})))\n    // (9L)\n    // >>> Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L})))\n    // (0L)\n    public static long Solution(List<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)8L, (long)7L, (long)1L}))) == (12L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)3L, (long)3L}))) == (9L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)24L, (long)321L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)5L, (long)9L}))) == (5L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)2L, (long)4L, (long)8L}))) == (0L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)30L, (long)13L, (long)23L, (long)32L}))) == (23L));\n    Debug.Assert(Solution((new List<long>(new long[]{(long)3L, (long)13L, (long)2L, (long)9L}))) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> StringToMd5((\"Hello world\"))\n    // (\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static string StringToMd5(string text) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L))\n    // (24L)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long AddElements(List<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)41L, (long)57L, (long)76L, (long)87L, (long)88L, (long)99L})), (3L)) == (-4L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)121L, (long)3L, (long)4000L, (long)5L, (long)6L})), (2L)) == (0L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)11L, (long)21L, (long)3L, (long)90L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (125L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)111L, (long)21L, (long)3L, (long)4000L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L})), (4L)) == (24L));\n    Debug.Assert(AddElements((new List<long>(new long[]{(long)1L})), (1L)) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> ChangeBase((8L), (3L))\n    // (\"22\")\n    // >>> ChangeBase((8L), (2L))\n    // (\"1000\")\n    // >>> ChangeBase((7L), (2L))\n    // (\"111\")\n    public static string ChangeBase(long x, long numBase) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> GetOddCollatz((5L))\n    // (new List<long>(new long[]{(long)1L, (long)5L}))\n    public static List<long> GetOddCollatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetOddCollatz((14L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(GetOddCollatz((5L)).Equals((new List<long>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((12L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(GetOddCollatz((1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> RightAngleTriangle((3L), (4L), (5L))\n    // (true)\n    // >>> RightAngleTriangle((1L), (2L), (3L))\n    // (false)\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> ValidDate((\"03-11-2000\"))\n    // (true)\n    // >>> ValidDate((\"15-01-2012\"))\n    // (false)\n    // >>> ValidDate((\"04-0-2040\"))\n    // (false)\n    // >>> ValidDate((\"06-04-2020\"))\n    // (true)\n    // >>> ValidDate((\"06/04/2020\"))\n    // (false)\n    public static bool ValidDate(string date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ValidDate((\"03-11-2000\")) == (true));\n    Debug.Assert(ValidDate((\"15-01-2012\")) == (false));\n    Debug.Assert(ValidDate((\"04-0-2040\")) == (false));\n    Debug.Assert(ValidDate((\"06-04-2020\")) == (true));\n    Debug.Assert(ValidDate((\"01-01-2007\")) == (true));\n    Debug.Assert(ValidDate((\"03-32-2011\")) == (false));\n    Debug.Assert(ValidDate((\"\")) == (false));\n    Debug.Assert(ValidDate((\"04-31-3000\")) == (false));\n    Debug.Assert(ValidDate((\"06-06-2005\")) == (true));\n    Debug.Assert(ValidDate((\"21-31-2000\")) == (false));\n    Debug.Assert(ValidDate((\"04-12-2003\")) == (true));\n    Debug.Assert(ValidDate((\"04122003\")) == (false));\n    Debug.Assert(ValidDate((\"20030412\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04\")) == (false));\n    Debug.Assert(ValidDate((\"2003-04-12\")) == (false));\n    Debug.Assert(ValidDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> GradeEquation((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f})))\n    // (new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> IsSorted((new List<long>(new long[]{(long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L})))\n    // (false)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L})))\n    // (true)\n    // >>> IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L})))\n    // (false)\n    public static bool IsSorted(List<long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>())) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)2L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L}))) == (false));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L}))) == (true));\n    Debug.Assert(IsSorted((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> Intersperse((new List<long>()), (4L))\n    // (new List<long>())\n    // >>> Intersperse((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)4L, (long)3L}))\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L)))\n    // (\"NO\")\n    // >>> Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L)))\n    // (\"YES\")\n    public static string Intersection(Tuple<long, long> interval1, Tuple<long, long> interval2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(2L, 3L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-1L, 1L)), (Tuple.Create(0L, 4L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-3L, -1L)), (Tuple.Create(-5L, 5L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, 2L)), (Tuple.Create(-4L, 0L))).Equals((\"YES\")));\n    Debug.Assert(Intersection((Tuple.Create(-11L, 2L)), (Tuple.Create(-1L, -1L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(3L, 5L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(1L, 2L)), (Tuple.Create(1L, 2L))).Equals((\"NO\")));\n    Debug.Assert(Intersection((Tuple.Create(-2L, -2L)), (Tuple.Create(-3L, -2L))).Equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L})))\n    // 9L\n    // >>> ProdSigns((new List<long>(new long[]{(long)0L, (long)1L})))\n    // 0L\n    // >>> ProdSigns((new List<long>()))\n    // null\n    public static Nullable<long> ProdSigns(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)-4L}))).Equals(-9L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)0L, (long)1L}))).Equals(0L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)-1L, (long)1L}))).Equals(-10L));\n    Debug.Assert(ProdSigns((new List<long>())).Equals(null));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)2L, (long)-1L, (long)-1L, (long)9L}))).Equals(20L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)-1L, (long)1L}))).Equals(4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)1L}))).Equals(-4L));\n    Debug.Assert(ProdSigns((new List<long>(new long[]{(long)-1L, (long)1L, (long)1L, (long)0L}))).Equals(0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))\n    // >>> Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L))\n    // (new List<long>(new long[]{(long)1L}))\n    public static List<long> Minpath(List<List<long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)9L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)2L})})), (1L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L, (long)16L})})), (4L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)10L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)12L, (long)1L}), (List<long>)new List<long>(new long[]{(long)3L, (long)16L, (long)11L, (long)15L}), (List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L})})), (7L)).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)1L, (long)10L, (long)1L, (long)10L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)14L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)13L, (long)15L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)12L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L, (long)11L, (long)16L})})), (5L)).Equals((new List<long>(new long[]{(long)1L, (long)7L, (long)1L, (long)7L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L})})), (9L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)12L, (long)13L, (long)10L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)3L, (long)15L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)16L, (long)14L, (long)4L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)7L, (long)2L})})), (12L)).Equals((new List<long>(new long[]{(long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L, (long)1L, (long)6L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)8L, (long)9L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)1L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)4L})})), (8L)).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L, (long)1L, (long)5L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L, (long)1L, (long)2L}))));\n    Debug.Assert(Minpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L})})), (10L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L, (long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> Longest((new List<string>()))\n    // null\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"a\")\n    // >>> Longest((new List<string>(new string[]{(string)\"a\", (string)\"bb\", (string)\"ccc\"})))\n    // (\"ccc\")\n    public static string Longest(List<string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Longest((new List<string>())).Equals(null));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"x\")));\n    Debug.Assert(Longest((new List<string>(new string[]{(string)\"x\", (string)\"yyy\", (string)\"zzzz\", (string)\"www\", (string)\"kkkk\", (string)\"abc\"}))).Equals((\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> Tri((3L))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))\n    public static List<long> Tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Tri((3L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L}))));\n    Debug.Assert(Tri((4L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L}))));\n    Debug.Assert(Tri((5L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L}))));\n    Debug.Assert(Tri((6L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L}))));\n    Debug.Assert(Tri((7L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L}))));\n    Debug.Assert(Tri((8L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L}))));\n    Debug.Assert(Tri((9L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L}))));\n    Debug.Assert(Tri((20L)).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)8L, (long)3L, (long)15L, (long)4L, (long)24L, (long)5L, (long)35L, (long)6L, (long)48L, (long)7L, (long)63L, (long)8L, (long)80L, (long)9L, (long)99L, (long)10L, (long)120L, (long)11L}))));\n    Debug.Assert(Tri((0L)).Equals((new List<long>(new long[]{(long)1L}))));\n    Debug.Assert(Tri((1L)).Equals((new List<long>(new long[]{(long)1L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> Digits((1L))\n    // (1L)\n    // >>> Digits((4L))\n    // (0L)\n    // >>> Digits((235L))\n    // (15L)\n    public static long Digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digits((5L)) == (5L));\n    Debug.Assert(Digits((54L)) == (5L));\n    Debug.Assert(Digits((120L)) == (1L));\n    Debug.Assert(Digits((5014L)) == (5L));\n    Debug.Assert(Digits((98765L)) == (315L));\n    Debug.Assert(Digits((5576543L)) == (2625L));\n    Debug.Assert(Digits((2468L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> IsNested((\"[[]]\"))\n    // (true)\n    // >>> IsNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> IsNested((\"[][]\"))\n    // (false)\n    // >>> IsNested((\"[]\"))\n    // (false)\n    // >>> IsNested((\"[[][]]\"))\n    // (true)\n    // >>> IsNested((\"[[]][[\"))\n    // (true)\n    public static bool IsNested(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNested((\"[[]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]][[[[[]\")) == (false));\n    Debug.Assert(IsNested((\"[][]\")) == (false));\n    Debug.Assert(IsNested((\"[]\")) == (false));\n    Debug.Assert(IsNested((\"[[[[]]]]\")) == (true));\n    Debug.Assert(IsNested((\"[]]]]]]]]]]\")) == (false));\n    Debug.Assert(IsNested((\"[][][[]]\")) == (true));\n    Debug.Assert(IsNested((\"[[]\")) == (false));\n    Debug.Assert(IsNested((\"[]]\")) == (false));\n    Debug.Assert(IsNested((\"[[]][[\")) == (true));\n    Debug.Assert(IsNested((\"[[][]]\")) == (true));\n    Debug.Assert(IsNested((\"\")) == (false));\n    Debug.Assert(IsNested((\"[[[[[[[[\")) == (false));\n    Debug.Assert(IsNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f})))\n    // (14L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)4.0f, (float)9.0f})))\n    // (98L)\n    // >>> Lst((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f})))\n    // (84L)\n    // >>> Lst((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f})))\n    // (29L)\n    // >>> Lst((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f})))\n    // (6L)\n    public static long SumSquares(List<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f}))) == (14L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f}))) == (84L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)1.4f, (float)4.2f, (float)0.0f}))) == (29L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-2.4f, (float)1.0f, (float)1.0f}))) == (6L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f}))) == (10230L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)10000.0f, (float)10000.0f}))) == (200000000L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)4.6f, (float)6.3f}))) == (75L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f}))) == (1086L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)0.0f}))) == (0L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f}))) == (1L));\n    Debug.Assert(SumSquares((new List<float>(new float[]{(float)-1.0f, (float)1.0f, (float)0.0f}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> CheckIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> CheckIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> CheckIfLastCharIsALetter((\"\"))\n    // (false)\n    public static bool CheckIfLastCharIsALetter(string txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"A\")) == (true));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"eeeee e \")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pie\")) == (false));\n    Debug.Assert(CheckIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L})))\n    // (3L)\n    // >>> CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (-1L)\n    public static long CanArrange(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)3L, (long)5L}))) == (3L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L}))) == (-1L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(CanArrange((new List<long>(new long[]{(long)4L, (long)8L, (long)5L, (long)7L, (long)3L}))) == (4L));\n    Debug.Assert(CanArrange((new List<long>())) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L})))\n    // Tuple.Create((Nullable<long>)null, 1L)\n    // >>> LargestSmallestIntegers((new List<long>()))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    // >>> LargestSmallestIntegers((new List<long>(new long[]{(long)0L})))\n    // Tuple.Create((Nullable<long>)null, (Nullable<long>)null)\n    public static Tuple<Nullable<long>, Nullable<long>> LargestSmallestIntegers(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L, (long)5L, (long)7L, (long)0L}))).Equals(Tuple.Create((Nullable<long>)null, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)1L, (long)3L, (long)2L, (long)4L, (long)5L, (long)6L, (long)-2L}))).Equals(Tuple.Create(-2L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)4L, (long)5L, (long)3L, (long)6L, (long)2L, (long)7L, (long)-7L}))).Equals(Tuple.Create(-7L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)7L, (long)3L, (long)8L, (long)4L, (long)9L, (long)2L, (long)5L, (long)-9L}))).Equals(Tuple.Create(-9L, 2L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>())).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)0L}))).Equals(Tuple.Create((Nullable<long>)null, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-5L, (long)-6L, (long)0L}))).Equals(Tuple.Create(-1L, (Nullable<long>)null)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    Debug.Assert(LargestSmallestIntegers((new List<long>(new long[]{(long)-6L, (long)-4L, (long)-4L, (long)-3L, (long)-100L, (long)1L}))).Equals(Tuple.Create(-3L, 1L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> IsEqualToSumEven((4L))\n    // (false)\n    // >>> IsEqualToSumEven((6L))\n    // (false)\n    // >>> IsEqualToSumEven((8L))\n    // (true)\n    public static bool IsEqualToSumEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEqualToSumEven((4L)) == (false));\n    Debug.Assert(IsEqualToSumEven((6L)) == (false));\n    Debug.Assert(IsEqualToSumEven((8L)) == (true));\n    Debug.Assert(IsEqualToSumEven((10L)) == (true));\n    Debug.Assert(IsEqualToSumEven((11L)) == (false));\n    Debug.Assert(IsEqualToSumEven((12L)) == (true));\n    Debug.Assert(IsEqualToSumEven((13L)) == (false));\n    Debug.Assert(IsEqualToSumEven((16L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> SpecialFactorial((4L))\n    // (288L)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long SpecialFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SpecialFactorial((4L)) == (288L));\n    Debug.Assert(SpecialFactorial((5L)) == (34560L));\n    Debug.Assert(SpecialFactorial((7L)) == (125411328000L));\n    Debug.Assert(SpecialFactorial((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> GreatestCommonDivisor((3L), (5L))\n    // (1L)\n    // >>> GreatestCommonDivisor((25L), (15L))\n    // (5L)\n    public static long GreatestCommonDivisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GreatestCommonDivisor((3L), (7L)) == (1L));\n    Debug.Assert(GreatestCommonDivisor((10L), (15L)) == (5L));\n    Debug.Assert(GreatestCommonDivisor((49L), (14L)) == (7L));\n    Debug.Assert(GreatestCommonDivisor((144L), (60L)) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> FixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> FixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> FixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> FixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static string FixSpaces(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FixSpaces((\"Example\")).Equals((\"Example\")));\n    Debug.Assert(FixSpaces((\"Mudasir Hanif \")).Equals((\"Mudasir_Hanif_\")));\n    Debug.Assert(FixSpaces((\"Yellow Yellow  Dirty  Fellow\")).Equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    Debug.Assert(FixSpaces((\"Exa   mple\")).Equals((\"Exa-mple\")));\n    Debug.Assert(FixSpaces((\"   Exa 1 2 2 mple\")).Equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> FileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> FileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static string FileNameCheck(string file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FileNameCheck((\"example.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1example.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s1sdf3.asd\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"K.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"MY16FILE3.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"His12FILE94.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_Y.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"?aREYA.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"/this_is_valid.dll\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.wow\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"this_is_valid.txtexe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"#this2_i4s_5valid.ten\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"@this1_is6_valid.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"this_is_12valid.6exe4.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"all.exe.txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_No.exe\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"Is3youfault.txt\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"no_one#knows.dll\")).Equals((\"Yes\")));\n    Debug.Assert(FileNameCheck((\"1I563_Yes3.exe\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"I563_Yes3.txtt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final..txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"final132\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"_f4indsartal132.\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\".txt\")).Equals((\"No\")));\n    Debug.Assert(FileNameCheck((\"s.\")).Equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})\n    // >>> lst\n    // (long)new List<long>()\n    // >>> lst\n    // (long)new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L})\n    public static long SumSquares(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)4L, (long)9L}))) == (14L));\n    Debug.Assert(SumSquares((new List<long>())) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L, (long)1L}))) == (9L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L, (long)-1L}))) == (-3L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)0L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-5L, (long)2L, (long)-1L, (long)-5L}))) == (-126L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-56L, (long)-99L, (long)1L, (long)0L, (long)-2L}))) == (3030L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)-1L}))) == (0L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-16L, (long)-9L, (long)-2L, (long)36L, (long)36L, (long)26L, (long)-20L, (long)25L, (long)-40L, (long)20L, (long)-4L, (long)12L, (long)-26L, (long)35L, (long)37L}))) == (-14196L));\n    Debug.Assert(SumSquares((new List<long>(new long[]{(long)-1L, (long)-3L, (long)17L, (long)-1L, (long)-15L, (long)13L, (long)-1L, (long)14L, (long)-14L, (long)-12L, (long)-5L, (long)14L, (long)-14L, (long)6L, (long)13L, (long)11L, (long)16L, (long)16L, (long)4L, (long)10L}))) == (-1448L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> WordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> WordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static string WordsInSentence(string sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordsInSentence((\"This is a test\")).Equals((\"is\")));\n    Debug.Assert(WordsInSentence((\"lets go for swimming\")).Equals((\"go for\")));\n    Debug.Assert(WordsInSentence((\"there is no place available here\")).Equals((\"there is no place\")));\n    Debug.Assert(WordsInSentence((\"Hi I am Hussein\")).Equals((\"Hi am Hussein\")));\n    Debug.Assert(WordsInSentence((\"go for it\")).Equals((\"go for it\")));\n    Debug.Assert(WordsInSentence((\"here\")).Equals((\"\")));\n    Debug.Assert(WordsInSentence((\"here is\")).Equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> Simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> Simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> Simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static bool Simplify(string x, string n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/6\"), (\"2/1\")) == (false));\n    Debug.Assert(Simplify((\"5/1\"), (\"3/1\")) == (true));\n    Debug.Assert(Simplify((\"7/10\"), (\"10/2\")) == (false));\n    Debug.Assert(Simplify((\"2/10\"), (\"50/10\")) == (true));\n    Debug.Assert(Simplify((\"7/2\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"11/6\"), (\"6/1\")) == (true));\n    Debug.Assert(Simplify((\"2/3\"), (\"5/2\")) == (false));\n    Debug.Assert(Simplify((\"5/2\"), (\"3/5\")) == (false));\n    Debug.Assert(Simplify((\"2/4\"), (\"8/4\")) == (true));\n    Debug.Assert(Simplify((\"2/4\"), (\"4/2\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"5/1\")) == (true));\n    Debug.Assert(Simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L})))\n    // (new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))\n    // >>> OrderByPoints((new List<long>()))\n    // (new List<long>())\n    public static List<long> OrderByPoints(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)11L, (long)-1L, (long)-11L, (long)-12L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-11L, (long)1L, (long)-12L, (long)11L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1234L, (long)423L, (long)463L, (long)145L, (long)2L, (long)423L, (long)423L, (long)53L, (long)6L, (long)37L, (long)3457L, (long)3L, (long)56L, (long)0L, (long)46L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)6L, (long)53L, (long)423L, (long)423L, (long)423L, (long)1234L, (long)145L, (long)37L, (long)46L, (long)56L, (long)463L, (long)3457L}))));\n    Debug.Assert(OrderByPoints((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)-11L, (long)-32L, (long)43L, (long)54L, (long)-98L, (long)2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-32L, (long)-98L, (long)-11L, (long)1L, (long)2L, (long)43L, (long)54L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)2L, (long)11L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(OrderByPoints((new List<long>(new long[]{(long)0L, (long)6L, (long)6L, (long)-76L, (long)-21L, (long)23L, (long)4L}))).Equals((new List<long>(new long[]{(long)-76L, (long)-21L, (long)0L, (long)4L, (long)23L, (long)6L, (long)6L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +580,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L})))\n    // (1L)\n    // >>> Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L})))\n    // (2L)\n    public static long Specialfilter(List<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)5L, (long)-2L, (long)1L, (long)-5L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)15L, (long)-73L, (long)14L, (long)-15L}))) == (1L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)33L, (long)-2L, (long)-3L, (long)45L, (long)21L, (long)109L}))) == (2L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)43L, (long)-12L, (long)93L, (long)125L, (long)121L, (long)109L}))) == (4L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)71L, (long)-2L, (long)-33L, (long)75L, (long)21L, (long)19L}))) == (3L));\n    Debug.Assert(Specialfilter((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(Specialfilter((new List<long>())) == (0L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,25 +588,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> SumToN((30L))\n    // (465L)\n    // >>> SumToN((100L))\n    // (5050L)\n    // >>> SumToN((5L))\n    // (15L)\n    // >>> SumToN((10L))\n    // (55L)\n    // >>> SumToN((1L))\n    // (1L)\n    public static long SumToN(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> GetMaxTriples((5L))\n    // (1L)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long GetMaxTriples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxTriples((5L)) == (1L));\n    Debug.Assert(GetMaxTriples((6L)) == (4L));\n    Debug.Assert(GetMaxTriples((10L)) == (36L));\n    Debug.Assert(GetMaxTriples((100L)) == (53361L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)4L}))\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> Bf((\"Jupiter\"), (\"Neptune\"))\n    // (new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))\n    // >>> Bf((\"Earth\"), (\"Mercury\"))\n    // (List<string>(\"Venus\"))\n    // >>> Bf((\"Mercury\"), (\"Uranus\"))\n    // (new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))\n    public static List<string> Bf(string planet1, string planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Bf((\"Jupiter\"), (\"Neptune\")).Equals((new List<string>(new string[]{(string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Mercury\")).Equals((new List<string>(new string[]{(string)\"Venus\"}))));\n    Debug.Assert(Bf((\"Mercury\"), (\"Uranus\")).Equals((new List<string>(new string[]{(string)\"Venus\", (string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\"}))));\n    Debug.Assert(Bf((\"Neptune\"), (\"Venus\")).Equals((new List<string>(new string[]{(string)\"Earth\", (string)\"Mars\", (string)\"Jupiter\", (string)\"Saturn\", (string)\"Uranus\"}))));\n    Debug.Assert(Bf((\"Earth\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Mars\"), (\"Earth\")).Equals((new List<string>())));\n    Debug.Assert(Bf((\"Jupiter\"), (\"Makemake\")).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> ListSort((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"})))\n    // (new List<string>(new string[]{(string)\"aa\"}))\n    // >>> ListSort((new List<string>(new string[]{(string)\"ab\", (string)\"a\", (string)\"aaa\", (string)\"cd\"})))\n    // (new List<string>(new string[]{(string)\"ab\", (string)\"cd\"}))\n    public static List<string> SortedListSum(List<string> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aa\", (string)\"a\", (string)\"aaa\"}))).Equals((new List<string>(new string[]{(string)\"aa\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"school\", (string)\"AI\", (string)\"asdf\", (string)\"b\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"asdf\", (string)\"school\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"b\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"d\", (string)\"dcba\", (string)\"abcd\", (string)\"a\"}))).Equals((new List<string>(new string[]{(string)\"abcd\", (string)\"dcba\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))).Equals((new List<string>(new string[]{(string)\"AI\", (string)\"ai\", (string)\"au\"}))));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\", (string)\"c\", (string)\"c\", (string)\"a\"}))).Equals((new List<string>())));\n    Debug.Assert(SortedListSum((new List<string>(new string[]{(string)\"aaaa\", (string)\"bbbb\", (string)\"dd\", (string)\"cc\"}))).Equals((new List<string>(new string[]{(string)\"cc\", (string)\"dd\", (string)\"aaaa\", (string)\"bbbb\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> AllPrefixes((\"abc\"))\n    // (new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))\n    public static List<string> AllPrefixes(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllPrefixes((\"\")).Equals((new List<string>())));\n    Debug.Assert(AllPrefixes((\"asdfgh\")).Equals((new List<string>(new string[]{(string)\"a\", (string)\"as\", (string)\"asd\", (string)\"asdf\", (string)\"asdfg\", (string)\"asdfgh\"}))));\n    Debug.Assert(AllPrefixes((\"WWW\")).Equals((new List<string>(new string[]{(string)\"W\", (string)\"WW\", (string)\"WWW\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> XOrY((7L), (34L), (12L))\n    // (34L)\n    // >>> XOrY((15L), (8L), (5L))\n    // (5L)\n    public static long XOrY(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(XOrY((7L), (34L), (12L)) == (34L));\n    Debug.Assert(XOrY((15L), (8L), (5L)) == (5L));\n    Debug.Assert(XOrY((3L), (33L), (5212L)) == (33L));\n    Debug.Assert(XOrY((1259L), (3L), (52L)) == (3L));\n    Debug.Assert(XOrY((7919L), (-1L), (12L)) == (-1L));\n    Debug.Assert(XOrY((3609L), (1245L), (583L)) == (583L));\n    Debug.Assert(XOrY((91L), (56L), (129L)) == (129L));\n    Debug.Assert(XOrY((6L), (34L), (1234L)) == (1234L));\n    Debug.Assert(XOrY((1L), (2L), (0L)) == (0L));\n    Debug.Assert(XOrY((2L), (2L), (0L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)1L, (long)3L, (long)2L, (long)0L})))\n    // (10L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)-1L, (long)-2L, (long)0L})))\n    // (0L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)9L, (long)-2L})))\n    // (81L)\n    // >>> DoubleTheDifference((new List<float>(new long[]{(long)0L})))\n    // (0L)\n    // If the input list is empty, return 0.\n    public static long DoubleTheDifference(List<float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoubleTheDifference((new List<float>())) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)5.0f, (float)4.0f}))) == (25L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.1f, (float)0.2f, (float)0.3f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-10.0f, (float)-20.0f, (float)-30.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-1.0f, (float)-2.0f, (float)8.0f}))) == (0L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)0.2f, (float)3.0f, (float)5.0f}))) == (34L));\n    Debug.Assert(DoubleTheDifference((new List<float>(new float[]{(float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f}))) == (165L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L})))\n    // (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))\n    // >>> Compare((new List<long>(new long[]{(long)0L, (long)5L, (long)0L, (long)0L, (long)0L, (long)4L})), (new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L, (long)0L, (long)-2L})))\n    // (new List<long>(new long[]{(long)4L, (long)4L, (long)1L, (long)0L, (long)0L, (long)6L}))\n    public static List<long> Compare(List<long> game, List<long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)-2L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)3L, (long)3L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L})), (new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(Compare((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)0L, (long)0L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new List<string>(new string[]{(string)\"AA\", (string)\"Be\", (string)\"CC\"})))\n    // (\"my_class.AA\")\n    public static string StrongestExtension(string class_name, List<string> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrongestExtension((\"Watashi\"), (new List<string>(new string[]{(string)\"tEN\", (string)\"niNE\", (string)\"eIGHt8OKe\"}))).Equals((\"Watashi.eIGHt8OKe\")));\n    Debug.Assert(StrongestExtension((\"Boku123\"), (new List<string>(new string[]{(string)\"nani\", (string)\"NazeDa\", (string)\"YEs.WeCaNe\", (string)\"32145tggg\"}))).Equals((\"Boku123.YEs.WeCaNe\")));\n    Debug.Assert(StrongestExtension((\"__YESIMHERE\"), (new List<string>(new string[]{(string)\"t\", (string)\"eMptY\", (string)\"nothing\", (string)\"zeR00\", (string)\"NuLl__\", (string)\"123NoooneB321\"}))).Equals((\"__YESIMHERE.NuLl__\")));\n    Debug.Assert(StrongestExtension((\"K\"), (new List<string>(new string[]{(string)\"Ta\", (string)\"TAR\", (string)\"t234An\", (string)\"cosSo\"}))).Equals((\"K.TAR\")));\n    Debug.Assert(StrongestExtension((\"__HAHA\"), (new List<string>(new string[]{(string)\"Tab\", (string)\"123\", (string)\"781345\", (string)\"-_-\"}))).Equals((\"__HAHA.123\")));\n    Debug.Assert(StrongestExtension((\"YameRore\"), (new List<string>(new string[]{(string)\"HhAas\", (string)\"okIWILL123\", (string)\"WorkOut\", (string)\"Fails\", (string)\"-_-\"}))).Equals((\"YameRore.okIWILL123\")));\n    Debug.Assert(StrongestExtension((\"finNNalLLly\"), (new List<string>(new string[]{(string)\"Die\", (string)\"NowW\", (string)\"Wow\", (string)\"WoW\"}))).Equals((\"finNNalLLly.WoW\")));\n    Debug.Assert(StrongestExtension((\"_\"), (new List<string>(new string[]{(string)\"Bb\", (string)\"91245\"}))).Equals((\"_.Bb\")));\n    Debug.Assert(StrongestExtension((\"Sp\"), (new List<string>(new string[]{(string)\"671235\", (string)\"Bb\"}))).Equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> CycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> CycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> CycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> CycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> CycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> CycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static bool CycpatternCheck(string a, string b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    Debug.Assert(CycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    Debug.Assert(CycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    Debug.Assert(CycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    Debug.Assert(CycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    Debug.Assert(CycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> EvenOddCount((-12L))\n    // (Tuple.Create(1L, 1L))\n    // >>> EvenOddCount((123L))\n    // (Tuple.Create(1L, 2L))\n    public static Tuple<long, long> EvenOddCount(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenOddCount((7L)).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(EvenOddCount((-78L)).Equals((Tuple.Create(1L, 1L))));\n    Debug.Assert(EvenOddCount((3452L)).Equals((Tuple.Create(2L, 2L))));\n    Debug.Assert(EvenOddCount((346211L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-345821L)).Equals((Tuple.Create(3L, 3L))));\n    Debug.Assert(EvenOddCount((-2L)).Equals((Tuple.Create(1L, 0L))));\n    Debug.Assert(EvenOddCount((-45347L)).Equals((Tuple.Create(2L, 3L))));\n    Debug.Assert(EvenOddCount((0L)).Equals((Tuple.Create(1L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> IntToMiniRoman((19L))\n    // (\"xix\")\n    // >>> IntToMiniRoman((152L))\n    // (\"clii\")\n    // >>> IntToMiniRoman((426L))\n    // (\"cdxxvi\")\n    public static string IntToMiniRoman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntToMiniRoman((19L)).Equals((\"xix\")));\n    Debug.Assert(IntToMiniRoman((152L)).Equals((\"clii\")));\n    Debug.Assert(IntToMiniRoman((251L)).Equals((\"ccli\")));\n    Debug.Assert(IntToMiniRoman((426L)).Equals((\"cdxxvi\")));\n    Debug.Assert(IntToMiniRoman((500L)).Equals((\"d\")));\n    Debug.Assert(IntToMiniRoman((1L)).Equals((\"i\")));\n    Debug.Assert(IntToMiniRoman((4L)).Equals((\"iv\")));\n    Debug.Assert(IntToMiniRoman((43L)).Equals((\"xliii\")));\n    Debug.Assert(IntToMiniRoman((90L)).Equals((\"xc\")));\n    Debug.Assert(IntToMiniRoman((94L)).Equals((\"xciv\")));\n    Debug.Assert(IntToMiniRoman((532L)).Equals((\"dxxxii\")));\n    Debug.Assert(IntToMiniRoman((900L)).Equals((\"cm\")));\n    Debug.Assert(IntToMiniRoman((994L)).Equals((\"cmxciv\")));\n    Debug.Assert(IntToMiniRoman((1000L)).Equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> RightAngleTriangle((3L), (4L), (5L))\n    // (true)\n    // >>> RightAngleTriangle((1L), (2L), (3L))\n    // (false)\n    public static bool RightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightAngleTriangle((3L), (4L), (5L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (2L), (3L)) == (false));\n    Debug.Assert(RightAngleTriangle((10L), (6L), (8L)) == (true));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (2L)) == (false));\n    Debug.Assert(RightAngleTriangle((7L), (24L), (25L)) == (true));\n    Debug.Assert(RightAngleTriangle((10L), (5L), (7L)) == (false));\n    Debug.Assert(RightAngleTriangle((5L), (12L), (13L)) == (true));\n    Debug.Assert(RightAngleTriangle((15L), (8L), (17L)) == (true));\n    Debug.Assert(RightAngleTriangle((48L), (55L), (73L)) == (true));\n    Debug.Assert(RightAngleTriangle((1L), (1L), (1L)) == (false));\n    Debug.Assert(RightAngleTriangle((2L), (2L), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"})))\n    // (\"string\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"})))\n    // (\"enam\")\n    // >>> FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"})))\n    // (\"aaaaaaa\")\n    public static string FindMax(List<string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"of\", (string)\"string\"}))).Equals((\"string\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"name\", (string)\"enam\", (string)\"game\"}))).Equals((\"enam\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"aaaaaaa\", (string)\"bb\", (string)\"cc\"}))).Equals((\"aaaaaaa\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"abc\", (string)\"cba\"}))).Equals((\"abc\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"this\", (string)\"game\", (string)\"of\", (string)\"footbott\"}))).Equals((\"footbott\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"gonna\", (string)\"rock\"}))).Equals((\"gonna\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"we\", (string)\"are\", (string)\"a\", (string)\"mad\", (string)\"nation\"}))).Equals((\"nation\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"this\", (string)\"is\", (string)\"a\", (string)\"prrk\"}))).Equals((\"this\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"b\"}))).Equals((\"b\")));\n    Debug.Assert(FindMax((new List<string>(new string[]{(string)\"play\", (string)\"play\", (string)\"play\"}))).Equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> Eat((5L), (6L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)4L}))\n    // >>> Eat((4L), (8L), (9L))\n    // (new List<long>(new long[]{(long)12L, (long)1L}))\n    // >>> Eat((1L), (10L), (10L))\n    // (new List<long>(new long[]{(long)11L, (long)0L}))\n    // >>> Eat((2L), (11L), (5L))\n    // (new List<long>(new long[]{(long)7L, (long)0L}))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static List<long> Eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Eat((5L), (6L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)4L}))));\n    Debug.Assert(Eat((4L), (8L), (9L)).Equals((new List<long>(new long[]{(long)12L, (long)1L}))));\n    Debug.Assert(Eat((1L), (10L), (10L)).Equals((new List<long>(new long[]{(long)11L, (long)0L}))));\n    Debug.Assert(Eat((2L), (11L), (5L)).Equals((new List<long>(new long[]{(long)7L, (long)0L}))));\n    Debug.Assert(Eat((4L), (5L), (7L)).Equals((new List<long>(new long[]{(long)9L, (long)2L}))));\n    Debug.Assert(Eat((4L), (5L), (1L)).Equals((new List<long>(new long[]{(long)5L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> StringSequence((0L))\n    // (\"0\")\n    // >>> StringSequence((5L))\n    // (\"0 1 2 3 4 5\")\n    public static string StringSequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringSequence((0L)).Equals((\"0\")));\n    Debug.Assert(StringSequence((3L)).Equals((\"0 1 2 3\")));\n    Debug.Assert(StringSequence((10L)).Equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long DoAlgebra(List<string> op, List<long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"**\", (string)\"*\", (string)\"+\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (37L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"+\", (string)\"*\", (string)\"-\"})), (new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L}))) == (9L));\n    Debug.Assert(DoAlgebra((new List<string>(new string[]{(string)\"//\", (string)\"*\"})), (new List<long>(new long[]{(long)7L, (long)3L, (long)4L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> Solve((\"1234\"))\n    // (\"4321\")\n    // >>> Solve((\"ab\"))\n    // (\"AB\")\n    // >>> Solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static string Solve(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((\"AsDf\")).Equals((\"aSdF\")));\n    Debug.Assert(Solve((\"1234\")).Equals((\"4321\")));\n    Debug.Assert(Solve((\"ab\")).Equals((\"AB\")));\n    Debug.Assert(Solve((\"#a@C\")).Equals((\"#A@c\")));\n    Debug.Assert(Solve((\"#AsdfW^45\")).Equals((\"#aSDFw^45\")));\n    Debug.Assert(Solve((\"#6@2\")).Equals((\"2@6#\")));\n    Debug.Assert(Solve((\"#$a^D\")).Equals((\"#$A^d\")));\n    Debug.Assert(Solve((\"#ccc\")).Equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> StringToMd5((\"Hello world\"))\n    // (\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static string StringToMd5(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToMd5((\"Hello world\")).Equals((\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    Debug.Assert(StringToMd5((\"\")).Equals(null));\n    Debug.Assert(StringToMd5((\"A B C\")).Equals((\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    Debug.Assert(StringToMd5((\"password\")).Equals((\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1804,7 +808,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> GenerateIntegers((2L), (8L))\n    // (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))\n    // >>> GenerateIntegers((8L), (2L))\n    // (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))\n    // >>> GenerateIntegers((10L), (14L))\n    // (new List<long>())\n    public static List<long> GenerateIntegers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GenerateIntegers((2L), (10L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((10L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((132L), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(GenerateIntegers((17L), (89L)).Equals((new List<long>())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1812,49 +816,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L}))\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> CountDistinctCharacters((\"xyzXYZ\"))\n    // (3L)\n    // >>> CountDistinctCharacters((\"Jerry\"))\n    // (4L)\n    public static long CountDistinctCharacters(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDistinctCharacters((\"\")) == (0L));\n    Debug.Assert(CountDistinctCharacters((\"abcde\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"abcdecadeCADE\")) == (5L));\n    Debug.Assert(CountDistinctCharacters((\"aaaaAAAAaaaa\")) == (1L));\n    Debug.Assert(CountDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (false)\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L})))\n    // (true)\n    public static bool BelowZero(List<long> operations) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> ParseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new List<long>(new long[]{(long)4L, (long)2L, (long)1L, (long)2L, (long)2L, (long)1L, (long)1L, (long)1L, (long)1L, (long)4L, (long)4L}))\n    public static List<long> ParseMusic(string music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseMusic((\"\")).Equals((new List<long>())));\n    Debug.Assert(ParseMusic((\"o o o o\")).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\".| .| .| .|\")).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L}))));\n    Debug.Assert(ParseMusic((\"o| o| .| .| o o o o\")).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)1L, (long)1L, (long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(ParseMusic((\"o| .| o| .| o o| o o|\")).Equals((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)1L, (long)4L, (long)2L, (long)4L, (long)2L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> Search((new List<long>(new long[]{(long)4L, (long)1L, (long)2L, (long)2L, (long)3L, (long)1L})))\n    // (2L)\n    // >>> Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L, (long)4L})))\n    // (3L)\n    // >>> Search((new List<long>(new long[]{(long)5L, (long)5L, (long)4L, (long)4L, (long)4L})))\n    // (-1L)\n    public static long Search(List<long> lst) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> HowManyTimes((\"\"), (\"a\"))\n    // (0L)\n    // >>> HowManyTimes((\"aaa\"), (\"a\"))\n    // (3L)\n    // >>> HowManyTimes((\"aaaa\"), (\"aa\"))\n    // (3L)\n    public static long HowManyTimes(string str, string substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HowManyTimes((\"\"), (\"x\")) == (0L));\n    Debug.Assert(HowManyTimes((\"xyxyxyx\"), (\"x\")) == (4L));\n    Debug.Assert(HowManyTimes((\"cacacacac\"), (\"cac\")) == (4L));\n    Debug.Assert(HowManyTimes((\"john doe\"), (\"john\")) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"(\"))\n    // (false)\n    // >>> CorrectBracketing((\"()\"))\n    // (true)\n    // >>> CorrectBracketing((\"(()())\"))\n    // (true)\n    // >>> CorrectBracketing((\")(()\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> SortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static string SortNumbers(string numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumbers((\"\")).Equals((\"\")));\n    Debug.Assert(SortNumbers((\"three\")).Equals((\"three\")));\n    Debug.Assert(SortNumbers((\"three five nine\")).Equals((\"three five nine\")));\n    Debug.Assert(SortNumbers((\"five zero four seven nine eight\")).Equals((\"zero four five seven eight nine\")));\n    Debug.Assert(SortNumbers((\"six five four three two one zero\")).Equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> SeparateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))\n    public static List<string> SeparateParenGroups(string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SeparateParenGroups((\"(()()) ((())) () ((())()())\")).Equals((new List<string>(new string[]{(string)\"(()())\", (string)\"((()))\", (string)\"()\", (string)\"((())()())\"}))));\n    Debug.Assert(SeparateParenGroups((\"() (()) ((())) (((())))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"((()))\", (string)\"(((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"(()(())((())))\")).Equals((new List<string>(new string[]{(string)\"(()(())((())))\"}))));\n    Debug.Assert(SeparateParenGroups((\"( ) (( )) (( )( ))\")).Equals((new List<string>(new string[]{(string)\"()\", (string)\"(())\", (string)\"(()())\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f})))\n    // (Tuple.Create(2.0f, 2.2f))\n    // >>> FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f})))\n    // (Tuple.Create(2.0f, 2.0f))\n    public static Tuple<float, float> FindClosestElements(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(3.9f, 4.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f}))).Equals((Tuple.Create(5.0f, 5.9f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f}))).Equals((Tuple.Create(2.0f, 2.2f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f}))).Equals((Tuple.Create(2.0f, 2.0f))));\n    Debug.Assert(FindClosestElements((new List<float>(new float[]{(float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f}))).Equals((Tuple.Create(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f})))\n    // (new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))\n    public static List<float> RescaleToUnit(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)100.0f, (float)49.9f}))).Equals((new List<float>(new float[]{(float)1.0f, (float)0.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))).Equals((new List<float>(new float[]{(float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    Debug.Assert(RescaleToUnit((new List<float>(new float[]{(float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f}))).Equals((new List<float>(new float[]{(float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> FilterIntegers((new List<object>(new string[]{(string)\"a\", (string)3.14f, (string)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> FilterIntegers((new List<object>(new object[]{1L, 2L, 3L, \"abc\", new List<object>()})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    public static List<long> FilterIntegers(List<object> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterIntegers((new List<object>())).Equals((new List<long>())));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{4L, new List<object>(), 23.2f, 9L, \"adasd\"}))).Equals((new List<long>(new long[]{(long)4L, (long)9L}))));\n    Debug.Assert(FilterIntegers((new List<object>(new object[]{3L, \"c\", 3L, 3L, \"a\", \"b\"}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return length of given string\n    // >>> StringLength((\"\"))\n    // (0L)\n    // >>> StringLength((\"abc\"))\n    // (3L)\n    public static long Strlen(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Strlen((\"\")) == (0L));\n    Debug.Assert(Strlen((\"x\")) == (1L));\n    Debug.Assert(Strlen((\"asdasnakj\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> LargestDivisor((15L))\n    // (5L)\n    public static long LargestDivisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestDivisor((3L)) == (1L));\n    Debug.Assert(LargestDivisor((7L)) == (1L));\n    Debug.Assert(LargestDivisor((10L)) == (5L));\n    Debug.Assert(LargestDivisor((100L)) == (50L));\n    Debug.Assert(LargestDivisor((49L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> Factorize((8L))\n    // (new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))\n    // >>> Factorize((25L))\n    // (new List<long>(new long[]{(long)5L, (long)5L}))\n    // >>> Factorize((70L))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)7L}))\n    public static List<long> Factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Factorize((2L)).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(Factorize((4L)).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Factorize((8L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(Factorize((57L)).Equals((new List<long>(new long[]{(long)3L, (long)19L}))));\n    Debug.Assert(Factorize((3249L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((185193L)).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((20577L)).Equals((new List<long>(new long[]{(long)3L, (long)19L, (long)19L, (long)19L}))));\n    Debug.Assert(Factorize((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)3L, (long)4L}))\n    public static List<long> RemoveDuplicates(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDuplicates((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RemoveDuplicates((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)3L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> FlipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static string FlipCase(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FlipCase((\"\")).Equals((\"\")));\n    Debug.Assert(FlipCase((\"Hello!\")).Equals((\"hELLO!\")));\n    Debug.Assert(FlipCase((\"These violent delights have violent ends\")).Equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> Concatenate((new List<string>()))\n    // (\"\")\n    // >>> Concatenate((new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})))\n    // (\"abc\")\n    public static string Concatenate(List<string> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Concatenate((new List<string>())).Equals((\"\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}))).Equals((\"xyz\")));\n    Debug.Assert(Concatenate((new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\", (string)\"w\", (string)\"k\"}))).Equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> FilterByPrefix((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterByPrefix((new List<string>(new string[]{(string)\"abc\", (string)\"bcd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"array\"}))\n    public static List<string> FilterByPrefix(List<string> strings, string prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterByPrefix((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterByPrefix((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> TruncateNumber((3.5f))\n    // (0.5f)\n    public static float TruncateNumber(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TruncateNumber((3.5f)) == (0.5f));\n    Debug.Assert(TruncateNumber((1.25f)) == (0.25f));\n    Debug.Assert(TruncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> GetPositive((new List<long>(new long[]{(long)-1L, (long)2L, (long)-4L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)2L, (long)5L, (long)6L}))\n    // >>> GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)9L, (long)123L, (long)1L}))\n    public static List<long> GetPositive(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)3L, (long)3L, (long)9L, (long)123L, (long)1L}))));\n    Debug.Assert(GetPositive((new List<long>(new long[]{(long)-1L, (long)-2L}))).Equals((new List<long>())));\n    Debug.Assert(GetPositive((new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> IsPrime((6L))\n    // (false)\n    // >>> IsPrime((101L))\n    // (true)\n    // >>> IsPrime((11L))\n    // (true)\n    // >>> IsPrime((13441L))\n    // (true)\n    // >>> IsPrime((61L))\n    // (true)\n    // >>> IsPrime((4L))\n    // (false)\n    // >>> IsPrime((1L))\n    // (false)\n    public static bool IsPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPrime((6L)) == (false));\n    Debug.Assert(IsPrime((101L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((13441L)) == (true));\n    Debug.Assert(IsPrime((61L)) == (true));\n    Debug.Assert(IsPrime((4L)) == (false));\n    Debug.Assert(IsPrime((1L)) == (false));\n    Debug.Assert(IsPrime((5L)) == (true));\n    Debug.Assert(IsPrime((11L)) == (true));\n    Debug.Assert(IsPrime((17L)) == (true));\n    Debug.Assert(IsPrime((85L)) == (false));\n    Debug.Assert(IsPrime((77L)) == (false));\n    Debug.Assert(IsPrime((255379L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> SortThird((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))\n    public static List<long> SortThird(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)8L, (long)3L, (long)4L, (long)6L, (long)9L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)9L, (long)4L, (long)8L, (long)3L, (long)5L}))));\n    Debug.Assert(SortThird((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L, (long)3L, (long)4L, (long)8L, (long)9L, (long)5L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))\n    public static List<long> Unique(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Unique((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)0L, (long)2L, (long)3L, (long)5L, (long)9L, (long)123L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (3L)\n    // >>> MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L})))\n    // (123L)\n    public static long MaxElement(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(MaxElement((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)124L, (long)1L, (long)-10L}))) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> FizzBuzz((50L))\n    // (0L)\n    // >>> FizzBuzz((78L))\n    // (2L)\n    // >>> FizzBuzz((79L))\n    // (3L)\n    public static long FizzBuzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FizzBuzz((50L)) == (0L));\n    Debug.Assert(FizzBuzz((78L)) == (2L));\n    Debug.Assert(FizzBuzz((79L)) == (3L));\n    Debug.Assert(FizzBuzz((100L)) == (3L));\n    Debug.Assert(FizzBuzz((200L)) == (6L));\n    Debug.Assert(FizzBuzz((4000L)) == (192L));\n    Debug.Assert(FizzBuzz((10000L)) == (639L));\n    Debug.Assert(FizzBuzz((100000L)) == (8026L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1864,9 +1084,201 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))\n    // >>> SortEven((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)3L, (long)6L, (long)5L, (long)4L}))\n    public static List<long> SortEven(List<long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)9L, (long)0L, (long)123L, (long)1L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-10L, (long)3L, (long)-5L, (long)2L, (long)-3L, (long)3L, (long)5L, (long)0L, (long)9L, (long)1L, (long)123L}))));\n    Debug.Assert(SortEven((new List<long>(new long[]{(long)5L, (long)8L, (long)-12L, (long)4L, (long)23L, (long)2L, (long)3L, (long)11L, (long)12L, (long)-10L}))).Equals((new List<long>(new long[]{(long)-12L, (long)8L, (long)3L, (long)4L, (long)5L, (long)2L, (long)12L, (long)11L, (long)23L, (long)-10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> PrimeFib((1L))\n    // (2L)\n    // >>> PrimeFib((2L))\n    // (3L)\n    // >>> PrimeFib((3L))\n    // (5L)\n    // >>> PrimeFib((4L))\n    // (13L)\n    // >>> PrimeFib((5L))\n    // (89L)\n    public static long PrimeFib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeFib((1L)) == (2L));\n    Debug.Assert(PrimeFib((2L)) == (3L));\n    Debug.Assert(PrimeFib((3L)) == (5L));\n    Debug.Assert(PrimeFib((4L)) == (13L));\n    Debug.Assert(PrimeFib((5L)) == (89L));\n    Debug.Assert(PrimeFib((6L)) == (233L));\n    Debug.Assert(PrimeFib((7L)) == (1597L));\n    Debug.Assert(PrimeFib((8L)) == (28657L));\n    Debug.Assert(PrimeFib((9L)) == (514229L));\n    Debug.Assert(PrimeFib((10L)) == (433494437L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (false)\n    // >>> BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L})))\n    // (true)\n    public static bool BelowZero(List<long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowZero((new List<long>())) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-3L, (long)1L, (long)2L, (long)-3L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)2L, (long)-4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (false));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-1L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-5L}))) == (true));\n    Debug.Assert(BelowZero((new List<long>(new long[]{(long)1L, (long)-2L, (long)2L, (long)-2L, (long)5L, (long)-5L, (long)4L, (long)-4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L})))\n    // (true)\n    // >>> TriplesSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool TriplesSumToZero(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)7L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)9L, (long)7L}))) == (true));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    Debug.Assert(TriplesSumToZero((new List<long>(new long[]{(long)100L, (long)3L, (long)5L, (long)-100L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long CarRaceCollision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CarRaceCollision((2L)) == (4L));\n    Debug.Assert(CarRaceCollision((3L)) == (9L));\n    Debug.Assert(CarRaceCollision((4L)) == (16L));\n    Debug.Assert(CarRaceCollision((8L)) == (64L));\n    Debug.Assert(CarRaceCollision((10L)) == (100L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> IncrList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))\n    // >>> IncrList((new List<long>(new long[]{(long)5L, (long)3L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L})))\n    // (new List<long>(new long[]{(long)6L, (long)4L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))\n    public static List<long> IncrList(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IncrList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L}))));\n    Debug.Assert(IncrList((new List<long>(new long[]{(long)5L, (long)2L, (long)5L, (long)2L, (long)3L, (long)3L, (long)9L, (long)0L, (long)123L}))).Equals((new List<long>(new long[]{(long)6L, (long)3L, (long)6L, (long)3L, (long)4L, (long)4L, (long)10L, (long)1L, (long)124L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L})))\n    // (false)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L})))\n    // (true)\n    // >>> PairsSumToZero((new List<long>(new long[]{(long)1L})))\n    // (false)\n    public static bool PairsSumToZero(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)0L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)3L, (long)-2L, (long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)7L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)2L, (long)4L, (long)-5L, (long)3L, (long)5L, (long)7L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)1L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)30L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)3L, (long)2L, (long)31L}))) == (true));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)30L}))) == (false));\n    Debug.Assert(PairsSumToZero((new List<long>(new long[]{(long)-3L, (long)9L, (long)-1L, (long)4L, (long)2L, (long)31L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> ChangeBase((8L), (3L))\n    // (\"22\")\n    // >>> ChangeBase((8L), (2L))\n    // (\"1000\")\n    // >>> ChangeBase((7L), (2L))\n    // (\"111\")\n    public static string ChangeBase(long x, long numBase) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeBase((8L), (3L)).Equals((\"22\")));\n    Debug.Assert(ChangeBase((9L), (3L)).Equals((\"100\")));\n    Debug.Assert(ChangeBase((234L), (2L)).Equals((\"11101010\")));\n    Debug.Assert(ChangeBase((16L), (2L)).Equals((\"10000\")));\n    Debug.Assert(ChangeBase((8L), (2L)).Equals((\"1000\")));\n    Debug.Assert(ChangeBase((7L), (2L)).Equals((\"111\")));\n    Debug.Assert(ChangeBase((2L), (3L)).Equals((\"2\")));\n    Debug.Assert(ChangeBase((3L), (4L)).Equals((\"3\")));\n    Debug.Assert(ChangeBase((4L), (5L)).Equals((\"4\")));\n    Debug.Assert(ChangeBase((5L), (6L)).Equals((\"5\")));\n    Debug.Assert(ChangeBase((6L), (7L)).Equals((\"6\")));\n    Debug.Assert(ChangeBase((7L), (8L)).Equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> TriangleArea((5L), (3L))\n    // (7.5f)\n    public static float TriangleArea(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((5L), (3L)) == (7.5f));\n    Debug.Assert(TriangleArea((2L), (2L)) == (2.0f));\n    Debug.Assert(TriangleArea((10L), (8L)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> Fib4((5L))\n    // (4L)\n    // >>> Fib4((6L))\n    // (8L)\n    // >>> Fib4((7L))\n    // (14L)\n    public static long Fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib4((5L)) == (4L));\n    Debug.Assert(Fib4((8L)) == (28L));\n    Debug.Assert(Fib4((10L)) == (104L));\n    Debug.Assert(Fib4((12L)) == (386L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (float)3L\n    // >>> Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L})))\n    // (15.0f)\n    public static float Median(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Median((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))) == (float)3L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)-10L, (long)4L, (long)6L, (long)1000L, (long)10L, (long)20L}))) == (8.0f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)5L}))) == (float)5L);\n    Debug.Assert(Median((new List<long>(new long[]{(long)6L, (long)5L}))) == (5.5f));\n    Debug.Assert(Median((new List<long>(new long[]{(long)8L, (long)1L, (long)3L, (long)9L, (long)9L, (long)2L, (long)7L}))) == (float)7L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> IsPalindrome((\"\"))\n    // (true)\n    // >>> IsPalindrome((\"aba\"))\n    // (true)\n    // >>> IsPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> IsPalindrome((\"zbcd\"))\n    // (false)\n    public static bool IsPalindrome(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPalindrome((\"\")) == (true));\n    Debug.Assert(IsPalindrome((\"aba\")) == (true));\n    Debug.Assert(IsPalindrome((\"aaaaa\")) == (true));\n    Debug.Assert(IsPalindrome((\"zbcd\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywyx\")) == (true));\n    Debug.Assert(IsPalindrome((\"xywyz\")) == (false));\n    Debug.Assert(IsPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> Modp((3L), (5L))\n    // (3L)\n    // >>> Modp((1101L), (101L))\n    // (2L)\n    // >>> Modp((0L), (101L))\n    // (1L)\n    // >>> Modp((3L), (11L))\n    // (8L)\n    // >>> Modp((100L), (101L))\n    // (1L)\n    public static long Modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Modp((3L), (5L)) == (3L));\n    Debug.Assert(Modp((1101L), (101L)) == (2L));\n    Debug.Assert(Modp((0L), (101L)) == (1L));\n    Debug.Assert(Modp((3L), (11L)) == (8L));\n    Debug.Assert(Modp((100L), (101L)) == (1L));\n    Debug.Assert(Modp((30L), (5L)) == (4L));\n    Debug.Assert(Modp((31L), (5L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f})))\n    // (1.0f)\n    public static float MeanAbsoluteDeviation(List<float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f}))) == (0.5f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f}))) == (1.0f));\n    Debug.Assert(MeanAbsoluteDeviation((new List<float>(new float[]{(float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f}))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> RemoveVowels((\"\"))\n    // (\"\")\n    // >>> RemoveVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> RemoveVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> RemoveVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> RemoveVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static string RemoveVowels(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveVowels((\"\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"abcdef\\nghijklm\")).Equals((\"bcdf\\nghjklm\")));\n    Debug.Assert(RemoveVowels((\"fedcba\")).Equals((\"fdcb\")));\n    Debug.Assert(RemoveVowels((\"eeeee\")).Equals((\"\")));\n    Debug.Assert(RemoveVowels((\"acBAA\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"EcBOO\")).Equals((\"cB\")));\n    Debug.Assert(RemoveVowels((\"ybcd\")).Equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L))\n    // (true)\n    // >>> BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L))\n    // (false)\n    public static bool BelowThreshold(List<long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L})), (100L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (5L)) == (false));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (21L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})), (22L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (11L)) == (true));\n    Debug.Assert(BelowThreshold((new List<long>(new long[]{(long)1L, (long)8L, (long)4L, (long)10L})), (10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Add two numbers x and y\n    // >>> Add((2L), (3L))\n    // (5L)\n    // >>> Add((5L), (7L))\n    // (12L)\n    public static long Add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((0L), (1L)) == (1L));\n    Debug.Assert(Add((1L), (0L)) == (1L));\n    Debug.Assert(Add((2L), (3L)) == (5L));\n    Debug.Assert(Add((5L), (7L)) == (12L));\n    Debug.Assert(Add((7L), (5L)) == (12L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,9 +1288,21 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> SameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> SameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> SameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> SameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    public static bool SameChars(string s0, string s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    Debug.Assert(SameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    Debug.Assert(SameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    Debug.Assert(SameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    Debug.Assert(SameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    Debug.Assert(SameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> Fib((10L))\n    // (55L)\n    // >>> Fib((1L))\n    // (1L)\n    // >>> Fib((8L))\n    // (21L)\n    public static long Fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fib((10L)) == (55L));\n    Debug.Assert(Fib((1L)) == (1L));\n    Debug.Assert(Fib((8L)) == (21L));\n    Debug.Assert(Fib((11L)) == (89L));\n    Debug.Assert(Fib((12L)) == (144L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1312,585 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"<\"))\n    // (false)\n    // >>> CorrectBracketing((\"<>\"))\n    // (true)\n    // >>> CorrectBracketing((\"<<><>>\"))\n    // (true)\n    // >>> CorrectBracketing((\"><<>\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"<>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<><>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    Debug.Assert(CorrectBracketing((\"<<<><>>>>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<<<\")) == (false));\n    Debug.Assert(CorrectBracketing((\">\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>><<>\")) == (false));\n    Debug.Assert(CorrectBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L})))\n    // (true)\n    // >>> Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L})))\n    // (false)\n    // >>> Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L})))\n    // (true)\n    public static bool Monotonic(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)20L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)20L, (long)4L, (long)10L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)0L, (long)-10L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)4L, (long)1L, (long)1L, (long)0L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)5L, (long)60L}))) == (false));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)60L}))) == (true));\n    Debug.Assert(Monotonic((new List<long>(new long[]{(long)9L, (long)9L, (long)9L, (long)9L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L})))\n    // (new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))\n    // >>> Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L})))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    public static List<long> Common(List<long> l1, List<long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Common((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)34L, (long)653L, (long)2L, (long)5L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)1L, (long)5L, (long)9L, (long)653L, (long)121L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)653L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>(new long[]{(long)3L, (long)2L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(Common((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)8L})), (new List<long>())).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> LargestPrimeFactor((13195L))\n    // (29L)\n    // >>> LargestPrimeFactor((2048L))\n    // (2L)\n    public static long LargestPrimeFactor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestPrimeFactor((15L)) == (5L));\n    Debug.Assert(LargestPrimeFactor((27L)) == (3L));\n    Debug.Assert(LargestPrimeFactor((63L)) == (7L));\n    Debug.Assert(LargestPrimeFactor((330L)) == (11L));\n    Debug.Assert(LargestPrimeFactor((13195L)) == (29L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> Intersperse((new List<long>()), (4L))\n    // (new List<long>())\n    // >>> Intersperse((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)4L, (long)3L}))\n    public static List<long> Intersperse(List<long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Intersperse((new List<long>()), (7L)).Equals((new List<long>())));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)5L, (long)6L, (long)3L, (long)2L})), (8L)).Equals((new List<long>(new long[]{(long)5L, (long)8L, (long)6L, (long)8L, (long)3L, (long)8L, (long)2L}))));\n    Debug.Assert(Intersperse((new List<long>(new long[]{(long)2L, (long)2L, (long)2L})), (2L)).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)2L, (long)2L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> SumToN((30L))\n    // (465L)\n    // >>> SumToN((100L))\n    // (5050L)\n    // >>> SumToN((5L))\n    // (15L)\n    // >>> SumToN((10L))\n    // (55L)\n    // >>> SumToN((1L))\n    // (1L)\n    public static long SumToN(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumToN((1L)) == (1L));\n    Debug.Assert(SumToN((6L)) == (21L));\n    Debug.Assert(SumToN((11L)) == (66L));\n    Debug.Assert(SumToN((30L)) == (465L));\n    Debug.Assert(SumToN((100L)) == (5050L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> CorrectBracketing((\"(\"))\n    // (false)\n    // >>> CorrectBracketing((\"()\"))\n    // (true)\n    // >>> CorrectBracketing((\"(()())\"))\n    // (true)\n    // >>> CorrectBracketing((\")(()\"))\n    // (false)\n    public static bool CorrectBracketing(string brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CorrectBracketing((\"()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"(()())\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()(()())()\")) == (true));\n    Debug.Assert(CorrectBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    Debug.Assert(CorrectBracketing((\"((()())))\")) == (false));\n    Debug.Assert(CorrectBracketing((\")(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(\")) == (false));\n    Debug.Assert(CorrectBracketing((\"((((\")) == (false));\n    Debug.Assert(CorrectBracketing((\")\")) == (false));\n    Debug.Assert(CorrectBracketing((\"(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())())(()\")) == (false));\n    Debug.Assert(CorrectBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))\n    // >>> Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)6L}))\n    public static List<long> Derivative(List<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)1L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)12L, (long)20L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)6L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)3L, (long)2L, (long)1L, (long)0L, (long)4L}))).Equals((new List<long>(new long[]{(long)2L, (long)2L, (long)0L, (long)16L}))));\n    Debug.Assert(Derivative((new List<long>(new long[]{(long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> Fibfib((1L))\n    // (0L)\n    // >>> Fibfib((5L))\n    // (4L)\n    // >>> Fibfib((8L))\n    // (24L)\n    public static long Fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Fibfib((2L)) == (1L));\n    Debug.Assert(Fibfib((1L)) == (0L));\n    Debug.Assert(Fibfib((5L)) == (4L));\n    Debug.Assert(Fibfib((8L)) == (24L));\n    Debug.Assert(Fibfib((10L)) == (81L));\n    Debug.Assert(Fibfib((12L)) == (274L));\n    Debug.Assert(Fibfib((14L)) == (927L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> VowelsCount((\"abcde\"))\n    // (2L)\n    // >>> VowelsCount((\"ACEDY\"))\n    // (3L)\n    public static long VowelsCount(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VowelsCount((\"abcde\")) == (2L));\n    Debug.Assert(VowelsCount((\"Alone\")) == (3L));\n    Debug.Assert(VowelsCount((\"key\")) == (2L));\n    Debug.Assert(VowelsCount((\"bye\")) == (1L));\n    Debug.Assert(VowelsCount((\"keY\")) == (2L));\n    Debug.Assert(VowelsCount((\"bYe\")) == (1L));\n    Debug.Assert(VowelsCount((\"ACEDY\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> CircularShift((12L), (1L))\n    // (\"21\")\n    // >>> CircularShift((12L), (2L))\n    // (\"12\")\n    public static string CircularShift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CircularShift((100L), (2L)).Equals((\"001\")));\n    Debug.Assert(CircularShift((12L), (2L)).Equals((\"12\")));\n    Debug.Assert(CircularShift((97L), (8L)).Equals((\"79\")));\n    Debug.Assert(CircularShift((12L), (1L)).Equals((\"21\")));\n    Debug.Assert(CircularShift((11L), (101L)).Equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> Digitsum((\"\"))\n    // (0L)\n    // >>> Digitsum((\"abAB\"))\n    // (131L)\n    // >>> Digitsum((\"abcCd\"))\n    // (67L)\n    // >>> Digitsum((\"helloE\"))\n    // (69L)\n    // >>> Digitsum((\"woArBld\"))\n    // (131L)\n    // >>> Digitsum((\"aAaaaXa\"))\n    // (153L)\n    public static long Digitsum(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Digitsum((\"\")) == (0L));\n    Debug.Assert(Digitsum((\"abAB\")) == (131L));\n    Debug.Assert(Digitsum((\"abcCd\")) == (67L));\n    Debug.Assert(Digitsum((\"helloE\")) == (69L));\n    Debug.Assert(Digitsum((\"woArBld\")) == (131L));\n    Debug.Assert(Digitsum((\"aAaaaXa\")) == (153L));\n    Debug.Assert(Digitsum((\" How are yOu?\")) == (151L));\n    Debug.Assert(Digitsum((\"You arE Very Smart\")) == (327L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> FruitDistribution((\"5 apples and 6 oranges\"), (19L))\n    // (8L)\n    // >>> FruitDistribution((\"0 apples and 1 oranges\"), (3L))\n    // (2L)\n    // >>> FruitDistribution((\"2 apples and 3 oranges\"), (100L))\n    // (95L)\n    // >>> FruitDistribution((\"100 apples and 1 oranges\"), (120L))\n    // (19L)\n    public static long FruitDistribution(string s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (19L)) == (8L));\n    Debug.Assert(FruitDistribution((\"5 apples and 6 oranges\"), (21L)) == (10L));\n    Debug.Assert(FruitDistribution((\"0 apples and 1 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"1 apples and 0 oranges\"), (3L)) == (2L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (100L)) == (95L));\n    Debug.Assert(FruitDistribution((\"2 apples and 3 oranges\"), (5L)) == (0L));\n    Debug.Assert(FruitDistribution((\"1 apples and 100 oranges\"), (120L)) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})))\n    // (new List<long>(new long[]{(long)2L, (long)1L}))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> Pluck((new List<long>()))\n    // (new List<long>())\n    // Example 4:\n    // >>> Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L}))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static List<long> Pluck(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)4L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)0L, (long)3L, (long)0L, (long)4L, (long)2L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)0L, (long)5L, (long)3L}))).Equals((new List<long>(new long[]{(long)0L, (long)3L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)5L, (long)4L, (long)8L, (long)4L, (long)8L}))).Equals((new List<long>(new long[]{(long)4L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)6L, (long)1L}))));\n    Debug.Assert(Pluck((new List<long>(new long[]{(long)7L, (long)9L, (long)7L, (long)1L}))).Equals((new List<long>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> Search((new List<long>(new long[]{(long)4L, (long)1L, (long)2L, (long)2L, (long)3L, (long)1L})))\n    // (2L)\n    // >>> Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L, (long)4L})))\n    // (3L)\n    // >>> Search((new List<long>(new long[]{(long)5L, (long)5L, (long)4L, (long)4L, (long)4L})))\n    // (-1L)\n    public static long Search(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)4L, (long)1L, (long)4L, (long)1L, (long)4L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)3L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)3L, (long)3L, (long)2L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)7L, (long)8L, (long)8L, (long)4L, (long)8L, (long)7L, (long)3L, (long)9L, (long)6L, (long)5L, (long)10L, (long)4L, (long)3L, (long)6L, (long)7L, (long)1L, (long)7L, (long)4L, (long)10L, (long)8L, (long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)2L, (long)8L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)7L, (long)1L, (long)8L, (long)8L, (long)10L, (long)5L, (long)8L, (long)5L, (long)3L, (long)10L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)3L, (long)6L, (long)5L, (long)6L, (long)4L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)6L, (long)7L, (long)1L, (long)4L, (long)7L, (long)1L, (long)8L, (long)8L, (long)9L, (long)8L, (long)10L, (long)10L, (long)8L, (long)4L, (long)10L, (long)4L, (long)10L, (long)1L, (long)2L, (long)9L, (long)5L, (long)7L, (long)9L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)9L, (long)10L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)6L, (long)9L, (long)7L, (long)5L, (long)8L, (long)7L, (long)5L, (long)3L, (long)7L, (long)5L, (long)10L, (long)10L, (long)3L, (long)6L, (long)10L, (long)2L, (long)8L, (long)6L, (long)5L, (long)4L, (long)9L, (long)5L, (long)3L, (long)10L}))) == (5L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)8L, (long)8L, (long)10L, (long)6L, (long)4L, (long)3L, (long)5L, (long)8L, (long)2L, (long)4L, (long)2L, (long)8L, (long)4L, (long)6L, (long)10L, (long)4L, (long)2L, (long)1L, (long)10L, (long)2L, (long)1L, (long)1L, (long)5L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)8L, (long)2L, (long)10L, (long)5L, (long)1L, (long)2L, (long)9L, (long)5L, (long)5L, (long)6L, (long)3L, (long)8L, (long)6L, (long)4L, (long)10L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)6L, (long)10L, (long)1L, (long)6L, (long)9L, (long)10L, (long)8L, (long)6L, (long)8L, (long)7L, (long)3L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)2L, (long)4L, (long)1L, (long)5L, (long)1L, (long)5L, (long)2L, (long)5L, (long)7L, (long)7L, (long)7L, (long)3L, (long)10L, (long)1L, (long)5L, (long)4L, (long)2L, (long)8L, (long)4L, (long)1L, (long)9L, (long)10L, (long)7L, (long)10L, (long)2L, (long)8L, (long)10L, (long)9L, (long)4L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)2L, (long)6L, (long)4L, (long)2L, (long)8L, (long)7L, (long)5L, (long)6L, (long)4L, (long)10L, (long)4L, (long)6L, (long)3L, (long)7L, (long)8L, (long)8L, (long)3L, (long)1L, (long)4L, (long)2L, (long)2L, (long)10L, (long)7L}))) == (4L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)8L, (long)6L, (long)10L, (long)2L, (long)6L, (long)10L, (long)2L, (long)7L, (long)8L, (long)10L, (long)3L, (long)8L, (long)2L, (long)6L, (long)2L, (long)3L, (long)1L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)5L, (long)3L, (long)9L, (long)5L, (long)6L, (long)3L, (long)2L, (long)8L, (long)5L, (long)6L, (long)10L, (long)10L, (long)6L, (long)8L, (long)4L, (long)10L, (long)7L, (long)7L, (long)10L, (long)8L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)10L}))) == (-1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)9L, (long)7L, (long)7L, (long)2L, (long)4L, (long)7L, (long)2L, (long)10L, (long)9L, (long)7L, (long)5L, (long)7L, (long)2L}))) == (2L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)5L, (long)4L, (long)10L, (long)2L, (long)1L, (long)1L, (long)10L, (long)3L, (long)6L, (long)1L, (long)8L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)7L, (long)9L, (long)9L, (long)9L, (long)3L, (long)4L, (long)1L, (long)5L, (long)9L, (long)1L, (long)2L, (long)1L, (long)1L, (long)10L, (long)7L, (long)5L, (long)6L, (long)7L, (long)6L, (long)7L, (long)7L, (long)6L}))) == (1L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)3L, (long)10L, (long)10L, (long)9L, (long)2L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> ParseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))\n    public static List<long> ParseNestedParens(string paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParseNestedParens((\"(()()) ((())) () ((())()())\")).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L, (long)3L}))));\n    Debug.Assert(ParseNestedParens((\"() (()) ((())) (((())))\")).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(ParseNestedParens((\"(()(())((())))\")).Equals((new List<long>(new long[]{(long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))\n    // >>> StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L})))\n    // (new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))\n    // >>> StrangeSortList((new List<long>()))\n    // (new List<long>())\n    public static List<long> StrangeSortList(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)2L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)5L, (long)9L, (long)6L, (long)8L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)2L, (long)4L, (long)3L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)9L, (long)5L, (long)8L, (long)6L, (long)7L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))).Equals((new List<long>(new long[]{(long)5L, (long)5L, (long)5L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)2L, (long)7L, (long)3L, (long)6L, (long)4L, (long)5L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)0L, (long)2L, (long)2L, (long)2L, (long)5L, (long)5L, (long)-5L, (long)-5L}))).Equals((new List<long>(new long[]{(long)-5L, (long)5L, (long)-5L, (long)5L, (long)0L, (long)2L, (long)2L, (long)2L}))));\n    Debug.Assert(StrangeSortList((new List<long>(new long[]{(long)111111L}))).Equals((new List<long>(new long[]{(long)111111L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> TriangleArea((3L), (4L), (5L))\n    // (6.0f)\n    // >>> TriangleArea((1L), (2L), (10L))\n    // (float)-1L\n    public static float TriangleArea(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((3L), (4L), (5L)) == (6.0f));\n    Debug.Assert(TriangleArea((1L), (2L), (10L)) == (float)-1L);\n    Debug.Assert(TriangleArea((4L), (8L), (5L)) == (8.18f));\n    Debug.Assert(TriangleArea((2L), (2L), (2L)) == (1.73f));\n    Debug.Assert(TriangleArea((1L), (2L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((10L), (5L), (7L)) == (16.25f));\n    Debug.Assert(TriangleArea((2L), (6L), (3L)) == (float)-1L);\n    Debug.Assert(TriangleArea((1L), (1L), (1L)) == (0.43f));\n    Debug.Assert(TriangleArea((2L), (2L), (10L)) == (float)-1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> WillItFly((new List<long>(new long[]{(long)3L})), (5L))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static bool WillItFly(List<long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (9L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L})), (5L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L})), (5L)) == (true));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)3L, (long)2L, (long)3L})), (1L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (6L)) == (false));\n    Debug.Assert(WillItFly((new List<long>(new long[]{(long)5L})), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L})))\n    // (4L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L})))\n    // (1L)\n    // >>> SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L})))\n    // (0L)\n    public static long SmallestChange(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)4L, (long)7L, (long)9L, (long)6L}))) == (4L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)4L, (long)4L, (long)2L}))) == (1L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)3L, (long)1L, (long)1L, (long)3L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)1L}))) == (0L));\n    Debug.Assert(SmallestChange((new List<long>(new long[]{(long)0L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> TotalMatch((new List<string>()), (new List<string>()))\n    // (new List<string>())\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"})))\n    // (new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"})))\n    // (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))\n    // >>> TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"})))\n    // (new List<string>(new string[]{(string)\"4\"}))\n    public static List<string> TotalMatch(List<string> lst1, List<string> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>())).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hi\", (string)\"hi\", (string)\"admin\", (string)\"project\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"4\"})), (new List<string>(new string[]{(string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"5\"}))).Equals((new List<string>(new string[]{(string)\"4\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"Hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))).Equals((new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hi\"}))));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"})), (new List<string>(new string[]{(string)\"hI\", (string)\"hi\", (string)\"hii\"}))).Equals((new List<string>(new string[]{(string)\"hi\", (string)\"admin\"}))));\n    Debug.Assert(TotalMatch((new List<string>()), (new List<string>(new string[]{(string)\"this\"}))).Equals((new List<string>())));\n    Debug.Assert(TotalMatch((new List<string>(new string[]{(string)\"this\"})), (new List<string>())).Equals((new List<string>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> IsMultiplyPrime((30L))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static bool IsMultiplyPrime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMultiplyPrime((5L)) == (false));\n    Debug.Assert(IsMultiplyPrime((30L)) == (true));\n    Debug.Assert(IsMultiplyPrime((8L)) == (true));\n    Debug.Assert(IsMultiplyPrime((10L)) == (false));\n    Debug.Assert(IsMultiplyPrime((125L)) == (true));\n    Debug.Assert(IsMultiplyPrime((105L)) == (true));\n    Debug.Assert(IsMultiplyPrime((126L)) == (false));\n    Debug.Assert(IsMultiplyPrime((729L)) == (false));\n    Debug.Assert(IsMultiplyPrime((891L)) == (false));\n    Debug.Assert(IsMultiplyPrime((1001L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> IsSimplePower((1L), (4L))\n    // (true)\n    // >>> IsSimplePower((2L), (2L))\n    // (true)\n    // >>> IsSimplePower((8L), (2L))\n    // (true)\n    // >>> IsSimplePower((3L), (2L))\n    // (false)\n    // >>> IsSimplePower((3L), (1L))\n    // (false)\n    // >>> IsSimplePower((5L), (3L))\n    // (false)\n    public static bool IsSimplePower(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSimplePower((16L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((143214L), (16L)) == (false));\n    Debug.Assert(IsSimplePower((4L), (2L)) == (true));\n    Debug.Assert(IsSimplePower((9L), (3L)) == (true));\n    Debug.Assert(IsSimplePower((16L), (4L)) == (true));\n    Debug.Assert(IsSimplePower((24L), (2L)) == (false));\n    Debug.Assert(IsSimplePower((128L), (4L)) == (false));\n    Debug.Assert(IsSimplePower((12L), (6L)) == (false));\n    Debug.Assert(IsSimplePower((1L), (1L)) == (true));\n    Debug.Assert(IsSimplePower((1L), (12L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> Iscube((1L))\n    // (true)\n    // >>> Iscube((2L))\n    // (false)\n    // >>> Iscube((-1L))\n    // (true)\n    // >>> Iscube((64L))\n    // (true)\n    // >>> Iscube((0L))\n    // (true)\n    // >>> Iscube((180L))\n    // (false)\n    public static bool Iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Iscube((1L)) == (true));\n    Debug.Assert(Iscube((2L)) == (false));\n    Debug.Assert(Iscube((-1L)) == (true));\n    Debug.Assert(Iscube((64L)) == (true));\n    Debug.Assert(Iscube((180L)) == (false));\n    Debug.Assert(Iscube((1000L)) == (true));\n    Debug.Assert(Iscube((0L)) == (true));\n    Debug.Assert(Iscube((1729L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> HexKey((\"AB\"))\n    // (1L)\n    // >>> HexKey((\"1077E\"))\n    // (2L)\n    // >>> HexKey((\"ABED1A33\"))\n    // (4L)\n    // >>> HexKey((\"123456789ABCDEF0\"))\n    // (6L)\n    // >>> HexKey((\"2020\"))\n    // (2L)\n    public static long HexKey(string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexKey((\"AB\")) == (1L));\n    Debug.Assert(HexKey((\"1077E\")) == (2L));\n    Debug.Assert(HexKey((\"ABED1A33\")) == (4L));\n    Debug.Assert(HexKey((\"2020\")) == (2L));\n    Debug.Assert(HexKey((\"123456789ABCDEF0\")) == (6L));\n    Debug.Assert(HexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> DecimalToBinary((15L))\n    // (\"db1111db\")\n    // >>> DecimalToBinary((32L))\n    // (\"db100000db\")\n    public static string DecimalToBinary(long decimalNum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((0L)).Equals((\"db0db\")));\n    Debug.Assert(DecimalToBinary((32L)).Equals((\"db100000db\")));\n    Debug.Assert(DecimalToBinary((103L)).Equals((\"db1100111db\")));\n    Debug.Assert(DecimalToBinary((15L)).Equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> FilterBySubstring((new List<string>()), (\"a\"))\n    // (new List<string>())\n    // >>> FilterBySubstring((new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"cde\", (string)\"array\"})), (\"a\"))\n    // (new List<string>(new string[]{(string)\"abc\", (string)\"bacd\", (string)\"array\"}))\n    public static List<string> FilterBySubstring(List<string> strings, string substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterBySubstring((new List<string>()), (\"john\")).Equals((new List<string>())));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"xxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xxx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"xxx\", (string)\"asd\", (string)\"aaaxxy\", (string)\"john doe\", (string)\"xxxAAA\", (string)\"xxx\"})), (\"xx\")).Equals((new List<string>(new string[]{(string)\"xxx\", (string)\"aaaxxy\", (string)\"xxxAAA\", (string)\"xxx\"}))));\n    Debug.Assert(FilterBySubstring((new List<string>(new string[]{(string)\"grunt\", (string)\"trumpet\", (string)\"prune\", (string)\"gruesome\"})), (\"run\")).Equals((new List<string>(new string[]{(string)\"grunt\", (string)\"prune\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> IsHappy((\"a\"))\n    // (false)\n    // >>> IsHappy((\"aa\"))\n    // (false)\n    // >>> IsHappy((\"abcd\"))\n    // (true)\n    // >>> IsHappy((\"aabb\"))\n    // (false)\n    // >>> IsHappy((\"adb\"))\n    // (true)\n    // >>> IsHappy((\"xyy\"))\n    // (false)\n    public static bool IsHappy(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsHappy((\"a\")) == (false));\n    Debug.Assert(IsHappy((\"aa\")) == (false));\n    Debug.Assert(IsHappy((\"abcd\")) == (true));\n    Debug.Assert(IsHappy((\"aabb\")) == (false));\n    Debug.Assert(IsHappy((\"adb\")) == (true));\n    Debug.Assert(IsHappy((\"xyy\")) == (false));\n    Debug.Assert(IsHappy((\"iopaxpoi\")) == (true));\n    Debug.Assert(IsHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> GradeEquation((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f})))\n    // (new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))\n    public static List<string> NumericalLetterGrade(List<float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)4.0f, (float)3L, (float)1.7f, (float)2L, (float)3.5f}))).Equals((new List<string>(new string[]{(string)\"A+\", (string)\"B\", (string)\"C-\", (string)\"C\", (string)\"A-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.2f}))).Equals((new List<string>(new string[]{(string)\"D+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.5f}))).Equals((new List<string>(new string[]{(string)\"D-\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f}))).Equals((new List<string>(new string[]{(string)\"E\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f}))).Equals((new List<string>(new string[]{(string)\"D\", (string)\"D-\", (string)\"C-\", (string)\"B\", (string)\"B+\"}))));\n    Debug.Assert(NumericalLetterGrade((new List<float>(new float[]{(float)0.0f, (float)0.7f}))).Equals((new List<string>(new string[]{(string)\"E\", (string)\"D-\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> PrimeLength((\"Hello\"))\n    // (true)\n    // >>> PrimeLength((\"abcdcba\"))\n    // (true)\n    // >>> PrimeLength((\"kittens\"))\n    // (true)\n    // >>> PrimeLength((\"orange\"))\n    // (false)\n    public static bool PrimeLength(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeLength((\"Hello\")) == (true));\n    Debug.Assert(PrimeLength((\"abcdcba\")) == (true));\n    Debug.Assert(PrimeLength((\"kittens\")) == (true));\n    Debug.Assert(PrimeLength((\"orange\")) == (false));\n    Debug.Assert(PrimeLength((\"wow\")) == (true));\n    Debug.Assert(PrimeLength((\"world\")) == (true));\n    Debug.Assert(PrimeLength((\"MadaM\")) == (true));\n    Debug.Assert(PrimeLength((\"Wow\")) == (true));\n    Debug.Assert(PrimeLength((\"\")) == (false));\n    Debug.Assert(PrimeLength((\"HI\")) == (true));\n    Debug.Assert(PrimeLength((\"go\")) == (true));\n    Debug.Assert(PrimeLength((\"gogo\")) == (false));\n    Debug.Assert(PrimeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    Debug.Assert(PrimeLength((\"Madam\")) == (true));\n    Debug.Assert(PrimeLength((\"M\")) == (false));\n    Debug.Assert(PrimeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long StartsOneEnds(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartsOneEnds((1L)) == (1L));\n    Debug.Assert(StartsOneEnds((2L)) == (18L));\n    Debug.Assert(StartsOneEnds((3L)) == (180L));\n    Debug.Assert(StartsOneEnds((4L)) == (1800L));\n    Debug.Assert(StartsOneEnds((5L)) == (18000L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> Solve((1000L))\n    // (\"1\")\n    // >>> Solve((150L))\n    // (\"110\")\n    // >>> Solve((147L))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static string Solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Solve((1000L)).Equals((\"1\")));\n    Debug.Assert(Solve((150L)).Equals((\"110\")));\n    Debug.Assert(Solve((147L)).Equals((\"1100\")));\n    Debug.Assert(Solve((333L)).Equals((\"1001\")));\n    Debug.Assert(Solve((963L)).Equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> Add((new List<long>(new long[]{(long)4L, (long)2L, (long)6L, (long)7L})))\n    // (2L)\n    public static long Add(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)88L}))) == (88L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)2L, (long)122L}))) == (122L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)0L, (long)6L, (long)7L}))) == (0L));\n    Debug.Assert(Add((new List<long>(new long[]{(long)4L, (long)4L, (long)6L, (long)8L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> AntiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> AntiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> AntiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static string AntiShuffle(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AntiShuffle((\"Hi\")).Equals((\"Hi\")));\n    Debug.Assert(AntiShuffle((\"hello\")).Equals((\"ehllo\")));\n    Debug.Assert(AntiShuffle((\"number\")).Equals((\"bemnru\")));\n    Debug.Assert(AntiShuffle((\"abcd\")).Equals((\"abcd\")));\n    Debug.Assert(AntiShuffle((\"Hello World!!!\")).Equals((\"Hello !!!Wdlor\")));\n    Debug.Assert(AntiShuffle((\"\")).Equals((\"\")));\n    Debug.Assert(AntiShuffle((\"Hi. My name is Mister Robot. How are you?\")).Equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))\n    // >>> GetRow((new List<List<long>>()), (1L))\n    // (new List<Tuple<long, long>>())\n    // >>> GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L))\n    // (new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))\n    public static List<Tuple<long, long>> GetRow(List<List<long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 4L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(2L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})})), (2L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 1L), (Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(4L, 1L), (Tuple<long, long>)Tuple.Create(5L, 1L)}))));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)1L})})), (1L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(0L, 0L), (Tuple<long, long>)Tuple.Create(1L, 0L), (Tuple<long, long>)Tuple.Create(2L, 1L), (Tuple<long, long>)Tuple.Create(2L, 0L), (Tuple<long, long>)Tuple.Create(3L, 2L), (Tuple<long, long>)Tuple.Create(3L, 0L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(4L, 0L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(5L, 0L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 0L)}))));\n    Debug.Assert(GetRow((new List<List<long>>()), (1L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L})})), (2L)).Equals((new List<Tuple<long, long>>())));\n    Debug.Assert(GetRow((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})})), (3L)).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 2L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> SortArray((new List<long>()))\n    // (new List<long>())\n    // >>> SortArray((new List<long>(new long[]{(long)5L})))\n    // (new List<long>(new long[]{(long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L})))\n    // (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))\n    // >>> SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L})))\n    // (new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))\n    public static List<long> SortArray(List<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortArray((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)5L}))).Equals((new List<long>(new long[]{(long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)0L, (long)1L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L, (long)0L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)15L, (long)42L, (long)87L, (long)32L, (long)11L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)11L, (long)15L, (long)32L, (long)42L, (long)87L}))));\n    Debug.Assert(SortArray((new List<long>(new long[]{(long)21L, (long)14L, (long)23L, (long)11L}))).Equals((new List<long>(new long[]{(long)23L, (long)21L, (long)14L, (long)11L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> Encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> Encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> Encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> Encrypt((\"et\"))\n    // (\"ix\")\n    public static string Encrypt(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encrypt((\"hi\")).Equals((\"lm\")));\n    Debug.Assert(Encrypt((\"asdfghjkl\")).Equals((\"ewhjklnop\")));\n    Debug.Assert(Encrypt((\"gf\")).Equals((\"kj\")));\n    Debug.Assert(Encrypt((\"et\")).Equals((\"ix\")));\n    Debug.Assert(Encrypt((\"faewfawefaewg\")).Equals((\"jeiajeaijeiak\")));\n    Debug.Assert(Encrypt((\"hellomyfriend\")).Equals((\"lippsqcjvmirh\")));\n    Debug.Assert(Encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).Equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    Debug.Assert(Encrypt((\"a\")).Equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> SumProduct((new List<long>()))\n    // (Tuple.Create(0L, 1L))\n    // >>> SumProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})))\n    // (Tuple.Create(10L, 24L))\n    public static Tuple<long, long> SumProduct(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumProduct((new List<long>())).Equals((Tuple.Create(0L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))).Equals((Tuple.Create(3L, 1L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)100L, (long)0L}))).Equals((Tuple.Create(100L, 0L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)3L, (long)5L, (long)7L}))).Equals((Tuple.Create(15L, 105L))));\n    Debug.Assert(SumProduct((new List<long>(new long[]{(long)10L}))).Equals((Tuple.Create(10L, 10L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))\n    // 2L\n    // >>> NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L})))\n    // 2L\n    // >>> NextSmallest((new List<long>()))\n    // null\n    // >>> NextSmallest((new List<long>(new long[]{(long)1L, (long)1L})))\n    // null\n    public static Nullable<long> NextSmallest(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)5L, (long)1L, (long)4L, (long)3L, (long)2L}))).Equals(2L));\n    Debug.Assert(NextSmallest((new List<long>())).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L, (long)0L}))).Equals(1L));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)1L, (long)1L}))).Equals(null));\n    Debug.Assert(NextSmallest((new List<long>(new long[]{(long)-35L, (long)34L, (long)12L, (long)-45L}))).Equals(-35L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> IsBored((\"Hello world\"))\n    // (0L)\n    // >>> IsBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1L)\n    public static long IsBored(string S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsBored((\"Hello world\")) == (0L));\n    Debug.Assert(IsBored((\"Is the sky blue?\")) == (0L));\n    Debug.Assert(IsBored((\"I love It !\")) == (1L));\n    Debug.Assert(IsBored((\"bIt\")) == (0L));\n    Debug.Assert(IsBored((\"I feel good today. I will be productive. will kill It\")) == (2L));\n    Debug.Assert(IsBored((\"You and I are going for a walk\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> AnyInt((float)5L, (float)2L, (float)7L)\n    // (true)\n    // >>> AnyInt((float)3L, (float)2L, (float)2L)\n    // (false)\n    // >>> AnyInt((float)3L, (float)-2L, (float)1L)\n    // (true)\n    // >>> AnyInt((3.6f), (-2.2f), (float)2L)\n    // (false)\n    public static bool AnyInt(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AnyInt((float)2L, (float)3L, (float)1L) == (true));\n    Debug.Assert(AnyInt((2.5f), (float)2L, (float)3L) == (false));\n    Debug.Assert(AnyInt((1.5f), (float)5L, (3.5f)) == (false));\n    Debug.Assert(AnyInt((float)2L, (float)6L, (float)2L) == (false));\n    Debug.Assert(AnyInt((float)4L, (float)2L, (float)2L) == (true));\n    Debug.Assert(AnyInt((2.2f), (2.2f), (2.2f)) == (false));\n    Debug.Assert(AnyInt((float)-4L, (float)6L, (float)2L) == (true));\n    Debug.Assert(AnyInt((float)2L, (float)1L, (float)1L) == (true));\n    Debug.Assert(AnyInt((float)3L, (float)4L, (float)7L) == (true));\n    Debug.Assert(AnyInt((3.0f), (float)4L, (float)7L) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> Encode((\"test\"))\n    // (\"TGST\")\n    // >>> Encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static string Encode(string message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Encode((\"TEST\")).Equals((\"tgst\")));\n    Debug.Assert(Encode((\"Mudasir\")).Equals((\"mWDCSKR\")));\n    Debug.Assert(Encode((\"YES\")).Equals((\"ygs\")));\n    Debug.Assert(Encode((\"This is a message\")).Equals((\"tHKS KS C MGSSCGG\")));\n    Debug.Assert(Encode((\"I DoNt KnOw WhAt tO WrItE\")).Equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L})))\n    // (10L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L})))\n    // (25L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L})))\n    // (13L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L})))\n    // (11L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L})))\n    // (3L)\n    // >>> Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L})))\n    // (7L)\n    public static long Skjkasdkd(List<long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)3L, (long)2L, (long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)5L, (long)5L, (long)5L, (long)2L, (long)181L, (long)32L, (long)4L, (long)32L, (long)3L, (long)2L, (long)32L, (long)324L, (long)4L, (long)3L}))) == (10L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)0L, (long)1L, (long)8L, (long)2L, (long)4597L, (long)2L, (long)1L, (long)3L, (long)40L, (long)1L, (long)2L, (long)1L, (long)2L, (long)4L, (long)2L, (long)5L, (long)1L}))) == (25L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)1L, (long)3L, (long)1L, (long)32L, (long)5107L, (long)34L, (long)83278L, (long)109L, (long)163L, (long)23L, (long)2323L, (long)32L, (long)30L, (long)1L, (long)9L, (long)3L}))) == (13L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)724L, (long)32L, (long)71L, (long)99L, (long)32L, (long)6L, (long)0L, (long)5L, (long)91L, (long)83L, (long)0L, (long)5L, (long)6L}))) == (11L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)81L, (long)12L, (long)3L, (long)1L, (long)21L}))) == (3L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)0L, (long)8L, (long)1L, (long)2L, (long)1L, (long)7L}))) == (7L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)8191L, (long)123456L, (long)127L, (long)7L}))) == (19L));\n    Debug.Assert(Skjkasdkd((new List<long>(new long[]{(long)127L, (long)97L, (long)8192L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"b\", \"banana\"}}))\n    // (true)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"a\", \"apple\"}, {8L, \"banana\"}, {\"a\", \"apple\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}}))\n    // (false)\n    // >>> CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}}))\n    // (true)\n    public static bool CheckDictCase(Dictionary<string,string> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"b\", \"banana\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"A\", \"banana\"}, {\"B\", \"banana\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"p\", \"pineapple\"}, {\"5\", \"banana\"}, {\"a\", \"apple\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"Name\", \"John\"}, {\"Age\", \"36\"}, {\"City\", \"Houston\"}})) == (false));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"STATE\", \"NC\"}, {\"ZIP\", \"12345\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>(){{\"fruit\", \"Orange\"}, {\"taste\", \"Sweet\"}})) == (true));\n    Debug.Assert(CheckDictCase((new Dictionary<string,string>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> CountUpTo((5L))\n    // (new List<long>(new long[]{(long)2L, (long)3L}))\n    // >>> CountUpTo((11L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))\n    // >>> CountUpTo((0L))\n    // (new List<long>())\n    // >>> CountUpTo((20L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))\n    // >>> CountUpTo((1L))\n    // (new List<long>())\n    // >>> CountUpTo((18L))\n    // (new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))\n    public static List<long> CountUpTo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpTo((5L)).Equals((new List<long>(new long[]{(long)2L, (long)3L}))));\n    Debug.Assert(CountUpTo((6L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((7L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L}))));\n    Debug.Assert(CountUpTo((10L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(CountUpTo((0L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((22L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L}))));\n    Debug.Assert(CountUpTo((1L)).Equals((new List<long>())));\n    Debug.Assert(CountUpTo((18L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L}))));\n    Debug.Assert(CountUpTo((47L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L}))));\n    Debug.Assert(CountUpTo((101L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)19L, (long)23L, (long)29L, (long)31L, (long)37L, (long)41L, (long)43L, (long)47L, (long)53L, (long)59L, (long)61L, (long)67L, (long)71L, (long)73L, (long)79L, (long)83L, (long)89L, (long)97L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> Multiply((148L), (412L))\n    // (16L)\n    // >>> Multiply((19L), (28L))\n    // (72L)\n    // >>> Multiply((2020L), (1851L))\n    // (0L)\n    // >>> Multiply((14L), (-15L))\n    // (20L)\n    public static long Multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Multiply((148L), (412L)) == (16L));\n    Debug.Assert(Multiply((19L), (28L)) == (72L));\n    Debug.Assert(Multiply((2020L), (1851L)) == (0L));\n    Debug.Assert(Multiply((14L), (-15L)) == (20L));\n    Debug.Assert(Multiply((76L), (67L)) == (42L));\n    Debug.Assert(Multiply((17L), (27L)) == (49L));\n    Debug.Assert(Multiply((0L), (1L)) == (0L));\n    Debug.Assert(Multiply((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> CountUpper((\"aBCdEf\"))\n    // (1L)\n    // >>> CountUpper((\"abcdefg\"))\n    // (0L)\n    // >>> CountUpper((\"dBBE\"))\n    // (0L)\n    public static long CountUpper(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountUpper((\"aBCdEf\")) == (1L));\n    Debug.Assert(CountUpper((\"abcdefg\")) == (0L));\n    Debug.Assert(CountUpper((\"dBBE\")) == (0L));\n    Debug.Assert(CountUpper((\"B\")) == (0L));\n    Debug.Assert(CountUpper((\"U\")) == (1L));\n    Debug.Assert(CountUpper((\"\")) == (0L));\n    Debug.Assert(CountUpper((\"EEEE\")) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> ClosestInteger((\"10\"))\n    // (10L)\n    // >>> ClosestInteger((\"15.3\"))\n    // (15L)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long ClosestInteger(string value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestInteger((\"10\")) == (10L));\n    Debug.Assert(ClosestInteger((\"14.5\")) == (15L));\n    Debug.Assert(ClosestInteger((\"-15.5\")) == (-16L));\n    Debug.Assert(ClosestInteger((\"15.3\")) == (15L));\n    Debug.Assert(ClosestInteger((\"0\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)2L})))\n    // (new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L, (long)4L}))\n    public static List<long> RollingMax(List<long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RollingMax((new List<long>())).Equals((new List<long>())));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L}))));\n    Debug.Assert(RollingMax((new List<long>(new long[]{(long)3L, (long)2L, (long)3L, (long)100L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)3L, (long)3L, (long)100L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-d-keep.json
+++ b/prompts/humaneval-d-keep.json
@@ -1,1227 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \n*/\nbool iscube(long a) \n",
+    "prompt": "import std.math;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \n*/\nstring encode(string message) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \n*/\nlong solution(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \n*/\nstring string_sequence(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \n*/\nlong minSubArraySum(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \n*/\nlong is_bored(string S) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \n*/\nlong[] get_odd_collatz(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \n*/\nbool below_threshold(long[] l, long t) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \n*/\nbool is_happy(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \n*/\nstring file_name_check(string file_name) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \n*/\nNullable!(long[string]) histogram(string test) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = histogram;\n\n{\n        auto result = candidate(\"a b b a\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c a b\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c d g\");\n        assert(!result.isNull && result.get == [\"a\": 1L, \"b\": 1L, \"c\": 1L, \"d\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"b b b b a\");\n        assert(!result.isNull && result.get == [\"b\": 4L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"a\");\n        assert(!result.isNull && result.get == [\"a\": 1L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \n*/\nbool simplify(string x, string n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = reverse_delete;\n\n    assert(candidate(\"abcde\", \"ae\") == tuple(\"bcd\", false));\n    assert(candidate(\"abcdef\", \"b\") == tuple(\"acdef\", false));\n    assert(candidate(\"abcdedcba\", \"ab\") == tuple(\"cdedc\", true));\n    assert(candidate(\"dwik\", \"w\") == tuple(\"dik\", false));\n    assert(candidate(\"a\", \"a\") == tuple(\"\", true));\n    assert(candidate(\"abcdedcba\", \"\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"abcdedcba\", \"v\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"vabba\", \"v\") == tuple(\"abba\", true));\n    assert(candidate(\"mamma\", \"mia\") == tuple(\"\", true));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \n*/\nlong skjkasdkd(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \n*/\nstring[] all_prefixes(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \n*/\nlong digits(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \n*/\nlong strlen(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \n*/\nlong fibfib(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \n*/\nbool monotonic(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \n*/\nlong[] parse_music(string music_string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \n*/\nstring remove_vowels(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \n*/\nlong[] sort_third(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \n*/\nlong[] count_up_to(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \n*/\nlong max_element(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \n*/\nlong[] unique(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \n*/\nlong smallest_change(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \n*/\nlong[] f(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \n*/\nstring match_parens(string[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \n*/\nlong largest_prime_factor(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \n*/\nstring encrypt(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \n*/\nlong how_many_times(string string, string substring) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \n*/\nstring solve(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \n*/\nlong[] sort_even(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_even;\n\n    assert(candidate([1L, 2L, 3L]) == [1L, 2L, 3L]);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [-10L, 3L, -5L, 2L, -3L, 3L, 5L, 0L, 9L, 1L, 123L]);\n    assert(candidate([5L, 8L, -12L, 4L, 23L, 2L, 3L, 11L, 12L, -10L]) == [-12L, 8L, 3L, 4L, 5L, 2L, 12L, 11L, 23L, -10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \n*/\nbool below_zero(long[] operations) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \n*/\nbool same_chars(string s0, string s1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = same_chars;\n\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true);\n    assert(candidate(\"abcd\", \"dddddddabc\") == true);\n    assert(candidate(\"dddddddabc\", \"abcd\") == true);\n    assert(candidate(\"eabcd\", \"dddddddabc\") == false);\n    assert(candidate(\"abcd\", \"dddddddabcf\") == false);\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false);\n    assert(candidate(\"aabb\", \"aaccc\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \n*/\nlong count_upper(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \n*/\nlong sum_squares(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \n*/\nlong add(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \n*/\nlong multiply(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \n*/\nlong[] tri(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \n*/\nbool is_simple_power(long x, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1232,9 +17,9 @@
   {
     "name": "HumanEval_100_make_a_pile",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \n*/\nlong[] make_a_pile(long n) \n",
+    "prompt": "import std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \n*/\nlong[] make_a_pile(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1245,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nAdd two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \n*/\nlong add(long x, long y) \n",
+    "prompt": "import std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1260,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_29_filter_by_prefix",
+    "name": "HumanEval_102_choose_num",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
+    "prompt": "import std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    choose_num(12, 15) = 14\n    choose_num(13, 12) = -1\n    \n*/\nlong choose_num(long x, long y) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1275,178 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_79_decimal_to_binary",
+    "name": "HumanEval_104_unique_digits",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
+    "prompt": "import std.math;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \n*/\nbool is_palindrome(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \n*/\nlong[] factorize(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \n*/\nstring sort_numbers(string numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \n*/\nstring flip_case(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \n*/\nlong can_arrange(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \n*/\nbool is_nested(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1457,9 +77,9 @@
   {
     "name": "HumanEval_105_by_length",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \n*/\nstring[] by_length(long[] arr) \n",
+    "prompt": "import std.math;\n/*\n\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \n*/\nstring[] by_length(long[] arr) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = by_length;\n\n    assert(candidate([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -1L, 55L]) == [\"One\"]);\n    assert(candidate([1L, -1L, 3L, 2L]) == [\"Three\", \"Two\", \"One\"]);\n    assert(candidate([9L, 4L, 8L]) == [\"Nine\", \"Eight\", \"Four\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1470,298 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_4_mean_absolute_deviation",
+    "name": "HumanEval_106_f",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
+    "prompt": "import std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \n*/\nlong[] f(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \n*/\nlong sum_to_n(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \n*/\nstring concatenate(string[] strings) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \n*/\nlong[] sort_array(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([1L, 5L, 2L, 3L, 4L]) == [1L, 2L, 4L, 3L, 5L]);\n    assert(candidate([-2L, -3L, -4L, -5L, -6L]) == [-4L, -2L, -6L, -5L, -3L]);\n    assert(candidate([1L, 0L, 2L, 3L, 4L]) == [0L, 1L, 2L, 4L, 3L]);\n    assert(candidate([]) == []);\n    assert(candidate([2L, 5L, 77L, 4L, 5L, 3L, 5L, 7L, 2L, 3L, 4L]) == [2L, 2L, 4L, 4L, 3L, 3L, 5L, 5L, 5L, 7L, 77L]);\n    assert(candidate([3L, 6L, 44L, 12L, 32L, 5L]) == [32L, 3L, 5L, 6L, 12L, 44L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \n*/\nNullable!(string) longest(string[] strings) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \n*/\nbool is_sorted(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \n*/\nlong[] derivative(long[] xs) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \n*/\nstring anti_shuffle(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \n*/\nstring make_palindrome(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \n*/\nstring change_base(long x, long base) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \n*/\nbool prime_length(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \n*/\nlong search(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \n*/\nlong fizz_buzz(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1774,249 +109,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n        Input: 3\n        Output: (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n        Input: 12\n        Output: (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \n*/\nlong[] sort_array(long[] array) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \n*/\nlong vowels_count(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \n*/\nbool is_prime(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \n*/\nlong hex_key(string num) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \n*/\nlong specialFilter(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = specialFilter;\n\n    assert(candidate([5L, -2L, 1L, -5L]) == 0L);\n    assert(candidate([15L, -73L, 14L, -15L]) == 1L);\n    assert(candidate([33L, -2L, -3L, 45L, 21L, 109L]) == 2L);\n    assert(candidate([43L, -12L, 93L, 125L, 121L, 109L]) == 4L);\n    assert(candidate([71L, -2L, -33L, 75L, 21L, 19L]) == 3L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([]) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \n*/\nlong modp(long n, long p) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \n*/\nlong prime_fib(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \n*/\nbool valid_date(string date) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2029,7 +124,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([]) == 0\n    >>> count_nums([-1, 11, -11]) == 1\n    >>> count_nums([1, 1, 2]) == 3\n    \n*/\nlong count_nums(long[] arr) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = count_nums;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([-1L, -2L, 0L]) == 0L);\n    assert(candidate([1L, 1L, 2L, -2L, 3L, 4L, 5L]) == 6L);\n    assert(candidate([1L, 6L, 9L, -6L, 0L, 1L, 5L]) == 5L);\n    assert(candidate([1L, 100L, 98L, -7L, 1L, -1L]) == 4L);\n    assert(candidate([12L, 23L, 34L, -45L, -56L, 0L]) == 5L);\n    assert(candidate([0L, 1L]) == 1L);\n    assert(candidate([1L]) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2040,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_66_digitSum",
+    "name": "HumanEval_109_move_one_ball",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \n*/\nlong digitSum(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2055,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_145_order_by_points",
+    "name": "HumanEval_10_make_palindrome",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \n*/\nstring make_palindrome(string string) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2070,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_110_exchange",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2085,13 +180,133 @@
     ]
   },
   {
-    "name": "HumanEval_46_fib4",
+    "name": "HumanEval_111_histogram",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \n*/\nlong fib4(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \n*/\nNullable!(long[string]) histogram(string test) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = histogram;\n\n{\n        auto result = candidate(\"a b b a\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c a b\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c d g\");\n        assert(!result.isNull && result.get == [\"a\": 1L, \"b\": 1L, \"c\": 1L, \"d\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"b b b b a\");\n        assert(!result.isNull && result.get == [\"b\": 4L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"a\");\n        assert(!result.isNull && result.get == [\"a\": 1L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = reverse_delete;\n\n    assert(candidate(\"abcde\", \"ae\") == tuple(\"bcd\", false));\n    assert(candidate(\"abcdef\", \"b\") == tuple(\"acdef\", false));\n    assert(candidate(\"abcdedcba\", \"ab\") == tuple(\"cdedc\", true));\n    assert(candidate(\"dwik\", \"w\") == tuple(\"dik\", false));\n    assert(candidate(\"a\", \"a\") == tuple(\"\", true));\n    assert(candidate(\"abcdedcba\", \"\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"abcdedcba\", \"v\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"vabba\", \"v\") == tuple(\"abba\", true));\n    assert(candidate(\"mamma\", \"mia\") == tuple(\"\", true));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \n*/\nlong minSubArraySum(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \n*/\nlong[] sort_array(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([1L, 5L, 2L, 3L, 4L]) == [1L, 2L, 4L, 3L, 5L]);\n    assert(candidate([-2L, -3L, -4L, -5L, -6L]) == [-4L, -2L, -6L, -5L, -3L]);\n    assert(candidate([1L, 0L, 2L, 3L, 4L]) == [0L, 1L, 2L, 4L, 3L]);\n    assert(candidate([]) == []);\n    assert(candidate([2L, 5L, 77L, 4L, 5L, 3L, 5L, 7L, 2L, 3L, 4L]) == [2L, 2L, 4L, 4L, 3L, 3L, 5L, 5L, 5L, 7L, 77L]);\n    assert(candidate([3L, 6L, 44L, 12L, 32L, 5L]) == [32L, 3L, 5L, 6L, 12L, 44L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \n*/\nstring match_parens(string[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2104,7 +319,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \n*/\nstring string_xor(string a, string b) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2115,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_0_has_close_elements",
+    "name": "HumanEval_120_maximum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2130,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_67_fruit_distribution",
+    "name": "HumanEval_121_solution",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \n*/\nlong fruit_distribution(string s, long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \n*/\nlong solution(long[] lst) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2145,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_24_largest_divisor",
+    "name": "HumanEval_122_add_elements",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \n*/\nlong largest_divisor(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2160,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_156_int_to_mini_roman",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \n*/\nstring int_to_mini_roman(long number) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \n*/\nlong[] get_odd_collatz(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2175,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_124_valid_date",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \n*/\nbool valid_date(string date) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2190,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_56_correct_bracketing",
+    "name": "HumanEval_126_is_sorted",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \n*/\nbool is_sorted(long[] lst) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"<>\") == true);\n    assert(candidate(\"<<><>>\") == true);\n    assert(candidate(\"<><><<><>><>\") == true);\n    assert(candidate(\"<><><<<><><>><>><<><><<>>>\") == true);\n    assert(candidate(\"<<<><>>>>\") == false);\n    assert(candidate(\"><<>\") == false);\n    assert(candidate(\"<\") == false);\n    assert(candidate(\"<<<<\") == false);\n    assert(candidate(\">\") == false);\n    assert(candidate(\"<<>\") == false);\n    assert(candidate(\"<><><<><>><>><<>\") == false);\n    assert(candidate(\"<><><<><>><>>><>\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2205,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_55_fib",
+    "name": "HumanEval_127_intersection",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \n*/\nlong fib(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2224,7 +439,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4]) == -9\n    >>> prod_signs([0, 1]) == 0\n    >>> prod_signs([]) == None\n    \n*/\nNullable!(long) prod_signs(long[] arr) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2235,13 +450,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_129_minPath",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2250,13 +465,13 @@
     ]
   },
   {
-    "name": "HumanEval_42_incr_list",
+    "name": "HumanEval_12_longest",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \n*/\nlong[] incr_list(long[] l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \n*/\nNullable!(string) longest(string[] strings) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2265,13 +480,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_130_tri",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \n*/\nlong[] get_positive(long[] l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \n*/\nlong[] tri(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2280,13 +495,13 @@
     ]
   },
   {
-    "name": "HumanEval_102_choose_num",
+    "name": "HumanEval_131_digits",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    choose_num(12, 15) = 14\n    choose_num(13, 12) = -1\n    \n*/\nlong choose_num(long x, long y) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \n*/\nlong digits(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2295,13 +510,478 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_132_is_nested",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \n*/\nbool is_nested(string string) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \n*/\nlong can_arrange(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \n*/\nstring file_name_check(string file_name) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \n*/\nlong sum_squares(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \n*/\nbool simplify(string x, string n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \n*/\nlong specialFilter(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = specialFilter;\n\n    assert(candidate([5L, -2L, 1L, -5L]) == 0L);\n    assert(candidate([15L, -73L, 14L, -15L]) == 1L);\n    assert(candidate([33L, -2L, -3L, 45L, 21L, 109L]) == 2L);\n    assert(candidate([43L, -12L, 93L, 125L, 121L, 109L]) == 4L);\n    assert(candidate([71L, -2L, -33L, 75L, 21L, 19L]) == 3L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([]) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \n*/\nstring[] all_prefixes(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \n*/\nstring int_to_mini_roman(long number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \n*/\nstring string_sequence(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \n*/\nstring solve(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2314,7 +994,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    generate_integers(2, 8) => [2, 4, 6, 8]\n    generate_integers(8, 2) => [2, 4, 6, 8]\n    generate_integers(10, 14) => []\n    \n*/\nlong[] generate_integers(long a, long b) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = generate_integers;\n\n    assert(candidate(2L, 10L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(10L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(132L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(17L, 89L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2329,9 +1009,1329 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \n*/\nlong count_distinct_characters(string string) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \n*/\nlong[] parse_music(string music_string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \n*/\nlong how_many_times(string string, string substring) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \n*/\nstring sort_numbers(string numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \n*/\nlong strlen(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \n*/\nlong largest_divisor(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \n*/\nlong[] factorize(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \n*/\nstring flip_case(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \n*/\nstring concatenate(string[] strings) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \n*/\nlong[] get_positive(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \n*/\nbool is_prime(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \n*/\nlong[] sort_third(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \n*/\nlong[] unique(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \n*/\nlong max_element(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \n*/\nlong fizz_buzz(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \n*/\nlong[] sort_even(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_even;\n\n    assert(candidate([1L, 2L, 3L]) == [1L, 2L, 3L]);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [-10L, 3L, -5L, 2L, -3L, 3L, 5L, 0L, 9L, 1L, 123L]);\n    assert(candidate([5L, 8L, -12L, 4L, 23L, 2L, 3L, 11L, 12L, -10L]) == [-12L, 8L, 3L, 4L, 5L, 2L, 12L, 11L, 23L, -10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \n*/\nlong prime_fib(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \n*/\nbool below_zero(long[] operations) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \n*/\nlong[] incr_list(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \n*/\nstring change_base(long x, long base) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \n*/\nlong fib4(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \n*/\nbool is_palindrome(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \n*/\nlong modp(long n, long p) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \n*/\nstring remove_vowels(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \n*/\nbool below_threshold(long[] l, long t) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nAdd two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \n*/\nlong add(long x, long y) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \n*/\nbool same_chars(string s0, string s1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = same_chars;\n\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true);\n    assert(candidate(\"abcd\", \"dddddddabc\") == true);\n    assert(candidate(\"dddddddabc\", \"abcd\") == true);\n    assert(candidate(\"eabcd\", \"dddddddabc\") == false);\n    assert(candidate(\"abcd\", \"dddddddabcf\") == false);\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false);\n    assert(candidate(\"aabb\", \"aaccc\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \n*/\nlong fib(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"<>\") == true);\n    assert(candidate(\"<<><>>\") == true);\n    assert(candidate(\"<><><<><>><>\") == true);\n    assert(candidate(\"<><><<<><><>><>><<><><<>>>\") == true);\n    assert(candidate(\"<<<><>>>>\") == false);\n    assert(candidate(\"><<>\") == false);\n    assert(candidate(\"<\") == false);\n    assert(candidate(\"<<<<\") == false);\n    assert(candidate(\">\") == false);\n    assert(candidate(\"<<>\") == false);\n    assert(candidate(\"<><><<><>><>><<>\") == false);\n    assert(candidate(\"<><><<><>><>>><>\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \n*/\nbool monotonic(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \n*/\nlong largest_prime_factor(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \n*/\nlong sum_to_n(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \n*/\nlong[] derivative(long[] xs) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \n*/\nlong fibfib(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \n*/\nlong vowels_count(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \n*/\nlong digitSum(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \n*/\nlong fruit_distribution(string s, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \n*/\nlong search(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \n*/\nlong smallest_change(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \n*/\nbool is_simple_power(long x, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \n*/\nbool iscube(long a) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \n*/\nlong hex_key(string num) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \n*/\nbool is_happy(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \n*/\nbool prime_length(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \n*/\nlong add(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \n*/\nstring anti_shuffle(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \n*/\nlong[] sort_array(long[] array) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \n*/\nstring encrypt(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \n*/\nlong is_bored(string S) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \n*/\nstring encode(string message) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \n*/\nlong skjkasdkd(long[] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \n*/\nlong[] count_up_to(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \n*/\nlong multiply(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \n*/\nlong count_upper(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/humaneval-d-remove.json
+++ b/prompts/humaneval-d-remove.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
+    "name": "HumanEval_0_has_close_elements",
     "language": "d",
-    "prompt": "import std.math;\n/*\n Return length of given string\n            \n*/\nlong strlen(string string) \n",
+    "prompt": "import std.math;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n            \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -15,13 +15,13 @@
     ]
   },
   {
-    "name": "HumanEval_89_encrypt",
+    "name": "HumanEval_100_make_a_pile",
     "language": "d",
-    "prompt": "import std.math;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \n*/\nstring encrypt(string s) \n",
+    "prompt": "import std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n        \n*/\nlong[] make_a_pile(long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -30,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_95_check_dict_case",
+    "name": "HumanEval_101_words_string",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "prompt": "import std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \n*/\nstring[] words_string(string s) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -45,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_85_add",
+    "name": "HumanEval_102_choose_num",
     "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \n*/\nlong add(long[] lst) \n",
+    "prompt": "import std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \n*/\nlong choose_num(long x, long y) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -60,148 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_140_fix_spaces",
+    "name": "HumanEval_104_unique_digits",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \n*/\nstring fix_spaces(string text) \n",
+    "prompt": "import std.math;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \n*/\nlong[] unique_digits(long[] x) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \n*/\nlong fibfib(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \n*/\nlong[] parse_music(string music_string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \n*/\nstring decimal_to_binary(long decimal) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return list of all prefixes from shortest to longest of the input string\n        \n*/\nstring[] all_prefixes(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nAdd two numbers x and y\n            \n*/\nlong add(long x, long y) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \n*/\nstring flip_case(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -214,7 +79,7 @@
     "language": "d",
     "prompt": "import std.math;\n/*\n\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n        \n      If the array is empty, return an empty array:\n        \n      If the array has any strange number ignore it:\n        \n*/\nstring[] by_length(long[] arr) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = by_length;\n\n    assert(candidate([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -1L, 55L]) == [\"One\"]);\n    assert(candidate([1L, -1L, 3L, 2L]) == [\"Three\", \"Two\", \"One\"]);\n    assert(candidate([9L, 4L, 8L]) == [\"Nine\", \"Eight\", \"Four\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -225,341 +90,11 @@
     ]
   },
   {
-    "name": "HumanEval_25_factorize",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \n*/\nlong[] factorize(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \n*/\nlong[] count_up_to(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn sorted unique elements in a list\n        \n*/\nlong[] unique(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn maximum element in the list.\n            \n*/\nlong max_element(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \n*/\nbool is_nested(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \n*/\nstring[] odd_count(string[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \n*/\nbool is_equal_to_sum_even(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \n*/\nlong[] derivative(long[] xs) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \n*/\nbool is_sorted(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \n*/\nstring solve(string s) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \n*/\nlong[] tri(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \n*/\nlong fizz_buzz(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n            \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \n*/\nlong[] minPath(long[][] grid, long k) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \n*/\nlong count_upper(string s) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n        \n*/\nlong largest_divisor(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \n*/\nlong[] sort_array(long[] array) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "HumanEval_106_f",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \n*/\nlong[] f(long n) \n",
+    "prompt": "import std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \n*/\nlong[] f(long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -570,778 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \n*/\nbool iscube(long a) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \n*/\nstring encode(string message) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \n*/\nlong is_bored(string S) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \n*/\nbool pairs_sum_to_zero(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \n*/\nfloat triangle_area(long a, long b, long c) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \n*/\nlong digits(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \n*/\nstring[] words_string(string s) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \n*/\nlong how_many_times(string string, string substring) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \n*/\nstring remove_vowels(string text) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \n*/\nlong[] strange_sort_list(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \n*/\nbool is_simple_power(long x, long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \n*/\nlong prime_fib(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \n*/\nlong[] order_by_points(long[] nums) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n            \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \n*/\nstring make_palindrome(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \n*/\nstring string_xor(string a, string b) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \n*/\nlong fib4(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \n*/\nlong[] unique_digits(long[] x) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \n*/\nstring[] select_words(string s, long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn n-th Fibonacci number.\n                \n*/\nlong fib(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \n*/\nstring match_parens(string[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \n*/\nfloat truncate_number(float number) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn list with elements incremented by 1.\n            \n*/\nlong[] incr_list(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn 2^n modulo p (be aware of numerics).\n                        \n*/\nlong modp(long n, long p) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \n*/\nTuple!(long, long) even_odd_count(long num) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \n*/\nbool is_happy(string s) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n            \n*/\nlong largest_prime_factor(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \n*/\nlong digitSum(string s) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \n*/\nlong solution(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn median of elements in the list l.\n            \n*/\nfloat median(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \n*/\nbool prime_length(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \n*/\nlong smallest_change(long[] arr) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \n*/\nlong sum_squares(float[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \n*/\nstring file_name_check(string file_name) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \n*/\nbool triples_sum_to_zero(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \n*/\nstring[] separate_paren_groups(string paren_string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \n*/\nlong[] compare(long[] game, long[] guess) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \n*/\nbool valid_date(string date) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1352,9 +122,9 @@
   {
     "name": "HumanEval_108_count_nums",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \n*/\nlong count_nums(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \n*/\nlong count_nums(long[] arr) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = count_nums;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([-1L, -2L, 0L]) == 0L);\n    assert(candidate([1L, 1L, 2L, -2L, 3L, 4L, 5L]) == 6L);\n    assert(candidate([1L, 6L, 9L, -6L, 0L, 1L, 5L]) == 5L);\n    assert(candidate([1L, 100L, 98L, -7L, 1L, -1L]) == 4L);\n    assert(candidate([12L, 23L, 34L, -45L, -56L, 0L]) == 5L);\n    assert(candidate([0L, 1L]) == 1L);\n    assert(candidate([1L]) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1365,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_86_anti_shuffle",
+    "name": "HumanEval_109_move_one_ball",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \n*/\nstring anti_shuffle(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1380,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_48_is_palindrome",
+    "name": "HumanEval_10_make_palindrome",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Checks if given string is a palindrome\n                    \n*/\nbool is_palindrome(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \n*/\nstring make_palindrome(string string) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1395,73 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_118_get_closest_vowel",
+    "name": "HumanEval_110_exchange",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \n*/\nstring get_closest_vowel(string word) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn true if a given number is prime, and false otherwise.\n                                \n*/\nbool is_prime(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \n*/\nbool simplify(string x, string n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \n*/\nlong hex_key(string num) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1472,9 +182,9 @@
   {
     "name": "HumanEval_111_histogram",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \n*/\nNullable!(long[string]) histogram(string test) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \n*/\nNullable!(long[string]) histogram(string test) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = histogram;\n\n{\n        auto result = candidate(\"a b b a\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c a b\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c d g\");\n        assert(!result.isNull && result.get == [\"a\": 1L, \"b\": 1L, \"c\": 1L, \"d\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"b b b b a\");\n        assert(!result.isNull && result.get == [\"b\": 4L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"a\");\n        assert(!result.isNull && result.get == [\"a\": 1L]);\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1485,446 +195,11 @@
     ]
   },
   {
-    "name": "HumanEval_87_get_row",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \n*/\nlong[] get_odd_collatz(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \n*/\nlong can_arrange(long[] arr) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \n*/\nstring sort_numbers(string numbers) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \n*/\nstring circular_shift(long x, long shift) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \n*/\nlong sum_squares(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \n*/\nlong skjkasdkd(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \n*/\nlong choose_num(long x, long y) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \n*/\nlong count_distinct_characters(string string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_100_make_a_pile",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n        \n*/\nlong[] make_a_pile(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \n*/\nNullable!(long) prod_signs(long[] arr) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \n*/\nlong minSubArraySum(long[] nums) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \n*/\nstring string_sequence(long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \n*/\nbool cycpattern_check(string a, string b) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n                \n*/\nbool monotonic(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \n*/\nNullable!(string) longest(string[] strings) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn True if all numbers in the list l are below threshold t.\n            \n*/\nbool below_threshold(long[] l, long t) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn only positive numbers in the list.\n            \n*/\nlong[] get_positive(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \n*/\nlong[] sort_third(long[] l) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \n*/\nlong[] parse_nested_parens(string paren_string) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven length of a side and high return area for a triangle.\n        \n*/\nfloat triangle_area(long a, long h) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \n*/\nlong multiply(long a, long b) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn sorted unique common elements for two lists.\n        \n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \n*/\nstring int_to_mini_roman(long number) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \n*/\nlong fruit_distribution(string s, long n) \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "HumanEval_112_reverse_delete",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n                \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n                \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = reverse_delete;\n\n    assert(candidate(\"abcde\", \"ae\") == tuple(\"bcd\", false));\n    assert(candidate(\"abcdef\", \"b\") == tuple(\"acdef\", false));\n    assert(candidate(\"abcdedcba\", \"ab\") == tuple(\"cdedc\", true));\n    assert(candidate(\"dwik\", \"w\") == tuple(\"dik\", false));\n    assert(candidate(\"a\", \"a\") == tuple(\"\", true));\n    assert(candidate(\"abcdedcba\", \"\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"abcdedcba\", \"v\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"vabba\", \"v\") == tuple(\"abba\", true));\n    assert(candidate(\"mamma\", \"mia\") == tuple(\"\", true));\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1935,13 +210,43 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Return a greatest common divisor of two integers a and b\n            \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \n*/\nstring[] odd_count(string[] lst) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \n*/\nlong minSubArraySum(long[] nums) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1952,9 +257,9 @@
   {
     "name": "HumanEval_116_sort_array",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n                \n*/\nlong[] sort_array(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n                \n*/\nlong[] sort_array(long[] arr) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([1L, 5L, 2L, 3L, 4L]) == [1L, 2L, 4L, 3L, 5L]);\n    assert(candidate([-2L, -3L, -4L, -5L, -6L]) == [-4L, -2L, -6L, -5L, -3L]);\n    assert(candidate([1L, 0L, 2L, 3L, 4L]) == [0L, 1L, 2L, 4L, 3L]);\n    assert(candidate([]) == []);\n    assert(candidate([2L, 5L, 77L, 4L, 5L, 3L, 5L, 7L, 2L, 3L, 4L]) == [2L, 2L, 4L, 4L, 3L, 3L, 5L, 5L, 5L, 7L, 77L]);\n    assert(candidate([3L, 6L, 44L, 12L, 32L, 5L]) == [32L, 3L, 5L, 6L, 12L, 44L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1965,13 +270,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Concatenate list of strings into a single string\n            \n*/\nstring concatenate(string[] strings) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \n*/\nstring[] select_words(string s, long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1980,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \n*/\nstring[] sorted_list_sum(string[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \n*/\nstring get_closest_vowel(string word) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1995,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Filter an input list of strings only for ones that contain given substring\n            \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \n*/\nstring match_parens(string[] lst) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2010,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \n*/\nstring string_xor(string a, string b) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2025,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \n*/\nlong vowels_count(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2040,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \n*/\nstring find_max(string[] words) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \n*/\nlong solution(long[] lst) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2055,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2070,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \n*/\nstring change_base(long x, long base) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \n*/\nlong[] get_odd_collatz(long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2085,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \n*/\nbool valid_date(string date) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2100,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \n*/\nbool is_sorted(long[] lst) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2115,13 +420,298 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \n*/\nNullable!(long) prod_signs(long[] arr) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \n*/\nlong[] minPath(long[][] grid, long k) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \n*/\nNullable!(string) longest(string[] strings) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \n*/\nlong[] tri(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \n*/\nlong digits(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \n*/\nbool is_nested(string string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \n*/\nlong sum_squares(float[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \n*/\nlong can_arrange(long[] arr) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \n*/\nbool is_equal_to_sum_even(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n            \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \n*/\nstring fix_spaces(string text) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \n*/\nstring file_name_check(string file_name) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \n*/\nlong sum_squares(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \n*/\nbool simplify(string x, string n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \n*/\nlong[] order_by_points(long[] nums) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2132,9 +722,9 @@
   {
     "name": "HumanEval_146_specialFilter",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n            \n*/\nlong specialFilter(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n            \n*/\nlong specialFilter(long[] nums) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = specialFilter;\n\n    assert(candidate([5L, -2L, 1L, -5L]) == 0L);\n    assert(candidate([15L, -73L, 14L, -15L]) == 1L);\n    assert(candidate([33L, -2L, -3L, 45L, 21L, 109L]) == 2L);\n    assert(candidate([43L, -12L, 93L, 125L, 121L, 109L]) == 4L);\n    assert(candidate([71L, -2L, -33L, 75L, 21L, 19L]) == 3L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([]) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2145,13 +735,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n                        \n*/\nlong sum_to_n(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2160,13 +750,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \n*/\nstring[] sorted_list_sum(string[] lst) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of all prefixes from shortest to longest of the input string\n        \n*/\nstring[] all_prefixes(string string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \n*/\nlong[] compare(long[] game, long[] guess) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \n*/\nbool cycpattern_check(string a, string b) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \n*/\nTuple!(long, long) even_odd_count(long num) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \n*/\nstring int_to_mini_roman(long number) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \n*/\nstring find_max(string[] words) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \n*/\nstring string_sequence(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \n*/\nstring solve(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2177,9 +977,9 @@
   {
     "name": "HumanEval_163_generate_integers",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n                \n*/\nlong[] generate_integers(long a, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n                \n*/\nlong[] generate_integers(long a, long b) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = generate_integers;\n\n    assert(candidate(2L, 10L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(10L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(132L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(17L, 89L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2190,13 +990,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \n*/\nlong count_distinct_characters(string string) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2205,13 +1005,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \n*/\nbool below_zero(long[] operations) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \n*/\nlong[] parse_music(string music_string) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2220,13 +1020,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \n*/\nlong search(long[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \n*/\nlong how_many_times(string string, string substring) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2235,13 +1035,268 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \n*/\nstring sort_numbers(string numbers) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \n*/\nstring[] separate_paren_groups(string paren_string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return length of given string\n            \n*/\nlong strlen(string string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n        \n*/\nlong largest_divisor(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \n*/\nlong[] factorize(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \n*/\nstring flip_case(string string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate list of strings into a single string\n            \n*/\nstring concatenate(string[] strings) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n            \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \n*/\nfloat truncate_number(float number) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the list.\n            \n*/\nlong[] get_positive(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n                                \n*/\nbool is_prime(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \n*/\nlong[] sort_third(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique elements in a list\n        \n*/\nlong[] unique(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn maximum element in the list.\n            \n*/\nlong max_element(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \n*/\nlong fizz_buzz(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2252,9 +1307,9 @@
   {
     "name": "HumanEval_37_sort_even",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n            \n*/\nlong[] sort_even(long[] l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n            \n*/\nlong[] sort_even(long[] l) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = sort_even;\n\n    assert(candidate([1L, 2L, 3L]) == [1L, 2L, 3L]);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [-10L, 3L, -5L, 2L, -3L, 3L, 5L, 0L, 9L, 1L, 123L]);\n    assert(candidate([5L, 8L, -12L, 4L, 23L, 2L, 3L, 11L, 12L, -10L]) == [-12L, 8L, 3L, 4L, 5L, 2L, 12L, 11L, 23L, -10L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2265,11 +1320,236 @@
     ]
   },
   {
+    "name": "HumanEval_39_prime_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \n*/\nlong prime_fib(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \n*/\nbool below_zero(long[] operations) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \n*/\nbool triples_sum_to_zero(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn list with elements incremented by 1.\n            \n*/\nlong[] incr_list(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \n*/\nbool pairs_sum_to_zero(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \n*/\nstring change_base(long x, long base) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n        \n*/\nfloat triangle_area(long a, long h) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \n*/\nlong fib4(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the list l.\n            \n*/\nfloat median(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n                    \n*/\nbool is_palindrome(string text) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n                        \n*/\nlong modp(long n, long p) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \n*/\nstring remove_vowels(string text) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True if all numbers in the list l are below threshold t.\n            \n*/\nbool below_threshold(long[] l, long t) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nAdd two numbers x and y\n            \n*/\nlong add(long x, long y) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "HumanEval_54_same_chars",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Check if two words have the same characters.\n                            \n*/\nbool same_chars(string s0, string s1) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Check if two words have the same characters.\n                            \n*/\nbool same_chars(string s0, string s1) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = same_chars;\n\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true);\n    assert(candidate(\"abcd\", \"dddddddabc\") == true);\n    assert(candidate(\"dddddddabc\", \"abcd\") == true);\n    assert(candidate(\"eabcd\", \"dddddddabc\") == false);\n    assert(candidate(\"abcd\", \"dddddddabcf\") == false);\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false);\n    assert(candidate(\"aabb\", \"aaccc\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2280,13 +1560,733 @@
     ]
   },
   {
+    "name": "HumanEval_55_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n                \n*/\nlong fib(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "HumanEval_56_correct_bracketing",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \n*/\nbool correct_bracketing(string brackets) \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"<>\") == true);\n    assert(candidate(\"<<><>>\") == true);\n    assert(candidate(\"<><><<><>><>\") == true);\n    assert(candidate(\"<><><<<><><>><>><<><><<>>>\") == true);\n    assert(candidate(\"<<<><>>>>\") == false);\n    assert(candidate(\"><<>\") == false);\n    assert(candidate(\"<\") == false);\n    assert(candidate(\"<<<<\") == false);\n    assert(candidate(\">\") == false);\n    assert(candidate(\"<<>\") == false);\n    assert(candidate(\"<><><<><>><>><<>\") == false);\n    assert(candidate(\"<><><<><>><>>><>\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n                \n*/\nbool monotonic(long[] l) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two lists.\n        \n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n            \n*/\nlong largest_prime_factor(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n                        \n*/\nlong sum_to_n(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \n*/\nbool correct_bracketing(string brackets) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \n*/\nlong[] derivative(long[] xs) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \n*/\nlong fibfib(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \n*/\nlong vowels_count(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \n*/\nstring circular_shift(long x, long shift) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \n*/\nlong digitSum(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \n*/\nlong fruit_distribution(string s, long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \n*/\nlong search(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \n*/\nlong[] parse_nested_parens(string paren_string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \n*/\nlong[] strange_sort_list(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \n*/\nfloat triangle_area(long a, long b, long c) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \n*/\nlong smallest_change(long[] arr) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \n*/\nbool is_simple_power(long x, long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \n*/\nbool iscube(long a) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \n*/\nlong hex_key(string num) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \n*/\nstring decimal_to_binary(long decimal) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that contain given substring\n            \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \n*/\nbool is_happy(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \n*/\nbool prime_length(string string) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \n*/\nlong add(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \n*/\nstring anti_shuffle(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \n*/\nlong[] sort_array(long[] array) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \n*/\nstring encrypt(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \n*/\nlong is_bored(string S) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \n*/\nstring encode(string message) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \n*/\nlong skjkasdkd(long[] lst) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \n*/\nlong[] count_up_to(long n) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \n*/\nlong multiply(long a, long b) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \n*/\nlong count_upper(string s) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/humaneval-d-reworded.json
+++ b/prompts/humaneval-d-reworded.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
+    "name": "HumanEval_0_has_close_elements",
     "language": "d",
-    "prompt": "import std.math;\n/*\n Return length of given string\n    >>> strlen(\"\")\n    0L\n    >>> strlen(\"abc\")\n    3L\n    \n*/\nlong strlen(string string) \n",
+    "prompt": "import std.math;\n/*\n Check if in given array of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -15,13 +15,13 @@
     ]
   },
   {
-    "name": "HumanEval_89_encrypt",
+    "name": "HumanEval_100_make_a_pile",
     "language": "d",
-    "prompt": "import std.math;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \n*/\nstring encrypt(string s) \n",
+    "prompt": "import std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in an array, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3L)\n    [3L, 5L, 7L]\n    \n*/\nlong[] make_a_pile(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -30,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_95_check_dict_case",
+    "name": "HumanEval_101_words_string",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given an associative array, return true if all keys are strings in lower \n    case or all keys are strings in upper case, else return false.\n    The function should return false is the given associative array is empty.\n    Examples:\n    >>> check_dict_case([\"a\": \"apple\", \"b\": \"banana\"].nullable)\n    true\n    >>> check_dict_case([\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"].nullable)\n    false\n    >>> check_dict_case([\"a\": \"apple\", 8L: \"banana\", \"a\": \"apple\"].nullable)\n    false\n    >>> check_dict_case([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable)\n    false\n    >>> check_dict_case([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable)\n    true\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "prompt": "import std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -45,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_85_add",
+    "name": "HumanEval_102_choose_num",
     "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a non-empty array of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4L, 2L, 6L, 7L])\n    2L\n    \n*/\nlong add(long[] lst) \n",
+    "prompt": "import std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12L, 15L)\n    14L\n    >>> choose_num(13L, 12L)\n    -1L\n    \n*/\nlong choose_num(long x, long y) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -60,178 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_140_fix_spaces",
+    "name": "HumanEval_104_unique_digits",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
+    "prompt": "import std.math;\n/*\nGiven an array of positive integers x. return a sorted array of all \n    elements that hasn't any even digit.\n\n    Note: Returned array should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15L, 33L, 1422L, 1L])\n    [1L, 15L, 33L]\n    >>> unique_digits([152L, 323L, 1422L, 10L])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1L)\n    0L\n    >>> fibfib(5L)\n    4L\n    >>> fibfib(8L)\n    24L\n    \n*/\nlong fibfib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given an array of numbers, return the sum of squares of the numbers\n    in the array that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1L, 3L, 2L, 0L])\n    10L\n    >>> double_the_difference([-1L, -2L, 0L])\n    0L\n    >>> double_the_difference([9L, -2L])\n    81L\n    >>> double_the_difference([0L])\n    0L\n   \n    If the input array is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return array of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4L, 2L, 1L, 2L, 2L, 1L, 1L, 1L, 1L, 4L, 4L]\n    \n*/\nlong[] parse_music(string music_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15L)\n    \"db1111db\"\n    >>> decimal_to_binary(32L)\n    \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return array of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \n*/\nstring[] all_prefixes(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nAdd two numbers x and y\n    >>> add(2L, 3L)\n    5L\n    >>> add(5L, 7L)\n    12L\n    \n*/\nlong add(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5L, 6L, 10L)\n    [11L, 4L]\n    >>> eat(4L, 8L, 9L)\n    [12L, 1L]\n    >>> eat(1L, 10L, 10L)\n    [11L, 0L]\n    >>> eat(2L, 11L, 5L)\n    [7L, 0L]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L)\n    6L\n\n    Example 2:\n    >>> max_fill([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L)\n    5L\n    \n    Example 3:\n    >>> max_fill([[0L, 0L, 0L], [0L, 0L, 0L]], 5L)\n    0L\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given two arrays operator, and operand. The first array has basic algebra operations, and \n    the second array is an array of integers. Use the two given arrays to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator array is equal to the length of operand array minus one.\n        Operand is an array of of non-negative integers.\n        Operator array has at least one operator, and operand array has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \n*/\nstring flip_case(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -244,7 +79,7 @@
     "language": "d",
     "prompt": "import std.math;\n/*\n\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1L, -1L, 55L])\n    [\"One\"]\n    \n*/\nstring[] by_length(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = by_length;\n\n    assert(candidate([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -1L, 55L]) == [\"One\"]);\n    assert(candidate([1L, -1L, 3L, 2L]) == [\"Three\", \"Two\", \"One\"]);\n    assert(candidate([9L, 4L, 8L]) == [\"Nine\", \"Eight\", \"Four\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -255,341 +90,11 @@
     ]
   },
   {
-    "name": "HumanEval_25_factorize",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return array of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8L)\n    [2L, 2L, 2L]\n    >>> factorize(25L)\n    [5L, 5L]\n    >>> factorize(70L)\n    [2L, 5L, 7L]\n    \n*/\nlong[] factorize(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5L)\n    [2L, 3L]\n    >>> count_up_to(11L)\n    [2L, 3L, 5L, 7L]\n    >>> count_up_to(0L)\n    []\n    >>> count_up_to(20L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]\n    >>> count_up_to(1L)\n    []\n    >>> count_up_to(18L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L]\n    \n*/\nlong[] count_up_to(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn sorted unique elements in an array\n    >>> unique([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [0L, 2L, 3L, 5L, 9L, 123L]\n    \n*/\nlong[] unique(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Write a function that accepts two arrays of strings and returns the array that has \n    total number of chars in the all strings of the array less than the other array.\n\n    if the two arrays have the same number of chars, return the first array.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn maximum element in the array.\n    >>> max_element([1L, 2L, 3L])\n    3L\n    >>> max_element([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    123L\n    \n*/\nlong max_element(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return true if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \n*/\nbool is_nested(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nGiven an array of strings, where each string consists of only digits, return an array.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return true else return false.\n    If the given array is empty then return true.\n\n    Note: The given array is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3L, 4L, 5L, 1L, 2L])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3L, 5L, 4L, 1L, 2L])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3L)\n    tuple(1L, 2L)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12L)\n    tuple(4L, 6L)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4L)\n    false\n    >>> is_equal_to_sum_even(6L)\n    false\n    >>> is_equal_to_sum_even(8L)\n    true\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3L, 1L, 2L, 4L, 5L])\n    [1L, 4L, 12L, 20L]\n    >>> derivative([1L, 2L, 3L])\n    [2L, 6L]\n    \n*/\nlong[] derivative(long[] xs) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array of numbers, return whether or not they are sorted\n    in ascending order. If array has more than 1 duplicate of the same\n    number, return false. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L])\n    false\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L, 7L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L, 6L, 7L])\n    false\n    >>> is_sorted([1L, 2L, 2L, 3L, 3L, 4L])\n    true\n    >>> is_sorted([1L, 2L, 2L, 2L, 3L, 4L])\n    false\n    \n*/\nbool is_sorted(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \n*/\nstring solve(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return an array of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3L)\n    [1L, 3L, 2L, 8L]\n    \n*/\nlong[] tri(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50L)\n    0L\n    >>> fizz_buzz(78L)\n    2L\n    >>> fizz_buzz(79L)\n    3L\n    \n*/\nlong fizz_buzz(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Filter an input array of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000L)\n    \"1\"\n    >>> solve(150L)\n    \"110\"\n    >>> solve(147L)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered arrays of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered array of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L)\n    [1L, 2L, 1L]\n\n    >>> minPath([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L)\n    [1L]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1L\n    >>> count_upper(\"abcdefg\")\n    0L\n    >>> count_upper(\"dBBE\")\n    0L\n    \n*/\nlong count_upper(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted array \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3L, -4L, 5L], 3L)\n    [-4L, -3L, 5L]\n\n    Example 2:\n\n    >>> maximum([4L, -4L, 4L], 2L)\n    [4L, 4L]\n\n    Example 3:\n\n    >>> maximum([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L)\n    [2L]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15L)\n    5L\n    \n*/\nlong largest_divisor(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array of non-negative integers, return a cod of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5L])\n    [5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L])\n    [0L, 1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L, 6L])\n    [6L, 5L, 4L, 3L, 2L, 1L, 0L]\n    \n*/\nlong[] sort_array(long[] array) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "HumanEval_106_f",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5L)\n    [1L, 2L, 6L, 24L, 15L]\n    \n*/\nlong[] f(long n) \n",
+    "prompt": "import std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5L)\n    [1L, 2L, 6L, 24L, 15L]\n    \n*/\nlong[] f(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -600,793 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes an integer a and returns true \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1L)\n    true\n    >>> iscube(2L)\n    false\n    >>> iscube(-1L)\n    true\n    >>> iscube(64L)\n    true\n    >>> iscube(0L)\n    true\n    >>> iscube(180L)\n    false\n    \n*/\nbool iscube(long a) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3L)\n    tuple(1L, 2L)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12L)\n    tuple(4L, 6L)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \n*/\nstring encode(string message) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0L\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1L\n    \n*/\nlong is_bored(string S) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    pairs_sum_to_zero takes an array of integers as an input.\n    it returns true if there are two distinct elements in the array that\n    sum to zero, and false otherwise.\n    >>> pairs_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> pairs_sum_to_zero([1L, 3L, -2L, 1L])\n    false\n    >>> pairs_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> pairs_sum_to_zero([2L, 4L, -5L, 3L, 5L, 7L])\n    true\n    >>> pairs_sum_to_zero([1L])\n    false\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3L, 4L, 5L)\n    6.0\n    >>> triangle_area(1L, 2L, 10L)\n    -1L\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1L)\n    1L\n    >>> digits(4L)\n    0L\n    >>> digits(235L)\n    15L\n    \n*/\nlong digits(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0L\n    >>> how_many_times(\"aaa\", \"a\")\n    3L\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3L\n    \n*/\nlong how_many_times(string string, string substring) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \n*/\nstring remove_vowels(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given array of integers, return array in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1L, 2L, 3L, 4L])\n    [1L, 4L, 2L, 3L]\n    >>> strange_sort_list([5L, 5L, 5L, 5L])\n    [5L, 5L, 5L, 5L]\n    >>> strange_sort_list([])\n    []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    tuple(2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    tuple(2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1L, 4L)\n    true\n    >>> is_simple_power(2L, 2L)\n    true\n    >>> is_simple_power(8L, 2L)\n    true\n    >>> is_simple_power(3L, 2L)\n    false\n    >>> is_simple_power(3L, 1L)\n    false\n    >>> is_simple_power(5L, 3L)\n    false\n    \n*/\nbool is_simple_power(long x, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1L)\n    2L\n    >>> prime_fib(2L)\n    3L\n    >>> prime_fib(3L)\n    5L\n    >>> prime_fib(4L)\n    13L\n    >>> prime_fib(5L)\n    89L\n    \n*/\nlong prime_fib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function which sorts the given array of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original array.\n\n    For example:\n    >>> order_by_points([1L, 11L, -1L, -11L, -12L])\n    [-1L, -11L, 1L, -12L, 11L]\n    >>> order_by_points([])\n    []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Check if in given array of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \n*/\nstring make_palindrome(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \n*/\nstring string_xor(string a, string b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4L)\n    288L\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L)\n    24L\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5L)\n    4L\n    >>> fib4(6L)\n    8L\n    >>> fib4(7L)\n    14L\n    \n*/\nlong fib4(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven an array of positive integers x. return a sorted array of all \n    elements that hasn't any even digit.\n\n    Note: Returned array should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15L, 33L, 1422L, 1L])\n    [1L, 15L, 33L]\n    >>> unique_digits([152L, 323L, 1422L, 10L])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns an array of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty array.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4L)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3L)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2L)\n    []\n    >>> select_words(\"Hello world\", 4L)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3L)\n    [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that returns true if the object q will fly, and false otherwise.\n    The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1L, 2L], 5L)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3L, 2L, 3L], 1L)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3L, 2L, 3L], 9L)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3L], 5L)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10L)\n    55L\n    >>> fib(1L)\n    1L\n    >>> fib(8L)\n    21L\n    \n*/\nlong fib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou will be given the name of a class (a string) and an array of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the array.\n    For example, if you are given \"Slices\" as the class and an array of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given an array of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \n*/\nstring match_parens(string[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given an array of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the array.\n    Return null if there is no such element.\n    >>> next_smallest([1L, 2L, 3L, 4L, 5L])\n    2L\n    >>> next_smallest([5L, 1L, 4L, 3L, 2L])\n    2L\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1L, 1L])\n    None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5L, 2L, 7L)\n    true\n    \n    >>> any_int(3L, 2L, 2L)\n    false\n\n    >>> any_int(3L, -2L, 1L)\n    true\n    \n    >>> any_int(3.6, -2.2, 2L)\n    false\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn array with elements incremented by 1.\n    >>> incr_list([1L, 2L, 3L])\n    [2L, 3L, 4L]\n    >>> incr_list([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [6L, 4L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]\n    \n*/\nlong[] incr_list(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7L, 34L, 12L)\n    34L\n    >>> x_or_y(15L, 8L, 5L)\n    5L\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3L, 5L)\n    3L\n    >>> modp(1101L, 101L)\n    2L\n    >>> modp(0L, 101L)\n    1L\n    >>> modp(3L, 11L)\n    8L\n    >>> modp(100L, 101L)\n    1L\n    \n*/\nlong modp(long n, long p) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12L)\n    tuple(1L, 1L)\n    >>> even_odd_count(123L)\n    tuple(1L, 2L)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a string s.\n    Your task is to check if the string is hapd or not.\n    A string is hapd if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \n*/\nbool is_happy(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195L)\n    29L\n    >>> largest_prime_factor(2048L)\n    2L\n    \n*/\nlong largest_prime_factor(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0L\n    >>> digitSum(\"abAB\")\n    131L\n    >>> digitSum(\"abcCd\")\n    67L\n    >>> digitSum(\"helloE\")\n    69L\n    >>> digitSum(\"woArBld\")\n    131L\n    >>> digitSum(\"aAaaaXa\")\n    153L\n    \n*/\nlong digitSum(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given array of numbers (of at least two elements), apply a linear transform to that array,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5L, 8L, 7L, 1L])\n    12L\n    >>> solution([3L, 3L, 3L, 3L, 3L])\n    9L\n    >>> solution([30L, 13L, 24L, 321L])\n    0L\n    \n*/\nlong solution(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in an array, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5L, 0L, 3L, 0L, 4L, 2L])\n    [0L, 1L]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5L)\n    1L\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nIn this problem, you will implement a function that takes two arrays of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 an array of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L])\n    \"YES\"\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L])\n    \"NO\"\n    It is assumed that the input arrays will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn median of elements in the array l.\n    >>> median([3L, 1L, 2L, 4L, 5L])\n    3L\n    >>> median([-10L, 4L, 6L, 1000L, 10L, 20L])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that takes a string and returns true if the string\n    length is a prime number or false otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \n*/\nbool prime_length(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L])\n    4L\n    >>> smallest_change([1L, 2L, 3L, 4L, 3L, 2L, 2L])\n    1L\n    >>> smallest_change([1L, 2L, 3L, 2L, 1L])\n    0L\n    \n*/\nlong smallest_change(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given an array of numbers.\n    You need to return the sum of squared numbers in the given array,\n    round each element in the array to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14L\n    >>> lst([1.0, 4.0, 9.0])\n    98L\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84L\n    >>> lst([1.4, 4.2, 0.0])\n    29L\n    >>> lst([-2.4, 1.0, 1.0])\n    6L\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \n*/\nstring file_name_check(string file_name) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    triples_sum_to_zero takes an array of integers as an input.\n    it returns true if there are three distinct elements in the array that\n    sum to zero, and false otherwise.\n\n    >>> triples_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> triples_sum_to_zero([1L, 3L, -2L, 1L])\n    true\n    >>> triples_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> triples_sum_to_zero([2L, 4L, -5L, 3L, 9L, 7L])\n    true\n    >>> triples_sum_to_zero([1L])\n    false\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection(tuple(1L, 2L), tuple(2L, 3L))\n    \"NO\"\n    >>> intersection(tuple(-1L, 1L), tuple(0L, 4L))\n    \"NO\"\n    >>> intersection(tuple(-3L, -1L), tuple(-5L, 5L))\n    \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the array of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L])\n    [0L, 0L, 0L, 0L, 3L, 3L]\n    >>> compare([0L, 5L, 0L, 0L, 0L, 4L], [4L, 1L, 1L, 0L, 0L, -2L])\n    [4L, 4L, 1L, 0L, 0L, 6L]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that returns true if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and false otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou have to write a function which validates a given date string and\n    returns true if the date is valid otherwise false.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \n*/\nbool valid_date(string date) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1397,9 +122,9 @@
   {
     "name": "HumanEval_108_count_nums",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0L\n    >>> count_nums([-1L, 11L, -11L])\n    1L\n    >>> count_nums([1L, 1L, 2L])\n    3L\n    \n*/\nlong count_nums(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0L\n    >>> count_nums([-1L, 11L, -11L])\n    1L\n    >>> count_nums([1L, 1L, 2L])\n    3L\n    \n*/\nlong count_nums(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = count_nums;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([-1L, -2L, 0L]) == 0L);\n    assert(candidate([1L, 1L, 2L, -2L, 3L, 4L, 5L]) == 6L);\n    assert(candidate([1L, 6L, 9L, -6L, 0L, 1L, 5L]) == 5L);\n    assert(candidate([1L, 100L, 98L, -7L, 1L, -1L]) == 4L);\n    assert(candidate([12L, 23L, 34L, -45L, -56L, 0L]) == 5L);\n    assert(candidate([0L, 1L]) == 1L);\n    assert(candidate([1L]) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1410,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_86_anti_shuffle",
+    "name": "HumanEval_109_move_one_ball",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \n*/\nstring anti_shuffle(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return true else return false.\n    If the given array is empty then return true.\n\n    Note: The given array is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3L, 4L, 5L, 1L, 2L])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3L, 5L, 4L, 1L, 2L])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1425,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_48_is_palindrome",
+    "name": "HumanEval_10_make_palindrome",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \n*/\nbool is_palindrome(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \n*/\nstring make_palindrome(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1440,73 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_118_get_closest_vowel",
+    "name": "HumanEval_110_exchange",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIn this problem, you will implement a function that takes two arrays of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 an array of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L])\n    \"YES\"\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L])\n    \"NO\"\n    It is assumed that the input arrays will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6L)\n    false\n    >>> is_prime(101L)\n    true\n    >>> is_prime(11L)\n    true\n    >>> is_prime(13441L)\n    true\n    >>> is_prime(61L)\n    true\n    >>> is_prime(4L)\n    false\n    >>> is_prime(1L)\n    false\n    \n*/\nbool is_prime(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns true if x * n evaluates to a whole number and false\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \n*/\nbool simplify(string x, string n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1L\n    >>> hex_key(\"1077E\")\n    2L\n    >>> hex_key(\"ABED1A33\")\n    4L\n    >>> hex_key(\"123456789ABCDEF0\")\n    6L\n    >>> hex_key(\"2020\")\n    2L\n    \n*/\nlong hex_key(string num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1517,9 +182,9 @@
   {
     "name": "HumanEval_111_histogram",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven a string representing a space separated lowercase letters, return an associative array\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    [\"a\": 1L, \"b\": 1L, \"c\": 1L].nullable\n    >>> histogram(\"a b b a\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"a b c a b\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"b b b b a\")\n    [\"b\": 4L].nullable\n    >>> histogram(\"\")\n    ___null_dict___\n\n    \n*/\nNullable!(long[string]) histogram(string test) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string representing a space separated lowercase letters, return an associative array\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    [\"a\": 1L, \"b\": 1L, \"c\": 1L].nullable\n    >>> histogram(\"a b b a\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"a b c a b\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"b b b b a\")\n    [\"b\": 4L].nullable\n    >>> histogram(\"\")\n    ___null_dict___\n\n    \n*/\nNullable!(long[string]) histogram(string test) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = histogram;\n\n{\n        auto result = candidate(\"a b b a\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c a b\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c d g\");\n        assert(!result.isNull && result.get == [\"a\": 1L, \"b\": 1L, \"c\": 1L, \"d\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"b b b b a\");\n        assert(!result.isNull && result.get == [\"b\": 4L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"a\");\n        assert(!result.isNull && result.get == [\"a\": 1L]);\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1530,446 +195,11 @@
     ]
   },
   {
-    "name": "HumanEval_87_get_row",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a 2 dimensional data, as a nested arrays,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the array,\n    and return array of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L)\n    [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]\n    >>> get_row([], 1L)\n    []\n    >>> get_row([[], [1L], [1L, 2L, 3L]], 3L)\n    [tuple(2L, 2L)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned array sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5L)\n    [1L, 5L]\n    \n*/\nlong[] get_odd_collatz(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1L, 2L, 4L, 3L, 5L])\n    3L\n    >>> can_arrange([1L, 2L, 3L])\n    -1L\n    \n*/\nlong can_arrange(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \n*/\nstring sort_numbers(string numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12L, 1L)\n    \"21\"\n    >>> circular_shift(12L, 2L)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\"\n    This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1L, 2L, 3L]\n    >>> lst\n    []\n    >>> lst\n    [-1L, -5L, 2L, -1L, -5L]\n    \n*/\nlong sum_squares(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given an array of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L])\n    10L\n    >>> skjkasdkd([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L])\n    25L\n    >>> skjkasdkd([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L])\n    13L\n    >>> skjkasdkd([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L])\n    11L\n    >>> skjkasdkd([0L, 81L, 12L, 3L, 1L, 21L])\n    3L\n    >>> skjkasdkd([0L, 8L, 1L, 2L, 1L, 7L])\n    7L\n    \n*/\nlong skjkasdkd(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given array of integers, return a tuple consisting of a sum and a product of all the integers in an array.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    tuple(0L, 1L)\n    >>> sum_product([1L, 2L, 3L, 4L])\n    tuple(10L, 24L)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12L, 15L)\n    14L\n    >>> choose_num(13L, 12L)\n    -1L\n    \n*/\nlong choose_num(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in an array.\n    If there is no negative or positive integers, return them as null.\n\n    Examples:\n    >>> largest_smallest_integers([2L, 4L, 1L, 3L, 5L, 7L])\n    tuple(None, 1L)\n    >>> largest_smallest_integers([])\n    tuple(None, None)\n    >>> largest_smallest_integers([0L])\n    tuple(None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3L\n    >>> count_distinct_characters(\"Jerry\")\n    4L\n    \n*/\nlong count_distinct_characters(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_100_make_a_pile",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in an array, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3L)\n    [3L, 5L, 7L]\n    \n*/\nlong[] make_a_pile(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return null for empty arr.\n\n    Example:\n    >>> prod_signs([1L, 2L, 2L, -4L])\n    9L\n    >>> prod_signs([0L, 1L])\n    0L\n    >>> prod_signs([])\n    None\n    \n*/\nNullable!(long) prod_signs(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2L, 3L, 4L, 1L, 2L, 4L])\n    1L\n    >>> minSubArraySum([-1L, -2L, -3L])\n    -6L\n    \n*/\nlong minSubArraySum(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0L)\n    \"0\"\n    >>> string_sequence(5L)\n    \"0 1 2 3 4 5\"\n    \n*/\nstring string_sequence(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nYou are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn true is array elements are monotonically increasing or decreasing.\n    >>> monotonic([1L, 2L, 4L, 20L])\n    true\n    >>> monotonic([1L, 20L, 4L, 10L])\n    false\n    >>> monotonic([4L, 1L, 0L, -10L])\n    true\n    \n*/\nbool monotonic(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Out of array of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return null in case the input array is empty.\n    >>> longest([])\n    None\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \n*/\nNullable!(string) longest(string[] strings) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn true if all numbers in the array l are below threshold t.\n    >>> below_threshold([1L, 2L, 4L, 10L], 100L)\n    true\n    >>> below_threshold([1L, 20L, 4L, 10L], 5L)\n    false\n    \n*/\nbool below_threshold(long[] l, long t) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30L)\n    true\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn only positive numbers in the array.\n    >>> get_positive([-1L, 2L, -4L, 5L, 6L])\n    [2L, 5L, 6L]\n    >>> get_positive([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    [5L, 3L, 2L, 3L, 9L, 123L, 1L]\n    \n*/\nlong[] get_positive(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes an array l and returns an array l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_third([5L, 6L, 3L, 4L, 8L, 9L, 2L])\n    [2L, 6L, 3L, 4L, 8L, 9L, 5L]\n    \n*/\nlong[] sort_third(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2L, 3L, 1L, 3L]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5L, 3L)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148L, 412L)\n    16L\n    >>> multiply(19L, 28L)\n    72L\n    >>> multiply(2020L, 1851L)\n    0L\n    >>> multiply(14L, -15L)\n    20L\n    \n*/\nlong multiply(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n For a given array of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nReturn sorted unique common elements for two arrays.\n    >>> common([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L])\n    [1L, 5L, 653L]\n    >>> common([5L, 3L, 2L, 8L], [3L, 2L])\n    [2L, 3L]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19L)\n    \"xix\"\n    >>> int_to_mini_roman(152L)\n    \"clii\"\n    >>> int_to_mini_roman(426L)\n    \"cdxxvi\"\n    \n*/\nstring int_to_mini_roman(long number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19L)\n    8L\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3L)\n    2L\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100L)\n    95L\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120L)\n    19L\n    \n*/\nlong fruit_distribution(string s, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "HumanEval_112_reverse_delete",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and true/false for the check.\n    Example\n    >>> reverse_delete(\"abcde\", \"ae\")\n    tuple(\"bcd\", false)\n    >>> reverse_delete(\"abcdef\", \"b\")\n    tuple(\"acdef\", false)\n    >>> reverse_delete(\"abcdedcba\", \"ab\")\n    tuple(\"cdedc\", true)\n    \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and true/false for the check.\n    Example\n    >>> reverse_delete(\"abcde\", \"ae\")\n    tuple(\"bcd\", false)\n    >>> reverse_delete(\"abcdef\", \"b\")\n    tuple(\"acdef\", false)\n    >>> reverse_delete(\"abcdedcba\", \"ab\")\n    tuple(\"cdedc\", true)\n    \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = reverse_delete;\n\n    assert(candidate(\"abcde\", \"ae\") == tuple(\"bcd\", false));\n    assert(candidate(\"abcdef\", \"b\") == tuple(\"acdef\", false));\n    assert(candidate(\"abcdedcba\", \"ab\") == tuple(\"cdedc\", true));\n    assert(candidate(\"dwik\", \"w\") == tuple(\"dik\", false));\n    assert(candidate(\"a\", \"a\") == tuple(\"\", true));\n    assert(candidate(\"abcdedcba\", \"\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"abcdedcba\", \"v\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"vabba\", \"v\") == tuple(\"abba\", true));\n    assert(candidate(\"mamma\", \"mia\") == tuple(\"\", true));\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1980,13 +210,43 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3L, 5L)\n    1L\n    >>> greatest_common_divisor(25L, 15L)\n    5L\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an array of strings, where each string consists of only digits, return an array.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2L, 3L, 4L, 1L, 2L, 4L])\n    1L\n    >>> minSubArraySum([-1L, -2L, -3L])\n    -6L\n    \n*/\nlong minSubArraySum(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L)\n    6L\n\n    Example 2:\n    >>> max_fill([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L)\n    5L\n    \n    Example 3:\n    >>> max_fill([[0L, 0L, 0L], [0L, 0L, 0L]], 5L)\n    0L\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1997,9 +257,9 @@
   {
     "name": "HumanEval_116_sort_array",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1L, 5L, 2L, 3L, 4L])\n    [1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([-2L, -3L, -4L, -5L, -6L])\n    [-6L, -5L, -4L, -3L, -2L]\n    >>> sort_array([1L, 0L, 2L, 3L, 4L])\n    [0L, 1L, 2L, 3L, 4L]\n    \n*/\nlong[] sort_array(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1L, 5L, 2L, 3L, 4L])\n    [1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([-2L, -3L, -4L, -5L, -6L])\n    [-6L, -5L, -4L, -3L, -2L]\n    >>> sort_array([1L, 0L, 2L, 3L, 4L])\n    [0L, 1L, 2L, 3L, 4L]\n    \n*/\nlong[] sort_array(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([1L, 5L, 2L, 3L, 4L]) == [1L, 2L, 4L, 3L, 5L]);\n    assert(candidate([-2L, -3L, -4L, -5L, -6L]) == [-4L, -2L, -6L, -5L, -3L]);\n    assert(candidate([1L, 0L, 2L, 3L, 4L]) == [0L, 1L, 2L, 4L, 3L]);\n    assert(candidate([]) == []);\n    assert(candidate([2L, 5L, 77L, 4L, 5L, 3L, 5L, 7L, 2L, 3L, 4L]) == [2L, 2L, 4L, 4L, 3L, 3L, 5L, 5L, 5L, 7L, 77L]);\n    assert(candidate([3L, 6L, 44L, 12L, 32L, 5L]) == [32L, 3L, 5L, 6L, 12L, 44L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2010,13 +270,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Concatenate array of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \n*/\nstring concatenate(string[] strings) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns an array of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty array.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4L)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3L)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2L)\n    []\n    >>> select_words(\"Hello world\", 4L)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3L)\n    [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2025,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that accepts an array of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted array with a sorted order,\n    The array is always an array of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the array should be ascending by length of each word, and you\n    should return the array sorted by that rule.\n    If two words have the same length, sort the array alphabetically.\n    The function should return an array of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2040,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Filter an input array of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \n*/\nstring match_parens(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2055,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10L\n    >>> closest_integer(\"15.3\")\n    15L\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \n*/\nstring string_xor(string a, string b) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2070,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2L\n    >>> vowels_count(\"ACEDY\")\n    3L\n    \n*/\nlong vowels_count(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted array \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3L, -4L, 5L], 3L)\n    [-4L, -3L, 5L]\n\n    Example 2:\n\n    >>> maximum([4L, -4L, 4L], 2L)\n    [4L, 4L]\n\n    Example 3:\n\n    >>> maximum([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L)\n    [2L]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2085,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that accepts an array of strings.\n    The array contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5L, 8L, 7L, 1L])\n    12L\n    >>> solution([3L, 3L, 3L, 3L, 3L])\n    9L\n    >>> solution([30L, 13L, 24L, 321L])\n    0L\n    \n*/\nlong solution(long[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2100,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return null.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L)\n    24L\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2115,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8L, 3L)\n    \"22\"\n    >>> change_base(8L, 2L)\n    \"1000\"\n    >>> change_base(7L, 2L)\n    \"111\"\n    \n*/\nstring change_base(long x, long base) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned array sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5L)\n    [1L, 5L]\n    \n*/\nlong[] get_odd_collatz(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2130,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given the lengths of the three sides of a triangle. Return true if the three\n    sides form a right-angled triangle, false otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3L, 4L, 5L)\n    true\n    >>> right_angle_triangle(1L, 2L, 3L)\n    false\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns true if the date is valid otherwise false.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \n*/\nbool valid_date(string date) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2145,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you an array of GPAs for some students and you have to write \n    a function that can output an array of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3L, 1.7, 2L, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of numbers, return whether or not they are sorted\n    in ascending order. If array has more than 1 duplicate of the same\n    number, return false. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L])\n    false\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L, 7L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L, 6L, 7L])\n    false\n    >>> is_sorted([1L, 2L, 2L, 3L, 3L, 4L])\n    true\n    >>> is_sorted([1L, 2L, 2L, 2L, 3L, 4L])\n    false\n    \n*/\nbool is_sorted(long[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2160,13 +420,298 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n    >>> intersperse([], 4L)\n    []\n    >>> intersperse([1L, 2L, 3L], 4L)\n    [1L, 4L, 2L, 4L, 3L]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection(tuple(1L, 2L), tuple(2L, 3L))\n    \"NO\"\n    >>> intersection(tuple(-1L, 1L), tuple(0L, 4L))\n    \"NO\"\n    >>> intersection(tuple(-3L, -1L), tuple(-5L, 5L))\n    \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return null for empty arr.\n\n    Example:\n    >>> prod_signs([1L, 2L, 2L, -4L])\n    9L\n    >>> prod_signs([0L, 1L])\n    0L\n    >>> prod_signs([])\n    None\n    \n*/\nNullable!(long) prod_signs(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered arrays of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered array of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L)\n    [1L, 2L, 1L]\n\n    >>> minPath([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L)\n    [1L]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of array of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return null in case the input array is empty.\n    >>> longest([])\n    None\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \n*/\nNullable!(string) longest(string[] strings) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return an array of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3L)\n    [1L, 3L, 2L, 8L]\n    \n*/\nlong[] tri(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1L)\n    1L\n    >>> digits(4L)\n    0L\n    >>> digits(235L)\n    15L\n    \n*/\nlong digits(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return true if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \n*/\nbool is_nested(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given an array of numbers.\n    You need to return the sum of squared numbers in the given array,\n    round each element in the array to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14L\n    >>> lst([1.0, 4.0, 9.0])\n    98L\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84L\n    >>> lst([1.4, 4.2, 0.0])\n    29L\n    >>> lst([-2.4, 1.0, 1.0])\n    6L\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns true if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and false otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1L, 2L, 4L, 3L, 5L])\n    3L\n    >>> can_arrange([1L, 2L, 3L])\n    -1L\n    \n*/\nlong can_arrange(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in an array.\n    If there is no negative or positive integers, return them as null.\n\n    Examples:\n    >>> largest_smallest_integers([2L, 4L, 1L, 3L, 5L, 7L])\n    tuple(None, 1L)\n    >>> largest_smallest_integers([])\n    tuple(None, None)\n    >>> largest_smallest_integers([0L])\n    tuple(None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4L)\n    false\n    >>> is_equal_to_sum_even(6L)\n    false\n    >>> is_equal_to_sum_even(8L)\n    true\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4L)\n    288L\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3L, 5L)\n    1L\n    >>> greatest_common_divisor(25L, 15L)\n    5L\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \n*/\nstring file_name_check(string file_name) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1L, 2L, 3L]\n    >>> lst\n    []\n    >>> lst\n    [-1L, -5L, 2L, -1L, -5L]\n    \n*/\nlong sum_squares(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns true if x * n evaluates to a whole number and false\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \n*/\nbool simplify(string x, string n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given array of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original array.\n\n    For example:\n    >>> order_by_points([1L, 11L, -1L, -11L, -12L])\n    [-1L, -11L, 1L, -12L, 11L]\n    >>> order_by_points([])\n    []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2177,9 +722,9 @@
   {
     "name": "HumanEval_146_specialFilter",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15L, -73L, 14L, -15L])\n    1L\n    >>> specialFilter([33L, -2L, -3L, 45L, 21L, 109L])\n    2L\n    \n*/\nlong specialFilter(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15L, -73L, 14L, -15L])\n    1L\n    >>> specialFilter([33L, -2L, -3L, 45L, 21L, 109L])\n    2L\n    \n*/\nlong specialFilter(long[] nums) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = specialFilter;\n\n    assert(candidate([5L, -2L, 1L, -5L]) == 0L);\n    assert(candidate([15L, -73L, 14L, -15L]) == 1L);\n    assert(candidate([33L, -2L, -3L, 45L, 21L, 109L]) == 2L);\n    assert(candidate([43L, -12L, 93L, 125L, 121L, 109L]) == 4L);\n    assert(candidate([71L, -2L, -33L, 75L, 21L, 19L]) == 3L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([]) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2190,13 +735,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30L)\n    465L\n    >>> sum_to_n(100L)\n    5050L\n    >>> sum_to_n(5L)\n    15L\n    >>> sum_to_n(10L)\n    55L\n    >>> sum_to_n(1L)\n    1L\n    \n*/\nlong sum_to_n(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5L)\n    1L\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2205,13 +750,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From an array of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1L, 2L, 3L, 2L, 4L])\n    [1L, 3L, 4L]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts an array of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted array with a sorted order,\n    The array is always an array of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the array should be ascending by length of each word, and you\n    should return the array sorted by that rule.\n    If two words have the same length, sort the array alphabetically.\n    The function should return an array of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return array of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \n*/\nstring[] all_prefixes(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7L, 34L, 12L)\n    34L\n    >>> x_or_y(15L, 8L, 5L)\n    5L\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of numbers, return the sum of squares of the numbers\n    in the array that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1L, 3L, 2L, 0L])\n    10L\n    >>> double_the_difference([-1L, -2L, 0L])\n    0L\n    >>> double_the_difference([9L, -2L])\n    81L\n    >>> double_the_difference([0L])\n    0L\n   \n    If the input array is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L])\n    [0L, 0L, 0L, 0L, 3L, 3L]\n    >>> compare([0L, 5L, 0L, 0L, 0L, 4L], [4L, 1L, 1L, 0L, 0L, -2L])\n    [4L, 4L, 1L, 0L, 0L, 6L]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and an array of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the array.\n    For example, if you are given \"Slices\" as the class and an array of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12L)\n    tuple(1L, 1L)\n    >>> even_odd_count(123L)\n    tuple(1L, 2L)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19L)\n    \"xix\"\n    >>> int_to_mini_roman(152L)\n    \"clii\"\n    >>> int_to_mini_roman(426L)\n    \"cdxxvi\"\n    \n*/\nstring int_to_mini_roman(long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return true if the three\n    sides form a right-angled triangle, false otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3L, 4L, 5L)\n    true\n    >>> right_angle_triangle(1L, 2L, 3L)\n    false\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts an array of strings.\n    The array contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5L, 6L, 10L)\n    [11L, 4L]\n    >>> eat(4L, 8L, 9L)\n    [12L, 1L]\n    >>> eat(1L, 10L, 10L)\n    [11L, 0L]\n    >>> eat(2L, 11L, 5L)\n    [7L, 0L]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0L)\n    \"0\"\n    >>> string_sequence(5L)\n    \"0 1 2 3 4 5\"\n    \n*/\nstring string_sequence(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two arrays operator, and operand. The first array has basic algebra operations, and \n    the second array is an array of integers. Use the two given arrays to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator array is equal to the length of operand array minus one.\n        Operand is an array of of non-negative integers.\n        Operator array has at least one operator, and operand array has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \n*/\nstring solve(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return null.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2222,9 +992,9 @@
   {
     "name": "HumanEval_163_generate_integers",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2L, 8L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(8L, 2L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(10L, 14L)\n    []\n    \n*/\nlong[] generate_integers(long a, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2L, 8L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(8L, 2L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(10L, 14L)\n    []\n    \n*/\nlong[] generate_integers(long a, long b) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = generate_integers;\n\n    assert(candidate(2L, 10L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(10L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(132L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(17L, 89L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2235,13 +1005,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n From a given array of integers, generate an array of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1L, 2L, 3L, 2L, 3L, 4L, 2L])\n    [1L, 2L, 3L, 3L, 3L, 4L, 4L]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3L\n    >>> count_distinct_characters(\"Jerry\")\n    4L\n    \n*/\nlong count_distinct_characters(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2250,13 +1020,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n You're given an array of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return true. Otherwise it should return false.\n    >>> below_zero([1L, 2L, 3L])\n    false\n    >>> below_zero([1L, 2L, -4L, 5L])\n    true\n    \n*/\nbool below_zero(long[] operations) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return array of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4L, 2L, 1L, 2L, 2L, 1L, 1L, 1L, 1L, 4L, 4L]\n    \n*/\nlong[] parse_music(string music_string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2265,13 +1035,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the array.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4L, 1L, 2L, 2L, 3L, 1L])\n    2L\n    >>> search([1L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L])\n    3L\n    >>> search([5L, 5L, 4L, 4L, 4L])\n    -1L\n    \n*/\nlong search(long[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0L\n    >>> how_many_times(\"aaa\", \"a\")\n    3L\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3L\n    \n*/\nlong how_many_times(string string, string substring) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2280,13 +1050,268 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n brackets is a string of \"(\" and \")\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \n*/\nstring sort_numbers(string numbers) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the array of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    tuple(2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    tuple(2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given array of numbers (of at least two elements), apply a linear transform to that array,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return length of given string\n    >>> strlen(\"\")\n    0L\n    >>> strlen(\"abc\")\n    3L\n    \n*/\nlong strlen(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15L)\n    5L\n    \n*/\nlong largest_divisor(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return array of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8L)\n    [2L, 2L, 2L]\n    >>> factorize(25L)\n    [5L, 5L]\n    >>> factorize(70L)\n    [2L, 5L, 7L]\n    \n*/\nlong[] factorize(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From an array of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1L, 2L, 3L, 2L, 4L])\n    [1L, 3L, 4L]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \n*/\nstring flip_case(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate array of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \n*/\nstring concatenate(string[] strings) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input array of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the array.\n    >>> get_positive([-1L, 2L, -4L, 5L, 6L])\n    [2L, 5L, 6L]\n    >>> get_positive([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    [5L, 3L, 2L, 3L, 9L, 123L, 1L]\n    \n*/\nlong[] get_positive(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6L)\n    false\n    >>> is_prime(101L)\n    true\n    >>> is_prime(11L)\n    true\n    >>> is_prime(13441L)\n    true\n    >>> is_prime(61L)\n    true\n    >>> is_prime(4L)\n    false\n    >>> is_prime(1L)\n    false\n    \n*/\nbool is_prime(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes an array l and returns an array l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_third([5L, 6L, 3L, 4L, 8L, 9L, 2L])\n    [2L, 6L, 3L, 4L, 8L, 9L, 5L]\n    \n*/\nlong[] sort_third(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique elements in an array\n    >>> unique([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [0L, 2L, 3L, 5L, 9L, 123L]\n    \n*/\nlong[] unique(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn maximum element in the array.\n    >>> max_element([1L, 2L, 3L])\n    3L\n    >>> max_element([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    123L\n    \n*/\nlong max_element(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50L)\n    0L\n    >>> fizz_buzz(78L)\n    2L\n    >>> fizz_buzz(79L)\n    3L\n    \n*/\nlong fizz_buzz(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2297,9 +1322,9 @@
   {
     "name": "HumanEval_37_sort_even",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\nThis function takes an array l and returns an array l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_even([5L, 6L, 3L, 4L])\n    [3L, 6L, 5L, 4L]\n    \n*/\nlong[] sort_even(long[] l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes an array l and returns an array l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_even([5L, 6L, 3L, 4L])\n    [3L, 6L, 5L, 4L]\n    \n*/\nlong[] sort_even(long[] l) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = sort_even;\n\n    assert(candidate([1L, 2L, 3L]) == [1L, 2L, 3L]);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [-10L, 3L, -5L, 2L, -3L, 3L, 5L, 0L, 9L, 1L, 123L]);\n    assert(candidate([5L, 8L, -12L, 4L, 23L, 2L, 3L, 11L, 12L, -10L]) == [-12L, 8L, 3L, 4L, 5L, 2L, 12L, 11L, 23L, -10L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2310,11 +1335,251 @@
     ]
   },
   {
+    "name": "HumanEval_39_prime_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1L)\n    2L\n    >>> prime_fib(2L)\n    3L\n    >>> prime_fib(3L)\n    5L\n    >>> prime_fib(4L)\n    13L\n    >>> prime_fib(5L)\n    89L\n    \n*/\nlong prime_fib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given an array of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return true. Otherwise it should return false.\n    >>> below_zero([1L, 2L, 3L])\n    false\n    >>> below_zero([1L, 2L, -4L, 5L])\n    true\n    \n*/\nbool below_zero(long[] operations) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes an array of integers as an input.\n    it returns true if there are three distinct elements in the array that\n    sum to zero, and false otherwise.\n\n    >>> triples_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> triples_sum_to_zero([1L, 3L, -2L, 1L])\n    true\n    >>> triples_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> triples_sum_to_zero([2L, 4L, -5L, 3L, 9L, 7L])\n    true\n    >>> triples_sum_to_zero([1L])\n    false\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn array with elements incremented by 1.\n    >>> incr_list([1L, 2L, 3L])\n    [2L, 3L, 4L]\n    >>> incr_list([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [6L, 4L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]\n    \n*/\nlong[] incr_list(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes an array of integers as an input.\n    it returns true if there are two distinct elements in the array that\n    sum to zero, and false otherwise.\n    >>> pairs_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> pairs_sum_to_zero([1L, 3L, -2L, 1L])\n    false\n    >>> pairs_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> pairs_sum_to_zero([2L, 4L, -5L, 3L, 5L, 7L])\n    true\n    >>> pairs_sum_to_zero([1L])\n    false\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8L, 3L)\n    \"22\"\n    >>> change_base(8L, 2L)\n    \"1000\"\n    >>> change_base(7L, 2L)\n    \"111\"\n    \n*/\nstring change_base(long x, long base) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5L, 3L)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5L)\n    4L\n    >>> fib4(6L)\n    8L\n    >>> fib4(7L)\n    14L\n    \n*/\nlong fib4(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the array l.\n    >>> median([3L, 1L, 2L, 4L, 5L])\n    3L\n    >>> median([-10L, 4L, 6L, 1000L, 10L, 20L])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \n*/\nbool is_palindrome(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3L, 5L)\n    3L\n    >>> modp(1101L, 101L)\n    2L\n    >>> modp(0L, 101L)\n    1L\n    >>> modp(3L, 11L)\n    8L\n    >>> modp(100L, 101L)\n    1L\n    \n*/\nlong modp(long n, long p) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given array of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \n*/\nstring remove_vowels(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if all numbers in the array l are below threshold t.\n    >>> below_threshold([1L, 2L, 4L, 10L], 100L)\n    true\n    >>> below_threshold([1L, 20L, 4L, 10L], 5L)\n    false\n    \n*/\nbool below_threshold(long[] l, long t) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nAdd two numbers x and y\n    >>> add(2L, 3L)\n    5L\n    >>> add(5L, 7L)\n    12L\n    \n*/\nlong add(long x, long y) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "HumanEval_54_same_chars",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n    Check if two words have the same characters.\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n    true\n    >>> same_chars(\"abcd\", \"dddddddabc\")\n    true\n    >>> same_chars(\"dddddddabc\", \"abcd\")\n    true\n    >>> same_chars(\"eabcd\", \"dddddddabc\")\n    false\n    >>> same_chars(\"abcd\", \"dddddddabce\")\n    false\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n    false\n    \n*/\nbool same_chars(string s0, string s1) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Check if two words have the same characters.\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n    true\n    >>> same_chars(\"abcd\", \"dddddddabc\")\n    true\n    >>> same_chars(\"dddddddabc\", \"abcd\")\n    true\n    >>> same_chars(\"eabcd\", \"dddddddabc\")\n    false\n    >>> same_chars(\"abcd\", \"dddddddabce\")\n    false\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n    false\n    \n*/\nbool same_chars(string s0, string s1) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = same_chars;\n\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true);\n    assert(candidate(\"abcd\", \"dddddddabc\") == true);\n    assert(candidate(\"dddddddabc\", \"abcd\") == true);\n    assert(candidate(\"eabcd\", \"dddddddabc\") == false);\n    assert(candidate(\"abcd\", \"dddddddabcf\") == false);\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false);\n    assert(candidate(\"aabb\", \"aaccc\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2325,13 +1590,748 @@
     ]
   },
   {
+    "name": "HumanEval_55_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10L)\n    55L\n    >>> fib(1L)\n    1L\n    >>> fib(8L)\n    21L\n    \n*/\nlong fib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "HumanEval_56_correct_bracketing",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n brackets is a string of \"<\" and \">\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    false\n    >>> correct_bracketing(\"<>\")\n    true\n    >>> correct_bracketing(\"<<><>>\")\n    true\n    >>> correct_bracketing(\"><<>\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"<\" and \">\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    false\n    >>> correct_bracketing(\"<>\")\n    true\n    >>> correct_bracketing(\"<<><>>\")\n    true\n    >>> correct_bracketing(\"><<>\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"<>\") == true);\n    assert(candidate(\"<<><>>\") == true);\n    assert(candidate(\"<><><<><>><>\") == true);\n    assert(candidate(\"<><><<<><><>><>><<><><<>>>\") == true);\n    assert(candidate(\"<<<><>>>>\") == false);\n    assert(candidate(\"><<>\") == false);\n    assert(candidate(\"<\") == false);\n    assert(candidate(\"<<<<\") == false);\n    assert(candidate(\">\") == false);\n    assert(candidate(\"<<>\") == false);\n    assert(candidate(\"<><><<><>><>><<>\") == false);\n    assert(candidate(\"<><><<><>><>>><>\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true is array elements are monotonically increasing or decreasing.\n    >>> monotonic([1L, 2L, 4L, 20L])\n    true\n    >>> monotonic([1L, 20L, 4L, 10L])\n    false\n    >>> monotonic([4L, 1L, 0L, -10L])\n    true\n    \n*/\nbool monotonic(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two arrays.\n    >>> common([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L])\n    [1L, 5L, 653L]\n    >>> common([5L, 3L, 2L, 8L], [3L, 2L])\n    [2L, 3L]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195L)\n    29L\n    >>> largest_prime_factor(2048L)\n    2L\n    \n*/\nlong largest_prime_factor(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n    >>> intersperse([], 4L)\n    []\n    >>> intersperse([1L, 2L, 3L], 4L)\n    [1L, 4L, 2L, 4L, 3L]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30L)\n    465L\n    >>> sum_to_n(100L)\n    5050L\n    >>> sum_to_n(5L)\n    15L\n    >>> sum_to_n(10L)\n    55L\n    >>> sum_to_n(1L)\n    1L\n    \n*/\nlong sum_to_n(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3L, 1L, 2L, 4L, 5L])\n    [1L, 4L, 12L, 20L]\n    >>> derivative([1L, 2L, 3L])\n    [2L, 6L]\n    \n*/\nlong[] derivative(long[] xs) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1L)\n    0L\n    >>> fibfib(5L)\n    4L\n    >>> fibfib(8L)\n    24L\n    \n*/\nlong fibfib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2L\n    >>> vowels_count(\"ACEDY\")\n    3L\n    \n*/\nlong vowels_count(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12L, 1L)\n    \"21\"\n    >>> circular_shift(12L, 2L)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0L\n    >>> digitSum(\"abAB\")\n    131L\n    >>> digitSum(\"abcCd\")\n    67L\n    >>> digitSum(\"helloE\")\n    69L\n    >>> digitSum(\"woArBld\")\n    131L\n    >>> digitSum(\"aAaaaXa\")\n    153L\n    \n*/\nlong digitSum(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19L)\n    8L\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3L)\n    2L\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100L)\n    95L\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120L)\n    19L\n    \n*/\nlong fruit_distribution(string s, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in an array, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5L, 0L, 3L, 0L, 4L, 2L])\n    [0L, 1L]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the array.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4L, 1L, 2L, 2L, 3L, 1L])\n    2L\n    >>> search([1L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L])\n    3L\n    >>> search([5L, 5L, 4L, 4L, 4L])\n    -1L\n    \n*/\nlong search(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2L, 3L, 1L, 3L]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given array of integers, return array in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1L, 2L, 3L, 4L])\n    [1L, 4L, 2L, 3L]\n    >>> strange_sort_list([5L, 5L, 5L, 5L])\n    [5L, 5L, 5L, 5L]\n    >>> strange_sort_list([])\n    []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3L, 4L, 5L)\n    6.0\n    >>> triangle_area(1L, 2L, 10L)\n    -1L\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns true if the object q will fly, and false otherwise.\n    The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1L, 2L], 5L)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3L, 2L, 3L], 1L)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3L, 2L, 3L], 9L)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3L], 5L)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L])\n    4L\n    >>> smallest_change([1L, 2L, 3L, 4L, 3L, 2L, 2L])\n    1L\n    >>> smallest_change([1L, 2L, 3L, 2L, 1L])\n    0L\n    \n*/\nlong smallest_change(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that accepts two arrays of strings and returns the array that has \n    total number of chars in the all strings of the array less than the other array.\n\n    if the two arrays have the same number of chars, return the first array.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30L)\n    true\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1L, 4L)\n    true\n    >>> is_simple_power(2L, 2L)\n    true\n    >>> is_simple_power(8L, 2L)\n    true\n    >>> is_simple_power(3L, 2L)\n    false\n    >>> is_simple_power(3L, 1L)\n    false\n    >>> is_simple_power(5L, 3L)\n    false\n    \n*/\nbool is_simple_power(long x, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes an integer a and returns true \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1L)\n    true\n    >>> iscube(2L)\n    false\n    >>> iscube(-1L)\n    true\n    >>> iscube(64L)\n    true\n    >>> iscube(0L)\n    true\n    >>> iscube(180L)\n    false\n    \n*/\nbool iscube(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1L\n    >>> hex_key(\"1077E\")\n    2L\n    >>> hex_key(\"ABED1A33\")\n    4L\n    >>> hex_key(\"123456789ABCDEF0\")\n    6L\n    >>> hex_key(\"2020\")\n    2L\n    \n*/\nlong hex_key(string num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15L)\n    \"db1111db\"\n    >>> decimal_to_binary(32L)\n    \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input array of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is hapd or not.\n    A string is hapd if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \n*/\nbool is_happy(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you an array of GPAs for some students and you have to write \n    a function that can output an array of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3L, 1.7, 2L, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns true if the string\n    length is a prime number or false otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \n*/\nbool prime_length(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000L)\n    \"1\"\n    >>> solve(150L)\n    \"110\"\n    >>> solve(147L)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty array of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4L, 2L, 6L, 7L])\n    2L\n    \n*/\nlong add(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \n*/\nstring anti_shuffle(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested arrays,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the array,\n    and return array of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L)\n    [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]\n    >>> get_row([], 1L)\n    []\n    >>> get_row([[], [1L], [1L, 2L, 3L]], 3L)\n    [tuple(2L, 2L)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a cod of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5L])\n    [5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L])\n    [0L, 1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L, 6L])\n    [6L, 5L, 4L, 3L, 2L, 1L, 0L]\n    \n*/\nlong[] sort_array(long[] array) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \n*/\nstring encrypt(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given array of integers, return a tuple consisting of a sum and a product of all the integers in an array.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    tuple(0L, 1L)\n    >>> sum_product([1L, 2L, 3L, 4L])\n    tuple(10L, 24L)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the array.\n    Return null if there is no such element.\n    >>> next_smallest([1L, 2L, 3L, 4L, 5L])\n    2L\n    >>> next_smallest([5L, 1L, 4L, 3L, 2L])\n    2L\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1L, 1L])\n    None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0L\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1L\n    \n*/\nlong is_bored(string S) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5L, 2L, 7L)\n    true\n    \n    >>> any_int(3L, 2L, 2L)\n    false\n\n    >>> any_int(3L, -2L, 1L)\n    true\n    \n    >>> any_int(3.6, -2.2, 2L)\n    false\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \n*/\nstring encode(string message) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given an array of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L])\n    10L\n    >>> skjkasdkd([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L])\n    25L\n    >>> skjkasdkd([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L])\n    13L\n    >>> skjkasdkd([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L])\n    11L\n    >>> skjkasdkd([0L, 81L, 12L, 3L, 1L, 21L])\n    3L\n    >>> skjkasdkd([0L, 8L, 1L, 2L, 1L, 7L])\n    7L\n    \n*/\nlong skjkasdkd(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an associative array, return true if all keys are strings in lower \n    case or all keys are strings in upper case, else return false.\n    The function should return false is the given associative array is empty.\n    Examples:\n    >>> check_dict_case([\"a\": \"apple\", \"b\": \"banana\"].nullable)\n    true\n    >>> check_dict_case([\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"].nullable)\n    false\n    >>> check_dict_case([\"a\": \"apple\", 8L: \"banana\", \"a\": \"apple\"].nullable)\n    false\n    >>> check_dict_case([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable)\n    false\n    >>> check_dict_case([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable)\n    true\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5L)\n    [2L, 3L]\n    >>> count_up_to(11L)\n    [2L, 3L, 5L, 7L]\n    >>> count_up_to(0L)\n    []\n    >>> count_up_to(20L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]\n    >>> count_up_to(1L)\n    []\n    >>> count_up_to(18L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L]\n    \n*/\nlong[] count_up_to(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148L, 412L)\n    16L\n    >>> multiply(19L, 28L)\n    72L\n    >>> multiply(2020L, 1851L)\n    0L\n    >>> multiply(14L, -15L)\n    20L\n    \n*/\nlong multiply(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1L\n    >>> count_upper(\"abcdefg\")\n    0L\n    >>> count_upper(\"dBBE\")\n    0L\n    \n*/\nlong count_upper(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10L\n    >>> closest_integer(\"15.3\")\n    15L\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given array of integers, generate an array of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1L, 2L, 3L, 2L, 3L, 4L, 2L])\n    [1L, 2L, 3L, 3L, 3L, 4L, 4L]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/humaneval-d-transform.json
+++ b/prompts/humaneval-d-transform.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
+    "name": "HumanEval_0_has_close_elements",
     "language": "d",
-    "prompt": "import std.math;\n/*\n Return length of given string\n    >>> strlen(\"\")\n    0L\n    >>> strlen(\"abc\")\n    3L\n    \n*/\nlong strlen(string string) \n",
+    "prompt": "import std.math;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -15,13 +15,13 @@
     ]
   },
   {
-    "name": "HumanEval_89_encrypt",
+    "name": "HumanEval_100_make_a_pile",
     "language": "d",
-    "prompt": "import std.math;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \n*/\nstring encrypt(string s) \n",
+    "prompt": "import std.math;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3L)\n    [3L, 5L, 7L]\n    \n*/\nlong[] make_a_pile(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -30,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_95_check_dict_case",
+    "name": "HumanEval_101_words_string",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case([\"a\": \"apple\", \"b\": \"banana\"].nullable)\n    true\n    >>> check_dict_case([\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"].nullable)\n    false\n    >>> check_dict_case([\"a\": \"apple\", 8L: \"banana\", \"a\": \"apple\"].nullable)\n    false\n    >>> check_dict_case([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable)\n    false\n    >>> check_dict_case([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable)\n    true\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "prompt": "import std.math;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -45,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_85_add",
+    "name": "HumanEval_102_choose_num",
     "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4L, 2L, 6L, 7L])\n    2L\n    \n*/\nlong add(long[] lst) \n",
+    "prompt": "import std.math;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12L, 15L)\n    14L\n    >>> choose_num(13L, 12L)\n    -1L\n    \n*/\nlong choose_num(long x, long y) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -60,178 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_140_fix_spaces",
+    "name": "HumanEval_104_unique_digits",
     "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
+    "prompt": "import std.math;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15L, 33L, 1422L, 1L])\n    [1L, 15L, 33L]\n    >>> unique_digits([152L, 323L, 1422L, 10L])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1L)\n    0L\n    >>> fibfib(5L)\n    4L\n    >>> fibfib(8L)\n    24L\n    \n*/\nlong fibfib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1L, 3L, 2L, 0L])\n    10L\n    >>> double_the_difference([-1L, -2L, 0L])\n    0L\n    >>> double_the_difference([9L, -2L])\n    81L\n    >>> double_the_difference([0L])\n    0L\n   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4L, 2L, 1L, 2L, 2L, 1L, 1L, 1L, 1L, 4L, 4L]\n    \n*/\nlong[] parse_music(string music_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15L)\n    \"db1111db\"\n    >>> decimal_to_binary(32L)\n    \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \n*/\nstring[] all_prefixes(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nAdd two numbers x and y\n    >>> add(2L, 3L)\n    5L\n    >>> add(5L, 7L)\n    12L\n    \n*/\nlong add(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5L, 6L, 10L)\n    [11L, 4L]\n    >>> eat(4L, 8L, 9L)\n    [12L, 1L]\n    >>> eat(1L, 10L, 10L)\n    [11L, 0L]\n    >>> eat(2L, 11L, 5L)\n    [7L, 0L]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L)\n    6L\n\n    Example 2:\n    >>> max_fill([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L)\n    5L\n    \n    Example 3:\n    >>> max_fill([[0L, 0L, 0L], [0L, 0L, 0L]], 5L)\n    0L\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \n*/\nstring flip_case(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -244,7 +79,7 @@
     "language": "d",
     "prompt": "import std.math;\n/*\n\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1L, -1L, 55L])\n    [\"One\"]\n    \n*/\nstring[] by_length(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = by_length;\n\n    assert(candidate([2L, 1L, 1L, 4L, 5L, 8L, 2L, 3L]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -1L, 55L]) == [\"One\"]);\n    assert(candidate([1L, -1L, 3L, 2L]) == [\"Three\", \"Two\", \"One\"]);\n    assert(candidate([9L, 4L, 8L]) == [\"Nine\", \"Eight\", \"Four\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -255,118 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_25_factorize",
+    "name": "HumanEval_106_f",
     "language": "d",
-    "prompt": "import std.math;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8L)\n    [2L, 2L, 2L]\n    >>> factorize(25L)\n    [5L, 5L]\n    >>> factorize(70L)\n    [2L, 5L, 7L]\n    \n*/\nlong[] factorize(long n) \n",
+    "prompt": "import std.math;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5L)\n    [1L, 2L, 6L, 24L, 15L]\n    \n*/\nlong[] f(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5L)\n    [2L, 3L]\n    >>> count_up_to(11L)\n    [2L, 3L, 5L, 7L]\n    >>> count_up_to(0L)\n    []\n    >>> count_up_to(20L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]\n    >>> count_up_to(1L)\n    []\n    >>> count_up_to(18L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L]\n    \n*/\nlong[] count_up_to(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn sorted unique elements in a list\n    >>> unique([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [0L, 2L, 3L, 5L, 9L, 123L]\n    \n*/\nlong[] unique(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nReturn maximum element in the list.\n    >>> max_element([1L, 2L, 3L])\n    3L\n    >>> max_element([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    123L\n    \n*/\nlong max_element(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \n*/\nbool is_nested(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "d",
-    "prompt": "import std.math;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3L, 4L, 5L, 1L, 2L])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3L, 5L, 4L, 1L, 2L])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -379,1014 +109,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3L)\n    tuple(1L, 2L)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12L)\n    tuple(4L, 6L)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \n*/\nTuple!(long, long) even_odd_palindrome(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = even_odd_palindrome;\n\n    assert(candidate(123L) == tuple(8L, 13L));\n    assert(candidate(12L) == tuple(4L, 6L));\n    assert(candidate(3L) == tuple(1L, 2L));\n    assert(candidate(63L) == tuple(6L, 8L));\n    assert(candidate(25L) == tuple(5L, 6L));\n    assert(candidate(19L) == tuple(4L, 6L));\n    assert(candidate(9L) == tuple(4L, 5L));\n    assert(candidate(1L) == tuple(0L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4L)\n    false\n    >>> is_equal_to_sum_even(6L)\n    false\n    >>> is_equal_to_sum_even(8L)\n    true\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3L, 1L, 2L, 4L, 5L])\n    [1L, 4L, 12L, 20L]\n    >>> derivative([1L, 2L, 3L])\n    [2L, 6L]\n    \n*/\nlong[] derivative(long[] xs) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L])\n    false\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L, 7L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L, 6L, 7L])\n    false\n    >>> is_sorted([1L, 2L, 2L, 3L, 3L, 4L])\n    true\n    >>> is_sorted([1L, 2L, 2L, 2L, 3L, 4L])\n    false\n    \n*/\nbool is_sorted(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \n*/\nstring solve(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3L)\n    [1L, 3L, 2L, 8L]\n    \n*/\nlong[] tri(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50L)\n    0L\n    >>> fizz_buzz(78L)\n    2L\n    >>> fizz_buzz(79L)\n    3L\n    \n*/\nlong fizz_buzz(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000L)\n    \"1\"\n    >>> solve(150L)\n    \"110\"\n    >>> solve(147L)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L)\n    [1L, 2L, 1L]\n\n    >>> minPath([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L)\n    [1L]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1L\n    >>> count_upper(\"abcdefg\")\n    0L\n    >>> count_upper(\"dBBE\")\n    0L\n    \n*/\nlong count_upper(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3L, -4L, 5L], 3L)\n    [-4L, -3L, 5L]\n\n    Example 2:\n\n    >>> maximum([4L, -4L, 4L], 2L)\n    [4L, 4L]\n\n    Example 3:\n\n    >>> maximum([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L)\n    [2L]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15L)\n    5L\n    \n*/\nlong largest_divisor(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5L])\n    [5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L])\n    [0L, 1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L, 6L])\n    [6L, 5L, 4L, 3L, 2L, 1L, 0L]\n    \n*/\nlong[] sort_array(long[] array) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5L)\n    [1L, 2L, 6L, 24L, 15L]\n    \n*/\nlong[] f(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = f;\n\n    assert(candidate(5L) == [1L, 2L, 6L, 24L, 15L]);\n    assert(candidate(7L) == [1L, 2L, 6L, 24L, 15L, 720L, 28L]);\n    assert(candidate(1L) == [1L]);\n    assert(candidate(3L) == [1L, 2L, 6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1L)\n    true\n    >>> iscube(2L)\n    false\n    >>> iscube(-1L)\n    true\n    >>> iscube(64L)\n    true\n    >>> iscube(0L)\n    true\n    >>> iscube(180L)\n    false\n    \n*/\nbool iscube(long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \n*/\nstring encode(string message) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0L\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1L\n    \n*/\nlong is_bored(string S) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> pairs_sum_to_zero([1L, 3L, -2L, 1L])\n    false\n    >>> pairs_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> pairs_sum_to_zero([2L, 4L, -5L, 3L, 5L, 7L])\n    true\n    >>> pairs_sum_to_zero([1L])\n    false\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3L, 4L, 5L)\n    6.0\n    >>> triangle_area(1L, 2L, 10L)\n    -1L\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1L)\n    1L\n    >>> digits(4L)\n    0L\n    >>> digits(235L)\n    15L\n    \n*/\nlong digits(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \n*/\nstring[] words_string(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_string;\n\n    assert(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n    assert(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"]);\n    assert(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n    assert(candidate(\"\") == []);\n    assert(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0L\n    >>> how_many_times(\"aaa\", \"a\")\n    3L\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3L\n    \n*/\nlong how_many_times(string string, string substring) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \n*/\nstring remove_vowels(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1L, 2L, 3L, 4L])\n    [1L, 4L, 2L, 3L]\n    >>> strange_sort_list([5L, 5L, 5L, 5L])\n    [5L, 5L, 5L, 5L]\n    >>> strange_sort_list([])\n    []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    tuple(2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    tuple(2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1L, 4L)\n    true\n    >>> is_simple_power(2L, 2L)\n    true\n    >>> is_simple_power(8L, 2L)\n    true\n    >>> is_simple_power(3L, 2L)\n    false\n    >>> is_simple_power(3L, 1L)\n    false\n    >>> is_simple_power(5L, 3L)\n    false\n    \n*/\nbool is_simple_power(long x, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1L)\n    2L\n    >>> prime_fib(2L)\n    3L\n    >>> prime_fib(3L)\n    5L\n    >>> prime_fib(4L)\n    13L\n    >>> prime_fib(5L)\n    89L\n    \n*/\nlong prime_fib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1L, 11L, -1L, -11L, -12L])\n    [-1L, -11L, 1L, -12L, 11L]\n    >>> order_by_points([])\n    []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \n*/\nbool has_close_elements(float[] numbers, float threshold) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = has_close_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true);\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true);\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true);\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \n*/\nstring make_palindrome(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \n*/\nstring string_xor(string a, string b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4L)\n    288L\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L)\n    24L\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5L)\n    4L\n    >>> fib4(6L)\n    8L\n    >>> fib4(7L)\n    14L\n    \n*/\nlong fib4(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15L, 33L, 1422L, 1L])\n    [1L, 15L, 33L]\n    >>> unique_digits([152L, 323L, 1422L, 10L])\n    []\n    \n*/\nlong[] unique_digits(long[] x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique_digits;\n\n    assert(candidate([15L, 33L, 1422L, 1L]) == [1L, 15L, 33L]);\n    assert(candidate([152L, 323L, 1422L, 10L]) == []);\n    assert(candidate([12345L, 2033L, 111L, 151L]) == [111L, 151L]);\n    assert(candidate([135L, 103L, 31L]) == [31L, 135L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4L)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3L)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2L)\n    []\n    >>> select_words(\"Hello world\", 4L)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3L)\n    [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1L, 2L], 5L)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3L, 2L, 3L], 1L)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3L, 2L, 3L], 9L)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3L], 5L)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10L)\n    55L\n    >>> fib(1L)\n    1L\n    >>> fib(8L)\n    21L\n    \n*/\nlong fib(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \n*/\nstring match_parens(string[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1L, 2L, 3L, 4L, 5L])\n    2L\n    >>> next_smallest([5L, 1L, 4L, 3L, 2L])\n    2L\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1L, 1L])\n    None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5L, 2L, 7L)\n    true\n    \n    >>> any_int(3L, 2L, 2L)\n    false\n\n    >>> any_int(3L, -2L, 1L)\n    true\n    \n    >>> any_int(3.6, -2.2, 2L)\n    false\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn list with elements incremented by 1.\n    >>> incr_list([1L, 2L, 3L])\n    [2L, 3L, 4L]\n    >>> incr_list([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [6L, 4L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]\n    \n*/\nlong[] incr_list(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7L, 34L, 12L)\n    34L\n    >>> x_or_y(15L, 8L, 5L)\n    5L\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3L, 5L)\n    3L\n    >>> modp(1101L, 101L)\n    2L\n    >>> modp(0L, 101L)\n    1L\n    >>> modp(3L, 11L)\n    8L\n    >>> modp(100L, 101L)\n    1L\n    \n*/\nlong modp(long n, long p) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12L)\n    tuple(1L, 1L)\n    >>> even_odd_count(123L)\n    tuple(1L, 2L)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \n*/\nbool is_happy(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195L)\n    29L\n    >>> largest_prime_factor(2048L)\n    2L\n    \n*/\nlong largest_prime_factor(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0L\n    >>> digitSum(\"abAB\")\n    131L\n    >>> digitSum(\"abcCd\")\n    67L\n    >>> digitSum(\"helloE\")\n    69L\n    >>> digitSum(\"woArBld\")\n    131L\n    >>> digitSum(\"aAaaaXa\")\n    153L\n    \n*/\nlong digitSum(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5L, 8L, 7L, 1L])\n    12L\n    >>> solution([3L, 3L, 3L, 3L, 3L])\n    9L\n    >>> solution([30L, 13L, 24L, 321L])\n    0L\n    \n*/\nlong solution(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5L, 0L, 3L, 0L, 4L, 2L])\n    [0L, 1L]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5L)\n    1L\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L])\n    \"YES\"\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L])\n    \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the list l.\n    >>> median([3L, 1L, 2L, 4L, 5L])\n    3L\n    >>> median([-10L, 4L, 6L, 1000L, 10L, 20L])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \n*/\nbool prime_length(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L])\n    4L\n    >>> smallest_change([1L, 2L, 3L, 4L, 3L, 2L, 2L])\n    1L\n    >>> smallest_change([1L, 2L, 3L, 2L, 1L])\n    0L\n    \n*/\nlong smallest_change(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14L\n    >>> lst([1.0, 4.0, 9.0])\n    98L\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84L\n    >>> lst([1.4, 4.2, 0.0])\n    29L\n    >>> lst([-2.4, 1.0, 1.0])\n    6L\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \n*/\nstring file_name_check(string file_name) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> triples_sum_to_zero([1L, 3L, -2L, 1L])\n    true\n    >>> triples_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> triples_sum_to_zero([2L, 4L, -5L, 3L, 9L, 7L])\n    true\n    >>> triples_sum_to_zero([1L])\n    false\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection(tuple(1L, 2L), tuple(2L, 3L))\n    \"NO\"\n    >>> intersection(tuple(-1L, 1L), tuple(0L, 4L))\n    \"NO\"\n    >>> intersection(tuple(-3L, -1L), tuple(-5L, 5L))\n    \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L])\n    [0L, 0L, 0L, 0L, 3L, 3L]\n    >>> compare([0L, 5L, 0L, 0L, 0L, 4L], [4L, 1L, 1L, 0L, 0L, -2L])\n    [4L, 4L, 1L, 0L, 0L, 6L]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \n*/\nbool valid_date(string date) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1399,7 +124,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0L\n    >>> count_nums([-1L, 11L, -11L])\n    1L\n    >>> count_nums([1L, 1L, 2L])\n    3L\n    \n*/\nlong count_nums(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = count_nums;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([-1L, -2L, 0L]) == 0L);\n    assert(candidate([1L, 1L, 2L, -2L, 3L, 4L, 5L]) == 6L);\n    assert(candidate([1L, 6L, 9L, -6L, 0L, 1L, 5L]) == 5L);\n    assert(candidate([1L, 100L, 98L, -7L, 1L, -1L]) == 4L);\n    assert(candidate([12L, 23L, 34L, -45L, -56L, 0L]) == 5L);\n    assert(candidate([0L, 1L]) == 1L);\n    assert(candidate([1L]) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1410,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_86_anti_shuffle",
+    "name": "HumanEval_109_move_one_ball",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \n*/\nstring anti_shuffle(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWe have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3L, 4L, 5L, 1L, 2L])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3L, 5L, 4L, 1L, 2L])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \n*/\nbool move_one_ball(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = move_one_ball;\n\n    assert(candidate([3L, 4L, 5L, 1L, 2L]) == true);\n    assert(candidate([3L, 5L, 10L, 1L, 2L]) == true);\n    assert(candidate([4L, 3L, 1L, 2L]) == false);\n    assert(candidate([3L, 5L, 4L, 1L, 2L]) == false);\n    assert(candidate([]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1425,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_48_is_palindrome",
+    "name": "HumanEval_10_make_palindrome",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \n*/\nbool is_palindrome(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \n*/\nstring make_palindrome(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = make_palindrome;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"x\") == \"x\");\n    assert(candidate(\"xyz\") == \"xyzyx\");\n    assert(candidate(\"xyx\") == \"xyx\");\n    assert(candidate(\"jerry\") == \"jerryrrej\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1440,73 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_118_get_closest_vowel",
+    "name": "HumanEval_110_exchange",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIn this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L])\n    \"YES\"\n    >>> exchange([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L])\n    \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \n*/\nstring exchange(long[] lst1, long[] lst2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6L)\n    false\n    >>> is_prime(101L)\n    true\n    >>> is_prime(11L)\n    true\n    >>> is_prime(13441L)\n    true\n    >>> is_prime(61L)\n    true\n    >>> is_prime(4L)\n    false\n    >>> is_prime(1L)\n    false\n    \n*/\nbool is_prime(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \n*/\nbool simplify(string x, string n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1L\n    >>> hex_key(\"1077E\")\n    2L\n    >>> hex_key(\"ABED1A33\")\n    4L\n    >>> hex_key(\"123456789ABCDEF0\")\n    6L\n    >>> hex_key(\"2020\")\n    2L\n    \n*/\nlong hex_key(string num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = exchange;\n\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 2L, 3L, 4L]) == \"YES\");\n    assert(candidate([1L, 2L, 3L, 4L], [1L, 5L, 3L, 4L]) == \"NO\");\n    assert(candidate([1L, 2L, 3L, 4L], [2L, 1L, 4L, 3L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 4L]) == \"YES\");\n    assert(candidate([5L, 7L, 3L], [2L, 6L, 3L]) == \"NO\");\n    assert(candidate([3L, 2L, 6L, 1L, 8L, 9L], [3L, 5L, 5L, 1L, 1L, 1L]) == \"NO\");\n    assert(candidate([100L, 200L], [200L, 200L]) == \"YES\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1519,444 +184,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    [\"a\": 1L, \"b\": 1L, \"c\": 1L].nullable\n    >>> histogram(\"a b b a\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"a b c a b\")\n    [\"a\": 2L, \"b\": 2L].nullable\n    >>> histogram(\"b b b b a\")\n    [\"b\": 4L].nullable\n    >>> histogram(\"\")\n    ___null_dict___\n\n    \n*/\nNullable!(long[string]) histogram(string test) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = histogram;\n\n{\n        auto result = candidate(\"a b b a\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c a b\");\n        assert(!result.isNull && result.get == [\"a\": 2L, \"b\": 2L]);\n}\n\n{\n        auto result = candidate(\"a b c d g\");\n        assert(!result.isNull && result.get == [\"a\": 1L, \"b\": 1L, \"c\": 1L, \"d\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"b b b b a\");\n        assert(!result.isNull && result.get == [\"b\": 4L]);\n}\n\n{\n        auto result = candidate(\"r t g\");\n        assert(!result.isNull && result.get == [\"r\": 1L, \"t\": 1L, \"g\": 1L]);\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"a\");\n        assert(!result.isNull && result.get == [\"a\": 1L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L)\n    [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]\n    >>> get_row([], 1L)\n    []\n    >>> get_row([[], [1L], [1L, 2L, 3L]], 3L)\n    [tuple(2L, 2L)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5L)\n    [1L, 5L]\n    \n*/\nlong[] get_odd_collatz(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1L, 2L, 4L, 3L, 5L])\n    3L\n    >>> can_arrange([1L, 2L, 3L])\n    -1L\n    \n*/\nlong can_arrange(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \n*/\nstring sort_numbers(string numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12L, 1L)\n    \"21\"\n    >>> circular_shift(12L, 2L)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1L, 2L, 3L]\n    >>> lst\n    []\n    >>> lst\n    [-1L, -5L, 2L, -1L, -5L]\n    \n*/\nlong sum_squares(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L])\n    10L\n    >>> skjkasdkd([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L])\n    25L\n    >>> skjkasdkd([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L])\n    13L\n    >>> skjkasdkd([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L])\n    11L\n    >>> skjkasdkd([0L, 81L, 12L, 3L, 1L, 21L])\n    3L\n    >>> skjkasdkd([0L, 8L, 1L, 2L, 1L, 7L])\n    7L\n    \n*/\nlong skjkasdkd(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    tuple(0L, 1L)\n    >>> sum_product([1L, 2L, 3L, 4L])\n    tuple(10L, 24L)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12L, 15L)\n    14L\n    >>> choose_num(13L, 12L)\n    -1L\n    \n*/\nlong choose_num(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = choose_num;\n\n    assert(candidate(12L, 15L) == 14L);\n    assert(candidate(13L, 12L) == -1L);\n    assert(candidate(33L, 12354L) == 12354L);\n    assert(candidate(5234L, 5233L) == -1L);\n    assert(candidate(6L, 29L) == 28L);\n    assert(candidate(27L, 10L) == -1L);\n    assert(candidate(7L, 7L) == -1L);\n    assert(candidate(546L, 546L) == 546L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2L, 4L, 1L, 3L, 5L, 7L])\n    tuple(None, 1L)\n    >>> largest_smallest_integers([])\n    tuple(None, None)\n    >>> largest_smallest_integers([0L])\n    tuple(None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3L\n    >>> count_distinct_characters(\"Jerry\")\n    4L\n    \n*/\nlong count_distinct_characters(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_100_make_a_pile",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3L)\n    [3L, 5L, 7L]\n    \n*/\nlong[] make_a_pile(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = make_a_pile;\n\n    assert(candidate(3L) == [3L, 5L, 7L]);\n    assert(candidate(4L) == [4L, 6L, 8L, 10L]);\n    assert(candidate(5L) == [5L, 7L, 9L, 11L, 13L]);\n    assert(candidate(6L) == [6L, 8L, 10L, 12L, 14L, 16L]);\n    assert(candidate(8L) == [8L, 10L, 12L, 14L, 16L, 18L, 20L, 22L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1L, 2L, 2L, -4L])\n    9L\n    >>> prod_signs([0L, 1L])\n    0L\n    >>> prod_signs([])\n    None\n    \n*/\nNullable!(long) prod_signs(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2L, 3L, 4L, 1L, 2L, 4L])\n    1L\n    >>> minSubArraySum([-1L, -2L, -3L])\n    -6L\n    \n*/\nlong minSubArraySum(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0L)\n    \"0\"\n    >>> string_sequence(5L)\n    \"0 1 2 3 4 5\"\n    \n*/\nstring string_sequence(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1L, 2L, 4L, 20L])\n    true\n    >>> monotonic([1L, 20L, 4L, 10L])\n    false\n    >>> monotonic([4L, 1L, 0L, -10L])\n    true\n    \n*/\nbool monotonic(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \n*/\nNullable!(string) longest(string[] strings) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1L, 2L, 4L, 10L], 100L)\n    true\n    >>> below_threshold([1L, 20L, 4L, 10L], 5L)\n    false\n    \n*/\nbool below_threshold(long[] l, long t) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30L)\n    true\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the list.\n    >>> get_positive([-1L, 2L, -4L, 5L, 6L])\n    [2L, 5L, 6L]\n    >>> get_positive([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    [5L, 3L, 2L, 3L, 9L, 123L, 1L]\n    \n*/\nlong[] get_positive(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_third([5L, 6L, 3L, 4L, 8L, 9L, 2L])\n    [2L, 6L, 3L, 4L, 8L, 9L, 5L]\n    \n*/\nlong[] sort_third(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2L, 3L, 1L, 3L]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5L, 3L)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148L, 412L)\n    16L\n    >>> multiply(19L, 28L)\n    72L\n    >>> multiply(2020L, 1851L)\n    0L\n    >>> multiply(14L, -15L)\n    20L\n    \n*/\nlong multiply(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two lists.\n    >>> common([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L])\n    [1L, 5L, 653L]\n    >>> common([5L, 3L, 2L, 8L], [3L, 2L])\n    [2L, 3L]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19L)\n    \"xix\"\n    >>> int_to_mini_roman(152L)\n    \"clii\"\n    >>> int_to_mini_roman(426L)\n    \"cdxxvi\"\n    \n*/\nstring int_to_mini_roman(long number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19L)\n    8L\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3L)\n    2L\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100L)\n    95L\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120L)\n    19L\n    \n*/\nlong fruit_distribution(string s, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1969,7 +199,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    >>> reverse_delete(\"abcde\", \"ae\")\n    tuple(\"bcd\", false)\n    >>> reverse_delete(\"abcdef\", \"b\")\n    tuple(\"acdef\", false)\n    >>> reverse_delete(\"abcdedcba\", \"ab\")\n    tuple(\"cdedc\", true)\n    \n*/\nTuple!(string, bool) reverse_delete(string s, string c) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = reverse_delete;\n\n    assert(candidate(\"abcde\", \"ae\") == tuple(\"bcd\", false));\n    assert(candidate(\"abcdef\", \"b\") == tuple(\"acdef\", false));\n    assert(candidate(\"abcdedcba\", \"ab\") == tuple(\"cdedc\", true));\n    assert(candidate(\"dwik\", \"w\") == tuple(\"dik\", false));\n    assert(candidate(\"a\", \"a\") == tuple(\"\", true));\n    assert(candidate(\"abcdedcba\", \"\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"abcdedcba\", \"v\") == tuple(\"abcdedcba\", true));\n    assert(candidate(\"vabba\", \"v\") == tuple(\"abba\", true));\n    assert(candidate(\"mamma\", \"mia\") == tuple(\"\", true));\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1980,13 +210,43 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3L, 5L)\n    1L\n    >>> greatest_common_divisor(25L, 15L)\n    5L\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \n*/\nstring[] odd_count(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = odd_count;\n\n    assert(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n    assert(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n    assert(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2L, 3L, 4L, 1L, 2L, 4L])\n    1L\n    >>> minSubArraySum([-1L, -2L, -3L])\n    -6L\n    \n*/\nlong minSubArraySum(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minSubArraySum;\n\n    assert(candidate([2L, 3L, 4L, 1L, 2L, 4L]) == 1L);\n    assert(candidate([-1L, -2L, -3L]) == -6L);\n    assert(candidate([-1L, -2L, -3L, 2L, -10L]) == -14L);\n    assert(candidate([-9999999999999999L]) == -9999999999999999L);\n    assert(candidate([0L, 10L, 20L, 1000000L]) == 0L);\n    assert(candidate([-1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([100L, -1L, -2L, -3L, 10L, -5L]) == -6L);\n    assert(candidate([10L, 11L, 13L, 8L, 3L, 4L]) == 3L);\n    assert(candidate([100L, -33L, 32L, -1L, 0L, -2L]) == -33L);\n    assert(candidate([-10L]) == -10L);\n    assert(candidate([7L]) == 7L);\n    assert(candidate([1L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L)\n    6L\n\n    Example 2:\n    >>> max_fill([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L)\n    5L\n    \n    Example 3:\n    >>> max_fill([[0L, 0L, 0L], [0L, 0L, 0L]], 5L)\n    0L\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \n*/\nlong max_fill(long[][] grid, long capacity) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_fill;\n\n    assert(candidate([[0L, 0L, 1L, 0L], [0L, 1L, 0L, 0L], [1L, 1L, 1L, 1L]], 1L) == 6L);\n    assert(candidate([[0L, 0L, 1L, 1L], [0L, 0L, 0L, 0L], [1L, 1L, 1L, 1L], [0L, 1L, 1L, 1L]], 2L) == 5L);\n    assert(candidate([[0L, 0L, 0L], [0L, 0L, 0L]], 5L) == 0L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 2L) == 4L);\n    assert(candidate([[1L, 1L, 1L, 1L], [1L, 1L, 1L, 1L]], 9L) == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1999,7 +259,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1L, 5L, 2L, 3L, 4L])\n    [1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([-2L, -3L, -4L, -5L, -6L])\n    [-6L, -5L, -4L, -3L, -2L]\n    >>> sort_array([1L, 0L, 2L, 3L, 4L])\n    [0L, 1L, 2L, 3L, 4L]\n    \n*/\nlong[] sort_array(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([1L, 5L, 2L, 3L, 4L]) == [1L, 2L, 4L, 3L, 5L]);\n    assert(candidate([-2L, -3L, -4L, -5L, -6L]) == [-4L, -2L, -6L, -5L, -3L]);\n    assert(candidate([1L, 0L, 2L, 3L, 4L]) == [0L, 1L, 2L, 4L, 3L]);\n    assert(candidate([]) == []);\n    assert(candidate([2L, 5L, 77L, 4L, 5L, 3L, 5L, 7L, 2L, 3L, 4L]) == [2L, 2L, 4L, 4L, 3L, 3L, 5L, 5L, 5L, 7L, 77L]);\n    assert(candidate([3L, 6L, 44L, 12L, 32L, 5L]) == [32L, 3L, 5L, 6L, 12L, 44L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n    assert(candidate([2L, 4L, 8L, 16L, 32L]) == [2L, 4L, 8L, 16L, 32L]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2010,13 +270,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate list of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \n*/\nstring concatenate(string[] strings) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4L)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3L)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2L)\n    []\n    >>> select_words(\"Hello world\", 4L)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3L)\n    [\"Uncle\"]\n    \n*/\nstring[] select_words(string s, long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = select_words;\n\n    assert(candidate(\"Mary had a little lamb\", 4L) == [\"little\"]);\n    assert(candidate(\"Mary had a little lamb\", 3L) == [\"Mary\", \"lamb\"]);\n    assert(candidate(\"simple white space\", 2L) == []);\n    assert(candidate(\"Hello world\", 4L) == [\"world\"]);\n    assert(candidate(\"Uncle sam\", 3L) == [\"Uncle\"]);\n    assert(candidate(\"\", 4L) == []);\n    assert(candidate(\"a b c d e f\", 1L) == [\"b\", \"c\", \"d\", \"f\"]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2025,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \n*/\nstring get_closest_vowel(string word) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_closest_vowel;\n\n    assert(candidate(\"yogurt\") == \"u\");\n    assert(candidate(\"full\") == \"u\");\n    assert(candidate(\"easy\") == \"\");\n    assert(candidate(\"eAsy\") == \"\");\n    assert(candidate(\"ali\") == \"\");\n    assert(candidate(\"bad\") == \"a\");\n    assert(candidate(\"most\") == \"o\");\n    assert(candidate(\"ab\") == \"\");\n    assert(candidate(\"ba\") == \"\");\n    assert(candidate(\"quick\") == \"\");\n    assert(candidate(\"anime\") == \"i\");\n    assert(candidate(\"Asia\") == \"\");\n    assert(candidate(\"Above\") == \"o\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2040,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \n*/\nstring match_parens(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = match_parens;\n\n    assert(candidate([\"()(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \")\"]) == \"No\");\n    assert(candidate([\"(()(())\", \"())())\"]) == \"No\");\n    assert(candidate([\")())\", \"(()()(\"]) == \"Yes\");\n    assert(candidate([\"(())))\", \"(()())((\"]) == \"Yes\");\n    assert(candidate([\"()\", \"())\"]) == \"No\");\n    assert(candidate([\"(()(\", \"()))()\"]) == \"Yes\");\n    assert(candidate([\"((((\", \"((())\"]) == \"No\");\n    assert(candidate([\")(()\", \"(()(\"]) == \"No\");\n    assert(candidate([\")(\", \")(\"]) == \"No\");\n    assert(candidate([\"(\", \")\"]) == \"Yes\");\n    assert(candidate([\")\", \"(\"]) == \"Yes\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2055,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10L\n    >>> closest_integer(\"15.3\")\n    15L\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \n*/\nstring string_xor(string a, string b) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = string_xor;\n\n    assert(candidate(\"111000\", \"101010\") == \"010010\");\n    assert(candidate(\"1\", \"1\") == \"0\");\n    assert(candidate(\"0101\", \"0000\") == \"0101\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2070,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2L\n    >>> vowels_count(\"ACEDY\")\n    3L\n    \n*/\nlong vowels_count(string s) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3L, -4L, 5L], 3L)\n    [-4L, -3L, 5L]\n\n    Example 2:\n\n    >>> maximum([4L, -4L, 4L], 2L)\n    [4L, 4L]\n\n    Example 3:\n\n    >>> maximum([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L)\n    [2L]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \n*/\nlong[] maximum(long[] arr, long k) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate([-3L, -4L, 5L], 3L) == [-4L, -3L, 5L]);\n    assert(candidate([4L, -4L, 4L], 2L) == [4L, 4L]);\n    assert(candidate([-3L, 2L, 1L, 2L, -1L, -2L, 1L], 1L) == [2L]);\n    assert(candidate([123L, -123L, 20L, 0L, 1L, 2L, -3L], 3L) == [2L, 20L, 123L]);\n    assert(candidate([-123L, 20L, 0L, 1L, 2L, -3L], 4L) == [0L, 1L, 2L, 20L]);\n    assert(candidate([5L, 15L, 0L, 3L, -13L, -8L, 0L], 7L) == [-13L, -8L, 0L, 0L, 3L, 5L, 15L]);\n    assert(candidate([-1L, 0L, 2L, 5L, 3L, -10L], 2L) == [3L, 5L]);\n    assert(candidate([1L, 0L, 5L, -7L], 1L) == [5L]);\n    assert(candidate([4L, -4L], 2L) == [-4L, 4L]);\n    assert(candidate([-10L, 10L], 2L) == [-10L, 10L]);\n    assert(candidate([1L, 2L, 3L, -23L, 243L, -400L, 0L], 0L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2085,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5L, 8L, 7L, 1L])\n    12L\n    >>> solution([3L, 3L, 3L, 3L, 3L])\n    9L\n    >>> solution([30L, 13L, 24L, 321L])\n    0L\n    \n*/\nlong solution(long[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = solution;\n\n    assert(candidate([5L, 8L, 7L, 1L]) == 12L);\n    assert(candidate([3L, 3L, 3L, 3L, 3L]) == 9L);\n    assert(candidate([30L, 13L, 24L, 321L]) == 0L);\n    assert(candidate([5L, 9L]) == 5L);\n    assert(candidate([2L, 4L, 8L]) == 0L);\n    assert(candidate([30L, 13L, 23L, 32L]) == 23L);\n    assert(candidate([3L, 13L, 2L, 9L]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2100,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L)\n    24L\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \n*/\nlong add_elements(long[] arr, long k) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_elements;\n\n    assert(candidate([1L, -2L, -3L, 41L, 57L, 76L, 87L, 88L, 99L], 3L) == -4L);\n    assert(candidate([111L, 121L, 3L, 4000L, 5L, 6L], 2L) == 0L);\n    assert(candidate([11L, 21L, 3L, 90L, 5L, 6L, 7L, 8L, 9L], 4L) == 125L);\n    assert(candidate([111L, 21L, 3L, 4000L, 5L, 6L, 7L, 8L, 9L], 4L) == 24L);\n    assert(candidate([1L], 1L) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2115,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8L, 3L)\n    \"22\"\n    >>> change_base(8L, 2L)\n    \"1000\"\n    >>> change_base(7L, 2L)\n    \"111\"\n    \n*/\nstring change_base(long x, long base) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5L)\n    [1L, 5L]\n    \n*/\nlong[] get_odd_collatz(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_odd_collatz;\n\n    assert(candidate(14L) == [1L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(5L) == [1L, 5L]);\n    assert(candidate(12L) == [1L, 3L, 5L]);\n    assert(candidate(1L) == [1L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2130,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3L, 4L, 5L)\n    true\n    >>> right_angle_triangle(1L, 2L, 3L)\n    false\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \n*/\nbool valid_date(string date) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = valid_date;\n\n    assert(candidate(\"03-11-2000\") == true);\n    assert(candidate(\"15-01-2012\") == false);\n    assert(candidate(\"04-0-2040\") == false);\n    assert(candidate(\"06-04-2020\") == true);\n    assert(candidate(\"01-01-2007\") == true);\n    assert(candidate(\"03-32-2011\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"04-31-3000\") == false);\n    assert(candidate(\"06-06-2005\") == true);\n    assert(candidate(\"21-31-2000\") == false);\n    assert(candidate(\"04-12-2003\") == true);\n    assert(candidate(\"04122003\") == false);\n    assert(candidate(\"20030412\") == false);\n    assert(candidate(\"2003-04\") == false);\n    assert(candidate(\"2003-04-12\") == false);\n    assert(candidate(\"04-2003\") == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2145,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3L, 1.7, 2L, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L])\n    false\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L])\n    true\n    >>> is_sorted([1L, 2L, 3L, 4L, 5L, 6L, 7L])\n    true\n    >>> is_sorted([1L, 3L, 2L, 4L, 5L, 6L, 7L])\n    false\n    >>> is_sorted([1L, 2L, 2L, 3L, 3L, 4L])\n    true\n    >>> is_sorted([1L, 2L, 2L, 2L, 3L, 4L])\n    false\n    \n*/\nbool is_sorted(long[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = is_sorted;\n\n    assert(candidate([5L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L]) == true);\n    assert(candidate([1L, 3L, 2L, 4L, 5L, 6L, 7L]) == false);\n    assert(candidate([]) == true);\n    assert(candidate([1L]) == true);\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 2L, 2L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 4L]) == false);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L]) == true);\n    assert(candidate([1L, 2L, 3L, 4L]) == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2160,13 +420,298 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4L)\n    []\n    >>> intersperse([1L, 2L, 3L], 4L)\n    [1L, 4L, 2L, 4L, 3L]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection(tuple(1L, 2L), tuple(2L, 3L))\n    \"NO\"\n    >>> intersection(tuple(-1L, 1L), tuple(0L, 4L))\n    \"NO\"\n    >>> intersection(tuple(-3L, -1L), tuple(-5L, 5L))\n    \"YES\"\n    \n*/\nstring intersection(Tuple!(long, long) interval1, Tuple!(long, long) interval2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = intersection;\n\n    assert(candidate(tuple(1L, 2L), tuple(2L, 3L)) == \"NO\");\n    assert(candidate(tuple(-1L, 1L), tuple(0L, 4L)) == \"NO\");\n    assert(candidate(tuple(-3L, -1L), tuple(-5L, 5L)) == \"YES\");\n    assert(candidate(tuple(-2L, 2L), tuple(-4L, 0L)) == \"YES\");\n    assert(candidate(tuple(-11L, 2L), tuple(-1L, -1L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(3L, 5L)) == \"NO\");\n    assert(candidate(tuple(1L, 2L), tuple(1L, 2L)) == \"NO\");\n    assert(candidate(tuple(-2L, -2L), tuple(-3L, -2L)) == \"NO\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1L, 2L, 2L, -4L])\n    9L\n    >>> prod_signs([0L, 1L])\n    0L\n    >>> prod_signs([])\n    None\n    \n*/\nNullable!(long) prod_signs(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prod_signs;\n\n{\n        auto result = candidate([1L, 2L, 2L, -4L]);\n        assert(!result.isNull && result.get == -9L);\n}\n\n{\n        auto result = candidate([0L, 1L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 2L, 3L, -1L, 1L]);\n        assert(!result.isNull && result.get == -10L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 2L, -1L, -1L, 9L]);\n        assert(!result.isNull && result.get == 20L);\n}\n\n{\n        auto result = candidate([-1L, 1L, -1L, 1L]);\n        assert(!result.isNull && result.get == 4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 1L]);\n        assert(!result.isNull && result.get == -4L);\n}\n\n{\n        auto result = candidate([-1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 0L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L)\n    [1L, 2L, 1L]\n\n    >>> minPath([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L)\n    [1L]\n    \n*/\nlong[] minPath(long[][] grid, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minPath;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]], 3L) == [1L, 2L, 1L]);\n    assert(candidate([[5L, 9L, 3L], [4L, 1L, 6L], [7L, 8L, 2L]], 1L) == [1L]);\n    assert(candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L], [13L, 14L, 15L, 16L]], 4L) == [1L, 2L, 1L, 2L]);\n    assert(candidate([[6L, 4L, 13L, 10L], [5L, 7L, 12L, 1L], [3L, 16L, 11L, 15L], [8L, 14L, 9L, 2L]], 7L) == [1L, 10L, 1L, 10L, 1L, 10L, 1L]);\n    assert(candidate([[8L, 14L, 9L, 2L], [6L, 4L, 13L, 15L], [5L, 7L, 1L, 12L], [3L, 10L, 11L, 16L]], 5L) == [1L, 7L, 1L, 7L, 1L]);\n    assert(candidate([[11L, 8L, 7L, 2L], [5L, 16L, 14L, 4L], [9L, 3L, 15L, 6L], [12L, 13L, 10L, 1L]], 9L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L]);\n    assert(candidate([[12L, 13L, 10L, 1L], [9L, 3L, 15L, 6L], [5L, 16L, 14L, 4L], [11L, 8L, 7L, 2L]], 12L) == [1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L, 1L, 6L]);\n    assert(candidate([[2L, 7L, 4L], [3L, 1L, 5L], [6L, 8L, 9L]], 8L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n    assert(candidate([[6L, 1L, 5L], [3L, 8L, 9L], [2L, 7L, 4L]], 8L) == [1L, 5L, 1L, 5L, 1L, 5L, 1L, 5L]);\n    assert(candidate([[1L, 2L], [3L, 4L]], 10L) == [1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L]);\n    assert(candidate([[1L, 3L], [3L, 2L]], 10L) == [1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L, 1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \n*/\nNullable!(string) longest(string[] strings) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = longest;\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([\"x\", \"y\", \"z\"]);\n        assert(!result.isNull && result.get == \"x\");\n}\n\n{\n        auto result = candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]);\n        assert(!result.isNull && result.get == \"zzzz\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEveryone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3L)\n    [1L, 3L, 2L, 8L]\n    \n*/\nlong[] tri(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tri;\n\n    assert(candidate(3L) == [1L, 3L, 2L, 8L]);\n    assert(candidate(4L) == [1L, 3L, 2L, 8L, 3L]);\n    assert(candidate(5L) == [1L, 3L, 2L, 8L, 3L, 15L]);\n    assert(candidate(6L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L]);\n    assert(candidate(7L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L]);\n    assert(candidate(8L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L]);\n    assert(candidate(9L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L]);\n    assert(candidate(20L) == [1L, 3L, 2L, 8L, 3L, 15L, 4L, 24L, 5L, 35L, 6L, 48L, 7L, 63L, 8L, 80L, 9L, 99L, 10L, 120L, 11L]);\n    assert(candidate(0L) == [1L]);\n    assert(candidate(1L) == [1L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1L)\n    1L\n    >>> digits(4L)\n    0L\n    >>> digits(235L)\n    15L\n    \n*/\nlong digits(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digits;\n\n    assert(candidate(5L) == 5L);\n    assert(candidate(54L) == 5L);\n    assert(candidate(120L) == 1L);\n    assert(candidate(5014L) == 5L);\n    assert(candidate(98765L) == 315L);\n    assert(candidate(5576543L) == 2625L);\n    assert(candidate(2468L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \n*/\nbool is_nested(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_nested;\n\n    assert(candidate(\"[[]]\") == true);\n    assert(candidate(\"[]]]]]]][[[[[]\") == false);\n    assert(candidate(\"[][]\") == false);\n    assert(candidate(\"[]\") == false);\n    assert(candidate(\"[[[[]]]]\") == true);\n    assert(candidate(\"[]]]]]]]]]]\") == false);\n    assert(candidate(\"[][][[]]\") == true);\n    assert(candidate(\"[[]\") == false);\n    assert(candidate(\"[]]\") == false);\n    assert(candidate(\"[[]][[\") == true);\n    assert(candidate(\"[[][]]\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"[[[[[[[[\") == false);\n    assert(candidate(\"]]]]]]]]\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14L\n    >>> lst([1.0, 4.0, 9.0])\n    98L\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84L\n    >>> lst([1.4, 4.2, 0.0])\n    29L\n    >>> lst([-2.4, 1.0, 1.0])\n    6L\n    \n\n    \n*/\nlong sum_squares(float[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 2.0, 3.0]) == 14L);\n    assert(candidate([1.0, 3.0, 5.0, 7.0]) == 84L);\n    assert(candidate([1.4, 4.2, 0.0]) == 29L);\n    assert(candidate([-2.4, 1.0, 1.0]) == 6L);\n    assert(candidate([100.0, 1.0, 15.0, 2.0]) == 10230L);\n    assert(candidate([10000.0, 10000.0]) == 200000000L);\n    assert(candidate([-1.4, 4.6, 6.3]) == 75L);\n    assert(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086L);\n    assert(candidate([0.0]) == 0L);\n    assert(candidate([-1.0]) == 1L);\n    assert(candidate([-1.0, 1.0, 0.0]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \n*/\nbool check_if_last_char_is_a_letter(string txt) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_if_last_char_is_a_letter;\n\n    assert(candidate(\"apple\") == false);\n    assert(candidate(\"apple pi e\") == true);\n    assert(candidate(\"eeeee\") == false);\n    assert(candidate(\"A\") == true);\n    assert(candidate(\"Pumpkin pie \") == false);\n    assert(candidate(\"Pumpkin pie 1\") == false);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"eeeee e \") == false);\n    assert(candidate(\"apple pie\") == false);\n    assert(candidate(\"apple pi e \") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1L, 2L, 4L, 3L, 5L])\n    3L\n    >>> can_arrange([1L, 2L, 3L])\n    -1L\n    \n*/\nlong can_arrange(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = can_arrange;\n\n    assert(candidate([1L, 2L, 4L, 3L, 5L]) == 3L);\n    assert(candidate([1L, 2L, 4L, 5L]) == -1L);\n    assert(candidate([1L, 4L, 2L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([4L, 8L, 5L, 7L, 3L]) == 4L);\n    assert(candidate([]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2L, 4L, 1L, 3L, 5L, 7L])\n    tuple(None, 1L)\n    >>> largest_smallest_integers([])\n    tuple(None, None)\n    >>> largest_smallest_integers([0L])\n    tuple(None, None)\n    \n*/\nTuple!(Nullable!(long), Nullable!(long)) largest_smallest_integers(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_smallest_integers;\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([2L, 4L, 1L, 3L, 5L, 7L, 0L]);\n        assert(result[0].isNull);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([1L, 3L, 2L, 4L, 5L, 6L, -2L]);\n        assert(!result[0].isNull && result[0].get == -2L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([4L, 5L, 3L, 6L, 2L, 7L, -7L]);\n        assert(!result[0].isNull && result[0].get == -7L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([7L, 3L, 8L, 4L, 9L, 2L, 5L, -9L]);\n        assert(!result[0].isNull && result[0].get == -9L);\n        assert(!result[1].isNull && result[1].get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([0L]);\n        assert(result[0].isNull);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-1L, -3L, -5L, -6L, 0L]);\n        assert(!result[0].isNull && result[0].get == -1L);\n        assert(result[1].isNull);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n{\n        auto result = candidate([-6L, -4L, -4L, -3L, -100L, 1L]);\n        assert(!result[0].isNull && result[0].get == -3L);\n        assert(!result[1].isNull && result[1].get == 1L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nEvaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4L)\n    false\n    >>> is_equal_to_sum_even(6L)\n    false\n    >>> is_equal_to_sum_even(8L)\n    true\n    \n*/\nbool is_equal_to_sum_even(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_equal_to_sum_even;\n\n    assert(candidate(4L) == false);\n    assert(candidate(6L) == false);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == true);\n    assert(candidate(11L) == false);\n    assert(candidate(12L) == true);\n    assert(candidate(13L) == false);\n    assert(candidate(16L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4L)\n    288L\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \n*/\nlong special_factorial(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = special_factorial;\n\n    assert(candidate(4L) == 288L);\n    assert(candidate(5L) == 34560L);\n    assert(candidate(7L) == 125411328000L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3L, 5L)\n    1L\n    >>> greatest_common_divisor(25L, 15L)\n    5L\n    \n*/\nlong greatest_common_divisor(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = greatest_common_divisor;\n\n    assert(candidate(3L, 7L) == 1L);\n    assert(candidate(10L, 15L) == 5L);\n    assert(candidate(49L, 14L) == 7L);\n    assert(candidate(144L, 60L) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \n*/\nstring fix_spaces(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fix_spaces;\n\n    assert(candidate(\"Example\") == \"Example\");\n    assert(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\");\n    assert(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\");\n    assert(candidate(\"Exa   mple\") == \"Exa-mple\");\n    assert(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \n*/\nstring file_name_check(string file_name) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = file_name_check;\n\n    assert(candidate(\"example.txt\") == \"Yes\");\n    assert(candidate(\"1example.dll\") == \"No\");\n    assert(candidate(\"s1sdf3.asd\") == \"No\");\n    assert(candidate(\"K.dll\") == \"Yes\");\n    assert(candidate(\"MY16FILE3.exe\") == \"Yes\");\n    assert(candidate(\"His12FILE94.exe\") == \"No\");\n    assert(candidate(\"_Y.txt\") == \"No\");\n    assert(candidate(\"?aREYA.exe\") == \"No\");\n    assert(candidate(\"/this_is_valid.dll\") == \"No\");\n    assert(candidate(\"this_is_valid.wow\") == \"No\");\n    assert(candidate(\"this_is_valid.txt\") == \"Yes\");\n    assert(candidate(\"this_is_valid.txtexe\") == \"No\");\n    assert(candidate(\"#this2_i4s_5valid.ten\") == \"No\");\n    assert(candidate(\"@this1_is6_valid.exe\") == \"No\");\n    assert(candidate(\"this_is_12valid.6exe4.txt\") == \"No\");\n    assert(candidate(\"all.exe.txt\") == \"No\");\n    assert(candidate(\"I563_No.exe\") == \"Yes\");\n    assert(candidate(\"Is3youfault.txt\") == \"Yes\");\n    assert(candidate(\"no_one#knows.dll\") == \"Yes\");\n    assert(candidate(\"1I563_Yes3.exe\") == \"No\");\n    assert(candidate(\"I563_Yes3.txtt\") == \"No\");\n    assert(candidate(\"final..txt\") == \"No\");\n    assert(candidate(\"final132\") == \"No\");\n    assert(candidate(\"_f4indsartal132.\") == \"No\");\n    assert(candidate(\".txt\") == \"No\");\n    assert(candidate(\"s.\") == \"No\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1L, 2L, 3L]\n    >>> lst\n    []\n    >>> lst\n    [-1L, -5L, 2L, -1L, -5L]\n    \n*/\nlong sum_squares(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_squares;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([1L, 4L, 9L]) == 14L);\n    assert(candidate([]) == 0L);\n    assert(candidate([1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L]) == 9L);\n    assert(candidate([-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L]) == -3L);\n    assert(candidate([0L]) == 0L);\n    assert(candidate([-1L, -5L, 2L, -1L, -5L]) == -126L);\n    assert(candidate([-56L, -99L, 1L, 0L, -2L]) == 3030L);\n    assert(candidate([-1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, -1L]) == 0L);\n    assert(candidate([-16L, -9L, -2L, 36L, 36L, 26L, -20L, 25L, -40L, 20L, -4L, 12L, -26L, 35L, 37L]) == -14196L);\n    assert(candidate([-1L, -3L, 17L, -1L, -15L, 13L, -1L, 14L, -14L, -12L, -5L, 14L, -14L, 6L, 13L, 11L, 16L, 16L, 4L, 10L]) == -1448L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \n*/\nstring words_in_sentence(string sentence) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = words_in_sentence;\n\n    assert(candidate(\"This is a test\") == \"is\");\n    assert(candidate(\"lets go for swimming\") == \"go for\");\n    assert(candidate(\"there is no place available here\") == \"there is no place\");\n    assert(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\");\n    assert(candidate(\"go for it\") == \"go for it\");\n    assert(candidate(\"here\") == \"\");\n    assert(candidate(\"here is\") == \"is\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \n*/\nbool simplify(string x, string n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = simplify;\n\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/6\", \"2/1\") == false);\n    assert(candidate(\"5/1\", \"3/1\") == true);\n    assert(candidate(\"7/10\", \"10/2\") == false);\n    assert(candidate(\"2/10\", \"50/10\") == true);\n    assert(candidate(\"7/2\", \"4/2\") == true);\n    assert(candidate(\"11/6\", \"6/1\") == true);\n    assert(candidate(\"2/3\", \"5/2\") == false);\n    assert(candidate(\"5/2\", \"3/5\") == false);\n    assert(candidate(\"2/4\", \"8/4\") == true);\n    assert(candidate(\"2/4\", \"4/2\") == true);\n    assert(candidate(\"1/5\", \"5/1\") == true);\n    assert(candidate(\"1/5\", \"1/5\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1L, 11L, -1L, -11L, -12L])\n    [-1L, -11L, 1L, -12L, 11L]\n    >>> order_by_points([])\n    []\n    \n*/\nlong[] order_by_points(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = order_by_points;\n\n    assert(candidate([1L, 11L, -1L, -11L, -12L]) == [-1L, -11L, 1L, -12L, 11L]);\n    assert(candidate([1234L, 423L, 463L, 145L, 2L, 423L, 423L, 53L, 6L, 37L, 3457L, 3L, 56L, 0L, 46L]) == [0L, 2L, 3L, 6L, 53L, 423L, 423L, 423L, 1234L, 145L, 37L, 46L, 56L, 463L, 3457L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, -11L, -32L, 43L, 54L, -98L, 2L, -3L]) == [-3L, -32L, -98L, -11L, 1L, 2L, 43L, 54L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L]) == [1L, 10L, 2L, 11L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([0L, 6L, 6L, -76L, -21L, 23L, 4L]) == [-76L, -21L, 0L, 4L, 23L, 6L, 6L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2179,7 +724,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15L, -73L, 14L, -15L])\n    1L\n    >>> specialFilter([33L, -2L, -3L, 45L, 21L, 109L])\n    2L\n    \n*/\nlong specialFilter(long[] nums) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = specialFilter;\n\n    assert(candidate([5L, -2L, 1L, -5L]) == 0L);\n    assert(candidate([15L, -73L, 14L, -15L]) == 1L);\n    assert(candidate([33L, -2L, -3L, 45L, 21L, 109L]) == 2L);\n    assert(candidate([43L, -12L, 93L, 125L, 121L, 109L]) == 4L);\n    assert(candidate([71L, -2L, -33L, 75L, 21L, 19L]) == 3L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([]) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2190,13 +735,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30L)\n    465L\n    >>> sum_to_n(100L)\n    5050L\n    >>> sum_to_n(5L)\n    15L\n    >>> sum_to_n(10L)\n    55L\n    >>> sum_to_n(1L)\n    1L\n    \n*/\nlong sum_to_n(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5L)\n    1L\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \n*/\nlong get_max_triples(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = get_max_triples;\n\n    assert(candidate(5L) == 1L);\n    assert(candidate(6L) == 4L);\n    assert(candidate(10L) == 36L);\n    assert(candidate(100L) == 53361L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2205,13 +750,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1L, 2L, 3L, 2L, 4L])\n    [1L, 3L, 4L]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \n*/\nstring[] sorted_list_sum(string[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sorted_list_sum;\n\n    assert(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"]);\n    assert(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"]);\n    assert(candidate([\"d\", \"b\", \"c\", \"a\"]) == []);\n    assert(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"]);\n    assert(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"]);\n    assert(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == []);\n    assert(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \n*/\nstring[] all_prefixes(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_prefixes;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n    assert(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nA simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7L, 34L, 12L)\n    34L\n    >>> x_or_y(15L, 8L, 5L)\n    5L\n    \n    \n*/\nlong x_or_y(long n, long x, long y) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = x_or_y;\n\n    assert(candidate(7L, 34L, 12L) == 34L);\n    assert(candidate(15L, 8L, 5L) == 5L);\n    assert(candidate(3L, 33L, 5212L) == 33L);\n    assert(candidate(1259L, 3L, 52L) == 3L);\n    assert(candidate(7919L, -1L, 12L) == -1L);\n    assert(candidate(3609L, 1245L, 583L) == 583L);\n    assert(candidate(91L, 56L, 129L) == 129L);\n    assert(candidate(6L, 34L, 1234L) == 1234L);\n    assert(candidate(1L, 2L, 0L) == 0L);\n    assert(candidate(2L, 2L, 0L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1L, 3L, 2L, 0L])\n    10L\n    >>> double_the_difference([-1L, -2L, 0L])\n    0L\n    >>> double_the_difference([9L, -2L])\n    81L\n    >>> double_the_difference([0L])\n    0L\n   \n    If the input list is empty, return 0.\n    \n*/\nlong double_the_difference(float[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = double_the_difference;\n\n    assert(candidate([]) == 0L);\n    assert(candidate([5.0, 4.0]) == 25L);\n    assert(candidate([0.1, 0.2, 0.3]) == 0L);\n    assert(candidate([-10.0, -20.0, -30.0]) == 0L);\n    assert(candidate([-1.0, -2.0, 8.0]) == 0L);\n    assert(candidate([0.2, 3.0, 5.0]) == 34L);\n    assert(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nI think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L])\n    [0L, 0L, 0L, 0L, 3L, 3L]\n    >>> compare([0L, 5L, 0L, 0L, 0L, 4L], [4L, 1L, 1L, 0L, 0L, -2L])\n    [4L, 4L, 1L, 0L, 0L, 6L]\n    \n*/\nlong[] compare(long[] game, long[] guess) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = compare;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 1L], [1L, 2L, 3L, 4L, 2L, -2L]) == [0L, 0L, 0L, 0L, 3L, 3L]);\n    assert(candidate([0L, 0L, 0L, 0L, 0L, 0L], [0L, 0L, 0L, 0L, 0L, 0L]) == [0L, 0L, 0L, 0L, 0L, 0L]);\n    assert(candidate([1L, 2L, 3L], [-1L, -2L, -3L]) == [2L, 4L, 6L]);\n    assert(candidate([1L, 2L, 3L, 5L], [-1L, 2L, 3L, 4L]) == [2L, 0L, 0L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \n*/\nstring Strongest_Extension(string class_name, string[] extensions) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Strongest_Extension;\n\n    assert(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\");\n    assert(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\");\n    assert(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\");\n    assert(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\");\n    assert(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\");\n    assert(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\");\n    assert(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\");\n    assert(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\");\n    assert(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \n*/\nbool cycpattern_check(string a, string b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cycpattern_check;\n\n    assert(candidate(\"xyzw\", \"xyw\") == false);\n    assert(candidate(\"yello\", \"ell\") == true);\n    assert(candidate(\"whattup\", \"ptut\") == false);\n    assert(candidate(\"efef\", \"fee\") == true);\n    assert(candidate(\"abab\", \"aabb\") == false);\n    assert(candidate(\"winemtt\", \"tinem\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12L)\n    tuple(1L, 1L)\n    >>> even_odd_count(123L)\n    tuple(1L, 2L)\n    \n*/\nTuple!(long, long) even_odd_count(long num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_odd_count;\n\n    assert(candidate(7L) == tuple(0L, 1L));\n    assert(candidate(-78L) == tuple(1L, 1L));\n    assert(candidate(3452L) == tuple(2L, 2L));\n    assert(candidate(346211L) == tuple(3L, 3L));\n    assert(candidate(-345821L) == tuple(3L, 3L));\n    assert(candidate(-2L) == tuple(1L, 0L));\n    assert(candidate(-45347L) == tuple(2L, 3L));\n    assert(candidate(0L) == tuple(1L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19L)\n    \"xix\"\n    >>> int_to_mini_roman(152L)\n    \"clii\"\n    >>> int_to_mini_roman(426L)\n    \"cdxxvi\"\n    \n*/\nstring int_to_mini_roman(long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = int_to_mini_roman;\n\n    assert(candidate(19L) == \"xix\");\n    assert(candidate(152L) == \"clii\");\n    assert(candidate(251L) == \"ccli\");\n    assert(candidate(426L) == \"cdxxvi\");\n    assert(candidate(500L) == \"d\");\n    assert(candidate(1L) == \"i\");\n    assert(candidate(4L) == \"iv\");\n    assert(candidate(43L) == \"xliii\");\n    assert(candidate(90L) == \"xc\");\n    assert(candidate(94L) == \"xciv\");\n    assert(candidate(532L) == \"dxxxii\");\n    assert(candidate(900L) == \"cm\");\n    assert(candidate(994L) == \"cmxciv\");\n    assert(candidate(1000L) == \"m\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3L, 4L, 5L)\n    true\n    >>> right_angle_triangle(1L, 2L, 3L)\n    false\n    \n*/\nbool right_angle_triangle(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = right_angle_triangle;\n\n    assert(candidate(3L, 4L, 5L) == true);\n    assert(candidate(1L, 2L, 3L) == false);\n    assert(candidate(10L, 6L, 8L) == true);\n    assert(candidate(2L, 2L, 2L) == false);\n    assert(candidate(7L, 24L, 25L) == true);\n    assert(candidate(10L, 5L, 7L) == false);\n    assert(candidate(5L, 12L, 13L) == true);\n    assert(candidate(15L, 8L, 17L) == true);\n    assert(candidate(48L, 55L, 73L) == true);\n    assert(candidate(1L, 1L, 1L) == false);\n    assert(candidate(2L, 2L, 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \n*/\nstring find_max(string[] words) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_max;\n\n    assert(candidate([\"name\", \"of\", \"string\"]) == \"string\");\n    assert(candidate([\"name\", \"enam\", \"game\"]) == \"enam\");\n    assert(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\");\n    assert(candidate([\"abc\", \"cba\"]) == \"abc\");\n    assert(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\");\n    assert(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\");\n    assert(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\");\n    assert(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\");\n    assert(candidate([\"b\"]) == \"b\");\n    assert(candidate([\"play\", \"play\", \"play\"]) == \"play\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5L, 6L, 10L)\n    [11L, 4L]\n    >>> eat(4L, 8L, 9L)\n    [12L, 1L]\n    >>> eat(1L, 10L, 10L)\n    [11L, 0L]\n    >>> eat(2L, 11L, 5L)\n    [7L, 0L]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \n*/\nlong[] eat(long number, long need, long remaining) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = eat;\n\n    assert(candidate(5L, 6L, 10L) == [11L, 4L]);\n    assert(candidate(4L, 8L, 9L) == [12L, 1L]);\n    assert(candidate(1L, 10L, 10L) == [11L, 0L]);\n    assert(candidate(2L, 11L, 5L) == [7L, 0L]);\n    assert(candidate(4L, 5L, 7L) == [9L, 2L]);\n    assert(candidate(4L, 5L, 1L) == [5L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0L)\n    \"0\"\n    >>> string_sequence(5L)\n    \"0 1 2 3 4 5\"\n    \n*/\nstring string_sequence(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_sequence;\n\n    assert(candidate(0L) == \"0\");\n    assert(candidate(3L) == \"0 1 2 3\");\n    assert(candidate(10L) == \"0 1 2 3 4 5 6 7 8 9 10\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \n*/\nlong do_algebra(string[] operator, long[] operand) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = do_algebra;\n\n    assert(candidate([\"**\", \"*\", \"+\"], [2L, 3L, 4L, 5L]) == 37L);\n    assert(candidate([\"+\", \"*\", \"-\"], [2L, 3L, 4L, 5L]) == 9L);\n    assert(candidate([\"//\", \"*\"], [7L, 3L, 4L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \n*/\nstring solve(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(\"AsDf\") == \"aSdF\");\n    assert(candidate(\"1234\") == \"4321\");\n    assert(candidate(\"ab\") == \"AB\");\n    assert(candidate(\"#a@C\") == \"#A@c\");\n    assert(candidate(\"#AsdfW^45\") == \"#aSDFw^45\");\n    assert(candidate(\"#6@2\") == \"2@6#\");\n    assert(candidate(\"#$a^D\") == \"#$A^d\");\n    assert(candidate(\"#ccc\") == \"#CCC\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \n*/\nNullable!(string) string_to_md5(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_to_md5;\n\n{\n        auto result = candidate(\"Hello world\");\n        assert(!result.isNull && result.get == \"3e25960a79dbc69b674cd4ec67a72c62\");\n}\n\n{\n        auto result = candidate(\"\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"A B C\");\n        assert(!result.isNull && result.get == \"0ef78513b0cb8cef12743f5aeb35f888\");\n}\n\n{\n        auto result = candidate(\"password\");\n        assert(!result.isNull && result.get == \"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2224,7 +994,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2L, 8L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(8L, 2L)\n    [2L, 4L, 6L, 8L]\n    >>> generate_integers(10L, 14L)\n    []\n    \n*/\nlong[] generate_integers(long a, long b) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = generate_integers;\n\n    assert(candidate(2L, 10L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(10L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(132L, 2L) == [2L, 4L, 6L, 8L]);\n    assert(candidate(17L, 89L) == []);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -2235,13 +1005,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1L, 2L, 3L, 2L, 3L, 4L, 2L])\n    [1L, 2L, 3L, 3L, 3L, 4L, 4L]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3L\n    >>> count_distinct_characters(\"Jerry\")\n    4L\n    \n*/\nlong count_distinct_characters(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = count_distinct_characters;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abcde\") == 5L);\n    assert(candidate(\"abcdecadeCADE\") == 5L);\n    assert(candidate(\"aaaaAAAAaaaa\") == 1L);\n    assert(candidate(\"Jerry jERRY JeRRRY\") == 5L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2250,13 +1020,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1L, 2L, 3L])\n    false\n    >>> below_zero([1L, 2L, -4L, 5L])\n    true\n    \n*/\nbool below_zero(long[] operations) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4L, 2L, 1L, 2L, 2L, 1L, 1L, 1L, 1L, 4L, 4L]\n    \n*/\nlong[] parse_music(string music_string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = parse_music;\n\n    assert(candidate(\"\") == []);\n    assert(candidate(\"o o o o\") == [4L, 4L, 4L, 4L]);\n    assert(candidate(\".| .| .| .|\") == [1L, 1L, 1L, 1L]);\n    assert(candidate(\"o| o| .| .| o o o o\") == [2L, 2L, 1L, 1L, 4L, 4L, 4L, 4L]);\n    assert(candidate(\"o| .| o| .| o o| o o|\") == [2L, 1L, 2L, 1L, 4L, 2L, 4L, 2L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2265,13 +1035,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4L, 1L, 2L, 2L, 3L, 1L])\n    2L\n    >>> search([1L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L])\n    3L\n    >>> search([5L, 5L, 4L, 4L, 4L])\n    -1L\n    \n*/\nlong search(long[] lst) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0L\n    >>> how_many_times(\"aaa\", \"a\")\n    3L\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3L\n    \n*/\nlong how_many_times(string string, string substring) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = how_many_times;\n\n    assert(candidate(\"\", \"x\") == 0L);\n    assert(candidate(\"xyxyxyx\", \"x\") == 4L);\n    assert(candidate(\"cacacacac\", \"cac\") == 4L);\n    assert(candidate(\"john doe\", \"john\") == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2280,13 +1050,268 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \n*/\nstring sort_numbers(string numbers) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_numbers;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"three\") == \"three\");\n    assert(candidate(\"three five nine\") == \"three five nine\");\n    assert(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\");\n    assert(candidate(\"six five four three two one zero\") == \"zero one two three four five six\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \n*/\nstring[] separate_paren_groups(string paren_string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = separate_paren_groups;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n    assert(candidate(\"(()(())((())))\") == [\"(()(())((())))\"]);\n    assert(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    tuple(2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    tuple(2.0, 2.0)\n    \n*/\nTuple!(float, float) find_closest_elements(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_closest_elements;\n\n    assert(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == tuple(3.9, 4.0));\n    assert(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == tuple(5.0, 5.9));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == tuple(2.0, 2.2));\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == tuple(2.0, 2.0));\n    assert(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == tuple(2.2, 3.1));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \n*/\nfloat[] rescale_to_unit(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rescale_to_unit;\n\n    assert(candidate([2.0, 49.9]) == [0.0, 1.0]);\n    assert(candidate([100.0, 49.9]) == [1.0, 0.0]);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return length of given string\n    >>> strlen(\"\")\n    0L\n    >>> strlen(\"abc\")\n    3L\n    \n*/\nlong strlen(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strlen;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"x\") == 1L);\n    assert(candidate(\"asdasnakj\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15L)\n    5L\n    \n*/\nlong largest_divisor(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_divisor;\n\n    assert(candidate(3L) == 1L);\n    assert(candidate(7L) == 1L);\n    assert(candidate(10L) == 5L);\n    assert(candidate(100L) == 50L);\n    assert(candidate(49L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8L)\n    [2L, 2L, 2L]\n    >>> factorize(25L)\n    [5L, 5L]\n    >>> factorize(70L)\n    [2L, 5L, 7L]\n    \n*/\nlong[] factorize(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = factorize;\n\n    assert(candidate(2L) == [2L]);\n    assert(candidate(4L) == [2L, 2L]);\n    assert(candidate(8L) == [2L, 2L, 2L]);\n    assert(candidate(57L) == [3L, 19L]);\n    assert(candidate(3249L) == [3L, 3L, 19L, 19L]);\n    assert(candidate(185193L) == [3L, 3L, 3L, 19L, 19L, 19L]);\n    assert(candidate(20577L) == [3L, 19L, 19L, 19L]);\n    assert(candidate(18L) == [2L, 3L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1L, 2L, 3L, 2L, 4L])\n    [1L, 3L, 4L]\n    \n*/\nlong[] remove_duplicates(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_duplicates;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 3L, 5L]) == [1L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \n*/\nstring flip_case(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = flip_case;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hello!\") == \"hELLO!\");\n    assert(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Concatenate list of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \n*/\nstring concatenate(string[] strings) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = concatenate;\n\n    assert(candidate([]) == \"\");\n    assert(candidate([\"x\", \"y\", \"z\"]) == \"xyz\");\n    assert(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \n*/\nstring[] filter_by_prefix(string[] strings, string prefix) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_prefix;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \n*/\nfloat truncate_number(float number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = truncate_number;\n\n    assert(candidate(3.5) == 0.5);\n    assert(candidate(1.25) == 0.25);\n    assert(candidate(123.0) == 0.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn only positive numbers in the list.\n    >>> get_positive([-1L, 2L, -4L, 5L, 6L])\n    [2L, 5L, 6L]\n    >>> get_positive([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    [5L, 3L, 2L, 3L, 9L, 123L, 1L]\n    \n*/\nlong[] get_positive(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_positive;\n\n    assert(candidate([-1L, -2L, 4L, 5L, 6L]) == [4L, 5L, 6L]);\n    assert(candidate([5L, 3L, -5L, 2L, 3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [5L, 3L, 2L, 3L, 3L, 9L, 123L, 1L]);\n    assert(candidate([-1L, -2L]) == []);\n    assert(candidate([]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn true if a given number is prime, and false otherwise.\n    >>> is_prime(6L)\n    false\n    >>> is_prime(101L)\n    true\n    >>> is_prime(11L)\n    true\n    >>> is_prime(13441L)\n    true\n    >>> is_prime(61L)\n    true\n    >>> is_prime(4L)\n    false\n    >>> is_prime(1L)\n    false\n    \n*/\nbool is_prime(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_prime;\n\n    assert(candidate(6L) == false);\n    assert(candidate(101L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(13441L) == true);\n    assert(candidate(61L) == true);\n    assert(candidate(4L) == false);\n    assert(candidate(1L) == false);\n    assert(candidate(5L) == true);\n    assert(candidate(11L) == true);\n    assert(candidate(17L) == true);\n    assert(candidate(85L) == false);\n    assert(candidate(77L) == false);\n    assert(candidate(255379L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_third([5L, 6L, 3L, 4L, 8L, 9L, 2L])\n    [2L, 6L, 3L, 4L, 8L, 9L, 5L]\n    \n*/\nlong[] sort_third(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_third;\n\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L]);\n    assert(candidate([5L, 8L, 3L, 4L, 6L, 9L, 2L]) == [2L, 8L, 3L, 4L, 6L, 9L, 5L]);\n    assert(candidate([5L, 6L, 9L, 4L, 8L, 3L, 2L]) == [2L, 6L, 9L, 4L, 8L, 3L, 5L]);\n    assert(candidate([5L, 6L, 3L, 4L, 8L, 9L, 2L, 1L]) == [2L, 6L, 3L, 4L, 8L, 9L, 5L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique elements in a list\n    >>> unique([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [0L, 2L, 3L, 5L, 9L, 123L]\n    \n*/\nlong[] unique(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = unique;\n\n    assert(candidate([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [0L, 2L, 3L, 5L, 9L, 123L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn maximum element in the list.\n    >>> max_element([1L, 2L, 3L])\n    3L\n    >>> max_element([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L])\n    123L\n    \n*/\nlong max_element(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_element;\n\n    assert(candidate([1L, 2L, 3L]) == 3L);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 124L, 1L, -10L]) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50L)\n    0L\n    >>> fizz_buzz(78L)\n    2L\n    >>> fizz_buzz(79L)\n    3L\n    \n*/\nlong fizz_buzz(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fizz_buzz;\n\n    assert(candidate(50L) == 0L);\n    assert(candidate(78L) == 2L);\n    assert(candidate(79L) == 3L);\n    assert(candidate(100L) == 3L);\n    assert(candidate(200L) == 6L);\n    assert(candidate(4000L) == 192L);\n    assert(candidate(10000L) == 639L);\n    assert(candidate(100000L) == 8026L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2299,9 +1324,249 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\nThis function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1L, 2L, 3L])\n    [1L, 2L, 3L]\n    >>> sort_even([5L, 6L, 3L, 4L])\n    [3L, 6L, 5L, 4L]\n    \n*/\nlong[] sort_even(long[] l) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = sort_even;\n\n    assert(candidate([1L, 2L, 3L]) == [1L, 2L, 3L]);\n    assert(candidate([5L, 3L, -5L, 2L, -3L, 3L, 9L, 0L, 123L, 1L, -10L]) == [-10L, 3L, -5L, 2L, -3L, 3L, 5L, 0L, 9L, 1L, 123L]);\n    assert(candidate([5L, 8L, -12L, 4L, 23L, 2L, 3L, 11L, 12L, -10L]) == [-12L, 8L, 3L, 4L, 5L, 2L, 12L, 11L, 23L, -10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1L)\n    2L\n    >>> prime_fib(2L)\n    3L\n    >>> prime_fib(3L)\n    5L\n    >>> prime_fib(4L)\n    13L\n    >>> prime_fib(5L)\n    89L\n    \n*/\nlong prime_fib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_fib;\n\n    assert(candidate(1L) == 2L);\n    assert(candidate(2L) == 3L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 13L);\n    assert(candidate(5L) == 89L);\n    assert(candidate(6L) == 233L);\n    assert(candidate(7L) == 1597L);\n    assert(candidate(8L) == 28657L);\n    assert(candidate(9L) == 514229L);\n    assert(candidate(10L) == 433494437L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1L, 2L, 3L])\n    false\n    >>> below_zero([1L, 2L, -4L, 5L])\n    true\n    \n*/\nbool below_zero(long[] operations) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_zero;\n\n    assert(candidate([]) == false);\n    assert(candidate([1L, 2L, -3L, 1L, 2L, -3L]) == false);\n    assert(candidate([1L, 2L, -4L, 5L, 6L]) == true);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -4L]) == false);\n    assert(candidate([1L, -1L, 2L, -2L, 5L, -5L, 4L, -5L]) == true);\n    assert(candidate([1L, -2L, 2L, -2L, 5L, -5L, 4L, -4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> triples_sum_to_zero([1L, 3L, -2L, 1L])\n    true\n    >>> triples_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> triples_sum_to_zero([2L, 4L, -5L, 3L, 9L, 7L])\n    true\n    >>> triples_sum_to_zero([1L])\n    false\n    \n*/\nbool triples_sum_to_zero(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triples_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, 5L, -1L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == true);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([1L, 2L, 5L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 9L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([1L, 3L, 5L, -100L]) == false);\n    assert(candidate([100L, 3L, 5L, -100L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \n*/\nlong car_race_collision(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = car_race_collision;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 9L);\n    assert(candidate(4L) == 16L);\n    assert(candidate(8L) == 64L);\n    assert(candidate(10L) == 100L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn list with elements incremented by 1.\n    >>> incr_list([1L, 2L, 3L])\n    [2L, 3L, 4L]\n    >>> incr_list([5L, 3L, 5L, 2L, 3L, 3L, 9L, 0L, 123L])\n    [6L, 4L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]\n    \n*/\nlong[] incr_list(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = incr_list;\n\n    assert(candidate([]) == []);\n    assert(candidate([3L, 2L, 1L]) == [4L, 3L, 2L]);\n    assert(candidate([5L, 2L, 5L, 2L, 3L, 3L, 9L, 0L, 123L]) == [6L, 3L, 6L, 3L, 4L, 4L, 10L, 1L, 124L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1L, 3L, 5L, 0L])\n    false\n    >>> pairs_sum_to_zero([1L, 3L, -2L, 1L])\n    false\n    >>> pairs_sum_to_zero([1L, 2L, 3L, 7L])\n    false\n    >>> pairs_sum_to_zero([2L, 4L, -5L, 3L, 5L, 7L])\n    true\n    >>> pairs_sum_to_zero([1L])\n    false\n    \n*/\nbool pairs_sum_to_zero(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pairs_sum_to_zero;\n\n    assert(candidate([1L, 3L, 5L, 0L]) == false);\n    assert(candidate([1L, 3L, -2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L, 7L]) == false);\n    assert(candidate([2L, 4L, -5L, 3L, 5L, 7L]) == true);\n    assert(candidate([1L]) == false);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 30L]) == true);\n    assert(candidate([-3L, 9L, -1L, 3L, 2L, 31L]) == true);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 30L]) == false);\n    assert(candidate([-3L, 9L, -1L, 4L, 2L, 31L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nChange numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8L, 3L)\n    \"22\"\n    >>> change_base(8L, 2L)\n    \"1000\"\n    >>> change_base(7L, 2L)\n    \"111\"\n    \n*/\nstring change_base(long x, long base) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = change_base;\n\n    assert(candidate(8L, 3L) == \"22\");\n    assert(candidate(9L, 3L) == \"100\");\n    assert(candidate(234L, 2L) == \"11101010\");\n    assert(candidate(16L, 2L) == \"10000\");\n    assert(candidate(8L, 2L) == \"1000\");\n    assert(candidate(7L, 2L) == \"111\");\n    assert(candidate(2L, 3L) == \"2\");\n    assert(candidate(3L, 4L) == \"3\");\n    assert(candidate(4L, 5L) == \"4\");\n    assert(candidate(5L, 6L) == \"5\");\n    assert(candidate(6L, 7L) == \"6\");\n    assert(candidate(7L, 8L) == \"7\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven length of a side and high return area for a triangle.\n    >>> triangle_area(5L, 3L)\n    7.5\n    \n*/\nfloat triangle_area(long a, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(5L, 3L) == 7.5);\n    assert(candidate(2L, 2L) == 2.0);\n    assert(candidate(10L, 8L) == 40.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5L)\n    4L\n    >>> fib4(6L)\n    8L\n    >>> fib4(7L)\n    14L\n    \n*/\nlong fib4(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib4;\n\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 28L);\n    assert(candidate(10L) == 104L);\n    assert(candidate(12L) == 386L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn median of elements in the list l.\n    >>> median([3L, 1L, 2L, 4L, 5L])\n    3L\n    >>> median([-10L, 4L, 6L, 1000L, 10L, 20L])\n    15.0\n    \n*/\nfloat median(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = median;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == 3L);\n    assert(candidate([-10L, 4L, 6L, 1000L, 10L, 20L]) == 8.0);\n    assert(candidate([5L]) == 5L);\n    assert(candidate([6L, 5L]) == 5.5);\n    assert(candidate([8L, 1L, 3L, 9L, 9L, 2L, 7L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \n*/\nbool is_palindrome(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_palindrome;\n\n    assert(candidate(\"\") == true);\n    assert(candidate(\"aba\") == true);\n    assert(candidate(\"aaaaa\") == true);\n    assert(candidate(\"zbcd\") == false);\n    assert(candidate(\"xywyx\") == true);\n    assert(candidate(\"xywyz\") == false);\n    assert(candidate(\"xywzx\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn 2^n modulo p (be aware of numerics).\n    >>> modp(3L, 5L)\n    3L\n    >>> modp(1101L, 101L)\n    2L\n    >>> modp(0L, 101L)\n    1L\n    >>> modp(3L, 11L)\n    8L\n    >>> modp(100L, 101L)\n    1L\n    \n*/\nlong modp(long n, long p) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = modp;\n\n    assert(candidate(3L, 5L) == 3L);\n    assert(candidate(1101L, 101L) == 2L);\n    assert(candidate(0L, 101L) == 1L);\n    assert(candidate(3L, 11L) == 8L);\n    assert(candidate(100L, 101L) == 1L);\n    assert(candidate(30L, 5L) == 4L);\n    assert(candidate(31L, 5L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \n*/\nfloat mean_absolute_deviation(float[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = mean_absolute_deviation;\n\n    assert(candidate([1.0, 2.0]) == 0.5);\n    assert(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0);\n    assert(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \n*/\nstring remove_vowels(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_vowels;\n\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\");\n    assert(candidate(\"fedcba\") == \"fdcb\");\n    assert(candidate(\"eeeee\") == \"\");\n    assert(candidate(\"acBAA\") == \"cB\");\n    assert(candidate(\"EcBOO\") == \"cB\");\n    assert(candidate(\"ybcd\") == \"ybcd\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1L, 2L, 4L, 10L], 100L)\n    true\n    >>> below_threshold([1L, 20L, 4L, 10L], 5L)\n    false\n    \n*/\nbool below_threshold(long[] l, long t) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = below_threshold;\n\n    assert(candidate([1L, 2L, 4L, 10L], 100L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 5L) == false);\n    assert(candidate([1L, 20L, 4L, 10L], 21L) == true);\n    assert(candidate([1L, 20L, 4L, 10L], 22L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 11L) == true);\n    assert(candidate([1L, 8L, 4L, 10L], 10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nAdd two numbers x and y\n    >>> add(2L, 3L)\n    5L\n    >>> add(5L, 7L)\n    12L\n    \n*/\nlong add(long x, long y) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate(0L, 1L) == 1L);\n    assert(candidate(1L, 0L) == 1L);\n    assert(candidate(2L, 3L) == 5L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 5L) == 12L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2314,9 +1579,24 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Check if two words have the same characters.\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n    true\n    >>> same_chars(\"abcd\", \"dddddddabc\")\n    true\n    >>> same_chars(\"dddddddabc\", \"abcd\")\n    true\n    >>> same_chars(\"eabcd\", \"dddddddabc\")\n    false\n    >>> same_chars(\"abcd\", \"dddddddabce\")\n    false\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n    false\n    \n*/\nbool same_chars(string s0, string s1) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = same_chars;\n\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true);\n    assert(candidate(\"abcd\", \"dddddddabc\") == true);\n    assert(candidate(\"dddddddabc\", \"abcd\") == true);\n    assert(candidate(\"eabcd\", \"dddddddabc\") == false);\n    assert(candidate(\"abcd\", \"dddddddabcf\") == false);\n    assert(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false);\n    assert(candidate(\"aabb\", \"aaccc\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn n-th Fibonacci number.\n    >>> fib(10L)\n    55L\n    >>> fib(1L)\n    1L\n    >>> fib(8L)\n    21L\n    \n*/\nlong fib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fib;\n\n    assert(candidate(10L) == 55L);\n    assert(candidate(1L) == 1L);\n    assert(candidate(8L) == 21L);\n    assert(candidate(11L) == 89L);\n    assert(candidate(12L) == 144L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -2329,9 +1609,729 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    false\n    >>> correct_bracketing(\"<>\")\n    true\n    >>> correct_bracketing(\"<<><>>\")\n    true\n    >>> correct_bracketing(\"><<>\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"<>\") == true);\n    assert(candidate(\"<<><>>\") == true);\n    assert(candidate(\"<><><<><>><>\") == true);\n    assert(candidate(\"<><><<<><><>><>><<><><<>>>\") == true);\n    assert(candidate(\"<<<><>>>>\") == false);\n    assert(candidate(\"><<>\") == false);\n    assert(candidate(\"<\") == false);\n    assert(candidate(\"<<<<\") == false);\n    assert(candidate(\">\") == false);\n    assert(candidate(\"<<>\") == false);\n    assert(candidate(\"<><><<><>><>><<>\") == false);\n    assert(candidate(\"<><><<><>><>>><>\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1L, 2L, 4L, 20L])\n    true\n    >>> monotonic([1L, 20L, 4L, 10L])\n    false\n    >>> monotonic([4L, 1L, 0L, -10L])\n    true\n    \n*/\nbool monotonic(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = monotonic;\n\n    assert(candidate([1L, 2L, 4L, 10L]) == true);\n    assert(candidate([1L, 2L, 4L, 20L]) == true);\n    assert(candidate([1L, 20L, 4L, 10L]) == false);\n    assert(candidate([4L, 1L, 0L, -10L]) == true);\n    assert(candidate([4L, 1L, 1L, 0L]) == true);\n    assert(candidate([1L, 2L, 3L, 2L, 5L, 60L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 60L]) == true);\n    assert(candidate([9L, 9L, 9L, 9L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn sorted unique common elements for two lists.\n    >>> common([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L])\n    [1L, 5L, 653L]\n    >>> common([5L, 3L, 2L, 8L], [3L, 2L])\n    [2L, 3L]\n\n    \n*/\nlong[] common(long[] l1, long[] l2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = common;\n\n    assert(candidate([1L, 4L, 3L, 34L, 653L, 2L, 5L], [5L, 7L, 1L, 5L, 9L, 653L, 121L]) == [1L, 5L, 653L]);\n    assert(candidate([5L, 3L, 2L, 8L], [3L, 2L]) == [2L, 3L]);\n    assert(candidate([4L, 3L, 2L, 8L], [3L, 2L, 4L]) == [2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 8L], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nReturn the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195L)\n    29L\n    >>> largest_prime_factor(2048L)\n    2L\n    \n*/\nlong largest_prime_factor(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_prime_factor;\n\n    assert(candidate(15L) == 5L);\n    assert(candidate(27L) == 3L);\n    assert(candidate(63L) == 7L);\n    assert(candidate(330L) == 11L);\n    assert(candidate(13195L) == 29L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4L)\n    []\n    >>> intersperse([1L, 2L, 3L], 4L)\n    [1L, 4L, 2L, 4L, 3L]\n    \n*/\nlong[] intersperse(long[] numbers, long delimeter) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = intersperse;\n\n    assert(candidate([], 7L) == []);\n    assert(candidate([5L, 6L, 3L, 2L], 8L) == [5L, 8L, 6L, 8L, 3L, 8L, 2L]);\n    assert(candidate([2L, 2L, 2L], 2L) == [2L, 2L, 2L, 2L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nsum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30L)\n    465L\n    >>> sum_to_n(100L)\n    5050L\n    >>> sum_to_n(5L)\n    15L\n    >>> sum_to_n(10L)\n    55L\n    >>> sum_to_n(1L)\n    1L\n    \n*/\nlong sum_to_n(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_to_n;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(6L) == 21L);\n    assert(candidate(11L) == 66L);\n    assert(candidate(30L) == 465L);\n    assert(candidate(100L) == 5050L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \n*/\nbool correct_bracketing(string brackets) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = correct_bracketing;\n\n    assert(candidate(\"()\") == true);\n    assert(candidate(\"(()())\") == true);\n    assert(candidate(\"()()(()())()\") == true);\n    assert(candidate(\"()()((()()())())(()()(()))\") == true);\n    assert(candidate(\"((()())))\") == false);\n    assert(candidate(\")(()\") == false);\n    assert(candidate(\"(\") == false);\n    assert(candidate(\"((((\") == false);\n    assert(candidate(\")\") == false);\n    assert(candidate(\"(()\") == false);\n    assert(candidate(\"()()(()())())(()\") == false);\n    assert(candidate(\"()()(()())()))()\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3L, 1L, 2L, 4L, 5L])\n    [1L, 4L, 12L, 20L]\n    >>> derivative([1L, 2L, 3L])\n    [2L, 6L]\n    \n*/\nlong[] derivative(long[] xs) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = derivative;\n\n    assert(candidate([3L, 1L, 2L, 4L, 5L]) == [1L, 4L, 12L, 20L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 6L]);\n    assert(candidate([3L, 2L, 1L]) == [2L, 2L]);\n    assert(candidate([3L, 2L, 1L, 0L, 4L]) == [2L, 2L, 0L, 16L]);\n    assert(candidate([1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nThe FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1L)\n    0L\n    >>> fibfib(5L)\n    4L\n    >>> fibfib(8L)\n    24L\n    \n*/\nlong fibfib(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fibfib;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(1L) == 0L);\n    assert(candidate(5L) == 4L);\n    assert(candidate(8L) == 24L);\n    assert(candidate(10L) == 81L);\n    assert(candidate(12L) == 274L);\n    assert(candidate(14L) == 927L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2L\n    >>> vowels_count(\"ACEDY\")\n    3L\n    \n*/\nlong vowels_count(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = vowels_count;\n\n    assert(candidate(\"abcde\") == 2L);\n    assert(candidate(\"Alone\") == 3L);\n    assert(candidate(\"key\") == 2L);\n    assert(candidate(\"bye\") == 1L);\n    assert(candidate(\"keY\") == 2L);\n    assert(candidate(\"bYe\") == 1L);\n    assert(candidate(\"ACEDY\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCircular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12L, 1L)\n    \"21\"\n    >>> circular_shift(12L, 2L)\n    \"12\"\n    \n*/\nstring circular_shift(long x, long shift) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = circular_shift;\n\n    assert(candidate(100L, 2L) == \"001\");\n    assert(candidate(12L, 2L) == \"12\");\n    assert(candidate(97L, 8L) == \"79\");\n    assert(candidate(12L, 1L) == \"21\");\n    assert(candidate(11L, 101L) == \"11\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nTask\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0L\n    >>> digitSum(\"abAB\")\n    131L\n    >>> digitSum(\"abcCd\")\n    67L\n    >>> digitSum(\"helloE\")\n    69L\n    >>> digitSum(\"woArBld\")\n    131L\n    >>> digitSum(\"aAaaaXa\")\n    153L\n    \n*/\nlong digitSum(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digitSum;\n\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"abAB\") == 131L);\n    assert(candidate(\"abcCd\") == 67L);\n    assert(candidate(\"helloE\") == 69L);\n    assert(candidate(\"woArBld\") == 131L);\n    assert(candidate(\"aAaaaXa\") == 153L);\n    assert(candidate(\" How are yOu?\") == 151L);\n    assert(candidate(\"You arE Very Smart\") == 327L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19L)\n    8L\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3L)\n    2L\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100L)\n    95L\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120L)\n    19L\n    \n*/\nlong fruit_distribution(string s, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = fruit_distribution;\n\n    assert(candidate(\"5 apples and 6 oranges\", 19L) == 8L);\n    assert(candidate(\"5 apples and 6 oranges\", 21L) == 10L);\n    assert(candidate(\"0 apples and 1 oranges\", 3L) == 2L);\n    assert(candidate(\"1 apples and 0 oranges\", 3L) == 2L);\n    assert(candidate(\"2 apples and 3 oranges\", 100L) == 95L);\n    assert(candidate(\"2 apples and 3 oranges\", 5L) == 0L);\n    assert(candidate(\"1 apples and 100 oranges\", 120L) == 19L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1L, 2L, 3L])\n    [2L, 1L]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5L, 0L, 3L, 0L, 4L, 2L])\n    [0L, 1L]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \n*/\nlong[] pluck(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pluck;\n\n    assert(candidate([4L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([1L, 2L, 3L]) == [2L, 1L]);\n    assert(candidate([]) == []);\n    assert(candidate([5L, 0L, 3L, 0L, 4L, 2L]) == [0L, 1L]);\n    assert(candidate([1L, 2L, 3L, 0L, 5L, 3L]) == [0L, 3L]);\n    assert(candidate([5L, 4L, 8L, 4L, 8L]) == [4L, 1L]);\n    assert(candidate([7L, 6L, 7L, 1L]) == [6L, 1L]);\n    assert(candidate([7L, 9L, 7L, 1L]) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4L, 1L, 2L, 2L, 3L, 1L])\n    2L\n    >>> search([1L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L])\n    3L\n    >>> search([5L, 5L, 4L, 4L, 4L])\n    -1L\n    \n*/\nlong search(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([5L, 5L, 5L, 5L, 1L]) == 1L);\n    assert(candidate([4L, 1L, 4L, 1L, 4L, 4L]) == 4L);\n    assert(candidate([3L, 3L]) == -1L);\n    assert(candidate([8L, 8L, 8L, 8L, 8L, 8L, 8L, 8L]) == 8L);\n    assert(candidate([2L, 3L, 3L, 2L, 2L]) == 2L);\n    assert(candidate([2L, 7L, 8L, 8L, 4L, 8L, 7L, 3L, 9L, 6L, 5L, 10L, 4L, 3L, 6L, 7L, 1L, 7L, 4L, 10L, 8L, 1L]) == 1L);\n    assert(candidate([3L, 2L, 8L, 2L]) == 2L);\n    assert(candidate([6L, 7L, 1L, 8L, 8L, 10L, 5L, 8L, 5L, 3L, 10L]) == 1L);\n    assert(candidate([8L, 8L, 3L, 6L, 5L, 6L, 4L]) == -1L);\n    assert(candidate([6L, 9L, 6L, 7L, 1L, 4L, 7L, 1L, 8L, 8L, 9L, 8L, 10L, 10L, 8L, 4L, 10L, 4L, 10L, 1L, 2L, 9L, 5L, 7L, 9L]) == 1L);\n    assert(candidate([1L, 9L, 10L, 1L, 3L]) == 1L);\n    assert(candidate([6L, 9L, 7L, 5L, 8L, 7L, 5L, 3L, 7L, 5L, 10L, 10L, 3L, 6L, 10L, 2L, 8L, 6L, 5L, 4L, 9L, 5L, 3L, 10L]) == 5L);\n    assert(candidate([1L]) == 1L);\n    assert(candidate([8L, 8L, 10L, 6L, 4L, 3L, 5L, 8L, 2L, 4L, 2L, 8L, 4L, 6L, 10L, 4L, 2L, 1L, 10L, 2L, 1L, 1L, 5L]) == 4L);\n    assert(candidate([2L, 10L, 4L, 8L, 2L, 10L, 5L, 1L, 2L, 9L, 5L, 5L, 6L, 3L, 8L, 6L, 4L, 10L]) == 2L);\n    assert(candidate([1L, 6L, 10L, 1L, 6L, 9L, 10L, 8L, 6L, 8L, 7L, 3L]) == 1L);\n    assert(candidate([9L, 2L, 4L, 1L, 5L, 1L, 5L, 2L, 5L, 7L, 7L, 7L, 3L, 10L, 1L, 5L, 4L, 2L, 8L, 4L, 1L, 9L, 10L, 7L, 10L, 2L, 8L, 10L, 9L, 4L]) == 4L);\n    assert(candidate([2L, 6L, 4L, 2L, 8L, 7L, 5L, 6L, 4L, 10L, 4L, 6L, 3L, 7L, 8L, 8L, 3L, 1L, 4L, 2L, 2L, 10L, 7L]) == 4L);\n    assert(candidate([9L, 8L, 6L, 10L, 2L, 6L, 10L, 2L, 7L, 8L, 10L, 3L, 8L, 2L, 6L, 2L, 3L, 1L]) == 2L);\n    assert(candidate([5L, 5L, 3L, 9L, 5L, 6L, 3L, 2L, 8L, 5L, 6L, 10L, 10L, 6L, 8L, 4L, 10L, 7L, 7L, 10L, 8L]) == -1L);\n    assert(candidate([10L]) == -1L);\n    assert(candidate([9L, 7L, 7L, 2L, 4L, 7L, 2L, 10L, 9L, 7L, 5L, 7L, 2L]) == 2L);\n    assert(candidate([5L, 4L, 10L, 2L, 1L, 1L, 10L, 3L, 6L, 1L, 8L]) == 1L);\n    assert(candidate([7L, 9L, 9L, 9L, 3L, 4L, 1L, 5L, 9L, 1L, 2L, 1L, 1L, 10L, 7L, 5L, 6L, 7L, 6L, 7L, 7L, 6L]) == 1L);\n    assert(candidate([3L, 10L, 10L, 9L, 2L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2L, 3L, 1L, 3L]\n    \n*/\nlong[] parse_nested_parens(string paren_string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = parse_nested_parens;\n\n    assert(candidate(\"(()()) ((())) () ((())()())\") == [2L, 3L, 1L, 3L]);\n    assert(candidate(\"() (()) ((())) (((())))\") == [1L, 2L, 3L, 4L]);\n    assert(candidate(\"(()(())((())))\") == [4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1L, 2L, 3L, 4L])\n    [1L, 4L, 2L, 3L]\n    >>> strange_sort_list([5L, 5L, 5L, 5L])\n    [5L, 5L, 5L, 5L]\n    >>> strange_sort_list([])\n    []\n    \n*/\nlong[] strange_sort_list(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = strange_sort_list;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 4L, 2L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L]) == [5L, 9L, 6L, 8L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 5L, 2L, 4L, 3L]);\n    assert(candidate([5L, 6L, 7L, 8L, 9L, 1L]) == [1L, 9L, 5L, 8L, 6L, 7L]);\n    assert(candidate([5L, 5L, 5L, 5L]) == [5L, 5L, 5L, 5L]);\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]) == [1L, 8L, 2L, 7L, 3L, 6L, 4L, 5L]);\n    assert(candidate([0L, 2L, 2L, 2L, 5L, 5L, -5L, -5L]) == [-5L, 5L, -5L, 5L, 0L, 2L, 2L, 2L]);\n    assert(candidate([111111L]) == [111111L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3L, 4L, 5L)\n    6.0\n    >>> triangle_area(1L, 2L, 10L)\n    -1L\n    \n*/\nfloat triangle_area(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n    assert(candidate(3L, 4L, 5L) == 6.0);\n    assert(candidate(1L, 2L, 10L) == -1L);\n    assert(candidate(4L, 8L, 5L) == 8.18);\n    assert(candidate(2L, 2L, 2L) == 1.73);\n    assert(candidate(1L, 2L, 3L) == -1L);\n    assert(candidate(10L, 5L, 7L) == 16.25);\n    assert(candidate(2L, 6L, 3L) == -1L);\n    assert(candidate(1L, 1L, 1L) == 0.43);\n    assert(candidate(2L, 2L, 10L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1L, 2L], 5L)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3L, 2L, 3L], 1L)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3L, 2L, 3L], 9L)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3L], 5L)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \n*/\nbool will_it_fly(long[] q, long w) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = will_it_fly;\n\n    assert(candidate([3L, 2L, 3L], 9L) == true);\n    assert(candidate([1L, 2L], 5L) == false);\n    assert(candidate([3L], 5L) == true);\n    assert(candidate([3L, 2L, 3L], 1L) == false);\n    assert(candidate([1L, 2L, 3L], 6L) == false);\n    assert(candidate([5L], 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L])\n    4L\n    >>> smallest_change([1L, 2L, 3L, 4L, 3L, 2L, 2L])\n    1L\n    >>> smallest_change([1L, 2L, 3L, 2L, 1L])\n    0L\n    \n*/\nlong smallest_change(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = smallest_change;\n\n    assert(candidate([1L, 2L, 3L, 5L, 4L, 7L, 9L, 6L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 3L, 2L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 4L, 4L, 2L]) == 1L);\n    assert(candidate([1L, 2L, 3L, 2L, 1L]) == 0L);\n    assert(candidate([3L, 1L, 1L, 3L]) == 0L);\n    assert(candidate([1L]) == 0L);\n    assert(candidate([0L, 1L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \n*/\nstring[] total_match(string[] lst1, string[] lst2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = total_match;\n\n    assert(candidate([], []) == []);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"]);\n    assert(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"]);\n    assert(candidate([], [\"this\"]) == []);\n    assert(candidate([\"this\"], []) == []);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30L)\n    true\n    30 = 2 * 3 * 5\n    \n*/\nbool is_multiply_prime(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_multiply_prime;\n\n    assert(candidate(5L) == false);\n    assert(candidate(30L) == true);\n    assert(candidate(8L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(125L) == true);\n    assert(candidate(105L) == true);\n    assert(candidate(126L) == false);\n    assert(candidate(729L) == false);\n    assert(candidate(891L) == false);\n    assert(candidate(1001L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYour task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1L, 4L)\n    true\n    >>> is_simple_power(2L, 2L)\n    true\n    >>> is_simple_power(8L, 2L)\n    true\n    >>> is_simple_power(3L, 2L)\n    false\n    >>> is_simple_power(3L, 1L)\n    false\n    >>> is_simple_power(5L, 3L)\n    false\n    \n*/\nbool is_simple_power(long x, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_simple_power;\n\n    assert(candidate(16L, 2L) == true);\n    assert(candidate(143214L, 16L) == false);\n    assert(candidate(4L, 2L) == true);\n    assert(candidate(9L, 3L) == true);\n    assert(candidate(16L, 4L) == true);\n    assert(candidate(24L, 2L) == false);\n    assert(candidate(128L, 4L) == false);\n    assert(candidate(12L, 6L) == false);\n    assert(candidate(1L, 1L) == true);\n    assert(candidate(1L, 12L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1L)\n    true\n    >>> iscube(2L)\n    false\n    >>> iscube(-1L)\n    true\n    >>> iscube(64L)\n    true\n    >>> iscube(0L)\n    true\n    >>> iscube(180L)\n    false\n    \n*/\nbool iscube(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = iscube;\n\n    assert(candidate(1L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(-1L) == true);\n    assert(candidate(64L) == true);\n    assert(candidate(180L) == false);\n    assert(candidate(1000L) == true);\n    assert(candidate(0L) == true);\n    assert(candidate(1729L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1L\n    >>> hex_key(\"1077E\")\n    2L\n    >>> hex_key(\"ABED1A33\")\n    4L\n    >>> hex_key(\"123456789ABCDEF0\")\n    6L\n    >>> hex_key(\"2020\")\n    2L\n    \n*/\nlong hex_key(string num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = hex_key;\n\n    assert(candidate(\"AB\") == 1L);\n    assert(candidate(\"1077E\") == 2L);\n    assert(candidate(\"ABED1A33\") == 4L);\n    assert(candidate(\"2020\") == 2L);\n    assert(candidate(\"123456789ABCDEF0\") == 6L);\n    assert(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15L)\n    \"db1111db\"\n    >>> decimal_to_binary(32L)\n    \"db100000db\"\n    \n*/\nstring decimal_to_binary(long decimal) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(0L) == \"db0db\");\n    assert(candidate(32L) == \"db100000db\");\n    assert(candidate(103L) == \"db1100111db\");\n    assert(candidate(15L) == \"db1111db\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \n*/\nstring[] filter_by_substring(string[] strings, string substring) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_by_substring;\n\n    assert(candidate([], \"john\") == []);\n    assert(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n    assert(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \n*/\nbool is_happy(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_happy;\n\n    assert(candidate(\"a\") == false);\n    assert(candidate(\"aa\") == false);\n    assert(candidate(\"abcd\") == true);\n    assert(candidate(\"aabb\") == false);\n    assert(candidate(\"adb\") == true);\n    assert(candidate(\"xyy\") == false);\n    assert(candidate(\"iopaxpoi\") == true);\n    assert(candidate(\"iopaxioi\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nIt is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3L, 1.7, 2L, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \n*/\nstring[] numerical_letter_grade(float[] grades) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = numerical_letter_grade;\n\n    assert(candidate([4.0, 3L, 1.7, 2L, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n    assert(candidate([1.2]) == [\"D+\"]);\n    assert(candidate([0.5]) == [\"D-\"]);\n    assert(candidate([0.0]) == [\"E\"]);\n    assert(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n    assert(candidate([0.0, 0.7]) == [\"E\", \"D-\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nWrite a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \n*/\nbool prime_length(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_length;\n\n    assert(candidate(\"Hello\") == true);\n    assert(candidate(\"abcdcba\") == true);\n    assert(candidate(\"kittens\") == true);\n    assert(candidate(\"orange\") == false);\n    assert(candidate(\"wow\") == true);\n    assert(candidate(\"world\") == true);\n    assert(candidate(\"MadaM\") == true);\n    assert(candidate(\"Wow\") == true);\n    assert(candidate(\"\") == false);\n    assert(candidate(\"HI\") == true);\n    assert(candidate(\"go\") == true);\n    assert(candidate(\"gogo\") == false);\n    assert(candidate(\"aaaaaaaaaaaaaaa\") == false);\n    assert(candidate(\"Madam\") == true);\n    assert(candidate(\"M\") == false);\n    assert(candidate(\"0\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \n*/\nlong starts_one_ends(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = starts_one_ends;\n\n    assert(candidate(1L) == 1L);\n    assert(candidate(2L) == 18L);\n    assert(candidate(3L) == 180L);\n    assert(candidate(4L) == 1800L);\n    assert(candidate(5L) == 18000L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000L)\n    \"1\"\n    >>> solve(150L)\n    \"110\"\n    >>> solve(147L)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \n*/\nstring solve(long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = solve;\n\n    assert(candidate(1000L) == \"1\");\n    assert(candidate(150L) == \"110\");\n    assert(candidate(147L) == \"1100\");\n    assert(candidate(333L) == \"1001\");\n    assert(candidate(963L) == \"10010\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nGiven a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4L, 2L, 6L, 7L])\n    2L\n    \n*/\nlong add(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add;\n\n    assert(candidate([4L, 88L]) == 88L);\n    assert(candidate([4L, 5L, 6L, 7L, 2L, 122L]) == 122L);\n    assert(candidate([4L, 0L, 6L, 7L]) == 0L);\n    assert(candidate([4L, 4L, 6L, 8L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \n*/\nstring anti_shuffle(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = anti_shuffle;\n\n    assert(candidate(\"Hi\") == \"Hi\");\n    assert(candidate(\"hello\") == \"ehllo\");\n    assert(candidate(\"number\") == \"bemnru\");\n    assert(candidate(\"abcd\") == \"abcd\");\n    assert(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\");\n    assert(candidate(\"\") == \"\");\n    assert(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L)\n    [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]\n    >>> get_row([], 1L)\n    []\n    >>> get_row([[], [1L], [1L, 2L, 3L]], 3L)\n    [tuple(2L, 2L)]\n    \n*/\nTuple!(long, long)[] get_row(long[][] lst, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_row;\n\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 4L), tuple(1L, 0L), tuple(2L, 5L), tuple(2L, 0L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L]], 2L) == [tuple(0L, 1L), tuple(1L, 1L), tuple(2L, 1L), tuple(3L, 1L), tuple(4L, 1L), tuple(5L, 1L)]);\n    assert(candidate([[1L, 2L, 3L, 4L, 5L, 6L], [1L, 2L, 3L, 4L, 5L, 6L], [1L, 1L, 3L, 4L, 5L, 6L], [1L, 2L, 1L, 4L, 5L, 6L], [1L, 2L, 3L, 1L, 5L, 6L], [1L, 2L, 3L, 4L, 1L, 6L], [1L, 2L, 3L, 4L, 5L, 1L]], 1L) == [tuple(0L, 0L), tuple(1L, 0L), tuple(2L, 1L), tuple(2L, 0L), tuple(3L, 2L), tuple(3L, 0L), tuple(4L, 3L), tuple(4L, 0L), tuple(5L, 4L), tuple(5L, 0L), tuple(6L, 5L), tuple(6L, 0L)]);\n    assert(candidate([], 1L) == []);\n    assert(candidate([[1L]], 2L) == []);\n    assert(candidate([[], [1L], [1L, 2L, 3L]], 3L) == [tuple(2L, 2L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5L])\n    [5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L])\n    [0L, 1L, 2L, 3L, 4L, 5L]\n    >>> sort_array([2L, 4L, 3L, 0L, 1L, 5L, 6L])\n    [6L, 5L, 4L, 3L, 2L, 1L, 0L]\n    \n*/\nlong[] sort_array(long[] array) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_array;\n\n    assert(candidate([]) == []);\n    assert(candidate([5L]) == [5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L]) == [0L, 1L, 2L, 3L, 4L, 5L]);\n    assert(candidate([2L, 4L, 3L, 0L, 1L, 5L, 6L]) == [6L, 5L, 4L, 3L, 2L, 1L, 0L]);\n    assert(candidate([2L, 1L]) == [1L, 2L]);\n    assert(candidate([15L, 42L, 87L, 32L, 11L, 0L]) == [0L, 11L, 15L, 32L, 42L, 87L]);\n    assert(candidate([21L, 14L, 23L, 11L]) == [23L, 21L, 14L, 11L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nCreate a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \n*/\nstring encrypt(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encrypt;\n\n    assert(candidate(\"hi\") == \"lm\");\n    assert(candidate(\"asdfghjkl\") == \"ewhjklnop\");\n    assert(candidate(\"gf\") == \"kj\");\n    assert(candidate(\"et\") == \"ix\");\n    assert(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\");\n    assert(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\");\n    assert(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n    assert(candidate(\"a\") == \"e\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    tuple(0L, 1L)\n    >>> sum_product([1L, 2L, 3L, 4L])\n    tuple(10L, 24L)\n    \n*/\nTuple!(long, long) sum_product(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_product;\n\n    assert(candidate([]) == tuple(0L, 1L));\n    assert(candidate([1L, 1L, 1L]) == tuple(3L, 1L));\n    assert(candidate([100L, 0L]) == tuple(100L, 0L));\n    assert(candidate([3L, 5L, 7L]) == tuple(15L, 105L));\n    assert(candidate([10L]) == tuple(10L, 10L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1L, 2L, 3L, 4L, 5L])\n    2L\n    >>> next_smallest([5L, 1L, 4L, 3L, 2L])\n    2L\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1L, 1L])\n    None\n    \n*/\nNullable!(long) next_smallest(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = next_smallest;\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 5L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([5L, 1L, 4L, 3L, 2L]);\n        assert(!result.isNull && result.get == 2L);\n}\n\n{\n        auto result = candidate([]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([1L, 1L, 1L, 1L, 0L]);\n        assert(!result.isNull && result.get == 1L);\n}\n\n{\n        auto result = candidate([1L, 1L]);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate([-35L, 34L, 12L, -45L]);\n        assert(!result.isNull && result.get == -35L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0L\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1L\n    \n*/\nlong is_bored(string S) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_bored;\n\n    assert(candidate(\"Hello world\") == 0L);\n    assert(candidate(\"Is the sky blue?\") == 0L);\n    assert(candidate(\"I love It !\") == 1L);\n    assert(candidate(\"bIt\") == 0L);\n    assert(candidate(\"I feel good today. I will be productive. will kill It\") == 2L);\n    assert(candidate(\"You and I are going for a walk\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5L, 2L, 7L)\n    true\n    \n    >>> any_int(3L, 2L, 2L)\n    false\n\n    >>> any_int(3L, -2L, 1L)\n    true\n    \n    >>> any_int(3.6, -2.2, 2L)\n    false\n  \n\n    \n    \n*/\nbool any_int(float x, float y, float z) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = any_int;\n\n    assert(candidate(2L, 3L, 1L) == true);\n    assert(candidate(2.5, 2L, 3L) == false);\n    assert(candidate(1.5, 5L, 3.5) == false);\n    assert(candidate(2L, 6L, 2L) == false);\n    assert(candidate(4L, 2L, 2L) == true);\n    assert(candidate(2.2, 2.2, 2.2) == false);\n    assert(candidate(-4L, 6L, 2L) == true);\n    assert(candidate(2L, 1L, 1L) == true);\n    assert(candidate(3L, 4L, 7L) == true);\n    assert(candidate(3.0, 4L, 7L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \n*/\nstring encode(string message) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = encode;\n\n    assert(candidate(\"TEST\") == \"tgst\");\n    assert(candidate(\"Mudasir\") == \"mWDCSKR\");\n    assert(candidate(\"YES\") == \"ygs\");\n    assert(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\");\n    assert(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nYou are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L])\n    10L\n    >>> skjkasdkd([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L])\n    25L\n    >>> skjkasdkd([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L])\n    13L\n    >>> skjkasdkd([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L])\n    11L\n    >>> skjkasdkd([0L, 81L, 12L, 3L, 1L, 21L])\n    3L\n    >>> skjkasdkd([0L, 8L, 1L, 2L, 1L, 7L])\n    7L\n    \n*/\nlong skjkasdkd(long[] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = skjkasdkd;\n\n    assert(candidate([0L, 3L, 2L, 1L, 3L, 5L, 7L, 4L, 5L, 5L, 5L, 2L, 181L, 32L, 4L, 32L, 3L, 2L, 32L, 324L, 4L, 3L]) == 10L);\n    assert(candidate([1L, 0L, 1L, 8L, 2L, 4597L, 2L, 1L, 3L, 40L, 1L, 2L, 1L, 2L, 4L, 2L, 5L, 1L]) == 25L);\n    assert(candidate([1L, 3L, 1L, 32L, 5107L, 34L, 83278L, 109L, 163L, 23L, 2323L, 32L, 30L, 1L, 9L, 3L]) == 13L);\n    assert(candidate([0L, 724L, 32L, 71L, 99L, 32L, 6L, 0L, 5L, 91L, 83L, 0L, 5L, 6L]) == 11L);\n    assert(candidate([0L, 81L, 12L, 3L, 1L, 21L]) == 3L);\n    assert(candidate([0L, 8L, 1L, 2L, 1L, 7L]) == 7L);\n    assert(candidate([8191L]) == 19L);\n    assert(candidate([8191L, 123456L, 127L, 7L]) == 19L);\n    assert(candidate([127L, 97L, 8192L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case([\"a\": \"apple\", \"b\": \"banana\"].nullable)\n    true\n    >>> check_dict_case([\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"].nullable)\n    false\n    >>> check_dict_case([\"a\": \"apple\", 8L: \"banana\", \"a\": \"apple\"].nullable)\n    false\n    >>> check_dict_case([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable)\n    false\n    >>> check_dict_case([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable)\n    true\n    \n*/\nbool check_dict_case(Nullable!(string[string]) dict) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_dict_case;\n\n    assert(candidate([\"p\": \"pineapple\", \"b\": \"banana\"].nullable) == true);\n    assert(candidate([\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"].nullable) == false);\n    assert(candidate([\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"].nullable) == false);\n    assert(candidate([\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"].nullable) == false);\n    assert(candidate([\"STATE\": \"NC\", \"ZIP\": \"12345\"].nullable) == true);\n    assert(candidate([\"fruit\": \"Orange\", \"taste\": \"Sweet\"].nullable) == true);\n    assert(candidate(Nullable!(string[string]).init) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nImplement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5L)\n    [2L, 3L]\n    >>> count_up_to(11L)\n    [2L, 3L, 5L, 7L]\n    >>> count_up_to(0L)\n    []\n    >>> count_up_to(20L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]\n    >>> count_up_to(1L)\n    []\n    >>> count_up_to(18L)\n    [2L, 3L, 5L, 7L, 11L, 13L, 17L]\n    \n*/\nlong[] count_up_to(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_up_to;\n\n    assert(candidate(5L) == [2L, 3L]);\n    assert(candidate(6L) == [2L, 3L, 5L]);\n    assert(candidate(7L) == [2L, 3L, 5L]);\n    assert(candidate(10L) == [2L, 3L, 5L, 7L]);\n    assert(candidate(0L) == []);\n    assert(candidate(22L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L]);\n    assert(candidate(1L) == []);\n    assert(candidate(18L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L]);\n    assert(candidate(47L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L]);\n    assert(candidate(101L) == [2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L, 29L, 31L, 37L, 41L, 43L, 47L, 53L, 59L, 61L, 67L, 71L, 73L, 79L, 83L, 89L, 97L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\nComplete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148L, 412L)\n    16L\n    >>> multiply(19L, 28L)\n    72L\n    >>> multiply(2020L, 1851L)\n    0L\n    >>> multiply(14L, -15L)\n    20L\n    \n*/\nlong multiply(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = multiply;\n\n    assert(candidate(148L, 412L) == 16L);\n    assert(candidate(19L, 28L) == 72L);\n    assert(candidate(2020L, 1851L) == 0L);\n    assert(candidate(14L, -15L) == 20L);\n    assert(candidate(76L, 67L) == 42L);\n    assert(candidate(17L, 27L) == 49L);\n    assert(candidate(0L, 1L) == 0L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1L\n    >>> count_upper(\"abcdefg\")\n    0L\n    >>> count_upper(\"dBBE\")\n    0L\n    \n*/\nlong count_upper(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_upper;\n\n    assert(candidate(\"aBCdEf\") == 1L);\n    assert(candidate(\"abcdefg\") == 0L);\n    assert(candidate(\"dBBE\") == 0L);\n    assert(candidate(\"B\") == 0L);\n    assert(candidate(\"U\") == 1L);\n    assert(candidate(\"\") == 0L);\n    assert(candidate(\"EEEE\") == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10L\n    >>> closest_integer(\"15.3\")\n    15L\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \n*/\nlong closest_integer(string value) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = closest_integer;\n\n    assert(candidate(\"10\") == 10L);\n    assert(candidate(\"14.5\") == 15L);\n    assert(candidate(\"-15.5\") == -16L);\n    assert(candidate(\"15.3\") == 15L);\n    assert(candidate(\"0\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1L, 2L, 3L, 2L, 3L, 4L, 2L])\n    [1L, 2L, 3L, 3L, 3L, 4L, 4L]\n    \n*/\nlong[] rolling_max(long[] numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rolling_max;\n\n    assert(candidate([]) == []);\n    assert(candidate([1L, 2L, 3L, 4L]) == [1L, 2L, 3L, 4L]);\n    assert(candidate([4L, 3L, 2L, 1L]) == [4L, 4L, 4L, 4L]);\n    assert(candidate([3L, 2L, 3L, 100L, 3L]) == [3L, 3L, 3L, 100L, 100L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/humaneval-go-keep.json
+++ b/prompts/humaneval-go-keep.json
@@ -1,1132 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "go_test.go",
-    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunc iscube(a int) bool {\n",
+    "prompt": "package has_close_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunc has_close_elements(numbers []float64, threshold float64) bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "go_test.go",
-    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunc encode(message string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "go_test.go",
-    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "go_test.go",
-    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunc solution(lst []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "go_test.go",
-    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "go_test.go",
-    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunc string_sequence(n int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "go_test.go",
-    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunc minSubArraySum(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "go_test.go",
-    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "go_test.go",
-    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "go_test.go",
-    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "go_test.go",
-    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunc below_threshold(l []int, t int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "go_test.go",
-    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunc any_int(x float64, y float64, z float64) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "go_test.go",
-    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunc x_or_y(n int, x int, y int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "go_test.go",
-    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "go_test.go",
-    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunc triples_sum_to_zero(l []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "go_test.go",
-    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "go_test.go",
-    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunc is_happy(s string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "go_test.go",
-    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunc file_name_check(file_name string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "go_test.go",
-    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunc histogram(test string) map[string]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "go_test.go",
-    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "go_test.go",
-    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunc simplify(x string, n string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "go_test.go",
-    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "go_test.go",
-    "prompt": "package reverse_delete_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunc reverse_delete(s string, c string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReverse_Delete(t *testing.T) {\n  candidate := reverse_delete\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\", \"ae\"), expected: []interface{}{\"bcd\", false} },\n     { actual: candidate(\"abcdef\", \"b\"), expected: []interface{}{\"acdef\", false} },\n     { actual: candidate(\"abcdedcba\", \"ab\"), expected: []interface{}{\"cdedc\", true} },\n     { actual: candidate(\"dwik\", \"w\"), expected: []interface{}{\"dik\", false} },\n     { actual: candidate(\"a\", \"a\"), expected: []interface{}{\"\", true} },\n     { actual: candidate(\"abcdedcba\", \"\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"abcdedcba\", \"v\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"vabba\", \"v\"), expected: []interface{}{\"abba\", true} },\n     { actual: candidate(\"mamma\", \"mia\"), expected: []interface{}{\"\", true} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "go_test.go",
-    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunc sum_product(numbers []int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "go_test.go",
-    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunc skjkasdkd(lst []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "go_test.go",
-    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunc all_prefixes(myString string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "go_test.go",
-    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunc digits(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "go_test.go",
-    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunc strlen(myString string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "go_test.go",
-    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "go_test.go",
-    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "go_test.go",
-    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "go_test.go",
-    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "go_test.go",
-    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunc monotonic(l []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "go_test.go",
-    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "go_test.go",
-    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "go_test.go",
-    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunc cycpattern_check(a string, b string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "go_test.go",
-    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "go_test.go",
-    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "go_test.go",
-    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string string) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "go_test.go",
-    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunc remove_vowels(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "go_test.go",
-    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "go_test.go",
-    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "go_test.go",
-    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunc count_up_to(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "go_test.go",
-    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunc max_element(l []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "go_test.go",
-    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst []string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "go_test.go",
-    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "go_test.go",
-    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "go_test.go",
-    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "go_test.go",
-    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunc unique(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "go_test.go",
-    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunc smallest_change(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "go_test.go",
-    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunc unique_digits(x []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "go_test.go",
-    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunc f(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "go_test.go",
-    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunc minPath(grid [][]int, k int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "go_test.go",
-    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunc match_parens(lst []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "go_test.go",
-    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunc is_equal_to_sum_even(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "go_test.go",
-    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "go_test.go",
-    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "go_test.go",
-    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunc encrypt(s string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "go_test.go",
-    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "go_test.go",
-    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "go_test.go",
-    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunc intersperse(numbers []int, delimeter int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunc solve(s string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "go_test.go",
-    "prompt": "package sort_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunc sort_even(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Even(t *testing.T) {\n  candidate := sort_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{1, 2, 3} },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), expected: []int{-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123} },\n     { actual: candidate([]int{5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), expected: []int{-12, 8, 3, 4, 5, 2, 12, 11, 23, -10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "go_test.go",
-    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunc below_zero(operations []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "go_test.go",
-    "prompt": "package same_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunc same_chars(s0 string, s1 string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSame_Chars(t *testing.T) {\n  candidate := same_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"), expected: true },\n     { actual: candidate(\"abcd\", \"dddddddabc\"), expected: true },\n     { actual: candidate(\"dddddddabc\", \"abcd\"), expected: true },\n     { actual: candidate(\"eabcd\", \"dddddddabc\"), expected: false },\n     { actual: candidate(\"abcd\", \"dddddddabcf\"), expected: false },\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"), expected: false },\n     { actual: candidate(\"aabb\", \"aaccc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "go_test.go",
-    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunc separate_paren_groups(paren_string string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "go_test.go",
-    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunc count_upper(s string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "go_test.go",
-    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "go_test.go",
-    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunc remove_duplicates(numbers []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "go_test.go",
-    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunc select_words(s string, n int) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "go_test.go",
-    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunc find_max(words []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "go_test.go",
-    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunc sum_squares(lst []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunc add(lst []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "go_test.go",
-    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunc multiply(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "go_test.go",
-    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "go_test.go",
-    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunc tri(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "go_test.go",
-    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunc is_simple_power(x int, n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHas_Close_Elements(t *testing.T) {\n  candidate := has_close_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1138,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package make_a_pile_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunc make_a_pile(n int) []int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestMake_A_Pile(t *testing.T) {\n  candidate := make_a_pile\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{3, 5, 7} },\n     { actual: candidate(4), expected: []int{4, 6, 8, 10} },\n     { actual: candidate(5), expected: []int{5, 7, 9, 11, 13} },\n     { actual: candidate(6), expected: []int{6, 8, 10, 12, 14, 16} },\n     { actual: candidate(8), expected: []int{8, 10, 12, 14, 16, 18, 20, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1148,951 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
+    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s string) []string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "go_test.go",
-    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "go_test.go",
-    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunc is_palindrome(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "go_test.go",
-    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "go_test.go",
-    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunc factorize(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "go_test.go",
-    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "go_test.go",
-    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunc get_closest_vowel(word string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "go_test.go",
-    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "go_test.go",
-    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunc sort_numbers(numbers string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "go_test.go",
-    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunc flip_case(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "go_test.go",
-    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunc common(l1 []int, l2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "go_test.go",
-    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunc can_arrange(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "go_test.go",
-    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunc is_nested(myString string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "go_test.go",
-    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunc by_length(arr []int) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "go_test.go",
-    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "go_test.go",
-    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "go_test.go",
-    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst []string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "go_test.go",
-    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunc concatenate(strings []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunc sum_squares(lst []float64) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "go_test.go",
-    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunc sort_array(arr []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 2, 3, 4}), expected: []int{1, 2, 4, 3, 5} },\n     { actual: candidate([]int{-2, -3, -4, -5, -6}), expected: []int{-4, -2, -6, -5, -3} },\n     { actual: candidate([]int{1, 0, 2, 3, 4}), expected: []int{0, 1, 2, 4, 3} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), expected: []int{2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77} },\n     { actual: candidate([]int{3, 6, 44, 12, 32, 5}), expected: []int{32, 3, 5, 6, 12, 44} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "go_test.go",
-    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunc is_sorted(lst []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "go_test.go",
-    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunc even_odd_count(num int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "go_test.go",
-    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunc derivative(xs []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "go_test.go",
-    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunc anti_shuffle(s string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "go_test.go",
-    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "go_test.go",
-    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunc make_palindrome(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "go_test.go",
-    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "go_test.go",
-    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunc change_base(x int, base int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "go_test.go",
-    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunc prime_length(myString string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "go_test.go",
-    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunc numerical_letter_grade(grades []float64) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "go_test.go",
-    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunc search(lst []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "go_test.go",
-    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "go_test.go",
-    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "go_test.go",
-    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "go_test.go",
-    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string string) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "go_test.go",
-    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunc compare(game []int, guess []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "go_test.go",
-    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "go_test.go",
-    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "go_test.go",
-    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "go_test.go",
-    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunc is_prime(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "go_test.go",
-    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "go_test.go",
-    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunc hex_key(num string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "go_test.go",
-    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunc median(l []int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "go_test.go",
-    "prompt": "package specialFilter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunc specialFilter(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSpecialfilter(t *testing.T) {\n  candidate := specialFilter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, -2, 1, -5}), expected: 0 },\n     { actual: candidate([]int{15, -73, 14, -15}), expected: 1 },\n     { actual: candidate([]int{33, -2, -3, 45, 21, 109}), expected: 2 },\n     { actual: candidate([]int{43, -12, 93, 125, 121, 109}), expected: 4 },\n     { actual: candidate([]int{71, -2, -33, 75, 21, 19}), expected: 3 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "go_test.go",
-    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunc pairs_sum_to_zero(l []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "go_test.go",
-    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunc strange_sort_list(lst []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "go_test.go",
-    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "go_test.go",
-    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunc check_dict_case(dict map[string]string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "go_test.go",
-    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunc valid_date(date string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "go_test.go",
-    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunc count_nums(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "go_test.go",
-    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunc filter_integers(values []interface{}) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "go_test.go",
-    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunc digitSum(s string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "go_test.go",
-    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunc order_by_points(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "go_test.go",
-    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "go_test.go",
-    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunc string_xor(a string, b string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "go_test.go",
-    "prompt": "package has_close_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunc has_close_elements(numbers []float64, threshold float64) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHas_Close_Elements(t *testing.T) {\n  candidate := has_close_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "go_test.go",
-    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunc fruit_distribution(s string, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "go_test.go",
-    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "go_test.go",
-    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunc int_to_mini_roman(number int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "go_test.go",
-    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunc correct_bracketing(brackets string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "go_test.go",
-    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunc correct_bracketing(brackets string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"<>\"), expected: true },\n     { actual: candidate(\"<<><>>\"), expected: true },\n     { actual: candidate(\"<><><<><>><>\"), expected: true },\n     { actual: candidate(\"<><><<<><><>><>><<><><<>>>\"), expected: true },\n     { actual: candidate(\"<<<><>>>>\"), expected: false },\n     { actual: candidate(\"><<>\"), expected: false },\n     { actual: candidate(\"<\"), expected: false },\n     { actual: candidate(\"<<<<\"), expected: false },\n     { actual: candidate(\">\"), expected: false },\n     { actual: candidate(\"<<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>><<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>>><>\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "go_test.go",
-    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "go_test.go",
-    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunc filter_by_substring(strings []string, substring string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "go_test.go",
-    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "go_test.go",
-    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2104,7 +46,7 @@
     "language": "go_test.go",
     "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// choose_num(12, 15) = 14\n// choose_num(13, 12) = -1\nfunc choose_num(x int, y int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2114,13 +56,839 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_104_unique_digits",
     "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
+    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunc unique_digits(x []int) []int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "go_test.go",
+    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunc by_length(arr []int) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "go_test.go",
+    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunc f(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "go_test.go",
+    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "go_test.go",
+    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunc count_nums(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "go_test.go",
+    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "go_test.go",
+    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunc make_palindrome(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "go_test.go",
+    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "go_test.go",
+    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunc histogram(test string) map[string]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "go_test.go",
+    "prompt": "package reverse_delete_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunc reverse_delete(s string, c string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReverse_Delete(t *testing.T) {\n  candidate := reverse_delete\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\", \"ae\"), expected: []interface{}{\"bcd\", false} },\n     { actual: candidate(\"abcdef\", \"b\"), expected: []interface{}{\"acdef\", false} },\n     { actual: candidate(\"abcdedcba\", \"ab\"), expected: []interface{}{\"cdedc\", true} },\n     { actual: candidate(\"dwik\", \"w\"), expected: []interface{}{\"dik\", false} },\n     { actual: candidate(\"a\", \"a\"), expected: []interface{}{\"\", true} },\n     { actual: candidate(\"abcdedcba\", \"\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"abcdedcba\", \"v\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"vabba\", \"v\"), expected: []interface{}{\"abba\", true} },\n     { actual: candidate(\"mamma\", \"mia\"), expected: []interface{}{\"\", true} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "go_test.go",
+    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst []string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "go_test.go",
+    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunc minSubArraySum(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "go_test.go",
+    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "go_test.go",
+    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunc sort_array(arr []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 2, 3, 4}), expected: []int{1, 2, 4, 3, 5} },\n     { actual: candidate([]int{-2, -3, -4, -5, -6}), expected: []int{-4, -2, -6, -5, -3} },\n     { actual: candidate([]int{1, 0, 2, 3, 4}), expected: []int{0, 1, 2, 4, 3} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), expected: []int{2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77} },\n     { actual: candidate([]int{3, 6, 44, 12, 32, 5}), expected: []int{32, 3, 5, 6, 12, 44} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "go_test.go",
+    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunc select_words(s string, n int) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "go_test.go",
+    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunc get_closest_vowel(word string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "go_test.go",
+    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunc match_parens(lst []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "go_test.go",
+    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunc string_xor(a string, b string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "go_test.go",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "go_test.go",
+    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunc solution(lst []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "go_test.go",
+    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "go_test.go",
+    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "go_test.go",
+    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunc valid_date(date string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "go_test.go",
+    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunc is_sorted(lst []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "go_test.go",
+    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "go_test.go",
+    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunc minPath(grid [][]int, k int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "go_test.go",
+    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunc tri(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "go_test.go",
+    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunc digits(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "go_test.go",
+    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunc is_nested(myString string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunc sum_squares(lst []float64) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "go_test.go",
+    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "go_test.go",
+    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunc can_arrange(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "go_test.go",
+    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "go_test.go",
+    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunc is_equal_to_sum_even(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "go_test.go",
+    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "go_test.go",
+    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "go_test.go",
+    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "go_test.go",
+    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunc file_name_check(file_name string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunc sum_squares(lst []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "go_test.go",
+    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "go_test.go",
+    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunc simplify(x string, n string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "go_test.go",
+    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunc order_by_points(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "go_test.go",
+    "prompt": "package specialFilter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunc specialFilter(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSpecialfilter(t *testing.T) {\n  candidate := specialFilter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, -2, 1, -5}), expected: 0 },\n     { actual: candidate([]int{15, -73, 14, -15}), expected: 1 },\n     { actual: candidate([]int{33, -2, -3, 45, 21, 109}), expected: 2 },\n     { actual: candidate([]int{43, -12, 93, 125, 121, 109}), expected: 4 },\n     { actual: candidate([]int{71, -2, -33, 75, 21, 19}), expected: 3 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "go_test.go",
+    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "go_test.go",
+    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "go_test.go",
+    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst []string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "go_test.go",
+    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunc all_prefixes(myString string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "go_test.go",
+    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunc x_or_y(n int, x int, y int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "go_test.go",
+    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "go_test.go",
+    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunc compare(game []int, guess []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "go_test.go",
+    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "go_test.go",
+    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunc cycpattern_check(a string, b string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "go_test.go",
+    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunc even_odd_count(num int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "go_test.go",
+    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunc int_to_mini_roman(number int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "go_test.go",
+    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "go_test.go",
+    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunc find_max(words []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "go_test.go",
+    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "go_test.go",
+    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunc string_sequence(n int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "go_test.go",
+    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunc solve(s string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2132,7 +900,7 @@
     "language": "go_test.go",
     "prompt": "package generate_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// generate_integers(2, 8) => [2, 4, 6, 8]\n// generate_integers(8, 2) => [2, 4, 6, 8]\n// generate_integers(10, 14) => []\nfunc generate_integers(a int, b int) []int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestGenerate_Integers(t *testing.T) {\n  candidate := generate_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 10), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(10, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(132, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(17, 89), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2146,9 +914,1241 @@
     "language": "go_test.go",
     "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters('xyzXYZ')\n// 3\n// >>> count_distinct_characters('Jerry')\n// 4\nfunc count_distinct_characters(myString string) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "go_test.go",
+    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string string) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "go_test.go",
+    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "go_test.go",
+    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunc sort_numbers(numbers string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "go_test.go",
+    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunc separate_paren_groups(paren_string string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "go_test.go",
+    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "go_test.go",
+    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "go_test.go",
+    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunc filter_integers(values []interface{}) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "go_test.go",
+    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunc strlen(myString string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "go_test.go",
+    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "go_test.go",
+    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunc factorize(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "go_test.go",
+    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunc remove_duplicates(numbers []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "go_test.go",
+    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunc flip_case(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "go_test.go",
+    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunc concatenate(strings []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "go_test.go",
+    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "go_test.go",
+    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "go_test.go",
+    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "go_test.go",
+    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunc is_prime(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "go_test.go",
+    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "go_test.go",
+    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunc unique(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "go_test.go",
+    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunc max_element(l []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "go_test.go",
+    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "go_test.go",
+    "prompt": "package sort_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunc sort_even(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Even(t *testing.T) {\n  candidate := sort_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{1, 2, 3} },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), expected: []int{-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123} },\n     { actual: candidate([]int{5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), expected: []int{-12, 8, 3, 4, 5, 2, 12, 11, 23, -10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "go_test.go",
+    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "go_test.go",
+    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunc below_zero(operations []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunc triples_sum_to_zero(l []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "go_test.go",
+    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "go_test.go",
+    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunc pairs_sum_to_zero(l []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "go_test.go",
+    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunc change_base(x int, base int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "go_test.go",
+    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "go_test.go",
+    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunc median(l []int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "go_test.go",
+    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunc is_palindrome(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "go_test.go",
+    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "go_test.go",
+    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "go_test.go",
+    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunc remove_vowels(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "go_test.go",
+    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunc below_threshold(l []int, t int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "go_test.go",
+    "prompt": "package same_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunc same_chars(s0 string, s1 string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSame_Chars(t *testing.T) {\n  candidate := same_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"), expected: true },\n     { actual: candidate(\"abcd\", \"dddddddabc\"), expected: true },\n     { actual: candidate(\"dddddddabc\", \"abcd\"), expected: true },\n     { actual: candidate(\"eabcd\", \"dddddddabc\"), expected: false },\n     { actual: candidate(\"abcd\", \"dddddddabcf\"), expected: false },\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"), expected: false },\n     { actual: candidate(\"aabb\", \"aaccc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "go_test.go",
+    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "go_test.go",
+    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunc correct_bracketing(brackets string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"<>\"), expected: true },\n     { actual: candidate(\"<<><>>\"), expected: true },\n     { actual: candidate(\"<><><<><>><>\"), expected: true },\n     { actual: candidate(\"<><><<<><><>><>><<><><<>>>\"), expected: true },\n     { actual: candidate(\"<<<><>>>>\"), expected: false },\n     { actual: candidate(\"><<>\"), expected: false },\n     { actual: candidate(\"<\"), expected: false },\n     { actual: candidate(\"<<<<\"), expected: false },\n     { actual: candidate(\">\"), expected: false },\n     { actual: candidate(\"<<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>><<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>>><>\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "go_test.go",
+    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunc monotonic(l []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "go_test.go",
+    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunc common(l1 []int, l2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "go_test.go",
+    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "go_test.go",
+    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "go_test.go",
+    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "go_test.go",
+    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunc correct_bracketing(brackets string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "go_test.go",
+    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunc derivative(xs []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "go_test.go",
+    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "go_test.go",
+    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "go_test.go",
+    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "go_test.go",
+    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunc digitSum(s string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "go_test.go",
+    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunc fruit_distribution(s string, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "go_test.go",
+    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "go_test.go",
+    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunc search(lst []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "go_test.go",
+    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "go_test.go",
+    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunc strange_sort_list(lst []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "go_test.go",
+    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "go_test.go",
+    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunc smallest_change(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "go_test.go",
+    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "go_test.go",
+    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "go_test.go",
+    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunc is_simple_power(x int, n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "go_test.go",
+    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunc iscube(a int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "go_test.go",
+    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunc hex_key(num string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "go_test.go",
+    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "go_test.go",
+    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunc is_happy(s string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "go_test.go",
+    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "go_test.go",
+    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunc prime_length(myString string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "go_test.go",
+    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunc add(lst []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "go_test.go",
+    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunc anti_shuffle(s string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "go_test.go",
+    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "go_test.go",
+    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "go_test.go",
+    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunc encrypt(s string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "go_test.go",
+    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunc sum_product(numbers []int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "go_test.go",
+    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "go_test.go",
+    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunc any_int(x float64, y float64, z float64) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "go_test.go",
+    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunc encode(message string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "go_test.go",
+    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunc skjkasdkd(lst []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "go_test.go",
+    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunc check_dict_case(dict map[string]string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "go_test.go",
+    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunc count_up_to(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "go_test.go",
+    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunc multiply(a int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "go_test.go",
+    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunc count_upper(s string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "go_test.go",
+    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "go_test.go",
+    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/humaneval-go-remove.json
+++ b/prompts/humaneval-go-remove.json
@@ -1,1552 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "go_test.go",
-    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\nfunc strlen(myString string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "go_test.go",
-    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunc encrypt(s string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "go_test.go",
-    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunc check_dict_case(dict map[string]string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunc add(lst []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "go_test.go",
-    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunc fix_spaces(text string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "go_test.go",
-    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunc fibfib(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "go_test.go",
-    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "go_test.go",
-    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\nfunc filter_integers(values []interface{}) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "go_test.go",
-    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunc parse_music(music_string string) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunc decimal_to_binary(decimal int) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "go_test.go",
-    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\nfunc all_prefixes(myString string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\nfunc add(x int, y int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "go_test.go",
-    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "go_test.go",
-    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "go_test.go",
-    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunc flip_case(myString string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "go_test.go",
-    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunc by_length(arr []int) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "go_test.go",
-    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunc factorize(n int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "go_test.go",
-    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunc count_up_to(n int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "go_test.go",
-    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\nfunc unique(l []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "go_test.go",
-    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "go_test.go",
-    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\nfunc max_element(l []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "go_test.go",
-    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunc is_nested(myString string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "go_test.go",
-    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunc odd_count(lst []string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "go_test.go",
-    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "go_test.go",
-    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "go_test.go",
-    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunc is_equal_to_sum_even(n int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "go_test.go",
-    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunc derivative(xs []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "go_test.go",
-    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunc is_sorted(lst []int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunc solve(s string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "go_test.go",
-    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunc tri(n int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "go_test.go",
-    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunc fizz_buzz(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "go_test.go",
-    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "go_test.go",
-    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunc minPath(grid [][]int, k int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "go_test.go",
-    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunc count_upper(s string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "go_test.go",
-    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\nfunc largest_divisor(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "go_test.go",
-    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunc sort_array(array []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "go_test.go",
-    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunc f(n int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "go_test.go",
-    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunc iscube(a int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "go_test.go",
-    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunc encode(message string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "go_test.go",
-    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunc is_bored(S string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunc pairs_sum_to_zero(l []int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunc triangle_area(a int, b int, c int) float64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "go_test.go",
-    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "go_test.go",
-    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunc digits(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "go_test.go",
-    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunc words_string(s string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "go_test.go",
-    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunc how_many_times(myString string, substring string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "go_test.go",
-    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\nfunc remove_vowels(text string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "go_test.go",
-    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunc strange_sort_list(lst []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "go_test.go",
-    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "go_test.go",
-    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunc is_simple_power(x int, n int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "go_test.go",
-    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunc prime_fib(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "go_test.go",
-    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunc order_by_points(nums []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "go_test.go",
     "prompt": "package has_close_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\nfunc has_close_elements(numbers []float64, threshold float64) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestHas_Close_Elements(t *testing.T) {\n  candidate := has_close_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "go_test.go",
-    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunc make_palindrome(myString string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "go_test.go",
-    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunc string_xor(a string, b string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "go_test.go",
-    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "go_test.go",
-    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "go_test.go",
-    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunc fib4(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "go_test.go",
-    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunc unique_digits(x []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "go_test.go",
-    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunc select_words(s string, n int) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "go_test.go",
-    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "go_test.go",
-    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\nfunc fib(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "go_test.go",
-    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "go_test.go",
-    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunc match_parens(lst []string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "go_test.go",
-    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunc any_int(x float64, y float64, z float64) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "go_test.go",
-    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunc truncate_number(number float64) float64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "go_test.go",
-    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\nfunc incr_list(l []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "go_test.go",
-    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunc x_or_y(n int, x int, y int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "go_test.go",
-    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\nfunc modp(n int, p int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "go_test.go",
-    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunc even_odd_count(num int) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "go_test.go",
-    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunc is_happy(s string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "go_test.go",
-    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunc largest_prime_factor(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "go_test.go",
-    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunc digitSum(s string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "go_test.go",
-    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "go_test.go",
-    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunc solution(lst []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "go_test.go",
-    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "go_test.go",
-    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "go_test.go",
-    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "go_test.go",
-    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\nfunc median(l []int) float64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "go_test.go",
-    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunc prime_length(myString string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "go_test.go",
-    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunc smallest_change(arr []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunc sum_squares(lst []float64) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "go_test.go",
-    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunc file_name_check(file_name string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunc triples_sum_to_zero(l []int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "go_test.go",
-    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "go_test.go",
-    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunc separate_paren_groups(paren_string string) []string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "go_test.go",
-    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunc compare(game []int, guess []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "go_test.go",
-    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "go_test.go",
-    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunc valid_date(date string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "go_test.go",
-    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunc count_nums(arr []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "go_test.go",
-    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunc anti_shuffle(s string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "go_test.go",
-    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\nfunc is_palindrome(text string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "go_test.go",
-    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunc get_closest_vowel(word string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "go_test.go",
-    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\nfunc is_prime(n int) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "go_test.go",
-    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunc simplify(x string, n string) bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "go_test.go",
-    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunc hex_key(num string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "go_test.go",
-    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "go_test.go",
-    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunc histogram(test string) map[string]int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "go_test.go",
-    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "go_test.go",
-    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "go_test.go",
-    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunc can_arrange(arr []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "go_test.go",
-    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunc sort_numbers(numbers string) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "go_test.go",
-    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunc circular_shift(x int, shift int) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunc sum_squares(lst []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "go_test.go",
-    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunc skjkasdkd(lst []int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "go_test.go",
-    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunc sum_product(numbers []int) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "go_test.go",
-    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunc choose_num(x int, y int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "go_test.go",
-    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "go_test.go",
-    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunc count_distinct_characters(myString string) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1558,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package make_a_pile_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\nfunc make_a_pile(n int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestMake_A_Pile(t *testing.T) {\n  candidate := make_a_pile\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{3, 5, 7} },\n     { actual: candidate(4), expected: []int{4, 6, 8, 10} },\n     { actual: candidate(5), expected: []int{5, 7, 9, 11, 13} },\n     { actual: candidate(6), expected: []int{6, 8, 10, 12, 14, 16} },\n     { actual: candidate(8), expected: []int{8, 10, 12, 14, 16, 18, 20, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1568,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_101_words_string",
     "language": "go_test.go",
-    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunc minSubArraySum(nums []int) int {\n",
+    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunc words_string(s string) []string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1582,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_102_choose_num",
     "language": "go_test.go",
-    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunc string_sequence(n int) string {\n",
+    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunc choose_num(x int, y int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1596,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "go_test.go",
-    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunc cycpattern_check(a string, b string) bool {\n",
+    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunc unique_digits(x []int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1610,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "go_test.go",
-    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\nfunc monotonic(l []int) bool {\n",
+    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunc by_length(arr []int) []string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1624,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_106_f",
     "language": "go_test.go",
-    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\nfunc below_threshold(l []int, t int) bool {\n",
+    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunc f(n int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1638,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "go_test.go",
-    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1652,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_108_count_nums",
     "language": "go_test.go",
-    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\nfunc get_positive(l []int) []int {\n",
+    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunc count_nums(arr []int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1666,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_109_move_one_ball",
     "language": "go_test.go",
-    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunc sort_third(l []int) []int {\n",
+    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1680,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_10_make_palindrome",
     "language": "go_test.go",
-    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunc make_palindrome(myString string) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1694,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_110_exchange",
     "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\nfunc triangle_area(a int, h int) float64 {\n",
+    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1708,69 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_97_multiply",
+    "name": "HumanEval_111_histogram",
     "language": "go_test.go",
-    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunc multiply(a int, b int) int {\n",
+    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunc histogram(test string) map[string]int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "go_test.go",
-    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "go_test.go",
-    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\nfunc common(l1 []int, l2 []int) []int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "go_test.go",
-    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunc int_to_mini_roman(number int) string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "go_test.go",
-    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunc fruit_distribution(s string, n int) int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1782,7 +186,7 @@
     "language": "go_test.go",
     "prompt": "package reverse_delete_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\nfunc reverse_delete(s string, c string) []interface{} {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestReverse_Delete(t *testing.T) {\n  candidate := reverse_delete\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\", \"ae\"), expected: []interface{}{\"bcd\", false} },\n     { actual: candidate(\"abcdef\", \"b\"), expected: []interface{}{\"acdef\", false} },\n     { actual: candidate(\"abcdedcba\", \"ab\"), expected: []interface{}{\"cdedc\", true} },\n     { actual: candidate(\"dwik\", \"w\"), expected: []interface{}{\"dik\", false} },\n     { actual: candidate(\"a\", \"a\"), expected: []interface{}{\"\", true} },\n     { actual: candidate(\"abcdedcba\", \"\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"abcdedcba\", \"v\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"vabba\", \"v\"), expected: []interface{}{\"abba\", true} },\n     { actual: candidate(\"mamma\", \"mia\"), expected: []interface{}{\"\", true} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1792,13 +196,41 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "go_test.go",
-    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunc odd_count(lst []string) []string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "go_test.go",
+    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunc minSubArraySum(nums []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "go_test.go",
+    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1810,7 +242,7 @@
     "language": "go_test.go",
     "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\nfunc sort_array(arr []int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 2, 3, 4}), expected: []int{1, 2, 4, 3, 5} },\n     { actual: candidate([]int{-2, -3, -4, -5, -6}), expected: []int{-4, -2, -6, -5, -3} },\n     { actual: candidate([]int{1, 0, 2, 3, 4}), expected: []int{0, 1, 2, 4, 3} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), expected: []int{2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77} },\n     { actual: candidate([]int{3, 6, 44, 12, 32, 5}), expected: []int{32, 3, 5, 6, 12, 44} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1820,13 +252,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "go_test.go",
-    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\nfunc concatenate(strings []string) string {\n",
+    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunc select_words(s string, n int) []string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1834,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "go_test.go",
-    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunc sorted_list_sum(lst []string) []string {\n",
+    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunc get_closest_vowel(word string) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1848,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "go_test.go",
-    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunc match_parens(lst []string) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1862,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "go_test.go",
-    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunc string_xor(a string, b string) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1876,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "go_test.go",
-    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunc vowels_count(s string) int {\n",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1890,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "go_test.go",
-    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunc find_max(words []string) string {\n",
+    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunc solution(lst []int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1904,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "go_test.go",
-    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunc change_base(x int, base int) string {\n",
+    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1918,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "go_test.go",
-    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1932,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "go_test.go",
-    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunc valid_date(date string) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1946,13 +378,265 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "go_test.go",
-    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunc is_sorted(lst []int) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "go_test.go",
+    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "go_test.go",
+    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunc minPath(grid [][]int, k int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "go_test.go",
+    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunc tri(n int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "go_test.go",
+    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunc digits(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "go_test.go",
+    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunc is_nested(myString string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunc sum_squares(lst []float64) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "go_test.go",
+    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "go_test.go",
+    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunc can_arrange(arr []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "go_test.go",
+    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "go_test.go",
+    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunc is_equal_to_sum_even(n int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "go_test.go",
+    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "go_test.go",
+    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "go_test.go",
+    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunc fix_spaces(text string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "go_test.go",
+    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunc file_name_check(file_name string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunc sum_squares(lst []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "go_test.go",
+    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "go_test.go",
+    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunc simplify(x string, n string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "go_test.go",
+    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunc order_by_points(nums []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1964,7 +648,7 @@
     "language": "go_test.go",
     "prompt": "package specialFilter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\nfunc specialFilter(nums []int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSpecialfilter(t *testing.T) {\n  candidate := specialFilter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, -2, 1, -5}), expected: 0 },\n     { actual: candidate([]int{15, -73, 14, -15}), expected: 1 },\n     { actual: candidate([]int{33, -2, -3, 45, 21, 109}), expected: 2 },\n     { actual: candidate([]int{43, -12, 93, 125, 121, 109}), expected: 4 },\n     { actual: candidate([]int{71, -2, -33, 75, 21, 19}), expected: 3 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1974,13 +658,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "go_test.go",
-    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\nfunc sum_to_n(n int) int {\n",
+    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1988,13 +672,209 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "go_test.go",
-    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunc remove_duplicates(numbers []int) []int {\n",
+    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "go_test.go",
+    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunc sorted_list_sum(lst []string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "go_test.go",
+    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\nfunc all_prefixes(myString string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "go_test.go",
+    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunc x_or_y(n int, x int, y int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "go_test.go",
+    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "go_test.go",
+    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunc compare(game []int, guess []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "go_test.go",
+    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "go_test.go",
+    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunc cycpattern_check(a string, b string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "go_test.go",
+    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunc even_odd_count(num int) []interface{} {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "go_test.go",
+    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunc int_to_mini_roman(number int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "go_test.go",
+    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "go_test.go",
+    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunc find_max(words []string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "go_test.go",
+    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "go_test.go",
+    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunc string_sequence(n int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunc solve(s string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2006,7 +886,7 @@
     "language": "go_test.go",
     "prompt": "package generate_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\nfunc generate_integers(a int, b int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestGenerate_Integers(t *testing.T) {\n  candidate := generate_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 10), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(10, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(132, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(17, 89), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2016,13 +896,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "go_test.go",
-    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunc rolling_max(numbers []int) []int {\n",
+    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunc count_distinct_characters(myString string) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2030,13 +910,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "go_test.go",
-    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunc below_zero(operations []int) bool {\n",
+    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunc parse_music(music_string string) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2044,13 +924,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "go_test.go",
-    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunc search(lst []int) int {\n",
+    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunc how_many_times(myString string, substring string) int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2058,13 +938,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "go_test.go",
-    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets string) bool {\n",
+    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunc sort_numbers(numbers string) string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "go_test.go",
+    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunc separate_paren_groups(paren_string string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "go_test.go",
+    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "go_test.go",
+    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "go_test.go",
+    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\nfunc filter_integers(values []interface{}) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "go_test.go",
+    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\nfunc strlen(myString string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "go_test.go",
+    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\nfunc largest_divisor(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "go_test.go",
+    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunc factorize(n int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "go_test.go",
+    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunc remove_duplicates(numbers []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "go_test.go",
+    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunc flip_case(myString string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "go_test.go",
+    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\nfunc concatenate(strings []string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "go_test.go",
+    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "go_test.go",
+    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunc truncate_number(number float64) float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "go_test.go",
+    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\nfunc get_positive(l []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "go_test.go",
+    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\nfunc is_prime(n int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "go_test.go",
+    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunc sort_third(l []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "go_test.go",
+    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\nfunc unique(l []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "go_test.go",
+    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\nfunc max_element(l []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "go_test.go",
+    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunc fizz_buzz(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2076,9 +1208,219 @@
     "language": "go_test.go",
     "prompt": "package sort_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\nfunc sort_even(l []int) []int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSort_Even(t *testing.T) {\n  candidate := sort_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{1, 2, 3} },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), expected: []int{-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123} },\n     { actual: candidate([]int{5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), expected: []int{-12, 8, 3, 4, 5, 2, 12, 11, 23, -10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "go_test.go",
+    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunc prime_fib(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "go_test.go",
+    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunc below_zero(operations []int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunc triples_sum_to_zero(l []int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "go_test.go",
+    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\nfunc incr_list(l []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunc pairs_sum_to_zero(l []int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "go_test.go",
+    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunc change_base(x int, base int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\nfunc triangle_area(a int, h int) float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "go_test.go",
+    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunc fib4(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "go_test.go",
+    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\nfunc median(l []int) float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "go_test.go",
+    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\nfunc is_palindrome(text string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "go_test.go",
+    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\nfunc modp(n int, p int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "go_test.go",
+    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "go_test.go",
+    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\nfunc remove_vowels(text string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "go_test.go",
+    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\nfunc below_threshold(l []int, t int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\nfunc add(x int, y int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2090,9 +1432,23 @@
     "language": "go_test.go",
     "prompt": "package same_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if two words have the same characters.\nfunc same_chars(s0 string, s1 string) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSame_Chars(t *testing.T) {\n  candidate := same_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"), expected: true },\n     { actual: candidate(\"abcd\", \"dddddddabc\"), expected: true },\n     { actual: candidate(\"dddddddabc\", \"abcd\"), expected: true },\n     { actual: candidate(\"eabcd\", \"dddddddabc\"), expected: false },\n     { actual: candidate(\"abcd\", \"dddddddabcf\"), expected: false },\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"), expected: false },\n     { actual: candidate(\"aabb\", \"aaccc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "go_test.go",
+    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\nfunc fib(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2104,9 +1460,653 @@
     "language": "go_test.go",
     "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets string) bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"<>\"), expected: true },\n     { actual: candidate(\"<<><>>\"), expected: true },\n     { actual: candidate(\"<><><<><>><>\"), expected: true },\n     { actual: candidate(\"<><><<<><><>><>><<><><<>>>\"), expected: true },\n     { actual: candidate(\"<<<><>>>>\"), expected: false },\n     { actual: candidate(\"><<>\"), expected: false },\n     { actual: candidate(\"<\"), expected: false },\n     { actual: candidate(\"<<<<\"), expected: false },\n     { actual: candidate(\">\"), expected: false },\n     { actual: candidate(\"<<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>><<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>>><>\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "go_test.go",
+    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\nfunc monotonic(l []int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "go_test.go",
+    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\nfunc common(l1 []int, l2 []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "go_test.go",
+    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunc largest_prime_factor(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "go_test.go",
+    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "go_test.go",
+    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\nfunc sum_to_n(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "go_test.go",
+    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "go_test.go",
+    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunc derivative(xs []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "go_test.go",
+    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunc fibfib(n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "go_test.go",
+    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunc vowels_count(s string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "go_test.go",
+    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunc circular_shift(x int, shift int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "go_test.go",
+    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunc digitSum(s string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "go_test.go",
+    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunc fruit_distribution(s string, n int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "go_test.go",
+    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "go_test.go",
+    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunc search(lst []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "go_test.go",
+    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "go_test.go",
+    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunc strange_sort_list(lst []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunc triangle_area(a int, b int, c int) float64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "go_test.go",
+    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "go_test.go",
+    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunc smallest_change(arr []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "go_test.go",
+    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "go_test.go",
+    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "go_test.go",
+    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunc is_simple_power(x int, n int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "go_test.go",
+    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunc iscube(a int) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "go_test.go",
+    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunc hex_key(num string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunc decimal_to_binary(decimal int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "go_test.go",
+    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "go_test.go",
+    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunc is_happy(s string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "go_test.go",
+    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "go_test.go",
+    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunc prime_length(myString string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunc add(lst []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "go_test.go",
+    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunc anti_shuffle(s string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "go_test.go",
+    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "go_test.go",
+    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunc sort_array(array []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "go_test.go",
+    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunc encrypt(s string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "go_test.go",
+    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunc sum_product(numbers []int) []interface{} {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "go_test.go",
+    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunc is_bored(S string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "go_test.go",
+    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunc any_int(x float64, y float64, z float64) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "go_test.go",
+    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunc encode(message string) string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "go_test.go",
+    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunc skjkasdkd(lst []int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "go_test.go",
+    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunc check_dict_case(dict map[string]string) bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "go_test.go",
+    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunc count_up_to(n int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "go_test.go",
+    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunc multiply(a int, b int) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "go_test.go",
+    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunc count_upper(s string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "go_test.go",
+    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "go_test.go",
+    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunc rolling_max(numbers []int) []int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/humaneval-go-reworded.json
+++ b/prompts/humaneval-go-reworded.json
@@ -1,1594 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "go_test.go",
-    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunc strlen(myString string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "go_test.go",
-    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunc encrypt(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "go_test.go",
-    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a map, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given map is empty.\n// Examples:\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case(map[interface{}]string{\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunc check_dict_case(dict map[string]string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([]int{4, 2, 6, 7})\n// 2\nfunc add(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "go_test.go",
-    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "go_test.go",
-    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "go_test.go",
-    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([]int{1, 3, 2, 0})\n// 10\n// >>> double_the_difference([]int{-1, -2, 0})\n// 0\n// >>> double_the_difference([]int{9, -2})\n// 81\n// >>> double_the_difference([]int{0})\n// 0\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "go_test.go",
-    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any gothon values only for integers\n// >>> filter_integers([]float64{\"a\", 3.14, 5})\n// []int{5}\n// >>> filter_integers([]interface{}{1, 2, 3, \"abc\", map[interface{}]interface{}{}, []interface{}{}})\n// []int{1, 2, 3}\nfunc filter_integers(values []interface{}) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "go_test.go",
-    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "go_test.go",
-    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// []int{4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nfunc parse_music(music_string string) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "go_test.go",
-    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// []string{\"a\", \"ab\", \"abc\"}\nfunc all_prefixes(myString string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "go_test.go",
-    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return a list of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// []int{11, 4}\n// >>> eat(4, 8, 9)\n// []int{12, 1}\n// >>> eat(1, 10, 10)\n// []int{11, 0}\n// >>> eat(2, 11, 5)\n// []int{7, 0}\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "go_test.go",
-    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1)\n// 6\n// Example 2:\n// >>> max_fill([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2)\n// 5\n// Example 3:\n// >>> max_fill([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "go_test.go",
-    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// list = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "go_test.go",
-    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunc flip_case(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "go_test.go",
-    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting list, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([]int{2, 1, 1, 4, 5, 8, 2, 3})\n// []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"}\n// If the list is empty, return an empty list:\n// >>> by_length([]int{})\n// []string{}\n// If the list has any strange number ignore it:\n// >>> by_length([]int{1, -1, 55})\n// []string{\"One\"}\nfunc by_length(arr []int) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "go_test.go",
-    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// []int{2, 2, 2}\n// >>> factorize(25)\n// []int{5, 5}\n// >>> factorize(70)\n// []int{2, 5, 7}\nfunc factorize(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "go_test.go",
-    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns a list of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// []int{2, 3}\n// >>> count_up_to(11)\n// []int{2, 3, 5, 7}\n// >>> count_up_to(0)\n// []int{}\n// >>> count_up_to(20)\n// []int{2, 3, 5, 7, 11, 13, 17, 19}\n// >>> count_up_to(1)\n// []int{}\n// >>> count_up_to(18)\n// []int{2, 3, 5, 7, 11, 13, 17}\nfunc count_up_to(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "go_test.go",
-    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{0, 2, 3, 5, 9, 123}\nfunc unique(l []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "go_test.go",
-    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([]string{}, []string{})\n// []string{}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"})\n// []string{\"hI\", \"Hi\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"})\n// []string{\"hi\", \"admin\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"})\n// []string{\"hI\", \"hi\", \"hi\"}\n// >>> total_match([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"})\n// []string{\"4\"}\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "go_test.go",
-    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([]int{1, 2, 3})\n// 3\n// >>> max_element([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// 123\nfunc max_element(l []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "go_test.go",
-    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunc is_nested(myString string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "go_test.go",
-    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([]string{\"1234567\"})\n// []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}\n// >>> odd_count([]string{\"3\", \"11111111\"})\n// []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"}\nfunc odd_count(lst []string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "go_test.go",
-    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the list will be randomly ordered. Your task is to determine if\n// it is possible to get a list sorted in non-decreasing order by performing \n// the following operation on the given list:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the list by one\n// position in the right direction. The last element of the list will be moved to\n// the starting position in the list i.e. 0th index. \n// If it is possible to obtain the sorted list by performing the above operation\n// then return true else return false.\n// If the given list is empty then return true.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([]int{3, 4, 5, 1, 2})\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given list.\n// >>> move_one_ball([]int{3, 5, 4, 1, 2})\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// list by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "go_test.go",
-    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a list that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// []interface{}{1, 2}\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// []interface{}{4, 6}\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned list has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "go_test.go",
-    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunc is_equal_to_sum_even(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "go_test.go",
-    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([]int{3, 1, 2, 4, 5})\n// []int{1, 4, 12, 20}\n// >>> derivative([]int{1, 2, 3})\n// []int{2, 6}\nfunc derivative(xs []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "go_test.go",
-    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([]int{5})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5})\n// false\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6, 7})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5, 6, 7})\n// false\n// >>> is_sorted([]int{1, 2, 2, 3, 3, 4})\n// true\n// >>> is_sorted([]int{1, 2, 2, 2, 3, 4})\n// false\nfunc is_sorted(lst []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunc solve(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "go_test.go",
-    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// []int{1, 3, 2, 8}\nfunc tri(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "go_test.go",
-    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "go_test.go",
-    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([]string{}, \"a\")\n// []string{}\n// >>> filter_by_prefix([]string{\"abc\", \"bcd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"array\"}\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "go_test.go",
-    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3)\n// []int{1, 2, 1}\n// >>> minPath([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1)\n// []int{1}\nfunc minPath(grid [][]int, k int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "go_test.go",
-    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunc count_upper(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([]int{-3, -4, 5}, 3)\n// []int{-4, -3, 5}\n// Example 2:\n// >>> maximum([]int{4, -4, 4}, 2)\n// []int{4, 4}\n// Example 3:\n// >>> maximum([]int{-3, 2, 1, 2, -1, -2, 1}, 1)\n// []int{2}\n// Note:\n// 1. The length of the list will be in the range of [1, 1000].\n// 2. The elements in the list will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "go_test.go",
-    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "go_test.go",
-    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of non-negative integers, return a cogo of the given list after sorting,\n// you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given list.\n// Examples:\n// >>> sort_array([]int{})\n// []int{}\n// >>> sort_array([]int{5})\n// []int{5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5})\n// []int{0, 1, 2, 3, 4, 5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5, 6})\n// []int{6, 5, 4, 3, 2, 1, 0}\nfunc sort_array(array []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "go_test.go",
-    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// []int{1, 2, 6, 24, 15}\nfunc f(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "go_test.go",
-    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunc iscube(a int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "go_test.go",
-    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunc encode(message string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "go_test.go",
-    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns true if there are two distinct elements in the list that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> pairs_sum_to_zero([]int{1, 3, -2, 1})\n// false\n// >>> pairs_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> pairs_sum_to_zero([]int{2, 4, -5, 3, 5, 7})\n// true\n// >>> pairs_sum_to_zero([]int{1})\n// false\nfunc pairs_sum_to_zero(l []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "go_test.go",
-    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a list containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty list if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// []interface{}{\"Saturn\", \"Uranus\"}\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"}\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "go_test.go",
-    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunc digits(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "go_test.go",
-    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return a list of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"}\n// >>> words_string(\"One, two, three, four, five, six\")\n// []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"}\nfunc words_string(s string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "go_test.go",
-    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "go_test.go",
-    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunc remove_vowels(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "go_test.go",
-    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([]int{1, 2, 3, 4})\n// []int{1, 4, 2, 3}\n// >>> strange_sort_list([]int{5, 5, 5, 5})\n// []int{5, 5, 5, 5}\n// >>> strange_sort_list([]int{})\n// []int{}\nfunc strange_sort_list(lst []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "go_test.go",
-    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n// []interface{}{2.0, 2.2}\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n// []interface{}{2.0, 2.0}\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "go_test.go",
-    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunc is_simple_power(x int, n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "go_test.go",
-    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "go_test.go",
-    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([]int{1, 11, -1, -11, -12})\n// []int{-1, -11, 1, -12, 11}\n// >>> order_by_points([]int{})\n// []int{}\nfunc order_by_points(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "go_test.go",
     "prompt": "package has_close_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([]float64{1.0, 2.0, 3.0}, 0.5)\n// false\n// >>> has_close_elements([]float64{1.0, 2.8, 3.0, 4.0, 5.0, 2.0}, 0.3)\n// true\nfunc has_close_elements(numbers []float64, threshold float64) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "func TestHas_Close_Elements(t *testing.T) {\n  candidate := has_close_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "go_test.go",
-    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunc make_palindrome(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "go_test.go",
-    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunc string_xor(a string, b string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "go_test.go",
-    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "go_test.go",
-    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "go_test.go",
-    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "go_test.go",
-    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([]int{15, 33, 1422, 1})\n// []int{1, 15, 33}\n// >>> unique_digits([]int{152, 323, 1422, 10})\n// []int{}\nfunc unique_digits(x []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "go_test.go",
-    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// []string{\"little\"}\n// >>> select_words(\"Mary had a little lamb\", 3)\n// []string{\"Mary\", \"lamb\"}\n// >>> select_words(\"simple white space\", 2)\n// []string{}\n// >>> select_words(\"Hello world\", 4)\n// []string{\"world\"}\n// >>> select_words(\"Uncle sam\", 3)\n// []string{\"Uncle\"}\nfunc select_words(s string, n int) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "go_test.go",
-    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([]int{1, 2}, 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([]int{3, 2, 3}, 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([]int{3, 2, 3}, 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([]int{3}, 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "go_test.go",
-    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "go_test.go",
-    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", []string{\"AA\", \"Be\", \"CC\"})\n// \"my_class.AA\"\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "go_test.go",
-    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([]string{\"()(\", \")\"})\n// \"Yes\"\n// >>> match_parens([]string{\")\", \")\"})\n// \"No\"\nfunc match_parens(lst []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "go_test.go",
-    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunc any_int(x float64, y float64, z float64) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "go_test.go",
-    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "go_test.go",
-    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([]int{1, 2, 3})\n// []int{2, 3, 4}\n// >>> incr_list([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{6, 4, 6, 3, 4, 4, 10, 1, 124}\nfunc incr_list(l []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "go_test.go",
-    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunc x_or_y(n int, x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "go_test.go",
-    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "go_test.go",
-    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a list that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// []interface{}{1, 1}\n// >>> even_odd_count(123)\n// []interface{}{1, 2}\nfunc even_odd_count(num int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "go_test.go",
-    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is hapgo or not.\n// A string is hapgo if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunc is_happy(s string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "go_test.go",
-    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "go_test.go",
-    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunc digitSum(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "go_test.go",
-    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([]float64{1.0, 2.0, 3.0, 4.0, 5.0})\n// []float64{0.0, 0.25, 0.5, 0.75, 1.0}\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "go_test.go",
-    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([]int{5, 8, 7, 1})\n// 12\n// >>> solution([]int{3, 3, 3, 3, 3})\n// 9\n// >>> solution([]int{30, 13, 24, 321})\n// 0\nfunc solution(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "go_test.go",
-    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given a list representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given list is empty, return [].\n// Example 1:\n// >>> pluck([]int{4, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([]int{1, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([]int{})\n// []int{}\n// Example 4:\n// >>> pluck([]int{5, 0, 3, 0, 4, 2})\n// []int{0, 1}\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "go_test.go",
-    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer list a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "go_test.go",
-    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 2, 3, 4})\n// \"YES\"\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 5, 3, 4})\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "go_test.go",
-    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([]int{3, 1, 2, 4, 5})\n// 3\n// >>> median([]int{-10, 4, 6, 1000, 10, 20})\n// 15.0\nfunc median(l []int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "go_test.go",
-    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunc prime_length(myString string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "go_test.go",
-    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list arr of integers, find the minimum number of elements that\n// need to be changed to make the list palindromic. A palindromic list is a list that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([]int{1, 2, 3, 5, 4, 7, 9, 6})\n// 4\n// >>> smallest_change([]int{1, 2, 3, 4, 3, 2, 2})\n// 1\n// >>> smallest_change([]int{1, 2, 3, 2, 1})\n// 0\nfunc smallest_change(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([]float64{1.0, 2.0, 3.0})\n// 14\n// >>> lst([]float64{1.0, 4.0, 9.0})\n// 98\n// >>> lst([]float64{1.0, 3.0, 5.0, 7.0})\n// 84\n// >>> lst([]float64{1.4, 4.2, 0.0})\n// 29\n// >>> lst([]float64{-2.4, 1.0, 1.0})\n// 6\nfunc sum_squares(lst []float64) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "go_test.go",
-    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunc file_name_check(file_name string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns true if there are three distinct elements in the list that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> triples_sum_to_zero([]int{1, 3, -2, 1})\n// true\n// >>> triples_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> triples_sum_to_zero([]int{2, 4, -5, 3, 9, 7})\n// true\n// >>> triples_sum_to_zero([]int{1})\n// false\nfunc triples_sum_to_zero(l []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "go_test.go",
-    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([]interface{}{1, 2}, []interface{}{2, 3})\n// \"NO\"\n// >>> intersection([]interface{}{-1, 1}, []interface{}{0, 4})\n// \"NO\"\n// >>> intersection([]interface{}{-3, -1}, []interface{}{-5, 5})\n// \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "go_test.go",
-    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// []string{\"()\", \"(())\", \"(()())\"}\nfunc separate_paren_groups(paren_string string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "go_test.go",
-    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two lists of scores and guesses of equal length, where each index shows a match. \n// Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2})\n// []int{0, 0, 0, 0, 3, 3}\n// >>> compare([]int{0, 5, 0, 0, 0, 4}, []int{4, 1, 1, 0, 0, -2})\n// []int{4, 4, 1, 0, 0, 6}\nfunc compare(game []int, guess []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "go_test.go",
-    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "go_test.go",
-    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "go_test.go",
-    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunc valid_date(date string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "go_test.go",
-    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes a list of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]int{})\n// 0\n// >>> count_nums([]int{-1, 11, -11})\n// 1\n// >>> count_nums([]int{1, 1, 2})\n// 3\nfunc count_nums(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "go_test.go",
-    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "go_test.go",
-    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunc is_palindrome(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "go_test.go",
-    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunc get_closest_vowel(word string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "go_test.go",
-    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunc is_prime(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "go_test.go",
-    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunc simplify(x string, n string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "go_test.go",
-    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunc hex_key(num string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "go_test.go",
-    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "go_test.go",
-    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a map\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// map[string]int{\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// map[string]int{\"b\": 4}\n// >>> histogram(\"\")\n// map[string]int{}\nfunc histogram(test string) map[string]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "go_test.go",
-    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of lists, [(x1, y1), (x2, y2) ...] such that\n// each list is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1)\n// [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}}\n// >>> get_row([][]int{}, 1)\n// [][]interface{}{}\n// >>> get_row([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3)\n// [][]int{[]interface{}{2, 2}}\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "go_test.go",
-    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// []int{1, 5}\nfunc get_odd_collatz(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "go_test.go",
-    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given list will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([]int{1, 2, 4, 3, 5})\n// 3\n// >>> can_arrange([]int{1, 2, 3})\n// -1\nfunc can_arrange(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "go_test.go",
-    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunc sort_numbers(numbers string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "go_test.go",
-    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// []int{1, 2, 3}\n// >>> lst\n// int{}\n// >>> lst\n// []int{-1, -5, 2, -1, -5}\nfunc sum_squares(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "go_test.go",
-    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n// 10\n// >>> skjkasdkd([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n// 25\n// >>> skjkasdkd([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n// 13\n// >>> skjkasdkd([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n// 11\n// >>> skjkasdkd([]int{0, 81, 12, 3, 1, 21})\n// 3\n// >>> skjkasdkd([]int{0, 8, 1, 2, 1, 7})\n// 7\nfunc skjkasdkd(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "go_test.go",
-    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([]int{})\n// []interface{}{0, 1}\n// >>> sum_product([]int{1, 2, 3, 4})\n// []interface{}{10, 24}\nfunc sum_product(numbers []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "go_test.go",
-    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunc choose_num(x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "go_test.go",
-    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a list (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as nil.\n// Examples:\n// >>> largest_smallest_integers([]int{2, 4, 1, 3, 5, 7})\n// []interface{}{nil, 1}\n// >>> largest_smallest_integers([]int{})\n// []interface{}{nil, nil}\n// >>> largest_smallest_integers([]int{0})\n// []interface{}{nil, nil}\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "go_test.go",
-    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunc count_distinct_characters(myString string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1600,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package make_a_pile_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// []int{3, 5, 7}\nfunc make_a_pile(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "func TestMake_A_Pile(t *testing.T) {\n  candidate := make_a_pile\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{3, 5, 7} },\n     { actual: candidate(4), expected: []int{4, 6, 8, 10} },\n     { actual: candidate(5), expected: []int{5, 7, 9, 11, 13} },\n     { actual: candidate(6), expected: []int{6, 8, 10, 12, 14, 16} },\n     { actual: candidate(8), expected: []int{8, 10, 12, 14, 16, 18, 20, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1610,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_101_words_string",
     "language": "go_test.go",
-    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of integers nums, find the minimum sum of any non-empty sub-list\n// of nums.\n// Example\n// >>> minSubArraySum([]int{2, 3, 4, 1, 2, 4})\n// 1\n// >>> minSubArraySum([]int{-1, -2, -3})\n// -6\nfunc minSubArraySum(nums []int) int {\n",
+    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return a list of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"}\n// >>> words_string(\"One, two, three, four, five, six\")\n// []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"}\nfunc words_string(s string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1624,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_102_choose_num",
     "language": "go_test.go",
-    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunc string_sequence(n int) string {\n",
+    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunc choose_num(x int, y int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1638,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "go_test.go",
-    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunc cycpattern_check(a string, b string) bool {\n",
+    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([]int{15, 33, 1422, 1})\n// []int{1, 15, 33}\n// >>> unique_digits([]int{152, 323, 1422, 10})\n// []int{}\nfunc unique_digits(x []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1652,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "go_test.go",
-    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true is list elements are monotonically increasing or decreasing.\n// >>> monotonic([]int{1, 2, 4, 20})\n// true\n// >>> monotonic([]int{1, 20, 4, 10})\n// false\n// >>> monotonic([]int{4, 1, 0, -10})\n// true\nfunc monotonic(l []int) bool {\n",
+    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting list, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([]int{2, 1, 1, 4, 5, 8, 2, 3})\n// []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"}\n// If the list is empty, return an empty list:\n// >>> by_length([]int{})\n// []string{}\n// If the list has any strange number ignore it:\n// >>> by_length([]int{1, -1, 55})\n// []string{\"One\"}\nfunc by_length(arr []int) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1666,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_106_f",
     "language": "go_test.go",
-    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if all numbers in the list l are below threshold t.\n// >>> below_threshold([]int{1, 2, 4, 10}, 100)\n// true\n// >>> below_threshold([]int{1, 20, 4, 10}, 5)\n// false\nfunc below_threshold(l []int, t int) bool {\n",
+    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// []int{1, 2, 6, 24, 15}\nfunc f(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1680,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "go_test.go",
-    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a list that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// []interface{}{1, 2}\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// []interface{}{4, 6}\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned list has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1694,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_108_count_nums",
     "language": "go_test.go",
-    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([]int{-1, 2, -4, 5, 6})\n// []int{2, 5, 6}\n// >>> get_positive([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// []int{5, 3, 2, 3, 9, 123, 1}\nfunc get_positive(l []int) []int {\n",
+    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes a list of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]int{})\n// 0\n// >>> count_nums([]int{-1, 11, -11})\n// 1\n// >>> count_nums([]int{1, 1, 2})\n// 3\nfunc count_nums(arr []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1708,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_109_move_one_ball",
     "language": "go_test.go",
-    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_third([]int{5, 6, 3, 4, 8, 9, 2})\n// []int{2, 6, 3, 4, 8, 9, 5}\nfunc sort_third(l []int) []int {\n",
+    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the list will be randomly ordered. Your task is to determine if\n// it is possible to get a list sorted in non-decreasing order by performing \n// the following operation on the given list:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the list by one\n// position in the right direction. The last element of the list will be moved to\n// the starting position in the list i.e. 0th index. \n// If it is possible to obtain the sorted list by performing the above operation\n// then return true else return false.\n// If the given list is empty then return true.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([]int{3, 4, 5, 1, 2})\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given list.\n// >>> move_one_ball([]int{3, 5, 4, 1, 2})\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// list by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1722,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_10_make_palindrome",
     "language": "go_test.go",
-    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// []int{2, 3, 1, 3}\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunc make_palindrome(myString string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1736,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_110_exchange",
     "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
+    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 2, 3, 4})\n// \"YES\"\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 5, 3, 4})\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1750,69 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_97_multiply",
+    "name": "HumanEval_111_histogram",
     "language": "go_test.go",
-    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunc multiply(a int, b int) int {\n",
+    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a map\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// map[string]int{\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// map[string]int{\"b\": 4}\n// >>> histogram(\"\")\n// map[string]int{}\nfunc histogram(test string) map[string]int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "go_test.go",
-    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([]float64{1.0, 2.0, 3.0, 4.0})\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "go_test.go",
-    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121})\n// []int{1, 5, 653}\n// >>> common([]int{5, 3, 2, 8}, []int{3, 2})\n// []int{2, 3}\nfunc common(l1 []int, l2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "go_test.go",
-    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunc int_to_mini_roman(number int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "go_test.go",
-    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunc fruit_distribution(s string, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1824,7 +186,7 @@
     "language": "go_test.go",
     "prompt": "package reverse_delete_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a list containing the result string and true/false for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// []interface{}{\"bcd\", false}\n// >>> reverse_delete(\"abcdef\", \"b\")\n// []interface{}{\"acdef\", false}\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// []interface{}{\"cdedc\", true}\nfunc reverse_delete(s string, c string) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "func TestReverse_Delete(t *testing.T) {\n  candidate := reverse_delete\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\", \"ae\"), expected: []interface{}{\"bcd\", false} },\n     { actual: candidate(\"abcdef\", \"b\"), expected: []interface{}{\"acdef\", false} },\n     { actual: candidate(\"abcdedcba\", \"ab\"), expected: []interface{}{\"cdedc\", true} },\n     { actual: candidate(\"dwik\", \"w\"), expected: []interface{}{\"dik\", false} },\n     { actual: candidate(\"a\", \"a\"), expected: []interface{}{\"\", true} },\n     { actual: candidate(\"abcdedcba\", \"\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"abcdedcba\", \"v\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"vabba\", \"v\"), expected: []interface{}{\"abba\", true} },\n     { actual: candidate(\"mamma\", \"mia\"), expected: []interface{}{\"\", true} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1834,13 +196,41 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "go_test.go",
-    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([]string{\"1234567\"})\n// []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}\n// >>> odd_count([]string{\"3\", \"11111111\"})\n// []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"}\nfunc odd_count(lst []string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "go_test.go",
+    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of integers nums, find the minimum sum of any non-empty sub-list\n// of nums.\n// Example\n// >>> minSubArraySum([]int{2, 3, 4, 1, 2, 4})\n// 1\n// >>> minSubArraySum([]int{-1, -2, -3})\n// -6\nfunc minSubArraySum(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "go_test.go",
+    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1)\n// 6\n// Example 2:\n// >>> max_fill([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2)\n// 5\n// Example 3:\n// >>> max_fill([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1852,7 +242,7 @@
     "language": "go_test.go",
     "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this Kata, you have to sort a list of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([]int{1, 5, 2, 3, 4})\n// []int{1, 2, 3, 4, 5}\n// >>> sort_array([]int{-2, -3, -4, -5, -6})\n// []int{-6, -5, -4, -3, -2}\n// >>> sort_array([]int{1, 0, 2, 3, 4})\n// []int{0, 1, 2, 3, 4}\nfunc sort_array(arr []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 2, 3, 4}), expected: []int{1, 2, 4, 3, 5} },\n     { actual: candidate([]int{-2, -3, -4, -5, -6}), expected: []int{-4, -2, -6, -5, -3} },\n     { actual: candidate([]int{1, 0, 2, 3, 4}), expected: []int{0, 1, 2, 4, 3} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), expected: []int{2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77} },\n     { actual: candidate([]int{3, 6, 44, 12, 32, 5}), expected: []int{32, 3, 5, 6, 12, 44} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1862,13 +252,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "go_test.go",
-    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([]string{})\n// \"\"\n// >>> concatenate([]string{\"a\", \"b\", \"c\"})\n// \"abc\"\nfunc concatenate(strings []string) string {\n",
+    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// []string{\"little\"}\n// >>> select_words(\"Mary had a little lamb\", 3)\n// []string{\"Mary\", \"lamb\"}\n// >>> select_words(\"simple white space\", 2)\n// []string{}\n// >>> select_words(\"Hello world\", 4)\n// []string{\"world\"}\n// >>> select_words(\"Uncle sam\", 3)\n// []string{\"Uncle\"}\nfunc select_words(s string, n int) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1876,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "go_test.go",
-    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never a list of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([]string{\"aa\", \"a\", \"aaa\"})\n// []string{\"aa\"}\n// >>> list_sort([]string{\"ab\", \"a\", \"aaa\", \"cd\"})\n// []string{\"ab\", \"cd\"}\nfunc sorted_list_sum(lst []string) []string {\n",
+    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunc get_closest_vowel(word string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1890,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "go_test.go",
-    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([]string{}, \"a\")\n// []string{}\n// >>> filter_by_substring([]string{\"abc\", \"bacd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"bacd\", \"array\"}\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([]string{\"()(\", \")\"})\n// \"Yes\"\n// >>> match_parens([]string{\")\", \")\"})\n// \"No\"\nfunc match_parens(lst []string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1904,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "go_test.go",
-    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunc string_xor(a string, b string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1918,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "go_test.go",
-    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([]int{-3, -4, 5}, 3)\n// []int{-4, -3, 5}\n// Example 2:\n// >>> maximum([]int{4, -4, 4}, 2)\n// []int{4, 4}\n// Example 3:\n// >>> maximum([]int{-3, 2, 1, 2, -1, -2, 1}, 1)\n// []int{2}\n// Note:\n// 1. The length of the list will be in the range of [1, 1000].\n// 2. The elements in the list will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1932,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "go_test.go",
-    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([]string{\"name\", \"of\", \"string\"})\n// \"string\"\n// >>> find_max([]string{\"name\", \"enam\", \"game\"})\n// \"enam\"\n// >>> find_max([]string{\"aaaaaaa\", \"bb\", \"cc\"})\n// \"aaaaaaa\"\nfunc find_max(words []string) string {\n",
+    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([]int{5, 8, 7, 1})\n// 12\n// >>> solution([]int{3, 3, 3, 3, 3})\n// 9\n// >>> solution([]int{30, 13, 24, 321})\n// 0\nfunc solution(lst []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1946,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "go_test.go",
-    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunc change_base(x int, base int) string {\n",
+    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1960,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "go_test.go",
-    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// []int{1, 5}\nfunc get_odd_collatz(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1974,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "go_test.go",
-    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([]float64{4.0, 3, 1.7, 2, 3.5})\n// []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"}\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunc valid_date(date string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1988,13 +378,265 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "go_test.go",
-    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([]int{}, 4)\n// []int{}\n// >>> intersperse([]int{1, 2, 3}, 4)\n// []int{1, 4, 2, 4, 3}\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([]int{5})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5})\n// false\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6, 7})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5, 6, 7})\n// false\n// >>> is_sorted([]int{1, 2, 2, 3, 3, 4})\n// true\n// >>> is_sorted([]int{1, 2, 2, 2, 3, 4})\n// false\nfunc is_sorted(lst []int) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "go_test.go",
+    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([]interface{}{1, 2}, []interface{}{2, 3})\n// \"NO\"\n// >>> intersection([]interface{}{-1, 1}, []interface{}{0, 4})\n// \"NO\"\n// >>> intersection([]interface{}{-3, -1}, []interface{}{-5, 5})\n// \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "go_test.go",
+    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3)\n// []int{1, 2, 1}\n// >>> minPath([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1)\n// []int{1}\nfunc minPath(grid [][]int, k int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "go_test.go",
+    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// []int{1, 3, 2, 8}\nfunc tri(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "go_test.go",
+    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunc digits(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "go_test.go",
+    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunc is_nested(myString string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([]float64{1.0, 2.0, 3.0})\n// 14\n// >>> lst([]float64{1.0, 4.0, 9.0})\n// 98\n// >>> lst([]float64{1.0, 3.0, 5.0, 7.0})\n// 84\n// >>> lst([]float64{1.4, 4.2, 0.0})\n// 29\n// >>> lst([]float64{-2.4, 1.0, 1.0})\n// 6\nfunc sum_squares(lst []float64) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "go_test.go",
+    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "go_test.go",
+    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given list will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([]int{1, 2, 4, 3, 5})\n// 3\n// >>> can_arrange([]int{1, 2, 3})\n// -1\nfunc can_arrange(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "go_test.go",
+    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a list (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as nil.\n// Examples:\n// >>> largest_smallest_integers([]int{2, 4, 1, 3, 5, 7})\n// []interface{}{nil, 1}\n// >>> largest_smallest_integers([]int{})\n// []interface{}{nil, nil}\n// >>> largest_smallest_integers([]int{0})\n// []interface{}{nil, nil}\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "go_test.go",
+    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunc is_equal_to_sum_even(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "go_test.go",
+    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "go_test.go",
+    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "go_test.go",
+    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "go_test.go",
+    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunc file_name_check(file_name string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// []int{1, 2, 3}\n// >>> lst\n// int{}\n// >>> lst\n// []int{-1, -5, 2, -1, -5}\nfunc sum_squares(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "go_test.go",
+    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "go_test.go",
+    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunc simplify(x string, n string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "go_test.go",
+    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([]int{1, 11, -1, -11, -12})\n// []int{-1, -11, 1, -12, 11}\n// >>> order_by_points([]int{})\n// []int{}\nfunc order_by_points(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2006,7 +648,7 @@
     "language": "go_test.go",
     "prompt": "package specialFilter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a list of numbers as input and returns \n// the number of elements in the list that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([]int{15, -73, 14, -15})\n// 1\n// >>> specialFilter([]int{33, -2, -3, 45, 21, 109})\n// 2\nfunc specialFilter(nums []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSpecialfilter(t *testing.T) {\n  candidate := specialFilter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, -2, 1, -5}), expected: 0 },\n     { actual: candidate([]int{15, -73, 14, -15}), expected: 1 },\n     { actual: candidate([]int{33, -2, -3, 45, 21, 109}), expected: 2 },\n     { actual: candidate([]int{43, -12, 93, 125, 121, 109}), expected: 4 },\n     { actual: candidate([]int{71, -2, -33, 75, 21, 19}), expected: 3 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2016,13 +658,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "go_test.go",
-    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
+    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer list a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2030,13 +672,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "go_test.go",
-    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([]int{1, 2, 3, 2, 4})\n// []int{1, 3, 4}\nfunc remove_duplicates(numbers []int) []int {\n",
+    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a list containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty list if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// []interface{}{\"Saturn\", \"Uranus\"}\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"}\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "go_test.go",
+    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never a list of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([]string{\"aa\", \"a\", \"aaa\"})\n// []string{\"aa\"}\n// >>> list_sort([]string{\"ab\", \"a\", \"aaa\", \"cd\"})\n// []string{\"ab\", \"cd\"}\nfunc sorted_list_sum(lst []string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "go_test.go",
+    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// []string{\"a\", \"ab\", \"abc\"}\nfunc all_prefixes(myString string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "go_test.go",
+    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunc x_or_y(n int, x int, y int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "go_test.go",
+    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([]int{1, 3, 2, 0})\n// 10\n// >>> double_the_difference([]int{-1, -2, 0})\n// 0\n// >>> double_the_difference([]int{9, -2})\n// 81\n// >>> double_the_difference([]int{0})\n// 0\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "go_test.go",
+    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two lists of scores and guesses of equal length, where each index shows a match. \n// Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2})\n// []int{0, 0, 0, 0, 3, 3}\n// >>> compare([]int{0, 5, 0, 0, 0, 4}, []int{4, 1, 1, 0, 0, -2})\n// []int{4, 4, 1, 0, 0, 6}\nfunc compare(game []int, guess []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "go_test.go",
+    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", []string{\"AA\", \"Be\", \"CC\"})\n// \"my_class.AA\"\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "go_test.go",
+    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunc cycpattern_check(a string, b string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "go_test.go",
+    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a list that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// []interface{}{1, 1}\n// >>> even_odd_count(123)\n// []interface{}{1, 2}\nfunc even_odd_count(num int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "go_test.go",
+    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunc int_to_mini_roman(number int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "go_test.go",
+    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "go_test.go",
+    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([]string{\"name\", \"of\", \"string\"})\n// \"string\"\n// >>> find_max([]string{\"name\", \"enam\", \"game\"})\n// \"enam\"\n// >>> find_max([]string{\"aaaaaaa\", \"bb\", \"cc\"})\n// \"aaaaaaa\"\nfunc find_max(words []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "go_test.go",
+    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return a list of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// []int{11, 4}\n// >>> eat(4, 8, 9)\n// []int{12, 1}\n// >>> eat(1, 10, 10)\n// []int{11, 0}\n// >>> eat(2, 11, 5)\n// []int{7, 0}\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "go_test.go",
+    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunc string_sequence(n int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "go_test.go",
+    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// list = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunc solve(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2048,7 +900,7 @@
     "language": "go_test.go",
     "prompt": "package generate_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// []int{2, 4, 6, 8}\n// >>> generate_integers(8, 2)\n// []int{2, 4, 6, 8}\n// >>> generate_integers(10, 14)\n// []int{}\nfunc generate_integers(a int, b int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "func TestGenerate_Integers(t *testing.T) {\n  candidate := generate_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 10), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(10, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(132, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(17, 89), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2058,13 +910,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "go_test.go",
-    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([]int{1, 2, 3, 2, 3, 4, 2})\n// []int{1, 2, 3, 3, 3, 4, 4}\nfunc rolling_max(numbers []int) []int {\n",
+    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunc count_distinct_characters(myString string) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2072,13 +924,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "go_test.go",
-    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([]int{1, 2, 3})\n// false\n// >>> below_zero([]int{1, 2, -4, 5})\n// true\nfunc below_zero(operations []int) bool {\n",
+    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// []int{4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nfunc parse_music(music_string string) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2086,13 +938,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "go_test.go",
-    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([]int{4, 1, 2, 2, 3, 1})\n// 2\n// >>> search([]int{1, 2, 2, 3, 3, 3, 4, 4, 4})\n// 3\n// >>> search([]int{5, 5, 4, 4, 4})\n// -1\nfunc search(lst []int) int {\n",
+    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2100,13 +952,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "go_test.go",
-    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
+    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunc sort_numbers(numbers string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "go_test.go",
+    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// []string{\"()\", \"(())\", \"(()())\"}\nfunc separate_paren_groups(paren_string string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "go_test.go",
+    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n// []interface{}{2.0, 2.2}\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n// []interface{}{2.0, 2.0}\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "go_test.go",
+    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([]float64{1.0, 2.0, 3.0, 4.0, 5.0})\n// []float64{0.0, 0.25, 0.5, 0.75, 1.0}\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "go_test.go",
+    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any gothon values only for integers\n// >>> filter_integers([]float64{\"a\", 3.14, 5})\n// []int{5}\n// >>> filter_integers([]interface{}{1, 2, 3, \"abc\", map[interface{}]interface{}{}, []interface{}{}})\n// []int{1, 2, 3}\nfunc filter_integers(values []interface{}) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "go_test.go",
+    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunc strlen(myString string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "go_test.go",
+    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "go_test.go",
+    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// []int{2, 2, 2}\n// >>> factorize(25)\n// []int{5, 5}\n// >>> factorize(70)\n// []int{2, 5, 7}\nfunc factorize(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "go_test.go",
+    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([]int{1, 2, 3, 2, 4})\n// []int{1, 3, 4}\nfunc remove_duplicates(numbers []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "go_test.go",
+    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunc flip_case(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "go_test.go",
+    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([]string{})\n// \"\"\n// >>> concatenate([]string{\"a\", \"b\", \"c\"})\n// \"abc\"\nfunc concatenate(strings []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "go_test.go",
+    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([]string{}, \"a\")\n// []string{}\n// >>> filter_by_prefix([]string{\"abc\", \"bcd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"array\"}\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "go_test.go",
+    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "go_test.go",
+    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([]int{-1, 2, -4, 5, 6})\n// []int{2, 5, 6}\n// >>> get_positive([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// []int{5, 3, 2, 3, 9, 123, 1}\nfunc get_positive(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "go_test.go",
+    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunc is_prime(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "go_test.go",
+    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_third([]int{5, 6, 3, 4, 8, 9, 2})\n// []int{2, 6, 3, 4, 8, 9, 5}\nfunc sort_third(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "go_test.go",
+    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{0, 2, 3, 5, 9, 123}\nfunc unique(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "go_test.go",
+    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([]int{1, 2, 3})\n// 3\n// >>> max_element([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// 123\nfunc max_element(l []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "go_test.go",
+    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2118,9 +1222,233 @@
     "language": "go_test.go",
     "prompt": "package sort_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_even([]int{5, 6, 3, 4})\n// []int{3, 6, 5, 4}\nfunc sort_even(l []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSort_Even(t *testing.T) {\n  candidate := sort_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{1, 2, 3} },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), expected: []int{-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123} },\n     { actual: candidate([]int{5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), expected: []int{-12, 8, 3, 4, 5, 2, 12, 11, 23, -10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "go_test.go",
+    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "go_test.go",
+    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([]int{1, 2, 3})\n// false\n// >>> below_zero([]int{1, 2, -4, 5})\n// true\nfunc below_zero(operations []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns true if there are three distinct elements in the list that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> triples_sum_to_zero([]int{1, 3, -2, 1})\n// true\n// >>> triples_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> triples_sum_to_zero([]int{2, 4, -5, 3, 9, 7})\n// true\n// >>> triples_sum_to_zero([]int{1})\n// false\nfunc triples_sum_to_zero(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "go_test.go",
+    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "go_test.go",
+    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([]int{1, 2, 3})\n// []int{2, 3, 4}\n// >>> incr_list([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{6, 4, 6, 3, 4, 4, 10, 1, 124}\nfunc incr_list(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns true if there are two distinct elements in the list that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> pairs_sum_to_zero([]int{1, 3, -2, 1})\n// false\n// >>> pairs_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> pairs_sum_to_zero([]int{2, 4, -5, 3, 5, 7})\n// true\n// >>> pairs_sum_to_zero([]int{1})\n// false\nfunc pairs_sum_to_zero(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "go_test.go",
+    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunc change_base(x int, base int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "go_test.go",
+    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "go_test.go",
+    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([]int{3, 1, 2, 4, 5})\n// 3\n// >>> median([]int{-10, 4, 6, 1000, 10, 20})\n// 15.0\nfunc median(l []int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "go_test.go",
+    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunc is_palindrome(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "go_test.go",
+    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "go_test.go",
+    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([]float64{1.0, 2.0, 3.0, 4.0})\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "go_test.go",
+    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunc remove_vowels(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "go_test.go",
+    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if all numbers in the list l are below threshold t.\n// >>> below_threshold([]int{1, 2, 4, 10}, 100)\n// true\n// >>> below_threshold([]int{1, 20, 4, 10}, 5)\n// false\nfunc below_threshold(l []int, t int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2132,9 +1460,23 @@
     "language": "go_test.go",
     "prompt": "package same_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunc same_chars(s0 string, s1 string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSame_Chars(t *testing.T) {\n  candidate := same_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"), expected: true },\n     { actual: candidate(\"abcd\", \"dddddddabc\"), expected: true },\n     { actual: candidate(\"dddddddabc\", \"abcd\"), expected: true },\n     { actual: candidate(\"eabcd\", \"dddddddabc\"), expected: false },\n     { actual: candidate(\"abcd\", \"dddddddabcf\"), expected: false },\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"), expected: false },\n     { actual: candidate(\"aabb\", \"aaccc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "go_test.go",
+    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2146,9 +1488,667 @@
     "language": "go_test.go",
     "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"<\" and \">\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"<>\"), expected: true },\n     { actual: candidate(\"<<><>>\"), expected: true },\n     { actual: candidate(\"<><><<><>><>\"), expected: true },\n     { actual: candidate(\"<><><<<><><>><>><<><><<>>>\"), expected: true },\n     { actual: candidate(\"<<<><>>>>\"), expected: false },\n     { actual: candidate(\"><<>\"), expected: false },\n     { actual: candidate(\"<\"), expected: false },\n     { actual: candidate(\"<<<<\"), expected: false },\n     { actual: candidate(\">\"), expected: false },\n     { actual: candidate(\"<<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>><<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>>><>\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "go_test.go",
+    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true is list elements are monotonically increasing or decreasing.\n// >>> monotonic([]int{1, 2, 4, 20})\n// true\n// >>> monotonic([]int{1, 20, 4, 10})\n// false\n// >>> monotonic([]int{4, 1, 0, -10})\n// true\nfunc monotonic(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "go_test.go",
+    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121})\n// []int{1, 5, 653}\n// >>> common([]int{5, 3, 2, 8}, []int{3, 2})\n// []int{2, 3}\nfunc common(l1 []int, l2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "go_test.go",
+    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "go_test.go",
+    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([]int{}, 4)\n// []int{}\n// >>> intersperse([]int{1, 2, 3}, 4)\n// []int{1, 4, 2, 4, 3}\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "go_test.go",
+    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "go_test.go",
+    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "go_test.go",
+    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([]int{3, 1, 2, 4, 5})\n// []int{1, 4, 12, 20}\n// >>> derivative([]int{1, 2, 3})\n// []int{2, 6}\nfunc derivative(xs []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "go_test.go",
+    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "go_test.go",
+    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "go_test.go",
+    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "go_test.go",
+    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunc digitSum(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "go_test.go",
+    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunc fruit_distribution(s string, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "go_test.go",
+    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given a list representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given list is empty, return [].\n// Example 1:\n// >>> pluck([]int{4, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([]int{1, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([]int{})\n// []int{}\n// Example 4:\n// >>> pluck([]int{5, 0, 3, 0, 4, 2})\n// []int{0, 1}\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "go_test.go",
+    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([]int{4, 1, 2, 2, 3, 1})\n// 2\n// >>> search([]int{1, 2, 2, 3, 3, 3, 4, 4, 4})\n// 3\n// >>> search([]int{5, 5, 4, 4, 4})\n// -1\nfunc search(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "go_test.go",
+    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// []int{2, 3, 1, 3}\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "go_test.go",
+    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([]int{1, 2, 3, 4})\n// []int{1, 4, 2, 3}\n// >>> strange_sort_list([]int{5, 5, 5, 5})\n// []int{5, 5, 5, 5}\n// >>> strange_sort_list([]int{})\n// []int{}\nfunc strange_sort_list(lst []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "go_test.go",
+    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([]int{1, 2}, 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([]int{3, 2, 3}, 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([]int{3, 2, 3}, 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([]int{3}, 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "go_test.go",
+    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list arr of integers, find the minimum number of elements that\n// need to be changed to make the list palindromic. A palindromic list is a list that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([]int{1, 2, 3, 5, 4, 7, 9, 6})\n// 4\n// >>> smallest_change([]int{1, 2, 3, 4, 3, 2, 2})\n// 1\n// >>> smallest_change([]int{1, 2, 3, 2, 1})\n// 0\nfunc smallest_change(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "go_test.go",
+    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([]string{}, []string{})\n// []string{}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"})\n// []string{\"hI\", \"Hi\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"})\n// []string{\"hi\", \"admin\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"})\n// []string{\"hI\", \"hi\", \"hi\"}\n// >>> total_match([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"})\n// []string{\"4\"}\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "go_test.go",
+    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "go_test.go",
+    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunc is_simple_power(x int, n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "go_test.go",
+    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunc iscube(a int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "go_test.go",
+    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunc hex_key(num string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "go_test.go",
+    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([]string{}, \"a\")\n// []string{}\n// >>> filter_by_substring([]string{\"abc\", \"bacd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"bacd\", \"array\"}\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "go_test.go",
+    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is hapgo or not.\n// A string is hapgo if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunc is_happy(s string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "go_test.go",
+    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([]float64{4.0, 3, 1.7, 2, 3.5})\n// []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"}\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "go_test.go",
+    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunc prime_length(myString string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "go_test.go",
+    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([]int{4, 2, 6, 7})\n// 2\nfunc add(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "go_test.go",
+    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "go_test.go",
+    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of lists, [(x1, y1), (x2, y2) ...] such that\n// each list is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1)\n// [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}}\n// >>> get_row([][]int{}, 1)\n// [][]interface{}{}\n// >>> get_row([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3)\n// [][]int{[]interface{}{2, 2}}\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "go_test.go",
+    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of non-negative integers, return a cogo of the given list after sorting,\n// you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given list.\n// Examples:\n// >>> sort_array([]int{})\n// []int{}\n// >>> sort_array([]int{5})\n// []int{5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5})\n// []int{0, 1, 2, 3, 4, 5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5, 6})\n// []int{6, 5, 4, 3, 2, 1, 0}\nfunc sort_array(array []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "go_test.go",
+    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunc encrypt(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "go_test.go",
+    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([]int{})\n// []interface{}{0, 1}\n// >>> sum_product([]int{1, 2, 3, 4})\n// []interface{}{10, 24}\nfunc sum_product(numbers []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "go_test.go",
+    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "go_test.go",
+    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunc any_int(x float64, y float64, z float64) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "go_test.go",
+    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunc encode(message string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "go_test.go",
+    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n// 10\n// >>> skjkasdkd([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n// 25\n// >>> skjkasdkd([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n// 13\n// >>> skjkasdkd([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n// 11\n// >>> skjkasdkd([]int{0, 81, 12, 3, 1, 21})\n// 3\n// >>> skjkasdkd([]int{0, 8, 1, 2, 1, 7})\n// 7\nfunc skjkasdkd(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "go_test.go",
+    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a map, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given map is empty.\n// Examples:\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case(map[interface{}]string{\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunc check_dict_case(dict map[string]string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "go_test.go",
+    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns a list of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// []int{2, 3}\n// >>> count_up_to(11)\n// []int{2, 3, 5, 7}\n// >>> count_up_to(0)\n// []int{}\n// >>> count_up_to(20)\n// []int{2, 3, 5, 7, 11, 13, 17, 19}\n// >>> count_up_to(1)\n// []int{}\n// >>> count_up_to(18)\n// []int{2, 3, 5, 7, 11, 13, 17}\nfunc count_up_to(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "go_test.go",
+    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunc multiply(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "go_test.go",
+    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunc count_upper(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "go_test.go",
+    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "go_test.go",
+    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([]int{1, 2, 3, 2, 3, 4, 2})\n// []int{1, 2, 3, 3, 3, 4, 4}\nfunc rolling_max(numbers []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/humaneval-go-transform.json
+++ b/prompts/humaneval-go-transform.json
@@ -1,1594 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "go_test.go",
-    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunc strlen(myString string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "go_test.go",
-    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunc encrypt(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "go_test.go",
-    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case(map[interface{}]string{\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunc check_dict_case(dict map[string]string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([]int{4, 2, 6, 7})\n// 2\nfunc add(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "go_test.go",
-    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "go_test.go",
-    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "go_test.go",
-    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([]int{1, 3, 2, 0})\n// 10\n// >>> double_the_difference([]int{-1, -2, 0})\n// 0\n// >>> double_the_difference([]int{9, -2})\n// 81\n// >>> double_the_difference([]int{0})\n// 0\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "go_test.go",
-    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\n// >>> filter_integers([]float64{\"a\", 3.14, 5})\n// []int{5}\n// >>> filter_integers([]interface{}{1, 2, 3, \"abc\", map[interface{}]interface{}{}, []interface{}{}})\n// []int{1, 2, 3}\nfunc filter_integers(values []interface{}) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "go_test.go",
-    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "go_test.go",
-    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// []int{4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nfunc parse_music(music_string string) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "go_test.go",
-    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// []string{\"a\", \"ab\", \"abc\"}\nfunc all_prefixes(myString string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "go_test.go",
-    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "go_test.go",
-    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// []int{11, 4}\n// >>> eat(4, 8, 9)\n// []int{12, 1}\n// >>> eat(1, 10, 10)\n// []int{11, 0}\n// >>> eat(2, 11, 5)\n// []int{7, 0}\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "go_test.go",
-    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1)\n// 6\n// Example 2:\n// >>> max_fill([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2)\n// 5\n// Example 3:\n// >>> max_fill([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "go_test.go",
-    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "go_test.go",
-    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunc flip_case(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "go_test.go",
-    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([]int{2, 1, 1, 4, 5, 8, 2, 3})\n// []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"}\n// If the array is empty, return an empty array:\n// >>> by_length([]int{})\n// []string{}\n// If the array has any strange number ignore it:\n// >>> by_length([]int{1, -1, 55})\n// []string{\"One\"}\nfunc by_length(arr []int) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "go_test.go",
-    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// []int{2, 2, 2}\n// >>> factorize(25)\n// []int{5, 5}\n// >>> factorize(70)\n// []int{2, 5, 7}\nfunc factorize(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "go_test.go",
-    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// []int{2, 3}\n// >>> count_up_to(11)\n// []int{2, 3, 5, 7}\n// >>> count_up_to(0)\n// []int{}\n// >>> count_up_to(20)\n// []int{2, 3, 5, 7, 11, 13, 17, 19}\n// >>> count_up_to(1)\n// []int{}\n// >>> count_up_to(18)\n// []int{2, 3, 5, 7, 11, 13, 17}\nfunc count_up_to(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "go_test.go",
-    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{0, 2, 3, 5, 9, 123}\nfunc unique(l []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "go_test.go",
-    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([]string{}, []string{})\n// []string{}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"})\n// []string{\"hI\", \"Hi\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"})\n// []string{\"hi\", \"admin\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"})\n// []string{\"hI\", \"hi\", \"hi\"}\n// >>> total_match([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"})\n// []string{\"4\"}\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "go_test.go",
-    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([]int{1, 2, 3})\n// 3\n// >>> max_element([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// 123\nfunc max_element(l []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "go_test.go",
-    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunc is_nested(myString string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "go_test.go",
-    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([]string{\"1234567\"})\n// []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}\n// >>> odd_count([]string{\"3\", \"11111111\"})\n// []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"}\nfunc odd_count(lst []string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "go_test.go",
-    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([]int{3, 4, 5, 1, 2})\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([]int{3, 5, 4, 1, 2})\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "go_test.go",
-    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// []interface{}{1, 2}\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// []interface{}{4, 6}\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "go_test.go",
-    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunc is_equal_to_sum_even(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "go_test.go",
-    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([]int{3, 1, 2, 4, 5})\n// []int{1, 4, 12, 20}\n// >>> derivative([]int{1, 2, 3})\n// []int{2, 6}\nfunc derivative(xs []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "go_test.go",
-    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([]int{5})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5})\n// false\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6, 7})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5, 6, 7})\n// false\n// >>> is_sorted([]int{1, 2, 2, 3, 3, 4})\n// true\n// >>> is_sorted([]int{1, 2, 2, 2, 3, 4})\n// false\nfunc is_sorted(lst []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunc solve(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "go_test.go",
-    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// []int{1, 3, 2, 8}\nfunc tri(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "go_test.go",
-    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "go_test.go",
-    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([]string{}, \"a\")\n// []string{}\n// >>> filter_by_prefix([]string{\"abc\", \"bcd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"array\"}\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "go_test.go",
-    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "go_test.go",
-    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3)\n// []int{1, 2, 1}\n// >>> minPath([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1)\n// []int{1}\nfunc minPath(grid [][]int, k int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "go_test.go",
-    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunc count_upper(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([]int{-3, -4, 5}, 3)\n// []int{-4, -3, 5}\n// Example 2:\n// >>> maximum([]int{4, -4, 4}, 2)\n// []int{4, 4}\n// Example 3:\n// >>> maximum([]int{-3, 2, 1, 2, -1, -2, 1}, 1)\n// []int{2}\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "go_test.go",
-    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "go_test.go",
-    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([]int{})\n// []int{}\n// >>> sort_array([]int{5})\n// []int{5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5})\n// []int{0, 1, 2, 3, 4, 5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5, 6})\n// []int{6, 5, 4, 3, 2, 1, 0}\nfunc sort_array(array []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "go_test.go",
-    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// []int{1, 2, 6, 24, 15}\nfunc f(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "go_test.go",
-    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunc iscube(a int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "go_test.go",
-    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunc encode(message string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "go_test.go",
-    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> pairs_sum_to_zero([]int{1, 3, -2, 1})\n// false\n// >>> pairs_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> pairs_sum_to_zero([]int{2, 4, -5, 3, 5, 7})\n// true\n// >>> pairs_sum_to_zero([]int{1})\n// false\nfunc pairs_sum_to_zero(l []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "go_test.go",
-    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// []interface{}{\"Saturn\", \"Uranus\"}\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"}\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "go_test.go",
-    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunc digits(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "go_test.go",
-    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"}\n// >>> words_string(\"One, two, three, four, five, six\")\n// []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"}\nfunc words_string(s string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "go_test.go",
-    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "go_test.go",
-    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunc remove_vowels(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "go_test.go",
-    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([]int{1, 2, 3, 4})\n// []int{1, 4, 2, 3}\n// >>> strange_sort_list([]int{5, 5, 5, 5})\n// []int{5, 5, 5, 5}\n// >>> strange_sort_list([]int{})\n// []int{}\nfunc strange_sort_list(lst []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "go_test.go",
-    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n// []interface{}{2.0, 2.2}\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n// []interface{}{2.0, 2.0}\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "go_test.go",
-    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunc is_simple_power(x int, n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "go_test.go",
-    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "go_test.go",
-    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([]int{1, 11, -1, -11, -12})\n// []int{-1, -11, 1, -12, 11}\n// >>> order_by_points([]int{})\n// []int{}\nfunc order_by_points(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "go_test.go",
     "prompt": "package has_close_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([]float64{1.0, 2.0, 3.0}, 0.5)\n// false\n// >>> has_close_elements([]float64{1.0, 2.8, 3.0, 4.0, 5.0, 2.0}, 0.3)\n// true\nfunc has_close_elements(numbers []float64, threshold float64) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestHas_Close_Elements(t *testing.T) {\n  candidate := has_close_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), expected: true },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), expected: false },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), expected: true },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "go_test.go",
-    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunc make_palindrome(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "go_test.go",
-    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunc string_xor(a string, b string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "go_test.go",
-    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "go_test.go",
-    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "go_test.go",
-    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "go_test.go",
-    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([]int{15, 33, 1422, 1})\n// []int{1, 15, 33}\n// >>> unique_digits([]int{152, 323, 1422, 10})\n// []int{}\nfunc unique_digits(x []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "go_test.go",
-    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// []string{\"little\"}\n// >>> select_words(\"Mary had a little lamb\", 3)\n// []string{\"Mary\", \"lamb\"}\n// >>> select_words(\"simple white space\", 2)\n// []string{}\n// >>> select_words(\"Hello world\", 4)\n// []string{\"world\"}\n// >>> select_words(\"Uncle sam\", 3)\n// []string{\"Uncle\"}\nfunc select_words(s string, n int) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "go_test.go",
-    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([]int{1, 2}, 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([]int{3, 2, 3}, 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([]int{3, 2, 3}, 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([]int{3}, 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "go_test.go",
-    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "go_test.go",
-    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", []string{\"AA\", \"Be\", \"CC\"})\n// \"my_class.AA\"\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "go_test.go",
-    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([]string{\"()(\", \")\"})\n// \"Yes\"\n// >>> match_parens([]string{\")\", \")\"})\n// \"No\"\nfunc match_parens(lst []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "go_test.go",
-    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunc any_int(x float64, y float64, z float64) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "go_test.go",
-    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "go_test.go",
-    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([]int{1, 2, 3})\n// []int{2, 3, 4}\n// >>> incr_list([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{6, 4, 6, 3, 4, 4, 10, 1, 124}\nfunc incr_list(l []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "go_test.go",
-    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunc x_or_y(n int, x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "go_test.go",
-    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "go_test.go",
-    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// []interface{}{1, 1}\n// >>> even_odd_count(123)\n// []interface{}{1, 2}\nfunc even_odd_count(num int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "go_test.go",
-    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunc is_happy(s string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "go_test.go",
-    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "go_test.go",
-    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunc digitSum(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "go_test.go",
-    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([]float64{1.0, 2.0, 3.0, 4.0, 5.0})\n// []float64{0.0, 0.25, 0.5, 0.75, 1.0}\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "go_test.go",
-    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([]int{5, 8, 7, 1})\n// 12\n// >>> solution([]int{3, 3, 3, 3, 3})\n// 9\n// >>> solution([]int{30, 13, 24, 321})\n// 0\nfunc solution(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "go_test.go",
-    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([]int{4, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([]int{1, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([]int{})\n// []int{}\n// Example 4:\n// >>> pluck([]int{5, 0, 3, 0, 4, 2})\n// []int{0, 1}\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "go_test.go",
-    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "go_test.go",
-    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 2, 3, 4})\n// \"YES\"\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 5, 3, 4})\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "go_test.go",
-    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([]int{3, 1, 2, 4, 5})\n// 3\n// >>> median([]int{-10, 4, 6, 1000, 10, 20})\n// 15.0\nfunc median(l []int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "go_test.go",
-    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunc prime_length(myString string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "go_test.go",
-    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([]int{1, 2, 3, 5, 4, 7, 9, 6})\n// 4\n// >>> smallest_change([]int{1, 2, 3, 4, 3, 2, 2})\n// 1\n// >>> smallest_change([]int{1, 2, 3, 2, 1})\n// 0\nfunc smallest_change(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([]float64{1.0, 2.0, 3.0})\n// 14\n// >>> lst([]float64{1.0, 4.0, 9.0})\n// 98\n// >>> lst([]float64{1.0, 3.0, 5.0, 7.0})\n// 84\n// >>> lst([]float64{1.4, 4.2, 0.0})\n// 29\n// >>> lst([]float64{-2.4, 1.0, 1.0})\n// 6\nfunc sum_squares(lst []float64) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "go_test.go",
-    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunc file_name_check(file_name string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "go_test.go",
-    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> triples_sum_to_zero([]int{1, 3, -2, 1})\n// true\n// >>> triples_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> triples_sum_to_zero([]int{2, 4, -5, 3, 9, 7})\n// true\n// >>> triples_sum_to_zero([]int{1})\n// false\nfunc triples_sum_to_zero(l []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "go_test.go",
-    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([]interface{}{1, 2}, []interface{}{2, 3})\n// \"NO\"\n// >>> intersection([]interface{}{-1, 1}, []interface{}{0, 4})\n// \"NO\"\n// >>> intersection([]interface{}{-3, -1}, []interface{}{-5, 5})\n// \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "go_test.go",
-    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// []string{\"()\", \"(())\", \"(()())\"}\nfunc separate_paren_groups(paren_string string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "go_test.go",
-    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2})\n// []int{0, 0, 0, 0, 3, 3}\n// >>> compare([]int{0, 5, 0, 0, 0, 4}, []int{4, 1, 1, 0, 0, -2})\n// []int{4, 4, 1, 0, 0, 6}\nfunc compare(game []int, guess []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "go_test.go",
-    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "go_test.go",
-    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "go_test.go",
-    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunc valid_date(date string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "go_test.go",
-    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]int{})\n// 0\n// >>> count_nums([]int{-1, 11, -11})\n// 1\n// >>> count_nums([]int{1, 1, 2})\n// 3\nfunc count_nums(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "go_test.go",
-    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "go_test.go",
-    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunc is_palindrome(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "go_test.go",
-    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunc get_closest_vowel(word string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "go_test.go",
-    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunc is_prime(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "go_test.go",
-    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunc simplify(x string, n string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "go_test.go",
-    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunc hex_key(num string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "go_test.go",
-    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "go_test.go",
-    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// map[string]int{\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// map[string]int{\"b\": 4}\n// >>> histogram(\"\")\n// map[string]int{}\nfunc histogram(test string) map[string]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "go_test.go",
-    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1)\n// [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}}\n// >>> get_row([][]int{}, 1)\n// [][]interface{}{}\n// >>> get_row([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3)\n// [][]int{[]interface{}{2, 2}}\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "go_test.go",
-    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// []int{1, 5}\nfunc get_odd_collatz(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "go_test.go",
-    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([]int{1, 2, 4, 3, 5})\n// 3\n// >>> can_arrange([]int{1, 2, 3})\n// -1\nfunc can_arrange(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "go_test.go",
-    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunc sort_numbers(numbers string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "go_test.go",
-    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "go_test.go",
-    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// []int{1, 2, 3}\n// >>> lst\n// int{}\n// >>> lst\n// []int{-1, -5, 2, -1, -5}\nfunc sum_squares(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "go_test.go",
-    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n// 10\n// >>> skjkasdkd([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n// 25\n// >>> skjkasdkd([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n// 13\n// >>> skjkasdkd([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n// 11\n// >>> skjkasdkd([]int{0, 81, 12, 3, 1, 21})\n// 3\n// >>> skjkasdkd([]int{0, 8, 1, 2, 1, 7})\n// 7\nfunc skjkasdkd(lst []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "go_test.go",
-    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([]int{})\n// []interface{}{0, 1}\n// >>> sum_product([]int{1, 2, 3, 4})\n// []interface{}{10, 24}\nfunc sum_product(numbers []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "go_test.go",
-    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunc choose_num(x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "go_test.go",
-    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([]int{2, 4, 1, 3, 5, 7})\n// []interface{}{nil, 1}\n// >>> largest_smallest_integers([]int{})\n// []interface{}{nil, nil}\n// >>> largest_smallest_integers([]int{0})\n// []interface{}{nil, nil}\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "go_test.go",
-    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunc count_distinct_characters(myString string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1600,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package make_a_pile_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// []int{3, 5, 7}\nfunc make_a_pile(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestMake_A_Pile(t *testing.T) {\n  candidate := make_a_pile\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{3, 5, 7} },\n     { actual: candidate(4), expected: []int{4, 6, 8, 10} },\n     { actual: candidate(5), expected: []int{5, 7, 9, 11, 13} },\n     { actual: candidate(6), expected: []int{6, 8, 10, 12, 14, 16} },\n     { actual: candidate(8), expected: []int{8, 10, 12, 14, 16, 18, 20, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1610,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_101_words_string",
     "language": "go_test.go",
-    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([]int{2, 3, 4, 1, 2, 4})\n// 1\n// >>> minSubArraySum([]int{-1, -2, -3})\n// -6\nfunc minSubArraySum(nums []int) int {\n",
+    "prompt": "package words_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"}\n// >>> words_string(\"One, two, three, four, five, six\")\n// []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"}\nfunc words_string(s string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestWords_String(t *testing.T) {\n  candidate := words_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi, my name is John\"), expected: []string{\"Hi\", \"my\", \"name\", \"is\", \"John\"} },\n     { actual: candidate(\"One, two, three, four, five, six\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"Hi, my name\"), expected: []string{\"Hi\", \"my\", \"name\"} },\n     { actual: candidate(\"One,, two, three, four, five, six,\"), expected: []string{\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"} },\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"ahmed     , gamal\"), expected: []string{\"ahmed\", \"gamal\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1624,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_102_choose_num",
     "language": "go_test.go",
-    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunc string_sequence(n int) string {\n",
+    "prompt": "package choose_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunc choose_num(x int, y int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestChoose_Num(t *testing.T) {\n  candidate := choose_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12, 15), expected: 14 },\n     { actual: candidate(13, 12), expected: -1 },\n     { actual: candidate(33, 12354), expected: 12354 },\n     { actual: candidate(5234, 5233), expected: -1 },\n     { actual: candidate(6, 29), expected: 28 },\n     { actual: candidate(27, 10), expected: -1 },\n     { actual: candidate(7, 7), expected: -1 },\n     { actual: candidate(546, 546), expected: 546 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1638,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "go_test.go",
-    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunc cycpattern_check(a string, b string) bool {\n",
+    "prompt": "package unique_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([]int{15, 33, 1422, 1})\n// []int{1, 15, 33}\n// >>> unique_digits([]int{152, 323, 1422, 10})\n// []int{}\nfunc unique_digits(x []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestUnique_Digits(t *testing.T) {\n  candidate := unique_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 33, 1422, 1}), expected: []int{1, 15, 33} },\n     { actual: candidate([]int{152, 323, 1422, 10}), expected: []int{} },\n     { actual: candidate([]int{12345, 2033, 111, 151}), expected: []int{111, 151} },\n     { actual: candidate([]int{135, 103, 31}), expected: []int{31, 135} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1652,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "go_test.go",
-    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([]int{1, 2, 4, 20})\n// true\n// >>> monotonic([]int{1, 20, 4, 10})\n// false\n// >>> monotonic([]int{4, 1, 0, -10})\n// true\nfunc monotonic(l []int) bool {\n",
+    "prompt": "package by_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([]int{2, 1, 1, 4, 5, 8, 2, 3})\n// []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"}\n// If the array is empty, return an empty array:\n// >>> by_length([]int{})\n// []string{}\n// If the array has any strange number ignore it:\n// >>> by_length([]int{1, -1, 55})\n// []string{\"One\"}\nfunc by_length(arr []int) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBy_Length(t *testing.T) {\n  candidate := by_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 1, 4, 5, 8, 2, 3}), expected: []string{\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"} },\n     { actual: candidate([]int{}), expected: []string{} },\n     { actual: candidate([]int{1, -1, 55}), expected: []string{\"One\"} },\n     { actual: candidate([]int{1, -1, 3, 2}), expected: []string{\"Three\", \"Two\", \"One\"} },\n     { actual: candidate([]int{9, 4, 8}), expected: []string{\"Nine\", \"Eight\", \"Four\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1666,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_106_f",
     "language": "go_test.go",
-    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([]int{1, 2, 4, 10}, 100)\n// true\n// >>> below_threshold([]int{1, 20, 4, 10}, 5)\n// false\nfunc below_threshold(l []int, t int) bool {\n",
+    "prompt": "package f_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// []int{1, 2, 6, 24, 15}\nfunc f(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestF(t *testing.T) {\n  candidate := f\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{1, 2, 6, 24, 15} },\n     { actual: candidate(7), expected: []int{1, 2, 6, 24, 15, 720, 28} },\n     { actual: candidate(1), expected: []int{1} },\n     { actual: candidate(3), expected: []int{1, 2, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1680,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "go_test.go",
-    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "prompt": "package even_odd_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// []interface{}{1, 2}\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// []interface{}{4, 6}\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n int) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestEven_Odd_Palindrome(t *testing.T) {\n  candidate := even_odd_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: []interface{}{8, 13} },\n     { actual: candidate(12), expected: []interface{}{4, 6} },\n     { actual: candidate(3), expected: []interface{}{1, 2} },\n     { actual: candidate(63), expected: []interface{}{6, 8} },\n     { actual: candidate(25), expected: []interface{}{5, 6} },\n     { actual: candidate(19), expected: []interface{}{4, 6} },\n     { actual: candidate(9), expected: []interface{}{4, 5} },\n     { actual: candidate(1), expected: []interface{}{0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1694,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_108_count_nums",
     "language": "go_test.go",
-    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([]int{-1, 2, -4, 5, 6})\n// []int{2, 5, 6}\n// >>> get_positive([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// []int{5, 3, 2, 3, 9, 123, 1}\nfunc get_positive(l []int) []int {\n",
+    "prompt": "package count_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]int{})\n// 0\n// >>> count_nums([]int{-1, 11, -11})\n// 1\n// >>> count_nums([]int{1, 1, 2})\n// 3\nfunc count_nums(arr []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Nums(t *testing.T) {\n  candidate := count_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{-1, -2, 0}), expected: 0 },\n     { actual: candidate([]int{1, 1, 2, -2, 3, 4, 5}), expected: 6 },\n     { actual: candidate([]int{1, 6, 9, -6, 0, 1, 5}), expected: 5 },\n     { actual: candidate([]int{1, 100, 98, -7, 1, -1}), expected: 4 },\n     { actual: candidate([]int{12, 23, 34, -45, -56, 0}), expected: 5 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n     { actual: candidate([]int{1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1708,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_109_move_one_ball",
     "language": "go_test.go",
-    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_third([]int{5, 6, 3, 4, 8, 9, 2})\n// []int{2, 6, 3, 4, 8, 9, 5}\nfunc sort_third(l []int) []int {\n",
+    "prompt": "package move_one_ball_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([]int{3, 4, 5, 1, 2})\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([]int{3, 5, 4, 1, 2})\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunc move_one_ball(arr []int) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMove_One_Ball(t *testing.T) {\n  candidate := move_one_ball\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 1, 2}), expected: true },\n     { actual: candidate([]int{3, 5, 10, 1, 2}), expected: true },\n     { actual: candidate([]int{4, 3, 1, 2}), expected: false },\n     { actual: candidate([]int{3, 5, 4, 1, 2}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1722,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_10_make_palindrome",
     "language": "go_test.go",
-    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// []int{2, 3, 1, 3}\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "prompt": "package make_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunc make_palindrome(myString string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMake_Palindrome(t *testing.T) {\n  candidate := make_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"x\"), expected: \"x\" },\n     { actual: candidate(\"xyz\"), expected: \"xyzyx\" },\n     { actual: candidate(\"xyx\"), expected: \"xyx\" },\n     { actual: candidate(\"jerry\"), expected: \"jerryrrej\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1736,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_110_exchange",
     "language": "go_test.go",
-    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
+    "prompt": "package exchange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 2, 3, 4})\n// \"YES\"\n// >>> exchange([]int{1, 2, 3, 4}, []int{1, 5, 3, 4})\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1 []int, lst2 []int) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestExchange(t *testing.T) {\n  candidate := exchange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}), expected: \"YES\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{1, 5, 3, 4}), expected: \"NO\" },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{2, 1, 4, 3}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 4}), expected: \"YES\" },\n     { actual: candidate([]int{5, 7, 3}, []int{2, 6, 3}), expected: \"NO\" },\n     { actual: candidate([]int{3, 2, 6, 1, 8, 9}, []int{3, 5, 5, 1, 1, 1}), expected: \"NO\" },\n     { actual: candidate([]int{100, 200}, []int{200, 200}), expected: \"YES\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1750,69 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_97_multiply",
+    "name": "HumanEval_111_histogram",
     "language": "go_test.go",
-    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunc multiply(a int, b int) int {\n",
+    "prompt": "package histogram_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// map[string]int{\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// map[string]int{\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// map[string]int{\"b\": 4}\n// >>> histogram(\"\")\n// map[string]int{}\nfunc histogram(test string) map[string]int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "go_test.go",
-    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([]float64{1.0, 2.0, 3.0, 4.0})\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "go_test.go",
-    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121})\n// []int{1, 5, 653}\n// >>> common([]int{5, 3, 2, 8}, []int{3, 2})\n// []int{2, 3}\nfunc common(l1 []int, l2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "go_test.go",
-    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunc int_to_mini_roman(number int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "go_test.go",
-    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunc fruit_distribution(s string, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHistogram(t *testing.T) {\n  candidate := histogram\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a b b a\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c a b\"), expected: map[string]int{\"a\": 2, \"b\": 2} },\n     { actual: candidate(\"a b c d g\"), expected: map[string]int{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"b b b b a\"), expected: map[string]int{\"b\": 4} },\n     { actual: candidate(\"r t g\"), expected: map[string]int{\"r\": 1, \"t\": 1, \"g\": 1} },\n     { actual: candidate(\"\"), expected: map[string]int{} },\n     { actual: candidate(\"a\"), expected: map[string]int{\"a\": 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1824,7 +186,7 @@
     "language": "go_test.go",
     "prompt": "package reverse_delete_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// []interface{}{\"bcd\", false}\n// >>> reverse_delete(\"abcdef\", \"b\")\n// []interface{}{\"acdef\", false}\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// []interface{}{\"cdedc\", true}\nfunc reverse_delete(s string, c string) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestReverse_Delete(t *testing.T) {\n  candidate := reverse_delete\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\", \"ae\"), expected: []interface{}{\"bcd\", false} },\n     { actual: candidate(\"abcdef\", \"b\"), expected: []interface{}{\"acdef\", false} },\n     { actual: candidate(\"abcdedcba\", \"ab\"), expected: []interface{}{\"cdedc\", true} },\n     { actual: candidate(\"dwik\", \"w\"), expected: []interface{}{\"dik\", false} },\n     { actual: candidate(\"a\", \"a\"), expected: []interface{}{\"\", true} },\n     { actual: candidate(\"abcdedcba\", \"\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"abcdedcba\", \"v\"), expected: []interface{}{\"abcdedcba\", true} },\n     { actual: candidate(\"vabba\", \"v\"), expected: []interface{}{\"abba\", true} },\n     { actual: candidate(\"mamma\", \"mia\"), expected: []interface{}{\"\", true} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1834,13 +196,41 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "go_test.go",
-    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "prompt": "package odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([]string{\"1234567\"})\n// []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"}\n// >>> odd_count([]string{\"3\", \"11111111\"})\n// []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"}\nfunc odd_count(lst []string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestOdd_Count(t *testing.T) {\n  candidate := odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"1234567\"}), expected: []string{\"the number of odd elements 4n the str4ng 4 of the 4nput.\"} },\n     { actual: candidate([]string{\"3\", \"11111111\"}), expected: []string{\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"} },\n     { actual: candidate([]string{\"271\", \"137\", \"314\"}), expected: []string{\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "go_test.go",
+    "prompt": "package minSubArraySum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([]int{2, 3, 4, 1, 2, 4})\n// 1\n// >>> minSubArraySum([]int{-1, -2, -3})\n// -6\nfunc minSubArraySum(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinsubarraysum(t *testing.T) {\n  candidate := minSubArraySum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 4, 1, 2, 4}), expected: 1 },\n     { actual: candidate([]int{-1, -2, -3}), expected: -6 },\n     { actual: candidate([]int{-1, -2, -3, 2, -10}), expected: -14 },\n     { actual: candidate([]int{-9999999999999999}), expected: -9999999999999999 },\n     { actual: candidate([]int{0, 10, 20, 1000000}), expected: 0 },\n     { actual: candidate([]int{-1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{100, -1, -2, -3, 10, -5}), expected: -6 },\n     { actual: candidate([]int{10, 11, 13, 8, 3, 4}), expected: 3 },\n     { actual: candidate([]int{100, -33, 32, -1, 0, -2}), expected: -33 },\n     { actual: candidate([]int{-10}), expected: -10 },\n     { actual: candidate([]int{7}), expected: 7 },\n     { actual: candidate([]int{1, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "go_test.go",
+    "prompt": "package max_fill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1)\n// 6\n// Example 2:\n// >>> max_fill([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2)\n// 5\n// Example 3:\n// >>> max_fill([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunc max_fill(grid [][]int, capacity int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Fill(t *testing.T) {\n  candidate := max_fill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0, 0, 1, 0}, []int{0, 1, 0, 0}, []int{1, 1, 1, 1}}, 1), expected: 6 },\n     { actual: candidate([][]int{[]int{0, 0, 1, 1}, []int{0, 0, 0, 0}, []int{1, 1, 1, 1}, []int{0, 1, 1, 1}}, 2), expected: 5 },\n     { actual: candidate([][]int{[]int{0, 0, 0}, []int{0, 0, 0}}, 5), expected: 0 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 2), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 1, 1, 1}, []int{1, 1, 1, 1}}, 9), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1852,7 +242,7 @@
     "language": "go_test.go",
     "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([]int{1, 5, 2, 3, 4})\n// []int{1, 2, 3, 4, 5}\n// >>> sort_array([]int{-2, -3, -4, -5, -6})\n// []int{-6, -5, -4, -3, -2}\n// >>> sort_array([]int{1, 0, 2, 3, 4})\n// []int{0, 1, 2, 3, 4}\nfunc sort_array(arr []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 2, 3, 4}), expected: []int{1, 2, 4, 3, 5} },\n     { actual: candidate([]int{-2, -3, -4, -5, -6}), expected: []int{-4, -2, -6, -5, -3} },\n     { actual: candidate([]int{1, 0, 2, 3, 4}), expected: []int{0, 1, 2, 4, 3} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), expected: []int{2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77} },\n     { actual: candidate([]int{3, 6, 44, 12, 32, 5}), expected: []int{32, 3, 5, 6, 12, 44} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n     { actual: candidate([]int{2, 4, 8, 16, 32}), expected: []int{2, 4, 8, 16, 32} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -1862,13 +252,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "go_test.go",
-    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([]string{})\n// \"\"\n// >>> concatenate([]string{\"a\", \"b\", \"c\"})\n// \"abc\"\nfunc concatenate(strings []string) string {\n",
+    "prompt": "package select_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// []string{\"little\"}\n// >>> select_words(\"Mary had a little lamb\", 3)\n// []string{\"Mary\", \"lamb\"}\n// >>> select_words(\"simple white space\", 2)\n// []string{}\n// >>> select_words(\"Hello world\", 4)\n// []string{\"world\"}\n// >>> select_words(\"Uncle sam\", 3)\n// []string{\"Uncle\"}\nfunc select_words(s string, n int) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSelect_Words(t *testing.T) {\n  candidate := select_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Mary had a little lamb\", 4), expected: []string{\"little\"} },\n     { actual: candidate(\"Mary had a little lamb\", 3), expected: []string{\"Mary\", \"lamb\"} },\n     { actual: candidate(\"simple white space\", 2), expected: []string{} },\n     { actual: candidate(\"Hello world\", 4), expected: []string{\"world\"} },\n     { actual: candidate(\"Uncle sam\", 3), expected: []string{\"Uncle\"} },\n     { actual: candidate(\"\", 4), expected: []string{} },\n     { actual: candidate(\"a b c d e f\", 1), expected: []string{\"b\", \"c\", \"d\", \"f\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1876,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "go_test.go",
-    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([]string{\"aa\", \"a\", \"aaa\"})\n// []string{\"aa\"}\n// >>> list_sort([]string{\"ab\", \"a\", \"aaa\", \"cd\"})\n// []string{\"ab\", \"cd\"}\nfunc sorted_list_sum(lst []string) []string {\n",
+    "prompt": "package get_closest_vowel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunc get_closest_vowel(word string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Closest_Vowel(t *testing.T) {\n  candidate := get_closest_vowel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"yogurt\"), expected: \"u\" },\n     { actual: candidate(\"full\"), expected: \"u\" },\n     { actual: candidate(\"easy\"), expected: \"\" },\n     { actual: candidate(\"eAsy\"), expected: \"\" },\n     { actual: candidate(\"ali\"), expected: \"\" },\n     { actual: candidate(\"bad\"), expected: \"a\" },\n     { actual: candidate(\"most\"), expected: \"o\" },\n     { actual: candidate(\"ab\"), expected: \"\" },\n     { actual: candidate(\"ba\"), expected: \"\" },\n     { actual: candidate(\"quick\"), expected: \"\" },\n     { actual: candidate(\"anime\"), expected: \"i\" },\n     { actual: candidate(\"Asia\"), expected: \"\" },\n     { actual: candidate(\"Above\"), expected: \"o\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1890,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "go_test.go",
-    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([]string{}, \"a\")\n// []string{}\n// >>> filter_by_substring([]string{\"abc\", \"bacd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"bacd\", \"array\"}\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "prompt": "package match_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([]string{\"()(\", \")\"})\n// \"Yes\"\n// >>> match_parens([]string{\")\", \")\"})\n// \"No\"\nfunc match_parens(lst []string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMatch_Parens(t *testing.T) {\n  candidate := match_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"()(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \")\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(())\", \"())())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")())\", \"(()()(\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"(())))\", \"(()())((\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"()\", \"())\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(()(\", \"()))()\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\"((((\", \"((())\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(()\", \"(()(\"}), expected: \"No\" },\n     { actual: candidate([]string{\")(\", \")(\"}), expected: \"No\" },\n     { actual: candidate([]string{\"(\", \")\"}), expected: \"Yes\" },\n     { actual: candidate([]string{\")\", \"(\"}), expected: \"Yes\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1904,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "go_test.go",
-    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "prompt": "package string_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunc string_xor(a string, b string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestString_Xor(t *testing.T) {\n  candidate := string_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"111000\", \"101010\"), expected: \"010010\" },\n     { actual: candidate(\"1\", \"1\"), expected: \"0\" },\n     { actual: candidate(\"0101\", \"0000\"), expected: \"0101\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1918,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "go_test.go",
-    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([]int{-3, -4, 5}, 3)\n// []int{-4, -3, 5}\n// Example 2:\n// >>> maximum([]int{4, -4, 4}, 2)\n// []int{4, 4}\n// Example 3:\n// >>> maximum([]int{-3, 2, 1, 2, -1, -2, 1}, 1)\n// []int{2}\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunc maximum(arr []int, k int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-3, -4, 5}, 3), expected: []int{-4, -3, 5} },\n     { actual: candidate([]int{4, -4, 4}, 2), expected: []int{4, 4} },\n     { actual: candidate([]int{-3, 2, 1, 2, -1, -2, 1}, 1), expected: []int{2} },\n     { actual: candidate([]int{123, -123, 20, 0, 1, 2, -3}, 3), expected: []int{2, 20, 123} },\n     { actual: candidate([]int{-123, 20, 0, 1, 2, -3}, 4), expected: []int{0, 1, 2, 20} },\n     { actual: candidate([]int{5, 15, 0, 3, -13, -8, 0}, 7), expected: []int{-13, -8, 0, 0, 3, 5, 15} },\n     { actual: candidate([]int{-1, 0, 2, 5, 3, -10}, 2), expected: []int{3, 5} },\n     { actual: candidate([]int{1, 0, 5, -7}, 1), expected: []int{5} },\n     { actual: candidate([]int{4, -4}, 2), expected: []int{-4, 4} },\n     { actual: candidate([]int{-10, 10}, 2), expected: []int{-10, 10} },\n     { actual: candidate([]int{1, 2, 3, -23, 243, -400, 0}, 0), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1932,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "go_test.go",
-    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([]string{\"name\", \"of\", \"string\"})\n// \"string\"\n// >>> find_max([]string{\"name\", \"enam\", \"game\"})\n// \"enam\"\n// >>> find_max([]string{\"aaaaaaa\", \"bb\", \"cc\"})\n// \"aaaaaaa\"\nfunc find_max(words []string) string {\n",
+    "prompt": "package solution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([]int{5, 8, 7, 1})\n// 12\n// >>> solution([]int{3, 3, 3, 3, 3})\n// 9\n// >>> solution([]int{30, 13, 24, 321})\n// 0\nfunc solution(lst []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSolution(t *testing.T) {\n  candidate := solution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 8, 7, 1}), expected: 12 },\n     { actual: candidate([]int{3, 3, 3, 3, 3}), expected: 9 },\n     { actual: candidate([]int{30, 13, 24, 321}), expected: 0 },\n     { actual: candidate([]int{5, 9}), expected: 5 },\n     { actual: candidate([]int{2, 4, 8}), expected: 0 },\n     { actual: candidate([]int{30, 13, 23, 32}), expected: 23 },\n     { actual: candidate([]int{3, 13, 2, 9}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1946,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "go_test.go",
-    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunc change_base(x int, base int) string {\n",
+    "prompt": "package add_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunc add_elements(arr []int, k int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAdd_Elements(t *testing.T) {\n  candidate := add_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), expected: -4 },\n     { actual: candidate([]int{111, 121, 3, 4000, 5, 6}, 2), expected: 0 },\n     { actual: candidate([]int{11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), expected: 125 },\n     { actual: candidate([]int{111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), expected: 24 },\n     { actual: candidate([]int{1}, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1960,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "go_test.go",
-    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "prompt": "package get_odd_collatz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// []int{1, 5}\nfunc get_odd_collatz(n int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Odd_Collatz(t *testing.T) {\n  candidate := get_odd_collatz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(14), expected: []int{1, 5, 7, 11, 13, 17} },\n     { actual: candidate(5), expected: []int{1, 5} },\n     { actual: candidate(12), expected: []int{1, 3, 5} },\n     { actual: candidate(1), expected: []int{1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1974,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "go_test.go",
-    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([]float64{4.0, 3, 1.7, 2, 3.5})\n// []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"}\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "prompt": "package valid_date_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunc valid_date(date string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestValid_Date(t *testing.T) {\n  candidate := valid_date\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"03-11-2000\"), expected: true },\n     { actual: candidate(\"15-01-2012\"), expected: false },\n     { actual: candidate(\"04-0-2040\"), expected: false },\n     { actual: candidate(\"06-04-2020\"), expected: true },\n     { actual: candidate(\"01-01-2007\"), expected: true },\n     { actual: candidate(\"03-32-2011\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"04-31-3000\"), expected: false },\n     { actual: candidate(\"06-06-2005\"), expected: true },\n     { actual: candidate(\"21-31-2000\"), expected: false },\n     { actual: candidate(\"04-12-2003\"), expected: true },\n     { actual: candidate(\"04122003\"), expected: false },\n     { actual: candidate(\"20030412\"), expected: false },\n     { actual: candidate(\"2003-04\"), expected: false },\n     { actual: candidate(\"2003-04-12\"), expected: false },\n     { actual: candidate(\"04-2003\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -1988,13 +378,265 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "go_test.go",
-    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([]int{}, 4)\n// []int{}\n// >>> intersperse([]int{1, 2, 3}, 4)\n// []int{1, 4, 2, 4, 3}\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "prompt": "package is_sorted_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([]int{5})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5})\n// false\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6})\n// true\n// >>> is_sorted([]int{1, 2, 3, 4, 5, 6, 7})\n// true\n// >>> is_sorted([]int{1, 3, 2, 4, 5, 6, 7})\n// false\n// >>> is_sorted([]int{1, 2, 2, 3, 3, 4})\n// true\n// >>> is_sorted([]int{1, 2, 2, 2, 3, 4})\n// false\nfunc is_sorted(lst []int) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestIs_Sorted(t *testing.T) {\n  candidate := is_sorted\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}), expected: true },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, 7}), expected: false },\n     { actual: candidate([]int{}), expected: true },\n     { actual: candidate([]int{1}), expected: true },\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 2, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 3, 3, 4}), expected: false },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "go_test.go",
+    "prompt": "package intersection_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([]interface{}{1, 2}, []interface{}{2, 3})\n// \"NO\"\n// >>> intersection([]interface{}{-1, 1}, []interface{}{0, 4})\n// \"NO\"\n// >>> intersection([]interface{}{-3, -1}, []interface{}{-5, 5})\n// \"YES\"\nfunc intersection(interval1 []interface{}, interval2 []interface{}) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersection(t *testing.T) {\n  candidate := intersection\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2}, []interface{}{2, 3}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-1, 1}, []interface{}{0, 4}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-3, -1}, []interface{}{-5, 5}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-2, 2}, []interface{}{-4, 0}), expected: \"YES\" },\n     { actual: candidate([]interface{}{-11, 2}, []interface{}{-1, -1}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{3, 5}), expected: \"NO\" },\n     { actual: candidate([]interface{}{1, 2}, []interface{}{1, 2}), expected: \"NO\" },\n     { actual: candidate([]interface{}{-2, -2}, []interface{}{-3, -2}), expected: \"NO\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "go_test.go",
+    "prompt": "package minPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3)\n// []int{1, 2, 1}\n// >>> minPath([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1)\n// []int{1}\nfunc minPath(grid [][]int, k int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinpath(t *testing.T) {\n  candidate := minPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}, 3), expected: []int{1, 2, 1} },\n     { actual: candidate([][]int{[]int{5, 9, 3}, []int{4, 1, 6}, []int{7, 8, 2}}, 1), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}, []int{13, 14, 15, 16}}, 4), expected: []int{1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{6, 4, 13, 10}, []int{5, 7, 12, 1}, []int{3, 16, 11, 15}, []int{8, 14, 9, 2}}, 7), expected: []int{1, 10, 1, 10, 1, 10, 1} },\n     { actual: candidate([][]int{[]int{8, 14, 9, 2}, []int{6, 4, 13, 15}, []int{5, 7, 1, 12}, []int{3, 10, 11, 16}}, 5), expected: []int{1, 7, 1, 7, 1} },\n     { actual: candidate([][]int{[]int{11, 8, 7, 2}, []int{5, 16, 14, 4}, []int{9, 3, 15, 6}, []int{12, 13, 10, 1}}, 9), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1} },\n     { actual: candidate([][]int{[]int{12, 13, 10, 1}, []int{9, 3, 15, 6}, []int{5, 16, 14, 4}, []int{11, 8, 7, 2}}, 12), expected: []int{1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6} },\n     { actual: candidate([][]int{[]int{2, 7, 4}, []int{3, 1, 5}, []int{6, 8, 9}}, 8), expected: []int{1, 3, 1, 3, 1, 3, 1, 3} },\n     { actual: candidate([][]int{[]int{6, 1, 5}, []int{3, 8, 9}, []int{2, 7, 4}}, 8), expected: []int{1, 5, 1, 5, 1, 5, 1, 5} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}, 10), expected: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2} },\n     { actual: candidate([][]int{[]int{1, 3}, []int{3, 2}}, 10), expected: []int{1, 3, 1, 3, 1, 3, 1, 3, 1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "go_test.go",
+    "prompt": "package tri_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// []int{1, 3, 2, 8}\nfunc tri(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTri(t *testing.T) {\n  candidate := tri\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: []int{1, 3, 2, 8} },\n     { actual: candidate(4), expected: []int{1, 3, 2, 8, 3} },\n     { actual: candidate(5), expected: []int{1, 3, 2, 8, 3, 15} },\n     { actual: candidate(6), expected: []int{1, 3, 2, 8, 3, 15, 4} },\n     { actual: candidate(7), expected: []int{1, 3, 2, 8, 3, 15, 4, 24} },\n     { actual: candidate(8), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5} },\n     { actual: candidate(9), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35} },\n     { actual: candidate(20), expected: []int{1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11} },\n     { actual: candidate(0), expected: []int{1} },\n     { actual: candidate(1), expected: []int{1, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "go_test.go",
+    "prompt": "package digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunc digits(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigits(t *testing.T) {\n  candidate := digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 5 },\n     { actual: candidate(54), expected: 5 },\n     { actual: candidate(120), expected: 1 },\n     { actual: candidate(5014), expected: 5 },\n     { actual: candidate(98765), expected: 315 },\n     { actual: candidate(5576543), expected: 2625 },\n     { actual: candidate(2468), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "go_test.go",
+    "prompt": "package is_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunc is_nested(myString string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Nested(t *testing.T) {\n  candidate := is_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"[[]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]][[[[[]\"), expected: false },\n     { actual: candidate(\"[][]\"), expected: false },\n     { actual: candidate(\"[]\"), expected: false },\n     { actual: candidate(\"[[[[]]]]\"), expected: true },\n     { actual: candidate(\"[]]]]]]]]]]\"), expected: false },\n     { actual: candidate(\"[][][[]]\"), expected: true },\n     { actual: candidate(\"[[]\"), expected: false },\n     { actual: candidate(\"[]]\"), expected: false },\n     { actual: candidate(\"[[]][[\"), expected: true },\n     { actual: candidate(\"[[][]]\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"[[[[[[[[\"), expected: false },\n     { actual: candidate(\"]]]]]]]]\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([]float64{1.0, 2.0, 3.0})\n// 14\n// >>> lst([]float64{1.0, 4.0, 9.0})\n// 98\n// >>> lst([]float64{1.0, 3.0, 5.0, 7.0})\n// 84\n// >>> lst([]float64{1.4, 4.2, 0.0})\n// 29\n// >>> lst([]float64{-2.4, 1.0, 1.0})\n// 6\nfunc sum_squares(lst []float64) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0}), expected: 14 },\n     { actual: candidate([]float64{1.0, 3.0, 5.0, 7.0}), expected: 84 },\n     { actual: candidate([]float64{1.4, 4.2, 0.0}), expected: 29 },\n     { actual: candidate([]float64{-2.4, 1.0, 1.0}), expected: 6 },\n     { actual: candidate([]float64{100.0, 1.0, 15.0, 2.0}), expected: 10230 },\n     { actual: candidate([]float64{10000.0, 10000.0}), expected: 200000000 },\n     { actual: candidate([]float64{-1.4, 4.6, 6.3}), expected: 75 },\n     { actual: candidate([]float64{-1.4, 17.9, 18.9, 19.9}), expected: 1086 },\n     { actual: candidate([]float64{0.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0}), expected: 1 },\n     { actual: candidate([]float64{-1.0, 1.0, 0.0}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "go_test.go",
+    "prompt": "package check_if_last_char_is_a_letter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunc check_if_last_char_is_a_letter(txt string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_If_Last_Char_Is_A_Letter(t *testing.T) {\n  candidate := check_if_last_char_is_a_letter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"apple\"), expected: false },\n     { actual: candidate(\"apple pi e\"), expected: true },\n     { actual: candidate(\"eeeee\"), expected: false },\n     { actual: candidate(\"A\"), expected: true },\n     { actual: candidate(\"Pumpkin pie \"), expected: false },\n     { actual: candidate(\"Pumpkin pie 1\"), expected: false },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"eeeee e \"), expected: false },\n     { actual: candidate(\"apple pie\"), expected: false },\n     { actual: candidate(\"apple pi e \"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "go_test.go",
+    "prompt": "package can_arrange_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([]int{1, 2, 4, 3, 5})\n// 3\n// >>> can_arrange([]int{1, 2, 3})\n// -1\nfunc can_arrange(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCan_Arrange(t *testing.T) {\n  candidate := can_arrange\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 3, 5}), expected: 3 },\n     { actual: candidate([]int{1, 2, 4, 5}), expected: -1 },\n     { actual: candidate([]int{1, 4, 2, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{4, 8, 5, 7, 3}), expected: 4 },\n     { actual: candidate([]int{}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "go_test.go",
+    "prompt": "package largest_smallest_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([]int{2, 4, 1, 3, 5, 7})\n// []interface{}{nil, 1}\n// >>> largest_smallest_integers([]int{})\n// []interface{}{nil, nil}\n// >>> largest_smallest_integers([]int{0})\n// []interface{}{nil, nil}\nfunc largest_smallest_integers(lst []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Smallest_Integers(t *testing.T) {\n  candidate := largest_smallest_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{2, 4, 1, 3, 5, 7, 0}), expected: []interface{}{nil, 1} },\n     { actual: candidate([]int{1, 3, 2, 4, 5, 6, -2}), expected: []interface{}{-2, 1} },\n     { actual: candidate([]int{4, 5, 3, 6, 2, 7, -7}), expected: []interface{}{-7, 2} },\n     { actual: candidate([]int{7, 3, 8, 4, 9, 2, 5, -9}), expected: []interface{}{-9, 2} },\n     { actual: candidate([]int{}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{0}), expected: []interface{}{nil, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-1, -3, -5, -6, 0}), expected: []interface{}{-1, nil} },\n     { actual: candidate([]int{-6, -4, -4, -3, 1}), expected: []interface{}{-3, 1} },\n     { actual: candidate([]int{-6, -4, -4, -3, -100, 1}), expected: []interface{}{-3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "go_test.go",
+    "prompt": "package is_equal_to_sum_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunc is_equal_to_sum_even(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Equal_To_Sum_Even(t *testing.T) {\n  candidate := is_equal_to_sum_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: false },\n     { actual: candidate(6), expected: false },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(11), expected: false },\n     { actual: candidate(12), expected: true },\n     { actual: candidate(13), expected: false },\n     { actual: candidate(16), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "go_test.go",
+    "prompt": "package special_factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunc special_factorial(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSpecial_Factorial(t *testing.T) {\n  candidate := special_factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 288 },\n     { actual: candidate(5), expected: 34560 },\n     { actual: candidate(7), expected: 125411328000 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "go_test.go",
+    "prompt": "package greatest_common_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunc greatest_common_divisor(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGreatest_Common_Divisor(t *testing.T) {\n  candidate := greatest_common_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 7), expected: 1 },\n     { actual: candidate(10, 15), expected: 5 },\n     { actual: candidate(49, 14), expected: 7 },\n     { actual: candidate(144, 60), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "go_test.go",
+    "prompt": "package fix_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunc fix_spaces(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFix_Spaces(t *testing.T) {\n  candidate := fix_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Example\"), expected: \"Example\" },\n     { actual: candidate(\"Mudasir Hanif \"), expected: \"Mudasir_Hanif_\" },\n     { actual: candidate(\"Yellow Yellow  Dirty  Fellow\"), expected: \"Yellow_Yellow__Dirty__Fellow\" },\n     { actual: candidate(\"Exa   mple\"), expected: \"Exa-mple\" },\n     { actual: candidate(\"   Exa 1 2 2 mple\"), expected: \"-Exa_1_2_2_mple\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "go_test.go",
+    "prompt": "package file_name_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunc file_name_check(file_name string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFile_Name_Check(t *testing.T) {\n  candidate := file_name_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"example.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"1example.dll\"), expected: \"No\" },\n     { actual: candidate(\"s1sdf3.asd\"), expected: \"No\" },\n     { actual: candidate(\"K.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"MY16FILE3.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"His12FILE94.exe\"), expected: \"No\" },\n     { actual: candidate(\"_Y.txt\"), expected: \"No\" },\n     { actual: candidate(\"?aREYA.exe\"), expected: \"No\" },\n     { actual: candidate(\"/this_is_valid.dll\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.wow\"), expected: \"No\" },\n     { actual: candidate(\"this_is_valid.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"this_is_valid.txtexe\"), expected: \"No\" },\n     { actual: candidate(\"#this2_i4s_5valid.ten\"), expected: \"No\" },\n     { actual: candidate(\"@this1_is6_valid.exe\"), expected: \"No\" },\n     { actual: candidate(\"this_is_12valid.6exe4.txt\"), expected: \"No\" },\n     { actual: candidate(\"all.exe.txt\"), expected: \"No\" },\n     { actual: candidate(\"I563_No.exe\"), expected: \"Yes\" },\n     { actual: candidate(\"Is3youfault.txt\"), expected: \"Yes\" },\n     { actual: candidate(\"no_one#knows.dll\"), expected: \"Yes\" },\n     { actual: candidate(\"1I563_Yes3.exe\"), expected: \"No\" },\n     { actual: candidate(\"I563_Yes3.txtt\"), expected: \"No\" },\n     { actual: candidate(\"final..txt\"), expected: \"No\" },\n     { actual: candidate(\"final132\"), expected: \"No\" },\n     { actual: candidate(\"_f4indsartal132.\"), expected: \"No\" },\n     { actual: candidate(\".txt\"), expected: \"No\" },\n     { actual: candidate(\"s.\"), expected: \"No\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "go_test.go",
+    "prompt": "package sum_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// []int{1, 2, 3}\n// >>> lst\n// int{}\n// >>> lst\n// []int{-1, -5, 2, -1, -5}\nfunc sum_squares(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Squares(t *testing.T) {\n  candidate := sum_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{1, 4, 9}), expected: 14 },\n     { actual: candidate([]int{}), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 1, 1, 1, 1, 1, 1}), expected: 9 },\n     { actual: candidate([]int{-1, -1, -1, -1, -1, -1, -1, -1, -1}), expected: -3 },\n     { actual: candidate([]int{0}), expected: 0 },\n     { actual: candidate([]int{-1, -5, 2, -1, -5}), expected: -126 },\n     { actual: candidate([]int{-56, -99, 1, 0, -2}), expected: 3030 },\n     { actual: candidate([]int{-1, 0, 0, 0, 0, 0, 0, 0, -1}), expected: 0 },\n     { actual: candidate([]int{-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), expected: -14196 },\n     { actual: candidate([]int{-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), expected: -1448 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "go_test.go",
+    "prompt": "package words_in_sentence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunc words_in_sentence(sentence string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWords_In_Sentence(t *testing.T) {\n  candidate := words_in_sentence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"This is a test\"), expected: \"is\" },\n     { actual: candidate(\"lets go for swimming\"), expected: \"go for\" },\n     { actual: candidate(\"there is no place available here\"), expected: \"there is no place\" },\n     { actual: candidate(\"Hi I am Hussein\"), expected: \"Hi am Hussein\" },\n     { actual: candidate(\"go for it\"), expected: \"go for it\" },\n     { actual: candidate(\"here\"), expected: \"\" },\n     { actual: candidate(\"here is\"), expected: \"is\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "go_test.go",
+    "prompt": "package simplify_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunc simplify(x string, n string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSimplify(t *testing.T) {\n  candidate := simplify\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/6\", \"2/1\"), expected: false },\n     { actual: candidate(\"5/1\", \"3/1\"), expected: true },\n     { actual: candidate(\"7/10\", \"10/2\"), expected: false },\n     { actual: candidate(\"2/10\", \"50/10\"), expected: true },\n     { actual: candidate(\"7/2\", \"4/2\"), expected: true },\n     { actual: candidate(\"11/6\", \"6/1\"), expected: true },\n     { actual: candidate(\"2/3\", \"5/2\"), expected: false },\n     { actual: candidate(\"5/2\", \"3/5\"), expected: false },\n     { actual: candidate(\"2/4\", \"8/4\"), expected: true },\n     { actual: candidate(\"2/4\", \"4/2\"), expected: true },\n     { actual: candidate(\"1/5\", \"5/1\"), expected: true },\n     { actual: candidate(\"1/5\", \"1/5\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "go_test.go",
+    "prompt": "package order_by_points_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([]int{1, 11, -1, -11, -12})\n// []int{-1, -11, 1, -12, 11}\n// >>> order_by_points([]int{})\n// []int{}\nfunc order_by_points(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOrder_By_Points(t *testing.T) {\n  candidate := order_by_points\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 11, -1, -11, -12}), expected: []int{-1, -11, 1, -12, 11} },\n     { actual: candidate([]int{1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), expected: []int{0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, -11, -32, 43, 54, -98, 2, -3}), expected: []int{-3, -32, -98, -11, 1, 2, 43, 54} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), expected: []int{1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{0, 6, 6, -76, -21, 23, 4}), expected: []int{-76, -21, 0, 4, 23, 6, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2006,7 +648,7 @@
     "language": "go_test.go",
     "prompt": "package specialFilter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([]int{15, -73, 14, -15})\n// 1\n// >>> specialFilter([]int{33, -2, -3, 45, 21, 109})\n// 2\nfunc specialFilter(nums []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSpecialfilter(t *testing.T) {\n  candidate := specialFilter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, -2, 1, -5}), expected: 0 },\n     { actual: candidate([]int{15, -73, 14, -15}), expected: 1 },\n     { actual: candidate([]int{33, -2, -3, 45, 21, 109}), expected: 2 },\n     { actual: candidate([]int{43, -12, 93, 125, 121, 109}), expected: 4 },\n     { actual: candidate([]int{71, -2, -33, 75, 21, 19}), expected: 3 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2016,13 +658,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "go_test.go",
-    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
+    "prompt": "package get_max_triples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestGet_Max_Triples(t *testing.T) {\n  candidate := get_max_triples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 1 },\n     { actual: candidate(6), expected: 4 },\n     { actual: candidate(10), expected: 36 },\n     { actual: candidate(100), expected: 53361 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2030,13 +672,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "go_test.go",
-    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([]int{1, 2, 3, 2, 4})\n// []int{1, 3, 4}\nfunc remove_duplicates(numbers []int) []int {\n",
+    "prompt": "package bf_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// []interface{}{\"Saturn\", \"Uranus\"}\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"}\nfunc bf(planet1 string, planet2 string) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestBf(t *testing.T) {\n  candidate := bf\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jupiter\", \"Neptune\"), expected: []interface{}{\"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Mercury\"), expected: []interface{}{\"Venus\"} },\n     { actual: candidate(\"Mercury\", \"Uranus\"), expected: []interface{}{\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"} },\n     { actual: candidate(\"Neptune\", \"Venus\"), expected: []interface{}{\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"} },\n     { actual: candidate(\"Earth\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Mars\", \"Earth\"), expected: []interface{}{} },\n     { actual: candidate(\"Jupiter\", \"Makemake\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "go_test.go",
+    "prompt": "package sorted_list_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([]string{\"aa\", \"a\", \"aaa\"})\n// []string{\"aa\"}\n// >>> list_sort([]string{\"ab\", \"a\", \"aaa\", \"cd\"})\n// []string{\"ab\", \"cd\"}\nfunc sorted_list_sum(lst []string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSorted_List_Sum(t *testing.T) {\n  candidate := sorted_list_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"aa\", \"a\", \"aaa\"}), expected: []string{\"aa\"} },\n     { actual: candidate([]string{\"school\", \"AI\", \"asdf\", \"b\"}), expected: []string{\"AI\", \"asdf\", \"school\"} },\n     { actual: candidate([]string{\"d\", \"b\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"d\", \"dcba\", \"abcd\", \"a\"}), expected: []string{\"abcd\", \"dcba\"} },\n     { actual: candidate([]string{\"AI\", \"ai\", \"au\"}), expected: []string{\"AI\", \"ai\", \"au\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"}), expected: []string{} },\n     { actual: candidate([]string{\"aaaa\", \"bbbb\", \"dd\", \"cc\"}), expected: []string{\"cc\", \"dd\", \"aaaa\", \"bbbb\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "go_test.go",
+    "prompt": "package all_prefixes_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// []string{\"a\", \"ab\", \"abc\"}\nfunc all_prefixes(myString string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Prefixes(t *testing.T) {\n  candidate := all_prefixes\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []string{} },\n     { actual: candidate(\"asdfgh\"), expected: []string{\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"} },\n     { actual: candidate(\"WWW\"), expected: []string{\"W\", \"WW\", \"WWW\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "go_test.go",
+    "prompt": "package x_or_y_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunc x_or_y(n int, x int, y int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestX_Or_Y(t *testing.T) {\n  candidate := x_or_y\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 34, 12), expected: 34 },\n     { actual: candidate(15, 8, 5), expected: 5 },\n     { actual: candidate(3, 33, 5212), expected: 33 },\n     { actual: candidate(1259, 3, 52), expected: 3 },\n     { actual: candidate(7919, -1, 12), expected: -1 },\n     { actual: candidate(3609, 1245, 583), expected: 583 },\n     { actual: candidate(91, 56, 129), expected: 129 },\n     { actual: candidate(6, 34, 1234), expected: 1234 },\n     { actual: candidate(1, 2, 0), expected: 0 },\n     { actual: candidate(2, 2, 0), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "go_test.go",
+    "prompt": "package double_the_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([]int{1, 3, 2, 0})\n// 10\n// >>> double_the_difference([]int{-1, -2, 0})\n// 0\n// >>> double_the_difference([]int{9, -2})\n// 81\n// >>> double_the_difference([]int{0})\n// 0\n// If the input list is empty, return 0.\nfunc double_the_difference(lst []float64) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDouble_The_Difference(t *testing.T) {\n  candidate := double_the_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{}), expected: 0 },\n     { actual: candidate([]float64{5.0, 4.0}), expected: 25 },\n     { actual: candidate([]float64{0.1, 0.2, 0.3}), expected: 0 },\n     { actual: candidate([]float64{-10.0, -20.0, -30.0}), expected: 0 },\n     { actual: candidate([]float64{-1.0, -2.0, 8.0}), expected: 0 },\n     { actual: candidate([]float64{0.2, 3.0, 5.0}), expected: 34 },\n     { actual: candidate([]float64{-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), expected: 165 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "go_test.go",
+    "prompt": "package compare_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2})\n// []int{0, 0, 0, 0, 3, 3}\n// >>> compare([]int{0, 5, 0, 0, 0, 4}, []int{4, 1, 1, 0, 0, -2})\n// []int{4, 4, 1, 0, 0, 6}\nfunc compare(game []int, guess []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCompare(t *testing.T) {\n  candidate := compare\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 1}, []int{1, 2, 3, 4, 2, -2}), expected: []int{0, 0, 0, 0, 3, 3} },\n     { actual: candidate([]int{0, 0, 0, 0, 0, 0}, []int{0, 0, 0, 0, 0, 0}), expected: []int{0, 0, 0, 0, 0, 0} },\n     { actual: candidate([]int{1, 2, 3}, []int{-1, -2, -3}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{1, 2, 3, 5}, []int{-1, 2, 3, 4}), expected: []int{2, 0, 0, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "go_test.go",
+    "prompt": "package Strongest_Extension_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", []string{\"AA\", \"Be\", \"CC\"})\n// \"my_class.AA\"\nfunc Strongest_Extension(class_name string, extensions []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrongest_Extension(t *testing.T) {\n  candidate := Strongest_Extension\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Watashi\", []string{\"tEN\", \"niNE\", \"eIGHt8OKe\"}), expected: \"Watashi.eIGHt8OKe\" },\n     { actual: candidate(\"Boku123\", []string{\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"}), expected: \"Boku123.YEs.WeCaNe\" },\n     { actual: candidate(\"__YESIMHERE\", []string{\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"}), expected: \"__YESIMHERE.NuLl__\" },\n     { actual: candidate(\"K\", []string{\"Ta\", \"TAR\", \"t234An\", \"cosSo\"}), expected: \"K.TAR\" },\n     { actual: candidate(\"__HAHA\", []string{\"Tab\", \"123\", \"781345\", \"-_-\"}), expected: \"__HAHA.123\" },\n     { actual: candidate(\"YameRore\", []string{\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"}), expected: \"YameRore.okIWILL123\" },\n     { actual: candidate(\"finNNalLLly\", []string{\"Die\", \"NowW\", \"Wow\", \"WoW\"}), expected: \"finNNalLLly.WoW\" },\n     { actual: candidate(\"_\", []string{\"Bb\", \"91245\"}), expected: \"_.Bb\" },\n     { actual: candidate(\"Sp\", []string{\"671235\", \"Bb\"}), expected: \"Sp.671235\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "go_test.go",
+    "prompt": "package cycpattern_check_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunc cycpattern_check(a string, b string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCycpattern_Check(t *testing.T) {\n  candidate := cycpattern_check\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xyzw\", \"xyw\"), expected: false },\n     { actual: candidate(\"yello\", \"ell\"), expected: true },\n     { actual: candidate(\"whattup\", \"ptut\"), expected: false },\n     { actual: candidate(\"efef\", \"fee\"), expected: true },\n     { actual: candidate(\"abab\", \"aabb\"), expected: false },\n     { actual: candidate(\"winemtt\", \"tinem\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "go_test.go",
+    "prompt": "package even_odd_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// []interface{}{1, 1}\n// >>> even_odd_count(123)\n// []interface{}{1, 2}\nfunc even_odd_count(num int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Odd_Count(t *testing.T) {\n  candidate := even_odd_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: []interface{}{0, 1} },\n     { actual: candidate(-78), expected: []interface{}{1, 1} },\n     { actual: candidate(3452), expected: []interface{}{2, 2} },\n     { actual: candidate(346211), expected: []interface{}{3, 3} },\n     { actual: candidate(-345821), expected: []interface{}{3, 3} },\n     { actual: candidate(-2), expected: []interface{}{1, 0} },\n     { actual: candidate(-45347), expected: []interface{}{2, 3} },\n     { actual: candidate(0), expected: []interface{}{1, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "go_test.go",
+    "prompt": "package int_to_mini_roman_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunc int_to_mini_roman(number int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestInt_To_Mini_Roman(t *testing.T) {\n  candidate := int_to_mini_roman\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(19), expected: \"xix\" },\n     { actual: candidate(152), expected: \"clii\" },\n     { actual: candidate(251), expected: \"ccli\" },\n     { actual: candidate(426), expected: \"cdxxvi\" },\n     { actual: candidate(500), expected: \"d\" },\n     { actual: candidate(1), expected: \"i\" },\n     { actual: candidate(4), expected: \"iv\" },\n     { actual: candidate(43), expected: \"xliii\" },\n     { actual: candidate(90), expected: \"xc\" },\n     { actual: candidate(94), expected: \"xciv\" },\n     { actual: candidate(532), expected: \"dxxxii\" },\n     { actual: candidate(900), expected: \"cm\" },\n     { actual: candidate(994), expected: \"cmxciv\" },\n     { actual: candidate(1000), expected: \"m\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "go_test.go",
+    "prompt": "package right_angle_triangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunc right_angle_triangle(a int, b int, c int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRight_Angle_Triangle(t *testing.T) {\n  candidate := right_angle_triangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: true },\n     { actual: candidate(1, 2, 3), expected: false },\n     { actual: candidate(10, 6, 8), expected: true },\n     { actual: candidate(2, 2, 2), expected: false },\n     { actual: candidate(7, 24, 25), expected: true },\n     { actual: candidate(10, 5, 7), expected: false },\n     { actual: candidate(5, 12, 13), expected: true },\n     { actual: candidate(15, 8, 17), expected: true },\n     { actual: candidate(48, 55, 73), expected: true },\n     { actual: candidate(1, 1, 1), expected: false },\n     { actual: candidate(2, 2, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "go_test.go",
+    "prompt": "package find_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([]string{\"name\", \"of\", \"string\"})\n// \"string\"\n// >>> find_max([]string{\"name\", \"enam\", \"game\"})\n// \"enam\"\n// >>> find_max([]string{\"aaaaaaa\", \"bb\", \"cc\"})\n// \"aaaaaaa\"\nfunc find_max(words []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := find_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"name\", \"of\", \"string\"}), expected: \"string\" },\n     { actual: candidate([]string{\"name\", \"enam\", \"game\"}), expected: \"enam\" },\n     { actual: candidate([]string{\"aaaaaaa\", \"bb\", \"cc\"}), expected: \"aaaaaaa\" },\n     { actual: candidate([]string{\"abc\", \"cba\"}), expected: \"abc\" },\n     { actual: candidate([]string{\"play\", \"this\", \"game\", \"of\", \"footbott\"}), expected: \"footbott\" },\n     { actual: candidate([]string{\"we\", \"are\", \"gonna\", \"rock\"}), expected: \"gonna\" },\n     { actual: candidate([]string{\"we\", \"are\", \"a\", \"mad\", \"nation\"}), expected: \"nation\" },\n     { actual: candidate([]string{\"this\", \"is\", \"a\", \"prrk\"}), expected: \"this\" },\n     { actual: candidate([]string{\"b\"}), expected: \"b\" },\n     { actual: candidate([]string{\"play\", \"play\", \"play\"}), expected: \"play\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "go_test.go",
+    "prompt": "package eat_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// []int{11, 4}\n// >>> eat(4, 8, 9)\n// []int{12, 1}\n// >>> eat(1, 10, 10)\n// []int{11, 0}\n// >>> eat(2, 11, 5)\n// []int{7, 0}\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunc eat(number int, need int, remaining int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEat(t *testing.T) {\n  candidate := eat\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 6, 10), expected: []int{11, 4} },\n     { actual: candidate(4, 8, 9), expected: []int{12, 1} },\n     { actual: candidate(1, 10, 10), expected: []int{11, 0} },\n     { actual: candidate(2, 11, 5), expected: []int{7, 0} },\n     { actual: candidate(4, 5, 7), expected: []int{9, 2} },\n     { actual: candidate(4, 5, 1), expected: []int{5, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "go_test.go",
+    "prompt": "package string_sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunc string_sequence(n int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestString_Sequence(t *testing.T) {\n  candidate := string_sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"0\" },\n     { actual: candidate(3), expected: \"0 1 2 3\" },\n     { actual: candidate(10), expected: \"0 1 2 3 4 5 6 7 8 9 10\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "go_test.go",
+    "prompt": "package do_algebra_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator []string, operand []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDo_Algebra(t *testing.T) {\n  candidate := do_algebra\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"**\", \"*\", \"+\"}, []int{2, 3, 4, 5}), expected: 37 },\n     { actual: candidate([]string{\"+\", \"*\", \"-\"}, []int{2, 3, 4, 5}), expected: 9 },\n     { actual: candidate([]string{\"//\", \"*\"}, []int{7, 3, 4}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunc solve(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AsDf\"), expected: \"aSdF\" },\n     { actual: candidate(\"1234\"), expected: \"4321\" },\n     { actual: candidate(\"ab\"), expected: \"AB\" },\n     { actual: candidate(\"#a@C\"), expected: \"#A@c\" },\n     { actual: candidate(\"#AsdfW^45\"), expected: \"#aSDFw^45\" },\n     { actual: candidate(\"#6@2\"), expected: \"2@6#\" },\n     { actual: candidate(\"#$a^D\"), expected: \"#$A^d\" },\n     { actual: candidate(\"#ccc\"), expected: \"#CCC\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2048,7 +900,7 @@
     "language": "go_test.go",
     "prompt": "package generate_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// []int{2, 4, 6, 8}\n// >>> generate_integers(8, 2)\n// []int{2, 4, 6, 8}\n// >>> generate_integers(10, 14)\n// []int{}\nfunc generate_integers(a int, b int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestGenerate_Integers(t *testing.T) {\n  candidate := generate_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 10), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(10, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(132, 2), expected: []int{2, 4, 6, 8} },\n     { actual: candidate(17, 89), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -2058,13 +910,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "go_test.go",
-    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([]int{1, 2, 3, 2, 3, 4, 2})\n// []int{1, 2, 3, 3, 3, 4, 4}\nfunc rolling_max(numbers []int) []int {\n",
+    "prompt": "package count_distinct_characters_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunc count_distinct_characters(myString string) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount_Distinct_Characters(t *testing.T) {\n  candidate := count_distinct_characters\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abcde\"), expected: 5 },\n     { actual: candidate(\"abcdecadeCADE\"), expected: 5 },\n     { actual: candidate(\"aaaaAAAAaaaa\"), expected: 1 },\n     { actual: candidate(\"Jerry jERRY JeRRRY\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2072,13 +924,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "go_test.go",
-    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([]int{1, 2, 3})\n// false\n// >>> below_zero([]int{1, 2, -4, 5})\n// true\nfunc below_zero(operations []int) bool {\n",
+    "prompt": "package parse_music_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// []int{4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nfunc parse_music(music_string string) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestParse_Music(t *testing.T) {\n  candidate := parse_music\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: []int{} },\n     { actual: candidate(\"o o o o\"), expected: []int{4, 4, 4, 4} },\n     { actual: candidate(\".| .| .| .|\"), expected: []int{1, 1, 1, 1} },\n     { actual: candidate(\"o| o| .| .| o o o o\"), expected: []int{2, 2, 1, 1, 4, 4, 4, 4} },\n     { actual: candidate(\"o| .| o| .| o o| o o|\"), expected: []int{2, 1, 2, 1, 4, 2, 4, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2086,13 +938,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "go_test.go",
-    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([]int{4, 1, 2, 2, 3, 1})\n// 2\n// >>> search([]int{1, 2, 2, 3, 3, 3, 4, 4, 4})\n// 3\n// >>> search([]int{5, 5, 4, 4, 4})\n// -1\nfunc search(lst []int) int {\n",
+    "prompt": "package how_many_times_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunc how_many_times(myString string, substring string) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestHow_Many_Times(t *testing.T) {\n  candidate := how_many_times\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\", \"x\"), expected: 0 },\n     { actual: candidate(\"xyxyxyx\", \"x\"), expected: 4 },\n     { actual: candidate(\"cacacacac\", \"cac\"), expected: 4 },\n     { actual: candidate(\"john doe\", \"john\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2100,13 +952,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "go_test.go",
-    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
+    "prompt": "package sort_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunc sort_numbers(numbers string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Numbers(t *testing.T) {\n  candidate := sort_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"three\"), expected: \"three\" },\n     { actual: candidate(\"three five nine\"), expected: \"three five nine\" },\n     { actual: candidate(\"five zero four seven nine eight\"), expected: \"zero four five seven eight nine\" },\n     { actual: candidate(\"six five four three two one zero\"), expected: \"zero one two three four five six\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "go_test.go",
+    "prompt": "package separate_paren_groups_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// []string{\"()\", \"(())\", \"(()())\"}\nfunc separate_paren_groups(paren_string string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSeparate_Paren_Groups(t *testing.T) {\n  candidate := separate_paren_groups\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []string{\"(()())\", \"((()))\", \"()\", \"((())()())\"} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []string{\"()\", \"(())\", \"((()))\", \"(((())))\"} },\n     { actual: candidate(\"(()(())((())))\"), expected: []string{\"(()(())((())))\"} },\n     { actual: candidate(\"( ) (( )) (( )( ))\"), expected: []string{\"()\", \"(())\", \"(()())\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "go_test.go",
+    "prompt": "package find_closest_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n// []interface{}{2.0, 2.2}\n// >>> find_closest_elements([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n// []interface{}{2.0, 2.0}\nfunc find_closest_elements(numbers []float64) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Closest_Elements(t *testing.T) {\n  candidate := find_closest_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), expected: []interface{}{3.9, 4.0} },\n     { actual: candidate([]float64{1.0, 2.0, 5.9, 4.0, 5.0}), expected: []interface{}{5.0, 5.9} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), expected: []interface{}{2.0, 2.2} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), expected: []interface{}{2.0, 2.0} },\n     { actual: candidate([]float64{1.1, 2.2, 3.1, 4.1, 5.1}), expected: []interface{}{2.2, 3.1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "go_test.go",
+    "prompt": "package rescale_to_unit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([]float64{1.0, 2.0, 3.0, 4.0, 5.0})\n// []float64{0.0, 0.25, 0.5, 0.75, 1.0}\nfunc rescale_to_unit(numbers []float64) []float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRescale_To_Unit(t *testing.T) {\n  candidate := rescale_to_unit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{2.0, 49.9}), expected: []float64{0.0, 1.0} },\n     { actual: candidate([]float64{100.0, 49.9}), expected: []float64{1.0, 0.0} },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: []float64{0.0, 0.25, 0.5, 0.75, 1.0} },\n     { actual: candidate([]float64{2.0, 1.0, 5.0, 3.0, 4.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n     { actual: candidate([]float64{12.0, 11.0, 15.0, 13.0, 14.0}), expected: []float64{0.25, 0.0, 1.0, 0.5, 0.75} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "go_test.go",
+    "prompt": "package filter_integers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter given list of any python values only for integers\n// >>> filter_integers([]float64{\"a\", 3.14, 5})\n// []int{5}\n// >>> filter_integers([]interface{}{1, 2, 3, \"abc\", map[interface{}]interface{}{}, []interface{}{}})\n// []int{1, 2, 3}\nfunc filter_integers(values []interface{}) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_Integers(t *testing.T) {\n  candidate := filter_integers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{}), expected: []int{} },\n     { actual: candidate([]interface{}{4, map[interface{}]interface{}{}, []interface{}{}, 23.2, 9, \"adasd\"}), expected: []int{4, 9} },\n     { actual: candidate([]interface{}{3, \"c\", 3, 3, \"a\", \"b\"}), expected: []int{3, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "go_test.go",
+    "prompt": "package strlen_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunc strlen(myString string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrlen(t *testing.T) {\n  candidate := strlen\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"x\"), expected: 1 },\n     { actual: candidate(\"asdasnakj\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "go_test.go",
+    "prompt": "package largest_divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunc largest_divisor(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Divisor(t *testing.T) {\n  candidate := largest_divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 1 },\n     { actual: candidate(7), expected: 1 },\n     { actual: candidate(10), expected: 5 },\n     { actual: candidate(100), expected: 50 },\n     { actual: candidate(49), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "go_test.go",
+    "prompt": "package factorize_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// []int{2, 2, 2}\n// >>> factorize(25)\n// []int{5, 5}\n// >>> factorize(70)\n// []int{2, 5, 7}\nfunc factorize(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFactorize(t *testing.T) {\n  candidate := factorize\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: []int{2} },\n     { actual: candidate(4), expected: []int{2, 2} },\n     { actual: candidate(8), expected: []int{2, 2, 2} },\n     { actual: candidate(57), expected: []int{3, 19} },\n     { actual: candidate(3249), expected: []int{3, 3, 19, 19} },\n     { actual: candidate(185193), expected: []int{3, 3, 3, 19, 19, 19} },\n     { actual: candidate(20577), expected: []int{3, 19, 19, 19} },\n     { actual: candidate(18), expected: []int{2, 3, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "go_test.go",
+    "prompt": "package remove_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([]int{1, 2, 3, 2, 4})\n// []int{1, 3, 4}\nfunc remove_duplicates(numbers []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Duplicates(t *testing.T) {\n  candidate := remove_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 3, 5}), expected: []int{1, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "go_test.go",
+    "prompt": "package flip_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunc flip_case(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFlip_Case(t *testing.T) {\n  candidate := flip_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hello!\"), expected: \"hELLO!\" },\n     { actual: candidate(\"These violent delights have violent ends\"), expected: \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "go_test.go",
+    "prompt": "package concatenate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Concatenate list of strings into a single string\n// >>> concatenate([]string{})\n// \"\"\n// >>> concatenate([]string{\"a\", \"b\", \"c\"})\n// \"abc\"\nfunc concatenate(strings []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConcatenate(t *testing.T) {\n  candidate := concatenate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}), expected: \"\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\"}), expected: \"xyz\" },\n     { actual: candidate([]string{\"x\", \"y\", \"z\", \"w\", \"k\"}), expected: \"xyzwk\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "go_test.go",
+    "prompt": "package filter_by_prefix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([]string{}, \"a\")\n// []string{}\n// >>> filter_by_prefix([]string{\"abc\", \"bcd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"array\"}\nfunc filter_by_prefix(strings []string, prefix string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Prefix(t *testing.T) {\n  candidate := filter_by_prefix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "go_test.go",
+    "prompt": "package truncate_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunc truncate_number(number float64) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTruncate_Number(t *testing.T) {\n  candidate := truncate_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3.5), expected: 0.5 },\n     { actual: candidate(1.25), expected: 0.25 },\n     { actual: candidate(123.0), expected: 0.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "go_test.go",
+    "prompt": "package get_positive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return only positive numbers in the list.\n// >>> get_positive([]int{-1, 2, -4, 5, 6})\n// []int{2, 5, 6}\n// >>> get_positive([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// []int{5, 3, 2, 3, 9, 123, 1}\nfunc get_positive(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Positive(t *testing.T) {\n  candidate := get_positive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, -2, 4, 5, 6}), expected: []int{4, 5, 6} },\n     { actual: candidate([]int{5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), expected: []int{5, 3, 2, 3, 3, 9, 123, 1} },\n     { actual: candidate([]int{-1, -2}), expected: []int{} },\n     { actual: candidate([]int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "go_test.go",
+    "prompt": "package is_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunc is_prime(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Prime(t *testing.T) {\n  candidate := is_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: false },\n     { actual: candidate(101), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(13441), expected: true },\n     { actual: candidate(61), expected: true },\n     { actual: candidate(4), expected: false },\n     { actual: candidate(1), expected: false },\n     { actual: candidate(5), expected: true },\n     { actual: candidate(11), expected: true },\n     { actual: candidate(17), expected: true },\n     { actual: candidate(85), expected: false },\n     { actual: candidate(77), expected: false },\n     { actual: candidate(255379), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "go_test.go",
+    "prompt": "package sort_third_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_third([]int{5, 6, 3, 4, 8, 9, 2})\n// []int{2, 6, 3, 4, 8, 9, 5}\nfunc sort_third(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Third(t *testing.T) {\n  candidate := sort_third\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2}), expected: []int{2, 6, 3, 4, 8, 9, 5} },\n     { actual: candidate([]int{5, 8, 3, 4, 6, 9, 2}), expected: []int{2, 8, 3, 4, 6, 9, 5} },\n     { actual: candidate([]int{5, 6, 9, 4, 8, 3, 2}), expected: []int{2, 6, 9, 4, 8, 3, 5} },\n     { actual: candidate([]int{5, 6, 3, 4, 8, 9, 2, 1}), expected: []int{2, 6, 3, 4, 8, 9, 5, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "go_test.go",
+    "prompt": "package unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique elements in a list\n// >>> unique([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{0, 2, 3, 5, 9, 123}\nfunc unique(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnique(t *testing.T) {\n  candidate := unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 3, 5, 2, 3, 3, 9, 0, 123}), expected: []int{0, 2, 3, 5, 9, 123} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "go_test.go",
+    "prompt": "package max_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return maximum element in the list.\n// >>> max_element([]int{1, 2, 3})\n// 3\n// >>> max_element([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n// 123\nfunc max_element(l []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Element(t *testing.T) {\n  candidate := max_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "go_test.go",
+    "prompt": "package fizz_buzz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunc fizz_buzz(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFizz_Buzz(t *testing.T) {\n  candidate := fizz_buzz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(50), expected: 0 },\n     { actual: candidate(78), expected: 2 },\n     { actual: candidate(79), expected: 3 },\n     { actual: candidate(100), expected: 3 },\n     { actual: candidate(200), expected: 6 },\n     { actual: candidate(4000), expected: 192 },\n     { actual: candidate(10000), expected: 639 },\n     { actual: candidate(100000), expected: 8026 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2118,9 +1222,233 @@
     "language": "go_test.go",
     "prompt": "package sort_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([]int{1, 2, 3})\n// []int{1, 2, 3}\n// >>> sort_even([]int{5, 6, 3, 4})\n// []int{3, 6, 5, 4}\nfunc sort_even(l []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSort_Even(t *testing.T) {\n  candidate := sort_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{1, 2, 3} },\n     { actual: candidate([]int{5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), expected: []int{-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123} },\n     { actual: candidate([]int{5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), expected: []int{-12, 8, 3, 4, 5, 2, 12, 11, 23, -10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "go_test.go",
+    "prompt": "package prime_fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunc prime_fib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Fib(t *testing.T) {\n  candidate := prime_fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 2 },\n     { actual: candidate(2), expected: 3 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 13 },\n     { actual: candidate(5), expected: 89 },\n     { actual: candidate(6), expected: 233 },\n     { actual: candidate(7), expected: 1597 },\n     { actual: candidate(8), expected: 28657 },\n     { actual: candidate(9), expected: 514229 },\n     { actual: candidate(10), expected: 433494437 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "go_test.go",
+    "prompt": "package below_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([]int{1, 2, 3})\n// false\n// >>> below_zero([]int{1, 2, -4, 5})\n// true\nfunc below_zero(operations []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Zero(t *testing.T) {\n  candidate := below_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: false },\n     { actual: candidate([]int{1, 2, -3, 1, 2, -3}), expected: false },\n     { actual: candidate([]int{1, 2, -4, 5, 6}), expected: true },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -4}), expected: false },\n     { actual: candidate([]int{1, -1, 2, -2, 5, -5, 4, -5}), expected: true },\n     { actual: candidate([]int{1, -2, 2, -2, 5, -5, 4, -4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package triples_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> triples_sum_to_zero([]int{1, 3, -2, 1})\n// true\n// >>> triples_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> triples_sum_to_zero([]int{2, 4, -5, 3, 9, 7})\n// true\n// >>> triples_sum_to_zero([]int{1})\n// false\nfunc triples_sum_to_zero(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriples_Sum_To_Zero(t *testing.T) {\n  candidate := triples_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -1}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{1, 2, 5, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 9, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{1, 3, 5, -100}), expected: false },\n     { actual: candidate([]int{100, 3, 5, -100}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "go_test.go",
+    "prompt": "package car_race_collision_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunc car_race_collision(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCar_Race_Collision(t *testing.T) {\n  candidate := car_race_collision\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 9 },\n     { actual: candidate(4), expected: 16 },\n     { actual: candidate(8), expected: 64 },\n     { actual: candidate(10), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "go_test.go",
+    "prompt": "package incr_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return list with elements incremented by 1.\n// >>> incr_list([]int{1, 2, 3})\n// []int{2, 3, 4}\n// >>> incr_list([]int{5, 3, 5, 2, 3, 3, 9, 0, 123})\n// []int{6, 4, 6, 3, 4, 4, 10, 1, 124}\nfunc incr_list(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIncr_List(t *testing.T) {\n  candidate := incr_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{4, 3, 2} },\n     { actual: candidate([]int{5, 2, 5, 2, 3, 3, 9, 0, 123}), expected: []int{6, 3, 6, 3, 4, 4, 10, 1, 124} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "go_test.go",
+    "prompt": "package pairs_sum_to_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([]int{1, 3, 5, 0})\n// false\n// >>> pairs_sum_to_zero([]int{1, 3, -2, 1})\n// false\n// >>> pairs_sum_to_zero([]int{1, 2, 3, 7})\n// false\n// >>> pairs_sum_to_zero([]int{2, 4, -5, 3, 5, 7})\n// true\n// >>> pairs_sum_to_zero([]int{1})\n// false\nfunc pairs_sum_to_zero(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPairs_Sum_To_Zero(t *testing.T) {\n  candidate := pairs_sum_to_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 0}), expected: false },\n     { actual: candidate([]int{1, 3, -2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, -5, 3, 5, 7}), expected: true },\n     { actual: candidate([]int{1}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 30}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 3, 2, 31}), expected: true },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 30}), expected: false },\n     { actual: candidate([]int{-3, 9, -1, 4, 2, 31}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "go_test.go",
+    "prompt": "package change_base_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunc change_base(x int, base int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestChange_Base(t *testing.T) {\n  candidate := change_base\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8, 3), expected: \"22\" },\n     { actual: candidate(9, 3), expected: \"100\" },\n     { actual: candidate(234, 2), expected: \"11101010\" },\n     { actual: candidate(16, 2), expected: \"10000\" },\n     { actual: candidate(8, 2), expected: \"1000\" },\n     { actual: candidate(7, 2), expected: \"111\" },\n     { actual: candidate(2, 3), expected: \"2\" },\n     { actual: candidate(3, 4), expected: \"3\" },\n     { actual: candidate(4, 5), expected: \"4\" },\n     { actual: candidate(5, 6), expected: \"5\" },\n     { actual: candidate(6, 7), expected: \"6\" },\n     { actual: candidate(7, 8), expected: \"7\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunc triangle_area(a int, h int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3), expected: 7.5 },\n     { actual: candidate(2, 2), expected: 2.0 },\n     { actual: candidate(10, 8), expected: 40.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "go_test.go",
+    "prompt": "package fib4_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunc fib4(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib4(t *testing.T) {\n  candidate := fib4\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 28 },\n     { actual: candidate(10), expected: 104 },\n     { actual: candidate(12), expected: 386 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "go_test.go",
+    "prompt": "package median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return median of elements in the list l.\n// >>> median([]int{3, 1, 2, 4, 5})\n// 3\n// >>> median([]int{-10, 4, 6, 1000, 10, 20})\n// 15.0\nfunc median(l []int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMedian(t *testing.T) {\n  candidate := median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: 3 },\n     { actual: candidate([]int{-10, 4, 6, 1000, 10, 20}), expected: 8.0 },\n     { actual: candidate([]int{5}), expected: 5 },\n     { actual: candidate([]int{6, 5}), expected: 5.5 },\n     { actual: candidate([]int{8, 1, 3, 9, 9, 2, 7}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "go_test.go",
+    "prompt": "package is_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunc is_palindrome(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Palindrome(t *testing.T) {\n  candidate := is_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: true },\n     { actual: candidate(\"aba\"), expected: true },\n     { actual: candidate(\"aaaaa\"), expected: true },\n     { actual: candidate(\"zbcd\"), expected: false },\n     { actual: candidate(\"xywyx\"), expected: true },\n     { actual: candidate(\"xywyz\"), expected: false },\n     { actual: candidate(\"xywzx\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "go_test.go",
+    "prompt": "package modp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunc modp(n int, p int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestModp(t *testing.T) {\n  candidate := modp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 5), expected: 3 },\n     { actual: candidate(1101, 101), expected: 2 },\n     { actual: candidate(0, 101), expected: 1 },\n     { actual: candidate(3, 11), expected: 8 },\n     { actual: candidate(100, 101), expected: 1 },\n     { actual: candidate(30, 5), expected: 4 },\n     { actual: candidate(31, 5), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "go_test.go",
+    "prompt": "package mean_absolute_deviation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([]float64{1.0, 2.0, 3.0, 4.0})\n// 1.0\nfunc mean_absolute_deviation(numbers []float64) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMean_Absolute_Deviation(t *testing.T) {\n  candidate := mean_absolute_deviation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{1.0, 2.0}), expected: 0.5 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0}), expected: 1.0 },\n     { actual: candidate([]float64{1.0, 2.0, 3.0, 4.0, 5.0}), expected: 1.2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "go_test.go",
+    "prompt": "package remove_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunc remove_vowels(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Vowels(t *testing.T) {\n  candidate := remove_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"abcdef\\nghijklm\"), expected: \"bcdf\\nghjklm\" },\n     { actual: candidate(\"fedcba\"), expected: \"fdcb\" },\n     { actual: candidate(\"eeeee\"), expected: \"\" },\n     { actual: candidate(\"acBAA\"), expected: \"cB\" },\n     { actual: candidate(\"EcBOO\"), expected: \"cB\" },\n     { actual: candidate(\"ybcd\"), expected: \"ybcd\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "go_test.go",
+    "prompt": "package below_threshold_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([]int{1, 2, 4, 10}, 100)\n// true\n// >>> below_threshold([]int{1, 20, 4, 10}, 5)\n// false\nfunc below_threshold(l []int, t int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBelow_Threshold(t *testing.T) {\n  candidate := below_threshold\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}, 100), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 5), expected: false },\n     { actual: candidate([]int{1, 20, 4, 10}, 21), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}, 22), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 11), expected: true },\n     { actual: candidate([]int{1, 8, 4, 10}, 10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunc add(x int, y int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0, 1), expected: 1 },\n     { actual: candidate(1, 0), expected: 1 },\n     { actual: candidate(2, 3), expected: 5 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 5), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2132,9 +1460,23 @@
     "language": "go_test.go",
     "prompt": "package same_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunc same_chars(s0 string, s1 string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSame_Chars(t *testing.T) {\n  candidate := same_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"), expected: true },\n     { actual: candidate(\"abcd\", \"dddddddabc\"), expected: true },\n     { actual: candidate(\"dddddddabc\", \"abcd\"), expected: true },\n     { actual: candidate(\"eabcd\", \"dddddddabc\"), expected: false },\n     { actual: candidate(\"abcd\", \"dddddddabcf\"), expected: false },\n     { actual: candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"), expected: false },\n     { actual: candidate(\"aabb\", \"aaccc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "go_test.go",
+    "prompt": "package fib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunc fib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFib(t *testing.T) {\n  candidate := fib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 55 },\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(8), expected: 21 },\n     { actual: candidate(11), expected: 89 },\n     { actual: candidate(12), expected: 144 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -2146,9 +1488,667 @@
     "language": "go_test.go",
     "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"<>\"), expected: true },\n     { actual: candidate(\"<<><>>\"), expected: true },\n     { actual: candidate(\"<><><<><>><>\"), expected: true },\n     { actual: candidate(\"<><><<<><><>><>><<><><<>>>\"), expected: true },\n     { actual: candidate(\"<<<><>>>>\"), expected: false },\n     { actual: candidate(\"><<>\"), expected: false },\n     { actual: candidate(\"<\"), expected: false },\n     { actual: candidate(\"<<<<\"), expected: false },\n     { actual: candidate(\">\"), expected: false },\n     { actual: candidate(\"<<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>><<>\"), expected: false },\n     { actual: candidate(\"<><><<><>><>>><>\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "go_test.go",
+    "prompt": "package monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([]int{1, 2, 4, 20})\n// true\n// >>> monotonic([]int{1, 20, 4, 10})\n// false\n// >>> monotonic([]int{4, 1, 0, -10})\n// true\nfunc monotonic(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMonotonic(t *testing.T) {\n  candidate := monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 10}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 20}), expected: true },\n     { actual: candidate([]int{1, 20, 4, 10}), expected: false },\n     { actual: candidate([]int{4, 1, 0, -10}), expected: true },\n     { actual: candidate([]int{4, 1, 1, 0}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 2, 5, 60}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 60}), expected: true },\n     { actual: candidate([]int{9, 9, 9, 9}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "go_test.go",
+    "prompt": "package common_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return sorted unique common elements for two lists.\n// >>> common([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121})\n// []int{1, 5, 653}\n// >>> common([]int{5, 3, 2, 8}, []int{3, 2})\n// []int{2, 3}\nfunc common(l1 []int, l2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCommon(t *testing.T) {\n  candidate := common\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 34, 653, 2, 5}, []int{5, 7, 1, 5, 9, 653, 121}), expected: []int{1, 5, 653} },\n     { actual: candidate([]int{5, 3, 2, 8}, []int{3, 2}), expected: []int{2, 3} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{3, 2, 4}), expected: []int{2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 8}, []int{}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "go_test.go",
+    "prompt": "package largest_prime_factor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunc largest_prime_factor(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Prime_Factor(t *testing.T) {\n  candidate := largest_prime_factor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 5 },\n     { actual: candidate(27), expected: 3 },\n     { actual: candidate(63), expected: 7 },\n     { actual: candidate(330), expected: 11 },\n     { actual: candidate(13195), expected: 29 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "go_test.go",
+    "prompt": "package intersperse_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([]int{}, 4)\n// []int{}\n// >>> intersperse([]int{1, 2, 3}, 4)\n// []int{1, 4, 2, 4, 3}\nfunc intersperse(numbers []int, delimeter int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersperse(t *testing.T) {\n  candidate := intersperse\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}, 7), expected: []int{} },\n     { actual: candidate([]int{5, 6, 3, 2}, 8), expected: []int{5, 8, 6, 8, 3, 8, 2} },\n     { actual: candidate([]int{2, 2, 2}, 2), expected: []int{2, 2, 2, 2, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "go_test.go",
+    "prompt": "package sum_to_n_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunc sum_to_n(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_To_N(t *testing.T) {\n  candidate := sum_to_n\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(6), expected: 21 },\n     { actual: candidate(11), expected: 66 },\n     { actual: candidate(30), expected: 465 },\n     { actual: candidate(100), expected: 5050 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "go_test.go",
+    "prompt": "package correct_bracketing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunc correct_bracketing(brackets string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCorrect_Bracketing(t *testing.T) {\n  candidate := correct_bracketing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"()\"), expected: true },\n     { actual: candidate(\"(()())\"), expected: true },\n     { actual: candidate(\"()()(()())()\"), expected: true },\n     { actual: candidate(\"()()((()()())())(()()(()))\"), expected: true },\n     { actual: candidate(\"((()())))\"), expected: false },\n     { actual: candidate(\")(()\"), expected: false },\n     { actual: candidate(\"(\"), expected: false },\n     { actual: candidate(\"((((\"), expected: false },\n     { actual: candidate(\")\"), expected: false },\n     { actual: candidate(\"(()\"), expected: false },\n     { actual: candidate(\"()()(()())())(()\"), expected: false },\n     { actual: candidate(\"()()(()())()))()\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "go_test.go",
+    "prompt": "package derivative_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([]int{3, 1, 2, 4, 5})\n// []int{1, 4, 12, 20}\n// >>> derivative([]int{1, 2, 3})\n// []int{2, 6}\nfunc derivative(xs []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDerivative(t *testing.T) {\n  candidate := derivative\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 1, 2, 4, 5}), expected: []int{1, 4, 12, 20} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 6} },\n     { actual: candidate([]int{3, 2, 1}), expected: []int{2, 2} },\n     { actual: candidate([]int{3, 2, 1, 0, 4}), expected: []int{2, 2, 0, 16} },\n     { actual: candidate([]int{1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "go_test.go",
+    "prompt": "package fibfib_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunc fibfib(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFibfib(t *testing.T) {\n  candidate := fibfib\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(1), expected: 0 },\n     { actual: candidate(5), expected: 4 },\n     { actual: candidate(8), expected: 24 },\n     { actual: candidate(10), expected: 81 },\n     { actual: candidate(12), expected: 274 },\n     { actual: candidate(14), expected: 927 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "go_test.go",
+    "prompt": "package vowels_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunc vowels_count(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestVowels_Count(t *testing.T) {\n  candidate := vowels_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcde\"), expected: 2 },\n     { actual: candidate(\"Alone\"), expected: 3 },\n     { actual: candidate(\"key\"), expected: 2 },\n     { actual: candidate(\"bye\"), expected: 1 },\n     { actual: candidate(\"keY\"), expected: 2 },\n     { actual: candidate(\"bYe\"), expected: 1 },\n     { actual: candidate(\"ACEDY\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "go_test.go",
+    "prompt": "package circular_shift_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunc circular_shift(x int, shift int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCircular_Shift(t *testing.T) {\n  candidate := circular_shift\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(100, 2), expected: \"001\" },\n     { actual: candidate(12, 2), expected: \"12\" },\n     { actual: candidate(97, 8), expected: \"79\" },\n     { actual: candidate(12, 1), expected: \"21\" },\n     { actual: candidate(11, 101), expected: \"11\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "go_test.go",
+    "prompt": "package digitSum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunc digitSum(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigitsum(t *testing.T) {\n  candidate := digitSum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"abAB\"), expected: 131 },\n     { actual: candidate(\"abcCd\"), expected: 67 },\n     { actual: candidate(\"helloE\"), expected: 69 },\n     { actual: candidate(\"woArBld\"), expected: 131 },\n     { actual: candidate(\"aAaaaXa\"), expected: 153 },\n     { actual: candidate(\" How are yOu?\"), expected: 151 },\n     { actual: candidate(\"You arE Very Smart\"), expected: 327 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "go_test.go",
+    "prompt": "package fruit_distribution_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunc fruit_distribution(s string, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFruit_Distribution(t *testing.T) {\n  candidate := fruit_distribution\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"5 apples and 6 oranges\", 19), expected: 8 },\n     { actual: candidate(\"5 apples and 6 oranges\", 21), expected: 10 },\n     { actual: candidate(\"0 apples and 1 oranges\", 3), expected: 2 },\n     { actual: candidate(\"1 apples and 0 oranges\", 3), expected: 2 },\n     { actual: candidate(\"2 apples and 3 oranges\", 100), expected: 95 },\n     { actual: candidate(\"2 apples and 3 oranges\", 5), expected: 0 },\n     { actual: candidate(\"1 apples and 100 oranges\", 120), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "go_test.go",
+    "prompt": "package pluck_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([]int{4, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([]int{1, 2, 3})\n// []int{2, 1}\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([]int{})\n// []int{}\n// Example 4:\n// >>> pluck([]int{5, 0, 3, 0, 4, 2})\n// []int{0, 1}\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunc pluck(arr []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPluck(t *testing.T) {\n  candidate := pluck\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2, 1} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5, 0, 3, 0, 4, 2}), expected: []int{0, 1} },\n     { actual: candidate([]int{1, 2, 3, 0, 5, 3}), expected: []int{0, 3} },\n     { actual: candidate([]int{5, 4, 8, 4, 8}), expected: []int{4, 1} },\n     { actual: candidate([]int{7, 6, 7, 1}), expected: []int{6, 1} },\n     { actual: candidate([]int{7, 9, 7, 1}), expected: []int{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "go_test.go",
+    "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([]int{4, 1, 2, 2, 3, 1})\n// 2\n// >>> search([]int{1, 2, 2, 3, 3, 3, 4, 4, 4})\n// 3\n// >>> search([]int{5, 5, 4, 4, 4})\n// -1\nfunc search(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 5, 5, 5, 1}), expected: 1 },\n     { actual: candidate([]int{4, 1, 4, 1, 4, 4}), expected: 4 },\n     { actual: candidate([]int{3, 3}), expected: -1 },\n     { actual: candidate([]int{8, 8, 8, 8, 8, 8, 8, 8}), expected: 8 },\n     { actual: candidate([]int{2, 3, 3, 2, 2}), expected: 2 },\n     { actual: candidate([]int{2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), expected: 1 },\n     { actual: candidate([]int{3, 2, 8, 2}), expected: 2 },\n     { actual: candidate([]int{6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), expected: 1 },\n     { actual: candidate([]int{8, 8, 3, 6, 5, 6, 4}), expected: -1 },\n     { actual: candidate([]int{6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), expected: 1 },\n     { actual: candidate([]int{1, 9, 10, 1, 3}), expected: 1 },\n     { actual: candidate([]int{6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), expected: 5 },\n     { actual: candidate([]int{1}), expected: 1 },\n     { actual: candidate([]int{8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), expected: 4 },\n     { actual: candidate([]int{2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), expected: 2 },\n     { actual: candidate([]int{1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), expected: 1 },\n     { actual: candidate([]int{9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), expected: 4 },\n     { actual: candidate([]int{2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), expected: 4 },\n     { actual: candidate([]int{9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), expected: 2 },\n     { actual: candidate([]int{5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), expected: -1 },\n     { actual: candidate([]int{10}), expected: -1 },\n     { actual: candidate([]int{9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), expected: 2 },\n     { actual: candidate([]int{5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), expected: 1 },\n     { actual: candidate([]int{7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), expected: 1 },\n     { actual: candidate([]int{3, 10, 10, 9, 2}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "go_test.go",
+    "prompt": "package parse_nested_parens_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// []int{2, 3, 1, 3}\nfunc parse_nested_parens(paren_string string) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestParse_Nested_Parens(t *testing.T) {\n  candidate := parse_nested_parens\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(()()) ((())) () ((())()())\"), expected: []int{2, 3, 1, 3} },\n     { actual: candidate(\"() (()) ((())) (((())))\"), expected: []int{1, 2, 3, 4} },\n     { actual: candidate(\"(()(())((())))\"), expected: []int{4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "go_test.go",
+    "prompt": "package strange_sort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([]int{1, 2, 3, 4})\n// []int{1, 4, 2, 3}\n// >>> strange_sort_list([]int{5, 5, 5, 5})\n// []int{5, 5, 5, 5}\n// >>> strange_sort_list([]int{})\n// []int{}\nfunc strange_sort_list(lst []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStrange_Sort_List(t *testing.T) {\n  candidate := strange_sort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 4, 2, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9}), expected: []int{5, 9, 6, 8, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 5, 2, 4, 3} },\n     { actual: candidate([]int{5, 6, 7, 8, 9, 1}), expected: []int{1, 9, 5, 8, 6, 7} },\n     { actual: candidate([]int{5, 5, 5, 5}), expected: []int{5, 5, 5, 5} },\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}), expected: []int{1, 8, 2, 7, 3, 6, 4, 5} },\n     { actual: candidate([]int{0, 2, 2, 2, 5, 5, -5, -5}), expected: []int{-5, 5, -5, 5, 0, 2, 2, 2} },\n     { actual: candidate([]int{111111}), expected: []int{111111} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "go_test.go",
+    "prompt": "package triangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunc triangle_area(a int, b int, c int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTriangle_Area(t *testing.T) {\n  candidate := triangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4, 5), expected: 6.0 },\n     { actual: candidate(1, 2, 10), expected: -1 },\n     { actual: candidate(4, 8, 5), expected: 8.18 },\n     { actual: candidate(2, 2, 2), expected: 1.73 },\n     { actual: candidate(1, 2, 3), expected: -1 },\n     { actual: candidate(10, 5, 7), expected: 16.25 },\n     { actual: candidate(2, 6, 3), expected: -1 },\n     { actual: candidate(1, 1, 1), expected: 0.43 },\n     { actual: candidate(2, 2, 10), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "go_test.go",
+    "prompt": "package will_it_fly_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([]int{1, 2}, 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([]int{3, 2, 3}, 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([]int{3, 2, 3}, 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([]int{3}, 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q []int, w int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWill_It_Fly(t *testing.T) {\n  candidate := will_it_fly\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 3}, 9), expected: true },\n     { actual: candidate([]int{1, 2}, 5), expected: false },\n     { actual: candidate([]int{3}, 5), expected: true },\n     { actual: candidate([]int{3, 2, 3}, 1), expected: false },\n     { actual: candidate([]int{1, 2, 3}, 6), expected: false },\n     { actual: candidate([]int{5}, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "go_test.go",
+    "prompt": "package smallest_change_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([]int{1, 2, 3, 5, 4, 7, 9, 6})\n// 4\n// >>> smallest_change([]int{1, 2, 3, 4, 3, 2, 2})\n// 1\n// >>> smallest_change([]int{1, 2, 3, 2, 1})\n// 0\nfunc smallest_change(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSmallest_Change(t *testing.T) {\n  candidate := smallest_change\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 4, 7, 9, 6}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 4, 4, 2}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3, 2, 1}), expected: 0 },\n     { actual: candidate([]int{3, 1, 1, 3}), expected: 0 },\n     { actual: candidate([]int{1}), expected: 0 },\n     { actual: candidate([]int{0, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "go_test.go",
+    "prompt": "package total_match_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([]string{}, []string{})\n// []string{}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"})\n// []string{\"hI\", \"Hi\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"})\n// []string{\"hi\", \"admin\"}\n// >>> total_match([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"})\n// []string{\"hI\", \"hi\", \"hi\"}\n// >>> total_match([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"})\n// []string{\"4\"}\nfunc total_match(lst1 []string, lst2 []string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTotal_Match(t *testing.T) {\n  candidate := total_match\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, []string{}), expected: []string{} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\"}), expected: []string{\"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hi\", \"hi\", \"admin\", \"project\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{\"4\"}, []string{\"1\", \"2\", \"3\", \"4\", \"5\"}), expected: []string{\"4\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"Hi\"}), expected: []string{\"hI\", \"Hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hi\"}), expected: []string{\"hI\", \"hi\", \"hi\"} },\n     { actual: candidate([]string{\"hi\", \"admin\"}, []string{\"hI\", \"hi\", \"hii\"}), expected: []string{\"hi\", \"admin\"} },\n     { actual: candidate([]string{}, []string{\"this\"}), expected: []string{} },\n     { actual: candidate([]string{\"this\"}, []string{}), expected: []string{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "go_test.go",
+    "prompt": "package is_multiply_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Multiply_Prime(t *testing.T) {\n  candidate := is_multiply_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: false },\n     { actual: candidate(30), expected: true },\n     { actual: candidate(8), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(125), expected: true },\n     { actual: candidate(105), expected: true },\n     { actual: candidate(126), expected: false },\n     { actual: candidate(729), expected: false },\n     { actual: candidate(891), expected: false },\n     { actual: candidate(1001), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "go_test.go",
+    "prompt": "package is_simple_power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunc is_simple_power(x int, n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Simple_Power(t *testing.T) {\n  candidate := is_simple_power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: true },\n     { actual: candidate(143214, 16), expected: false },\n     { actual: candidate(4, 2), expected: true },\n     { actual: candidate(9, 3), expected: true },\n     { actual: candidate(16, 4), expected: true },\n     { actual: candidate(24, 2), expected: false },\n     { actual: candidate(128, 4), expected: false },\n     { actual: candidate(12, 6), expected: false },\n     { actual: candidate(1, 1), expected: true },\n     { actual: candidate(1, 12), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "go_test.go",
+    "prompt": "package iscube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunc iscube(a int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIscube(t *testing.T) {\n  candidate := iscube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(-1), expected: true },\n     { actual: candidate(64), expected: true },\n     { actual: candidate(180), expected: false },\n     { actual: candidate(1000), expected: true },\n     { actual: candidate(0), expected: true },\n     { actual: candidate(1729), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "go_test.go",
+    "prompt": "package hex_key_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunc hex_key(num string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHex_Key(t *testing.T) {\n  candidate := hex_key\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AB\"), expected: 1 },\n     { actual: candidate(\"1077E\"), expected: 2 },\n     { actual: candidate(\"ABED1A33\"), expected: 4 },\n     { actual: candidate(\"2020\"), expected: 2 },\n     { actual: candidate(\"123456789ABCDEF0\"), expected: 6 },\n     { actual: candidate(\"112233445566778899AABBCCDDEEFF00\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunc decimal_to_binary(decimal int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: \"db0db\" },\n     { actual: candidate(32), expected: \"db100000db\" },\n     { actual: candidate(103), expected: \"db1100111db\" },\n     { actual: candidate(15), expected: \"db1111db\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "go_test.go",
+    "prompt": "package filter_by_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([]string{}, \"a\")\n// []string{}\n// >>> filter_by_substring([]string{\"abc\", \"bacd\", \"cde\", \"array\"}, \"a\")\n// []string{\"abc\", \"bacd\", \"array\"}\nfunc filter_by_substring(strings []string, substring string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_By_Substring(t *testing.T) {\n  candidate := filter_by_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{}, \"john\"), expected: []string{} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xxx\"), expected: []string{\"xxx\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"}, \"xx\"), expected: []string{\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"} },\n     { actual: candidate([]string{\"grunt\", \"trumpet\", \"prune\", \"gruesome\"}, \"run\"), expected: []string{\"grunt\", \"prune\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "go_test.go",
+    "prompt": "package is_happy_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunc is_happy(s string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Happy(t *testing.T) {\n  candidate := is_happy\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"a\"), expected: false },\n     { actual: candidate(\"aa\"), expected: false },\n     { actual: candidate(\"abcd\"), expected: true },\n     { actual: candidate(\"aabb\"), expected: false },\n     { actual: candidate(\"adb\"), expected: true },\n     { actual: candidate(\"xyy\"), expected: false },\n     { actual: candidate(\"iopaxpoi\"), expected: true },\n     { actual: candidate(\"iopaxioi\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "go_test.go",
+    "prompt": "package numerical_letter_grade_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([]float64{4.0, 3, 1.7, 2, 3.5})\n// []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"}\nfunc numerical_letter_grade(grades []float64) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNumerical_Letter_Grade(t *testing.T) {\n  candidate := numerical_letter_grade\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]float64{4.0, 3, 1.7, 2, 3.5}), expected: []string{\"A+\", \"B\", \"C-\", \"C\", \"A-\"} },\n     { actual: candidate([]float64{1.2}), expected: []string{\"D+\"} },\n     { actual: candidate([]float64{0.5}), expected: []string{\"D-\"} },\n     { actual: candidate([]float64{0.0}), expected: []string{\"E\"} },\n     { actual: candidate([]float64{1.0, 0.3, 1.5, 2.8, 3.3}), expected: []string{\"D\", \"D-\", \"C-\", \"B\", \"B+\"} },\n     { actual: candidate([]float64{0.0, 0.7}), expected: []string{\"E\", \"D-\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "go_test.go",
+    "prompt": "package prime_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunc prime_length(myString string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Length(t *testing.T) {\n  candidate := prime_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello\"), expected: true },\n     { actual: candidate(\"abcdcba\"), expected: true },\n     { actual: candidate(\"kittens\"), expected: true },\n     { actual: candidate(\"orange\"), expected: false },\n     { actual: candidate(\"wow\"), expected: true },\n     { actual: candidate(\"world\"), expected: true },\n     { actual: candidate(\"MadaM\"), expected: true },\n     { actual: candidate(\"Wow\"), expected: true },\n     { actual: candidate(\"\"), expected: false },\n     { actual: candidate(\"HI\"), expected: true },\n     { actual: candidate(\"go\"), expected: true },\n     { actual: candidate(\"gogo\"), expected: false },\n     { actual: candidate(\"aaaaaaaaaaaaaaa\"), expected: false },\n     { actual: candidate(\"Madam\"), expected: true },\n     { actual: candidate(\"M\"), expected: false },\n     { actual: candidate(\"0\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "go_test.go",
+    "prompt": "package starts_one_ends_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunc starts_one_ends(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStarts_One_Ends(t *testing.T) {\n  candidate := starts_one_ends\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: 1 },\n     { actual: candidate(2), expected: 18 },\n     { actual: candidate(3), expected: 180 },\n     { actual: candidate(4), expected: 1800 },\n     { actual: candidate(5), expected: 18000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "go_test.go",
+    "prompt": "package solve_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunc solve(N int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSolve(t *testing.T) {\n  candidate := solve\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1000), expected: \"1\" },\n     { actual: candidate(150), expected: \"110\" },\n     { actual: candidate(147), expected: \"1100\" },\n     { actual: candidate(333), expected: \"1001\" },\n     { actual: candidate(963), expected: \"10010\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "go_test.go",
+    "prompt": "package add_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([]int{4, 2, 6, 7})\n// 2\nfunc add(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd(t *testing.T) {\n  candidate := add\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 88}), expected: 88 },\n     { actual: candidate([]int{4, 5, 6, 7, 2, 122}), expected: 122 },\n     { actual: candidate([]int{4, 0, 6, 7}), expected: 0 },\n     { actual: candidate([]int{4, 4, 6, 8}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "go_test.go",
+    "prompt": "package anti_shuffle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAnti_Shuffle(t *testing.T) {\n  candidate := anti_shuffle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hi\"), expected: \"Hi\" },\n     { actual: candidate(\"hello\"), expected: \"ehllo\" },\n     { actual: candidate(\"number\"), expected: \"bemnru\" },\n     { actual: candidate(\"abcd\"), expected: \"abcd\" },\n     { actual: candidate(\"Hello World!!!\"), expected: \"Hello !!!Wdlor\" },\n     { actual: candidate(\"\"), expected: \"\" },\n     { actual: candidate(\"Hi. My name is Mister Robot. How are you?\"), expected: \".Hi My aemn is Meirst .Rboot How aer ?ouy\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "go_test.go",
+    "prompt": "package get_row_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1)\n// [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}}\n// >>> get_row([][]int{}, 1)\n// [][]interface{}{}\n// >>> get_row([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3)\n// [][]int{[]interface{}{2, 2}}\nfunc get_row(lst [][]int, x int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Row(t *testing.T) {\n  candidate := get_row\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 4}, []interface{}{1, 0}, []interface{}{2, 5}, []interface{}{2, 0}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}}, 2), expected: [][]int{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}, []int{1, 1, 3, 4, 5, 6}, []int{1, 2, 1, 4, 5, 6}, []int{1, 2, 3, 1, 5, 6}, []int{1, 2, 3, 4, 1, 6}, []int{1, 2, 3, 4, 5, 1}}, 1), expected: [][]int{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{2, 1}, []interface{}{2, 0}, []interface{}{3, 2}, []interface{}{3, 0}, []interface{}{4, 3}, []interface{}{4, 0}, []interface{}{5, 4}, []interface{}{5, 0}, []interface{}{6, 5}, []interface{}{6, 0}} },\n     { actual: candidate([][]int{}, 1), expected: [][]interface{}{} },\n     { actual: candidate([][]int{[]int{1}}, 2), expected: [][]interface{}{} },\n     { actual: candidate([]interface{}{[]interface{}{}, []int{1}, []int{1, 2, 3}}, 3), expected: [][]int{[]interface{}{2, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "go_test.go",
+    "prompt": "package sort_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([]int{})\n// []int{}\n// >>> sort_array([]int{5})\n// []int{5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5})\n// []int{0, 1, 2, 3, 4, 5}\n// >>> sort_array([]int{2, 4, 3, 0, 1, 5, 6})\n// []int{6, 5, 4, 3, 2, 1, 0}\nfunc sort_array(array []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Array(t *testing.T) {\n  candidate := sort_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{5}), expected: []int{5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5}), expected: []int{0, 1, 2, 3, 4, 5} },\n     { actual: candidate([]int{2, 4, 3, 0, 1, 5, 6}), expected: []int{6, 5, 4, 3, 2, 1, 0} },\n     { actual: candidate([]int{2, 1}), expected: []int{1, 2} },\n     { actual: candidate([]int{15, 42, 87, 32, 11, 0}), expected: []int{0, 11, 15, 32, 42, 87} },\n     { actual: candidate([]int{21, 14, 23, 11}), expected: []int{23, 21, 14, 11} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "go_test.go",
+    "prompt": "package encrypt_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunc encrypt(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncrypt(t *testing.T) {\n  candidate := encrypt\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hi\"), expected: \"lm\" },\n     { actual: candidate(\"asdfghjkl\"), expected: \"ewhjklnop\" },\n     { actual: candidate(\"gf\"), expected: \"kj\" },\n     { actual: candidate(\"et\"), expected: \"ix\" },\n     { actual: candidate(\"faewfawefaewg\"), expected: \"jeiajeaijeiak\" },\n     { actual: candidate(\"hellomyfriend\"), expected: \"lippsqcjvmirh\" },\n     { actual: candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"), expected: \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" },\n     { actual: candidate(\"a\"), expected: \"e\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "go_test.go",
+    "prompt": "package sum_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([]int{})\n// []interface{}{0, 1}\n// >>> sum_product([]int{1, 2, 3, 4})\n// []interface{}{10, 24}\nfunc sum_product(numbers []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Product(t *testing.T) {\n  candidate := sum_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []interface{}{0, 1} },\n     { actual: candidate([]int{1, 1, 1}), expected: []interface{}{3, 1} },\n     { actual: candidate([]int{100, 0}), expected: []interface{}{100, 0} },\n     { actual: candidate([]int{3, 5, 7}), expected: []interface{}{15, 105} },\n     { actual: candidate([]int{10}), expected: []interface{}{10, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "go_test.go",
+    "prompt": "package is_bored_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunc is_bored(S string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Bored(t *testing.T) {\n  candidate := is_bored\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hello world\"), expected: 0 },\n     { actual: candidate(\"Is the sky blue?\"), expected: 0 },\n     { actual: candidate(\"I love It !\"), expected: 1 },\n     { actual: candidate(\"bIt\"), expected: 0 },\n     { actual: candidate(\"I feel good today. I will be productive. will kill It\"), expected: 2 },\n     { actual: candidate(\"You and I are going for a walk\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "go_test.go",
+    "prompt": "package any_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunc any_int(x float64, y float64, z float64) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAny_Int(t *testing.T) {\n  candidate := any_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 3, 1), expected: true },\n     { actual: candidate(2.5, 2, 3), expected: false },\n     { actual: candidate(1.5, 5, 3.5), expected: false },\n     { actual: candidate(2, 6, 2), expected: false },\n     { actual: candidate(4, 2, 2), expected: true },\n     { actual: candidate(2.2, 2.2, 2.2), expected: false },\n     { actual: candidate(-4, 6, 2), expected: true },\n     { actual: candidate(2, 1, 1), expected: true },\n     { actual: candidate(3, 4, 7), expected: true },\n     { actual: candidate(3.0, 4, 7), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "go_test.go",
+    "prompt": "package encode_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunc encode(message string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEncode(t *testing.T) {\n  candidate := encode\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TEST\"), expected: \"tgst\" },\n     { actual: candidate(\"Mudasir\"), expected: \"mWDCSKR\" },\n     { actual: candidate(\"YES\"), expected: \"ygs\" },\n     { actual: candidate(\"This is a message\"), expected: \"tHKS KS C MGSSCGG\" },\n     { actual: candidate(\"I DoNt KnOw WhAt tO WrItE\"), expected: \"k dQnT kNqW wHcT Tq wRkTg\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "go_test.go",
+    "prompt": "package skjkasdkd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n// 10\n// >>> skjkasdkd([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n// 25\n// >>> skjkasdkd([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n// 13\n// >>> skjkasdkd([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n// 11\n// >>> skjkasdkd([]int{0, 81, 12, 3, 1, 21})\n// 3\n// >>> skjkasdkd([]int{0, 8, 1, 2, 1, 7})\n// 7\nfunc skjkasdkd(lst []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSkjkasdkd(t *testing.T) {\n  candidate := skjkasdkd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), expected: 10 },\n     { actual: candidate([]int{1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), expected: 25 },\n     { actual: candidate([]int{1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), expected: 13 },\n     { actual: candidate([]int{0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), expected: 11 },\n     { actual: candidate([]int{0, 81, 12, 3, 1, 21}), expected: 3 },\n     { actual: candidate([]int{0, 8, 1, 2, 1, 7}), expected: 7 },\n     { actual: candidate([]int{8191}), expected: 19 },\n     { actual: candidate([]int{8191, 123456, 127, 7}), expected: 19 },\n     { actual: candidate([]int{127, 97, 8192}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "go_test.go",
+    "prompt": "package check_dict_case_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case(map[string]string{\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case(map[interface{}]string{\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunc check_dict_case(dict map[string]string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Dict_Case(t *testing.T) {\n  candidate := check_dict_case\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"b\": \"banana\"}), expected: true },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}), expected: false },\n     { actual: candidate(map[string]string{\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}), expected: false },\n     { actual: candidate(map[string]string{\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}), expected: false },\n     { actual: candidate(map[string]string{\"STATE\": \"NC\", \"ZIP\": \"12345\"}), expected: true },\n     { actual: candidate(map[string]string{\"fruit\": \"Orange\", \"taste\": \"Sweet\"}), expected: true },\n     { actual: candidate(map[string]string{}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "go_test.go",
+    "prompt": "package count_up_to_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// []int{2, 3}\n// >>> count_up_to(11)\n// []int{2, 3, 5, 7}\n// >>> count_up_to(0)\n// []int{}\n// >>> count_up_to(20)\n// []int{2, 3, 5, 7, 11, 13, 17, 19}\n// >>> count_up_to(1)\n// []int{}\n// >>> count_up_to(18)\n// []int{2, 3, 5, 7, 11, 13, 17}\nfunc count_up_to(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Up_To(t *testing.T) {\n  candidate := count_up_to\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: []int{2, 3} },\n     { actual: candidate(6), expected: []int{2, 3, 5} },\n     { actual: candidate(7), expected: []int{2, 3, 5} },\n     { actual: candidate(10), expected: []int{2, 3, 5, 7} },\n     { actual: candidate(0), expected: []int{} },\n     { actual: candidate(22), expected: []int{2, 3, 5, 7, 11, 13, 17, 19} },\n     { actual: candidate(1), expected: []int{} },\n     { actual: candidate(18), expected: []int{2, 3, 5, 7, 11, 13, 17} },\n     { actual: candidate(47), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43} },\n     { actual: candidate(101), expected: []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "go_test.go",
+    "prompt": "package multiply_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunc multiply(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMultiply(t *testing.T) {\n  candidate := multiply\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(148, 412), expected: 16 },\n     { actual: candidate(19, 28), expected: 72 },\n     { actual: candidate(2020, 1851), expected: 0 },\n     { actual: candidate(14, -15), expected: 20 },\n     { actual: candidate(76, 67), expected: 42 },\n     { actual: candidate(17, 27), expected: 49 },\n     { actual: candidate(0, 1), expected: 0 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "go_test.go",
+    "prompt": "package count_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunc count_upper(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Upper(t *testing.T) {\n  candidate := count_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aBCdEf\"), expected: 1 },\n     { actual: candidate(\"abcdefg\"), expected: 0 },\n     { actual: candidate(\"dBBE\"), expected: 0 },\n     { actual: candidate(\"B\"), expected: 0 },\n     { actual: candidate(\"U\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n     { actual: candidate(\"EEEE\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "go_test.go",
+    "prompt": "package closest_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestClosest_Integer(t *testing.T) {\n  candidate := closest_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"10\"), expected: 10 },\n     { actual: candidate(\"14.5\"), expected: 15 },\n     { actual: candidate(\"-15.5\"), expected: -16 },\n     { actual: candidate(\"15.3\"), expected: 15 },\n     { actual: candidate(\"0\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "go_test.go",
+    "prompt": "package rolling_max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([]int{1, 2, 3, 2, 3, 4, 2})\n// []int{1, 2, 3, 3, 3, 4, 4}\nfunc rolling_max(numbers []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRolling_Max(t *testing.T) {\n  candidate := rolling_max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{}), expected: []int{} },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: []int{1, 2, 3, 4} },\n     { actual: candidate([]int{4, 3, 2, 1}), expected: []int{4, 4, 4, 4} },\n     { actual: candidate([]int{3, 2, 3, 100, 3}), expected: []int{3, 3, 3, 100, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/humaneval-java-keep.json
+++ b/prompts/humaneval-java-keep.json
@@ -1,984 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    public static boolean iscube(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    public static boolean hasCloseElements(ArrayList<Float> numbers, float threshold) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    public static String encode(String message) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    public static long solution(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    public static String stringSequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    public static long isBored(String S) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    public static boolean anyInt(float x, float y, float z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    public static long xOrY(long n, long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    public static boolean isHappy(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    public static String fileNameCheck(String file_name) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    public static HashMap<String,Long> histogram(String test) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    public static boolean simplify(String x, String n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    public static Pair<String, Boolean> reverseDelete(String s, String c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals((Pair.with(\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals((Pair.with(\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals((Pair.with(\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals((Pair.with(\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals((Pair.with(\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals((Pair.with(\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals((Pair.with(\"\", true))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    public static ArrayList<String> allPrefixes(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    public static long digits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    public static long strlen(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    public static long fibfib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    public static ArrayList<String> wordsString(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    public static boolean monotonic(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    public static String fixSpaces(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    public static boolean cycpatternCheck(String a, String b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    public static float truncateNumber(float number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    public static String removeVowels(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    public static ArrayList<Long> countUpTo(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    public static long maxElement(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    public static float triangleArea(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    public static long smallestChange(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    public static ArrayList<Long> f(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    public static String matchParens(ArrayList<String> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    public static boolean isEqualToSumEven(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    public static long largestPrimeFactor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    public static String encrypt(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    public static long howManyTimes(String string, String substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    public static String solve(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    public static ArrayList<Long> sortEven(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)5l, (long)0l, (long)9l, (long)1l, (long)123l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)-12l, (long)4l, (long)23l, (long)2l, (long)3l, (long)11l, (long)12l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-12l, (long)8l, (long)3l, (long)4l, (long)5l, (long)2l, (long)12l, (long)11l, (long)23l, (long)-10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    public static boolean sameChars(String s0, String s1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    public static long countUpper(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    public static ArrayList<String> selectWords(String s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    public static String findMax(ArrayList<String> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    public static long sumSquares(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    public static long add(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    public static long multiply(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    public static ArrayList<Long> tri(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    public static boolean isSimplePower(long x, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.3f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.05f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.95f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.8f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.1f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (1.0f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (0.5f)) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -988,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> make_a_pile(3)\n    // [3, 5, 7]\n    public static ArrayList<Long> makeAPile(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(makeAPile((3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))));\n    assert(makeAPile((4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)10l)))));\n    assert(makeAPile((5l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)11l, (long)13l)))));\n    assert(makeAPile((6l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l)))));\n    assert(makeAPile((8l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)18l, (long)20l, (long)22l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -996,853 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    public static long add(long x, long y) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    public static ArrayList<String> wordsString(String s) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    public static String decimalToBinary(long decimal) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    public static boolean isPalindrome(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    public static long greatestCommonDivisor(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    public static ArrayList<Long> factorize(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    public static String circularShift(long x, long shift) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    public static String getClosestVowel(String word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    public static String sortNumbers(String numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    public static String flipCase(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    public static long canArrange(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    public static boolean isNested(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    public static long sumToN(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    public static String concatenate(ArrayList<String> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    public static long sumSquares(ArrayList<Float> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    public static ArrayList<Long> sortArray(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-2l, (long)-6l, (long)-5l, (long)-3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)4l, (long)3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)77l, (long)4l, (long)5l, (long)3l, (long)5l, (long)7l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)4l, (long)4l, (long)3l, (long)3l, (long)5l, (long)5l, (long)5l, (long)7l, (long)77l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)44l, (long)12l, (long)32l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)32l, (long)3l, (long)5l, (long)6l, (long)12l, (long)44l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    public static String antiShuffle(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    public static String makePalindrome(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    public static String changeBase(long x, long base) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    public static boolean primeLength(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    public static long search(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    public static long fizzBuzz(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    public static long vowelsCount(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    public static Optional<String> stringToMd5(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    public static boolean isPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    public static long hexKey(String num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    public static float median(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    public static long specialFilter(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)5l, (long)-2l, (long)1l, (long)-5l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l)))) == (1l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l)))) == (2l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)43l, (long)-12l, (long)93l, (long)125l, (long)121l, (long)109l)))) == (4l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)71l, (long)-2l, (long)-33l, (long)75l, (long)21l, (long)19l)))) == (3l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    public static long modp(long n, long p) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    public static long primeFib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    public static boolean validDate(String date) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    public static long countNums(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    public static long digitSum(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    public static float triangleArea(long a, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    public static long fib4(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    public static String stringXor(String a, String b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    public static boolean hasCloseElements(ArrayList<Float> numbers, float threshold) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.3f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.05f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.95f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.8f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.1f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (1.0f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    public static long fruitDistribution(String s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    public static long largestDivisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    public static String intToMiniRoman(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    public static boolean correctBracketing(String brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    public static boolean correctBracketing(String brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    public static long fib(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1852,7 +40,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // choose_num(12, 15) = 14\n    // choose_num(13, 12) = -1\n    public static long chooseNum(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1860,13 +48,757 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_104_unique_digits",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    public static ArrayList<Long> f(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    public static long countNums(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    public static String makePalindrome(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    public static HashMap<String,Long> histogram(String test) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    public static Pair<String, Boolean> reverseDelete(String s, String c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals((Pair.with(\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals((Pair.with(\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals((Pair.with(\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals((Pair.with(\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals((Pair.with(\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals((Pair.with(\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals((Pair.with(\"\", true))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    public static ArrayList<Long> sortArray(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-2l, (long)-6l, (long)-5l, (long)-3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)4l, (long)3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)77l, (long)4l, (long)5l, (long)3l, (long)5l, (long)7l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)4l, (long)4l, (long)3l, (long)3l, (long)5l, (long)5l, (long)5l, (long)7l, (long)77l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)44l, (long)12l, (long)32l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)32l, (long)3l, (long)5l, (long)6l, (long)12l, (long)44l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    public static ArrayList<String> selectWords(String s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    public static String getClosestVowel(String word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    public static String matchParens(ArrayList<String> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    public static String stringXor(String a, String b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    public static long solution(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    public static boolean validDate(String date) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    public static ArrayList<Long> tri(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    public static long digits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    public static boolean isNested(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    public static long sumSquares(ArrayList<Float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    public static long canArrange(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    public static boolean isEqualToSumEven(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    public static String fixSpaces(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    public static String fileNameCheck(String file_name) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    public static long sumSquares(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    public static boolean simplify(String x, String n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    public static long specialFilter(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)5l, (long)-2l, (long)1l, (long)-5l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l)))) == (1l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l)))) == (2l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)43l, (long)-12l, (long)93l, (long)125l, (long)121l, (long)109l)))) == (4l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)71l, (long)-2l, (long)-33l, (long)75l, (long)21l, (long)19l)))) == (3l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    public static ArrayList<String> allPrefixes(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    public static long xOrY(long n, long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    public static String intToMiniRoman(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    public static String findMax(ArrayList<String> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    public static String stringSequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    public static String solve(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    public static Optional<String> stringToMd5(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,7 +808,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // generate_integers(2, 8) => [2, 4, 6, 8]\n    // generate_integers(8, 2) => [2, 4, 6, 8]\n    // generate_integers(10, 14) => []\n    public static ArrayList<Long> generateIntegers(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(generateIntegers((2l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((10l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((132l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((17l), (89l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1888,9 +820,1077 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> count_distinct_characters('xyzXYZ')\n    // 3\n    // >>> count_distinct_characters('Jerry')\n    // 4\n    public static long countDistinctCharacters(String string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    public static long howManyTimes(String string, String substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    public static String sortNumbers(String numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    public static long strlen(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    public static long largestDivisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    public static ArrayList<Long> factorize(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    public static String flipCase(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    public static float truncateNumber(float number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    public static boolean isPrime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    public static long maxElement(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    public static long fizzBuzz(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    public static ArrayList<Long> sortEven(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)5l, (long)0l, (long)9l, (long)1l, (long)123l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)-12l, (long)4l, (long)23l, (long)2l, (long)3l, (long)11l, (long)12l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-12l, (long)8l, (long)3l, (long)4l, (long)5l, (long)2l, (long)12l, (long)11l, (long)23l, (long)-10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    public static long primeFib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    public static String changeBase(long x, long base) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    public static float triangleArea(long a, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    public static long fib4(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    public static float median(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    public static boolean isPalindrome(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    public static long modp(long n, long p) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    public static String removeVowels(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    public static long add(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    public static boolean sameChars(String s0, String s1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    public static long fib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    public static boolean correctBracketing(String brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    public static long largestPrimeFactor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    public static long sumToN(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    public static boolean correctBracketing(String brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    public static long fibfib(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    public static long vowelsCount(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    public static String circularShift(long x, long shift) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    public static long digitSum(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    public static long fruitDistribution(String s, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    public static long search(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    public static float triangleArea(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    public static long smallestChange(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    public static boolean isSimplePower(long x, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    public static boolean iscube(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    public static long hexKey(String num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    public static String decimalToBinary(long decimal) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    public static boolean isHappy(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    public static boolean primeLength(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    public static long add(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    public static String antiShuffle(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    public static String encrypt(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    public static long isBored(String S) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    public static boolean anyInt(float x, float y, float z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    public static String encode(String message) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    public static ArrayList<Long> countUpTo(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    public static long multiply(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    public static long countUpper(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-java-remove.json
+++ b/prompts/humaneval-java-remove.json
@@ -1,1344 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    public static long strlen(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    public static String encrypt(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    public static long add(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    public static String fixSpaces(String text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    public static long fibfib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    public static String decimalToBinary(long decimal) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    public static ArrayList<String> allPrefixes(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    public static long add(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    public static String flipCase(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    public static ArrayList<Long> factorize(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    public static ArrayList<Long> countUpTo(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    public static long maxElement(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    public static boolean isNested(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    public static boolean isEqualToSumEven(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    public static String solve(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    public static ArrayList<Long> tri(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    public static long fizzBuzz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    public static long countUpper(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    public static long largestDivisor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    public static ArrayList<Long> f(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    public static boolean iscube(long a) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    public static String encode(String message) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    public static long isBored(String S) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    public static float triangleArea(long a, long b, long c) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    public static long digits(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    public static ArrayList<String> wordsString(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    public static long howManyTimes(String string, String substring) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    public static String removeVowels(String text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    public static boolean isSimplePower(long x, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    public static long primeFib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    public static boolean hasCloseElements(ArrayList<Float> numbers, float threshold) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.3f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.05f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.95f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.8f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.1f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (1.0f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    public static String makePalindrome(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    public static String stringXor(String a, String b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    public static long fib4(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    public static ArrayList<String> selectWords(String s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    public static long fib(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    public static String matchParens(ArrayList<String> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    public static boolean anyInt(float x, float y, float z) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    public static float truncateNumber(float number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    public static long xOrY(long n, long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    public static long modp(long n, long p) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    public static boolean isHappy(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    public static long largestPrimeFactor(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    public static long digitSum(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    public static long solution(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    public static float median(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    public static boolean primeLength(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    public static long smallestChange(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    public static long sumSquares(ArrayList<Float> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    public static String fileNameCheck(String file_name) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    public static boolean validDate(String date) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    public static long countNums(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    public static String antiShuffle(String s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    public static boolean isPalindrome(String text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    public static String getClosestVowel(String word) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    public static boolean isPrime(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    public static boolean simplify(String x, String n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    public static long hexKey(String num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    public static HashMap<String,Long> histogram(String test) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    public static long canArrange(ArrayList<Long> arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    public static String sortNumbers(String numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    public static String circularShift(long x, long shift) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    public static long sumSquares(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    public static long chooseNum(long x, long y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    public static long countDistinctCharacters(String string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1348,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    public static ArrayList<Long> makeAPile(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(makeAPile((3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))));\n    assert(makeAPile((4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)10l)))));\n    assert(makeAPile((5l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)11l, (long)13l)))));\n    assert(makeAPile((6l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l)))));\n    assert(makeAPile((8l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)18l, (long)20l, (long)22l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1356,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    public static ArrayList<String> wordsString(String s) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    public static long chooseNum(long x, long y) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    public static String stringSequence(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    public static ArrayList<Long> f(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    public static long countNums(ArrayList<Long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    public static String makePalindrome(String string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    public static HashMap<String,Long> histogram(String test) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    public static float triangleArea(long a, long h) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    public static long multiply(long a, long b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    public static String intToMiniRoman(long number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    public static long fruitDistribution(String s, long n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1564,7 +160,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    public static Pair<String, Boolean> reverseDelete(String s, String c) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals((Pair.with(\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals((Pair.with(\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals((Pair.with(\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals((Pair.with(\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals((Pair.with(\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals((Pair.with(\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals((Pair.with(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1572,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1588,7 +208,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    public static ArrayList<Long> sortArray(ArrayList<Long> arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-2l, (long)-6l, (long)-5l, (long)-3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)4l, (long)3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)77l, (long)4l, (long)5l, (long)3l, (long)5l, (long)7l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)4l, (long)4l, (long)3l, (long)3l, (long)5l, (long)5l, (long)5l, (long)7l, (long)77l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)44l, (long)12l, (long)32l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)32l, (long)3l, (long)5l, (long)6l, (long)12l, (long)44l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1596,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    public static ArrayList<String> selectWords(String s, long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    public static String getClosestVowel(String word) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    public static String matchParens(ArrayList<String> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    public static String stringXor(String a, String b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    public static long vowelsCount(String s) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    public static String findMax(ArrayList<String> words) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    public static long solution(ArrayList<Long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    public static Optional<String> stringToMd5(String text) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    public static String changeBase(long x, long base) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    public static boolean validDate(String date) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    public static ArrayList<Long> tri(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    public static long digits(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    public static boolean isNested(String string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    public static long sumSquares(ArrayList<Float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    public static long canArrange(ArrayList<Long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    public static boolean isEqualToSumEven(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    public static String fixSpaces(String text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    public static String fileNameCheck(String file_name) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    public static long sumSquares(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    public static boolean simplify(String x, String n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1732,7 +580,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    public static long specialFilter(ArrayList<Long> nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)5l, (long)-2l, (long)1l, (long)-5l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l)))) == (1l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l)))) == (2l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)43l, (long)-12l, (long)93l, (long)125l, (long)121l, (long)109l)))) == (4l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)71l, (long)-2l, (long)-33l, (long)75l, (long)21l, (long)19l)))) == (3l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1740,25 +588,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    public static long sumToN(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    public static ArrayList<String> allPrefixes(String string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    public static long xOrY(long n, long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    public static String intToMiniRoman(long number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    public static String findMax(ArrayList<String> words) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    public static String stringSequence(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    public static String solve(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    public static Optional<String> stringToMd5(String text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +796,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    public static ArrayList<Long> generateIntegers(long a, long b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(generateIntegers((2l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((10l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((132l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((17l), (89l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,49 +804,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    public static long countDistinctCharacters(String string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    public static long search(ArrayList<Long> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    public static long howManyTimes(String string, String substring) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static boolean correctBracketing(String brackets) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    public static String sortNumbers(String numbers) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    public static long strlen(String string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    public static long largestDivisor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    public static ArrayList<Long> factorize(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    public static String flipCase(String string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    public static float truncateNumber(float number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    public static boolean isPrime(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    public static long maxElement(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    public static long fizzBuzz(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1828,9 +1072,189 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    public static ArrayList<Long> sortEven(ArrayList<Long> l) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)5l, (long)0l, (long)9l, (long)1l, (long)123l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)-12l, (long)4l, (long)23l, (long)2l, (long)3l, (long)11l, (long)12l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-12l, (long)8l, (long)3l, (long)4l, (long)5l, (long)2l, (long)12l, (long)11l, (long)23l, (long)-10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    public static long primeFib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    public static String changeBase(long x, long base) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    public static float triangleArea(long a, long h) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    public static long fib4(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    public static float median(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    public static boolean isPalindrome(String text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    public static long modp(long n, long p) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    public static String removeVowels(String text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    public static long add(long x, long y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1840,9 +1264,21 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if two words have the same characters.\n    public static boolean sameChars(String s0, String s1) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    public static long fib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1852,9 +1288,573 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static boolean correctBracketing(String brackets) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    public static long largestPrimeFactor(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    public static long sumToN(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    public static boolean correctBracketing(String brackets) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    public static long fibfib(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    public static long vowelsCount(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    public static String circularShift(long x, long shift) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    public static long digitSum(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    public static long fruitDistribution(String s, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    public static long search(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    public static float triangleArea(long a, long b, long c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    public static long smallestChange(ArrayList<Long> arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    public static boolean isSimplePower(long x, long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    public static boolean iscube(long a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    public static long hexKey(String num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    public static String decimalToBinary(long decimal) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    public static boolean isHappy(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    public static boolean primeLength(String string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    public static long add(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    public static String antiShuffle(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    public static String encrypt(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    public static long isBored(String S) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    public static boolean anyInt(float x, float y, float z) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    public static String encode(String message) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    public static ArrayList<Long> countUpTo(long n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    public static long multiply(long a, long b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    public static long countUpper(String s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-java-reworded.json
+++ b/prompts/humaneval-java-reworded.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    public static long strlen(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    public static String encrypt(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a hash map, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given hash map is empty.\n    // Examples:\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"b\", \"banana\"))))\n    // (true)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"A\", \"banana\", \"B\", \"banana\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", 8l, \"banana\", \"a\", \"apple\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\"))))\n    // (true)\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)6l, (long)7l))))\n    // (2l)\n    public static long add(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static String fixSpaces(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    public static long fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of numbers, return the sum of squares of the numbers\n    // in the array list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)0l))))\n    // (10l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)-1l, (long)-2l, (long)0l))))\n    // (0l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)9l, (long)-2l))))\n    // (81l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)0l))))\n    // (0l)\n    // If the input array list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given array list of any javathon values only for integers\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)3.14f, (String)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList(1l, 2l, 3l, \"abc\", new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList())))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return array list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)1l, (long)2l, (long)2l, (long)1l, (long)1l, (long)1l, (long)1l, (long)4l, (long)4l)))\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    public static String decimalToBinary(long decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))\n    public static ArrayList<String> allPrefixes(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    public static long add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array array list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))\n    // >>> eat((4l), (8l), (9l))\n    // (new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))\n    // >>> eat((1l), (10l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))\n    // >>> eat((2l), (11l), (5l))\n    // (new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two array lists operator, and operand. The first array list has basic algebra operations, and \n    // the second array list is an array array list of integers. Use the two given array lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array array list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator array list is equal to the length of operand array list minus one.\n    // Operand is an array array list of of non-negative integers.\n    // Operator array list has at least one operator, and operand array list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static String flipCase(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array array list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))\n    // If the array array list is empty, return an empty array array list:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // If the array array list has any strange number ignore it:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\")))\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be array listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))\n    // >>> factorize((25l))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)))\n    // >>> factorize((70l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l)))\n    public static ArrayList<Long> factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array array list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    // >>> countUpTo((11l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))\n    // >>> countUpTo((0l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((20l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))\n    // >>> countUpTo((1l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((18l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))\n    public static ArrayList<Long> countUpTo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in an array array list\n    // >>> unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two array lists of strings and returns the array list that has \n    // total number of chars in the all strings of the array list less than the other array list.\n    // if the two array lists have the same number of chars, return the first array list.\n    // Examples\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"4\")))\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the array list.\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (3l)\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (123l)\n    public static long maxElement(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    public static boolean isNested(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of strings, where each string consists of only digits, return an array array list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array array list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array array list will be randomly ordered. Your task is to determine if\n    // it is possible to get an array array list sorted in non-decreasing order by performing \n    // the following operation on the given array array list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array array list by one\n    // position in the right direction. The last element of the array array list will be moved to\n    // the starting position in the array array list i.e. 0th index. \n    // If it is possible to obtain the sorted array array list by performing the above operation\n    // then return true else return false.\n    // If the given array array list is empty then return true.\n    // Note: The given array list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l))))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array array list.\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l))))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array array list by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a pair that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // (Pair.with(1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // (Pair.with(4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned pair has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    public static boolean isEqualToSumEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of numbers, return whether or not they are sorted\n    // in ascending order. If array list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l))))\n    // (false)\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static String solve(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return an array array list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))\n    public static ArrayList<Long> tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    public static long fizzBuzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input array list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bcd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"array\")))\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered array lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered array list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))\n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l)))\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    public static long countUpper(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list arr of integers and a positive integer k, return a sorted array list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))\n    // Example 2:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))\n    // Example 3:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l)))\n    // Note:\n    // 1. The length of the array array list will be in the range of [1, 1000].\n    // 2. The elements in the array array list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    public static long largestDivisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of non-negative integers, return a cojava of the given array array list after sorting,\n    // you will sort the given array array list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array array list.\n    // Examples:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns an array array list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))\n    public static ArrayList<Long> f(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    public static boolean iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static String encode(String message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    public static long isBored(String S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes an array array list of integers as an input.\n    // it returns true if there are two distinct elements in the array list that\n    // sum to zero, and false otherwise.\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l))))\n    // (true)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // (float)-1l\n    public static float triangleArea(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a pair containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty pair if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (ArrayList<String>(\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    public static long digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array array list of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))\n    public static ArrayList<String> wordsString(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    public static long howManyTimes(String string, String substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static String removeVowels(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given array list of integers, return array list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied array list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f))))\n    // (Pair.with(2.0f, 2.2f))\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))))\n    // (Pair.with(2.0f, 2.0f))\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    public static boolean isSimplePower(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    public static long primeFib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given array list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original array list.\n    // For example:\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if in given array list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))), (0.5f))\n    // (false)\n    // >>> hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.3f))\n    // (true)\n    public static boolean hasCloseElements(ArrayList<Float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.3f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.05f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.95f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.8f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.1f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (1.0f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    public static String makePalindrome(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static String stringXor(String a, String b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array array list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    public static long fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of positive integers x. return a sorted array list of all \n    // elements that hasn't any even digit.\n    // Note: Returned array list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l))))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns an array array list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty array list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"little\")))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"world\")))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Uncle\")))\n    public static ArrayList<String> selectWords(String s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic array list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    public static long fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and an array array list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the array list.\n    // For example, if you are given \"Slices\" as the class and an array array list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new ArrayList<String>(Arrays.asList((String)\"AA\", (String)\"Be\", (String)\"CC\"))))\n    // (\"my_class.AA\")\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\"))))\n    // (\"Yes\")\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\"))))\n    // (\"No\")\n    public static String matchParens(ArrayList<String> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the array list.\n    // Return null if there is no such element.\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l))))\n    // Optional.empty()\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt((float)5l, (float)2l, (float)7l)\n    // (true)\n    // >>> anyInt((float)3l, (float)2l, (float)2l)\n    // (false)\n    // >>> anyInt((float)3l, (float)-2l, (float)1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), (float)2l)\n    // (false)\n    public static boolean anyInt(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    public static float truncateNumber(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list with elements incremented by 1.\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    public static long xOrY(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    public static long modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a pair that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // (Pair.with(1l, 1l))\n    // >>> evenOddCount((123l))\n    // (Pair.with(1l, 2l))\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapjava or not.\n    // A string is hapjava if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    public static boolean isHappy(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    public static long largestPrimeFactor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    public static long digitSum(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given array list of numbers (of at least two elements), apply a linear transform to that array list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f))))\n    // (new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l))))\n    // (12l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l))))\n    // (9l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l))))\n    // (0l)\n    public static long solution(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array array list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in an array array list, [ smalest_value, its index ],\n    // If there are no even values or the given array array list is empty, return [].\n    // Example 1:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // Example 4:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array array list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two array lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 an array array list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (\"YES\")\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l))))\n    // (\"NO\")\n    // It is assumed that the input array lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the array list l.\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (float)3l\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l))))\n    // (15.0f)\n    public static float median(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    public static boolean primeLength(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list arr of integers, find the minimum number of elements that\n    // need to be changed to make the array array list palindromic. A palindromic array array list is an array array list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l))))\n    // (4l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l))))\n    // (1l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l))))\n    // (0l)\n    public static long smallestChange(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of numbers.\n    // You need to return the sum of squared numbers in the given array list,\n    // round each element in the array list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))))\n    // (14l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)4.0f, (float)9.0f))))\n    // (98l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f))))\n    // (84l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f))))\n    // (29l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f))))\n    // (6l)\n    public static long sumSquares(ArrayList<Float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static String fileNameCheck(String file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes an array array list of integers as an input.\n    // it returns true if there are three distinct elements in the array list that\n    // sum to zero, and false otherwise.\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l)))\n    // (\"YES\")\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the array list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two array array lists of scores and guesses of equal length, where each index shows a match. \n    // Return an array array list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)5l, (long)0l, (long)0l, (long)0l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l, (long)0l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)1l, (long)0l, (long)0l, (long)6l)))\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    public static boolean validDate(String date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array array list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((new ArrayList<Long>(Arrays.asList())))\n    // (0l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)11l, (long)-11l))))\n    // (1l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l))))\n    // (3l)\n    public static long countNums(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static String antiShuffle(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    public static boolean isPalindrome(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    public static String getClosestVowel(String word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    public static boolean isPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static boolean simplify(String x, String n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    public static long hexKey(String num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a hash map\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l)))\n    // >>> histogram((\"a b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"a b c a b\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"b b b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"b\", 4l)))\n    // >>> histogram((\"\"))\n    // (new HashMap<String,Long>())\n    public static HashMap<String,Long> histogram(String test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested array lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the array list,\n    // and return array list of pairs, [(x1, y1), (x2, y2) ...] such that\n    // each pair is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList()))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted array list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned array list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array array list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l))))\n    // (3l)\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (-1l)\n    public static long canArrange(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static String sortNumbers(String numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    public static String circularShift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take an array array list of integers. For all entries in the array list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the array list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList())\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l))\n    public static long sumSquares(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l))))\n    // (10l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l))))\n    // (25l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l))))\n    // (13l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l))))\n    // (11l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l))))\n    // (3l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l))))\n    // (7l)\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given array list of integers, return a pair consisting of a sum and a product of all the integers in an array array list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList())))\n    // (Pair.with(0l, 1l))\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (Pair.with(10l, 24l))\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    public static long chooseNum(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a pair (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in an array array list.\n    // If there is no negative or positive integers, return them as null.\n    // Examples:\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(1l))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList())))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    public static long countDistinctCharacters(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1384,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in an array array list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> makeAPile((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))\n    public static ArrayList<Long> makeAPile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(makeAPile((3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))));\n    assert(makeAPile((4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)10l)))));\n    assert(makeAPile((5l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)11l, (long)13l)))));\n    assert(makeAPile((6l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l)))));\n    assert(makeAPile((8l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)18l, (long)20l, (long)22l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1392,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array array list, represented by 1, -1 or 0.\n    // Note: return null for empty arr.\n    // Example:\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l))))\n    // Optional.of(9l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l))))\n    // Optional.of(0l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array array list of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))\n    public static ArrayList<String> wordsString(String s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of integers nums, find the minimum sum of any non-empty sub-array array list\n    // of nums.\n    // Example\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l))))\n    // (1l)\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))))\n    // (-6l)\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    public static long chooseNum(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    public static String stringSequence(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of positive integers x. return a sorted array list of all \n    // elements that hasn't any even digit.\n    // Note: Returned array list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l))))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array array list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))\n    // If the array array list is empty, return an empty array array list:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // If the array array list has any strange number ignore it:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\")))\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true is array list elements are monotonically increasing or decreasing.\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l))))\n    // (true)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))))\n    // (false)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l))))\n    // (true)\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns an array array list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))\n    public static ArrayList<Long> f(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of array list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return null in case the input array list is empty.\n    // >>> longest((new ArrayList<String>(Arrays.asList())))\n    // Optional.empty()\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // Optional.of(\"a\")\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"bb\", (String)\"ccc\"))))\n    // Optional.of(\"ccc\")\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a pair that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // (Pair.with(1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // (Pair.with(4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned pair has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if all numbers in the array list l are below threshold t.\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l))\n    // (true)\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l))\n    // (false)\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array array list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((new ArrayList<Long>(Arrays.asList())))\n    // (0l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)11l, (long)-11l))))\n    // (1l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l))))\n    // (3l)\n    public static long countNums(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array array list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array array list will be randomly ordered. Your task is to determine if\n    // it is possible to get an array array list sorted in non-decreasing order by performing \n    // the following operation on the given array array list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array array list by one\n    // position in the right direction. The last element of the array array list will be moved to\n    // the starting position in the array array list i.e. 0th index. \n    // If it is possible to obtain the sorted array array list by performing the above operation\n    // then return true else return false.\n    // If the given array array list is empty then return true.\n    // Note: The given array list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l))))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array array list.\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l))))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array array list by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the array list.\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-4l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)6l)))\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)9l, (long)123l, (long)1l)))\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    public static String makePalindrome(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes an array array list l and returns an array array list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two array lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 an array array list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (\"YES\")\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l))))\n    // (\"NO\")\n    // It is assumed that the input array lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a hash map\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l)))\n    // >>> histogram((\"a b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"a b c a b\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"b b b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"b\", 4l)))\n    // >>> histogram((\"\"))\n    // (new HashMap<String,Long>())\n    public static HashMap<String,Long> histogram(String test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    public static float triangleArea(long a, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    public static long multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given array list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f))))\n    // (1.0f)\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two array lists.\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    public static String intToMiniRoman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    public static long fruitDistribution(String s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1600,7 +160,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a pair containing the result string and true/false for the check.\n    // Example\n    // >>> reverseDelete((\"abcde\"), (\"ae\"))\n    // (Pair.with(\"bcd\", false))\n    // >>> reverseDelete((\"abcdef\"), (\"b\"))\n    // (Pair.with(\"acdef\", false))\n    // >>> reverseDelete((\"abcdedcba\"), (\"ab\"))\n    // (Pair.with(\"cdedc\", true))\n    public static Pair<String, Boolean> reverseDelete(String s, String c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals((Pair.with(\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals((Pair.with(\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals((Pair.with(\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals((Pair.with(\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals((Pair.with(\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals((Pair.with(\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals((Pair.with(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1608,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of strings, where each string consists of only digits, return an array array list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of integers nums, find the minimum sum of any non-empty sub-array array list\n    // of nums.\n    // Example\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l))))\n    // (1l)\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))))\n    // (-6l)\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1624,7 +208,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this Kata, you have to sort an array array list of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-6l, (long)-5l, (long)-4l, (long)-3l, (long)-2l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-2l, (long)-6l, (long)-5l, (long)-3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)4l, (long)3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)77l, (long)4l, (long)5l, (long)3l, (long)5l, (long)7l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)4l, (long)4l, (long)3l, (long)3l, (long)5l, (long)5l, (long)5l, (long)7l, (long)77l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)44l, (long)12l, (long)32l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)32l, (long)3l, (long)5l, (long)6l, (long)12l, (long)44l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1632,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate array list of strings into a single string\n    // >>> concatenate((new ArrayList<String>(Arrays.asList())))\n    // (\"\")\n    // >>> concatenate((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // (\"abc\")\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns an array array list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty array list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"little\")))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"world\")))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Uncle\")))\n    public static ArrayList<String> selectWords(String s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts an array array list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted array list with a sorted order,\n    // The array list is always an array array list of strings and never an array array list of numbers,\n    // and it may contain duplicates.\n    // The order of the array list should be ascending by length of each word, and you\n    // should return the array list sorted by that rule.\n    // If two words have the same length, sort the array list alphabetically.\n    // The function should return an array array list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"aa\")))\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"a\", (String)\"aaa\", (String)\"cd\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"cd\")))\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    public static String getClosestVowel(String word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input array list of strings only for ones that contain given substring\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"array\")))\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\"))))\n    // (\"Yes\")\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\"))))\n    // (\"No\")\n    public static String matchParens(ArrayList<String> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static String stringXor(String a, String b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    public static long vowelsCount(String s) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list arr of integers and a positive integer k, return a sorted array list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))\n    // Example 2:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))\n    // Example 3:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l)))\n    // Note:\n    // 1. The length of the array array list will be in the range of [1, 1000].\n    // 2. The elements in the array array list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts an array array list of strings.\n    // The array list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\"))))\n    // (\"string\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\"))))\n    // (\"enam\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\"))))\n    // (\"aaaaaaa\")\n    public static String findMax(ArrayList<String> words) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l))))\n    // (12l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l))))\n    // (9l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l))))\n    // (0l)\n    public static long solution(ArrayList<Long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return null.\n    // >>> stringToMd5((\"Hello world\"))\n    // Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static Optional<String> stringToMd5(String text) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array array list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    public static String changeBase(long x, long base) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted array list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned array list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    public static boolean validDate(String date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you an array array list of GPAs for some students and you have to write \n    // a function that can output an array array list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f))))\n    // (new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of numbers, return whether or not they are sorted\n    // in ascending order. If array list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l))))\n    // (false)\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input array list `numbers'\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList())), (4l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)4l, (long)3l)))\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l)))\n    // (\"YES\")\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array array list, represented by 1, -1 or 0.\n    // Note: return null for empty arr.\n    // Example:\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l))))\n    // Optional.of(9l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l))))\n    // Optional.of(0l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered array lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered array list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))\n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l)))\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of array list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return null in case the input array list is empty.\n    // >>> longest((new ArrayList<String>(Arrays.asList())))\n    // Optional.empty()\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // Optional.of(\"a\")\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"bb\", (String)\"ccc\"))))\n    // Optional.of(\"ccc\")\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return an array array list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))\n    public static ArrayList<Long> tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    public static long digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    public static boolean isNested(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of numbers.\n    // You need to return the sum of squared numbers in the given array list,\n    // round each element in the array list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))))\n    // (14l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)4.0f, (float)9.0f))))\n    // (98l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f))))\n    // (84l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f))))\n    // (29l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f))))\n    // (6l)\n    public static long sumSquares(ArrayList<Float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array array list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l))))\n    // (3l)\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (-1l)\n    public static long canArrange(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a pair (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in an array array list.\n    // If there is no negative or positive integers, return them as null.\n    // Examples:\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(1l))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList())))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    public static boolean isEqualToSumEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static String fixSpaces(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static String fileNameCheck(String file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take an array array list of integers. For all entries in the array list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the array list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList())\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l))\n    public static long sumSquares(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static boolean simplify(String x, String n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given array list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original array list.\n    // For example:\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +580,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array array list of numbers as input and returns \n    // the number of elements in the array array list that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l))))\n    // (1l)\n    // >>> specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l))))\n    // (2l)\n    public static long specialFilter(ArrayList<Long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)5l, (long)-2l, (long)1l, (long)-5l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l)))) == (1l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l)))) == (2l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)43l, (long)-12l, (long)93l, (long)125l, (long)121l, (long)109l)))) == (4l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)71l, (long)-2l, (long)-33l, (long)75l, (long)21l, (long)19l)))) == (3l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,25 +588,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    public static long sumToN(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array array list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From an array array list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l)))\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a pair containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty pair if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (ArrayList<String>(\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts an array array list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted array list with a sorted order,\n    // The array list is always an array array list of strings and never an array array list of numbers,\n    // and it may contain duplicates.\n    // The order of the array list should be ascending by length of each word, and you\n    // should return the array list sorted by that rule.\n    // If two words have the same length, sort the array list alphabetically.\n    // The function should return an array array list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"aa\")))\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"a\", (String)\"aaa\", (String)\"cd\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"cd\")))\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))\n    public static ArrayList<String> allPrefixes(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    public static long xOrY(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of numbers, return the sum of squares of the numbers\n    // in the array list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)0l))))\n    // (10l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)-1l, (long)-2l, (long)0l))))\n    // (0l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)9l, (long)-2l))))\n    // (81l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)0l))))\n    // (0l)\n    // If the input array list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two array array lists of scores and guesses of equal length, where each index shows a match. \n    // Return an array array list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)5l, (long)0l, (long)0l, (long)0l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l, (long)0l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)1l, (long)0l, (long)0l, (long)6l)))\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and an array array list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the array list.\n    // For example, if you are given \"Slices\" as the class and an array array list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new ArrayList<String>(Arrays.asList((String)\"AA\", (String)\"Be\", (String)\"CC\"))))\n    // (\"my_class.AA\")\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a pair that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // (Pair.with(1l, 1l))\n    // >>> evenOddCount((123l))\n    // (Pair.with(1l, 2l))\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    public static String intToMiniRoman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts an array array list of strings.\n    // The array list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\"))))\n    // (\"string\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\"))))\n    // (\"enam\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\"))))\n    // (\"aaaaaaa\")\n    public static String findMax(ArrayList<String> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array array list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))\n    // >>> eat((4l), (8l), (9l))\n    // (new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))\n    // >>> eat((1l), (10l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))\n    // >>> eat((2l), (11l), (5l))\n    // (new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    public static String stringSequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two array lists operator, and operand. The first array list has basic algebra operations, and \n    // the second array list is an array array list of integers. Use the two given array lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array array list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator array list is equal to the length of operand array list minus one.\n    // Operand is an array array list of of non-negative integers.\n    // Operator array list has at least one operator, and operand array list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static String solve(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return null.\n    // >>> stringToMd5((\"Hello world\"))\n    // Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static Optional<String> stringToMd5(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1804,7 +808,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> generateIntegers((2l), (8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))\n    // >>> generateIntegers((8l), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))\n    // >>> generateIntegers((10l), (14l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> generateIntegers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(generateIntegers((2l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((10l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((132l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((17l), (89l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1812,49 +816,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given array list of integers, generate an array array list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l)))\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    public static long countDistinctCharacters(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given an array array list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (false)\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l))))\n    // (true)\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return array list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)1l, (long)2l, (long)2l, (long)1l, (long)1l, (long)1l, (long)1l, (long)4l, (long)4l)))\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty array list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the array list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l, (long)2l, (long)3l, (long)1l))))\n    // (2l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l, (long)4l))))\n    // (3l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)4l, (long)4l, (long)4l))))\n    // (-1l)\n    public static long search(ArrayList<Long> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    public static long howManyTimes(String string, String substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static String sortNumbers(String numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the array list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied array list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f))))\n    // (Pair.with(2.0f, 2.2f))\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))))\n    // (Pair.with(2.0f, 2.0f))\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given array list of numbers (of at least two elements), apply a linear transform to that array list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f))))\n    // (new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given array list of any javathon values only for integers\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)3.14f, (String)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList(1l, 2l, 3l, \"abc\", new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList())))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    public static long strlen(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    public static long largestDivisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be array listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))\n    // >>> factorize((25l))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)))\n    // >>> factorize((70l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l)))\n    public static ArrayList<Long> factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From an array array list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l)))\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static String flipCase(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate array list of strings into a single string\n    // >>> concatenate((new ArrayList<String>(Arrays.asList())))\n    // (\"\")\n    // >>> concatenate((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // (\"abc\")\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input array list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bcd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"array\")))\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    public static float truncateNumber(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the array list.\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-4l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)6l)))\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)9l, (long)123l, (long)1l)))\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    public static boolean isPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes an array array list l and returns an array array list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in an array array list\n    // >>> unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the array list.\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (3l)\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (123l)\n    public static long maxElement(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    public static long fizzBuzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1864,9 +1084,201 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes an array array list l and returns an array array list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)5l, (long)4l)))\n    public static ArrayList<Long> sortEven(ArrayList<Long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)5l, (long)0l, (long)9l, (long)1l, (long)123l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)-12l, (long)4l, (long)23l, (long)2l, (long)3l, (long)11l, (long)12l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-12l, (long)8l, (long)3l, (long)4l, (long)5l, (long)2l, (long)12l, (long)11l, (long)23l, (long)-10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    public static long primeFib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given an array array list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (false)\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l))))\n    // (true)\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes an array array list of integers as an input.\n    // it returns true if there are three distinct elements in the array list that\n    // sum to zero, and false otherwise.\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return array list with elements incremented by 1.\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes an array array list of integers as an input.\n    // it returns true if there are two distinct elements in the array list that\n    // sum to zero, and false otherwise.\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l))))\n    // (true)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    public static String changeBase(long x, long base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    public static float triangleArea(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    public static long fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the array list l.\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (float)3l\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l))))\n    // (15.0f)\n    public static float median(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    public static boolean isPalindrome(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    public static long modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given array list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f))))\n    // (1.0f)\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static String removeVowels(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if all numbers in the array list l are below threshold t.\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l))\n    // (true)\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l))\n    // (false)\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    public static long add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,9 +1288,21 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> sameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> sameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> sameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> sameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    public static boolean sameChars(String s0, String s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    public static long fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1312,585 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"<\"))\n    // (false)\n    // >>> correctBracketing((\"<>\"))\n    // (true)\n    // >>> correctBracketing((\"<<><>>\"))\n    // (true)\n    // >>> correctBracketing((\"><<>\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true is array list elements are monotonically increasing or decreasing.\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l))))\n    // (true)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))))\n    // (false)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l))))\n    // (true)\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two array lists.\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    public static long largestPrimeFactor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input array list `numbers'\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList())), (4l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)4l, (long)3l)))\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    public static long sumToN(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    public static long fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    public static long vowelsCount(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    public static String circularShift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    public static long digitSum(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    public static long fruitDistribution(String s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array array list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in an array array list, [ smalest_value, its index ],\n    // If there are no even values or the given array array list is empty, return [].\n    // Example 1:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // Example 4:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty array list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the array list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l, (long)2l, (long)3l, (long)1l))))\n    // (2l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l, (long)4l))))\n    // (3l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)4l, (long)4l, (long)4l))))\n    // (-1l)\n    public static long search(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given array list of integers, return array list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // (float)-1l\n    public static float triangleArea(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic array list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list arr of integers, find the minimum number of elements that\n    // need to be changed to make the array array list palindromic. A palindromic array array list is an array array list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l))))\n    // (4l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l))))\n    // (1l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l))))\n    // (0l)\n    public static long smallestChange(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two array lists of strings and returns the array list that has \n    // total number of chars in the all strings of the array list less than the other array list.\n    // if the two array lists have the same number of chars, return the first array list.\n    // Examples\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"4\")))\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    public static boolean isSimplePower(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    public static boolean iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    public static long hexKey(String num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    public static String decimalToBinary(long decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input array list of strings only for ones that contain given substring\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"array\")))\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapjava or not.\n    // A string is hapjava if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    public static boolean isHappy(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you an array array list of GPAs for some students and you have to write \n    // a function that can output an array array list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f))))\n    // (new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    public static boolean primeLength(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)6l, (long)7l))))\n    // (2l)\n    public static long add(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static String antiShuffle(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested array lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the array list,\n    // and return array list of pairs, [(x1, y1), (x2, y2) ...] such that\n    // each pair is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList()))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of non-negative integers, return a cojava of the given array array list after sorting,\n    // you will sort the given array array list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array array list.\n    // Examples:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    public static String encrypt(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given array list of integers, return a pair consisting of a sum and a product of all the integers in an array array list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList())))\n    // (Pair.with(0l, 1l))\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (Pair.with(10l, 24l))\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the array list.\n    // Return null if there is no such element.\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l))))\n    // Optional.empty()\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    public static long isBored(String S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt((float)5l, (float)2l, (float)7l)\n    // (true)\n    // >>> anyInt((float)3l, (float)2l, (float)2l)\n    // (false)\n    // >>> anyInt((float)3l, (float)-2l, (float)1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), (float)2l)\n    // (false)\n    public static boolean anyInt(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static String encode(String message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array array list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l))))\n    // (10l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l))))\n    // (25l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l))))\n    // (13l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l))))\n    // (11l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l))))\n    // (3l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l))))\n    // (7l)\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a hash map, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given hash map is empty.\n    // Examples:\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"b\", \"banana\"))))\n    // (true)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"A\", \"banana\", \"B\", \"banana\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", 8l, \"banana\", \"a\", \"apple\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\"))))\n    // (true)\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array array list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    // >>> countUpTo((11l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))\n    // >>> countUpTo((0l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((20l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))\n    // >>> countUpTo((1l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((18l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))\n    public static ArrayList<Long> countUpTo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    public static long multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    public static long countUpper(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given array list of integers, generate an array array list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l)))\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-java-transform.json
+++ b/prompts/humaneval-java-transform.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    public static long strlen(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    public static String encrypt(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"b\", \"banana\"))))\n    // (true)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"A\", \"banana\", \"B\", \"banana\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", 8l, \"banana\", \"a\", \"apple\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\"))))\n    // (true)\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)6l, (long)7l))))\n    // (2l)\n    public static long add(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static String fixSpaces(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    public static long fibfib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)0l))))\n    // (10l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)-1l, (long)-2l, (long)0l))))\n    // (0l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)9l, (long)-2l))))\n    // (81l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)0l))))\n    // (0l)\n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)3.14f, (String)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList(1l, 2l, 3l, \"abc\", new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList())))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)1l, (long)2l, (long)2l, (long)1l, (long)1l, (long)1l, (long)1l, (long)4l, (long)4l)))\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    public static String decimalToBinary(long decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))\n    public static ArrayList<String> allPrefixes(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    public static long add(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))\n    // >>> eat((4l), (8l), (9l))\n    // (new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))\n    // >>> eat((1l), (10l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))\n    // >>> eat((2l), (11l), (5l))\n    // (new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static String flipCase(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))\n    // If the array is empty, return an empty array:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // If the array has any strange number ignore it:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\")))\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))\n    // >>> factorize((25l))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)))\n    // >>> factorize((70l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l)))\n    public static ArrayList<Long> factorize(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    // >>> countUpTo((11l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))\n    // >>> countUpTo((0l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((20l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))\n    // >>> countUpTo((1l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((18l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))\n    public static ArrayList<Long> countUpTo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"4\")))\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (3l)\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (123l)\n    public static long maxElement(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    public static boolean isNested(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l))))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l))))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // (Pair.with(1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // (Pair.with(4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    public static boolean isEqualToSumEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l))))\n    // (false)\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static String solve(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))\n    public static ArrayList<Long> tri(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    public static long fizzBuzz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bcd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"array\")))\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))\n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l)))\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    public static long countUpper(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))\n    // Example 2:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))\n    // Example 3:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l)))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    public static long largestDivisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))\n    public static ArrayList<Long> f(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    public static boolean iscube(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static String encode(String message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    public static long isBored(String S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l))))\n    // (true)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // (float)-1l\n    public static float triangleArea(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (ArrayList<String>(\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    public static long digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))\n    public static ArrayList<String> wordsString(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    public static long howManyTimes(String string, String substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static String removeVowels(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f))))\n    // (Pair.with(2.0f, 2.2f))\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))))\n    // (Pair.with(2.0f, 2.0f))\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    public static boolean isSimplePower(long x, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    public static long primeFib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))), (0.5f))\n    // (false)\n    // >>> hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.8f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.3f))\n    // (true)\n    public static boolean hasCloseElements(ArrayList<Float> numbers, float threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.3f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f))), (0.05f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.95f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f))), (0.8f)) == (false));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))), (0.1f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (1.0f)) == (true));\n    assert(hasCloseElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f))), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    public static String makePalindrome(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static String stringXor(String a, String b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    public static long fib4(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l))))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"little\")))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"world\")))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Uncle\")))\n    public static ArrayList<String> selectWords(String s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    public static long fib(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new ArrayList<String>(Arrays.asList((String)\"AA\", (String)\"Be\", (String)\"CC\"))))\n    // (\"my_class.AA\")\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\"))))\n    // (\"Yes\")\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\"))))\n    // (\"No\")\n    public static String matchParens(ArrayList<String> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l))))\n    // Optional.empty()\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt((float)5l, (float)2l, (float)7l)\n    // (true)\n    // >>> anyInt((float)3l, (float)2l, (float)2l)\n    // (false)\n    // >>> anyInt((float)3l, (float)-2l, (float)1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), (float)2l)\n    // (false)\n    public static boolean anyInt(float x, float y, float z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    public static float truncateNumber(float number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    public static long xOrY(long n, long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    public static long modp(long n, long p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // (Pair.with(1l, 1l))\n    // >>> evenOddCount((123l))\n    // (Pair.with(1l, 2l))\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    public static boolean isHappy(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    public static long largestPrimeFactor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    public static long digitSum(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f))))\n    // (new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l))))\n    // (12l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l))))\n    // (9l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l))))\n    // (0l)\n    public static long solution(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // Example 4:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (\"YES\")\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l))))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (float)3l\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l))))\n    // (15.0f)\n    public static float median(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    public static boolean primeLength(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l))))\n    // (4l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l))))\n    // (1l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l))))\n    // (0l)\n    public static long smallestChange(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))))\n    // (14l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)4.0f, (float)9.0f))))\n    // (98l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f))))\n    // (84l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f))))\n    // (29l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f))))\n    // (6l)\n    public static long sumSquares(ArrayList<Float> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static String fileNameCheck(String file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l)))\n    // (\"YES\")\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)5l, (long)0l, (long)0l, (long)0l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l, (long)0l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)1l, (long)0l, (long)0l, (long)6l)))\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    public static boolean validDate(String date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((new ArrayList<Long>(Arrays.asList())))\n    // (0l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)11l, (long)-11l))))\n    // (1l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l))))\n    // (3l)\n    public static long countNums(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static String antiShuffle(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    public static boolean isPalindrome(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    public static String getClosestVowel(String word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    public static boolean isPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static boolean simplify(String x, String n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    public static long hexKey(String num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l)))\n    // >>> histogram((\"a b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"a b c a b\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"b b b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"b\", 4l)))\n    // >>> histogram((\"\"))\n    // (new HashMap<String,Long>())\n    public static HashMap<String,Long> histogram(String test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList()))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l))))\n    // (3l)\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (-1l)\n    public static long canArrange(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static String sortNumbers(String numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    public static String circularShift(long x, long shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList())\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l))\n    public static long sumSquares(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l))))\n    // (10l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l))))\n    // (25l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l))))\n    // (13l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l))))\n    // (11l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l))))\n    // (3l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l))))\n    // (7l)\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList())))\n    // (Pair.with(0l, 1l))\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (Pair.with(10l, 24l))\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    public static long chooseNum(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(1l))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList())))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    public static long countDistinctCharacters(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1384,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> makeAPile((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))\n    public static ArrayList<Long> makeAPile(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(makeAPile((3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))));\n    assert(makeAPile((4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)10l)))));\n    assert(makeAPile((5l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)11l, (long)13l)))));\n    assert(makeAPile((6l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l)))));\n    assert(makeAPile((8l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)18l, (long)20l, (long)22l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1392,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l))))\n    // Optional.of(9l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l))))\n    // Optional.of(0l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))\n    public static ArrayList<String> wordsString(String s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsString((\"Hi, my name is John\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\", (String)\"is\", (String)\"John\")))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"Hi, my name\")).equals((new ArrayList<String>(Arrays.asList((String)\"Hi\", (String)\"my\", (String)\"name\")))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((new ArrayList<String>(Arrays.asList((String)\"One\", (String)\"two\", (String)\"three\", (String)\"four\", (String)\"five\", (String)\"six\")))));\n    assert(wordsString((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(wordsString((\"ahmed     , gamal\")).equals((new ArrayList<String>(Arrays.asList((String)\"ahmed\", (String)\"gamal\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l))))\n    // (1l)\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))))\n    // (-6l)\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    public static long chooseNum(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    public static String stringSequence(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))\n    // >>> uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l))))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> uniqueDigits(ArrayList<Long> x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)15l, (long)33l, (long)1422l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)33l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)152l, (long)323l, (long)1422l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)12345l, (long)2033l, (long)111l, (long)151l)))).equals((new ArrayList<Long>(Arrays.asList((long)111l, (long)151l)))));\n    assert(uniqueDigits((new ArrayList<Long>(Arrays.asList((long)135l, (long)103l, (long)31l)))).equals((new ArrayList<Long>(Arrays.asList((long)31l, (long)135l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))\n    // If the array is empty, return an empty array:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // If the array has any strange number ignore it:\n    // >>> byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l))))\n    // (new ArrayList<String>(Arrays.asList((String)\"One\")))\n    public static ArrayList<String> byLength(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)1l, (long)4l, (long)5l, (long)8l, (long)2l, (long)3l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Eight\", (String)\"Five\", (String)\"Four\", (String)\"Three\", (String)\"Two\", (String)\"Two\", (String)\"One\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)55l)))).equals((new ArrayList<String>(Arrays.asList((String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)3l, (long)2l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Three\", (String)\"Two\", (String)\"One\")))));\n    assert(byLength((new ArrayList<Long>(Arrays.asList((long)9l, (long)4l, (long)8l)))).equals((new ArrayList<String>(Arrays.asList((String)\"Nine\", (String)\"Eight\", (String)\"Four\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l))))\n    // (true)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))))\n    // (false)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l))))\n    // (true)\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))\n    public static ArrayList<Long> f(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(f((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l)))));\n    assert(f((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l, (long)24l, (long)15l, (long)720l, (long)28l)))));\n    assert(f((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(f((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((new ArrayList<String>(Arrays.asList())))\n    // Optional.empty()\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // Optional.of(\"a\")\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"bb\", (String)\"ccc\"))))\n    // Optional.of(\"ccc\")\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // (Pair.with(1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // (Pair.with(4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    public static Pair<Long, Long> evenOddPalindrome(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddPalindrome((123l)).equals((Pair.with(8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals((Pair.with(1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals((Pair.with(6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals((Pair.with(5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals((Pair.with(4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals((Pair.with(4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals((Pair.with(0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l))\n    // (true)\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l))\n    // (false)\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((new ArrayList<Long>(Arrays.asList())))\n    // (0l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)11l, (long)-11l))))\n    // (1l)\n    // >>> countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l))))\n    // (3l)\n    public static long countNums(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNums((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)0l)))) == (0l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)-2l, (long)3l, (long)4l, (long)5l)))) == (6l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)9l, (long)-6l, (long)0l, (long)1l, (long)5l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)100l, (long)98l, (long)-7l, (long)1l, (long)-1l)))) == (4l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)34l, (long)-45l, (long)-56l, (long)0l)))) == (5l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    assert(countNums((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l))))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l))))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    public static boolean moveOneBall(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)10l, (long)1l, (long)2l)))) == (true));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)4l, (long)1l, (long)2l)))) == (false));\n    assert(moveOneBall((new ArrayList<Long>(Arrays.asList()))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-4l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)6l)))\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)9l, (long)123l, (long)1l)))\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    public static String makePalindrome(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (\"YES\")\n    // >>> exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l))))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    public static String exchange(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)4l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l)))).equals((\"YES\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)6l, (long)1l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)5l, (long)1l, (long)1l, (long)1l)))).equals((\"NO\")));\n    assert(exchange((new ArrayList<Long>(Arrays.asList((long)100l, (long)200l))), (new ArrayList<Long>(Arrays.asList((long)200l, (long)200l)))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l)))\n    // >>> histogram((\"a b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"a b c a b\"))\n    // (new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))\n    // >>> histogram((\"b b b b a\"))\n    // (new HashMap<String,Long>(Map.of(\"b\", 4l)))\n    // >>> histogram((\"\"))\n    // (new HashMap<String,Long>())\n    public static HashMap<String,Long> histogram(String test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    public static float triangleArea(long a, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    public static long multiply(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f))))\n    // (1.0f)\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    public static String intToMiniRoman(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    public static long fruitDistribution(String s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(histogram((\"a b b a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c a b\")).equals((new HashMap<String,Long>(Map.of(\"a\", 2l, \"b\", 2l)))));\n    assert(histogram((\"a b c d g\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l, \"b\", 1l, \"c\", 1l, \"d\", 1l, \"g\", 1l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"b b b b a\")).equals((new HashMap<String,Long>(Map.of(\"b\", 4l)))));\n    assert(histogram((\"r t g\")).equals((new HashMap<String,Long>(Map.of(\"r\", 1l, \"t\", 1l, \"g\", 1l)))));\n    assert(histogram((\"\")).equals((new HashMap<String,Long>())));\n    assert(histogram((\"a\")).equals((new HashMap<String,Long>(Map.of(\"a\", 1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1600,7 +160,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // >>> reverseDelete((\"abcde\"), (\"ae\"))\n    // (Pair.with(\"bcd\", false))\n    // >>> reverseDelete((\"abcdef\"), (\"b\"))\n    // (Pair.with(\"acdef\", false))\n    // >>> reverseDelete((\"abcdedcba\"), (\"ab\"))\n    // (Pair.with(\"cdedc\", true))\n    public static Pair<String, Boolean> reverseDelete(String s, String c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals((Pair.with(\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals((Pair.with(\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals((Pair.with(\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals((Pair.with(\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals((Pair.with(\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals((Pair.with(\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals((Pair.with(\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals((Pair.with(\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1608,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))\n    // >>> oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))\n    public static ArrayList<String> oddCount(ArrayList<String> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"1234567\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 4n the str4ng 4 of the 4nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"3\", (String)\"11111111\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 1n the str1ng 1 of the 1nput.\", (String)\"the number of odd elements 8n the str8ng 8 of the 8nput.\")))));\n    assert(oddCount((new ArrayList<String>(Arrays.asList((String)\"271\", (String)\"137\", (String)\"314\")))).equals((new ArrayList<String>(Arrays.asList((String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\", (String)\"the number of odd elements 3n the str3ng 3 of the 3nput.\", (String)\"the number of odd elements 2n the str2ng 2 of the 2nput.\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l))))\n    // (1l)\n    // >>> minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))))\n    // (-6l)\n    public static long minSubArraySum(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l, (long)2l, (long)4l)))) == (1l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)2l, (long)-10l)))) == (-14l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-9999999999999999l)))) == (-9999999999999999l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)0l, (long)10l, (long)20l, (long)1000000l)))) == (0l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-1l, (long)-2l, (long)-3l, (long)10l, (long)-5l)))) == (-6l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)13l, (long)8l, (long)3l, (long)4l)))) == (3l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)100l, (long)-33l, (long)32l, (long)-1l, (long)0l, (long)-2l)))) == (-33l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)-10l)))) == (-10l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)7l)))) == (7l));\n    assert(minSubArraySum((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    public static long maxFill(ArrayList<ArrayList<Long>> grid, long capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (1l)) == (6l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)1l))))), (2l)) == (5l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l))))), (5l)) == (0l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (2l)) == (4l));\n    assert(maxFill((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1624,7 +208,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-6l, (long)-5l, (long)-4l, (long)-3l, (long)-2l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)-4l, (long)-5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-2l, (long)-6l, (long)-5l, (long)-3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)4l, (long)3l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)77l, (long)4l, (long)5l, (long)3l, (long)5l, (long)7l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)4l, (long)4l, (long)3l, (long)3l, (long)5l, (long)5l, (long)5l, (long)7l, (long)77l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)44l, (long)12l, (long)32l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)32l, (long)3l, (long)5l, (long)6l, (long)12l, (long)44l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)16l, (long)32l)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1632,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((new ArrayList<String>(Arrays.asList())))\n    // (\"\")\n    // >>> concatenate((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // (\"abc\")\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"little\")))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (new ArrayList<String>(Arrays.asList((String)\"world\")))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (new ArrayList<String>(Arrays.asList((String)\"Uncle\")))\n    public static ArrayList<String> selectWords(String s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"little\")))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Mary\", (String)\"lamb\")))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"Hello world\"), (4l)).equals((new ArrayList<String>(Arrays.asList((String)\"world\")))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((new ArrayList<String>(Arrays.asList((String)\"Uncle\")))));\n    assert(selectWords((\"\"), (4l)).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"c\", (String)\"d\", (String)\"f\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"aa\")))\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"a\", (String)\"aaa\", (String)\"cd\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"cd\")))\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    public static String getClosestVowel(String word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"array\")))\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\"))))\n    // (\"Yes\")\n    // >>> matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\"))))\n    // (\"No\")\n    public static String matchParens(ArrayList<String> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\")\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(())\", (String)\"())())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")())\", (String)\"(()()(\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(())))\", (String)\"(()())((\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(()(\", (String)\"()))()\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"((((\", (String)\"((())\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(()\", (String)\"(()(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")(\", (String)\")(\")))).equals((\"No\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\"(\", (String)\")\")))).equals((\"Yes\")));\n    assert(matchParens((new ArrayList<String>(Arrays.asList((String)\")\", (String)\"(\")))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    public static String stringXor(String a, String b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    public static long vowelsCount(String s) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))\n    // Example 2:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))\n    // Example 3:\n    // >>> maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l)))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    public static ArrayList<Long> maximum(ArrayList<Long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l, (long)4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)2l, (long)1l, (long)2l, (long)-1l, (long)-2l, (long)1l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)123l, (long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)20l, (long)123l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-123l, (long)20l, (long)0l, (long)1l, (long)2l, (long)-3l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)20l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)0l, (long)3l, (long)-13l, (long)-8l, (long)0l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-13l, (long)-8l, (long)0l, (long)0l, (long)3l, (long)5l, (long)15l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)2l, (long)5l, (long)3l, (long)-10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)5l, (long)-7l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)4l, (long)-4l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-4l, (long)4l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)10l)))));\n    assert(maximum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-23l, (long)243l, (long)-400l, (long)0l))), (0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\"))))\n    // (\"string\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\"))))\n    // (\"enam\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\"))))\n    // (\"aaaaaaa\")\n    public static String findMax(ArrayList<String> words) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l))))\n    // (12l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l))))\n    // (9l)\n    // >>> solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l))))\n    // (0l)\n    public static long solution(ArrayList<Long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)7l, (long)1l)))) == (12l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)3l, (long)3l)))) == (9l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)24l, (long)321l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l)))) == (5l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l)))) == (0l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)30l, (long)13l, (long)23l, (long)32l)))) == (23l));\n    assert(solution((new ArrayList<Long>(Arrays.asList((long)3l, (long)13l, (long)2l, (long)9l)))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static Optional<String> stringToMd5(String text) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    public static long addElements(ArrayList<Long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)41l, (long)57l, (long)76l, (long)87l, (long)88l, (long)99l))), (3l)) == (-4l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)121l, (long)3l, (long)4000l, (long)5l, (long)6l))), (2l)) == (0l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)21l, (long)3l, (long)90l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (125l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)111l, (long)21l, (long)3l, (long)4000l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l))), (4l)) == (24l));\n    assert(addElements((new ArrayList<Long>(Arrays.asList((long)1l))), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    public static String changeBase(long x, long base) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))\n    public static ArrayList<Long> getOddCollatz(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getOddCollatz((14l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(getOddCollatz((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l)))));\n    assert(getOddCollatz((12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(getOddCollatz((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    public static boolean validDate(String date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f))))\n    // (new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l))))\n    // (false)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l))))\n    // (true)\n    // >>> isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l))))\n    // (false)\n    public static boolean isSorted(ArrayList<Long> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList()))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)2l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l)))) == (false));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l)))) == (true));\n    assert(isSorted((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList())), (4l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)4l, (long)3l)))\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l)))\n    // (\"NO\")\n    // >>> intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l)))\n    // (\"YES\")\n    public static String intersection(Pair<Long, Long> interval1, Pair<Long, Long> interval2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(2l, 3l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-1l, 1l)), (Pair.with(0l, 4l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-3l, -1l)), (Pair.with(-5l, 5l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-2l, 2l)), (Pair.with(-4l, 0l))).equals((\"YES\")));\n    assert(intersection((Pair.with(-11l, 2l)), (Pair.with(-1l, -1l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(3l, 5l))).equals((\"NO\")));\n    assert(intersection((Pair.with(1l, 2l)), (Pair.with(1l, 2l))).equals((\"NO\")));\n    assert(intersection((Pair.with(-2l, -2l)), (Pair.with(-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l))))\n    // Optional.of(9l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l))))\n    // Optional.of(0l)\n    // >>> prodSigns((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    public static Optional<Long> prodSigns(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)-4l)))).equals(Optional.of(-9l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))).equals(Optional.of(0l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)-1l, (long)1l)))).equals(Optional.of(-10l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)2l, (long)-1l, (long)-1l, (long)9l)))).equals(Optional.of(20l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)-1l, (long)1l)))).equals(Optional.of(4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)1l)))).equals(Optional.of(-4l)));\n    assert(prodSigns((new ArrayList<Long>(Arrays.asList((long)-1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))\n    // >>> minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l)))\n    public static ArrayList<Long> minPath(ArrayList<ArrayList<Long>> grid, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)2l))))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l, (long)16l))))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)12l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)16l, (long)11l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l))))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)1l, (long)10l, (long)1l, (long)10l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)14l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)13l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)11l, (long)16l))))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l, (long)1l, (long)7l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l))))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)10l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)15l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)16l, (long)14l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)7l, (long)2l))))), (12l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l, (long)1l, (long)6l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)9l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)1l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)4l))))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l, (long)1l, (long)5l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l, (long)1l, (long)2l)))));\n    assert(minPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l, (long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((new ArrayList<String>(Arrays.asList())))\n    // Optional.empty()\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // Optional.of(\"a\")\n    // >>> longest((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"bb\", (String)\"ccc\"))))\n    // Optional.of(\"ccc\")\n    public static Optional<String> longest(ArrayList<String> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(longest((new ArrayList<String>(Arrays.asList()))).equals(Optional.empty()));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals(Optional.of(\"x\")));\n    assert(longest((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"yyy\", (String)\"zzzz\", (String)\"www\", (String)\"kkkk\", (String)\"abc\")))).equals(Optional.of(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))\n    public static ArrayList<Long> tri(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tri((3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l)))));\n    assert(tri((4l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l)))));\n    assert(tri((5l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l)))));\n    assert(tri((6l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l)))));\n    assert(tri((7l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l)))));\n    assert(tri((8l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l)))));\n    assert(tri((9l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l)))));\n    assert(tri((20l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)8l, (long)3l, (long)15l, (long)4l, (long)24l, (long)5l, (long)35l, (long)6l, (long)48l, (long)7l, (long)63l, (long)8l, (long)80l, (long)9l, (long)99l, (long)10l, (long)120l, (long)11l)))));\n    assert(tri((0l)).equals((new ArrayList<Long>(Arrays.asList((long)1l)))));\n    assert(tri((1l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    public static long digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    public static boolean isNested(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f))))\n    // (14l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)4.0f, (float)9.0f))))\n    // (98l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f))))\n    // (84l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f))))\n    // (29l)\n    // >>> lst((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f))))\n    // (6l)\n    public static long sumSquares(ArrayList<Float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f)))) == (14l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f)))) == (84l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)1.4f, (float)4.2f, (float)0.0f)))) == (29l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-2.4f, (float)1.0f, (float)1.0f)))) == (6l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)1.0f, (float)15.0f, (float)2.0f)))) == (10230l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)10000.0f, (float)10000.0f)))) == (200000000l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)4.6f, (float)6.3f)))) == (75l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.4f, (float)17.9f, (float)18.9f, (float)19.9f)))) == (1086l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)0.0f)))) == (0l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f)))) == (1l));\n    assert(sumSquares((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)1.0f, (float)0.0f)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    public static boolean checkIfLastCharIsALetter(String txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l))))\n    // (3l)\n    // >>> canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (-1l)\n    public static long canArrange(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)3l, (long)5l)))) == (3l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l)))) == (-1l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)5l, (long)7l, (long)3l)))) == (4l));\n    assert(canArrange((new ArrayList<Long>(Arrays.asList()))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(1l))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList())))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    // >>> largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l))))\n    // Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))\n    public static Pair<Optional<Long>, Optional<Long>> largestSmallestIntegers(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l, (long)5l, (long)7l, (long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)4l, (long)5l, (long)6l, (long)-2l)))).equals(Optional.of(Pair.with(-2l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)3l, (long)6l, (long)2l, (long)7l, (long)-7l)))).equals(Optional.of(Pair.with(-7l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)8l, (long)4l, (long)9l, (long)2l, (long)5l, (long)-9l)))).equals(Optional.of(Pair.with(-9l, 2l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList()))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)0l)))).equals(Pair.with(Optional.of(Optional.empty()), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-5l, (long)-6l, (long)0l)))).equals(Pair.with(Optional.of(-1l), Optional.of(Optional.empty()))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    assert(largestSmallestIntegers((new ArrayList<Long>(Arrays.asList((long)-6l, (long)-4l, (long)-4l, (long)-3l, (long)-100l, (long)1l)))).equals(Optional.of(Pair.with(-3l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    public static boolean isEqualToSumEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    public static long specialFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    public static long greatestCommonDivisor(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    public static String fixSpaces(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    public static String fileNameCheck(String file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList())\n    // >>> lst\n    // (long)new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l))\n    public static long sumSquares(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l)))) == (14l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l, (long)1l)))) == (9l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l, (long)-1l)))) == (-3l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)0l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-5l, (long)2l, (long)-1l, (long)-5l)))) == (-126l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-56l, (long)-99l, (long)1l, (long)0l, (long)-2l)))) == (3030l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)-1l)))) == (0l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-16l, (long)-9l, (long)-2l, (long)36l, (long)36l, (long)26l, (long)-20l, (long)25l, (long)-40l, (long)20l, (long)-4l, (long)12l, (long)-26l, (long)35l, (long)37l)))) == (-14196l));\n    assert(sumSquares((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)17l, (long)-1l, (long)-15l, (long)13l, (long)-1l, (long)14l, (long)-14l, (long)-12l, (long)-5l, (long)14l, (long)-14l, (long)6l, (long)13l, (long)11l, (long)16l, (long)16l, (long)4l, (long)10l)))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    public static String wordsInSentence(String sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    public static boolean simplify(String x, String n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l))))\n    // (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))\n    // >>> orderByPoints((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> orderByPoints(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)11l, (long)-1l, (long)-11l, (long)-12l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-11l, (long)1l, (long)-12l, (long)11l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1234l, (long)423l, (long)463l, (long)145l, (long)2l, (long)423l, (long)423l, (long)53l, (long)6l, (long)37l, (long)3457l, (long)3l, (long)56l, (long)0l, (long)46l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)6l, (long)53l, (long)423l, (long)423l, (long)423l, (long)1234l, (long)145l, (long)37l, (long)46l, (long)56l, (long)463l, (long)3457l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)-11l, (long)-32l, (long)43l, (long)54l, (long)-98l, (long)2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-32l, (long)-98l, (long)-11l, (long)1l, (long)2l, (long)43l, (long)54l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)2l, (long)11l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(orderByPoints((new ArrayList<Long>(Arrays.asList((long)0l, (long)6l, (long)6l, (long)-76l, (long)-21l, (long)23l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-76l, (long)-21l, (long)0l, (long)4l, (long)23l, (long)6l, (long)6l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1768,7 +580,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l))))\n    // (1l)\n    // >>> specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l))))\n    // (2l)\n    public static long specialFilter(ArrayList<Long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)5l, (long)-2l, (long)1l, (long)-5l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)15l, (long)-73l, (long)14l, (long)-15l)))) == (1l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)33l, (long)-2l, (long)-3l, (long)45l, (long)21l, (long)109l)))) == (2l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)43l, (long)-12l, (long)93l, (long)125l, (long)121l, (long)109l)))) == (4l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)71l, (long)-2l, (long)-33l, (long)75l, (long)21l, (long)19l)))) == (3l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(specialFilter((new ArrayList<Long>(Arrays.asList()))) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1776,25 +588,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    public static long sumToN(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    public static long getMaxTriples(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l)))\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (ArrayList<String>(\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))\n    public static ArrayList<String> bf(String planet1, String planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((new ArrayList<String>(Arrays.asList((String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\")))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Venus\", (String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\")))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((new ArrayList<String>(Arrays.asList((String)\"Earth\", (String)\"Mars\", (String)\"Jupiter\", (String)\"Saturn\", (String)\"Uranus\")))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"aa\")))\n    // >>> listSort((new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"a\", (String)\"aaa\", (String)\"cd\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"ab\", (String)\"cd\")))\n    public static ArrayList<String> sortedListSum(ArrayList<String> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aa\", (String)\"a\", (String)\"aaa\")))).equals((new ArrayList<String>(Arrays.asList((String)\"aa\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"school\", (String)\"AI\", (String)\"asdf\", (String)\"b\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"asdf\", (String)\"school\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"dcba\", (String)\"abcd\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"dcba\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))).equals((new ArrayList<String>(Arrays.asList((String)\"AI\", (String)\"ai\", (String)\"au\")))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\", (String)\"c\", (String)\"c\", (String)\"a\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(sortedListSum((new ArrayList<String>(Arrays.asList((String)\"aaaa\", (String)\"bbbb\", (String)\"dd\", (String)\"cc\")))).equals((new ArrayList<String>(Arrays.asList((String)\"cc\", (String)\"dd\", (String)\"aaaa\", (String)\"bbbb\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))\n    public static ArrayList<String> allPrefixes(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allPrefixes((\"\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(allPrefixes((\"asdfgh\")).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"as\", (String)\"asd\", (String)\"asdf\", (String)\"asdfg\", (String)\"asdfgh\")))));\n    assert(allPrefixes((\"WWW\")).equals((new ArrayList<String>(Arrays.asList((String)\"W\", (String)\"WW\", (String)\"WWW\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    public static long xOrY(long n, long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)1l, (long)3l, (long)2l, (long)0l))))\n    // (10l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)-1l, (long)-2l, (long)0l))))\n    // (0l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)9l, (long)-2l))))\n    // (81l)\n    // >>> doubleTheDifference((new ArrayList<Float>(Arrays.asList((long)0l))))\n    // (0l)\n    // If the input list is empty, return 0.\n    public static long doubleTheDifference(ArrayList<Float> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList()))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)5.0f, (float)4.0f)))) == (25l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.1f, (float)0.2f, (float)0.3f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-10.0f, (float)-20.0f, (float)-30.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-1.0f, (float)-2.0f, (float)8.0f)))) == (0l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)0.2f, (float)3.0f, (float)5.0f)))) == (34l));\n    assert(doubleTheDifference((new ArrayList<Float>(Arrays.asList((float)-9.0f, (float)-7.0f, (float)-5.0f, (float)-3.0f, (float)-1.0f, (float)1.0f, (float)3.0f, (float)5.0f, (float)7.0f, (float)9.0f)))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))\n    // >>> compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)5l, (long)0l, (long)0l, (long)0l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l, (long)0l, (long)-2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)1l, (long)0l, (long)0l, (long)6l)))\n    public static ArrayList<Long> compare(ArrayList<Long> game, ArrayList<Long> guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)3l, (long)3l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(compare((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)0l, (long)0l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (new ArrayList<String>(Arrays.asList((String)\"AA\", (String)\"Be\", (String)\"CC\"))))\n    // (\"my_class.AA\")\n    public static String StrongestExtension(String class_name, ArrayList<String> extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(StrongestExtension((\"Watashi\"), (new ArrayList<String>(Arrays.asList((String)\"tEN\", (String)\"niNE\", (String)\"eIGHt8OKe\")))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (new ArrayList<String>(Arrays.asList((String)\"nani\", (String)\"NazeDa\", (String)\"YEs.WeCaNe\", (String)\"32145tggg\")))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (new ArrayList<String>(Arrays.asList((String)\"t\", (String)\"eMptY\", (String)\"nothing\", (String)\"zeR00\", (String)\"NuLl__\", (String)\"123NoooneB321\")))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (new ArrayList<String>(Arrays.asList((String)\"Ta\", (String)\"TAR\", (String)\"t234An\", (String)\"cosSo\")))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (new ArrayList<String>(Arrays.asList((String)\"Tab\", (String)\"123\", (String)\"781345\", (String)\"-_-\")))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (new ArrayList<String>(Arrays.asList((String)\"HhAas\", (String)\"okIWILL123\", (String)\"WorkOut\", (String)\"Fails\", (String)\"-_-\")))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (new ArrayList<String>(Arrays.asList((String)\"Die\", (String)\"NowW\", (String)\"Wow\", (String)\"WoW\")))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (new ArrayList<String>(Arrays.asList((String)\"Bb\", (String)\"91245\")))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (new ArrayList<String>(Arrays.asList((String)\"671235\", (String)\"Bb\")))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    public static boolean cycpatternCheck(String a, String b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // (Pair.with(1l, 1l))\n    // >>> evenOddCount((123l))\n    // (Pair.with(1l, 2l))\n    public static Pair<Long, Long> evenOddCount(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenOddCount((7l)).equals((Pair.with(0l, 1l))));\n    assert(evenOddCount((-78l)).equals((Pair.with(1l, 1l))));\n    assert(evenOddCount((3452l)).equals((Pair.with(2l, 2l))));\n    assert(evenOddCount((346211l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-345821l)).equals((Pair.with(3l, 3l))));\n    assert(evenOddCount((-2l)).equals((Pair.with(1l, 0l))));\n    assert(evenOddCount((-45347l)).equals((Pair.with(2l, 3l))));\n    assert(evenOddCount((0l)).equals((Pair.with(1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    public static String intToMiniRoman(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    public static boolean rightAngleTriangle(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\"))))\n    // (\"string\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\"))))\n    // (\"enam\")\n    // >>> findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\"))))\n    // (\"aaaaaaa\")\n    public static String findMax(ArrayList<String> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"of\", (String)\"string\")))).equals((\"string\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"name\", (String)\"enam\", (String)\"game\")))).equals((\"enam\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"aaaaaaa\", (String)\"bb\", (String)\"cc\")))).equals((\"aaaaaaa\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"cba\")))).equals((\"abc\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"this\", (String)\"game\", (String)\"of\", (String)\"footbott\")))).equals((\"footbott\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"gonna\", (String)\"rock\")))).equals((\"gonna\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"we\", (String)\"are\", (String)\"a\", (String)\"mad\", (String)\"nation\")))).equals((\"nation\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"this\", (String)\"is\", (String)\"a\", (String)\"prrk\")))).equals((\"this\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"b\")))).equals((\"b\")));\n    assert(findMax((new ArrayList<String>(Arrays.asList((String)\"play\", (String)\"play\", (String)\"play\")))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))\n    // >>> eat((4l), (8l), (9l))\n    // (new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))\n    // >>> eat((1l), (10l), (10l))\n    // (new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))\n    // >>> eat((2l), (11l), (5l))\n    // (new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    public static ArrayList<Long> eat(long number, long need, long remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eat((5l), (6l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)4l)))));\n    assert(eat((4l), (8l), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)1l)))));\n    assert(eat((1l), (10l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)0l)))));\n    assert(eat((2l), (11l), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)0l)))));\n    assert(eat((4l), (5l), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l)))));\n    assert(eat((4l), (5l), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    public static String stringSequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    public static long doAlgebra(ArrayList<String> op, ArrayList<Long> operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"**\", (String)\"*\", (String)\"+\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (37l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"+\", (String)\"*\", (String)\"-\"))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l)))) == (9l));\n    assert(doAlgebra((new ArrayList<String>(Arrays.asList((String)\"//\", (String)\"*\"))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)4l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    public static String solve(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    public static Optional<String> stringToMd5(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToMd5((\"Hello world\")).equals(Optional.of(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(Optional.empty()));\n    assert(stringToMd5((\"A B C\")).equals(Optional.of(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Optional.of(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1804,7 +808,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> generateIntegers((2l), (8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))\n    // >>> generateIntegers((8l), (2l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))\n    // >>> generateIntegers((10l), (14l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> generateIntegers(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(generateIntegers((2l), (10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((10l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((132l), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(generateIntegers((17l), (89l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1812,49 +816,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l)))\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    public static long countDistinctCharacters(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (false)\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l))))\n    // (true)\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)1l, (long)2l, (long)2l, (long)1l, (long)1l, (long)1l, (long)1l, (long)4l, (long)4l)))\n    public static ArrayList<Long> parseMusic(String music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseMusic((\"\")).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(parseMusic((\"o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\".| .| .| .|\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l)))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)1l, (long)1l, (long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)1l, (long)4l, (long)2l, (long)4l, (long)2l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l, (long)2l, (long)3l, (long)1l))))\n    // (2l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l, (long)4l))))\n    // (3l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)4l, (long)4l, (long)4l))))\n    // (-1l)\n    public static long search(ArrayList<Long> lst) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    public static long howManyTimes(String string, String substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    public static String sortNumbers(String numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))\n    public static ArrayList<String> separateParenGroups(String paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()())\", (String)\"((()))\", (String)\"()\", (String)\"((())()())\")))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"((()))\", (String)\"(((())))\")))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((new ArrayList<String>(Arrays.asList((String)\"(()(())((())))\")))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((new ArrayList<String>(Arrays.asList((String)\"()\", (String)\"(())\", (String)\"(()())\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f))))\n    // (Pair.with(2.0f, 2.2f))\n    // >>> findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f))))\n    // (Pair.with(2.0f, 2.0f))\n    public static Pair<Float, Float> findClosestElements(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.9f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(3.9f, 4.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)5.9f, (float)4.0f, (float)5.0f)))).equals((Pair.with(5.0f, 5.9f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.2f)))).equals((Pair.with(2.0f, 2.2f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f, (float)2.0f)))).equals((Pair.with(2.0f, 2.0f))));\n    assert(findClosestElements((new ArrayList<Float>(Arrays.asList((float)1.1f, (float)2.2f, (float)3.1f, (float)4.1f, (float)5.1f)))).equals((Pair.with(2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f))))\n    // (new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))\n    public static ArrayList<Float> rescaleToUnit(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)100.0f, (float)49.9f)))).equals((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.25f, (float)0.5f, (float)0.75f, (float)1.0f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)2.0f, (float)1.0f, (float)5.0f, (float)3.0f, (float)4.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    assert(rescaleToUnit((new ArrayList<Float>(Arrays.asList((float)12.0f, (float)11.0f, (float)15.0f, (float)13.0f, (float)14.0f)))).equals((new ArrayList<Float>(Arrays.asList((float)0.25f, (float)0.0f, (float)1.0f, (float)0.5f, (float)0.75f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter given list of any python values only for integers\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)3.14f, (String)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> filterIntegers((new ArrayList<Object>(Arrays.asList(1l, 2l, 3l, \"abc\", new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList())))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    public static ArrayList<Long> filterIntegers(ArrayList<Object> values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(4l, new HashMap<Long,Long>(Map.of()), new ArrayList<Long>(Arrays.asList()), 23.2f, 9l, \"adasd\")))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)))));\n    assert(filterIntegers((new ArrayList<Object>(Arrays.asList(3l, \"c\", 3l, 3l, \"a\", \"b\")))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    public static long strlen(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    public static long largestDivisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))\n    // >>> factorize((25l))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)))\n    // >>> factorize((70l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l)))\n    public static ArrayList<Long> factorize(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(factorize((2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(factorize((4l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(factorize((8l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l)))));\n    assert(factorize((57l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l)))));\n    assert(factorize((3249l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)19l, (long)19l)))));\n    assert(factorize((185193l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((20577l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)19l, (long)19l, (long)19l)))));\n    assert(factorize((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l)))\n    public static ArrayList<Long> removeDuplicates(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(removeDuplicates((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)3l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    public static String flipCase(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((new ArrayList<String>(Arrays.asList())))\n    // (\"\")\n    // >>> concatenate((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))))\n    // (\"abc\")\n    public static String concatenate(ArrayList<String> strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenate((new ArrayList<String>(Arrays.asList()))).equals((\"\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))).equals((\"xyz\")));\n    assert(concatenate((new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\", (String)\"w\", (String)\"k\")))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bcd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"array\")))\n    public static ArrayList<String> filterByPrefix(ArrayList<String> strings, String prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterByPrefix((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    public static float truncateNumber(float number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-4l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)6l)))\n    // >>> getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)9l, (long)123l, (long)1l)))\n    public static ArrayList<Long> getPositive(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)3l, (long)3l, (long)9l, (long)123l, (long)1l)))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(getPositive((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    public static boolean isPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))\n    public static ArrayList<Long> sortThird(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)8l, (long)3l, (long)4l, (long)6l, (long)9l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)9l, (long)4l, (long)8l, (long)3l, (long)5l)))));\n    assert(sortThird((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)3l, (long)4l, (long)8l, (long)9l, (long)5l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))\n    public static ArrayList<Long> unique(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unique((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)3l, (long)5l, (long)9l, (long)123l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (3l)\n    // >>> maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l))))\n    // (123l)\n    public static long maxElement(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(maxElement((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)124l, (long)1l, (long)-10l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    public static long fizzBuzz(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1864,9 +1084,201 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))\n    // >>> sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)5l, (long)4l)))\n    public static ArrayList<Long> sortEven(ArrayList<Long> l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)9l, (long)0l, (long)123l, (long)1l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-10l, (long)3l, (long)-5l, (long)2l, (long)-3l, (long)3l, (long)5l, (long)0l, (long)9l, (long)1l, (long)123l)))));\n    assert(sortEven((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)-12l, (long)4l, (long)23l, (long)2l, (long)3l, (long)11l, (long)12l, (long)-10l)))).equals((new ArrayList<Long>(Arrays.asList((long)-12l, (long)8l, (long)3l, (long)4l, (long)5l, (long)2l, (long)12l, (long)11l, (long)23l, (long)-10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    public static long primeFib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (false)\n    // >>> belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l))))\n    // (true)\n    public static boolean belowZero(ArrayList<Long> operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowZero((new ArrayList<Long>(Arrays.asList()))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-3l, (long)1l, (long)2l, (long)-3l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)-4l, (long)5l, (long)6l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (false));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-5l)))) == (true));\n    assert(belowZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)2l, (long)-2l, (long)5l, (long)-5l, (long)4l, (long)-4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l))))\n    // (true)\n    // >>> triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean triplesSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)7l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)9l, (long)7l)))) == (true));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    assert(triplesSumToZero((new ArrayList<Long>(Arrays.asList((long)100l, (long)3l, (long)5l, (long)-100l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    public static long carRaceCollision(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))\n    // >>> incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))\n    public static ArrayList<Long> incrList(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(incrList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l)))));\n    assert(incrList((new ArrayList<Long>(Arrays.asList((long)5l, (long)2l, (long)5l, (long)2l, (long)3l, (long)3l, (long)9l, (long)0l, (long)123l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)3l, (long)6l, (long)3l, (long)4l, (long)4l, (long)10l, (long)1l, (long)124l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l))))\n    // (false)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l))))\n    // (true)\n    // >>> pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l))))\n    // (false)\n    public static boolean pairsSumToZero(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)0l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)-2l, (long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)7l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-5l, (long)3l, (long)5l, (long)7l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)1l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)30l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)3l, (long)2l, (long)31l)))) == (true));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)30l)))) == (false));\n    assert(pairsSumToZero((new ArrayList<Long>(Arrays.asList((long)-3l, (long)9l, (long)-1l, (long)4l, (long)2l, (long)31l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    public static String changeBase(long x, long base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    public static float triangleArea(long a, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    public static long fib4(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return median of elements in the list l.\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (float)3l\n    // >>> median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l))))\n    // (15.0f)\n    public static float median(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(median((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))) == (float)3l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)-10l, (long)4l, (long)6l, (long)1000l, (long)10l, (long)20l)))) == (8.0f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)5l)))) == (float)5l);\n    assert(median((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)))) == (5.5f));\n    assert(median((new ArrayList<Long>(Arrays.asList((long)8l, (long)1l, (long)3l, (long)9l, (long)9l, (long)2l, (long)7l)))) == (float)7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    public static boolean isPalindrome(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    public static long modp(long n, long p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f))))\n    // (1.0f)\n    public static float meanAbsoluteDeviation(ArrayList<Float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f)))) == (0.5f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f)))) == (1.0f));\n    assert(meanAbsoluteDeviation((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)2.0f, (float)3.0f, (float)4.0f, (float)5.0f)))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    public static String removeVowels(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l))\n    // (true)\n    // >>> belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l))\n    // (false)\n    public static boolean belowThreshold(ArrayList<Long> l, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l))), (100l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (5l)) == (false));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (21l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))), (22l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (11l)) == (true));\n    assert(belowThreshold((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)4l, (long)10l))), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    public static long add(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,9 +1288,21 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Check if two words have the same characters.\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> sameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> sameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> sameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> sameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    public static boolean sameChars(String s0, String s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    public static long fib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1312,585 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"<\"))\n    // (false)\n    // >>> correctBracketing((\"<>\"))\n    // (true)\n    // >>> correctBracketing((\"<<><>>\"))\n    // (true)\n    // >>> correctBracketing((\"><<>\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l))))\n    // (true)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l))))\n    // (false)\n    // >>> monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l))))\n    // (true)\n    public static boolean monotonic(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)20l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)4l, (long)10l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)0l, (long)-10l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)1l, (long)0l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)5l, (long)60l)))) == (false));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)60l)))) == (true));\n    assert(monotonic((new ArrayList<Long>(Arrays.asList((long)9l, (long)9l, (long)9l, (long)9l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))\n    // >>> common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    public static ArrayList<Long> common(ArrayList<Long> l1, ArrayList<Long> l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(common((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)34l, (long)653l, (long)2l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)1l, (long)5l, (long)9l, (long)653l, (long)121l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)653l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)))));\n    assert(common((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)8l))), (new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    public static long largestPrimeFactor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList())), (4l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> intersperse((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)4l, (long)3l)))\n    public static ArrayList<Long> intersperse(ArrayList<Long> numbers, long delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersperse((new ArrayList<Long>(Arrays.asList())), (7l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)3l, (long)2l))), (8l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)6l, (long)8l, (long)3l, (long)8l, (long)2l)))));\n    assert(intersperse((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)2l, (long)2l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    public static long sumToN(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    public static boolean correctBracketing(String brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))\n    // >>> derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))\n    public static ArrayList<Long> derivative(ArrayList<Long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)12l, (long)20l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l, (long)0l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l, (long)16l)))));\n    assert(derivative((new ArrayList<Long>(Arrays.asList((long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    public static long fibfib(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    public static long vowelsCount(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    public static String circularShift(long x, long shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    public static long digitSum(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    public static long fruitDistribution(String s, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // Example 4:\n    // >>> pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    public static ArrayList<Long> pluck(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)0l, (long)3l, (long)0l, (long)4l, (long)2l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)0l, (long)5l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)8l, (long)4l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)1l)))));\n    assert(pluck((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l, (long)2l, (long)3l, (long)1l))))\n    // (2l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l, (long)4l))))\n    // (3l)\n    // >>> search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)4l, (long)4l, (long)4l))))\n    // (-1l)\n    public static long search(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)4l, (long)1l, (long)4l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)3l, (long)2l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)8l, (long)8l, (long)4l, (long)8l, (long)7l, (long)3l, (long)9l, (long)6l, (long)5l, (long)10l, (long)4l, (long)3l, (long)6l, (long)7l, (long)1l, (long)7l, (long)4l, (long)10l, (long)8l, (long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)8l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l, (long)8l, (long)8l, (long)10l, (long)5l, (long)8l, (long)5l, (long)3l, (long)10l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)3l, (long)6l, (long)5l, (long)6l, (long)4l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)6l, (long)7l, (long)1l, (long)4l, (long)7l, (long)1l, (long)8l, (long)8l, (long)9l, (long)8l, (long)10l, (long)10l, (long)8l, (long)4l, (long)10l, (long)4l, (long)10l, (long)1l, (long)2l, (long)9l, (long)5l, (long)7l, (long)9l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)10l, (long)1l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)6l, (long)9l, (long)7l, (long)5l, (long)8l, (long)7l, (long)5l, (long)3l, (long)7l, (long)5l, (long)10l, (long)10l, (long)3l, (long)6l, (long)10l, (long)2l, (long)8l, (long)6l, (long)5l, (long)4l, (long)9l, (long)5l, (long)3l, (long)10l)))) == (5l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)8l, (long)8l, (long)10l, (long)6l, (long)4l, (long)3l, (long)5l, (long)8l, (long)2l, (long)4l, (long)2l, (long)8l, (long)4l, (long)6l, (long)10l, (long)4l, (long)2l, (long)1l, (long)10l, (long)2l, (long)1l, (long)1l, (long)5l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)8l, (long)2l, (long)10l, (long)5l, (long)1l, (long)2l, (long)9l, (long)5l, (long)5l, (long)6l, (long)3l, (long)8l, (long)6l, (long)4l, (long)10l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)6l, (long)10l, (long)1l, (long)6l, (long)9l, (long)10l, (long)8l, (long)6l, (long)8l, (long)7l, (long)3l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)4l, (long)1l, (long)5l, (long)1l, (long)5l, (long)2l, (long)5l, (long)7l, (long)7l, (long)7l, (long)3l, (long)10l, (long)1l, (long)5l, (long)4l, (long)2l, (long)8l, (long)4l, (long)1l, (long)9l, (long)10l, (long)7l, (long)10l, (long)2l, (long)8l, (long)10l, (long)9l, (long)4l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)2l, (long)6l, (long)4l, (long)2l, (long)8l, (long)7l, (long)5l, (long)6l, (long)4l, (long)10l, (long)4l, (long)6l, (long)3l, (long)7l, (long)8l, (long)8l, (long)3l, (long)1l, (long)4l, (long)2l, (long)2l, (long)10l, (long)7l)))) == (4l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)6l, (long)10l, (long)2l, (long)6l, (long)10l, (long)2l, (long)7l, (long)8l, (long)10l, (long)3l, (long)8l, (long)2l, (long)6l, (long)2l, (long)3l, (long)1l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)3l, (long)9l, (long)5l, (long)6l, (long)3l, (long)2l, (long)8l, (long)5l, (long)6l, (long)10l, (long)10l, (long)6l, (long)8l, (long)4l, (long)10l, (long)7l, (long)7l, (long)10l, (long)8l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)10l)))) == (-1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)7l, (long)2l, (long)4l, (long)7l, (long)2l, (long)10l, (long)9l, (long)7l, (long)5l, (long)7l, (long)2l)))) == (2l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)10l, (long)2l, (long)1l, (long)1l, (long)10l, (long)3l, (long)6l, (long)1l, (long)8l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)9l, (long)9l, (long)3l, (long)4l, (long)1l, (long)5l, (long)9l, (long)1l, (long)2l, (long)1l, (long)1l, (long)10l, (long)7l, (long)5l, (long)6l, (long)7l, (long)6l, (long)7l, (long)7l, (long)6l)))) == (1l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)3l, (long)10l, (long)10l, (long)9l, (long)2l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))\n    public static ArrayList<Long> parseNestedParens(String paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l, (long)3l)))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((new ArrayList<Long>(Arrays.asList((long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))\n    // >>> strangeSortList((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    public static ArrayList<Long> strangeSortList(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)6l, (long)8l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)2l, (long)4l, (long)3l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)9l, (long)5l, (long)8l, (long)6l, (long)7l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)5l, (long)5l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)2l, (long)7l, (long)3l, (long)6l, (long)4l, (long)5l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)0l, (long)2l, (long)2l, (long)2l, (long)5l, (long)5l, (long)-5l, (long)-5l)))).equals((new ArrayList<Long>(Arrays.asList((long)-5l, (long)5l, (long)-5l, (long)5l, (long)0l, (long)2l, (long)2l, (long)2l)))));\n    assert(strangeSortList((new ArrayList<Long>(Arrays.asList((long)111111l)))).equals((new ArrayList<Long>(Arrays.asList((long)111111l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // (float)-1l\n    public static float triangleArea(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == (float)-1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == (float)-1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == (float)-1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == (float)-1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    public static boolean willItFly(ArrayList<Long> q, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (9l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (5l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l))), (5l)) == (true));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l))), (1l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (6l)) == (false));\n    assert(willItFly((new ArrayList<Long>(Arrays.asList((long)5l))), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l))))\n    // (4l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l))))\n    // (1l)\n    // >>> smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l))))\n    // (0l)\n    public static long smallestChange(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)4l, (long)7l, (long)9l, (long)6l)))) == (4l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)4l, (long)2l)))) == (1l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)3l, (long)1l, (long)1l, (long)3l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)1l)))) == (0l));\n    assert(smallestChange((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList())))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))\n    // >>> totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\"))))\n    // (new ArrayList<String>(Arrays.asList((String)\"4\")))\n    public static ArrayList<String> totalMatch(ArrayList<String> lst1, ArrayList<String> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"hi\", (String)\"admin\", (String)\"project\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"4\"))), (new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"5\")))).equals((new ArrayList<String>(Arrays.asList((String)\"4\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"Hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hi\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\"))), (new ArrayList<String>(Arrays.asList((String)\"hI\", (String)\"hi\", (String)\"hii\")))).equals((new ArrayList<String>(Arrays.asList((String)\"hi\", (String)\"admin\")))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList())), (new ArrayList<String>(Arrays.asList((String)\"this\")))).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(totalMatch((new ArrayList<String>(Arrays.asList((String)\"this\"))), (new ArrayList<String>(Arrays.asList()))).equals((new ArrayList<String>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    public static boolean isMultiplyPrime(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    public static boolean isSimplePower(long x, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    public static boolean iscube(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    public static long hexKey(String num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    public static String decimalToBinary(long decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList()))\n    // >>> filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"cde\", (String)\"array\"))), (\"a\"))\n    // (new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"bacd\", (String)\"array\")))\n    public static ArrayList<String> filterBySubstring(ArrayList<String> strings, String substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList())), (\"john\")).equals((new ArrayList<String>(Arrays.asList()))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"xxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xxx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"asd\", (String)\"aaaxxy\", (String)\"john doe\", (String)\"xxxAAA\", (String)\"xxx\"))), (\"xx\")).equals((new ArrayList<String>(Arrays.asList((String)\"xxx\", (String)\"aaaxxy\", (String)\"xxxAAA\", (String)\"xxx\")))));\n    assert(filterBySubstring((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"trumpet\", (String)\"prune\", (String)\"gruesome\"))), (\"run\")).equals((new ArrayList<String>(Arrays.asList((String)\"grunt\", (String)\"prune\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    public static boolean isHappy(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f))))\n    // (new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))\n    public static ArrayList<String> numericalLetterGrade(ArrayList<Float> grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)3l, (float)1.7f, (float)2l, (float)3.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"A+\", (String)\"B\", (String)\"C-\", (String)\"C\", (String)\"A-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.2f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.5f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D-\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)1.0f, (float)0.3f, (float)1.5f, (float)2.8f, (float)3.3f)))).equals((new ArrayList<String>(Arrays.asList((String)\"D\", (String)\"D-\", (String)\"C-\", (String)\"B\", (String)\"B+\")))));\n    assert(numericalLetterGrade((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.7f)))).equals((new ArrayList<String>(Arrays.asList((String)\"E\", (String)\"D-\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    public static boolean primeLength(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    public static long startsOneEnds(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    public static String solve(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)6l, (long)7l))))\n    // (2l)\n    public static long add(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)88l)))) == (88l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)2l, (long)122l)))) == (122l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)0l, (long)6l, (long)7l)))) == (0l));\n    assert(add((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)6l, (long)8l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    public static String antiShuffle(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList()))\n    // >>> getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l))\n    // (new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))\n    public static ArrayList<Pair<Long, Long>> getRow(ArrayList<ArrayList<Long>> lst, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 4l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(2l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 1l), (Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(4l, 1l), (Pair<Long, Long>)Pair.with(5l, 1l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)1l))))), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(0l, 0l), (Pair<Long, Long>)Pair.with(1l, 0l), (Pair<Long, Long>)Pair.with(2l, 1l), (Pair<Long, Long>)Pair.with(2l, 0l), (Pair<Long, Long>)Pair.with(3l, 2l), (Pair<Long, Long>)Pair.with(3l, 0l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(4l, 0l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(5l, 0l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 0l))))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList())), (1l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l))))), (2l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList()))));\n    assert(getRow((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList()), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))))), (3l)).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 2l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList())))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l))))\n    // (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))\n    // >>> sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l))))\n    // (new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))\n    public static ArrayList<Long> sortArray(ArrayList<Long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortArray((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)0l, (long)1l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l, (long)0l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)15l, (long)42l, (long)87l, (long)32l, (long)11l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)11l, (long)15l, (long)32l, (long)42l, (long)87l)))));\n    assert(sortArray((new ArrayList<Long>(Arrays.asList((long)21l, (long)14l, (long)23l, (long)11l)))).equals((new ArrayList<Long>(Arrays.asList((long)23l, (long)21l, (long)14l, (long)11l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    public static String encrypt(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList())))\n    // (Pair.with(0l, 1l))\n    // >>> sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))))\n    // (Pair.with(10l, 24l))\n    public static Pair<Long, Long> sumProduct(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList()))).equals((Pair.with(0l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))).equals((Pair.with(3l, 1l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)100l, (long)0l)))).equals((Pair.with(100l, 0l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)))).equals((Pair.with(15l, 105l))));\n    assert(sumProduct((new ArrayList<Long>(Arrays.asList((long)10l)))).equals((Pair.with(10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l))))\n    // Optional.of(2l)\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList())))\n    // Optional.empty()\n    // >>> nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l))))\n    // Optional.empty()\n    public static Optional<Long> nextSmallest(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)4l, (long)3l, (long)2l)))).equals(Optional.of(2l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList()))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l, (long)0l)))).equals(Optional.of(1l)));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))).equals(Optional.empty()));\n    assert(nextSmallest((new ArrayList<Long>(Arrays.asList((long)-35l, (long)34l, (long)12l, (long)-45l)))).equals(Optional.of(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    public static long isBored(String S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt((float)5l, (float)2l, (float)7l)\n    // (true)\n    // >>> anyInt((float)3l, (float)2l, (float)2l)\n    // (false)\n    // >>> anyInt((float)3l, (float)-2l, (float)1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), (float)2l)\n    // (false)\n    public static boolean anyInt(float x, float y, float z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(anyInt((float)2l, (float)3l, (float)1l) == (true));\n    assert(anyInt((2.5f), (float)2l, (float)3l) == (false));\n    assert(anyInt((1.5f), (float)5l, (3.5f)) == (false));\n    assert(anyInt((float)2l, (float)6l, (float)2l) == (false));\n    assert(anyInt((float)4l, (float)2l, (float)2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt((float)-4l, (float)6l, (float)2l) == (true));\n    assert(anyInt((float)2l, (float)1l, (float)1l) == (true));\n    assert(anyInt((float)3l, (float)4l, (float)7l) == (true));\n    assert(anyInt((3.0f), (float)4l, (float)7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    public static String encode(String message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l))))\n    // (10l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l))))\n    // (25l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l))))\n    // (13l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l))))\n    // (11l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l))))\n    // (3l)\n    // >>> skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l))))\n    // (7l)\n    public static long skjkasdkd(ArrayList<Long> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)3l, (long)2l, (long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)5l, (long)5l, (long)5l, (long)2l, (long)181l, (long)32l, (long)4l, (long)32l, (long)3l, (long)2l, (long)32l, (long)324l, (long)4l, (long)3l)))) == (10l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)1l, (long)8l, (long)2l, (long)4597l, (long)2l, (long)1l, (long)3l, (long)40l, (long)1l, (long)2l, (long)1l, (long)2l, (long)4l, (long)2l, (long)5l, (long)1l)))) == (25l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)1l, (long)32l, (long)5107l, (long)34l, (long)83278l, (long)109l, (long)163l, (long)23l, (long)2323l, (long)32l, (long)30l, (long)1l, (long)9l, (long)3l)))) == (13l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)724l, (long)32l, (long)71l, (long)99l, (long)32l, (long)6l, (long)0l, (long)5l, (long)91l, (long)83l, (long)0l, (long)5l, (long)6l)))) == (11l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)81l, (long)12l, (long)3l, (long)1l, (long)21l)))) == (3l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)0l, (long)8l, (long)1l, (long)2l, (long)1l, (long)7l)))) == (7l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)8191l, (long)123456l, (long)127l, (long)7l)))) == (19l));\n    assert(skjkasdkd((new ArrayList<Long>(Arrays.asList((long)127l, (long)97l, (long)8192l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"b\", \"banana\"))))\n    // (true)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", \"A\", \"banana\", \"B\", \"banana\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"a\", \"apple\", 8l, \"banana\", \"a\", \"apple\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\"))))\n    // (false)\n    // >>> checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\"))))\n    // (true)\n    public static boolean checkDictCase(HashMap<String,String> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"b\", \"banana\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"A\", \"banana\", \"B\", \"banana\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"p\", \"pineapple\", \"5\", \"banana\", \"a\", \"apple\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"Name\", \"John\", \"Age\", \"36\", \"City\", \"Houston\")))) == (false));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"STATE\", \"NC\", \"ZIP\", \"12345\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>(Map.of(\"fruit\", \"Orange\", \"taste\", \"Sweet\")))) == (true));\n    assert(checkDictCase((new HashMap<String,String>())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))\n    // >>> countUpTo((11l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))\n    // >>> countUpTo((0l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((20l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))\n    // >>> countUpTo((1l))\n    // (new ArrayList<Long>(Arrays.asList()))\n    // >>> countUpTo((18l))\n    // (new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))\n    public static ArrayList<Long> countUpTo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpTo((5l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)))));\n    assert(countUpTo((6l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((7l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l)))));\n    assert(countUpTo((10l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(countUpTo((0l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((22l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l)))));\n    assert(countUpTo((1l)).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(countUpTo((18l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l)))));\n    assert(countUpTo((47l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l)))));\n    assert(countUpTo((101l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)19l, (long)23l, (long)29l, (long)31l, (long)37l, (long)41l, (long)43l, (long)47l, (long)53l, (long)59l, (long)61l, (long)67l, (long)71l, (long)73l, (long)79l, (long)83l, (long)89l, (long)97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    public static long multiply(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    public static long countUpper(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    public static long closestInteger(String value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)2l))))\n    // (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l, (long)4l)))\n    public static ArrayList<Long> rollingMax(ArrayList<Long> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList()))).equals((new ArrayList<Long>(Arrays.asList()))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))));\n    assert(rollingMax((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)3l, (long)100l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l, (long)100l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-jl-keep.json
+++ b/prompts/humaneval-jl-keep.json
@@ -1,1160 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
+    "prompt": "\"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\nfunction has_close_elements(numbers::Vector{Float64}, threshold::Float64)::Bool \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\nfunction encode(message::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "jl",
-    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "jl",
-    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    rounded_avg(1, 5) => \"0b11\"\n    rounded_avg(7, 5) => -1\n    rounded_avg(10, 20) => \"0b1111\"\n    rounded_avg(20, 33) => \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "jl",
-    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "jl",
-    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "jl",
-    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "jl",
-    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "jl",
-    "prompt": "\"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \"\"\"\nfunction reverse_delete(s::String, c::String)::Tuple{String, Bool} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_delete;\n\t@test(candidate(\"abcde\", \"ae\") == (\"bcd\", false))\n\t@test(candidate(\"abcdef\", \"b\") == (\"acdef\", false))\n\t@test(candidate(\"abcdedcba\", \"ab\") == (\"cdedc\", true))\n\t@test(candidate(\"dwik\", \"w\") == (\"dik\", false))\n\t@test(candidate(\"a\", \"a\") == (\"\", true))\n\t@test(candidate(\"abcdedcba\", \"\") == (\"abcdedcba\", true))\n\t@test(candidate(\"abcdedcba\", \"v\") == (\"abcdedcba\", true))\n\t@test(candidate(\"vabba\", \"v\") == (\"abba\", true))\n\t@test(candidate(\"mamma\", \"mia\") == (\"\", true))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "jl",
-    "prompt": "\"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "jl",
-    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "jl",
-    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "jl",
-    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "jl",
-    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "jl",
-    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "jl",
-    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "jl",
-    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "jl",
-    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "jl",
-    "prompt": "\"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "jl",
-    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "jl",
-    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "jl",
-    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "jl",
-    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \"\"\"\nfunction encrypt(s::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "jl",
-    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "jl",
-    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "jl",
-    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\nfunction sort_even(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_even;\n\t@test(candidate([1, 2, 3]) == [1, 2, 3])\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\n\t@test(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "jl",
-    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\nfunction same_chars(s0::String, s1::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = same_chars;\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true)\n\t@test(candidate(\"abcd\", \"dddddddabc\") == true)\n\t@test(candidate(\"dddddddabc\", \"abcd\") == true)\n\t@test(candidate(\"eabcd\", \"dddddddabc\") == false)\n\t@test(candidate(\"abcd\", \"dddddddabcf\") == false)\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false)\n\t@test(candidate(\"aabb\", \"aaccc\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "jl",
-    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "jl",
-    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "jl",
-    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "jl",
-    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = has_close_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true)\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1166,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\nfunction make_a_pile(n::Int64)::Vector{Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = make_a_pile;\n\t@test(candidate(3) == [3, 5, 7])\n\t@test(candidate(4) == [4, 6, 8, 10])\n\t@test(candidate(5) == [5, 7, 9, 11, 13])\n\t@test(candidate(6) == [6, 8, 10, 12, 14, 16])\n\t@test(candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22])\nend\n",
     "stop_tokens": [
@@ -1176,993 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "jl",
-    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "jl",
-    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "jl",
-    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "jl",
-    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "jl",
-    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\nfunction flip_case(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "jl",
-    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "jl",
-    "prompt": "\"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \"\"\"\nfunction sort_array(arr::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\n\t@test(candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\n\t@test(candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\n\t@test(candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "jl",
-    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "jl",
-    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "jl",
-    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "jl",
-    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "jl",
-    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n        Input: 3\n        Output: (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n        Input: 12\n        Output: (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "jl",
-    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "jl",
-    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "jl",
-    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "jl",
-    "prompt": "\"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \"\"\"\nfunction specialFilter(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = specialFilter;\n\t@test(candidate([5, -2, 1, -5]) == 0)\n\t@test(candidate([15, -73, 14, -15]) == 1)\n\t@test(candidate([33, -2, -3, 45, 21, 109]) == 2)\n\t@test(candidate([43, -12, 93, 125, 121, 109]) == 4)\n\t@test(candidate([71, -2, -33, 75, 21, 19]) == 3)\n\t@test(candidate([1]) == 0)\n\t@test(candidate(Vector{Int64}([])) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "jl",
-    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "jl",
-    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "jl",
-    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([]) == 0\n    >>> count_nums([-1, 11, -11]) == 1\n    >>> count_nums([1, 1, 2]) == 3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "jl",
-    "prompt": "\"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "jl",
-    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"abcdef\") == 3 \n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "jl",
-    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "jl",
-    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "jl",
-    "prompt": "\"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\nfunction has_close_elements(numbers::Vector{Float64}, threshold::Float64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = has_close_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true)\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "jl",
-    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "jl",
-    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "jl",
-    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "jl",
-    "prompt": "\"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"<>\") == true)\n\t@test(candidate(\"<<><>>\") == true)\n\t@test(candidate(\"<><><<><>><>\") == true)\n\t@test(candidate(\"<><><<<><><>><>><<><><<>>>\") == true)\n\t@test(candidate(\"<<<><>>>>\") == false)\n\t@test(candidate(\"><<>\") == false)\n\t@test(candidate(\"<\") == false)\n\t@test(candidate(\"<<<<\") == false)\n\t@test(candidate(\">\") == false)\n\t@test(candidate(\"<<>\") == false)\n\t@test(candidate(\"<><><<><>><>><<>\") == false)\n\t@test(candidate(\"<><><<><>><>>><>\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "jl",
-    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4]) == -9\n    >>> prod_signs([0, 1]) == 0\n    >>> prod_signs([]) == None\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "jl",
-    "prompt": "\"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "jl",
-    "prompt": "\"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2174,7 +46,7 @@
     "language": "jl",
     "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    choose_num(12, 15) = 14\n    choose_num(13, 12) = -1\n    \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
     "stop_tokens": [
@@ -2184,13 +56,895 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "jl",
-    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
+    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    rounded_avg(1, 5) => \"0b11\"\n    rounded_avg(7, 5) => -1\n    rounded_avg(10, 20) => \"0b1111\"\n    rounded_avg(20, 33) => \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "jl",
+    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "jl",
+    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n        Input: 3\n        Output: (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n        Input: 12\n        Output: (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([]) == 0\n    >>> count_nums([-1, 11, -11]) == 1\n    >>> count_nums([1, 1, 2]) == 3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "jl",
+    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "jl",
+    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "jl",
+    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "jl",
+    "prompt": "\"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \"\"\"\nfunction reverse_delete(s::String, c::String)::Tuple{String, Bool} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_delete;\n\t@test(candidate(\"abcde\", \"ae\") == (\"bcd\", false))\n\t@test(candidate(\"abcdef\", \"b\") == (\"acdef\", false))\n\t@test(candidate(\"abcdedcba\", \"ab\") == (\"cdedc\", true))\n\t@test(candidate(\"dwik\", \"w\") == (\"dik\", false))\n\t@test(candidate(\"a\", \"a\") == (\"\", true))\n\t@test(candidate(\"abcdedcba\", \"\") == (\"abcdedcba\", true))\n\t@test(candidate(\"abcdedcba\", \"v\") == (\"abcdedcba\", true))\n\t@test(candidate(\"vabba\", \"v\") == (\"abba\", true))\n\t@test(candidate(\"mamma\", \"mia\") == (\"\", true))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "jl",
+    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \"\"\"\nfunction sort_array(arr::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\n\t@test(candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\n\t@test(candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\n\t@test(candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "jl",
+    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "jl",
+    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "jl",
+    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "jl",
+    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"abcdef\") == 3 \n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "jl",
+    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4]) == -9\n    >>> prod_signs([0, 1]) == 0\n    >>> prod_signs([]) == None\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "jl",
+    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "jl",
+    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "jl",
+    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "jl",
+    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \"\"\"\nfunction specialFilter(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = specialFilter;\n\t@test(candidate([5, -2, 1, -5]) == 0)\n\t@test(candidate([15, -73, 14, -15]) == 1)\n\t@test(candidate([33, -2, -3, 45, 21, 109]) == 2)\n\t@test(candidate([43, -12, 93, 125, 121, 109]) == 4)\n\t@test(candidate([71, -2, -33, 75, 21, 19]) == 3)\n\t@test(candidate([1]) == 0)\n\t@test(candidate(Vector{Int64}([])) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "jl",
+    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "jl",
+    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "jl",
+    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "jl",
+    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "jl",
+    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2202,7 +956,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    generate_integers(2, 8) => [2, 4, 6, 8]\n    generate_integers(8, 2) => [2, 4, 6, 8]\n    generate_integers(10, 14) => []\n    \"\"\"\nfunction generate_integers(a::Int64, b::Int64)::Vector{Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = generate_integers;\n\t@test(candidate(2, 10) == [2, 4, 6, 8])\n\t@test(candidate(10, 2) == [2, 4, 6, 8])\n\t@test(candidate(132, 2) == [2, 4, 6, 8])\n\t@test(candidate(17, 89) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
@@ -2216,9 +970,1255 @@
     "language": "jl",
     "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "jl",
+    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "jl",
+    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "jl",
+    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "jl",
+    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "jl",
+    "prompt": "\"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "jl",
+    "prompt": "\"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "jl",
+    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\nfunction flip_case(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "jl",
+    "prompt": "\"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "jl",
+    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "jl",
+    "prompt": "\"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "jl",
+    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "jl",
+    "prompt": "\"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "jl",
+    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "jl",
+    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\nfunction sort_even(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_even;\n\t@test(candidate([1, 2, 3]) == [1, 2, 3])\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\n\t@test(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "jl",
+    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "jl",
+    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "jl",
+    "prompt": "\"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "jl",
+    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "jl",
+    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "jl",
+    "prompt": "\"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "jl",
+    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "jl",
+    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "jl",
+    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\nfunction same_chars(s0::String, s1::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = same_chars;\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true)\n\t@test(candidate(\"abcd\", \"dddddddabc\") == true)\n\t@test(candidate(\"dddddddabc\", \"abcd\") == true)\n\t@test(candidate(\"eabcd\", \"dddddddabc\") == false)\n\t@test(candidate(\"abcd\", \"dddddddabcf\") == false)\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false)\n\t@test(candidate(\"aabb\", \"aaccc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "jl",
+    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "jl",
+    "prompt": "\"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"<>\") == true)\n\t@test(candidate(\"<<><>>\") == true)\n\t@test(candidate(\"<><><<><>><>\") == true)\n\t@test(candidate(\"<><><<<><><>><>><<><><<>>>\") == true)\n\t@test(candidate(\"<<<><>>>>\") == false)\n\t@test(candidate(\"><<>\") == false)\n\t@test(candidate(\"<\") == false)\n\t@test(candidate(\"<<<<\") == false)\n\t@test(candidate(\">\") == false)\n\t@test(candidate(\"<<>\") == false)\n\t@test(candidate(\"<><><<><>><>><<>\") == false)\n\t@test(candidate(\"<><><<><>><>>><>\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "jl",
+    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "jl",
+    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "jl",
+    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "jl",
+    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "jl",
+    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "jl",
+    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "jl",
+    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "jl",
+    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "jl",
+    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "jl",
+    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "jl",
+    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "jl",
+    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "jl",
+    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \"\"\"\nfunction encrypt(s::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\nfunction encode(message::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "jl",
+    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "jl",
+    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "jl",
+    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/humaneval-jl-remove.json
+++ b/prompts/humaneval-jl-remove.json
@@ -1,1566 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "jl",
-    "prompt": "\"\"\" Return length of given string\n            \"\"\"\nfunction strlen(string::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \"\"\"\nfunction encrypt(s::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \"\"\"\nfunction fix_spaces(text::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "jl",
-    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "jl",
-    "prompt": "\"\"\" Filter given list of any python values only for integers\n            \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n        \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "jl",
-    "prompt": "\"\"\"Add two numbers x and y\n            \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "jl",
-    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \"\"\"\nfunction flip_case(string::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n        \n      If the array is empty, return an empty array:\n        \n      If the array has any strange number ignore it:\n        \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "jl",
-    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique elements in a list\n        \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "jl",
-    "prompt": "\"\"\"Return maximum element in the list.\n            \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \"\"\"\nfunction is_nested(string::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n                    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "jl",
-    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "jl",
-    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "jl",
-    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \"\"\"\nfunction solve(s::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "jl",
-    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "jl",
-    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n            \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \"\"\"\nfunction count_upper(s::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "jl",
-    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n        \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "jl",
-    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \"\"\"\nfunction iscube(a::Int64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \"\"\"\nfunction encode(message::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \"\"\"\nfunction is_bored(S::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \"\"\"\nfunction digits(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "jl",
-    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \"\"\"\nfunction remove_vowels(text::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "jl",
-    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "jl",
-    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "jl",
     "prompt": "\"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n            \"\"\"\nfunction has_close_elements(numbers::Vector{Float64}, threshold::Float64)::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = has_close_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true)\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \"\"\"\nfunction make_palindrome(string::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "jl",
-    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "jl",
-    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "jl",
-    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "jl",
-    "prompt": "\"\"\"Return n-th Fibonacci number.\n                \"\"\"\nfunction fib(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "jl",
-    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "jl",
-    "prompt": "\"\"\"Return list with elements incremented by 1.\n            \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "jl",
-    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "jl",
-    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n                        \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \"\"\"\nfunction is_happy(s::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "jl",
-    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n            \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "jl",
-    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \"\"\"\nfunction digitSum(s::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "jl",
-    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "jl",
-    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "jl",
-    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "jl",
-    "prompt": "\"\"\"Return median of elements in the list l.\n            \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \"\"\"\nfunction prime_length(string::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \"\"\"\nfunction file_name_check(file_name::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "jl",
-    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "jl",
-    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \"\"\"\nfunction valid_date(date::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \"\"\"\nfunction anti_shuffle(s::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n                    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "jl",
-    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n                                \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "jl",
-    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \"\"\"\nfunction hex_key(num::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "jl",
-    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "jl",
-    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "jl",
-    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "jl",
-    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1572,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n        \"\"\"\nfunction make_a_pile(n::Int64)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = make_a_pile;\n\t@test(candidate(3) == [3, 5, 7])\n\t@test(candidate(4) == [4, 6, 8, 10])\n\t@test(candidate(5) == [5, 7, 9, 11, 13])\n\t@test(candidate(6) == [6, 8, 10, 12, 14, 16])\n\t@test(candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22])\nend\n",
     "stop_tokens": [
@@ -1582,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1596,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1610,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "jl",
-    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n                    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1624,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "jl",
-    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1638,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "jl",
-    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n                \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n        \n      If the array is empty, return an empty array:\n        \n      If the array has any strange number ignore it:\n        \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1652,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "jl",
-    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1666,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n            \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1680,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1694,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "jl",
-    "prompt": "\"\"\"Return only positive numbers in the list.\n            \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1708,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \"\"\"\nfunction make_palindrome(string::String)::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1722,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1736,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "jl",
-    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n        \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "jl",
-    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n        \n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "jl",
-    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1824,7 +200,7 @@
     "language": "jl",
     "prompt": "\"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n                \"\"\"\nfunction reverse_delete(s::String, c::String)::Tuple{String, Bool} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_delete;\n\t@test(candidate(\"abcde\", \"ae\") == (\"bcd\", false))\n\t@test(candidate(\"abcdef\", \"b\") == (\"acdef\", false))\n\t@test(candidate(\"abcdedcba\", \"ab\") == (\"cdedc\", true))\n\t@test(candidate(\"dwik\", \"w\") == (\"dik\", false))\n\t@test(candidate(\"a\", \"a\") == (\"\", true))\n\t@test(candidate(\"abcdedcba\", \"\") == (\"abcdedcba\", true))\n\t@test(candidate(\"abcdedcba\", \"v\") == (\"abcdedcba\", true))\n\t@test(candidate(\"vabba\", \"v\") == (\"abba\", true))\n\t@test(candidate(\"mamma\", \"mia\") == (\"\", true))\nend\n",
     "stop_tokens": [
@@ -1834,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "jl",
-    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n            \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1848,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n                \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
+    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1866,7 +256,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n                \"\"\"\nfunction sort_array(arr::Vector{Int64})::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\n\t@test(candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\n\t@test(candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\n\t@test(candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nend\n",
     "stop_tokens": [
@@ -1876,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "jl",
-    "prompt": "\"\"\" Concatenate list of strings into a single string\n            \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1890,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
+    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1904,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n            \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1918,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1932,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "jl",
-    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1946,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1960,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1974,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "jl",
-    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1988,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \"\"\"\nfunction valid_date(date::String)::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2002,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "jl",
-    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n                \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2016,13 +406,293 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "jl",
-    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "jl",
+    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "jl",
+    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "jl",
+    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \"\"\"\nfunction digits(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \"\"\"\nfunction is_nested(string::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "jl",
+    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "jl",
+    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n            \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \"\"\"\nfunction fix_spaces(text::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \"\"\"\nfunction file_name_check(file_name::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2034,7 +704,7 @@
     "language": "jl",
     "prompt": "\"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n            \"\"\"\nfunction specialFilter(nums::Vector{Int64})::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = specialFilter;\n\t@test(candidate([5, -2, 1, -5]) == 0)\n\t@test(candidate([15, -73, 14, -15]) == 1)\n\t@test(candidate([33, -2, -3, 45, 21, 109]) == 2)\n\t@test(candidate([43, -12, 93, 125, 121, 109]) == 4)\n\t@test(candidate([71, -2, -33, 75, 21, 19]) == 3)\n\t@test(candidate([1]) == 0)\n\t@test(candidate(Vector{Int64}([])) == 0)\nend\n",
     "stop_tokens": [
@@ -2044,13 +714,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "jl",
-    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n                        \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2058,13 +728,209 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "jl",
-    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n        \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "jl",
+    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "jl",
+    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "jl",
+    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "jl",
+    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "jl",
+    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \"\"\"\nfunction solve(s::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2076,7 +942,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n                \"\"\"\nfunction generate_integers(a::Int64, b::Int64)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = generate_integers;\n\t@test(candidate(2, 10) == [2, 4, 6, 8])\n\t@test(candidate(10, 2) == [2, 4, 6, 8])\n\t@test(candidate(132, 2) == [2, 4, 6, 8])\n\t@test(candidate(17, 89) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
@@ -2086,13 +952,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "jl",
-    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2100,13 +966,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "jl",
-    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2114,13 +980,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2128,13 +994,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "jl",
-    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "jl",
+    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "jl",
+    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "jl",
+    "prompt": "\"\"\" Filter given list of any python values only for integers\n            \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "jl",
+    "prompt": "\"\"\" Return length of given string\n            \"\"\"\nfunction strlen(string::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n        \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "jl",
+    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \"\"\"\nfunction flip_case(string::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "jl",
+    "prompt": "\"\"\" Concatenate list of strings into a single string\n            \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n            \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "jl",
+    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "jl",
+    "prompt": "\"\"\"Return only positive numbers in the list.\n            \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n                                \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "jl",
+    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique elements in a list\n        \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "jl",
+    "prompt": "\"\"\"Return maximum element in the list.\n            \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "jl",
+    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2146,9 +1264,219 @@
     "language": "jl",
     "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n            \"\"\"\nfunction sort_even(l::Vector{Int64})::Vector{Int64} \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_even;\n\t@test(candidate([1, 2, 3]) == [1, 2, 3])\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\n\t@test(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "jl",
+    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "jl",
+    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "jl",
+    "prompt": "\"\"\"Return list with elements incremented by 1.\n            \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "jl",
+    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n        \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "jl",
+    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "jl",
+    "prompt": "\"\"\"Return median of elements in the list l.\n            \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n                    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "jl",
+    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n                        \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \"\"\"\nfunction remove_vowels(text::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "jl",
+    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n            \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "jl",
+    "prompt": "\"\"\"Add two numbers x and y\n            \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2160,9 +1488,23 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Check if two words have the same characters.\n                            \"\"\"\nfunction same_chars(s0::String, s1::String)::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = same_chars;\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true)\n\t@test(candidate(\"abcd\", \"dddddddabc\") == true)\n\t@test(candidate(\"dddddddabc\", \"abcd\") == true)\n\t@test(candidate(\"eabcd\", \"dddddddabc\") == false)\n\t@test(candidate(\"abcd\", \"dddddddabcf\") == false)\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false)\n\t@test(candidate(\"aabb\", \"aaccc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "jl",
+    "prompt": "\"\"\"Return n-th Fibonacci number.\n                \"\"\"\nfunction fib(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2174,9 +1516,667 @@
     "language": "jl",
     "prompt": "\"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"<>\") == true)\n\t@test(candidate(\"<<><>>\") == true)\n\t@test(candidate(\"<><><<><>><>\") == true)\n\t@test(candidate(\"<><><<<><><>><>><<><><<>>>\") == true)\n\t@test(candidate(\"<<<><>>>>\") == false)\n\t@test(candidate(\"><<>\") == false)\n\t@test(candidate(\"<\") == false)\n\t@test(candidate(\"<<<<\") == false)\n\t@test(candidate(\">\") == false)\n\t@test(candidate(\"<<>\") == false)\n\t@test(candidate(\"<><><<><>><>><<>\") == false)\n\t@test(candidate(\"<><><<><>><>>><>\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n                \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n        \n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "jl",
+    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n            \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "jl",
+    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "jl",
+    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n                        \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "jl",
+    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "jl",
+    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "jl",
+    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "jl",
+    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "jl",
+    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \"\"\"\nfunction digitSum(s::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "jl",
+    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "jl",
+    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \"\"\"\nfunction iscube(a::Int64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "jl",
+    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \"\"\"\nfunction hex_key(num::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n            \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \"\"\"\nfunction is_happy(s::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "jl",
+    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \"\"\"\nfunction prime_length(string::String)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "jl",
+    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \"\"\"\nfunction anti_shuffle(s::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \"\"\"\nfunction encrypt(s::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \"\"\"\nfunction is_bored(S::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \"\"\"\nfunction encode(message::String)::String \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "jl",
+    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "jl",
+    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \"\"\"\nfunction count_upper(s::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "jl",
+    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/humaneval-jl-reworded.json
+++ b/prompts/humaneval-jl-reworded.json
@@ -1,1608 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "jl",
-    "prompt": "\"\"\" Return length of given string\n    >>> strlen(\"\")\n    0\n    >>> strlen(\"abc\")\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \"\"\"\nfunction encrypt(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a dictionary, return true if all keys are strings in lower \n    case or all keys are strings in upper case, else return false.\n    The function should return false is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"b\" => \"banana\"))\n    true\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n    false\n    >>> check_dict_case(Dict(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n    false\n    >>> check_dict_case(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n    false\n    >>> check_dict_case(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n    true\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "jl",
-    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector of numbers, return the sum of squares of the numbers\n    in the vector that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input vector is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "jl",
-    "prompt": "\"\"\" Filter given vector of any jlthon values only for integers\n    >>> filter_integers([\"a\", 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, \"abc\", Dict(), []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return vector of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    \"db1111db\"\n    >>> decimal_to_binary(32)\n    \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "jl",
-    "prompt": "\"\"\" Return vector of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "jl",
-    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return a vector of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given two vectors operator, and operand. The first vector has basic algebra operations, and \n    the second vector is a vector of integers. Use the two given vectors to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    vector = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator vector is equal to the length of operand vector minus one.\n        Operand is a vector of of non-negative integers.\n        Operator vector has at least one operator, and operand vector has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "jl",
-    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \"\"\"\nfunction flip_case(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting vector, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the vector is empty, return an empty vector:\n    >>> by_length([])\n    []\n    \n      If the vector has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    [\"One\"]\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "jl",
-    "prompt": "\"\"\" Return vector of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "jl",
-    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns a vector of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique elements in a vector\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that accepts two vectors of strings and returns the vector that has \n    total number of chars in the all strings of the vector less than the other vector.\n\n    if the two vectors have the same number of chars, return the first vector.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "jl",
-    "prompt": "\"\"\"Return maximum element in the vector.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return true if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    \"0b11\"\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    \"0b1111\"\n    >>> rounded_avg(20, 33)\n    \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given a vector of strings, where each string consists of only digits, return a vector.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "jl",
-    "prompt": "\"\"\"We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the vector will be randomly ordered. Your task is to determine if\n    it is possible to get a vector sorted in non-decreasing order by performing \n    the following operation on the given vector:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the vector by one\n    position in the right direction. The last element of the vector will be moved to\n    the starting position in the vector i.e. 0th index. \n\n    If it is possible to obtain the sorted vector by performing the above operation\n    then return true else return false.\n    If the given vector is empty then return true.\n\n    Note: The given vector is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given vector.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                vector by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "jl",
-    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    false\n    >>> is_equal_to_sum_even(6)\n    false\n    >>> is_equal_to_sum_even(8)\n    true\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "jl",
-    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector of numbers, return whether or not they are sorted\n    in ascending order. If vector has more than 1 duplicate of the same\n    number, return false. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5])\n    false\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    false\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    true\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    false\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "jl",
-    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a vector of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "jl",
-    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "jl",
-    "prompt": "\"\"\" Filter an input vector of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    \"1\"\n    >>> solve(150)\n    \"110\"\n    >>> solve(147)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered vectors of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered vector of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1\n    >>> count_upper(\"abcdefg\")\n    0\n    >>> count_upper(\"dBBE\")\n    0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector arr of integers and a positive integer k, return a sorted vector \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the vector will be in the range of [1, 1000].\n        2. The elements in the vector will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "jl",
-    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector of non-negative integers, return a cojl of the given vector after sorting,\n    you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given vector.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "jl",
-    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns true \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    true\n    >>> iscube(2)\n    false\n    >>> iscube(-1)\n    true\n    >>> iscube(64)\n    true\n    >>> iscube(0)\n    true\n    >>> iscube(180)\n    false\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \"\"\"\nfunction encode(message::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a vector of integers as an input.\n    it returns true if there are two distinct elements in the vector that\n    sum to zero, and false otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    false\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    true\n    >>> pairs_sum_to_zero([1])\n    false\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return a vector of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "jl",
-    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0\n    >>> how_many_times(\"aaa\", \"a\")\n    3\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given vector of integers, return vector in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "jl",
-    "prompt": "\"\"\" From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    true\n    >>> is_simple_power(2, 2)\n    true\n    >>> is_simple_power(8, 2)\n    true\n    >>> is_simple_power(3, 2)\n    false\n    >>> is_simple_power(3, 1)\n    false\n    >>> is_simple_power(5, 3)\n    false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "jl",
-    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function which sorts the given vector of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original vector.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "jl",
     "prompt": "\"\"\" Check if in given vector of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \"\"\"\nfunction has_close_elements(numbers::Vector{Float64}, threshold::Float64)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = has_close_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true)\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "jl",
-    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "jl",
-    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a non-empty vector of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "jl",
-    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a vector of positive integers x. return a sorted vector of all \n    elements that hasn't any even digit.\n\n    Note: Returned vector should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a vector of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty vector.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2)\n    []\n    >>> select_words(\"Hello world\", 4)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3)\n    [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that returns true if the object q will fly, and false otherwise.\n    The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "jl",
-    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given the name of a class (a string) and a vector of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the vector.\n    For example, if you are given \"Slices\" as the class and a vector of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a vector of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a vector of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the vector.\n    Return nothing if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    nothing\n    >>> next_smallest([1, 1])\n    nothing\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    true\n    \n    >>> any_int(3, 2, 2)\n    false\n\n    >>> any_int(3, -2, 1)\n    true\n    \n    >>> any_int(3.6, -2.2, 2)\n    false\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "jl",
-    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "jl",
-    "prompt": "\"\"\"Return vector with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "jl",
-    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "jl",
-    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is hapjl or not.\n    A string is hapjl if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "jl",
-    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "jl",
-    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0\n    >>> digitSum(\"abAB\")\n    131\n    >>> digitSum(\"abcCd\")\n    67\n    >>> digitSum(\"helloE\")\n    69\n    >>> digitSum(\"woArBld\")\n    131\n    >>> digitSum(\"aAaaaXa\")\n    153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "jl",
-    "prompt": "\"\"\" Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "jl",
-    "prompt": "\"\"\"\n    \"Given a vector representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a vector, [ smalest_value, its index ],\n    If there are no even values or the given vector is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer vector a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "jl",
-    "prompt": "\"\"\"In this problem, you will implement a function that takes two vectors of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a vector of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    \"YES\"\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    \"NO\"\n    It is assumed that the input vectors will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "jl",
-    "prompt": "\"\"\"Return median of elements in the vector l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that takes a string and returns true if the string\n    length is a prime number or false otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector arr of integers, find the minimum number of elements that\n    need to be changed to make the vector palindromic. A palindromic vector is a vector that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a vector of numbers.\n    You need to return the sum of squared numbers in the given vector,\n    round each element in the vector to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    triples_sum_to_zero takes a vector of integers as an input.\n    it returns true if there are three distinct elements in the vector that\n    sum to zero, and false otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    true\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    true\n    >>> triples_sum_to_zero([1])\n    false\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    \"NO\"\n    >>> intersection((-1, 1), (0, 4))\n    \"NO\"\n    >>> intersection((-3, -1), (-5, 5))\n    \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the vector of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "jl",
-    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two vectors of scores and guesses of equal length, where each index shows a match. \n    Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns true if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and false otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "jl",
-    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns true if the date is valid otherwise false.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function count_nums which takes a vector of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "jl",
-    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    false\n    >>> is_prime(101)\n    true\n    >>> is_prime(11)\n    true\n    >>> is_prime(13441)\n    true\n    >>> is_prime(61)\n    true\n    >>> is_prime(4)\n    false\n    >>> is_prime(1)\n    false\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns true if x * n evaluates to a whole number and false\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "jl",
-    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1\n    >>> hex_key(\"1077E\")\n    2\n    >>> hex_key(\"ABED1A33\")\n    4\n    >>> hex_key(\"123456789ABCDEF0\")\n    6\n    >>> hex_key(\"2020\")\n    2\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n    >>> histogram(\"a b b a\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"a b c a b\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"b b b b a\")\n    Dict(\"b\" => 4)\n    >>> histogram(\"\")\n    Dict()\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested vectors,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the vector,\n    and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned vector sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given vector will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "jl",
-    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "jl",
-    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\"\n    This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a vector of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "jl",
-    "prompt": "\"\"\" For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "jl",
-    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a vector.\n    If there is no negative or positive integers, return them as nothing.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (nothing, 1)\n    >>> largest_smallest_integers([])\n    (nothing, nothing)\n    >>> largest_smallest_integers([0])\n    (nothing, nothing)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "jl",
-    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3\n    >>> count_distinct_characters(\"Jerry\")\n    4\n    \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1614,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a vector, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\nfunction make_a_pile(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = make_a_pile;\n\t@test(candidate(3) == [3, 5, 7])\n\t@test(candidate(4) == [4, 6, 8, 10])\n\t@test(candidate(5) == [5, 7, 9, 11, 13])\n\t@test(candidate(6) == [6, 8, 10, 12, 14, 16])\n\t@test(candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22])\nend\n",
     "stop_tokens": [
@@ -1624,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given a vector arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the vector, represented by 1, -1 or 0.\n    Note: return nothing for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    nothing\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return a vector of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1638,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1652,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "jl",
-    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    \"0\"\n    >>> string_sequence(5)\n    \"0 1 2 3 4 5\"\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    \"0b11\"\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    \"0b1111\"\n    >>> rounded_avg(20, 33)\n    \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1666,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "jl",
-    "prompt": "\"\"\"You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "prompt": "\"\"\"Given a vector of positive integers x. return a sorted vector of all \n    elements that hasn't any even digit.\n\n    Note: Returned vector should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1680,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "jl",
-    "prompt": "\"\"\"Return true is vector elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    true\n    >>> monotonic([1, 20, 4, 10])\n    false\n    >>> monotonic([4, 1, 0, -10])\n    true\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\"\n    Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting vector, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the vector is empty, return an empty vector:\n    >>> by_length([])\n    []\n    \n      If the vector has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    [\"One\"]\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1694,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "jl",
-    "prompt": "\"\"\" Out of vector of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return nothing in case the input vector is empty.\n    >>> longest([])\n    nothing\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1708,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"Return true if all numbers in the vector l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    true\n    >>> below_threshold([1, 20, 4, 10], 5)\n    false\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1722,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    true\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Write a function count_nums which takes a vector of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1736,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "jl",
-    "prompt": "\"\"\"Return only positive numbers in the vector.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the vector will be randomly ordered. Your task is to determine if\n    it is possible to get a vector sorted in non-decreasing order by performing \n    the following operation on the given vector:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the vector by one\n    position in the right direction. The last element of the vector will be moved to\n    the starting position in the vector i.e. 0th index. \n\n    If it is possible to obtain the sorted vector by performing the above operation\n    then return true else return false.\n    If the given vector is empty then return true.\n\n    Note: The given vector is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given vector.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                vector by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1750,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"This function takes a vector l and returns a vector l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1764,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "prompt": "\"\"\"In this problem, you will implement a function that takes two vectors of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a vector of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    \"YES\"\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    \"NO\"\n    It is assumed that the input vectors will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1778,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "jl",
-    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n    >>> histogram(\"a b b a\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"a b c a b\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"b b b b a\")\n    Dict(\"b\" => 4)\n    >>> histogram(\"\")\n    Dict()\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "jl",
-    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "jl",
-    "prompt": "\"\"\" For a given vector of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique common elements for two vectors.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    \"xix\"\n    >>> int_to_mini_roman(152)\n    \"clii\"\n    >>> int_to_mini_roman(426)\n    \"cdxxvi\"\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "jl",
-    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n    8\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n    2\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n    95\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n    19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1866,7 +200,7 @@
     "language": "jl",
     "prompt": "\"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and true/false for the check.\n    Example\n    >>> reverse_delete(\"abcde\", \"ae\")\n    (\"bcd\", false)\n    >>> reverse_delete(\"abcdef\", \"b\")\n    (\"acdef\", false)\n    >>> reverse_delete(\"abcdedcba\", \"ab\")\n    (\"cdedc\", true)\n    \"\"\"\nfunction reverse_delete(s::String, c::String)::Tuple{String, Bool} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_delete;\n\t@test(candidate(\"abcde\", \"ae\") == (\"bcd\", false))\n\t@test(candidate(\"abcdef\", \"b\") == (\"acdef\", false))\n\t@test(candidate(\"abcdedcba\", \"ab\") == (\"cdedc\", true))\n\t@test(candidate(\"dwik\", \"w\") == (\"dik\", false))\n\t@test(candidate(\"a\", \"a\") == (\"\", true))\n\t@test(candidate(\"abcdedcba\", \"\") == (\"abcdedcba\", true))\n\t@test(candidate(\"abcdedcba\", \"v\") == (\"abcdedcba\", true))\n\t@test(candidate(\"vabba\", \"v\") == (\"abba\", true))\n\t@test(candidate(\"mamma\", \"mia\") == (\"\", true))\nend\n",
     "stop_tokens": [
@@ -1876,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "jl",
-    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "prompt": "\"\"\"Given a vector of strings, where each string consists of only digits, return a vector.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1890,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string of words, return a vector of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words(\"Hello world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"Hello,world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"abcdef\")\n    3\n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
+    "prompt": "\"\"\"\n    Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1908,7 +256,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    In this Kata, you have to sort a vector of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4])\n    [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6])\n    [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4])\n    [0, 1, 2, 3, 4]\n    \"\"\"\nfunction sort_array(arr::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\n\t@test(candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\n\t@test(candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\n\t@test(candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nend\n",
     "stop_tokens": [
@@ -1918,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "jl",
-    "prompt": "\"\"\" Concatenate vector of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a vector of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty vector.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2)\n    []\n    >>> select_words(\"Hello world\", 4)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3)\n    [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1932,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a vector of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted vector with a sorted order,\n    The vector is always a vector of strings and never a vector of numbers,\n    and it may contain duplicates.\n    The order of the vector should be ascending by length of each word, and you\n    should return the vector sorted by that rule.\n    If two words have the same length, sort the vector alphabetically.\n    The function should return a vector of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
+    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1946,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "jl",
-    "prompt": "\"\"\" Filter an input vector of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "prompt": "\"\"\"\n    You are given a vector of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1960,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1974,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "jl",
-    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "prompt": "\"\"\"\n    Given a vector arr of integers and a positive integer k, return a sorted vector \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the vector will be in the range of [1, 1000].\n        2. The elements in the vector will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1988,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a vector of strings.\n    The vector contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2002,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return nothing.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "prompt": "\"\"\"\n    Given a non-empty vector of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2016,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "jl",
-    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    \"22\"\n    >>> change_base(8, 2)\n    \"1000\"\n    >>> change_base(7, 2)\n    \"111\"\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned vector sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2030,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return true if the three\n    sides form a right-angled triangle, false otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    true\n    >>> right_angle_triangle(1, 2, 3)\n    false\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns true if the date is valid otherwise false.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2044,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "jl",
-    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a vector of GPAs for some students and you have to write \n    a function that can output a vector of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "prompt": "\"\"\"\n    Given a string of words, return a vector of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words(\"Hello world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"Hello,world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"abcdef\")\n    3\n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2058,13 +406,293 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "jl",
-    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "prompt": "\"\"\"\n    Given a vector of numbers, return whether or not they are sorted\n    in ascending order. If vector has more than 1 duplicate of the same\n    number, return false. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5])\n    false\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    false\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    true\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    false\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "jl",
+    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    \"NO\"\n    >>> intersection((-1, 1), (0, 4))\n    \"NO\"\n    >>> intersection((-3, -1), (-5, 5))\n    \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a vector arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the vector, represented by 1, -1 or 0.\n    Note: return nothing for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    nothing\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered vectors of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered vector of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "jl",
+    "prompt": "\"\"\" Out of vector of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return nothing in case the input vector is empty.\n    >>> longest([])\n    nothing\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "jl",
+    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a vector of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return true if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a vector of numbers.\n    You need to return the sum of squared numbers in the given vector,\n    round each element in the vector to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns true if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and false otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given vector will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a vector.\n    If there is no negative or positive integers, return them as nothing.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (nothing, 1)\n    >>> largest_smallest_integers([])\n    (nothing, nothing)\n    >>> largest_smallest_integers([0])\n    (nothing, nothing)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "jl",
+    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    false\n    >>> is_equal_to_sum_even(6)\n    false\n    >>> is_equal_to_sum_even(8)\n    true\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "jl",
+    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\"\n    This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns true if x * n evaluates to a whole number and false\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function which sorts the given vector of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original vector.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2076,7 +704,7 @@
     "language": "jl",
     "prompt": "\"\"\"Write a function that takes a vector of numbers as input and returns \n    the number of elements in the vector that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15, -73, 14, -15])\n    1\n    >>> specialFilter([33, -2, -3, 45, 21, 109])\n    2\n    \"\"\"\nfunction specialFilter(nums::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = specialFilter;\n\t@test(candidate([5, -2, 1, -5]) == 0)\n\t@test(candidate([15, -73, 14, -15]) == 1)\n\t@test(candidate([33, -2, -3, 45, 21, 109]) == 2)\n\t@test(candidate([43, -12, 93, 125, 121, 109]) == 4)\n\t@test(candidate([71, -2, -33, 75, 21, 19]) == 3)\n\t@test(candidate([1]) == 0)\n\t@test(candidate(Vector{Int64}([])) == 0)\nend\n",
     "stop_tokens": [
@@ -2086,13 +714,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "jl",
-    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer vector a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2100,13 +728,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "jl",
-    "prompt": "\"\"\" From a vector of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"Write a function that accepts a vector of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted vector with a sorted order,\n    The vector is always a vector of strings and never a vector of numbers,\n    and it may contain duplicates.\n    The order of the vector should be ascending by length of each word, and you\n    should return the vector sorted by that rule.\n    If two words have the same length, sort the vector alphabetically.\n    The function should return a vector of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "jl",
+    "prompt": "\"\"\" Return vector of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "jl",
+    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a vector of numbers, return the sum of squares of the numbers\n    in the vector that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input vector is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "jl",
+    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two vectors of scores and guesses of equal length, where each index shows a match. \n    Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given the name of a class (a string) and a vector of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the vector.\n    For example, if you are given \"Slices\" as the class and a vector of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "jl",
+    "prompt": "\"\"\"You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "jl",
+    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    \"xix\"\n    >>> int_to_mini_roman(152)\n    \"clii\"\n    >>> int_to_mini_roman(426)\n    \"cdxxvi\"\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return true if the three\n    sides form a right-angled triangle, false otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    true\n    >>> right_angle_triangle(1, 2, 3)\n    false\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that accepts a vector of strings.\n    The vector contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return a vector of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "jl",
+    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    \"0\"\n    >>> string_sequence(5)\n    \"0 1 2 3 4 5\"\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given two vectors operator, and operand. The first vector has basic algebra operations, and \n    the second vector is a vector of integers. Use the two given vectors to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    vector = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator vector is equal to the length of operand vector minus one.\n        Operand is a vector of of non-negative integers.\n        Operator vector has at least one operator, and operand vector has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return nothing.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2118,7 +956,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2, 8)\n    [2, 4, 6, 8]\n    >>> generate_integers(8, 2)\n    [2, 4, 6, 8]\n    >>> generate_integers(10, 14)\n    []\n    \"\"\"\nfunction generate_integers(a::Int64, b::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = generate_integers;\n\t@test(candidate(2, 10) == [2, 4, 6, 8])\n\t@test(candidate(10, 2) == [2, 4, 6, 8])\n\t@test(candidate(132, 2) == [2, 4, 6, 8])\n\t@test(candidate(17, 89) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
@@ -2128,13 +966,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "jl",
-    "prompt": "\"\"\" From a given vector of integers, generate a vector of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3\n    >>> count_distinct_characters(\"Jerry\")\n    4\n    \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2142,13 +980,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "jl",
-    "prompt": "\"\"\" You're given a vector of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return true. Otherwise it should return false.\n    >>> below_zero([1, 2, 3])\n    false\n    >>> below_zero([1, 2, -4, 5])\n    true\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return vector of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2156,13 +994,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the vector.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0\n    >>> how_many_times(\"aaa\", \"a\")\n    3\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2170,13 +1008,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "jl",
-    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the vector of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "jl",
+    "prompt": "\"\"\" From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "jl",
+    "prompt": "\"\"\" Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "jl",
+    "prompt": "\"\"\" Filter given vector of any jlthon values only for integers\n    >>> filter_integers([\"a\", 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, \"abc\", Dict(), []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "jl",
+    "prompt": "\"\"\" Return length of given string\n    >>> strlen(\"\")\n    0\n    >>> strlen(\"abc\")\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "jl",
+    "prompt": "\"\"\" Return vector of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\" From a vector of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "jl",
+    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \"\"\"\nfunction flip_case(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "jl",
+    "prompt": "\"\"\" Concatenate vector of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input vector of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "jl",
+    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "jl",
+    "prompt": "\"\"\"Return only positive numbers in the vector.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    false\n    >>> is_prime(101)\n    true\n    >>> is_prime(11)\n    true\n    >>> is_prime(13441)\n    true\n    >>> is_prime(61)\n    true\n    >>> is_prime(4)\n    false\n    >>> is_prime(1)\n    false\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "jl",
+    "prompt": "\"\"\"This function takes a vector l and returns a vector l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique elements in a vector\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "jl",
+    "prompt": "\"\"\"Return maximum element in the vector.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "jl",
+    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2188,9 +1278,233 @@
     "language": "jl",
     "prompt": "\"\"\"This function takes a vector l and returns a vector l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\nfunction sort_even(l::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_even;\n\t@test(candidate([1, 2, 3]) == [1, 2, 3])\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\n\t@test(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "jl",
+    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "jl",
+    "prompt": "\"\"\" You're given a vector of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return true. Otherwise it should return false.\n    >>> below_zero([1, 2, 3])\n    false\n    >>> below_zero([1, 2, -4, 5])\n    true\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    triples_sum_to_zero takes a vector of integers as an input.\n    it returns true if there are three distinct elements in the vector that\n    sum to zero, and false otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    true\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    true\n    >>> triples_sum_to_zero([1])\n    false\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "jl",
+    "prompt": "\"\"\"Return vector with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a vector of integers as an input.\n    it returns true if there are two distinct elements in the vector that\n    sum to zero, and false otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    false\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    true\n    >>> pairs_sum_to_zero([1])\n    false\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "jl",
+    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    \"22\"\n    >>> change_base(8, 2)\n    \"1000\"\n    >>> change_base(7, 2)\n    \"111\"\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "jl",
+    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "jl",
+    "prompt": "\"\"\"Return median of elements in the vector l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "jl",
+    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "jl",
+    "prompt": "\"\"\" For a given vector of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "jl",
+    "prompt": "\"\"\"Return true if all numbers in the vector l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    true\n    >>> below_threshold([1, 20, 4, 10], 5)\n    false\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "jl",
+    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2202,9 +1516,23 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Check if two words have the same characters.\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n    true\n    >>> same_chars(\"abcd\", \"dddddddabc\")\n    true\n    >>> same_chars(\"dddddddabc\", \"abcd\")\n    true\n    >>> same_chars(\"eabcd\", \"dddddddabc\")\n    false\n    >>> same_chars(\"abcd\", \"dddddddabce\")\n    false\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n    false\n    \"\"\"\nfunction same_chars(s0::String, s1::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = same_chars;\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true)\n\t@test(candidate(\"abcd\", \"dddddddabc\") == true)\n\t@test(candidate(\"dddddddabc\", \"abcd\") == true)\n\t@test(candidate(\"eabcd\", \"dddddddabc\") == false)\n\t@test(candidate(\"abcd\", \"dddddddabcf\") == false)\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false)\n\t@test(candidate(\"aabb\", \"aaccc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "jl",
+    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2216,9 +1544,681 @@
     "language": "jl",
     "prompt": "\"\"\" brackets is a string of \"<\" and \">\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    false\n    >>> correct_bracketing(\"<>\")\n    true\n    >>> correct_bracketing(\"<<><>>\")\n    true\n    >>> correct_bracketing(\"><<>\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"<>\") == true)\n\t@test(candidate(\"<<><>>\") == true)\n\t@test(candidate(\"<><><<><>><>\") == true)\n\t@test(candidate(\"<><><<<><><>><>><<><><<>>>\") == true)\n\t@test(candidate(\"<<<><>>>>\") == false)\n\t@test(candidate(\"><<>\") == false)\n\t@test(candidate(\"<\") == false)\n\t@test(candidate(\"<<<<\") == false)\n\t@test(candidate(\">\") == false)\n\t@test(candidate(\"<<>\") == false)\n\t@test(candidate(\"<><><<><>><>><<>\") == false)\n\t@test(candidate(\"<><><<><>><>>><>\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"Return true is vector elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    true\n    >>> monotonic([1, 20, 4, 10])\n    false\n    >>> monotonic([4, 1, 0, -10])\n    true\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique common elements for two vectors.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "jl",
+    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "jl",
+    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "jl",
+    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "jl",
+    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return true if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "jl",
+    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "jl",
+    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "jl",
+    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "jl",
+    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0\n    >>> digitSum(\"abAB\")\n    131\n    >>> digitSum(\"abcCd\")\n    67\n    >>> digitSum(\"helloE\")\n    69\n    >>> digitSum(\"woArBld\")\n    131\n    >>> digitSum(\"aAaaaXa\")\n    153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "jl",
+    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n    8\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n    2\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n    95\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n    19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "jl",
+    "prompt": "\"\"\"\n    \"Given a vector representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a vector, [ smalest_value, its index ],\n    If there are no even values or the given vector is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the vector.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given vector of integers, return vector in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that returns true if the object q will fly, and false otherwise.\n    The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a vector arr of integers, find the minimum number of elements that\n    need to be changed to make the vector palindromic. A palindromic vector is a vector that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that accepts two vectors of strings and returns the vector that has \n    total number of chars in the all strings of the vector less than the other vector.\n\n    if the two vectors have the same number of chars, return the first vector.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    true\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    true\n    >>> is_simple_power(2, 2)\n    true\n    >>> is_simple_power(8, 2)\n    true\n    >>> is_simple_power(3, 2)\n    false\n    >>> is_simple_power(3, 1)\n    false\n    >>> is_simple_power(5, 3)\n    false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns true \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    true\n    >>> iscube(2)\n    false\n    >>> iscube(-1)\n    true\n    >>> iscube(64)\n    true\n    >>> iscube(0)\n    true\n    >>> iscube(180)\n    false\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "jl",
+    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1\n    >>> hex_key(\"1077E\")\n    2\n    >>> hex_key(\"ABED1A33\")\n    4\n    >>> hex_key(\"123456789ABCDEF0\")\n    6\n    >>> hex_key(\"2020\")\n    2\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    \"db1111db\"\n    >>> decimal_to_binary(32)\n    \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input vector of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is hapjl or not.\n    A string is hapjl if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "jl",
+    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a vector of GPAs for some students and you have to write \n    a function that can output a vector of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that takes a string and returns true if the string\n    length is a prime number or false otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    \"1\"\n    >>> solve(150)\n    \"110\"\n    >>> solve(147)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "jl",
+    "prompt": "\"\"\"Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested vectors,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the vector,\n    and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a vector of non-negative integers, return a cojl of the given vector after sorting,\n    you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given vector.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \"\"\"\nfunction encrypt(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "jl",
+    "prompt": "\"\"\" For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a vector of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the vector.\n    Return nothing if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    nothing\n    >>> next_smallest([1, 1])\n    nothing\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    true\n    \n    >>> any_int(3, 2, 2)\n    false\n\n    >>> any_int(3, -2, 1)\n    true\n    \n    >>> any_int(3.6, -2.2, 2)\n    false\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \"\"\"\nfunction encode(message::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a vector of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a dictionary, return true if all keys are strings in lower \n    case or all keys are strings in upper case, else return false.\n    The function should return false is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"b\" => \"banana\"))\n    true\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n    false\n    >>> check_dict_case(Dict(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n    false\n    >>> check_dict_case(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n    false\n    >>> check_dict_case(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n    true\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "jl",
+    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns a vector of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "jl",
+    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1\n    >>> count_upper(\"abcdefg\")\n    0\n    >>> count_upper(\"dBBE\")\n    0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "jl",
+    "prompt": "\"\"\" From a given vector of integers, generate a vector of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/humaneval-jl-transform.json
+++ b/prompts/humaneval-jl-transform.json
@@ -1,1608 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "jl",
-    "prompt": "\"\"\" Return length of given string\n    >>> strlen(\"\")\n    0\n    >>> strlen(\"abc\")\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \"\"\"\nfunction encrypt(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"b\" => \"banana\"))\n    true\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n    false\n    >>> check_dict_case(Dict(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n    false\n    >>> check_dict_case(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n    false\n    >>> check_dict_case(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n    true\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "jl",
-    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "jl",
-    "prompt": "\"\"\" Filter given list of any python values only for integers\n    >>> filter_integers([\"a\", 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, \"abc\", Dict(), []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    \"db1111db\"\n    >>> decimal_to_binary(32)\n    \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "jl",
-    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "jl",
-    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \"\"\"\nfunction flip_case(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    [\"One\"]\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "jl",
-    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "jl",
-    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "jl",
-    "prompt": "\"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    \"0b11\"\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    \"0b1111\"\n    >>> rounded_avg(20, 33)\n    \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "jl",
-    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "jl",
-    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    false\n    >>> is_equal_to_sum_even(6)\n    false\n    >>> is_equal_to_sum_even(8)\n    true\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "jl",
-    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5])\n    false\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    false\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    true\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    false\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "jl",
-    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "jl",
-    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    \"1\"\n    >>> solve(150)\n    \"110\"\n    >>> solve(147)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1\n    >>> count_upper(\"abcdefg\")\n    0\n    >>> count_upper(\"dBBE\")\n    0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "jl",
-    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "jl",
-    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    true\n    >>> iscube(2)\n    false\n    >>> iscube(-1)\n    true\n    >>> iscube(64)\n    true\n    >>> iscube(0)\n    true\n    >>> iscube(180)\n    false\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \"\"\"\nfunction encode(message::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    false\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    true\n    >>> pairs_sum_to_zero([1])\n    false\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "jl",
-    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0\n    >>> how_many_times(\"aaa\", \"a\")\n    3\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "jl",
-    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    true\n    >>> is_simple_power(2, 2)\n    true\n    >>> is_simple_power(8, 2)\n    true\n    >>> is_simple_power(3, 2)\n    false\n    >>> is_simple_power(3, 1)\n    false\n    >>> is_simple_power(5, 3)\n    false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "jl",
-    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "jl",
     "prompt": "\"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    false\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    true\n    \"\"\"\nfunction has_close_elements(numbers::Vector{Float64}, threshold::Float64)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = has_close_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == true)\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == false)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == true)\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == false)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == true)\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "jl",
-    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "jl",
-    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "jl",
-    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "jl",
-    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2)\n    []\n    >>> select_words(\"Hello world\", 4)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3)\n    [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "jl",
-    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "jl",
-    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    nothing\n    >>> next_smallest([1, 1])\n    nothing\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    true\n    \n    >>> any_int(3, 2, 2)\n    false\n\n    >>> any_int(3, -2, 1)\n    true\n    \n    >>> any_int(3.6, -2.2, 2)\n    false\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "jl",
-    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "jl",
-    "prompt": "\"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "jl",
-    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "jl",
-    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "jl",
-    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "jl",
-    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "jl",
-    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0\n    >>> digitSum(\"abAB\")\n    131\n    >>> digitSum(\"abcCd\")\n    67\n    >>> digitSum(\"helloE\")\n    69\n    >>> digitSum(\"woArBld\")\n    131\n    >>> digitSum(\"aAaaaXa\")\n    153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "jl",
-    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "jl",
-    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "jl",
-    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "jl",
-    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    \"YES\"\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "jl",
-    "prompt": "\"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "jl",
-    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    true\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    true\n    >>> triples_sum_to_zero([1])\n    false\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "jl",
-    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    \"NO\"\n    >>> intersection((-1, 1), (0, 4))\n    \"NO\"\n    >>> intersection((-3, -1), (-5, 5))\n    \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "jl",
-    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "jl",
-    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "jl",
-    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    false\n    >>> is_prime(101)\n    true\n    >>> is_prime(11)\n    true\n    >>> is_prime(13441)\n    true\n    >>> is_prime(61)\n    true\n    >>> is_prime(4)\n    false\n    >>> is_prime(1)\n    false\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "jl",
-    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "jl",
-    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1\n    >>> hex_key(\"1077E\")\n    2\n    >>> hex_key(\"ABED1A33\")\n    4\n    >>> hex_key(\"123456789ABCDEF0\")\n    6\n    >>> hex_key(\"2020\")\n    2\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "jl",
-    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n    >>> histogram(\"a b b a\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"a b c a b\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"b b b b a\")\n    Dict(\"b\" => 4)\n    >>> histogram(\"\")\n    Dict()\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "jl",
-    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "jl",
-    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "jl",
-    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "jl",
-    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "jl",
-    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "jl",
-    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (nothing, 1)\n    >>> largest_smallest_integers([])\n    (nothing, nothing)\n    >>> largest_smallest_integers([0])\n    (nothing, nothing)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "jl",
-    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3\n    >>> count_distinct_characters(\"Jerry\")\n    4\n    \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1614,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\nfunction make_a_pile(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = make_a_pile;\n\t@test(candidate(3) == [3, 5, 7])\n\t@test(candidate(4) == [4, 6, 8, 10])\n\t@test(candidate(5) == [5, 7, 9, 11, 13])\n\t@test(candidate(6) == [6, 8, 10, 12, 14, 16])\n\t@test(candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22])\nend\n",
     "stop_tokens": [
@@ -1624,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    nothing\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "prompt": "\"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string(\"Hi, my name is John\")\n    [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    >>> words_string(\"One, two, three, four, five, six\")\n    [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\nfunction words_string(s::String)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_string;\n\t@test(candidate(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\n\t@test(candidate(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\n\t@test(candidate(\"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1638,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\nfunction choose_num(x::Int64, y::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = choose_num;\n\t@test(candidate(12, 15) == 14)\n\t@test(candidate(13, 12) == -1)\n\t@test(candidate(33, 12354) == 12354)\n\t@test(candidate(5234, 5233) == -1)\n\t@test(candidate(6, 29) == 28)\n\t@test(candidate(27, 10) == -1)\n\t@test(candidate(7, 7) == -1)\n\t@test(candidate(546, 546) == 546)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1652,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "jl",
-    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    \"0\"\n    >>> string_sequence(5)\n    \"0 1 2 3 4 5\"\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "prompt": "\"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    \"0b11\"\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    \"0b1111\"\n    >>> rounded_avg(20, 33)\n    \"0b11010\"\n    \"\"\"\nfunction rounded_avg(n::Int64, m::Int64)::Union{String, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rounded_avg;\n\t@test(candidate(1, 5) == \"0b11\")\n\t@test(candidate(7, 13) == \"0b1010\")\n\t@test(candidate(964, 977) == \"0b1111001010\")\n\t@test(candidate(996, 997) == \"0b1111100100\")\n\t@test(candidate(560, 851) == \"0b1011000010\")\n\t@test(candidate(185, 546) == \"0b101101110\")\n\t@test(candidate(362, 496) == \"0b110101101\")\n\t@test(candidate(350, 902) == \"0b1001110010\")\n\t@test(candidate(197, 233) == \"0b11010111\")\n\t@test(candidate(7, 5) == -1)\n\t@test(candidate(5, 1) == -1)\n\t@test(candidate(5, 5) == \"0b101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1666,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "jl",
-    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "prompt": "\"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\nfunction unique_digits(x::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_digits;\n\t@test(candidate([15, 33, 1422, 1]) == [1, 15, 33])\n\t@test(candidate([152, 323, 1422, 10]) == Vector{Int64}([]))\n\t@test(candidate([12345, 2033, 111, 151]) == [111, 151])\n\t@test(candidate([135, 103, 31]) == [31, 135])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1680,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "jl",
-    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    true\n    >>> monotonic([1, 20, 4, 10])\n    false\n    >>> monotonic([4, 1, 0, -10])\n    true\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    [\"One\"]\n    \"\"\"\nfunction by_length(arr::Vector{Int64})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = by_length;\n\t@test(candidate([2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\n\t@test(candidate(Vector{Int64}([])) == Vector{String}([]))\n\t@test(candidate([1, -1, 55]) == [\"One\"])\n\t@test(candidate([1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\n\t@test(candidate([9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1694,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "jl",
-    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    nothing\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "prompt": "\"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\nfunction f(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = f;\n\t@test(candidate(5) == [1, 2, 6, 24, 15])\n\t@test(candidate(7) == [1, 2, 6, 24, 15, 720, 28])\n\t@test(candidate(1) == [1])\n\t@test(candidate(3) == [1, 2, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1708,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    true\n    >>> below_threshold([1, 20, 4, 10], 5)\n    false\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\nfunction even_odd_palindrome(n::Int64)::Tuple{Int64, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_palindrome;\n\t@test(candidate(123) == (8, 13))\n\t@test(candidate(12) == (4, 6))\n\t@test(candidate(3) == (1, 2))\n\t@test(candidate(63) == (6, 8))\n\t@test(candidate(25) == (5, 6))\n\t@test(candidate(19) == (4, 6))\n\t@test(candidate(9) == (4, 5))\n\t@test(candidate(1) == (0, 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1722,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    true\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "prompt": "\"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\nfunction count_nums(arr::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_nums;\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([-1, -2, 0]) == 0)\n\t@test(candidate([1, 1, 2, -2, 3, 4, 5]) == 6)\n\t@test(candidate([1, 6, 9, -6, 0, 1, 5]) == 5)\n\t@test(candidate([1, 100, 98, -7, 1, -1]) == 4)\n\t@test(candidate([12, 23, 34, -45, -56, 0]) == 5)\n\t@test(candidate([0, 1]) == 1)\n\t@test(candidate([1]) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1736,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "jl",
-    "prompt": "\"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    true\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    false\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\nfunction move_one_ball(arr::Vector{Int64})::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_one_ball;\n\t@test(candidate([3, 4, 5, 1, 2]) == true)\n\t@test(candidate([3, 5, 10, 1, 2]) == true)\n\t@test(candidate([4, 3, 1, 2]) == false)\n\t@test(candidate([3, 5, 4, 1, 2]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1750,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "jl",
-    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome(\"\")\n    \"\"\n    >>> make_palindrome(\"cat\")\n    \"catac\"\n    >>> make_palindrome(\"cata\")\n    \"catac\"\n    \"\"\"\nfunction make_palindrome(string::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = make_palindrome;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"x\") == \"x\")\n\t@test(candidate(\"xyz\") == \"xyzyx\")\n\t@test(candidate(\"xyx\") == \"xyx\")\n\t@test(candidate(\"jerry\") == \"jerryrrej\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1764,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "jl",
-    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "prompt": "\"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    \"YES\"\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\nfunction exchange(lst1::Vector{Int64}, lst2::Vector{Int64})::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = exchange;\n\t@test(candidate([1, 2, 3, 4], [1, 2, 3, 4]) == \"YES\")\n\t@test(candidate([1, 2, 3, 4], [1, 5, 3, 4]) == \"NO\")\n\t@test(candidate([1, 2, 3, 4], [2, 1, 4, 3]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 4]) == \"YES\")\n\t@test(candidate([5, 7, 3], [2, 6, 3]) == \"NO\")\n\t@test(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == \"NO\")\n\t@test(candidate([100, 200], [200, 200]) == \"YES\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1778,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "jl",
-    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "prompt": "\"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram(\"a b c\")\n    Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n    >>> histogram(\"a b b a\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"a b c a b\")\n    Dict(\"a\" => 2, \"b\" => 2)\n    >>> histogram(\"b b b b a\")\n    Dict(\"b\" => 4)\n    >>> histogram(\"\")\n    Dict()\n\n    \"\"\"\nfunction histogram(test::String)::Dict{String, Int64}> \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "jl",
-    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "jl",
-    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "jl",
-    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "jl",
-    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    \"xix\"\n    >>> int_to_mini_roman(152)\n    \"clii\"\n    >>> int_to_mini_roman(426)\n    \"cdxxvi\"\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "jl",
-    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n    8\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n    2\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n    95\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n    19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = histogram;\n\t@test(candidate(\"a b b a\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c a b\") == Dict(\"a\" => 2, \"b\" => 2))\n\t@test(candidate(\"a b c d g\") == Dict(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"b b b b a\") == Dict(\"b\" => 4))\n\t@test(candidate(\"r t g\") == Dict(\"r\" => 1, \"t\" => 1, \"g\" => 1))\n\t@test(candidate(\"\") == Dict())\n\t@test(candidate(\"a\") == Dict(\"a\" => 1))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1866,7 +200,7 @@
     "language": "jl",
     "prompt": "\"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    >>> reverse_delete(\"abcde\", \"ae\")\n    (\"bcd\", false)\n    >>> reverse_delete(\"abcdef\", \"b\")\n    (\"acdef\", false)\n    >>> reverse_delete(\"abcdedcba\", \"ab\")\n    (\"cdedc\", true)\n    \"\"\"\nfunction reverse_delete(s::String, c::String)::Tuple{String, Bool} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_delete;\n\t@test(candidate(\"abcde\", \"ae\") == (\"bcd\", false))\n\t@test(candidate(\"abcdef\", \"b\") == (\"acdef\", false))\n\t@test(candidate(\"abcdedcba\", \"ab\") == (\"cdedc\", true))\n\t@test(candidate(\"dwik\", \"w\") == (\"dik\", false))\n\t@test(candidate(\"a\", \"a\") == (\"\", true))\n\t@test(candidate(\"abcdedcba\", \"\") == (\"abcdedcba\", true))\n\t@test(candidate(\"abcdedcba\", \"v\") == (\"abcdedcba\", true))\n\t@test(candidate(\"vabba\", \"v\") == (\"abba\", true))\n\t@test(candidate(\"mamma\", \"mia\") == (\"\", true))\nend\n",
     "stop_tokens": [
@@ -1876,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "jl",
-    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "prompt": "\"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count([\"1234567\"])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count([\"3\", \"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\nfunction odd_count(lst::Vector{String})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_count;\n\t@test(candidate([\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\n\t@test(candidate([\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\n\t@test(candidate([\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1890,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words(\"Hello world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"Hello,world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"abcdef\")\n    3\n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
+    "prompt": "\"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\nfunction minSubArraySum(nums::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minSubArraySum;\n\t@test(candidate([2, 3, 4, 1, 2, 4]) == 1)\n\t@test(candidate([-1, -2, -3]) == -6)\n\t@test(candidate([-1, -2, -3, 2, -10]) == -14)\n\t@test(candidate([-9999999999999999]) == -9999999999999999)\n\t@test(candidate([0, 10, 20, 1000000]) == 0)\n\t@test(candidate([-1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([100, -1, -2, -3, 10, -5]) == -6)\n\t@test(candidate([10, 11, 13, 8, 3, 4]) == 3)\n\t@test(candidate([100, -33, 32, -1, 0, -2]) == -33)\n\t@test(candidate([-10]) == -10)\n\t@test(candidate([7]) == 7)\n\t@test(candidate([1, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\nfunction max_fill(grid::Vector{Vector{Int64}}, capacity::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_fill;\n\t@test(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6)\n\t@test(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5)\n\t@test(candidate([[0, 0, 0], [0, 0, 0]], 5) == 0)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4)\n\t@test(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1908,7 +256,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4])\n    [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6])\n    [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4])\n    [0, 1, 2, 3, 4]\n    \"\"\"\nfunction sort_array(arr::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\n\t@test(candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\n\t@test(candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\n\t@test(candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\n\t@test(candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nend\n",
     "stop_tokens": [
@@ -1918,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "jl",
-    "prompt": "\"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words(\"Mary had a little lamb\", 4)\n    [\"little\"]\n    >>> select_words(\"Mary had a little lamb\", 3)\n    [\"Mary\", \"lamb\"]\n    >>> select_words(\"simple white space\", 2)\n    []\n    >>> select_words(\"Hello world\", 4)\n    [\"world\"]\n    >>> select_words(\"Uncle sam\", 3)\n    [\"Uncle\"]\n    \"\"\"\nfunction select_words(s::String, n::Int64)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = select_words;\n\t@test(candidate(\"Mary had a little lamb\", 4) == [\"little\"])\n\t@test(candidate(\"Mary had a little lamb\", 3) == [\"Mary\", \"lamb\"])\n\t@test(candidate(\"simple white space\", 2) == Vector{String}([]))\n\t@test(candidate(\"Hello world\", 4) == [\"world\"])\n\t@test(candidate(\"Uncle sam\", 3) == [\"Uncle\"])\n\t@test(candidate(\"\", 4) == Vector{String}([]))\n\t@test(candidate(\"a b c d e f\", 1) == [\"b\", \"c\", \"d\", \"f\"])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1932,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
+    "prompt": "\"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel(\"yogurt\")\n    \"u\"\n    >>> get_closest_vowel(\"FULL\")\n    \"U\"\n    >>> get_closest_vowel(\"quick\")\n    \"\"\n    >>> get_closest_vowel(\"ab\")\n    \"\"\n    \"\"\"\nfunction get_closest_vowel(word::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_closest_vowel;\n\t@test(candidate(\"yogurt\") == \"u\")\n\t@test(candidate(\"full\") == \"u\")\n\t@test(candidate(\"easy\") == \"\")\n\t@test(candidate(\"eAsy\") == \"\")\n\t@test(candidate(\"ali\") == \"\")\n\t@test(candidate(\"bad\") == \"a\")\n\t@test(candidate(\"most\") == \"o\")\n\t@test(candidate(\"ab\") == \"\")\n\t@test(candidate(\"ba\") == \"\")\n\t@test(candidate(\"quick\") == \"\")\n\t@test(candidate(\"anime\") == \"i\")\n\t@test(candidate(\"Asia\") == \"\")\n\t@test(candidate(\"Above\") == \"o\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1946,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "jl",
-    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "prompt": "\"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens([\"()(\", \")\"])\n    \"Yes\"\n    >>> match_parens([\")\", \")\"])\n    \"No\"\n    \"\"\"\nfunction match_parens(lst::Vector{String})::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = match_parens;\n\t@test(candidate([\"()(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \")\"]) == \"No\")\n\t@test(candidate([\"(()(())\", \"())())\"]) == \"No\")\n\t@test(candidate([\")())\", \"(()()(\"]) == \"Yes\")\n\t@test(candidate([\"(())))\", \"(()())((\"]) == \"Yes\")\n\t@test(candidate([\"()\", \"())\"]) == \"No\")\n\t@test(candidate([\"(()(\", \"()))()\"]) == \"Yes\")\n\t@test(candidate([\"((((\", \"((())\"]) == \"No\")\n\t@test(candidate([\")(()\", \"(()(\"]) == \"No\")\n\t@test(candidate([\")(\", \")(\"]) == \"No\")\n\t@test(candidate([\"(\", \")\"]) == \"Yes\")\n\t@test(candidate([\")\", \"(\"]) == \"Yes\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1960,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "jl",
-    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "prompt": "\"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor(\"010\", \"110\")\n    \"100\"\n    \"\"\"\nfunction string_xor(a::String, b::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_xor;\n\t@test(candidate(\"111000\", \"101010\") == \"010010\")\n\t@test(candidate(\"1\", \"1\") == \"0\")\n\t@test(candidate(\"0101\", \"0000\") == \"0101\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1974,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "jl",
-    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "prompt": "\"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\nfunction maximum(arr::Vector{Int64}, k::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate([-3, -4, 5], 3) == [-4, -3, 5])\n\t@test(candidate([4, -4, 4], 2) == [4, 4])\n\t@test(candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2])\n\t@test(candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123])\n\t@test(candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20])\n\t@test(candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15])\n\t@test(candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5])\n\t@test(candidate([1, 0, 5, -7], 1) == [5])\n\t@test(candidate([4, -4], 2) == [-4, 4])\n\t@test(candidate([-10, 10], 2) == [-10, 10])\n\t@test(candidate([1, 2, 3, -23, 243, -400, 0], 0) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -1988,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "jl",
-    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "prompt": "\"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\nfunction solution(lst::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solution;\n\t@test(candidate([5, 8, 7, 1]) == 12)\n\t@test(candidate([3, 3, 3, 3, 3]) == 9)\n\t@test(candidate([30, 13, 24, 321]) == 0)\n\t@test(candidate([5, 9]) == 5)\n\t@test(candidate([2, 4, 8]) == 0)\n\t@test(candidate([30, 13, 23, 32]) == 23)\n\t@test(candidate([3, 13, 2, 9]) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2002,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "prompt": "\"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\nfunction add_elements(arr::Vector{Int64}, k::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_elements;\n\t@test(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4)\n\t@test(candidate([111, 121, 3, 4000, 5, 6], 2) == 0)\n\t@test(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125)\n\t@test(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24)\n\t@test(candidate([1], 1) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2016,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "jl",
-    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    \"22\"\n    >>> change_base(8, 2)\n    \"1000\"\n    >>> change_base(7, 2)\n    \"111\"\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "prompt": "\"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\nfunction get_odd_collatz(n::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_odd_collatz;\n\t@test(candidate(14) == [1, 5, 7, 11, 13, 17])\n\t@test(candidate(5) == [1, 5])\n\t@test(candidate(12) == [1, 3, 5])\n\t@test(candidate(1) == [1])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2030,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "jl",
-    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    true\n    >>> right_angle_triangle(1, 2, 3)\n    false\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "prompt": "\"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date(\"03-11-2000\")\n    true\n\n    >>> valid_date(\"15-01-2012\")\n    false\n\n    >>> valid_date(\"04-0-2040\")\n    false\n\n    >>> valid_date(\"06-04-2020\")\n    true\n\n    >>> valid_date(\"06/04/2020\")\n    false\n    \"\"\"\nfunction valid_date(date::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = valid_date;\n\t@test(candidate(\"03-11-2000\") == true)\n\t@test(candidate(\"15-01-2012\") == false)\n\t@test(candidate(\"04-0-2040\") == false)\n\t@test(candidate(\"06-04-2020\") == true)\n\t@test(candidate(\"01-01-2007\") == true)\n\t@test(candidate(\"03-32-2011\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"04-31-3000\") == false)\n\t@test(candidate(\"06-06-2005\") == true)\n\t@test(candidate(\"21-31-2000\") == false)\n\t@test(candidate(\"04-12-2003\") == true)\n\t@test(candidate(\"04122003\") == false)\n\t@test(candidate(\"20030412\") == false)\n\t@test(candidate(\"2003-04\") == false)\n\t@test(candidate(\"2003-04-12\") == false)\n\t@test(candidate(\"04-2003\") == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2044,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "jl",
-    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "prompt": "\"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words(\"Hello world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"Hello,world!\")\n    [\"Hello\", \"world!\"]\n    >>> split_words(\"abcdef\")\n    3\n    \"\"\"\nfunction split_words(txt::String)::Union{Vector{String}, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_words;\n\t@test(candidate(\"Hello world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello,world!\") == [\"Hello\", \"world!\"])\n\t@test(candidate(\"Hello world,!\") == [\"Hello\", \"world,!\"])\n\t@test(candidate(\"Hello,Hello,world !\") == [\"Hello,Hello,world\", \"!\"])\n\t@test(candidate(\"abcdef\") == 3)\n\t@test(candidate(\"aaabb\") == 2)\n\t@test(candidate(\"aaaBb\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2058,13 +406,293 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "jl",
-    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "prompt": "\"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5])\n    false\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    true\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    true\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    false\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    true\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    false\n    \"\"\"\nfunction is_sorted(lst::Vector{Int64})::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sorted;\n\t@test(candidate([5]) == true)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 3, 2, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7]) == true)\n\t@test(candidate([1, 3, 2, 4, 5, 6, 7]) == false)\n\t@test(candidate(Vector{Int64}([])) == true)\n\t@test(candidate([1]) == true)\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 2, 2, 3, 4]) == false)\n\t@test(candidate([1, 2, 3, 3, 3, 4]) == false)\n\t@test(candidate([1, 2, 2, 3, 3, 4]) == true)\n\t@test(candidate([1, 2, 3, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "jl",
+    "prompt": "\"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    \"NO\"\n    >>> intersection((-1, 1), (0, 4))\n    \"NO\"\n    >>> intersection((-3, -1), (-5, 5))\n    \"YES\"\n    \"\"\"\nfunction intersection(interval1::Tuple{Int64, Int64}, interval2::Tuple{Int64, Int64})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection;\n\t@test(candidate((1, 2), (2, 3)) == \"NO\")\n\t@test(candidate((-1, 1), (0, 4)) == \"NO\")\n\t@test(candidate((-3, -1), (-5, 5)) == \"YES\")\n\t@test(candidate((-2, 2), (-4, 0)) == \"YES\")\n\t@test(candidate((-11, 2), (-1, -1)) == \"NO\")\n\t@test(candidate((1, 2), (3, 5)) == \"NO\")\n\t@test(candidate((1, 2), (1, 2)) == \"NO\")\n\t@test(candidate((-2, -2), (-3, -2)) == \"NO\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    nothing\n    \"\"\"\nfunction prod_signs(arr::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prod_signs;\n\t@test(candidate([1, 2, 2, -4]) == -9)\n\t@test(candidate([0, 1]) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, -1, 1]) == -10)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([2, 4, 1, 2, -1, -1, 9]) == 20)\n\t@test(candidate([-1, 1, -1, 1]) == 4)\n\t@test(candidate([-1, 1, 1, 1]) == -4)\n\t@test(candidate([-1, 1, 1, 0]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\nfunction minPath(grid::Vector{Vector{Int64}}, k::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minPath;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1])\n\t@test(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1])\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2])\n\t@test(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1])\n\t@test(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1])\n\t@test(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\n\t@test(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\n\t@test(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3])\n\t@test(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5])\n\t@test(candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\n\t@test(candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "jl",
+    "prompt": "\"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    nothing\n    >>> longest([\"a\", \"b\", \"c\"])\n    \"a\"\n    >>> longest([\"a\", \"bb\", \"ccc\"])\n    \"ccc\"\n    \"\"\"\nfunction longest(strings::Vector{String})::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = longest;\n\t@test(candidate(Vector{String}([])) == nothing)\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"x\")\n\t@test(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "jl",
+    "prompt": "\"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\nfunction tri(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tri;\n\t@test(candidate(3) == [1, 3, 2, 8])\n\t@test(candidate(4) == [1, 3, 2, 8, 3])\n\t@test(candidate(5) == [1, 3, 2, 8, 3, 15])\n\t@test(candidate(6) == [1, 3, 2, 8, 3, 15, 4])\n\t@test(candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24])\n\t@test(candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\n\t@test(candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\n\t@test(candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\n\t@test(candidate(0) == [1])\n\t@test(candidate(1) == [1, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\nfunction digits(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digits;\n\t@test(candidate(5) == 5)\n\t@test(candidate(54) == 5)\n\t@test(candidate(120) == 1)\n\t@test(candidate(5014) == 5)\n\t@test(candidate(98765) == 315)\n\t@test(candidate(5576543) == 2625)\n\t@test(candidate(2468) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested(\"[[]]\")\n    true\n    >>> is_nested(\"[]]]]]]][[[[[]\")\n    false\n    >>> is_nested(\"[][]\")\n    false\n    >>> is_nested(\"[]\")\n    false\n    >>> is_nested(\"[[][]]\")\n    true\n    >>> is_nested(\"[[]][[\")\n    true\n    \"\"\"\nfunction is_nested(string::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nested;\n\t@test(candidate(\"[[]]\") == true)\n\t@test(candidate(\"[]]]]]]][[[[[]\") == false)\n\t@test(candidate(\"[][]\") == false)\n\t@test(candidate(\"[]\") == false)\n\t@test(candidate(\"[[[[]]]]\") == true)\n\t@test(candidate(\"[]]]]]]]]]]\") == false)\n\t@test(candidate(\"[][][[]]\") == true)\n\t@test(candidate(\"[[]\") == false)\n\t@test(candidate(\"[]]\") == false)\n\t@test(candidate(\"[[]][[\") == true)\n\t@test(candidate(\"[[][]]\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"[[[[[[[[\") == false)\n\t@test(candidate(\"]]]]]]]]\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\nfunction sum_squares(lst::Vector{Float64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 2.0, 3.0]) == 14)\n\t@test(candidate([1.0, 3.0, 5.0, 7.0]) == 84)\n\t@test(candidate([1.4, 4.2, 0.0]) == 29)\n\t@test(candidate([-2.4, 1.0, 1.0]) == 6)\n\t@test(candidate([100.0, 1.0, 15.0, 2.0]) == 10230)\n\t@test(candidate([10000.0, 10000.0]) == 200000000)\n\t@test(candidate([-1.4, 4.6, 6.3]) == 75)\n\t@test(candidate([-1.4, 17.9, 18.9, 19.9]) == 1086)\n\t@test(candidate([0.0]) == 0)\n\t@test(candidate([-1.0]) == 1)\n\t@test(candidate([-1.0, 1.0, 0.0]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter(\"apple pie\")\n    false\n    >>> check_if_last_char_is_a_letter(\"apple pi e\")\n    true\n    >>> check_if_last_char_is_a_letter(\"apple pi e \")\n    false\n    >>> check_if_last_char_is_a_letter(\"\")\n    false\n    \"\"\"\nfunction check_if_last_char_is_a_letter(txt::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_if_last_char_is_a_letter;\n\t@test(candidate(\"apple\") == false)\n\t@test(candidate(\"apple pi e\") == true)\n\t@test(candidate(\"eeeee\") == false)\n\t@test(candidate(\"A\") == true)\n\t@test(candidate(\"Pumpkin pie \") == false)\n\t@test(candidate(\"Pumpkin pie 1\") == false)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"eeeee e \") == false)\n\t@test(candidate(\"apple pie\") == false)\n\t@test(candidate(\"apple pi e \") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\nfunction can_arrange(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = can_arrange;\n\t@test(candidate([1, 2, 4, 3, 5]) == 3)\n\t@test(candidate([1, 2, 4, 5]) == -1)\n\t@test(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([4, 8, 5, 7, 3]) == 4)\n\t@test(candidate(Vector{Int64}([])) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (nothing, 1)\n    >>> largest_smallest_integers([])\n    (nothing, nothing)\n    >>> largest_smallest_integers([0])\n    (nothing, nothing)\n    \"\"\"\nfunction largest_smallest_integers(lst::Vector{Int64})::Tuple{Union{Int64, Nothing}, Union{Int64, Nothing}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_smallest_integers;\n\t@test(candidate([2, 4, 1, 3, 5, 7]) == (nothing, 1))\n\t@test(candidate([2, 4, 1, 3, 5, 7, 0]) == (nothing, 1))\n\t@test(candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\n\t@test(candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\n\t@test(candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\n\t@test(candidate(Vector{Int64}([])) == (nothing, nothing))\n\t@test(candidate([0]) == (nothing, nothing))\n\t@test(candidate([-1, -3, -5, -6]) == (-1, nothing))\n\t@test(candidate([-1, -3, -5, -6, 0]) == (-1, nothing))\n\t@test(candidate([-6, -4, -4, -3, 1]) == (-3, 1))\n\t@test(candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "jl",
+    "prompt": "\"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    false\n    >>> is_equal_to_sum_even(6)\n    false\n    >>> is_equal_to_sum_even(8)\n    true\n    \"\"\"\nfunction is_equal_to_sum_even(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_equal_to_sum_even;\n\t@test(candidate(4) == false)\n\t@test(candidate(6) == false)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == true)\n\t@test(candidate(11) == false)\n\t@test(candidate(12) == true)\n\t@test(candidate(13) == false)\n\t@test(candidate(16) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "jl",
+    "prompt": "\"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\nfunction special_factorial(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = special_factorial;\n\t@test(candidate(4) == 288)\n\t@test(candidate(5) == 34560)\n\t@test(candidate(7) == 125411328000)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\nfunction greatest_common_divisor(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = greatest_common_divisor;\n\t@test(candidate(3, 7) == 1)\n\t@test(candidate(10, 15) == 5)\n\t@test(candidate(49, 14) == 7)\n\t@test(candidate(144, 60) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(\" Example\")\n    \"Example\"\n    >>> fix_spaces(\" Example 1\")\n    \"Example_1\"\n    >>> fix_spaces(\" Example 2\")\n    \"_Example_2\"\n    >>> fix_spaces(\" Example 3\")\n    \"_Example-3\"\n    \"\"\"\nfunction fix_spaces(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fix_spaces;\n\t@test(candidate(\"Example\") == \"Example\")\n\t@test(candidate(\"Mudasir Hanif \") == \"Mudasir_Hanif_\")\n\t@test(candidate(\"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\n\t@test(candidate(\"Exa   mple\") == \"Exa-mple\")\n\t@test(candidate(\"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check(\"example.txt\")\n    \"Yes\"\n    >>> file_name_check(\"1example.dll\")\n    \"No\"\n    \"\"\"\nfunction file_name_check(file_name::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = file_name_check;\n\t@test(candidate(\"example.txt\") == \"Yes\")\n\t@test(candidate(\"1example.dll\") == \"No\")\n\t@test(candidate(\"s1sdf3.asd\") == \"No\")\n\t@test(candidate(\"K.dll\") == \"Yes\")\n\t@test(candidate(\"MY16FILE3.exe\") == \"Yes\")\n\t@test(candidate(\"His12FILE94.exe\") == \"No\")\n\t@test(candidate(\"_Y.txt\") == \"No\")\n\t@test(candidate(\"?aREYA.exe\") == \"No\")\n\t@test(candidate(\"/this_is_valid.dll\") == \"No\")\n\t@test(candidate(\"this_is_valid.wow\") == \"No\")\n\t@test(candidate(\"this_is_valid.txt\") == \"Yes\")\n\t@test(candidate(\"this_is_valid.txtexe\") == \"No\")\n\t@test(candidate(\"#this2_i4s_5valid.ten\") == \"No\")\n\t@test(candidate(\"@this1_is6_valid.exe\") == \"No\")\n\t@test(candidate(\"this_is_12valid.6exe4.txt\") == \"No\")\n\t@test(candidate(\"all.exe.txt\") == \"No\")\n\t@test(candidate(\"I563_No.exe\") == \"Yes\")\n\t@test(candidate(\"Is3youfault.txt\") == \"Yes\")\n\t@test(candidate(\"no_one#knows.dll\") == \"Yes\")\n\t@test(candidate(\"1I563_Yes3.exe\") == \"No\")\n\t@test(candidate(\"I563_Yes3.txtt\") == \"No\")\n\t@test(candidate(\"final..txt\") == \"No\")\n\t@test(candidate(\"final132\") == \"No\")\n\t@test(candidate(\"_f4indsartal132.\") == \"No\")\n\t@test(candidate(\".txt\") == \"No\")\n\t@test(candidate(\"s.\") == \"No\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\nfunction sum_squares(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_squares;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([1, 4, 9]) == 14)\n\t@test(candidate(Vector{Int64}([])) == 0)\n\t@test(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\n\t@test(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\n\t@test(candidate([0]) == 0)\n\t@test(candidate([-1, -5, 2, -1, -5]) == -126)\n\t@test(candidate([-56, -99, 1, 0, -2]) == 3030)\n\t@test(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\n\t@test(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\n\t@test(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence(\"This is a test\")\n    \"is\"\n\n    Example 2:\n    >>> words_in_sentence(\"lets go for swimming\")\n    \"go for\"\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\nfunction words_in_sentence(sentence::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = words_in_sentence;\n\t@test(candidate(\"This is a test\") == \"is\")\n\t@test(candidate(\"lets go for swimming\") == \"go for\")\n\t@test(candidate(\"there is no place available here\") == \"there is no place\")\n\t@test(candidate(\"Hi I am Hussein\") == \"Hi am Hussein\")\n\t@test(candidate(\"go for it\") == \"go for it\")\n\t@test(candidate(\"here\") == \"\")\n\t@test(candidate(\"here is\") == \"is\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify(\"1/5\", \"5/1\")\n    true\n    >>> simplify(\"1/6\", \"2/1\")\n    false\n    >>> simplify(\"7/10\", \"10/2\")\n    false\n    \"\"\"\nfunction simplify(x::String, n::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = simplify;\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/6\", \"2/1\") == false)\n\t@test(candidate(\"5/1\", \"3/1\") == true)\n\t@test(candidate(\"7/10\", \"10/2\") == false)\n\t@test(candidate(\"2/10\", \"50/10\") == true)\n\t@test(candidate(\"7/2\", \"4/2\") == true)\n\t@test(candidate(\"11/6\", \"6/1\") == true)\n\t@test(candidate(\"2/3\", \"5/2\") == false)\n\t@test(candidate(\"5/2\", \"3/5\") == false)\n\t@test(candidate(\"2/4\", \"8/4\") == true)\n\t@test(candidate(\"2/4\", \"4/2\") == true)\n\t@test(candidate(\"1/5\", \"5/1\") == true)\n\t@test(candidate(\"1/5\", \"1/5\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\nfunction order_by_points(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = order_by_points;\n\t@test(candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\n\t@test(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2076,7 +704,7 @@
     "language": "jl",
     "prompt": "\"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15, -73, 14, -15])\n    1\n    >>> specialFilter([33, -2, -3, 45, 21, 109])\n    2\n    \"\"\"\nfunction specialFilter(nums::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = specialFilter;\n\t@test(candidate([5, -2, 1, -5]) == 0)\n\t@test(candidate([15, -73, 14, -15]) == 1)\n\t@test(candidate([33, -2, -3, 45, 21, 109]) == 2)\n\t@test(candidate([43, -12, 93, 125, 121, 109]) == 4)\n\t@test(candidate([71, -2, -33, 75, 21, 19]) == 3)\n\t@test(candidate([1]) == 0)\n\t@test(candidate(Vector{Int64}([])) == 0)\nend\n",
     "stop_tokens": [
@@ -2086,13 +714,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "jl",
-    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\nfunction get_max_triples(n::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_triples;\n\t@test(candidate(5) == 1)\n\t@test(candidate(6) == 4)\n\t@test(candidate(10) == 36)\n\t@test(candidate(100) == 53361)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2100,13 +728,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "jl",
-    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort([\"aa\", \"a\", \"aaa\"])\n    [\"aa\"]\n    >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n    [\"ab\", \"cd\"]\n    \"\"\"\nfunction sorted_list_sum(lst::Vector{String})::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sorted_list_sum;\n\t@test(candidate([\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\n\t@test(candidate([\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\n\t@test(candidate([\"d\", \"b\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\n\t@test(candidate([\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\n\t@test(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == Vector{String}([]))\n\t@test(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes(\"abc\")\n    [\"a\", \"ab\", \"abc\"]\n    \"\"\"\nfunction all_prefixes(string::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_prefixes;\n\t@test(candidate(\"\") == Vector{String}([]))\n\t@test(candidate(\"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\n\t@test(candidate(\"WWW\") == [\"W\", \"WW\", \"WWW\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "jl",
+    "prompt": "\"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\nfunction x_or_y(n::Int64, x::Int64, y::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = x_or_y;\n\t@test(candidate(7, 34, 12) == 34)\n\t@test(candidate(15, 8, 5) == 5)\n\t@test(candidate(3, 33, 5212) == 33)\n\t@test(candidate(1259, 3, 52) == 3)\n\t@test(candidate(7919, -1, 12) == -1)\n\t@test(candidate(3609, 1245, 583) == 583)\n\t@test(candidate(91, 56, 129) == 129)\n\t@test(candidate(6, 34, 1234) == 1234)\n\t@test(candidate(1, 2, 0) == 0)\n\t@test(candidate(2, 2, 0) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\nfunction double_the_difference(lst::Vector{Float64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = double_the_difference;\n\t@test(candidate(Vector{Float64}([])) == 0)\n\t@test(candidate([5.0, 4.0]) == 25)\n\t@test(candidate([0.1, 0.2, 0.3]) == 0)\n\t@test(candidate([-10.0, -20.0, -30.0]) == 0)\n\t@test(candidate([-1.0, -2.0, 8.0]) == 0)\n\t@test(candidate([0.2, 3.0, 5.0]) == 34)\n\t@test(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "jl",
+    "prompt": "\"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\nfunction compare(game::Vector{Int64}, guess::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = compare;\n\t@test(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\n\t@test(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\n\t@test(candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6])\n\t@test(candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n    \"my_class.AA\"\n    \"\"\"\nfunction Strongest_Extension(class_name::String, extensions::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Strongest_Extension;\n\t@test(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\n\t@test(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\n\t@test(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\n\t@test(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\n\t@test(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\n\t@test(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\n\t@test(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\n\t@test(candidate(\"_\", [\"Bb\", \"91245\"]) == \"_.Bb\")\n\t@test(candidate(\"Sp\", [\"671235\", \"Bb\"]) == \"Sp.671235\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "jl",
+    "prompt": "\"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check(\"abcd\", \"abd\")\n    false\n    >>> cycpattern_check(\"hello\", \"ell\")\n    true\n    >>> cycpattern_check(\"whassup\", \"psus\")\n    false\n    >>> cycpattern_check(\"abab\", \"baa\")\n    true\n    >>> cycpattern_check(\"efef\", \"eeff\")\n    false\n    >>> cycpattern_check(\"himenss\", \"simen\")\n    true\n\n    \"\"\"\nfunction cycpattern_check(a::String, b::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cycpattern_check;\n\t@test(candidate(\"xyzw\", \"xyw\") == false)\n\t@test(candidate(\"yello\", \"ell\") == true)\n\t@test(candidate(\"whattup\", \"ptut\") == false)\n\t@test(candidate(\"efef\", \"fee\") == true)\n\t@test(candidate(\"abab\", \"aabb\") == false)\n\t@test(candidate(\"winemtt\", \"tinem\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "jl",
+    "prompt": "\"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\nfunction even_odd_count(num::Int64)::Tuple{Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_odd_count;\n\t@test(candidate(7) == (0, 1))\n\t@test(candidate(-78) == (1, 1))\n\t@test(candidate(3452) == (2, 2))\n\t@test(candidate(346211) == (3, 3))\n\t@test(candidate(-345821) == (3, 3))\n\t@test(candidate(-2) == (1, 0))\n\t@test(candidate(-45347) == (2, 3))\n\t@test(candidate(0) == (1, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    \"xix\"\n    >>> int_to_mini_roman(152)\n    \"clii\"\n    >>> int_to_mini_roman(426)\n    \"cdxxvi\"\n    \"\"\"\nfunction int_to_mini_roman(number::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = int_to_mini_roman;\n\t@test(candidate(19) == \"xix\")\n\t@test(candidate(152) == \"clii\")\n\t@test(candidate(251) == \"ccli\")\n\t@test(candidate(426) == \"cdxxvi\")\n\t@test(candidate(500) == \"d\")\n\t@test(candidate(1) == \"i\")\n\t@test(candidate(4) == \"iv\")\n\t@test(candidate(43) == \"xliii\")\n\t@test(candidate(90) == \"xc\")\n\t@test(candidate(94) == \"xciv\")\n\t@test(candidate(532) == \"dxxxii\")\n\t@test(candidate(900) == \"cm\")\n\t@test(candidate(994) == \"cmxciv\")\n\t@test(candidate(1000) == \"m\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    true\n    >>> right_angle_triangle(1, 2, 3)\n    false\n    \"\"\"\nfunction right_angle_triangle(a::Int64, b::Int64, c::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_angle_triangle;\n\t@test(candidate(3, 4, 5) == true)\n\t@test(candidate(1, 2, 3) == false)\n\t@test(candidate(10, 6, 8) == true)\n\t@test(candidate(2, 2, 2) == false)\n\t@test(candidate(7, 24, 25) == true)\n\t@test(candidate(10, 5, 7) == false)\n\t@test(candidate(5, 12, 13) == true)\n\t@test(candidate(15, 8, 17) == true)\n\t@test(candidate(48, 55, 73) == true)\n\t@test(candidate(1, 1, 1) == false)\n\t@test(candidate(2, 2, 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max([\"name\", \"of\", \"string\"])\n    \"string\"\n    >>> find_max([\"name\", \"enam\", \"game\"])\n    \"enam\"\n    >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n    \"aaaaaaa\"\n    \"\"\"\nfunction find_max(words::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_max;\n\t@test(candidate([\"name\", \"of\", \"string\"]) == \"string\")\n\t@test(candidate([\"name\", \"enam\", \"game\"]) == \"enam\")\n\t@test(candidate([\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\n\t@test(candidate([\"abc\", \"cba\"]) == \"abc\")\n\t@test(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\n\t@test(candidate([\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\n\t@test(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\n\t@test(candidate([\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\n\t@test(candidate([\"b\"]) == \"b\")\n\t@test(candidate([\"play\", \"play\", \"play\"]) == \"play\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\nfunction eat(number::Int64, need::Int64, remaining::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eat;\n\t@test(candidate(5, 6, 10) == [11, 4])\n\t@test(candidate(4, 8, 9) == [12, 1])\n\t@test(candidate(1, 10, 10) == [11, 0])\n\t@test(candidate(2, 11, 5) == [7, 0])\n\t@test(candidate(4, 5, 7) == [9, 2])\n\t@test(candidate(4, 5, 1) == [5, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "jl",
+    "prompt": "\"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    \"0\"\n    >>> string_sequence(5)\n    \"0 1 2 3 4 5\"\n    \"\"\"\nfunction string_sequence(n::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_sequence;\n\t@test(candidate(0) == \"0\")\n\t@test(candidate(3) == \"0 1 2 3\")\n\t@test(candidate(10) == \"0 1 2 3 4 5 6 7 8 9 10\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\nfunction do_algebra(operator::Vector{String}, operand::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = do_algebra;\n\t@test(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]) == 37)\n\t@test(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]) == 9)\n\t@test(candidate([\"//\", \"*\"], [7, 3, 4]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve(\"1234\")\n    \"4321\"\n    >>> solve(\"ab\")\n    \"AB\"\n    >>> solve(\"#a@C\")\n    \"#A@c\"\n    \"\"\"\nfunction solve(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(\"AsDf\") == \"aSdF\")\n\t@test(candidate(\"1234\") == \"4321\")\n\t@test(candidate(\"ab\") == \"AB\")\n\t@test(candidate(\"#a@C\") == \"#A@c\")\n\t@test(candidate(\"#AsdfW^45\") == \"#aSDFw^45\")\n\t@test(candidate(\"#6@2\") == \"2@6#\")\n\t@test(candidate(\"#\\$a^D\") == \"#\\$A^d\")\n\t@test(candidate(\"#ccc\") == \"#CCC\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5(\"Hello world\")\n    \"3e25960a79dbc69b674cd4ec67a72c62\"\n    \"\"\"\nfunction string_to_md5(text::String)::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_md5;\n\t@test(candidate(\"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\n\t@test(candidate(\"\") == nothing)\n\t@test(candidate(\"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\n\t@test(candidate(\"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2118,7 +956,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2, 8)\n    [2, 4, 6, 8]\n    >>> generate_integers(8, 2)\n    [2, 4, 6, 8]\n    >>> generate_integers(10, 14)\n    []\n    \"\"\"\nfunction generate_integers(a::Int64, b::Int64)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = generate_integers;\n\t@test(candidate(2, 10) == [2, 4, 6, 8])\n\t@test(candidate(10, 2) == [2, 4, 6, 8])\n\t@test(candidate(132, 2) == [2, 4, 6, 8])\n\t@test(candidate(17, 89) == Vector{Int64}([]))\nend\n",
     "stop_tokens": [
@@ -2128,13 +966,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "jl",
-    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters(\"xyzXYZ\")\n    3\n    >>> count_distinct_characters(\"Jerry\")\n    4\n    \"\"\"\nfunction count_distinct_characters(string::String)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_distinct_characters;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abcde\") == 5)\n\t@test(candidate(\"abcdecadeCADE\") == 5)\n\t@test(candidate(\"aaaaAAAAaaaa\") == 1)\n\t@test(candidate(\"Jerry jERRY JeRRRY\") == 5)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2142,13 +980,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "jl",
-    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    false\n    >>> below_zero([1, 2, -4, 5])\n    true\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\nfunction parse_music(music_string::String)::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_music;\n\t@test(candidate(\"\") == Vector{Int64}([]))\n\t@test(candidate(\"o o o o\") == [4, 4, 4, 4])\n\t@test(candidate(\".| .| .| .|\") == [1, 1, 1, 1])\n\t@test(candidate(\"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\n\t@test(candidate(\"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2156,13 +994,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "jl",
-    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times(\"\", \"a\")\n    0\n    >>> how_many_times(\"aaa\", \"a\")\n    3\n    >>> how_many_times(\"aaaa\", \"aa\")\n    3\n    \"\"\"\nfunction how_many_times(string::String, substring::String)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = how_many_times;\n\t@test(candidate(\"\", \"x\") == 0)\n\t@test(candidate(\"xyxyxyx\", \"x\") == 4)\n\t@test(candidate(\"cacacacac\", \"cac\") == 4)\n\t@test(candidate(\"john doe\", \"john\") == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2170,13 +1008,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "jl",
-    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "prompt": "\"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers(\"three one five\")\n    \"one three five\"\n    \"\"\"\nfunction sort_numbers(numbers::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numbers;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"three\") == \"three\")\n\t@test(candidate(\"three five nine\") == \"three five nine\")\n\t@test(candidate(\"five zero four seven nine eight\") == \"zero four five seven eight nine\")\n\t@test(candidate(\"six five four three two one zero\") == \"zero one two three four five six\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n    [\"()\", \"(())\", \"(()())\"]\n    \"\"\"\nfunction separate_paren_groups(paren_string::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = separate_paren_groups;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\n\t@test(candidate(\"(()(())((())))\") == [\"(()(())((())))\"])\n\t@test(candidate(\"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "jl",
+    "prompt": "\"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\nfunction find_closest_elements(numbers::Vector{Float64})::Tuple{Float64, Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_closest_elements;\n\t@test(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\n\t@test(candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\n\t@test(candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "jl",
+    "prompt": "\"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\nfunction rescale_to_unit(numbers::Vector{Float64})::Vector{Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rescale_to_unit;\n\t@test(candidate([2.0, 49.9]) == [0.0, 1.0])\n\t@test(candidate([100.0, 49.9]) == [1.0, 0.0])\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\n\t@test(candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\n\t@test(candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "jl",
+    "prompt": "\"\"\" Filter given list of any python values only for integers\n    >>> filter_integers([\"a\", 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, \"abc\", Dict(), []])\n    [1, 2, 3]\n    \"\"\"\nfunction filter_integers(values::Vector{Any})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_integers;\n\t@test(candidate(Vector{Any}([])) == Vector{Int64}([]))\n\t@test(candidate([4, Dict(), [], 23.2, 9, \"adasd\"]) == [4, 9])\n\t@test(candidate([3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "jl",
+    "prompt": "\"\"\" Return length of given string\n    >>> strlen(\"\")\n    0\n    >>> strlen(\"abc\")\n    3\n    \"\"\"\nfunction strlen(string::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strlen;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"x\") == 1)\n\t@test(candidate(\"asdasnakj\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "jl",
+    "prompt": "\"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\nfunction largest_divisor(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_divisor;\n\t@test(candidate(3) == 1)\n\t@test(candidate(7) == 1)\n\t@test(candidate(10) == 5)\n\t@test(candidate(100) == 50)\n\t@test(candidate(49) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "jl",
+    "prompt": "\"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\nfunction factorize(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = factorize;\n\t@test(candidate(2) == [2])\n\t@test(candidate(4) == [2, 2])\n\t@test(candidate(8) == [2, 2, 2])\n\t@test(candidate(57) == [3, 19])\n\t@test(candidate(3249) == [3, 3, 19, 19])\n\t@test(candidate(185193) == [3, 3, 3, 19, 19, 19])\n\t@test(candidate(20577) == [3, 19, 19, 19])\n\t@test(candidate(18) == [2, 3, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\nfunction remove_duplicates(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_duplicates;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "jl",
+    "prompt": "\"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case(\"Hello\")\n    \"hELLO\"\n    \"\"\"\nfunction flip_case(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flip_case;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hello!\") == \"hELLO!\")\n\t@test(candidate(\"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "jl",
+    "prompt": "\"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    \"\"\n    >>> concatenate([\"a\", \"b\", \"c\"])\n    \"abc\"\n    \"\"\"\nfunction concatenate(strings::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate;\n\t@test(candidate(Vector{String}([])) == \"\")\n\t@test(candidate([\"x\", \"y\", \"z\"]) == \"xyz\")\n\t@test(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], \"a\")\n    []\n    >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"array\"]\n    \"\"\"\nfunction filter_by_prefix(strings::Vector{String}, prefix::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_prefix;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "jl",
+    "prompt": "\"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\nfunction truncate_number(number::Float64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = truncate_number;\n\t@test(candidate(3.5) == 0.5)\n\t@test(candidate(1.25) == 0.25)\n\t@test(candidate(123.0) == 0.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "jl",
+    "prompt": "\"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\nfunction get_positive(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_positive;\n\t@test(candidate([-1, -2, 4, 5, 6]) == [4, 5, 6])\n\t@test(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\n\t@test(candidate([-1, -2]) == Vector{Int64}([]))\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    false\n    >>> is_prime(101)\n    true\n    >>> is_prime(11)\n    true\n    >>> is_prime(13441)\n    true\n    >>> is_prime(61)\n    true\n    >>> is_prime(4)\n    false\n    >>> is_prime(1)\n    false\n    \"\"\"\nfunction is_prime(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_prime;\n\t@test(candidate(6) == false)\n\t@test(candidate(101) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(13441) == true)\n\t@test(candidate(61) == true)\n\t@test(candidate(4) == false)\n\t@test(candidate(1) == false)\n\t@test(candidate(5) == true)\n\t@test(candidate(11) == true)\n\t@test(candidate(17) == true)\n\t@test(candidate(85) == false)\n\t@test(candidate(77) == false)\n\t@test(candidate(255379) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "jl",
+    "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\nfunction sort_third(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_third;\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\n\t@test(candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\n\t@test(candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\n\t@test(candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\nfunction unique(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique;\n\t@test(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "jl",
+    "prompt": "\"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\nfunction max_element(l::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_element;\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "jl",
+    "prompt": "\"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\nfunction fizz_buzz(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fizz_buzz;\n\t@test(candidate(50) == 0)\n\t@test(candidate(78) == 2)\n\t@test(candidate(79) == 3)\n\t@test(candidate(100) == 3)\n\t@test(candidate(200) == 6)\n\t@test(candidate(4000) == 192)\n\t@test(candidate(10000) == 639)\n\t@test(candidate(100000) == 8026)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2188,9 +1278,233 @@
     "language": "jl",
     "prompt": "\"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\nfunction sort_even(l::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = sort_even;\n\t@test(candidate([1, 2, 3]) == [1, 2, 3])\n\t@test(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\n\t@test(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "jl",
+    "prompt": "\"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\nfunction prime_fib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_fib;\n\t@test(candidate(1) == 2)\n\t@test(candidate(2) == 3)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 13)\n\t@test(candidate(5) == 89)\n\t@test(candidate(6) == 233)\n\t@test(candidate(7) == 1597)\n\t@test(candidate(8) == 28657)\n\t@test(candidate(9) == 514229)\n\t@test(candidate(10) == 433494437)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "jl",
+    "prompt": "\"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    false\n    >>> below_zero([1, 2, -4, 5])\n    true\n    \"\"\"\nfunction below_zero(operations::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_zero;\n\t@test(candidate(Vector{Int64}([])) == false)\n\t@test(candidate([1, 2, -3, 1, 2, -3]) == false)\n\t@test(candidate([1, 2, -4, 5, 6]) == true)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -4]) == false)\n\t@test(candidate([1, -1, 2, -2, 5, -5, 4, -5]) == true)\n\t@test(candidate([1, -2, 2, -2, 5, -5, 4, -4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    true\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    true\n    >>> triples_sum_to_zero([1])\n    false\n    \"\"\"\nfunction triples_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triples_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, 5, -1]) == false)\n\t@test(candidate([1, 3, -2, 1]) == true)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([1, 2, 5, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 9, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([1, 3, 5, -100]) == false)\n\t@test(candidate([100, 3, 5, -100]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\nfunction car_race_collision(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = car_race_collision;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 9)\n\t@test(candidate(4) == 16)\n\t@test(candidate(8) == 64)\n\t@test(candidate(10) == 100)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "jl",
+    "prompt": "\"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\nfunction incr_list(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = incr_list;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([3, 2, 1]) == [4, 3, 2])\n\t@test(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    false\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    false\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    false\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    true\n    >>> pairs_sum_to_zero([1])\n    false\n    \"\"\"\nfunction pairs_sum_to_zero(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pairs_sum_to_zero;\n\t@test(candidate([1, 3, 5, 0]) == false)\n\t@test(candidate([1, 3, -2, 1]) == false)\n\t@test(candidate([1, 2, 3, 7]) == false)\n\t@test(candidate([2, 4, -5, 3, 5, 7]) == true)\n\t@test(candidate([1]) == false)\n\t@test(candidate([-3, 9, -1, 3, 2, 30]) == true)\n\t@test(candidate([-3, 9, -1, 3, 2, 31]) == true)\n\t@test(candidate([-3, 9, -1, 4, 2, 30]) == false)\n\t@test(candidate([-3, 9, -1, 4, 2, 31]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "jl",
+    "prompt": "\"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    \"22\"\n    >>> change_base(8, 2)\n    \"1000\"\n    >>> change_base(7, 2)\n    \"111\"\n    \"\"\"\nfunction change_base(x::Int64, base::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_base;\n\t@test(candidate(8, 3) == \"22\")\n\t@test(candidate(9, 3) == \"100\")\n\t@test(candidate(234, 2) == \"11101010\")\n\t@test(candidate(16, 2) == \"10000\")\n\t@test(candidate(8, 2) == \"1000\")\n\t@test(candidate(7, 2) == \"111\")\n\t@test(candidate(2, 3) == \"2\")\n\t@test(candidate(3, 4) == \"3\")\n\t@test(candidate(4, 5) == \"4\")\n\t@test(candidate(5, 6) == \"5\")\n\t@test(candidate(6, 7) == \"6\")\n\t@test(candidate(7, 8) == \"7\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\nfunction triangle_area(a::Int64, h::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(5, 3) == 7.5)\n\t@test(candidate(2, 2) == 2.0)\n\t@test(candidate(10, 8) == 40.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "jl",
+    "prompt": "\"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\nfunction fib4(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib4;\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 28)\n\t@test(candidate(10) == 104)\n\t@test(candidate(12) == 386)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "jl",
+    "prompt": "\"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\nfunction median(l::Vector{Int64})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median;\n\t@test(candidate([3, 1, 2, 4, 5]) == 3)\n\t@test(candidate([-10, 4, 6, 1000, 10, 20]) == 8.0)\n\t@test(candidate([5]) == 5)\n\t@test(candidate([6, 5]) == 5.5)\n\t@test(candidate([8, 1, 3, 9, 9, 2, 7]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome(\"\")\n    true\n    >>> is_palindrome(\"aba\")\n    true\n    >>> is_palindrome(\"aaaaa\")\n    true\n    >>> is_palindrome(\"zbcd\")\n    false\n    \"\"\"\nfunction is_palindrome(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_palindrome;\n\t@test(candidate(\"\") == true)\n\t@test(candidate(\"aba\") == true)\n\t@test(candidate(\"aaaaa\") == true)\n\t@test(candidate(\"zbcd\") == false)\n\t@test(candidate(\"xywyx\") == true)\n\t@test(candidate(\"xywyz\") == false)\n\t@test(candidate(\"xywzx\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "jl",
+    "prompt": "\"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\nfunction modp(n::Int64, p::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = modp;\n\t@test(candidate(3, 5) == 3)\n\t@test(candidate(1101, 101) == 2)\n\t@test(candidate(0, 101) == 1)\n\t@test(candidate(3, 11) == 8)\n\t@test(candidate(100, 101) == 1)\n\t@test(candidate(30, 5) == 4)\n\t@test(candidate(31, 5) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\nfunction mean_absolute_deviation(numbers::Vector{Float64})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mean_absolute_deviation;\n\t@test(candidate([1.0, 2.0]) == 0.5)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0]) == 1.0)\n\t@test(candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels(\"\")\n    \"\"\n    >>> remove_vowels(\"abcdef\")\n    \"bcdf\"\n    >>> remove_vowels(\"aaaaa\")\n    \"\"\n    >>> remove_vowels(\"aaBAA\")\n    \"B\"\n    >>> remove_vowels(\"zbcd\")\n    \"zbcd\"\n    \"\"\"\nfunction remove_vowels(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_vowels;\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"abcdef\nghijklm\") == \"bcdf\nghjklm\")\n\t@test(candidate(\"fedcba\") == \"fdcb\")\n\t@test(candidate(\"eeeee\") == \"\")\n\t@test(candidate(\"acBAA\") == \"cB\")\n\t@test(candidate(\"EcBOO\") == \"cB\")\n\t@test(candidate(\"ybcd\") == \"ybcd\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "jl",
+    "prompt": "\"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    true\n    >>> below_threshold([1, 20, 4, 10], 5)\n    false\n    \"\"\"\nfunction below_threshold(l::Vector{Int64}, t::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = below_threshold;\n\t@test(candidate([1, 2, 4, 10], 100) == true)\n\t@test(candidate([1, 20, 4, 10], 5) == false)\n\t@test(candidate([1, 20, 4, 10], 21) == true)\n\t@test(candidate([1, 20, 4, 10], 22) == true)\n\t@test(candidate([1, 8, 4, 10], 11) == true)\n\t@test(candidate([1, 8, 4, 10], 10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "jl",
+    "prompt": "\"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\nfunction add(x::Int64, y::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate(0, 1) == 1)\n\t@test(candidate(1, 0) == 1)\n\t@test(candidate(2, 3) == 5)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 5) == 12)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2202,9 +1516,23 @@
     "language": "jl",
     "prompt": "\"\"\"\n    Check if two words have the same characters.\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n    true\n    >>> same_chars(\"abcd\", \"dddddddabc\")\n    true\n    >>> same_chars(\"dddddddabc\", \"abcd\")\n    true\n    >>> same_chars(\"eabcd\", \"dddddddabc\")\n    false\n    >>> same_chars(\"abcd\", \"dddddddabce\")\n    false\n    >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n    false\n    \"\"\"\nfunction same_chars(s0::String, s1::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = same_chars;\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") == true)\n\t@test(candidate(\"abcd\", \"dddddddabc\") == true)\n\t@test(candidate(\"dddddddabc\", \"abcd\") == true)\n\t@test(candidate(\"eabcd\", \"dddddddabc\") == false)\n\t@test(candidate(\"abcd\", \"dddddddabcf\") == false)\n\t@test(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") == false)\n\t@test(candidate(\"aabb\", \"aaccc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "jl",
+    "prompt": "\"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\nfunction fib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fib;\n\t@test(candidate(10) == 55)\n\t@test(candidate(1) == 1)\n\t@test(candidate(8) == 21)\n\t@test(candidate(11) == 89)\n\t@test(candidate(12) == 144)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -2216,9 +1544,681 @@
     "language": "jl",
     "prompt": "\"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    false\n    >>> correct_bracketing(\"<>\")\n    true\n    >>> correct_bracketing(\"<<><>>\")\n    true\n    >>> correct_bracketing(\"><<>\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"<>\") == true)\n\t@test(candidate(\"<<><>>\") == true)\n\t@test(candidate(\"<><><<><>><>\") == true)\n\t@test(candidate(\"<><><<<><><>><>><<><><<>>>\") == true)\n\t@test(candidate(\"<<<><>>>>\") == false)\n\t@test(candidate(\"><<>\") == false)\n\t@test(candidate(\"<\") == false)\n\t@test(candidate(\"<<<<\") == false)\n\t@test(candidate(\">\") == false)\n\t@test(candidate(\"<<>\") == false)\n\t@test(candidate(\"<><><<><>><>><<>\") == false)\n\t@test(candidate(\"<><><<><>><>>><>\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    true\n    >>> monotonic([1, 20, 4, 10])\n    false\n    >>> monotonic([4, 1, 0, -10])\n    true\n    \"\"\"\nfunction monotonic(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = monotonic;\n\t@test(candidate([1, 2, 4, 10]) == true)\n\t@test(candidate([1, 2, 4, 20]) == true)\n\t@test(candidate([1, 20, 4, 10]) == false)\n\t@test(candidate([4, 1, 0, -10]) == true)\n\t@test(candidate([4, 1, 1, 0]) == true)\n\t@test(candidate([1, 2, 3, 2, 5, 60]) == false)\n\t@test(candidate([1, 2, 3, 4, 5, 60]) == true)\n\t@test(candidate([9, 9, 9, 9]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "jl",
+    "prompt": "\"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\nfunction common(l1::Vector{Int64}, l2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common;\n\t@test(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\n\t@test(candidate([5, 3, 2, 8], [3, 2]) == [2, 3])\n\t@test(candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4])\n\t@test(candidate([4, 3, 2, 8], Vector{Int64}([])) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "jl",
+    "prompt": "\"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\nfunction largest_prime_factor(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_prime_factor;\n\t@test(candidate(15) == 5)\n\t@test(candidate(27) == 3)\n\t@test(candidate(63) == 7)\n\t@test(candidate(330) == 11)\n\t@test(candidate(13195) == 29)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "jl",
+    "prompt": "\"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\nfunction intersperse(numbers::Vector{Int64}, delimeter::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersperse;\n\t@test(candidate(Vector{Int64}([]), 7) == Vector{Int64}([]))\n\t@test(candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2])\n\t@test(candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "jl",
+    "prompt": "\"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\nfunction sum_to_n(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_to_n;\n\t@test(candidate(1) == 1)\n\t@test(candidate(6) == 21)\n\t@test(candidate(11) == 66)\n\t@test(candidate(30) == 465)\n\t@test(candidate(100) == 5050)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "jl",
+    "prompt": "\"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    false\n    >>> correct_bracketing(\"()\")\n    true\n    >>> correct_bracketing(\"(()())\")\n    true\n    >>> correct_bracketing(\")(()\")\n    false\n    \"\"\"\nfunction correct_bracketing(brackets::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = correct_bracketing;\n\t@test(candidate(\"()\") == true)\n\t@test(candidate(\"(()())\") == true)\n\t@test(candidate(\"()()(()())()\") == true)\n\t@test(candidate(\"()()((()()())())(()()(()))\") == true)\n\t@test(candidate(\"((()())))\") == false)\n\t@test(candidate(\")(()\") == false)\n\t@test(candidate(\"(\") == false)\n\t@test(candidate(\"((((\") == false)\n\t@test(candidate(\")\") == false)\n\t@test(candidate(\"(()\") == false)\n\t@test(candidate(\"()()(()())())(()\") == false)\n\t@test(candidate(\"()()(()())()))()\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "jl",
+    "prompt": "\"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\nfunction derivative(xs::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = derivative;\n\t@test(candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20])\n\t@test(candidate([1, 2, 3]) == [2, 6])\n\t@test(candidate([3, 2, 1]) == [2, 2])\n\t@test(candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16])\n\t@test(candidate([1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "jl",
+    "prompt": "\"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\nfunction fibfib(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fibfib;\n\t@test(candidate(2) == 1)\n\t@test(candidate(1) == 0)\n\t@test(candidate(5) == 4)\n\t@test(candidate(8) == 24)\n\t@test(candidate(10) == 81)\n\t@test(candidate(12) == 274)\n\t@test(candidate(14) == 927)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\nfunction vowels_count(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = vowels_count;\n\t@test(candidate(\"abcde\") == 2)\n\t@test(candidate(\"Alone\") == 3)\n\t@test(candidate(\"key\") == 2)\n\t@test(candidate(\"bye\") == 1)\n\t@test(candidate(\"keY\") == 2)\n\t@test(candidate(\"bYe\") == 1)\n\t@test(candidate(\"ACEDY\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "jl",
+    "prompt": "\"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\nfunction circular_shift(x::Int64, shift::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = circular_shift;\n\t@test(candidate(100, 2) == \"001\")\n\t@test(candidate(12, 2) == \"12\")\n\t@test(candidate(97, 8) == \"79\")\n\t@test(candidate(12, 1) == \"21\")\n\t@test(candidate(11, 101) == \"11\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "jl",
+    "prompt": "\"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum(\"\")\n    0\n    >>> digitSum(\"abAB\")\n    131\n    >>> digitSum(\"abcCd\")\n    67\n    >>> digitSum(\"helloE\")\n    69\n    >>> digitSum(\"woArBld\")\n    131\n    >>> digitSum(\"aAaaaXa\")\n    153\n    \"\"\"\nfunction digitSum(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digitSum;\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"abAB\") == 131)\n\t@test(candidate(\"abcCd\") == 67)\n\t@test(candidate(\"helloE\") == 69)\n\t@test(candidate(\"woArBld\") == 131)\n\t@test(candidate(\"aAaaaXa\") == 153)\n\t@test(candidate(\" How are yOu?\") == 151)\n\t@test(candidate(\"You arE Very Smart\") == 327)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "jl",
+    "prompt": "\"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n    8\n    >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n    2\n    >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n    95\n    >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n    19\n    \"\"\"\nfunction fruit_distribution(s::String, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = fruit_distribution;\n\t@test(candidate(\"5 apples and 6 oranges\", 19) == 8)\n\t@test(candidate(\"5 apples and 6 oranges\", 21) == 10)\n\t@test(candidate(\"0 apples and 1 oranges\", 3) == 2)\n\t@test(candidate(\"1 apples and 0 oranges\", 3) == 2)\n\t@test(candidate(\"2 apples and 3 oranges\", 100) == 95)\n\t@test(candidate(\"2 apples and 3 oranges\", 5) == 0)\n\t@test(candidate(\"1 apples and 100 oranges\", 120) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "jl",
+    "prompt": "\"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\nfunction pluck(arr::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pluck;\n\t@test(candidate([4, 2, 3]) == [2, 1])\n\t@test(candidate([1, 2, 3]) == [2, 1])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5, 0, 3, 0, 4, 2]) == [0, 1])\n\t@test(candidate([1, 2, 3, 0, 5, 3]) == [0, 3])\n\t@test(candidate([5, 4, 8, 4, 8]) == [4, 1])\n\t@test(candidate([7, 6, 7, 1]) == [6, 1])\n\t@test(candidate([7, 9, 7, 1]) == Vector{Int64}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\nfunction search(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([5, 5, 5, 5, 1]) == 1)\n\t@test(candidate([4, 1, 4, 1, 4, 4]) == 4)\n\t@test(candidate([3, 3]) == -1)\n\t@test(candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8)\n\t@test(candidate([2, 3, 3, 2, 2]) == 2)\n\t@test(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\n\t@test(candidate([3, 2, 8, 2]) == 2)\n\t@test(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\n\t@test(candidate([8, 8, 3, 6, 5, 6, 4]) == -1)\n\t@test(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\n\t@test(candidate([1, 9, 10, 1, 3]) == 1)\n\t@test(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\n\t@test(candidate([1]) == 1)\n\t@test(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\n\t@test(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\n\t@test(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\n\t@test(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\n\t@test(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\n\t@test(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\n\t@test(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\n\t@test(candidate([10]) == -1)\n\t@test(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\n\t@test(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\n\t@test(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\n\t@test(candidate([3, 10, 10, 9, 2]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "jl",
+    "prompt": "\"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n    [2, 3, 1, 3]\n    \"\"\"\nfunction parse_nested_parens(paren_string::String)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parse_nested_parens;\n\t@test(candidate(\"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\n\t@test(candidate(\"() (()) ((())) (((())))\") == [1, 2, 3, 4])\n\t@test(candidate(\"(()(())((())))\") == [4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\nfunction strange_sort_list(lst::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = strange_sort_list;\n\t@test(candidate([1, 2, 3, 4]) == [1, 4, 2, 3])\n\t@test(candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\n\t@test(candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\n\t@test(candidate([5, 5, 5, 5]) == [5, 5, 5, 5])\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\n\t@test(candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\n\t@test(candidate([111111]) == [111111])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\nfunction triangle_area(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(3, 4, 5) == 6.0)\n\t@test(candidate(1, 2, 10) == -1)\n\t@test(candidate(4, 8, 5) == 8.18)\n\t@test(candidate(2, 2, 2) == 1.73)\n\t@test(candidate(1, 2, 3) == -1)\n\t@test(candidate(10, 5, 7) == 16.25)\n\t@test(candidate(2, 6, 3) == -1)\n\t@test(candidate(1, 1, 1) == 0.43)\n\t@test(candidate(2, 2, 10) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    false\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    false\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    true\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    true\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\nfunction will_it_fly(q::Vector{Int64}, w::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = will_it_fly;\n\t@test(candidate([3, 2, 3], 9) == true)\n\t@test(candidate([1, 2], 5) == false)\n\t@test(candidate([3], 5) == true)\n\t@test(candidate([3, 2, 3], 1) == false)\n\t@test(candidate([1, 2, 3], 6) == false)\n\t@test(candidate([5], 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\nfunction smallest_change(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_change;\n\t@test(candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4)\n\t@test(candidate([1, 2, 3, 4, 3, 2, 2]) == 1)\n\t@test(candidate([1, 4, 2]) == 1)\n\t@test(candidate([1, 4, 4, 2]) == 1)\n\t@test(candidate([1, 2, 3, 2, 1]) == 0)\n\t@test(candidate([3, 1, 1, 3]) == 0)\n\t@test(candidate([1]) == 0)\n\t@test(candidate([0, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n    [\"hI\", \"Hi\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n    [\"hi\", \"admin\"]\n    >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n    [\"hI\", \"hi\", \"hi\"]\n    >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n    [\"4\"]\n    \"\"\"\nfunction total_match(lst1::Vector{String}, lst2::Vector{String})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = total_match;\n\t@test(candidate(Vector{String}([]), Vector{String}([])) == Vector{String}([]))\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\n\t@test(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\n\t@test(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\n\t@test(candidate(Vector{String}([]), [\"this\"]) == Vector{String}([]))\n\t@test(candidate([\"this\"], Vector{String}([])) == Vector{String}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    true\n    30 = 2 * 3 * 5\n    \"\"\"\nfunction is_multiply_prime(a::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_multiply_prime;\n\t@test(candidate(5) == false)\n\t@test(candidate(30) == true)\n\t@test(candidate(8) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(125) == true)\n\t@test(candidate(105) == true)\n\t@test(candidate(126) == false)\n\t@test(candidate(729) == false)\n\t@test(candidate(891) == false)\n\t@test(candidate(1001) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "jl",
+    "prompt": "\"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    true\n    >>> is_simple_power(2, 2)\n    true\n    >>> is_simple_power(8, 2)\n    true\n    >>> is_simple_power(3, 2)\n    false\n    >>> is_simple_power(3, 1)\n    false\n    >>> is_simple_power(5, 3)\n    false\n    \"\"\"\nfunction is_simple_power(x::Int64, n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_simple_power;\n\t@test(candidate(16, 2) == true)\n\t@test(candidate(143214, 16) == false)\n\t@test(candidate(4, 2) == true)\n\t@test(candidate(9, 3) == true)\n\t@test(candidate(16, 4) == true)\n\t@test(candidate(24, 2) == false)\n\t@test(candidate(128, 4) == false)\n\t@test(candidate(12, 6) == false)\n\t@test(candidate(1, 1) == true)\n\t@test(candidate(1, 12) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    true\n    >>> iscube(2)\n    false\n    >>> iscube(-1)\n    true\n    >>> iscube(64)\n    true\n    >>> iscube(0)\n    true\n    >>> iscube(180)\n    false\n    \"\"\"\nfunction iscube(a::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = iscube;\n\t@test(candidate(1) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(-1) == true)\n\t@test(candidate(64) == true)\n\t@test(candidate(180) == false)\n\t@test(candidate(1000) == true)\n\t@test(candidate(0) == true)\n\t@test(candidate(1729) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "jl",
+    "prompt": "\"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key(\"AB\")\n    1\n    >>> hex_key(\"1077E\")\n    2\n    >>> hex_key(\"ABED1A33\")\n    4\n    >>> hex_key(\"123456789ABCDEF0\")\n    6\n    >>> hex_key(\"2020\")\n    2\n    \"\"\"\nfunction hex_key(num::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hex_key;\n\t@test(candidate(\"AB\") == 1)\n\t@test(candidate(\"1077E\") == 2)\n\t@test(candidate(\"ABED1A33\") == 4)\n\t@test(candidate(\"2020\") == 2)\n\t@test(candidate(\"123456789ABCDEF0\") == 6)\n\t@test(candidate(\"112233445566778899AABBCCDDEEFF00\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    \"db1111db\"\n    >>> decimal_to_binary(32)\n    \"db100000db\"\n    \"\"\"\nfunction decimal_to_binary(decimal::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(0) == \"db0db\")\n\t@test(candidate(32) == \"db100000db\")\n\t@test(candidate(103) == \"db1100111db\")\n\t@test(candidate(15) == \"db1111db\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "jl",
+    "prompt": "\"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], \"a\")\n    []\n    >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n    [\"abc\", \"bacd\", \"array\"]\n    \"\"\"\nfunction filter_by_substring(strings::Vector{String}, substring::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_by_substring;\n\t@test(candidate(Vector{String}([]), \"john\") == Vector{String}([]))\n\t@test(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\n\t@test(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\") == [\"grunt\", \"prune\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy(\"a\")\n    false\n    >>> is_happy(\"aa\")\n    false\n    >>> is_happy(\"abcd\")\n    true\n    >>> is_happy(\"aabb\")\n    false\n    >>> is_happy(\"adb\")\n    true\n    >>> is_happy(\"xyy\")\n    false\n    \"\"\"\nfunction is_happy(s::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_happy;\n\t@test(candidate(\"a\") == false)\n\t@test(candidate(\"aa\") == false)\n\t@test(candidate(\"abcd\") == true)\n\t@test(candidate(\"aabb\") == false)\n\t@test(candidate(\"adb\") == true)\n\t@test(candidate(\"xyy\") == false)\n\t@test(candidate(\"iopaxpoi\") == true)\n\t@test(candidate(\"iopaxioi\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "jl",
+    "prompt": "\"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\n    \"\"\"\nfunction numerical_letter_grade(grades::Vector{Float64})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = numerical_letter_grade;\n\t@test(candidate([4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\n\t@test(candidate([1.2]) == [\"D+\"])\n\t@test(candidate([0.5]) == [\"D-\"])\n\t@test(candidate([0.0]) == [\"E\"])\n\t@test(candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\n\t@test(candidate([0.0, 0.7]) == [\"E\", \"D-\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "jl",
+    "prompt": "\"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length(\"Hello\")\n    true\n    >>> prime_length(\"abcdcba\")\n    true\n    >>> prime_length(\"kittens\")\n    true\n    >>> prime_length(\"orange\")\n    false\n    \"\"\"\nfunction prime_length(string::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_length;\n\t@test(candidate(\"Hello\") == true)\n\t@test(candidate(\"abcdcba\") == true)\n\t@test(candidate(\"kittens\") == true)\n\t@test(candidate(\"orange\") == false)\n\t@test(candidate(\"wow\") == true)\n\t@test(candidate(\"world\") == true)\n\t@test(candidate(\"MadaM\") == true)\n\t@test(candidate(\"Wow\") == true)\n\t@test(candidate(\"\") == false)\n\t@test(candidate(\"HI\") == true)\n\t@test(candidate(\"go\") == true)\n\t@test(candidate(\"gogo\") == false)\n\t@test(candidate(\"aaaaaaaaaaaaaaa\") == false)\n\t@test(candidate(\"Madam\") == true)\n\t@test(candidate(\"M\") == false)\n\t@test(candidate(\"0\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\nfunction starts_one_ends(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = starts_one_ends;\n\t@test(candidate(1) == 1)\n\t@test(candidate(2) == 18)\n\t@test(candidate(3) == 180)\n\t@test(candidate(4) == 1800)\n\t@test(candidate(5) == 18000)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "jl",
+    "prompt": "\"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    \"1\"\n    >>> solve(150)\n    \"110\"\n    >>> solve(147)\n    \"1100\"\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\nfunction solve(N::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = solve;\n\t@test(candidate(1000) == \"1\")\n\t@test(candidate(150) == \"110\")\n\t@test(candidate(147) == \"1100\")\n\t@test(candidate(333) == \"1001\")\n\t@test(candidate(963) == \"10010\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "jl",
+    "prompt": "\"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\nfunction add(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add;\n\t@test(candidate([4, 88]) == 88)\n\t@test(candidate([4, 5, 6, 7, 2, 122]) == 122)\n\t@test(candidate([4, 0, 6, 7]) == 0)\n\t@test(candidate([4, 4, 6, 8]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle(\"Hi\")\n    \"Hi\"\n    >>> anti_shuffle(\"hello\")\n    \"ehllo\"\n    >>> anti_shuffle(\"Hello World!!!\")\n    \"Hello !!!Wdlor\"\n    \"\"\"\nfunction anti_shuffle(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = anti_shuffle;\n\t@test(candidate(\"Hi\") == \"Hi\")\n\t@test(candidate(\"hello\") == \"ehllo\")\n\t@test(candidate(\"number\") == \"bemnru\")\n\t@test(candidate(\"abcd\") == \"abcd\")\n\t@test(candidate(\"Hello World!!!\") == \"Hello !!!Wdlor\")\n\t@test(candidate(\"\") == \"\")\n\t@test(candidate(\"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\nfunction get_row(lst::Vector{Vector{Int64}}, x::Int64)::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_row;\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\n\t@test(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\n\t@test(candidate(Vector{Vector{Int64}}([]), 1) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[1]], 2) == Vector{Tuple{Int64, Int64}}([]))\n\t@test(candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\nfunction sort_array(array::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_array;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([5]) == [5])\n\t@test(candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\n\t@test(candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\n\t@test(candidate([2, 1]) == [1, 2])\n\t@test(candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\n\t@test(candidate([21, 14, 23, 11]) == [23, 21, 14, 11])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "jl",
+    "prompt": "\"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt(\"hi\")\n    \"lm\"\n    >>> encrypt(\"asdfghjkl\")\n    \"ewhjklnop\"\n    >>> encrypt(\"gf\")\n    \"kj\"\n    >>> encrypt(\"et\")\n    \"ix\"\n    \"\"\"\nfunction encrypt(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encrypt;\n\t@test(candidate(\"hi\") == \"lm\")\n\t@test(candidate(\"asdfghjkl\") == \"ewhjklnop\")\n\t@test(candidate(\"gf\") == \"kj\")\n\t@test(candidate(\"et\") == \"ix\")\n\t@test(candidate(\"faewfawefaewg\") == \"jeiajeaijeiak\")\n\t@test(candidate(\"hellomyfriend\") == \"lippsqcjvmirh\")\n\t@test(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\n\t@test(candidate(\"a\") == \"e\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "jl",
+    "prompt": "\"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\nfunction sum_product(numbers::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_product;\n\t@test(candidate(Vector{Int64}([])) == (0, 1))\n\t@test(candidate([1, 1, 1]) == (3, 1))\n\t@test(candidate([100, 0]) == (100, 0))\n\t@test(candidate([3, 5, 7]) == (15, 105))\n\t@test(candidate([10]) == (10, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    nothing\n    >>> next_smallest([1, 1])\n    nothing\n    \"\"\"\nfunction next_smallest(lst::Vector{Int64})::Union{Int64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest;\n\t@test(candidate([1, 2, 3, 4, 5]) == 2)\n\t@test(candidate([5, 1, 4, 3, 2]) == 2)\n\t@test(candidate(Vector{Int64}([])) == nothing)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([1, 1, 1, 1, 0]) == 1)\n\t@test(candidate([1, 1]) == nothing)\n\t@test(candidate([-35, 34, 12, -45]) == -35)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "jl",
+    "prompt": "\"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\nfunction is_bored(S::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_bored;\n\t@test(candidate(\"Hello world\") == 0)\n\t@test(candidate(\"Is the sky blue?\") == 0)\n\t@test(candidate(\"I love It !\") == 1)\n\t@test(candidate(\"bIt\") == 0)\n\t@test(candidate(\"I feel good today. I will be productive. will kill It\") == 2)\n\t@test(candidate(\"You and I are going for a walk\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    true\n    \n    >>> any_int(3, 2, 2)\n    false\n\n    >>> any_int(3, -2, 1)\n    true\n    \n    >>> any_int(3.6, -2.2, 2)\n    false\n  \n\n    \n    \"\"\"\nfunction any_int(x::Float64, y::Float64, z::Float64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = any_int;\n\t@test(candidate(2, 3, 1) == true)\n\t@test(candidate(2.5, 2, 3) == false)\n\t@test(candidate(1.5, 5, 3.5) == false)\n\t@test(candidate(2, 6, 2) == false)\n\t@test(candidate(4, 2, 2) == true)\n\t@test(candidate(2.2, 2.2, 2.2) == false)\n\t@test(candidate(-4, 6, 2) == true)\n\t@test(candidate(2, 1, 1) == true)\n\t@test(candidate(3, 4, 7) == true)\n\t@test(candidate(3.0, 4, 7) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode(\"test\")\n    \"TGST\"\n    >>> encode(\"This is a message\")\n    \"tHKS KS C MGSSCGG\"\n    \"\"\"\nfunction encode(message::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = encode;\n\t@test(candidate(\"TEST\") == \"tgst\")\n\t@test(candidate(\"Mudasir\") == \"mWDCSKR\")\n\t@test(candidate(\"YES\") == \"ygs\")\n\t@test(candidate(\"This is a message\") == \"tHKS KS C MGSSCGG\")\n\t@test(candidate(\"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "jl",
+    "prompt": "\"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\nfunction skjkasdkd(lst::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = skjkasdkd;\n\t@test(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\n\t@test(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\n\t@test(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\n\t@test(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\n\t@test(candidate([0, 81, 12, 3, 1, 21]) == 3)\n\t@test(candidate([0, 8, 1, 2, 1, 7]) == 7)\n\t@test(candidate([8191]) == 19)\n\t@test(candidate([8191, 123456, 127, 7]) == 19)\n\t@test(candidate([127, 97, 8192]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"b\" => \"banana\"))\n    true\n    >>> check_dict_case(Dict(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n    false\n    >>> check_dict_case(Dict(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n    false\n    >>> check_dict_case(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n    false\n    >>> check_dict_case(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n    true\n    \"\"\"\nfunction check_dict_case(dict::Dict{String, String}>)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_dict_case;\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"b\" => \"banana\")) == true)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) == false)\n\t@test(candidate(Dict(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) == false)\n\t@test(candidate(Dict(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) == false)\n\t@test(candidate(Dict(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) == true)\n\t@test(candidate(Dict(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) == true)\n\t@test(candidate(Dict()) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "jl",
+    "prompt": "\"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\nfunction count_up_to(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_up_to;\n\t@test(candidate(5) == [2, 3])\n\t@test(candidate(6) == [2, 3, 5])\n\t@test(candidate(7) == [2, 3, 5])\n\t@test(candidate(10) == [2, 3, 5, 7])\n\t@test(candidate(0) == Vector{Int64}([]))\n\t@test(candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19])\n\t@test(candidate(1) == Vector{Int64}([]))\n\t@test(candidate(18) == [2, 3, 5, 7, 11, 13, 17])\n\t@test(candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\n\t@test(candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "jl",
+    "prompt": "\"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\nfunction multiply(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply;\n\t@test(candidate(148, 412) == 16)\n\t@test(candidate(19, 28) == 72)\n\t@test(candidate(2020, 1851) == 0)\n\t@test(candidate(14, -15) == 20)\n\t@test(candidate(76, 67) == 42)\n\t@test(candidate(17, 27) == 49)\n\t@test(candidate(0, 1) == 0)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper(\"aBCdEf\")\n    1\n    >>> count_upper(\"abcdefg\")\n    0\n    >>> count_upper(\"dBBE\")\n    0\n    \"\"\"\nfunction count_upper(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_upper;\n\t@test(candidate(\"aBCdEf\") == 1)\n\t@test(candidate(\"abcdefg\") == 0)\n\t@test(candidate(\"dBBE\") == 0)\n\t@test(candidate(\"B\") == 0)\n\t@test(candidate(\"U\") == 1)\n\t@test(candidate(\"\") == 0)\n\t@test(candidate(\"EEEE\") == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\nfunction closest_integer(value::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_integer;\n\t@test(candidate(\"10\") == 10)\n\t@test(candidate(\"14.5\") == 15)\n\t@test(candidate(\"-15.5\") == -16)\n\t@test(candidate(\"15.3\") == 15)\n\t@test(candidate(\"0\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "jl",
+    "prompt": "\"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\nfunction rolling_max(numbers::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rolling_max;\n\t@test(candidate(Vector{Int64}([])) == Vector{Int64}([]))\n\t@test(candidate([1, 2, 3, 4]) == [1, 2, 3, 4])\n\t@test(candidate([4, 3, 2, 1]) == [4, 4, 4, 4])\n\t@test(candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/humaneval-js-keep.json
+++ b/prompts/humaneval-js-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "js",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube(a){\n",
+    "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements(numbers, threshold){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "js",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode(message){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "js",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "js",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "js",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "js",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "js",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg(n, m){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "js",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "js",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "js",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold(l, t){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "js",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int(x, y, z){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "js",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y(n, x, y){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "js",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "js",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "js",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "js",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "js",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check(file_name){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "js",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram(test){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "js",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "js",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify(x, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "js",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "js",
-    "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete(s, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "js",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "js",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "js",
-    "prompt": "//Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "js",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "js",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "js",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "js",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "js",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "js",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "js",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "js",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "js",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "js",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "js",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "js",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "js",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "js",
-    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "js",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "js",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match(lst1, lst2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area(a, b, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "js",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter(txt){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "js",
-    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator, operand){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "js",
-    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "js",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "js",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "js",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "js",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath(grid, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "js",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "js",
-    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nfunction compare_one(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "js",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "js",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "js",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "js",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "js",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "js",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times(string, substring){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "js",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "js",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "js",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero(operations){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "js",
-    "prompt": "//Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars(s0, s1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "js",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups(paren_string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "js",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "js",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "js",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "js",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words(s, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "js",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max(words){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "js",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "js",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "js",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "js",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection(interval1, interval2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "js",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "js",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power(x, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1264,7 +19,7 @@
     "language": "js",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "js",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix(strings, prefix){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "js",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "js",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "js",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "js",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "js",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "js",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel(word){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "js",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension(class_name, extensions){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "js",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "js",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "js",
-    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "js",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "js",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "js",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "js",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "js",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "js",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "js",
-    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate(strings){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "js",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "js",
-    "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "js",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest(strings){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "js",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count(num){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "js",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "js",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "js",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "js",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "js",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base(x, base){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "js",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade(grades){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "js",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle(a, b, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "js",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "js",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "js",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare(game, guess){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "js",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "js",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row(lst, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "js",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "js",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "js",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "js",
-    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf(planet1, planet2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "js",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key(num){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "js",
-    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "js",
-    "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "js",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "js",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "js",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "js",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "js",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case(dict){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "js",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date(date){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "js",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "js",
-    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "js",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "js",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "js",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "js",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words(txt){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "js",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "js",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "js",
-    "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements(numbers, threshold){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "js",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution(s, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "js",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "js",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman(number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "js",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing(brackets){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "js",
-    "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing(brackets){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "js",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "js",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring(strings, substring){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "js",
-    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "js",
-    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2359,7 +49,7 @@
     "language": "js",
     "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// choose_num(12, 15) = 14\n// choose_num(13, 12) = -1\nfunction choose_num(x, y){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "js",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg(n, m){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "js",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "js",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "js",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "js",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "js",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "js",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "js",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "js",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram(test){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "js",
+    "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete(s, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "js",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "js",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "js",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "js",
+    "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "js",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words(s, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "js",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel(word){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "js",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "js",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "js",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "js",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "js",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "js",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date(date){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "js",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words(txt){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "js",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "js",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection(interval1, interval2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "js",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "js",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath(grid, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "js",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest(strings){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "js",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "js",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "js",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "js",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter(txt){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "js",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "js",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "js",
+    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nfunction compare_one(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "js",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "js",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "js",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "js",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "js",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check(file_name){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "js",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "js",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "js",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify(x, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "js",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "js",
+    "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "js",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "js",
+    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf(planet1, planet2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "js",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "js",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y(n, x, y){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "js",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "js",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare(game, guess){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "js",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension(class_name, extensions){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "js",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "js",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count(num){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "js",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman(number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle(a, b, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max(words){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "js",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "js",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "js",
+    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator, operand){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "js",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2389,7 +1054,7 @@
     "language": "js",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// generate_integers(2, 8) => [2, 4, 6, 8]\n// generate_integers(8, 2) => [2, 4, 6, 8]\n// generate_integers(10, 14) => []\nfunction generate_integers(a, b){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "js",
     "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters('xyzXYZ')\n// 3\n// >>> count_distinct_characters('Jerry')\n// 4\nfunction count_distinct_characters(string){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "js",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "js",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times(string, substring){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "js",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "js",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups(paren_string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "js",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "js",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "js",
+    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "js",
+    "prompt": "//Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "js",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "js",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "js",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "js",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "js",
+    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate(strings){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix(strings, prefix){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "js",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "js",
+    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "js",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "js",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "js",
+    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "js",
+    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "js",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "js",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "js",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "js",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero(operations){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "js",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "js",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "js",
+    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "js",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "js",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base(x, base){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "js",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "js",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "js",
+    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "js",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "js",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "js",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "js",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "js",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold(l, t){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "js",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "js",
+    "prompt": "//Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars(s0, s1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "js",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "js",
+    "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing(brackets){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "js",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "js",
+    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "js",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "js",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "js",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "js",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing(brackets){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "js",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "js",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "js",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "js",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "js",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "js",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution(s, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "js",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "js",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "js",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "js",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area(a, b, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "js",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "js",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "js",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match(lst1, lst2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "js",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "js",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power(x, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "js",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube(a){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "js",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key(num){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "js",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring(strings, substring){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "js",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade(grades){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "js",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "js",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "js",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row(lst, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "js",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "js",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "js",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "js",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "js",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int(x, y, z){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "js",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode(message){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "js",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case(dict){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "js",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "js",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "js",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "js",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "js",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-js-remove.json
+++ b/prompts/humaneval-js-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "js",
-    "prompt": "//Return length of given string\nfunction strlen(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "js",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "js",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case(dict){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "js",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces(text){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "js",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "js",
-    "prompt": "//Filter given list of any python values only for integers\nfunction filter_integers(values){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "js",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music(music_string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "js",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary(decimal){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "js",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "js",
-    "prompt": "//Add two numbers x and y\nfunction add(x, y){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "js",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "js",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "js",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "js",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "js",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "js",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "js",
-    "prompt": "//Return sorted unique elements in a list\nfunction unique(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "js",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match(lst1, lst2){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "js",
-    "prompt": "//Return maximum element in the list.\nfunction max_element(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "js",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "js",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg(n, m){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "js",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "js",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "js",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "js",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative(xs){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "js",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "js",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix(strings, prefix){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "js",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "js",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath(grid, k){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "js",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "js",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "js",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "js",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array(array){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "js",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "js",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube(a){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "js",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode(message){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "js",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored(S){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "js",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area(a, b, c){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "js",
-    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunction bf(planet1, planet2){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "js",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "js",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times(string, substring){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "js",
-    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nfunction compare_one(a, b){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "js",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels(text){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "js",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "js",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements(numbers){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "js",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power(x, n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "js",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "js",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points(nums){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "js",
     "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\nfunction has_close_elements(numbers, threshold){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "js",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "js",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor(a, b){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "js",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "js",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "js",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits(x){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "js",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words(s, n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "js",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "js",
-    "prompt": "//Return n-th Fibonacci number.\nfunction fib(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "js",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension(class_name, extensions){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "js",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "js",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int(x, y, z){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "js",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number(number){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "js",
-    "prompt": "//Return list with elements incremented by 1.\nfunction incr_list(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "js",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y(n, x, y){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "js",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\nfunction modp(n, p){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "js",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count(num){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "js",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "js",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "js",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit(numbers){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "js",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "js",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "js",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "js",
-    "prompt": "//Return median of elements in the list l.\nfunction median(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "js",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "js",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "js",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check(file_name){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "js",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero(l){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "js",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection(interval1, interval2){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "js",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups(paren_string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "js",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare(game, guess){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "js",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter(txt){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "js",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date(date){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "js",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle(s){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "js",
-    "prompt": "//Checks if given string is a palindrome\nfunction is_palindrome(text){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "js",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel(word){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "js",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\nfunction is_prime(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "js",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify(x, n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "js",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key(num){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "js",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "js",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram(test){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "js",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row(lst, x){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "js",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange(arr){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "js",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers(numbers){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "js",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift(x, shift){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "js",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "js",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product(numbers){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "js",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num(x, y){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "js",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers(lst){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "js",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters(string){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1714,7 +19,7 @@
     "language": "js",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\nfunction make_a_pile(n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "js",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs(arr){\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string(s){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "js",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum(nums){\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num(x, y){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "js",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence(n){\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg(n, m){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "js",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check(a, b){\n",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits(x){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "js",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic(l){\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length(arr){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "js",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest(strings){\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f(n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "js",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\nfunction below_threshold(l, t){\n",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "js",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums(arr){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "js",
-    "prompt": "//Return only positive numbers in the list.\nfunction get_positive(l){\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "js",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third(l){\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome(string){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "js",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens(paren_string){\n",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "js",
-    "prompt": "//Given length of a side and high return area for a triangle.\nfunction triangle_area(a, h){\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram(test){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "js",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply(a, b){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "js",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation(numbers){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "js",
-    "prompt": "//Return sorted unique common elements for two lists.\nfunction common(l1, l2){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "js",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman(number){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "js",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution(s, n){\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1984,7 +214,7 @@
     "language": "js",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\nfunction reverse_delete(s, c){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "js",
-    "prompt": "//Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor(a, b){\n",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count(lst){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "js",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words(txt){\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum(nums){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "js",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2029,7 +274,7 @@
     "language": "js",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\nfunction sort_array(arr){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "js",
-    "prompt": "//Concatenate list of strings into a single string\nfunction concatenate(strings){\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words(s, n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "js",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum(lst){\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel(word){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring(strings, substring){\n",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens(lst){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "js",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor(a, b){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "js",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count(s){\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "js",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max(words){\n",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution(lst){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "js",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5(text){\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "js",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base(x, base){\n",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle(a, b, c){\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date(date){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "js",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade(grades){\n",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words(txt){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "js",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse(numbers, delimeter){\n",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted(lst){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "js",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection(interval1, interval2){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "js",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs(arr){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "js",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath(grid, k){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "js",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest(strings){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "js",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "js",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested(string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "js",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "js",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter(txt){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "js",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange(arr){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "js",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "js",
+    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nfunction compare_one(a, b){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "js",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "js",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "js",
+    "prompt": "//Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor(a, b){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "js",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces(text){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "js",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check(file_name){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "js",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "js",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "js",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify(x, n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "js",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points(nums){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2209,7 +769,7 @@
     "language": "js",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\nfunction specialFilter(nums){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "js",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n(n){\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "js",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates(numbers){\n",
+    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunction bf(planet1, planet2){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "js",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes(string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "js",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y(n, x, y){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "js",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "js",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare(game, guess){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "js",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension(class_name, extensions){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "js",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check(a, b){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "js",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count(num){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "js",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman(number){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle(a, b, c){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max(words){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "js",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "js",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "js",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5(text){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2254,7 +1039,7 @@
     "language": "js",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\nfunction generate_integers(a, b){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "js",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max(numbers){\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters(string){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "js",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero(operations){\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music(music_string){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "js",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search(lst){\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times(string, substring){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "js",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets){\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers(numbers){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "js",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups(paren_string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "js",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "js",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "js",
+    "prompt": "//Filter given list of any python values only for integers\nfunction filter_integers(values){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "js",
+    "prompt": "//Return length of given string\nfunction strlen(string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "js",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "js",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "js",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "js",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case(string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "js",
+    "prompt": "//Concatenate list of strings into a single string\nfunction concatenate(strings){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix(strings, prefix){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "js",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number(number){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "js",
+    "prompt": "//Return only positive numbers in the list.\nfunction get_positive(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "js",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\nfunction is_prime(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "js",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "js",
+    "prompt": "//Return sorted unique elements in a list\nfunction unique(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "js",
+    "prompt": "//Return maximum element in the list.\nfunction max_element(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "js",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2329,9 +1384,234 @@
     "language": "js",
     "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\nfunction sort_even(l){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "js",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "js",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero(operations){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "js",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "js",
+    "prompt": "//Return list with elements incremented by 1.\nfunction incr_list(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "js",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "js",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base(x, base){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "js",
+    "prompt": "//Given length of a side and high return area for a triangle.\nfunction triangle_area(a, h){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "js",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "js",
+    "prompt": "//Return median of elements in the list l.\nfunction median(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "js",
+    "prompt": "//Checks if given string is a palindrome\nfunction is_palindrome(text){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "js",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\nfunction modp(n, p){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "js",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "js",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels(text){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "js",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\nfunction below_threshold(l, t){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "js",
+    "prompt": "//Add two numbers x and y\nfunction add(x, y){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2344,9 +1624,24 @@
     "language": "js",
     "prompt": "//Check if two words have the same characters.\nfunction same_chars(s0, s1){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "js",
+    "prompt": "//Return n-th Fibonacci number.\nfunction fib(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2359,9 +1654,714 @@
     "language": "js",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets){\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "js",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic(l){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "js",
+    "prompt": "//Return sorted unique common elements for two lists.\nfunction common(l1, l2){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "js",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "js",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse(numbers, delimeter){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "js",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "js",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "js",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative(xs){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "js",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "js",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "js",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift(x, shift){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "js",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "js",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution(s, n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "js",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "js",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "js",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens(paren_string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "js",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area(a, b, c){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "js",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "js",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change(arr){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "js",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match(lst1, lst2){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "js",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "js",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power(x, n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "js",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube(a){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "js",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key(num){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "js",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary(decimal){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring(strings, substring){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "js",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade(grades){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length(string){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "js",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "js",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "js",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row(lst, x){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "js",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array(array){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "js",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "js",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "js",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored(S){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "js",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int(x, y, z){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "js",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode(message){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd(lst){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "js",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case(dict){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "js",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to(n){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "js",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply(a, b){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "js",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper(s){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "js",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "js",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max(numbers){\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-js-reworded.json
+++ b/prompts/humaneval-js-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "js",
-    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "js",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "js",
-    "prompt": "//Given an object, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given object is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "js",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "js",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "js",
-    "prompt": "//Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "js",
-    "prompt": "//Filter given array of any jsthon values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "js",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "js",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "js",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "js",
-    "prompt": "//Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "js",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "js",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "js",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "js",
-    "prompt": "//Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra(operator, operand){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "js",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "js",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "js",
-    "prompt": "//Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "js",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "js",
-    "prompt": "//Return sorted unique elements in an array\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "js",
-    "prompt": "//Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1, lst2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "js",
-    "prompt": "//Return maximum element in the array.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "js",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "js",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n, m){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "js",
-    "prompt": "//Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "js",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "js",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "js",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "js",
-    "prompt": "//Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "js",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "js",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "js",
-    "prompt": "//Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings, prefix){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "js",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "js",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "js",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "js",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "js",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "js",
-    "prompt": "//Given an array of non-negative integers, return a cojs of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "js",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "js",
-    "prompt": "//Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "js",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "js",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "js",
-    "prompt": "//pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a, b, c){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "js",
-    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return an array containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty array if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// [\"Saturn\", \"Uranus\"]\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nfunction bf(planet1, planet2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "js",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "js",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string, substring){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "js",
-    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return undefined if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// undefined\nfunction compare_one(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "js",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "js",
-    "prompt": "//Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "js",
-    "prompt": "//From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "js",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "js",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "js",
-    "prompt": "//Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "js",
     "prompt": "//Check if in given array of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// false\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// true\nfunction has_close_elements(numbers, threshold){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "js",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "js",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "js",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "js",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "js",
-    "prompt": "//Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "js",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "js",
-    "prompt": "//Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "js",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "js",
-    "prompt": "//You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name, extensions){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "js",
-    "prompt": "//You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "js",
-    "prompt": "//You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return undefined if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "js",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x, y, z){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "js",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "js",
-    "prompt": "//Return array with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "js",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n, x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "js",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "js",
-    "prompt": "//Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is hapjs or not.\n// A string is hapjs if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "js",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "js",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "js",
-    "prompt": "//Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "js",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "js",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "js",
-    "prompt": "//In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange(lst1, lst2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "js",
-    "prompt": "//Return median of elements in the array l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "js",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "js",
-    "prompt": "//You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "js",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "js",
-    "prompt": "//triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "js",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1, interval2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "js",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "js",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game, guess){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "js",
-    "prompt": "//Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "js",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "js",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "js",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "js",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "js",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "js",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "js",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "js",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "js",
-    "prompt": "//Given a string representing a space separated lowercase letters, return an object\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "js",
-    "prompt": "//You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "js",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "js",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "js",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "js",
-    "prompt": "//\"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "js",
-    "prompt": "//You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "js",
-    "prompt": "//For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "js",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "js",
-    "prompt": "//Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as undefined.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "js",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1759,7 +19,7 @@
     "language": "js",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in an array, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "js",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return undefined for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr){\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "js",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums){\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x, y){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "js",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n){\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n, m){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "js",
-    "prompt": "//You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a, b){\n",
+    "prompt": "//Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "js",
-    "prompt": "//Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l){\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "js",
-    "prompt": "//Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return undefined in case the input array is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings){\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "js",
-    "prompt": "//Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l, t){\n",
+    "prompt": "//Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "js",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "js",
-    "prompt": "//Return only positive numbers in the array.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "js",
-    "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "js",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
+    "prompt": "//In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange(lst1, lst2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "js",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return an object\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "js",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "js",
-    "prompt": "//For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "js",
-    "prompt": "//Return sorted unique common elements for two arrays.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "js",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "js",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2029,7 +214,7 @@
     "language": "js",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return an array containing the result string and true/false for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// [\"bcd\", false]\n// >>> reverse_delete(\"abcdef\", \"b\")\n// [\"acdef\", false]\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// [\"cdedc\", true]\nfunction reverse_delete(s, c){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "js",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
+    "prompt": "//Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "js",
-    "prompt": "//Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt){\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "js",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2074,7 +274,7 @@
     "language": "js",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4])\n// [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6])\n// [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4])\n// [0, 1, 2, 3, 4]\nfunction sort_array(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "js",
-    "prompt": "//Concatenate array of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings){\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s, n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "js",
-    "prompt": "//Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "js",
-    "prompt": "//Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings, substring){\n",
+    "prompt": "//You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "js",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a, b){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "js",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "js",
-    "prompt": "//Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words){\n",
+    "prompt": "//Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "js",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return undefined.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text){\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "js",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x, base){\n",
+    "prompt": "//Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a, b, c){\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "js",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades){\n",
+    "prompt": "//Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "js",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
+    "prompt": "//Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "js",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1, interval2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "js",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return undefined for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "js",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "js",
+    "prompt": "//Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return undefined in case the input array is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "js",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "js",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "js",
+    "prompt": "//You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "js",
+    "prompt": "//Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "js",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "js",
+    "prompt": "//Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as undefined.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "js",
+    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return undefined if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// undefined\nfunction compare_one(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "js",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "js",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "js",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "js",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "js",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "js",
+    "prompt": "//\"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "js",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "js",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "js",
+    "prompt": "//Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2254,7 +769,7 @@
     "language": "js",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([15, -73, 14, -15])\n// 1\n// >>> specialFilter([33, -2, -3, 45, 21, 109])\n// 2\nfunction specialFilter(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "js",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "js",
-    "prompt": "//From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
+    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return an array containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty array if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// [\"Saturn\", \"Uranus\"]\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nfunction bf(planet1, planet2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "js",
+    "prompt": "//Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "js",
+    "prompt": "//Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "js",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n, x, y){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "js",
+    "prompt": "//Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "js",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game, guess){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "js",
+    "prompt": "//You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name, extensions){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "js",
+    "prompt": "//You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "js",
+    "prompt": "//Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "js",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "js",
+    "prompt": "//Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "js",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "js",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "js",
+    "prompt": "//Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra(operator, operand){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "js",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return undefined.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2299,7 +1054,7 @@
     "language": "js",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// [2, 4, 6, 8]\n// >>> generate_integers(8, 2)\n// [2, 4, 6, 8]\n// >>> generate_integers(10, 14)\n// []\nfunction generate_integers(a, b){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "js",
-    "prompt": "//From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "js",
-    "prompt": "//You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations){\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "js",
-    "prompt": "//You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst){\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string, substring){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "js",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets){\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "js",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "js",
+    "prompt": "//From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "js",
+    "prompt": "//Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "js",
+    "prompt": "//Filter given array of any jsthon values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "js",
+    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "js",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "js",
+    "prompt": "//Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "js",
+    "prompt": "//From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "js",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "js",
+    "prompt": "//Concatenate array of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "js",
+    "prompt": "//Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings, prefix){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "js",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "js",
+    "prompt": "//Return only positive numbers in the array.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "js",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "js",
+    "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "js",
+    "prompt": "//Return sorted unique elements in an array\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "js",
+    "prompt": "//Return maximum element in the array.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "js",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2374,9 +1399,249 @@
     "language": "js",
     "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "js",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "js",
+    "prompt": "//You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "js",
+    "prompt": "//triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "js",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "js",
+    "prompt": "//Return array with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "js",
+    "prompt": "//pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "js",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x, base){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "js",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "js",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "js",
+    "prompt": "//Return median of elements in the array l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "js",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "js",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "js",
+    "prompt": "//For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "js",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "js",
+    "prompt": "//Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l, t){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "js",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2389,9 +1654,24 @@
     "language": "js",
     "prompt": "//Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars(s0, s1){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "js",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2404,9 +1684,729 @@
     "language": "js",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing(brackets){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "js",
+    "prompt": "//Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "js",
+    "prompt": "//Return sorted unique common elements for two arrays.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "js",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "js",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "js",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "js",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "js",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "js",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "js",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "js",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "js",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "js",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "js",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "js",
+    "prompt": "//You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "js",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "js",
+    "prompt": "//Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "js",
+    "prompt": "//Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "js",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "js",
+    "prompt": "//Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1, lst2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "js",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "js",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "js",
+    "prompt": "//Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "js",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "js",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "js",
+    "prompt": "//Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings, substring){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is hapjs or not.\n// A string is hapjs if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "js",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "js",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "js",
+    "prompt": "//Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "js",
+    "prompt": "//You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "js",
+    "prompt": "//Given an array of non-negative integers, return a cojs of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "js",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "js",
+    "prompt": "//For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "js",
+    "prompt": "//You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return undefined if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "js",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "js",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x, y, z){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "js",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "js",
+    "prompt": "//You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "js",
+    "prompt": "//Given an object, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given object is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "js",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "js",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "js",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "js",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "js",
+    "prompt": "//From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-js-transform.json
+++ b/prompts/humaneval-js-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "js",
-    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "js",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "js",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "js",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "js",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "js",
-    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "js",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "js",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "js",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "js",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "js",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "js",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "js",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "js",
-    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator, operand){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "js",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "js",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "js",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "js",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "js",
-    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "js",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1, lst2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "js",
-    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "js",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "js",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n, m){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "js",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "js",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "js",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "js",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "js",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "js",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "js",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings, prefix){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "js",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "js",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "js",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "js",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "js",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "js",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "js",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "js",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "js",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "js",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "js",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a, b, c){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "js",
-    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// [\"Saturn\", \"Uranus\"]\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nfunction bf(planet1, planet2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "js",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "js",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string, substring){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "js",
-    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// undefined\nfunction compare_one(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "js",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "js",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "js",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "js",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "js",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "js",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "js",
     "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// false\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// true\nfunction has_close_elements(numbers, threshold){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "js",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "js",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "js",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "js",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "js",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "js",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "js",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "js",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "js",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "js",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name, extensions){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "js",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "js",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x, y, z){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "js",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "js",
-    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "js",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n, x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "js",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "js",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "js",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "js",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "js",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "js",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "js",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "js",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "js",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "js",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "js",
-    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "js",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "js",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "js",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "js",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "js",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1, interval2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "js",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "js",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game, guess){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "js",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "js",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "js",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "js",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "js",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "js",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "js",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "js",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "js",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "js",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "js",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "js",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "js",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "js",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "js",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "js",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "js",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "js",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "js",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "js",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "js",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "js",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1759,7 +19,7 @@
     "language": "js",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "js",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr){\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "js",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums){\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x, y){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "js",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n){\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n, m){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "js",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a, b){\n",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "js",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l){\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "js",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings){\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "js",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l, t){\n",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "js",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "js",
-    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "js",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "js",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1, lst2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "js",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "js",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "js",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "js",
-    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "js",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "js",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2029,7 +214,7 @@
     "language": "js",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// [\"bcd\", false]\n// >>> reverse_delete(\"abcdef\", \"b\")\n// [\"acdef\", false]\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// [\"cdedc\", true]\nfunction reverse_delete(s, c){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "js",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "js",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt){\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "js",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid, capacity){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2074,7 +274,7 @@
     "language": "js",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4])\n// [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6])\n// [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4])\n// [0, 1, 2, 3, 4]\nfunction sort_array(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "js",
-    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings){\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s, n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "js",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "js",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings, substring){\n",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "js",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a, b){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "js",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr, k){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "js",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words){\n",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "js",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text){\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr, k){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "js",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x, base){\n",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "js",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a, b, c){\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "js",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades){\n",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "js",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "js",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1, interval2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "js",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "js",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "js",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "js",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "js",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "js",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "js",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "js",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "js",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "js",
+    "prompt": "//Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// undefined\nfunction compare_one(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare_one;\n  assert.deepEqual(candidate(1, 2),2);\n  assert.deepEqual(candidate(1, 2.5),2.5);\n  assert.deepEqual(candidate(2, 3),3);\n  assert.deepEqual(candidate(5, 6),6);\n  assert.deepEqual(candidate(1, \"2,3\"),\"2,3\");\n  assert.deepEqual(candidate(\"5,1\", \"6\"),\"6\");\n  assert.deepEqual(candidate(\"1\", \"2\"),\"2\");\n  assert.deepEqual(candidate(\"1\", 1),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "js",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "js",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "js",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "js",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "js",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "js",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "js",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "js",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "js",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2254,7 +769,7 @@
     "language": "js",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([15, -73, 14, -15])\n// 1\n// >>> specialFilter([33, -2, -3, 45, 21, 109])\n// 2\nfunction specialFilter(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "js",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "js",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
+    "prompt": "//There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// [\"Saturn\", \"Uranus\"]\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nfunction bf(planet1, planet2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bf;\n  assert.deepEqual(candidate(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Mercury\"),[\"Venus\"]);\n  assert.deepEqual(candidate(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]);\n  assert.deepEqual(candidate(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"]);\n  assert.deepEqual(candidate(\"Earth\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Mars\", \"Earth\"),[]);\n  assert.deepEqual(candidate(\"Jupiter\", \"Makemake\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "js",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "js",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n, x, y){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "js",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "js",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game, guess){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "js",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name, extensions){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "js",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "js",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "js",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "js",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "js",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number, need, remaining){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "js",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "js",
+    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator, operand){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "js",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2299,7 +1054,7 @@
     "language": "js",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// [2, 4, 6, 8]\n// >>> generate_integers(8, 2)\n// [2, 4, 6, 8]\n// >>> generate_integers(10, 14)\n// []\nfunction generate_integers(a, b){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "js",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "js",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations){\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "js",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst){\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string, substring){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "js",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets){\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "js",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "js",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "js",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "js",
+    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "js",
+    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "js",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "js",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "js",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "js",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "js",
+    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings, prefix){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "js",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "js",
+    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "js",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "js",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "js",
+    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "js",
+    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "js",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2374,9 +1399,249 @@
     "language": "js",
     "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "js",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "js",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "js",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "js",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "js",
+    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "js",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "js",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x, base){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "js",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "js",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "js",
+    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "js",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "js",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n, p){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "js",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "js",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\nghijklm\"),\"bcdf\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "js",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l, t){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "js",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x, y){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2389,9 +1654,24 @@
     "language": "js",
     "prompt": "//Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars(s0, s1){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "js",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2404,9 +1684,729 @@
     "language": "js",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing(brackets){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "js",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "js",
+    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1, l2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "js",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "js",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers, delimeter){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "js",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "js",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "js",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "js",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "js",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "js",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x, shift){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "js",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "js",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "js",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "js",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "js",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "js",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "js",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "js",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q, w){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "js",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "js",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1, lst2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "js",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "js",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "js",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "js",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "js",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "js",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings, substring){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "js",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "js",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "js",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "js",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "js",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "js",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "js",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "js",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "js",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "js",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "js",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "js",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x, y, z){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "js",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "js",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "js",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "js",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "js",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "js",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "js",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "js",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-lua-keep.json
+++ b/prompts/humaneval-lua-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "lua",
-    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- iscube(1) ==> True\n-- iscube(2) ==> False\n-- iscube(-1) ==> True\n-- iscube(64) ==> True\n-- iscube(0) ==> True\n-- iscube(180) ==> False\nlocal function iscube(a)\n",
+    "prompt": "-- Check if in given list of numbers, are any two numbers closer to each other than\n-- given threshold.\n-- >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n-- False\n-- >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n-- True\nlocal function has_close_elements(numbers, threshold)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "lua",
-    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n-- exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- solution([5, 8, 7, 1]) ==> 12\n-- solution([3, 3, 3, 3, 3]) ==> 9\n-- solution([30, 13, 24, 321]) ==>0\nlocal function solution(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "lua",
-    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "lua",
-    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "lua",
-    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\n-- minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n-- minSubArraySum([-1, -2, -3]) == -6\nlocal function minSubArraySum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "lua",
-    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- rounded_avg(1, 5) => \"0b11\"\n-- rounded_avg(7, 5) => -1\n-- rounded_avg(10, 20) => \"0b1111\"\n-- rounded_avg(20, 33) => \"0b11010\"\nlocal function rounded_avg(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "lua",
-    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored(\"Hello world\")\n-- 0\n-- >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n-- 1\nlocal function is_bored(S)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nlocal function get_odd_collatz(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "lua",
-    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n-- (2.0, 2.2)\n-- >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n-- (2.0, 2.0)\nlocal function find_closest_elements(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "lua",
-    "prompt": "-- Return True if all numbers in the list l are below threshold t.\n-- >>> below_threshold([1, 2, 4, 10], 100)\n-- True\n-- >>> below_threshold([1, 20, 4, 10], 5)\n-- False\nlocal function below_threshold(l, t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "lua",
-    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- any_int(5, 2, 7) \u279e True\n-- any_int(3, 2, 2) \u279e False\n-- any_int(3, -2, 1) \u279e True\n-- any_int(3.6, -2.2, 2) \u279e False\nlocal function any_int(x, y, z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "lua",
-    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- for x_or_y(7, 34, 12) == 34\n-- for x_or_y(15, 8, 5) == 5\nlocal function x_or_y(n, x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "lua",
-    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- move_one_ball([3, 4, 5, 1, 2])==>True\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- move_one_ball([3, 5, 4, 1, 2])==>False\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "lua",
-    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer(\"10\")\n-- 10\n-- >>> closest_integer(\"15.3\")\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> triples_sum_to_zero([1, 3, 5, 0])\n-- False\n-- >>> triples_sum_to_zero([1, 3, -2, 1])\n-- True\n-- >>> triples_sum_to_zero([1, 2, 3, 7])\n-- False\n-- >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n-- True\n-- >>> triples_sum_to_zero([1])\n-- False\nlocal function triples_sum_to_zero(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "lua",
-    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- will_it_fly([1, 2], 5) \u279e False \n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- will_it_fly([3, 2, 3], 1) \u279e False\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- will_it_fly([3, 2, 3], 9) \u279e True\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- will_it_fly([3], 5) \u279e True\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- is_happy(a) => False\n-- is_happy(aa) => False\n-- is_happy(abcd) => True\n-- is_happy(aabb) => False\n-- is_happy(adb) => True\n-- is_happy(xyy) => False\nlocal function is_happy(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "lua",
-    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- file_name_check(\"example.txt\") # => 'Yes'\n-- file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nlocal function file_name_check(file_name)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "lua",
-    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n-- histogram('a b b a') == {'a': 2, 'b': 2}\n-- histogram('a b c a b') == {'a': 2, 'b': 2}\n-- histogram('b b b b a') == {'b': 4}\n-- histogram('') == {}\nlocal function histogram(test)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "lua",
-    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n-- largest_smallest_integers([]) == (None, None)\n-- largest_smallest_integers([0]) == (None, None)\nlocal function largest_smallest_integers(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "lua",
-    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- simplify(\"1/5\", \"5/1\") = True\n-- simplify(\"1/6\", \"2/1\") = False\n-- simplify(\"7/10\", \"10/2\") = False\nlocal function simplify(x, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "lua",
-    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- Input: n = 5\n-- Output: 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "lua",
-    "prompt": "-- Task\n-- We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n-- then check if the result string is palindrome.\n-- A string is called palindrome if it reads the same backward as forward.\n-- You should return a tuple containing the result string and True/False for the check.\n-- Example\n-- For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n-- For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n-- For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nlocal function reverse_delete(s, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_delete\n    lu.assertEquals(candidate('abcde', 'ae'), {'bcd', false})\n    lu.assertEquals(candidate('abcdef', 'b'), {'acdef', false})\n    lu.assertEquals(candidate('abcdedcba', 'ab'), {'cdedc', true})\n    lu.assertEquals(candidate('dwik', 'w'), {'dik', false})\n    lu.assertEquals(candidate('a', 'a'), {'', true})\n    lu.assertEquals(candidate('abcdedcba', ''), {'abcdedcba', true})\n    lu.assertEquals(candidate('abcdedcba', 'v'), {'abcdedcba', true})\n    lu.assertEquals(candidate('vabba', 'v'), {'abba', true})\n    lu.assertEquals(candidate('mamma', 'mia'), {'', true})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "lua",
-    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product([])\n-- (0, 1)\n-- >>> sum_product([1, 2, 3, 4])\n-- (10, 24)\nlocal function sum_product(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n-- For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n-- For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n-- For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n-- For lst = [0,81,12,3,1,21] the output should be 3\n-- For lst = [0,8,1,2,1,7] the output should be 7\nlocal function skjkasdkd(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "lua",
-    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- ['a', 'ab', 'abc']\nlocal function all_prefixes(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- digits(1)  == 1\n-- digits(4)  == 0\n-- digits(235) == 15\nlocal function digits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "lua",
-    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "lua",
-    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- Input: [4,2,3]\n-- Output: [2, 1]\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- Input: [1,2,3]\n-- Output: [2, 1]\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index. \n-- Example 3:\n-- Input: []\n-- Output: []\n-- Example 4:\n-- Input: [5, 0, 3, 0, 4, 2]\n-- Output: [0, 1]\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "lua",
-    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- is_multiply_prime(30) == True\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "lua",
-    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "lua",
-    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\n-- words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n-- words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nlocal function words_string(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "lua",
-    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\n-- >>> monotonic([1, 2, 4, 20])\n-- True\n-- >>> monotonic([1, 20, 4, 10])\n-- False\n-- >>> monotonic([4, 1, 0, -10])\n-- True\nlocal function monotonic(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "lua",
-    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- fix_spaces(\"Example\") == \"Example\"\n-- fix_spaces(\"Example 1\") == \"Example_1\"\n-- fix_spaces(\" Example 2\") == \"_Example_2\"\n-- fix_spaces(\" Example   3\") == \"_Example-3\"\nlocal function fix_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "lua",
-    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n-- cycpattern_check(\"abcd\",\"abd\") => False\n-- cycpattern_check(\"hello\",\"ell\") => True\n-- cycpattern_check(\"whassup\",\"psus\") => False\n-- cycpattern_check(\"abab\",\"baa\") => True\n-- cycpattern_check(\"efef\",\"eeff\") => False\n-- cycpattern_check(\"himenss\",\"simen\") => True\nlocal function cycpattern_check(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n-- double_the_difference([-1, -2, 0]) == 0\n-- double_the_difference([9, -2]) == 81\n-- double_the_difference([0]) == 0  \n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "lua",
-    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nlocal function parse_music(music_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "lua",
-    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "lua",
-    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third([1, 2, 3])\n-- [1, 2, 3]\n-- >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n-- [2, 6, 3, 4, 8, 9, 5]\nlocal function sort_third(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "lua",
-    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n-- [0.0, 0.25, 0.5, 0.75, 1.0]\nlocal function rescale_to_unit(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "lua",
-    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- count_up_to(5) => [2,3]\n-- count_up_to(11) => [2,3,5,7]\n-- count_up_to(0) => []\n-- count_up_to(20) => [2,3,5,7,11,13,17,19]\n-- count_up_to(1) => []\n-- count_up_to(18) => [2,3,5,7,11,13,17]\nlocal function count_up_to(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "lua",
-    "prompt": "-- Return maximum element in the list.\n-- >>> max_element([1, 2, 3])\n-- 3\n-- >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n-- 123\nlocal function max_element(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n-- assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nlocal function sorted_list_sum(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\n-- total_match([], []) \u279e []\n-- total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n-- total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n-- total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n-- total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nlocal function total_match(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- triangle_area(3, 4, 5) == 6.00\n-- triangle_area(1, 2, 10) == -1\nlocal function triangle_area(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "lua",
-    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n-- check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n-- check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n-- check_if_last_char_is_a_letter(\"\") \u279e False\nlocal function check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "lua",
-    "prompt": "-- Given two lists operator, and operand. The first list has basic algebra operations, and \n-- the second list is a list of integers. Use the two given lists to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- array = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator list is equal to the length of operand list minus one.\n-- Operand is a list of of non-negative integers.\n-- Operator list has at least one operator, and operand list has at least two operands.\nlocal function do_algebra(operator, operand)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "lua",
-    "prompt": "-- Return sorted unique elements in a list\n-- >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n-- [0, 2, 3, 5, 9, 123]\nlocal function unique(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- smallest_change([1,2,3,5,4,7,9,6]) == 4\n-- smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n-- smallest_change([1, 2, 3, 2, 1]) == 0\nlocal function smallest_change(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "lua",
-    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits([15, 33, 1422, 1])\n-- [1, 15, 33]\n-- >>> unique_digits([152, 323, 1422, 10])\n-- []\nlocal function unique_digits(x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "lua",
-    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- f(5) == [1, 2, 6, 24, 15]\nlocal function f(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\n-- next_smallest([1, 2, 3, 4, 5]) == 2\n-- next_smallest([5, 1, 4, 3, 2]) == 2\n-- next_smallest([]) == None\n-- next_smallest([1, 1]) == None\nlocal function next_smallest(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "lua",
-    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:\n-- Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n-- Output: [1, 2, 1]\n-- Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n-- Output: [1]\nlocal function minPath(grid, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- Input: arr = [-3, -4, 5], k = 3\n-- Output: [-4, -3, 5]\n-- Example 2:\n-- Input: arr = [4, -4, 4], k = 2\n-- Output: [4, 4]\n-- Example 3:\n-- Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n-- Output: [2]\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "lua",
-    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- compare_one(1, 2.5) \u279e 2.5\n-- compare_one(1, \"2,3\") \u279e \"2,3\"\n-- compare_one(\"5,1\", \"6\") \u279e \"6\"\n-- compare_one(\"1\", 1) \u279e None\nlocal function compare_one(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "lua",
-    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- match_parens(['()(', ')']) == 'Yes'\n-- match_parens([')', ')']) == 'No'\nlocal function match_parens(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "lua",
-    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- is_equal_to_sum_even(4) == False\n-- is_equal_to_sum_even(6) == False\n-- is_equal_to_sum_even(8) == True\nlocal function is_equal_to_sum_even(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "lua",
-    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "lua",
-    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "lua",
-    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- encrypt('hi') returns 'lm'\n-- encrypt('asdfghjkl') returns 'ewhjklnop'\n-- encrypt('gf') returns 'kj'\n-- encrypt('et') returns 'ix'\nlocal function encrypt(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "lua",
-    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "lua",
-    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n-- Output: 24 # sum of 21 + 3\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "lua",
-    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n-- >>> intersperse([], 4)\n-- []\n-- >>> intersperse([1, 2, 3], 4)\n-- [1, 4, 2, 4, 3]\nlocal function intersperse(numbers, delimeter)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- solve(\"1234\") = \"4321\"\n-- solve(\"ab\") = \"AB\"\n-- solve(\"#a@C\") = \"#A@c\"\nlocal function solve(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "lua",
-    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the odd indicies, while its values at the even indicies are equal\n-- to the values of the even indicies of l, but sorted.\n-- >>> sort_even([1, 2, 3])\n-- [1, 2, 3]\n-- >>> sort_even([5, 6, 3, 4])\n-- [3, 6, 5, 4]\nlocal function sort_even(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_even\n    lu.assertEquals(candidate({1, 2, 3}), {1, 2, 3})\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), {-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123})\n    lu.assertEquals(candidate({5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), {-12, 8, 3, 4, 5, 2, 12, 11, 23, -10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "lua",
-    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\n-- >>> below_zero([1, 2, 3])\n-- False\n-- >>> below_zero([1, 2, -4, 5])\n-- True\nlocal function below_zero(operations)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "lua",
-    "prompt": "-- Check if two words have the same characters.\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n-- True\n-- >>> same_chars('abcd', 'dddddddabc')\n-- True\n-- >>> same_chars('dddddddabc', 'abcd')\n-- True\n-- >>> same_chars('eabcd', 'dddddddabc')\n-- False\n-- >>> same_chars('abcd', 'dddddddabce')\n-- False\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n-- False\nlocal function same_chars(s0, s1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = same_chars\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), true)\n    lu.assertEquals(candidate('abcd', 'dddddddabc'), true)\n    lu.assertEquals(candidate('dddddddabc', 'abcd'), true)\n    lu.assertEquals(candidate('eabcd', 'dddddddabc'), false)\n    lu.assertEquals(candidate('abcd', 'dddddddabcf'), false)\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), false)\n    lu.assertEquals(candidate('aabb', 'aaccc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- ['()', '(())', '(()())']\nlocal function separate_paren_groups(paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "lua",
-    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- count_upper('aBCdEf') returns 1\n-- count_upper('abcdefg') returns 0\n-- count_upper('dBBE') returns 0\nlocal function count_upper(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "lua",
-    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n-- [1, 2, 3, 3, 3, 4, 4]\nlocal function rolling_max(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "lua",
-    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates([1, 2, 3, 2, 4])\n-- [1, 3, 4]\nlocal function remove_duplicates(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "lua",
-    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n-- select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n-- select_words(\"simple white space\", 2) ==> []\n-- select_words(\"Hello world\", 4) ==> [\"world\"]\n-- select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nlocal function select_words(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- find_max([\"name\", \"of\", \"string\"]) == \"string\"\n-- find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n-- find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nlocal function find_max(words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "lua",
-    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- Input: \n-- grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n-- bucket_capacity : 1\n-- Output: 6\n-- Example 2:\n-- Input: \n-- grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n-- bucket_capacity : 2\n-- Output: 5\n-- Example 3:\n-- Input: \n-- grid : [[0,0,0], [0,0,0]]\n-- bucket_capacity : 5\n-- Output: 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "lua",
-    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- For lst = [1,2,3] the output should be 6\n-- For lst = []  the output should be 0\n-- For lst = [-1,-5,2,-1,-5]  the output should be -126\nlocal function sum_squares(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- add([4, 2, 6, 7]) ==> 2\nlocal function add(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "lua",
-    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- multiply(148, 412) should return 16.\n-- multiply(19, 28) should return 72.\n-- multiply(2020, 1851) should return 0.\n-- multiply(14,-15) should return 20.\nlocal function multiply(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "lua",
-    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- intersection((1, 2), (2, 3)) ==> \"NO\"\n-- intersection((-1, 1), (0, 4)) ==> \"NO\"\n-- intersection((-3, -1), (-5, 5)) ==> \"YES\"\nlocal function intersection(interval1, interval2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "lua",
-    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- tri(3) = [1, 3, 2, 8]\nlocal function tri(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "lua",
-    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- is_simple_power(1, 4) => true\n-- is_simple_power(2, 2) => true\n-- is_simple_power(8, 2) => true\n-- is_simple_power(3, 2) => false\n-- is_simple_power(3, 1) => false\n-- is_simple_power(5, 3) => false\nlocal function is_simple_power(x, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = has_close_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), true)\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), false)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), true)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), false)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1264,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Given a positive integer n, you have to make a pile of n levels of stones.\n-- The first level has n stones.\n-- The number of stones in the next level is:\n-- - the next odd number if n is odd.\n-- - the next even number if n is even.\n-- Return the number of stones in each level in a list, where element at index\n-- i represents the number of stones in the level (i+1).\n-- Examples:\n-- >>> make_a_pile(3)\n-- [3, 5, 7]\nlocal function make_a_pile(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_a_pile\n    lu.assertEquals(candidate(3), {3, 5, 7})\n    lu.assertEquals(candidate(4), {4, 6, 8, 10})\n    lu.assertEquals(candidate(5), {5, 7, 9, 11, 13})\n    lu.assertEquals(candidate(6), {6, 8, 10, 12, 14, 16})\n    lu.assertEquals(candidate(8), {8, 10, 12, 14, 16, 18, 20, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "lua",
-    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
+    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\n-- words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n-- words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nlocal function words_string(s)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix([], 'a')\n-- []\n-- >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n-- ['abc', 'array']\nlocal function filter_by_prefix(strings, prefix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- decimal_to_binary(15)   # returns \"db1111db\"\n-- decimal_to_binary(32)   # returns \"db100000db\"\nlocal function decimal_to_binary(decimal)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "lua",
-    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- True\n-- >>> is_palindrome('aba')\n-- True\n-- >>> is_palindrome('aaaaa')\n-- True\n-- >>> is_palindrome('zbcd')\n-- False\nlocal function is_palindrome(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "lua",
-    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "lua",
-    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- [2, 2, 2]\n-- >>> factorize(25)\n-- [5, 5]\n-- >>> factorize(70)\n-- [2, 5, 7]\nlocal function factorize(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "lua",
-    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- \"21\"\n-- >>> circular_shift(12, 2)\n-- \"12\"\nlocal function circular_shift(x, shift)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "lua",
-    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- get_closest_vowel(\"yogurt\") ==> \"u\"\n-- get_closest_vowel(\"FULL\") ==> \"U\"\n-- get_closest_vowel(\"quick\") ==> \"\"\n-- get_closest_vowel(\"ab\") ==> \"\"\nlocal function get_closest_vowel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "lua",
-    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "lua",
-    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "lua",
-    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "lua",
-    "prompt": "-- Return sorted unique common elements for two lists.\n-- >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n-- [1, 5, 653]\n-- >>> common([5, 3, 2, 8], [3, 2])\n-- [2, 3]\nlocal function common(l1, l2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "lua",
-    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\n-- can_arrange([1,2,4,3,5]) = 3\n-- can_arrange([1,2,3]) = -1\nlocal function can_arrange(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "lua",
-    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- is_nested('[[]]') \u279e True\n-- is_nested('[]]]]]]][[[[[]') \u279e False\n-- is_nested('[][]') \u279e False\n-- is_nested('[]') \u279e False\n-- is_nested('[[][]]') \u279e True\n-- is_nested('[[]][[') \u279e True\nlocal function is_nested(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "lua",
-    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n-- -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n-- -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n-- return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n-- If the array is empty, return an empty array:\n-- arr = []\n-- return []\n-- If the array has any strange number ignore it:\n-- arr = [1, -1 , 55] \n-- -> sort arr -> [-1, 1, 55]\n-- -> reverse arr -> [55, 1, -1]\n-- return = ['One']\nlocal function by_length(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "lua",
-    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "lua",
-    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "lua",
-    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count(['1234567'])\n-- [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n-- >>> odd_count(['3',\"11111111\"])\n-- [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n-- \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nlocal function odd_count(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "lua",
-    "prompt": "-- Concatenate list of strings into a single string\n-- >>> concatenate([])\n-- ''\n-- >>> concatenate(['a', 'b', 'c'])\n-- 'abc'\nlocal function concatenate(strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "lua",
-    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\n-- For lst = [1,2,3] the output should be 14\n-- For lst = [1,4,9] the output should be 98\n-- For lst = [1,3,5,7] the output should be 84\n-- For lst = [1.4,4.2,0] the output should be 29\n-- For lst = [-2.4,1,1] the output should be 6\nlocal function sum_squares(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "lua",
-    "prompt": "-- In this Kata, you have to sort an array of non-negative integers according to\n-- number of ones in their binary representation in ascending order.\n-- For similar number of ones, sort based on decimal value.\n-- It must be implemented like this:\n-- >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n-- >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n-- >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nlocal function sort_array(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({1, 5, 2, 3, 4}), {1, 2, 4, 3, 5})\n    lu.assertEquals(candidate({-2, -3, -4, -5, -6}), {-4, -2, -6, -5, -3})\n    lu.assertEquals(candidate({1, 0, 2, 3, 4}), {0, 1, 2, 4, 3})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), {2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77})\n    lu.assertEquals(candidate({3, 6, 44, 12, 32, 5}), {32, 3, 5, 6, 12, 44})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "lua",
-    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\n-- >>> longest([])\n-- >>> longest(['a', 'b', 'c'])\n-- 'a'\n-- >>> longest(['a', 'bb', 'ccc'])\n-- 'ccc'\nlocal function longest(strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\n-- is_sorted([5]) \u279e True\n-- is_sorted([1, 2, 3, 4, 5]) \u279e True\n-- is_sorted([1, 3, 2, 4, 5]) \u279e False\n-- is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n-- is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n-- is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n-- is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n-- is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nlocal function is_sorted(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "lua",
-    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\n-- even_odd_count(-12) ==> (1, 1)\n-- even_odd_count(123) ==> (1, 2)\nlocal function even_odd_count(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "lua",
-    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative([3, 1, 2, 4, 5])\n-- [1, 4, 12, 20]\n-- >>> derivative([1, 2, 3])\n-- [2, 6]\nlocal function derivative(xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- anti_shuffle('Hi') returns 'Hi'\n-- anti_shuffle('hello') returns 'ehllo'\n-- anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "lua",
-    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- Input: sentence = \"This is a test\"\n-- Output: \"is\"\n-- Example 2:\n-- Input: sentence = \"lets go for swimming\"\n-- Output: \"go for\"\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "lua",
-    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "lua",
-    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- * eat(5, 6, 10) -> [11, 4]\n-- * eat(4, 8, 9) -> [12, 1]\n-- * eat(1, 10, 10) -> [11, 0]\n-- * eat(2, 11, 5) -> [7, 0]\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "lua",
-    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\n-- prime_length('Hello') == True\n-- prime_length('abcdcba') == True\n-- prime_length('kittens') == True\n-- prime_length('orange') == False\nlocal function prime_length(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "lua",
-    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nlocal function numerical_letter_grade(grades)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "lua",
-    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\n-- search([4, 1, 2, 2, 3, 1]) == 2\n-- search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n-- search([5, 5, 4, 4, 4]) == -1\nlocal function search(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- right_angle_triangle(3, 4, 5) == True\n-- right_angle_triangle(1, 2, 3) == False\nlocal function right_angle_triangle(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "lua",
-    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- Input: 3\n-- Output: (1, 2)\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- Input: 12\n-- Output: (4, 6)\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- [2, 3, 1, 3]\nlocal function parse_nested_parens(paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "lua",
-    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n-- compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nlocal function compare(game, guess)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "lua",
-    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\n-- * sort_array([]) => []\n-- * sort_array([5]) => [5]\n-- * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n-- * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nlocal function sort_array(array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "lua",
-    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- get_row([\n-- [1,2,3,4,5,6],\n-- [1,2,3,4,1,6],\n-- [1,2,3,4,5,1]\n-- ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n-- get_row([], 1) == []\n-- get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nlocal function get_row(lst, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "lua",
-    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count(\"abcde\")\n-- 2\n-- >>> vowels_count(\"ACEDY\")\n-- 3\nlocal function vowels_count(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "lua",
-    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "lua",
-    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- False\n-- >>> is_prime(101)\n-- True\n-- >>> is_prime(11)\n-- True\n-- >>> is_prime(13441)\n-- True\n-- >>> is_prime(61)\n-- True\n-- >>> is_prime(4)\n-- False\n-- >>> is_prime(1)\n-- False\nlocal function is_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "lua",
-    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n-- bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n-- bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nlocal function bf(planet1, planet2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "lua",
-    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- For num = \"AB\" the output should be 1.\n-- For num = \"1077E\" the output should be 2.\n-- For num = \"ABED1A33\" the output should be 4.\n-- For num = \"123456789ABCDEF0\" the output should be 6.\n-- For num = \"2020\" the output should be 2.\nlocal function hex_key(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "lua",
-    "prompt": "-- Return median of elements in the list l.\n-- >>> median([3, 1, 2, 4, 5])\n-- 3\n-- >>> median([-10, 4, 6, 1000, 10, 20])\n-- 15.0\nlocal function median(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "lua",
-    "prompt": "-- Write a function that takes an array of numbers as input and returns \n-- the number of elements in the array that are greater than 10 and both \n-- first and last digits of a number are odd (1, 3, 5, 7, 9).\n-- For example:\n-- specialFilter([15, -73, 14, -15]) => 1 \n-- specialFilter([33, -2, -3, 45, 21, 109]) => 2\nlocal function specialFilter(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = specialFilter\n    lu.assertEquals(candidate({5, -2, 1, -5}), 0)\n    lu.assertEquals(candidate({15, -73, 14, -15}), 1)\n    lu.assertEquals(candidate({33, -2, -3, 45, 21, 109}), 2)\n    lu.assertEquals(candidate({43, -12, 93, 125, 121, 109}), 4)\n    lu.assertEquals(candidate({71, -2, -33, 75, 21, 19}), 3)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "lua",
-    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> pairs_sum_to_zero([1, 3, 5, 0])\n-- False\n-- >>> pairs_sum_to_zero([1, 3, -2, 1])\n-- False\n-- >>> pairs_sum_to_zero([1, 2, 3, 7])\n-- False\n-- >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n-- True\n-- >>> pairs_sum_to_zero([1])\n-- False\nlocal function pairs_sum_to_zero(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "lua",
-    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n-- strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n-- strange_sort_list([]) == []\nlocal function strange_sort_list(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "lua",
-    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "lua",
-    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\n-- check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n-- check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n-- check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n-- check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n-- check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nlocal function check_dict_case(dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "lua",
-    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- for example: \n-- valid_date('03-11-2000') => True\n-- valid_date('15-01-2012') => False\n-- valid_date('04-0-2040') => False\n-- valid_date('06-04-2020') => True\n-- valid_date('06/04/2020') => False\nlocal function valid_date(date)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "lua",
-    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums([]) == 0\n-- >>> count_nums([-1, 11, -11]) == 1\n-- >>> count_nums([1, 1, 2]) == 3\nlocal function count_nums(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "lua",
-    "prompt": "-- Filter given list of any python values only for integers\n-- >>> filter_integers(['a', 3.14, 5])\n-- [5]\n-- >>> filter_integers([1, 2, 3, 'abc', {}, []])\n-- [1, 2, 3]\nlocal function filter_integers(values)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "lua",
-    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- digitSum(\"\") => 0\n-- digitSum(\"abAB\") => 131\n-- digitSum(\"abcCd\") => 67\n-- digitSum(\"helloE\") => 69\n-- digitSum(\"woArBld\") => 131\n-- digitSum(\"aAaaaXa\") => 153\nlocal function digitSum(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "lua",
-    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\n-- >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n-- >>> order_by_points([]) == []\nlocal function order_by_points(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "lua",
-    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "lua",
-    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n-- split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n-- split_words(\"abcdef\") == 3\nlocal function split_words(txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "lua",
-    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "lua",
-    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "lua",
-    "prompt": "-- Check if in given list of numbers, are any two numbers closer to each other than\n-- given threshold.\n-- >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n-- False\n-- >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n-- True\nlocal function has_close_elements(numbers, threshold)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = has_close_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), true)\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), false)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), true)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), false)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "lua",
-    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n-- fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n-- fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n-- fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nlocal function fruit_distribution(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "lua",
-    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "lua",
-    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19) == 'xix'\n-- >>> int_to_mini_roman(152) == 'clii'\n-- >>> int_to_mini_roman(426) == 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "lua",
-    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing(\"(\")\n-- False\n-- >>> correct_bracketing(\"()\")\n-- True\n-- >>> correct_bracketing(\"(()())\")\n-- True\n-- >>> correct_bracketing(\")(()\")\n-- False\nlocal function correct_bracketing(brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "lua",
-    "prompt": "-- brackets is a string of \"<\" and \">\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing(\"<\")\n-- False\n-- >>> correct_bracketing(\"<>\")\n-- True\n-- >>> correct_bracketing(\"<<><>>\")\n-- True\n-- >>> correct_bracketing(\"><<>\")\n-- False\nlocal function correct_bracketing(brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('<>'), true)\n    lu.assertEquals(candidate('<<><>>'), true)\n    lu.assertEquals(candidate('<><><<><>><>'), true)\n    lu.assertEquals(candidate('<><><<<><><>><>><<><><<>>>'), true)\n    lu.assertEquals(candidate('<<<><>>>>'), false)\n    lu.assertEquals(candidate('><<>'), false)\n    lu.assertEquals(candidate('<'), false)\n    lu.assertEquals(candidate('<<<<'), false)\n    lu.assertEquals(candidate('>'), false)\n    lu.assertEquals(candidate('<<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>><<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>>><>'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "lua",
-    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "lua",
-    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs([1, 2, 2, -4]) == -9\n-- >>> prod_signs([0, 1]) == 0\n-- >>> prod_signs([]) == None\nlocal function prod_signs(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that contain given substring\n-- >>> filter_by_substring([], 'a')\n-- []\n-- >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n-- ['abc', 'bacd', 'array']\nlocal function filter_by_substring(strings, substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "lua",
-    "prompt": "-- Return list with elements incremented by 1.\n-- >>> incr_list([1, 2, 3])\n-- [2, 3, 4]\n-- >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n-- [6, 4, 6, 3, 4, 4, 10, 1, 124]\nlocal function incr_list(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "lua",
-    "prompt": "-- Return only positive numbers in the list.\n-- >>> get_positive([-1, 2, -4, 5, 6])\n-- [2, 5, 6]\n-- >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n-- [5, 3, 2, 3, 9, 123, 1]\nlocal function get_positive(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2359,7 +49,7 @@
     "language": "lua",
     "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\n-- choose_num(12, 15) = 14\n-- choose_num(13, 12) = -1\nlocal function choose_num(x, y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "lua",
-    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- For N = 1000, the sum of digits will be 1 the output should be \"1\".\n-- For N = 150, the sum of digits will be 6 the output should be \"110\".\n-- For N = 147, the sum of digits will be 12 the output should be \"1100\".\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
+    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- rounded_avg(1, 5) => \"0b11\"\n-- rounded_avg(7, 5) => -1\n-- rounded_avg(10, 20) => \"0b1111\"\n-- rounded_avg(20, 33) => \"0b11010\"\nlocal function rounded_avg(n, m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "lua",
+    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits([15, 33, 1422, 1])\n-- [1, 15, 33]\n-- >>> unique_digits([152, 323, 1422, 10])\n-- []\nlocal function unique_digits(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "lua",
+    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n-- -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n-- -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n-- return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n-- If the array is empty, return an empty array:\n-- arr = []\n-- return []\n-- If the array has any strange number ignore it:\n-- arr = [1, -1 , 55] \n-- -> sort arr -> [-1, 1, 55]\n-- -> reverse arr -> [55, 1, -1]\n-- return = ['One']\nlocal function by_length(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "lua",
+    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- f(5) == [1, 2, 6, 24, 15]\nlocal function f(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- Input: 3\n-- Output: (1, 2)\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- Input: 12\n-- Output: (4, 6)\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "lua",
+    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums([]) == 0\n-- >>> count_nums([-1, 11, -11]) == 1\n-- >>> count_nums([1, 1, 2]) == 3\nlocal function count_nums(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "lua",
+    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- move_one_ball([3, 4, 5, 1, 2])==>True\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- move_one_ball([3, 5, 4, 1, 2])==>False\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "lua",
+    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "lua",
+    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n-- exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "lua",
+    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n-- histogram('a b b a') == {'a': 2, 'b': 2}\n-- histogram('a b c a b') == {'a': 2, 'b': 2}\n-- histogram('b b b b a') == {'b': 4}\n-- histogram('') == {}\nlocal function histogram(test)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "lua",
+    "prompt": "-- Task\n-- We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n-- then check if the result string is palindrome.\n-- A string is called palindrome if it reads the same backward as forward.\n-- You should return a tuple containing the result string and True/False for the check.\n-- Example\n-- For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n-- For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n-- For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nlocal function reverse_delete(s, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_delete\n    lu.assertEquals(candidate('abcde', 'ae'), {'bcd', false})\n    lu.assertEquals(candidate('abcdef', 'b'), {'acdef', false})\n    lu.assertEquals(candidate('abcdedcba', 'ab'), {'cdedc', true})\n    lu.assertEquals(candidate('dwik', 'w'), {'dik', false})\n    lu.assertEquals(candidate('a', 'a'), {'', true})\n    lu.assertEquals(candidate('abcdedcba', ''), {'abcdedcba', true})\n    lu.assertEquals(candidate('abcdedcba', 'v'), {'abcdedcba', true})\n    lu.assertEquals(candidate('vabba', 'v'), {'abba', true})\n    lu.assertEquals(candidate('mamma', 'mia'), {'', true})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "lua",
+    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count(['1234567'])\n-- [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n-- >>> odd_count(['3',\"11111111\"])\n-- [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n-- \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nlocal function odd_count(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "lua",
+    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\n-- minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n-- minSubArraySum([-1, -2, -3]) == -6\nlocal function minSubArraySum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "lua",
+    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- Input: \n-- grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n-- bucket_capacity : 1\n-- Output: 6\n-- Example 2:\n-- Input: \n-- grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n-- bucket_capacity : 2\n-- Output: 5\n-- Example 3:\n-- Input: \n-- grid : [[0,0,0], [0,0,0]]\n-- bucket_capacity : 5\n-- Output: 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "lua",
+    "prompt": "-- In this Kata, you have to sort an array of non-negative integers according to\n-- number of ones in their binary representation in ascending order.\n-- For similar number of ones, sort based on decimal value.\n-- It must be implemented like this:\n-- >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n-- >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n-- >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nlocal function sort_array(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({1, 5, 2, 3, 4}), {1, 2, 4, 3, 5})\n    lu.assertEquals(candidate({-2, -3, -4, -5, -6}), {-4, -2, -6, -5, -3})\n    lu.assertEquals(candidate({1, 0, 2, 3, 4}), {0, 1, 2, 4, 3})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), {2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77})\n    lu.assertEquals(candidate({3, 6, 44, 12, 32, 5}), {32, 3, 5, 6, 12, 44})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "lua",
+    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n-- select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n-- select_words(\"simple white space\", 2) ==> []\n-- select_words(\"Hello world\", 4) ==> [\"world\"]\n-- select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nlocal function select_words(s, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "lua",
+    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- get_closest_vowel(\"yogurt\") ==> \"u\"\n-- get_closest_vowel(\"FULL\") ==> \"U\"\n-- get_closest_vowel(\"quick\") ==> \"\"\n-- get_closest_vowel(\"ab\") ==> \"\"\nlocal function get_closest_vowel(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "lua",
+    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- match_parens(['()(', ')']) == 'Yes'\n-- match_parens([')', ')']) == 'No'\nlocal function match_parens(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "lua",
+    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "lua",
+    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- Input: arr = [-3, -4, 5], k = 3\n-- Output: [-4, -3, 5]\n-- Example 2:\n-- Input: arr = [4, -4, 4], k = 2\n-- Output: [4, 4]\n-- Example 3:\n-- Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n-- Output: [2]\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "lua",
+    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- solution([5, 8, 7, 1]) ==> 12\n-- solution([3, 3, 3, 3, 3]) ==> 9\n-- solution([30, 13, 24, 321]) ==>0\nlocal function solution(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "lua",
+    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n-- Output: 24 # sum of 21 + 3\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nlocal function get_odd_collatz(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "lua",
+    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- for example: \n-- valid_date('03-11-2000') => True\n-- valid_date('15-01-2012') => False\n-- valid_date('04-0-2040') => False\n-- valid_date('06-04-2020') => True\n-- valid_date('06/04/2020') => False\nlocal function valid_date(date)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "lua",
+    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n-- split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n-- split_words(\"abcdef\") == 3\nlocal function split_words(txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "lua",
+    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\n-- is_sorted([5]) \u279e True\n-- is_sorted([1, 2, 3, 4, 5]) \u279e True\n-- is_sorted([1, 3, 2, 4, 5]) \u279e False\n-- is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n-- is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n-- is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n-- is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n-- is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nlocal function is_sorted(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "lua",
+    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- intersection((1, 2), (2, 3)) ==> \"NO\"\n-- intersection((-1, 1), (0, 4)) ==> \"NO\"\n-- intersection((-3, -1), (-5, 5)) ==> \"YES\"\nlocal function intersection(interval1, interval2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "lua",
+    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs([1, 2, 2, -4]) == -9\n-- >>> prod_signs([0, 1]) == 0\n-- >>> prod_signs([]) == None\nlocal function prod_signs(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "lua",
+    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:\n-- Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n-- Output: [1, 2, 1]\n-- Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n-- Output: [1]\nlocal function minPath(grid, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "lua",
+    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\n-- >>> longest([])\n-- >>> longest(['a', 'b', 'c'])\n-- 'a'\n-- >>> longest(['a', 'bb', 'ccc'])\n-- 'ccc'\nlocal function longest(strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "lua",
+    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- tri(3) = [1, 3, 2, 8]\nlocal function tri(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- digits(1)  == 1\n-- digits(4)  == 0\n-- digits(235) == 15\nlocal function digits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- is_nested('[[]]') \u279e True\n-- is_nested('[]]]]]]][[[[[]') \u279e False\n-- is_nested('[][]') \u279e False\n-- is_nested('[]') \u279e False\n-- is_nested('[[][]]') \u279e True\n-- is_nested('[[]][[') \u279e True\nlocal function is_nested(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "lua",
+    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\n-- For lst = [1,2,3] the output should be 14\n-- For lst = [1,4,9] the output should be 98\n-- For lst = [1,3,5,7] the output should be 84\n-- For lst = [1.4,4.2,0] the output should be 29\n-- For lst = [-2.4,1,1] the output should be 6\nlocal function sum_squares(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "lua",
+    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n-- check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n-- check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n-- check_if_last_char_is_a_letter(\"\") \u279e False\nlocal function check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "lua",
+    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\n-- can_arrange([1,2,4,3,5]) = 3\n-- can_arrange([1,2,3]) = -1\nlocal function can_arrange(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "lua",
+    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n-- largest_smallest_integers([]) == (None, None)\n-- largest_smallest_integers([0]) == (None, None)\nlocal function largest_smallest_integers(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "lua",
+    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- compare_one(1, 2.5) \u279e 2.5\n-- compare_one(1, \"2,3\") \u279e \"2,3\"\n-- compare_one(\"5,1\", \"6\") \u279e \"6\"\n-- compare_one(\"1\", 1) \u279e None\nlocal function compare_one(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "lua",
+    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- is_equal_to_sum_even(4) == False\n-- is_equal_to_sum_even(6) == False\n-- is_equal_to_sum_even(8) == True\nlocal function is_equal_to_sum_even(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "lua",
+    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "lua",
+    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "lua",
+    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- fix_spaces(\"Example\") == \"Example\"\n-- fix_spaces(\"Example 1\") == \"Example_1\"\n-- fix_spaces(\" Example 2\") == \"_Example_2\"\n-- fix_spaces(\" Example   3\") == \"_Example-3\"\nlocal function fix_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "lua",
+    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- file_name_check(\"example.txt\") # => 'Yes'\n-- file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nlocal function file_name_check(file_name)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "lua",
+    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- For lst = [1,2,3] the output should be 6\n-- For lst = []  the output should be 0\n-- For lst = [-1,-5,2,-1,-5]  the output should be -126\nlocal function sum_squares(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "lua",
+    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- Input: sentence = \"This is a test\"\n-- Output: \"is\"\n-- Example 2:\n-- Input: sentence = \"lets go for swimming\"\n-- Output: \"go for\"\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "lua",
+    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- simplify(\"1/5\", \"5/1\") = True\n-- simplify(\"1/6\", \"2/1\") = False\n-- simplify(\"7/10\", \"10/2\") = False\nlocal function simplify(x, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "lua",
+    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\n-- >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n-- >>> order_by_points([]) == []\nlocal function order_by_points(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an array of numbers as input and returns \n-- the number of elements in the array that are greater than 10 and both \n-- first and last digits of a number are odd (1, 3, 5, 7, 9).\n-- For example:\n-- specialFilter([15, -73, 14, -15]) => 1 \n-- specialFilter([33, -2, -3, 45, 21, 109]) => 2\nlocal function specialFilter(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = specialFilter\n    lu.assertEquals(candidate({5, -2, 1, -5}), 0)\n    lu.assertEquals(candidate({15, -73, 14, -15}), 1)\n    lu.assertEquals(candidate({33, -2, -3, 45, 21, 109}), 2)\n    lu.assertEquals(candidate({43, -12, 93, 125, 121, 109}), 4)\n    lu.assertEquals(candidate({71, -2, -33, 75, 21, 19}), 3)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "lua",
+    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- Input: n = 5\n-- Output: 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "lua",
+    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n-- bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n-- bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nlocal function bf(planet1, planet2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n-- assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nlocal function sorted_list_sum(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "lua",
+    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- ['a', 'ab', 'abc']\nlocal function all_prefixes(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "lua",
+    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- for x_or_y(7, 34, 12) == 34\n-- for x_or_y(15, 8, 5) == 5\nlocal function x_or_y(n, x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "lua",
+    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n-- double_the_difference([-1, -2, 0]) == 0\n-- double_the_difference([9, -2]) == 81\n-- double_the_difference([0]) == 0  \n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "lua",
+    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n-- compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nlocal function compare(game, guess)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "lua",
+    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "lua",
+    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n-- cycpattern_check(\"abcd\",\"abd\") => False\n-- cycpattern_check(\"hello\",\"ell\") => True\n-- cycpattern_check(\"whassup\",\"psus\") => False\n-- cycpattern_check(\"abab\",\"baa\") => True\n-- cycpattern_check(\"efef\",\"eeff\") => False\n-- cycpattern_check(\"himenss\",\"simen\") => True\nlocal function cycpattern_check(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "lua",
+    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\n-- even_odd_count(-12) ==> (1, 1)\n-- even_odd_count(123) ==> (1, 2)\nlocal function even_odd_count(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "lua",
+    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19) == 'xix'\n-- >>> int_to_mini_roman(152) == 'clii'\n-- >>> int_to_mini_roman(426) == 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- right_angle_triangle(3, 4, 5) == True\n-- right_angle_triangle(1, 2, 3) == False\nlocal function right_angle_triangle(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- find_max([\"name\", \"of\", \"string\"]) == \"string\"\n-- find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n-- find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nlocal function find_max(words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "lua",
+    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- * eat(5, 6, 10) -> [11, 4]\n-- * eat(4, 8, 9) -> [12, 1]\n-- * eat(1, 10, 10) -> [11, 0]\n-- * eat(2, 11, 5) -> [7, 0]\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "lua",
+    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "lua",
+    "prompt": "-- Given two lists operator, and operand. The first list has basic algebra operations, and \n-- the second list is a list of integers. Use the two given lists to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- array = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator list is equal to the length of operand list minus one.\n-- Operand is a list of of non-negative integers.\n-- Operator list has at least one operator, and operand list has at least two operands.\nlocal function do_algebra(operator, operand)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- solve(\"1234\") = \"4321\"\n-- solve(\"ab\") = \"AB\"\n-- solve(\"#a@C\") = \"#A@c\"\nlocal function solve(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "lua",
+    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2389,7 +1054,7 @@
     "language": "lua",
     "prompt": "-- Given two positive integers a and b, return the even digits between a\n-- and b, in ascending order.\n-- For example:\n-- generate_integers(2, 8) => [2, 4, 6, 8]\n-- generate_integers(8, 2) => [2, 4, 6, 8]\n-- generate_integers(10, 14) => []\nlocal function generate_integers(a, b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = generate_integers\n    lu.assertEquals(candidate(2, 10), {2, 4, 6, 8})\n    lu.assertEquals(candidate(10, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(132, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(17, 89), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "lua",
     "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\n-- >>> count_distinct_characters('xyzXYZ')\n-- 3\n-- >>> count_distinct_characters('Jerry')\n-- 4\nlocal function count_distinct_characters(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nlocal function parse_music(music_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "lua",
+    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "lua",
+    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- ['()', '(())', '(()())']\nlocal function separate_paren_groups(paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "lua",
+    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n-- (2.0, 2.2)\n-- >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n-- (2.0, 2.0)\nlocal function find_closest_elements(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "lua",
+    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n-- [0.0, 0.25, 0.5, 0.75, 1.0]\nlocal function rescale_to_unit(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "lua",
+    "prompt": "-- Filter given list of any python values only for integers\n-- >>> filter_integers(['a', 3.14, 5])\n-- [5]\n-- >>> filter_integers([1, 2, 3, 'abc', {}, []])\n-- [1, 2, 3]\nlocal function filter_integers(values)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "lua",
+    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "lua",
+    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "lua",
+    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- [2, 2, 2]\n-- >>> factorize(25)\n-- [5, 5]\n-- >>> factorize(70)\n-- [2, 5, 7]\nlocal function factorize(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "lua",
+    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates([1, 2, 3, 2, 4])\n-- [1, 3, 4]\nlocal function remove_duplicates(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "lua",
+    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "lua",
+    "prompt": "-- Concatenate list of strings into a single string\n-- >>> concatenate([])\n-- ''\n-- >>> concatenate(['a', 'b', 'c'])\n-- 'abc'\nlocal function concatenate(strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix([], 'a')\n-- []\n-- >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n-- ['abc', 'array']\nlocal function filter_by_prefix(strings, prefix)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "lua",
+    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "lua",
+    "prompt": "-- Return only positive numbers in the list.\n-- >>> get_positive([-1, 2, -4, 5, 6])\n-- [2, 5, 6]\n-- >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n-- [5, 3, 2, 3, 9, 123, 1]\nlocal function get_positive(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "lua",
+    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- False\n-- >>> is_prime(101)\n-- True\n-- >>> is_prime(11)\n-- True\n-- >>> is_prime(13441)\n-- True\n-- >>> is_prime(61)\n-- True\n-- >>> is_prime(4)\n-- False\n-- >>> is_prime(1)\n-- False\nlocal function is_prime(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "lua",
+    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third([1, 2, 3])\n-- [1, 2, 3]\n-- >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n-- [2, 6, 3, 4, 8, 9, 5]\nlocal function sort_third(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "lua",
+    "prompt": "-- Return sorted unique elements in a list\n-- >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n-- [0, 2, 3, 5, 9, 123]\nlocal function unique(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "lua",
+    "prompt": "-- Return maximum element in the list.\n-- >>> max_element([1, 2, 3])\n-- 3\n-- >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n-- 123\nlocal function max_element(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "lua",
+    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "lua",
+    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the odd indicies, while its values at the even indicies are equal\n-- to the values of the even indicies of l, but sorted.\n-- >>> sort_even([1, 2, 3])\n-- [1, 2, 3]\n-- >>> sort_even([5, 6, 3, 4])\n-- [3, 6, 5, 4]\nlocal function sort_even(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_even\n    lu.assertEquals(candidate({1, 2, 3}), {1, 2, 3})\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), {-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123})\n    lu.assertEquals(candidate({5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), {-12, 8, 3, 4, 5, 2, 12, 11, 23, -10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "lua",
+    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "lua",
+    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\n-- >>> below_zero([1, 2, 3])\n-- False\n-- >>> below_zero([1, 2, -4, 5])\n-- True\nlocal function below_zero(operations)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> triples_sum_to_zero([1, 3, 5, 0])\n-- False\n-- >>> triples_sum_to_zero([1, 3, -2, 1])\n-- True\n-- >>> triples_sum_to_zero([1, 2, 3, 7])\n-- False\n-- >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n-- True\n-- >>> triples_sum_to_zero([1])\n-- False\nlocal function triples_sum_to_zero(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "lua",
+    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "lua",
+    "prompt": "-- Return list with elements incremented by 1.\n-- >>> incr_list([1, 2, 3])\n-- [2, 3, 4]\n-- >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n-- [6, 4, 6, 3, 4, 4, 10, 1, 124]\nlocal function incr_list(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> pairs_sum_to_zero([1, 3, 5, 0])\n-- False\n-- >>> pairs_sum_to_zero([1, 3, -2, 1])\n-- False\n-- >>> pairs_sum_to_zero([1, 2, 3, 7])\n-- False\n-- >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n-- True\n-- >>> pairs_sum_to_zero([1])\n-- False\nlocal function pairs_sum_to_zero(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "lua",
+    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "lua",
+    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "lua",
+    "prompt": "-- Return median of elements in the list l.\n-- >>> median([3, 1, 2, 4, 5])\n-- 3\n-- >>> median([-10, 4, 6, 1000, 10, 20])\n-- 15.0\nlocal function median(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "lua",
+    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- True\n-- >>> is_palindrome('aba')\n-- True\n-- >>> is_palindrome('aaaaa')\n-- True\n-- >>> is_palindrome('zbcd')\n-- False\nlocal function is_palindrome(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "lua",
+    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "lua",
+    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "lua",
+    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "lua",
+    "prompt": "-- Return True if all numbers in the list l are below threshold t.\n-- >>> below_threshold([1, 2, 4, 10], 100)\n-- True\n-- >>> below_threshold([1, 20, 4, 10], 5)\n-- False\nlocal function below_threshold(l, t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "lua",
+    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "lua",
+    "prompt": "-- Check if two words have the same characters.\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n-- True\n-- >>> same_chars('abcd', 'dddddddabc')\n-- True\n-- >>> same_chars('dddddddabc', 'abcd')\n-- True\n-- >>> same_chars('eabcd', 'dddddddabc')\n-- False\n-- >>> same_chars('abcd', 'dddddddabce')\n-- False\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n-- False\nlocal function same_chars(s0, s1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = same_chars\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), true)\n    lu.assertEquals(candidate('abcd', 'dddddddabc'), true)\n    lu.assertEquals(candidate('dddddddabc', 'abcd'), true)\n    lu.assertEquals(candidate('eabcd', 'dddddddabc'), false)\n    lu.assertEquals(candidate('abcd', 'dddddddabcf'), false)\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), false)\n    lu.assertEquals(candidate('aabb', 'aaccc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "lua",
+    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "lua",
+    "prompt": "-- brackets is a string of \"<\" and \">\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing(\"<\")\n-- False\n-- >>> correct_bracketing(\"<>\")\n-- True\n-- >>> correct_bracketing(\"<<><>>\")\n-- True\n-- >>> correct_bracketing(\"><<>\")\n-- False\nlocal function correct_bracketing(brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('<>'), true)\n    lu.assertEquals(candidate('<<><>>'), true)\n    lu.assertEquals(candidate('<><><<><>><>'), true)\n    lu.assertEquals(candidate('<><><<<><><>><>><<><><<>>>'), true)\n    lu.assertEquals(candidate('<<<><>>>>'), false)\n    lu.assertEquals(candidate('><<>'), false)\n    lu.assertEquals(candidate('<'), false)\n    lu.assertEquals(candidate('<<<<'), false)\n    lu.assertEquals(candidate('>'), false)\n    lu.assertEquals(candidate('<<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>><<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>>><>'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "lua",
+    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\n-- >>> monotonic([1, 2, 4, 20])\n-- True\n-- >>> monotonic([1, 20, 4, 10])\n-- False\n-- >>> monotonic([4, 1, 0, -10])\n-- True\nlocal function monotonic(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "lua",
+    "prompt": "-- Return sorted unique common elements for two lists.\n-- >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n-- [1, 5, 653]\n-- >>> common([5, 3, 2, 8], [3, 2])\n-- [2, 3]\nlocal function common(l1, l2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "lua",
+    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "lua",
+    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n-- >>> intersperse([], 4)\n-- []\n-- >>> intersperse([1, 2, 3], 4)\n-- [1, 4, 2, 4, 3]\nlocal function intersperse(numbers, delimeter)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "lua",
+    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "lua",
+    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing(\"(\")\n-- False\n-- >>> correct_bracketing(\"()\")\n-- True\n-- >>> correct_bracketing(\"(()())\")\n-- True\n-- >>> correct_bracketing(\")(()\")\n-- False\nlocal function correct_bracketing(brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "lua",
+    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative([3, 1, 2, 4, 5])\n-- [1, 4, 12, 20]\n-- >>> derivative([1, 2, 3])\n-- [2, 6]\nlocal function derivative(xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "lua",
+    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "lua",
+    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count(\"abcde\")\n-- 2\n-- >>> vowels_count(\"ACEDY\")\n-- 3\nlocal function vowels_count(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "lua",
+    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- \"21\"\n-- >>> circular_shift(12, 2)\n-- \"12\"\nlocal function circular_shift(x, shift)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "lua",
+    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- digitSum(\"\") => 0\n-- digitSum(\"abAB\") => 131\n-- digitSum(\"abcCd\") => 67\n-- digitSum(\"helloE\") => 69\n-- digitSum(\"woArBld\") => 131\n-- digitSum(\"aAaaaXa\") => 153\nlocal function digitSum(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "lua",
+    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n-- fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n-- fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n-- fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nlocal function fruit_distribution(s, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "lua",
+    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- Input: [4,2,3]\n-- Output: [2, 1]\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- Input: [1,2,3]\n-- Output: [2, 1]\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index. \n-- Example 3:\n-- Input: []\n-- Output: []\n-- Example 4:\n-- Input: [5, 0, 3, 0, 4, 2]\n-- Output: [0, 1]\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "lua",
+    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\n-- search([4, 1, 2, 2, 3, 1]) == 2\n-- search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n-- search([5, 5, 4, 4, 4]) == -1\nlocal function search(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- [2, 3, 1, 3]\nlocal function parse_nested_parens(paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "lua",
+    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n-- strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n-- strange_sort_list([]) == []\nlocal function strange_sort_list(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- triangle_area(3, 4, 5) == 6.00\n-- triangle_area(1, 2, 10) == -1\nlocal function triangle_area(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "lua",
+    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- will_it_fly([1, 2], 5) \u279e False \n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- will_it_fly([3, 2, 3], 1) \u279e False\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- will_it_fly([3, 2, 3], 9) \u279e True\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- will_it_fly([3], 5) \u279e True\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "lua",
+    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- smallest_change([1,2,3,5,4,7,9,6]) == 4\n-- smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n-- smallest_change([1, 2, 3, 2, 1]) == 0\nlocal function smallest_change(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\n-- total_match([], []) \u279e []\n-- total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n-- total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n-- total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n-- total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nlocal function total_match(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "lua",
+    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- is_multiply_prime(30) == True\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "lua",
+    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- is_simple_power(1, 4) => true\n-- is_simple_power(2, 2) => true\n-- is_simple_power(8, 2) => true\n-- is_simple_power(3, 2) => false\n-- is_simple_power(3, 1) => false\n-- is_simple_power(5, 3) => false\nlocal function is_simple_power(x, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- iscube(1) ==> True\n-- iscube(2) ==> False\n-- iscube(-1) ==> True\n-- iscube(64) ==> True\n-- iscube(0) ==> True\n-- iscube(180) ==> False\nlocal function iscube(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "lua",
+    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- For num = \"AB\" the output should be 1.\n-- For num = \"1077E\" the output should be 2.\n-- For num = \"ABED1A33\" the output should be 4.\n-- For num = \"123456789ABCDEF0\" the output should be 6.\n-- For num = \"2020\" the output should be 2.\nlocal function hex_key(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- decimal_to_binary(15)   # returns \"db1111db\"\n-- decimal_to_binary(32)   # returns \"db100000db\"\nlocal function decimal_to_binary(decimal)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that contain given substring\n-- >>> filter_by_substring([], 'a')\n-- []\n-- >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n-- ['abc', 'bacd', 'array']\nlocal function filter_by_substring(strings, substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- is_happy(a) => False\n-- is_happy(aa) => False\n-- is_happy(abcd) => True\n-- is_happy(aabb) => False\n-- is_happy(adb) => True\n-- is_happy(xyy) => False\nlocal function is_happy(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "lua",
+    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nlocal function numerical_letter_grade(grades)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\n-- prime_length('Hello') == True\n-- prime_length('abcdcba') == True\n-- prime_length('kittens') == True\n-- prime_length('orange') == False\nlocal function prime_length(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "lua",
+    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- For N = 1000, the sum of digits will be 1 the output should be \"1\".\n-- For N = 150, the sum of digits will be 6 the output should be \"110\".\n-- For N = 147, the sum of digits will be 12 the output should be \"1100\".\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "lua",
+    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- add([4, 2, 6, 7]) ==> 2\nlocal function add(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- anti_shuffle('Hi') returns 'Hi'\n-- anti_shuffle('hello') returns 'ehllo'\n-- anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "lua",
+    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- get_row([\n-- [1,2,3,4,5,6],\n-- [1,2,3,4,1,6],\n-- [1,2,3,4,5,1]\n-- ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n-- get_row([], 1) == []\n-- get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nlocal function get_row(lst, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "lua",
+    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\n-- * sort_array([]) => []\n-- * sort_array([5]) => [5]\n-- * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n-- * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nlocal function sort_array(array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "lua",
+    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- encrypt('hi') returns 'lm'\n-- encrypt('asdfghjkl') returns 'ewhjklnop'\n-- encrypt('gf') returns 'kj'\n-- encrypt('et') returns 'ix'\nlocal function encrypt(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "lua",
+    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product([])\n-- (0, 1)\n-- >>> sum_product([1, 2, 3, 4])\n-- (10, 24)\nlocal function sum_product(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\n-- next_smallest([1, 2, 3, 4, 5]) == 2\n-- next_smallest([5, 1, 4, 3, 2]) == 2\n-- next_smallest([]) == None\n-- next_smallest([1, 1]) == None\nlocal function next_smallest(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "lua",
+    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored(\"Hello world\")\n-- 0\n-- >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n-- 1\nlocal function is_bored(S)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "lua",
+    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- any_int(5, 2, 7) \u279e True\n-- any_int(3, 2, 2) \u279e False\n-- any_int(3, -2, 1) \u279e True\n-- any_int(3.6, -2.2, 2) \u279e False\nlocal function any_int(x, y, z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n-- For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n-- For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n-- For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n-- For lst = [0,81,12,3,1,21] the output should be 3\n-- For lst = [0,8,1,2,1,7] the output should be 7\nlocal function skjkasdkd(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "lua",
+    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\n-- check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n-- check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n-- check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n-- check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n-- check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nlocal function check_dict_case(dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "lua",
+    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- count_up_to(5) => [2,3]\n-- count_up_to(11) => [2,3,5,7]\n-- count_up_to(0) => []\n-- count_up_to(20) => [2,3,5,7,11,13,17,19]\n-- count_up_to(1) => []\n-- count_up_to(18) => [2,3,5,7,11,13,17]\nlocal function count_up_to(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "lua",
+    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- multiply(148, 412) should return 16.\n-- multiply(19, 28) should return 72.\n-- multiply(2020, 1851) should return 0.\n-- multiply(14,-15) should return 20.\nlocal function multiply(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "lua",
+    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- count_upper('aBCdEf') returns 1\n-- count_upper('abcdefg') returns 0\n-- count_upper('dBBE') returns 0\nlocal function count_upper(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer(\"10\")\n-- 10\n-- >>> closest_integer(\"15.3\")\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "lua",
+    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n-- [1, 2, 3, 3, 3, 4, 4]\nlocal function rolling_max(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/humaneval-lua-remove.json
+++ b/prompts/humaneval-lua-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "lua",
-    "prompt": "-- Return length of given string\nlocal function strlen(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "lua",
-    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\nlocal function encrypt(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "lua",
-    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\nlocal function check_dict_case(dict)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\nlocal function add(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "lua",
-    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with -\nlocal function fix_spaces(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "lua",
-    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nlocal function fibfib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "lua",
-    "prompt": "-- Filter given list of any python values only for integers\nlocal function filter_integers(values)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\nlocal function parse_music(music_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\nlocal function decimal_to_binary(decimal)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "lua",
-    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\nlocal function all_prefixes(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "lua",
-    "prompt": "-- Add two numbers x and y\nlocal function add(x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "lua",
-    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "lua",
-    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- Example 2:\n-- Example 3:\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "lua",
-    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nlocal function flip_case(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "lua",
-    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- If the array is empty, return an empty array:\n-- If the array has any strange number ignore it:\nlocal function by_length(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "lua",
-    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\nlocal function factorize(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "lua",
-    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\nlocal function count_up_to(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "lua",
-    "prompt": "-- Return sorted unique elements in a list\nlocal function unique(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\nlocal function total_match(lst1, lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "lua",
-    "prompt": "-- Return maximum element in the list.\nlocal function max_element(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "lua",
-    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\nlocal function is_nested(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "lua",
-    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\nlocal function rounded_avg(n, m)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "lua",
-    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\nlocal function odd_count(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "lua",
-    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "lua",
-    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\nlocal function is_equal_to_sum_even(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "lua",
-    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\nlocal function derivative(xs)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\nlocal function is_sorted(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\nlocal function solve(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "lua",
-    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\nlocal function tri(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "lua",
-    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nlocal function fizz_buzz(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\nlocal function filter_by_prefix(strings, prefix)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "lua",
-    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "lua",
-    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:\nlocal function minPath(grid, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "lua",
-    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\nlocal function count_upper(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- Example 2:\n-- Example 3:\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "lua",
-    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\nlocal function largest_divisor(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "lua",
-    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\nlocal function sort_array(array)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "lua",
-    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\nlocal function f(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "lua",
-    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\nlocal function iscube(a)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\nlocal function encode(message)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "lua",
-    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\nlocal function is_bored(S)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\nlocal function pairs_sum_to_zero(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\nlocal function triangle_area(a, b, c)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "lua",
-    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\nlocal function bf(planet1, planet2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\nlocal function digits(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "lua",
-    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\nlocal function words_string(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "lua",
-    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\nlocal function how_many_times(string, substring)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "lua",
-    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\nlocal function compare_one(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "lua",
-    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\nlocal function remove_vowels(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "lua",
-    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\nlocal function strange_sort_list(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "lua",
-    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\nlocal function find_closest_elements(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "lua",
-    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\nlocal function is_simple_power(x, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "lua",
-    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nlocal function prime_fib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "lua",
-    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\nlocal function order_by_points(nums)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "lua",
     "prompt": "-- Check if in given list of numbers, are any two numbers closer to each other than\n-- given threshold.\nlocal function has_close_elements(numbers, threshold)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = has_close_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), true)\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), false)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), true)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), false)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "lua",
-    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nlocal function make_palindrome(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "lua",
-    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\nlocal function string_xor(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "lua",
-    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "lua",
-    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "lua",
-    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nlocal function fib4(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "lua",
-    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\nlocal function unique_digits(x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "lua",
-    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\nlocal function select_words(s, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "lua",
-    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "lua",
-    "prompt": "-- Return n-th Fibonacci number.\nlocal function fib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "lua",
-    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\nlocal function Strongest_Extension(class_name, extensions)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "lua",
-    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\nlocal function match_parens(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\nlocal function next_smallest(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "lua",
-    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\nlocal function any_int(x, y, z)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "lua",
-    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\nlocal function truncate_number(number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "lua",
-    "prompt": "-- Return list with elements incremented by 1.\nlocal function incr_list(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "lua",
-    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\nlocal function x_or_y(n, x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "lua",
-    "prompt": "-- Return 2^n modulo p (be aware of numerics).\nlocal function modp(n, p)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "lua",
-    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\nlocal function even_odd_count(num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\nlocal function is_happy(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "lua",
-    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlocal function largest_prime_factor(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "lua",
-    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\nlocal function digitSum(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "lua",
-    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\nlocal function rescale_to_unit(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\nlocal function solution(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "lua",
-    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- Example 4:\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "lua",
-    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "lua",
-    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "lua",
-    "prompt": "-- Return median of elements in the list l.\nlocal function median(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\nlocal function prime_length(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\nlocal function smallest_change(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "lua",
-    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\nlocal function sum_squares(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "lua",
-    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\nlocal function file_name_check(file_name)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\nlocal function triples_sum_to_zero(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "lua",
-    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\nlocal function intersection(interval1, interval2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\nlocal function separate_paren_groups(paren_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "lua",
-    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\nlocal function compare(game, guess)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "lua",
-    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\nlocal function check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "lua",
-    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\nlocal function valid_date(date)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "lua",
-    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\nlocal function count_nums(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\nlocal function anti_shuffle(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "lua",
-    "prompt": "-- Checks if given string is a palindrome\nlocal function is_palindrome(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "lua",
-    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\nlocal function get_closest_vowel(word)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "lua",
-    "prompt": "-- Return true if a given number is prime, and false otherwise.\nlocal function is_prime(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "lua",
-    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\nlocal function simplify(x, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "lua",
-    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\nlocal function hex_key(num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "lua",
-    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- Example 2:\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "lua",
-    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\nlocal function histogram(test)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "lua",
-    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\nlocal function get_row(lst, x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nlocal function get_odd_collatz(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "lua",
-    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\nlocal function can_arrange(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "lua",
-    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\nlocal function sort_numbers(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "lua",
-    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\nlocal function circular_shift(x, shift)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "lua",
-    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\nlocal function sum_squares(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\nlocal function skjkasdkd(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "lua",
-    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\nlocal function sum_product(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "lua",
-    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\nlocal function choose_num(x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "lua",
-    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\nlocal function largest_smallest_integers(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "lua",
-    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\nlocal function count_distinct_characters(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1714,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Given a positive integer n, you have to make a pile of n levels of stones.\n-- The first level has n stones.\n-- The number of stones in the next level is:\n-- - the next odd number if n is odd.\n-- - the next even number if n is even.\n-- Return the number of stones in each level in a list, where element at index\n-- i represents the number of stones in the level (i+1).\n-- Examples:\nlocal function make_a_pile(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_a_pile\n    lu.assertEquals(candidate(3), {3, 5, 7})\n    lu.assertEquals(candidate(4), {4, 6, 8, 10})\n    lu.assertEquals(candidate(5), {5, 7, 9, 11, 13})\n    lu.assertEquals(candidate(6), {6, 8, 10, 12, 14, 16})\n    lu.assertEquals(candidate(8), {8, 10, 12, 14, 16, 18, 20, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "lua",
-    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\nlocal function prod_signs(arr)\n",
+    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\nlocal function words_string(s)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "lua",
-    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\nlocal function minSubArraySum(nums)\n",
+    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\nlocal function choose_num(x, y)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "lua",
-    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nlocal function string_sequence(n)\n",
+    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\nlocal function rounded_avg(n, m)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "lua",
-    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nlocal function cycpattern_check(a, b)\n",
+    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\nlocal function unique_digits(x)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "lua",
-    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\nlocal function monotonic(l)\n",
+    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- If the array is empty, return an empty array:\n-- If the array has any strange number ignore it:\nlocal function by_length(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "lua",
-    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\nlocal function longest(strings)\n",
+    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\nlocal function f(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "lua",
-    "prompt": "-- Return True if all numbers in the list l are below threshold t.\nlocal function below_threshold(l, t)\n",
+    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "lua",
-    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\nlocal function count_nums(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "lua",
-    "prompt": "-- Return only positive numbers in the list.\nlocal function get_positive(l)\n",
+    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "lua",
-    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\nlocal function sort_third(l)\n",
+    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nlocal function make_palindrome(string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "lua",
-    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\nlocal function parse_nested_parens(paren_string)\n",
+    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "lua",
-    "prompt": "-- Given length of a side and high return area for a triangle.\nlocal function triangle_area(a, h)\n",
+    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\nlocal function histogram(test)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "lua",
-    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\nlocal function multiply(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "lua",
-    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\nlocal function mean_absolute_deviation(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "lua",
-    "prompt": "-- Return sorted unique common elements for two lists.\nlocal function common(l1, l2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "lua",
-    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\nlocal function int_to_mini_roman(number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "lua",
-    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\nlocal function fruit_distribution(s, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1984,7 +214,7 @@
     "language": "lua",
     "prompt": "-- Task\n-- We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n-- then check if the result string is palindrome.\n-- A string is called palindrome if it reads the same backward as forward.\n-- You should return a tuple containing the result string and True/False for the check.\n-- Example\nlocal function reverse_delete(s, c)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_delete\n    lu.assertEquals(candidate('abcde', 'ae'), {'bcd', false})\n    lu.assertEquals(candidate('abcdef', 'b'), {'acdef', false})\n    lu.assertEquals(candidate('abcdedcba', 'ab'), {'cdedc', true})\n    lu.assertEquals(candidate('dwik', 'w'), {'dik', false})\n    lu.assertEquals(candidate('a', 'a'), {'', true})\n    lu.assertEquals(candidate('abcdedcba', ''), {'abcdedcba', true})\n    lu.assertEquals(candidate('abcdedcba', 'v'), {'abcdedcba', true})\n    lu.assertEquals(candidate('vabba', 'v'), {'abba', true})\n    lu.assertEquals(candidate('mamma', 'mia'), {'', true})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "lua",
-    "prompt": "-- Return a greatest common divisor of two integers a and b\nlocal function greatest_common_divisor(a, b)\n",
+    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\nlocal function odd_count(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "lua",
-    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\nlocal function split_words(txt)\n",
+    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\nlocal function minSubArraySum(nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "lua",
+    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- Example 2:\n-- Example 3:\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2029,7 +274,7 @@
     "language": "lua",
     "prompt": "-- In this Kata, you have to sort an array of non-negative integers according to\n-- number of ones in their binary representation in ascending order.\n-- For similar number of ones, sort based on decimal value.\n-- It must be implemented like this:\nlocal function sort_array(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({1, 5, 2, 3, 4}), {1, 2, 4, 3, 5})\n    lu.assertEquals(candidate({-2, -3, -4, -5, -6}), {-4, -2, -6, -5, -3})\n    lu.assertEquals(candidate({1, 0, 2, 3, 4}), {0, 1, 2, 4, 3})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), {2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77})\n    lu.assertEquals(candidate({3, 6, 44, 12, 32, 5}), {32, 3, 5, 6, 12, 44})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "lua",
-    "prompt": "-- Concatenate list of strings into a single string\nlocal function concatenate(strings)\n",
+    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\nlocal function select_words(s, n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\nlocal function sorted_list_sum(lst)\n",
+    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\nlocal function get_closest_vowel(word)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that contain given substring\nlocal function filter_by_substring(strings, substring)\n",
+    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\nlocal function match_parens(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "lua",
-    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\nlocal function string_xor(a, b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "lua",
-    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\nlocal function vowels_count(s)\n",
+    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- Example 2:\n-- Example 3:\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\nlocal function find_max(words)\n",
+    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\nlocal function solution(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "lua",
-    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\nlocal function string_to_md5(text)\n",
+    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "lua",
-    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\nlocal function change_base(x, base)\n",
+    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nlocal function get_odd_collatz(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\nlocal function right_angle_triangle(a, b, c)\n",
+    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\nlocal function valid_date(date)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "lua",
-    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\nlocal function numerical_letter_grade(grades)\n",
+    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\nlocal function split_words(txt)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "lua",
-    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nlocal function intersperse(numbers, delimeter)\n",
+    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\nlocal function is_sorted(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "lua",
+    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\nlocal function intersection(interval1, interval2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "lua",
+    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\nlocal function prod_signs(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "lua",
+    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:\nlocal function minPath(grid, k)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "lua",
+    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\nlocal function longest(strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "lua",
+    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\nlocal function tri(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\nlocal function digits(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\nlocal function is_nested(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "lua",
+    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\nlocal function sum_squares(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "lua",
+    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\nlocal function check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "lua",
+    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\nlocal function can_arrange(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "lua",
+    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\nlocal function largest_smallest_integers(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "lua",
+    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\nlocal function compare_one(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "lua",
+    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\nlocal function is_equal_to_sum_even(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "lua",
+    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "lua",
+    "prompt": "-- Return a greatest common divisor of two integers a and b\nlocal function greatest_common_divisor(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "lua",
+    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with -\nlocal function fix_spaces(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "lua",
+    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\nlocal function file_name_check(file_name)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "lua",
+    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\nlocal function sum_squares(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "lua",
+    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- Example 2:\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "lua",
+    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\nlocal function simplify(x, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "lua",
+    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\nlocal function order_by_points(nums)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2209,7 +769,7 @@
     "language": "lua",
     "prompt": "-- Write a function that takes an array of numbers as input and returns \n-- the number of elements in the array that are greater than 10 and both \n-- first and last digits of a number are odd (1, 3, 5, 7, 9).\n-- For example:\nlocal function specialFilter(nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = specialFilter\n    lu.assertEquals(candidate({5, -2, 1, -5}), 0)\n    lu.assertEquals(candidate({15, -73, 14, -15}), 1)\n    lu.assertEquals(candidate({33, -2, -3, 45, 21, 109}), 2)\n    lu.assertEquals(candidate({43, -12, 93, 125, 121, 109}), 4)\n    lu.assertEquals(candidate({71, -2, -33, 75, 21, 19}), 3)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "lua",
-    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\nlocal function sum_to_n(n)\n",
+    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "lua",
-    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\nlocal function remove_duplicates(numbers)\n",
+    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\nlocal function bf(planet1, planet2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\nlocal function sorted_list_sum(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "lua",
+    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\nlocal function all_prefixes(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "lua",
+    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\nlocal function x_or_y(n, x, y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "lua",
+    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "lua",
+    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\nlocal function compare(game, guess)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "lua",
+    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\nlocal function Strongest_Extension(class_name, extensions)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "lua",
+    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nlocal function cycpattern_check(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "lua",
+    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\nlocal function even_odd_count(num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "lua",
+    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\nlocal function int_to_mini_roman(number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\nlocal function right_angle_triangle(a, b, c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\nlocal function find_max(words)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "lua",
+    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "lua",
+    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nlocal function string_sequence(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\nlocal function solve(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "lua",
+    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\nlocal function string_to_md5(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2254,7 +1039,7 @@
     "language": "lua",
     "prompt": "-- Given two positive integers a and b, return the even digits between a\n-- and b, in ascending order.\n-- For example:\nlocal function generate_integers(a, b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = generate_integers\n    lu.assertEquals(candidate(2, 10), {2, 4, 6, 8})\n    lu.assertEquals(candidate(10, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(132, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(17, 89), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "lua",
-    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\nlocal function rolling_max(numbers)\n",
+    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\nlocal function count_distinct_characters(string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "lua",
-    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\nlocal function below_zero(operations)\n",
+    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\nlocal function parse_music(music_string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "lua",
-    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\nlocal function search(lst)\n",
+    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\nlocal function how_many_times(string, substring)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "lua",
-    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\nlocal function correct_bracketing(brackets)\n",
+    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\nlocal function sort_numbers(numbers)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\nlocal function separate_paren_groups(paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "lua",
+    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\nlocal function find_closest_elements(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "lua",
+    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\nlocal function rescale_to_unit(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "lua",
+    "prompt": "-- Filter given list of any python values only for integers\nlocal function filter_integers(values)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "lua",
+    "prompt": "-- Return length of given string\nlocal function strlen(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "lua",
+    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\nlocal function largest_divisor(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "lua",
+    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\nlocal function factorize(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "lua",
+    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\nlocal function remove_duplicates(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "lua",
+    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nlocal function flip_case(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "lua",
+    "prompt": "-- Concatenate list of strings into a single string\nlocal function concatenate(strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\nlocal function filter_by_prefix(strings, prefix)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "lua",
+    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\nlocal function truncate_number(number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "lua",
+    "prompt": "-- Return only positive numbers in the list.\nlocal function get_positive(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "lua",
+    "prompt": "-- Return true if a given number is prime, and false otherwise.\nlocal function is_prime(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "lua",
+    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\nlocal function sort_third(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "lua",
+    "prompt": "-- Return sorted unique elements in a list\nlocal function unique(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "lua",
+    "prompt": "-- Return maximum element in the list.\nlocal function max_element(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "lua",
+    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nlocal function fizz_buzz(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2329,9 +1384,234 @@
     "language": "lua",
     "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the odd indicies, while its values at the even indicies are equal\n-- to the values of the even indicies of l, but sorted.\nlocal function sort_even(l)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_even\n    lu.assertEquals(candidate({1, 2, 3}), {1, 2, 3})\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), {-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123})\n    lu.assertEquals(candidate({5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), {-12, 8, 3, 4, 5, 2, 12, 11, 23, -10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "lua",
+    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nlocal function prime_fib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "lua",
+    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\nlocal function below_zero(operations)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\nlocal function triples_sum_to_zero(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "lua",
+    "prompt": "-- Return list with elements incremented by 1.\nlocal function incr_list(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\nlocal function pairs_sum_to_zero(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "lua",
+    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\nlocal function change_base(x, base)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given length of a side and high return area for a triangle.\nlocal function triangle_area(a, h)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "lua",
+    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nlocal function fib4(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "lua",
+    "prompt": "-- Return median of elements in the list l.\nlocal function median(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "lua",
+    "prompt": "-- Checks if given string is a palindrome\nlocal function is_palindrome(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "lua",
+    "prompt": "-- Return 2^n modulo p (be aware of numerics).\nlocal function modp(n, p)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "lua",
+    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\nlocal function mean_absolute_deviation(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "lua",
+    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\nlocal function remove_vowels(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "lua",
+    "prompt": "-- Return True if all numbers in the list l are below threshold t.\nlocal function below_threshold(l, t)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "lua",
+    "prompt": "-- Add two numbers x and y\nlocal function add(x, y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2344,9 +1624,24 @@
     "language": "lua",
     "prompt": "-- Check if two words have the same characters.\nlocal function same_chars(s0, s1)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = same_chars\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), true)\n    lu.assertEquals(candidate('abcd', 'dddddddabc'), true)\n    lu.assertEquals(candidate('dddddddabc', 'abcd'), true)\n    lu.assertEquals(candidate('eabcd', 'dddddddabc'), false)\n    lu.assertEquals(candidate('abcd', 'dddddddabcf'), false)\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), false)\n    lu.assertEquals(candidate('aabb', 'aaccc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "lua",
+    "prompt": "-- Return n-th Fibonacci number.\nlocal function fib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2359,9 +1654,714 @@
     "language": "lua",
     "prompt": "-- brackets is a string of \"<\" and \">\".\n-- return True if every opening bracket has a corresponding closing bracket.\nlocal function correct_bracketing(brackets)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('<>'), true)\n    lu.assertEquals(candidate('<<><>>'), true)\n    lu.assertEquals(candidate('<><><<><>><>'), true)\n    lu.assertEquals(candidate('<><><<<><><>><>><<><><<>>>'), true)\n    lu.assertEquals(candidate('<<<><>>>>'), false)\n    lu.assertEquals(candidate('><<>'), false)\n    lu.assertEquals(candidate('<'), false)\n    lu.assertEquals(candidate('<<<<'), false)\n    lu.assertEquals(candidate('>'), false)\n    lu.assertEquals(candidate('<<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>><<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>>><>'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "lua",
+    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\nlocal function monotonic(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "lua",
+    "prompt": "-- Return sorted unique common elements for two lists.\nlocal function common(l1, l2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "lua",
+    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlocal function largest_prime_factor(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "lua",
+    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nlocal function intersperse(numbers, delimeter)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "lua",
+    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\nlocal function sum_to_n(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "lua",
+    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\nlocal function correct_bracketing(brackets)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "lua",
+    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\nlocal function derivative(xs)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "lua",
+    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nlocal function fibfib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "lua",
+    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\nlocal function vowels_count(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "lua",
+    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\nlocal function circular_shift(x, shift)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "lua",
+    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\nlocal function digitSum(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "lua",
+    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\nlocal function fruit_distribution(s, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "lua",
+    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- Example 4:\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "lua",
+    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\nlocal function search(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\nlocal function parse_nested_parens(paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "lua",
+    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\nlocal function strange_sort_list(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\nlocal function triangle_area(a, b, c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "lua",
+    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "lua",
+    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\nlocal function smallest_change(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\nlocal function total_match(lst1, lst2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "lua",
+    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "lua",
+    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\nlocal function is_simple_power(x, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\nlocal function iscube(a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "lua",
+    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\nlocal function hex_key(num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\nlocal function decimal_to_binary(decimal)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that contain given substring\nlocal function filter_by_substring(strings, substring)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\nlocal function is_happy(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "lua",
+    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\nlocal function numerical_letter_grade(grades)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\nlocal function prime_length(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "lua",
+    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "lua",
+    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\nlocal function add(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\nlocal function anti_shuffle(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "lua",
+    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\nlocal function get_row(lst, x)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "lua",
+    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\nlocal function sort_array(array)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "lua",
+    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\nlocal function encrypt(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "lua",
+    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\nlocal function sum_product(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\nlocal function next_smallest(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "lua",
+    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\nlocal function is_bored(S)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "lua",
+    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\nlocal function any_int(x, y, z)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\nlocal function encode(message)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\nlocal function skjkasdkd(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "lua",
+    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\nlocal function check_dict_case(dict)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "lua",
+    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\nlocal function count_up_to(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "lua",
+    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\nlocal function multiply(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "lua",
+    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\nlocal function count_upper(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "lua",
+    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\nlocal function rolling_max(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/humaneval-lua-reworded.json
+++ b/prompts/humaneval-lua-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "lua",
-    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "lua",
-    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- >>> encrypt('hi')\n-- 'lm'\n-- >>> encrypt('asdfghjkl')\n-- 'ewhjklnop'\n-- >>> encrypt('gf')\n-- 'kj'\n-- >>> encrypt('et')\n-- 'ix'\nlocal function encrypt(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "lua",
-    "prompt": "-- Given a table, return true if all keys are strings in lower \n-- case or all keys are strings in upper case, else return false.\n-- The function should return false is the given table is empty.\n-- Examples:\n-- >>> check_dict_case({['a'] = 'apple', ['b'] = 'banana'})\n-- true\n-- >>> check_dict_case({['a'] = 'apple', ['A'] = 'banana', ['B'] = 'banana'})\n-- false\n-- >>> check_dict_case({['a'] = 'apple', [8] = 'banana', ['a'] = 'apple'})\n-- false\n-- >>> check_dict_case({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'})\n-- false\n-- >>> check_dict_case({['STATE'] = 'NC', ['ZIP'] = '12345'})\n-- true\nlocal function check_dict_case(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "lua",
-    "prompt": "-- Given a non-empty table of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- >>> add({4, 2, 6, 7})\n-- 2\nlocal function add(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "lua",
-    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- >>> fix_spaces(' Example')\n-- 'Example'\n-- >>> fix_spaces(' Example 1')\n-- 'Example_1'\n-- >>> fix_spaces(' Example 2')\n-- '_Example_2'\n-- >>> fix_spaces(' Example 3')\n-- '_Example-3'\nlocal function fix_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "lua",
-    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "lua",
-    "prompt": "-- Given a table of numbers, return the sum of squares of the numbers\n-- in the table that are odd. Ignore numbers that are negative or not integers.\n-- >>> double_the_difference({1, 3, 2, 0})\n-- 10\n-- >>> double_the_difference({-1, -2, 0})\n-- 0\n-- >>> double_the_difference({9, -2})\n-- 81\n-- >>> double_the_difference({0})\n-- 0\n-- If the input table is empty, return 0.\nlocal function double_the_difference(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "lua",
-    "prompt": "-- Filter given table of any luathon values only for integers\n-- >>> filter_integers({'a', 3.14, 5})\n-- {5}\n-- >>> filter_integers({1, 2, 3, 'abc', {}, {}})\n-- {1, 2, 3}\nlocal function filter_integers(values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "lua",
-    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return table of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- {4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nlocal function parse_music(music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- >>> decimal_to_binary(15)\n-- 'db1111db'\n-- >>> decimal_to_binary(32)\n-- 'db100000db'\nlocal function decimal_to_binary(decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "lua",
-    "prompt": "-- Return table of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- {'a', 'ab', 'abc'}\nlocal function all_prefixes(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "lua",
-    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "lua",
-    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return a table of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- >>> eat(5, 6, 10)\n-- {11, 4}\n-- >>> eat(4, 8, 9)\n-- {12, 1}\n-- >>> eat(1, 10, 10)\n-- {11, 0}\n-- >>> eat(2, 11, 5)\n-- {7, 0}\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "lua",
-    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- >>> max_fill({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1)\n-- 6\n-- Example 2:\n-- >>> max_fill({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2)\n-- 5\n-- Example 3:\n-- >>> max_fill({{0, 0, 0}, {0, 0, 0}}, 5)\n-- 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "lua",
-    "prompt": "-- Given two tables operator, and operand. The first table has basic algebra operations, and \n-- the second table is a table of integers. Use the two given tables to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- table = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator table is equal to the length of operand table minus one.\n-- Operand is a table of of non-negative integers.\n-- Operator table has at least one operator, and operand table has at least two operands.\nlocal function do_algebra(operator, operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "lua",
-    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "lua",
-    "prompt": "-- Given a table of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting table, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- >>> by_length({2, 1, 1, 4, 5, 8, 2, 3})\n-- {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'}\n-- If the table is empty, return an empty table:\n-- >>> by_length({})\n-- {}\n-- If the table has any strange number ignore it:\n-- >>> by_length({1, -1, 55})\n-- {'One'}\nlocal function by_length(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "lua",
-    "prompt": "-- Return table of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be tableed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- {2, 2, 2}\n-- >>> factorize(25)\n-- {5, 5}\n-- >>> factorize(70)\n-- {2, 5, 7}\nlocal function factorize(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "lua",
-    "prompt": "-- Implement a function that takes an non-negative integer and returns a table of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- >>> count_up_to(5)\n-- {2, 3}\n-- >>> count_up_to(11)\n-- {2, 3, 5, 7}\n-- >>> count_up_to(0)\n-- {}\n-- >>> count_up_to(20)\n-- {2, 3, 5, 7, 11, 13, 17, 19}\n-- >>> count_up_to(1)\n-- {}\n-- >>> count_up_to(18)\n-- {2, 3, 5, 7, 11, 13, 17}\nlocal function count_up_to(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "lua",
-    "prompt": "-- Return sorted unique elements in a table\n-- >>> unique({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {0, 2, 3, 5, 9, 123}\nlocal function unique(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts two tables of strings and returns the table that has \n-- total number of chars in the all strings of the table less than the other table.\n-- if the two tables have the same number of chars, return the first table.\n-- Examples\n-- >>> total_match({}, {})\n-- {}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'Hi'})\n-- {'hI', 'Hi'}\n-- >>> total_match({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'})\n-- {'hi', 'admin'}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'hi', 'hi'})\n-- {'hI', 'hi', 'hi'}\n-- >>> total_match({'4'}, {'1', '2', '3', '4', '5'})\n-- {'4'}\nlocal function total_match(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "lua",
-    "prompt": "-- Return maximum element in the table.\n-- >>> max_element({1, 2, 3})\n-- 3\n-- >>> max_element({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- 123\nlocal function max_element(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "lua",
-    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return true if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- >>> is_nested('[[]]')\n-- true\n-- >>> is_nested('[]]]]]]][[[[[]')\n-- false\n-- >>> is_nested('[][]')\n-- false\n-- >>> is_nested('[]')\n-- false\n-- >>> is_nested('[[][]]')\n-- true\n-- >>> is_nested('[[]][[')\n-- true\nlocal function is_nested(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "lua",
-    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- >>> rounded_avg(1, 5)\n-- '0b11'\n-- >>> rounded_avg(7, 5)\n-- -1\n-- >>> rounded_avg(10, 20)\n-- '0b1111'\n-- >>> rounded_avg(20, 33)\n-- '0b11010'\nlocal function rounded_avg(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "lua",
-    "prompt": "-- Given a table of strings, where each string consists of only digits, return a table.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count({'1234567'})\n-- {'the number of odd elements 4n the str4ng 4 of the 4nput.'}\n-- >>> odd_count({'3', '11111111'})\n-- {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'}\nlocal function odd_count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "lua",
-    "prompt": "-- We have a table 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the table will be randomly ordered. Your task is to determine if\n-- it is possible to get a table sorted in non-decreasing order by performing \n-- the following operation on the given table:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the table by one\n-- position in the right direction. The last element of the table will be moved to\n-- the starting position in the table i.e. 0th index. \n-- If it is possible to obtain the sorted table by performing the above operation\n-- then return true else return false.\n-- If the given table is empty then return true.\n-- Note: The given table is guaranteed to have unique elements.\n-- For Example:\n-- >>> move_one_ball({3, 4, 5, 1, 2})\n-- true\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given table.\n-- >>> move_one_ball({3, 5, 4, 1, 2})\n-- false\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- table by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a table that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- >>> even_odd_palindrome(3)\n-- {1, 2}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- >>> even_odd_palindrome(12)\n-- {4, 6}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned table has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "lua",
-    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- >>> is_equal_to_sum_even(4)\n-- false\n-- >>> is_equal_to_sum_even(6)\n-- false\n-- >>> is_equal_to_sum_even(8)\n-- true\nlocal function is_equal_to_sum_even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "lua",
-    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative({3, 1, 2, 4, 5})\n-- {1, 4, 12, 20}\n-- >>> derivative({1, 2, 3})\n-- {2, 6}\nlocal function derivative(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "lua",
-    "prompt": "-- Given a table of numbers, return whether or not they are sorted\n-- in ascending order. If table has more than 1 duplicate of the same\n-- number, return false. Assume no negative numbers and only integers.\n-- Examples\n-- >>> is_sorted({5})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5})\n-- false\n-- >>> is_sorted({1, 2, 3, 4, 5, 6})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5, 6, 7})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5, 6, 7})\n-- false\n-- >>> is_sorted({1, 2, 2, 3, 3, 4})\n-- true\n-- >>> is_sorted({1, 2, 2, 2, 3, 4})\n-- false\nlocal function is_sorted(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- >>> solve('1234')\n-- '4321'\n-- >>> solve('ab')\n-- 'AB'\n-- >>> solve('#a@C')\n-- '#A@c'\nlocal function solve(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "lua",
-    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a table of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- >>> tri(3)\n-- {1, 3, 2, 8}\nlocal function tri(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "lua",
-    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "lua",
-    "prompt": "-- Filter an input table of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix({}, 'a')\n-- {}\n-- >>> filter_by_prefix({'abc', 'bcd', 'cde', 'array'}, 'a')\n-- {'abc', 'array'}\nlocal function filter_by_prefix(strings, prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "lua",
-    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- >>> solve(1000)\n-- '1'\n-- >>> solve(150)\n-- '110'\n-- >>> solve(147)\n-- '1100'\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "lua",
-    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered tables of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered table of the values on the cells that the minimum path go through.\n-- Examples:    \n-- >>> minPath({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3)\n-- {1, 2, 1}\n-- >>> minPath({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1)\n-- {1}\nlocal function minPath(grid, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "lua",
-    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- >>> count_upper('aBCdEf')\n-- 1\n-- >>> count_upper('abcdefg')\n-- 0\n-- >>> count_upper('dBBE')\n-- 0\nlocal function count_upper(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "lua",
-    "prompt": "-- Given a table arr of integers and a positive integer k, return a sorted table \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- >>> maximum({-3, -4, 5}, 3)\n-- {-4, -3, 5}\n-- Example 2:\n-- >>> maximum({4, -4, 4}, 2)\n-- {4, 4}\n-- Example 3:\n-- >>> maximum({-3, 2, 1, 2, -1, -2, 1}, 1)\n-- {2}\n-- Note:\n-- 1. The length of the table will be in the range of [1, 1000].\n-- 2. The elements in the table will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "lua",
-    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "lua",
-    "prompt": "-- Given a table of non-negative integers, return a colua of the given table after sorting,\n-- you will sort the given table in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given table.\n-- Examples:\n-- >>> sort_array({})\n-- {}\n-- >>> sort_array({5})\n-- {5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5})\n-- {0, 1, 2, 3, 4, 5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5, 6})\n-- {6, 5, 4, 3, 2, 1, 0}\nlocal function sort_array(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "lua",
-    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a table of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- >>> f(5)\n-- {1, 2, 6, 24, 15}\nlocal function f(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "lua",
-    "prompt": "-- Write a function that takes an integer a and returns true \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- >>> iscube(1)\n-- true\n-- >>> iscube(2)\n-- false\n-- >>> iscube(-1)\n-- true\n-- >>> iscube(64)\n-- true\n-- >>> iscube(0)\n-- true\n-- >>> iscube(180)\n-- false\nlocal function iscube(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "lua",
-    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored('Hello world')\n-- 0\n-- >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n-- 1\nlocal function is_bored(S)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- pairs_sum_to_zero takes a table of integers as an input.\n-- it returns true if there are two distinct elements in the table that\n-- sum to zero, and false otherwise.\n-- >>> pairs_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> pairs_sum_to_zero({1, 3, -2, 1})\n-- false\n-- >>> pairs_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> pairs_sum_to_zero({2, 4, -5, 3, 5, 7})\n-- true\n-- >>> pairs_sum_to_zero({1})\n-- false\nlocal function pairs_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- >>> triangle_area(3, 4, 5)\n-- 6.0\n-- >>> triangle_area(1, 2, 10)\n-- -1\nlocal function triangle_area(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "lua",
-    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a table containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty table if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- >>> bf('Jupiter', 'Neptune')\n-- {'Saturn', 'Uranus'}\n-- >>> bf('Earth', 'Mercury')\n-- 'Venus'\n-- >>> bf('Mercury', 'Uranus')\n-- {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'}\nlocal function bf(planet1, planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- >>> digits(1)\n-- 1\n-- >>> digits(4)\n-- 0\n-- >>> digits(235)\n-- 15\nlocal function digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "lua",
-    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return a table of the words.\n-- For example:\n-- >>> words_string('Hi, my name is John')\n-- {'Hi', 'my', 'name', 'is', 'John'}\n-- >>> words_string('One, two, three, four, five, six')\n-- {'One', 'two', 'three', 'four', 'five', 'six'}\nlocal function words_string(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "lua",
-    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "lua",
-    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- >>> compare_one(1, 2.5)\n-- 2.5\n-- >>> compare_one(1, '2,3')\n-- '2,3'\n-- >>> compare_one('5,1', '6')\n-- '6'\n-- >>> compare_one('1', 1)\n-- None\nlocal function compare_one(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "lua",
-    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "lua",
-    "prompt": "-- Given table of integers, return table in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- >>> strange_sort_list({1, 2, 3, 4})\n-- {1, 4, 2, 3}\n-- >>> strange_sort_list({5, 5, 5, 5})\n-- {5, 5, 5, 5}\n-- >>> strange_sort_list({})\n-- {}\nlocal function strange_sort_list(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "lua",
-    "prompt": "-- From a supplied table of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n-- {2.0, 2.2}\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n-- {2.0, 2.0}\nlocal function find_closest_elements(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "lua",
-    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- >>> is_simple_power(1, 4)\n-- true\n-- >>> is_simple_power(2, 2)\n-- true\n-- >>> is_simple_power(8, 2)\n-- true\n-- >>> is_simple_power(3, 2)\n-- false\n-- >>> is_simple_power(3, 1)\n-- false\n-- >>> is_simple_power(5, 3)\n-- false\nlocal function is_simple_power(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "lua",
-    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "lua",
-    "prompt": "-- Write a function which sorts the given table of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original table.\n-- For example:\n-- >>> order_by_points({1, 11, -1, -11, -12})\n-- {-1, -11, 1, -12, 11}\n-- >>> order_by_points({})\n-- {}\nlocal function order_by_points(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "lua",
     "prompt": "-- Check if in given table of numbers, are any two numbers closer to each other than\n-- given threshold.\n-- >>> has_close_elements({1.0, 2.0, 3.0}, 0.5)\n-- false\n-- >>> has_close_elements({1.0, 2.8, 3.0, 4.0, 5.0, 2.0}, 0.3)\n-- true\nlocal function has_close_elements(numbers, threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = has_close_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), true)\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), false)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), true)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), false)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "lua",
-    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "lua",
-    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "lua",
-    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "lua",
-    "prompt": "-- Given a non-empty table of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- >>> add_elements({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n-- 24\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "lua",
-    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "lua",
-    "prompt": "-- Given a table of positive integers x. return a sorted table of all \n-- elements that hasn't any even digit.\n-- Note: Returned table should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits({15, 33, 1422, 1})\n-- {1, 15, 33}\n-- >>> unique_digits({152, 323, 1422, 10})\n-- {}\nlocal function unique_digits(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "lua",
-    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a table of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty table.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- >>> select_words('Mary had a little lamb', 4)\n-- {'little'}\n-- >>> select_words('Mary had a little lamb', 3)\n-- {'Mary', 'lamb'}\n-- >>> select_words('simple white space', 2)\n-- {}\n-- >>> select_words('Hello world', 4)\n-- {'world'}\n-- >>> select_words('Uncle sam', 3)\n-- {'Uncle'}\nlocal function select_words(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "lua",
-    "prompt": "-- Write a function that returns true if the object q will fly, and false otherwise.\n-- The object q will fly if it's balanced (it is a palindromic table) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- >>> will_it_fly({1, 2}, 5)\n-- false\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- >>> will_it_fly({3, 2, 3}, 1)\n-- false\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- >>> will_it_fly({3, 2, 3}, 9)\n-- true\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- >>> will_it_fly({3}, 5)\n-- true\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "lua",
-    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "lua",
-    "prompt": "-- You will be given the name of a class (a string) and a table of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the table.\n-- For example, if you are given \"Slices\" as the class and a table of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- >>> Strongest_Extension('my_class', {'AA', 'Be', 'CC'})\n-- 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "lua",
-    "prompt": "-- You are given a table of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- >>> match_parens({'()(', ')'})\n-- 'Yes'\n-- >>> match_parens({')', ')'})\n-- 'No'\nlocal function match_parens(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "lua",
-    "prompt": "-- You are given a table of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the table.\n-- Return None if there is no such element.\n-- >>> next_smallest({1, 2, 3, 4, 5})\n-- 2\n-- >>> next_smallest({5, 1, 4, 3, 2})\n-- 2\n-- >>> next_smallest({})\n-- None\n-- >>> next_smallest({1, 1})\n-- None\nlocal function next_smallest(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "lua",
-    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- >>> any_int(5, 2, 7)\n-- true\n-- >>> any_int(3, 2, 2)\n-- false\n-- >>> any_int(3, -2, 1)\n-- true\n-- >>> any_int(3.6, -2.2, 2)\n-- false\nlocal function any_int(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "lua",
-    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "lua",
-    "prompt": "-- Return table with elements incremented by 1.\n-- >>> incr_list({1, 2, 3})\n-- {2, 3, 4}\n-- >>> incr_list({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {6, 4, 6, 3, 4, 4, 10, 1, 124}\nlocal function incr_list(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "lua",
-    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- >>> x_or_y(7, 34, 12)\n-- 34\n-- >>> x_or_y(15, 8, 5)\n-- 5\nlocal function x_or_y(n, x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "lua",
-    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "lua",
-    "prompt": "-- Given an integer. return a table that has the number of even and odd digits respectively.\n-- Example:\n-- >>> even_odd_count(-12)\n-- {1, 1}\n-- >>> even_odd_count(123)\n-- {1, 2}\nlocal function even_odd_count(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is haplua or not.\n-- A string is haplua if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- >>> is_happy('a')\n-- false\n-- >>> is_happy('aa')\n-- false\n-- >>> is_happy('abcd')\n-- true\n-- >>> is_happy('aabb')\n-- false\n-- >>> is_happy('adb')\n-- true\n-- >>> is_happy('xyy')\n-- false\nlocal function is_happy(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "lua",
-    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "lua",
-    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- >>> digitSum('')\n-- 0\n-- >>> digitSum('abAB')\n-- 131\n-- >>> digitSum('abcCd')\n-- 67\n-- >>> digitSum('helloE')\n-- 69\n-- >>> digitSum('woArBld')\n-- 131\n-- >>> digitSum('aAaaaXa')\n-- 153\nlocal function digitSum(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "lua",
-    "prompt": "-- Given table of numbers (of at least two elements), apply a linear transform to that table,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit({1.0, 2.0, 3.0, 4.0, 5.0})\n-- {0.0, 0.25, 0.5, 0.75, 1.0}\nlocal function rescale_to_unit(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "lua",
-    "prompt": "-- Given a non-empty table of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- >>> solution({5, 8, 7, 1})\n-- 12\n-- >>> solution({3, 3, 3, 3, 3})\n-- 9\n-- >>> solution({30, 13, 24, 321})\n-- 0\nlocal function solution(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "lua",
-    "prompt": "-- \"Given a table representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a table, [ smalest_value, its index ],\n-- If there are no even values or the given table is empty, return [].\n-- Example 1:\n-- >>> pluck({4, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- >>> pluck({1, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- >>> pluck({})\n-- {}\n-- Example 4:\n-- >>> pluck({5, 0, 3, 0, 4, 2})\n-- {0, 1}\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "lua",
-    "prompt": "-- You are given a positive integer n. You have to create an integer table a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- >>> get_max_triples(5)\n-- 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "lua",
-    "prompt": "-- In this problem, you will implement a function that takes two tables of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a table of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- >>> exchange({1, 2, 3, 4}, {1, 2, 3, 4})\n-- 'YES'\n-- >>> exchange({1, 2, 3, 4}, {1, 5, 3, 4})\n-- 'NO'\n-- It is assumed that the input tables will be non-empty.\nlocal function exchange(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "lua",
-    "prompt": "-- Return median of elements in the table l.\n-- >>> median({3, 1, 2, 4, 5})\n-- 3\n-- >>> median({-10, 4, 6, 1000, 10, 20})\n-- 15.0\nlocal function median(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns true if the string\n-- length is a prime number or false otherwise\n-- Examples\n-- >>> prime_length('Hello')\n-- true\n-- >>> prime_length('abcdcba')\n-- true\n-- >>> prime_length('kittens')\n-- true\n-- >>> prime_length('orange')\n-- false\nlocal function prime_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "lua",
-    "prompt": "-- Given a table arr of integers, find the minimum number of elements that\n-- need to be changed to make the table palindromic. A palindromic table is a table that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- >>> smallest_change({1, 2, 3, 5, 4, 7, 9, 6})\n-- 4\n-- >>> smallest_change({1, 2, 3, 4, 3, 2, 2})\n-- 1\n-- >>> smallest_change({1, 2, 3, 2, 1})\n-- 0\nlocal function smallest_change(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "lua",
-    "prompt": "-- You are given a table of numbers.\n-- You need to return the sum of squared numbers in the given table,\n-- round each element in the table to the upper int(Ceiling) first.\n-- Examples:\n-- >>> lst({1.0, 2.0, 3.0})\n-- 14\n-- >>> lst({1.0, 4.0, 9.0})\n-- 98\n-- >>> lst({1.0, 3.0, 5.0, 7.0})\n-- 84\n-- >>> lst({1.4, 4.2, 0.0})\n-- 29\n-- >>> lst({-2.4, 1.0, 1.0})\n-- 6\nlocal function sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "lua",
-    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- >>> file_name_check('example.txt')\n-- 'Yes'\n-- >>> file_name_check('1example.dll')\n-- 'No'\nlocal function file_name_check(file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- triples_sum_to_zero takes a table of integers as an input.\n-- it returns true if there are three distinct elements in the table that\n-- sum to zero, and false otherwise.\n-- >>> triples_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> triples_sum_to_zero({1, 3, -2, 1})\n-- true\n-- >>> triples_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> triples_sum_to_zero({2, 4, -5, 3, 9, 7})\n-- true\n-- >>> triples_sum_to_zero({1})\n-- false\nlocal function triples_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "lua",
-    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- >>> intersection({1, 2}, {2, 3})\n-- 'NO'\n-- >>> intersection({-1, 1}, {0, 4})\n-- 'NO'\n-- >>> intersection({-3, -1}, {-5, 5})\n-- 'YES'\nlocal function intersection(interval1, interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the table of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- {'()', '(())', '(()())'}\nlocal function separate_paren_groups(paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "lua",
-    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two tables of scores and guesses of equal length, where each index shows a match. \n-- Return a table of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- >>> compare({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2})\n-- {0, 0, 0, 0, 3, 3}\n-- >>> compare({0, 5, 0, 0, 0, 4}, {4, 1, 1, 0, 0, -2})\n-- {4, 4, 1, 0, 0, 6}\nlocal function compare(game, guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "lua",
-    "prompt": "-- Create a function that returns true if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and false otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- >>> check_if_last_char_is_a_letter('apple pie')\n-- false\n-- >>> check_if_last_char_is_a_letter('apple pi e')\n-- true\n-- >>> check_if_last_char_is_a_letter('apple pi e ')\n-- false\n-- >>> check_if_last_char_is_a_letter('')\n-- false\nlocal function check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "lua",
-    "prompt": "-- You have to write a function which validates a given date string and\n-- returns true if the date is valid otherwise false.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- >>> valid_date('03-11-2000')\n-- true\n-- >>> valid_date('15-01-2012')\n-- false\n-- >>> valid_date('04-0-2040')\n-- false\n-- >>> valid_date('06-04-2020')\n-- true\n-- >>> valid_date('06/04/2020')\n-- false\nlocal function valid_date(date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "lua",
-    "prompt": "-- Write a function count_nums which takes a table of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums({})\n-- 0\n-- >>> count_nums({-1, 11, -11})\n-- 1\n-- >>> count_nums({1, 1, 2})\n-- 3\nlocal function count_nums(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- >>> anti_shuffle('Hi')\n-- 'Hi'\n-- >>> anti_shuffle('hello')\n-- 'ehllo'\n-- >>> anti_shuffle('Hello World!!!')\n-- 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "lua",
-    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- true\n-- >>> is_palindrome('aba')\n-- true\n-- >>> is_palindrome('aaaaa')\n-- true\n-- >>> is_palindrome('zbcd')\n-- false\nlocal function is_palindrome(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "lua",
-    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- >>> get_closest_vowel('yogurt')\n-- 'u'\n-- >>> get_closest_vowel('FULL')\n-- 'U'\n-- >>> get_closest_vowel('quick')\n-- ''\n-- >>> get_closest_vowel('ab')\n-- ''\nlocal function get_closest_vowel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "lua",
-    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- false\n-- >>> is_prime(101)\n-- true\n-- >>> is_prime(11)\n-- true\n-- >>> is_prime(13441)\n-- true\n-- >>> is_prime(61)\n-- true\n-- >>> is_prime(4)\n-- false\n-- >>> is_prime(1)\n-- false\nlocal function is_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "lua",
-    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns true if x * n evaluates to a whole number and false\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- >>> simplify('1/5', '5/1')\n-- true\n-- >>> simplify('1/6', '2/1')\n-- false\n-- >>> simplify('7/10', '10/2')\n-- false\nlocal function simplify(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "lua",
-    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- >>> hex_key('AB')\n-- 1\n-- >>> hex_key('1077E')\n-- 2\n-- >>> hex_key('ABED1A33')\n-- 4\n-- >>> hex_key('123456789ABCDEF0')\n-- 6\n-- >>> hex_key('2020')\n-- 2\nlocal function hex_key(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "lua",
-    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- >>> words_in_sentence('This is a test')\n-- 'is'\n-- Example 2:\n-- >>> words_in_sentence('lets go for swimming')\n-- 'go for'\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "lua",
-    "prompt": "-- Given a string representing a space separated lowercase letters, return a table\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- >>> histogram('a b c')\n-- {['a'] = 1, ['b'] = 1, ['c'] = 1}\n-- >>> histogram('a b b a')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('a b c a b')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('b b b b a')\n-- {['b'] = 4}\n-- >>> histogram('')\n-- {}\nlocal function histogram(test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "lua",
-    "prompt": "-- You are given a 2 dimensional data, as a nested tables,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the table,\n-- and return table of tables, [(x1, y1), (x2, y2) ...] such that\n-- each table is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- >>> get_row({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1)\n-- {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}}\n-- >>> get_row({}, 1)\n-- {}\n-- >>> get_row({{}, {1}, {1, 2, 3}}, 3)\n-- {{2, 2}}\nlocal function get_row(lst, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a sorted table that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned table sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n-- >>> get_odd_collatz(5)\n-- {1, 5}\nlocal function get_odd_collatz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "lua",
-    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given table will not contain\n-- duplicate values.\n-- Examples:\n-- >>> can_arrange({1, 2, 4, 3, 5})\n-- 3\n-- >>> can_arrange({1, 2, 3})\n-- -1\nlocal function can_arrange(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "lua",
-    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "lua",
-    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- '21'\n-- >>> circular_shift(12, 2)\n-- '12'\nlocal function circular_shift(x, shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "lua",
-    "prompt": "-- \"\n-- This function will take a table of integers. For all entries in the table, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the table whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- >>> lst\n-- {1, 2, 3}\n-- >>> lst\n-- {}\n-- >>> lst\n-- {-1, -5, 2, -1, -5}\nlocal function sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "lua",
-    "prompt": "-- You are given a table of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- >>> skjkasdkd({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n-- 10\n-- >>> skjkasdkd({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n-- 25\n-- >>> skjkasdkd({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n-- 13\n-- >>> skjkasdkd({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n-- 11\n-- >>> skjkasdkd({0, 81, 12, 3, 1, 21})\n-- 3\n-- >>> skjkasdkd({0, 8, 1, 2, 1, 7})\n-- 7\nlocal function skjkasdkd(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "lua",
-    "prompt": "-- For a given table of integers, return a table consisting of a sum and a product of all the integers in a table.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product({})\n-- {0, 1}\n-- >>> sum_product({1, 2, 3, 4})\n-- {10, 24}\nlocal function sum_product(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "lua",
-    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\n-- >>> choose_num(12, 15)\n-- 14\n-- >>> choose_num(13, 12)\n-- -1\nlocal function choose_num(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "lua",
-    "prompt": "-- Create a function that returns a table (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a table.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- >>> largest_smallest_integers({2, 4, 1, 3, 5, 7})\n-- {None, 1}\n-- >>> largest_smallest_integers({})\n-- {None, None}\n-- >>> largest_smallest_integers({0})\n-- {None, None}\nlocal function largest_smallest_integers(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "lua",
-    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\n-- >>> count_distinct_characters('xyzXYZ')\n-- 3\n-- >>> count_distinct_characters('Jerry')\n-- 4\nlocal function count_distinct_characters(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1759,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Given a positive integer n, you have to make a pile of n levels of stones.\n-- The first level has n stones.\n-- The number of stones in the next level is:\n-- - the next odd number if n is odd.\n-- - the next even number if n is even.\n-- Return the number of stones in each level in a table, where element at index\n-- i represents the number of stones in the level (i+1).\n-- Examples:\n-- >>> make_a_pile(3)\n-- {3, 5, 7}\nlocal function make_a_pile(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_a_pile\n    lu.assertEquals(candidate(3), {3, 5, 7})\n    lu.assertEquals(candidate(4), {4, 6, 8, 10})\n    lu.assertEquals(candidate(5), {5, 7, 9, 11, 13})\n    lu.assertEquals(candidate(6), {6, 8, 10, 12, 14, 16})\n    lu.assertEquals(candidate(8), {8, 10, 12, 14, 16, 18, 20, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "lua",
-    "prompt": "-- You are given a table arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the table, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs({1, 2, 2, -4})\n-- 9\n-- >>> prod_signs({0, 1})\n-- 0\n-- >>> prod_signs({})\n-- None\nlocal function prod_signs(arr)\n",
+    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return a table of the words.\n-- For example:\n-- >>> words_string('Hi, my name is John')\n-- {'Hi', 'my', 'name', 'is', 'John'}\n-- >>> words_string('One, two, three, four, five, six')\n-- {'One', 'two', 'three', 'four', 'five', 'six'}\nlocal function words_string(s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "lua",
-    "prompt": "-- Given a table of integers nums, find the minimum sum of any non-empty sub-table\n-- of nums.\n-- Example\n-- >>> minSubArraySum({2, 3, 4, 1, 2, 4})\n-- 1\n-- >>> minSubArraySum({-1, -2, -3})\n-- -6\nlocal function minSubArraySum(nums)\n",
+    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\n-- >>> choose_num(12, 15)\n-- 14\n-- >>> choose_num(13, 12)\n-- -1\nlocal function choose_num(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "lua",
-    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
+    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- >>> rounded_avg(1, 5)\n-- '0b11'\n-- >>> rounded_avg(7, 5)\n-- -1\n-- >>> rounded_avg(10, 20)\n-- '0b1111'\n-- >>> rounded_avg(20, 33)\n-- '0b11010'\nlocal function rounded_avg(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "lua",
-    "prompt": "-- You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n-- >>> cycpattern_check('abcd', 'abd')\n-- false\n-- >>> cycpattern_check('hello', 'ell')\n-- true\n-- >>> cycpattern_check('whassup', 'psus')\n-- false\n-- >>> cycpattern_check('abab', 'baa')\n-- true\n-- >>> cycpattern_check('efef', 'eeff')\n-- false\n-- >>> cycpattern_check('himenss', 'simen')\n-- true\nlocal function cycpattern_check(a, b)\n",
+    "prompt": "-- Given a table of positive integers x. return a sorted table of all \n-- elements that hasn't any even digit.\n-- Note: Returned table should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits({15, 33, 1422, 1})\n-- {1, 15, 33}\n-- >>> unique_digits({152, 323, 1422, 10})\n-- {}\nlocal function unique_digits(x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "lua",
-    "prompt": "-- Return true is table elements are monotonically increasing or decreasing.\n-- >>> monotonic({1, 2, 4, 20})\n-- true\n-- >>> monotonic({1, 20, 4, 10})\n-- false\n-- >>> monotonic({4, 1, 0, -10})\n-- true\nlocal function monotonic(l)\n",
+    "prompt": "-- Given a table of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting table, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- >>> by_length({2, 1, 1, 4, 5, 8, 2, 3})\n-- {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'}\n-- If the table is empty, return an empty table:\n-- >>> by_length({})\n-- {}\n-- If the table has any strange number ignore it:\n-- >>> by_length({1, -1, 55})\n-- {'One'}\nlocal function by_length(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "lua",
-    "prompt": "-- Out of table of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input table is empty.\n-- >>> longest({})\n-- None\n-- >>> longest({'a', 'b', 'c'})\n-- 'a'\n-- >>> longest({'a', 'bb', 'ccc'})\n-- 'ccc'\nlocal function longest(strings)\n",
+    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a table of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- >>> f(5)\n-- {1, 2, 6, 24, 15}\nlocal function f(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "lua",
-    "prompt": "-- Return true if all numbers in the table l are below threshold t.\n-- >>> below_threshold({1, 2, 4, 10}, 100)\n-- true\n-- >>> below_threshold({1, 20, 4, 10}, 5)\n-- false\nlocal function below_threshold(l, t)\n",
+    "prompt": "-- Given a positive integer n, return a table that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- >>> even_odd_palindrome(3)\n-- {1, 2}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- >>> even_odd_palindrome(12)\n-- {4, 6}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned table has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "lua",
-    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- >>> is_multiply_prime(30)\n-- true\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "prompt": "-- Write a function count_nums which takes a table of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums({})\n-- 0\n-- >>> count_nums({-1, 11, -11})\n-- 1\n-- >>> count_nums({1, 1, 2})\n-- 3\nlocal function count_nums(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "lua",
-    "prompt": "-- Return only positive numbers in the table.\n-- >>> get_positive({-1, 2, -4, 5, 6})\n-- {2, 5, 6}\n-- >>> get_positive({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- {5, 3, 2, 3, 9, 123, 1}\nlocal function get_positive(l)\n",
+    "prompt": "-- We have a table 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the table will be randomly ordered. Your task is to determine if\n-- it is possible to get a table sorted in non-decreasing order by performing \n-- the following operation on the given table:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the table by one\n-- position in the right direction. The last element of the table will be moved to\n-- the starting position in the table i.e. 0th index. \n-- If it is possible to obtain the sorted table by performing the above operation\n-- then return true else return false.\n-- If the given table is empty then return true.\n-- Note: The given table is guaranteed to have unique elements.\n-- For Example:\n-- >>> move_one_ball({3, 4, 5, 1, 2})\n-- true\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given table.\n-- >>> move_one_ball({3, 5, 4, 1, 2})\n-- false\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- table by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "lua",
-    "prompt": "-- This function takes a table l and returns a table l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_third({5, 6, 3, 4, 8, 9, 2})\n-- {2, 6, 3, 4, 8, 9, 5}\nlocal function sort_third(l)\n",
+    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "lua",
-    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- {2, 3, 1, 3}\nlocal function parse_nested_parens(paren_string)\n",
+    "prompt": "-- In this problem, you will implement a function that takes two tables of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a table of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- >>> exchange({1, 2, 3, 4}, {1, 2, 3, 4})\n-- 'YES'\n-- >>> exchange({1, 2, 3, 4}, {1, 5, 3, 4})\n-- 'NO'\n-- It is assumed that the input tables will be non-empty.\nlocal function exchange(lst1, lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "lua",
-    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
+    "prompt": "-- Given a string representing a space separated lowercase letters, return a table\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- >>> histogram('a b c')\n-- {['a'] = 1, ['b'] = 1, ['c'] = 1}\n-- >>> histogram('a b b a')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('a b c a b')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('b b b b a')\n-- {['b'] = 4}\n-- >>> histogram('')\n-- {}\nlocal function histogram(test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "lua",
-    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- >>> multiply(148, 412)\n-- 16\n-- >>> multiply(19, 28)\n-- 72\n-- >>> multiply(2020, 1851)\n-- 0\n-- >>> multiply(14, -15)\n-- 20\nlocal function multiply(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "lua",
-    "prompt": "-- For a given table of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation({1.0, 2.0, 3.0, 4.0})\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "lua",
-    "prompt": "-- Return sorted unique common elements for two tables.\n-- >>> common({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121})\n-- {1, 5, 653}\n-- >>> common({5, 3, 2, 8}, {3, 2})\n-- {2, 3}\nlocal function common(l1, l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "lua",
-    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19)\n-- 'xix'\n-- >>> int_to_mini_roman(152)\n-- 'clii'\n-- >>> int_to_mini_roman(426)\n-- 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "lua",
-    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- >>> fruit_distribution('5 apples and 6 oranges', 19)\n-- 8\n-- >>> fruit_distribution('0 apples and 1 oranges', 3)\n-- 2\n-- >>> fruit_distribution('2 apples and 3 oranges', 100)\n-- 95\n-- >>> fruit_distribution('100 apples and 1 oranges', 120)\n-- 19\nlocal function fruit_distribution(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2029,7 +214,7 @@
     "language": "lua",
     "prompt": "-- Task\n-- We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n-- then check if the result string is palindrome.\n-- A string is called palindrome if it reads the same backward as forward.\n-- You should return a table containing the result string and true/false for the check.\n-- Example\n-- >>> reverse_delete('abcde', 'ae')\n-- {'bcd', false}\n-- >>> reverse_delete('abcdef', 'b')\n-- {'acdef', false}\n-- >>> reverse_delete('abcdedcba', 'ab')\n-- {'cdedc', true}\nlocal function reverse_delete(s, c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_delete\n    lu.assertEquals(candidate('abcde', 'ae'), {'bcd', false})\n    lu.assertEquals(candidate('abcdef', 'b'), {'acdef', false})\n    lu.assertEquals(candidate('abcdedcba', 'ab'), {'cdedc', true})\n    lu.assertEquals(candidate('dwik', 'w'), {'dik', false})\n    lu.assertEquals(candidate('a', 'a'), {'', true})\n    lu.assertEquals(candidate('abcdedcba', ''), {'abcdedcba', true})\n    lu.assertEquals(candidate('abcdedcba', 'v'), {'abcdedcba', true})\n    lu.assertEquals(candidate('vabba', 'v'), {'abba', true})\n    lu.assertEquals(candidate('mamma', 'mia'), {'', true})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "lua",
-    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
+    "prompt": "-- Given a table of strings, where each string consists of only digits, return a table.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count({'1234567'})\n-- {'the number of odd elements 4n the str4ng 4 of the 4nput.'}\n-- >>> odd_count({'3', '11111111'})\n-- {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'}\nlocal function odd_count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "lua",
-    "prompt": "-- Given a string of words, return a table of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- >>> split_words('Hello world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('Hello,world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('abcdef')\n-- 3\nlocal function split_words(txt)\n",
+    "prompt": "-- Given a table of integers nums, find the minimum sum of any non-empty sub-table\n-- of nums.\n-- Example\n-- >>> minSubArraySum({2, 3, 4, 1, 2, 4})\n-- 1\n-- >>> minSubArraySum({-1, -2, -3})\n-- -6\nlocal function minSubArraySum(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "lua",
+    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- >>> max_fill({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1)\n-- 6\n-- Example 2:\n-- >>> max_fill({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2)\n-- 5\n-- Example 3:\n-- >>> max_fill({{0, 0, 0}, {0, 0, 0}}, 5)\n-- 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2074,7 +274,7 @@
     "language": "lua",
     "prompt": "-- In this Kata, you have to sort a table of non-negative integers according to\n-- number of ones in their binary representation in ascending order.\n-- For similar number of ones, sort based on decimal value.\n-- It must be implemented like this:\n-- >>> sort_array({1, 5, 2, 3, 4})\n-- {1, 2, 3, 4, 5}\n-- >>> sort_array({-2, -3, -4, -5, -6})\n-- {-6, -5, -4, -3, -2}\n-- >>> sort_array({1, 0, 2, 3, 4})\n-- {0, 1, 2, 3, 4}\nlocal function sort_array(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({1, 5, 2, 3, 4}), {1, 2, 4, 3, 5})\n    lu.assertEquals(candidate({-2, -3, -4, -5, -6}), {-4, -2, -6, -5, -3})\n    lu.assertEquals(candidate({1, 0, 2, 3, 4}), {0, 1, 2, 4, 3})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), {2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77})\n    lu.assertEquals(candidate({3, 6, 44, 12, 32, 5}), {32, 3, 5, 6, 12, 44})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "lua",
-    "prompt": "-- Concatenate table of strings into a single string\n-- >>> concatenate({})\n-- ''\n-- >>> concatenate({'a', 'b', 'c'})\n-- 'abc'\nlocal function concatenate(strings)\n",
+    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a table of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty table.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- >>> select_words('Mary had a little lamb', 4)\n-- {'little'}\n-- >>> select_words('Mary had a little lamb', 3)\n-- {'Mary', 'lamb'}\n-- >>> select_words('simple white space', 2)\n-- {}\n-- >>> select_words('Hello world', 4)\n-- {'world'}\n-- >>> select_words('Uncle sam', 3)\n-- {'Uncle'}\nlocal function select_words(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a table of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted table with a sorted order,\n-- The table is always a table of strings and never a table of numbers,\n-- and it may contain duplicates.\n-- The order of the table should be ascending by length of each word, and you\n-- should return the table sorted by that rule.\n-- If two words have the same length, sort the table alphabetically.\n-- The function should return a table of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- >>> list_sort({'aa', 'a', 'aaa'})\n-- {'aa'}\n-- >>> list_sort({'ab', 'a', 'aaa', 'cd'})\n-- {'ab', 'cd'}\nlocal function sorted_list_sum(lst)\n",
+    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- >>> get_closest_vowel('yogurt')\n-- 'u'\n-- >>> get_closest_vowel('FULL')\n-- 'U'\n-- >>> get_closest_vowel('quick')\n-- ''\n-- >>> get_closest_vowel('ab')\n-- ''\nlocal function get_closest_vowel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "lua",
-    "prompt": "-- Filter an input table of strings only for ones that contain given substring\n-- >>> filter_by_substring({}, 'a')\n-- {}\n-- >>> filter_by_substring({'abc', 'bacd', 'cde', 'array'}, 'a')\n-- {'abc', 'bacd', 'array'}\nlocal function filter_by_substring(strings, substring)\n",
+    "prompt": "-- You are given a table of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- >>> match_parens({'()(', ')'})\n-- 'Yes'\n-- >>> match_parens({')', ')'})\n-- 'No'\nlocal function match_parens(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "lua",
-    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer('10')\n-- 10\n-- >>> closest_integer('15.3')\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "lua",
-    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count('abcde')\n-- 2\n-- >>> vowels_count('ACEDY')\n-- 3\nlocal function vowels_count(s)\n",
+    "prompt": "-- Given a table arr of integers and a positive integer k, return a sorted table \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- >>> maximum({-3, -4, 5}, 3)\n-- {-4, -3, 5}\n-- Example 2:\n-- >>> maximum({4, -4, 4}, 2)\n-- {4, 4}\n-- Example 3:\n-- >>> maximum({-3, 2, 1, 2, -1, -2, 1}, 1)\n-- {2}\n-- Note:\n-- 1. The length of the table will be in the range of [1, 1000].\n-- 2. The elements in the table will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a table of strings.\n-- The table contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- >>> find_max({'name', 'of', 'string'})\n-- 'string'\n-- >>> find_max({'name', 'enam', 'game'})\n-- 'enam'\n-- >>> find_max({'aaaaaaa', 'bb', 'cc'})\n-- 'aaaaaaa'\nlocal function find_max(words)\n",
+    "prompt": "-- Given a non-empty table of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- >>> solution({5, 8, 7, 1})\n-- 12\n-- >>> solution({3, 3, 3, 3, 3})\n-- 9\n-- >>> solution({30, 13, 24, 321})\n-- 0\nlocal function solution(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "lua",
-    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world')\n-- '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
+    "prompt": "-- Given a non-empty table of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- >>> add_elements({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n-- 24\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "lua",
-    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
+    "prompt": "-- Given a positive integer n, return a sorted table that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned table sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n-- >>> get_odd_collatz(5)\n-- {1, 5}\nlocal function get_odd_collatz(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return true if the three\n-- sides form a right-angled triangle, false otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- >>> right_angle_triangle(3, 4, 5)\n-- true\n-- >>> right_angle_triangle(1, 2, 3)\n-- false\nlocal function right_angle_triangle(a, b, c)\n",
+    "prompt": "-- You have to write a function which validates a given date string and\n-- returns true if the date is valid otherwise false.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- >>> valid_date('03-11-2000')\n-- true\n-- >>> valid_date('15-01-2012')\n-- false\n-- >>> valid_date('04-0-2040')\n-- false\n-- >>> valid_date('06-04-2020')\n-- true\n-- >>> valid_date('06/04/2020')\n-- false\nlocal function valid_date(date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "lua",
-    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a table of GPAs for some students and you have to write \n-- a function that can output a table of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- >>> grade_equation({4.0, 3, 1.7, 2, 3.5})\n-- {'A+', 'B', 'C-', 'C', 'A-'}\nlocal function numerical_letter_grade(grades)\n",
+    "prompt": "-- Given a string of words, return a table of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- >>> split_words('Hello world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('Hello,world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('abcdef')\n-- 3\nlocal function split_words(txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "lua",
-    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input table `numbers'\n-- >>> intersperse({}, 4)\n-- {}\n-- >>> intersperse({1, 2, 3}, 4)\n-- {1, 4, 2, 4, 3}\nlocal function intersperse(numbers, delimeter)\n",
+    "prompt": "-- Given a table of numbers, return whether or not they are sorted\n-- in ascending order. If table has more than 1 duplicate of the same\n-- number, return false. Assume no negative numbers and only integers.\n-- Examples\n-- >>> is_sorted({5})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5})\n-- false\n-- >>> is_sorted({1, 2, 3, 4, 5, 6})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5, 6, 7})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5, 6, 7})\n-- false\n-- >>> is_sorted({1, 2, 2, 3, 3, 4})\n-- true\n-- >>> is_sorted({1, 2, 2, 2, 3, 4})\n-- false\nlocal function is_sorted(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "lua",
+    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- >>> intersection({1, 2}, {2, 3})\n-- 'NO'\n-- >>> intersection({-1, 1}, {0, 4})\n-- 'NO'\n-- >>> intersection({-3, -1}, {-5, 5})\n-- 'YES'\nlocal function intersection(interval1, interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "lua",
+    "prompt": "-- You are given a table arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the table, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs({1, 2, 2, -4})\n-- 9\n-- >>> prod_signs({0, 1})\n-- 0\n-- >>> prod_signs({})\n-- None\nlocal function prod_signs(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "lua",
+    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered tables of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered table of the values on the cells that the minimum path go through.\n-- Examples:    \n-- >>> minPath({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3)\n-- {1, 2, 1}\n-- >>> minPath({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1)\n-- {1}\nlocal function minPath(grid, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "lua",
+    "prompt": "-- Out of table of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input table is empty.\n-- >>> longest({})\n-- None\n-- >>> longest({'a', 'b', 'c'})\n-- 'a'\n-- >>> longest({'a', 'bb', 'ccc'})\n-- 'ccc'\nlocal function longest(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "lua",
+    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a table of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- >>> tri(3)\n-- {1, 3, 2, 8}\nlocal function tri(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- >>> digits(1)\n-- 1\n-- >>> digits(4)\n-- 0\n-- >>> digits(235)\n-- 15\nlocal function digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return true if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- >>> is_nested('[[]]')\n-- true\n-- >>> is_nested('[]]]]]]][[[[[]')\n-- false\n-- >>> is_nested('[][]')\n-- false\n-- >>> is_nested('[]')\n-- false\n-- >>> is_nested('[[][]]')\n-- true\n-- >>> is_nested('[[]][[')\n-- true\nlocal function is_nested(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "lua",
+    "prompt": "-- You are given a table of numbers.\n-- You need to return the sum of squared numbers in the given table,\n-- round each element in the table to the upper int(Ceiling) first.\n-- Examples:\n-- >>> lst({1.0, 2.0, 3.0})\n-- 14\n-- >>> lst({1.0, 4.0, 9.0})\n-- 98\n-- >>> lst({1.0, 3.0, 5.0, 7.0})\n-- 84\n-- >>> lst({1.4, 4.2, 0.0})\n-- 29\n-- >>> lst({-2.4, 1.0, 1.0})\n-- 6\nlocal function sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "lua",
+    "prompt": "-- Create a function that returns true if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and false otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- >>> check_if_last_char_is_a_letter('apple pie')\n-- false\n-- >>> check_if_last_char_is_a_letter('apple pi e')\n-- true\n-- >>> check_if_last_char_is_a_letter('apple pi e ')\n-- false\n-- >>> check_if_last_char_is_a_letter('')\n-- false\nlocal function check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "lua",
+    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given table will not contain\n-- duplicate values.\n-- Examples:\n-- >>> can_arrange({1, 2, 4, 3, 5})\n-- 3\n-- >>> can_arrange({1, 2, 3})\n-- -1\nlocal function can_arrange(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "lua",
+    "prompt": "-- Create a function that returns a table (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a table.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- >>> largest_smallest_integers({2, 4, 1, 3, 5, 7})\n-- {None, 1}\n-- >>> largest_smallest_integers({})\n-- {None, None}\n-- >>> largest_smallest_integers({0})\n-- {None, None}\nlocal function largest_smallest_integers(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "lua",
+    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- >>> compare_one(1, 2.5)\n-- 2.5\n-- >>> compare_one(1, '2,3')\n-- '2,3'\n-- >>> compare_one('5,1', '6')\n-- '6'\n-- >>> compare_one('1', 1)\n-- None\nlocal function compare_one(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "lua",
+    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- >>> is_equal_to_sum_even(4)\n-- false\n-- >>> is_equal_to_sum_even(6)\n-- false\n-- >>> is_equal_to_sum_even(8)\n-- true\nlocal function is_equal_to_sum_even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "lua",
+    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "lua",
+    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "lua",
+    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- >>> fix_spaces(' Example')\n-- 'Example'\n-- >>> fix_spaces(' Example 1')\n-- 'Example_1'\n-- >>> fix_spaces(' Example 2')\n-- '_Example_2'\n-- >>> fix_spaces(' Example 3')\n-- '_Example-3'\nlocal function fix_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "lua",
+    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- >>> file_name_check('example.txt')\n-- 'Yes'\n-- >>> file_name_check('1example.dll')\n-- 'No'\nlocal function file_name_check(file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "lua",
+    "prompt": "-- \"\n-- This function will take a table of integers. For all entries in the table, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the table whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- >>> lst\n-- {1, 2, 3}\n-- >>> lst\n-- {}\n-- >>> lst\n-- {-1, -5, 2, -1, -5}\nlocal function sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "lua",
+    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- >>> words_in_sentence('This is a test')\n-- 'is'\n-- Example 2:\n-- >>> words_in_sentence('lets go for swimming')\n-- 'go for'\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "lua",
+    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns true if x * n evaluates to a whole number and false\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- >>> simplify('1/5', '5/1')\n-- true\n-- >>> simplify('1/6', '2/1')\n-- false\n-- >>> simplify('7/10', '10/2')\n-- false\nlocal function simplify(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "lua",
+    "prompt": "-- Write a function which sorts the given table of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original table.\n-- For example:\n-- >>> order_by_points({1, 11, -1, -11, -12})\n-- {-1, -11, 1, -12, 11}\n-- >>> order_by_points({})\n-- {}\nlocal function order_by_points(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2254,7 +769,7 @@
     "language": "lua",
     "prompt": "-- Write a function that takes a table of numbers as input and returns \n-- the number of elements in the table that are greater than 10 and both \n-- first and last digits of a number are odd (1, 3, 5, 7, 9).\n-- For example:\n-- >>> specialFilter({15, -73, 14, -15})\n-- 1\n-- >>> specialFilter({33, -2, -3, 45, 21, 109})\n-- 2\nlocal function specialFilter(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = specialFilter\n    lu.assertEquals(candidate({5, -2, 1, -5}), 0)\n    lu.assertEquals(candidate({15, -73, 14, -15}), 1)\n    lu.assertEquals(candidate({33, -2, -3, 45, 21, 109}), 2)\n    lu.assertEquals(candidate({43, -12, 93, 125, 121, 109}), 4)\n    lu.assertEquals(candidate({71, -2, -33, 75, 21, 19}), 3)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "lua",
-    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
+    "prompt": "-- You are given a positive integer n. You have to create an integer table a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- >>> get_max_triples(5)\n-- 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "lua",
-    "prompt": "-- From a table of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates({1, 2, 3, 2, 4})\n-- {1, 3, 4}\nlocal function remove_duplicates(numbers)\n",
+    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a table containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty table if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- >>> bf('Jupiter', 'Neptune')\n-- {'Saturn', 'Uranus'}\n-- >>> bf('Earth', 'Mercury')\n-- 'Venus'\n-- >>> bf('Mercury', 'Uranus')\n-- {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'}\nlocal function bf(planet1, planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a table of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted table with a sorted order,\n-- The table is always a table of strings and never a table of numbers,\n-- and it may contain duplicates.\n-- The order of the table should be ascending by length of each word, and you\n-- should return the table sorted by that rule.\n-- If two words have the same length, sort the table alphabetically.\n-- The function should return a table of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- >>> list_sort({'aa', 'a', 'aaa'})\n-- {'aa'}\n-- >>> list_sort({'ab', 'a', 'aaa', 'cd'})\n-- {'ab', 'cd'}\nlocal function sorted_list_sum(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "lua",
+    "prompt": "-- Return table of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- {'a', 'ab', 'abc'}\nlocal function all_prefixes(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "lua",
+    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- >>> x_or_y(7, 34, 12)\n-- 34\n-- >>> x_or_y(15, 8, 5)\n-- 5\nlocal function x_or_y(n, x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "lua",
+    "prompt": "-- Given a table of numbers, return the sum of squares of the numbers\n-- in the table that are odd. Ignore numbers that are negative or not integers.\n-- >>> double_the_difference({1, 3, 2, 0})\n-- 10\n-- >>> double_the_difference({-1, -2, 0})\n-- 0\n-- >>> double_the_difference({9, -2})\n-- 81\n-- >>> double_the_difference({0})\n-- 0\n-- If the input table is empty, return 0.\nlocal function double_the_difference(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "lua",
+    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two tables of scores and guesses of equal length, where each index shows a match. \n-- Return a table of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- >>> compare({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2})\n-- {0, 0, 0, 0, 3, 3}\n-- >>> compare({0, 5, 0, 0, 0, 4}, {4, 1, 1, 0, 0, -2})\n-- {4, 4, 1, 0, 0, 6}\nlocal function compare(game, guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "lua",
+    "prompt": "-- You will be given the name of a class (a string) and a table of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the table.\n-- For example, if you are given \"Slices\" as the class and a table of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- >>> Strongest_Extension('my_class', {'AA', 'Be', 'CC'})\n-- 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "lua",
+    "prompt": "-- You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n-- >>> cycpattern_check('abcd', 'abd')\n-- false\n-- >>> cycpattern_check('hello', 'ell')\n-- true\n-- >>> cycpattern_check('whassup', 'psus')\n-- false\n-- >>> cycpattern_check('abab', 'baa')\n-- true\n-- >>> cycpattern_check('efef', 'eeff')\n-- false\n-- >>> cycpattern_check('himenss', 'simen')\n-- true\nlocal function cycpattern_check(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "lua",
+    "prompt": "-- Given an integer. return a table that has the number of even and odd digits respectively.\n-- Example:\n-- >>> even_odd_count(-12)\n-- {1, 1}\n-- >>> even_odd_count(123)\n-- {1, 2}\nlocal function even_odd_count(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "lua",
+    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19)\n-- 'xix'\n-- >>> int_to_mini_roman(152)\n-- 'clii'\n-- >>> int_to_mini_roman(426)\n-- 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return true if the three\n-- sides form a right-angled triangle, false otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- >>> right_angle_triangle(3, 4, 5)\n-- true\n-- >>> right_angle_triangle(1, 2, 3)\n-- false\nlocal function right_angle_triangle(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a table of strings.\n-- The table contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- >>> find_max({'name', 'of', 'string'})\n-- 'string'\n-- >>> find_max({'name', 'enam', 'game'})\n-- 'enam'\n-- >>> find_max({'aaaaaaa', 'bb', 'cc'})\n-- 'aaaaaaa'\nlocal function find_max(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "lua",
+    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return a table of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- >>> eat(5, 6, 10)\n-- {11, 4}\n-- >>> eat(4, 8, 9)\n-- {12, 1}\n-- >>> eat(1, 10, 10)\n-- {11, 0}\n-- >>> eat(2, 11, 5)\n-- {7, 0}\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "lua",
+    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "lua",
+    "prompt": "-- Given two tables operator, and operand. The first table has basic algebra operations, and \n-- the second table is a table of integers. Use the two given tables to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- table = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator table is equal to the length of operand table minus one.\n-- Operand is a table of of non-negative integers.\n-- Operator table has at least one operator, and operand table has at least two operands.\nlocal function do_algebra(operator, operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- >>> solve('1234')\n-- '4321'\n-- >>> solve('ab')\n-- 'AB'\n-- >>> solve('#a@C')\n-- '#A@c'\nlocal function solve(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "lua",
+    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world')\n-- '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2299,7 +1054,7 @@
     "language": "lua",
     "prompt": "-- Given two positive integers a and b, return the even digits between a\n-- and b, in ascending order.\n-- For example:\n-- >>> generate_integers(2, 8)\n-- {2, 4, 6, 8}\n-- >>> generate_integers(8, 2)\n-- {2, 4, 6, 8}\n-- >>> generate_integers(10, 14)\n-- {}\nlocal function generate_integers(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = generate_integers\n    lu.assertEquals(candidate(2, 10), {2, 4, 6, 8})\n    lu.assertEquals(candidate(10, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(132, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(17, 89), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "lua",
-    "prompt": "-- From a given table of integers, generate a table of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max({1, 2, 3, 2, 3, 4, 2})\n-- {1, 2, 3, 3, 3, 4, 4}\nlocal function rolling_max(numbers)\n",
+    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\n-- >>> count_distinct_characters('xyzXYZ')\n-- 3\n-- >>> count_distinct_characters('Jerry')\n-- 4\nlocal function count_distinct_characters(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "lua",
-    "prompt": "-- You're given a table of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return true. Otherwise it should return false.\n-- >>> below_zero({1, 2, 3})\n-- false\n-- >>> below_zero({1, 2, -4, 5})\n-- true\nlocal function below_zero(operations)\n",
+    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return table of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- {4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nlocal function parse_music(music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "lua",
-    "prompt": "-- You are given a non-empty table of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the table.\n-- If no such a value exist, return -1.\n-- Examples:\n-- >>> search({4, 1, 2, 2, 3, 1})\n-- 2\n-- >>> search({1, 2, 2, 3, 3, 3, 4, 4, 4})\n-- 3\n-- >>> search({5, 5, 4, 4, 4})\n-- -1\nlocal function search(lst)\n",
+    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "lua",
-    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return true if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('(')\n-- false\n-- >>> correct_bracketing('()')\n-- true\n-- >>> correct_bracketing('(()())')\n-- true\n-- >>> correct_bracketing(')(()')\n-- false\nlocal function correct_bracketing(brackets)\n",
+    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the table of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- {'()', '(())', '(()())'}\nlocal function separate_paren_groups(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "lua",
+    "prompt": "-- From a supplied table of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n-- {2.0, 2.2}\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n-- {2.0, 2.0}\nlocal function find_closest_elements(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "lua",
+    "prompt": "-- Given table of numbers (of at least two elements), apply a linear transform to that table,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit({1.0, 2.0, 3.0, 4.0, 5.0})\n-- {0.0, 0.25, 0.5, 0.75, 1.0}\nlocal function rescale_to_unit(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "lua",
+    "prompt": "-- Filter given table of any luathon values only for integers\n-- >>> filter_integers({'a', 3.14, 5})\n-- {5}\n-- >>> filter_integers({1, 2, 3, 'abc', {}, {}})\n-- {1, 2, 3}\nlocal function filter_integers(values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "lua",
+    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "lua",
+    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "lua",
+    "prompt": "-- Return table of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be tableed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- {2, 2, 2}\n-- >>> factorize(25)\n-- {5, 5}\n-- >>> factorize(70)\n-- {2, 5, 7}\nlocal function factorize(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "lua",
+    "prompt": "-- From a table of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates({1, 2, 3, 2, 4})\n-- {1, 3, 4}\nlocal function remove_duplicates(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "lua",
+    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "lua",
+    "prompt": "-- Concatenate table of strings into a single string\n-- >>> concatenate({})\n-- ''\n-- >>> concatenate({'a', 'b', 'c'})\n-- 'abc'\nlocal function concatenate(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "lua",
+    "prompt": "-- Filter an input table of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix({}, 'a')\n-- {}\n-- >>> filter_by_prefix({'abc', 'bcd', 'cde', 'array'}, 'a')\n-- {'abc', 'array'}\nlocal function filter_by_prefix(strings, prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "lua",
+    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "lua",
+    "prompt": "-- Return only positive numbers in the table.\n-- >>> get_positive({-1, 2, -4, 5, 6})\n-- {2, 5, 6}\n-- >>> get_positive({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- {5, 3, 2, 3, 9, 123, 1}\nlocal function get_positive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "lua",
+    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- false\n-- >>> is_prime(101)\n-- true\n-- >>> is_prime(11)\n-- true\n-- >>> is_prime(13441)\n-- true\n-- >>> is_prime(61)\n-- true\n-- >>> is_prime(4)\n-- false\n-- >>> is_prime(1)\n-- false\nlocal function is_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "lua",
+    "prompt": "-- This function takes a table l and returns a table l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_third({5, 6, 3, 4, 8, 9, 2})\n-- {2, 6, 3, 4, 8, 9, 5}\nlocal function sort_third(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "lua",
+    "prompt": "-- Return sorted unique elements in a table\n-- >>> unique({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {0, 2, 3, 5, 9, 123}\nlocal function unique(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "lua",
+    "prompt": "-- Return maximum element in the table.\n-- >>> max_element({1, 2, 3})\n-- 3\n-- >>> max_element({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- 123\nlocal function max_element(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "lua",
+    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2374,9 +1399,249 @@
     "language": "lua",
     "prompt": "-- This function takes a table l and returns a table l' such that\n-- l' is identical to l in the odd indicies, while its values at the even indicies are equal\n-- to the values of the even indicies of l, but sorted.\n-- >>> sort_even({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_even({5, 6, 3, 4})\n-- {3, 6, 5, 4}\nlocal function sort_even(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_even\n    lu.assertEquals(candidate({1, 2, 3}), {1, 2, 3})\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), {-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123})\n    lu.assertEquals(candidate({5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), {-12, 8, 3, 4, 5, 2, 12, 11, 23, -10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "lua",
+    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "lua",
+    "prompt": "-- You're given a table of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return true. Otherwise it should return false.\n-- >>> below_zero({1, 2, 3})\n-- false\n-- >>> below_zero({1, 2, -4, 5})\n-- true\nlocal function below_zero(operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- triples_sum_to_zero takes a table of integers as an input.\n-- it returns true if there are three distinct elements in the table that\n-- sum to zero, and false otherwise.\n-- >>> triples_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> triples_sum_to_zero({1, 3, -2, 1})\n-- true\n-- >>> triples_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> triples_sum_to_zero({2, 4, -5, 3, 9, 7})\n-- true\n-- >>> triples_sum_to_zero({1})\n-- false\nlocal function triples_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "lua",
+    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "lua",
+    "prompt": "-- Return table with elements incremented by 1.\n-- >>> incr_list({1, 2, 3})\n-- {2, 3, 4}\n-- >>> incr_list({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {6, 4, 6, 3, 4, 4, 10, 1, 124}\nlocal function incr_list(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- pairs_sum_to_zero takes a table of integers as an input.\n-- it returns true if there are two distinct elements in the table that\n-- sum to zero, and false otherwise.\n-- >>> pairs_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> pairs_sum_to_zero({1, 3, -2, 1})\n-- false\n-- >>> pairs_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> pairs_sum_to_zero({2, 4, -5, 3, 5, 7})\n-- true\n-- >>> pairs_sum_to_zero({1})\n-- false\nlocal function pairs_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "lua",
+    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "lua",
+    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "lua",
+    "prompt": "-- Return median of elements in the table l.\n-- >>> median({3, 1, 2, 4, 5})\n-- 3\n-- >>> median({-10, 4, 6, 1000, 10, 20})\n-- 15.0\nlocal function median(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "lua",
+    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- true\n-- >>> is_palindrome('aba')\n-- true\n-- >>> is_palindrome('aaaaa')\n-- true\n-- >>> is_palindrome('zbcd')\n-- false\nlocal function is_palindrome(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "lua",
+    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "lua",
+    "prompt": "-- For a given table of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation({1.0, 2.0, 3.0, 4.0})\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "lua",
+    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "lua",
+    "prompt": "-- Return true if all numbers in the table l are below threshold t.\n-- >>> below_threshold({1, 2, 4, 10}, 100)\n-- true\n-- >>> below_threshold({1, 20, 4, 10}, 5)\n-- false\nlocal function below_threshold(l, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "lua",
+    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2389,9 +1654,24 @@
     "language": "lua",
     "prompt": "-- Check if two words have the same characters.\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n-- true\n-- >>> same_chars('abcd', 'dddddddabc')\n-- true\n-- >>> same_chars('dddddddabc', 'abcd')\n-- true\n-- >>> same_chars('eabcd', 'dddddddabc')\n-- false\n-- >>> same_chars('abcd', 'dddddddabce')\n-- false\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n-- false\nlocal function same_chars(s0, s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = same_chars\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), true)\n    lu.assertEquals(candidate('abcd', 'dddddddabc'), true)\n    lu.assertEquals(candidate('dddddddabc', 'abcd'), true)\n    lu.assertEquals(candidate('eabcd', 'dddddddabc'), false)\n    lu.assertEquals(candidate('abcd', 'dddddddabcf'), false)\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), false)\n    lu.assertEquals(candidate('aabb', 'aaccc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "lua",
+    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2404,9 +1684,729 @@
     "language": "lua",
     "prompt": "-- brackets is a string of \"<\" and \">\".\n-- return true if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('<')\n-- false\n-- >>> correct_bracketing('<>')\n-- true\n-- >>> correct_bracketing('<<><>>')\n-- true\n-- >>> correct_bracketing('><<>')\n-- false\nlocal function correct_bracketing(brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('<>'), true)\n    lu.assertEquals(candidate('<<><>>'), true)\n    lu.assertEquals(candidate('<><><<><>><>'), true)\n    lu.assertEquals(candidate('<><><<<><><>><>><<><><<>>>'), true)\n    lu.assertEquals(candidate('<<<><>>>>'), false)\n    lu.assertEquals(candidate('><<>'), false)\n    lu.assertEquals(candidate('<'), false)\n    lu.assertEquals(candidate('<<<<'), false)\n    lu.assertEquals(candidate('>'), false)\n    lu.assertEquals(candidate('<<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>><<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>>><>'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "lua",
+    "prompt": "-- Return true is table elements are monotonically increasing or decreasing.\n-- >>> monotonic({1, 2, 4, 20})\n-- true\n-- >>> monotonic({1, 20, 4, 10})\n-- false\n-- >>> monotonic({4, 1, 0, -10})\n-- true\nlocal function monotonic(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "lua",
+    "prompt": "-- Return sorted unique common elements for two tables.\n-- >>> common({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121})\n-- {1, 5, 653}\n-- >>> common({5, 3, 2, 8}, {3, 2})\n-- {2, 3}\nlocal function common(l1, l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "lua",
+    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "lua",
+    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input table `numbers'\n-- >>> intersperse({}, 4)\n-- {}\n-- >>> intersperse({1, 2, 3}, 4)\n-- {1, 4, 2, 4, 3}\nlocal function intersperse(numbers, delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "lua",
+    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "lua",
+    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return true if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('(')\n-- false\n-- >>> correct_bracketing('()')\n-- true\n-- >>> correct_bracketing('(()())')\n-- true\n-- >>> correct_bracketing(')(()')\n-- false\nlocal function correct_bracketing(brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "lua",
+    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative({3, 1, 2, 4, 5})\n-- {1, 4, 12, 20}\n-- >>> derivative({1, 2, 3})\n-- {2, 6}\nlocal function derivative(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "lua",
+    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "lua",
+    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count('abcde')\n-- 2\n-- >>> vowels_count('ACEDY')\n-- 3\nlocal function vowels_count(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "lua",
+    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- '21'\n-- >>> circular_shift(12, 2)\n-- '12'\nlocal function circular_shift(x, shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "lua",
+    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- >>> digitSum('')\n-- 0\n-- >>> digitSum('abAB')\n-- 131\n-- >>> digitSum('abcCd')\n-- 67\n-- >>> digitSum('helloE')\n-- 69\n-- >>> digitSum('woArBld')\n-- 131\n-- >>> digitSum('aAaaaXa')\n-- 153\nlocal function digitSum(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "lua",
+    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- >>> fruit_distribution('5 apples and 6 oranges', 19)\n-- 8\n-- >>> fruit_distribution('0 apples and 1 oranges', 3)\n-- 2\n-- >>> fruit_distribution('2 apples and 3 oranges', 100)\n-- 95\n-- >>> fruit_distribution('100 apples and 1 oranges', 120)\n-- 19\nlocal function fruit_distribution(s, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "lua",
+    "prompt": "-- \"Given a table representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a table, [ smalest_value, its index ],\n-- If there are no even values or the given table is empty, return [].\n-- Example 1:\n-- >>> pluck({4, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- >>> pluck({1, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- >>> pluck({})\n-- {}\n-- Example 4:\n-- >>> pluck({5, 0, 3, 0, 4, 2})\n-- {0, 1}\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "lua",
+    "prompt": "-- You are given a non-empty table of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the table.\n-- If no such a value exist, return -1.\n-- Examples:\n-- >>> search({4, 1, 2, 2, 3, 1})\n-- 2\n-- >>> search({1, 2, 2, 3, 3, 3, 4, 4, 4})\n-- 3\n-- >>> search({5, 5, 4, 4, 4})\n-- -1\nlocal function search(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- {2, 3, 1, 3}\nlocal function parse_nested_parens(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "lua",
+    "prompt": "-- Given table of integers, return table in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- >>> strange_sort_list({1, 2, 3, 4})\n-- {1, 4, 2, 3}\n-- >>> strange_sort_list({5, 5, 5, 5})\n-- {5, 5, 5, 5}\n-- >>> strange_sort_list({})\n-- {}\nlocal function strange_sort_list(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- >>> triangle_area(3, 4, 5)\n-- 6.0\n-- >>> triangle_area(1, 2, 10)\n-- -1\nlocal function triangle_area(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "lua",
+    "prompt": "-- Write a function that returns true if the object q will fly, and false otherwise.\n-- The object q will fly if it's balanced (it is a palindromic table) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- >>> will_it_fly({1, 2}, 5)\n-- false\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- >>> will_it_fly({3, 2, 3}, 1)\n-- false\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- >>> will_it_fly({3, 2, 3}, 9)\n-- true\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- >>> will_it_fly({3}, 5)\n-- true\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "lua",
+    "prompt": "-- Given a table arr of integers, find the minimum number of elements that\n-- need to be changed to make the table palindromic. A palindromic table is a table that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- >>> smallest_change({1, 2, 3, 5, 4, 7, 9, 6})\n-- 4\n-- >>> smallest_change({1, 2, 3, 4, 3, 2, 2})\n-- 1\n-- >>> smallest_change({1, 2, 3, 2, 1})\n-- 0\nlocal function smallest_change(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts two tables of strings and returns the table that has \n-- total number of chars in the all strings of the table less than the other table.\n-- if the two tables have the same number of chars, return the first table.\n-- Examples\n-- >>> total_match({}, {})\n-- {}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'Hi'})\n-- {'hI', 'Hi'}\n-- >>> total_match({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'})\n-- {'hi', 'admin'}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'hi', 'hi'})\n-- {'hI', 'hi', 'hi'}\n-- >>> total_match({'4'}, {'1', '2', '3', '4', '5'})\n-- {'4'}\nlocal function total_match(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "lua",
+    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- >>> is_multiply_prime(30)\n-- true\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "lua",
+    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- >>> is_simple_power(1, 4)\n-- true\n-- >>> is_simple_power(2, 2)\n-- true\n-- >>> is_simple_power(8, 2)\n-- true\n-- >>> is_simple_power(3, 2)\n-- false\n-- >>> is_simple_power(3, 1)\n-- false\n-- >>> is_simple_power(5, 3)\n-- false\nlocal function is_simple_power(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an integer a and returns true \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- >>> iscube(1)\n-- true\n-- >>> iscube(2)\n-- false\n-- >>> iscube(-1)\n-- true\n-- >>> iscube(64)\n-- true\n-- >>> iscube(0)\n-- true\n-- >>> iscube(180)\n-- false\nlocal function iscube(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "lua",
+    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- >>> hex_key('AB')\n-- 1\n-- >>> hex_key('1077E')\n-- 2\n-- >>> hex_key('ABED1A33')\n-- 4\n-- >>> hex_key('123456789ABCDEF0')\n-- 6\n-- >>> hex_key('2020')\n-- 2\nlocal function hex_key(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- >>> decimal_to_binary(15)\n-- 'db1111db'\n-- >>> decimal_to_binary(32)\n-- 'db100000db'\nlocal function decimal_to_binary(decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "lua",
+    "prompt": "-- Filter an input table of strings only for ones that contain given substring\n-- >>> filter_by_substring({}, 'a')\n-- {}\n-- >>> filter_by_substring({'abc', 'bacd', 'cde', 'array'}, 'a')\n-- {'abc', 'bacd', 'array'}\nlocal function filter_by_substring(strings, substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is haplua or not.\n-- A string is haplua if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- >>> is_happy('a')\n-- false\n-- >>> is_happy('aa')\n-- false\n-- >>> is_happy('abcd')\n-- true\n-- >>> is_happy('aabb')\n-- false\n-- >>> is_happy('adb')\n-- true\n-- >>> is_happy('xyy')\n-- false\nlocal function is_happy(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "lua",
+    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a table of GPAs for some students and you have to write \n-- a function that can output a table of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- >>> grade_equation({4.0, 3, 1.7, 2, 3.5})\n-- {'A+', 'B', 'C-', 'C', 'A-'}\nlocal function numerical_letter_grade(grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns true if the string\n-- length is a prime number or false otherwise\n-- Examples\n-- >>> prime_length('Hello')\n-- true\n-- >>> prime_length('abcdcba')\n-- true\n-- >>> prime_length('kittens')\n-- true\n-- >>> prime_length('orange')\n-- false\nlocal function prime_length(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "lua",
+    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- >>> solve(1000)\n-- '1'\n-- >>> solve(150)\n-- '110'\n-- >>> solve(147)\n-- '1100'\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "lua",
+    "prompt": "-- Given a non-empty table of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- >>> add({4, 2, 6, 7})\n-- 2\nlocal function add(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- >>> anti_shuffle('Hi')\n-- 'Hi'\n-- >>> anti_shuffle('hello')\n-- 'ehllo'\n-- >>> anti_shuffle('Hello World!!!')\n-- 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "lua",
+    "prompt": "-- You are given a 2 dimensional data, as a nested tables,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the table,\n-- and return table of tables, [(x1, y1), (x2, y2) ...] such that\n-- each table is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- >>> get_row({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1)\n-- {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}}\n-- >>> get_row({}, 1)\n-- {}\n-- >>> get_row({{}, {1}, {1, 2, 3}}, 3)\n-- {{2, 2}}\nlocal function get_row(lst, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "lua",
+    "prompt": "-- Given a table of non-negative integers, return a colua of the given table after sorting,\n-- you will sort the given table in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given table.\n-- Examples:\n-- >>> sort_array({})\n-- {}\n-- >>> sort_array({5})\n-- {5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5})\n-- {0, 1, 2, 3, 4, 5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5, 6})\n-- {6, 5, 4, 3, 2, 1, 0}\nlocal function sort_array(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "lua",
+    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- >>> encrypt('hi')\n-- 'lm'\n-- >>> encrypt('asdfghjkl')\n-- 'ewhjklnop'\n-- >>> encrypt('gf')\n-- 'kj'\n-- >>> encrypt('et')\n-- 'ix'\nlocal function encrypt(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "lua",
+    "prompt": "-- For a given table of integers, return a table consisting of a sum and a product of all the integers in a table.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product({})\n-- {0, 1}\n-- >>> sum_product({1, 2, 3, 4})\n-- {10, 24}\nlocal function sum_product(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "lua",
+    "prompt": "-- You are given a table of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the table.\n-- Return None if there is no such element.\n-- >>> next_smallest({1, 2, 3, 4, 5})\n-- 2\n-- >>> next_smallest({5, 1, 4, 3, 2})\n-- 2\n-- >>> next_smallest({})\n-- None\n-- >>> next_smallest({1, 1})\n-- None\nlocal function next_smallest(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "lua",
+    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored('Hello world')\n-- 0\n-- >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n-- 1\nlocal function is_bored(S)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "lua",
+    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- >>> any_int(5, 2, 7)\n-- true\n-- >>> any_int(3, 2, 2)\n-- false\n-- >>> any_int(3, -2, 1)\n-- true\n-- >>> any_int(3.6, -2.2, 2)\n-- false\nlocal function any_int(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "lua",
+    "prompt": "-- You are given a table of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- >>> skjkasdkd({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n-- 10\n-- >>> skjkasdkd({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n-- 25\n-- >>> skjkasdkd({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n-- 13\n-- >>> skjkasdkd({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n-- 11\n-- >>> skjkasdkd({0, 81, 12, 3, 1, 21})\n-- 3\n-- >>> skjkasdkd({0, 8, 1, 2, 1, 7})\n-- 7\nlocal function skjkasdkd(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "lua",
+    "prompt": "-- Given a table, return true if all keys are strings in lower \n-- case or all keys are strings in upper case, else return false.\n-- The function should return false is the given table is empty.\n-- Examples:\n-- >>> check_dict_case({['a'] = 'apple', ['b'] = 'banana'})\n-- true\n-- >>> check_dict_case({['a'] = 'apple', ['A'] = 'banana', ['B'] = 'banana'})\n-- false\n-- >>> check_dict_case({['a'] = 'apple', [8] = 'banana', ['a'] = 'apple'})\n-- false\n-- >>> check_dict_case({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'})\n-- false\n-- >>> check_dict_case({['STATE'] = 'NC', ['ZIP'] = '12345'})\n-- true\nlocal function check_dict_case(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "lua",
+    "prompt": "-- Implement a function that takes an non-negative integer and returns a table of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- >>> count_up_to(5)\n-- {2, 3}\n-- >>> count_up_to(11)\n-- {2, 3, 5, 7}\n-- >>> count_up_to(0)\n-- {}\n-- >>> count_up_to(20)\n-- {2, 3, 5, 7, 11, 13, 17, 19}\n-- >>> count_up_to(1)\n-- {}\n-- >>> count_up_to(18)\n-- {2, 3, 5, 7, 11, 13, 17}\nlocal function count_up_to(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "lua",
+    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- >>> multiply(148, 412)\n-- 16\n-- >>> multiply(19, 28)\n-- 72\n-- >>> multiply(2020, 1851)\n-- 0\n-- >>> multiply(14, -15)\n-- 20\nlocal function multiply(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "lua",
+    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- >>> count_upper('aBCdEf')\n-- 1\n-- >>> count_upper('abcdefg')\n-- 0\n-- >>> count_upper('dBBE')\n-- 0\nlocal function count_upper(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer('10')\n-- 10\n-- >>> closest_integer('15.3')\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "lua",
+    "prompt": "-- From a given table of integers, generate a table of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max({1, 2, 3, 2, 3, 4, 2})\n-- {1, 2, 3, 3, 3, 4, 4}\nlocal function rolling_max(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/humaneval-lua-transform.json
+++ b/prompts/humaneval-lua-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "lua",
-    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "lua",
-    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- >>> encrypt('hi')\n-- 'lm'\n-- >>> encrypt('asdfghjkl')\n-- 'ewhjklnop'\n-- >>> encrypt('gf')\n-- 'kj'\n-- >>> encrypt('et')\n-- 'ix'\nlocal function encrypt(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "lua",
-    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\n-- >>> check_dict_case({['a'] = 'apple', ['b'] = 'banana'})\n-- true\n-- >>> check_dict_case({['a'] = 'apple', ['A'] = 'banana', ['B'] = 'banana'})\n-- false\n-- >>> check_dict_case({['a'] = 'apple', [8] = 'banana', ['a'] = 'apple'})\n-- false\n-- >>> check_dict_case({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'})\n-- false\n-- >>> check_dict_case({['STATE'] = 'NC', ['ZIP'] = '12345'})\n-- true\nlocal function check_dict_case(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- >>> add({4, 2, 6, 7})\n-- 2\nlocal function add(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "lua",
-    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- >>> fix_spaces(' Example')\n-- 'Example'\n-- >>> fix_spaces(' Example 1')\n-- 'Example_1'\n-- >>> fix_spaces(' Example 2')\n-- '_Example_2'\n-- >>> fix_spaces(' Example 3')\n-- '_Example-3'\nlocal function fix_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "lua",
-    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- >>> double_the_difference({1, 3, 2, 0})\n-- 10\n-- >>> double_the_difference({-1, -2, 0})\n-- 0\n-- >>> double_the_difference({9, -2})\n-- 81\n-- >>> double_the_difference({0})\n-- 0\n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "lua",
-    "prompt": "-- Filter given list of any python values only for integers\n-- >>> filter_integers({'a', 3.14, 5})\n-- {5}\n-- >>> filter_integers({1, 2, 3, 'abc', {}, {}})\n-- {1, 2, 3}\nlocal function filter_integers(values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "lua",
-    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- {4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nlocal function parse_music(music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- >>> decimal_to_binary(15)\n-- 'db1111db'\n-- >>> decimal_to_binary(32)\n-- 'db100000db'\nlocal function decimal_to_binary(decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "lua",
-    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- {'a', 'ab', 'abc'}\nlocal function all_prefixes(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "lua",
-    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "lua",
-    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- >>> eat(5, 6, 10)\n-- {11, 4}\n-- >>> eat(4, 8, 9)\n-- {12, 1}\n-- >>> eat(1, 10, 10)\n-- {11, 0}\n-- >>> eat(2, 11, 5)\n-- {7, 0}\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "lua",
-    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- >>> max_fill({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1)\n-- 6\n-- Example 2:\n-- >>> max_fill({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2)\n-- 5\n-- Example 3:\n-- >>> max_fill({{0, 0, 0}, {0, 0, 0}}, 5)\n-- 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "lua",
-    "prompt": "-- Given two lists operator, and operand. The first list has basic algebra operations, and \n-- the second list is a list of integers. Use the two given lists to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- array = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator list is equal to the length of operand list minus one.\n-- Operand is a list of of non-negative integers.\n-- Operator list has at least one operator, and operand list has at least two operands.\nlocal function do_algebra(operator, operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "lua",
-    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "lua",
-    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- >>> by_length({2, 1, 1, 4, 5, 8, 2, 3})\n-- {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'}\n-- If the array is empty, return an empty array:\n-- >>> by_length({})\n-- {}\n-- If the array has any strange number ignore it:\n-- >>> by_length({1, -1, 55})\n-- {'One'}\nlocal function by_length(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "lua",
-    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- {2, 2, 2}\n-- >>> factorize(25)\n-- {5, 5}\n-- >>> factorize(70)\n-- {2, 5, 7}\nlocal function factorize(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "lua",
-    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- >>> count_up_to(5)\n-- {2, 3}\n-- >>> count_up_to(11)\n-- {2, 3, 5, 7}\n-- >>> count_up_to(0)\n-- {}\n-- >>> count_up_to(20)\n-- {2, 3, 5, 7, 11, 13, 17, 19}\n-- >>> count_up_to(1)\n-- {}\n-- >>> count_up_to(18)\n-- {2, 3, 5, 7, 11, 13, 17}\nlocal function count_up_to(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "lua",
-    "prompt": "-- Return sorted unique elements in a list\n-- >>> unique({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {0, 2, 3, 5, 9, 123}\nlocal function unique(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "lua",
-    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\n-- >>> total_match({}, {})\n-- {}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'Hi'})\n-- {'hI', 'Hi'}\n-- >>> total_match({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'})\n-- {'hi', 'admin'}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'hi', 'hi'})\n-- {'hI', 'hi', 'hi'}\n-- >>> total_match({'4'}, {'1', '2', '3', '4', '5'})\n-- {'4'}\nlocal function total_match(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "lua",
-    "prompt": "-- Return maximum element in the list.\n-- >>> max_element({1, 2, 3})\n-- 3\n-- >>> max_element({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- 123\nlocal function max_element(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "lua",
-    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- >>> is_nested('[[]]')\n-- true\n-- >>> is_nested('[]]]]]]][[[[[]')\n-- false\n-- >>> is_nested('[][]')\n-- false\n-- >>> is_nested('[]')\n-- false\n-- >>> is_nested('[[][]]')\n-- true\n-- >>> is_nested('[[]][[')\n-- true\nlocal function is_nested(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "lua",
-    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- >>> rounded_avg(1, 5)\n-- '0b11'\n-- >>> rounded_avg(7, 5)\n-- -1\n-- >>> rounded_avg(10, 20)\n-- '0b1111'\n-- >>> rounded_avg(20, 33)\n-- '0b11010'\nlocal function rounded_avg(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "lua",
-    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count({'1234567'})\n-- {'the number of odd elements 4n the str4ng 4 of the 4nput.'}\n-- >>> odd_count({'3', '11111111'})\n-- {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'}\nlocal function odd_count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "lua",
-    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- >>> move_one_ball({3, 4, 5, 1, 2})\n-- true\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- >>> move_one_ball({3, 5, 4, 1, 2})\n-- false\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- >>> even_odd_palindrome(3)\n-- {1, 2}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- >>> even_odd_palindrome(12)\n-- {4, 6}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "lua",
-    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- >>> is_equal_to_sum_even(4)\n-- false\n-- >>> is_equal_to_sum_even(6)\n-- false\n-- >>> is_equal_to_sum_even(8)\n-- true\nlocal function is_equal_to_sum_even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "lua",
-    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative({3, 1, 2, 4, 5})\n-- {1, 4, 12, 20}\n-- >>> derivative({1, 2, 3})\n-- {2, 6}\nlocal function derivative(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "lua",
-    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\n-- >>> is_sorted({5})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5})\n-- false\n-- >>> is_sorted({1, 2, 3, 4, 5, 6})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5, 6, 7})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5, 6, 7})\n-- false\n-- >>> is_sorted({1, 2, 2, 3, 3, 4})\n-- true\n-- >>> is_sorted({1, 2, 2, 2, 3, 4})\n-- false\nlocal function is_sorted(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- >>> solve('1234')\n-- '4321'\n-- >>> solve('ab')\n-- 'AB'\n-- >>> solve('#a@C')\n-- '#A@c'\nlocal function solve(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "lua",
-    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- >>> tri(3)\n-- {1, 3, 2, 8}\nlocal function tri(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "lua",
-    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix({}, 'a')\n-- {}\n-- >>> filter_by_prefix({'abc', 'bcd', 'cde', 'array'}, 'a')\n-- {'abc', 'array'}\nlocal function filter_by_prefix(strings, prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "lua",
-    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- >>> solve(1000)\n-- '1'\n-- >>> solve(150)\n-- '110'\n-- >>> solve(147)\n-- '1100'\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "lua",
-    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:    \n-- >>> minPath({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3)\n-- {1, 2, 1}\n-- >>> minPath({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1)\n-- {1}\nlocal function minPath(grid, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "lua",
-    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- >>> count_upper('aBCdEf')\n-- 1\n-- >>> count_upper('abcdefg')\n-- 0\n-- >>> count_upper('dBBE')\n-- 0\nlocal function count_upper(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- >>> maximum({-3, -4, 5}, 3)\n-- {-4, -3, 5}\n-- Example 2:\n-- >>> maximum({4, -4, 4}, 2)\n-- {4, 4}\n-- Example 3:\n-- >>> maximum({-3, 2, 1, 2, -1, -2, 1}, 1)\n-- {2}\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "lua",
-    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "lua",
-    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\n-- >>> sort_array({})\n-- {}\n-- >>> sort_array({5})\n-- {5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5})\n-- {0, 1, 2, 3, 4, 5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5, 6})\n-- {6, 5, 4, 3, 2, 1, 0}\nlocal function sort_array(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "lua",
-    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- >>> f(5)\n-- {1, 2, 6, 24, 15}\nlocal function f(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "lua",
-    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- >>> iscube(1)\n-- true\n-- >>> iscube(2)\n-- false\n-- >>> iscube(-1)\n-- true\n-- >>> iscube(64)\n-- true\n-- >>> iscube(0)\n-- true\n-- >>> iscube(180)\n-- false\nlocal function iscube(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "lua",
-    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored('Hello world')\n-- 0\n-- >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n-- 1\nlocal function is_bored(S)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> pairs_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> pairs_sum_to_zero({1, 3, -2, 1})\n-- false\n-- >>> pairs_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> pairs_sum_to_zero({2, 4, -5, 3, 5, 7})\n-- true\n-- >>> pairs_sum_to_zero({1})\n-- false\nlocal function pairs_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- >>> triangle_area(3, 4, 5)\n-- 6.0\n-- >>> triangle_area(1, 2, 10)\n-- -1\nlocal function triangle_area(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "lua",
-    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- >>> bf('Jupiter', 'Neptune')\n-- {'Saturn', 'Uranus'}\n-- >>> bf('Earth', 'Mercury')\n-- 'Venus'\n-- >>> bf('Mercury', 'Uranus')\n-- {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'}\nlocal function bf(planet1, planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- >>> digits(1)\n-- 1\n-- >>> digits(4)\n-- 0\n-- >>> digits(235)\n-- 15\nlocal function digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "lua",
-    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\n-- >>> words_string('Hi, my name is John')\n-- {'Hi', 'my', 'name', 'is', 'John'}\n-- >>> words_string('One, two, three, four, five, six')\n-- {'One', 'two', 'three', 'four', 'five', 'six'}\nlocal function words_string(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "lua",
-    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "lua",
-    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- >>> compare_one(1, 2.5)\n-- 2.5\n-- >>> compare_one(1, '2,3')\n-- '2,3'\n-- >>> compare_one('5,1', '6')\n-- '6'\n-- >>> compare_one('1', 1)\n-- None\nlocal function compare_one(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "lua",
-    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "lua",
-    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- >>> strange_sort_list({1, 2, 3, 4})\n-- {1, 4, 2, 3}\n-- >>> strange_sort_list({5, 5, 5, 5})\n-- {5, 5, 5, 5}\n-- >>> strange_sort_list({})\n-- {}\nlocal function strange_sort_list(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "lua",
-    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n-- {2.0, 2.2}\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n-- {2.0, 2.0}\nlocal function find_closest_elements(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "lua",
-    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- >>> is_simple_power(1, 4)\n-- true\n-- >>> is_simple_power(2, 2)\n-- true\n-- >>> is_simple_power(8, 2)\n-- true\n-- >>> is_simple_power(3, 2)\n-- false\n-- >>> is_simple_power(3, 1)\n-- false\n-- >>> is_simple_power(5, 3)\n-- false\nlocal function is_simple_power(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "lua",
-    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "lua",
-    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\n-- >>> order_by_points({1, 11, -1, -11, -12})\n-- {-1, -11, 1, -12, 11}\n-- >>> order_by_points({})\n-- {}\nlocal function order_by_points(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "lua",
     "prompt": "-- Check if in given list of numbers, are any two numbers closer to each other than\n-- given threshold.\n-- >>> has_close_elements({1.0, 2.0, 3.0}, 0.5)\n-- false\n-- >>> has_close_elements({1.0, 2.8, 3.0, 4.0, 5.0, 2.0}, 0.3)\n-- true\nlocal function has_close_elements(numbers, threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = has_close_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.3), true)\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}, 0.05), false)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.95), true)\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}, 0.8), false)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}, 0.1), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 1.0), true)\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}, 0.5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "lua",
-    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "lua",
-    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "lua",
-    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "lua",
-    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- >>> add_elements({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n-- 24\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "lua",
-    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "lua",
-    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits({15, 33, 1422, 1})\n-- {1, 15, 33}\n-- >>> unique_digits({152, 323, 1422, 10})\n-- {}\nlocal function unique_digits(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "lua",
-    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- >>> select_words('Mary had a little lamb', 4)\n-- {'little'}\n-- >>> select_words('Mary had a little lamb', 3)\n-- {'Mary', 'lamb'}\n-- >>> select_words('simple white space', 2)\n-- {}\n-- >>> select_words('Hello world', 4)\n-- {'world'}\n-- >>> select_words('Uncle sam', 3)\n-- {'Uncle'}\nlocal function select_words(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "lua",
-    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- >>> will_it_fly({1, 2}, 5)\n-- false\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- >>> will_it_fly({3, 2, 3}, 1)\n-- false\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- >>> will_it_fly({3, 2, 3}, 9)\n-- true\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- >>> will_it_fly({3}, 5)\n-- true\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "lua",
-    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "lua",
-    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- >>> Strongest_Extension('my_class', {'AA', 'Be', 'CC'})\n-- 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "lua",
-    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- >>> match_parens({'()(', ')'})\n-- 'Yes'\n-- >>> match_parens({')', ')'})\n-- 'No'\nlocal function match_parens(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\n-- >>> next_smallest({1, 2, 3, 4, 5})\n-- 2\n-- >>> next_smallest({5, 1, 4, 3, 2})\n-- 2\n-- >>> next_smallest({})\n-- None\n-- >>> next_smallest({1, 1})\n-- None\nlocal function next_smallest(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "lua",
-    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- >>> any_int(5, 2, 7)\n-- true\n-- >>> any_int(3, 2, 2)\n-- false\n-- >>> any_int(3, -2, 1)\n-- true\n-- >>> any_int(3.6, -2.2, 2)\n-- false\nlocal function any_int(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "lua",
-    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "lua",
-    "prompt": "-- Return list with elements incremented by 1.\n-- >>> incr_list({1, 2, 3})\n-- {2, 3, 4}\n-- >>> incr_list({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {6, 4, 6, 3, 4, 4, 10, 1, 124}\nlocal function incr_list(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "lua",
-    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- >>> x_or_y(7, 34, 12)\n-- 34\n-- >>> x_or_y(15, 8, 5)\n-- 5\nlocal function x_or_y(n, x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "lua",
-    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "lua",
-    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\n-- >>> even_odd_count(-12)\n-- {1, 1}\n-- >>> even_odd_count(123)\n-- {1, 2}\nlocal function even_odd_count(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "lua",
-    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- >>> is_happy('a')\n-- false\n-- >>> is_happy('aa')\n-- false\n-- >>> is_happy('abcd')\n-- true\n-- >>> is_happy('aabb')\n-- false\n-- >>> is_happy('adb')\n-- true\n-- >>> is_happy('xyy')\n-- false\nlocal function is_happy(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "lua",
-    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "lua",
-    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- >>> digitSum('')\n-- 0\n-- >>> digitSum('abAB')\n-- 131\n-- >>> digitSum('abcCd')\n-- 67\n-- >>> digitSum('helloE')\n-- 69\n-- >>> digitSum('woArBld')\n-- 131\n-- >>> digitSum('aAaaaXa')\n-- 153\nlocal function digitSum(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "lua",
-    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit({1.0, 2.0, 3.0, 4.0, 5.0})\n-- {0.0, 0.25, 0.5, 0.75, 1.0}\nlocal function rescale_to_unit(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "lua",
-    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- >>> solution({5, 8, 7, 1})\n-- 12\n-- >>> solution({3, 3, 3, 3, 3})\n-- 9\n-- >>> solution({30, 13, 24, 321})\n-- 0\nlocal function solution(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "lua",
-    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- >>> pluck({4, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- >>> pluck({1, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- >>> pluck({})\n-- {}\n-- Example 4:\n-- >>> pluck({5, 0, 3, 0, 4, 2})\n-- {0, 1}\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "lua",
-    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- >>> get_max_triples(5)\n-- 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "lua",
-    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- >>> exchange({1, 2, 3, 4}, {1, 2, 3, 4})\n-- 'YES'\n-- >>> exchange({1, 2, 3, 4}, {1, 5, 3, 4})\n-- 'NO'\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "lua",
-    "prompt": "-- Return median of elements in the list l.\n-- >>> median({3, 1, 2, 4, 5})\n-- 3\n-- >>> median({-10, 4, 6, 1000, 10, 20})\n-- 15.0\nlocal function median(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\n-- >>> prime_length('Hello')\n-- true\n-- >>> prime_length('abcdcba')\n-- true\n-- >>> prime_length('kittens')\n-- true\n-- >>> prime_length('orange')\n-- false\nlocal function prime_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "lua",
-    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- >>> smallest_change({1, 2, 3, 5, 4, 7, 9, 6})\n-- 4\n-- >>> smallest_change({1, 2, 3, 4, 3, 2, 2})\n-- 1\n-- >>> smallest_change({1, 2, 3, 2, 1})\n-- 0\nlocal function smallest_change(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "lua",
-    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\n-- >>> lst({1.0, 2.0, 3.0})\n-- 14\n-- >>> lst({1.0, 4.0, 9.0})\n-- 98\n-- >>> lst({1.0, 3.0, 5.0, 7.0})\n-- 84\n-- >>> lst({1.4, 4.2, 0.0})\n-- 29\n-- >>> lst({-2.4, 1.0, 1.0})\n-- 6\nlocal function sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "lua",
-    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- >>> file_name_check('example.txt')\n-- 'Yes'\n-- >>> file_name_check('1example.dll')\n-- 'No'\nlocal function file_name_check(file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "lua",
-    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> triples_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> triples_sum_to_zero({1, 3, -2, 1})\n-- true\n-- >>> triples_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> triples_sum_to_zero({2, 4, -5, 3, 9, 7})\n-- true\n-- >>> triples_sum_to_zero({1})\n-- false\nlocal function triples_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "lua",
-    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- >>> intersection({1, 2}, {2, 3})\n-- 'NO'\n-- >>> intersection({-1, 1}, {0, 4})\n-- 'NO'\n-- >>> intersection({-3, -1}, {-5, 5})\n-- 'YES'\nlocal function intersection(interval1, interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "lua",
-    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- {'()', '(())', '(()())'}\nlocal function separate_paren_groups(paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "lua",
-    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- >>> compare({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2})\n-- {0, 0, 0, 0, 3, 3}\n-- >>> compare({0, 5, 0, 0, 0, 4}, {4, 1, 1, 0, 0, -2})\n-- {4, 4, 1, 0, 0, 6}\nlocal function compare(game, guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "lua",
-    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- >>> check_if_last_char_is_a_letter('apple pie')\n-- false\n-- >>> check_if_last_char_is_a_letter('apple pi e')\n-- true\n-- >>> check_if_last_char_is_a_letter('apple pi e ')\n-- false\n-- >>> check_if_last_char_is_a_letter('')\n-- false\nlocal function check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "lua",
-    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- >>> valid_date('03-11-2000')\n-- true\n-- >>> valid_date('15-01-2012')\n-- false\n-- >>> valid_date('04-0-2040')\n-- false\n-- >>> valid_date('06-04-2020')\n-- true\n-- >>> valid_date('06/04/2020')\n-- false\nlocal function valid_date(date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "lua",
-    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums({})\n-- 0\n-- >>> count_nums({-1, 11, -11})\n-- 1\n-- >>> count_nums({1, 1, 2})\n-- 3\nlocal function count_nums(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- >>> anti_shuffle('Hi')\n-- 'Hi'\n-- >>> anti_shuffle('hello')\n-- 'ehllo'\n-- >>> anti_shuffle('Hello World!!!')\n-- 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "lua",
-    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- true\n-- >>> is_palindrome('aba')\n-- true\n-- >>> is_palindrome('aaaaa')\n-- true\n-- >>> is_palindrome('zbcd')\n-- false\nlocal function is_palindrome(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "lua",
-    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- >>> get_closest_vowel('yogurt')\n-- 'u'\n-- >>> get_closest_vowel('FULL')\n-- 'U'\n-- >>> get_closest_vowel('quick')\n-- ''\n-- >>> get_closest_vowel('ab')\n-- ''\nlocal function get_closest_vowel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "lua",
-    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- false\n-- >>> is_prime(101)\n-- true\n-- >>> is_prime(11)\n-- true\n-- >>> is_prime(13441)\n-- true\n-- >>> is_prime(61)\n-- true\n-- >>> is_prime(4)\n-- false\n-- >>> is_prime(1)\n-- false\nlocal function is_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "lua",
-    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- >>> simplify('1/5', '5/1')\n-- true\n-- >>> simplify('1/6', '2/1')\n-- false\n-- >>> simplify('7/10', '10/2')\n-- false\nlocal function simplify(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "lua",
-    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- >>> hex_key('AB')\n-- 1\n-- >>> hex_key('1077E')\n-- 2\n-- >>> hex_key('ABED1A33')\n-- 4\n-- >>> hex_key('123456789ABCDEF0')\n-- 6\n-- >>> hex_key('2020')\n-- 2\nlocal function hex_key(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "lua",
-    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- >>> words_in_sentence('This is a test')\n-- 'is'\n-- Example 2:\n-- >>> words_in_sentence('lets go for swimming')\n-- 'go for'\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "lua",
-    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- >>> histogram('a b c')\n-- {['a'] = 1, ['b'] = 1, ['c'] = 1}\n-- >>> histogram('a b b a')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('a b c a b')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('b b b b a')\n-- {['b'] = 4}\n-- >>> histogram('')\n-- {}\nlocal function histogram(test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "lua",
-    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- >>> get_row({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1)\n-- {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}}\n-- >>> get_row({}, 1)\n-- {}\n-- >>> get_row({{}, {1}, {1, 2, 3}}, 3)\n-- {{2, 2}}\nlocal function get_row(lst, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "lua",
-    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n-- >>> get_odd_collatz(5)\n-- {1, 5}\nlocal function get_odd_collatz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "lua",
-    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\n-- >>> can_arrange({1, 2, 4, 3, 5})\n-- 3\n-- >>> can_arrange({1, 2, 3})\n-- -1\nlocal function can_arrange(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "lua",
-    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "lua",
-    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- '21'\n-- >>> circular_shift(12, 2)\n-- '12'\nlocal function circular_shift(x, shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "lua",
-    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- >>> lst\n-- {1, 2, 3}\n-- >>> lst\n-- {}\n-- >>> lst\n-- {-1, -5, 2, -1, -5}\nlocal function sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "lua",
-    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- >>> skjkasdkd({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n-- 10\n-- >>> skjkasdkd({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n-- 25\n-- >>> skjkasdkd({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n-- 13\n-- >>> skjkasdkd({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n-- 11\n-- >>> skjkasdkd({0, 81, 12, 3, 1, 21})\n-- 3\n-- >>> skjkasdkd({0, 8, 1, 2, 1, 7})\n-- 7\nlocal function skjkasdkd(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "lua",
-    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product({})\n-- {0, 1}\n-- >>> sum_product({1, 2, 3, 4})\n-- {10, 24}\nlocal function sum_product(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "lua",
-    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\n-- >>> choose_num(12, 15)\n-- 14\n-- >>> choose_num(13, 12)\n-- -1\nlocal function choose_num(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "lua",
-    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- >>> largest_smallest_integers({2, 4, 1, 3, 5, 7})\n-- {None, 1}\n-- >>> largest_smallest_integers({})\n-- {None, None}\n-- >>> largest_smallest_integers({0})\n-- {None, None}\nlocal function largest_smallest_integers(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "lua",
-    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\n-- >>> count_distinct_characters('xyzXYZ')\n-- 3\n-- >>> count_distinct_characters('Jerry')\n-- 4\nlocal function count_distinct_characters(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1759,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Given a positive integer n, you have to make a pile of n levels of stones.\n-- The first level has n stones.\n-- The number of stones in the next level is:\n-- - the next odd number if n is odd.\n-- - the next even number if n is even.\n-- Return the number of stones in each level in a list, where element at index\n-- i represents the number of stones in the level (i+1).\n-- Examples:\n-- >>> make_a_pile(3)\n-- {3, 5, 7}\nlocal function make_a_pile(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_a_pile\n    lu.assertEquals(candidate(3), {3, 5, 7})\n    lu.assertEquals(candidate(4), {4, 6, 8, 10})\n    lu.assertEquals(candidate(5), {5, 7, 9, 11, 13})\n    lu.assertEquals(candidate(6), {6, 8, 10, 12, 14, 16})\n    lu.assertEquals(candidate(8), {8, 10, 12, 14, 16, 18, 20, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "lua",
-    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs({1, 2, 2, -4})\n-- 9\n-- >>> prod_signs({0, 1})\n-- 0\n-- >>> prod_signs({})\n-- None\nlocal function prod_signs(arr)\n",
+    "prompt": "-- You will be given a string of words separated by commas or spaces. Your task is\n-- to split the string into words and return an array of the words.\n-- For example:\n-- >>> words_string('Hi, my name is John')\n-- {'Hi', 'my', 'name', 'is', 'John'}\n-- >>> words_string('One, two, three, four, five, six')\n-- {'One', 'two', 'three', 'four', 'five', 'six'}\nlocal function words_string(s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_string\n    lu.assertEquals(candidate('Hi, my name is John'), {'Hi', 'my', 'name', 'is', 'John'})\n    lu.assertEquals(candidate('One, two, three, four, five, six'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate('Hi, my name'), {'Hi', 'my', 'name'})\n    lu.assertEquals(candidate('One,, two, three, four, five, six,'), {'One', 'two', 'three', 'four', 'five', 'six'})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('ahmed     , gamal'), {'ahmed', 'gamal'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "lua",
-    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\n-- >>> minSubArraySum({2, 3, 4, 1, 2, 4})\n-- 1\n-- >>> minSubArraySum({-1, -2, -3})\n-- -6\nlocal function minSubArraySum(nums)\n",
+    "prompt": "-- This function takes two positive numbers x and y and returns the\n-- biggest even integer number that is in the range [x, y] inclusive. If \n-- there's no such number, then the function should return -1.\n-- For example:\n-- >>> choose_num(12, 15)\n-- 14\n-- >>> choose_num(13, 12)\n-- -1\nlocal function choose_num(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = choose_num\n    lu.assertEquals(candidate(12, 15), 14)\n    lu.assertEquals(candidate(13, 12), -1)\n    lu.assertEquals(candidate(33, 12354), 12354)\n    lu.assertEquals(candidate(5234, 5233), -1)\n    lu.assertEquals(candidate(6, 29), 28)\n    lu.assertEquals(candidate(27, 10), -1)\n    lu.assertEquals(candidate(7, 7), -1)\n    lu.assertEquals(candidate(546, 546), 546)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "lua",
-    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
+    "prompt": "-- You are given two positive integers n and m, and your task is to compute the\n-- average of the integers from n through m (including n and m). \n-- Round the answer to the nearest integer and convert that to binary.\n-- If n is greater than m, return -1.\n-- Example:\n-- >>> rounded_avg(1, 5)\n-- '0b11'\n-- >>> rounded_avg(7, 5)\n-- -1\n-- >>> rounded_avg(10, 20)\n-- '0b1111'\n-- >>> rounded_avg(20, 33)\n-- '0b11010'\nlocal function rounded_avg(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rounded_avg\n    lu.assertEquals(candidate(1, 5), '0b11')\n    lu.assertEquals(candidate(7, 13), '0b1010')\n    lu.assertEquals(candidate(964, 977), '0b1111001010')\n    lu.assertEquals(candidate(996, 997), '0b1111100100')\n    lu.assertEquals(candidate(560, 851), '0b1011000010')\n    lu.assertEquals(candidate(185, 546), '0b101101110')\n    lu.assertEquals(candidate(362, 496), '0b110101101')\n    lu.assertEquals(candidate(350, 902), '0b1001110010')\n    lu.assertEquals(candidate(197, 233), '0b11010111')\n    lu.assertEquals(candidate(7, 5), -1)\n    lu.assertEquals(candidate(5, 1), -1)\n    lu.assertEquals(candidate(5, 5), '0b101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "lua",
-    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n-- >>> cycpattern_check('abcd', 'abd')\n-- false\n-- >>> cycpattern_check('hello', 'ell')\n-- true\n-- >>> cycpattern_check('whassup', 'psus')\n-- false\n-- >>> cycpattern_check('abab', 'baa')\n-- true\n-- >>> cycpattern_check('efef', 'eeff')\n-- false\n-- >>> cycpattern_check('himenss', 'simen')\n-- true\nlocal function cycpattern_check(a, b)\n",
+    "prompt": "-- Given a list of positive integers x. return a sorted list of all \n-- elements that hasn't any even digit.\n-- Note: Returned list should be sorted in increasing order.\n-- For example:\n-- >>> unique_digits({15, 33, 1422, 1})\n-- {1, 15, 33}\n-- >>> unique_digits({152, 323, 1422, 10})\n-- {}\nlocal function unique_digits(x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_digits\n    lu.assertEquals(candidate({15, 33, 1422, 1}), {1, 15, 33})\n    lu.assertEquals(candidate({152, 323, 1422, 10}), {})\n    lu.assertEquals(candidate({12345, 2033, 111, 151}), {111, 151})\n    lu.assertEquals(candidate({135, 103, 31}), {31, 135})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "lua",
-    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\n-- >>> monotonic({1, 2, 4, 20})\n-- true\n-- >>> monotonic({1, 20, 4, 10})\n-- false\n-- >>> monotonic({4, 1, 0, -10})\n-- true\nlocal function monotonic(l)\n",
+    "prompt": "-- Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n-- reverse the resulting array, and then replace each digit by its corresponding name from\n-- \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n-- For example:\n-- >>> by_length({2, 1, 1, 4, 5, 8, 2, 3})\n-- {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'}\n-- If the array is empty, return an empty array:\n-- >>> by_length({})\n-- {}\n-- If the array has any strange number ignore it:\n-- >>> by_length({1, -1, 55})\n-- {'One'}\nlocal function by_length(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = by_length\n    lu.assertEquals(candidate({2, 1, 1, 4, 5, 8, 2, 3}), {'Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -1, 55}), {'One'})\n    lu.assertEquals(candidate({1, -1, 3, 2}), {'Three', 'Two', 'One'})\n    lu.assertEquals(candidate({9, 4, 8}), {'Nine', 'Eight', 'Four'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "lua",
-    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\n-- >>> longest({})\n-- None\n-- >>> longest({'a', 'b', 'c'})\n-- 'a'\n-- >>> longest({'a', 'bb', 'ccc'})\n-- 'ccc'\nlocal function longest(strings)\n",
+    "prompt": "-- Implement the function f that takes n as a parameter,\n-- and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n-- or the sum of numbers from 1 to i otherwise.\n-- i starts from 1.\n-- the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n-- Example:\n-- >>> f(5)\n-- {1, 2, 6, 24, 15}\nlocal function f(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = f\n    lu.assertEquals(candidate(5), {1, 2, 6, 24, 15})\n    lu.assertEquals(candidate(7), {1, 2, 6, 24, 15, 720, 28})\n    lu.assertEquals(candidate(1), {1})\n    lu.assertEquals(candidate(3), {1, 2, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "lua",
-    "prompt": "-- Return True if all numbers in the list l are below threshold t.\n-- >>> below_threshold({1, 2, 4, 10}, 100)\n-- true\n-- >>> below_threshold({1, 20, 4, 10}, 5)\n-- false\nlocal function below_threshold(l, t)\n",
+    "prompt": "-- Given a positive integer n, return a tuple that has the number of even and odd\n-- integer palindromes that fall within the range(1, n), inclusive.\n-- Example 1:\n-- >>> even_odd_palindrome(3)\n-- {1, 2}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n-- Example 2:\n-- >>> even_odd_palindrome(12)\n-- {4, 6}\n-- Explanation:\n-- Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n-- Note:\n-- 1. 1 <= n <= 10^3\n-- 2. returned tuple has the number of even and odd integer palindromes respectively.\nlocal function even_odd_palindrome(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_palindrome\n    lu.assertEquals(candidate(123), {8, 13})\n    lu.assertEquals(candidate(12), {4, 6})\n    lu.assertEquals(candidate(3), {1, 2})\n    lu.assertEquals(candidate(63), {6, 8})\n    lu.assertEquals(candidate(25), {5, 6})\n    lu.assertEquals(candidate(19), {4, 6})\n    lu.assertEquals(candidate(9), {4, 5})\n    lu.assertEquals(candidate(1), {0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "lua",
-    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- >>> is_multiply_prime(30)\n-- true\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "prompt": "-- Write a function count_nums which takes an array of integers and returns\n-- the number of elements which has a sum of digits > 0.\n-- If a number is negative, then its first signed digit will be negative:\n-- e.g. -123 has signed digits -1, 2, and 3.\n-- >>> count_nums({})\n-- 0\n-- >>> count_nums({-1, 11, -11})\n-- 1\n-- >>> count_nums({1, 1, 2})\n-- 3\nlocal function count_nums(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_nums\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({-1, -2, 0}), 0)\n    lu.assertEquals(candidate({1, 1, 2, -2, 3, 4, 5}), 6)\n    lu.assertEquals(candidate({1, 6, 9, -6, 0, 1, 5}), 5)\n    lu.assertEquals(candidate({1, 100, 98, -7, 1, -1}), 4)\n    lu.assertEquals(candidate({12, 23, 34, -45, -56, 0}), 5)\n    lu.assertEquals(candidate({0, 1}), 1)\n    lu.assertEquals(candidate({1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "lua",
-    "prompt": "-- Return only positive numbers in the list.\n-- >>> get_positive({-1, 2, -4, 5, 6})\n-- {2, 5, 6}\n-- >>> get_positive({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- {5, 3, 2, 3, 9, 123, 1}\nlocal function get_positive(l)\n",
+    "prompt": "-- We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n-- numbers in the array will be randomly ordered. Your task is to determine if\n-- it is possible to get an array sorted in non-decreasing order by performing \n-- the following operation on the given array:\n-- You are allowed to perform right shift operation any number of times.\n-- One right shift operation means shifting all elements of the array by one\n-- position in the right direction. The last element of the array will be moved to\n-- the starting position in the array i.e. 0th index. \n-- If it is possible to obtain the sorted array by performing the above operation\n-- then return True else return False.\n-- If the given array is empty then return True.\n-- Note: The given list is guaranteed to have unique elements.\n-- For Example:\n-- >>> move_one_ball({3, 4, 5, 1, 2})\n-- true\n-- Explanation: By performin 2 right shift operations, non-decreasing order can\n-- be achieved for the given array.\n-- >>> move_one_ball({3, 5, 4, 1, 2})\n-- false\n-- Explanation:It is not possible to get non-decreasing order for the given\n-- array by performing any number of right shift operations.\nlocal function move_one_ball(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_one_ball\n    lu.assertEquals(candidate({3, 4, 5, 1, 2}), true)\n    lu.assertEquals(candidate({3, 5, 10, 1, 2}), true)\n    lu.assertEquals(candidate({4, 3, 1, 2}), false)\n    lu.assertEquals(candidate({3, 5, 4, 1, 2}), false)\n    lu.assertEquals(candidate({}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "lua",
-    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_third({5, 6, 3, 4, 8, 9, 2})\n-- {2, 6, 3, 4, 8, 9, 5}\nlocal function sort_third(l)\n",
+    "prompt": "-- Find the shortest palindrome that begins with a supplied string.\n-- Algorithm idea is simple:\n-- - Find the longest postfix of supplied string that is a palindrome.\n-- - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n-- >>> make_palindrome('')\n-- ''\n-- >>> make_palindrome('cat')\n-- 'catac'\n-- >>> make_palindrome('cata')\n-- 'catac'\nlocal function make_palindrome(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = make_palindrome\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('x'), 'x')\n    lu.assertEquals(candidate('xyz'), 'xyzyx')\n    lu.assertEquals(candidate('xyx'), 'xyx')\n    lu.assertEquals(candidate('jerry'), 'jerryrrej')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "lua",
-    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- {2, 3, 1, 3}\nlocal function parse_nested_parens(paren_string)\n",
+    "prompt": "-- In this problem, you will implement a function that takes two lists of numbers,\n-- and determines whether it is possible to perform an exchange of elements\n-- between them to make lst1 a list of only even numbers.\n-- There is no limit on the number of exchanged elements between lst1 and lst2.\n-- If it is possible to exchange elements between the lst1 and lst2 to make\n-- all the elements of lst1 to be even, return \"YES\".\n-- Otherwise, return \"NO\".\n-- For example:\n-- >>> exchange({1, 2, 3, 4}, {1, 2, 3, 4})\n-- 'YES'\n-- >>> exchange({1, 2, 3, 4}, {1, 5, 3, 4})\n-- 'NO'\n-- It is assumed that the input lists will be non-empty.\nlocal function exchange(lst1, lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = exchange\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 2, 3, 4}), 'YES')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {1, 5, 3, 4}), 'NO')\n    lu.assertEquals(candidate({1, 2, 3, 4}, {2, 1, 4, 3}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 4}), 'YES')\n    lu.assertEquals(candidate({5, 7, 3}, {2, 6, 3}), 'NO')\n    lu.assertEquals(candidate({3, 2, 6, 1, 8, 9}, {3, 5, 5, 1, 1, 1}), 'NO')\n    lu.assertEquals(candidate({100, 200}, {200, 200}), 'YES')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "lua",
-    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
+    "prompt": "-- Given a string representing a space separated lowercase letters, return a dictionary\n-- of the letter with the most repetition and containing the corresponding count.\n-- If several letters have the same occurrence, return all of them.\n-- Example:\n-- >>> histogram('a b c')\n-- {['a'] = 1, ['b'] = 1, ['c'] = 1}\n-- >>> histogram('a b b a')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('a b c a b')\n-- {['a'] = 2, ['b'] = 2}\n-- >>> histogram('b b b b a')\n-- {['b'] = 4}\n-- >>> histogram('')\n-- {}\nlocal function histogram(test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "lua",
-    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- >>> multiply(148, 412)\n-- 16\n-- >>> multiply(19, 28)\n-- 72\n-- >>> multiply(2020, 1851)\n-- 0\n-- >>> multiply(14, -15)\n-- 20\nlocal function multiply(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "lua",
-    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation({1.0, 2.0, 3.0, 4.0})\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "lua",
-    "prompt": "-- Return sorted unique common elements for two lists.\n-- >>> common({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121})\n-- {1, 5, 653}\n-- >>> common({5, 3, 2, 8}, {3, 2})\n-- {2, 3}\nlocal function common(l1, l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "lua",
-    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19)\n-- 'xix'\n-- >>> int_to_mini_roman(152)\n-- 'clii'\n-- >>> int_to_mini_roman(426)\n-- 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "lua",
-    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- >>> fruit_distribution('5 apples and 6 oranges', 19)\n-- 8\n-- >>> fruit_distribution('0 apples and 1 oranges', 3)\n-- 2\n-- >>> fruit_distribution('2 apples and 3 oranges', 100)\n-- 95\n-- >>> fruit_distribution('100 apples and 1 oranges', 120)\n-- 19\nlocal function fruit_distribution(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = histogram\n    lu.assertEquals(candidate('a b b a'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c a b'), {['a'] = 2, ['b'] = 2})\n    lu.assertEquals(candidate('a b c d g'), {['a'] = 1, ['b'] = 1, ['c'] = 1, ['d'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate('b b b b a'), {['b'] = 4})\n    lu.assertEquals(candidate('r t g'), {['r'] = 1, ['t'] = 1, ['g'] = 1})\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('a'), {['a'] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2029,7 +214,7 @@
     "language": "lua",
     "prompt": "-- Task\n-- We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n-- then check if the result string is palindrome.\n-- A string is called palindrome if it reads the same backward as forward.\n-- You should return a tuple containing the result string and True/False for the check.\n-- Example\n-- >>> reverse_delete('abcde', 'ae')\n-- {'bcd', false}\n-- >>> reverse_delete('abcdef', 'b')\n-- {'acdef', false}\n-- >>> reverse_delete('abcdedcba', 'ab')\n-- {'cdedc', true}\nlocal function reverse_delete(s, c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_delete\n    lu.assertEquals(candidate('abcde', 'ae'), {'bcd', false})\n    lu.assertEquals(candidate('abcdef', 'b'), {'acdef', false})\n    lu.assertEquals(candidate('abcdedcba', 'ab'), {'cdedc', true})\n    lu.assertEquals(candidate('dwik', 'w'), {'dik', false})\n    lu.assertEquals(candidate('a', 'a'), {'', true})\n    lu.assertEquals(candidate('abcdedcba', ''), {'abcdedcba', true})\n    lu.assertEquals(candidate('abcdedcba', 'v'), {'abcdedcba', true})\n    lu.assertEquals(candidate('vabba', 'v'), {'abba', true})\n    lu.assertEquals(candidate('mamma', 'mia'), {'', true})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "lua",
-    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
+    "prompt": "-- Given a list of strings, where each string consists of only digits, return a list.\n-- Each element i of the output should be \"the number of odd elements in the\n-- string i of the input.\" where all the i's should be replaced by the number\n-- of odd digits in the i'th string of the input.\n-- >>> odd_count({'1234567'})\n-- {'the number of odd elements 4n the str4ng 4 of the 4nput.'}\n-- >>> odd_count({'3', '11111111'})\n-- {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'}\nlocal function odd_count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_count\n    lu.assertEquals(candidate({'1234567'}), {'the number of odd elements 4n the str4ng 4 of the 4nput.'})\n    lu.assertEquals(candidate({'3', '11111111'}), {'the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'})\n    lu.assertEquals(candidate({'271', '137', '314'}), {'the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "lua",
-    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- >>> split_words('Hello world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('Hello,world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('abcdef')\n-- 3\nlocal function split_words(txt)\n",
+    "prompt": "-- Given an array of integers nums, find the minimum sum of any non-empty sub-array\n-- of nums.\n-- Example\n-- >>> minSubArraySum({2, 3, 4, 1, 2, 4})\n-- 1\n-- >>> minSubArraySum({-1, -2, -3})\n-- -6\nlocal function minSubArraySum(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minSubArraySum\n    lu.assertEquals(candidate({2, 3, 4, 1, 2, 4}), 1)\n    lu.assertEquals(candidate({-1, -2, -3}), -6)\n    lu.assertEquals(candidate({-1, -2, -3, 2, -10}), -14)\n    lu.assertEquals(candidate({-9999999999999999}), -9999999999999999)\n    lu.assertEquals(candidate({0, 10, 20, 1000000}), 0)\n    lu.assertEquals(candidate({-1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({100, -1, -2, -3, 10, -5}), -6)\n    lu.assertEquals(candidate({10, 11, 13, 8, 3, 4}), 3)\n    lu.assertEquals(candidate({100, -33, 32, -1, 0, -2}), -33)\n    lu.assertEquals(candidate({-10}), -10)\n    lu.assertEquals(candidate({7}), 7)\n    lu.assertEquals(candidate({1, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "lua",
+    "prompt": "-- You are given a rectangular grid of wells. Each row represents a single well,\n-- and each 1 in a row represents a single unit of water.\n-- Each well has a corresponding bucket that can be used to extract water from it, \n-- and all buckets have the same capacity.\n-- Your task is to use the buckets to empty the wells.\n-- Output the number of times you need to lower the buckets.\n-- Example 1:\n-- >>> max_fill({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1)\n-- 6\n-- Example 2:\n-- >>> max_fill({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2)\n-- 5\n-- Example 3:\n-- >>> max_fill({{0, 0, 0}, {0, 0, 0}}, 5)\n-- 0\n-- Constraints:\n-- * all wells have the same length\n-- * 1 <= grid.length <= 10^2\n-- * 1 <= grid[:,1].length <= 10^2\n-- * grid[i][j] -> 0 | 1\n-- * 1 <= capacity <= 10\nlocal function max_fill(grid, capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_fill\n    lu.assertEquals(candidate({{0, 0, 1, 0}, {0, 1, 0, 0}, {1, 1, 1, 1}}, 1), 6)\n    lu.assertEquals(candidate({{0, 0, 1, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}, {0, 1, 1, 1}}, 2), 5)\n    lu.assertEquals(candidate({{0, 0, 0}, {0, 0, 0}}, 5), 0)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 2), 4)\n    lu.assertEquals(candidate({{1, 1, 1, 1}, {1, 1, 1, 1}}, 9), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2074,7 +274,7 @@
     "language": "lua",
     "prompt": "-- In this Kata, you have to sort an array of non-negative integers according to\n-- number of ones in their binary representation in ascending order.\n-- For similar number of ones, sort based on decimal value.\n-- It must be implemented like this:\n-- >>> sort_array({1, 5, 2, 3, 4})\n-- {1, 2, 3, 4, 5}\n-- >>> sort_array({-2, -3, -4, -5, -6})\n-- {-6, -5, -4, -3, -2}\n-- >>> sort_array({1, 0, 2, 3, 4})\n-- {0, 1, 2, 3, 4}\nlocal function sort_array(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({1, 5, 2, 3, 4}), {1, 2, 4, 3, 5})\n    lu.assertEquals(candidate({-2, -3, -4, -5, -6}), {-4, -2, -6, -5, -3})\n    lu.assertEquals(candidate({1, 0, 2, 3, 4}), {0, 1, 2, 4, 3})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4}), {2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77})\n    lu.assertEquals(candidate({3, 6, 44, 12, 32, 5}), {32, 3, 5, 6, 12, 44})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\n    lu.assertEquals(candidate({2, 4, 8, 16, 32}), {2, 4, 8, 16, 32})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "lua",
-    "prompt": "-- Concatenate list of strings into a single string\n-- >>> concatenate({})\n-- ''\n-- >>> concatenate({'a', 'b', 'c'})\n-- 'abc'\nlocal function concatenate(strings)\n",
+    "prompt": "-- Given a string s and a natural number n, you have been tasked to implement \n-- a function that returns a list of all words from string s that contain exactly \n-- n consonants, in order these words appear in the string s.\n-- If the string s is empty then the function should return an empty list.\n-- Note: you may assume the input string contains only letters and spaces.\n-- Examples:\n-- >>> select_words('Mary had a little lamb', 4)\n-- {'little'}\n-- >>> select_words('Mary had a little lamb', 3)\n-- {'Mary', 'lamb'}\n-- >>> select_words('simple white space', 2)\n-- {}\n-- >>> select_words('Hello world', 4)\n-- {'world'}\n-- >>> select_words('Uncle sam', 3)\n-- {'Uncle'}\nlocal function select_words(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = select_words\n    lu.assertEquals(candidate('Mary had a little lamb', 4), {'little'})\n    lu.assertEquals(candidate('Mary had a little lamb', 3), {'Mary', 'lamb'})\n    lu.assertEquals(candidate('simple white space', 2), {})\n    lu.assertEquals(candidate('Hello world', 4), {'world'})\n    lu.assertEquals(candidate('Uncle sam', 3), {'Uncle'})\n    lu.assertEquals(candidate('', 4), {})\n    lu.assertEquals(candidate('a b c d e f', 1), {'b', 'c', 'd', 'f'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- >>> list_sort({'aa', 'a', 'aaa'})\n-- {'aa'}\n-- >>> list_sort({'ab', 'a', 'aaa', 'cd'})\n-- {'ab', 'cd'}\nlocal function sorted_list_sum(lst)\n",
+    "prompt": "-- You are given a word. Your task is to find the closest vowel that stands between \n-- two consonants from the right side of the word (case sensitive).\n-- Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n-- find any vowel met the above condition. \n-- You may assume that the given string contains English letter only.\n-- Example:\n-- >>> get_closest_vowel('yogurt')\n-- 'u'\n-- >>> get_closest_vowel('FULL')\n-- 'U'\n-- >>> get_closest_vowel('quick')\n-- ''\n-- >>> get_closest_vowel('ab')\n-- ''\nlocal function get_closest_vowel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_closest_vowel\n    lu.assertEquals(candidate('yogurt'), 'u')\n    lu.assertEquals(candidate('full'), 'u')\n    lu.assertEquals(candidate('easy'), '')\n    lu.assertEquals(candidate('eAsy'), '')\n    lu.assertEquals(candidate('ali'), '')\n    lu.assertEquals(candidate('bad'), 'a')\n    lu.assertEquals(candidate('most'), 'o')\n    lu.assertEquals(candidate('ab'), '')\n    lu.assertEquals(candidate('ba'), '')\n    lu.assertEquals(candidate('quick'), '')\n    lu.assertEquals(candidate('anime'), 'i')\n    lu.assertEquals(candidate('Asia'), '')\n    lu.assertEquals(candidate('Above'), 'o')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "lua",
-    "prompt": "-- Filter an input list of strings only for ones that contain given substring\n-- >>> filter_by_substring({}, 'a')\n-- {}\n-- >>> filter_by_substring({'abc', 'bacd', 'cde', 'array'}, 'a')\n-- {'abc', 'bacd', 'array'}\nlocal function filter_by_substring(strings, substring)\n",
+    "prompt": "-- You are given a list of two strings, both strings consist of open\n-- parentheses '(' or close parentheses ')' only.\n-- Your job is to check if it is possible to concatenate the two strings in\n-- some order, that the resulting string will be good.\n-- A string S is considered to be good if and only if all parentheses in S\n-- are balanced. For example: the string '(())()' is good, while the string\n-- '())' is not.\n-- Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n-- Examples:\n-- >>> match_parens({'()(', ')'})\n-- 'Yes'\n-- >>> match_parens({')', ')'})\n-- 'No'\nlocal function match_parens(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = match_parens\n    lu.assertEquals(candidate({'()(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', ')'}), 'No')\n    lu.assertEquals(candidate({'(()(())', '())())'}), 'No')\n    lu.assertEquals(candidate({')())', '(()()('}), 'Yes')\n    lu.assertEquals(candidate({'(())))', '(()())(('}), 'Yes')\n    lu.assertEquals(candidate({'()', '())'}), 'No')\n    lu.assertEquals(candidate({'(()(', '()))()'}), 'Yes')\n    lu.assertEquals(candidate({'((((', '((())'}), 'No')\n    lu.assertEquals(candidate({')(()', '(()('}), 'No')\n    lu.assertEquals(candidate({')(', ')('}), 'No')\n    lu.assertEquals(candidate({'(', ')'}), 'Yes')\n    lu.assertEquals(candidate({')', '('}), 'Yes')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "lua",
-    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer('10')\n-- 10\n-- >>> closest_integer('15.3')\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "prompt": "-- Input are two strings a and b consisting only of 1s and 0s.\n-- Perform binary XOR on these inputs and return result also as a string.\n-- >>> string_xor('010', '110')\n-- '100'\nlocal function string_xor(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_xor\n    lu.assertEquals(candidate('111000', '101010'), '010010')\n    lu.assertEquals(candidate('1', '1'), '0')\n    lu.assertEquals(candidate('0101', '0000'), '0101')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "lua",
-    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count('abcde')\n-- 2\n-- >>> vowels_count('ACEDY')\n-- 3\nlocal function vowels_count(s)\n",
+    "prompt": "-- Given an array arr of integers and a positive integer k, return a sorted list \n-- of length k with the maximum k numbers in arr.\n-- Example 1:\n-- >>> maximum({-3, -4, 5}, 3)\n-- {-4, -3, 5}\n-- Example 2:\n-- >>> maximum({4, -4, 4}, 2)\n-- {4, 4}\n-- Example 3:\n-- >>> maximum({-3, 2, 1, 2, -1, -2, 1}, 1)\n-- {2}\n-- Note:\n-- 1. The length of the array will be in the range of [1, 1000].\n-- 2. The elements in the array will be in the range of [-1000, 1000].\n-- 3. 0 <= k <= len(arr)\nlocal function maximum(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate({-3, -4, 5}, 3), {-4, -3, 5})\n    lu.assertEquals(candidate({4, -4, 4}, 2), {4, 4})\n    lu.assertEquals(candidate({-3, 2, 1, 2, -1, -2, 1}, 1), {2})\n    lu.assertEquals(candidate({123, -123, 20, 0, 1, 2, -3}, 3), {2, 20, 123})\n    lu.assertEquals(candidate({-123, 20, 0, 1, 2, -3}, 4), {0, 1, 2, 20})\n    lu.assertEquals(candidate({5, 15, 0, 3, -13, -8, 0}, 7), {-13, -8, 0, 0, 3, 5, 15})\n    lu.assertEquals(candidate({-1, 0, 2, 5, 3, -10}, 2), {3, 5})\n    lu.assertEquals(candidate({1, 0, 5, -7}, 1), {5})\n    lu.assertEquals(candidate({4, -4}, 2), {-4, 4})\n    lu.assertEquals(candidate({-10, 10}, 2), {-10, 10})\n    lu.assertEquals(candidate({1, 2, 3, -23, 243, -400, 0}, 0), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "lua",
-    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- >>> find_max({'name', 'of', 'string'})\n-- 'string'\n-- >>> find_max({'name', 'enam', 'game'})\n-- 'enam'\n-- >>> find_max({'aaaaaaa', 'bb', 'cc'})\n-- 'aaaaaaa'\nlocal function find_max(words)\n",
+    "prompt": "-- Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n-- Examples\n-- >>> solution({5, 8, 7, 1})\n-- 12\n-- >>> solution({3, 3, 3, 3, 3})\n-- 9\n-- >>> solution({30, 13, 24, 321})\n-- 0\nlocal function solution(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solution\n    lu.assertEquals(candidate({5, 8, 7, 1}), 12)\n    lu.assertEquals(candidate({3, 3, 3, 3, 3}), 9)\n    lu.assertEquals(candidate({30, 13, 24, 321}), 0)\n    lu.assertEquals(candidate({5, 9}), 5)\n    lu.assertEquals(candidate({2, 4, 8}), 0)\n    lu.assertEquals(candidate({30, 13, 23, 32}), 23)\n    lu.assertEquals(candidate({3, 13, 2, 9}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "lua",
-    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world')\n-- '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
+    "prompt": "-- Given a non-empty array of integers arr and an integer k, return\n-- the sum of the elements with at most two digits from the first k elements of arr.\n-- Example:\n-- >>> add_elements({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4)\n-- 24\n-- Constraints:\n-- 1. 1 <= len(arr) <= 100\n-- 2. 1 <= k <= len(arr)\nlocal function add_elements(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_elements\n    lu.assertEquals(candidate({1, -2, -3, 41, 57, 76, 87, 88, 99}, 3), -4)\n    lu.assertEquals(candidate({111, 121, 3, 4000, 5, 6}, 2), 0)\n    lu.assertEquals(candidate({11, 21, 3, 90, 5, 6, 7, 8, 9}, 4), 125)\n    lu.assertEquals(candidate({111, 21, 3, 4000, 5, 6, 7, 8, 9}, 4), 24)\n    lu.assertEquals(candidate({1}, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "lua",
-    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
+    "prompt": "-- Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n-- The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n-- as follows: start with any positive integer n. Then each term is obtained from the \n-- previous term as follows: if the previous term is even, the next term is one half of \n-- the previous term. If the previous term is odd, the next term is 3 times the previous\n-- term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n-- Note: \n-- 1. Collatz(1) is [1].\n-- 2. returned list sorted in increasing order.\n-- For example:\n-- get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n-- >>> get_odd_collatz(5)\n-- {1, 5}\nlocal function get_odd_collatz(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_odd_collatz\n    lu.assertEquals(candidate(14), {1, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(5), {1, 5})\n    lu.assertEquals(candidate(12), {1, 3, 5})\n    lu.assertEquals(candidate(1), {1})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "lua",
-    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- >>> right_angle_triangle(3, 4, 5)\n-- true\n-- >>> right_angle_triangle(1, 2, 3)\n-- false\nlocal function right_angle_triangle(a, b, c)\n",
+    "prompt": "-- You have to write a function which validates a given date string and\n-- returns True if the date is valid otherwise False.\n-- The date is valid if all of the following rules are satisfied:\n-- 1. The date string is not empty.\n-- 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n-- 3. The months should not be less than 1 or higher than 12.\n-- 4. The date should be in the format: mm-dd-yyyy\n-- >>> valid_date('03-11-2000')\n-- true\n-- >>> valid_date('15-01-2012')\n-- false\n-- >>> valid_date('04-0-2040')\n-- false\n-- >>> valid_date('06-04-2020')\n-- true\n-- >>> valid_date('06/04/2020')\n-- false\nlocal function valid_date(date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = valid_date\n    lu.assertEquals(candidate('03-11-2000'), true)\n    lu.assertEquals(candidate('15-01-2012'), false)\n    lu.assertEquals(candidate('04-0-2040'), false)\n    lu.assertEquals(candidate('06-04-2020'), true)\n    lu.assertEquals(candidate('01-01-2007'), true)\n    lu.assertEquals(candidate('03-32-2011'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('04-31-3000'), false)\n    lu.assertEquals(candidate('06-06-2005'), true)\n    lu.assertEquals(candidate('21-31-2000'), false)\n    lu.assertEquals(candidate('04-12-2003'), true)\n    lu.assertEquals(candidate('04122003'), false)\n    lu.assertEquals(candidate('20030412'), false)\n    lu.assertEquals(candidate('2003-04'), false)\n    lu.assertEquals(candidate('2003-04-12'), false)\n    lu.assertEquals(candidate('04-2003'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "lua",
-    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- >>> grade_equation({4.0, 3, 1.7, 2, 3.5})\n-- {'A+', 'B', 'C-', 'C', 'A-'}\nlocal function numerical_letter_grade(grades)\n",
+    "prompt": "-- Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n-- should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n-- alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n-- Examples\n-- >>> split_words('Hello world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('Hello,world!')\n-- {'Hello', 'world!'}\n-- >>> split_words('abcdef')\n-- 3\nlocal function split_words(txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_words\n    lu.assertEquals(candidate('Hello world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello,world!'), {'Hello', 'world!'})\n    lu.assertEquals(candidate('Hello world,!'), {'Hello', 'world,!'})\n    lu.assertEquals(candidate('Hello,Hello,world !'), {'Hello,Hello,world', '!'})\n    lu.assertEquals(candidate('abcdef'), 3)\n    lu.assertEquals(candidate('aaabb'), 2)\n    lu.assertEquals(candidate('aaaBb'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "lua",
-    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n-- >>> intersperse({}, 4)\n-- {}\n-- >>> intersperse({1, 2, 3}, 4)\n-- {1, 4, 2, 4, 3}\nlocal function intersperse(numbers, delimeter)\n",
+    "prompt": "-- Given a list of numbers, return whether or not they are sorted\n-- in ascending order. If list has more than 1 duplicate of the same\n-- number, return False. Assume no negative numbers and only integers.\n-- Examples\n-- >>> is_sorted({5})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5})\n-- false\n-- >>> is_sorted({1, 2, 3, 4, 5, 6})\n-- true\n-- >>> is_sorted({1, 2, 3, 4, 5, 6, 7})\n-- true\n-- >>> is_sorted({1, 3, 2, 4, 5, 6, 7})\n-- false\n-- >>> is_sorted({1, 2, 2, 3, 3, 4})\n-- true\n-- >>> is_sorted({1, 2, 2, 2, 3, 4})\n-- false\nlocal function is_sorted(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sorted\n    lu.assertEquals(candidate({5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}), true)\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, 7}), false)\n    lu.assertEquals(candidate({}), true)\n    lu.assertEquals(candidate({1}), true)\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 2, 2, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 4}), false)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "lua",
+    "prompt": "-- You are given two intervals,\n-- where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n-- The given intervals are closed which means that the interval (start, end)\n-- includes both start and end.\n-- For each given interval, it is assumed that its start is less or equal its end.\n-- Your task is to determine whether the length of intersection of these two \n-- intervals is a prime number.\n-- Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n-- which its length is 1, which not a prime number.\n-- If the length of the intersection is a prime number, return \"YES\",\n-- otherwise, return \"NO\".\n-- If the two intervals don't intersect, return \"NO\".\n-- [input/output] samples:\n-- >>> intersection({1, 2}, {2, 3})\n-- 'NO'\n-- >>> intersection({-1, 1}, {0, 4})\n-- 'NO'\n-- >>> intersection({-3, -1}, {-5, 5})\n-- 'YES'\nlocal function intersection(interval1, interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection\n    lu.assertEquals(candidate({1, 2}, {2, 3}), 'NO')\n    lu.assertEquals(candidate({-1, 1}, {0, 4}), 'NO')\n    lu.assertEquals(candidate({-3, -1}, {-5, 5}), 'YES')\n    lu.assertEquals(candidate({-2, 2}, {-4, 0}), 'YES')\n    lu.assertEquals(candidate({-11, 2}, {-1, -1}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {3, 5}), 'NO')\n    lu.assertEquals(candidate({1, 2}, {1, 2}), 'NO')\n    lu.assertEquals(candidate({-2, -2}, {-3, -2}), 'NO')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "lua",
+    "prompt": "-- You are given an array arr of integers and you need to return\n-- sum of magnitudes of integers multiplied by product of all signs\n-- of each number in the array, represented by 1, -1 or 0.\n-- Note: return None for empty arr.\n-- Example:\n-- >>> prod_signs({1, 2, 2, -4})\n-- 9\n-- >>> prod_signs({0, 1})\n-- 0\n-- >>> prod_signs({})\n-- None\nlocal function prod_signs(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prod_signs\n    lu.assertEquals(candidate({1, 2, 2, -4}), -9)\n    lu.assertEquals(candidate({0, 1}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, -1, 1}), -10)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({2, 4, 1, 2, -1, -1, 9}), 20)\n    lu.assertEquals(candidate({-1, 1, -1, 1}), 4)\n    lu.assertEquals(candidate({-1, 1, 1, 1}), -4)\n    lu.assertEquals(candidate({-1, 1, 1, 0}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "lua",
+    "prompt": "-- Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n-- each cell of the grid contains a value. Every integer in the range [1, N * N]\n-- inclusive appears exactly once on the cells of the grid.\n-- You have to find the minimum path of length k in the grid. You can start\n-- from any cell, and in each step you can move to any of the neighbor cells,\n-- in other words, you can go to cells which share an edge with you current\n-- cell.\n-- Please note that a path of length k means visiting exactly k cells (not\n-- necessarily distinct).\n-- You CANNOT go off the grid.\n-- A path A (of length k) is considered less than a path B (of length k) if\n-- after making the ordered lists of the values on the cells that A and B go\n-- through (let's call them lst_A and lst_B), lst_A is lexicographically less\n-- than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n-- such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n-- lst_A[j] = lst_B[j].\n-- It is guaranteed that the answer is unique.\n-- Return an ordered list of the values on the cells that the minimum path go through.\n-- Examples:    \n-- >>> minPath({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3)\n-- {1, 2, 1}\n-- >>> minPath({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1)\n-- {1}\nlocal function minPath(grid, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minPath\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 3), {1, 2, 1})\n    lu.assertEquals(candidate({{5, 9, 3}, {4, 1, 6}, {7, 8, 2}}, 1), {1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}, 4), {1, 2, 1, 2})\n    lu.assertEquals(candidate({{6, 4, 13, 10}, {5, 7, 12, 1}, {3, 16, 11, 15}, {8, 14, 9, 2}}, 7), {1, 10, 1, 10, 1, 10, 1})\n    lu.assertEquals(candidate({{8, 14, 9, 2}, {6, 4, 13, 15}, {5, 7, 1, 12}, {3, 10, 11, 16}}, 5), {1, 7, 1, 7, 1})\n    lu.assertEquals(candidate({{11, 8, 7, 2}, {5, 16, 14, 4}, {9, 3, 15, 6}, {12, 13, 10, 1}}, 9), {1, 6, 1, 6, 1, 6, 1, 6, 1})\n    lu.assertEquals(candidate({{12, 13, 10, 1}, {9, 3, 15, 6}, {5, 16, 14, 4}, {11, 8, 7, 2}}, 12), {1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6})\n    lu.assertEquals(candidate({{2, 7, 4}, {3, 1, 5}, {6, 8, 9}}, 8), {1, 3, 1, 3, 1, 3, 1, 3})\n    lu.assertEquals(candidate({{6, 1, 5}, {3, 8, 9}, {2, 7, 4}}, 8), {1, 5, 1, 5, 1, 5, 1, 5})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}, 10), {1, 2, 1, 2, 1, 2, 1, 2, 1, 2})\n    lu.assertEquals(candidate({{1, 3}, {3, 2}}, 10), {1, 3, 1, 3, 1, 3, 1, 3, 1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "lua",
+    "prompt": "-- Out of list of strings, return the longest one. Return the first one in case of multiple\n-- strings of the same length. Return None in case the input list is empty.\n-- >>> longest({})\n-- None\n-- >>> longest({'a', 'b', 'c'})\n-- 'a'\n-- >>> longest({'a', 'bb', 'ccc'})\n-- 'ccc'\nlocal function longest(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = longest\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'x')\n    lu.assertEquals(candidate({'x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc'}), 'zzzz')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "lua",
+    "prompt": "-- Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n-- the last couple centuries. However, what people don't know is Tribonacci sequence.\n-- Tribonacci sequence is defined by the recurrence:\n-- tri(1) = 3\n-- tri(n) = 1 + n / 2, if n is even.\n-- tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n-- For example:\n-- tri(2) = 1 + (2 / 2) = 2\n-- tri(4) = 3\n-- tri(3) = tri(2) + tri(1) + tri(4)\n-- = 2 + 3 + 3 = 8 \n-- You are given a non-negative integer number n, you have to a return a list of the \n-- first n + 1 numbers of the Tribonacci sequence.\n-- Examples:\n-- >>> tri(3)\n-- {1, 3, 2, 8}\nlocal function tri(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tri\n    lu.assertEquals(candidate(3), {1, 3, 2, 8})\n    lu.assertEquals(candidate(4), {1, 3, 2, 8, 3})\n    lu.assertEquals(candidate(5), {1, 3, 2, 8, 3, 15})\n    lu.assertEquals(candidate(6), {1, 3, 2, 8, 3, 15, 4})\n    lu.assertEquals(candidate(7), {1, 3, 2, 8, 3, 15, 4, 24})\n    lu.assertEquals(candidate(8), {1, 3, 2, 8, 3, 15, 4, 24, 5})\n    lu.assertEquals(candidate(9), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35})\n    lu.assertEquals(candidate(20), {1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11})\n    lu.assertEquals(candidate(0), {1})\n    lu.assertEquals(candidate(1), {1, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the product of the odd digits.\n-- Return 0 if all digits are even.\n-- For example:\n-- >>> digits(1)\n-- 1\n-- >>> digits(4)\n-- 0\n-- >>> digits(235)\n-- 15\nlocal function digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digits\n    lu.assertEquals(candidate(5), 5)\n    lu.assertEquals(candidate(54), 5)\n    lu.assertEquals(candidate(120), 1)\n    lu.assertEquals(candidate(5014), 5)\n    lu.assertEquals(candidate(98765), 315)\n    lu.assertEquals(candidate(5576543), 2625)\n    lu.assertEquals(candidate(2468), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a string as input which contains only square brackets.\n-- The function should return True if and only if there is a valid subsequence of brackets \n-- where at least one bracket in the subsequence is nested.\n-- >>> is_nested('[[]]')\n-- true\n-- >>> is_nested('[]]]]]]][[[[[]')\n-- false\n-- >>> is_nested('[][]')\n-- false\n-- >>> is_nested('[]')\n-- false\n-- >>> is_nested('[[][]]')\n-- true\n-- >>> is_nested('[[]][[')\n-- true\nlocal function is_nested(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nested\n    lu.assertEquals(candidate('[[]]'), true)\n    lu.assertEquals(candidate('[]]]]]]][[[[[]'), false)\n    lu.assertEquals(candidate('[][]'), false)\n    lu.assertEquals(candidate('[]'), false)\n    lu.assertEquals(candidate('[[[[]]]]'), true)\n    lu.assertEquals(candidate('[]]]]]]]]]]'), false)\n    lu.assertEquals(candidate('[][][[]]'), true)\n    lu.assertEquals(candidate('[[]'), false)\n    lu.assertEquals(candidate('[]]'), false)\n    lu.assertEquals(candidate('[[]][['), true)\n    lu.assertEquals(candidate('[[][]]'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('[[[[[[[['), false)\n    lu.assertEquals(candidate(']]]]]]]]'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "lua",
+    "prompt": "-- You are given a list of numbers.\n-- You need to return the sum of squared numbers in the given list,\n-- round each element in the list to the upper int(Ceiling) first.\n-- Examples:\n-- >>> lst({1.0, 2.0, 3.0})\n-- 14\n-- >>> lst({1.0, 4.0, 9.0})\n-- 98\n-- >>> lst({1.0, 3.0, 5.0, 7.0})\n-- 84\n-- >>> lst({1.4, 4.2, 0.0})\n-- 29\n-- >>> lst({-2.4, 1.0, 1.0})\n-- 6\nlocal function sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0}), 14)\n    lu.assertEquals(candidate({1.0, 3.0, 5.0, 7.0}), 84)\n    lu.assertEquals(candidate({1.4, 4.2, 0.0}), 29)\n    lu.assertEquals(candidate({-2.4, 1.0, 1.0}), 6)\n    lu.assertEquals(candidate({100.0, 1.0, 15.0, 2.0}), 10230)\n    lu.assertEquals(candidate({10000.0, 10000.0}), 200000000)\n    lu.assertEquals(candidate({-1.4, 4.6, 6.3}), 75)\n    lu.assertEquals(candidate({-1.4, 17.9, 18.9, 19.9}), 1086)\n    lu.assertEquals(candidate({0.0}), 0)\n    lu.assertEquals(candidate({-1.0}), 1)\n    lu.assertEquals(candidate({-1.0, 1.0, 0.0}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "lua",
+    "prompt": "-- Create a function that returns True if the last character\n-- of a given string is an alphabetical character and is not\n-- a part of a word, and False otherwise.\n-- Note: \"word\" is a group of characters separated by space.\n-- Examples:\n-- >>> check_if_last_char_is_a_letter('apple pie')\n-- false\n-- >>> check_if_last_char_is_a_letter('apple pi e')\n-- true\n-- >>> check_if_last_char_is_a_letter('apple pi e ')\n-- false\n-- >>> check_if_last_char_is_a_letter('')\n-- false\nlocal function check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_if_last_char_is_a_letter\n    lu.assertEquals(candidate('apple'), false)\n    lu.assertEquals(candidate('apple pi e'), true)\n    lu.assertEquals(candidate('eeeee'), false)\n    lu.assertEquals(candidate('A'), true)\n    lu.assertEquals(candidate('Pumpkin pie '), false)\n    lu.assertEquals(candidate('Pumpkin pie 1'), false)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('eeeee e '), false)\n    lu.assertEquals(candidate('apple pie'), false)\n    lu.assertEquals(candidate('apple pi e '), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "lua",
+    "prompt": "-- Create a function which returns the largest index of an element which\n-- is not greater than or equal to the element immediately preceding it. If\n-- no such element exists then return -1. The given array will not contain\n-- duplicate values.\n-- Examples:\n-- >>> can_arrange({1, 2, 4, 3, 5})\n-- 3\n-- >>> can_arrange({1, 2, 3})\n-- -1\nlocal function can_arrange(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = can_arrange\n    lu.assertEquals(candidate({1, 2, 4, 3, 5}), 3)\n    lu.assertEquals(candidate({1, 2, 4, 5}), -1)\n    lu.assertEquals(candidate({1, 4, 2, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({4, 8, 5, 7, 3}), 4)\n    lu.assertEquals(candidate({}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "lua",
+    "prompt": "-- Create a function that returns a tuple (a, b), where 'a' is\n-- the largest of negative integers, and 'b' is the smallest\n-- of positive integers in a list.\n-- If there is no negative or positive integers, return them as None.\n-- Examples:\n-- >>> largest_smallest_integers({2, 4, 1, 3, 5, 7})\n-- {None, 1}\n-- >>> largest_smallest_integers({})\n-- {None, None}\n-- >>> largest_smallest_integers({0})\n-- {None, None}\nlocal function largest_smallest_integers(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_smallest_integers\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7}), {None, 1})\n    lu.assertEquals(candidate({2, 4, 1, 3, 5, 7, 0}), {None, 1})\n    lu.assertEquals(candidate({1, 3, 2, 4, 5, 6, -2}), {-2, 1})\n    lu.assertEquals(candidate({4, 5, 3, 6, 2, 7, -7}), {-7, 2})\n    lu.assertEquals(candidate({7, 3, 8, 4, 9, 2, 5, -9}), {-9, 2})\n    lu.assertEquals(candidate({}), {None, None})\n    lu.assertEquals(candidate({0}), {None, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6}), {-1, None})\n    lu.assertEquals(candidate({-1, -3, -5, -6, 0}), {-1, None})\n    lu.assertEquals(candidate({-6, -4, -4, -3, 1}), {-3, 1})\n    lu.assertEquals(candidate({-6, -4, -4, -3, -100, 1}), {-3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "lua",
+    "prompt": "-- Create a function that takes integers, floats, or strings representing\n-- real numbers, and returns the larger variable in its given variable type.\n-- Return None if the values are equal.\n-- Note: If a real number is represented as a string, the floating point might be . or ,\n-- >>> compare_one(1, 2.5)\n-- 2.5\n-- >>> compare_one(1, '2,3')\n-- '2,3'\n-- >>> compare_one('5,1', '6')\n-- '6'\n-- >>> compare_one('1', 1)\n-- None\nlocal function compare_one(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare_one\n    lu.assertEquals(candidate(1, 2), 2)\n    lu.assertEquals(candidate(1, 2.5), 2.5)\n    lu.assertEquals(candidate(2, 3), 3)\n    lu.assertEquals(candidate(5, 6), 6)\n    lu.assertEquals(candidate(1, '2,3'), '2,3')\n    lu.assertEquals(candidate('5,1', '6'), '6')\n    lu.assertEquals(candidate('1', '2'), '2')\n    lu.assertEquals(candidate('1', 1), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "lua",
+    "prompt": "-- Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n-- Example\n-- >>> is_equal_to_sum_even(4)\n-- false\n-- >>> is_equal_to_sum_even(6)\n-- false\n-- >>> is_equal_to_sum_even(8)\n-- true\nlocal function is_equal_to_sum_even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_equal_to_sum_even\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(11), false)\n    lu.assertEquals(candidate(12), true)\n    lu.assertEquals(candidate(13), false)\n    lu.assertEquals(candidate(16), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "lua",
+    "prompt": "-- The Brazilian factorial is defined as:\n-- brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n-- where n > 0\n-- For example:\n-- >>> special_factorial(4)\n-- 288\n-- The function will receive an integer as input and should return the special\n-- factorial of this integer.\nlocal function special_factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = special_factorial\n    lu.assertEquals(candidate(4), 288)\n    lu.assertEquals(candidate(5), 34560)\n    lu.assertEquals(candidate(7), 125411328000)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "lua",
+    "prompt": "-- Return a greatest common divisor of two integers a and b\n-- >>> greatest_common_divisor(3, 5)\n-- 1\n-- >>> greatest_common_divisor(25, 15)\n-- 5\nlocal function greatest_common_divisor(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = greatest_common_divisor\n    lu.assertEquals(candidate(3, 7), 1)\n    lu.assertEquals(candidate(10, 15), 5)\n    lu.assertEquals(candidate(49, 14), 7)\n    lu.assertEquals(candidate(144, 60), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "lua",
+    "prompt": "-- Given a string text, replace all spaces in it with underscores, \n-- and if a string has more than 2 consecutive spaces, \n-- then replace all consecutive spaces with - \n-- >>> fix_spaces(' Example')\n-- 'Example'\n-- >>> fix_spaces(' Example 1')\n-- 'Example_1'\n-- >>> fix_spaces(' Example 2')\n-- '_Example_2'\n-- >>> fix_spaces(' Example 3')\n-- '_Example-3'\nlocal function fix_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fix_spaces\n    lu.assertEquals(candidate('Example'), 'Example')\n    lu.assertEquals(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')\n    lu.assertEquals(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')\n    lu.assertEquals(candidate('Exa   mple'), 'Exa-mple')\n    lu.assertEquals(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "lua",
+    "prompt": "-- Create a function which takes a string representing a file's name, and returns\n-- 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n-- A file's name is considered to be valid if and only if all the following conditions \n-- are met:\n-- - There should not be more than three digits ('0'-'9') in the file's name.\n-- - The file's name contains exactly one dot '.'\n-- - The substring before the dot should not be empty, and it starts with a letter from \n-- the latin alphapet ('a'-'z' and 'A'-'Z').\n-- - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n-- Examples:\n-- >>> file_name_check('example.txt')\n-- 'Yes'\n-- >>> file_name_check('1example.dll')\n-- 'No'\nlocal function file_name_check(file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = file_name_check\n    lu.assertEquals(candidate('example.txt'), 'Yes')\n    lu.assertEquals(candidate('1example.dll'), 'No')\n    lu.assertEquals(candidate('s1sdf3.asd'), 'No')\n    lu.assertEquals(candidate('K.dll'), 'Yes')\n    lu.assertEquals(candidate('MY16FILE3.exe'), 'Yes')\n    lu.assertEquals(candidate('His12FILE94.exe'), 'No')\n    lu.assertEquals(candidate('_Y.txt'), 'No')\n    lu.assertEquals(candidate('?aREYA.exe'), 'No')\n    lu.assertEquals(candidate('/this_is_valid.dll'), 'No')\n    lu.assertEquals(candidate('this_is_valid.wow'), 'No')\n    lu.assertEquals(candidate('this_is_valid.txt'), 'Yes')\n    lu.assertEquals(candidate('this_is_valid.txtexe'), 'No')\n    lu.assertEquals(candidate('#this2_i4s_5valid.ten'), 'No')\n    lu.assertEquals(candidate('@this1_is6_valid.exe'), 'No')\n    lu.assertEquals(candidate('this_is_12valid.6exe4.txt'), 'No')\n    lu.assertEquals(candidate('all.exe.txt'), 'No')\n    lu.assertEquals(candidate('I563_No.exe'), 'Yes')\n    lu.assertEquals(candidate('Is3youfault.txt'), 'Yes')\n    lu.assertEquals(candidate('no_one#knows.dll'), 'Yes')\n    lu.assertEquals(candidate('1I563_Yes3.exe'), 'No')\n    lu.assertEquals(candidate('I563_Yes3.txtt'), 'No')\n    lu.assertEquals(candidate('final..txt'), 'No')\n    lu.assertEquals(candidate('final132'), 'No')\n    lu.assertEquals(candidate('_f4indsartal132.'), 'No')\n    lu.assertEquals(candidate('.txt'), 'No')\n    lu.assertEquals(candidate('s.'), 'No')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "lua",
+    "prompt": "-- \"\n-- This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n-- multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n-- change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n-- Examples:\n-- >>> lst\n-- {1, 2, 3}\n-- >>> lst\n-- {}\n-- >>> lst\n-- {-1, -5, 2, -1, -5}\nlocal function sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_squares\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({1, 4, 9}), 14)\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({1, 1, 1, 1, 1, 1, 1, 1, 1}), 9)\n    lu.assertEquals(candidate({-1, -1, -1, -1, -1, -1, -1, -1, -1}), -3)\n    lu.assertEquals(candidate({0}), 0)\n    lu.assertEquals(candidate({-1, -5, 2, -1, -5}), -126)\n    lu.assertEquals(candidate({-56, -99, 1, 0, -2}), 3030)\n    lu.assertEquals(candidate({-1, 0, 0, 0, 0, 0, 0, 0, -1}), 0)\n    lu.assertEquals(candidate({-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37}), -14196)\n    lu.assertEquals(candidate({-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10}), -1448)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "lua",
+    "prompt": "-- You are given a string representing a sentence,\n-- the sentence contains some words separated by a space,\n-- and you have to return a string that contains the words from the original sentence,\n-- whose lengths are prime numbers,\n-- the order of the words in the new string should be the same as the original one.\n-- Example 1:\n-- >>> words_in_sentence('This is a test')\n-- 'is'\n-- Example 2:\n-- >>> words_in_sentence('lets go for swimming')\n-- 'go for'\n-- Constraints:\n-- * 1 <= len(sentence) <= 100\n-- * sentence contains only letters\nlocal function words_in_sentence(sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = words_in_sentence\n    lu.assertEquals(candidate('This is a test'), 'is')\n    lu.assertEquals(candidate('lets go for swimming'), 'go for')\n    lu.assertEquals(candidate('there is no place available here'), 'there is no place')\n    lu.assertEquals(candidate('Hi I am Hussein'), 'Hi am Hussein')\n    lu.assertEquals(candidate('go for it'), 'go for it')\n    lu.assertEquals(candidate('here'), '')\n    lu.assertEquals(candidate('here is'), 'is')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "lua",
+    "prompt": "-- Your task is to implement a function that will simplify the expression\n-- x * n. The function returns True if x * n evaluates to a whole number and False\n-- otherwise. Both x and n, are string representation of a fraction, and have the following format,\n-- <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n-- You can assume that x, and n are valid fractions, and do not have zero as denominator.\n-- >>> simplify('1/5', '5/1')\n-- true\n-- >>> simplify('1/6', '2/1')\n-- false\n-- >>> simplify('7/10', '10/2')\n-- false\nlocal function simplify(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = simplify\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/6', '2/1'), false)\n    lu.assertEquals(candidate('5/1', '3/1'), true)\n    lu.assertEquals(candidate('7/10', '10/2'), false)\n    lu.assertEquals(candidate('2/10', '50/10'), true)\n    lu.assertEquals(candidate('7/2', '4/2'), true)\n    lu.assertEquals(candidate('11/6', '6/1'), true)\n    lu.assertEquals(candidate('2/3', '5/2'), false)\n    lu.assertEquals(candidate('5/2', '3/5'), false)\n    lu.assertEquals(candidate('2/4', '8/4'), true)\n    lu.assertEquals(candidate('2/4', '4/2'), true)\n    lu.assertEquals(candidate('1/5', '5/1'), true)\n    lu.assertEquals(candidate('1/5', '1/5'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "lua",
+    "prompt": "-- Write a function which sorts the given list of integers\n-- in ascending order according to the sum of their digits.\n-- Note: if there are several items with similar sum of their digits,\n-- order them based on their index in original list.\n-- For example:\n-- >>> order_by_points({1, 11, -1, -11, -12})\n-- {-1, -11, 1, -12, 11}\n-- >>> order_by_points({})\n-- {}\nlocal function order_by_points(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = order_by_points\n    lu.assertEquals(candidate({1, 11, -1, -11, -12}), {-1, -11, 1, -12, 11})\n    lu.assertEquals(candidate({1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46}), {0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, -11, -32, 43, 54, -98, 2, -3}), {-3, -32, -98, -11, 1, 2, 43, 54})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({0, 6, 6, -76, -21, 23, 4}), {-76, -21, 0, 4, 23, 6, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2254,7 +769,7 @@
     "language": "lua",
     "prompt": "-- Write a function that takes an array of numbers as input and returns \n-- the number of elements in the array that are greater than 10 and both \n-- first and last digits of a number are odd (1, 3, 5, 7, 9).\n-- For example:\n-- >>> specialFilter({15, -73, 14, -15})\n-- 1\n-- >>> specialFilter({33, -2, -3, 45, 21, 109})\n-- 2\nlocal function specialFilter(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = specialFilter\n    lu.assertEquals(candidate({5, -2, 1, -5}), 0)\n    lu.assertEquals(candidate({15, -73, 14, -15}), 1)\n    lu.assertEquals(candidate({33, -2, -3, 45, 21, 109}), 2)\n    lu.assertEquals(candidate({43, -12, 93, 125, 121, 109}), 4)\n    lu.assertEquals(candidate({71, -2, -33, 75, 21, 19}), 3)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "lua",
-    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
+    "prompt": "-- You are given a positive integer n. You have to create an integer array a of length n.\n-- For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n-- Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n-- and a[i] + a[j] + a[k] is a multiple of 3.\n-- Example :\n-- >>> get_max_triples(5)\n-- 1\n-- Explanation: \n-- a = [1, 3, 7, 13, 21]\n-- The only valid triple is (1, 7, 13).\nlocal function get_max_triples(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_triples\n    lu.assertEquals(candidate(5), 1)\n    lu.assertEquals(candidate(6), 4)\n    lu.assertEquals(candidate(10), 36)\n    lu.assertEquals(candidate(100), 53361)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "lua",
-    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates({1, 2, 3, 2, 4})\n-- {1, 3, 4}\nlocal function remove_duplicates(numbers)\n",
+    "prompt": "-- There are eight planets in our solar system: the closerst to the Sun \n-- is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n-- Uranus, Neptune.\n-- Write a function that takes two planet names as strings planet1 and planet2. \n-- The function should return a tuple containing all planets whose orbits are \n-- located between the orbit of planet1 and the orbit of planet2, sorted by \n-- the proximity to the sun. \n-- The function should return an empty tuple if planet1 or planet2\n-- are not correct planet names. \n-- Examples\n-- >>> bf('Jupiter', 'Neptune')\n-- {'Saturn', 'Uranus'}\n-- >>> bf('Earth', 'Mercury')\n-- 'Venus'\n-- >>> bf('Mercury', 'Uranus')\n-- {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'}\nlocal function bf(planet1, planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bf\n    lu.assertEquals(candidate('Jupiter', 'Neptune'), {'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Mercury'), {'Venus'})\n    lu.assertEquals(candidate('Mercury', 'Uranus'), {'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'})\n    lu.assertEquals(candidate('Neptune', 'Venus'), {'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'})\n    lu.assertEquals(candidate('Earth', 'Earth'), {})\n    lu.assertEquals(candidate('Mars', 'Earth'), {})\n    lu.assertEquals(candidate('Jupiter', 'Makemake'), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings as a parameter,\n-- deletes the strings that have odd lengths from it,\n-- and returns the resulted list with a sorted order,\n-- The list is always a list of strings and never an array of numbers,\n-- and it may contain duplicates.\n-- The order of the list should be ascending by length of each word, and you\n-- should return the list sorted by that rule.\n-- If two words have the same length, sort the list alphabetically.\n-- The function should return a list of strings in sorted order.\n-- You may assume that all words will have the same length.\n-- For example:\n-- >>> list_sort({'aa', 'a', 'aaa'})\n-- {'aa'}\n-- >>> list_sort({'ab', 'a', 'aaa', 'cd'})\n-- {'ab', 'cd'}\nlocal function sorted_list_sum(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sorted_list_sum\n    lu.assertEquals(candidate({'aa', 'a', 'aaa'}), {'aa'})\n    lu.assertEquals(candidate({'school', 'AI', 'asdf', 'b'}), {'AI', 'asdf', 'school'})\n    lu.assertEquals(candidate({'d', 'b', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'d', 'dcba', 'abcd', 'a'}), {'abcd', 'dcba'})\n    lu.assertEquals(candidate({'AI', 'ai', 'au'}), {'AI', 'ai', 'au'})\n    lu.assertEquals(candidate({'a', 'b', 'b', 'c', 'c', 'a'}), {})\n    lu.assertEquals(candidate({'aaaa', 'bbbb', 'dd', 'cc'}), {'cc', 'dd', 'aaaa', 'bbbb'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "lua",
+    "prompt": "-- Return list of all prefixes from shortest to longest of the input string\n-- >>> all_prefixes('abc')\n-- {'a', 'ab', 'abc'}\nlocal function all_prefixes(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_prefixes\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('asdfgh'), {'a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'})\n    lu.assertEquals(candidate('WWW'), {'W', 'WW', 'WWW'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "lua",
+    "prompt": "-- A simple program which should return the value of x if n is \n-- a prime number and should return the value of y otherwise.\n-- Examples:\n-- >>> x_or_y(7, 34, 12)\n-- 34\n-- >>> x_or_y(15, 8, 5)\n-- 5\nlocal function x_or_y(n, x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = x_or_y\n    lu.assertEquals(candidate(7, 34, 12), 34)\n    lu.assertEquals(candidate(15, 8, 5), 5)\n    lu.assertEquals(candidate(3, 33, 5212), 33)\n    lu.assertEquals(candidate(1259, 3, 52), 3)\n    lu.assertEquals(candidate(7919, -1, 12), -1)\n    lu.assertEquals(candidate(3609, 1245, 583), 583)\n    lu.assertEquals(candidate(91, 56, 129), 129)\n    lu.assertEquals(candidate(6, 34, 1234), 1234)\n    lu.assertEquals(candidate(1, 2, 0), 0)\n    lu.assertEquals(candidate(2, 2, 0), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "lua",
+    "prompt": "-- Given a list of numbers, return the sum of squares of the numbers\n-- in the list that are odd. Ignore numbers that are negative or not integers.\n-- >>> double_the_difference({1, 3, 2, 0})\n-- 10\n-- >>> double_the_difference({-1, -2, 0})\n-- 0\n-- >>> double_the_difference({9, -2})\n-- 81\n-- >>> double_the_difference({0})\n-- 0\n-- If the input list is empty, return 0.\nlocal function double_the_difference(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = double_the_difference\n    lu.assertEquals(candidate({}), 0)\n    lu.assertEquals(candidate({5.0, 4.0}), 25)\n    lu.assertEquals(candidate({0.1, 0.2, 0.3}), 0)\n    lu.assertEquals(candidate({-10.0, -20.0, -30.0}), 0)\n    lu.assertEquals(candidate({-1.0, -2.0, 8.0}), 0)\n    lu.assertEquals(candidate({0.2, 3.0, 5.0}), 34)\n    lu.assertEquals(candidate({-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0}), 165)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "lua",
+    "prompt": "-- I think we all remember that feeling when the result of some long-awaited\n-- event is finally known. The feelings and thoughts you have at that moment are\n-- definitely worth noting down and comparing.\n-- Your task is to determine if a person correctly guessed the results of a number of matches.\n-- You are given two arrays of scores and guesses of equal length, where each index shows a match. \n-- Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n-- the value is 0, and if not, the value is the absolute difference between the guess and the score.\n-- example:\n-- >>> compare({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2})\n-- {0, 0, 0, 0, 3, 3}\n-- >>> compare({0, 5, 0, 0, 0, 4}, {4, 1, 1, 0, 0, -2})\n-- {4, 4, 1, 0, 0, 6}\nlocal function compare(game, guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = compare\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 1}, {1, 2, 3, 4, 2, -2}), {0, 0, 0, 0, 3, 3})\n    lu.assertEquals(candidate({0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}), {0, 0, 0, 0, 0, 0})\n    lu.assertEquals(candidate({1, 2, 3}, {-1, -2, -3}), {2, 4, 6})\n    lu.assertEquals(candidate({1, 2, 3, 5}, {-1, 2, 3, 4}), {2, 0, 0, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "lua",
+    "prompt": "-- You will be given the name of a class (a string) and a list of extensions.\n-- The extensions are to be used to load additional classes to the class. The\n-- strength of the extension is as follows: Let CAP be the number of the uppercase\n-- letters in the extension's name, and let SM be the number of lowercase letters \n-- in the extension's name, the strength is given by the fraction CAP - SM. \n-- You should find the strongest extension and return a string in this \n-- format: ClassName.StrongestExtensionName.\n-- If there are two or more extensions with the same strength, you should\n-- choose the one that comes first in the list.\n-- For example, if you are given \"Slices\" as the class and a list of the\n-- extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n-- return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n-- (its strength is -1).\n-- Example:\n-- >>> Strongest_Extension('my_class', {'AA', 'Be', 'CC'})\n-- 'my_class.AA'\nlocal function Strongest_Extension(class_name, extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Strongest_Extension\n    lu.assertEquals(candidate('Watashi', {'tEN', 'niNE', 'eIGHt8OKe'}), 'Watashi.eIGHt8OKe')\n    lu.assertEquals(candidate('Boku123', {'nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg'}), 'Boku123.YEs.WeCaNe')\n    lu.assertEquals(candidate('__YESIMHERE', {'t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321'}), '__YESIMHERE.NuLl__')\n    lu.assertEquals(candidate('K', {'Ta', 'TAR', 't234An', 'cosSo'}), 'K.TAR')\n    lu.assertEquals(candidate('__HAHA', {'Tab', '123', '781345', '-_-'}), '__HAHA.123')\n    lu.assertEquals(candidate('YameRore', {'HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-'}), 'YameRore.okIWILL123')\n    lu.assertEquals(candidate('finNNalLLly', {'Die', 'NowW', 'Wow', 'WoW'}), 'finNNalLLly.WoW')\n    lu.assertEquals(candidate('_', {'Bb', '91245'}), '_.Bb')\n    lu.assertEquals(candidate('Sp', {'671235', 'Bb'}), 'Sp.671235')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "lua",
+    "prompt": "-- You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n-- >>> cycpattern_check('abcd', 'abd')\n-- false\n-- >>> cycpattern_check('hello', 'ell')\n-- true\n-- >>> cycpattern_check('whassup', 'psus')\n-- false\n-- >>> cycpattern_check('abab', 'baa')\n-- true\n-- >>> cycpattern_check('efef', 'eeff')\n-- false\n-- >>> cycpattern_check('himenss', 'simen')\n-- true\nlocal function cycpattern_check(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cycpattern_check\n    lu.assertEquals(candidate('xyzw', 'xyw'), false)\n    lu.assertEquals(candidate('yello', 'ell'), true)\n    lu.assertEquals(candidate('whattup', 'ptut'), false)\n    lu.assertEquals(candidate('efef', 'fee'), true)\n    lu.assertEquals(candidate('abab', 'aabb'), false)\n    lu.assertEquals(candidate('winemtt', 'tinem'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "lua",
+    "prompt": "-- Given an integer. return a tuple that has the number of even and odd digits respectively.\n-- Example:\n-- >>> even_odd_count(-12)\n-- {1, 1}\n-- >>> even_odd_count(123)\n-- {1, 2}\nlocal function even_odd_count(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_odd_count\n    lu.assertEquals(candidate(7), {0, 1})\n    lu.assertEquals(candidate(-78), {1, 1})\n    lu.assertEquals(candidate(3452), {2, 2})\n    lu.assertEquals(candidate(346211), {3, 3})\n    lu.assertEquals(candidate(-345821), {3, 3})\n    lu.assertEquals(candidate(-2), {1, 0})\n    lu.assertEquals(candidate(-45347), {2, 3})\n    lu.assertEquals(candidate(0), {1, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "lua",
+    "prompt": "-- Given a positive integer, obtain its roman numeral equivalent as a string,\n-- and return it in lowercase.\n-- Restrictions: 1 <= num <= 1000\n-- Examples:\n-- >>> int_to_mini_roman(19)\n-- 'xix'\n-- >>> int_to_mini_roman(152)\n-- 'clii'\n-- >>> int_to_mini_roman(426)\n-- 'cdxxvi'\nlocal function int_to_mini_roman(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = int_to_mini_roman\n    lu.assertEquals(candidate(19), 'xix')\n    lu.assertEquals(candidate(152), 'clii')\n    lu.assertEquals(candidate(251), 'ccli')\n    lu.assertEquals(candidate(426), 'cdxxvi')\n    lu.assertEquals(candidate(500), 'd')\n    lu.assertEquals(candidate(1), 'i')\n    lu.assertEquals(candidate(4), 'iv')\n    lu.assertEquals(candidate(43), 'xliii')\n    lu.assertEquals(candidate(90), 'xc')\n    lu.assertEquals(candidate(94), 'xciv')\n    lu.assertEquals(candidate(532), 'dxxxii')\n    lu.assertEquals(candidate(900), 'cm')\n    lu.assertEquals(candidate(994), 'cmxciv')\n    lu.assertEquals(candidate(1000), 'm')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return True if the three\n-- sides form a right-angled triangle, False otherwise.\n-- A right-angled triangle is a triangle in which one angle is right angle or \n-- 90 degree.\n-- Example:\n-- >>> right_angle_triangle(3, 4, 5)\n-- true\n-- >>> right_angle_triangle(1, 2, 3)\n-- false\nlocal function right_angle_triangle(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_angle_triangle\n    lu.assertEquals(candidate(3, 4, 5), true)\n    lu.assertEquals(candidate(1, 2, 3), false)\n    lu.assertEquals(candidate(10, 6, 8), true)\n    lu.assertEquals(candidate(2, 2, 2), false)\n    lu.assertEquals(candidate(7, 24, 25), true)\n    lu.assertEquals(candidate(10, 5, 7), false)\n    lu.assertEquals(candidate(5, 12, 13), true)\n    lu.assertEquals(candidate(15, 8, 17), true)\n    lu.assertEquals(candidate(48, 55, 73), true)\n    lu.assertEquals(candidate(1, 1, 1), false)\n    lu.assertEquals(candidate(2, 2, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts a list of strings.\n-- The list contains different words. Return the word with maximum number\n-- of unique characters. If multiple strings have maximum number of unique\n-- characters, return the one which comes first in lexicographical order.\n-- >>> find_max({'name', 'of', 'string'})\n-- 'string'\n-- >>> find_max({'name', 'enam', 'game'})\n-- 'enam'\n-- >>> find_max({'aaaaaaa', 'bb', 'cc'})\n-- 'aaaaaaa'\nlocal function find_max(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_max\n    lu.assertEquals(candidate({'name', 'of', 'string'}), 'string')\n    lu.assertEquals(candidate({'name', 'enam', 'game'}), 'enam')\n    lu.assertEquals(candidate({'aaaaaaa', 'bb', 'cc'}), 'aaaaaaa')\n    lu.assertEquals(candidate({'abc', 'cba'}), 'abc')\n    lu.assertEquals(candidate({'play', 'this', 'game', 'of', 'footbott'}), 'footbott')\n    lu.assertEquals(candidate({'we', 'are', 'gonna', 'rock'}), 'gonna')\n    lu.assertEquals(candidate({'we', 'are', 'a', 'mad', 'nation'}), 'nation')\n    lu.assertEquals(candidate({'this', 'is', 'a', 'prrk'}), 'this')\n    lu.assertEquals(candidate({'b'}), 'b')\n    lu.assertEquals(candidate({'play', 'play', 'play'}), 'play')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "lua",
+    "prompt": "-- You're a hungry rabbit, and you already have eaten a certain number of carrots,\n-- but now you need to eat more carrots to complete the day's meals.\n-- you should return an array of [ total number of eaten carrots after your meals,\n-- the number of carrots left after your meals ]\n-- if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n-- Example:\n-- >>> eat(5, 6, 10)\n-- {11, 4}\n-- >>> eat(4, 8, 9)\n-- {12, 1}\n-- >>> eat(1, 10, 10)\n-- {11, 0}\n-- >>> eat(2, 11, 5)\n-- {7, 0}\n-- Variables:\n-- @number : integer\n-- the number of carrots that you have eaten.\n-- @need : integer\n-- the number of carrots that you need to eat.\n-- @remaining : integer\n-- the number of remaining carrots thet exist in stock\n-- Constrain:\n-- * 0 <= number <= 1000\n-- * 0 <= need <= 1000\n-- * 0 <= remaining <= 1000\n-- Have fun :)\nlocal function eat(number, need, remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eat\n    lu.assertEquals(candidate(5, 6, 10), {11, 4})\n    lu.assertEquals(candidate(4, 8, 9), {12, 1})\n    lu.assertEquals(candidate(1, 10, 10), {11, 0})\n    lu.assertEquals(candidate(2, 11, 5), {7, 0})\n    lu.assertEquals(candidate(4, 5, 7), {9, 2})\n    lu.assertEquals(candidate(4, 5, 1), {5, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "lua",
+    "prompt": "-- Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n-- >>> string_sequence(0)\n-- '0'\n-- >>> string_sequence(5)\n-- '0 1 2 3 4 5'\nlocal function string_sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_sequence\n    lu.assertEquals(candidate(0), '0')\n    lu.assertEquals(candidate(3), '0 1 2 3')\n    lu.assertEquals(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "lua",
+    "prompt": "-- Given two lists operator, and operand. The first list has basic algebra operations, and \n-- the second list is a list of integers. Use the two given lists to build the algebric \n-- expression and return the evaluation of this expression.\n-- The basic algebra operations:\n-- Addition ( + ) \n-- Subtraction ( - ) \n-- Multiplication ( * ) \n-- Floor division ( // ) \n-- Exponentiation ( ** ) \n-- Example:\n-- operator['+', '*', '-']\n-- array = [2, 3, 4, 5]\n-- result = 2 + 3 * 4 - 5\n-- => result = 9\n-- Note:\n-- The length of operator list is equal to the length of operand list minus one.\n-- Operand is a list of of non-negative integers.\n-- Operator list has at least one operator, and operand list has at least two operands.\nlocal function do_algebra(operator, operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = do_algebra\n    lu.assertEquals(candidate({'**', '*', '+'}, {2, 3, 4, 5}), 37)\n    lu.assertEquals(candidate({'+', '*', '-'}, {2, 3, 4, 5}), 9)\n    lu.assertEquals(candidate({'//', '*'}, {7, 3, 4}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- if s[i] is a letter, reverse its case from lower to upper or vise versa, \n-- otherwise keep it as it is.\n-- If the string contains no letters, reverse the string.\n-- The function should return the resulted string.\n-- Examples\n-- >>> solve('1234')\n-- '4321'\n-- >>> solve('ab')\n-- 'AB'\n-- >>> solve('#a@C')\n-- '#A@c'\nlocal function solve(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate('AsDf'), 'aSdF')\n    lu.assertEquals(candidate('1234'), '4321')\n    lu.assertEquals(candidate('ab'), 'AB')\n    lu.assertEquals(candidate('#a@C'), '#A@c')\n    lu.assertEquals(candidate('#AsdfW^45'), '#aSDFw^45')\n    lu.assertEquals(candidate('#6@2'), '2@6#')\n    lu.assertEquals(candidate('#$a^D'), '#$A^d')\n    lu.assertEquals(candidate('#ccc'), '#CCC')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "lua",
+    "prompt": "-- Given a string 'text', return its md5 hash equivalent string.\n-- If 'text' is an empty string, return None.\n-- >>> string_to_md5('Hello world')\n-- '3e25960a79dbc69b674cd4ec67a72c62'\nlocal function string_to_md5(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_md5\n    lu.assertEquals(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')\n    lu.assertEquals(candidate(''), None)\n    lu.assertEquals(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')\n    lu.assertEquals(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2299,7 +1054,7 @@
     "language": "lua",
     "prompt": "-- Given two positive integers a and b, return the even digits between a\n-- and b, in ascending order.\n-- For example:\n-- >>> generate_integers(2, 8)\n-- {2, 4, 6, 8}\n-- >>> generate_integers(8, 2)\n-- {2, 4, 6, 8}\n-- >>> generate_integers(10, 14)\n-- {}\nlocal function generate_integers(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = generate_integers\n    lu.assertEquals(candidate(2, 10), {2, 4, 6, 8})\n    lu.assertEquals(candidate(10, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(132, 2), {2, 4, 6, 8})\n    lu.assertEquals(candidate(17, 89), {})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "lua",
-    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max({1, 2, 3, 2, 3, 4, 2})\n-- {1, 2, 3, 3, 3, 4, 4}\nlocal function rolling_max(numbers)\n",
+    "prompt": "-- Given a string, find out how many distinct characters (regardless of case) does it consist of\n-- >>> count_distinct_characters('xyzXYZ')\n-- 3\n-- >>> count_distinct_characters('Jerry')\n-- 4\nlocal function count_distinct_characters(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_distinct_characters\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abcde'), 5)\n    lu.assertEquals(candidate('abcdecadeCADE'), 5)\n    lu.assertEquals(candidate('aaaaAAAAaaaa'), 1)\n    lu.assertEquals(candidate('Jerry jERRY JeRRRY'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "lua",
-    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\n-- >>> below_zero({1, 2, 3})\n-- false\n-- >>> below_zero({1, 2, -4, 5})\n-- true\nlocal function below_zero(operations)\n",
+    "prompt": "-- Input to this function is a string representing musical notes in a special ASCII format.\n-- Your task is to parse this string and return list of integers corresponding to how many beats does each\n-- not last.\n-- Here is a legend:\n-- 'o' - whole note, lasts four beats\n-- 'o|' - half note, lasts two beats\n-- '.|' - quater note, lasts one beat\n-- >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n-- {4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4}\nlocal function parse_music(music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_music\n    lu.assertEquals(candidate(''), {})\n    lu.assertEquals(candidate('o o o o'), {4, 4, 4, 4})\n    lu.assertEquals(candidate('.| .| .| .|'), {1, 1, 1, 1})\n    lu.assertEquals(candidate('o| o| .| .| o o o o'), {2, 2, 1, 1, 4, 4, 4, 4})\n    lu.assertEquals(candidate('o| .| o| .| o o| o o|'), {2, 1, 2, 1, 4, 2, 4, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "lua",
-    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\n-- >>> search({4, 1, 2, 2, 3, 1})\n-- 2\n-- >>> search({1, 2, 2, 3, 3, 3, 4, 4, 4})\n-- 3\n-- >>> search({5, 5, 4, 4, 4})\n-- -1\nlocal function search(lst)\n",
+    "prompt": "-- Find how many times a given substring can be found in the original string. Count overlaping cases.\n-- >>> how_many_times('', 'a')\n-- 0\n-- >>> how_many_times('aaa', 'a')\n-- 3\n-- >>> how_many_times('aaaa', 'aa')\n-- 3\nlocal function how_many_times(string, substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = how_many_times\n    lu.assertEquals(candidate('', 'x'), 0)\n    lu.assertEquals(candidate('xyxyxyx', 'x'), 4)\n    lu.assertEquals(candidate('cacacacac', 'cac'), 4)\n    lu.assertEquals(candidate('john doe', 'john'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "lua",
-    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('(')\n-- false\n-- >>> correct_bracketing('()')\n-- true\n-- >>> correct_bracketing('(()())')\n-- true\n-- >>> correct_bracketing(')(()')\n-- false\nlocal function correct_bracketing(brackets)\n",
+    "prompt": "-- Input is a space-delimited string of numberals from 'zero' to 'nine'.\n-- Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n-- Return the string with numbers sorted from smallest to largest\n-- >>> sort_numbers('three one five')\n-- 'one three five'\nlocal function sort_numbers(numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numbers\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('three'), 'three')\n    lu.assertEquals(candidate('three five nine'), 'three five nine')\n    lu.assertEquals(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')\n    lu.assertEquals(candidate('six five four three two one zero'), 'zero one two three four five six')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n-- separate those group into separate strings and return the list of those.\n-- Separate groups are balanced (each open brace is properly closed) and not nested within each other\n-- Ignore any spaces in the input string.\n-- >>> separate_paren_groups('( ) (( )) (( )( ))')\n-- {'()', '(())', '(()())'}\nlocal function separate_paren_groups(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = separate_paren_groups\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {'(()())', '((()))', '()', '((())()())'})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {'()', '(())', '((()))', '(((())))'})\n    lu.assertEquals(candidate('(()(())((())))'), {'(()(())((())))'})\n    lu.assertEquals(candidate('( ) (( )) (( )( ))'), {'()', '(())', '(()())'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "lua",
+    "prompt": "-- From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n-- other and return them in order (smaller number, larger number).\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.2})\n-- {2.0, 2.2}\n-- >>> find_closest_elements({1.0, 2.0, 3.0, 4.0, 5.0, 2.0})\n-- {2.0, 2.0}\nlocal function find_closest_elements(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_closest_elements\n    lu.assertEquals(candidate({1.0, 2.0, 3.9, 4.0, 5.0, 2.2}), {3.9, 4.0})\n    lu.assertEquals(candidate({1.0, 2.0, 5.9, 4.0, 5.0}), {5.0, 5.9})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.2}), {2.0, 2.2})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0, 2.0}), {2.0, 2.0})\n    lu.assertEquals(candidate({1.1, 2.2, 3.1, 4.1, 5.1}), {2.2, 3.1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "lua",
+    "prompt": "-- Given list of numbers (of at least two elements), apply a linear transform to that list,\n-- such that the smallest number will become 0 and the largest will become 1\n-- >>> rescale_to_unit({1.0, 2.0, 3.0, 4.0, 5.0})\n-- {0.0, 0.25, 0.5, 0.75, 1.0}\nlocal function rescale_to_unit(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rescale_to_unit\n    lu.assertEquals(candidate({2.0, 49.9}), {0.0, 1.0})\n    lu.assertEquals(candidate({100.0, 49.9}), {1.0, 0.0})\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), {0.0, 0.25, 0.5, 0.75, 1.0})\n    lu.assertEquals(candidate({2.0, 1.0, 5.0, 3.0, 4.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\n    lu.assertEquals(candidate({12.0, 11.0, 15.0, 13.0, 14.0}), {0.25, 0.0, 1.0, 0.5, 0.75})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "lua",
+    "prompt": "-- Filter given list of any python values only for integers\n-- >>> filter_integers({'a', 3.14, 5})\n-- {5}\n-- >>> filter_integers({1, 2, 3, 'abc', {}, {}})\n-- {1, 2, 3}\nlocal function filter_integers(values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_integers\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({4, {}, {}, 23.2, 9, 'adasd'}), {4, 9})\n    lu.assertEquals(candidate({3, 'c', 3, 3, 'a', 'b'}), {3, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "lua",
+    "prompt": "-- Return length of given string\n-- >>> strlen('')\n-- 0\n-- >>> strlen('abc')\n-- 3\nlocal function strlen(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strlen\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('x'), 1)\n    lu.assertEquals(candidate('asdasnakj'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "lua",
+    "prompt": "-- For a given number n, find the largest number that divides n evenly, smaller than n\n-- >>> largest_divisor(15)\n-- 5\nlocal function largest_divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_divisor\n    lu.assertEquals(candidate(3), 1)\n    lu.assertEquals(candidate(7), 1)\n    lu.assertEquals(candidate(10), 5)\n    lu.assertEquals(candidate(100), 50)\n    lu.assertEquals(candidate(49), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "lua",
+    "prompt": "-- Return list of prime factors of given integer in the order from smallest to largest.\n-- Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n-- Input number should be equal to the product of all factors\n-- >>> factorize(8)\n-- {2, 2, 2}\n-- >>> factorize(25)\n-- {5, 5}\n-- >>> factorize(70)\n-- {2, 5, 7}\nlocal function factorize(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = factorize\n    lu.assertEquals(candidate(2), {2})\n    lu.assertEquals(candidate(4), {2, 2})\n    lu.assertEquals(candidate(8), {2, 2, 2})\n    lu.assertEquals(candidate(57), {3, 19})\n    lu.assertEquals(candidate(3249), {3, 3, 19, 19})\n    lu.assertEquals(candidate(185193), {3, 3, 3, 19, 19, 19})\n    lu.assertEquals(candidate(20577), {3, 19, 19, 19})\n    lu.assertEquals(candidate(18), {2, 3, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "lua",
+    "prompt": "-- From a list of integers, remove all elements that occur more than once.\n-- Keep order of elements left the same as in the input.\n-- >>> remove_duplicates({1, 2, 3, 2, 4})\n-- {1, 3, 4}\nlocal function remove_duplicates(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_duplicates\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 3, 5}), {1, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "lua",
+    "prompt": "-- For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n-- >>> flip_case('Hello')\n-- 'hELLO'\nlocal function flip_case(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flip_case\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hello!'), 'hELLO!')\n    lu.assertEquals(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "lua",
+    "prompt": "-- Concatenate list of strings into a single string\n-- >>> concatenate({})\n-- ''\n-- >>> concatenate({'a', 'b', 'c'})\n-- 'abc'\nlocal function concatenate(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate\n    lu.assertEquals(candidate({}), '')\n    lu.assertEquals(candidate({'x', 'y', 'z'}), 'xyz')\n    lu.assertEquals(candidate({'x', 'y', 'z', 'w', 'k'}), 'xyzwk')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that start with a given prefix.\n-- >>> filter_by_prefix({}, 'a')\n-- {}\n-- >>> filter_by_prefix({'abc', 'bcd', 'cde', 'array'}, 'a')\n-- {'abc', 'array'}\nlocal function filter_by_prefix(strings, prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_prefix\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "lua",
+    "prompt": "-- Given a positive floating point number, it can be decomposed into\n-- and integer part (largest integer smaller than given number) and decimals\n-- (leftover part always smaller than 1).\n-- Return the decimal part of the number.\n-- >>> truncate_number(3.5)\n-- 0.5\nlocal function truncate_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = truncate_number\n    lu.assertEquals(candidate(3.5), 0.5)\n    lu.assertEquals(candidate(1.25), 0.25)\n    lu.assertEquals(candidate(123.0), 0.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "lua",
+    "prompt": "-- Return only positive numbers in the list.\n-- >>> get_positive({-1, 2, -4, 5, 6})\n-- {2, 5, 6}\n-- >>> get_positive({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- {5, 3, 2, 3, 9, 123, 1}\nlocal function get_positive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_positive\n    lu.assertEquals(candidate({-1, -2, 4, 5, 6}), {4, 5, 6})\n    lu.assertEquals(candidate({5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10}), {5, 3, 2, 3, 3, 9, 123, 1})\n    lu.assertEquals(candidate({-1, -2}), {})\n    lu.assertEquals(candidate({}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "lua",
+    "prompt": "-- Return true if a given number is prime, and false otherwise.\n-- >>> is_prime(6)\n-- false\n-- >>> is_prime(101)\n-- true\n-- >>> is_prime(11)\n-- true\n-- >>> is_prime(13441)\n-- true\n-- >>> is_prime(61)\n-- true\n-- >>> is_prime(4)\n-- false\n-- >>> is_prime(1)\n-- false\nlocal function is_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_prime\n    lu.assertEquals(candidate(6), false)\n    lu.assertEquals(candidate(101), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(13441), true)\n    lu.assertEquals(candidate(61), true)\n    lu.assertEquals(candidate(4), false)\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(11), true)\n    lu.assertEquals(candidate(17), true)\n    lu.assertEquals(candidate(85), false)\n    lu.assertEquals(candidate(77), false)\n    lu.assertEquals(candidate(255379), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "lua",
+    "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n-- to the values of the corresponding indicies of l, but sorted.\n-- >>> sort_third({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_third({5, 6, 3, 4, 8, 9, 2})\n-- {2, 6, 3, 4, 8, 9, 5}\nlocal function sort_third(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_third\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2}), {2, 6, 3, 4, 8, 9, 5})\n    lu.assertEquals(candidate({5, 8, 3, 4, 6, 9, 2}), {2, 8, 3, 4, 6, 9, 5})\n    lu.assertEquals(candidate({5, 6, 9, 4, 8, 3, 2}), {2, 6, 9, 4, 8, 3, 5})\n    lu.assertEquals(candidate({5, 6, 3, 4, 8, 9, 2, 1}), {2, 6, 3, 4, 8, 9, 5, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "lua",
+    "prompt": "-- Return sorted unique elements in a list\n-- >>> unique({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {0, 2, 3, 5, 9, 123}\nlocal function unique(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique\n    lu.assertEquals(candidate({5, 3, 5, 2, 3, 3, 9, 0, 123}), {0, 2, 3, 5, 9, 123})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "lua",
+    "prompt": "-- Return maximum element in the list.\n-- >>> max_element({1, 2, 3})\n-- 3\n-- >>> max_element({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10})\n-- 123\nlocal function max_element(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_element\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "lua",
+    "prompt": "-- Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n-- >>> fizz_buzz(50)\n-- 0\n-- >>> fizz_buzz(78)\n-- 2\n-- >>> fizz_buzz(79)\n-- 3\nlocal function fizz_buzz(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fizz_buzz\n    lu.assertEquals(candidate(50), 0)\n    lu.assertEquals(candidate(78), 2)\n    lu.assertEquals(candidate(79), 3)\n    lu.assertEquals(candidate(100), 3)\n    lu.assertEquals(candidate(200), 6)\n    lu.assertEquals(candidate(4000), 192)\n    lu.assertEquals(candidate(10000), 639)\n    lu.assertEquals(candidate(100000), 8026)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2374,9 +1399,249 @@
     "language": "lua",
     "prompt": "-- This function takes a list l and returns a list l' such that\n-- l' is identical to l in the odd indicies, while its values at the even indicies are equal\n-- to the values of the even indicies of l, but sorted.\n-- >>> sort_even({1, 2, 3})\n-- {1, 2, 3}\n-- >>> sort_even({5, 6, 3, 4})\n-- {3, 6, 5, 4}\nlocal function sort_even(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_even\n    lu.assertEquals(candidate({1, 2, 3}), {1, 2, 3})\n    lu.assertEquals(candidate({5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10}), {-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123})\n    lu.assertEquals(candidate({5, 8, -12, 4, 23, 2, 3, 11, 12, -10}), {-12, 8, 3, 4, 5, 2, 12, 11, 23, -10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "lua",
+    "prompt": "-- prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n-- >>> prime_fib(1)\n-- 2\n-- >>> prime_fib(2)\n-- 3\n-- >>> prime_fib(3)\n-- 5\n-- >>> prime_fib(4)\n-- 13\n-- >>> prime_fib(5)\n-- 89\nlocal function prime_fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_fib\n    lu.assertEquals(candidate(1), 2)\n    lu.assertEquals(candidate(2), 3)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 13)\n    lu.assertEquals(candidate(5), 89)\n    lu.assertEquals(candidate(6), 233)\n    lu.assertEquals(candidate(7), 1597)\n    lu.assertEquals(candidate(8), 28657)\n    lu.assertEquals(candidate(9), 514229)\n    lu.assertEquals(candidate(10), 433494437)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "lua",
+    "prompt": "-- You're given a list of deposit and withdrawal operations on a bank account that starts with\n-- zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n-- at that point function should return True. Otherwise it should return False.\n-- >>> below_zero({1, 2, 3})\n-- false\n-- >>> below_zero({1, 2, -4, 5})\n-- true\nlocal function below_zero(operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_zero\n    lu.assertEquals(candidate({}), false)\n    lu.assertEquals(candidate({1, 2, -3, 1, 2, -3}), false)\n    lu.assertEquals(candidate({1, 2, -4, 5, 6}), true)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -4}), false)\n    lu.assertEquals(candidate({1, -1, 2, -2, 5, -5, 4, -5}), true)\n    lu.assertEquals(candidate({1, -2, 2, -2, 5, -5, 4, -4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- triples_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are three distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> triples_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> triples_sum_to_zero({1, 3, -2, 1})\n-- true\n-- >>> triples_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> triples_sum_to_zero({2, 4, -5, 3, 9, 7})\n-- true\n-- >>> triples_sum_to_zero({1})\n-- false\nlocal function triples_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triples_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, 5, -1}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), true)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({1, 2, 5, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 9, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({1, 3, 5, -100}), false)\n    lu.assertEquals(candidate({100, 3, 5, -100}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "lua",
+    "prompt": "-- Imagine a road that's a perfectly straight infinitely long line.\n-- n cars are driving left to right;  simultaneously, a different set of n cars\n-- are driving right to left.   The two sets of cars start out being very far from\n-- each other.  All cars move in the same speed.  Two cars are said to collide\n-- when a car that's moving left to right hits a car that's moving right to left.\n-- However, the cars are infinitely sturdy and strong; as a result, they continue moving\n-- in their trajectory as if they did not collide.\n-- This function outputs the number of such collisions.\nlocal function car_race_collision(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = car_race_collision\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 9)\n    lu.assertEquals(candidate(4), 16)\n    lu.assertEquals(candidate(8), 64)\n    lu.assertEquals(candidate(10), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "lua",
+    "prompt": "-- Return list with elements incremented by 1.\n-- >>> incr_list({1, 2, 3})\n-- {2, 3, 4}\n-- >>> incr_list({5, 3, 5, 2, 3, 3, 9, 0, 123})\n-- {6, 4, 6, 3, 4, 4, 10, 1, 124}\nlocal function incr_list(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = incr_list\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({3, 2, 1}), {4, 3, 2})\n    lu.assertEquals(candidate({5, 2, 5, 2, 3, 3, 9, 0, 123}), {6, 3, 6, 3, 4, 4, 10, 1, 124})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "lua",
+    "prompt": "-- pairs_sum_to_zero takes a list of integers as an input.\n-- it returns True if there are two distinct elements in the list that\n-- sum to zero, and False otherwise.\n-- >>> pairs_sum_to_zero({1, 3, 5, 0})\n-- false\n-- >>> pairs_sum_to_zero({1, 3, -2, 1})\n-- false\n-- >>> pairs_sum_to_zero({1, 2, 3, 7})\n-- false\n-- >>> pairs_sum_to_zero({2, 4, -5, 3, 5, 7})\n-- true\n-- >>> pairs_sum_to_zero({1})\n-- false\nlocal function pairs_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pairs_sum_to_zero\n    lu.assertEquals(candidate({1, 3, 5, 0}), false)\n    lu.assertEquals(candidate({1, 3, -2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3, 7}), false)\n    lu.assertEquals(candidate({2, 4, -5, 3, 5, 7}), true)\n    lu.assertEquals(candidate({1}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 30}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 3, 2, 31}), true)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 30}), false)\n    lu.assertEquals(candidate({-3, 9, -1, 4, 2, 31}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "lua",
+    "prompt": "-- Change numerical base of input number x to base.\n-- return string representation after the conversion.\n-- base numbers are less than 10.\n-- >>> change_base(8, 3)\n-- '22'\n-- >>> change_base(8, 2)\n-- '1000'\n-- >>> change_base(7, 2)\n-- '111'\nlocal function change_base(x, base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_base\n    lu.assertEquals(candidate(8, 3), '22')\n    lu.assertEquals(candidate(9, 3), '100')\n    lu.assertEquals(candidate(234, 2), '11101010')\n    lu.assertEquals(candidate(16, 2), '10000')\n    lu.assertEquals(candidate(8, 2), '1000')\n    lu.assertEquals(candidate(7, 2), '111')\n    lu.assertEquals(candidate(2, 3), '2')\n    lu.assertEquals(candidate(3, 4), '3')\n    lu.assertEquals(candidate(4, 5), '4')\n    lu.assertEquals(candidate(5, 6), '5')\n    lu.assertEquals(candidate(6, 7), '6')\n    lu.assertEquals(candidate(7, 8), '7')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given length of a side and high return area for a triangle.\n-- >>> triangle_area(5, 3)\n-- 7.5\nlocal function triangle_area(a, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(5, 3), 7.5)\n    lu.assertEquals(candidate(2, 2), 2.0)\n    lu.assertEquals(candidate(10, 8), 40.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "lua",
+    "prompt": "-- The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fib4(0) -> 0\n-- fib4(1) -> 0\n-- fib4(2) -> 2\n-- fib4(3) -> 0\n-- fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n-- Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n-- >>> fib4(5)\n-- 4\n-- >>> fib4(6)\n-- 8\n-- >>> fib4(7)\n-- 14\nlocal function fib4(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib4\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 28)\n    lu.assertEquals(candidate(10), 104)\n    lu.assertEquals(candidate(12), 386)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "lua",
+    "prompt": "-- Return median of elements in the list l.\n-- >>> median({3, 1, 2, 4, 5})\n-- 3\n-- >>> median({-10, 4, 6, 1000, 10, 20})\n-- 15.0\nlocal function median(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), 3)\n    lu.assertEquals(candidate({-10, 4, 6, 1000, 10, 20}), 8.0)\n    lu.assertEquals(candidate({5}), 5)\n    lu.assertEquals(candidate({6, 5}), 5.5)\n    lu.assertEquals(candidate({8, 1, 3, 9, 9, 2, 7}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "lua",
+    "prompt": "-- Checks if given string is a palindrome\n-- >>> is_palindrome('')\n-- true\n-- >>> is_palindrome('aba')\n-- true\n-- >>> is_palindrome('aaaaa')\n-- true\n-- >>> is_palindrome('zbcd')\n-- false\nlocal function is_palindrome(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_palindrome\n    lu.assertEquals(candidate(''), true)\n    lu.assertEquals(candidate('aba'), true)\n    lu.assertEquals(candidate('aaaaa'), true)\n    lu.assertEquals(candidate('zbcd'), false)\n    lu.assertEquals(candidate('xywyx'), true)\n    lu.assertEquals(candidate('xywyz'), false)\n    lu.assertEquals(candidate('xywzx'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "lua",
+    "prompt": "-- Return 2^n modulo p (be aware of numerics).\n-- >>> modp(3, 5)\n-- 3\n-- >>> modp(1101, 101)\n-- 2\n-- >>> modp(0, 101)\n-- 1\n-- >>> modp(3, 11)\n-- 8\n-- >>> modp(100, 101)\n-- 1\nlocal function modp(n, p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = modp\n    lu.assertEquals(candidate(3, 5), 3)\n    lu.assertEquals(candidate(1101, 101), 2)\n    lu.assertEquals(candidate(0, 101), 1)\n    lu.assertEquals(candidate(3, 11), 8)\n    lu.assertEquals(candidate(100, 101), 1)\n    lu.assertEquals(candidate(30, 5), 4)\n    lu.assertEquals(candidate(31, 5), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "lua",
+    "prompt": "-- For a given list of input numbers, calculate Mean Absolute Deviation\n-- around the mean of this dataset.\n-- Mean Absolute Deviation is the average absolute difference between each\n-- element and a centerpoint (mean in this case):\n-- MAD = average | x - x_mean |\n-- >>> mean_absolute_deviation({1.0, 2.0, 3.0, 4.0})\n-- 1.0\nlocal function mean_absolute_deviation(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mean_absolute_deviation\n    lu.assertEquals(candidate({1.0, 2.0}), 0.5)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0}), 1.0)\n    lu.assertEquals(candidate({1.0, 2.0, 3.0, 4.0, 5.0}), 1.2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "lua",
+    "prompt": "-- remove_vowels is a function that takes string and returns string without vowels.\n-- >>> remove_vowels('')\n-- ''\n-- >>> remove_vowels('abcdef')\n-- 'bcdf'\n-- >>> remove_vowels('aaaaa')\n-- ''\n-- >>> remove_vowels('aaBAA')\n-- 'B'\n-- >>> remove_vowels('zbcd')\n-- 'zbcd'\nlocal function remove_vowels(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_vowels\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')\n    lu.assertEquals(candidate('fedcba'), 'fdcb')\n    lu.assertEquals(candidate('eeeee'), '')\n    lu.assertEquals(candidate('acBAA'), 'cB')\n    lu.assertEquals(candidate('EcBOO'), 'cB')\n    lu.assertEquals(candidate('ybcd'), 'ybcd')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "lua",
+    "prompt": "-- Return True if all numbers in the list l are below threshold t.\n-- >>> below_threshold({1, 2, 4, 10}, 100)\n-- true\n-- >>> below_threshold({1, 20, 4, 10}, 5)\n-- false\nlocal function below_threshold(l, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = below_threshold\n    lu.assertEquals(candidate({1, 2, 4, 10}, 100), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 5), false)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 21), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}, 22), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 11), true)\n    lu.assertEquals(candidate({1, 8, 4, 10}, 10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "lua",
+    "prompt": "-- Add two numbers x and y\n-- >>> add(2, 3)\n-- 5\n-- >>> add(5, 7)\n-- 12\nlocal function add(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate(0, 1), 1)\n    lu.assertEquals(candidate(1, 0), 1)\n    lu.assertEquals(candidate(2, 3), 5)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 5), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2389,9 +1654,24 @@
     "language": "lua",
     "prompt": "-- Check if two words have the same characters.\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n-- true\n-- >>> same_chars('abcd', 'dddddddabc')\n-- true\n-- >>> same_chars('dddddddabc', 'abcd')\n-- true\n-- >>> same_chars('eabcd', 'dddddddabc')\n-- false\n-- >>> same_chars('abcd', 'dddddddabce')\n-- false\n-- >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n-- false\nlocal function same_chars(s0, s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = same_chars\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), true)\n    lu.assertEquals(candidate('abcd', 'dddddddabc'), true)\n    lu.assertEquals(candidate('dddddddabc', 'abcd'), true)\n    lu.assertEquals(candidate('eabcd', 'dddddddabc'), false)\n    lu.assertEquals(candidate('abcd', 'dddddddabcf'), false)\n    lu.assertEquals(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), false)\n    lu.assertEquals(candidate('aabb', 'aaccc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "lua",
+    "prompt": "-- Return n-th Fibonacci number.\n-- >>> fib(10)\n-- 55\n-- >>> fib(1)\n-- 1\n-- >>> fib(8)\n-- 21\nlocal function fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fib\n    lu.assertEquals(candidate(10), 55)\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(8), 21)\n    lu.assertEquals(candidate(11), 89)\n    lu.assertEquals(candidate(12), 144)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -2404,9 +1684,729 @@
     "language": "lua",
     "prompt": "-- brackets is a string of \"<\" and \">\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('<')\n-- false\n-- >>> correct_bracketing('<>')\n-- true\n-- >>> correct_bracketing('<<><>>')\n-- true\n-- >>> correct_bracketing('><<>')\n-- false\nlocal function correct_bracketing(brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('<>'), true)\n    lu.assertEquals(candidate('<<><>>'), true)\n    lu.assertEquals(candidate('<><><<><>><>'), true)\n    lu.assertEquals(candidate('<><><<<><><>><>><<><><<>>>'), true)\n    lu.assertEquals(candidate('<<<><>>>>'), false)\n    lu.assertEquals(candidate('><<>'), false)\n    lu.assertEquals(candidate('<'), false)\n    lu.assertEquals(candidate('<<<<'), false)\n    lu.assertEquals(candidate('>'), false)\n    lu.assertEquals(candidate('<<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>><<>'), false)\n    lu.assertEquals(candidate('<><><<><>><>>><>'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "lua",
+    "prompt": "-- Return True is list elements are monotonically increasing or decreasing.\n-- >>> monotonic({1, 2, 4, 20})\n-- true\n-- >>> monotonic({1, 20, 4, 10})\n-- false\n-- >>> monotonic({4, 1, 0, -10})\n-- true\nlocal function monotonic(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = monotonic\n    lu.assertEquals(candidate({1, 2, 4, 10}), true)\n    lu.assertEquals(candidate({1, 2, 4, 20}), true)\n    lu.assertEquals(candidate({1, 20, 4, 10}), false)\n    lu.assertEquals(candidate({4, 1, 0, -10}), true)\n    lu.assertEquals(candidate({4, 1, 1, 0}), true)\n    lu.assertEquals(candidate({1, 2, 3, 2, 5, 60}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 60}), true)\n    lu.assertEquals(candidate({9, 9, 9, 9}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "lua",
+    "prompt": "-- Return sorted unique common elements for two lists.\n-- >>> common({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121})\n-- {1, 5, 653}\n-- >>> common({5, 3, 2, 8}, {3, 2})\n-- {2, 3}\nlocal function common(l1, l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common\n    lu.assertEquals(candidate({1, 4, 3, 34, 653, 2, 5}, {5, 7, 1, 5, 9, 653, 121}), {1, 5, 653})\n    lu.assertEquals(candidate({5, 3, 2, 8}, {3, 2}), {2, 3})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {3, 2, 4}), {2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 8}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "lua",
+    "prompt": "-- Return the largest prime factor of n. Assume n > 1 and is not a prime.\n-- >>> largest_prime_factor(13195)\n-- 29\n-- >>> largest_prime_factor(2048)\n-- 2\nlocal function largest_prime_factor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_prime_factor\n    lu.assertEquals(candidate(15), 5)\n    lu.assertEquals(candidate(27), 3)\n    lu.assertEquals(candidate(63), 7)\n    lu.assertEquals(candidate(330), 11)\n    lu.assertEquals(candidate(13195), 29)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "lua",
+    "prompt": "-- Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n-- >>> intersperse({}, 4)\n-- {}\n-- >>> intersperse({1, 2, 3}, 4)\n-- {1, 4, 2, 4, 3}\nlocal function intersperse(numbers, delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersperse\n    lu.assertEquals(candidate({}, 7), {})\n    lu.assertEquals(candidate({5, 6, 3, 2}, 8), {5, 8, 6, 8, 3, 8, 2})\n    lu.assertEquals(candidate({2, 2, 2}, 2), {2, 2, 2, 2, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "lua",
+    "prompt": "-- sum_to_n is a function that sums numbers from 1 to n.\n-- >>> sum_to_n(30)\n-- 465\n-- >>> sum_to_n(100)\n-- 5050\n-- >>> sum_to_n(5)\n-- 15\n-- >>> sum_to_n(10)\n-- 55\n-- >>> sum_to_n(1)\n-- 1\nlocal function sum_to_n(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_to_n\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(6), 21)\n    lu.assertEquals(candidate(11), 66)\n    lu.assertEquals(candidate(30), 465)\n    lu.assertEquals(candidate(100), 5050)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "lua",
+    "prompt": "-- brackets is a string of \"(\" and \")\".\n-- return True if every opening bracket has a corresponding closing bracket.\n-- >>> correct_bracketing('(')\n-- false\n-- >>> correct_bracketing('()')\n-- true\n-- >>> correct_bracketing('(()())')\n-- true\n-- >>> correct_bracketing(')(()')\n-- false\nlocal function correct_bracketing(brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = correct_bracketing\n    lu.assertEquals(candidate('()'), true)\n    lu.assertEquals(candidate('(()())'), true)\n    lu.assertEquals(candidate('()()(()())()'), true)\n    lu.assertEquals(candidate('()()((()()())())(()()(()))'), true)\n    lu.assertEquals(candidate('((()())))'), false)\n    lu.assertEquals(candidate(')(()'), false)\n    lu.assertEquals(candidate('('), false)\n    lu.assertEquals(candidate('(((('), false)\n    lu.assertEquals(candidate(')'), false)\n    lu.assertEquals(candidate('(()'), false)\n    lu.assertEquals(candidate('()()(()())())(()'), false)\n    lu.assertEquals(candidate('()()(()())()))()'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "lua",
+    "prompt": "-- xs represent coefficients of a polynomial.\n-- xs[0] + xs[1] * x + xs[2] * x^2 + ....\n-- Return derivative of this polynomial in the same form.\n-- >>> derivative({3, 1, 2, 4, 5})\n-- {1, 4, 12, 20}\n-- >>> derivative({1, 2, 3})\n-- {2, 6}\nlocal function derivative(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = derivative\n    lu.assertEquals(candidate({3, 1, 2, 4, 5}), {1, 4, 12, 20})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 6})\n    lu.assertEquals(candidate({3, 2, 1}), {2, 2})\n    lu.assertEquals(candidate({3, 2, 1, 0, 4}), {2, 2, 0, 16})\n    lu.assertEquals(candidate({1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "lua",
+    "prompt": "-- The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n-- fibfib(0) == 0\n-- fibfib(1) == 0\n-- fibfib(2) == 1\n-- fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n-- Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n-- >>> fibfib(1)\n-- 0\n-- >>> fibfib(5)\n-- 4\n-- >>> fibfib(8)\n-- 24\nlocal function fibfib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fibfib\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(1), 0)\n    lu.assertEquals(candidate(5), 4)\n    lu.assertEquals(candidate(8), 24)\n    lu.assertEquals(candidate(10), 81)\n    lu.assertEquals(candidate(12), 274)\n    lu.assertEquals(candidate(14), 927)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "lua",
+    "prompt": "-- Write a function vowels_count which takes a string representing\n-- a word as input and returns the number of vowels in the string.\n-- Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n-- vowel, but only when it is at the end of the given word.\n-- Example:\n-- >>> vowels_count('abcde')\n-- 2\n-- >>> vowels_count('ACEDY')\n-- 3\nlocal function vowels_count(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = vowels_count\n    lu.assertEquals(candidate('abcde'), 2)\n    lu.assertEquals(candidate('Alone'), 3)\n    lu.assertEquals(candidate('key'), 2)\n    lu.assertEquals(candidate('bye'), 1)\n    lu.assertEquals(candidate('keY'), 2)\n    lu.assertEquals(candidate('bYe'), 1)\n    lu.assertEquals(candidate('ACEDY'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "lua",
+    "prompt": "-- Circular shift the digits of the integer x, shift the digits right by shift\n-- and return the result as a string.\n-- If shift > number of digits, return digits reversed.\n-- >>> circular_shift(12, 1)\n-- '21'\n-- >>> circular_shift(12, 2)\n-- '12'\nlocal function circular_shift(x, shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = circular_shift\n    lu.assertEquals(candidate(100, 2), '001')\n    lu.assertEquals(candidate(12, 2), '12')\n    lu.assertEquals(candidate(97, 8), '79')\n    lu.assertEquals(candidate(12, 1), '21')\n    lu.assertEquals(candidate(11, 101), '11')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "lua",
+    "prompt": "-- Task\n-- Write a function that takes a string as input and returns the sum of the upper characters only'\n-- ASCII codes.\n-- Examples:\n-- >>> digitSum('')\n-- 0\n-- >>> digitSum('abAB')\n-- 131\n-- >>> digitSum('abcCd')\n-- 67\n-- >>> digitSum('helloE')\n-- 69\n-- >>> digitSum('woArBld')\n-- 131\n-- >>> digitSum('aAaaaXa')\n-- 153\nlocal function digitSum(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digitSum\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('abAB'), 131)\n    lu.assertEquals(candidate('abcCd'), 67)\n    lu.assertEquals(candidate('helloE'), 69)\n    lu.assertEquals(candidate('woArBld'), 131)\n    lu.assertEquals(candidate('aAaaaXa'), 153)\n    lu.assertEquals(candidate(' How are yOu?'), 151)\n    lu.assertEquals(candidate('You arE Very Smart'), 327)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "lua",
+    "prompt": "-- In this task, you will be given a string that represents a number of apples and oranges \n-- that are distributed in a basket of fruit this basket contains \n-- apples, oranges, and mango fruits. Given the string that represents the total number of \n-- the oranges and apples and an integer that represent the total number of the fruits \n-- in the basket return the number of the mango fruits in the basket.\n-- for examble:\n-- >>> fruit_distribution('5 apples and 6 oranges', 19)\n-- 8\n-- >>> fruit_distribution('0 apples and 1 oranges', 3)\n-- 2\n-- >>> fruit_distribution('2 apples and 3 oranges', 100)\n-- 95\n-- >>> fruit_distribution('100 apples and 1 oranges', 120)\n-- 19\nlocal function fruit_distribution(s, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = fruit_distribution\n    lu.assertEquals(candidate('5 apples and 6 oranges', 19), 8)\n    lu.assertEquals(candidate('5 apples and 6 oranges', 21), 10)\n    lu.assertEquals(candidate('0 apples and 1 oranges', 3), 2)\n    lu.assertEquals(candidate('1 apples and 0 oranges', 3), 2)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 100), 95)\n    lu.assertEquals(candidate('2 apples and 3 oranges', 5), 0)\n    lu.assertEquals(candidate('1 apples and 100 oranges', 120), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "lua",
+    "prompt": "-- \"Given an array representing a branch of a tree that has non-negative integer nodes\n-- your task is to pluck one of the nodes and return it.\n-- The plucked node should be the node with the smallest even value.\n-- If multiple nodes with the same smallest even value are found return the node that has smallest index.\n-- The plucked node should be returned in a list, [ smalest_value, its index ],\n-- If there are no even values or the given array is empty, return [].\n-- Example 1:\n-- >>> pluck({4, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 2:\n-- >>> pluck({1, 2, 3})\n-- {2, 1}\n-- Explanation: 2 has the smallest even value, and 2 has the smallest index.\n-- Example 3:\n-- >>> pluck({})\n-- {}\n-- Example 4:\n-- >>> pluck({5, 0, 3, 0, 4, 2})\n-- {0, 1}\n-- Explanation: 0 is the smallest value, but  there are two zeros,\n-- so we will choose the first zero, which has the smallest index.\n-- Constraints:\n-- * 1 <= nodes.length <= 10000\n-- * 0 <= node.value\nlocal function pluck(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pluck\n    lu.assertEquals(candidate({4, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 1})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5, 0, 3, 0, 4, 2}), {0, 1})\n    lu.assertEquals(candidate({1, 2, 3, 0, 5, 3}), {0, 3})\n    lu.assertEquals(candidate({5, 4, 8, 4, 8}), {4, 1})\n    lu.assertEquals(candidate({7, 6, 7, 1}), {6, 1})\n    lu.assertEquals(candidate({7, 9, 7, 1}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "lua",
+    "prompt": "-- You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n-- zero, and has a frequency greater than or equal to the value of the integer itself. \n-- The frequency of an integer is the number of times it appears in the list.\n-- If no such a value exist, return -1.\n-- Examples:\n-- >>> search({4, 1, 2, 2, 3, 1})\n-- 2\n-- >>> search({1, 2, 2, 3, 3, 3, 4, 4, 4})\n-- 3\n-- >>> search({5, 5, 4, 4, 4})\n-- -1\nlocal function search(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({5, 5, 5, 5, 1}), 1)\n    lu.assertEquals(candidate({4, 1, 4, 1, 4, 4}), 4)\n    lu.assertEquals(candidate({3, 3}), -1)\n    lu.assertEquals(candidate({8, 8, 8, 8, 8, 8, 8, 8}), 8)\n    lu.assertEquals(candidate({2, 3, 3, 2, 2}), 2)\n    lu.assertEquals(candidate({2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1}), 1)\n    lu.assertEquals(candidate({3, 2, 8, 2}), 2)\n    lu.assertEquals(candidate({6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10}), 1)\n    lu.assertEquals(candidate({8, 8, 3, 6, 5, 6, 4}), -1)\n    lu.assertEquals(candidate({6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9}), 1)\n    lu.assertEquals(candidate({1, 9, 10, 1, 3}), 1)\n    lu.assertEquals(candidate({6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10}), 5)\n    lu.assertEquals(candidate({1}), 1)\n    lu.assertEquals(candidate({8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5}), 4)\n    lu.assertEquals(candidate({2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10}), 2)\n    lu.assertEquals(candidate({1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3}), 1)\n    lu.assertEquals(candidate({9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4}), 4)\n    lu.assertEquals(candidate({2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7}), 4)\n    lu.assertEquals(candidate({9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1}), 2)\n    lu.assertEquals(candidate({5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8}), -1)\n    lu.assertEquals(candidate({10}), -1)\n    lu.assertEquals(candidate({9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2}), 2)\n    lu.assertEquals(candidate({5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8}), 1)\n    lu.assertEquals(candidate({7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6}), 1)\n    lu.assertEquals(candidate({3, 10, 10, 9, 2}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "lua",
+    "prompt": "-- Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n-- For each of the group, output the deepest level of nesting of parentheses.\n-- E.g. (()()) has maximum two levels of nesting while ((())) has three.\n-- >>> parse_nested_parens('(()()) ((())) () ((())()())')\n-- {2, 3, 1, 3}\nlocal function parse_nested_parens(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parse_nested_parens\n    lu.assertEquals(candidate('(()()) ((())) () ((())()())'), {2, 3, 1, 3})\n    lu.assertEquals(candidate('() (()) ((())) (((())))'), {1, 2, 3, 4})\n    lu.assertEquals(candidate('(()(())((())))'), {4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "lua",
+    "prompt": "-- Given list of integers, return list in strange order.\n-- Strange sorting, is when you start with the minimum value,\n-- then maximum of the remaining integers, then minimum and so on.\n-- Examples:\n-- >>> strange_sort_list({1, 2, 3, 4})\n-- {1, 4, 2, 3}\n-- >>> strange_sort_list({5, 5, 5, 5})\n-- {5, 5, 5, 5}\n-- >>> strange_sort_list({})\n-- {}\nlocal function strange_sort_list(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = strange_sort_list\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 4, 2, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9}), {5, 9, 6, 8, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 5, 2, 4, 3})\n    lu.assertEquals(candidate({5, 6, 7, 8, 9, 1}), {1, 9, 5, 8, 6, 7})\n    lu.assertEquals(candidate({5, 5, 5, 5}), {5, 5, 5, 5})\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}), {1, 8, 2, 7, 3, 6, 4, 5})\n    lu.assertEquals(candidate({0, 2, 2, 2, 5, 5, -5, -5}), {-5, 5, -5, 5, 0, 2, 2, 2})\n    lu.assertEquals(candidate({111111}), {111111})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "lua",
+    "prompt": "-- Given the lengths of the three sides of a triangle. Return the area of\n-- the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n-- Otherwise return -1\n-- Three sides make a valid triangle when the sum of any two sides is greater \n-- than the third side.\n-- Example:\n-- >>> triangle_area(3, 4, 5)\n-- 6.0\n-- >>> triangle_area(1, 2, 10)\n-- -1\nlocal function triangle_area(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(3, 4, 5), 6.0)\n    lu.assertEquals(candidate(1, 2, 10), -1)\n    lu.assertEquals(candidate(4, 8, 5), 8.18)\n    lu.assertEquals(candidate(2, 2, 2), 1.73)\n    lu.assertEquals(candidate(1, 2, 3), -1)\n    lu.assertEquals(candidate(10, 5, 7), 16.25)\n    lu.assertEquals(candidate(2, 6, 3), -1)\n    lu.assertEquals(candidate(1, 1, 1), 0.43)\n    lu.assertEquals(candidate(2, 2, 10), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "lua",
+    "prompt": "-- Write a function that returns True if the object q will fly, and False otherwise.\n-- The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n-- Example:\n-- >>> will_it_fly({1, 2}, 5)\n-- false\n-- # 1+2 is less than the maximum possible weight, but it's unbalanced.\n-- >>> will_it_fly({3, 2, 3}, 1)\n-- false\n-- # it's balanced, but 3+2+3 is more than the maximum possible weight.\n-- >>> will_it_fly({3, 2, 3}, 9)\n-- true\n-- # 3+2+3 is less than the maximum possible weight, and it's balanced.\n-- >>> will_it_fly({3}, 5)\n-- true\n-- # 3 is less than the maximum possible weight, and it's balanced.\nlocal function will_it_fly(q, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = will_it_fly\n    lu.assertEquals(candidate({3, 2, 3}, 9), true)\n    lu.assertEquals(candidate({1, 2}, 5), false)\n    lu.assertEquals(candidate({3}, 5), true)\n    lu.assertEquals(candidate({3, 2, 3}, 1), false)\n    lu.assertEquals(candidate({1, 2, 3}, 6), false)\n    lu.assertEquals(candidate({5}, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "lua",
+    "prompt": "-- Given an array arr of integers, find the minimum number of elements that\n-- need to be changed to make the array palindromic. A palindromic array is an array that\n-- is read the same backwards and forwards. In one change, you can change one element to any other element.\n-- For example:\n-- >>> smallest_change({1, 2, 3, 5, 4, 7, 9, 6})\n-- 4\n-- >>> smallest_change({1, 2, 3, 4, 3, 2, 2})\n-- 1\n-- >>> smallest_change({1, 2, 3, 2, 1})\n-- 0\nlocal function smallest_change(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_change\n    lu.assertEquals(candidate({1, 2, 3, 5, 4, 7, 9, 6}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 4, 4, 2}), 1)\n    lu.assertEquals(candidate({1, 2, 3, 2, 1}), 0)\n    lu.assertEquals(candidate({3, 1, 1, 3}), 0)\n    lu.assertEquals(candidate({1}), 0)\n    lu.assertEquals(candidate({0, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "lua",
+    "prompt": "-- Write a function that accepts two lists of strings and returns the list that has \n-- total number of chars in the all strings of the list less than the other list.\n-- if the two lists have the same number of chars, return the first list.\n-- Examples\n-- >>> total_match({}, {})\n-- {}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'Hi'})\n-- {'hI', 'Hi'}\n-- >>> total_match({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'})\n-- {'hi', 'admin'}\n-- >>> total_match({'hi', 'admin'}, {'hI', 'hi', 'hi'})\n-- {'hI', 'hi', 'hi'}\n-- >>> total_match({'4'}, {'1', '2', '3', '4', '5'})\n-- {'4'}\nlocal function total_match(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = total_match\n    lu.assertEquals(candidate({}, {}), {})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi'}), {'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hi', 'hi', 'admin', 'project'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({'4'}, {'1', '2', '3', '4', '5'}), {'4'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'Hi'}), {'hI', 'Hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hi'}), {'hI', 'hi', 'hi'})\n    lu.assertEquals(candidate({'hi', 'admin'}, {'hI', 'hi', 'hii'}), {'hi', 'admin'})\n    lu.assertEquals(candidate({}, {'this'}), {})\n    lu.assertEquals(candidate({'this'}, {}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "lua",
+    "prompt": "-- Write a function that returns true if the given number is the multiplication of 3 prime numbers\n-- and false otherwise.\n-- Knowing that (a) is less then 100. \n-- Example:\n-- >>> is_multiply_prime(30)\n-- true\n-- 30 = 2 * 3 * 5\nlocal function is_multiply_prime(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_multiply_prime\n    lu.assertEquals(candidate(5), false)\n    lu.assertEquals(candidate(30), true)\n    lu.assertEquals(candidate(8), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(125), true)\n    lu.assertEquals(candidate(105), true)\n    lu.assertEquals(candidate(126), false)\n    lu.assertEquals(candidate(729), false)\n    lu.assertEquals(candidate(891), false)\n    lu.assertEquals(candidate(1001), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "lua",
+    "prompt": "-- Your task is to write a function that returns true if a number x is a simple\n-- power of n and false in other cases.\n-- x is a simple power of n if n**int=x\n-- For example:\n-- >>> is_simple_power(1, 4)\n-- true\n-- >>> is_simple_power(2, 2)\n-- true\n-- >>> is_simple_power(8, 2)\n-- true\n-- >>> is_simple_power(3, 2)\n-- false\n-- >>> is_simple_power(3, 1)\n-- false\n-- >>> is_simple_power(5, 3)\n-- false\nlocal function is_simple_power(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_simple_power\n    lu.assertEquals(candidate(16, 2), true)\n    lu.assertEquals(candidate(143214, 16), false)\n    lu.assertEquals(candidate(4, 2), true)\n    lu.assertEquals(candidate(9, 3), true)\n    lu.assertEquals(candidate(16, 4), true)\n    lu.assertEquals(candidate(24, 2), false)\n    lu.assertEquals(candidate(128, 4), false)\n    lu.assertEquals(candidate(12, 6), false)\n    lu.assertEquals(candidate(1, 1), true)\n    lu.assertEquals(candidate(1, 12), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an integer a and returns True \n-- if this ingeger is a cube of some integer number.\n-- Note: you may assume the input is always valid.\n-- Examples:\n-- >>> iscube(1)\n-- true\n-- >>> iscube(2)\n-- false\n-- >>> iscube(-1)\n-- true\n-- >>> iscube(64)\n-- true\n-- >>> iscube(0)\n-- true\n-- >>> iscube(180)\n-- false\nlocal function iscube(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = iscube\n    lu.assertEquals(candidate(1), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(-1), true)\n    lu.assertEquals(candidate(64), true)\n    lu.assertEquals(candidate(180), false)\n    lu.assertEquals(candidate(1000), true)\n    lu.assertEquals(candidate(0), true)\n    lu.assertEquals(candidate(1729), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "lua",
+    "prompt": "-- You have been tasked to write a function that receives \n-- a hexadecimal number as a string and counts the number of hexadecimal \n-- digits that are primes (prime number, or a prime, is a natural number \n-- greater than 1 that is not a product of two smaller natural numbers).\n-- Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n-- Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n-- So you have to determine a number of the following digits: 2, 3, 5, 7, \n-- B (=decimal 11), D (=decimal 13).\n-- Note: you may assume the input is always correct or empty string, \n-- and symbols A,B,C,D,E,F are always uppercase.\n-- Examples:\n-- >>> hex_key('AB')\n-- 1\n-- >>> hex_key('1077E')\n-- 2\n-- >>> hex_key('ABED1A33')\n-- 4\n-- >>> hex_key('123456789ABCDEF0')\n-- 6\n-- >>> hex_key('2020')\n-- 2\nlocal function hex_key(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hex_key\n    lu.assertEquals(candidate('AB'), 1)\n    lu.assertEquals(candidate('1077E'), 2)\n    lu.assertEquals(candidate('ABED1A33'), 4)\n    lu.assertEquals(candidate('2020'), 2)\n    lu.assertEquals(candidate('123456789ABCDEF0'), 6)\n    lu.assertEquals(candidate('112233445566778899AABBCCDDEEFF00'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- You will be given a number in decimal form and your task is to convert it to\n-- binary format. The function should return a string, with each character representing a binary\n-- number. Each character in the string will be '0' or '1'.\n-- There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n-- The extra characters are there to help with the format.\n-- Examples:\n-- >>> decimal_to_binary(15)\n-- 'db1111db'\n-- >>> decimal_to_binary(32)\n-- 'db100000db'\nlocal function decimal_to_binary(decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(0), 'db0db')\n    lu.assertEquals(candidate(32), 'db100000db')\n    lu.assertEquals(candidate(103), 'db1100111db')\n    lu.assertEquals(candidate(15), 'db1111db')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "lua",
+    "prompt": "-- Filter an input list of strings only for ones that contain given substring\n-- >>> filter_by_substring({}, 'a')\n-- {}\n-- >>> filter_by_substring({'abc', 'bacd', 'cde', 'array'}, 'a')\n-- {'abc', 'bacd', 'array'}\nlocal function filter_by_substring(strings, substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_by_substring\n    lu.assertEquals(candidate({}, 'john'), {})\n    lu.assertEquals(candidate({'xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'}, 'xxx'), {'xxx', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'}, 'xx'), {'xxx', 'aaaxxy', 'xxxAAA', 'xxx'})\n    lu.assertEquals(candidate({'grunt', 'trumpet', 'prune', 'gruesome'}, 'run'), {'grunt', 'prune'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "lua",
+    "prompt": "-- You are given a string s.\n-- Your task is to check if the string is happy or not.\n-- A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n-- For example:\n-- >>> is_happy('a')\n-- false\n-- >>> is_happy('aa')\n-- false\n-- >>> is_happy('abcd')\n-- true\n-- >>> is_happy('aabb')\n-- false\n-- >>> is_happy('adb')\n-- true\n-- >>> is_happy('xyy')\n-- false\nlocal function is_happy(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_happy\n    lu.assertEquals(candidate('a'), false)\n    lu.assertEquals(candidate('aa'), false)\n    lu.assertEquals(candidate('abcd'), true)\n    lu.assertEquals(candidate('aabb'), false)\n    lu.assertEquals(candidate('adb'), true)\n    lu.assertEquals(candidate('xyy'), false)\n    lu.assertEquals(candidate('iopaxpoi'), true)\n    lu.assertEquals(candidate('iopaxioi'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "lua",
+    "prompt": "-- It is the last week of the semester and the teacher has to give the grades\n-- to students. The teacher has been making her own algorithm for grading.\n-- The only problem is, she has lost the code she used for grading.\n-- She has given you a list of GPAs for some students and you have to write \n-- a function that can output a list of letter grades using the following table:\n-- GPA       |    Letter grade\n-- 4.0                A+\n-- > 3.7                A \n-- > 3.3                A- \n-- > 3.0                B+\n-- > 2.7                B \n-- > 2.3                B-\n-- > 2.0                C+\n-- > 1.7                C\n-- > 1.3                C-\n-- > 1.0                D+ \n-- > 0.7                D \n-- > 0.0                D-\n-- 0.0                E\n-- Example:\n-- >>> grade_equation({4.0, 3, 1.7, 2, 3.5})\n-- {'A+', 'B', 'C-', 'C', 'A-'}\nlocal function numerical_letter_grade(grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = numerical_letter_grade\n    lu.assertEquals(candidate({4.0, 3, 1.7, 2, 3.5}), {'A+', 'B', 'C-', 'C', 'A-'})\n    lu.assertEquals(candidate({1.2}), {'D+'})\n    lu.assertEquals(candidate({0.5}), {'D-'})\n    lu.assertEquals(candidate({0.0}), {'E'})\n    lu.assertEquals(candidate({1.0, 0.3, 1.5, 2.8, 3.3}), {'D', 'D-', 'C-', 'B', 'B+'})\n    lu.assertEquals(candidate({0.0, 0.7}), {'E', 'D-'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns True if the string\n-- length is a prime number or False otherwise\n-- Examples\n-- >>> prime_length('Hello')\n-- true\n-- >>> prime_length('abcdcba')\n-- true\n-- >>> prime_length('kittens')\n-- true\n-- >>> prime_length('orange')\n-- false\nlocal function prime_length(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_length\n    lu.assertEquals(candidate('Hello'), true)\n    lu.assertEquals(candidate('abcdcba'), true)\n    lu.assertEquals(candidate('kittens'), true)\n    lu.assertEquals(candidate('orange'), false)\n    lu.assertEquals(candidate('wow'), true)\n    lu.assertEquals(candidate('world'), true)\n    lu.assertEquals(candidate('MadaM'), true)\n    lu.assertEquals(candidate('Wow'), true)\n    lu.assertEquals(candidate(''), false)\n    lu.assertEquals(candidate('HI'), true)\n    lu.assertEquals(candidate('go'), true)\n    lu.assertEquals(candidate('gogo'), false)\n    lu.assertEquals(candidate('aaaaaaaaaaaaaaa'), false)\n    lu.assertEquals(candidate('Madam'), true)\n    lu.assertEquals(candidate('M'), false)\n    lu.assertEquals(candidate('0'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "lua",
+    "prompt": "-- Given a positive integer n, return the count of the numbers of n-digit\n-- positive integers that start or end with 1.\nlocal function starts_one_ends(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = starts_one_ends\n    lu.assertEquals(candidate(1), 1)\n    lu.assertEquals(candidate(2), 18)\n    lu.assertEquals(candidate(3), 180)\n    lu.assertEquals(candidate(4), 1800)\n    lu.assertEquals(candidate(5), 18000)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "lua",
+    "prompt": "-- Given a positive integer N, return the total sum of its digits in binary.\n-- Example\n-- >>> solve(1000)\n-- '1'\n-- >>> solve(150)\n-- '110'\n-- >>> solve(147)\n-- '1100'\n-- Variables:\n-- @N integer\n-- Constraints: 0 \u2264 N \u2264 10000.\n-- Output:\n-- a string of binary number\nlocal function solve(N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = solve\n    lu.assertEquals(candidate(1000), '1')\n    lu.assertEquals(candidate(150), '110')\n    lu.assertEquals(candidate(147), '1100')\n    lu.assertEquals(candidate(333), '1001')\n    lu.assertEquals(candidate(963), '10010')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "lua",
+    "prompt": "-- Given a non-empty list of integers lst. add the even elements that are at odd indices..\n-- Examples:\n-- >>> add({4, 2, 6, 7})\n-- 2\nlocal function add(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add\n    lu.assertEquals(candidate({4, 88}), 88)\n    lu.assertEquals(candidate({4, 5, 6, 7, 2, 122}), 122)\n    lu.assertEquals(candidate({4, 0, 6, 7}), 0)\n    lu.assertEquals(candidate({4, 4, 6, 8}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a string and returns an ordered version of it.\n-- Ordered version of string, is a string where all words (separated by space)\n-- are replaced by a new word where all the characters arranged in\n-- ascending order based on ascii value.\n-- Note: You should keep the order of words and blank spaces in the sentence.\n-- For example:\n-- >>> anti_shuffle('Hi')\n-- 'Hi'\n-- >>> anti_shuffle('hello')\n-- 'ehllo'\n-- >>> anti_shuffle('Hello World!!!')\n-- 'Hello !!!Wdlor'\nlocal function anti_shuffle(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = anti_shuffle\n    lu.assertEquals(candidate('Hi'), 'Hi')\n    lu.assertEquals(candidate('hello'), 'ehllo')\n    lu.assertEquals(candidate('number'), 'bemnru')\n    lu.assertEquals(candidate('abcd'), 'abcd')\n    lu.assertEquals(candidate('Hello World!!!'), 'Hello !!!Wdlor')\n    lu.assertEquals(candidate(''), '')\n    lu.assertEquals(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "lua",
+    "prompt": "-- You are given a 2 dimensional data, as a nested lists,\n-- which is similar to matrix, however, unlike matrices,\n-- each row may contain a different number of columns.\n-- Given lst, and integer x, find integers x in the list,\n-- and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n-- each tuple is a coordinate - (row, columns), starting with 0.\n-- Sort coordinates initially by rows in ascending order.\n-- Also, sort coordinates of the row by columns in descending order.\n-- Examples:\n-- >>> get_row({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1)\n-- {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}}\n-- >>> get_row({}, 1)\n-- {}\n-- >>> get_row({{}, {1}, {1, 2, 3}}, 3)\n-- {{2, 2}}\nlocal function get_row(lst, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_row\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 4}, {1, 0}, {2, 5}, {2, 0}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}}, 2), {{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}, {1, 1, 3, 4, 5, 6}, {1, 2, 1, 4, 5, 6}, {1, 2, 3, 1, 5, 6}, {1, 2, 3, 4, 1, 6}, {1, 2, 3, 4, 5, 1}}, 1), {{0, 0}, {1, 0}, {2, 1}, {2, 0}, {3, 2}, {3, 0}, {4, 3}, {4, 0}, {5, 4}, {5, 0}, {6, 5}, {6, 0}})\n    lu.assertEquals(candidate({}, 1), {})\n    lu.assertEquals(candidate({{1}}, 2), {})\n    lu.assertEquals(candidate({{}, {1}, {1, 2, 3}}, 3), {{2, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "lua",
+    "prompt": "-- Given an array of non-negative integers, return a copy of the given array after sorting,\n-- you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n-- or sort it in descending order if the sum( first index value, last index value) is even.\n-- Note:\n-- * don't change the given array.\n-- Examples:\n-- >>> sort_array({})\n-- {}\n-- >>> sort_array({5})\n-- {5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5})\n-- {0, 1, 2, 3, 4, 5}\n-- >>> sort_array({2, 4, 3, 0, 1, 5, 6})\n-- {6, 5, 4, 3, 2, 1, 0}\nlocal function sort_array(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_array\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({5}), {5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5}), {0, 1, 2, 3, 4, 5})\n    lu.assertEquals(candidate({2, 4, 3, 0, 1, 5, 6}), {6, 5, 4, 3, 2, 1, 0})\n    lu.assertEquals(candidate({2, 1}), {1, 2})\n    lu.assertEquals(candidate({15, 42, 87, 32, 11, 0}), {0, 11, 15, 32, 42, 87})\n    lu.assertEquals(candidate({21, 14, 23, 11}), {23, 21, 14, 11})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "lua",
+    "prompt": "-- Create a function encrypt that takes a string as an argument and\n-- returns a string encrypted with the alphabet being rotated. \n-- The alphabet should be rotated in a manner such that the letters \n-- shift down by two multiplied to two places.\n-- For example:\n-- >>> encrypt('hi')\n-- 'lm'\n-- >>> encrypt('asdfghjkl')\n-- 'ewhjklnop'\n-- >>> encrypt('gf')\n-- 'kj'\n-- >>> encrypt('et')\n-- 'ix'\nlocal function encrypt(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encrypt\n    lu.assertEquals(candidate('hi'), 'lm')\n    lu.assertEquals(candidate('asdfghjkl'), 'ewhjklnop')\n    lu.assertEquals(candidate('gf'), 'kj')\n    lu.assertEquals(candidate('et'), 'ix')\n    lu.assertEquals(candidate('faewfawefaewg'), 'jeiajeaijeiak')\n    lu.assertEquals(candidate('hellomyfriend'), 'lippsqcjvmirh')\n    lu.assertEquals(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')\n    lu.assertEquals(candidate('a'), 'e')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "lua",
+    "prompt": "-- For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n-- Empty sum should be equal to 0 and empty product should be equal to 1.\n-- >>> sum_product({})\n-- {0, 1}\n-- >>> sum_product({1, 2, 3, 4})\n-- {10, 24}\nlocal function sum_product(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_product\n    lu.assertEquals(candidate({}), {0, 1})\n    lu.assertEquals(candidate({1, 1, 1}), {3, 1})\n    lu.assertEquals(candidate({100, 0}), {100, 0})\n    lu.assertEquals(candidate({3, 5, 7}), {15, 105})\n    lu.assertEquals(candidate({10}), {10, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- Write a function next_smallest() that returns the 2nd smallest element of the list.\n-- Return None if there is no such element.\n-- >>> next_smallest({1, 2, 3, 4, 5})\n-- 2\n-- >>> next_smallest({5, 1, 4, 3, 2})\n-- 2\n-- >>> next_smallest({})\n-- None\n-- >>> next_smallest({1, 1})\n-- None\nlocal function next_smallest(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), 2)\n    lu.assertEquals(candidate({5, 1, 4, 3, 2}), 2)\n    lu.assertEquals(candidate({}), None)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({1, 1, 1, 1, 0}), 1)\n    lu.assertEquals(candidate({1, 1}), None)\n    lu.assertEquals(candidate({-35, 34, 12, -45}), -35)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "lua",
+    "prompt": "-- You'll be given a string of words, and your task is to count the number\n-- of boredoms. A boredom is a sentence that starts with the word \"I\".\n-- Sentences are delimited by '.', '?' or '!'.\n-- For example:\n-- >>> is_bored('Hello world')\n-- 0\n-- >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n-- 1\nlocal function is_bored(S)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_bored\n    lu.assertEquals(candidate('Hello world'), 0)\n    lu.assertEquals(candidate('Is the sky blue?'), 0)\n    lu.assertEquals(candidate('I love It !'), 1)\n    lu.assertEquals(candidate('bIt'), 0)\n    lu.assertEquals(candidate('I feel good today. I will be productive. will kill It'), 2)\n    lu.assertEquals(candidate('You and I are going for a walk'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "lua",
+    "prompt": "-- Create a function that takes 3 numbers.\n-- Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n-- Returns false in any other cases.\n-- Examples\n-- >>> any_int(5, 2, 7)\n-- true\n-- >>> any_int(3, 2, 2)\n-- false\n-- >>> any_int(3, -2, 1)\n-- true\n-- >>> any_int(3.6, -2.2, 2)\n-- false\nlocal function any_int(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = any_int\n    lu.assertEquals(candidate(2, 3, 1), true)\n    lu.assertEquals(candidate(2.5, 2, 3), false)\n    lu.assertEquals(candidate(1.5, 5, 3.5), false)\n    lu.assertEquals(candidate(2, 6, 2), false)\n    lu.assertEquals(candidate(4, 2, 2), true)\n    lu.assertEquals(candidate(2.2, 2.2, 2.2), false)\n    lu.assertEquals(candidate(-4, 6, 2), true)\n    lu.assertEquals(candidate(2, 1, 1), true)\n    lu.assertEquals(candidate(3, 4, 7), true)\n    lu.assertEquals(candidate(3.0, 4, 7), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a message, and encodes in such a \n-- way that it swaps case of all letters, replaces all vowels in \n-- the message with the letter that appears 2 places ahead of that \n-- vowel in the english alphabet. \n-- Assume only letters. \n-- Examples:\n-- >>> encode('test')\n-- 'TGST'\n-- >>> encode('This is a message')\n-- 'tHKS KS C MGSSCGG'\nlocal function encode(message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = encode\n    lu.assertEquals(candidate('TEST'), 'tgst')\n    lu.assertEquals(candidate('Mudasir'), 'mWDCSKR')\n    lu.assertEquals(candidate('YES'), 'ygs')\n    lu.assertEquals(candidate('This is a message'), 'tHKS KS C MGSSCGG')\n    lu.assertEquals(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "lua",
+    "prompt": "-- You are given a list of integers.\n-- You need to find the largest prime value and return the sum of its digits.\n-- Examples:\n-- >>> skjkasdkd({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3})\n-- 10\n-- >>> skjkasdkd({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1})\n-- 25\n-- >>> skjkasdkd({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3})\n-- 13\n-- >>> skjkasdkd({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6})\n-- 11\n-- >>> skjkasdkd({0, 81, 12, 3, 1, 21})\n-- 3\n-- >>> skjkasdkd({0, 8, 1, 2, 1, 7})\n-- 7\nlocal function skjkasdkd(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = skjkasdkd\n    lu.assertEquals(candidate({0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3}), 10)\n    lu.assertEquals(candidate({1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1}), 25)\n    lu.assertEquals(candidate({1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3}), 13)\n    lu.assertEquals(candidate({0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6}), 11)\n    lu.assertEquals(candidate({0, 81, 12, 3, 1, 21}), 3)\n    lu.assertEquals(candidate({0, 8, 1, 2, 1, 7}), 7)\n    lu.assertEquals(candidate({8191}), 19)\n    lu.assertEquals(candidate({8191, 123456, 127, 7}), 19)\n    lu.assertEquals(candidate({127, 97, 8192}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "lua",
+    "prompt": "-- Given a dictionary, return True if all keys are strings in lower \n-- case or all keys are strings in upper case, else return False.\n-- The function should return False is the given dictionary is empty.\n-- Examples:\n-- >>> check_dict_case({['a'] = 'apple', ['b'] = 'banana'})\n-- true\n-- >>> check_dict_case({['a'] = 'apple', ['A'] = 'banana', ['B'] = 'banana'})\n-- false\n-- >>> check_dict_case({['a'] = 'apple', [8] = 'banana', ['a'] = 'apple'})\n-- false\n-- >>> check_dict_case({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'})\n-- false\n-- >>> check_dict_case({['STATE'] = 'NC', ['ZIP'] = '12345'})\n-- true\nlocal function check_dict_case(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_dict_case\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['b'] = 'banana'}), true)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['A'] = 'banana', ['B'] = 'banana'}), false)\n    lu.assertEquals(candidate({['p'] = 'pineapple', ['5'] = 'banana', ['a'] = 'apple'}), false)\n    lu.assertEquals(candidate({['Name'] = 'John', ['Age'] = '36', ['City'] = 'Houston'}), false)\n    lu.assertEquals(candidate({['STATE'] = 'NC', ['ZIP'] = '12345'}), true)\n    lu.assertEquals(candidate({['fruit'] = 'Orange', ['taste'] = 'Sweet'}), true)\n    lu.assertEquals(candidate({}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "lua",
+    "prompt": "-- Implement a function that takes an non-negative integer and returns an array of the first n\n-- integers that are prime numbers and less than n.\n-- for example:\n-- >>> count_up_to(5)\n-- {2, 3}\n-- >>> count_up_to(11)\n-- {2, 3, 5, 7}\n-- >>> count_up_to(0)\n-- {}\n-- >>> count_up_to(20)\n-- {2, 3, 5, 7, 11, 13, 17, 19}\n-- >>> count_up_to(1)\n-- {}\n-- >>> count_up_to(18)\n-- {2, 3, 5, 7, 11, 13, 17}\nlocal function count_up_to(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_up_to\n    lu.assertEquals(candidate(5), {2, 3})\n    lu.assertEquals(candidate(6), {2, 3, 5})\n    lu.assertEquals(candidate(7), {2, 3, 5})\n    lu.assertEquals(candidate(10), {2, 3, 5, 7})\n    lu.assertEquals(candidate(0), {})\n    lu.assertEquals(candidate(22), {2, 3, 5, 7, 11, 13, 17, 19})\n    lu.assertEquals(candidate(1), {})\n    lu.assertEquals(candidate(18), {2, 3, 5, 7, 11, 13, 17})\n    lu.assertEquals(candidate(47), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43})\n    lu.assertEquals(candidate(101), {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "lua",
+    "prompt": "-- Complete the function that takes two integers and returns \n-- the product of their unit digits.\n-- Assume the input is always valid.\n-- Examples:\n-- >>> multiply(148, 412)\n-- 16\n-- >>> multiply(19, 28)\n-- 72\n-- >>> multiply(2020, 1851)\n-- 0\n-- >>> multiply(14, -15)\n-- 20\nlocal function multiply(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply\n    lu.assertEquals(candidate(148, 412), 16)\n    lu.assertEquals(candidate(19, 28), 72)\n    lu.assertEquals(candidate(2020, 1851), 0)\n    lu.assertEquals(candidate(14, -15), 20)\n    lu.assertEquals(candidate(76, 67), 42)\n    lu.assertEquals(candidate(17, 27), 49)\n    lu.assertEquals(candidate(0, 1), 0)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "lua",
+    "prompt": "-- Given a string s, count the number of uppercase vowels in even indices.\n-- For example:\n-- >>> count_upper('aBCdEf')\n-- 1\n-- >>> count_upper('abcdefg')\n-- 0\n-- >>> count_upper('dBBE')\n-- 0\nlocal function count_upper(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_upper\n    lu.assertEquals(candidate('aBCdEf'), 1)\n    lu.assertEquals(candidate('abcdefg'), 0)\n    lu.assertEquals(candidate('dBBE'), 0)\n    lu.assertEquals(candidate('B'), 0)\n    lu.assertEquals(candidate('U'), 1)\n    lu.assertEquals(candidate(''), 0)\n    lu.assertEquals(candidate('EEEE'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "lua",
+    "prompt": "-- Create a function that takes a value (string) representing a number\n-- and returns the closest integer to it. If the number is equidistant\n-- from two integers, round it away from zero.\n-- Examples\n-- >>> closest_integer('10')\n-- 10\n-- >>> closest_integer('15.3')\n-- 15\n-- Note:\n-- Rounding away from zero means that if the given number is equidistant\n-- from two integers, the one you should return is the one that is the\n-- farthest from zero. For example closest_integer(\"14.5\") should\n-- return 15 and closest_integer(\"-14.5\") should return -15.\nlocal function closest_integer(value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_integer\n    lu.assertEquals(candidate('10'), 10)\n    lu.assertEquals(candidate('14.5'), 15)\n    lu.assertEquals(candidate('-15.5'), -16)\n    lu.assertEquals(candidate('15.3'), 15)\n    lu.assertEquals(candidate('0'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "lua",
+    "prompt": "-- From a given list of integers, generate a list of rolling maximum element found until given moment\n-- in the sequence.\n-- >>> rolling_max({1, 2, 3, 2, 3, 4, 2})\n-- {1, 2, 3, 3, 3, 4, 4}\nlocal function rolling_max(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rolling_max\n    lu.assertEquals(candidate({}), {})\n    lu.assertEquals(candidate({1, 2, 3, 4}), {1, 2, 3, 4})\n    lu.assertEquals(candidate({4, 3, 2, 1}), {4, 4, 4, 4})\n    lu.assertEquals(candidate({3, 2, 3, 100, 3}), {3, 3, 3, 100, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/humaneval-php-keep.json
+++ b/prompts/humaneval-php-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "php",
-    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube($a) {\n",
+    "prompt": "<?php\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements($numbers, $threshold) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode($message) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "php",
-    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "php",
-    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "php",
-    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "php",
-    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "php",
-    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "php",
-    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "php",
-    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold($l, $t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int($x, $y, $z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "php",
-    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y($n, $x, $y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "php",
-    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check($file_name) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "php",
-    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram($test) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify($x, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "php",
-    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "php",
-    "prompt": "<?php\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete($s, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return reverse_delete(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\", \"ae\") !== array(\"bcd\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\", \"b\") !== array(\"acdef\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"ab\") !== array(\"cdedc\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dwik\", \"w\") !== array(\"dik\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\", \"a\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"v\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"vabba\", \"v\") !== array(\"abba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"mamma\", \"mia\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "php",
-    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "php",
-    "prompt": "<?php\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "php",
-    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "php",
-    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "php",
-    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "php",
-    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music($music_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "php",
-    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "php",
-    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "php",
-    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "php",
-    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "php",
-    "prompt": "<?php\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match($lst1, $lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area($a, $b, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter($txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "php",
-    "prompt": "<?php\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits($x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "php",
-    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath($grid, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nfunction compare_one($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "php",
-    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "php",
-    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "php",
-    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "php",
-    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "php",
-    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times($string, $substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "php",
-    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse($numbers, $delimeter) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "php",
-    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)) !== array(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)) !== array(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "php",
-    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero($operations) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "php",
-    "prompt": "<?php\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars($s0, $s1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return same_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dddddddabc\", \"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcd\", \"dddddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabcf\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\", \"aaccc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups($paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "php",
-    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "php",
-    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words($s, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max($words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "php",
-    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "php",
-    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "php",
-    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection($interval1, $interval2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "php",
-    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power($x, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return has_close_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.95) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 1.0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 0.5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1264,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile($n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return make_a_pile(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4, 6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5, 7, 9, 11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(6, 8, 10, 12, 14, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(8, 10, 12, 14, 16, 18, 20, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "php",
-    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
+    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string($s) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix($strings, $prefix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "php",
-    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "php",
-    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "php",
-    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "php",
-    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel($word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "php",
-    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension($class_name, $extensions) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "php",
-    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common($l1, $l2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "php",
-    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "php",
-    "prompt": "<?php\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate($strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "php",
-    "prompt": "<?php\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 2, 3, 4)) !== array(1, 2, 4, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -3, -4, -5, -6)) !== array(-4, -2, -6, -5, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 3, 4)) !== array(0, 1, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)) !== array(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 44, 12, 32, 5)) !== array(32, 3, 5, 6, 12, 44)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "php",
-    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest($strings) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count($num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "php",
-    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative($xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "php",
-    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "php",
-    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base($x, $base) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "php",
-    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade($grades) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "php",
-    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle($a, $b, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "php",
-    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens($paren_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "php",
-    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare($game, $guess) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array($array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "php",
-    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row($lst, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "php",
-    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "php",
-    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "php",
-    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "php",
-    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key($num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "php",
-    "prompt": "<?php\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return specialFilter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, -2, 1, -5)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, -73, 14, -15)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(33, -2, -3, 45, 21, 109)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(43, -12, 93, 125, 121, 109)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(71, -2, -33, 75, 21, 19)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "php",
-    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "php",
-    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "php",
-    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "php",
-    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case($dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "php",
-    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date($date) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "php",
-    "prompt": "<?php\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers($values) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "php",
-    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "php",
-    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words($txt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "php",
-    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "php",
-    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "php",
-    "prompt": "<?php\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements($numbers, $threshold) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return has_close_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.95) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 1.0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 0.5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "php",
-    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution($s, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "php",
-    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman($number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "php",
-    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing($brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "php",
-    "prompt": "<?php\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing($brackets) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"<>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<><>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<<><><>><>><<><><<>>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<><>>>>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\">\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>>><>\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "php",
-    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "php",
-    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring($strings, $substring) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "php",
-    "prompt": "<?php\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "php",
-    "prompt": "<?php\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2359,7 +49,7 @@
     "language": "php",
     "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// choose_num(12, 15) = 14\n// choose_num(13, 12) = -1\nfunction choose_num($x, $y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "php",
-    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
+    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits($x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "php",
+    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "php",
+    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "php",
+    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "php",
+    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram($test) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "php",
+    "prompt": "<?php\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete($s, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return reverse_delete(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\", \"ae\") !== array(\"bcd\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\", \"b\") !== array(\"acdef\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"ab\") !== array(\"cdedc\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dwik\", \"w\") !== array(\"dik\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\", \"a\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"v\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"vabba\", \"v\") !== array(\"abba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"mamma\", \"mia\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "php",
+    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "php",
+    "prompt": "<?php\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 2, 3, 4)) !== array(1, 2, 4, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -3, -4, -5, -6)) !== array(-4, -2, -6, -5, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 3, 4)) !== array(0, 1, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)) !== array(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 44, 12, 32, 5)) !== array(32, 3, 5, 6, 12, 44)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "php",
+    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words($s, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "php",
+    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel($word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "php",
+    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "php",
+    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "php",
+    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date($date) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "php",
+    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words($txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "php",
+    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection($interval1, $interval2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath($grid, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "php",
+    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest($strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "php",
+    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter($txt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// compare_one(1, 2.5) \u279e 2.5\n// compare_one(1, \"2,3\") \u279e \"2,3\"\n// compare_one(\"5,1\", \"6\") \u279e \"6\"\n// compare_one(\"1\", 1) \u279e None\nfunction compare_one($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "php",
+    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "php",
+    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check($file_name) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify($x, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return specialFilter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, -2, 1, -5)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, -73, 14, -15)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(33, -2, -3, 45, 21, 109)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(43, -12, 93, 125, 121, 109)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(71, -2, -33, 75, 21, 19)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "php",
+    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "php",
+    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "php",
+    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "php",
+    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y($n, $x, $y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "php",
+    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare($game, $guess) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "php",
+    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension($class_name, $extensions) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "php",
+    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "php",
+    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count($num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman($number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max($words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "php",
+    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "php",
+    "prompt": "<?php\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "php",
+    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2389,7 +1054,7 @@
     "language": "php",
     "prompt": "<?php\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// generate_integers(2, 8) => [2, 4, 6, 8]\n// generate_integers(8, 2) => [2, 4, 6, 8]\n// generate_integers(10, 14) => []\nfunction generate_integers($a, $b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return generate_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 10) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(132, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 89) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "php",
     "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters('xyzXYZ')\n// 3\n// >>> count_distinct_characters('Jerry')\n// 4\nfunction count_distinct_characters($string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music($music_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "php",
+    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times($string, $substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "php",
+    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups($paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "php",
+    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "php",
+    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "php",
+    "prompt": "<?php\n// Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers($values) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "php",
+    "prompt": "<?php\n// Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "php",
+    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "php",
+    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "php",
+    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "php",
+    "prompt": "<?php\n// Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate($strings) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix($strings, $prefix) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "php",
+    "prompt": "<?php\n// Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "php",
+    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "php",
+    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "php",
+    "prompt": "<?php\n// Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "php",
+    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "php",
+    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)) !== array(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)) !== array(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "php",
+    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "php",
+    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero($operations) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "php",
+    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "php",
+    "prompt": "<?php\n// Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "php",
+    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base($x, $base) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "php",
+    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "php",
+    "prompt": "<?php\n// Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "php",
+    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "php",
+    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "php",
+    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold($l, $t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "php",
+    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "php",
+    "prompt": "<?php\n// Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars($s0, $s1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return same_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dddddddabc\", \"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcd\", \"dddddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabcf\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\", \"aaccc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "php",
+    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "php",
+    "prompt": "<?php\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing($brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"<>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<><>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<<><><>><>><<><><<>>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<><>>>>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\">\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>>><>\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common($l1, $l2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "php",
+    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "php",
+    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse($numbers, $delimeter) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "php",
+    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "php",
+    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing($brackets) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "php",
+    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative($xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "php",
+    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "php",
+    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "php",
+    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "php",
+    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution($s, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "php",
+    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "php",
+    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens($paren_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "php",
+    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area($a, $b, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "php",
+    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match($lst1, $lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power($x, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube($a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "php",
+    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key($num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring($strings, $substring) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "php",
+    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade($grades) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "php",
+    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row($lst, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array($array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "php",
+    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "php",
+    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int($x, $y, $z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode($message) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "php",
+    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case($dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "php",
+    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "php",
+    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "php",
+    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "php",
+    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/humaneval-php-remove.json
+++ b/prompts/humaneval-php-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "php",
-    "prompt": "<?php\n// Return length of given string\nfunction strlen($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "php",
-    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "php",
-    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case($dict) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces($text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "php",
-    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "php",
-    "prompt": "<?php\n// Filter given list of any python values only for integers\nfunction filter_integers($values) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music($music_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary($decimal) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "php",
-    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "php",
-    "prompt": "<?php\n// Add two numbers x and y\nfunction add($x, $y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "php",
-    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "php",
-    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "php",
-    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "php",
-    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "php",
-    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique elements in a list\nfunction unique($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match($lst1, $lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "php",
-    "prompt": "<?php\n// Return maximum element in the list.\nfunction max_element($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "php",
-    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg($n, $m) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "php",
-    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "php",
-    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "php",
-    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative($xs) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "php",
-    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "php",
-    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix($strings, $prefix) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath($grid, $k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "php",
-    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array($array) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "php",
-    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube($a) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode($message) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "php",
-    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored($S) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area($a, $b, $c) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "php",
-    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunction bf($planet1, $planet2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "php",
-    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times($string, $substring) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nfunction compare_one($a, $b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "php",
-    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels($text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "php",
-    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "php",
-    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements($numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power($x, $n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "php",
-    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points($nums) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "php",
     "prompt": "<?php\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\nfunction has_close_elements($numbers, $threshold) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return has_close_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.95) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 1.0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 0.5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "php",
-    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor($a, $b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "php",
-    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "php",
-    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits($x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words($s, $n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "php",
-    "prompt": "<?php\n// Return n-th Fibonacci number.\nfunction fib($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "php",
-    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension($class_name, $extensions) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int($x, $y, $z) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number($number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "php",
-    "prompt": "<?php\n// Return list with elements incremented by 1.\nfunction incr_list($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "php",
-    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y($n, $x, $y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "php",
-    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\nfunction modp($n, $p) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count($num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "php",
-    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "php",
-    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "php",
-    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit($numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "php",
-    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "php",
-    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "php",
-    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "php",
-    "prompt": "<?php\n// Return median of elements in the list l.\nfunction median($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check($file_name) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero($l) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "php",
-    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection($interval1, $interval2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups($paren_string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "php",
-    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare($game, $guess) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter($txt) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "php",
-    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date($date) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle($s) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Checks if given string is a palindrome\nfunction is_palindrome($text) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "php",
-    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel($word) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "php",
-    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\nfunction is_prime($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify($x, $n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "php",
-    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key($num) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "php",
-    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram($test) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "php",
-    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row($lst, $x) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz($n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange($arr) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers($numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "php",
-    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift($x, $shift) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product($numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "php",
-    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num($x, $y) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers($lst) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "php",
-    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters($string) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1714,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\nfunction make_a_pile($n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return make_a_pile(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4, 6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5, 7, 9, 11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(6, 8, 10, 12, 14, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(8, 10, 12, 14, 16, 18, 20, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "php",
-    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs($arr) {\n",
+    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string($s) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "php",
-    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum($nums) {\n",
+    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num($x, $y) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "php",
-    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence($n) {\n",
+    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg($n, $m) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "php",
-    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check($a, $b) {\n",
+    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits($x) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "php",
-    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic($l) {\n",
+    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length($arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "php",
-    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest($strings) {\n",
+    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f($n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "php",
-    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\nfunction below_threshold($l, $t) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "php",
-    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums($arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "php",
-    "prompt": "<?php\n// Return only positive numbers in the list.\nfunction get_positive($l) {\n",
+    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "php",
-    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third($l) {\n",
+    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome($string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "php",
-    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens($paren_string) {\n",
+    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "php",
-    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\nfunction triangle_area($a, $h) {\n",
+    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram($test) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "php",
-    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply($a, $b) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation($numbers) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique common elements for two lists.\nfunction common($l1, $l2) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman($number) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "php",
-    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution($s, $n) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1984,7 +214,7 @@
     "language": "php",
     "prompt": "<?php\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\nfunction reverse_delete($s, $c) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return reverse_delete(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\", \"ae\") !== array(\"bcd\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\", \"b\") !== array(\"acdef\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"ab\") !== array(\"cdedc\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dwik\", \"w\") !== array(\"dik\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\", \"a\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"v\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"vabba\", \"v\") !== array(\"abba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"mamma\", \"mia\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "php",
-    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor($a, $b) {\n",
+    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count($lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "php",
-    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words($txt) {\n",
+    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum($nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "php",
+    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2029,7 +274,7 @@
     "language": "php",
     "prompt": "<?php\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\nfunction sort_array($arr) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 2, 3, 4)) !== array(1, 2, 4, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -3, -4, -5, -6)) !== array(-4, -2, -6, -5, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 3, 4)) !== array(0, 1, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)) !== array(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 44, 12, 32, 5)) !== array(32, 3, 5, 6, 12, 44)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "php",
-    "prompt": "<?php\n// Concatenate list of strings into a single string\nfunction concatenate($strings) {\n",
+    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words($s, $n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum($lst) {\n",
+    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel($word) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring($strings, $substring) {\n",
+    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens($lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "php",
-    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor($a, $b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "php",
-    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count($s) {\n",
+    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max($words) {\n",
+    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution($lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "php",
-    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5($text) {\n",
+    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "php",
-    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base($x, $base) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz($n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date($date) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "php",
-    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade($grades) {\n",
+    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words($txt) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "php",
-    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse($numbers, $delimeter) {\n",
+    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted($lst) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "php",
+    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection($interval1, $interval2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs($arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath($grid, $k) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "php",
+    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest($strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "php",
+    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested($string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter($txt) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange($arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\nfunction compare_one($a, $b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "php",
+    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "php",
+    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor($a, $b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces($text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check($file_name) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify($x, $n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points($nums) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2209,7 +769,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\nfunction specialFilter($nums) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return specialFilter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, -2, 1, -5)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, -73, 14, -15)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(33, -2, -3, 45, 21, 109)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(43, -12, 93, 125, 121, 109)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(71, -2, -33, 75, 21, 19)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "php",
-    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n($n) {\n",
+    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "php",
-    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates($numbers) {\n",
+    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\nfunction bf($planet1, $planet2) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "php",
+    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes($string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "php",
+    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y($n, $x, $y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "php",
+    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare($game, $guess) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "php",
+    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension($class_name, $extensions) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "php",
+    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check($a, $b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "php",
+    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count($num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman($number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max($words) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "php",
+    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "php",
+    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5($text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2254,7 +1039,7 @@
     "language": "php",
     "prompt": "<?php\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\nfunction generate_integers($a, $b) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return generate_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 10) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(132, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 89) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "php",
-    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max($numbers) {\n",
+    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters($string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "php",
-    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero($operations) {\n",
+    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music($music_string) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "php",
-    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search($lst) {\n",
+    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times($string, $substring) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "php",
-    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing($brackets) {\n",
+    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers($numbers) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups($paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "php",
+    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "php",
+    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "php",
+    "prompt": "<?php\n// Filter given list of any python values only for integers\nfunction filter_integers($values) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "php",
+    "prompt": "<?php\n// Return length of given string\nfunction strlen($string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "php",
+    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "php",
+    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "php",
+    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case($string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "php",
+    "prompt": "<?php\n// Concatenate list of strings into a single string\nfunction concatenate($strings) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix($strings, $prefix) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number($number) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "php",
+    "prompt": "<?php\n// Return only positive numbers in the list.\nfunction get_positive($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "php",
+    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\nfunction is_prime($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "php",
+    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique elements in a list\nfunction unique($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "php",
+    "prompt": "<?php\n// Return maximum element in the list.\nfunction max_element($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "php",
+    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2329,9 +1384,234 @@
     "language": "php",
     "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\nfunction sort_even($l) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return sort_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)) !== array(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)) !== array(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "php",
+    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "php",
+    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero($operations) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "php",
+    "prompt": "<?php\n// Return list with elements incremented by 1.\nfunction incr_list($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "php",
+    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base($x, $base) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\nfunction triangle_area($a, $h) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "php",
+    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "php",
+    "prompt": "<?php\n// Return median of elements in the list l.\nfunction median($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Checks if given string is a palindrome\nfunction is_palindrome($text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "php",
+    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\nfunction modp($n, $p) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "php",
+    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels($text) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "php",
+    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\nfunction below_threshold($l, $t) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "php",
+    "prompt": "<?php\n// Add two numbers x and y\nfunction add($x, $y) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2344,9 +1624,24 @@
     "language": "php",
     "prompt": "<?php\n// Check if two words have the same characters.\nfunction same_chars($s0, $s1) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return same_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dddddddabc\", \"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcd\", \"dddddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabcf\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\", \"aaccc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "php",
+    "prompt": "<?php\n// Return n-th Fibonacci number.\nfunction fib($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2359,9 +1654,714 @@
     "language": "php",
     "prompt": "<?php\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing($brackets) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"<>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<><>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<<><><>><>><<><><<>>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<><>>>>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\">\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>>><>\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic($l) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique common elements for two lists.\nfunction common($l1, $l2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "php",
+    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "php",
+    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse($numbers, $delimeter) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "php",
+    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "php",
+    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing($brackets) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "php",
+    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative($xs) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "php",
+    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "php",
+    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift($x, $shift) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "php",
+    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "php",
+    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution($s, $n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "php",
+    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "php",
+    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens($paren_string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "php",
+    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area($a, $b, $c) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "php",
+    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change($arr) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match($lst1, $lst2) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power($x, $n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube($a) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "php",
+    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key($num) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary($decimal) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring($strings, $substring) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "php",
+    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade($grades) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length($string) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "php",
+    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row($lst, $x) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array($array) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "php",
+    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "php",
+    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored($S) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int($x, $y, $z) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode($message) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd($lst) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "php",
+    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case($dict) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "php",
+    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to($n) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "php",
+    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply($a, $b) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "php",
+    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper($s) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "php",
+    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max($numbers) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/humaneval-php-reworded.json
+++ b/prompts/humaneval-php-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "php",
-    "prompt": "<?php\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "php",
-    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "php",
-    "prompt": "<?php\n// Given an array, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given array is empty.\n// Examples:\n// >>> check_dict_case(array(\"a\" => \"apple\", \"b\" => \"banana\"))\n// true\n// >>> check_dict_case(array(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n// false\n// >>> check_dict_case(array(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n// false\n// >>> check_dict_case(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n// false\n// >>> check_dict_case(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n// true\nfunction check_dict_case($dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add(array(4, 2, 6, 7))\n// 2\nfunction add($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "php",
-    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference(array(1, 3, 2, 0))\n// 10\n// >>> double_the_difference(array(-1, -2, 0))\n// 0\n// >>> double_the_difference(array(9, -2))\n// 81\n// >>> double_the_difference(array(0))\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "php",
-    "prompt": "<?php\n// Filter given array of any phpthon values only for integers\n// >>> filter_integers(array(\"a\", 3.14, 5))\n// array(5)\n// >>> filter_integers(array(1, 2, 3, \"abc\", array(), array()))\n// array(1, 2, 3)\nfunction filter_integers($values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "php",
-    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// array(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nfunction parse_music($music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "php",
-    "prompt": "<?php\n// Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// array(\"a\", \"ab\", \"abc\")\nfunction all_prefixes($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "php",
-    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "php",
-    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// array(11, 4)\n// >>> eat(4, 8, 9)\n// array(12, 1)\n// >>> eat(1, 10, 10)\n// array(11, 0)\n// >>> eat(2, 11, 5)\n// array(7, 0)\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "php",
-    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1)\n// 6\n// Example 2:\n// >>> max_fill(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2)\n// 5\n// Example 3:\n// >>> max_fill(array(array(0, 0, 0), array(0, 0, 0)), 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "php",
-    "prompt": "<?php\n// Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "php",
-    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length(array(2, 1, 1, 4, 5, 8, 2, 3))\n// array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")\n// If the array is empty, return an empty array:\n// >>> by_length(array())\n// array()\n// If the array has any strange number ignore it:\n// >>> by_length(array(1, -1, 55))\n// array(\"One\")\nfunction by_length($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "php",
-    "prompt": "<?php\n// Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// array(2, 2, 2)\n// >>> factorize(25)\n// array(5, 5)\n// >>> factorize(70)\n// array(2, 5, 7)\nfunction factorize($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "php",
-    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// array(2, 3)\n// >>> count_up_to(11)\n// array(2, 3, 5, 7)\n// >>> count_up_to(0)\n// array()\n// >>> count_up_to(20)\n// array(2, 3, 5, 7, 11, 13, 17, 19)\n// >>> count_up_to(1)\n// array()\n// >>> count_up_to(18)\n// array(2, 3, 5, 7, 11, 13, 17)\nfunction count_up_to($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique elements in an array\n// >>> unique(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(0, 2, 3, 5, 9, 123)\nfunction unique($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match(array(), array())\n// array()\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\"))\n// array(\"hI\", \"Hi\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\"))\n// array(\"hi\", \"admin\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\"))\n// array(\"hI\", \"hi\", \"hi\")\n// >>> total_match(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\"))\n// array(\"4\")\nfunction total_match($lst1, $lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "php",
-    "prompt": "<?php\n// Return maximum element in the array.\n// >>> max_element(array(1, 2, 3))\n// 3\n// >>> max_element(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// 123\nfunction max_element($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "php",
-    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(array(\"1234567\"))\n// array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n// >>> odd_count(array(\"3\", \"11111111\"))\n// array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\nfunction odd_count($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "php",
-    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball(array(3, 4, 5, 1, 2))\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball(array(3, 5, 4, 1, 2))\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// array(1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// array(4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "php",
-    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "php",
-    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative(array(3, 1, 2, 4, 5))\n// array(1, 4, 12, 20)\n// >>> derivative(array(1, 2, 3))\n// array(2, 6)\nfunction derivative($xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted(array(5))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5))\n// false\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6, 7))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5, 6, 7))\n// false\n// >>> is_sorted(array(1, 2, 2, 3, 3, 4))\n// true\n// >>> is_sorted(array(1, 2, 2, 2, 3, 4))\n// false\nfunction is_sorted($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "php",
-    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// array(1, 3, 2, 8)\nfunction tri($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "php",
-    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "php",
-    "prompt": "<?php\n// Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix(array(), \"a\")\n// array()\n// >>> filter_by_prefix(array(\"abc\", \"bcd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"array\")\nfunction filter_by_prefix($strings, $prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3)\n// array(1, 2, 1)\n// >>> minPath(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1)\n// array(1)\nfunction minPath($grid, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum(array(-3, -4, 5), 3)\n// array(-4, -3, 5)\n// Example 2:\n// >>> maximum(array(4, -4, 4), 2)\n// array(4, 4)\n// Example 3:\n// >>> maximum(array(-3, 2, 1, 2, -1, -2, 1), 1)\n// array(2)\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "php",
-    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of non-negative integers, return a cophp of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array(array())\n// array()\n// >>> sort_array(array(5))\n// array(5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5))\n// array(0, 1, 2, 3, 4, 5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5, 6))\n// array(6, 5, 4, 3, 2, 1, 0)\nfunction sort_array($array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "php",
-    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// array(1, 2, 6, 24, 15)\nfunction f($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube($a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode($message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "php",
-    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> pairs_sum_to_zero(array(1, 3, -2, 1))\n// false\n// >>> pairs_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> pairs_sum_to_zero(array(2, 4, -5, 3, 5, 7))\n// true\n// >>> pairs_sum_to_zero(array(1))\n// false\nfunction pairs_sum_to_zero($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area($a, $b, $c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "php",
-    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return an array containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty array if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// array(\"Saturn\", \"Uranus\")\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// array(\"Hi\", \"my\", \"name\", \"is\", \"John\")\n// >>> words_string(\"One, two, three, four, five, six\")\n// array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")\nfunction words_string($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "php",
-    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times($string, $substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return null if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// null\nfunction compare_one($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "php",
-    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "php",
-    "prompt": "<?php\n// Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list(array(1, 2, 3, 4))\n// array(1, 4, 2, 3)\n// >>> strange_sort_list(array(5, 5, 5, 5))\n// array(5, 5, 5, 5)\n// >>> strange_sort_list(array())\n// array()\nfunction strange_sort_list($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "php",
-    "prompt": "<?php\n// From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n// array(2.0, 2.2)\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n// array(2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power($x, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "php",
-    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points(array(1, 11, -1, -11, -12))\n// array(-1, -11, 1, -12, 11)\n// >>> order_by_points(array())\n// array()\nfunction order_by_points($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "php",
     "prompt": "<?php\n// Check if in given array of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements(array(1.0, 2.0, 3.0), 0.5)\n// false\n// >>> has_close_elements(array(1.0, 2.8, 3.0, 4.0, 5.0, 2.0), 0.3)\n// true\nfunction has_close_elements($numbers, $threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return has_close_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.95) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 1.0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 0.5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "php",
-    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "php",
-    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "php",
-    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits(array(15, 33, 1422, 1))\n// array(1, 15, 33)\n// >>> unique_digits(array(152, 323, 1422, 10))\n// array()\nfunction unique_digits($x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// array(\"little\")\n// >>> select_words(\"Mary had a little lamb\", 3)\n// array(\"Mary\", \"lamb\")\n// >>> select_words(\"simple white space\", 2)\n// array()\n// >>> select_words(\"Hello world\", 4)\n// array(\"world\")\n// >>> select_words(\"Uncle sam\", 3)\n// array(\"Uncle\")\nfunction select_words($s, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly(array(1, 2), 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly(array(3, 2, 3), 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly(array(3, 2, 3), 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly(array(3), 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "php",
-    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "php",
-    "prompt": "<?php\n// You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", array(\"AA\", \"Be\", \"CC\"))\n// \"my_class.AA\"\nfunction Strongest_Extension($class_name, $extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "php",
-    "prompt": "<?php\n// You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens(array(\"()(\", \")\"))\n// \"Yes\"\n// >>> match_parens(array(\")\", \")\"))\n// \"No\"\nfunction match_parens($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "php",
-    "prompt": "<?php\n// You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return null if there is no such element.\n// >>> next_smallest(array(1, 2, 3, 4, 5))\n// 2\n// >>> next_smallest(array(5, 1, 4, 3, 2))\n// 2\n// >>> next_smallest(array())\n// null\n// >>> next_smallest(array(1, 1))\n// null\nfunction next_smallest($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int($x, $y, $z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "php",
-    "prompt": "<?php\n// Return array with elements incremented by 1.\n// >>> incr_list(array(1, 2, 3))\n// array(2, 3, 4)\n// >>> incr_list(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(6, 4, 6, 3, 4, 4, 10, 1, 124)\nfunction incr_list($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "php",
-    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y($n, $x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "php",
-    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// array(1, 1)\n// >>> even_odd_count(123)\n// array(1, 2)\nfunction even_odd_count($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happhp or not.\n// A string is happhp if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "php",
-    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "php",
-    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "php",
-    "prompt": "<?php\n// Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit(array(1.0, 2.0, 3.0, 4.0, 5.0))\n// array(0.0, 0.25, 0.5, 0.75, 1.0)\nfunction rescale_to_unit($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution(array(5, 8, 7, 1))\n// 12\n// >>> solution(array(3, 3, 3, 3, 3))\n// 9\n// >>> solution(array(30, 13, 24, 321))\n// 0\nfunction solution($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "php",
-    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck(array(4, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck(array(1, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck(array())\n// array()\n// Example 4:\n// >>> pluck(array(5, 0, 3, 0, 4, 2))\n// array(0, 1)\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "php",
-    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "php",
-    "prompt": "<?php\n// In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange(array(1, 2, 3, 4), array(1, 2, 3, 4))\n// \"YES\"\n// >>> exchange(array(1, 2, 3, 4), array(1, 5, 3, 4))\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "php",
-    "prompt": "<?php\n// Return median of elements in the array l.\n// >>> median(array(3, 1, 2, 4, 5))\n// 3\n// >>> median(array(-10, 4, 6, 1000, 10, 20))\n// 15.0\nfunction median($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change(array(1, 2, 3, 5, 4, 7, 9, 6))\n// 4\n// >>> smallest_change(array(1, 2, 3, 4, 3, 2, 2))\n// 1\n// >>> smallest_change(array(1, 2, 3, 2, 1))\n// 0\nfunction smallest_change($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst(array(1.0, 2.0, 3.0))\n// 14\n// >>> lst(array(1.0, 4.0, 9.0))\n// 98\n// >>> lst(array(1.0, 3.0, 5.0, 7.0))\n// 84\n// >>> lst(array(1.4, 4.2, 0.0))\n// 29\n// >>> lst(array(-2.4, 1.0, 1.0))\n// 6\nfunction sum_squares($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check($file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> triples_sum_to_zero(array(1, 3, -2, 1))\n// true\n// >>> triples_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> triples_sum_to_zero(array(2, 4, -5, 3, 9, 7))\n// true\n// >>> triples_sum_to_zero(array(1))\n// false\nfunction triples_sum_to_zero($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "php",
-    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection(array(1, 2), array(2, 3))\n// \"NO\"\n// >>> intersection(array(-1, 1), array(0, 4))\n// \"NO\"\n// >>> intersection(array(-3, -1), array(-5, 5))\n// \"YES\"\nfunction intersection($interval1, $interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// array(\"()\", \"(())\", \"(()())\")\nfunction separate_paren_groups($paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "php",
-    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2))\n// array(0, 0, 0, 0, 3, 3)\n// >>> compare(array(0, 5, 0, 0, 0, 4), array(4, 1, 1, 0, 0, -2))\n// array(4, 4, 1, 0, 0, 6)\nfunction compare($game, $guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter($txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "php",
-    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date($date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums(array())\n// 0\n// >>> count_nums(array(-1, 11, -11))\n// 1\n// >>> count_nums(array(1, 1, 2))\n// 3\nfunction count_nums($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "php",
-    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel($word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "php",
-    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify($x, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "php",
-    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "php",
-    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return an array\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// array(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n// >>> histogram(\"a b b a\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"a b c a b\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"b b b b a\")\n// array(\"b\" => 4)\n// >>> histogram(\"\")\n// array()\nfunction histogram($test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "php",
-    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1)\n// array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))\n// >>> get_row(array(), 1)\n// array()\n// >>> get_row(array(array(), array(1), array(1, 2, 3)), 3)\n// array(array(2, 2))\nfunction get_row($lst, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// array(1, 5)\nfunction get_odd_collatz($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange(array(1, 2, 4, 3, 5))\n// 3\n// >>> can_arrange(array(1, 2, 3))\n// -1\nfunction can_arrange($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "php",
-    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// \"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// array(1, 2, 3)\n// >>> lst\n// array()\n// >>> lst\n// array(-1, -5, 2, -1, -5)\nfunction sum_squares($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "php",
-    "prompt": "<?php\n// You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n// 10\n// >>> skjkasdkd(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n// 25\n// >>> skjkasdkd(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n// 13\n// >>> skjkasdkd(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n// 11\n// >>> skjkasdkd(array(0, 81, 12, 3, 1, 21))\n// 3\n// >>> skjkasdkd(array(0, 8, 1, 2, 1, 7))\n// 7\nfunction skjkasdkd($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "php",
-    "prompt": "<?php\n// For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product(array())\n// array(0, 1)\n// >>> sum_product(array(1, 2, 3, 4))\n// array(10, 24)\nfunction sum_product($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "php",
-    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as null.\n// Examples:\n// >>> largest_smallest_integers(array(2, 4, 1, 3, 5, 7))\n// array(null, 1)\n// >>> largest_smallest_integers(array())\n// array(null, null)\n// >>> largest_smallest_integers(array(0))\n// array(null, null)\nfunction largest_smallest_integers($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "php",
-    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1759,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in an array, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// array(3, 5, 7)\nfunction make_a_pile($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return make_a_pile(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4, 6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5, 7, 9, 11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(6, 8, 10, 12, 14, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(8, 10, 12, 14, 16, 18, 20, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "php",
-    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return null for empty arr.\n// Example:\n// >>> prod_signs(array(1, 2, 2, -4))\n// 9\n// >>> prod_signs(array(0, 1))\n// 0\n// >>> prod_signs(array())\n// null\nfunction prod_signs($arr) {\n",
+    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// array(\"Hi\", \"my\", \"name\", \"is\", \"John\")\n// >>> words_string(\"One, two, three, four, five, six\")\n// array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")\nfunction words_string($s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "php",
-    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum(array(2, 3, 4, 1, 2, 4))\n// 1\n// >>> minSubArraySum(array(-1, -2, -3))\n// -6\nfunction minSubArraySum($nums) {\n",
+    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num($x, $y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "php",
-    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence($n) {\n",
+    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "php",
-    "prompt": "<?php\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check($a, $b) {\n",
+    "prompt": "<?php\n// Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits(array(15, 33, 1422, 1))\n// array(1, 15, 33)\n// >>> unique_digits(array(152, 323, 1422, 10))\n// array()\nfunction unique_digits($x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "php",
-    "prompt": "<?php\n// Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic(array(1, 2, 4, 20))\n// true\n// >>> monotonic(array(1, 20, 4, 10))\n// false\n// >>> monotonic(array(4, 1, 0, -10))\n// true\nfunction monotonic($l) {\n",
+    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length(array(2, 1, 1, 4, 5, 8, 2, 3))\n// array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")\n// If the array is empty, return an empty array:\n// >>> by_length(array())\n// array()\n// If the array has any strange number ignore it:\n// >>> by_length(array(1, -1, 55))\n// array(\"One\")\nfunction by_length($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "php",
-    "prompt": "<?php\n// Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return null in case the input array is empty.\n// >>> longest(array())\n// null\n// >>> longest(array(\"a\", \"b\", \"c\"))\n// \"a\"\n// >>> longest(array(\"a\", \"bb\", \"ccc\"))\n// \"ccc\"\nfunction longest($strings) {\n",
+    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// array(1, 2, 6, 24, 15)\nfunction f($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "php",
-    "prompt": "<?php\n// Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold(array(1, 2, 4, 10), 100)\n// true\n// >>> below_threshold(array(1, 20, 4, 10), 5)\n// false\nfunction below_threshold($l, $t) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// array(1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// array(4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "php",
-    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums(array())\n// 0\n// >>> count_nums(array(-1, 11, -11))\n// 1\n// >>> count_nums(array(1, 1, 2))\n// 3\nfunction count_nums($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "php",
-    "prompt": "<?php\n// Return only positive numbers in the array.\n// >>> get_positive(array(-1, 2, -4, 5, 6))\n// array(2, 5, 6)\n// >>> get_positive(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// array(5, 3, 2, 3, 9, 123, 1)\nfunction get_positive($l) {\n",
+    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball(array(3, 4, 5, 1, 2))\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball(array(3, 5, 4, 1, 2))\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "php",
-    "prompt": "<?php\n// This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_third(array(5, 6, 3, 4, 8, 9, 2))\n// array(2, 6, 3, 4, 8, 9, 5)\nfunction sort_third($l) {\n",
+    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "php",
-    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// array(2, 3, 1, 3)\nfunction parse_nested_parens($paren_string) {\n",
+    "prompt": "<?php\n// In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange(array(1, 2, 3, 4), array(1, 2, 3, 4))\n// \"YES\"\n// >>> exchange(array(1, 2, 3, 4), array(1, 5, 3, 4))\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "php",
-    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
+    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return an array\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// array(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n// >>> histogram(\"a b b a\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"a b c a b\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"b b b b a\")\n// array(\"b\" => 4)\n// >>> histogram(\"\")\n// array()\nfunction histogram($test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "php",
-    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "php",
-    "prompt": "<?php\n// For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation(array(1.0, 2.0, 3.0, 4.0))\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique common elements for two arrays.\n// >>> common(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121))\n// array(1, 5, 653)\n// >>> common(array(5, 3, 2, 8), array(3, 2))\n// array(2, 3)\nfunction common($l1, $l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "php",
-    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution($s, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2029,7 +214,7 @@
     "language": "php",
     "prompt": "<?php\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return an array containing the result string and true/false for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// array(\"bcd\", false)\n// >>> reverse_delete(\"abcdef\", \"b\")\n// array(\"acdef\", false)\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// array(\"cdedc\", true)\nfunction reverse_delete($s, $c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return reverse_delete(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\", \"ae\") !== array(\"bcd\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\", \"b\") !== array(\"acdef\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"ab\") !== array(\"cdedc\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dwik\", \"w\") !== array(\"dik\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\", \"a\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"v\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"vabba\", \"v\") !== array(\"abba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"mamma\", \"mia\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "php",
-    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
+    "prompt": "<?php\n// Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(array(\"1234567\"))\n// array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n// >>> odd_count(array(\"3\", \"11111111\"))\n// array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\nfunction odd_count($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "php",
-    "prompt": "<?php\n// Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"Hello,world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words($txt) {\n",
+    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum(array(2, 3, 4, 1, 2, 4))\n// 1\n// >>> minSubArraySum(array(-1, -2, -3))\n// -6\nfunction minSubArraySum($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "php",
+    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1)\n// 6\n// Example 2:\n// >>> max_fill(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2)\n// 5\n// Example 3:\n// >>> max_fill(array(array(0, 0, 0), array(0, 0, 0)), 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2074,7 +274,7 @@
     "language": "php",
     "prompt": "<?php\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array(array(1, 5, 2, 3, 4))\n// array(1, 2, 3, 4, 5)\n// >>> sort_array(array(-2, -3, -4, -5, -6))\n// array(-6, -5, -4, -3, -2)\n// >>> sort_array(array(1, 0, 2, 3, 4))\n// array(0, 1, 2, 3, 4)\nfunction sort_array($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 2, 3, 4)) !== array(1, 2, 4, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -3, -4, -5, -6)) !== array(-4, -2, -6, -5, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 3, 4)) !== array(0, 1, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)) !== array(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 44, 12, 32, 5)) !== array(32, 3, 5, 6, 12, 44)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "php",
-    "prompt": "<?php\n// Concatenate array of strings into a single string\n// >>> concatenate(array())\n// \"\"\n// >>> concatenate(array(\"a\", \"b\", \"c\"))\n// \"abc\"\nfunction concatenate($strings) {\n",
+    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// array(\"little\")\n// >>> select_words(\"Mary had a little lamb\", 3)\n// array(\"Mary\", \"lamb\")\n// >>> select_words(\"simple white space\", 2)\n// array()\n// >>> select_words(\"Hello world\", 4)\n// array(\"world\")\n// >>> select_words(\"Uncle sam\", 3)\n// array(\"Uncle\")\nfunction select_words($s, $n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort(array(\"aa\", \"a\", \"aaa\"))\n// array(\"aa\")\n// >>> list_sort(array(\"ab\", \"a\", \"aaa\", \"cd\"))\n// array(\"ab\", \"cd\")\nfunction sorted_list_sum($lst) {\n",
+    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel($word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "php",
-    "prompt": "<?php\n// Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring(array(), \"a\")\n// array()\n// >>> filter_by_substring(array(\"abc\", \"bacd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"bacd\", \"array\")\nfunction filter_by_substring($strings, $substring) {\n",
+    "prompt": "<?php\n// You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens(array(\"()(\", \")\"))\n// \"Yes\"\n// >>> match_parens(array(\")\", \")\"))\n// \"No\"\nfunction match_parens($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "php",
-    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor($a, $b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "php",
-    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
+    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum(array(-3, -4, 5), 3)\n// array(-4, -3, 5)\n// Example 2:\n// >>> maximum(array(4, -4, 4), 2)\n// array(4, 4)\n// Example 3:\n// >>> maximum(array(-3, 2, 1, 2, -1, -2, 1), 1)\n// array(2)\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max(array(\"name\", \"of\", \"string\"))\n// \"string\"\n// >>> find_max(array(\"name\", \"enam\", \"game\"))\n// \"enam\"\n// >>> find_max(array(\"aaaaaaa\", \"bb\", \"cc\"))\n// \"aaaaaaa\"\nfunction find_max($words) {\n",
+    "prompt": "<?php\n// Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution(array(5, 8, 7, 1))\n// 12\n// >>> solution(array(3, 3, 3, 3, 3))\n// 9\n// >>> solution(array(30, 13, 24, 321))\n// 0\nfunction solution($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "php",
-    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return null.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5($text) {\n",
+    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "php",
-    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base($x, $base) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// array(1, 5)\nfunction get_odd_collatz($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date($date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "php",
-    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation(array(4.0, 3, 1.7, 2, 3.5))\n// array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")\nfunction numerical_letter_grade($grades) {\n",
+    "prompt": "<?php\n// Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"Hello,world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words($txt) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "php",
-    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse(array(), 4)\n// array()\n// >>> intersperse(array(1, 2, 3), 4)\n// array(1, 4, 2, 4, 3)\nfunction intersperse($numbers, $delimeter) {\n",
+    "prompt": "<?php\n// Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted(array(5))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5))\n// false\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6, 7))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5, 6, 7))\n// false\n// >>> is_sorted(array(1, 2, 2, 3, 3, 4))\n// true\n// >>> is_sorted(array(1, 2, 2, 2, 3, 4))\n// false\nfunction is_sorted($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "php",
+    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection(array(1, 2), array(2, 3))\n// \"NO\"\n// >>> intersection(array(-1, 1), array(0, 4))\n// \"NO\"\n// >>> intersection(array(-3, -1), array(-5, 5))\n// \"YES\"\nfunction intersection($interval1, $interval2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return null for empty arr.\n// Example:\n// >>> prod_signs(array(1, 2, 2, -4))\n// 9\n// >>> prod_signs(array(0, 1))\n// 0\n// >>> prod_signs(array())\n// null\nfunction prod_signs($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3)\n// array(1, 2, 1)\n// >>> minPath(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1)\n// array(1)\nfunction minPath($grid, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "php",
+    "prompt": "<?php\n// Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return null in case the input array is empty.\n// >>> longest(array())\n// null\n// >>> longest(array(\"a\", \"b\", \"c\"))\n// \"a\"\n// >>> longest(array(\"a\", \"bb\", \"ccc\"))\n// \"ccc\"\nfunction longest($strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "php",
+    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// array(1, 3, 2, 8)\nfunction tri($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst(array(1.0, 2.0, 3.0))\n// 14\n// >>> lst(array(1.0, 4.0, 9.0))\n// 98\n// >>> lst(array(1.0, 3.0, 5.0, 7.0))\n// 84\n// >>> lst(array(1.4, 4.2, 0.0))\n// 29\n// >>> lst(array(-2.4, 1.0, 1.0))\n// 6\nfunction sum_squares($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter($txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange(array(1, 2, 4, 3, 5))\n// 3\n// >>> can_arrange(array(1, 2, 3))\n// -1\nfunction can_arrange($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as null.\n// Examples:\n// >>> largest_smallest_integers(array(2, 4, 1, 3, 5, 7))\n// array(null, 1)\n// >>> largest_smallest_integers(array())\n// array(null, null)\n// >>> largest_smallest_integers(array(0))\n// array(null, null)\nfunction largest_smallest_integers($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return null if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// null\nfunction compare_one($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "php",
+    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "php",
+    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check($file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// \"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// array(1, 2, 3)\n// >>> lst\n// array()\n// >>> lst\n// array(-1, -5, 2, -1, -5)\nfunction sum_squares($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify($x, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points(array(1, 11, -1, -11, -12))\n// array(-1, -11, 1, -12, 11)\n// >>> order_by_points(array())\n// array()\nfunction order_by_points($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2254,7 +769,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter(array(15, -73, 14, -15))\n// 1\n// >>> specialFilter(array(33, -2, -3, 45, 21, 109))\n// 2\nfunction specialFilter($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return specialFilter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, -2, 1, -5)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, -73, 14, -15)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(33, -2, -3, 45, 21, 109)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(43, -12, 93, 125, 121, 109)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(71, -2, -33, 75, 21, 19)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "php",
-    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
+    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "php",
-    "prompt": "<?php\n// From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates(array(1, 2, 3, 2, 4))\n// array(1, 3, 4)\nfunction remove_duplicates($numbers) {\n",
+    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return an array containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty array if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// array(\"Saturn\", \"Uranus\")\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort(array(\"aa\", \"a\", \"aaa\"))\n// array(\"aa\")\n// >>> list_sort(array(\"ab\", \"a\", \"aaa\", \"cd\"))\n// array(\"ab\", \"cd\")\nfunction sorted_list_sum($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "php",
+    "prompt": "<?php\n// Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// array(\"a\", \"ab\", \"abc\")\nfunction all_prefixes($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "php",
+    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y($n, $x, $y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference(array(1, 3, 2, 0))\n// 10\n// >>> double_the_difference(array(-1, -2, 0))\n// 0\n// >>> double_the_difference(array(9, -2))\n// 81\n// >>> double_the_difference(array(0))\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "php",
+    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2))\n// array(0, 0, 0, 0, 3, 3)\n// >>> compare(array(0, 5, 0, 0, 0, 4), array(4, 1, 1, 0, 0, -2))\n// array(4, 4, 1, 0, 0, 6)\nfunction compare($game, $guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "php",
+    "prompt": "<?php\n// You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", array(\"AA\", \"Be\", \"CC\"))\n// \"my_class.AA\"\nfunction Strongest_Extension($class_name, $extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "php",
+    "prompt": "<?php\n// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "php",
+    "prompt": "<?php\n// Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// array(1, 1)\n// >>> even_odd_count(123)\n// array(1, 2)\nfunction even_odd_count($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max(array(\"name\", \"of\", \"string\"))\n// \"string\"\n// >>> find_max(array(\"name\", \"enam\", \"game\"))\n// \"enam\"\n// >>> find_max(array(\"aaaaaaa\", \"bb\", \"cc\"))\n// \"aaaaaaa\"\nfunction find_max($words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "php",
+    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// array(11, 4)\n// >>> eat(4, 8, 9)\n// array(12, 1)\n// >>> eat(1, 10, 10)\n// array(11, 0)\n// >>> eat(2, 11, 5)\n// array(7, 0)\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "php",
+    "prompt": "<?php\n// Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "php",
+    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return null.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2299,7 +1054,7 @@
     "language": "php",
     "prompt": "<?php\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// array(2, 4, 6, 8)\n// >>> generate_integers(8, 2)\n// array(2, 4, 6, 8)\n// >>> generate_integers(10, 14)\n// array()\nfunction generate_integers($a, $b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return generate_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 10) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(132, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 89) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "php",
-    "prompt": "<?php\n// From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max(array(1, 2, 3, 2, 3, 4, 2))\n// array(1, 2, 3, 3, 3, 4, 4)\nfunction rolling_max($numbers) {\n",
+    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "php",
-    "prompt": "<?php\n// You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero(array(1, 2, 3))\n// false\n// >>> below_zero(array(1, 2, -4, 5))\n// true\nfunction below_zero($operations) {\n",
+    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// array(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nfunction parse_music($music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "php",
-    "prompt": "<?php\n// You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search(array(4, 1, 2, 2, 3, 1))\n// 2\n// >>> search(array(1, 2, 2, 3, 3, 3, 4, 4, 4))\n// 3\n// >>> search(array(5, 5, 4, 4, 4))\n// -1\nfunction search($lst) {\n",
+    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times($string, $substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "php",
-    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing($brackets) {\n",
+    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers($numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// array(\"()\", \"(())\", \"(()())\")\nfunction separate_paren_groups($paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "php",
+    "prompt": "<?php\n// From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n// array(2.0, 2.2)\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n// array(2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "php",
+    "prompt": "<?php\n// Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit(array(1.0, 2.0, 3.0, 4.0, 5.0))\n// array(0.0, 0.25, 0.5, 0.75, 1.0)\nfunction rescale_to_unit($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "php",
+    "prompt": "<?php\n// Filter given array of any phpthon values only for integers\n// >>> filter_integers(array(\"a\", 3.14, 5))\n// array(5)\n// >>> filter_integers(array(1, 2, 3, \"abc\", array(), array()))\n// array(1, 2, 3)\nfunction filter_integers($values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "php",
+    "prompt": "<?php\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "php",
+    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "php",
+    "prompt": "<?php\n// Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// array(2, 2, 2)\n// >>> factorize(25)\n// array(5, 5)\n// >>> factorize(70)\n// array(2, 5, 7)\nfunction factorize($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates(array(1, 2, 3, 2, 4))\n// array(1, 3, 4)\nfunction remove_duplicates($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "php",
+    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "php",
+    "prompt": "<?php\n// Concatenate array of strings into a single string\n// >>> concatenate(array())\n// \"\"\n// >>> concatenate(array(\"a\", \"b\", \"c\"))\n// \"abc\"\nfunction concatenate($strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix(array(), \"a\")\n// array()\n// >>> filter_by_prefix(array(\"abc\", \"bcd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"array\")\nfunction filter_by_prefix($strings, $prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "php",
+    "prompt": "<?php\n// Return only positive numbers in the array.\n// >>> get_positive(array(-1, 2, -4, 5, 6))\n// array(2, 5, 6)\n// >>> get_positive(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// array(5, 3, 2, 3, 9, 123, 1)\nfunction get_positive($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "php",
+    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "php",
+    "prompt": "<?php\n// This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_third(array(5, 6, 3, 4, 8, 9, 2))\n// array(2, 6, 3, 4, 8, 9, 5)\nfunction sort_third($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique elements in an array\n// >>> unique(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(0, 2, 3, 5, 9, 123)\nfunction unique($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "php",
+    "prompt": "<?php\n// Return maximum element in the array.\n// >>> max_element(array(1, 2, 3))\n// 3\n// >>> max_element(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// 123\nfunction max_element($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "php",
+    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2374,9 +1399,249 @@
     "language": "php",
     "prompt": "<?php\n// This function takes an array l and returns an array l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_even(array(5, 6, 3, 4))\n// array(3, 6, 5, 4)\nfunction sort_even($l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return sort_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)) !== array(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)) !== array(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "php",
+    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "php",
+    "prompt": "<?php\n// You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero(array(1, 2, 3))\n// false\n// >>> below_zero(array(1, 2, -4, 5))\n// true\nfunction below_zero($operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> triples_sum_to_zero(array(1, 3, -2, 1))\n// true\n// >>> triples_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> triples_sum_to_zero(array(2, 4, -5, 3, 9, 7))\n// true\n// >>> triples_sum_to_zero(array(1))\n// false\nfunction triples_sum_to_zero($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "php",
+    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "php",
+    "prompt": "<?php\n// Return array with elements incremented by 1.\n// >>> incr_list(array(1, 2, 3))\n// array(2, 3, 4)\n// >>> incr_list(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(6, 4, 6, 3, 4, 4, 10, 1, 124)\nfunction incr_list($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> pairs_sum_to_zero(array(1, 3, -2, 1))\n// false\n// >>> pairs_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> pairs_sum_to_zero(array(2, 4, -5, 3, 5, 7))\n// true\n// >>> pairs_sum_to_zero(array(1))\n// false\nfunction pairs_sum_to_zero($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "php",
+    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base($x, $base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "php",
+    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "php",
+    "prompt": "<?php\n// Return median of elements in the array l.\n// >>> median(array(3, 1, 2, 4, 5))\n// 3\n// >>> median(array(-10, 4, 6, 1000, 10, 20))\n// 15.0\nfunction median($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "php",
+    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "php",
+    "prompt": "<?php\n// For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation(array(1.0, 2.0, 3.0, 4.0))\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "php",
+    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "php",
+    "prompt": "<?php\n// Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold(array(1, 2, 4, 10), 100)\n// true\n// >>> below_threshold(array(1, 20, 4, 10), 5)\n// false\nfunction below_threshold($l, $t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "php",
+    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2389,9 +1654,24 @@
     "language": "php",
     "prompt": "<?php\n// Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars($s0, $s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return same_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dddddddabc\", \"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcd\", \"dddddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabcf\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\", \"aaccc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "php",
+    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2404,9 +1684,729 @@
     "language": "php",
     "prompt": "<?php\n// brackets is a string of \"<\" and \">\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing($brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"<>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<><>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<<><><>><>><<><><<>>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<><>>>>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\">\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>>><>\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic(array(1, 2, 4, 20))\n// true\n// >>> monotonic(array(1, 20, 4, 10))\n// false\n// >>> monotonic(array(4, 1, 0, -10))\n// true\nfunction monotonic($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique common elements for two arrays.\n// >>> common(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121))\n// array(1, 5, 653)\n// >>> common(array(5, 3, 2, 8), array(3, 2))\n// array(2, 3)\nfunction common($l1, $l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "php",
+    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "php",
+    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse(array(), 4)\n// array()\n// >>> intersperse(array(1, 2, 3), 4)\n// array(1, 4, 2, 4, 3)\nfunction intersperse($numbers, $delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "php",
+    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "php",
+    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing($brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "php",
+    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative(array(3, 1, 2, 4, 5))\n// array(1, 4, 12, 20)\n// >>> derivative(array(1, 2, 3))\n// array(2, 6)\nfunction derivative($xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "php",
+    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "php",
+    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "php",
+    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "php",
+    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution($s, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "php",
+    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck(array(4, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck(array(1, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck(array())\n// array()\n// Example 4:\n// >>> pluck(array(5, 0, 3, 0, 4, 2))\n// array(0, 1)\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "php",
+    "prompt": "<?php\n// You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search(array(4, 1, 2, 2, 3, 1))\n// 2\n// >>> search(array(1, 2, 2, 3, 3, 3, 4, 4, 4))\n// 3\n// >>> search(array(5, 5, 4, 4, 4))\n// -1\nfunction search($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// array(2, 3, 1, 3)\nfunction parse_nested_parens($paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "php",
+    "prompt": "<?php\n// Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list(array(1, 2, 3, 4))\n// array(1, 4, 2, 3)\n// >>> strange_sort_list(array(5, 5, 5, 5))\n// array(5, 5, 5, 5)\n// >>> strange_sort_list(array())\n// array()\nfunction strange_sort_list($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly(array(1, 2), 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly(array(3, 2, 3), 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly(array(3, 2, 3), 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly(array(3), 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "php",
+    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change(array(1, 2, 3, 5, 4, 7, 9, 6))\n// 4\n// >>> smallest_change(array(1, 2, 3, 4, 3, 2, 2))\n// 1\n// >>> smallest_change(array(1, 2, 3, 2, 1))\n// 0\nfunction smallest_change($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match(array(), array())\n// array()\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\"))\n// array(\"hI\", \"Hi\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\"))\n// array(\"hi\", \"admin\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\"))\n// array(\"hI\", \"hi\", \"hi\")\n// >>> total_match(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\"))\n// array(\"4\")\nfunction total_match($lst1, $lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power($x, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "php",
+    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring(array(), \"a\")\n// array()\n// >>> filter_by_substring(array(\"abc\", \"bacd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"bacd\", \"array\")\nfunction filter_by_substring($strings, $substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happhp or not.\n// A string is happhp if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "php",
+    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation(array(4.0, 3, 1.7, 2, 3.5))\n// array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")\nfunction numerical_letter_grade($grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add(array(4, 2, 6, 7))\n// 2\nfunction add($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "php",
+    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1)\n// array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))\n// >>> get_row(array(), 1)\n// array()\n// >>> get_row(array(array(), array(1), array(1, 2, 3)), 3)\n// array(array(2, 2))\nfunction get_row($lst, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of non-negative integers, return a cophp of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array(array())\n// array()\n// >>> sort_array(array(5))\n// array(5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5))\n// array(0, 1, 2, 3, 4, 5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5, 6))\n// array(6, 5, 4, 3, 2, 1, 0)\nfunction sort_array($array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "php",
+    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "php",
+    "prompt": "<?php\n// For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product(array())\n// array(0, 1)\n// >>> sum_product(array(1, 2, 3, 4))\n// array(10, 24)\nfunction sum_product($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return null if there is no such element.\n// >>> next_smallest(array(1, 2, 3, 4, 5))\n// 2\n// >>> next_smallest(array(5, 1, 4, 3, 2))\n// 2\n// >>> next_smallest(array())\n// null\n// >>> next_smallest(array(1, 1))\n// null\nfunction next_smallest($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "php",
+    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int($x, $y, $z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode($message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n// 10\n// >>> skjkasdkd(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n// 25\n// >>> skjkasdkd(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n// 13\n// >>> skjkasdkd(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n// 11\n// >>> skjkasdkd(array(0, 81, 12, 3, 1, 21))\n// 3\n// >>> skjkasdkd(array(0, 8, 1, 2, 1, 7))\n// 7\nfunction skjkasdkd($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "php",
+    "prompt": "<?php\n// Given an array, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given array is empty.\n// Examples:\n// >>> check_dict_case(array(\"a\" => \"apple\", \"b\" => \"banana\"))\n// true\n// >>> check_dict_case(array(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n// false\n// >>> check_dict_case(array(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n// false\n// >>> check_dict_case(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n// false\n// >>> check_dict_case(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n// true\nfunction check_dict_case($dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "php",
+    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// array(2, 3)\n// >>> count_up_to(11)\n// array(2, 3, 5, 7)\n// >>> count_up_to(0)\n// array()\n// >>> count_up_to(20)\n// array(2, 3, 5, 7, 11, 13, 17, 19)\n// >>> count_up_to(1)\n// array()\n// >>> count_up_to(18)\n// array(2, 3, 5, 7, 11, 13, 17)\nfunction count_up_to($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "php",
+    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "php",
+    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "php",
+    "prompt": "<?php\n// From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max(array(1, 2, 3, 2, 3, 4, 2))\n// array(1, 2, 3, 3, 3, 4, 4)\nfunction rolling_max($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/humaneval-php-transform.json
+++ b/prompts/humaneval-php-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "php",
-    "prompt": "<?php\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "php",
-    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "php",
-    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case(array(\"a\" => \"apple\", \"b\" => \"banana\"))\n// true\n// >>> check_dict_case(array(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n// false\n// >>> check_dict_case(array(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n// false\n// >>> check_dict_case(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n// false\n// >>> check_dict_case(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n// true\nfunction check_dict_case($dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add(array(4, 2, 6, 7))\n// 2\nfunction add($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "php",
-    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference(array(1, 3, 2, 0))\n// 10\n// >>> double_the_difference(array(-1, -2, 0))\n// 0\n// >>> double_the_difference(array(9, -2))\n// 81\n// >>> double_the_difference(array(0))\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "php",
-    "prompt": "<?php\n// Filter given list of any python values only for integers\n// >>> filter_integers(array(\"a\", 3.14, 5))\n// array(5)\n// >>> filter_integers(array(1, 2, 3, \"abc\", array(), array()))\n// array(1, 2, 3)\nfunction filter_integers($values) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "php",
-    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// array(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nfunction parse_music($music_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "php",
-    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// array(\"a\", \"ab\", \"abc\")\nfunction all_prefixes($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "php",
-    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "php",
-    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// array(11, 4)\n// >>> eat(4, 8, 9)\n// array(12, 1)\n// >>> eat(1, 10, 10)\n// array(11, 0)\n// >>> eat(2, 11, 5)\n// array(7, 0)\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "php",
-    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1)\n// 6\n// Example 2:\n// >>> max_fill(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2)\n// 5\n// Example 3:\n// >>> max_fill(array(array(0, 0, 0), array(0, 0, 0)), 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "php",
-    "prompt": "<?php\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "php",
-    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length(array(2, 1, 1, 4, 5, 8, 2, 3))\n// array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")\n// If the array is empty, return an empty array:\n// >>> by_length(array())\n// array()\n// If the array has any strange number ignore it:\n// >>> by_length(array(1, -1, 55))\n// array(\"One\")\nfunction by_length($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "php",
-    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// array(2, 2, 2)\n// >>> factorize(25)\n// array(5, 5)\n// >>> factorize(70)\n// array(2, 5, 7)\nfunction factorize($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "php",
-    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// array(2, 3)\n// >>> count_up_to(11)\n// array(2, 3, 5, 7)\n// >>> count_up_to(0)\n// array()\n// >>> count_up_to(20)\n// array(2, 3, 5, 7, 11, 13, 17, 19)\n// >>> count_up_to(1)\n// array()\n// >>> count_up_to(18)\n// array(2, 3, 5, 7, 11, 13, 17)\nfunction count_up_to($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique elements in a list\n// >>> unique(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(0, 2, 3, 5, 9, 123)\nfunction unique($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match(array(), array())\n// array()\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\"))\n// array(\"hI\", \"Hi\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\"))\n// array(\"hi\", \"admin\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\"))\n// array(\"hI\", \"hi\", \"hi\")\n// >>> total_match(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\"))\n// array(\"4\")\nfunction total_match($lst1, $lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "php",
-    "prompt": "<?php\n// Return maximum element in the list.\n// >>> max_element(array(1, 2, 3))\n// 3\n// >>> max_element(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// 123\nfunction max_element($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "php",
-    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(array(\"1234567\"))\n// array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n// >>> odd_count(array(\"3\", \"11111111\"))\n// array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\nfunction odd_count($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "php",
-    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball(array(3, 4, 5, 1, 2))\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball(array(3, 5, 4, 1, 2))\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// array(1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// array(4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "php",
-    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "php",
-    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative(array(3, 1, 2, 4, 5))\n// array(1, 4, 12, 20)\n// >>> derivative(array(1, 2, 3))\n// array(2, 6)\nfunction derivative($xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted(array(5))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5))\n// false\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6, 7))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5, 6, 7))\n// false\n// >>> is_sorted(array(1, 2, 2, 3, 3, 4))\n// true\n// >>> is_sorted(array(1, 2, 2, 2, 3, 4))\n// false\nfunction is_sorted($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "php",
-    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// array(1, 3, 2, 8)\nfunction tri($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "php",
-    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix(array(), \"a\")\n// array()\n// >>> filter_by_prefix(array(\"abc\", \"bcd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"array\")\nfunction filter_by_prefix($strings, $prefix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3)\n// array(1, 2, 1)\n// >>> minPath(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1)\n// array(1)\nfunction minPath($grid, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum(array(-3, -4, 5), 3)\n// array(-4, -3, 5)\n// Example 2:\n// >>> maximum(array(4, -4, 4), 2)\n// array(4, 4)\n// Example 3:\n// >>> maximum(array(-3, 2, 1, 2, -1, -2, 1), 1)\n// array(2)\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "php",
-    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array(array())\n// array()\n// >>> sort_array(array(5))\n// array(5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5))\n// array(0, 1, 2, 3, 4, 5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5, 6))\n// array(6, 5, 4, 3, 2, 1, 0)\nfunction sort_array($array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "php",
-    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// array(1, 2, 6, 24, 15)\nfunction f($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube($a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode($message) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "php",
-    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> pairs_sum_to_zero(array(1, 3, -2, 1))\n// false\n// >>> pairs_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> pairs_sum_to_zero(array(2, 4, -5, 3, 5, 7))\n// true\n// >>> pairs_sum_to_zero(array(1))\n// false\nfunction pairs_sum_to_zero($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area($a, $b, $c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "php",
-    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// array(\"Saturn\", \"Uranus\")\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "php",
-    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// array(\"Hi\", \"my\", \"name\", \"is\", \"John\")\n// >>> words_string(\"One, two, three, four, five, six\")\n// array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")\nfunction words_string($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "php",
-    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times($string, $substring) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// null\nfunction compare_one($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "php",
-    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "php",
-    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list(array(1, 2, 3, 4))\n// array(1, 4, 2, 3)\n// >>> strange_sort_list(array(5, 5, 5, 5))\n// array(5, 5, 5, 5)\n// >>> strange_sort_list(array())\n// array()\nfunction strange_sort_list($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "php",
-    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n// array(2.0, 2.2)\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n// array(2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power($x, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "php",
-    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points(array(1, 11, -1, -11, -12))\n// array(-1, -11, 1, -12, 11)\n// >>> order_by_points(array())\n// array()\nfunction order_by_points($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "php",
     "prompt": "<?php\n// Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements(array(1.0, 2.0, 3.0), 0.5)\n// false\n// >>> has_close_elements(array(1.0, 2.8, 3.0, 4.0, 5.0, 2.0), 0.3)\n// true\nfunction has_close_elements($numbers, $threshold) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return has_close_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.95) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0), 0.8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 1.0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1), 0.5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "php",
-    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "php",
-    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "php",
-    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits(array(15, 33, 1422, 1))\n// array(1, 15, 33)\n// >>> unique_digits(array(152, 323, 1422, 10))\n// array()\nfunction unique_digits($x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "php",
-    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// array(\"little\")\n// >>> select_words(\"Mary had a little lamb\", 3)\n// array(\"Mary\", \"lamb\")\n// >>> select_words(\"simple white space\", 2)\n// array()\n// >>> select_words(\"Hello world\", 4)\n// array(\"world\")\n// >>> select_words(\"Uncle sam\", 3)\n// array(\"Uncle\")\nfunction select_words($s, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly(array(1, 2), 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly(array(3, 2, 3), 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly(array(3, 2, 3), 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly(array(3), 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "php",
-    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "php",
-    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", array(\"AA\", \"Be\", \"CC\"))\n// \"my_class.AA\"\nfunction Strongest_Extension($class_name, $extensions) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens(array(\"()(\", \")\"))\n// \"Yes\"\n// >>> match_parens(array(\")\", \")\"))\n// \"No\"\nfunction match_parens($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest(array(1, 2, 3, 4, 5))\n// 2\n// >>> next_smallest(array(5, 1, 4, 3, 2))\n// 2\n// >>> next_smallest(array())\n// null\n// >>> next_smallest(array(1, 1))\n// null\nfunction next_smallest($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int($x, $y, $z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "php",
-    "prompt": "<?php\n// Return list with elements incremented by 1.\n// >>> incr_list(array(1, 2, 3))\n// array(2, 3, 4)\n// >>> incr_list(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(6, 4, 6, 3, 4, 4, 10, 1, 124)\nfunction incr_list($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "php",
-    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y($n, $x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "php",
-    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "php",
-    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// array(1, 1)\n// >>> even_odd_count(123)\n// array(1, 2)\nfunction even_odd_count($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "php",
-    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "php",
-    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "php",
-    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit(array(1.0, 2.0, 3.0, 4.0, 5.0))\n// array(0.0, 0.25, 0.5, 0.75, 1.0)\nfunction rescale_to_unit($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "php",
-    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution(array(5, 8, 7, 1))\n// 12\n// >>> solution(array(3, 3, 3, 3, 3))\n// 9\n// >>> solution(array(30, 13, 24, 321))\n// 0\nfunction solution($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "php",
-    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck(array(4, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck(array(1, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck(array())\n// array()\n// Example 4:\n// >>> pluck(array(5, 0, 3, 0, 4, 2))\n// array(0, 1)\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "php",
-    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "php",
-    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange(array(1, 2, 3, 4), array(1, 2, 3, 4))\n// \"YES\"\n// >>> exchange(array(1, 2, 3, 4), array(1, 5, 3, 4))\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "php",
-    "prompt": "<?php\n// Return median of elements in the list l.\n// >>> median(array(3, 1, 2, 4, 5))\n// 3\n// >>> median(array(-10, 4, 6, 1000, 10, 20))\n// 15.0\nfunction median($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "php",
-    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change(array(1, 2, 3, 5, 4, 7, 9, 6))\n// 4\n// >>> smallest_change(array(1, 2, 3, 4, 3, 2, 2))\n// 1\n// >>> smallest_change(array(1, 2, 3, 2, 1))\n// 0\nfunction smallest_change($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst(array(1.0, 2.0, 3.0))\n// 14\n// >>> lst(array(1.0, 4.0, 9.0))\n// 98\n// >>> lst(array(1.0, 3.0, 5.0, 7.0))\n// 84\n// >>> lst(array(1.4, 4.2, 0.0))\n// 29\n// >>> lst(array(-2.4, 1.0, 1.0))\n// 6\nfunction sum_squares($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check($file_name) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "php",
-    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> triples_sum_to_zero(array(1, 3, -2, 1))\n// true\n// >>> triples_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> triples_sum_to_zero(array(2, 4, -5, 3, 9, 7))\n// true\n// >>> triples_sum_to_zero(array(1))\n// false\nfunction triples_sum_to_zero($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "php",
-    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection(array(1, 2), array(2, 3))\n// \"NO\"\n// >>> intersection(array(-1, 1), array(0, 4))\n// \"NO\"\n// >>> intersection(array(-3, -1), array(-5, 5))\n// \"YES\"\nfunction intersection($interval1, $interval2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "php",
-    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// array(\"()\", \"(())\", \"(()())\")\nfunction separate_paren_groups($paren_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "php",
-    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2))\n// array(0, 0, 0, 0, 3, 3)\n// >>> compare(array(0, 5, 0, 0, 0, 4), array(4, 1, 1, 0, 0, -2))\n// array(4, 4, 1, 0, 0, 6)\nfunction compare($game, $guess) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter($txt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "php",
-    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date($date) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums(array())\n// 0\n// >>> count_nums(array(-1, 11, -11))\n// 1\n// >>> count_nums(array(1, 1, 2))\n// 3\nfunction count_nums($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "php",
-    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "php",
-    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel($word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "php",
-    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "php",
-    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify($x, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "php",
-    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "php",
-    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "php",
-    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// array(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n// >>> histogram(\"a b b a\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"a b c a b\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"b b b b a\")\n// array(\"b\" => 4)\n// >>> histogram(\"\")\n// array()\nfunction histogram($test) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "php",
-    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1)\n// array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))\n// >>> get_row(array(), 1)\n// array()\n// >>> get_row(array(array(), array(1), array(1, 2, 3)), 3)\n// array(array(2, 2))\nfunction get_row($lst, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// array(1, 5)\nfunction get_odd_collatz($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "php",
-    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange(array(1, 2, 4, 3, 5))\n// 3\n// >>> can_arrange(array(1, 2, 3))\n// -1\nfunction can_arrange($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "php",
-    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "php",
-    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// array(1, 2, 3)\n// >>> lst\n// array()\n// >>> lst\n// array(-1, -5, 2, -1, -5)\nfunction sum_squares($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "php",
-    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n// 10\n// >>> skjkasdkd(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n// 25\n// >>> skjkasdkd(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n// 13\n// >>> skjkasdkd(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n// 11\n// >>> skjkasdkd(array(0, 81, 12, 3, 1, 21))\n// 3\n// >>> skjkasdkd(array(0, 8, 1, 2, 1, 7))\n// 7\nfunction skjkasdkd($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product(array())\n// array(0, 1)\n// >>> sum_product(array(1, 2, 3, 4))\n// array(10, 24)\nfunction sum_product($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "php",
-    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "php",
-    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers(array(2, 4, 1, 3, 5, 7))\n// array(null, 1)\n// >>> largest_smallest_integers(array())\n// array(null, null)\n// >>> largest_smallest_integers(array(0))\n// array(null, null)\nfunction largest_smallest_integers($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "php",
-    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1759,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// array(3, 5, 7)\nfunction make_a_pile($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return make_a_pile(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4, 6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5, 7, 9, 11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(6, 8, 10, 12, 14, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(8, 10, 12, 14, 16, 18, 20, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "php",
-    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs(array(1, 2, 2, -4))\n// 9\n// >>> prod_signs(array(0, 1))\n// 0\n// >>> prod_signs(array())\n// null\nfunction prod_signs($arr) {\n",
+    "prompt": "<?php\n// You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// array(\"Hi\", \"my\", \"name\", \"is\", \"John\")\n// >>> words_string(\"One, two, three, four, five, six\")\n// array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")\nfunction words_string($s) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return words_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi, my name is John\") !== array(\"Hi\", \"my\", \"name\", \"is\", \"John\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One, two, three, four, five, six\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi, my name\") !== array(\"Hi\", \"my\", \"name\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"One,, two, three, four, five, six,\") !== array(\"One\", \"two\", \"three\", \"four\", \"five\", \"six\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ahmed     , gamal\") !== array(\"ahmed\", \"gamal\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "php",
-    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum(array(2, 3, 4, 1, 2, 4))\n// 1\n// >>> minSubArraySum(array(-1, -2, -3))\n// -6\nfunction minSubArraySum($nums) {\n",
+    "prompt": "<?php\n// This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num($x, $y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return choose_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12, 15) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(33, 12354) !== 12354) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5234, 5233) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 29) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 7) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(546, 546) !== 546) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "php",
-    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence($n) {\n",
+    "prompt": "<?php\n// You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg($n, $m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return rounded_avg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 5) !== \"0b11\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== \"0b1010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(964, 977) !== \"0b1111001010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(996, 997) !== \"0b1111100100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(560, 851) !== \"0b1011000010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(185, 546) !== \"0b101101110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(362, 496) !== \"0b110101101\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(350, 902) !== \"0b1001110010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(197, 233) !== \"0b11010111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== \"0b101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "php",
-    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check($a, $b) {\n",
+    "prompt": "<?php\n// Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits(array(15, 33, 1422, 1))\n// array(1, 15, 33)\n// >>> unique_digits(array(152, 323, 1422, 10))\n// array()\nfunction unique_digits($x) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return unique_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 33, 1422, 1)) !== array(1, 15, 33)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(152, 323, 1422, 10)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12345, 2033, 111, 151)) !== array(111, 151)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(135, 103, 31)) !== array(31, 135)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "php",
-    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic(array(1, 2, 4, 20))\n// true\n// >>> monotonic(array(1, 20, 4, 10))\n// false\n// >>> monotonic(array(4, 1, 0, -10))\n// true\nfunction monotonic($l) {\n",
+    "prompt": "<?php\n// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length(array(2, 1, 1, 4, 5, 8, 2, 3))\n// array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")\n// If the array is empty, return an empty array:\n// >>> by_length(array())\n// array()\n// If the array has any strange number ignore it:\n// >>> by_length(array(1, -1, 55))\n// array(\"One\")\nfunction by_length($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return by_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 1, 4, 5, 8, 2, 3)) !== array(\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 55)) !== array(\"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 3, 2)) !== array(\"Three\", \"Two\", \"One\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 4, 8)) !== array(\"Nine\", \"Eight\", \"Four\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "php",
-    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest(array())\n// null\n// >>> longest(array(\"a\", \"b\", \"c\"))\n// \"a\"\n// >>> longest(array(\"a\", \"bb\", \"ccc\"))\n// \"ccc\"\nfunction longest($strings) {\n",
+    "prompt": "<?php\n// Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// array(1, 2, 6, 24, 15)\nfunction f($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return f(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(1, 2, 6, 24, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 2, 6, 24, 15, 720, 28)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "php",
-    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold(array(1, 2, 4, 10), 100)\n// true\n// >>> below_threshold(array(1, 20, 4, 10), 5)\n// false\nfunction below_threshold($l, $t) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// array(1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// array(4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return even_odd_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== array(8, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== array(6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== array(4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "php",
-    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "prompt": "<?php\n// Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums(array())\n// 0\n// >>> count_nums(array(-1, 11, -11))\n// 1\n// >>> count_nums(array(1, 1, 2))\n// 3\nfunction count_nums($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, -2, 3, 4, 5)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 9, -6, 0, 1, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 100, 98, -7, 1, -1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 23, 34, -45, -56, 0)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "php",
-    "prompt": "<?php\n// Return only positive numbers in the list.\n// >>> get_positive(array(-1, 2, -4, 5, 6))\n// array(2, 5, 6)\n// >>> get_positive(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// array(5, 3, 2, 3, 9, 123, 1)\nfunction get_positive($l) {\n",
+    "prompt": "<?php\n// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball(array(3, 4, 5, 1, 2))\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball(array(3, 5, 4, 1, 2))\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return move_one_ball(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 10, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 4, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "php",
-    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_third(array(5, 6, 3, 4, 8, 9, 2))\n// array(2, 6, 3, 4, 8, 9, 5)\nfunction sort_third($l) {\n",
+    "prompt": "<?php\n// Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return make_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz\") !== \"xyzyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyx\") !== \"xyx\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"jerry\") !== \"jerryrrej\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "php",
-    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// array(2, 3, 1, 3)\nfunction parse_nested_parens($paren_string) {\n",
+    "prompt": "<?php\n// In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange(array(1, 2, 3, 4), array(1, 2, 3, 4))\n// \"YES\"\n// >>> exchange(array(1, 2, 3, 4), array(1, 5, 3, 4))\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange($lst1, $lst2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return exchange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), array(1, 2, 3, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(1, 5, 3, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(2, 1, 4, 3)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 4)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 3), array(2, 6, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 6, 1, 8, 9), array(3, 5, 5, 1, 1, 1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 200), array(200, 200)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "php",
-    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
+    "prompt": "<?php\n// Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// array(\"a\" => 1, \"b\" => 1, \"c\" => 1)\n// >>> histogram(\"a b b a\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"a b c a b\")\n// array(\"a\" => 2, \"b\" => 2)\n// >>> histogram(\"b b b b a\")\n// array(\"b\" => 4)\n// >>> histogram(\"\")\n// array()\nfunction histogram($test) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "php",
-    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "php",
-    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation(array(1.0, 2.0, 3.0, 4.0))\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "php",
-    "prompt": "<?php\n// Return sorted unique common elements for two lists.\n// >>> common(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121))\n// array(1, 5, 653)\n// >>> common(array(5, 3, 2, 8), array(3, 2))\n// array(2, 3)\nfunction common($l1, $l2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "php",
-    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "php",
-    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution($s, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return histogram(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a b b a\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c a b\") !== array(\"a\" => 2, \"b\" => 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d g\") !== array(\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"b b b b a\") !== array(\"b\" => 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"r t g\") !== array(\"r\" => 1, \"t\" => 1, \"g\" => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== array(\"a\" => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2029,7 +214,7 @@
     "language": "php",
     "prompt": "<?php\n// Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// array(\"bcd\", false)\n// >>> reverse_delete(\"abcdef\", \"b\")\n// array(\"acdef\", false)\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// array(\"cdedc\", true)\nfunction reverse_delete($s, $c) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return reverse_delete(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\", \"ae\") !== array(\"bcd\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\", \"b\") !== array(\"acdef\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"ab\") !== array(\"cdedc\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dwik\", \"w\") !== array(\"dik\", false)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\", \"a\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdedcba\", \"v\") !== array(\"abcdedcba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"vabba\", \"v\") !== array(\"abba\", true)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"mamma\", \"mia\") !== array(\"\", true)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "php",
-    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
+    "prompt": "<?php\n// Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(array(\"1234567\"))\n// array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n// >>> odd_count(array(\"3\", \"11111111\"))\n// array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\nfunction odd_count($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"1234567\")) !== array(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"3\", \"11111111\")) !== array(\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"271\", \"137\", \"314\")) !== array(\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "php",
-    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"Hello,world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words($txt) {\n",
+    "prompt": "<?php\n// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum(array(2, 3, 4, 1, 2, 4))\n// 1\n// >>> minSubArraySum(array(-1, -2, -3))\n// -6\nfunction minSubArraySum($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return minSubArraySum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 4, 1, 2, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 2, -10)) !== -14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9999999999999999)) !== -9999999999999999) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 10, 20, 1000000)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -1, -2, -3, 10, -5)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 13, 8, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, -33, 32, -1, 0, -2)) !== -33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "php",
+    "prompt": "<?php\n// You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1)\n// 6\n// Example 2:\n// >>> max_fill(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2)\n// 5\n// Example 3:\n// >>> max_fill(array(array(0, 0, 0), array(0, 0, 0)), 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill($grid, $capacity) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_fill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0, 0, 1, 0), array(0, 1, 0, 0), array(1, 1, 1, 1)), 1) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 1, 1), array(0, 0, 0, 0), array(1, 1, 1, 1), array(0, 1, 1, 1)), 2) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 0, 0), array(0, 0, 0)), 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, 1, 1), array(1, 1, 1, 1)), 9) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2074,7 +274,7 @@
     "language": "php",
     "prompt": "<?php\n// In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array(array(1, 5, 2, 3, 4))\n// array(1, 2, 3, 4, 5)\n// >>> sort_array(array(-2, -3, -4, -5, -6))\n// array(-6, -5, -4, -3, -2)\n// >>> sort_array(array(1, 0, 2, 3, 4))\n// array(0, 1, 2, 3, 4)\nfunction sort_array($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 2, 3, 4)) !== array(1, 2, 4, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -3, -4, -5, -6)) !== array(-4, -2, -6, -5, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 3, 4)) !== array(0, 1, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)) !== array(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 44, 12, 32, 5)) !== array(32, 3, 5, 6, 12, 44)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 16, 32)) !== array(2, 4, 8, 16, 32)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "php",
-    "prompt": "<?php\n// Concatenate list of strings into a single string\n// >>> concatenate(array())\n// \"\"\n// >>> concatenate(array(\"a\", \"b\", \"c\"))\n// \"abc\"\nfunction concatenate($strings) {\n",
+    "prompt": "<?php\n// Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// array(\"little\")\n// >>> select_words(\"Mary had a little lamb\", 3)\n// array(\"Mary\", \"lamb\")\n// >>> select_words(\"simple white space\", 2)\n// array()\n// >>> select_words(\"Hello world\", 4)\n// array(\"world\")\n// >>> select_words(\"Uncle sam\", 3)\n// array(\"Uncle\")\nfunction select_words($s, $n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return select_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Mary had a little lamb\", 4) !== array(\"little\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mary had a little lamb\", 3) !== array(\"Mary\", \"lamb\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"simple white space\", 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world\", 4) !== array(\"world\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Uncle sam\", 3) !== array(\"Uncle\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\", 4) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c d e f\", 1) !== array(\"b\", \"c\", \"d\", \"f\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort(array(\"aa\", \"a\", \"aaa\"))\n// array(\"aa\")\n// >>> list_sort(array(\"ab\", \"a\", \"aaa\", \"cd\"))\n// array(\"ab\", \"cd\")\nfunction sorted_list_sum($lst) {\n",
+    "prompt": "<?php\n// You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel($word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_closest_vowel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"yogurt\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"full\") !== \"u\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"easy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eAsy\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ali\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bad\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"most\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ba\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"quick\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"anime\") !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Asia\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Above\") !== \"o\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "php",
-    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring(array(), \"a\")\n// array()\n// >>> filter_by_substring(array(\"abc\", \"bacd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"bacd\", \"array\")\nfunction filter_by_substring($strings, $substring) {\n",
+    "prompt": "<?php\n// You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens(array(\"()(\", \")\"))\n// \"Yes\"\n// >>> match_parens(array(\")\", \")\"))\n// \"No\"\nfunction match_parens($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return match_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"()(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \")\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(())\", \"())())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")())\", \"(()()(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(())))\", \"(()())((\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"()\", \"())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(()(\", \"()))()\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"((((\", \"((())\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(()\", \"(()(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")(\", \")(\")) !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"(\", \")\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\")\", \"(\")) !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "php",
-    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "prompt": "<?php\n// Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor($a, $b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return string_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"111000\", \"101010\") !== \"010010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"1\") !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0101\", \"0000\") !== \"0101\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "php",
-    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
+    "prompt": "<?php\n// Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum(array(-3, -4, 5), 3)\n// array(-4, -3, 5)\n// Example 2:\n// >>> maximum(array(4, -4, 4), 2)\n// array(4, 4)\n// Example 3:\n// >>> maximum(array(-3, 2, 1, 2, -1, -2, 1), 1)\n// array(2)\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum($arr, $k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-3, -4, 5), 3) !== array(-4, -3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4, 4), 2) !== array(4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 2, 1, 2, -1, -2, 1), 1) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(123, -123, 20, 0, 1, 2, -3), 3) !== array(2, 20, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-123, 20, 0, 1, 2, -3), 4) !== array(0, 1, 2, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 15, 0, 3, -13, -8, 0), 7) !== array(-13, -8, 0, 0, 3, 5, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 2, 5, 3, -10), 2) !== array(3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 5, -7), 1) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, -4), 2) !== array(-4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 10), 2) !== array(-10, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -23, 243, -400, 0), 0) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "php",
-    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max(array(\"name\", \"of\", \"string\"))\n// \"string\"\n// >>> find_max(array(\"name\", \"enam\", \"game\"))\n// \"enam\"\n// >>> find_max(array(\"aaaaaaa\", \"bb\", \"cc\"))\n// \"aaaaaaa\"\nfunction find_max($words) {\n",
+    "prompt": "<?php\n// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution(array(5, 8, 7, 1))\n// 12\n// >>> solution(array(3, 3, 3, 3, 3))\n// 9\n// >>> solution(array(30, 13, 24, 321))\n// 0\nfunction solution($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 8, 7, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3, 3, 3, 3)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 24, 321)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 9)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 13, 23, 32)) !== 23) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 13, 2, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "php",
-    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5($text) {\n",
+    "prompt": "<?php\n// Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements($arr, $k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return add_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 41, 57, 76, 87, 88, 99), 3) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 121, 3, 4000, 5, 6), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 21, 3, 90, 5, 6, 7, 8, 9), 4) !== 125) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "php",
-    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base($x, $base) {\n",
+    "prompt": "<?php\n// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// array(1, 5)\nfunction get_odd_collatz($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_odd_collatz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(14) !== array(1, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "php",
-    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "prompt": "<?php\n// You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date($date) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return valid_date(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"03-11-2000\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15-01-2012\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-0-2040\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-04-2020\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"01-01-2007\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"03-32-2011\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-31-3000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"06-06-2005\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"21-31-2000\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-12-2003\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04122003\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"20030412\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2003-04-12\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"04-2003\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "php",
-    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation(array(4.0, 3, 1.7, 2, 3.5))\n// array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")\nfunction numerical_letter_grade($grades) {\n",
+    "prompt": "<?php\n// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"Hello,world!\")\n// array(\"Hello\", \"world!\")\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words($txt) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return split_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,world!\") !== array(\"Hello\", \"world!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello world,!\") !== array(\"Hello\", \"world,!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello,Hello,world !\") !== array(\"Hello,Hello,world\", \"!\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaabb\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaBb\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "php",
-    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse(array(), 4)\n// array()\n// >>> intersperse(array(1, 2, 3), 4)\n// array(1, 4, 2, 4, 3)\nfunction intersperse($numbers, $delimeter) {\n",
+    "prompt": "<?php\n// Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted(array(5))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5))\n// false\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6))\n// true\n// >>> is_sorted(array(1, 2, 3, 4, 5, 6, 7))\n// true\n// >>> is_sorted(array(1, 3, 2, 4, 5, 6, 7))\n// false\n// >>> is_sorted(array(1, 2, 2, 3, 3, 4))\n// true\n// >>> is_sorted(array(1, 2, 2, 2, 3, 4))\n// false\nfunction is_sorted($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return is_sorted(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 3, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "php",
+    "prompt": "<?php\n// You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection(array(1, 2), array(2, 3))\n// \"NO\"\n// >>> intersection(array(-1, 1), array(0, 4))\n// \"NO\"\n// >>> intersection(array(-3, -1), array(-5, 5))\n// \"YES\"\nfunction intersection($interval1, $interval2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersection(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2), array(2, 3)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1), array(0, 4)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -1), array(-5, 5)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, 2), array(-4, 0)) !== \"YES\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-11, 2), array(-1, -1)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 5)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(1, 2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -2), array(-3, -2)) !== \"NO\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "php",
+    "prompt": "<?php\n// You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs(array(1, 2, 2, -4))\n// 9\n// >>> prod_signs(array(0, 1))\n// 0\n// >>> prod_signs(array())\n// null\nfunction prod_signs($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prod_signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 2, -4)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, -1, 1)) !== -10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 2, -1, -1, 9)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, -1, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 1)) !== -4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 1, 1, 0)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3)\n// array(1, 2, 1)\n// >>> minPath(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1)\n// array(1)\nfunction minPath($grid, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return minPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9)), 3) !== array(1, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 9, 3), array(4, 1, 6), array(7, 8, 2)), 1) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12), array(13, 14, 15, 16)), 4) !== array(1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 4, 13, 10), array(5, 7, 12, 1), array(3, 16, 11, 15), array(8, 14, 9, 2)), 7) !== array(1, 10, 1, 10, 1, 10, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(8, 14, 9, 2), array(6, 4, 13, 15), array(5, 7, 1, 12), array(3, 10, 11, 16)), 5) !== array(1, 7, 1, 7, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 8, 7, 2), array(5, 16, 14, 4), array(9, 3, 15, 6), array(12, 13, 10, 1)), 9) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 13, 10, 1), array(9, 3, 15, 6), array(5, 16, 14, 4), array(11, 8, 7, 2)), 12) !== array(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 4), array(3, 1, 5), array(6, 8, 9)), 8) !== array(1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 1, 5), array(3, 8, 9), array(2, 7, 4)), 8) !== array(1, 5, 1, 5, 1, 5, 1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4)), 10) !== array(1, 2, 1, 2, 1, 2, 1, 2, 1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 3), array(3, 2)), 10) !== array(1, 3, 1, 3, 1, 3, 1, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "php",
+    "prompt": "<?php\n// Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest(array())\n// null\n// >>> longest(array(\"a\", \"b\", \"c\"))\n// \"a\"\n// >>> longest(array(\"a\", \"bb\", \"ccc\"))\n// \"ccc\"\nfunction longest($strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return longest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"x\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\")) !== \"zzzz\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "php",
+    "prompt": "<?php\n// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// array(1, 3, 2, 8)\nfunction tri($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tri(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== array(1, 3, 2, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(1, 3, 2, 8, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(1, 3, 2, 8, 3, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(1, 3, 2, 8, 3, 15, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(1, 3, 2, 8, 3, 15, 4, 24)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array(1, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(54) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5014) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(98765) !== 315) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5576543) !== 2625) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2468) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"[[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]][[[[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[]]]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[][][[]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[]]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[]][[\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[][]]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"[[[[[[[[\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"]]]]]]]]\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst(array(1.0, 2.0, 3.0))\n// 14\n// >>> lst(array(1.0, 4.0, 9.0))\n// 98\n// >>> lst(array(1.0, 3.0, 5.0, 7.0))\n// 84\n// >>> lst(array(1.4, 4.2, 0.0))\n// 29\n// >>> lst(array(-2.4, 1.0, 1.0))\n// 6\nfunction sum_squares($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 3.0, 5.0, 7.0)) !== 84) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.4, 4.2, 0.0)) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2.4, 1.0, 1.0)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 1.0, 15.0, 2.0)) !== 10230) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10000.0, 10000.0)) !== 200000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 4.6, 6.3)) !== 75) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.4, 17.9, 18.9, 19.9)) !== 1086) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, 1.0, 0.0)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter($txt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_if_last_char_is_a_letter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"apple\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pumpkin pie 1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee e \") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pie\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple pi e \") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange(array(1, 2, 4, 3, 5))\n// 3\n// >>> can_arrange(array(1, 2, 3))\n// -1\nfunction can_arrange($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return can_arrange(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 3, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 8, 5, 7, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers(array(2, 4, 1, 3, 5, 7))\n// array(null, 1)\n// >>> largest_smallest_integers(array())\n// array(null, null)\n// >>> largest_smallest_integers(array(0))\n// array(null, null)\nfunction largest_smallest_integers($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_smallest_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 1, 3, 5, 7)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3, 5, 7, 0)) !== array(null, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2, 4, 5, 6, -2)) !== array(-2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 3, 6, 2, 7, -7)) !== array(-7, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 8, 4, 9, 2, 5, -9)) !== array(-9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== array(null, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, -5, -6, 0)) !== array(-1, null)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-6, -4, -4, -3, -100, 1)) !== array(-3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes integers, floats, or strings representing\n// real numbers, and returns the larger variable in its given variable type.\n// Return None if the values are equal.\n// Note: If a real number is represented as a string, the floating point might be . or ,\n// >>> compare_one(1, 2.5)\n// 2.5\n// >>> compare_one(1, \"2,3\")\n// \"2,3\"\n// >>> compare_one(\"5,1\", \"6\")\n// \"6\"\n// >>> compare_one(\"1\", 1)\n// null\nfunction compare_one($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2.5) !== 2.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, \"2,3\") !== \"2,3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5,1\", \"6\") !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", \"2\") !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\", 1) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "php",
+    "prompt": "<?php\n// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_equal_to_sum_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "php",
+    "prompt": "<?php\n// The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return special_factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 34560) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 125411328000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return greatest_common_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49, 14) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(144, 60) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fix_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Example\") !== \"Example\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir Hanif \") !== \"Mudasir_Hanif_\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Yellow Yellow  Dirty  Fellow\") !== \"Yellow_Yellow__Dirty__Fellow\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Exa   mple\") !== \"Exa-mple\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   Exa 1 2 2 mple\") !== \"-Exa_1_2_2_mple\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "php",
+    "prompt": "<?php\n// Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check($file_name) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return file_name_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"example.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1example.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s1sdf3.asd\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MY16FILE3.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"His12FILE94.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_Y.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"?aREYA.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"/this_is_valid.dll\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.wow\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_valid.txtexe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#this2_i4s_5valid.ten\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"@this1_is6_valid.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"this_is_12valid.6exe4.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"all.exe.txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_No.exe\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is3youfault.txt\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"no_one#knows.dll\") !== \"Yes\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1I563_Yes3.exe\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I563_Yes3.txtt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final..txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final132\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_f4indsartal132.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".txt\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"s.\") !== \"No\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "php",
+    "prompt": "<?php\n// \"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// array(1, 2, 3)\n// >>> lst\n// array()\n// >>> lst\n// array(-1, -5, 2, -1, -5)\nfunction sum_squares($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 9)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 1, 1, 1, 1, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -1, -1, -1, -1, -1, -1, -1, -1)) !== -3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -5, 2, -1, -5)) !== -126) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-56, -99, 1, 0, -2)) !== 3030) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 0, 0, 0, 0, 0, 0, 0, -1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)) !== -14196) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)) !== -1448) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence($sentence) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return words_in_sentence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"This is a test\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lets go for swimming\") !== \"go for\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"there is no place available here\") !== \"there is no place\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi I am Hussein\") !== \"Hi am Hussein\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go for it\") !== \"go for it\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"here is\") !== \"is\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify($x, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return simplify(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/6\", \"2/1\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/1\", \"3/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/10\", \"10/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/10\", \"50/10\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"7/2\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11/6\", \"6/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/3\", \"5/2\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5/2\", \"3/5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"8/4\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2/4\", \"4/2\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"5/1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1/5\", \"1/5\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points(array(1, 11, -1, -11, -12))\n// array(-1, -11, 1, -12, 11)\n// >>> order_by_points(array())\n// array()\nfunction order_by_points($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return order_by_points(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 11, -1, -11, -12)) !== array(-1, -11, 1, -12, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)) !== array(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -11, -32, 43, 54, -98, 2, -3)) !== array(-3, -32, -98, -11, 1, 2, 43, 54)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)) !== array(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 6, 6, -76, -21, 23, 4)) !== array(-76, -21, 0, 4, 23, 6, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2254,7 +769,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter(array(15, -73, 14, -15))\n// 1\n// >>> specialFilter(array(33, -2, -3, 45, 21, 109))\n// 2\nfunction specialFilter($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return specialFilter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, -2, 1, -5)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, -73, 14, -15)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(33, -2, -3, 45, 21, 109)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(43, -12, 93, 125, 121, 109)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(71, -2, -33, 75, 21, 19)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "php",
-    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
+    "prompt": "<?php\n// You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return get_max_triples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 53361) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "php",
-    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates(array(1, 2, 3, 2, 4))\n// array(1, 3, 4)\nfunction remove_duplicates($numbers) {\n",
+    "prompt": "<?php\n// There are eight planets in our solar system: the closerst to the Sun \n// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n// Uranus, Neptune.\n// Write a function that takes two planet names as strings planet1 and planet2. \n// The function should return a tuple containing all planets whose orbits are \n// located between the orbit of planet1 and the orbit of planet2, sorted by \n// the proximity to the sun. \n// The function should return an empty tuple if planet1 or planet2\n// are not correct planet names. \n// Examples\n// >>> bf(\"Jupiter\", \"Neptune\")\n// array(\"Saturn\", \"Uranus\")\n// >>> bf(\"Earth\", \"Mercury\")\n// \"Venus\"\n// >>> bf(\"Mercury\", \"Uranus\")\n// array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunction bf($planet1, $planet2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return bf(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jupiter\", \"Neptune\") !== array(\"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Mercury\") !== array(\"Venus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mercury\", \"Uranus\") !== array(\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Neptune\", \"Venus\") !== array(\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Earth\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mars\", \"Earth\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jupiter\", \"Makemake\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort(array(\"aa\", \"a\", \"aaa\"))\n// array(\"aa\")\n// >>> list_sort(array(\"ab\", \"a\", \"aaa\", \"cd\"))\n// array(\"ab\", \"cd\")\nfunction sorted_list_sum($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sorted_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"aa\", \"a\", \"aaa\")) !== array(\"aa\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"school\", \"AI\", \"asdf\", \"b\")) !== array(\"AI\", \"asdf\", \"school\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"b\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"d\", \"dcba\", \"abcd\", \"a\")) !== array(\"abcd\", \"dcba\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"AI\", \"ai\", \"au\")) !== array(\"AI\", \"ai\", \"au\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"b\", \"c\", \"c\", \"a\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaa\", \"bbbb\", \"dd\", \"cc\")) !== array(\"cc\", \"dd\", \"aaaa\", \"bbbb\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "php",
+    "prompt": "<?php\n// Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// array(\"a\", \"ab\", \"abc\")\nfunction all_prefixes($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_prefixes(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfgh\") !== array(\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"WWW\") !== array(\"W\", \"WW\", \"WWW\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "php",
+    "prompt": "<?php\n// A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y($n, $x, $y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return x_or_y(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 34, 12) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 5) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 33, 5212) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1259, 3, 52) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7919, -1, 12) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3609, 1245, 583) !== 583) { throw new Exception(\"Test failed!\"); }\n    if (candidate(91, 56, 129) !== 129) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 34, 1234) !== 1234) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 0) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference(array(1, 3, 2, 0))\n// 10\n// >>> double_the_difference(array(-1, -2, 0))\n// 0\n// >>> double_the_difference(array(9, -2))\n// 81\n// >>> double_the_difference(array(0))\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return double_the_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5.0, 4.0)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.1, 0.2, 0.3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10.0, -20.0, -30.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1.0, -2.0, 8.0)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.2, 3.0, 5.0)) !== 34) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)) !== 165) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "php",
+    "prompt": "<?php\n// I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2))\n// array(0, 0, 0, 0, 3, 3)\n// >>> compare(array(0, 5, 0, 0, 0, 4), array(4, 1, 1, 0, 0, -2))\n// array(4, 4, 1, 0, 0, 6)\nfunction compare($game, $guess) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return compare(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 1), array(1, 2, 3, 4, 2, -2)) !== array(0, 0, 0, 0, 3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 0, 0, 0, 0), array(0, 0, 0, 0, 0, 0)) !== array(0, 0, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(-1, -2, -3)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5), array(-1, 2, 3, 4)) !== array(2, 0, 0, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "php",
+    "prompt": "<?php\n// You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", array(\"AA\", \"Be\", \"CC\"))\n// \"my_class.AA\"\nfunction Strongest_Extension($class_name, $extensions) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Strongest_Extension(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Watashi\", array(\"tEN\", \"niNE\", \"eIGHt8OKe\")) !== \"Watashi.eIGHt8OKe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Boku123\", array(\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\")) !== \"Boku123.YEs.WeCaNe\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__YESIMHERE\", array(\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\")) !== \"__YESIMHERE.NuLl__\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"K\", array(\"Ta\", \"TAR\", \"t234An\", \"cosSo\")) !== \"K.TAR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"__HAHA\", array(\"Tab\", \"123\", \"781345\", \"-_-\")) !== \"__HAHA.123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YameRore\", array(\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\")) !== \"YameRore.okIWILL123\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"finNNalLLly\", array(\"Die\", \"NowW\", \"Wow\", \"WoW\")) !== \"finNNalLLly.WoW\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"_\", array(\"Bb\", \"91245\")) !== \"_.Bb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Sp\", array(\"671235\", \"Bb\")) !== \"Sp.671235\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "php",
+    "prompt": "<?php\n// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cycpattern_check(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xyzw\", \"xyw\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"yello\", \"ell\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"whattup\", \"ptut\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"efef\", \"fee\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abab\", \"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"winemtt\", \"tinem\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "php",
+    "prompt": "<?php\n// Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// array(1, 1)\n// >>> even_odd_count(123)\n// array(1, 2)\nfunction even_odd_count($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_odd_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-78) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3452) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(346211) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-345821) !== array(3, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-45347) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array(1, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return int_to_mini_roman(...$args);\n}\n\nfunction test(): void {\n    if (candidate(19) !== \"xix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(152) !== \"clii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(251) !== \"ccli\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(426) !== \"cdxxvi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(500) !== \"d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== \"i\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== \"iv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(43) !== \"xliii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(90) !== \"xc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(94) !== \"xciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(532) !== \"dxxxii\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(900) !== \"cm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(994) !== \"cmxciv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== \"m\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return right_angle_triangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 6, 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 24, 25) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 12, 13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8, 17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(48, 55, 73) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max(array(\"name\", \"of\", \"string\"))\n// \"string\"\n// >>> find_max(array(\"name\", \"enam\", \"game\"))\n// \"enam\"\n// >>> find_max(array(\"aaaaaaa\", \"bb\", \"cc\"))\n// \"aaaaaaa\"\nfunction find_max($words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"name\", \"of\", \"string\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"name\", \"enam\", \"game\")) !== \"enam\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"aaaaaaa\", \"bb\", \"cc\")) !== \"aaaaaaa\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"cba\")) !== \"abc\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"this\", \"game\", \"of\", \"footbott\")) !== \"footbott\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"gonna\", \"rock\")) !== \"gonna\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"we\", \"are\", \"a\", \"mad\", \"nation\")) !== \"nation\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\", \"is\", \"a\", \"prrk\")) !== \"this\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"b\")) !== \"b\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"play\", \"play\", \"play\")) !== \"play\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "php",
+    "prompt": "<?php\n// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// array(11, 4)\n// >>> eat(4, 8, 9)\n// array(12, 1)\n// >>> eat(1, 10, 10)\n// array(11, 0)\n// >>> eat(2, 11, 5)\n// array(7, 0)\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat($number, $need, $remaining) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return eat(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 6, 10) !== array(11, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 9) !== array(12, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 10, 10) !== array(11, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 11, 5) !== array(7, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 7) !== array(9, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5, 1) !== array(5, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"0\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== \"0 1 2 3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== \"0 1 2 3 4 5 6 7 8 9 10\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "php",
+    "prompt": "<?php\n// Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra($operator, $operand) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return do_algebra(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"**\", \"*\", \"+\"), array(2, 3, 4, 5)) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"+\", \"*\", \"-\"), array(2, 3, 4, 5)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"//\", \"*\"), array(7, 3, 4)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AsDf\") !== \"aSdF\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1234\") !== \"4321\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"AB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#a@C\") !== \"#A@c\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#AsdfW^45\") !== \"#aSDFw^45\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#6@2\") !== \"2@6#\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#$a^D\") !== \"#$A^d\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"#ccc\") !== \"#CCC\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "php",
+    "prompt": "<?php\n// Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_to_md5(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== \"3e25960a79dbc69b674cd4ec67a72c62\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"A B C\") !== \"0ef78513b0cb8cef12743f5aeb35f888\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"password\") !== \"5f4dcc3b5aa765d61d8327deb882cf99\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2299,7 +1054,7 @@
     "language": "php",
     "prompt": "<?php\n// Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// array(2, 4, 6, 8)\n// >>> generate_integers(8, 2)\n// array(2, 4, 6, 8)\n// >>> generate_integers(10, 14)\n// array()\nfunction generate_integers($a, $b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return generate_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 10) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(132, 2) !== array(2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 89) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "php",
-    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max(array(1, 2, 3, 2, 3, 4, 2))\n// array(1, 2, 3, 3, 3, 4, 4)\nfunction rolling_max($numbers) {\n",
+    "prompt": "<?php\n// Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count_distinct_characters(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdecadeCADE\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaAAAAaaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Jerry jERRY JeRRRY\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "php",
-    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero(array(1, 2, 3))\n// false\n// >>> below_zero(array(1, 2, -4, 5))\n// true\nfunction below_zero($operations) {\n",
+    "prompt": "<?php\n// Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// array(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nfunction parse_music($music_string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return parse_music(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o o o o\") !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\".| .| .| .|\") !== array(1, 1, 1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| o| .| .| o o o o\") !== array(2, 2, 1, 1, 4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"o| .| o| .| o o| o o|\") !== array(2, 1, 2, 1, 4, 2, 4, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "php",
-    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search(array(4, 1, 2, 2, 3, 1))\n// 2\n// >>> search(array(1, 2, 2, 3, 3, 3, 4, 4, 4))\n// 3\n// >>> search(array(5, 5, 4, 4, 4))\n// -1\nfunction search($lst) {\n",
+    "prompt": "<?php\n// Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times($string, $substring) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return how_many_times(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\", \"x\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyxyxyx\", \"x\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"cacacacac\", \"cac\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"john doe\", \"john\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "php",
-    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing($brackets) {\n",
+    "prompt": "<?php\n// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers($numbers) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three\") !== \"three\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"three five nine\") !== \"three five nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"five zero four seven nine eight\") !== \"zero four five seven eight nine\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"six five four three two one zero\") !== \"zero one two three four five six\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// array(\"()\", \"(())\", \"(()())\")\nfunction separate_paren_groups($paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return separate_paren_groups(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(\"(()())\", \"((()))\", \"()\", \"((())()())\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(\"()\", \"(())\", \"((()))\", \"(((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(\"(()(())((())))\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"( ) (( )) (( )( ))\") !== array(\"()\", \"(())\", \"(()())\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "php",
+    "prompt": "<?php\n// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n// array(2.0, 2.2)\n// >>> find_closest_elements(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n// array(2.0, 2.0)\nfunction find_closest_elements($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_closest_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)) !== array(3.9, 4.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 5.9, 4.0, 5.0)) !== array(5.0, 5.9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)) !== array(2.0, 2.2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)) !== array(2.0, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.1, 2.2, 3.1, 4.1, 5.1)) !== array(2.2, 3.1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "php",
+    "prompt": "<?php\n// Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit(array(1.0, 2.0, 3.0, 4.0, 5.0))\n// array(0.0, 0.25, 0.5, 0.75, 1.0)\nfunction rescale_to_unit($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rescale_to_unit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2.0, 49.9)) !== array(0.0, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100.0, 49.9)) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== array(0.0, 0.25, 0.5, 0.75, 1.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2.0, 1.0, 5.0, 3.0, 4.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12.0, 11.0, 15.0, 13.0, 14.0)) !== array(0.25, 0.0, 1.0, 0.5, 0.75)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "php",
+    "prompt": "<?php\n// Filter given list of any python values only for integers\n// >>> filter_integers(array(\"a\", 3.14, 5))\n// array(5)\n// >>> filter_integers(array(1, 2, 3, \"abc\", array(), array()))\n// array(1, 2, 3)\nfunction filter_integers($values) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_integers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, array(), array(), 23.2, 9, \"adasd\")) !== array(4, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, \"c\", 3, 3, \"a\", \"b\")) !== array(3, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "php",
+    "prompt": "<?php\n// Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strlen(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"x\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdasnakj\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "php",
+    "prompt": "<?php\n// For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(49) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "php",
+    "prompt": "<?php\n// Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// array(2, 2, 2)\n// >>> factorize(25)\n// array(5, 5)\n// >>> factorize(70)\n// array(2, 5, 7)\nfunction factorize($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return factorize(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== array(2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(57) !== array(3, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3249) !== array(3, 3, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(185193) !== array(3, 3, 3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20577) !== array(3, 19, 19, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates(array(1, 2, 3, 2, 4))\n// array(1, 3, 4)\nfunction remove_duplicates($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 3, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "php",
+    "prompt": "<?php\n// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return flip_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello!\") !== \"hELLO!\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"These violent delights have violent ends\") !== \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "php",
+    "prompt": "<?php\n// Concatenate list of strings into a single string\n// >>> concatenate(array())\n// \"\"\n// >>> concatenate(array(\"a\", \"b\", \"c\"))\n// \"abc\"\nfunction concatenate($strings) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return concatenate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\")) !== \"xyz\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"x\", \"y\", \"z\", \"w\", \"k\")) !== \"xyzwk\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix(array(), \"a\")\n// array()\n// >>> filter_by_prefix(array(\"abc\", \"bcd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"array\")\nfunction filter_by_prefix($strings, $prefix) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_prefix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return truncate_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3.5) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.25) !== 0.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123.0) !== 0.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "php",
+    "prompt": "<?php\n// Return only positive numbers in the list.\n// >>> get_positive(array(-1, 2, -4, 5, 6))\n// array(2, 5, 6)\n// >>> get_positive(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// array(5, 3, 2, 3, 9, 123, 1)\nfunction get_positive($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_positive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, -2, 4, 5, 6)) !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)) !== array(5, 3, 2, 3, 3, 9, 123, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2)) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "php",
+    "prompt": "<?php\n// Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13441) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(61) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(85) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(255379) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "php",
+    "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_third(array(5, 6, 3, 4, 8, 9, 2))\n// array(2, 6, 3, 4, 8, 9, 5)\nfunction sort_third($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_third(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2)) !== array(2, 6, 3, 4, 8, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, 3, 4, 6, 9, 2)) !== array(2, 8, 3, 4, 6, 9, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 9, 4, 8, 3, 2)) !== array(2, 6, 9, 4, 8, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 4, 8, 9, 2, 1)) !== array(2, 6, 3, 4, 8, 9, 5, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique elements in a list\n// >>> unique(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(0, 2, 3, 5, 9, 123)\nfunction unique($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 3, 5, 2, 3, 3, 9, 0, 123)) !== array(0, 2, 3, 5, 9, 123)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "php",
+    "prompt": "<?php\n// Return maximum element in the list.\n// >>> max_element(array(1, 2, 3))\n// 3\n// >>> max_element(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n// 123\nfunction max_element($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "php",
+    "prompt": "<?php\n// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fizz_buzz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(50) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(78) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(79) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4000) !== 192) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10000) !== 639) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100000) !== 8026) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2374,9 +1399,249 @@
     "language": "php",
     "prompt": "<?php\n// This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even(array(1, 2, 3))\n// array(1, 2, 3)\n// >>> sort_even(array(5, 6, 3, 4))\n// array(3, 6, 5, 4)\nfunction sort_even($l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return sort_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)) !== array(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)) !== array(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "php",
+    "prompt": "<?php\n// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 233) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1597) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28657) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 514229) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 433494437) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "php",
+    "prompt": "<?php\n// You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero(array(1, 2, 3))\n// false\n// >>> below_zero(array(1, 2, -4, 5))\n// true\nfunction below_zero($operations) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -3, 1, 2, -3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, -4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -1, 2, -2, 5, -5, 4, -5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 2, -2, 5, -5, 4, -4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> triples_sum_to_zero(array(1, 3, -2, 1))\n// true\n// >>> triples_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> triples_sum_to_zero(array(2, 4, -5, 3, 9, 7))\n// true\n// >>> triples_sum_to_zero(array(1))\n// false\nfunction triples_sum_to_zero($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triples_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 9, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 3, 5, -100)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "php",
+    "prompt": "<?php\n// Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return car_race_collision(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "php",
+    "prompt": "<?php\n// Return list with elements incremented by 1.\n// >>> incr_list(array(1, 2, 3))\n// array(2, 3, 4)\n// >>> incr_list(array(5, 3, 5, 2, 3, 3, 9, 0, 123))\n// array(6, 4, 6, 3, 4, 4, 10, 1, 124)\nfunction incr_list($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return incr_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(4, 3, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 5, 2, 3, 3, 9, 0, 123)) !== array(6, 3, 6, 3, 4, 4, 10, 1, 124)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "php",
+    "prompt": "<?php\n// pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero(array(1, 3, 5, 0))\n// false\n// >>> pairs_sum_to_zero(array(1, 3, -2, 1))\n// false\n// >>> pairs_sum_to_zero(array(1, 2, 3, 7))\n// false\n// >>> pairs_sum_to_zero(array(2, 4, -5, 3, 5, 7))\n// true\n// >>> pairs_sum_to_zero(array(1))\n// false\nfunction pairs_sum_to_zero($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pairs_sum_to_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, -2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -5, 3, 5, 7)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 30)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 3, 2, 31)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 30)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, 9, -1, 4, 2, 31)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "php",
+    "prompt": "<?php\n// Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base($x, $base) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return change_base(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8, 3) !== \"22\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== \"100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(234, 2) !== \"11101010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 2) !== \"10000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 2) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 2) !== \"111\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== \"2\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== \"3\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== \"4\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 6) !== \"5\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 7) !== \"6\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 8) !== \"7\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area($a, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3) !== 7.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2) !== 2.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 40.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "php",
+    "prompt": "<?php\n// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib4(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 28) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 104) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 386) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "php",
+    "prompt": "<?php\n// Return median of elements in the list l.\n// >>> median(array(3, 1, 2, 4, 5))\n// 3\n// >>> median(array(-10, 4, 6, 1000, 10, 20))\n// 15.0\nfunction median($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-10, 4, 6, 1000, 10, 20)) !== 8.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 5)) !== 5.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 1, 3, 9, 9, 2, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "php",
+    "prompt": "<?php\n// Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zbcd\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyx\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywyz\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xywzx\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "php",
+    "prompt": "<?php\n// Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp($n, $p) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return modp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1101, 101) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 11) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 101) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(31, 5) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation(array(1.0, 2.0, 3.0, 4.0))\n// 1.0\nfunction mean_absolute_deviation($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return mean_absolute_deviation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1.0, 2.0)) !== 0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0)) !== 1.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 2.0, 3.0, 4.0, 5.0)) !== 1.2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "php",
+    "prompt": "<?php\n// remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdef\\nghijklm\") !== \"bcdf\\nghjklm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"fedcba\") !== \"fdcb\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eeeee\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"acBAA\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EcBOO\") !== \"cB\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ybcd\") !== \"ybcd\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "php",
+    "prompt": "<?php\n// Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold(array(1, 2, 4, 10), 100)\n// true\n// >>> below_threshold(array(1, 20, 4, 10), 5)\n// false\nfunction below_threshold($l, $t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return below_threshold(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10), 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 21) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10), 22) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 11) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 8, 4, 10), 10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "php",
+    "prompt": "<?php\n// Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add($x, $y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 5) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2389,9 +1654,24 @@
     "language": "php",
     "prompt": "<?php\n// Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars($s0, $s1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return same_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dddddddabc\", \"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcd\", \"dddddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\", \"dddddddabcf\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\", \"aaccc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "php",
+    "prompt": "<?php\n// Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 55) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 89) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 144) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -2404,9 +1684,729 @@
     "language": "php",
     "prompt": "<?php\n// brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing($brackets) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"<>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<><>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<<><><>><>><<><><<>>>\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<><>>>>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<<<\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\">\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>><<>\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"<><><<><>><>>><>\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic(array(1, 2, 4, 20))\n// true\n// >>> monotonic(array(1, 20, 4, 10))\n// false\n// >>> monotonic(array(4, 1, 0, -10))\n// true\nfunction monotonic($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 20)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 20, 4, 10)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 0, -10)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 1, 0)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 5, 60)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 60)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 9, 9, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "php",
+    "prompt": "<?php\n// Return sorted unique common elements for two lists.\n// >>> common(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121))\n// array(1, 5, 653)\n// >>> common(array(5, 3, 2, 8), array(3, 2))\n// array(2, 3)\nfunction common($l1, $l2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return common(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 34, 653, 2, 5), array(5, 7, 1, 5, 9, 653, 121)) !== array(1, 5, 653)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 3, 2, 8), array(3, 2)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array(3, 2, 4)) !== array(2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 8), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "php",
+    "prompt": "<?php\n// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_prime_factor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(27) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(63) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(330) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13195) !== 29) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "php",
+    "prompt": "<?php\n// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse(array(), 4)\n// array()\n// >>> intersperse(array(1, 2, 3), 4)\n// array(1, 4, 2, 4, 3)\nfunction intersperse($numbers, $delimeter) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersperse(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), 7) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 3, 2), 8) !== array(5, 8, 6, 8, 3, 8, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2), 2) !== array(2, 2, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "php",
+    "prompt": "<?php\n// sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_to_n(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 5050) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "php",
+    "prompt": "<?php\n// brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing($brackets) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return correct_bracketing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()())\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()((()()())())(()()(()))\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((()())))\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"((((\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\")\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())())(()\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"()()(()())()))()\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "php",
+    "prompt": "<?php\n// xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative(array(3, 1, 2, 4, 5))\n// array(1, 4, 12, 20)\n// >>> derivative(array(1, 2, 3))\n// array(2, 6)\nfunction derivative($xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return derivative(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 1, 2, 4, 5)) !== array(1, 4, 12, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== array(2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 0, 4)) !== array(2, 2, 0, 16)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "php",
+    "prompt": "<?php\n// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fibfib(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 24) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 274) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== 927) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return vowels_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcde\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Alone\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"key\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bye\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"keY\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bYe\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ACEDY\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "php",
+    "prompt": "<?php\n// Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift($x, $shift) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return circular_shift(...$args);\n}\n\nfunction test(): void {\n    if (candidate(100, 2) !== \"001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 2) !== \"12\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(97, 8) !== \"79\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 1) !== \"21\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(11, 101) !== \"11\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "php",
+    "prompt": "<?php\n// Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digitSum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abAB\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcCd\") !== 67) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"helloE\") !== 69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"woArBld\") !== 131) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aAaaaXa\") !== 153) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" How are yOu?\") !== 151) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You arE Very Smart\") !== 327) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "php",
+    "prompt": "<?php\n// In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution($s, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return fruit_distribution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"5 apples and 6 oranges\", 19) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"5 apples and 6 oranges\", 21) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0 apples and 1 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 0 oranges\", 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 100) !== 95) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2 apples and 3 oranges\", 5) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1 apples and 100 oranges\", 120) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "php",
+    "prompt": "<?php\n// \"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck(array(4, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck(array(1, 2, 3))\n// array(2, 1)\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck(array())\n// array()\n// Example 4:\n// >>> pluck(array(5, 0, 3, 0, 4, 2))\n// array(0, 1)\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pluck(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 0, 3, 0, 4, 2)) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 0, 5, 3)) !== array(0, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 8, 4, 8)) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 6, 7, 1)) !== array(6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 7, 1)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "php",
+    "prompt": "<?php\n// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search(array(4, 1, 2, 2, 3, 1))\n// 2\n// >>> search(array(1, 2, 2, 3, 3, 3, 4, 4, 4))\n// 3\n// >>> search(array(5, 5, 4, 4, 4))\n// -1\nfunction search($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 5, 5, 5, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 4, 1, 4, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 3)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 8, 8, 8, 8, 8, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 3, 2, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 8, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 3, 6, 5, 6, 4)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 9, 10, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 10, 10, 9, 2)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "php",
+    "prompt": "<?php\n// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// array(2, 3, 1, 3)\nfunction parse_nested_parens($paren_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return parse_nested_parens(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(()()) ((())) () ((())()())\") !== array(2, 3, 1, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"() (()) ((())) (((())))\") !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(()(())((())))\") !== array(4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "php",
+    "prompt": "<?php\n// Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list(array(1, 2, 3, 4))\n// array(1, 4, 2, 3)\n// >>> strange_sort_list(array(5, 5, 5, 5))\n// array(5, 5, 5, 5)\n// >>> strange_sort_list(array())\n// array()\nfunction strange_sort_list($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return strange_sort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 4, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9)) !== array(5, 9, 6, 8, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 5, 2, 4, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8, 9, 1)) !== array(1, 9, 5, 8, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 5, 5, 5)) !== array(5, 5, 5, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8)) !== array(1, 8, 2, 7, 3, 6, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 2, 2, 2, 5, 5, -5, -5)) !== array(-5, 5, -5, 5, 0, 2, 2, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(111111)) !== array(111111)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4, 5) !== 6.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8, 5) !== 8.18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 2) !== 1.73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5, 7) !== 16.25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1, 1) !== 0.43) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 2, 10) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly(array(1, 2), 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly(array(3, 2, 3), 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly(array(3, 2, 3), 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly(array(3), 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly($q, $w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return will_it_fly(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 3), 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), 5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3), 5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3), 1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5), 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "php",
+    "prompt": "<?php\n// Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change(array(1, 2, 3, 5, 4, 7, 9, 6))\n// 4\n// >>> smallest_change(array(1, 2, 3, 4, 3, 2, 2))\n// 1\n// >>> smallest_change(array(1, 2, 3, 2, 1))\n// 0\nfunction smallest_change($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return smallest_change(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 4, 7, 9, 6)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 4, 2)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 1, 1, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match(array(), array())\n// array()\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\"))\n// array(\"hI\", \"Hi\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\"))\n// array(\"hi\", \"admin\")\n// >>> total_match(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\"))\n// array(\"hI\", \"hi\", \"hi\")\n// >>> total_match(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\"))\n// array(\"4\")\nfunction total_match($lst1, $lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return total_match(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\")) !== array(\"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hi\", \"hi\", \"admin\", \"project\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"4\"), array(\"1\", \"2\", \"3\", \"4\", \"5\")) !== array(\"4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"Hi\")) !== array(\"hI\", \"Hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hi\")) !== array(\"hI\", \"hi\", \"hi\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"hi\", \"admin\"), array(\"hI\", \"hi\", \"hii\")) !== array(\"hi\", \"admin\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), array(\"this\")) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"this\"), array()) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_multiply_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(105) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(126) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(729) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(891) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1001) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "php",
+    "prompt": "<?php\n// Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power($x, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_simple_power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(143214, 16) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(128, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12, 6) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 12) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return iscube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(64) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(180) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1000) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1729) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "php",
+    "prompt": "<?php\n// You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return hex_key(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AB\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1077E\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABED1A33\") !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123456789ABCDEF0\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"112233445566778899AABBCCDDEEFF00\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary($decimal) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== \"db0db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== \"db100000db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(103) !== \"db1100111db\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== \"db1111db\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "php",
+    "prompt": "<?php\n// Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring(array(), \"a\")\n// array()\n// >>> filter_by_substring(array(\"abc\", \"bacd\", \"cde\", \"array\"), \"a\")\n// array(\"abc\", \"bacd\", \"array\")\nfunction filter_by_substring($strings, $substring) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_by_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(), \"john\") !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xxx\") !== array(\"xxx\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"), \"xx\") !== array(\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"grunt\", \"trumpet\", \"prune\", \"gruesome\"), \"run\") !== array(\"grunt\", \"prune\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "php",
+    "prompt": "<?php\n// You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_happy(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"a\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabb\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"adb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyy\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxpoi\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"iopaxioi\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "php",
+    "prompt": "<?php\n// It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation(array(4.0, 3, 1.7, 2, 3.5))\n// array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")\nfunction numerical_letter_grade($grades) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return numerical_letter_grade(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4.0, 3, 1.7, 2, 3.5)) !== array(\"A+\", \"B\", \"C-\", \"C\", \"A-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.2)) !== array(\"D+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.5)) !== array(\"D-\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0)) !== array(\"E\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1.0, 0.3, 1.5, 2.8, 3.3)) !== array(\"D\", \"D-\", \"C-\", \"B\", \"B+\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0.0, 0.7)) !== array(\"E\", \"D-\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdcba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"kittens\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"orange\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"world\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"MadaM\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Wow\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"HI\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"go\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gogo\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaaaaaaaaaaaaaa\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Madam\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"M\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return starts_one_ends(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1800) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 18000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "php",
+    "prompt": "<?php\n// Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve($N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return solve(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1000) !== \"1\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(150) !== \"110\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(147) !== \"1100\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(333) !== \"1001\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(963) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "php",
+    "prompt": "<?php\n// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add(array(4, 2, 6, 7))\n// 2\nfunction add($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 88)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 2, 122)) !== 122) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 0, 6, 7)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 4, 6, 8)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return anti_shuffle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hi\") !== \"Hi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hello\") !== \"ehllo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"number\") !== \"bemnru\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"abcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hello World!!!\") !== \"Hello !!!Wdlor\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== \"\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hi. My name is Mister Robot. How are you?\") !== \".Hi My aemn is Meirst .Rboot How aer ?ouy\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "php",
+    "prompt": "<?php\n// You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1)\n// array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))\n// >>> get_row(array(), 1)\n// array()\n// >>> get_row(array(array(), array(1), array(1, 2, 3)), 3)\n// array(array(2, 2))\nfunction get_row($lst, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_row(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 4), array(1, 0), array(2, 5), array(2, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6)), 2) !== array(array(0, 1), array(1, 1), array(2, 1), array(3, 1), array(4, 1), array(5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5, 6), array(1, 2, 3, 4, 5, 6), array(1, 1, 3, 4, 5, 6), array(1, 2, 1, 4, 5, 6), array(1, 2, 3, 1, 5, 6), array(1, 2, 3, 4, 1, 6), array(1, 2, 3, 4, 5, 1)), 1) !== array(array(0, 0), array(1, 0), array(2, 1), array(2, 0), array(3, 2), array(3, 0), array(4, 3), array(4, 0), array(5, 4), array(5, 0), array(6, 5), array(6, 0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(), 1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1)), 2) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(), array(1), array(1, 2, 3)), 3) !== array(array(2, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array(array())\n// array()\n// >>> sort_array(array(5))\n// array(5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5))\n// array(0, 1, 2, 3, 4, 5)\n// >>> sort_array(array(2, 4, 3, 0, 1, 5, 6))\n// array(6, 5, 4, 3, 2, 1, 0)\nfunction sort_array($array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5)) !== array(5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5)) !== array(0, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 0, 1, 5, 6)) !== array(6, 5, 4, 3, 2, 1, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1)) !== array(1, 2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 42, 87, 32, 11, 0)) !== array(0, 11, 15, 32, 42, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 14, 23, 11)) !== array(23, 21, 14, 11)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "php",
+    "prompt": "<?php\n// Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encrypt(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hi\") !== \"lm\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asdfghjkl\") !== \"ewhjklnop\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gf\") !== \"kj\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"et\") !== \"ix\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"faewfawefaewg\") !== \"jeiajeaijeiak\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"hellomyfriend\") !== \"lippsqcjvmirh\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") !== \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"e\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "php",
+    "prompt": "<?php\n// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product(array())\n// array(0, 1)\n// >>> sum_product(array(1, 2, 3, 4))\n// array(10, 24)\nfunction sum_product($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array(0, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1)) !== array(3, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 0)) !== array(100, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 5, 7)) !== array(15, 105)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10)) !== array(10, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest(array(1, 2, 3, 4, 5))\n// 2\n// >>> next_smallest(array(5, 1, 4, 3, 2))\n// 2\n// >>> next_smallest(array())\n// null\n// >>> next_smallest(array(1, 1))\n// null\nfunction next_smallest($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return next_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 4, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1, 0)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-35, 34, 12, -45)) !== -35) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "php",
+    "prompt": "<?php\n// You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored($S) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_bored(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hello world\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Is the sky blue?\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love It !\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"bIt\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I feel good today. I will be productive. will kill It\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"You and I are going for a walk\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int($x, $y, $z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return any_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.5, 2, 3) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1.5, 5, 3.5) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 6, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2.2, 2.2, 2.2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-4, 6, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 1, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4, 7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3.0, 4, 7) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode($message) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return encode(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TEST\") !== \"tgst\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Mudasir\") !== \"mWDCSKR\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"YES\") !== \"ygs\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"This is a message\") !== \"tHKS KS C MGSSCGG\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I DoNt KnOw WhAt tO WrItE\") !== \"k dQnT kNqW wHcT Tq wRkTg\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "php",
+    "prompt": "<?php\n// You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n// 10\n// >>> skjkasdkd(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n// 25\n// >>> skjkasdkd(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n// 13\n// >>> skjkasdkd(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n// 11\n// >>> skjkasdkd(array(0, 81, 12, 3, 1, 21))\n// 3\n// >>> skjkasdkd(array(0, 8, 1, 2, 1, 7))\n// 7\nfunction skjkasdkd($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return skjkasdkd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 81, 12, 3, 1, 21)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 8, 1, 2, 1, 7)) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8191, 123456, 127, 7)) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(127, 97, 8192)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "php",
+    "prompt": "<?php\n// Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case(array(\"a\" => \"apple\", \"b\" => \"banana\"))\n// true\n// >>> check_dict_case(array(\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"))\n// false\n// >>> check_dict_case(array(\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"))\n// false\n// >>> check_dict_case(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"))\n// false\n// >>> check_dict_case(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\"))\n// true\nfunction check_dict_case($dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_dict_case(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"p\" => \"pineapple\", \"b\" => \"banana\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"STATE\" => \"NC\", \"ZIP\" => \"12345\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"fruit\" => \"Orange\", \"taste\" => \"Sweet\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array()) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "php",
+    "prompt": "<?php\n// Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// array(2, 3)\n// >>> count_up_to(11)\n// array(2, 3, 5, 7)\n// >>> count_up_to(0)\n// array()\n// >>> count_up_to(20)\n// array(2, 3, 5, 7, 11, 13, 17, 19)\n// >>> count_up_to(1)\n// array()\n// >>> count_up_to(18)\n// array(2, 3, 5, 7, 11, 13, 17)\nfunction count_up_to($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_up_to(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(2, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== array(2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(22) !== array(2, 3, 5, 7, 11, 13, 17, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== array(2, 3, 5, 7, 11, 13, 17)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(47) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(101) !== array(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "php",
+    "prompt": "<?php\n// Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return multiply(...$args);\n}\n\nfunction test(): void {\n    if (candidate(148, 412) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 28) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2020, 1851) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14, -15) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(76, 67) !== 42) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 27) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "php",
+    "prompt": "<?php\n// Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aBCdEf\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcdefg\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dBBE\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"B\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"U\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"EEEE\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "php",
+    "prompt": "<?php\n// Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer($value) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return closest_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"10\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"14.5\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"-15.5\") !== -16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.3\") !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"0\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "php",
+    "prompt": "<?php\n// From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max(array(1, 2, 3, 2, 3, 4, 2))\n// array(1, 2, 3, 3, 3, 4, 4)\nfunction rolling_max($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rolling_max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array()) !== array()) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== array(1, 2, 3, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 1)) !== array(4, 4, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 3, 100, 3)) !== array(3, 3, 3, 100, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/humaneval-pl-keep.json
+++ b/prompts/humaneval-pl-keep.json
@@ -1,1174 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "pl",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\nsub iscube {\n    my($a) = @_;\n",
+    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\nsub has_close_elements {\n    my($numbers, $threshold) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "pl",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nsub encode {\n    my($message) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "pl",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\nsub solution {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "pl",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "pl",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nsub string_sequence {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "pl",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "pl",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "pl",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nsub get_odd_collatz {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "pl",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\nsub find_closest_elements {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "pl",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\nsub below_threshold {\n    my($l, $t) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "pl",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\nsub any_int {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "pl",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "pl",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "pl",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "pl",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "pl",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\nsub is_happy {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "pl",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nsub file_name_check {\n    my($file_name) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "pl",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\nsub histogram {\n    my($test) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "pl",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "pl",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\nsub simplify {\n    my($x, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "pl",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "pl",
-    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nsub reverse_delete {\n    my($s, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_delete;\n        if(eq_deeply($candidate->(\"abcde\", \"ae\"),[\"bcd\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\", \"b\"),[\"acdef\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"ab\"),[\"cdedc\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dwik\", \"w\"),[\"dik\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\", \"a\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"v\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"vabba\", \"v\"),[\"abba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"mamma\", \"mia\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "pl",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\nsub sum_product {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "pl",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\nsub all_prefixes {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\nsub digits {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "pl",
-    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nsub strlen {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "pl",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "pl",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "pl",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "pl",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "pl",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\nsub monotonic {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "pl",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "pl",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "pl",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "pl",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "pl",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nsub remove_vowels {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "pl",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "pl",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "pl",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\nsub count_up_to {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "pl",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "pl",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "pl",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "pl",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "pl",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\nsub smallest_change {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "pl",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "pl",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\nsub next_smallest {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "pl",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "pl",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\nsub compare_one {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "pl",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\nsub match_parens {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "pl",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "pl",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "pl",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "pl",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\nsub encrypt {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "pl",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "pl",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "pl",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsub sort_even {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_even;\n        if(eq_deeply($candidate->([1, 2, 3]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "pl",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\nsub below_zero {\n    my($operations) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "pl",
-    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\nsub same_chars {\n    my($s0, $s1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&same_chars;\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dddddddabc\", \"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcd\", \"dddddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabcf\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\", \"aaccc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "pl",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "pl",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\nsub count_upper {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "pl",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "pl",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "pl",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "pl",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "pl",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\nsub add {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "pl",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\nsub multiply {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "pl",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "pl",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "pl",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\nsub is_simple_power {\n    my($x, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&has_close_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1180,7 +18,7 @@
     "language": "pl",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\nsub make_a_pile {\n    my($n) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_a_pile;\n        if(eq_deeply($candidate->(3),[3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4, 6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5, 7, 9, 11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[6, 8, 10, 12, 14, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[8, 10, 12, 14, 16, 18, 20, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1190,1007 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "pl",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "pl",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\nsub is_palindrome {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "pl",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "pl",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "pl",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "pl",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "pl",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "pl",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsub sort_numbers {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "pl",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nsub flip_case {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "pl",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "pl",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\nsub can_arrange {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "pl",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\nsub is_nested {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "pl",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\nsub by_length {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "pl",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "pl",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "pl",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "pl",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\nsub concatenate {\n    my($strings) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "pl",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "pl",
-    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nsub sort_array {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "pl",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\nsub longest {\n    my($strings) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nsub is_sorted {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "pl",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\nsub even_odd_count {\n    my($num) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "pl",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nsub anti_shuffle {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "pl",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "pl",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nsub make_palindrome {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "pl",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "pl",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nsub change_base {\n    my($x, $base) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\nsub prime_length {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "pl",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "pl",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\nsub search {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "pl",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "pl",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "pl",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nsub compare {\n    my($game, $guess) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "pl",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "pl",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nsub get_row {\n    my($lst, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "pl",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "pl",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nsub string_to_md5 {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "pl",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\nsub is_prime {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "pl",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nsub bf {\n    my($planet1, $planet2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "pl",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\nsub hex_key {\n    my($num) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "pl",
-    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "pl",
-    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\nsub specialFilter {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&specialFilter;\n        if(eq_deeply($candidate->([5, -2, 1, -5]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, -73, 14, -15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([33, -2, -3, 45, 21, 109]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([43, -12, 93, 125, 121, 109]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([71, -2, -33, 75, 21, 19]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "pl",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "pl",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "pl",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\nsub strange_sort_list {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "pl",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "pl",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nsub check_dict_case {\n    my($dict) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "pl",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\nsub valid_date {\n    my($date) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "pl",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\nsub count_nums {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "pl",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "pl",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\nsub digitSum {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "pl",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\nsub order_by_points {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "pl",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "pl",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\nsub split_words {\n    my($txt) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "pl",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "pl",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nsub string_xor {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "pl",
-    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\nsub has_close_elements {\n    my($numbers, $threshold) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&has_close_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "pl",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "pl",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "pl",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\nsub int_to_mini_roman {\n    my($number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "pl",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\nsub correct_bracketing {\n    my($brackets) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "pl",
-    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\nsub correct_bracketing {\n    my($brackets) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"<>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<><>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<<><><>><>><<><><<>>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<><>>>>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\">\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>>><>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "pl",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "pl",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\nsub prod_signs {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "pl",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "pl",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2202,7 +46,7 @@
     "language": "pl",
     "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# choose_num(12, 15) = 14\n# choose_num(13, 12) = -1\nsub choose_num {\n    my($x, $y) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2212,13 +56,923 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "pl",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "pl",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "pl",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\nsub by_length {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "pl",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "pl",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\nsub count_nums {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "pl",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "pl",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nsub make_palindrome {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "pl",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "pl",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\nsub histogram {\n    my($test) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "pl",
+    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nsub reverse_delete {\n    my($s, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_delete;\n        if(eq_deeply($candidate->(\"abcde\", \"ae\"),[\"bcd\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\", \"b\"),[\"acdef\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"ab\"),[\"cdedc\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dwik\", \"w\"),[\"dik\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\", \"a\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"v\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"vabba\", \"v\"),[\"abba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"mamma\", \"mia\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "pl",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "pl",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "pl",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "pl",
+    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nsub sort_array {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "pl",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "pl",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "pl",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\nsub match_parens {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "pl",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nsub string_xor {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "pl",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "pl",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\nsub solution {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "pl",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nsub get_odd_collatz {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "pl",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\nsub valid_date {\n    my($date) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "pl",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\nsub split_words {\n    my($txt) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "pl",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nsub is_sorted {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "pl",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "pl",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\nsub prod_signs {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "pl",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "pl",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\nsub longest {\n    my($strings) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "pl",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\nsub digits {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "pl",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\nsub is_nested {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "pl",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "pl",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "pl",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\nsub can_arrange {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "pl",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "pl",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\nsub compare_one {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "pl",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "pl",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "pl",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "pl",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "pl",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nsub file_name_check {\n    my($file_name) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "pl",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "pl",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "pl",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\nsub simplify {\n    my($x, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "pl",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\nsub order_by_points {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "pl",
+    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\nsub specialFilter {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&specialFilter;\n        if(eq_deeply($candidate->([5, -2, 1, -5]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, -73, 14, -15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([33, -2, -3, 45, 21, 109]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([43, -12, 93, 125, 121, 109]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([71, -2, -33, 75, 21, 19]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "pl",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "pl",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nsub bf {\n    my($planet1, $planet2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "pl",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\nsub all_prefixes {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "pl",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "pl",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "pl",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nsub compare {\n    my($game, $guess) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "pl",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "pl",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "pl",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\nsub even_odd_count {\n    my($num) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "pl",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\nsub int_to_mini_roman {\n    my($number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "pl",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "pl",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nsub string_sequence {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "pl",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "pl",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2230,7 +984,7 @@
     "language": "pl",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# generate_integers(2, 8) => [2, 4, 6, 8]\n# generate_integers(8, 2) => [2, 4, 6, 8]\n# generate_integers(10, 14) => []\nsub generate_integers {\n    my($a, $b) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&generate_integers;\n        if(eq_deeply($candidate->(2, 10),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(132, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 89),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2244,9 +998,1255 @@
     "language": "pl",
     "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\nsub count_distinct_characters {\n    my($string) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "pl",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "pl",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "pl",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsub sort_numbers {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "pl",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "pl",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\nsub find_closest_elements {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "pl",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "pl",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "pl",
+    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nsub strlen {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "pl",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "pl",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "pl",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "pl",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nsub flip_case {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "pl",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\nsub concatenate {\n    my($strings) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "pl",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "pl",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "pl",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\nsub is_prime {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "pl",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "pl",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "pl",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "pl",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "pl",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsub sort_even {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_even;\n        if(eq_deeply($candidate->([1, 2, 3]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "pl",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "pl",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\nsub below_zero {\n    my($operations) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "pl",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "pl",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "pl",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "pl",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "pl",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nsub change_base {\n    my($x, $base) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "pl",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "pl",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "pl",
+    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "pl",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\nsub is_palindrome {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "pl",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "pl",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "pl",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nsub remove_vowels {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "pl",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "pl",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "pl",
+    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\nsub same_chars {\n    my($s0, $s1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&same_chars;\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dddddddabc\", \"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcd\", \"dddddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabcf\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\", \"aaccc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "pl",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "pl",
+    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"<>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<><>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<<><><>><>><<><><<>>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<><>>>>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\">\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>>><>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "pl",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\nsub monotonic {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "pl",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "pl",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "pl",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "pl",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "pl",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "pl",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "pl",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "pl",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "pl",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "pl",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\nsub digitSum {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "pl",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "pl",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "pl",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\nsub search {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "pl",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "pl",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\nsub strange_sort_list {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "pl",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "pl",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\nsub smallest_change {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "pl",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "pl",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "pl",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\nsub is_simple_power {\n    my($x, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "pl",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\nsub iscube {\n    my($a) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "pl",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\nsub hex_key {\n    my($num) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\nsub is_happy {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "pl",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\nsub prime_length {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "pl",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "pl",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\nsub add {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nsub anti_shuffle {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "pl",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nsub get_row {\n    my($lst, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "pl",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "pl",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\nsub encrypt {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "pl",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\nsub sum_product {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\nsub next_smallest {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "pl",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "pl",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\nsub any_int {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "pl",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nsub encode {\n    my($message) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "pl",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nsub check_dict_case {\n    my($dict) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "pl",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\nsub count_up_to {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "pl",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\nsub multiply {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "pl",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\nsub count_upper {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "pl",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "pl",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/humaneval-pl-remove.json
+++ b/prompts/humaneval-pl-remove.json
@@ -1,1594 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "pl",
-    "prompt": "# Return length of given string\nsub strlen {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "pl",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\nsub encrypt {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "pl",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\nsub check_dict_case {\n    my($dict) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\nsub add {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "pl",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\nsub fix_spaces {\n    my($text) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "pl",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nsub fibfib {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "pl",
-    "prompt": "# Filter given list of any python values only for integers\nsub filter_integers {\n    my($values) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "pl",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\nsub parse_music {\n    my($music_string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "pl",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\nsub all_prefixes {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "pl",
-    "prompt": "# Add two numbers x and y\nsub add {\n    my($x, $y) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "pl",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "pl",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "pl",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nsub flip_case {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "pl",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\nsub by_length {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "pl",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\nsub factorize {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "pl",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\nsub count_up_to {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "pl",
-    "prompt": "# Return sorted unique elements in a list\nsub unique {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "pl",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "pl",
-    "prompt": "# Return maximum element in the list.\nsub max_element {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "pl",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\nsub is_nested {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "pl",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\nsub rounded_avg {\n    my($n, $m) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "pl",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\nsub odd_count {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "pl",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "pl",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "pl",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\nsub derivative {\n    my($xs) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\nsub is_sorted {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\nsub solve {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "pl",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\nsub tri {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "pl",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nsub fizz_buzz {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "pl",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "pl",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\nsub minPath {\n    my($grid, $k) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "pl",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\nsub count_upper {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "pl",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\nsub largest_divisor {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "pl",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\nsub sort_array {\n    my($array) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "pl",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\nsub f {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "pl",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\nsub iscube {\n    my($a) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "pl",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\nsub encode {\n    my($message) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "pl",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\nsub is_bored {\n    my($S) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "pl",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "pl",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\nsub bf {\n    my($planet1, $planet2) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\nsub digits {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "pl",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\nsub words_string {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "pl",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\nsub how_many_times {\n    my($string, $substring) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "pl",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\nsub compare_one {\n    my($a, $b) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "pl",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\nsub remove_vowels {\n    my($text) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "pl",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\nsub strange_sort_list {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "pl",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\nsub find_closest_elements {\n    my($numbers) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "pl",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\nsub is_simple_power {\n    my($x, $n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "pl",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nsub prime_fib {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "pl",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\nsub order_by_points {\n    my($nums) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "pl",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\nsub has_close_elements {\n    my($numbers, $threshold) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&has_close_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "pl",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nsub make_palindrome {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "pl",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\nsub string_xor {\n    my($a, $b) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "pl",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "pl",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nsub fib4 {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "pl",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\nsub unique_digits {\n    my($x) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "pl",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\nsub select_words {\n    my($s, $n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "pl",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "pl",
-    "prompt": "# Return n-th Fibonacci number.\nsub fib {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "pl",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "pl",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\nsub match_parens {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\nsub next_smallest {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "pl",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\nsub any_int {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "pl",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\nsub truncate_number {\n    my($number) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "pl",
-    "prompt": "# Return list with elements incremented by 1.\nsub incr_list {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "pl",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "pl",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\nsub modp {\n    my($n, $p) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "pl",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\nsub even_odd_count {\n    my($num) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\nsub is_happy {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "pl",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\nsub largest_prime_factor {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "pl",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\nsub digitSum {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "pl",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\nsub solution {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "pl",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "pl",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "pl",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "pl",
-    "prompt": "# Return median of elements in the list l.\nsub median {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\nsub prime_length {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\nsub smallest_change {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "pl",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "pl",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\nsub file_name_check {\n    my($file_name) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "pl",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "pl",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "pl",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "pl",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\nsub compare {\n    my($game, $guess) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "pl",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "pl",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\nsub valid_date {\n    my($date) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "pl",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\nsub count_nums {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\nsub anti_shuffle {\n    my($s) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "pl",
-    "prompt": "# Checks if given string is a palindrome\nsub is_palindrome {\n    my($text) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "pl",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\nsub get_closest_vowel {\n    my($word) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "pl",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\nsub is_prime {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "pl",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\nsub simplify {\n    my($x, $n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "pl",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\nsub hex_key {\n    my($num) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "pl",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "pl",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\nsub histogram {\n    my($test) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "pl",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\nsub get_row {\n    my($lst, $x) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nsub get_odd_collatz {\n    my($n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "pl",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\nsub can_arrange {\n    my($arr) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "pl",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\nsub sort_numbers {\n    my($numbers) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "pl",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\nsub circular_shift {\n    my($x, $shift) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "pl",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\nsub skjkasdkd {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "pl",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\nsub sum_product {\n    my($numbers) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "pl",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\nsub choose_num {\n    my($x, $y) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "pl",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "pl",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\nsub count_distinct_characters {\n    my($string) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1600,7 +18,7 @@
     "language": "pl",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\nsub make_a_pile {\n    my($n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_a_pile;\n        if(eq_deeply($candidate->(3),[3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4, 6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5, 7, 9, 11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[6, 8, 10, 12, 14, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[8, 10, 12, 14, 16, 18, 20, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1610,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "pl",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\nsub prod_signs {\n    my($arr) = @_;\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\nsub words_string {\n    my($s) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1624,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "pl",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\nsub minSubArraySum {\n    my($nums) = @_;\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\nsub choose_num {\n    my($x, $y) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1638,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "pl",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nsub string_sequence {\n    my($n) = @_;\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\nsub rounded_avg {\n    my($n, $m) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1652,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "pl",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\nsub unique_digits {\n    my($x) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1666,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "pl",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\nsub monotonic {\n    my($l) = @_;\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\nsub by_length {\n    my($arr) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1680,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "pl",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\nsub longest {\n    my($strings) = @_;\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\nsub f {\n    my($n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1694,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "pl",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1708,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "pl",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\nsub count_nums {\n    my($arr) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1722,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "pl",
-    "prompt": "# Return only positive numbers in the list.\nsub get_positive {\n    my($l) = @_;\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1736,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "pl",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\nsub sort_third {\n    my($l) = @_;\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nsub make_palindrome {\n    my($string) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1750,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "pl",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1764,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "pl",
-    "prompt": "# Given length of a side and high return area for a triangle.\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\nsub histogram {\n    my($test) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "pl",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\nsub multiply {\n    my($a, $b) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "pl",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "pl",
-    "prompt": "# Return sorted unique common elements for two lists.\nsub common {\n    my($l1, $l2) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "pl",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\nsub int_to_mini_roman {\n    my($number) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "pl",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1852,7 +200,7 @@
     "language": "pl",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\nsub reverse_delete {\n    my($s, $c) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_delete;\n        if(eq_deeply($candidate->(\"abcde\", \"ae\"),[\"bcd\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\", \"b\"),[\"acdef\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"ab\"),[\"cdedc\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dwik\", \"w\"),[\"dik\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\", \"a\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"v\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"vabba\", \"v\"),[\"abba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"mamma\", \"mia\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1862,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "pl",
-    "prompt": "# Return a greatest common divisor of two integers a and b\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\nsub odd_count {\n    my($lst) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1876,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "pl",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\nsub split_words {\n    my($txt) = @_;\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\nsub minSubArraySum {\n    my($nums) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "pl",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1894,7 +256,7 @@
     "language": "pl",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\nsub sort_array {\n    my($arr) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1904,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "pl",
-    "prompt": "# Concatenate list of strings into a single string\nsub concatenate {\n    my($strings) = @_;\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\nsub select_words {\n    my($s, $n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1918,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\nsub get_closest_vowel {\n    my($word) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1932,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\nsub match_parens {\n    my($lst) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1946,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "pl",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\nsub string_xor {\n    my($a, $b) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1960,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "pl",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\nsub vowels_count {\n    my($s) = @_;\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1974,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\nsub find_max {\n    my($words) = @_;\n",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\nsub solution {\n    my($lst) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1988,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "pl",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2002,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "pl",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\nsub change_base {\n    my($x, $base) = @_;\n",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nsub get_odd_collatz {\n    my($n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2016,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\nsub valid_date {\n    my($date) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2030,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "pl",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\nsub split_words {\n    my($txt) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2044,13 +406,307 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "pl",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\nsub is_sorted {\n    my($lst) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "pl",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "pl",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\nsub prod_signs {\n    my($arr) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "pl",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\nsub minPath {\n    my($grid, $k) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "pl",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\nsub longest {\n    my($strings) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "pl",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\nsub tri {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\nsub digits {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "pl",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\nsub is_nested {\n    my($string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "pl",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "pl",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "pl",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\nsub can_arrange {\n    my($arr) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "pl",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "pl",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\nsub compare_one {\n    my($a, $b) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "pl",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "pl",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "pl",
+    "prompt": "# Return a greatest common divisor of two integers a and b\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "pl",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\nsub fix_spaces {\n    my($text) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "pl",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\nsub file_name_check {\n    my($file_name) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "pl",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "pl",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "pl",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\nsub simplify {\n    my($x, $n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "pl",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\nsub order_by_points {\n    my($nums) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2062,7 +718,7 @@
     "language": "pl",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\nsub specialFilter {\n    my($nums) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&specialFilter;\n        if(eq_deeply($candidate->([5, -2, 1, -5]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, -73, 14, -15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([33, -2, -3, 45, 21, 109]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([43, -12, 93, 125, 121, 109]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([71, -2, -33, 75, 21, 19]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2072,13 +728,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "pl",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\nsub sum_to_n {\n    my($n) = @_;\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2086,13 +742,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "pl",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\nsub bf {\n    my($planet1, $planet2) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "pl",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\nsub all_prefixes {\n    my($string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "pl",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "pl",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "pl",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\nsub compare {\n    my($game, $guess) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "pl",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "pl",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "pl",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\nsub even_odd_count {\n    my($num) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "pl",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\nsub int_to_mini_roman {\n    my($number) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\nsub find_max {\n    my($words) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "pl",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "pl",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nsub string_sequence {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\nsub solve {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "pl",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2104,7 +970,7 @@
     "language": "pl",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\nsub generate_integers {\n    my($a, $b) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&generate_integers;\n        if(eq_deeply($candidate->(2, 10),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(132, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 89),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2114,13 +980,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "pl",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\nsub count_distinct_characters {\n    my($string) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2128,13 +994,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "pl",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\nsub below_zero {\n    my($operations) = @_;\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\nsub parse_music {\n    my($music_string) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2142,13 +1008,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "pl",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\nsub search {\n    my($lst) = @_;\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\nsub how_many_times {\n    my($string, $substring) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2156,13 +1022,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "pl",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\nsub sort_numbers {\n    my($numbers) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "pl",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "pl",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\nsub find_closest_elements {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "pl",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "pl",
+    "prompt": "# Filter given list of any python values only for integers\nsub filter_integers {\n    my($values) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "pl",
+    "prompt": "# Return length of given string\nsub strlen {\n    my($string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "pl",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\nsub largest_divisor {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "pl",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\nsub factorize {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "pl",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "pl",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nsub flip_case {\n    my($string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "pl",
+    "prompt": "# Concatenate list of strings into a single string\nsub concatenate {\n    my($strings) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "pl",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\nsub truncate_number {\n    my($number) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "pl",
+    "prompt": "# Return only positive numbers in the list.\nsub get_positive {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "pl",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\nsub is_prime {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "pl",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\nsub sort_third {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "pl",
+    "prompt": "# Return sorted unique elements in a list\nsub unique {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "pl",
+    "prompt": "# Return maximum element in the list.\nsub max_element {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "pl",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nsub fizz_buzz {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2174,9 +1292,219 @@
     "language": "pl",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\nsub sort_even {\n    my($l) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_even;\n        if(eq_deeply($candidate->([1, 2, 3]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "pl",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nsub prime_fib {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "pl",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\nsub below_zero {\n    my($operations) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "pl",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "pl",
+    "prompt": "# Return list with elements incremented by 1.\nsub incr_list {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "pl",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "pl",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\nsub change_base {\n    my($x, $base) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "pl",
+    "prompt": "# Given length of a side and high return area for a triangle.\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "pl",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nsub fib4 {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "pl",
+    "prompt": "# Return median of elements in the list l.\nsub median {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "pl",
+    "prompt": "# Checks if given string is a palindrome\nsub is_palindrome {\n    my($text) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "pl",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\nsub modp {\n    my($n, $p) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "pl",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "pl",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\nsub remove_vowels {\n    my($text) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "pl",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "pl",
+    "prompt": "# Add two numbers x and y\nsub add {\n    my($x, $y) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2188,9 +1516,23 @@
     "language": "pl",
     "prompt": "# Check if two words have the same characters.\nsub same_chars {\n    my($s0, $s1) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&same_chars;\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dddddddabc\", \"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcd\", \"dddddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabcf\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\", \"aaccc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "pl",
+    "prompt": "# Return n-th Fibonacci number.\nsub fib {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2202,9 +1544,667 @@
     "language": "pl",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\nsub correct_bracketing {\n    my($brackets) = @_;\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"<>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<><>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<<><><>><>><<><><<>>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<><>>>>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\">\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>>><>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "pl",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\nsub monotonic {\n    my($l) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "pl",
+    "prompt": "# Return sorted unique common elements for two lists.\nsub common {\n    my($l1, $l2) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "pl",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\nsub largest_prime_factor {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "pl",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "pl",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\nsub sum_to_n {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "pl",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "pl",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\nsub derivative {\n    my($xs) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "pl",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nsub fibfib {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "pl",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\nsub vowels_count {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "pl",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\nsub circular_shift {\n    my($x, $shift) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "pl",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\nsub digitSum {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "pl",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "pl",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "pl",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\nsub search {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "pl",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "pl",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\nsub strange_sort_list {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "pl",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "pl",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\nsub smallest_change {\n    my($arr) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "pl",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "pl",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "pl",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\nsub is_simple_power {\n    my($x, $n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "pl",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\nsub iscube {\n    my($a) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "pl",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\nsub hex_key {\n    my($num) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\nsub is_happy {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "pl",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\nsub prime_length {\n    my($string) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "pl",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "pl",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\nsub add {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\nsub anti_shuffle {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "pl",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\nsub get_row {\n    my($lst, $x) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "pl",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\nsub sort_array {\n    my($array) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "pl",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\nsub encrypt {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "pl",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\nsub sum_product {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\nsub next_smallest {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "pl",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\nsub is_bored {\n    my($S) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "pl",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\nsub any_int {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "pl",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\nsub encode {\n    my($message) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\nsub skjkasdkd {\n    my($lst) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "pl",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\nsub check_dict_case {\n    my($dict) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "pl",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\nsub count_up_to {\n    my($n) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "pl",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\nsub multiply {\n    my($a, $b) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "pl",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\nsub count_upper {\n    my($s) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "pl",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "pl",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/humaneval-pl-reworded.json
+++ b/prompts/humaneval-pl-reworded.json
@@ -1,1636 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "pl",
-    "prompt": "# Return length of given string\n# >>> strlen(\"\")\n# 0\n# >>> strlen(\"abc\")\n# 3\nsub strlen {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "pl",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt(\"hi\")\n# \"lm\"\n# >>> encrypt(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt(\"gf\")\n# \"kj\"\n# >>> encrypt(\"et\")\n# \"ix\"\nsub encrypt {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "pl",
-    "prompt": "# Given a hash, return 1 if all keys are strings in lower \n# case or all keys are strings in upper case, else return ''.\n# The function should return '' is the given hash is empty.\n# Examples:\n# >>> check_dict_case({\"a\" => \"apple\", \"b\" => \"banana\"})\n# 1\n# >>> check_dict_case({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# \"\"\n# >>> check_dict_case({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# \"\"\n# >>> check_dict_case({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# \"\"\n# >>> check_dict_case({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# 1\nsub check_dict_case {\n    my($dict) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add([4, 2, 6, 7])\n# 2\nsub add {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "pl",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(\" Example\")\n# \"Example\"\n# >>> fix_spaces(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces(\" Example 3\")\n# \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "pl",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "pl",
-    "prompt": "# Given an array of numbers, return the sum of squares of the numbers\n# in the array that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference([1, 3, 2, 0])\n# 10\n# >>> double_the_difference([-1, -2, 0])\n# 0\n# >>> double_the_difference([9, -2])\n# 81\n# >>> double_the_difference([0])\n# 0\n# If the input array is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "pl",
-    "prompt": "# Filter given array of any plthon values only for integers\n# >>> filter_integers([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "pl",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "pl",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return array of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# \"db1111db\"\n# >>> decimal_to_binary(32)\n# \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "pl",
-    "prompt": "# Return array of all prefixes from shortest to longest of the input string\n# >>> all_prefixes(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\nsub all_prefixes {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "pl",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "pl",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# [11, 4]\n# >>> eat(4, 8, 9)\n# [12, 1]\n# >>> eat(1, 10, 10)\n# [11, 0]\n# >>> eat(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "pl",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "pl",
-    "prompt": "# Given two arrays operator, and operand. The first array has basic algebra operations, and \n# the second array is an array of integers. Use the two given arrays to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator array is equal to the length of operand array minus one.\n# Operand is an array of of non-negative integers.\n# Operator array has at least one operator, and operand array has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "pl",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case(\"Hello\")\n# \"hELLO\"\nsub flip_case {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "pl",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length([1, -1, 55])\n# [\"One\"]\nsub by_length {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "pl",
-    "prompt": "# Return array of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "pl",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# [2, 3]\n# >>> count_up_to(11)\n# [2, 3, 5, 7]\n# >>> count_up_to(0)\n# []\n# >>> count_up_to(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to(1)\n# []\n# >>> count_up_to(18)\n# [2, 3, 5, 7, 11, 13, 17]\nsub count_up_to {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "pl",
-    "prompt": "# Return sorted unique elements in an array\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "pl",
-    "prompt": "# Write a function that accepts two arrays of strings and returns the array that has \n# total number of chars in the all strings of the array less than the other array.\n# if the two arrays have the same number of chars, return the first array.\n# Examples\n# >>> total_match([], [])\n# []\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "pl",
-    "prompt": "# Return maximum element in the array.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "pl",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return 1 if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested(\"[[]]\")\n# 1\n# >>> is_nested(\"[]]]]]]][[[[[]\")\n# \"\"\n# >>> is_nested(\"[][]\")\n# \"\"\n# >>> is_nested(\"[]\")\n# \"\"\n# >>> is_nested(\"[[][]]\")\n# 1\n# >>> is_nested(\"[[]][[\")\n# 1\nsub is_nested {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "pl",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# \"0b11\"\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# \"0b1111\"\n# >>> rounded_avg(20, 33)\n# \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "pl",
-    "prompt": "# Given an array of strings, where each string consists of only digits, return an array.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "pl",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return 1 else return ''.\n# If the given array is empty then return 1.\n# Note: The given array is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball([3, 4, 5, 1, 2])\n# 1\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball([3, 5, 4, 1, 2])\n# \"\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return an array that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned array has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "pl",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# \"\"\n# >>> is_equal_to_sum_even(6)\n# \"\"\n# >>> is_equal_to_sum_even(8)\n# 1\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "pl",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "pl",
-    "prompt": "# Given an array of numbers, return whether or not they are sorted\n# in ascending order. If array has more than 1 duplicate of the same\n# number, return ''. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted([5])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5])\n# \"\"\n# >>> is_sorted([1, 2, 3, 4, 5, 6])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n# \"\"\n# >>> is_sorted([1, 2, 2, 3, 3, 4])\n# 1\n# >>> is_sorted([1, 2, 2, 2, 3, 4])\n# \"\"\nsub is_sorted {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve(\"1234\")\n# \"4321\"\n# >>> solve(\"ab\")\n# \"AB\"\n# >>> solve(\"#a@C\")\n# \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "pl",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return an array of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "pl",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "pl",
-    "prompt": "# Filter an input array of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], \"a\")\n# []\n# >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "pl",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# \"1\"\n# >>> solve(150)\n# \"110\"\n# >>> solve(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "pl",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered arrays of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered array of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "pl",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper(\"aBCdEf\")\n# 1\n# >>> count_upper(\"abcdefg\")\n# 0\n# >>> count_upper(\"dBBE\")\n# 0\nsub count_upper {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted array \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "pl",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "pl",
-    "prompt": "# Given an array of non-negative integers, return a copl of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array([])\n# []\n# >>> sort_array([5])\n# [5]\n# >>> sort_array([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "pl",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "pl",
-    "prompt": "# Write a function that takes an integer a and returns 1 \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# 1\n# >>> iscube(2)\n# \"\"\n# >>> iscube(-1)\n# 1\n# >>> iscube(64)\n# 1\n# >>> iscube(0)\n# 1\n# >>> iscube(180)\n# \"\"\nsub iscube {\n    my($a) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "pl",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode(\"test\")\n# \"TGST\"\n# >>> encode(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\nsub encode {\n    my($message) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "pl",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "pl",
-    "prompt": "# pairs_sum_to_zero takes an array of integers as an input.\n# it returns 1 if there are two distinct elements in the array that\n# sum to zero, and '' otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# \"\"\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# 1\n# >>> pairs_sum_to_zero([1])\n# \"\"\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "pl",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return an array containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty array if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nsub bf {\n    my($planet1, $planet2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\nsub digits {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "pl",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "pl",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times(\"\", \"a\")\n# 0\n# >>> how_many_times(\"aaa\", \"a\")\n# 3\n# >>> how_many_times(\"aaaa\", \"aa\")\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "pl",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return undef if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one(\"1\", 1)\n# undef\nsub compare_one {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "pl",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels(\"\")\n# \"\"\n# >>> remove_vowels(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels(\"aaaaa\")\n# \"\"\n# >>> remove_vowels(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels(\"zbcd\")\n# \"zbcd\"\nsub remove_vowels {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "pl",
-    "prompt": "# Given array of integers, return array in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list([])\n# []\nsub strange_sort_list {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "pl",
-    "prompt": "# From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\nsub find_closest_elements {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "pl",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# 1\n# >>> is_simple_power(2, 2)\n# 1\n# >>> is_simple_power(8, 2)\n# 1\n# >>> is_simple_power(3, 2)\n# \"\"\n# >>> is_simple_power(3, 1)\n# \"\"\n# >>> is_simple_power(5, 3)\n# \"\"\nsub is_simple_power {\n    my($x, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "pl",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "pl",
-    "prompt": "# Write a function which sorts the given array of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original array.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points([])\n# []\nsub order_by_points {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "pl",
     "prompt": "# Check if in given array of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# \"\"\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# 1\nsub has_close_elements {\n    my($numbers, $threshold) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&has_close_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "pl",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome(\"\")\n# \"\"\n# >>> make_palindrome(\"cat\")\n# \"catac\"\n# >>> make_palindrome(\"cata\")\n# \"catac\"\nsub make_palindrome {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "pl",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor(\"010\", \"110\")\n# \"100\"\nsub string_xor {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "pl",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "pl",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "pl",
-    "prompt": "# Given an array of positive integers x. return a sorted array of all \n# elements that hasn't any even digit.\n# Note: Returned array should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "pl",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns an array of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty array.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words(\"simple white space\", 2)\n# []\n# >>> select_words(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words(\"Uncle sam\", 3)\n# [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "pl",
-    "prompt": "# Write a function that returns 1 if the object q will fly, and '' otherwise.\n# The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly([1, 2], 5)\n# \"\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly([3, 2, 3], 1)\n# \"\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly([3, 2, 3], 9)\n# 1\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly([3], 5)\n# 1\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "pl",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "pl",
-    "prompt": "# You will be given the name of a class (a string) and an array of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the array.\n# For example, if you are given \"Slices\" as the class and an array of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "pl",
-    "prompt": "# You are given an array of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens([\")\", \")\"])\n# \"No\"\nsub match_parens {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "pl",
-    "prompt": "# You are given an array of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the array.\n# Return undef if there is no such element.\n# >>> next_smallest([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest([])\n# undef\n# >>> next_smallest([1, 1])\n# undef\nsub next_smallest {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "pl",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# 1\n# >>> any_int(3, 2, 2)\n# \"\"\n# >>> any_int(3, -2, 1)\n# 1\n# >>> any_int(3.6, -2.2, 2)\n# \"\"\nsub any_int {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "pl",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "pl",
-    "prompt": "# Return array with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "pl",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "pl",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "pl",
-    "prompt": "# Given an integer. return an array that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# [1, 1]\n# >>> even_odd_count(123)\n# [1, 2]\nsub even_odd_count {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happl or not.\n# A string is happl if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy(\"a\")\n# \"\"\n# >>> is_happy(\"aa\")\n# \"\"\n# >>> is_happy(\"abcd\")\n# 1\n# >>> is_happy(\"aabb\")\n# \"\"\n# >>> is_happy(\"adb\")\n# 1\n# >>> is_happy(\"xyy\")\n# \"\"\nsub is_happy {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "pl",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "pl",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum(\"\")\n# 0\n# >>> digitSum(\"abAB\")\n# 131\n# >>> digitSum(\"abcCd\")\n# 67\n# >>> digitSum(\"helloE\")\n# 69\n# >>> digitSum(\"woArBld\")\n# 131\n# >>> digitSum(\"aAaaaXa\")\n# 153\nsub digitSum {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "pl",
-    "prompt": "# Given array of numbers (of at least two elements), apply a linear transform to that array,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution([5, 8, 7, 1])\n# 12\n# >>> solution([3, 3, 3, 3, 3])\n# 9\n# >>> solution([30, 13, 24, 321])\n# 0\nsub solution {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "pl",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in an array, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck([])\n# []\n# Example 4:\n# >>> pluck([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "pl",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "pl",
-    "prompt": "# In this problem, you will implement a function that takes two arrays of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 an array of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input arrays will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "pl",
-    "prompt": "# Return median of elements in the array l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns 1 if the string\n# length is a prime number or '' otherwise\n# Examples\n# >>> prime_length(\"Hello\")\n# 1\n# >>> prime_length(\"abcdcba\")\n# 1\n# >>> prime_length(\"kittens\")\n# 1\n# >>> prime_length(\"orange\")\n# \"\"\nsub prime_length {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change([1, 2, 3, 2, 1])\n# 0\nsub smallest_change {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "pl",
-    "prompt": "# You are given an array of numbers.\n# You need to return the sum of squared numbers in the given array,\n# round each element in the array to the upper int(Ceiling) first.\n# Examples:\n# >>> lst([1.0, 2.0, 3.0])\n# 14\n# >>> lst([1.0, 4.0, 9.0])\n# 98\n# >>> lst([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst([1.4, 4.2, 0.0])\n# 29\n# >>> lst([-2.4, 1.0, 1.0])\n# 6\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "pl",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check(\"1example.dll\")\n# \"No\"\nsub file_name_check {\n    my($file_name) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "pl",
-    "prompt": "# triples_sum_to_zero takes an array of integers as an input.\n# it returns 1 if there are three distinct elements in the array that\n# sum to zero, and '' otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# 1\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# 1\n# >>> triples_sum_to_zero([1])\n# \"\"\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "pl",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection([-3, -1], [-5, 5])\n# \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "pl",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the array of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "pl",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\nsub compare {\n    my($game, $guess) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "pl",
-    "prompt": "# Create a function that returns 1 if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and '' otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter(\"apple pie\")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"apple pi e\")\n# 1\n# >>> check_if_last_char_is_a_letter(\"apple pi e \")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"\")\n# \"\"\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "pl",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns 1 if the date is valid otherwise ''.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date(\"03-11-2000\")\n# 1\n# >>> valid_date(\"15-01-2012\")\n# \"\"\n# >>> valid_date(\"04-0-2040\")\n# \"\"\n# >>> valid_date(\"06-04-2020\")\n# 1\n# >>> valid_date(\"06/04/2020\")\n# \"\"\nsub valid_date {\n    my($date) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "pl",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([])\n# 0\n# >>> count_nums([-1, 11, -11])\n# 1\n# >>> count_nums([1, 1, 2])\n# 3\nsub count_nums {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\nsub anti_shuffle {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "pl",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome(\"\")\n# 1\n# >>> is_palindrome(\"aba\")\n# 1\n# >>> is_palindrome(\"aaaaa\")\n# 1\n# >>> is_palindrome(\"zbcd\")\n# \"\"\nsub is_palindrome {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "pl",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel(\"quick\")\n# \"\"\n# >>> get_closest_vowel(\"ab\")\n# \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "pl",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# \"\"\n# >>> is_prime(101)\n# 1\n# >>> is_prime(11)\n# 1\n# >>> is_prime(13441)\n# 1\n# >>> is_prime(61)\n# 1\n# >>> is_prime(4)\n# \"\"\n# >>> is_prime(1)\n# \"\"\nsub is_prime {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "pl",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns 1 if x * n evaluates to a whole number and ''\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify(\"1/5\", \"5/1\")\n# 1\n# >>> simplify(\"1/6\", \"2/1\")\n# \"\"\n# >>> simplify(\"7/10\", \"10/2\")\n# \"\"\nsub simplify {\n    my($x, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "pl",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key(\"AB\")\n# 1\n# >>> hex_key(\"1077E\")\n# 2\n# >>> hex_key(\"ABED1A33\")\n# 4\n# >>> hex_key(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key(\"2020\")\n# 2\nsub hex_key {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "pl",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "pl",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a hash\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram(\"\")\n# {}\nsub histogram {\n    my($test) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "pl",
-    "prompt": "# You are given a 2 dimensional data, as a nested arrays,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the array,\n# and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n# each array is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row([], 1)\n# []\n# >>> get_row([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\nsub get_row {\n    my($lst, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned array sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# [1, 5]\nsub get_odd_collatz {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "pl",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange([1, 2, 3])\n# -1\nsub can_arrange {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "pl",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers(\"three one five\")\n# \"one three five\"\nsub sort_numbers {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "pl",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "pl",
-    "prompt": "# \"\n# This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "pl",
-    "prompt": "# You are given an array of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n# 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "pl",
-    "prompt": "# For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# [0, 1]\n# >>> sum_product([1, 2, 3, 4])\n# [10, 24]\nsub sum_product {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "pl",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nsub choose_num {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "pl",
-    "prompt": "# Create a function that returns an array (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in an array.\n# If there is no negative or positive integers, return them as undef.\n# Examples:\n# >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n# [undef, 1]\n# >>> largest_smallest_integers([])\n# [undef, undef]\n# >>> largest_smallest_integers([0])\n# [undef, undef]\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "pl",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters(\"Jerry\")\n# 4\nsub count_distinct_characters {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1642,7 +18,7 @@
     "language": "pl",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in an array, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\nsub make_a_pile {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_a_pile;\n        if(eq_deeply($candidate->(3),[3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4, 6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5, 7, 9, 11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[6, 8, 10, 12, 14, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[8, 10, 12, 14, 16, 18, 20, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1652,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "pl",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return undef for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4])\n# 9\n# >>> prod_signs([0, 1])\n# 0\n# >>> prod_signs([])\n# undef\nsub prod_signs {\n    my($arr) = @_;\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1666,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "pl",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum([-1, -2, -3])\n# -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nsub choose_num {\n    my($x, $y) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1680,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "pl",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# \"0\"\n# >>> string_sequence(5)\n# \"0 1 2 3 4 5\"\nsub string_sequence {\n    my($n) = @_;\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# \"0b11\"\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# \"0b1111\"\n# >>> rounded_avg(20, 33)\n# \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1694,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "pl",
-    "prompt": "# You are given 2 words. You need to return 1 if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check(\"abcd\", \"abd\")\n# \"\"\n# >>> cycpattern_check(\"hello\", \"ell\")\n# 1\n# >>> cycpattern_check(\"whassup\", \"psus\")\n# \"\"\n# >>> cycpattern_check(\"abab\", \"baa\")\n# 1\n# >>> cycpattern_check(\"efef\", \"eeff\")\n# \"\"\n# >>> cycpattern_check(\"himenss\", \"simen\")\n# 1\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given an array of positive integers x. return a sorted array of all \n# elements that hasn't any even digit.\n# Note: Returned array should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1708,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "pl",
-    "prompt": "# Return 1 is array elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# 1\n# >>> monotonic([1, 20, 4, 10])\n# \"\"\n# >>> monotonic([4, 1, 0, -10])\n# 1\nsub monotonic {\n    my($l) = @_;\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length([1, -1, 55])\n# [\"One\"]\nsub by_length {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1722,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "pl",
-    "prompt": "# Out of array of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return undef in case the input array is empty.\n# >>> longest([])\n# undef\n# >>> longest([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\nsub longest {\n    my($strings) = @_;\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1736,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "pl",
-    "prompt": "# Return 1 if all numbers in the array l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# 1\n# >>> below_threshold([1, 20, 4, 10], 5)\n# \"\"\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "prompt": "# Given a positive integer n, return an array that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned array has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1750,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "pl",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# 1\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([])\n# 0\n# >>> count_nums([-1, 11, -11])\n# 1\n# >>> count_nums([1, 1, 2])\n# 3\nsub count_nums {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1764,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "pl",
-    "prompt": "# Return only positive numbers in the array.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return 1 else return ''.\n# If the given array is empty then return 1.\n# Note: The given array is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball([3, 4, 5, 1, 2])\n# 1\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball([3, 5, 4, 1, 2])\n# \"\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1778,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "pl",
-    "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome(\"\")\n# \"\"\n# >>> make_palindrome(\"cat\")\n# \"catac\"\n# >>> make_palindrome(\"cata\")\n# \"catac\"\nsub make_palindrome {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1792,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "pl",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "prompt": "# In this problem, you will implement a function that takes two arrays of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 an array of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input arrays will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1806,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "pl",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a hash\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram(\"\")\n# {}\nsub histogram {\n    my($test) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "pl",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nsub multiply {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "pl",
-    "prompt": "# For a given array of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "pl",
-    "prompt": "# Return sorted unique common elements for two arrays.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "pl",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# \"xix\"\n# >>> int_to_mini_roman(152)\n# \"clii\"\n# >>> int_to_mini_roman(426)\n# \"cdxxvi\"\nsub int_to_mini_roman {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "pl",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n# 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1894,7 +200,7 @@
     "language": "pl",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return an array containing the result string and 1/'' for the check.\n# Example\n# >>> reverse_delete(\"abcde\", \"ae\")\n# [\"bcd\", \"\"]\n# >>> reverse_delete(\"abcdef\", \"b\")\n# [\"acdef\", \"\"]\n# >>> reverse_delete(\"abcdedcba\", \"ab\")\n# [\"cdedc\", 1]\nsub reverse_delete {\n    my($s, $c) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_delete;\n        if(eq_deeply($candidate->(\"abcde\", \"ae\"),[\"bcd\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\", \"b\"),[\"acdef\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"ab\"),[\"cdedc\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dwik\", \"w\"),[\"dik\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\", \"a\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"v\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"vabba\", \"v\"),[\"abba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"mamma\", \"mia\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1904,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "pl",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given an array of strings, where each string consists of only digits, return an array.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1918,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "pl",
-    "prompt": "# Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"abcdef\")\n# 3\nsub split_words {\n    my($txt) = @_;\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum([-1, -2, -3])\n# -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "pl",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1936,7 +256,7 @@
     "language": "pl",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4])\n# [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6])\n# [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4])\n# [0, 1, 2, 3, 4]\nsub sort_array {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1946,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "pl",
-    "prompt": "# Concatenate array of strings into a single string\n# >>> concatenate([])\n# \"\"\n# >>> concatenate([\"a\", \"b\", \"c\"])\n# \"abc\"\nsub concatenate {\n    my($strings) = @_;\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns an array of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty array.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words(\"simple white space\", 2)\n# []\n# >>> select_words(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words(\"Uncle sam\", 3)\n# [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1960,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "pl",
-    "prompt": "# Write a function that accepts an array of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted array with a sorted order,\n# The array is always an array of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the array should be ascending by length of each word, and you\n# should return the array sorted by that rule.\n# If two words have the same length, sort the array alphabetically.\n# The function should return an array of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel(\"quick\")\n# \"\"\n# >>> get_closest_vowel(\"ab\")\n# \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1974,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "pl",
-    "prompt": "# Filter an input array of strings only for ones that contain given substring\n# >>> filter_by_substring([], \"a\")\n# []\n# >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "prompt": "# You are given an array of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens([\")\", \")\"])\n# \"No\"\nsub match_parens {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1988,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "pl",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor(\"010\", \"110\")\n# \"100\"\nsub string_xor {\n    my($a, $b) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2002,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "pl",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted array \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2016,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "pl",
-    "prompt": "# Write a function that accepts an array of strings.\n# The array contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
+    "prompt": "# Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution([5, 8, 7, 1])\n# 12\n# >>> solution([3, 3, 3, 3, 3])\n# 9\n# >>> solution([30, 13, 24, 321])\n# 0\nsub solution {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2030,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "pl",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return undef.\n# >>> string_to_md5(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2044,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "pl",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# \"22\"\n# >>> change_base(8, 2)\n# \"1000\"\n# >>> change_base(7, 2)\n# \"111\"\nsub change_base {\n    my($x, $base) = @_;\n",
+    "prompt": "# Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned array sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# [1, 5]\nsub get_odd_collatz {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2058,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return 1 if the three\n# sides form a right-angled triangle, '' otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# 1\n# >>> right_angle_triangle(1, 2, 3)\n# \"\"\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns 1 if the date is valid otherwise ''.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date(\"03-11-2000\")\n# 1\n# >>> valid_date(\"15-01-2012\")\n# \"\"\n# >>> valid_date(\"04-0-2040\")\n# \"\"\n# >>> valid_date(\"06-04-2020\")\n# 1\n# >>> valid_date(\"06/04/2020\")\n# \"\"\nsub valid_date {\n    my($date) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2072,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "pl",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you an array of GPAs for some students and you have to write \n# a function that can output an array of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "prompt": "# Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"abcdef\")\n# 3\nsub split_words {\n    my($txt) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2086,13 +406,307 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "pl",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "prompt": "# Given an array of numbers, return whether or not they are sorted\n# in ascending order. If array has more than 1 duplicate of the same\n# number, return ''. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted([5])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5])\n# \"\"\n# >>> is_sorted([1, 2, 3, 4, 5, 6])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n# \"\"\n# >>> is_sorted([1, 2, 2, 3, 3, 4])\n# 1\n# >>> is_sorted([1, 2, 2, 2, 3, 4])\n# \"\"\nsub is_sorted {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "pl",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection([-3, -1], [-5, 5])\n# \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "pl",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return undef for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4])\n# 9\n# >>> prod_signs([0, 1])\n# 0\n# >>> prod_signs([])\n# undef\nsub prod_signs {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "pl",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered arrays of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered array of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "pl",
+    "prompt": "# Out of array of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return undef in case the input array is empty.\n# >>> longest([])\n# undef\n# >>> longest([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\nsub longest {\n    my($strings) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "pl",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return an array of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\nsub digits {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "pl",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return 1 if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested(\"[[]]\")\n# 1\n# >>> is_nested(\"[]]]]]]][[[[[]\")\n# \"\"\n# >>> is_nested(\"[][]\")\n# \"\"\n# >>> is_nested(\"[]\")\n# \"\"\n# >>> is_nested(\"[[][]]\")\n# 1\n# >>> is_nested(\"[[]][[\")\n# 1\nsub is_nested {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "pl",
+    "prompt": "# You are given an array of numbers.\n# You need to return the sum of squared numbers in the given array,\n# round each element in the array to the upper int(Ceiling) first.\n# Examples:\n# >>> lst([1.0, 2.0, 3.0])\n# 14\n# >>> lst([1.0, 4.0, 9.0])\n# 98\n# >>> lst([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst([1.4, 4.2, 0.0])\n# 29\n# >>> lst([-2.4, 1.0, 1.0])\n# 6\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "pl",
+    "prompt": "# Create a function that returns 1 if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and '' otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter(\"apple pie\")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"apple pi e\")\n# 1\n# >>> check_if_last_char_is_a_letter(\"apple pi e \")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"\")\n# \"\"\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "pl",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange([1, 2, 3])\n# -1\nsub can_arrange {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "pl",
+    "prompt": "# Create a function that returns an array (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in an array.\n# If there is no negative or positive integers, return them as undef.\n# Examples:\n# >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n# [undef, 1]\n# >>> largest_smallest_integers([])\n# [undef, undef]\n# >>> largest_smallest_integers([0])\n# [undef, undef]\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "pl",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return undef if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one(\"1\", 1)\n# undef\nsub compare_one {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "pl",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# \"\"\n# >>> is_equal_to_sum_even(6)\n# \"\"\n# >>> is_equal_to_sum_even(8)\n# 1\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "pl",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "pl",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "pl",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(\" Example\")\n# \"Example\"\n# >>> fix_spaces(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces(\" Example 3\")\n# \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "pl",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check(\"1example.dll\")\n# \"No\"\nsub file_name_check {\n    my($file_name) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "pl",
+    "prompt": "# \"\n# This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "pl",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "pl",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns 1 if x * n evaluates to a whole number and ''\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify(\"1/5\", \"5/1\")\n# 1\n# >>> simplify(\"1/6\", \"2/1\")\n# \"\"\n# >>> simplify(\"7/10\", \"10/2\")\n# \"\"\nsub simplify {\n    my($x, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "pl",
+    "prompt": "# Write a function which sorts the given array of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original array.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points([])\n# []\nsub order_by_points {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2104,7 +718,7 @@
     "language": "pl",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter([15, -73, 14, -15])\n# 1\n# >>> specialFilter([33, -2, -3, 45, 21, 109])\n# 2\nsub specialFilter {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&specialFilter;\n        if(eq_deeply($candidate->([5, -2, 1, -5]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, -73, 14, -15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([33, -2, -3, 45, 21, 109]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([43, -12, 93, 125, 121, 109]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([71, -2, -33, 75, 21, 19]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2114,13 +728,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "pl",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2128,13 +742,237 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "pl",
-    "prompt": "# From an array of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return an array containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty array if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nsub bf {\n    my($planet1, $planet2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function that accepts an array of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted array with a sorted order,\n# The array is always an array of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the array should be ascending by length of each word, and you\n# should return the array sorted by that rule.\n# If two words have the same length, sort the array alphabetically.\n# The function should return an array of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "pl",
+    "prompt": "# Return array of all prefixes from shortest to longest of the input string\n# >>> all_prefixes(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\nsub all_prefixes {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "pl",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "pl",
+    "prompt": "# Given an array of numbers, return the sum of squares of the numbers\n# in the array that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference([1, 3, 2, 0])\n# 10\n# >>> double_the_difference([-1, -2, 0])\n# 0\n# >>> double_the_difference([9, -2])\n# 81\n# >>> double_the_difference([0])\n# 0\n# If the input array is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "pl",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\nsub compare {\n    my($game, $guess) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "pl",
+    "prompt": "# You will be given the name of a class (a string) and an array of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the array.\n# For example, if you are given \"Slices\" as the class and an array of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "pl",
+    "prompt": "# You are given 2 words. You need to return 1 if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check(\"abcd\", \"abd\")\n# \"\"\n# >>> cycpattern_check(\"hello\", \"ell\")\n# 1\n# >>> cycpattern_check(\"whassup\", \"psus\")\n# \"\"\n# >>> cycpattern_check(\"abab\", \"baa\")\n# 1\n# >>> cycpattern_check(\"efef\", \"eeff\")\n# \"\"\n# >>> cycpattern_check(\"himenss\", \"simen\")\n# 1\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "pl",
+    "prompt": "# Given an integer. return an array that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# [1, 1]\n# >>> even_odd_count(123)\n# [1, 2]\nsub even_odd_count {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "pl",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# \"xix\"\n# >>> int_to_mini_roman(152)\n# \"clii\"\n# >>> int_to_mini_roman(426)\n# \"cdxxvi\"\nsub int_to_mini_roman {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return 1 if the three\n# sides form a right-angled triangle, '' otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# 1\n# >>> right_angle_triangle(1, 2, 3)\n# \"\"\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "pl",
+    "prompt": "# Write a function that accepts an array of strings.\n# The array contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "pl",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# [11, 4]\n# >>> eat(4, 8, 9)\n# [12, 1]\n# >>> eat(1, 10, 10)\n# [11, 0]\n# >>> eat(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "pl",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# \"0\"\n# >>> string_sequence(5)\n# \"0 1 2 3 4 5\"\nsub string_sequence {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "pl",
+    "prompt": "# Given two arrays operator, and operand. The first array has basic algebra operations, and \n# the second array is an array of integers. Use the two given arrays to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator array is equal to the length of operand array minus one.\n# Operand is an array of of non-negative integers.\n# Operator array has at least one operator, and operand array has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve(\"1234\")\n# \"4321\"\n# >>> solve(\"ab\")\n# \"AB\"\n# >>> solve(\"#a@C\")\n# \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "pl",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return undef.\n# >>> string_to_md5(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2146,7 +984,7 @@
     "language": "pl",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers(2, 8)\n# [2, 4, 6, 8]\n# >>> generate_integers(8, 2)\n# [2, 4, 6, 8]\n# >>> generate_integers(10, 14)\n# []\nsub generate_integers {\n    my($a, $b) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&generate_integers;\n        if(eq_deeply($candidate->(2, 10),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(132, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 89),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2156,13 +994,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "pl",
-    "prompt": "# From a given array of integers, generate an array of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters(\"Jerry\")\n# 4\nsub count_distinct_characters {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2170,13 +1008,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "pl",
-    "prompt": "# You're given an array of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return 1. Otherwise it should return ''.\n# >>> below_zero([1, 2, 3])\n# \"\"\n# >>> below_zero([1, 2, -4, 5])\n# 1\nsub below_zero {\n    my($operations) = @_;\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return array of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2184,13 +1022,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "pl",
-    "prompt": "# You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the array.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search([5, 5, 4, 4, 4])\n# -1\nsub search {\n    my($lst) = @_;\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times(\"\", \"a\")\n# 0\n# >>> how_many_times(\"aaa\", \"a\")\n# 3\n# >>> how_many_times(\"aaaa\", \"aa\")\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2198,13 +1036,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "pl",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return 1 if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# \"\"\n# >>> correct_bracketing(\"()\")\n# 1\n# >>> correct_bracketing(\"(()())\")\n# 1\n# >>> correct_bracketing(\")(()\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers(\"three one five\")\n# \"one three five\"\nsub sort_numbers {\n    my($numbers) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "pl",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the array of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "pl",
+    "prompt": "# From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\nsub find_closest_elements {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "pl",
+    "prompt": "# Given array of numbers (of at least two elements), apply a linear transform to that array,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "pl",
+    "prompt": "# Filter given array of any plthon values only for integers\n# >>> filter_integers([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "pl",
+    "prompt": "# Return length of given string\n# >>> strlen(\"\")\n# 0\n# >>> strlen(\"abc\")\n# 3\nsub strlen {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "pl",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "pl",
+    "prompt": "# Return array of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "pl",
+    "prompt": "# From an array of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "pl",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case(\"Hello\")\n# \"hELLO\"\nsub flip_case {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "pl",
+    "prompt": "# Concatenate array of strings into a single string\n# >>> concatenate([])\n# \"\"\n# >>> concatenate([\"a\", \"b\", \"c\"])\n# \"abc\"\nsub concatenate {\n    my($strings) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "pl",
+    "prompt": "# Filter an input array of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], \"a\")\n# []\n# >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "pl",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "pl",
+    "prompt": "# Return only positive numbers in the array.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "pl",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# \"\"\n# >>> is_prime(101)\n# 1\n# >>> is_prime(11)\n# 1\n# >>> is_prime(13441)\n# 1\n# >>> is_prime(61)\n# 1\n# >>> is_prime(4)\n# \"\"\n# >>> is_prime(1)\n# \"\"\nsub is_prime {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "pl",
+    "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "pl",
+    "prompt": "# Return sorted unique elements in an array\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "pl",
+    "prompt": "# Return maximum element in the array.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "pl",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2216,9 +1306,233 @@
     "language": "pl",
     "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsub sort_even {\n    my($l) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_even;\n        if(eq_deeply($candidate->([1, 2, 3]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "pl",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "pl",
+    "prompt": "# You're given an array of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return 1. Otherwise it should return ''.\n# >>> below_zero([1, 2, 3])\n# \"\"\n# >>> below_zero([1, 2, -4, 5])\n# 1\nsub below_zero {\n    my($operations) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "pl",
+    "prompt": "# triples_sum_to_zero takes an array of integers as an input.\n# it returns 1 if there are three distinct elements in the array that\n# sum to zero, and '' otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# 1\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# 1\n# >>> triples_sum_to_zero([1])\n# \"\"\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "pl",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "pl",
+    "prompt": "# Return array with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "pl",
+    "prompt": "# pairs_sum_to_zero takes an array of integers as an input.\n# it returns 1 if there are two distinct elements in the array that\n# sum to zero, and '' otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# \"\"\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# 1\n# >>> pairs_sum_to_zero([1])\n# \"\"\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "pl",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# \"22\"\n# >>> change_base(8, 2)\n# \"1000\"\n# >>> change_base(7, 2)\n# \"111\"\nsub change_base {\n    my($x, $base) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "pl",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "pl",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "pl",
+    "prompt": "# Return median of elements in the array l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "pl",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome(\"\")\n# 1\n# >>> is_palindrome(\"aba\")\n# 1\n# >>> is_palindrome(\"aaaaa\")\n# 1\n# >>> is_palindrome(\"zbcd\")\n# \"\"\nsub is_palindrome {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "pl",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "pl",
+    "prompt": "# For a given array of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "pl",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels(\"\")\n# \"\"\n# >>> remove_vowels(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels(\"aaaaa\")\n# \"\"\n# >>> remove_vowels(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels(\"zbcd\")\n# \"zbcd\"\nsub remove_vowels {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "pl",
+    "prompt": "# Return 1 if all numbers in the array l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# 1\n# >>> below_threshold([1, 20, 4, 10], 5)\n# \"\"\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "pl",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2230,9 +1544,23 @@
     "language": "pl",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n# 1\n# >>> same_chars(\"abcd\", \"dddddddabc\")\n# 1\n# >>> same_chars(\"dddddddabc\", \"abcd\")\n# 1\n# >>> same_chars(\"eabcd\", \"dddddddabc\")\n# \"\"\n# >>> same_chars(\"abcd\", \"dddddddabce\")\n# \"\"\n# >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n# \"\"\nsub same_chars {\n    my($s0, $s1) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&same_chars;\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dddddddabc\", \"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcd\", \"dddddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabcf\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\", \"aaccc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "pl",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2244,9 +1572,681 @@
     "language": "pl",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return 1 if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# \"\"\n# >>> correct_bracketing(\"<>\")\n# 1\n# >>> correct_bracketing(\"<<><>>\")\n# 1\n# >>> correct_bracketing(\"><<>\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"<>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<><>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<<><><>><>><<><><<>>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<><>>>>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\">\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>>><>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "pl",
+    "prompt": "# Return 1 is array elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# 1\n# >>> monotonic([1, 20, 4, 10])\n# \"\"\n# >>> monotonic([4, 1, 0, -10])\n# 1\nsub monotonic {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "pl",
+    "prompt": "# Return sorted unique common elements for two arrays.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "pl",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "pl",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "pl",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "pl",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return 1 if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# \"\"\n# >>> correct_bracketing(\"()\")\n# 1\n# >>> correct_bracketing(\"(()())\")\n# 1\n# >>> correct_bracketing(\")(()\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "pl",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "pl",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "pl",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "pl",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "pl",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum(\"\")\n# 0\n# >>> digitSum(\"abAB\")\n# 131\n# >>> digitSum(\"abcCd\")\n# 67\n# >>> digitSum(\"helloE\")\n# 69\n# >>> digitSum(\"woArBld\")\n# 131\n# >>> digitSum(\"aAaaaXa\")\n# 153\nsub digitSum {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "pl",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n# 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "pl",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in an array, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck([])\n# []\n# Example 4:\n# >>> pluck([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "pl",
+    "prompt": "# You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the array.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search([5, 5, 4, 4, 4])\n# -1\nsub search {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "pl",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "pl",
+    "prompt": "# Given array of integers, return array in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list([])\n# []\nsub strange_sort_list {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "pl",
+    "prompt": "# Write a function that returns 1 if the object q will fly, and '' otherwise.\n# The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly([1, 2], 5)\n# \"\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly([3, 2, 3], 1)\n# \"\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly([3, 2, 3], 9)\n# 1\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly([3], 5)\n# 1\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "pl",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change([1, 2, 3, 2, 1])\n# 0\nsub smallest_change {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "pl",
+    "prompt": "# Write a function that accepts two arrays of strings and returns the array that has \n# total number of chars in the all strings of the array less than the other array.\n# if the two arrays have the same number of chars, return the first array.\n# Examples\n# >>> total_match([], [])\n# []\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "pl",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# 1\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "pl",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# 1\n# >>> is_simple_power(2, 2)\n# 1\n# >>> is_simple_power(8, 2)\n# 1\n# >>> is_simple_power(3, 2)\n# \"\"\n# >>> is_simple_power(3, 1)\n# \"\"\n# >>> is_simple_power(5, 3)\n# \"\"\nsub is_simple_power {\n    my($x, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "pl",
+    "prompt": "# Write a function that takes an integer a and returns 1 \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# 1\n# >>> iscube(2)\n# \"\"\n# >>> iscube(-1)\n# 1\n# >>> iscube(64)\n# 1\n# >>> iscube(0)\n# 1\n# >>> iscube(180)\n# \"\"\nsub iscube {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "pl",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key(\"AB\")\n# 1\n# >>> hex_key(\"1077E\")\n# 2\n# >>> hex_key(\"ABED1A33\")\n# 4\n# >>> hex_key(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key(\"2020\")\n# 2\nsub hex_key {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# \"db1111db\"\n# >>> decimal_to_binary(32)\n# \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "pl",
+    "prompt": "# Filter an input array of strings only for ones that contain given substring\n# >>> filter_by_substring([], \"a\")\n# []\n# >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happl or not.\n# A string is happl if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy(\"a\")\n# \"\"\n# >>> is_happy(\"aa\")\n# \"\"\n# >>> is_happy(\"abcd\")\n# 1\n# >>> is_happy(\"aabb\")\n# \"\"\n# >>> is_happy(\"adb\")\n# 1\n# >>> is_happy(\"xyy\")\n# \"\"\nsub is_happy {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "pl",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you an array of GPAs for some students and you have to write \n# a function that can output an array of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns 1 if the string\n# length is a prime number or '' otherwise\n# Examples\n# >>> prime_length(\"Hello\")\n# 1\n# >>> prime_length(\"abcdcba\")\n# 1\n# >>> prime_length(\"kittens\")\n# 1\n# >>> prime_length(\"orange\")\n# \"\"\nsub prime_length {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "pl",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# \"1\"\n# >>> solve(150)\n# \"110\"\n# >>> solve(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "pl",
+    "prompt": "# Given a non-empty array of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add([4, 2, 6, 7])\n# 2\nsub add {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\nsub anti_shuffle {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "pl",
+    "prompt": "# You are given a 2 dimensional data, as a nested arrays,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the array,\n# and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n# each array is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row([], 1)\n# []\n# >>> get_row([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\nsub get_row {\n    my($lst, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "pl",
+    "prompt": "# Given an array of non-negative integers, return a copl of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array([])\n# []\n# >>> sort_array([5])\n# [5]\n# >>> sort_array([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "pl",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt(\"hi\")\n# \"lm\"\n# >>> encrypt(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt(\"gf\")\n# \"kj\"\n# >>> encrypt(\"et\")\n# \"ix\"\nsub encrypt {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "pl",
+    "prompt": "# For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# [0, 1]\n# >>> sum_product([1, 2, 3, 4])\n# [10, 24]\nsub sum_product {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "pl",
+    "prompt": "# You are given an array of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the array.\n# Return undef if there is no such element.\n# >>> next_smallest([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest([])\n# undef\n# >>> next_smallest([1, 1])\n# undef\nsub next_smallest {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "pl",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "pl",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# 1\n# >>> any_int(3, 2, 2)\n# \"\"\n# >>> any_int(3, -2, 1)\n# 1\n# >>> any_int(3.6, -2.2, 2)\n# \"\"\nsub any_int {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "pl",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode(\"test\")\n# \"TGST\"\n# >>> encode(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\nsub encode {\n    my($message) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "pl",
+    "prompt": "# You are given an array of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n# 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "pl",
+    "prompt": "# Given a hash, return 1 if all keys are strings in lower \n# case or all keys are strings in upper case, else return ''.\n# The function should return '' is the given hash is empty.\n# Examples:\n# >>> check_dict_case({\"a\" => \"apple\", \"b\" => \"banana\"})\n# 1\n# >>> check_dict_case({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# \"\"\n# >>> check_dict_case({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# \"\"\n# >>> check_dict_case({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# \"\"\n# >>> check_dict_case({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# 1\nsub check_dict_case {\n    my($dict) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "pl",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# [2, 3]\n# >>> count_up_to(11)\n# [2, 3, 5, 7]\n# >>> count_up_to(0)\n# []\n# >>> count_up_to(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to(1)\n# []\n# >>> count_up_to(18)\n# [2, 3, 5, 7, 11, 13, 17]\nsub count_up_to {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "pl",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nsub multiply {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "pl",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper(\"aBCdEf\")\n# 1\n# >>> count_upper(\"abcdefg\")\n# 0\n# >>> count_upper(\"dBBE\")\n# 0\nsub count_upper {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "pl",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "pl",
+    "prompt": "# From a given array of integers, generate an array of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/humaneval-pl-transform.json
+++ b/prompts/humaneval-pl-transform.json
@@ -1,1636 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "pl",
-    "prompt": "# Return length of given string\n# >>> strlen(\"\")\n# 0\n# >>> strlen(\"abc\")\n# 3\nsub strlen {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "pl",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt(\"hi\")\n# \"lm\"\n# >>> encrypt(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt(\"gf\")\n# \"kj\"\n# >>> encrypt(\"et\")\n# \"ix\"\nsub encrypt {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "pl",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case({\"a\" => \"apple\", \"b\" => \"banana\"})\n# 1\n# >>> check_dict_case({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# \"\"\n# >>> check_dict_case({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# \"\"\n# >>> check_dict_case({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# \"\"\n# >>> check_dict_case({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# 1\nsub check_dict_case {\n    my($dict) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add([4, 2, 6, 7])\n# 2\nsub add {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "pl",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(\" Example\")\n# \"Example\"\n# >>> fix_spaces(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces(\" Example 3\")\n# \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "pl",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference([1, 3, 2, 0])\n# 10\n# >>> double_the_difference([-1, -2, 0])\n# 0\n# >>> double_the_difference([9, -2])\n# 81\n# >>> double_the_difference([0])\n# 0\n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "pl",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "pl",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "pl",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# \"db1111db\"\n# >>> decimal_to_binary(32)\n# \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "pl",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\nsub all_prefixes {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "pl",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "pl",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# [11, 4]\n# >>> eat(4, 8, 9)\n# [12, 1]\n# >>> eat(1, 10, 10)\n# [11, 0]\n# >>> eat(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "pl",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "pl",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "pl",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case(\"Hello\")\n# \"hELLO\"\nsub flip_case {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "pl",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length([1, -1, 55])\n# [\"One\"]\nsub by_length {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "pl",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "pl",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# [2, 3]\n# >>> count_up_to(11)\n# [2, 3, 5, 7]\n# >>> count_up_to(0)\n# []\n# >>> count_up_to(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to(1)\n# []\n# >>> count_up_to(18)\n# [2, 3, 5, 7, 11, 13, 17]\nsub count_up_to {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "pl",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "pl",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match([], [])\n# []\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "pl",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "pl",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested(\"[[]]\")\n# 1\n# >>> is_nested(\"[]]]]]]][[[[[]\")\n# \"\"\n# >>> is_nested(\"[][]\")\n# \"\"\n# >>> is_nested(\"[]\")\n# \"\"\n# >>> is_nested(\"[[][]]\")\n# 1\n# >>> is_nested(\"[[]][[\")\n# 1\nsub is_nested {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "pl",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# \"0b11\"\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# \"0b1111\"\n# >>> rounded_avg(20, 33)\n# \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "pl",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "pl",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball([3, 4, 5, 1, 2])\n# 1\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball([3, 5, 4, 1, 2])\n# \"\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "pl",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# \"\"\n# >>> is_equal_to_sum_even(6)\n# \"\"\n# >>> is_equal_to_sum_even(8)\n# 1\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "pl",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "pl",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted([5])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5])\n# \"\"\n# >>> is_sorted([1, 2, 3, 4, 5, 6])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n# \"\"\n# >>> is_sorted([1, 2, 2, 3, 3, 4])\n# 1\n# >>> is_sorted([1, 2, 2, 2, 3, 4])\n# \"\"\nsub is_sorted {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve(\"1234\")\n# \"4321\"\n# >>> solve(\"ab\")\n# \"AB\"\n# >>> solve(\"#a@C\")\n# \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "pl",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "pl",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], \"a\")\n# []\n# >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "pl",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# \"1\"\n# >>> solve(150)\n# \"110\"\n# >>> solve(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "pl",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "pl",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper(\"aBCdEf\")\n# 1\n# >>> count_upper(\"abcdefg\")\n# 0\n# >>> count_upper(\"dBBE\")\n# 0\nsub count_upper {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "pl",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "pl",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array([])\n# []\n# >>> sort_array([5])\n# [5]\n# >>> sort_array([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "pl",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "pl",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# 1\n# >>> iscube(2)\n# \"\"\n# >>> iscube(-1)\n# 1\n# >>> iscube(64)\n# 1\n# >>> iscube(0)\n# 1\n# >>> iscube(180)\n# \"\"\nsub iscube {\n    my($a) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "pl",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode(\"test\")\n# \"TGST\"\n# >>> encode(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\nsub encode {\n    my($message) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "pl",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "pl",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# \"\"\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# 1\n# >>> pairs_sum_to_zero([1])\n# \"\"\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "pl",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nsub bf {\n    my($planet1, $planet2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\nsub digits {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "pl",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "pl",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times(\"\", \"a\")\n# 0\n# >>> how_many_times(\"aaa\", \"a\")\n# 3\n# >>> how_many_times(\"aaaa\", \"aa\")\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "pl",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one(\"1\", 1)\n# undef\nsub compare_one {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "pl",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels(\"\")\n# \"\"\n# >>> remove_vowels(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels(\"aaaaa\")\n# \"\"\n# >>> remove_vowels(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels(\"zbcd\")\n# \"zbcd\"\nsub remove_vowels {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "pl",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list([])\n# []\nsub strange_sort_list {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "pl",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\nsub find_closest_elements {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "pl",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# 1\n# >>> is_simple_power(2, 2)\n# 1\n# >>> is_simple_power(8, 2)\n# 1\n# >>> is_simple_power(3, 2)\n# \"\"\n# >>> is_simple_power(3, 1)\n# \"\"\n# >>> is_simple_power(5, 3)\n# \"\"\nsub is_simple_power {\n    my($x, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "pl",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "pl",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points([])\n# []\nsub order_by_points {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "pl",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# \"\"\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# 1\nsub has_close_elements {\n    my($numbers, $threshold) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&has_close_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "pl",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome(\"\")\n# \"\"\n# >>> make_palindrome(\"cat\")\n# \"catac\"\n# >>> make_palindrome(\"cata\")\n# \"catac\"\nsub make_palindrome {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "pl",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor(\"010\", \"110\")\n# \"100\"\nsub string_xor {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "pl",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "pl",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "pl",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "pl",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "pl",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words(\"simple white space\", 2)\n# []\n# >>> select_words(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words(\"Uncle sam\", 3)\n# [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "pl",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly([1, 2], 5)\n# \"\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly([3, 2, 3], 1)\n# \"\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly([3, 2, 3], 9)\n# 1\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly([3], 5)\n# 1\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "pl",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "pl",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "pl",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens([\")\", \")\"])\n# \"No\"\nsub match_parens {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest([])\n# undef\n# >>> next_smallest([1, 1])\n# undef\nsub next_smallest {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "pl",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# 1\n# >>> any_int(3, 2, 2)\n# \"\"\n# >>> any_int(3, -2, 1)\n# 1\n# >>> any_int(3.6, -2.2, 2)\n# \"\"\nsub any_int {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "pl",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "pl",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "pl",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "pl",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "pl",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# [1, 1]\n# >>> even_odd_count(123)\n# [1, 2]\nsub even_odd_count {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "pl",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy(\"a\")\n# \"\"\n# >>> is_happy(\"aa\")\n# \"\"\n# >>> is_happy(\"abcd\")\n# 1\n# >>> is_happy(\"aabb\")\n# \"\"\n# >>> is_happy(\"adb\")\n# 1\n# >>> is_happy(\"xyy\")\n# \"\"\nsub is_happy {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "pl",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "pl",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum(\"\")\n# 0\n# >>> digitSum(\"abAB\")\n# 131\n# >>> digitSum(\"abcCd\")\n# 67\n# >>> digitSum(\"helloE\")\n# 69\n# >>> digitSum(\"woArBld\")\n# 131\n# >>> digitSum(\"aAaaaXa\")\n# 153\nsub digitSum {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "pl",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "pl",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution([5, 8, 7, 1])\n# 12\n# >>> solution([3, 3, 3, 3, 3])\n# 9\n# >>> solution([30, 13, 24, 321])\n# 0\nsub solution {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "pl",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck([])\n# []\n# Example 4:\n# >>> pluck([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "pl",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "pl",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "pl",
-    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length(\"Hello\")\n# 1\n# >>> prime_length(\"abcdcba\")\n# 1\n# >>> prime_length(\"kittens\")\n# 1\n# >>> prime_length(\"orange\")\n# \"\"\nsub prime_length {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "pl",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change([1, 2, 3, 2, 1])\n# 0\nsub smallest_change {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "pl",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst([1.0, 2.0, 3.0])\n# 14\n# >>> lst([1.0, 4.0, 9.0])\n# 98\n# >>> lst([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst([1.4, 4.2, 0.0])\n# 29\n# >>> lst([-2.4, 1.0, 1.0])\n# 6\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "pl",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check(\"1example.dll\")\n# \"No\"\nsub file_name_check {\n    my($file_name) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "pl",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# 1\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# 1\n# >>> triples_sum_to_zero([1])\n# \"\"\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "pl",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection([-3, -1], [-5, 5])\n# \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "pl",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "pl",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\nsub compare {\n    my($game, $guess) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "pl",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter(\"apple pie\")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"apple pi e\")\n# 1\n# >>> check_if_last_char_is_a_letter(\"apple pi e \")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"\")\n# \"\"\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "pl",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date(\"03-11-2000\")\n# 1\n# >>> valid_date(\"15-01-2012\")\n# \"\"\n# >>> valid_date(\"04-0-2040\")\n# \"\"\n# >>> valid_date(\"06-04-2020\")\n# 1\n# >>> valid_date(\"06/04/2020\")\n# \"\"\nsub valid_date {\n    my($date) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "pl",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([])\n# 0\n# >>> count_nums([-1, 11, -11])\n# 1\n# >>> count_nums([1, 1, 2])\n# 3\nsub count_nums {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "pl",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\nsub anti_shuffle {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "pl",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome(\"\")\n# 1\n# >>> is_palindrome(\"aba\")\n# 1\n# >>> is_palindrome(\"aaaaa\")\n# 1\n# >>> is_palindrome(\"zbcd\")\n# \"\"\nsub is_palindrome {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "pl",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel(\"quick\")\n# \"\"\n# >>> get_closest_vowel(\"ab\")\n# \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "pl",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# \"\"\n# >>> is_prime(101)\n# 1\n# >>> is_prime(11)\n# 1\n# >>> is_prime(13441)\n# 1\n# >>> is_prime(61)\n# 1\n# >>> is_prime(4)\n# \"\"\n# >>> is_prime(1)\n# \"\"\nsub is_prime {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "pl",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify(\"1/5\", \"5/1\")\n# 1\n# >>> simplify(\"1/6\", \"2/1\")\n# \"\"\n# >>> simplify(\"7/10\", \"10/2\")\n# \"\"\nsub simplify {\n    my($x, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "pl",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key(\"AB\")\n# 1\n# >>> hex_key(\"1077E\")\n# 2\n# >>> hex_key(\"ABED1A33\")\n# 4\n# >>> hex_key(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key(\"2020\")\n# 2\nsub hex_key {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "pl",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "pl",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram(\"\")\n# {}\nsub histogram {\n    my($test) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "pl",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row([], 1)\n# []\n# >>> get_row([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\nsub get_row {\n    my($lst, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "pl",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# [1, 5]\nsub get_odd_collatz {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "pl",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange([1, 2, 3])\n# -1\nsub can_arrange {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "pl",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers(\"three one five\")\n# \"one three five\"\nsub sort_numbers {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "pl",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "pl",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\nsub sum_squares {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "pl",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n# 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "pl",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# [0, 1]\n# >>> sum_product([1, 2, 3, 4])\n# [10, 24]\nsub sum_product {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "pl",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nsub choose_num {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "pl",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n# [undef, 1]\n# >>> largest_smallest_integers([])\n# [undef, undef]\n# >>> largest_smallest_integers([0])\n# [undef, undef]\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "pl",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters(\"Jerry\")\n# 4\nsub count_distinct_characters {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1642,7 +18,7 @@
     "language": "pl",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\nsub make_a_pile {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_a_pile;\n        if(eq_deeply($candidate->(3),[3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4, 6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5, 7, 9, 11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[6, 8, 10, 12, 14, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[8, 10, 12, 14, 16, 18, 20, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1652,13 +28,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "pl",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4])\n# 9\n# >>> prod_signs([0, 1])\n# 0\n# >>> prod_signs([])\n# undef\nsub prod_signs {\n    my($arr) = @_;\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nsub words_string {\n    my($s) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_string;\n        if(eq_deeply($candidate->(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1666,13 +42,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "pl",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum([-1, -2, -3])\n# -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nsub choose_num {\n    my($x, $y) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&choose_num;\n        if(eq_deeply($candidate->(12, 15),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(33, 12354),12354)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5234, 5233),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 29),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 7),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(546, 546),546)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1680,13 +56,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "pl",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# \"0\"\n# >>> string_sequence(5)\n# \"0 1 2 3 4 5\"\nsub string_sequence {\n    my($n) = @_;\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# \"0b11\"\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# \"0b1111\"\n# >>> rounded_avg(20, 33)\n# \"0b11010\"\nsub rounded_avg {\n    my($n, $m) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rounded_avg;\n        if(eq_deeply($candidate->(1, 5),\"0b11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),\"0b1010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(964, 977),\"0b1111001010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(996, 997),\"0b1111100100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(560, 851),\"0b1011000010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185, 546),\"0b101101110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(362, 496),\"0b110101101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(350, 902),\"0b1001110010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(197, 233),\"0b11010111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),\"0b101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1694,13 +70,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "pl",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check(\"abcd\", \"abd\")\n# \"\"\n# >>> cycpattern_check(\"hello\", \"ell\")\n# 1\n# >>> cycpattern_check(\"whassup\", \"psus\")\n# \"\"\n# >>> cycpattern_check(\"abab\", \"baa\")\n# 1\n# >>> cycpattern_check(\"efef\", \"eeff\")\n# \"\"\n# >>> cycpattern_check(\"himenss\", \"simen\")\n# 1\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nsub unique_digits {\n    my($x) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_digits;\n        if(eq_deeply($candidate->([15, 33, 1422, 1]),[1, 15, 33])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([152, 323, 1422, 10]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12345, 2033, 111, 151]),[111, 151])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([135, 103, 31]),[31, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1708,13 +84,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "pl",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# 1\n# >>> monotonic([1, 20, 4, 10])\n# \"\"\n# >>> monotonic([4, 1, 0, -10])\n# 1\nsub monotonic {\n    my($l) = @_;\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length([1, -1, 55])\n# [\"One\"]\nsub by_length {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&by_length;\n        if(eq_deeply($candidate->([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 55]),[\"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1722,13 +98,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "pl",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# undef\n# >>> longest([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\nsub longest {\n    my($strings) = @_;\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# [1, 2, 6, 24, 15]\nsub f {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&f;\n        if(eq_deeply($candidate->(5),[1, 2, 6, 24, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 2, 6, 24, 15, 720, 28])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1736,13 +112,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "pl",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# 1\n# >>> below_threshold([1, 20, 4, 10], 5)\n# \"\"\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\nsub even_odd_palindrome {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_palindrome;\n        if(eq_deeply($candidate->(123),[8, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),[6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),[4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1750,13 +126,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "pl",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# 1\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([])\n# 0\n# >>> count_nums([-1, 11, -11])\n# 1\n# >>> count_nums([1, 1, 2])\n# 3\nsub count_nums {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_nums;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, -2, 3, 4, 5]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 9, -6, 0, 1, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 100, 98, -7, 1, -1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 23, 34, -45, -56, 0]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1764,13 +140,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "pl",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball([3, 4, 5, 1, 2])\n# 1\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball([3, 5, 4, 1, 2])\n# \"\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nsub move_one_ball {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_one_ball;\n        if(eq_deeply($candidate->([3, 4, 5, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 10, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 4, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1778,13 +154,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "pl",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome(\"\")\n# \"\"\n# >>> make_palindrome(\"cat\")\n# \"catac\"\n# >>> make_palindrome(\"cata\")\n# \"catac\"\nsub make_palindrome {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&make_palindrome;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz\"),\"xyzyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyx\"),\"xyx\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"jerry\"),\"jerryrrej\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1792,13 +168,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "pl",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\nsub exchange {\n    my($lst1, $lst2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&exchange;\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 4]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 3], [2, 6, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 200], [200, 200]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1806,83 +182,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "pl",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram(\"\")\n# {}\nsub histogram {\n    my($test) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "pl",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nsub multiply {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "pl",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "pl",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "pl",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# \"xix\"\n# >>> int_to_mini_roman(152)\n# \"clii\"\n# >>> int_to_mini_roman(426)\n# \"cdxxvi\"\nsub int_to_mini_roman {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "pl",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n# 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&histogram;\n        if(eq_deeply($candidate->(\"a b b a\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c a b\"),{\"a\" => 2, \"b\" => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d g\"),{\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"b b b b a\"),{\"b\" => 4})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"r t g\"),{\"r\" => 1, \"t\" => 1, \"g\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),{})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),{\"a\" => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1894,7 +200,7 @@
     "language": "pl",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# >>> reverse_delete(\"abcde\", \"ae\")\n# [\"bcd\", \"\"]\n# >>> reverse_delete(\"abcdef\", \"b\")\n# [\"acdef\", \"\"]\n# >>> reverse_delete(\"abcdedcba\", \"ab\")\n# [\"cdedc\", 1]\nsub reverse_delete {\n    my($s, $c) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_delete;\n        if(eq_deeply($candidate->(\"abcde\", \"ae\"),[\"bcd\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\", \"b\"),[\"acdef\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"ab\"),[\"cdedc\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dwik\", \"w\"),[\"dik\", \"\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\", \"a\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdedcba\", \"v\"),[\"abcdedcba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"vabba\", \"v\"),[\"abba\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"mamma\", \"mia\"),[\"\", 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1904,13 +210,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "pl",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nsub odd_count {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_count;\n        if(eq_deeply($candidate->([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1918,13 +224,27 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "pl",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"abcdef\")\n# 3\nsub split_words {\n    my($txt) = @_;\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum([-1, -2, -3])\n# -6\nsub minSubArraySum {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minSubArraySum;\n        if(eq_deeply($candidate->([2, 3, 4, 1, 2, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 2, -10]),-14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9999999999999999]),-9999999999999999)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 10, 20, 1000000]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -1, -2, -3, 10, -5]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 13, 8, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, -33, 32, -1, 0, -2]),-33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "pl",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nsub max_fill {\n    my($grid, $capacity) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_fill;\n        if(eq_deeply($candidate->([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 0, 0], [0, 0, 0]], 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1936,7 +256,7 @@
     "language": "pl",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4])\n# [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6])\n# [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4])\n# [0, 1, 2, 3, 4]\nsub sort_array {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -1946,13 +266,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "pl",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# \"\"\n# >>> concatenate([\"a\", \"b\", \"c\"])\n# \"abc\"\nsub concatenate {\n    my($strings) = @_;\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words(\"simple white space\", 2)\n# []\n# >>> select_words(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words(\"Uncle sam\", 3)\n# [\"Uncle\"]\nsub select_words {\n    my($s, $n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&select_words;\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 4),[\"little\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"simple white space\", 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world\", 4),[\"world\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Uncle sam\", 3),[\"Uncle\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\", 4),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1960,13 +280,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel(\"quick\")\n# \"\"\n# >>> get_closest_vowel(\"ab\")\n# \"\"\nsub get_closest_vowel {\n    my($word) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_closest_vowel;\n        if(eq_deeply($candidate->(\"yogurt\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"full\"),\"u\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"easy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eAsy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ali\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bad\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"most\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"quick\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"anime\"),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Asia\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Above\"),\"o\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1974,13 +294,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "pl",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], \"a\")\n# []\n# >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens([\")\", \")\"])\n# \"No\"\nsub match_parens {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&match_parens;\n        if(eq_deeply($candidate->([\"()(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \")\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(())\", \"())())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")())\", \"(()()(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(())))\", \"(()())((\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"()\", \"())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(()(\", \"()))()\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"((((\", \"((())\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(()\", \"(()(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")(\", \")(\"]),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"(\", \")\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\")\", \"(\"]),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -1988,13 +308,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "pl",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor(\"010\", \"110\")\n# \"100\"\nsub string_xor {\n    my($a, $b) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_xor;\n        if(eq_deeply($candidate->(\"111000\", \"101010\"),\"010010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"1\"),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0101\", \"0000\"),\"0101\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2002,13 +322,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "pl",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nsub maximum {\n    my($arr, $k) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->([-3, -4, 5], 3),[-4, -3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4, 4], 2),[4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 2, 1, 2, -1, -2, 1], 1),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 2, 5, 3, -10], 2),[3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 5, -7], 1),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, -4], 2),[-4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 10], 2),[-10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -23, 243, -400, 0], 0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2016,13 +336,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "pl",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution([5, 8, 7, 1])\n# 12\n# >>> solution([3, 3, 3, 3, 3])\n# 9\n# >>> solution([30, 13, 24, 321])\n# 0\nsub solution {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solution;\n        if(eq_deeply($candidate->([5, 8, 7, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3, 3, 3, 3]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 24, 321]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 9]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 13, 23, 32]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 13, 2, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2030,13 +350,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "pl",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nsub add_elements {\n    my($arr, $k) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_elements;\n        if(eq_deeply($candidate->([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 121, 3, 4000, 5, 6], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2044,13 +364,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "pl",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# \"22\"\n# >>> change_base(8, 2)\n# \"1000\"\n# >>> change_base(7, 2)\n# \"111\"\nsub change_base {\n    my($x, $base) = @_;\n",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# [1, 5]\nsub get_odd_collatz {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_odd_collatz;\n        if(eq_deeply($candidate->(14),[1, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2058,13 +378,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "pl",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# 1\n# >>> right_angle_triangle(1, 2, 3)\n# \"\"\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date(\"03-11-2000\")\n# 1\n# >>> valid_date(\"15-01-2012\")\n# \"\"\n# >>> valid_date(\"04-0-2040\")\n# \"\"\n# >>> valid_date(\"06-04-2020\")\n# 1\n# >>> valid_date(\"06/04/2020\")\n# \"\"\nsub valid_date {\n    my($date) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&valid_date;\n        if(eq_deeply($candidate->(\"03-11-2000\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15-01-2012\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-0-2040\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-04-2020\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"01-01-2007\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"03-32-2011\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-31-3000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"06-06-2005\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"21-31-2000\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-12-2003\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04122003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"20030412\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2003-04-12\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"04-2003\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2072,13 +392,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "pl",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words(\"abcdef\")\n# 3\nsub split_words {\n    my($txt) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_words;\n        if(eq_deeply($candidate->(\"Hello world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,world!\"),[\"Hello\", \"world!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello world,!\"),[\"Hello\", \"world,!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaabb\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaBb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2086,13 +406,307 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "pl",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted([5])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5])\n# \"\"\n# >>> is_sorted([1, 2, 3, 4, 5, 6])\n# 1\n# >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n# 1\n# >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n# \"\"\n# >>> is_sorted([1, 2, 2, 3, 3, 4])\n# 1\n# >>> is_sorted([1, 2, 2, 2, 3, 4])\n# \"\"\nsub is_sorted {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sorted;\n        if(eq_deeply($candidate->([5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "pl",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection([-3, -1], [-5, 5])\n# \"YES\"\nsub intersection {\n    my($interval1, $interval2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection;\n        if(eq_deeply($candidate->([1, 2], [2, 3]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1], [0, 4]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -1], [-5, 5]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, 2], [-4, 0]),\"YES\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-11, 2], [-1, -1]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 5]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [1, 2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -2], [-3, -2]),\"NO\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "pl",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4])\n# 9\n# >>> prod_signs([0, 1])\n# 0\n# >>> prod_signs([])\n# undef\nsub prod_signs {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prod_signs;\n        if(eq_deeply($candidate->([1, 2, 2, -4]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, -1, 1]),-10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 2, -1, -1, 9]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, -1, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 1]),-4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 1, 1, 0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "pl",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\nsub minPath {\n    my($grid, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "pl",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# undef\n# >>> longest([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\nsub longest {\n    my($strings) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&longest;\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"x\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "pl",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# [1, 3, 2, 8]\nsub tri {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tri;\n        if(eq_deeply($candidate->(3),[1, 3, 2, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[1, 3, 2, 8, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[1, 3, 2, 8, 3, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[1, 3, 2, 8, 3, 15, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[1, 3, 2, 8, 3, 15, 4, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[1, 3, 2, 8, 3, 15, 4, 24, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\nsub digits {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digits;\n        if(eq_deeply($candidate->(5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(54),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5014),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(98765),315)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5576543),2625)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2468),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "pl",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested(\"[[]]\")\n# 1\n# >>> is_nested(\"[]]]]]]][[[[[]\")\n# \"\"\n# >>> is_nested(\"[][]\")\n# \"\"\n# >>> is_nested(\"[]\")\n# \"\"\n# >>> is_nested(\"[[][]]\")\n# 1\n# >>> is_nested(\"[[]][[\")\n# 1\nsub is_nested {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nested;\n        if(eq_deeply($candidate->(\"[[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]][[[[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[]]]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[][][[]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[]][[\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[][]]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"[[[[[[[[\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"]]]]]]]]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "pl",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst([1.0, 2.0, 3.0])\n# 14\n# >>> lst([1.0, 4.0, 9.0])\n# 98\n# >>> lst([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst([1.4, 4.2, 0.0])\n# 29\n# >>> lst([-2.4, 1.0, 1.0])\n# 6\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 3.0, 5.0, 7.0]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.4, 4.2, 0.0]),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2.4, 1.0, 1.0]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 1.0, 15.0, 2.0]),10230)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10000.0, 10000.0]),200000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 4.6, 6.3]),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.4, 17.9, 18.9, 19.9]),1086)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, 1.0, 0.0]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "pl",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter(\"apple pie\")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"apple pi e\")\n# 1\n# >>> check_if_last_char_is_a_letter(\"apple pi e \")\n# \"\"\n# >>> check_if_last_char_is_a_letter(\"\")\n# \"\"\nsub check_if_last_char_is_a_letter {\n    my($txt) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_if_last_char_is_a_letter;\n        if(eq_deeply($candidate->(\"apple\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pumpkin pie 1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pie\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple pi e \"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "pl",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange([1, 2, 3])\n# -1\nsub can_arrange {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&can_arrange;\n        if(eq_deeply($candidate->([1, 2, 4, 3, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 8, 5, 7, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "pl",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n# [undef, 1]\n# >>> largest_smallest_integers([])\n# [undef, undef]\n# >>> largest_smallest_integers([0])\n# [undef, undef]\nsub largest_smallest_integers {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_smallest_integers;\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3, 5, 7, 0]),[undef, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2, 4, 5, 6, -2]),[-2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 3, 6, 2, 7, -7]),[-7, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),[undef, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, -5, -6, 0]),[-1, undef])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-6, -4, -4, -3, -100, 1]),[-3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "pl",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one(\"1\", 1)\n# undef\nsub compare_one {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare_one;\n        if(eq_deeply($candidate->(1, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2.5),2.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, \"2,3\"),\"2,3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5,1\", \"6\"),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", \"2\"),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\", 1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "pl",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# \"\"\n# >>> is_equal_to_sum_even(6)\n# \"\"\n# >>> is_equal_to_sum_even(8)\n# 1\nsub is_equal_to_sum_even {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_equal_to_sum_even;\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "pl",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nsub special_factorial {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&special_factorial;\n        if(eq_deeply($candidate->(4),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),34560)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),125411328000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "pl",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\nsub greatest_common_divisor {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&greatest_common_divisor;\n        if(eq_deeply($candidate->(3, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49, 14),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(144, 60),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "pl",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(\" Example\")\n# \"Example\"\n# >>> fix_spaces(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces(\" Example 3\")\n# \"_Example-3\"\nsub fix_spaces {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fix_spaces;\n        if(eq_deeply($candidate->(\"Example\"),\"Example\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir Hanif \"),\"Mudasir_Hanif_\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Exa   mple\"),\"Exa-mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "pl",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check(\"1example.dll\")\n# \"No\"\nsub file_name_check {\n    my($file_name) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&file_name_check;\n        if(eq_deeply($candidate->(\"example.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1example.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s1sdf3.asd\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MY16FILE3.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"His12FILE94.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_Y.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"?aREYA.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"/this_is_valid.dll\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.wow\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_valid.txtexe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#this2_i4s_5valid.ten\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"@this1_is6_valid.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"this_is_12valid.6exe4.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"all.exe.txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_No.exe\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is3youfault.txt\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"no_one#knows.dll\"),\"Yes\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1I563_Yes3.exe\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I563_Yes3.txtt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final..txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final132\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_f4indsartal132.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".txt\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"s.\"),\"No\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "pl",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\nsub sum_squares {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_squares;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 9]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 1, 1, 1, 1, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -5, 2, -1, -5]),-126)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-56, -99, 1, 0, -2]),3030)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "pl",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nsub words_in_sentence {\n    my($sentence) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&words_in_sentence;\n        if(eq_deeply($candidate->(\"This is a test\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lets go for swimming\"),\"go for\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"there is no place available here\"),\"there is no place\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi I am Hussein\"),\"Hi am Hussein\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go for it\"),\"go for it\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"here is\"),\"is\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "pl",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify(\"1/5\", \"5/1\")\n# 1\n# >>> simplify(\"1/6\", \"2/1\")\n# \"\"\n# >>> simplify(\"7/10\", \"10/2\")\n# \"\"\nsub simplify {\n    my($x, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&simplify;\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/6\", \"2/1\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/1\", \"3/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/10\", \"10/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/10\", \"50/10\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"7/2\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11/6\", \"6/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/3\", \"5/2\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5/2\", \"3/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"8/4\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2/4\", \"4/2\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"5/1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1/5\", \"1/5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "pl",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points([])\n# []\nsub order_by_points {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&order_by_points;\n        if(eq_deeply($candidate->([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2104,7 +718,7 @@
     "language": "pl",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter([15, -73, 14, -15])\n# 1\n# >>> specialFilter([33, -2, -3, 45, 21, 109])\n# 2\nsub specialFilter {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&specialFilter;\n        if(eq_deeply($candidate->([5, -2, 1, -5]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, -73, 14, -15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([33, -2, -3, 45, 21, 109]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([43, -12, 93, 125, 121, 109]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([71, -2, -33, 75, 21, 19]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2114,13 +728,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "pl",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nsub get_max_triples {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_triples;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),53361)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2128,13 +742,237 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "pl",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\nsub bf {\n    my($planet1, $planet2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bf;\n        if(eq_deeply($candidate->(\"Jupiter\", \"Neptune\"),[\"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Mercury\"),[\"Venus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mercury\", \"Uranus\"),[\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Neptune\", \"Venus\"),[\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Earth\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mars\", \"Earth\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jupiter\", \"Makemake\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\nsub sorted_list_sum {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sorted_list_sum;\n        if(eq_deeply($candidate->([\"aa\", \"a\", \"aaa\"]),[\"aa\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"b\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "pl",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\nsub all_prefixes {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_prefixes;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"WWW\"),[\"W\", \"WW\", \"WWW\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "pl",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nsub x_or_y {\n    my($n, $x, $y) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&x_or_y;\n        if(eq_deeply($candidate->(7, 34, 12),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 5),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 33, 5212),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1259, 3, 52),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7919, -1, 12),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3609, 1245, 583),583)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(91, 56, 129),129)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 34, 1234),1234)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 0),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "pl",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference([1, 3, 2, 0])\n# 10\n# >>> double_the_difference([-1, -2, 0])\n# 0\n# >>> double_the_difference([9, -2])\n# 81\n# >>> double_the_difference([0])\n# 0\n# If the input list is empty, return 0.\nsub double_the_difference {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&double_the_difference;\n        if(eq_deeply($candidate->([]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5.0, 4.0]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.1, 0.2, 0.3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10.0, -20.0, -30.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1.0, -2.0, 8.0]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.2, 3.0, 5.0]),34)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "pl",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\nsub compare {\n    my($game, $guess) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&compare;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [-1, -2, -3]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "pl",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\nsub Strongest_Extension {\n    my($class_name, $extensions) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Strongest_Extension;\n        if(eq_deeply($candidate->(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "pl",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check(\"abcd\", \"abd\")\n# \"\"\n# >>> cycpattern_check(\"hello\", \"ell\")\n# 1\n# >>> cycpattern_check(\"whassup\", \"psus\")\n# \"\"\n# >>> cycpattern_check(\"abab\", \"baa\")\n# 1\n# >>> cycpattern_check(\"efef\", \"eeff\")\n# \"\"\n# >>> cycpattern_check(\"himenss\", \"simen\")\n# 1\nsub cycpattern_check {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cycpattern_check;\n        if(eq_deeply($candidate->(\"xyzw\", \"xyw\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"yello\", \"ell\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"whattup\", \"ptut\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"efef\", \"fee\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abab\", \"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"winemtt\", \"tinem\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "pl",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# [1, 1]\n# >>> even_odd_count(123)\n# [1, 2]\nsub even_odd_count {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_odd_count;\n        if(eq_deeply($candidate->(7),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-78),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3452),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(346211),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-345821),[3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-45347),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "pl",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# \"xix\"\n# >>> int_to_mini_roman(152)\n# \"clii\"\n# >>> int_to_mini_roman(426)\n# \"cdxxvi\"\nsub int_to_mini_roman {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&int_to_mini_roman;\n        if(eq_deeply($candidate->(19),\"xix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(152),\"clii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(251),\"ccli\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(426),\"cdxxvi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(500),\"d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"i\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"iv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(43),\"xliii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(90),\"xc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(94),\"xciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(532),\"dxxxii\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(900),\"cm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(994),\"cmxciv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),\"m\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# 1\n# >>> right_angle_triangle(1, 2, 3)\n# \"\"\nsub right_angle_triangle {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_angle_triangle;\n        if(eq_deeply($candidate->(3, 4, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 6, 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 24, 25),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 12, 13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8, 17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(48, 55, 73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "pl",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\nsub find_max {\n    my($words) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_max;\n        if(eq_deeply($candidate->([\"name\", \"of\", \"string\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"name\", \"enam\", \"game\"]),\"enam\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"cba\"]),\"abc\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\", \"is\", \"a\", \"prrk\"]),\"this\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"b\"]),\"b\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"play\", \"play\", \"play\"]),\"play\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "pl",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# [11, 4]\n# >>> eat(4, 8, 9)\n# [12, 1]\n# >>> eat(1, 10, 10)\n# [11, 0]\n# >>> eat(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\nsub eat {\n    my($number, $need, $remaining) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eat;\n        if(eq_deeply($candidate->(5, 6, 10),[11, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 9),[12, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 10, 10),[11, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 11, 5),[7, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 7),[9, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5, 1),[5, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "pl",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# \"0\"\n# >>> string_sequence(5)\n# \"0 1 2 3 4 5\"\nsub string_sequence {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_sequence;\n        if(eq_deeply($candidate->(0),\"0\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"0 1 2 3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"0 1 2 3 4 5 6 7 8 9 10\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "pl",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\nsub do_algebra {\n    my($operator, $operand) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&do_algebra;\n        if(eq_deeply($candidate->([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"//\", \"*\"], [7, 3, 4]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve(\"1234\")\n# \"4321\"\n# >>> solve(\"ab\")\n# \"AB\"\n# >>> solve(\"#a@C\")\n# \"#A@c\"\nsub solve {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(\"AsDf\"),\"aSdF\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1234\"),\"4321\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"AB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#a@C\"),\"#A@c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#AsdfW^45\"),\"#aSDFw^45\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#6@2\"),\"2@6#\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#$a^D\"),\"#$A^d\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"#ccc\"),\"#CCC\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "pl",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\nsub string_to_md5 {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_md5;\n        if(eq_deeply($candidate->(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2146,7 +984,7 @@
     "language": "pl",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers(2, 8)\n# [2, 4, 6, 8]\n# >>> generate_integers(8, 2)\n# [2, 4, 6, 8]\n# >>> generate_integers(10, 14)\n# []\nsub generate_integers {\n    my($a, $b) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&generate_integers;\n        if(eq_deeply($candidate->(2, 10),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(132, 2),[2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 89),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -2156,13 +994,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "pl",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters(\"Jerry\")\n# 4\nsub count_distinct_characters {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_distinct_characters;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdecadeCADE\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaAAAAaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Jerry jERRY JeRRRY\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2170,13 +1008,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "pl",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# \"\"\n# >>> below_zero([1, 2, -4, 5])\n# 1\nsub below_zero {\n    my($operations) = @_;\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nsub parse_music {\n    my($music_string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_music;\n        if(eq_deeply($candidate->(\"\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o o o o\"),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\".| .| .| .|\"),[1, 1, 1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2184,13 +1022,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "pl",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search([5, 5, 4, 4, 4])\n# -1\nsub search {\n    my($lst) = @_;\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times(\"\", \"a\")\n# 0\n# >>> how_many_times(\"aaa\", \"a\")\n# 3\n# >>> how_many_times(\"aaaa\", \"aa\")\n# 3\nsub how_many_times {\n    my($string, $substring) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&how_many_times;\n        if(eq_deeply($candidate->(\"\", \"x\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyxyxyx\", \"x\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"cacacacac\", \"cac\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"john doe\", \"john\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2198,13 +1036,265 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "pl",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# \"\"\n# >>> correct_bracketing(\"()\")\n# 1\n# >>> correct_bracketing(\"(()())\")\n# 1\n# >>> correct_bracketing(\")(()\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers(\"three one five\")\n# \"one three five\"\nsub sort_numbers {\n    my($numbers) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numbers;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three\"),\"three\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"three five nine\"),\"three five nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"five zero four seven nine eight\"),\"zero four five seven eight nine\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"six five four three two one zero\"),\"zero one two three four five six\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "pl",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\nsub separate_paren_groups {\n    my($paren_string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&separate_paren_groups;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[\"(()(())((())))\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "pl",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\nsub find_closest_elements {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_closest_elements;\n        if(eq_deeply($candidate->([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "pl",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nsub rescale_to_unit {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rescale_to_unit;\n        if(eq_deeply($candidate->([2.0, 49.9]),[0.0, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100.0, 49.9]),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "pl",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\nsub filter_integers {\n    my($values) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_integers;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "pl",
+    "prompt": "# Return length of given string\n# >>> strlen(\"\")\n# 0\n# >>> strlen(\"abc\")\n# 3\nsub strlen {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strlen;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"x\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdasnakj\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "pl",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nsub largest_divisor {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_divisor;\n        if(eq_deeply($candidate->(3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(49),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "pl",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nsub factorize {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&factorize;\n        if(eq_deeply($candidate->(2),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),[2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(57),[3, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3249),[3, 3, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(185193),[3, 3, 3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20577),[3, 19, 19, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "pl",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nsub remove_duplicates {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_duplicates;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "pl",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case(\"Hello\")\n# \"hELLO\"\nsub flip_case {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flip_case;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello!\"),\"hELLO!\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "pl",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# \"\"\n# >>> concatenate([\"a\", \"b\", \"c\"])\n# \"abc\"\nsub concatenate {\n    my($strings) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\"]),\"xyz\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], \"a\")\n# []\n# >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\nsub filter_by_prefix {\n    my($strings, $prefix) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_prefix;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "pl",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\nsub truncate_number {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&truncate_number;\n        if(eq_deeply($candidate->(3.5),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.25),0.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123.0),0.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "pl",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nsub get_positive {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_positive;\n        if(eq_deeply($candidate->([-1, -2, 4, 5, 6]),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "pl",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# \"\"\n# >>> is_prime(101)\n# 1\n# >>> is_prime(11)\n# 1\n# >>> is_prime(13441)\n# 1\n# >>> is_prime(61)\n# 1\n# >>> is_prime(4)\n# \"\"\n# >>> is_prime(1)\n# \"\"\nsub is_prime {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_prime;\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13441),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(61),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(85),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(255379),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "pl",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsub sort_third {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_third;\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "pl",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nsub unique {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique;\n        if(eq_deeply($candidate->([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "pl",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nsub max_element {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_element;\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "pl",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nsub fizz_buzz {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fizz_buzz;\n        if(eq_deeply($candidate->(50),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(78),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(79),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4000),192)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10000),639)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100000),8026)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2216,9 +1306,233 @@
     "language": "pl",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsub sort_even {\n    my($l) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_even;\n        if(eq_deeply($candidate->([1, 2, 3]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "pl",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nsub prime_fib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_fib;\n        if(eq_deeply($candidate->(1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),233)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1597)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28657)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),514229)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),433494437)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "pl",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# \"\"\n# >>> below_zero([1, 2, -4, 5])\n# 1\nsub below_zero {\n    my($operations) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_zero;\n        if(eq_deeply($candidate->([]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -3, 1, 2, -3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, -4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -1, 2, -2, 5, -5, 4, -5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 2, -2, 5, -5, 4, -4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "pl",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# 1\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# 1\n# >>> triples_sum_to_zero([1])\n# \"\"\nsub triples_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triples_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 9, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 3, 5, -100]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "pl",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\nsub car_race_collision {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&car_race_collision;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "pl",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nsub incr_list {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&incr_list;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[4, 3, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "pl",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# \"\"\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# \"\"\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# \"\"\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# 1\n# >>> pairs_sum_to_zero([1])\n# \"\"\nsub pairs_sum_to_zero {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pairs_sum_to_zero;\n        if(eq_deeply($candidate->([1, 3, 5, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, -2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -5, 3, 5, 7]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 30]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 3, 2, 31]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 30]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, 9, -1, 4, 2, 31]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "pl",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# \"22\"\n# >>> change_base(8, 2)\n# \"1000\"\n# >>> change_base(7, 2)\n# \"111\"\nsub change_base {\n    my($x, $base) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_base;\n        if(eq_deeply($candidate->(8, 3),\"22\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),\"100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(234, 2),\"11101010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 2),\"10000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 2),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 2),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),\"2\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),\"3\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),\"4\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 6),\"5\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 7),\"6\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 8),\"7\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "pl",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\nsub triangle_area {\n    my($a, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(5, 3),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2),2.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),40.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "pl",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nsub fib4 {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib4;\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),28)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),104)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),386)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "pl",
+    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nsub median {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-10, 4, 6, 1000, 10, 20]),8.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 5]),5.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 1, 3, 9, 9, 2, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "pl",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome(\"\")\n# 1\n# >>> is_palindrome(\"aba\")\n# 1\n# >>> is_palindrome(\"aaaaa\")\n# 1\n# >>> is_palindrome(\"zbcd\")\n# \"\"\nsub is_palindrome {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_palindrome;\n        if(eq_deeply($candidate->(\"\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zbcd\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyx\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywyz\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xywzx\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "pl",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nsub modp {\n    my($n, $p) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&modp;\n        if(eq_deeply($candidate->(3, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1101, 101),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 11),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 101),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(31, 5),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "pl",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nsub mean_absolute_deviation {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mean_absolute_deviation;\n        if(eq_deeply($candidate->([1.0, 2.0]),0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0]),1.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 2.0, 3.0, 4.0, 5.0]),1.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "pl",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels(\"\")\n# \"\"\n# >>> remove_vowels(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels(\"aaaaa\")\n# \"\"\n# >>> remove_vowels(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels(\"zbcd\")\n# \"zbcd\"\nsub remove_vowels {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_vowels;\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdef\nghijklm\"),\"bcdf\nghjklm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"fedcba\"),\"fdcb\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eeeee\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"acBAA\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EcBOO\"),\"cB\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ybcd\"),\"ybcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "pl",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# 1\n# >>> below_threshold([1, 20, 4, 10], 5)\n# \"\"\nsub below_threshold {\n    my($l, $t) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&below_threshold;\n        if(eq_deeply($candidate->([1, 2, 4, 10], 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 21),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10], 22),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 8, 4, 10], 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "pl",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nsub add {\n    my($x, $y) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->(0, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 5),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2230,9 +1544,23 @@
     "language": "pl",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n# 1\n# >>> same_chars(\"abcd\", \"dddddddabc\")\n# 1\n# >>> same_chars(\"dddddddabc\", \"abcd\")\n# 1\n# >>> same_chars(\"eabcd\", \"dddddddabc\")\n# \"\"\n# >>> same_chars(\"abcd\", \"dddddddabce\")\n# \"\"\n# >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n# \"\"\nsub same_chars {\n    my($s0, $s1) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&same_chars;\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dddddddabc\", \"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcd\", \"dddddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\", \"dddddddabcf\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\", \"aaccc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "pl",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nsub fib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fib;\n        if(eq_deeply($candidate->(10),55)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),89)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),144)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -2244,9 +1572,681 @@
     "language": "pl",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# \"\"\n# >>> correct_bracketing(\"<>\")\n# 1\n# >>> correct_bracketing(\"<<><>>\")\n# 1\n# >>> correct_bracketing(\"><<>\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"<>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<><>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<<><><>><>><<><><<>>>\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<><>>>>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<<<\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\">\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>><<>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"<><><<><>><>>><>\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "pl",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# 1\n# >>> monotonic([1, 20, 4, 10])\n# \"\"\n# >>> monotonic([4, 1, 0, -10])\n# 1\nsub monotonic {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&monotonic;\n        if(eq_deeply($candidate->([1, 2, 4, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 20]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 20, 4, 10]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 0, -10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 5, 60]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 60]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 9, 9, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "pl",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\nsub common {\n    my($l1, $l2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common;\n        if(eq_deeply($candidate->([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 3, 2, 8], [3, 2]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 8], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "pl",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nsub largest_prime_factor {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_prime_factor;\n        if(eq_deeply($candidate->(15),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(27),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(63),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(330),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13195),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "pl",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nsub intersperse {\n    my($numbers, $delimeter) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersperse;\n        if(eq_deeply($candidate->([], 7),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2], 2),[2, 2, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "pl",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsub sum_to_n {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_to_n;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),5050)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "pl",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# \"\"\n# >>> correct_bracketing(\"()\")\n# 1\n# >>> correct_bracketing(\"(()())\")\n# 1\n# >>> correct_bracketing(\")(()\")\n# \"\"\nsub correct_bracketing {\n    my($brackets) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&correct_bracketing;\n        if(eq_deeply($candidate->(\"()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()())\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()((()()())())(()()(()))\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((()())))\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"((((\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\")\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())())(()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"()()(()())()))()\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "pl",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nsub derivative {\n    my($xs) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&derivative;\n        if(eq_deeply($candidate->([3, 1, 2, 4, 5]),[1, 4, 12, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),[2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 0, 4]),[2, 2, 0, 16])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "pl",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nsub fibfib {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fibfib;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),24)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),274)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),927)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "pl",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nsub vowels_count {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&vowels_count;\n        if(eq_deeply($candidate->(\"abcde\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Alone\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"key\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bye\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"keY\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bYe\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ACEDY\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "pl",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\nsub circular_shift {\n    my($x, $shift) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&circular_shift;\n        if(eq_deeply($candidate->(100, 2),\"001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 2),\"12\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97, 8),\"79\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 1),\"21\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11, 101),\"11\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "pl",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum(\"\")\n# 0\n# >>> digitSum(\"abAB\")\n# 131\n# >>> digitSum(\"abcCd\")\n# 67\n# >>> digitSum(\"helloE\")\n# 69\n# >>> digitSum(\"woArBld\")\n# 131\n# >>> digitSum(\"aAaaaXa\")\n# 153\nsub digitSum {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digitSum;\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abAB\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcCd\"),67)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"helloE\"),69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"woArBld\"),131)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aAaaaXa\"),153)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" How are yOu?\"),151)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You arE Very Smart\"),327)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "pl",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n# 19\nsub fruit_distribution {\n    my($s, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&fruit_distribution;\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 19),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"5 apples and 6 oranges\", 21),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0 apples and 1 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 0 oranges\", 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 100),95)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2 apples and 3 oranges\", 5),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1 apples and 100 oranges\", 120),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "pl",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck([])\n# []\n# Example 4:\n# >>> pluck([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\nsub pluck {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pluck;\n        if(eq_deeply($candidate->([4, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 0, 3, 0, 4, 2]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 0, 5, 3]),[0, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 8, 4, 8]),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 6, 7, 1]),[6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 7, 1]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "pl",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search([5, 5, 4, 4, 4])\n# -1\nsub search {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([5, 5, 5, 5, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 4, 1, 4, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 3]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 8, 8, 8, 8, 8, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 3, 2, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 8, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 3, 6, 5, 6, 4]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 9, 10, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 10, 10, 9, 2]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "pl",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\nsub parse_nested_parens {\n    my($paren_string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parse_nested_parens;\n        if(eq_deeply($candidate->(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"() (()) ((())) (((())))\"),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(()(())((())))\"),[4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "pl",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list([])\n# []\nsub strange_sort_list {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&strange_sort_list;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 4, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 5, 5, 5]),[5, 5, 5, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([111111]),[111111])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "pl",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\nsub triangle_area {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(3, 4, 5),6.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8, 5),8.18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 2),1.73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5, 7),16.25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1, 1),0.43)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 2, 10),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "pl",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly([1, 2], 5)\n# \"\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly([3, 2, 3], 1)\n# \"\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly([3, 2, 3], 9)\n# 1\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly([3], 5)\n# 1\n# # 3 is less than the maximum possible weight, and it's balanced.\nsub will_it_fly {\n    my($q, $w) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&will_it_fly;\n        if(eq_deeply($candidate->([3, 2, 3], 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3], 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "pl",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change([1, 2, 3, 2, 1])\n# 0\nsub smallest_change {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_change;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 4, 7, 9, 6]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 4, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 1, 1, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "pl",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match([], [])\n# []\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\nsub total_match {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&total_match;\n        if(eq_deeply($candidate->([], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], [\"this\"]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"this\"], []),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "pl",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# 1\n# 30 = 2 * 3 * 5\nsub is_multiply_prime {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_multiply_prime;\n        if(eq_deeply($candidate->(5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(105),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(126),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(891),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1001),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "pl",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# 1\n# >>> is_simple_power(2, 2)\n# 1\n# >>> is_simple_power(8, 2)\n# 1\n# >>> is_simple_power(3, 2)\n# \"\"\n# >>> is_simple_power(3, 1)\n# \"\"\n# >>> is_simple_power(5, 3)\n# \"\"\nsub is_simple_power {\n    my($x, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_simple_power;\n        if(eq_deeply($candidate->(16, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(143214, 16),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(128, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "pl",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# 1\n# >>> iscube(2)\n# \"\"\n# >>> iscube(-1)\n# 1\n# >>> iscube(64)\n# 1\n# >>> iscube(0)\n# 1\n# >>> iscube(180)\n# \"\"\nsub iscube {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&iscube;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(64),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(180),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1000),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1729),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "pl",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key(\"AB\")\n# 1\n# >>> hex_key(\"1077E\")\n# 2\n# >>> hex_key(\"ABED1A33\")\n# 4\n# >>> hex_key(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key(\"2020\")\n# 2\nsub hex_key {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hex_key;\n        if(eq_deeply($candidate->(\"AB\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1077E\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABED1A33\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123456789ABCDEF0\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"112233445566778899AABBCCDDEEFF00\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# \"db1111db\"\n# >>> decimal_to_binary(32)\n# \"db100000db\"\nsub decimal_to_binary {\n    my($decimal) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(0),\"db0db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),\"db100000db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(103),\"db1100111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),\"db1111db\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "pl",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], \"a\")\n# []\n# >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\nsub filter_by_substring {\n    my($strings, $substring) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_by_substring;\n        if(eq_deeply($candidate->([], \"john\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "pl",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy(\"a\")\n# \"\"\n# >>> is_happy(\"aa\")\n# \"\"\n# >>> is_happy(\"abcd\")\n# 1\n# >>> is_happy(\"aabb\")\n# \"\"\n# >>> is_happy(\"adb\")\n# 1\n# >>> is_happy(\"xyy\")\n# \"\"\nsub is_happy {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_happy;\n        if(eq_deeply($candidate->(\"a\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabb\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"adb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyy\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxpoi\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"iopaxioi\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "pl",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nsub numerical_letter_grade {\n    my($grades) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&numerical_letter_grade;\n        if(eq_deeply($candidate->([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.2]),[\"D+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.5]),[\"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0]),[\"E\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0.0, 0.7]),[\"E\", \"D-\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length(\"Hello\")\n# 1\n# >>> prime_length(\"abcdcba\")\n# 1\n# >>> prime_length(\"kittens\")\n# 1\n# >>> prime_length(\"orange\")\n# \"\"\nsub prime_length {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_length;\n        if(eq_deeply($candidate->(\"Hello\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdcba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"kittens\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"orange\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"world\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"MadaM\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Wow\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"HI\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"go\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gogo\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaaaaaaaaaaaaaa\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Madam\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"M\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "pl",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nsub starts_one_ends {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&starts_one_ends;\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),18000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "pl",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# \"1\"\n# >>> solve(150)\n# \"110\"\n# >>> solve(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsub solve {\n    my($N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&solve;\n        if(eq_deeply($candidate->(1000),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(150),\"110\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(147),\"1100\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(333),\"1001\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(963),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "pl",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add([4, 2, 6, 7])\n# 2\nsub add {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add;\n        if(eq_deeply($candidate->([4, 88]),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 2, 122]),122)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 0, 6, 7]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 4, 6, 8]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "pl",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\nsub anti_shuffle {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&anti_shuffle;\n        if(eq_deeply($candidate->(\"Hi\"),\"Hi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hello\"),\"ehllo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"number\"),\"bemnru\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"abcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hello World!!!\"),\"Hello !!!Wdlor\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "pl",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row([], 1)\n# []\n# >>> get_row([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\nsub get_row {\n    my($lst, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_row;\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([], 1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1]], 2),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[], [1], [1, 2, 3]], 3),[[2, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "pl",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array([])\n# []\n# >>> sort_array([5])\n# [5]\n# >>> sort_array([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\nsub sort_array {\n    my($array) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_array;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5]),[5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1]),[1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 14, 23, 11]),[23, 21, 14, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "pl",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt(\"hi\")\n# \"lm\"\n# >>> encrypt(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt(\"gf\")\n# \"kj\"\n# >>> encrypt(\"et\")\n# \"ix\"\nsub encrypt {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encrypt;\n        if(eq_deeply($candidate->(\"hi\"),\"lm\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asdfghjkl\"),\"ewhjklnop\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gf\"),\"kj\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"et\"),\"ix\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"faewfawefaewg\"),\"jeiajeaijeiak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"hellomyfriend\"),\"lippsqcjvmirh\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"e\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "pl",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# [0, 1]\n# >>> sum_product([1, 2, 3, 4])\n# [10, 24]\nsub sum_product {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_product;\n        if(eq_deeply($candidate->([]),[0, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1]),[3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 0]),[100, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 5, 7]),[15, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10]),[10, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest([])\n# undef\n# >>> next_smallest([1, 1])\n# undef\nsub next_smallest {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 4, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1, 0]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-35, 34, 12, -45]),-35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "pl",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nsub is_bored {\n    my($S) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_bored;\n        if(eq_deeply($candidate->(\"Hello world\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Is the sky blue?\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love It !\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"bIt\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I feel good today. I will be productive. will kill It\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"You and I are going for a walk\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "pl",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# 1\n# >>> any_int(3, 2, 2)\n# \"\"\n# >>> any_int(3, -2, 1)\n# 1\n# >>> any_int(3.6, -2.2, 2)\n# \"\"\nsub any_int {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&any_int;\n        if(eq_deeply($candidate->(2, 3, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.5, 2, 3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1.5, 5, 3.5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 6, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2.2, 2.2, 2.2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-4, 6, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4, 7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3.0, 4, 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "pl",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode(\"test\")\n# \"TGST\"\n# >>> encode(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\nsub encode {\n    my($message) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&encode;\n        if(eq_deeply($candidate->(\"TEST\"),\"tgst\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Mudasir\"),\"mWDCSKR\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"YES\"),\"ygs\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"This is a message\"),\"tHKS KS C MGSSCGG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "pl",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n# 7\nsub skjkasdkd {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&skjkasdkd;\n        if(eq_deeply($candidate->([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 81, 12, 3, 1, 21]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 8, 1, 2, 1, 7]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8191, 123456, 127, 7]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([127, 97, 8192]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "pl",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case({\"a\" => \"apple\", \"b\" => \"banana\"})\n# 1\n# >>> check_dict_case({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# \"\"\n# >>> check_dict_case({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# \"\"\n# >>> check_dict_case({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# \"\"\n# >>> check_dict_case({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# 1\nsub check_dict_case {\n    my($dict) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_dict_case;\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"b\" => \"banana\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({}),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "pl",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# [2, 3]\n# >>> count_up_to(11)\n# [2, 3, 5, 7]\n# >>> count_up_to(0)\n# []\n# >>> count_up_to(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to(1)\n# []\n# >>> count_up_to(18)\n# [2, 3, 5, 7, 11, 13, 17]\nsub count_up_to {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_up_to;\n        if(eq_deeply($candidate->(5),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[2, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),[2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(22),[2, 3, 5, 7, 11, 13, 17, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),[2, 3, 5, 7, 11, 13, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "pl",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nsub multiply {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply;\n        if(eq_deeply($candidate->(148, 412),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 28),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2020, 1851),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14, -15),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(76, 67),42)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 27),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "pl",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper(\"aBCdEf\")\n# 1\n# >>> count_upper(\"abcdefg\")\n# 0\n# >>> count_upper(\"dBBE\")\n# 0\nsub count_upper {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_upper;\n        if(eq_deeply($candidate->(\"aBCdEf\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcdefg\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dBBE\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"B\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"U\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"EEEE\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "pl",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nsub closest_integer {\n    my($value) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_integer;\n        if(eq_deeply($candidate->(\"10\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"14.5\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"-15.5\"),-16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.3\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"0\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "pl",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nsub rolling_max {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rolling_max;\n        if(eq_deeply($candidate->([]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),[1, 2, 3, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 1]),[4, 4, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/humaneval-py-keep.json
+++ b/prompts/humaneval-py-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "py",
-    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "py",
-    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "py",
-    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "py",
-    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    rounded_avg(1, 5) => \"0b11\"\n    rounded_avg(7, 5) => -1\n    rounded_avg(10, 20) => \"0b1111\"\n    rounded_avg(20, 33) => \"0b11010\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "py",
-    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "py",
-    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "py",
-    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "py",
-    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "py",
-    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "py",
-    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "py",
-    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "py",
-    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef reverse_delete(s: str, c: str) -> Tuple[str, bool]:\n    \"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcde', 'ae') == ('bcd', False)\n    assert candidate('abcdef', 'b') == ('acdef', False)\n    assert candidate('abcdedcba', 'ab') == ('cdedc', True)\n    assert candidate('dwik', 'w') == ('dik', False)\n    assert candidate('a', 'a') == ('', True)\n    assert candidate('abcdedcba', '') == ('abcdedcba', True)\n    assert candidate('abcdedcba', 'v') == ('abcdedcba', True)\n    assert candidate('vabba', 'v') == ('abba', True)\n    assert candidate('mamma', 'mia') == ('', True)\n\ndef test_check():\n    check(reverse_delete)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "py",
-    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "py",
-    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "py",
-    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "py",
-    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "py",
-    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "py",
-    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "py",
-    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "py",
-    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "py",
-    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "py",
-    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "py",
-    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    compare_one(1, 2.5) \u279e 2.5\n    compare_one(1, \"2,3\") \u279e \"2,3\"\n    compare_one(\"5,1\", \"6\") \u279e \"6\"\n    compare_one(\"1\", 1) \u279e None\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "py",
-    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "py",
-    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "py",
-    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "py",
-    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "py",
-    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "py",
-    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_even(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]\n    assert candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]\n\ndef test_check():\n    check(sort_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "py",
-    "prompt": "def same_chars(s0: str, s1: str) -> bool:\n    \"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddeddabc') == True\n    assert candidate('abcd', 'dddddddabc') == True\n    assert candidate('dddddddabc', 'abcd') == True\n    assert candidate('eabcd', 'dddddddabc') == False\n    assert candidate('abcd', 'dddddddabcf') == False\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddddabc') == False\n    assert candidate('aabb', 'aaccc') == False\n\ndef test_check():\n    check(same_chars)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "py",
-    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "py",
-    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "py",
-    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n\ndef test_check():\n    check(has_close_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1264,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef make_a_pile(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(3) == [3, 5, 7]\n    assert candidate(4) == [4, 6, 8, 10]\n    assert candidate(5) == [5, 7, 9, 11, 13]\n    assert candidate(6) == [6, 8, 10, 12, 14, 16]\n    assert candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22]\n\ndef test_check():\n    check(make_a_pile)\n\ntest_check()\n",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "py",
-    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "py",
-    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "py",
-    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "py",
-    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "py",
-    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "py",
-    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "py",
-    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "py",
-    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "py",
-    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_array(arr: List[int]) -> List[int]:\n    \"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5]\n    assert candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3]\n    assert candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3]\n    assert candidate([]) == []\n    assert candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]\n    assert candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "py",
-    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "py",
-    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "py",
-    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "py",
-    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "py",
-    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "py",
-    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "py",
-    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n        Input: 3\n        Output: (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n        Input: 12\n        Output: (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "py",
-    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "py",
-    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "py",
-    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef specialFilter(nums: List[int]) -> int:\n    \"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, -2, 1, -5]) == 0\n    assert candidate([15, -73, 14, -15]) == 1\n    assert candidate([33, -2, -3, 45, 21, 109]) == 2\n    assert candidate([43, -12, 93, 125, 121, 109]) == 4\n    assert candidate([71, -2, -33, 75, 21, 19]) == 3\n    assert candidate([1]) == 0\n    assert candidate([]) == 0\n\ndef test_check():\n    check(specialFilter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "py",
-    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "py",
-    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "py",
-    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([]) == 0\n    >>> count_nums([-1, 11, -11]) == 1\n    >>> count_nums([1, 1, 2]) == 3\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    [1, 2, 3]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "py",
-    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "py",
-    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "py",
-    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"abcdef\") == 3 \n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "py",
-    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "py",
-    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n\ndef test_check():\n    check(has_close_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "py",
-    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "py",
-    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "py",
-    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "py",
-    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "py",
-    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('<>') == True\n    assert candidate('<<><>>') == True\n    assert candidate('<><><<><>><>') == True\n    assert candidate('<><><<<><><>><>><<><><<>>>') == True\n    assert candidate('<<<><>>>>') == False\n    assert candidate('><<>') == False\n    assert candidate('<') == False\n    assert candidate('<<<<') == False\n    assert candidate('>') == False\n    assert candidate('<<>') == False\n    assert candidate('<><><<><>><>><<>') == False\n    assert candidate('<><><<><>><>>><>') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "py",
-    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4]) == -9\n    >>> prod_signs([0, 1]) == 0\n    >>> prod_signs([]) == None\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2359,7 +49,7 @@
     "language": "py",
     "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    choose_num(12, 15) = 14\n    choose_num(13, 12) = -1\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "py",
-    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
+    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    rounded_avg(1, 5) => \"0b11\"\n    rounded_avg(7, 5) => -1\n    rounded_avg(10, 20) => \"0b1111\"\n    rounded_avg(20, 33) => \"0b11010\"\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n      arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n            -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n            -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n      return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    \n      If the array is empty, return an empty array:\n      arr = []\n      return []\n    \n      If the array has any strange number ignore it:\n      arr = [1, -1 , 55] \n            -> sort arr -> [-1, 1, 55]\n            -> reverse arr -> [55, 1, -1]\n      return = ['One']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    f(5) == [1, 2, 6, 24, 15]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n        Input: 3\n        Output: (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n        Input: 12\n        Output: (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([]) == 0\n    >>> count_nums([-1, 11, -11]) == 1\n    >>> count_nums([1, 1, 2]) == 3\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    move_one_ball([3, 4, 5, 1, 2])==>True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    move_one_ball([3, 5, 4, 1, 2])==>False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "py",
+    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    histogram('a b b a') == {'a': 2, 'b': 2}\n    histogram('a b c a b') == {'a': 2, 'b': 2}\n    histogram('b b b b a') == {'b': 4}\n    histogram('') == {}\n\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef reverse_delete(s: str, c: str) -> Tuple[str, bool]:\n    \"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcde', 'ae') == ('bcd', False)\n    assert candidate('abcdef', 'b') == ('acdef', False)\n    assert candidate('abcdedcba', 'ab') == ('cdedc', True)\n    assert candidate('dwik', 'w') == ('dik', False)\n    assert candidate('a', 'a') == ('', True)\n    assert candidate('abcdedcba', '') == ('abcdedcba', True)\n    assert candidate('abcdedcba', 'v') == ('abcdedcba', True)\n    assert candidate('vabba', 'v') == ('abba', True)\n    assert candidate('mamma', 'mia') == ('', True)\n\ndef test_check():\n    check(reverse_delete)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    >>> odd_count(['3',\"11111111\"])\n    [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n     \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    minSubArraySum([-1, -2, -3]) == -6\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n        Input: \n            grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n            bucket_capacity : 1\n        Output: 6\n\n    Example 2:\n        Input: \n            grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n            bucket_capacity : 2\n        Output: 5\n    \n    Example 3:\n        Input: \n            grid : [[0,0,0], [0,0,0]]\n            bucket_capacity : 5\n        Output: 0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_array(arr: List[int]) -> List[int]:\n    \"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5]\n    assert candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3]\n    assert candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3]\n    assert candidate([]) == []\n    assert candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]\n    assert candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    select_words(\"simple white space\", 2) ==> []\n    select_words(\"Hello world\", 4) ==> [\"world\"]\n    select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "py",
+    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    get_closest_vowel(\"yogurt\") ==> \"u\"\n    get_closest_vowel(\"FULL\") ==> \"U\"\n    get_closest_vowel(\"quick\") ==> \"\"\n    get_closest_vowel(\"ab\") ==> \"\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    match_parens(['()(', ')']) == 'Yes'\n    match_parens([')', ')']) == 'No'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "py",
+    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n        Input: arr = [-3, -4, 5], k = 3\n        Output: [-4, -3, 5]\n\n    Example 2:\n\n        Input: arr = [4, -4, 4], k = 2\n        Output: [4, 4]\n\n    Example 3:\n\n        Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n        Output: [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    solution([5, 8, 7, 1]) ==> 12\n    solution([3, 3, 3, 3, 3]) ==> 9\n    solution([30, 13, 24, 321]) ==>0\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n        Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n        Output: 24 # sum of 21 + 3\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "py",
+    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    for example: \n    valid_date('03-11-2000') => True\n\n    valid_date('15-01-2012') => False\n\n    valid_date('04-0-2040') => False\n\n    valid_date('06-04-2020') => True\n\n    valid_date('06/04/2020') => False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "py",
+    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    split_words(\"abcdef\") == 3 \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    is_sorted([5]) \u279e True\n    is_sorted([1, 2, 3, 4, 5]) \u279e True\n    is_sorted([1, 3, 2, 4, 5]) \u279e False\n    is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    intersection((1, 2), (2, 3)) ==> \"NO\"\n    intersection((-1, 1), (0, 4)) ==> \"NO\"\n    intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4]) == -9\n    >>> prod_signs([0, 1]) == 0\n    >>> prod_signs([]) == None\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:\n\n        Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n        Output: [1, 2, 1]\n\n        Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n        Output: [1]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    tri(3) = [1, 3, 2, 8]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "py",
+    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    digits(1)  == 1\n    digits(4)  == 0\n    digits(235) == 15\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "py",
+    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    is_nested('[[]]') \u279e True\n    is_nested('[]]]]]]][[[[[]') \u279e False\n    is_nested('[][]') \u279e False\n    is_nested('[]') \u279e False\n    is_nested('[[][]]') \u279e True\n    is_nested('[[]][[') \u279e True\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    For lst = [1,2,3] the output should be 14\n    For lst = [1,4,9] the output should be 98\n    For lst = [1,3,5,7] the output should be 84\n    For lst = [1.4,4.2,0] the output should be 29\n    For lst = [-2.4,1,1] the output should be 6\n    \n\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "py",
+    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    check_if_last_char_is_a_letter(\"\") \u279e False \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    can_arrange([1,2,4,3,5]) = 3\n    can_arrange([1,2,3]) = -1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    largest_smallest_integers([]) == (None, None)\n    largest_smallest_integers([0]) == (None, None)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "py",
+    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    compare_one(1, 2.5) \u279e 2.5\n    compare_one(1, \"2,3\") \u279e \"2,3\"\n    compare_one(\"5,1\", \"6\") \u279e \"6\"\n    compare_one(\"1\", 1) \u279e None\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "py",
+    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    is_equal_to_sum_even(4) == False\n    is_equal_to_sum_even(6) == False\n    is_equal_to_sum_even(8) == True\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "py",
+    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "py",
+    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "py",
+    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    fix_spaces(\"Example\") == \"Example\"\n    fix_spaces(\"Example 1\") == \"Example_1\"\n    fix_spaces(\" Example 2\") == \"_Example_2\"\n    fix_spaces(\" Example   3\") == \"_Example-3\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "py",
+    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    file_name_check(\"example.txt\") # => 'Yes'\n    file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    For lst = [1,2,3] the output should be 6\n    For lst = []  the output should be 0\n    For lst = [-1,-5,2,-1,-5]  the output should be -126\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "py",
+    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n        Input: sentence = \"This is a test\"\n        Output: \"is\"\n\n    Example 2:\n        Input: sentence = \"lets go for swimming\"\n        Output: \"go for\"\n\n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "py",
+    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    simplify(\"1/5\", \"5/1\") = True\n    simplify(\"1/6\", \"2/1\") = False\n    simplify(\"7/10\", \"10/2\") = False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    >>> order_by_points([]) == []\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef specialFilter(nums: List[int]) -> int:\n    \"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    specialFilter([15, -73, 14, -15]) => 1 \n    specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, -2, 1, -5]) == 0\n    assert candidate([15, -73, 14, -15]) == 1\n    assert candidate([33, -2, -3, 45, 21, 109]) == 2\n    assert candidate([43, -12, 93, 125, 121, 109]) == 4\n    assert candidate([71, -2, -33, 75, 21, 19]) == 3\n    assert candidate([1]) == 0\n    assert candidate([]) == 0\n\ndef test_check():\n    check(specialFilter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "py",
+    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n        Input: n = 5\n        Output: 1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "py",
+    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    for x_or_y(7, 34, 12) == 34\n    for x_or_y(15, 8, 5) == 5\n    \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    double_the_difference([-1, -2, 0]) == 0\n    double_the_difference([9, -2]) == 81\n    double_the_difference([0]) == 0  \n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "py",
+    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    cycpattern_check(\"abcd\",\"abd\") => False\n    cycpattern_check(\"hello\",\"ell\") => True\n    cycpattern_check(\"whassup\",\"psus\") => False\n    cycpattern_check(\"abab\",\"baa\") => True\n    cycpattern_check(\"efef\",\"eeff\") => False\n    cycpattern_check(\"himenss\",\"simen\") => True\n\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n        even_odd_count(-12) ==> (1, 1)\n        even_odd_count(123) ==> (1, 2)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "py",
+    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19) == 'xix'\n    >>> int_to_mini_roman(152) == 'clii'\n    >>> int_to_mini_roman(426) == 'cdxxvi'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "py",
+    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    right_angle_triangle(3, 4, 5) == True\n    right_angle_triangle(1, 2, 3) == False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    * eat(5, 6, 10) -> [11, 4]\n    * eat(4, 8, 9) -> [12, 1]\n    * eat(1, 10, 10) -> [11, 0]\n    * eat(2, 11, 5) -> [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "py",
+    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "py",
+    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    solve(\"1234\") = \"4321\"\n    solve(\"ab\") = \"AB\"\n    solve(\"#a@C\") = \"#A@c\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2389,7 +1054,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef generate_integers(a: int, b: int) -> List[int]:\n    \"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    generate_integers(2, 8) => [2, 4, 6, 8]\n    generate_integers(8, 2) => [2, 4, 6, 8]\n    generate_integers(10, 14) => []\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(2, 10) == [2, 4, 6, 8]\n    assert candidate(10, 2) == [2, 4, 6, 8]\n    assert candidate(132, 2) == [2, 4, 6, 8]\n    assert candidate(17, 89) == []\n\ndef test_check():\n    check(generate_integers)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "py",
     "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "py",
+    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "py",
+    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    [1, 2, 3]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "py",
+    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "py",
+    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "py",
+    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "py",
+    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "py",
+    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "py",
+    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_even(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]\n    assert candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]\n\ndef test_check():\n    check(sort_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "py",
+    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "py",
+    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "py",
+    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "py",
+    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "py",
+    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "py",
+    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "py",
+    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "py",
+    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "py",
+    "prompt": "def same_chars(s0: str, s1: str) -> bool:\n    \"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddeddabc') == True\n    assert candidate('abcd', 'dddddddabc') == True\n    assert candidate('dddddddabc', 'abcd') == True\n    assert candidate('eabcd', 'dddddddabc') == False\n    assert candidate('abcd', 'dddddddabcf') == False\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddddabc') == False\n    assert candidate('aabb', 'aaccc') == False\n\ndef test_check():\n    check(same_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "py",
+    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "py",
+    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"<\")\n    False\n    >>> correct_bracketing(\"<>\")\n    True\n    >>> correct_bracketing(\"<<><>>\")\n    True\n    >>> correct_bracketing(\"><<>\")\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('<>') == True\n    assert candidate('<<><>>') == True\n    assert candidate('<><><<><>><>') == True\n    assert candidate('<><><<<><><>><>><<><><<>>>') == True\n    assert candidate('<<<><>>>>') == False\n    assert candidate('><<>') == False\n    assert candidate('<') == False\n    assert candidate('<<<<') == False\n    assert candidate('>') == False\n    assert candidate('<<>') == False\n    assert candidate('<><><<><>><>><<>') == False\n    assert candidate('<><><<><>><>>><>') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "py",
+    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "py",
+    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "py",
+    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing(\"(\")\n    False\n    >>> correct_bracketing(\"()\")\n    True\n    >>> correct_bracketing(\"(()())\")\n    True\n    >>> correct_bracketing(\")(()\")\n    False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "py",
+    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "py",
+    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count(\"abcde\")\n    2\n    >>> vowels_count(\"ACEDY\")\n    3\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "py",
+    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    \"21\"\n    >>> circular_shift(12, 2)\n    \"12\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "py",
+    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n        digitSum(\"\") => 0\n        digitSum(\"abAB\") => 131\n        digitSum(\"abcCd\") => 67\n        digitSum(\"helloE\") => 69\n        digitSum(\"woArBld\") => 131\n        digitSum(\"aAaaaXa\") => 153\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "py",
+    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Input: [4,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Input: [1,2,3]\n        Output: [2, 1]\n        Explanation: 2 has the smallest even value, and 2 has the smallest index. \n\n    Example 3:\n        Input: []\n        Output: []\n    \n    Example 4:\n        Input: [5, 0, 3, 0, 4, 2]\n        Output: [0, 1]\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                     so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n        search([4, 1, 2, 2, 3, 1]) == 2\n        search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n        search([5, 5, 4, 4, 4]) == -1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    strange_sort_list([]) == []\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    triangle_area(3, 4, 5) == 6.00\n    triangle_area(1, 2, 10) == -1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    will_it_fly([1, 2], 5) \u279e False \n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    will_it_fly([3, 2, 3], 1) \u279e False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    will_it_fly([3, 2, 3], 9) \u279e True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    will_it_fly([3], 5) \u279e True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    smallest_change([1,2,3,5,4,7,9,6]) == 4\n    smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    smallest_change([1, 2, 3, 2, 1]) == 0\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    total_match([], []) \u279e []\n    total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "py",
+    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    is_multiply_prime(30) == True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "py",
+    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    is_simple_power(1, 4) => true\n    is_simple_power(2, 2) => true\n    is_simple_power(8, 2) => true\n    is_simple_power(3, 2) => false\n    is_simple_power(3, 1) => false\n    is_simple_power(5, 3) => false\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "py",
+    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    iscube(1) ==> True\n    iscube(2) ==> False\n    iscube(-1) ==> True\n    iscube(64) ==> True\n    iscube(0) ==> True\n    iscube(180) ==> False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "py",
+    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    For num = \"AB\" the output should be 1.\n    For num = \"1077E\" the output should be 2.\n    For num = \"ABED1A33\" the output should be 4.\n    For num = \"123456789ABCDEF0\" the output should be 6.\n    For num = \"2020\" the output should be 2.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    decimal_to_binary(15)   # returns \"db1111db\"\n    decimal_to_binary(32)   # returns \"db100000db\"\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "py",
+    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    is_happy(a) => False\n    is_happy(aa) => False\n    is_happy(abcd) => True\n    is_happy(aabb) => False\n    is_happy(adb) => True\n    is_happy(xyy) => False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "py",
+    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    prime_length('Hello') == True\n    prime_length('abcdcba') == True\n    prime_length('kittens') == True\n    prime_length('orange') == False\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "py",
+    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "py",
+    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n        For N = 1000, the sum of digits will be 1 the output should be \"1\".\n        For N = 150, the sum of digits will be 6 the output should be \"110\".\n        For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        add([4, 2, 6, 7]) ==> 2 \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "py",
+    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    anti_shuffle('Hi') returns 'Hi'\n    anti_shuffle('hello') returns 'ehllo'\n    anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    get_row([\n      [1,2,3,4,5,6],\n      [1,2,3,4,1,6],\n      [1,2,3,4,5,1]\n    ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    get_row([], 1) == []\n    get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    * sort_array([]) => []\n    * sort_array([5]) => [5]\n    * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "py",
+    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    encrypt('hi') returns 'lm'\n    encrypt('asdfghjkl') returns 'ewhjklnop'\n    encrypt('gf') returns 'kj'\n    encrypt('et') returns 'ix'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    \n    next_smallest([1, 2, 3, 4, 5]) == 2\n    next_smallest([5, 1, 4, 3, 2]) == 2\n    next_smallest([]) == None\n    next_smallest([1, 1]) == None\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "py",
+    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored(\"Hello world\")\n    0\n    >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    1\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "py",
+    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    any_int(5, 2, 7) \u279e True\n    \n    any_int(3, 2, 2) \u279e False\n\n    any_int(3, -2, 1) \u279e True\n    \n    any_int(3.6, -2.2, 2) \u279e False\n  \n\n    \n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "py",
+    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    For lst = [0,81,12,3,1,21] the output should be 3\n    For lst = [0,8,1,2,1,7] the output should be 7\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    count_up_to(5) => [2,3]\n    count_up_to(11) => [2,3,5,7]\n    count_up_to(0) => []\n    count_up_to(20) => [2,3,5,7,11,13,17,19]\n    count_up_to(1) => []\n    count_up_to(18) => [2,3,5,7,11,13,17]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "py",
+    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    multiply(148, 412) should return 16.\n    multiply(19, 28) should return 72.\n    multiply(2020, 1851) should return 0.\n    multiply(14,-15) should return 20.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "py",
+    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    count_upper('aBCdEf') returns 1\n    count_upper('abcdefg') returns 0\n    count_upper('dBBE') returns 0\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "py",
+    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer(\"10\")\n    10\n    >>> closest_integer(\"15.3\")\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/humaneval-py-remove.json
+++ b/prompts/humaneval-py-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "py",
-    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "py",
-    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "py",
-    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "py",
-    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "py",
-    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "py",
-    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n        \n      If the array is empty, return an empty array:\n        \n      If the array has any strange number ignore it:\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "py",
-    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "py",
-    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "py",
-    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "py",
-    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "py",
-    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "py",
-    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "py",
-    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "py",
-    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "py",
-    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "py",
-    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "py",
-    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "py",
-    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "py",
-    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "py",
-    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "py",
-    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "py",
-    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "py",
     "prompt": "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n\ndef test_check():\n    check(has_close_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "py",
-    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "py",
-    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "py",
-    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "py",
-    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "py",
-    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "py",
-    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "py",
-    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "py",
-    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "py",
-    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "py",
-    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "py",
-    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "py",
-    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "py",
-    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "py",
-    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "py",
-    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "py",
-    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "py",
-    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "py",
-    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "py",
-    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "py",
-    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "py",
-    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n                                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "py",
-    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "py",
-    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "py",
-    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "py",
-    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "py",
-    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "py",
-    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "py",
-    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1714,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef make_a_pile(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(3) == [3, 5, 7]\n    assert candidate(4) == [4, 6, 8, 10]\n    assert candidate(5) == [5, 7, 9, 11, 13]\n    assert candidate(6) == [6, 8, 10, 12, 14, 16]\n    assert candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22]\n\ndef test_check():\n    check(make_a_pile)\n\ntest_check()\n",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "py",
-    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \"\"\"\n",
+    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "py",
-    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \"\"\"\n",
+    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n                    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "py",
-    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "py",
-    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n        \n      If the array is empty, return an empty array:\n        \n      If the array has any strange number ignore it:\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n            \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n            Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "py",
-    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "py",
-    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n        Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n        Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \"\"\"\n",
+    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "py",
-    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \"\"\"\n",
+    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n            It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "py",
-    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n        \"\"\"\n",
+    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n                    \n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "py",
-    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n        \n    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "py",
-    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "py",
-    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \"\"\"\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1984,7 +214,7 @@
     "language": "py",
     "prompt": "from typing import Tuple\n\ndef reverse_delete(s: str, c: str) -> Tuple[str, bool]:\n    \"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('abcde', 'ae') == ('bcd', False)\n    assert candidate('abcdef', 'b') == ('acdef', False)\n    assert candidate('abcdedcba', 'ab') == ('cdedc', True)\n    assert candidate('dwik', 'w') == ('dik', False)\n    assert candidate('a', 'a') == ('', True)\n    assert candidate('abcdedcba', '') == ('abcdedcba', True)\n    assert candidate('abcdedcba', 'v') == ('abcdedcba', True)\n    assert candidate('vabba', 'v') == ('abba', True)\n    assert candidate('mamma', 'mia') == ('', True)\n\ndef test_check():\n    check(reverse_delete)\n\ntest_check()\n",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "py",
-    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "py",
-    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    \n    Example 2:\n        \n    Example 3:\n    \n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2029,7 +274,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_array(arr: List[int]) -> List[int]:\n    \"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5]\n    assert candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3]\n    assert candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3]\n    assert candidate([]) == []\n    assert candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]\n    assert candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n                        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \"\"\"\n",
+    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n                    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "py",
-    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "py",
-    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    \n    Example 2:\n\n    \n    Example 3:\n\n    \n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "py",
-    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \"\"\"\n",
+    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    \n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "py",
-    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \"\"\"\n",
+    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "py",
-    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \"\"\"\n",
+    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    \n    \n    \n    \n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \"\"\"\n",
+    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "py",
-    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n                                    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    \n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "py",
+    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "py",
+    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n                        \n\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "py",
+    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "py",
+    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "py",
+    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "py",
+    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    \n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "py",
+    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "py",
+    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "py",
+    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "py",
+    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    \n    Example 2:\n        \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "py",
+    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2209,7 +769,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef specialFilter(nums: List[int]) -> int:\n    \"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([5, -2, 1, -5]) == 0\n    assert candidate([15, -73, 14, -15]) == 1\n    assert candidate([33, -2, -3, 45, 21, 109]) == 2\n    assert candidate([43, -12, 93, 125, 121, 109]) == 4\n    assert candidate([71, -2, -33, 75, 21, 19]) == 3\n    assert candidate([1]) == 0\n    assert candidate([]) == 0\n\ndef test_check():\n    check(specialFilter)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "py",
-    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n                        \"\"\"\n",
+    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n            Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "py",
-    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "py",
+    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n            \n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n                   \n    If the input list is empty, return 0.\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "py",
+    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n                        \n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "py",
+    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "py",
+    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n                    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "py",
+    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "py",
+    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2254,7 +1039,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef generate_integers(a: int, b: int) -> List[int]:\n    \"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(2, 10) == [2, 4, 6, 8]\n    assert candidate(10, 2) == [2, 4, 6, 8]\n    assert candidate(132, 2) == [2, 4, 6, 8]\n    assert candidate(17, 89) == []\n\ndef test_check():\n    check(generate_integers)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "py",
-    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \"\"\"\n",
+    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \"\"\"\n",
+    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "py",
-    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \"\"\"\n",
+    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n                \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "py",
-    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\n",
+    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n        \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "py",
+    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "py",
+    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "py",
+    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "py",
+    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "py",
+    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n                                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "py",
+    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2329,9 +1384,234 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_even(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]\n    assert candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]\n\ndef test_check():\n    check(sort_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "py",
+    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "py",
+    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "py",
+    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "py",
+    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "py",
+    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "py",
+    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "py",
+    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2344,9 +1624,24 @@
     "language": "py",
     "prompt": "def same_chars(s0: str, s1: str) -> bool:\n    \"\"\"\n    Check if two words have the same characters.\n                            \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddeddabc') == True\n    assert candidate('abcd', 'dddddddabc') == True\n    assert candidate('dddddddabc', 'abcd') == True\n    assert candidate('eabcd', 'dddddddabc') == False\n    assert candidate('abcd', 'dddddddabcf') == False\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddddabc') == False\n    assert candidate('aabb', 'aaccc') == False\n\ndef test_check():\n    check(same_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "py",
+    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2359,9 +1654,714 @@
     "language": "py",
     "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('<>') == True\n    assert candidate('<<><>>') == True\n    assert candidate('<><><<><>><>') == True\n    assert candidate('<><><<<><><>><>><<><><<>>>') == True\n    assert candidate('<<<><>>>>') == False\n    assert candidate('><<>') == False\n    assert candidate('<') == False\n    assert candidate('<<<<') == False\n    assert candidate('>') == False\n    assert candidate('<<>') == False\n    assert candidate('<><><<><>><>><<>') == False\n    assert candidate('<><><<><>><>>><>') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n        \n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "py",
+    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "py",
+    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "py",
+    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "py",
+    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "py",
+    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "py",
+    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "py",
+    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "py",
+    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n        Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n        \n    Example 4:\n        Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n        # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n        # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n        # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n        # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "py",
+    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n        30 = 2 * 3 * 5\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "py",
+    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "py",
+    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "py",
+    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "py",
+    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "py",
+    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "py",
+    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n                \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "py",
+    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "py",
+    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "py",
+    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "py",
+    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n        \n    \n        \n      \n\n    \n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "py",
+    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n                        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n                            \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "py",
+    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n                    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "py",
+    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n                \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "py",
+    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n        \n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n        \"\"\"\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/humaneval-py-reworded.json
+++ b/prompts/humaneval-py-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "py",
-    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "py",
-    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt('hi')\n    'lm'\n    >>> encrypt('asdfghjkl')\n    'ewhjklnop'\n    >>> encrypt('gf')\n    'kj'\n    >>> encrypt('et')\n    'ix'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case({ 'a': 'apple', 'b': 'banana' })\n    True\n    >>> check_dict_case({ 'a': 'apple', 'A': 'banana', 'B': 'banana' })\n    False\n    >>> check_dict_case({ 'a': 'apple', 8: 'banana', 'a': 'apple' })\n    False\n    >>> check_dict_case({ 'Name': 'John', 'Age': '36', 'City': 'Houston' })\n    False\n    >>> check_dict_case({ 'STATE': 'NC', 'ZIP': '12345' })\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "py",
-    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(' Example')\n    'Example'\n    >>> fix_spaces(' Example 1')\n    'Example_1'\n    >>> fix_spaces(' Example 2')\n    '_Example_2'\n    >>> fix_spaces(' Example 3')\n    '_Example-3'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "py",
-    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {  }, []])\n    [1, 2, 3]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "py",
-    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    'db1111db'\n    >>> decimal_to_binary(32)\n    'db100000db'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "py",
-    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "py",
-    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    ['One']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match(['hi', 'admin'], ['hI', 'Hi'])\n    ['hI', 'Hi']\n    >>> total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project'])\n    ['hi', 'admin']\n    >>> total_match(['hi', 'admin'], ['hI', 'hi', 'hi'])\n    ['hI', 'hi', 'hi']\n    >>> total_match(['4'], ['1', '2', '3', '4', '5'])\n    ['4']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "py",
-    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested('[[]]')\n    True\n    >>> is_nested('[]]]]]]][[[[[]')\n    False\n    >>> is_nested('[][]')\n    False\n    >>> is_nested('[]')\n    False\n    >>> is_nested('[[][]]')\n    True\n    >>> is_nested('[[]][[')\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    '0b11'\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    '0b1111'\n    >>> rounded_avg(20, 33)\n    '0b11010'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    >>> odd_count(['3', '11111111'])\n    ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "py",
-    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    False\n    >>> is_equal_to_sum_even(6)\n    False\n    >>> is_equal_to_sum_even(8)\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5])\n    False\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    False\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    True\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "py",
-    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve('1234')\n    '4321'\n    >>> solve('ab')\n    'AB'\n    >>> solve('#a@C')\n    '#A@c'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "py",
-    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "py",
-    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    '1'\n    >>> solve(150)\n    '110'\n    >>> solve(147)\n    '1100'\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "py",
-    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper('aBCdEf')\n    1\n    >>> count_upper('abcdefg')\n    0\n    >>> count_upper('dBBE')\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "py",
-    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "py",
-    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    True\n    >>> iscube(2)\n    False\n    >>> iscube(-1)\n    True\n    >>> iscube(64)\n    True\n    >>> iscube(0)\n    True\n    >>> iscube(180)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "py",
-    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "py",
-    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored('Hello world')\n    0\n    >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n    1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "py",
-    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    >>> bf('Jupiter', 'Neptune')\n    ('Saturn', 'Uranus')\n    >>> bf('Earth', 'Mercury')\n    'Venus'\n    >>> bf('Mercury', 'Uranus')\n    ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "py",
-    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string('Hi, my name is John')\n    ['Hi', 'my', 'name', 'is', 'John']\n    >>> words_string('One, two, three, four, five, six')\n    ['One', 'two', 'three', 'four', 'five', 'six']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "py",
-    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    >>> compare_one(1, 2.5)\n    2.5\n    >>> compare_one(1, '2,3')\n    '2,3'\n    >>> compare_one('5,1', '6')\n    '6'\n    >>> compare_one('1', 1)\n    None\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "py",
-    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "py",
-    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    True\n    >>> is_simple_power(2, 2)\n    True\n    >>> is_simple_power(8, 2)\n    True\n    >>> is_simple_power(3, 2)\n    False\n    >>> is_simple_power(3, 1)\n    False\n    >>> is_simple_power(5, 3)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "py",
-    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "py",
     "prompt": "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n\ndef test_check():\n    check(has_close_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "py",
-    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "py",
-    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "py",
-    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "py",
-    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words('Mary had a little lamb', 4)\n    ['little']\n    >>> select_words('Mary had a little lamb', 3)\n    ['Mary', 'lamb']\n    >>> select_words('simple white space', 2)\n    []\n    >>> select_words('Hello world', 4)\n    ['world']\n    >>> select_words('Uncle sam', 3)\n    ['Uncle']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    False\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "py",
-    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension('my_class', ['AA', 'Be', 'CC'])\n    'my_class.AA'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens(['()(', ')'])\n    'Yes'\n    >>> match_parens([')', ')'])\n    'No'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1, 1])\n    None\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "py",
-    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    True\n    \n    >>> any_int(3, 2, 2)\n    False\n\n    >>> any_int(3, -2, 1)\n    True\n    \n    >>> any_int(3.6, -2.2, 2)\n    False\n  \n\n    \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "py",
-    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "py",
-    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "py",
-    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "py",
-    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy('a')\n    False\n    >>> is_happy('aa')\n    False\n    >>> is_happy('abcd')\n    True\n    >>> is_happy('aabb')\n    False\n    >>> is_happy('adb')\n    True\n    >>> is_happy('xyy')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "py",
-    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "py",
-    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum('')\n    0\n    >>> digitSum('abAB')\n    131\n    >>> digitSum('abcCd')\n    67\n    >>> digitSum('helloE')\n    69\n    >>> digitSum('woArBld')\n    131\n    >>> digitSum('aAaaaXa')\n    153\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "py",
-    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    'YES'\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    'NO'\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "py",
-    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length('Hello')\n    True\n    >>> prime_length('abcdcba')\n    True\n    >>> prime_length('kittens')\n    True\n    >>> prime_length('orange')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "py",
-    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check('example.txt')\n    'Yes'\n    >>> file_name_check('1example.dll')\n    'No'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    'NO'\n    >>> intersection((-1, 1), (0, 4))\n    'NO'\n    >>> intersection((-3, -1), (-5, 5))\n    'YES'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "py",
-    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "py",
-    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter('apple pie')\n    False\n    >>> check_if_last_char_is_a_letter('apple pi e')\n    True\n    >>> check_if_last_char_is_a_letter('apple pi e ')\n    False\n    >>> check_if_last_char_is_a_letter('')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "py",
-    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date('03-11-2000')\n    True\n\n    >>> valid_date('15-01-2012')\n    False\n\n    >>> valid_date('04-0-2040')\n    False\n\n    >>> valid_date('06-04-2020')\n    True\n\n    >>> valid_date('06/04/2020')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "py",
-    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle('Hi')\n    'Hi'\n    >>> anti_shuffle('hello')\n    'ehllo'\n    >>> anti_shuffle('Hello World!!!')\n    'Hello !!!Wdlor'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "py",
-    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "py",
-    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel('yogurt')\n    'u'\n    >>> get_closest_vowel('FULL')\n    'U'\n    >>> get_closest_vowel('quick')\n    ''\n    >>> get_closest_vowel('ab')\n    ''\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "py",
-    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "py",
-    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify('1/5', '5/1')\n    True\n    >>> simplify('1/6', '2/1')\n    False\n    >>> simplify('7/10', '10/2')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "py",
-    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key('AB')\n    1\n    >>> hex_key('1077E')\n    2\n    >>> hex_key('ABED1A33')\n    4\n    >>> hex_key('123456789ABCDEF0')\n    6\n    >>> hex_key('2020')\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "py",
-    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence('This is a test')\n    'is'\n\n    Example 2:\n    >>> words_in_sentence('lets go for swimming')\n    'go for'\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram('a b c')\n    { 'a': 1, 'b': 1, 'c': 1 }\n    >>> histogram('a b b a')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('a b c a b')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('b b b b a')\n    { 'b': 4 }\n    >>> histogram('')\n    {  }\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "py",
-    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "py",
-    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    '21'\n    >>> circular_shift(12, 2)\n    '12'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "py",
-    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (None, 1)\n    >>> largest_smallest_integers([])\n    (None, None)\n    >>> largest_smallest_integers([0])\n    (None, None)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "py",
-    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1759,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef make_a_pile(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate(3) == [3, 5, 7]\n    assert candidate(4) == [4, 6, 8, 10]\n    assert candidate(5) == [5, 7, 9, 11, 13]\n    assert candidate(6) == [6, 8, 10, 12, 14, 16]\n    assert candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22]\n\ndef test_check():\n    check(make_a_pile)\n\ntest_check()\n",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    None\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string('Hi, my name is John')\n    ['Hi', 'my', 'name', 'is', 'John']\n    >>> words_string('One, two, three, four, five, six')\n    ['One', 'two', 'three', 'four', 'five', 'six']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "py",
-    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\n",
+    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "py",
-    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
+    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    '0b11'\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    '0b1111'\n    >>> rounded_avg(20, 33)\n    '0b11010'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "py",
-    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check('abcd', 'abd')\n    False\n    >>> cycpattern_check('hello', 'ell')\n    True\n    >>> cycpattern_check('whassup', 'psus')\n    False\n    >>> cycpattern_check('abab', 'baa')\n    True\n    >>> cycpattern_check('efef', 'eeff')\n    False\n    >>> cycpattern_check('himenss', 'simen')\n    True\n\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "py",
-    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    ['One']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "py",
-    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "py",
-    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
+    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "py",
-    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    'YES'\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    'NO'\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "py",
-    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
+    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram('a b c')\n    { 'a': 1, 'b': 1, 'c': 1 }\n    >>> histogram('a b b a')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('a b c a b')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('b b b b a')\n    { 'b': 4 }\n    >>> histogram('')\n    {  }\n\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "py",
-    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "py",
-    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    'xix'\n    >>> int_to_mini_roman(152)\n    'clii'\n    >>> int_to_mini_roman(426)\n    'cdxxvi'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "py",
-    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution('5 apples and 6 oranges', 19)\n    8\n    >>> fruit_distribution('0 apples and 1 oranges', 3)\n    2\n    >>> fruit_distribution('2 apples and 3 oranges', 100)\n    95\n    >>> fruit_distribution('100 apples and 1 oranges', 120)\n    19\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2029,7 +214,7 @@
     "language": "py",
     "prompt": "from typing import Tuple\n\ndef reverse_delete(s: str, c: str) -> Tuple[str, bool]:\n    \"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    >>> reverse_delete('abcde', 'ae')\n    ('bcd', False)\n    >>> reverse_delete('abcdef', 'b')\n    ('acdef', False)\n    >>> reverse_delete('abcdedcba', 'ab')\n    ('cdedc', True)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('abcde', 'ae') == ('bcd', False)\n    assert candidate('abcdef', 'b') == ('acdef', False)\n    assert candidate('abcdedcba', 'ab') == ('cdedc', True)\n    assert candidate('dwik', 'w') == ('dik', False)\n    assert candidate('a', 'a') == ('', True)\n    assert candidate('abcdedcba', '') == ('abcdedcba', True)\n    assert candidate('abcdedcba', 'v') == ('abcdedcba', True)\n    assert candidate('vabba', 'v') == ('abba', True)\n    assert candidate('mamma', 'mia') == ('', True)\n\ndef test_check():\n    check(reverse_delete)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "py",
-    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    >>> odd_count(['3', '11111111'])\n    ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "py",
-    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words('Hello world!')\n    ['Hello', 'world!']\n    >>> split_words('Hello,world!')\n    ['Hello', 'world!']\n    >>> split_words('abcdef')\n    3\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2074,7 +274,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_array(arr: List[int]) -> List[int]:\n    \"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4])\n    [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6])\n    [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4])\n    [0, 1, 2, 3, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5]\n    assert candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3]\n    assert candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3]\n    assert candidate([]) == []\n    assert candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]\n    assert candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words('Mary had a little lamb', 4)\n    ['little']\n    >>> select_words('Mary had a little lamb', 3)\n    ['Mary', 'lamb']\n    >>> select_words('simple white space', 2)\n    []\n    >>> select_words('Hello world', 4)\n    ['world']\n    >>> select_words('Uncle sam', 3)\n    ['Uncle']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort(['aa', 'a', 'aaa'])\n    ['aa']\n    >>> list_sort(['ab', 'a', 'aaa', 'cd'])\n    ['ab', 'cd']\n    \"\"\"\n",
+    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel('yogurt')\n    'u'\n    >>> get_closest_vowel('FULL')\n    'U'\n    >>> get_closest_vowel('quick')\n    ''\n    >>> get_closest_vowel('ab')\n    ''\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens(['()(', ')'])\n    'Yes'\n    >>> match_parens([')', ')'])\n    'No'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "py",
-    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer('10')\n    10\n    >>> closest_integer('15.3')\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "py",
-    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count('abcde')\n    2\n    >>> vowels_count('ACEDY')\n    3\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max(['name', 'of', 'string'])\n    'string'\n    >>> find_max(['name', 'enam', 'game'])\n    'enam'\n    >>> find_max(['aaaaaaa', 'bb', 'cc'])\n    'aaaaaaa'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "py",
-    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world')\n    '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "py",
-    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "py",
-    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    True\n    >>> right_angle_triangle(1, 2, 3)\n    False\n    \"\"\"\n",
+    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date('03-11-2000')\n    True\n\n    >>> valid_date('15-01-2012')\n    False\n\n    >>> valid_date('04-0-2040')\n    False\n\n    >>> valid_date('06-04-2020')\n    True\n\n    >>> valid_date('06/04/2020')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
+    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words('Hello world!')\n    ['Hello', 'world!']\n    >>> split_words('Hello,world!')\n    ['Hello', 'world!']\n    >>> split_words('abcdef')\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "py",
-    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5])\n    False\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    False\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    True\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    'NO'\n    >>> intersection((-1, 1), (0, 4))\n    'NO'\n    >>> intersection((-3, -1), (-5, 5))\n    'YES'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "py",
+    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "py",
+    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested('[[]]')\n    True\n    >>> is_nested('[]]]]]]][[[[[]')\n    False\n    >>> is_nested('[][]')\n    False\n    >>> is_nested('[]')\n    False\n    >>> is_nested('[[][]]')\n    True\n    >>> is_nested('[[]][[')\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "py",
+    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter('apple pie')\n    False\n    >>> check_if_last_char_is_a_letter('apple pi e')\n    True\n    >>> check_if_last_char_is_a_letter('apple pi e ')\n    False\n    >>> check_if_last_char_is_a_letter('')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (None, 1)\n    >>> largest_smallest_integers([])\n    (None, None)\n    >>> largest_smallest_integers([0])\n    (None, None)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "py",
+    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    >>> compare_one(1, 2.5)\n    2.5\n    >>> compare_one(1, '2,3')\n    '2,3'\n    >>> compare_one('5,1', '6')\n    '6'\n    >>> compare_one('1', 1)\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "py",
+    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    False\n    >>> is_equal_to_sum_even(6)\n    False\n    >>> is_equal_to_sum_even(8)\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "py",
+    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "py",
+    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "py",
+    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(' Example')\n    'Example'\n    >>> fix_spaces(' Example 1')\n    'Example_1'\n    >>> fix_spaces(' Example 2')\n    '_Example_2'\n    >>> fix_spaces(' Example 3')\n    '_Example-3'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "py",
+    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check('example.txt')\n    'Yes'\n    >>> file_name_check('1example.dll')\n    'No'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "py",
+    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence('This is a test')\n    'is'\n\n    Example 2:\n    >>> words_in_sentence('lets go for swimming')\n    'go for'\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "py",
+    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify('1/5', '5/1')\n    True\n    >>> simplify('1/6', '2/1')\n    False\n    >>> simplify('7/10', '10/2')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2254,7 +769,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef specialFilter(nums: List[int]) -> int:\n    \"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15, -73, 14, -15])\n    1\n    >>> specialFilter([33, -2, -3, 45, 21, 109])\n    2\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([5, -2, 1, -5]) == 0\n    assert candidate([15, -73, 14, -15]) == 1\n    assert candidate([33, -2, -3, 45, 21, 109]) == 2\n    assert candidate([43, -12, 93, 125, 121, 109]) == 4\n    assert candidate([71, -2, -33, 75, 21, 19]) == 3\n    assert candidate([1]) == 0\n    assert candidate([]) == 0\n\ndef test_check():\n    check(specialFilter)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "py",
-    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
+    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "py",
-    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    >>> bf('Jupiter', 'Neptune')\n    ('Saturn', 'Uranus')\n    >>> bf('Earth', 'Mercury')\n    'Venus'\n    >>> bf('Mercury', 'Uranus')\n    ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort(['aa', 'a', 'aaa'])\n    ['aa']\n    >>> list_sort(['ab', 'a', 'aaa', 'cd'])\n    ['ab', 'cd']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "py",
+    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension('my_class', ['AA', 'Be', 'CC'])\n    'my_class.AA'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "py",
+    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check('abcd', 'abd')\n    False\n    >>> cycpattern_check('hello', 'ell')\n    True\n    >>> cycpattern_check('whassup', 'psus')\n    False\n    >>> cycpattern_check('abab', 'baa')\n    True\n    >>> cycpattern_check('efef', 'eeff')\n    False\n    >>> cycpattern_check('himenss', 'simen')\n    True\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "py",
+    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    'xix'\n    >>> int_to_mini_roman(152)\n    'clii'\n    >>> int_to_mini_roman(426)\n    'cdxxvi'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "py",
+    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    True\n    >>> right_angle_triangle(1, 2, 3)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max(['name', 'of', 'string'])\n    'string'\n    >>> find_max(['name', 'enam', 'game'])\n    'enam'\n    >>> find_max(['aaaaaaa', 'bb', 'cc'])\n    'aaaaaaa'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "py",
+    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "py",
+    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve('1234')\n    '4321'\n    >>> solve('ab')\n    'AB'\n    >>> solve('#a@C')\n    '#A@c'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world')\n    '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2299,7 +1054,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef generate_integers(a: int, b: int) -> List[int]:\n    \"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2, 8)\n    [2, 4, 6, 8]\n    >>> generate_integers(8, 2)\n    [2, 4, 6, 8]\n    >>> generate_integers(10, 14)\n    []\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate(2, 10) == [2, 4, 6, 8]\n    assert candidate(10, 2) == [2, 4, 6, 8]\n    assert candidate(132, 2) == [2, 4, 6, 8]\n    assert candidate(17, 89) == []\n\ndef test_check():\n    check(generate_integers)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "py",
-    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
+    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "py",
-    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\n",
+    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "py",
-    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('(')\n    False\n    >>> correct_bracketing('()')\n    True\n    >>> correct_bracketing('(()())')\n    True\n    >>> correct_bracketing(')(()')\n    False\n    \"\"\"\n",
+    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {  }, []])\n    [1, 2, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "py",
+    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "py",
+    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "py",
+    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "py",
+    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "py",
+    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "py",
+    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2374,9 +1399,249 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_even(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]\n    assert candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]\n\ndef test_check():\n    check(sort_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "py",
+    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "py",
+    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "py",
+    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "py",
+    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "py",
+    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "py",
+    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "py",
+    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "py",
+    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2389,9 +1654,24 @@
     "language": "py",
     "prompt": "def same_chars(s0: str, s1: str) -> bool:\n    \"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddeddabc') == True\n    assert candidate('abcd', 'dddddddabc') == True\n    assert candidate('dddddddabc', 'abcd') == True\n    assert candidate('eabcd', 'dddddddabc') == False\n    assert candidate('abcd', 'dddddddabcf') == False\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddddabc') == False\n    assert candidate('aabb', 'aaccc') == False\n\ndef test_check():\n    check(same_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "py",
+    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2404,9 +1684,729 @@
     "language": "py",
     "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('<')\n    False\n    >>> correct_bracketing('<>')\n    True\n    >>> correct_bracketing('<<><>>')\n    True\n    >>> correct_bracketing('><<>')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('<>') == True\n    assert candidate('<<><>>') == True\n    assert candidate('<><><<><>><>') == True\n    assert candidate('<><><<<><><>><>><<><><<>>>') == True\n    assert candidate('<<<><>>>>') == False\n    assert candidate('><<>') == False\n    assert candidate('<') == False\n    assert candidate('<<<<') == False\n    assert candidate('>') == False\n    assert candidate('<<>') == False\n    assert candidate('<><><<><>><>><<>') == False\n    assert candidate('<><><<><>><>>><>') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "py",
+    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "py",
+    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "py",
+    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('(')\n    False\n    >>> correct_bracketing('()')\n    True\n    >>> correct_bracketing('(()())')\n    True\n    >>> correct_bracketing(')(()')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "py",
+    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "py",
+    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count('abcde')\n    2\n    >>> vowels_count('ACEDY')\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "py",
+    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    '21'\n    >>> circular_shift(12, 2)\n    '12'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "py",
+    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum('')\n    0\n    >>> digitSum('abAB')\n    131\n    >>> digitSum('abcCd')\n    67\n    >>> digitSum('helloE')\n    69\n    >>> digitSum('woArBld')\n    131\n    >>> digitSum('aAaaaXa')\n    153\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "py",
+    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution('5 apples and 6 oranges', 19)\n    8\n    >>> fruit_distribution('0 apples and 1 oranges', 3)\n    2\n    >>> fruit_distribution('2 apples and 3 oranges', 100)\n    95\n    >>> fruit_distribution('100 apples and 1 oranges', 120)\n    19\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    False\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match(['hi', 'admin'], ['hI', 'Hi'])\n    ['hI', 'Hi']\n    >>> total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project'])\n    ['hi', 'admin']\n    >>> total_match(['hi', 'admin'], ['hI', 'hi', 'hi'])\n    ['hI', 'hi', 'hi']\n    >>> total_match(['4'], ['1', '2', '3', '4', '5'])\n    ['4']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "py",
+    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "py",
+    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    True\n    >>> is_simple_power(2, 2)\n    True\n    >>> is_simple_power(8, 2)\n    True\n    >>> is_simple_power(3, 2)\n    False\n    >>> is_simple_power(3, 1)\n    False\n    >>> is_simple_power(5, 3)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "py",
+    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    True\n    >>> iscube(2)\n    False\n    >>> iscube(-1)\n    True\n    >>> iscube(64)\n    True\n    >>> iscube(0)\n    True\n    >>> iscube(180)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "py",
+    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key('AB')\n    1\n    >>> hex_key('1077E')\n    2\n    >>> hex_key('ABED1A33')\n    4\n    >>> hex_key('123456789ABCDEF0')\n    6\n    >>> hex_key('2020')\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    'db1111db'\n    >>> decimal_to_binary(32)\n    'db100000db'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "py",
+    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy('a')\n    False\n    >>> is_happy('aa')\n    False\n    >>> is_happy('abcd')\n    True\n    >>> is_happy('aabb')\n    False\n    >>> is_happy('adb')\n    True\n    >>> is_happy('xyy')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "py",
+    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length('Hello')\n    True\n    >>> prime_length('abcdcba')\n    True\n    >>> prime_length('kittens')\n    True\n    >>> prime_length('orange')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "py",
+    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "py",
+    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    '1'\n    >>> solve(150)\n    '110'\n    >>> solve(147)\n    '1100'\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "py",
+    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle('Hi')\n    'Hi'\n    >>> anti_shuffle('hello')\n    'ehllo'\n    >>> anti_shuffle('Hello World!!!')\n    'Hello !!!Wdlor'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "py",
+    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt('hi')\n    'lm'\n    >>> encrypt('asdfghjkl')\n    'ewhjklnop'\n    >>> encrypt('gf')\n    'kj'\n    >>> encrypt('et')\n    'ix'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1, 1])\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "py",
+    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored('Hello world')\n    0\n    >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "py",
+    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    True\n    \n    >>> any_int(3, 2, 2)\n    False\n\n    >>> any_int(3, -2, 1)\n    True\n    \n    >>> any_int(3.6, -2.2, 2)\n    False\n  \n\n    \n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "py",
+    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case({ 'a': 'apple', 'b': 'banana' })\n    True\n    >>> check_dict_case({ 'a': 'apple', 'A': 'banana', 'B': 'banana' })\n    False\n    >>> check_dict_case({ 'a': 'apple', 8: 'banana', 'a': 'apple' })\n    False\n    >>> check_dict_case({ 'Name': 'John', 'Age': '36', 'City': 'Houston' })\n    False\n    >>> check_dict_case({ 'STATE': 'NC', 'ZIP': '12345' })\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "py",
+    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "py",
+    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper('aBCdEf')\n    1\n    >>> count_upper('abcdefg')\n    0\n    >>> count_upper('dBBE')\n    0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "py",
+    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer('10')\n    10\n    >>> closest_integer('15.3')\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/humaneval-py-transform.json
+++ b/prompts/humaneval-py-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "py",
-    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "py",
-    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt('hi')\n    'lm'\n    >>> encrypt('asdfghjkl')\n    'ewhjklnop'\n    >>> encrypt('gf')\n    'kj'\n    >>> encrypt('et')\n    'ix'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case({ 'a': 'apple', 'b': 'banana' })\n    True\n    >>> check_dict_case({ 'a': 'apple', 'A': 'banana', 'B': 'banana' })\n    False\n    >>> check_dict_case({ 'a': 'apple', 8: 'banana', 'a': 'apple' })\n    False\n    >>> check_dict_case({ 'Name': 'John', 'Age': '36', 'City': 'Houston' })\n    False\n    >>> check_dict_case({ 'STATE': 'NC', 'ZIP': '12345' })\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "py",
-    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(' Example')\n    'Example'\n    >>> fix_spaces(' Example 1')\n    'Example_1'\n    >>> fix_spaces(' Example 2')\n    '_Example_2'\n    >>> fix_spaces(' Example 3')\n    '_Example-3'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "py",
-    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {  }, []])\n    [1, 2, 3]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "py",
-    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    'db1111db'\n    >>> decimal_to_binary(32)\n    'db100000db'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "py",
-    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "py",
-    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    ['One']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match(['hi', 'admin'], ['hI', 'Hi'])\n    ['hI', 'Hi']\n    >>> total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project'])\n    ['hi', 'admin']\n    >>> total_match(['hi', 'admin'], ['hI', 'hi', 'hi'])\n    ['hI', 'hi', 'hi']\n    >>> total_match(['4'], ['1', '2', '3', '4', '5'])\n    ['4']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "py",
-    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested('[[]]')\n    True\n    >>> is_nested('[]]]]]]][[[[[]')\n    False\n    >>> is_nested('[][]')\n    False\n    >>> is_nested('[]')\n    False\n    >>> is_nested('[[][]]')\n    True\n    >>> is_nested('[[]][[')\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    '0b11'\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    '0b1111'\n    >>> rounded_avg(20, 33)\n    '0b11010'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    >>> odd_count(['3', '11111111'])\n    ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "py",
-    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    False\n    >>> is_equal_to_sum_even(6)\n    False\n    >>> is_equal_to_sum_even(8)\n    True\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5])\n    False\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    False\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    True\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "py",
-    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve('1234')\n    '4321'\n    >>> solve('ab')\n    'AB'\n    >>> solve('#a@C')\n    '#A@c'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "py",
-    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "py",
-    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    '1'\n    >>> solve(150)\n    '110'\n    >>> solve(147)\n    '1100'\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "py",
-    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper('aBCdEf')\n    1\n    >>> count_upper('abcdefg')\n    0\n    >>> count_upper('dBBE')\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "py",
-    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "py",
-    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    True\n    >>> iscube(2)\n    False\n    >>> iscube(-1)\n    True\n    >>> iscube(64)\n    True\n    >>> iscube(0)\n    True\n    >>> iscube(180)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "py",
-    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "py",
-    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored('Hello world')\n    0\n    >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n    1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "py",
-    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    >>> bf('Jupiter', 'Neptune')\n    ('Saturn', 'Uranus')\n    >>> bf('Earth', 'Mercury')\n    'Venus'\n    >>> bf('Mercury', 'Uranus')\n    ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "py",
-    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string('Hi, my name is John')\n    ['Hi', 'my', 'name', 'is', 'John']\n    >>> words_string('One, two, three, four, five, six')\n    ['One', 'two', 'three', 'four', 'five', 'six']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "py",
-    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "py",
-    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    >>> compare_one(1, 2.5)\n    2.5\n    >>> compare_one(1, '2,3')\n    '2,3'\n    >>> compare_one('5,1', '6')\n    '6'\n    >>> compare_one('1', 1)\n    None\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "py",
-    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "py",
-    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    True\n    >>> is_simple_power(2, 2)\n    True\n    >>> is_simple_power(8, 2)\n    True\n    >>> is_simple_power(3, 2)\n    False\n    >>> is_simple_power(3, 1)\n    False\n    >>> is_simple_power(5, 3)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "py",
-    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "py",
     "prompt": "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n\ndef test_check():\n    check(has_close_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "py",
-    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "py",
-    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "py",
-    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "py",
-    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words('Mary had a little lamb', 4)\n    ['little']\n    >>> select_words('Mary had a little lamb', 3)\n    ['Mary', 'lamb']\n    >>> select_words('simple white space', 2)\n    []\n    >>> select_words('Hello world', 4)\n    ['world']\n    >>> select_words('Uncle sam', 3)\n    ['Uncle']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    False\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "py",
-    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension('my_class', ['AA', 'Be', 'CC'])\n    'my_class.AA'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens(['()(', ')'])\n    'Yes'\n    >>> match_parens([')', ')'])\n    'No'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1, 1])\n    None\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "py",
-    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    True\n    \n    >>> any_int(3, 2, 2)\n    False\n\n    >>> any_int(3, -2, 1)\n    True\n    \n    >>> any_int(3.6, -2.2, 2)\n    False\n  \n\n    \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "py",
-    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "py",
-    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "py",
-    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "py",
-    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy('a')\n    False\n    >>> is_happy('aa')\n    False\n    >>> is_happy('abcd')\n    True\n    >>> is_happy('aabb')\n    False\n    >>> is_happy('adb')\n    True\n    >>> is_happy('xyy')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "py",
-    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "py",
-    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum('')\n    0\n    >>> digitSum('abAB')\n    131\n    >>> digitSum('abcCd')\n    67\n    >>> digitSum('helloE')\n    69\n    >>> digitSum('woArBld')\n    131\n    >>> digitSum('aAaaaXa')\n    153\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "py",
-    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    'YES'\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    'NO'\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "py",
-    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length('Hello')\n    True\n    >>> prime_length('abcdcba')\n    True\n    >>> prime_length('kittens')\n    True\n    >>> prime_length('orange')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "py",
-    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check('example.txt')\n    'Yes'\n    >>> file_name_check('1example.dll')\n    'No'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    'NO'\n    >>> intersection((-1, 1), (0, 4))\n    'NO'\n    >>> intersection((-3, -1), (-5, 5))\n    'YES'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "py",
-    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "py",
-    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter('apple pie')\n    False\n    >>> check_if_last_char_is_a_letter('apple pi e')\n    True\n    >>> check_if_last_char_is_a_letter('apple pi e ')\n    False\n    >>> check_if_last_char_is_a_letter('')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "py",
-    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date('03-11-2000')\n    True\n\n    >>> valid_date('15-01-2012')\n    False\n\n    >>> valid_date('04-0-2040')\n    False\n\n    >>> valid_date('06-04-2020')\n    True\n\n    >>> valid_date('06/04/2020')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "py",
-    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle('Hi')\n    'Hi'\n    >>> anti_shuffle('hello')\n    'ehllo'\n    >>> anti_shuffle('Hello World!!!')\n    'Hello !!!Wdlor'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "py",
-    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "py",
-    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel('yogurt')\n    'u'\n    >>> get_closest_vowel('FULL')\n    'U'\n    >>> get_closest_vowel('quick')\n    ''\n    >>> get_closest_vowel('ab')\n    ''\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "py",
-    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "py",
-    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify('1/5', '5/1')\n    True\n    >>> simplify('1/6', '2/1')\n    False\n    >>> simplify('7/10', '10/2')\n    False\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "py",
-    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key('AB')\n    1\n    >>> hex_key('1077E')\n    2\n    >>> hex_key('ABED1A33')\n    4\n    >>> hex_key('123456789ABCDEF0')\n    6\n    >>> hex_key('2020')\n    2\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "py",
-    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence('This is a test')\n    'is'\n\n    Example 2:\n    >>> words_in_sentence('lets go for swimming')\n    'go for'\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram('a b c')\n    { 'a': 1, 'b': 1, 'c': 1 }\n    >>> histogram('a b b a')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('a b c a b')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('b b b b a')\n    { 'b': 4 }\n    >>> histogram('')\n    {  }\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "py",
-    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "py",
-    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    '21'\n    >>> circular_shift(12, 2)\n    '12'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "py",
-    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (None, 1)\n    >>> largest_smallest_integers([])\n    (None, None)\n    >>> largest_smallest_integers([0])\n    (None, None)\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "py",
-    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1759,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef make_a_pile(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, you have to make a pile of n levels of stones.\n    The first level has n stones.\n    The number of stones in the next level is:\n        - the next odd number if n is odd.\n        - the next even number if n is even.\n    Return the number of stones in each level in a list, where element at index\n    i represents the number of stones in the level (i+1).\n\n    Examples:\n    >>> make_a_pile(3)\n    [3, 5, 7]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(3) == [3, 5, 7]\n    assert candidate(4) == [4, 6, 8, 10]\n    assert candidate(5) == [5, 7, 9, 11, 13]\n    assert candidate(6) == [6, 8, 10, 12, 14, 16]\n    assert candidate(8) == [8, 10, 12, 14, 16, 18, 20, 22]\n\ndef test_check():\n    check(make_a_pile)\n\ntest_check()\n",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    None\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef words_string(s: str) -> List[str]:\n    \"\"\"\n    You will be given a string of words separated by commas or spaces. Your task is\n    to split the string into words and return an array of the words.\n    \n    For example:\n    >>> words_string('Hi, my name is John')\n    ['Hi', 'my', 'name', 'is', 'John']\n    >>> words_string('One, two, three, four, five, six')\n    ['One', 'two', 'three', 'four', 'five', 'six']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hi, my name is John') == ['Hi', 'my', 'name', 'is', 'John']\n    assert candidate('One, two, three, four, five, six') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('Hi, my name') == ['Hi', 'my', 'name']\n    assert candidate('One,, two, three, four, five, six,') == ['One', 'two', 'three', 'four', 'five', 'six']\n    assert candidate('') == []\n    assert candidate('ahmed     , gamal') == ['ahmed', 'gamal']\n\ndef test_check():\n    check(words_string)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "py",
-    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\n",
+    "prompt": "def choose_num(x: int, y: int) -> int:\n    \"\"\"This function takes two positive numbers x and y and returns the\n    biggest even integer number that is in the range [x, y] inclusive. If \n    there's no such number, then the function should return -1.\n\n    For example:\n    >>> choose_num(12, 15)\n    14\n    >>> choose_num(13, 12)\n    -1\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(12, 15) == 14\n    assert candidate(13, 12) == -1\n    assert candidate(33, 12354) == 12354\n    assert candidate(5234, 5233) == -1\n    assert candidate(6, 29) == 28\n    assert candidate(27, 10) == -1\n    assert candidate(7, 7) == -1\n    assert candidate(546, 546) == 546\n\ndef test_check():\n    check(choose_num)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "py",
-    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
+    "prompt": "from typing import Union\n\ndef rounded_avg(n: int, m: int) -> Union[str, int]:\n    \"\"\"You are given two positive integers n and m, and your task is to compute the\n    average of the integers from n through m (including n and m). \n    Round the answer to the nearest integer and convert that to binary.\n    If n is greater than m, return -1.\n    Example:\n    >>> rounded_avg(1, 5)\n    '0b11'\n    >>> rounded_avg(7, 5)\n    -1\n    >>> rounded_avg(10, 20)\n    '0b1111'\n    >>> rounded_avg(20, 33)\n    '0b11010'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(1, 5) == '0b11'\n    assert candidate(7, 13) == '0b1010'\n    assert candidate(964, 977) == '0b1111001010'\n    assert candidate(996, 997) == '0b1111100100'\n    assert candidate(560, 851) == '0b1011000010'\n    assert candidate(185, 546) == '0b101101110'\n    assert candidate(362, 496) == '0b110101101'\n    assert candidate(350, 902) == '0b1001110010'\n    assert candidate(197, 233) == '0b11010111'\n    assert candidate(7, 5) == -1\n    assert candidate(5, 1) == -1\n    assert candidate(5, 5) == '0b101'\n\ndef test_check():\n    check(rounded_avg)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "py",
-    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check('abcd', 'abd')\n    False\n    >>> cycpattern_check('hello', 'ell')\n    True\n    >>> cycpattern_check('whassup', 'psus')\n    False\n    >>> cycpattern_check('abab', 'baa')\n    True\n    >>> cycpattern_check('efef', 'eeff')\n    False\n    >>> cycpattern_check('himenss', 'simen')\n    True\n\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef unique_digits(x: List[int]) -> List[int]:\n    \"\"\"Given a list of positive integers x. return a sorted list of all \n    elements that hasn't any even digit.\n\n    Note: Returned list should be sorted in increasing order.\n    \n    For example:\n    >>> unique_digits([15, 33, 1422, 1])\n    [1, 15, 33]\n    >>> unique_digits([152, 323, 1422, 10])\n    []\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([15, 33, 1422, 1]) == [1, 15, 33]\n    assert candidate([152, 323, 1422, 10]) == []\n    assert candidate([12345, 2033, 111, 151]) == [111, 151]\n    assert candidate([135, 103, 31]) == [31, 135]\n\ndef test_check():\n    check(unique_digits)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "py",
-    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef by_length(arr: List[int]) -> List[str]:\n    \"\"\"\n    Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    reverse the resulting array, and then replace each digit by its corresponding name from\n    \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n\n    For example:\n    >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n    ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    \n      If the array is empty, return an empty array:\n    >>> by_length([])\n    []\n    \n      If the array has any strange number ignore it:\n    >>> by_length([1, -1, 55])\n    ['One']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 1, 4, 5, 8, 2, 3]) == ['Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One']\n    assert candidate([]) == []\n    assert candidate([1, -1, 55]) == ['One']\n    assert candidate([1, -1, 3, 2]) == ['Three', 'Two', 'One']\n    assert candidate([9, 4, 8]) == ['Nine', 'Eight', 'Four']\n\ndef test_check():\n    check(by_length)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "py",
-    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef f(n: int) -> List[int]:\n    \"\"\" Implement the function f that takes n as a parameter,\n    and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    or the sum of numbers from 1 to i otherwise.\n    i starts from 1.\n    the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    Example:\n    >>> f(5)\n    [1, 2, 6, 24, 15]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == [1, 2, 6, 24, 15]\n    assert candidate(7) == [1, 2, 6, 24, 15, 720, 28]\n    assert candidate(1) == [1]\n    assert candidate(3) == [1, 2, 6]\n\ndef test_check():\n    check(f)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef even_odd_palindrome(n: int) -> Tuple[int, int]:\n    \"\"\"\n    Given a positive integer n, return a tuple that has the number of even and odd\n    integer palindromes that fall within the range(1, n), inclusive.\n\n    Example 1:\n\n    >>> even_odd_palindrome(3)\n    (1, 2)\n        Explanation:\n        Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n\n    Example 2:\n\n    >>> even_odd_palindrome(12)\n    (4, 6)\n        Explanation:\n        Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n\n    Note:\n        1. 1 <= n <= 10^3\n        2. returned tuple has the number of even and odd integer palindromes respectively.\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(123) == (8, 13)\n    assert candidate(12) == (4, 6)\n    assert candidate(3) == (1, 2)\n    assert candidate(63) == (6, 8)\n    assert candidate(25) == (5, 6)\n    assert candidate(19) == (4, 6)\n    assert candidate(9) == (4, 5)\n    assert candidate(1) == (0, 1)\n\ndef test_check():\n    check(even_odd_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "py",
-    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef count_nums(arr: List[int]) -> int:\n    \"\"\"\n    Write a function count_nums which takes an array of integers and returns\n    the number of elements which has a sum of digits > 0.\n    If a number is negative, then its first signed digit will be negative:\n    e.g. -123 has signed digits -1, 2, and 3.\n    >>> count_nums([])\n    0\n    >>> count_nums([-1, 11, -11])\n    1\n    >>> count_nums([1, 1, 2])\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([-1, -2, 0]) == 0\n    assert candidate([1, 1, 2, -2, 3, 4, 5]) == 6\n    assert candidate([1, 6, 9, -6, 0, 1, 5]) == 5\n    assert candidate([1, 100, 98, -7, 1, -1]) == 4\n    assert candidate([12, 23, 34, -45, -56, 0]) == 5\n    assert candidate([0, 1]) == 1\n    assert candidate([1]) == 1\n\ndef test_check():\n    check(count_nums)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "py",
-    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef move_one_ball(arr: List[int]) -> bool:\n    \"\"\"We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    numbers in the array will be randomly ordered. Your task is to determine if\n    it is possible to get an array sorted in non-decreasing order by performing \n    the following operation on the given array:\n        You are allowed to perform right shift operation any number of times.\n    \n    One right shift operation means shifting all elements of the array by one\n    position in the right direction. The last element of the array will be moved to\n    the starting position in the array i.e. 0th index. \n\n    If it is possible to obtain the sorted array by performing the above operation\n    then return True else return False.\n    If the given array is empty then return True.\n\n    Note: The given list is guaranteed to have unique elements.\n\n    For Example:\n    \n    >>> move_one_ball([3, 4, 5, 1, 2])\n    True\n    Explanation: By performin 2 right shift operations, non-decreasing order can\n                 be achieved for the given array.\n    >>> move_one_ball([3, 5, 4, 1, 2])\n    False\n    Explanation:It is not possible to get non-decreasing order for the given\n                array by performing any number of right shift operations.\n                \n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 1, 2]) == True\n    assert candidate([3, 5, 10, 1, 2]) == True\n    assert candidate([4, 3, 1, 2]) == False\n    assert candidate([3, 5, 4, 1, 2]) == False\n    assert candidate([]) == True\n\ndef test_check():\n    check(move_one_ball)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
+    "prompt": "def make_palindrome(string: str) -> str:\n    \"\"\" Find the shortest palindrome that begins with a supplied string.\n    Algorithm idea is simple:\n    - Find the longest postfix of supplied string that is a palindrome.\n    - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    >>> make_palindrome('')\n    ''\n    >>> make_palindrome('cat')\n    'catac'\n    >>> make_palindrome('cata')\n    'catac'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('x') == 'x'\n    assert candidate('xyz') == 'xyzyx'\n    assert candidate('xyx') == 'xyx'\n    assert candidate('jerry') == 'jerryrrej'\n\ndef test_check():\n    check(make_palindrome)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "py",
-    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef exchange(lst1: List[int], lst2: List[int]) -> str:\n    \"\"\"In this problem, you will implement a function that takes two lists of numbers,\n    and determines whether it is possible to perform an exchange of elements\n    between them to make lst1 a list of only even numbers.\n    There is no limit on the number of exchanged elements between lst1 and lst2.\n    If it is possible to exchange elements between the lst1 and lst2 to make\n    all the elements of lst1 to be even, return \"YES\".\n    Otherwise, return \"NO\".\n    For example:\n    >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n    'YES'\n    >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n    'NO'\n    It is assumed that the input lists will be non-empty.\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], [1, 2, 3, 4]) == 'YES'\n    assert candidate([1, 2, 3, 4], [1, 5, 3, 4]) == 'NO'\n    assert candidate([1, 2, 3, 4], [2, 1, 4, 3]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 4]) == 'YES'\n    assert candidate([5, 7, 3], [2, 6, 3]) == 'NO'\n    assert candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]) == 'NO'\n    assert candidate([100, 200], [200, 200]) == 'YES'\n\ndef test_check():\n    check(exchange)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "py",
-    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
+    "prompt": "from typing import Dict\n\ndef histogram(test: str) -> Dict[str, int]:\n    \"\"\"Given a string representing a space separated lowercase letters, return a dictionary\n    of the letter with the most repetition and containing the corresponding count.\n    If several letters have the same occurrence, return all of them.\n    \n    Example:\n    >>> histogram('a b c')\n    { 'a': 1, 'b': 1, 'c': 1 }\n    >>> histogram('a b b a')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('a b c a b')\n    { 'a': 2, 'b': 2 }\n    >>> histogram('b b b b a')\n    { 'b': 4 }\n    >>> histogram('')\n    {  }\n\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "py",
-    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "py",
-    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    'xix'\n    >>> int_to_mini_roman(152)\n    'clii'\n    >>> int_to_mini_roman(426)\n    'cdxxvi'\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "py",
-    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution('5 apples and 6 oranges', 19)\n    8\n    >>> fruit_distribution('0 apples and 1 oranges', 3)\n    2\n    >>> fruit_distribution('2 apples and 3 oranges', 100)\n    95\n    >>> fruit_distribution('100 apples and 1 oranges', 120)\n    19\n    \"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('a b b a') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c a b') == { 'a': 2, 'b': 2 }\n    assert candidate('a b c d g') == { 'a': 1, 'b': 1, 'c': 1, 'd': 1, 'g': 1 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('b b b b a') == { 'b': 4 }\n    assert candidate('r t g') == { 'r': 1, 't': 1, 'g': 1 }\n    assert candidate('') == {  }\n    assert candidate('a') == { 'a': 1 }\n\ndef test_check():\n    check(histogram)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2029,7 +214,7 @@
     "language": "py",
     "prompt": "from typing import Tuple\n\ndef reverse_delete(s: str, c: str) -> Tuple[str, bool]:\n    \"\"\"Task\n    We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    then check if the result string is palindrome.\n    A string is called palindrome if it reads the same backward as forward.\n    You should return a tuple containing the result string and True/False for the check.\n    Example\n    >>> reverse_delete('abcde', 'ae')\n    ('bcd', False)\n    >>> reverse_delete('abcdef', 'b')\n    ('acdef', False)\n    >>> reverse_delete('abcdedcba', 'ab')\n    ('cdedc', True)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('abcde', 'ae') == ('bcd', False)\n    assert candidate('abcdef', 'b') == ('acdef', False)\n    assert candidate('abcdedcba', 'ab') == ('cdedc', True)\n    assert candidate('dwik', 'w') == ('dik', False)\n    assert candidate('a', 'a') == ('', True)\n    assert candidate('abcdedcba', '') == ('abcdedcba', True)\n    assert candidate('abcdedcba', 'v') == ('abcdedcba', True)\n    assert candidate('vabba', 'v') == ('abba', True)\n    assert candidate('mamma', 'mia') == ('', True)\n\ndef test_check():\n    check(reverse_delete)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "py",
-    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef odd_count(lst: List[str]) -> List[str]:\n    \"\"\"Given a list of strings, where each string consists of only digits, return a list.\n    Each element i of the output should be \"the number of odd elements in the\n    string i of the input.\" where all the i's should be replaced by the number\n    of odd digits in the i'th string of the input.\n\n    >>> odd_count(['1234567'])\n    ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    >>> odd_count(['3', '11111111'])\n    ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['1234567']) == ['the number of odd elements 4n the str4ng 4 of the 4nput.']\n    assert candidate(['3', '11111111']) == ['the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.']\n    assert candidate(['271', '137', '314']) == ['the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.']\n\ndef test_check():\n    check(odd_count)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "py",
-    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words('Hello world!')\n    ['Hello', 'world!']\n    >>> split_words('Hello,world!')\n    ['Hello', 'world!']\n    >>> split_words('abcdef')\n    3\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef minSubArraySum(nums: List[int]) -> int:\n    \"\"\"\n    Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    of nums.\n    Example\n    >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n    1\n    >>> minSubArraySum([-1, -2, -3])\n    -6\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 4, 1, 2, 4]) == 1\n    assert candidate([-1, -2, -3]) == -6\n    assert candidate([-1, -2, -3, 2, -10]) == -14\n    assert candidate([-9999999999999999]) == -9999999999999999\n    assert candidate([0, 10, 20, 1000000]) == 0\n    assert candidate([-1, -2, -3, 10, -5]) == -6\n    assert candidate([100, -1, -2, -3, 10, -5]) == -6\n    assert candidate([10, 11, 13, 8, 3, 4]) == 3\n    assert candidate([100, -33, 32, -1, 0, -2]) == -33\n    assert candidate([-10]) == -10\n    assert candidate([7]) == 7\n    assert candidate([1, -1]) == -1\n\ndef test_check():\n    check(minSubArraySum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_fill(grid: List[List[int]], capacity: int) -> int:\n    \"\"\"\n    You are given a rectangular grid of wells. Each row represents a single well,\n    and each 1 in a row represents a single unit of water.\n    Each well has a corresponding bucket that can be used to extract water from it, \n    and all buckets have the same capacity.\n    Your task is to use the buckets to empty the wells.\n    Output the number of times you need to lower the buckets.\n\n    Example 1:\n    >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n    6\n\n    Example 2:\n    >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n    5\n    \n    Example 3:\n    >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n    0\n\n    Constraints:\n        * all wells have the same length\n        * 1 <= grid.length <= 10^2\n        * 1 <= grid[:,1].length <= 10^2\n        * grid[i][j] -> 0 | 1\n        * 1 <= capacity <= 10\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1) == 6\n    assert candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2) == 5\n    assert candidate([[0, 0, 0], [0, 0, 0]], 5) == 0\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2) == 4\n    assert candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9) == 2\n\ndef test_check():\n    check(max_fill)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2074,7 +274,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_array(arr: List[int]) -> List[int]:\n    \"\"\"\n    In this Kata, you have to sort an array of non-negative integers according to\n    number of ones in their binary representation in ascending order.\n    For similar number of ones, sort based on decimal value.\n\n    It must be implemented like this:\n    >>> sort_array([1, 5, 2, 3, 4])\n    [1, 2, 3, 4, 5]\n    >>> sort_array([-2, -3, -4, -5, -6])\n    [-6, -5, -4, -3, -2]\n    >>> sort_array([1, 0, 2, 3, 4])\n    [0, 1, 2, 3, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5]\n    assert candidate([-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3]\n    assert candidate([1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3]\n    assert candidate([]) == []\n    assert candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]\n    assert candidate([3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n    assert candidate([2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef select_words(s: str, n: int) -> List[str]:\n    \"\"\"Given a string s and a natural number n, you have been tasked to implement \n    a function that returns a list of all words from string s that contain exactly \n    n consonants, in order these words appear in the string s.\n    If the string s is empty then the function should return an empty list.\n    Note: you may assume the input string contains only letters and spaces.\n    Examples:\n    >>> select_words('Mary had a little lamb', 4)\n    ['little']\n    >>> select_words('Mary had a little lamb', 3)\n    ['Mary', 'lamb']\n    >>> select_words('simple white space', 2)\n    []\n    >>> select_words('Hello world', 4)\n    ['world']\n    >>> select_words('Uncle sam', 3)\n    ['Uncle']\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Mary had a little lamb', 4) == ['little']\n    assert candidate('Mary had a little lamb', 3) == ['Mary', 'lamb']\n    assert candidate('simple white space', 2) == []\n    assert candidate('Hello world', 4) == ['world']\n    assert candidate('Uncle sam', 3) == ['Uncle']\n    assert candidate('', 4) == []\n    assert candidate('a b c d e f', 1) == ['b', 'c', 'd', 'f']\n\ndef test_check():\n    check(select_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "py",
-    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort(['aa', 'a', 'aaa'])\n    ['aa']\n    >>> list_sort(['ab', 'a', 'aaa', 'cd'])\n    ['ab', 'cd']\n    \"\"\"\n",
+    "prompt": "def get_closest_vowel(word: str) -> str:\n    \"\"\"You are given a word. Your task is to find the closest vowel that stands between \n    two consonants from the right side of the word (case sensitive).\n    \n    Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    find any vowel met the above condition. \n\n    You may assume that the given string contains English letter only.\n\n    Example:\n    >>> get_closest_vowel('yogurt')\n    'u'\n    >>> get_closest_vowel('FULL')\n    'U'\n    >>> get_closest_vowel('quick')\n    ''\n    >>> get_closest_vowel('ab')\n    ''\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('yogurt') == 'u'\n    assert candidate('full') == 'u'\n    assert candidate('easy') == ''\n    assert candidate('eAsy') == ''\n    assert candidate('ali') == ''\n    assert candidate('bad') == 'a'\n    assert candidate('most') == 'o'\n    assert candidate('ab') == ''\n    assert candidate('ba') == ''\n    assert candidate('quick') == ''\n    assert candidate('anime') == 'i'\n    assert candidate('Asia') == ''\n    assert candidate('Above') == 'o'\n\ndef test_check():\n    check(get_closest_vowel)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "py",
-    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef match_parens(lst: List[str]) -> str:\n    \"\"\"\n    You are given a list of two strings, both strings consist of open\n    parentheses '(' or close parentheses ')' only.\n    Your job is to check if it is possible to concatenate the two strings in\n    some order, that the resulting string will be good.\n    A string S is considered to be good if and only if all parentheses in S\n    are balanced. For example: the string '(())()' is good, while the string\n    '())' is not.\n    Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n\n    Examples:\n    >>> match_parens(['()(', ')'])\n    'Yes'\n    >>> match_parens([')', ')'])\n    'No'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['()(', ')']) == 'Yes'\n    assert candidate([')', ')']) == 'No'\n    assert candidate(['(()(())', '())())']) == 'No'\n    assert candidate([')())', '(()()(']) == 'Yes'\n    assert candidate(['(())))', '(()())((']) == 'Yes'\n    assert candidate(['()', '())']) == 'No'\n    assert candidate(['(()(', '()))()']) == 'Yes'\n    assert candidate(['((((', '((())']) == 'No'\n    assert candidate([')(()', '(()(']) == 'No'\n    assert candidate([')(', ')(']) == 'No'\n    assert candidate(['(', ')']) == 'Yes'\n    assert candidate([')', '(']) == 'Yes'\n\ndef test_check():\n    check(match_parens)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "py",
-    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer('10')\n    10\n    >>> closest_integer('15.3')\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "prompt": "def string_xor(a: str, b: str) -> str:\n    \"\"\" Input are two strings a and b consisting only of 1s and 0s.\n    Perform binary XOR on these inputs and return result also as a string.\n    >>> string_xor('010', '110')\n    '100'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('111000', '101010') == '010010'\n    assert candidate('1', '1') == '0'\n    assert candidate('0101', '0000') == '0101'\n\ndef test_check():\n    check(string_xor)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "py",
-    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count('abcde')\n    2\n    >>> vowels_count('ACEDY')\n    3\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef maximum(arr: List[int], k: int) -> List[int]:\n    \"\"\"\n    Given an array arr of integers and a positive integer k, return a sorted list \n    of length k with the maximum k numbers in arr.\n\n    Example 1:\n\n    >>> maximum([-3, -4, 5], 3)\n    [-4, -3, 5]\n\n    Example 2:\n\n    >>> maximum([4, -4, 4], 2)\n    [4, 4]\n\n    Example 3:\n\n    >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n    [2]\n\n    Note:\n        1. The length of the array will be in the range of [1, 1000].\n        2. The elements in the array will be in the range of [-1000, 1000].\n        3. 0 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([-3, -4, 5], 3) == [-4, -3, 5]\n    assert candidate([4, -4, 4], 2) == [4, 4]\n    assert candidate([-3, 2, 1, 2, -1, -2, 1], 1) == [2]\n    assert candidate([123, -123, 20, 0, 1, 2, -3], 3) == [2, 20, 123]\n    assert candidate([-123, 20, 0, 1, 2, -3], 4) == [0, 1, 2, 20]\n    assert candidate([5, 15, 0, 3, -13, -8, 0], 7) == [-13, -8, 0, 0, 3, 5, 15]\n    assert candidate([-1, 0, 2, 5, 3, -10], 2) == [3, 5]\n    assert candidate([1, 0, 5, -7], 1) == [5]\n    assert candidate([4, -4], 2) == [-4, 4]\n    assert candidate([-10, 10], 2) == [-10, 10]\n    assert candidate([1, 2, 3, -23, 243, -400, 0], 0) == []\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max(['name', 'of', 'string'])\n    'string'\n    >>> find_max(['name', 'enam', 'game'])\n    'enam'\n    >>> find_max(['aaaaaaa', 'bb', 'cc'])\n    'aaaaaaa'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef solution(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    \n\n    Examples\n    >>> solution([5, 8, 7, 1])\n    12\n    >>> solution([3, 3, 3, 3, 3])\n    9\n    >>> solution([30, 13, 24, 321])\n    0\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5, 8, 7, 1]) == 12\n    assert candidate([3, 3, 3, 3, 3]) == 9\n    assert candidate([30, 13, 24, 321]) == 0\n    assert candidate([5, 9]) == 5\n    assert candidate([2, 4, 8]) == 0\n    assert candidate([30, 13, 23, 32]) == 23\n    assert candidate([3, 13, 2, 9]) == 3\n\ndef test_check():\n    check(solution)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "py",
-    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world')\n    '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef add_elements(arr: List[int], k: int) -> int:\n    \"\"\"\n    Given a non-empty array of integers arr and an integer k, return\n    the sum of the elements with at most two digits from the first k elements of arr.\n\n    Example:\n\n    >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n    24\n\n    Constraints:\n        1. 1 <= len(arr) <= 100\n        2. 1 <= k <= len(arr)\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3) == -4\n    assert candidate([111, 121, 3, 4000, 5, 6], 2) == 0\n    assert candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4) == 125\n    assert candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4) == 24\n    assert candidate([1], 1) == 1\n\ndef test_check():\n    check(add_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "py",
-    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef get_odd_collatz(n: int) -> List[int]:\n    \"\"\"\n    Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n\n    The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    as follows: start with any positive integer n. Then each term is obtained from the \n    previous term as follows: if the previous term is even, the next term is one half of \n    the previous term. If the previous term is odd, the next term is 3 times the previous\n    term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n\n    Note: \n        1. Collatz(1) is [1].\n        2. returned list sorted in increasing order.\n\n    For example:\n    get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    >>> get_odd_collatz(5)\n    [1, 5]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(14) == [1, 5, 7, 11, 13, 17]\n    assert candidate(5) == [1, 5]\n    assert candidate(12) == [1, 3, 5]\n    assert candidate(1) == [1]\n\ndef test_check():\n    check(get_odd_collatz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "py",
-    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    True\n    >>> right_angle_triangle(1, 2, 3)\n    False\n    \"\"\"\n",
+    "prompt": "def valid_date(date: str) -> bool:\n    \"\"\"You have to write a function which validates a given date string and\n    returns True if the date is valid otherwise False.\n    The date is valid if all of the following rules are satisfied:\n    1. The date string is not empty.\n    2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    3. The months should not be less than 1 or higher than 12.\n    4. The date should be in the format: mm-dd-yyyy\n\n    >>> valid_date('03-11-2000')\n    True\n\n    >>> valid_date('15-01-2012')\n    False\n\n    >>> valid_date('04-0-2040')\n    False\n\n    >>> valid_date('06-04-2020')\n    True\n\n    >>> valid_date('06/04/2020')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('03-11-2000') == True\n    assert candidate('15-01-2012') == False\n    assert candidate('04-0-2040') == False\n    assert candidate('06-04-2020') == True\n    assert candidate('01-01-2007') == True\n    assert candidate('03-32-2011') == False\n    assert candidate('') == False\n    assert candidate('04-31-3000') == False\n    assert candidate('06-06-2005') == True\n    assert candidate('21-31-2000') == False\n    assert candidate('04-12-2003') == True\n    assert candidate('04122003') == False\n    assert candidate('20030412') == False\n    assert candidate('2003-04') == False\n    assert candidate('2003-04-12') == False\n    assert candidate('04-2003') == False\n\ndef test_check():\n    check(valid_date)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "py",
-    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
+    "prompt": "from typing import Union, List\n\ndef split_words(txt: str) -> Union[List[str], int]:\n    \"\"\"\n    Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    Examples\n    >>> split_words('Hello world!')\n    ['Hello', 'world!']\n    >>> split_words('Hello,world!')\n    ['Hello', 'world!']\n    >>> split_words('abcdef')\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Hello world!') == ['Hello', 'world!']\n    assert candidate('Hello,world!') == ['Hello', 'world!']\n    assert candidate('Hello world,!') == ['Hello', 'world,!']\n    assert candidate('Hello,Hello,world !') == ['Hello,Hello,world', '!']\n    assert candidate('abcdef') == 3\n    assert candidate('aaabb') == 2\n    assert candidate('aaaBb') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(split_words)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "py",
-    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef is_sorted(lst: List[int]) -> bool:\n    \"\"\"\n    Given a list of numbers, return whether or not they are sorted\n    in ascending order. If list has more than 1 duplicate of the same\n    number, return False. Assume no negative numbers and only integers.\n\n    Examples\n    >>> is_sorted([5])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5])\n    False\n    >>> is_sorted([1, 2, 3, 4, 5, 6])\n    True\n    >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n    True\n    >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n    False\n    >>> is_sorted([1, 2, 2, 3, 3, 4])\n    True\n    >>> is_sorted([1, 2, 2, 2, 3, 4])\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5]) == True\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 3, 2, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([1, 2, 3, 4, 5, 6, 7]) == True\n    assert candidate([1, 3, 2, 4, 5, 6, 7]) == False\n    assert candidate([]) == True\n    assert candidate([1]) == True\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 2, 2, 3, 4]) == False\n    assert candidate([1, 2, 3, 3, 3, 4]) == False\n    assert candidate([1, 2, 2, 3, 3, 4]) == True\n    assert candidate([1, 2, 3, 4]) == True\n\ndef test_check():\n    check(is_sorted)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef intersection(interval1: Tuple[int, int], interval2: Tuple[int, int]) -> str:\n    \"\"\"You are given two intervals,\n    where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    The given intervals are closed which means that the interval (start, end)\n    includes both start and end.\n    For each given interval, it is assumed that its start is less or equal its end.\n    Your task is to determine whether the length of intersection of these two \n    intervals is a prime number.\n    Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    which its length is 1, which not a prime number.\n    If the length of the intersection is a prime number, return \"YES\",\n    otherwise, return \"NO\".\n    If the two intervals don't intersect, return \"NO\".\n\n\n    [input/output] samples:\n    >>> intersection((1, 2), (2, 3))\n    'NO'\n    >>> intersection((-1, 1), (0, 4))\n    'NO'\n    >>> intersection((-3, -1), (-5, 5))\n    'YES'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 2), (2, 3)) == 'NO'\n    assert candidate((-1, 1), (0, 4)) == 'NO'\n    assert candidate((-3, -1), (-5, 5)) == 'YES'\n    assert candidate((-2, 2), (-4, 0)) == 'YES'\n    assert candidate((-11, 2), (-1, -1)) == 'NO'\n    assert candidate((1, 2), (3, 5)) == 'NO'\n    assert candidate((1, 2), (1, 2)) == 'NO'\n    assert candidate((-2, -2), (-3, -2)) == 'NO'\n\ndef test_check():\n    check(intersection)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef prod_signs(arr: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given an array arr of integers and you need to return\n    sum of magnitudes of integers multiplied by product of all signs\n    of each number in the array, represented by 1, -1 or 0.\n    Note: return None for empty arr.\n\n    Example:\n    >>> prod_signs([1, 2, 2, -4])\n    9\n    >>> prod_signs([0, 1])\n    0\n    >>> prod_signs([])\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 2, -4]) == -9\n    assert candidate([0, 1]) == 0\n    assert candidate([1, 1, 1, 2, 3, -1, 1]) == -10\n    assert candidate([]) == None\n    assert candidate([2, 4, 1, 2, -1, -1, 9]) == 20\n    assert candidate([-1, 1, -1, 1]) == 4\n    assert candidate([-1, 1, 1, 1]) == -4\n    assert candidate([-1, 1, 1, 0]) == 0\n\ndef test_check():\n    check(prod_signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef minPath(grid: List[List[int]], k: int) -> List[int]:\n    \"\"\"\n    Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    each cell of the grid contains a value. Every integer in the range [1, N * N]\n    inclusive appears exactly once on the cells of the grid.\n\n    You have to find the minimum path of length k in the grid. You can start\n    from any cell, and in each step you can move to any of the neighbor cells,\n    in other words, you can go to cells which share an edge with you current\n    cell.\n    Please note that a path of length k means visiting exactly k cells (not\n    necessarily distinct).\n    You CANNOT go off the grid.\n    A path A (of length k) is considered less than a path B (of length k) if\n    after making the ordered lists of the values on the cells that A and B go\n    through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    lst_A[j] = lst_B[j].\n    It is guaranteed that the answer is unique.\n    Return an ordered list of the values on the cells that the minimum path go through.\n\n    Examples:    \n    >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n    [1, 2, 1]\n\n    >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n    [1]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3) == [1, 2, 1]\n    assert candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1) == [1]\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4) == [1, 2, 1, 2]\n    assert candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7) == [1, 10, 1, 10, 1, 10, 1]\n    assert candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5) == [1, 7, 1, 7, 1]\n    assert candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1]\n    assert candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]\n    assert candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8) == [1, 3, 1, 3, 1, 3, 1, 3]\n    assert candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8) == [1, 5, 1, 5, 1, 5, 1, 5]\n    assert candidate([[1, 2], [3, 4]], 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]\n    assert candidate([[1, 3], [3, 2]], 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3]\n\ndef test_check():\n    check(minPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef longest(strings: List[str]) -> Optional[str]:\n    \"\"\" Out of list of strings, return the longest one. Return the first one in case of multiple\n    strings of the same length. Return None in case the input list is empty.\n    >>> longest([])\n    None\n    >>> longest(['a', 'b', 'c'])\n    'a'\n    >>> longest(['a', 'bb', 'ccc'])\n    'ccc'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == None\n    assert candidate(['x', 'y', 'z']) == 'x'\n    assert candidate(['x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc']) == 'zzzz'\n\ndef test_check():\n    check(longest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tri(n: int) -> List[int]:\n    \"\"\"Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    the last couple centuries. However, what people don't know is Tribonacci sequence.\n    Tribonacci sequence is defined by the recurrence:\n    tri(1) = 3\n    tri(n) = 1 + n / 2, if n is even.\n    tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    For example:\n    tri(2) = 1 + (2 / 2) = 2\n    tri(4) = 3\n    tri(3) = tri(2) + tri(1) + tri(4)\n           = 2 + 3 + 3 = 8 \n    You are given a non-negative integer number n, you have to a return a list of the \n    first n + 1 numbers of the Tribonacci sequence.\n    Examples:\n    >>> tri(3)\n    [1, 3, 2, 8]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == [1, 3, 2, 8]\n    assert candidate(4) == [1, 3, 2, 8, 3]\n    assert candidate(5) == [1, 3, 2, 8, 3, 15]\n    assert candidate(6) == [1, 3, 2, 8, 3, 15, 4]\n    assert candidate(7) == [1, 3, 2, 8, 3, 15, 4, 24]\n    assert candidate(8) == [1, 3, 2, 8, 3, 15, 4, 24, 5]\n    assert candidate(9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35]\n    assert candidate(20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]\n    assert candidate(0) == [1]\n    assert candidate(1) == [1, 3]\n\ndef test_check():\n    check(tri)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "py",
+    "prompt": "def digits(n: int) -> int:\n    \"\"\"Given a positive integer n, return the product of the odd digits.\n    Return 0 if all digits are even.\n    For example:\n    >>> digits(1)\n    1\n    >>> digits(4)\n    0\n    >>> digits(235)\n    15\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 5\n    assert candidate(54) == 5\n    assert candidate(120) == 1\n    assert candidate(5014) == 5\n    assert candidate(98765) == 315\n    assert candidate(5576543) == 2625\n    assert candidate(2468) == 0\n\ndef test_check():\n    check(digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "py",
+    "prompt": "def is_nested(string: str) -> bool:\n    \"\"\"\n    Create a function that takes a string as input which contains only square brackets.\n    The function should return True if and only if there is a valid subsequence of brackets \n    where at least one bracket in the subsequence is nested.\n\n    >>> is_nested('[[]]')\n    True\n    >>> is_nested('[]]]]]]][[[[[]')\n    False\n    >>> is_nested('[][]')\n    False\n    >>> is_nested('[]')\n    False\n    >>> is_nested('[[][]]')\n    True\n    >>> is_nested('[[]][[')\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('[[]]') == True\n    assert candidate('[]]]]]]][[[[[]') == False\n    assert candidate('[][]') == False\n    assert candidate('[]') == False\n    assert candidate('[[[[]]]]') == True\n    assert candidate('[]]]]]]]]]]') == False\n    assert candidate('[][][[]]') == True\n    assert candidate('[[]') == False\n    assert candidate('[]]') == False\n    assert candidate('[[]][[') == True\n    assert candidate('[[][]]') == True\n    assert candidate('') == False\n    assert candidate('[[[[[[[[') == False\n    assert candidate(']]]]]]]]') == False\n\ndef test_check():\n    check(is_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[float]) -> int:\n    \"\"\"You are given a list of numbers.\n    You need to return the sum of squared numbers in the given list,\n    round each element in the list to the upper int(Ceiling) first.\n    Examples:\n    >>> lst([1.0, 2.0, 3.0])\n    14\n    >>> lst([1.0, 4.0, 9.0])\n    98\n    >>> lst([1.0, 3.0, 5.0, 7.0])\n    84\n    >>> lst([1.4, 4.2, 0.0])\n    29\n    >>> lst([-2.4, 1.0, 1.0])\n    6\n    \n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 2.0, 3.0]) == 14\n    assert candidate([1.0, 3.0, 5.0, 7.0]) == 84\n    assert candidate([1.4, 4.2, 0.0]) == 29\n    assert candidate([-2.4, 1.0, 1.0]) == 6\n    assert candidate([100.0, 1.0, 15.0, 2.0]) == 10230\n    assert candidate([10000.0, 10000.0]) == 200000000\n    assert candidate([-1.4, 4.6, 6.3]) == 75\n    assert candidate([-1.4, 17.9, 18.9, 19.9]) == 1086\n    assert candidate([0.0]) == 0\n    assert candidate([-1.0]) == 1\n    assert candidate([-1.0, 1.0, 0.0]) == 2\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "py",
+    "prompt": "def check_if_last_char_is_a_letter(txt: str) -> bool:\n    \"\"\"\n    Create a function that returns True if the last character\n    of a given string is an alphabetical character and is not\n    a part of a word, and False otherwise.\n    Note: \"word\" is a group of characters separated by space.\n\n    Examples:\n    >>> check_if_last_char_is_a_letter('apple pie')\n    False\n    >>> check_if_last_char_is_a_letter('apple pi e')\n    True\n    >>> check_if_last_char_is_a_letter('apple pi e ')\n    False\n    >>> check_if_last_char_is_a_letter('')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('apple') == False\n    assert candidate('apple pi e') == True\n    assert candidate('eeeee') == False\n    assert candidate('A') == True\n    assert candidate('Pumpkin pie ') == False\n    assert candidate('Pumpkin pie 1') == False\n    assert candidate('') == False\n    assert candidate('eeeee e ') == False\n    assert candidate('apple pie') == False\n    assert candidate('apple pi e ') == False\n\ndef test_check():\n    check(check_if_last_char_is_a_letter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef can_arrange(arr: List[int]) -> int:\n    \"\"\"Create a function which returns the largest index of an element which\n    is not greater than or equal to the element immediately preceding it. If\n    no such element exists then return -1. The given array will not contain\n    duplicate values.\n\n    Examples:\n    >>> can_arrange([1, 2, 4, 3, 5])\n    3\n    >>> can_arrange([1, 2, 3])\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 3, 5]) == 3\n    assert candidate([1, 2, 4, 5]) == -1\n    assert candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([4, 8, 5, 7, 3]) == 4\n    assert candidate([]) == -1\n\ndef test_check():\n    check(can_arrange)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Optional\n\ndef largest_smallest_integers(lst: List[int]) -> Tuple[Optional[int], Optional[int]]:\n    \"\"\"\n    Create a function that returns a tuple (a, b), where 'a' is\n    the largest of negative integers, and 'b' is the smallest\n    of positive integers in a list.\n    If there is no negative or positive integers, return them as None.\n\n    Examples:\n    >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n    (None, 1)\n    >>> largest_smallest_integers([])\n    (None, None)\n    >>> largest_smallest_integers([0])\n    (None, None)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 1, 3, 5, 7]) == (None, 1)\n    assert candidate([2, 4, 1, 3, 5, 7, 0]) == (None, 1)\n    assert candidate([1, 3, 2, 4, 5, 6, -2]) == (-2, 1)\n    assert candidate([4, 5, 3, 6, 2, 7, -7]) == (-7, 2)\n    assert candidate([7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2)\n    assert candidate([]) == (None, None)\n    assert candidate([0]) == (None, None)\n    assert candidate([-1, -3, -5, -6]) == (-1, None)\n    assert candidate([-1, -3, -5, -6, 0]) == (-1, None)\n    assert candidate([-6, -4, -4, -3, 1]) == (-3, 1)\n    assert candidate([-6, -4, -4, -3, -100, 1]) == (-3, 1)\n\ndef test_check():\n    check(largest_smallest_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "py",
+    "prompt": "from typing import Union\n\ndef compare_one(a: Union[int, float, str], b: Union[int, float, str]) -> Union[int, float, str, None]:\n    \"\"\"\n    Create a function that takes integers, floats, or strings representing\n    real numbers, and returns the larger variable in its given variable type.\n    Return None if the values are equal.\n    Note: If a real number is represented as a string, the floating point might be . or ,\n\n    >>> compare_one(1, 2.5)\n    2.5\n    >>> compare_one(1, '2,3')\n    '2,3'\n    >>> compare_one('5,1', '6')\n    '6'\n    >>> compare_one('1', 1)\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 2\n    assert candidate(1, 2.5) == 2.5\n    assert candidate(2, 3) == 3\n    assert candidate(5, 6) == 6\n    assert candidate(1, '2,3') == '2,3'\n    assert candidate('5,1', '6') == '6'\n    assert candidate('1', '2') == '2'\n    assert candidate('1', 1) == None\n\ndef test_check():\n    check(compare_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "py",
+    "prompt": "def is_equal_to_sum_even(n: int) -> bool:\n    \"\"\"Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    Example\n    >>> is_equal_to_sum_even(4)\n    False\n    >>> is_equal_to_sum_even(6)\n    False\n    >>> is_equal_to_sum_even(8)\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == False\n    assert candidate(6) == False\n    assert candidate(8) == True\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(12) == True\n    assert candidate(13) == False\n    assert candidate(16) == True\n\ndef test_check():\n    check(is_equal_to_sum_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "py",
+    "prompt": "def special_factorial(n: int) -> int:\n    \"\"\"The Brazilian factorial is defined as:\n    brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    where n > 0\n\n    For example:\n    >>> special_factorial(4)\n    288\n\n    The function will receive an integer as input and should return the special\n    factorial of this integer.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == 288\n    assert candidate(5) == 34560\n    assert candidate(7) == 125411328000\n    assert candidate(1) == 1\n\ndef test_check():\n    check(special_factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "py",
+    "prompt": "def greatest_common_divisor(a: int, b: int) -> int:\n    \"\"\" Return a greatest common divisor of two integers a and b\n    >>> greatest_common_divisor(3, 5)\n    1\n    >>> greatest_common_divisor(25, 15)\n    5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 7) == 1\n    assert candidate(10, 15) == 5\n    assert candidate(49, 14) == 7\n    assert candidate(144, 60) == 12\n\ndef test_check():\n    check(greatest_common_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "py",
+    "prompt": "def fix_spaces(text: str) -> str:\n    \"\"\"\n    Given a string text, replace all spaces in it with underscores, \n    and if a string has more than 2 consecutive spaces, \n    then replace all consecutive spaces with - \n    \n    >>> fix_spaces(' Example')\n    'Example'\n    >>> fix_spaces(' Example 1')\n    'Example_1'\n    >>> fix_spaces(' Example 2')\n    '_Example_2'\n    >>> fix_spaces(' Example 3')\n    '_Example-3'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Example') == 'Example'\n    assert candidate('Mudasir Hanif ') == 'Mudasir_Hanif_'\n    assert candidate('Yellow Yellow  Dirty  Fellow') == 'Yellow_Yellow__Dirty__Fellow'\n    assert candidate('Exa   mple') == 'Exa-mple'\n    assert candidate('   Exa 1 2 2 mple') == '-Exa_1_2_2_mple'\n\ndef test_check():\n    check(fix_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "py",
+    "prompt": "def file_name_check(file_name: str) -> str:\n    \"\"\"Create a function which takes a string representing a file's name, and returns\n    'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    A file's name is considered to be valid if and only if all the following conditions \n    are met:\n    - There should not be more than three digits ('0'-'9') in the file's name.\n    - The file's name contains exactly one dot '.'\n    - The substring before the dot should not be empty, and it starts with a letter from \n    the latin alphapet ('a'-'z' and 'A'-'Z').\n    - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    Examples:\n    >>> file_name_check('example.txt')\n    'Yes'\n    >>> file_name_check('1example.dll')\n    'No'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('example.txt') == 'Yes'\n    assert candidate('1example.dll') == 'No'\n    assert candidate('s1sdf3.asd') == 'No'\n    assert candidate('K.dll') == 'Yes'\n    assert candidate('MY16FILE3.exe') == 'Yes'\n    assert candidate('His12FILE94.exe') == 'No'\n    assert candidate('_Y.txt') == 'No'\n    assert candidate('?aREYA.exe') == 'No'\n    assert candidate('/this_is_valid.dll') == 'No'\n    assert candidate('this_is_valid.wow') == 'No'\n    assert candidate('this_is_valid.txt') == 'Yes'\n    assert candidate('this_is_valid.txtexe') == 'No'\n    assert candidate('#this2_i4s_5valid.ten') == 'No'\n    assert candidate('@this1_is6_valid.exe') == 'No'\n    assert candidate('this_is_12valid.6exe4.txt') == 'No'\n    assert candidate('all.exe.txt') == 'No'\n    assert candidate('I563_No.exe') == 'Yes'\n    assert candidate('Is3youfault.txt') == 'Yes'\n    assert candidate('no_one#knows.dll') == 'Yes'\n    assert candidate('1I563_Yes3.exe') == 'No'\n    assert candidate('I563_Yes3.txtt') == 'No'\n    assert candidate('final..txt') == 'No'\n    assert candidate('final132') == 'No'\n    assert candidate('_f4indsartal132.') == 'No'\n    assert candidate('.txt') == 'No'\n    assert candidate('s.') == 'No'\n\ndef test_check():\n    check(file_name_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_squares(lst: List[int]) -> int:\n    \"\"\"\"\n    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    \n    Examples:\n    >>> lst\n    [1, 2, 3]\n    >>> lst\n    []\n    >>> lst\n    [-1, -5, 2, -1, -5]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([1, 4, 9]) == 14\n    assert candidate([]) == 0\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9\n    assert candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3\n    assert candidate([0]) == 0\n    assert candidate([-1, -5, 2, -1, -5]) == -126\n    assert candidate([-56, -99, 1, 0, -2]) == 3030\n    assert candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0\n    assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196\n    assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448\n\ndef test_check():\n    check(sum_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "py",
+    "prompt": "def words_in_sentence(sentence: str) -> str:\n    \"\"\"\n    You are given a string representing a sentence,\n    the sentence contains some words separated by a space,\n    and you have to return a string that contains the words from the original sentence,\n    whose lengths are prime numbers,\n    the order of the words in the new string should be the same as the original one.\n\n    Example 1:\n    >>> words_in_sentence('This is a test')\n    'is'\n\n    Example 2:\n    >>> words_in_sentence('lets go for swimming')\n    'go for'\n    \n    Constraints:\n        * 1 <= len(sentence) <= 100\n        * sentence contains only letters\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('This is a test') == 'is'\n    assert candidate('lets go for swimming') == 'go for'\n    assert candidate('there is no place available here') == 'there is no place'\n    assert candidate('Hi I am Hussein') == 'Hi am Hussein'\n    assert candidate('go for it') == 'go for it'\n    assert candidate('here') == ''\n    assert candidate('here is') == 'is'\n\ndef test_check():\n    check(words_in_sentence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "py",
+    "prompt": "def simplify(x: str, n: str) -> bool:\n    \"\"\"Your task is to implement a function that will simplify the expression\n    x * n. The function returns True if x * n evaluates to a whole number and False\n    otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n\n    You can assume that x, and n are valid fractions, and do not have zero as denominator.\n\n    >>> simplify('1/5', '5/1')\n    True\n    >>> simplify('1/6', '2/1')\n    False\n    >>> simplify('7/10', '10/2')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/6', '2/1') == False\n    assert candidate('5/1', '3/1') == True\n    assert candidate('7/10', '10/2') == False\n    assert candidate('2/10', '50/10') == True\n    assert candidate('7/2', '4/2') == True\n    assert candidate('11/6', '6/1') == True\n    assert candidate('2/3', '5/2') == False\n    assert candidate('5/2', '3/5') == False\n    assert candidate('2/4', '8/4') == True\n    assert candidate('2/4', '4/2') == True\n    assert candidate('1/5', '5/1') == True\n    assert candidate('1/5', '1/5') == False\n\ndef test_check():\n    check(simplify)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef order_by_points(nums: List[int]) -> List[int]:\n    \"\"\"\n    Write a function which sorts the given list of integers\n    in ascending order according to the sum of their digits.\n    Note: if there are several items with similar sum of their digits,\n    order them based on their index in original list.\n\n    For example:\n    >>> order_by_points([1, 11, -1, -11, -12])\n    [-1, -11, 1, -12, 11]\n    >>> order_by_points([])\n    []\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    assert candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]\n    assert candidate([]) == []\n    assert candidate([1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6]\n\ndef test_check():\n    check(order_by_points)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2254,7 +769,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef specialFilter(nums: List[int]) -> int:\n    \"\"\"Write a function that takes an array of numbers as input and returns \n    the number of elements in the array that are greater than 10 and both \n    first and last digits of a number are odd (1, 3, 5, 7, 9).\n    For example:\n    >>> specialFilter([15, -73, 14, -15])\n    1\n    >>> specialFilter([33, -2, -3, 45, 21, 109])\n    2\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([5, -2, 1, -5]) == 0\n    assert candidate([15, -73, 14, -15]) == 1\n    assert candidate([33, -2, -3, 45, 21, 109]) == 2\n    assert candidate([43, -12, 93, 125, 121, 109]) == 4\n    assert candidate([71, -2, -33, 75, 21, 19]) == 3\n    assert candidate([1]) == 0\n    assert candidate([]) == 0\n\ndef test_check():\n    check(specialFilter)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "py",
-    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
+    "prompt": "def get_max_triples(n: int) -> int:\n    \"\"\"\n    You are given a positive integer n. You have to create an integer array a of length n.\n        For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n        Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    and a[i] + a[j] + a[k] is a multiple of 3.\n\n    Example :\n    >>> get_max_triples(5)\n    1\n        Explanation: \n        a = [1, 3, 7, 13, 21]\n        The only valid triple is (1, 7, 13).\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == 1\n    assert candidate(6) == 4\n    assert candidate(10) == 36\n    assert candidate(100) == 53361\n\ndef test_check():\n    check(get_max_triples)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "py",
-    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef bf(planet1: str, planet2: str) -> Tuple[str, ...]:\n    \"\"\"\n    There are eight planets in our solar system: the closerst to the Sun \n    is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    Uranus, Neptune.\n    Write a function that takes two planet names as strings planet1 and planet2. \n    The function should return a tuple containing all planets whose orbits are \n    located between the orbit of planet1 and the orbit of planet2, sorted by \n    the proximity to the sun. \n    The function should return an empty tuple if planet1 or planet2\n    are not correct planet names. \n    Examples\n    >>> bf('Jupiter', 'Neptune')\n    ('Saturn', 'Uranus')\n    >>> bf('Earth', 'Mercury')\n    'Venus'\n    >>> bf('Mercury', 'Uranus')\n    ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('Jupiter', 'Neptune') == ('Saturn', 'Uranus')\n    assert candidate('Earth', 'Mercury') == ('Venus',)\n    assert candidate('Mercury', 'Uranus') == ('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\n    assert candidate('Neptune', 'Venus') == ('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus')\n    assert candidate('Earth', 'Earth') == ()\n    assert candidate('Mars', 'Earth') == ()\n    assert candidate('Jupiter', 'Makemake') == ()\n\ndef test_check():\n    check(bf)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sorted_list_sum(lst: List[str]) -> List[str]:\n    \"\"\"Write a function that accepts a list of strings as a parameter,\n    deletes the strings that have odd lengths from it,\n    and returns the resulted list with a sorted order,\n    The list is always a list of strings and never an array of numbers,\n    and it may contain duplicates.\n    The order of the list should be ascending by length of each word, and you\n    should return the list sorted by that rule.\n    If two words have the same length, sort the list alphabetically.\n    The function should return a list of strings in sorted order.\n    You may assume that all words will have the same length.\n    For example:\n    >>> list_sort(['aa', 'a', 'aaa'])\n    ['aa']\n    >>> list_sort(['ab', 'a', 'aaa', 'cd'])\n    ['ab', 'cd']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['aa', 'a', 'aaa']) == ['aa']\n    assert candidate(['school', 'AI', 'asdf', 'b']) == ['AI', 'asdf', 'school']\n    assert candidate(['d', 'b', 'c', 'a']) == []\n    assert candidate(['d', 'dcba', 'abcd', 'a']) == ['abcd', 'dcba']\n    assert candidate(['AI', 'ai', 'au']) == ['AI', 'ai', 'au']\n    assert candidate(['a', 'b', 'b', 'c', 'c', 'a']) == []\n    assert candidate(['aaaa', 'bbbb', 'dd', 'cc']) == ['cc', 'dd', 'aaaa', 'bbbb']\n\ndef test_check():\n    check(sorted_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_prefixes(string: str) -> List[str]:\n    \"\"\" Return list of all prefixes from shortest to longest of the input string\n    >>> all_prefixes('abc')\n    ['a', 'ab', 'abc']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('asdfgh') == ['a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh']\n    assert candidate('WWW') == ['W', 'WW', 'WWW']\n\ndef test_check():\n    check(all_prefixes)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "py",
+    "prompt": "def x_or_y(n: int, x: int, y: int) -> int:\n    \"\"\"A simple program which should return the value of x if n is \n    a prime number and should return the value of y otherwise.\n\n    Examples:\n    >>> x_or_y(7, 34, 12)\n    34\n    >>> x_or_y(15, 8, 5)\n    5\n    \n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7, 34, 12) == 34\n    assert candidate(15, 8, 5) == 5\n    assert candidate(3, 33, 5212) == 33\n    assert candidate(1259, 3, 52) == 3\n    assert candidate(7919, -1, 12) == -1\n    assert candidate(3609, 1245, 583) == 583\n    assert candidate(91, 56, 129) == 129\n    assert candidate(6, 34, 1234) == 1234\n    assert candidate(1, 2, 0) == 0\n    assert candidate(2, 2, 0) == 2\n\ndef test_check():\n    check(x_or_y)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef double_the_difference(lst: List[float]) -> int:\n    \"\"\"\n    Given a list of numbers, return the sum of squares of the numbers\n    in the list that are odd. Ignore numbers that are negative or not integers.\n    \n    >>> double_the_difference([1, 3, 2, 0])\n    10\n    >>> double_the_difference([-1, -2, 0])\n    0\n    >>> double_the_difference([9, -2])\n    81\n    >>> double_the_difference([0])\n    0\n   \n    If the input list is empty, return 0.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == 0\n    assert candidate([5.0, 4.0]) == 25\n    assert candidate([0.1, 0.2, 0.3]) == 0\n    assert candidate([-10.0, -20.0, -30.0]) == 0\n    assert candidate([-1.0, -2.0, 8.0]) == 0\n    assert candidate([0.2, 3.0, 5.0]) == 34\n    assert candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165\n\ndef test_check():\n    check(double_the_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef compare(game: List[int], guess: List[int]) -> List[int]:\n    \"\"\"I think we all remember that feeling when the result of some long-awaited\n    event is finally known. The feelings and thoughts you have at that moment are\n    definitely worth noting down and comparing.\n    Your task is to determine if a person correctly guessed the results of a number of matches.\n    You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    \n    \n    example:\n\n    >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n    [0, 0, 0, 0, 3, 3]\n    >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n    [4, 4, 1, 0, 0, 6]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3]\n    assert candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0]\n    assert candidate([1, 2, 3], [-1, -2, -3]) == [2, 4, 6]\n    assert candidate([1, 2, 3, 5], [-1, 2, 3, 4]) == [2, 0, 0, 1]\n\ndef test_check():\n    check(compare)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Strongest_Extension(class_name: str, extensions: List[str]) -> str:\n    \"\"\"You will be given the name of a class (a string) and a list of extensions.\n    The extensions are to be used to load additional classes to the class. The\n    strength of the extension is as follows: Let CAP be the number of the uppercase\n    letters in the extension's name, and let SM be the number of lowercase letters \n    in the extension's name, the strength is given by the fraction CAP - SM. \n    You should find the strongest extension and return a string in this \n    format: ClassName.StrongestExtensionName.\n    If there are two or more extensions with the same strength, you should\n    choose the one that comes first in the list.\n    For example, if you are given \"Slices\" as the class and a list of the\n    extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    (its strength is -1).\n    Example:\n    >>> Strongest_Extension('my_class', ['AA', 'Be', 'CC'])\n    'my_class.AA'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Watashi', ['tEN', 'niNE', 'eIGHt8OKe']) == 'Watashi.eIGHt8OKe'\n    assert candidate('Boku123', ['nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg']) == 'Boku123.YEs.WeCaNe'\n    assert candidate('__YESIMHERE', ['t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321']) == '__YESIMHERE.NuLl__'\n    assert candidate('K', ['Ta', 'TAR', 't234An', 'cosSo']) == 'K.TAR'\n    assert candidate('__HAHA', ['Tab', '123', '781345', '-_-']) == '__HAHA.123'\n    assert candidate('YameRore', ['HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-']) == 'YameRore.okIWILL123'\n    assert candidate('finNNalLLly', ['Die', 'NowW', 'Wow', 'WoW']) == 'finNNalLLly.WoW'\n    assert candidate('_', ['Bb', '91245']) == '_.Bb'\n    assert candidate('Sp', ['671235', 'Bb']) == 'Sp.671235'\n\ndef test_check():\n    check(Strongest_Extension)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "py",
+    "prompt": "def cycpattern_check(a: str, b: str) -> bool:\n    \"\"\"You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    >>> cycpattern_check('abcd', 'abd')\n    False\n    >>> cycpattern_check('hello', 'ell')\n    True\n    >>> cycpattern_check('whassup', 'psus')\n    False\n    >>> cycpattern_check('abab', 'baa')\n    True\n    >>> cycpattern_check('efef', 'eeff')\n    False\n    >>> cycpattern_check('himenss', 'simen')\n    True\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('xyzw', 'xyw') == False\n    assert candidate('yello', 'ell') == True\n    assert candidate('whattup', 'ptut') == False\n    assert candidate('efef', 'fee') == True\n    assert candidate('abab', 'aabb') == False\n    assert candidate('winemtt', 'tinem') == True\n\ndef test_check():\n    check(cycpattern_check)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef even_odd_count(num: int) -> Tuple[int, int]:\n    \"\"\"Given an integer. return a tuple that has the number of even and odd digits respectively.\n\n     Example:\n    >>> even_odd_count(-12)\n    (1, 1)\n    >>> even_odd_count(123)\n    (1, 2)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7) == (0, 1)\n    assert candidate(-78) == (1, 1)\n    assert candidate(3452) == (2, 2)\n    assert candidate(346211) == (3, 3)\n    assert candidate(-345821) == (3, 3)\n    assert candidate(-2) == (1, 0)\n    assert candidate(-45347) == (2, 3)\n    assert candidate(0) == (1, 0)\n\ndef test_check():\n    check(even_odd_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "py",
+    "prompt": "def int_to_mini_roman(number: int) -> str:\n    \"\"\"\n    Given a positive integer, obtain its roman numeral equivalent as a string,\n    and return it in lowercase.\n    Restrictions: 1 <= num <= 1000\n\n    Examples:\n    >>> int_to_mini_roman(19)\n    'xix'\n    >>> int_to_mini_roman(152)\n    'clii'\n    >>> int_to_mini_roman(426)\n    'cdxxvi'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(19) == 'xix'\n    assert candidate(152) == 'clii'\n    assert candidate(251) == 'ccli'\n    assert candidate(426) == 'cdxxvi'\n    assert candidate(500) == 'd'\n    assert candidate(1) == 'i'\n    assert candidate(4) == 'iv'\n    assert candidate(43) == 'xliii'\n    assert candidate(90) == 'xc'\n    assert candidate(94) == 'xciv'\n    assert candidate(532) == 'dxxxii'\n    assert candidate(900) == 'cm'\n    assert candidate(994) == 'cmxciv'\n    assert candidate(1000) == 'm'\n\ndef test_check():\n    check(int_to_mini_roman)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "py",
+    "prompt": "def right_angle_triangle(a: int, b: int, c: int) -> bool:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return True if the three\n    sides form a right-angled triangle, False otherwise.\n    A right-angled triangle is a triangle in which one angle is right angle or \n    90 degree.\n    Example:\n    >>> right_angle_triangle(3, 4, 5)\n    True\n    >>> right_angle_triangle(1, 2, 3)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == True\n    assert candidate(1, 2, 3) == False\n    assert candidate(10, 6, 8) == True\n    assert candidate(2, 2, 2) == False\n    assert candidate(7, 24, 25) == True\n    assert candidate(10, 5, 7) == False\n    assert candidate(5, 12, 13) == True\n    assert candidate(15, 8, 17) == True\n    assert candidate(48, 55, 73) == True\n    assert candidate(1, 1, 1) == False\n    assert candidate(2, 2, 10) == False\n\ndef test_check():\n    check(right_angle_triangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_max(words: List[str]) -> str:\n    \"\"\"Write a function that accepts a list of strings.\n    The list contains different words. Return the word with maximum number\n    of unique characters. If multiple strings have maximum number of unique\n    characters, return the one which comes first in lexicographical order.\n\n    >>> find_max(['name', 'of', 'string'])\n    'string'\n    >>> find_max(['name', 'enam', 'game'])\n    'enam'\n    >>> find_max(['aaaaaaa', 'bb', 'cc'])\n    'aaaaaaa'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['name', 'of', 'string']) == 'string'\n    assert candidate(['name', 'enam', 'game']) == 'enam'\n    assert candidate(['aaaaaaa', 'bb', 'cc']) == 'aaaaaaa'\n    assert candidate(['abc', 'cba']) == 'abc'\n    assert candidate(['play', 'this', 'game', 'of', 'footbott']) == 'footbott'\n    assert candidate(['we', 'are', 'gonna', 'rock']) == 'gonna'\n    assert candidate(['we', 'are', 'a', 'mad', 'nation']) == 'nation'\n    assert candidate(['this', 'is', 'a', 'prrk']) == 'this'\n    assert candidate(['b']) == 'b'\n    assert candidate(['play', 'play', 'play']) == 'play'\n\ndef test_check():\n    check(find_max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef eat(number: int, need: int, remaining: int) -> List[int]:\n    \"\"\"\n    You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    but now you need to eat more carrots to complete the day's meals.\n    you should return an array of [ total number of eaten carrots after your meals,\n                                    the number of carrots left after your meals ]\n    if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    \n    Example:\n    >>> eat(5, 6, 10)\n    [11, 4]\n    >>> eat(4, 8, 9)\n    [12, 1]\n    >>> eat(1, 10, 10)\n    [11, 0]\n    >>> eat(2, 11, 5)\n    [7, 0]\n    \n    Variables:\n    @number : integer\n        the number of carrots that you have eaten.\n    @need : integer\n        the number of carrots that you need to eat.\n    @remaining : integer\n        the number of remaining carrots thet exist in stock\n    \n    Constrain:\n    * 0 <= number <= 1000\n    * 0 <= need <= 1000\n    * 0 <= remaining <= 1000\n\n    Have fun :)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 6, 10) == [11, 4]\n    assert candidate(4, 8, 9) == [12, 1]\n    assert candidate(1, 10, 10) == [11, 0]\n    assert candidate(2, 11, 5) == [7, 0]\n    assert candidate(4, 5, 7) == [9, 2]\n    assert candidate(4, 5, 1) == [5, 0]\n\ndef test_check():\n    check(eat)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "py",
+    "prompt": "def string_sequence(n: int) -> str:\n    \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    >>> string_sequence(0)\n    '0'\n    >>> string_sequence(5)\n    '0 1 2 3 4 5'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == '0'\n    assert candidate(3) == '0 1 2 3'\n    assert candidate(10) == '0 1 2 3 4 5 6 7 8 9 10'\n\ndef test_check():\n    check(string_sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef do_algebra(operator: List[str], operand: List[int]) -> int:\n    \"\"\"\n    Given two lists operator, and operand. The first list has basic algebra operations, and \n    the second list is a list of integers. Use the two given lists to build the algebric \n    expression and return the evaluation of this expression.\n\n    The basic algebra operations:\n    Addition ( + ) \n    Subtraction ( - ) \n    Multiplication ( * ) \n    Floor division ( // ) \n    Exponentiation ( ** ) \n\n    Example:\n    operator['+', '*', '-']\n    array = [2, 3, 4, 5]\n    result = 2 + 3 * 4 - 5\n    => result = 9\n\n    Note:\n        The length of operator list is equal to the length of operand list minus one.\n        Operand is a list of of non-negative integers.\n        Operator list has at least one operator, and operand list has at least two operands.\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['**', '*', '+'], [2, 3, 4, 5]) == 37\n    assert candidate(['+', '*', '-'], [2, 3, 4, 5]) == 9\n    assert candidate(['//', '*'], [7, 3, 4]) == 8\n\ndef test_check():\n    check(do_algebra)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "py",
+    "prompt": "def solve(s: str) -> str:\n    \"\"\"You are given a string s.\n    if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    otherwise keep it as it is.\n    If the string contains no letters, reverse the string.\n    The function should return the resulted string.\n    Examples\n    >>> solve('1234')\n    '4321'\n    >>> solve('ab')\n    'AB'\n    >>> solve('#a@C')\n    '#A@c'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AsDf') == 'aSdF'\n    assert candidate('1234') == '4321'\n    assert candidate('ab') == 'AB'\n    assert candidate('#a@C') == '#A@c'\n    assert candidate('#AsdfW^45') == '#aSDFw^45'\n    assert candidate('#6@2') == '2@6#'\n    assert candidate('#$a^D') == '#$A^d'\n    assert candidate('#ccc') == '#CCC'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef string_to_md5(text: str) -> Optional[str]:\n    \"\"\"\n    Given a string 'text', return its md5 hash equivalent string.\n    If 'text' is an empty string, return None.\n\n    >>> string_to_md5('Hello world')\n    '3e25960a79dbc69b674cd4ec67a72c62'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    assert candidate('') == None\n    assert candidate('A B C') == '0ef78513b0cb8cef12743f5aeb35f888'\n    assert candidate('password') == '5f4dcc3b5aa765d61d8327deb882cf99'\n\ndef test_check():\n    check(string_to_md5)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2299,7 +1054,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef generate_integers(a: int, b: int) -> List[int]:\n    \"\"\"\n    Given two positive integers a and b, return the even digits between a\n    and b, in ascending order.\n\n    For example:\n    >>> generate_integers(2, 8)\n    [2, 4, 6, 8]\n    >>> generate_integers(8, 2)\n    [2, 4, 6, 8]\n    >>> generate_integers(10, 14)\n    []\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(2, 10) == [2, 4, 6, 8]\n    assert candidate(10, 2) == [2, 4, 6, 8]\n    assert candidate(132, 2) == [2, 4, 6, 8]\n    assert candidate(17, 89) == []\n\ndef test_check():\n    check(generate_integers)\n\ntest_check()\n",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "py",
-    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
+    "prompt": "def count_distinct_characters(string: str) -> int:\n    \"\"\" Given a string, find out how many distinct characters (regardless of case) does it consist of\n    >>> count_distinct_characters('xyzXYZ')\n    3\n    >>> count_distinct_characters('Jerry')\n    4\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abcde') == 5\n    assert candidate('abcdecadeCADE') == 5\n    assert candidate('aaaaAAAAaaaa') == 1\n    assert candidate('Jerry jERRY JeRRRY') == 5\n\ndef test_check():\n    check(count_distinct_characters)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "py",
-    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
+    "prompt": "from typing import List\n\ndef parse_music(music_string: str) -> List[int]:\n    \"\"\" Input to this function is a string representing musical notes in a special ASCII format.\n    Your task is to parse this string and return list of integers corresponding to how many beats does each\n    not last.\n\n    Here is a legend:\n    'o' - whole note, lasts four beats\n    'o|' - half note, lasts two beats\n    '.|' - quater note, lasts one beat\n\n    >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == []\n    assert candidate('o o o o') == [4, 4, 4, 4]\n    assert candidate('.| .| .| .|') == [1, 1, 1, 1]\n    assert candidate('o| o| .| .| o o o o') == [2, 2, 1, 1, 4, 4, 4, 4]\n    assert candidate('o| .| o| .| o o| o o|') == [2, 1, 2, 1, 4, 2, 4, 2]\n\ndef test_check():\n    check(parse_music)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "py",
-    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\n",
+    "prompt": "def how_many_times(string: str, substring: str) -> int:\n    \"\"\" Find how many times a given substring can be found in the original string. Count overlaping cases.\n    >>> how_many_times('', 'a')\n    0\n    >>> how_many_times('aaa', 'a')\n    3\n    >>> how_many_times('aaaa', 'aa')\n    3\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('', 'x') == 0\n    assert candidate('xyxyxyx', 'x') == 4\n    assert candidate('cacacacac', 'cac') == 4\n    assert candidate('john doe', 'john') == 1\n\ndef test_check():\n    check(how_many_times)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "py",
-    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('(')\n    False\n    >>> correct_bracketing('()')\n    True\n    >>> correct_bracketing('(()())')\n    True\n    >>> correct_bracketing(')(()')\n    False\n    \"\"\"\n",
+    "prompt": "def sort_numbers(numbers: str) -> str:\n    \"\"\" Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    Return the string with numbers sorted from smallest to largest\n    >>> sort_numbers('three one five')\n    'one three five'\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('three') == 'three'\n    assert candidate('three five nine') == 'three five nine'\n    assert candidate('five zero four seven nine eight') == 'zero four five seven eight nine'\n    assert candidate('six five four three two one zero') == 'zero one two three four five six'\n\ndef test_check():\n    check(sort_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n    \"\"\" Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    separate those group into separate strings and return the list of those.\n    Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    Ignore any spaces in the input string.\n    >>> separate_paren_groups('( ) (( )) (( )( ))')\n    ['()', '(())', '(()())']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == ['(()())', '((()))', '()', '((())()())']\n    assert candidate('() (()) ((())) (((())))') == ['()', '(())', '((()))', '(((())))']\n    assert candidate('(()(())((())))') == ['(()(())((())))']\n    assert candidate('( ) (( )) (( )( ))') == ['()', '(())', '(()())']\n\ndef test_check():\n    check(separate_paren_groups)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_closest_elements(numbers: List[float]) -> Tuple[float, float]:\n    \"\"\" From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    other and return them in order (smaller number, larger number).\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    (2.0, 2.2)\n    >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    (2.0, 2.0)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0)\n    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2)\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0)\n    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1)\n\ndef test_check():\n    check(find_closest_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rescale_to_unit(numbers: List[float]) -> List[float]:\n    \"\"\" Given list of numbers (of at least two elements), apply a linear transform to that list,\n    such that the smallest number will become 0 and the largest will become 1\n    >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    [0.0, 0.25, 0.5, 0.75, 1.0]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2.0, 49.9]) == [0.0, 1.0]\n    assert candidate([100.0, 49.9]) == [1.0, 0.0]\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0]\n    assert candidate([2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n    assert candidate([12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75]\n\ndef test_check():\n    check(rescale_to_unit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef filter_integers(values: List[Any]) -> List[int]:\n    \"\"\" Filter given list of any python values only for integers\n    >>> filter_integers(['a', 3.14, 5])\n    [5]\n    >>> filter_integers([1, 2, 3, 'abc', {  }, []])\n    [1, 2, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([4, {  }, [], 23.2, 9, 'adasd']) == [4, 9]\n    assert candidate([3, 'c', 3, 3, 'a', 'b']) == [3, 3, 3]\n\ndef test_check():\n    check(filter_integers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "py",
+    "prompt": "def strlen(string: str) -> int:\n    \"\"\" Return length of given string\n    >>> strlen('')\n    0\n    >>> strlen('abc')\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('x') == 1\n    assert candidate('asdasnakj') == 9\n\ndef test_check():\n    check(strlen)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "py",
+    "prompt": "def largest_divisor(n: int) -> int:\n    \"\"\" For a given number n, find the largest number that divides n evenly, smaller than n\n    >>> largest_divisor(15)\n    5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 1\n    assert candidate(7) == 1\n    assert candidate(10) == 5\n    assert candidate(100) == 50\n    assert candidate(49) == 7\n\ndef test_check():\n    check(largest_divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef factorize(n: int) -> List[int]:\n    \"\"\" Return list of prime factors of given integer in the order from smallest to largest.\n    Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    Input number should be equal to the product of all factors\n    >>> factorize(8)\n    [2, 2, 2]\n    >>> factorize(25)\n    [5, 5]\n    >>> factorize(70)\n    [2, 5, 7]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == [2]\n    assert candidate(4) == [2, 2]\n    assert candidate(8) == [2, 2, 2]\n    assert candidate(57) == [3, 19]\n    assert candidate(3249) == [3, 3, 19, 19]\n    assert candidate(185193) == [3, 3, 3, 19, 19, 19]\n    assert candidate(20577) == [3, 19, 19, 19]\n    assert candidate(18) == [2, 3, 3]\n\ndef test_check():\n    check(factorize)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_duplicates(numbers: List[int]) -> List[int]:\n    \"\"\" From a list of integers, remove all elements that occur more than once.\n    Keep order of elements left the same as in the input.\n    >>> remove_duplicates([1, 2, 3, 2, 4])\n    [1, 3, 4]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5]\n\ndef test_check():\n    check(remove_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "py",
+    "prompt": "def flip_case(string: str) -> str:\n    \"\"\" For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    >>> flip_case('Hello')\n    'hELLO'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('Hello!') == 'hELLO!'\n    assert candidate('These violent delights have violent ends') == 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS'\n\ndef test_check():\n    check(flip_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef concatenate(strings: List[str]) -> str:\n    \"\"\" Concatenate list of strings into a single string\n    >>> concatenate([])\n    ''\n    >>> concatenate(['a', 'b', 'c'])\n    'abc'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == ''\n    assert candidate(['x', 'y', 'z']) == 'xyz'\n    assert candidate(['x', 'y', 'z', 'w', 'k']) == 'xyzwk'\n\ndef test_check():\n    check(concatenate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_prefix(strings: List[str], prefix: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that start with a given prefix.\n    >>> filter_by_prefix([], 'a')\n    []\n    >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    ['abc', 'array']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n\ndef test_check():\n    check(filter_by_prefix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "py",
+    "prompt": "def truncate_number(number: float) -> float:\n    \"\"\" Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3.5) == 0.5\n    assert candidate(1.25) == 0.25\n    assert candidate(123.0) == 0.0\n\ndef test_check():\n    check(truncate_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_positive(l: List[int]) -> List[int]:\n    \"\"\"Return only positive numbers in the list.\n    >>> get_positive([-1, 2, -4, 5, 6])\n    [2, 5, 6]\n    >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    [5, 3, 2, 3, 9, 123, 1]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-1, -2, 4, 5, 6]) == [4, 5, 6]\n    assert candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1]\n    assert candidate([-1, -2]) == []\n    assert candidate([]) == []\n\ndef test_check():\n    check(get_positive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "py",
+    "prompt": "def is_prime(n: int) -> bool:\n    \"\"\"Return true if a given number is prime, and false otherwise.\n    >>> is_prime(6)\n    False\n    >>> is_prime(101)\n    True\n    >>> is_prime(11)\n    True\n    >>> is_prime(13441)\n    True\n    >>> is_prime(61)\n    True\n    >>> is_prime(4)\n    False\n    >>> is_prime(1)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(6) == False\n    assert candidate(101) == True\n    assert candidate(11) == True\n    assert candidate(13441) == True\n    assert candidate(61) == True\n    assert candidate(4) == False\n    assert candidate(1) == False\n    assert candidate(5) == True\n    assert candidate(11) == True\n    assert candidate(17) == True\n    assert candidate(85) == False\n    assert candidate(77) == False\n    assert candidate(255379) == False\n\ndef test_check():\n    check(is_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_third(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    to the values of the corresponding indicies of l, but sorted.\n    >>> sort_third([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    [2, 6, 3, 4, 8, 9, 5]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5]\n    assert candidate([5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5]\n    assert candidate([5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5]\n    assert candidate([5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1]\n\ndef test_check():\n    check(sort_third)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique(l: List[int]) -> List[int]:\n    \"\"\"Return sorted unique elements in a list\n    >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [0, 2, 3, 5, 9, 123]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123]\n\ndef test_check():\n    check(unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_element(l: List[int]) -> int:\n    \"\"\"Return maximum element in the list.\n    >>> max_element([1, 2, 3])\n    3\n    >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    123\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124\n\ndef test_check():\n    check(max_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "py",
+    "prompt": "def fizz_buzz(n: int) -> int:\n    \"\"\"Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    >>> fizz_buzz(50)\n    0\n    >>> fizz_buzz(78)\n    2\n    >>> fizz_buzz(79)\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(50) == 0\n    assert candidate(78) == 2\n    assert candidate(79) == 3\n    assert candidate(100) == 3\n    assert candidate(200) == 6\n    assert candidate(4000) == 192\n    assert candidate(10000) == 639\n    assert candidate(100000) == 8026\n\ndef test_check():\n    check(fizz_buzz)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2374,9 +1399,249 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef sort_even(l: List[int]) -> List[int]:\n    \"\"\"This function takes a list l and returns a list l' such that\n    l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    to the values of the even indicies of l, but sorted.\n    >>> sort_even([1, 2, 3])\n    [1, 2, 3]\n    >>> sort_even([5, 6, 3, 4])\n    [3, 6, 5, 4]\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]\n    assert candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]\n\ndef test_check():\n    check(sort_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "py",
+    "prompt": "def prime_fib(n: int) -> int:\n    \"\"\"\n    prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    >>> prime_fib(1)\n    2\n    >>> prime_fib(2)\n    3\n    >>> prime_fib(3)\n    5\n    >>> prime_fib(4)\n    13\n    >>> prime_fib(5)\n    89\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 2\n    assert candidate(2) == 3\n    assert candidate(3) == 5\n    assert candidate(4) == 13\n    assert candidate(5) == 89\n    assert candidate(6) == 233\n    assert candidate(7) == 1597\n    assert candidate(8) == 28657\n    assert candidate(9) == 514229\n    assert candidate(10) == 433494437\n\ndef test_check():\n    check(prime_fib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_zero(operations: List[int]) -> bool:\n    \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with\n    zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    at that point function should return True. Otherwise it should return False.\n    >>> below_zero([1, 2, 3])\n    False\n    >>> below_zero([1, 2, -4, 5])\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == False\n    assert candidate([1, 2, -3, 1, 2, -3]) == False\n    assert candidate([1, 2, -4, 5, 6]) == True\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False\n    assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True\n    assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True\n\ndef test_check():\n    check(below_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef triples_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    triples_sum_to_zero takes a list of integers as an input.\n    it returns True if there are three distinct elements in the list that\n    sum to zero, and False otherwise.\n\n    >>> triples_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> triples_sum_to_zero([1, 3, -2, 1])\n    True\n    >>> triples_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    True\n    >>> triples_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, 5, -1]) == False\n    assert candidate([1, 3, -2, 1]) == True\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([1, 2, 5, 7]) == False\n    assert candidate([2, 4, -5, 3, 9, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([1, 3, 5, -100]) == False\n    assert candidate([100, 3, 5, -100]) == False\n\ndef test_check():\n    check(triples_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "py",
+    "prompt": "def car_race_collision(n: int) -> int:\n    \"\"\"\n    Imagine a road that's a perfectly straight infinitely long line.\n    n cars are driving left to right;  simultaneously, a different set of n cars\n    are driving right to left.   The two sets of cars start out being very far from\n    each other.  All cars move in the same speed.  Two cars are said to collide\n    when a car that's moving left to right hits a car that's moving right to left.\n    However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    in their trajectory as if they did not collide.\n\n    This function outputs the number of such collisions.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 9\n    assert candidate(4) == 16\n    assert candidate(8) == 64\n    assert candidate(10) == 100\n\ndef test_check():\n    check(car_race_collision)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef incr_list(l: List[int]) -> List[int]:\n    \"\"\"Return list with elements incremented by 1.\n    >>> incr_list([1, 2, 3])\n    [2, 3, 4]\n    >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([3, 2, 1]) == [4, 3, 2]\n    assert candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124]\n\ndef test_check():\n    check(incr_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pairs_sum_to_zero(l: List[int]) -> bool:\n    \"\"\"\n    pairs_sum_to_zero takes a list of integers as an input.\n    it returns True if there are two distinct elements in the list that\n    sum to zero, and False otherwise.\n    >>> pairs_sum_to_zero([1, 3, 5, 0])\n    False\n    >>> pairs_sum_to_zero([1, 3, -2, 1])\n    False\n    >>> pairs_sum_to_zero([1, 2, 3, 7])\n    False\n    >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    True\n    >>> pairs_sum_to_zero([1])\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 0]) == False\n    assert candidate([1, 3, -2, 1]) == False\n    assert candidate([1, 2, 3, 7]) == False\n    assert candidate([2, 4, -5, 3, 5, 7]) == True\n    assert candidate([1]) == False\n    assert candidate([-3, 9, -1, 3, 2, 30]) == True\n    assert candidate([-3, 9, -1, 3, 2, 31]) == True\n    assert candidate([-3, 9, -1, 4, 2, 30]) == False\n    assert candidate([-3, 9, -1, 4, 2, 31]) == False\n\ndef test_check():\n    check(pairs_sum_to_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "py",
+    "prompt": "def change_base(x: int, base: int) -> str:\n    \"\"\"Change numerical base of input number x to base.\n    return string representation after the conversion.\n    base numbers are less than 10.\n    >>> change_base(8, 3)\n    '22'\n    >>> change_base(8, 2)\n    '1000'\n    >>> change_base(7, 2)\n    '111'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(8, 3) == '22'\n    assert candidate(9, 3) == '100'\n    assert candidate(234, 2) == '11101010'\n    assert candidate(16, 2) == '10000'\n    assert candidate(8, 2) == '1000'\n    assert candidate(7, 2) == '111'\n    assert candidate(2, 3) == '2'\n    assert candidate(3, 4) == '3'\n    assert candidate(4, 5) == '4'\n    assert candidate(5, 6) == '5'\n    assert candidate(6, 7) == '6'\n    assert candidate(7, 8) == '7'\n\ndef test_check():\n    check(change_base)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, h: int) -> float:\n    \"\"\"Given length of a side and high return area for a triangle.\n    >>> triangle_area(5, 3)\n    7.5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 3) == 7.5\n    assert candidate(2, 2) == 2.0\n    assert candidate(10, 8) == 40.0\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "py",
+    "prompt": "def fib4(n: int) -> int:\n    \"\"\"The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fib4(0) -> 0\n    fib4(1) -> 0\n    fib4(2) -> 2\n    fib4(3) -> 0\n    fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    >>> fib4(5)\n    4\n    >>> fib4(6)\n    8\n    >>> fib4(7)\n    14\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 4\n    assert candidate(8) == 28\n    assert candidate(10) == 104\n    assert candidate(12) == 386\n\ndef test_check():\n    check(fib4)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef median(l: List[int]) -> float:\n    \"\"\"Return median of elements in the list l.\n    >>> median([3, 1, 2, 4, 5])\n    3\n    >>> median([-10, 4, 6, 1000, 10, 20])\n    15.0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == 3\n    assert candidate([-10, 4, 6, 1000, 10, 20]) == 8.0\n    assert candidate([5]) == 5\n    assert candidate([6, 5]) == 5.5\n    assert candidate([8, 1, 3, 9, 9, 2, 7]) == 7\n\ndef test_check():\n    check(median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "py",
+    "prompt": "def is_palindrome(text: str) -> bool:\n    \"\"\"\n    Checks if given string is a palindrome\n    >>> is_palindrome('')\n    True\n    >>> is_palindrome('aba')\n    True\n    >>> is_palindrome('aaaaa')\n    True\n    >>> is_palindrome('zbcd')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == True\n    assert candidate('aba') == True\n    assert candidate('aaaaa') == True\n    assert candidate('zbcd') == False\n    assert candidate('xywyx') == True\n    assert candidate('xywyz') == False\n    assert candidate('xywzx') == False\n\ndef test_check():\n    check(is_palindrome)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "py",
+    "prompt": "def modp(n: int, p: int) -> int:\n    \"\"\"Return 2^n modulo p (be aware of numerics).\n    >>> modp(3, 5)\n    3\n    >>> modp(1101, 101)\n    2\n    >>> modp(0, 101)\n    1\n    >>> modp(3, 11)\n    8\n    >>> modp(100, 101)\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 5) == 3\n    assert candidate(1101, 101) == 2\n    assert candidate(0, 101) == 1\n    assert candidate(3, 11) == 8\n    assert candidate(100, 101) == 1\n    assert candidate(30, 5) == 4\n    assert candidate(31, 5) == 3\n\ndef test_check():\n    check(modp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mean_absolute_deviation(numbers: List[float]) -> float:\n    \"\"\" For a given list of input numbers, calculate Mean Absolute Deviation\n    around the mean of this dataset.\n    Mean Absolute Deviation is the average absolute difference between each\n    element and a centerpoint (mean in this case):\n    MAD = average | x - x_mean |\n    >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    1.0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1.0, 2.0]) == 0.5\n    assert candidate([1.0, 2.0, 3.0, 4.0]) == 1.0\n    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2\n\ndef test_check():\n    check(mean_absolute_deviation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "py",
+    "prompt": "def remove_vowels(text: str) -> str:\n    \"\"\"\n    remove_vowels is a function that takes string and returns string without vowels.\n    >>> remove_vowels('')\n    ''\n    >>> remove_vowels('abcdef')\n    'bcdf'\n    >>> remove_vowels('aaaaa')\n    ''\n    >>> remove_vowels('aaBAA')\n    'B'\n    >>> remove_vowels('zbcd')\n    'zbcd'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == ''\n    assert candidate('abcdef\\nghijklm') == 'bcdf\\nghjklm'\n    assert candidate('fedcba') == 'fdcb'\n    assert candidate('eeeee') == ''\n    assert candidate('acBAA') == 'cB'\n    assert candidate('EcBOO') == 'cB'\n    assert candidate('ybcd') == 'ybcd'\n\ndef test_check():\n    check(remove_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef below_threshold(l: List[int], t: int) -> bool:\n    \"\"\"Return True if all numbers in the list l are below threshold t.\n    >>> below_threshold([1, 2, 4, 10], 100)\n    True\n    >>> below_threshold([1, 20, 4, 10], 5)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10], 100) == True\n    assert candidate([1, 20, 4, 10], 5) == False\n    assert candidate([1, 20, 4, 10], 21) == True\n    assert candidate([1, 20, 4, 10], 22) == True\n    assert candidate([1, 8, 4, 10], 11) == True\n    assert candidate([1, 8, 4, 10], 10) == False\n\ndef test_check():\n    check(below_threshold)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "py",
+    "prompt": "def add(x: int, y: int) -> int:\n    \"\"\"Add two numbers x and y\n    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0, 1) == 1\n    assert candidate(1, 0) == 1\n    assert candidate(2, 3) == 5\n    assert candidate(5, 7) == 12\n    assert candidate(7, 5) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2389,9 +1654,24 @@
     "language": "py",
     "prompt": "def same_chars(s0: str, s1: str) -> bool:\n    \"\"\"\n    Check if two words have the same characters.\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    True\n    >>> same_chars('abcd', 'dddddddabc')\n    True\n    >>> same_chars('dddddddabc', 'abcd')\n    True\n    >>> same_chars('eabcd', 'dddddddabc')\n    False\n    >>> same_chars('abcd', 'dddddddabce')\n    False\n    >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddeddabc') == True\n    assert candidate('abcd', 'dddddddabc') == True\n    assert candidate('dddddddabc', 'abcd') == True\n    assert candidate('eabcd', 'dddddddabc') == False\n    assert candidate('abcd', 'dddddddabcf') == False\n    assert candidate('eabcdzzzz', 'dddzzzzzzzddddabc') == False\n    assert candidate('aabb', 'aaccc') == False\n\ndef test_check():\n    check(same_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "py",
+    "prompt": "def fib(n: int) -> int:\n    \"\"\"Return n-th Fibonacci number.\n    >>> fib(10)\n    55\n    >>> fib(1)\n    1\n    >>> fib(8)\n    21\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 55\n    assert candidate(1) == 1\n    assert candidate(8) == 21\n    assert candidate(11) == 89\n    assert candidate(12) == 144\n\ndef test_check():\n    check(fib)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -2404,9 +1684,729 @@
     "language": "py",
     "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"<\" and \">\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('<')\n    False\n    >>> correct_bracketing('<>')\n    True\n    >>> correct_bracketing('<<><>>')\n    True\n    >>> correct_bracketing('><<>')\n    False\n    \"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('<>') == True\n    assert candidate('<<><>>') == True\n    assert candidate('<><><<><>><>') == True\n    assert candidate('<><><<<><><>><>><<><><<>>>') == True\n    assert candidate('<<<><>>>>') == False\n    assert candidate('><<>') == False\n    assert candidate('<') == False\n    assert candidate('<<<<') == False\n    assert candidate('>') == False\n    assert candidate('<<>') == False\n    assert candidate('<><><<><>><>><<>') == False\n    assert candidate('<><><<><>><>>><>') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef monotonic(l: List[int]) -> bool:\n    \"\"\"Return True is list elements are monotonically increasing or decreasing.\n    >>> monotonic([1, 2, 4, 20])\n    True\n    >>> monotonic([1, 20, 4, 10])\n    False\n    >>> monotonic([4, 1, 0, -10])\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 10]) == True\n    assert candidate([1, 2, 4, 20]) == True\n    assert candidate([1, 20, 4, 10]) == False\n    assert candidate([4, 1, 0, -10]) == True\n    assert candidate([4, 1, 1, 0]) == True\n    assert candidate([1, 2, 3, 2, 5, 60]) == False\n    assert candidate([1, 2, 3, 4, 5, 60]) == True\n    assert candidate([9, 9, 9, 9]) == True\n\ndef test_check():\n    check(monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef common(l1: List[int], l2: List[int]) -> List[int]:\n    \"\"\"Return sorted unique common elements for two lists.\n    >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    [1, 5, 653]\n    >>> common([5, 3, 2, 8], [3, 2])\n    [2, 3]\n\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653]\n    assert candidate([5, 3, 2, 8], [3, 2]) == [2, 3]\n    assert candidate([4, 3, 2, 8], [3, 2, 4]) == [2, 3, 4]\n    assert candidate([4, 3, 2, 8], []) == []\n\ndef test_check():\n    check(common)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "py",
+    "prompt": "def largest_prime_factor(n: int) -> int:\n    \"\"\"Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    >>> largest_prime_factor(13195)\n    29\n    >>> largest_prime_factor(2048)\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(15) == 5\n    assert candidate(27) == 3\n    assert candidate(63) == 7\n    assert candidate(330) == 11\n    assert candidate(13195) == 29\n\ndef test_check():\n    check(largest_prime_factor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersperse(numbers: List[int], delimeter: int) -> List[int]:\n    \"\"\" Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    >>> intersperse([], 4)\n    []\n    >>> intersperse([1, 2, 3], 4)\n    [1, 4, 2, 4, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 7) == []\n    assert candidate([5, 6, 3, 2], 8) == [5, 8, 6, 8, 3, 8, 2]\n    assert candidate([2, 2, 2], 2) == [2, 2, 2, 2, 2]\n\ndef test_check():\n    check(intersperse)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "py",
+    "prompt": "def sum_to_n(n: int) -> int:\n    \"\"\"sum_to_n is a function that sums numbers from 1 to n.\n    >>> sum_to_n(30)\n    465\n    >>> sum_to_n(100)\n    5050\n    >>> sum_to_n(5)\n    15\n    >>> sum_to_n(10)\n    55\n    >>> sum_to_n(1)\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(6) == 21\n    assert candidate(11) == 66\n    assert candidate(30) == 465\n    assert candidate(100) == 5050\n\ndef test_check():\n    check(sum_to_n)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "py",
+    "prompt": "def correct_bracketing(brackets: str) -> bool:\n    \"\"\" brackets is a string of \"(\" and \")\".\n    return True if every opening bracket has a corresponding closing bracket.\n\n    >>> correct_bracketing('(')\n    False\n    >>> correct_bracketing('()')\n    True\n    >>> correct_bracketing('(()())')\n    True\n    >>> correct_bracketing(')(()')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('()') == True\n    assert candidate('(()())') == True\n    assert candidate('()()(()())()') == True\n    assert candidate('()()((()()())())(()()(()))') == True\n    assert candidate('((()())))') == False\n    assert candidate(')(()') == False\n    assert candidate('(') == False\n    assert candidate('((((') == False\n    assert candidate(')') == False\n    assert candidate('(()') == False\n    assert candidate('()()(()())())(()') == False\n    assert candidate('()()(()())()))()') == False\n\ndef test_check():\n    check(correct_bracketing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef derivative(xs: List[int]) -> List[int]:\n    \"\"\" xs represent coefficients of a polynomial.\n    xs[0] + xs[1] * x + xs[2] * x^2 + ....\n     Return derivative of this polynomial in the same form.\n    >>> derivative([3, 1, 2, 4, 5])\n    [1, 4, 12, 20]\n    >>> derivative([1, 2, 3])\n    [2, 6]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 1, 2, 4, 5]) == [1, 4, 12, 20]\n    assert candidate([1, 2, 3]) == [2, 6]\n    assert candidate([3, 2, 1]) == [2, 2]\n    assert candidate([3, 2, 1, 0, 4]) == [2, 2, 0, 16]\n    assert candidate([1]) == []\n\ndef test_check():\n    check(derivative)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "py",
+    "prompt": "def fibfib(n: int) -> int:\n    \"\"\"The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    fibfib(0) == 0\n    fibfib(1) == 0\n    fibfib(2) == 1\n    fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    >>> fibfib(1)\n    0\n    >>> fibfib(5)\n    4\n    >>> fibfib(8)\n    24\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(1) == 0\n    assert candidate(5) == 4\n    assert candidate(8) == 24\n    assert candidate(10) == 81\n    assert candidate(12) == 274\n    assert candidate(14) == 927\n\ndef test_check():\n    check(fibfib)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "py",
+    "prompt": "def vowels_count(s: str) -> int:\n    \"\"\"Write a function vowels_count which takes a string representing\n    a word as input and returns the number of vowels in the string.\n    Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    vowel, but only when it is at the end of the given word.\n\n    Example:\n    >>> vowels_count('abcde')\n    2\n    >>> vowels_count('ACEDY')\n    3\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcde') == 2\n    assert candidate('Alone') == 3\n    assert candidate('key') == 2\n    assert candidate('bye') == 1\n    assert candidate('keY') == 2\n    assert candidate('bYe') == 1\n    assert candidate('ACEDY') == 3\n\ndef test_check():\n    check(vowels_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "py",
+    "prompt": "def circular_shift(x: int, shift: int) -> str:\n    \"\"\"Circular shift the digits of the integer x, shift the digits right by shift\n    and return the result as a string.\n    If shift > number of digits, return digits reversed.\n    >>> circular_shift(12, 1)\n    '21'\n    >>> circular_shift(12, 2)\n    '12'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(100, 2) == '001'\n    assert candidate(12, 2) == '12'\n    assert candidate(97, 8) == '79'\n    assert candidate(12, 1) == '21'\n    assert candidate(11, 101) == '11'\n\ndef test_check():\n    check(circular_shift)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "py",
+    "prompt": "def digitSum(s: str) -> int:\n    \"\"\"Task\n    Write a function that takes a string as input and returns the sum of the upper characters only'\n    ASCII codes.\n\n    Examples:\n    >>> digitSum('')\n    0\n    >>> digitSum('abAB')\n    131\n    >>> digitSum('abcCd')\n    67\n    >>> digitSum('helloE')\n    69\n    >>> digitSum('woArBld')\n    131\n    >>> digitSum('aAaaaXa')\n    153\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('') == 0\n    assert candidate('abAB') == 131\n    assert candidate('abcCd') == 67\n    assert candidate('helloE') == 69\n    assert candidate('woArBld') == 131\n    assert candidate('aAaaaXa') == 153\n    assert candidate(' How are yOu?') == 151\n    assert candidate('You arE Very Smart') == 327\n\ndef test_check():\n    check(digitSum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "py",
+    "prompt": "def fruit_distribution(s: str, n: int) -> int:\n    \"\"\"\n    In this task, you will be given a string that represents a number of apples and oranges \n    that are distributed in a basket of fruit this basket contains \n    apples, oranges, and mango fruits. Given the string that represents the total number of \n    the oranges and apples and an integer that represent the total number of the fruits \n    in the basket return the number of the mango fruits in the basket.\n    for examble:\n    >>> fruit_distribution('5 apples and 6 oranges', 19)\n    8\n    >>> fruit_distribution('0 apples and 1 oranges', 3)\n    2\n    >>> fruit_distribution('2 apples and 3 oranges', 100)\n    95\n    >>> fruit_distribution('100 apples and 1 oranges', 120)\n    19\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('5 apples and 6 oranges', 19) == 8\n    assert candidate('5 apples and 6 oranges', 21) == 10\n    assert candidate('0 apples and 1 oranges', 3) == 2\n    assert candidate('1 apples and 0 oranges', 3) == 2\n    assert candidate('2 apples and 3 oranges', 100) == 95\n    assert candidate('2 apples and 3 oranges', 5) == 0\n    assert candidate('1 apples and 100 oranges', 120) == 19\n\ndef test_check():\n    check(fruit_distribution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pluck(arr: List[int]) -> List[int]:\n    \"\"\"\n    \"Given an array representing a branch of a tree that has non-negative integer nodes\n    your task is to pluck one of the nodes and return it.\n    The plucked node should be the node with the smallest even value.\n    If multiple nodes with the same smallest even value are found return the node that has smallest index.\n\n    The plucked node should be returned in a list, [ smalest_value, its index ],\n    If there are no even values or the given array is empty, return [].\n\n    Example 1:\n    >>> pluck([4, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 2:\n    >>> pluck([1, 2, 3])\n    [2, 1]\n    Explanation: 2 has the smallest even value, and 2 has the smallest index.\n\n    Example 3:\n    >>> pluck([])\n    []\n    \n    Example 4:\n    >>> pluck([5, 0, 3, 0, 4, 2])\n    [0, 1]\n    Explanation: 0 is the smallest value, but  there are two zeros,\n                 so we will choose the first zero, which has the smallest index.\n\n    Constraints:\n        * 1 <= nodes.length <= 10000\n        * 0 <= node.value\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 2, 3]) == [2, 1]\n    assert candidate([1, 2, 3]) == [2, 1]\n    assert candidate([]) == []\n    assert candidate([5, 0, 3, 0, 4, 2]) == [0, 1]\n    assert candidate([1, 2, 3, 0, 5, 3]) == [0, 3]\n    assert candidate([5, 4, 8, 4, 8]) == [4, 1]\n    assert candidate([7, 6, 7, 1]) == [6, 1]\n    assert candidate([7, 9, 7, 1]) == []\n\ndef test_check():\n    check(pluck)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef search(lst: List[int]) -> int:\n    \"\"\"\n    You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    zero, and has a frequency greater than or equal to the value of the integer itself. \n    The frequency of an integer is the number of times it appears in the list.\n    If no such a value exist, return -1.\n    Examples:\n    >>> search([4, 1, 2, 2, 3, 1])\n    2\n    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n    3\n    >>> search([5, 5, 4, 4, 4])\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 5, 5, 5, 1]) == 1\n    assert candidate([4, 1, 4, 1, 4, 4]) == 4\n    assert candidate([3, 3]) == -1\n    assert candidate([8, 8, 8, 8, 8, 8, 8, 8]) == 8\n    assert candidate([2, 3, 3, 2, 2]) == 2\n    assert candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1\n    assert candidate([3, 2, 8, 2]) == 2\n    assert candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1\n    assert candidate([8, 8, 3, 6, 5, 6, 4]) == -1\n    assert candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1\n    assert candidate([1, 9, 10, 1, 3]) == 1\n    assert candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5\n    assert candidate([1]) == 1\n    assert candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4\n    assert candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2\n    assert candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1\n    assert candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4\n    assert candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4\n    assert candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2\n    assert candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1\n    assert candidate([10]) == -1\n    assert candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2\n    assert candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1\n    assert candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1\n    assert candidate([3, 10, 10, 9, 2]) == -1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef parse_nested_parens(paren_string: str) -> List[int]:\n    \"\"\" Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    For each of the group, output the deepest level of nesting of parentheses.\n    E.g. (()()) has maximum two levels of nesting while ((())) has three.\n\n    >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    [2, 3, 1, 3]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(()()) ((())) () ((())()())') == [2, 3, 1, 3]\n    assert candidate('() (()) ((())) (((())))') == [1, 2, 3, 4]\n    assert candidate('(()(())((())))') == [4]\n\ndef test_check():\n    check(parse_nested_parens)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef strange_sort_list(lst: List[int]) -> List[int]:\n    \"\"\"\n    Given list of integers, return list in strange order.\n    Strange sorting, is when you start with the minimum value,\n    then maximum of the remaining integers, then minimum and so on.\n\n    Examples:\n    >>> strange_sort_list([1, 2, 3, 4])\n    [1, 4, 2, 3]\n    >>> strange_sort_list([5, 5, 5, 5])\n    [5, 5, 5, 5]\n    >>> strange_sort_list([])\n    []\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == [1, 4, 2, 3]\n    assert candidate([5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3]\n    assert candidate([5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7]\n    assert candidate([5, 5, 5, 5]) == [5, 5, 5, 5]\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5]\n    assert candidate([0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2]\n    assert candidate([111111]) == [111111]\n\ndef test_check():\n    check(strange_sort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "py",
+    "prompt": "def triangle_area(a: int, b: int, c: int) -> float:\n    \"\"\"\n    Given the lengths of the three sides of a triangle. Return the area of\n    the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    Otherwise return -1\n    Three sides make a valid triangle when the sum of any two sides is greater \n    than the third side.\n    Example:\n    >>> triangle_area(3, 4, 5)\n    6.0\n    >>> triangle_area(1, 2, 10)\n    -1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4, 5) == 6.0\n    assert candidate(1, 2, 10) == -1\n    assert candidate(4, 8, 5) == 8.18\n    assert candidate(2, 2, 2) == 1.73\n    assert candidate(1, 2, 3) == -1\n    assert candidate(10, 5, 7) == 16.25\n    assert candidate(2, 6, 3) == -1\n    assert candidate(1, 1, 1) == 0.43\n    assert candidate(2, 2, 10) == -1\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef will_it_fly(q: List[int], w: int) -> bool:\n    \"\"\"\n    Write a function that returns True if the object q will fly, and False otherwise.\n    The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n\n    Example:\n    >>> will_it_fly([1, 2], 5)\n    False\n    # 1+2 is less than the maximum possible weight, but it's unbalanced.\n\n    >>> will_it_fly([3, 2, 3], 1)\n    False\n    # it's balanced, but 3+2+3 is more than the maximum possible weight.\n\n    >>> will_it_fly([3, 2, 3], 9)\n    True\n    # 3+2+3 is less than the maximum possible weight, and it's balanced.\n\n    >>> will_it_fly([3], 5)\n    True\n    # 3 is less than the maximum possible weight, and it's balanced.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 3], 9) == True\n    assert candidate([1, 2], 5) == False\n    assert candidate([3], 5) == True\n    assert candidate([3, 2, 3], 1) == False\n    assert candidate([1, 2, 3], 6) == False\n    assert candidate([5], 5) == True\n\ndef test_check():\n    check(will_it_fly)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_change(arr: List[int]) -> int:\n    \"\"\"\n    Given an array arr of integers, find the minimum number of elements that\n    need to be changed to make the array palindromic. A palindromic array is an array that\n    is read the same backwards and forwards. In one change, you can change one element to any other element.\n\n    For example:\n    >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n    4\n    >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n    1\n    >>> smallest_change([1, 2, 3, 2, 1])\n    0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 4, 7, 9, 6]) == 4\n    assert candidate([1, 2, 3, 4, 3, 2, 2]) == 1\n    assert candidate([1, 4, 2]) == 1\n    assert candidate([1, 4, 4, 2]) == 1\n    assert candidate([1, 2, 3, 2, 1]) == 0\n    assert candidate([3, 1, 1, 3]) == 0\n    assert candidate([1]) == 0\n    assert candidate([0, 1]) == 1\n\ndef test_check():\n    check(smallest_change)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef total_match(lst1: List[str], lst2: List[str]) -> List[str]:\n    \"\"\"\n    Write a function that accepts two lists of strings and returns the list that has \n    total number of chars in the all strings of the list less than the other list.\n\n    if the two lists have the same number of chars, return the first list.\n\n    Examples\n    >>> total_match([], [])\n    []\n    >>> total_match(['hi', 'admin'], ['hI', 'Hi'])\n    ['hI', 'Hi']\n    >>> total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project'])\n    ['hi', 'admin']\n    >>> total_match(['hi', 'admin'], ['hI', 'hi', 'hi'])\n    ['hI', 'hi', 'hi']\n    >>> total_match(['4'], ['1', '2', '3', '4', '5'])\n    ['4']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], []) == []\n    assert candidate(['hi', 'admin'], ['hi', 'hi']) == ['hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) == ['hi', 'admin']\n    assert candidate(['4'], ['1', '2', '3', '4', '5']) == ['4']\n    assert candidate(['hi', 'admin'], ['hI', 'Hi']) == ['hI', 'Hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hi']) == ['hI', 'hi', 'hi']\n    assert candidate(['hi', 'admin'], ['hI', 'hi', 'hii']) == ['hi', 'admin']\n    assert candidate([], ['this']) == []\n    assert candidate(['this'], []) == []\n\ndef test_check():\n    check(total_match)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "py",
+    "prompt": "def is_multiply_prime(a: int) -> bool:\n    \"\"\"Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    and false otherwise.\n    Knowing that (a) is less then 100. \n    Example:\n    >>> is_multiply_prime(30)\n    True\n    30 = 2 * 3 * 5\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == False\n    assert candidate(30) == True\n    assert candidate(8) == True\n    assert candidate(10) == False\n    assert candidate(125) == True\n    assert candidate(105) == True\n    assert candidate(126) == False\n    assert candidate(729) == False\n    assert candidate(891) == False\n    assert candidate(1001) == True\n\ndef test_check():\n    check(is_multiply_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "py",
+    "prompt": "def is_simple_power(x: int, n: int) -> bool:\n    \"\"\"Your task is to write a function that returns true if a number x is a simple\n    power of n and false in other cases.\n    x is a simple power of n if n**int=x\n    For example:\n    >>> is_simple_power(1, 4)\n    True\n    >>> is_simple_power(2, 2)\n    True\n    >>> is_simple_power(8, 2)\n    True\n    >>> is_simple_power(3, 2)\n    False\n    >>> is_simple_power(3, 1)\n    False\n    >>> is_simple_power(5, 3)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == True\n    assert candidate(143214, 16) == False\n    assert candidate(4, 2) == True\n    assert candidate(9, 3) == True\n    assert candidate(16, 4) == True\n    assert candidate(24, 2) == False\n    assert candidate(128, 4) == False\n    assert candidate(12, 6) == False\n    assert candidate(1, 1) == True\n    assert candidate(1, 12) == True\n\ndef test_check():\n    check(is_simple_power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "py",
+    "prompt": "def iscube(a: int) -> bool:\n    \"\"\"\n    Write a function that takes an integer a and returns True \n    if this ingeger is a cube of some integer number.\n    Note: you may assume the input is always valid.\n    Examples:\n    >>> iscube(1)\n    True\n    >>> iscube(2)\n    False\n    >>> iscube(-1)\n    True\n    >>> iscube(64)\n    True\n    >>> iscube(0)\n    True\n    >>> iscube(180)\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == True\n    assert candidate(2) == False\n    assert candidate(-1) == True\n    assert candidate(64) == True\n    assert candidate(180) == False\n    assert candidate(1000) == True\n    assert candidate(0) == True\n    assert candidate(1729) == False\n\ndef test_check():\n    check(iscube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "py",
+    "prompt": "def hex_key(num: str) -> int:\n    \"\"\"You have been tasked to write a function that receives \n    a hexadecimal number as a string and counts the number of hexadecimal \n    digits that are primes (prime number, or a prime, is a natural number \n    greater than 1 that is not a product of two smaller natural numbers).\n    Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    So you have to determine a number of the following digits: 2, 3, 5, 7, \n    B (=decimal 11), D (=decimal 13).\n    Note: you may assume the input is always correct or empty string, \n    and symbols A,B,C,D,E,F are always uppercase.\n    Examples:\n    >>> hex_key('AB')\n    1\n    >>> hex_key('1077E')\n    2\n    >>> hex_key('ABED1A33')\n    4\n    >>> hex_key('123456789ABCDEF0')\n    6\n    >>> hex_key('2020')\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AB') == 1\n    assert candidate('1077E') == 2\n    assert candidate('ABED1A33') == 4\n    assert candidate('2020') == 2\n    assert candidate('123456789ABCDEF0') == 6\n    assert candidate('112233445566778899AABBCCDDEEFF00') == 12\n\ndef test_check():\n    check(hex_key)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(decimal: int) -> str:\n    \"\"\"You will be given a number in decimal form and your task is to convert it to\n    binary format. The function should return a string, with each character representing a binary\n    number. Each character in the string will be '0' or '1'.\n\n    There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    The extra characters are there to help with the format.\n\n    Examples:\n    >>> decimal_to_binary(15)\n    'db1111db'\n    >>> decimal_to_binary(32)\n    'db100000db'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == 'db0db'\n    assert candidate(32) == 'db100000db'\n    assert candidate(103) == 'db1100111db'\n    assert candidate(15) == 'db1111db'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_by_substring(strings: List[str], substring: str) -> List[str]:\n    \"\"\" Filter an input list of strings only for ones that contain given substring\n    >>> filter_by_substring([], 'a')\n    []\n    >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    ['abc', 'bacd', 'array']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([], 'john') == []\n    assert candidate(['xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'], 'xxx') == ['xxx', 'xxxAAA', 'xxx']\n    assert candidate(['xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'], 'xx') == ['xxx', 'aaaxxy', 'xxxAAA', 'xxx']\n    assert candidate(['grunt', 'trumpet', 'prune', 'gruesome'], 'run') == ['grunt', 'prune']\n\ndef test_check():\n    check(filter_by_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "py",
+    "prompt": "def is_happy(s: str) -> bool:\n    \"\"\"You are given a string s.\n    Your task is to check if the string is happy or not.\n    A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    For example:\n    >>> is_happy('a')\n    False\n    >>> is_happy('aa')\n    False\n    >>> is_happy('abcd')\n    True\n    >>> is_happy('aabb')\n    False\n    >>> is_happy('adb')\n    True\n    >>> is_happy('xyy')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('a') == False\n    assert candidate('aa') == False\n    assert candidate('abcd') == True\n    assert candidate('aabb') == False\n    assert candidate('adb') == True\n    assert candidate('xyy') == False\n    assert candidate('iopaxpoi') == True\n    assert candidate('iopaxioi') == False\n\ndef test_check():\n    check(is_happy)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef numerical_letter_grade(grades: List[float]) -> List[str]:\n    \"\"\"It is the last week of the semester and the teacher has to give the grades\n    to students. The teacher has been making her own algorithm for grading.\n    The only problem is, she has lost the code she used for grading.\n    She has given you a list of GPAs for some students and you have to write \n    a function that can output a list of letter grades using the following table:\n             GPA       |    Letter grade\n              4.0                A+\n            > 3.7                A \n            > 3.3                A- \n            > 3.0                B+\n            > 2.7                B \n            > 2.3                B-\n            > 2.0                C+\n            > 1.7                C\n            > 1.3                C-\n            > 1.0                D+ \n            > 0.7                D \n            > 0.0                D-\n              0.0                E\n    \n\n    Example:\n    >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n    ['A+', 'B', 'C-', 'C', 'A-']\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4.0, 3, 1.7, 2, 3.5]) == ['A+', 'B', 'C-', 'C', 'A-']\n    assert candidate([1.2]) == ['D+']\n    assert candidate([0.5]) == ['D-']\n    assert candidate([0.0]) == ['E']\n    assert candidate([1.0, 0.3, 1.5, 2.8, 3.3]) == ['D', 'D-', 'C-', 'B', 'B+']\n    assert candidate([0.0, 0.7]) == ['E', 'D-']\n\ndef test_check():\n    check(numerical_letter_grade)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "py",
+    "prompt": "def prime_length(string: str) -> bool:\n    \"\"\"Write a function that takes a string and returns True if the string\n    length is a prime number or False otherwise\n    Examples\n    >>> prime_length('Hello')\n    True\n    >>> prime_length('abcdcba')\n    True\n    >>> prime_length('kittens')\n    True\n    >>> prime_length('orange')\n    False\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello') == True\n    assert candidate('abcdcba') == True\n    assert candidate('kittens') == True\n    assert candidate('orange') == False\n    assert candidate('wow') == True\n    assert candidate('world') == True\n    assert candidate('MadaM') == True\n    assert candidate('Wow') == True\n    assert candidate('') == False\n    assert candidate('HI') == True\n    assert candidate('go') == True\n    assert candidate('gogo') == False\n    assert candidate('aaaaaaaaaaaaaaa') == False\n    assert candidate('Madam') == True\n    assert candidate('M') == False\n    assert candidate('0') == False\n\ndef test_check():\n    check(prime_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "py",
+    "prompt": "def starts_one_ends(n: int) -> int:\n    \"\"\"\n    Given a positive integer n, return the count of the numbers of n-digit\n    positive integers that start or end with 1.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 18\n    assert candidate(3) == 180\n    assert candidate(4) == 1800\n    assert candidate(5) == 18000\n\ndef test_check():\n    check(starts_one_ends)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "py",
+    "prompt": "def solve(N: int) -> str:\n    \"\"\"Given a positive integer N, return the total sum of its digits in binary.\n    \n    Example\n    >>> solve(1000)\n    '1'\n    >>> solve(150)\n    '110'\n    >>> solve(147)\n    '1100'\n    \n    Variables:\n        @N integer\n             Constraints: 0 \u2264 N \u2264 10000.\n    Output:\n         a string of binary number\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1000) == '1'\n    assert candidate(150) == '110'\n    assert candidate(147) == '1100'\n    assert candidate(333) == '1001'\n    assert candidate(963) == '10010'\n\ndef test_check():\n    check(solve)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add(lst: List[int]) -> int:\n    \"\"\"Given a non-empty list of integers lst. add the even elements that are at odd indices..\n\n\n    Examples:\n    >>> add([4, 2, 6, 7])\n    2\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 88]) == 88\n    assert candidate([4, 5, 6, 7, 2, 122]) == 122\n    assert candidate([4, 0, 6, 7]) == 0\n    assert candidate([4, 4, 6, 8]) == 12\n\ndef test_check():\n    check(add)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "py",
+    "prompt": "def anti_shuffle(s: str) -> str:\n    \"\"\"\n    Write a function that takes a string and returns an ordered version of it.\n    Ordered version of string, is a string where all words (separated by space)\n    are replaced by a new word where all the characters arranged in\n    ascending order based on ascii value.\n    Note: You should keep the order of words and blank spaces in the sentence.\n\n    For example:\n    >>> anti_shuffle('Hi')\n    'Hi'\n    >>> anti_shuffle('hello')\n    'ehllo'\n    >>> anti_shuffle('Hello World!!!')\n    'Hello !!!Wdlor'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hi') == 'Hi'\n    assert candidate('hello') == 'ehllo'\n    assert candidate('number') == 'bemnru'\n    assert candidate('abcd') == 'abcd'\n    assert candidate('Hello World!!!') == 'Hello !!!Wdlor'\n    assert candidate('') == ''\n    assert candidate('Hi. My name is Mister Robot. How are you?') == '.Hi My aemn is Meirst .Rboot How aer ?ouy'\n\ndef test_check():\n    check(anti_shuffle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef get_row(lst: List[List[int]], x: int) -> List[Tuple[int, int]]:\n    \"\"\"\n    You are given a 2 dimensional data, as a nested lists,\n    which is similar to matrix, however, unlike matrices,\n    each row may contain a different number of columns.\n    Given lst, and integer x, find integers x in the list,\n    and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    each tuple is a coordinate - (row, columns), starting with 0.\n    Sort coordinates initially by rows in ascending order.\n    Also, sort coordinates of the row by columns in descending order.\n    \n    Examples:\n    >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n    [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    >>> get_row([], 1)\n    []\n    >>> get_row([[], [1], [1, 2, 3]], 3)\n    [(2, 2)]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]\n    assert candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]\n    assert candidate([], 1) == []\n    assert candidate([[1]], 2) == []\n    assert candidate([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n\ndef test_check():\n    check(get_row)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_array(array: List[int]) -> List[int]:\n    \"\"\"\n    Given an array of non-negative integers, return a copy of the given array after sorting,\n    you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    or sort it in descending order if the sum( first index value, last index value) is even.\n\n    Note:\n    * don't change the given array.\n\n    Examples:\n    >>> sort_array([])\n    []\n    >>> sort_array([5])\n    [5]\n    >>> sort_array([2, 4, 3, 0, 1, 5])\n    [0, 1, 2, 3, 4, 5]\n    >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n    [6, 5, 4, 3, 2, 1, 0]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([5]) == [5]\n    assert candidate([2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5]\n    assert candidate([2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0]\n    assert candidate([2, 1]) == [1, 2]\n    assert candidate([15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87]\n    assert candidate([21, 14, 23, 11]) == [23, 21, 14, 11]\n\ndef test_check():\n    check(sort_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "py",
+    "prompt": "def encrypt(s: str) -> str:\n    \"\"\"Create a function encrypt that takes a string as an argument and\n    returns a string encrypted with the alphabet being rotated. \n    The alphabet should be rotated in a manner such that the letters \n    shift down by two multiplied to two places.\n    For example:\n    >>> encrypt('hi')\n    'lm'\n    >>> encrypt('asdfghjkl')\n    'ewhjklnop'\n    >>> encrypt('gf')\n    'kj'\n    >>> encrypt('et')\n    'ix'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('hi') == 'lm'\n    assert candidate('asdfghjkl') == 'ewhjklnop'\n    assert candidate('gf') == 'kj'\n    assert candidate('et') == 'ix'\n    assert candidate('faewfawefaewg') == 'jeiajeaijeiak'\n    assert candidate('hellomyfriend') == 'lippsqcjvmirh'\n    assert candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh') == 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl'\n    assert candidate('a') == 'e'\n\ndef test_check():\n    check(encrypt)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    Empty sum should be equal to 0 and empty product should be equal to 1.\n    >>> sum_product([])\n    (0, 1)\n    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == (0, 1)\n    assert candidate([1, 1, 1]) == (3, 1)\n    assert candidate([100, 0]) == (100, 0)\n    assert candidate([3, 5, 7]) == (15, 105)\n    assert candidate([10]) == (10, 10)\n\ndef test_check():\n    check(sum_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Optional\n\ndef next_smallest(lst: List[int]) -> Optional[int]:\n    \"\"\"\n    You are given a list of integers.\n    Write a function next_smallest() that returns the 2nd smallest element of the list.\n    Return None if there is no such element.\n    >>> next_smallest([1, 2, 3, 4, 5])\n    2\n    >>> next_smallest([5, 1, 4, 3, 2])\n    2\n    >>> next_smallest([])\n    None\n    >>> next_smallest([1, 1])\n    None\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == 2\n    assert candidate([5, 1, 4, 3, 2]) == 2\n    assert candidate([]) == None\n    assert candidate([1, 1]) == None\n    assert candidate([1, 1, 1, 1, 0]) == 1\n    assert candidate([1, 1]) == None\n    assert candidate([-35, 34, 12, -45]) == -35\n\ndef test_check():\n    check(next_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "py",
+    "prompt": "def is_bored(S: str) -> int:\n    \"\"\"\n    You'll be given a string of words, and your task is to count the number\n    of boredoms. A boredom is a sentence that starts with the word \"I\".\n    Sentences are delimited by '.', '?' or '!'.\n   \n    For example:\n    >>> is_bored('Hello world')\n    0\n    >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n    1\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hello world') == 0\n    assert candidate('Is the sky blue?') == 0\n    assert candidate('I love It !') == 1\n    assert candidate('bIt') == 0\n    assert candidate('I feel good today. I will be productive. will kill It') == 2\n    assert candidate('You and I are going for a walk') == 0\n\ndef test_check():\n    check(is_bored)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "py",
+    "prompt": "def any_int(x: float, y: float, z: float) -> bool:\n    \"\"\"\n    Create a function that takes 3 numbers.\n    Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    Returns false in any other cases.\n    \n    Examples\n    >>> any_int(5, 2, 7)\n    True\n    \n    >>> any_int(3, 2, 2)\n    False\n\n    >>> any_int(3, -2, 1)\n    True\n    \n    >>> any_int(3.6, -2.2, 2)\n    False\n  \n\n    \n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 1) == True\n    assert candidate(2.5, 2, 3) == False\n    assert candidate(1.5, 5, 3.5) == False\n    assert candidate(2, 6, 2) == False\n    assert candidate(4, 2, 2) == True\n    assert candidate(2.2, 2.2, 2.2) == False\n    assert candidate(-4, 6, 2) == True\n    assert candidate(2, 1, 1) == True\n    assert candidate(3, 4, 7) == True\n    assert candidate(3.0, 4, 7) == False\n\ndef test_check():\n    check(any_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "py",
+    "prompt": "def encode(message: str) -> str:\n    \"\"\"\n    Write a function that takes a message, and encodes in such a \n    way that it swaps case of all letters, replaces all vowels in \n    the message with the letter that appears 2 places ahead of that \n    vowel in the english alphabet. \n    Assume only letters. \n    \n    Examples:\n    >>> encode('test')\n    'TGST'\n    >>> encode('This is a message')\n    'tHKS KS C MGSSCGG'\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('TEST') == 'tgst'\n    assert candidate('Mudasir') == 'mWDCSKR'\n    assert candidate('YES') == 'ygs'\n    assert candidate('This is a message') == 'tHKS KS C MGSSCGG'\n    assert candidate('I DoNt KnOw WhAt tO WrItE') == 'k dQnT kNqW wHcT Tq wRkTg'\n\ndef test_check():\n    check(encode)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef skjkasdkd(lst: List[int]) -> int:\n    \"\"\"You are given a list of integers.\n    You need to find the largest prime value and return the sum of its digits.\n\n    Examples:\n    >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n    10\n    >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n    25\n    >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n    13\n    >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n    11\n    >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n    3\n    >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n    7\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10\n    assert candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25\n    assert candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13\n    assert candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11\n    assert candidate([0, 81, 12, 3, 1, 21]) == 3\n    assert candidate([0, 8, 1, 2, 1, 7]) == 7\n    assert candidate([8191]) == 19\n    assert candidate([8191, 123456, 127, 7]) == 19\n    assert candidate([127, 97, 8192]) == 10\n\ndef test_check():\n    check(skjkasdkd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_dict_case(dict: Dict[str, str]) -> bool:\n    \"\"\"\n    Given a dictionary, return True if all keys are strings in lower \n    case or all keys are strings in upper case, else return False.\n    The function should return False is the given dictionary is empty.\n    Examples:\n    >>> check_dict_case({ 'a': 'apple', 'b': 'banana' })\n    True\n    >>> check_dict_case({ 'a': 'apple', 'A': 'banana', 'B': 'banana' })\n    False\n    >>> check_dict_case({ 'a': 'apple', 8: 'banana', 'a': 'apple' })\n    False\n    >>> check_dict_case({ 'Name': 'John', 'Age': '36', 'City': 'Houston' })\n    False\n    >>> check_dict_case({ 'STATE': 'NC', 'ZIP': '12345' })\n    True\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'p': 'pineapple', 'b': 'banana' }) == True\n    assert candidate({ 'p': 'pineapple', 'A': 'banana', 'B': 'banana' }) == False\n    assert candidate({ 'p': 'pineapple', '5': 'banana', 'a': 'apple' }) == False\n    assert candidate({ 'Name': 'John', 'Age': '36', 'City': 'Houston' }) == False\n    assert candidate({ 'STATE': 'NC', 'ZIP': '12345' }) == True\n    assert candidate({ 'fruit': 'Orange', 'taste': 'Sweet' }) == True\n    assert candidate({  }) == False\n\ndef test_check():\n    check(check_dict_case)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_up_to(n: int) -> List[int]:\n    \"\"\"Implement a function that takes an non-negative integer and returns an array of the first n\n    integers that are prime numbers and less than n.\n    for example:\n    >>> count_up_to(5)\n    [2, 3]\n    >>> count_up_to(11)\n    [2, 3, 5, 7]\n    >>> count_up_to(0)\n    []\n    >>> count_up_to(20)\n    [2, 3, 5, 7, 11, 13, 17, 19]\n    >>> count_up_to(1)\n    []\n    >>> count_up_to(18)\n    [2, 3, 5, 7, 11, 13, 17]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == [2, 3]\n    assert candidate(6) == [2, 3, 5]\n    assert candidate(7) == [2, 3, 5]\n    assert candidate(10) == [2, 3, 5, 7]\n    assert candidate(0) == []\n    assert candidate(22) == [2, 3, 5, 7, 11, 13, 17, 19]\n    assert candidate(1) == []\n    assert candidate(18) == [2, 3, 5, 7, 11, 13, 17]\n    assert candidate(47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]\n    assert candidate(101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]\n\ndef test_check():\n    check(count_up_to)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "py",
+    "prompt": "def multiply(a: int, b: int) -> int:\n    \"\"\"Complete the function that takes two integers and returns \n    the product of their unit digits.\n    Assume the input is always valid.\n    Examples:\n    >>> multiply(148, 412)\n    16\n    >>> multiply(19, 28)\n    72\n    >>> multiply(2020, 1851)\n    0\n    >>> multiply(14, -15)\n    20\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(148, 412) == 16\n    assert candidate(19, 28) == 72\n    assert candidate(2020, 1851) == 0\n    assert candidate(14, -15) == 20\n    assert candidate(76, 67) == 42\n    assert candidate(17, 27) == 49\n    assert candidate(0, 1) == 0\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(multiply)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "py",
+    "prompt": "def count_upper(s: str) -> int:\n    \"\"\"\n    Given a string s, count the number of uppercase vowels in even indices.\n    \n    For example:\n    >>> count_upper('aBCdEf')\n    1\n    >>> count_upper('abcdefg')\n    0\n    >>> count_upper('dBBE')\n    0\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aBCdEf') == 1\n    assert candidate('abcdefg') == 0\n    assert candidate('dBBE') == 0\n    assert candidate('B') == 0\n    assert candidate('U') == 1\n    assert candidate('') == 0\n    assert candidate('EEEE') == 2\n\ndef test_check():\n    check(count_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "py",
+    "prompt": "def closest_integer(value: str) -> int:\n    \"\"\"\n    Create a function that takes a value (string) representing a number\n    and returns the closest integer to it. If the number is equidistant\n    from two integers, round it away from zero.\n\n    Examples\n    >>> closest_integer('10')\n    10\n    >>> closest_integer('15.3')\n    15\n\n    Note:\n    Rounding away from zero means that if the given number is equidistant\n    from two integers, the one you should return is the one that is the\n    farthest from zero. For example closest_integer(\"14.5\") should\n    return 15 and closest_integer(\"-14.5\") should return -15.\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('10') == 10\n    assert candidate('14.5') == 15\n    assert candidate('-15.5') == -16\n    assert candidate('15.3') == 15\n    assert candidate('0') == 0\n\ndef test_check():\n    check(closest_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\" From a given list of integers, generate a list of rolling maximum element found until given moment\n    in the sequence.\n    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n    \"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([]) == []\n    assert candidate([1, 2, 3, 4]) == [1, 2, 3, 4]\n    assert candidate([4, 3, 2, 1]) == [4, 4, 4, 4]\n    assert candidate([3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100]\n\ndef test_check():\n    check(rolling_max)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/humaneval-r-keep.json
+++ b/prompts/humaneval-r-keep.json
@@ -1,1091 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "r",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\niscube <- function(a) {",
+    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\nhas_close_elements <- function(numbers, threshold) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "r",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "r",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\nsolution <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "r",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "r",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "r",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\nminSubArraySum <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "r",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\nrounded_avg <- function(n, m) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "r",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nis_bored <- function(S) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nget_odd_collatz <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "r",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "r",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\nbelow_threshold <- function(l, t) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "r",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\nany_int <- function(x, y, z) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "r",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\nx_or_y <- function(n, x, y) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "r",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "r",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "r",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\ntriples_sum_to_zero <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "r",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\nis_happy <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "r",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfile_name_check <- function(file_name) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "r",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\nhistogram <- function(test) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "r",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\nlargest_smallest_integers <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "r",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\nsimplify <- function(x, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "r",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "r",
-    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nreverse_delete <- function(s, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_delete\n    stopifnot(isTRUE(all.equal(candidate('abcde', 'ae'), list('bcd', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef', 'b'), list('acdef', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'ab'), list('cdedc', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('dwik', 'w'), list('dik', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('a', 'a'), list('', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', ''), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'v'), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('vabba', 'v'), list('abba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('mamma', 'mia'), list('', TRUE))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "r",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\nsum_product <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\nskjkasdkd <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "r",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\nall_prefixes <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\ndigits <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "r",
-    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "r",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "r",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "r",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "r",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nwords_string <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "r",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\nmonotonic <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "r",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\nfix_spaces <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "r",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\ncycpattern_check <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "r",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "r",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nparse_music <- function(music_string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "r",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "r",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsort_third <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "r",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nrescale_to_unit <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "r",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\ncount_up_to <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "r",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nmax_element <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "r",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nsorted_list_sum <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "r",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\ntotal_match <- function(lst1, lst2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\ntriangle_area <- function(a, b, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "r",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\ncheck_if_last_char_is_a_letter <- function(txt) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "r",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "r",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nunique <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "r",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\nsmallest_change <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "r",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nunique_digits <- function(x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "r",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\nf <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\nnext_smallest <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "r",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\nminPath <- function(grid, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "r",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "r",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\ncompare_one <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "r",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\nmatch_parens <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "r",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\nis_equal_to_sum_even <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "r",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "r",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "r",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\nencrypt <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "r",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "r",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "r",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nintersperse <- function(numbers, delimeter) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\nsolve <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "r",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsort_even <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)), c(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)), c(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "r",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\nbelow_zero <- function(operations) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "r",
-    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\nsame_chars <- function(s0, s1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- same_chars\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dddddddabc', 'abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcd', 'dddddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabcf'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb', 'aaccc'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "r",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\nseparate_paren_groups <- function(paren_string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "r",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\ncount_upper <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "r",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nrolling_max <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "r",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nremove_duplicates <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "r",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nselect_words <- function(s, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "r",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfind_max <- function(words) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "r",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "r",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\nsum_squares <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\nadd <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "r",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\nmultiply <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "r",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\nintersection <- function(interval1, interval2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "r",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\ntri <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "r",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\nis_simple_power <- function(x, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- has_close_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.95), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 1.0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 0.5), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1096,7 +17,7 @@
     "language": "r",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\nmake_a_pile <- function(n) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- make_a_pile\n    stopifnot(isTRUE(all.equal(candidate(3), c(3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4, 6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5, 7, 9, 11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(6, 8, 10, 12, 14, 16))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(8, 10, 12, 14, 16, 18, 20, 22))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1105,936 +26,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "r",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nwords_string <- function(s) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\nfilter_by_prefix <- function(strings, prefix) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "r",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\ndecimal_to_binary <- function(decimal) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "r",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\nis_palindrome <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "r",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "r",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nfactorize <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "r",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\ncircular_shift <- function(x, shift) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "r",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\nget_closest_vowel <- function(word) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "r",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "r",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "r",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "r",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\ncommon <- function(l1, l2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "r",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\ncan_arrange <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "r",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\nis_nested <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "r",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\nby_length <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "r",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "r",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "r",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nodd_count <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "r",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\nconcatenate <- function(strings) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "r",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\nsum_squares <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "r",
-    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nsort_array <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 2, 3, 4)), c(1, 2, 4, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, -4, -5, -6)), c(-4, -2, -6, -5, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 3, 4)), c(0, 1, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)), c(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 44, 12, 32, 5)), c(32, 3, 5, 6, 12, 44))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "r",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\nlongest <- function(strings) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nis_sorted <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "r",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\neven_odd_count <- function(num) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "r",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nderivative <- function(xs) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "r",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "r",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "r",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "r",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\nprime_length <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "r",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nnumerical_letter_grade <- function(grades) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "r",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\nsearch <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\nright_angle_triangle <- function(a, b, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "r",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "r",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\nparse_nested_parens <- function(paren_string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "r",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\ncompare <- function(game, guess) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "r",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nsort_array <- function(array) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "r",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nget_row <- function(lst, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "r",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nvowels_count <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "r",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "r",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\nis_prime <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "r",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nbf <- function(planet1, planet2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "r",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\nhex_key <- function(num) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "r",
-    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nmedian <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "r",
-    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\nspecialFilter <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- specialFilter\n    stopifnot(isTRUE(all.equal(candidate(c(5, -2, 1, -5)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, -73, 14, -15)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(33, -2, -3, 45, 21, 109)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(43, -12, 93, 125, 121, 109)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(71, -2, -33, 75, 21, 19)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "r",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "r",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\npairs_sum_to_zero <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "r",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\nstrange_sort_list <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "r",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "r",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\ncheck_dict_case <- function(dict) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "r",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\nvalid_date <- function(date) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "r",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\ncount_nums <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "r",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\nfilter_integers <- function(values) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "r",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\ndigitSum <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "r",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\norder_by_points <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "r",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "r",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\nsplit_words <- function(txt) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "r",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "r",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "r",
-    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\nhas_close_elements <- function(numbers, threshold) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- has_close_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.95), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 1.0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 0.5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "r",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfruit_distribution <- function(s, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "r",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "r",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\nint_to_mini_roman <- function(number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "r",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\ncorrect_bracketing <- function(brackets) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "r",
-    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\ncorrect_bracketing <- function(brackets) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('<>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<><>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<<><><>><>><<><><<>>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<><>>>>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>>><>'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "r",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "r",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\nprod_signs <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\nfilter_by_substring <- function(strings, substring) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "r",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nincr_list <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "r",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nget_positive <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2045,7 +43,7 @@
     "language": "r",
     "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# choose_num(12, 15) = 14\n# choose_num(13, 12) = -1\nchoose_num <- function(x, y) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -2054,13 +52,858 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "r",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\nrounded_avg <- function(n, m) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "r",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\nunique_digits <- function(x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "r",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\nby_length <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "r",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\nf <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "r",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\ncount_nums <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "r",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "r",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "r",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "r",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\nhistogram <- function(test) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "r",
+    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nreverse_delete <- function(s, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_delete\n    stopifnot(isTRUE(all.equal(candidate('abcde', 'ae'), list('bcd', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef', 'b'), list('acdef', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'ab'), list('cdedc', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('dwik', 'w'), list('dik', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('a', 'a'), list('', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', ''), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'v'), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('vabba', 'v'), list('abba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('mamma', 'mia'), list('', TRUE))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "r",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nodd_count <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "r",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\nminSubArraySum <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "r",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "r",
+    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nsort_array <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 2, 3, 4)), c(1, 2, 4, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, -4, -5, -6)), c(-4, -2, -6, -5, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 3, 4)), c(0, 1, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)), c(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 44, 12, 32, 5)), c(32, 3, 5, 6, 12, 44))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "r",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nselect_words <- function(s, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "r",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\nget_closest_vowel <- function(word) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "r",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\nmatch_parens <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "r",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "r",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "r",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\nsolution <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "r",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nget_odd_collatz <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "r",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\nvalid_date <- function(date) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "r",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\nsplit_words <- function(txt) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "r",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nis_sorted <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "r",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\nintersection <- function(interval1, interval2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "r",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\nprod_signs <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "r",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\nminPath <- function(grid, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "r",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\nlongest <- function(strings) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "r",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\ntri <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\ndigits <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "r",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\nis_nested <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "r",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\nsum_squares <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "r",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\ncheck_if_last_char_is_a_letter <- function(txt) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "r",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\ncan_arrange <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "r",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\nlargest_smallest_integers <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "r",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\ncompare_one <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "r",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\nis_equal_to_sum_even <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "r",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "r",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "r",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\nfix_spaces <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "r",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfile_name_check <- function(file_name) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "r",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\nsum_squares <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "r",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "r",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\nsimplify <- function(x, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "r",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\norder_by_points <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "r",
+    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\nspecialFilter <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- specialFilter\n    stopifnot(isTRUE(all.equal(candidate(c(5, -2, 1, -5)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, -73, 14, -15)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(33, -2, -3, 45, 21, 109)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(43, -12, 93, 125, 121, 109)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(71, -2, -33, 75, 21, 19)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "r",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "r",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nbf <- function(planet1, planet2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nsorted_list_sum <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "r",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\nall_prefixes <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "r",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\nx_or_y <- function(n, x, y) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "r",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "r",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\ncompare <- function(game, guess) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "r",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "r",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\ncycpattern_check <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "r",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\neven_odd_count <- function(num) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "r",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\nint_to_mini_roman <- function(number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\nright_angle_triangle <- function(a, b, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfind_max <- function(words) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "r",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "r",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "r",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\nsolve <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "r",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2071,7 +914,7 @@
     "language": "r",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# generate_integers(2, 8) => [2, 4, 6, 8]\n# generate_integers(8, 2) => [2, 4, 6, 8]\n# generate_integers(10, 14) => []\ngenerate_integers <- function(a, b) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- generate_integers\n    stopifnot(isTRUE(all.equal(candidate(2, 10), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(132, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(17, 89), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -2084,9 +927,1166 @@
     "language": "r",
     "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ncount_distinct_characters <- function(string) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "r",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nparse_music <- function(music_string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "r",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "r",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "r",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\nseparate_paren_groups <- function(paren_string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "r",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "r",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\nrescale_to_unit <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "r",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\nfilter_integers <- function(values) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "r",
+    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "r",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "r",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\nfactorize <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "r",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\nremove_duplicates <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "r",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "r",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\nconcatenate <- function(strings) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\nfilter_by_prefix <- function(strings, prefix) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "r",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "r",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\nget_positive <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "r",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\nis_prime <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "r",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\nsort_third <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "r",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\nunique <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "r",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\nmax_element <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "r",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "r",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\nsort_even <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)), c(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)), c(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "r",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "r",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\nbelow_zero <- function(operations) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "r",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\ntriples_sum_to_zero <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "r",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "r",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\nincr_list <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "r",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\npairs_sum_to_zero <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "r",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "r",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "r",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "r",
+    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\nmedian <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "r",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\nis_palindrome <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "r",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "r",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "r",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "r",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\nbelow_threshold <- function(l, t) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "r",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "r",
+    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\nsame_chars <- function(s0, s1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- same_chars\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dddddddabc', 'abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcd', 'dddddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabcf'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb', 'aaccc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "r",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "r",
+    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\ncorrect_bracketing <- function(brackets) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('<>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<><>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<<><><>><>><<><><<>>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<><>>>>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>>><>'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "r",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\nmonotonic <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "r",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\ncommon <- function(l1, l2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "r",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "r",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\nintersperse <- function(numbers, delimeter) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "r",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "r",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\ncorrect_bracketing <- function(brackets) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "r",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\nderivative <- function(xs) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "r",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "r",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\nvowels_count <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "r",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\ncircular_shift <- function(x, shift) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "r",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\ndigitSum <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "r",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfruit_distribution <- function(s, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "r",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "r",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\nsearch <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "r",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\nparse_nested_parens <- function(paren_string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "r",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\nstrange_sort_list <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\ntriangle_area <- function(a, b, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "r",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "r",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\nsmallest_change <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "r",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\ntotal_match <- function(lst1, lst2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "r",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "r",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\nis_simple_power <- function(x, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "r",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\niscube <- function(a) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "r",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\nhex_key <- function(num) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "r",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\ndecimal_to_binary <- function(decimal) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\nfilter_by_substring <- function(strings, substring) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\nis_happy <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "r",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nnumerical_letter_grade <- function(grades) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\nprime_length <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "r",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "r",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\nadd <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "r",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nget_row <- function(lst, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "r",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nsort_array <- function(array) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "r",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\nencrypt <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "r",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\nsum_product <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\nnext_smallest <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "r",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\nis_bored <- function(S) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "r",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\nany_int <- function(x, y, z) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "r",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\nskjkasdkd <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "r",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\ncheck_dict_case <- function(dict) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "r",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\ncount_up_to <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "r",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\nmultiply <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "r",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\ncount_upper <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "r",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "r",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\nrolling_max <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/humaneval-r-remove.json
+++ b/prompts/humaneval-r-remove.json
@@ -1,1481 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "r",
-    "prompt": "# Return length of given string\nstrlen <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "r",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\nencrypt <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "r",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\ncheck_dict_case <- function(dict) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\nadd <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "r",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\nfix_spaces <- function(text) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "r",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfibfib <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "r",
-    "prompt": "# Filter given list of any python values only for integers\nfilter_integers <- function(values) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "r",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\nparse_music <- function(music_string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "r",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\ndecimal_to_binary <- function(decimal) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "r",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\nall_prefixes <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "r",
-    "prompt": "# Add two numbers x and y\nadd <- function(x, y) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "r",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "r",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "r",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nflip_case <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "r",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\nby_length <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "r",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\nfactorize <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "r",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\ncount_up_to <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "r",
-    "prompt": "# Return sorted unique elements in a list\nunique <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "r",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\ntotal_match <- function(lst1, lst2) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "r",
-    "prompt": "# Return maximum element in the list.\nmax_element <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "r",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\nis_nested <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "r",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\nrounded_avg <- function(n, m) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "r",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\nodd_count <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "r",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "r",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\nis_equal_to_sum_even <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "r",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\nderivative <- function(xs) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\nis_sorted <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\nsolve <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "r",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\ntri <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "r",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfizz_buzz <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\nfilter_by_prefix <- function(strings, prefix) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "r",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "r",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\nminPath <- function(grid, k) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "r",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\ncount_upper <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "r",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "r",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\nlargest_divisor <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "r",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\nsort_array <- function(array) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "r",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\nf <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "r",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\niscube <- function(a) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "r",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\nencode <- function(message) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "r",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\nis_bored <- function(S) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "r",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\npairs_sum_to_zero <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\ntriangle_area <- function(a, b, c) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "r",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\nbf <- function(planet1, planet2) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\ndigits <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "r",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\nwords_string <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "r",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\nhow_many_times <- function(string, substring) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "r",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\ncompare_one <- function(a, b) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "r",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\nremove_vowels <- function(text) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "r",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\nstrange_sort_list <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "r",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\nfind_closest_elements <- function(numbers) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "r",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\nis_simple_power <- function(x, n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "r",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nprime_fib <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "r",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\norder_by_points <- function(nums) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "r",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\nhas_close_elements <- function(numbers, threshold) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- has_close_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.95), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 1.0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 0.5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "r",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nmake_palindrome <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "r",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\nstring_xor <- function(a, b) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "r",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "r",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "r",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfib4 <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "r",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\nunique_digits <- function(x) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "r",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\nselect_words <- function(s, n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "r",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "r",
-    "prompt": "# Return n-th Fibonacci number.\nfib <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "r",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\nStrongest_Extension <- function(class_name, extensions) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "r",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\nmatch_parens <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\nnext_smallest <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "r",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\nany_int <- function(x, y, z) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "r",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\ntruncate_number <- function(number) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "r",
-    "prompt": "# Return list with elements incremented by 1.\nincr_list <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "r",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\nx_or_y <- function(n, x, y) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "r",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\nmodp <- function(n, p) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "r",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\neven_odd_count <- function(num) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\nis_happy <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "r",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlargest_prime_factor <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "r",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\ndigitSum <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "r",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\nrescale_to_unit <- function(numbers) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\nsolution <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "r",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "r",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "r",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "r",
-    "prompt": "# Return median of elements in the list l.\nmedian <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\nprime_length <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "r",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\nsmallest_change <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "r",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\nsum_squares <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "r",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\nfile_name_check <- function(file_name) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "r",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\ntriples_sum_to_zero <- function(l) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "r",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\nintersection <- function(interval1, interval2) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "r",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\nseparate_paren_groups <- function(paren_string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "r",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\ncompare <- function(game, guess) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "r",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\ncheck_if_last_char_is_a_letter <- function(txt) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "r",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\nvalid_date <- function(date) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "r",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\ncount_nums <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\nanti_shuffle <- function(s) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "r",
-    "prompt": "# Checks if given string is a palindrome\nis_palindrome <- function(text) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "r",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\nget_closest_vowel <- function(word) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "r",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\nis_prime <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "r",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\nsimplify <- function(x, n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "r",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\nhex_key <- function(num) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "r",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "r",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\nhistogram <- function(test) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "r",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\nget_row <- function(lst, x) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nget_odd_collatz <- function(n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "r",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\ncan_arrange <- function(arr) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "r",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\nsort_numbers <- function(numbers) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "r",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\ncircular_shift <- function(x, shift) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "r",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\nsum_squares <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\nskjkasdkd <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "r",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\nsum_product <- function(numbers) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "r",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\nchoose_num <- function(x, y) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "r",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\nlargest_smallest_integers <- function(lst) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "r",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\ncount_distinct_characters <- function(string) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1486,7 +17,7 @@
     "language": "r",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\nmake_a_pile <- function(n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- make_a_pile\n    stopifnot(isTRUE(all.equal(candidate(3), c(3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4, 6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5, 7, 9, 11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(6, 8, 10, 12, 14, 16))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(8, 10, 12, 14, 16, 18, 20, 22))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1495,221 +26,156 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "r",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\nprod_signs <- function(arr) {",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\nwords_string <- function(s) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "r",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\nminSubArraySum <- function(nums) {",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\nchoose_num <- function(x, y) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "r",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nstring_sequence <- function(n) {",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\nrounded_avg <- function(n, m) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "r",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\ncycpattern_check <- function(a, b) {",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\nunique_digits <- function(x) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "r",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\nmonotonic <- function(l) {",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\nby_length <- function(arr) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "r",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\nlongest <- function(strings) {",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\nf <- function(n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "r",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\nbelow_threshold <- function(l, t) {",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "r",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\ncount_nums <- function(arr) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "r",
-    "prompt": "# Return only positive numbers in the list.\nget_positive <- function(l) {",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "r",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\nsort_third <- function(l) {",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nmake_palindrome <- function(string) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "r",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\nparse_nested_parens <- function(paren_string) {",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "r",
-    "prompt": "# Given length of a side and high return area for a triangle.\ntriangle_area <- function(a, h) {",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\nhistogram <- function(test) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "r",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\nmultiply <- function(a, b) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "r",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\nmean_absolute_deviation <- function(numbers) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "r",
-    "prompt": "# Return sorted unique common elements for two lists.\ncommon <- function(l1, l2) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "r",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\nint_to_mini_roman <- function(number) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "r",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\nfruit_distribution <- function(s, n) {",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1720,7 +186,7 @@
     "language": "r",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\nreverse_delete <- function(s, c) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- reverse_delete\n    stopifnot(isTRUE(all.equal(candidate('abcde', 'ae'), list('bcd', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef', 'b'), list('acdef', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'ab'), list('cdedc', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('dwik', 'w'), list('dik', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('a', 'a'), list('', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', ''), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'v'), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('vabba', 'v'), list('abba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('mamma', 'mia'), list('', TRUE))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1729,26 +195,39 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "r",
-    "prompt": "# Return a greatest common divisor of two integers a and b\ngreatest_common_divisor <- function(a, b) {",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\nodd_count <- function(lst) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "r",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\nsplit_words <- function(txt) {",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\nminSubArraySum <- function(nums) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "r",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1759,7 +238,7 @@
     "language": "r",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\nsort_array <- function(arr) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 2, 3, 4)), c(1, 2, 4, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, -4, -5, -6)), c(-4, -2, -6, -5, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 3, 4)), c(0, 1, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)), c(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 44, 12, 32, 5)), c(32, 3, 5, 6, 12, 44))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1768,143 +247,416 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "r",
-    "prompt": "# Concatenate list of strings into a single string\nconcatenate <- function(strings) {",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\nselect_words <- function(s, n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\nsorted_list_sum <- function(lst) {",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\nget_closest_vowel <- function(word) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\nfilter_by_substring <- function(strings, substring) {",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\nmatch_parens <- function(lst) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "r",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\nstring_xor <- function(a, b) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "r",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\nvowels_count <- function(s) {",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\nfind_max <- function(words) {",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\nsolution <- function(lst) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "r",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\nstring_to_md5 <- function(text) {",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "r",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\nchange_base <- function(x, base) {",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nget_odd_collatz <- function(n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\nright_angle_triangle <- function(a, b, c) {",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\nvalid_date <- function(date) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "r",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\nnumerical_letter_grade <- function(grades) {",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\nsplit_words <- function(txt) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "r",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nintersperse <- function(numbers, delimeter) {",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\nis_sorted <- function(lst) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "r",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\nintersection <- function(interval1, interval2) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "r",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\nprod_signs <- function(arr) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "r",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\nminPath <- function(grid, k) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "r",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\nlongest <- function(strings) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "r",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\ntri <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\ndigits <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "r",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\nis_nested <- function(string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "r",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\nsum_squares <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "r",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\ncheck_if_last_char_is_a_letter <- function(txt) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "r",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\ncan_arrange <- function(arr) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "r",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\nlargest_smallest_integers <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "r",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\ncompare_one <- function(a, b) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "r",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\nis_equal_to_sum_even <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "r",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "r",
+    "prompt": "# Return a greatest common divisor of two integers a and b\ngreatest_common_divisor <- function(a, b) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "r",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\nfix_spaces <- function(text) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "r",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\nfile_name_check <- function(file_name) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "r",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\nsum_squares <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "r",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "r",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\nsimplify <- function(x, n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "r",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\norder_by_points <- function(nums) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1915,7 +667,7 @@
     "language": "r",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\nspecialFilter <- function(nums) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- specialFilter\n    stopifnot(isTRUE(all.equal(candidate(c(5, -2, 1, -5)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, -73, 14, -15)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(33, -2, -3, 45, 21, 109)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(43, -12, 93, 125, 121, 109)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(71, -2, -33, 75, 21, 19)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1924,26 +676,221 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "r",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\nsum_to_n <- function(n) {",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "r",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\nremove_duplicates <- function(numbers) {",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\nbf <- function(planet1, planet2) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\nsorted_list_sum <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "r",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\nall_prefixes <- function(string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "r",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\nx_or_y <- function(n, x, y) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "r",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "r",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\ncompare <- function(game, guess) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "r",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\nStrongest_Extension <- function(class_name, extensions) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "r",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\ncycpattern_check <- function(a, b) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "r",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\neven_odd_count <- function(num) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "r",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\nint_to_mini_roman <- function(number) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\nright_angle_triangle <- function(a, b, c) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\nfind_max <- function(words) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "r",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "r",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nstring_sequence <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\nsolve <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "r",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\nstring_to_md5 <- function(text) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1954,7 +901,7 @@
     "language": "r",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\ngenerate_integers <- function(a, b) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- generate_integers\n    stopifnot(isTRUE(all.equal(candidate(2, 10), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(132, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(17, 89), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1963,52 +910,286 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "r",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\nrolling_max <- function(numbers) {",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\ncount_distinct_characters <- function(string) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "r",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\nbelow_zero <- function(operations) {",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\nparse_music <- function(music_string) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "r",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\nsearch <- function(lst) {",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\nhow_many_times <- function(string, substring) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "r",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\ncorrect_bracketing <- function(brackets) {",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\nsort_numbers <- function(numbers) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "r",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\nseparate_paren_groups <- function(paren_string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "r",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\nfind_closest_elements <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "r",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\nrescale_to_unit <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "r",
+    "prompt": "# Filter given list of any python values only for integers\nfilter_integers <- function(values) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "r",
+    "prompt": "# Return length of given string\nstrlen <- function(string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "r",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\nlargest_divisor <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "r",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\nfactorize <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "r",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\nremove_duplicates <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "r",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nflip_case <- function(string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "r",
+    "prompt": "# Concatenate list of strings into a single string\nconcatenate <- function(strings) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\nfilter_by_prefix <- function(strings, prefix) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "r",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\ntruncate_number <- function(number) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "r",
+    "prompt": "# Return only positive numbers in the list.\nget_positive <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "r",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\nis_prime <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "r",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\nsort_third <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "r",
+    "prompt": "# Return sorted unique elements in a list\nunique <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "r",
+    "prompt": "# Return maximum element in the list.\nmax_element <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "r",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfizz_buzz <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2019,9 +1200,204 @@
     "language": "r",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\nsort_even <- function(l) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)), c(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)), c(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "r",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nprime_fib <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "r",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\nbelow_zero <- function(operations) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "r",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\ntriples_sum_to_zero <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "r",
+    "prompt": "# Return list with elements incremented by 1.\nincr_list <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "r",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\npairs_sum_to_zero <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "r",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\nchange_base <- function(x, base) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "r",
+    "prompt": "# Given length of a side and high return area for a triangle.\ntriangle_area <- function(a, h) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "r",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfib4 <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "r",
+    "prompt": "# Return median of elements in the list l.\nmedian <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "r",
+    "prompt": "# Checks if given string is a palindrome\nis_palindrome <- function(text) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "r",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\nmodp <- function(n, p) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "r",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\nmean_absolute_deviation <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "r",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\nremove_vowels <- function(text) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "r",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\nbelow_threshold <- function(l, t) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "r",
+    "prompt": "# Add two numbers x and y\nadd <- function(x, y) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2032,9 +1408,22 @@
     "language": "r",
     "prompt": "# Check if two words have the same characters.\nsame_chars <- function(s0, s1) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- same_chars\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dddddddabc', 'abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcd', 'dddddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabcf'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb', 'aaccc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "r",
+    "prompt": "# Return n-th Fibonacci number.\nfib <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2045,9 +1434,620 @@
     "language": "r",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\ncorrect_bracketing <- function(brackets) {",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('<>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<><>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<<><><>><>><<><><<>>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<><>>>>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>>><>'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "r",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\nmonotonic <- function(l) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "r",
+    "prompt": "# Return sorted unique common elements for two lists.\ncommon <- function(l1, l2) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "r",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\nlargest_prime_factor <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "r",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nintersperse <- function(numbers, delimeter) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "r",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\nsum_to_n <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "r",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\ncorrect_bracketing <- function(brackets) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "r",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\nderivative <- function(xs) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "r",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfibfib <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "r",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\nvowels_count <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "r",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\ncircular_shift <- function(x, shift) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "r",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\ndigitSum <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "r",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\nfruit_distribution <- function(s, n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "r",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "r",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\nsearch <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "r",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\nparse_nested_parens <- function(paren_string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "r",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\nstrange_sort_list <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\ntriangle_area <- function(a, b, c) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "r",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "r",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\nsmallest_change <- function(arr) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "r",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\ntotal_match <- function(lst1, lst2) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "r",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "r",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\nis_simple_power <- function(x, n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "r",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\niscube <- function(a) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "r",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\nhex_key <- function(num) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "r",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\ndecimal_to_binary <- function(decimal) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\nfilter_by_substring <- function(strings, substring) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\nis_happy <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "r",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\nnumerical_letter_grade <- function(grades) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\nprime_length <- function(string) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "r",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "r",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\nadd <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\nanti_shuffle <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "r",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\nget_row <- function(lst, x) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "r",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\nsort_array <- function(array) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "r",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\nencrypt <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "r",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\nsum_product <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\nnext_smallest <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "r",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\nis_bored <- function(S) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "r",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\nany_int <- function(x, y, z) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "r",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\nencode <- function(message) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\nskjkasdkd <- function(lst) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "r",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\ncheck_dict_case <- function(dict) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "r",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\ncount_up_to <- function(n) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "r",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\nmultiply <- function(a, b) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "r",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\ncount_upper <- function(s) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "r",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "r",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\nrolling_max <- function(numbers) {",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/humaneval-r-reworded.json
+++ b/prompts/humaneval-r-reworded.json
@@ -1,1520 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "r",
-    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "r",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt('hi')\n# 'lm'\n# >>> encrypt('asdfghjkl')\n# 'ewhjklnop'\n# >>> encrypt('gf')\n# 'kj'\n# >>> encrypt('et')\n# 'ix'\nencrypt <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "r",
-    "prompt": "# Given a named list, return TRUE if all keys are strings in lower \n# case or all keys are strings in upper case, else return FALSE.\n# The function should return FALSE is the given named list is empty.\n# Examples:\n# >>> check_dict_case(list('a' = 'apple', 'b' = 'banana'))\n# TRUE\n# >>> check_dict_case(list('a' = 'apple', 'A' = 'banana', 'B' = 'banana'))\n# FALSE\n# >>> check_dict_case(list('a' = 'apple', 8 = 'banana', 'a' = 'apple'))\n# FALSE\n# >>> check_dict_case(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston'))\n# FALSE\n# >>> check_dict_case(list('STATE' = 'NC', 'ZIP' = '12345'))\n# TRUE\ncheck_dict_case <- function(dict) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add(c(4, 2, 6, 7))\n# 2\nadd <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "r",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(' Example')\n# 'Example'\n# >>> fix_spaces(' Example 1')\n# 'Example_1'\n# >>> fix_spaces(' Example 2')\n# '_Example_2'\n# >>> fix_spaces(' Example 3')\n# '_Example-3'\nfix_spaces <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "r",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference(c(1, 3, 2, 0))\n# 10\n# >>> double_the_difference(c(-1, -2, 0))\n# 0\n# >>> double_the_difference(c(9, -2))\n# 81\n# >>> double_the_difference(c(0))\n# 0\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "r",
-    "prompt": "# Filter given list of any rthon values only for integers\n# >>> filter_integers(list('a', 3.14, 5))\n# c(5)\n# >>> filter_integers(list(1, 2, 3, 'abc', list(), c()))\n# c(1, 2, 3)\nfilter_integers <- function(values) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "r",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "r",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# c(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nparse_music <- function(music_string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "r",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# 'db1111db'\n# >>> decimal_to_binary(32)\n# 'db100000db'\ndecimal_to_binary <- function(decimal) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "r",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# c('a', 'ab', 'abc')\nall_prefixes <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "r",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "r",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return a vector of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# c(11, 4)\n# >>> eat(4, 8, 9)\n# c(12, 1)\n# >>> eat(1, 10, 10)\n# c(11, 0)\n# >>> eat(2, 11, 5)\n# c(7, 0)\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "r",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1)\n# 6\n# Example 2:\n# >>> max_fill(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2)\n# 5\n# Example 3:\n# >>> max_fill(list(c(0, 0, 0), c(0, 0, 0)), 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "r",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# vector = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "r",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "r",
-    "prompt": "# Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting vector, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length(c(2, 1, 1, 4, 5, 8, 2, 3))\n# c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One')\n# If the vector is empty, return an empty vector:\n# >>> by_length(c())\n# c()\n# If the vector has any strange number ignore it:\n# >>> by_length(c(1, -1, 55))\n# c('One')\nby_length <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "r",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# c(2, 2, 2)\n# >>> factorize(25)\n# c(5, 5)\n# >>> factorize(70)\n# c(2, 5, 7)\nfactorize <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "r",
-    "prompt": "# Implement a function that takes an non-negative integer and returns a vector of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# c(2, 3)\n# >>> count_up_to(11)\n# c(2, 3, 5, 7)\n# >>> count_up_to(0)\n# c()\n# >>> count_up_to(20)\n# c(2, 3, 5, 7, 11, 13, 17, 19)\n# >>> count_up_to(1)\n# c()\n# >>> count_up_to(18)\n# c(2, 3, 5, 7, 11, 13, 17)\ncount_up_to <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "r",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(0, 2, 3, 5, 9, 123)\nunique <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "r",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match(c(), c())\n# c()\n# >>> total_match(c('hi', 'admin'), c('hI', 'Hi'))\n# c('hI', 'Hi')\n# >>> total_match(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project'))\n# c('hi', 'admin')\n# >>> total_match(c('hi', 'admin'), c('hI', 'hi', 'hi'))\n# c('hI', 'hi', 'hi')\n# >>> total_match(c('4'), c('1', '2', '3', '4', '5'))\n# c('4')\ntotal_match <- function(lst1, lst2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "r",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element(c(1, 2, 3))\n# 3\n# >>> max_element(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# 123\nmax_element <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "r",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return TRUE if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested('[[]]')\n# TRUE\n# >>> is_nested('[]]]]]]][[[[[]')\n# FALSE\n# >>> is_nested('[][]')\n# FALSE\n# >>> is_nested('[]')\n# FALSE\n# >>> is_nested('[[][]]')\n# TRUE\n# >>> is_nested('[[]][[')\n# TRUE\nis_nested <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "r",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# '0b11'\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# '0b1111'\n# >>> rounded_avg(20, 33)\n# '0b11010'\nrounded_avg <- function(n, m) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "r",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(c('1234567'))\n# c('the number of odd elements 4n the str4ng 4 of the 4nput.')\n# >>> odd_count(c('3', '11111111'))\n# c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.')\nodd_count <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "r",
-    "prompt": "# We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the vector will be randomly ordered. Your task is to determine if\n# it is possible to get a vector sorted in non-decreasing order by performing \n# the following operation on the given vector:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the vector by one\n# position in the right direction. The last element of the vector will be moved to\n# the starting position in the vector i.e. 0th index. \n# If it is possible to obtain the sorted vector by performing the above operation\n# then return TRUE else return FALSE.\n# If the given vector is empty then return TRUE.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball(c(3, 4, 5, 1, 2))\n# TRUE\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given vector.\n# >>> move_one_ball(c(3, 5, 4, 1, 2))\n# FALSE\n# Explanation:It is not possible to get non-decreasing order for the given\n# vector by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a list that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# c(1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# c(4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned list has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "r",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# FALSE\n# >>> is_equal_to_sum_even(6)\n# FALSE\n# >>> is_equal_to_sum_even(8)\n# TRUE\nis_equal_to_sum_even <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "r",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative(c(3, 1, 2, 4, 5))\n# c(1, 4, 12, 20)\n# >>> derivative(c(1, 2, 3))\n# c(2, 6)\nderivative <- function(xs) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return FALSE. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted(c(5))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5))\n# FALSE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6, 7))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5, 6, 7))\n# FALSE\n# >>> is_sorted(c(1, 2, 2, 3, 3, 4))\n# TRUE\n# >>> is_sorted(c(1, 2, 2, 2, 3, 4))\n# FALSE\nis_sorted <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve('1234')\n# '4321'\n# >>> solve('ab')\n# 'AB'\n# >>> solve('#a@C')\n# '#A@c'\nsolve <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "r",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# c(1, 3, 2, 8)\ntri <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "r",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix(c(), 'a')\n# c()\n# >>> filter_by_prefix(c('abc', 'bcd', 'cde', 'array'), 'a')\n# c('abc', 'array')\nfilter_by_prefix <- function(strings, prefix) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "r",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# '1'\n# >>> solve(150)\n# '110'\n# >>> solve(147)\n# '1100'\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "r",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3)\n# c(1, 2, 1)\n# >>> minPath(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1)\n# c(1)\nminPath <- function(grid, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "r",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper('aBCdEf')\n# 1\n# >>> count_upper('abcdefg')\n# 0\n# >>> count_upper('dBBE')\n# 0\ncount_upper <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "r",
-    "prompt": "# Given a vector arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum(c(-3, -4, 5), 3)\n# c(-4, -3, 5)\n# Example 2:\n# >>> maximum(c(4, -4, 4), 2)\n# c(4, 4)\n# Example 3:\n# >>> maximum(c(-3, 2, 1, 2, -1, -2, 1), 1)\n# c(2)\n# Note:\n# 1. The length of the vector will be in the range of [1, 1000].\n# 2. The elements in the vector will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "r",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "r",
-    "prompt": "# Given a vector of non-negative integers, return a cor of the given vector after sorting,\n# you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given vector.\n# Examples:\n# >>> sort_array(c())\n# c()\n# >>> sort_array(c(5))\n# c(5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5))\n# c(0, 1, 2, 3, 4, 5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5, 6))\n# c(6, 5, 4, 3, 2, 1, 0)\nsort_array <- function(array) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "r",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# c(1, 2, 6, 24, 15)\nf <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "r",
-    "prompt": "# Write a function that takes an integer a and returns TRUE \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# TRUE\n# >>> iscube(2)\n# FALSE\n# >>> iscube(-1)\n# TRUE\n# >>> iscube(64)\n# TRUE\n# >>> iscube(0)\n# TRUE\n# >>> iscube(180)\n# FALSE\niscube <- function(a) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "r",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "r",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored('Hello world')\n# 0\n# >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n# 1\nis_bored <- function(S) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "r",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns TRUE if there are two distinct elements in the list that\n# sum to zero, and FALSE otherwise.\n# >>> pairs_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 3, -2, 1))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> pairs_sum_to_zero(c(2, 4, -5, 3, 5, 7))\n# TRUE\n# >>> pairs_sum_to_zero(c(1))\n# FALSE\npairs_sum_to_zero <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\ntriangle_area <- function(a, b, c) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "r",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a list containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty list if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf('Jupiter', 'Neptune')\n# c('Saturn', 'Uranus')\n# >>> bf('Earth', 'Mercury')\n# 'Venus'\n# >>> bf('Mercury', 'Uranus')\n# c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\nbf <- function(planet1, planet2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\ndigits <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "r",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return a vector of the words.\n# For example:\n# >>> words_string('Hi, my name is John')\n# c('Hi', 'my', 'name', 'is', 'John')\n# >>> words_string('One, two, three, four, five, six')\n# c('One', 'two', 'three', 'four', 'five', 'six')\nwords_string <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "r",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "r",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return NULL if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, '2,3')\n# '2,3'\n# >>> compare_one('5,1', '6')\n# '6'\n# >>> compare_one('1', 1)\n# NULL\ncompare_one <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "r",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "r",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list(c(1, 2, 3, 4))\n# c(1, 4, 2, 3)\n# >>> strange_sort_list(c(5, 5, 5, 5))\n# c(5, 5, 5, 5)\n# >>> strange_sort_list(c())\n# c()\nstrange_sort_list <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "r",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n# c(2.0, 2.2)\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n# c(2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "r",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# TRUE\n# >>> is_simple_power(2, 2)\n# TRUE\n# >>> is_simple_power(8, 2)\n# TRUE\n# >>> is_simple_power(3, 2)\n# FALSE\n# >>> is_simple_power(3, 1)\n# FALSE\n# >>> is_simple_power(5, 3)\n# FALSE\nis_simple_power <- function(x, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "r",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "r",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points(c(1, 11, -1, -11, -12))\n# c(-1, -11, 1, -12, 11)\n# >>> order_by_points(c())\n# c()\norder_by_points <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "r",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements(c(1.0, 2.0, 3.0), 0.5)\n# FALSE\n# >>> has_close_elements(c(1.0, 2.8, 3.0, 4.0, 5.0, 2.0), 0.3)\n# TRUE\nhas_close_elements <- function(numbers, threshold) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- has_close_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.95), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 1.0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 0.5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "r",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "r",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "r",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "r",
-    "prompt": "# Given a non-empty vector of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "r",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "r",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits(c(15, 33, 1422, 1))\n# c(1, 15, 33)\n# >>> unique_digits(c(152, 323, 1422, 10))\n# c()\nunique_digits <- function(x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "r",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words('Mary had a little lamb', 4)\n# c('little')\n# >>> select_words('Mary had a little lamb', 3)\n# c('Mary', 'lamb')\n# >>> select_words('simple white space', 2)\n# c()\n# >>> select_words('Hello world', 4)\n# c('world')\n# >>> select_words('Uncle sam', 3)\n# c('Uncle')\nselect_words <- function(s, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "r",
-    "prompt": "# Write a function that returns TRUE if the object q will fly, and FALSE otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly(c(1, 2), 5)\n# FALSE\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly(c(3, 2, 3), 1)\n# FALSE\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly(c(3, 2, 3), 9)\n# TRUE\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly(c(3), 5)\n# TRUE\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "r",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "r",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension('my_class', c('AA', 'Be', 'CC'))\n# 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "r",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens(c('()(', ')'))\n# 'Yes'\n# >>> match_parens(c(')', ')'))\n# 'No'\nmatch_parens <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return NULL if there is no such element.\n# >>> next_smallest(c(1, 2, 3, 4, 5))\n# 2\n# >>> next_smallest(c(5, 1, 4, 3, 2))\n# 2\n# >>> next_smallest(c())\n# NULL\n# >>> next_smallest(c(1, 1))\n# NULL\nnext_smallest <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "r",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# TRUE\n# >>> any_int(3, 2, 2)\n# FALSE\n# >>> any_int(3, -2, 1)\n# TRUE\n# >>> any_int(3.6, -2.2, 2)\n# FALSE\nany_int <- function(x, y, z) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "r",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "r",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list(c(1, 2, 3))\n# c(2, 3, 4)\n# >>> incr_list(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(6, 4, 6, 3, 4, 4, 10, 1, 124)\nincr_list <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "r",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nx_or_y <- function(n, x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "r",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "r",
-    "prompt": "# Given an integer. return a list that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# c(1, 1)\n# >>> even_odd_count(123)\n# c(1, 2)\neven_odd_count <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is hapr or not.\n# A string is hapr if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy('a')\n# FALSE\n# >>> is_happy('aa')\n# FALSE\n# >>> is_happy('abcd')\n# TRUE\n# >>> is_happy('aabb')\n# FALSE\n# >>> is_happy('adb')\n# TRUE\n# >>> is_happy('xyy')\n# FALSE\nis_happy <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "r",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "r",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum('')\n# 0\n# >>> digitSum('abAB')\n# 131\n# >>> digitSum('abcCd')\n# 67\n# >>> digitSum('helloE')\n# 69\n# >>> digitSum('woArBld')\n# 131\n# >>> digitSum('aAaaaXa')\n# 153\ndigitSum <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "r",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit(c(1.0, 2.0, 3.0, 4.0, 5.0))\n# c(0.0, 0.25, 0.5, 0.75, 1.0)\nrescale_to_unit <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution(c(5, 8, 7, 1))\n# 12\n# >>> solution(c(3, 3, 3, 3, 3))\n# 9\n# >>> solution(c(30, 13, 24, 321))\n# 0\nsolution <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "r",
-    "prompt": "# \"Given a vector representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given vector is empty, return [].\n# Example 1:\n# >>> pluck(c(4, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck(c(1, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck(c())\n# c()\n# Example 4:\n# >>> pluck(c(5, 0, 3, 0, 4, 2))\n# c(0, 1)\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "r",
-    "prompt": "# You are given a positive integer n. You have to create an integer vector a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "r",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange(c(1, 2, 3, 4), c(1, 2, 3, 4))\n# 'YES'\n# >>> exchange(c(1, 2, 3, 4), c(1, 5, 3, 4))\n# 'NO'\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "r",
-    "prompt": "# Return median of elements in the list l.\n# >>> median(c(3, 1, 2, 4, 5))\n# 3\n# >>> median(c(-10, 4, 6, 1000, 10, 20))\n# 15.0\nmedian <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns TRUE if the string\n# length is a prime number or FALSE otherwise\n# Examples\n# >>> prime_length('Hello')\n# TRUE\n# >>> prime_length('abcdcba')\n# TRUE\n# >>> prime_length('kittens')\n# TRUE\n# >>> prime_length('orange')\n# FALSE\nprime_length <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "r",
-    "prompt": "# Given a vector arr of integers, find the minimum number of elements that\n# need to be changed to make the vector palindromic. A palindromic vector is a vector that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change(c(1, 2, 3, 5, 4, 7, 9, 6))\n# 4\n# >>> smallest_change(c(1, 2, 3, 4, 3, 2, 2))\n# 1\n# >>> smallest_change(c(1, 2, 3, 2, 1))\n# 0\nsmallest_change <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "r",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst(c(1.0, 2.0, 3.0))\n# 14\n# >>> lst(c(1.0, 4.0, 9.0))\n# 98\n# >>> lst(c(1.0, 3.0, 5.0, 7.0))\n# 84\n# >>> lst(c(1.4, 4.2, 0.0))\n# 29\n# >>> lst(c(-2.4, 1.0, 1.0))\n# 6\nsum_squares <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "r",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check('example.txt')\n# 'Yes'\n# >>> file_name_check('1example.dll')\n# 'No'\nfile_name_check <- function(file_name) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "r",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns TRUE if there are three distinct elements in the list that\n# sum to zero, and FALSE otherwise.\n# >>> triples_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> triples_sum_to_zero(c(1, 3, -2, 1))\n# TRUE\n# >>> triples_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> triples_sum_to_zero(c(2, 4, -5, 3, 9, 7))\n# TRUE\n# >>> triples_sum_to_zero(c(1))\n# FALSE\ntriples_sum_to_zero <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "r",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection(c(1, 2), c(2, 3))\n# 'NO'\n# >>> intersection(c(-1, 1), c(0, 4))\n# 'NO'\n# >>> intersection(c(-3, -1), c(-5, 5))\n# 'YES'\nintersection <- function(interval1, interval2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "r",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# c('()', '(())', '(()())')\nseparate_paren_groups <- function(paren_string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "r",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two vectors of scores and guesses of equal length, where each index shows a match. \n# Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2))\n# c(0, 0, 0, 0, 3, 3)\n# >>> compare(c(0, 5, 0, 0, 0, 4), c(4, 1, 1, 0, 0, -2))\n# c(4, 4, 1, 0, 0, 6)\ncompare <- function(game, guess) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "r",
-    "prompt": "# Create a function that returns TRUE if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and FALSE otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter('apple pie')\n# FALSE\n# >>> check_if_last_char_is_a_letter('apple pi e')\n# TRUE\n# >>> check_if_last_char_is_a_letter('apple pi e ')\n# FALSE\n# >>> check_if_last_char_is_a_letter('')\n# FALSE\ncheck_if_last_char_is_a_letter <- function(txt) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "r",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns TRUE if the date is valid otherwise FALSE.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date('03-11-2000')\n# TRUE\n# >>> valid_date('15-01-2012')\n# FALSE\n# >>> valid_date('04-0-2040')\n# FALSE\n# >>> valid_date('06-04-2020')\n# TRUE\n# >>> valid_date('06/04/2020')\n# FALSE\nvalid_date <- function(date) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "r",
-    "prompt": "# Write a function count_nums which takes a vector of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums(c())\n# 0\n# >>> count_nums(c(-1, 11, -11))\n# 1\n# >>> count_nums(c(1, 1, 2))\n# 3\ncount_nums <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle('Hi')\n# 'Hi'\n# >>> anti_shuffle('hello')\n# 'ehllo'\n# >>> anti_shuffle('Hello World!!!')\n# 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "r",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# TRUE\n# >>> is_palindrome('aba')\n# TRUE\n# >>> is_palindrome('aaaaa')\n# TRUE\n# >>> is_palindrome('zbcd')\n# FALSE\nis_palindrome <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "r",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel('yogurt')\n# 'u'\n# >>> get_closest_vowel('FULL')\n# 'U'\n# >>> get_closest_vowel('quick')\n# ''\n# >>> get_closest_vowel('ab')\n# ''\nget_closest_vowel <- function(word) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "r",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# FALSE\n# >>> is_prime(101)\n# TRUE\n# >>> is_prime(11)\n# TRUE\n# >>> is_prime(13441)\n# TRUE\n# >>> is_prime(61)\n# TRUE\n# >>> is_prime(4)\n# FALSE\n# >>> is_prime(1)\n# FALSE\nis_prime <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "r",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns TRUE if x * n evaluates to a whole number and FALSE\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify('1/5', '5/1')\n# TRUE\n# >>> simplify('1/6', '2/1')\n# FALSE\n# >>> simplify('7/10', '10/2')\n# FALSE\nsimplify <- function(x, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "r",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key('AB')\n# 1\n# >>> hex_key('1077E')\n# 2\n# >>> hex_key('ABED1A33')\n# 4\n# >>> hex_key('123456789ABCDEF0')\n# 6\n# >>> hex_key('2020')\n# 2\nhex_key <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "r",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence('This is a test')\n# 'is'\n# Example 2:\n# >>> words_in_sentence('lets go for swimming')\n# 'go for'\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "r",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a named list\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram('a b c')\n# list('a' = 1, 'b' = 1, 'c' = 1)\n# >>> histogram('a b b a')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('a b c a b')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('b b b b a')\n# list('b' = 4)\n# >>> histogram('')\n# list()\nhistogram <- function(test) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "r",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of lists, [(x1, y1), (x2, y2) ...] such that\n# each list is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1)\n# list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0))\n# >>> get_row(c(), 1)\n# c()\n# >>> get_row(list(c(), c(1), c(1, 2, 3)), 3)\n# list(c(2, 2))\nget_row <- function(lst, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# c(1, 5)\nget_odd_collatz <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "r",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given vector will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange(c(1, 2, 4, 3, 5))\n# 3\n# >>> can_arrange(c(1, 2, 3))\n# -1\ncan_arrange <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "r",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "r",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# '21'\n# >>> circular_shift(12, 2)\n# '12'\ncircular_shift <- function(x, shift) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "r",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# c(1, 2, 3)\n# >>> lst\n# c()\n# >>> lst\n# c(-1, -5, 2, -1, -5)\nsum_squares <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n# 10\n# >>> skjkasdkd(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n# 25\n# >>> skjkasdkd(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n# 13\n# >>> skjkasdkd(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n# 11\n# >>> skjkasdkd(c(0, 81, 12, 3, 1, 21))\n# 3\n# >>> skjkasdkd(c(0, 8, 1, 2, 1, 7))\n# 7\nskjkasdkd <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "r",
-    "prompt": "# For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product(c())\n# c(0, 1)\n# >>> sum_product(c(1, 2, 3, 4))\n# c(10, 24)\nsum_product <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "r",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nchoose_num <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "r",
-    "prompt": "# Create a function that returns a list (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as NULL.\n# Examples:\n# >>> largest_smallest_integers(c(2, 4, 1, 3, 5, 7))\n# list(NULL, 1)\n# >>> largest_smallest_integers(c())\n# list(NULL, NULL)\n# >>> largest_smallest_integers(c(0))\n# list(NULL, NULL)\nlargest_smallest_integers <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "r",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ncount_distinct_characters <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1525,7 +17,7 @@
     "language": "r",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# c(3, 5, 7)\nmake_a_pile <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- make_a_pile\n    stopifnot(isTRUE(all.equal(candidate(3), c(3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4, 6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5, 7, 9, 11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(6, 8, 10, 12, 14, 16))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(8, 10, 12, 14, 16, 18, 20, 22))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1534,221 +26,156 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "r",
-    "prompt": "# You are given a vector arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the vector, represented by 1, -1 or 0.\n# Note: return NULL for empty arr.\n# Example:\n# >>> prod_signs(c(1, 2, 2, -4))\n# 9\n# >>> prod_signs(c(0, 1))\n# 0\n# >>> prod_signs(c())\n# NULL\nprod_signs <- function(arr) {",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return a vector of the words.\n# For example:\n# >>> words_string('Hi, my name is John')\n# c('Hi', 'my', 'name', 'is', 'John')\n# >>> words_string('One, two, three, four, five, six')\n# c('One', 'two', 'three', 'four', 'five', 'six')\nwords_string <- function(s) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "r",
-    "prompt": "# Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n# of nums.\n# Example\n# >>> minSubArraySum(c(2, 3, 4, 1, 2, 4))\n# 1\n# >>> minSubArraySum(c(-1, -2, -3))\n# -6\nminSubArraySum <- function(nums) {",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nchoose_num <- function(x, y) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "r",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# '0b11'\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# '0b1111'\n# >>> rounded_avg(20, 33)\n# '0b11010'\nrounded_avg <- function(n, m) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "r",
-    "prompt": "# You are given 2 words. You need to return TRUE if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check('abcd', 'abd')\n# FALSE\n# >>> cycpattern_check('hello', 'ell')\n# TRUE\n# >>> cycpattern_check('whassup', 'psus')\n# FALSE\n# >>> cycpattern_check('abab', 'baa')\n# TRUE\n# >>> cycpattern_check('efef', 'eeff')\n# FALSE\n# >>> cycpattern_check('himenss', 'simen')\n# TRUE\ncycpattern_check <- function(a, b) {",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits(c(15, 33, 1422, 1))\n# c(1, 15, 33)\n# >>> unique_digits(c(152, 323, 1422, 10))\n# c()\nunique_digits <- function(x) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "r",
-    "prompt": "# Return TRUE is list elements are monotonically increasing or decreasing.\n# >>> monotonic(c(1, 2, 4, 20))\n# TRUE\n# >>> monotonic(c(1, 20, 4, 10))\n# FALSE\n# >>> monotonic(c(4, 1, 0, -10))\n# TRUE\nmonotonic <- function(l) {",
+    "prompt": "# Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting vector, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length(c(2, 1, 1, 4, 5, 8, 2, 3))\n# c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One')\n# If the vector is empty, return an empty vector:\n# >>> by_length(c())\n# c()\n# If the vector has any strange number ignore it:\n# >>> by_length(c(1, -1, 55))\n# c('One')\nby_length <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "r",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return NULL in case the input list is empty.\n# >>> longest(c())\n# NULL\n# >>> longest(c('a', 'b', 'c'))\n# 'a'\n# >>> longest(c('a', 'bb', 'ccc'))\n# 'ccc'\nlongest <- function(strings) {",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# c(1, 2, 6, 24, 15)\nf <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "r",
-    "prompt": "# Return TRUE if all numbers in the list l are below threshold t.\n# >>> below_threshold(c(1, 2, 4, 10), 100)\n# TRUE\n# >>> below_threshold(c(1, 20, 4, 10), 5)\n# FALSE\nbelow_threshold <- function(l, t) {",
+    "prompt": "# Given a positive integer n, return a list that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# c(1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# c(4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned list has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "r",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# TRUE\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "prompt": "# Write a function count_nums which takes a vector of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums(c())\n# 0\n# >>> count_nums(c(-1, 11, -11))\n# 1\n# >>> count_nums(c(1, 1, 2))\n# 3\ncount_nums <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "r",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive(c(-1, 2, -4, 5, 6))\n# c(2, 5, 6)\n# >>> get_positive(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# c(5, 3, 2, 3, 9, 123, 1)\nget_positive <- function(l) {",
+    "prompt": "# We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the vector will be randomly ordered. Your task is to determine if\n# it is possible to get a vector sorted in non-decreasing order by performing \n# the following operation on the given vector:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the vector by one\n# position in the right direction. The last element of the vector will be moved to\n# the starting position in the vector i.e. 0th index. \n# If it is possible to obtain the sorted vector by performing the above operation\n# then return TRUE else return FALSE.\n# If the given vector is empty then return TRUE.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball(c(3, 4, 5, 1, 2))\n# TRUE\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given vector.\n# >>> move_one_ball(c(3, 5, 4, 1, 2))\n# FALSE\n# Explanation:It is not possible to get non-decreasing order for the given\n# vector by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "r",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_third(c(5, 6, 3, 4, 8, 9, 2))\n# c(2, 6, 3, 4, 8, 9, 5)\nsort_third <- function(l) {",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "r",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# c(2, 3, 1, 3)\nparse_nested_parens <- function(paren_string) {",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange(c(1, 2, 3, 4), c(1, 2, 3, 4))\n# 'YES'\n# >>> exchange(c(1, 2, 3, 4), c(1, 5, 3, 4))\n# 'NO'\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "r",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a named list\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram('a b c')\n# list('a' = 1, 'b' = 1, 'c' = 1)\n# >>> histogram('a b b a')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('a b c a b')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('b b b b a')\n# list('b' = 4)\n# >>> histogram('')\n# list()\nhistogram <- function(test) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "r",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nmultiply <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "r",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation(c(1.0, 2.0, 3.0, 4.0))\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "r",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121))\n# c(1, 5, 653)\n# >>> common(c(5, 3, 2, 8), c(3, 2))\n# c(2, 3)\ncommon <- function(l1, l2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "r",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# 'xix'\n# >>> int_to_mini_roman(152)\n# 'clii'\n# >>> int_to_mini_roman(426)\n# 'cdxxvi'\nint_to_mini_roman <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "r",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution('5 apples and 6 oranges', 19)\n# 8\n# >>> fruit_distribution('0 apples and 1 oranges', 3)\n# 2\n# >>> fruit_distribution('2 apples and 3 oranges', 100)\n# 95\n# >>> fruit_distribution('100 apples and 1 oranges', 120)\n# 19\nfruit_distribution <- function(s, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1759,7 +186,7 @@
     "language": "r",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a list containing the result string and TRUE/FALSE for the check.\n# Example\n# >>> reverse_delete('abcde', 'ae')\n# list('bcd', FALSE)\n# >>> reverse_delete('abcdef', 'b')\n# list('acdef', FALSE)\n# >>> reverse_delete('abcdedcba', 'ab')\n# list('cdedc', TRUE)\nreverse_delete <- function(s, c) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- reverse_delete\n    stopifnot(isTRUE(all.equal(candidate('abcde', 'ae'), list('bcd', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef', 'b'), list('acdef', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'ab'), list('cdedc', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('dwik', 'w'), list('dik', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('a', 'a'), list('', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', ''), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'v'), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('vabba', 'v'), list('abba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('mamma', 'mia'), list('', TRUE))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1768,26 +195,39 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "r",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(c('1234567'))\n# c('the number of odd elements 4n the str4ng 4 of the 4nput.')\n# >>> odd_count(c('3', '11111111'))\n# c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.')\nodd_count <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "r",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words('Hello world!')\n# c('Hello', 'world!')\n# >>> split_words('Hello,world!')\n# c('Hello', 'world!')\n# >>> split_words('abcdef')\n# 3\nsplit_words <- function(txt) {",
+    "prompt": "# Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n# of nums.\n# Example\n# >>> minSubArraySum(c(2, 3, 4, 1, 2, 4))\n# 1\n# >>> minSubArraySum(c(-1, -2, -3))\n# -6\nminSubArraySum <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "r",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1)\n# 6\n# Example 2:\n# >>> max_fill(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2)\n# 5\n# Example 3:\n# >>> max_fill(list(c(0, 0, 0), c(0, 0, 0)), 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1798,7 +238,7 @@
     "language": "r",
     "prompt": "# In this Kata, you have to sort a vector of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array(c(1, 5, 2, 3, 4))\n# c(1, 2, 3, 4, 5)\n# >>> sort_array(c(-2, -3, -4, -5, -6))\n# c(-6, -5, -4, -3, -2)\n# >>> sort_array(c(1, 0, 2, 3, 4))\n# c(0, 1, 2, 3, 4)\nsort_array <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 2, 3, 4)), c(1, 2, 4, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, -4, -5, -6)), c(-4, -2, -6, -5, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 3, 4)), c(0, 1, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)), c(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 44, 12, 32, 5)), c(32, 3, 5, 6, 12, 44))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1807,143 +247,416 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "r",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate(c())\n# ''\n# >>> concatenate(c('a', 'b', 'c'))\n# 'abc'\nconcatenate <- function(strings) {",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words('Mary had a little lamb', 4)\n# c('little')\n# >>> select_words('Mary had a little lamb', 3)\n# c('Mary', 'lamb')\n# >>> select_words('simple white space', 2)\n# c()\n# >>> select_words('Hello world', 4)\n# c('world')\n# >>> select_words('Uncle sam', 3)\n# c('Uncle')\nselect_words <- function(s, n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never a vector of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort(c('aa', 'a', 'aaa'))\n# c('aa')\n# >>> list_sort(c('ab', 'a', 'aaa', 'cd'))\n# c('ab', 'cd')\nsorted_list_sum <- function(lst) {",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel('yogurt')\n# 'u'\n# >>> get_closest_vowel('FULL')\n# 'U'\n# >>> get_closest_vowel('quick')\n# ''\n# >>> get_closest_vowel('ab')\n# ''\nget_closest_vowel <- function(word) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring(c(), 'a')\n# c()\n# >>> filter_by_substring(c('abc', 'bacd', 'cde', 'array'), 'a')\n# c('abc', 'bacd', 'array')\nfilter_by_substring <- function(strings, substring) {",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens(c('()(', ')'))\n# 'Yes'\n# >>> match_parens(c(')', ')'))\n# 'No'\nmatch_parens <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "r",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer('10')\n# 10\n# >>> closest_integer('15.3')\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "r",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count('abcde')\n# 2\n# >>> vowels_count('ACEDY')\n# 3\nvowels_count <- function(s) {",
+    "prompt": "# Given a vector arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum(c(-3, -4, 5), 3)\n# c(-4, -3, 5)\n# Example 2:\n# >>> maximum(c(4, -4, 4), 2)\n# c(4, 4)\n# Example 3:\n# >>> maximum(c(-3, 2, 1, 2, -1, -2, 1), 1)\n# c(2)\n# Note:\n# 1. The length of the vector will be in the range of [1, 1000].\n# 2. The elements in the vector will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max(c('name', 'of', 'string'))\n# 'string'\n# >>> find_max(c('name', 'enam', 'game'))\n# 'enam'\n# >>> find_max(c('aaaaaaa', 'bb', 'cc'))\n# 'aaaaaaa'\nfind_max <- function(words) {",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution(c(5, 8, 7, 1))\n# 12\n# >>> solution(c(3, 3, 3, 3, 3))\n# 9\n# >>> solution(c(30, 13, 24, 321))\n# 0\nsolution <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "r",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return NULL.\n# >>> string_to_md5('Hello world')\n# '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
+    "prompt": "# Given a non-empty vector of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "r",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# c(1, 5)\nget_odd_collatz <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return TRUE if the three\n# sides form a right-angled triangle, FALSE otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# TRUE\n# >>> right_angle_triangle(1, 2, 3)\n# FALSE\nright_angle_triangle <- function(a, b, c) {",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns TRUE if the date is valid otherwise FALSE.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date('03-11-2000')\n# TRUE\n# >>> valid_date('15-01-2012')\n# FALSE\n# >>> valid_date('04-0-2040')\n# FALSE\n# >>> valid_date('06-04-2020')\n# TRUE\n# >>> valid_date('06/04/2020')\n# FALSE\nvalid_date <- function(date) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "r",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation(c(4.0, 3, 1.7, 2, 3.5))\n# c('A+', 'B', 'C-', 'C', 'A-')\nnumerical_letter_grade <- function(grades) {",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words('Hello world!')\n# c('Hello', 'world!')\n# >>> split_words('Hello,world!')\n# c('Hello', 'world!')\n# >>> split_words('abcdef')\n# 3\nsplit_words <- function(txt) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "r",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse(c(), 4)\n# c()\n# >>> intersperse(c(1, 2, 3), 4)\n# c(1, 4, 2, 4, 3)\nintersperse <- function(numbers, delimeter) {",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return FALSE. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted(c(5))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5))\n# FALSE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6, 7))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5, 6, 7))\n# FALSE\n# >>> is_sorted(c(1, 2, 2, 3, 3, 4))\n# TRUE\n# >>> is_sorted(c(1, 2, 2, 2, 3, 4))\n# FALSE\nis_sorted <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "r",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection(c(1, 2), c(2, 3))\n# 'NO'\n# >>> intersection(c(-1, 1), c(0, 4))\n# 'NO'\n# >>> intersection(c(-3, -1), c(-5, 5))\n# 'YES'\nintersection <- function(interval1, interval2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "r",
+    "prompt": "# You are given a vector arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the vector, represented by 1, -1 or 0.\n# Note: return NULL for empty arr.\n# Example:\n# >>> prod_signs(c(1, 2, 2, -4))\n# 9\n# >>> prod_signs(c(0, 1))\n# 0\n# >>> prod_signs(c())\n# NULL\nprod_signs <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "r",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3)\n# c(1, 2, 1)\n# >>> minPath(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1)\n# c(1)\nminPath <- function(grid, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "r",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return NULL in case the input list is empty.\n# >>> longest(c())\n# NULL\n# >>> longest(c('a', 'b', 'c'))\n# 'a'\n# >>> longest(c('a', 'bb', 'ccc'))\n# 'ccc'\nlongest <- function(strings) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "r",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# c(1, 3, 2, 8)\ntri <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\ndigits <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "r",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return TRUE if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested('[[]]')\n# TRUE\n# >>> is_nested('[]]]]]]][[[[[]')\n# FALSE\n# >>> is_nested('[][]')\n# FALSE\n# >>> is_nested('[]')\n# FALSE\n# >>> is_nested('[[][]]')\n# TRUE\n# >>> is_nested('[[]][[')\n# TRUE\nis_nested <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "r",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst(c(1.0, 2.0, 3.0))\n# 14\n# >>> lst(c(1.0, 4.0, 9.0))\n# 98\n# >>> lst(c(1.0, 3.0, 5.0, 7.0))\n# 84\n# >>> lst(c(1.4, 4.2, 0.0))\n# 29\n# >>> lst(c(-2.4, 1.0, 1.0))\n# 6\nsum_squares <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "r",
+    "prompt": "# Create a function that returns TRUE if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and FALSE otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter('apple pie')\n# FALSE\n# >>> check_if_last_char_is_a_letter('apple pi e')\n# TRUE\n# >>> check_if_last_char_is_a_letter('apple pi e ')\n# FALSE\n# >>> check_if_last_char_is_a_letter('')\n# FALSE\ncheck_if_last_char_is_a_letter <- function(txt) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "r",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given vector will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange(c(1, 2, 4, 3, 5))\n# 3\n# >>> can_arrange(c(1, 2, 3))\n# -1\ncan_arrange <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "r",
+    "prompt": "# Create a function that returns a list (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as NULL.\n# Examples:\n# >>> largest_smallest_integers(c(2, 4, 1, 3, 5, 7))\n# list(NULL, 1)\n# >>> largest_smallest_integers(c())\n# list(NULL, NULL)\n# >>> largest_smallest_integers(c(0))\n# list(NULL, NULL)\nlargest_smallest_integers <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "r",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return NULL if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, '2,3')\n# '2,3'\n# >>> compare_one('5,1', '6')\n# '6'\n# >>> compare_one('1', 1)\n# NULL\ncompare_one <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "r",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# FALSE\n# >>> is_equal_to_sum_even(6)\n# FALSE\n# >>> is_equal_to_sum_even(8)\n# TRUE\nis_equal_to_sum_even <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "r",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "r",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "r",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(' Example')\n# 'Example'\n# >>> fix_spaces(' Example 1')\n# 'Example_1'\n# >>> fix_spaces(' Example 2')\n# '_Example_2'\n# >>> fix_spaces(' Example 3')\n# '_Example-3'\nfix_spaces <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "r",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check('example.txt')\n# 'Yes'\n# >>> file_name_check('1example.dll')\n# 'No'\nfile_name_check <- function(file_name) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "r",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# c(1, 2, 3)\n# >>> lst\n# c()\n# >>> lst\n# c(-1, -5, 2, -1, -5)\nsum_squares <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "r",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence('This is a test')\n# 'is'\n# Example 2:\n# >>> words_in_sentence('lets go for swimming')\n# 'go for'\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "r",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns TRUE if x * n evaluates to a whole number and FALSE\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify('1/5', '5/1')\n# TRUE\n# >>> simplify('1/6', '2/1')\n# FALSE\n# >>> simplify('7/10', '10/2')\n# FALSE\nsimplify <- function(x, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "r",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points(c(1, 11, -1, -11, -12))\n# c(-1, -11, 1, -12, 11)\n# >>> order_by_points(c())\n# c()\norder_by_points <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1954,7 +667,7 @@
     "language": "r",
     "prompt": "# Write a function that takes a vector of numbers as input and returns \n# the number of elements in the vector that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter(c(15, -73, 14, -15))\n# 1\n# >>> specialFilter(c(33, -2, -3, 45, 21, 109))\n# 2\nspecialFilter <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- specialFilter\n    stopifnot(isTRUE(all.equal(candidate(c(5, -2, 1, -5)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, -73, 14, -15)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(33, -2, -3, 45, 21, 109)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(43, -12, 93, 125, 121, 109)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(71, -2, -33, 75, 21, 19)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1963,26 +676,234 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "r",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
+    "prompt": "# You are given a positive integer n. You have to create an integer vector a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "r",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates(c(1, 2, 3, 2, 4))\n# c(1, 3, 4)\nremove_duplicates <- function(numbers) {",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a list containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty list if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf('Jupiter', 'Neptune')\n# c('Saturn', 'Uranus')\n# >>> bf('Earth', 'Mercury')\n# 'Venus'\n# >>> bf('Mercury', 'Uranus')\n# c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\nbf <- function(planet1, planet2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never a vector of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort(c('aa', 'a', 'aaa'))\n# c('aa')\n# >>> list_sort(c('ab', 'a', 'aaa', 'cd'))\n# c('ab', 'cd')\nsorted_list_sum <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "r",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# c('a', 'ab', 'abc')\nall_prefixes <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "r",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nx_or_y <- function(n, x, y) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "r",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference(c(1, 3, 2, 0))\n# 10\n# >>> double_the_difference(c(-1, -2, 0))\n# 0\n# >>> double_the_difference(c(9, -2))\n# 81\n# >>> double_the_difference(c(0))\n# 0\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "r",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two vectors of scores and guesses of equal length, where each index shows a match. \n# Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2))\n# c(0, 0, 0, 0, 3, 3)\n# >>> compare(c(0, 5, 0, 0, 0, 4), c(4, 1, 1, 0, 0, -2))\n# c(4, 4, 1, 0, 0, 6)\ncompare <- function(game, guess) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "r",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension('my_class', c('AA', 'Be', 'CC'))\n# 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "r",
+    "prompt": "# You are given 2 words. You need to return TRUE if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check('abcd', 'abd')\n# FALSE\n# >>> cycpattern_check('hello', 'ell')\n# TRUE\n# >>> cycpattern_check('whassup', 'psus')\n# FALSE\n# >>> cycpattern_check('abab', 'baa')\n# TRUE\n# >>> cycpattern_check('efef', 'eeff')\n# FALSE\n# >>> cycpattern_check('himenss', 'simen')\n# TRUE\ncycpattern_check <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "r",
+    "prompt": "# Given an integer. return a list that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# c(1, 1)\n# >>> even_odd_count(123)\n# c(1, 2)\neven_odd_count <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "r",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# 'xix'\n# >>> int_to_mini_roman(152)\n# 'clii'\n# >>> int_to_mini_roman(426)\n# 'cdxxvi'\nint_to_mini_roman <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return TRUE if the three\n# sides form a right-angled triangle, FALSE otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# TRUE\n# >>> right_angle_triangle(1, 2, 3)\n# FALSE\nright_angle_triangle <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max(c('name', 'of', 'string'))\n# 'string'\n# >>> find_max(c('name', 'enam', 'game'))\n# 'enam'\n# >>> find_max(c('aaaaaaa', 'bb', 'cc'))\n# 'aaaaaaa'\nfind_max <- function(words) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "r",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return a vector of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# c(11, 4)\n# >>> eat(4, 8, 9)\n# c(12, 1)\n# >>> eat(1, 10, 10)\n# c(11, 0)\n# >>> eat(2, 11, 5)\n# c(7, 0)\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "r",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "r",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# vector = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve('1234')\n# '4321'\n# >>> solve('ab')\n# 'AB'\n# >>> solve('#a@C')\n# '#A@c'\nsolve <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "r",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return NULL.\n# >>> string_to_md5('Hello world')\n# '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1993,7 +914,7 @@
     "language": "r",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers(2, 8)\n# c(2, 4, 6, 8)\n# >>> generate_integers(8, 2)\n# c(2, 4, 6, 8)\n# >>> generate_integers(10, 14)\n# c()\ngenerate_integers <- function(a, b) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- generate_integers\n    stopifnot(isTRUE(all.equal(candidate(2, 10), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(132, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(17, 89), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -2002,52 +923,286 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "r",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max(c(1, 2, 3, 2, 3, 4, 2))\n# c(1, 2, 3, 3, 3, 4, 4)\nrolling_max <- function(numbers) {",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ncount_distinct_characters <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "r",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return TRUE. Otherwise it should return FALSE.\n# >>> below_zero(c(1, 2, 3))\n# FALSE\n# >>> below_zero(c(1, 2, -4, 5))\n# TRUE\nbelow_zero <- function(operations) {",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# c(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nparse_music <- function(music_string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "r",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search(c(4, 1, 2, 2, 3, 1))\n# 2\n# >>> search(c(1, 2, 2, 3, 3, 3, 4, 4, 4))\n# 3\n# >>> search(c(5, 5, 4, 4, 4))\n# -1\nsearch <- function(lst) {",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "r",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return TRUE if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('(')\n# FALSE\n# >>> correct_bracketing('()')\n# TRUE\n# >>> correct_bracketing('(()())')\n# TRUE\n# >>> correct_bracketing(')(()')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "r",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# c('()', '(())', '(()())')\nseparate_paren_groups <- function(paren_string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "r",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n# c(2.0, 2.2)\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n# c(2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "r",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit(c(1.0, 2.0, 3.0, 4.0, 5.0))\n# c(0.0, 0.25, 0.5, 0.75, 1.0)\nrescale_to_unit <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "r",
+    "prompt": "# Filter given list of any rthon values only for integers\n# >>> filter_integers(list('a', 3.14, 5))\n# c(5)\n# >>> filter_integers(list(1, 2, 3, 'abc', list(), c()))\n# c(1, 2, 3)\nfilter_integers <- function(values) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "r",
+    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "r",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "r",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# c(2, 2, 2)\n# >>> factorize(25)\n# c(5, 5)\n# >>> factorize(70)\n# c(2, 5, 7)\nfactorize <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "r",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates(c(1, 2, 3, 2, 4))\n# c(1, 3, 4)\nremove_duplicates <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "r",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "r",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate(c())\n# ''\n# >>> concatenate(c('a', 'b', 'c'))\n# 'abc'\nconcatenate <- function(strings) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix(c(), 'a')\n# c()\n# >>> filter_by_prefix(c('abc', 'bcd', 'cde', 'array'), 'a')\n# c('abc', 'array')\nfilter_by_prefix <- function(strings, prefix) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "r",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "r",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive(c(-1, 2, -4, 5, 6))\n# c(2, 5, 6)\n# >>> get_positive(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# c(5, 3, 2, 3, 9, 123, 1)\nget_positive <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "r",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# FALSE\n# >>> is_prime(101)\n# TRUE\n# >>> is_prime(11)\n# TRUE\n# >>> is_prime(13441)\n# TRUE\n# >>> is_prime(61)\n# TRUE\n# >>> is_prime(4)\n# FALSE\n# >>> is_prime(1)\n# FALSE\nis_prime <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "r",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_third(c(5, 6, 3, 4, 8, 9, 2))\n# c(2, 6, 3, 4, 8, 9, 5)\nsort_third <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "r",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(0, 2, 3, 5, 9, 123)\nunique <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "r",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element(c(1, 2, 3))\n# 3\n# >>> max_element(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# 123\nmax_element <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "r",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2058,9 +1213,217 @@
     "language": "r",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_even(c(5, 6, 3, 4))\n# c(3, 6, 5, 4)\nsort_even <- function(l) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)), c(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)), c(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "r",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "r",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return TRUE. Otherwise it should return FALSE.\n# >>> below_zero(c(1, 2, 3))\n# FALSE\n# >>> below_zero(c(1, 2, -4, 5))\n# TRUE\nbelow_zero <- function(operations) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "r",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns TRUE if there are three distinct elements in the list that\n# sum to zero, and FALSE otherwise.\n# >>> triples_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> triples_sum_to_zero(c(1, 3, -2, 1))\n# TRUE\n# >>> triples_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> triples_sum_to_zero(c(2, 4, -5, 3, 9, 7))\n# TRUE\n# >>> triples_sum_to_zero(c(1))\n# FALSE\ntriples_sum_to_zero <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "r",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "r",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list(c(1, 2, 3))\n# c(2, 3, 4)\n# >>> incr_list(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(6, 4, 6, 3, 4, 4, 10, 1, 124)\nincr_list <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "r",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns TRUE if there are two distinct elements in the list that\n# sum to zero, and FALSE otherwise.\n# >>> pairs_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 3, -2, 1))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> pairs_sum_to_zero(c(2, 4, -5, 3, 5, 7))\n# TRUE\n# >>> pairs_sum_to_zero(c(1))\n# FALSE\npairs_sum_to_zero <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "r",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "r",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "r",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "r",
+    "prompt": "# Return median of elements in the list l.\n# >>> median(c(3, 1, 2, 4, 5))\n# 3\n# >>> median(c(-10, 4, 6, 1000, 10, 20))\n# 15.0\nmedian <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "r",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# TRUE\n# >>> is_palindrome('aba')\n# TRUE\n# >>> is_palindrome('aaaaa')\n# TRUE\n# >>> is_palindrome('zbcd')\n# FALSE\nis_palindrome <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "r",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "r",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation(c(1.0, 2.0, 3.0, 4.0))\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "r",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "r",
+    "prompt": "# Return TRUE if all numbers in the list l are below threshold t.\n# >>> below_threshold(c(1, 2, 4, 10), 100)\n# TRUE\n# >>> below_threshold(c(1, 20, 4, 10), 5)\n# FALSE\nbelow_threshold <- function(l, t) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "r",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2071,9 +1434,22 @@
     "language": "r",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# TRUE\n# >>> same_chars('abcd', 'dddddddabc')\n# TRUE\n# >>> same_chars('dddddddabc', 'abcd')\n# TRUE\n# >>> same_chars('eabcd', 'dddddddabc')\n# FALSE\n# >>> same_chars('abcd', 'dddddddabce')\n# FALSE\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# FALSE\nsame_chars <- function(s0, s1) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- same_chars\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dddddddabc', 'abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcd', 'dddddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabcf'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb', 'aaccc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "r",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2084,9 +1460,633 @@
     "language": "r",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return TRUE if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('<')\n# FALSE\n# >>> correct_bracketing('<>')\n# TRUE\n# >>> correct_bracketing('<<><>>')\n# TRUE\n# >>> correct_bracketing('><<>')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('<>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<><>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<<><><>><>><<><><<>>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<><>>>>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>>><>'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "r",
+    "prompt": "# Return TRUE is list elements are monotonically increasing or decreasing.\n# >>> monotonic(c(1, 2, 4, 20))\n# TRUE\n# >>> monotonic(c(1, 20, 4, 10))\n# FALSE\n# >>> monotonic(c(4, 1, 0, -10))\n# TRUE\nmonotonic <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "r",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121))\n# c(1, 5, 653)\n# >>> common(c(5, 3, 2, 8), c(3, 2))\n# c(2, 3)\ncommon <- function(l1, l2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "r",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "r",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse(c(), 4)\n# c()\n# >>> intersperse(c(1, 2, 3), 4)\n# c(1, 4, 2, 4, 3)\nintersperse <- function(numbers, delimeter) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "r",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "r",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return TRUE if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('(')\n# FALSE\n# >>> correct_bracketing('()')\n# TRUE\n# >>> correct_bracketing('(()())')\n# TRUE\n# >>> correct_bracketing(')(()')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "r",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative(c(3, 1, 2, 4, 5))\n# c(1, 4, 12, 20)\n# >>> derivative(c(1, 2, 3))\n# c(2, 6)\nderivative <- function(xs) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "r",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "r",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count('abcde')\n# 2\n# >>> vowels_count('ACEDY')\n# 3\nvowels_count <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "r",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# '21'\n# >>> circular_shift(12, 2)\n# '12'\ncircular_shift <- function(x, shift) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "r",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum('')\n# 0\n# >>> digitSum('abAB')\n# 131\n# >>> digitSum('abcCd')\n# 67\n# >>> digitSum('helloE')\n# 69\n# >>> digitSum('woArBld')\n# 131\n# >>> digitSum('aAaaaXa')\n# 153\ndigitSum <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "r",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution('5 apples and 6 oranges', 19)\n# 8\n# >>> fruit_distribution('0 apples and 1 oranges', 3)\n# 2\n# >>> fruit_distribution('2 apples and 3 oranges', 100)\n# 95\n# >>> fruit_distribution('100 apples and 1 oranges', 120)\n# 19\nfruit_distribution <- function(s, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "r",
+    "prompt": "# \"Given a vector representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given vector is empty, return [].\n# Example 1:\n# >>> pluck(c(4, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck(c(1, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck(c())\n# c()\n# Example 4:\n# >>> pluck(c(5, 0, 3, 0, 4, 2))\n# c(0, 1)\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "r",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search(c(4, 1, 2, 2, 3, 1))\n# 2\n# >>> search(c(1, 2, 2, 3, 3, 3, 4, 4, 4))\n# 3\n# >>> search(c(5, 5, 4, 4, 4))\n# -1\nsearch <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "r",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# c(2, 3, 1, 3)\nparse_nested_parens <- function(paren_string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "r",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list(c(1, 2, 3, 4))\n# c(1, 4, 2, 3)\n# >>> strange_sort_list(c(5, 5, 5, 5))\n# c(5, 5, 5, 5)\n# >>> strange_sort_list(c())\n# c()\nstrange_sort_list <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\ntriangle_area <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "r",
+    "prompt": "# Write a function that returns TRUE if the object q will fly, and FALSE otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly(c(1, 2), 5)\n# FALSE\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly(c(3, 2, 3), 1)\n# FALSE\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly(c(3, 2, 3), 9)\n# TRUE\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly(c(3), 5)\n# TRUE\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "r",
+    "prompt": "# Given a vector arr of integers, find the minimum number of elements that\n# need to be changed to make the vector palindromic. A palindromic vector is a vector that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change(c(1, 2, 3, 5, 4, 7, 9, 6))\n# 4\n# >>> smallest_change(c(1, 2, 3, 4, 3, 2, 2))\n# 1\n# >>> smallest_change(c(1, 2, 3, 2, 1))\n# 0\nsmallest_change <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "r",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match(c(), c())\n# c()\n# >>> total_match(c('hi', 'admin'), c('hI', 'Hi'))\n# c('hI', 'Hi')\n# >>> total_match(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project'))\n# c('hi', 'admin')\n# >>> total_match(c('hi', 'admin'), c('hI', 'hi', 'hi'))\n# c('hI', 'hi', 'hi')\n# >>> total_match(c('4'), c('1', '2', '3', '4', '5'))\n# c('4')\ntotal_match <- function(lst1, lst2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "r",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# TRUE\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "r",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# TRUE\n# >>> is_simple_power(2, 2)\n# TRUE\n# >>> is_simple_power(8, 2)\n# TRUE\n# >>> is_simple_power(3, 2)\n# FALSE\n# >>> is_simple_power(3, 1)\n# FALSE\n# >>> is_simple_power(5, 3)\n# FALSE\nis_simple_power <- function(x, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "r",
+    "prompt": "# Write a function that takes an integer a and returns TRUE \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# TRUE\n# >>> iscube(2)\n# FALSE\n# >>> iscube(-1)\n# TRUE\n# >>> iscube(64)\n# TRUE\n# >>> iscube(0)\n# TRUE\n# >>> iscube(180)\n# FALSE\niscube <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "r",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key('AB')\n# 1\n# >>> hex_key('1077E')\n# 2\n# >>> hex_key('ABED1A33')\n# 4\n# >>> hex_key('123456789ABCDEF0')\n# 6\n# >>> hex_key('2020')\n# 2\nhex_key <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "r",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# 'db1111db'\n# >>> decimal_to_binary(32)\n# 'db100000db'\ndecimal_to_binary <- function(decimal) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring(c(), 'a')\n# c()\n# >>> filter_by_substring(c('abc', 'bacd', 'cde', 'array'), 'a')\n# c('abc', 'bacd', 'array')\nfilter_by_substring <- function(strings, substring) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is hapr or not.\n# A string is hapr if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy('a')\n# FALSE\n# >>> is_happy('aa')\n# FALSE\n# >>> is_happy('abcd')\n# TRUE\n# >>> is_happy('aabb')\n# FALSE\n# >>> is_happy('adb')\n# TRUE\n# >>> is_happy('xyy')\n# FALSE\nis_happy <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "r",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation(c(4.0, 3, 1.7, 2, 3.5))\n# c('A+', 'B', 'C-', 'C', 'A-')\nnumerical_letter_grade <- function(grades) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns TRUE if the string\n# length is a prime number or FALSE otherwise\n# Examples\n# >>> prime_length('Hello')\n# TRUE\n# >>> prime_length('abcdcba')\n# TRUE\n# >>> prime_length('kittens')\n# TRUE\n# >>> prime_length('orange')\n# FALSE\nprime_length <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "r",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# '1'\n# >>> solve(150)\n# '110'\n# >>> solve(147)\n# '1100'\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "r",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add(c(4, 2, 6, 7))\n# 2\nadd <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle('Hi')\n# 'Hi'\n# >>> anti_shuffle('hello')\n# 'ehllo'\n# >>> anti_shuffle('Hello World!!!')\n# 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "r",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of lists, [(x1, y1), (x2, y2) ...] such that\n# each list is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1)\n# list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0))\n# >>> get_row(c(), 1)\n# c()\n# >>> get_row(list(c(), c(1), c(1, 2, 3)), 3)\n# list(c(2, 2))\nget_row <- function(lst, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "r",
+    "prompt": "# Given a vector of non-negative integers, return a cor of the given vector after sorting,\n# you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given vector.\n# Examples:\n# >>> sort_array(c())\n# c()\n# >>> sort_array(c(5))\n# c(5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5))\n# c(0, 1, 2, 3, 4, 5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5, 6))\n# c(6, 5, 4, 3, 2, 1, 0)\nsort_array <- function(array) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "r",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt('hi')\n# 'lm'\n# >>> encrypt('asdfghjkl')\n# 'ewhjklnop'\n# >>> encrypt('gf')\n# 'kj'\n# >>> encrypt('et')\n# 'ix'\nencrypt <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "r",
+    "prompt": "# For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product(c())\n# c(0, 1)\n# >>> sum_product(c(1, 2, 3, 4))\n# c(10, 24)\nsum_product <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return NULL if there is no such element.\n# >>> next_smallest(c(1, 2, 3, 4, 5))\n# 2\n# >>> next_smallest(c(5, 1, 4, 3, 2))\n# 2\n# >>> next_smallest(c())\n# NULL\n# >>> next_smallest(c(1, 1))\n# NULL\nnext_smallest <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "r",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored('Hello world')\n# 0\n# >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n# 1\nis_bored <- function(S) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "r",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# TRUE\n# >>> any_int(3, 2, 2)\n# FALSE\n# >>> any_int(3, -2, 1)\n# TRUE\n# >>> any_int(3.6, -2.2, 2)\n# FALSE\nany_int <- function(x, y, z) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "r",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n# 10\n# >>> skjkasdkd(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n# 25\n# >>> skjkasdkd(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n# 13\n# >>> skjkasdkd(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n# 11\n# >>> skjkasdkd(c(0, 81, 12, 3, 1, 21))\n# 3\n# >>> skjkasdkd(c(0, 8, 1, 2, 1, 7))\n# 7\nskjkasdkd <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "r",
+    "prompt": "# Given a named list, return TRUE if all keys are strings in lower \n# case or all keys are strings in upper case, else return FALSE.\n# The function should return FALSE is the given named list is empty.\n# Examples:\n# >>> check_dict_case(list('a' = 'apple', 'b' = 'banana'))\n# TRUE\n# >>> check_dict_case(list('a' = 'apple', 'A' = 'banana', 'B' = 'banana'))\n# FALSE\n# >>> check_dict_case(list('a' = 'apple', 8 = 'banana', 'a' = 'apple'))\n# FALSE\n# >>> check_dict_case(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston'))\n# FALSE\n# >>> check_dict_case(list('STATE' = 'NC', 'ZIP' = '12345'))\n# TRUE\ncheck_dict_case <- function(dict) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "r",
+    "prompt": "# Implement a function that takes an non-negative integer and returns a vector of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# c(2, 3)\n# >>> count_up_to(11)\n# c(2, 3, 5, 7)\n# >>> count_up_to(0)\n# c()\n# >>> count_up_to(20)\n# c(2, 3, 5, 7, 11, 13, 17, 19)\n# >>> count_up_to(1)\n# c()\n# >>> count_up_to(18)\n# c(2, 3, 5, 7, 11, 13, 17)\ncount_up_to <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "r",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nmultiply <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "r",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper('aBCdEf')\n# 1\n# >>> count_upper('abcdefg')\n# 0\n# >>> count_upper('dBBE')\n# 0\ncount_upper <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "r",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer('10')\n# 10\n# >>> closest_integer('15.3')\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "r",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max(c(1, 2, 3, 2, 3, 4, 2))\n# c(1, 2, 3, 3, 3, 4, 4)\nrolling_max <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/humaneval-r-transform.json
+++ b/prompts/humaneval-r-transform.json
@@ -1,1520 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "r",
-    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "r",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt('hi')\n# 'lm'\n# >>> encrypt('asdfghjkl')\n# 'ewhjklnop'\n# >>> encrypt('gf')\n# 'kj'\n# >>> encrypt('et')\n# 'ix'\nencrypt <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "r",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case(list('a' = 'apple', 'b' = 'banana'))\n# TRUE\n# >>> check_dict_case(list('a' = 'apple', 'A' = 'banana', 'B' = 'banana'))\n# FALSE\n# >>> check_dict_case(list('a' = 'apple', 8 = 'banana', 'a' = 'apple'))\n# FALSE\n# >>> check_dict_case(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston'))\n# FALSE\n# >>> check_dict_case(list('STATE' = 'NC', 'ZIP' = '12345'))\n# TRUE\ncheck_dict_case <- function(dict) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add(c(4, 2, 6, 7))\n# 2\nadd <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "r",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(' Example')\n# 'Example'\n# >>> fix_spaces(' Example 1')\n# 'Example_1'\n# >>> fix_spaces(' Example 2')\n# '_Example_2'\n# >>> fix_spaces(' Example 3')\n# '_Example-3'\nfix_spaces <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "r",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference(c(1, 3, 2, 0))\n# 10\n# >>> double_the_difference(c(-1, -2, 0))\n# 0\n# >>> double_the_difference(c(9, -2))\n# 81\n# >>> double_the_difference(c(0))\n# 0\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "r",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(list('a', 3.14, 5))\n# c(5)\n# >>> filter_integers(list(1, 2, 3, 'abc', list(), c()))\n# c(1, 2, 3)\nfilter_integers <- function(values) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "r",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "r",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# c(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nparse_music <- function(music_string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "r",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# 'db1111db'\n# >>> decimal_to_binary(32)\n# 'db100000db'\ndecimal_to_binary <- function(decimal) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "r",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# c('a', 'ab', 'abc')\nall_prefixes <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "r",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "r",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# c(11, 4)\n# >>> eat(4, 8, 9)\n# c(12, 1)\n# >>> eat(1, 10, 10)\n# c(11, 0)\n# >>> eat(2, 11, 5)\n# c(7, 0)\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "r",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1)\n# 6\n# Example 2:\n# >>> max_fill(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2)\n# 5\n# Example 3:\n# >>> max_fill(list(c(0, 0, 0), c(0, 0, 0)), 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "r",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "r",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "r",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length(c(2, 1, 1, 4, 5, 8, 2, 3))\n# c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One')\n# If the array is empty, return an empty array:\n# >>> by_length(c())\n# c()\n# If the array has any strange number ignore it:\n# >>> by_length(c(1, -1, 55))\n# c('One')\nby_length <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "r",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# c(2, 2, 2)\n# >>> factorize(25)\n# c(5, 5)\n# >>> factorize(70)\n# c(2, 5, 7)\nfactorize <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "r",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# c(2, 3)\n# >>> count_up_to(11)\n# c(2, 3, 5, 7)\n# >>> count_up_to(0)\n# c()\n# >>> count_up_to(20)\n# c(2, 3, 5, 7, 11, 13, 17, 19)\n# >>> count_up_to(1)\n# c()\n# >>> count_up_to(18)\n# c(2, 3, 5, 7, 11, 13, 17)\ncount_up_to <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "r",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(0, 2, 3, 5, 9, 123)\nunique <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "r",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match(c(), c())\n# c()\n# >>> total_match(c('hi', 'admin'), c('hI', 'Hi'))\n# c('hI', 'Hi')\n# >>> total_match(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project'))\n# c('hi', 'admin')\n# >>> total_match(c('hi', 'admin'), c('hI', 'hi', 'hi'))\n# c('hI', 'hi', 'hi')\n# >>> total_match(c('4'), c('1', '2', '3', '4', '5'))\n# c('4')\ntotal_match <- function(lst1, lst2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "r",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element(c(1, 2, 3))\n# 3\n# >>> max_element(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# 123\nmax_element <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "r",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested('[[]]')\n# TRUE\n# >>> is_nested('[]]]]]]][[[[[]')\n# FALSE\n# >>> is_nested('[][]')\n# FALSE\n# >>> is_nested('[]')\n# FALSE\n# >>> is_nested('[[][]]')\n# TRUE\n# >>> is_nested('[[]][[')\n# TRUE\nis_nested <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "r",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# '0b11'\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# '0b1111'\n# >>> rounded_avg(20, 33)\n# '0b11010'\nrounded_avg <- function(n, m) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "r",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(c('1234567'))\n# c('the number of odd elements 4n the str4ng 4 of the 4nput.')\n# >>> odd_count(c('3', '11111111'))\n# c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.')\nodd_count <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "r",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball(c(3, 4, 5, 1, 2))\n# TRUE\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball(c(3, 5, 4, 1, 2))\n# FALSE\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# c(1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# c(4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "r",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# FALSE\n# >>> is_equal_to_sum_even(6)\n# FALSE\n# >>> is_equal_to_sum_even(8)\n# TRUE\nis_equal_to_sum_even <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "r",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative(c(3, 1, 2, 4, 5))\n# c(1, 4, 12, 20)\n# >>> derivative(c(1, 2, 3))\n# c(2, 6)\nderivative <- function(xs) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "r",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted(c(5))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5))\n# FALSE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6, 7))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5, 6, 7))\n# FALSE\n# >>> is_sorted(c(1, 2, 2, 3, 3, 4))\n# TRUE\n# >>> is_sorted(c(1, 2, 2, 2, 3, 4))\n# FALSE\nis_sorted <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve('1234')\n# '4321'\n# >>> solve('ab')\n# 'AB'\n# >>> solve('#a@C')\n# '#A@c'\nsolve <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "r",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# c(1, 3, 2, 8)\ntri <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "r",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix(c(), 'a')\n# c()\n# >>> filter_by_prefix(c('abc', 'bcd', 'cde', 'array'), 'a')\n# c('abc', 'array')\nfilter_by_prefix <- function(strings, prefix) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "r",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# '1'\n# >>> solve(150)\n# '110'\n# >>> solve(147)\n# '1100'\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "r",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3)\n# c(1, 2, 1)\n# >>> minPath(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1)\n# c(1)\nminPath <- function(grid, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "r",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper('aBCdEf')\n# 1\n# >>> count_upper('abcdefg')\n# 0\n# >>> count_upper('dBBE')\n# 0\ncount_upper <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "r",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum(c(-3, -4, 5), 3)\n# c(-4, -3, 5)\n# Example 2:\n# >>> maximum(c(4, -4, 4), 2)\n# c(4, 4)\n# Example 3:\n# >>> maximum(c(-3, 2, 1, 2, -1, -2, 1), 1)\n# c(2)\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "r",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "r",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array(c())\n# c()\n# >>> sort_array(c(5))\n# c(5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5))\n# c(0, 1, 2, 3, 4, 5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5, 6))\n# c(6, 5, 4, 3, 2, 1, 0)\nsort_array <- function(array) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "r",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# c(1, 2, 6, 24, 15)\nf <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "r",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# TRUE\n# >>> iscube(2)\n# FALSE\n# >>> iscube(-1)\n# TRUE\n# >>> iscube(64)\n# TRUE\n# >>> iscube(0)\n# TRUE\n# >>> iscube(180)\n# FALSE\niscube <- function(a) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "r",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "r",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored('Hello world')\n# 0\n# >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n# 1\nis_bored <- function(S) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "r",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 3, -2, 1))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> pairs_sum_to_zero(c(2, 4, -5, 3, 5, 7))\n# TRUE\n# >>> pairs_sum_to_zero(c(1))\n# FALSE\npairs_sum_to_zero <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\ntriangle_area <- function(a, b, c) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "r",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf('Jupiter', 'Neptune')\n# c('Saturn', 'Uranus')\n# >>> bf('Earth', 'Mercury')\n# 'Venus'\n# >>> bf('Mercury', 'Uranus')\n# c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\nbf <- function(planet1, planet2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\ndigits <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "r",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string('Hi, my name is John')\n# c('Hi', 'my', 'name', 'is', 'John')\n# >>> words_string('One, two, three, four, five, six')\n# c('One', 'two', 'three', 'four', 'five', 'six')\nwords_string <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "r",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "r",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, '2,3')\n# '2,3'\n# >>> compare_one('5,1', '6')\n# '6'\n# >>> compare_one('1', 1)\n# NULL\ncompare_one <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "r",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "r",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list(c(1, 2, 3, 4))\n# c(1, 4, 2, 3)\n# >>> strange_sort_list(c(5, 5, 5, 5))\n# c(5, 5, 5, 5)\n# >>> strange_sort_list(c())\n# c()\nstrange_sort_list <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "r",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n# c(2.0, 2.2)\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n# c(2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "r",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# TRUE\n# >>> is_simple_power(2, 2)\n# TRUE\n# >>> is_simple_power(8, 2)\n# TRUE\n# >>> is_simple_power(3, 2)\n# FALSE\n# >>> is_simple_power(3, 1)\n# FALSE\n# >>> is_simple_power(5, 3)\n# FALSE\nis_simple_power <- function(x, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "r",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "r",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points(c(1, 11, -1, -11, -12))\n# c(-1, -11, 1, -12, 11)\n# >>> order_by_points(c())\n# c()\norder_by_points <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "r",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements(c(1.0, 2.0, 3.0), 0.5)\n# FALSE\n# >>> has_close_elements(c(1.0, 2.8, 3.0, 4.0, 5.0, 2.0), 0.3)\n# TRUE\nhas_close_elements <- function(numbers, threshold) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- has_close_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2), 0.05), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.95), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0), 0.8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0), 0.1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 1.0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1), 0.5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "r",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "r",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "r",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "r",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "r",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "r",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits(c(15, 33, 1422, 1))\n# c(1, 15, 33)\n# >>> unique_digits(c(152, 323, 1422, 10))\n# c()\nunique_digits <- function(x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "r",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words('Mary had a little lamb', 4)\n# c('little')\n# >>> select_words('Mary had a little lamb', 3)\n# c('Mary', 'lamb')\n# >>> select_words('simple white space', 2)\n# c()\n# >>> select_words('Hello world', 4)\n# c('world')\n# >>> select_words('Uncle sam', 3)\n# c('Uncle')\nselect_words <- function(s, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "r",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly(c(1, 2), 5)\n# FALSE\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly(c(3, 2, 3), 1)\n# FALSE\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly(c(3, 2, 3), 9)\n# TRUE\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly(c(3), 5)\n# TRUE\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "r",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "r",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension('my_class', c('AA', 'Be', 'CC'))\n# 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "r",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens(c('()(', ')'))\n# 'Yes'\n# >>> match_parens(c(')', ')'))\n# 'No'\nmatch_parens <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest(c(1, 2, 3, 4, 5))\n# 2\n# >>> next_smallest(c(5, 1, 4, 3, 2))\n# 2\n# >>> next_smallest(c())\n# NULL\n# >>> next_smallest(c(1, 1))\n# NULL\nnext_smallest <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "r",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# TRUE\n# >>> any_int(3, 2, 2)\n# FALSE\n# >>> any_int(3, -2, 1)\n# TRUE\n# >>> any_int(3.6, -2.2, 2)\n# FALSE\nany_int <- function(x, y, z) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "r",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "r",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list(c(1, 2, 3))\n# c(2, 3, 4)\n# >>> incr_list(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(6, 4, 6, 3, 4, 4, 10, 1, 124)\nincr_list <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "r",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nx_or_y <- function(n, x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "r",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "r",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# c(1, 1)\n# >>> even_odd_count(123)\n# c(1, 2)\neven_odd_count <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "r",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy('a')\n# FALSE\n# >>> is_happy('aa')\n# FALSE\n# >>> is_happy('abcd')\n# TRUE\n# >>> is_happy('aabb')\n# FALSE\n# >>> is_happy('adb')\n# TRUE\n# >>> is_happy('xyy')\n# FALSE\nis_happy <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "r",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "r",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum('')\n# 0\n# >>> digitSum('abAB')\n# 131\n# >>> digitSum('abcCd')\n# 67\n# >>> digitSum('helloE')\n# 69\n# >>> digitSum('woArBld')\n# 131\n# >>> digitSum('aAaaaXa')\n# 153\ndigitSum <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "r",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit(c(1.0, 2.0, 3.0, 4.0, 5.0))\n# c(0.0, 0.25, 0.5, 0.75, 1.0)\nrescale_to_unit <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "r",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution(c(5, 8, 7, 1))\n# 12\n# >>> solution(c(3, 3, 3, 3, 3))\n# 9\n# >>> solution(c(30, 13, 24, 321))\n# 0\nsolution <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "r",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck(c(4, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck(c(1, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck(c())\n# c()\n# Example 4:\n# >>> pluck(c(5, 0, 3, 0, 4, 2))\n# c(0, 1)\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "r",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "r",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange(c(1, 2, 3, 4), c(1, 2, 3, 4))\n# 'YES'\n# >>> exchange(c(1, 2, 3, 4), c(1, 5, 3, 4))\n# 'NO'\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "r",
-    "prompt": "# Return median of elements in the list l.\n# >>> median(c(3, 1, 2, 4, 5))\n# 3\n# >>> median(c(-10, 4, 6, 1000, 10, 20))\n# 15.0\nmedian <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length('Hello')\n# TRUE\n# >>> prime_length('abcdcba')\n# TRUE\n# >>> prime_length('kittens')\n# TRUE\n# >>> prime_length('orange')\n# FALSE\nprime_length <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "r",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change(c(1, 2, 3, 5, 4, 7, 9, 6))\n# 4\n# >>> smallest_change(c(1, 2, 3, 4, 3, 2, 2))\n# 1\n# >>> smallest_change(c(1, 2, 3, 2, 1))\n# 0\nsmallest_change <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "r",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst(c(1.0, 2.0, 3.0))\n# 14\n# >>> lst(c(1.0, 4.0, 9.0))\n# 98\n# >>> lst(c(1.0, 3.0, 5.0, 7.0))\n# 84\n# >>> lst(c(1.4, 4.2, 0.0))\n# 29\n# >>> lst(c(-2.4, 1.0, 1.0))\n# 6\nsum_squares <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "r",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check('example.txt')\n# 'Yes'\n# >>> file_name_check('1example.dll')\n# 'No'\nfile_name_check <- function(file_name) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "r",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> triples_sum_to_zero(c(1, 3, -2, 1))\n# TRUE\n# >>> triples_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> triples_sum_to_zero(c(2, 4, -5, 3, 9, 7))\n# TRUE\n# >>> triples_sum_to_zero(c(1))\n# FALSE\ntriples_sum_to_zero <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "r",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection(c(1, 2), c(2, 3))\n# 'NO'\n# >>> intersection(c(-1, 1), c(0, 4))\n# 'NO'\n# >>> intersection(c(-3, -1), c(-5, 5))\n# 'YES'\nintersection <- function(interval1, interval2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "r",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# c('()', '(())', '(()())')\nseparate_paren_groups <- function(paren_string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "r",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2))\n# c(0, 0, 0, 0, 3, 3)\n# >>> compare(c(0, 5, 0, 0, 0, 4), c(4, 1, 1, 0, 0, -2))\n# c(4, 4, 1, 0, 0, 6)\ncompare <- function(game, guess) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "r",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter('apple pie')\n# FALSE\n# >>> check_if_last_char_is_a_letter('apple pi e')\n# TRUE\n# >>> check_if_last_char_is_a_letter('apple pi e ')\n# FALSE\n# >>> check_if_last_char_is_a_letter('')\n# FALSE\ncheck_if_last_char_is_a_letter <- function(txt) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "r",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date('03-11-2000')\n# TRUE\n# >>> valid_date('15-01-2012')\n# FALSE\n# >>> valid_date('04-0-2040')\n# FALSE\n# >>> valid_date('06-04-2020')\n# TRUE\n# >>> valid_date('06/04/2020')\n# FALSE\nvalid_date <- function(date) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "r",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums(c())\n# 0\n# >>> count_nums(c(-1, 11, -11))\n# 1\n# >>> count_nums(c(1, 1, 2))\n# 3\ncount_nums <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "r",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle('Hi')\n# 'Hi'\n# >>> anti_shuffle('hello')\n# 'ehllo'\n# >>> anti_shuffle('Hello World!!!')\n# 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "r",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# TRUE\n# >>> is_palindrome('aba')\n# TRUE\n# >>> is_palindrome('aaaaa')\n# TRUE\n# >>> is_palindrome('zbcd')\n# FALSE\nis_palindrome <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "r",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel('yogurt')\n# 'u'\n# >>> get_closest_vowel('FULL')\n# 'U'\n# >>> get_closest_vowel('quick')\n# ''\n# >>> get_closest_vowel('ab')\n# ''\nget_closest_vowel <- function(word) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "r",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# FALSE\n# >>> is_prime(101)\n# TRUE\n# >>> is_prime(11)\n# TRUE\n# >>> is_prime(13441)\n# TRUE\n# >>> is_prime(61)\n# TRUE\n# >>> is_prime(4)\n# FALSE\n# >>> is_prime(1)\n# FALSE\nis_prime <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "r",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify('1/5', '5/1')\n# TRUE\n# >>> simplify('1/6', '2/1')\n# FALSE\n# >>> simplify('7/10', '10/2')\n# FALSE\nsimplify <- function(x, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "r",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key('AB')\n# 1\n# >>> hex_key('1077E')\n# 2\n# >>> hex_key('ABED1A33')\n# 4\n# >>> hex_key('123456789ABCDEF0')\n# 6\n# >>> hex_key('2020')\n# 2\nhex_key <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "r",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence('This is a test')\n# 'is'\n# Example 2:\n# >>> words_in_sentence('lets go for swimming')\n# 'go for'\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "r",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram('a b c')\n# list('a' = 1, 'b' = 1, 'c' = 1)\n# >>> histogram('a b b a')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('a b c a b')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('b b b b a')\n# list('b' = 4)\n# >>> histogram('')\n# list()\nhistogram <- function(test) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "r",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1)\n# list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0))\n# >>> get_row(c(), 1)\n# c()\n# >>> get_row(list(c(), c(1), c(1, 2, 3)), 3)\n# list(c(2, 2))\nget_row <- function(lst, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "r",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# c(1, 5)\nget_odd_collatz <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "r",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange(c(1, 2, 4, 3, 5))\n# 3\n# >>> can_arrange(c(1, 2, 3))\n# -1\ncan_arrange <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "r",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "r",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# '21'\n# >>> circular_shift(12, 2)\n# '12'\ncircular_shift <- function(x, shift) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "r",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# c(1, 2, 3)\n# >>> lst\n# c()\n# >>> lst\n# c(-1, -5, 2, -1, -5)\nsum_squares <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "r",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n# 10\n# >>> skjkasdkd(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n# 25\n# >>> skjkasdkd(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n# 13\n# >>> skjkasdkd(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n# 11\n# >>> skjkasdkd(c(0, 81, 12, 3, 1, 21))\n# 3\n# >>> skjkasdkd(c(0, 8, 1, 2, 1, 7))\n# 7\nskjkasdkd <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "r",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product(c())\n# c(0, 1)\n# >>> sum_product(c(1, 2, 3, 4))\n# c(10, 24)\nsum_product <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "r",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nchoose_num <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "r",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers(c(2, 4, 1, 3, 5, 7))\n# list(NULL, 1)\n# >>> largest_smallest_integers(c())\n# list(NULL, NULL)\n# >>> largest_smallest_integers(c(0))\n# list(NULL, NULL)\nlargest_smallest_integers <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "r",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ncount_distinct_characters <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1525,7 +17,7 @@
     "language": "r",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# c(3, 5, 7)\nmake_a_pile <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- make_a_pile\n    stopifnot(isTRUE(all.equal(candidate(3), c(3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4, 6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5, 7, 9, 11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(6, 8, 10, 12, 14, 16))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(8, 10, 12, 14, 16, 18, 20, 22))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1534,221 +26,156 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "r",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs(c(1, 2, 2, -4))\n# 9\n# >>> prod_signs(c(0, 1))\n# 0\n# >>> prod_signs(c())\n# NULL\nprod_signs <- function(arr) {",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string('Hi, my name is John')\n# c('Hi', 'my', 'name', 'is', 'John')\n# >>> words_string('One, two, three, four, five, six')\n# c('One', 'two', 'three', 'four', 'five', 'six')\nwords_string <- function(s) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_string\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name is John'), c('Hi', 'my', 'name', 'is', 'John'))))\n    stopifnot(isTRUE(all.equal(candidate('One, two, three, four, five, six'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate('Hi, my name'), c('Hi', 'my', 'name'))))\n    stopifnot(isTRUE(all.equal(candidate('One,, two, three, four, five, six,'), c('One', 'two', 'three', 'four', 'five', 'six'))))\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('ahmed     , gamal'), c('ahmed', 'gamal'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "r",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum(c(2, 3, 4, 1, 2, 4))\n# 1\n# >>> minSubArraySum(c(-1, -2, -3))\n# -6\nminSubArraySum <- function(nums) {",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num(12, 15)\n# 14\n# >>> choose_num(13, 12)\n# -1\nchoose_num <- function(x, y) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- choose_num\n    stopifnot(isTRUE(all.equal(candidate(12, 15), 14)))\n    stopifnot(isTRUE(all.equal(candidate(13, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(33, 12354), 12354)))\n    stopifnot(isTRUE(all.equal(candidate(5234, 5233), -1)))\n    stopifnot(isTRUE(all.equal(candidate(6, 29), 28)))\n    stopifnot(isTRUE(all.equal(candidate(27, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(7, 7), -1)))\n    stopifnot(isTRUE(all.equal(candidate(546, 546), 546)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "r",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg(1, 5)\n# '0b11'\n# >>> rounded_avg(7, 5)\n# -1\n# >>> rounded_avg(10, 20)\n# '0b1111'\n# >>> rounded_avg(20, 33)\n# '0b11010'\nrounded_avg <- function(n, m) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- rounded_avg\n    stopifnot(isTRUE(all.equal(candidate(1, 5), '0b11')))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), '0b1010')))\n    stopifnot(isTRUE(all.equal(candidate(964, 977), '0b1111001010')))\n    stopifnot(isTRUE(all.equal(candidate(996, 997), '0b1111100100')))\n    stopifnot(isTRUE(all.equal(candidate(560, 851), '0b1011000010')))\n    stopifnot(isTRUE(all.equal(candidate(185, 546), '0b101101110')))\n    stopifnot(isTRUE(all.equal(candidate(362, 496), '0b110101101')))\n    stopifnot(isTRUE(all.equal(candidate(350, 902), '0b1001110010')))\n    stopifnot(isTRUE(all.equal(candidate(197, 233), '0b11010111')))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), -1)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), '0b101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "r",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check('abcd', 'abd')\n# FALSE\n# >>> cycpattern_check('hello', 'ell')\n# TRUE\n# >>> cycpattern_check('whassup', 'psus')\n# FALSE\n# >>> cycpattern_check('abab', 'baa')\n# TRUE\n# >>> cycpattern_check('efef', 'eeff')\n# FALSE\n# >>> cycpattern_check('himenss', 'simen')\n# TRUE\ncycpattern_check <- function(a, b) {",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits(c(15, 33, 1422, 1))\n# c(1, 15, 33)\n# >>> unique_digits(c(152, 323, 1422, 10))\n# c()\nunique_digits <- function(x) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_digits\n    stopifnot(isTRUE(all.equal(candidate(c(15, 33, 1422, 1)), c(1, 15, 33))))\n    stopifnot(isTRUE(all.equal(candidate(c(152, 323, 1422, 10)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(12345, 2033, 111, 151)), c(111, 151))))\n    stopifnot(isTRUE(all.equal(candidate(c(135, 103, 31)), c(31, 135))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "r",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic(c(1, 2, 4, 20))\n# TRUE\n# >>> monotonic(c(1, 20, 4, 10))\n# FALSE\n# >>> monotonic(c(4, 1, 0, -10))\n# TRUE\nmonotonic <- function(l) {",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length(c(2, 1, 1, 4, 5, 8, 2, 3))\n# c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One')\n# If the array is empty, return an empty array:\n# >>> by_length(c())\n# c()\n# If the array has any strange number ignore it:\n# >>> by_length(c(1, -1, 55))\n# c('One')\nby_length <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- by_length\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 1, 4, 5, 8, 2, 3)), c('Eight', 'Five', 'Four', 'Three', 'Two', 'Two', 'One', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 55)), c('One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 3, 2)), c('Three', 'Two', 'One'))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 4, 8)), c('Nine', 'Eight', 'Four'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "r",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest(c())\n# NULL\n# >>> longest(c('a', 'b', 'c'))\n# 'a'\n# >>> longest(c('a', 'bb', 'ccc'))\n# 'ccc'\nlongest <- function(strings) {",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f(5)\n# c(1, 2, 6, 24, 15)\nf <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- f\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 2, 6, 24, 15))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 2, 6, 24, 15, 720, 28))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "r",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold(c(1, 2, 4, 10), 100)\n# TRUE\n# >>> below_threshold(c(1, 20, 4, 10), 5)\n# FALSE\nbelow_threshold <- function(l, t) {",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome(3)\n# c(1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome(12)\n# c(4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\neven_odd_palindrome <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_palindrome\n    stopifnot(isTRUE(all.equal(candidate(123), c(8, 13))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(63), c(6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(19), c(4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(0, 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "r",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# TRUE\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums(c())\n# 0\n# >>> count_nums(c(-1, 11, -11))\n# 1\n# >>> count_nums(c(1, 1, 2))\n# 3\ncount_nums <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_nums\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, -2, 3, 4, 5)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 9, -6, 0, 1, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 100, 98, -7, 1, -1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 34, -45, -56, 0)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "r",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive(c(-1, 2, -4, 5, 6))\n# c(2, 5, 6)\n# >>> get_positive(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# c(5, 3, 2, 3, 9, 123, 1)\nget_positive <- function(l) {",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball(c(3, 4, 5, 1, 2))\n# TRUE\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball(c(3, 5, 4, 1, 2))\n# FALSE\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\nmove_one_ball <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_one_ball\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 10, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 4, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "r",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_third(c(5, 6, 3, 4, 8, 9, 2))\n# c(2, 6, 3, 4, 8, 9, 5)\nsort_third <- function(l) {",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\nmake_palindrome <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- make_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('x'), 'x')))\n    stopifnot(isTRUE(all.equal(candidate('xyz'), 'xyzyx')))\n    stopifnot(isTRUE(all.equal(candidate('xyx'), 'xyx')))\n    stopifnot(isTRUE(all.equal(candidate('jerry'), 'jerryrrej')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "r",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# c(2, 3, 1, 3)\nparse_nested_parens <- function(paren_string) {",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange(c(1, 2, 3, 4), c(1, 2, 3, 4))\n# 'YES'\n# >>> exchange(c(1, 2, 3, 4), c(1, 5, 3, 4))\n# 'NO'\n# It is assumed that the input lists will be non-empty.\nexchange <- function(lst1, lst2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- exchange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 2, 3, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(1, 5, 3, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(2, 1, 4, 3)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 4)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 3), c(2, 6, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 6, 1, 8, 9), c(3, 5, 5, 1, 1, 1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 200), c(200, 200)), 'YES')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "r",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram('a b c')\n# list('a' = 1, 'b' = 1, 'c' = 1)\n# >>> histogram('a b b a')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('a b c a b')\n# list('a' = 2, 'b' = 2)\n# >>> histogram('b b b b a')\n# list('b' = 4)\n# >>> histogram('')\n# list()\nhistogram <- function(test) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "r",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nmultiply <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "r",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation(c(1.0, 2.0, 3.0, 4.0))\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "r",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121))\n# c(1, 5, 653)\n# >>> common(c(5, 3, 2, 8), c(3, 2))\n# c(2, 3)\ncommon <- function(l1, l2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "r",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# 'xix'\n# >>> int_to_mini_roman(152)\n# 'clii'\n# >>> int_to_mini_roman(426)\n# 'cdxxvi'\nint_to_mini_roman <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "r",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution('5 apples and 6 oranges', 19)\n# 8\n# >>> fruit_distribution('0 apples and 1 oranges', 3)\n# 2\n# >>> fruit_distribution('2 apples and 3 oranges', 100)\n# 95\n# >>> fruit_distribution('100 apples and 1 oranges', 120)\n# 19\nfruit_distribution <- function(s, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- histogram\n    stopifnot(isTRUE(all.equal(candidate('a b b a'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c a b'), list('a' = 2, 'b' = 2))))\n    stopifnot(isTRUE(all.equal(candidate('a b c d g'), list('a' = 1, 'b' = 1, 'c' = 1, 'd' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate('b b b b a'), list('b' = 4))))\n    stopifnot(isTRUE(all.equal(candidate('r t g'), list('r' = 1, 't' = 1, 'g' = 1))))\n    stopifnot(isTRUE(all.equal(candidate(''), list())))\n    stopifnot(isTRUE(all.equal(candidate('a'), list('a' = 1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1759,7 +186,7 @@
     "language": "r",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# >>> reverse_delete('abcde', 'ae')\n# list('bcd', FALSE)\n# >>> reverse_delete('abcdef', 'b')\n# list('acdef', FALSE)\n# >>> reverse_delete('abcdedcba', 'ab')\n# list('cdedc', TRUE)\nreverse_delete <- function(s, c) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- reverse_delete\n    stopifnot(isTRUE(all.equal(candidate('abcde', 'ae'), list('bcd', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef', 'b'), list('acdef', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'ab'), list('cdedc', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('dwik', 'w'), list('dik', FALSE))))\n    stopifnot(isTRUE(all.equal(candidate('a', 'a'), list('', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', ''), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('abcdedcba', 'v'), list('abcdedcba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('vabba', 'v'), list('abba', TRUE))))\n    stopifnot(isTRUE(all.equal(candidate('mamma', 'mia'), list('', TRUE))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1768,26 +195,39 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "r",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(c('1234567'))\n# c('the number of odd elements 4n the str4ng 4 of the 4nput.')\n# >>> odd_count(c('3', '11111111'))\n# c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.')\nodd_count <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_count\n    stopifnot(isTRUE(all.equal(candidate(c('1234567')), c('the number of odd elements 4n the str4ng 4 of the 4nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('3', '11111111')), c('the number of odd elements 1n the str1ng 1 of the 1nput.', 'the number of odd elements 8n the str8ng 8 of the 8nput.'))))\n    stopifnot(isTRUE(all.equal(candidate(c('271', '137', '314')), c('the number of odd elements 2n the str2ng 2 of the 2nput.', 'the number of odd elements 3n the str3ng 3 of the 3nput.', 'the number of odd elements 2n the str2ng 2 of the 2nput.'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "r",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words('Hello world!')\n# c('Hello', 'world!')\n# >>> split_words('Hello,world!')\n# c('Hello', 'world!')\n# >>> split_words('abcdef')\n# 3\nsplit_words <- function(txt) {",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum(c(2, 3, 4, 1, 2, 4))\n# 1\n# >>> minSubArraySum(c(-1, -2, -3))\n# -6\nminSubArraySum <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- minSubArraySum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 1, 2, 4)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 2, -10)), -14)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9999999999999999)), -9999999999999999)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 10, 20, 1000000)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -1, -2, -3, 10, -5)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 13, 8, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, -33, 32, -1, 0, -2)), -33)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c(7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "r",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1)\n# 6\n# Example 2:\n# >>> max_fill(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2)\n# 5\n# Example 3:\n# >>> max_fill(list(c(0, 0, 0), c(0, 0, 0)), 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\nmax_fill <- function(grid, capacity) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_fill\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 0), c(0, 1, 0, 0), c(1, 1, 1, 1)), 1), 6)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 1, 1), c(0, 0, 0, 0), c(1, 1, 1, 1), c(0, 1, 1, 1)), 2), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 0, 0), c(0, 0, 0)), 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, 1, 1), c(1, 1, 1, 1)), 9), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1798,7 +238,7 @@
     "language": "r",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array(c(1, 5, 2, 3, 4))\n# c(1, 2, 3, 4, 5)\n# >>> sort_array(c(-2, -3, -4, -5, -6))\n# c(-6, -5, -4, -3, -2)\n# >>> sort_array(c(1, 0, 2, 3, 4))\n# c(0, 1, 2, 3, 4)\nsort_array <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 2, 3, 4)), c(1, 2, 4, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, -4, -5, -6)), c(-4, -2, -6, -5, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 3, 4)), c(0, 1, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4)), c(2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 44, 12, 32, 5)), c(32, 3, 5, 6, 12, 44))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 16, 32)), c(2, 4, 8, 16, 32))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1807,143 +247,416 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "r",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate(c())\n# ''\n# >>> concatenate(c('a', 'b', 'c'))\n# 'abc'\nconcatenate <- function(strings) {",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words('Mary had a little lamb', 4)\n# c('little')\n# >>> select_words('Mary had a little lamb', 3)\n# c('Mary', 'lamb')\n# >>> select_words('simple white space', 2)\n# c()\n# >>> select_words('Hello world', 4)\n# c('world')\n# >>> select_words('Uncle sam', 3)\n# c('Uncle')\nselect_words <- function(s, n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- select_words\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 4), c('little'))))\n    stopifnot(isTRUE(all.equal(candidate('Mary had a little lamb', 3), c('Mary', 'lamb'))))\n    stopifnot(isTRUE(all.equal(candidate('simple white space', 2), c())))\n    stopifnot(isTRUE(all.equal(candidate('Hello world', 4), c('world'))))\n    stopifnot(isTRUE(all.equal(candidate('Uncle sam', 3), c('Uncle'))))\n    stopifnot(isTRUE(all.equal(candidate('', 4), c())))\n    stopifnot(isTRUE(all.equal(candidate('a b c d e f', 1), c('b', 'c', 'd', 'f'))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort(c('aa', 'a', 'aaa'))\n# c('aa')\n# >>> list_sort(c('ab', 'a', 'aaa', 'cd'))\n# c('ab', 'cd')\nsorted_list_sum <- function(lst) {",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel('yogurt')\n# 'u'\n# >>> get_closest_vowel('FULL')\n# 'U'\n# >>> get_closest_vowel('quick')\n# ''\n# >>> get_closest_vowel('ab')\n# ''\nget_closest_vowel <- function(word) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_closest_vowel\n    stopifnot(isTRUE(all.equal(candidate('yogurt'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('full'), 'u')))\n    stopifnot(isTRUE(all.equal(candidate('easy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('eAsy'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ali'), '')))\n    stopifnot(isTRUE(all.equal(candidate('bad'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('most'), 'o')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), '')))\n    stopifnot(isTRUE(all.equal(candidate('ba'), '')))\n    stopifnot(isTRUE(all.equal(candidate('quick'), '')))\n    stopifnot(isTRUE(all.equal(candidate('anime'), 'i')))\n    stopifnot(isTRUE(all.equal(candidate('Asia'), '')))\n    stopifnot(isTRUE(all.equal(candidate('Above'), 'o')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "r",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring(c(), 'a')\n# c()\n# >>> filter_by_substring(c('abc', 'bacd', 'cde', 'array'), 'a')\n# c('abc', 'bacd', 'array')\nfilter_by_substring <- function(strings, substring) {",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens(c('()(', ')'))\n# 'Yes'\n# >>> match_parens(c(')', ')'))\n# 'No'\nmatch_parens <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- match_parens\n    stopifnot(isTRUE(all.equal(candidate(c('()(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', ')')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(())', '())())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')())', '(()()(')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('(())))', '(()())((')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('()', '())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(()(', '()))()')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c('((((', '((())')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(()', '(()(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c(')(', ')(')), 'No')))\n    stopifnot(isTRUE(all.equal(candidate(c('(', ')')), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate(c(')', '(')), 'Yes')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "r",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer('10')\n# 10\n# >>> closest_integer('15.3')\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\nstring_xor <- function(a, b) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_xor\n    stopifnot(isTRUE(all.equal(candidate('111000', '101010'), '010010')))\n    stopifnot(isTRUE(all.equal(candidate('1', '1'), '0')))\n    stopifnot(isTRUE(all.equal(candidate('0101', '0000'), '0101')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "r",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count('abcde')\n# 2\n# >>> vowels_count('ACEDY')\n# 3\nvowels_count <- function(s) {",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum(c(-3, -4, 5), 3)\n# c(-4, -3, 5)\n# Example 2:\n# >>> maximum(c(4, -4, 4), 2)\n# c(4, 4)\n# Example 3:\n# >>> maximum(c(-3, 2, 1, 2, -1, -2, 1), 1)\n# c(2)\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\nmaximum <- function(arr, k) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5), 3), c(-4, -3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4, 4), 2), c(4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 2, 1, 2, -1, -2, 1), 1), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(123, -123, 20, 0, 1, 2, -3), 3), c(2, 20, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(-123, 20, 0, 1, 2, -3), 4), c(0, 1, 2, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 0, 3, -13, -8, 0), 7), c(-13, -8, 0, 0, 3, 5, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 2, 5, 3, -10), 2), c(3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 5, -7), 1), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, -4), 2), c(-4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 10), 2), c(-10, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -23, 243, -400, 0), 0), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "r",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max(c('name', 'of', 'string'))\n# 'string'\n# >>> find_max(c('name', 'enam', 'game'))\n# 'enam'\n# >>> find_max(c('aaaaaaa', 'bb', 'cc'))\n# 'aaaaaaa'\nfind_max <- function(words) {",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution(c(5, 8, 7, 1))\n# 12\n# >>> solution(c(3, 3, 3, 3, 3))\n# 9\n# >>> solution(c(30, 13, 24, 321))\n# 0\nsolution <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- solution\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 7, 1)), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3, 3, 3, 3)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 24, 321)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 13, 23, 32)), 23)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 13, 2, 9)), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "r",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world')\n# '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\nadd_elements <- function(arr, k) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 41, 57, 76, 87, 88, 99), 3), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 121, 3, 4000, 5, 6), 2), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 21, 3, 90, 5, 6, 7, 8, 9), 4), 125)))\n    stopifnot(isTRUE(all.equal(candidate(c(111, 21, 3, 4000, 5, 6, 7, 8, 9), 4), 24)))\n    stopifnot(isTRUE(all.equal(candidate(c(1), 1), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "r",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz(5)\n# c(1, 5)\nget_odd_collatz <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_odd_collatz\n    stopifnot(isTRUE(all.equal(candidate(14), c(1, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(12), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "r",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# TRUE\n# >>> right_angle_triangle(1, 2, 3)\n# FALSE\nright_angle_triangle <- function(a, b, c) {",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date('03-11-2000')\n# TRUE\n# >>> valid_date('15-01-2012')\n# FALSE\n# >>> valid_date('04-0-2040')\n# FALSE\n# >>> valid_date('06-04-2020')\n# TRUE\n# >>> valid_date('06/04/2020')\n# FALSE\nvalid_date <- function(date) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- valid_date\n    stopifnot(isTRUE(all.equal(candidate('03-11-2000'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('15-01-2012'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-0-2040'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-04-2020'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('01-01-2007'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('03-32-2011'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-31-3000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('06-06-2005'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('21-31-2000'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-12-2003'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('04122003'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('20030412'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2003-04-12'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('04-2003'), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "r",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation(c(4.0, 3, 1.7, 2, 3.5))\n# c('A+', 'B', 'C-', 'C', 'A-')\nnumerical_letter_grade <- function(grades) {",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words('Hello world!')\n# c('Hello', 'world!')\n# >>> split_words('Hello,world!')\n# c('Hello', 'world!')\n# >>> split_words('abcdef')\n# 3\nsplit_words <- function(txt) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_words\n    stopifnot(isTRUE(all.equal(candidate('Hello world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,world!'), c('Hello', 'world!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello world,!'), c('Hello', 'world,!'))))\n    stopifnot(isTRUE(all.equal(candidate('Hello,Hello,world !'), c('Hello,Hello,world', '!'))))\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('aaabb'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('aaaBb'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "r",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse(c(), 4)\n# c()\n# >>> intersperse(c(1, 2, 3), 4)\n# c(1, 4, 2, 4, 3)\nintersperse <- function(numbers, delimeter) {",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted(c(5))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5))\n# FALSE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6))\n# TRUE\n# >>> is_sorted(c(1, 2, 3, 4, 5, 6, 7))\n# TRUE\n# >>> is_sorted(c(1, 3, 2, 4, 5, 6, 7))\n# FALSE\n# >>> is_sorted(c(1, 2, 2, 3, 3, 4))\n# TRUE\n# >>> is_sorted(c(1, 2, 2, 2, 3, 4))\n# FALSE\nis_sorted <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sorted\n    stopifnot(isTRUE(all.equal(candidate(c(5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c()), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "r",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection(c(1, 2), c(2, 3))\n# 'NO'\n# >>> intersection(c(-1, 1), c(0, 4))\n# 'NO'\n# >>> intersection(c(-3, -1), c(-5, 5))\n# 'YES'\nintersection <- function(interval1, interval2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(2, 3)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1), c(0, 4)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -1), c(-5, 5)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, 2), c(-4, 0)), 'YES')))\n    stopifnot(isTRUE(all.equal(candidate(c(-11, 2), c(-1, -1)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 5)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(1, 2)), 'NO')))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -2), c(-3, -2)), 'NO')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "r",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs(c(1, 2, 2, -4))\n# 9\n# >>> prod_signs(c(0, 1))\n# 0\n# >>> prod_signs(c())\n# NULL\nprod_signs <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prod_signs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, -4)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, -1, 1)), -10)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 2, -1, -1, 9)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, -1, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 1)), -4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 1, 1, 0)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "r",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3)\n# c(1, 2, 1)\n# >>> minPath(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1)\n# c(1)\nminPath <- function(grid, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- minPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9)), 3), c(1, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 9, 3), c(4, 1, 6), c(7, 8, 2)), 1), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12), c(13, 14, 15, 16)), 4), c(1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 4, 13, 10), c(5, 7, 12, 1), c(3, 16, 11, 15), c(8, 14, 9, 2)), 7), c(1, 10, 1, 10, 1, 10, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(8, 14, 9, 2), c(6, 4, 13, 15), c(5, 7, 1, 12), c(3, 10, 11, 16)), 5), c(1, 7, 1, 7, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 8, 7, 2), c(5, 16, 14, 4), c(9, 3, 15, 6), c(12, 13, 10, 1)), 9), c(1, 6, 1, 6, 1, 6, 1, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 13, 10, 1), c(9, 3, 15, 6), c(5, 16, 14, 4), c(11, 8, 7, 2)), 12), c(1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 4), c(3, 1, 5), c(6, 8, 9)), 8), c(1, 3, 1, 3, 1, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 1, 5), c(3, 8, 9), c(2, 7, 4)), 8), c(1, 5, 1, 5, 1, 5, 1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4)), 10), c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(3, 2)), 10), c(1, 3, 1, 3, 1, 3, 1, 3, 1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "r",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest(c())\n# NULL\n# >>> longest(c('a', 'b', 'c'))\n# 'a'\n# >>> longest(c('a', 'bb', 'ccc'))\n# 'ccc'\nlongest <- function(strings) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- longest\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'x')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'yyy', 'zzzz', 'www', 'kkkk', 'abc')), 'zzzz')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "r",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri(3)\n# c(1, 3, 2, 8)\ntri <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tri\n    stopifnot(isTRUE(all.equal(candidate(3), c(1, 3, 2, 8))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(1, 3, 2, 8, 3))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(1, 3, 2, 8, 3, 15))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(1, 3, 2, 8, 3, 15, 4))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(1, 3, 2, 8, 3, 15, 4, 24))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(1, 3, 2, 8, 3, 15, 4, 24, 5))))\n    stopifnot(isTRUE(all.equal(candidate(9), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(1), c(1, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits(1)\n# 1\n# >>> digits(4)\n# 0\n# >>> digits(235)\n# 15\ndigits <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digits\n    stopifnot(isTRUE(all.equal(candidate(5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(54), 5)))\n    stopifnot(isTRUE(all.equal(candidate(120), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5014), 5)))\n    stopifnot(isTRUE(all.equal(candidate(98765), 315)))\n    stopifnot(isTRUE(all.equal(candidate(5576543), 2625)))\n    stopifnot(isTRUE(all.equal(candidate(2468), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "r",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested('[[]]')\n# TRUE\n# >>> is_nested('[]]]]]]][[[[[]')\n# FALSE\n# >>> is_nested('[][]')\n# FALSE\n# >>> is_nested('[]')\n# FALSE\n# >>> is_nested('[[][]]')\n# TRUE\n# >>> is_nested('[[]][[')\n# TRUE\nis_nested <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nested\n    stopifnot(isTRUE(all.equal(candidate('[[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]][[[[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[]]]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]]]]]]]]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[][][[]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[]]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[]][['), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('[[][]]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('[[[[[[[['), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(']]]]]]]]'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "r",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst(c(1.0, 2.0, 3.0))\n# 14\n# >>> lst(c(1.0, 4.0, 9.0))\n# 98\n# >>> lst(c(1.0, 3.0, 5.0, 7.0))\n# 84\n# >>> lst(c(1.4, 4.2, 0.0))\n# 29\n# >>> lst(c(-2.4, 1.0, 1.0))\n# 6\nsum_squares <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 3.0, 5.0, 7.0)), 84)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.4, 4.2, 0.0)), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2.4, 1.0, 1.0)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 1.0, 15.0, 2.0)), 10230)))\n    stopifnot(isTRUE(all.equal(candidate(c(10000.0, 10000.0)), 200000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 4.6, 6.3)), 75)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.4, 17.9, 18.9, 19.9)), 1086)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, 1.0, 0.0)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "r",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter('apple pie')\n# FALSE\n# >>> check_if_last_char_is_a_letter('apple pi e')\n# TRUE\n# >>> check_if_last_char_is_a_letter('apple pi e ')\n# FALSE\n# >>> check_if_last_char_is_a_letter('')\n# FALSE\ncheck_if_last_char_is_a_letter <- function(txt) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_if_last_char_is_a_letter\n    stopifnot(isTRUE(all.equal(candidate('apple'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('A'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Pumpkin pie 1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eeeee e '), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pie'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('apple pi e '), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "r",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange(c(1, 2, 4, 3, 5))\n# 3\n# >>> can_arrange(c(1, 2, 3))\n# -1\ncan_arrange <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- can_arrange\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 3, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 8, 5, 7, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c()), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "r",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers(c(2, 4, 1, 3, 5, 7))\n# list(NULL, 1)\n# >>> largest_smallest_integers(c())\n# list(NULL, NULL)\n# >>> largest_smallest_integers(c(0))\n# list(NULL, NULL)\nlargest_smallest_integers <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_smallest_integers\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3, 5, 7, 0)), list(NULL, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2, 4, 5, 6, -2)), c(-2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 3, 6, 2, 7, -7)), c(-7, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 8, 4, 9, 2, 5, -9)), c(-9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c()), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), list(NULL, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, -5, -6, 0)), list(-1, NULL))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, 1)), c(-3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-6, -4, -4, -3, -100, 1)), c(-3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "r",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one(1, 2.5)\n# 2.5\n# >>> compare_one(1, '2,3')\n# '2,3'\n# >>> compare_one('5,1', '6')\n# '6'\n# >>> compare_one('1', 1)\n# NULL\ncompare_one <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare_one\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2.5), 2.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, '2,3'), '2,3')))\n    stopifnot(isTRUE(all.equal(candidate('5,1', '6'), '6')))\n    stopifnot(isTRUE(all.equal(candidate('1', '2'), '2')))\n    stopifnot(isTRUE(all.equal(candidate('1', 1), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "r",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even(4)\n# FALSE\n# >>> is_equal_to_sum_even(6)\n# FALSE\n# >>> is_equal_to_sum_even(8)\n# TRUE\nis_equal_to_sum_even <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_equal_to_sum_even\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(16), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "r",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\nspecial_factorial <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- special_factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 288)))\n    stopifnot(isTRUE(all.equal(candidate(5), 34560)))\n    stopifnot(isTRUE(all.equal(candidate(7), 125411328000)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "r",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ngreatest_common_divisor <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- greatest_common_divisor\n    stopifnot(isTRUE(all.equal(candidate(3, 7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(49, 14), 7)))\n    stopifnot(isTRUE(all.equal(candidate(144, 60), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "r",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces(' Example')\n# 'Example'\n# >>> fix_spaces(' Example 1')\n# 'Example_1'\n# >>> fix_spaces(' Example 2')\n# '_Example_2'\n# >>> fix_spaces(' Example 3')\n# '_Example-3'\nfix_spaces <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fix_spaces\n    stopifnot(isTRUE(all.equal(candidate('Example'), 'Example')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir Hanif '), 'Mudasir_Hanif_')))\n    stopifnot(isTRUE(all.equal(candidate('Yellow Yellow  Dirty  Fellow'), 'Yellow_Yellow__Dirty__Fellow')))\n    stopifnot(isTRUE(all.equal(candidate('Exa   mple'), 'Exa-mple')))\n    stopifnot(isTRUE(all.equal(candidate('   Exa 1 2 2 mple'), '-Exa_1_2_2_mple')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "r",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check('example.txt')\n# 'Yes'\n# >>> file_name_check('1example.dll')\n# 'No'\nfile_name_check <- function(file_name) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- file_name_check\n    stopifnot(isTRUE(all.equal(candidate('example.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1example.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s1sdf3.asd'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('K.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('MY16FILE3.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('His12FILE94.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_Y.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('?aREYA.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('/this_is_valid.dll'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.wow'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_valid.txtexe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('#this2_i4s_5valid.ten'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('@this1_is6_valid.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('this_is_12valid.6exe4.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('all.exe.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_No.exe'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('Is3youfault.txt'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('no_one#knows.dll'), 'Yes')))\n    stopifnot(isTRUE(all.equal(candidate('1I563_Yes3.exe'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('I563_Yes3.txtt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final..txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('final132'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('_f4indsartal132.'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('.txt'), 'No')))\n    stopifnot(isTRUE(all.equal(candidate('s.'), 'No')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "r",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# c(1, 2, 3)\n# >>> lst\n# c()\n# >>> lst\n# c(-1, -5, 2, -1, -5)\nsum_squares <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_squares\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 9)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 1, 1, 1, 1, 1)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -1, -1, -1, -1, -1, -1, -1, -1)), -3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -5, 2, -1, -5)), -126)))\n    stopifnot(isTRUE(all.equal(candidate(c(-56, -99, 1, 0, -2)), 3030)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 0, 0, 0, 0, 0, 0, 0, -1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37)), -14196)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10)), -1448)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "r",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence('This is a test')\n# 'is'\n# Example 2:\n# >>> words_in_sentence('lets go for swimming')\n# 'go for'\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\nwords_in_sentence <- function(sentence) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- words_in_sentence\n    stopifnot(isTRUE(all.equal(candidate('This is a test'), 'is')))\n    stopifnot(isTRUE(all.equal(candidate('lets go for swimming'), 'go for')))\n    stopifnot(isTRUE(all.equal(candidate('there is no place available here'), 'there is no place')))\n    stopifnot(isTRUE(all.equal(candidate('Hi I am Hussein'), 'Hi am Hussein')))\n    stopifnot(isTRUE(all.equal(candidate('go for it'), 'go for it')))\n    stopifnot(isTRUE(all.equal(candidate('here'), '')))\n    stopifnot(isTRUE(all.equal(candidate('here is'), 'is')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "r",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify('1/5', '5/1')\n# TRUE\n# >>> simplify('1/6', '2/1')\n# FALSE\n# >>> simplify('7/10', '10/2')\n# FALSE\nsimplify <- function(x, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- simplify\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/6', '2/1'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/1', '3/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/10', '10/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/10', '50/10'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('7/2', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('11/6', '6/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/3', '5/2'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('5/2', '3/5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '8/4'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('2/4', '4/2'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '5/1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1/5', '1/5'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "r",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points(c(1, 11, -1, -11, -12))\n# c(-1, -11, 1, -12, 11)\n# >>> order_by_points(c())\n# c()\norder_by_points <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- order_by_points\n    stopifnot(isTRUE(all.equal(candidate(c(1, 11, -1, -11, -12)), c(-1, -11, 1, -12, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46)), c(0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -11, -32, 43, 54, -98, 2, -3)), c(-3, -32, -98, -11, 1, 2, 43, 54))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)), c(1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 6, 6, -76, -21, 23, 4)), c(-76, -21, 0, 4, 23, 6, 6))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1954,7 +667,7 @@
     "language": "r",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter(c(15, -73, 14, -15))\n# 1\n# >>> specialFilter(c(33, -2, -3, 45, 21, 109))\n# 2\nspecialFilter <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- specialFilter\n    stopifnot(isTRUE(all.equal(candidate(c(5, -2, 1, -5)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, -73, 14, -15)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(33, -2, -3, 45, 21, 109)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(43, -12, 93, 125, 121, 109)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(71, -2, -33, 75, 21, 19)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -1963,26 +676,234 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "r",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\nget_max_triples <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_triples\n    stopifnot(isTRUE(all.equal(candidate(5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(10), 36)))\n    stopifnot(isTRUE(all.equal(candidate(100), 53361)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "r",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates(c(1, 2, 3, 2, 4))\n# c(1, 3, 4)\nremove_duplicates <- function(numbers) {",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf('Jupiter', 'Neptune')\n# c('Saturn', 'Uranus')\n# >>> bf('Earth', 'Mercury')\n# 'Venus'\n# >>> bf('Mercury', 'Uranus')\n# c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn')\nbf <- function(planet1, planet2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- bf\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Neptune'), c('Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Mercury'), c('Venus'))))\n    stopifnot(isTRUE(all.equal(candidate('Mercury', 'Uranus'), c('Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn'))))\n    stopifnot(isTRUE(all.equal(candidate('Neptune', 'Venus'), c('Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus'))))\n    stopifnot(isTRUE(all.equal(candidate('Earth', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Mars', 'Earth'), c())))\n    stopifnot(isTRUE(all.equal(candidate('Jupiter', 'Makemake'), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort(c('aa', 'a', 'aaa'))\n# c('aa')\n# >>> list_sort(c('ab', 'a', 'aaa', 'cd'))\n# c('ab', 'cd')\nsorted_list_sum <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sorted_list_sum\n    stopifnot(isTRUE(all.equal(candidate(c('aa', 'a', 'aaa')), c('aa'))))\n    stopifnot(isTRUE(all.equal(candidate(c('school', 'AI', 'asdf', 'b')), c('AI', 'asdf', 'school'))))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'b', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('d', 'dcba', 'abcd', 'a')), c('abcd', 'dcba'))))\n    stopifnot(isTRUE(all.equal(candidate(c('AI', 'ai', 'au')), c('AI', 'ai', 'au'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'b', 'c', 'c', 'a')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaa', 'bbbb', 'dd', 'cc')), c('cc', 'dd', 'aaaa', 'bbbb'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "r",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# c('a', 'ab', 'abc')\nall_prefixes <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_prefixes\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('asdfgh'), c('a', 'as', 'asd', 'asdf', 'asdfg', 'asdfgh'))))\n    stopifnot(isTRUE(all.equal(candidate('WWW'), c('W', 'WW', 'WWW'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "r",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y(7, 34, 12)\n# 34\n# >>> x_or_y(15, 8, 5)\n# 5\nx_or_y <- function(n, x, y) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- x_or_y\n    stopifnot(isTRUE(all.equal(candidate(7, 34, 12), 34)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 5), 5)))\n    stopifnot(isTRUE(all.equal(candidate(3, 33, 5212), 33)))\n    stopifnot(isTRUE(all.equal(candidate(1259, 3, 52), 3)))\n    stopifnot(isTRUE(all.equal(candidate(7919, -1, 12), -1)))\n    stopifnot(isTRUE(all.equal(candidate(3609, 1245, 583), 583)))\n    stopifnot(isTRUE(all.equal(candidate(91, 56, 129), 129)))\n    stopifnot(isTRUE(all.equal(candidate(6, 34, 1234), 1234)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 0), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "r",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference(c(1, 3, 2, 0))\n# 10\n# >>> double_the_difference(c(-1, -2, 0))\n# 0\n# >>> double_the_difference(c(9, -2))\n# 81\n# >>> double_the_difference(c(0))\n# 0\n# If the input list is empty, return 0.\ndouble_the_difference <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- double_the_difference\n    stopifnot(isTRUE(all.equal(candidate(c()), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5.0, 4.0)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.1, 0.2, 0.3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10.0, -20.0, -30.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1.0, -2.0, 8.0)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0.2, 3.0, 5.0)), 34)))\n    stopifnot(isTRUE(all.equal(candidate(c(-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0)), 165)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "r",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2))\n# c(0, 0, 0, 0, 3, 3)\n# >>> compare(c(0, 5, 0, 0, 0, 4), c(4, 1, 1, 0, 0, -2))\n# c(4, 4, 1, 0, 0, 6)\ncompare <- function(game, guess) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- compare\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 1), c(1, 2, 3, 4, 2, -2)), c(0, 0, 0, 0, 3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 0, 0, 0, 0), c(0, 0, 0, 0, 0, 0)), c(0, 0, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(-1, -2, -3)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5), c(-1, 2, 3, 4)), c(2, 0, 0, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "r",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension('my_class', c('AA', 'Be', 'CC'))\n# 'my_class.AA'\nStrongest_Extension <- function(class_name, extensions) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Strongest_Extension\n    stopifnot(isTRUE(all.equal(candidate('Watashi', c('tEN', 'niNE', 'eIGHt8OKe')), 'Watashi.eIGHt8OKe')))\n    stopifnot(isTRUE(all.equal(candidate('Boku123', c('nani', 'NazeDa', 'YEs.WeCaNe', '32145tggg')), 'Boku123.YEs.WeCaNe')))\n    stopifnot(isTRUE(all.equal(candidate('__YESIMHERE', c('t', 'eMptY', 'nothing', 'zeR00', 'NuLl__', '123NoooneB321')), '__YESIMHERE.NuLl__')))\n    stopifnot(isTRUE(all.equal(candidate('K', c('Ta', 'TAR', 't234An', 'cosSo')), 'K.TAR')))\n    stopifnot(isTRUE(all.equal(candidate('__HAHA', c('Tab', '123', '781345', '-_-')), '__HAHA.123')))\n    stopifnot(isTRUE(all.equal(candidate('YameRore', c('HhAas', 'okIWILL123', 'WorkOut', 'Fails', '-_-')), 'YameRore.okIWILL123')))\n    stopifnot(isTRUE(all.equal(candidate('finNNalLLly', c('Die', 'NowW', 'Wow', 'WoW')), 'finNNalLLly.WoW')))\n    stopifnot(isTRUE(all.equal(candidate('_', c('Bb', '91245')), '_.Bb')))\n    stopifnot(isTRUE(all.equal(candidate('Sp', c('671235', 'Bb')), 'Sp.671235')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "r",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check('abcd', 'abd')\n# FALSE\n# >>> cycpattern_check('hello', 'ell')\n# TRUE\n# >>> cycpattern_check('whassup', 'psus')\n# FALSE\n# >>> cycpattern_check('abab', 'baa')\n# TRUE\n# >>> cycpattern_check('efef', 'eeff')\n# FALSE\n# >>> cycpattern_check('himenss', 'simen')\n# TRUE\ncycpattern_check <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cycpattern_check\n    stopifnot(isTRUE(all.equal(candidate('xyzw', 'xyw'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('yello', 'ell'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('whattup', 'ptut'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('efef', 'fee'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abab', 'aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('winemtt', 'tinem'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "r",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count(-12)\n# c(1, 1)\n# >>> even_odd_count(123)\n# c(1, 2)\neven_odd_count <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_odd_count\n    stopifnot(isTRUE(all.equal(candidate(7), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(-78), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(3452), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(346211), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-345821), c(3, 3))))\n    stopifnot(isTRUE(all.equal(candidate(-2), c(1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(-45347), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(0), c(1, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "r",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19)\n# 'xix'\n# >>> int_to_mini_roman(152)\n# 'clii'\n# >>> int_to_mini_roman(426)\n# 'cdxxvi'\nint_to_mini_roman <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- int_to_mini_roman\n    stopifnot(isTRUE(all.equal(candidate(19), 'xix')))\n    stopifnot(isTRUE(all.equal(candidate(152), 'clii')))\n    stopifnot(isTRUE(all.equal(candidate(251), 'ccli')))\n    stopifnot(isTRUE(all.equal(candidate(426), 'cdxxvi')))\n    stopifnot(isTRUE(all.equal(candidate(500), 'd')))\n    stopifnot(isTRUE(all.equal(candidate(1), 'i')))\n    stopifnot(isTRUE(all.equal(candidate(4), 'iv')))\n    stopifnot(isTRUE(all.equal(candidate(43), 'xliii')))\n    stopifnot(isTRUE(all.equal(candidate(90), 'xc')))\n    stopifnot(isTRUE(all.equal(candidate(94), 'xciv')))\n    stopifnot(isTRUE(all.equal(candidate(532), 'dxxxii')))\n    stopifnot(isTRUE(all.equal(candidate(900), 'cm')))\n    stopifnot(isTRUE(all.equal(candidate(994), 'cmxciv')))\n    stopifnot(isTRUE(all.equal(candidate(1000), 'm')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle(3, 4, 5)\n# TRUE\n# >>> right_angle_triangle(1, 2, 3)\n# FALSE\nright_angle_triangle <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_angle_triangle\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 6, 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7, 24, 25), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 12, 13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8, 17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(48, 55, 73), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "r",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max(c('name', 'of', 'string'))\n# 'string'\n# >>> find_max(c('name', 'enam', 'game'))\n# 'enam'\n# >>> find_max(c('aaaaaaa', 'bb', 'cc'))\n# 'aaaaaaa'\nfind_max <- function(words) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_max\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'of', 'string')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('name', 'enam', 'game')), 'enam')))\n    stopifnot(isTRUE(all.equal(candidate(c('aaaaaaa', 'bb', 'cc')), 'aaaaaaa')))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'cba')), 'abc')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'this', 'game', 'of', 'footbott')), 'footbott')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'gonna', 'rock')), 'gonna')))\n    stopifnot(isTRUE(all.equal(candidate(c('we', 'are', 'a', 'mad', 'nation')), 'nation')))\n    stopifnot(isTRUE(all.equal(candidate(c('this', 'is', 'a', 'prrk')), 'this')))\n    stopifnot(isTRUE(all.equal(candidate(c('b')), 'b')))\n    stopifnot(isTRUE(all.equal(candidate(c('play', 'play', 'play')), 'play')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "r",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat(5, 6, 10)\n# c(11, 4)\n# >>> eat(4, 8, 9)\n# c(12, 1)\n# >>> eat(1, 10, 10)\n# c(11, 0)\n# >>> eat(2, 11, 5)\n# c(7, 0)\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\neat <- function(number, need, remaining) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- eat\n    stopifnot(isTRUE(all.equal(candidate(5, 6, 10), c(11, 4))))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 9), c(12, 1))))\n    stopifnot(isTRUE(all.equal(candidate(1, 10, 10), c(11, 0))))\n    stopifnot(isTRUE(all.equal(candidate(2, 11, 5), c(7, 0))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 7), c(9, 2))))\n    stopifnot(isTRUE(all.equal(candidate(4, 5, 1), c(5, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "r",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\nstring_sequence <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_sequence\n    stopifnot(isTRUE(all.equal(candidate(0), '0')))\n    stopifnot(isTRUE(all.equal(candidate(3), '0 1 2 3')))\n    stopifnot(isTRUE(all.equal(candidate(10), '0 1 2 3 4 5 6 7 8 9 10')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "r",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndo_algebra <- function(operator, operand) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- do_algebra\n    stopifnot(isTRUE(all.equal(candidate(c('**', '*', '+'), c(2, 3, 4, 5)), 37)))\n    stopifnot(isTRUE(all.equal(candidate(c('+', '*', '-'), c(2, 3, 4, 5)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c('//', '*'), c(7, 3, 4)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve('1234')\n# '4321'\n# >>> solve('ab')\n# 'AB'\n# >>> solve('#a@C')\n# '#A@c'\nsolve <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate('AsDf'), 'aSdF')))\n    stopifnot(isTRUE(all.equal(candidate('1234'), '4321')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'AB')))\n    stopifnot(isTRUE(all.equal(candidate('#a@C'), '#A@c')))\n    stopifnot(isTRUE(all.equal(candidate('#AsdfW^45'), '#aSDFw^45')))\n    stopifnot(isTRUE(all.equal(candidate('#6@2'), '2@6#')))\n    stopifnot(isTRUE(all.equal(candidate('#$a^D'), '#$A^d')))\n    stopifnot(isTRUE(all.equal(candidate('#ccc'), '#CCC')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "r",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world')\n# '3e25960a79dbc69b674cd4ec67a72c62'\nstring_to_md5 <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_md5\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), '3e25960a79dbc69b674cd4ec67a72c62')))\n    stopifnot(isTRUE(all.equal(candidate(''), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('A B C'), '0ef78513b0cb8cef12743f5aeb35f888')))\n    stopifnot(isTRUE(all.equal(candidate('password'), '5f4dcc3b5aa765d61d8327deb882cf99')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -1993,7 +914,7 @@
     "language": "r",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers(2, 8)\n# c(2, 4, 6, 8)\n# >>> generate_integers(8, 2)\n# c(2, 4, 6, 8)\n# >>> generate_integers(10, 14)\n# c()\ngenerate_integers <- function(a, b) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- generate_integers\n    stopifnot(isTRUE(all.equal(candidate(2, 10), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(132, 2), c(2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(17, 89), c())))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -2002,52 +923,286 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "r",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max(c(1, 2, 3, 2, 3, 4, 2))\n# c(1, 2, 3, 3, 3, 4, 4)\nrolling_max <- function(numbers) {",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ncount_distinct_characters <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_distinct_characters\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcdecadeCADE'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaAAAAaaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('Jerry jERRY JeRRRY'), 5)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "r",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero(c(1, 2, 3))\n# FALSE\n# >>> below_zero(c(1, 2, -4, 5))\n# TRUE\nbelow_zero <- function(operations) {",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# c(4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4)\nparse_music <- function(music_string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_music\n    stopifnot(isTRUE(all.equal(candidate(''), c())))\n    stopifnot(isTRUE(all.equal(candidate('o o o o'), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('.| .| .| .|'), c(1, 1, 1, 1))))\n    stopifnot(isTRUE(all.equal(candidate('o| o| .| .| o o o o'), c(2, 2, 1, 1, 4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate('o| .| o| .| o o| o o|'), c(2, 1, 2, 1, 4, 2, 4, 2))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "r",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search(c(4, 1, 2, 2, 3, 1))\n# 2\n# >>> search(c(1, 2, 2, 3, 3, 3, 4, 4, 4))\n# 3\n# >>> search(c(5, 5, 4, 4, 4))\n# -1\nsearch <- function(lst) {",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\nhow_many_times <- function(string, substring) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- how_many_times\n    stopifnot(isTRUE(all.equal(candidate('', 'x'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('xyxyxyx', 'x'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('cacacacac', 'cac'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('john doe', 'john'), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "r",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('(')\n# FALSE\n# >>> correct_bracketing('()')\n# TRUE\n# >>> correct_bracketing('(()())')\n# TRUE\n# >>> correct_bracketing(')(()')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\nsort_numbers <- function(numbers) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numbers\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('three'), 'three')))\n    stopifnot(isTRUE(all.equal(candidate('three five nine'), 'three five nine')))\n    stopifnot(isTRUE(all.equal(candidate('five zero four seven nine eight'), 'zero four five seven eight nine')))\n    stopifnot(isTRUE(all.equal(candidate('six five four three two one zero'), 'zero one two three four five six')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "r",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# c('()', '(())', '(()())')\nseparate_paren_groups <- function(paren_string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- separate_paren_groups\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c('(()())', '((()))', '()', '((())()())'))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c('()', '(())', '((()))', '(((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c('(()(())((())))'))))\n    stopifnot(isTRUE(all.equal(candidate('( ) (( )) (( )( ))'), c('()', '(())', '(()())'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "r",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2))\n# c(2.0, 2.2)\n# >>> find_closest_elements(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0))\n# c(2.0, 2.0)\nfind_closest_elements <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_closest_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.9, 4.0, 5.0, 2.2)), c(3.9, 4.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 5.9, 4.0, 5.0)), c(5.0, 5.9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.2)), c(2.0, 2.2))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0, 2.0)), c(2.0, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.1, 2.2, 3.1, 4.1, 5.1)), c(2.2, 3.1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "r",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit(c(1.0, 2.0, 3.0, 4.0, 5.0))\n# c(0.0, 0.25, 0.5, 0.75, 1.0)\nrescale_to_unit <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rescale_to_unit\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 49.9)), c(0.0, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(100.0, 49.9)), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), c(0.0, 0.25, 0.5, 0.75, 1.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2.0, 1.0, 5.0, 3.0, 4.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n    stopifnot(isTRUE(all.equal(candidate(c(12.0, 11.0, 15.0, 13.0, 14.0)), c(0.25, 0.0, 1.0, 0.5, 0.75))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "r",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(list('a', 3.14, 5))\n# c(5)\n# >>> filter_integers(list(1, 2, 3, 'abc', list(), c()))\n# c(1, 2, 3)\nfilter_integers <- function(values) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_integers\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(4, list(), c(), 23.2, 9, 'adasd')), c(4, 9))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 'c', 3, 3, 'a', 'b')), c(3, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "r",
+    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\nstrlen <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strlen\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('x'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('asdasnakj'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "r",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\nlargest_divisor <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_divisor\n    stopifnot(isTRUE(all.equal(candidate(3), 1)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n    stopifnot(isTRUE(all.equal(candidate(10), 5)))\n    stopifnot(isTRUE(all.equal(candidate(100), 50)))\n    stopifnot(isTRUE(all.equal(candidate(49), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "r",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# c(2, 2, 2)\n# >>> factorize(25)\n# c(5, 5)\n# >>> factorize(70)\n# c(2, 5, 7)\nfactorize <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- factorize\n    stopifnot(isTRUE(all.equal(candidate(2), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(8), c(2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(57), c(3, 19))))\n    stopifnot(isTRUE(all.equal(candidate(3249), c(3, 3, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(185193), c(3, 3, 3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(20577), c(3, 19, 19, 19))))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "r",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates(c(1, 2, 3, 2, 4))\n# c(1, 3, 4)\nremove_duplicates <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 3, 5)), c(1, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "r",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\nflip_case <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- flip_case\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hello!'), 'hELLO!')))\n    stopifnot(isTRUE(all.equal(candidate('These violent delights have violent ends'), 'tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "r",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate(c())\n# ''\n# >>> concatenate(c('a', 'b', 'c'))\n# 'abc'\nconcatenate <- function(strings) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate\n    stopifnot(isTRUE(all.equal(candidate(c()), '')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z')), 'xyz')))\n    stopifnot(isTRUE(all.equal(candidate(c('x', 'y', 'z', 'w', 'k')), 'xyzwk')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix(c(), 'a')\n# c()\n# >>> filter_by_prefix(c('abc', 'bcd', 'cde', 'array'), 'a')\n# c('abc', 'array')\nfilter_by_prefix <- function(strings, prefix) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_prefix\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "r",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ntruncate_number <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- truncate_number\n    stopifnot(isTRUE(all.equal(candidate(3.5), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(1.25), 0.25)))\n    stopifnot(isTRUE(all.equal(candidate(123.0), 0.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "r",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive(c(-1, 2, -4, 5, 6))\n# c(2, 5, 6)\n# >>> get_positive(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# c(5, 3, 2, 3, 9, 123, 1)\nget_positive <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_positive\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 4, 5, 6)), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10)), c(5, 3, 2, 3, 3, 9, 123, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2)), c())))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "r",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# FALSE\n# >>> is_prime(101)\n# TRUE\n# >>> is_prime(11)\n# TRUE\n# >>> is_prime(13441)\n# TRUE\n# >>> is_prime(61)\n# TRUE\n# >>> is_prime(4)\n# FALSE\n# >>> is_prime(1)\n# FALSE\nis_prime <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_prime\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(101), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(13441), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(61), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(85), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(77), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(255379), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "r",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_third(c(5, 6, 3, 4, 8, 9, 2))\n# c(2, 6, 3, 4, 8, 9, 5)\nsort_third <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_third\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2)), c(2, 6, 3, 4, 8, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, 3, 4, 6, 9, 2)), c(2, 8, 3, 4, 6, 9, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 9, 4, 8, 3, 2)), c(2, 6, 9, 4, 8, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 4, 8, 9, 2, 1)), c(2, 6, 3, 4, 8, 9, 5, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "r",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(0, 2, 3, 5, 9, 123)\nunique <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 5, 2, 3, 3, 9, 0, 123)), c(0, 2, 3, 5, 9, 123))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "r",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element(c(1, 2, 3))\n# 3\n# >>> max_element(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10))\n# 123\nmax_element <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "r",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\nfizz_buzz <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fizz_buzz\n    stopifnot(isTRUE(all.equal(candidate(50), 0)))\n    stopifnot(isTRUE(all.equal(candidate(78), 2)))\n    stopifnot(isTRUE(all.equal(candidate(79), 3)))\n    stopifnot(isTRUE(all.equal(candidate(100), 3)))\n    stopifnot(isTRUE(all.equal(candidate(200), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4000), 192)))\n    stopifnot(isTRUE(all.equal(candidate(10000), 639)))\n    stopifnot(isTRUE(all.equal(candidate(100000), 8026)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2058,9 +1213,217 @@
     "language": "r",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even(c(1, 2, 3))\n# c(1, 2, 3)\n# >>> sort_even(c(5, 6, 3, 4))\n# c(3, 6, 5, 4)\nsort_even <- function(l) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- sort_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10)), c(-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 8, -12, 4, 23, 2, 3, 11, 12, -10)), c(-12, 8, 3, 4, 5, 2, 12, 11, 23, -10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "r",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\nprime_fib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_fib\n    stopifnot(isTRUE(all.equal(candidate(1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 13)))\n    stopifnot(isTRUE(all.equal(candidate(5), 89)))\n    stopifnot(isTRUE(all.equal(candidate(6), 233)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1597)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28657)))\n    stopifnot(isTRUE(all.equal(candidate(9), 514229)))\n    stopifnot(isTRUE(all.equal(candidate(10), 433494437)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "r",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero(c(1, 2, 3))\n# FALSE\n# >>> below_zero(c(1, 2, -4, 5))\n# TRUE\nbelow_zero <- function(operations) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_zero\n    stopifnot(isTRUE(all.equal(candidate(c()), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -3, 1, 2, -3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -1, 2, -2, 5, -5, 4, -5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 2, -2, 5, -5, 4, -4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "r",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> triples_sum_to_zero(c(1, 3, -2, 1))\n# TRUE\n# >>> triples_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> triples_sum_to_zero(c(2, 4, -5, 3, 9, 7))\n# TRUE\n# >>> triples_sum_to_zero(c(1))\n# FALSE\ntriples_sum_to_zero <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triples_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 9, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, -100)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 3, 5, -100)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "r",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ncar_race_collision <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- car_race_collision\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 9)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(8), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10), 100)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "r",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list(c(1, 2, 3))\n# c(2, 3, 4)\n# >>> incr_list(c(5, 3, 5, 2, 3, 3, 9, 0, 123))\n# c(6, 4, 6, 3, 4, 4, 10, 1, 124)\nincr_list <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- incr_list\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(4, 3, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 5, 2, 3, 3, 9, 0, 123)), c(6, 3, 6, 3, 4, 4, 10, 1, 124))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "r",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero(c(1, 3, 5, 0))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 3, -2, 1))\n# FALSE\n# >>> pairs_sum_to_zero(c(1, 2, 3, 7))\n# FALSE\n# >>> pairs_sum_to_zero(c(2, 4, -5, 3, 5, 7))\n# TRUE\n# >>> pairs_sum_to_zero(c(1))\n# FALSE\npairs_sum_to_zero <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pairs_sum_to_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 0)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, -2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -5, 3, 5, 7)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 30)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 3, 2, 31)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 30)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, 9, -1, 4, 2, 31)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "r",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\nchange_base <- function(x, base) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_base\n    stopifnot(isTRUE(all.equal(candidate(8, 3), '22')))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), '100')))\n    stopifnot(isTRUE(all.equal(candidate(234, 2), '11101010')))\n    stopifnot(isTRUE(all.equal(candidate(16, 2), '10000')))\n    stopifnot(isTRUE(all.equal(candidate(8, 2), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(7, 2), '111')))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), '2')))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), '3')))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), '4')))\n    stopifnot(isTRUE(all.equal(candidate(5, 6), '5')))\n    stopifnot(isTRUE(all.equal(candidate(6, 7), '6')))\n    stopifnot(isTRUE(all.equal(candidate(7, 8), '7')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "r",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ntriangle_area <- function(a, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 7.5)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2), 2.0)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 40.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "r",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\nfib4 <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib4\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 28)))\n    stopifnot(isTRUE(all.equal(candidate(10), 104)))\n    stopifnot(isTRUE(all.equal(candidate(12), 386)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "r",
+    "prompt": "# Return median of elements in the list l.\n# >>> median(c(3, 1, 2, 4, 5))\n# 3\n# >>> median(c(-10, 4, 6, 1000, 10, 20))\n# 15.0\nmedian <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- median\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(-10, 4, 6, 1000, 10, 20)), 8.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5)), 5.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 1, 3, 9, 9, 2, 7)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "r",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# TRUE\n# >>> is_palindrome('aba')\n# TRUE\n# >>> is_palindrome('aaaaa')\n# TRUE\n# >>> is_palindrome('zbcd')\n# FALSE\nis_palindrome <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_palindrome\n    stopifnot(isTRUE(all.equal(candidate(''), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zbcd'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyx'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xywyz'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('xywzx'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "r",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\nmodp <- function(n, p) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- modp\n    stopifnot(isTRUE(all.equal(candidate(3, 5), 3)))\n    stopifnot(isTRUE(all.equal(candidate(1101, 101), 2)))\n    stopifnot(isTRUE(all.equal(candidate(0, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3, 11), 8)))\n    stopifnot(isTRUE(all.equal(candidate(100, 101), 1)))\n    stopifnot(isTRUE(all.equal(candidate(30, 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(31, 5), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "r",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation(c(1.0, 2.0, 3.0, 4.0))\n# 1.0\nmean_absolute_deviation <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- mean_absolute_deviation\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0)), 0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0)), 1.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 2.0, 3.0, 4.0, 5.0)), 1.2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "r",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\nremove_vowels <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_vowels\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('abcdef\\nghijklm'), 'bcdf\\nghjklm')))\n    stopifnot(isTRUE(all.equal(candidate('fedcba'), 'fdcb')))\n    stopifnot(isTRUE(all.equal(candidate('eeeee'), '')))\n    stopifnot(isTRUE(all.equal(candidate('acBAA'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('EcBOO'), 'cB')))\n    stopifnot(isTRUE(all.equal(candidate('ybcd'), 'ybcd')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "r",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold(c(1, 2, 4, 10), 100)\n# TRUE\n# >>> below_threshold(c(1, 20, 4, 10), 5)\n# FALSE\nbelow_threshold <- function(l, t) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- below_threshold\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10), 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 21), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10), 22), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 11), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 8, 4, 10), 10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "r",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\nadd <- function(x, y) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 5), 12)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2071,9 +1434,22 @@
     "language": "r",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# TRUE\n# >>> same_chars('abcd', 'dddddddabc')\n# TRUE\n# >>> same_chars('dddddddabc', 'abcd')\n# TRUE\n# >>> same_chars('eabcd', 'dddddddabc')\n# FALSE\n# >>> same_chars('abcd', 'dddddddabce')\n# FALSE\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# FALSE\nsame_chars <- function(s0, s1) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- same_chars\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddeddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dddddddabc', 'abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcd', 'dddddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd', 'dddddddabcf'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('eabcdzzzz', 'dddzzzzzzzddddabc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb', 'aaccc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "r",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\nfib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fib\n    stopifnot(isTRUE(all.equal(candidate(10), 55)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(8), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 89)))\n    stopifnot(isTRUE(all.equal(candidate(12), 144)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -2084,9 +1460,633 @@
     "language": "r",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('<')\n# FALSE\n# >>> correct_bracketing('<>')\n# TRUE\n# >>> correct_bracketing('<<><>>')\n# TRUE\n# >>> correct_bracketing('><<>')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('<>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<><>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<<><><>><>><<><><<>>>'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<><>>>>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<<<'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>><<>'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('<><><<><>><>>><>'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "r",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic(c(1, 2, 4, 20))\n# TRUE\n# >>> monotonic(c(1, 20, 4, 10))\n# FALSE\n# >>> monotonic(c(4, 1, 0, -10))\n# TRUE\nmonotonic <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 20)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 4, 10)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 0, -10)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 1, 0)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 5, 60)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 60)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 9, 9, 9)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "r",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121))\n# c(1, 5, 653)\n# >>> common(c(5, 3, 2, 8), c(3, 2))\n# c(2, 3)\ncommon <- function(l1, l2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- common\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 34, 653, 2, 5), c(5, 7, 1, 5, 9, 653, 121)), c(1, 5, 653))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 3, 2, 8), c(3, 2)), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c(3, 2, 4)), c(2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 8), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "r",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\nlargest_prime_factor <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_prime_factor\n    stopifnot(isTRUE(all.equal(candidate(15), 5)))\n    stopifnot(isTRUE(all.equal(candidate(27), 3)))\n    stopifnot(isTRUE(all.equal(candidate(63), 7)))\n    stopifnot(isTRUE(all.equal(candidate(330), 11)))\n    stopifnot(isTRUE(all.equal(candidate(13195), 29)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "r",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse(c(), 4)\n# c()\n# >>> intersperse(c(1, 2, 3), 4)\n# c(1, 4, 2, 4, 3)\nintersperse <- function(numbers, delimeter) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersperse\n    stopifnot(isTRUE(all.equal(candidate(c(), 7), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 3, 2), 8), c(5, 8, 6, 8, 3, 8, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2), 2), c(2, 2, 2, 2, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "r",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\nsum_to_n <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_to_n\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 21)))\n    stopifnot(isTRUE(all.equal(candidate(11), 66)))\n    stopifnot(isTRUE(all.equal(candidate(30), 465)))\n    stopifnot(isTRUE(all.equal(candidate(100), 5050)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "r",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing('(')\n# FALSE\n# >>> correct_bracketing('()')\n# TRUE\n# >>> correct_bracketing('(()())')\n# TRUE\n# >>> correct_bracketing(')(()')\n# FALSE\ncorrect_bracketing <- function(brackets) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- correct_bracketing\n    stopifnot(isTRUE(all.equal(candidate('()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('(()())'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('()()((()()())())(()()(()))'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('((()())))'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(((('), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(')'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())())(()'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('()()(()())()))()'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "r",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative(c(3, 1, 2, 4, 5))\n# c(1, 4, 12, 20)\n# >>> derivative(c(1, 2, 3))\n# c(2, 6)\nderivative <- function(xs) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- derivative\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 2, 4, 5)), c(1, 4, 12, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), c(2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 0, 4)), c(2, 2, 0, 16))))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "r",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\nfibfib <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fibfib\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(5), 4)))\n    stopifnot(isTRUE(all.equal(candidate(8), 24)))\n    stopifnot(isTRUE(all.equal(candidate(10), 81)))\n    stopifnot(isTRUE(all.equal(candidate(12), 274)))\n    stopifnot(isTRUE(all.equal(candidate(14), 927)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "r",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count('abcde')\n# 2\n# >>> vowels_count('ACEDY')\n# 3\nvowels_count <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- vowels_count\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Alone'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('key'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bye'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('keY'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('bYe'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ACEDY'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "r",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# '21'\n# >>> circular_shift(12, 2)\n# '12'\ncircular_shift <- function(x, shift) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- circular_shift\n    stopifnot(isTRUE(all.equal(candidate(100, 2), '001')))\n    stopifnot(isTRUE(all.equal(candidate(12, 2), '12')))\n    stopifnot(isTRUE(all.equal(candidate(97, 8), '79')))\n    stopifnot(isTRUE(all.equal(candidate(12, 1), '21')))\n    stopifnot(isTRUE(all.equal(candidate(11, 101), '11')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "r",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum('')\n# 0\n# >>> digitSum('abAB')\n# 131\n# >>> digitSum('abcCd')\n# 67\n# >>> digitSum('helloE')\n# 69\n# >>> digitSum('woArBld')\n# 131\n# >>> digitSum('aAaaaXa')\n# 153\ndigitSum <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digitSum\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('abAB'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('abcCd'), 67)))\n    stopifnot(isTRUE(all.equal(candidate('helloE'), 69)))\n    stopifnot(isTRUE(all.equal(candidate('woArBld'), 131)))\n    stopifnot(isTRUE(all.equal(candidate('aAaaaXa'), 153)))\n    stopifnot(isTRUE(all.equal(candidate(' How are yOu?'), 151)))\n    stopifnot(isTRUE(all.equal(candidate('You arE Very Smart'), 327)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "r",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution('5 apples and 6 oranges', 19)\n# 8\n# >>> fruit_distribution('0 apples and 1 oranges', 3)\n# 2\n# >>> fruit_distribution('2 apples and 3 oranges', 100)\n# 95\n# >>> fruit_distribution('100 apples and 1 oranges', 120)\n# 19\nfruit_distribution <- function(s, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- fruit_distribution\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 19), 8)))\n    stopifnot(isTRUE(all.equal(candidate('5 apples and 6 oranges', 21), 10)))\n    stopifnot(isTRUE(all.equal(candidate('0 apples and 1 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 0 oranges', 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 100), 95)))\n    stopifnot(isTRUE(all.equal(candidate('2 apples and 3 oranges', 5), 0)))\n    stopifnot(isTRUE(all.equal(candidate('1 apples and 100 oranges', 120), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "r",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck(c(4, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck(c(1, 2, 3))\n# c(2, 1)\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck(c())\n# c()\n# Example 4:\n# >>> pluck(c(5, 0, 3, 0, 4, 2))\n# c(0, 1)\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\npluck <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pluck\n    stopifnot(isTRUE(all.equal(candidate(c(4, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 0, 3, 0, 4, 2)), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 0, 5, 3)), c(0, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 8, 4, 8)), c(4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 6, 7, 1)), c(6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 7, 1)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "r",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search(c(4, 1, 2, 2, 3, 1))\n# 2\n# >>> search(c(1, 2, 2, 3, 3, 3, 4, 4, 4))\n# 3\n# >>> search(c(5, 5, 4, 4, 4))\n# -1\nsearch <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 4, 1, 4, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 3)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 8, 8, 8, 8, 8, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 3, 2, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 8, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 3, 6, 5, 6, 4)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 9, 10, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), -1)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 10, 10, 9, 2)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "r",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# c(2, 3, 1, 3)\nparse_nested_parens <- function(paren_string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- parse_nested_parens\n    stopifnot(isTRUE(all.equal(candidate('(()()) ((())) () ((())()())'), c(2, 3, 1, 3))))\n    stopifnot(isTRUE(all.equal(candidate('() (()) ((())) (((())))'), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate('(()(())((())))'), c(4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "r",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list(c(1, 2, 3, 4))\n# c(1, 4, 2, 3)\n# >>> strange_sort_list(c(5, 5, 5, 5))\n# c(5, 5, 5, 5)\n# >>> strange_sort_list(c())\n# c()\nstrange_sort_list <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- strange_sort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 4, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9)), c(5, 9, 6, 8, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 5, 2, 4, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8, 9, 1)), c(1, 9, 5, 8, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 5, 5, 5)), c(5, 5, 5, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8)), c(1, 8, 2, 7, 3, 6, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 2, 2, 2, 5, 5, -5, -5)), c(-5, 5, -5, 5, 0, 2, 2, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(111111)), c(111111))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "r",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area(3, 4, 5)\n# 6.0\n# >>> triangle_area(1, 2, 10)\n# -1\ntriangle_area <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 5), 6.0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 10), -1)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8, 5), 8.18)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 2), 1.73)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5, 7), 16.25)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 3), -1)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 0.43)))\n    stopifnot(isTRUE(all.equal(candidate(2, 2, 10), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "r",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly(c(1, 2), 5)\n# FALSE\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly(c(3, 2, 3), 1)\n# FALSE\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly(c(3, 2, 3), 9)\n# TRUE\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly(c(3), 5)\n# TRUE\n# # 3 is less than the maximum possible weight, and it's balanced.\nwill_it_fly <- function(q, w) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- will_it_fly\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), 5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3), 5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3), 1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(5), 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "r",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change(c(1, 2, 3, 5, 4, 7, 9, 6))\n# 4\n# >>> smallest_change(c(1, 2, 3, 4, 3, 2, 2))\n# 1\n# >>> smallest_change(c(1, 2, 3, 2, 1))\n# 0\nsmallest_change <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_change\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 4, 7, 9, 6)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 4, 2)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 1, 1, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "r",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match(c(), c())\n# c()\n# >>> total_match(c('hi', 'admin'), c('hI', 'Hi'))\n# c('hI', 'Hi')\n# >>> total_match(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project'))\n# c('hi', 'admin')\n# >>> total_match(c('hi', 'admin'), c('hI', 'hi', 'hi'))\n# c('hI', 'hi', 'hi')\n# >>> total_match(c('4'), c('1', '2', '3', '4', '5'))\n# c('4')\ntotal_match <- function(lst1, lst2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- total_match\n    stopifnot(isTRUE(all.equal(candidate(c(), c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi')), c('hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hi', 'hi', 'admin', 'project')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c('4'), c('1', '2', '3', '4', '5')), c('4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'Hi')), c('hI', 'Hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hi')), c('hI', 'hi', 'hi'))))\n    stopifnot(isTRUE(all.equal(candidate(c('hi', 'admin'), c('hI', 'hi', 'hii')), c('hi', 'admin'))))\n    stopifnot(isTRUE(all.equal(candidate(c(), c('this')), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('this'), c()), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "r",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime(30)\n# TRUE\n# 30 = 2 * 3 * 5\nis_multiply_prime <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_multiply_prime\n    stopifnot(isTRUE(all.equal(candidate(5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(30), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(105), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(126), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(729), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(891), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1001), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "r",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power(1, 4)\n# TRUE\n# >>> is_simple_power(2, 2)\n# TRUE\n# >>> is_simple_power(8, 2)\n# TRUE\n# >>> is_simple_power(3, 2)\n# FALSE\n# >>> is_simple_power(3, 1)\n# FALSE\n# >>> is_simple_power(5, 3)\n# FALSE\nis_simple_power <- function(x, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_simple_power\n    stopifnot(isTRUE(all.equal(candidate(16, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(143214, 16), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(9, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(16, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(24, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(128, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12, 6), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 12), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "r",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube(1)\n# TRUE\n# >>> iscube(2)\n# FALSE\n# >>> iscube(-1)\n# TRUE\n# >>> iscube(64)\n# TRUE\n# >>> iscube(0)\n# TRUE\n# >>> iscube(180)\n# FALSE\niscube <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- iscube\n    stopifnot(isTRUE(all.equal(candidate(1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(64), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(180), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1000), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(0), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1729), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "r",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key('AB')\n# 1\n# >>> hex_key('1077E')\n# 2\n# >>> hex_key('ABED1A33')\n# 4\n# >>> hex_key('123456789ABCDEF0')\n# 6\n# >>> hex_key('2020')\n# 2\nhex_key <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- hex_key\n    stopifnot(isTRUE(all.equal(candidate('AB'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('1077E'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABED1A33'), 4)))\n    stopifnot(isTRUE(all.equal(candidate('2020'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('123456789ABCDEF0'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('112233445566778899AABBCCDDEEFF00'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "r",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary(15)\n# 'db1111db'\n# >>> decimal_to_binary(32)\n# 'db100000db'\ndecimal_to_binary <- function(decimal) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(0), 'db0db')))\n    stopifnot(isTRUE(all.equal(candidate(32), 'db100000db')))\n    stopifnot(isTRUE(all.equal(candidate(103), 'db1100111db')))\n    stopifnot(isTRUE(all.equal(candidate(15), 'db1111db')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "r",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring(c(), 'a')\n# c()\n# >>> filter_by_substring(c('abc', 'bacd', 'cde', 'array'), 'a')\n# c('abc', 'bacd', 'array')\nfilter_by_substring <- function(strings, substring) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_by_substring\n    stopifnot(isTRUE(all.equal(candidate(c(), 'john'), c())))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'xxy', 'john doe', 'xxxAAA', 'xxx'), 'xxx'), c('xxx', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('xxx', 'asd', 'aaaxxy', 'john doe', 'xxxAAA', 'xxx'), 'xx'), c('xxx', 'aaaxxy', 'xxxAAA', 'xxx'))))\n    stopifnot(isTRUE(all.equal(candidate(c('grunt', 'trumpet', 'prune', 'gruesome'), 'run'), c('grunt', 'prune'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "r",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy('a')\n# FALSE\n# >>> is_happy('aa')\n# FALSE\n# >>> is_happy('abcd')\n# TRUE\n# >>> is_happy('aabb')\n# FALSE\n# >>> is_happy('adb')\n# TRUE\n# >>> is_happy('xyy')\n# FALSE\nis_happy <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_happy\n    stopifnot(isTRUE(all.equal(candidate('a'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabb'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('adb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyy'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxpoi'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('iopaxioi'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "r",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation(c(4.0, 3, 1.7, 2, 3.5))\n# c('A+', 'B', 'C-', 'C', 'A-')\nnumerical_letter_grade <- function(grades) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- numerical_letter_grade\n    stopifnot(isTRUE(all.equal(candidate(c(4.0, 3, 1.7, 2, 3.5)), c('A+', 'B', 'C-', 'C', 'A-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.2)), c('D+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.5)), c('D-'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0)), c('E'))))\n    stopifnot(isTRUE(all.equal(candidate(c(1.0, 0.3, 1.5, 2.8, 3.3)), c('D', 'D-', 'C-', 'B', 'B+'))))\n    stopifnot(isTRUE(all.equal(candidate(c(0.0, 0.7)), c('E', 'D-'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length('Hello')\n# TRUE\n# >>> prime_length('abcdcba')\n# TRUE\n# >>> prime_length('kittens')\n# TRUE\n# >>> prime_length('orange')\n# FALSE\nprime_length <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_length\n    stopifnot(isTRUE(all.equal(candidate('Hello'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('abcdcba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('kittens'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('orange'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('world'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('MadaM'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('Wow'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(''), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('HI'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('go'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('gogo'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaaaaaaaaaaaaaa'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Madam'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('M'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('0'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "r",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\nstarts_one_ends <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- starts_one_ends\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(2), 18)))\n    stopifnot(isTRUE(all.equal(candidate(3), 180)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1800)))\n    stopifnot(isTRUE(all.equal(candidate(5), 18000)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "r",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve(1000)\n# '1'\n# >>> solve(150)\n# '110'\n# >>> solve(147)\n# '1100'\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\nsolve <- function(N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- solve\n    stopifnot(isTRUE(all.equal(candidate(1000), '1')))\n    stopifnot(isTRUE(all.equal(candidate(150), '110')))\n    stopifnot(isTRUE(all.equal(candidate(147), '1100')))\n    stopifnot(isTRUE(all.equal(candidate(333), '1001')))\n    stopifnot(isTRUE(all.equal(candidate(963), '10010')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "r",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add(c(4, 2, 6, 7))\n# 2\nadd <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add\n    stopifnot(isTRUE(all.equal(candidate(c(4, 88)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 2, 122)), 122)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 0, 6, 7)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 4, 6, 8)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "r",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle('Hi')\n# 'Hi'\n# >>> anti_shuffle('hello')\n# 'ehllo'\n# >>> anti_shuffle('Hello World!!!')\n# 'Hello !!!Wdlor'\nanti_shuffle <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- anti_shuffle\n    stopifnot(isTRUE(all.equal(candidate('Hi'), 'Hi')))\n    stopifnot(isTRUE(all.equal(candidate('hello'), 'ehllo')))\n    stopifnot(isTRUE(all.equal(candidate('number'), 'bemnru')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'abcd')))\n    stopifnot(isTRUE(all.equal(candidate('Hello World!!!'), 'Hello !!!Wdlor')))\n    stopifnot(isTRUE(all.equal(candidate(''), '')))\n    stopifnot(isTRUE(all.equal(candidate('Hi. My name is Mister Robot. How are you?'), '.Hi My aemn is Meirst .Rboot How aer ?ouy')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "r",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1)\n# list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0))\n# >>> get_row(c(), 1)\n# c()\n# >>> get_row(list(c(), c(1), c(1, 2, 3)), 3)\n# list(c(2, 2))\nget_row <- function(lst, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_row\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 4), c(1, 0), c(2, 5), c(2, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6)), 2), list(c(0, 1), c(1, 1), c(2, 1), c(3, 1), c(4, 1), c(5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5, 6), c(1, 2, 3, 4, 5, 6), c(1, 1, 3, 4, 5, 6), c(1, 2, 1, 4, 5, 6), c(1, 2, 3, 1, 5, 6), c(1, 2, 3, 4, 1, 6), c(1, 2, 3, 4, 5, 1)), 1), list(c(0, 0), c(1, 0), c(2, 1), c(2, 0), c(3, 2), c(3, 0), c(4, 3), c(4, 0), c(5, 4), c(5, 0), c(6, 5), c(6, 0)))))\n    stopifnot(isTRUE(all.equal(candidate(c(), 1), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1)), 2), c())))\n    stopifnot(isTRUE(all.equal(candidate(list(c(), c(1), c(1, 2, 3)), 3), list(c(2, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "r",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array(c())\n# c()\n# >>> sort_array(c(5))\n# c(5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5))\n# c(0, 1, 2, 3, 4, 5)\n# >>> sort_array(c(2, 4, 3, 0, 1, 5, 6))\n# c(6, 5, 4, 3, 2, 1, 0)\nsort_array <- function(array) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_array\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(5)), c(5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5)), c(0, 1, 2, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 0, 1, 5, 6)), c(6, 5, 4, 3, 2, 1, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1)), c(1, 2))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 42, 87, 32, 11, 0)), c(0, 11, 15, 32, 42, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 14, 23, 11)), c(23, 21, 14, 11))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "r",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt('hi')\n# 'lm'\n# >>> encrypt('asdfghjkl')\n# 'ewhjklnop'\n# >>> encrypt('gf')\n# 'kj'\n# >>> encrypt('et')\n# 'ix'\nencrypt <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encrypt\n    stopifnot(isTRUE(all.equal(candidate('hi'), 'lm')))\n    stopifnot(isTRUE(all.equal(candidate('asdfghjkl'), 'ewhjklnop')))\n    stopifnot(isTRUE(all.equal(candidate('gf'), 'kj')))\n    stopifnot(isTRUE(all.equal(candidate('et'), 'ix')))\n    stopifnot(isTRUE(all.equal(candidate('faewfawefaewg'), 'jeiajeaijeiak')))\n    stopifnot(isTRUE(all.equal(candidate('hellomyfriend'), 'lippsqcjvmirh')))\n    stopifnot(isTRUE(all.equal(candidate('dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh'), 'hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'e')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "r",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product(c())\n# c(0, 1)\n# >>> sum_product(c(1, 2, 3, 4))\n# c(10, 24)\nsum_product <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_product\n    stopifnot(isTRUE(all.equal(candidate(c()), c(0, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), c(3, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 0)), c(100, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 5, 7)), c(15, 105))))\n    stopifnot(isTRUE(all.equal(candidate(c(10)), c(10, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest(c(1, 2, 3, 4, 5))\n# 2\n# >>> next_smallest(c(5, 1, 4, 3, 2))\n# 2\n# >>> next_smallest(c())\n# NULL\n# >>> next_smallest(c(1, 1))\n# NULL\nnext_smallest <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 4, 3, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c()), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1, 0)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(-35, 34, 12, -45)), -35)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "r",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored('Hello world')\n# 0\n# >>> is_bored('The sky is blue. The sun is shining. I love this weather')\n# 1\nis_bored <- function(S) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_bored\n    stopifnot(isTRUE(all.equal(candidate('Hello world'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('Is the sky blue?'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I love It !'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('bIt'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('I feel good today. I will be productive. will kill It'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('You and I are going for a walk'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "r",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int(5, 2, 7)\n# TRUE\n# >>> any_int(3, 2, 2)\n# FALSE\n# >>> any_int(3, -2, 1)\n# TRUE\n# >>> any_int(3.6, -2.2, 2)\n# FALSE\nany_int <- function(x, y, z) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- any_int\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.5, 2, 3), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1.5, 5, 3.5), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 6, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2.2, 2.2, 2.2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-4, 6, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 1, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4, 7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3.0, 4, 7), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "r",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\nencode <- function(message) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- encode\n    stopifnot(isTRUE(all.equal(candidate('TEST'), 'tgst')))\n    stopifnot(isTRUE(all.equal(candidate('Mudasir'), 'mWDCSKR')))\n    stopifnot(isTRUE(all.equal(candidate('YES'), 'ygs')))\n    stopifnot(isTRUE(all.equal(candidate('This is a message'), 'tHKS KS C MGSSCGG')))\n    stopifnot(isTRUE(all.equal(candidate('I DoNt KnOw WhAt tO WrItE'), 'k dQnT kNqW wHcT Tq wRkTg')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "r",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3))\n# 10\n# >>> skjkasdkd(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1))\n# 25\n# >>> skjkasdkd(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3))\n# 13\n# >>> skjkasdkd(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6))\n# 11\n# >>> skjkasdkd(c(0, 81, 12, 3, 1, 21))\n# 3\n# >>> skjkasdkd(c(0, 8, 1, 2, 1, 7))\n# 7\nskjkasdkd <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- skjkasdkd\n    stopifnot(isTRUE(all.equal(candidate(c(0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3)), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3)), 13)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 81, 12, 3, 1, 21)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 8, 1, 2, 1, 7)), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(8191, 123456, 127, 7)), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(127, 97, 8192)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "r",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case(list('a' = 'apple', 'b' = 'banana'))\n# TRUE\n# >>> check_dict_case(list('a' = 'apple', 'A' = 'banana', 'B' = 'banana'))\n# FALSE\n# >>> check_dict_case(list('a' = 'apple', 8 = 'banana', 'a' = 'apple'))\n# FALSE\n# >>> check_dict_case(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston'))\n# FALSE\n# >>> check_dict_case(list('STATE' = 'NC', 'ZIP' = '12345'))\n# TRUE\ncheck_dict_case <- function(dict) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_dict_case\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'b' = 'banana')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', 'A' = 'banana', 'B' = 'banana')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('p' = 'pineapple', '5' = 'banana', 'a' = 'apple')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Name' = 'John', 'Age' = '36', 'City' = 'Houston')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('STATE' = 'NC', 'ZIP' = '12345')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('fruit' = 'Orange', 'taste' = 'Sweet')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list()), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "r",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to(5)\n# c(2, 3)\n# >>> count_up_to(11)\n# c(2, 3, 5, 7)\n# >>> count_up_to(0)\n# c()\n# >>> count_up_to(20)\n# c(2, 3, 5, 7, 11, 13, 17, 19)\n# >>> count_up_to(1)\n# c()\n# >>> count_up_to(18)\n# c(2, 3, 5, 7, 11, 13, 17)\ncount_up_to <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_up_to\n    stopifnot(isTRUE(all.equal(candidate(5), c(2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(6), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(7), c(2, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(10), c(2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(0), c())))\n    stopifnot(isTRUE(all.equal(candidate(22), c(2, 3, 5, 7, 11, 13, 17, 19))))\n    stopifnot(isTRUE(all.equal(candidate(1), c())))\n    stopifnot(isTRUE(all.equal(candidate(18), c(2, 3, 5, 7, 11, 13, 17))))\n    stopifnot(isTRUE(all.equal(candidate(47), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43))))\n    stopifnot(isTRUE(all.equal(candidate(101), c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "r",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply(148, 412)\n# 16\n# >>> multiply(19, 28)\n# 72\n# >>> multiply(2020, 1851)\n# 0\n# >>> multiply(14, -15)\n# 20\nmultiply <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply\n    stopifnot(isTRUE(all.equal(candidate(148, 412), 16)))\n    stopifnot(isTRUE(all.equal(candidate(19, 28), 72)))\n    stopifnot(isTRUE(all.equal(candidate(2020, 1851), 0)))\n    stopifnot(isTRUE(all.equal(candidate(14, -15), 20)))\n    stopifnot(isTRUE(all.equal(candidate(76, 67), 42)))\n    stopifnot(isTRUE(all.equal(candidate(17, 27), 49)))\n    stopifnot(isTRUE(all.equal(candidate(0, 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "r",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper('aBCdEf')\n# 1\n# >>> count_upper('abcdefg')\n# 0\n# >>> count_upper('dBBE')\n# 0\ncount_upper <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_upper\n    stopifnot(isTRUE(all.equal(candidate('aBCdEf'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('abcdefg'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('dBBE'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('B'), 0)))\n    stopifnot(isTRUE(all.equal(candidate('U'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n    stopifnot(isTRUE(all.equal(candidate('EEEE'), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "r",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer('10')\n# 10\n# >>> closest_integer('15.3')\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\nclosest_integer <- function(value) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_integer\n    stopifnot(isTRUE(all.equal(candidate('10'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('14.5'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('-15.5'), -16)))\n    stopifnot(isTRUE(all.equal(candidate('15.3'), 15)))\n    stopifnot(isTRUE(all.equal(candidate('0'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "r",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max(c(1, 2, 3, 2, 3, 4, 2))\n# c(1, 2, 3, 3, 3, 4, 4)\nrolling_max <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rolling_max\n    stopifnot(isTRUE(all.equal(candidate(c()), c())))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), c(1, 2, 3, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 1)), c(4, 4, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 3, 100, 3)), c(3, 3, 3, 100, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/humaneval-rb-keep.json
+++ b/prompts/humaneval-rb-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "rb",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\ndef iscube(a)\n",
+    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\ndef has_close_elements(numbers, threshold)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rb",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\ndef encode(message)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rb",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\ndef solution(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rb",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "rb",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\ndef string_sequence(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "rb",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\ndef minSubArraySum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rb",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\ndef rounded_avg(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rb",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\ndef get_odd_collatz(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rb",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\ndef find_closest_elements(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "rb",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\ndef below_threshold(l, t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rb",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\ndef any_int(x, y, z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rb",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\ndef x_or_y(n, x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rb",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "rb",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rb",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\ndef triples_sum_to_zero(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rb",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\ndef is_happy(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rb",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\ndef file_name_check(file_name)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rb",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\ndef histogram(test)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rb",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\ndef largest_smallest_integers(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rb",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\ndef simplify(x, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rb",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "rb",
-    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\ndef reverse_delete(s, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_delete\n    candidate = method(:reverse_delete)\n    assert_equal([\"bcd\", false], candidate.call(\"abcde\", \"ae\"))\n    assert_equal([\"acdef\", false], candidate.call(\"abcdef\", \"b\"))\n    assert_equal([\"cdedc\", true], candidate.call(\"abcdedcba\", \"ab\"))\n    assert_equal([\"dik\", false], candidate.call(\"dwik\", \"w\"))\n    assert_equal([\"\", true], candidate.call(\"a\", \"a\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"v\"))\n    assert_equal([\"abba\", true], candidate.call(\"vabba\", \"v\"))\n    assert_equal([\"\", true], candidate.call(\"mamma\", \"mia\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rb",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\ndef sum_product(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\ndef skjkasdkd(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rb",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\ndef all_prefixes(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\ndef digits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "rb",
-    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\ndef strlen(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rb",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "rb",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rb",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\ndef fibfib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rb",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "rb",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\ndef monotonic(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rb",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\ndef fix_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "rb",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\ndef cycpattern_check(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rb",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ndef truncate_number(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rb",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rb",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\ndef remove_vowels(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "rb",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rb",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rb",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\ndef count_up_to(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rb",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rb",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\ndef total_match(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\ndef triangle_area(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rb",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\ndef check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rb",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndef do_algebra(operator, operand)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rb",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\ndef smallest_change(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rb",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rb",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\ndef f(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\ndef next_smallest(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rb",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\ndef minPath(grid, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rb",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\ndef compare_one(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rb",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\ndef match_parens(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rb",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\ndef is_equal_to_sum_even(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rb",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\ndef largest_prime_factor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rb",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rb",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\ndef encrypt(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rb",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\ndef how_many_times(string, substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "rb",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\ndef solve(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "rb",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\ndef sort_even(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_even\n    candidate = method(:sort_even)\n    assert_equal([1, 2, 3], candidate.call([1, 2, 3]))\n    assert_equal([-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123], candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([-12, 8, 3, 4, 5, 2, 12, 11, 23, -10], candidate.call([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "rb",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\ndef below_zero(operations)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "rb",
-    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\ndef same_chars(s0, s1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_same_chars\n    candidate = method(:same_chars)\n    assert_equal(true, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"))\n    assert_equal(true, candidate.call(\"abcd\", \"dddddddabc\"))\n    assert_equal(true, candidate.call(\"dddddddabc\", \"abcd\"))\n    assert_equal(false, candidate.call(\"eabcd\", \"dddddddabc\"))\n    assert_equal(false, candidate.call(\"abcd\", \"dddddddabcf\"))\n    assert_equal(false, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"))\n    assert_equal(false, candidate.call(\"aabb\", \"aaccc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rb",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\ndef separate_paren_groups(paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rb",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\ndef count_upper(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "rb",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "rb",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rb",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\ndef select_words(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\ndef find_max(words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rb",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rb",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\ndef sum_squares(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\ndef add(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rb",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\ndef multiply(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rb",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\ndef intersection(interval1, interval2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rb",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\ndef tri(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rb",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\ndef is_simple_power(x, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_has_close_elements\n    candidate = method(:has_close_elements)\n    assert_equal(true, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3))\n    assert_equal(false, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05))\n    assert_equal(true, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.95))\n    assert_equal(false, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.8))\n    assert_equal(true, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1))\n    assert_equal(true, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 1.0))\n    assert_equal(false, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 0.5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1264,7 +19,7 @@
     "language": "rb",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\ndef make_a_pile(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_a_pile\n    candidate = method(:make_a_pile)\n    assert_equal([3, 5, 7], candidate.call(3))\n    assert_equal([4, 6, 8, 10], candidate.call(4))\n    assert_equal([5, 7, 9, 11, 13], candidate.call(5))\n    assert_equal([6, 8, 10, 12, 14, 16], candidate.call(6))\n    assert_equal([8, 10, 12, 14, 16, 18, 20, 22], candidate.call(8))\n  end\nend\n",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "rb",
-    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\ndef add(x, y)\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\ndef filter_by_prefix(strings, prefix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\ndef decimal_to_binary(decimal)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rb",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\ndef is_palindrome(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "rb",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rb",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\ndef factorize(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rb",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rb",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\ndef get_closest_vowel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rb",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\ndef Strongest_Extension(class_name, extensions)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rb",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\ndef sort_numbers(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rb",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\ndef flip_case(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rb",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rb",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\ndef can_arrange(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rb",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\ndef is_nested(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rb",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\ndef by_length(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rb",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "rb",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\ndef sum_to_n(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rb",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "rb",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\ndef concatenate(strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rb",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\ndef sum_squares(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "rb",
-    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\ndef sort_array(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([1, 2, 4, 3, 5], candidate.call([1, 5, 2, 3, 4]))\n    assert_equal([-4, -2, -6, -5, -3], candidate.call([-2, -3, -4, -5, -6]))\n    assert_equal([0, 1, 2, 4, 3], candidate.call([1, 0, 2, 3, 4]))\n    assert_equal([], candidate.call([]))\n    assert_equal([2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77], candidate.call([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]))\n    assert_equal([32, 3, 5, 6, 12, 44], candidate.call([3, 6, 44, 12, 32, 5]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "rb",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\ndef longest(strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\ndef is_sorted(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rb",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\ndef even_odd_count(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rb",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\ndef anti_shuffle(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rb",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rb",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\ndef make_palindrome(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rb",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "rb",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\ndef change_base(x, base)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\ndef prime_length(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "rb",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\ndef numerical_letter_grade(grades)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "rb",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\ndef search(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\ndef right_angle_triangle(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rb",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\ndef fizz_buzz(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "rb",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rb",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\ndef compare(game, guess)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rb",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rb",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\ndef get_row(lst, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "rb",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "rb",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\ndef string_to_md5(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rb",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\ndef is_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rb",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\ndef bf(planet1, planet2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rb",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\ndef hex_key(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rb",
-    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "rb",
-    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\ndef specialFilter(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_specialFilter\n    candidate = method(:specialFilter)\n    assert_equal(0, candidate.call([5, -2, 1, -5]))\n    assert_equal(1, candidate.call([15, -73, 14, -15]))\n    assert_equal(2, candidate.call([33, -2, -3, 45, 21, 109]))\n    assert_equal(4, candidate.call([43, -12, 93, 125, 121, 109]))\n    assert_equal(3, candidate.call([71, -2, -33, 75, 21, 19]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(0, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rb",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\ndef modp(n, p)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rb",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\ndef pairs_sum_to_zero(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rb",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\ndef strange_sort_list(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rb",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\ndef prime_fib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rb",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\ndef check_dict_case(dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rb",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\ndef valid_date(date)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rb",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\ndef count_nums(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rb",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rb",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\ndef digitSum(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rb",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\ndef order_by_points(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rb",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "rb",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\ndef split_words(txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rb",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\ndef fib4(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rb",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\ndef string_xor(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "rb",
-    "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\ndef has_close_elements(numbers, threshold)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_has_close_elements\n    candidate = method(:has_close_elements)\n    assert_equal(true, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3))\n    assert_equal(false, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05))\n    assert_equal(true, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.95))\n    assert_equal(false, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.8))\n    assert_equal(true, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1))\n    assert_equal(true, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 1.0))\n    assert_equal(false, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 0.5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rb",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\ndef fruit_distribution(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rb",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\ndef largest_divisor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rb",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\ndef int_to_mini_roman(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "rb",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\ndef correct_bracketing(brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "rb",
-    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\ndef correct_bracketing(brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"<>\"))\n    assert_equal(true, candidate.call(\"<<><>>\"))\n    assert_equal(true, candidate.call(\"<><><<><>><>\"))\n    assert_equal(true, candidate.call(\"<><><<<><><>><>><<><><<>>>\"))\n    assert_equal(false, candidate.call(\"<<<><>>>>\"))\n    assert_equal(false, candidate.call(\"><<>\"))\n    assert_equal(false, candidate.call(\"<\"))\n    assert_equal(false, candidate.call(\"<<<<\"))\n    assert_equal(false, candidate.call(\">\"))\n    assert_equal(false, candidate.call(\"<<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>><<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>>><>\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rb",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\ndef fib(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "rb",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\ndef prod_signs(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\ndef filter_by_substring(strings, substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rb",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "rb",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2359,7 +49,7 @@
     "language": "rb",
     "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# choose_num(12, 15) = 14\n# choose_num(13, 12) = -1\ndef choose_num(x, y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rb",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\ndef rounded_avg(n, m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "rb",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "rb",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\ndef by_length(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "rb",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\ndef f(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "rb",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\ndef count_nums(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "rb",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "rb",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\ndef make_palindrome(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "rb",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "rb",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\ndef histogram(test)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "rb",
+    "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\ndef reverse_delete(s, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_delete\n    candidate = method(:reverse_delete)\n    assert_equal([\"bcd\", false], candidate.call(\"abcde\", \"ae\"))\n    assert_equal([\"acdef\", false], candidate.call(\"abcdef\", \"b\"))\n    assert_equal([\"cdedc\", true], candidate.call(\"abcdedcba\", \"ab\"))\n    assert_equal([\"dik\", false], candidate.call(\"dwik\", \"w\"))\n    assert_equal([\"\", true], candidate.call(\"a\", \"a\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"v\"))\n    assert_equal([\"abba\", true], candidate.call(\"vabba\", \"v\"))\n    assert_equal([\"\", true], candidate.call(\"mamma\", \"mia\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "rb",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count(['1234567'])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count(['3',\"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n# \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rb",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\ndef minSubArraySum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rb",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "rb",
+    "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\ndef sort_array(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([1, 2, 4, 3, 5], candidate.call([1, 5, 2, 3, 4]))\n    assert_equal([-4, -2, -6, -5, -3], candidate.call([-2, -3, -4, -5, -6]))\n    assert_equal([0, 1, 2, 4, 3], candidate.call([1, 0, 2, 3, 4]))\n    assert_equal([], candidate.call([]))\n    assert_equal([2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77], candidate.call([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]))\n    assert_equal([32, 3, 5, 6, 12, 44], candidate.call([3, 6, 44, 12, 32, 5]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "rb",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\ndef select_words(s, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "rb",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\ndef get_closest_vowel(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "rb",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\ndef match_parens(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "rb",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\ndef string_xor(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "rb",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "rb",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\ndef solution(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "rb",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\ndef get_odd_collatz(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "rb",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\ndef valid_date(date)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "rb",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\ndef split_words(txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "rb",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\ndef is_sorted(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rb",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\ndef intersection(interval1, interval2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rb",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\ndef prod_signs(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rb",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\ndef minPath(grid, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rb",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\ndef longest(strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rb",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\ndef tri(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\ndef digits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rb",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\ndef is_nested(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rb",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\ndef sum_squares(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rb",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\ndef check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rb",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\ndef can_arrange(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rb",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\ndef largest_smallest_integers(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rb",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\ndef compare_one(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rb",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\ndef is_equal_to_sum_even(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rb",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rb",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rb",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\ndef fix_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rb",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\ndef file_name_check(file_name)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rb",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\ndef sum_squares(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rb",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rb",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\ndef simplify(x, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rb",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\ndef order_by_points(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "rb",
+    "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\ndef specialFilter(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_specialFilter\n    candidate = method(:specialFilter)\n    assert_equal(0, candidate.call([5, -2, 1, -5]))\n    assert_equal(1, candidate.call([15, -73, 14, -15]))\n    assert_equal(2, candidate.call([33, -2, -3, 45, 21, 109]))\n    assert_equal(4, candidate.call([43, -12, 93, 125, 121, 109]))\n    assert_equal(3, candidate.call([71, -2, -33, 75, 21, 19]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(0, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "rb",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "rb",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\ndef bf(planet1, planet2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rb",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\ndef all_prefixes(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rb",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\ndef x_or_y(n, x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rb",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rb",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\ndef compare(game, guess)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rb",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\ndef Strongest_Extension(class_name, extensions)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rb",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\ndef cycpattern_check(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rb",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\ndef even_odd_count(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rb",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\ndef int_to_mini_roman(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\ndef right_angle_triangle(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\ndef find_max(words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rb",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rb",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\ndef string_sequence(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rb",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndef do_algebra(operator, operand)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\ndef solve(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rb",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\ndef string_to_md5(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2389,7 +1054,7 @@
     "language": "rb",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# generate_integers(2, 8) => [2, 4, 6, 8]\n# generate_integers(8, 2) => [2, 4, 6, 8]\n# generate_integers(10, 14) => []\ndef generate_integers(a, b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_generate_integers\n    candidate = method(:generate_integers)\n    assert_equal([2, 4, 6, 8], candidate.call(2, 10))\n    assert_equal([2, 4, 6, 8], candidate.call(10, 2))\n    assert_equal([2, 4, 6, 8], candidate.call(132, 2))\n    assert_equal([], candidate.call(17, 89))\n  end\nend\n",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "rb",
     "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\ndef count_distinct_characters(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "rb",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "rb",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\ndef how_many_times(string, substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "rb",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\ndef sort_numbers(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rb",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\ndef separate_paren_groups(paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rb",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\ndef find_closest_elements(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rb",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rb",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rb",
+    "prompt": "# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\ndef strlen(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rb",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\ndef largest_divisor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rb",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\ndef factorize(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rb",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rb",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\ndef flip_case(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rb",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\ndef concatenate(strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix([], 'a')\n# []\n# >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n# ['abc', 'array']\ndef filter_by_prefix(strings, prefix)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rb",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\ndef truncate_number(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rb",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rb",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\ndef is_prime(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rb",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rb",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rb",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rb",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\ndef fizz_buzz(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "rb",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\ndef sort_even(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_even\n    candidate = method(:sort_even)\n    assert_equal([1, 2, 3], candidate.call([1, 2, 3]))\n    assert_equal([-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123], candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([-12, 8, 3, 4, 5, 2, 12, 11, 23, -10], candidate.call([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rb",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\ndef prime_fib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rb",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\ndef below_zero(operations)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rb",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\ndef triples_sum_to_zero(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rb",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rb",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rb",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\ndef pairs_sum_to_zero(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rb",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\ndef change_base(x, base)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rb",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rb",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\ndef fib4(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rb",
+    "prompt": "# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rb",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\ndef is_palindrome(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rb",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\ndef modp(n, p)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rb",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rb",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\ndef remove_vowels(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rb",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\ndef below_threshold(l, t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rb",
+    "prompt": "# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\ndef add(x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "rb",
+    "prompt": "# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\ndef same_chars(s0, s1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_same_chars\n    candidate = method(:same_chars)\n    assert_equal(true, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"))\n    assert_equal(true, candidate.call(\"abcd\", \"dddddddabc\"))\n    assert_equal(true, candidate.call(\"dddddddabc\", \"abcd\"))\n    assert_equal(false, candidate.call(\"eabcd\", \"dddddddabc\"))\n    assert_equal(false, candidate.call(\"abcd\", \"dddddddabcf\"))\n    assert_equal(false, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"))\n    assert_equal(false, candidate.call(\"aabb\", \"aaccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rb",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\ndef fib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "rb",
+    "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\ndef correct_bracketing(brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"<>\"))\n    assert_equal(true, candidate.call(\"<<><>>\"))\n    assert_equal(true, candidate.call(\"<><><<><>><>\"))\n    assert_equal(true, candidate.call(\"<><><<<><><>><>><<><><<>>>\"))\n    assert_equal(false, candidate.call(\"<<<><>>>>\"))\n    assert_equal(false, candidate.call(\"><<>\"))\n    assert_equal(false, candidate.call(\"<\"))\n    assert_equal(false, candidate.call(\"<<<<\"))\n    assert_equal(false, candidate.call(\">\"))\n    assert_equal(false, candidate.call(\"<<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>><<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>>><>\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rb",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\ndef monotonic(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rb",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rb",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\ndef largest_prime_factor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rb",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rb",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\ndef sum_to_n(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rb",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\ndef correct_bracketing(brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rb",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rb",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\ndef fibfib(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rb",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rb",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rb",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\ndef digitSum(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rb",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\ndef fruit_distribution(s, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rb",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rb",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\ndef search(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rb",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rb",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\ndef strange_sort_list(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\ndef triangle_area(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rb",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rb",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\ndef smallest_change(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rb",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\ndef total_match(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rb",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rb",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\ndef is_simple_power(x, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rb",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\ndef iscube(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rb",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\ndef hex_key(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\ndef decimal_to_binary(decimal)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring([], 'a')\n# []\n# >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n# ['abc', 'bacd', 'array']\ndef filter_by_substring(strings, substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\ndef is_happy(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rb",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\ndef numerical_letter_grade(grades)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\ndef prime_length(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rb",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rb",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\ndef add(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\ndef anti_shuffle(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rb",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\ndef get_row(lst, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rb",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rb",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\ndef encrypt(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rb",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\ndef sum_product(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\ndef next_smallest(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rb",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rb",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\ndef any_int(x, y, z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rb",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\ndef encode(message)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\ndef skjkasdkd(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rb",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\ndef check_dict_case(dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rb",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\ndef count_up_to(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rb",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\ndef multiply(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rb",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\ndef count_upper(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rb",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rb",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/humaneval-rb-remove.json
+++ b/prompts/humaneval-rb-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rb",
-    "prompt": "# Return length of given string\ndef strlen(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rb",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\ndef encrypt(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rb",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\ndef check_dict_case(dict)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\ndef add(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rb",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\ndef fix_spaces(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rb",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\ndef fibfib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rb",
-    "prompt": "# Filter given list of any python values only for integers\ndef filter_integers(values)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rb",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\ndef parse_music(music_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\ndef decimal_to_binary(decimal)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rb",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\ndef all_prefixes(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rb",
-    "prompt": "# Add two numbers x and y\ndef add(x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rb",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rb",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rb",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\ndef flip_case(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rb",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\ndef by_length(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rb",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\ndef factorize(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rb",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\ndef count_up_to(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rb",
-    "prompt": "# Return sorted unique elements in a list\ndef unique(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rb",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\ndef total_match(lst1, lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rb",
-    "prompt": "# Return maximum element in the list.\ndef max_element(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rb",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\ndef is_nested(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rb",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\ndef rounded_avg(n, m)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rb",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\ndef odd_count(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rb",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rb",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\ndef is_equal_to_sum_even(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rb",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\ndef derivative(xs)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\ndef is_sorted(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\ndef solve(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rb",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\ndef tri(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rb",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\ndef fizz_buzz(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\ndef filter_by_prefix(strings, prefix)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rb",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rb",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\ndef minPath(grid, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rb",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\ndef count_upper(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rb",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\ndef largest_divisor(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rb",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\ndef sort_array(array)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rb",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\ndef f(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rb",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\ndef iscube(a)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rb",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\ndef encode(message)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rb",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\ndef is_bored(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rb",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\ndef pairs_sum_to_zero(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\ndef triangle_area(a, b, c)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rb",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\ndef bf(planet1, planet2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\ndef digits(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rb",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\ndef words_string(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rb",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\ndef how_many_times(string, substring)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rb",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\ndef compare_one(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rb",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\ndef remove_vowels(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rb",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\ndef strange_sort_list(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rb",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\ndef find_closest_elements(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rb",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\ndef is_simple_power(x, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rb",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\ndef prime_fib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rb",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\ndef order_by_points(nums)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rb",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\ndef has_close_elements(numbers, threshold)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_has_close_elements\n    candidate = method(:has_close_elements)\n    assert_equal(true, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3))\n    assert_equal(false, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05))\n    assert_equal(true, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.95))\n    assert_equal(false, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.8))\n    assert_equal(true, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1))\n    assert_equal(true, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 1.0))\n    assert_equal(false, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 0.5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rb",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\ndef make_palindrome(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rb",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\ndef string_xor(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rb",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rb",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\ndef fib4(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rb",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\ndef unique_digits(x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rb",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\ndef select_words(s, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rb",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rb",
-    "prompt": "# Return n-th Fibonacci number.\ndef fib(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rb",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\ndef Strongest_Extension(class_name, extensions)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rb",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\ndef match_parens(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\ndef next_smallest(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rb",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\ndef any_int(x, y, z)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rb",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\ndef truncate_number(number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rb",
-    "prompt": "# Return list with elements incremented by 1.\ndef incr_list(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rb",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\ndef x_or_y(n, x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rb",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\ndef modp(n, p)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rb",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\ndef even_odd_count(num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\ndef is_happy(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rb",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\ndef largest_prime_factor(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rb",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\ndef digitSum(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rb",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\ndef rescale_to_unit(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\ndef solution(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rb",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rb",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rb",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rb",
-    "prompt": "# Return median of elements in the list l.\ndef median(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\ndef prime_length(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\ndef smallest_change(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rb",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\ndef sum_squares(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rb",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\ndef file_name_check(file_name)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rb",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\ndef triples_sum_to_zero(l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rb",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\ndef intersection(interval1, interval2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rb",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\ndef separate_paren_groups(paren_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rb",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\ndef compare(game, guess)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rb",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\ndef check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rb",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\ndef valid_date(date)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rb",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\ndef count_nums(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\ndef anti_shuffle(s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rb",
-    "prompt": "# Checks if given string is a palindrome\ndef is_palindrome(text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rb",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\ndef get_closest_vowel(word)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rb",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\ndef is_prime(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rb",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\ndef simplify(x, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rb",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\ndef hex_key(num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rb",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rb",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\ndef histogram(test)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rb",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\ndef get_row(lst, x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\ndef get_odd_collatz(n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rb",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\ndef can_arrange(arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rb",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\ndef sort_numbers(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rb",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\ndef circular_shift(x, shift)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rb",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\ndef sum_squares(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\ndef skjkasdkd(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rb",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\ndef sum_product(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rb",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\ndef choose_num(x, y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rb",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\ndef largest_smallest_integers(lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rb",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\ndef count_distinct_characters(string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1714,7 +19,7 @@
     "language": "rb",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\ndef make_a_pile(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_a_pile\n    candidate = method(:make_a_pile)\n    assert_equal([3, 5, 7], candidate.call(3))\n    assert_equal([4, 6, 8, 10], candidate.call(4))\n    assert_equal([5, 7, 9, 11, 13], candidate.call(5))\n    assert_equal([6, 8, 10, 12, 14, 16], candidate.call(6))\n    assert_equal([8, 10, 12, 14, 16, 18, 20, 22], candidate.call(8))\n  end\nend\n",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rb",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\ndef prod_signs(arr)\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\ndef words_string(s)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rb",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\ndef minSubArraySum(nums)\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\ndef choose_num(x, y)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rb",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\ndef string_sequence(n)\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\ndef rounded_avg(n, m)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rb",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\ndef cycpattern_check(a, b)\n",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\ndef unique_digits(x)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rb",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\ndef monotonic(l)\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\ndef by_length(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rb",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\ndef longest(strings)\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\ndef f(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rb",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\ndef below_threshold(l, t)\n",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rb",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\ndef count_nums(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rb",
-    "prompt": "# Return only positive numbers in the list.\ndef get_positive(l)\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rb",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\ndef sort_third(l)\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\ndef make_palindrome(string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rb",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\ndef parse_nested_parens(paren_string)\n",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rb",
-    "prompt": "# Given length of a side and high return area for a triangle.\ndef triangle_area(a, h)\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\ndef histogram(test)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rb",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\ndef multiply(a, b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rb",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\ndef mean_absolute_deviation(numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rb",
-    "prompt": "# Return sorted unique common elements for two lists.\ndef common(l1, l2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rb",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\ndef int_to_mini_roman(number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rb",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\ndef fruit_distribution(s, n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1984,7 +214,7 @@
     "language": "rb",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\ndef reverse_delete(s, c)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_delete\n    candidate = method(:reverse_delete)\n    assert_equal([\"bcd\", false], candidate.call(\"abcde\", \"ae\"))\n    assert_equal([\"acdef\", false], candidate.call(\"abcdef\", \"b\"))\n    assert_equal([\"cdedc\", true], candidate.call(\"abcdedcba\", \"ab\"))\n    assert_equal([\"dik\", false], candidate.call(\"dwik\", \"w\"))\n    assert_equal([\"\", true], candidate.call(\"a\", \"a\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"v\"))\n    assert_equal([\"abba\", true], candidate.call(\"vabba\", \"v\"))\n    assert_equal([\"\", true], candidate.call(\"mamma\", \"mia\"))\n  end\nend\n",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rb",
-    "prompt": "# Return a greatest common divisor of two integers a and b\ndef greatest_common_divisor(a, b)\n",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\ndef odd_count(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rb",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\ndef split_words(txt)\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\ndef minSubArraySum(nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rb",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2029,7 +274,7 @@
     "language": "rb",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\ndef sort_array(arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([1, 2, 4, 3, 5], candidate.call([1, 5, 2, 3, 4]))\n    assert_equal([-4, -2, -6, -5, -3], candidate.call([-2, -3, -4, -5, -6]))\n    assert_equal([0, 1, 2, 4, 3], candidate.call([1, 0, 2, 3, 4]))\n    assert_equal([], candidate.call([]))\n    assert_equal([2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77], candidate.call([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]))\n    assert_equal([32, 3, 5, 6, 12, 44], candidate.call([3, 6, 44, 12, 32, 5]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n  end\nend\n",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rb",
-    "prompt": "# Concatenate list of strings into a single string\ndef concatenate(strings)\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\ndef select_words(s, n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\ndef sorted_list_sum(lst)\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\ndef get_closest_vowel(word)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\ndef filter_by_substring(strings, substring)\n",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\ndef match_parens(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rb",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\ndef string_xor(a, b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rb",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\ndef vowels_count(s)\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\ndef find_max(words)\n",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\ndef solution(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rb",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\ndef string_to_md5(text)\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rb",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\ndef change_base(x, base)\n",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\ndef get_odd_collatz(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\ndef right_angle_triangle(a, b, c)\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\ndef valid_date(date)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rb",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\ndef numerical_letter_grade(grades)\n",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\ndef split_words(txt)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rb",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\ndef intersperse(numbers, delimeter)\n",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\ndef is_sorted(lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rb",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\ndef intersection(interval1, interval2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rb",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\ndef prod_signs(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rb",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\ndef minPath(grid, k)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rb",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\ndef longest(strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rb",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\ndef tri(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\ndef digits(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rb",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\ndef is_nested(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rb",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\ndef sum_squares(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rb",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\ndef check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rb",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\ndef can_arrange(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rb",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\ndef largest_smallest_integers(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rb",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\ndef compare_one(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rb",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\ndef is_equal_to_sum_even(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rb",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rb",
+    "prompt": "# Return a greatest common divisor of two integers a and b\ndef greatest_common_divisor(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rb",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\ndef fix_spaces(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rb",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\ndef file_name_check(file_name)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rb",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\ndef sum_squares(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rb",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rb",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\ndef simplify(x, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rb",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\ndef order_by_points(nums)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2209,7 +769,7 @@
     "language": "rb",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\ndef specialFilter(nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_specialFilter\n    candidate = method(:specialFilter)\n    assert_equal(0, candidate.call([5, -2, 1, -5]))\n    assert_equal(1, candidate.call([15, -73, 14, -15]))\n    assert_equal(2, candidate.call([33, -2, -3, 45, 21, 109]))\n    assert_equal(4, candidate.call([43, -12, 93, 125, 121, 109]))\n    assert_equal(3, candidate.call([71, -2, -33, 75, 21, 19]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(0, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rb",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\ndef sum_to_n(n)\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rb",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\ndef remove_duplicates(numbers)\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\ndef bf(planet1, planet2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\ndef sorted_list_sum(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rb",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\ndef all_prefixes(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rb",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\ndef x_or_y(n, x, y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rb",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rb",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\ndef compare(game, guess)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rb",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\ndef Strongest_Extension(class_name, extensions)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rb",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\ndef cycpattern_check(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rb",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\ndef even_odd_count(num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rb",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\ndef int_to_mini_roman(number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\ndef right_angle_triangle(a, b, c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\ndef find_max(words)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rb",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rb",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\ndef string_sequence(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\ndef solve(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rb",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\ndef string_to_md5(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2254,7 +1039,7 @@
     "language": "rb",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\ndef generate_integers(a, b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_generate_integers\n    candidate = method(:generate_integers)\n    assert_equal([2, 4, 6, 8], candidate.call(2, 10))\n    assert_equal([2, 4, 6, 8], candidate.call(10, 2))\n    assert_equal([2, 4, 6, 8], candidate.call(132, 2))\n    assert_equal([], candidate.call(17, 89))\n  end\nend\n",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rb",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\ndef rolling_max(numbers)\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\ndef count_distinct_characters(string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rb",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\ndef below_zero(operations)\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\ndef parse_music(music_string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rb",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\ndef search(lst)\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\ndef how_many_times(string, substring)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rb",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\ndef correct_bracketing(brackets)\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\ndef sort_numbers(numbers)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rb",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\ndef separate_paren_groups(paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rb",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\ndef find_closest_elements(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rb",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\ndef rescale_to_unit(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rb",
+    "prompt": "# Filter given list of any python values only for integers\ndef filter_integers(values)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rb",
+    "prompt": "# Return length of given string\ndef strlen(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rb",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\ndef largest_divisor(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rb",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\ndef factorize(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rb",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\ndef remove_duplicates(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rb",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\ndef flip_case(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rb",
+    "prompt": "# Concatenate list of strings into a single string\ndef concatenate(strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\ndef filter_by_prefix(strings, prefix)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rb",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\ndef truncate_number(number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rb",
+    "prompt": "# Return only positive numbers in the list.\ndef get_positive(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rb",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\ndef is_prime(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rb",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\ndef sort_third(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rb",
+    "prompt": "# Return sorted unique elements in a list\ndef unique(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rb",
+    "prompt": "# Return maximum element in the list.\ndef max_element(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rb",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\ndef fizz_buzz(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2329,9 +1384,234 @@
     "language": "rb",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\ndef sort_even(l)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_even\n    candidate = method(:sort_even)\n    assert_equal([1, 2, 3], candidate.call([1, 2, 3]))\n    assert_equal([-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123], candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([-12, 8, 3, 4, 5, 2, 12, 11, 23, -10], candidate.call([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rb",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\ndef prime_fib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rb",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\ndef below_zero(operations)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rb",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\ndef triples_sum_to_zero(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rb",
+    "prompt": "# Return list with elements incremented by 1.\ndef incr_list(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rb",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\ndef pairs_sum_to_zero(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rb",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\ndef change_base(x, base)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rb",
+    "prompt": "# Given length of a side and high return area for a triangle.\ndef triangle_area(a, h)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rb",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\ndef fib4(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rb",
+    "prompt": "# Return median of elements in the list l.\ndef median(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rb",
+    "prompt": "# Checks if given string is a palindrome\ndef is_palindrome(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rb",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\ndef modp(n, p)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rb",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\ndef mean_absolute_deviation(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rb",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\ndef remove_vowels(text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rb",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\ndef below_threshold(l, t)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rb",
+    "prompt": "# Add two numbers x and y\ndef add(x, y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2344,9 +1624,24 @@
     "language": "rb",
     "prompt": "# Check if two words have the same characters.\ndef same_chars(s0, s1)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_same_chars\n    candidate = method(:same_chars)\n    assert_equal(true, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"))\n    assert_equal(true, candidate.call(\"abcd\", \"dddddddabc\"))\n    assert_equal(true, candidate.call(\"dddddddabc\", \"abcd\"))\n    assert_equal(false, candidate.call(\"eabcd\", \"dddddddabc\"))\n    assert_equal(false, candidate.call(\"abcd\", \"dddddddabcf\"))\n    assert_equal(false, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"))\n    assert_equal(false, candidate.call(\"aabb\", \"aaccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rb",
+    "prompt": "# Return n-th Fibonacci number.\ndef fib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2359,9 +1654,714 @@
     "language": "rb",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\ndef correct_bracketing(brackets)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"<>\"))\n    assert_equal(true, candidate.call(\"<<><>>\"))\n    assert_equal(true, candidate.call(\"<><><<><>><>\"))\n    assert_equal(true, candidate.call(\"<><><<<><><>><>><<><><<>>>\"))\n    assert_equal(false, candidate.call(\"<<<><>>>>\"))\n    assert_equal(false, candidate.call(\"><<>\"))\n    assert_equal(false, candidate.call(\"<\"))\n    assert_equal(false, candidate.call(\"<<<<\"))\n    assert_equal(false, candidate.call(\">\"))\n    assert_equal(false, candidate.call(\"<<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>><<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>>><>\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rb",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\ndef monotonic(l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rb",
+    "prompt": "# Return sorted unique common elements for two lists.\ndef common(l1, l2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rb",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\ndef largest_prime_factor(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rb",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\ndef intersperse(numbers, delimeter)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rb",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\ndef sum_to_n(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rb",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\ndef correct_bracketing(brackets)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rb",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\ndef derivative(xs)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rb",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\ndef fibfib(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rb",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\ndef vowels_count(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rb",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\ndef circular_shift(x, shift)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rb",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\ndef digitSum(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rb",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\ndef fruit_distribution(s, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rb",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rb",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\ndef search(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rb",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\ndef parse_nested_parens(paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rb",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\ndef strange_sort_list(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\ndef triangle_area(a, b, c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rb",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rb",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\ndef smallest_change(arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rb",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\ndef total_match(lst1, lst2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rb",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rb",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\ndef is_simple_power(x, n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rb",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\ndef iscube(a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rb",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\ndef hex_key(num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\ndef decimal_to_binary(decimal)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\ndef filter_by_substring(strings, substring)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\ndef is_happy(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rb",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\ndef numerical_letter_grade(grades)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\ndef prime_length(string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rb",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rb",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\ndef add(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\ndef anti_shuffle(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rb",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\ndef get_row(lst, x)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rb",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\ndef sort_array(array)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rb",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\ndef encrypt(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rb",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\ndef sum_product(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\ndef next_smallest(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rb",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\ndef is_bored(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rb",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\ndef any_int(x, y, z)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rb",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\ndef encode(message)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\ndef skjkasdkd(lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rb",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\ndef check_dict_case(dict)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rb",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\ndef count_up_to(n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rb",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\ndef multiply(a, b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rb",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\ndef count_upper(s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rb",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rb",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\ndef rolling_max(numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/humaneval-rb-reworded.json
+++ b/prompts/humaneval-rb-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rb",
-    "prompt": "# Return length of given string\n# >>> strlen.call(\"\")\n# 0\n# >>> strlen.call(\"abc\")\n# 3\ndef strlen(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rb",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt.call(\"hi\")\n# \"lm\"\n# >>> encrypt.call(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt.call(\"gf\")\n# \"kj\"\n# >>> encrypt.call(\"et\")\n# \"ix\"\ndef encrypt(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rb",
-    "prompt": "# Given a hash, return true if all keys are strings in lower \n# case or all keys are strings in upper case, else return false.\n# The function should return false is the given hash is empty.\n# Examples:\n# >>> check_dict_case.call({\"a\" => \"apple\", \"b\" => \"banana\"})\n# true\n# >>> check_dict_case.call({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# false\n# >>> check_dict_case.call({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# false\n# >>> check_dict_case.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# false\n# >>> check_dict_case.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# true\ndef check_dict_case(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add.call([4, 2, 6, 7])\n# 2\ndef add(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rb",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces.call(\" Example\")\n# \"Example\"\n# >>> fix_spaces.call(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces.call(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces.call(\" Example 3\")\n# \"_Example-3\"\ndef fix_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rb",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib.call(1)\n# 0\n# >>> fibfib.call(5)\n# 4\n# >>> fibfib.call(8)\n# 24\ndef fibfib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rb",
-    "prompt": "# Given an array of numbers, return the sum of squares of the numbers\n# in the array that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference.call([1, 3, 2, 0])\n# 10\n# >>> double_the_difference.call([-1, -2, 0])\n# 0\n# >>> double_the_difference.call([9, -2])\n# 81\n# >>> double_the_difference.call([0])\n# 0\n# If the input array is empty, return 0.\ndef double_the_difference(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rb",
-    "prompt": "# Filter given array of any rbthon values only for integers\n# >>> filter_integers.call([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers.call([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rb",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rb",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return array of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music.call(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary.call(15)\n# \"db1111db\"\n# >>> decimal_to_binary.call(32)\n# \"db100000db\"\ndef decimal_to_binary(decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rb",
-    "prompt": "# Return array of all prefixes from shortest to longest of the input string\n# >>> all_prefixes.call(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\ndef all_prefixes(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rb",
-    "prompt": "# Add two numbers x and y\n# >>> add.call(2, 3)\n# 5\n# >>> add.call(5, 7)\n# 12\ndef add(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rb",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat.call(5, 6, 10)\n# [11, 4]\n# >>> eat.call(4, 8, 9)\n# [12, 1]\n# >>> eat.call(1, 10, 10)\n# [11, 0]\n# >>> eat.call(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rb",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill.call([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rb",
-    "prompt": "# Given two arrays operator, and operand. The first array has basic algebra operations, and \n# the second array is an array of integers. Use the two given arrays to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator array is equal to the length of operand array minus one.\n# Operand is an array of of non-negative integers.\n# Operator array has at least one operator, and operand array has at least two operands.\ndef do_algebra(operator, operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rb",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case.call(\"Hello\")\n# \"hELLO\"\ndef flip_case(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rb",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length.call([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length.call([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length.call([1, -1, 55])\n# [\"One\"]\ndef by_length(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rb",
-    "prompt": "# Return array of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize.call(8)\n# [2, 2, 2]\n# >>> factorize.call(25)\n# [5, 5]\n# >>> factorize.call(70)\n# [2, 5, 7]\ndef factorize(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rb",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to.call(5)\n# [2, 3]\n# >>> count_up_to.call(11)\n# [2, 3, 5, 7]\n# >>> count_up_to.call(0)\n# []\n# >>> count_up_to.call(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to.call(1)\n# []\n# >>> count_up_to.call(18)\n# [2, 3, 5, 7, 11, 13, 17]\ndef count_up_to(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rb",
-    "prompt": "# Return sorted unique elements in an array\n# >>> unique.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rb",
-    "prompt": "# Write a function that accepts two arrays of strings and returns the array that has \n# total number of chars in the all strings of the array less than the other array.\n# if the two arrays have the same number of chars, return the first array.\n# Examples\n# >>> total_match.call([], [])\n# []\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\ndef total_match(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rb",
-    "prompt": "# Return maximum element in the array.\n# >>> max_element.call([1, 2, 3])\n# 3\n# >>> max_element.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rb",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return true if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested.call(\"[[]]\")\n# true\n# >>> is_nested.call(\"[]]]]]]][[[[[]\")\n# false\n# >>> is_nested.call(\"[][]\")\n# false\n# >>> is_nested.call(\"[]\")\n# false\n# >>> is_nested.call(\"[[][]]\")\n# true\n# >>> is_nested.call(\"[[]][[\")\n# true\ndef is_nested(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rb",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg.call(1, 5)\n# \"0b11\"\n# >>> rounded_avg.call(7, 5)\n# -1\n# >>> rounded_avg.call(10, 20)\n# \"0b1111\"\n# >>> rounded_avg.call(20, 33)\n# \"0b11010\"\ndef rounded_avg(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rb",
-    "prompt": "# Given an array of strings, where each string consists of only digits, return an array.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count.call([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count.call([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rb",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return true else return false.\n# If the given array is empty then return true.\n# Note: The given array is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball.call([3, 4, 5, 1, 2])\n# true\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball.call([3, 5, 4, 1, 2])\n# false\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return an array that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome.call(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome.call(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned array has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rb",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even.call(4)\n# false\n# >>> is_equal_to_sum_even.call(6)\n# false\n# >>> is_equal_to_sum_even.call(8)\n# true\ndef is_equal_to_sum_even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rb",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative.call([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative.call([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rb",
-    "prompt": "# Given an array of numbers, return whether or not they are sorted\n# in ascending order. If array has more than 1 duplicate of the same\n# number, return false. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted.call([5])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5])\n# false\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6, 7])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5, 6, 7])\n# false\n# >>> is_sorted.call([1, 2, 2, 3, 3, 4])\n# true\n# >>> is_sorted.call([1, 2, 2, 2, 3, 4])\n# false\ndef is_sorted(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve.call(\"1234\")\n# \"4321\"\n# >>> solve.call(\"ab\")\n# \"AB\"\n# >>> solve.call(\"#a@C\")\n# \"#A@c\"\ndef solve(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rb",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return an array of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri.call(3)\n# [1, 3, 2, 8]\ndef tri(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rb",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz.call(50)\n# 0\n# >>> fizz_buzz.call(78)\n# 2\n# >>> fizz_buzz.call(79)\n# 3\ndef fizz_buzz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rb",
-    "prompt": "# Filter an input array of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix.call([], \"a\")\n# []\n# >>> filter_by_prefix.call([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\ndef filter_by_prefix(strings, prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rb",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve.call(1000)\n# \"1\"\n# >>> solve.call(150)\n# \"110\"\n# >>> solve.call(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rb",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered arrays of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered array of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\ndef minPath(grid, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rb",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper.call(\"aBCdEf\")\n# 1\n# >>> count_upper.call(\"abcdefg\")\n# 0\n# >>> count_upper.call(\"dBBE\")\n# 0\ndef count_upper(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted array \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum.call([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum.call([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum.call([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rb",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor.call(15)\n# 5\ndef largest_divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rb",
-    "prompt": "# Given an array of non-negative integers, return a corb of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array.call([])\n# []\n# >>> sort_array.call([5])\n# [5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rb",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f.call(5)\n# [1, 2, 6, 24, 15]\ndef f(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rb",
-    "prompt": "# Write a function that takes an integer a and returns true \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube.call(1)\n# true\n# >>> iscube.call(2)\n# false\n# >>> iscube.call(-1)\n# true\n# >>> iscube.call(64)\n# true\n# >>> iscube.call(0)\n# true\n# >>> iscube.call(180)\n# false\ndef iscube(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rb",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode.call(\"test\")\n# \"TGST\"\n# >>> encode.call(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\ndef encode(message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rb",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored.call(\"Hello world\")\n# 0\n# >>> is_bored.call(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rb",
-    "prompt": "# pairs_sum_to_zero takes an array of integers as an input.\n# it returns true if there are two distinct elements in the array that\n# sum to zero, and false otherwise.\n# >>> pairs_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> pairs_sum_to_zero.call([1, 3, -2, 1])\n# false\n# >>> pairs_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> pairs_sum_to_zero.call([2, 4, -5, 3, 5, 7])\n# true\n# >>> pairs_sum_to_zero.call([1])\n# false\ndef pairs_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area.call(3, 4, 5)\n# 6.0\n# >>> triangle_area.call(1, 2, 10)\n# -1\ndef triangle_area(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rb",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return an array containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty array if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf.call(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf.call(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf.call(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\ndef bf(planet1, planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits.call(1)\n# 1\n# >>> digits.call(4)\n# 0\n# >>> digits.call(235)\n# 15\ndef digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rb",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string.call(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string.call(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rb",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times.call(\"\", \"a\")\n# 0\n# >>> how_many_times.call(\"aaa\", \"a\")\n# 3\n# >>> how_many_times.call(\"aaaa\", \"aa\")\n# 3\ndef how_many_times(string, substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rb",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return nil if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one.call(1, 2.5)\n# 2.5\n# >>> compare_one.call(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one.call(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one.call(\"1\", 1)\n# nil\ndef compare_one(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rb",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels.call(\"\")\n# \"\"\n# >>> remove_vowels.call(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels.call(\"aaaaa\")\n# \"\"\n# >>> remove_vowels.call(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels.call(\"zbcd\")\n# \"zbcd\"\ndef remove_vowels(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rb",
-    "prompt": "# Given array of integers, return array in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list.call([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list.call([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list.call([])\n# []\ndef strange_sort_list(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rb",
-    "prompt": "# From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\ndef find_closest_elements(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rb",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power.call(1, 4)\n# true\n# >>> is_simple_power.call(2, 2)\n# true\n# >>> is_simple_power.call(8, 2)\n# true\n# >>> is_simple_power.call(3, 2)\n# false\n# >>> is_simple_power.call(3, 1)\n# false\n# >>> is_simple_power.call(5, 3)\n# false\ndef is_simple_power(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rb",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib.call(1)\n# 2\n# >>> prime_fib.call(2)\n# 3\n# >>> prime_fib.call(3)\n# 5\n# >>> prime_fib.call(4)\n# 13\n# >>> prime_fib.call(5)\n# 89\ndef prime_fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rb",
-    "prompt": "# Write a function which sorts the given array of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original array.\n# For example:\n# >>> order_by_points.call([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points.call([])\n# []\ndef order_by_points(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rb",
     "prompt": "# Check if in given array of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements.call([1.0, 2.0, 3.0], 0.5)\n# false\n# >>> has_close_elements.call([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# true\ndef has_close_elements(numbers, threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_has_close_elements\n    candidate = method(:has_close_elements)\n    assert_equal(true, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3))\n    assert_equal(false, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05))\n    assert_equal(true, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.95))\n    assert_equal(false, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.8))\n    assert_equal(true, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1))\n    assert_equal(true, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 1.0))\n    assert_equal(false, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 0.5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rb",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome.call(\"\")\n# \"\"\n# >>> make_palindrome.call(\"cat\")\n# \"catac\"\n# >>> make_palindrome.call(\"cata\")\n# \"catac\"\ndef make_palindrome(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rb",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor.call(\"010\", \"110\")\n# \"100\"\ndef string_xor(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rb",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial.call(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rb",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4.call(5)\n# 4\n# >>> fib4.call(6)\n# 8\n# >>> fib4.call(7)\n# 14\ndef fib4(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rb",
-    "prompt": "# Given an array of positive integers x. return a sorted array of all \n# elements that hasn't any even digit.\n# Note: Returned array should be sorted in increasing order.\n# For example:\n# >>> unique_digits.call([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits.call([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rb",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns an array of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty array.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words.call(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words.call(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words.call(\"simple white space\", 2)\n# []\n# >>> select_words.call(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words.call(\"Uncle sam\", 3)\n# [\"Uncle\"]\ndef select_words(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rb",
-    "prompt": "# Write a function that returns true if the object q will fly, and false otherwise.\n# The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly.call([1, 2], 5)\n# false\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly.call([3, 2, 3], 1)\n# false\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly.call([3, 2, 3], 9)\n# true\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly.call([3], 5)\n# true\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rb",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib.call(10)\n# 55\n# >>> fib.call(1)\n# 1\n# >>> fib.call(8)\n# 21\ndef fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rb",
-    "prompt": "# You will be given the name of a class (a string) and an array of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the array.\n# For example, if you are given \"Slices\" as the class and an array of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension.call(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\ndef Strongest_Extension(class_name, extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rb",
-    "prompt": "# You are given an array of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens.call([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens.call([\")\", \")\"])\n# \"No\"\ndef match_parens(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rb",
-    "prompt": "# You are given an array of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the array.\n# Return nil if there is no such element.\n# >>> next_smallest.call([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest.call([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest.call([])\n# nil\n# >>> next_smallest.call([1, 1])\n# nil\ndef next_smallest(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rb",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int.call(5, 2, 7)\n# true\n# >>> any_int.call(3, 2, 2)\n# false\n# >>> any_int.call(3, -2, 1)\n# true\n# >>> any_int.call(3.6, -2.2, 2)\n# false\ndef any_int(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rb",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number.call(3.5)\n# 0.5\ndef truncate_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rb",
-    "prompt": "# Return array with elements incremented by 1.\n# >>> incr_list.call([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rb",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y.call(7, 34, 12)\n# 34\n# >>> x_or_y.call(15, 8, 5)\n# 5\ndef x_or_y(n, x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rb",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp.call(3, 5)\n# 3\n# >>> modp.call(1101, 101)\n# 2\n# >>> modp.call(0, 101)\n# 1\n# >>> modp.call(3, 11)\n# 8\n# >>> modp.call(100, 101)\n# 1\ndef modp(n, p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rb",
-    "prompt": "# Given an integer. return an array that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count.call(-12)\n# [1, 1]\n# >>> even_odd_count.call(123)\n# [1, 2]\ndef even_odd_count(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is haprb or not.\n# A string is haprb if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy.call(\"a\")\n# false\n# >>> is_happy.call(\"aa\")\n# false\n# >>> is_happy.call(\"abcd\")\n# true\n# >>> is_happy.call(\"aabb\")\n# false\n# >>> is_happy.call(\"adb\")\n# true\n# >>> is_happy.call(\"xyy\")\n# false\ndef is_happy(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rb",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor.call(13195)\n# 29\n# >>> largest_prime_factor.call(2048)\n# 2\ndef largest_prime_factor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rb",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum.call(\"\")\n# 0\n# >>> digitSum.call(\"abAB\")\n# 131\n# >>> digitSum.call(\"abcCd\")\n# 67\n# >>> digitSum.call(\"helloE\")\n# 69\n# >>> digitSum.call(\"woArBld\")\n# 131\n# >>> digitSum.call(\"aAaaaXa\")\n# 153\ndef digitSum(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rb",
-    "prompt": "# Given array of numbers (of at least two elements), apply a linear transform to that array,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit.call([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution.call([5, 8, 7, 1])\n# 12\n# >>> solution.call([3, 3, 3, 3, 3])\n# 9\n# >>> solution.call([30, 13, 24, 321])\n# 0\ndef solution(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rb",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in an array, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck.call([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck.call([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck.call([])\n# []\n# Example 4:\n# >>> pluck.call([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rb",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples.call(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rb",
-    "prompt": "# In this problem, you will implement a function that takes two arrays of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 an array of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange.call([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange.call([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input arrays will be non-empty.\ndef exchange(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rb",
-    "prompt": "# Return median of elements in the array l.\n# >>> median.call([3, 1, 2, 4, 5])\n# 3\n# >>> median.call([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns true if the string\n# length is a prime number or false otherwise\n# Examples\n# >>> prime_length.call(\"Hello\")\n# true\n# >>> prime_length.call(\"abcdcba\")\n# true\n# >>> prime_length.call(\"kittens\")\n# true\n# >>> prime_length.call(\"orange\")\n# false\ndef prime_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change.call([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change.call([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change.call([1, 2, 3, 2, 1])\n# 0\ndef smallest_change(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rb",
-    "prompt": "# You are given an array of numbers.\n# You need to return the sum of squared numbers in the given array,\n# round each element in the array to the upper int(Ceiling) first.\n# Examples:\n# >>> lst.call([1.0, 2.0, 3.0])\n# 14\n# >>> lst.call([1.0, 4.0, 9.0])\n# 98\n# >>> lst.call([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst.call([1.4, 4.2, 0.0])\n# 29\n# >>> lst.call([-2.4, 1.0, 1.0])\n# 6\ndef sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rb",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check.call(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check.call(\"1example.dll\")\n# \"No\"\ndef file_name_check(file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rb",
-    "prompt": "# triples_sum_to_zero takes an array of integers as an input.\n# it returns true if there are three distinct elements in the array that\n# sum to zero, and false otherwise.\n# >>> triples_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> triples_sum_to_zero.call([1, 3, -2, 1])\n# true\n# >>> triples_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> triples_sum_to_zero.call([2, 4, -5, 3, 9, 7])\n# true\n# >>> triples_sum_to_zero.call([1])\n# false\ndef triples_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rb",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection.call([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection.call([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection.call([-3, -1], [-5, 5])\n# \"YES\"\ndef intersection(interval1, interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rb",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the array of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups.call(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\ndef separate_paren_groups(paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rb",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare.call([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\ndef compare(game, guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rb",
-    "prompt": "# Create a function that returns true if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and false otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter.call(\"apple pie\")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e\")\n# true\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e \")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"\")\n# false\ndef check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rb",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns true if the date is valid otherwise false.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date.call(\"03-11-2000\")\n# true\n# >>> valid_date.call(\"15-01-2012\")\n# false\n# >>> valid_date.call(\"04-0-2040\")\n# false\n# >>> valid_date.call(\"06-04-2020\")\n# true\n# >>> valid_date.call(\"06/04/2020\")\n# false\ndef valid_date(date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rb",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums.call([])\n# 0\n# >>> count_nums.call([-1, 11, -11])\n# 1\n# >>> count_nums.call([1, 1, 2])\n# 3\ndef count_nums(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle.call(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle.call(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle.call(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\ndef anti_shuffle(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rb",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome.call(\"\")\n# true\n# >>> is_palindrome.call(\"aba\")\n# true\n# >>> is_palindrome.call(\"aaaaa\")\n# true\n# >>> is_palindrome.call(\"zbcd\")\n# false\ndef is_palindrome(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rb",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel.call(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel.call(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel.call(\"quick\")\n# \"\"\n# >>> get_closest_vowel.call(\"ab\")\n# \"\"\ndef get_closest_vowel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rb",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime.call(6)\n# false\n# >>> is_prime.call(101)\n# true\n# >>> is_prime.call(11)\n# true\n# >>> is_prime.call(13441)\n# true\n# >>> is_prime.call(61)\n# true\n# >>> is_prime.call(4)\n# false\n# >>> is_prime.call(1)\n# false\ndef is_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rb",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns true if x * n evaluates to a whole number and false\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify.call(\"1/5\", \"5/1\")\n# true\n# >>> simplify.call(\"1/6\", \"2/1\")\n# false\n# >>> simplify.call(\"7/10\", \"10/2\")\n# false\ndef simplify(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rb",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key.call(\"AB\")\n# 1\n# >>> hex_key.call(\"1077E\")\n# 2\n# >>> hex_key.call(\"ABED1A33\")\n# 4\n# >>> hex_key.call(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key.call(\"2020\")\n# 2\ndef hex_key(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rb",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence.call(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence.call(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rb",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a hash\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram.call(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram.call(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram.call(\"\")\n# {}\ndef histogram(test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rb",
-    "prompt": "# You are given a 2 dimensional data, as a nested arrays,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the array,\n# and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n# each array is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row.call([], 1)\n# []\n# >>> get_row.call([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\ndef get_row(lst, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned array sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz.call(5)\n# [1, 5]\ndef get_odd_collatz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rb",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange.call([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange.call([1, 2, 3])\n# -1\ndef can_arrange(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rb",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers.call(\"three one five\")\n# \"one three five\"\ndef sort_numbers(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rb",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift.call(12, 1)\n# \"21\"\n# >>> circular_shift.call(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rb",
-    "prompt": "# \"\n# This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\ndef sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rb",
-    "prompt": "# You are given an array of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd.call([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd.call([0, 8, 1, 2, 1, 7])\n# 7\ndef skjkasdkd(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rb",
-    "prompt": "# For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product.call([])\n# [0, 1]\n# >>> sum_product.call([1, 2, 3, 4])\n# [10, 24]\ndef sum_product(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rb",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num.call(12, 15)\n# 14\n# >>> choose_num.call(13, 12)\n# -1\ndef choose_num(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rb",
-    "prompt": "# Create a function that returns an array (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in an array.\n# If there is no negative or positive integers, return them as nil.\n# Examples:\n# >>> largest_smallest_integers.call([2, 4, 1, 3, 5, 7])\n# [nil, 1]\n# >>> largest_smallest_integers.call([])\n# [nil, nil]\n# >>> largest_smallest_integers.call([0])\n# [nil, nil]\ndef largest_smallest_integers(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rb",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters.call(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters.call(\"Jerry\")\n# 4\ndef count_distinct_characters(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1759,7 +19,7 @@
     "language": "rb",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in an array, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile.call(3)\n# [3, 5, 7]\ndef make_a_pile(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_a_pile\n    candidate = method(:make_a_pile)\n    assert_equal([3, 5, 7], candidate.call(3))\n    assert_equal([4, 6, 8, 10], candidate.call(4))\n    assert_equal([5, 7, 9, 11, 13], candidate.call(5))\n    assert_equal([6, 8, 10, 12, 14, 16], candidate.call(6))\n    assert_equal([8, 10, 12, 14, 16, 18, 20, 22], candidate.call(8))\n  end\nend\n",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rb",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return nil for empty arr.\n# Example:\n# >>> prod_signs.call([1, 2, 2, -4])\n# 9\n# >>> prod_signs.call([0, 1])\n# 0\n# >>> prod_signs.call([])\n# nil\ndef prod_signs(arr)\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string.call(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string.call(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rb",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum.call([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum.call([-1, -2, -3])\n# -6\ndef minSubArraySum(nums)\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num.call(12, 15)\n# 14\n# >>> choose_num.call(13, 12)\n# -1\ndef choose_num(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rb",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence.call(0)\n# \"0\"\n# >>> string_sequence.call(5)\n# \"0 1 2 3 4 5\"\ndef string_sequence(n)\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg.call(1, 5)\n# \"0b11\"\n# >>> rounded_avg.call(7, 5)\n# -1\n# >>> rounded_avg.call(10, 20)\n# \"0b1111\"\n# >>> rounded_avg.call(20, 33)\n# \"0b11010\"\ndef rounded_avg(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rb",
-    "prompt": "# You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check.call(\"abcd\", \"abd\")\n# false\n# >>> cycpattern_check.call(\"hello\", \"ell\")\n# true\n# >>> cycpattern_check.call(\"whassup\", \"psus\")\n# false\n# >>> cycpattern_check.call(\"abab\", \"baa\")\n# true\n# >>> cycpattern_check.call(\"efef\", \"eeff\")\n# false\n# >>> cycpattern_check.call(\"himenss\", \"simen\")\n# true\ndef cycpattern_check(a, b)\n",
+    "prompt": "# Given an array of positive integers x. return a sorted array of all \n# elements that hasn't any even digit.\n# Note: Returned array should be sorted in increasing order.\n# For example:\n# >>> unique_digits.call([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits.call([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rb",
-    "prompt": "# Return true is array elements are monotonically increasing or decreasing.\n# >>> monotonic.call([1, 2, 4, 20])\n# true\n# >>> monotonic.call([1, 20, 4, 10])\n# false\n# >>> monotonic.call([4, 1, 0, -10])\n# true\ndef monotonic(l)\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length.call([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length.call([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length.call([1, -1, 55])\n# [\"One\"]\ndef by_length(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rb",
-    "prompt": "# Out of array of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return nil in case the input array is empty.\n# >>> longest.call([])\n# nil\n# >>> longest.call([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest.call([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\ndef longest(strings)\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f.call(5)\n# [1, 2, 6, 24, 15]\ndef f(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rb",
-    "prompt": "# Return true if all numbers in the array l are below threshold t.\n# >>> below_threshold.call([1, 2, 4, 10], 100)\n# true\n# >>> below_threshold.call([1, 20, 4, 10], 5)\n# false\ndef below_threshold(l, t)\n",
+    "prompt": "# Given a positive integer n, return an array that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome.call(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome.call(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned array has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rb",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime.call(30)\n# true\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums.call([])\n# 0\n# >>> count_nums.call([-1, 11, -11])\n# 1\n# >>> count_nums.call([1, 1, 2])\n# 3\ndef count_nums(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rb",
-    "prompt": "# Return only positive numbers in the array.\n# >>> get_positive.call([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return true else return false.\n# If the given array is empty then return true.\n# Note: The given array is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball.call([3, 4, 5, 1, 2])\n# true\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball.call([3, 5, 4, 1, 2])\n# false\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rb",
-    "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third.call([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome.call(\"\")\n# \"\"\n# >>> make_palindrome.call(\"cat\")\n# \"catac\"\n# >>> make_palindrome.call(\"cata\")\n# \"catac\"\ndef make_palindrome(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rb",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens.call(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
+    "prompt": "# In this problem, you will implement a function that takes two arrays of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 an array of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange.call([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange.call([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input arrays will be non-empty.\ndef exchange(lst1, lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rb",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area.call(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a hash\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram.call(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram.call(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram.call(\"\")\n# {}\ndef histogram(test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rb",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply.call(148, 412)\n# 16\n# >>> multiply.call(19, 28)\n# 72\n# >>> multiply.call(2020, 1851)\n# 0\n# >>> multiply.call(14, -15)\n# 20\ndef multiply(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rb",
-    "prompt": "# For a given array of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation.call([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rb",
-    "prompt": "# Return sorted unique common elements for two arrays.\n# >>> common.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common.call([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rb",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman.call(19)\n# \"xix\"\n# >>> int_to_mini_roman.call(152)\n# \"clii\"\n# >>> int_to_mini_roman.call(426)\n# \"cdxxvi\"\ndef int_to_mini_roman(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rb",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution.call(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution.call(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution.call(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution.call(\"100 apples and 1 oranges\", 120)\n# 19\ndef fruit_distribution(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2029,7 +214,7 @@
     "language": "rb",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return an array containing the result string and true/false for the check.\n# Example\n# >>> reverse_delete.call(\"abcde\", \"ae\")\n# [\"bcd\", false]\n# >>> reverse_delete.call(\"abcdef\", \"b\")\n# [\"acdef\", false]\n# >>> reverse_delete.call(\"abcdedcba\", \"ab\")\n# [\"cdedc\", true]\ndef reverse_delete(s, c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_delete\n    candidate = method(:reverse_delete)\n    assert_equal([\"bcd\", false], candidate.call(\"abcde\", \"ae\"))\n    assert_equal([\"acdef\", false], candidate.call(\"abcdef\", \"b\"))\n    assert_equal([\"cdedc\", true], candidate.call(\"abcdedcba\", \"ab\"))\n    assert_equal([\"dik\", false], candidate.call(\"dwik\", \"w\"))\n    assert_equal([\"\", true], candidate.call(\"a\", \"a\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"v\"))\n    assert_equal([\"abba\", true], candidate.call(\"vabba\", \"v\"))\n    assert_equal([\"\", true], candidate.call(\"mamma\", \"mia\"))\n  end\nend\n",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rb",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor.call(3, 5)\n# 1\n# >>> greatest_common_divisor.call(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
+    "prompt": "# Given an array of strings, where each string consists of only digits, return an array.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count.call([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count.call([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rb",
-    "prompt": "# Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words.call(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"abcdef\")\n# 3\ndef split_words(txt)\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum.call([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum.call([-1, -2, -3])\n# -6\ndef minSubArraySum(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rb",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill.call([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2074,7 +274,7 @@
     "language": "rb",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array.call([1, 5, 2, 3, 4])\n# [1, 2, 3, 4, 5]\n# >>> sort_array.call([-2, -3, -4, -5, -6])\n# [-6, -5, -4, -3, -2]\n# >>> sort_array.call([1, 0, 2, 3, 4])\n# [0, 1, 2, 3, 4]\ndef sort_array(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([1, 2, 4, 3, 5], candidate.call([1, 5, 2, 3, 4]))\n    assert_equal([-4, -2, -6, -5, -3], candidate.call([-2, -3, -4, -5, -6]))\n    assert_equal([0, 1, 2, 4, 3], candidate.call([1, 0, 2, 3, 4]))\n    assert_equal([], candidate.call([]))\n    assert_equal([2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77], candidate.call([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]))\n    assert_equal([32, 3, 5, 6, 12, 44], candidate.call([3, 6, 44, 12, 32, 5]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n  end\nend\n",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rb",
-    "prompt": "# Concatenate array of strings into a single string\n# >>> concatenate.call([])\n# \"\"\n# >>> concatenate.call([\"a\", \"b\", \"c\"])\n# \"abc\"\ndef concatenate(strings)\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns an array of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty array.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words.call(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words.call(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words.call(\"simple white space\", 2)\n# []\n# >>> select_words.call(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words.call(\"Uncle sam\", 3)\n# [\"Uncle\"]\ndef select_words(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rb",
-    "prompt": "# Write a function that accepts an array of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted array with a sorted order,\n# The array is always an array of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the array should be ascending by length of each word, and you\n# should return the array sorted by that rule.\n# If two words have the same length, sort the array alphabetically.\n# The function should return an array of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort.call([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort.call([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel.call(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel.call(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel.call(\"quick\")\n# \"\"\n# >>> get_closest_vowel.call(\"ab\")\n# \"\"\ndef get_closest_vowel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rb",
-    "prompt": "# Filter an input array of strings only for ones that contain given substring\n# >>> filter_by_substring.call([], \"a\")\n# []\n# >>> filter_by_substring.call([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\ndef filter_by_substring(strings, substring)\n",
+    "prompt": "# You are given an array of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens.call([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens.call([\")\", \")\"])\n# \"No\"\ndef match_parens(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rb",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer.call(\"10\")\n# 10\n# >>> closest_integer.call(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor.call(\"010\", \"110\")\n# \"100\"\ndef string_xor(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rb",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count.call(\"abcde\")\n# 2\n# >>> vowels_count.call(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted array \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum.call([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum.call([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum.call([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rb",
-    "prompt": "# Write a function that accepts an array of strings.\n# The array contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max.call([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max.call([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max.call([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\ndef find_max(words)\n",
+    "prompt": "# Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution.call([5, 8, 7, 1])\n# 12\n# >>> solution.call([3, 3, 3, 3, 3])\n# 9\n# >>> solution.call([30, 13, 24, 321])\n# 0\ndef solution(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rb",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return nil.\n# >>> string_to_md5.call(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\ndef string_to_md5(text)\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rb",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base.call(8, 3)\n# \"22\"\n# >>> change_base.call(8, 2)\n# \"1000\"\n# >>> change_base.call(7, 2)\n# \"111\"\ndef change_base(x, base)\n",
+    "prompt": "# Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned array sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz.call(5)\n# [1, 5]\ndef get_odd_collatz(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return true if the three\n# sides form a right-angled triangle, false otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle.call(3, 4, 5)\n# true\n# >>> right_angle_triangle.call(1, 2, 3)\n# false\ndef right_angle_triangle(a, b, c)\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns true if the date is valid otherwise false.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date.call(\"03-11-2000\")\n# true\n# >>> valid_date.call(\"15-01-2012\")\n# false\n# >>> valid_date.call(\"04-0-2040\")\n# false\n# >>> valid_date.call(\"06-04-2020\")\n# true\n# >>> valid_date.call(\"06/04/2020\")\n# false\ndef valid_date(date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rb",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you an array of GPAs for some students and you have to write \n# a function that can output an array of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation.call([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\ndef numerical_letter_grade(grades)\n",
+    "prompt": "# Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words.call(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"abcdef\")\n# 3\ndef split_words(txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rb",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n# >>> intersperse.call([], 4)\n# []\n# >>> intersperse.call([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
+    "prompt": "# Given an array of numbers, return whether or not they are sorted\n# in ascending order. If array has more than 1 duplicate of the same\n# number, return false. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted.call([5])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5])\n# false\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6, 7])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5, 6, 7])\n# false\n# >>> is_sorted.call([1, 2, 2, 3, 3, 4])\n# true\n# >>> is_sorted.call([1, 2, 2, 2, 3, 4])\n# false\ndef is_sorted(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rb",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection.call([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection.call([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection.call([-3, -1], [-5, 5])\n# \"YES\"\ndef intersection(interval1, interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rb",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return nil for empty arr.\n# Example:\n# >>> prod_signs.call([1, 2, 2, -4])\n# 9\n# >>> prod_signs.call([0, 1])\n# 0\n# >>> prod_signs.call([])\n# nil\ndef prod_signs(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rb",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered arrays of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered array of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\ndef minPath(grid, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rb",
+    "prompt": "# Out of array of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return nil in case the input array is empty.\n# >>> longest.call([])\n# nil\n# >>> longest.call([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest.call([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\ndef longest(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rb",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return an array of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri.call(3)\n# [1, 3, 2, 8]\ndef tri(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits.call(1)\n# 1\n# >>> digits.call(4)\n# 0\n# >>> digits.call(235)\n# 15\ndef digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rb",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return true if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested.call(\"[[]]\")\n# true\n# >>> is_nested.call(\"[]]]]]]][[[[[]\")\n# false\n# >>> is_nested.call(\"[][]\")\n# false\n# >>> is_nested.call(\"[]\")\n# false\n# >>> is_nested.call(\"[[][]]\")\n# true\n# >>> is_nested.call(\"[[]][[\")\n# true\ndef is_nested(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rb",
+    "prompt": "# You are given an array of numbers.\n# You need to return the sum of squared numbers in the given array,\n# round each element in the array to the upper int(Ceiling) first.\n# Examples:\n# >>> lst.call([1.0, 2.0, 3.0])\n# 14\n# >>> lst.call([1.0, 4.0, 9.0])\n# 98\n# >>> lst.call([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst.call([1.4, 4.2, 0.0])\n# 29\n# >>> lst.call([-2.4, 1.0, 1.0])\n# 6\ndef sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rb",
+    "prompt": "# Create a function that returns true if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and false otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter.call(\"apple pie\")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e\")\n# true\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e \")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"\")\n# false\ndef check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rb",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange.call([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange.call([1, 2, 3])\n# -1\ndef can_arrange(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rb",
+    "prompt": "# Create a function that returns an array (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in an array.\n# If there is no negative or positive integers, return them as nil.\n# Examples:\n# >>> largest_smallest_integers.call([2, 4, 1, 3, 5, 7])\n# [nil, 1]\n# >>> largest_smallest_integers.call([])\n# [nil, nil]\n# >>> largest_smallest_integers.call([0])\n# [nil, nil]\ndef largest_smallest_integers(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rb",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return nil if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one.call(1, 2.5)\n# 2.5\n# >>> compare_one.call(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one.call(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one.call(\"1\", 1)\n# nil\ndef compare_one(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rb",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even.call(4)\n# false\n# >>> is_equal_to_sum_even.call(6)\n# false\n# >>> is_equal_to_sum_even.call(8)\n# true\ndef is_equal_to_sum_even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rb",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial.call(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rb",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor.call(3, 5)\n# 1\n# >>> greatest_common_divisor.call(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rb",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces.call(\" Example\")\n# \"Example\"\n# >>> fix_spaces.call(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces.call(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces.call(\" Example 3\")\n# \"_Example-3\"\ndef fix_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rb",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check.call(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check.call(\"1example.dll\")\n# \"No\"\ndef file_name_check(file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rb",
+    "prompt": "# \"\n# This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\ndef sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rb",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence.call(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence.call(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rb",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns true if x * n evaluates to a whole number and false\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify.call(\"1/5\", \"5/1\")\n# true\n# >>> simplify.call(\"1/6\", \"2/1\")\n# false\n# >>> simplify.call(\"7/10\", \"10/2\")\n# false\ndef simplify(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rb",
+    "prompt": "# Write a function which sorts the given array of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original array.\n# For example:\n# >>> order_by_points.call([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points.call([])\n# []\ndef order_by_points(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2254,7 +769,7 @@
     "language": "rb",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter.call([15, -73, 14, -15])\n# 1\n# >>> specialFilter.call([33, -2, -3, 45, 21, 109])\n# 2\ndef specialFilter(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_specialFilter\n    candidate = method(:specialFilter)\n    assert_equal(0, candidate.call([5, -2, 1, -5]))\n    assert_equal(1, candidate.call([15, -73, 14, -15]))\n    assert_equal(2, candidate.call([33, -2, -3, 45, 21, 109]))\n    assert_equal(4, candidate.call([43, -12, 93, 125, 121, 109]))\n    assert_equal(3, candidate.call([71, -2, -33, 75, 21, 19]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(0, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rb",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n.call(30)\n# 465\n# >>> sum_to_n.call(100)\n# 5050\n# >>> sum_to_n.call(5)\n# 15\n# >>> sum_to_n.call(10)\n# 55\n# >>> sum_to_n.call(1)\n# 1\ndef sum_to_n(n)\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples.call(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rb",
-    "prompt": "# From an array of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates.call([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return an array containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty array if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf.call(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf.call(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf.call(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\ndef bf(planet1, planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function that accepts an array of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted array with a sorted order,\n# The array is always an array of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the array should be ascending by length of each word, and you\n# should return the array sorted by that rule.\n# If two words have the same length, sort the array alphabetically.\n# The function should return an array of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort.call([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort.call([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rb",
+    "prompt": "# Return array of all prefixes from shortest to longest of the input string\n# >>> all_prefixes.call(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\ndef all_prefixes(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rb",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y.call(7, 34, 12)\n# 34\n# >>> x_or_y.call(15, 8, 5)\n# 5\ndef x_or_y(n, x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rb",
+    "prompt": "# Given an array of numbers, return the sum of squares of the numbers\n# in the array that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference.call([1, 3, 2, 0])\n# 10\n# >>> double_the_difference.call([-1, -2, 0])\n# 0\n# >>> double_the_difference.call([9, -2])\n# 81\n# >>> double_the_difference.call([0])\n# 0\n# If the input array is empty, return 0.\ndef double_the_difference(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rb",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare.call([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\ndef compare(game, guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rb",
+    "prompt": "# You will be given the name of a class (a string) and an array of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the array.\n# For example, if you are given \"Slices\" as the class and an array of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension.call(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\ndef Strongest_Extension(class_name, extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rb",
+    "prompt": "# You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check.call(\"abcd\", \"abd\")\n# false\n# >>> cycpattern_check.call(\"hello\", \"ell\")\n# true\n# >>> cycpattern_check.call(\"whassup\", \"psus\")\n# false\n# >>> cycpattern_check.call(\"abab\", \"baa\")\n# true\n# >>> cycpattern_check.call(\"efef\", \"eeff\")\n# false\n# >>> cycpattern_check.call(\"himenss\", \"simen\")\n# true\ndef cycpattern_check(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rb",
+    "prompt": "# Given an integer. return an array that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count.call(-12)\n# [1, 1]\n# >>> even_odd_count.call(123)\n# [1, 2]\ndef even_odd_count(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rb",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman.call(19)\n# \"xix\"\n# >>> int_to_mini_roman.call(152)\n# \"clii\"\n# >>> int_to_mini_roman.call(426)\n# \"cdxxvi\"\ndef int_to_mini_roman(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return true if the three\n# sides form a right-angled triangle, false otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle.call(3, 4, 5)\n# true\n# >>> right_angle_triangle.call(1, 2, 3)\n# false\ndef right_angle_triangle(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rb",
+    "prompt": "# Write a function that accepts an array of strings.\n# The array contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max.call([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max.call([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max.call([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\ndef find_max(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rb",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat.call(5, 6, 10)\n# [11, 4]\n# >>> eat.call(4, 8, 9)\n# [12, 1]\n# >>> eat.call(1, 10, 10)\n# [11, 0]\n# >>> eat.call(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rb",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence.call(0)\n# \"0\"\n# >>> string_sequence.call(5)\n# \"0 1 2 3 4 5\"\ndef string_sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rb",
+    "prompt": "# Given two arrays operator, and operand. The first array has basic algebra operations, and \n# the second array is an array of integers. Use the two given arrays to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator array is equal to the length of operand array minus one.\n# Operand is an array of of non-negative integers.\n# Operator array has at least one operator, and operand array has at least two operands.\ndef do_algebra(operator, operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve.call(\"1234\")\n# \"4321\"\n# >>> solve.call(\"ab\")\n# \"AB\"\n# >>> solve.call(\"#a@C\")\n# \"#A@c\"\ndef solve(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rb",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return nil.\n# >>> string_to_md5.call(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\ndef string_to_md5(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2299,7 +1054,7 @@
     "language": "rb",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers.call(2, 8)\n# [2, 4, 6, 8]\n# >>> generate_integers.call(8, 2)\n# [2, 4, 6, 8]\n# >>> generate_integers.call(10, 14)\n# []\ndef generate_integers(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_generate_integers\n    candidate = method(:generate_integers)\n    assert_equal([2, 4, 6, 8], candidate.call(2, 10))\n    assert_equal([2, 4, 6, 8], candidate.call(10, 2))\n    assert_equal([2, 4, 6, 8], candidate.call(132, 2))\n    assert_equal([], candidate.call(17, 89))\n  end\nend\n",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rb",
-    "prompt": "# From a given array of integers, generate an array of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max.call([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters.call(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters.call(\"Jerry\")\n# 4\ndef count_distinct_characters(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rb",
-    "prompt": "# You're given an array of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return true. Otherwise it should return false.\n# >>> below_zero.call([1, 2, 3])\n# false\n# >>> below_zero.call([1, 2, -4, 5])\n# true\ndef below_zero(operations)\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return array of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music.call(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rb",
-    "prompt": "# You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the array.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search.call([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search.call([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search.call([5, 5, 4, 4, 4])\n# -1\ndef search(lst)\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times.call(\"\", \"a\")\n# 0\n# >>> how_many_times.call(\"aaa\", \"a\")\n# 3\n# >>> how_many_times.call(\"aaaa\", \"aa\")\n# 3\ndef how_many_times(string, substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rb",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"(\")\n# false\n# >>> correct_bracketing.call(\"()\")\n# true\n# >>> correct_bracketing.call(\"(()())\")\n# true\n# >>> correct_bracketing.call(\")(()\")\n# false\ndef correct_bracketing(brackets)\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers.call(\"three one five\")\n# \"one three five\"\ndef sort_numbers(numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rb",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the array of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups.call(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\ndef separate_paren_groups(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rb",
+    "prompt": "# From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\ndef find_closest_elements(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rb",
+    "prompt": "# Given array of numbers (of at least two elements), apply a linear transform to that array,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit.call([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rb",
+    "prompt": "# Filter given array of any rbthon values only for integers\n# >>> filter_integers.call([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers.call([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rb",
+    "prompt": "# Return length of given string\n# >>> strlen.call(\"\")\n# 0\n# >>> strlen.call(\"abc\")\n# 3\ndef strlen(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rb",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor.call(15)\n# 5\ndef largest_divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rb",
+    "prompt": "# Return array of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize.call(8)\n# [2, 2, 2]\n# >>> factorize.call(25)\n# [5, 5]\n# >>> factorize.call(70)\n# [2, 5, 7]\ndef factorize(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rb",
+    "prompt": "# From an array of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates.call([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rb",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case.call(\"Hello\")\n# \"hELLO\"\ndef flip_case(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rb",
+    "prompt": "# Concatenate array of strings into a single string\n# >>> concatenate.call([])\n# \"\"\n# >>> concatenate.call([\"a\", \"b\", \"c\"])\n# \"abc\"\ndef concatenate(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rb",
+    "prompt": "# Filter an input array of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix.call([], \"a\")\n# []\n# >>> filter_by_prefix.call([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\ndef filter_by_prefix(strings, prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rb",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number.call(3.5)\n# 0.5\ndef truncate_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rb",
+    "prompt": "# Return only positive numbers in the array.\n# >>> get_positive.call([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rb",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime.call(6)\n# false\n# >>> is_prime.call(101)\n# true\n# >>> is_prime.call(11)\n# true\n# >>> is_prime.call(13441)\n# true\n# >>> is_prime.call(61)\n# true\n# >>> is_prime.call(4)\n# false\n# >>> is_prime.call(1)\n# false\ndef is_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rb",
+    "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third.call([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rb",
+    "prompt": "# Return sorted unique elements in an array\n# >>> unique.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rb",
+    "prompt": "# Return maximum element in the array.\n# >>> max_element.call([1, 2, 3])\n# 3\n# >>> max_element.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rb",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz.call(50)\n# 0\n# >>> fizz_buzz.call(78)\n# 2\n# >>> fizz_buzz.call(79)\n# 3\ndef fizz_buzz(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2374,9 +1399,249 @@
     "language": "rb",
     "prompt": "# This function takes an array l and returns an array l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even.call([5, 6, 3, 4])\n# [3, 6, 5, 4]\ndef sort_even(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_even\n    candidate = method(:sort_even)\n    assert_equal([1, 2, 3], candidate.call([1, 2, 3]))\n    assert_equal([-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123], candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([-12, 8, 3, 4, 5, 2, 12, 11, 23, -10], candidate.call([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rb",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib.call(1)\n# 2\n# >>> prime_fib.call(2)\n# 3\n# >>> prime_fib.call(3)\n# 5\n# >>> prime_fib.call(4)\n# 13\n# >>> prime_fib.call(5)\n# 89\ndef prime_fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rb",
+    "prompt": "# You're given an array of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return true. Otherwise it should return false.\n# >>> below_zero.call([1, 2, 3])\n# false\n# >>> below_zero.call([1, 2, -4, 5])\n# true\ndef below_zero(operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rb",
+    "prompt": "# triples_sum_to_zero takes an array of integers as an input.\n# it returns true if there are three distinct elements in the array that\n# sum to zero, and false otherwise.\n# >>> triples_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> triples_sum_to_zero.call([1, 3, -2, 1])\n# true\n# >>> triples_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> triples_sum_to_zero.call([2, 4, -5, 3, 9, 7])\n# true\n# >>> triples_sum_to_zero.call([1])\n# false\ndef triples_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rb",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rb",
+    "prompt": "# Return array with elements incremented by 1.\n# >>> incr_list.call([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rb",
+    "prompt": "# pairs_sum_to_zero takes an array of integers as an input.\n# it returns true if there are two distinct elements in the array that\n# sum to zero, and false otherwise.\n# >>> pairs_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> pairs_sum_to_zero.call([1, 3, -2, 1])\n# false\n# >>> pairs_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> pairs_sum_to_zero.call([2, 4, -5, 3, 5, 7])\n# true\n# >>> pairs_sum_to_zero.call([1])\n# false\ndef pairs_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rb",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base.call(8, 3)\n# \"22\"\n# >>> change_base.call(8, 2)\n# \"1000\"\n# >>> change_base.call(7, 2)\n# \"111\"\ndef change_base(x, base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rb",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area.call(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rb",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4.call(5)\n# 4\n# >>> fib4.call(6)\n# 8\n# >>> fib4.call(7)\n# 14\ndef fib4(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rb",
+    "prompt": "# Return median of elements in the array l.\n# >>> median.call([3, 1, 2, 4, 5])\n# 3\n# >>> median.call([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rb",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome.call(\"\")\n# true\n# >>> is_palindrome.call(\"aba\")\n# true\n# >>> is_palindrome.call(\"aaaaa\")\n# true\n# >>> is_palindrome.call(\"zbcd\")\n# false\ndef is_palindrome(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rb",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp.call(3, 5)\n# 3\n# >>> modp.call(1101, 101)\n# 2\n# >>> modp.call(0, 101)\n# 1\n# >>> modp.call(3, 11)\n# 8\n# >>> modp.call(100, 101)\n# 1\ndef modp(n, p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rb",
+    "prompt": "# For a given array of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation.call([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rb",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels.call(\"\")\n# \"\"\n# >>> remove_vowels.call(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels.call(\"aaaaa\")\n# \"\"\n# >>> remove_vowels.call(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels.call(\"zbcd\")\n# \"zbcd\"\ndef remove_vowels(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rb",
+    "prompt": "# Return true if all numbers in the array l are below threshold t.\n# >>> below_threshold.call([1, 2, 4, 10], 100)\n# true\n# >>> below_threshold.call([1, 20, 4, 10], 5)\n# false\ndef below_threshold(l, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rb",
+    "prompt": "# Add two numbers x and y\n# >>> add.call(2, 3)\n# 5\n# >>> add.call(5, 7)\n# 12\ndef add(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2389,9 +1654,24 @@
     "language": "rb",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n# true\n# >>> same_chars.call(\"abcd\", \"dddddddabc\")\n# true\n# >>> same_chars.call(\"dddddddabc\", \"abcd\")\n# true\n# >>> same_chars.call(\"eabcd\", \"dddddddabc\")\n# false\n# >>> same_chars.call(\"abcd\", \"dddddddabce\")\n# false\n# >>> same_chars.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n# false\ndef same_chars(s0, s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_same_chars\n    candidate = method(:same_chars)\n    assert_equal(true, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"))\n    assert_equal(true, candidate.call(\"abcd\", \"dddddddabc\"))\n    assert_equal(true, candidate.call(\"dddddddabc\", \"abcd\"))\n    assert_equal(false, candidate.call(\"eabcd\", \"dddddddabc\"))\n    assert_equal(false, candidate.call(\"abcd\", \"dddddddabcf\"))\n    assert_equal(false, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"))\n    assert_equal(false, candidate.call(\"aabb\", \"aaccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rb",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib.call(10)\n# 55\n# >>> fib.call(1)\n# 1\n# >>> fib.call(8)\n# 21\ndef fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2404,9 +1684,729 @@
     "language": "rb",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"<\")\n# false\n# >>> correct_bracketing.call(\"<>\")\n# true\n# >>> correct_bracketing.call(\"<<><>>\")\n# true\n# >>> correct_bracketing.call(\"><<>\")\n# false\ndef correct_bracketing(brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"<>\"))\n    assert_equal(true, candidate.call(\"<<><>>\"))\n    assert_equal(true, candidate.call(\"<><><<><>><>\"))\n    assert_equal(true, candidate.call(\"<><><<<><><>><>><<><><<>>>\"))\n    assert_equal(false, candidate.call(\"<<<><>>>>\"))\n    assert_equal(false, candidate.call(\"><<>\"))\n    assert_equal(false, candidate.call(\"<\"))\n    assert_equal(false, candidate.call(\"<<<<\"))\n    assert_equal(false, candidate.call(\">\"))\n    assert_equal(false, candidate.call(\"<<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>><<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>>><>\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rb",
+    "prompt": "# Return true is array elements are monotonically increasing or decreasing.\n# >>> monotonic.call([1, 2, 4, 20])\n# true\n# >>> monotonic.call([1, 20, 4, 10])\n# false\n# >>> monotonic.call([4, 1, 0, -10])\n# true\ndef monotonic(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rb",
+    "prompt": "# Return sorted unique common elements for two arrays.\n# >>> common.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common.call([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rb",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor.call(13195)\n# 29\n# >>> largest_prime_factor.call(2048)\n# 2\ndef largest_prime_factor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rb",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n# >>> intersperse.call([], 4)\n# []\n# >>> intersperse.call([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rb",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n.call(30)\n# 465\n# >>> sum_to_n.call(100)\n# 5050\n# >>> sum_to_n.call(5)\n# 15\n# >>> sum_to_n.call(10)\n# 55\n# >>> sum_to_n.call(1)\n# 1\ndef sum_to_n(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rb",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"(\")\n# false\n# >>> correct_bracketing.call(\"()\")\n# true\n# >>> correct_bracketing.call(\"(()())\")\n# true\n# >>> correct_bracketing.call(\")(()\")\n# false\ndef correct_bracketing(brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rb",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative.call([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative.call([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rb",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib.call(1)\n# 0\n# >>> fibfib.call(5)\n# 4\n# >>> fibfib.call(8)\n# 24\ndef fibfib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rb",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count.call(\"abcde\")\n# 2\n# >>> vowels_count.call(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rb",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift.call(12, 1)\n# \"21\"\n# >>> circular_shift.call(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rb",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum.call(\"\")\n# 0\n# >>> digitSum.call(\"abAB\")\n# 131\n# >>> digitSum.call(\"abcCd\")\n# 67\n# >>> digitSum.call(\"helloE\")\n# 69\n# >>> digitSum.call(\"woArBld\")\n# 131\n# >>> digitSum.call(\"aAaaaXa\")\n# 153\ndef digitSum(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rb",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution.call(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution.call(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution.call(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution.call(\"100 apples and 1 oranges\", 120)\n# 19\ndef fruit_distribution(s, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rb",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in an array, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck.call([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck.call([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck.call([])\n# []\n# Example 4:\n# >>> pluck.call([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rb",
+    "prompt": "# You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the array.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search.call([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search.call([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search.call([5, 5, 4, 4, 4])\n# -1\ndef search(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rb",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens.call(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rb",
+    "prompt": "# Given array of integers, return array in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list.call([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list.call([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list.call([])\n# []\ndef strange_sort_list(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area.call(3, 4, 5)\n# 6.0\n# >>> triangle_area.call(1, 2, 10)\n# -1\ndef triangle_area(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rb",
+    "prompt": "# Write a function that returns true if the object q will fly, and false otherwise.\n# The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly.call([1, 2], 5)\n# false\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly.call([3, 2, 3], 1)\n# false\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly.call([3, 2, 3], 9)\n# true\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly.call([3], 5)\n# true\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rb",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change.call([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change.call([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change.call([1, 2, 3, 2, 1])\n# 0\ndef smallest_change(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rb",
+    "prompt": "# Write a function that accepts two arrays of strings and returns the array that has \n# total number of chars in the all strings of the array less than the other array.\n# if the two arrays have the same number of chars, return the first array.\n# Examples\n# >>> total_match.call([], [])\n# []\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\ndef total_match(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rb",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime.call(30)\n# true\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rb",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power.call(1, 4)\n# true\n# >>> is_simple_power.call(2, 2)\n# true\n# >>> is_simple_power.call(8, 2)\n# true\n# >>> is_simple_power.call(3, 2)\n# false\n# >>> is_simple_power.call(3, 1)\n# false\n# >>> is_simple_power.call(5, 3)\n# false\ndef is_simple_power(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rb",
+    "prompt": "# Write a function that takes an integer a and returns true \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube.call(1)\n# true\n# >>> iscube.call(2)\n# false\n# >>> iscube.call(-1)\n# true\n# >>> iscube.call(64)\n# true\n# >>> iscube.call(0)\n# true\n# >>> iscube.call(180)\n# false\ndef iscube(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rb",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key.call(\"AB\")\n# 1\n# >>> hex_key.call(\"1077E\")\n# 2\n# >>> hex_key.call(\"ABED1A33\")\n# 4\n# >>> hex_key.call(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key.call(\"2020\")\n# 2\ndef hex_key(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary.call(15)\n# \"db1111db\"\n# >>> decimal_to_binary.call(32)\n# \"db100000db\"\ndef decimal_to_binary(decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rb",
+    "prompt": "# Filter an input array of strings only for ones that contain given substring\n# >>> filter_by_substring.call([], \"a\")\n# []\n# >>> filter_by_substring.call([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\ndef filter_by_substring(strings, substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is haprb or not.\n# A string is haprb if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy.call(\"a\")\n# false\n# >>> is_happy.call(\"aa\")\n# false\n# >>> is_happy.call(\"abcd\")\n# true\n# >>> is_happy.call(\"aabb\")\n# false\n# >>> is_happy.call(\"adb\")\n# true\n# >>> is_happy.call(\"xyy\")\n# false\ndef is_happy(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rb",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you an array of GPAs for some students and you have to write \n# a function that can output an array of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation.call([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\ndef numerical_letter_grade(grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns true if the string\n# length is a prime number or false otherwise\n# Examples\n# >>> prime_length.call(\"Hello\")\n# true\n# >>> prime_length.call(\"abcdcba\")\n# true\n# >>> prime_length.call(\"kittens\")\n# true\n# >>> prime_length.call(\"orange\")\n# false\ndef prime_length(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rb",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve.call(1000)\n# \"1\"\n# >>> solve.call(150)\n# \"110\"\n# >>> solve.call(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rb",
+    "prompt": "# Given a non-empty array of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add.call([4, 2, 6, 7])\n# 2\ndef add(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle.call(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle.call(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle.call(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\ndef anti_shuffle(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rb",
+    "prompt": "# You are given a 2 dimensional data, as a nested arrays,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the array,\n# and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n# each array is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row.call([], 1)\n# []\n# >>> get_row.call([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\ndef get_row(lst, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rb",
+    "prompt": "# Given an array of non-negative integers, return a corb of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array.call([])\n# []\n# >>> sort_array.call([5])\n# [5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rb",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt.call(\"hi\")\n# \"lm\"\n# >>> encrypt.call(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt.call(\"gf\")\n# \"kj\"\n# >>> encrypt.call(\"et\")\n# \"ix\"\ndef encrypt(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rb",
+    "prompt": "# For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product.call([])\n# [0, 1]\n# >>> sum_product.call([1, 2, 3, 4])\n# [10, 24]\ndef sum_product(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rb",
+    "prompt": "# You are given an array of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the array.\n# Return nil if there is no such element.\n# >>> next_smallest.call([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest.call([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest.call([])\n# nil\n# >>> next_smallest.call([1, 1])\n# nil\ndef next_smallest(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rb",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored.call(\"Hello world\")\n# 0\n# >>> is_bored.call(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rb",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int.call(5, 2, 7)\n# true\n# >>> any_int.call(3, 2, 2)\n# false\n# >>> any_int.call(3, -2, 1)\n# true\n# >>> any_int.call(3.6, -2.2, 2)\n# false\ndef any_int(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rb",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode.call(\"test\")\n# \"TGST\"\n# >>> encode.call(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\ndef encode(message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rb",
+    "prompt": "# You are given an array of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd.call([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd.call([0, 8, 1, 2, 1, 7])\n# 7\ndef skjkasdkd(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rb",
+    "prompt": "# Given a hash, return true if all keys are strings in lower \n# case or all keys are strings in upper case, else return false.\n# The function should return false is the given hash is empty.\n# Examples:\n# >>> check_dict_case.call({\"a\" => \"apple\", \"b\" => \"banana\"})\n# true\n# >>> check_dict_case.call({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# false\n# >>> check_dict_case.call({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# false\n# >>> check_dict_case.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# false\n# >>> check_dict_case.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# true\ndef check_dict_case(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rb",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to.call(5)\n# [2, 3]\n# >>> count_up_to.call(11)\n# [2, 3, 5, 7]\n# >>> count_up_to.call(0)\n# []\n# >>> count_up_to.call(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to.call(1)\n# []\n# >>> count_up_to.call(18)\n# [2, 3, 5, 7, 11, 13, 17]\ndef count_up_to(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rb",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply.call(148, 412)\n# 16\n# >>> multiply.call(19, 28)\n# 72\n# >>> multiply.call(2020, 1851)\n# 0\n# >>> multiply.call(14, -15)\n# 20\ndef multiply(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rb",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper.call(\"aBCdEf\")\n# 1\n# >>> count_upper.call(\"abcdefg\")\n# 0\n# >>> count_upper.call(\"dBBE\")\n# 0\ndef count_upper(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rb",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer.call(\"10\")\n# 10\n# >>> closest_integer.call(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rb",
+    "prompt": "# From a given array of integers, generate an array of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max.call([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/humaneval-rb-transform.json
+++ b/prompts/humaneval-rb-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rb",
-    "prompt": "# Return length of given string\n# >>> strlen.call(\"\")\n# 0\n# >>> strlen.call(\"abc\")\n# 3\ndef strlen(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rb",
-    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt.call(\"hi\")\n# \"lm\"\n# >>> encrypt.call(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt.call(\"gf\")\n# \"kj\"\n# >>> encrypt.call(\"et\")\n# \"ix\"\ndef encrypt(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rb",
-    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case.call({\"a\" => \"apple\", \"b\" => \"banana\"})\n# true\n# >>> check_dict_case.call({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# false\n# >>> check_dict_case.call({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# false\n# >>> check_dict_case.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# false\n# >>> check_dict_case.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# true\ndef check_dict_case(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add.call([4, 2, 6, 7])\n# 2\ndef add(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rb",
-    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces.call(\" Example\")\n# \"Example\"\n# >>> fix_spaces.call(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces.call(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces.call(\" Example 3\")\n# \"_Example-3\"\ndef fix_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rb",
-    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib.call(1)\n# 0\n# >>> fibfib.call(5)\n# 4\n# >>> fibfib.call(8)\n# 24\ndef fibfib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference.call([1, 3, 2, 0])\n# 10\n# >>> double_the_difference.call([-1, -2, 0])\n# 0\n# >>> double_the_difference.call([9, -2])\n# 81\n# >>> double_the_difference.call([0])\n# 0\n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rb",
-    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers.call([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers.call([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rb",
-    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rb",
-    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music.call(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary.call(15)\n# \"db1111db\"\n# >>> decimal_to_binary.call(32)\n# \"db100000db\"\ndef decimal_to_binary(decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rb",
-    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes.call(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\ndef all_prefixes(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rb",
-    "prompt": "# Add two numbers x and y\n# >>> add.call(2, 3)\n# 5\n# >>> add.call(5, 7)\n# 12\ndef add(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rb",
-    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat.call(5, 6, 10)\n# [11, 4]\n# >>> eat.call(4, 8, 9)\n# [12, 1]\n# >>> eat.call(1, 10, 10)\n# [11, 0]\n# >>> eat.call(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rb",
-    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill.call([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rb",
-    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndef do_algebra(operator, operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rb",
-    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case.call(\"Hello\")\n# \"hELLO\"\ndef flip_case(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rb",
-    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length.call([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length.call([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length.call([1, -1, 55])\n# [\"One\"]\ndef by_length(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rb",
-    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize.call(8)\n# [2, 2, 2]\n# >>> factorize.call(25)\n# [5, 5]\n# >>> factorize.call(70)\n# [2, 5, 7]\ndef factorize(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rb",
-    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to.call(5)\n# [2, 3]\n# >>> count_up_to.call(11)\n# [2, 3, 5, 7]\n# >>> count_up_to.call(0)\n# []\n# >>> count_up_to.call(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to.call(1)\n# []\n# >>> count_up_to.call(18)\n# [2, 3, 5, 7, 11, 13, 17]\ndef count_up_to(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rb",
-    "prompt": "# Return sorted unique elements in a list\n# >>> unique.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rb",
-    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match.call([], [])\n# []\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\ndef total_match(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rb",
-    "prompt": "# Return maximum element in the list.\n# >>> max_element.call([1, 2, 3])\n# 3\n# >>> max_element.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rb",
-    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested.call(\"[[]]\")\n# true\n# >>> is_nested.call(\"[]]]]]]][[[[[]\")\n# false\n# >>> is_nested.call(\"[][]\")\n# false\n# >>> is_nested.call(\"[]\")\n# false\n# >>> is_nested.call(\"[[][]]\")\n# true\n# >>> is_nested.call(\"[[]][[\")\n# true\ndef is_nested(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rb",
-    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg.call(1, 5)\n# \"0b11\"\n# >>> rounded_avg.call(7, 5)\n# -1\n# >>> rounded_avg.call(10, 20)\n# \"0b1111\"\n# >>> rounded_avg.call(20, 33)\n# \"0b11010\"\ndef rounded_avg(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rb",
-    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count.call([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count.call([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rb",
-    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball.call([3, 4, 5, 1, 2])\n# true\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball.call([3, 5, 4, 1, 2])\n# false\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome.call(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome.call(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rb",
-    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even.call(4)\n# false\n# >>> is_equal_to_sum_even.call(6)\n# false\n# >>> is_equal_to_sum_even.call(8)\n# true\ndef is_equal_to_sum_even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rb",
-    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative.call([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative.call([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rb",
-    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted.call([5])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5])\n# false\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6, 7])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5, 6, 7])\n# false\n# >>> is_sorted.call([1, 2, 2, 3, 3, 4])\n# true\n# >>> is_sorted.call([1, 2, 2, 2, 3, 4])\n# false\ndef is_sorted(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve.call(\"1234\")\n# \"4321\"\n# >>> solve.call(\"ab\")\n# \"AB\"\n# >>> solve.call(\"#a@C\")\n# \"#A@c\"\ndef solve(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rb",
-    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri.call(3)\n# [1, 3, 2, 8]\ndef tri(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rb",
-    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz.call(50)\n# 0\n# >>> fizz_buzz.call(78)\n# 2\n# >>> fizz_buzz.call(79)\n# 3\ndef fizz_buzz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix.call([], \"a\")\n# []\n# >>> filter_by_prefix.call([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\ndef filter_by_prefix(strings, prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rb",
-    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve.call(1000)\n# \"1\"\n# >>> solve.call(150)\n# \"110\"\n# >>> solve.call(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rb",
-    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\ndef minPath(grid, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rb",
-    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper.call(\"aBCdEf\")\n# 1\n# >>> count_upper.call(\"abcdefg\")\n# 0\n# >>> count_upper.call(\"dBBE\")\n# 0\ndef count_upper(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum.call([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum.call([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum.call([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rb",
-    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor.call(15)\n# 5\ndef largest_divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rb",
-    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array.call([])\n# []\n# >>> sort_array.call([5])\n# [5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rb",
-    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f.call(5)\n# [1, 2, 6, 24, 15]\ndef f(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rb",
-    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube.call(1)\n# true\n# >>> iscube.call(2)\n# false\n# >>> iscube.call(-1)\n# true\n# >>> iscube.call(64)\n# true\n# >>> iscube.call(0)\n# true\n# >>> iscube.call(180)\n# false\ndef iscube(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rb",
-    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode.call(\"test\")\n# \"TGST\"\n# >>> encode.call(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\ndef encode(message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rb",
-    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored.call(\"Hello world\")\n# 0\n# >>> is_bored.call(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rb",
-    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> pairs_sum_to_zero.call([1, 3, -2, 1])\n# false\n# >>> pairs_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> pairs_sum_to_zero.call([2, 4, -5, 3, 5, 7])\n# true\n# >>> pairs_sum_to_zero.call([1])\n# false\ndef pairs_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area.call(3, 4, 5)\n# 6.0\n# >>> triangle_area.call(1, 2, 10)\n# -1\ndef triangle_area(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rb",
-    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf.call(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf.call(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf.call(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\ndef bf(planet1, planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits.call(1)\n# 1\n# >>> digits.call(4)\n# 0\n# >>> digits.call(235)\n# 15\ndef digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rb",
-    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string.call(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string.call(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rb",
-    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times.call(\"\", \"a\")\n# 0\n# >>> how_many_times.call(\"aaa\", \"a\")\n# 3\n# >>> how_many_times.call(\"aaaa\", \"aa\")\n# 3\ndef how_many_times(string, substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rb",
-    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one.call(1, 2.5)\n# 2.5\n# >>> compare_one.call(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one.call(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one.call(\"1\", 1)\n# nil\ndef compare_one(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rb",
-    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels.call(\"\")\n# \"\"\n# >>> remove_vowels.call(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels.call(\"aaaaa\")\n# \"\"\n# >>> remove_vowels.call(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels.call(\"zbcd\")\n# \"zbcd\"\ndef remove_vowels(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rb",
-    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list.call([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list.call([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list.call([])\n# []\ndef strange_sort_list(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rb",
-    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\ndef find_closest_elements(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rb",
-    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power.call(1, 4)\n# true\n# >>> is_simple_power.call(2, 2)\n# true\n# >>> is_simple_power.call(8, 2)\n# true\n# >>> is_simple_power.call(3, 2)\n# false\n# >>> is_simple_power.call(3, 1)\n# false\n# >>> is_simple_power.call(5, 3)\n# false\ndef is_simple_power(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rb",
-    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib.call(1)\n# 2\n# >>> prime_fib.call(2)\n# 3\n# >>> prime_fib.call(3)\n# 5\n# >>> prime_fib.call(4)\n# 13\n# >>> prime_fib.call(5)\n# 89\ndef prime_fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rb",
-    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points.call([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points.call([])\n# []\ndef order_by_points(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rb",
     "prompt": "# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements.call([1.0, 2.0, 3.0], 0.5)\n# false\n# >>> has_close_elements.call([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# true\ndef has_close_elements(numbers, threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_has_close_elements\n    candidate = method(:has_close_elements)\n    assert_equal(true, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3))\n    assert_equal(false, candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05))\n    assert_equal(true, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.95))\n    assert_equal(false, candidate.call([1.0, 2.0, 5.9, 4.0, 5.0], 0.8))\n    assert_equal(true, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1))\n    assert_equal(true, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 1.0))\n    assert_equal(false, candidate.call([1.1, 2.2, 3.1, 4.1, 5.1], 0.5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rb",
-    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome.call(\"\")\n# \"\"\n# >>> make_palindrome.call(\"cat\")\n# \"catac\"\n# >>> make_palindrome.call(\"cata\")\n# \"catac\"\ndef make_palindrome(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rb",
-    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor.call(\"010\", \"110\")\n# \"100\"\ndef string_xor(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rb",
-    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial.call(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rb",
-    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rb",
-    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4.call(5)\n# 4\n# >>> fib4.call(6)\n# 8\n# >>> fib4.call(7)\n# 14\ndef fib4(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rb",
-    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits.call([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits.call([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rb",
-    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words.call(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words.call(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words.call(\"simple white space\", 2)\n# []\n# >>> select_words.call(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words.call(\"Uncle sam\", 3)\n# [\"Uncle\"]\ndef select_words(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rb",
-    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly.call([1, 2], 5)\n# false\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly.call([3, 2, 3], 1)\n# false\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly.call([3, 2, 3], 9)\n# true\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly.call([3], 5)\n# true\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rb",
-    "prompt": "# Return n-th Fibonacci number.\n# >>> fib.call(10)\n# 55\n# >>> fib.call(1)\n# 1\n# >>> fib.call(8)\n# 21\ndef fib(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rb",
-    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension.call(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\ndef Strongest_Extension(class_name, extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rb",
-    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens.call([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens.call([\")\", \")\"])\n# \"No\"\ndef match_parens(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest.call([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest.call([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest.call([])\n# nil\n# >>> next_smallest.call([1, 1])\n# nil\ndef next_smallest(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rb",
-    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int.call(5, 2, 7)\n# true\n# >>> any_int.call(3, 2, 2)\n# false\n# >>> any_int.call(3, -2, 1)\n# true\n# >>> any_int.call(3.6, -2.2, 2)\n# false\ndef any_int(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rb",
-    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number.call(3.5)\n# 0.5\ndef truncate_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rb",
-    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list.call([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rb",
-    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y.call(7, 34, 12)\n# 34\n# >>> x_or_y.call(15, 8, 5)\n# 5\ndef x_or_y(n, x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rb",
-    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp.call(3, 5)\n# 3\n# >>> modp.call(1101, 101)\n# 2\n# >>> modp.call(0, 101)\n# 1\n# >>> modp.call(3, 11)\n# 8\n# >>> modp.call(100, 101)\n# 1\ndef modp(n, p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rb",
-    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count.call(-12)\n# [1, 1]\n# >>> even_odd_count.call(123)\n# [1, 2]\ndef even_odd_count(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rb",
-    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy.call(\"a\")\n# false\n# >>> is_happy.call(\"aa\")\n# false\n# >>> is_happy.call(\"abcd\")\n# true\n# >>> is_happy.call(\"aabb\")\n# false\n# >>> is_happy.call(\"adb\")\n# true\n# >>> is_happy.call(\"xyy\")\n# false\ndef is_happy(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rb",
-    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor.call(13195)\n# 29\n# >>> largest_prime_factor.call(2048)\n# 2\ndef largest_prime_factor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rb",
-    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum.call(\"\")\n# 0\n# >>> digitSum.call(\"abAB\")\n# 131\n# >>> digitSum.call(\"abcCd\")\n# 67\n# >>> digitSum.call(\"helloE\")\n# 69\n# >>> digitSum.call(\"woArBld\")\n# 131\n# >>> digitSum.call(\"aAaaaXa\")\n# 153\ndef digitSum(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rb",
-    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit.call([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rb",
-    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution.call([5, 8, 7, 1])\n# 12\n# >>> solution.call([3, 3, 3, 3, 3])\n# 9\n# >>> solution.call([30, 13, 24, 321])\n# 0\ndef solution(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rb",
-    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck.call([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck.call([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck.call([])\n# []\n# Example 4:\n# >>> pluck.call([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rb",
-    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples.call(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rb",
-    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange.call([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange.call([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rb",
-    "prompt": "# Return median of elements in the list l.\n# >>> median.call([3, 1, 2, 4, 5])\n# 3\n# >>> median.call([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length.call(\"Hello\")\n# true\n# >>> prime_length.call(\"abcdcba\")\n# true\n# >>> prime_length.call(\"kittens\")\n# true\n# >>> prime_length.call(\"orange\")\n# false\ndef prime_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rb",
-    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change.call([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change.call([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change.call([1, 2, 3, 2, 1])\n# 0\ndef smallest_change(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rb",
-    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst.call([1.0, 2.0, 3.0])\n# 14\n# >>> lst.call([1.0, 4.0, 9.0])\n# 98\n# >>> lst.call([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst.call([1.4, 4.2, 0.0])\n# 29\n# >>> lst.call([-2.4, 1.0, 1.0])\n# 6\ndef sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rb",
-    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check.call(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check.call(\"1example.dll\")\n# \"No\"\ndef file_name_check(file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rb",
-    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> triples_sum_to_zero.call([1, 3, -2, 1])\n# true\n# >>> triples_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> triples_sum_to_zero.call([2, 4, -5, 3, 9, 7])\n# true\n# >>> triples_sum_to_zero.call([1])\n# false\ndef triples_sum_to_zero(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rb",
-    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection.call([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection.call([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection.call([-3, -1], [-5, 5])\n# \"YES\"\ndef intersection(interval1, interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rb",
-    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups.call(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\ndef separate_paren_groups(paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rb",
-    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare.call([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\ndef compare(game, guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rb",
-    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter.call(\"apple pie\")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e\")\n# true\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e \")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"\")\n# false\ndef check_if_last_char_is_a_letter(txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rb",
-    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date.call(\"03-11-2000\")\n# true\n# >>> valid_date.call(\"15-01-2012\")\n# false\n# >>> valid_date.call(\"04-0-2040\")\n# false\n# >>> valid_date.call(\"06-04-2020\")\n# true\n# >>> valid_date.call(\"06/04/2020\")\n# false\ndef valid_date(date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rb",
-    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums.call([])\n# 0\n# >>> count_nums.call([-1, 11, -11])\n# 1\n# >>> count_nums.call([1, 1, 2])\n# 3\ndef count_nums(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rb",
-    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle.call(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle.call(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle.call(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\ndef anti_shuffle(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rb",
-    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome.call(\"\")\n# true\n# >>> is_palindrome.call(\"aba\")\n# true\n# >>> is_palindrome.call(\"aaaaa\")\n# true\n# >>> is_palindrome.call(\"zbcd\")\n# false\ndef is_palindrome(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rb",
-    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel.call(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel.call(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel.call(\"quick\")\n# \"\"\n# >>> get_closest_vowel.call(\"ab\")\n# \"\"\ndef get_closest_vowel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rb",
-    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime.call(6)\n# false\n# >>> is_prime.call(101)\n# true\n# >>> is_prime.call(11)\n# true\n# >>> is_prime.call(13441)\n# true\n# >>> is_prime.call(61)\n# true\n# >>> is_prime.call(4)\n# false\n# >>> is_prime.call(1)\n# false\ndef is_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rb",
-    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify.call(\"1/5\", \"5/1\")\n# true\n# >>> simplify.call(\"1/6\", \"2/1\")\n# false\n# >>> simplify.call(\"7/10\", \"10/2\")\n# false\ndef simplify(x, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rb",
-    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key.call(\"AB\")\n# 1\n# >>> hex_key.call(\"1077E\")\n# 2\n# >>> hex_key.call(\"ABED1A33\")\n# 4\n# >>> hex_key.call(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key.call(\"2020\")\n# 2\ndef hex_key(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rb",
-    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence.call(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence.call(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rb",
-    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram.call(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram.call(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram.call(\"\")\n# {}\ndef histogram(test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rb",
-    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row.call([], 1)\n# []\n# >>> get_row.call([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\ndef get_row(lst, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rb",
-    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz.call(5)\n# [1, 5]\ndef get_odd_collatz(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rb",
-    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange.call([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange.call([1, 2, 3])\n# -1\ndef can_arrange(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rb",
-    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers.call(\"three one five\")\n# \"one three five\"\ndef sort_numbers(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rb",
-    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift.call(12, 1)\n# \"21\"\n# >>> circular_shift.call(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rb",
-    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\ndef sum_squares(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rb",
-    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd.call([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd.call([0, 8, 1, 2, 1, 7])\n# 7\ndef skjkasdkd(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rb",
-    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product.call([])\n# [0, 1]\n# >>> sum_product.call([1, 2, 3, 4])\n# [10, 24]\ndef sum_product(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rb",
-    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num.call(12, 15)\n# 14\n# >>> choose_num.call(13, 12)\n# -1\ndef choose_num(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rb",
-    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers.call([2, 4, 1, 3, 5, 7])\n# [nil, 1]\n# >>> largest_smallest_integers.call([])\n# [nil, nil]\n# >>> largest_smallest_integers.call([0])\n# [nil, nil]\ndef largest_smallest_integers(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rb",
-    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters.call(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters.call(\"Jerry\")\n# 4\ndef count_distinct_characters(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1759,7 +19,7 @@
     "language": "rb",
     "prompt": "# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile.call(3)\n# [3, 5, 7]\ndef make_a_pile(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_a_pile\n    candidate = method(:make_a_pile)\n    assert_equal([3, 5, 7], candidate.call(3))\n    assert_equal([4, 6, 8, 10], candidate.call(4))\n    assert_equal([5, 7, 9, 11, 13], candidate.call(5))\n    assert_equal([6, 8, 10, 12, 14, 16], candidate.call(6))\n    assert_equal([8, 10, 12, 14, 16, 18, 20, 22], candidate.call(8))\n  end\nend\n",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rb",
-    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs.call([1, 2, 2, -4])\n# 9\n# >>> prod_signs.call([0, 1])\n# 0\n# >>> prod_signs.call([])\n# nil\ndef prod_signs(arr)\n",
+    "prompt": "# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> words_string.call(\"Hi, my name is John\")\n# [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# >>> words_string.call(\"One, two, three, four, five, six\")\n# [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\ndef words_string(s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_string\n    candidate = method(:words_string)\n    assert_equal([\"Hi\", \"my\", \"name\", \"is\", \"John\"], candidate.call(\"Hi, my name is John\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One, two, three, four, five, six\"))\n    assert_equal([\"Hi\", \"my\", \"name\"], candidate.call(\"Hi, my name\"))\n    assert_equal([\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"], candidate.call(\"One,, two, three, four, five, six,\"))\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"ahmed\", \"gamal\"], candidate.call(\"ahmed     , gamal\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rb",
-    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum.call([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum.call([-1, -2, -3])\n# -6\ndef minSubArraySum(nums)\n",
+    "prompt": "# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> choose_num.call(12, 15)\n# 14\n# >>> choose_num.call(13, 12)\n# -1\ndef choose_num(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_choose_num\n    candidate = method(:choose_num)\n    assert_equal(14, candidate.call(12, 15))\n    assert_equal(-1, candidate.call(13, 12))\n    assert_equal(12354, candidate.call(33, 12354))\n    assert_equal(-1, candidate.call(5234, 5233))\n    assert_equal(28, candidate.call(6, 29))\n    assert_equal(-1, candidate.call(27, 10))\n    assert_equal(-1, candidate.call(7, 7))\n    assert_equal(546, candidate.call(546, 546))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rb",
-    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence.call(0)\n# \"0\"\n# >>> string_sequence.call(5)\n# \"0 1 2 3 4 5\"\ndef string_sequence(n)\n",
+    "prompt": "# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> rounded_avg.call(1, 5)\n# \"0b11\"\n# >>> rounded_avg.call(7, 5)\n# -1\n# >>> rounded_avg.call(10, 20)\n# \"0b1111\"\n# >>> rounded_avg.call(20, 33)\n# \"0b11010\"\ndef rounded_avg(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rounded_avg\n    candidate = method(:rounded_avg)\n    assert_equal(\"0b11\", candidate.call(1, 5))\n    assert_equal(\"0b1010\", candidate.call(7, 13))\n    assert_equal(\"0b1111001010\", candidate.call(964, 977))\n    assert_equal(\"0b1111100100\", candidate.call(996, 997))\n    assert_equal(\"0b1011000010\", candidate.call(560, 851))\n    assert_equal(\"0b101101110\", candidate.call(185, 546))\n    assert_equal(\"0b110101101\", candidate.call(362, 496))\n    assert_equal(\"0b1001110010\", candidate.call(350, 902))\n    assert_equal(\"0b11010111\", candidate.call(197, 233))\n    assert_equal(-1, candidate.call(7, 5))\n    assert_equal(-1, candidate.call(5, 1))\n    assert_equal(\"0b101\", candidate.call(5, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rb",
-    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check.call(\"abcd\", \"abd\")\n# false\n# >>> cycpattern_check.call(\"hello\", \"ell\")\n# true\n# >>> cycpattern_check.call(\"whassup\", \"psus\")\n# false\n# >>> cycpattern_check.call(\"abab\", \"baa\")\n# true\n# >>> cycpattern_check.call(\"efef\", \"eeff\")\n# false\n# >>> cycpattern_check.call(\"himenss\", \"simen\")\n# true\ndef cycpattern_check(a, b)\n",
+    "prompt": "# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits.call([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits.call([152, 323, 1422, 10])\n# []\ndef unique_digits(x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_digits\n    candidate = method(:unique_digits)\n    assert_equal([1, 15, 33], candidate.call([15, 33, 1422, 1]))\n    assert_equal([], candidate.call([152, 323, 1422, 10]))\n    assert_equal([111, 151], candidate.call([12345, 2033, 111, 151]))\n    assert_equal([31, 135], candidate.call([135, 103, 31]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rb",
-    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic.call([1, 2, 4, 20])\n# true\n# >>> monotonic.call([1, 20, 4, 10])\n# false\n# >>> monotonic.call([4, 1, 0, -10])\n# true\ndef monotonic(l)\n",
+    "prompt": "# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> by_length.call([2, 1, 1, 4, 5, 8, 2, 3])\n# [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# >>> by_length.call([])\n# []\n# If the array has any strange number ignore it:\n# >>> by_length.call([1, -1, 55])\n# [\"One\"]\ndef by_length(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_by_length\n    candidate = method(:by_length)\n    assert_equal([\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"], candidate.call([2, 1, 1, 4, 5, 8, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([\"One\"], candidate.call([1, -1, 55]))\n    assert_equal([\"Three\", \"Two\", \"One\"], candidate.call([1, -1, 3, 2]))\n    assert_equal([\"Nine\", \"Eight\", \"Four\"], candidate.call([9, 4, 8]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rb",
-    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest.call([])\n# nil\n# >>> longest.call([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest.call([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\ndef longest(strings)\n",
+    "prompt": "# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> f.call(5)\n# [1, 2, 6, 24, 15]\ndef f(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_f\n    candidate = method(:f)\n    assert_equal([1, 2, 6, 24, 15], candidate.call(5))\n    assert_equal([1, 2, 6, 24, 15, 720, 28], candidate.call(7))\n    assert_equal([1], candidate.call(1))\n    assert_equal([1, 2, 6], candidate.call(3))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rb",
-    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold.call([1, 2, 4, 10], 100)\n# true\n# >>> below_threshold.call([1, 20, 4, 10], 5)\n# false\ndef below_threshold(l, t)\n",
+    "prompt": "# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> even_odd_palindrome.call(3)\n# [1, 2]\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> even_odd_palindrome.call(12)\n# [4, 6]\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\ndef even_odd_palindrome(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_palindrome\n    candidate = method(:even_odd_palindrome)\n    assert_equal([8, 13], candidate.call(123))\n    assert_equal([4, 6], candidate.call(12))\n    assert_equal([1, 2], candidate.call(3))\n    assert_equal([6, 8], candidate.call(63))\n    assert_equal([5, 6], candidate.call(25))\n    assert_equal([4, 6], candidate.call(19))\n    assert_equal([4, 5], candidate.call(9))\n    assert_equal([0, 1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rb",
-    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime.call(30)\n# true\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "prompt": "# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums.call([])\n# 0\n# >>> count_nums.call([-1, 11, -11])\n# 1\n# >>> count_nums.call([1, 1, 2])\n# 3\ndef count_nums(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_nums\n    candidate = method(:count_nums)\n    assert_equal(0, candidate.call([]))\n    assert_equal(0, candidate.call([-1, -2, 0]))\n    assert_equal(6, candidate.call([1, 1, 2, -2, 3, 4, 5]))\n    assert_equal(5, candidate.call([1, 6, 9, -6, 0, 1, 5]))\n    assert_equal(4, candidate.call([1, 100, 98, -7, 1, -1]))\n    assert_equal(5, candidate.call([12, 23, 34, -45, -56, 0]))\n    assert_equal(1, candidate.call([0, 1]))\n    assert_equal(1, candidate.call([1]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rb",
-    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive.call([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
+    "prompt": "# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> move_one_ball.call([3, 4, 5, 1, 2])\n# true\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> move_one_ball.call([3, 5, 4, 1, 2])\n# false\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\ndef move_one_ball(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_one_ball\n    candidate = method(:move_one_ball)\n    assert_equal(true, candidate.call([3, 4, 5, 1, 2]))\n    assert_equal(true, candidate.call([3, 5, 10, 1, 2]))\n    assert_equal(false, candidate.call([4, 3, 1, 2]))\n    assert_equal(false, candidate.call([3, 5, 4, 1, 2]))\n    assert_equal(true, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rb",
-    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third.call([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
+    "prompt": "# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome.call(\"\")\n# \"\"\n# >>> make_palindrome.call(\"cat\")\n# \"catac\"\n# >>> make_palindrome.call(\"cata\")\n# \"catac\"\ndef make_palindrome(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_make_palindrome\n    candidate = method(:make_palindrome)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"x\", candidate.call(\"x\"))\n    assert_equal(\"xyzyx\", candidate.call(\"xyz\"))\n    assert_equal(\"xyx\", candidate.call(\"xyx\"))\n    assert_equal(\"jerryrrej\", candidate.call(\"jerry\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rb",
-    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens.call(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
+    "prompt": "# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> exchange.call([1, 2, 3, 4], [1, 2, 3, 4])\n# \"YES\"\n# >>> exchange.call([1, 2, 3, 4], [1, 5, 3, 4])\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\ndef exchange(lst1, lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_exchange\n    candidate = method(:exchange)\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [1, 2, 3, 4]))\n    assert_equal(\"NO\", candidate.call([1, 2, 3, 4], [1, 5, 3, 4]))\n    assert_equal(\"YES\", candidate.call([1, 2, 3, 4], [2, 1, 4, 3]))\n    assert_equal(\"YES\", candidate.call([5, 7, 3], [2, 6, 4]))\n    assert_equal(\"NO\", candidate.call([5, 7, 3], [2, 6, 3]))\n    assert_equal(\"NO\", candidate.call([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]))\n    assert_equal(\"YES\", candidate.call([100, 200], [200, 200]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rb",
-    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area.call(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
+    "prompt": "# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> histogram.call(\"a b c\")\n# {\"a\" => 1, \"b\" => 1, \"c\" => 1}\n# >>> histogram.call(\"a b b a\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"a b c a b\")\n# {\"a\" => 2, \"b\" => 2}\n# >>> histogram.call(\"b b b b a\")\n# {\"b\" => 4}\n# >>> histogram.call(\"\")\n# {}\ndef histogram(test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rb",
-    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply.call(148, 412)\n# 16\n# >>> multiply.call(19, 28)\n# 72\n# >>> multiply.call(2020, 1851)\n# 0\n# >>> multiply.call(14, -15)\n# 20\ndef multiply(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rb",
-    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation.call([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rb",
-    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common.call([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rb",
-    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman.call(19)\n# \"xix\"\n# >>> int_to_mini_roman.call(152)\n# \"clii\"\n# >>> int_to_mini_roman.call(426)\n# \"cdxxvi\"\ndef int_to_mini_roman(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rb",
-    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution.call(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution.call(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution.call(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution.call(\"100 apples and 1 oranges\", 120)\n# 19\ndef fruit_distribution(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_histogram\n    candidate = method(:histogram)\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b b a\"))\n    assert_equal({\"a\" => 2, \"b\" => 2}, candidate.call(\"a b c a b\"))\n    assert_equal({\"a\" => 1, \"b\" => 1, \"c\" => 1, \"d\" => 1, \"g\" => 1}, candidate.call(\"a b c d g\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({\"b\" => 4}, candidate.call(\"b b b b a\"))\n    assert_equal({\"r\" => 1, \"t\" => 1, \"g\" => 1}, candidate.call(\"r t g\"))\n    assert_equal({}, candidate.call(\"\"))\n    assert_equal({\"a\" => 1}, candidate.call(\"a\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2029,7 +214,7 @@
     "language": "rb",
     "prompt": "# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# >>> reverse_delete.call(\"abcde\", \"ae\")\n# [\"bcd\", false]\n# >>> reverse_delete.call(\"abcdef\", \"b\")\n# [\"acdef\", false]\n# >>> reverse_delete.call(\"abcdedcba\", \"ab\")\n# [\"cdedc\", true]\ndef reverse_delete(s, c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_delete\n    candidate = method(:reverse_delete)\n    assert_equal([\"bcd\", false], candidate.call(\"abcde\", \"ae\"))\n    assert_equal([\"acdef\", false], candidate.call(\"abcdef\", \"b\"))\n    assert_equal([\"cdedc\", true], candidate.call(\"abcdedcba\", \"ab\"))\n    assert_equal([\"dik\", false], candidate.call(\"dwik\", \"w\"))\n    assert_equal([\"\", true], candidate.call(\"a\", \"a\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"\"))\n    assert_equal([\"abcdedcba\", true], candidate.call(\"abcdedcba\", \"v\"))\n    assert_equal([\"abba\", true], candidate.call(\"vabba\", \"v\"))\n    assert_equal([\"\", true], candidate.call(\"mamma\", \"mia\"))\n  end\nend\n",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rb",
-    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor.call(3, 5)\n# 1\n# >>> greatest_common_divisor.call(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
+    "prompt": "# Given a list of strings, where each string consists of only digits, return a list.\n# Each element i of the output should be \"the number of odd elements in the\n# string i of the input.\" where all the i's should be replaced by the number\n# of odd digits in the i'th string of the input.\n# >>> odd_count.call([\"1234567\"])\n# [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n# >>> odd_count.call([\"3\", \"11111111\"])\n# [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\ndef odd_count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_count\n    candidate = method(:odd_count)\n    assert_equal([\"the number of odd elements 4n the str4ng 4 of the 4nput.\"], candidate.call([\"1234567\"]))\n    assert_equal([\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"], candidate.call([\"3\", \"11111111\"]))\n    assert_equal([\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"], candidate.call([\"271\", \"137\", \"314\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rb",
-    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words.call(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"abcdef\")\n# 3\ndef split_words(txt)\n",
+    "prompt": "# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> minSubArraySum.call([2, 3, 4, 1, 2, 4])\n# 1\n# >>> minSubArraySum.call([-1, -2, -3])\n# -6\ndef minSubArraySum(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minSubArraySum\n    candidate = method(:minSubArraySum)\n    assert_equal(1, candidate.call([2, 3, 4, 1, 2, 4]))\n    assert_equal(-6, candidate.call([-1, -2, -3]))\n    assert_equal(-14, candidate.call([-1, -2, -3, 2, -10]))\n    assert_equal(-9999999999999999, candidate.call([-9999999999999999]))\n    assert_equal(0, candidate.call([0, 10, 20, 1000000]))\n    assert_equal(-6, candidate.call([-1, -2, -3, 10, -5]))\n    assert_equal(-6, candidate.call([100, -1, -2, -3, 10, -5]))\n    assert_equal(3, candidate.call([10, 11, 13, 8, 3, 4]))\n    assert_equal(-33, candidate.call([100, -33, 32, -1, 0, -2]))\n    assert_equal(-10, candidate.call([-10]))\n    assert_equal(7, candidate.call([7]))\n    assert_equal(-1, candidate.call([1, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rb",
+    "prompt": "# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> max_fill.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n# 6\n# Example 2:\n# >>> max_fill.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n# 5\n# Example 3:\n# >>> max_fill.call([[0, 0, 0], [0, 0, 0]], 5)\n# 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\ndef max_fill(grid, capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_fill\n    candidate = method(:max_fill)\n    assert_equal(6, candidate.call([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1))\n    assert_equal(5, candidate.call([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2))\n    assert_equal(0, candidate.call([[0, 0, 0], [0, 0, 0]], 5))\n    assert_equal(4, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 2))\n    assert_equal(2, candidate.call([[1, 1, 1, 1], [1, 1, 1, 1]], 9))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2074,7 +274,7 @@
     "language": "rb",
     "prompt": "# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array.call([1, 5, 2, 3, 4])\n# [1, 2, 3, 4, 5]\n# >>> sort_array.call([-2, -3, -4, -5, -6])\n# [-6, -5, -4, -3, -2]\n# >>> sort_array.call([1, 0, 2, 3, 4])\n# [0, 1, 2, 3, 4]\ndef sort_array(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([1, 2, 4, 3, 5], candidate.call([1, 5, 2, 3, 4]))\n    assert_equal([-4, -2, -6, -5, -3], candidate.call([-2, -3, -4, -5, -6]))\n    assert_equal([0, 1, 2, 4, 3], candidate.call([1, 0, 2, 3, 4]))\n    assert_equal([], candidate.call([]))\n    assert_equal([2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77], candidate.call([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]))\n    assert_equal([32, 3, 5, 6, 12, 44], candidate.call([3, 6, 44, 12, 32, 5]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n    assert_equal([2, 4, 8, 16, 32], candidate.call([2, 4, 8, 16, 32]))\n  end\nend\n",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rb",
-    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate.call([])\n# \"\"\n# >>> concatenate.call([\"a\", \"b\", \"c\"])\n# \"abc\"\ndef concatenate(strings)\n",
+    "prompt": "# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> select_words.call(\"Mary had a little lamb\", 4)\n# [\"little\"]\n# >>> select_words.call(\"Mary had a little lamb\", 3)\n# [\"Mary\", \"lamb\"]\n# >>> select_words.call(\"simple white space\", 2)\n# []\n# >>> select_words.call(\"Hello world\", 4)\n# [\"world\"]\n# >>> select_words.call(\"Uncle sam\", 3)\n# [\"Uncle\"]\ndef select_words(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_select_words\n    candidate = method(:select_words)\n    assert_equal([\"little\"], candidate.call(\"Mary had a little lamb\", 4))\n    assert_equal([\"Mary\", \"lamb\"], candidate.call(\"Mary had a little lamb\", 3))\n    assert_equal([], candidate.call(\"simple white space\", 2))\n    assert_equal([\"world\"], candidate.call(\"Hello world\", 4))\n    assert_equal([\"Uncle\"], candidate.call(\"Uncle sam\", 3))\n    assert_equal([], candidate.call(\"\", 4))\n    assert_equal([\"b\", \"c\", \"d\", \"f\"], candidate.call(\"a b c d e f\", 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort.call([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort.call([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
+    "prompt": "# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> get_closest_vowel.call(\"yogurt\")\n# \"u\"\n# >>> get_closest_vowel.call(\"FULL\")\n# \"U\"\n# >>> get_closest_vowel.call(\"quick\")\n# \"\"\n# >>> get_closest_vowel.call(\"ab\")\n# \"\"\ndef get_closest_vowel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_closest_vowel\n    candidate = method(:get_closest_vowel)\n    assert_equal(\"u\", candidate.call(\"yogurt\"))\n    assert_equal(\"u\", candidate.call(\"full\"))\n    assert_equal(\"\", candidate.call(\"easy\"))\n    assert_equal(\"\", candidate.call(\"eAsy\"))\n    assert_equal(\"\", candidate.call(\"ali\"))\n    assert_equal(\"a\", candidate.call(\"bad\"))\n    assert_equal(\"o\", candidate.call(\"most\"))\n    assert_equal(\"\", candidate.call(\"ab\"))\n    assert_equal(\"\", candidate.call(\"ba\"))\n    assert_equal(\"\", candidate.call(\"quick\"))\n    assert_equal(\"i\", candidate.call(\"anime\"))\n    assert_equal(\"\", candidate.call(\"Asia\"))\n    assert_equal(\"o\", candidate.call(\"Above\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rb",
-    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring.call([], \"a\")\n# []\n# >>> filter_by_substring.call([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\ndef filter_by_substring(strings, substring)\n",
+    "prompt": "# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> match_parens.call([\"()(\", \")\"])\n# \"Yes\"\n# >>> match_parens.call([\")\", \")\"])\n# \"No\"\ndef match_parens(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_match_parens\n    candidate = method(:match_parens)\n    assert_equal(\"Yes\", candidate.call([\"()(\", \")\"]))\n    assert_equal(\"No\", candidate.call([\")\", \")\"]))\n    assert_equal(\"No\", candidate.call([\"(()(())\", \"())())\"]))\n    assert_equal(\"Yes\", candidate.call([\")())\", \"(()()(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(())))\", \"(()())((\"]))\n    assert_equal(\"No\", candidate.call([\"()\", \"())\"]))\n    assert_equal(\"Yes\", candidate.call([\"(()(\", \"()))()\"]))\n    assert_equal(\"No\", candidate.call([\"((((\", \"((())\"]))\n    assert_equal(\"No\", candidate.call([\")(()\", \"(()(\"]))\n    assert_equal(\"No\", candidate.call([\")(\", \")(\"]))\n    assert_equal(\"Yes\", candidate.call([\"(\", \")\"]))\n    assert_equal(\"Yes\", candidate.call([\")\", \"(\"]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rb",
-    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer.call(\"10\")\n# 10\n# >>> closest_integer.call(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "prompt": "# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor.call(\"010\", \"110\")\n# \"100\"\ndef string_xor(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_xor\n    candidate = method(:string_xor)\n    assert_equal(\"010010\", candidate.call(\"111000\", \"101010\"))\n    assert_equal(\"0\", candidate.call(\"1\", \"1\"))\n    assert_equal(\"0101\", candidate.call(\"0101\", \"0000\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rb",
-    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count.call(\"abcde\")\n# 2\n# >>> vowels_count.call(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
+    "prompt": "# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> maximum.call([-3, -4, 5], 3)\n# [-4, -3, 5]\n# Example 2:\n# >>> maximum.call([4, -4, 4], 2)\n# [4, 4]\n# Example 3:\n# >>> maximum.call([-3, 2, 1, 2, -1, -2, 1], 1)\n# [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\ndef maximum(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal([-4, -3, 5], candidate.call([-3, -4, 5], 3))\n    assert_equal([4, 4], candidate.call([4, -4, 4], 2))\n    assert_equal([2], candidate.call([-3, 2, 1, 2, -1, -2, 1], 1))\n    assert_equal([2, 20, 123], candidate.call([123, -123, 20, 0, 1, 2, -3], 3))\n    assert_equal([0, 1, 2, 20], candidate.call([-123, 20, 0, 1, 2, -3], 4))\n    assert_equal([-13, -8, 0, 0, 3, 5, 15], candidate.call([5, 15, 0, 3, -13, -8, 0], 7))\n    assert_equal([3, 5], candidate.call([-1, 0, 2, 5, 3, -10], 2))\n    assert_equal([5], candidate.call([1, 0, 5, -7], 1))\n    assert_equal([-4, 4], candidate.call([4, -4], 2))\n    assert_equal([-10, 10], candidate.call([-10, 10], 2))\n    assert_equal([], candidate.call([1, 2, 3, -23, 243, -400, 0], 0))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rb",
-    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max.call([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max.call([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max.call([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\ndef find_max(words)\n",
+    "prompt": "# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> solution.call([5, 8, 7, 1])\n# 12\n# >>> solution.call([3, 3, 3, 3, 3])\n# 9\n# >>> solution.call([30, 13, 24, 321])\n# 0\ndef solution(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solution\n    candidate = method(:solution)\n    assert_equal(12, candidate.call([5, 8, 7, 1]))\n    assert_equal(9, candidate.call([3, 3, 3, 3, 3]))\n    assert_equal(0, candidate.call([30, 13, 24, 321]))\n    assert_equal(5, candidate.call([5, 9]))\n    assert_equal(0, candidate.call([2, 4, 8]))\n    assert_equal(23, candidate.call([30, 13, 23, 32]))\n    assert_equal(3, candidate.call([3, 13, 2, 9]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rb",
-    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5.call(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\ndef string_to_md5(text)\n",
+    "prompt": "# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> add_elements.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n# 24\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\ndef add_elements(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_elements\n    candidate = method(:add_elements)\n    assert_equal(-4, candidate.call([1, -2, -3, 41, 57, 76, 87, 88, 99], 3))\n    assert_equal(0, candidate.call([111, 121, 3, 4000, 5, 6], 2))\n    assert_equal(125, candidate.call([11, 21, 3, 90, 5, 6, 7, 8, 9], 4))\n    assert_equal(24, candidate.call([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4))\n    assert_equal(1, candidate.call([1], 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rb",
-    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base.call(8, 3)\n# \"22\"\n# >>> change_base.call(8, 2)\n# \"1000\"\n# >>> change_base.call(7, 2)\n# \"111\"\ndef change_base(x, base)\n",
+    "prompt": "# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> get_odd_collatz.call(5)\n# [1, 5]\ndef get_odd_collatz(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_odd_collatz\n    candidate = method(:get_odd_collatz)\n    assert_equal([1, 5, 7, 11, 13, 17], candidate.call(14))\n    assert_equal([1, 5], candidate.call(5))\n    assert_equal([1, 3, 5], candidate.call(12))\n    assert_equal([1], candidate.call(1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rb",
-    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle.call(3, 4, 5)\n# true\n# >>> right_angle_triangle.call(1, 2, 3)\n# false\ndef right_angle_triangle(a, b, c)\n",
+    "prompt": "# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> valid_date.call(\"03-11-2000\")\n# true\n# >>> valid_date.call(\"15-01-2012\")\n# false\n# >>> valid_date.call(\"04-0-2040\")\n# false\n# >>> valid_date.call(\"06-04-2020\")\n# true\n# >>> valid_date.call(\"06/04/2020\")\n# false\ndef valid_date(date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_valid_date\n    candidate = method(:valid_date)\n    assert_equal(true, candidate.call(\"03-11-2000\"))\n    assert_equal(false, candidate.call(\"15-01-2012\"))\n    assert_equal(false, candidate.call(\"04-0-2040\"))\n    assert_equal(true, candidate.call(\"06-04-2020\"))\n    assert_equal(true, candidate.call(\"01-01-2007\"))\n    assert_equal(false, candidate.call(\"03-32-2011\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"04-31-3000\"))\n    assert_equal(true, candidate.call(\"06-06-2005\"))\n    assert_equal(false, candidate.call(\"21-31-2000\"))\n    assert_equal(true, candidate.call(\"04-12-2003\"))\n    assert_equal(false, candidate.call(\"04122003\"))\n    assert_equal(false, candidate.call(\"20030412\"))\n    assert_equal(false, candidate.call(\"2003-04\"))\n    assert_equal(false, candidate.call(\"2003-04-12\"))\n    assert_equal(false, candidate.call(\"04-2003\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rb",
-    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation.call([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\ndef numerical_letter_grade(grades)\n",
+    "prompt": "# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> split_words.call(\"Hello world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"Hello,world!\")\n# [\"Hello\", \"world!\"]\n# >>> split_words.call(\"abcdef\")\n# 3\ndef split_words(txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_words\n    candidate = method(:split_words)\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello world!\"))\n    assert_equal([\"Hello\", \"world!\"], candidate.call(\"Hello,world!\"))\n    assert_equal([\"Hello\", \"world,!\"], candidate.call(\"Hello world,!\"))\n    assert_equal([\"Hello,Hello,world\", \"!\"], candidate.call(\"Hello,Hello,world !\"))\n    assert_equal(3, candidate.call(\"abcdef\"))\n    assert_equal(2, candidate.call(\"aaabb\"))\n    assert_equal(1, candidate.call(\"aaaBb\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rb",
-    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse.call([], 4)\n# []\n# >>> intersperse.call([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
+    "prompt": "# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> is_sorted.call([5])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5])\n# false\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6])\n# true\n# >>> is_sorted.call([1, 2, 3, 4, 5, 6, 7])\n# true\n# >>> is_sorted.call([1, 3, 2, 4, 5, 6, 7])\n# false\n# >>> is_sorted.call([1, 2, 2, 3, 3, 4])\n# true\n# >>> is_sorted.call([1, 2, 2, 2, 3, 4])\n# false\ndef is_sorted(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sorted\n    candidate = method(:is_sorted)\n    assert_equal(true, candidate.call([5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6, 7]))\n    assert_equal(false, candidate.call([1, 3, 2, 4, 5, 6, 7]))\n    assert_equal(true, candidate.call([]))\n    assert_equal(true, candidate.call([1]))\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 2, 2, 3, 4]))\n    assert_equal(false, candidate.call([1, 2, 3, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3, 3, 4]))\n    assert_equal(true, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rb",
+    "prompt": "# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> intersection.call([1, 2], [2, 3])\n# \"NO\"\n# >>> intersection.call([-1, 1], [0, 4])\n# \"NO\"\n# >>> intersection.call([-3, -1], [-5, 5])\n# \"YES\"\ndef intersection(interval1, interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection\n    candidate = method(:intersection)\n    assert_equal(\"NO\", candidate.call([1, 2], [2, 3]))\n    assert_equal(\"NO\", candidate.call([-1, 1], [0, 4]))\n    assert_equal(\"YES\", candidate.call([-3, -1], [-5, 5]))\n    assert_equal(\"YES\", candidate.call([-2, 2], [-4, 0]))\n    assert_equal(\"NO\", candidate.call([-11, 2], [-1, -1]))\n    assert_equal(\"NO\", candidate.call([1, 2], [3, 5]))\n    assert_equal(\"NO\", candidate.call([1, 2], [1, 2]))\n    assert_equal(\"NO\", candidate.call([-2, -2], [-3, -2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rb",
+    "prompt": "# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs.call([1, 2, 2, -4])\n# 9\n# >>> prod_signs.call([0, 1])\n# 0\n# >>> prod_signs.call([])\n# nil\ndef prod_signs(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prod_signs\n    candidate = method(:prod_signs)\n    assert_equal(-9, candidate.call([1, 2, 2, -4]))\n    assert_equal(0, candidate.call([0, 1]))\n    assert_equal(-10, candidate.call([1, 1, 1, 2, 3, -1, 1]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(20, candidate.call([2, 4, 1, 2, -1, -1, 9]))\n    assert_equal(4, candidate.call([-1, 1, -1, 1]))\n    assert_equal(-4, candidate.call([-1, 1, 1, 1]))\n    assert_equal(0, candidate.call([-1, 1, 1, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rb",
+    "prompt": "# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> minPath.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n# [1, 2, 1]\n# >>> minPath.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n# [1]\ndef minPath(grid, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minPath\n    candidate = method(:minPath)\n    assert_equal([1, 2, 1], candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3))\n    assert_equal([1], candidate.call([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1))\n    assert_equal([1, 2, 1, 2], candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4))\n    assert_equal([1, 10, 1, 10, 1, 10, 1], candidate.call([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7))\n    assert_equal([1, 7, 1, 7, 1], candidate.call([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1], candidate.call([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9))\n    assert_equal([1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6], candidate.call([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8))\n    assert_equal([1, 5, 1, 5, 1, 5, 1, 5], candidate.call([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8))\n    assert_equal([1, 2, 1, 2, 1, 2, 1, 2, 1, 2], candidate.call([[1, 2], [3, 4]], 10))\n    assert_equal([1, 3, 1, 3, 1, 3, 1, 3, 1, 3], candidate.call([[1, 3], [3, 2]], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rb",
+    "prompt": "# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest.call([])\n# nil\n# >>> longest.call([\"a\", \"b\", \"c\"])\n# \"a\"\n# >>> longest.call([\"a\", \"bb\", \"ccc\"])\n# \"ccc\"\ndef longest(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_longest\n    candidate = method(:longest)\n    assert_equal(nil, candidate.call([]))\n    assert_equal(\"x\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"zzzz\", candidate.call([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rb",
+    "prompt": "# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> tri.call(3)\n# [1, 3, 2, 8]\ndef tri(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tri\n    candidate = method(:tri)\n    assert_equal([1, 3, 2, 8], candidate.call(3))\n    assert_equal([1, 3, 2, 8, 3], candidate.call(4))\n    assert_equal([1, 3, 2, 8, 3, 15], candidate.call(5))\n    assert_equal([1, 3, 2, 8, 3, 15, 4], candidate.call(6))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24], candidate.call(7))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5], candidate.call(8))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35], candidate.call(9))\n    assert_equal([1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11], candidate.call(20))\n    assert_equal([1], candidate.call(0))\n    assert_equal([1, 3], candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> digits.call(1)\n# 1\n# >>> digits.call(4)\n# 0\n# >>> digits.call(235)\n# 15\ndef digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digits\n    candidate = method(:digits)\n    assert_equal(5, candidate.call(5))\n    assert_equal(5, candidate.call(54))\n    assert_equal(1, candidate.call(120))\n    assert_equal(5, candidate.call(5014))\n    assert_equal(315, candidate.call(98765))\n    assert_equal(2625, candidate.call(5576543))\n    assert_equal(0, candidate.call(2468))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rb",
+    "prompt": "# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> is_nested.call(\"[[]]\")\n# true\n# >>> is_nested.call(\"[]]]]]]][[[[[]\")\n# false\n# >>> is_nested.call(\"[][]\")\n# false\n# >>> is_nested.call(\"[]\")\n# false\n# >>> is_nested.call(\"[[][]]\")\n# true\n# >>> is_nested.call(\"[[]][[\")\n# true\ndef is_nested(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nested\n    candidate = method(:is_nested)\n    assert_equal(true, candidate.call(\"[[]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]][[[[[]\"))\n    assert_equal(false, candidate.call(\"[][]\"))\n    assert_equal(false, candidate.call(\"[]\"))\n    assert_equal(true, candidate.call(\"[[[[]]]]\"))\n    assert_equal(false, candidate.call(\"[]]]]]]]]]]\"))\n    assert_equal(true, candidate.call(\"[][][[]]\"))\n    assert_equal(false, candidate.call(\"[[]\"))\n    assert_equal(false, candidate.call(\"[]]\"))\n    assert_equal(true, candidate.call(\"[[]][[\"))\n    assert_equal(true, candidate.call(\"[[][]]\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"[[[[[[[[\"))\n    assert_equal(false, candidate.call(\"]]]]]]]]\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rb",
+    "prompt": "# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> lst.call([1.0, 2.0, 3.0])\n# 14\n# >>> lst.call([1.0, 4.0, 9.0])\n# 98\n# >>> lst.call([1.0, 3.0, 5.0, 7.0])\n# 84\n# >>> lst.call([1.4, 4.2, 0.0])\n# 29\n# >>> lst.call([-2.4, 1.0, 1.0])\n# 6\ndef sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(14, candidate.call([1.0, 2.0, 3.0]))\n    assert_equal(84, candidate.call([1.0, 3.0, 5.0, 7.0]))\n    assert_equal(29, candidate.call([1.4, 4.2, 0.0]))\n    assert_equal(6, candidate.call([-2.4, 1.0, 1.0]))\n    assert_equal(10230, candidate.call([100.0, 1.0, 15.0, 2.0]))\n    assert_equal(200000000, candidate.call([10000.0, 10000.0]))\n    assert_equal(75, candidate.call([-1.4, 4.6, 6.3]))\n    assert_equal(1086, candidate.call([-1.4, 17.9, 18.9, 19.9]))\n    assert_equal(0, candidate.call([0.0]))\n    assert_equal(1, candidate.call([-1.0]))\n    assert_equal(2, candidate.call([-1.0, 1.0, 0.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rb",
+    "prompt": "# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> check_if_last_char_is_a_letter.call(\"apple pie\")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e\")\n# true\n# >>> check_if_last_char_is_a_letter.call(\"apple pi e \")\n# false\n# >>> check_if_last_char_is_a_letter.call(\"\")\n# false\ndef check_if_last_char_is_a_letter(txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_if_last_char_is_a_letter\n    candidate = method(:check_if_last_char_is_a_letter)\n    assert_equal(false, candidate.call(\"apple\"))\n    assert_equal(true, candidate.call(\"apple pi e\"))\n    assert_equal(false, candidate.call(\"eeeee\"))\n    assert_equal(true, candidate.call(\"A\"))\n    assert_equal(false, candidate.call(\"Pumpkin pie \"))\n    assert_equal(false, candidate.call(\"Pumpkin pie 1\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(false, candidate.call(\"eeeee e \"))\n    assert_equal(false, candidate.call(\"apple pie\"))\n    assert_equal(false, candidate.call(\"apple pi e \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rb",
+    "prompt": "# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> can_arrange.call([1, 2, 4, 3, 5])\n# 3\n# >>> can_arrange.call([1, 2, 3])\n# -1\ndef can_arrange(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_can_arrange\n    candidate = method(:can_arrange)\n    assert_equal(3, candidate.call([1, 2, 4, 3, 5]))\n    assert_equal(-1, candidate.call([1, 2, 4, 5]))\n    assert_equal(2, candidate.call([1, 4, 2, 5, 6, 7, 8, 9, 10]))\n    assert_equal(4, candidate.call([4, 8, 5, 7, 3]))\n    assert_equal(-1, candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rb",
+    "prompt": "# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> largest_smallest_integers.call([2, 4, 1, 3, 5, 7])\n# [nil, 1]\n# >>> largest_smallest_integers.call([])\n# [nil, nil]\n# >>> largest_smallest_integers.call([0])\n# [nil, nil]\ndef largest_smallest_integers(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_smallest_integers\n    candidate = method(:largest_smallest_integers)\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7]))\n    assert_equal([nil, 1], candidate.call([2, 4, 1, 3, 5, 7, 0]))\n    assert_equal([-2, 1], candidate.call([1, 3, 2, 4, 5, 6, -2]))\n    assert_equal([-7, 2], candidate.call([4, 5, 3, 6, 2, 7, -7]))\n    assert_equal([-9, 2], candidate.call([7, 3, 8, 4, 9, 2, 5, -9]))\n    assert_equal([nil, nil], candidate.call([]))\n    assert_equal([nil, nil], candidate.call([0]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6]))\n    assert_equal([-1, nil], candidate.call([-1, -3, -5, -6, 0]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, 1]))\n    assert_equal([-3, 1], candidate.call([-6, -4, -4, -3, -100, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rb",
+    "prompt": "# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> compare_one.call(1, 2.5)\n# 2.5\n# >>> compare_one.call(1, \"2,3\")\n# \"2,3\"\n# >>> compare_one.call(\"5,1\", \"6\")\n# \"6\"\n# >>> compare_one.call(\"1\", 1)\n# nil\ndef compare_one(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare_one\n    candidate = method(:compare_one)\n    assert_equal(2, candidate.call(1, 2))\n    assert_equal(2.5, candidate.call(1, 2.5))\n    assert_equal(3, candidate.call(2, 3))\n    assert_equal(6, candidate.call(5, 6))\n    assert_equal(\"2,3\", candidate.call(1, \"2,3\"))\n    assert_equal(\"6\", candidate.call(\"5,1\", \"6\"))\n    assert_equal(\"2\", candidate.call(\"1\", \"2\"))\n    assert_equal(nil, candidate.call(\"1\", 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rb",
+    "prompt": "# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> is_equal_to_sum_even.call(4)\n# false\n# >>> is_equal_to_sum_even.call(6)\n# false\n# >>> is_equal_to_sum_even.call(8)\n# true\ndef is_equal_to_sum_even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_equal_to_sum_even\n    candidate = method(:is_equal_to_sum_even)\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(8))\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(11))\n    assert_equal(true, candidate.call(12))\n    assert_equal(false, candidate.call(13))\n    assert_equal(true, candidate.call(16))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rb",
+    "prompt": "# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial.call(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\ndef special_factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_special_factorial\n    candidate = method(:special_factorial)\n    assert_equal(288, candidate.call(4))\n    assert_equal(34560, candidate.call(5))\n    assert_equal(125411328000, candidate.call(7))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rb",
+    "prompt": "# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor.call(3, 5)\n# 1\n# >>> greatest_common_divisor.call(25, 15)\n# 5\ndef greatest_common_divisor(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_greatest_common_divisor\n    candidate = method(:greatest_common_divisor)\n    assert_equal(1, candidate.call(3, 7))\n    assert_equal(5, candidate.call(10, 15))\n    assert_equal(7, candidate.call(49, 14))\n    assert_equal(12, candidate.call(144, 60))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rb",
+    "prompt": "# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> fix_spaces.call(\" Example\")\n# \"Example\"\n# >>> fix_spaces.call(\" Example 1\")\n# \"Example_1\"\n# >>> fix_spaces.call(\" Example 2\")\n# \"_Example_2\"\n# >>> fix_spaces.call(\" Example 3\")\n# \"_Example-3\"\ndef fix_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fix_spaces\n    candidate = method(:fix_spaces)\n    assert_equal(\"Example\", candidate.call(\"Example\"))\n    assert_equal(\"Mudasir_Hanif_\", candidate.call(\"Mudasir Hanif \"))\n    assert_equal(\"Yellow_Yellow__Dirty__Fellow\", candidate.call(\"Yellow Yellow  Dirty  Fellow\"))\n    assert_equal(\"Exa-mple\", candidate.call(\"Exa   mple\"))\n    assert_equal(\"-Exa_1_2_2_mple\", candidate.call(\"   Exa 1 2 2 mple\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rb",
+    "prompt": "# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> file_name_check.call(\"example.txt\")\n# \"Yes\"\n# >>> file_name_check.call(\"1example.dll\")\n# \"No\"\ndef file_name_check(file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_file_name_check\n    candidate = method(:file_name_check)\n    assert_equal(\"Yes\", candidate.call(\"example.txt\"))\n    assert_equal(\"No\", candidate.call(\"1example.dll\"))\n    assert_equal(\"No\", candidate.call(\"s1sdf3.asd\"))\n    assert_equal(\"Yes\", candidate.call(\"K.dll\"))\n    assert_equal(\"Yes\", candidate.call(\"MY16FILE3.exe\"))\n    assert_equal(\"No\", candidate.call(\"His12FILE94.exe\"))\n    assert_equal(\"No\", candidate.call(\"_Y.txt\"))\n    assert_equal(\"No\", candidate.call(\"?aREYA.exe\"))\n    assert_equal(\"No\", candidate.call(\"/this_is_valid.dll\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.wow\"))\n    assert_equal(\"Yes\", candidate.call(\"this_is_valid.txt\"))\n    assert_equal(\"No\", candidate.call(\"this_is_valid.txtexe\"))\n    assert_equal(\"No\", candidate.call(\"#this2_i4s_5valid.ten\"))\n    assert_equal(\"No\", candidate.call(\"@this1_is6_valid.exe\"))\n    assert_equal(\"No\", candidate.call(\"this_is_12valid.6exe4.txt\"))\n    assert_equal(\"No\", candidate.call(\"all.exe.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"I563_No.exe\"))\n    assert_equal(\"Yes\", candidate.call(\"Is3youfault.txt\"))\n    assert_equal(\"Yes\", candidate.call(\"no_one#knows.dll\"))\n    assert_equal(\"No\", candidate.call(\"1I563_Yes3.exe\"))\n    assert_equal(\"No\", candidate.call(\"I563_Yes3.txtt\"))\n    assert_equal(\"No\", candidate.call(\"final..txt\"))\n    assert_equal(\"No\", candidate.call(\"final132\"))\n    assert_equal(\"No\", candidate.call(\"_f4indsartal132.\"))\n    assert_equal(\"No\", candidate.call(\".txt\"))\n    assert_equal(\"No\", candidate.call(\"s.\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rb",
+    "prompt": "# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# [1, 2, 3]\n# >>> lst\n# []\n# >>> lst\n# [-1, -5, 2, -1, -5]\ndef sum_squares(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_squares\n    candidate = method(:sum_squares)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(14, candidate.call([1, 4, 9]))\n    assert_equal(0, candidate.call([]))\n    assert_equal(9, candidate.call([1, 1, 1, 1, 1, 1, 1, 1, 1]))\n    assert_equal(-3, candidate.call([-1, -1, -1, -1, -1, -1, -1, -1, -1]))\n    assert_equal(0, candidate.call([0]))\n    assert_equal(-126, candidate.call([-1, -5, 2, -1, -5]))\n    assert_equal(3030, candidate.call([-56, -99, 1, 0, -2]))\n    assert_equal(0, candidate.call([-1, 0, 0, 0, 0, 0, 0, 0, -1]))\n    assert_equal(-14196, candidate.call([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]))\n    assert_equal(-1448, candidate.call([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rb",
+    "prompt": "# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> words_in_sentence.call(\"This is a test\")\n# \"is\"\n# Example 2:\n# >>> words_in_sentence.call(\"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\ndef words_in_sentence(sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_words_in_sentence\n    candidate = method(:words_in_sentence)\n    assert_equal(\"is\", candidate.call(\"This is a test\"))\n    assert_equal(\"go for\", candidate.call(\"lets go for swimming\"))\n    assert_equal(\"there is no place\", candidate.call(\"there is no place available here\"))\n    assert_equal(\"Hi am Hussein\", candidate.call(\"Hi I am Hussein\"))\n    assert_equal(\"go for it\", candidate.call(\"go for it\"))\n    assert_equal(\"\", candidate.call(\"here\"))\n    assert_equal(\"is\", candidate.call(\"here is\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rb",
+    "prompt": "# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> simplify.call(\"1/5\", \"5/1\")\n# true\n# >>> simplify.call(\"1/6\", \"2/1\")\n# false\n# >>> simplify.call(\"7/10\", \"10/2\")\n# false\ndef simplify(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_simplify\n    candidate = method(:simplify)\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/6\", \"2/1\"))\n    assert_equal(true, candidate.call(\"5/1\", \"3/1\"))\n    assert_equal(false, candidate.call(\"7/10\", \"10/2\"))\n    assert_equal(true, candidate.call(\"2/10\", \"50/10\"))\n    assert_equal(true, candidate.call(\"7/2\", \"4/2\"))\n    assert_equal(true, candidate.call(\"11/6\", \"6/1\"))\n    assert_equal(false, candidate.call(\"2/3\", \"5/2\"))\n    assert_equal(false, candidate.call(\"5/2\", \"3/5\"))\n    assert_equal(true, candidate.call(\"2/4\", \"8/4\"))\n    assert_equal(true, candidate.call(\"2/4\", \"4/2\"))\n    assert_equal(true, candidate.call(\"1/5\", \"5/1\"))\n    assert_equal(false, candidate.call(\"1/5\", \"1/5\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rb",
+    "prompt": "# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points.call([1, 11, -1, -11, -12])\n# [-1, -11, 1, -12, 11]\n# >>> order_by_points.call([])\n# []\ndef order_by_points(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_order_by_points\n    candidate = method(:order_by_points)\n    assert_equal([-1, -11, 1, -12, 11], candidate.call([1, 11, -1, -11, -12]))\n    assert_equal([0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457], candidate.call([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]))\n    assert_equal([], candidate.call([]))\n    assert_equal([-3, -32, -98, -11, 1, 2, 43, 54], candidate.call([1, -11, -32, 43, 54, -98, 2, -3]))\n    assert_equal([1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))\n    assert_equal([-76, -21, 0, 4, 23, 6, 6], candidate.call([0, 6, 6, -76, -21, 23, 4]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2254,7 +769,7 @@
     "language": "rb",
     "prompt": "# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> specialFilter.call([15, -73, 14, -15])\n# 1\n# >>> specialFilter.call([33, -2, -3, 45, 21, 109])\n# 2\ndef specialFilter(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_specialFilter\n    candidate = method(:specialFilter)\n    assert_equal(0, candidate.call([5, -2, 1, -5]))\n    assert_equal(1, candidate.call([15, -73, 14, -15]))\n    assert_equal(2, candidate.call([33, -2, -3, 45, 21, 109]))\n    assert_equal(4, candidate.call([43, -12, 93, 125, 121, 109]))\n    assert_equal(3, candidate.call([71, -2, -33, 75, 21, 19]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(0, candidate.call([]))\n  end\nend\n",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rb",
-    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n.call(30)\n# 465\n# >>> sum_to_n.call(100)\n# 5050\n# >>> sum_to_n.call(5)\n# 15\n# >>> sum_to_n.call(10)\n# 55\n# >>> sum_to_n.call(1)\n# 1\ndef sum_to_n(n)\n",
+    "prompt": "# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> get_max_triples.call(5)\n# 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\ndef get_max_triples(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_triples\n    candidate = method(:get_max_triples)\n    assert_equal(1, candidate.call(5))\n    assert_equal(4, candidate.call(6))\n    assert_equal(36, candidate.call(10))\n    assert_equal(53361, candidate.call(100))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rb",
-    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates.call([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
+    "prompt": "# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> bf.call(\"Jupiter\", \"Neptune\")\n# [\"Saturn\", \"Uranus\"]\n# >>> bf.call(\"Earth\", \"Mercury\")\n# \"Venus\"\n# >>> bf.call(\"Mercury\", \"Uranus\")\n# [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"]\ndef bf(planet1, planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bf\n    candidate = method(:bf)\n    assert_equal([\"Saturn\", \"Uranus\"], candidate.call(\"Jupiter\", \"Neptune\"))\n    assert_equal([\"Venus\"], candidate.call(\"Earth\", \"Mercury\"))\n    assert_equal([\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"], candidate.call(\"Mercury\", \"Uranus\"))\n    assert_equal([\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"], candidate.call(\"Neptune\", \"Venus\"))\n    assert_equal([], candidate.call(\"Earth\", \"Earth\"))\n    assert_equal([], candidate.call(\"Mars\", \"Earth\"))\n    assert_equal([], candidate.call(\"Jupiter\", \"Makemake\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> list_sort.call([\"aa\", \"a\", \"aaa\"])\n# [\"aa\"]\n# >>> list_sort.call([\"ab\", \"a\", \"aaa\", \"cd\"])\n# [\"ab\", \"cd\"]\ndef sorted_list_sum(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sorted_list_sum\n    candidate = method(:sorted_list_sum)\n    assert_equal([\"aa\"], candidate.call([\"aa\", \"a\", \"aaa\"]))\n    assert_equal([\"AI\", \"asdf\", \"school\"], candidate.call([\"school\", \"AI\", \"asdf\", \"b\"]))\n    assert_equal([], candidate.call([\"d\", \"b\", \"c\", \"a\"]))\n    assert_equal([\"abcd\", \"dcba\"], candidate.call([\"d\", \"dcba\", \"abcd\", \"a\"]))\n    assert_equal([\"AI\", \"ai\", \"au\"], candidate.call([\"AI\", \"ai\", \"au\"]))\n    assert_equal([], candidate.call([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]))\n    assert_equal([\"cc\", \"dd\", \"aaaa\", \"bbbb\"], candidate.call([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rb",
+    "prompt": "# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes.call(\"abc\")\n# [\"a\", \"ab\", \"abc\"]\ndef all_prefixes(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_prefixes\n    candidate = method(:all_prefixes)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"], candidate.call(\"asdfgh\"))\n    assert_equal([\"W\", \"WW\", \"WWW\"], candidate.call(\"WWW\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rb",
+    "prompt": "# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> x_or_y.call(7, 34, 12)\n# 34\n# >>> x_or_y.call(15, 8, 5)\n# 5\ndef x_or_y(n, x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_x_or_y\n    candidate = method(:x_or_y)\n    assert_equal(34, candidate.call(7, 34, 12))\n    assert_equal(5, candidate.call(15, 8, 5))\n    assert_equal(33, candidate.call(3, 33, 5212))\n    assert_equal(3, candidate.call(1259, 3, 52))\n    assert_equal(-1, candidate.call(7919, -1, 12))\n    assert_equal(583, candidate.call(3609, 1245, 583))\n    assert_equal(129, candidate.call(91, 56, 129))\n    assert_equal(1234, candidate.call(6, 34, 1234))\n    assert_equal(0, candidate.call(1, 2, 0))\n    assert_equal(2, candidate.call(2, 2, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rb",
+    "prompt": "# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> double_the_difference.call([1, 3, 2, 0])\n# 10\n# >>> double_the_difference.call([-1, -2, 0])\n# 0\n# >>> double_the_difference.call([9, -2])\n# 81\n# >>> double_the_difference.call([0])\n# 0\n# If the input list is empty, return 0.\ndef double_the_difference(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_double_the_difference\n    candidate = method(:double_the_difference)\n    assert_equal(0, candidate.call([]))\n    assert_equal(25, candidate.call([5.0, 4.0]))\n    assert_equal(0, candidate.call([0.1, 0.2, 0.3]))\n    assert_equal(0, candidate.call([-10.0, -20.0, -30.0]))\n    assert_equal(0, candidate.call([-1.0, -2.0, 8.0]))\n    assert_equal(34, candidate.call([0.2, 3.0, 5.0]))\n    assert_equal(165, candidate.call([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rb",
+    "prompt": "# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> compare.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n# [0, 0, 0, 0, 3, 3]\n# >>> compare.call([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n# [4, 4, 1, 0, 0, 6]\ndef compare(game, guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_compare\n    candidate = method(:compare)\n    assert_equal([0, 0, 0, 0, 3, 3], candidate.call([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]))\n    assert_equal([0, 0, 0, 0, 0, 0], candidate.call([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]))\n    assert_equal([2, 4, 6], candidate.call([1, 2, 3], [-1, -2, -3]))\n    assert_equal([2, 0, 0, 1], candidate.call([1, 2, 3, 5], [-1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rb",
+    "prompt": "# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> Strongest_Extension.call(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n# \"my_class.AA\"\ndef Strongest_Extension(class_name, extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Strongest_Extension\n    candidate = method(:Strongest_Extension)\n    assert_equal(\"Watashi.eIGHt8OKe\", candidate.call(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]))\n    assert_equal(\"Boku123.YEs.WeCaNe\", candidate.call(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]))\n    assert_equal(\"__YESIMHERE.NuLl__\", candidate.call(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]))\n    assert_equal(\"K.TAR\", candidate.call(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]))\n    assert_equal(\"__HAHA.123\", candidate.call(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]))\n    assert_equal(\"YameRore.okIWILL123\", candidate.call(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]))\n    assert_equal(\"finNNalLLly.WoW\", candidate.call(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]))\n    assert_equal(\"_.Bb\", candidate.call(\"_\", [\"Bb\", \"91245\"]))\n    assert_equal(\"Sp.671235\", candidate.call(\"Sp\", [\"671235\", \"Bb\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rb",
+    "prompt": "# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> cycpattern_check.call(\"abcd\", \"abd\")\n# false\n# >>> cycpattern_check.call(\"hello\", \"ell\")\n# true\n# >>> cycpattern_check.call(\"whassup\", \"psus\")\n# false\n# >>> cycpattern_check.call(\"abab\", \"baa\")\n# true\n# >>> cycpattern_check.call(\"efef\", \"eeff\")\n# false\n# >>> cycpattern_check.call(\"himenss\", \"simen\")\n# true\ndef cycpattern_check(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cycpattern_check\n    candidate = method(:cycpattern_check)\n    assert_equal(false, candidate.call(\"xyzw\", \"xyw\"))\n    assert_equal(true, candidate.call(\"yello\", \"ell\"))\n    assert_equal(false, candidate.call(\"whattup\", \"ptut\"))\n    assert_equal(true, candidate.call(\"efef\", \"fee\"))\n    assert_equal(false, candidate.call(\"abab\", \"aabb\"))\n    assert_equal(true, candidate.call(\"winemtt\", \"tinem\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rb",
+    "prompt": "# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> even_odd_count.call(-12)\n# [1, 1]\n# >>> even_odd_count.call(123)\n# [1, 2]\ndef even_odd_count(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_odd_count\n    candidate = method(:even_odd_count)\n    assert_equal([0, 1], candidate.call(7))\n    assert_equal([1, 1], candidate.call(-78))\n    assert_equal([2, 2], candidate.call(3452))\n    assert_equal([3, 3], candidate.call(346211))\n    assert_equal([3, 3], candidate.call(-345821))\n    assert_equal([1, 0], candidate.call(-2))\n    assert_equal([2, 3], candidate.call(-45347))\n    assert_equal([1, 0], candidate.call(0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rb",
+    "prompt": "# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman.call(19)\n# \"xix\"\n# >>> int_to_mini_roman.call(152)\n# \"clii\"\n# >>> int_to_mini_roman.call(426)\n# \"cdxxvi\"\ndef int_to_mini_roman(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_int_to_mini_roman\n    candidate = method(:int_to_mini_roman)\n    assert_equal(\"xix\", candidate.call(19))\n    assert_equal(\"clii\", candidate.call(152))\n    assert_equal(\"ccli\", candidate.call(251))\n    assert_equal(\"cdxxvi\", candidate.call(426))\n    assert_equal(\"d\", candidate.call(500))\n    assert_equal(\"i\", candidate.call(1))\n    assert_equal(\"iv\", candidate.call(4))\n    assert_equal(\"xliii\", candidate.call(43))\n    assert_equal(\"xc\", candidate.call(90))\n    assert_equal(\"xciv\", candidate.call(94))\n    assert_equal(\"dxxxii\", candidate.call(532))\n    assert_equal(\"cm\", candidate.call(900))\n    assert_equal(\"cmxciv\", candidate.call(994))\n    assert_equal(\"m\", candidate.call(1000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> right_angle_triangle.call(3, 4, 5)\n# true\n# >>> right_angle_triangle.call(1, 2, 3)\n# false\ndef right_angle_triangle(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_angle_triangle\n    candidate = method(:right_angle_triangle)\n    assert_equal(true, candidate.call(3, 4, 5))\n    assert_equal(false, candidate.call(1, 2, 3))\n    assert_equal(true, candidate.call(10, 6, 8))\n    assert_equal(false, candidate.call(2, 2, 2))\n    assert_equal(true, candidate.call(7, 24, 25))\n    assert_equal(false, candidate.call(10, 5, 7))\n    assert_equal(true, candidate.call(5, 12, 13))\n    assert_equal(true, candidate.call(15, 8, 17))\n    assert_equal(true, candidate.call(48, 55, 73))\n    assert_equal(false, candidate.call(1, 1, 1))\n    assert_equal(false, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rb",
+    "prompt": "# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> find_max.call([\"name\", \"of\", \"string\"])\n# \"string\"\n# >>> find_max.call([\"name\", \"enam\", \"game\"])\n# \"enam\"\n# >>> find_max.call([\"aaaaaaa\", \"bb\", \"cc\"])\n# \"aaaaaaa\"\ndef find_max(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_max\n    candidate = method(:find_max)\n    assert_equal(\"string\", candidate.call([\"name\", \"of\", \"string\"]))\n    assert_equal(\"enam\", candidate.call([\"name\", \"enam\", \"game\"]))\n    assert_equal(\"aaaaaaa\", candidate.call([\"aaaaaaa\", \"bb\", \"cc\"]))\n    assert_equal(\"abc\", candidate.call([\"abc\", \"cba\"]))\n    assert_equal(\"footbott\", candidate.call([\"play\", \"this\", \"game\", \"of\", \"footbott\"]))\n    assert_equal(\"gonna\", candidate.call([\"we\", \"are\", \"gonna\", \"rock\"]))\n    assert_equal(\"nation\", candidate.call([\"we\", \"are\", \"a\", \"mad\", \"nation\"]))\n    assert_equal(\"this\", candidate.call([\"this\", \"is\", \"a\", \"prrk\"]))\n    assert_equal(\"b\", candidate.call([\"b\"]))\n    assert_equal(\"play\", candidate.call([\"play\", \"play\", \"play\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rb",
+    "prompt": "# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> eat.call(5, 6, 10)\n# [11, 4]\n# >>> eat.call(4, 8, 9)\n# [12, 1]\n# >>> eat.call(1, 10, 10)\n# [11, 0]\n# >>> eat.call(2, 11, 5)\n# [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\ndef eat(number, need, remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eat\n    candidate = method(:eat)\n    assert_equal([11, 4], candidate.call(5, 6, 10))\n    assert_equal([12, 1], candidate.call(4, 8, 9))\n    assert_equal([11, 0], candidate.call(1, 10, 10))\n    assert_equal([7, 0], candidate.call(2, 11, 5))\n    assert_equal([9, 2], candidate.call(4, 5, 7))\n    assert_equal([5, 0], candidate.call(4, 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rb",
+    "prompt": "# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence.call(0)\n# \"0\"\n# >>> string_sequence.call(5)\n# \"0 1 2 3 4 5\"\ndef string_sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_sequence\n    candidate = method(:string_sequence)\n    assert_equal(\"0\", candidate.call(0))\n    assert_equal(\"0 1 2 3\", candidate.call(3))\n    assert_equal(\"0 1 2 3 4 5 6 7 8 9 10\", candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rb",
+    "prompt": "# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\ndef do_algebra(operator, operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_do_algebra\n    candidate = method(:do_algebra)\n    assert_equal(37, candidate.call([\"**\", \"*\", \"+\"], [2, 3, 4, 5]))\n    assert_equal(9, candidate.call([\"+\", \"*\", \"-\"], [2, 3, 4, 5]))\n    assert_equal(8, candidate.call([\"//\", \"*\"], [7, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> solve.call(\"1234\")\n# \"4321\"\n# >>> solve.call(\"ab\")\n# \"AB\"\n# >>> solve.call(\"#a@C\")\n# \"#A@c\"\ndef solve(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"aSdF\", candidate.call(\"AsDf\"))\n    assert_equal(\"4321\", candidate.call(\"1234\"))\n    assert_equal(\"AB\", candidate.call(\"ab\"))\n    assert_equal(\"#A@c\", candidate.call(\"#a@C\"))\n    assert_equal(\"#aSDFw^45\", candidate.call(\"#AsdfW^45\"))\n    assert_equal(\"2@6#\", candidate.call(\"#6@2\"))\n    assert_equal(\"#$A^d\", candidate.call(\"#$a^D\"))\n    assert_equal(\"#CCC\", candidate.call(\"#ccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rb",
+    "prompt": "# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5.call(\"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\ndef string_to_md5(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_md5\n    candidate = method(:string_to_md5)\n    assert_equal(\"3e25960a79dbc69b674cd4ec67a72c62\", candidate.call(\"Hello world\"))\n    assert_equal(nil, candidate.call(\"\"))\n    assert_equal(\"0ef78513b0cb8cef12743f5aeb35f888\", candidate.call(\"A B C\"))\n    assert_equal(\"5f4dcc3b5aa765d61d8327deb882cf99\", candidate.call(\"password\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2299,7 +1054,7 @@
     "language": "rb",
     "prompt": "# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> generate_integers.call(2, 8)\n# [2, 4, 6, 8]\n# >>> generate_integers.call(8, 2)\n# [2, 4, 6, 8]\n# >>> generate_integers.call(10, 14)\n# []\ndef generate_integers(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_generate_integers\n    candidate = method(:generate_integers)\n    assert_equal([2, 4, 6, 8], candidate.call(2, 10))\n    assert_equal([2, 4, 6, 8], candidate.call(10, 2))\n    assert_equal([2, 4, 6, 8], candidate.call(132, 2))\n    assert_equal([], candidate.call(17, 89))\n  end\nend\n",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rb",
-    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max.call([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
+    "prompt": "# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters.call(\"xyzXYZ\")\n# 3\n# >>> count_distinct_characters.call(\"Jerry\")\n# 4\ndef count_distinct_characters(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_distinct_characters\n    candidate = method(:count_distinct_characters)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(5, candidate.call(\"abcde\"))\n    assert_equal(5, candidate.call(\"abcdecadeCADE\"))\n    assert_equal(1, candidate.call(\"aaaaAAAAaaaa\"))\n    assert_equal(5, candidate.call(\"Jerry jERRY JeRRRY\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rb",
-    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero.call([1, 2, 3])\n# false\n# >>> below_zero.call([1, 2, -4, 5])\n# true\ndef below_zero(operations)\n",
+    "prompt": "# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music.call(\"o o| .| o| o| .| .| .| .| o o\")\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\ndef parse_music(music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_music\n    candidate = method(:parse_music)\n    assert_equal([], candidate.call(\"\"))\n    assert_equal([4, 4, 4, 4], candidate.call(\"o o o o\"))\n    assert_equal([1, 1, 1, 1], candidate.call(\".| .| .| .|\"))\n    assert_equal([2, 2, 1, 1, 4, 4, 4, 4], candidate.call(\"o| o| .| .| o o o o\"))\n    assert_equal([2, 1, 2, 1, 4, 2, 4, 2], candidate.call(\"o| .| o| .| o o| o o|\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rb",
-    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search.call([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search.call([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search.call([5, 5, 4, 4, 4])\n# -1\ndef search(lst)\n",
+    "prompt": "# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times.call(\"\", \"a\")\n# 0\n# >>> how_many_times.call(\"aaa\", \"a\")\n# 3\n# >>> how_many_times.call(\"aaaa\", \"aa\")\n# 3\ndef how_many_times(string, substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_how_many_times\n    candidate = method(:how_many_times)\n    assert_equal(0, candidate.call(\"\", \"x\"))\n    assert_equal(4, candidate.call(\"xyxyxyx\", \"x\"))\n    assert_equal(4, candidate.call(\"cacacacac\", \"cac\"))\n    assert_equal(1, candidate.call(\"john doe\", \"john\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rb",
-    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"(\")\n# false\n# >>> correct_bracketing.call(\"()\")\n# true\n# >>> correct_bracketing.call(\"(()())\")\n# true\n# >>> correct_bracketing.call(\")(()\")\n# false\ndef correct_bracketing(brackets)\n",
+    "prompt": "# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers.call(\"three one five\")\n# \"one three five\"\ndef sort_numbers(numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numbers\n    candidate = method(:sort_numbers)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"three\", candidate.call(\"three\"))\n    assert_equal(\"three five nine\", candidate.call(\"three five nine\"))\n    assert_equal(\"zero four five seven eight nine\", candidate.call(\"five zero four seven nine eight\"))\n    assert_equal(\"zero one two three four five six\", candidate.call(\"six five four three two one zero\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rb",
+    "prompt": "# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups.call(\"( ) (( )) (( )( ))\")\n# [\"()\", \"(())\", \"(()())\"]\ndef separate_paren_groups(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_separate_paren_groups\n    candidate = method(:separate_paren_groups)\n    assert_equal([\"(()())\", \"((()))\", \"()\", \"((())()())\"], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([\"()\", \"(())\", \"((()))\", \"(((())))\"], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([\"(()(())((())))\"], candidate.call(\"(()(())((())))\"))\n    assert_equal([\"()\", \"(())\", \"(()())\"], candidate.call(\"( ) (( )) (( )( ))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rb",
+    "prompt": "# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# [2.0, 2.2]\n# >>> find_closest_elements.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# [2.0, 2.0]\ndef find_closest_elements(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_closest_elements\n    candidate = method(:find_closest_elements)\n    assert_equal([3.9, 4.0], candidate.call([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]))\n    assert_equal([5.0, 5.9], candidate.call([1.0, 2.0, 5.9, 4.0, 5.0]))\n    assert_equal([2.0, 2.2], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]))\n    assert_equal([2.0, 2.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]))\n    assert_equal([2.2, 3.1], candidate.call([1.1, 2.2, 3.1, 4.1, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rb",
+    "prompt": "# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit.call([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\ndef rescale_to_unit(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rescale_to_unit\n    candidate = method(:rescale_to_unit)\n    assert_equal([0.0, 1.0], candidate.call([2.0, 49.9]))\n    assert_equal([1.0, 0.0], candidate.call([100.0, 49.9]))\n    assert_equal([0.0, 0.25, 0.5, 0.75, 1.0], candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([2.0, 1.0, 5.0, 3.0, 4.0]))\n    assert_equal([0.25, 0.0, 1.0, 0.5, 0.75], candidate.call([12.0, 11.0, 15.0, 13.0, 14.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rb",
+    "prompt": "# Filter given list of any python values only for integers\n# >>> filter_integers.call([\"a\", 3.14, 5])\n# [5]\n# >>> filter_integers.call([1, 2, 3, \"abc\", {}, []])\n# [1, 2, 3]\ndef filter_integers(values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_integers\n    candidate = method(:filter_integers)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 9], candidate.call([4, {}, [], 23.2, 9, \"adasd\"]))\n    assert_equal([3, 3, 3], candidate.call([3, \"c\", 3, 3, \"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rb",
+    "prompt": "# Return length of given string\n# >>> strlen.call(\"\")\n# 0\n# >>> strlen.call(\"abc\")\n# 3\ndef strlen(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strlen\n    candidate = method(:strlen)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(1, candidate.call(\"x\"))\n    assert_equal(9, candidate.call(\"asdasnakj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rb",
+    "prompt": "# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor.call(15)\n# 5\ndef largest_divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_divisor\n    candidate = method(:largest_divisor)\n    assert_equal(1, candidate.call(3))\n    assert_equal(1, candidate.call(7))\n    assert_equal(5, candidate.call(10))\n    assert_equal(50, candidate.call(100))\n    assert_equal(7, candidate.call(49))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rb",
+    "prompt": "# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize.call(8)\n# [2, 2, 2]\n# >>> factorize.call(25)\n# [5, 5]\n# >>> factorize.call(70)\n# [2, 5, 7]\ndef factorize(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_factorize\n    candidate = method(:factorize)\n    assert_equal([2], candidate.call(2))\n    assert_equal([2, 2], candidate.call(4))\n    assert_equal([2, 2, 2], candidate.call(8))\n    assert_equal([3, 19], candidate.call(57))\n    assert_equal([3, 3, 19, 19], candidate.call(3249))\n    assert_equal([3, 3, 3, 19, 19, 19], candidate.call(185193))\n    assert_equal([3, 19, 19, 19], candidate.call(20577))\n    assert_equal([2, 3, 3], candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rb",
+    "prompt": "# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates.call([1, 2, 3, 2, 4])\n# [1, 3, 4]\ndef remove_duplicates(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_duplicates\n    candidate = method(:remove_duplicates)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 4, 3, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rb",
+    "prompt": "# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case.call(\"Hello\")\n# \"hELLO\"\ndef flip_case(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flip_case\n    candidate = method(:flip_case)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"hELLO!\", candidate.call(\"Hello!\"))\n    assert_equal(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\", candidate.call(\"These violent delights have violent ends\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rb",
+    "prompt": "# Concatenate list of strings into a single string\n# >>> concatenate.call([])\n# \"\"\n# >>> concatenate.call([\"a\", \"b\", \"c\"])\n# \"abc\"\ndef concatenate(strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate\n    candidate = method(:concatenate)\n    assert_equal(\"\", candidate.call([]))\n    assert_equal(\"xyz\", candidate.call([\"x\", \"y\", \"z\"]))\n    assert_equal(\"xyzwk\", candidate.call([\"x\", \"y\", \"z\", \"w\", \"k\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that start with a given prefix.\n# >>> filter_by_prefix.call([], \"a\")\n# []\n# >>> filter_by_prefix.call([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"array\"]\ndef filter_by_prefix(strings, prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_prefix\n    candidate = method(:filter_by_prefix)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rb",
+    "prompt": "# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number.call(3.5)\n# 0.5\ndef truncate_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_truncate_number\n    candidate = method(:truncate_number)\n    assert_equal(0.5, candidate.call(3.5))\n    assert_equal(0.25, candidate.call(1.25))\n    assert_equal(0.0, candidate.call(123.0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rb",
+    "prompt": "# Return only positive numbers in the list.\n# >>> get_positive.call([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\ndef get_positive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_positive\n    candidate = method(:get_positive)\n    assert_equal([4, 5, 6], candidate.call([-1, -2, 4, 5, 6]))\n    assert_equal([5, 3, 2, 3, 3, 9, 123, 1], candidate.call([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([], candidate.call([-1, -2]))\n    assert_equal([], candidate.call([]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rb",
+    "prompt": "# Return true if a given number is prime, and false otherwise.\n# >>> is_prime.call(6)\n# false\n# >>> is_prime.call(101)\n# true\n# >>> is_prime.call(11)\n# true\n# >>> is_prime.call(13441)\n# true\n# >>> is_prime.call(61)\n# true\n# >>> is_prime.call(4)\n# false\n# >>> is_prime.call(1)\n# false\ndef is_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_prime\n    candidate = method(:is_prime)\n    assert_equal(false, candidate.call(6))\n    assert_equal(true, candidate.call(101))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(13441))\n    assert_equal(true, candidate.call(61))\n    assert_equal(false, candidate.call(4))\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(5))\n    assert_equal(true, candidate.call(11))\n    assert_equal(true, candidate.call(17))\n    assert_equal(false, candidate.call(85))\n    assert_equal(false, candidate.call(77))\n    assert_equal(false, candidate.call(255379))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rb",
+    "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third.call([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\ndef sort_third(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_third\n    candidate = method(:sort_third)\n    assert_equal([2, 6, 3, 4, 8, 9, 5], candidate.call([5, 6, 3, 4, 8, 9, 2]))\n    assert_equal([2, 8, 3, 4, 6, 9, 5], candidate.call([5, 8, 3, 4, 6, 9, 2]))\n    assert_equal([2, 6, 9, 4, 8, 3, 5], candidate.call([5, 6, 9, 4, 8, 3, 2]))\n    assert_equal([2, 6, 3, 4, 8, 9, 5, 1], candidate.call([5, 6, 3, 4, 8, 9, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rb",
+    "prompt": "# Return sorted unique elements in a list\n# >>> unique.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\ndef unique(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique\n    candidate = method(:unique)\n    assert_equal([0, 2, 3, 5, 9, 123], candidate.call([5, 3, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rb",
+    "prompt": "# Return maximum element in the list.\n# >>> max_element.call([1, 2, 3])\n# 3\n# >>> max_element.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\ndef max_element(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_element\n    candidate = method(:max_element)\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(124, candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rb",
+    "prompt": "# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz.call(50)\n# 0\n# >>> fizz_buzz.call(78)\n# 2\n# >>> fizz_buzz.call(79)\n# 3\ndef fizz_buzz(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fizz_buzz\n    candidate = method(:fizz_buzz)\n    assert_equal(0, candidate.call(50))\n    assert_equal(2, candidate.call(78))\n    assert_equal(3, candidate.call(79))\n    assert_equal(3, candidate.call(100))\n    assert_equal(6, candidate.call(200))\n    assert_equal(192, candidate.call(4000))\n    assert_equal(639, candidate.call(10000))\n    assert_equal(8026, candidate.call(100000))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2374,9 +1399,249 @@
     "language": "rb",
     "prompt": "# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even.call([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even.call([5, 6, 3, 4])\n# [3, 6, 5, 4]\ndef sort_even(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_even\n    candidate = method(:sort_even)\n    assert_equal([1, 2, 3], candidate.call([1, 2, 3]))\n    assert_equal([-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123], candidate.call([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]))\n    assert_equal([-12, 8, 3, 4, 5, 2, 12, 11, 23, -10], candidate.call([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rb",
+    "prompt": "# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib.call(1)\n# 2\n# >>> prime_fib.call(2)\n# 3\n# >>> prime_fib.call(3)\n# 5\n# >>> prime_fib.call(4)\n# 13\n# >>> prime_fib.call(5)\n# 89\ndef prime_fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_fib\n    candidate = method(:prime_fib)\n    assert_equal(2, candidate.call(1))\n    assert_equal(3, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(13, candidate.call(4))\n    assert_equal(89, candidate.call(5))\n    assert_equal(233, candidate.call(6))\n    assert_equal(1597, candidate.call(7))\n    assert_equal(28657, candidate.call(8))\n    assert_equal(514229, candidate.call(9))\n    assert_equal(433494437, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rb",
+    "prompt": "# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero.call([1, 2, 3])\n# false\n# >>> below_zero.call([1, 2, -4, 5])\n# true\ndef below_zero(operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_zero\n    candidate = method(:below_zero)\n    assert_equal(false, candidate.call([]))\n    assert_equal(false, candidate.call([1, 2, -3, 1, 2, -3]))\n    assert_equal(true, candidate.call([1, 2, -4, 5, 6]))\n    assert_equal(false, candidate.call([1, -1, 2, -2, 5, -5, 4, -4]))\n    assert_equal(true, candidate.call([1, -1, 2, -2, 5, -5, 4, -5]))\n    assert_equal(true, candidate.call([1, -2, 2, -2, 5, -5, 4, -4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rb",
+    "prompt": "# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> triples_sum_to_zero.call([1, 3, -2, 1])\n# true\n# >>> triples_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> triples_sum_to_zero.call([2, 4, -5, 3, 9, 7])\n# true\n# >>> triples_sum_to_zero.call([1])\n# false\ndef triples_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triples_sum_to_zero\n    candidate = method(:triples_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, 5, -1]))\n    assert_equal(true, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(false, candidate.call([1, 2, 5, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 9, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(false, candidate.call([1, 3, 5, -100]))\n    assert_equal(false, candidate.call([100, 3, 5, -100]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rb",
+    "prompt": "# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\ndef car_race_collision(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_car_race_collision\n    candidate = method(:car_race_collision)\n    assert_equal(4, candidate.call(2))\n    assert_equal(9, candidate.call(3))\n    assert_equal(16, candidate.call(4))\n    assert_equal(64, candidate.call(8))\n    assert_equal(100, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rb",
+    "prompt": "# Return list with elements incremented by 1.\n# >>> incr_list.call([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list.call([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\ndef incr_list(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_incr_list\n    candidate = method(:incr_list)\n    assert_equal([], candidate.call([]))\n    assert_equal([4, 3, 2], candidate.call([3, 2, 1]))\n    assert_equal([6, 3, 6, 3, 4, 4, 10, 1, 124], candidate.call([5, 2, 5, 2, 3, 3, 9, 0, 123]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rb",
+    "prompt": "# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero.call([1, 3, 5, 0])\n# false\n# >>> pairs_sum_to_zero.call([1, 3, -2, 1])\n# false\n# >>> pairs_sum_to_zero.call([1, 2, 3, 7])\n# false\n# >>> pairs_sum_to_zero.call([2, 4, -5, 3, 5, 7])\n# true\n# >>> pairs_sum_to_zero.call([1])\n# false\ndef pairs_sum_to_zero(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pairs_sum_to_zero\n    candidate = method(:pairs_sum_to_zero)\n    assert_equal(false, candidate.call([1, 3, 5, 0]))\n    assert_equal(false, candidate.call([1, 3, -2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3, 7]))\n    assert_equal(true, candidate.call([2, 4, -5, 3, 5, 7]))\n    assert_equal(false, candidate.call([1]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 30]))\n    assert_equal(true, candidate.call([-3, 9, -1, 3, 2, 31]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 30]))\n    assert_equal(false, candidate.call([-3, 9, -1, 4, 2, 31]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rb",
+    "prompt": "# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base.call(8, 3)\n# \"22\"\n# >>> change_base.call(8, 2)\n# \"1000\"\n# >>> change_base.call(7, 2)\n# \"111\"\ndef change_base(x, base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_base\n    candidate = method(:change_base)\n    assert_equal(\"22\", candidate.call(8, 3))\n    assert_equal(\"100\", candidate.call(9, 3))\n    assert_equal(\"11101010\", candidate.call(234, 2))\n    assert_equal(\"10000\", candidate.call(16, 2))\n    assert_equal(\"1000\", candidate.call(8, 2))\n    assert_equal(\"111\", candidate.call(7, 2))\n    assert_equal(\"2\", candidate.call(2, 3))\n    assert_equal(\"3\", candidate.call(3, 4))\n    assert_equal(\"4\", candidate.call(4, 5))\n    assert_equal(\"5\", candidate.call(5, 6))\n    assert_equal(\"6\", candidate.call(6, 7))\n    assert_equal(\"7\", candidate.call(7, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rb",
+    "prompt": "# Given length of a side and high return area for a triangle.\n# >>> triangle_area.call(5, 3)\n# 7.5\ndef triangle_area(a, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(7.5, candidate.call(5, 3))\n    assert_equal(2.0, candidate.call(2, 2))\n    assert_equal(40.0, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rb",
+    "prompt": "# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4.call(5)\n# 4\n# >>> fib4.call(6)\n# 8\n# >>> fib4.call(7)\n# 14\ndef fib4(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib4\n    candidate = method(:fib4)\n    assert_equal(4, candidate.call(5))\n    assert_equal(28, candidate.call(8))\n    assert_equal(104, candidate.call(10))\n    assert_equal(386, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rb",
+    "prompt": "# Return median of elements in the list l.\n# >>> median.call([3, 1, 2, 4, 5])\n# 3\n# >>> median.call([-10, 4, 6, 1000, 10, 20])\n# 15.0\ndef median(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median\n    candidate = method(:median)\n    assert_equal(3, candidate.call([3, 1, 2, 4, 5]))\n    assert_equal(8.0, candidate.call([-10, 4, 6, 1000, 10, 20]))\n    assert_equal(5, candidate.call([5]))\n    assert_equal(5.5, candidate.call([6, 5]))\n    assert_equal(7, candidate.call([8, 1, 3, 9, 9, 2, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rb",
+    "prompt": "# Checks if given string is a palindrome\n# >>> is_palindrome.call(\"\")\n# true\n# >>> is_palindrome.call(\"aba\")\n# true\n# >>> is_palindrome.call(\"aaaaa\")\n# true\n# >>> is_palindrome.call(\"zbcd\")\n# false\ndef is_palindrome(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_palindrome\n    candidate = method(:is_palindrome)\n    assert_equal(true, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"aba\"))\n    assert_equal(true, candidate.call(\"aaaaa\"))\n    assert_equal(false, candidate.call(\"zbcd\"))\n    assert_equal(true, candidate.call(\"xywyx\"))\n    assert_equal(false, candidate.call(\"xywyz\"))\n    assert_equal(false, candidate.call(\"xywzx\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rb",
+    "prompt": "# Return 2^n modulo p (be aware of numerics).\n# >>> modp.call(3, 5)\n# 3\n# >>> modp.call(1101, 101)\n# 2\n# >>> modp.call(0, 101)\n# 1\n# >>> modp.call(3, 11)\n# 8\n# >>> modp.call(100, 101)\n# 1\ndef modp(n, p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_modp\n    candidate = method(:modp)\n    assert_equal(3, candidate.call(3, 5))\n    assert_equal(2, candidate.call(1101, 101))\n    assert_equal(1, candidate.call(0, 101))\n    assert_equal(8, candidate.call(3, 11))\n    assert_equal(1, candidate.call(100, 101))\n    assert_equal(4, candidate.call(30, 5))\n    assert_equal(3, candidate.call(31, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rb",
+    "prompt": "# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation.call([1.0, 2.0, 3.0, 4.0])\n# 1.0\ndef mean_absolute_deviation(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mean_absolute_deviation\n    candidate = method(:mean_absolute_deviation)\n    assert_equal(0.5, candidate.call([1.0, 2.0]))\n    assert_equal(1.0, candidate.call([1.0, 2.0, 3.0, 4.0]))\n    assert_equal(1.2, candidate.call([1.0, 2.0, 3.0, 4.0, 5.0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rb",
+    "prompt": "# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels.call(\"\")\n# \"\"\n# >>> remove_vowels.call(\"abcdef\")\n# \"bcdf\"\n# >>> remove_vowels.call(\"aaaaa\")\n# \"\"\n# >>> remove_vowels.call(\"aaBAA\")\n# \"B\"\n# >>> remove_vowels.call(\"zbcd\")\n# \"zbcd\"\ndef remove_vowels(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_vowels\n    candidate = method(:remove_vowels)\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\"bcdf\nghjklm\", candidate.call(\"abcdef\nghijklm\"))\n    assert_equal(\"fdcb\", candidate.call(\"fedcba\"))\n    assert_equal(\"\", candidate.call(\"eeeee\"))\n    assert_equal(\"cB\", candidate.call(\"acBAA\"))\n    assert_equal(\"cB\", candidate.call(\"EcBOO\"))\n    assert_equal(\"ybcd\", candidate.call(\"ybcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rb",
+    "prompt": "# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold.call([1, 2, 4, 10], 100)\n# true\n# >>> below_threshold.call([1, 20, 4, 10], 5)\n# false\ndef below_threshold(l, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_below_threshold\n    candidate = method(:below_threshold)\n    assert_equal(true, candidate.call([1, 2, 4, 10], 100))\n    assert_equal(false, candidate.call([1, 20, 4, 10], 5))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 21))\n    assert_equal(true, candidate.call([1, 20, 4, 10], 22))\n    assert_equal(true, candidate.call([1, 8, 4, 10], 11))\n    assert_equal(false, candidate.call([1, 8, 4, 10], 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rb",
+    "prompt": "# Add two numbers x and y\n# >>> add.call(2, 3)\n# 5\n# >>> add.call(5, 7)\n# 12\ndef add(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(1, candidate.call(0, 1))\n    assert_equal(1, candidate.call(1, 0))\n    assert_equal(5, candidate.call(2, 3))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(12, candidate.call(7, 5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2389,9 +1654,24 @@
     "language": "rb",
     "prompt": "# Check if two words have the same characters.\n# >>> same_chars.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n# true\n# >>> same_chars.call(\"abcd\", \"dddddddabc\")\n# true\n# >>> same_chars.call(\"dddddddabc\", \"abcd\")\n# true\n# >>> same_chars.call(\"eabcd\", \"dddddddabc\")\n# false\n# >>> same_chars.call(\"abcd\", \"dddddddabce\")\n# false\n# >>> same_chars.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n# false\ndef same_chars(s0, s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_same_chars\n    candidate = method(:same_chars)\n    assert_equal(true, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"))\n    assert_equal(true, candidate.call(\"abcd\", \"dddddddabc\"))\n    assert_equal(true, candidate.call(\"dddddddabc\", \"abcd\"))\n    assert_equal(false, candidate.call(\"eabcd\", \"dddddddabc\"))\n    assert_equal(false, candidate.call(\"abcd\", \"dddddddabcf\"))\n    assert_equal(false, candidate.call(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"))\n    assert_equal(false, candidate.call(\"aabb\", \"aaccc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rb",
+    "prompt": "# Return n-th Fibonacci number.\n# >>> fib.call(10)\n# 55\n# >>> fib.call(1)\n# 1\n# >>> fib.call(8)\n# 21\ndef fib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fib\n    candidate = method(:fib)\n    assert_equal(55, candidate.call(10))\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(8))\n    assert_equal(89, candidate.call(11))\n    assert_equal(144, candidate.call(12))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -2404,9 +1684,729 @@
     "language": "rb",
     "prompt": "# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"<\")\n# false\n# >>> correct_bracketing.call(\"<>\")\n# true\n# >>> correct_bracketing.call(\"<<><>>\")\n# true\n# >>> correct_bracketing.call(\"><<>\")\n# false\ndef correct_bracketing(brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"<>\"))\n    assert_equal(true, candidate.call(\"<<><>>\"))\n    assert_equal(true, candidate.call(\"<><><<><>><>\"))\n    assert_equal(true, candidate.call(\"<><><<<><><>><>><<><><<>>>\"))\n    assert_equal(false, candidate.call(\"<<<><>>>>\"))\n    assert_equal(false, candidate.call(\"><<>\"))\n    assert_equal(false, candidate.call(\"<\"))\n    assert_equal(false, candidate.call(\"<<<<\"))\n    assert_equal(false, candidate.call(\">\"))\n    assert_equal(false, candidate.call(\"<<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>><<>\"))\n    assert_equal(false, candidate.call(\"<><><<><>><>>><>\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rb",
+    "prompt": "# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic.call([1, 2, 4, 20])\n# true\n# >>> monotonic.call([1, 20, 4, 10])\n# false\n# >>> monotonic.call([4, 1, 0, -10])\n# true\ndef monotonic(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_monotonic\n    candidate = method(:monotonic)\n    assert_equal(true, candidate.call([1, 2, 4, 10]))\n    assert_equal(true, candidate.call([1, 2, 4, 20]))\n    assert_equal(false, candidate.call([1, 20, 4, 10]))\n    assert_equal(true, candidate.call([4, 1, 0, -10]))\n    assert_equal(true, candidate.call([4, 1, 1, 0]))\n    assert_equal(false, candidate.call([1, 2, 3, 2, 5, 60]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 60]))\n    assert_equal(true, candidate.call([9, 9, 9, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rb",
+    "prompt": "# Return sorted unique common elements for two lists.\n# >>> common.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common.call([5, 3, 2, 8], [3, 2])\n# [2, 3]\ndef common(l1, l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common\n    candidate = method(:common)\n    assert_equal([1, 5, 653], candidate.call([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]))\n    assert_equal([2, 3], candidate.call([5, 3, 2, 8], [3, 2]))\n    assert_equal([2, 3, 4], candidate.call([4, 3, 2, 8], [3, 2, 4]))\n    assert_equal([], candidate.call([4, 3, 2, 8], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rb",
+    "prompt": "# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor.call(13195)\n# 29\n# >>> largest_prime_factor.call(2048)\n# 2\ndef largest_prime_factor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_prime_factor\n    candidate = method(:largest_prime_factor)\n    assert_equal(5, candidate.call(15))\n    assert_equal(3, candidate.call(27))\n    assert_equal(7, candidate.call(63))\n    assert_equal(11, candidate.call(330))\n    assert_equal(29, candidate.call(13195))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rb",
+    "prompt": "# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse.call([], 4)\n# []\n# >>> intersperse.call([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\ndef intersperse(numbers, delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersperse\n    candidate = method(:intersperse)\n    assert_equal([], candidate.call([], 7))\n    assert_equal([5, 8, 6, 8, 3, 8, 2], candidate.call([5, 6, 3, 2], 8))\n    assert_equal([2, 2, 2, 2, 2], candidate.call([2, 2, 2], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rb",
+    "prompt": "# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n.call(30)\n# 465\n# >>> sum_to_n.call(100)\n# 5050\n# >>> sum_to_n.call(5)\n# 15\n# >>> sum_to_n.call(10)\n# 55\n# >>> sum_to_n.call(1)\n# 1\ndef sum_to_n(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_to_n\n    candidate = method(:sum_to_n)\n    assert_equal(1, candidate.call(1))\n    assert_equal(21, candidate.call(6))\n    assert_equal(66, candidate.call(11))\n    assert_equal(465, candidate.call(30))\n    assert_equal(5050, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rb",
+    "prompt": "# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing.call(\"(\")\n# false\n# >>> correct_bracketing.call(\"()\")\n# true\n# >>> correct_bracketing.call(\"(()())\")\n# true\n# >>> correct_bracketing.call(\")(()\")\n# false\ndef correct_bracketing(brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_correct_bracketing\n    candidate = method(:correct_bracketing)\n    assert_equal(true, candidate.call(\"()\"))\n    assert_equal(true, candidate.call(\"(()())\"))\n    assert_equal(true, candidate.call(\"()()(()())()\"))\n    assert_equal(true, candidate.call(\"()()((()()())())(()()(()))\"))\n    assert_equal(false, candidate.call(\"((()())))\"))\n    assert_equal(false, candidate.call(\")(()\"))\n    assert_equal(false, candidate.call(\"(\"))\n    assert_equal(false, candidate.call(\"((((\"))\n    assert_equal(false, candidate.call(\")\"))\n    assert_equal(false, candidate.call(\"(()\"))\n    assert_equal(false, candidate.call(\"()()(()())())(()\"))\n    assert_equal(false, candidate.call(\"()()(()())()))()\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rb",
+    "prompt": "# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative.call([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative.call([1, 2, 3])\n# [2, 6]\ndef derivative(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_derivative\n    candidate = method(:derivative)\n    assert_equal([1, 4, 12, 20], candidate.call([3, 1, 2, 4, 5]))\n    assert_equal([2, 6], candidate.call([1, 2, 3]))\n    assert_equal([2, 2], candidate.call([3, 2, 1]))\n    assert_equal([2, 2, 0, 16], candidate.call([3, 2, 1, 0, 4]))\n    assert_equal([], candidate.call([1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rb",
+    "prompt": "# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib.call(1)\n# 0\n# >>> fibfib.call(5)\n# 4\n# >>> fibfib.call(8)\n# 24\ndef fibfib(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fibfib\n    candidate = method(:fibfib)\n    assert_equal(1, candidate.call(2))\n    assert_equal(0, candidate.call(1))\n    assert_equal(4, candidate.call(5))\n    assert_equal(24, candidate.call(8))\n    assert_equal(81, candidate.call(10))\n    assert_equal(274, candidate.call(12))\n    assert_equal(927, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rb",
+    "prompt": "# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count.call(\"abcde\")\n# 2\n# >>> vowels_count.call(\"ACEDY\")\n# 3\ndef vowels_count(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_vowels_count\n    candidate = method(:vowels_count)\n    assert_equal(2, candidate.call(\"abcde\"))\n    assert_equal(3, candidate.call(\"Alone\"))\n    assert_equal(2, candidate.call(\"key\"))\n    assert_equal(1, candidate.call(\"bye\"))\n    assert_equal(2, candidate.call(\"keY\"))\n    assert_equal(1, candidate.call(\"bYe\"))\n    assert_equal(3, candidate.call(\"ACEDY\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rb",
+    "prompt": "# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift.call(12, 1)\n# \"21\"\n# >>> circular_shift.call(12, 2)\n# \"12\"\ndef circular_shift(x, shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_circular_shift\n    candidate = method(:circular_shift)\n    assert_equal(\"001\", candidate.call(100, 2))\n    assert_equal(\"12\", candidate.call(12, 2))\n    assert_equal(\"79\", candidate.call(97, 8))\n    assert_equal(\"21\", candidate.call(12, 1))\n    assert_equal(\"11\", candidate.call(11, 101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rb",
+    "prompt": "# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> digitSum.call(\"\")\n# 0\n# >>> digitSum.call(\"abAB\")\n# 131\n# >>> digitSum.call(\"abcCd\")\n# 67\n# >>> digitSum.call(\"helloE\")\n# 69\n# >>> digitSum.call(\"woArBld\")\n# 131\n# >>> digitSum.call(\"aAaaaXa\")\n# 153\ndef digitSum(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digitSum\n    candidate = method(:digitSum)\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(131, candidate.call(\"abAB\"))\n    assert_equal(67, candidate.call(\"abcCd\"))\n    assert_equal(69, candidate.call(\"helloE\"))\n    assert_equal(131, candidate.call(\"woArBld\"))\n    assert_equal(153, candidate.call(\"aAaaaXa\"))\n    assert_equal(151, candidate.call(\" How are yOu?\"))\n    assert_equal(327, candidate.call(\"You arE Very Smart\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rb",
+    "prompt": "# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> fruit_distribution.call(\"5 apples and 6 oranges\", 19)\n# 8\n# >>> fruit_distribution.call(\"0 apples and 1 oranges\", 3)\n# 2\n# >>> fruit_distribution.call(\"2 apples and 3 oranges\", 100)\n# 95\n# >>> fruit_distribution.call(\"100 apples and 1 oranges\", 120)\n# 19\ndef fruit_distribution(s, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_fruit_distribution\n    candidate = method(:fruit_distribution)\n    assert_equal(8, candidate.call(\"5 apples and 6 oranges\", 19))\n    assert_equal(10, candidate.call(\"5 apples and 6 oranges\", 21))\n    assert_equal(2, candidate.call(\"0 apples and 1 oranges\", 3))\n    assert_equal(2, candidate.call(\"1 apples and 0 oranges\", 3))\n    assert_equal(95, candidate.call(\"2 apples and 3 oranges\", 100))\n    assert_equal(0, candidate.call(\"2 apples and 3 oranges\", 5))\n    assert_equal(19, candidate.call(\"1 apples and 100 oranges\", 120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rb",
+    "prompt": "# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> pluck.call([4, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> pluck.call([1, 2, 3])\n# [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> pluck.call([])\n# []\n# Example 4:\n# >>> pluck.call([5, 0, 3, 0, 4, 2])\n# [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\ndef pluck(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pluck\n    candidate = method(:pluck)\n    assert_equal([2, 1], candidate.call([4, 2, 3]))\n    assert_equal([2, 1], candidate.call([1, 2, 3]))\n    assert_equal([], candidate.call([]))\n    assert_equal([0, 1], candidate.call([5, 0, 3, 0, 4, 2]))\n    assert_equal([0, 3], candidate.call([1, 2, 3, 0, 5, 3]))\n    assert_equal([4, 1], candidate.call([5, 4, 8, 4, 8]))\n    assert_equal([6, 1], candidate.call([7, 6, 7, 1]))\n    assert_equal([], candidate.call([7, 9, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rb",
+    "prompt": "# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> search.call([4, 1, 2, 2, 3, 1])\n# 2\n# >>> search.call([1, 2, 2, 3, 3, 3, 4, 4, 4])\n# 3\n# >>> search.call([5, 5, 4, 4, 4])\n# -1\ndef search(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(1, candidate.call([5, 5, 5, 5, 1]))\n    assert_equal(4, candidate.call([4, 1, 4, 1, 4, 4]))\n    assert_equal(-1, candidate.call([3, 3]))\n    assert_equal(8, candidate.call([8, 8, 8, 8, 8, 8, 8, 8]))\n    assert_equal(2, candidate.call([2, 3, 3, 2, 2]))\n    assert_equal(1, candidate.call([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]))\n    assert_equal(2, candidate.call([3, 2, 8, 2]))\n    assert_equal(1, candidate.call([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]))\n    assert_equal(-1, candidate.call([8, 8, 3, 6, 5, 6, 4]))\n    assert_equal(1, candidate.call([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]))\n    assert_equal(1, candidate.call([1, 9, 10, 1, 3]))\n    assert_equal(5, candidate.call([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]))\n    assert_equal(1, candidate.call([1]))\n    assert_equal(4, candidate.call([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]))\n    assert_equal(2, candidate.call([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]))\n    assert_equal(1, candidate.call([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]))\n    assert_equal(4, candidate.call([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]))\n    assert_equal(4, candidate.call([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]))\n    assert_equal(2, candidate.call([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]))\n    assert_equal(-1, candidate.call([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]))\n    assert_equal(-1, candidate.call([10]))\n    assert_equal(2, candidate.call([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]))\n    assert_equal(1, candidate.call([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]))\n    assert_equal(1, candidate.call([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]))\n    assert_equal(-1, candidate.call([3, 10, 10, 9, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rb",
+    "prompt": "# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens.call(\"(()()) ((())) () ((())()())\")\n# [2, 3, 1, 3]\ndef parse_nested_parens(paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parse_nested_parens\n    candidate = method(:parse_nested_parens)\n    assert_equal([2, 3, 1, 3], candidate.call(\"(()()) ((())) () ((())()())\"))\n    assert_equal([1, 2, 3, 4], candidate.call(\"() (()) ((())) (((())))\"))\n    assert_equal([4], candidate.call(\"(()(())((())))\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rb",
+    "prompt": "# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> strange_sort_list.call([1, 2, 3, 4])\n# [1, 4, 2, 3]\n# >>> strange_sort_list.call([5, 5, 5, 5])\n# [5, 5, 5, 5]\n# >>> strange_sort_list.call([])\n# []\ndef strange_sort_list(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_strange_sort_list\n    candidate = method(:strange_sort_list)\n    assert_equal([1, 4, 2, 3], candidate.call([1, 2, 3, 4]))\n    assert_equal([5, 9, 6, 8, 7], candidate.call([5, 6, 7, 8, 9]))\n    assert_equal([1, 5, 2, 4, 3], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([1, 9, 5, 8, 6, 7], candidate.call([5, 6, 7, 8, 9, 1]))\n    assert_equal([5, 5, 5, 5], candidate.call([5, 5, 5, 5]))\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 8, 2, 7, 3, 6, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8]))\n    assert_equal([-5, 5, -5, 5, 0, 2, 2, 2], candidate.call([0, 2, 2, 2, 5, 5, -5, -5]))\n    assert_equal([111111], candidate.call([111111]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rb",
+    "prompt": "# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> triangle_area.call(3, 4, 5)\n# 6.0\n# >>> triangle_area.call(1, 2, 10)\n# -1\ndef triangle_area(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(6.0, candidate.call(3, 4, 5))\n    assert_equal(-1, candidate.call(1, 2, 10))\n    assert_equal(8.18, candidate.call(4, 8, 5))\n    assert_equal(1.73, candidate.call(2, 2, 2))\n    assert_equal(-1, candidate.call(1, 2, 3))\n    assert_equal(16.25, candidate.call(10, 5, 7))\n    assert_equal(-1, candidate.call(2, 6, 3))\n    assert_equal(0.43, candidate.call(1, 1, 1))\n    assert_equal(-1, candidate.call(2, 2, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rb",
+    "prompt": "# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> will_it_fly.call([1, 2], 5)\n# false\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> will_it_fly.call([3, 2, 3], 1)\n# false\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> will_it_fly.call([3, 2, 3], 9)\n# true\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> will_it_fly.call([3], 5)\n# true\n# # 3 is less than the maximum possible weight, and it's balanced.\ndef will_it_fly(q, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_will_it_fly\n    candidate = method(:will_it_fly)\n    assert_equal(true, candidate.call([3, 2, 3], 9))\n    assert_equal(false, candidate.call([1, 2], 5))\n    assert_equal(true, candidate.call([3], 5))\n    assert_equal(false, candidate.call([3, 2, 3], 1))\n    assert_equal(false, candidate.call([1, 2, 3], 6))\n    assert_equal(true, candidate.call([5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rb",
+    "prompt": "# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> smallest_change.call([1, 2, 3, 5, 4, 7, 9, 6])\n# 4\n# >>> smallest_change.call([1, 2, 3, 4, 3, 2, 2])\n# 1\n# >>> smallest_change.call([1, 2, 3, 2, 1])\n# 0\ndef smallest_change(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_change\n    candidate = method(:smallest_change)\n    assert_equal(4, candidate.call([1, 2, 3, 5, 4, 7, 9, 6]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 3, 2, 2]))\n    assert_equal(1, candidate.call([1, 4, 2]))\n    assert_equal(1, candidate.call([1, 4, 4, 2]))\n    assert_equal(0, candidate.call([1, 2, 3, 2, 1]))\n    assert_equal(0, candidate.call([3, 1, 1, 3]))\n    assert_equal(0, candidate.call([1]))\n    assert_equal(1, candidate.call([0, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rb",
+    "prompt": "# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> total_match.call([], [])\n# []\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n# [\"hI\", \"Hi\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n# [\"hi\", \"admin\"]\n# >>> total_match.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n# [\"hI\", \"hi\", \"hi\"]\n# >>> total_match.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n# [\"4\"]\ndef total_match(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_total_match\n    candidate = method(:total_match)\n    assert_equal([], candidate.call([], []))\n    assert_equal([\"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]))\n    assert_equal([\"4\"], candidate.call([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]))\n    assert_equal([\"hI\", \"Hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"Hi\"]))\n    assert_equal([\"hI\", \"hi\", \"hi\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]))\n    assert_equal([\"hi\", \"admin\"], candidate.call([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]))\n    assert_equal([], candidate.call([], [\"this\"]))\n    assert_equal([], candidate.call([\"this\"], []))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rb",
+    "prompt": "# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> is_multiply_prime.call(30)\n# true\n# 30 = 2 * 3 * 5\ndef is_multiply_prime(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_multiply_prime\n    candidate = method(:is_multiply_prime)\n    assert_equal(false, candidate.call(5))\n    assert_equal(true, candidate.call(30))\n    assert_equal(true, candidate.call(8))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(125))\n    assert_equal(true, candidate.call(105))\n    assert_equal(false, candidate.call(126))\n    assert_equal(false, candidate.call(729))\n    assert_equal(false, candidate.call(891))\n    assert_equal(true, candidate.call(1001))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rb",
+    "prompt": "# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> is_simple_power.call(1, 4)\n# true\n# >>> is_simple_power.call(2, 2)\n# true\n# >>> is_simple_power.call(8, 2)\n# true\n# >>> is_simple_power.call(3, 2)\n# false\n# >>> is_simple_power.call(3, 1)\n# false\n# >>> is_simple_power.call(5, 3)\n# false\ndef is_simple_power(x, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_simple_power\n    candidate = method(:is_simple_power)\n    assert_equal(true, candidate.call(16, 2))\n    assert_equal(false, candidate.call(143214, 16))\n    assert_equal(true, candidate.call(4, 2))\n    assert_equal(true, candidate.call(9, 3))\n    assert_equal(true, candidate.call(16, 4))\n    assert_equal(false, candidate.call(24, 2))\n    assert_equal(false, candidate.call(128, 4))\n    assert_equal(false, candidate.call(12, 6))\n    assert_equal(true, candidate.call(1, 1))\n    assert_equal(true, candidate.call(1, 12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rb",
+    "prompt": "# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> iscube.call(1)\n# true\n# >>> iscube.call(2)\n# false\n# >>> iscube.call(-1)\n# true\n# >>> iscube.call(64)\n# true\n# >>> iscube.call(0)\n# true\n# >>> iscube.call(180)\n# false\ndef iscube(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_iscube\n    candidate = method(:iscube)\n    assert_equal(true, candidate.call(1))\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(-1))\n    assert_equal(true, candidate.call(64))\n    assert_equal(false, candidate.call(180))\n    assert_equal(true, candidate.call(1000))\n    assert_equal(true, candidate.call(0))\n    assert_equal(false, candidate.call(1729))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rb",
+    "prompt": "# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> hex_key.call(\"AB\")\n# 1\n# >>> hex_key.call(\"1077E\")\n# 2\n# >>> hex_key.call(\"ABED1A33\")\n# 4\n# >>> hex_key.call(\"123456789ABCDEF0\")\n# 6\n# >>> hex_key.call(\"2020\")\n# 2\ndef hex_key(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hex_key\n    candidate = method(:hex_key)\n    assert_equal(1, candidate.call(\"AB\"))\n    assert_equal(2, candidate.call(\"1077E\"))\n    assert_equal(4, candidate.call(\"ABED1A33\"))\n    assert_equal(2, candidate.call(\"2020\"))\n    assert_equal(6, candidate.call(\"123456789ABCDEF0\"))\n    assert_equal(12, candidate.call(\"112233445566778899AABBCCDDEEFF00\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> decimal_to_binary.call(15)\n# \"db1111db\"\n# >>> decimal_to_binary.call(32)\n# \"db100000db\"\ndef decimal_to_binary(decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"db0db\", candidate.call(0))\n    assert_equal(\"db100000db\", candidate.call(32))\n    assert_equal(\"db1100111db\", candidate.call(103))\n    assert_equal(\"db1111db\", candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rb",
+    "prompt": "# Filter an input list of strings only for ones that contain given substring\n# >>> filter_by_substring.call([], \"a\")\n# []\n# >>> filter_by_substring.call([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n# [\"abc\", \"bacd\", \"array\"]\ndef filter_by_substring(strings, substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_by_substring\n    candidate = method(:filter_by_substring)\n    assert_equal([], candidate.call([], \"john\"))\n    assert_equal([\"xxx\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"))\n    assert_equal([\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"], candidate.call([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"))\n    assert_equal([\"grunt\", \"prune\"], candidate.call([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rb",
+    "prompt": "# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> is_happy.call(\"a\")\n# false\n# >>> is_happy.call(\"aa\")\n# false\n# >>> is_happy.call(\"abcd\")\n# true\n# >>> is_happy.call(\"aabb\")\n# false\n# >>> is_happy.call(\"adb\")\n# true\n# >>> is_happy.call(\"xyy\")\n# false\ndef is_happy(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_happy\n    candidate = method(:is_happy)\n    assert_equal(false, candidate.call(\"a\"))\n    assert_equal(false, candidate.call(\"aa\"))\n    assert_equal(true, candidate.call(\"abcd\"))\n    assert_equal(false, candidate.call(\"aabb\"))\n    assert_equal(true, candidate.call(\"adb\"))\n    assert_equal(false, candidate.call(\"xyy\"))\n    assert_equal(true, candidate.call(\"iopaxpoi\"))\n    assert_equal(false, candidate.call(\"iopaxioi\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rb",
+    "prompt": "# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> grade_equation.call([4.0, 3, 1.7, 2, 3.5])\n# [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\ndef numerical_letter_grade(grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_numerical_letter_grade\n    candidate = method(:numerical_letter_grade)\n    assert_equal([\"A+\", \"B\", \"C-\", \"C\", \"A-\"], candidate.call([4.0, 3, 1.7, 2, 3.5]))\n    assert_equal([\"D+\"], candidate.call([1.2]))\n    assert_equal([\"D-\"], candidate.call([0.5]))\n    assert_equal([\"E\"], candidate.call([0.0]))\n    assert_equal([\"D\", \"D-\", \"C-\", \"B\", \"B+\"], candidate.call([1.0, 0.3, 1.5, 2.8, 3.3]))\n    assert_equal([\"E\", \"D-\"], candidate.call([0.0, 0.7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> prime_length.call(\"Hello\")\n# true\n# >>> prime_length.call(\"abcdcba\")\n# true\n# >>> prime_length.call(\"kittens\")\n# true\n# >>> prime_length.call(\"orange\")\n# false\ndef prime_length(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_length\n    candidate = method(:prime_length)\n    assert_equal(true, candidate.call(\"Hello\"))\n    assert_equal(true, candidate.call(\"abcdcba\"))\n    assert_equal(true, candidate.call(\"kittens\"))\n    assert_equal(false, candidate.call(\"orange\"))\n    assert_equal(true, candidate.call(\"wow\"))\n    assert_equal(true, candidate.call(\"world\"))\n    assert_equal(true, candidate.call(\"MadaM\"))\n    assert_equal(true, candidate.call(\"Wow\"))\n    assert_equal(false, candidate.call(\"\"))\n    assert_equal(true, candidate.call(\"HI\"))\n    assert_equal(true, candidate.call(\"go\"))\n    assert_equal(false, candidate.call(\"gogo\"))\n    assert_equal(false, candidate.call(\"aaaaaaaaaaaaaaa\"))\n    assert_equal(true, candidate.call(\"Madam\"))\n    assert_equal(false, candidate.call(\"M\"))\n    assert_equal(false, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rb",
+    "prompt": "# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\ndef starts_one_ends(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_starts_one_ends\n    candidate = method(:starts_one_ends)\n    assert_equal(1, candidate.call(1))\n    assert_equal(18, candidate.call(2))\n    assert_equal(180, candidate.call(3))\n    assert_equal(1800, candidate.call(4))\n    assert_equal(18000, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rb",
+    "prompt": "# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> solve.call(1000)\n# \"1\"\n# >>> solve.call(150)\n# \"110\"\n# >>> solve.call(147)\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\ndef solve(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_solve\n    candidate = method(:solve)\n    assert_equal(\"1\", candidate.call(1000))\n    assert_equal(\"110\", candidate.call(150))\n    assert_equal(\"1100\", candidate.call(147))\n    assert_equal(\"1001\", candidate.call(333))\n    assert_equal(\"10010\", candidate.call(963))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rb",
+    "prompt": "# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> add.call([4, 2, 6, 7])\n# 2\ndef add(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add\n    candidate = method(:add)\n    assert_equal(88, candidate.call([4, 88]))\n    assert_equal(122, candidate.call([4, 5, 6, 7, 2, 122]))\n    assert_equal(0, candidate.call([4, 0, 6, 7]))\n    assert_equal(12, candidate.call([4, 4, 6, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rb",
+    "prompt": "# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> anti_shuffle.call(\"Hi\")\n# \"Hi\"\n# >>> anti_shuffle.call(\"hello\")\n# \"ehllo\"\n# >>> anti_shuffle.call(\"Hello World!!!\")\n# \"Hello !!!Wdlor\"\ndef anti_shuffle(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_anti_shuffle\n    candidate = method(:anti_shuffle)\n    assert_equal(\"Hi\", candidate.call(\"Hi\"))\n    assert_equal(\"ehllo\", candidate.call(\"hello\"))\n    assert_equal(\"bemnru\", candidate.call(\"number\"))\n    assert_equal(\"abcd\", candidate.call(\"abcd\"))\n    assert_equal(\"Hello !!!Wdlor\", candidate.call(\"Hello World!!!\"))\n    assert_equal(\"\", candidate.call(\"\"))\n    assert_equal(\".Hi My aemn is Meirst .Rboot How aer ?ouy\", candidate.call(\"Hi. My name is Mister Robot. How are you?\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rb",
+    "prompt": "# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> get_row.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n# [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n# >>> get_row.call([], 1)\n# []\n# >>> get_row.call([[], [1], [1, 2, 3]], 3)\n# [[2, 2]]\ndef get_row(lst, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_row\n    candidate = method(:get_row)\n    assert_equal([[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2))\n    assert_equal([[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]], candidate.call([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1))\n    assert_equal([], candidate.call([], 1))\n    assert_equal([], candidate.call([[1]], 2))\n    assert_equal([[2, 2]], candidate.call([[], [1], [1, 2, 3]], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rb",
+    "prompt": "# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> sort_array.call([])\n# []\n# >>> sort_array.call([5])\n# [5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5])\n# [0, 1, 2, 3, 4, 5]\n# >>> sort_array.call([2, 4, 3, 0, 1, 5, 6])\n# [6, 5, 4, 3, 2, 1, 0]\ndef sort_array(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_array\n    candidate = method(:sort_array)\n    assert_equal([], candidate.call([]))\n    assert_equal([5], candidate.call([5]))\n    assert_equal([0, 1, 2, 3, 4, 5], candidate.call([2, 4, 3, 0, 1, 5]))\n    assert_equal([6, 5, 4, 3, 2, 1, 0], candidate.call([2, 4, 3, 0, 1, 5, 6]))\n    assert_equal([1, 2], candidate.call([2, 1]))\n    assert_equal([0, 11, 15, 32, 42, 87], candidate.call([15, 42, 87, 32, 11, 0]))\n    assert_equal([23, 21, 14, 11], candidate.call([21, 14, 23, 11]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rb",
+    "prompt": "# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> encrypt.call(\"hi\")\n# \"lm\"\n# >>> encrypt.call(\"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> encrypt.call(\"gf\")\n# \"kj\"\n# >>> encrypt.call(\"et\")\n# \"ix\"\ndef encrypt(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encrypt\n    candidate = method(:encrypt)\n    assert_equal(\"lm\", candidate.call(\"hi\"))\n    assert_equal(\"ewhjklnop\", candidate.call(\"asdfghjkl\"))\n    assert_equal(\"kj\", candidate.call(\"gf\"))\n    assert_equal(\"ix\", candidate.call(\"et\"))\n    assert_equal(\"jeiajeaijeiak\", candidate.call(\"faewfawefaewg\"))\n    assert_equal(\"lippsqcjvmirh\", candidate.call(\"hellomyfriend\"))\n    assert_equal(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\", candidate.call(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"))\n    assert_equal(\"e\", candidate.call(\"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rb",
+    "prompt": "# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product.call([])\n# [0, 1]\n# >>> sum_product.call([1, 2, 3, 4])\n# [10, 24]\ndef sum_product(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_product\n    candidate = method(:sum_product)\n    assert_equal([0, 1], candidate.call([]))\n    assert_equal([3, 1], candidate.call([1, 1, 1]))\n    assert_equal([100, 0], candidate.call([100, 0]))\n    assert_equal([15, 105], candidate.call([3, 5, 7]))\n    assert_equal([10, 10], candidate.call([10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> next_smallest.call([1, 2, 3, 4, 5])\n# 2\n# >>> next_smallest.call([5, 1, 4, 3, 2])\n# 2\n# >>> next_smallest.call([])\n# nil\n# >>> next_smallest.call([1, 1])\n# nil\ndef next_smallest(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest\n    candidate = method(:next_smallest)\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(2, candidate.call([5, 1, 4, 3, 2]))\n    assert_equal(nil, candidate.call([]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(1, candidate.call([1, 1, 1, 1, 0]))\n    assert_equal(nil, candidate.call([1, 1]))\n    assert_equal(-35, candidate.call([-35, 34, 12, -45]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rb",
+    "prompt": "# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored.call(\"Hello world\")\n# 0\n# >>> is_bored.call(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\ndef is_bored(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_bored\n    candidate = method(:is_bored)\n    assert_equal(0, candidate.call(\"Hello world\"))\n    assert_equal(0, candidate.call(\"Is the sky blue?\"))\n    assert_equal(1, candidate.call(\"I love It !\"))\n    assert_equal(0, candidate.call(\"bIt\"))\n    assert_equal(2, candidate.call(\"I feel good today. I will be productive. will kill It\"))\n    assert_equal(0, candidate.call(\"You and I are going for a walk\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rb",
+    "prompt": "# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> any_int.call(5, 2, 7)\n# true\n# >>> any_int.call(3, 2, 2)\n# false\n# >>> any_int.call(3, -2, 1)\n# true\n# >>> any_int.call(3.6, -2.2, 2)\n# false\ndef any_int(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_any_int\n    candidate = method(:any_int)\n    assert_equal(true, candidate.call(2, 3, 1))\n    assert_equal(false, candidate.call(2.5, 2, 3))\n    assert_equal(false, candidate.call(1.5, 5, 3.5))\n    assert_equal(false, candidate.call(2, 6, 2))\n    assert_equal(true, candidate.call(4, 2, 2))\n    assert_equal(false, candidate.call(2.2, 2.2, 2.2))\n    assert_equal(true, candidate.call(-4, 6, 2))\n    assert_equal(true, candidate.call(2, 1, 1))\n    assert_equal(true, candidate.call(3, 4, 7))\n    assert_equal(false, candidate.call(3.0, 4, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rb",
+    "prompt": "# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode.call(\"test\")\n# \"TGST\"\n# >>> encode.call(\"This is a message\")\n# \"tHKS KS C MGSSCGG\"\ndef encode(message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_encode\n    candidate = method(:encode)\n    assert_equal(\"tgst\", candidate.call(\"TEST\"))\n    assert_equal(\"mWDCSKR\", candidate.call(\"Mudasir\"))\n    assert_equal(\"ygs\", candidate.call(\"YES\"))\n    assert_equal(\"tHKS KS C MGSSCGG\", candidate.call(\"This is a message\"))\n    assert_equal(\"k dQnT kNqW wHcT Tq wRkTg\", candidate.call(\"I DoNt KnOw WhAt tO WrItE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rb",
+    "prompt": "# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> skjkasdkd.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n# 10\n# >>> skjkasdkd.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n# 25\n# >>> skjkasdkd.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n# 13\n# >>> skjkasdkd.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n# 11\n# >>> skjkasdkd.call([0, 81, 12, 3, 1, 21])\n# 3\n# >>> skjkasdkd.call([0, 8, 1, 2, 1, 7])\n# 7\ndef skjkasdkd(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_skjkasdkd\n    candidate = method(:skjkasdkd)\n    assert_equal(10, candidate.call([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]))\n    assert_equal(25, candidate.call([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]))\n    assert_equal(13, candidate.call([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]))\n    assert_equal(11, candidate.call([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]))\n    assert_equal(3, candidate.call([0, 81, 12, 3, 1, 21]))\n    assert_equal(7, candidate.call([0, 8, 1, 2, 1, 7]))\n    assert_equal(19, candidate.call([8191]))\n    assert_equal(19, candidate.call([8191, 123456, 127, 7]))\n    assert_equal(10, candidate.call([127, 97, 8192]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rb",
+    "prompt": "# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> check_dict_case.call({\"a\" => \"apple\", \"b\" => \"banana\"})\n# true\n# >>> check_dict_case.call({\"a\" => \"apple\", \"A\" => \"banana\", \"B\" => \"banana\"})\n# false\n# >>> check_dict_case.call({\"a\" => \"apple\", 8 => \"banana\", \"a\" => \"apple\"})\n# false\n# >>> check_dict_case.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"})\n# false\n# >>> check_dict_case.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"})\n# true\ndef check_dict_case(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_dict_case\n    candidate = method(:check_dict_case)\n    assert_equal(true, candidate.call({\"p\" => \"pineapple\", \"b\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"A\" => \"banana\", \"B\" => \"banana\"}))\n    assert_equal(false, candidate.call({\"p\" => \"pineapple\", \"5\" => \"banana\", \"a\" => \"apple\"}))\n    assert_equal(false, candidate.call({\"Name\" => \"John\", \"Age\" => \"36\", \"City\" => \"Houston\"}))\n    assert_equal(true, candidate.call({\"STATE\" => \"NC\", \"ZIP\" => \"12345\"}))\n    assert_equal(true, candidate.call({\"fruit\" => \"Orange\", \"taste\" => \"Sweet\"}))\n    assert_equal(false, candidate.call({}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rb",
+    "prompt": "# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> count_up_to.call(5)\n# [2, 3]\n# >>> count_up_to.call(11)\n# [2, 3, 5, 7]\n# >>> count_up_to.call(0)\n# []\n# >>> count_up_to.call(20)\n# [2, 3, 5, 7, 11, 13, 17, 19]\n# >>> count_up_to.call(1)\n# []\n# >>> count_up_to.call(18)\n# [2, 3, 5, 7, 11, 13, 17]\ndef count_up_to(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_up_to\n    candidate = method(:count_up_to)\n    assert_equal([2, 3], candidate.call(5))\n    assert_equal([2, 3, 5], candidate.call(6))\n    assert_equal([2, 3, 5], candidate.call(7))\n    assert_equal([2, 3, 5, 7], candidate.call(10))\n    assert_equal([], candidate.call(0))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19], candidate.call(22))\n    assert_equal([], candidate.call(1))\n    assert_equal([2, 3, 5, 7, 11, 13, 17], candidate.call(18))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43], candidate.call(47))\n    assert_equal([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97], candidate.call(101))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rb",
+    "prompt": "# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> multiply.call(148, 412)\n# 16\n# >>> multiply.call(19, 28)\n# 72\n# >>> multiply.call(2020, 1851)\n# 0\n# >>> multiply.call(14, -15)\n# 20\ndef multiply(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply\n    candidate = method(:multiply)\n    assert_equal(16, candidate.call(148, 412))\n    assert_equal(72, candidate.call(19, 28))\n    assert_equal(0, candidate.call(2020, 1851))\n    assert_equal(20, candidate.call(14, -15))\n    assert_equal(42, candidate.call(76, 67))\n    assert_equal(49, candidate.call(17, 27))\n    assert_equal(0, candidate.call(0, 1))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rb",
+    "prompt": "# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> count_upper.call(\"aBCdEf\")\n# 1\n# >>> count_upper.call(\"abcdefg\")\n# 0\n# >>> count_upper.call(\"dBBE\")\n# 0\ndef count_upper(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_upper\n    candidate = method(:count_upper)\n    assert_equal(1, candidate.call(\"aBCdEf\"))\n    assert_equal(0, candidate.call(\"abcdefg\"))\n    assert_equal(0, candidate.call(\"dBBE\"))\n    assert_equal(0, candidate.call(\"B\"))\n    assert_equal(1, candidate.call(\"U\"))\n    assert_equal(0, candidate.call(\"\"))\n    assert_equal(2, candidate.call(\"EEEE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rb",
+    "prompt": "# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer.call(\"10\")\n# 10\n# >>> closest_integer.call(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\ndef closest_integer(value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_integer\n    candidate = method(:closest_integer)\n    assert_equal(10, candidate.call(\"10\"))\n    assert_equal(15, candidate.call(\"14.5\"))\n    assert_equal(-16, candidate.call(\"-15.5\"))\n    assert_equal(15, candidate.call(\"15.3\"))\n    assert_equal(0, candidate.call(\"0\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rb",
+    "prompt": "# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max.call([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\ndef rolling_max(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rolling_max\n    candidate = method(:rolling_max)\n    assert_equal([], candidate.call([]))\n    assert_equal([1, 2, 3, 4], candidate.call([1, 2, 3, 4]))\n    assert_equal([4, 4, 4, 4], candidate.call([4, 3, 2, 1]))\n    assert_equal([3, 3, 3, 100, 100], candidate.call([3, 2, 3, 100, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/humaneval-rkt-keep.json
+++ b/prompts/humaneval-rkt-keep.json
@@ -1,1257 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; iscube(1) ==> True\n;; iscube(2) ==> False\n;; iscube(-1) ==> True\n;; iscube(64) ==> True\n;; iscube(0) ==> True\n;; iscube(180) ==> False\n(define (iscube a)\n",
+    "prompt": "#lang racket\n\n;; Check if in given list of numbers, are any two numbers closer to each other than\n;; given threshold.\n;; >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n;; False\n;; >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n;; True\n(define (has_close_elements numbers threshold)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> encode('test')\n;; 'TGST'\n;; >>> encode('This is a message')\n;; 'tHKS KS C MGSSCGG'\n(define (encode message)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n;; exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; solution([5, 8, 7, 1]) ==> 12\n;; solution([3, 3, 3, 3, 3]) ==> 9\n;; solution([30, 13, 24, 321]) ==>0\n(define (solution lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> string_sequence(0)\n;; '0'\n;; >>> string_sequence(5)\n;; '0 1 2 3 4 5'\n(define (string_sequence n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n;; minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n;; minSubArraySum([-1, -2, -3]) == -6\n(define (minSubArraySum nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; rounded_avg(1, 5) => \"0b11\"\n;; rounded_avg(7, 5) => -1\n;; rounded_avg(10, 20) => \"0b1111\"\n;; rounded_avg(20, 33) => \"0b11010\"\n(define (rounded_avg n m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> is_bored(\"Hello world\")\n;; 0\n;; >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n(define (get_odd_collatz n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n;; (2.0, 2.2)\n;; >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n;; (2.0, 2.0)\n(define (find_closest_elements numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n;; >>> below_threshold([1, 2, 4, 10], 100)\n;; True\n;; >>> below_threshold([1, 20, 4, 10], 5)\n;; False\n(define (below_threshold l t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; any_int(5, 2, 7) \u279e True\n;; any_int(3, 2, 2) \u279e False\n;; any_int(3, -2, 1) \u279e True\n;; any_int(3.6, -2.2, 2) \u279e False\n(define (any_int x y z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; for x_or_y(7, 34, 12) == 34\n;; for x_or_y(15, 8, 5) == 5\n(define (x_or_y n x y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; move_one_ball([3, 4, 5, 1, 2])==>True\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; move_one_ball([3, 5, 4, 1, 2])==>False\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> closest_integer(\"10\")\n;; 10\n;; >>> closest_integer(\"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> triples_sum_to_zero([1, 3, 5, 0])\n;; False\n;; >>> triples_sum_to_zero([1, 3, -2, 1])\n;; True\n;; >>> triples_sum_to_zero([1, 2, 3, 7])\n;; False\n;; >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n;; True\n;; >>> triples_sum_to_zero([1])\n;; False\n(define (triples_sum_to_zero l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; will_it_fly([1, 2], 5) \u279e False \n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; will_it_fly([3, 2, 3], 1) \u279e False\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; will_it_fly([3, 2, 3], 9) \u279e True\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; will_it_fly([3], 5) \u279e True\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; is_happy(a) => False\n;; is_happy(aa) => False\n;; is_happy(abcd) => True\n;; is_happy(aabb) => False\n;; is_happy(adb) => True\n;; is_happy(xyy) => False\n(define (is_happy s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; file_name_check(\"example.txt\") # => 'Yes'\n;; file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n(define (file_name_check file_name)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n;; histogram('a b b a') == {'a': 2, 'b': 2}\n;; histogram('a b c a b') == {'a': 2, 'b': 2}\n;; histogram('b b b b a') == {'b': 4}\n;; histogram('') == {}\n(define (histogram test)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n;; largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n;; largest_smallest_integers([]) == (None, None)\n;; largest_smallest_integers([0]) == (None, None)\n(define (largest_smallest_integers lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; simplify(\"1/5\", \"5/1\") = True\n;; simplify(\"1/6\", \"2/1\") = False\n;; simplify(\"7/10\", \"10/2\") = False\n(define (simplify x n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; Input: n = 5\n;; Output: 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Task\n;; We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n;; then check if the result string is palindrome.\n;; A string is called palindrome if it reads the same backward as forward.\n;; You should return a tuple containing the result string and True/False for the check.\n;; Example\n;; For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n;; For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n;; For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n(define (reverse_delete s c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_delete))\n    (check-within (candidate \"abcde\" \"ae\") (list \"bcd\" #f) 0.001)\n    (check-within (candidate \"abcdef\" \"b\") (list \"acdef\" #f) 0.001)\n    (check-within (candidate \"abcdedcba\" \"ab\") (list \"cdedc\" #t) 0.001)\n    (check-within (candidate \"dwik\" \"w\") (list \"dik\" #f) 0.001)\n    (check-within (candidate \"a\" \"a\") (list \"\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"v\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"vabba\" \"v\") (list \"abba\" #t) 0.001)\n    (check-within (candidate \"mamma\" \"mia\") (list \"\" #t) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> sum_product([])\n;; (0, 1)\n;; >>> sum_product([1, 2, 3, 4])\n;; (10, 24)\n(define (sum_product numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n;; For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n;; For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n;; For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n;; For lst = [0,81,12,3,1,21] the output should be 3\n;; For lst = [0,8,1,2,1,7] the output should be 7\n(define (skjkasdkd lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> all_prefixes('abc')\n;; ['a', 'ab', 'abc']\n(define (all_prefixes string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; digits(1)  == 1\n;; digits(4)  == 0\n;; digits(235) == 15\n(define (digits n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> strlen('')\n;; 0\n;; >>> strlen('abc')\n;; 3\n(define (strlen string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; Input: [4,2,3]\n;; Output: [2, 1]\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; Input: [1,2,3]\n;; Output: [2, 1]\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index. \n;; Example 3:\n;; Input: []\n;; Output: []\n;; Example 4:\n;; Input: [5, 0, 3, 0, 4, 2]\n;; Output: [0, 1]\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; is_multiply_prime(30) == True\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> fibfib(1)\n;; 0\n;; >>> fibfib(5)\n;; 4\n;; >>> fibfib(8)\n;; 24\n(define (fibfib n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n;; words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n;; words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n(define (words_string s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n;; >>> monotonic([1, 2, 4, 20])\n;; True\n;; >>> monotonic([1, 20, 4, 10])\n;; False\n;; >>> monotonic([4, 1, 0, -10])\n;; True\n(define (monotonic l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; fix_spaces(\"Example\") == \"Example\"\n;; fix_spaces(\"Example 1\") == \"Example_1\"\n;; fix_spaces(\" Example 2\") == \"_Example_2\"\n;; fix_spaces(\" Example   3\") == \"_Example-3\"\n(define (fix_spaces text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n;; cycpattern_check(\"abcd\",\"abd\") => False\n;; cycpattern_check(\"hello\",\"ell\") => True\n;; cycpattern_check(\"whassup\",\"psus\") => False\n;; cycpattern_check(\"abab\",\"baa\") => True\n;; cycpattern_check(\"efef\",\"eeff\") => False\n;; cycpattern_check(\"himenss\",\"simen\") => True\n(define (cycpattern_check a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n;; double_the_difference([-1, -2, 0]) == 0\n;; double_the_difference([9, -2]) == 81\n;; double_the_difference([0]) == 0  \n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> truncate_number(3.5)\n;; 0.5\n(define (truncate_number number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n;; [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n(define (parse_music music_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> remove_vowels('')\n;; ''\n;; >>> remove_vowels('abcdef')\n;; 'bcdf'\n;; >>> remove_vowels('aaaaa')\n;; ''\n;; >>> remove_vowels('aaBAA')\n;; 'B'\n;; >>> remove_vowels('zbcd')\n;; 'zbcd'\n(define (remove_vowels text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> sort_third([1, 2, 3])\n;; [1, 2, 3]\n;; >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n;; [2, 6, 3, 4, 8, 9, 5]\n(define (sort_third l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n;; [0.0, 0.25, 0.5, 0.75, 1.0]\n(define (rescale_to_unit numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; count_up_to(5) => [2,3]\n;; count_up_to(11) => [2,3,5,7]\n;; count_up_to(0) => []\n;; count_up_to(20) => [2,3,5,7,11,13,17,19]\n;; count_up_to(1) => []\n;; count_up_to(18) => [2,3,5,7,11,13,17]\n(define (count_up_to n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> max_element([1, 2, 3])\n;; 3\n;; >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n;; 123\n(define (max_element l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n;; assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n(define (sorted_list_sum lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; total_match([], []) \u279e []\n;; total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n;; total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n;; total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n;; total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n(define (total_match lst1 lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; triangle_area(3, 4, 5) == 6.00\n;; triangle_area(1, 2, 10) == -1\n(define (triangle_area a b c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n;; check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n;; check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n;; check_if_last_char_is_a_letter(\"\") \u279e False\n(define (check_if_last_char_is_a_letter txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; array = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n;; [0, 2, 3, 5, 9, 123]\n(define (unique l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; smallest_change([1,2,3,5,4,7,9,6]) == 4\n;; smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n;; smallest_change([1, 2, 3, 2, 1]) == 0\n(define (smallest_change arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> unique_digits([15, 33, 1422, 1])\n;; [1, 15, 33]\n;; >>> unique_digits([152, 323, 1422, 10])\n;; []\n(define (unique_digits x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; f(5) == [1, 2, 6, 24, 15]\n(define (f n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n;; next_smallest([1, 2, 3, 4, 5]) == 2\n;; next_smallest([5, 1, 4, 3, 2]) == 2\n;; next_smallest([]) == None\n;; next_smallest([1, 1]) == None\n(define (next_smallest lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:\n;; Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n;; Output: [1, 2, 1]\n;; Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n;; Output: [1]\n(define (minPath grid k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; Input: arr = [-3, -4, 5], k = 3\n;; Output: [-4, -3, 5]\n;; Example 2:\n;; Input: arr = [4, -4, 4], k = 2\n;; Output: [4, 4]\n;; Example 3:\n;; Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n;; Output: [2]\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; compare_one(1, 2.5) \u279e 2.5\n;; compare_one(1, \"2,3\") \u279e \"2,3\"\n;; compare_one(\"5,1\", \"6\") \u279e \"6\"\n;; compare_one(\"1\", 1) \u279e None\n(define (compare_one a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; match_parens(['()(', ')']) == 'Yes'\n;; match_parens([')', ')']) == 'No'\n(define (match_parens lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; is_equal_to_sum_even(4) == False\n;; is_equal_to_sum_even(6) == False\n;; is_equal_to_sum_even(8) == True\n(define (is_equal_to_sum_even n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> largest_prime_factor(13195)\n;; 29\n;; >>> largest_prime_factor(2048)\n;; 2\n(define (largest_prime_factor n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> special_factorial(4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; encrypt('hi') returns 'lm'\n;; encrypt('asdfghjkl') returns 'ewhjklnop'\n;; encrypt('gf') returns 'kj'\n;; encrypt('et') returns 'ix'\n(define (encrypt s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> how_many_times('', 'a')\n;; 0\n;; >>> how_many_times('aaa', 'a')\n;; 3\n;; >>> how_many_times('aaaa', 'aa')\n;; 3\n(define (how_many_times string substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n;; Output: 24 # sum of 21 + 3\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> intersperse([], 4)\n;; []\n;; >>> intersperse([1, 2, 3], 4)\n;; [1, 4, 2, 4, 3]\n(define (intersperse numbers delimeter)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; solve(\"1234\") = \"4321\"\n;; solve(\"ab\") = \"AB\"\n;; solve(\"#a@C\") = \"#A@c\"\n(define (solve s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the odd indicies, while its values at the even indicies are equal\n;; to the values of the even indicies of l, but sorted.\n;; >>> sort_even([1, 2, 3])\n;; [1, 2, 3]\n;; >>> sort_even([5, 6, 3, 4])\n;; [3, 6, 5, 4]\n(define (sort_even l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_even))\n    (check-within (candidate (list 1 2 3)) (list 1 2 3) 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 123 1 -10)) (list -10 3 -5 2 -3 3 5 0 9 1 123) 0.001)\n    (check-within (candidate (list 5 8 -12 4 23 2 3 11 12 -10)) (list -12 8 3 4 5 2 12 11 23 -10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n;; >>> below_zero([1, 2, 3])\n;; False\n;; >>> below_zero([1, 2, -4, 5])\n;; True\n(define (below_zero operations)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Check if two words have the same characters.\n;; >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n;; True\n;; >>> same_chars('abcd', 'dddddddabc')\n;; True\n;; >>> same_chars('dddddddabc', 'abcd')\n;; True\n;; >>> same_chars('eabcd', 'dddddddabc')\n;; False\n;; >>> same_chars('abcd', 'dddddddabce')\n;; False\n;; >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n;; False\n(define (same_chars s0 s1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate same_chars))\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") #t 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabc\") #t 0.001)\n    (check-within (candidate \"dddddddabc\" \"abcd\") #t 0.001)\n    (check-within (candidate \"eabcd\" \"dddddddabc\") #f 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabcf\") #f 0.001)\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") #f 0.001)\n    (check-within (candidate \"aabb\" \"aaccc\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> separate_paren_groups('( ) (( )) (( )( ))')\n;; ['()', '(())', '(()())']\n(define (separate_paren_groups paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; count_upper('aBCdEf') returns 1\n;; count_upper('abcdefg') returns 0\n;; count_upper('dBBE') returns 0\n(define (count_upper s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n;; [1, 2, 3, 3, 3, 4, 4]\n(define (rolling_max numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> remove_duplicates([1, 2, 3, 2, 4])\n;; [1, 3, 4]\n(define (remove_duplicates numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n;; select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n;; select_words(\"simple white space\", 2) ==> []\n;; select_words(\"Hello world\", 4) ==> [\"world\"]\n;; select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n(define (select_words s n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; find_max([\"name\", \"of\", \"string\"]) == \"string\"\n;; find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n;; find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n(define (find_max words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; Input: \n;; grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n;; bucket_capacity : 1\n;; Output: 6\n;; Example 2:\n;; Input: \n;; grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n;; bucket_capacity : 2\n;; Output: 5\n;; Example 3:\n;; Input: \n;; grid : [[0,0,0], [0,0,0]]\n;; bucket_capacity : 5\n;; Output: 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; For lst = [1,2,3] the output should be 6\n;; For lst = []  the output should be 0\n;; For lst = [-1,-5,2,-1,-5]  the output should be -126\n(define (sum_squares lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; add([4, 2, 6, 7]) ==> 2\n(define (add lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; multiply(148, 412) should return 16.\n;; multiply(19, 28) should return 72.\n;; multiply(2020, 1851) should return 0.\n;; multiply(14,-15) should return 20.\n(define (multiply a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; intersection((1, 2), (2, 3)) ==> \"NO\"\n;; intersection((-1, 1), (0, 4)) ==> \"NO\"\n;; intersection((-3, -1), (-5, 5)) ==> \"YES\"\n(define (intersection interval1 interval2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; tri(3) = [1, 3, 2, 8]\n(define (tri n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; is_simple_power(1, 4) => true\n;; is_simple_power(2, 2) => true\n;; is_simple_power(8, 2) => true\n;; is_simple_power(3, 2) => false\n;; is_simple_power(3, 1) => false\n;; is_simple_power(5, 3) => false\n(define (is_simple_power x n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate has_close_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.3) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.05) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.95) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.8) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0) 0.1) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 1.0) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 0.5) #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1264,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given a positive integer n, you have to make a pile of n levels of stones.\n;; The first level has n stones.\n;; The number of stones in the next level is:\n;; - the next odd number if n is odd.\n;; - the next even number if n is even.\n;; Return the number of stones in each level in a list, where element at index\n;; i represents the number of stones in the level (i+1).\n;; Examples:\n;; >>> make_a_pile(3)\n;; [3, 5, 7]\n(define (make_a_pile n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_a_pile))\n    (check-within (candidate 3) (list 3 5 7) 0.001)\n    (check-within (candidate 4) (list 4 6 8 10) 0.001)\n    (check-within (candidate 5) (list 5 7 9 11 13) 0.001)\n    (check-within (candidate 6) (list 6 8 10 12 14 16) 0.001)\n    (check-within (candidate 8) (list 8 10 12 14 16 18 20 22) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -1275,1078 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> add(2, 3)\n;; 5\n;; >>> add(5, 7)\n;; 12\n(define (add x y)\n",
+    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n;; words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n;; words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n(define (words_string s)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> filter_by_prefix([], 'a')\n;; []\n;; >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n;; ['abc', 'array']\n(define (filter_by_prefix strings prefix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; decimal_to_binary(15)   # returns \"db1111db\"\n;; decimal_to_binary(32)   # returns \"db100000db\"\n(define (decimal_to_binary decimal)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> is_palindrome('')\n;; True\n;; >>> is_palindrome('aba')\n;; True\n;; >>> is_palindrome('aaaaa')\n;; True\n;; >>> is_palindrome('zbcd')\n;; False\n(define (is_palindrome text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> greatest_common_divisor(3, 5)\n;; 1\n;; >>> greatest_common_divisor(25, 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> factorize(8)\n;; [2, 2, 2]\n;; >>> factorize(25)\n;; [5, 5]\n;; >>> factorize(70)\n;; [2, 5, 7]\n(define (factorize n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> circular_shift(12, 1)\n;; \"21\"\n;; >>> circular_shift(12, 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; get_closest_vowel(\"yogurt\") ==> \"u\"\n;; get_closest_vowel(\"FULL\") ==> \"U\"\n;; get_closest_vowel(\"quick\") ==> \"\"\n;; get_closest_vowel(\"ab\") ==> \"\"\n(define (get_closest_vowel word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n(define (Strongest_Extension class_name extensions)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> sort_numbers('three one five')\n;; 'one three five'\n(define (sort_numbers numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> flip_case('Hello')\n;; 'hELLO'\n(define (flip_case string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n;; [1, 5, 653]\n;; >>> common([5, 3, 2, 8], [3, 2])\n;; [2, 3]\n(define (common l1 l2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n;; can_arrange([1,2,4,3,5]) = 3\n;; can_arrange([1,2,3]) = -1\n(define (can_arrange arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; is_nested('[[]]') \u279e True\n;; is_nested('[]]]]]]][[[[[]') \u279e False\n;; is_nested('[][]') \u279e False\n;; is_nested('[]') \u279e False\n;; is_nested('[[][]]') \u279e True\n;; is_nested('[[]][[') \u279e True\n(define (is_nested string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n;; -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n;; -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n;; return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n;; If the array is empty, return an empty array:\n;; arr = []\n;; return []\n;; If the array has any strange number ignore it:\n;; arr = [1, -1 , 55] \n;; -> sort arr -> [-1, 1, 55]\n;; -> reverse arr -> [55, 1, -1]\n;; return = ['One']\n(define (by_length arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> sum_to_n(30)\n;; 465\n;; >>> sum_to_n(100)\n;; 5050\n;; >>> sum_to_n(5)\n;; 15\n;; >>> sum_to_n(10)\n;; 55\n;; >>> sum_to_n(1)\n;; 1\n(define (sum_to_n n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> odd_count(['1234567'])\n;; [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n;; >>> odd_count(['3',\"11111111\"])\n;; [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n;; \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n(define (odd_count lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> concatenate([])\n;; ''\n;; >>> concatenate(['a', 'b', 'c'])\n;; 'abc'\n(define (concatenate strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; For lst = [1,2,3] the output should be 14\n;; For lst = [1,4,9] the output should be 98\n;; For lst = [1,3,5,7] the output should be 84\n;; For lst = [1.4,4.2,0] the output should be 29\n;; For lst = [-2.4,1,1] the output should be 6\n(define (sum_squares lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this Kata, you have to sort an array of non-negative integers according to\n;; number of ones in their binary representation in ascending order.\n;; For similar number of ones, sort based on decimal value.\n;; It must be implemented like this:\n;; >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n;; >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n;; >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n(define (sort_array arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list 1 5 2 3 4)) (list 1 2 4 3 5) 0.001)\n    (check-within (candidate (list -2 -3 -4 -5 -6)) (list -4 -2 -6 -5 -3) 0.001)\n    (check-within (candidate (list 1 0 2 3 4)) (list 0 1 2 4 3) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 2 5 77 4 5 3 5 7 2 3 4)) (list 2 2 4 4 3 3 5 5 5 7 77) 0.001)\n    (check-within (candidate (list 3 6 44 12 32 5)) (list 32 3 5 6 12 44) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n;; >>> longest([])\n;; >>> longest(['a', 'b', 'c'])\n;; 'a'\n;; >>> longest(['a', 'bb', 'ccc'])\n;; 'ccc'\n(define (longest strings)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n;; is_sorted([5]) \u279e True\n;; is_sorted([1, 2, 3, 4, 5]) \u279e True\n;; is_sorted([1, 3, 2, 4, 5]) \u279e False\n;; is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n;; is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n;; is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n;; is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n;; is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n(define (is_sorted lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n;; even_odd_count(-12) ==> (1, 1)\n;; even_odd_count(123) ==> (1, 2)\n(define (even_odd_count num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> derivative([3, 1, 2, 4, 5])\n;; [1, 4, 12, 20]\n;; >>> derivative([1, 2, 3])\n;; [2, 6]\n(define (derivative xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; anti_shuffle('Hi') returns 'Hi'\n;; anti_shuffle('hello') returns 'ehllo'\n;; anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n(define (anti_shuffle s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; Input: sentence = \"This is a test\"\n;; Output: \"is\"\n;; Example 2:\n;; Input: sentence = \"lets go for swimming\"\n;; Output: \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> make_palindrome('')\n;; ''\n;; >>> make_palindrome('cat')\n;; 'catac'\n;; >>> make_palindrome('cata')\n;; 'catac'\n(define (make_palindrome string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; * eat(5, 6, 10) -> [11, 4]\n;; * eat(4, 8, 9) -> [12, 1]\n;; * eat(1, 10, 10) -> [11, 0]\n;; * eat(2, 11, 5) -> [7, 0]\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> change_base(8, 3)\n;; '22'\n;; >>> change_base(8, 2)\n;; '1000'\n;; >>> change_base(7, 2)\n;; '111'\n(define (change_base x base)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n;; prime_length('Hello') == True\n;; prime_length('abcdcba') == True\n;; prime_length('kittens') == True\n;; prime_length('orange') == False\n(define (prime_length string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n(define (numerical_letter_grade grades)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; search([4, 1, 2, 2, 3, 1]) == 2\n;; search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n;; search([5, 5, 4, 4, 4]) == -1\n(define (search lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; right_angle_triangle(3, 4, 5) == True\n;; right_angle_triangle(1, 2, 3) == False\n(define (right_angle_triangle a b c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> fizz_buzz(50)\n;; 0\n;; >>> fizz_buzz(78)\n;; 2\n;; >>> fizz_buzz(79)\n;; 3\n(define (fizz_buzz n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; Input: 3\n;; Output: (1, 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; Input: 12\n;; Output: (4, 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> parse_nested_parens('(()()) ((())) () ((())()())')\n;; [2, 3, 1, 3]\n(define (parse_nested_parens paren_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n;; compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n(define (compare game guess)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n;; * sort_array([]) => []\n;; * sort_array([5]) => [5]\n;; * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n;; * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n(define (sort_array array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; get_row([\n;; [1,2,3,4,5,6],\n;; [1,2,3,4,1,6],\n;; [1,2,3,4,5,1]\n;; ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n;; get_row([], 1) == []\n;; get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n(define (get_row lst x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> vowels_count(\"abcde\")\n;; 2\n;; >>> vowels_count(\"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n;; >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n(define (string_to_md5 text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> is_prime(6)\n;; False\n;; >>> is_prime(101)\n;; True\n;; >>> is_prime(11)\n;; True\n;; >>> is_prime(13441)\n;; True\n;; >>> is_prime(61)\n;; True\n;; >>> is_prime(4)\n;; False\n;; >>> is_prime(1)\n;; False\n(define (is_prime n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n;; bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n;; bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n(define (bf planet1 planet2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; For num = \"AB\" the output should be 1.\n;; For num = \"1077E\" the output should be 2.\n;; For num = \"ABED1A33\" the output should be 4.\n;; For num = \"123456789ABCDEF0\" the output should be 6.\n;; For num = \"2020\" the output should be 2.\n(define (hex_key num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> median([3, 1, 2, 4, 5])\n;; 3\n;; >>> median([-10, 4, 6, 1000, 10, 20])\n;; 15.0\n(define (median l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an array of numbers as input and returns \n;; the number of elements in the array that are greater than 10 and both \n;; first and last digits of a number are odd (1, 3, 5, 7, 9).\n;; For example:\n;; specialFilter([15, -73, 14, -15]) => 1 \n;; specialFilter([33, -2, -3, 45, 21, 109]) => 2\n(define (specialFilter nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate specialFilter))\n    (check-within (candidate (list 5 -2 1 -5)) 0 0.001)\n    (check-within (candidate (list 15 -73 14 -15)) 1 0.001)\n    (check-within (candidate (list 33 -2 -3 45 21 109)) 2 0.001)\n    (check-within (candidate (list 43 -12 93 125 121 109)) 4 0.001)\n    (check-within (candidate (list 71 -2 -33 75 21 19)) 3 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list )) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> modp(3, 5)\n;; 3\n;; >>> modp(1101, 101)\n;; 2\n;; >>> modp(0, 101)\n;; 1\n;; >>> modp(3, 11)\n;; 8\n;; >>> modp(100, 101)\n;; 1\n(define (modp n p)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> pairs_sum_to_zero([1, 3, 5, 0])\n;; False\n;; >>> pairs_sum_to_zero([1, 3, -2, 1])\n;; False\n;; >>> pairs_sum_to_zero([1, 2, 3, 7])\n;; False\n;; >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n;; True\n;; >>> pairs_sum_to_zero([1])\n;; False\n(define (pairs_sum_to_zero l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n;; strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n;; strange_sort_list([]) == []\n(define (strange_sort_list lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> prime_fib(1)\n;; 2\n;; >>> prime_fib(2)\n;; 3\n;; >>> prime_fib(3)\n;; 5\n;; >>> prime_fib(4)\n;; 13\n;; >>> prime_fib(5)\n;; 89\n(define (prime_fib n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n;; check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n;; check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n;; check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n;; check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n;; check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n(define (check_dict_case dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; for example: \n;; valid_date('03-11-2000') => True\n;; valid_date('15-01-2012') => False\n;; valid_date('04-0-2040') => False\n;; valid_date('06-04-2020') => True\n;; valid_date('06/04/2020') => False\n(define (valid_date date)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> count_nums([]) == 0\n;; >>> count_nums([-1, 11, -11]) == 1\n;; >>> count_nums([1, 1, 2]) == 3\n(define (count_nums arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n;; >>> filter_integers(['a', 3.14, 5])\n;; [5]\n;; >>> filter_integers([1, 2, 3, 'abc', {}, []])\n;; [1, 2, 3]\n(define (filter_integers values)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; digitSum(\"\") => 0\n;; digitSum(\"abAB\") => 131\n;; digitSum(\"abcCd\") => 67\n;; digitSum(\"helloE\") => 69\n;; digitSum(\"woArBld\") => 131\n;; digitSum(\"aAaaaXa\") => 153\n(define (digitSum s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n;; >>> order_by_points([]) == []\n(define (order_by_points nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> triangle_area(5, 3)\n;; 7.5\n(define (triangle_area a h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n;; split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n;; split_words(\"abcdef\") == 3\n(define (split_words txt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> fib4(5)\n;; 4\n;; >>> fib4(6)\n;; 8\n;; >>> fib4(7)\n;; 14\n(define (fib4 n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> string_xor('010', '110')\n;; '100'\n(define (string_xor a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Check if in given list of numbers, are any two numbers closer to each other than\n;; given threshold.\n;; >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n;; False\n;; >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n;; True\n(define (has_close_elements numbers threshold)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate has_close_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.3) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.05) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.95) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.8) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0) 0.1) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 1.0) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 0.5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n;; fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n;; fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n;; fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n(define (fruit_distribution s n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> largest_divisor(15)\n;; 5\n(define (largest_divisor n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> int_to_mini_roman(19) == 'xix'\n;; >>> int_to_mini_roman(152) == 'clii'\n;; >>> int_to_mini_roman(426) == 'cdxxvi'\n(define (int_to_mini_roman number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> correct_bracketing(\"(\")\n;; False\n;; >>> correct_bracketing(\"()\")\n;; True\n;; >>> correct_bracketing(\"(()())\")\n;; True\n;; >>> correct_bracketing(\")(()\")\n;; False\n(define (correct_bracketing brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; brackets is a string of \"<\" and \">\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> correct_bracketing(\"<\")\n;; False\n;; >>> correct_bracketing(\"<>\")\n;; True\n;; >>> correct_bracketing(\"<<><>>\")\n;; True\n;; >>> correct_bracketing(\"><<>\")\n;; False\n(define (correct_bracketing brackets)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"<>\") #t 0.001)\n    (check-within (candidate \"<<><>>\") #t 0.001)\n    (check-within (candidate \"<><><<><>><>\") #t 0.001)\n    (check-within (candidate \"<><><<<><><>><>><<><><<>>>\") #t 0.001)\n    (check-within (candidate \"<<<><>>>>\") #f 0.001)\n    (check-within (candidate \"><<>\") #f 0.001)\n    (check-within (candidate \"<\") #f 0.001)\n    (check-within (candidate \"<<<<\") #f 0.001)\n    (check-within (candidate \">\") #f 0.001)\n    (check-within (candidate \"<<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>><<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>>><>\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> fib(10)\n;; 55\n;; >>> fib(1)\n;; 1\n;; >>> fib(8)\n;; 21\n(define (fib n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n;; >>> prod_signs([1, 2, 2, -4]) == -9\n;; >>> prod_signs([0, 1]) == 0\n;; >>> prod_signs([]) == None\n(define (prod_signs arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> filter_by_substring([], 'a')\n;; []\n;; >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n;; ['abc', 'bacd', 'array']\n(define (filter_by_substring strings substring)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> incr_list([1, 2, 3])\n;; [2, 3, 4]\n;; >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n;; [6, 4, 6, 3, 4, 4, 10, 1, 124]\n(define (incr_list l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> get_positive([-1, 2, -4, 5, 6])\n;; [2, 5, 6]\n;; >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n;; [5, 3, 2, 3, 9, 123, 1]\n(define (get_positive l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2359,7 +49,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n;; choose_num(12, 15) = 14\n;; choose_num(13, 12) = -1\n(define (choose_num x y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2370,13 +60,988 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; For N = 1000, the sum of digits will be 1 the output should be \"1\".\n;; For N = 150, the sum of digits will be 6 the output should be \"110\".\n;; For N = 147, the sum of digits will be 12 the output should be \"1100\".\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
+    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; rounded_avg(1, 5) => \"0b11\"\n;; rounded_avg(7, 5) => -1\n;; rounded_avg(10, 20) => \"0b1111\"\n;; rounded_avg(20, 33) => \"0b11010\"\n(define (rounded_avg n m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> unique_digits([15, 33, 1422, 1])\n;; [1, 15, 33]\n;; >>> unique_digits([152, 323, 1422, 10])\n;; []\n(define (unique_digits x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n;; -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n;; -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n;; return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n;; If the array is empty, return an empty array:\n;; arr = []\n;; return []\n;; If the array has any strange number ignore it:\n;; arr = [1, -1 , 55] \n;; -> sort arr -> [-1, 1, 55]\n;; -> reverse arr -> [55, 1, -1]\n;; return = ['One']\n(define (by_length arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; f(5) == [1, 2, 6, 24, 15]\n(define (f n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; Input: 3\n;; Output: (1, 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; Input: 12\n;; Output: (4, 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> count_nums([]) == 0\n;; >>> count_nums([-1, 11, -11]) == 1\n;; >>> count_nums([1, 1, 2]) == 3\n(define (count_nums arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; move_one_ball([3, 4, 5, 1, 2])==>True\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; move_one_ball([3, 5, 4, 1, 2])==>False\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> make_palindrome('')\n;; ''\n;; >>> make_palindrome('cat')\n;; 'catac'\n;; >>> make_palindrome('cata')\n;; 'catac'\n(define (make_palindrome string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n;; exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n;; histogram('a b b a') == {'a': 2, 'b': 2}\n;; histogram('a b c a b') == {'a': 2, 'b': 2}\n;; histogram('b b b b a') == {'b': 4}\n;; histogram('') == {}\n(define (histogram test)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Task\n;; We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n;; then check if the result string is palindrome.\n;; A string is called palindrome if it reads the same backward as forward.\n;; You should return a tuple containing the result string and True/False for the check.\n;; Example\n;; For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n;; For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n;; For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n(define (reverse_delete s c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_delete))\n    (check-within (candidate \"abcde\" \"ae\") (list \"bcd\" #f) 0.001)\n    (check-within (candidate \"abcdef\" \"b\") (list \"acdef\" #f) 0.001)\n    (check-within (candidate \"abcdedcba\" \"ab\") (list \"cdedc\" #t) 0.001)\n    (check-within (candidate \"dwik\" \"w\") (list \"dik\" #f) 0.001)\n    (check-within (candidate \"a\" \"a\") (list \"\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"v\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"vabba\" \"v\") (list \"abba\" #t) 0.001)\n    (check-within (candidate \"mamma\" \"mia\") (list \"\" #t) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> odd_count(['1234567'])\n;; [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n;; >>> odd_count(['3',\"11111111\"])\n;; [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n;; \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n(define (odd_count lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n;; minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n;; minSubArraySum([-1, -2, -3]) == -6\n(define (minSubArraySum nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; Input: \n;; grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n;; bucket_capacity : 1\n;; Output: 6\n;; Example 2:\n;; Input: \n;; grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n;; bucket_capacity : 2\n;; Output: 5\n;; Example 3:\n;; Input: \n;; grid : [[0,0,0], [0,0,0]]\n;; bucket_capacity : 5\n;; Output: 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this Kata, you have to sort an array of non-negative integers according to\n;; number of ones in their binary representation in ascending order.\n;; For similar number of ones, sort based on decimal value.\n;; It must be implemented like this:\n;; >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n;; >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n;; >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n(define (sort_array arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list 1 5 2 3 4)) (list 1 2 4 3 5) 0.001)\n    (check-within (candidate (list -2 -3 -4 -5 -6)) (list -4 -2 -6 -5 -3) 0.001)\n    (check-within (candidate (list 1 0 2 3 4)) (list 0 1 2 4 3) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 2 5 77 4 5 3 5 7 2 3 4)) (list 2 2 4 4 3 3 5 5 5 7 77) 0.001)\n    (check-within (candidate (list 3 6 44 12 32 5)) (list 32 3 5 6 12 44) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n;; select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n;; select_words(\"simple white space\", 2) ==> []\n;; select_words(\"Hello world\", 4) ==> [\"world\"]\n;; select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n(define (select_words s n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; get_closest_vowel(\"yogurt\") ==> \"u\"\n;; get_closest_vowel(\"FULL\") ==> \"U\"\n;; get_closest_vowel(\"quick\") ==> \"\"\n;; get_closest_vowel(\"ab\") ==> \"\"\n(define (get_closest_vowel word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; match_parens(['()(', ')']) == 'Yes'\n;; match_parens([')', ')']) == 'No'\n(define (match_parens lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> string_xor('010', '110')\n;; '100'\n(define (string_xor a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; Input: arr = [-3, -4, 5], k = 3\n;; Output: [-4, -3, 5]\n;; Example 2:\n;; Input: arr = [4, -4, 4], k = 2\n;; Output: [4, 4]\n;; Example 3:\n;; Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n;; Output: [2]\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; solution([5, 8, 7, 1]) ==> 12\n;; solution([3, 3, 3, 3, 3]) ==> 9\n;; solution([30, 13, 24, 321]) ==>0\n(define (solution lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n;; Output: 24 # sum of 21 + 3\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n(define (get_odd_collatz n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; for example: \n;; valid_date('03-11-2000') => True\n;; valid_date('15-01-2012') => False\n;; valid_date('04-0-2040') => False\n;; valid_date('06-04-2020') => True\n;; valid_date('06/04/2020') => False\n(define (valid_date date)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n;; split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n;; split_words(\"abcdef\") == 3\n(define (split_words txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n;; is_sorted([5]) \u279e True\n;; is_sorted([1, 2, 3, 4, 5]) \u279e True\n;; is_sorted([1, 3, 2, 4, 5]) \u279e False\n;; is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n;; is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n;; is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n;; is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n;; is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n(define (is_sorted lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; intersection((1, 2), (2, 3)) ==> \"NO\"\n;; intersection((-1, 1), (0, 4)) ==> \"NO\"\n;; intersection((-3, -1), (-5, 5)) ==> \"YES\"\n(define (intersection interval1 interval2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n;; >>> prod_signs([1, 2, 2, -4]) == -9\n;; >>> prod_signs([0, 1]) == 0\n;; >>> prod_signs([]) == None\n(define (prod_signs arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:\n;; Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n;; Output: [1, 2, 1]\n;; Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n;; Output: [1]\n(define (minPath grid k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n;; >>> longest([])\n;; >>> longest(['a', 'b', 'c'])\n;; 'a'\n;; >>> longest(['a', 'bb', 'ccc'])\n;; 'ccc'\n(define (longest strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; tri(3) = [1, 3, 2, 8]\n(define (tri n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; digits(1)  == 1\n;; digits(4)  == 0\n;; digits(235) == 15\n(define (digits n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; is_nested('[[]]') \u279e True\n;; is_nested('[]]]]]]][[[[[]') \u279e False\n;; is_nested('[][]') \u279e False\n;; is_nested('[]') \u279e False\n;; is_nested('[[][]]') \u279e True\n;; is_nested('[[]][[') \u279e True\n(define (is_nested string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; For lst = [1,2,3] the output should be 14\n;; For lst = [1,4,9] the output should be 98\n;; For lst = [1,3,5,7] the output should be 84\n;; For lst = [1.4,4.2,0] the output should be 29\n;; For lst = [-2.4,1,1] the output should be 6\n(define (sum_squares lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n;; check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n;; check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n;; check_if_last_char_is_a_letter(\"\") \u279e False\n(define (check_if_last_char_is_a_letter txt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n;; can_arrange([1,2,4,3,5]) = 3\n;; can_arrange([1,2,3]) = -1\n(define (can_arrange arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n;; largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n;; largest_smallest_integers([]) == (None, None)\n;; largest_smallest_integers([0]) == (None, None)\n(define (largest_smallest_integers lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; compare_one(1, 2.5) \u279e 2.5\n;; compare_one(1, \"2,3\") \u279e \"2,3\"\n;; compare_one(\"5,1\", \"6\") \u279e \"6\"\n;; compare_one(\"1\", 1) \u279e None\n(define (compare_one a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; is_equal_to_sum_even(4) == False\n;; is_equal_to_sum_even(6) == False\n;; is_equal_to_sum_even(8) == True\n(define (is_equal_to_sum_even n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> special_factorial(4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> greatest_common_divisor(3, 5)\n;; 1\n;; >>> greatest_common_divisor(25, 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; fix_spaces(\"Example\") == \"Example\"\n;; fix_spaces(\"Example 1\") == \"Example_1\"\n;; fix_spaces(\" Example 2\") == \"_Example_2\"\n;; fix_spaces(\" Example   3\") == \"_Example-3\"\n(define (fix_spaces text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; file_name_check(\"example.txt\") # => 'Yes'\n;; file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n(define (file_name_check file_name)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; For lst = [1,2,3] the output should be 6\n;; For lst = []  the output should be 0\n;; For lst = [-1,-5,2,-1,-5]  the output should be -126\n(define (sum_squares lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; Input: sentence = \"This is a test\"\n;; Output: \"is\"\n;; Example 2:\n;; Input: sentence = \"lets go for swimming\"\n;; Output: \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; simplify(\"1/5\", \"5/1\") = True\n;; simplify(\"1/6\", \"2/1\") = False\n;; simplify(\"7/10\", \"10/2\") = False\n(define (simplify x n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n;; >>> order_by_points([]) == []\n(define (order_by_points nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an array of numbers as input and returns \n;; the number of elements in the array that are greater than 10 and both \n;; first and last digits of a number are odd (1, 3, 5, 7, 9).\n;; For example:\n;; specialFilter([15, -73, 14, -15]) => 1 \n;; specialFilter([33, -2, -3, 45, 21, 109]) => 2\n(define (specialFilter nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate specialFilter))\n    (check-within (candidate (list 5 -2 1 -5)) 0 0.001)\n    (check-within (candidate (list 15 -73 14 -15)) 1 0.001)\n    (check-within (candidate (list 33 -2 -3 45 21 109)) 2 0.001)\n    (check-within (candidate (list 43 -12 93 125 121 109)) 4 0.001)\n    (check-within (candidate (list 71 -2 -33 75 21 19)) 3 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list )) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; Input: n = 5\n;; Output: 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n;; bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n;; bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n(define (bf planet1 planet2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n;; assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n(define (sorted_list_sum lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> all_prefixes('abc')\n;; ['a', 'ab', 'abc']\n(define (all_prefixes string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; for x_or_y(7, 34, 12) == 34\n;; for x_or_y(15, 8, 5) == 5\n(define (x_or_y n x y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n;; double_the_difference([-1, -2, 0]) == 0\n;; double_the_difference([9, -2]) == 81\n;; double_the_difference([0]) == 0  \n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n;; compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n(define (compare game guess)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n(define (Strongest_Extension class_name extensions)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n;; cycpattern_check(\"abcd\",\"abd\") => False\n;; cycpattern_check(\"hello\",\"ell\") => True\n;; cycpattern_check(\"whassup\",\"psus\") => False\n;; cycpattern_check(\"abab\",\"baa\") => True\n;; cycpattern_check(\"efef\",\"eeff\") => False\n;; cycpattern_check(\"himenss\",\"simen\") => True\n(define (cycpattern_check a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n;; even_odd_count(-12) ==> (1, 1)\n;; even_odd_count(123) ==> (1, 2)\n(define (even_odd_count num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> int_to_mini_roman(19) == 'xix'\n;; >>> int_to_mini_roman(152) == 'clii'\n;; >>> int_to_mini_roman(426) == 'cdxxvi'\n(define (int_to_mini_roman number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; right_angle_triangle(3, 4, 5) == True\n;; right_angle_triangle(1, 2, 3) == False\n(define (right_angle_triangle a b c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; find_max([\"name\", \"of\", \"string\"]) == \"string\"\n;; find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n;; find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n(define (find_max words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; * eat(5, 6, 10) -> [11, 4]\n;; * eat(4, 8, 9) -> [12, 1]\n;; * eat(1, 10, 10) -> [11, 0]\n;; * eat(2, 11, 5) -> [7, 0]\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> string_sequence(0)\n;; '0'\n;; >>> string_sequence(5)\n;; '0 1 2 3 4 5'\n(define (string_sequence n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; array = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; solve(\"1234\") = \"4321\"\n;; solve(\"ab\") = \"AB\"\n;; solve(\"#a@C\") = \"#A@c\"\n(define (solve s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n;; >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n(define (string_to_md5 text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2389,7 +1054,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given two positive integers a and b, return the even digits between a\n;; and b, in ascending order.\n;; For example:\n;; generate_integers(2, 8) => [2, 4, 6, 8]\n;; generate_integers(8, 2) => [2, 4, 6, 8]\n;; generate_integers(10, 14) => []\n(define (generate_integers a b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate generate_integers))\n    (check-within (candidate 2 10) (list 2 4 6 8) 0.001)\n    (check-within (candidate 10 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 132 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 17 89) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2404,9 +1069,1344 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n;; >>> count_distinct_characters('xyzXYZ')\n;; 3\n;; >>> count_distinct_characters('Jerry')\n;; 4\n(define (count_distinct_characters string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n;; [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n(define (parse_music music_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> how_many_times('', 'a')\n;; 0\n;; >>> how_many_times('aaa', 'a')\n;; 3\n;; >>> how_many_times('aaaa', 'aa')\n;; 3\n(define (how_many_times string substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> sort_numbers('three one five')\n;; 'one three five'\n(define (sort_numbers numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> separate_paren_groups('( ) (( )) (( )( ))')\n;; ['()', '(())', '(()())']\n(define (separate_paren_groups paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n;; (2.0, 2.2)\n;; >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n;; (2.0, 2.0)\n(define (find_closest_elements numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n;; [0.0, 0.25, 0.5, 0.75, 1.0]\n(define (rescale_to_unit numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n;; >>> filter_integers(['a', 3.14, 5])\n;; [5]\n;; >>> filter_integers([1, 2, 3, 'abc', {}, []])\n;; [1, 2, 3]\n(define (filter_integers values)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> strlen('')\n;; 0\n;; >>> strlen('abc')\n;; 3\n(define (strlen string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> largest_divisor(15)\n;; 5\n(define (largest_divisor n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> factorize(8)\n;; [2, 2, 2]\n;; >>> factorize(25)\n;; [5, 5]\n;; >>> factorize(70)\n;; [2, 5, 7]\n(define (factorize n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> remove_duplicates([1, 2, 3, 2, 4])\n;; [1, 3, 4]\n(define (remove_duplicates numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> flip_case('Hello')\n;; 'hELLO'\n(define (flip_case string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> concatenate([])\n;; ''\n;; >>> concatenate(['a', 'b', 'c'])\n;; 'abc'\n(define (concatenate strings)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> filter_by_prefix([], 'a')\n;; []\n;; >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n;; ['abc', 'array']\n(define (filter_by_prefix strings prefix)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> truncate_number(3.5)\n;; 0.5\n(define (truncate_number number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> get_positive([-1, 2, -4, 5, 6])\n;; [2, 5, 6]\n;; >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n;; [5, 3, 2, 3, 9, 123, 1]\n(define (get_positive l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> is_prime(6)\n;; False\n;; >>> is_prime(101)\n;; True\n;; >>> is_prime(11)\n;; True\n;; >>> is_prime(13441)\n;; True\n;; >>> is_prime(61)\n;; True\n;; >>> is_prime(4)\n;; False\n;; >>> is_prime(1)\n;; False\n(define (is_prime n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> sort_third([1, 2, 3])\n;; [1, 2, 3]\n;; >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n;; [2, 6, 3, 4, 8, 9, 5]\n(define (sort_third l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n;; [0, 2, 3, 5, 9, 123]\n(define (unique l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> max_element([1, 2, 3])\n;; 3\n;; >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n;; 123\n(define (max_element l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> fizz_buzz(50)\n;; 0\n;; >>> fizz_buzz(78)\n;; 2\n;; >>> fizz_buzz(79)\n;; 3\n(define (fizz_buzz n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the odd indicies, while its values at the even indicies are equal\n;; to the values of the even indicies of l, but sorted.\n;; >>> sort_even([1, 2, 3])\n;; [1, 2, 3]\n;; >>> sort_even([5, 6, 3, 4])\n;; [3, 6, 5, 4]\n(define (sort_even l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_even))\n    (check-within (candidate (list 1 2 3)) (list 1 2 3) 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 123 1 -10)) (list -10 3 -5 2 -3 3 5 0 9 1 123) 0.001)\n    (check-within (candidate (list 5 8 -12 4 23 2 3 11 12 -10)) (list -12 8 3 4 5 2 12 11 23 -10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> prime_fib(1)\n;; 2\n;; >>> prime_fib(2)\n;; 3\n;; >>> prime_fib(3)\n;; 5\n;; >>> prime_fib(4)\n;; 13\n;; >>> prime_fib(5)\n;; 89\n(define (prime_fib n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n;; >>> below_zero([1, 2, 3])\n;; False\n;; >>> below_zero([1, 2, -4, 5])\n;; True\n(define (below_zero operations)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> triples_sum_to_zero([1, 3, 5, 0])\n;; False\n;; >>> triples_sum_to_zero([1, 3, -2, 1])\n;; True\n;; >>> triples_sum_to_zero([1, 2, 3, 7])\n;; False\n;; >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n;; True\n;; >>> triples_sum_to_zero([1])\n;; False\n(define (triples_sum_to_zero l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> incr_list([1, 2, 3])\n;; [2, 3, 4]\n;; >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n;; [6, 4, 6, 3, 4, 4, 10, 1, 124]\n(define (incr_list l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> pairs_sum_to_zero([1, 3, 5, 0])\n;; False\n;; >>> pairs_sum_to_zero([1, 3, -2, 1])\n;; False\n;; >>> pairs_sum_to_zero([1, 2, 3, 7])\n;; False\n;; >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n;; True\n;; >>> pairs_sum_to_zero([1])\n;; False\n(define (pairs_sum_to_zero l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> change_base(8, 3)\n;; '22'\n;; >>> change_base(8, 2)\n;; '1000'\n;; >>> change_base(7, 2)\n;; '111'\n(define (change_base x base)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> triangle_area(5, 3)\n;; 7.5\n(define (triangle_area a h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> fib4(5)\n;; 4\n;; >>> fib4(6)\n;; 8\n;; >>> fib4(7)\n;; 14\n(define (fib4 n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> median([3, 1, 2, 4, 5])\n;; 3\n;; >>> median([-10, 4, 6, 1000, 10, 20])\n;; 15.0\n(define (median l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> is_palindrome('')\n;; True\n;; >>> is_palindrome('aba')\n;; True\n;; >>> is_palindrome('aaaaa')\n;; True\n;; >>> is_palindrome('zbcd')\n;; False\n(define (is_palindrome text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> modp(3, 5)\n;; 3\n;; >>> modp(1101, 101)\n;; 2\n;; >>> modp(0, 101)\n;; 1\n;; >>> modp(3, 11)\n;; 8\n;; >>> modp(100, 101)\n;; 1\n(define (modp n p)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> remove_vowels('')\n;; ''\n;; >>> remove_vowels('abcdef')\n;; 'bcdf'\n;; >>> remove_vowels('aaaaa')\n;; ''\n;; >>> remove_vowels('aaBAA')\n;; 'B'\n;; >>> remove_vowels('zbcd')\n;; 'zbcd'\n(define (remove_vowels text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n;; >>> below_threshold([1, 2, 4, 10], 100)\n;; True\n;; >>> below_threshold([1, 20, 4, 10], 5)\n;; False\n(define (below_threshold l t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> add(2, 3)\n;; 5\n;; >>> add(5, 7)\n;; 12\n(define (add x y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Check if two words have the same characters.\n;; >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n;; True\n;; >>> same_chars('abcd', 'dddddddabc')\n;; True\n;; >>> same_chars('dddddddabc', 'abcd')\n;; True\n;; >>> same_chars('eabcd', 'dddddddabc')\n;; False\n;; >>> same_chars('abcd', 'dddddddabce')\n;; False\n;; >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n;; False\n(define (same_chars s0 s1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate same_chars))\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") #t 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabc\") #t 0.001)\n    (check-within (candidate \"dddddddabc\" \"abcd\") #t 0.001)\n    (check-within (candidate \"eabcd\" \"dddddddabc\") #f 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabcf\") #f 0.001)\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") #f 0.001)\n    (check-within (candidate \"aabb\" \"aaccc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> fib(10)\n;; 55\n;; >>> fib(1)\n;; 1\n;; >>> fib(8)\n;; 21\n(define (fib n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; brackets is a string of \"<\" and \">\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> correct_bracketing(\"<\")\n;; False\n;; >>> correct_bracketing(\"<>\")\n;; True\n;; >>> correct_bracketing(\"<<><>>\")\n;; True\n;; >>> correct_bracketing(\"><<>\")\n;; False\n(define (correct_bracketing brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"<>\") #t 0.001)\n    (check-within (candidate \"<<><>>\") #t 0.001)\n    (check-within (candidate \"<><><<><>><>\") #t 0.001)\n    (check-within (candidate \"<><><<<><><>><>><<><><<>>>\") #t 0.001)\n    (check-within (candidate \"<<<><>>>>\") #f 0.001)\n    (check-within (candidate \"><<>\") #f 0.001)\n    (check-within (candidate \"<\") #f 0.001)\n    (check-within (candidate \"<<<<\") #f 0.001)\n    (check-within (candidate \">\") #f 0.001)\n    (check-within (candidate \"<<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>><<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>>><>\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n;; >>> monotonic([1, 2, 4, 20])\n;; True\n;; >>> monotonic([1, 20, 4, 10])\n;; False\n;; >>> monotonic([4, 1, 0, -10])\n;; True\n(define (monotonic l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n;; [1, 5, 653]\n;; >>> common([5, 3, 2, 8], [3, 2])\n;; [2, 3]\n(define (common l1 l2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> largest_prime_factor(13195)\n;; 29\n;; >>> largest_prime_factor(2048)\n;; 2\n(define (largest_prime_factor n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> intersperse([], 4)\n;; []\n;; >>> intersperse([1, 2, 3], 4)\n;; [1, 4, 2, 4, 3]\n(define (intersperse numbers delimeter)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> sum_to_n(30)\n;; 465\n;; >>> sum_to_n(100)\n;; 5050\n;; >>> sum_to_n(5)\n;; 15\n;; >>> sum_to_n(10)\n;; 55\n;; >>> sum_to_n(1)\n;; 1\n(define (sum_to_n n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> correct_bracketing(\"(\")\n;; False\n;; >>> correct_bracketing(\"()\")\n;; True\n;; >>> correct_bracketing(\"(()())\")\n;; True\n;; >>> correct_bracketing(\")(()\")\n;; False\n(define (correct_bracketing brackets)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> derivative([3, 1, 2, 4, 5])\n;; [1, 4, 12, 20]\n;; >>> derivative([1, 2, 3])\n;; [2, 6]\n(define (derivative xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> fibfib(1)\n;; 0\n;; >>> fibfib(5)\n;; 4\n;; >>> fibfib(8)\n;; 24\n(define (fibfib n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> vowels_count(\"abcde\")\n;; 2\n;; >>> vowels_count(\"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> circular_shift(12, 1)\n;; \"21\"\n;; >>> circular_shift(12, 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; digitSum(\"\") => 0\n;; digitSum(\"abAB\") => 131\n;; digitSum(\"abcCd\") => 67\n;; digitSum(\"helloE\") => 69\n;; digitSum(\"woArBld\") => 131\n;; digitSum(\"aAaaaXa\") => 153\n(define (digitSum s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n;; fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n;; fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n;; fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n(define (fruit_distribution s n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; Input: [4,2,3]\n;; Output: [2, 1]\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; Input: [1,2,3]\n;; Output: [2, 1]\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index. \n;; Example 3:\n;; Input: []\n;; Output: []\n;; Example 4:\n;; Input: [5, 0, 3, 0, 4, 2]\n;; Output: [0, 1]\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; search([4, 1, 2, 2, 3, 1]) == 2\n;; search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n;; search([5, 5, 4, 4, 4]) == -1\n(define (search lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> parse_nested_parens('(()()) ((())) () ((())()())')\n;; [2, 3, 1, 3]\n(define (parse_nested_parens paren_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n;; strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n;; strange_sort_list([]) == []\n(define (strange_sort_list lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; triangle_area(3, 4, 5) == 6.00\n;; triangle_area(1, 2, 10) == -1\n(define (triangle_area a b c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; will_it_fly([1, 2], 5) \u279e False \n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; will_it_fly([3, 2, 3], 1) \u279e False\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; will_it_fly([3, 2, 3], 9) \u279e True\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; will_it_fly([3], 5) \u279e True\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; smallest_change([1,2,3,5,4,7,9,6]) == 4\n;; smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n;; smallest_change([1, 2, 3, 2, 1]) == 0\n(define (smallest_change arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; total_match([], []) \u279e []\n;; total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n;; total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n;; total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n;; total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n(define (total_match lst1 lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; is_multiply_prime(30) == True\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; is_simple_power(1, 4) => true\n;; is_simple_power(2, 2) => true\n;; is_simple_power(8, 2) => true\n;; is_simple_power(3, 2) => false\n;; is_simple_power(3, 1) => false\n;; is_simple_power(5, 3) => false\n(define (is_simple_power x n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; iscube(1) ==> True\n;; iscube(2) ==> False\n;; iscube(-1) ==> True\n;; iscube(64) ==> True\n;; iscube(0) ==> True\n;; iscube(180) ==> False\n(define (iscube a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; For num = \"AB\" the output should be 1.\n;; For num = \"1077E\" the output should be 2.\n;; For num = \"ABED1A33\" the output should be 4.\n;; For num = \"123456789ABCDEF0\" the output should be 6.\n;; For num = \"2020\" the output should be 2.\n(define (hex_key num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; decimal_to_binary(15)   # returns \"db1111db\"\n;; decimal_to_binary(32)   # returns \"db100000db\"\n(define (decimal_to_binary decimal)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> filter_by_substring([], 'a')\n;; []\n;; >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n;; ['abc', 'bacd', 'array']\n(define (filter_by_substring strings substring)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; is_happy(a) => False\n;; is_happy(aa) => False\n;; is_happy(abcd) => True\n;; is_happy(aabb) => False\n;; is_happy(adb) => True\n;; is_happy(xyy) => False\n(define (is_happy s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n(define (numerical_letter_grade grades)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n;; prime_length('Hello') == True\n;; prime_length('abcdcba') == True\n;; prime_length('kittens') == True\n;; prime_length('orange') == False\n(define (prime_length string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; For N = 1000, the sum of digits will be 1 the output should be \"1\".\n;; For N = 150, the sum of digits will be 6 the output should be \"110\".\n;; For N = 147, the sum of digits will be 12 the output should be \"1100\".\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; add([4, 2, 6, 7]) ==> 2\n(define (add lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; anti_shuffle('Hi') returns 'Hi'\n;; anti_shuffle('hello') returns 'ehllo'\n;; anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n(define (anti_shuffle s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; get_row([\n;; [1,2,3,4,5,6],\n;; [1,2,3,4,1,6],\n;; [1,2,3,4,5,1]\n;; ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n;; get_row([], 1) == []\n;; get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n(define (get_row lst x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n;; * sort_array([]) => []\n;; * sort_array([5]) => [5]\n;; * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n;; * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n(define (sort_array array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; encrypt('hi') returns 'lm'\n;; encrypt('asdfghjkl') returns 'ewhjklnop'\n;; encrypt('gf') returns 'kj'\n;; encrypt('et') returns 'ix'\n(define (encrypt s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> sum_product([])\n;; (0, 1)\n;; >>> sum_product([1, 2, 3, 4])\n;; (10, 24)\n(define (sum_product numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n;; next_smallest([1, 2, 3, 4, 5]) == 2\n;; next_smallest([5, 1, 4, 3, 2]) == 2\n;; next_smallest([]) == None\n;; next_smallest([1, 1]) == None\n(define (next_smallest lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> is_bored(\"Hello world\")\n;; 0\n;; >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; any_int(5, 2, 7) \u279e True\n;; any_int(3, 2, 2) \u279e False\n;; any_int(3, -2, 1) \u279e True\n;; any_int(3.6, -2.2, 2) \u279e False\n(define (any_int x y z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> encode('test')\n;; 'TGST'\n;; >>> encode('This is a message')\n;; 'tHKS KS C MGSSCGG'\n(define (encode message)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n;; For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n;; For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n;; For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n;; For lst = [0,81,12,3,1,21] the output should be 3\n;; For lst = [0,8,1,2,1,7] the output should be 7\n(define (skjkasdkd lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n;; check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n;; check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n;; check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n;; check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n;; check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n(define (check_dict_case dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; count_up_to(5) => [2,3]\n;; count_up_to(11) => [2,3,5,7]\n;; count_up_to(0) => []\n;; count_up_to(20) => [2,3,5,7,11,13,17,19]\n;; count_up_to(1) => []\n;; count_up_to(18) => [2,3,5,7,11,13,17]\n(define (count_up_to n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; multiply(148, 412) should return 16.\n;; multiply(19, 28) should return 72.\n;; multiply(2020, 1851) should return 0.\n;; multiply(14,-15) should return 20.\n(define (multiply a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; count_upper('aBCdEf') returns 1\n;; count_upper('abcdefg') returns 0\n;; count_upper('dBBE') returns 0\n(define (count_upper s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> closest_integer(\"10\")\n;; 10\n;; >>> closest_integer(\"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n;; [1, 2, 3, 3, 3, 4, 4]\n(define (rolling_max numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/humaneval-rkt-remove.json
+++ b/prompts/humaneval-rkt-remove.json
@@ -1,1707 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return length of given string\n(define (strlen string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n(define (encrypt s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n(define (check_dict_case dict)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n(define (add lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with -\n(define (fix_spaces text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n(define (fibfib n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n(define (filter_integers values)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n(define (parse_music music_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n(define (decimal_to_binary decimal)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n(define (all_prefixes string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Add two numbers x and y\n(define (add x y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; Example 2:\n;; Example 3:\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n(define (flip_case string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; If the array is empty, return an empty array:\n;; If the array has any strange number ignore it:\n(define (by_length arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n(define (factorize n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n(define (count_up_to n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n(define (unique l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n(define (total_match lst1 lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n(define (max_element l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n(define (is_nested string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n(define (rounded_avg n m)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n(define (odd_count lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n(define (is_equal_to_sum_even n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n(define (derivative xs)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n(define (is_sorted lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n(define (solve s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n(define (tri n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n(define (fizz_buzz n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n(define (filter_by_prefix strings prefix)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:\n(define (minPath grid k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n(define (count_upper s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; Example 2:\n;; Example 3:\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n(define (largest_divisor n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n(define (sort_array array)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n(define (f n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n(define (iscube a)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n(define (encode message)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n(define (is_bored S)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n(define (pairs_sum_to_zero l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n(define (triangle_area a b c)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n(define (bf planet1 planet2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n(define (digits n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n(define (words_string s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n(define (how_many_times string substring)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n(define (compare_one a b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n(define (remove_vowels text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n(define (strange_sort_list lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n(define (find_closest_elements numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n(define (is_simple_power x n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n(define (prime_fib n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n(define (order_by_points nums)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if in given list of numbers, are any two numbers closer to each other than\n;; given threshold.\n(define (has_close_elements numbers threshold)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate has_close_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.3) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.05) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.95) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.8) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0) 0.1) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 1.0) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 0.5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n(define (make_palindrome string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n(define (string_xor a b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n(define (fib4 n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n(define (unique_digits x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n(define (select_words s n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n(define (fib n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n(define (Strongest_Extension class_name extensions)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n(define (match_parens lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n(define (next_smallest lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n(define (any_int x y z)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n(define (truncate_number number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n(define (incr_list l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n(define (x_or_y n x y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n(define (modp n p)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n(define (even_odd_count num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n(define (is_happy s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n(define (largest_prime_factor n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n(define (digitSum s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n(define (rescale_to_unit numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n(define (solution lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; Example 4:\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n(define (median l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n(define (prime_length string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n(define (smallest_change arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n(define (sum_squares lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n(define (file_name_check file_name)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n(define (triples_sum_to_zero l)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n(define (intersection interval1 interval2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n(define (separate_paren_groups paren_string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n(define (compare game guess)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n(define (check_if_last_char_is_a_letter txt)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n(define (valid_date date)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n(define (count_nums arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n(define (anti_shuffle s)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n(define (is_palindrome text)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n(define (get_closest_vowel word)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n(define (is_prime n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n(define (simplify x n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n(define (hex_key num)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; Example 2:\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n(define (histogram test)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n(define (get_row lst x)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n(define (get_odd_collatz n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n(define (can_arrange arr)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n(define (sort_numbers numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n(define (circular_shift x shift)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n(define (sum_squares lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n(define (skjkasdkd lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n(define (sum_product numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n(define (choose_num x y)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n(define (largest_smallest_integers lst)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n(define (count_distinct_characters string)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1714,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given a positive integer n, you have to make a pile of n levels of stones.\n;; The first level has n stones.\n;; The number of stones in the next level is:\n;; - the next odd number if n is odd.\n;; - the next even number if n is even.\n;; Return the number of stones in each level in a list, where element at index\n;; i represents the number of stones in the level (i+1).\n;; Examples:\n(define (make_a_pile n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_a_pile))\n    (check-within (candidate 3) (list 3 5 7) 0.001)\n    (check-within (candidate 4) (list 4 6 8 10) 0.001)\n    (check-within (candidate 5) (list 5 7 9 11 13) 0.001)\n    (check-within (candidate 6) (list 6 8 10 12 14 16) 0.001)\n    (check-within (candidate 8) (list 8 10 12 14 16 18 20 22) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -1725,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n(define (prod_signs arr)\n",
+    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n(define (words_string s)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1740,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n(define (minSubArraySum nums)\n",
+    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n(define (choose_num x y)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1755,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n(define (string_sequence n)\n",
+    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n(define (rounded_avg n m)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1770,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n(define (cycpattern_check a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n(define (unique_digits x)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1785,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n(define (monotonic l)\n",
+    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; If the array is empty, return an empty array:\n;; If the array has any strange number ignore it:\n(define (by_length arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1800,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n(define (longest strings)\n",
+    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n(define (f n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1815,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n(define (below_threshold l t)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1830,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n(define (count_nums arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1845,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n(define (get_positive l)\n",
+    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1860,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n(define (sort_third l)\n",
+    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n(define (make_palindrome string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1875,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n(define (parse_nested_parens paren_string)\n",
+    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1890,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n(define (triangle_area a h)\n",
+    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n(define (histogram test)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n(define (multiply a b)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n(define (mean_absolute_deviation numbers)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n(define (common l1 l2)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n(define (int_to_mini_roman number)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n(define (fruit_distribution s n)\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1984,7 +214,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Task\n;; We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n;; then check if the result string is palindrome.\n;; A string is called palindrome if it reads the same backward as forward.\n;; You should return a tuple containing the result string and True/False for the check.\n;; Example\n(define (reverse_delete s c)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_delete))\n    (check-within (candidate \"abcde\" \"ae\") (list \"bcd\" #f) 0.001)\n    (check-within (candidate \"abcdef\" \"b\") (list \"acdef\" #f) 0.001)\n    (check-within (candidate \"abcdedcba\" \"ab\") (list \"cdedc\" #t) 0.001)\n    (check-within (candidate \"dwik\" \"w\") (list \"dik\" #f) 0.001)\n    (check-within (candidate \"a\" \"a\") (list \"\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"v\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"vabba\" \"v\") (list \"abba\" #t) 0.001)\n    (check-within (candidate \"mamma\" \"mia\") (list \"\" #t) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -1995,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n(define (greatest_common_divisor a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n(define (odd_count lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2010,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n(define (split_words txt)\n",
+    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n(define (minSubArraySum nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; Example 2:\n;; Example 3:\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2029,7 +274,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; In this Kata, you have to sort an array of non-negative integers according to\n;; number of ones in their binary representation in ascending order.\n;; For similar number of ones, sort based on decimal value.\n;; It must be implemented like this:\n(define (sort_array arr)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list 1 5 2 3 4)) (list 1 2 4 3 5) 0.001)\n    (check-within (candidate (list -2 -3 -4 -5 -6)) (list -4 -2 -6 -5 -3) 0.001)\n    (check-within (candidate (list 1 0 2 3 4)) (list 0 1 2 4 3) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 2 5 77 4 5 3 5 7 2 3 4)) (list 2 2 4 4 3 3 5 5 5 7 77) 0.001)\n    (check-within (candidate (list 3 6 44 12 32 5)) (list 32 3 5 6 12 44) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2040,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n(define (concatenate strings)\n",
+    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n(define (select_words s n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2055,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n(define (sorted_list_sum lst)\n",
+    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n(define (get_closest_vowel word)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2070,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n(define (filter_by_substring strings substring)\n",
+    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n(define (match_parens lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2085,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n(define (string_xor a b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2100,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n(define (vowels_count s)\n",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; Example 2:\n;; Example 3:\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2115,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n(define (find_max words)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n(define (solution lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2130,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n(define (string_to_md5 text)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2145,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n(define (change_base x base)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n(define (get_odd_collatz n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2160,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n(define (right_angle_triangle a b c)\n",
+    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n(define (valid_date date)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2175,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n(define (numerical_letter_grade grades)\n",
+    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n(define (split_words txt)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2190,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n(define (intersperse numbers delimeter)\n",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n(define (is_sorted lst)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n(define (intersection interval1 interval2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n(define (prod_signs arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:\n(define (minPath grid k)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n(define (longest strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n(define (tri n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n(define (digits n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n(define (is_nested string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n(define (sum_squares lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n(define (check_if_last_char_is_a_letter txt)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n(define (can_arrange arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n(define (largest_smallest_integers lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n(define (compare_one a b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n(define (is_equal_to_sum_even n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n(define (greatest_common_divisor a b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with -\n(define (fix_spaces text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n(define (file_name_check file_name)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n(define (sum_squares lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; Example 2:\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n(define (simplify x n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n(define (order_by_points nums)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2209,7 +769,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function that takes an array of numbers as input and returns \n;; the number of elements in the array that are greater than 10 and both \n;; first and last digits of a number are odd (1, 3, 5, 7, 9).\n;; For example:\n(define (specialFilter nums)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate specialFilter))\n    (check-within (candidate (list 5 -2 1 -5)) 0 0.001)\n    (check-within (candidate (list 15 -73 14 -15)) 1 0.001)\n    (check-within (candidate (list 33 -2 -3 45 21 109)) 2 0.001)\n    (check-within (candidate (list 43 -12 93 125 121 109)) 4 0.001)\n    (check-within (candidate (list 71 -2 -33 75 21 19)) 3 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list )) 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2220,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n(define (sum_to_n n)\n",
+    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2235,13 +795,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n(define (remove_duplicates numbers)\n",
+    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n(define (bf planet1 planet2)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n(define (sorted_list_sum lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n(define (all_prefixes string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n(define (x_or_y n x y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n(define (compare game guess)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n(define (Strongest_Extension class_name extensions)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n(define (cycpattern_check a b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n(define (even_odd_count num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n(define (int_to_mini_roman number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n(define (right_angle_triangle a b c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n(define (find_max words)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n(define (string_sequence n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n(define (solve s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n(define (string_to_md5 text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2254,7 +1039,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given two positive integers a and b, return the even digits between a\n;; and b, in ascending order.\n;; For example:\n(define (generate_integers a b)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate generate_integers))\n    (check-within (candidate 2 10) (list 2 4 6 8) 0.001)\n    (check-within (candidate 10 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 132 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 17 89) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n(define (rolling_max numbers)\n",
+    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n(define (count_distinct_characters string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2280,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n(define (below_zero operations)\n",
+    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n(define (parse_music music_string)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2295,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n(define (search lst)\n",
+    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n(define (how_many_times string substring)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2310,13 +1095,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n(define (correct_bracketing brackets)\n",
+    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n(define (sort_numbers numbers)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n(define (separate_paren_groups paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n(define (find_closest_elements numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n(define (rescale_to_unit numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n(define (filter_integers values)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return length of given string\n(define (strlen string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n(define (largest_divisor n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n(define (factorize n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n(define (remove_duplicates numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n(define (flip_case string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n(define (concatenate strings)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n(define (filter_by_prefix strings prefix)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n(define (truncate_number number)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n(define (get_positive l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n(define (is_prime n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n(define (sort_third l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n(define (unique l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n(define (max_element l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n(define (fizz_buzz n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2329,9 +1384,234 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the odd indicies, while its values at the even indicies are equal\n;; to the values of the even indicies of l, but sorted.\n(define (sort_even l)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_even))\n    (check-within (candidate (list 1 2 3)) (list 1 2 3) 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 123 1 -10)) (list -10 3 -5 2 -3 3 5 0 9 1 123) 0.001)\n    (check-within (candidate (list 5 8 -12 4 23 2 3 11 12 -10)) (list -12 8 3 4 5 2 12 11 23 -10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n(define (prime_fib n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n(define (below_zero operations)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n(define (triples_sum_to_zero l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n(define (incr_list l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n(define (pairs_sum_to_zero l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n(define (change_base x base)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n(define (triangle_area a h)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n(define (fib4 n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n(define (median l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n(define (is_palindrome text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n(define (modp n p)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n(define (mean_absolute_deviation numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n(define (remove_vowels text)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n(define (below_threshold l t)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Add two numbers x and y\n(define (add x y)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2344,9 +1624,24 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if two words have the same characters.\n(define (same_chars s0 s1)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate same_chars))\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") #t 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabc\") #t 0.001)\n    (check-within (candidate \"dddddddabc\" \"abcd\") #t 0.001)\n    (check-within (candidate \"eabcd\" \"dddddddabc\") #f 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabcf\") #f 0.001)\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") #f 0.001)\n    (check-within (candidate \"aabb\" \"aaccc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n(define (fib n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2359,9 +1654,714 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; brackets is a string of \"<\" and \">\".\n;; return True if every opening bracket has a corresponding closing bracket.\n(define (correct_bracketing brackets)\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"<>\") #t 0.001)\n    (check-within (candidate \"<<><>>\") #t 0.001)\n    (check-within (candidate \"<><><<><>><>\") #t 0.001)\n    (check-within (candidate \"<><><<<><><>><>><<><><<>>>\") #t 0.001)\n    (check-within (candidate \"<<<><>>>>\") #f 0.001)\n    (check-within (candidate \"><<>\") #f 0.001)\n    (check-within (candidate \"<\") #f 0.001)\n    (check-within (candidate \"<<<<\") #f 0.001)\n    (check-within (candidate \">\") #f 0.001)\n    (check-within (candidate \"<<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>><<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>>><>\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n(define (monotonic l)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n(define (common l1 l2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n(define (largest_prime_factor n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n(define (intersperse numbers delimeter)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n(define (sum_to_n n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n(define (correct_bracketing brackets)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n(define (derivative xs)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n(define (fibfib n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n(define (vowels_count s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n(define (circular_shift x shift)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n(define (digitSum s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n(define (fruit_distribution s n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; Example 4:\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n(define (search lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n(define (parse_nested_parens paren_string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n(define (strange_sort_list lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n(define (triangle_area a b c)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n(define (smallest_change arr)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n(define (total_match lst1 lst2)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n(define (is_simple_power x n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n(define (iscube a)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n(define (hex_key num)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n(define (decimal_to_binary decimal)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n(define (filter_by_substring strings substring)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n(define (is_happy s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n(define (numerical_letter_grade grades)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n(define (prime_length string)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n(define (add lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n(define (anti_shuffle s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n(define (get_row lst x)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n(define (sort_array array)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n(define (encrypt s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n(define (sum_product numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n(define (next_smallest lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n(define (is_bored S)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n(define (any_int x y z)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n(define (encode message)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n(define (skjkasdkd lst)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n(define (check_dict_case dict)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n(define (count_up_to n)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n(define (multiply a b)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n(define (count_upper s)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n(define (rolling_max numbers)\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/humaneval-rkt-reworded.json
+++ b/prompts/humaneval-rkt-reworded.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> (strlen \"\")\n;; 0\n;; >>> (strlen \"abc\")\n;; 3\n(define (strlen string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; >>> (encrypt \"hi\")\n;; \"lm\"\n;; >>> (encrypt \"asdfghjkl\")\n;; \"ewhjklnop\"\n;; >>> (encrypt \"gf\")\n;; \"kj\"\n;; >>> (encrypt \"et\")\n;; \"ix\"\n(define (encrypt s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a hash, return #t if all keys are strings in lower \n;; case or all keys are strings in upper case, else return #f.\n;; The function should return #f is the given hash is empty.\n;; Examples:\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"b\" .  \"banana\")))\n;; #t\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\")))\n;; #f\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (8 .  \"banana\") (\"a\" .  \"apple\")))\n;; #f\n;; >>> (check_dict_case #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\")))\n;; #f\n;; >>> (check_dict_case #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\")))\n;; #t\n(define (check_dict_case dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; >>> (add (list 4 2 6 7))\n;; 2\n(define (add lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; >>> (fix_spaces \" Example\")\n;; \"Example\"\n;; >>> (fix_spaces \" Example 1\")\n;; \"Example_1\"\n;; >>> (fix_spaces \" Example 2\")\n;; \"_Example_2\"\n;; >>> (fix_spaces \" Example 3\")\n;; \"_Example-3\"\n(define (fix_spaces text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> (fibfib 1)\n;; 0\n;; >>> (fibfib 5)\n;; 4\n;; >>> (fibfib 8)\n;; 24\n(define (fibfib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; >>> (double_the_difference (list 1 3 2 0))\n;; 10\n;; >>> (double_the_difference (list -1 -2 0))\n;; 0\n;; >>> (double_the_difference (list 9 -2))\n;; 81\n;; >>> (double_the_difference (list 0))\n;; 0\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter given list of any rktthon values only for integers\n;; >>> (filter_integers (list \"a\" 3.14 5))\n;; (list 5)\n;; >>> (filter_integers (list 1 2 3 \"abc\" #hash() (list )))\n;; (list 1 2 3)\n(define (filter_integers values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> (parse_music \"o o| .| o| o| .| .| .| .| o o\")\n;; (list 4 2 1 2 2 1 1 1 1 4 4)\n(define (parse_music music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; >>> (decimal_to_binary 15)\n;; \"db1111db\"\n;; >>> (decimal_to_binary 32)\n;; \"db100000db\"\n(define (decimal_to_binary decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> (all_prefixes \"abc\")\n;; (list \"a\" \"ab\" \"abc\")\n(define (all_prefixes string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> (add 2 3)\n;; 5\n;; >>> (add 5 7)\n;; 12\n(define (add x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return a list of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; >>> (eat 5 6 10)\n;; (list 11 4)\n;; >>> (eat 4 8 9)\n;; (list 12 1)\n;; >>> (eat 1 10 10)\n;; (list 11 0)\n;; >>> (eat 2 11 5)\n;; (list 7 0)\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; >>> (max_fill (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1)\n;; 6\n;; Example 2:\n;; >>> (max_fill (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2)\n;; 5\n;; Example 3:\n;; >>> (max_fill (list (list 0 0 0) (list 0 0 0)) 5)\n;; 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; list = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> (flip_case \"Hello\")\n;; \"hELLO\"\n(define (flip_case string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting list, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; >>> (by_length (list 2 1 1 4 5 8 2 3))\n;; (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\")\n;; If the list is empty, return an empty list:\n;; >>> (by_length (list ))\n;; (list )\n;; If the list has any strange number ignore it:\n;; >>> (by_length (list 1 -1 55))\n;; (list \"One\")\n(define (by_length arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> (factorize 8)\n;; (list 2 2 2)\n;; >>> (factorize 25)\n;; (list 5 5)\n;; >>> (factorize 70)\n;; (list 2 5 7)\n(define (factorize n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns a list of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; >>> (count_up_to 5)\n;; (list 2 3)\n;; >>> (count_up_to 11)\n;; (list 2 3 5 7)\n;; >>> (count_up_to 0)\n;; (list )\n;; >>> (count_up_to 20)\n;; (list 2 3 5 7 11 13 17 19)\n;; >>> (count_up_to 1)\n;; (list )\n;; >>> (count_up_to 18)\n;; (list 2 3 5 7 11 13 17)\n(define (count_up_to n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> (unique (list 5 3 5 2 3 3 9 0 123))\n;; (list 0 2 3 5 9 123)\n(define (unique l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; >>> (total_match (list ) (list ))\n;; (list )\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"Hi\"))\n;; (list \"hI\" \"Hi\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\"))\n;; (list \"hi\" \"admin\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\"))\n;; (list \"hI\" \"hi\" \"hi\")\n;; >>> (total_match (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\"))\n;; (list \"4\")\n(define (total_match lst1 lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> (max_element (list 1 2 3))\n;; 3\n;; >>> (max_element (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; 123\n(define (max_element l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return #t if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; >>> (is_nested \"[[]]\")\n;; #t\n;; >>> (is_nested \"[]]]]]]][[[[[]\")\n;; #f\n;; >>> (is_nested \"[][]\")\n;; #f\n;; >>> (is_nested \"[]\")\n;; #f\n;; >>> (is_nested \"[[][]]\")\n;; #t\n;; >>> (is_nested \"[[]][[\")\n;; #t\n(define (is_nested string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; >>> (rounded_avg 1 5)\n;; \"0b11\"\n;; >>> (rounded_avg 7 5)\n;; -1\n;; >>> (rounded_avg 10 20)\n;; \"0b1111\"\n;; >>> (rounded_avg 20 33)\n;; \"0b11010\"\n(define (rounded_avg n m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> (odd_count (list \"1234567\"))\n;; (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n;; >>> (odd_count (list \"3\" \"11111111\"))\n;; (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\n(define (odd_count lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the list will be randomly ordered. Your task is to determine if\n;; it is possible to get a list sorted in non-decreasing order by performing \n;; the following operation on the given list:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the list by one\n;; position in the right direction. The last element of the list will be moved to\n;; the starting position in the list i.e. 0th index. \n;; If it is possible to obtain the sorted list by performing the above operation\n;; then return #t else return #f.\n;; If the given list is empty then return #t.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; >>> (move_one_ball (list 3 4 5 1 2))\n;; #t\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given list.\n;; >>> (move_one_ball (list 3 5 4 1 2))\n;; #f\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; list by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a list that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; >>> (even_odd_palindrome 3)\n;; (list 1 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; >>> (even_odd_palindrome 12)\n;; (list 4 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned list has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; >>> (is_equal_to_sum_even 4)\n;; #f\n;; >>> (is_equal_to_sum_even 6)\n;; #f\n;; >>> (is_equal_to_sum_even 8)\n;; #t\n(define (is_equal_to_sum_even n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> (derivative (list 3 1 2 4 5))\n;; (list 1 4 12 20)\n;; >>> (derivative (list 1 2 3))\n;; (list 2 6)\n(define (derivative xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return #f. Assume no negative numbers and only integers.\n;; Examples\n;; >>> (is_sorted (list 5))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5))\n;; #f\n;; >>> (is_sorted (list 1 2 3 4 5 6))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5 6 7))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5 6 7))\n;; #f\n;; >>> (is_sorted (list 1 2 2 3 3 4))\n;; #t\n;; >>> (is_sorted (list 1 2 2 2 3 4))\n;; #f\n(define (is_sorted lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; >>> (solve \"1234\")\n;; \"4321\"\n;; >>> (solve \"ab\")\n;; \"AB\"\n;; >>> (solve \"#a@C\")\n;; \"#A@c\"\n(define (solve s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; >>> (tri 3)\n;; (list 1 3 2 8)\n(define (tri n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> (fizz_buzz 50)\n;; 0\n;; >>> (fizz_buzz 78)\n;; 2\n;; >>> (fizz_buzz 79)\n;; 3\n(define (fizz_buzz n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> (filter_by_prefix (list ) \"a\")\n;; (list )\n;; >>> (filter_by_prefix (list \"abc\" \"bcd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"array\")\n(define (filter_by_prefix strings prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; >>> (solve 1000)\n;; \"1\"\n;; >>> (solve 150)\n;; \"110\"\n;; >>> (solve 147)\n;; \"1100\"\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:    \n;; >>> (minPath (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3)\n;; (list 1 2 1)\n;; >>> (minPath (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1)\n;; (list 1)\n(define (minPath grid k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; >>> (count_upper \"aBCdEf\")\n;; 1\n;; >>> (count_upper \"abcdefg\")\n;; 0\n;; >>> (count_upper \"dBBE\")\n;; 0\n(define (count_upper s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; >>> (maximum (list -3 -4 5) 3)\n;; (list -4 -3 5)\n;; Example 2:\n;; >>> (maximum (list 4 -4 4) 2)\n;; (list 4 4)\n;; Example 3:\n;; >>> (maximum (list -3 2 1 2 -1 -2 1) 1)\n;; (list 2)\n;; Note:\n;; 1. The length of the list will be in the range of [1, 1000].\n;; 2. The elements in the list will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> (largest_divisor 15)\n;; 5\n(define (largest_divisor n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of non-negative integers, return a corkt of the given list after sorting,\n;; you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given list.\n;; Examples:\n;; >>> (sort_array (list ))\n;; (list )\n;; >>> (sort_array (list 5))\n;; (list 5)\n;; >>> (sort_array (list 2 4 3 0 1 5))\n;; (list 0 1 2 3 4 5)\n;; >>> (sort_array (list 2 4 3 0 1 5 6))\n;; (list 6 5 4 3 2 1 0)\n(define (sort_array array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; >>> (f 5)\n;; (list 1 2 6 24 15)\n(define (f n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns #t \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; >>> (iscube 1)\n;; #t\n;; >>> (iscube 2)\n;; #f\n;; >>> (iscube -1)\n;; #t\n;; >>> (iscube 64)\n;; #t\n;; >>> (iscube 0)\n;; #t\n;; >>> (iscube 180)\n;; #f\n(define (iscube a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> (encode \"test\")\n;; \"TGST\"\n;; >>> (encode \"This is a message\")\n;; \"tHKS KS C MGSSCGG\"\n(define (encode message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> (is_bored \"Hello world\")\n;; 0\n;; >>> (is_bored \"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns #t if there are two distinct elements in the list that\n;; sum to zero, and #f otherwise.\n;; >>> (pairs_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 3 -2 1))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (pairs_sum_to_zero (list 2 4 -5 3 5 7))\n;; #t\n;; >>> (pairs_sum_to_zero (list 1))\n;; #f\n(define (pairs_sum_to_zero l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; >>> (triangle_area 3 4 5)\n;; 6.0\n;; >>> (triangle_area 1 2 10)\n;; -1\n(define (triangle_area a b c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a list containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty list if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; >>> (bf \"Jupiter\" \"Neptune\")\n;; (list \"Saturn\" \"Uranus\")\n;; >>> (bf \"Earth\" \"Mercury\")\n;; \"Venus\"\n;; >>> (bf \"Mercury\" \"Uranus\")\n;; (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\")\n(define (bf planet1 planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; >>> (digits 1)\n;; 1\n;; >>> (digits 4)\n;; 0\n;; >>> (digits 235)\n;; 15\n(define (digits n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return a list of the words.\n;; For example:\n;; >>> (words_string \"Hi, my name is John\")\n;; (list \"Hi\" \"my\" \"name\" \"is\" \"John\")\n;; >>> (words_string \"One, two, three, four, five, six\")\n;; (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\")\n(define (words_string s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> (how_many_times \"\" \"a\")\n;; 0\n;; >>> (how_many_times \"aaa\" \"a\")\n;; 3\n;; >>> (how_many_times \"aaaa\" \"aa\")\n;; 3\n(define (how_many_times string substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return #f if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; >>> (compare_one 1 2.5)\n;; 2.5\n;; >>> (compare_one 1 \"2,3\")\n;; \"2,3\"\n;; >>> (compare_one \"5,1\" \"6\")\n;; \"6\"\n;; >>> (compare_one \"1\" 1)\n;; #f\n(define (compare_one a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> (remove_vowels \"\")\n;; \"\"\n;; >>> (remove_vowels \"abcdef\")\n;; \"bcdf\"\n;; >>> (remove_vowels \"aaaaa\")\n;; \"\"\n;; >>> (remove_vowels \"aaBAA\")\n;; \"B\"\n;; >>> (remove_vowels \"zbcd\")\n;; \"zbcd\"\n(define (remove_vowels text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; >>> (strange_sort_list (list 1 2 3 4))\n;; (list 1 4 2 3)\n;; >>> (strange_sort_list (list 5 5 5 5))\n;; (list 5 5 5 5)\n;; >>> (strange_sort_list (list ))\n;; (list )\n(define (strange_sort_list lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.2))\n;; (list 2.0 2.2)\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.0))\n;; (list 2.0 2.0)\n(define (find_closest_elements numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; >>> (is_simple_power 1 4)\n;; #t\n;; >>> (is_simple_power 2 2)\n;; #t\n;; >>> (is_simple_power 8 2)\n;; #t\n;; >>> (is_simple_power 3 2)\n;; #f\n;; >>> (is_simple_power 3 1)\n;; #f\n;; >>> (is_simple_power 5 3)\n;; #f\n(define (is_simple_power x n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> (prime_fib 1)\n;; 2\n;; >>> (prime_fib 2)\n;; 3\n;; >>> (prime_fib 3)\n;; 5\n;; >>> (prime_fib 4)\n;; 13\n;; >>> (prime_fib 5)\n;; 89\n(define (prime_fib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> (order_by_points (list 1 11 -1 -11 -12))\n;; (list -1 -11 1 -12 11)\n;; >>> (order_by_points (list ))\n;; (list )\n(define (order_by_points nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if in given list of numbers, are any two numbers closer to each other than\n;; given threshold.\n;; >>> (has_close_elements (list 1.0 2.0 3.0) 0.5)\n;; #f\n;; >>> (has_close_elements (list 1.0 2.8 3.0 4.0 5.0 2.0) 0.3)\n;; #t\n(define (has_close_elements numbers threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate has_close_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.3) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.05) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.95) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.8) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0) 0.1) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 1.0) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 0.5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> (make_palindrome \"\")\n;; \"\"\n;; >>> (make_palindrome \"cat\")\n;; \"catac\"\n;; >>> (make_palindrome \"cata\")\n;; \"catac\"\n(define (make_palindrome string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> (string_xor \"010\" \"110\")\n;; \"100\"\n(define (string_xor a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> (special_factorial 4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; >>> (add_elements (list 111 21 3 4000 5 6 7 8 9) 4)\n;; 24\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> (fib4 5)\n;; 4\n;; >>> (fib4 6)\n;; 8\n;; >>> (fib4 7)\n;; 14\n(define (fib4 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> (unique_digits (list 15 33 1422 1))\n;; (list 1 15 33)\n;; >>> (unique_digits (list 152 323 1422 10))\n;; (list )\n(define (unique_digits x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; >>> (select_words \"Mary had a little lamb\" 4)\n;; (list \"little\")\n;; >>> (select_words \"Mary had a little lamb\" 3)\n;; (list \"Mary\" \"lamb\")\n;; >>> (select_words \"simple white space\" 2)\n;; (list )\n;; >>> (select_words \"Hello world\" 4)\n;; (list \"world\")\n;; >>> (select_words \"Uncle sam\" 3)\n;; (list \"Uncle\")\n(define (select_words s n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns #t if the object q will fly, and #f otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; >>> (will_it_fly (list 1 2) 5)\n;; #f\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; >>> (will_it_fly (list 3 2 3) 1)\n;; #f\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; >>> (will_it_fly (list 3 2 3) 9)\n;; #t\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; >>> (will_it_fly (list 3) 5)\n;; #t\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> (fib 10)\n;; 55\n;; >>> (fib 1)\n;; 1\n;; >>> (fib 8)\n;; 21\n(define (fib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; >>> (Strongest_Extension \"my_class\" (list \"AA\" \"Be\" \"CC\"))\n;; \"my_class.AA\"\n(define (Strongest_Extension class_name extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; >>> (match_parens (list \"()(\" \")\"))\n;; \"Yes\"\n;; >>> (match_parens (list \")\" \")\"))\n;; \"No\"\n(define (match_parens lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return #f if there is no such element.\n;; >>> (next_smallest (list 1 2 3 4 5))\n;; 2\n;; >>> (next_smallest (list 5 1 4 3 2))\n;; 2\n;; >>> (next_smallest (list ))\n;; #f\n;; >>> (next_smallest (list 1 1))\n;; #f\n(define (next_smallest lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; >>> (any_int 5 2 7)\n;; #t\n;; >>> (any_int 3 2 2)\n;; #f\n;; >>> (any_int 3 -2 1)\n;; #t\n;; >>> (any_int 3.6 -2.2 2)\n;; #f\n(define (any_int x y z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> (truncate_number 3.5)\n;; 0.5\n(define (truncate_number number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> (incr_list (list 1 2 3))\n;; (list 2 3 4)\n;; >>> (incr_list (list 5 3 5 2 3 3 9 0 123))\n;; (list 6 4 6 3 4 4 10 1 124)\n(define (incr_list l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; >>> (x_or_y 7 34 12)\n;; 34\n;; >>> (x_or_y 15 8 5)\n;; 5\n(define (x_or_y n x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> (modp 3 5)\n;; 3\n;; >>> (modp 1101 101)\n;; 2\n;; >>> (modp 0 101)\n;; 1\n;; >>> (modp 3 11)\n;; 8\n;; >>> (modp 100 101)\n;; 1\n(define (modp n p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an integer. return a list that has the number of even and odd digits respectively.\n;; Example:\n;; >>> (even_odd_count -12)\n;; (list 1 1)\n;; >>> (even_odd_count 123)\n;; (list 1 2)\n(define (even_odd_count num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is haprkt or not.\n;; A string is haprkt if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; >>> (is_happy \"a\")\n;; #f\n;; >>> (is_happy \"aa\")\n;; #f\n;; >>> (is_happy \"abcd\")\n;; #t\n;; >>> (is_happy \"aabb\")\n;; #f\n;; >>> (is_happy \"adb\")\n;; #t\n;; >>> (is_happy \"xyy\")\n;; #f\n(define (is_happy s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> (largest_prime_factor 13195)\n;; 29\n;; >>> (largest_prime_factor 2048)\n;; 2\n(define (largest_prime_factor n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; >>> (digitSum \"\")\n;; 0\n;; >>> (digitSum \"abAB\")\n;; 131\n;; >>> (digitSum \"abcCd\")\n;; 67\n;; >>> (digitSum \"helloE\")\n;; 69\n;; >>> (digitSum \"woArBld\")\n;; 131\n;; >>> (digitSum \"aAaaaXa\")\n;; 153\n(define (digitSum s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> (rescale_to_unit (list 1.0 2.0 3.0 4.0 5.0))\n;; (list 0.0 0.25 0.5 0.75 1.0)\n(define (rescale_to_unit numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; >>> (solution (list 5 8 7 1))\n;; 12\n;; >>> (solution (list 3 3 3 3 3))\n;; 9\n;; >>> (solution (list 30 13 24 321))\n;; 0\n(define (solution lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"Given a list representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given list is empty, return [].\n;; Example 1:\n;; >>> (pluck (list 4 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; >>> (pluck (list 1 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; >>> (pluck (list ))\n;; (list )\n;; Example 4:\n;; >>> (pluck (list 5 0 3 0 4 2))\n;; (list 0 1)\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer list a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; >>> (get_max_triples 5)\n;; 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; >>> (exchange (list 1 2 3 4) (list 1 2 3 4))\n;; \"YES\"\n;; >>> (exchange (list 1 2 3 4) (list 1 5 3 4))\n;; \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> (median (list 3 1 2 4 5))\n;; 3\n;; >>> (median (list -10 4 6 1000 10 20))\n;; 15.0\n(define (median l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns #t if the string\n;; length is a prime number or #f otherwise\n;; Examples\n;; >>> (prime_length \"Hello\")\n;; #t\n;; >>> (prime_length \"abcdcba\")\n;; #t\n;; >>> (prime_length \"kittens\")\n;; #t\n;; >>> (prime_length \"orange\")\n;; #f\n(define (prime_length string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list arr of integers, find the minimum number of elements that\n;; need to be changed to make the list palindromic. A palindromic list is a list that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; >>> (smallest_change (list 1 2 3 5 4 7 9 6))\n;; 4\n;; >>> (smallest_change (list 1 2 3 4 3 2 2))\n;; 1\n;; >>> (smallest_change (list 1 2 3 2 1))\n;; 0\n(define (smallest_change arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; >>> (lst (list 1.0 2.0 3.0))\n;; 14\n;; >>> (lst (list 1.0 4.0 9.0))\n;; 98\n;; >>> (lst (list 1.0 3.0 5.0 7.0))\n;; 84\n;; >>> (lst (list 1.4 4.2 0.0))\n;; 29\n;; >>> (lst (list -2.4 1.0 1.0))\n;; 6\n(define (sum_squares lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; >>> (file_name_check \"example.txt\")\n;; \"Yes\"\n;; >>> (file_name_check \"1example.dll\")\n;; \"No\"\n(define (file_name_check file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns #t if there are three distinct elements in the list that\n;; sum to zero, and #f otherwise.\n;; >>> (triples_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (triples_sum_to_zero (list 1 3 -2 1))\n;; #t\n;; >>> (triples_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (triples_sum_to_zero (list 2 4 -5 3 9 7))\n;; #t\n;; >>> (triples_sum_to_zero (list 1))\n;; #f\n(define (triples_sum_to_zero l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; >>> (intersection (list 1 2) (list 2 3))\n;; \"NO\"\n;; >>> (intersection (list -1 1) (list 0 4))\n;; \"NO\"\n;; >>> (intersection (list -3 -1) (list -5 5))\n;; \"YES\"\n(define (intersection interval1 interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> (separate_paren_groups \"( ) (( )) (( )( ))\")\n;; (list \"()\" \"(())\" \"(()())\")\n(define (separate_paren_groups paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two lists of scores and guesses of equal length, where each index shows a match. \n;; Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; >>> (compare (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2))\n;; (list 0 0 0 0 3 3)\n;; >>> (compare (list 0 5 0 0 0 4) (list 4 1 1 0 0 -2))\n;; (list 4 4 1 0 0 6)\n(define (compare game guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns #t if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and #f otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; >>> (check_if_last_char_is_a_letter \"apple pie\")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"apple pi e\")\n;; #t\n;; >>> (check_if_last_char_is_a_letter \"apple pi e \")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"\")\n;; #f\n(define (check_if_last_char_is_a_letter txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns #t if the date is valid otherwise #f.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; >>> (valid_date \"03-11-2000\")\n;; #t\n;; >>> (valid_date \"15-01-2012\")\n;; #f\n;; >>> (valid_date \"04-0-2040\")\n;; #f\n;; >>> (valid_date \"06-04-2020\")\n;; #t\n;; >>> (valid_date \"06/04/2020\")\n;; #f\n(define (valid_date date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function count_nums which takes a list of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> (count_nums (list ))\n;; 0\n;; >>> (count_nums (list -1 11 -11))\n;; 1\n;; >>> (count_nums (list 1 1 2))\n;; 3\n(define (count_nums arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; >>> (anti_shuffle \"Hi\")\n;; \"Hi\"\n;; >>> (anti_shuffle \"hello\")\n;; \"ehllo\"\n;; >>> (anti_shuffle \"Hello World!!!\")\n;; \"Hello !!!Wdlor\"\n(define (anti_shuffle s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> (is_palindrome \"\")\n;; #t\n;; >>> (is_palindrome \"aba\")\n;; #t\n;; >>> (is_palindrome \"aaaaa\")\n;; #t\n;; >>> (is_palindrome \"zbcd\")\n;; #f\n(define (is_palindrome text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; >>> (get_closest_vowel \"yogurt\")\n;; \"u\"\n;; >>> (get_closest_vowel \"FULL\")\n;; \"U\"\n;; >>> (get_closest_vowel \"quick\")\n;; \"\"\n;; >>> (get_closest_vowel \"ab\")\n;; \"\"\n(define (get_closest_vowel word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> (is_prime 6)\n;; #f\n;; >>> (is_prime 101)\n;; #t\n;; >>> (is_prime 11)\n;; #t\n;; >>> (is_prime 13441)\n;; #t\n;; >>> (is_prime 61)\n;; #t\n;; >>> (is_prime 4)\n;; #f\n;; >>> (is_prime 1)\n;; #f\n(define (is_prime n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns #t if x * n evaluates to a whole number and #f\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; >>> (simplify \"1/5\" \"5/1\")\n;; #t\n;; >>> (simplify \"1/6\" \"2/1\")\n;; #f\n;; >>> (simplify \"7/10\" \"10/2\")\n;; #f\n(define (simplify x n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; >>> (hex_key \"AB\")\n;; 1\n;; >>> (hex_key \"1077E\")\n;; 2\n;; >>> (hex_key \"ABED1A33\")\n;; 4\n;; >>> (hex_key \"123456789ABCDEF0\")\n;; 6\n;; >>> (hex_key \"2020\")\n;; 2\n(define (hex_key num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; >>> (words_in_sentence \"This is a test\")\n;; \"is\"\n;; Example 2:\n;; >>> (words_in_sentence \"lets go for swimming\")\n;; \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a hash\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; >>> (histogram \"a b c\")\n;; #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1))\n;; >>> (histogram \"a b b a\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"a b c a b\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"b b b b a\")\n;; #hash((\"b\" .  4))\n;; >>> (histogram \"\")\n;; #hash()\n(define (histogram test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of lists, [(x1, y1), (x2, y2) ...] such that\n;; each list is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; >>> (get_row (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1)\n;; (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0))\n;; >>> (get_row (list ) 1)\n;; (list )\n;; >>> (get_row (list (list ) (list 1) (list 1 2 3)) 3)\n;; (list (list 2 2))\n(define (get_row lst x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n;; >>> (get_odd_collatz 5)\n;; (list 1 5)\n(define (get_odd_collatz n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given list will not contain\n;; duplicate values.\n;; Examples:\n;; >>> (can_arrange (list 1 2 4 3 5))\n;; 3\n;; >>> (can_arrange (list 1 2 3))\n;; -1\n(define (can_arrange arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> (sort_numbers \"three one five\")\n;; \"one three five\"\n(define (sort_numbers numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> (circular_shift 12 1)\n;; \"21\"\n;; >>> (circular_shift 12 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; >>> lst\n;; (list 1 2 3)\n;; >>> lst\n;; (list )\n;; >>> lst\n;; (list -1 -5 2 -1 -5)\n(define (sum_squares lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; >>> (skjkasdkd (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3))\n;; 10\n;; >>> (skjkasdkd (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1))\n;; 25\n;; >>> (skjkasdkd (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3))\n;; 13\n;; >>> (skjkasdkd (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6))\n;; 11\n;; >>> (skjkasdkd (list 0 81 12 3 1 21))\n;; 3\n;; >>> (skjkasdkd (list 0 8 1 2 1 7))\n;; 7\n(define (skjkasdkd lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> (sum_product (list ))\n;; (list 0 1)\n;; >>> (sum_product (list 1 2 3 4))\n;; (list 10 24)\n(define (sum_product numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n;; >>> (choose_num 12 15)\n;; 14\n;; >>> (choose_num 13 12)\n;; -1\n(define (choose_num x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns a list (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as #f.\n;; Examples:\n;; >>> (largest_smallest_integers (list 2 4 1 3 5 7))\n;; (list #f 1)\n;; >>> (largest_smallest_integers (list ))\n;; (list #f #f)\n;; >>> (largest_smallest_integers (list 0))\n;; (list #f #f)\n(define (largest_smallest_integers lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n;; >>> (count_distinct_characters \"xyzXYZ\")\n;; 3\n;; >>> (count_distinct_characters \"Jerry\")\n;; 4\n(define (count_distinct_characters string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1759,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given a positive integer n, you have to make a pile of n levels of stones.\n;; The first level has n stones.\n;; The number of stones in the next level is:\n;; - the next odd number if n is odd.\n;; - the next even number if n is even.\n;; Return the number of stones in each level in a list, where element at index\n;; i represents the number of stones in the level (i+1).\n;; Examples:\n;; >>> (make_a_pile 3)\n;; (list 3 5 7)\n(define (make_a_pile n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_a_pile))\n    (check-within (candidate 3) (list 3 5 7) 0.001)\n    (check-within (candidate 4) (list 4 6 8 10) 0.001)\n    (check-within (candidate 5) (list 5 7 9 11 13) 0.001)\n    (check-within (candidate 6) (list 6 8 10 12 14 16) 0.001)\n    (check-within (candidate 8) (list 8 10 12 14 16 18 20 22) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the list, represented by 1, -1 or 0.\n;; Note: return #f for empty arr.\n;; Example:\n;; >>> (prod_signs (list 1 2 2 -4))\n;; 9\n;; >>> (prod_signs (list 0 1))\n;; 0\n;; >>> (prod_signs (list ))\n;; #f\n(define (prod_signs arr)\n",
+    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return a list of the words.\n;; For example:\n;; >>> (words_string \"Hi, my name is John\")\n;; (list \"Hi\" \"my\" \"name\" \"is\" \"John\")\n;; >>> (words_string \"One, two, three, four, five, six\")\n;; (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\")\n(define (words_string s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of integers nums, find the minimum sum of any non-empty sub-list\n;; of nums.\n;; Example\n;; >>> (minSubArraySum (list 2 3 4 1 2 4))\n;; 1\n;; >>> (minSubArraySum (list -1 -2 -3))\n;; -6\n(define (minSubArraySum nums)\n",
+    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n;; >>> (choose_num 12 15)\n;; 14\n;; >>> (choose_num 13 12)\n;; -1\n(define (choose_num x y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> (string_sequence 0)\n;; \"0\"\n;; >>> (string_sequence 5)\n;; \"0 1 2 3 4 5\"\n(define (string_sequence n)\n",
+    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; >>> (rounded_avg 1 5)\n;; \"0b11\"\n;; >>> (rounded_avg 7 5)\n;; -1\n;; >>> (rounded_avg 10 20)\n;; \"0b1111\"\n;; >>> (rounded_avg 20 33)\n;; \"0b11010\"\n(define (rounded_avg n m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return #t if the second word or any of its rotations is a substring in the first word\n;; >>> (cycpattern_check \"abcd\" \"abd\")\n;; #f\n;; >>> (cycpattern_check \"hello\" \"ell\")\n;; #t\n;; >>> (cycpattern_check \"whassup\" \"psus\")\n;; #f\n;; >>> (cycpattern_check \"abab\" \"baa\")\n;; #t\n;; >>> (cycpattern_check \"efef\" \"eeff\")\n;; #f\n;; >>> (cycpattern_check \"himenss\" \"simen\")\n;; #t\n(define (cycpattern_check a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> (unique_digits (list 15 33 1422 1))\n;; (list 1 15 33)\n;; >>> (unique_digits (list 152 323 1422 10))\n;; (list )\n(define (unique_digits x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return #t is list elements are monotonically increasing or decreasing.\n;; >>> (monotonic (list 1 2 4 20))\n;; #t\n;; >>> (monotonic (list 1 20 4 10))\n;; #f\n;; >>> (monotonic (list 4 1 0 -10))\n;; #t\n(define (monotonic l)\n",
+    "prompt": "#lang racket\n\n;; Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting list, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; >>> (by_length (list 2 1 1 4 5 8 2 3))\n;; (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\")\n;; If the list is empty, return an empty list:\n;; >>> (by_length (list ))\n;; (list )\n;; If the list has any strange number ignore it:\n;; >>> (by_length (list 1 -1 55))\n;; (list \"One\")\n(define (by_length arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return #f in case the input list is empty.\n;; >>> (longest (list ))\n;; #f\n;; >>> (longest (list \"a\" \"b\" \"c\"))\n;; \"a\"\n;; >>> (longest (list \"a\" \"bb\" \"ccc\"))\n;; \"ccc\"\n(define (longest strings)\n",
+    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; >>> (f 5)\n;; (list 1 2 6 24 15)\n(define (f n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return #t if all numbers in the list l are below threshold t.\n;; >>> (below_threshold (list 1 2 4 10) 100)\n;; #t\n;; >>> (below_threshold (list 1 20 4 10) 5)\n;; #f\n(define (below_threshold l t)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a list that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; >>> (even_odd_palindrome 3)\n;; (list 1 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; >>> (even_odd_palindrome 12)\n;; (list 4 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned list has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; >>> (is_multiply_prime 30)\n;; #t\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "prompt": "#lang racket\n\n;; Write a function count_nums which takes a list of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> (count_nums (list ))\n;; 0\n;; >>> (count_nums (list -1 11 -11))\n;; 1\n;; >>> (count_nums (list 1 1 2))\n;; 3\n(define (count_nums arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> (get_positive (list -1 2 -4 5 6))\n;; (list 2 5 6)\n;; >>> (get_positive (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; (list 5 3 2 3 9 123 1)\n(define (get_positive l)\n",
+    "prompt": "#lang racket\n\n;; We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the list will be randomly ordered. Your task is to determine if\n;; it is possible to get a list sorted in non-decreasing order by performing \n;; the following operation on the given list:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the list by one\n;; position in the right direction. The last element of the list will be moved to\n;; the starting position in the list i.e. 0th index. \n;; If it is possible to obtain the sorted list by performing the above operation\n;; then return #t else return #f.\n;; If the given list is empty then return #t.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; >>> (move_one_ball (list 3 4 5 1 2))\n;; #t\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given list.\n;; >>> (move_one_ball (list 3 5 4 1 2))\n;; #f\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; list by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> (sort_third (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_third (list 5 6 3 4 8 9 2))\n;; (list 2 6 3 4 8 9 5)\n(define (sort_third l)\n",
+    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> (make_palindrome \"\")\n;; \"\"\n;; >>> (make_palindrome \"cat\")\n;; \"catac\"\n;; >>> (make_palindrome \"cata\")\n;; \"catac\"\n(define (make_palindrome string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> (parse_nested_parens \"(()()) ((())) () ((())()())\")\n;; (list 2 3 1 3)\n(define (parse_nested_parens paren_string)\n",
+    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; >>> (exchange (list 1 2 3 4) (list 1 2 3 4))\n;; \"YES\"\n;; >>> (exchange (list 1 2 3 4) (list 1 5 3 4))\n;; \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> (triangle_area 5 3)\n;; 7.5\n(define (triangle_area a h)\n",
+    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a hash\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; >>> (histogram \"a b c\")\n;; #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1))\n;; >>> (histogram \"a b b a\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"a b c a b\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"b b b b a\")\n;; #hash((\"b\" .  4))\n;; >>> (histogram \"\")\n;; #hash()\n(define (histogram test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; >>> (multiply 148 412)\n;; 16\n;; >>> (multiply 19 28)\n;; 72\n;; >>> (multiply 2020 1851)\n;; 0\n;; >>> (multiply 14 -15)\n;; 20\n(define (multiply a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> (mean_absolute_deviation (list 1.0 2.0 3.0 4.0))\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> (common (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121))\n;; (list 1 5 653)\n;; >>> (common (list 5 3 2 8) (list 3 2))\n;; (list 2 3)\n(define (common l1 l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> (int_to_mini_roman 19)\n;; \"xix\"\n;; >>> (int_to_mini_roman 152)\n;; \"clii\"\n;; >>> (int_to_mini_roman 426)\n;; \"cdxxvi\"\n(define (int_to_mini_roman number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; >>> (fruit_distribution \"5 apples and 6 oranges\" 19)\n;; 8\n;; >>> (fruit_distribution \"0 apples and 1 oranges\" 3)\n;; 2\n;; >>> (fruit_distribution \"2 apples and 3 oranges\" 100)\n;; 95\n;; >>> (fruit_distribution \"100 apples and 1 oranges\" 120)\n;; 19\n(define (fruit_distribution s n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2029,7 +214,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Task\n;; We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n;; then check if the result string is palindrome.\n;; A string is called palindrome if it reads the same backward as forward.\n;; You should return a list containing the result string and #t/#f for the check.\n;; Example\n;; >>> (reverse_delete \"abcde\" \"ae\")\n;; (list \"bcd\" #f)\n;; >>> (reverse_delete \"abcdef\" \"b\")\n;; (list \"acdef\" #f)\n;; >>> (reverse_delete \"abcdedcba\" \"ab\")\n;; (list \"cdedc\" #t)\n(define (reverse_delete s c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_delete))\n    (check-within (candidate \"abcde\" \"ae\") (list \"bcd\" #f) 0.001)\n    (check-within (candidate \"abcdef\" \"b\") (list \"acdef\" #f) 0.001)\n    (check-within (candidate \"abcdedcba\" \"ab\") (list \"cdedc\" #t) 0.001)\n    (check-within (candidate \"dwik\" \"w\") (list \"dik\" #f) 0.001)\n    (check-within (candidate \"a\" \"a\") (list \"\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"v\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"vabba\" \"v\") (list \"abba\" #t) 0.001)\n    (check-within (candidate \"mamma\" \"mia\") (list \"\" #t) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> (greatest_common_divisor 3 5)\n;; 1\n;; >>> (greatest_common_divisor 25 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> (odd_count (list \"1234567\"))\n;; (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n;; >>> (odd_count (list \"3\" \"11111111\"))\n;; (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\n(define (odd_count lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; >>> (split_words \"Hello world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"Hello,world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"abcdef\")\n;; 3\n(define (split_words txt)\n",
+    "prompt": "#lang racket\n\n;; Given a list of integers nums, find the minimum sum of any non-empty sub-list\n;; of nums.\n;; Example\n;; >>> (minSubArraySum (list 2 3 4 1 2 4))\n;; 1\n;; >>> (minSubArraySum (list -1 -2 -3))\n;; -6\n(define (minSubArraySum nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; >>> (max_fill (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1)\n;; 6\n;; Example 2:\n;; >>> (max_fill (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2)\n;; 5\n;; Example 3:\n;; >>> (max_fill (list (list 0 0 0) (list 0 0 0)) 5)\n;; 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2074,7 +274,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; In this Kata, you have to sort a list of non-negative integers according to\n;; number of ones in their binary representation in ascending order.\n;; For similar number of ones, sort based on decimal value.\n;; It must be implemented like this:\n;; >>> (sort_array (list 1 5 2 3 4))\n;; (list 1 2 3 4 5)\n;; >>> (sort_array (list -2 -3 -4 -5 -6))\n;; (list -6 -5 -4 -3 -2)\n;; >>> (sort_array (list 1 0 2 3 4))\n;; (list 0 1 2 3 4)\n(define (sort_array arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list 1 5 2 3 4)) (list 1 2 4 3 5) 0.001)\n    (check-within (candidate (list -2 -3 -4 -5 -6)) (list -4 -2 -6 -5 -3) 0.001)\n    (check-within (candidate (list 1 0 2 3 4)) (list 0 1 2 4 3) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 2 5 77 4 5 3 5 7 2 3 4)) (list 2 2 4 4 3 3 5 5 5 7 77) 0.001)\n    (check-within (candidate (list 3 6 44 12 32 5)) (list 32 3 5 6 12 44) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> (concatenate (list ))\n;; \"\"\n;; >>> (concatenate (list \"a\" \"b\" \"c\"))\n;; \"abc\"\n(define (concatenate strings)\n",
+    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; >>> (select_words \"Mary had a little lamb\" 4)\n;; (list \"little\")\n;; >>> (select_words \"Mary had a little lamb\" 3)\n;; (list \"Mary\" \"lamb\")\n;; >>> (select_words \"simple white space\" 2)\n;; (list )\n;; >>> (select_words \"Hello world\" 4)\n;; (list \"world\")\n;; >>> (select_words \"Uncle sam\" 3)\n;; (list \"Uncle\")\n(define (select_words s n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never a list of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; >>> (list_sort (list \"aa\" \"a\" \"aaa\"))\n;; (list \"aa\")\n;; >>> (list_sort (list \"ab\" \"a\" \"aaa\" \"cd\"))\n;; (list \"ab\" \"cd\")\n(define (sorted_list_sum lst)\n",
+    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; >>> (get_closest_vowel \"yogurt\")\n;; \"u\"\n;; >>> (get_closest_vowel \"FULL\")\n;; \"U\"\n;; >>> (get_closest_vowel \"quick\")\n;; \"\"\n;; >>> (get_closest_vowel \"ab\")\n;; \"\"\n(define (get_closest_vowel word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> (filter_by_substring (list ) \"a\")\n;; (list )\n;; >>> (filter_by_substring (list \"abc\" \"bacd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"bacd\" \"array\")\n(define (filter_by_substring strings substring)\n",
+    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; >>> (match_parens (list \"()(\" \")\"))\n;; \"Yes\"\n;; >>> (match_parens (list \")\" \")\"))\n;; \"No\"\n(define (match_parens lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> (closest_integer \"10\")\n;; 10\n;; >>> (closest_integer \"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> (string_xor \"010\" \"110\")\n;; \"100\"\n(define (string_xor a b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> (vowels_count \"abcde\")\n;; 2\n;; >>> (vowels_count \"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
+    "prompt": "#lang racket\n\n;; Given a list arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; >>> (maximum (list -3 -4 5) 3)\n;; (list -4 -3 5)\n;; Example 2:\n;; >>> (maximum (list 4 -4 4) 2)\n;; (list 4 4)\n;; Example 3:\n;; >>> (maximum (list -3 2 1 2 -1 -2 1) 1)\n;; (list 2)\n;; Note:\n;; 1. The length of the list will be in the range of [1, 1000].\n;; 2. The elements in the list will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; >>> (find_max (list \"name\" \"of\" \"string\"))\n;; \"string\"\n;; >>> (find_max (list \"name\" \"enam\" \"game\"))\n;; \"enam\"\n;; >>> (find_max (list \"aaaaaaa\" \"bb\" \"cc\"))\n;; \"aaaaaaa\"\n(define (find_max words)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; >>> (solution (list 5 8 7 1))\n;; 12\n;; >>> (solution (list 3 3 3 3 3))\n;; 9\n;; >>> (solution (list 30 13 24 321))\n;; 0\n(define (solution lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return #f.\n;; >>> (string_to_md5 \"Hello world\")\n;; \"3e25960a79dbc69b674cd4ec67a72c62\"\n(define (string_to_md5 text)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; >>> (add_elements (list 111 21 3 4000 5 6 7 8 9) 4)\n;; 24\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> (change_base 8 3)\n;; \"22\"\n;; >>> (change_base 8 2)\n;; \"1000\"\n;; >>> (change_base 7 2)\n;; \"111\"\n(define (change_base x base)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n;; >>> (get_odd_collatz 5)\n;; (list 1 5)\n(define (get_odd_collatz n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return #t if the three\n;; sides form a right-angled triangle, #f otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; >>> (right_angle_triangle 3 4 5)\n;; #t\n;; >>> (right_angle_triangle 1 2 3)\n;; #f\n(define (right_angle_triangle a b c)\n",
+    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns #t if the date is valid otherwise #f.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; >>> (valid_date \"03-11-2000\")\n;; #t\n;; >>> (valid_date \"15-01-2012\")\n;; #f\n;; >>> (valid_date \"04-0-2040\")\n;; #f\n;; >>> (valid_date \"06-04-2020\")\n;; #t\n;; >>> (valid_date \"06/04/2020\")\n;; #f\n(define (valid_date date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; >>> (grade_equation (list 4.0 3 1.7 2 3.5))\n;; (list \"A+\" \"B\" \"C-\" \"C\" \"A-\")\n(define (numerical_letter_grade grades)\n",
+    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; >>> (split_words \"Hello world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"Hello,world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"abcdef\")\n;; 3\n(define (split_words txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> (intersperse (list ) 4)\n;; (list )\n;; >>> (intersperse (list 1 2 3) 4)\n;; (list 1 4 2 4 3)\n(define (intersperse numbers delimeter)\n",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return #f. Assume no negative numbers and only integers.\n;; Examples\n;; >>> (is_sorted (list 5))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5))\n;; #f\n;; >>> (is_sorted (list 1 2 3 4 5 6))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5 6 7))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5 6 7))\n;; #f\n;; >>> (is_sorted (list 1 2 2 3 3 4))\n;; #t\n;; >>> (is_sorted (list 1 2 2 2 3 4))\n;; #f\n(define (is_sorted lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; >>> (intersection (list 1 2) (list 2 3))\n;; \"NO\"\n;; >>> (intersection (list -1 1) (list 0 4))\n;; \"NO\"\n;; >>> (intersection (list -3 -1) (list -5 5))\n;; \"YES\"\n(define (intersection interval1 interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the list, represented by 1, -1 or 0.\n;; Note: return #f for empty arr.\n;; Example:\n;; >>> (prod_signs (list 1 2 2 -4))\n;; 9\n;; >>> (prod_signs (list 0 1))\n;; 0\n;; >>> (prod_signs (list ))\n;; #f\n(define (prod_signs arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:    \n;; >>> (minPath (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3)\n;; (list 1 2 1)\n;; >>> (minPath (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1)\n;; (list 1)\n(define (minPath grid k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return #f in case the input list is empty.\n;; >>> (longest (list ))\n;; #f\n;; >>> (longest (list \"a\" \"b\" \"c\"))\n;; \"a\"\n;; >>> (longest (list \"a\" \"bb\" \"ccc\"))\n;; \"ccc\"\n(define (longest strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; >>> (tri 3)\n;; (list 1 3 2 8)\n(define (tri n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; >>> (digits 1)\n;; 1\n;; >>> (digits 4)\n;; 0\n;; >>> (digits 235)\n;; 15\n(define (digits n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return #t if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; >>> (is_nested \"[[]]\")\n;; #t\n;; >>> (is_nested \"[]]]]]]][[[[[]\")\n;; #f\n;; >>> (is_nested \"[][]\")\n;; #f\n;; >>> (is_nested \"[]\")\n;; #f\n;; >>> (is_nested \"[[][]]\")\n;; #t\n;; >>> (is_nested \"[[]][[\")\n;; #t\n(define (is_nested string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; >>> (lst (list 1.0 2.0 3.0))\n;; 14\n;; >>> (lst (list 1.0 4.0 9.0))\n;; 98\n;; >>> (lst (list 1.0 3.0 5.0 7.0))\n;; 84\n;; >>> (lst (list 1.4 4.2 0.0))\n;; 29\n;; >>> (lst (list -2.4 1.0 1.0))\n;; 6\n(define (sum_squares lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns #t if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and #f otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; >>> (check_if_last_char_is_a_letter \"apple pie\")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"apple pi e\")\n;; #t\n;; >>> (check_if_last_char_is_a_letter \"apple pi e \")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"\")\n;; #f\n(define (check_if_last_char_is_a_letter txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given list will not contain\n;; duplicate values.\n;; Examples:\n;; >>> (can_arrange (list 1 2 4 3 5))\n;; 3\n;; >>> (can_arrange (list 1 2 3))\n;; -1\n(define (can_arrange arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns a list (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as #f.\n;; Examples:\n;; >>> (largest_smallest_integers (list 2 4 1 3 5 7))\n;; (list #f 1)\n;; >>> (largest_smallest_integers (list ))\n;; (list #f #f)\n;; >>> (largest_smallest_integers (list 0))\n;; (list #f #f)\n(define (largest_smallest_integers lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return #f if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; >>> (compare_one 1 2.5)\n;; 2.5\n;; >>> (compare_one 1 \"2,3\")\n;; \"2,3\"\n;; >>> (compare_one \"5,1\" \"6\")\n;; \"6\"\n;; >>> (compare_one \"1\" 1)\n;; #f\n(define (compare_one a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; >>> (is_equal_to_sum_even 4)\n;; #f\n;; >>> (is_equal_to_sum_even 6)\n;; #f\n;; >>> (is_equal_to_sum_even 8)\n;; #t\n(define (is_equal_to_sum_even n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> (special_factorial 4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> (greatest_common_divisor 3 5)\n;; 1\n;; >>> (greatest_common_divisor 25 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; >>> (fix_spaces \" Example\")\n;; \"Example\"\n;; >>> (fix_spaces \" Example 1\")\n;; \"Example_1\"\n;; >>> (fix_spaces \" Example 2\")\n;; \"_Example_2\"\n;; >>> (fix_spaces \" Example 3\")\n;; \"_Example-3\"\n(define (fix_spaces text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; >>> (file_name_check \"example.txt\")\n;; \"Yes\"\n;; >>> (file_name_check \"1example.dll\")\n;; \"No\"\n(define (file_name_check file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; >>> lst\n;; (list 1 2 3)\n;; >>> lst\n;; (list )\n;; >>> lst\n;; (list -1 -5 2 -1 -5)\n(define (sum_squares lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; >>> (words_in_sentence \"This is a test\")\n;; \"is\"\n;; Example 2:\n;; >>> (words_in_sentence \"lets go for swimming\")\n;; \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns #t if x * n evaluates to a whole number and #f\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; >>> (simplify \"1/5\" \"5/1\")\n;; #t\n;; >>> (simplify \"1/6\" \"2/1\")\n;; #f\n;; >>> (simplify \"7/10\" \"10/2\")\n;; #f\n(define (simplify x n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> (order_by_points (list 1 11 -1 -11 -12))\n;; (list -1 -11 1 -12 11)\n;; >>> (order_by_points (list ))\n;; (list )\n(define (order_by_points nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2254,7 +769,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function that takes a list of numbers as input and returns \n;; the number of elements in the list that are greater than 10 and both \n;; first and last digits of a number are odd (1, 3, 5, 7, 9).\n;; For example:\n;; >>> (specialFilter (list 15 -73 14 -15))\n;; 1\n;; >>> (specialFilter (list 33 -2 -3 45 21 109))\n;; 2\n(define (specialFilter nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate specialFilter))\n    (check-within (candidate (list 5 -2 1 -5)) 0 0.001)\n    (check-within (candidate (list 15 -73 14 -15)) 1 0.001)\n    (check-within (candidate (list 33 -2 -3 45 21 109)) 2 0.001)\n    (check-within (candidate (list 43 -12 93 125 121 109)) 4 0.001)\n    (check-within (candidate (list 71 -2 -33 75 21 19)) 3 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list )) 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> (sum_to_n 30)\n;; 465\n;; >>> (sum_to_n 100)\n;; 5050\n;; >>> (sum_to_n 5)\n;; 15\n;; >>> (sum_to_n 10)\n;; 55\n;; >>> (sum_to_n 1)\n;; 1\n(define (sum_to_n n)\n",
+    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer list a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; >>> (get_max_triples 5)\n;; 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> (remove_duplicates (list 1 2 3 2 4))\n;; (list 1 3 4)\n(define (remove_duplicates numbers)\n",
+    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a list containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty list if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; >>> (bf \"Jupiter\" \"Neptune\")\n;; (list \"Saturn\" \"Uranus\")\n;; >>> (bf \"Earth\" \"Mercury\")\n;; \"Venus\"\n;; >>> (bf \"Mercury\" \"Uranus\")\n;; (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\")\n(define (bf planet1 planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never a list of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; >>> (list_sort (list \"aa\" \"a\" \"aaa\"))\n;; (list \"aa\")\n;; >>> (list_sort (list \"ab\" \"a\" \"aaa\" \"cd\"))\n;; (list \"ab\" \"cd\")\n(define (sorted_list_sum lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> (all_prefixes \"abc\")\n;; (list \"a\" \"ab\" \"abc\")\n(define (all_prefixes string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; >>> (x_or_y 7 34 12)\n;; 34\n;; >>> (x_or_y 15 8 5)\n;; 5\n(define (x_or_y n x y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; >>> (double_the_difference (list 1 3 2 0))\n;; 10\n;; >>> (double_the_difference (list -1 -2 0))\n;; 0\n;; >>> (double_the_difference (list 9 -2))\n;; 81\n;; >>> (double_the_difference (list 0))\n;; 0\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two lists of scores and guesses of equal length, where each index shows a match. \n;; Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; >>> (compare (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2))\n;; (list 0 0 0 0 3 3)\n;; >>> (compare (list 0 5 0 0 0 4) (list 4 1 1 0 0 -2))\n;; (list 4 4 1 0 0 6)\n(define (compare game guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; >>> (Strongest_Extension \"my_class\" (list \"AA\" \"Be\" \"CC\"))\n;; \"my_class.AA\"\n(define (Strongest_Extension class_name extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return #t if the second word or any of its rotations is a substring in the first word\n;; >>> (cycpattern_check \"abcd\" \"abd\")\n;; #f\n;; >>> (cycpattern_check \"hello\" \"ell\")\n;; #t\n;; >>> (cycpattern_check \"whassup\" \"psus\")\n;; #f\n;; >>> (cycpattern_check \"abab\" \"baa\")\n;; #t\n;; >>> (cycpattern_check \"efef\" \"eeff\")\n;; #f\n;; >>> (cycpattern_check \"himenss\" \"simen\")\n;; #t\n(define (cycpattern_check a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an integer. return a list that has the number of even and odd digits respectively.\n;; Example:\n;; >>> (even_odd_count -12)\n;; (list 1 1)\n;; >>> (even_odd_count 123)\n;; (list 1 2)\n(define (even_odd_count num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> (int_to_mini_roman 19)\n;; \"xix\"\n;; >>> (int_to_mini_roman 152)\n;; \"clii\"\n;; >>> (int_to_mini_roman 426)\n;; \"cdxxvi\"\n(define (int_to_mini_roman number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return #t if the three\n;; sides form a right-angled triangle, #f otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; >>> (right_angle_triangle 3 4 5)\n;; #t\n;; >>> (right_angle_triangle 1 2 3)\n;; #f\n(define (right_angle_triangle a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; >>> (find_max (list \"name\" \"of\" \"string\"))\n;; \"string\"\n;; >>> (find_max (list \"name\" \"enam\" \"game\"))\n;; \"enam\"\n;; >>> (find_max (list \"aaaaaaa\" \"bb\" \"cc\"))\n;; \"aaaaaaa\"\n(define (find_max words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return a list of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; >>> (eat 5 6 10)\n;; (list 11 4)\n;; >>> (eat 4 8 9)\n;; (list 12 1)\n;; >>> (eat 1 10 10)\n;; (list 11 0)\n;; >>> (eat 2 11 5)\n;; (list 7 0)\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> (string_sequence 0)\n;; \"0\"\n;; >>> (string_sequence 5)\n;; \"0 1 2 3 4 5\"\n(define (string_sequence n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; list = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; >>> (solve \"1234\")\n;; \"4321\"\n;; >>> (solve \"ab\")\n;; \"AB\"\n;; >>> (solve \"#a@C\")\n;; \"#A@c\"\n(define (solve s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return #f.\n;; >>> (string_to_md5 \"Hello world\")\n;; \"3e25960a79dbc69b674cd4ec67a72c62\"\n(define (string_to_md5 text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2299,7 +1054,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given two positive integers a and b, return the even digits between a\n;; and b, in ascending order.\n;; For example:\n;; >>> (generate_integers 2 8)\n;; (list 2 4 6 8)\n;; >>> (generate_integers 8 2)\n;; (list 2 4 6 8)\n;; >>> (generate_integers 10 14)\n;; (list )\n(define (generate_integers a b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate generate_integers))\n    (check-within (candidate 2 10) (list 2 4 6 8) 0.001)\n    (check-within (candidate 10 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 132 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 17 89) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> (rolling_max (list 1 2 3 2 3 4 2))\n;; (list 1 2 3 3 3 4 4)\n(define (rolling_max numbers)\n",
+    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n;; >>> (count_distinct_characters \"xyzXYZ\")\n;; 3\n;; >>> (count_distinct_characters \"Jerry\")\n;; 4\n(define (count_distinct_characters string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return #t. Otherwise it should return #f.\n;; >>> (below_zero (list 1 2 3))\n;; #f\n;; >>> (below_zero (list 1 2 -4 5))\n;; #t\n(define (below_zero operations)\n",
+    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> (parse_music \"o o| .| o| o| .| .| .| .| o o\")\n;; (list 4 2 1 2 2 1 1 1 1 4 4)\n(define (parse_music music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; >>> (search (list 4 1 2 2 3 1))\n;; 2\n;; >>> (search (list 1 2 2 3 3 3 4 4 4))\n;; 3\n;; >>> (search (list 5 5 4 4 4))\n;; -1\n(define (search lst)\n",
+    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> (how_many_times \"\" \"a\")\n;; 0\n;; >>> (how_many_times \"aaa\" \"a\")\n;; 3\n;; >>> (how_many_times \"aaaa\" \"aa\")\n;; 3\n(define (how_many_times string substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return #t if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"(\")\n;; #f\n;; >>> (correct_bracketing \"()\")\n;; #t\n;; >>> (correct_bracketing \"(()())\")\n;; #t\n;; >>> (correct_bracketing \")(()\")\n;; #f\n(define (correct_bracketing brackets)\n",
+    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> (sort_numbers \"three one five\")\n;; \"one three five\"\n(define (sort_numbers numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> (separate_paren_groups \"( ) (( )) (( )( ))\")\n;; (list \"()\" \"(())\" \"(()())\")\n(define (separate_paren_groups paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.2))\n;; (list 2.0 2.2)\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.0))\n;; (list 2.0 2.0)\n(define (find_closest_elements numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> (rescale_to_unit (list 1.0 2.0 3.0 4.0 5.0))\n;; (list 0.0 0.25 0.5 0.75 1.0)\n(define (rescale_to_unit numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter given list of any rktthon values only for integers\n;; >>> (filter_integers (list \"a\" 3.14 5))\n;; (list 5)\n;; >>> (filter_integers (list 1 2 3 \"abc\" #hash() (list )))\n;; (list 1 2 3)\n(define (filter_integers values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> (strlen \"\")\n;; 0\n;; >>> (strlen \"abc\")\n;; 3\n(define (strlen string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> (largest_divisor 15)\n;; 5\n(define (largest_divisor n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> (factorize 8)\n;; (list 2 2 2)\n;; >>> (factorize 25)\n;; (list 5 5)\n;; >>> (factorize 70)\n;; (list 2 5 7)\n(define (factorize n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> (remove_duplicates (list 1 2 3 2 4))\n;; (list 1 3 4)\n(define (remove_duplicates numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> (flip_case \"Hello\")\n;; \"hELLO\"\n(define (flip_case string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> (concatenate (list ))\n;; \"\"\n;; >>> (concatenate (list \"a\" \"b\" \"c\"))\n;; \"abc\"\n(define (concatenate strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> (filter_by_prefix (list ) \"a\")\n;; (list )\n;; >>> (filter_by_prefix (list \"abc\" \"bcd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"array\")\n(define (filter_by_prefix strings prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> (truncate_number 3.5)\n;; 0.5\n(define (truncate_number number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> (get_positive (list -1 2 -4 5 6))\n;; (list 2 5 6)\n;; >>> (get_positive (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; (list 5 3 2 3 9 123 1)\n(define (get_positive l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> (is_prime 6)\n;; #f\n;; >>> (is_prime 101)\n;; #t\n;; >>> (is_prime 11)\n;; #t\n;; >>> (is_prime 13441)\n;; #t\n;; >>> (is_prime 61)\n;; #t\n;; >>> (is_prime 4)\n;; #f\n;; >>> (is_prime 1)\n;; #f\n(define (is_prime n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> (sort_third (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_third (list 5 6 3 4 8 9 2))\n;; (list 2 6 3 4 8 9 5)\n(define (sort_third l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> (unique (list 5 3 5 2 3 3 9 0 123))\n;; (list 0 2 3 5 9 123)\n(define (unique l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> (max_element (list 1 2 3))\n;; 3\n;; >>> (max_element (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; 123\n(define (max_element l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> (fizz_buzz 50)\n;; 0\n;; >>> (fizz_buzz 78)\n;; 2\n;; >>> (fizz_buzz 79)\n;; 3\n(define (fizz_buzz n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2374,9 +1399,249 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the odd indicies, while its values at the even indicies are equal\n;; to the values of the even indicies of l, but sorted.\n;; >>> (sort_even (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_even (list 5 6 3 4))\n;; (list 3 6 5 4)\n(define (sort_even l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_even))\n    (check-within (candidate (list 1 2 3)) (list 1 2 3) 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 123 1 -10)) (list -10 3 -5 2 -3 3 5 0 9 1 123) 0.001)\n    (check-within (candidate (list 5 8 -12 4 23 2 3 11 12 -10)) (list -12 8 3 4 5 2 12 11 23 -10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> (prime_fib 1)\n;; 2\n;; >>> (prime_fib 2)\n;; 3\n;; >>> (prime_fib 3)\n;; 5\n;; >>> (prime_fib 4)\n;; 13\n;; >>> (prime_fib 5)\n;; 89\n(define (prime_fib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return #t. Otherwise it should return #f.\n;; >>> (below_zero (list 1 2 3))\n;; #f\n;; >>> (below_zero (list 1 2 -4 5))\n;; #t\n(define (below_zero operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns #t if there are three distinct elements in the list that\n;; sum to zero, and #f otherwise.\n;; >>> (triples_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (triples_sum_to_zero (list 1 3 -2 1))\n;; #t\n;; >>> (triples_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (triples_sum_to_zero (list 2 4 -5 3 9 7))\n;; #t\n;; >>> (triples_sum_to_zero (list 1))\n;; #f\n(define (triples_sum_to_zero l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> (incr_list (list 1 2 3))\n;; (list 2 3 4)\n;; >>> (incr_list (list 5 3 5 2 3 3 9 0 123))\n;; (list 6 4 6 3 4 4 10 1 124)\n(define (incr_list l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns #t if there are two distinct elements in the list that\n;; sum to zero, and #f otherwise.\n;; >>> (pairs_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 3 -2 1))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (pairs_sum_to_zero (list 2 4 -5 3 5 7))\n;; #t\n;; >>> (pairs_sum_to_zero (list 1))\n;; #f\n(define (pairs_sum_to_zero l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> (change_base 8 3)\n;; \"22\"\n;; >>> (change_base 8 2)\n;; \"1000\"\n;; >>> (change_base 7 2)\n;; \"111\"\n(define (change_base x base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> (triangle_area 5 3)\n;; 7.5\n(define (triangle_area a h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> (fib4 5)\n;; 4\n;; >>> (fib4 6)\n;; 8\n;; >>> (fib4 7)\n;; 14\n(define (fib4 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> (median (list 3 1 2 4 5))\n;; 3\n;; >>> (median (list -10 4 6 1000 10 20))\n;; 15.0\n(define (median l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> (is_palindrome \"\")\n;; #t\n;; >>> (is_palindrome \"aba\")\n;; #t\n;; >>> (is_palindrome \"aaaaa\")\n;; #t\n;; >>> (is_palindrome \"zbcd\")\n;; #f\n(define (is_palindrome text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> (modp 3 5)\n;; 3\n;; >>> (modp 1101 101)\n;; 2\n;; >>> (modp 0 101)\n;; 1\n;; >>> (modp 3 11)\n;; 8\n;; >>> (modp 100 101)\n;; 1\n(define (modp n p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> (mean_absolute_deviation (list 1.0 2.0 3.0 4.0))\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> (remove_vowels \"\")\n;; \"\"\n;; >>> (remove_vowels \"abcdef\")\n;; \"bcdf\"\n;; >>> (remove_vowels \"aaaaa\")\n;; \"\"\n;; >>> (remove_vowels \"aaBAA\")\n;; \"B\"\n;; >>> (remove_vowels \"zbcd\")\n;; \"zbcd\"\n(define (remove_vowels text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return #t if all numbers in the list l are below threshold t.\n;; >>> (below_threshold (list 1 2 4 10) 100)\n;; #t\n;; >>> (below_threshold (list 1 20 4 10) 5)\n;; #f\n(define (below_threshold l t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> (add 2 3)\n;; 5\n;; >>> (add 5 7)\n;; 12\n(define (add x y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2389,9 +1654,24 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if two words have the same characters.\n;; >>> (same_chars \"eabcdzzzz\" \"dddzzzzzzzddeddabc\")\n;; #t\n;; >>> (same_chars \"abcd\" \"dddddddabc\")\n;; #t\n;; >>> (same_chars \"dddddddabc\" \"abcd\")\n;; #t\n;; >>> (same_chars \"eabcd\" \"dddddddabc\")\n;; #f\n;; >>> (same_chars \"abcd\" \"dddddddabce\")\n;; #f\n;; >>> (same_chars \"eabcdzzzz\" \"dddzzzzzzzddddabc\")\n;; #f\n(define (same_chars s0 s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate same_chars))\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") #t 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabc\") #t 0.001)\n    (check-within (candidate \"dddddddabc\" \"abcd\") #t 0.001)\n    (check-within (candidate \"eabcd\" \"dddddddabc\") #f 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabcf\") #f 0.001)\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") #f 0.001)\n    (check-within (candidate \"aabb\" \"aaccc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> (fib 10)\n;; 55\n;; >>> (fib 1)\n;; 1\n;; >>> (fib 8)\n;; 21\n(define (fib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2404,9 +1684,729 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; brackets is a string of \"<\" and \">\".\n;; return #t if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"<\")\n;; #f\n;; >>> (correct_bracketing \"<>\")\n;; #t\n;; >>> (correct_bracketing \"<<><>>\")\n;; #t\n;; >>> (correct_bracketing \"><<>\")\n;; #f\n(define (correct_bracketing brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"<>\") #t 0.001)\n    (check-within (candidate \"<<><>>\") #t 0.001)\n    (check-within (candidate \"<><><<><>><>\") #t 0.001)\n    (check-within (candidate \"<><><<<><><>><>><<><><<>>>\") #t 0.001)\n    (check-within (candidate \"<<<><>>>>\") #f 0.001)\n    (check-within (candidate \"><<>\") #f 0.001)\n    (check-within (candidate \"<\") #f 0.001)\n    (check-within (candidate \"<<<<\") #f 0.001)\n    (check-within (candidate \">\") #f 0.001)\n    (check-within (candidate \"<<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>><<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>>><>\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return #t is list elements are monotonically increasing or decreasing.\n;; >>> (monotonic (list 1 2 4 20))\n;; #t\n;; >>> (monotonic (list 1 20 4 10))\n;; #f\n;; >>> (monotonic (list 4 1 0 -10))\n;; #t\n(define (monotonic l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> (common (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121))\n;; (list 1 5 653)\n;; >>> (common (list 5 3 2 8) (list 3 2))\n;; (list 2 3)\n(define (common l1 l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> (largest_prime_factor 13195)\n;; 29\n;; >>> (largest_prime_factor 2048)\n;; 2\n(define (largest_prime_factor n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> (intersperse (list ) 4)\n;; (list )\n;; >>> (intersperse (list 1 2 3) 4)\n;; (list 1 4 2 4 3)\n(define (intersperse numbers delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> (sum_to_n 30)\n;; 465\n;; >>> (sum_to_n 100)\n;; 5050\n;; >>> (sum_to_n 5)\n;; 15\n;; >>> (sum_to_n 10)\n;; 55\n;; >>> (sum_to_n 1)\n;; 1\n(define (sum_to_n n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return #t if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"(\")\n;; #f\n;; >>> (correct_bracketing \"()\")\n;; #t\n;; >>> (correct_bracketing \"(()())\")\n;; #t\n;; >>> (correct_bracketing \")(()\")\n;; #f\n(define (correct_bracketing brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> (derivative (list 3 1 2 4 5))\n;; (list 1 4 12 20)\n;; >>> (derivative (list 1 2 3))\n;; (list 2 6)\n(define (derivative xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> (fibfib 1)\n;; 0\n;; >>> (fibfib 5)\n;; 4\n;; >>> (fibfib 8)\n;; 24\n(define (fibfib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> (vowels_count \"abcde\")\n;; 2\n;; >>> (vowels_count \"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> (circular_shift 12 1)\n;; \"21\"\n;; >>> (circular_shift 12 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; >>> (digitSum \"\")\n;; 0\n;; >>> (digitSum \"abAB\")\n;; 131\n;; >>> (digitSum \"abcCd\")\n;; 67\n;; >>> (digitSum \"helloE\")\n;; 69\n;; >>> (digitSum \"woArBld\")\n;; 131\n;; >>> (digitSum \"aAaaaXa\")\n;; 153\n(define (digitSum s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; >>> (fruit_distribution \"5 apples and 6 oranges\" 19)\n;; 8\n;; >>> (fruit_distribution \"0 apples and 1 oranges\" 3)\n;; 2\n;; >>> (fruit_distribution \"2 apples and 3 oranges\" 100)\n;; 95\n;; >>> (fruit_distribution \"100 apples and 1 oranges\" 120)\n;; 19\n(define (fruit_distribution s n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"Given a list representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given list is empty, return [].\n;; Example 1:\n;; >>> (pluck (list 4 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; >>> (pluck (list 1 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; >>> (pluck (list ))\n;; (list )\n;; Example 4:\n;; >>> (pluck (list 5 0 3 0 4 2))\n;; (list 0 1)\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; >>> (search (list 4 1 2 2 3 1))\n;; 2\n;; >>> (search (list 1 2 2 3 3 3 4 4 4))\n;; 3\n;; >>> (search (list 5 5 4 4 4))\n;; -1\n(define (search lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> (parse_nested_parens \"(()()) ((())) () ((())()())\")\n;; (list 2 3 1 3)\n(define (parse_nested_parens paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; >>> (strange_sort_list (list 1 2 3 4))\n;; (list 1 4 2 3)\n;; >>> (strange_sort_list (list 5 5 5 5))\n;; (list 5 5 5 5)\n;; >>> (strange_sort_list (list ))\n;; (list )\n(define (strange_sort_list lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; >>> (triangle_area 3 4 5)\n;; 6.0\n;; >>> (triangle_area 1 2 10)\n;; -1\n(define (triangle_area a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns #t if the object q will fly, and #f otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; >>> (will_it_fly (list 1 2) 5)\n;; #f\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; >>> (will_it_fly (list 3 2 3) 1)\n;; #f\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; >>> (will_it_fly (list 3 2 3) 9)\n;; #t\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; >>> (will_it_fly (list 3) 5)\n;; #t\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list arr of integers, find the minimum number of elements that\n;; need to be changed to make the list palindromic. A palindromic list is a list that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; >>> (smallest_change (list 1 2 3 5 4 7 9 6))\n;; 4\n;; >>> (smallest_change (list 1 2 3 4 3 2 2))\n;; 1\n;; >>> (smallest_change (list 1 2 3 2 1))\n;; 0\n(define (smallest_change arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; >>> (total_match (list ) (list ))\n;; (list )\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"Hi\"))\n;; (list \"hI\" \"Hi\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\"))\n;; (list \"hi\" \"admin\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\"))\n;; (list \"hI\" \"hi\" \"hi\")\n;; >>> (total_match (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\"))\n;; (list \"4\")\n(define (total_match lst1 lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; >>> (is_multiply_prime 30)\n;; #t\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; >>> (is_simple_power 1 4)\n;; #t\n;; >>> (is_simple_power 2 2)\n;; #t\n;; >>> (is_simple_power 8 2)\n;; #t\n;; >>> (is_simple_power 3 2)\n;; #f\n;; >>> (is_simple_power 3 1)\n;; #f\n;; >>> (is_simple_power 5 3)\n;; #f\n(define (is_simple_power x n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns #t \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; >>> (iscube 1)\n;; #t\n;; >>> (iscube 2)\n;; #f\n;; >>> (iscube -1)\n;; #t\n;; >>> (iscube 64)\n;; #t\n;; >>> (iscube 0)\n;; #t\n;; >>> (iscube 180)\n;; #f\n(define (iscube a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; >>> (hex_key \"AB\")\n;; 1\n;; >>> (hex_key \"1077E\")\n;; 2\n;; >>> (hex_key \"ABED1A33\")\n;; 4\n;; >>> (hex_key \"123456789ABCDEF0\")\n;; 6\n;; >>> (hex_key \"2020\")\n;; 2\n(define (hex_key num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; >>> (decimal_to_binary 15)\n;; \"db1111db\"\n;; >>> (decimal_to_binary 32)\n;; \"db100000db\"\n(define (decimal_to_binary decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> (filter_by_substring (list ) \"a\")\n;; (list )\n;; >>> (filter_by_substring (list \"abc\" \"bacd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"bacd\" \"array\")\n(define (filter_by_substring strings substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is haprkt or not.\n;; A string is haprkt if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; >>> (is_happy \"a\")\n;; #f\n;; >>> (is_happy \"aa\")\n;; #f\n;; >>> (is_happy \"abcd\")\n;; #t\n;; >>> (is_happy \"aabb\")\n;; #f\n;; >>> (is_happy \"adb\")\n;; #t\n;; >>> (is_happy \"xyy\")\n;; #f\n(define (is_happy s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; >>> (grade_equation (list 4.0 3 1.7 2 3.5))\n;; (list \"A+\" \"B\" \"C-\" \"C\" \"A-\")\n(define (numerical_letter_grade grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns #t if the string\n;; length is a prime number or #f otherwise\n;; Examples\n;; >>> (prime_length \"Hello\")\n;; #t\n;; >>> (prime_length \"abcdcba\")\n;; #t\n;; >>> (prime_length \"kittens\")\n;; #t\n;; >>> (prime_length \"orange\")\n;; #f\n(define (prime_length string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; >>> (solve 1000)\n;; \"1\"\n;; >>> (solve 150)\n;; \"110\"\n;; >>> (solve 147)\n;; \"1100\"\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; >>> (add (list 4 2 6 7))\n;; 2\n(define (add lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; >>> (anti_shuffle \"Hi\")\n;; \"Hi\"\n;; >>> (anti_shuffle \"hello\")\n;; \"ehllo\"\n;; >>> (anti_shuffle \"Hello World!!!\")\n;; \"Hello !!!Wdlor\"\n(define (anti_shuffle s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of lists, [(x1, y1), (x2, y2) ...] such that\n;; each list is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; >>> (get_row (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1)\n;; (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0))\n;; >>> (get_row (list ) 1)\n;; (list )\n;; >>> (get_row (list (list ) (list 1) (list 1 2 3)) 3)\n;; (list (list 2 2))\n(define (get_row lst x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of non-negative integers, return a corkt of the given list after sorting,\n;; you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given list.\n;; Examples:\n;; >>> (sort_array (list ))\n;; (list )\n;; >>> (sort_array (list 5))\n;; (list 5)\n;; >>> (sort_array (list 2 4 3 0 1 5))\n;; (list 0 1 2 3 4 5)\n;; >>> (sort_array (list 2 4 3 0 1 5 6))\n;; (list 6 5 4 3 2 1 0)\n(define (sort_array array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; >>> (encrypt \"hi\")\n;; \"lm\"\n;; >>> (encrypt \"asdfghjkl\")\n;; \"ewhjklnop\"\n;; >>> (encrypt \"gf\")\n;; \"kj\"\n;; >>> (encrypt \"et\")\n;; \"ix\"\n(define (encrypt s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> (sum_product (list ))\n;; (list 0 1)\n;; >>> (sum_product (list 1 2 3 4))\n;; (list 10 24)\n(define (sum_product numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return #f if there is no such element.\n;; >>> (next_smallest (list 1 2 3 4 5))\n;; 2\n;; >>> (next_smallest (list 5 1 4 3 2))\n;; 2\n;; >>> (next_smallest (list ))\n;; #f\n;; >>> (next_smallest (list 1 1))\n;; #f\n(define (next_smallest lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> (is_bored \"Hello world\")\n;; 0\n;; >>> (is_bored \"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; >>> (any_int 5 2 7)\n;; #t\n;; >>> (any_int 3 2 2)\n;; #f\n;; >>> (any_int 3 -2 1)\n;; #t\n;; >>> (any_int 3.6 -2.2 2)\n;; #f\n(define (any_int x y z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> (encode \"test\")\n;; \"TGST\"\n;; >>> (encode \"This is a message\")\n;; \"tHKS KS C MGSSCGG\"\n(define (encode message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; >>> (skjkasdkd (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3))\n;; 10\n;; >>> (skjkasdkd (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1))\n;; 25\n;; >>> (skjkasdkd (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3))\n;; 13\n;; >>> (skjkasdkd (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6))\n;; 11\n;; >>> (skjkasdkd (list 0 81 12 3 1 21))\n;; 3\n;; >>> (skjkasdkd (list 0 8 1 2 1 7))\n;; 7\n(define (skjkasdkd lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a hash, return #t if all keys are strings in lower \n;; case or all keys are strings in upper case, else return #f.\n;; The function should return #f is the given hash is empty.\n;; Examples:\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"b\" .  \"banana\")))\n;; #t\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\")))\n;; #f\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (8 .  \"banana\") (\"a\" .  \"apple\")))\n;; #f\n;; >>> (check_dict_case #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\")))\n;; #f\n;; >>> (check_dict_case #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\")))\n;; #t\n(define (check_dict_case dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns a list of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; >>> (count_up_to 5)\n;; (list 2 3)\n;; >>> (count_up_to 11)\n;; (list 2 3 5 7)\n;; >>> (count_up_to 0)\n;; (list )\n;; >>> (count_up_to 20)\n;; (list 2 3 5 7 11 13 17 19)\n;; >>> (count_up_to 1)\n;; (list )\n;; >>> (count_up_to 18)\n;; (list 2 3 5 7 11 13 17)\n(define (count_up_to n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; >>> (multiply 148 412)\n;; 16\n;; >>> (multiply 19 28)\n;; 72\n;; >>> (multiply 2020 1851)\n;; 0\n;; >>> (multiply 14 -15)\n;; 20\n(define (multiply a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; >>> (count_upper \"aBCdEf\")\n;; 1\n;; >>> (count_upper \"abcdefg\")\n;; 0\n;; >>> (count_upper \"dBBE\")\n;; 0\n(define (count_upper s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> (closest_integer \"10\")\n;; 10\n;; >>> (closest_integer \"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> (rolling_max (list 1 2 3 2 3 4 2))\n;; (list 1 2 3 3 3 4 4)\n(define (rolling_max numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/humaneval-rkt-transform.json
+++ b/prompts/humaneval-rkt-transform.json
@@ -1,1752 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> (strlen \"\")\n;; 0\n;; >>> (strlen \"abc\")\n;; 3\n(define (strlen string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; >>> (encrypt \"hi\")\n;; \"lm\"\n;; >>> (encrypt \"asdfghjkl\")\n;; \"ewhjklnop\"\n;; >>> (encrypt \"gf\")\n;; \"kj\"\n;; >>> (encrypt \"et\")\n;; \"ix\"\n(define (encrypt s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"b\" .  \"banana\")))\n;; #t\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\")))\n;; #f\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (8 .  \"banana\") (\"a\" .  \"apple\")))\n;; #f\n;; >>> (check_dict_case #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\")))\n;; #f\n;; >>> (check_dict_case #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\")))\n;; #t\n(define (check_dict_case dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; >>> (add (list 4 2 6 7))\n;; 2\n(define (add lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; >>> (fix_spaces \" Example\")\n;; \"Example\"\n;; >>> (fix_spaces \" Example 1\")\n;; \"Example_1\"\n;; >>> (fix_spaces \" Example 2\")\n;; \"_Example_2\"\n;; >>> (fix_spaces \" Example 3\")\n;; \"_Example-3\"\n(define (fix_spaces text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> (fibfib 1)\n;; 0\n;; >>> (fibfib 5)\n;; 4\n;; >>> (fibfib 8)\n;; 24\n(define (fibfib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; >>> (double_the_difference (list 1 3 2 0))\n;; 10\n;; >>> (double_the_difference (list -1 -2 0))\n;; 0\n;; >>> (double_the_difference (list 9 -2))\n;; 81\n;; >>> (double_the_difference (list 0))\n;; 0\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n;; >>> (filter_integers (list \"a\" 3.14 5))\n;; (list 5)\n;; >>> (filter_integers (list 1 2 3 \"abc\" #hash() (list )))\n;; (list 1 2 3)\n(define (filter_integers values)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> (parse_music \"o o| .| o| o| .| .| .| .| o o\")\n;; (list 4 2 1 2 2 1 1 1 1 4 4)\n(define (parse_music music_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; >>> (decimal_to_binary 15)\n;; \"db1111db\"\n;; >>> (decimal_to_binary 32)\n;; \"db100000db\"\n(define (decimal_to_binary decimal)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> (all_prefixes \"abc\")\n;; (list \"a\" \"ab\" \"abc\")\n(define (all_prefixes string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> (add 2 3)\n;; 5\n;; >>> (add 5 7)\n;; 12\n(define (add x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; >>> (eat 5 6 10)\n;; (list 11 4)\n;; >>> (eat 4 8 9)\n;; (list 12 1)\n;; >>> (eat 1 10 10)\n;; (list 11 0)\n;; >>> (eat 2 11 5)\n;; (list 7 0)\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; >>> (max_fill (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1)\n;; 6\n;; Example 2:\n;; >>> (max_fill (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2)\n;; 5\n;; Example 3:\n;; >>> (max_fill (list (list 0 0 0) (list 0 0 0)) 5)\n;; 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; array = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> (flip_case \"Hello\")\n;; \"hELLO\"\n(define (flip_case string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; >>> (by_length (list 2 1 1 4 5 8 2 3))\n;; (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\")\n;; If the array is empty, return an empty array:\n;; >>> (by_length (list ))\n;; (list )\n;; If the array has any strange number ignore it:\n;; >>> (by_length (list 1 -1 55))\n;; (list \"One\")\n(define (by_length arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> (factorize 8)\n;; (list 2 2 2)\n;; >>> (factorize 25)\n;; (list 5 5)\n;; >>> (factorize 70)\n;; (list 2 5 7)\n(define (factorize n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; >>> (count_up_to 5)\n;; (list 2 3)\n;; >>> (count_up_to 11)\n;; (list 2 3 5 7)\n;; >>> (count_up_to 0)\n;; (list )\n;; >>> (count_up_to 20)\n;; (list 2 3 5 7 11 13 17 19)\n;; >>> (count_up_to 1)\n;; (list )\n;; >>> (count_up_to 18)\n;; (list 2 3 5 7 11 13 17)\n(define (count_up_to n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> (unique (list 5 3 5 2 3 3 9 0 123))\n;; (list 0 2 3 5 9 123)\n(define (unique l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; >>> (total_match (list ) (list ))\n;; (list )\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"Hi\"))\n;; (list \"hI\" \"Hi\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\"))\n;; (list \"hi\" \"admin\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\"))\n;; (list \"hI\" \"hi\" \"hi\")\n;; >>> (total_match (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\"))\n;; (list \"4\")\n(define (total_match lst1 lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> (max_element (list 1 2 3))\n;; 3\n;; >>> (max_element (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; 123\n(define (max_element l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; >>> (is_nested \"[[]]\")\n;; #t\n;; >>> (is_nested \"[]]]]]]][[[[[]\")\n;; #f\n;; >>> (is_nested \"[][]\")\n;; #f\n;; >>> (is_nested \"[]\")\n;; #f\n;; >>> (is_nested \"[[][]]\")\n;; #t\n;; >>> (is_nested \"[[]][[\")\n;; #t\n(define (is_nested string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; >>> (rounded_avg 1 5)\n;; \"0b11\"\n;; >>> (rounded_avg 7 5)\n;; -1\n;; >>> (rounded_avg 10 20)\n;; \"0b1111\"\n;; >>> (rounded_avg 20 33)\n;; \"0b11010\"\n(define (rounded_avg n m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> (odd_count (list \"1234567\"))\n;; (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n;; >>> (odd_count (list \"3\" \"11111111\"))\n;; (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\n(define (odd_count lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; >>> (move_one_ball (list 3 4 5 1 2))\n;; #t\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; >>> (move_one_ball (list 3 5 4 1 2))\n;; #f\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; >>> (even_odd_palindrome 3)\n;; (list 1 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; >>> (even_odd_palindrome 12)\n;; (list 4 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; >>> (is_equal_to_sum_even 4)\n;; #f\n;; >>> (is_equal_to_sum_even 6)\n;; #f\n;; >>> (is_equal_to_sum_even 8)\n;; #t\n(define (is_equal_to_sum_even n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> (derivative (list 3 1 2 4 5))\n;; (list 1 4 12 20)\n;; >>> (derivative (list 1 2 3))\n;; (list 2 6)\n(define (derivative xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n;; >>> (is_sorted (list 5))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5))\n;; #f\n;; >>> (is_sorted (list 1 2 3 4 5 6))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5 6 7))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5 6 7))\n;; #f\n;; >>> (is_sorted (list 1 2 2 3 3 4))\n;; #t\n;; >>> (is_sorted (list 1 2 2 2 3 4))\n;; #f\n(define (is_sorted lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; >>> (solve \"1234\")\n;; \"4321\"\n;; >>> (solve \"ab\")\n;; \"AB\"\n;; >>> (solve \"#a@C\")\n;; \"#A@c\"\n(define (solve s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; >>> (tri 3)\n;; (list 1 3 2 8)\n(define (tri n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> (fizz_buzz 50)\n;; 0\n;; >>> (fizz_buzz 78)\n;; 2\n;; >>> (fizz_buzz 79)\n;; 3\n(define (fizz_buzz n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> (filter_by_prefix (list ) \"a\")\n;; (list )\n;; >>> (filter_by_prefix (list \"abc\" \"bcd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"array\")\n(define (filter_by_prefix strings prefix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; >>> (solve 1000)\n;; \"1\"\n;; >>> (solve 150)\n;; \"110\"\n;; >>> (solve 147)\n;; \"1100\"\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:    \n;; >>> (minPath (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3)\n;; (list 1 2 1)\n;; >>> (minPath (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1)\n;; (list 1)\n(define (minPath grid k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; >>> (count_upper \"aBCdEf\")\n;; 1\n;; >>> (count_upper \"abcdefg\")\n;; 0\n;; >>> (count_upper \"dBBE\")\n;; 0\n(define (count_upper s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; >>> (maximum (list -3 -4 5) 3)\n;; (list -4 -3 5)\n;; Example 2:\n;; >>> (maximum (list 4 -4 4) 2)\n;; (list 4 4)\n;; Example 3:\n;; >>> (maximum (list -3 2 1 2 -1 -2 1) 1)\n;; (list 2)\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> (largest_divisor 15)\n;; 5\n(define (largest_divisor n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n;; >>> (sort_array (list ))\n;; (list )\n;; >>> (sort_array (list 5))\n;; (list 5)\n;; >>> (sort_array (list 2 4 3 0 1 5))\n;; (list 0 1 2 3 4 5)\n;; >>> (sort_array (list 2 4 3 0 1 5 6))\n;; (list 6 5 4 3 2 1 0)\n(define (sort_array array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; >>> (f 5)\n;; (list 1 2 6 24 15)\n(define (f n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; >>> (iscube 1)\n;; #t\n;; >>> (iscube 2)\n;; #f\n;; >>> (iscube -1)\n;; #t\n;; >>> (iscube 64)\n;; #t\n;; >>> (iscube 0)\n;; #t\n;; >>> (iscube 180)\n;; #f\n(define (iscube a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> (encode \"test\")\n;; \"TGST\"\n;; >>> (encode \"This is a message\")\n;; \"tHKS KS C MGSSCGG\"\n(define (encode message)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> (is_bored \"Hello world\")\n;; 0\n;; >>> (is_bored \"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> (pairs_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 3 -2 1))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (pairs_sum_to_zero (list 2 4 -5 3 5 7))\n;; #t\n;; >>> (pairs_sum_to_zero (list 1))\n;; #f\n(define (pairs_sum_to_zero l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; >>> (triangle_area 3 4 5)\n;; 6.0\n;; >>> (triangle_area 1 2 10)\n;; -1\n(define (triangle_area a b c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; >>> (bf \"Jupiter\" \"Neptune\")\n;; (list \"Saturn\" \"Uranus\")\n;; >>> (bf \"Earth\" \"Mercury\")\n;; \"Venus\"\n;; >>> (bf \"Mercury\" \"Uranus\")\n;; (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\")\n(define (bf planet1 planet2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; >>> (digits 1)\n;; 1\n;; >>> (digits 4)\n;; 0\n;; >>> (digits 235)\n;; 15\n(define (digits n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n;; >>> (words_string \"Hi, my name is John\")\n;; (list \"Hi\" \"my\" \"name\" \"is\" \"John\")\n;; >>> (words_string \"One, two, three, four, five, six\")\n;; (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\")\n(define (words_string s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> (how_many_times \"\" \"a\")\n;; 0\n;; >>> (how_many_times \"aaa\" \"a\")\n;; 3\n;; >>> (how_many_times \"aaaa\" \"aa\")\n;; 3\n(define (how_many_times string substring)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; >>> (compare_one 1 2.5)\n;; 2.5\n;; >>> (compare_one 1 \"2,3\")\n;; \"2,3\"\n;; >>> (compare_one \"5,1\" \"6\")\n;; \"6\"\n;; >>> (compare_one \"1\" 1)\n;; #f\n(define (compare_one a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> (remove_vowels \"\")\n;; \"\"\n;; >>> (remove_vowels \"abcdef\")\n;; \"bcdf\"\n;; >>> (remove_vowels \"aaaaa\")\n;; \"\"\n;; >>> (remove_vowels \"aaBAA\")\n;; \"B\"\n;; >>> (remove_vowels \"zbcd\")\n;; \"zbcd\"\n(define (remove_vowels text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; >>> (strange_sort_list (list 1 2 3 4))\n;; (list 1 4 2 3)\n;; >>> (strange_sort_list (list 5 5 5 5))\n;; (list 5 5 5 5)\n;; >>> (strange_sort_list (list ))\n;; (list )\n(define (strange_sort_list lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.2))\n;; (list 2.0 2.2)\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.0))\n;; (list 2.0 2.0)\n(define (find_closest_elements numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; >>> (is_simple_power 1 4)\n;; #t\n;; >>> (is_simple_power 2 2)\n;; #t\n;; >>> (is_simple_power 8 2)\n;; #t\n;; >>> (is_simple_power 3 2)\n;; #f\n;; >>> (is_simple_power 3 1)\n;; #f\n;; >>> (is_simple_power 5 3)\n;; #f\n(define (is_simple_power x n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> (prime_fib 1)\n;; 2\n;; >>> (prime_fib 2)\n;; 3\n;; >>> (prime_fib 3)\n;; 5\n;; >>> (prime_fib 4)\n;; 13\n;; >>> (prime_fib 5)\n;; 89\n(define (prime_fib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> (order_by_points (list 1 11 -1 -11 -12))\n;; (list -1 -11 1 -12 11)\n;; >>> (order_by_points (list ))\n;; (list )\n(define (order_by_points nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if in given list of numbers, are any two numbers closer to each other than\n;; given threshold.\n;; >>> (has_close_elements (list 1.0 2.0 3.0) 0.5)\n;; #f\n;; >>> (has_close_elements (list 1.0 2.8 3.0 4.0 5.0 2.0) 0.3)\n;; #t\n(define (has_close_elements numbers threshold)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate has_close_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.3) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2) 0.05) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.95) #t 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0) 0.8) #f 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0) 0.1) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 1.0) #t 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1) 0.5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> (make_palindrome \"\")\n;; \"\"\n;; >>> (make_palindrome \"cat\")\n;; \"catac\"\n;; >>> (make_palindrome \"cata\")\n;; \"catac\"\n(define (make_palindrome string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> (string_xor \"010\" \"110\")\n;; \"100\"\n(define (string_xor a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> (special_factorial 4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; >>> (add_elements (list 111 21 3 4000 5 6 7 8 9) 4)\n;; 24\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> (fib4 5)\n;; 4\n;; >>> (fib4 6)\n;; 8\n;; >>> (fib4 7)\n;; 14\n(define (fib4 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> (unique_digits (list 15 33 1422 1))\n;; (list 1 15 33)\n;; >>> (unique_digits (list 152 323 1422 10))\n;; (list )\n(define (unique_digits x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; >>> (select_words \"Mary had a little lamb\" 4)\n;; (list \"little\")\n;; >>> (select_words \"Mary had a little lamb\" 3)\n;; (list \"Mary\" \"lamb\")\n;; >>> (select_words \"simple white space\" 2)\n;; (list )\n;; >>> (select_words \"Hello world\" 4)\n;; (list \"world\")\n;; >>> (select_words \"Uncle sam\" 3)\n;; (list \"Uncle\")\n(define (select_words s n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; >>> (will_it_fly (list 1 2) 5)\n;; #f\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; >>> (will_it_fly (list 3 2 3) 1)\n;; #f\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; >>> (will_it_fly (list 3 2 3) 9)\n;; #t\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; >>> (will_it_fly (list 3) 5)\n;; #t\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> (fib 10)\n;; 55\n;; >>> (fib 1)\n;; 1\n;; >>> (fib 8)\n;; 21\n(define (fib n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; >>> (Strongest_Extension \"my_class\" (list \"AA\" \"Be\" \"CC\"))\n;; \"my_class.AA\"\n(define (Strongest_Extension class_name extensions)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; >>> (match_parens (list \"()(\" \")\"))\n;; \"Yes\"\n;; >>> (match_parens (list \")\" \")\"))\n;; \"No\"\n(define (match_parens lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n;; >>> (next_smallest (list 1 2 3 4 5))\n;; 2\n;; >>> (next_smallest (list 5 1 4 3 2))\n;; 2\n;; >>> (next_smallest (list ))\n;; #f\n;; >>> (next_smallest (list 1 1))\n;; #f\n(define (next_smallest lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; >>> (any_int 5 2 7)\n;; #t\n;; >>> (any_int 3 2 2)\n;; #f\n;; >>> (any_int 3 -2 1)\n;; #t\n;; >>> (any_int 3.6 -2.2 2)\n;; #f\n(define (any_int x y z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> (truncate_number 3.5)\n;; 0.5\n(define (truncate_number number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> (incr_list (list 1 2 3))\n;; (list 2 3 4)\n;; >>> (incr_list (list 5 3 5 2 3 3 9 0 123))\n;; (list 6 4 6 3 4 4 10 1 124)\n(define (incr_list l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; >>> (x_or_y 7 34 12)\n;; 34\n;; >>> (x_or_y 15 8 5)\n;; 5\n(define (x_or_y n x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> (modp 3 5)\n;; 3\n;; >>> (modp 1101 101)\n;; 2\n;; >>> (modp 0 101)\n;; 1\n;; >>> (modp 3 11)\n;; 8\n;; >>> (modp 100 101)\n;; 1\n(define (modp n p)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n;; >>> (even_odd_count -12)\n;; (list 1 1)\n;; >>> (even_odd_count 123)\n;; (list 1 2)\n(define (even_odd_count num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; >>> (is_happy \"a\")\n;; #f\n;; >>> (is_happy \"aa\")\n;; #f\n;; >>> (is_happy \"abcd\")\n;; #t\n;; >>> (is_happy \"aabb\")\n;; #f\n;; >>> (is_happy \"adb\")\n;; #t\n;; >>> (is_happy \"xyy\")\n;; #f\n(define (is_happy s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> (largest_prime_factor 13195)\n;; 29\n;; >>> (largest_prime_factor 2048)\n;; 2\n(define (largest_prime_factor n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; >>> (digitSum \"\")\n;; 0\n;; >>> (digitSum \"abAB\")\n;; 131\n;; >>> (digitSum \"abcCd\")\n;; 67\n;; >>> (digitSum \"helloE\")\n;; 69\n;; >>> (digitSum \"woArBld\")\n;; 131\n;; >>> (digitSum \"aAaaaXa\")\n;; 153\n(define (digitSum s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> (rescale_to_unit (list 1.0 2.0 3.0 4.0 5.0))\n;; (list 0.0 0.25 0.5 0.75 1.0)\n(define (rescale_to_unit numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; >>> (solution (list 5 8 7 1))\n;; 12\n;; >>> (solution (list 3 3 3 3 3))\n;; 9\n;; >>> (solution (list 30 13 24 321))\n;; 0\n(define (solution lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; >>> (pluck (list 4 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; >>> (pluck (list 1 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; >>> (pluck (list ))\n;; (list )\n;; Example 4:\n;; >>> (pluck (list 5 0 3 0 4 2))\n;; (list 0 1)\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; >>> (get_max_triples 5)\n;; 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; >>> (exchange (list 1 2 3 4) (list 1 2 3 4))\n;; \"YES\"\n;; >>> (exchange (list 1 2 3 4) (list 1 5 3 4))\n;; \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> (median (list 3 1 2 4 5))\n;; 3\n;; >>> (median (list -10 4 6 1000 10 20))\n;; 15.0\n(define (median l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n;; >>> (prime_length \"Hello\")\n;; #t\n;; >>> (prime_length \"abcdcba\")\n;; #t\n;; >>> (prime_length \"kittens\")\n;; #t\n;; >>> (prime_length \"orange\")\n;; #f\n(define (prime_length string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; >>> (smallest_change (list 1 2 3 5 4 7 9 6))\n;; 4\n;; >>> (smallest_change (list 1 2 3 4 3 2 2))\n;; 1\n;; >>> (smallest_change (list 1 2 3 2 1))\n;; 0\n(define (smallest_change arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; >>> (lst (list 1.0 2.0 3.0))\n;; 14\n;; >>> (lst (list 1.0 4.0 9.0))\n;; 98\n;; >>> (lst (list 1.0 3.0 5.0 7.0))\n;; 84\n;; >>> (lst (list 1.4 4.2 0.0))\n;; 29\n;; >>> (lst (list -2.4 1.0 1.0))\n;; 6\n(define (sum_squares lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; >>> (file_name_check \"example.txt\")\n;; \"Yes\"\n;; >>> (file_name_check \"1example.dll\")\n;; \"No\"\n(define (file_name_check file_name)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> (triples_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (triples_sum_to_zero (list 1 3 -2 1))\n;; #t\n;; >>> (triples_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (triples_sum_to_zero (list 2 4 -5 3 9 7))\n;; #t\n;; >>> (triples_sum_to_zero (list 1))\n;; #f\n(define (triples_sum_to_zero l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; >>> (intersection (list 1 2) (list 2 3))\n;; \"NO\"\n;; >>> (intersection (list -1 1) (list 0 4))\n;; \"NO\"\n;; >>> (intersection (list -3 -1) (list -5 5))\n;; \"YES\"\n(define (intersection interval1 interval2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> (separate_paren_groups \"( ) (( )) (( )( ))\")\n;; (list \"()\" \"(())\" \"(()())\")\n(define (separate_paren_groups paren_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; >>> (compare (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2))\n;; (list 0 0 0 0 3 3)\n;; >>> (compare (list 0 5 0 0 0 4) (list 4 1 1 0 0 -2))\n;; (list 4 4 1 0 0 6)\n(define (compare game guess)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; >>> (check_if_last_char_is_a_letter \"apple pie\")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"apple pi e\")\n;; #t\n;; >>> (check_if_last_char_is_a_letter \"apple pi e \")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"\")\n;; #f\n(define (check_if_last_char_is_a_letter txt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; >>> (valid_date \"03-11-2000\")\n;; #t\n;; >>> (valid_date \"15-01-2012\")\n;; #f\n;; >>> (valid_date \"04-0-2040\")\n;; #f\n;; >>> (valid_date \"06-04-2020\")\n;; #t\n;; >>> (valid_date \"06/04/2020\")\n;; #f\n(define (valid_date date)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> (count_nums (list ))\n;; 0\n;; >>> (count_nums (list -1 11 -11))\n;; 1\n;; >>> (count_nums (list 1 1 2))\n;; 3\n(define (count_nums arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; >>> (anti_shuffle \"Hi\")\n;; \"Hi\"\n;; >>> (anti_shuffle \"hello\")\n;; \"ehllo\"\n;; >>> (anti_shuffle \"Hello World!!!\")\n;; \"Hello !!!Wdlor\"\n(define (anti_shuffle s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> (is_palindrome \"\")\n;; #t\n;; >>> (is_palindrome \"aba\")\n;; #t\n;; >>> (is_palindrome \"aaaaa\")\n;; #t\n;; >>> (is_palindrome \"zbcd\")\n;; #f\n(define (is_palindrome text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; >>> (get_closest_vowel \"yogurt\")\n;; \"u\"\n;; >>> (get_closest_vowel \"FULL\")\n;; \"U\"\n;; >>> (get_closest_vowel \"quick\")\n;; \"\"\n;; >>> (get_closest_vowel \"ab\")\n;; \"\"\n(define (get_closest_vowel word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> (is_prime 6)\n;; #f\n;; >>> (is_prime 101)\n;; #t\n;; >>> (is_prime 11)\n;; #t\n;; >>> (is_prime 13441)\n;; #t\n;; >>> (is_prime 61)\n;; #t\n;; >>> (is_prime 4)\n;; #f\n;; >>> (is_prime 1)\n;; #f\n(define (is_prime n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; >>> (simplify \"1/5\" \"5/1\")\n;; #t\n;; >>> (simplify \"1/6\" \"2/1\")\n;; #f\n;; >>> (simplify \"7/10\" \"10/2\")\n;; #f\n(define (simplify x n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; >>> (hex_key \"AB\")\n;; 1\n;; >>> (hex_key \"1077E\")\n;; 2\n;; >>> (hex_key \"ABED1A33\")\n;; 4\n;; >>> (hex_key \"123456789ABCDEF0\")\n;; 6\n;; >>> (hex_key \"2020\")\n;; 2\n(define (hex_key num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; >>> (words_in_sentence \"This is a test\")\n;; \"is\"\n;; Example 2:\n;; >>> (words_in_sentence \"lets go for swimming\")\n;; \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; >>> (histogram \"a b c\")\n;; #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1))\n;; >>> (histogram \"a b b a\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"a b c a b\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"b b b b a\")\n;; #hash((\"b\" .  4))\n;; >>> (histogram \"\")\n;; #hash()\n(define (histogram test)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; >>> (get_row (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1)\n;; (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0))\n;; >>> (get_row (list ) 1)\n;; (list )\n;; >>> (get_row (list (list ) (list 1) (list 1 2 3)) 3)\n;; (list (list 2 2))\n(define (get_row lst x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n;; >>> (get_odd_collatz 5)\n;; (list 1 5)\n(define (get_odd_collatz n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n;; >>> (can_arrange (list 1 2 4 3 5))\n;; 3\n;; >>> (can_arrange (list 1 2 3))\n;; -1\n(define (can_arrange arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> (sort_numbers \"three one five\")\n;; \"one three five\"\n(define (sort_numbers numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> (circular_shift 12 1)\n;; \"21\"\n;; >>> (circular_shift 12 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; >>> lst\n;; (list 1 2 3)\n;; >>> lst\n;; (list )\n;; >>> lst\n;; (list -1 -5 2 -1 -5)\n(define (sum_squares lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; >>> (skjkasdkd (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3))\n;; 10\n;; >>> (skjkasdkd (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1))\n;; 25\n;; >>> (skjkasdkd (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3))\n;; 13\n;; >>> (skjkasdkd (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6))\n;; 11\n;; >>> (skjkasdkd (list 0 81 12 3 1 21))\n;; 3\n;; >>> (skjkasdkd (list 0 8 1 2 1 7))\n;; 7\n(define (skjkasdkd lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> (sum_product (list ))\n;; (list 0 1)\n;; >>> (sum_product (list 1 2 3 4))\n;; (list 10 24)\n(define (sum_product numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n;; >>> (choose_num 12 15)\n;; 14\n;; >>> (choose_num 13 12)\n;; -1\n(define (choose_num x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n;; >>> (largest_smallest_integers (list 2 4 1 3 5 7))\n;; (list #f 1)\n;; >>> (largest_smallest_integers (list ))\n;; (list #f #f)\n;; >>> (largest_smallest_integers (list 0))\n;; (list #f #f)\n(define (largest_smallest_integers lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n;; >>> (count_distinct_characters \"xyzXYZ\")\n;; 3\n;; >>> (count_distinct_characters \"Jerry\")\n;; 4\n(define (count_distinct_characters string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1759,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given a positive integer n, you have to make a pile of n levels of stones.\n;; The first level has n stones.\n;; The number of stones in the next level is:\n;; - the next odd number if n is odd.\n;; - the next even number if n is even.\n;; Return the number of stones in each level in a list, where element at index\n;; i represents the number of stones in the level (i+1).\n;; Examples:\n;; >>> (make_a_pile 3)\n;; (list 3 5 7)\n(define (make_a_pile n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_a_pile))\n    (check-within (candidate 3) (list 3 5 7) 0.001)\n    (check-within (candidate 4) (list 4 6 8 10) 0.001)\n    (check-within (candidate 5) (list 5 7 9 11 13) 0.001)\n    (check-within (candidate 6) (list 6 8 10 12 14 16) 0.001)\n    (check-within (candidate 8) (list 8 10 12 14 16 18 20 22) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -1770,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n;; >>> (prod_signs (list 1 2 2 -4))\n;; 9\n;; >>> (prod_signs (list 0 1))\n;; 0\n;; >>> (prod_signs (list ))\n;; #f\n(define (prod_signs arr)\n",
+    "prompt": "#lang racket\n\n;; You will be given a string of words separated by commas or spaces. Your task is\n;; to split the string into words and return an array of the words.\n;; For example:\n;; >>> (words_string \"Hi, my name is John\")\n;; (list \"Hi\" \"my\" \"name\" \"is\" \"John\")\n;; >>> (words_string \"One, two, three, four, five, six\")\n;; (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\")\n(define (words_string s)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_string))\n    (check-within (candidate \"Hi, my name is John\") (list \"Hi\" \"my\" \"name\" \"is\" \"John\") 0.001)\n    (check-within (candidate \"One, two, three, four, five, six\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"Hi, my name\") (list \"Hi\" \"my\" \"name\") 0.001)\n    (check-within (candidate \"One,, two, three, four, five, six,\") (list \"One\" \"two\" \"three\" \"four\" \"five\" \"six\") 0.001)\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"ahmed     , gamal\") (list \"ahmed\" \"gamal\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1785,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n;; >>> (minSubArraySum (list 2 3 4 1 2 4))\n;; 1\n;; >>> (minSubArraySum (list -1 -2 -3))\n;; -6\n(define (minSubArraySum nums)\n",
+    "prompt": "#lang racket\n\n;; This function takes two positive numbers x and y and returns the\n;; biggest even integer number that is in the range [x, y] inclusive. If \n;; there's no such number, then the function should return -1.\n;; For example:\n;; >>> (choose_num 12 15)\n;; 14\n;; >>> (choose_num 13 12)\n;; -1\n(define (choose_num x y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate choose_num))\n    (check-within (candidate 12 15) 14 0.001)\n    (check-within (candidate 13 12) -1 0.001)\n    (check-within (candidate 33 12354) 12354 0.001)\n    (check-within (candidate 5234 5233) -1 0.001)\n    (check-within (candidate 6 29) 28 0.001)\n    (check-within (candidate 27 10) -1 0.001)\n    (check-within (candidate 7 7) -1 0.001)\n    (check-within (candidate 546 546) 546 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1800,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> (string_sequence 0)\n;; \"0\"\n;; >>> (string_sequence 5)\n;; \"0 1 2 3 4 5\"\n(define (string_sequence n)\n",
+    "prompt": "#lang racket\n\n;; You are given two positive integers n and m, and your task is to compute the\n;; average of the integers from n through m (including n and m). \n;; Round the answer to the nearest integer and convert that to binary.\n;; If n is greater than m, return -1.\n;; Example:\n;; >>> (rounded_avg 1 5)\n;; \"0b11\"\n;; >>> (rounded_avg 7 5)\n;; -1\n;; >>> (rounded_avg 10 20)\n;; \"0b1111\"\n;; >>> (rounded_avg 20 33)\n;; \"0b11010\"\n(define (rounded_avg n m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rounded_avg))\n    (check-within (candidate 1 5) \"0b11\" 0.001)\n    (check-within (candidate 7 13) \"0b1010\" 0.001)\n    (check-within (candidate 964 977) \"0b1111001010\" 0.001)\n    (check-within (candidate 996 997) \"0b1111100100\" 0.001)\n    (check-within (candidate 560 851) \"0b1011000010\" 0.001)\n    (check-within (candidate 185 546) \"0b101101110\" 0.001)\n    (check-within (candidate 362 496) \"0b110101101\" 0.001)\n    (check-within (candidate 350 902) \"0b1001110010\" 0.001)\n    (check-within (candidate 197 233) \"0b11010111\" 0.001)\n    (check-within (candidate 7 5) -1 0.001)\n    (check-within (candidate 5 1) -1 0.001)\n    (check-within (candidate 5 5) \"0b101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1815,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n;; >>> (cycpattern_check \"abcd\" \"abd\")\n;; #f\n;; >>> (cycpattern_check \"hello\" \"ell\")\n;; #t\n;; >>> (cycpattern_check \"whassup\" \"psus\")\n;; #f\n;; >>> (cycpattern_check \"abab\" \"baa\")\n;; #t\n;; >>> (cycpattern_check \"efef\" \"eeff\")\n;; #f\n;; >>> (cycpattern_check \"himenss\" \"simen\")\n;; #t\n(define (cycpattern_check a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of positive integers x. return a sorted list of all \n;; elements that hasn't any even digit.\n;; Note: Returned list should be sorted in increasing order.\n;; For example:\n;; >>> (unique_digits (list 15 33 1422 1))\n;; (list 1 15 33)\n;; >>> (unique_digits (list 152 323 1422 10))\n;; (list )\n(define (unique_digits x)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_digits))\n    (check-within (candidate (list 15 33 1422 1)) (list 1 15 33) 0.001)\n    (check-within (candidate (list 152 323 1422 10)) (list ) 0.001)\n    (check-within (candidate (list 12345 2033 111 151)) (list 111 151) 0.001)\n    (check-within (candidate (list 135 103 31)) (list 31 135) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1830,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n;; >>> (monotonic (list 1 2 4 20))\n;; #t\n;; >>> (monotonic (list 1 20 4 10))\n;; #f\n;; >>> (monotonic (list 4 1 0 -10))\n;; #t\n(define (monotonic l)\n",
+    "prompt": "#lang racket\n\n;; Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n;; reverse the resulting array, and then replace each digit by its corresponding name from\n;; \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n;; For example:\n;; >>> (by_length (list 2 1 1 4 5 8 2 3))\n;; (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\")\n;; If the array is empty, return an empty array:\n;; >>> (by_length (list ))\n;; (list )\n;; If the array has any strange number ignore it:\n;; >>> (by_length (list 1 -1 55))\n;; (list \"One\")\n(define (by_length arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate by_length))\n    (check-within (candidate (list 2 1 1 4 5 8 2 3)) (list \"Eight\" \"Five\" \"Four\" \"Three\" \"Two\" \"Two\" \"One\" \"One\") 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -1 55)) (list \"One\") 0.001)\n    (check-within (candidate (list 1 -1 3 2)) (list \"Three\" \"Two\" \"One\") 0.001)\n    (check-within (candidate (list 9 4 8)) (list \"Nine\" \"Eight\" \"Four\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1845,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n;; >>> (longest (list ))\n;; #f\n;; >>> (longest (list \"a\" \"b\" \"c\"))\n;; \"a\"\n;; >>> (longest (list \"a\" \"bb\" \"ccc\"))\n;; \"ccc\"\n(define (longest strings)\n",
+    "prompt": "#lang racket\n\n;; Implement the function f that takes n as a parameter,\n;; and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n;; or the sum of numbers from 1 to i otherwise.\n;; i starts from 1.\n;; the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n;; Example:\n;; >>> (f 5)\n;; (list 1 2 6 24 15)\n(define (f n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate f))\n    (check-within (candidate 5) (list 1 2 6 24 15) 0.001)\n    (check-within (candidate 7) (list 1 2 6 24 15 720 28) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n    (check-within (candidate 3) (list 1 2 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1860,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n;; >>> (below_threshold (list 1 2 4 10) 100)\n;; #t\n;; >>> (below_threshold (list 1 20 4 10) 5)\n;; #f\n(define (below_threshold l t)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a tuple that has the number of even and odd\n;; integer palindromes that fall within the range(1, n), inclusive.\n;; Example 1:\n;; >>> (even_odd_palindrome 3)\n;; (list 1 2)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n;; Example 2:\n;; >>> (even_odd_palindrome 12)\n;; (list 4 6)\n;; Explanation:\n;; Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n;; Note:\n;; 1. 1 <= n <= 10^3\n;; 2. returned tuple has the number of even and odd integer palindromes respectively.\n(define (even_odd_palindrome n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_palindrome))\n    (check-within (candidate 123) (list 8 13) 0.001)\n    (check-within (candidate 12) (list 4 6) 0.001)\n    (check-within (candidate 3) (list 1 2) 0.001)\n    (check-within (candidate 63) (list 6 8) 0.001)\n    (check-within (candidate 25) (list 5 6) 0.001)\n    (check-within (candidate 19) (list 4 6) 0.001)\n    (check-within (candidate 9) (list 4 5) 0.001)\n    (check-within (candidate 1) (list 0 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1875,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; >>> (is_multiply_prime 30)\n;; #t\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "prompt": "#lang racket\n\n;; Write a function count_nums which takes an array of integers and returns\n;; the number of elements which has a sum of digits > 0.\n;; If a number is negative, then its first signed digit will be negative:\n;; e.g. -123 has signed digits -1, 2, and 3.\n;; >>> (count_nums (list ))\n;; 0\n;; >>> (count_nums (list -1 11 -11))\n;; 1\n;; >>> (count_nums (list 1 1 2))\n;; 3\n(define (count_nums arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_nums))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list -1 -2 0)) 0 0.001)\n    (check-within (candidate (list 1 1 2 -2 3 4 5)) 6 0.001)\n    (check-within (candidate (list 1 6 9 -6 0 1 5)) 5 0.001)\n    (check-within (candidate (list 1 100 98 -7 1 -1)) 4 0.001)\n    (check-within (candidate (list 12 23 34 -45 -56 0)) 5 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1890,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> (get_positive (list -1 2 -4 5 6))\n;; (list 2 5 6)\n;; >>> (get_positive (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; (list 5 3 2 3 9 123 1)\n(define (get_positive l)\n",
+    "prompt": "#lang racket\n\n;; We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n;; numbers in the array will be randomly ordered. Your task is to determine if\n;; it is possible to get an array sorted in non-decreasing order by performing \n;; the following operation on the given array:\n;; You are allowed to perform right shift operation any number of times.\n;; One right shift operation means shifting all elements of the array by one\n;; position in the right direction. The last element of the array will be moved to\n;; the starting position in the array i.e. 0th index. \n;; If it is possible to obtain the sorted array by performing the above operation\n;; then return True else return False.\n;; If the given array is empty then return True.\n;; Note: The given list is guaranteed to have unique elements.\n;; For Example:\n;; >>> (move_one_ball (list 3 4 5 1 2))\n;; #t\n;; Explanation: By performin 2 right shift operations, non-decreasing order can\n;; be achieved for the given array.\n;; >>> (move_one_ball (list 3 5 4 1 2))\n;; #f\n;; Explanation:It is not possible to get non-decreasing order for the given\n;; array by performing any number of right shift operations.\n(define (move_one_ball arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_one_ball))\n    (check-within (candidate (list 3 4 5 1 2)) #t 0.001)\n    (check-within (candidate (list 3 5 10 1 2)) #t 0.001)\n    (check-within (candidate (list 4 3 1 2)) #f 0.001)\n    (check-within (candidate (list 3 5 4 1 2)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1905,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> (sort_third (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_third (list 5 6 3 4 8 9 2))\n;; (list 2 6 3 4 8 9 5)\n(define (sort_third l)\n",
+    "prompt": "#lang racket\n\n;; Find the shortest palindrome that begins with a supplied string.\n;; Algorithm idea is simple:\n;; - Find the longest postfix of supplied string that is a palindrome.\n;; - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n;; >>> (make_palindrome \"\")\n;; \"\"\n;; >>> (make_palindrome \"cat\")\n;; \"catac\"\n;; >>> (make_palindrome \"cata\")\n;; \"catac\"\n(define (make_palindrome string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate make_palindrome))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"x\") \"x\" 0.001)\n    (check-within (candidate \"xyz\") \"xyzyx\" 0.001)\n    (check-within (candidate \"xyx\") \"xyx\" 0.001)\n    (check-within (candidate \"jerry\") \"jerryrrej\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1920,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> (parse_nested_parens \"(()()) ((())) () ((())()())\")\n;; (list 2 3 1 3)\n(define (parse_nested_parens paren_string)\n",
+    "prompt": "#lang racket\n\n;; In this problem, you will implement a function that takes two lists of numbers,\n;; and determines whether it is possible to perform an exchange of elements\n;; between them to make lst1 a list of only even numbers.\n;; There is no limit on the number of exchanged elements between lst1 and lst2.\n;; If it is possible to exchange elements between the lst1 and lst2 to make\n;; all the elements of lst1 to be even, return \"YES\".\n;; Otherwise, return \"NO\".\n;; For example:\n;; >>> (exchange (list 1 2 3 4) (list 1 2 3 4))\n;; \"YES\"\n;; >>> (exchange (list 1 2 3 4) (list 1 5 3 4))\n;; \"NO\"\n;; It is assumed that the input lists will be non-empty.\n(define (exchange lst1 lst2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate exchange))\n    (check-within (candidate (list 1 2 3 4) (list 1 2 3 4)) \"YES\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 1 5 3 4)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 2 1 4 3)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 4)) \"YES\" 0.001)\n    (check-within (candidate (list 5 7 3) (list 2 6 3)) \"NO\" 0.001)\n    (check-within (candidate (list 3 2 6 1 8 9) (list 3 5 5 1 1 1)) \"NO\" 0.001)\n    (check-within (candidate (list 100 200) (list 200 200)) \"YES\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -1935,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> (triangle_area 5 3)\n;; 7.5\n(define (triangle_area a h)\n",
+    "prompt": "#lang racket\n\n;; Given a string representing a space separated lowercase letters, return a dictionary\n;; of the letter with the most repetition and containing the corresponding count.\n;; If several letters have the same occurrence, return all of them.\n;; Example:\n;; >>> (histogram \"a b c\")\n;; #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1))\n;; >>> (histogram \"a b b a\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"a b c a b\")\n;; #hash((\"a\" .  2) (\"b\" .  2))\n;; >>> (histogram \"b b b b a\")\n;; #hash((\"b\" .  4))\n;; >>> (histogram \"\")\n;; #hash()\n(define (histogram test)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; >>> (multiply 148 412)\n;; 16\n;; >>> (multiply 19 28)\n;; 72\n;; >>> (multiply 2020 1851)\n;; 0\n;; >>> (multiply 14 -15)\n;; 20\n(define (multiply a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> (mean_absolute_deviation (list 1.0 2.0 3.0 4.0))\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> (common (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121))\n;; (list 1 5 653)\n;; >>> (common (list 5 3 2 8) (list 3 2))\n;; (list 2 3)\n(define (common l1 l2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> (int_to_mini_roman 19)\n;; \"xix\"\n;; >>> (int_to_mini_roman 152)\n;; \"clii\"\n;; >>> (int_to_mini_roman 426)\n;; \"cdxxvi\"\n(define (int_to_mini_roman number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; >>> (fruit_distribution \"5 apples and 6 oranges\" 19)\n;; 8\n;; >>> (fruit_distribution \"0 apples and 1 oranges\" 3)\n;; 2\n;; >>> (fruit_distribution \"2 apples and 3 oranges\" 100)\n;; 95\n;; >>> (fruit_distribution \"100 apples and 1 oranges\" 120)\n;; 19\n(define (fruit_distribution s n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate histogram))\n    (check-within (candidate \"a b b a\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c a b\") #hash((\"a\" .  2) (\"b\" .  2)) 0.001)\n    (check-within (candidate \"a b c d g\") #hash((\"a\" .  1) (\"b\" .  1) (\"c\" .  1) (\"d\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"b b b b a\") #hash((\"b\" .  4)) 0.001)\n    (check-within (candidate \"r t g\") #hash((\"r\" .  1) (\"t\" .  1) (\"g\" .  1)) 0.001)\n    (check-within (candidate \"\") #hash() 0.001)\n    (check-within (candidate \"a\") #hash((\"a\" .  1)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2029,7 +214,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Task\n;; We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n;; then check if the result string is palindrome.\n;; A string is called palindrome if it reads the same backward as forward.\n;; You should return a tuple containing the result string and True/False for the check.\n;; Example\n;; >>> (reverse_delete \"abcde\" \"ae\")\n;; (list \"bcd\" #f)\n;; >>> (reverse_delete \"abcdef\" \"b\")\n;; (list \"acdef\" #f)\n;; >>> (reverse_delete \"abcdedcba\" \"ab\")\n;; (list \"cdedc\" #t)\n(define (reverse_delete s c)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_delete))\n    (check-within (candidate \"abcde\" \"ae\") (list \"bcd\" #f) 0.001)\n    (check-within (candidate \"abcdef\" \"b\") (list \"acdef\" #f) 0.001)\n    (check-within (candidate \"abcdedcba\" \"ab\") (list \"cdedc\" #t) 0.001)\n    (check-within (candidate \"dwik\" \"w\") (list \"dik\" #f) 0.001)\n    (check-within (candidate \"a\" \"a\") (list \"\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"abcdedcba\" \"v\") (list \"abcdedcba\" #t) 0.001)\n    (check-within (candidate \"vabba\" \"v\") (list \"abba\" #t) 0.001)\n    (check-within (candidate \"mamma\" \"mia\") (list \"\" #t) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2040,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> (greatest_common_divisor 3 5)\n;; 1\n;; >>> (greatest_common_divisor 25 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
+    "prompt": "#lang racket\n\n;; Given a list of strings, where each string consists of only digits, return a list.\n;; Each element i of the output should be \"the number of odd elements in the\n;; string i of the input.\" where all the i's should be replaced by the number\n;; of odd digits in the i'th string of the input.\n;; >>> (odd_count (list \"1234567\"))\n;; (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\")\n;; >>> (odd_count (list \"3\" \"11111111\"))\n;; (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\")\n(define (odd_count lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_count))\n    (check-within (candidate (list \"1234567\")) (list \"the number of odd elements 4n the str4ng 4 of the 4nput.\") 0.001)\n    (check-within (candidate (list \"3\" \"11111111\")) (list \"the number of odd elements 1n the str1ng 1 of the 1nput.\" \"the number of odd elements 8n the str8ng 8 of the 8nput.\") 0.001)\n    (check-within (candidate (list \"271\" \"137\" \"314\")) (list \"the number of odd elements 2n the str2ng 2 of the 2nput.\" \"the number of odd elements 3n the str3ng 3 of the 3nput.\" \"the number of odd elements 2n the str2ng 2 of the 2nput.\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2055,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; >>> (split_words \"Hello world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"Hello,world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"abcdef\")\n;; 3\n(define (split_words txt)\n",
+    "prompt": "#lang racket\n\n;; Given an array of integers nums, find the minimum sum of any non-empty sub-array\n;; of nums.\n;; Example\n;; >>> (minSubArraySum (list 2 3 4 1 2 4))\n;; 1\n;; >>> (minSubArraySum (list -1 -2 -3))\n;; -6\n(define (minSubArraySum nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minSubArraySum))\n    (check-within (candidate (list 2 3 4 1 2 4)) 1 0.001)\n    (check-within (candidate (list -1 -2 -3)) -6 0.001)\n    (check-within (candidate (list -1 -2 -3 2 -10)) -14 0.001)\n    (check-within (candidate (list -9999999999999999)) -9999999999999999 0.001)\n    (check-within (candidate (list 0 10 20 1000000)) 0 0.001)\n    (check-within (candidate (list -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 100 -1 -2 -3 10 -5)) -6 0.001)\n    (check-within (candidate (list 10 11 13 8 3 4)) 3 0.001)\n    (check-within (candidate (list 100 -33 32 -1 0 -2)) -33 0.001)\n    (check-within (candidate (list -10)) -10 0.001)\n    (check-within (candidate (list 7)) 7 0.001)\n    (check-within (candidate (list 1 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a rectangular grid of wells. Each row represents a single well,\n;; and each 1 in a row represents a single unit of water.\n;; Each well has a corresponding bucket that can be used to extract water from it, \n;; and all buckets have the same capacity.\n;; Your task is to use the buckets to empty the wells.\n;; Output the number of times you need to lower the buckets.\n;; Example 1:\n;; >>> (max_fill (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1)\n;; 6\n;; Example 2:\n;; >>> (max_fill (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2)\n;; 5\n;; Example 3:\n;; >>> (max_fill (list (list 0 0 0) (list 0 0 0)) 5)\n;; 0\n;; Constraints:\n;; * all wells have the same length\n;; * 1 <= grid.length <= 10^2\n;; * 1 <= grid[:,1].length <= 10^2\n;; * grid[i][j] -> 0 | 1\n;; * 1 <= capacity <= 10\n(define (max_fill grid capacity)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_fill))\n    (check-within (candidate (list (list 0 0 1 0) (list 0 1 0 0) (list 1 1 1 1)) 1) 6 0.001)\n    (check-within (candidate (list (list 0 0 1 1) (list 0 0 0 0) (list 1 1 1 1) (list 0 1 1 1)) 2) 5 0.001)\n    (check-within (candidate (list (list 0 0 0) (list 0 0 0)) 5) 0 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 2) 4 0.001)\n    (check-within (candidate (list (list 1 1 1 1) (list 1 1 1 1)) 9) 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2074,7 +274,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; In this Kata, you have to sort an array of non-negative integers according to\n;; number of ones in their binary representation in ascending order.\n;; For similar number of ones, sort based on decimal value.\n;; It must be implemented like this:\n;; >>> (sort_array (list 1 5 2 3 4))\n;; (list 1 2 3 4 5)\n;; >>> (sort_array (list -2 -3 -4 -5 -6))\n;; (list -6 -5 -4 -3 -2)\n;; >>> (sort_array (list 1 0 2 3 4))\n;; (list 0 1 2 3 4)\n(define (sort_array arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list 1 5 2 3 4)) (list 1 2 4 3 5) 0.001)\n    (check-within (candidate (list -2 -3 -4 -5 -6)) (list -4 -2 -6 -5 -3) 0.001)\n    (check-within (candidate (list 1 0 2 3 4)) (list 0 1 2 4 3) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 2 5 77 4 5 3 5 7 2 3 4)) (list 2 2 4 4 3 3 5 5 5 7 77) 0.001)\n    (check-within (candidate (list 3 6 44 12 32 5)) (list 32 3 5 6 12 44) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n    (check-within (candidate (list 2 4 8 16 32)) (list 2 4 8 16 32) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2085,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> (concatenate (list ))\n;; \"\"\n;; >>> (concatenate (list \"a\" \"b\" \"c\"))\n;; \"abc\"\n(define (concatenate strings)\n",
+    "prompt": "#lang racket\n\n;; Given a string s and a natural number n, you have been tasked to implement \n;; a function that returns a list of all words from string s that contain exactly \n;; n consonants, in order these words appear in the string s.\n;; If the string s is empty then the function should return an empty list.\n;; Note: you may assume the input string contains only letters and spaces.\n;; Examples:\n;; >>> (select_words \"Mary had a little lamb\" 4)\n;; (list \"little\")\n;; >>> (select_words \"Mary had a little lamb\" 3)\n;; (list \"Mary\" \"lamb\")\n;; >>> (select_words \"simple white space\" 2)\n;; (list )\n;; >>> (select_words \"Hello world\" 4)\n;; (list \"world\")\n;; >>> (select_words \"Uncle sam\" 3)\n;; (list \"Uncle\")\n(define (select_words s n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate select_words))\n    (check-within (candidate \"Mary had a little lamb\" 4) (list \"little\") 0.001)\n    (check-within (candidate \"Mary had a little lamb\" 3) (list \"Mary\" \"lamb\") 0.001)\n    (check-within (candidate \"simple white space\" 2) (list ) 0.001)\n    (check-within (candidate \"Hello world\" 4) (list \"world\") 0.001)\n    (check-within (candidate \"Uncle sam\" 3) (list \"Uncle\") 0.001)\n    (check-within (candidate \"\" 4) (list ) 0.001)\n    (check-within (candidate \"a b c d e f\" 1) (list \"b\" \"c\" \"d\" \"f\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2100,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; >>> (list_sort (list \"aa\" \"a\" \"aaa\"))\n;; (list \"aa\")\n;; >>> (list_sort (list \"ab\" \"a\" \"aaa\" \"cd\"))\n;; (list \"ab\" \"cd\")\n(define (sorted_list_sum lst)\n",
+    "prompt": "#lang racket\n\n;; You are given a word. Your task is to find the closest vowel that stands between \n;; two consonants from the right side of the word (case sensitive).\n;; Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n;; find any vowel met the above condition. \n;; You may assume that the given string contains English letter only.\n;; Example:\n;; >>> (get_closest_vowel \"yogurt\")\n;; \"u\"\n;; >>> (get_closest_vowel \"FULL\")\n;; \"U\"\n;; >>> (get_closest_vowel \"quick\")\n;; \"\"\n;; >>> (get_closest_vowel \"ab\")\n;; \"\"\n(define (get_closest_vowel word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_closest_vowel))\n    (check-within (candidate \"yogurt\") \"u\" 0.001)\n    (check-within (candidate \"full\") \"u\" 0.001)\n    (check-within (candidate \"easy\") \"\" 0.001)\n    (check-within (candidate \"eAsy\") \"\" 0.001)\n    (check-within (candidate \"ali\") \"\" 0.001)\n    (check-within (candidate \"bad\") \"a\" 0.001)\n    (check-within (candidate \"most\") \"o\" 0.001)\n    (check-within (candidate \"ab\") \"\" 0.001)\n    (check-within (candidate \"ba\") \"\" 0.001)\n    (check-within (candidate \"quick\") \"\" 0.001)\n    (check-within (candidate \"anime\") \"i\" 0.001)\n    (check-within (candidate \"Asia\") \"\" 0.001)\n    (check-within (candidate \"Above\") \"o\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2115,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> (filter_by_substring (list ) \"a\")\n;; (list )\n;; >>> (filter_by_substring (list \"abc\" \"bacd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"bacd\" \"array\")\n(define (filter_by_substring strings substring)\n",
+    "prompt": "#lang racket\n\n;; You are given a list of two strings, both strings consist of open\n;; parentheses '(' or close parentheses ')' only.\n;; Your job is to check if it is possible to concatenate the two strings in\n;; some order, that the resulting string will be good.\n;; A string S is considered to be good if and only if all parentheses in S\n;; are balanced. For example: the string '(())()' is good, while the string\n;; '())' is not.\n;; Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n;; Examples:\n;; >>> (match_parens (list \"()(\" \")\"))\n;; \"Yes\"\n;; >>> (match_parens (list \")\" \")\"))\n;; \"No\"\n(define (match_parens lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate match_parens))\n    (check-within (candidate (list \"()(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \")\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(())\" \"())())\")) \"No\" 0.001)\n    (check-within (candidate (list \")())\" \"(()()(\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"(())))\" \"(()())((\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"()\" \"())\")) \"No\" 0.001)\n    (check-within (candidate (list \"(()(\" \"()))()\")) \"Yes\" 0.001)\n    (check-within (candidate (list \"((((\" \"((())\")) \"No\" 0.001)\n    (check-within (candidate (list \")(()\" \"(()(\")) \"No\" 0.001)\n    (check-within (candidate (list \")(\" \")(\")) \"No\" 0.001)\n    (check-within (candidate (list \"(\" \")\")) \"Yes\" 0.001)\n    (check-within (candidate (list \")\" \"(\")) \"Yes\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2130,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> (closest_integer \"10\")\n;; 10\n;; >>> (closest_integer \"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "prompt": "#lang racket\n\n;; Input are two strings a and b consisting only of 1s and 0s.\n;; Perform binary XOR on these inputs and return result also as a string.\n;; >>> (string_xor \"010\" \"110\")\n;; \"100\"\n(define (string_xor a b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_xor))\n    (check-within (candidate \"111000\" \"101010\") \"010010\" 0.001)\n    (check-within (candidate \"1\" \"1\") \"0\" 0.001)\n    (check-within (candidate \"0101\" \"0000\") \"0101\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2145,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> (vowels_count \"abcde\")\n;; 2\n;; >>> (vowels_count \"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers and a positive integer k, return a sorted list \n;; of length k with the maximum k numbers in arr.\n;; Example 1:\n;; >>> (maximum (list -3 -4 5) 3)\n;; (list -4 -3 5)\n;; Example 2:\n;; >>> (maximum (list 4 -4 4) 2)\n;; (list 4 4)\n;; Example 3:\n;; >>> (maximum (list -3 2 1 2 -1 -2 1) 1)\n;; (list 2)\n;; Note:\n;; 1. The length of the array will be in the range of [1, 1000].\n;; 2. The elements in the array will be in the range of [-1000, 1000].\n;; 3. 0 <= k <= len(arr)\n(define (maximum arr k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate (list -3 -4 5) 3) (list -4 -3 5) 0.001)\n    (check-within (candidate (list 4 -4 4) 2) (list 4 4) 0.001)\n    (check-within (candidate (list -3 2 1 2 -1 -2 1) 1) (list 2) 0.001)\n    (check-within (candidate (list 123 -123 20 0 1 2 -3) 3) (list 2 20 123) 0.001)\n    (check-within (candidate (list -123 20 0 1 2 -3) 4) (list 0 1 2 20) 0.001)\n    (check-within (candidate (list 5 15 0 3 -13 -8 0) 7) (list -13 -8 0 0 3 5 15) 0.001)\n    (check-within (candidate (list -1 0 2 5 3 -10) 2) (list 3 5) 0.001)\n    (check-within (candidate (list 1 0 5 -7) 1) (list 5) 0.001)\n    (check-within (candidate (list 4 -4) 2) (list -4 4) 0.001)\n    (check-within (candidate (list -10 10) 2) (list -10 10) 0.001)\n    (check-within (candidate (list 1 2 3 -23 243 -400 0) 0) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2160,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; >>> (find_max (list \"name\" \"of\" \"string\"))\n;; \"string\"\n;; >>> (find_max (list \"name\" \"enam\" \"game\"))\n;; \"enam\"\n;; >>> (find_max (list \"aaaaaaa\" \"bb\" \"cc\"))\n;; \"aaaaaaa\"\n(define (find_max words)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n;; Examples\n;; >>> (solution (list 5 8 7 1))\n;; 12\n;; >>> (solution (list 3 3 3 3 3))\n;; 9\n;; >>> (solution (list 30 13 24 321))\n;; 0\n(define (solution lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solution))\n    (check-within (candidate (list 5 8 7 1)) 12 0.001)\n    (check-within (candidate (list 3 3 3 3 3)) 9 0.001)\n    (check-within (candidate (list 30 13 24 321)) 0 0.001)\n    (check-within (candidate (list 5 9)) 5 0.001)\n    (check-within (candidate (list 2 4 8)) 0 0.001)\n    (check-within (candidate (list 30 13 23 32)) 23 0.001)\n    (check-within (candidate (list 3 13 2 9)) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2175,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n;; >>> (string_to_md5 \"Hello world\")\n;; \"3e25960a79dbc69b674cd4ec67a72c62\"\n(define (string_to_md5 text)\n",
+    "prompt": "#lang racket\n\n;; Given a non-empty array of integers arr and an integer k, return\n;; the sum of the elements with at most two digits from the first k elements of arr.\n;; Example:\n;; >>> (add_elements (list 111 21 3 4000 5 6 7 8 9) 4)\n;; 24\n;; Constraints:\n;; 1. 1 <= len(arr) <= 100\n;; 2. 1 <= k <= len(arr)\n(define (add_elements arr k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_elements))\n    (check-within (candidate (list 1 -2 -3 41 57 76 87 88 99) 3) -4 0.001)\n    (check-within (candidate (list 111 121 3 4000 5 6) 2) 0 0.001)\n    (check-within (candidate (list 11 21 3 90 5 6 7 8 9) 4) 125 0.001)\n    (check-within (candidate (list 111 21 3 4000 5 6 7 8 9) 4) 24 0.001)\n    (check-within (candidate (list 1) 1) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2190,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> (change_base 8 3)\n;; \"22\"\n;; >>> (change_base 8 2)\n;; \"1000\"\n;; >>> (change_base 7 2)\n;; \"111\"\n(define (change_base x base)\n",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n;; The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n;; as follows: start with any positive integer n. Then each term is obtained from the \n;; previous term as follows: if the previous term is even, the next term is one half of \n;; the previous term. If the previous term is odd, the next term is 3 times the previous\n;; term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n;; Note: \n;; 1. Collatz(1) is [1].\n;; 2. returned list sorted in increasing order.\n;; For example:\n;; get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n;; >>> (get_odd_collatz 5)\n;; (list 1 5)\n(define (get_odd_collatz n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_odd_collatz))\n    (check-within (candidate 14) (list 1 5 7 11 13 17) 0.001)\n    (check-within (candidate 5) (list 1 5) 0.001)\n    (check-within (candidate 12) (list 1 3 5) 0.001)\n    (check-within (candidate 1) (list 1) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2205,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; >>> (right_angle_triangle 3 4 5)\n;; #t\n;; >>> (right_angle_triangle 1 2 3)\n;; #f\n(define (right_angle_triangle a b c)\n",
+    "prompt": "#lang racket\n\n;; You have to write a function which validates a given date string and\n;; returns True if the date is valid otherwise False.\n;; The date is valid if all of the following rules are satisfied:\n;; 1. The date string is not empty.\n;; 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n;; 3. The months should not be less than 1 or higher than 12.\n;; 4. The date should be in the format: mm-dd-yyyy\n;; >>> (valid_date \"03-11-2000\")\n;; #t\n;; >>> (valid_date \"15-01-2012\")\n;; #f\n;; >>> (valid_date \"04-0-2040\")\n;; #f\n;; >>> (valid_date \"06-04-2020\")\n;; #t\n;; >>> (valid_date \"06/04/2020\")\n;; #f\n(define (valid_date date)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate valid_date))\n    (check-within (candidate \"03-11-2000\") #t 0.001)\n    (check-within (candidate \"15-01-2012\") #f 0.001)\n    (check-within (candidate \"04-0-2040\") #f 0.001)\n    (check-within (candidate \"06-04-2020\") #t 0.001)\n    (check-within (candidate \"01-01-2007\") #t 0.001)\n    (check-within (candidate \"03-32-2011\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"04-31-3000\") #f 0.001)\n    (check-within (candidate \"06-06-2005\") #t 0.001)\n    (check-within (candidate \"21-31-2000\") #f 0.001)\n    (check-within (candidate \"04-12-2003\") #t 0.001)\n    (check-within (candidate \"04122003\") #f 0.001)\n    (check-within (candidate \"20030412\") #f 0.001)\n    (check-within (candidate \"2003-04\") #f 0.001)\n    (check-within (candidate \"2003-04-12\") #f 0.001)\n    (check-within (candidate \"04-2003\") #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2220,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; >>> (grade_equation (list 4.0 3 1.7 2 3.5))\n;; (list \"A+\" \"B\" \"C-\" \"C\" \"A-\")\n(define (numerical_letter_grade grades)\n",
+    "prompt": "#lang racket\n\n;; Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n;; should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n;; alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n;; Examples\n;; >>> (split_words \"Hello world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"Hello,world!\")\n;; (list \"Hello\" \"world!\")\n;; >>> (split_words \"abcdef\")\n;; 3\n(define (split_words txt)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_words))\n    (check-within (candidate \"Hello world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello,world!\") (list \"Hello\" \"world!\") 0.001)\n    (check-within (candidate \"Hello world,!\") (list \"Hello\" \"world,!\") 0.001)\n    (check-within (candidate \"Hello,Hello,world !\") (list \"Hello,Hello,world\" \"!\") 0.001)\n    (check-within (candidate \"abcdef\") 3 0.001)\n    (check-within (candidate \"aaabb\") 2 0.001)\n    (check-within (candidate \"aaaBb\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2235,13 +435,328 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> (intersperse (list ) 4)\n;; (list )\n;; >>> (intersperse (list 1 2 3) 4)\n;; (list 1 4 2 4 3)\n(define (intersperse numbers delimeter)\n",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return whether or not they are sorted\n;; in ascending order. If list has more than 1 duplicate of the same\n;; number, return False. Assume no negative numbers and only integers.\n;; Examples\n;; >>> (is_sorted (list 5))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5))\n;; #f\n;; >>> (is_sorted (list 1 2 3 4 5 6))\n;; #t\n;; >>> (is_sorted (list 1 2 3 4 5 6 7))\n;; #t\n;; >>> (is_sorted (list 1 3 2 4 5 6 7))\n;; #f\n;; >>> (is_sorted (list 1 2 2 3 3 4))\n;; #t\n;; >>> (is_sorted (list 1 2 2 2 3 4))\n;; #f\n(define (is_sorted lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sorted))\n    (check-within (candidate (list 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7)) #t 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 7)) #f 0.001)\n    (check-within (candidate (list )) #t 0.001)\n    (check-within (candidate (list 1)) #t 0.001)\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 2 2 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 3 3 3 4)) #f 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given two intervals,\n;; where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n;; The given intervals are closed which means that the interval (start, end)\n;; includes both start and end.\n;; For each given interval, it is assumed that its start is less or equal its end.\n;; Your task is to determine whether the length of intersection of these two \n;; intervals is a prime number.\n;; Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n;; which its length is 1, which not a prime number.\n;; If the length of the intersection is a prime number, return \"YES\",\n;; otherwise, return \"NO\".\n;; If the two intervals don't intersect, return \"NO\".\n;; [input/output] samples:\n;; >>> (intersection (list 1 2) (list 2 3))\n;; \"NO\"\n;; >>> (intersection (list -1 1) (list 0 4))\n;; \"NO\"\n;; >>> (intersection (list -3 -1) (list -5 5))\n;; \"YES\"\n(define (intersection interval1 interval2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection))\n    (check-within (candidate (list 1 2) (list 2 3)) \"NO\" 0.001)\n    (check-within (candidate (list -1 1) (list 0 4)) \"NO\" 0.001)\n    (check-within (candidate (list -3 -1) (list -5 5)) \"YES\" 0.001)\n    (check-within (candidate (list -2 2) (list -4 0)) \"YES\" 0.001)\n    (check-within (candidate (list -11 2) (list -1 -1)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 3 5)) \"NO\" 0.001)\n    (check-within (candidate (list 1 2) (list 1 2)) \"NO\" 0.001)\n    (check-within (candidate (list -2 -2) (list -3 -2)) \"NO\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given an array arr of integers and you need to return\n;; sum of magnitudes of integers multiplied by product of all signs\n;; of each number in the array, represented by 1, -1 or 0.\n;; Note: return None for empty arr.\n;; Example:\n;; >>> (prod_signs (list 1 2 2 -4))\n;; 9\n;; >>> (prod_signs (list 0 1))\n;; 0\n;; >>> (prod_signs (list ))\n;; #f\n(define (prod_signs arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prod_signs))\n    (check-within (candidate (list 1 2 2 -4)) -9 0.001)\n    (check-within (candidate (list 0 1)) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 -1 1)) -10 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 2 4 1 2 -1 -1 9)) 20 0.001)\n    (check-within (candidate (list -1 1 -1 1)) 4 0.001)\n    (check-within (candidate (list -1 1 1 1)) -4 0.001)\n    (check-within (candidate (list -1 1 1 0)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n;; each cell of the grid contains a value. Every integer in the range [1, N * N]\n;; inclusive appears exactly once on the cells of the grid.\n;; You have to find the minimum path of length k in the grid. You can start\n;; from any cell, and in each step you can move to any of the neighbor cells,\n;; in other words, you can go to cells which share an edge with you current\n;; cell.\n;; Please note that a path of length k means visiting exactly k cells (not\n;; necessarily distinct).\n;; You CANNOT go off the grid.\n;; A path A (of length k) is considered less than a path B (of length k) if\n;; after making the ordered lists of the values on the cells that A and B go\n;; through (let's call them lst_A and lst_B), lst_A is lexicographically less\n;; than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n;; such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n;; lst_A[j] = lst_B[j].\n;; It is guaranteed that the answer is unique.\n;; Return an ordered list of the values on the cells that the minimum path go through.\n;; Examples:    \n;; >>> (minPath (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3)\n;; (list 1 2 1)\n;; >>> (minPath (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1)\n;; (list 1)\n(define (minPath grid k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minPath))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9)) 3) (list 1 2 1) 0.001)\n    (check-within (candidate (list (list 5 9 3) (list 4 1 6) (list 7 8 2)) 1) (list 1) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12) (list 13 14 15 16)) 4) (list 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 6 4 13 10) (list 5 7 12 1) (list 3 16 11 15) (list 8 14 9 2)) 7) (list 1 10 1 10 1 10 1) 0.001)\n    (check-within (candidate (list (list 8 14 9 2) (list 6 4 13 15) (list 5 7 1 12) (list 3 10 11 16)) 5) (list 1 7 1 7 1) 0.001)\n    (check-within (candidate (list (list 11 8 7 2) (list 5 16 14 4) (list 9 3 15 6) (list 12 13 10 1)) 9) (list 1 6 1 6 1 6 1 6 1) 0.001)\n    (check-within (candidate (list (list 12 13 10 1) (list 9 3 15 6) (list 5 16 14 4) (list 11 8 7 2)) 12) (list 1 6 1 6 1 6 1 6 1 6 1 6) 0.001)\n    (check-within (candidate (list (list 2 7 4) (list 3 1 5) (list 6 8 9)) 8) (list 1 3 1 3 1 3 1 3) 0.001)\n    (check-within (candidate (list (list 6 1 5) (list 3 8 9) (list 2 7 4)) 8) (list 1 5 1 5 1 5 1 5) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4)) 10) (list 1 2 1 2 1 2 1 2 1 2) 0.001)\n    (check-within (candidate (list (list 1 3) (list 3 2)) 10) (list 1 3 1 3 1 3 1 3 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Out of list of strings, return the longest one. Return the first one in case of multiple\n;; strings of the same length. Return None in case the input list is empty.\n;; >>> (longest (list ))\n;; #f\n;; >>> (longest (list \"a\" \"b\" \"c\"))\n;; \"a\"\n;; >>> (longest (list \"a\" \"bb\" \"ccc\"))\n;; \"ccc\"\n(define (longest strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate longest))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"x\" 0.001)\n    (check-within (candidate (list \"x\" \"yyy\" \"zzzz\" \"www\" \"kkkk\" \"abc\")) \"zzzz\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n;; the last couple centuries. However, what people don't know is Tribonacci sequence.\n;; Tribonacci sequence is defined by the recurrence:\n;; tri(1) = 3\n;; tri(n) = 1 + n / 2, if n is even.\n;; tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n;; For example:\n;; tri(2) = 1 + (2 / 2) = 2\n;; tri(4) = 3\n;; tri(3) = tri(2) + tri(1) + tri(4)\n;; = 2 + 3 + 3 = 8 \n;; You are given a non-negative integer number n, you have to a return a list of the \n;; first n + 1 numbers of the Tribonacci sequence.\n;; Examples:\n;; >>> (tri 3)\n;; (list 1 3 2 8)\n(define (tri n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tri))\n    (check-within (candidate 3) (list 1 3 2 8) 0.001)\n    (check-within (candidate 4) (list 1 3 2 8 3) 0.001)\n    (check-within (candidate 5) (list 1 3 2 8 3 15) 0.001)\n    (check-within (candidate 6) (list 1 3 2 8 3 15 4) 0.001)\n    (check-within (candidate 7) (list 1 3 2 8 3 15 4 24) 0.001)\n    (check-within (candidate 8) (list 1 3 2 8 3 15 4 24 5) 0.001)\n    (check-within (candidate 9) (list 1 3 2 8 3 15 4 24 5 35) 0.001)\n    (check-within (candidate 20) (list 1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11) 0.001)\n    (check-within (candidate 0) (list 1) 0.001)\n    (check-within (candidate 1) (list 1 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the product of the odd digits.\n;; Return 0 if all digits are even.\n;; For example:\n;; >>> (digits 1)\n;; 1\n;; >>> (digits 4)\n;; 0\n;; >>> (digits 235)\n;; 15\n(define (digits n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digits))\n    (check-within (candidate 5) 5 0.001)\n    (check-within (candidate 54) 5 0.001)\n    (check-within (candidate 120) 1 0.001)\n    (check-within (candidate 5014) 5 0.001)\n    (check-within (candidate 98765) 315 0.001)\n    (check-within (candidate 5576543) 2625 0.001)\n    (check-within (candidate 2468) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a string as input which contains only square brackets.\n;; The function should return True if and only if there is a valid subsequence of brackets \n;; where at least one bracket in the subsequence is nested.\n;; >>> (is_nested \"[[]]\")\n;; #t\n;; >>> (is_nested \"[]]]]]]][[[[[]\")\n;; #f\n;; >>> (is_nested \"[][]\")\n;; #f\n;; >>> (is_nested \"[]\")\n;; #f\n;; >>> (is_nested \"[[][]]\")\n;; #t\n;; >>> (is_nested \"[[]][[\")\n;; #t\n(define (is_nested string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nested))\n    (check-within (candidate \"[[]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]][[[[[]\") #f 0.001)\n    (check-within (candidate \"[][]\") #f 0.001)\n    (check-within (candidate \"[]\") #f 0.001)\n    (check-within (candidate \"[[[[]]]]\") #t 0.001)\n    (check-within (candidate \"[]]]]]]]]]]\") #f 0.001)\n    (check-within (candidate \"[][][[]]\") #t 0.001)\n    (check-within (candidate \"[[]\") #f 0.001)\n    (check-within (candidate \"[]]\") #f 0.001)\n    (check-within (candidate \"[[]][[\") #t 0.001)\n    (check-within (candidate \"[[][]]\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"[[[[[[[[\") #f 0.001)\n    (check-within (candidate \"]]]]]]]]\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of numbers.\n;; You need to return the sum of squared numbers in the given list,\n;; round each element in the list to the upper int(Ceiling) first.\n;; Examples:\n;; >>> (lst (list 1.0 2.0 3.0))\n;; 14\n;; >>> (lst (list 1.0 4.0 9.0))\n;; 98\n;; >>> (lst (list 1.0 3.0 5.0 7.0))\n;; 84\n;; >>> (lst (list 1.4 4.2 0.0))\n;; 29\n;; >>> (lst (list -2.4 1.0 1.0))\n;; 6\n(define (sum_squares lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0)) 14 0.001)\n    (check-within (candidate (list 1.0 3.0 5.0 7.0)) 84 0.001)\n    (check-within (candidate (list 1.4 4.2 0.0)) 29 0.001)\n    (check-within (candidate (list -2.4 1.0 1.0)) 6 0.001)\n    (check-within (candidate (list 100.0 1.0 15.0 2.0)) 10230 0.001)\n    (check-within (candidate (list 10000.0 10000.0)) 200000000 0.001)\n    (check-within (candidate (list -1.4 4.6 6.3)) 75 0.001)\n    (check-within (candidate (list -1.4 17.9 18.9 19.9)) 1086 0.001)\n    (check-within (candidate (list 0.0)) 0 0.001)\n    (check-within (candidate (list -1.0)) 1 0.001)\n    (check-within (candidate (list -1.0 1.0 0.0)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns True if the last character\n;; of a given string is an alphabetical character and is not\n;; a part of a word, and False otherwise.\n;; Note: \"word\" is a group of characters separated by space.\n;; Examples:\n;; >>> (check_if_last_char_is_a_letter \"apple pie\")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"apple pi e\")\n;; #t\n;; >>> (check_if_last_char_is_a_letter \"apple pi e \")\n;; #f\n;; >>> (check_if_last_char_is_a_letter \"\")\n;; #f\n(define (check_if_last_char_is_a_letter txt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_if_last_char_is_a_letter))\n    (check-within (candidate \"apple\") #f 0.001)\n    (check-within (candidate \"apple pi e\") #t 0.001)\n    (check-within (candidate \"eeeee\") #f 0.001)\n    (check-within (candidate \"A\") #t 0.001)\n    (check-within (candidate \"Pumpkin pie \") #f 0.001)\n    (check-within (candidate \"Pumpkin pie 1\") #f 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"eeeee e \") #f 0.001)\n    (check-within (candidate \"apple pie\") #f 0.001)\n    (check-within (candidate \"apple pi e \") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which returns the largest index of an element which\n;; is not greater than or equal to the element immediately preceding it. If\n;; no such element exists then return -1. The given array will not contain\n;; duplicate values.\n;; Examples:\n;; >>> (can_arrange (list 1 2 4 3 5))\n;; 3\n;; >>> (can_arrange (list 1 2 3))\n;; -1\n(define (can_arrange arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate can_arrange))\n    (check-within (candidate (list 1 2 4 3 5)) 3 0.001)\n    (check-within (candidate (list 1 2 4 5)) -1 0.001)\n    (check-within (candidate (list 1 4 2 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 4 8 5 7 3)) 4 0.001)\n    (check-within (candidate (list )) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that returns a tuple (a, b), where 'a' is\n;; the largest of negative integers, and 'b' is the smallest\n;; of positive integers in a list.\n;; If there is no negative or positive integers, return them as None.\n;; Examples:\n;; >>> (largest_smallest_integers (list 2 4 1 3 5 7))\n;; (list #f 1)\n;; >>> (largest_smallest_integers (list ))\n;; (list #f #f)\n;; >>> (largest_smallest_integers (list 0))\n;; (list #f #f)\n(define (largest_smallest_integers lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_smallest_integers))\n    (check-within (candidate (list 2 4 1 3 5 7)) (list #f 1) 0.001)\n    (check-within (candidate (list 2 4 1 3 5 7 0)) (list #f 1) 0.001)\n    (check-within (candidate (list 1 3 2 4 5 6 -2)) (list -2 1) 0.001)\n    (check-within (candidate (list 4 5 3 6 2 7 -7)) (list -7 2) 0.001)\n    (check-within (candidate (list 7 3 8 4 9 2 5 -9)) (list -9 2) 0.001)\n    (check-within (candidate (list )) (list #f #f) 0.001)\n    (check-within (candidate (list 0)) (list #f #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6)) (list -1 #f) 0.001)\n    (check-within (candidate (list -1 -3 -5 -6 0)) (list -1 #f) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 1)) (list -3 1) 0.001)\n    (check-within (candidate (list -6 -4 -4 -3 -100 1)) (list -3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes integers, floats, or strings representing\n;; real numbers, and returns the larger variable in its given variable type.\n;; Return None if the values are equal.\n;; Note: If a real number is represented as a string, the floating point might be . or ,\n;; >>> (compare_one 1 2.5)\n;; 2.5\n;; >>> (compare_one 1 \"2,3\")\n;; \"2,3\"\n;; >>> (compare_one \"5,1\" \"6\")\n;; \"6\"\n;; >>> (compare_one \"1\" 1)\n;; #f\n(define (compare_one a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare_one))\n    (check-within (candidate 1 2) 2 0.001)\n    (check-within (candidate 1 2.5) 2.5 0.001)\n    (check-within (candidate 2 3) 3 0.001)\n    (check-within (candidate 5 6) 6 0.001)\n    (check-within (candidate 1 \"2,3\") \"2,3\" 0.001)\n    (check-within (candidate \"5,1\" \"6\") \"6\" 0.001)\n    (check-within (candidate \"1\" \"2\") \"2\" 0.001)\n    (check-within (candidate \"1\" 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n;; Example\n;; >>> (is_equal_to_sum_even 4)\n;; #f\n;; >>> (is_equal_to_sum_even 6)\n;; #f\n;; >>> (is_equal_to_sum_even 8)\n;; #t\n(define (is_equal_to_sum_even n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_equal_to_sum_even))\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 11) #f 0.001)\n    (check-within (candidate 12) #t 0.001)\n    (check-within (candidate 13) #f 0.001)\n    (check-within (candidate 16) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Brazilian factorial is defined as:\n;; brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n;; where n > 0\n;; For example:\n;; >>> (special_factorial 4)\n;; 288\n;; The function will receive an integer as input and should return the special\n;; factorial of this integer.\n(define (special_factorial n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate special_factorial))\n    (check-within (candidate 4) 288 0.001)\n    (check-within (candidate 5) 34560 0.001)\n    (check-within (candidate 7) 125411328000 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a greatest common divisor of two integers a and b\n;; >>> (greatest_common_divisor 3 5)\n;; 1\n;; >>> (greatest_common_divisor 25 15)\n;; 5\n(define (greatest_common_divisor a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate greatest_common_divisor))\n    (check-within (candidate 3 7) 1 0.001)\n    (check-within (candidate 10 15) 5 0.001)\n    (check-within (candidate 49 14) 7 0.001)\n    (check-within (candidate 144 60) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string text, replace all spaces in it with underscores, \n;; and if a string has more than 2 consecutive spaces, \n;; then replace all consecutive spaces with - \n;; >>> (fix_spaces \" Example\")\n;; \"Example\"\n;; >>> (fix_spaces \" Example 1\")\n;; \"Example_1\"\n;; >>> (fix_spaces \" Example 2\")\n;; \"_Example_2\"\n;; >>> (fix_spaces \" Example 3\")\n;; \"_Example-3\"\n(define (fix_spaces text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fix_spaces))\n    (check-within (candidate \"Example\") \"Example\" 0.001)\n    (check-within (candidate \"Mudasir Hanif \") \"Mudasir_Hanif_\" 0.001)\n    (check-within (candidate \"Yellow Yellow  Dirty  Fellow\") \"Yellow_Yellow__Dirty__Fellow\" 0.001)\n    (check-within (candidate \"Exa   mple\") \"Exa-mple\" 0.001)\n    (check-within (candidate \"   Exa 1 2 2 mple\") \"-Exa_1_2_2_mple\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function which takes a string representing a file's name, and returns\n;; 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n;; A file's name is considered to be valid if and only if all the following conditions \n;; are met:\n;; - There should not be more than three digits ('0'-'9') in the file's name.\n;; - The file's name contains exactly one dot '.'\n;; - The substring before the dot should not be empty, and it starts with a letter from \n;; the latin alphapet ('a'-'z' and 'A'-'Z').\n;; - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n;; Examples:\n;; >>> (file_name_check \"example.txt\")\n;; \"Yes\"\n;; >>> (file_name_check \"1example.dll\")\n;; \"No\"\n(define (file_name_check file_name)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate file_name_check))\n    (check-within (candidate \"example.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"1example.dll\") \"No\" 0.001)\n    (check-within (candidate \"s1sdf3.asd\") \"No\" 0.001)\n    (check-within (candidate \"K.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"MY16FILE3.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"His12FILE94.exe\") \"No\" 0.001)\n    (check-within (candidate \"_Y.txt\") \"No\" 0.001)\n    (check-within (candidate \"?aREYA.exe\") \"No\" 0.001)\n    (check-within (candidate \"/this_is_valid.dll\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.wow\") \"No\" 0.001)\n    (check-within (candidate \"this_is_valid.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"this_is_valid.txtexe\") \"No\" 0.001)\n    (check-within (candidate \"#this2_i4s_5valid.ten\") \"No\" 0.001)\n    (check-within (candidate \"@this1_is6_valid.exe\") \"No\" 0.001)\n    (check-within (candidate \"this_is_12valid.6exe4.txt\") \"No\" 0.001)\n    (check-within (candidate \"all.exe.txt\") \"No\" 0.001)\n    (check-within (candidate \"I563_No.exe\") \"Yes\" 0.001)\n    (check-within (candidate \"Is3youfault.txt\") \"Yes\" 0.001)\n    (check-within (candidate \"no_one#knows.dll\") \"Yes\" 0.001)\n    (check-within (candidate \"1I563_Yes3.exe\") \"No\" 0.001)\n    (check-within (candidate \"I563_Yes3.txtt\") \"No\" 0.001)\n    (check-within (candidate \"final..txt\") \"No\" 0.001)\n    (check-within (candidate \"final132\") \"No\" 0.001)\n    (check-within (candidate \"_f4indsartal132.\") \"No\" 0.001)\n    (check-within (candidate \".txt\") \"No\" 0.001)\n    (check-within (candidate \"s.\") \"No\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"\n;; This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n;; multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n;; change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n;; Examples:\n;; >>> lst\n;; (list 1 2 3)\n;; >>> lst\n;; (list )\n;; >>> lst\n;; (list -1 -5 2 -1 -5)\n(define (sum_squares lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_squares))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 1 4 9)) 14 0.001)\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 1 1 1 1 1 1 1 1 1)) 9 0.001)\n    (check-within (candidate (list -1 -1 -1 -1 -1 -1 -1 -1 -1)) -3 0.001)\n    (check-within (candidate (list 0)) 0 0.001)\n    (check-within (candidate (list -1 -5 2 -1 -5)) -126 0.001)\n    (check-within (candidate (list -56 -99 1 0 -2)) 3030 0.001)\n    (check-within (candidate (list -1 0 0 0 0 0 0 0 -1)) 0 0.001)\n    (check-within (candidate (list -16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37)) -14196 0.001)\n    (check-within (candidate (list -1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10)) -1448 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string representing a sentence,\n;; the sentence contains some words separated by a space,\n;; and you have to return a string that contains the words from the original sentence,\n;; whose lengths are prime numbers,\n;; the order of the words in the new string should be the same as the original one.\n;; Example 1:\n;; >>> (words_in_sentence \"This is a test\")\n;; \"is\"\n;; Example 2:\n;; >>> (words_in_sentence \"lets go for swimming\")\n;; \"go for\"\n;; Constraints:\n;; * 1 <= len(sentence) <= 100\n;; * sentence contains only letters\n(define (words_in_sentence sentence)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate words_in_sentence))\n    (check-within (candidate \"This is a test\") \"is\" 0.001)\n    (check-within (candidate \"lets go for swimming\") \"go for\" 0.001)\n    (check-within (candidate \"there is no place available here\") \"there is no place\" 0.001)\n    (check-within (candidate \"Hi I am Hussein\") \"Hi am Hussein\" 0.001)\n    (check-within (candidate \"go for it\") \"go for it\" 0.001)\n    (check-within (candidate \"here\") \"\" 0.001)\n    (check-within (candidate \"here is\") \"is\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to implement a function that will simplify the expression\n;; x * n. The function returns True if x * n evaluates to a whole number and False\n;; otherwise. Both x and n, are string representation of a fraction, and have the following format,\n;; <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n;; You can assume that x, and n are valid fractions, and do not have zero as denominator.\n;; >>> (simplify \"1/5\" \"5/1\")\n;; #t\n;; >>> (simplify \"1/6\" \"2/1\")\n;; #f\n;; >>> (simplify \"7/10\" \"10/2\")\n;; #f\n(define (simplify x n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate simplify))\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/6\" \"2/1\") #f 0.001)\n    (check-within (candidate \"5/1\" \"3/1\") #t 0.001)\n    (check-within (candidate \"7/10\" \"10/2\") #f 0.001)\n    (check-within (candidate \"2/10\" \"50/10\") #t 0.001)\n    (check-within (candidate \"7/2\" \"4/2\") #t 0.001)\n    (check-within (candidate \"11/6\" \"6/1\") #t 0.001)\n    (check-within (candidate \"2/3\" \"5/2\") #f 0.001)\n    (check-within (candidate \"5/2\" \"3/5\") #f 0.001)\n    (check-within (candidate \"2/4\" \"8/4\") #t 0.001)\n    (check-within (candidate \"2/4\" \"4/2\") #t 0.001)\n    (check-within (candidate \"1/5\" \"5/1\") #t 0.001)\n    (check-within (candidate \"1/5\" \"1/5\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which sorts the given list of integers\n;; in ascending order according to the sum of their digits.\n;; Note: if there are several items with similar sum of their digits,\n;; order them based on their index in original list.\n;; For example:\n;; >>> (order_by_points (list 1 11 -1 -11 -12))\n;; (list -1 -11 1 -12 11)\n;; >>> (order_by_points (list ))\n;; (list )\n(define (order_by_points nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate order_by_points))\n    (check-within (candidate (list 1 11 -1 -11 -12)) (list -1 -11 1 -12 11) 0.001)\n    (check-within (candidate (list 1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46)) (list 0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 -11 -32 43 54 -98 2 -3)) (list -3 -32 -98 -11 1 2 43 54) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11)) (list 1 10 2 11 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 0 6 6 -76 -21 23 4)) (list -76 -21 0 4 23 6 6) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2254,7 +769,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function that takes an array of numbers as input and returns \n;; the number of elements in the array that are greater than 10 and both \n;; first and last digits of a number are odd (1, 3, 5, 7, 9).\n;; For example:\n;; >>> (specialFilter (list 15 -73 14 -15))\n;; 1\n;; >>> (specialFilter (list 33 -2 -3 45 21 109))\n;; 2\n(define (specialFilter nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate specialFilter))\n    (check-within (candidate (list 5 -2 1 -5)) 0 0.001)\n    (check-within (candidate (list 15 -73 14 -15)) 1 0.001)\n    (check-within (candidate (list 33 -2 -3 45 21 109)) 2 0.001)\n    (check-within (candidate (list 43 -12 93 125 121 109)) 4 0.001)\n    (check-within (candidate (list 71 -2 -33 75 21 19)) 3 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list )) 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2265,13 +780,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> (sum_to_n 30)\n;; 465\n;; >>> (sum_to_n 100)\n;; 5050\n;; >>> (sum_to_n 5)\n;; 15\n;; >>> (sum_to_n 10)\n;; 55\n;; >>> (sum_to_n 1)\n;; 1\n(define (sum_to_n n)\n",
+    "prompt": "#lang racket\n\n;; You are given a positive integer n. You have to create an integer array a of length n.\n;; For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n;; Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n;; and a[i] + a[j] + a[k] is a multiple of 3.\n;; Example :\n;; >>> (get_max_triples 5)\n;; 1\n;; Explanation: \n;; a = [1, 3, 7, 13, 21]\n;; The only valid triple is (1, 7, 13).\n(define (get_max_triples n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_triples))\n    (check-within (candidate 5) 1 0.001)\n    (check-within (candidate 6) 4 0.001)\n    (check-within (candidate 10) 36 0.001)\n    (check-within (candidate 100) 53361 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2280,13 +795,253 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> (remove_duplicates (list 1 2 3 2 4))\n;; (list 1 3 4)\n(define (remove_duplicates numbers)\n",
+    "prompt": "#lang racket\n\n;; There are eight planets in our solar system: the closerst to the Sun \n;; is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n;; Uranus, Neptune.\n;; Write a function that takes two planet names as strings planet1 and planet2. \n;; The function should return a tuple containing all planets whose orbits are \n;; located between the orbit of planet1 and the orbit of planet2, sorted by \n;; the proximity to the sun. \n;; The function should return an empty tuple if planet1 or planet2\n;; are not correct planet names. \n;; Examples\n;; >>> (bf \"Jupiter\" \"Neptune\")\n;; (list \"Saturn\" \"Uranus\")\n;; >>> (bf \"Earth\" \"Mercury\")\n;; \"Venus\"\n;; >>> (bf \"Mercury\" \"Uranus\")\n;; (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\")\n(define (bf planet1 planet2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bf))\n    (check-within (candidate \"Jupiter\" \"Neptune\") (list \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Mercury\") (list \"Venus\") 0.001)\n    (check-within (candidate \"Mercury\" \"Uranus\") (list \"Venus\" \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\") 0.001)\n    (check-within (candidate \"Neptune\" \"Venus\") (list \"Earth\" \"Mars\" \"Jupiter\" \"Saturn\" \"Uranus\") 0.001)\n    (check-within (candidate \"Earth\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Mars\" \"Earth\") (list ) 0.001)\n    (check-within (candidate \"Jupiter\" \"Makemake\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings as a parameter,\n;; deletes the strings that have odd lengths from it,\n;; and returns the resulted list with a sorted order,\n;; The list is always a list of strings and never an array of numbers,\n;; and it may contain duplicates.\n;; The order of the list should be ascending by length of each word, and you\n;; should return the list sorted by that rule.\n;; If two words have the same length, sort the list alphabetically.\n;; The function should return a list of strings in sorted order.\n;; You may assume that all words will have the same length.\n;; For example:\n;; >>> (list_sort (list \"aa\" \"a\" \"aaa\"))\n;; (list \"aa\")\n;; >>> (list_sort (list \"ab\" \"a\" \"aaa\" \"cd\"))\n;; (list \"ab\" \"cd\")\n(define (sorted_list_sum lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sorted_list_sum))\n    (check-within (candidate (list \"aa\" \"a\" \"aaa\")) (list \"aa\") 0.001)\n    (check-within (candidate (list \"school\" \"AI\" \"asdf\" \"b\")) (list \"AI\" \"asdf\" \"school\") 0.001)\n    (check-within (candidate (list \"d\" \"b\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"d\" \"dcba\" \"abcd\" \"a\")) (list \"abcd\" \"dcba\") 0.001)\n    (check-within (candidate (list \"AI\" \"ai\" \"au\")) (list \"AI\" \"ai\" \"au\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"b\" \"c\" \"c\" \"a\")) (list ) 0.001)\n    (check-within (candidate (list \"aaaa\" \"bbbb\" \"dd\" \"cc\")) (list \"cc\" \"dd\" \"aaaa\" \"bbbb\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of all prefixes from shortest to longest of the input string\n;; >>> (all_prefixes \"abc\")\n;; (list \"a\" \"ab\" \"abc\")\n(define (all_prefixes string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_prefixes))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"asdfgh\") (list \"a\" \"as\" \"asd\" \"asdf\" \"asdfg\" \"asdfgh\") 0.001)\n    (check-within (candidate \"WWW\") (list \"W\" \"WW\" \"WWW\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; A simple program which should return the value of x if n is \n;; a prime number and should return the value of y otherwise.\n;; Examples:\n;; >>> (x_or_y 7 34 12)\n;; 34\n;; >>> (x_or_y 15 8 5)\n;; 5\n(define (x_or_y n x y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate x_or_y))\n    (check-within (candidate 7 34 12) 34 0.001)\n    (check-within (candidate 15 8 5) 5 0.001)\n    (check-within (candidate 3 33 5212) 33 0.001)\n    (check-within (candidate 1259 3 52) 3 0.001)\n    (check-within (candidate 7919 -1 12) -1 0.001)\n    (check-within (candidate 3609 1245 583) 583 0.001)\n    (check-within (candidate 91 56 129) 129 0.001)\n    (check-within (candidate 6 34 1234) 1234 0.001)\n    (check-within (candidate 1 2 0) 0 0.001)\n    (check-within (candidate 2 2 0) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of numbers, return the sum of squares of the numbers\n;; in the list that are odd. Ignore numbers that are negative or not integers.\n;; >>> (double_the_difference (list 1 3 2 0))\n;; 10\n;; >>> (double_the_difference (list -1 -2 0))\n;; 0\n;; >>> (double_the_difference (list 9 -2))\n;; 81\n;; >>> (double_the_difference (list 0))\n;; 0\n;; If the input list is empty, return 0.\n(define (double_the_difference lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate double_the_difference))\n    (check-within (candidate (list )) 0 0.001)\n    (check-within (candidate (list 5.0 4.0)) 25 0.001)\n    (check-within (candidate (list 0.1 0.2 0.3)) 0 0.001)\n    (check-within (candidate (list -10.0 -20.0 -30.0)) 0 0.001)\n    (check-within (candidate (list -1.0 -2.0 8.0)) 0 0.001)\n    (check-within (candidate (list 0.2 3.0 5.0)) 34 0.001)\n    (check-within (candidate (list -9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0)) 165 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; I think we all remember that feeling when the result of some long-awaited\n;; event is finally known. The feelings and thoughts you have at that moment are\n;; definitely worth noting down and comparing.\n;; Your task is to determine if a person correctly guessed the results of a number of matches.\n;; You are given two arrays of scores and guesses of equal length, where each index shows a match. \n;; Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n;; the value is 0, and if not, the value is the absolute difference between the guess and the score.\n;; example:\n;; >>> (compare (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2))\n;; (list 0 0 0 0 3 3)\n;; >>> (compare (list 0 5 0 0 0 4) (list 4 1 1 0 0 -2))\n;; (list 4 4 1 0 0 6)\n(define (compare game guess)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate compare))\n    (check-within (candidate (list 1 2 3 4 5 1) (list 1 2 3 4 2 -2)) (list 0 0 0 0 3 3) 0.001)\n    (check-within (candidate (list 0 0 0 0 0 0) (list 0 0 0 0 0 0)) (list 0 0 0 0 0 0) 0.001)\n    (check-within (candidate (list 1 2 3) (list -1 -2 -3)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 1 2 3 5) (list -1 2 3 4)) (list 2 0 0 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given the name of a class (a string) and a list of extensions.\n;; The extensions are to be used to load additional classes to the class. The\n;; strength of the extension is as follows: Let CAP be the number of the uppercase\n;; letters in the extension's name, and let SM be the number of lowercase letters \n;; in the extension's name, the strength is given by the fraction CAP - SM. \n;; You should find the strongest extension and return a string in this \n;; format: ClassName.StrongestExtensionName.\n;; If there are two or more extensions with the same strength, you should\n;; choose the one that comes first in the list.\n;; For example, if you are given \"Slices\" as the class and a list of the\n;; extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n;; return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n;; (its strength is -1).\n;; Example:\n;; >>> (Strongest_Extension \"my_class\" (list \"AA\" \"Be\" \"CC\"))\n;; \"my_class.AA\"\n(define (Strongest_Extension class_name extensions)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Strongest_Extension))\n    (check-within (candidate \"Watashi\" (list \"tEN\" \"niNE\" \"eIGHt8OKe\")) \"Watashi.eIGHt8OKe\" 0.001)\n    (check-within (candidate \"Boku123\" (list \"nani\" \"NazeDa\" \"YEs.WeCaNe\" \"32145tggg\")) \"Boku123.YEs.WeCaNe\" 0.001)\n    (check-within (candidate \"__YESIMHERE\" (list \"t\" \"eMptY\" \"nothing\" \"zeR00\" \"NuLl__\" \"123NoooneB321\")) \"__YESIMHERE.NuLl__\" 0.001)\n    (check-within (candidate \"K\" (list \"Ta\" \"TAR\" \"t234An\" \"cosSo\")) \"K.TAR\" 0.001)\n    (check-within (candidate \"__HAHA\" (list \"Tab\" \"123\" \"781345\" \"-_-\")) \"__HAHA.123\" 0.001)\n    (check-within (candidate \"YameRore\" (list \"HhAas\" \"okIWILL123\" \"WorkOut\" \"Fails\" \"-_-\")) \"YameRore.okIWILL123\" 0.001)\n    (check-within (candidate \"finNNalLLly\" (list \"Die\" \"NowW\" \"Wow\" \"WoW\")) \"finNNalLLly.WoW\" 0.001)\n    (check-within (candidate \"_\" (list \"Bb\" \"91245\")) \"_.Bb\" 0.001)\n    (check-within (candidate \"Sp\" (list \"671235\" \"Bb\")) \"Sp.671235\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n;; >>> (cycpattern_check \"abcd\" \"abd\")\n;; #f\n;; >>> (cycpattern_check \"hello\" \"ell\")\n;; #t\n;; >>> (cycpattern_check \"whassup\" \"psus\")\n;; #f\n;; >>> (cycpattern_check \"abab\" \"baa\")\n;; #t\n;; >>> (cycpattern_check \"efef\" \"eeff\")\n;; #f\n;; >>> (cycpattern_check \"himenss\" \"simen\")\n;; #t\n(define (cycpattern_check a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cycpattern_check))\n    (check-within (candidate \"xyzw\" \"xyw\") #f 0.001)\n    (check-within (candidate \"yello\" \"ell\") #t 0.001)\n    (check-within (candidate \"whattup\" \"ptut\") #f 0.001)\n    (check-within (candidate \"efef\" \"fee\") #t 0.001)\n    (check-within (candidate \"abab\" \"aabb\") #f 0.001)\n    (check-within (candidate \"winemtt\" \"tinem\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an integer. return a tuple that has the number of even and odd digits respectively.\n;; Example:\n;; >>> (even_odd_count -12)\n;; (list 1 1)\n;; >>> (even_odd_count 123)\n;; (list 1 2)\n(define (even_odd_count num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_odd_count))\n    (check-within (candidate 7) (list 0 1) 0.001)\n    (check-within (candidate -78) (list 1 1) 0.001)\n    (check-within (candidate 3452) (list 2 2) 0.001)\n    (check-within (candidate 346211) (list 3 3) 0.001)\n    (check-within (candidate -345821) (list 3 3) 0.001)\n    (check-within (candidate -2) (list 1 0) 0.001)\n    (check-within (candidate -45347) (list 2 3) 0.001)\n    (check-within (candidate 0) (list 1 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer, obtain its roman numeral equivalent as a string,\n;; and return it in lowercase.\n;; Restrictions: 1 <= num <= 1000\n;; Examples:\n;; >>> (int_to_mini_roman 19)\n;; \"xix\"\n;; >>> (int_to_mini_roman 152)\n;; \"clii\"\n;; >>> (int_to_mini_roman 426)\n;; \"cdxxvi\"\n(define (int_to_mini_roman number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate int_to_mini_roman))\n    (check-within (candidate 19) \"xix\" 0.001)\n    (check-within (candidate 152) \"clii\" 0.001)\n    (check-within (candidate 251) \"ccli\" 0.001)\n    (check-within (candidate 426) \"cdxxvi\" 0.001)\n    (check-within (candidate 500) \"d\" 0.001)\n    (check-within (candidate 1) \"i\" 0.001)\n    (check-within (candidate 4) \"iv\" 0.001)\n    (check-within (candidate 43) \"xliii\" 0.001)\n    (check-within (candidate 90) \"xc\" 0.001)\n    (check-within (candidate 94) \"xciv\" 0.001)\n    (check-within (candidate 532) \"dxxxii\" 0.001)\n    (check-within (candidate 900) \"cm\" 0.001)\n    (check-within (candidate 994) \"cmxciv\" 0.001)\n    (check-within (candidate 1000) \"m\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return True if the three\n;; sides form a right-angled triangle, False otherwise.\n;; A right-angled triangle is a triangle in which one angle is right angle or \n;; 90 degree.\n;; Example:\n;; >>> (right_angle_triangle 3 4 5)\n;; #t\n;; >>> (right_angle_triangle 1 2 3)\n;; #f\n(define (right_angle_triangle a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_angle_triangle))\n    (check-within (candidate 3 4 5) #t 0.001)\n    (check-within (candidate 1 2 3) #f 0.001)\n    (check-within (candidate 10 6 8) #t 0.001)\n    (check-within (candidate 2 2 2) #f 0.001)\n    (check-within (candidate 7 24 25) #t 0.001)\n    (check-within (candidate 10 5 7) #f 0.001)\n    (check-within (candidate 5 12 13) #t 0.001)\n    (check-within (candidate 15 8 17) #t 0.001)\n    (check-within (candidate 48 55 73) #t 0.001)\n    (check-within (candidate 1 1 1) #f 0.001)\n    (check-within (candidate 2 2 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts a list of strings.\n;; The list contains different words. Return the word with maximum number\n;; of unique characters. If multiple strings have maximum number of unique\n;; characters, return the one which comes first in lexicographical order.\n;; >>> (find_max (list \"name\" \"of\" \"string\"))\n;; \"string\"\n;; >>> (find_max (list \"name\" \"enam\" \"game\"))\n;; \"enam\"\n;; >>> (find_max (list \"aaaaaaa\" \"bb\" \"cc\"))\n;; \"aaaaaaa\"\n(define (find_max words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_max))\n    (check-within (candidate (list \"name\" \"of\" \"string\")) \"string\" 0.001)\n    (check-within (candidate (list \"name\" \"enam\" \"game\")) \"enam\" 0.001)\n    (check-within (candidate (list \"aaaaaaa\" \"bb\" \"cc\")) \"aaaaaaa\" 0.001)\n    (check-within (candidate (list \"abc\" \"cba\")) \"abc\" 0.001)\n    (check-within (candidate (list \"play\" \"this\" \"game\" \"of\" \"footbott\")) \"footbott\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"gonna\" \"rock\")) \"gonna\" 0.001)\n    (check-within (candidate (list \"we\" \"are\" \"a\" \"mad\" \"nation\")) \"nation\" 0.001)\n    (check-within (candidate (list \"this\" \"is\" \"a\" \"prrk\")) \"this\" 0.001)\n    (check-within (candidate (list \"b\")) \"b\" 0.001)\n    (check-within (candidate (list \"play\" \"play\" \"play\")) \"play\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're a hungry rabbit, and you already have eaten a certain number of carrots,\n;; but now you need to eat more carrots to complete the day's meals.\n;; you should return an array of [ total number of eaten carrots after your meals,\n;; the number of carrots left after your meals ]\n;; if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n;; Example:\n;; >>> (eat 5 6 10)\n;; (list 11 4)\n;; >>> (eat 4 8 9)\n;; (list 12 1)\n;; >>> (eat 1 10 10)\n;; (list 11 0)\n;; >>> (eat 2 11 5)\n;; (list 7 0)\n;; Variables:\n;; @number : integer\n;; the number of carrots that you have eaten.\n;; @need : integer\n;; the number of carrots that you need to eat.\n;; @remaining : integer\n;; the number of remaining carrots thet exist in stock\n;; Constrain:\n;; * 0 <= number <= 1000\n;; * 0 <= need <= 1000\n;; * 0 <= remaining <= 1000\n;; Have fun :)\n(define (eat number need remaining)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eat))\n    (check-within (candidate 5 6 10) (list 11 4) 0.001)\n    (check-within (candidate 4 8 9) (list 12 1) 0.001)\n    (check-within (candidate 1 10 10) (list 11 0) 0.001)\n    (check-within (candidate 2 11 5) (list 7 0) 0.001)\n    (check-within (candidate 4 5 7) (list 9 2) 0.001)\n    (check-within (candidate 4 5 1) (list 5 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n;; >>> (string_sequence 0)\n;; \"0\"\n;; >>> (string_sequence 5)\n;; \"0 1 2 3 4 5\"\n(define (string_sequence n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_sequence))\n    (check-within (candidate 0) \"0\" 0.001)\n    (check-within (candidate 3) \"0 1 2 3\" 0.001)\n    (check-within (candidate 10) \"0 1 2 3 4 5 6 7 8 9 10\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given two lists operator, and operand. The first list has basic algebra operations, and \n;; the second list is a list of integers. Use the two given lists to build the algebric \n;; expression and return the evaluation of this expression.\n;; The basic algebra operations:\n;; Addition ( + ) \n;; Subtraction ( - ) \n;; Multiplication ( * ) \n;; Floor division ( // ) \n;; Exponentiation ( ** ) \n;; Example:\n;; operator['+', '*', '-']\n;; array = [2, 3, 4, 5]\n;; result = 2 + 3 * 4 - 5\n;; => result = 9\n;; Note:\n;; The length of operator list is equal to the length of operand list minus one.\n;; Operand is a list of of non-negative integers.\n;; Operator list has at least one operator, and operand list has at least two operands.\n(define (do_algebra operator operand)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate do_algebra))\n    (check-within (candidate (list \"**\" \"*\" \"+\") (list 2 3 4 5)) 37 0.001)\n    (check-within (candidate (list \"+\" \"*\" \"-\") (list 2 3 4 5)) 9 0.001)\n    (check-within (candidate (list \"//\" \"*\") (list 7 3 4)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; if s[i] is a letter, reverse its case from lower to upper or vise versa, \n;; otherwise keep it as it is.\n;; If the string contains no letters, reverse the string.\n;; The function should return the resulted string.\n;; Examples\n;; >>> (solve \"1234\")\n;; \"4321\"\n;; >>> (solve \"ab\")\n;; \"AB\"\n;; >>> (solve \"#a@C\")\n;; \"#A@c\"\n(define (solve s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate \"AsDf\") \"aSdF\" 0.001)\n    (check-within (candidate \"1234\") \"4321\" 0.001)\n    (check-within (candidate \"ab\") \"AB\" 0.001)\n    (check-within (candidate \"#a@C\") \"#A@c\" 0.001)\n    (check-within (candidate \"#AsdfW^45\") \"#aSDFw^45\" 0.001)\n    (check-within (candidate \"#6@2\") \"2@6#\" 0.001)\n    (check-within (candidate \"#$a^D\") \"#$A^d\" 0.001)\n    (check-within (candidate \"#ccc\") \"#CCC\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string 'text', return its md5 hash equivalent string.\n;; If 'text' is an empty string, return None.\n;; >>> (string_to_md5 \"Hello world\")\n;; \"3e25960a79dbc69b674cd4ec67a72c62\"\n(define (string_to_md5 text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_md5))\n    (check-within (candidate \"Hello world\") \"3e25960a79dbc69b674cd4ec67a72c62\" 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"A B C\") \"0ef78513b0cb8cef12743f5aeb35f888\" 0.001)\n    (check-within (candidate \"password\") \"5f4dcc3b5aa765d61d8327deb882cf99\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2299,7 +1054,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Given two positive integers a and b, return the even digits between a\n;; and b, in ascending order.\n;; For example:\n;; >>> (generate_integers 2 8)\n;; (list 2 4 6 8)\n;; >>> (generate_integers 8 2)\n;; (list 2 4 6 8)\n;; >>> (generate_integers 10 14)\n;; (list )\n(define (generate_integers a b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate generate_integers))\n    (check-within (candidate 2 10) (list 2 4 6 8) 0.001)\n    (check-within (candidate 10 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 132 2) (list 2 4 6 8) 0.001)\n    (check-within (candidate 17 89) (list ) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> (rolling_max (list 1 2 3 2 3 4 2))\n;; (list 1 2 3 3 3 4 4)\n(define (rolling_max numbers)\n",
+    "prompt": "#lang racket\n\n;; Given a string, find out how many distinct characters (regardless of case) does it consist of\n;; >>> (count_distinct_characters \"xyzXYZ\")\n;; 3\n;; >>> (count_distinct_characters \"Jerry\")\n;; 4\n(define (count_distinct_characters string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_distinct_characters))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abcde\") 5 0.001)\n    (check-within (candidate \"abcdecadeCADE\") 5 0.001)\n    (check-within (candidate \"aaaaAAAAaaaa\") 1 0.001)\n    (check-within (candidate \"Jerry jERRY JeRRRY\") 5 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2325,13 +1080,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n;; >>> (below_zero (list 1 2 3))\n;; #f\n;; >>> (below_zero (list 1 2 -4 5))\n;; #t\n(define (below_zero operations)\n",
+    "prompt": "#lang racket\n\n;; Input to this function is a string representing musical notes in a special ASCII format.\n;; Your task is to parse this string and return list of integers corresponding to how many beats does each\n;; not last.\n;; Here is a legend:\n;; 'o' - whole note, lasts four beats\n;; 'o|' - half note, lasts two beats\n;; '.|' - quater note, lasts one beat\n;; >>> (parse_music \"o o| .| o| o| .| .| .| .| o o\")\n;; (list 4 2 1 2 2 1 1 1 1 4 4)\n(define (parse_music music_string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_music))\n    (check-within (candidate \"\") (list ) 0.001)\n    (check-within (candidate \"o o o o\") (list 4 4 4 4) 0.001)\n    (check-within (candidate \".| .| .| .|\") (list 1 1 1 1) 0.001)\n    (check-within (candidate \"o| o| .| .| o o o o\") (list 2 2 1 1 4 4 4 4) 0.001)\n    (check-within (candidate \"o| .| o| .| o o| o o|\") (list 2 1 2 1 4 2 4 2) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2340,13 +1095,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; >>> (search (list 4 1 2 2 3 1))\n;; 2\n;; >>> (search (list 1 2 2 3 3 3 4 4 4))\n;; 3\n;; >>> (search (list 5 5 4 4 4))\n;; -1\n(define (search lst)\n",
+    "prompt": "#lang racket\n\n;; Find how many times a given substring can be found in the original string. Count overlaping cases.\n;; >>> (how_many_times \"\" \"a\")\n;; 0\n;; >>> (how_many_times \"aaa\" \"a\")\n;; 3\n;; >>> (how_many_times \"aaaa\" \"aa\")\n;; 3\n(define (how_many_times string substring)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate how_many_times))\n    (check-within (candidate \"\" \"x\") 0 0.001)\n    (check-within (candidate \"xyxyxyx\" \"x\") 4 0.001)\n    (check-within (candidate \"cacacacac\" \"cac\") 4 0.001)\n    (check-within (candidate \"john doe\" \"john\") 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2355,13 +1110,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"(\")\n;; #f\n;; >>> (correct_bracketing \"()\")\n;; #t\n;; >>> (correct_bracketing \"(()())\")\n;; #t\n;; >>> (correct_bracketing \")(()\")\n;; #f\n(define (correct_bracketing brackets)\n",
+    "prompt": "#lang racket\n\n;; Input is a space-delimited string of numberals from 'zero' to 'nine'.\n;; Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n;; Return the string with numbers sorted from smallest to largest\n;; >>> (sort_numbers \"three one five\")\n;; \"one three five\"\n(define (sort_numbers numbers)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numbers))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"three\") \"three\" 0.001)\n    (check-within (candidate \"three five nine\") \"three five nine\" 0.001)\n    (check-within (candidate \"five zero four seven nine eight\") \"zero four five seven eight nine\" 0.001)\n    (check-within (candidate \"six five four three two one zero\") \"zero one two three four five six\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n;; separate those group into separate strings and return the list of those.\n;; Separate groups are balanced (each open brace is properly closed) and not nested within each other\n;; Ignore any spaces in the input string.\n;; >>> (separate_paren_groups \"( ) (( )) (( )( ))\")\n;; (list \"()\" \"(())\" \"(()())\")\n(define (separate_paren_groups paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate separate_paren_groups))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list \"(()())\" \"((()))\" \"()\" \"((())()())\") 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list \"()\" \"(())\" \"((()))\" \"(((())))\") 0.001)\n    (check-within (candidate \"(()(())((())))\") (list \"(()(())((())))\") 0.001)\n    (check-within (candidate \"( ) (( )) (( )( ))\") (list \"()\" \"(())\" \"(()())\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n;; other and return them in order (smaller number, larger number).\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.2))\n;; (list 2.0 2.2)\n;; >>> (find_closest_elements (list 1.0 2.0 3.0 4.0 5.0 2.0))\n;; (list 2.0 2.0)\n(define (find_closest_elements numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_closest_elements))\n    (check-within (candidate (list 1.0 2.0 3.9 4.0 5.0 2.2)) (list 3.9 4.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 5.9 4.0 5.0)) (list 5.0 5.9) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.2)) (list 2.0 2.2) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0 2.0)) (list 2.0 2.0) 0.001)\n    (check-within (candidate (list 1.1 2.2 3.1 4.1 5.1)) (list 2.2 3.1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of numbers (of at least two elements), apply a linear transform to that list,\n;; such that the smallest number will become 0 and the largest will become 1\n;; >>> (rescale_to_unit (list 1.0 2.0 3.0 4.0 5.0))\n;; (list 0.0 0.25 0.5 0.75 1.0)\n(define (rescale_to_unit numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rescale_to_unit))\n    (check-within (candidate (list 2.0 49.9)) (list 0.0 1.0) 0.001)\n    (check-within (candidate (list 100.0 49.9)) (list 1.0 0.0) 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) (list 0.0 0.25 0.5 0.75 1.0) 0.001)\n    (check-within (candidate (list 2.0 1.0 5.0 3.0 4.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n    (check-within (candidate (list 12.0 11.0 15.0 13.0 14.0)) (list 0.25 0.0 1.0 0.5 0.75) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter given list of any python values only for integers\n;; >>> (filter_integers (list \"a\" 3.14 5))\n;; (list 5)\n;; >>> (filter_integers (list 1 2 3 \"abc\" #hash() (list )))\n;; (list 1 2 3)\n(define (filter_integers values)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_integers))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 4 #hash() (list ) 23.2 9 \"adasd\")) (list 4 9) 0.001)\n    (check-within (candidate (list 3 \"c\" 3 3 \"a\" \"b\")) (list 3 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return length of given string\n;; >>> (strlen \"\")\n;; 0\n;; >>> (strlen \"abc\")\n;; 3\n(define (strlen string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strlen))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"x\") 1 0.001)\n    (check-within (candidate \"asdasnakj\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given number n, find the largest number that divides n evenly, smaller than n\n;; >>> (largest_divisor 15)\n;; 5\n(define (largest_divisor n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_divisor))\n    (check-within (candidate 3) 1 0.001)\n    (check-within (candidate 7) 1 0.001)\n    (check-within (candidate 10) 5 0.001)\n    (check-within (candidate 100) 50 0.001)\n    (check-within (candidate 49) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list of prime factors of given integer in the order from smallest to largest.\n;; Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n;; Input number should be equal to the product of all factors\n;; >>> (factorize 8)\n;; (list 2 2 2)\n;; >>> (factorize 25)\n;; (list 5 5)\n;; >>> (factorize 70)\n;; (list 2 5 7)\n(define (factorize n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate factorize))\n    (check-within (candidate 2) (list 2) 0.001)\n    (check-within (candidate 4) (list 2 2) 0.001)\n    (check-within (candidate 8) (list 2 2 2) 0.001)\n    (check-within (candidate 57) (list 3 19) 0.001)\n    (check-within (candidate 3249) (list 3 3 19 19) 0.001)\n    (check-within (candidate 185193) (list 3 3 3 19 19 19) 0.001)\n    (check-within (candidate 20577) (list 3 19 19 19) 0.001)\n    (check-within (candidate 18) (list 2 3 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a list of integers, remove all elements that occur more than once.\n;; Keep order of elements left the same as in the input.\n;; >>> (remove_duplicates (list 1 2 3 2 4))\n;; (list 1 3 4)\n(define (remove_duplicates numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_duplicates))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 3 5)) (list 1 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n;; >>> (flip_case \"Hello\")\n;; \"hELLO\"\n(define (flip_case string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flip_case))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hello!\") \"hELLO!\" 0.001)\n    (check-within (candidate \"These violent delights have violent ends\") \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Concatenate list of strings into a single string\n;; >>> (concatenate (list ))\n;; \"\"\n;; >>> (concatenate (list \"a\" \"b\" \"c\"))\n;; \"abc\"\n(define (concatenate strings)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate))\n    (check-within (candidate (list )) \"\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\")) \"xyz\" 0.001)\n    (check-within (candidate (list \"x\" \"y\" \"z\" \"w\" \"k\")) \"xyzwk\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that start with a given prefix.\n;; >>> (filter_by_prefix (list ) \"a\")\n;; (list )\n;; >>> (filter_by_prefix (list \"abc\" \"bcd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"array\")\n(define (filter_by_prefix strings prefix)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_prefix))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive floating point number, it can be decomposed into\n;; and integer part (largest integer smaller than given number) and decimals\n;; (leftover part always smaller than 1).\n;; Return the decimal part of the number.\n;; >>> (truncate_number 3.5)\n;; 0.5\n(define (truncate_number number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate truncate_number))\n    (check-within (candidate 3.5) 0.5 0.001)\n    (check-within (candidate 1.25) 0.25 0.001)\n    (check-within (candidate 123.0) 0.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return only positive numbers in the list.\n;; >>> (get_positive (list -1 2 -4 5 6))\n;; (list 2 5 6)\n;; >>> (get_positive (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; (list 5 3 2 3 9 123 1)\n(define (get_positive l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_positive))\n    (check-within (candidate (list -1 -2 4 5 6)) (list 4 5 6) 0.001)\n    (check-within (candidate (list 5 3 -5 2 3 3 9 0 123 1 -10)) (list 5 3 2 3 3 9 123 1) 0.001)\n    (check-within (candidate (list -1 -2)) (list ) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return true if a given number is prime, and false otherwise.\n;; >>> (is_prime 6)\n;; #f\n;; >>> (is_prime 101)\n;; #t\n;; >>> (is_prime 11)\n;; #t\n;; >>> (is_prime 13441)\n;; #t\n;; >>> (is_prime 61)\n;; #t\n;; >>> (is_prime 4)\n;; #f\n;; >>> (is_prime 1)\n;; #f\n(define (is_prime n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_prime))\n    (check-within (candidate 6) #f 0.001)\n    (check-within (candidate 101) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 13441) #t 0.001)\n    (check-within (candidate 61) #t 0.001)\n    (check-within (candidate 4) #f 0.001)\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 11) #t 0.001)\n    (check-within (candidate 17) #t 0.001)\n    (check-within (candidate 85) #f 0.001)\n    (check-within (candidate 77) #f 0.001)\n    (check-within (candidate 255379) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n;; to the values of the corresponding indicies of l, but sorted.\n;; >>> (sort_third (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_third (list 5 6 3 4 8 9 2))\n;; (list 2 6 3 4 8 9 5)\n(define (sort_third l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_third))\n    (check-within (candidate (list 5 6 3 4 8 9 2)) (list 2 6 3 4 8 9 5) 0.001)\n    (check-within (candidate (list 5 8 3 4 6 9 2)) (list 2 8 3 4 6 9 5) 0.001)\n    (check-within (candidate (list 5 6 9 4 8 3 2)) (list 2 6 9 4 8 3 5) 0.001)\n    (check-within (candidate (list 5 6 3 4 8 9 2 1)) (list 2 6 3 4 8 9 5 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique elements in a list\n;; >>> (unique (list 5 3 5 2 3 3 9 0 123))\n;; (list 0 2 3 5 9 123)\n(define (unique l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique))\n    (check-within (candidate (list 5 3 5 2 3 3 9 0 123)) (list 0 2 3 5 9 123) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return maximum element in the list.\n;; >>> (max_element (list 1 2 3))\n;; 3\n;; >>> (max_element (list 5 3 -5 2 -3 3 9 0 123 1 -10))\n;; 123\n(define (max_element l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_element))\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 124 1 -10)) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n;; >>> (fizz_buzz 50)\n;; 0\n;; >>> (fizz_buzz 78)\n;; 2\n;; >>> (fizz_buzz 79)\n;; 3\n(define (fizz_buzz n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fizz_buzz))\n    (check-within (candidate 50) 0 0.001)\n    (check-within (candidate 78) 2 0.001)\n    (check-within (candidate 79) 3 0.001)\n    (check-within (candidate 100) 3 0.001)\n    (check-within (candidate 200) 6 0.001)\n    (check-within (candidate 4000) 192 0.001)\n    (check-within (candidate 10000) 639 0.001)\n    (check-within (candidate 100000) 8026 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2374,9 +1399,249 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; This function takes a list l and returns a list l' such that\n;; l' is identical to l in the odd indicies, while its values at the even indicies are equal\n;; to the values of the even indicies of l, but sorted.\n;; >>> (sort_even (list 1 2 3))\n;; (list 1 2 3)\n;; >>> (sort_even (list 5 6 3 4))\n;; (list 3 6 5 4)\n(define (sort_even l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_even))\n    (check-within (candidate (list 1 2 3)) (list 1 2 3) 0.001)\n    (check-within (candidate (list 5 3 -5 2 -3 3 9 0 123 1 -10)) (list -10 3 -5 2 -3 3 5 0 9 1 123) 0.001)\n    (check-within (candidate (list 5 8 -12 4 23 2 3 11 12 -10)) (list -12 8 3 4 5 2 12 11 23 -10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n;; >>> (prime_fib 1)\n;; 2\n;; >>> (prime_fib 2)\n;; 3\n;; >>> (prime_fib 3)\n;; 5\n;; >>> (prime_fib 4)\n;; 13\n;; >>> (prime_fib 5)\n;; 89\n(define (prime_fib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_fib))\n    (check-within (candidate 1) 2 0.001)\n    (check-within (candidate 2) 3 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 13 0.001)\n    (check-within (candidate 5) 89 0.001)\n    (check-within (candidate 6) 233 0.001)\n    (check-within (candidate 7) 1597 0.001)\n    (check-within (candidate 8) 28657 0.001)\n    (check-within (candidate 9) 514229 0.001)\n    (check-within (candidate 10) 433494437 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You're given a list of deposit and withdrawal operations on a bank account that starts with\n;; zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n;; at that point function should return True. Otherwise it should return False.\n;; >>> (below_zero (list 1 2 3))\n;; #f\n;; >>> (below_zero (list 1 2 -4 5))\n;; #t\n(define (below_zero operations)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_zero))\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 2 -3 1 2 -3)) #f 0.001)\n    (check-within (candidate (list 1 2 -4 5 6)) #t 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -4)) #f 0.001)\n    (check-within (candidate (list 1 -1 2 -2 5 -5 4 -5)) #t 0.001)\n    (check-within (candidate (list 1 -2 2 -2 5 -5 4 -4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; triples_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are three distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> (triples_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (triples_sum_to_zero (list 1 3 -2 1))\n;; #t\n;; >>> (triples_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (triples_sum_to_zero (list 2 4 -5 3 9 7))\n;; #t\n;; >>> (triples_sum_to_zero (list 1))\n;; #f\n(define (triples_sum_to_zero l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triples_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -1)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #t 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 1 2 5 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 9 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list 1 3 5 -100)) #f 0.001)\n    (check-within (candidate (list 100 3 5 -100)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Imagine a road that's a perfectly straight infinitely long line.\n;; n cars are driving left to right;  simultaneously, a different set of n cars\n;; are driving right to left.   The two sets of cars start out being very far from\n;; each other.  All cars move in the same speed.  Two cars are said to collide\n;; when a car that's moving left to right hits a car that's moving right to left.\n;; However, the cars are infinitely sturdy and strong; as a result, they continue moving\n;; in their trajectory as if they did not collide.\n;; This function outputs the number of such collisions.\n(define (car_race_collision n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate car_race_collision))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 9 0.001)\n    (check-within (candidate 4) 16 0.001)\n    (check-within (candidate 8) 64 0.001)\n    (check-within (candidate 10) 100 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return list with elements incremented by 1.\n;; >>> (incr_list (list 1 2 3))\n;; (list 2 3 4)\n;; >>> (incr_list (list 5 3 5 2 3 3 9 0 123))\n;; (list 6 4 6 3 4 4 10 1 124)\n(define (incr_list l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate incr_list))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 4 3 2) 0.001)\n    (check-within (candidate (list 5 2 5 2 3 3 9 0 123)) (list 6 3 6 3 4 4 10 1 124) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; pairs_sum_to_zero takes a list of integers as an input.\n;; it returns True if there are two distinct elements in the list that\n;; sum to zero, and False otherwise.\n;; >>> (pairs_sum_to_zero (list 1 3 5 0))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 3 -2 1))\n;; #f\n;; >>> (pairs_sum_to_zero (list 1 2 3 7))\n;; #f\n;; >>> (pairs_sum_to_zero (list 2 4 -5 3 5 7))\n;; #t\n;; >>> (pairs_sum_to_zero (list 1))\n;; #f\n(define (pairs_sum_to_zero l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pairs_sum_to_zero))\n    (check-within (candidate (list 1 3 5 0)) #f 0.001)\n    (check-within (candidate (list 1 3 -2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 -5 3 5 7)) #t 0.001)\n    (check-within (candidate (list 1)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 30)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 3 2 31)) #t 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 30)) #f 0.001)\n    (check-within (candidate (list -3 9 -1 4 2 31)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Change numerical base of input number x to base.\n;; return string representation after the conversion.\n;; base numbers are less than 10.\n;; >>> (change_base 8 3)\n;; \"22\"\n;; >>> (change_base 8 2)\n;; \"1000\"\n;; >>> (change_base 7 2)\n;; \"111\"\n(define (change_base x base)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_base))\n    (check-within (candidate 8 3) \"22\" 0.001)\n    (check-within (candidate 9 3) \"100\" 0.001)\n    (check-within (candidate 234 2) \"11101010\" 0.001)\n    (check-within (candidate 16 2) \"10000\" 0.001)\n    (check-within (candidate 8 2) \"1000\" 0.001)\n    (check-within (candidate 7 2) \"111\" 0.001)\n    (check-within (candidate 2 3) \"2\" 0.001)\n    (check-within (candidate 3 4) \"3\" 0.001)\n    (check-within (candidate 4 5) \"4\" 0.001)\n    (check-within (candidate 5 6) \"5\" 0.001)\n    (check-within (candidate 6 7) \"6\" 0.001)\n    (check-within (candidate 7 8) \"7\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given length of a side and high return area for a triangle.\n;; >>> (triangle_area 5 3)\n;; 7.5\n(define (triangle_area a h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 5 3) 7.5 0.001)\n    (check-within (candidate 2 2) 2.0 0.001)\n    (check-within (candidate 10 8) 40.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fib4(0) -> 0\n;; fib4(1) -> 0\n;; fib4(2) -> 2\n;; fib4(3) -> 0\n;; fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n;; Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n;; >>> (fib4 5)\n;; 4\n;; >>> (fib4 6)\n;; 8\n;; >>> (fib4 7)\n;; 14\n(define (fib4 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib4))\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 28 0.001)\n    (check-within (candidate 10) 104 0.001)\n    (check-within (candidate 12) 386 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return median of elements in the list l.\n;; >>> (median (list 3 1 2 4 5))\n;; 3\n;; >>> (median (list -10 4 6 1000 10 20))\n;; 15.0\n(define (median l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median))\n    (check-within (candidate (list 3 1 2 4 5)) 3 0.001)\n    (check-within (candidate (list -10 4 6 1000 10 20)) 8.0 0.001)\n    (check-within (candidate (list 5)) 5 0.001)\n    (check-within (candidate (list 6 5)) 5.5 0.001)\n    (check-within (candidate (list 8 1 3 9 9 2 7)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Checks if given string is a palindrome\n;; >>> (is_palindrome \"\")\n;; #t\n;; >>> (is_palindrome \"aba\")\n;; #t\n;; >>> (is_palindrome \"aaaaa\")\n;; #t\n;; >>> (is_palindrome \"zbcd\")\n;; #f\n(define (is_palindrome text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_palindrome))\n    (check-within (candidate \"\") #t 0.001)\n    (check-within (candidate \"aba\") #t 0.001)\n    (check-within (candidate \"aaaaa\") #t 0.001)\n    (check-within (candidate \"zbcd\") #f 0.001)\n    (check-within (candidate \"xywyx\") #t 0.001)\n    (check-within (candidate \"xywyz\") #f 0.001)\n    (check-within (candidate \"xywzx\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return 2^n modulo p (be aware of numerics).\n;; >>> (modp 3 5)\n;; 3\n;; >>> (modp 1101 101)\n;; 2\n;; >>> (modp 0 101)\n;; 1\n;; >>> (modp 3 11)\n;; 8\n;; >>> (modp 100 101)\n;; 1\n(define (modp n p)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate modp))\n    (check-within (candidate 3 5) 3 0.001)\n    (check-within (candidate 1101 101) 2 0.001)\n    (check-within (candidate 0 101) 1 0.001)\n    (check-within (candidate 3 11) 8 0.001)\n    (check-within (candidate 100 101) 1 0.001)\n    (check-within (candidate 30 5) 4 0.001)\n    (check-within (candidate 31 5) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of input numbers, calculate Mean Absolute Deviation\n;; around the mean of this dataset.\n;; Mean Absolute Deviation is the average absolute difference between each\n;; element and a centerpoint (mean in this case):\n;; MAD = average | x - x_mean |\n;; >>> (mean_absolute_deviation (list 1.0 2.0 3.0 4.0))\n;; 1.0\n(define (mean_absolute_deviation numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mean_absolute_deviation))\n    (check-within (candidate (list 1.0 2.0)) 0.5 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0)) 1.0 0.001)\n    (check-within (candidate (list 1.0 2.0 3.0 4.0 5.0)) 1.2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; remove_vowels is a function that takes string and returns string without vowels.\n;; >>> (remove_vowels \"\")\n;; \"\"\n;; >>> (remove_vowels \"abcdef\")\n;; \"bcdf\"\n;; >>> (remove_vowels \"aaaaa\")\n;; \"\"\n;; >>> (remove_vowels \"aaBAA\")\n;; \"B\"\n;; >>> (remove_vowels \"zbcd\")\n;; \"zbcd\"\n(define (remove_vowels text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_vowels))\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"abcdef\nghijklm\") \"bcdf\nghjklm\" 0.001)\n    (check-within (candidate \"fedcba\") \"fdcb\" 0.001)\n    (check-within (candidate \"eeeee\") \"\" 0.001)\n    (check-within (candidate \"acBAA\") \"cB\" 0.001)\n    (check-within (candidate \"EcBOO\") \"cB\" 0.001)\n    (check-within (candidate \"ybcd\") \"ybcd\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True if all numbers in the list l are below threshold t.\n;; >>> (below_threshold (list 1 2 4 10) 100)\n;; #t\n;; >>> (below_threshold (list 1 20 4 10) 5)\n;; #f\n(define (below_threshold l t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate below_threshold))\n    (check-within (candidate (list 1 2 4 10) 100) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 5) #f 0.001)\n    (check-within (candidate (list 1 20 4 10) 21) #t 0.001)\n    (check-within (candidate (list 1 20 4 10) 22) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 11) #t 0.001)\n    (check-within (candidate (list 1 8 4 10) 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Add two numbers x and y\n;; >>> (add 2 3)\n;; 5\n;; >>> (add 5 7)\n;; 12\n(define (add x y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate 0 1) 1 0.001)\n    (check-within (candidate 1 0) 1 0.001)\n    (check-within (candidate 2 3) 5 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 5) 12 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2389,9 +1654,24 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Check if two words have the same characters.\n;; >>> (same_chars \"eabcdzzzz\" \"dddzzzzzzzddeddabc\")\n;; #t\n;; >>> (same_chars \"abcd\" \"dddddddabc\")\n;; #t\n;; >>> (same_chars \"dddddddabc\" \"abcd\")\n;; #t\n;; >>> (same_chars \"eabcd\" \"dddddddabc\")\n;; #f\n;; >>> (same_chars \"abcd\" \"dddddddabce\")\n;; #f\n;; >>> (same_chars \"eabcdzzzz\" \"dddzzzzzzzddddabc\")\n;; #f\n(define (same_chars s0 s1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate same_chars))\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") #t 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabc\") #t 0.001)\n    (check-within (candidate \"dddddddabc\" \"abcd\") #t 0.001)\n    (check-within (candidate \"eabcd\" \"dddddddabc\") #f 0.001)\n    (check-within (candidate \"abcd\" \"dddddddabcf\") #f 0.001)\n    (check-within (candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") #f 0.001)\n    (check-within (candidate \"aabb\" \"aaccc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return n-th Fibonacci number.\n;; >>> (fib 10)\n;; 55\n;; >>> (fib 1)\n;; 1\n;; >>> (fib 8)\n;; 21\n(define (fib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fib))\n    (check-within (candidate 10) 55 0.001)\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 8) 21 0.001)\n    (check-within (candidate 11) 89 0.001)\n    (check-within (candidate 12) 144 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -2404,9 +1684,729 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; brackets is a string of \"<\" and \">\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"<\")\n;; #f\n;; >>> (correct_bracketing \"<>\")\n;; #t\n;; >>> (correct_bracketing \"<<><>>\")\n;; #t\n;; >>> (correct_bracketing \"><<>\")\n;; #f\n(define (correct_bracketing brackets)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"<>\") #t 0.001)\n    (check-within (candidate \"<<><>>\") #t 0.001)\n    (check-within (candidate \"<><><<><>><>\") #t 0.001)\n    (check-within (candidate \"<><><<<><><>><>><<><><<>>>\") #t 0.001)\n    (check-within (candidate \"<<<><>>>>\") #f 0.001)\n    (check-within (candidate \"><<>\") #f 0.001)\n    (check-within (candidate \"<\") #f 0.001)\n    (check-within (candidate \"<<<<\") #f 0.001)\n    (check-within (candidate \">\") #f 0.001)\n    (check-within (candidate \"<<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>><<>\") #f 0.001)\n    (check-within (candidate \"<><><<><>><>>><>\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return True is list elements are monotonically increasing or decreasing.\n;; >>> (monotonic (list 1 2 4 20))\n;; #t\n;; >>> (monotonic (list 1 20 4 10))\n;; #f\n;; >>> (monotonic (list 4 1 0 -10))\n;; #t\n(define (monotonic l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate monotonic))\n    (check-within (candidate (list 1 2 4 10)) #t 0.001)\n    (check-within (candidate (list 1 2 4 20)) #t 0.001)\n    (check-within (candidate (list 1 20 4 10)) #f 0.001)\n    (check-within (candidate (list 4 1 0 -10)) #t 0.001)\n    (check-within (candidate (list 4 1 1 0)) #t 0.001)\n    (check-within (candidate (list 1 2 3 2 5 60)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5 60)) #t 0.001)\n    (check-within (candidate (list 9 9 9 9)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return sorted unique common elements for two lists.\n;; >>> (common (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121))\n;; (list 1 5 653)\n;; >>> (common (list 5 3 2 8) (list 3 2))\n;; (list 2 3)\n(define (common l1 l2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common))\n    (check-within (candidate (list 1 4 3 34 653 2 5) (list 5 7 1 5 9 653 121)) (list 1 5 653) 0.001)\n    (check-within (candidate (list 5 3 2 8) (list 3 2)) (list 2 3) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list 3 2 4)) (list 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 8) (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Return the largest prime factor of n. Assume n > 1 and is not a prime.\n;; >>> (largest_prime_factor 13195)\n;; 29\n;; >>> (largest_prime_factor 2048)\n;; 2\n(define (largest_prime_factor n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_prime_factor))\n    (check-within (candidate 15) 5 0.001)\n    (check-within (candidate 27) 3 0.001)\n    (check-within (candidate 63) 7 0.001)\n    (check-within (candidate 330) 11 0.001)\n    (check-within (candidate 13195) 29 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n;; >>> (intersperse (list ) 4)\n;; (list )\n;; >>> (intersperse (list 1 2 3) 4)\n;; (list 1 4 2 4 3)\n(define (intersperse numbers delimeter)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersperse))\n    (check-within (candidate (list ) 7) (list ) 0.001)\n    (check-within (candidate (list 5 6 3 2) 8) (list 5 8 6 8 3 8 2) 0.001)\n    (check-within (candidate (list 2 2 2) 2) (list 2 2 2 2 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; sum_to_n is a function that sums numbers from 1 to n.\n;; >>> (sum_to_n 30)\n;; 465\n;; >>> (sum_to_n 100)\n;; 5050\n;; >>> (sum_to_n 5)\n;; 15\n;; >>> (sum_to_n 10)\n;; 55\n;; >>> (sum_to_n 1)\n;; 1\n(define (sum_to_n n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_to_n))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 6) 21 0.001)\n    (check-within (candidate 11) 66 0.001)\n    (check-within (candidate 30) 465 0.001)\n    (check-within (candidate 100) 5050 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; brackets is a string of \"(\" and \")\".\n;; return True if every opening bracket has a corresponding closing bracket.\n;; >>> (correct_bracketing \"(\")\n;; #f\n;; >>> (correct_bracketing \"()\")\n;; #t\n;; >>> (correct_bracketing \"(()())\")\n;; #t\n;; >>> (correct_bracketing \")(()\")\n;; #f\n(define (correct_bracketing brackets)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate correct_bracketing))\n    (check-within (candidate \"()\") #t 0.001)\n    (check-within (candidate \"(()())\") #t 0.001)\n    (check-within (candidate \"()()(()())()\") #t 0.001)\n    (check-within (candidate \"()()((()()())())(()()(()))\") #t 0.001)\n    (check-within (candidate \"((()())))\") #f 0.001)\n    (check-within (candidate \")(()\") #f 0.001)\n    (check-within (candidate \"(\") #f 0.001)\n    (check-within (candidate \"((((\") #f 0.001)\n    (check-within (candidate \")\") #f 0.001)\n    (check-within (candidate \"(()\") #f 0.001)\n    (check-within (candidate \"()()(()())())(()\") #f 0.001)\n    (check-within (candidate \"()()(()())()))()\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; xs represent coefficients of a polynomial.\n;; xs[0] + xs[1] * x + xs[2] * x^2 + ....\n;; Return derivative of this polynomial in the same form.\n;; >>> (derivative (list 3 1 2 4 5))\n;; (list 1 4 12 20)\n;; >>> (derivative (list 1 2 3))\n;; (list 2 6)\n(define (derivative xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate derivative))\n    (check-within (candidate (list 3 1 2 4 5)) (list 1 4 12 20) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 6) 0.001)\n    (check-within (candidate (list 3 2 1)) (list 2 2) 0.001)\n    (check-within (candidate (list 3 2 1 0 4)) (list 2 2 0 16) 0.001)\n    (check-within (candidate (list 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n;; fibfib(0) == 0\n;; fibfib(1) == 0\n;; fibfib(2) == 1\n;; fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n;; Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n;; >>> (fibfib 1)\n;; 0\n;; >>> (fibfib 5)\n;; 4\n;; >>> (fibfib 8)\n;; 24\n(define (fibfib n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fibfib))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 1) 0 0.001)\n    (check-within (candidate 5) 4 0.001)\n    (check-within (candidate 8) 24 0.001)\n    (check-within (candidate 10) 81 0.001)\n    (check-within (candidate 12) 274 0.001)\n    (check-within (candidate 14) 927 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function vowels_count which takes a string representing\n;; a word as input and returns the number of vowels in the string.\n;; Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n;; vowel, but only when it is at the end of the given word.\n;; Example:\n;; >>> (vowels_count \"abcde\")\n;; 2\n;; >>> (vowels_count \"ACEDY\")\n;; 3\n(define (vowels_count s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate vowels_count))\n    (check-within (candidate \"abcde\") 2 0.001)\n    (check-within (candidate \"Alone\") 3 0.001)\n    (check-within (candidate \"key\") 2 0.001)\n    (check-within (candidate \"bye\") 1 0.001)\n    (check-within (candidate \"keY\") 2 0.001)\n    (check-within (candidate \"bYe\") 1 0.001)\n    (check-within (candidate \"ACEDY\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Circular shift the digits of the integer x, shift the digits right by shift\n;; and return the result as a string.\n;; If shift > number of digits, return digits reversed.\n;; >>> (circular_shift 12 1)\n;; \"21\"\n;; >>> (circular_shift 12 2)\n;; \"12\"\n(define (circular_shift x shift)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate circular_shift))\n    (check-within (candidate 100 2) \"001\" 0.001)\n    (check-within (candidate 12 2) \"12\" 0.001)\n    (check-within (candidate 97 8) \"79\" 0.001)\n    (check-within (candidate 12 1) \"21\" 0.001)\n    (check-within (candidate 11 101) \"11\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Task\n;; Write a function that takes a string as input and returns the sum of the upper characters only'\n;; ASCII codes.\n;; Examples:\n;; >>> (digitSum \"\")\n;; 0\n;; >>> (digitSum \"abAB\")\n;; 131\n;; >>> (digitSum \"abcCd\")\n;; 67\n;; >>> (digitSum \"helloE\")\n;; 69\n;; >>> (digitSum \"woArBld\")\n;; 131\n;; >>> (digitSum \"aAaaaXa\")\n;; 153\n(define (digitSum s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digitSum))\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"abAB\") 131 0.001)\n    (check-within (candidate \"abcCd\") 67 0.001)\n    (check-within (candidate \"helloE\") 69 0.001)\n    (check-within (candidate \"woArBld\") 131 0.001)\n    (check-within (candidate \"aAaaaXa\") 153 0.001)\n    (check-within (candidate \" How are yOu?\") 151 0.001)\n    (check-within (candidate \"You arE Very Smart\") 327 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; In this task, you will be given a string that represents a number of apples and oranges \n;; that are distributed in a basket of fruit this basket contains \n;; apples, oranges, and mango fruits. Given the string that represents the total number of \n;; the oranges and apples and an integer that represent the total number of the fruits \n;; in the basket return the number of the mango fruits in the basket.\n;; for examble:\n;; >>> (fruit_distribution \"5 apples and 6 oranges\" 19)\n;; 8\n;; >>> (fruit_distribution \"0 apples and 1 oranges\" 3)\n;; 2\n;; >>> (fruit_distribution \"2 apples and 3 oranges\" 100)\n;; 95\n;; >>> (fruit_distribution \"100 apples and 1 oranges\" 120)\n;; 19\n(define (fruit_distribution s n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate fruit_distribution))\n    (check-within (candidate \"5 apples and 6 oranges\" 19) 8 0.001)\n    (check-within (candidate \"5 apples and 6 oranges\" 21) 10 0.001)\n    (check-within (candidate \"0 apples and 1 oranges\" 3) 2 0.001)\n    (check-within (candidate \"1 apples and 0 oranges\" 3) 2 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 100) 95 0.001)\n    (check-within (candidate \"2 apples and 3 oranges\" 5) 0 0.001)\n    (check-within (candidate \"1 apples and 100 oranges\" 120) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; \"Given an array representing a branch of a tree that has non-negative integer nodes\n;; your task is to pluck one of the nodes and return it.\n;; The plucked node should be the node with the smallest even value.\n;; If multiple nodes with the same smallest even value are found return the node that has smallest index.\n;; The plucked node should be returned in a list, [ smalest_value, its index ],\n;; If there are no even values or the given array is empty, return [].\n;; Example 1:\n;; >>> (pluck (list 4 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 2:\n;; >>> (pluck (list 1 2 3))\n;; (list 2 1)\n;; Explanation: 2 has the smallest even value, and 2 has the smallest index.\n;; Example 3:\n;; >>> (pluck (list ))\n;; (list )\n;; Example 4:\n;; >>> (pluck (list 5 0 3 0 4 2))\n;; (list 0 1)\n;; Explanation: 0 is the smallest value, but  there are two zeros,\n;; so we will choose the first zero, which has the smallest index.\n;; Constraints:\n;; * 1 <= nodes.length <= 10000\n;; * 0 <= node.value\n(define (pluck arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pluck))\n    (check-within (candidate (list 4 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 1) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5 0 3 0 4 2)) (list 0 1) 0.001)\n    (check-within (candidate (list 1 2 3 0 5 3)) (list 0 3) 0.001)\n    (check-within (candidate (list 5 4 8 4 8)) (list 4 1) 0.001)\n    (check-within (candidate (list 7 6 7 1)) (list 6 1) 0.001)\n    (check-within (candidate (list 7 9 7 1)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n;; zero, and has a frequency greater than or equal to the value of the integer itself. \n;; The frequency of an integer is the number of times it appears in the list.\n;; If no such a value exist, return -1.\n;; Examples:\n;; >>> (search (list 4 1 2 2 3 1))\n;; 2\n;; >>> (search (list 1 2 2 3 3 3 4 4 4))\n;; 3\n;; >>> (search (list 5 5 4 4 4))\n;; -1\n(define (search lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 5 5 5 5 1)) 1 0.001)\n    (check-within (candidate (list 4 1 4 1 4 4)) 4 0.001)\n    (check-within (candidate (list 3 3)) -1 0.001)\n    (check-within (candidate (list 8 8 8 8 8 8 8 8)) 8 0.001)\n    (check-within (candidate (list 2 3 3 2 2)) 2 0.001)\n    (check-within (candidate (list 2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1)) 1 0.001)\n    (check-within (candidate (list 3 2 8 2)) 2 0.001)\n    (check-within (candidate (list 6 7 1 8 8 10 5 8 5 3 10)) 1 0.001)\n    (check-within (candidate (list 8 8 3 6 5 6 4)) -1 0.001)\n    (check-within (candidate (list 6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9)) 1 0.001)\n    (check-within (candidate (list 1 9 10 1 3)) 1 0.001)\n    (check-within (candidate (list 6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10)) 5 0.001)\n    (check-within (candidate (list 1)) 1 0.001)\n    (check-within (candidate (list 8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5)) 4 0.001)\n    (check-within (candidate (list 2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10)) 2 0.001)\n    (check-within (candidate (list 1 6 10 1 6 9 10 8 6 8 7 3)) 1 0.001)\n    (check-within (candidate (list 9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4)) 4 0.001)\n    (check-within (candidate (list 2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7)) 4 0.001)\n    (check-within (candidate (list 9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1)) 2 0.001)\n    (check-within (candidate (list 5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8)) -1 0.001)\n    (check-within (candidate (list 10)) -1 0.001)\n    (check-within (candidate (list 9 7 7 2 4 7 2 10 9 7 5 7 2)) 2 0.001)\n    (check-within (candidate (list 5 4 10 2 1 1 10 3 6 1 8)) 1 0.001)\n    (check-within (candidate (list 7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6)) 1 0.001)\n    (check-within (candidate (list 3 10 10 9 2)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n;; For each of the group, output the deepest level of nesting of parentheses.\n;; E.g. (()()) has maximum two levels of nesting while ((())) has three.\n;; >>> (parse_nested_parens \"(()()) ((())) () ((())()())\")\n;; (list 2 3 1 3)\n(define (parse_nested_parens paren_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parse_nested_parens))\n    (check-within (candidate \"(()()) ((())) () ((())()())\") (list 2 3 1 3) 0.001)\n    (check-within (candidate \"() (()) ((())) (((())))\") (list 1 2 3 4) 0.001)\n    (check-within (candidate \"(()(())((())))\") (list 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given list of integers, return list in strange order.\n;; Strange sorting, is when you start with the minimum value,\n;; then maximum of the remaining integers, then minimum and so on.\n;; Examples:\n;; >>> (strange_sort_list (list 1 2 3 4))\n;; (list 1 4 2 3)\n;; >>> (strange_sort_list (list 5 5 5 5))\n;; (list 5 5 5 5)\n;; >>> (strange_sort_list (list ))\n;; (list )\n(define (strange_sort_list lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate strange_sort_list))\n    (check-within (candidate (list 1 2 3 4)) (list 1 4 2 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9)) (list 5 9 6 8 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 5 2 4 3) 0.001)\n    (check-within (candidate (list 5 6 7 8 9 1)) (list 1 9 5 8 6 7) 0.001)\n    (check-within (candidate (list 5 5 5 5)) (list 5 5 5 5) 0.001)\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8)) (list 1 8 2 7 3 6 4 5) 0.001)\n    (check-within (candidate (list 0 2 2 2 5 5 -5 -5)) (list -5 5 -5 5 0 2 2 2) 0.001)\n    (check-within (candidate (list 111111)) (list 111111) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given the lengths of the three sides of a triangle. Return the area of\n;; the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n;; Otherwise return -1\n;; Three sides make a valid triangle when the sum of any two sides is greater \n;; than the third side.\n;; Example:\n;; >>> (triangle_area 3 4 5)\n;; 6.0\n;; >>> (triangle_area 1 2 10)\n;; -1\n(define (triangle_area a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate 3 4 5) 6.0 0.001)\n    (check-within (candidate 1 2 10) -1 0.001)\n    (check-within (candidate 4 8 5) 8.18 0.001)\n    (check-within (candidate 2 2 2) 1.73 0.001)\n    (check-within (candidate 1 2 3) -1 0.001)\n    (check-within (candidate 10 5 7) 16.25 0.001)\n    (check-within (candidate 2 6 3) -1 0.001)\n    (check-within (candidate 1 1 1) 0.43 0.001)\n    (check-within (candidate 2 2 10) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns True if the object q will fly, and False otherwise.\n;; The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n;; Example:\n;; >>> (will_it_fly (list 1 2) 5)\n;; #f\n;; # 1+2 is less than the maximum possible weight, but it's unbalanced.\n;; >>> (will_it_fly (list 3 2 3) 1)\n;; #f\n;; # it's balanced, but 3+2+3 is more than the maximum possible weight.\n;; >>> (will_it_fly (list 3 2 3) 9)\n;; #t\n;; # 3+2+3 is less than the maximum possible weight, and it's balanced.\n;; >>> (will_it_fly (list 3) 5)\n;; #t\n;; # 3 is less than the maximum possible weight, and it's balanced.\n(define (will_it_fly q w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate will_it_fly))\n    (check-within (candidate (list 3 2 3) 9) #t 0.001)\n    (check-within (candidate (list 1 2) 5) #f 0.001)\n    (check-within (candidate (list 3) 5) #t 0.001)\n    (check-within (candidate (list 3 2 3) 1) #f 0.001)\n    (check-within (candidate (list 1 2 3) 6) #f 0.001)\n    (check-within (candidate (list 5) 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array arr of integers, find the minimum number of elements that\n;; need to be changed to make the array palindromic. A palindromic array is an array that\n;; is read the same backwards and forwards. In one change, you can change one element to any other element.\n;; For example:\n;; >>> (smallest_change (list 1 2 3 5 4 7 9 6))\n;; 4\n;; >>> (smallest_change (list 1 2 3 4 3 2 2))\n;; 1\n;; >>> (smallest_change (list 1 2 3 2 1))\n;; 0\n(define (smallest_change arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_change))\n    (check-within (candidate (list 1 2 3 5 4 7 9 6)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 2)) 1 0.001)\n    (check-within (candidate (list 1 4 2)) 1 0.001)\n    (check-within (candidate (list 1 4 4 2)) 1 0.001)\n    (check-within (candidate (list 1 2 3 2 1)) 0 0.001)\n    (check-within (candidate (list 3 1 1 3)) 0 0.001)\n    (check-within (candidate (list 1)) 0 0.001)\n    (check-within (candidate (list 0 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that accepts two lists of strings and returns the list that has \n;; total number of chars in the all strings of the list less than the other list.\n;; if the two lists have the same number of chars, return the first list.\n;; Examples\n;; >>> (total_match (list ) (list ))\n;; (list )\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"Hi\"))\n;; (list \"hI\" \"Hi\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\"))\n;; (list \"hi\" \"admin\")\n;; >>> (total_match (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\"))\n;; (list \"hI\" \"hi\" \"hi\")\n;; >>> (total_match (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\"))\n;; (list \"4\")\n(define (total_match lst1 lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate total_match))\n    (check-within (candidate (list ) (list )) (list ) 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\")) (list \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hi\" \"hi\" \"admin\" \"project\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list \"4\") (list \"1\" \"2\" \"3\" \"4\" \"5\")) (list \"4\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"Hi\")) (list \"hI\" \"Hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hi\")) (list \"hI\" \"hi\" \"hi\") 0.001)\n    (check-within (candidate (list \"hi\" \"admin\") (list \"hI\" \"hi\" \"hii\")) (list \"hi\" \"admin\") 0.001)\n    (check-within (candidate (list ) (list \"this\")) (list ) 0.001)\n    (check-within (candidate (list \"this\") (list )) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns true if the given number is the multiplication of 3 prime numbers\n;; and false otherwise.\n;; Knowing that (a) is less then 100. \n;; Example:\n;; >>> (is_multiply_prime 30)\n;; #t\n;; 30 = 2 * 3 * 5\n(define (is_multiply_prime a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_multiply_prime))\n    (check-within (candidate 5) #f 0.001)\n    (check-within (candidate 30) #t 0.001)\n    (check-within (candidate 8) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n    (check-within (candidate 105) #t 0.001)\n    (check-within (candidate 126) #f 0.001)\n    (check-within (candidate 729) #f 0.001)\n    (check-within (candidate 891) #f 0.001)\n    (check-within (candidate 1001) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Your task is to write a function that returns true if a number x is a simple\n;; power of n and false in other cases.\n;; x is a simple power of n if n**int=x\n;; For example:\n;; >>> (is_simple_power 1 4)\n;; #t\n;; >>> (is_simple_power 2 2)\n;; #t\n;; >>> (is_simple_power 8 2)\n;; #t\n;; >>> (is_simple_power 3 2)\n;; #f\n;; >>> (is_simple_power 3 1)\n;; #f\n;; >>> (is_simple_power 5 3)\n;; #f\n(define (is_simple_power x n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_simple_power))\n    (check-within (candidate 16 2) #t 0.001)\n    (check-within (candidate 143214 16) #f 0.001)\n    (check-within (candidate 4 2) #t 0.001)\n    (check-within (candidate 9 3) #t 0.001)\n    (check-within (candidate 16 4) #t 0.001)\n    (check-within (candidate 24 2) #f 0.001)\n    (check-within (candidate 128 4) #f 0.001)\n    (check-within (candidate 12 6) #f 0.001)\n    (check-within (candidate 1 1) #t 0.001)\n    (check-within (candidate 1 12) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an integer a and returns True \n;; if this ingeger is a cube of some integer number.\n;; Note: you may assume the input is always valid.\n;; Examples:\n;; >>> (iscube 1)\n;; #t\n;; >>> (iscube 2)\n;; #f\n;; >>> (iscube -1)\n;; #t\n;; >>> (iscube 64)\n;; #t\n;; >>> (iscube 0)\n;; #t\n;; >>> (iscube 180)\n;; #f\n(define (iscube a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate iscube))\n    (check-within (candidate 1) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate -1) #t 0.001)\n    (check-within (candidate 64) #t 0.001)\n    (check-within (candidate 180) #f 0.001)\n    (check-within (candidate 1000) #t 0.001)\n    (check-within (candidate 0) #t 0.001)\n    (check-within (candidate 1729) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You have been tasked to write a function that receives \n;; a hexadecimal number as a string and counts the number of hexadecimal \n;; digits that are primes (prime number, or a prime, is a natural number \n;; greater than 1 that is not a product of two smaller natural numbers).\n;; Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n;; Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n;; So you have to determine a number of the following digits: 2, 3, 5, 7, \n;; B (=decimal 11), D (=decimal 13).\n;; Note: you may assume the input is always correct or empty string, \n;; and symbols A,B,C,D,E,F are always uppercase.\n;; Examples:\n;; >>> (hex_key \"AB\")\n;; 1\n;; >>> (hex_key \"1077E\")\n;; 2\n;; >>> (hex_key \"ABED1A33\")\n;; 4\n;; >>> (hex_key \"123456789ABCDEF0\")\n;; 6\n;; >>> (hex_key \"2020\")\n;; 2\n(define (hex_key num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hex_key))\n    (check-within (candidate \"AB\") 1 0.001)\n    (check-within (candidate \"1077E\") 2 0.001)\n    (check-within (candidate \"ABED1A33\") 4 0.001)\n    (check-within (candidate \"2020\") 2 0.001)\n    (check-within (candidate \"123456789ABCDEF0\") 6 0.001)\n    (check-within (candidate \"112233445566778899AABBCCDDEEFF00\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You will be given a number in decimal form and your task is to convert it to\n;; binary format. The function should return a string, with each character representing a binary\n;; number. Each character in the string will be '0' or '1'.\n;; There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n;; The extra characters are there to help with the format.\n;; Examples:\n;; >>> (decimal_to_binary 15)\n;; \"db1111db\"\n;; >>> (decimal_to_binary 32)\n;; \"db100000db\"\n(define (decimal_to_binary decimal)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 0) \"db0db\" 0.001)\n    (check-within (candidate 32) \"db100000db\" 0.001)\n    (check-within (candidate 103) \"db1100111db\" 0.001)\n    (check-within (candidate 15) \"db1111db\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Filter an input list of strings only for ones that contain given substring\n;; >>> (filter_by_substring (list ) \"a\")\n;; (list )\n;; >>> (filter_by_substring (list \"abc\" \"bacd\" \"cde\" \"array\") \"a\")\n;; (list \"abc\" \"bacd\" \"array\")\n(define (filter_by_substring strings substring)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_by_substring))\n    (check-within (candidate (list ) \"john\") (list ) 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"xxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xxx\") (list \"xxx\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"xxx\" \"asd\" \"aaaxxy\" \"john doe\" \"xxxAAA\" \"xxx\") \"xx\") (list \"xxx\" \"aaaxxy\" \"xxxAAA\" \"xxx\") 0.001)\n    (check-within (candidate (list \"grunt\" \"trumpet\" \"prune\" \"gruesome\") \"run\") (list \"grunt\" \"prune\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a string s.\n;; Your task is to check if the string is happy or not.\n;; A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n;; For example:\n;; >>> (is_happy \"a\")\n;; #f\n;; >>> (is_happy \"aa\")\n;; #f\n;; >>> (is_happy \"abcd\")\n;; #t\n;; >>> (is_happy \"aabb\")\n;; #f\n;; >>> (is_happy \"adb\")\n;; #t\n;; >>> (is_happy \"xyy\")\n;; #f\n(define (is_happy s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_happy))\n    (check-within (candidate \"a\") #f 0.001)\n    (check-within (candidate \"aa\") #f 0.001)\n    (check-within (candidate \"abcd\") #t 0.001)\n    (check-within (candidate \"aabb\") #f 0.001)\n    (check-within (candidate \"adb\") #t 0.001)\n    (check-within (candidate \"xyy\") #f 0.001)\n    (check-within (candidate \"iopaxpoi\") #t 0.001)\n    (check-within (candidate \"iopaxioi\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; It is the last week of the semester and the teacher has to give the grades\n;; to students. The teacher has been making her own algorithm for grading.\n;; The only problem is, she has lost the code she used for grading.\n;; She has given you a list of GPAs for some students and you have to write \n;; a function that can output a list of letter grades using the following table:\n;; GPA       |    Letter grade\n;; 4.0                A+\n;; > 3.7                A \n;; > 3.3                A- \n;; > 3.0                B+\n;; > 2.7                B \n;; > 2.3                B-\n;; > 2.0                C+\n;; > 1.7                C\n;; > 1.3                C-\n;; > 1.0                D+ \n;; > 0.7                D \n;; > 0.0                D-\n;; 0.0                E\n;; Example:\n;; >>> (grade_equation (list 4.0 3 1.7 2 3.5))\n;; (list \"A+\" \"B\" \"C-\" \"C\" \"A-\")\n(define (numerical_letter_grade grades)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate numerical_letter_grade))\n    (check-within (candidate (list 4.0 3 1.7 2 3.5)) (list \"A+\" \"B\" \"C-\" \"C\" \"A-\") 0.001)\n    (check-within (candidate (list 1.2)) (list \"D+\") 0.001)\n    (check-within (candidate (list 0.5)) (list \"D-\") 0.001)\n    (check-within (candidate (list 0.0)) (list \"E\") 0.001)\n    (check-within (candidate (list 1.0 0.3 1.5 2.8 3.3)) (list \"D\" \"D-\" \"C-\" \"B\" \"B+\") 0.001)\n    (check-within (candidate (list 0.0 0.7)) (list \"E\" \"D-\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns True if the string\n;; length is a prime number or False otherwise\n;; Examples\n;; >>> (prime_length \"Hello\")\n;; #t\n;; >>> (prime_length \"abcdcba\")\n;; #t\n;; >>> (prime_length \"kittens\")\n;; #t\n;; >>> (prime_length \"orange\")\n;; #f\n(define (prime_length string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_length))\n    (check-within (candidate \"Hello\") #t 0.001)\n    (check-within (candidate \"abcdcba\") #t 0.001)\n    (check-within (candidate \"kittens\") #t 0.001)\n    (check-within (candidate \"orange\") #f 0.001)\n    (check-within (candidate \"wow\") #t 0.001)\n    (check-within (candidate \"world\") #t 0.001)\n    (check-within (candidate \"MadaM\") #t 0.001)\n    (check-within (candidate \"Wow\") #t 0.001)\n    (check-within (candidate \"\") #f 0.001)\n    (check-within (candidate \"HI\") #t 0.001)\n    (check-within (candidate \"go\") #t 0.001)\n    (check-within (candidate \"gogo\") #f 0.001)\n    (check-within (candidate \"aaaaaaaaaaaaaaa\") #f 0.001)\n    (check-within (candidate \"Madam\") #t 0.001)\n    (check-within (candidate \"M\") #f 0.001)\n    (check-within (candidate \"0\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer n, return the count of the numbers of n-digit\n;; positive integers that start or end with 1.\n(define (starts_one_ends n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate starts_one_ends))\n    (check-within (candidate 1) 1 0.001)\n    (check-within (candidate 2) 18 0.001)\n    (check-within (candidate 3) 180 0.001)\n    (check-within (candidate 4) 1800 0.001)\n    (check-within (candidate 5) 18000 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a positive integer N, return the total sum of its digits in binary.\n;; Example\n;; >>> (solve 1000)\n;; \"1\"\n;; >>> (solve 150)\n;; \"110\"\n;; >>> (solve 147)\n;; \"1100\"\n;; Variables:\n;; @N integer\n;; Constraints: 0 \u2264 N \u2264 10000.\n;; Output:\n;; a string of binary number\n(define (solve N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate solve))\n    (check-within (candidate 1000) \"1\" 0.001)\n    (check-within (candidate 150) \"110\" 0.001)\n    (check-within (candidate 147) \"1100\" 0.001)\n    (check-within (candidate 333) \"1001\" 0.001)\n    (check-within (candidate 963) \"10010\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a non-empty list of integers lst. add the even elements that are at odd indices..\n;; Examples:\n;; >>> (add (list 4 2 6 7))\n;; 2\n(define (add lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add))\n    (check-within (candidate (list 4 88)) 88 0.001)\n    (check-within (candidate (list 4 5 6 7 2 122)) 122 0.001)\n    (check-within (candidate (list 4 0 6 7)) 0 0.001)\n    (check-within (candidate (list 4 4 6 8)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a string and returns an ordered version of it.\n;; Ordered version of string, is a string where all words (separated by space)\n;; are replaced by a new word where all the characters arranged in\n;; ascending order based on ascii value.\n;; Note: You should keep the order of words and blank spaces in the sentence.\n;; For example:\n;; >>> (anti_shuffle \"Hi\")\n;; \"Hi\"\n;; >>> (anti_shuffle \"hello\")\n;; \"ehllo\"\n;; >>> (anti_shuffle \"Hello World!!!\")\n;; \"Hello !!!Wdlor\"\n(define (anti_shuffle s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate anti_shuffle))\n    (check-within (candidate \"Hi\") \"Hi\" 0.001)\n    (check-within (candidate \"hello\") \"ehllo\" 0.001)\n    (check-within (candidate \"number\") \"bemnru\" 0.001)\n    (check-within (candidate \"abcd\") \"abcd\" 0.001)\n    (check-within (candidate \"Hello World!!!\") \"Hello !!!Wdlor\" 0.001)\n    (check-within (candidate \"\") \"\" 0.001)\n    (check-within (candidate \"Hi. My name is Mister Robot. How are you?\") \".Hi My aemn is Meirst .Rboot How aer ?ouy\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a 2 dimensional data, as a nested lists,\n;; which is similar to matrix, however, unlike matrices,\n;; each row may contain a different number of columns.\n;; Given lst, and integer x, find integers x in the list,\n;; and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n;; each tuple is a coordinate - (row, columns), starting with 0.\n;; Sort coordinates initially by rows in ascending order.\n;; Also, sort coordinates of the row by columns in descending order.\n;; Examples:\n;; >>> (get_row (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1)\n;; (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0))\n;; >>> (get_row (list ) 1)\n;; (list )\n;; >>> (get_row (list (list ) (list 1) (list 1 2 3)) 3)\n;; (list (list 2 2))\n(define (get_row lst x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_row))\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 4) (list 1 0) (list 2 5) (list 2 0)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 2 3 4 5 6)) 2) (list (list 0 1) (list 1 1) (list 2 1) (list 3 1) (list 4 1) (list 5 1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5 6) (list 1 2 3 4 5 6) (list 1 1 3 4 5 6) (list 1 2 1 4 5 6) (list 1 2 3 1 5 6) (list 1 2 3 4 1 6) (list 1 2 3 4 5 1)) 1) (list (list 0 0) (list 1 0) (list 2 1) (list 2 0) (list 3 2) (list 3 0) (list 4 3) (list 4 0) (list 5 4) (list 5 0) (list 6 5) (list 6 0)) 0.001)\n    (check-within (candidate (list ) 1) (list ) 0.001)\n    (check-within (candidate (list (list 1)) 2) (list ) 0.001)\n    (check-within (candidate (list (list ) (list 1) (list 1 2 3)) 3) (list (list 2 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given an array of non-negative integers, return a copy of the given array after sorting,\n;; you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n;; or sort it in descending order if the sum( first index value, last index value) is even.\n;; Note:\n;; * don't change the given array.\n;; Examples:\n;; >>> (sort_array (list ))\n;; (list )\n;; >>> (sort_array (list 5))\n;; (list 5)\n;; >>> (sort_array (list 2 4 3 0 1 5))\n;; (list 0 1 2 3 4 5)\n;; >>> (sort_array (list 2 4 3 0 1 5 6))\n;; (list 6 5 4 3 2 1 0)\n(define (sort_array array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_array))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 5)) (list 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5)) (list 0 1 2 3 4 5) 0.001)\n    (check-within (candidate (list 2 4 3 0 1 5 6)) (list 6 5 4 3 2 1 0) 0.001)\n    (check-within (candidate (list 2 1)) (list 1 2) 0.001)\n    (check-within (candidate (list 15 42 87 32 11 0)) (list 0 11 15 32 42 87) 0.001)\n    (check-within (candidate (list 21 14 23 11)) (list 23 21 14 11) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function encrypt that takes a string as an argument and\n;; returns a string encrypted with the alphabet being rotated. \n;; The alphabet should be rotated in a manner such that the letters \n;; shift down by two multiplied to two places.\n;; For example:\n;; >>> (encrypt \"hi\")\n;; \"lm\"\n;; >>> (encrypt \"asdfghjkl\")\n;; \"ewhjklnop\"\n;; >>> (encrypt \"gf\")\n;; \"kj\"\n;; >>> (encrypt \"et\")\n;; \"ix\"\n(define (encrypt s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encrypt))\n    (check-within (candidate \"hi\") \"lm\" 0.001)\n    (check-within (candidate \"asdfghjkl\") \"ewhjklnop\" 0.001)\n    (check-within (candidate \"gf\") \"kj\" 0.001)\n    (check-within (candidate \"et\") \"ix\" 0.001)\n    (check-within (candidate \"faewfawefaewg\") \"jeiajeaijeiak\" 0.001)\n    (check-within (candidate \"hellomyfriend\") \"lippsqcjvmirh\" 0.001)\n    (check-within (candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" 0.001)\n    (check-within (candidate \"a\") \"e\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n;; Empty sum should be equal to 0 and empty product should be equal to 1.\n;; >>> (sum_product (list ))\n;; (list 0 1)\n;; >>> (sum_product (list 1 2 3 4))\n;; (list 10 24)\n(define (sum_product numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_product))\n    (check-within (candidate (list )) (list 0 1) 0.001)\n    (check-within (candidate (list 1 1 1)) (list 3 1) 0.001)\n    (check-within (candidate (list 100 0)) (list 100 0) 0.001)\n    (check-within (candidate (list 3 5 7)) (list 15 105) 0.001)\n    (check-within (candidate (list 10)) (list 10 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; Write a function next_smallest() that returns the 2nd smallest element of the list.\n;; Return None if there is no such element.\n;; >>> (next_smallest (list 1 2 3 4 5))\n;; 2\n;; >>> (next_smallest (list 5 1 4 3 2))\n;; 2\n;; >>> (next_smallest (list ))\n;; #f\n;; >>> (next_smallest (list 1 1))\n;; #f\n(define (next_smallest lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest))\n    (check-within (candidate (list 1 2 3 4 5)) 2 0.001)\n    (check-within (candidate (list 5 1 4 3 2)) 2 0.001)\n    (check-within (candidate (list )) #f 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list 1 1 1 1 0)) 1 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n    (check-within (candidate (list -35 34 12 -45)) -35 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You'll be given a string of words, and your task is to count the number\n;; of boredoms. A boredom is a sentence that starts with the word \"I\".\n;; Sentences are delimited by '.', '?' or '!'.\n;; For example:\n;; >>> (is_bored \"Hello world\")\n;; 0\n;; >>> (is_bored \"The sky is blue. The sun is shining. I love this weather\")\n;; 1\n(define (is_bored S)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_bored))\n    (check-within (candidate \"Hello world\") 0 0.001)\n    (check-within (candidate \"Is the sky blue?\") 0 0.001)\n    (check-within (candidate \"I love It !\") 1 0.001)\n    (check-within (candidate \"bIt\") 0 0.001)\n    (check-within (candidate \"I feel good today. I will be productive. will kill It\") 2 0.001)\n    (check-within (candidate \"You and I are going for a walk\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes 3 numbers.\n;; Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n;; Returns false in any other cases.\n;; Examples\n;; >>> (any_int 5 2 7)\n;; #t\n;; >>> (any_int 3 2 2)\n;; #f\n;; >>> (any_int 3 -2 1)\n;; #t\n;; >>> (any_int 3.6 -2.2 2)\n;; #f\n(define (any_int x y z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate any_int))\n    (check-within (candidate 2 3 1) #t 0.001)\n    (check-within (candidate 2.5 2 3) #f 0.001)\n    (check-within (candidate 1.5 5 3.5) #f 0.001)\n    (check-within (candidate 2 6 2) #f 0.001)\n    (check-within (candidate 4 2 2) #t 0.001)\n    (check-within (candidate 2.2 2.2 2.2) #f 0.001)\n    (check-within (candidate -4 6 2) #t 0.001)\n    (check-within (candidate 2 1 1) #t 0.001)\n    (check-within (candidate 3 4 7) #t 0.001)\n    (check-within (candidate 3.0 4 7) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a message, and encodes in such a \n;; way that it swaps case of all letters, replaces all vowels in \n;; the message with the letter that appears 2 places ahead of that \n;; vowel in the english alphabet. \n;; Assume only letters. \n;; Examples:\n;; >>> (encode \"test\")\n;; \"TGST\"\n;; >>> (encode \"This is a message\")\n;; \"tHKS KS C MGSSCGG\"\n(define (encode message)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate encode))\n    (check-within (candidate \"TEST\") \"tgst\" 0.001)\n    (check-within (candidate \"Mudasir\") \"mWDCSKR\" 0.001)\n    (check-within (candidate \"YES\") \"ygs\" 0.001)\n    (check-within (candidate \"This is a message\") \"tHKS KS C MGSSCGG\" 0.001)\n    (check-within (candidate \"I DoNt KnOw WhAt tO WrItE\") \"k dQnT kNqW wHcT Tq wRkTg\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; You are given a list of integers.\n;; You need to find the largest prime value and return the sum of its digits.\n;; Examples:\n;; >>> (skjkasdkd (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3))\n;; 10\n;; >>> (skjkasdkd (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1))\n;; 25\n;; >>> (skjkasdkd (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3))\n;; 13\n;; >>> (skjkasdkd (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6))\n;; 11\n;; >>> (skjkasdkd (list 0 81 12 3 1 21))\n;; 3\n;; >>> (skjkasdkd (list 0 8 1 2 1 7))\n;; 7\n(define (skjkasdkd lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate skjkasdkd))\n    (check-within (candidate (list 0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3)) 10 0.001)\n    (check-within (candidate (list 1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1)) 25 0.001)\n    (check-within (candidate (list 1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3)) 13 0.001)\n    (check-within (candidate (list 0 724 32 71 99 32 6 0 5 91 83 0 5 6)) 11 0.001)\n    (check-within (candidate (list 0 81 12 3 1 21)) 3 0.001)\n    (check-within (candidate (list 0 8 1 2 1 7)) 7 0.001)\n    (check-within (candidate (list 8191)) 19 0.001)\n    (check-within (candidate (list 8191 123456 127 7)) 19 0.001)\n    (check-within (candidate (list 127 97 8192)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a dictionary, return True if all keys are strings in lower \n;; case or all keys are strings in upper case, else return False.\n;; The function should return False is the given dictionary is empty.\n;; Examples:\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"b\" .  \"banana\")))\n;; #t\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\")))\n;; #f\n;; >>> (check_dict_case #hash((\"a\" .  \"apple\") (8 .  \"banana\") (\"a\" .  \"apple\")))\n;; #f\n;; >>> (check_dict_case #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\")))\n;; #f\n;; >>> (check_dict_case #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\")))\n;; #t\n(define (check_dict_case dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_dict_case))\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"b\" .  \"banana\"))) #t 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"A\" .  \"banana\") (\"B\" .  \"banana\"))) #f 0.001)\n    (check-within (candidate #hash((\"p\" .  \"pineapple\") (\"5\" .  \"banana\") (\"a\" .  \"apple\"))) #f 0.001)\n    (check-within (candidate #hash((\"Name\" .  \"John\") (\"Age\" .  \"36\") (\"City\" .  \"Houston\"))) #f 0.001)\n    (check-within (candidate #hash((\"STATE\" .  \"NC\") (\"ZIP\" .  \"12345\"))) #t 0.001)\n    (check-within (candidate #hash((\"fruit\" .  \"Orange\") (\"taste\" .  \"Sweet\"))) #t 0.001)\n    (check-within (candidate #hash()) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Implement a function that takes an non-negative integer and returns an array of the first n\n;; integers that are prime numbers and less than n.\n;; for example:\n;; >>> (count_up_to 5)\n;; (list 2 3)\n;; >>> (count_up_to 11)\n;; (list 2 3 5 7)\n;; >>> (count_up_to 0)\n;; (list )\n;; >>> (count_up_to 20)\n;; (list 2 3 5 7 11 13 17 19)\n;; >>> (count_up_to 1)\n;; (list )\n;; >>> (count_up_to 18)\n;; (list 2 3 5 7 11 13 17)\n(define (count_up_to n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_up_to))\n    (check-within (candidate 5) (list 2 3) 0.001)\n    (check-within (candidate 6) (list 2 3 5) 0.001)\n    (check-within (candidate 7) (list 2 3 5) 0.001)\n    (check-within (candidate 10) (list 2 3 5 7) 0.001)\n    (check-within (candidate 0) (list ) 0.001)\n    (check-within (candidate 22) (list 2 3 5 7 11 13 17 19) 0.001)\n    (check-within (candidate 1) (list ) 0.001)\n    (check-within (candidate 18) (list 2 3 5 7 11 13 17) 0.001)\n    (check-within (candidate 47) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43) 0.001)\n    (check-within (candidate 101) (list 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Complete the function that takes two integers and returns \n;; the product of their unit digits.\n;; Assume the input is always valid.\n;; Examples:\n;; >>> (multiply 148 412)\n;; 16\n;; >>> (multiply 19 28)\n;; 72\n;; >>> (multiply 2020 1851)\n;; 0\n;; >>> (multiply 14 -15)\n;; 20\n(define (multiply a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply))\n    (check-within (candidate 148 412) 16 0.001)\n    (check-within (candidate 19 28) 72 0.001)\n    (check-within (candidate 2020 1851) 0 0.001)\n    (check-within (candidate 14 -15) 20 0.001)\n    (check-within (candidate 76 67) 42 0.001)\n    (check-within (candidate 17 27) 49 0.001)\n    (check-within (candidate 0 1) 0 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a string s, count the number of uppercase vowels in even indices.\n;; For example:\n;; >>> (count_upper \"aBCdEf\")\n;; 1\n;; >>> (count_upper \"abcdefg\")\n;; 0\n;; >>> (count_upper \"dBBE\")\n;; 0\n(define (count_upper s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_upper))\n    (check-within (candidate \"aBCdEf\") 1 0.001)\n    (check-within (candidate \"abcdefg\") 0 0.001)\n    (check-within (candidate \"dBBE\") 0 0.001)\n    (check-within (candidate \"B\") 0 0.001)\n    (check-within (candidate \"U\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n    (check-within (candidate \"EEEE\") 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Create a function that takes a value (string) representing a number\n;; and returns the closest integer to it. If the number is equidistant\n;; from two integers, round it away from zero.\n;; Examples\n;; >>> (closest_integer \"10\")\n;; 10\n;; >>> (closest_integer \"15.3\")\n;; 15\n;; Note:\n;; Rounding away from zero means that if the given number is equidistant\n;; from two integers, the one you should return is the one that is the\n;; farthest from zero. For example closest_integer(\"14.5\") should\n;; return 15 and closest_integer(\"-14.5\") should return -15.\n(define (closest_integer value)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_integer))\n    (check-within (candidate \"10\") 10 0.001)\n    (check-within (candidate \"14.5\") 15 0.001)\n    (check-within (candidate \"-15.5\") -16 0.001)\n    (check-within (candidate \"15.3\") 15 0.001)\n    (check-within (candidate \"0\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; From a given list of integers, generate a list of rolling maximum element found until given moment\n;; in the sequence.\n;; >>> (rolling_max (list 1 2 3 2 3 4 2))\n;; (list 1 2 3 3 3 4 4)\n(define (rolling_max numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rolling_max))\n    (check-within (candidate (list )) (list ) 0.001)\n    (check-within (candidate (list 1 2 3 4)) (list 1 2 3 4) 0.001)\n    (check-within (candidate (list 4 3 2 1)) (list 4 4 4 4) 0.001)\n    (check-within (candidate (list 3 2 3 100 3)) (list 3 3 3 100 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/humaneval-rs-keep.json
+++ b/prompts/humaneval-rs-keep.json
@@ -1,984 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "rs",
-    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// iscube(1) ==> True\n/// iscube(2) ==> False\n/// iscube(-1) ==> True\n/// iscube(64) ==> True\n/// iscube(0) ==> True\n/// iscube(180) ==> False\nfn iscube(a: isize) -> bool {\n",
+    "prompt": "/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n/// False\n/// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// True\nfn has_close_elements(numbers: Vec<f64>, threshold: f64) -> bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode('test')\n/// 'TGST'\n/// >>> encode('This is a message')\n/// 'tHKS KS C MGSSCGG'\nfn encode(message: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rs",
-    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n/// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// solution([5, 8, 7, 1]) ==> 12\n/// solution([3, 3, 3, 3, 3]) ==> 9\n/// solution([30, 13, 24, 321]) ==>0\nfn solution(lst: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rs",
-    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "rs",
-    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// '0'\n/// >>> string_sequence(5)\n/// '0 1 2 3 4 5'\nfn string_sequence(n: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "rs",
-    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n/// minSubArraySum([-1, -2, -3]) == -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rs",
-    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(\"Hello world\")\n/// 0\n/// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfn is_bored(S: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rs",
-    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "rs",
-    "prompt": "/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold([1, 2, 4, 10], 100)\n/// True\n/// >>> below_threshold([1, 20, 4, 10], 5)\n/// False\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rs",
-    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// any_int(5, 2, 7) \u279e True\n/// any_int(3, 2, 2) \u279e False\n/// any_int(3, -2, 1) \u279e True\n/// any_int(3.6, -2.2, 2) \u279e False\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rs",
-    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// for x_or_y(7, 34, 12) == 34\n/// for x_or_y(15, 8, 5) == 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rs",
-    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// move_one_ball([3, 4, 5, 1, 2])==>True\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// move_one_ball([3, 5, 4, 1, 2])==>False\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "rs",
-    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(\"10\")\n/// 10\n/// >>> closest_integer(\"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> triples_sum_to_zero([1, 3, -2, 1])\n/// True\n/// >>> triples_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n/// True\n/// >>> triples_sum_to_zero([1])\n/// False\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rs",
-    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// will_it_fly([1, 2], 5) \u279e False \n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// will_it_fly([3, 2, 3], 1) \u279e False\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// will_it_fly([3, 2, 3], 9) \u279e True\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// will_it_fly([3], 5) \u279e True\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// is_happy(a) => False\n/// is_happy(aa) => False\n/// is_happy(abcd) => True\n/// is_happy(aabb) => False\n/// is_happy(adb) => True\n/// is_happy(xyy) => False\nfn is_happy(s: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rs",
-    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// file_name_check(\"example.txt\") # => 'Yes'\n/// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfn file_name_check(file_name: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n/// histogram('a b b a') == {'a': 2, 'b': 2}\n/// histogram('a b c a b') == {'a': 2, 'b': 2}\n/// histogram('b b b b a') == {'b': 4}\n/// histogram('') == {}\nfn histogram(test: String) -> HashMap<String, isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rs",
-    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n/// largest_smallest_integers([]) == (None, None)\n/// largest_smallest_integers([0]) == (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rs",
-    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// simplify(\"1/5\", \"5/1\") = True\n/// simplify(\"1/6\", \"2/1\") = False\n/// simplify(\"7/10\", \"10/2\") = False\nfn simplify(x: String, n: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rs",
-    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Input: n = 5\n/// Output: 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "rs",
-    "prompt": "/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n/// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n/// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfn reverse_delete(s: String, c: String) -> (String, bool) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_delete;\n    assert_eq!(candidate(String::from(\"abcde\"), String::from(\"ae\")), (String::from(\"bcd\"), false));\n    assert_eq!(candidate(String::from(\"abcdef\"), String::from(\"b\")), (String::from(\"acdef\"), false));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"ab\")), (String::from(\"cdedc\"), true));\n    assert_eq!(candidate(String::from(\"dwik\"), String::from(\"w\")), (String::from(\"dik\"), false));\n    assert_eq!(candidate(String::from(\"a\"), String::from(\"a\")), (String::from(\"\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"v\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"vabba\"), String::from(\"v\")), (String::from(\"abba\"), true));\n    assert_eq!(candidate(String::from(\"mamma\"), String::from(\"mia\")), (String::from(\"\"), true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rs",
-    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product([])\n/// (0, 1)\n/// >>> sum_product([1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n/// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n/// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n/// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n/// For lst = [0,81,12,3,1,21] the output should be 3\n/// For lst = [0,8,1,2,1,7] the output should be 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rs",
-    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes('abc')\n/// ['a', 'ab', 'abc']\nfn all_prefixes(string: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// digits(1)  == 1\n/// digits(4)  == 0\n/// digits(235) == 15\nfn digits(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "rs",
-    "prompt": "/// Return length of given string\n/// >>> strlen('')\n/// 0\n/// >>> strlen('abc')\n/// 3\nfn strlen(string: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rs",
-    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Input: [4,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Input: [1,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n/// Example 3:\n/// Input: []\n/// Output: []\n/// Example 4:\n/// Input: [5, 0, 3, 0, 4, 2]\n/// Output: [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "rs",
-    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// is_multiply_prime(30) == True\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rs",
-    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rs",
-    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfn words_string(s: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "rs",
-    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic([1, 2, 4, 20])\n/// True\n/// >>> monotonic([1, 20, 4, 10])\n/// False\n/// >>> monotonic([4, 1, 0, -10])\n/// True\nfn monotonic(l: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rs",
-    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// fix_spaces(\"Example\") == \"Example\"\n/// fix_spaces(\"Example 1\") == \"Example_1\"\n/// fix_spaces(\" Example 2\") == \"_Example_2\"\n/// fix_spaces(\" Example   3\") == \"_Example-3\"\nfn fix_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "rs",
-    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// cycpattern_check(\"abcd\",\"abd\") => False\n/// cycpattern_check(\"hello\",\"ell\") => True\n/// cycpattern_check(\"whassup\",\"psus\") => False\n/// cycpattern_check(\"abab\",\"baa\") => True\n/// cycpattern_check(\"efef\",\"eeff\") => False\n/// cycpattern_check(\"himenss\",\"simen\") => True\nfn cycpattern_check(a: String, b: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n/// double_the_difference([-1, -2, 0]) == 0\n/// double_the_difference([9, -2]) == 81\n/// double_the_difference([0]) == 0  \n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rs",
-    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rs",
-    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels('')\n/// ''\n/// >>> remove_vowels('abcdef')\n/// 'bcdf'\n/// >>> remove_vowels('aaaaa')\n/// ''\n/// >>> remove_vowels('aaBAA')\n/// 'B'\n/// >>> remove_vowels('zbcd')\n/// 'zbcd'\nfn remove_vowels(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "rs",
-    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rs",
-    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rs",
-    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// count_up_to(5) => [2,3]\n/// count_up_to(11) => [2,3,5,7]\n/// count_up_to(0) => []\n/// count_up_to(20) => [2,3,5,7,11,13,17,19]\n/// count_up_to(1) => []\n/// count_up_to(18) => [2,3,5,7,11,13,17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rs",
-    "prompt": "/// Return maximum element in the list.\n/// >>> max_element([1, 2, 3])\n/// 3\n/// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n/// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// total_match([], []) \u279e []\n/// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n/// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n/// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n/// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// triangle_area(3, 4, 5) == 6.00\n/// triangle_area(1, 2, 10) == -1\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rs",
-    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n/// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n/// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n/// check_if_last_char_is_a_letter(\"\") \u279e False\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rs",
-    "prompt": "/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rs",
-    "prompt": "/// Return sorted unique elements in a list\n/// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// smallest_change([1,2,3,5,4,7,9,6]) == 4\n/// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n/// smallest_change([1, 2, 3, 2, 1]) == 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rs",
-    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits([15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits([152, 323, 1422, 10])\n/// []\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rs",
-    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// f(5) == [1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// next_smallest([1, 2, 3, 4, 5]) == 2\n/// next_smallest([5, 1, 4, 3, 2]) == 2\n/// next_smallest([]) == None\n/// next_smallest([1, 1]) == None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rs",
-    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\n/// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n/// Output: [1, 2, 1]\n/// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n/// Output: [1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Input: arr = [-3, -4, 5], k = 3\n/// Output: [-4, -3, 5]\n/// Example 2:\n/// Input: arr = [4, -4, 4], k = 2\n/// Output: [4, 4]\n/// Example 3:\n/// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n/// Output: [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rs",
-    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// match_parens(['()(', ')']) == 'Yes'\n/// match_parens([')', ')']) == 'No'\nfn match_parens(lst: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rs",
-    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// is_equal_to_sum_even(4) == False\n/// is_equal_to_sum_even(6) == False\n/// is_equal_to_sum_even(8) == True\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rs",
-    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rs",
-    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rs",
-    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// encrypt('hi') returns 'lm'\n/// encrypt('asdfghjkl') returns 'ewhjklnop'\n/// encrypt('gf') returns 'kj'\n/// encrypt('et') returns 'ix'\nfn encrypt(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rs",
-    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times('', 'a')\n/// 0\n/// >>> how_many_times('aaa', 'a')\n/// 3\n/// >>> how_many_times('aaaa', 'aa')\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rs",
-    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n/// Output: 24 # sum of 21 + 3\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "rs",
-    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse([], 4)\n/// []\n/// >>> intersperse([1, 2, 3], 4)\n/// [1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// solve(\"1234\") = \"4321\"\n/// solve(\"ab\") = \"AB\"\n/// solve(\"#a@C\") = \"#A@c\"\nfn solve(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "rs",
-    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even([5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfn sort_even(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_even;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![1, 2, 3]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]), vec![-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n    assert_eq!(candidate(vec![5, 8, -12, 4, 23, 2, 3, 11, 12, -10]), vec![-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "rs",
-    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero([1, 2, 3])\n/// False\n/// >>> below_zero([1, 2, -4, 5])\n/// True\nfn below_zero(operations: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "rs",
-    "prompt": "/// Check if two words have the same characters.\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n/// True\n/// >>> same_chars('abcd', 'dddddddabc')\n/// True\n/// >>> same_chars('dddddddabc', 'abcd')\n/// True\n/// >>> same_chars('eabcd', 'dddddddabc')\n/// False\n/// >>> same_chars('abcd', 'dddddddabce')\n/// False\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n/// False\nfn same_chars(s0: String, s1: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = same_chars;\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\")), true);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabc\")), true);\n    assert_eq!(candidate(String::from(\"dddddddabc\"), String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"eabcd\"), String::from(\"dddddddabc\")), false);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabcf\")), false);\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\")), false);\n    assert_eq!(candidate(String::from(\"aabb\"), String::from(\"aaccc\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups('( ) (( )) (( )( ))')\n/// ['()', '(())', '(()())']\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rs",
-    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// count_upper('aBCdEf') returns 1\n/// count_upper('abcdefg') returns 0\n/// count_upper('dBBE') returns 0\nfn count_upper(s: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "rs",
-    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "rs",
-    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates([1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rs",
-    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n/// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n/// select_words(\"simple white space\", 2) ==> []\n/// select_words(\"Hello world\", 4) ==> [\"world\"]\n/// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n/// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n/// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfn find_max(words: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rs",
-    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Input: \n/// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n/// bucket_capacity : 1\n/// Output: 6\n/// Example 2:\n/// Input: \n/// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n/// bucket_capacity : 2\n/// Output: 5\n/// Example 3:\n/// Input: \n/// grid : [[0,0,0], [0,0,0]]\n/// bucket_capacity : 5\n/// Output: 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rs",
-    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// For lst = [1,2,3] the output should be 6\n/// For lst = []  the output should be 0\n/// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// add([4, 2, 6, 7]) ==> 2\nfn add(lst: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rs",
-    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// multiply(148, 412) should return 16.\n/// multiply(19, 28) should return 72.\n/// multiply(2020, 1851) should return 0.\n/// multiply(14,-15) should return 20.\nfn multiply(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rs",
-    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// intersection((1, 2), (2, 3)) ==> \"NO\"\n/// intersection((-1, 1), (0, 4)) ==> \"NO\"\n/// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rs",
-    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// tri(3) = [1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rs",
-    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// is_simple_power(1, 4) => true\n/// is_simple_power(2, 2) => true\n/// is_simple_power(8, 2) => true\n/// is_simple_power(3, 2) => false\n/// is_simple_power(3, 1) => false\n/// is_simple_power(5, 3) => false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = has_close_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.95), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.8), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 1.0), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 0.5), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -988,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(3)\n/// [3, 5, 7]\nfn make_a_pile(n: isize) -> Vec<isize> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = make_a_pile;\n    assert_eq!(candidate(3), vec![3, 5, 7]);\n    assert_eq!(candidate(4), vec![4, 6, 8, 10]);\n    assert_eq!(candidate(5), vec![5, 7, 9, 11, 13]);\n    assert_eq!(candidate(6), vec![6, 8, 10, 12, 14, 16]);\n    assert_eq!(candidate(8), vec![8, 10, 12, 14, 16, 18, 20, 22]);\n}\n",
     "stop_tokens": [
@@ -996,829 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "rs",
-    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
+    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfn words_string(s: String) -> Vec<String> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix([], 'a')\n/// []\n/// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n/// ['abc', 'array']\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// decimal_to_binary(15)   # returns \"db1111db\"\n/// decimal_to_binary(32)   # returns \"db100000db\"\nfn decimal_to_binary(decimal: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rs",
-    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome('')\n/// True\n/// >>> is_palindrome('aba')\n/// True\n/// >>> is_palindrome('aaaaa')\n/// True\n/// >>> is_palindrome('zbcd')\n/// False\nfn is_palindrome(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "rs",
-    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rs",
-    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// [2, 2, 2]\n/// >>> factorize(25)\n/// [5, 5]\n/// >>> factorize(70)\n/// [2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rs",
-    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// \"21\"\n/// >>> circular_shift(12, 2)\n/// \"12\"\nfn circular_shift(x: isize, shift: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rs",
-    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// get_closest_vowel(\"yogurt\") ==> \"u\"\n/// get_closest_vowel(\"FULL\") ==> \"U\"\n/// get_closest_vowel(\"quick\") ==> \"\"\n/// get_closest_vowel(\"ab\") ==> \"\"\nfn get_closest_vowel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rs",
-    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rs",
-    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers('three one five')\n/// 'one three five'\nfn sort_numbers(numbers: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rs",
-    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case('Hello')\n/// 'hELLO'\nfn flip_case(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rs",
-    "prompt": "/// Return sorted unique common elements for two lists.\n/// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common([5, 3, 2, 8], [3, 2])\n/// [2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rs",
-    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// can_arrange([1,2,4,3,5]) = 3\n/// can_arrange([1,2,3]) = -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rs",
-    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// is_nested('[[]]') \u279e True\n/// is_nested('[]]]]]]][[[[[]') \u279e False\n/// is_nested('[][]') \u279e False\n/// is_nested('[]') \u279e False\n/// is_nested('[[][]]') \u279e True\n/// is_nested('[[]][[') \u279e True\nfn is_nested(string: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rs",
-    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n/// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n/// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n/// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// arr = []\n/// return []\n/// If the array has any strange number ignore it:\n/// arr = [1, -1 , 55] \n/// -> sort arr -> [-1, 1, 55]\n/// -> reverse arr -> [55, 1, -1]\n/// return = ['One']\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rs",
-    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "rs",
-    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rs",
-    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(['1234567'])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(['3',\"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n/// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "rs",
-    "prompt": "/// Concatenate list of strings into a single string\n/// >>> concatenate([])\n/// ''\n/// >>> concatenate(['a', 'b', 'c'])\n/// 'abc'\nfn concatenate(strings: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rs",
-    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// For lst = [1,2,3] the output should be 14\n/// For lst = [1,4,9] the output should be 98\n/// For lst = [1,3,5,7] the output should be 84\n/// For lst = [1.4,4.2,0] the output should be 29\n/// For lst = [-2.4,1,1] the output should be 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "rs",
-    "prompt": "/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n/// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n/// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfn sort_array(arr: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(vec![1, 5, 2, 3, 4]), vec![1, 2, 4, 3, 5]);\n    assert_eq!(candidate(vec![-2, -3, -4, -5, -6]), vec![-4, -2, -6, -5, -3]);\n    assert_eq!(candidate(vec![1, 0, 2, 3, 4]), vec![0, 1, 2, 4, 3]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]), vec![2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n    assert_eq!(candidate(vec![3, 6, 44, 12, 32, 5]), vec![32, 3, 5, 6, 12, 44]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "rs",
-    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest([])\n/// >>> longest(['a', 'b', 'c'])\n/// 'a'\n/// >>> longest(['a', 'bb', 'ccc'])\n/// 'ccc'\nfn longest(strings: Vec<String>) -> Option<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// is_sorted([5]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5]) \u279e False\n/// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n/// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n/// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rs",
-    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// even_odd_count(-12) ==> (1, 1)\n/// even_odd_count(123) ==> (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rs",
-    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative([3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative([1, 2, 3])\n/// [2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// anti_shuffle('Hi') returns 'Hi'\n/// anti_shuffle('hello') returns 'ehllo'\n/// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfn anti_shuffle(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rs",
-    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Input: sentence = \"This is a test\"\n/// Output: \"is\"\n/// Example 2:\n/// Input: sentence = \"lets go for swimming\"\n/// Output: \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rs",
-    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome('')\n/// ''\n/// >>> make_palindrome('cat')\n/// 'catac'\n/// >>> make_palindrome('cata')\n/// 'catac'\nfn make_palindrome(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rs",
-    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// * eat(5, 6, 10) -> [11, 4]\n/// * eat(4, 8, 9) -> [12, 1]\n/// * eat(1, 10, 10) -> [11, 0]\n/// * eat(2, 11, 5) -> [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "rs",
-    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// '22'\n/// >>> change_base(8, 2)\n/// '1000'\n/// >>> change_base(7, 2)\n/// '111'\nfn change_base(x: isize, base: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// prime_length('Hello') == True\n/// prime_length('abcdcba') == True\n/// prime_length('kittens') == True\n/// prime_length('orange') == False\nfn prime_length(string: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "rs",
-    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "rs",
-    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// search([4, 1, 2, 2, 3, 1]) == 2\n/// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n/// search([5, 5, 4, 4, 4]) == -1\nfn search(lst: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// right_angle_triangle(3, 4, 5) == True\n/// right_angle_triangle(1, 2, 3) == False\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rs",
-    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Input: 3\n/// Output: (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Input: 12\n/// Output: (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n/// [2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rs",
-    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n/// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rs",
-    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// * sort_array([]) => []\n/// * sort_array([5]) => [5]\n/// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n/// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rs",
-    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// get_row([\n/// [1,2,3,4,5,6],\n/// [1,2,3,4,1,6],\n/// [1,2,3,4,5,1]\n/// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// get_row([], 1) == []\n/// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "rs",
-    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(\"abcde\")\n/// 2\n/// >>> vowels_count(\"ACEDY\")\n/// 3\nfn vowels_count(s: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "rs",
-    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfn string_to_md5(text: String) -> Option<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rs",
-    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// False\n/// >>> is_prime(101)\n/// True\n/// >>> is_prime(11)\n/// True\n/// >>> is_prime(13441)\n/// True\n/// >>> is_prime(61)\n/// True\n/// >>> is_prime(4)\n/// False\n/// >>> is_prime(1)\n/// False\nfn is_prime(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rs",
-    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// For num = \"AB\" the output should be 1.\n/// For num = \"1077E\" the output should be 2.\n/// For num = \"ABED1A33\" the output should be 4.\n/// For num = \"123456789ABCDEF0\" the output should be 6.\n/// For num = \"2020\" the output should be 2.\nfn hex_key(num: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rs",
-    "prompt": "/// Return median of elements in the list l.\n/// >>> median([3, 1, 2, 4, 5])\n/// 3\n/// >>> median([-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "rs",
-    "prompt": "/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// specialFilter([15, -73, 14, -15]) => 1 \n/// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfn specialFilter(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = specialFilter;\n    assert_eq!(candidate(vec![5, -2, 1, -5]), 0);\n    assert_eq!(candidate(vec![15, -73, 14, -15]), 1);\n    assert_eq!(candidate(vec![33, -2, -3, 45, 21, 109]), 2);\n    assert_eq!(candidate(vec![43, -12, 93, 125, 121, 109]), 4);\n    assert_eq!(candidate(vec![71, -2, -33, 75, 21, 19]), 3);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rs",
-    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> pairs_sum_to_zero([1, 3, -2, 1])\n/// False\n/// >>> pairs_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n/// True\n/// >>> pairs_sum_to_zero([1])\n/// False\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rs",
-    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n/// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n/// strange_sort_list([]) == []\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rs",
-    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n/// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n/// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n/// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n/// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rs",
-    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// for example: \n/// valid_date('03-11-2000') => True\n/// valid_date('15-01-2012') => False\n/// valid_date('04-0-2040') => False\n/// valid_date('06-04-2020') => True\n/// valid_date('06/04/2020') => False\nfn valid_date(date: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rs",
-    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums([]) == 0\n/// >>> count_nums([-1, 11, -11]) == 1\n/// >>> count_nums([1, 1, 2]) == 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rs",
-    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// digitSum(\"\") => 0\n/// digitSum(\"abAB\") => 131\n/// digitSum(\"abcCd\") => 67\n/// digitSum(\"helloE\") => 69\n/// digitSum(\"woArBld\") => 131\n/// digitSum(\"aAaaaXa\") => 153\nfn digitSum(s: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rs",
-    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n/// >>> order_by_points([]) == []\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rs",
-    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rs",
-    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor('010', '110')\n/// '100'\nfn string_xor(a: String, b: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "rs",
-    "prompt": "/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n/// False\n/// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// True\nfn has_close_elements(numbers: Vec<f64>, threshold: f64) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = has_close_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.95), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.8), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 1.0), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 0.5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rs",
-    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n/// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n/// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n/// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rs",
-    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rs",
-    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19) == 'xix'\n/// >>> int_to_mini_roman(152) == 'clii'\n/// >>> int_to_mini_roman(426) == 'cdxxvi'\nfn int_to_mini_roman(number: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "rs",
-    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"(\")\n/// False\n/// >>> correct_bracketing(\"()\")\n/// True\n/// >>> correct_bracketing(\"(()())\")\n/// True\n/// >>> correct_bracketing(\")(()\")\n/// False\nfn correct_bracketing(brackets: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "rs",
-    "prompt": "/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"<\")\n/// False\n/// >>> correct_bracketing(\"<>\")\n/// True\n/// >>> correct_bracketing(\"<<><>>\")\n/// True\n/// >>> correct_bracketing(\"><<>\")\n/// False\nfn correct_bracketing(brackets: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"<>\")), true);\n    assert_eq!(candidate(String::from(\"<<><>>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<><>><>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<<><><>><>><<><><<>>>\")), true);\n    assert_eq!(candidate(String::from(\"<<<><>>>>\")), false);\n    assert_eq!(candidate(String::from(\"><<>\")), false);\n    assert_eq!(candidate(String::from(\"<\")), false);\n    assert_eq!(candidate(String::from(\"<<<<\")), false);\n    assert_eq!(candidate(String::from(\">\")), false);\n    assert_eq!(candidate(String::from(\"<<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>><<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>>><>\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rs",
-    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "rs",
-    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs([1, 2, 2, -4]) == -9\n/// >>> prod_signs([0, 1]) == 0\n/// >>> prod_signs([]) == None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring([], 'a')\n/// []\n/// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n/// ['abc', 'bacd', 'array']\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rs",
-    "prompt": "/// Return list with elements incremented by 1.\n/// >>> incr_list([1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "rs",
-    "prompt": "/// Return only positive numbers in the list.\n/// >>> get_positive([-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1828,7 +40,7 @@
     "language": "rs",
     "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// choose_num(12, 15) = 14\n/// choose_num(13, 12) = -1\nfn choose_num(x: isize, y: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
     "stop_tokens": [
@@ -1836,13 +48,745 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_104_unique_digits",
     "language": "rs",
-    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n/// For N = 150, the sum of digits will be 6 the output should be \"110\".\n/// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
+    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits([15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits([152, 323, 1422, 10])\n/// []\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "rs",
+    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n/// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n/// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n/// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// arr = []\n/// return []\n/// If the array has any strange number ignore it:\n/// arr = [1, -1 , 55] \n/// -> sort arr -> [-1, 1, 55]\n/// -> reverse arr -> [55, 1, -1]\n/// return = ['One']\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "rs",
+    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// f(5) == [1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Input: 3\n/// Output: (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Input: 12\n/// Output: (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "rs",
+    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums([]) == 0\n/// >>> count_nums([-1, 11, -11]) == 1\n/// >>> count_nums([1, 1, 2]) == 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "rs",
+    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// move_one_ball([3, 4, 5, 1, 2])==>True\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// move_one_ball([3, 5, 4, 1, 2])==>False\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "rs",
+    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome('')\n/// ''\n/// >>> make_palindrome('cat')\n/// 'catac'\n/// >>> make_palindrome('cata')\n/// 'catac'\nfn make_palindrome(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "rs",
+    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n/// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n/// histogram('a b b a') == {'a': 2, 'b': 2}\n/// histogram('a b c a b') == {'a': 2, 'b': 2}\n/// histogram('b b b b a') == {'b': 4}\n/// histogram('') == {}\nfn histogram(test: String) -> HashMap<String, isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "rs",
+    "prompt": "/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n/// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n/// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfn reverse_delete(s: String, c: String) -> (String, bool) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_delete;\n    assert_eq!(candidate(String::from(\"abcde\"), String::from(\"ae\")), (String::from(\"bcd\"), false));\n    assert_eq!(candidate(String::from(\"abcdef\"), String::from(\"b\")), (String::from(\"acdef\"), false));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"ab\")), (String::from(\"cdedc\"), true));\n    assert_eq!(candidate(String::from(\"dwik\"), String::from(\"w\")), (String::from(\"dik\"), false));\n    assert_eq!(candidate(String::from(\"a\"), String::from(\"a\")), (String::from(\"\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"v\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"vabba\"), String::from(\"v\")), (String::from(\"abba\"), true));\n    assert_eq!(candidate(String::from(\"mamma\"), String::from(\"mia\")), (String::from(\"\"), true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "rs",
+    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(['1234567'])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(['3',\"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n/// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rs",
+    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n/// minSubArraySum([-1, -2, -3]) == -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rs",
+    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Input: \n/// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n/// bucket_capacity : 1\n/// Output: 6\n/// Example 2:\n/// Input: \n/// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n/// bucket_capacity : 2\n/// Output: 5\n/// Example 3:\n/// Input: \n/// grid : [[0,0,0], [0,0,0]]\n/// bucket_capacity : 5\n/// Output: 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "rs",
+    "prompt": "/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n/// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n/// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfn sort_array(arr: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(vec![1, 5, 2, 3, 4]), vec![1, 2, 4, 3, 5]);\n    assert_eq!(candidate(vec![-2, -3, -4, -5, -6]), vec![-4, -2, -6, -5, -3]);\n    assert_eq!(candidate(vec![1, 0, 2, 3, 4]), vec![0, 1, 2, 4, 3]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]), vec![2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n    assert_eq!(candidate(vec![3, 6, 44, 12, 32, 5]), vec![32, 3, 5, 6, 12, 44]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "rs",
+    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n/// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n/// select_words(\"simple white space\", 2) ==> []\n/// select_words(\"Hello world\", 4) ==> [\"world\"]\n/// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "rs",
+    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// get_closest_vowel(\"yogurt\") ==> \"u\"\n/// get_closest_vowel(\"FULL\") ==> \"U\"\n/// get_closest_vowel(\"quick\") ==> \"\"\n/// get_closest_vowel(\"ab\") ==> \"\"\nfn get_closest_vowel(word: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "rs",
+    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// match_parens(['()(', ')']) == 'Yes'\n/// match_parens([')', ')']) == 'No'\nfn match_parens(lst: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "rs",
+    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor('010', '110')\n/// '100'\nfn string_xor(a: String, b: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "rs",
+    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Input: arr = [-3, -4, 5], k = 3\n/// Output: [-4, -3, 5]\n/// Example 2:\n/// Input: arr = [4, -4, 4], k = 2\n/// Output: [4, 4]\n/// Example 3:\n/// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n/// Output: [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "rs",
+    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// solution([5, 8, 7, 1]) ==> 12\n/// solution([3, 3, 3, 3, 3]) ==> 9\n/// solution([30, 13, 24, 321]) ==>0\nfn solution(lst: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "rs",
+    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n/// Output: 24 # sum of 21 + 3\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "rs",
+    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// for example: \n/// valid_date('03-11-2000') => True\n/// valid_date('15-01-2012') => False\n/// valid_date('04-0-2040') => False\n/// valid_date('06-04-2020') => True\n/// valid_date('06/04/2020') => False\nfn valid_date(date: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "rs",
+    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// is_sorted([5]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5]) \u279e False\n/// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n/// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n/// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "rs",
+    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// intersection((1, 2), (2, 3)) ==> \"NO\"\n/// intersection((-1, 1), (0, 4)) ==> \"NO\"\n/// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rs",
+    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs([1, 2, 2, -4]) == -9\n/// >>> prod_signs([0, 1]) == 0\n/// >>> prod_signs([]) == None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rs",
+    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\n/// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n/// Output: [1, 2, 1]\n/// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n/// Output: [1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rs",
+    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest([])\n/// >>> longest(['a', 'b', 'c'])\n/// 'a'\n/// >>> longest(['a', 'bb', 'ccc'])\n/// 'ccc'\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rs",
+    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// tri(3) = [1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// digits(1)  == 1\n/// digits(4)  == 0\n/// digits(235) == 15\nfn digits(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// is_nested('[[]]') \u279e True\n/// is_nested('[]]]]]]][[[[[]') \u279e False\n/// is_nested('[][]') \u279e False\n/// is_nested('[]') \u279e False\n/// is_nested('[[][]]') \u279e True\n/// is_nested('[[]][[') \u279e True\nfn is_nested(string: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rs",
+    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// For lst = [1,2,3] the output should be 14\n/// For lst = [1,4,9] the output should be 98\n/// For lst = [1,3,5,7] the output should be 84\n/// For lst = [1.4,4.2,0] the output should be 29\n/// For lst = [-2.4,1,1] the output should be 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rs",
+    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n/// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n/// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n/// check_if_last_char_is_a_letter(\"\") \u279e False\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rs",
+    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// can_arrange([1,2,4,3,5]) = 3\n/// can_arrange([1,2,3]) = -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rs",
+    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n/// largest_smallest_integers([]) == (None, None)\n/// largest_smallest_integers([0]) == (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rs",
+    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// is_equal_to_sum_even(4) == False\n/// is_equal_to_sum_even(6) == False\n/// is_equal_to_sum_even(8) == True\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rs",
+    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rs",
+    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rs",
+    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// fix_spaces(\"Example\") == \"Example\"\n/// fix_spaces(\"Example 1\") == \"Example_1\"\n/// fix_spaces(\" Example 2\") == \"_Example_2\"\n/// fix_spaces(\" Example   3\") == \"_Example-3\"\nfn fix_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rs",
+    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// file_name_check(\"example.txt\") # => 'Yes'\n/// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfn file_name_check(file_name: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rs",
+    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// For lst = [1,2,3] the output should be 6\n/// For lst = []  the output should be 0\n/// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rs",
+    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Input: sentence = \"This is a test\"\n/// Output: \"is\"\n/// Example 2:\n/// Input: sentence = \"lets go for swimming\"\n/// Output: \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rs",
+    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// simplify(\"1/5\", \"5/1\") = True\n/// simplify(\"1/6\", \"2/1\") = False\n/// simplify(\"7/10\", \"10/2\") = False\nfn simplify(x: String, n: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rs",
+    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n/// >>> order_by_points([]) == []\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// specialFilter([15, -73, 14, -15]) => 1 \n/// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfn specialFilter(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = specialFilter;\n    assert_eq!(candidate(vec![5, -2, 1, -5]), 0);\n    assert_eq!(candidate(vec![15, -73, 14, -15]), 1);\n    assert_eq!(candidate(vec![33, -2, -3, 45, 21, 109]), 2);\n    assert_eq!(candidate(vec![43, -12, 93, 125, 121, 109]), 4);\n    assert_eq!(candidate(vec![71, -2, -33, 75, 21, 19]), 3);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "rs",
+    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Input: n = 5\n/// Output: 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n/// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rs",
+    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes('abc')\n/// ['a', 'ab', 'abc']\nfn all_prefixes(string: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rs",
+    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// for x_or_y(7, 34, 12) == 34\n/// for x_or_y(15, 8, 5) == 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rs",
+    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n/// double_the_difference([-1, -2, 0]) == 0\n/// double_the_difference([9, -2]) == 81\n/// double_the_difference([0]) == 0  \n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rs",
+    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n/// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rs",
+    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rs",
+    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// cycpattern_check(\"abcd\",\"abd\") => False\n/// cycpattern_check(\"hello\",\"ell\") => True\n/// cycpattern_check(\"whassup\",\"psus\") => False\n/// cycpattern_check(\"abab\",\"baa\") => True\n/// cycpattern_check(\"efef\",\"eeff\") => False\n/// cycpattern_check(\"himenss\",\"simen\") => True\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rs",
+    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// even_odd_count(-12) ==> (1, 1)\n/// even_odd_count(123) ==> (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rs",
+    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19) == 'xix'\n/// >>> int_to_mini_roman(152) == 'clii'\n/// >>> int_to_mini_roman(426) == 'cdxxvi'\nfn int_to_mini_roman(number: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// right_angle_triangle(3, 4, 5) == True\n/// right_angle_triangle(1, 2, 3) == False\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n/// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n/// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfn find_max(words: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rs",
+    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// * eat(5, 6, 10) -> [11, 4]\n/// * eat(4, 8, 9) -> [12, 1]\n/// * eat(1, 10, 10) -> [11, 0]\n/// * eat(2, 11, 5) -> [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rs",
+    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// '0'\n/// >>> string_sequence(5)\n/// '0 1 2 3 4 5'\nfn string_sequence(n: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rs",
+    "prompt": "/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// solve(\"1234\") = \"4321\"\n/// solve(\"ab\") = \"AB\"\n/// solve(\"#a@C\") = \"#A@c\"\nfn solve(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rs",
+    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1852,7 +796,7 @@
     "language": "rs",
     "prompt": "/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// generate_integers(2, 8) => [2, 4, 6, 8]\n/// generate_integers(8, 2) => [2, 4, 6, 8]\n/// generate_integers(10, 14) => []\nfn generate_integers(a: isize, b: isize) -> Vec<isize> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = generate_integers;\n    assert_eq!(candidate(2, 10), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(10, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(132, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(17, 89), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
@@ -1864,9 +808,1065 @@
     "language": "rs",
     "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters('xyzXYZ')\n/// 3\n/// >>> count_distinct_characters('Jerry')\n/// 4\nfn count_distinct_characters(string: String) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "rs",
+    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times('', 'a')\n/// 0\n/// >>> how_many_times('aaa', 'a')\n/// 3\n/// >>> how_many_times('aaaa', 'aa')\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "rs",
+    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers('three one five')\n/// 'one three five'\nfn sort_numbers(numbers: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups('( ) (( )) (( )( ))')\n/// ['()', '(())', '(()())']\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rs",
+    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rs",
+    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rs",
+    "prompt": "/// Return length of given string\n/// >>> strlen('')\n/// 0\n/// >>> strlen('abc')\n/// 3\nfn strlen(string: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rs",
+    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rs",
+    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// [2, 2, 2]\n/// >>> factorize(25)\n/// [5, 5]\n/// >>> factorize(70)\n/// [2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rs",
+    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates([1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rs",
+    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case('Hello')\n/// 'hELLO'\nfn flip_case(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rs",
+    "prompt": "/// Concatenate list of strings into a single string\n/// >>> concatenate([])\n/// ''\n/// >>> concatenate(['a', 'b', 'c'])\n/// 'abc'\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix([], 'a')\n/// []\n/// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n/// ['abc', 'array']\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rs",
+    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rs",
+    "prompt": "/// Return only positive numbers in the list.\n/// >>> get_positive([-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rs",
+    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// False\n/// >>> is_prime(101)\n/// True\n/// >>> is_prime(11)\n/// True\n/// >>> is_prime(13441)\n/// True\n/// >>> is_prime(61)\n/// True\n/// >>> is_prime(4)\n/// False\n/// >>> is_prime(1)\n/// False\nfn is_prime(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rs",
+    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rs",
+    "prompt": "/// Return sorted unique elements in a list\n/// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rs",
+    "prompt": "/// Return maximum element in the list.\n/// >>> max_element([1, 2, 3])\n/// 3\n/// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rs",
+    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "rs",
+    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even([5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfn sort_even(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_even;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![1, 2, 3]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]), vec![-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n    assert_eq!(candidate(vec![5, 8, -12, 4, 23, 2, 3, 11, 12, -10]), vec![-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rs",
+    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rs",
+    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero([1, 2, 3])\n/// False\n/// >>> below_zero([1, 2, -4, 5])\n/// True\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> triples_sum_to_zero([1, 3, -2, 1])\n/// True\n/// >>> triples_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n/// True\n/// >>> triples_sum_to_zero([1])\n/// False\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rs",
+    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rs",
+    "prompt": "/// Return list with elements incremented by 1.\n/// >>> incr_list([1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> pairs_sum_to_zero([1, 3, -2, 1])\n/// False\n/// >>> pairs_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n/// True\n/// >>> pairs_sum_to_zero([1])\n/// False\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rs",
+    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// '22'\n/// >>> change_base(8, 2)\n/// '1000'\n/// >>> change_base(7, 2)\n/// '111'\nfn change_base(x: isize, base: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rs",
+    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rs",
+    "prompt": "/// Return median of elements in the list l.\n/// >>> median([3, 1, 2, 4, 5])\n/// 3\n/// >>> median([-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rs",
+    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome('')\n/// True\n/// >>> is_palindrome('aba')\n/// True\n/// >>> is_palindrome('aaaaa')\n/// True\n/// >>> is_palindrome('zbcd')\n/// False\nfn is_palindrome(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rs",
+    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rs",
+    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rs",
+    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels('')\n/// ''\n/// >>> remove_vowels('abcdef')\n/// 'bcdf'\n/// >>> remove_vowels('aaaaa')\n/// ''\n/// >>> remove_vowels('aaBAA')\n/// 'B'\n/// >>> remove_vowels('zbcd')\n/// 'zbcd'\nfn remove_vowels(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rs",
+    "prompt": "/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold([1, 2, 4, 10], 100)\n/// True\n/// >>> below_threshold([1, 20, 4, 10], 5)\n/// False\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rs",
+    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "rs",
+    "prompt": "/// Check if two words have the same characters.\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n/// True\n/// >>> same_chars('abcd', 'dddddddabc')\n/// True\n/// >>> same_chars('dddddddabc', 'abcd')\n/// True\n/// >>> same_chars('eabcd', 'dddddddabc')\n/// False\n/// >>> same_chars('abcd', 'dddddddabce')\n/// False\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n/// False\nfn same_chars(s0: String, s1: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = same_chars;\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\")), true);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabc\")), true);\n    assert_eq!(candidate(String::from(\"dddddddabc\"), String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"eabcd\"), String::from(\"dddddddabc\")), false);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabcf\")), false);\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\")), false);\n    assert_eq!(candidate(String::from(\"aabb\"), String::from(\"aaccc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rs",
+    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "rs",
+    "prompt": "/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"<\")\n/// False\n/// >>> correct_bracketing(\"<>\")\n/// True\n/// >>> correct_bracketing(\"<<><>>\")\n/// True\n/// >>> correct_bracketing(\"><<>\")\n/// False\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"<>\")), true);\n    assert_eq!(candidate(String::from(\"<<><>>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<><>><>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<<><><>><>><<><><<>>>\")), true);\n    assert_eq!(candidate(String::from(\"<<<><>>>>\")), false);\n    assert_eq!(candidate(String::from(\"><<>\")), false);\n    assert_eq!(candidate(String::from(\"<\")), false);\n    assert_eq!(candidate(String::from(\"<<<<\")), false);\n    assert_eq!(candidate(String::from(\">\")), false);\n    assert_eq!(candidate(String::from(\"<<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>><<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>>><>\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rs",
+    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic([1, 2, 4, 20])\n/// True\n/// >>> monotonic([1, 20, 4, 10])\n/// False\n/// >>> monotonic([4, 1, 0, -10])\n/// True\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rs",
+    "prompt": "/// Return sorted unique common elements for two lists.\n/// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common([5, 3, 2, 8], [3, 2])\n/// [2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rs",
+    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rs",
+    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse([], 4)\n/// []\n/// >>> intersperse([1, 2, 3], 4)\n/// [1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rs",
+    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rs",
+    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"(\")\n/// False\n/// >>> correct_bracketing(\"()\")\n/// True\n/// >>> correct_bracketing(\"(()())\")\n/// True\n/// >>> correct_bracketing(\")(()\")\n/// False\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rs",
+    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative([3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative([1, 2, 3])\n/// [2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rs",
+    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rs",
+    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(\"abcde\")\n/// 2\n/// >>> vowels_count(\"ACEDY\")\n/// 3\nfn vowels_count(s: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rs",
+    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// \"21\"\n/// >>> circular_shift(12, 2)\n/// \"12\"\nfn circular_shift(x: isize, shift: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rs",
+    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// digitSum(\"\") => 0\n/// digitSum(\"abAB\") => 131\n/// digitSum(\"abcCd\") => 67\n/// digitSum(\"helloE\") => 69\n/// digitSum(\"woArBld\") => 131\n/// digitSum(\"aAaaaXa\") => 153\nfn digitSum(s: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rs",
+    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n/// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n/// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n/// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rs",
+    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Input: [4,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Input: [1,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n/// Example 3:\n/// Input: []\n/// Output: []\n/// Example 4:\n/// Input: [5, 0, 3, 0, 4, 2]\n/// Output: [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rs",
+    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// search([4, 1, 2, 2, 3, 1]) == 2\n/// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n/// search([5, 5, 4, 4, 4]) == -1\nfn search(lst: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n/// [2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rs",
+    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n/// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n/// strange_sort_list([]) == []\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// triangle_area(3, 4, 5) == 6.00\n/// triangle_area(1, 2, 10) == -1\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rs",
+    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// will_it_fly([1, 2], 5) \u279e False \n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// will_it_fly([3, 2, 3], 1) \u279e False\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// will_it_fly([3, 2, 3], 9) \u279e True\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// will_it_fly([3], 5) \u279e True\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rs",
+    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// smallest_change([1,2,3,5,4,7,9,6]) == 4\n/// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n/// smallest_change([1, 2, 3, 2, 1]) == 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// total_match([], []) \u279e []\n/// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n/// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n/// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n/// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rs",
+    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// is_multiply_prime(30) == True\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rs",
+    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// is_simple_power(1, 4) => true\n/// is_simple_power(2, 2) => true\n/// is_simple_power(8, 2) => true\n/// is_simple_power(3, 2) => false\n/// is_simple_power(3, 1) => false\n/// is_simple_power(5, 3) => false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// iscube(1) ==> True\n/// iscube(2) ==> False\n/// iscube(-1) ==> True\n/// iscube(64) ==> True\n/// iscube(0) ==> True\n/// iscube(180) ==> False\nfn iscube(a: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rs",
+    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// For num = \"AB\" the output should be 1.\n/// For num = \"1077E\" the output should be 2.\n/// For num = \"ABED1A33\" the output should be 4.\n/// For num = \"123456789ABCDEF0\" the output should be 6.\n/// For num = \"2020\" the output should be 2.\nfn hex_key(num: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// decimal_to_binary(15)   # returns \"db1111db\"\n/// decimal_to_binary(32)   # returns \"db100000db\"\nfn decimal_to_binary(decimal: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring([], 'a')\n/// []\n/// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n/// ['abc', 'bacd', 'array']\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// is_happy(a) => False\n/// is_happy(aa) => False\n/// is_happy(abcd) => True\n/// is_happy(aabb) => False\n/// is_happy(adb) => True\n/// is_happy(xyy) => False\nfn is_happy(s: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rs",
+    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// prime_length('Hello') == True\n/// prime_length('abcdcba') == True\n/// prime_length('kittens') == True\n/// prime_length('orange') == False\nfn prime_length(string: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rs",
+    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n/// For N = 150, the sum of digits will be 6 the output should be \"110\".\n/// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rs",
+    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// add([4, 2, 6, 7]) ==> 2\nfn add(lst: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// anti_shuffle('Hi') returns 'Hi'\n/// anti_shuffle('hello') returns 'ehllo'\n/// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfn anti_shuffle(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rs",
+    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// get_row([\n/// [1,2,3,4,5,6],\n/// [1,2,3,4,1,6],\n/// [1,2,3,4,5,1]\n/// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// get_row([], 1) == []\n/// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rs",
+    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// * sort_array([]) => []\n/// * sort_array([5]) => [5]\n/// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n/// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rs",
+    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// encrypt('hi') returns 'lm'\n/// encrypt('asdfghjkl') returns 'ewhjklnop'\n/// encrypt('gf') returns 'kj'\n/// encrypt('et') returns 'ix'\nfn encrypt(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rs",
+    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product([])\n/// (0, 1)\n/// >>> sum_product([1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// next_smallest([1, 2, 3, 4, 5]) == 2\n/// next_smallest([5, 1, 4, 3, 2]) == 2\n/// next_smallest([]) == None\n/// next_smallest([1, 1]) == None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rs",
+    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(\"Hello world\")\n/// 0\n/// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfn is_bored(S: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rs",
+    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// any_int(5, 2, 7) \u279e True\n/// any_int(3, 2, 2) \u279e False\n/// any_int(3, -2, 1) \u279e True\n/// any_int(3.6, -2.2, 2) \u279e False\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode('test')\n/// 'TGST'\n/// >>> encode('This is a message')\n/// 'tHKS KS C MGSSCGG'\nfn encode(message: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n/// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n/// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n/// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n/// For lst = [0,81,12,3,1,21] the output should be 3\n/// For lst = [0,8,1,2,1,7] the output should be 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n/// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n/// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n/// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n/// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rs",
+    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// count_up_to(5) => [2,3]\n/// count_up_to(11) => [2,3,5,7]\n/// count_up_to(0) => []\n/// count_up_to(20) => [2,3,5,7,11,13,17,19]\n/// count_up_to(1) => []\n/// count_up_to(18) => [2,3,5,7,11,13,17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rs",
+    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// multiply(148, 412) should return 16.\n/// multiply(19, 28) should return 72.\n/// multiply(2020, 1851) should return 0.\n/// multiply(14,-15) should return 20.\nfn multiply(a: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rs",
+    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// count_upper('aBCdEf') returns 1\n/// count_upper('abcdefg') returns 0\n/// count_upper('dBBE') returns 0\nfn count_upper(s: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(\"10\")\n/// 10\n/// >>> closest_integer(\"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rs",
+    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-rs-remove.json
+++ b/prompts/humaneval-rs-remove.json
@@ -1,1320 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rs",
-    "prompt": "/// Return length of given string\nfn strlen(string: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rs",
-    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\nfn encrypt(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\nfn add(lst: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rs",
-    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with -\nfn fix_spaces(text: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rs",
-    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfn fibfib(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\nfn parse_music(music_string: String) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\nfn decimal_to_binary(decimal: isize) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rs",
-    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\nfn all_prefixes(string: String) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rs",
-    "prompt": "/// Add two numbers x and y\nfn add(x: isize, y: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rs",
-    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rs",
-    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rs",
-    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfn flip_case(string: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rs",
-    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// If the array is empty, return an empty array:\n/// If the array has any strange number ignore it:\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rs",
-    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\nfn factorize(n: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rs",
-    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\nfn count_up_to(n: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rs",
-    "prompt": "/// Return sorted unique elements in a list\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rs",
-    "prompt": "/// Return maximum element in the list.\nfn max_element(l: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rs",
-    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\nfn is_nested(string: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rs",
-    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rs",
-    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rs",
-    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rs",
-    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\nfn solve(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rs",
-    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\nfn tri(n: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rs",
-    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfn fizz_buzz(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rs",
-    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rs",
-    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rs",
-    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\nfn count_upper(s: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rs",
-    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\nfn largest_divisor(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rs",
-    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rs",
-    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\nfn f(n: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rs",
-    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\nfn iscube(a: isize) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\nfn encode(message: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rs",
-    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\nfn is_bored(S: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\nfn digits(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rs",
-    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\nfn words_string(s: String) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rs",
-    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfn how_many_times(string: String, substring: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rs",
-    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\nfn remove_vowels(text: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rs",
-    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rs",
-    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rs",
-    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rs",
-    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfn prime_fib(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rs",
-    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rs",
     "prompt": "/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\nfn has_close_elements(numbers: Vec<f64>, threshold: f64) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = has_close_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.95), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.8), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 1.0), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 0.5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rs",
-    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfn make_palindrome(string: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rs",
-    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\nfn string_xor(a: String, b: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rs",
-    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rs",
-    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rs",
-    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfn fib4(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rs",
-    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rs",
-    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rs",
-    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rs",
-    "prompt": "/// Return n-th Fibonacci number.\nfn fib(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rs",
-    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rs",
-    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\nfn match_parens(lst: Vec<String>) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rs",
-    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rs",
-    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\nfn truncate_number(number: f64) -> f64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rs",
-    "prompt": "/// Return list with elements incremented by 1.\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rs",
-    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rs",
-    "prompt": "/// Return 2^n modulo p (be aware of numerics).\nfn modp(n: isize, p: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rs",
-    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\nfn is_happy(s: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rs",
-    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfn largest_prime_factor(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rs",
-    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\nfn digitSum(s: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rs",
-    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\nfn solution(lst: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rs",
-    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// Example 4:\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rs",
-    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rs",
-    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rs",
-    "prompt": "/// Return median of elements in the list l.\nfn median(l: Vec<isize>) -> f64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\nfn prime_length(string: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rs",
-    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rs",
-    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\nfn file_name_check(file_name: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rs",
-    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rs",
-    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rs",
-    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rs",
-    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\nfn valid_date(date: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rs",
-    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\nfn count_nums(arr: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\nfn anti_shuffle(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rs",
-    "prompt": "/// Checks if given string is a palindrome\nfn is_palindrome(text: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rs",
-    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\nfn get_closest_vowel(word: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rs",
-    "prompt": "/// Return true if a given number is prime, and false otherwise.\nfn is_prime(n: isize) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rs",
-    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfn simplify(x: String, n: String) -> bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rs",
-    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\nfn hex_key(num: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rs",
-    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Example 2:\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\nfn histogram(test: String) -> HashMap<String, isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rs",
-    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rs",
-    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rs",
-    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\nfn sort_numbers(numbers: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rs",
-    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\nfn circular_shift(x: isize, shift: isize) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rs",
-    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rs",
-    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rs",
-    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\nfn choose_num(x: isize, y: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rs",
-    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rs",
-    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfn count_distinct_characters(string: String) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1324,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\nfn make_a_pile(n: isize) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = make_a_pile;\n    assert_eq!(candidate(3), vec![3, 5, 7]);\n    assert_eq!(candidate(4), vec![4, 6, 8, 10]);\n    assert_eq!(candidate(5), vec![5, 7, 9, 11, 13]);\n    assert_eq!(candidate(6), vec![6, 8, 10, 12, 14, 16]);\n    assert_eq!(candidate(8), vec![8, 10, 12, 14, 16, 18, 20, 22]);\n}\n",
     "stop_tokens": [
@@ -1332,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rs",
-    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\nfn words_string(s: String) -> Vec<String> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rs",
-    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\nfn choose_num(x: isize, y: isize) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "rs",
-    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfn string_sequence(n: isize) -> String {\n",
+    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "rs",
-    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// If the array is empty, return an empty array:\n/// If the array has any strange number ignore it:\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "rs",
-    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\nfn f(n: isize) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rs",
-    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "rs",
-    "prompt": "/// Return True if all numbers in the list l are below threshold t.\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\nfn count_nums(arr: Vec<isize>) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rs",
-    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rs",
-    "prompt": "/// Return only positive numbers in the list.\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfn make_palindrome(string: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "rs",
-    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "rs",
-    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\nfn histogram(test: String) -> HashMap<String, isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given length of a side and high return area for a triangle.\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rs",
-    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\nfn multiply(a: isize, b: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rs",
-    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rs",
-    "prompt": "/// Return sorted unique common elements for two lists.\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rs",
-    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\nfn int_to_mini_roman(number: isize) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rs",
-    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1540,7 +160,7 @@
     "language": "rs",
     "prompt": "/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\nfn reverse_delete(s: String, c: String) -> (String, bool) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = reverse_delete;\n    assert_eq!(candidate(String::from(\"abcde\"), String::from(\"ae\")), (String::from(\"bcd\"), false));\n    assert_eq!(candidate(String::from(\"abcdef\"), String::from(\"b\")), (String::from(\"acdef\"), false));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"ab\")), (String::from(\"cdedc\"), true));\n    assert_eq!(candidate(String::from(\"dwik\"), String::from(\"w\")), (String::from(\"dik\"), false));\n    assert_eq!(candidate(String::from(\"a\"), String::from(\"a\")), (String::from(\"\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"v\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"vabba\"), String::from(\"v\")), (String::from(\"abba\"), true));\n    assert_eq!(candidate(String::from(\"mamma\"), String::from(\"mia\")), (String::from(\"\"), true));\n}\n",
     "stop_tokens": [
@@ -1548,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rs",
-    "prompt": "/// Return a greatest common divisor of two integers a and b\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rs",
+    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rs",
+    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1564,7 +208,7 @@
     "language": "rs",
     "prompt": "/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\nfn sort_array(arr: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(vec![1, 5, 2, 3, 4]), vec![1, 2, 4, 3, 5]);\n    assert_eq!(candidate(vec![-2, -3, -4, -5, -6]), vec![-4, -2, -6, -5, -3]);\n    assert_eq!(candidate(vec![1, 0, 2, 3, 4]), vec![0, 1, 2, 4, 3]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]), vec![2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n    assert_eq!(candidate(vec![3, 6, 44, 12, 32, 5]), vec![32, 3, 5, 6, 12, 44]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n}\n",
     "stop_tokens": [
@@ -1572,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rs",
-    "prompt": "/// Concatenate list of strings into a single string\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
+    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\nfn get_closest_vowel(word: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that contain given substring\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\nfn match_parens(lst: Vec<String>) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rs",
-    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\nfn string_xor(a: String, b: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rs",
-    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\nfn vowels_count(s: String) -> isize {\n",
+    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\nfn find_max(words: Vec<String>) -> String {\n",
+    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\nfn solution(lst: Vec<isize>) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rs",
-    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rs",
-    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\nfn change_base(x: isize, base: isize) -> String {\n",
+    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\nfn valid_date(date: String) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "rs",
-    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "rs",
-    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rs",
+    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rs",
+    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rs",
+    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rs",
+    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\nfn tri(n: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\nfn digits(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\nfn is_nested(string: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rs",
+    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rs",
+    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rs",
+    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rs",
+    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rs",
+    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rs",
+    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rs",
+    "prompt": "/// Return a greatest common divisor of two integers a and b\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rs",
+    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with -\nfn fix_spaces(text: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rs",
+    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\nfn file_name_check(file_name: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rs",
+    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rs",
+    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Example 2:\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rs",
+    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfn simplify(x: String, n: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rs",
+    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1708,7 +580,7 @@
     "language": "rs",
     "prompt": "/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\nfn specialFilter(nums: Vec<isize>) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = specialFilter;\n    assert_eq!(candidate(vec![5, -2, 1, -5]), 0);\n    assert_eq!(candidate(vec![15, -73, 14, -15]), 1);\n    assert_eq!(candidate(vec![33, -2, -3, 45, 21, 109]), 2);\n    assert_eq!(candidate(vec![43, -12, 93, 125, 121, 109]), 4);\n    assert_eq!(candidate(vec![71, -2, -33, 75, 21, 19]), 3);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n}\n",
     "stop_tokens": [
@@ -1716,25 +588,193 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rs",
-    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\nfn sum_to_n(n: isize) -> isize {\n",
+    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "rs",
-    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rs",
+    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\nfn all_prefixes(string: String) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rs",
+    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rs",
+    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rs",
+    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rs",
+    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rs",
+    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rs",
+    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rs",
+    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\nfn int_to_mini_roman(number: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\nfn find_max(words: Vec<String>) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rs",
+    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rs",
+    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfn string_sequence(n: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\nfn solve(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rs",
+    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1744,7 +784,7 @@
     "language": "rs",
     "prompt": "/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\nfn generate_integers(a: isize, b: isize) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = generate_integers;\n    assert_eq!(candidate(2, 10), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(10, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(132, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(17, 89), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
@@ -1752,49 +792,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rs",
-    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfn count_distinct_characters(string: String) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rs",
-    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\nfn parse_music(music_string: String) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rs",
-    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\nfn search(lst: Vec<isize>) -> isize {\n",
+    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfn how_many_times(string: String, substring: String) -> isize {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rs",
-    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\nfn sort_numbers(numbers: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rs",
+    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rs",
+    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rs",
+    "prompt": "/// Return length of given string\nfn strlen(string: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rs",
+    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\nfn largest_divisor(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rs",
+    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\nfn factorize(n: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rs",
+    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rs",
+    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfn flip_case(string: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rs",
+    "prompt": "/// Concatenate list of strings into a single string\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rs",
+    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\nfn truncate_number(number: f64) -> f64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rs",
+    "prompt": "/// Return only positive numbers in the list.\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rs",
+    "prompt": "/// Return true if a given number is prime, and false otherwise.\nfn is_prime(n: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rs",
+    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rs",
+    "prompt": "/// Return sorted unique elements in a list\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rs",
+    "prompt": "/// Return maximum element in the list.\nfn max_element(l: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rs",
+    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfn fizz_buzz(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,9 +1048,189 @@
     "language": "rs",
     "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\nfn sort_even(l: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = sort_even;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![1, 2, 3]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]), vec![-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n    assert_eq!(candidate(vec![5, 8, -12, 4, 23, 2, 3, 11, 12, -10]), vec![-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rs",
+    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfn prime_fib(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rs",
+    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rs",
+    "prompt": "/// Return list with elements incremented by 1.\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rs",
+    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\nfn change_base(x: isize, base: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given length of a side and high return area for a triangle.\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rs",
+    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfn fib4(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rs",
+    "prompt": "/// Return median of elements in the list l.\nfn median(l: Vec<isize>) -> f64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rs",
+    "prompt": "/// Checks if given string is a palindrome\nfn is_palindrome(text: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rs",
+    "prompt": "/// Return 2^n modulo p (be aware of numerics).\nfn modp(n: isize, p: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rs",
+    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rs",
+    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\nfn remove_vowels(text: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rs",
+    "prompt": "/// Return True if all numbers in the list l are below threshold t.\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rs",
+    "prompt": "/// Add two numbers x and y\nfn add(x: isize, y: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1816,9 +1240,21 @@
     "language": "rs",
     "prompt": "/// Check if two words have the same characters.\nfn same_chars(s0: String, s1: String) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = same_chars;\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\")), true);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabc\")), true);\n    assert_eq!(candidate(String::from(\"dddddddabc\"), String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"eabcd\"), String::from(\"dddddddabc\")), false);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabcf\")), false);\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\")), false);\n    assert_eq!(candidate(String::from(\"aabb\"), String::from(\"aaccc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rs",
+    "prompt": "/// Return n-th Fibonacci number.\nfn fib(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1828,9 +1264,573 @@
     "language": "rs",
     "prompt": "/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfn correct_bracketing(brackets: String) -> bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"<>\")), true);\n    assert_eq!(candidate(String::from(\"<<><>>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<><>><>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<<><><>><>><<><><<>>>\")), true);\n    assert_eq!(candidate(String::from(\"<<<><>>>>\")), false);\n    assert_eq!(candidate(String::from(\"><<>\")), false);\n    assert_eq!(candidate(String::from(\"<\")), false);\n    assert_eq!(candidate(String::from(\"<<<<\")), false);\n    assert_eq!(candidate(String::from(\">\")), false);\n    assert_eq!(candidate(String::from(\"<<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>><<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>>><>\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rs",
+    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rs",
+    "prompt": "/// Return sorted unique common elements for two lists.\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rs",
+    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfn largest_prime_factor(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rs",
+    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rs",
+    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\nfn sum_to_n(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rs",
+    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rs",
+    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rs",
+    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfn fibfib(n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rs",
+    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\nfn vowels_count(s: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rs",
+    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\nfn circular_shift(x: isize, shift: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rs",
+    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\nfn digitSum(s: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rs",
+    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rs",
+    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// Example 4:\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rs",
+    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\nfn search(lst: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rs",
+    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rs",
+    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rs",
+    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rs",
+    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rs",
+    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\nfn iscube(a: isize) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rs",
+    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\nfn hex_key(num: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\nfn decimal_to_binary(decimal: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that contain given substring\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\nfn is_happy(s: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rs",
+    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\nfn prime_length(string: String) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rs",
+    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rs",
+    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\nfn add(lst: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\nfn anti_shuffle(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rs",
+    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rs",
+    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rs",
+    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\nfn encrypt(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rs",
+    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rs",
+    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\nfn is_bored(S: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rs",
+    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\nfn encode(message: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rs",
+    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\nfn count_up_to(n: isize) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rs",
+    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\nfn multiply(a: isize, b: isize) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rs",
+    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\nfn count_upper(s: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rs",
+    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-rs-reworded.json
+++ b/prompts/humaneval-rs-reworded.json
@@ -1,1356 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rs",
-    "prompt": "/// Return length of given string\n/// >>> strlen(String::from(\"\"))\n/// 0\n/// >>> strlen(String::from(\"abc\"))\n/// 3\nfn strlen(string: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rs",
-    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(String::from(\"hi\"))\n/// String::from(\"lm\")\n/// >>> encrypt(String::from(\"asdfghjkl\"))\n/// String::from(\"ewhjklnop\")\n/// >>> encrypt(String::from(\"gf\"))\n/// String::from(\"kj\")\n/// >>> encrypt(String::from(\"et\"))\n/// String::from(\"ix\")\nfn encrypt(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a HashMap, return true if all keys are strings in lower \n/// case or all keys are strings in upper case, else return false.\n/// The function should return false is the given HashMap is empty.\n/// Examples:\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"b\"), String::from(\"banana\"))]))\n/// true\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (8, String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))]))\n/// true\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rs",
-    "prompt": "/// Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(vec![4, 2, 6, 7])\n/// 2\nfn add(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rs",
-    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(String::from(\" Example\"))\n/// String::from(\"Example\")\n/// >>> fix_spaces(String::from(\" Example 1\"))\n/// String::from(\"Example_1\")\n/// >>> fix_spaces(String::from(\" Example 2\"))\n/// String::from(\"_Example_2\")\n/// >>> fix_spaces(String::from(\" Example 3\"))\n/// String::from(\"_Example-3\")\nfn fix_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rs",
-    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rs",
-    "prompt": "/// Given a vector of numbers, return the sum of squares of the numbers\n/// in the vector that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(vec![1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(vec![-1, -2, 0])\n/// 0\n/// >>> double_the_difference(vec![9, -2])\n/// 81\n/// >>> double_the_difference(vec![0])\n/// 0\n/// If the input vector is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rs",
-    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return vector of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(String::from(\"o o| .| o| o| .| .| .| .| o o\"))\n/// vec![4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(15)\n/// String::from(\"db1111db\")\n/// >>> decimal_to_binary(32)\n/// String::from(\"db100000db\")\nfn decimal_to_binary(decimal: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rs",
-    "prompt": "/// Return vector of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(String::from(\"abc\"))\n/// vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]\nfn all_prefixes(string: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rs",
-    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rs",
-    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return a vector of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(5, 6, 10)\n/// vec![11, 4]\n/// >>> eat(4, 8, 9)\n/// vec![12, 1]\n/// >>> eat(1, 10, 10)\n/// vec![11, 0]\n/// >>> eat(2, 11, 5)\n/// vec![7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rs",
-    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(vec![vec![0, 0, 0], vec![0, 0, 0]], 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rs",
-    "prompt": "/// Given two vectors operator, and operand. The first vector has basic algebra operations, and \n/// the second vector is a vector of integers. Use the two given vectors to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// vector = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator vector is equal to the length of operand vector minus one.\n/// Operand is a vector of of non-negative integers.\n/// Operator vector has at least one operator, and operand vector has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rs",
-    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(String::from(\"Hello\"))\n/// String::from(\"hELLO\")\nfn flip_case(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rs",
-    "prompt": "/// Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting vector, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(vec![2, 1, 1, 4, 5, 8, 2, 3])\n/// vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]\n/// If the vector is empty, return an empty vector:\n/// >>> by_length(vec![])\n/// Vec::<String>::new()\n/// If the vector has any strange number ignore it:\n/// >>> by_length(vec![1, -1, 55])\n/// vec![String::from(\"One\")]\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rs",
-    "prompt": "/// Return vector of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// vec![2, 2, 2]\n/// >>> factorize(25)\n/// vec![5, 5]\n/// >>> factorize(70)\n/// vec![2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rs",
-    "prompt": "/// Implement a function that takes an non-negative integer and returns a vector of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(5)\n/// vec![2, 3]\n/// >>> count_up_to(11)\n/// vec![2, 3, 5, 7]\n/// >>> count_up_to(0)\n/// Vec::<isize>::new()\n/// >>> count_up_to(20)\n/// vec![2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(1)\n/// Vec::<isize>::new()\n/// >>> count_up_to(18)\n/// vec![2, 3, 5, 7, 11, 13, 17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rs",
-    "prompt": "/// Return sorted unique elements in a vector\n/// >>> unique(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts two vectors of strings and returns the vector that has \n/// total number of chars in the all strings of the vector less than the other vector.\n/// if the two vectors have the same number of chars, return the first vector.\n/// Examples\n/// >>> total_match(vec![], vec![])\n/// Vec::<String>::new()\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")])\n/// vec![String::from(\"hI\"), String::from(\"Hi\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")])\n/// vec![String::from(\"hi\"), String::from(\"admin\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")])\n/// vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]\n/// >>> total_match(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")])\n/// vec![String::from(\"4\")]\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rs",
-    "prompt": "/// Return maximum element in the vector.\n/// >>> max_element(vec![1, 2, 3])\n/// 3\n/// >>> max_element(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rs",
-    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return true if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(String::from(\"[[]]\"))\n/// true\n/// >>> is_nested(String::from(\"[]]]]]]][[[[[]\"))\n/// false\n/// >>> is_nested(String::from(\"[][]\"))\n/// false\n/// >>> is_nested(String::from(\"[]\"))\n/// false\n/// >>> is_nested(String::from(\"[[][]]\"))\n/// true\n/// >>> is_nested(String::from(\"[[]][[\"))\n/// true\nfn is_nested(string: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rs",
-    "prompt": "/// Given a vector of strings, where each string consists of only digits, return a vector.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(vec![String::from(\"1234567\")])\n/// vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]\n/// >>> odd_count(vec![String::from(\"3\"), String::from(\"11111111\")])\n/// vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rs",
-    "prompt": "/// We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the vector will be randomly ordered. Your task is to determine if\n/// it is possible to get a vector sorted in non-decreasing order by performing \n/// the following operation on the given vector:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the vector by one\n/// position in the right direction. The last element of the vector will be moved to\n/// the starting position in the vector i.e. 0th index. \n/// If it is possible to obtain the sorted vector by performing the above operation\n/// then return true else return false.\n/// If the given vector is empty then return true.\n/// Note: The given vector is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(vec![3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given vector.\n/// >>> move_one_ball(vec![3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// vector by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rs",
-    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(4)\n/// false\n/// >>> is_equal_to_sum_even(6)\n/// false\n/// >>> is_equal_to_sum_even(8)\n/// true\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rs",
-    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(vec![3, 1, 2, 4, 5])\n/// vec![1, 4, 12, 20]\n/// >>> derivative(vec![1, 2, 3])\n/// vec![2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rs",
-    "prompt": "/// Given a vector of numbers, return whether or not they are sorted\n/// in ascending order. If vector has more than 1 duplicate of the same\n/// number, return false. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(vec![5])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(vec![1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(vec![1, 2, 2, 2, 3, 4])\n/// false\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(String::from(\"1234\"))\n/// String::from(\"4321\")\n/// >>> solve(String::from(\"ab\"))\n/// String::from(\"AB\")\n/// >>> solve(String::from(\"#a@C\"))\n/// String::from(\"#A@c\")\nfn solve(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rs",
-    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a vector of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(3)\n/// vec![1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rs",
-    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rs",
-    "prompt": "/// Filter an input vector of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_prefix(vec![String::from(\"abc\"), String::from(\"bcd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"array\")]\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rs",
-    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(1000)\n/// String::from(\"1\")\n/// >>> solve(150)\n/// String::from(\"110\")\n/// >>> solve(147)\n/// String::from(\"1100\")\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rs",
-    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered vectors of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered vector of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3)\n/// vec![1, 2, 1]\n/// >>> minPath(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1)\n/// vec![1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rs",
-    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(String::from(\"aBCdEf\"))\n/// 1\n/// >>> count_upper(String::from(\"abcdefg\"))\n/// 0\n/// >>> count_upper(String::from(\"dBBE\"))\n/// 0\nfn count_upper(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rs",
-    "prompt": "/// Given a vector arr of integers and a positive integer k, return a sorted vector \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(vec![-3, -4, 5], 3)\n/// vec![-4, -3, 5]\n/// Example 2:\n/// >>> maximum(vec![4, -4, 4], 2)\n/// vec![4, 4]\n/// Example 3:\n/// >>> maximum(vec![-3, 2, 1, 2, -1, -2, 1], 1)\n/// vec![2]\n/// Note:\n/// 1. The length of the vector will be in the range of [1, 1000].\n/// 2. The elements in the vector will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rs",
-    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rs",
-    "prompt": "/// Given a vector of non-negative integers, return a cors of the given vector after sorting,\n/// you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given vector.\n/// Examples:\n/// >>> sort_array(vec![])\n/// Vec::<isize>::new()\n/// >>> sort_array(vec![5])\n/// vec![5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5])\n/// vec![0, 1, 2, 3, 4, 5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5, 6])\n/// vec![6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rs",
-    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(5)\n/// vec![1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rs",
-    "prompt": "/// Write a function that takes an integer a and returns true \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(1)\n/// true\n/// >>> iscube(2)\n/// false\n/// >>> iscube(-1)\n/// true\n/// >>> iscube(64)\n/// true\n/// >>> iscube(0)\n/// true\n/// >>> iscube(180)\n/// false\nfn iscube(a: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(String::from(\"test\"))\n/// String::from(\"TGST\")\n/// >>> encode(String::from(\"This is a message\"))\n/// String::from(\"tHKS KS C MGSSCGG\")\nfn encode(message: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rs",
-    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(String::from(\"Hello world\"))\n/// 0\n/// >>> is_bored(String::from(\"The sky is blue. The sun is shining. I love this weather\"))\n/// 1\nfn is_bored(S: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// pairs_sum_to_zero takes a vector of integers as an input.\n/// it returns true if there are two distinct elements in the vector that\n/// sum to zero, and false otherwise.\n/// >>> pairs_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(vec![2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(vec![1])\n/// false\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(3, 4, 5)\n/// 6.0\n/// >>> triangle_area(1, 2, 10)\n/// -1.0\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(1)\n/// 1\n/// >>> digits(4)\n/// 0\n/// >>> digits(235)\n/// 15\nfn digits(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rs",
-    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return a vector of the words.\n/// For example:\n/// >>> words_string(String::from(\"Hi, my name is John\"))\n/// vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]\n/// >>> words_string(String::from(\"One, two, three, four, five, six\"))\n/// vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]\nfn words_string(s: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rs",
-    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(String::from(\"\"), String::from(\"a\"))\n/// 0\n/// >>> how_many_times(String::from(\"aaa\"), String::from(\"a\"))\n/// 3\n/// >>> how_many_times(String::from(\"aaaa\"), String::from(\"aa\"))\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rs",
-    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(String::from(\"\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"abcdef\"))\n/// String::from(\"bcdf\")\n/// >>> remove_vowels(String::from(\"aaaaa\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"aaBAA\"))\n/// String::from(\"B\")\n/// >>> remove_vowels(String::from(\"zbcd\"))\n/// String::from(\"zbcd\")\nfn remove_vowels(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rs",
-    "prompt": "/// Given vector of integers, return vector in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(vec![1, 2, 3, 4])\n/// vec![1, 4, 2, 3]\n/// >>> strange_sort_list(vec![5, 5, 5, 5])\n/// vec![5, 5, 5, 5]\n/// >>> strange_sort_list(vec![])\n/// Vec::<isize>::new()\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rs",
-    "prompt": "/// From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rs",
-    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(1, 4)\n/// true\n/// >>> is_simple_power(2, 2)\n/// true\n/// >>> is_simple_power(8, 2)\n/// true\n/// >>> is_simple_power(3, 2)\n/// false\n/// >>> is_simple_power(3, 1)\n/// false\n/// >>> is_simple_power(5, 3)\n/// false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rs",
-    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rs",
-    "prompt": "/// Write a function which sorts the given vector of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original vector.\n/// For example:\n/// >>> order_by_points(vec![1, 11, -1, -11, -12])\n/// vec![-1, -11, 1, -12, 11]\n/// >>> order_by_points(vec![])\n/// Vec::<isize>::new()\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rs",
     "prompt": "/// Check if in given vector of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements(vec![1.0, 2.0, 3.0], 0.5)\n/// false\n/// >>> has_close_elements(vec![1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// true\nfn has_close_elements(numbers: Vec<f64>, threshold: f64) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = has_close_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.95), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.8), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 1.0), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 0.5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rs",
-    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(String::from(\"\"))\n/// String::from(\"\")\n/// >>> make_palindrome(String::from(\"cat\"))\n/// String::from(\"catac\")\n/// >>> make_palindrome(String::from(\"cata\"))\n/// String::from(\"catac\")\nfn make_palindrome(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rs",
-    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(String::from(\"010\"), String::from(\"110\"))\n/// String::from(\"100\")\nfn string_xor(a: String, b: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rs",
-    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rs",
-    "prompt": "/// Given a non-empty vector of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rs",
-    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rs",
-    "prompt": "/// Given a vector of positive integers x. return a sorted vector of all \n/// elements that hasn't any even digit.\n/// Note: Returned vector should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(vec![15, 33, 1422, 1])\n/// vec![1, 15, 33]\n/// >>> unique_digits(vec![152, 323, 1422, 10])\n/// Vec::<isize>::new()\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rs",
-    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a vector of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty vector.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 4)\n/// vec![String::from(\"little\")]\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 3)\n/// vec![String::from(\"Mary\"), String::from(\"lamb\")]\n/// >>> select_words(String::from(\"simple white space\"), 2)\n/// Vec::<String>::new()\n/// >>> select_words(String::from(\"Hello world\"), 4)\n/// vec![String::from(\"world\")]\n/// >>> select_words(String::from(\"Uncle sam\"), 3)\n/// vec![String::from(\"Uncle\")]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rs",
-    "prompt": "/// Write a function that returns true if the object q will fly, and false otherwise.\n/// The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(vec![1, 2], 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(vec![3, 2, 3], 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(vec![3, 2, 3], 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(vec![3], 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rs",
-    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rs",
-    "prompt": "/// You will be given the name of a class (a string) and a vector of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the vector.\n/// For example, if you are given \"Slices\" as the class and a vector of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(String::from(\"my_class\"), vec![String::from(\"AA\"), String::from(\"Be\"), String::from(\"CC\")])\n/// String::from(\"my_class.AA\")\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rs",
-    "prompt": "/// You are given a vector of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(vec![String::from(\"()(\"), String::from(\")\")])\n/// String::from(\"Yes\")\n/// >>> match_parens(vec![String::from(\")\"), String::from(\")\")])\n/// String::from(\"No\")\nfn match_parens(lst: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rs",
-    "prompt": "/// You are given a vector of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the vector.\n/// Return None if there is no such element.\n/// >>> next_smallest(vec![1, 2, 3, 4, 5])\n/// Some(2)\n/// >>> next_smallest(vec![5, 1, 4, 3, 2])\n/// Some(2)\n/// >>> next_smallest(vec![])\n/// None\n/// >>> next_smallest(vec![1, 1])\n/// None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rs",
-    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(5, 2, 7)\n/// true\n/// >>> any_int(3, 2, 2)\n/// false\n/// >>> any_int(3, -2, 1)\n/// true\n/// >>> any_int(3.6, -2.2, 2)\n/// false\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rs",
-    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rs",
-    "prompt": "/// Return vector with elements incremented by 1.\n/// >>> incr_list(vec![1, 2, 3])\n/// vec![2, 3, 4]\n/// >>> incr_list(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rs",
-    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(7, 34, 12)\n/// 34\n/// >>> x_or_y(15, 8, 5)\n/// 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rs",
-    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rs",
-    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(-12)\n/// (1, 1)\n/// >>> even_odd_count(123)\n/// (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is haprs or not.\n/// A string is haprs if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(String::from(\"a\"))\n/// false\n/// >>> is_happy(String::from(\"aa\"))\n/// false\n/// >>> is_happy(String::from(\"abcd\"))\n/// true\n/// >>> is_happy(String::from(\"aabb\"))\n/// false\n/// >>> is_happy(String::from(\"adb\"))\n/// true\n/// >>> is_happy(String::from(\"xyy\"))\n/// false\nfn is_happy(s: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rs",
-    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rs",
-    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(String::from(\"\"))\n/// 0\n/// >>> digitSum(String::from(\"abAB\"))\n/// 131\n/// >>> digitSum(String::from(\"abcCd\"))\n/// 67\n/// >>> digitSum(String::from(\"helloE\"))\n/// 69\n/// >>> digitSum(String::from(\"woArBld\"))\n/// 131\n/// >>> digitSum(String::from(\"aAaaaXa\"))\n/// 153\nfn digitSum(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rs",
-    "prompt": "/// Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(vec![1.0, 2.0, 3.0, 4.0, 5.0])\n/// vec![0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rs",
-    "prompt": "/// Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(vec![5, 8, 7, 1])\n/// 12\n/// >>> solution(vec![3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(vec![30, 13, 24, 321])\n/// 0\nfn solution(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rs",
-    "prompt": "/// \"Given a vector representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a vector, [ smalest_value, its index ],\n/// If there are no even values or the given vector is empty, return [].\n/// Example 1:\n/// >>> pluck(vec![4, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(vec![1, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(vec![])\n/// Vec::<isize>::new()\n/// Example 4:\n/// >>> pluck(vec![5, 0, 3, 0, 4, 2])\n/// vec![0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rs",
-    "prompt": "/// You are given a positive integer n. You have to create an integer vector a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rs",
-    "prompt": "/// In this problem, you will implement a function that takes two vectors of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a vector of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 2, 3, 4])\n/// String::from(\"YES\")\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 5, 3, 4])\n/// String::from(\"NO\")\n/// It is assumed that the input vectors will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rs",
-    "prompt": "/// Return median of elements in the vector l.\n/// >>> median(vec![3, 1, 2, 4, 5])\n/// 3.0\n/// >>> median(vec![-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns true if the string\n/// length is a prime number or false otherwise\n/// Examples\n/// >>> prime_length(String::from(\"Hello\"))\n/// true\n/// >>> prime_length(String::from(\"abcdcba\"))\n/// true\n/// >>> prime_length(String::from(\"kittens\"))\n/// true\n/// >>> prime_length(String::from(\"orange\"))\n/// false\nfn prime_length(string: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rs",
-    "prompt": "/// Given a vector arr of integers, find the minimum number of elements that\n/// need to be changed to make the vector palindromic. A palindromic vector is a vector that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(vec![1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(vec![1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(vec![1, 2, 3, 2, 1])\n/// 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rs",
-    "prompt": "/// You are given a vector of numbers.\n/// You need to return the sum of squared numbers in the given vector,\n/// round each element in the vector to the upper int(Ceiling) first.\n/// Examples:\n/// >>> lst(vec![1.0, 2.0, 3.0])\n/// 14\n/// >>> lst(vec![1.0, 4.0, 9.0])\n/// 98\n/// >>> lst(vec![1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> lst(vec![1.4, 4.2, 0.0])\n/// 29\n/// >>> lst(vec![-2.4, 1.0, 1.0])\n/// 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rs",
-    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(String::from(\"example.txt\"))\n/// String::from(\"Yes\")\n/// >>> file_name_check(String::from(\"1example.dll\"))\n/// String::from(\"No\")\nfn file_name_check(file_name: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// triples_sum_to_zero takes a vector of integers as an input.\n/// it returns true if there are three distinct elements in the vector that\n/// sum to zero, and false otherwise.\n/// >>> triples_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(vec![1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(vec![2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(vec![1])\n/// false\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rs",
-    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection((1, 2), (2, 3))\n/// String::from(\"NO\")\n/// >>> intersection((-1, 1), (0, 4))\n/// String::from(\"NO\")\n/// >>> intersection((-3, -1), (-5, 5))\n/// String::from(\"YES\")\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the vector of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(String::from(\"( ) (( )) (( )( ))\"))\n/// vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rs",
-    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two vectors of scores and guesses of equal length, where each index shows a match. \n/// Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2])\n/// vec![0, 0, 0, 0, 3, 3]\n/// >>> compare(vec![0, 5, 0, 0, 0, 4], vec![4, 1, 1, 0, 0, -2])\n/// vec![4, 4, 1, 0, 0, 6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rs",
-    "prompt": "/// Create a function that returns true if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and false otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pie\"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e\"))\n/// true\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e \"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"\"))\n/// false\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rs",
-    "prompt": "/// You have to write a function which validates a given date string and\n/// returns true if the date is valid otherwise false.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(String::from(\"03-11-2000\"))\n/// true\n/// >>> valid_date(String::from(\"15-01-2012\"))\n/// false\n/// >>> valid_date(String::from(\"04-0-2040\"))\n/// false\n/// >>> valid_date(String::from(\"06-04-2020\"))\n/// true\n/// >>> valid_date(String::from(\"06/04/2020\"))\n/// false\nfn valid_date(date: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rs",
-    "prompt": "/// Write a function count_nums which takes a vector of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(vec![])\n/// 0\n/// >>> count_nums(vec![-1, 11, -11])\n/// 1\n/// >>> count_nums(vec![1, 1, 2])\n/// 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(String::from(\"Hi\"))\n/// String::from(\"Hi\")\n/// >>> anti_shuffle(String::from(\"hello\"))\n/// String::from(\"ehllo\")\n/// >>> anti_shuffle(String::from(\"Hello World!!!\"))\n/// String::from(\"Hello !!!Wdlor\")\nfn anti_shuffle(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rs",
-    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome(String::from(\"\"))\n/// true\n/// >>> is_palindrome(String::from(\"aba\"))\n/// true\n/// >>> is_palindrome(String::from(\"aaaaa\"))\n/// true\n/// >>> is_palindrome(String::from(\"zbcd\"))\n/// false\nfn is_palindrome(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rs",
-    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(String::from(\"yogurt\"))\n/// String::from(\"u\")\n/// >>> get_closest_vowel(String::from(\"FULL\"))\n/// String::from(\"U\")\n/// >>> get_closest_vowel(String::from(\"quick\"))\n/// String::from(\"\")\n/// >>> get_closest_vowel(String::from(\"ab\"))\n/// String::from(\"\")\nfn get_closest_vowel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rs",
-    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// false\n/// >>> is_prime(101)\n/// true\n/// >>> is_prime(11)\n/// true\n/// >>> is_prime(13441)\n/// true\n/// >>> is_prime(61)\n/// true\n/// >>> is_prime(4)\n/// false\n/// >>> is_prime(1)\n/// false\nfn is_prime(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rs",
-    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns true if x * n evaluates to a whole number and false\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(String::from(\"1/5\"), String::from(\"5/1\"))\n/// true\n/// >>> simplify(String::from(\"1/6\"), String::from(\"2/1\"))\n/// false\n/// >>> simplify(String::from(\"7/10\"), String::from(\"10/2\"))\n/// false\nfn simplify(x: String, n: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rs",
-    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(String::from(\"AB\"))\n/// 1\n/// >>> hex_key(String::from(\"1077E\"))\n/// 2\n/// >>> hex_key(String::from(\"ABED1A33\"))\n/// 4\n/// >>> hex_key(String::from(\"123456789ABCDEF0\"))\n/// 6\n/// >>> hex_key(String::from(\"2020\"))\n/// 2\nfn hex_key(num: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rs",
-    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(String::from(\"This is a test\"))\n/// String::from(\"is\")\n/// Example 2:\n/// >>> words_in_sentence(String::from(\"lets go for swimming\"))\n/// String::from(\"go for\")\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a HashMap\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(String::from(\"a b c\"))\n/// HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1)])\n/// >>> histogram(String::from(\"a b b a\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"a b c a b\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"b b b b a\"))\n/// HashMap::from([(String::from(\"b\"), 4)])\n/// >>> histogram(String::from(\"\"))\n/// HashMap::from([])\nfn histogram(test: String) -> HashMap<String, isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rs",
-    "prompt": "/// You are given a 2 dimensional data, as a nested vectors,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the vector,\n/// and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1)\n/// vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(vec![], 1)\n/// Vec::<(isize, isize)>::new()\n/// >>> get_row(vec![vec![], vec![1], vec![1, 2, 3]], 3)\n/// vec![(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned vector sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(5)\n/// vec![1, 5]\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rs",
-    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given vector will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(vec![1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(vec![1, 2, 3])\n/// -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rs",
-    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(String::from(\"three one five\"))\n/// String::from(\"one three five\")\nfn sort_numbers(numbers: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rs",
-    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// String::from(\"21\")\n/// >>> circular_shift(12, 2)\n/// String::from(\"12\")\nfn circular_shift(x: isize, shift: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rs",
-    "prompt": "/// \"\n/// This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// >>> lst\n/// vec![1, 2, 3]\n/// >>> lst\n/// vec![]\n/// >>> lst\n/// vec![-1, -5, 2, -1, -5]\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rs",
-    "prompt": "/// You are given a vector of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(vec![0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(vec![0, 8, 1, 2, 1, 7])\n/// 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rs",
-    "prompt": "/// For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(vec![])\n/// (0, 1)\n/// >>> sum_product(vec![1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rs",
-    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(12, 15)\n/// 14\n/// >>> choose_num(13, 12)\n/// -1\nfn choose_num(x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rs",
-    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a vector.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(vec![2, 4, 1, 3, 5, 7])\n/// (None, Some(1))\n/// >>> largest_smallest_integers(vec![])\n/// (None, None)\n/// >>> largest_smallest_integers(vec![0])\n/// (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rs",
-    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(String::from(\"xyzXYZ\"))\n/// 3\n/// >>> count_distinct_characters(String::from(\"Jerry\"))\n/// 4\nfn count_distinct_characters(string: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1360,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a vector, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(3)\n/// vec![3, 5, 7]\nfn make_a_pile(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = make_a_pile;\n    assert_eq!(candidate(3), vec![3, 5, 7]);\n    assert_eq!(candidate(4), vec![4, 6, 8, 10]);\n    assert_eq!(candidate(5), vec![5, 7, 9, 11, 13]);\n    assert_eq!(candidate(6), vec![6, 8, 10, 12, 14, 16]);\n    assert_eq!(candidate(8), vec![8, 10, 12, 14, 16, 18, 20, 22]);\n}\n",
     "stop_tokens": [
@@ -1368,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rs",
-    "prompt": "/// You are given a vector arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the vector, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(vec![1, 2, 2, -4])\n/// Some(9)\n/// >>> prod_signs(vec![0, 1])\n/// Some(0)\n/// >>> prod_signs(vec![])\n/// None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return a vector of the words.\n/// For example:\n/// >>> words_string(String::from(\"Hi, my name is John\"))\n/// vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]\n/// >>> words_string(String::from(\"One, two, three, four, five, six\"))\n/// vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]\nfn words_string(s: String) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rs",
-    "prompt": "/// Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n/// of nums.\n/// Example\n/// >>> minSubArraySum(vec![2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(vec![-1, -2, -3])\n/// -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(12, 15)\n/// 14\n/// >>> choose_num(13, 12)\n/// -1\nfn choose_num(x: isize, y: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "rs",
-    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// String::from(\"0\")\n/// >>> string_sequence(5)\n/// String::from(\"0 1 2 3 4 5\")\nfn string_sequence(n: isize) -> String {\n",
+    "prompt": "/// Given a vector of positive integers x. return a sorted vector of all \n/// elements that hasn't any even digit.\n/// Note: Returned vector should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(vec![15, 33, 1422, 1])\n/// vec![1, 15, 33]\n/// >>> unique_digits(vec![152, 323, 1422, 10])\n/// Vec::<isize>::new()\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "rs",
-    "prompt": "/// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(String::from(\"abcd\"), String::from(\"abd\"))\n/// false\n/// >>> cycpattern_check(String::from(\"hello\"), String::from(\"ell\"))\n/// true\n/// >>> cycpattern_check(String::from(\"whassup\"), String::from(\"psus\"))\n/// false\n/// >>> cycpattern_check(String::from(\"abab\"), String::from(\"baa\"))\n/// true\n/// >>> cycpattern_check(String::from(\"efef\"), String::from(\"eeff\"))\n/// false\n/// >>> cycpattern_check(String::from(\"himenss\"), String::from(\"simen\"))\n/// true\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "prompt": "/// Given a vector of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting vector, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(vec![2, 1, 1, 4, 5, 8, 2, 3])\n/// vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]\n/// If the vector is empty, return an empty vector:\n/// >>> by_length(vec![])\n/// Vec::<String>::new()\n/// If the vector has any strange number ignore it:\n/// >>> by_length(vec![1, -1, 55])\n/// vec![String::from(\"One\")]\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "rs",
-    "prompt": "/// Return true is vector elements are monotonically increasing or decreasing.\n/// >>> monotonic(vec![1, 2, 4, 20])\n/// true\n/// >>> monotonic(vec![1, 20, 4, 10])\n/// false\n/// >>> monotonic(vec![4, 1, 0, -10])\n/// true\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a vector of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(5)\n/// vec![1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rs",
-    "prompt": "/// Out of vector of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input vector is empty.\n/// >>> longest(vec![])\n/// None\n/// >>> longest(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// Some(String::from(\"a\"))\n/// >>> longest(vec![String::from(\"a\"), String::from(\"bb\"), String::from(\"ccc\")])\n/// Some(String::from(\"ccc\"))\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "rs",
-    "prompt": "/// Return true if all numbers in the vector l are below threshold t.\n/// >>> below_threshold(vec![1, 2, 4, 10], 100)\n/// true\n/// >>> below_threshold(vec![1, 20, 4, 10], 5)\n/// false\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "prompt": "/// Write a function count_nums which takes a vector of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(vec![])\n/// 0\n/// >>> count_nums(vec![-1, 11, -11])\n/// 1\n/// >>> count_nums(vec![1, 1, 2])\n/// 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rs",
-    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(30)\n/// true\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "prompt": "/// We have a vector 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the vector will be randomly ordered. Your task is to determine if\n/// it is possible to get a vector sorted in non-decreasing order by performing \n/// the following operation on the given vector:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the vector by one\n/// position in the right direction. The last element of the vector will be moved to\n/// the starting position in the vector i.e. 0th index. \n/// If it is possible to obtain the sorted vector by performing the above operation\n/// then return true else return false.\n/// If the given vector is empty then return true.\n/// Note: The given vector is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(vec![3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given vector.\n/// >>> move_one_ball(vec![3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// vector by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rs",
-    "prompt": "/// Return only positive numbers in the vector.\n/// >>> get_positive(vec![-1, 2, -4, 5, 6])\n/// vec![2, 5, 6]\n/// >>> get_positive(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// vec![5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(String::from(\"\"))\n/// String::from(\"\")\n/// >>> make_palindrome(String::from(\"cat\"))\n/// String::from(\"catac\")\n/// >>> make_palindrome(String::from(\"cata\"))\n/// String::from(\"catac\")\nfn make_palindrome(string: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "rs",
-    "prompt": "/// This function takes a vector l and returns a vector l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_third(vec![5, 6, 3, 4, 8, 9, 2])\n/// vec![2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// In this problem, you will implement a function that takes two vectors of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a vector of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 2, 3, 4])\n/// String::from(\"YES\")\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 5, 3, 4])\n/// String::from(\"NO\")\n/// It is assumed that the input vectors will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "rs",
-    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(String::from(\"(()()) ((())) () ((())()())\"))\n/// vec![2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a HashMap\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(String::from(\"a b c\"))\n/// HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1)])\n/// >>> histogram(String::from(\"a b b a\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"a b c a b\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"b b b b a\"))\n/// HashMap::from([(String::from(\"b\"), 4)])\n/// >>> histogram(String::from(\"\"))\n/// HashMap::from([])\nfn histogram(test: String) -> HashMap<String, isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rs",
-    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(148, 412)\n/// 16\n/// >>> multiply(19, 28)\n/// 72\n/// >>> multiply(2020, 1851)\n/// 0\n/// >>> multiply(14, -15)\n/// 20\nfn multiply(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rs",
-    "prompt": "/// For a given vector of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(vec![1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rs",
-    "prompt": "/// Return sorted unique common elements for two vectors.\n/// >>> common(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121])\n/// vec![1, 5, 653]\n/// >>> common(vec![5, 3, 2, 8], vec![3, 2])\n/// vec![2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rs",
-    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19)\n/// String::from(\"xix\")\n/// >>> int_to_mini_roman(152)\n/// String::from(\"clii\")\n/// >>> int_to_mini_roman(426)\n/// String::from(\"cdxxvi\")\nfn int_to_mini_roman(number: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rs",
-    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(String::from(\"5 apples and 6 oranges\"), 19)\n/// 8\n/// >>> fruit_distribution(String::from(\"0 apples and 1 oranges\"), 3)\n/// 2\n/// >>> fruit_distribution(String::from(\"2 apples and 3 oranges\"), 100)\n/// 95\n/// >>> fruit_distribution(String::from(\"100 apples and 1 oranges\"), 120)\n/// 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1576,7 +160,7 @@
     "language": "rs",
     "prompt": "/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and true/false for the check.\n/// Example\n/// >>> reverse_delete(String::from(\"abcde\"), String::from(\"ae\"))\n/// (String::from(\"bcd\"), false)\n/// >>> reverse_delete(String::from(\"abcdef\"), String::from(\"b\"))\n/// (String::from(\"acdef\"), false)\n/// >>> reverse_delete(String::from(\"abcdedcba\"), String::from(\"ab\"))\n/// (String::from(\"cdedc\"), true)\nfn reverse_delete(s: String, c: String) -> (String, bool) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = reverse_delete;\n    assert_eq!(candidate(String::from(\"abcde\"), String::from(\"ae\")), (String::from(\"bcd\"), false));\n    assert_eq!(candidate(String::from(\"abcdef\"), String::from(\"b\")), (String::from(\"acdef\"), false));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"ab\")), (String::from(\"cdedc\"), true));\n    assert_eq!(candidate(String::from(\"dwik\"), String::from(\"w\")), (String::from(\"dik\"), false));\n    assert_eq!(candidate(String::from(\"a\"), String::from(\"a\")), (String::from(\"\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"v\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"vabba\"), String::from(\"v\")), (String::from(\"abba\"), true));\n    assert_eq!(candidate(String::from(\"mamma\"), String::from(\"mia\")), (String::from(\"\"), true));\n}\n",
     "stop_tokens": [
@@ -1584,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rs",
-    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "prompt": "/// Given a vector of strings, where each string consists of only digits, return a vector.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(vec![String::from(\"1234567\")])\n/// vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]\n/// >>> odd_count(vec![String::from(\"3\"), String::from(\"11111111\")])\n/// vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rs",
+    "prompt": "/// Given a vector of integers nums, find the minimum sum of any non-empty sub-vector\n/// of nums.\n/// Example\n/// >>> minSubArraySum(vec![2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(vec![-1, -2, -3])\n/// -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rs",
+    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(vec![vec![0, 0, 0], vec![0, 0, 0]], 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1600,7 +208,7 @@
     "language": "rs",
     "prompt": "/// In this Kata, you have to sort a vector of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array(vec![1, 5, 2, 3, 4])\n/// vec![1, 2, 3, 4, 5]\n/// >>> sort_array(vec![-2, -3, -4, -5, -6])\n/// vec![-6, -5, -4, -3, -2]\n/// >>> sort_array(vec![1, 0, 2, 3, 4])\n/// vec![0, 1, 2, 3, 4]\nfn sort_array(arr: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(vec![1, 5, 2, 3, 4]), vec![1, 2, 4, 3, 5]);\n    assert_eq!(candidate(vec![-2, -3, -4, -5, -6]), vec![-4, -2, -6, -5, -3]);\n    assert_eq!(candidate(vec![1, 0, 2, 3, 4]), vec![0, 1, 2, 4, 3]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]), vec![2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n    assert_eq!(candidate(vec![3, 6, 44, 12, 32, 5]), vec![32, 3, 5, 6, 12, 44]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n}\n",
     "stop_tokens": [
@@ -1608,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rs",
-    "prompt": "/// Concatenate vector of strings into a single string\n/// >>> concatenate(vec![])\n/// String::from(\"\")\n/// >>> concatenate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// String::from(\"abc\")\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a vector of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty vector.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 4)\n/// vec![String::from(\"little\")]\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 3)\n/// vec![String::from(\"Mary\"), String::from(\"lamb\")]\n/// >>> select_words(String::from(\"simple white space\"), 2)\n/// Vec::<String>::new()\n/// >>> select_words(String::from(\"Hello world\"), 4)\n/// vec![String::from(\"world\")]\n/// >>> select_words(String::from(\"Uncle sam\"), 3)\n/// vec![String::from(\"Uncle\")]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a vector of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted vector with a sorted order,\n/// The vector is always a vector of strings and never a vector of numbers,\n/// and it may contain duplicates.\n/// The order of the vector should be ascending by length of each word, and you\n/// should return the vector sorted by that rule.\n/// If two words have the same length, sort the vector alphabetically.\n/// The function should return a vector of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> list_sort(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")])\n/// vec![String::from(\"aa\")]\n/// >>> list_sort(vec![String::from(\"ab\"), String::from(\"a\"), String::from(\"aaa\"), String::from(\"cd\")])\n/// vec![String::from(\"ab\"), String::from(\"cd\")]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
+    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(String::from(\"yogurt\"))\n/// String::from(\"u\")\n/// >>> get_closest_vowel(String::from(\"FULL\"))\n/// String::from(\"U\")\n/// >>> get_closest_vowel(String::from(\"quick\"))\n/// String::from(\"\")\n/// >>> get_closest_vowel(String::from(\"ab\"))\n/// String::from(\"\")\nfn get_closest_vowel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rs",
-    "prompt": "/// Filter an input vector of strings only for ones that contain given substring\n/// >>> filter_by_substring(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_substring(vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"array\")]\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "prompt": "/// You are given a vector of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(vec![String::from(\"()(\"), String::from(\")\")])\n/// String::from(\"Yes\")\n/// >>> match_parens(vec![String::from(\")\"), String::from(\")\")])\n/// String::from(\"No\")\nfn match_parens(lst: Vec<String>) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rs",
-    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(String::from(\"10\"))\n/// 10\n/// >>> closest_integer(String::from(\"15.3\"))\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(String::from(\"010\"), String::from(\"110\"))\n/// String::from(\"100\")\nfn string_xor(a: String, b: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rs",
-    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(String::from(\"abcde\"))\n/// 2\n/// >>> vowels_count(String::from(\"ACEDY\"))\n/// 3\nfn vowels_count(s: String) -> isize {\n",
+    "prompt": "/// Given a vector arr of integers and a positive integer k, return a sorted vector \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(vec![-3, -4, 5], 3)\n/// vec![-4, -3, 5]\n/// Example 2:\n/// >>> maximum(vec![4, -4, 4], 2)\n/// vec![4, 4]\n/// Example 3:\n/// >>> maximum(vec![-3, 2, 1, 2, -1, -2, 1], 1)\n/// vec![2]\n/// Note:\n/// 1. The length of the vector will be in the range of [1, 1000].\n/// 2. The elements in the vector will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a vector of strings.\n/// The vector contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")])\n/// String::from(\"string\")\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")])\n/// String::from(\"enam\")\n/// >>> find_max(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")])\n/// String::from(\"aaaaaaa\")\nfn find_max(words: Vec<String>) -> String {\n",
+    "prompt": "/// Given a non-empty vector of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(vec![5, 8, 7, 1])\n/// 12\n/// >>> solution(vec![3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(vec![30, 13, 24, 321])\n/// 0\nfn solution(lst: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rs",
-    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(String::from(\"Hello world\"))\n/// Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\"))\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "prompt": "/// Given a non-empty vector of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rs",
-    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// String::from(\"22\")\n/// >>> change_base(8, 2)\n/// String::from(\"1000\")\n/// >>> change_base(7, 2)\n/// String::from(\"111\")\nfn change_base(x: isize, base: isize) -> String {\n",
+    "prompt": "/// Given a positive integer n, return a sorted vector that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned vector sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(5)\n/// vec![1, 5]\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return true if the three\n/// sides form a right-angled triangle, false otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(3, 4, 5)\n/// true\n/// >>> right_angle_triangle(1, 2, 3)\n/// false\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "prompt": "/// You have to write a function which validates a given date string and\n/// returns true if the date is valid otherwise false.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(String::from(\"03-11-2000\"))\n/// true\n/// >>> valid_date(String::from(\"15-01-2012\"))\n/// false\n/// >>> valid_date(String::from(\"04-0-2040\"))\n/// false\n/// >>> valid_date(String::from(\"06-04-2020\"))\n/// true\n/// >>> valid_date(String::from(\"06/04/2020\"))\n/// false\nfn valid_date(date: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "rs",
-    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a vector of GPAs for some students and you have to write \n/// a function that can output a vector of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> grade_equation(vec![4.0, 3, 1.7, 2, 3.5])\n/// vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "prompt": "/// Given a vector of numbers, return whether or not they are sorted\n/// in ascending order. If vector has more than 1 duplicate of the same\n/// number, return false. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(vec![5])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(vec![1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(vec![1, 2, 2, 2, 3, 4])\n/// false\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "rs",
-    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n/// >>> intersperse(vec![], 4)\n/// Vec::<isize>::new()\n/// >>> intersperse(vec![1, 2, 3], 4)\n/// vec![1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection((1, 2), (2, 3))\n/// String::from(\"NO\")\n/// >>> intersection((-1, 1), (0, 4))\n/// String::from(\"NO\")\n/// >>> intersection((-3, -1), (-5, 5))\n/// String::from(\"YES\")\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rs",
+    "prompt": "/// You are given a vector arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the vector, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(vec![1, 2, 2, -4])\n/// Some(9)\n/// >>> prod_signs(vec![0, 1])\n/// Some(0)\n/// >>> prod_signs(vec![])\n/// None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rs",
+    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered vectors of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered vector of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3)\n/// vec![1, 2, 1]\n/// >>> minPath(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1)\n/// vec![1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rs",
+    "prompt": "/// Out of vector of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input vector is empty.\n/// >>> longest(vec![])\n/// None\n/// >>> longest(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// Some(String::from(\"a\"))\n/// >>> longest(vec![String::from(\"a\"), String::from(\"bb\"), String::from(\"ccc\")])\n/// Some(String::from(\"ccc\"))\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rs",
+    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a vector of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(3)\n/// vec![1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(1)\n/// 1\n/// >>> digits(4)\n/// 0\n/// >>> digits(235)\n/// 15\nfn digits(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return true if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(String::from(\"[[]]\"))\n/// true\n/// >>> is_nested(String::from(\"[]]]]]]][[[[[]\"))\n/// false\n/// >>> is_nested(String::from(\"[][]\"))\n/// false\n/// >>> is_nested(String::from(\"[]\"))\n/// false\n/// >>> is_nested(String::from(\"[[][]]\"))\n/// true\n/// >>> is_nested(String::from(\"[[]][[\"))\n/// true\nfn is_nested(string: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rs",
+    "prompt": "/// You are given a vector of numbers.\n/// You need to return the sum of squared numbers in the given vector,\n/// round each element in the vector to the upper int(Ceiling) first.\n/// Examples:\n/// >>> lst(vec![1.0, 2.0, 3.0])\n/// 14\n/// >>> lst(vec![1.0, 4.0, 9.0])\n/// 98\n/// >>> lst(vec![1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> lst(vec![1.4, 4.2, 0.0])\n/// 29\n/// >>> lst(vec![-2.4, 1.0, 1.0])\n/// 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rs",
+    "prompt": "/// Create a function that returns true if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and false otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pie\"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e\"))\n/// true\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e \"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"\"))\n/// false\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rs",
+    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given vector will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(vec![1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(vec![1, 2, 3])\n/// -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rs",
+    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a vector.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(vec![2, 4, 1, 3, 5, 7])\n/// (None, Some(1))\n/// >>> largest_smallest_integers(vec![])\n/// (None, None)\n/// >>> largest_smallest_integers(vec![0])\n/// (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rs",
+    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(4)\n/// false\n/// >>> is_equal_to_sum_even(6)\n/// false\n/// >>> is_equal_to_sum_even(8)\n/// true\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rs",
+    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rs",
+    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rs",
+    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(String::from(\" Example\"))\n/// String::from(\"Example\")\n/// >>> fix_spaces(String::from(\" Example 1\"))\n/// String::from(\"Example_1\")\n/// >>> fix_spaces(String::from(\" Example 2\"))\n/// String::from(\"_Example_2\")\n/// >>> fix_spaces(String::from(\" Example 3\"))\n/// String::from(\"_Example-3\")\nfn fix_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rs",
+    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(String::from(\"example.txt\"))\n/// String::from(\"Yes\")\n/// >>> file_name_check(String::from(\"1example.dll\"))\n/// String::from(\"No\")\nfn file_name_check(file_name: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rs",
+    "prompt": "/// \"\n/// This function will take a vector of integers. For all entries in the vector, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the vector whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// >>> lst\n/// vec![1, 2, 3]\n/// >>> lst\n/// vec![]\n/// >>> lst\n/// vec![-1, -5, 2, -1, -5]\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rs",
+    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(String::from(\"This is a test\"))\n/// String::from(\"is\")\n/// Example 2:\n/// >>> words_in_sentence(String::from(\"lets go for swimming\"))\n/// String::from(\"go for\")\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rs",
+    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns true if x * n evaluates to a whole number and false\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(String::from(\"1/5\"), String::from(\"5/1\"))\n/// true\n/// >>> simplify(String::from(\"1/6\"), String::from(\"2/1\"))\n/// false\n/// >>> simplify(String::from(\"7/10\"), String::from(\"10/2\"))\n/// false\nfn simplify(x: String, n: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rs",
+    "prompt": "/// Write a function which sorts the given vector of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original vector.\n/// For example:\n/// >>> order_by_points(vec![1, 11, -1, -11, -12])\n/// vec![-1, -11, 1, -12, 11]\n/// >>> order_by_points(vec![])\n/// Vec::<isize>::new()\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1744,7 +580,7 @@
     "language": "rs",
     "prompt": "/// Write a function that takes a vector of numbers as input and returns \n/// the number of elements in the vector that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// >>> specialFilter(vec![15, -73, 14, -15])\n/// 1\n/// >>> specialFilter(vec![33, -2, -3, 45, 21, 109])\n/// 2\nfn specialFilter(nums: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = specialFilter;\n    assert_eq!(candidate(vec![5, -2, 1, -5]), 0);\n    assert_eq!(candidate(vec![15, -73, 14, -15]), 1);\n    assert_eq!(candidate(vec![33, -2, -3, 45, 21, 109]), 2);\n    assert_eq!(candidate(vec![43, -12, 93, 125, 121, 109]), 4);\n    assert_eq!(candidate(vec![71, -2, -33, 75, 21, 19]), 3);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n}\n",
     "stop_tokens": [
@@ -1752,25 +588,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rs",
-    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
+    "prompt": "/// You are given a positive integer n. You have to create an integer vector a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "rs",
-    "prompt": "/// From a vector of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(vec![1, 2, 3, 2, 4])\n/// vec![1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a function that accepts a vector of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted vector with a sorted order,\n/// The vector is always a vector of strings and never a vector of numbers,\n/// and it may contain duplicates.\n/// The order of the vector should be ascending by length of each word, and you\n/// should return the vector sorted by that rule.\n/// If two words have the same length, sort the vector alphabetically.\n/// The function should return a vector of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> list_sort(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")])\n/// vec![String::from(\"aa\")]\n/// >>> list_sort(vec![String::from(\"ab\"), String::from(\"a\"), String::from(\"aaa\"), String::from(\"cd\")])\n/// vec![String::from(\"ab\"), String::from(\"cd\")]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rs",
+    "prompt": "/// Return vector of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(String::from(\"abc\"))\n/// vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]\nfn all_prefixes(string: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rs",
+    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(7, 34, 12)\n/// 34\n/// >>> x_or_y(15, 8, 5)\n/// 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rs",
+    "prompt": "/// Given a vector of numbers, return the sum of squares of the numbers\n/// in the vector that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(vec![1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(vec![-1, -2, 0])\n/// 0\n/// >>> double_the_difference(vec![9, -2])\n/// 81\n/// >>> double_the_difference(vec![0])\n/// 0\n/// If the input vector is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rs",
+    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two vectors of scores and guesses of equal length, where each index shows a match. \n/// Return a vector of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2])\n/// vec![0, 0, 0, 0, 3, 3]\n/// >>> compare(vec![0, 5, 0, 0, 0, 4], vec![4, 1, 1, 0, 0, -2])\n/// vec![4, 4, 1, 0, 0, 6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rs",
+    "prompt": "/// You will be given the name of a class (a string) and a vector of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the vector.\n/// For example, if you are given \"Slices\" as the class and a vector of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(String::from(\"my_class\"), vec![String::from(\"AA\"), String::from(\"Be\"), String::from(\"CC\")])\n/// String::from(\"my_class.AA\")\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rs",
+    "prompt": "/// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(String::from(\"abcd\"), String::from(\"abd\"))\n/// false\n/// >>> cycpattern_check(String::from(\"hello\"), String::from(\"ell\"))\n/// true\n/// >>> cycpattern_check(String::from(\"whassup\"), String::from(\"psus\"))\n/// false\n/// >>> cycpattern_check(String::from(\"abab\"), String::from(\"baa\"))\n/// true\n/// >>> cycpattern_check(String::from(\"efef\"), String::from(\"eeff\"))\n/// false\n/// >>> cycpattern_check(String::from(\"himenss\"), String::from(\"simen\"))\n/// true\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rs",
+    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(-12)\n/// (1, 1)\n/// >>> even_odd_count(123)\n/// (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rs",
+    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19)\n/// String::from(\"xix\")\n/// >>> int_to_mini_roman(152)\n/// String::from(\"clii\")\n/// >>> int_to_mini_roman(426)\n/// String::from(\"cdxxvi\")\nfn int_to_mini_roman(number: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return true if the three\n/// sides form a right-angled triangle, false otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(3, 4, 5)\n/// true\n/// >>> right_angle_triangle(1, 2, 3)\n/// false\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts a vector of strings.\n/// The vector contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")])\n/// String::from(\"string\")\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")])\n/// String::from(\"enam\")\n/// >>> find_max(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")])\n/// String::from(\"aaaaaaa\")\nfn find_max(words: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rs",
+    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return a vector of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(5, 6, 10)\n/// vec![11, 4]\n/// >>> eat(4, 8, 9)\n/// vec![12, 1]\n/// >>> eat(1, 10, 10)\n/// vec![11, 0]\n/// >>> eat(2, 11, 5)\n/// vec![7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rs",
+    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// String::from(\"0\")\n/// >>> string_sequence(5)\n/// String::from(\"0 1 2 3 4 5\")\nfn string_sequence(n: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rs",
+    "prompt": "/// Given two vectors operator, and operand. The first vector has basic algebra operations, and \n/// the second vector is a vector of integers. Use the two given vectors to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// vector = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator vector is equal to the length of operand vector minus one.\n/// Operand is a vector of of non-negative integers.\n/// Operator vector has at least one operator, and operand vector has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(String::from(\"1234\"))\n/// String::from(\"4321\")\n/// >>> solve(String::from(\"ab\"))\n/// String::from(\"AB\")\n/// >>> solve(String::from(\"#a@C\"))\n/// String::from(\"#A@c\")\nfn solve(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rs",
+    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(String::from(\"Hello world\"))\n/// Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\"))\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1780,7 +796,7 @@
     "language": "rs",
     "prompt": "/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// >>> generate_integers(2, 8)\n/// vec![2, 4, 6, 8]\n/// >>> generate_integers(8, 2)\n/// vec![2, 4, 6, 8]\n/// >>> generate_integers(10, 14)\n/// Vec::<isize>::new()\nfn generate_integers(a: isize, b: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = generate_integers;\n    assert_eq!(candidate(2, 10), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(10, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(132, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(17, 89), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
@@ -1788,49 +804,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rs",
-    "prompt": "/// From a given vector of integers, generate a vector of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(vec![1, 2, 3, 2, 3, 4, 2])\n/// vec![1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(String::from(\"xyzXYZ\"))\n/// 3\n/// >>> count_distinct_characters(String::from(\"Jerry\"))\n/// 4\nfn count_distinct_characters(string: String) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rs",
-    "prompt": "/// You're given a vector of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return true. Otherwise it should return false.\n/// >>> below_zero(vec![1, 2, 3])\n/// false\n/// >>> below_zero(vec![1, 2, -4, 5])\n/// true\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return vector of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(String::from(\"o o| .| o| o| .| .| .| .| o o\"))\n/// vec![4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rs",
-    "prompt": "/// You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the vector.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(vec![4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(vec![1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(vec![5, 5, 4, 4, 4])\n/// -1\nfn search(lst: Vec<isize>) -> isize {\n",
+    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(String::from(\"\"), String::from(\"a\"))\n/// 0\n/// >>> how_many_times(String::from(\"aaa\"), String::from(\"a\"))\n/// 3\n/// >>> how_many_times(String::from(\"aaaa\"), String::from(\"aa\"))\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rs",
-    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"(\"))\n/// false\n/// >>> correct_bracketing(String::from(\"()\"))\n/// true\n/// >>> correct_bracketing(String::from(\"(()())\"))\n/// true\n/// >>> correct_bracketing(String::from(\")(()\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(String::from(\"three one five\"))\n/// String::from(\"one three five\")\nfn sort_numbers(numbers: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the vector of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(String::from(\"( ) (( )) (( )( ))\"))\n/// vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rs",
+    "prompt": "/// From a supplied vector of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rs",
+    "prompt": "/// Given vector of numbers (of at least two elements), apply a linear transform to that vector,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(vec![1.0, 2.0, 3.0, 4.0, 5.0])\n/// vec![0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rs",
+    "prompt": "/// Return length of given string\n/// >>> strlen(String::from(\"\"))\n/// 0\n/// >>> strlen(String::from(\"abc\"))\n/// 3\nfn strlen(string: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rs",
+    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rs",
+    "prompt": "/// Return vector of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be vectored number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// vec![2, 2, 2]\n/// >>> factorize(25)\n/// vec![5, 5]\n/// >>> factorize(70)\n/// vec![2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rs",
+    "prompt": "/// From a vector of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(vec![1, 2, 3, 2, 4])\n/// vec![1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rs",
+    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(String::from(\"Hello\"))\n/// String::from(\"hELLO\")\nfn flip_case(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rs",
+    "prompt": "/// Concatenate vector of strings into a single string\n/// >>> concatenate(vec![])\n/// String::from(\"\")\n/// >>> concatenate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// String::from(\"abc\")\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rs",
+    "prompt": "/// Filter an input vector of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_prefix(vec![String::from(\"abc\"), String::from(\"bcd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"array\")]\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rs",
+    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rs",
+    "prompt": "/// Return only positive numbers in the vector.\n/// >>> get_positive(vec![-1, 2, -4, 5, 6])\n/// vec![2, 5, 6]\n/// >>> get_positive(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// vec![5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rs",
+    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// false\n/// >>> is_prime(101)\n/// true\n/// >>> is_prime(11)\n/// true\n/// >>> is_prime(13441)\n/// true\n/// >>> is_prime(61)\n/// true\n/// >>> is_prime(4)\n/// false\n/// >>> is_prime(1)\n/// false\nfn is_prime(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rs",
+    "prompt": "/// This function takes a vector l and returns a vector l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_third(vec![5, 6, 3, 4, 8, 9, 2])\n/// vec![2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rs",
+    "prompt": "/// Return sorted unique elements in a vector\n/// >>> unique(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rs",
+    "prompt": "/// Return maximum element in the vector.\n/// >>> max_element(vec![1, 2, 3])\n/// 3\n/// >>> max_element(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rs",
+    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1840,9 +1060,201 @@
     "language": "rs",
     "prompt": "/// This function takes a vector l and returns a vector l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_even(vec![5, 6, 3, 4])\n/// vec![3, 6, 5, 4]\nfn sort_even(l: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = sort_even;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![1, 2, 3]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]), vec![-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n    assert_eq!(candidate(vec![5, 8, -12, 4, 23, 2, 3, 11, 12, -10]), vec![-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rs",
+    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rs",
+    "prompt": "/// You're given a vector of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return true. Otherwise it should return false.\n/// >>> below_zero(vec![1, 2, 3])\n/// false\n/// >>> below_zero(vec![1, 2, -4, 5])\n/// true\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// triples_sum_to_zero takes a vector of integers as an input.\n/// it returns true if there are three distinct elements in the vector that\n/// sum to zero, and false otherwise.\n/// >>> triples_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(vec![1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(vec![2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(vec![1])\n/// false\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rs",
+    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rs",
+    "prompt": "/// Return vector with elements incremented by 1.\n/// >>> incr_list(vec![1, 2, 3])\n/// vec![2, 3, 4]\n/// >>> incr_list(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// pairs_sum_to_zero takes a vector of integers as an input.\n/// it returns true if there are two distinct elements in the vector that\n/// sum to zero, and false otherwise.\n/// >>> pairs_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(vec![2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(vec![1])\n/// false\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rs",
+    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// String::from(\"22\")\n/// >>> change_base(8, 2)\n/// String::from(\"1000\")\n/// >>> change_base(7, 2)\n/// String::from(\"111\")\nfn change_base(x: isize, base: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rs",
+    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rs",
+    "prompt": "/// Return median of elements in the vector l.\n/// >>> median(vec![3, 1, 2, 4, 5])\n/// 3.0\n/// >>> median(vec![-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rs",
+    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome(String::from(\"\"))\n/// true\n/// >>> is_palindrome(String::from(\"aba\"))\n/// true\n/// >>> is_palindrome(String::from(\"aaaaa\"))\n/// true\n/// >>> is_palindrome(String::from(\"zbcd\"))\n/// false\nfn is_palindrome(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rs",
+    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rs",
+    "prompt": "/// For a given vector of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(vec![1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rs",
+    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(String::from(\"\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"abcdef\"))\n/// String::from(\"bcdf\")\n/// >>> remove_vowels(String::from(\"aaaaa\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"aaBAA\"))\n/// String::from(\"B\")\n/// >>> remove_vowels(String::from(\"zbcd\"))\n/// String::from(\"zbcd\")\nfn remove_vowels(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rs",
+    "prompt": "/// Return true if all numbers in the vector l are below threshold t.\n/// >>> below_threshold(vec![1, 2, 4, 10], 100)\n/// true\n/// >>> below_threshold(vec![1, 20, 4, 10], 5)\n/// false\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rs",
+    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1852,9 +1264,21 @@
     "language": "rs",
     "prompt": "/// Check if two words have the same characters.\n/// >>> same_chars(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\"))\n/// true\n/// >>> same_chars(String::from(\"abcd\"), String::from(\"dddddddabc\"))\n/// true\n/// >>> same_chars(String::from(\"dddddddabc\"), String::from(\"abcd\"))\n/// true\n/// >>> same_chars(String::from(\"eabcd\"), String::from(\"dddddddabc\"))\n/// false\n/// >>> same_chars(String::from(\"abcd\"), String::from(\"dddddddabce\"))\n/// false\n/// >>> same_chars(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\"))\n/// false\nfn same_chars(s0: String, s1: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = same_chars;\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\")), true);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabc\")), true);\n    assert_eq!(candidate(String::from(\"dddddddabc\"), String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"eabcd\"), String::from(\"dddddddabc\")), false);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabcf\")), false);\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\")), false);\n    assert_eq!(candidate(String::from(\"aabb\"), String::from(\"aaccc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rs",
+    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1288,585 @@
     "language": "rs",
     "prompt": "/// brackets is a string of \"<\" and \">\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"<\"))\n/// false\n/// >>> correct_bracketing(String::from(\"<>\"))\n/// true\n/// >>> correct_bracketing(String::from(\"<<><>>\"))\n/// true\n/// >>> correct_bracketing(String::from(\"><<>\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"<>\")), true);\n    assert_eq!(candidate(String::from(\"<<><>>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<><>><>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<<><><>><>><<><><<>>>\")), true);\n    assert_eq!(candidate(String::from(\"<<<><>>>>\")), false);\n    assert_eq!(candidate(String::from(\"><<>\")), false);\n    assert_eq!(candidate(String::from(\"<\")), false);\n    assert_eq!(candidate(String::from(\"<<<<\")), false);\n    assert_eq!(candidate(String::from(\">\")), false);\n    assert_eq!(candidate(String::from(\"<<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>><<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>>><>\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rs",
+    "prompt": "/// Return true is vector elements are monotonically increasing or decreasing.\n/// >>> monotonic(vec![1, 2, 4, 20])\n/// true\n/// >>> monotonic(vec![1, 20, 4, 10])\n/// false\n/// >>> monotonic(vec![4, 1, 0, -10])\n/// true\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rs",
+    "prompt": "/// Return sorted unique common elements for two vectors.\n/// >>> common(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121])\n/// vec![1, 5, 653]\n/// >>> common(vec![5, 3, 2, 8], vec![3, 2])\n/// vec![2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rs",
+    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rs",
+    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input vector `numbers'\n/// >>> intersperse(vec![], 4)\n/// Vec::<isize>::new()\n/// >>> intersperse(vec![1, 2, 3], 4)\n/// vec![1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rs",
+    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rs",
+    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"(\"))\n/// false\n/// >>> correct_bracketing(String::from(\"()\"))\n/// true\n/// >>> correct_bracketing(String::from(\"(()())\"))\n/// true\n/// >>> correct_bracketing(String::from(\")(()\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rs",
+    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(vec![3, 1, 2, 4, 5])\n/// vec![1, 4, 12, 20]\n/// >>> derivative(vec![1, 2, 3])\n/// vec![2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rs",
+    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rs",
+    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(String::from(\"abcde\"))\n/// 2\n/// >>> vowels_count(String::from(\"ACEDY\"))\n/// 3\nfn vowels_count(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rs",
+    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// String::from(\"21\")\n/// >>> circular_shift(12, 2)\n/// String::from(\"12\")\nfn circular_shift(x: isize, shift: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rs",
+    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(String::from(\"\"))\n/// 0\n/// >>> digitSum(String::from(\"abAB\"))\n/// 131\n/// >>> digitSum(String::from(\"abcCd\"))\n/// 67\n/// >>> digitSum(String::from(\"helloE\"))\n/// 69\n/// >>> digitSum(String::from(\"woArBld\"))\n/// 131\n/// >>> digitSum(String::from(\"aAaaaXa\"))\n/// 153\nfn digitSum(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rs",
+    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(String::from(\"5 apples and 6 oranges\"), 19)\n/// 8\n/// >>> fruit_distribution(String::from(\"0 apples and 1 oranges\"), 3)\n/// 2\n/// >>> fruit_distribution(String::from(\"2 apples and 3 oranges\"), 100)\n/// 95\n/// >>> fruit_distribution(String::from(\"100 apples and 1 oranges\"), 120)\n/// 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rs",
+    "prompt": "/// \"Given a vector representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a vector, [ smalest_value, its index ],\n/// If there are no even values or the given vector is empty, return [].\n/// Example 1:\n/// >>> pluck(vec![4, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(vec![1, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(vec![])\n/// Vec::<isize>::new()\n/// Example 4:\n/// >>> pluck(vec![5, 0, 3, 0, 4, 2])\n/// vec![0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rs",
+    "prompt": "/// You are given a non-empty vector of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the vector.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(vec![4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(vec![1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(vec![5, 5, 4, 4, 4])\n/// -1\nfn search(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(String::from(\"(()()) ((())) () ((())()())\"))\n/// vec![2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rs",
+    "prompt": "/// Given vector of integers, return vector in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(vec![1, 2, 3, 4])\n/// vec![1, 4, 2, 3]\n/// >>> strange_sort_list(vec![5, 5, 5, 5])\n/// vec![5, 5, 5, 5]\n/// >>> strange_sort_list(vec![])\n/// Vec::<isize>::new()\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(3, 4, 5)\n/// 6.0\n/// >>> triangle_area(1, 2, 10)\n/// -1.0\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rs",
+    "prompt": "/// Write a function that returns true if the object q will fly, and false otherwise.\n/// The object q will fly if it's balanced (it is a palindromic vector) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(vec![1, 2], 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(vec![3, 2, 3], 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(vec![3, 2, 3], 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(vec![3], 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rs",
+    "prompt": "/// Given a vector arr of integers, find the minimum number of elements that\n/// need to be changed to make the vector palindromic. A palindromic vector is a vector that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(vec![1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(vec![1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(vec![1, 2, 3, 2, 1])\n/// 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts two vectors of strings and returns the vector that has \n/// total number of chars in the all strings of the vector less than the other vector.\n/// if the two vectors have the same number of chars, return the first vector.\n/// Examples\n/// >>> total_match(vec![], vec![])\n/// Vec::<String>::new()\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")])\n/// vec![String::from(\"hI\"), String::from(\"Hi\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")])\n/// vec![String::from(\"hi\"), String::from(\"admin\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")])\n/// vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]\n/// >>> total_match(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")])\n/// vec![String::from(\"4\")]\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rs",
+    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(30)\n/// true\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rs",
+    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(1, 4)\n/// true\n/// >>> is_simple_power(2, 2)\n/// true\n/// >>> is_simple_power(8, 2)\n/// true\n/// >>> is_simple_power(3, 2)\n/// false\n/// >>> is_simple_power(3, 1)\n/// false\n/// >>> is_simple_power(5, 3)\n/// false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an integer a and returns true \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(1)\n/// true\n/// >>> iscube(2)\n/// false\n/// >>> iscube(-1)\n/// true\n/// >>> iscube(64)\n/// true\n/// >>> iscube(0)\n/// true\n/// >>> iscube(180)\n/// false\nfn iscube(a: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rs",
+    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(String::from(\"AB\"))\n/// 1\n/// >>> hex_key(String::from(\"1077E\"))\n/// 2\n/// >>> hex_key(String::from(\"ABED1A33\"))\n/// 4\n/// >>> hex_key(String::from(\"123456789ABCDEF0\"))\n/// 6\n/// >>> hex_key(String::from(\"2020\"))\n/// 2\nfn hex_key(num: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(15)\n/// String::from(\"db1111db\")\n/// >>> decimal_to_binary(32)\n/// String::from(\"db100000db\")\nfn decimal_to_binary(decimal: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rs",
+    "prompt": "/// Filter an input vector of strings only for ones that contain given substring\n/// >>> filter_by_substring(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_substring(vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"array\")]\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is haprs or not.\n/// A string is haprs if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(String::from(\"a\"))\n/// false\n/// >>> is_happy(String::from(\"aa\"))\n/// false\n/// >>> is_happy(String::from(\"abcd\"))\n/// true\n/// >>> is_happy(String::from(\"aabb\"))\n/// false\n/// >>> is_happy(String::from(\"adb\"))\n/// true\n/// >>> is_happy(String::from(\"xyy\"))\n/// false\nfn is_happy(s: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rs",
+    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a vector of GPAs for some students and you have to write \n/// a function that can output a vector of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> grade_equation(vec![4.0, 3, 1.7, 2, 3.5])\n/// vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns true if the string\n/// length is a prime number or false otherwise\n/// Examples\n/// >>> prime_length(String::from(\"Hello\"))\n/// true\n/// >>> prime_length(String::from(\"abcdcba\"))\n/// true\n/// >>> prime_length(String::from(\"kittens\"))\n/// true\n/// >>> prime_length(String::from(\"orange\"))\n/// false\nfn prime_length(string: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rs",
+    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(1000)\n/// String::from(\"1\")\n/// >>> solve(150)\n/// String::from(\"110\")\n/// >>> solve(147)\n/// String::from(\"1100\")\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rs",
+    "prompt": "/// Given a non-empty vector of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(vec![4, 2, 6, 7])\n/// 2\nfn add(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(String::from(\"Hi\"))\n/// String::from(\"Hi\")\n/// >>> anti_shuffle(String::from(\"hello\"))\n/// String::from(\"ehllo\")\n/// >>> anti_shuffle(String::from(\"Hello World!!!\"))\n/// String::from(\"Hello !!!Wdlor\")\nfn anti_shuffle(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rs",
+    "prompt": "/// You are given a 2 dimensional data, as a nested vectors,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the vector,\n/// and return vector of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1)\n/// vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(vec![], 1)\n/// Vec::<(isize, isize)>::new()\n/// >>> get_row(vec![vec![], vec![1], vec![1, 2, 3]], 3)\n/// vec![(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rs",
+    "prompt": "/// Given a vector of non-negative integers, return a cors of the given vector after sorting,\n/// you will sort the given vector in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given vector.\n/// Examples:\n/// >>> sort_array(vec![])\n/// Vec::<isize>::new()\n/// >>> sort_array(vec![5])\n/// vec![5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5])\n/// vec![0, 1, 2, 3, 4, 5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5, 6])\n/// vec![6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rs",
+    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(String::from(\"hi\"))\n/// String::from(\"lm\")\n/// >>> encrypt(String::from(\"asdfghjkl\"))\n/// String::from(\"ewhjklnop\")\n/// >>> encrypt(String::from(\"gf\"))\n/// String::from(\"kj\")\n/// >>> encrypt(String::from(\"et\"))\n/// String::from(\"ix\")\nfn encrypt(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rs",
+    "prompt": "/// For a given vector of integers, return a tuple consisting of a sum and a product of all the integers in a vector.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(vec![])\n/// (0, 1)\n/// >>> sum_product(vec![1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rs",
+    "prompt": "/// You are given a vector of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the vector.\n/// Return None if there is no such element.\n/// >>> next_smallest(vec![1, 2, 3, 4, 5])\n/// Some(2)\n/// >>> next_smallest(vec![5, 1, 4, 3, 2])\n/// Some(2)\n/// >>> next_smallest(vec![])\n/// None\n/// >>> next_smallest(vec![1, 1])\n/// None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rs",
+    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(String::from(\"Hello world\"))\n/// 0\n/// >>> is_bored(String::from(\"The sky is blue. The sun is shining. I love this weather\"))\n/// 1\nfn is_bored(S: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rs",
+    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(5, 2, 7)\n/// true\n/// >>> any_int(3, 2, 2)\n/// false\n/// >>> any_int(3, -2, 1)\n/// true\n/// >>> any_int(3.6, -2.2, 2)\n/// false\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(String::from(\"test\"))\n/// String::from(\"TGST\")\n/// >>> encode(String::from(\"This is a message\"))\n/// String::from(\"tHKS KS C MGSSCGG\")\nfn encode(message: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rs",
+    "prompt": "/// You are given a vector of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(vec![0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(vec![0, 8, 1, 2, 1, 7])\n/// 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a HashMap, return true if all keys are strings in lower \n/// case or all keys are strings in upper case, else return false.\n/// The function should return false is the given HashMap is empty.\n/// Examples:\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"b\"), String::from(\"banana\"))]))\n/// true\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (8, String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))]))\n/// true\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rs",
+    "prompt": "/// Implement a function that takes an non-negative integer and returns a vector of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(5)\n/// vec![2, 3]\n/// >>> count_up_to(11)\n/// vec![2, 3, 5, 7]\n/// >>> count_up_to(0)\n/// Vec::<isize>::new()\n/// >>> count_up_to(20)\n/// vec![2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(1)\n/// Vec::<isize>::new()\n/// >>> count_up_to(18)\n/// vec![2, 3, 5, 7, 11, 13, 17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rs",
+    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(148, 412)\n/// 16\n/// >>> multiply(19, 28)\n/// 72\n/// >>> multiply(2020, 1851)\n/// 0\n/// >>> multiply(14, -15)\n/// 20\nfn multiply(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rs",
+    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(String::from(\"aBCdEf\"))\n/// 1\n/// >>> count_upper(String::from(\"abcdefg\"))\n/// 0\n/// >>> count_upper(String::from(\"dBBE\"))\n/// 0\nfn count_upper(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(String::from(\"10\"))\n/// 10\n/// >>> closest_integer(String::from(\"15.3\"))\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rs",
+    "prompt": "/// From a given vector of integers, generate a vector of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(vec![1, 2, 3, 2, 3, 4, 2])\n/// vec![1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-rs-transform.json
+++ b/prompts/humaneval-rs-transform.json
@@ -1,1356 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "rs",
-    "prompt": "/// Return length of given string\n/// >>> strlen(String::from(\"\"))\n/// 0\n/// >>> strlen(String::from(\"abc\"))\n/// 3\nfn strlen(string: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "rs",
-    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(String::from(\"hi\"))\n/// String::from(\"lm\")\n/// >>> encrypt(String::from(\"asdfghjkl\"))\n/// String::from(\"ewhjklnop\")\n/// >>> encrypt(String::from(\"gf\"))\n/// String::from(\"kj\")\n/// >>> encrypt(String::from(\"et\"))\n/// String::from(\"ix\")\nfn encrypt(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"b\"), String::from(\"banana\"))]))\n/// true\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (8, String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))]))\n/// true\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(vec![4, 2, 6, 7])\n/// 2\nfn add(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "rs",
-    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(String::from(\" Example\"))\n/// String::from(\"Example\")\n/// >>> fix_spaces(String::from(\" Example 1\"))\n/// String::from(\"Example_1\")\n/// >>> fix_spaces(String::from(\" Example 2\"))\n/// String::from(\"_Example_2\")\n/// >>> fix_spaces(String::from(\" Example 3\"))\n/// String::from(\"_Example-3\")\nfn fix_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "rs",
-    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(vec![1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(vec![-1, -2, 0])\n/// 0\n/// >>> double_the_difference(vec![9, -2])\n/// 81\n/// >>> double_the_difference(vec![0])\n/// 0\n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "rs",
-    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(String::from(\"o o| .| o| o| .| .| .| .| o o\"))\n/// vec![4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(15)\n/// String::from(\"db1111db\")\n/// >>> decimal_to_binary(32)\n/// String::from(\"db100000db\")\nfn decimal_to_binary(decimal: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "rs",
-    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(String::from(\"abc\"))\n/// vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]\nfn all_prefixes(string: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "rs",
-    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "rs",
-    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(5, 6, 10)\n/// vec![11, 4]\n/// >>> eat(4, 8, 9)\n/// vec![12, 1]\n/// >>> eat(1, 10, 10)\n/// vec![11, 0]\n/// >>> eat(2, 11, 5)\n/// vec![7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "rs",
-    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(vec![vec![0, 0, 0], vec![0, 0, 0]], 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "rs",
-    "prompt": "/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "rs",
-    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(String::from(\"Hello\"))\n/// String::from(\"hELLO\")\nfn flip_case(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "rs",
-    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(vec![2, 1, 1, 4, 5, 8, 2, 3])\n/// vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]\n/// If the array is empty, return an empty array:\n/// >>> by_length(vec![])\n/// Vec::<String>::new()\n/// If the array has any strange number ignore it:\n/// >>> by_length(vec![1, -1, 55])\n/// vec![String::from(\"One\")]\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "rs",
-    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// vec![2, 2, 2]\n/// >>> factorize(25)\n/// vec![5, 5]\n/// >>> factorize(70)\n/// vec![2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "rs",
-    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(5)\n/// vec![2, 3]\n/// >>> count_up_to(11)\n/// vec![2, 3, 5, 7]\n/// >>> count_up_to(0)\n/// Vec::<isize>::new()\n/// >>> count_up_to(20)\n/// vec![2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(1)\n/// Vec::<isize>::new()\n/// >>> count_up_to(18)\n/// vec![2, 3, 5, 7, 11, 13, 17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "rs",
-    "prompt": "/// Return sorted unique elements in a list\n/// >>> unique(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "rs",
-    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// >>> total_match(vec![], vec![])\n/// Vec::<String>::new()\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")])\n/// vec![String::from(\"hI\"), String::from(\"Hi\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")])\n/// vec![String::from(\"hi\"), String::from(\"admin\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")])\n/// vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]\n/// >>> total_match(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")])\n/// vec![String::from(\"4\")]\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "rs",
-    "prompt": "/// Return maximum element in the list.\n/// >>> max_element(vec![1, 2, 3])\n/// 3\n/// >>> max_element(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "rs",
-    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(String::from(\"[[]]\"))\n/// true\n/// >>> is_nested(String::from(\"[]]]]]]][[[[[]\"))\n/// false\n/// >>> is_nested(String::from(\"[][]\"))\n/// false\n/// >>> is_nested(String::from(\"[]\"))\n/// false\n/// >>> is_nested(String::from(\"[[][]]\"))\n/// true\n/// >>> is_nested(String::from(\"[[]][[\"))\n/// true\nfn is_nested(string: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "rs",
-    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(vec![String::from(\"1234567\")])\n/// vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]\n/// >>> odd_count(vec![String::from(\"3\"), String::from(\"11111111\")])\n/// vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "rs",
-    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(vec![3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(vec![3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "rs",
-    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(4)\n/// false\n/// >>> is_equal_to_sum_even(6)\n/// false\n/// >>> is_equal_to_sum_even(8)\n/// true\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "rs",
-    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(vec![3, 1, 2, 4, 5])\n/// vec![1, 4, 12, 20]\n/// >>> derivative(vec![1, 2, 3])\n/// vec![2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "rs",
-    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(vec![5])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(vec![1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(vec![1, 2, 2, 2, 3, 4])\n/// false\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(String::from(\"1234\"))\n/// String::from(\"4321\")\n/// >>> solve(String::from(\"ab\"))\n/// String::from(\"AB\")\n/// >>> solve(String::from(\"#a@C\"))\n/// String::from(\"#A@c\")\nfn solve(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "rs",
-    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(3)\n/// vec![1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "rs",
-    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_prefix(vec![String::from(\"abc\"), String::from(\"bcd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"array\")]\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "rs",
-    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(1000)\n/// String::from(\"1\")\n/// >>> solve(150)\n/// String::from(\"110\")\n/// >>> solve(147)\n/// String::from(\"1100\")\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "rs",
-    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3)\n/// vec![1, 2, 1]\n/// >>> minPath(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1)\n/// vec![1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "rs",
-    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(String::from(\"aBCdEf\"))\n/// 1\n/// >>> count_upper(String::from(\"abcdefg\"))\n/// 0\n/// >>> count_upper(String::from(\"dBBE\"))\n/// 0\nfn count_upper(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(vec![-3, -4, 5], 3)\n/// vec![-4, -3, 5]\n/// Example 2:\n/// >>> maximum(vec![4, -4, 4], 2)\n/// vec![4, 4]\n/// Example 3:\n/// >>> maximum(vec![-3, 2, 1, 2, -1, -2, 1], 1)\n/// vec![2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "rs",
-    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "rs",
-    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(vec![])\n/// Vec::<isize>::new()\n/// >>> sort_array(vec![5])\n/// vec![5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5])\n/// vec![0, 1, 2, 3, 4, 5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5, 6])\n/// vec![6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "rs",
-    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(5)\n/// vec![1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "rs",
-    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(1)\n/// true\n/// >>> iscube(2)\n/// false\n/// >>> iscube(-1)\n/// true\n/// >>> iscube(64)\n/// true\n/// >>> iscube(0)\n/// true\n/// >>> iscube(180)\n/// false\nfn iscube(a: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(String::from(\"test\"))\n/// String::from(\"TGST\")\n/// >>> encode(String::from(\"This is a message\"))\n/// String::from(\"tHKS KS C MGSSCGG\")\nfn encode(message: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "rs",
-    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(String::from(\"Hello world\"))\n/// 0\n/// >>> is_bored(String::from(\"The sky is blue. The sun is shining. I love this weather\"))\n/// 1\nfn is_bored(S: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(vec![2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(vec![1])\n/// false\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(3, 4, 5)\n/// 6.0\n/// >>> triangle_area(1, 2, 10)\n/// -1.0\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(1)\n/// 1\n/// >>> digits(4)\n/// 0\n/// >>> digits(235)\n/// 15\nfn digits(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "rs",
-    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(String::from(\"Hi, my name is John\"))\n/// vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]\n/// >>> words_string(String::from(\"One, two, three, four, five, six\"))\n/// vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]\nfn words_string(s: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "rs",
-    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(String::from(\"\"), String::from(\"a\"))\n/// 0\n/// >>> how_many_times(String::from(\"aaa\"), String::from(\"a\"))\n/// 3\n/// >>> how_many_times(String::from(\"aaaa\"), String::from(\"aa\"))\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "rs",
-    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(String::from(\"\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"abcdef\"))\n/// String::from(\"bcdf\")\n/// >>> remove_vowels(String::from(\"aaaaa\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"aaBAA\"))\n/// String::from(\"B\")\n/// >>> remove_vowels(String::from(\"zbcd\"))\n/// String::from(\"zbcd\")\nfn remove_vowels(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "rs",
-    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(vec![1, 2, 3, 4])\n/// vec![1, 4, 2, 3]\n/// >>> strange_sort_list(vec![5, 5, 5, 5])\n/// vec![5, 5, 5, 5]\n/// >>> strange_sort_list(vec![])\n/// Vec::<isize>::new()\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "rs",
-    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "rs",
-    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(1, 4)\n/// true\n/// >>> is_simple_power(2, 2)\n/// true\n/// >>> is_simple_power(8, 2)\n/// true\n/// >>> is_simple_power(3, 2)\n/// false\n/// >>> is_simple_power(3, 1)\n/// false\n/// >>> is_simple_power(5, 3)\n/// false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "rs",
-    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "rs",
-    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points(vec![1, 11, -1, -11, -12])\n/// vec![-1, -11, 1, -12, 11]\n/// >>> order_by_points(vec![])\n/// Vec::<isize>::new()\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "rs",
     "prompt": "/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements(vec![1.0, 2.0, 3.0], 0.5)\n/// false\n/// >>> has_close_elements(vec![1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// true\nfn has_close_elements(numbers: Vec<f64>, threshold: f64) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = has_close_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.95), true);\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0], 0.8), false);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 1.0), true);\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1], 0.5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "rs",
-    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(String::from(\"\"))\n/// String::from(\"\")\n/// >>> make_palindrome(String::from(\"cat\"))\n/// String::from(\"catac\")\n/// >>> make_palindrome(String::from(\"cata\"))\n/// String::from(\"catac\")\nfn make_palindrome(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "rs",
-    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(String::from(\"010\"), String::from(\"110\"))\n/// String::from(\"100\")\nfn string_xor(a: String, b: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "rs",
-    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "rs",
-    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "rs",
-    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "rs",
-    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(vec![15, 33, 1422, 1])\n/// vec![1, 15, 33]\n/// >>> unique_digits(vec![152, 323, 1422, 10])\n/// Vec::<isize>::new()\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "rs",
-    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 4)\n/// vec![String::from(\"little\")]\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 3)\n/// vec![String::from(\"Mary\"), String::from(\"lamb\")]\n/// >>> select_words(String::from(\"simple white space\"), 2)\n/// Vec::<String>::new()\n/// >>> select_words(String::from(\"Hello world\"), 4)\n/// vec![String::from(\"world\")]\n/// >>> select_words(String::from(\"Uncle sam\"), 3)\n/// vec![String::from(\"Uncle\")]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "rs",
-    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(vec![1, 2], 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(vec![3, 2, 3], 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(vec![3, 2, 3], 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(vec![3], 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "rs",
-    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "rs",
-    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(String::from(\"my_class\"), vec![String::from(\"AA\"), String::from(\"Be\"), String::from(\"CC\")])\n/// String::from(\"my_class.AA\")\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "rs",
-    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(vec![String::from(\"()(\"), String::from(\")\")])\n/// String::from(\"Yes\")\n/// >>> match_parens(vec![String::from(\")\"), String::from(\")\")])\n/// String::from(\"No\")\nfn match_parens(lst: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// >>> next_smallest(vec![1, 2, 3, 4, 5])\n/// Some(2)\n/// >>> next_smallest(vec![5, 1, 4, 3, 2])\n/// Some(2)\n/// >>> next_smallest(vec![])\n/// None\n/// >>> next_smallest(vec![1, 1])\n/// None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "rs",
-    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(5, 2, 7)\n/// true\n/// >>> any_int(3, 2, 2)\n/// false\n/// >>> any_int(3, -2, 1)\n/// true\n/// >>> any_int(3.6, -2.2, 2)\n/// false\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "rs",
-    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "rs",
-    "prompt": "/// Return list with elements incremented by 1.\n/// >>> incr_list(vec![1, 2, 3])\n/// vec![2, 3, 4]\n/// >>> incr_list(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "rs",
-    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(7, 34, 12)\n/// 34\n/// >>> x_or_y(15, 8, 5)\n/// 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "rs",
-    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "rs",
-    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(-12)\n/// (1, 1)\n/// >>> even_odd_count(123)\n/// (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "rs",
-    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(String::from(\"a\"))\n/// false\n/// >>> is_happy(String::from(\"aa\"))\n/// false\n/// >>> is_happy(String::from(\"abcd\"))\n/// true\n/// >>> is_happy(String::from(\"aabb\"))\n/// false\n/// >>> is_happy(String::from(\"adb\"))\n/// true\n/// >>> is_happy(String::from(\"xyy\"))\n/// false\nfn is_happy(s: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "rs",
-    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "rs",
-    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(String::from(\"\"))\n/// 0\n/// >>> digitSum(String::from(\"abAB\"))\n/// 131\n/// >>> digitSum(String::from(\"abcCd\"))\n/// 67\n/// >>> digitSum(String::from(\"helloE\"))\n/// 69\n/// >>> digitSum(String::from(\"woArBld\"))\n/// 131\n/// >>> digitSum(String::from(\"aAaaaXa\"))\n/// 153\nfn digitSum(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "rs",
-    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(vec![1.0, 2.0, 3.0, 4.0, 5.0])\n/// vec![0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "rs",
-    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(vec![5, 8, 7, 1])\n/// 12\n/// >>> solution(vec![3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(vec![30, 13, 24, 321])\n/// 0\nfn solution(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "rs",
-    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(vec![4, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(vec![1, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(vec![])\n/// Vec::<isize>::new()\n/// Example 4:\n/// >>> pluck(vec![5, 0, 3, 0, 4, 2])\n/// vec![0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "rs",
-    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "rs",
-    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 2, 3, 4])\n/// String::from(\"YES\")\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 5, 3, 4])\n/// String::from(\"NO\")\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "rs",
-    "prompt": "/// Return median of elements in the list l.\n/// >>> median(vec![3, 1, 2, 4, 5])\n/// 3.0\n/// >>> median(vec![-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// >>> prime_length(String::from(\"Hello\"))\n/// true\n/// >>> prime_length(String::from(\"abcdcba\"))\n/// true\n/// >>> prime_length(String::from(\"kittens\"))\n/// true\n/// >>> prime_length(String::from(\"orange\"))\n/// false\nfn prime_length(string: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "rs",
-    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(vec![1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(vec![1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(vec![1, 2, 3, 2, 1])\n/// 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "rs",
-    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// >>> lst(vec![1.0, 2.0, 3.0])\n/// 14\n/// >>> lst(vec![1.0, 4.0, 9.0])\n/// 98\n/// >>> lst(vec![1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> lst(vec![1.4, 4.2, 0.0])\n/// 29\n/// >>> lst(vec![-2.4, 1.0, 1.0])\n/// 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "rs",
-    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(String::from(\"example.txt\"))\n/// String::from(\"Yes\")\n/// >>> file_name_check(String::from(\"1example.dll\"))\n/// String::from(\"No\")\nfn file_name_check(file_name: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "rs",
-    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(vec![1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(vec![2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(vec![1])\n/// false\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "rs",
-    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection((1, 2), (2, 3))\n/// String::from(\"NO\")\n/// >>> intersection((-1, 1), (0, 4))\n/// String::from(\"NO\")\n/// >>> intersection((-3, -1), (-5, 5))\n/// String::from(\"YES\")\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "rs",
-    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(String::from(\"( ) (( )) (( )( ))\"))\n/// vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "rs",
-    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2])\n/// vec![0, 0, 0, 0, 3, 3]\n/// >>> compare(vec![0, 5, 0, 0, 0, 4], vec![4, 1, 1, 0, 0, -2])\n/// vec![4, 4, 1, 0, 0, 6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "rs",
-    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pie\"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e\"))\n/// true\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e \"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"\"))\n/// false\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "rs",
-    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(String::from(\"03-11-2000\"))\n/// true\n/// >>> valid_date(String::from(\"15-01-2012\"))\n/// false\n/// >>> valid_date(String::from(\"04-0-2040\"))\n/// false\n/// >>> valid_date(String::from(\"06-04-2020\"))\n/// true\n/// >>> valid_date(String::from(\"06/04/2020\"))\n/// false\nfn valid_date(date: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "rs",
-    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(vec![])\n/// 0\n/// >>> count_nums(vec![-1, 11, -11])\n/// 1\n/// >>> count_nums(vec![1, 1, 2])\n/// 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(String::from(\"Hi\"))\n/// String::from(\"Hi\")\n/// >>> anti_shuffle(String::from(\"hello\"))\n/// String::from(\"ehllo\")\n/// >>> anti_shuffle(String::from(\"Hello World!!!\"))\n/// String::from(\"Hello !!!Wdlor\")\nfn anti_shuffle(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "rs",
-    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome(String::from(\"\"))\n/// true\n/// >>> is_palindrome(String::from(\"aba\"))\n/// true\n/// >>> is_palindrome(String::from(\"aaaaa\"))\n/// true\n/// >>> is_palindrome(String::from(\"zbcd\"))\n/// false\nfn is_palindrome(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "rs",
-    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(String::from(\"yogurt\"))\n/// String::from(\"u\")\n/// >>> get_closest_vowel(String::from(\"FULL\"))\n/// String::from(\"U\")\n/// >>> get_closest_vowel(String::from(\"quick\"))\n/// String::from(\"\")\n/// >>> get_closest_vowel(String::from(\"ab\"))\n/// String::from(\"\")\nfn get_closest_vowel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "rs",
-    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// false\n/// >>> is_prime(101)\n/// true\n/// >>> is_prime(11)\n/// true\n/// >>> is_prime(13441)\n/// true\n/// >>> is_prime(61)\n/// true\n/// >>> is_prime(4)\n/// false\n/// >>> is_prime(1)\n/// false\nfn is_prime(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "rs",
-    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(String::from(\"1/5\"), String::from(\"5/1\"))\n/// true\n/// >>> simplify(String::from(\"1/6\"), String::from(\"2/1\"))\n/// false\n/// >>> simplify(String::from(\"7/10\"), String::from(\"10/2\"))\n/// false\nfn simplify(x: String, n: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "rs",
-    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(String::from(\"AB\"))\n/// 1\n/// >>> hex_key(String::from(\"1077E\"))\n/// 2\n/// >>> hex_key(String::from(\"ABED1A33\"))\n/// 4\n/// >>> hex_key(String::from(\"123456789ABCDEF0\"))\n/// 6\n/// >>> hex_key(String::from(\"2020\"))\n/// 2\nfn hex_key(num: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "rs",
-    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(String::from(\"This is a test\"))\n/// String::from(\"is\")\n/// Example 2:\n/// >>> words_in_sentence(String::from(\"lets go for swimming\"))\n/// String::from(\"go for\")\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(String::from(\"a b c\"))\n/// HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1)])\n/// >>> histogram(String::from(\"a b b a\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"a b c a b\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"b b b b a\"))\n/// HashMap::from([(String::from(\"b\"), 4)])\n/// >>> histogram(String::from(\"\"))\n/// HashMap::from([])\nfn histogram(test: String) -> HashMap<String, isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "rs",
-    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1)\n/// vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(vec![], 1)\n/// Vec::<(isize, isize)>::new()\n/// >>> get_row(vec![vec![], vec![1], vec![1, 2, 3]], 3)\n/// vec![(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "rs",
-    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(5)\n/// vec![1, 5]\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "rs",
-    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(vec![1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(vec![1, 2, 3])\n/// -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "rs",
-    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(String::from(\"three one five\"))\n/// String::from(\"one three five\")\nfn sort_numbers(numbers: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "rs",
-    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// String::from(\"21\")\n/// >>> circular_shift(12, 2)\n/// String::from(\"12\")\nfn circular_shift(x: isize, shift: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "rs",
-    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// >>> lst\n/// vec![1, 2, 3]\n/// >>> lst\n/// vec![]\n/// >>> lst\n/// vec![-1, -5, 2, -1, -5]\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "rs",
-    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(vec![0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(vec![0, 8, 1, 2, 1, 7])\n/// 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "rs",
-    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(vec![])\n/// (0, 1)\n/// >>> sum_product(vec![1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "rs",
-    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(12, 15)\n/// 14\n/// >>> choose_num(13, 12)\n/// -1\nfn choose_num(x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "rs",
-    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(vec![2, 4, 1, 3, 5, 7])\n/// (None, Some(1))\n/// >>> largest_smallest_integers(vec![])\n/// (None, None)\n/// >>> largest_smallest_integers(vec![0])\n/// (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "rs",
-    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(String::from(\"xyzXYZ\"))\n/// 3\n/// >>> count_distinct_characters(String::from(\"Jerry\"))\n/// 4\nfn count_distinct_characters(string: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1360,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(3)\n/// vec![3, 5, 7]\nfn make_a_pile(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = make_a_pile;\n    assert_eq!(candidate(3), vec![3, 5, 7]);\n    assert_eq!(candidate(4), vec![4, 6, 8, 10]);\n    assert_eq!(candidate(5), vec![5, 7, 9, 11, 13]);\n    assert_eq!(candidate(6), vec![6, 8, 10, 12, 14, 16]);\n    assert_eq!(candidate(8), vec![8, 10, 12, 14, 16, 18, 20, 22]);\n}\n",
     "stop_tokens": [
@@ -1368,205 +24,133 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "rs",
-    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(vec![1, 2, 2, -4])\n/// Some(9)\n/// >>> prod_signs(vec![0, 1])\n/// Some(0)\n/// >>> prod_signs(vec![])\n/// None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "prompt": "/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(String::from(\"Hi, my name is John\"))\n/// vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]\n/// >>> words_string(String::from(\"One, two, three, four, five, six\"))\n/// vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]\nfn words_string(s: String) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = words_string;\n    assert_eq!(candidate(String::from(\"Hi, my name is John\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\"), String::from(\"is\"), String::from(\"John\")]);\n    assert_eq!(candidate(String::from(\"One, two, three, four, five, six\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"Hi, my name\")), vec![String::from(\"Hi\"), String::from(\"my\"), String::from(\"name\")]);\n    assert_eq!(candidate(String::from(\"One,, two, three, four, five, six,\")), vec![String::from(\"One\"), String::from(\"two\"), String::from(\"three\"), String::from(\"four\"), String::from(\"five\"), String::from(\"six\")]);\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"ahmed     , gamal\")), vec![String::from(\"ahmed\"), String::from(\"gamal\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "rs",
-    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(vec![2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(vec![-1, -2, -3])\n/// -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "prompt": "/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(12, 15)\n/// 14\n/// >>> choose_num(13, 12)\n/// -1\nfn choose_num(x: isize, y: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = choose_num;\n    assert_eq!(candidate(12, 15), 14);\n    assert_eq!(candidate(13, 12), -1);\n    assert_eq!(candidate(33, 12354), 12354);\n    assert_eq!(candidate(5234, 5233), -1);\n    assert_eq!(candidate(6, 29), 28);\n    assert_eq!(candidate(27, 10), -1);\n    assert_eq!(candidate(7, 7), -1);\n    assert_eq!(candidate(546, 546), 546);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_104_unique_digits",
     "language": "rs",
-    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// String::from(\"0\")\n/// >>> string_sequence(5)\n/// String::from(\"0 1 2 3 4 5\")\nfn string_sequence(n: isize) -> String {\n",
+    "prompt": "/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(vec![15, 33, 1422, 1])\n/// vec![1, 15, 33]\n/// >>> unique_digits(vec![152, 323, 1422, 10])\n/// Vec::<isize>::new()\nfn unique_digits(x: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_digits;\n    assert_eq!(candidate(vec![15, 33, 1422, 1]), vec![1, 15, 33]);\n    assert_eq!(candidate(vec![152, 323, 1422, 10]), Vec::<isize>::new());\n    assert_eq!(candidate(vec![12345, 2033, 111, 151]), vec![111, 151]);\n    assert_eq!(candidate(vec![135, 103, 31]), vec![31, 135]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_105_by_length",
     "language": "rs",
-    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(String::from(\"abcd\"), String::from(\"abd\"))\n/// false\n/// >>> cycpattern_check(String::from(\"hello\"), String::from(\"ell\"))\n/// true\n/// >>> cycpattern_check(String::from(\"whassup\"), String::from(\"psus\"))\n/// false\n/// >>> cycpattern_check(String::from(\"abab\"), String::from(\"baa\"))\n/// true\n/// >>> cycpattern_check(String::from(\"efef\"), String::from(\"eeff\"))\n/// false\n/// >>> cycpattern_check(String::from(\"himenss\"), String::from(\"simen\"))\n/// true\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "prompt": "/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(vec![2, 1, 1, 4, 5, 8, 2, 3])\n/// vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]\n/// If the array is empty, return an empty array:\n/// >>> by_length(vec![])\n/// Vec::<String>::new()\n/// If the array has any strange number ignore it:\n/// >>> by_length(vec![1, -1, 55])\n/// vec![String::from(\"One\")]\nfn by_length(arr: Vec<isize>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = by_length;\n    assert_eq!(candidate(vec![2, 1, 1, 4, 5, 8, 2, 3]), vec![String::from(\"Eight\"), String::from(\"Five\"), String::from(\"Four\"), String::from(\"Three\"), String::from(\"Two\"), String::from(\"Two\"), String::from(\"One\"), String::from(\"One\")]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![1, -1, 55]), vec![String::from(\"One\")]);\n    assert_eq!(candidate(vec![1, -1, 3, 2]), vec![String::from(\"Three\"), String::from(\"Two\"), String::from(\"One\")]);\n    assert_eq!(candidate(vec![9, 4, 8]), vec![String::from(\"Nine\"), String::from(\"Eight\"), String::from(\"Four\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_106_f",
     "language": "rs",
-    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic(vec![1, 2, 4, 20])\n/// true\n/// >>> monotonic(vec![1, 20, 4, 10])\n/// false\n/// >>> monotonic(vec![4, 1, 0, -10])\n/// true\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "prompt": "/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(5)\n/// vec![1, 2, 6, 24, 15]\nfn f(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = f;\n    assert_eq!(candidate(5), vec![1, 2, 6, 24, 15]);\n    assert_eq!(candidate(7), vec![1, 2, 6, 24, 15, 720, 28]);\n    assert_eq!(candidate(1), vec![1]);\n    assert_eq!(candidate(3), vec![1, 2, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "rs",
-    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest(vec![])\n/// None\n/// >>> longest(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// Some(String::from(\"a\"))\n/// >>> longest(vec![String::from(\"a\"), String::from(\"bb\"), String::from(\"ccc\")])\n/// Some(String::from(\"ccc\"))\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "prompt": "/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfn even_odd_palindrome(n: isize) -> (isize, isize) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_palindrome;\n    assert_eq!(candidate(123), (8, 13));\n    assert_eq!(candidate(12), (4, 6));\n    assert_eq!(candidate(3), (1, 2));\n    assert_eq!(candidate(63), (6, 8));\n    assert_eq!(candidate(25), (5, 6));\n    assert_eq!(candidate(19), (4, 6));\n    assert_eq!(candidate(9), (4, 5));\n    assert_eq!(candidate(1), (0, 1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_108_count_nums",
     "language": "rs",
-    "prompt": "/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold(vec![1, 2, 4, 10], 100)\n/// true\n/// >>> below_threshold(vec![1, 20, 4, 10], 5)\n/// false\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "prompt": "/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(vec![])\n/// 0\n/// >>> count_nums(vec![-1, 11, -11])\n/// 1\n/// >>> count_nums(vec![1, 1, 2])\n/// 3\nfn count_nums(arr: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_nums;\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![-1, -2, 0]), 0);\n    assert_eq!(candidate(vec![1, 1, 2, -2, 3, 4, 5]), 6);\n    assert_eq!(candidate(vec![1, 6, 9, -6, 0, 1, 5]), 5);\n    assert_eq!(candidate(vec![1, 100, 98, -7, 1, -1]), 4);\n    assert_eq!(candidate(vec![12, 23, 34, -45, -56, 0]), 5);\n    assert_eq!(candidate(vec![0, 1]), 1);\n    assert_eq!(candidate(vec![1]), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_109_move_one_ball",
     "language": "rs",
-    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(30)\n/// true\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "prompt": "/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(vec![3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(vec![3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfn move_one_ball(arr: Vec<isize>) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = move_one_ball;\n    assert_eq!(candidate(vec![3, 4, 5, 1, 2]), true);\n    assert_eq!(candidate(vec![3, 5, 10, 1, 2]), true);\n    assert_eq!(candidate(vec![4, 3, 1, 2]), false);\n    assert_eq!(candidate(vec![3, 5, 4, 1, 2]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_10_make_palindrome",
     "language": "rs",
-    "prompt": "/// Return only positive numbers in the list.\n/// >>> get_positive(vec![-1, 2, -4, 5, 6])\n/// vec![2, 5, 6]\n/// >>> get_positive(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// vec![5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(String::from(\"\"))\n/// String::from(\"\")\n/// >>> make_palindrome(String::from(\"cat\"))\n/// String::from(\"catac\")\n/// >>> make_palindrome(String::from(\"cata\"))\n/// String::from(\"catac\")\nfn make_palindrome(string: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = make_palindrome;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"x\")), String::from(\"x\"));\n    assert_eq!(candidate(String::from(\"xyz\")), String::from(\"xyzyx\"));\n    assert_eq!(candidate(String::from(\"xyx\")), String::from(\"xyx\"));\n    assert_eq!(candidate(String::from(\"jerry\")), String::from(\"jerryrrej\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_110_exchange",
     "language": "rs",
-    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_third(vec![5, 6, 3, 4, 8, 9, 2])\n/// vec![2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 2, 3, 4])\n/// String::from(\"YES\")\n/// >>> exchange(vec![1, 2, 3, 4], vec![1, 5, 3, 4])\n/// String::from(\"NO\")\n/// It is assumed that the input lists will be non-empty.\nfn exchange(lst1: Vec<isize>, lst2: Vec<isize>) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = exchange;\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 2, 3, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![1, 5, 3, 4]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![2, 1, 4, 3]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 4]), String::from(\"YES\"));\n    assert_eq!(candidate(vec![5, 7, 3], vec![2, 6, 3]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![3, 2, 6, 1, 8, 9], vec![3, 5, 5, 1, 1, 1]), String::from(\"NO\"));\n    assert_eq!(candidate(vec![100, 200], vec![200, 200]), String::from(\"YES\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_111_histogram",
     "language": "rs",
-    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(String::from(\"(()()) ((())) () ((())()())\"))\n/// vec![2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(String::from(\"a b c\"))\n/// HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1)])\n/// >>> histogram(String::from(\"a b b a\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"a b c a b\"))\n/// HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)])\n/// >>> histogram(String::from(\"b b b b a\"))\n/// HashMap::from([(String::from(\"b\"), 4)])\n/// >>> histogram(String::from(\"\"))\n/// HashMap::from([])\nfn histogram(test: String) -> HashMap<String, isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "rs",
-    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "rs",
-    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(148, 412)\n/// 16\n/// >>> multiply(19, 28)\n/// 72\n/// >>> multiply(2020, 1851)\n/// 0\n/// >>> multiply(14, -15)\n/// 20\nfn multiply(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "rs",
-    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(vec![1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "rs",
-    "prompt": "/// Return sorted unique common elements for two lists.\n/// >>> common(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121])\n/// vec![1, 5, 653]\n/// >>> common(vec![5, 3, 2, 8], vec![3, 2])\n/// vec![2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "rs",
-    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19)\n/// String::from(\"xix\")\n/// >>> int_to_mini_roman(152)\n/// String::from(\"clii\")\n/// >>> int_to_mini_roman(426)\n/// String::from(\"cdxxvi\")\nfn int_to_mini_roman(number: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "rs",
-    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(String::from(\"5 apples and 6 oranges\"), 19)\n/// 8\n/// >>> fruit_distribution(String::from(\"0 apples and 1 oranges\"), 3)\n/// 2\n/// >>> fruit_distribution(String::from(\"2 apples and 3 oranges\"), 100)\n/// 95\n/// >>> fruit_distribution(String::from(\"100 apples and 1 oranges\"), 120)\n/// 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = histogram;\n    assert_eq!(candidate(String::from(\"a b b a\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c a b\")), HashMap::from([(String::from(\"a\"), 2), (String::from(\"b\"), 2)]));\n    assert_eq!(candidate(String::from(\"a b c d g\")), HashMap::from([(String::from(\"a\"), 1), (String::from(\"b\"), 1), (String::from(\"c\"), 1), (String::from(\"d\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"b b b b a\")), HashMap::from([(String::from(\"b\"), 4)]));\n    assert_eq!(candidate(String::from(\"r t g\")), HashMap::from([(String::from(\"r\"), 1), (String::from(\"t\"), 1), (String::from(\"g\"), 1)]));\n    assert_eq!(candidate(String::from(\"\")), HashMap::from([]));\n    assert_eq!(candidate(String::from(\"a\")), HashMap::from([(String::from(\"a\"), 1)]));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1576,7 +160,7 @@
     "language": "rs",
     "prompt": "/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// >>> reverse_delete(String::from(\"abcde\"), String::from(\"ae\"))\n/// (String::from(\"bcd\"), false)\n/// >>> reverse_delete(String::from(\"abcdef\"), String::from(\"b\"))\n/// (String::from(\"acdef\"), false)\n/// >>> reverse_delete(String::from(\"abcdedcba\"), String::from(\"ab\"))\n/// (String::from(\"cdedc\"), true)\nfn reverse_delete(s: String, c: String) -> (String, bool) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = reverse_delete;\n    assert_eq!(candidate(String::from(\"abcde\"), String::from(\"ae\")), (String::from(\"bcd\"), false));\n    assert_eq!(candidate(String::from(\"abcdef\"), String::from(\"b\")), (String::from(\"acdef\"), false));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"ab\")), (String::from(\"cdedc\"), true));\n    assert_eq!(candidate(String::from(\"dwik\"), String::from(\"w\")), (String::from(\"dik\"), false));\n    assert_eq!(candidate(String::from(\"a\"), String::from(\"a\")), (String::from(\"\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"abcdedcba\"), String::from(\"v\")), (String::from(\"abcdedcba\"), true));\n    assert_eq!(candidate(String::from(\"vabba\"), String::from(\"v\")), (String::from(\"abba\"), true));\n    assert_eq!(candidate(String::from(\"mamma\"), String::from(\"mia\")), (String::from(\"\"), true));\n}\n",
     "stop_tokens": [
@@ -1584,13 +168,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "rs",
-    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "prompt": "/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(vec![String::from(\"1234567\")])\n/// vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]\n/// >>> odd_count(vec![String::from(\"3\"), String::from(\"11111111\")])\n/// vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]\nfn odd_count(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_count;\n    assert_eq!(candidate(vec![String::from(\"1234567\")]), vec![String::from(\"the number of odd elements 4n the str4ng 4 of the 4nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"3\"), String::from(\"11111111\")]), vec![String::from(\"the number of odd elements 1n the str1ng 1 of the 1nput.\"), String::from(\"the number of odd elements 8n the str8ng 8 of the 8nput.\")]);\n    assert_eq!(candidate(vec![String::from(\"271\"), String::from(\"137\"), String::from(\"314\")]), vec![String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\"), String::from(\"the number of odd elements 3n the str3ng 3 of the 3nput.\"), String::from(\"the number of odd elements 2n the str2ng 2 of the 2nput.\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "rs",
+    "prompt": "/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(vec![2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(vec![-1, -2, -3])\n/// -6\nfn minSubArraySum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minSubArraySum;\n    assert_eq!(candidate(vec![2, 3, 4, 1, 2, 4]), 1);\n    assert_eq!(candidate(vec![-1, -2, -3]), -6);\n    assert_eq!(candidate(vec![-1, -2, -3, 2, -10]), -14);\n    assert_eq!(candidate(vec![-9999999999999999]), -9999999999999999);\n    assert_eq!(candidate(vec![0, 10, 20, 1000000]), 0);\n    assert_eq!(candidate(vec![-1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![100, -1, -2, -3, 10, -5]), -6);\n    assert_eq!(candidate(vec![10, 11, 13, 8, 3, 4]), 3);\n    assert_eq!(candidate(vec![100, -33, 32, -1, 0, -2]), -33);\n    assert_eq!(candidate(vec![-10]), -10);\n    assert_eq!(candidate(vec![7]), 7);\n    assert_eq!(candidate(vec![1, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "rs",
+    "prompt": "/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(vec![vec![0, 0, 0], vec![0, 0, 0]], 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfn max_fill(grid: Vec<Vec<isize>>, capacity: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_fill;\n    assert_eq!(candidate(vec![vec![0, 0, 1, 0], vec![0, 1, 0, 0], vec![1, 1, 1, 1]], 1), 6);\n    assert_eq!(candidate(vec![vec![0, 0, 1, 1], vec![0, 0, 0, 0], vec![1, 1, 1, 1], vec![0, 1, 1, 1]], 2), 5);\n    assert_eq!(candidate(vec![vec![0, 0, 0], vec![0, 0, 0]], 5), 0);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 2), 4);\n    assert_eq!(candidate(vec![vec![1, 1, 1, 1], vec![1, 1, 1, 1]], 9), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1600,7 +208,7 @@
     "language": "rs",
     "prompt": "/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array(vec![1, 5, 2, 3, 4])\n/// vec![1, 2, 3, 4, 5]\n/// >>> sort_array(vec![-2, -3, -4, -5, -6])\n/// vec![-6, -5, -4, -3, -2]\n/// >>> sort_array(vec![1, 0, 2, 3, 4])\n/// vec![0, 1, 2, 3, 4]\nfn sort_array(arr: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(vec![1, 5, 2, 3, 4]), vec![1, 2, 4, 3, 5]);\n    assert_eq!(candidate(vec![-2, -3, -4, -5, -6]), vec![-4, -2, -6, -5, -3]);\n    assert_eq!(candidate(vec![1, 0, 2, 3, 4]), vec![0, 1, 2, 4, 3]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]), vec![2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n    assert_eq!(candidate(vec![3, 6, 44, 12, 32, 5]), vec![32, 3, 5, 6, 12, 44]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n    assert_eq!(candidate(vec![2, 4, 8, 16, 32]), vec![2, 4, 8, 16, 32]);\n}\n",
     "stop_tokens": [
@@ -1608,133 +216,361 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "rs",
-    "prompt": "/// Concatenate list of strings into a single string\n/// >>> concatenate(vec![])\n/// String::from(\"\")\n/// >>> concatenate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// String::from(\"abc\")\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "prompt": "/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 4)\n/// vec![String::from(\"little\")]\n/// >>> select_words(String::from(\"Mary had a little lamb\"), 3)\n/// vec![String::from(\"Mary\"), String::from(\"lamb\")]\n/// >>> select_words(String::from(\"simple white space\"), 2)\n/// Vec::<String>::new()\n/// >>> select_words(String::from(\"Hello world\"), 4)\n/// vec![String::from(\"world\")]\n/// >>> select_words(String::from(\"Uncle sam\"), 3)\n/// vec![String::from(\"Uncle\")]\nfn select_words(s: String, n: isize) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = select_words;\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 4), vec![String::from(\"little\")]);\n    assert_eq!(candidate(String::from(\"Mary had a little lamb\"), 3), vec![String::from(\"Mary\"), String::from(\"lamb\")]);\n    assert_eq!(candidate(String::from(\"simple white space\"), 2), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"Hello world\"), 4), vec![String::from(\"world\")]);\n    assert_eq!(candidate(String::from(\"Uncle sam\"), 3), vec![String::from(\"Uncle\")]);\n    assert_eq!(candidate(String::from(\"\"), 4), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"a b c d e f\"), 1), vec![String::from(\"b\"), String::from(\"c\"), String::from(\"d\"), String::from(\"f\")]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> list_sort(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")])\n/// vec![String::from(\"aa\")]\n/// >>> list_sort(vec![String::from(\"ab\"), String::from(\"a\"), String::from(\"aaa\"), String::from(\"cd\")])\n/// vec![String::from(\"ab\"), String::from(\"cd\")]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
+    "prompt": "/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(String::from(\"yogurt\"))\n/// String::from(\"u\")\n/// >>> get_closest_vowel(String::from(\"FULL\"))\n/// String::from(\"U\")\n/// >>> get_closest_vowel(String::from(\"quick\"))\n/// String::from(\"\")\n/// >>> get_closest_vowel(String::from(\"ab\"))\n/// String::from(\"\")\nfn get_closest_vowel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_closest_vowel;\n    assert_eq!(candidate(String::from(\"yogurt\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"full\")), String::from(\"u\"));\n    assert_eq!(candidate(String::from(\"easy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"eAsy\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ali\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"bad\")), String::from(\"a\"));\n    assert_eq!(candidate(String::from(\"most\")), String::from(\"o\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"ba\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"quick\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"anime\")), String::from(\"i\"));\n    assert_eq!(candidate(String::from(\"Asia\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Above\")), String::from(\"o\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "rs",
-    "prompt": "/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_substring(vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"array\")]\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "prompt": "/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(vec![String::from(\"()(\"), String::from(\")\")])\n/// String::from(\"Yes\")\n/// >>> match_parens(vec![String::from(\")\"), String::from(\")\")])\n/// String::from(\"No\")\nfn match_parens(lst: Vec<String>) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = match_parens;\n    assert_eq!(candidate(vec![String::from(\"()(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\")\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(())\"), String::from(\"())())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")())\"), String::from(\"(()()(\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"(())))\"), String::from(\"(()())((\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"()\"), String::from(\"())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(()(\"), String::from(\"()))()\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\"((((\"), String::from(\"((())\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(()\"), String::from(\"(()(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\")(\"), String::from(\")(\")]), String::from(\"No\"));\n    assert_eq!(candidate(vec![String::from(\"(\"), String::from(\")\")]), String::from(\"Yes\"));\n    assert_eq!(candidate(vec![String::from(\")\"), String::from(\"(\")]), String::from(\"Yes\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "rs",
-    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(String::from(\"10\"))\n/// 10\n/// >>> closest_integer(String::from(\"15.3\"))\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "prompt": "/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(String::from(\"010\"), String::from(\"110\"))\n/// String::from(\"100\")\nfn string_xor(a: String, b: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = string_xor;\n    assert_eq!(candidate(String::from(\"111000\"), String::from(\"101010\")), String::from(\"010010\"));\n    assert_eq!(candidate(String::from(\"1\"), String::from(\"1\")), String::from(\"0\"));\n    assert_eq!(candidate(String::from(\"0101\"), String::from(\"0000\")), String::from(\"0101\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "rs",
-    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(String::from(\"abcde\"))\n/// 2\n/// >>> vowels_count(String::from(\"ACEDY\"))\n/// 3\nfn vowels_count(s: String) -> isize {\n",
+    "prompt": "/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(vec![-3, -4, 5], 3)\n/// vec![-4, -3, 5]\n/// Example 2:\n/// >>> maximum(vec![4, -4, 4], 2)\n/// vec![4, 4]\n/// Example 3:\n/// >>> maximum(vec![-3, 2, 1, 2, -1, -2, 1], 1)\n/// vec![2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfn maximum(arr: Vec<isize>, k: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(vec![-3, -4, 5], 3), vec![-4, -3, 5]);\n    assert_eq!(candidate(vec![4, -4, 4], 2), vec![4, 4]);\n    assert_eq!(candidate(vec![-3, 2, 1, 2, -1, -2, 1], 1), vec![2]);\n    assert_eq!(candidate(vec![123, -123, 20, 0, 1, 2, -3], 3), vec![2, 20, 123]);\n    assert_eq!(candidate(vec![-123, 20, 0, 1, 2, -3], 4), vec![0, 1, 2, 20]);\n    assert_eq!(candidate(vec![5, 15, 0, 3, -13, -8, 0], 7), vec![-13, -8, 0, 0, 3, 5, 15]);\n    assert_eq!(candidate(vec![-1, 0, 2, 5, 3, -10], 2), vec![3, 5]);\n    assert_eq!(candidate(vec![1, 0, 5, -7], 1), vec![5]);\n    assert_eq!(candidate(vec![4, -4], 2), vec![-4, 4]);\n    assert_eq!(candidate(vec![-10, 10], 2), vec![-10, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, -23, 243, -400, 0], 0), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "rs",
-    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")])\n/// String::from(\"string\")\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")])\n/// String::from(\"enam\")\n/// >>> find_max(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")])\n/// String::from(\"aaaaaaa\")\nfn find_max(words: Vec<String>) -> String {\n",
+    "prompt": "/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(vec![5, 8, 7, 1])\n/// 12\n/// >>> solution(vec![3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(vec![30, 13, 24, 321])\n/// 0\nfn solution(lst: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = solution;\n    assert_eq!(candidate(vec![5, 8, 7, 1]), 12);\n    assert_eq!(candidate(vec![3, 3, 3, 3, 3]), 9);\n    assert_eq!(candidate(vec![30, 13, 24, 321]), 0);\n    assert_eq!(candidate(vec![5, 9]), 5);\n    assert_eq!(candidate(vec![2, 4, 8]), 0);\n    assert_eq!(candidate(vec![30, 13, 23, 32]), 23);\n    assert_eq!(candidate(vec![3, 13, 2, 9]), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "rs",
-    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(String::from(\"Hello world\"))\n/// Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\"))\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "prompt": "/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfn add_elements(arr: Vec<isize>, k: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = add_elements;\n    assert_eq!(candidate(vec![1, -2, -3, 41, 57, 76, 87, 88, 99], 3), -4);\n    assert_eq!(candidate(vec![111, 121, 3, 4000, 5, 6], 2), 0);\n    assert_eq!(candidate(vec![11, 21, 3, 90, 5, 6, 7, 8, 9], 4), 125);\n    assert_eq!(candidate(vec![111, 21, 3, 4000, 5, 6, 7, 8, 9], 4), 24);\n    assert_eq!(candidate(vec![1], 1), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "rs",
-    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// String::from(\"22\")\n/// >>> change_base(8, 2)\n/// String::from(\"1000\")\n/// >>> change_base(7, 2)\n/// String::from(\"111\")\nfn change_base(x: isize, base: isize) -> String {\n",
+    "prompt": "/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(5)\n/// vec![1, 5]\nfn get_odd_collatz(n: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_odd_collatz;\n    assert_eq!(candidate(14), vec![1, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(5), vec![1, 5]);\n    assert_eq!(candidate(12), vec![1, 3, 5]);\n    assert_eq!(candidate(1), vec![1]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "rs",
-    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(3, 4, 5)\n/// true\n/// >>> right_angle_triangle(1, 2, 3)\n/// false\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "prompt": "/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(String::from(\"03-11-2000\"))\n/// true\n/// >>> valid_date(String::from(\"15-01-2012\"))\n/// false\n/// >>> valid_date(String::from(\"04-0-2040\"))\n/// false\n/// >>> valid_date(String::from(\"06-04-2020\"))\n/// true\n/// >>> valid_date(String::from(\"06/04/2020\"))\n/// false\nfn valid_date(date: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = valid_date;\n    assert_eq!(candidate(String::from(\"03-11-2000\")), true);\n    assert_eq!(candidate(String::from(\"15-01-2012\")), false);\n    assert_eq!(candidate(String::from(\"04-0-2040\")), false);\n    assert_eq!(candidate(String::from(\"06-04-2020\")), true);\n    assert_eq!(candidate(String::from(\"01-01-2007\")), true);\n    assert_eq!(candidate(String::from(\"03-32-2011\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"04-31-3000\")), false);\n    assert_eq!(candidate(String::from(\"06-06-2005\")), true);\n    assert_eq!(candidate(String::from(\"21-31-2000\")), false);\n    assert_eq!(candidate(String::from(\"04-12-2003\")), true);\n    assert_eq!(candidate(String::from(\"04122003\")), false);\n    assert_eq!(candidate(String::from(\"20030412\")), false);\n    assert_eq!(candidate(String::from(\"2003-04\")), false);\n    assert_eq!(candidate(String::from(\"2003-04-12\")), false);\n    assert_eq!(candidate(String::from(\"04-2003\")), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_126_is_sorted",
     "language": "rs",
-    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> grade_equation(vec![4.0, 3, 1.7, 2, 3.5])\n/// vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "prompt": "/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(vec![5])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(vec![1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(vec![1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(vec![1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(vec![1, 2, 2, 2, 3, 4])\n/// false\nfn is_sorted(lst: Vec<isize>) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sorted;\n    assert_eq!(candidate(vec![5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7]), true);\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, 7]), false);\n    assert_eq!(candidate(Vec::<isize>::new()), true);\n    assert_eq!(candidate(vec![1]), true);\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 2, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 4]), false);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_127_intersection",
     "language": "rs",
-    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse(vec![], 4)\n/// Vec::<isize>::new()\n/// >>> intersperse(vec![1, 2, 3], 4)\n/// vec![1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "prompt": "/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection((1, 2), (2, 3))\n/// String::from(\"NO\")\n/// >>> intersection((-1, 1), (0, 4))\n/// String::from(\"NO\")\n/// >>> intersection((-3, -1), (-5, 5))\n/// String::from(\"YES\")\nfn intersection(interval1: (isize, isize), interval2: (isize, isize)) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection;\n    assert_eq!(candidate((1, 2), (2, 3)), String::from(\"NO\"));\n    assert_eq!(candidate((-1, 1), (0, 4)), String::from(\"NO\"));\n    assert_eq!(candidate((-3, -1), (-5, 5)), String::from(\"YES\"));\n    assert_eq!(candidate((-2, 2), (-4, 0)), String::from(\"YES\"));\n    assert_eq!(candidate((-11, 2), (-1, -1)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (3, 5)), String::from(\"NO\"));\n    assert_eq!(candidate((1, 2), (1, 2)), String::from(\"NO\"));\n    assert_eq!(candidate((-2, -2), (-3, -2)), String::from(\"NO\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "rs",
+    "prompt": "/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(vec![1, 2, 2, -4])\n/// Some(9)\n/// >>> prod_signs(vec![0, 1])\n/// Some(0)\n/// >>> prod_signs(vec![])\n/// None\nfn prod_signs(arr: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prod_signs;\n    assert_eq!(candidate(vec![1, 2, 2, -4]), Some(-9));\n    assert_eq!(candidate(vec![0, 1]), Some(0));\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, -1, 1]), Some(-10));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![2, 4, 1, 2, -1, -1, 9]), Some(20));\n    assert_eq!(candidate(vec![-1, 1, -1, 1]), Some(4));\n    assert_eq!(candidate(vec![-1, 1, 1, 1]), Some(-4));\n    assert_eq!(candidate(vec![-1, 1, 1, 0]), Some(0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "rs",
+    "prompt": "/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3)\n/// vec![1, 2, 1]\n/// >>> minPath(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1)\n/// vec![1]\nfn minPath(grid: Vec<Vec<isize>>, k: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3), vec![1, 2, 1]);\n    assert_eq!(candidate(vec![vec![5, 9, 3], vec![4, 1, 6], vec![7, 8, 2]], 1), vec![1]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12], vec![13, 14, 15, 16]], 4), vec![1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![6, 4, 13, 10], vec![5, 7, 12, 1], vec![3, 16, 11, 15], vec![8, 14, 9, 2]], 7), vec![1, 10, 1, 10, 1, 10, 1]);\n    assert_eq!(candidate(vec![vec![8, 14, 9, 2], vec![6, 4, 13, 15], vec![5, 7, 1, 12], vec![3, 10, 11, 16]], 5), vec![1, 7, 1, 7, 1]);\n    assert_eq!(candidate(vec![vec![11, 8, 7, 2], vec![5, 16, 14, 4], vec![9, 3, 15, 6], vec![12, 13, 10, 1]], 9), vec![1, 6, 1, 6, 1, 6, 1, 6, 1]);\n    assert_eq!(candidate(vec![vec![12, 13, 10, 1], vec![9, 3, 15, 6], vec![5, 16, 14, 4], vec![11, 8, 7, 2]], 12), vec![1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n    assert_eq!(candidate(vec![vec![2, 7, 4], vec![3, 1, 5], vec![6, 8, 9]], 8), vec![1, 3, 1, 3, 1, 3, 1, 3]);\n    assert_eq!(candidate(vec![vec![6, 1, 5], vec![3, 8, 9], vec![2, 7, 4]], 8), vec![1, 5, 1, 5, 1, 5, 1, 5]);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]], 10), vec![1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n    assert_eq!(candidate(vec![vec![1, 3], vec![3, 2]], 10), vec![1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "rs",
+    "prompt": "/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest(vec![])\n/// None\n/// >>> longest(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// Some(String::from(\"a\"))\n/// >>> longest(vec![String::from(\"a\"), String::from(\"bb\"), String::from(\"ccc\")])\n/// Some(String::from(\"ccc\"))\nfn longest(strings: Vec<String>) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = longest;\n    assert_eq!(candidate(Vec::<String>::new()), None);\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), Some(String::from(\"x\")));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"yyy\"), String::from(\"zzzz\"), String::from(\"www\"), String::from(\"kkkk\"), String::from(\"abc\")]), Some(String::from(\"zzzz\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "rs",
+    "prompt": "/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(3)\n/// vec![1, 3, 2, 8]\nfn tri(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tri;\n    assert_eq!(candidate(3), vec![1, 3, 2, 8]);\n    assert_eq!(candidate(4), vec![1, 3, 2, 8, 3]);\n    assert_eq!(candidate(5), vec![1, 3, 2, 8, 3, 15]);\n    assert_eq!(candidate(6), vec![1, 3, 2, 8, 3, 15, 4]);\n    assert_eq!(candidate(7), vec![1, 3, 2, 8, 3, 15, 4, 24]);\n    assert_eq!(candidate(8), vec![1, 3, 2, 8, 3, 15, 4, 24, 5]);\n    assert_eq!(candidate(9), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n    assert_eq!(candidate(20), vec![1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n    assert_eq!(candidate(0), vec![1]);\n    assert_eq!(candidate(1), vec![1, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(1)\n/// 1\n/// >>> digits(4)\n/// 0\n/// >>> digits(235)\n/// 15\nfn digits(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digits;\n    assert_eq!(candidate(5), 5);\n    assert_eq!(candidate(54), 5);\n    assert_eq!(candidate(120), 1);\n    assert_eq!(candidate(5014), 5);\n    assert_eq!(candidate(98765), 315);\n    assert_eq!(candidate(5576543), 2625);\n    assert_eq!(candidate(2468), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(String::from(\"[[]]\"))\n/// true\n/// >>> is_nested(String::from(\"[]]]]]]][[[[[]\"))\n/// false\n/// >>> is_nested(String::from(\"[][]\"))\n/// false\n/// >>> is_nested(String::from(\"[]\"))\n/// false\n/// >>> is_nested(String::from(\"[[][]]\"))\n/// true\n/// >>> is_nested(String::from(\"[[]][[\"))\n/// true\nfn is_nested(string: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nested;\n    assert_eq!(candidate(String::from(\"[[]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]][[[[[]\")), false);\n    assert_eq!(candidate(String::from(\"[][]\")), false);\n    assert_eq!(candidate(String::from(\"[]\")), false);\n    assert_eq!(candidate(String::from(\"[[[[]]]]\")), true);\n    assert_eq!(candidate(String::from(\"[]]]]]]]]]]\")), false);\n    assert_eq!(candidate(String::from(\"[][][[]]\")), true);\n    assert_eq!(candidate(String::from(\"[[]\")), false);\n    assert_eq!(candidate(String::from(\"[]]\")), false);\n    assert_eq!(candidate(String::from(\"[[]][[\")), true);\n    assert_eq!(candidate(String::from(\"[[][]]\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"[[[[[[[[\")), false);\n    assert_eq!(candidate(String::from(\"]]]]]]]]\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "rs",
+    "prompt": "/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// >>> lst(vec![1.0, 2.0, 3.0])\n/// 14\n/// >>> lst(vec![1.0, 4.0, 9.0])\n/// 98\n/// >>> lst(vec![1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> lst(vec![1.4, 4.2, 0.0])\n/// 29\n/// >>> lst(vec![-2.4, 1.0, 1.0])\n/// 6\nfn sum_squares(lst: Vec<f64>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0]), 14);\n    assert_eq!(candidate(vec![1.0, 3.0, 5.0, 7.0]), 84);\n    assert_eq!(candidate(vec![1.4, 4.2, 0.0]), 29);\n    assert_eq!(candidate(vec![-2.4, 1.0, 1.0]), 6);\n    assert_eq!(candidate(vec![100.0, 1.0, 15.0, 2.0]), 10230);\n    assert_eq!(candidate(vec![10000.0, 10000.0]), 200000000);\n    assert_eq!(candidate(vec![-1.4, 4.6, 6.3]), 75);\n    assert_eq!(candidate(vec![-1.4, 17.9, 18.9, 19.9]), 1086);\n    assert_eq!(candidate(vec![0.0]), 0);\n    assert_eq!(candidate(vec![-1.0]), 1);\n    assert_eq!(candidate(vec![-1.0, 1.0, 0.0]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "rs",
+    "prompt": "/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pie\"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e\"))\n/// true\n/// >>> check_if_last_char_is_a_letter(String::from(\"apple pi e \"))\n/// false\n/// >>> check_if_last_char_is_a_letter(String::from(\"\"))\n/// false\nfn check_if_last_char_is_a_letter(txt: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_if_last_char_is_a_letter;\n    assert_eq!(candidate(String::from(\"apple\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e\")), true);\n    assert_eq!(candidate(String::from(\"eeeee\")), false);\n    assert_eq!(candidate(String::from(\"A\")), true);\n    assert_eq!(candidate(String::from(\"Pumpkin pie \")), false);\n    assert_eq!(candidate(String::from(\"Pumpkin pie 1\")), false);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"eeeee e \")), false);\n    assert_eq!(candidate(String::from(\"apple pie\")), false);\n    assert_eq!(candidate(String::from(\"apple pi e \")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "rs",
+    "prompt": "/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(vec![1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(vec![1, 2, 3])\n/// -1\nfn can_arrange(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = can_arrange;\n    assert_eq!(candidate(vec![1, 2, 4, 3, 5]), 3);\n    assert_eq!(candidate(vec![1, 2, 4, 5]), -1);\n    assert_eq!(candidate(vec![1, 4, 2, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![4, 8, 5, 7, 3]), 4);\n    assert_eq!(candidate(Vec::<isize>::new()), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "rs",
+    "prompt": "/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(vec![2, 4, 1, 3, 5, 7])\n/// (None, Some(1))\n/// >>> largest_smallest_integers(vec![])\n/// (None, None)\n/// >>> largest_smallest_integers(vec![0])\n/// (None, None)\nfn largest_smallest_integers(lst: Vec<isize>) -> (Option<isize>, Option<isize>) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_smallest_integers;\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7]), (None, Some(1)));\n    assert_eq!(candidate(vec![2, 4, 1, 3, 5, 7, 0]), (None, Some(1)));\n    assert_eq!(candidate(vec![1, 3, 2, 4, 5, 6, -2]), (Some(-2), Some(1)));\n    assert_eq!(candidate(vec![4, 5, 3, 6, 2, 7, -7]), (Some(-7), Some(2)));\n    assert_eq!(candidate(vec![7, 3, 8, 4, 9, 2, 5, -9]), (Some(-9), Some(2)));\n    assert_eq!(candidate(Vec::<isize>::new()), (None, None));\n    assert_eq!(candidate(vec![0]), (None, None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6]), (Some(-1), None));\n    assert_eq!(candidate(vec![-1, -3, -5, -6, 0]), (Some(-1), None));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, 1]), (Some(-3), Some(1)));\n    assert_eq!(candidate(vec![-6, -4, -4, -3, -100, 1]), (Some(-3), Some(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "rs",
+    "prompt": "/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(4)\n/// false\n/// >>> is_equal_to_sum_even(6)\n/// false\n/// >>> is_equal_to_sum_even(8)\n/// true\nfn is_equal_to_sum_even(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_equal_to_sum_even;\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(11), false);\n    assert_eq!(candidate(12), true);\n    assert_eq!(candidate(13), false);\n    assert_eq!(candidate(16), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "rs",
+    "prompt": "/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfn special_factorial(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = special_factorial;\n    assert_eq!(candidate(4), 288);\n    assert_eq!(candidate(5), 34560);\n    assert_eq!(candidate(7), 125411328000);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "rs",
+    "prompt": "/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfn greatest_common_divisor(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = greatest_common_divisor;\n    assert_eq!(candidate(3, 7), 1);\n    assert_eq!(candidate(10, 15), 5);\n    assert_eq!(candidate(49, 14), 7);\n    assert_eq!(candidate(144, 60), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "rs",
+    "prompt": "/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(String::from(\" Example\"))\n/// String::from(\"Example\")\n/// >>> fix_spaces(String::from(\" Example 1\"))\n/// String::from(\"Example_1\")\n/// >>> fix_spaces(String::from(\" Example 2\"))\n/// String::from(\"_Example_2\")\n/// >>> fix_spaces(String::from(\" Example 3\"))\n/// String::from(\"_Example-3\")\nfn fix_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fix_spaces;\n    assert_eq!(candidate(String::from(\"Example\")), String::from(\"Example\"));\n    assert_eq!(candidate(String::from(\"Mudasir Hanif \")), String::from(\"Mudasir_Hanif_\"));\n    assert_eq!(candidate(String::from(\"Yellow Yellow  Dirty  Fellow\")), String::from(\"Yellow_Yellow__Dirty__Fellow\"));\n    assert_eq!(candidate(String::from(\"Exa   mple\")), String::from(\"Exa-mple\"));\n    assert_eq!(candidate(String::from(\"   Exa 1 2 2 mple\")), String::from(\"-Exa_1_2_2_mple\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "rs",
+    "prompt": "/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(String::from(\"example.txt\"))\n/// String::from(\"Yes\")\n/// >>> file_name_check(String::from(\"1example.dll\"))\n/// String::from(\"No\")\nfn file_name_check(file_name: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = file_name_check;\n    assert_eq!(candidate(String::from(\"example.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1example.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s1sdf3.asd\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"K.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"MY16FILE3.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"His12FILE94.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_Y.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"?aREYA.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"/this_is_valid.dll\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.wow\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"this_is_valid.txtexe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"#this2_i4s_5valid.ten\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"@this1_is6_valid.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"this_is_12valid.6exe4.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"all.exe.txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_No.exe\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"Is3youfault.txt\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"no_one#knows.dll\")), String::from(\"Yes\"));\n    assert_eq!(candidate(String::from(\"1I563_Yes3.exe\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"I563_Yes3.txtt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final..txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"final132\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"_f4indsartal132.\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\".txt\")), String::from(\"No\"));\n    assert_eq!(candidate(String::from(\"s.\")), String::from(\"No\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "rs",
+    "prompt": "/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// >>> lst\n/// vec![1, 2, 3]\n/// >>> lst\n/// vec![]\n/// >>> lst\n/// vec![-1, -5, 2, -1, -5]\nfn sum_squares(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_squares;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![1, 4, 9]), 14);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 1, 1, 1, 1, 1]), 9);\n    assert_eq!(candidate(vec![-1, -1, -1, -1, -1, -1, -1, -1, -1]), -3);\n    assert_eq!(candidate(vec![0]), 0);\n    assert_eq!(candidate(vec![-1, -5, 2, -1, -5]), -126);\n    assert_eq!(candidate(vec![-56, -99, 1, 0, -2]), 3030);\n    assert_eq!(candidate(vec![-1, 0, 0, 0, 0, 0, 0, 0, -1]), 0);\n    assert_eq!(candidate(vec![-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]), -14196);\n    assert_eq!(candidate(vec![-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]), -1448);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "rs",
+    "prompt": "/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(String::from(\"This is a test\"))\n/// String::from(\"is\")\n/// Example 2:\n/// >>> words_in_sentence(String::from(\"lets go for swimming\"))\n/// String::from(\"go for\")\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfn words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = words_in_sentence;\n    assert_eq!(candidate(String::from(\"This is a test\")), String::from(\"is\"));\n    assert_eq!(candidate(String::from(\"lets go for swimming\")), String::from(\"go for\"));\n    assert_eq!(candidate(String::from(\"there is no place available here\")), String::from(\"there is no place\"));\n    assert_eq!(candidate(String::from(\"Hi I am Hussein\")), String::from(\"Hi am Hussein\"));\n    assert_eq!(candidate(String::from(\"go for it\")), String::from(\"go for it\"));\n    assert_eq!(candidate(String::from(\"here\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"here is\")), String::from(\"is\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "rs",
+    "prompt": "/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(String::from(\"1/5\"), String::from(\"5/1\"))\n/// true\n/// >>> simplify(String::from(\"1/6\"), String::from(\"2/1\"))\n/// false\n/// >>> simplify(String::from(\"7/10\"), String::from(\"10/2\"))\n/// false\nfn simplify(x: String, n: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = simplify;\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/6\"), String::from(\"2/1\")), false);\n    assert_eq!(candidate(String::from(\"5/1\"), String::from(\"3/1\")), true);\n    assert_eq!(candidate(String::from(\"7/10\"), String::from(\"10/2\")), false);\n    assert_eq!(candidate(String::from(\"2/10\"), String::from(\"50/10\")), true);\n    assert_eq!(candidate(String::from(\"7/2\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"11/6\"), String::from(\"6/1\")), true);\n    assert_eq!(candidate(String::from(\"2/3\"), String::from(\"5/2\")), false);\n    assert_eq!(candidate(String::from(\"5/2\"), String::from(\"3/5\")), false);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"8/4\")), true);\n    assert_eq!(candidate(String::from(\"2/4\"), String::from(\"4/2\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"5/1\")), true);\n    assert_eq!(candidate(String::from(\"1/5\"), String::from(\"1/5\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "rs",
+    "prompt": "/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points(vec![1, 11, -1, -11, -12])\n/// vec![-1, -11, 1, -12, 11]\n/// >>> order_by_points(vec![])\n/// Vec::<isize>::new()\nfn order_by_points(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = order_by_points;\n    assert_eq!(candidate(vec![1, 11, -1, -11, -12]), vec![-1, -11, 1, -12, 11]);\n    assert_eq!(candidate(vec![1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]), vec![0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, -11, -32, 43, 54, -98, 2, -3]), vec![-3, -32, -98, -11, 1, 2, 43, 54]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), vec![1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![0, 6, 6, -76, -21, 23, 4]), vec![-76, -21, 0, 4, 23, 6, 6]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1744,7 +580,7 @@
     "language": "rs",
     "prompt": "/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// >>> specialFilter(vec![15, -73, 14, -15])\n/// 1\n/// >>> specialFilter(vec![33, -2, -3, 45, 21, 109])\n/// 2\nfn specialFilter(nums: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = specialFilter;\n    assert_eq!(candidate(vec![5, -2, 1, -5]), 0);\n    assert_eq!(candidate(vec![15, -73, 14, -15]), 1);\n    assert_eq!(candidate(vec![33, -2, -3, 45, 21, 109]), 2);\n    assert_eq!(candidate(vec![43, -12, 93, 125, 121, 109]), 4);\n    assert_eq!(candidate(vec![71, -2, -33, 75, 21, 19]), 3);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(Vec::<isize>::new()), 0);\n}\n",
     "stop_tokens": [
@@ -1752,25 +588,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "rs",
-    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
+    "prompt": "/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfn get_max_triples(n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_triples;\n    assert_eq!(candidate(5), 1);\n    assert_eq!(candidate(6), 4);\n    assert_eq!(candidate(10), 36);\n    assert_eq!(candidate(100), 53361);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "rs",
-    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(vec![1, 2, 3, 2, 4])\n/// vec![1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> list_sort(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")])\n/// vec![String::from(\"aa\")]\n/// >>> list_sort(vec![String::from(\"ab\"), String::from(\"a\"), String::from(\"aaa\"), String::from(\"cd\")])\n/// vec![String::from(\"ab\"), String::from(\"cd\")]\nfn sorted_list_sum(lst: Vec<String>) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sorted_list_sum;\n    assert_eq!(candidate(vec![String::from(\"aa\"), String::from(\"a\"), String::from(\"aaa\")]), vec![String::from(\"aa\")]);\n    assert_eq!(candidate(vec![String::from(\"school\"), String::from(\"AI\"), String::from(\"asdf\"), String::from(\"b\")]), vec![String::from(\"AI\"), String::from(\"asdf\"), String::from(\"school\")]);\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"b\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"d\"), String::from(\"dcba\"), String::from(\"abcd\"), String::from(\"a\")]), vec![String::from(\"abcd\"), String::from(\"dcba\")]);\n    assert_eq!(candidate(vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]), vec![String::from(\"AI\"), String::from(\"ai\"), String::from(\"au\")]);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\"), String::from(\"c\"), String::from(\"c\"), String::from(\"a\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"aaaa\"), String::from(\"bbbb\"), String::from(\"dd\"), String::from(\"cc\")]), vec![String::from(\"cc\"), String::from(\"dd\"), String::from(\"aaaa\"), String::from(\"bbbb\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "rs",
+    "prompt": "/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(String::from(\"abc\"))\n/// vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]\nfn all_prefixes(string: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_prefixes;\n    assert_eq!(candidate(String::from(\"\")), Vec::<String>::new());\n    assert_eq!(candidate(String::from(\"asdfgh\")), vec![String::from(\"a\"), String::from(\"as\"), String::from(\"asd\"), String::from(\"asdf\"), String::from(\"asdfg\"), String::from(\"asdfgh\")]);\n    assert_eq!(candidate(String::from(\"WWW\")), vec![String::from(\"W\"), String::from(\"WW\"), String::from(\"WWW\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "rs",
+    "prompt": "/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(7, 34, 12)\n/// 34\n/// >>> x_or_y(15, 8, 5)\n/// 5\nfn x_or_y(n: isize, x: isize, y: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = x_or_y;\n    assert_eq!(candidate(7, 34, 12), 34);\n    assert_eq!(candidate(15, 8, 5), 5);\n    assert_eq!(candidate(3, 33, 5212), 33);\n    assert_eq!(candidate(1259, 3, 52), 3);\n    assert_eq!(candidate(7919, -1, 12), -1);\n    assert_eq!(candidate(3609, 1245, 583), 583);\n    assert_eq!(candidate(91, 56, 129), 129);\n    assert_eq!(candidate(6, 34, 1234), 1234);\n    assert_eq!(candidate(1, 2, 0), 0);\n    assert_eq!(candidate(2, 2, 0), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "rs",
+    "prompt": "/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(vec![1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(vec![-1, -2, 0])\n/// 0\n/// >>> double_the_difference(vec![9, -2])\n/// 81\n/// >>> double_the_difference(vec![0])\n/// 0\n/// If the input list is empty, return 0.\nfn double_the_difference(lst: Vec<f64>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = double_the_difference;\n    assert_eq!(candidate(Vec::<f64>::new()), 0);\n    assert_eq!(candidate(vec![5.0, 4.0]), 25);\n    assert_eq!(candidate(vec![0.1, 0.2, 0.3]), 0);\n    assert_eq!(candidate(vec![-10.0, -20.0, -30.0]), 0);\n    assert_eq!(candidate(vec![-1.0, -2.0, 8.0]), 0);\n    assert_eq!(candidate(vec![0.2, 3.0, 5.0]), 34);\n    assert_eq!(candidate(vec![-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]), 165);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "rs",
+    "prompt": "/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2])\n/// vec![0, 0, 0, 0, 3, 3]\n/// >>> compare(vec![0, 5, 0, 0, 0, 4], vec![4, 1, 1, 0, 0, -2])\n/// vec![4, 4, 1, 0, 0, 6]\nfn compare(game: Vec<isize>, guess: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = compare;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 1], vec![1, 2, 3, 4, 2, -2]), vec![0, 0, 0, 0, 3, 3]);\n    assert_eq!(candidate(vec![0, 0, 0, 0, 0, 0], vec![0, 0, 0, 0, 0, 0]), vec![0, 0, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![-1, -2, -3]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![1, 2, 3, 5], vec![-1, 2, 3, 4]), vec![2, 0, 0, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "rs",
+    "prompt": "/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(String::from(\"my_class\"), vec![String::from(\"AA\"), String::from(\"Be\"), String::from(\"CC\")])\n/// String::from(\"my_class.AA\")\nfn Strongest_Extension(class_name: String, extensions: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Strongest_Extension;\n    assert_eq!(candidate(String::from(\"Watashi\"), vec![String::from(\"tEN\"), String::from(\"niNE\"), String::from(\"eIGHt8OKe\")]), String::from(\"Watashi.eIGHt8OKe\"));\n    assert_eq!(candidate(String::from(\"Boku123\"), vec![String::from(\"nani\"), String::from(\"NazeDa\"), String::from(\"YEs.WeCaNe\"), String::from(\"32145tggg\")]), String::from(\"Boku123.YEs.WeCaNe\"));\n    assert_eq!(candidate(String::from(\"__YESIMHERE\"), vec![String::from(\"t\"), String::from(\"eMptY\"), String::from(\"nothing\"), String::from(\"zeR00\"), String::from(\"NuLl__\"), String::from(\"123NoooneB321\")]), String::from(\"__YESIMHERE.NuLl__\"));\n    assert_eq!(candidate(String::from(\"K\"), vec![String::from(\"Ta\"), String::from(\"TAR\"), String::from(\"t234An\"), String::from(\"cosSo\")]), String::from(\"K.TAR\"));\n    assert_eq!(candidate(String::from(\"__HAHA\"), vec![String::from(\"Tab\"), String::from(\"123\"), String::from(\"781345\"), String::from(\"-_-\")]), String::from(\"__HAHA.123\"));\n    assert_eq!(candidate(String::from(\"YameRore\"), vec![String::from(\"HhAas\"), String::from(\"okIWILL123\"), String::from(\"WorkOut\"), String::from(\"Fails\"), String::from(\"-_-\")]), String::from(\"YameRore.okIWILL123\"));\n    assert_eq!(candidate(String::from(\"finNNalLLly\"), vec![String::from(\"Die\"), String::from(\"NowW\"), String::from(\"Wow\"), String::from(\"WoW\")]), String::from(\"finNNalLLly.WoW\"));\n    assert_eq!(candidate(String::from(\"_\"), vec![String::from(\"Bb\"), String::from(\"91245\")]), String::from(\"_.Bb\"));\n    assert_eq!(candidate(String::from(\"Sp\"), vec![String::from(\"671235\"), String::from(\"Bb\")]), String::from(\"Sp.671235\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "rs",
+    "prompt": "/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(String::from(\"abcd\"), String::from(\"abd\"))\n/// false\n/// >>> cycpattern_check(String::from(\"hello\"), String::from(\"ell\"))\n/// true\n/// >>> cycpattern_check(String::from(\"whassup\"), String::from(\"psus\"))\n/// false\n/// >>> cycpattern_check(String::from(\"abab\"), String::from(\"baa\"))\n/// true\n/// >>> cycpattern_check(String::from(\"efef\"), String::from(\"eeff\"))\n/// false\n/// >>> cycpattern_check(String::from(\"himenss\"), String::from(\"simen\"))\n/// true\nfn cycpattern_check(a: String, b: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cycpattern_check;\n    assert_eq!(candidate(String::from(\"xyzw\"), String::from(\"xyw\")), false);\n    assert_eq!(candidate(String::from(\"yello\"), String::from(\"ell\")), true);\n    assert_eq!(candidate(String::from(\"whattup\"), String::from(\"ptut\")), false);\n    assert_eq!(candidate(String::from(\"efef\"), String::from(\"fee\")), true);\n    assert_eq!(candidate(String::from(\"abab\"), String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"winemtt\"), String::from(\"tinem\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "rs",
+    "prompt": "/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(-12)\n/// (1, 1)\n/// >>> even_odd_count(123)\n/// (1, 2)\nfn even_odd_count(num: isize) -> (isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_odd_count;\n    assert_eq!(candidate(7), (0, 1));\n    assert_eq!(candidate(-78), (1, 1));\n    assert_eq!(candidate(3452), (2, 2));\n    assert_eq!(candidate(346211), (3, 3));\n    assert_eq!(candidate(-345821), (3, 3));\n    assert_eq!(candidate(-2), (1, 0));\n    assert_eq!(candidate(-45347), (2, 3));\n    assert_eq!(candidate(0), (1, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "rs",
+    "prompt": "/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19)\n/// String::from(\"xix\")\n/// >>> int_to_mini_roman(152)\n/// String::from(\"clii\")\n/// >>> int_to_mini_roman(426)\n/// String::from(\"cdxxvi\")\nfn int_to_mini_roman(number: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = int_to_mini_roman;\n    assert_eq!(candidate(19), String::from(\"xix\"));\n    assert_eq!(candidate(152), String::from(\"clii\"));\n    assert_eq!(candidate(251), String::from(\"ccli\"));\n    assert_eq!(candidate(426), String::from(\"cdxxvi\"));\n    assert_eq!(candidate(500), String::from(\"d\"));\n    assert_eq!(candidate(1), String::from(\"i\"));\n    assert_eq!(candidate(4), String::from(\"iv\"));\n    assert_eq!(candidate(43), String::from(\"xliii\"));\n    assert_eq!(candidate(90), String::from(\"xc\"));\n    assert_eq!(candidate(94), String::from(\"xciv\"));\n    assert_eq!(candidate(532), String::from(\"dxxxii\"));\n    assert_eq!(candidate(900), String::from(\"cm\"));\n    assert_eq!(candidate(994), String::from(\"cmxciv\"));\n    assert_eq!(candidate(1000), String::from(\"m\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(3, 4, 5)\n/// true\n/// >>> right_angle_triangle(1, 2, 3)\n/// false\nfn right_angle_triangle(a: isize, b: isize, c: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = right_angle_triangle;\n    assert_eq!(candidate(3, 4, 5), true);\n    assert_eq!(candidate(1, 2, 3), false);\n    assert_eq!(candidate(10, 6, 8), true);\n    assert_eq!(candidate(2, 2, 2), false);\n    assert_eq!(candidate(7, 24, 25), true);\n    assert_eq!(candidate(10, 5, 7), false);\n    assert_eq!(candidate(5, 12, 13), true);\n    assert_eq!(candidate(15, 8, 17), true);\n    assert_eq!(candidate(48, 55, 73), true);\n    assert_eq!(candidate(1, 1, 1), false);\n    assert_eq!(candidate(2, 2, 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")])\n/// String::from(\"string\")\n/// >>> find_max(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")])\n/// String::from(\"enam\")\n/// >>> find_max(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")])\n/// String::from(\"aaaaaaa\")\nfn find_max(words: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_max;\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"of\"), String::from(\"string\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"name\"), String::from(\"enam\"), String::from(\"game\")]), String::from(\"enam\"));\n    assert_eq!(candidate(vec![String::from(\"aaaaaaa\"), String::from(\"bb\"), String::from(\"cc\")]), String::from(\"aaaaaaa\"));\n    assert_eq!(candidate(vec![String::from(\"abc\"), String::from(\"cba\")]), String::from(\"abc\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"this\"), String::from(\"game\"), String::from(\"of\"), String::from(\"footbott\")]), String::from(\"footbott\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"gonna\"), String::from(\"rock\")]), String::from(\"gonna\"));\n    assert_eq!(candidate(vec![String::from(\"we\"), String::from(\"are\"), String::from(\"a\"), String::from(\"mad\"), String::from(\"nation\")]), String::from(\"nation\"));\n    assert_eq!(candidate(vec![String::from(\"this\"), String::from(\"is\"), String::from(\"a\"), String::from(\"prrk\")]), String::from(\"this\"));\n    assert_eq!(candidate(vec![String::from(\"b\")]), String::from(\"b\"));\n    assert_eq!(candidate(vec![String::from(\"play\"), String::from(\"play\"), String::from(\"play\")]), String::from(\"play\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "rs",
+    "prompt": "/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(5, 6, 10)\n/// vec![11, 4]\n/// >>> eat(4, 8, 9)\n/// vec![12, 1]\n/// >>> eat(1, 10, 10)\n/// vec![11, 0]\n/// >>> eat(2, 11, 5)\n/// vec![7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfn eat(number: isize, need: isize, remaining: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = eat;\n    assert_eq!(candidate(5, 6, 10), vec![11, 4]);\n    assert_eq!(candidate(4, 8, 9), vec![12, 1]);\n    assert_eq!(candidate(1, 10, 10), vec![11, 0]);\n    assert_eq!(candidate(2, 11, 5), vec![7, 0]);\n    assert_eq!(candidate(4, 5, 7), vec![9, 2]);\n    assert_eq!(candidate(4, 5, 1), vec![5, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "rs",
+    "prompt": "/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// String::from(\"0\")\n/// >>> string_sequence(5)\n/// String::from(\"0 1 2 3 4 5\")\nfn string_sequence(n: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_sequence;\n    assert_eq!(candidate(0), String::from(\"0\"));\n    assert_eq!(candidate(3), String::from(\"0 1 2 3\"));\n    assert_eq!(candidate(10), String::from(\"0 1 2 3 4 5 6 7 8 9 10\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "rs",
+    "prompt": "/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfn do_algebra(operator: Vec<String>, operand: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = do_algebra;\n    assert_eq!(candidate(vec![String::from(\"**\"), String::from(\"*\"), String::from(\"+\")], vec![2, 3, 4, 5]), 37);\n    assert_eq!(candidate(vec![String::from(\"+\"), String::from(\"*\"), String::from(\"-\")], vec![2, 3, 4, 5]), 9);\n    assert_eq!(candidate(vec![String::from(\"//\"), String::from(\"*\")], vec![7, 3, 4]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(String::from(\"1234\"))\n/// String::from(\"4321\")\n/// >>> solve(String::from(\"ab\"))\n/// String::from(\"AB\")\n/// >>> solve(String::from(\"#a@C\"))\n/// String::from(\"#A@c\")\nfn solve(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(String::from(\"AsDf\")), String::from(\"aSdF\"));\n    assert_eq!(candidate(String::from(\"1234\")), String::from(\"4321\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"AB\"));\n    assert_eq!(candidate(String::from(\"#a@C\")), String::from(\"#A@c\"));\n    assert_eq!(candidate(String::from(\"#AsdfW^45\")), String::from(\"#aSDFw^45\"));\n    assert_eq!(candidate(String::from(\"#6@2\")), String::from(\"2@6#\"));\n    assert_eq!(candidate(String::from(\"#$a^D\")), String::from(\"#$A^d\"));\n    assert_eq!(candidate(String::from(\"#ccc\")), String::from(\"#CCC\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "rs",
+    "prompt": "/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(String::from(\"Hello world\"))\n/// Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\"))\nfn string_to_md5(text: String) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_md5;\n    assert_eq!(candidate(String::from(\"Hello world\")), Some(String::from(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert_eq!(candidate(String::from(\"\")), None);\n    assert_eq!(candidate(String::from(\"A B C\")), Some(String::from(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert_eq!(candidate(String::from(\"password\")), Some(String::from(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1780,7 +796,7 @@
     "language": "rs",
     "prompt": "/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// >>> generate_integers(2, 8)\n/// vec![2, 4, 6, 8]\n/// >>> generate_integers(8, 2)\n/// vec![2, 4, 6, 8]\n/// >>> generate_integers(10, 14)\n/// Vec::<isize>::new()\nfn generate_integers(a: isize, b: isize) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = generate_integers;\n    assert_eq!(candidate(2, 10), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(10, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(132, 2), vec![2, 4, 6, 8]);\n    assert_eq!(candidate(17, 89), Vec::<isize>::new());\n}\n",
     "stop_tokens": [
@@ -1788,49 +804,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "rs",
-    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(vec![1, 2, 3, 2, 3, 4, 2])\n/// vec![1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(String::from(\"xyzXYZ\"))\n/// 3\n/// >>> count_distinct_characters(String::from(\"Jerry\"))\n/// 4\nfn count_distinct_characters(string: String) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count_distinct_characters;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abcde\")), 5);\n    assert_eq!(candidate(String::from(\"abcdecadeCADE\")), 5);\n    assert_eq!(candidate(String::from(\"aaaaAAAAaaaa\")), 1);\n    assert_eq!(candidate(String::from(\"Jerry jERRY JeRRRY\")), 5);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "rs",
-    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero(vec![1, 2, 3])\n/// false\n/// >>> below_zero(vec![1, 2, -4, 5])\n/// true\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "prompt": "/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(String::from(\"o o| .| o| o| .| .| .| .| o o\"))\n/// vec![4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfn parse_music(music_string: String) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_music;\n    assert_eq!(candidate(String::from(\"\")), Vec::<isize>::new());\n    assert_eq!(candidate(String::from(\"o o o o\")), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\".| .| .| .|\")), vec![1, 1, 1, 1]);\n    assert_eq!(candidate(String::from(\"o| o| .| .| o o o o\")), vec![2, 2, 1, 1, 4, 4, 4, 4]);\n    assert_eq!(candidate(String::from(\"o| .| o| .| o o| o o|\")), vec![2, 1, 2, 1, 4, 2, 4, 2]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "rs",
-    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(vec![4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(vec![1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(vec![5, 5, 4, 4, 4])\n/// -1\nfn search(lst: Vec<isize>) -> isize {\n",
+    "prompt": "/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(String::from(\"\"), String::from(\"a\"))\n/// 0\n/// >>> how_many_times(String::from(\"aaa\"), String::from(\"a\"))\n/// 3\n/// >>> how_many_times(String::from(\"aaaa\"), String::from(\"aa\"))\n/// 3\nfn how_many_times(string: String, substring: String) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = how_many_times;\n    assert_eq!(candidate(String::from(\"\"), String::from(\"x\")), 0);\n    assert_eq!(candidate(String::from(\"xyxyxyx\"), String::from(\"x\")), 4);\n    assert_eq!(candidate(String::from(\"cacacacac\"), String::from(\"cac\")), 4);\n    assert_eq!(candidate(String::from(\"john doe\"), String::from(\"john\")), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "rs",
-    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"(\"))\n/// false\n/// >>> correct_bracketing(String::from(\"()\"))\n/// true\n/// >>> correct_bracketing(String::from(\"(()())\"))\n/// true\n/// >>> correct_bracketing(String::from(\")(()\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "prompt": "/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(String::from(\"three one five\"))\n/// String::from(\"one three five\")\nfn sort_numbers(numbers: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numbers;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"three\")), String::from(\"three\"));\n    assert_eq!(candidate(String::from(\"three five nine\")), String::from(\"three five nine\"));\n    assert_eq!(candidate(String::from(\"five zero four seven nine eight\")), String::from(\"zero four five seven eight nine\"));\n    assert_eq!(candidate(String::from(\"six five four three two one zero\")), String::from(\"zero one two three four five six\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(String::from(\"( ) (( )) (( )( ))\"))\n/// vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]\nfn separate_paren_groups(paren_string: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = separate_paren_groups;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![String::from(\"(()())\"), String::from(\"((()))\"), String::from(\"()\"), String::from(\"((())()())\")]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"((()))\"), String::from(\"(((())))\")]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![String::from(\"(()(())((())))\")]);\n    assert_eq!(candidate(String::from(\"( ) (( )) (( )( ))\")), vec![String::from(\"()\"), String::from(\"(())\"), String::from(\"(()())\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "rs",
+    "prompt": "/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfn find_closest_elements(numbers: Vec<f64>) -> (f64, f64) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_closest_elements;\n    assert_eq!(candidate(vec![1.0, 2.0, 3.9, 4.0, 5.0, 2.2]), (3.9, 4.0));\n    assert_eq!(candidate(vec![1.0, 2.0, 5.9, 4.0, 5.0]), (5.0, 5.9));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.2]), (2.0, 2.2));\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0, 2.0]), (2.0, 2.0));\n    assert_eq!(candidate(vec![1.1, 2.2, 3.1, 4.1, 5.1]), (2.2, 3.1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "rs",
+    "prompt": "/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(vec![1.0, 2.0, 3.0, 4.0, 5.0])\n/// vec![0.0, 0.25, 0.5, 0.75, 1.0]\nfn rescale_to_unit(numbers: Vec<f64>) -> Vec<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rescale_to_unit;\n    assert_eq!(candidate(vec![2.0, 49.9]), vec![0.0, 1.0]);\n    assert_eq!(candidate(vec![100.0, 49.9]), vec![1.0, 0.0]);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), vec![0.0, 0.25, 0.5, 0.75, 1.0]);\n    assert_eq!(candidate(vec![2.0, 1.0, 5.0, 3.0, 4.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n    assert_eq!(candidate(vec![12.0, 11.0, 15.0, 13.0, 14.0]), vec![0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "rs",
+    "prompt": "/// Return length of given string\n/// >>> strlen(String::from(\"\"))\n/// 0\n/// >>> strlen(String::from(\"abc\"))\n/// 3\nfn strlen(string: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strlen;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"x\")), 1);\n    assert_eq!(candidate(String::from(\"asdasnakj\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "rs",
+    "prompt": "/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfn largest_divisor(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_divisor;\n    assert_eq!(candidate(3), 1);\n    assert_eq!(candidate(7), 1);\n    assert_eq!(candidate(10), 5);\n    assert_eq!(candidate(100), 50);\n    assert_eq!(candidate(49), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "rs",
+    "prompt": "/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// vec![2, 2, 2]\n/// >>> factorize(25)\n/// vec![5, 5]\n/// >>> factorize(70)\n/// vec![2, 5, 7]\nfn factorize(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = factorize;\n    assert_eq!(candidate(2), vec![2]);\n    assert_eq!(candidate(4), vec![2, 2]);\n    assert_eq!(candidate(8), vec![2, 2, 2]);\n    assert_eq!(candidate(57), vec![3, 19]);\n    assert_eq!(candidate(3249), vec![3, 3, 19, 19]);\n    assert_eq!(candidate(185193), vec![3, 3, 3, 19, 19, 19]);\n    assert_eq!(candidate(20577), vec![3, 19, 19, 19]);\n    assert_eq!(candidate(18), vec![2, 3, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "rs",
+    "prompt": "/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(vec![1, 2, 3, 2, 4])\n/// vec![1, 3, 4]\nfn remove_duplicates(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_duplicates;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 3, 5]), vec![1, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "rs",
+    "prompt": "/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(String::from(\"Hello\"))\n/// String::from(\"hELLO\")\nfn flip_case(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = flip_case;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hello!\")), String::from(\"hELLO!\"));\n    assert_eq!(candidate(String::from(\"These violent delights have violent ends\")), String::from(\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "rs",
+    "prompt": "/// Concatenate list of strings into a single string\n/// >>> concatenate(vec![])\n/// String::from(\"\")\n/// >>> concatenate(vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")])\n/// String::from(\"abc\")\nfn concatenate(strings: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate;\n    assert_eq!(candidate(Vec::<String>::new()), String::from(\"\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")]), String::from(\"xyz\"));\n    assert_eq!(candidate(vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\"), String::from(\"w\"), String::from(\"k\")]), String::from(\"xyzwk\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_prefix(vec![String::from(\"abc\"), String::from(\"bcd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"array\")]\nfn filter_by_prefix(strings: Vec<String>, prefix: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_prefix;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "rs",
+    "prompt": "/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfn truncate_number(number: f64) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = truncate_number;\n    assert_eq!(candidate(3.5), 0.5);\n    assert_eq!(candidate(1.25), 0.25);\n    assert_eq!(candidate(123.0), 0.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "rs",
+    "prompt": "/// Return only positive numbers in the list.\n/// >>> get_positive(vec![-1, 2, -4, 5, 6])\n/// vec![2, 5, 6]\n/// >>> get_positive(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// vec![5, 3, 2, 3, 9, 123, 1]\nfn get_positive(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_positive;\n    assert_eq!(candidate(vec![-1, -2, 4, 5, 6]), vec![4, 5, 6]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]), vec![5, 3, 2, 3, 3, 9, 123, 1]);\n    assert_eq!(candidate(vec![-1, -2]), Vec::<isize>::new());\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "rs",
+    "prompt": "/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// false\n/// >>> is_prime(101)\n/// true\n/// >>> is_prime(11)\n/// true\n/// >>> is_prime(13441)\n/// true\n/// >>> is_prime(61)\n/// true\n/// >>> is_prime(4)\n/// false\n/// >>> is_prime(1)\n/// false\nfn is_prime(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_prime;\n    assert_eq!(candidate(6), false);\n    assert_eq!(candidate(101), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(13441), true);\n    assert_eq!(candidate(61), true);\n    assert_eq!(candidate(4), false);\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(11), true);\n    assert_eq!(candidate(17), true);\n    assert_eq!(candidate(85), false);\n    assert_eq!(candidate(77), false);\n    assert_eq!(candidate(255379), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "rs",
+    "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_third(vec![5, 6, 3, 4, 8, 9, 2])\n/// vec![2, 6, 3, 4, 8, 9, 5]\nfn sort_third(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_third;\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2]), vec![2, 6, 3, 4, 8, 9, 5]);\n    assert_eq!(candidate(vec![5, 8, 3, 4, 6, 9, 2]), vec![2, 8, 3, 4, 6, 9, 5]);\n    assert_eq!(candidate(vec![5, 6, 9, 4, 8, 3, 2]), vec![2, 6, 9, 4, 8, 3, 5]);\n    assert_eq!(candidate(vec![5, 6, 3, 4, 8, 9, 2, 1]), vec![2, 6, 3, 4, 8, 9, 5, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "rs",
+    "prompt": "/// Return sorted unique elements in a list\n/// >>> unique(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![0, 2, 3, 5, 9, 123]\nfn unique(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = unique;\n    assert_eq!(candidate(vec![5, 3, 5, 2, 3, 3, 9, 0, 123]), vec![0, 2, 3, 5, 9, 123]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "rs",
+    "prompt": "/// Return maximum element in the list.\n/// >>> max_element(vec![1, 2, 3])\n/// 3\n/// >>> max_element(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfn max_element(l: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_element;\n    assert_eq!(candidate(vec![1, 2, 3]), 3);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "rs",
+    "prompt": "/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfn fizz_buzz(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fizz_buzz;\n    assert_eq!(candidate(50), 0);\n    assert_eq!(candidate(78), 2);\n    assert_eq!(candidate(79), 3);\n    assert_eq!(candidate(100), 3);\n    assert_eq!(candidate(200), 6);\n    assert_eq!(candidate(4000), 192);\n    assert_eq!(candidate(10000), 639);\n    assert_eq!(candidate(100000), 8026);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1840,9 +1060,201 @@
     "language": "rs",
     "prompt": "/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even(vec![1, 2, 3])\n/// vec![1, 2, 3]\n/// >>> sort_even(vec![5, 6, 3, 4])\n/// vec![3, 6, 5, 4]\nfn sort_even(l: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = sort_even;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![1, 2, 3]);\n    assert_eq!(candidate(vec![5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]), vec![-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n    assert_eq!(candidate(vec![5, 8, -12, 4, 23, 2, 3, 11, 12, -10]), vec![-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "rs",
+    "prompt": "/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfn prime_fib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_fib;\n    assert_eq!(candidate(1), 2);\n    assert_eq!(candidate(2), 3);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 13);\n    assert_eq!(candidate(5), 89);\n    assert_eq!(candidate(6), 233);\n    assert_eq!(candidate(7), 1597);\n    assert_eq!(candidate(8), 28657);\n    assert_eq!(candidate(9), 514229);\n    assert_eq!(candidate(10), 433494437);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "rs",
+    "prompt": "/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero(vec![1, 2, 3])\n/// false\n/// >>> below_zero(vec![1, 2, -4, 5])\n/// true\nfn below_zero(operations: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_zero;\n    assert_eq!(candidate(Vec::<isize>::new()), false);\n    assert_eq!(candidate(vec![1, 2, -3, 1, 2, -3]), false);\n    assert_eq!(candidate(vec![1, 2, -4, 5, 6]), true);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -4]), false);\n    assert_eq!(candidate(vec![1, -1, 2, -2, 5, -5, 4, -5]), true);\n    assert_eq!(candidate(vec![1, -2, 2, -2, 5, -5, 4, -4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(vec![1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(vec![2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(vec![1])\n/// false\nfn triples_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triples_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -1]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![1, 2, 5, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 9, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![1, 3, 5, -100]), false);\n    assert_eq!(candidate(vec![100, 3, 5, -100]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "rs",
+    "prompt": "/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfn car_race_collision(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = car_race_collision;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 9);\n    assert_eq!(candidate(4), 16);\n    assert_eq!(candidate(8), 64);\n    assert_eq!(candidate(10), 100);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "rs",
+    "prompt": "/// Return list with elements incremented by 1.\n/// >>> incr_list(vec![1, 2, 3])\n/// vec![2, 3, 4]\n/// >>> incr_list(vec![5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// vec![6, 4, 6, 3, 4, 4, 10, 1, 124]\nfn incr_list(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = incr_list;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![3, 2, 1]), vec![4, 3, 2]);\n    assert_eq!(candidate(vec![5, 2, 5, 2, 3, 3, 9, 0, 123]), vec![6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "rs",
+    "prompt": "/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero(vec![1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(vec![1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(vec![2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(vec![1])\n/// false\nfn pairs_sum_to_zero(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pairs_sum_to_zero;\n    assert_eq!(candidate(vec![1, 3, 5, 0]), false);\n    assert_eq!(candidate(vec![1, 3, -2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, -5, 3, 5, 7]), true);\n    assert_eq!(candidate(vec![1]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 30]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 3, 2, 31]), true);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 30]), false);\n    assert_eq!(candidate(vec![-3, 9, -1, 4, 2, 31]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "rs",
+    "prompt": "/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// String::from(\"22\")\n/// >>> change_base(8, 2)\n/// String::from(\"1000\")\n/// >>> change_base(7, 2)\n/// String::from(\"111\")\nfn change_base(x: isize, base: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = change_base;\n    assert_eq!(candidate(8, 3), String::from(\"22\"));\n    assert_eq!(candidate(9, 3), String::from(\"100\"));\n    assert_eq!(candidate(234, 2), String::from(\"11101010\"));\n    assert_eq!(candidate(16, 2), String::from(\"10000\"));\n    assert_eq!(candidate(8, 2), String::from(\"1000\"));\n    assert_eq!(candidate(7, 2), String::from(\"111\"));\n    assert_eq!(candidate(2, 3), String::from(\"2\"));\n    assert_eq!(candidate(3, 4), String::from(\"3\"));\n    assert_eq!(candidate(4, 5), String::from(\"4\"));\n    assert_eq!(candidate(5, 6), String::from(\"5\"));\n    assert_eq!(candidate(6, 7), String::from(\"6\"));\n    assert_eq!(candidate(7, 8), String::from(\"7\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfn triangle_area(a: isize, h: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(5, 3), 7.5);\n    assert_eq!(candidate(2, 2), 2.0);\n    assert_eq!(candidate(10, 8), 40.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "rs",
+    "prompt": "/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfn fib4(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib4;\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 28);\n    assert_eq!(candidate(10), 104);\n    assert_eq!(candidate(12), 386);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "rs",
+    "prompt": "/// Return median of elements in the list l.\n/// >>> median(vec![3, 1, 2, 4, 5])\n/// 3.0\n/// >>> median(vec![-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfn median(l: Vec<isize>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = median;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), 3.0);\n    assert_eq!(candidate(vec![-10, 4, 6, 1000, 10, 20]), 8.0);\n    assert_eq!(candidate(vec![5]), 5.0);\n    assert_eq!(candidate(vec![6, 5]), 5.5);\n    assert_eq!(candidate(vec![8, 1, 3, 9, 9, 2, 7]), 7.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "rs",
+    "prompt": "/// Checks if given string is a palindrome\n/// >>> is_palindrome(String::from(\"\"))\n/// true\n/// >>> is_palindrome(String::from(\"aba\"))\n/// true\n/// >>> is_palindrome(String::from(\"aaaaa\"))\n/// true\n/// >>> is_palindrome(String::from(\"zbcd\"))\n/// false\nfn is_palindrome(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_palindrome;\n    assert_eq!(candidate(String::from(\"\")), true);\n    assert_eq!(candidate(String::from(\"aba\")), true);\n    assert_eq!(candidate(String::from(\"aaaaa\")), true);\n    assert_eq!(candidate(String::from(\"zbcd\")), false);\n    assert_eq!(candidate(String::from(\"xywyx\")), true);\n    assert_eq!(candidate(String::from(\"xywyz\")), false);\n    assert_eq!(candidate(String::from(\"xywzx\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "rs",
+    "prompt": "/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfn modp(n: isize, p: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = modp;\n    assert_eq!(candidate(3, 5), 3);\n    assert_eq!(candidate(1101, 101), 2);\n    assert_eq!(candidate(0, 101), 1);\n    assert_eq!(candidate(3, 11), 8);\n    assert_eq!(candidate(100, 101), 1);\n    assert_eq!(candidate(30, 5), 4);\n    assert_eq!(candidate(31, 5), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "rs",
+    "prompt": "/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(vec![1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfn mean_absolute_deviation(numbers: Vec<f64>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = mean_absolute_deviation;\n    assert_eq!(candidate(vec![1.0, 2.0]), 0.5);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0]), 1.0);\n    assert_eq!(candidate(vec![1.0, 2.0, 3.0, 4.0, 5.0]), 1.2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "rs",
+    "prompt": "/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(String::from(\"\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"abcdef\"))\n/// String::from(\"bcdf\")\n/// >>> remove_vowels(String::from(\"aaaaa\"))\n/// String::from(\"\")\n/// >>> remove_vowels(String::from(\"aaBAA\"))\n/// String::from(\"B\")\n/// >>> remove_vowels(String::from(\"zbcd\"))\n/// String::from(\"zbcd\")\nfn remove_vowels(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_vowels;\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"abcdef\nghijklm\")), String::from(\"bcdf\nghjklm\"));\n    assert_eq!(candidate(String::from(\"fedcba\")), String::from(\"fdcb\"));\n    assert_eq!(candidate(String::from(\"eeeee\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"acBAA\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"EcBOO\")), String::from(\"cB\"));\n    assert_eq!(candidate(String::from(\"ybcd\")), String::from(\"ybcd\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "rs",
+    "prompt": "/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold(vec![1, 2, 4, 10], 100)\n/// true\n/// >>> below_threshold(vec![1, 20, 4, 10], 5)\n/// false\nfn below_threshold(l: Vec<isize>, t: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = below_threshold;\n    assert_eq!(candidate(vec![1, 2, 4, 10], 100), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 5), false);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 21), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10], 22), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 11), true);\n    assert_eq!(candidate(vec![1, 8, 4, 10], 10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "rs",
+    "prompt": "/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfn add(x: isize, y: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(0, 1), 1);\n    assert_eq!(candidate(1, 0), 1);\n    assert_eq!(candidate(2, 3), 5);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 5), 12);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1852,9 +1264,21 @@
     "language": "rs",
     "prompt": "/// Check if two words have the same characters.\n/// >>> same_chars(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\"))\n/// true\n/// >>> same_chars(String::from(\"abcd\"), String::from(\"dddddddabc\"))\n/// true\n/// >>> same_chars(String::from(\"dddddddabc\"), String::from(\"abcd\"))\n/// true\n/// >>> same_chars(String::from(\"eabcd\"), String::from(\"dddddddabc\"))\n/// false\n/// >>> same_chars(String::from(\"abcd\"), String::from(\"dddddddabce\"))\n/// false\n/// >>> same_chars(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\"))\n/// false\nfn same_chars(s0: String, s1: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = same_chars;\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddeddabc\")), true);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabc\")), true);\n    assert_eq!(candidate(String::from(\"dddddddabc\"), String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"eabcd\"), String::from(\"dddddddabc\")), false);\n    assert_eq!(candidate(String::from(\"abcd\"), String::from(\"dddddddabcf\")), false);\n    assert_eq!(candidate(String::from(\"eabcdzzzz\"), String::from(\"dddzzzzzzzddddabc\")), false);\n    assert_eq!(candidate(String::from(\"aabb\"), String::from(\"aaccc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "rs",
+    "prompt": "/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfn fib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fib;\n    assert_eq!(candidate(10), 55);\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(8), 21);\n    assert_eq!(candidate(11), 89);\n    assert_eq!(candidate(12), 144);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1288,585 @@
     "language": "rs",
     "prompt": "/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"<\"))\n/// false\n/// >>> correct_bracketing(String::from(\"<>\"))\n/// true\n/// >>> correct_bracketing(String::from(\"<<><>>\"))\n/// true\n/// >>> correct_bracketing(String::from(\"><<>\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"<>\")), true);\n    assert_eq!(candidate(String::from(\"<<><>>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<><>><>\")), true);\n    assert_eq!(candidate(String::from(\"<><><<<><><>><>><<><><<>>>\")), true);\n    assert_eq!(candidate(String::from(\"<<<><>>>>\")), false);\n    assert_eq!(candidate(String::from(\"><<>\")), false);\n    assert_eq!(candidate(String::from(\"<\")), false);\n    assert_eq!(candidate(String::from(\"<<<<\")), false);\n    assert_eq!(candidate(String::from(\">\")), false);\n    assert_eq!(candidate(String::from(\"<<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>><<>\")), false);\n    assert_eq!(candidate(String::from(\"<><><<><>><>>><>\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "rs",
+    "prompt": "/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic(vec![1, 2, 4, 20])\n/// true\n/// >>> monotonic(vec![1, 20, 4, 10])\n/// false\n/// >>> monotonic(vec![4, 1, 0, -10])\n/// true\nfn monotonic(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = monotonic;\n    assert_eq!(candidate(vec![1, 2, 4, 10]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 20]), true);\n    assert_eq!(candidate(vec![1, 20, 4, 10]), false);\n    assert_eq!(candidate(vec![4, 1, 0, -10]), true);\n    assert_eq!(candidate(vec![4, 1, 1, 0]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 5, 60]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 60]), true);\n    assert_eq!(candidate(vec![9, 9, 9, 9]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "rs",
+    "prompt": "/// Return sorted unique common elements for two lists.\n/// >>> common(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121])\n/// vec![1, 5, 653]\n/// >>> common(vec![5, 3, 2, 8], vec![3, 2])\n/// vec![2, 3]\nfn common(l1: Vec<isize>, l2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = common;\n    assert_eq!(candidate(vec![1, 4, 3, 34, 653, 2, 5], vec![5, 7, 1, 5, 9, 653, 121]), vec![1, 5, 653]);\n    assert_eq!(candidate(vec![5, 3, 2, 8], vec![3, 2]), vec![2, 3]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], vec![3, 2, 4]), vec![2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 8], Vec::<isize>::new()), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "rs",
+    "prompt": "/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfn largest_prime_factor(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_prime_factor;\n    assert_eq!(candidate(15), 5);\n    assert_eq!(candidate(27), 3);\n    assert_eq!(candidate(63), 7);\n    assert_eq!(candidate(330), 11);\n    assert_eq!(candidate(13195), 29);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "rs",
+    "prompt": "/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse(vec![], 4)\n/// Vec::<isize>::new()\n/// >>> intersperse(vec![1, 2, 3], 4)\n/// vec![1, 4, 2, 4, 3]\nfn intersperse(numbers: Vec<isize>, delimeter: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = intersperse;\n    assert_eq!(candidate(Vec::<isize>::new(), 7), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 6, 3, 2], 8), vec![5, 8, 6, 8, 3, 8, 2]);\n    assert_eq!(candidate(vec![2, 2, 2], 2), vec![2, 2, 2, 2, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "rs",
+    "prompt": "/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfn sum_to_n(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_to_n;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(6), 21);\n    assert_eq!(candidate(11), 66);\n    assert_eq!(candidate(30), 465);\n    assert_eq!(candidate(100), 5050);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "rs",
+    "prompt": "/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(String::from(\"(\"))\n/// false\n/// >>> correct_bracketing(String::from(\"()\"))\n/// true\n/// >>> correct_bracketing(String::from(\"(()())\"))\n/// true\n/// >>> correct_bracketing(String::from(\")(()\"))\n/// false\nfn correct_bracketing(brackets: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = correct_bracketing;\n    assert_eq!(candidate(String::from(\"()\")), true);\n    assert_eq!(candidate(String::from(\"(()())\")), true);\n    assert_eq!(candidate(String::from(\"()()(()())()\")), true);\n    assert_eq!(candidate(String::from(\"()()((()()())())(()()(()))\")), true);\n    assert_eq!(candidate(String::from(\"((()())))\")), false);\n    assert_eq!(candidate(String::from(\")(()\")), false);\n    assert_eq!(candidate(String::from(\"(\")), false);\n    assert_eq!(candidate(String::from(\"((((\")), false);\n    assert_eq!(candidate(String::from(\")\")), false);\n    assert_eq!(candidate(String::from(\"(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())())(()\")), false);\n    assert_eq!(candidate(String::from(\"()()(()())()))()\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "rs",
+    "prompt": "/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(vec![3, 1, 2, 4, 5])\n/// vec![1, 4, 12, 20]\n/// >>> derivative(vec![1, 2, 3])\n/// vec![2, 6]\nfn derivative(xs: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = derivative;\n    assert_eq!(candidate(vec![3, 1, 2, 4, 5]), vec![1, 4, 12, 20]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 6]);\n    assert_eq!(candidate(vec![3, 2, 1]), vec![2, 2]);\n    assert_eq!(candidate(vec![3, 2, 1, 0, 4]), vec![2, 2, 0, 16]);\n    assert_eq!(candidate(vec![1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "rs",
+    "prompt": "/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfn fibfib(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fibfib;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(1), 0);\n    assert_eq!(candidate(5), 4);\n    assert_eq!(candidate(8), 24);\n    assert_eq!(candidate(10), 81);\n    assert_eq!(candidate(12), 274);\n    assert_eq!(candidate(14), 927);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "rs",
+    "prompt": "/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(String::from(\"abcde\"))\n/// 2\n/// >>> vowels_count(String::from(\"ACEDY\"))\n/// 3\nfn vowels_count(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = vowels_count;\n    assert_eq!(candidate(String::from(\"abcde\")), 2);\n    assert_eq!(candidate(String::from(\"Alone\")), 3);\n    assert_eq!(candidate(String::from(\"key\")), 2);\n    assert_eq!(candidate(String::from(\"bye\")), 1);\n    assert_eq!(candidate(String::from(\"keY\")), 2);\n    assert_eq!(candidate(String::from(\"bYe\")), 1);\n    assert_eq!(candidate(String::from(\"ACEDY\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "rs",
+    "prompt": "/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// String::from(\"21\")\n/// >>> circular_shift(12, 2)\n/// String::from(\"12\")\nfn circular_shift(x: isize, shift: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = circular_shift;\n    assert_eq!(candidate(100, 2), String::from(\"001\"));\n    assert_eq!(candidate(12, 2), String::from(\"12\"));\n    assert_eq!(candidate(97, 8), String::from(\"79\"));\n    assert_eq!(candidate(12, 1), String::from(\"21\"));\n    assert_eq!(candidate(11, 101), String::from(\"11\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "rs",
+    "prompt": "/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(String::from(\"\"))\n/// 0\n/// >>> digitSum(String::from(\"abAB\"))\n/// 131\n/// >>> digitSum(String::from(\"abcCd\"))\n/// 67\n/// >>> digitSum(String::from(\"helloE\"))\n/// 69\n/// >>> digitSum(String::from(\"woArBld\"))\n/// 131\n/// >>> digitSum(String::from(\"aAaaaXa\"))\n/// 153\nfn digitSum(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digitSum;\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"abAB\")), 131);\n    assert_eq!(candidate(String::from(\"abcCd\")), 67);\n    assert_eq!(candidate(String::from(\"helloE\")), 69);\n    assert_eq!(candidate(String::from(\"woArBld\")), 131);\n    assert_eq!(candidate(String::from(\"aAaaaXa\")), 153);\n    assert_eq!(candidate(String::from(\" How are yOu?\")), 151);\n    assert_eq!(candidate(String::from(\"You arE Very Smart\")), 327);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "rs",
+    "prompt": "/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(String::from(\"5 apples and 6 oranges\"), 19)\n/// 8\n/// >>> fruit_distribution(String::from(\"0 apples and 1 oranges\"), 3)\n/// 2\n/// >>> fruit_distribution(String::from(\"2 apples and 3 oranges\"), 100)\n/// 95\n/// >>> fruit_distribution(String::from(\"100 apples and 1 oranges\"), 120)\n/// 19\nfn fruit_distribution(s: String, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = fruit_distribution;\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 19), 8);\n    assert_eq!(candidate(String::from(\"5 apples and 6 oranges\"), 21), 10);\n    assert_eq!(candidate(String::from(\"0 apples and 1 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"1 apples and 0 oranges\"), 3), 2);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 100), 95);\n    assert_eq!(candidate(String::from(\"2 apples and 3 oranges\"), 5), 0);\n    assert_eq!(candidate(String::from(\"1 apples and 100 oranges\"), 120), 19);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "rs",
+    "prompt": "/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(vec![4, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(vec![1, 2, 3])\n/// vec![2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(vec![])\n/// Vec::<isize>::new()\n/// Example 4:\n/// >>> pluck(vec![5, 0, 3, 0, 4, 2])\n/// vec![0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfn pluck(arr: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pluck;\n    assert_eq!(candidate(vec![4, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2, 1]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5, 0, 3, 0, 4, 2]), vec![0, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 0, 5, 3]), vec![0, 3]);\n    assert_eq!(candidate(vec![5, 4, 8, 4, 8]), vec![4, 1]);\n    assert_eq!(candidate(vec![7, 6, 7, 1]), vec![6, 1]);\n    assert_eq!(candidate(vec![7, 9, 7, 1]), Vec::<isize>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "rs",
+    "prompt": "/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(vec![4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(vec![1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(vec![5, 5, 4, 4, 4])\n/// -1\nfn search(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![5, 5, 5, 5, 1]), 1);\n    assert_eq!(candidate(vec![4, 1, 4, 1, 4, 4]), 4);\n    assert_eq!(candidate(vec![3, 3]), -1);\n    assert_eq!(candidate(vec![8, 8, 8, 8, 8, 8, 8, 8]), 8);\n    assert_eq!(candidate(vec![2, 3, 3, 2, 2]), 2);\n    assert_eq!(candidate(vec![2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]), 1);\n    assert_eq!(candidate(vec![3, 2, 8, 2]), 2);\n    assert_eq!(candidate(vec![6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]), 1);\n    assert_eq!(candidate(vec![8, 8, 3, 6, 5, 6, 4]), -1);\n    assert_eq!(candidate(vec![6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]), 1);\n    assert_eq!(candidate(vec![1, 9, 10, 1, 3]), 1);\n    assert_eq!(candidate(vec![6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]), 5);\n    assert_eq!(candidate(vec![1]), 1);\n    assert_eq!(candidate(vec![8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]), 4);\n    assert_eq!(candidate(vec![2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]), 2);\n    assert_eq!(candidate(vec![1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]), 1);\n    assert_eq!(candidate(vec![9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]), 4);\n    assert_eq!(candidate(vec![2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]), 4);\n    assert_eq!(candidate(vec![9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]), 2);\n    assert_eq!(candidate(vec![5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]), -1);\n    assert_eq!(candidate(vec![10]), -1);\n    assert_eq!(candidate(vec![9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]), 2);\n    assert_eq!(candidate(vec![5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]), 1);\n    assert_eq!(candidate(vec![7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]), 1);\n    assert_eq!(candidate(vec![3, 10, 10, 9, 2]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "rs",
+    "prompt": "/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(String::from(\"(()()) ((())) () ((())()())\"))\n/// vec![2, 3, 1, 3]\nfn parse_nested_parens(paren_string: String) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = parse_nested_parens;\n    assert_eq!(candidate(String::from(\"(()()) ((())) () ((())()())\")), vec![2, 3, 1, 3]);\n    assert_eq!(candidate(String::from(\"() (()) ((())) (((())))\")), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(String::from(\"(()(())((())))\")), vec![4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "rs",
+    "prompt": "/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(vec![1, 2, 3, 4])\n/// vec![1, 4, 2, 3]\n/// >>> strange_sort_list(vec![5, 5, 5, 5])\n/// vec![5, 5, 5, 5]\n/// >>> strange_sort_list(vec![])\n/// Vec::<isize>::new()\nfn strange_sort_list(lst: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = strange_sort_list;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 4, 2, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9]), vec![5, 9, 6, 8, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 5, 2, 4, 3]);\n    assert_eq!(candidate(vec![5, 6, 7, 8, 9, 1]), vec![1, 9, 5, 8, 6, 7]);\n    assert_eq!(candidate(vec![5, 5, 5, 5]), vec![5, 5, 5, 5]);\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8]), vec![1, 8, 2, 7, 3, 6, 4, 5]);\n    assert_eq!(candidate(vec![0, 2, 2, 2, 5, 5, -5, -5]), vec![-5, 5, -5, 5, 0, 2, 2, 2]);\n    assert_eq!(candidate(vec![111111]), vec![111111]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "rs",
+    "prompt": "/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(3, 4, 5)\n/// 6.0\n/// >>> triangle_area(1, 2, 10)\n/// -1.0\nfn triangle_area(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(3, 4, 5), 6.0);\n    assert_eq!(candidate(1, 2, 10), -1.0);\n    assert_eq!(candidate(4, 8, 5), 8.18);\n    assert_eq!(candidate(2, 2, 2), 1.73);\n    assert_eq!(candidate(1, 2, 3), -1.0);\n    assert_eq!(candidate(10, 5, 7), 16.25);\n    assert_eq!(candidate(2, 6, 3), -1.0);\n    assert_eq!(candidate(1, 1, 1), 0.43);\n    assert_eq!(candidate(2, 2, 10), -1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "rs",
+    "prompt": "/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(vec![1, 2], 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(vec![3, 2, 3], 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(vec![3, 2, 3], 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(vec![3], 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfn will_it_fly(q: Vec<isize>, w: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = will_it_fly;\n    assert_eq!(candidate(vec![3, 2, 3], 9), true);\n    assert_eq!(candidate(vec![1, 2], 5), false);\n    assert_eq!(candidate(vec![3], 5), true);\n    assert_eq!(candidate(vec![3, 2, 3], 1), false);\n    assert_eq!(candidate(vec![1, 2, 3], 6), false);\n    assert_eq!(candidate(vec![5], 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "rs",
+    "prompt": "/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(vec![1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(vec![1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(vec![1, 2, 3, 2, 1])\n/// 0\nfn smallest_change(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_change;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 4, 7, 9, 6]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 4, 4, 2]), 1);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 1]), 0);\n    assert_eq!(candidate(vec![3, 1, 1, 3]), 0);\n    assert_eq!(candidate(vec![1]), 0);\n    assert_eq!(candidate(vec![0, 1]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "rs",
+    "prompt": "/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// >>> total_match(vec![], vec![])\n/// Vec::<String>::new()\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")])\n/// vec![String::from(\"hI\"), String::from(\"Hi\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")])\n/// vec![String::from(\"hi\"), String::from(\"admin\")]\n/// >>> total_match(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")])\n/// vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]\n/// >>> total_match(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")])\n/// vec![String::from(\"4\")]\nfn total_match(lst1: Vec<String>, lst2: Vec<String>) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = total_match;\n    assert_eq!(candidate(Vec::<String>::new(), Vec::<String>::new()), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hi\"), String::from(\"hi\"), String::from(\"admin\"), String::from(\"project\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(vec![String::from(\"4\")], vec![String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"5\")]), vec![String::from(\"4\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"Hi\")]), vec![String::from(\"hI\"), String::from(\"Hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]), vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hi\")]);\n    assert_eq!(candidate(vec![String::from(\"hi\"), String::from(\"admin\")], vec![String::from(\"hI\"), String::from(\"hi\"), String::from(\"hii\")]), vec![String::from(\"hi\"), String::from(\"admin\")]);\n    assert_eq!(candidate(Vec::<String>::new(), vec![String::from(\"this\")]), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"this\")], Vec::<String>::new()), Vec::<String>::new());\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "rs",
+    "prompt": "/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(30)\n/// true\n/// 30 = 2 * 3 * 5\nfn is_multiply_prime(a: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_multiply_prime;\n    assert_eq!(candidate(5), false);\n    assert_eq!(candidate(30), true);\n    assert_eq!(candidate(8), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(125), true);\n    assert_eq!(candidate(105), true);\n    assert_eq!(candidate(126), false);\n    assert_eq!(candidate(729), false);\n    assert_eq!(candidate(891), false);\n    assert_eq!(candidate(1001), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "rs",
+    "prompt": "/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(1, 4)\n/// true\n/// >>> is_simple_power(2, 2)\n/// true\n/// >>> is_simple_power(8, 2)\n/// true\n/// >>> is_simple_power(3, 2)\n/// false\n/// >>> is_simple_power(3, 1)\n/// false\n/// >>> is_simple_power(5, 3)\n/// false\nfn is_simple_power(x: isize, n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_simple_power;\n    assert_eq!(candidate(16, 2), true);\n    assert_eq!(candidate(143214, 16), false);\n    assert_eq!(candidate(4, 2), true);\n    assert_eq!(candidate(9, 3), true);\n    assert_eq!(candidate(16, 4), true);\n    assert_eq!(candidate(24, 2), false);\n    assert_eq!(candidate(128, 4), false);\n    assert_eq!(candidate(12, 6), false);\n    assert_eq!(candidate(1, 1), true);\n    assert_eq!(candidate(1, 12), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(1)\n/// true\n/// >>> iscube(2)\n/// false\n/// >>> iscube(-1)\n/// true\n/// >>> iscube(64)\n/// true\n/// >>> iscube(0)\n/// true\n/// >>> iscube(180)\n/// false\nfn iscube(a: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = iscube;\n    assert_eq!(candidate(1), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(-1), true);\n    assert_eq!(candidate(64), true);\n    assert_eq!(candidate(180), false);\n    assert_eq!(candidate(1000), true);\n    assert_eq!(candidate(0), true);\n    assert_eq!(candidate(1729), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "rs",
+    "prompt": "/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(String::from(\"AB\"))\n/// 1\n/// >>> hex_key(String::from(\"1077E\"))\n/// 2\n/// >>> hex_key(String::from(\"ABED1A33\"))\n/// 4\n/// >>> hex_key(String::from(\"123456789ABCDEF0\"))\n/// 6\n/// >>> hex_key(String::from(\"2020\"))\n/// 2\nfn hex_key(num: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = hex_key;\n    assert_eq!(candidate(String::from(\"AB\")), 1);\n    assert_eq!(candidate(String::from(\"1077E\")), 2);\n    assert_eq!(candidate(String::from(\"ABED1A33\")), 4);\n    assert_eq!(candidate(String::from(\"2020\")), 2);\n    assert_eq!(candidate(String::from(\"123456789ABCDEF0\")), 6);\n    assert_eq!(candidate(String::from(\"112233445566778899AABBCCDDEEFF00\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(15)\n/// String::from(\"db1111db\")\n/// >>> decimal_to_binary(32)\n/// String::from(\"db100000db\")\nfn decimal_to_binary(decimal: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(0), String::from(\"db0db\"));\n    assert_eq!(candidate(32), String::from(\"db100000db\"));\n    assert_eq!(candidate(103), String::from(\"db1100111db\"));\n    assert_eq!(candidate(15), String::from(\"db1111db\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "rs",
+    "prompt": "/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring(vec![], String::from(\"a\"))\n/// Vec::<String>::new()\n/// >>> filter_by_substring(vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"cde\"), String::from(\"array\")], String::from(\"a\"))\n/// vec![String::from(\"abc\"), String::from(\"bacd\"), String::from(\"array\")]\nfn filter_by_substring(strings: Vec<String>, substring: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_by_substring;\n    assert_eq!(candidate(Vec::<String>::new(), String::from(\"john\")), Vec::<String>::new());\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"xxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xxx\")), vec![String::from(\"xxx\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"xxx\"), String::from(\"asd\"), String::from(\"aaaxxy\"), String::from(\"john doe\"), String::from(\"xxxAAA\"), String::from(\"xxx\")], String::from(\"xx\")), vec![String::from(\"xxx\"), String::from(\"aaaxxy\"), String::from(\"xxxAAA\"), String::from(\"xxx\")]);\n    assert_eq!(candidate(vec![String::from(\"grunt\"), String::from(\"trumpet\"), String::from(\"prune\"), String::from(\"gruesome\")], String::from(\"run\")), vec![String::from(\"grunt\"), String::from(\"prune\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "rs",
+    "prompt": "/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(String::from(\"a\"))\n/// false\n/// >>> is_happy(String::from(\"aa\"))\n/// false\n/// >>> is_happy(String::from(\"abcd\"))\n/// true\n/// >>> is_happy(String::from(\"aabb\"))\n/// false\n/// >>> is_happy(String::from(\"adb\"))\n/// true\n/// >>> is_happy(String::from(\"xyy\"))\n/// false\nfn is_happy(s: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_happy;\n    assert_eq!(candidate(String::from(\"a\")), false);\n    assert_eq!(candidate(String::from(\"aa\")), false);\n    assert_eq!(candidate(String::from(\"abcd\")), true);\n    assert_eq!(candidate(String::from(\"aabb\")), false);\n    assert_eq!(candidate(String::from(\"adb\")), true);\n    assert_eq!(candidate(String::from(\"xyy\")), false);\n    assert_eq!(candidate(String::from(\"iopaxpoi\")), true);\n    assert_eq!(candidate(String::from(\"iopaxioi\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "rs",
+    "prompt": "/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> grade_equation(vec![4.0, 3, 1.7, 2, 3.5])\n/// vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]\nfn numerical_letter_grade(grades: Vec<f64>) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = numerical_letter_grade;\n    assert_eq!(candidate(vec![4.0, 3.0, 1.7, 2.0, 3.5]), vec![String::from(\"A+\"), String::from(\"B\"), String::from(\"C-\"), String::from(\"C\"), String::from(\"A-\")]);\n    assert_eq!(candidate(vec![1.2]), vec![String::from(\"D+\")]);\n    assert_eq!(candidate(vec![0.5]), vec![String::from(\"D-\")]);\n    assert_eq!(candidate(vec![0.0]), vec![String::from(\"E\")]);\n    assert_eq!(candidate(vec![1.0, 0.3, 1.5, 2.8, 3.3]), vec![String::from(\"D\"), String::from(\"D-\"), String::from(\"C-\"), String::from(\"B\"), String::from(\"B+\")]);\n    assert_eq!(candidate(vec![0.0, 0.7]), vec![String::from(\"E\"), String::from(\"D-\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// >>> prime_length(String::from(\"Hello\"))\n/// true\n/// >>> prime_length(String::from(\"abcdcba\"))\n/// true\n/// >>> prime_length(String::from(\"kittens\"))\n/// true\n/// >>> prime_length(String::from(\"orange\"))\n/// false\nfn prime_length(string: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_length;\n    assert_eq!(candidate(String::from(\"Hello\")), true);\n    assert_eq!(candidate(String::from(\"abcdcba\")), true);\n    assert_eq!(candidate(String::from(\"kittens\")), true);\n    assert_eq!(candidate(String::from(\"orange\")), false);\n    assert_eq!(candidate(String::from(\"wow\")), true);\n    assert_eq!(candidate(String::from(\"world\")), true);\n    assert_eq!(candidate(String::from(\"MadaM\")), true);\n    assert_eq!(candidate(String::from(\"Wow\")), true);\n    assert_eq!(candidate(String::from(\"\")), false);\n    assert_eq!(candidate(String::from(\"HI\")), true);\n    assert_eq!(candidate(String::from(\"go\")), true);\n    assert_eq!(candidate(String::from(\"gogo\")), false);\n    assert_eq!(candidate(String::from(\"aaaaaaaaaaaaaaa\")), false);\n    assert_eq!(candidate(String::from(\"Madam\")), true);\n    assert_eq!(candidate(String::from(\"M\")), false);\n    assert_eq!(candidate(String::from(\"0\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "rs",
+    "prompt": "/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfn starts_one_ends(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = starts_one_ends;\n    assert_eq!(candidate(1), 1);\n    assert_eq!(candidate(2), 18);\n    assert_eq!(candidate(3), 180);\n    assert_eq!(candidate(4), 1800);\n    assert_eq!(candidate(5), 18000);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "rs",
+    "prompt": "/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(1000)\n/// String::from(\"1\")\n/// >>> solve(150)\n/// String::from(\"110\")\n/// >>> solve(147)\n/// String::from(\"1100\")\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfn solve(N: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = solve;\n    assert_eq!(candidate(1000), String::from(\"1\"));\n    assert_eq!(candidate(150), String::from(\"110\"));\n    assert_eq!(candidate(147), String::from(\"1100\"));\n    assert_eq!(candidate(333), String::from(\"1001\"));\n    assert_eq!(candidate(963), String::from(\"10010\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "rs",
+    "prompt": "/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(vec![4, 2, 6, 7])\n/// 2\nfn add(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add;\n    assert_eq!(candidate(vec![4, 88]), 88);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 2, 122]), 122);\n    assert_eq!(candidate(vec![4, 0, 6, 7]), 0);\n    assert_eq!(candidate(vec![4, 4, 6, 8]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(String::from(\"Hi\"))\n/// String::from(\"Hi\")\n/// >>> anti_shuffle(String::from(\"hello\"))\n/// String::from(\"ehllo\")\n/// >>> anti_shuffle(String::from(\"Hello World!!!\"))\n/// String::from(\"Hello !!!Wdlor\")\nfn anti_shuffle(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = anti_shuffle;\n    assert_eq!(candidate(String::from(\"Hi\")), String::from(\"Hi\"));\n    assert_eq!(candidate(String::from(\"hello\")), String::from(\"ehllo\"));\n    assert_eq!(candidate(String::from(\"number\")), String::from(\"bemnru\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"abcd\"));\n    assert_eq!(candidate(String::from(\"Hello World!!!\")), String::from(\"Hello !!!Wdlor\"));\n    assert_eq!(candidate(String::from(\"\")), String::from(\"\"));\n    assert_eq!(candidate(String::from(\"Hi. My name is Mister Robot. How are you?\")), String::from(\".Hi My aemn is Meirst .Rboot How aer ?ouy\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "rs",
+    "prompt": "/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1)\n/// vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(vec![], 1)\n/// Vec::<(isize, isize)>::new()\n/// >>> get_row(vec![vec![], vec![1], vec![1, 2, 3]], 3)\n/// vec![(2, 2)]\nfn get_row(lst: Vec<Vec<isize>>, x: isize) -> Vec<(isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_row;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]], 2), vec![(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6], vec![1, 1, 3, 4, 5, 6], vec![1, 2, 1, 4, 5, 6], vec![1, 2, 3, 1, 5, 6], vec![1, 2, 3, 4, 1, 6], vec![1, 2, 3, 4, 5, 1]], 1), vec![(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)]);\n    assert_eq!(candidate(Vec::<Vec<isize>>::new(), 1), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![1]], 2), Vec::<(isize, isize)>::new());\n    assert_eq!(candidate(vec![vec![], vec![1], vec![1, 2, 3]], 3), vec![(2, 2)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "rs",
+    "prompt": "/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(vec![])\n/// Vec::<isize>::new()\n/// >>> sort_array(vec![5])\n/// vec![5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5])\n/// vec![0, 1, 2, 3, 4, 5]\n/// >>> sort_array(vec![2, 4, 3, 0, 1, 5, 6])\n/// vec![6, 5, 4, 3, 2, 1, 0]\nfn sort_array(array: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_array;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![5]), vec![5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5]), vec![0, 1, 2, 3, 4, 5]);\n    assert_eq!(candidate(vec![2, 4, 3, 0, 1, 5, 6]), vec![6, 5, 4, 3, 2, 1, 0]);\n    assert_eq!(candidate(vec![2, 1]), vec![1, 2]);\n    assert_eq!(candidate(vec![15, 42, 87, 32, 11, 0]), vec![0, 11, 15, 32, 42, 87]);\n    assert_eq!(candidate(vec![21, 14, 23, 11]), vec![23, 21, 14, 11]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "rs",
+    "prompt": "/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(String::from(\"hi\"))\n/// String::from(\"lm\")\n/// >>> encrypt(String::from(\"asdfghjkl\"))\n/// String::from(\"ewhjklnop\")\n/// >>> encrypt(String::from(\"gf\"))\n/// String::from(\"kj\")\n/// >>> encrypt(String::from(\"et\"))\n/// String::from(\"ix\")\nfn encrypt(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encrypt;\n    assert_eq!(candidate(String::from(\"hi\")), String::from(\"lm\"));\n    assert_eq!(candidate(String::from(\"asdfghjkl\")), String::from(\"ewhjklnop\"));\n    assert_eq!(candidate(String::from(\"gf\")), String::from(\"kj\"));\n    assert_eq!(candidate(String::from(\"et\")), String::from(\"ix\"));\n    assert_eq!(candidate(String::from(\"faewfawefaewg\")), String::from(\"jeiajeaijeiak\"));\n    assert_eq!(candidate(String::from(\"hellomyfriend\")), String::from(\"lippsqcjvmirh\"));\n    assert_eq!(candidate(String::from(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")), String::from(\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"e\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "rs",
+    "prompt": "/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(vec![])\n/// (0, 1)\n/// >>> sum_product(vec![1, 2, 3, 4])\n/// (10, 24)\nfn sum_product(numbers: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_product;\n    assert_eq!(candidate(Vec::<isize>::new()), (0, 1));\n    assert_eq!(candidate(vec![1, 1, 1]), (3, 1));\n    assert_eq!(candidate(vec![100, 0]), (100, 0));\n    assert_eq!(candidate(vec![3, 5, 7]), (15, 105));\n    assert_eq!(candidate(vec![10]), (10, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// >>> next_smallest(vec![1, 2, 3, 4, 5])\n/// Some(2)\n/// >>> next_smallest(vec![5, 1, 4, 3, 2])\n/// Some(2)\n/// >>> next_smallest(vec![])\n/// None\n/// >>> next_smallest(vec![1, 1])\n/// None\nfn next_smallest(lst: Vec<isize>) -> Option<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = next_smallest;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), Some(2));\n    assert_eq!(candidate(vec![5, 1, 4, 3, 2]), Some(2));\n    assert_eq!(candidate(Vec::<isize>::new()), None);\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![1, 1, 1, 1, 0]), Some(1));\n    assert_eq!(candidate(vec![1, 1]), None);\n    assert_eq!(candidate(vec![-35, 34, 12, -45]), Some(-35));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "rs",
+    "prompt": "/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(String::from(\"Hello world\"))\n/// 0\n/// >>> is_bored(String::from(\"The sky is blue. The sun is shining. I love this weather\"))\n/// 1\nfn is_bored(S: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_bored;\n    assert_eq!(candidate(String::from(\"Hello world\")), 0);\n    assert_eq!(candidate(String::from(\"Is the sky blue?\")), 0);\n    assert_eq!(candidate(String::from(\"I love It !\")), 1);\n    assert_eq!(candidate(String::from(\"bIt\")), 0);\n    assert_eq!(candidate(String::from(\"I feel good today. I will be productive. will kill It\")), 2);\n    assert_eq!(candidate(String::from(\"You and I are going for a walk\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "rs",
+    "prompt": "/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(5, 2, 7)\n/// true\n/// >>> any_int(3, 2, 2)\n/// false\n/// >>> any_int(3, -2, 1)\n/// true\n/// >>> any_int(3.6, -2.2, 2)\n/// false\nfn any_int(x: f64, y: f64, z: f64) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = any_int;\n    assert_eq!(candidate(2.0, 3.0, 1.0), true);\n    assert_eq!(candidate(2.5, 2.0, 3.0), false);\n    assert_eq!(candidate(1.5, 5.0, 3.5), false);\n    assert_eq!(candidate(2.0, 6.0, 2.0), false);\n    assert_eq!(candidate(4.0, 2.0, 2.0), true);\n    assert_eq!(candidate(2.2, 2.2, 2.2), false);\n    assert_eq!(candidate(-4.0, 6.0, 2.0), true);\n    assert_eq!(candidate(2.0, 1.0, 1.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), true);\n    assert_eq!(candidate(3.0, 4.0, 7.0), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(String::from(\"test\"))\n/// String::from(\"TGST\")\n/// >>> encode(String::from(\"This is a message\"))\n/// String::from(\"tHKS KS C MGSSCGG\")\nfn encode(message: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = encode;\n    assert_eq!(candidate(String::from(\"TEST\")), String::from(\"tgst\"));\n    assert_eq!(candidate(String::from(\"Mudasir\")), String::from(\"mWDCSKR\"));\n    assert_eq!(candidate(String::from(\"YES\")), String::from(\"ygs\"));\n    assert_eq!(candidate(String::from(\"This is a message\")), String::from(\"tHKS KS C MGSSCGG\"));\n    assert_eq!(candidate(String::from(\"I DoNt KnOw WhAt tO WrItE\")), String::from(\"k dQnT kNqW wHcT Tq wRkTg\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "rs",
+    "prompt": "/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(vec![0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(vec![0, 8, 1, 2, 1, 7])\n/// 7\nfn skjkasdkd(lst: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = skjkasdkd;\n    assert_eq!(candidate(vec![0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]), 10);\n    assert_eq!(candidate(vec![1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]), 25);\n    assert_eq!(candidate(vec![1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]), 13);\n    assert_eq!(candidate(vec![0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]), 11);\n    assert_eq!(candidate(vec![0, 81, 12, 3, 1, 21]), 3);\n    assert_eq!(candidate(vec![0, 8, 1, 2, 1, 7]), 7);\n    assert_eq!(candidate(vec![8191]), 19);\n    assert_eq!(candidate(vec![8191, 123456, 127, 7]), 19);\n    assert_eq!(candidate(vec![127, 97, 8192]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"b\"), String::from(\"banana\"))]))\n/// true\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"a\"), String::from(\"apple\")), (8, String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))]))\n/// false\n/// >>> check_dict_case(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))]))\n/// true\nfn check_dict_case(dict: HashMap<String, String>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_dict_case;\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"b\"), String::from(\"banana\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"A\"), String::from(\"banana\")), (String::from(\"B\"), String::from(\"banana\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"p\"), String::from(\"pineapple\")), (String::from(\"5\"), String::from(\"banana\")), (String::from(\"a\"), String::from(\"apple\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Name\"), String::from(\"John\")), (String::from(\"Age\"), String::from(\"36\")), (String::from(\"City\"), String::from(\"Houston\"))])), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"STATE\"), String::from(\"NC\")), (String::from(\"ZIP\"), String::from(\"12345\"))])), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"fruit\"), String::from(\"Orange\")), (String::from(\"taste\"), String::from(\"Sweet\"))])), true);\n    assert_eq!(candidate(HashMap::from([])), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "rs",
+    "prompt": "/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(5)\n/// vec![2, 3]\n/// >>> count_up_to(11)\n/// vec![2, 3, 5, 7]\n/// >>> count_up_to(0)\n/// Vec::<isize>::new()\n/// >>> count_up_to(20)\n/// vec![2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(1)\n/// Vec::<isize>::new()\n/// >>> count_up_to(18)\n/// vec![2, 3, 5, 7, 11, 13, 17]\nfn count_up_to(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_up_to;\n    assert_eq!(candidate(5), vec![2, 3]);\n    assert_eq!(candidate(6), vec![2, 3, 5]);\n    assert_eq!(candidate(7), vec![2, 3, 5]);\n    assert_eq!(candidate(10), vec![2, 3, 5, 7]);\n    assert_eq!(candidate(0), Vec::<isize>::new());\n    assert_eq!(candidate(22), vec![2, 3, 5, 7, 11, 13, 17, 19]);\n    assert_eq!(candidate(1), Vec::<isize>::new());\n    assert_eq!(candidate(18), vec![2, 3, 5, 7, 11, 13, 17]);\n    assert_eq!(candidate(47), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n    assert_eq!(candidate(101), vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "rs",
+    "prompt": "/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(148, 412)\n/// 16\n/// >>> multiply(19, 28)\n/// 72\n/// >>> multiply(2020, 1851)\n/// 0\n/// >>> multiply(14, -15)\n/// 20\nfn multiply(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply;\n    assert_eq!(candidate(148, 412), 16);\n    assert_eq!(candidate(19, 28), 72);\n    assert_eq!(candidate(2020, 1851), 0);\n    assert_eq!(candidate(14, -15), 20);\n    assert_eq!(candidate(76, 67), 42);\n    assert_eq!(candidate(17, 27), 49);\n    assert_eq!(candidate(0, 1), 0);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "rs",
+    "prompt": "/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(String::from(\"aBCdEf\"))\n/// 1\n/// >>> count_upper(String::from(\"abcdefg\"))\n/// 0\n/// >>> count_upper(String::from(\"dBBE\"))\n/// 0\nfn count_upper(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_upper;\n    assert_eq!(candidate(String::from(\"aBCdEf\")), 1);\n    assert_eq!(candidate(String::from(\"abcdefg\")), 0);\n    assert_eq!(candidate(String::from(\"dBBE\")), 0);\n    assert_eq!(candidate(String::from(\"B\")), 0);\n    assert_eq!(candidate(String::from(\"U\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n    assert_eq!(candidate(String::from(\"EEEE\")), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "rs",
+    "prompt": "/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(String::from(\"10\"))\n/// 10\n/// >>> closest_integer(String::from(\"15.3\"))\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfn closest_integer(value: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_integer;\n    assert_eq!(candidate(String::from(\"10\")), 10);\n    assert_eq!(candidate(String::from(\"14.5\")), 15);\n    assert_eq!(candidate(String::from(\"-15.5\")), -16);\n    assert_eq!(candidate(String::from(\"15.3\")), 15);\n    assert_eq!(candidate(String::from(\"0\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "rs",
+    "prompt": "/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(vec![1, 2, 3, 2, 3, 4, 2])\n/// vec![1, 2, 3, 3, 3, 4, 4]\nfn rolling_max(numbers: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rolling_max;\n    assert_eq!(candidate(Vec::<isize>::new()), Vec::<isize>::new());\n    assert_eq!(candidate(vec![1, 2, 3, 4]), vec![1, 2, 3, 4]);\n    assert_eq!(candidate(vec![4, 3, 2, 1]), vec![4, 4, 4, 4]);\n    assert_eq!(candidate(vec![3, 2, 3, 100, 3]), vec![3, 3, 3, 100, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-scala-keep.json
+++ b/prompts/humaneval-scala-keep.json
@@ -1,996 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    def iscube(a : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    def hasCloseElements(numbers : List[Float], threshold : Float) : Boolean = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    def encode(message : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    def solution(lst : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    def stringSequence(n : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // rounded_avg(1, 5) => \"0b11\"\n    // rounded_avg(7, 5) => -1\n    // rounded_avg(10, 20) => \"0b1111\"\n    // rounded_avg(20, 33) => \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    def isBored(S : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    def getOddCollatz(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    def isHappy(s : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    def fileNameCheck(file_name : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    def histogram(test : String) : Map[String,Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    def simplify(x : String, n : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    def reverseDelete(s : String, c : String) : Tuple2[String, Boolean] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals(((\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals(((\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals(((\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals(((\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals(((\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals(((\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals(((\"\", true))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    def allPrefixes(string : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    def digits(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    def strlen(string : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    def fibfib(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    def wordsString(s : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    def monotonic(l : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    def fixSpaces(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    def truncateNumber(number : Float) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    def parseMusic(music_string : String) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    def removeVowels(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    def sortThird(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    def countUpTo(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    def maxElement(l : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    def unique(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    def smallestChange(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    def f(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(1l));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(-35l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    def matchParens(lst : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    def largestPrimeFactor(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    def encrypt(s : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    def howManyTimes(string : String, substring : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    def solve(s : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    def sortEven(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](-10l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 5l.toLong, 0l.toLong, 9l.toLong, 1l.toLong, 123l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 8l.toLong, -12l.toLong, 4l.toLong, 23l.toLong, 2l.toLong, 3l.toLong, 11l.toLong, 12l.toLong, -10l.toLong))).equals((List[Long](-12l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 2l.toLong, 12l.toLong, 11l.toLong, 23l.toLong, -10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    def belowZero(operations : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    def sameChars(s0 : String, s1 : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    def countUpper(s : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    def selectWords(s : String, n : Long) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    def findMax(words : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    def sumSquares(lst : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    def add(lst : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    def multiply(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    def tri(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.3f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.05f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.95f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.8f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.1f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (1.0f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (0.5f)) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1000,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> make_a_pile(3)\n    // [3, 5, 7]\n    def makeAPile(n : Long) : List[Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makeAPile((3l)).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(makeAPile((4l)).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(makeAPile((5l)).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong))));\n    assert(makeAPile((6l)).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong))));\n    assert(makeAPile((8l)).equals((List[Long](8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 18l.toLong, 20l.toLong, 22l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1008,865 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    def add(x : Long, y : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n    // words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n    def wordsString(s : String) : List[String] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    def decimalToBinary(decimal : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    def isPalindrome(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    def factorize(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    def circularShift(x : Long, shift : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    def getClosestVowel(word : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    def sortNumbers(numbers : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    def flipCase(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    def canArrange(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    def isNested(string : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    def byLength(arr : List[Long]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    def sumToN(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    def oddCount(lst : List[String]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    def concatenate(strings : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    def sumSquares(lst : List[Float]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    def sortArray(arr : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong))).equals((List[Long](-4l.toLong, -2l.toLong, -6l.toLong, -5l.toLong, -3l.toLong))));\n    assert(sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](2l.toLong, 5l.toLong, 77l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 77l.toLong))));\n    assert(sortArray((List[Long](3l.toLong, 6l.toLong, 44l.toLong, 12l.toLong, 32l.toLong, 5l.toLong))).equals((List[Long](32l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 12l.toLong, 44l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    def longest(strings : List[String]) : Option[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(\"x\"));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(\"zzzz\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    def isSorted(lst : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    def derivative(xs : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    def antiShuffle(s : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    def makePalindrome(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    def changeBase(x : Long, base : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    def primeLength(string : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    def search(lst : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    def fizzBuzz(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    def sortArray(array : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    def vowelsCount(s : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    def stringToMd5(text : String) : Option[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(\"3e25960a79dbc69b674cd4ec67a72c62\"));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(\"0ef78513b0cb8cef12743f5aeb35f888\"));\n    assert(stringToMd5((\"password\")).equals(\"5f4dcc3b5aa765d61d8327deb882cf99\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    def isPrime(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    def hexKey(num : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    def median(l : List[Long]) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    def specialFilter(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFilter((List[Long](5l.toLong, -2l.toLong, 1l.toLong, -5l.toLong))) == (0l));\n    assert(specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong))) == (1l));\n    assert(specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong))) == (2l));\n    assert(specialFilter((List[Long](43l.toLong, -12l.toLong, 93l.toLong, 125l.toLong, 121l.toLong, 109l.toLong))) == (4l));\n    assert(specialFilter((List[Long](71l.toLong, -2l.toLong, -33l.toLong, 75l.toLong, 21l.toLong, 19l.toLong))) == (3l));\n    assert(specialFilter((List[Long](1l.toLong))) == (0l));\n    assert(specialFilter((List[Long]())) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    def modp(n : Long, p : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    def primeFib(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    def validDate(date : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    def countNums(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    def digitSum(s : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    def triangleArea(a : Long, h : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    // split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    // split_words(\"abcdef\") == 3\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    def fib4(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    def stringXor(a : String, b : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    // False\n    // >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    // True\n    def hasCloseElements(numbers : List[Float], threshold : Float) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.3f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.05f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.95f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.8f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.1f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (1.0f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    def largestDivisor(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    def intToMiniRoman(number : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    def correctBracketing(brackets : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    def correctBracketing(brackets : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    def fib(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(-9l));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(0l));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(-10l));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(20l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(-4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    def incrList(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    def getPositive(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,7 +40,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // choose_num(12, 15) = 14\n    // choose_num(13, 12) = -1\n    def chooseNum(x : Long, y : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1884,13 +48,781 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // rounded_avg(1, 5) => \"0b11\"\n    // rounded_avg(7, 5) => -1\n    // rounded_avg(10, 20) => \"0b1111\"\n    // rounded_avg(20, 33) => \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> unique_digits([15, 33, 1422, 1])\n    // [1, 15, 33]\n    // >>> unique_digits([152, 323, 1422, 10])\n    // []\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n    // -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n    // -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n    // return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n    // If the array is empty, return an empty array:\n    // arr = []\n    // return []\n    // If the array has any strange number ignore it:\n    // arr = [1, -1 , 55] \n    // -> sort arr -> [-1, 1, 55]\n    // -> reverse arr -> [55, 1, -1]\n    // return = ['One']\n    def byLength(arr : List[Long]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // f(5) == [1, 2, 6, 24, 15]\n    def f(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Input: 3\n    // Output: (1, 2)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Input: 12\n    // Output: (4, 6)\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> count_nums([]) == 0\n    // >>> count_nums([-1, 11, -11]) == 1\n    // >>> count_nums([1, 1, 2]) == 3\n    def countNums(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // move_one_ball([3, 4, 5, 1, 2])==>True\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // move_one_ball([3, 5, 4, 1, 2])==>False\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> make_palindrome('')\n    // ''\n    // >>> make_palindrome('cat')\n    // 'catac'\n    // >>> make_palindrome('cata')\n    // 'catac'\n    def makePalindrome(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n    // exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n    // histogram('a b b a') == {'a': 2, 'b': 2}\n    // histogram('a b c a b') == {'a': 2, 'b': 2}\n    // histogram('b b b b a') == {'b': 4}\n    // histogram('') == {}\n    def histogram(test : String) : Map[String,Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n    // For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n    // For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n    def reverseDelete(s : String, c : String) : Tuple2[String, Boolean] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals(((\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals(((\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals(((\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals(((\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals(((\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals(((\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals(((\"\", true))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> odd_count(['1234567'])\n    // [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n    // >>> odd_count(['3',\"11111111\"])\n    // [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n    // \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\n    def oddCount(lst : List[String]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n    // minSubArraySum([-1, -2, -3]) == -6\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Input: \n    // grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n    // bucket_capacity : 1\n    // Output: 6\n    // Example 2:\n    // Input: \n    // grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n    // bucket_capacity : 2\n    // Output: 5\n    // Example 3:\n    // Input: \n    // grid : [[0,0,0], [0,0,0]]\n    // bucket_capacity : 5\n    // Output: 0\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n    // >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n    // >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n    def sortArray(arr : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong))).equals((List[Long](-4l.toLong, -2l.toLong, -6l.toLong, -5l.toLong, -3l.toLong))));\n    assert(sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](2l.toLong, 5l.toLong, 77l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 77l.toLong))));\n    assert(sortArray((List[Long](3l.toLong, 6l.toLong, 44l.toLong, 12l.toLong, 32l.toLong, 5l.toLong))).equals((List[Long](32l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 12l.toLong, 44l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n    // select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n    // select_words(\"simple white space\", 2) ==> []\n    // select_words(\"Hello world\", 4) ==> [\"world\"]\n    // select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n    def selectWords(s : String, n : Long) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // get_closest_vowel(\"yogurt\") ==> \"u\"\n    // get_closest_vowel(\"FULL\") ==> \"U\"\n    // get_closest_vowel(\"quick\") ==> \"\"\n    // get_closest_vowel(\"ab\") ==> \"\"\n    def getClosestVowel(word : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // match_parens(['()(', ')']) == 'Yes'\n    // match_parens([')', ')']) == 'No'\n    def matchParens(lst : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> string_xor('010', '110')\n    // '100'\n    def stringXor(a : String, b : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Input: arr = [-3, -4, 5], k = 3\n    // Output: [-4, -3, 5]\n    // Example 2:\n    // Input: arr = [4, -4, 4], k = 2\n    // Output: [4, 4]\n    // Example 3:\n    // Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n    // Output: [2]\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // solution([5, 8, 7, 1]) ==> 12\n    // solution([3, 3, 3, 3, 3]) ==> 9\n    // solution([30, 13, 24, 321]) ==>0\n    def solution(lst : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n    // Output: 24 # sum of 21 + 3\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    def getOddCollatz(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // for example: \n    // valid_date('03-11-2000') => True\n    // valid_date('15-01-2012') => False\n    // valid_date('04-0-2040') => False\n    // valid_date('06-04-2020') => True\n    // valid_date('06/04/2020') => False\n    def validDate(date : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n    // split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n    // split_words(\"abcdef\") == 3\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // is_sorted([5]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5]) \u279e False\n    // is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n    // is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n    // is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n    // is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n    // is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n    def isSorted(lst : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // intersection((1, 2), (2, 3)) ==> \"NO\"\n    // intersection((-1, 1), (0, 4)) ==> \"NO\"\n    // intersection((-3, -1), (-5, 5)) ==> \"YES\"\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prod_signs([1, 2, 2, -4]) == -9\n    // >>> prod_signs([0, 1]) == 0\n    // >>> prod_signs([]) == None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(Some(-9l)));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(Some(0l)));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(Some(-10l)));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(Some(20l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(Some(4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(Some(-4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    // Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n    // Output: [1, 2, 1]\n    // Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n    // Output: [1]\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest([])\n    // >>> longest(['a', 'b', 'c'])\n    // 'a'\n    // >>> longest(['a', 'bb', 'ccc'])\n    // 'ccc'\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(Some(\"x\")));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(Some(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // tri(3) = [1, 3, 2, 8]\n    def tri(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // digits(1)  == 1\n    // digits(4)  == 0\n    // digits(235) == 15\n    def digits(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // is_nested('[[]]') \u279e True\n    // is_nested('[]]]]]]][[[[[]') \u279e False\n    // is_nested('[][]') \u279e False\n    // is_nested('[]') \u279e False\n    // is_nested('[[][]]') \u279e True\n    // is_nested('[[]][[') \u279e True\n    def isNested(string : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // For lst = [1,2,3] the output should be 14\n    // For lst = [1,4,9] the output should be 98\n    // For lst = [1,3,5,7] the output should be 84\n    // For lst = [1.4,4.2,0] the output should be 29\n    // For lst = [-2.4,1,1] the output should be 6\n    def sumSquares(lst : List[Float]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n    // check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n    // check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n    // check_if_last_char_is_a_letter(\"\") \u279e False\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // can_arrange([1,2,4,3,5]) = 3\n    // can_arrange([1,2,3]) = -1\n    def canArrange(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n    // largest_smallest_integers([]) == (None, None)\n    // largest_smallest_integers([0]) == (None, None)\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // is_equal_to_sum_even(4) == False\n    // is_equal_to_sum_even(6) == False\n    // is_equal_to_sum_even(8) == True\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> special_factorial(4)\n    // 288\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatest_common_divisor(3, 5)\n    // 1\n    // >>> greatest_common_divisor(25, 15)\n    // 5\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // fix_spaces(\"Example\") == \"Example\"\n    // fix_spaces(\"Example 1\") == \"Example_1\"\n    // fix_spaces(\" Example 2\") == \"_Example_2\"\n    // fix_spaces(\" Example   3\") == \"_Example-3\"\n    def fixSpaces(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // file_name_check(\"example.txt\") # => 'Yes'\n    // file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n    def fileNameCheck(file_name : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // For lst = [1,2,3] the output should be 6\n    // For lst = []  the output should be 0\n    // For lst = [-1,-5,2,-1,-5]  the output should be -126\n    def sumSquares(lst : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Input: sentence = \"This is a test\"\n    // Output: \"is\"\n    // Example 2:\n    // Input: sentence = \"lets go for swimming\"\n    // Output: \"go for\"\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // simplify(\"1/5\", \"5/1\") = True\n    // simplify(\"1/6\", \"2/1\") = False\n    // simplify(\"7/10\", \"10/2\") = False\n    def simplify(x : String, n : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n    // >>> order_by_points([]) == []\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // specialFilter([15, -73, 14, -15]) => 1 \n    // specialFilter([33, -2, -3, 45, 21, 109]) => 2\n    def specialFilter(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFilter((List[Long](5l.toLong, -2l.toLong, 1l.toLong, -5l.toLong))) == (0l));\n    assert(specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong))) == (1l));\n    assert(specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong))) == (2l));\n    assert(specialFilter((List[Long](43l.toLong, -12l.toLong, 93l.toLong, 125l.toLong, 121l.toLong, 109l.toLong))) == (4l));\n    assert(specialFilter((List[Long](71l.toLong, -2l.toLong, -33l.toLong, 75l.toLong, 21l.toLong, 19l.toLong))) == (3l));\n    assert(specialFilter((List[Long](1l.toLong))) == (0l));\n    assert(specialFilter((List[Long]())) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Input: n = 5\n    // Output: 1\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n    // bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n    // bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n    // assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> all_prefixes('abc')\n    // ['a', 'ab', 'abc']\n    def allPrefixes(string : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // for x_or_y(7, 34, 12) == 34\n    // for x_or_y(15, 8, 5) == 5\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n    // double_the_difference([-1, -2, 0]) == 0\n    // double_the_difference([9, -2]) == 81\n    // double_the_difference([0]) == 0  \n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n    // compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // cycpattern_check(\"abcd\",\"abd\") => False\n    // cycpattern_check(\"hello\",\"ell\") => True\n    // cycpattern_check(\"whassup\",\"psus\") => False\n    // cycpattern_check(\"abab\",\"baa\") => True\n    // cycpattern_check(\"efef\",\"eeff\") => False\n    // cycpattern_check(\"himenss\",\"simen\") => True\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // even_odd_count(-12) ==> (1, 1)\n    // even_odd_count(123) ==> (1, 2)\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> int_to_mini_roman(19) == 'xix'\n    // >>> int_to_mini_roman(152) == 'clii'\n    // >>> int_to_mini_roman(426) == 'cdxxvi'\n    def intToMiniRoman(number : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // right_angle_triangle(3, 4, 5) == True\n    // right_angle_triangle(1, 2, 3) == False\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // find_max([\"name\", \"of\", \"string\"]) == \"string\"\n    // find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n    // find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n    def findMax(words : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // * eat(5, 6, 10) -> [11, 4]\n    // * eat(4, 8, 9) -> [12, 1]\n    // * eat(1, 10, 10) -> [11, 0]\n    // * eat(2, 11, 5) -> [7, 0]\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> string_sequence(0)\n    // '0'\n    // >>> string_sequence(5)\n    // '0 1 2 3 4 5'\n    def stringSequence(n : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // solve(\"1234\") = \"4321\"\n    // solve(\"ab\") = \"AB\"\n    // solve(\"#a@C\") = \"#A@c\"\n    def solve(s : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(Some(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(Some(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Some(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1900,7 +832,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // generate_integers(2, 8) => [2, 4, 6, 8]\n    // generate_integers(8, 2) => [2, 4, 6, 8]\n    // generate_integers(10, 14) => []\n    def generateIntegers(a : Long, b : Long) : List[Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(generateIntegers((2l), (10l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((10l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((132l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((17l), (89l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1912,9 +844,1077 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> count_distinct_characters('xyzXYZ')\n    // 3\n    // >>> count_distinct_characters('Jerry')\n    // 4\n    def countDistinctCharacters(string : String) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n    // [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n    def parseMusic(music_string : String) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> how_many_times('', 'a')\n    // 0\n    // >>> how_many_times('aaa', 'a')\n    // 3\n    // >>> how_many_times('aaaa', 'aa')\n    // 3\n    def howManyTimes(string : String, substring : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sort_numbers('three one five')\n    // 'one three five'\n    def sortNumbers(numbers : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separate_paren_groups('( ) (( )) (( )( ))')\n    // ['()', '(())', '(()())']\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n    // (2.0, 2.2)\n    // >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n    // (2.0, 2.0)\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n    // [0.0, 0.25, 0.5, 0.75, 1.0]\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    // >>> filter_integers(['a', 3.14, 5])\n    // [5]\n    // >>> filter_integers([1, 2, 3, 'abc', {}, []])\n    // [1, 2, 3]\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> strlen('')\n    // 0\n    // >>> strlen('abc')\n    // 3\n    def strlen(string : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largest_divisor(15)\n    // 5\n    def largestDivisor(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize(8)\n    // [2, 2, 2]\n    // >>> factorize(25)\n    // [5, 5]\n    // >>> factorize(70)\n    // [2, 5, 7]\n    def factorize(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> remove_duplicates([1, 2, 3, 2, 4])\n    // [1, 3, 4]\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flip_case('Hello')\n    // 'hELLO'\n    def flipCase(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate([])\n    // ''\n    // >>> concatenate(['a', 'b', 'c'])\n    // 'abc'\n    def concatenate(strings : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filter_by_prefix([], 'a')\n    // []\n    // >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n    // ['abc', 'array']\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncate_number(3.5)\n    // 0.5\n    def truncateNumber(number : Float) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> get_positive([-1, 2, -4, 5, 6])\n    // [2, 5, 6]\n    // >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // [5, 3, 2, 3, 9, 123, 1]\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> is_prime(6)\n    // False\n    // >>> is_prime(101)\n    // True\n    // >>> is_prime(11)\n    // True\n    // >>> is_prime(13441)\n    // True\n    // >>> is_prime(61)\n    // True\n    // >>> is_prime(4)\n    // False\n    // >>> is_prime(1)\n    // False\n    def isPrime(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sort_third([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n    // [2, 6, 3, 4, 8, 9, 5]\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [0, 2, 3, 5, 9, 123]\n    def unique(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> max_element([1, 2, 3])\n    // 3\n    // >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n    // 123\n    def maxElement(l : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizz_buzz(50)\n    // 0\n    // >>> fizz_buzz(78)\n    // 2\n    // >>> fizz_buzz(79)\n    // 3\n    def fizzBuzz(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sort_even([1, 2, 3])\n    // [1, 2, 3]\n    // >>> sort_even([5, 6, 3, 4])\n    // [3, 6, 5, 4]\n    def sortEven(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](-10l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 5l.toLong, 0l.toLong, 9l.toLong, 1l.toLong, 123l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 8l.toLong, -12l.toLong, 4l.toLong, 23l.toLong, 2l.toLong, 3l.toLong, 11l.toLong, 12l.toLong, -10l.toLong))).equals((List[Long](-12l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 2l.toLong, 12l.toLong, 11l.toLong, 23l.toLong, -10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> prime_fib(1)\n    // 2\n    // >>> prime_fib(2)\n    // 3\n    // >>> prime_fib(3)\n    // 5\n    // >>> prime_fib(4)\n    // 13\n    // >>> prime_fib(5)\n    // 89\n    def primeFib(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> below_zero([1, 2, 3])\n    // False\n    // >>> below_zero([1, 2, -4, 5])\n    // True\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triples_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> triples_sum_to_zero([1, 3, -2, 1])\n    // True\n    // >>> triples_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n    // True\n    // >>> triples_sum_to_zero([1])\n    // False\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incr_list([1, 2, 3])\n    // [2, 3, 4]\n    // >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n    // [6, 4, 6, 3, 4, 4, 10, 1, 124]\n    def incrList(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairs_sum_to_zero([1, 3, 5, 0])\n    // False\n    // >>> pairs_sum_to_zero([1, 3, -2, 1])\n    // False\n    // >>> pairs_sum_to_zero([1, 2, 3, 7])\n    // False\n    // >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n    // True\n    // >>> pairs_sum_to_zero([1])\n    // False\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> change_base(8, 3)\n    // '22'\n    // >>> change_base(8, 2)\n    // '1000'\n    // >>> change_base(7, 2)\n    // '111'\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangle_area(5, 3)\n    // 7.5\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4(5)\n    // 4\n    // >>> fib4(6)\n    // 8\n    // >>> fib4(7)\n    // 14\n    def fib4(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median([3, 1, 2, 4, 5])\n    // 3\n    // >>> median([-10, 4, 6, 1000, 10, 20])\n    // 15.0\n    def median(l : List[Long]) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> is_palindrome('')\n    // True\n    // >>> is_palindrome('aba')\n    // True\n    // >>> is_palindrome('aaaaa')\n    // True\n    // >>> is_palindrome('zbcd')\n    // False\n    def isPalindrome(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp(3, 5)\n    // 3\n    // >>> modp(1101, 101)\n    // 2\n    // >>> modp(0, 101)\n    // 1\n    // >>> modp(3, 11)\n    // 8\n    // >>> modp(100, 101)\n    // 1\n    def modp(n : Long, p : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n    // 1.0\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> remove_vowels('')\n    // ''\n    // >>> remove_vowels('abcdef')\n    // 'bcdf'\n    // >>> remove_vowels('aaaaa')\n    // ''\n    // >>> remove_vowels('aaBAA')\n    // 'B'\n    // >>> remove_vowels('zbcd')\n    // 'zbcd'\n    def removeVowels(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> below_threshold([1, 2, 4, 10], 100)\n    // True\n    // >>> below_threshold([1, 20, 4, 10], 5)\n    // False\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add(2, 3)\n    // 5\n    // >>> add(5, 7)\n    // 12\n    def add(x : Long, y : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if two words have the same characters.\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n    // True\n    // >>> same_chars('abcd', 'dddddddabc')\n    // True\n    // >>> same_chars('dddddddabc', 'abcd')\n    // True\n    // >>> same_chars('eabcd', 'dddddddabc')\n    // False\n    // >>> same_chars('abcd', 'dddddddabce')\n    // False\n    // >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n    // False\n    def sameChars(s0 : String, s1 : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib(10)\n    // 55\n    // >>> fib(1)\n    // 1\n    // >>> fib(8)\n    // 21\n    def fib(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"<\")\n    // False\n    // >>> correct_bracketing(\"<>\")\n    // True\n    // >>> correct_bracketing(\"<<><>>\")\n    // True\n    // >>> correct_bracketing(\"><<>\")\n    // False\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic([1, 2, 4, 20])\n    // True\n    // >>> monotonic([1, 20, 4, 10])\n    // False\n    // >>> monotonic([4, 1, 0, -10])\n    // True\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n    // [1, 5, 653]\n    // >>> common([5, 3, 2, 8], [3, 2])\n    // [2, 3]\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largest_prime_factor(13195)\n    // 29\n    // >>> largest_prime_factor(2048)\n    // 2\n    def largestPrimeFactor(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse([], 4)\n    // []\n    // >>> intersperse([1, 2, 3], 4)\n    // [1, 4, 2, 4, 3]\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sum_to_n(30)\n    // 465\n    // >>> sum_to_n(100)\n    // 5050\n    // >>> sum_to_n(5)\n    // 15\n    // >>> sum_to_n(10)\n    // 55\n    // >>> sum_to_n(1)\n    // 1\n    def sumToN(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correct_bracketing(\"(\")\n    // False\n    // >>> correct_bracketing(\"()\")\n    // True\n    // >>> correct_bracketing(\"(()())\")\n    // True\n    // >>> correct_bracketing(\")(()\")\n    // False\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative([3, 1, 2, 4, 5])\n    // [1, 4, 12, 20]\n    // >>> derivative([1, 2, 3])\n    // [2, 6]\n    def derivative(xs : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib(1)\n    // 0\n    // >>> fibfib(5)\n    // 4\n    // >>> fibfib(8)\n    // 24\n    def fibfib(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowels_count(\"abcde\")\n    // 2\n    // >>> vowels_count(\"ACEDY\")\n    // 3\n    def vowelsCount(s : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circular_shift(12, 1)\n    // \"21\"\n    // >>> circular_shift(12, 2)\n    // \"12\"\n    def circularShift(x : Long, shift : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // digitSum(\"\") => 0\n    // digitSum(\"abAB\") => 131\n    // digitSum(\"abcCd\") => 67\n    // digitSum(\"helloE\") => 69\n    // digitSum(\"woArBld\") => 131\n    // digitSum(\"aAaaaXa\") => 153\n    def digitSum(s : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n    // fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n    // fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n    // fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Input: [4,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Input: [1,2,3]\n    // Output: [2, 1]\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index. \n    // Example 3:\n    // Input: []\n    // Output: []\n    // Example 4:\n    // Input: [5, 0, 3, 0, 4, 2]\n    // Output: [0, 1]\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // search([4, 1, 2, 2, 3, 1]) == 2\n    // search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n    // search([5, 5, 4, 4, 4]) == -1\n    def search(lst : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parse_nested_parens('(()()) ((())) () ((())()())')\n    // [2, 3, 1, 3]\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n    // strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n    // strange_sort_list([]) == []\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // triangle_area(3, 4, 5) == 6.00\n    // triangle_area(1, 2, 10) == -1\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // will_it_fly([1, 2], 5) \u279e False \n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // will_it_fly([3, 2, 3], 1) \u279e False\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // will_it_fly([3, 2, 3], 9) \u279e True\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // will_it_fly([3], 5) \u279e True\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // smallest_change([1,2,3,5,4,7,9,6]) == 4\n    // smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n    // smallest_change([1, 2, 3, 2, 1]) == 0\n    def smallestChange(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // total_match([], []) \u279e []\n    // total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n    // total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n    // total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n    // total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // is_multiply_prime(30) == True\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // is_simple_power(1, 4) => true\n    // is_simple_power(2, 2) => true\n    // is_simple_power(8, 2) => true\n    // is_simple_power(3, 2) => false\n    // is_simple_power(3, 1) => false\n    // is_simple_power(5, 3) => false\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // iscube(1) ==> True\n    // iscube(2) ==> False\n    // iscube(-1) ==> True\n    // iscube(64) ==> True\n    // iscube(0) ==> True\n    // iscube(180) ==> False\n    def iscube(a : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // For num = \"AB\" the output should be 1.\n    // For num = \"1077E\" the output should be 2.\n    // For num = \"ABED1A33\" the output should be 4.\n    // For num = \"123456789ABCDEF0\" the output should be 6.\n    // For num = \"2020\" the output should be 2.\n    def hexKey(num : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // decimal_to_binary(15)   # returns \"db1111db\"\n    // decimal_to_binary(32)   # returns \"db100000db\"\n    def decimalToBinary(decimal : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filter_by_substring([], 'a')\n    // []\n    // >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n    // ['abc', 'bacd', 'array']\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // is_happy(a) => False\n    // is_happy(aa) => False\n    // is_happy(abcd) => True\n    // is_happy(aabb) => False\n    // is_happy(adb) => True\n    // is_happy(xyy) => False\n    def isHappy(s : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // prime_length('Hello') == True\n    // prime_length('abcdcba') == True\n    // prime_length('kittens') == True\n    // prime_length('orange') == False\n    def primeLength(string : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // For N = 1000, the sum of digits will be 1 the output should be \"1\".\n    // For N = 150, the sum of digits will be 6 the output should be \"110\".\n    // For N = 147, the sum of digits will be 12 the output should be \"1100\".\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // add([4, 2, 6, 7]) ==> 2\n    def add(lst : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // anti_shuffle('Hi') returns 'Hi'\n    // anti_shuffle('hello') returns 'ehllo'\n    // anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n    def antiShuffle(s : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // get_row([\n    // [1,2,3,4,5,6],\n    // [1,2,3,4,1,6],\n    // [1,2,3,4,5,1]\n    // ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n    // get_row([], 1) == []\n    // get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // * sort_array([]) => []\n    // * sort_array([5]) => [5]\n    // * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n    // * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n    def sortArray(array : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // encrypt('hi') returns 'lm'\n    // encrypt('asdfghjkl') returns 'ewhjklnop'\n    // encrypt('gf') returns 'kj'\n    // encrypt('et') returns 'ix'\n    def encrypt(s : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sum_product([])\n    // (0, 1)\n    // >>> sum_product([1, 2, 3, 4])\n    // (10, 24)\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // next_smallest([1, 2, 3, 4, 5]) == 2\n    // next_smallest([5, 1, 4, 3, 2]) == 2\n    // next_smallest([]) == None\n    // next_smallest([1, 1]) == None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(1l)));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(Some(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> is_bored(\"Hello world\")\n    // 0\n    // >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n    // 1\n    def isBored(S : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // any_int(5, 2, 7) \u279e True\n    // any_int(3, 2, 2) \u279e False\n    // any_int(3, -2, 1) \u279e True\n    // any_int(3.6, -2.2, 2) \u279e False\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode('test')\n    // 'TGST'\n    // >>> encode('This is a message')\n    // 'tHKS KS C MGSSCGG'\n    def encode(message : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n    // For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n    // For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n    // For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n    // For lst = [0,81,12,3,1,21] the output should be 3\n    // For lst = [0,8,1,2,1,7] the output should be 7\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n    // check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n    // check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n    // check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n    // check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // count_up_to(5) => [2,3]\n    // count_up_to(11) => [2,3,5,7]\n    // count_up_to(0) => []\n    // count_up_to(20) => [2,3,5,7,11,13,17,19]\n    // count_up_to(1) => []\n    // count_up_to(18) => [2,3,5,7,11,13,17]\n    def countUpTo(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // multiply(148, 412) should return 16.\n    // multiply(19, 28) should return 72.\n    // multiply(2020, 1851) should return 0.\n    // multiply(14,-15) should return 20.\n    def multiply(a : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // count_upper('aBCdEf') returns 1\n    // count_upper('abcdefg') returns 0\n    // count_upper('dBBE') returns 0\n    def countUpper(s : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closest_integer(\"10\")\n    // 10\n    // >>> closest_integer(\"15.3\")\n    // 15\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    // [1, 2, 3, 3, 3, 4, 4]\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-scala-remove.json
+++ b/prompts/humaneval-scala-remove.json
@@ -1,1356 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    def strlen(string : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    def encrypt(s : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    def add(lst : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    def fixSpaces(text : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    def fibfib(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    def parseMusic(music_string : String) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    def decimalToBinary(decimal : Long) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    def allPrefixes(string : String) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    def add(x : Long, y : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    def flipCase(string : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    def byLength(arr : List[Long]) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    def factorize(n : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    def countUpTo(n : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    def unique(l : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    def maxElement(l : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    def isNested(string : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    def oddCount(lst : List[String]) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    def derivative(xs : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    def isSorted(lst : List[Long]) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    def solve(s : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    def tri(n : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    def fizzBuzz(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    def countUpper(s : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    def largestDivisor(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    def sortArray(array : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    def f(n : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    def iscube(a : Long) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    def encode(message : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    def isBored(S : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    def digits(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    def wordsString(s : String) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    def howManyTimes(string : String, substring : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    def removeVowels(text : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    def primeFib(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    def hasCloseElements(numbers : List[Float], threshold : Float) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.3f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.05f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.95f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.8f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.1f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (1.0f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    def makePalindrome(string : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    def stringXor(a : String, b : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    def fib4(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    def selectWords(s : String, n : Long) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    def fib(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    def matchParens(lst : List[String]) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(1l));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(-35l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    def truncateNumber(number : Float) : Float = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    def incrList(l : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    def modp(n : Long, p : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    def isHappy(s : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    def largestPrimeFactor(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    def digitSum(s : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    def solution(lst : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    def median(l : List[Long]) : Float = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    def primeLength(string : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    def smallestChange(arr : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    def sumSquares(lst : List[Float]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    def fileNameCheck(file_name : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    def validDate(date : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    def countNums(arr : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    def antiShuffle(s : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    def isPalindrome(text : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    def getClosestVowel(word : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    def isPrime(n : Long) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    def simplify(x : String, n : String) : Boolean = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    def hexKey(num : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    def histogram(test : String) : Map[String,Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    def getOddCollatz(n : Long) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    def canArrange(arr : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    def sortNumbers(numbers : String) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    def circularShift(x : Long, shift : Long) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    def sumSquares(lst : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    def chooseNum(x : Long, y : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    def countDistinctCharacters(string : String) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1360,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    def makeAPile(n : Long) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makeAPile((3l)).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(makeAPile((4l)).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(makeAPile((5l)).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong))));\n    assert(makeAPile((6l)).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong))));\n    assert(makeAPile((8l)).equals((List[Long](8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 18l.toLong, 20l.toLong, 22l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1368,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    def wordsString(s : String) : List[String] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(-9l));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(0l));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(-10l));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(20l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(-4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    def chooseNum(x : Long, y : Long) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    def stringSequence(n : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // If the array is empty, return an empty array:\n    // If the array has any strange number ignore it:\n    def byLength(arr : List[Long]) : List[String] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    def f(n : Long) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(\"x\"));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(\"zzzz\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    def countNums(arr : List[Long]) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    def makePalindrome(string : String) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    def histogram(test : String) : Map[String,Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    def multiply(a : Long, b : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    def intToMiniRoman(number : Long) : String = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1576,7 +172,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    def reverseDelete(s : String, c : String) : Tuple2[String, Boolean] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals(((\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals(((\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals(((\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals(((\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals(((\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals(((\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals(((\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1584,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    def oddCount(lst : List[String]) : List[String] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1612,7 +220,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    def sortArray(arr : List[Long]) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong))).equals((List[Long](-4l.toLong, -2l.toLong, -6l.toLong, -5l.toLong, -3l.toLong))));\n    assert(sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](2l.toLong, 5l.toLong, 77l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 77l.toLong))));\n    assert(sortArray((List[Long](3l.toLong, 6l.toLong, 44l.toLong, 12l.toLong, 32l.toLong, 5l.toLong))).equals((List[Long](32l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 12l.toLong, 44l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1620,133 +228,373 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    def concatenate(strings : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    def selectWords(s : String, n : Long) : List[String] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    def getClosestVowel(word : String) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    def matchParens(lst : List[String]) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    def stringXor(a : String, b : String) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    def vowelsCount(s : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // Example 2:\n    // Example 3:\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    def findMax(words : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    def solution(lst : List[Long]) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(\"3e25960a79dbc69b674cd4ec67a72c62\"));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(\"0ef78513b0cb8cef12743f5aeb35f888\"));\n    assert(stringToMd5((\"password\")).equals(\"5f4dcc3b5aa765d61d8327deb882cf99\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    def getOddCollatz(n : Long) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    def validDate(date : String) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    def isSorted(lst : List[Long]) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(Some(-9l)));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(Some(0l)));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(Some(-10l)));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(Some(20l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(Some(4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(Some(-4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(Some(\"x\")));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(Some(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    def tri(n : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    def digits(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    def isNested(string : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    def sumSquares(lst : List[Float]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    def canArrange(arr : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with -\n    def fixSpaces(text : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    def fileNameCheck(file_name : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    def sumSquares(lst : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // Example 2:\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    def simplify(x : String, n : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1756,7 +604,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    def specialFilter(nums : List[Long]) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFilter((List[Long](5l.toLong, -2l.toLong, 1l.toLong, -5l.toLong))) == (0l));\n    assert(specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong))) == (1l));\n    assert(specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong))) == (2l));\n    assert(specialFilter((List[Long](43l.toLong, -12l.toLong, 93l.toLong, 125l.toLong, 121l.toLong, 109l.toLong))) == (4l));\n    assert(specialFilter((List[Long](71l.toLong, -2l.toLong, -33l.toLong, 75l.toLong, 21l.toLong, 19l.toLong))) == (3l));\n    assert(specialFilter((List[Long](1l.toLong))) == (0l));\n    assert(specialFilter((List[Long]())) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1764,25 +612,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    def sumToN(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    def allPrefixes(string : String) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    def intToMiniRoman(number : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    def findMax(words : List[String]) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    def stringSequence(n : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    def solve(s : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(Some(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(Some(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Some(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1792,7 +820,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    def generateIntegers(a : Long, b : Long) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(generateIntegers((2l), (10l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((10l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((132l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((17l), (89l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1800,49 +828,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    def countDistinctCharacters(string : String) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    def parseMusic(music_string : String) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    def search(lst : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    def howManyTimes(string : String, substring : String) : Long = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    def sortNumbers(numbers : String) : String = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    def strlen(string : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    def largestDivisor(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    def factorize(n : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    def flipCase(string : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    def concatenate(strings : List[String]) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    def truncateNumber(number : Float) : Float = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    def isPrime(n : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    def unique(l : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    def maxElement(l : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    def fizzBuzz(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1852,9 +1096,189 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    def sortEven(l : List[Long]) : List[Long] = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](-10l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 5l.toLong, 0l.toLong, 9l.toLong, 1l.toLong, 123l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 8l.toLong, -12l.toLong, 4l.toLong, 23l.toLong, 2l.toLong, 3l.toLong, 11l.toLong, 12l.toLong, -10l.toLong))).equals((List[Long](-12l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 2l.toLong, 12l.toLong, 11l.toLong, 23l.toLong, -10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    def primeFib(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    def incrList(l : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    def fib4(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    def median(l : List[Long]) : Float = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    def isPalindrome(text : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    def modp(n : Long, p : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    def removeVowels(text : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    def add(x : Long, y : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1864,9 +1288,21 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if two words have the same characters.\n    def sameChars(s0 : String, s1 : String) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    def fib(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1876,9 +1312,573 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    def correctBracketing(brackets : String) : Boolean = {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    def largestPrimeFactor(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    def sumToN(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    def derivative(xs : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    def fibfib(n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    def vowelsCount(s : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    def circularShift(x : Long, shift : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    def digitSum(s : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // Example 4:\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    def search(lst : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    def smallestChange(arr : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    def iscube(a : Long) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    def hexKey(num : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    def decimalToBinary(decimal : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    def isHappy(s : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    def primeLength(string : String) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    def add(lst : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    def antiShuffle(s : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    def sortArray(array : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    def encrypt(s : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(1l)));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(Some(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    def isBored(S : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    def encode(message : String) : String = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    def countUpTo(n : Long) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    def multiply(a : Long, b : Long) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    def countUpper(s : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-scala-reworded.json
+++ b/prompts/humaneval-scala-reworded.json
@@ -1,1392 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    def strlen(string : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    def encrypt(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a map, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given map is empty.\n    // Examples:\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"b\" -> \"banana\")))\n    // (true)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"A\" -> \"banana\", \"B\" -> \"banana\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", 8l -> \"banana\", \"a\" -> \"apple\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\")))\n    // (true)\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((List[Long](4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong)))\n    // (2l)\n    def add(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    def fixSpaces(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    def fibfib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((List[Float](1l.toLong, 3l.toLong, 2l.toLong, 0l.toLong)))\n    // (10l)\n    // >>> doubleTheDifference((List[Float](-1l.toLong, -2l.toLong, 0l.toLong)))\n    // (0l)\n    // >>> doubleTheDifference((List[Float](9l.toLong, -2l.toLong)))\n    // (81l)\n    // >>> doubleTheDifference((List[Float](0l.toLong)))\n    // (0l)\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any scalathon values only for integers\n    // >>> filterIntegers((List[Any](\"a\", 3.14f, 5l)))\n    // (List[Long](5l.toLong))\n    // >>> filterIntegers((List[Any](1l, 2l, 3l, \"abc\", Map[Long,Long](), List[Long]())))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (List[Long](4l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))\n    def parseMusic(music_string : String) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    def decimalToBinary(decimal : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (List[String](\"a\", \"ab\", \"abc\"))\n    def allPrefixes(string : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    def add(x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return a list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (List[Long](11l.toLong, 4l.toLong))\n    // >>> eat((4l), (8l), (9l))\n    // (List[Long](12l.toLong, 1l.toLong))\n    // >>> eat((1l), (10l), (10l))\n    // (List[Long](11l.toLong, 0l.toLong))\n    // >>> eat((2l), (11l), (5l))\n    // (List[Long](7l.toLong, 0l.toLong))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    def flipCase(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))\n    // If the list is empty, return an empty list:\n    // >>> byLength((List[Long]()))\n    // (List[String]())\n    // If the list has any strange number ignore it:\n    // >>> byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong)))\n    // (List[String](\"One\"))\n    def byLength(arr : List[Long]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (List[Long](2l.toLong, 2l.toLong, 2l.toLong))\n    // >>> factorize((25l))\n    // (List[Long](5l.toLong, 5l.toLong))\n    // >>> factorize((70l))\n    // (List[Long](2l.toLong, 5l.toLong, 7l.toLong))\n    def factorize(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns a list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (List[Long](2l.toLong, 3l.toLong))\n    // >>> countUpTo((11l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))\n    // >>> countUpTo((0l))\n    // (List[Long]())\n    // >>> countUpTo((20l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))\n    // >>> countUpTo((1l))\n    // (List[Long]())\n    // >>> countUpTo((18l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))\n    def countUpTo(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))\n    def unique(l : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((List[String]()), (List[String]()))\n    // (List[String]())\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\")))\n    // (List[String](\"hI\", \"Hi\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\")))\n    // (List[String](\"hi\", \"admin\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\")))\n    // (List[String](\"hI\", \"hi\", \"hi\"))\n    // >>> totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\")))\n    // (List[String](\"4\"))\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (3l)\n    // >>> maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (123l)\n    def maxElement(l : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    def isNested(string : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // >>> roundedAvg((1l), (5l))\n    // \"0b11\"\n    // >>> roundedAvg((7l), (5l))\n    // -1l\n    // >>> roundedAvg((10l), (20l))\n    // \"0b1111\"\n    // >>> roundedAvg((20l), (33l))\n    // \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((List[String](\"1234567\")))\n    // (List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))\n    // >>> oddCount((List[String](\"3\", \"11111111\")))\n    // (List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))\n    def oddCount(lst : List[String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the list will be randomly ordered. Your task is to determine if\n    // it is possible to get a list sorted in non-decreasing order by performing \n    // the following operation on the given list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the list by one\n    // position in the right direction. The last element of the list will be moved to\n    // the starting position in the list i.e. 0th index. \n    // If it is possible to obtain the sorted list by performing the above operation\n    // then return true else return false.\n    // If the given list is empty then return true.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong)))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given list.\n    // >>> moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong)))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // list by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // ((1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // ((4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))\n    // >>> derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong))\n    def derivative(xs : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((List[Long](5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (false)\n    def isSorted(lst : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    def solve(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))\n    def tri(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    def fizzBuzz(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterByPrefix((List[String](\"abc\", \"bcd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"array\"))\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l))\n    // (List[Long](1l.toLong, 2l.toLong, 1l.toLong))\n    // >>> minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l))\n    // (List[Long](1l.toLong))\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    def countUpper(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l))\n    // (List[Long](-4l.toLong, -3l.toLong, 5l.toLong))\n    // Example 2:\n    // >>> maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l))\n    // (List[Long](4l.toLong, 4l.toLong))\n    // Example 3:\n    // >>> maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l))\n    // (List[Long](2l.toLong))\n    // Note:\n    // 1. The length of the list will be in the range of [1, 1000].\n    // 2. The elements in the list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    def largestDivisor(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of non-negative integers, return a coscala of the given list after sorting,\n    // you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given list.\n    // Examples:\n    // >>> sortArray((List[Long]()))\n    // (List[Long]())\n    // >>> sortArray((List[Long](5l.toLong)))\n    // (List[Long](5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))\n    def sortArray(array : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))\n    def f(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    def iscube(a : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    def encode(message : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    def isBored(S : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are two distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (true)\n    // >>> pairsSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // -1l\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (List[String](\"Saturn\", \"Uranus\"))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (List[String](\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    def digits(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return a list of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))\n    def wordsString(s : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    def howManyTimes(string : String, substring : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    def removeVowels(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))\n    // >>> strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong)))\n    // (List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))\n    // >>> strangeSortList((List[Long]()))\n    // (List[Long]())\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)))\n    // ((2.0f, 2.2f))\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)))\n    // ((2.0f, 2.0f))\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    def primeFib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong)))\n    // (List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))\n    // >>> orderByPoints((List[Long]()))\n    // (List[Long]())\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)), (0.5f))\n    // (false)\n    // >>> hasCloseElements((List[Float](1.0f.toFloat, 2.8f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.3f))\n    // (true)\n    def hasCloseElements(numbers : List[Float], threshold : Float) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.3f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.05f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.95f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.8f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.1f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (1.0f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    def makePalindrome(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    def stringXor(a : String, b : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    def fib4(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong)))\n    // (List[Long](1l.toLong, 15l.toLong, 33l.toLong))\n    // >>> uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong)))\n    // (List[Long]())\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (List[String](\"little\"))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (List[String](\"Mary\", \"lamb\"))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (List[String]())\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (List[String](\"world\"))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (List[String](\"Uncle\"))\n    def selectWords(s : String, n : Long) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((List[Long](1l.toLong, 2l.toLong)), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((List[Long](3l.toLong)), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    def fib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (List[String](\"AA\", \"Be\", \"CC\")))\n    // (\"my_class.AA\")\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((List[String](\"()(\", \")\")))\n    // (\"Yes\")\n    // >>> matchParens((List[String](\")\", \")\")))\n    // (\"No\")\n    def matchParens(lst : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // 2l\n    // >>> nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong)))\n    // 2l\n    // >>> nextSmallest((List[Long]()))\n    // None\n    // >>> nextSmallest((List[Long](1l.toLong, 1l.toLong)))\n    // None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(1l));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(-35l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt(5l, 2l, 7l)\n    // (true)\n    // >>> anyInt(3l, 2l, 2l)\n    // (false)\n    // >>> anyInt(3l, -2l, 1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), 2l)\n    // (false)\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    def truncateNumber(number : Float) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong, 4l.toLong))\n    // >>> incrList((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](6l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))\n    def incrList(l : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    def modp(n : Long, p : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // ((1l, 1l))\n    // >>> evenOddCount((123l))\n    // ((1l, 2l))\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapscala or not.\n    // A string is hapscala if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    def isHappy(s : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    def largestPrimeFactor(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    def digitSum(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat)))\n    // (List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong)))\n    // (12l)\n    // >>> solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong)))\n    // (9l)\n    // >>> solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong)))\n    // (0l)\n    def solution(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given a list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given list is empty, return [].\n    // Example 1:\n    // >>> pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((List[Long]()))\n    // (List[Long]())\n    // Example 4:\n    // >>> pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"YES\")\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // 3l\n    // >>> median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong)))\n    // (15.0f)\n    def median(l : List[Long]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    def primeLength(string : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list arr of integers, find the minimum number of elements that\n    // need to be changed to make the list palindromic. A palindromic list is a list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong)))\n    // (4l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong)))\n    // (1l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong)))\n    // (0l)\n    def smallestChange(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)))\n    // (14l)\n    // >>> lst((List[Float](1.0f.toFloat, 4.0f.toFloat, 9.0f.toFloat)))\n    // (98l)\n    // >>> lst((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat)))\n    // (84l)\n    // >>> lst((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat)))\n    // (29l)\n    // >>> lst((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat)))\n    // (6l)\n    def sumSquares(lst : List[Float]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    def fileNameCheck(file_name : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are three distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection(((1l, 2l)), ((2l, 3l)))\n    // (\"NO\")\n    // >>> intersection(((-1l, 1l)), ((0l, 4l)))\n    // (\"NO\")\n    // >>> intersection(((-3l, -1l)), ((-5l, 5l)))\n    // (\"YES\")\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (List[String](\"()\", \"(())\", \"(()())\"))\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two lists of scores and guesses of equal length, where each index shows a match. \n    // Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong)))\n    // (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))\n    // >>> compare((List[Long](0l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 4l.toLong)), (List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, -2l.toLong)))\n    // (List[Long](4l.toLong, 4l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, 6l.toLong))\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    def validDate(date : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes a list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((List[Long]()))\n    // (0l)\n    // >>> countNums((List[Long](-1l.toLong, 11l.toLong, -11l.toLong)))\n    // (1l)\n    // >>> countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong)))\n    // (3l)\n    def countNums(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    def antiShuffle(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    def isPalindrome(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    def getClosestVowel(word : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    def isPrime(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    def simplify(x : String, n : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    def hexKey(num : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a map\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l))\n    // >>> histogram((\"a b b a\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"a b c a b\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"b b b b a\"))\n    // (Map[String,Long](\"b\" -> 4l))\n    // >>> histogram((\"\"))\n    // (Map[String,Long]())\n    def histogram(test : String) : Map[String,Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l))\n    // (List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))\n    // >>> getRow((List[List[Long]]()), (1l))\n    // (List[Tuple2[Long, Long]]())\n    // >>> getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l))\n    // (List[Tuple2[Long, Long]]((2l, 2l)))\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (List[Long](1l.toLong, 5l.toLong))\n    def getOddCollatz(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)))\n    // (3l)\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (-1l)\n    def canArrange(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    def sortNumbers(numbers : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    def circularShift(x : Long, shift : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // List[Long](1l.toLong, 2l.toLong, 3l.toLong)\n    // >>> lst\n    // List[Long]()\n    // >>> lst\n    // List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong)\n    def sumSquares(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong)))\n    // (10l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong)))\n    // (25l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong)))\n    // (13l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong)))\n    // (11l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong)))\n    // (3l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong)))\n    // (7l)\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((List[Long]()))\n    // ((0l, 1l))\n    // >>> sumProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // ((10l, 24l))\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    def chooseNum(x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (Some(None), Some(1l))\n    // >>> largestSmallestIntegers((List[Long]()))\n    // (Some(None), Some(None))\n    // >>> largestSmallestIntegers((List[Long](0l.toLong)))\n    // (Some(None), Some(None))\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    def countDistinctCharacters(string : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1396,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> makeAPile((3l))\n    // (List[Long](3l.toLong, 5l.toLong, 7l.toLong))\n    def makeAPile(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makeAPile((3l)).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(makeAPile((4l)).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(makeAPile((5l)).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong))));\n    assert(makeAPile((6l)).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong))));\n    assert(makeAPile((8l)).equals((List[Long](8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 18l.toLong, 20l.toLong, 22l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1404,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the list, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong)))\n    // 9l\n    // >>> prodSigns((List[Long](0l.toLong, 1l.toLong)))\n    // 0l\n    // >>> prodSigns((List[Long]()))\n    // None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return a list of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))\n    def wordsString(s : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(-9l));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(0l));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(-10l));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(20l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(-4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of integers nums, find the minimum sum of any non-empty sub-list\n    // of nums.\n    // Example\n    // >>> minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong)))\n    // (1l)\n    // >>> minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)))\n    // (-6l)\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    def chooseNum(x : Long, y : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    def stringSequence(n : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // >>> roundedAvg((1l), (5l))\n    // \"0b11\"\n    // >>> roundedAvg((7l), (5l))\n    // -1l\n    // >>> roundedAvg((10l), (20l))\n    // \"0b1111\"\n    // >>> roundedAvg((20l), (33l))\n    // \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong)))\n    // (List[Long](1l.toLong, 15l.toLong, 33l.toLong))\n    // >>> uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong)))\n    // (List[Long]())\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong)))\n    // (true)\n    // >>> monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)))\n    // (false)\n    // >>> monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong)))\n    // (true)\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting list, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))\n    // If the list is empty, return an empty list:\n    // >>> byLength((List[Long]()))\n    // (List[String]())\n    // If the list has any strange number ignore it:\n    // >>> byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong)))\n    // (List[String](\"One\"))\n    def byLength(arr : List[Long]) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((List[String]()))\n    // None\n    // >>> longest((List[String](\"a\", \"b\", \"c\")))\n    // \"a\"\n    // >>> longest((List[String](\"a\", \"bb\", \"ccc\")))\n    // \"ccc\"\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))\n    def f(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(\"x\"));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(\"zzzz\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l))\n    // (true)\n    // >>> belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l))\n    // (false)\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // ((1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // ((4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes a list of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((List[Long]()))\n    // (0l)\n    // >>> countNums((List[Long](-1l.toLong, 11l.toLong, -11l.toLong)))\n    // (1l)\n    // >>> countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong)))\n    // (3l)\n    def countNums(arr : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((List[Long](-1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](2l.toLong, 5l.toLong, 6l.toLong))\n    // >>> getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have a list 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the list will be randomly ordered. Your task is to determine if\n    // it is possible to get a list sorted in non-decreasing order by performing \n    // the following operation on the given list:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the list by one\n    // position in the right direction. The last element of the list will be moved to\n    // the starting position in the list i.e. 0th index. \n    // If it is possible to obtain the sorted list by performing the above operation\n    // then return true else return false.\n    // If the given list is empty then return true.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong)))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given list.\n    // >>> moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong)))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // list by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    def makePalindrome(string : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"YES\")\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a map\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l))\n    // >>> histogram((\"a b b a\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"a b c a b\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"b b b b a\"))\n    // (Map[String,Long](\"b\" -> 4l))\n    // >>> histogram((\"\"))\n    // (Map[String,Long]())\n    def histogram(test : String) : Map[String,Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    def multiply(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat)))\n    // (1.0f)\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong)))\n    // (List[Long](1l.toLong, 5l.toLong, 653l.toLong))\n    // >>> common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong))\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    def intToMiniRoman(number : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1612,7 +172,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and true/false for the check.\n    // Example\n    // >>> reverseDelete((\"abcde\"), (\"ae\"))\n    // ((\"bcd\", false))\n    // >>> reverseDelete((\"abcdef\"), (\"b\"))\n    // ((\"acdef\", false))\n    // >>> reverseDelete((\"abcdedcba\"), (\"ab\"))\n    // ((\"cdedc\", true))\n    def reverseDelete(s : String, c : String) : Tuple2[String, Boolean] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals(((\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals(((\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals(((\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals(((\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals(((\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals(((\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals(((\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1620,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((List[String](\"1234567\")))\n    // (List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))\n    // >>> oddCount((List[String](\"3\", \"11111111\")))\n    // (List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))\n    def oddCount(lst : List[String]) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // >>> splitWords((\"Hello world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"Hello,world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"abcdef\"))\n    // 3l\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of integers nums, find the minimum sum of any non-empty sub-list\n    // of nums.\n    // Example\n    // >>> minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong)))\n    // (1l)\n    // >>> minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)))\n    // (-6l)\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1648,7 +220,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this Kata, you have to sort a list of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong)))\n    // (List[Long](-6l.toLong, -5l.toLong, -4l.toLong, -3l.toLong, -2l.toLong))\n    // >>> sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))\n    def sortArray(arr : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong))).equals((List[Long](-4l.toLong, -2l.toLong, -6l.toLong, -5l.toLong, -3l.toLong))));\n    assert(sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](2l.toLong, 5l.toLong, 77l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 77l.toLong))));\n    assert(sortArray((List[Long](3l.toLong, 6l.toLong, 44l.toLong, 12l.toLong, 32l.toLong, 5l.toLong))).equals((List[Long](32l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 12l.toLong, 44l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1656,133 +228,373 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((List[String]()))\n    // (\"\")\n    // >>> concatenate((List[String](\"a\", \"b\", \"c\")))\n    // (\"abc\")\n    def concatenate(strings : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (List[String](\"little\"))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (List[String](\"Mary\", \"lamb\"))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (List[String]())\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (List[String](\"world\"))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (List[String](\"Uncle\"))\n    def selectWords(s : String, n : Long) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never a list of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((List[String](\"aa\", \"a\", \"aaa\")))\n    // (List[String](\"aa\"))\n    // >>> listSort((List[String](\"ab\", \"a\", \"aaa\", \"cd\")))\n    // (List[String](\"ab\", \"cd\"))\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    def getClosestVowel(word : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterBySubstring((List[String](\"abc\", \"bacd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"bacd\", \"array\"))\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((List[String](\"()(\", \")\")))\n    // (\"Yes\")\n    // >>> matchParens((List[String](\")\", \")\")))\n    // (\"No\")\n    def matchParens(lst : List[String]) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    def stringXor(a : String, b : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    def vowelsCount(s : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l))\n    // (List[Long](-4l.toLong, -3l.toLong, 5l.toLong))\n    // Example 2:\n    // >>> maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l))\n    // (List[Long](4l.toLong, 4l.toLong))\n    // Example 3:\n    // >>> maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l))\n    // (List[Long](2l.toLong))\n    // Note:\n    // 1. The length of the list will be in the range of [1, 1000].\n    // 2. The elements in the list will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((List[String](\"name\", \"of\", \"string\")))\n    // (\"string\")\n    // >>> findMax((List[String](\"name\", \"enam\", \"game\")))\n    // (\"enam\")\n    // >>> findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\")))\n    // (\"aaaaaaa\")\n    def findMax(words : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong)))\n    // (12l)\n    // >>> solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong)))\n    // (9l)\n    // >>> solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong)))\n    // (0l)\n    def solution(lst : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // \"3e25960a79dbc69b674cd4ec67a72c62\"\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(\"3e25960a79dbc69b674cd4ec67a72c62\"));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(\"0ef78513b0cb8cef12743f5aeb35f888\"));\n    assert(stringToMd5((\"password\")).equals(\"5f4dcc3b5aa765d61d8327deb882cf99\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (List[Long](1l.toLong, 5l.toLong))\n    def getOddCollatz(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns true if the date is valid otherwise false.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    def validDate(date : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat)))\n    // (List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // >>> splitWords((\"Hello world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"Hello,world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"abcdef\"))\n    // 3l\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((List[Long]()), (4l))\n    // (List[Long]())\n    // >>> intersperse((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return false. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((List[Long](5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (false)\n    def isSorted(lst : List[Long]) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection(((1l, 2l)), ((2l, 3l)))\n    // (\"NO\")\n    // >>> intersection(((-1l, 1l)), ((0l, 4l)))\n    // (\"NO\")\n    // >>> intersection(((-3l, -1l)), ((-5l, 5l)))\n    // (\"YES\")\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the list, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong)))\n    // Some(9l)\n    // >>> prodSigns((List[Long](0l.toLong, 1l.toLong)))\n    // Some(0l)\n    // >>> prodSigns((List[Long]()))\n    // None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(Some(-9l)));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(Some(0l)));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(Some(-10l)));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(Some(20l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(Some(4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(Some(-4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l))\n    // (List[Long](1l.toLong, 2l.toLong, 1l.toLong))\n    // >>> minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l))\n    // (List[Long](1l.toLong))\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((List[String]()))\n    // None\n    // >>> longest((List[String](\"a\", \"b\", \"c\")))\n    // Some(\"a\")\n    // >>> longest((List[String](\"a\", \"bb\", \"ccc\")))\n    // Some(\"ccc\")\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(Some(\"x\")));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(Some(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))\n    def tri(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    def digits(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return true if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    def isNested(string : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)))\n    // (14l)\n    // >>> lst((List[Float](1.0f.toFloat, 4.0f.toFloat, 9.0f.toFloat)))\n    // (98l)\n    // >>> lst((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat)))\n    // (84l)\n    // >>> lst((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat)))\n    // (29l)\n    // >>> lst((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat)))\n    // (6l)\n    def sumSquares(lst : List[Float]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns true if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and false otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given list will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)))\n    // (3l)\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (-1l)\n    def canArrange(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (Some(None), Some(1l))\n    // >>> largestSmallestIntegers((List[Long]()))\n    // (Some(None), Some(None))\n    // >>> largestSmallestIntegers((List[Long](0l.toLong)))\n    // (Some(None), Some(None))\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    def fixSpaces(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    def fileNameCheck(file_name : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // List[Long](1l.toLong, 2l.toLong, 3l.toLong)\n    // >>> lst\n    // List[Long]()\n    // >>> lst\n    // List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong)\n    def sumSquares(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns true if x * n evaluates to a whole number and false\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    def simplify(x : String, n : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong)))\n    // (List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))\n    // >>> orderByPoints((List[Long]()))\n    // (List[Long]())\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1792,7 +604,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a list of numbers as input and returns \n    // the number of elements in the list that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong)))\n    // (1l)\n    // >>> specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong)))\n    // (2l)\n    def specialFilter(nums : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFilter((List[Long](5l.toLong, -2l.toLong, 1l.toLong, -5l.toLong))) == (0l));\n    assert(specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong))) == (1l));\n    assert(specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong))) == (2l));\n    assert(specialFilter((List[Long](43l.toLong, -12l.toLong, 93l.toLong, 125l.toLong, 121l.toLong, 109l.toLong))) == (4l));\n    assert(specialFilter((List[Long](71l.toLong, -2l.toLong, -33l.toLong, 75l.toLong, 21l.toLong, 19l.toLong))) == (3l));\n    assert(specialFilter((List[Long](1l.toLong))) == (0l));\n    assert(specialFilter((List[Long]())) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1800,25 +612,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    def sumToN(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer list a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 3l.toLong, 4l.toLong))\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (List[String](\"Saturn\", \"Uranus\"))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (List[String](\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never a list of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((List[String](\"aa\", \"a\", \"aaa\")))\n    // (List[String](\"aa\"))\n    // >>> listSort((List[String](\"ab\", \"a\", \"aaa\", \"cd\")))\n    // (List[String](\"ab\", \"cd\"))\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (List[String](\"a\", \"ab\", \"abc\"))\n    def allPrefixes(string : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((List[Float](1l.toLong, 3l.toLong, 2l.toLong, 0l.toLong)))\n    // (10l)\n    // >>> doubleTheDifference((List[Float](-1l.toLong, -2l.toLong, 0l.toLong)))\n    // (0l)\n    // >>> doubleTheDifference((List[Float](9l.toLong, -2l.toLong)))\n    // (81l)\n    // >>> doubleTheDifference((List[Float](0l.toLong)))\n    // (0l)\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two lists of scores and guesses of equal length, where each index shows a match. \n    // Return a list of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong)))\n    // (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))\n    // >>> compare((List[Long](0l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 4l.toLong)), (List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, -2l.toLong)))\n    // (List[Long](4l.toLong, 4l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, 6l.toLong))\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (List[String](\"AA\", \"Be\", \"CC\")))\n    // (\"my_class.AA\")\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // ((1l, 1l))\n    // >>> evenOddCount((123l))\n    // ((1l, 2l))\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    def intToMiniRoman(number : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return true if the three\n    // sides form a right-angled triangle, false otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((List[String](\"name\", \"of\", \"string\")))\n    // (\"string\")\n    // >>> findMax((List[String](\"name\", \"enam\", \"game\")))\n    // (\"enam\")\n    // >>> findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\")))\n    // (\"aaaaaaa\")\n    def findMax(words : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return a list of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (List[Long](11l.toLong, 4l.toLong))\n    // >>> eat((4l), (8l), (9l))\n    // (List[Long](12l.toLong, 1l.toLong))\n    // >>> eat((1l), (10l), (10l))\n    // (List[Long](11l.toLong, 0l.toLong))\n    // >>> eat((2l), (11l), (5l))\n    // (List[Long](7l.toLong, 0l.toLong))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    def stringSequence(n : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // list = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    def solve(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // Some(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(Some(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(Some(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Some(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1828,7 +832,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> generateIntegers((2l), (8l))\n    // (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))\n    // >>> generateIntegers((8l), (2l))\n    // (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))\n    // >>> generateIntegers((10l), (14l))\n    // (List[Long]())\n    def generateIntegers(a : Long, b : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(generateIntegers((2l), (10l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((10l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((132l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((17l), (89l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1836,49 +840,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    def countDistinctCharacters(string : String) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (false)\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong)))\n    // (true)\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (List[Long](4l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))\n    def parseMusic(music_string : String) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((List[Long](4l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong)))\n    // (2l)\n    // >>> search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (3l)\n    // >>> search((List[Long](5l.toLong, 5l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (-1l)\n    def search(lst : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    def howManyTimes(string : String, substring : String) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    def sortNumbers(numbers : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (List[String](\"()\", \"(())\", \"(()())\"))\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)))\n    // ((2.0f, 2.2f))\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)))\n    // ((2.0f, 2.0f))\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat)))\n    // (List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any scalathon values only for integers\n    // >>> filterIntegers((List[Any](\"a\", 3.14f, 5l)))\n    // (List[Long](5l.toLong))\n    // >>> filterIntegers((List[Any](1l, 2l, 3l, \"abc\", Map[Long,Long](), List[Long]())))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    def strlen(string : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    def largestDivisor(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (List[Long](2l.toLong, 2l.toLong, 2l.toLong))\n    // >>> factorize((25l))\n    // (List[Long](5l.toLong, 5l.toLong))\n    // >>> factorize((70l))\n    // (List[Long](2l.toLong, 5l.toLong, 7l.toLong))\n    def factorize(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 3l.toLong, 4l.toLong))\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    def flipCase(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((List[String]()))\n    // (\"\")\n    // >>> concatenate((List[String](\"a\", \"b\", \"c\")))\n    // (\"abc\")\n    def concatenate(strings : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterByPrefix((List[String](\"abc\", \"bcd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"array\"))\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    def truncateNumber(number : Float) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((List[Long](-1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](2l.toLong, 5l.toLong, 6l.toLong))\n    // >>> getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    def isPrime(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))\n    def unique(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (3l)\n    // >>> maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (123l)\n    def maxElement(l : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    def fizzBuzz(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1108,201 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortEven((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](3l.toLong, 6l.toLong, 5l.toLong, 4l.toLong))\n    def sortEven(l : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](-10l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 5l.toLong, 0l.toLong, 9l.toLong, 1l.toLong, 123l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 8l.toLong, -12l.toLong, 4l.toLong, 23l.toLong, 2l.toLong, 3l.toLong, 11l.toLong, 12l.toLong, -10l.toLong))).equals((List[Long](-12l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 2l.toLong, 12l.toLong, 11l.toLong, 23l.toLong, -10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    def primeFib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return true. Otherwise it should return false.\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (false)\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong)))\n    // (true)\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are three distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong, 4l.toLong))\n    // >>> incrList((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](6l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))\n    def incrList(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns true if there are two distinct elements in the list that\n    // sum to zero, and false otherwise.\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (true)\n    // >>> pairsSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    def fib4(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // 3l\n    // >>> median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong)))\n    // (15.0f)\n    def median(l : List[Long]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    def isPalindrome(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    def modp(n : Long, p : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat)))\n    // (1.0f)\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    def removeVowels(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l))\n    // (true)\n    // >>> belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l))\n    // (false)\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    def add(x : Long, y : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1900,9 +1312,21 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if two words have the same characters.\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> sameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> sameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> sameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> sameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    def sameChars(s0 : String, s1 : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    def fib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1912,9 +1336,585 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"<\"))\n    // (false)\n    // >>> correctBracketing((\"<>\"))\n    // (true)\n    // >>> correctBracketing((\"<<><>>\"))\n    // (true)\n    // >>> correctBracketing((\"><<>\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong)))\n    // (true)\n    // >>> monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)))\n    // (false)\n    // >>> monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong)))\n    // (true)\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong)))\n    // (List[Long](1l.toLong, 5l.toLong, 653l.toLong))\n    // >>> common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong))\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    def largestPrimeFactor(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((List[Long]()), (4l))\n    // (List[Long]())\n    // >>> intersperse((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    def sumToN(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return true if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))\n    // >>> derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong))\n    def derivative(xs : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    def fibfib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    def vowelsCount(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    def circularShift(x : Long, shift : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    def digitSum(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given a list representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given list is empty, return [].\n    // Example 1:\n    // >>> pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((List[Long]()))\n    // (List[Long]())\n    // Example 4:\n    // >>> pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((List[Long](4l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong)))\n    // (2l)\n    // >>> search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (3l)\n    // >>> search((List[Long](5l.toLong, 5l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (-1l)\n    def search(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))\n    // >>> strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong)))\n    // (List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))\n    // >>> strangeSortList((List[Long]()))\n    // (List[Long]())\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // -1l\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the object q will fly, and false otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((List[Long](1l.toLong, 2l.toLong)), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((List[Long](3l.toLong)), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list arr of integers, find the minimum number of elements that\n    // need to be changed to make the list palindromic. A palindromic list is a list that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong)))\n    // (4l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong)))\n    // (1l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong)))\n    // (0l)\n    def smallestChange(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((List[String]()), (List[String]()))\n    // (List[String]())\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\")))\n    // (List[String](\"hI\", \"Hi\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\")))\n    // (List[String](\"hi\", \"admin\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\")))\n    // (List[String](\"hI\", \"hi\", \"hi\"))\n    // >>> totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\")))\n    // (List[String](\"4\"))\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns true \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    def iscube(a : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    def hexKey(num : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    def decimalToBinary(decimal : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterBySubstring((List[String](\"abc\", \"bacd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"bacd\", \"array\"))\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is hapscala or not.\n    // A string is hapscala if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    def isHappy(s : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat)))\n    // (List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns true if the string\n    // length is a prime number or false otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    def primeLength(string : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((List[Long](4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong)))\n    // (2l)\n    def add(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    def antiShuffle(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l))\n    // (List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))\n    // >>> getRow((List[List[Long]]()), (1l))\n    // (List[Tuple2[Long, Long]]())\n    // >>> getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l))\n    // (List[Tuple2[Long, Long]]((2l, 2l)))\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of non-negative integers, return a coscala of the given list after sorting,\n    // you will sort the given list in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given list.\n    // Examples:\n    // >>> sortArray((List[Long]()))\n    // (List[Long]())\n    // >>> sortArray((List[Long](5l.toLong)))\n    // (List[Long](5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))\n    def sortArray(array : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    def encrypt(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((List[Long]()))\n    // ((0l, 1l))\n    // >>> sumProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // ((10l, 24l))\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // Some(2l)\n    // >>> nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong)))\n    // Some(2l)\n    // >>> nextSmallest((List[Long]()))\n    // None\n    // >>> nextSmallest((List[Long](1l.toLong, 1l.toLong)))\n    // None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(1l)));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(Some(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    def isBored(S : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt(5l, 2l, 7l)\n    // (true)\n    // >>> anyInt(3l, 2l, 2l)\n    // (false)\n    // >>> anyInt(3l, -2l, 1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), 2l)\n    // (false)\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    def encode(message : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong)))\n    // (10l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong)))\n    // (25l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong)))\n    // (13l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong)))\n    // (11l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong)))\n    // (3l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong)))\n    // (7l)\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a map, return true if all keys are strings in lower \n    // case or all keys are strings in upper case, else return false.\n    // The function should return false is the given map is empty.\n    // Examples:\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"b\" -> \"banana\")))\n    // (true)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"A\" -> \"banana\", \"B\" -> \"banana\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", 8l -> \"banana\", \"a\" -> \"apple\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\")))\n    // (true)\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns a list of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (List[Long](2l.toLong, 3l.toLong))\n    // >>> countUpTo((11l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))\n    // >>> countUpTo((0l))\n    // (List[Long]())\n    // >>> countUpTo((20l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))\n    // >>> countUpTo((1l))\n    // (List[Long]())\n    // >>> countUpTo((18l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))\n    def countUpTo(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    def multiply(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    def countUpper(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-scala-transform.json
+++ b/prompts/humaneval-scala-transform.json
@@ -1,1392 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    def strlen(string : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    def encrypt(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"b\" -> \"banana\")))\n    // (true)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"A\" -> \"banana\", \"B\" -> \"banana\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", 8l -> \"banana\", \"a\" -> \"apple\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\")))\n    // (true)\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((List[Long](4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong)))\n    // (2l)\n    def add(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    def fixSpaces(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    def fibfib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((List[Float](1l.toLong, 3l.toLong, 2l.toLong, 0l.toLong)))\n    // (10l)\n    // >>> doubleTheDifference((List[Float](-1l.toLong, -2l.toLong, 0l.toLong)))\n    // (0l)\n    // >>> doubleTheDifference((List[Float](9l.toLong, -2l.toLong)))\n    // (81l)\n    // >>> doubleTheDifference((List[Float](0l.toLong)))\n    // (0l)\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    // >>> filterIntegers((List[Any](\"a\", 3.14f, 5l)))\n    // (List[Long](5l.toLong))\n    // >>> filterIntegers((List[Any](1l, 2l, 3l, \"abc\", Map[Long,Long](), List[Long]())))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (List[Long](4l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))\n    def parseMusic(music_string : String) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    def decimalToBinary(decimal : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (List[String](\"a\", \"ab\", \"abc\"))\n    def allPrefixes(string : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    def add(x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (List[Long](11l.toLong, 4l.toLong))\n    // >>> eat((4l), (8l), (9l))\n    // (List[Long](12l.toLong, 1l.toLong))\n    // >>> eat((1l), (10l), (10l))\n    // (List[Long](11l.toLong, 0l.toLong))\n    // >>> eat((2l), (11l), (5l))\n    // (List[Long](7l.toLong, 0l.toLong))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    def flipCase(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))\n    // If the array is empty, return an empty array:\n    // >>> byLength((List[Long]()))\n    // (List[String]())\n    // If the array has any strange number ignore it:\n    // >>> byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong)))\n    // (List[String](\"One\"))\n    def byLength(arr : List[Long]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (List[Long](2l.toLong, 2l.toLong, 2l.toLong))\n    // >>> factorize((25l))\n    // (List[Long](5l.toLong, 5l.toLong))\n    // >>> factorize((70l))\n    // (List[Long](2l.toLong, 5l.toLong, 7l.toLong))\n    def factorize(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (List[Long](2l.toLong, 3l.toLong))\n    // >>> countUpTo((11l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))\n    // >>> countUpTo((0l))\n    // (List[Long]())\n    // >>> countUpTo((20l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))\n    // >>> countUpTo((1l))\n    // (List[Long]())\n    // >>> countUpTo((18l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))\n    def countUpTo(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))\n    def unique(l : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((List[String]()), (List[String]()))\n    // (List[String]())\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\")))\n    // (List[String](\"hI\", \"Hi\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\")))\n    // (List[String](\"hi\", \"admin\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\")))\n    // (List[String](\"hI\", \"hi\", \"hi\"))\n    // >>> totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\")))\n    // (List[String](\"4\"))\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (3l)\n    // >>> maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (123l)\n    def maxElement(l : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    def isNested(string : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // >>> roundedAvg((1l), (5l))\n    // \"0b11\"\n    // >>> roundedAvg((7l), (5l))\n    // -1l\n    // >>> roundedAvg((10l), (20l))\n    // \"0b1111\"\n    // >>> roundedAvg((20l), (33l))\n    // \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((List[String](\"1234567\")))\n    // (List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))\n    // >>> oddCount((List[String](\"3\", \"11111111\")))\n    // (List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))\n    def oddCount(lst : List[String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong)))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong)))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // ((1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // ((4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))\n    // >>> derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong))\n    def derivative(xs : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((List[Long](5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (false)\n    def isSorted(lst : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    def solve(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))\n    def tri(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    def fizzBuzz(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterByPrefix((List[String](\"abc\", \"bcd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"array\"))\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l))\n    // (List[Long](1l.toLong, 2l.toLong, 1l.toLong))\n    // >>> minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l))\n    // (List[Long](1l.toLong))\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    def countUpper(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l))\n    // (List[Long](-4l.toLong, -3l.toLong, 5l.toLong))\n    // Example 2:\n    // >>> maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l))\n    // (List[Long](4l.toLong, 4l.toLong))\n    // Example 3:\n    // >>> maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l))\n    // (List[Long](2l.toLong))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    def largestDivisor(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> sortArray((List[Long]()))\n    // (List[Long]())\n    // >>> sortArray((List[Long](5l.toLong)))\n    // (List[Long](5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))\n    def sortArray(array : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))\n    def f(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    def iscube(a : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    def encode(message : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    def isBored(S : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (true)\n    // >>> pairsSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // -1l\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (List[String](\"Saturn\", \"Uranus\"))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (List[String](\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    def digits(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))\n    def wordsString(s : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    def howManyTimes(string : String, substring : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    def removeVowels(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))\n    // >>> strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong)))\n    // (List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))\n    // >>> strangeSortList((List[Long]()))\n    // (List[Long]())\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)))\n    // ((2.0f, 2.2f))\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)))\n    // ((2.0f, 2.0f))\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    def primeFib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong)))\n    // (List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))\n    // >>> orderByPoints((List[Long]()))\n    // (List[Long]())\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if in given list of numbers, are any two numbers closer to each other than\n    // given threshold.\n    // >>> hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)), (0.5f))\n    // (false)\n    // >>> hasCloseElements((List[Float](1.0f.toFloat, 2.8f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.3f))\n    // (true)\n    def hasCloseElements(numbers : List[Float], threshold : Float) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.3f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)), (0.05f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.95f)) == (true));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat)), (0.8f)) == (false));\n    assert(hasCloseElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)), (0.1f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (1.0f)) == (true));\n    assert(hasCloseElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat)), (0.5f)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    def makePalindrome(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    def stringXor(a : String, b : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    def fib4(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong)))\n    // (List[Long](1l.toLong, 15l.toLong, 33l.toLong))\n    // >>> uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong)))\n    // (List[Long]())\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (List[String](\"little\"))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (List[String](\"Mary\", \"lamb\"))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (List[String]())\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (List[String](\"world\"))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (List[String](\"Uncle\"))\n    def selectWords(s : String, n : Long) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((List[Long](1l.toLong, 2l.toLong)), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((List[Long](3l.toLong)), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    def fib(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (List[String](\"AA\", \"Be\", \"CC\")))\n    // (\"my_class.AA\")\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((List[String](\"()(\", \")\")))\n    // (\"Yes\")\n    // >>> matchParens((List[String](\")\", \")\")))\n    // (\"No\")\n    def matchParens(lst : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // 2l\n    // >>> nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong)))\n    // 2l\n    // >>> nextSmallest((List[Long]()))\n    // None\n    // >>> nextSmallest((List[Long](1l.toLong, 1l.toLong)))\n    // None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(2l));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(1l));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(-35l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt(5l, 2l, 7l)\n    // (true)\n    // >>> anyInt(3l, 2l, 2l)\n    // (false)\n    // >>> anyInt(3l, -2l, 1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), 2l)\n    // (false)\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    def truncateNumber(number : Float) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong, 4l.toLong))\n    // >>> incrList((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](6l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))\n    def incrList(l : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    def modp(n : Long, p : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // ((1l, 1l))\n    // >>> evenOddCount((123l))\n    // ((1l, 2l))\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    def isHappy(s : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    def largestPrimeFactor(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    def digitSum(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat)))\n    // (List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong)))\n    // (12l)\n    // >>> solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong)))\n    // (9l)\n    // >>> solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong)))\n    // (0l)\n    def solution(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((List[Long]()))\n    // (List[Long]())\n    // Example 4:\n    // >>> pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"YES\")\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // 3l\n    // >>> median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong)))\n    // (15.0f)\n    def median(l : List[Long]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    def primeLength(string : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong)))\n    // (4l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong)))\n    // (1l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong)))\n    // (0l)\n    def smallestChange(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)))\n    // (14l)\n    // >>> lst((List[Float](1.0f.toFloat, 4.0f.toFloat, 9.0f.toFloat)))\n    // (98l)\n    // >>> lst((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat)))\n    // (84l)\n    // >>> lst((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat)))\n    // (29l)\n    // >>> lst((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat)))\n    // (6l)\n    def sumSquares(lst : List[Float]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    def fileNameCheck(file_name : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection(((1l, 2l)), ((2l, 3l)))\n    // (\"NO\")\n    // >>> intersection(((-1l, 1l)), ((0l, 4l)))\n    // (\"NO\")\n    // >>> intersection(((-3l, -1l)), ((-5l, 5l)))\n    // (\"YES\")\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (List[String](\"()\", \"(())\", \"(()())\"))\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong)))\n    // (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))\n    // >>> compare((List[Long](0l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 4l.toLong)), (List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, -2l.toLong)))\n    // (List[Long](4l.toLong, 4l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, 6l.toLong))\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    def validDate(date : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((List[Long]()))\n    // (0l)\n    // >>> countNums((List[Long](-1l.toLong, 11l.toLong, -11l.toLong)))\n    // (1l)\n    // >>> countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong)))\n    // (3l)\n    def countNums(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    def antiShuffle(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    def isPalindrome(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    def getClosestVowel(word : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    def isPrime(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    def simplify(x : String, n : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    def hexKey(num : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l))\n    // >>> histogram((\"a b b a\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"a b c a b\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"b b b b a\"))\n    // (Map[String,Long](\"b\" -> 4l))\n    // >>> histogram((\"\"))\n    // (Map[String,Long]())\n    def histogram(test : String) : Map[String,Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l))\n    // (List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))\n    // >>> getRow((List[List[Long]]()), (1l))\n    // (List[Tuple2[Long, Long]]())\n    // >>> getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l))\n    // (List[Tuple2[Long, Long]]((2l, 2l)))\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (List[Long](1l.toLong, 5l.toLong))\n    def getOddCollatz(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)))\n    // (3l)\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (-1l)\n    def canArrange(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    def sortNumbers(numbers : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    def circularShift(x : Long, shift : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // List[Long](1l.toLong, 2l.toLong, 3l.toLong)\n    // >>> lst\n    // List[Long]()\n    // >>> lst\n    // List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong)\n    def sumSquares(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong)))\n    // (10l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong)))\n    // (25l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong)))\n    // (13l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong)))\n    // (11l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong)))\n    // (3l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong)))\n    // (7l)\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((List[Long]()))\n    // ((0l, 1l))\n    // >>> sumProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // ((10l, 24l))\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    def chooseNum(x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (Some(None), Some(1l))\n    // >>> largestSmallestIntegers((List[Long]()))\n    // (Some(None), Some(None))\n    // >>> largestSmallestIntegers((List[Long](0l.toLong)))\n    // (Some(None), Some(None))\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    def countDistinctCharacters(string : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1396,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, you have to make a pile of n levels of stones.\n    // The first level has n stones.\n    // The number of stones in the next level is:\n    // - the next odd number if n is odd.\n    // - the next even number if n is even.\n    // Return the number of stones in each level in a list, where element at index\n    // i represents the number of stones in the level (i+1).\n    // Examples:\n    // >>> makeAPile((3l))\n    // (List[Long](3l.toLong, 5l.toLong, 7l.toLong))\n    def makeAPile(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makeAPile((3l)).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(makeAPile((4l)).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(makeAPile((5l)).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong))));\n    assert(makeAPile((6l)).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong))));\n    assert(makeAPile((8l)).equals((List[Long](8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 18l.toLong, 20l.toLong, 22l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1404,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong)))\n    // 9l\n    // >>> prodSigns((List[Long](0l.toLong, 1l.toLong)))\n    // 0l\n    // >>> prodSigns((List[Long]()))\n    // None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a string of words separated by commas or spaces. Your task is\n    // to split the string into words and return an array of the words.\n    // For example:\n    // >>> wordsString((\"Hi, my name is John\"))\n    // (List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))\n    // >>> wordsString((\"One, two, three, four, five, six\"))\n    // (List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))\n    def wordsString(s : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(-9l));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(0l));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(-10l));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(20l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(-4l));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsString((\"Hi, my name is John\")).equals((List[String](\"Hi\", \"my\", \"name\", \"is\", \"John\"))));\n    assert(wordsString((\"One, two, three, four, five, six\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"Hi, my name\")).equals((List[String](\"Hi\", \"my\", \"name\"))));\n    assert(wordsString((\"One,, two, three, four, five, six,\")).equals((List[String](\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"))));\n    assert(wordsString((\"\")).equals((List[String]())));\n    assert(wordsString((\"ahmed     , gamal\")).equals((List[String](\"ahmed\", \"gamal\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong)))\n    // (1l)\n    // >>> minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)))\n    // (-6l)\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes two positive numbers x and y and returns the\n    // biggest even integer number that is in the range [x, y] inclusive. If \n    // there's no such number, then the function should return -1.\n    // For example:\n    // >>> chooseNum((12l), (15l))\n    // (14l)\n    // >>> chooseNum((13l), (12l))\n    // (-1l)\n    def chooseNum(x : Long, y : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(chooseNum((12l), (15l)) == (14l));\n    assert(chooseNum((13l), (12l)) == (-1l));\n    assert(chooseNum((33l), (12354l)) == (12354l));\n    assert(chooseNum((5234l), (5233l)) == (-1l));\n    assert(chooseNum((6l), (29l)) == (28l));\n    assert(chooseNum((27l), (10l)) == (-1l));\n    assert(chooseNum((7l), (7l)) == (-1l));\n    assert(chooseNum((546l), (546l)) == (546l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    def stringSequence(n : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two positive integers n and m, and your task is to compute the\n    // average of the integers from n through m (including n and m). \n    // Round the answer to the nearest integer and convert that to binary.\n    // If n is greater than m, return -1.\n    // Example:\n    // >>> roundedAvg((1l), (5l))\n    // \"0b11\"\n    // >>> roundedAvg((7l), (5l))\n    // -1l\n    // >>> roundedAvg((10l), (20l))\n    // \"0b1111\"\n    // >>> roundedAvg((20l), (33l))\n    // \"0b11010\"\n    def roundedAvg(n : Long, m : Long) : Either[String, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundedAvg((1l), (5l)).equals(\"0b11\"));\n    assert(roundedAvg((7l), (13l)).equals(\"0b1010\"));\n    assert(roundedAvg((964l), (977l)).equals(\"0b1111001010\"));\n    assert(roundedAvg((996l), (997l)).equals(\"0b1111100100\"));\n    assert(roundedAvg((560l), (851l)).equals(\"0b1011000010\"));\n    assert(roundedAvg((185l), (546l)).equals(\"0b101101110\"));\n    assert(roundedAvg((362l), (496l)).equals(\"0b110101101\"));\n    assert(roundedAvg((350l), (902l)).equals(\"0b1001110010\"));\n    assert(roundedAvg((197l), (233l)).equals(\"0b11010111\"));\n    assert(roundedAvg((7l), (5l)).equals(-1l));\n    assert(roundedAvg((5l), (1l)).equals(-1l));\n    assert(roundedAvg((5l), (5l)).equals(\"0b101\"));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of positive integers x. return a sorted list of all \n    // elements that hasn't any even digit.\n    // Note: Returned list should be sorted in increasing order.\n    // For example:\n    // >>> uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong)))\n    // (List[Long](1l.toLong, 15l.toLong, 33l.toLong))\n    // >>> uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong)))\n    // (List[Long]())\n    def uniqueDigits(x : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueDigits((List[Long](15l.toLong, 33l.toLong, 1422l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 15l.toLong, 33l.toLong))));\n    assert(uniqueDigits((List[Long](152l.toLong, 323l.toLong, 1422l.toLong, 10l.toLong))).equals((List[Long]())));\n    assert(uniqueDigits((List[Long](12345l.toLong, 2033l.toLong, 111l.toLong, 151l.toLong))).equals((List[Long](111l.toLong, 151l.toLong))));\n    assert(uniqueDigits((List[Long](135l.toLong, 103l.toLong, 31l.toLong))).equals((List[Long](31l.toLong, 135l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong)))\n    // (true)\n    // >>> monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)))\n    // (false)\n    // >>> monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong)))\n    // (true)\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n    // reverse the resulting array, and then replace each digit by its corresponding name from\n    // \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n    // For example:\n    // >>> byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))\n    // If the array is empty, return an empty array:\n    // >>> byLength((List[Long]()))\n    // (List[String]())\n    // If the array has any strange number ignore it:\n    // >>> byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong)))\n    // (List[String](\"One\"))\n    def byLength(arr : List[Long]) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(byLength((List[Long](2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 3l.toLong))).equals((List[String](\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"))));\n    assert(byLength((List[Long]())).equals((List[String]())));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 55l.toLong))).equals((List[String](\"One\"))));\n    assert(byLength((List[Long](1l.toLong, -1l.toLong, 3l.toLong, 2l.toLong))).equals((List[String](\"Three\", \"Two\", \"One\"))));\n    assert(byLength((List[Long](9l.toLong, 4l.toLong, 8l.toLong))).equals((List[String](\"Nine\", \"Eight\", \"Four\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((List[String]()))\n    // None\n    // >>> longest((List[String](\"a\", \"b\", \"c\")))\n    // \"a\"\n    // >>> longest((List[String](\"a\", \"bb\", \"ccc\")))\n    // \"ccc\"\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement the function f that takes n as a parameter,\n    // and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n    // or the sum of numbers from 1 to i otherwise.\n    // i starts from 1.\n    // the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n    // Example:\n    // >>> f((5l))\n    // (List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))\n    def f(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(\"x\"));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(\"zzzz\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(f((5l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong))));\n    assert(f((7l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong, 24l.toLong, 15l.toLong, 720l.toLong, 28l.toLong))));\n    assert(f((1l)).equals((List[Long](1l.toLong))));\n    assert(f((3l)).equals((List[Long](1l.toLong, 2l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l))\n    // (true)\n    // >>> belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l))\n    // (false)\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a tuple that has the number of even and odd\n    // integer palindromes that fall within the range(1, n), inclusive.\n    // Example 1:\n    // >>> evenOddPalindrome((3l))\n    // ((1l, 2l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n    // Example 2:\n    // >>> evenOddPalindrome((12l))\n    // ((4l, 6l))\n    // Explanation:\n    // Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n    // Note:\n    // 1. 1 <= n <= 10^3\n    // 2. returned tuple has the number of even and odd integer palindromes respectively.\n    def evenOddPalindrome(n : Long) : Tuple2[Long, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddPalindrome((123l)).equals(((8l, 13l))));\n    assert(evenOddPalindrome((12l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((3l)).equals(((1l, 2l))));\n    assert(evenOddPalindrome((63l)).equals(((6l, 8l))));\n    assert(evenOddPalindrome((25l)).equals(((5l, 6l))));\n    assert(evenOddPalindrome((19l)).equals(((4l, 6l))));\n    assert(evenOddPalindrome((9l)).equals(((4l, 5l))));\n    assert(evenOddPalindrome((1l)).equals(((0l, 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function count_nums which takes an array of integers and returns\n    // the number of elements which has a sum of digits > 0.\n    // If a number is negative, then its first signed digit will be negative:\n    // e.g. -123 has signed digits -1, 2, and 3.\n    // >>> countNums((List[Long]()))\n    // (0l)\n    // >>> countNums((List[Long](-1l.toLong, 11l.toLong, -11l.toLong)))\n    // (1l)\n    // >>> countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong)))\n    // (3l)\n    def countNums(arr : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNums((List[Long]())) == (0l));\n    assert(countNums((List[Long](-1l.toLong, -2l.toLong, 0l.toLong))) == (0l));\n    assert(countNums((List[Long](1l.toLong, 1l.toLong, 2l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (6l));\n    assert(countNums((List[Long](1l.toLong, 6l.toLong, 9l.toLong, -6l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))) == (5l));\n    assert(countNums((List[Long](1l.toLong, 100l.toLong, 98l.toLong, -7l.toLong, 1l.toLong, -1l.toLong))) == (4l));\n    assert(countNums((List[Long](12l.toLong, 23l.toLong, 34l.toLong, -45l.toLong, -56l.toLong, 0l.toLong))) == (5l));\n    assert(countNums((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    assert(countNums((List[Long](1l.toLong))) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((List[Long](-1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](2l.toLong, 5l.toLong, 6l.toLong))\n    // >>> getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n    // numbers in the array will be randomly ordered. Your task is to determine if\n    // it is possible to get an array sorted in non-decreasing order by performing \n    // the following operation on the given array:\n    // You are allowed to perform right shift operation any number of times.\n    // One right shift operation means shifting all elements of the array by one\n    // position in the right direction. The last element of the array will be moved to\n    // the starting position in the array i.e. 0th index. \n    // If it is possible to obtain the sorted array by performing the above operation\n    // then return True else return False.\n    // If the given array is empty then return True.\n    // Note: The given list is guaranteed to have unique elements.\n    // For Example:\n    // >>> moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong)))\n    // (true)\n    // Explanation: By performin 2 right shift operations, non-decreasing order can\n    // be achieved for the given array.\n    // >>> moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong)))\n    // (false)\n    // Explanation:It is not possible to get non-decreasing order for the given\n    // array by performing any number of right shift operations.\n    def moveOneBall(arr : List[Long]) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveOneBall((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 10l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(moveOneBall((List[Long](4l.toLong, 3l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long](3l.toLong, 5l.toLong, 4l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(moveOneBall((List[Long]())) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find the shortest palindrome that begins with a supplied string.\n    // Algorithm idea is simple:\n    // - Find the longest postfix of supplied string that is a palindrome.\n    // - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n    // >>> makePalindrome((\"\"))\n    // (\"\")\n    // >>> makePalindrome((\"cat\"))\n    // (\"catac\")\n    // >>> makePalindrome((\"cata\"))\n    // (\"catac\")\n    def makePalindrome(string : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(makePalindrome((\"\")).equals((\"\")));\n    assert(makePalindrome((\"x\")).equals((\"x\")));\n    assert(makePalindrome((\"xyz\")).equals((\"xyzyx\")));\n    assert(makePalindrome((\"xyx\")).equals((\"xyx\")));\n    assert(makePalindrome((\"jerry\")).equals((\"jerryrrej\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this problem, you will implement a function that takes two lists of numbers,\n    // and determines whether it is possible to perform an exchange of elements\n    // between them to make lst1 a list of only even numbers.\n    // There is no limit on the number of exchanged elements between lst1 and lst2.\n    // If it is possible to exchange elements between the lst1 and lst2 to make\n    // all the elements of lst1 to be even, return \"YES\".\n    // Otherwise, return \"NO\".\n    // For example:\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"YES\")\n    // >>> exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong)))\n    // (\"NO\")\n    // It is assumed that the input lists will be non-empty.\n    def exchange(lst1 : List[Long], lst2 : List[Long]) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](1l.toLong, 5l.toLong, 3l.toLong, 4l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 4l.toLong))).equals((\"YES\")));\n    assert(exchange((List[Long](5l.toLong, 7l.toLong, 3l.toLong)), (List[Long](2l.toLong, 6l.toLong, 3l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](3l.toLong, 2l.toLong, 6l.toLong, 1l.toLong, 8l.toLong, 9l.toLong)), (List[Long](3l.toLong, 5l.toLong, 5l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals((\"NO\")));\n    assert(exchange((List[Long](100l.toLong, 200l.toLong)), (List[Long](200l.toLong, 200l.toLong))).equals((\"YES\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string representing a space separated lowercase letters, return a dictionary\n    // of the letter with the most repetition and containing the corresponding count.\n    // If several letters have the same occurrence, return all of them.\n    // Example:\n    // >>> histogram((\"a b c\"))\n    // (Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l))\n    // >>> histogram((\"a b b a\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"a b c a b\"))\n    // (Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))\n    // >>> histogram((\"b b b b a\"))\n    // (Map[String,Long](\"b\" -> 4l))\n    // >>> histogram((\"\"))\n    // (Map[String,Long]())\n    def histogram(test : String) : Map[String,Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    def multiply(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat)))\n    // (1.0f)\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong)))\n    // (List[Long](1l.toLong, 5l.toLong, 653l.toLong))\n    // >>> common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong))\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    def intToMiniRoman(number : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(histogram((\"a b b a\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c a b\")).equals((Map[String,Long](\"a\" -> 2l, \"b\" -> 2l))));\n    assert(histogram((\"a b c d g\")).equals((Map[String,Long](\"a\" -> 1l, \"b\" -> 1l, \"c\" -> 1l, \"d\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"b b b b a\")).equals((Map[String,Long](\"b\" -> 4l))));\n    assert(histogram((\"r t g\")).equals((Map[String,Long](\"r\" -> 1l, \"t\" -> 1l, \"g\" -> 1l))));\n    assert(histogram((\"\")).equals((Map[String,Long]())));\n    assert(histogram((\"a\")).equals((Map[String,Long](\"a\" -> 1l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1612,7 +172,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n    // then check if the result string is palindrome.\n    // A string is called palindrome if it reads the same backward as forward.\n    // You should return a tuple containing the result string and True/False for the check.\n    // Example\n    // >>> reverseDelete((\"abcde\"), (\"ae\"))\n    // ((\"bcd\", false))\n    // >>> reverseDelete((\"abcdef\"), (\"b\"))\n    // ((\"acdef\", false))\n    // >>> reverseDelete((\"abcdedcba\"), (\"ab\"))\n    // ((\"cdedc\", true))\n    def reverseDelete(s : String, c : String) : Tuple2[String, Boolean] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseDelete((\"abcde\"), (\"ae\")).equals(((\"bcd\", false))));\n    assert(reverseDelete((\"abcdef\"), (\"b\")).equals(((\"acdef\", false))));\n    assert(reverseDelete((\"abcdedcba\"), (\"ab\")).equals(((\"cdedc\", true))));\n    assert(reverseDelete((\"dwik\"), (\"w\")).equals(((\"dik\", false))));\n    assert(reverseDelete((\"a\"), (\"a\")).equals(((\"\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"abcdedcba\"), (\"v\")).equals(((\"abcdedcba\", true))));\n    assert(reverseDelete((\"vabba\"), (\"v\")).equals(((\"abba\", true))));\n    assert(reverseDelete((\"mamma\"), (\"mia\")).equals(((\"\", true))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1620,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of strings, where each string consists of only digits, return a list.\n    // Each element i of the output should be \"the number of odd elements in the\n    // string i of the input.\" where all the i's should be replaced by the number\n    // of odd digits in the i'th string of the input.\n    // >>> oddCount((List[String](\"1234567\")))\n    // (List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))\n    // >>> oddCount((List[String](\"3\", \"11111111\")))\n    // (List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))\n    def oddCount(lst : List[String]) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddCount((List[String](\"1234567\"))).equals((List[String](\"the number of odd elements 4n the str4ng 4 of the 4nput.\"))));\n    assert(oddCount((List[String](\"3\", \"11111111\"))).equals((List[String](\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"))));\n    assert(oddCount((List[String](\"271\", \"137\", \"314\"))).equals((List[String](\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // >>> splitWords((\"Hello world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"Hello,world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"abcdef\"))\n    // 3l\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of integers nums, find the minimum sum of any non-empty sub-array\n    // of nums.\n    // Example\n    // >>> minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong)))\n    // (1l)\n    // >>> minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)))\n    // (-6l)\n    def minSubArraySum(nums : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSubArraySum((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, 4l.toLong))) == (1l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, -10l.toLong))) == (-14l));\n    assert(minSubArraySum((List[Long](-9999999999999999l.toLong))) == (-9999999999999999l));\n    assert(minSubArraySum((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 1000000l.toLong))) == (0l));\n    assert(minSubArraySum((List[Long](-1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](100l.toLong, -1l.toLong, -2l.toLong, -3l.toLong, 10l.toLong, -5l.toLong))) == (-6l));\n    assert(minSubArraySum((List[Long](10l.toLong, 11l.toLong, 13l.toLong, 8l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(minSubArraySum((List[Long](100l.toLong, -33l.toLong, 32l.toLong, -1l.toLong, 0l.toLong, -2l.toLong))) == (-33l));\n    assert(minSubArraySum((List[Long](-10l.toLong))) == (-10l));\n    assert(minSubArraySum((List[Long](7l.toLong))) == (7l));\n    assert(minSubArraySum((List[Long](1l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a rectangular grid of wells. Each row represents a single well,\n    // and each 1 in a row represents a single unit of water.\n    // Each well has a corresponding bucket that can be used to extract water from it, \n    // and all buckets have the same capacity.\n    // Your task is to use the buckets to empty the wells.\n    // Output the number of times you need to lower the buckets.\n    // Example 1:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l))\n    // (6l)\n    // Example 2:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l))\n    // (5l)\n    // Example 3:\n    // >>> maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l))\n    // (0l)\n    // Constraints:\n    // * all wells have the same length\n    // * 1 <= grid.length <= 10^2\n    // * 1 <= grid[:,1].length <= 10^2\n    // * grid[i][j] -> 0 | 1\n    // * 1 <= capacity <= 10\n    def maxFill(grid : List[List[Long]], capacity : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 0l.toLong), List[Long](0l.toLong, 1l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (1l)) == (6l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](0l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (5l));\n    assert(maxFill((List[List[Long]](List[Long](0l.toLong, 0l.toLong, 0l.toLong), List[Long](0l.toLong, 0l.toLong, 0l.toLong))), (5l)) == (0l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (2l)) == (4l));\n    assert(maxFill((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))), (9l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1648,7 +220,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this Kata, you have to sort an array of non-negative integers according to\n    // number of ones in their binary representation in ascending order.\n    // For similar number of ones, sort based on decimal value.\n    // It must be implemented like this:\n    // >>> sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong)))\n    // (List[Long](-6l.toLong, -5l.toLong, -4l.toLong, -3l.toLong, -2l.toLong))\n    // >>> sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))\n    def sortArray(arr : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](-2l.toLong, -3l.toLong, -4l.toLong, -5l.toLong, -6l.toLong))).equals((List[Long](-4l.toLong, -2l.toLong, -6l.toLong, -5l.toLong, -3l.toLong))));\n    assert(sortArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](2l.toLong, 5l.toLong, 77l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 77l.toLong))));\n    assert(sortArray((List[Long](3l.toLong, 6l.toLong, 44l.toLong, 12l.toLong, 32l.toLong, 5l.toLong))).equals((List[Long](32l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 12l.toLong, 44l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 16l.toLong, 32l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1656,133 +228,373 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((List[String]()))\n    // (\"\")\n    // >>> concatenate((List[String](\"a\", \"b\", \"c\")))\n    // (\"abc\")\n    def concatenate(strings : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s and a natural number n, you have been tasked to implement \n    // a function that returns a list of all words from string s that contain exactly \n    // n consonants, in order these words appear in the string s.\n    // If the string s is empty then the function should return an empty list.\n    // Note: you may assume the input string contains only letters and spaces.\n    // Examples:\n    // >>> selectWords((\"Mary had a little lamb\"), (4l))\n    // (List[String](\"little\"))\n    // >>> selectWords((\"Mary had a little lamb\"), (3l))\n    // (List[String](\"Mary\", \"lamb\"))\n    // >>> selectWords((\"simple white space\"), (2l))\n    // (List[String]())\n    // >>> selectWords((\"Hello world\"), (4l))\n    // (List[String](\"world\"))\n    // >>> selectWords((\"Uncle sam\"), (3l))\n    // (List[String](\"Uncle\"))\n    def selectWords(s : String, n : Long) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(selectWords((\"Mary had a little lamb\"), (4l)).equals((List[String](\"little\"))));\n    assert(selectWords((\"Mary had a little lamb\"), (3l)).equals((List[String](\"Mary\", \"lamb\"))));\n    assert(selectWords((\"simple white space\"), (2l)).equals((List[String]())));\n    assert(selectWords((\"Hello world\"), (4l)).equals((List[String](\"world\"))));\n    assert(selectWords((\"Uncle sam\"), (3l)).equals((List[String](\"Uncle\"))));\n    assert(selectWords((\"\"), (4l)).equals((List[String]())));\n    assert(selectWords((\"a b c d e f\"), (1l)).equals((List[String](\"b\", \"c\", \"d\", \"f\"))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((List[String](\"aa\", \"a\", \"aaa\")))\n    // (List[String](\"aa\"))\n    // >>> listSort((List[String](\"ab\", \"a\", \"aaa\", \"cd\")))\n    // (List[String](\"ab\", \"cd\"))\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a word. Your task is to find the closest vowel that stands between \n    // two consonants from the right side of the word (case sensitive).\n    // Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n    // find any vowel met the above condition. \n    // You may assume that the given string contains English letter only.\n    // Example:\n    // >>> getClosestVowel((\"yogurt\"))\n    // (\"u\")\n    // >>> getClosestVowel((\"FULL\"))\n    // (\"U\")\n    // >>> getClosestVowel((\"quick\"))\n    // (\"\")\n    // >>> getClosestVowel((\"ab\"))\n    // (\"\")\n    def getClosestVowel(word : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getClosestVowel((\"yogurt\")).equals((\"u\")));\n    assert(getClosestVowel((\"full\")).equals((\"u\")));\n    assert(getClosestVowel((\"easy\")).equals((\"\")));\n    assert(getClosestVowel((\"eAsy\")).equals((\"\")));\n    assert(getClosestVowel((\"ali\")).equals((\"\")));\n    assert(getClosestVowel((\"bad\")).equals((\"a\")));\n    assert(getClosestVowel((\"most\")).equals((\"o\")));\n    assert(getClosestVowel((\"ab\")).equals((\"\")));\n    assert(getClosestVowel((\"ba\")).equals((\"\")));\n    assert(getClosestVowel((\"quick\")).equals((\"\")));\n    assert(getClosestVowel((\"anime\")).equals((\"i\")));\n    assert(getClosestVowel((\"Asia\")).equals((\"\")));\n    assert(getClosestVowel((\"Above\")).equals((\"o\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterBySubstring((List[String](\"abc\", \"bacd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"bacd\", \"array\"))\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of two strings, both strings consist of open\n    // parentheses '(' or close parentheses ')' only.\n    // Your job is to check if it is possible to concatenate the two strings in\n    // some order, that the resulting string will be good.\n    // A string S is considered to be good if and only if all parentheses in S\n    // are balanced. For example: the string '(())()' is good, while the string\n    // '())' is not.\n    // Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n    // Examples:\n    // >>> matchParens((List[String](\"()(\", \")\")))\n    // (\"Yes\")\n    // >>> matchParens((List[String](\")\", \")\")))\n    // (\"No\")\n    def matchParens(lst : List[String]) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(matchParens((List[String](\"()(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \")\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(())\", \"())())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")())\", \"(()()(\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"(())))\", \"(()())((\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"()\", \"())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(()(\", \"()))()\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\"((((\", \"((())\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(()\", \"(()(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\")(\", \")(\"))).equals((\"No\")));\n    assert(matchParens((List[String](\"(\", \")\"))).equals((\"Yes\")));\n    assert(matchParens((List[String](\")\", \"(\"))).equals((\"Yes\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input are two strings a and b consisting only of 1s and 0s.\n    // Perform binary XOR on these inputs and return result also as a string.\n    // >>> stringXor((\"010\"), (\"110\"))\n    // (\"100\")\n    def stringXor(a : String, b : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringXor((\"111000\"), (\"101010\")).equals((\"010010\")));\n    assert(stringXor((\"1\"), (\"1\")).equals((\"0\")));\n    assert(stringXor((\"0101\"), (\"0000\")).equals((\"0101\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    def vowelsCount(s : String) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers and a positive integer k, return a sorted list \n    // of length k with the maximum k numbers in arr.\n    // Example 1:\n    // >>> maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l))\n    // (List[Long](-4l.toLong, -3l.toLong, 5l.toLong))\n    // Example 2:\n    // >>> maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l))\n    // (List[Long](4l.toLong, 4l.toLong))\n    // Example 3:\n    // >>> maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l))\n    // (List[Long](2l.toLong))\n    // Note:\n    // 1. The length of the array will be in the range of [1, 1000].\n    // 2. The elements in the array will be in the range of [-1000, 1000].\n    // 3. 0 <= k <= len(arr)\n    def maximum(arr : List[Long], k : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong)), (3l)).equals((List[Long](-4l.toLong, -3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong, 4l.toLong)), (2l)).equals((List[Long](4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-3l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -2l.toLong, 1l.toLong)), (1l)).equals((List[Long](2l.toLong))));\n    assert(maximum((List[Long](123l.toLong, -123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (3l)).equals((List[Long](2l.toLong, 20l.toLong, 123l.toLong))));\n    assert(maximum((List[Long](-123l.toLong, 20l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, -3l.toLong)), (4l)).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 20l.toLong))));\n    assert(maximum((List[Long](5l.toLong, 15l.toLong, 0l.toLong, 3l.toLong, -13l.toLong, -8l.toLong, 0l.toLong)), (7l)).equals((List[Long](-13l.toLong, -8l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 5l.toLong, 15l.toLong))));\n    assert(maximum((List[Long](-1l.toLong, 0l.toLong, 2l.toLong, 5l.toLong, 3l.toLong, -10l.toLong)), (2l)).equals((List[Long](3l.toLong, 5l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 0l.toLong, 5l.toLong, -7l.toLong)), (1l)).equals((List[Long](5l.toLong))));\n    assert(maximum((List[Long](4l.toLong, -4l.toLong)), (2l)).equals((List[Long](-4l.toLong, 4l.toLong))));\n    assert(maximum((List[Long](-10l.toLong, 10l.toLong)), (2l)).equals((List[Long](-10l.toLong, 10l.toLong))));\n    assert(maximum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -23l.toLong, 243l.toLong, -400l.toLong, 0l.toLong)), (0l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((List[String](\"name\", \"of\", \"string\")))\n    // (\"string\")\n    // >>> findMax((List[String](\"name\", \"enam\", \"game\")))\n    // (\"enam\")\n    // >>> findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\")))\n    // (\"aaaaaaa\")\n    def findMax(words : List[String]) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n    // Examples\n    // >>> solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong)))\n    // (12l)\n    // >>> solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong)))\n    // (9l)\n    // >>> solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong)))\n    // (0l)\n    def solution(lst : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solution((List[Long](5l.toLong, 8l.toLong, 7l.toLong, 1l.toLong))) == (12l));\n    assert(solution((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong))) == (9l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 24l.toLong, 321l.toLong))) == (0l));\n    assert(solution((List[Long](5l.toLong, 9l.toLong))) == (5l));\n    assert(solution((List[Long](2l.toLong, 4l.toLong, 8l.toLong))) == (0l));\n    assert(solution((List[Long](30l.toLong, 13l.toLong, 23l.toLong, 32l.toLong))) == (23l));\n    assert(solution((List[Long](3l.toLong, 13l.toLong, 2l.toLong, 9l.toLong))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // \"3e25960a79dbc69b674cd4ec67a72c62\"\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty array of integers arr and an integer k, return\n    // the sum of the elements with at most two digits from the first k elements of arr.\n    // Example:\n    // >>> addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l))\n    // (24l)\n    // Constraints:\n    // 1. 1 <= len(arr) <= 100\n    // 2. 1 <= k <= len(arr)\n    def addElements(arr : List[Long], k : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(\"3e25960a79dbc69b674cd4ec67a72c62\"));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(\"0ef78513b0cb8cef12743f5aeb35f888\"));\n    assert(stringToMd5((\"password\")).equals(\"5f4dcc3b5aa765d61d8327deb882cf99\"));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addElements((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 41l.toLong, 57l.toLong, 76l.toLong, 87l.toLong, 88l.toLong, 99l.toLong)), (3l)) == (-4l));\n    assert(addElements((List[Long](111l.toLong, 121l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong)), (2l)) == (0l));\n    assert(addElements((List[Long](11l.toLong, 21l.toLong, 3l.toLong, 90l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (125l));\n    assert(addElements((List[Long](111l.toLong, 21l.toLong, 3l.toLong, 4000l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)), (4l)) == (24l));\n    assert(addElements((List[Long](1l.toLong)), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n    // The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n    // as follows: start with any positive integer n. Then each term is obtained from the \n    // previous term as follows: if the previous term is even, the next term is one half of \n    // the previous term. If the previous term is odd, the next term is 3 times the previous\n    // term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n    // Note: \n    // 1. Collatz(1) is [1].\n    // 2. returned list sorted in increasing order.\n    // For example:\n    // get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n    // >>> getOddCollatz((5l))\n    // (List[Long](1l.toLong, 5l.toLong))\n    def getOddCollatz(n : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getOddCollatz((14l)).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(getOddCollatz((5l)).equals((List[Long](1l.toLong, 5l.toLong))));\n    assert(getOddCollatz((12l)).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(getOddCollatz((1l)).equals((List[Long](1l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have to write a function which validates a given date string and\n    // returns True if the date is valid otherwise False.\n    // The date is valid if all of the following rules are satisfied:\n    // 1. The date string is not empty.\n    // 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n    // 3. The months should not be less than 1 or higher than 12.\n    // 4. The date should be in the format: mm-dd-yyyy\n    // >>> validDate((\"03-11-2000\"))\n    // (true)\n    // >>> validDate((\"15-01-2012\"))\n    // (false)\n    // >>> validDate((\"04-0-2040\"))\n    // (false)\n    // >>> validDate((\"06-04-2020\"))\n    // (true)\n    // >>> validDate((\"06/04/2020\"))\n    // (false)\n    def validDate(date : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validDate((\"03-11-2000\")) == (true));\n    assert(validDate((\"15-01-2012\")) == (false));\n    assert(validDate((\"04-0-2040\")) == (false));\n    assert(validDate((\"06-04-2020\")) == (true));\n    assert(validDate((\"01-01-2007\")) == (true));\n    assert(validDate((\"03-32-2011\")) == (false));\n    assert(validDate((\"\")) == (false));\n    assert(validDate((\"04-31-3000\")) == (false));\n    assert(validDate((\"06-06-2005\")) == (true));\n    assert(validDate((\"21-31-2000\")) == (false));\n    assert(validDate((\"04-12-2003\")) == (true));\n    assert(validDate((\"04122003\")) == (false));\n    assert(validDate((\"20030412\")) == (false));\n    assert(validDate((\"2003-04\")) == (false));\n    assert(validDate((\"2003-04-12\")) == (false));\n    assert(validDate((\"04-2003\")) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat)))\n    // (List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n    // should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n    // alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n    // Examples\n    // >>> splitWords((\"Hello world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"Hello,world!\"))\n    // List[String](\"Hello\", \"world!\")\n    // >>> splitWords((\"abcdef\"))\n    // 3l\n    def splitWords(txt : String) : Either[List[String], Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitWords((\"Hello world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello,world!\")).equals(List[String](\"Hello\", \"world!\")));\n    assert(splitWords((\"Hello world,!\")).equals(List[String](\"Hello\", \"world,!\")));\n    assert(splitWords((\"Hello,Hello,world !\")).equals(List[String](\"Hello,Hello,world\", \"!\")));\n    assert(splitWords((\"abcdef\")).equals(3l));\n    assert(splitWords((\"aaabb\")).equals(2l));\n    assert(splitWords((\"aaaBb\")).equals(1l));\n    assert(splitWords((\"\")).equals(0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((List[Long]()), (4l))\n    // (List[Long]())\n    // >>> intersperse((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return whether or not they are sorted\n    // in ascending order. If list has more than 1 duplicate of the same\n    // number, return False. Assume no negative numbers and only integers.\n    // Examples\n    // >>> isSorted((List[Long](5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))\n    // (false)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)))\n    // (true)\n    // >>> isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (false)\n    def isSorted(lst : List[Long]) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSorted((List[Long](5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))) == (false));\n    assert(isSorted((List[Long]())) == (true));\n    assert(isSorted((List[Long](1l.toLong))) == (true));\n    assert(isSorted((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (false));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    assert(isSorted((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given two intervals,\n    // where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n    // The given intervals are closed which means that the interval (start, end)\n    // includes both start and end.\n    // For each given interval, it is assumed that its start is less or equal its end.\n    // Your task is to determine whether the length of intersection of these two \n    // intervals is a prime number.\n    // Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n    // which its length is 1, which not a prime number.\n    // If the length of the intersection is a prime number, return \"YES\",\n    // otherwise, return \"NO\".\n    // If the two intervals don't intersect, return \"NO\".\n    // [input/output] samples:\n    // >>> intersection(((1l, 2l)), ((2l, 3l)))\n    // (\"NO\")\n    // >>> intersection(((-1l, 1l)), ((0l, 4l)))\n    // (\"NO\")\n    // >>> intersection(((-3l, -1l)), ((-5l, 5l)))\n    // (\"YES\")\n    def intersection(interval1 : Tuple2[Long, Long], interval2 : Tuple2[Long, Long]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersection(((1l, 2l)), ((2l, 3l))).equals((\"NO\")));\n    assert(intersection(((-1l, 1l)), ((0l, 4l))).equals((\"NO\")));\n    assert(intersection(((-3l, -1l)), ((-5l, 5l))).equals((\"YES\")));\n    assert(intersection(((-2l, 2l)), ((-4l, 0l))).equals((\"YES\")));\n    assert(intersection(((-11l, 2l)), ((-1l, -1l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((3l, 5l))).equals((\"NO\")));\n    assert(intersection(((1l, 2l)), ((1l, 2l))).equals((\"NO\")));\n    assert(intersection(((-2l, -2l)), ((-3l, -2l))).equals((\"NO\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given an array arr of integers and you need to return\n    // sum of magnitudes of integers multiplied by product of all signs\n    // of each number in the array, represented by 1, -1 or 0.\n    // Note: return None for empty arr.\n    // Example:\n    // >>> prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong)))\n    // Some(9l)\n    // >>> prodSigns((List[Long](0l.toLong, 1l.toLong)))\n    // Some(0l)\n    // >>> prodSigns((List[Long]()))\n    // None\n    def prodSigns(arr : List[Long]) : Option[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(prodSigns((List[Long](1l.toLong, 2l.toLong, 2l.toLong, -4l.toLong))).equals(Some(-9l)));\n    assert(prodSigns((List[Long](0l.toLong, 1l.toLong))).equals(Some(0l)));\n    assert(prodSigns((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, -1l.toLong, 1l.toLong))).equals(Some(-10l)));\n    assert(prodSigns((List[Long]())).equals(None));\n    assert(prodSigns((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -1l.toLong, 9l.toLong))).equals(Some(20l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, -1l.toLong, 1l.toLong))).equals(Some(4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))).equals(Some(-4l)));\n    assert(prodSigns((List[Long](-1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(0l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n    // each cell of the grid contains a value. Every integer in the range [1, N * N]\n    // inclusive appears exactly once on the cells of the grid.\n    // You have to find the minimum path of length k in the grid. You can start\n    // from any cell, and in each step you can move to any of the neighbor cells,\n    // in other words, you can go to cells which share an edge with you current\n    // cell.\n    // Please note that a path of length k means visiting exactly k cells (not\n    // necessarily distinct).\n    // You CANNOT go off the grid.\n    // A path A (of length k) is considered less than a path B (of length k) if\n    // after making the ordered lists of the values on the cells that A and B go\n    // through (let's call them lst_A and lst_B), lst_A is lexicographically less\n    // than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n    // such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n    // lst_A[j] = lst_B[j].\n    // It is guaranteed that the answer is unique.\n    // Return an ordered list of the values on the cells that the minimum path go through.\n    // Examples:    \n    // >>> minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l))\n    // (List[Long](1l.toLong, 2l.toLong, 1l.toLong))\n    // >>> minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l))\n    // (List[Long](1l.toLong))\n    def minPath(grid : List[List[Long]], k : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong))), (3l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](5l.toLong, 9l.toLong, 3l.toLong), List[Long](4l.toLong, 1l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 2l.toLong))), (1l)).equals((List[Long](1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong))), (4l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 4l.toLong, 13l.toLong, 10l.toLong), List[Long](5l.toLong, 7l.toLong, 12l.toLong, 1l.toLong), List[Long](3l.toLong, 16l.toLong, 11l.toLong, 15l.toLong), List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong))), (7l)).equals((List[Long](1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong, 10l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](8l.toLong, 14l.toLong, 9l.toLong, 2l.toLong), List[Long](6l.toLong, 4l.toLong, 13l.toLong, 15l.toLong), List[Long](5l.toLong, 7l.toLong, 1l.toLong, 12l.toLong), List[Long](3l.toLong, 10l.toLong, 11l.toLong, 16l.toLong))), (5l)).equals((List[Long](1l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong))), (9l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](12l.toLong, 13l.toLong, 10l.toLong, 1l.toLong), List[Long](9l.toLong, 3l.toLong, 15l.toLong, 6l.toLong), List[Long](5l.toLong, 16l.toLong, 14l.toLong, 4l.toLong), List[Long](11l.toLong, 8l.toLong, 7l.toLong, 2l.toLong))), (12l)).equals((List[Long](1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 6l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 4l.toLong), List[Long](3l.toLong, 1l.toLong, 5l.toLong), List[Long](6l.toLong, 8l.toLong, 9l.toLong))), (8l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](6l.toLong, 1l.toLong, 5l.toLong), List[Long](3l.toLong, 8l.toLong, 9l.toLong), List[Long](2l.toLong, 7l.toLong, 4l.toLong))), (8l)).equals((List[Long](1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong))), (10l)).equals((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))));\n    assert(minPath((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](3l.toLong, 2l.toLong))), (10l)).equals((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Out of list of strings, return the longest one. Return the first one in case of multiple\n    // strings of the same length. Return None in case the input list is empty.\n    // >>> longest((List[String]()))\n    // None\n    // >>> longest((List[String](\"a\", \"b\", \"c\")))\n    // Some(\"a\")\n    // >>> longest((List[String](\"a\", \"bb\", \"ccc\")))\n    // Some(\"ccc\")\n    def longest(strings : List[String]) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longest((List[String]())).equals(None));\n    assert(longest((List[String](\"x\", \"y\", \"z\"))).equals(Some(\"x\")));\n    assert(longest((List[String](\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"))).equals(Some(\"zzzz\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n    // the last couple centuries. However, what people don't know is Tribonacci sequence.\n    // Tribonacci sequence is defined by the recurrence:\n    // tri(1) = 3\n    // tri(n) = 1 + n / 2, if n is even.\n    // tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n    // For example:\n    // tri(2) = 1 + (2 / 2) = 2\n    // tri(4) = 3\n    // tri(3) = tri(2) + tri(1) + tri(4)\n    // = 2 + 3 + 3 = 8 \n    // You are given a non-negative integer number n, you have to a return a list of the \n    // first n + 1 numbers of the Tribonacci sequence.\n    // Examples:\n    // >>> tri((3l))\n    // (List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))\n    def tri(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tri((3l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong))));\n    assert(tri((4l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong))));\n    assert(tri((5l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong))));\n    assert(tri((6l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong))));\n    assert(tri((7l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong))));\n    assert(tri((8l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong))));\n    assert(tri((9l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong))));\n    assert(tri((20l)).equals((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 3l.toLong, 15l.toLong, 4l.toLong, 24l.toLong, 5l.toLong, 35l.toLong, 6l.toLong, 48l.toLong, 7l.toLong, 63l.toLong, 8l.toLong, 80l.toLong, 9l.toLong, 99l.toLong, 10l.toLong, 120l.toLong, 11l.toLong))));\n    assert(tri((0l)).equals((List[Long](1l.toLong))));\n    assert(tri((1l)).equals((List[Long](1l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the product of the odd digits.\n    // Return 0 if all digits are even.\n    // For example:\n    // >>> digits((1l))\n    // (1l)\n    // >>> digits((4l))\n    // (0l)\n    // >>> digits((235l))\n    // (15l)\n    def digits(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digits((5l)) == (5l));\n    assert(digits((54l)) == (5l));\n    assert(digits((120l)) == (1l));\n    assert(digits((5014l)) == (5l));\n    assert(digits((98765l)) == (315l));\n    assert(digits((5576543l)) == (2625l));\n    assert(digits((2468l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a string as input which contains only square brackets.\n    // The function should return True if and only if there is a valid subsequence of brackets \n    // where at least one bracket in the subsequence is nested.\n    // >>> isNested((\"[[]]\"))\n    // (true)\n    // >>> isNested((\"[]]]]]]][[[[[]\"))\n    // (false)\n    // >>> isNested((\"[][]\"))\n    // (false)\n    // >>> isNested((\"[]\"))\n    // (false)\n    // >>> isNested((\"[[][]]\"))\n    // (true)\n    // >>> isNested((\"[[]][[\"))\n    // (true)\n    def isNested(string : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNested((\"[[]]\")) == (true));\n    assert(isNested((\"[]]]]]]][[[[[]\")) == (false));\n    assert(isNested((\"[][]\")) == (false));\n    assert(isNested((\"[]\")) == (false));\n    assert(isNested((\"[[[[]]]]\")) == (true));\n    assert(isNested((\"[]]]]]]]]]]\")) == (false));\n    assert(isNested((\"[][][[]]\")) == (true));\n    assert(isNested((\"[[]\")) == (false));\n    assert(isNested((\"[]]\")) == (false));\n    assert(isNested((\"[[]][[\")) == (true));\n    assert(isNested((\"[[][]]\")) == (true));\n    assert(isNested((\"\")) == (false));\n    assert(isNested((\"[[[[[[[[\")) == (false));\n    assert(isNested((\"]]]]]]]]\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of numbers.\n    // You need to return the sum of squared numbers in the given list,\n    // round each element in the list to the upper int(Ceiling) first.\n    // Examples:\n    // >>> lst((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat)))\n    // (14l)\n    // >>> lst((List[Float](1.0f.toFloat, 4.0f.toFloat, 9.0f.toFloat)))\n    // (98l)\n    // >>> lst((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat)))\n    // (84l)\n    // >>> lst((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat)))\n    // (29l)\n    // >>> lst((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat)))\n    // (6l)\n    def sumSquares(lst : List[Float]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat))) == (14l));\n    assert(sumSquares((List[Float](1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat))) == (84l));\n    assert(sumSquares((List[Float](1.4f.toFloat, 4.2f.toFloat, 0.0f.toFloat))) == (29l));\n    assert(sumSquares((List[Float](-2.4f.toFloat, 1.0f.toFloat, 1.0f.toFloat))) == (6l));\n    assert(sumSquares((List[Float](100.0f.toFloat, 1.0f.toFloat, 15.0f.toFloat, 2.0f.toFloat))) == (10230l));\n    assert(sumSquares((List[Float](10000.0f.toFloat, 10000.0f.toFloat))) == (200000000l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 4.6f.toFloat, 6.3f.toFloat))) == (75l));\n    assert(sumSquares((List[Float](-1.4f.toFloat, 17.9f.toFloat, 18.9f.toFloat, 19.9f.toFloat))) == (1086l));\n    assert(sumSquares((List[Float](0.0f.toFloat))) == (0l));\n    assert(sumSquares((List[Float](-1.0f.toFloat))) == (1l));\n    assert(sumSquares((List[Float](-1.0f.toFloat, 1.0f.toFloat, 0.0f.toFloat))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns True if the last character\n    // of a given string is an alphabetical character and is not\n    // a part of a word, and False otherwise.\n    // Note: \"word\" is a group of characters separated by space.\n    // Examples:\n    // >>> checkIfLastCharIsALetter((\"apple pie\"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"apple pi e\"))\n    // (true)\n    // >>> checkIfLastCharIsALetter((\"apple pi e \"))\n    // (false)\n    // >>> checkIfLastCharIsALetter((\"\"))\n    // (false)\n    def checkIfLastCharIsALetter(txt : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkIfLastCharIsALetter((\"apple\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e\")) == (true));\n    assert(checkIfLastCharIsALetter((\"eeeee\")) == (false));\n    assert(checkIfLastCharIsALetter((\"A\")) == (true));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie \")) == (false));\n    assert(checkIfLastCharIsALetter((\"Pumpkin pie 1\")) == (false));\n    assert(checkIfLastCharIsALetter((\"\")) == (false));\n    assert(checkIfLastCharIsALetter((\"eeeee e \")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pie\")) == (false));\n    assert(checkIfLastCharIsALetter((\"apple pi e \")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which returns the largest index of an element which\n    // is not greater than or equal to the element immediately preceding it. If\n    // no such element exists then return -1. The given array will not contain\n    // duplicate values.\n    // Examples:\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)))\n    // (3l)\n    // >>> canArrange((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (-1l)\n    def canArrange(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))) == (3l));\n    assert(canArrange((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == (-1l));\n    assert(canArrange((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(canArrange((List[Long](4l.toLong, 8l.toLong, 5l.toLong, 7l.toLong, 3l.toLong))) == (4l));\n    assert(canArrange((List[Long]())) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that returns a tuple (a, b), where 'a' is\n    // the largest of negative integers, and 'b' is the smallest\n    // of positive integers in a list.\n    // If there is no negative or positive integers, return them as None.\n    // Examples:\n    // >>> largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (Some(None), Some(1l))\n    // >>> largestSmallestIntegers((List[Long]()))\n    // (Some(None), Some(None))\n    // >>> largestSmallestIntegers((List[Long](0l.toLong)))\n    // (Some(None), Some(None))\n    def largestSmallestIntegers(lst : List[Long]) : Tuple2[Option[Long], Option[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 0l.toLong))).equals((Some(None), Some(1l))));\n    assert(largestSmallestIntegers((List[Long](1l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -2l.toLong))).equals((-2l, 1l)));\n    assert(largestSmallestIntegers((List[Long](4l.toLong, 5l.toLong, 3l.toLong, 6l.toLong, 2l.toLong, 7l.toLong, -7l.toLong))).equals((-7l, 2l)));\n    assert(largestSmallestIntegers((List[Long](7l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 5l.toLong, -9l.toLong))).equals((-9l, 2l)));\n    assert(largestSmallestIntegers((List[Long]())).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](0l.toLong))).equals((Some(None), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-1l.toLong, -3l.toLong, -5l.toLong, -6l.toLong, 0l.toLong))).equals((Some(-1l), Some(None))));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    assert(largestSmallestIntegers((List[Long](-6l.toLong, -4l.toLong, -4l.toLong, -3l.toLong, -100l.toLong, 1l.toLong))).equals((-3l, 1l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n    // Example\n    // >>> isEqualToSumEven((4l))\n    // (false)\n    // >>> isEqualToSumEven((6l))\n    // (false)\n    // >>> isEqualToSumEven((8l))\n    // (true)\n    def isEqualToSumEven(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEqualToSumEven((4l)) == (false));\n    assert(isEqualToSumEven((6l)) == (false));\n    assert(isEqualToSumEven((8l)) == (true));\n    assert(isEqualToSumEven((10l)) == (true));\n    assert(isEqualToSumEven((11l)) == (false));\n    assert(isEqualToSumEven((12l)) == (true));\n    assert(isEqualToSumEven((13l)) == (false));\n    assert(isEqualToSumEven((16l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Brazilian factorial is defined as:\n    // brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n    // where n > 0\n    // For example:\n    // >>> specialFactorial((4l))\n    // (288l)\n    // The function will receive an integer as input and should return the special\n    // factorial of this integer.\n    def specialFactorial(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFactorial((4l)) == (288l));\n    assert(specialFactorial((5l)) == (34560l));\n    assert(specialFactorial((7l)) == (125411328000l));\n    assert(specialFactorial((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a greatest common divisor of two integers a and b\n    // >>> greatestCommonDivisor((3l), (5l))\n    // (1l)\n    // >>> greatestCommonDivisor((25l), (15l))\n    // (5l)\n    def greatestCommonDivisor(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(greatestCommonDivisor((3l), (7l)) == (1l));\n    assert(greatestCommonDivisor((10l), (15l)) == (5l));\n    assert(greatestCommonDivisor((49l), (14l)) == (7l));\n    assert(greatestCommonDivisor((144l), (60l)) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string text, replace all spaces in it with underscores, \n    // and if a string has more than 2 consecutive spaces, \n    // then replace all consecutive spaces with - \n    // >>> fixSpaces((\" Example\"))\n    // (\"Example\")\n    // >>> fixSpaces((\" Example 1\"))\n    // (\"Example_1\")\n    // >>> fixSpaces((\" Example 2\"))\n    // (\"_Example_2\")\n    // >>> fixSpaces((\" Example 3\"))\n    // (\"_Example-3\")\n    def fixSpaces(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fixSpaces((\"Example\")).equals((\"Example\")));\n    assert(fixSpaces((\"Mudasir Hanif \")).equals((\"Mudasir_Hanif_\")));\n    assert(fixSpaces((\"Yellow Yellow  Dirty  Fellow\")).equals((\"Yellow_Yellow__Dirty__Fellow\")));\n    assert(fixSpaces((\"Exa   mple\")).equals((\"Exa-mple\")));\n    assert(fixSpaces((\"   Exa 1 2 2 mple\")).equals((\"-Exa_1_2_2_mple\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function which takes a string representing a file's name, and returns\n    // 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n    // A file's name is considered to be valid if and only if all the following conditions \n    // are met:\n    // - There should not be more than three digits ('0'-'9') in the file's name.\n    // - The file's name contains exactly one dot '.'\n    // - The substring before the dot should not be empty, and it starts with a letter from \n    // the latin alphapet ('a'-'z' and 'A'-'Z').\n    // - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n    // Examples:\n    // >>> fileNameCheck((\"example.txt\"))\n    // (\"Yes\")\n    // >>> fileNameCheck((\"1example.dll\"))\n    // (\"No\")\n    def fileNameCheck(file_name : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fileNameCheck((\"example.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1example.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"s1sdf3.asd\")).equals((\"No\")));\n    assert(fileNameCheck((\"K.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"MY16FILE3.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"His12FILE94.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"_Y.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"?aREYA.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"/this_is_valid.dll\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.wow\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_valid.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"this_is_valid.txtexe\")).equals((\"No\")));\n    assert(fileNameCheck((\"#this2_i4s_5valid.ten\")).equals((\"No\")));\n    assert(fileNameCheck((\"@this1_is6_valid.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"this_is_12valid.6exe4.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"all.exe.txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_No.exe\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"Is3youfault.txt\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"no_one#knows.dll\")).equals((\"Yes\")));\n    assert(fileNameCheck((\"1I563_Yes3.exe\")).equals((\"No\")));\n    assert(fileNameCheck((\"I563_Yes3.txtt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final..txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"final132\")).equals((\"No\")));\n    assert(fileNameCheck((\"_f4indsartal132.\")).equals((\"No\")));\n    assert(fileNameCheck((\".txt\")).equals((\"No\")));\n    assert(fileNameCheck((\"s.\")).equals((\"No\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"\n    // This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n    // multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n    // change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n    // Examples:\n    // >>> lst\n    // List[Long](1l.toLong, 2l.toLong, 3l.toLong)\n    // >>> lst\n    // List[Long]()\n    // >>> lst\n    // List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong)\n    def sumSquares(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSquares((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(sumSquares((List[Long](1l.toLong, 4l.toLong, 9l.toLong))) == (14l));\n    assert(sumSquares((List[Long]())) == (0l));\n    assert(sumSquares((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))) == (9l));\n    assert(sumSquares((List[Long](-1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong, -1l.toLong))) == (-3l));\n    assert(sumSquares((List[Long](0l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-1l.toLong, -5l.toLong, 2l.toLong, -1l.toLong, -5l.toLong))) == (-126l));\n    assert(sumSquares((List[Long](-56l.toLong, -99l.toLong, 1l.toLong, 0l.toLong, -2l.toLong))) == (3030l));\n    assert(sumSquares((List[Long](-1l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, -1l.toLong))) == (0l));\n    assert(sumSquares((List[Long](-16l.toLong, -9l.toLong, -2l.toLong, 36l.toLong, 36l.toLong, 26l.toLong, -20l.toLong, 25l.toLong, -40l.toLong, 20l.toLong, -4l.toLong, 12l.toLong, -26l.toLong, 35l.toLong, 37l.toLong))) == (-14196l));\n    assert(sumSquares((List[Long](-1l.toLong, -3l.toLong, 17l.toLong, -1l.toLong, -15l.toLong, 13l.toLong, -1l.toLong, 14l.toLong, -14l.toLong, -12l.toLong, -5l.toLong, 14l.toLong, -14l.toLong, 6l.toLong, 13l.toLong, 11l.toLong, 16l.toLong, 16l.toLong, 4l.toLong, 10l.toLong))) == (-1448l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string representing a sentence,\n    // the sentence contains some words separated by a space,\n    // and you have to return a string that contains the words from the original sentence,\n    // whose lengths are prime numbers,\n    // the order of the words in the new string should be the same as the original one.\n    // Example 1:\n    // >>> wordsInSentence((\"This is a test\"))\n    // (\"is\")\n    // Example 2:\n    // >>> wordsInSentence((\"lets go for swimming\"))\n    // (\"go for\")\n    // Constraints:\n    // * 1 <= len(sentence) <= 100\n    // * sentence contains only letters\n    def wordsInSentence(sentence : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordsInSentence((\"This is a test\")).equals((\"is\")));\n    assert(wordsInSentence((\"lets go for swimming\")).equals((\"go for\")));\n    assert(wordsInSentence((\"there is no place available here\")).equals((\"there is no place\")));\n    assert(wordsInSentence((\"Hi I am Hussein\")).equals((\"Hi am Hussein\")));\n    assert(wordsInSentence((\"go for it\")).equals((\"go for it\")));\n    assert(wordsInSentence((\"here\")).equals((\"\")));\n    assert(wordsInSentence((\"here is\")).equals((\"is\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to implement a function that will simplify the expression\n    // x * n. The function returns True if x * n evaluates to a whole number and False\n    // otherwise. Both x and n, are string representation of a fraction, and have the following format,\n    // <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n    // You can assume that x, and n are valid fractions, and do not have zero as denominator.\n    // >>> simplify((\"1/5\"), (\"5/1\"))\n    // (true)\n    // >>> simplify((\"1/6\"), (\"2/1\"))\n    // (false)\n    // >>> simplify((\"7/10\"), (\"10/2\"))\n    // (false)\n    def simplify(x : String, n : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/6\"), (\"2/1\")) == (false));\n    assert(simplify((\"5/1\"), (\"3/1\")) == (true));\n    assert(simplify((\"7/10\"), (\"10/2\")) == (false));\n    assert(simplify((\"2/10\"), (\"50/10\")) == (true));\n    assert(simplify((\"7/2\"), (\"4/2\")) == (true));\n    assert(simplify((\"11/6\"), (\"6/1\")) == (true));\n    assert(simplify((\"2/3\"), (\"5/2\")) == (false));\n    assert(simplify((\"5/2\"), (\"3/5\")) == (false));\n    assert(simplify((\"2/4\"), (\"8/4\")) == (true));\n    assert(simplify((\"2/4\"), (\"4/2\")) == (true));\n    assert(simplify((\"1/5\"), (\"5/1\")) == (true));\n    assert(simplify((\"1/5\"), (\"1/5\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which sorts the given list of integers\n    // in ascending order according to the sum of their digits.\n    // Note: if there are several items with similar sum of their digits,\n    // order them based on their index in original list.\n    // For example:\n    // >>> orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong)))\n    // (List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))\n    // >>> orderByPoints((List[Long]()))\n    // (List[Long]())\n    def orderByPoints(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(orderByPoints((List[Long](1l.toLong, 11l.toLong, -1l.toLong, -11l.toLong, -12l.toLong))).equals((List[Long](-1l.toLong, -11l.toLong, 1l.toLong, -12l.toLong, 11l.toLong))));\n    assert(orderByPoints((List[Long](1234l.toLong, 423l.toLong, 463l.toLong, 145l.toLong, 2l.toLong, 423l.toLong, 423l.toLong, 53l.toLong, 6l.toLong, 37l.toLong, 3457l.toLong, 3l.toLong, 56l.toLong, 0l.toLong, 46l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 53l.toLong, 423l.toLong, 423l.toLong, 423l.toLong, 1234l.toLong, 145l.toLong, 37l.toLong, 46l.toLong, 56l.toLong, 463l.toLong, 3457l.toLong))));\n    assert(orderByPoints((List[Long]())).equals((List[Long]())));\n    assert(orderByPoints((List[Long](1l.toLong, -11l.toLong, -32l.toLong, 43l.toLong, 54l.toLong, -98l.toLong, 2l.toLong, -3l.toLong))).equals((List[Long](-3l.toLong, -32l.toLong, -98l.toLong, -11l.toLong, 1l.toLong, 2l.toLong, 43l.toLong, 54l.toLong))));\n    assert(orderByPoints((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 2l.toLong, 11l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(orderByPoints((List[Long](0l.toLong, 6l.toLong, 6l.toLong, -76l.toLong, -21l.toLong, 23l.toLong, 4l.toLong))).equals((List[Long](-76l.toLong, -21l.toLong, 0l.toLong, 4l.toLong, 23l.toLong, 6l.toLong, 6l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1792,7 +604,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array of numbers as input and returns \n    // the number of elements in the array that are greater than 10 and both \n    // first and last digits of a number are odd (1, 3, 5, 7, 9).\n    // For example:\n    // >>> specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong)))\n    // (1l)\n    // >>> specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong)))\n    // (2l)\n    def specialFilter(nums : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(specialFilter((List[Long](5l.toLong, -2l.toLong, 1l.toLong, -5l.toLong))) == (0l));\n    assert(specialFilter((List[Long](15l.toLong, -73l.toLong, 14l.toLong, -15l.toLong))) == (1l));\n    assert(specialFilter((List[Long](33l.toLong, -2l.toLong, -3l.toLong, 45l.toLong, 21l.toLong, 109l.toLong))) == (2l));\n    assert(specialFilter((List[Long](43l.toLong, -12l.toLong, 93l.toLong, 125l.toLong, 121l.toLong, 109l.toLong))) == (4l));\n    assert(specialFilter((List[Long](71l.toLong, -2l.toLong, -33l.toLong, 75l.toLong, 21l.toLong, 19l.toLong))) == (3l));\n    assert(specialFilter((List[Long](1l.toLong))) == (0l));\n    assert(specialFilter((List[Long]())) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1800,25 +612,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    def sumToN(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a positive integer n. You have to create an integer array a of length n.\n    // For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n    // Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n    // and a[i] + a[j] + a[k] is a multiple of 3.\n    // Example :\n    // >>> getMaxTriples((5l))\n    // (1l)\n    // Explanation: \n    // a = [1, 3, 7, 13, 21]\n    // The only valid triple is (1, 7, 13).\n    def getMaxTriples(n : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxTriples((5l)) == (1l));\n    assert(getMaxTriples((6l)) == (4l));\n    assert(getMaxTriples((10l)) == (36l));\n    assert(getMaxTriples((100l)) == (53361l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 3l.toLong, 4l.toLong))\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // There are eight planets in our solar system: the closerst to the Sun \n    // is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n    // Uranus, Neptune.\n    // Write a function that takes two planet names as strings planet1 and planet2. \n    // The function should return a tuple containing all planets whose orbits are \n    // located between the orbit of planet1 and the orbit of planet2, sorted by \n    // the proximity to the sun. \n    // The function should return an empty tuple if planet1 or planet2\n    // are not correct planet names. \n    // Examples\n    // >>> bf((\"Jupiter\"), (\"Neptune\"))\n    // (List[String](\"Saturn\", \"Uranus\"))\n    // >>> bf((\"Earth\"), (\"Mercury\"))\n    // (List[String](\"Venus\"))\n    // >>> bf((\"Mercury\"), (\"Uranus\"))\n    // (List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))\n    def bf(planet1 : String, planet2 : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bf((\"Jupiter\"), (\"Neptune\")).equals((List[String](\"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Mercury\")).equals((List[String](\"Venus\"))));\n    assert(bf((\"Mercury\"), (\"Uranus\")).equals((List[String](\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"))));\n    assert(bf((\"Neptune\"), (\"Venus\")).equals((List[String](\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"))));\n    assert(bf((\"Earth\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Mars\"), (\"Earth\")).equals((List[String]())));\n    assert(bf((\"Jupiter\"), (\"Makemake\")).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings as a parameter,\n    // deletes the strings that have odd lengths from it,\n    // and returns the resulted list with a sorted order,\n    // The list is always a list of strings and never an array of numbers,\n    // and it may contain duplicates.\n    // The order of the list should be ascending by length of each word, and you\n    // should return the list sorted by that rule.\n    // If two words have the same length, sort the list alphabetically.\n    // The function should return a list of strings in sorted order.\n    // You may assume that all words will have the same length.\n    // For example:\n    // >>> listSort((List[String](\"aa\", \"a\", \"aaa\")))\n    // (List[String](\"aa\"))\n    // >>> listSort((List[String](\"ab\", \"a\", \"aaa\", \"cd\")))\n    // (List[String](\"ab\", \"cd\"))\n    def sortedListSum(lst : List[String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortedListSum((List[String](\"aa\", \"a\", \"aaa\"))).equals((List[String](\"aa\"))));\n    assert(sortedListSum((List[String](\"school\", \"AI\", \"asdf\", \"b\"))).equals((List[String](\"AI\", \"asdf\", \"school\"))));\n    assert(sortedListSum((List[String](\"d\", \"b\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"d\", \"dcba\", \"abcd\", \"a\"))).equals((List[String](\"abcd\", \"dcba\"))));\n    assert(sortedListSum((List[String](\"AI\", \"ai\", \"au\"))).equals((List[String](\"AI\", \"ai\", \"au\"))));\n    assert(sortedListSum((List[String](\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"))).equals((List[String]())));\n    assert(sortedListSum((List[String](\"aaaa\", \"bbbb\", \"dd\", \"cc\"))).equals((List[String](\"cc\", \"dd\", \"aaaa\", \"bbbb\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of all prefixes from shortest to longest of the input string\n    // >>> allPrefixes((\"abc\"))\n    // (List[String](\"a\", \"ab\", \"abc\"))\n    def allPrefixes(string : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allPrefixes((\"\")).equals((List[String]())));\n    assert(allPrefixes((\"asdfgh\")).equals((List[String](\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"))));\n    assert(allPrefixes((\"WWW\")).equals((List[String](\"W\", \"WW\", \"WWW\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // A simple program which should return the value of x if n is \n    // a prime number and should return the value of y otherwise.\n    // Examples:\n    // >>> xOrY((7l), (34l), (12l))\n    // (34l)\n    // >>> xOrY((15l), (8l), (5l))\n    // (5l)\n    def xOrY(n : Long, x : Long, y : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(xOrY((7l), (34l), (12l)) == (34l));\n    assert(xOrY((15l), (8l), (5l)) == (5l));\n    assert(xOrY((3l), (33l), (5212l)) == (33l));\n    assert(xOrY((1259l), (3l), (52l)) == (3l));\n    assert(xOrY((7919l), (-1l), (12l)) == (-1l));\n    assert(xOrY((3609l), (1245l), (583l)) == (583l));\n    assert(xOrY((91l), (56l), (129l)) == (129l));\n    assert(xOrY((6l), (34l), (1234l)) == (1234l));\n    assert(xOrY((1l), (2l), (0l)) == (0l));\n    assert(xOrY((2l), (2l), (0l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of numbers, return the sum of squares of the numbers\n    // in the list that are odd. Ignore numbers that are negative or not integers.\n    // >>> doubleTheDifference((List[Float](1l.toLong, 3l.toLong, 2l.toLong, 0l.toLong)))\n    // (10l)\n    // >>> doubleTheDifference((List[Float](-1l.toLong, -2l.toLong, 0l.toLong)))\n    // (0l)\n    // >>> doubleTheDifference((List[Float](9l.toLong, -2l.toLong)))\n    // (81l)\n    // >>> doubleTheDifference((List[Float](0l.toLong)))\n    // (0l)\n    // If the input list is empty, return 0.\n    def doubleTheDifference(lst : List[Float]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doubleTheDifference((List[Float]())) == (0l));\n    assert(doubleTheDifference((List[Float](5.0f.toFloat, 4.0f.toFloat))) == (25l));\n    assert(doubleTheDifference((List[Float](0.1f.toFloat, 0.2f.toFloat, 0.3f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-10.0f.toFloat, -20.0f.toFloat, -30.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](-1.0f.toFloat, -2.0f.toFloat, 8.0f.toFloat))) == (0l));\n    assert(doubleTheDifference((List[Float](0.2f.toFloat, 3.0f.toFloat, 5.0f.toFloat))) == (34l));\n    assert(doubleTheDifference((List[Float](-9.0f.toFloat, -7.0f.toFloat, -5.0f.toFloat, -3.0f.toFloat, -1.0f.toFloat, 1.0f.toFloat, 3.0f.toFloat, 5.0f.toFloat, 7.0f.toFloat, 9.0f.toFloat))) == (165l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // I think we all remember that feeling when the result of some long-awaited\n    // event is finally known. The feelings and thoughts you have at that moment are\n    // definitely worth noting down and comparing.\n    // Your task is to determine if a person correctly guessed the results of a number of matches.\n    // You are given two arrays of scores and guesses of equal length, where each index shows a match. \n    // Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n    // the value is 0, and if not, the value is the absolute difference between the guess and the score.\n    // example:\n    // >>> compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong)))\n    // (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))\n    // >>> compare((List[Long](0l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 4l.toLong)), (List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, -2l.toLong)))\n    // (List[Long](4l.toLong, 4l.toLong, 1l.toLong, 0l.toLong, 0l.toLong, 6l.toLong))\n    def compare(game : List[Long], guess : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, -2l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 3l.toLong, 3l.toLong))));\n    assert(compare((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong)), (List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](-1l.toLong, -2l.toLong, -3l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(compare((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong)), (List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 0l.toLong, 0l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given the name of a class (a string) and a list of extensions.\n    // The extensions are to be used to load additional classes to the class. The\n    // strength of the extension is as follows: Let CAP be the number of the uppercase\n    // letters in the extension's name, and let SM be the number of lowercase letters \n    // in the extension's name, the strength is given by the fraction CAP - SM. \n    // You should find the strongest extension and return a string in this \n    // format: ClassName.StrongestExtensionName.\n    // If there are two or more extensions with the same strength, you should\n    // choose the one that comes first in the list.\n    // For example, if you are given \"Slices\" as the class and a list of the\n    // extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n    // return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n    // (its strength is -1).\n    // Example:\n    // >>> StrongestExtension((\"my_class\"), (List[String](\"AA\", \"Be\", \"CC\")))\n    // (\"my_class.AA\")\n    def StrongestExtension(class_name : String, extensions : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(StrongestExtension((\"Watashi\"), (List[String](\"tEN\", \"niNE\", \"eIGHt8OKe\"))).equals((\"Watashi.eIGHt8OKe\")));\n    assert(StrongestExtension((\"Boku123\"), (List[String](\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"))).equals((\"Boku123.YEs.WeCaNe\")));\n    assert(StrongestExtension((\"__YESIMHERE\"), (List[String](\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"))).equals((\"__YESIMHERE.NuLl__\")));\n    assert(StrongestExtension((\"K\"), (List[String](\"Ta\", \"TAR\", \"t234An\", \"cosSo\"))).equals((\"K.TAR\")));\n    assert(StrongestExtension((\"__HAHA\"), (List[String](\"Tab\", \"123\", \"781345\", \"-_-\"))).equals((\"__HAHA.123\")));\n    assert(StrongestExtension((\"YameRore\"), (List[String](\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"))).equals((\"YameRore.okIWILL123\")));\n    assert(StrongestExtension((\"finNNalLLly\"), (List[String](\"Die\", \"NowW\", \"Wow\", \"WoW\"))).equals((\"finNNalLLly.WoW\")));\n    assert(StrongestExtension((\"_\"), (List[String](\"Bb\", \"91245\"))).equals((\"_.Bb\")));\n    assert(StrongestExtension((\"Sp\"), (List[String](\"671235\", \"Bb\"))).equals((\"Sp.671235\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n    // >>> cycpatternCheck((\"abcd\"), (\"abd\"))\n    // (false)\n    // >>> cycpatternCheck((\"hello\"), (\"ell\"))\n    // (true)\n    // >>> cycpatternCheck((\"whassup\"), (\"psus\"))\n    // (false)\n    // >>> cycpatternCheck((\"abab\"), (\"baa\"))\n    // (true)\n    // >>> cycpatternCheck((\"efef\"), (\"eeff\"))\n    // (false)\n    // >>> cycpatternCheck((\"himenss\"), (\"simen\"))\n    // (true)\n    def cycpatternCheck(a : String, b : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cycpatternCheck((\"xyzw\"), (\"xyw\")) == (false));\n    assert(cycpatternCheck((\"yello\"), (\"ell\")) == (true));\n    assert(cycpatternCheck((\"whattup\"), (\"ptut\")) == (false));\n    assert(cycpatternCheck((\"efef\"), (\"fee\")) == (true));\n    assert(cycpatternCheck((\"abab\"), (\"aabb\")) == (false));\n    assert(cycpatternCheck((\"winemtt\"), (\"tinem\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an integer. return a tuple that has the number of even and odd digits respectively.\n    // Example:\n    // >>> evenOddCount((-12l))\n    // ((1l, 1l))\n    // >>> evenOddCount((123l))\n    // ((1l, 2l))\n    def evenOddCount(num : Long) : Tuple2[Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenOddCount((7l)).equals(((0l, 1l))));\n    assert(evenOddCount((-78l)).equals(((1l, 1l))));\n    assert(evenOddCount((3452l)).equals(((2l, 2l))));\n    assert(evenOddCount((346211l)).equals(((3l, 3l))));\n    assert(evenOddCount((-345821l)).equals(((3l, 3l))));\n    assert(evenOddCount((-2l)).equals(((1l, 0l))));\n    assert(evenOddCount((-45347l)).equals(((2l, 3l))));\n    assert(evenOddCount((0l)).equals(((1l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer, obtain its roman numeral equivalent as a string,\n    // and return it in lowercase.\n    // Restrictions: 1 <= num <= 1000\n    // Examples:\n    // >>> intToMiniRoman((19l))\n    // (\"xix\")\n    // >>> intToMiniRoman((152l))\n    // (\"clii\")\n    // >>> intToMiniRoman((426l))\n    // (\"cdxxvi\")\n    def intToMiniRoman(number : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intToMiniRoman((19l)).equals((\"xix\")));\n    assert(intToMiniRoman((152l)).equals((\"clii\")));\n    assert(intToMiniRoman((251l)).equals((\"ccli\")));\n    assert(intToMiniRoman((426l)).equals((\"cdxxvi\")));\n    assert(intToMiniRoman((500l)).equals((\"d\")));\n    assert(intToMiniRoman((1l)).equals((\"i\")));\n    assert(intToMiniRoman((4l)).equals((\"iv\")));\n    assert(intToMiniRoman((43l)).equals((\"xliii\")));\n    assert(intToMiniRoman((90l)).equals((\"xc\")));\n    assert(intToMiniRoman((94l)).equals((\"xciv\")));\n    assert(intToMiniRoman((532l)).equals((\"dxxxii\")));\n    assert(intToMiniRoman((900l)).equals((\"cm\")));\n    assert(intToMiniRoman((994l)).equals((\"cmxciv\")));\n    assert(intToMiniRoman((1000l)).equals((\"m\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return True if the three\n    // sides form a right-angled triangle, False otherwise.\n    // A right-angled triangle is a triangle in which one angle is right angle or \n    // 90 degree.\n    // Example:\n    // >>> rightAngleTriangle((3l), (4l), (5l))\n    // (true)\n    // >>> rightAngleTriangle((1l), (2l), (3l))\n    // (false)\n    def rightAngleTriangle(a : Long, b : Long, c : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightAngleTriangle((3l), (4l), (5l)) == (true));\n    assert(rightAngleTriangle((1l), (2l), (3l)) == (false));\n    assert(rightAngleTriangle((10l), (6l), (8l)) == (true));\n    assert(rightAngleTriangle((2l), (2l), (2l)) == (false));\n    assert(rightAngleTriangle((7l), (24l), (25l)) == (true));\n    assert(rightAngleTriangle((10l), (5l), (7l)) == (false));\n    assert(rightAngleTriangle((5l), (12l), (13l)) == (true));\n    assert(rightAngleTriangle((15l), (8l), (17l)) == (true));\n    assert(rightAngleTriangle((48l), (55l), (73l)) == (true));\n    assert(rightAngleTriangle((1l), (1l), (1l)) == (false));\n    assert(rightAngleTriangle((2l), (2l), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts a list of strings.\n    // The list contains different words. Return the word with maximum number\n    // of unique characters. If multiple strings have maximum number of unique\n    // characters, return the one which comes first in lexicographical order.\n    // >>> findMax((List[String](\"name\", \"of\", \"string\")))\n    // (\"string\")\n    // >>> findMax((List[String](\"name\", \"enam\", \"game\")))\n    // (\"enam\")\n    // >>> findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\")))\n    // (\"aaaaaaa\")\n    def findMax(words : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMax((List[String](\"name\", \"of\", \"string\"))).equals((\"string\")));\n    assert(findMax((List[String](\"name\", \"enam\", \"game\"))).equals((\"enam\")));\n    assert(findMax((List[String](\"aaaaaaa\", \"bb\", \"cc\"))).equals((\"aaaaaaa\")));\n    assert(findMax((List[String](\"abc\", \"cba\"))).equals((\"abc\")));\n    assert(findMax((List[String](\"play\", \"this\", \"game\", \"of\", \"footbott\"))).equals((\"footbott\")));\n    assert(findMax((List[String](\"we\", \"are\", \"gonna\", \"rock\"))).equals((\"gonna\")));\n    assert(findMax((List[String](\"we\", \"are\", \"a\", \"mad\", \"nation\"))).equals((\"nation\")));\n    assert(findMax((List[String](\"this\", \"is\", \"a\", \"prrk\"))).equals((\"this\")));\n    assert(findMax((List[String](\"b\"))).equals((\"b\")));\n    assert(findMax((List[String](\"play\", \"play\", \"play\"))).equals((\"play\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're a hungry rabbit, and you already have eaten a certain number of carrots,\n    // but now you need to eat more carrots to complete the day's meals.\n    // you should return an array of [ total number of eaten carrots after your meals,\n    // the number of carrots left after your meals ]\n    // if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n    // Example:\n    // >>> eat((5l), (6l), (10l))\n    // (List[Long](11l.toLong, 4l.toLong))\n    // >>> eat((4l), (8l), (9l))\n    // (List[Long](12l.toLong, 1l.toLong))\n    // >>> eat((1l), (10l), (10l))\n    // (List[Long](11l.toLong, 0l.toLong))\n    // >>> eat((2l), (11l), (5l))\n    // (List[Long](7l.toLong, 0l.toLong))\n    // Variables:\n    // @number : integer\n    // the number of carrots that you have eaten.\n    // @need : integer\n    // the number of carrots that you need to eat.\n    // @remaining : integer\n    // the number of remaining carrots thet exist in stock\n    // Constrain:\n    // * 0 <= number <= 1000\n    // * 0 <= need <= 1000\n    // * 0 <= remaining <= 1000\n    // Have fun :)\n    def eat(number : Long, need : Long, remaining : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eat((5l), (6l), (10l)).equals((List[Long](11l.toLong, 4l.toLong))));\n    assert(eat((4l), (8l), (9l)).equals((List[Long](12l.toLong, 1l.toLong))));\n    assert(eat((1l), (10l), (10l)).equals((List[Long](11l.toLong, 0l.toLong))));\n    assert(eat((2l), (11l), (5l)).equals((List[Long](7l.toLong, 0l.toLong))));\n    assert(eat((4l), (5l), (7l)).equals((List[Long](9l.toLong, 2l.toLong))));\n    assert(eat((4l), (5l), (1l)).equals((List[Long](5l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n    // >>> stringSequence((0l))\n    // (\"0\")\n    // >>> stringSequence((5l))\n    // (\"0 1 2 3 4 5\")\n    def stringSequence(n : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringSequence((0l)).equals((\"0\")));\n    assert(stringSequence((3l)).equals((\"0 1 2 3\")));\n    assert(stringSequence((10l)).equals((\"0 1 2 3 4 5 6 7 8 9 10\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two lists operator, and operand. The first list has basic algebra operations, and \n    // the second list is a list of integers. Use the two given lists to build the algebric \n    // expression and return the evaluation of this expression.\n    // The basic algebra operations:\n    // Addition ( + ) \n    // Subtraction ( - ) \n    // Multiplication ( * ) \n    // Floor division ( // ) \n    // Exponentiation ( ** ) \n    // Example:\n    // operator['+', '*', '-']\n    // array = [2, 3, 4, 5]\n    // result = 2 + 3 * 4 - 5\n    // => result = 9\n    // Note:\n    // The length of operator list is equal to the length of operand list minus one.\n    // Operand is a list of of non-negative integers.\n    // Operator list has at least one operator, and operand list has at least two operands.\n    def doAlgebra(op : List[String], operand : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(doAlgebra((List[String](\"**\", \"*\", \"+\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (37l));\n    assert(doAlgebra((List[String](\"+\", \"*\", \"-\")), (List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (9l));\n    assert(doAlgebra((List[String](\"//\", \"*\")), (List[Long](7l.toLong, 3l.toLong, 4l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // if s[i] is a letter, reverse its case from lower to upper or vise versa, \n    // otherwise keep it as it is.\n    // If the string contains no letters, reverse the string.\n    // The function should return the resulted string.\n    // Examples\n    // >>> solve((\"1234\"))\n    // (\"4321\")\n    // >>> solve((\"ab\"))\n    // (\"AB\")\n    // >>> solve((\"#a@C\"))\n    // (\"#A@c\")\n    def solve(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((\"AsDf\")).equals((\"aSdF\")));\n    assert(solve((\"1234\")).equals((\"4321\")));\n    assert(solve((\"ab\")).equals((\"AB\")));\n    assert(solve((\"#a@C\")).equals((\"#A@c\")));\n    assert(solve((\"#AsdfW^45\")).equals((\"#aSDFw^45\")));\n    assert(solve((\"#6@2\")).equals((\"2@6#\")));\n    assert(solve((\"#$a^D\")).equals((\"#$A^d\")));\n    assert(solve((\"#ccc\")).equals((\"#CCC\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string 'text', return its md5 hash equivalent string.\n    // If 'text' is an empty string, return None.\n    // >>> stringToMd5((\"Hello world\"))\n    // Some(\"3e25960a79dbc69b674cd4ec67a72c62\")\n    def stringToMd5(text : String) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToMd5((\"Hello world\")).equals(Some(\"3e25960a79dbc69b674cd4ec67a72c62\")));\n    assert(stringToMd5((\"\")).equals(None));\n    assert(stringToMd5((\"A B C\")).equals(Some(\"0ef78513b0cb8cef12743f5aeb35f888\")));\n    assert(stringToMd5((\"password\")).equals(Some(\"5f4dcc3b5aa765d61d8327deb882cf99\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1828,7 +832,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given two positive integers a and b, return the even digits between a\n    // and b, in ascending order.\n    // For example:\n    // >>> generateIntegers((2l), (8l))\n    // (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))\n    // >>> generateIntegers((8l), (2l))\n    // (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))\n    // >>> generateIntegers((10l), (14l))\n    // (List[Long]())\n    def generateIntegers(a : Long, b : Long) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(generateIntegers((2l), (10l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((10l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((132l), (2l)).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(generateIntegers((17l), (89l)).equals((List[Long]())));\n    }\n\n}\n",
     "stop_tokens": [
@@ -1836,49 +840,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string, find out how many distinct characters (regardless of case) does it consist of\n    // >>> countDistinctCharacters((\"xyzXYZ\"))\n    // (3l)\n    // >>> countDistinctCharacters((\"Jerry\"))\n    // (4l)\n    def countDistinctCharacters(string : String) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDistinctCharacters((\"\")) == (0l));\n    assert(countDistinctCharacters((\"abcde\")) == (5l));\n    assert(countDistinctCharacters((\"abcdecadeCADE\")) == (5l));\n    assert(countDistinctCharacters((\"aaaaAAAAaaaa\")) == (1l));\n    assert(countDistinctCharacters((\"Jerry jERRY JeRRRY\")) == (5l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (false)\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong)))\n    // (true)\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string representing musical notes in a special ASCII format.\n    // Your task is to parse this string and return list of integers corresponding to how many beats does each\n    // not last.\n    // Here is a legend:\n    // 'o' - whole note, lasts four beats\n    // 'o|' - half note, lasts two beats\n    // '.|' - quater note, lasts one beat\n    // >>> parseMusic((\"o o| .| o| o| .| .| .| .| o o\"))\n    // (List[Long](4l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))\n    def parseMusic(music_string : String) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseMusic((\"\")).equals((List[Long]())));\n    assert(parseMusic((\"o o o o\")).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\".| .| .| .|\")).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong))));\n    assert(parseMusic((\"o| o| .| .| o o o o\")).equals((List[Long](2l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(parseMusic((\"o| .| o| .| o o| o o|\")).equals((List[Long](2l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 2l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((List[Long](4l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong)))\n    // (2l)\n    // >>> search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (3l)\n    // >>> search((List[Long](5l.toLong, 5l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (-1l)\n    def search(lst : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Find how many times a given substring can be found in the original string. Count overlaping cases.\n    // >>> howManyTimes((\"\"), (\"a\"))\n    // (0l)\n    // >>> howManyTimes((\"aaa\"), (\"a\"))\n    // (3l)\n    // >>> howManyTimes((\"aaaa\"), (\"aa\"))\n    // (3l)\n    def howManyTimes(string : String, substring : String) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(howManyTimes((\"\"), (\"x\")) == (0l));\n    assert(howManyTimes((\"xyxyxyx\"), (\"x\")) == (4l));\n    assert(howManyTimes((\"cacacacac\"), (\"cac\")) == (4l));\n    assert(howManyTimes((\"john doe\"), (\"john\")) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input is a space-delimited string of numberals from 'zero' to 'nine'.\n    // Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n    // Return the string with numbers sorted from smallest to largest\n    // >>> sortNumbers((\"three one five\"))\n    // (\"one three five\")\n    def sortNumbers(numbers : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumbers((\"\")).equals((\"\")));\n    assert(sortNumbers((\"three\")).equals((\"three\")));\n    assert(sortNumbers((\"three five nine\")).equals((\"three five nine\")));\n    assert(sortNumbers((\"five zero four seven nine eight\")).equals((\"zero four five seven eight nine\")));\n    assert(sortNumbers((\"six five four three two one zero\")).equals((\"zero one two three four five six\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n    // separate those group into separate strings and return the list of those.\n    // Separate groups are balanced (each open brace is properly closed) and not nested within each other\n    // Ignore any spaces in the input string.\n    // >>> separateParenGroups((\"( ) (( )) (( )( ))\"))\n    // (List[String](\"()\", \"(())\", \"(()())\"))\n    def separateParenGroups(paren_string : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(separateParenGroups((\"(()()) ((())) () ((())()())\")).equals((List[String](\"(()())\", \"((()))\", \"()\", \"((())()())\"))));\n    assert(separateParenGroups((\"() (()) ((())) (((())))\")).equals((List[String](\"()\", \"(())\", \"((()))\", \"(((())))\"))));\n    assert(separateParenGroups((\"(()(())((())))\")).equals((List[String](\"(()(())((())))\"))));\n    assert(separateParenGroups((\"( ) (( )) (( )( ))\")).equals((List[String](\"()\", \"(())\", \"(()())\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n    // other and return them in order (smaller number, larger number).\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat)))\n    // ((2.0f, 2.2f))\n    // >>> findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat)))\n    // ((2.0f, 2.0f))\n    def findClosestElements(numbers : List[Float]) : Tuple2[Float, Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((3.9f, 4.0f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 5.9f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals(((5.0f, 5.9f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.2f.toFloat))).equals(((2.0f, 2.2f))));\n    assert(findClosestElements((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat, 2.0f.toFloat))).equals(((2.0f, 2.0f))));\n    assert(findClosestElements((List[Float](1.1f.toFloat, 2.2f.toFloat, 3.1f.toFloat, 4.1f.toFloat, 5.1f.toFloat))).equals(((2.2f, 3.1f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of numbers (of at least two elements), apply a linear transform to that list,\n    // such that the smallest number will become 0 and the largest will become 1\n    // >>> rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat)))\n    // (List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))\n    def rescaleToUnit(numbers : List[Float]) : List[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 49.9f.toFloat))).equals((List[Float](0.0f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](100.0f.toFloat, 49.9f.toFloat))).equals((List[Float](1.0f.toFloat, 0.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))).equals((List[Float](0.0f.toFloat, 0.25f.toFloat, 0.5f.toFloat, 0.75f.toFloat, 1.0f.toFloat))));\n    assert(rescaleToUnit((List[Float](2.0f.toFloat, 1.0f.toFloat, 5.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    assert(rescaleToUnit((List[Float](12.0f.toFloat, 11.0f.toFloat, 15.0f.toFloat, 13.0f.toFloat, 14.0f.toFloat))).equals((List[Float](0.25f.toFloat, 0.0f.toFloat, 1.0f.toFloat, 0.5f.toFloat, 0.75f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter given list of any python values only for integers\n    // >>> filterIntegers((List[Any](\"a\", 3.14f, 5l)))\n    // (List[Long](5l.toLong))\n    // >>> filterIntegers((List[Any](1l, 2l, 3l, \"abc\", Map[Long,Long](), List[Long]())))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    def filterIntegers(values : List[Any]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterIntegers((List[Any]())).equals((List[Long]())));\n    assert(filterIntegers((List[Any](4l, Map[Long,Long](), List[Long](), 23.2f, 9l, \"adasd\"))).equals((List[Long](4l.toLong, 9l.toLong))));\n    assert(filterIntegers((List[Any](3l, \"c\", 3l, 3l, \"a\", \"b\"))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return length of given string\n    // >>> stringLength((\"\"))\n    // (0l)\n    // >>> stringLength((\"abc\"))\n    // (3l)\n    def strlen(string : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strlen((\"\")) == (0l));\n    assert(strlen((\"x\")) == (1l));\n    assert(strlen((\"asdasnakj\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given number n, find the largest number that divides n evenly, smaller than n\n    // >>> largestDivisor((15l))\n    // (5l)\n    def largestDivisor(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestDivisor((3l)) == (1l));\n    assert(largestDivisor((7l)) == (1l));\n    assert(largestDivisor((10l)) == (5l));\n    assert(largestDivisor((100l)) == (50l));\n    assert(largestDivisor((49l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list of prime factors of given integer in the order from smallest to largest.\n    // Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n    // Input number should be equal to the product of all factors\n    // >>> factorize((8l))\n    // (List[Long](2l.toLong, 2l.toLong, 2l.toLong))\n    // >>> factorize((25l))\n    // (List[Long](5l.toLong, 5l.toLong))\n    // >>> factorize((70l))\n    // (List[Long](2l.toLong, 5l.toLong, 7l.toLong))\n    def factorize(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(factorize((2l)).equals((List[Long](2l.toLong))));\n    assert(factorize((4l)).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(factorize((8l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(factorize((57l)).equals((List[Long](3l.toLong, 19l.toLong))));\n    assert(factorize((3249l)).equals((List[Long](3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((185193l)).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((20577l)).equals((List[Long](3l.toLong, 19l.toLong, 19l.toLong, 19l.toLong))));\n    assert(factorize((18l)).equals((List[Long](2l.toLong, 3l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a list of integers, remove all elements that occur more than once.\n    // Keep order of elements left the same as in the input.\n    // >>> removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 3l.toLong, 4l.toLong))\n    def removeDuplicates(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDuplicates((List[Long]())).equals((List[Long]())));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(removeDuplicates((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n    // >>> flipCase((\"Hello\"))\n    // (\"hELLO\")\n    def flipCase(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flipCase((\"\")).equals((\"\")));\n    assert(flipCase((\"Hello!\")).equals((\"hELLO!\")));\n    assert(flipCase((\"These violent delights have violent ends\")).equals((\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Concatenate list of strings into a single string\n    // >>> concatenate((List[String]()))\n    // (\"\")\n    // >>> concatenate((List[String](\"a\", \"b\", \"c\")))\n    // (\"abc\")\n    def concatenate(strings : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenate((List[String]())).equals((\"\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\"))).equals((\"xyz\")));\n    assert(concatenate((List[String](\"x\", \"y\", \"z\", \"w\", \"k\"))).equals((\"xyzwk\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that start with a given prefix.\n    // >>> filterByPrefix((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterByPrefix((List[String](\"abc\", \"bcd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"array\"))\n    def filterByPrefix(strings : List[String], prefix : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterByPrefix((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterByPrefix((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive floating point number, it can be decomposed into\n    // and integer part (largest integer smaller than given number) and decimals\n    // (leftover part always smaller than 1).\n    // Return the decimal part of the number.\n    // >>> truncateNumber((3.5f))\n    // (0.5f)\n    def truncateNumber(number : Float) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(truncateNumber((3.5f)) == (0.5f));\n    assert(truncateNumber((1.25f)) == (0.25f));\n    assert(truncateNumber((123.0f)) == (0.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return only positive numbers in the list.\n    // >>> getPositive((List[Long](-1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](2l.toLong, 5l.toLong, 6l.toLong))\n    // >>> getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))\n    def getPositive(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(getPositive((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 123l.toLong, 1l.toLong))));\n    assert(getPositive((List[Long](-1l.toLong, -2l.toLong))).equals((List[Long]())));\n    assert(getPositive((List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return true if a given number is prime, and false otherwise.\n    // >>> isPrime((6l))\n    // (false)\n    // >>> isPrime((101l))\n    // (true)\n    // >>> isPrime((11l))\n    // (true)\n    // >>> isPrime((13441l))\n    // (true)\n    // >>> isPrime((61l))\n    // (true)\n    // >>> isPrime((4l))\n    // (false)\n    // >>> isPrime((1l))\n    // (false)\n    def isPrime(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPrime((6l)) == (false));\n    assert(isPrime((101l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((13441l)) == (true));\n    assert(isPrime((61l)) == (true));\n    assert(isPrime((4l)) == (false));\n    assert(isPrime((1l)) == (false));\n    assert(isPrime((5l)) == (true));\n    assert(isPrime((11l)) == (true));\n    assert(isPrime((17l)) == (true));\n    assert(isPrime((85l)) == (false));\n    assert(isPrime((77l)) == (false));\n    assert(isPrime((255379l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n    // to the values of the corresponding indicies of l, but sorted.\n    // >>> sortThird((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))\n    def sortThird(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 9l.toLong, 4l.toLong, 8l.toLong, 3l.toLong, 5l.toLong))));\n    assert(sortThird((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 8l.toLong, 9l.toLong, 5l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique elements in a list\n    // >>> unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))\n    def unique(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unique((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](0l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 9l.toLong, 123l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return maximum element in the list.\n    // >>> maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (3l)\n    // >>> maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong)))\n    // (123l)\n    def maxElement(l : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(maxElement((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 124l.toLong, 1l.toLong, -10l.toLong))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n    // >>> fizzBuzz((50l))\n    // (0l)\n    // >>> fizzBuzz((78l))\n    // (2l)\n    // >>> fizzBuzz((79l))\n    // (3l)\n    def fizzBuzz(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fizzBuzz((50l)) == (0l));\n    assert(fizzBuzz((78l)) == (2l));\n    assert(fizzBuzz((79l)) == (3l));\n    assert(fizzBuzz((100l)) == (3l));\n    assert(fizzBuzz((200l)) == (6l));\n    assert(fizzBuzz((4000l)) == (192l));\n    assert(fizzBuzz((10000l)) == (639l));\n    assert(fizzBuzz((100000l)) == (8026l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1888,9 +1108,201 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // This function takes a list l and returns a list l' such that\n    // l' is identical to l in the odd indicies, while its values at the even indicies are equal\n    // to the values of the even indicies of l, but sorted.\n    // >>> sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong))\n    // >>> sortEven((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](3l.toLong, 6l.toLong, 5l.toLong, 4l.toLong))\n    def sortEven(l : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong, 1l.toLong, -10l.toLong))).equals((List[Long](-10l.toLong, 3l.toLong, -5l.toLong, 2l.toLong, -3l.toLong, 3l.toLong, 5l.toLong, 0l.toLong, 9l.toLong, 1l.toLong, 123l.toLong))));\n    assert(sortEven((List[Long](5l.toLong, 8l.toLong, -12l.toLong, 4l.toLong, 23l.toLong, 2l.toLong, 3l.toLong, 11l.toLong, 12l.toLong, -10l.toLong))).equals((List[Long](-12l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 2l.toLong, 12l.toLong, 11l.toLong, 23l.toLong, -10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n    // >>> primeFib((1l))\n    // (2l)\n    // >>> primeFib((2l))\n    // (3l)\n    // >>> primeFib((3l))\n    // (5l)\n    // >>> primeFib((4l))\n    // (13l)\n    // >>> primeFib((5l))\n    // (89l)\n    def primeFib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeFib((1l)) == (2l));\n    assert(primeFib((2l)) == (3l));\n    assert(primeFib((3l)) == (5l));\n    assert(primeFib((4l)) == (13l));\n    assert(primeFib((5l)) == (89l));\n    assert(primeFib((6l)) == (233l));\n    assert(primeFib((7l)) == (1597l));\n    assert(primeFib((8l)) == (28657l));\n    assert(primeFib((9l)) == (514229l));\n    assert(primeFib((10l)) == (433494437l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You're given a list of deposit and withdrawal operations on a bank account that starts with\n    // zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n    // at that point function should return True. Otherwise it should return False.\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (false)\n    // >>> belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong)))\n    // (true)\n    def belowZero(operations : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowZero((List[Long]())) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -3l.toLong, 1l.toLong, 2l.toLong, -3l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, 2l.toLong, -4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (false));\n    assert(belowZero((List[Long](1l.toLong, -1l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -5l.toLong))) == (true));\n    assert(belowZero((List[Long](1l.toLong, -2l.toLong, 2l.toLong, -2l.toLong, 5l.toLong, -5l.toLong, 4l.toLong, -4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // triples_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are three distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong)))\n    // (true)\n    // >>> triplesSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def triplesSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 7l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 9l.toLong, 7l.toLong))) == (true));\n    assert(triplesSumToZero((List[Long](1l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    assert(triplesSumToZero((List[Long](100l.toLong, 3l.toLong, 5l.toLong, -100l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Imagine a road that's a perfectly straight infinitely long line.\n    // n cars are driving left to right;  simultaneously, a different set of n cars\n    // are driving right to left.   The two sets of cars start out being very far from\n    // each other.  All cars move in the same speed.  Two cars are said to collide\n    // when a car that's moving left to right hits a car that's moving right to left.\n    // However, the cars are infinitely sturdy and strong; as a result, they continue moving\n    // in their trajectory as if they did not collide.\n    // This function outputs the number of such collisions.\n    def carRaceCollision(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(carRaceCollision((2l)) == (4l));\n    assert(carRaceCollision((3l)) == (9l));\n    assert(carRaceCollision((4l)) == (16l));\n    assert(carRaceCollision((8l)) == (64l));\n    assert(carRaceCollision((10l)) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return list with elements incremented by 1.\n    // >>> incrList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong, 4l.toLong))\n    // >>> incrList((List[Long](5l.toLong, 3l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong)))\n    // (List[Long](6l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))\n    def incrList(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(incrList((List[Long]())).equals((List[Long]())));\n    assert(incrList((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong))));\n    assert(incrList((List[Long](5l.toLong, 2l.toLong, 5l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 9l.toLong, 0l.toLong, 123l.toLong))).equals((List[Long](6l.toLong, 3l.toLong, 6l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 124l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // pairs_sum_to_zero takes a list of integers as an input.\n    // it returns True if there are two distinct elements in the list that\n    // sum to zero, and False otherwise.\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong)))\n    // (false)\n    // >>> pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)))\n    // (true)\n    // >>> pairsSumToZero((List[Long](1l.toLong)))\n    // (false)\n    def pairsSumToZero(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 0l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 3l.toLong, -2l.toLong, 1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 7l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](2l.toLong, 4l.toLong, -5l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](1l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 30l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 3l.toLong, 2l.toLong, 31l.toLong))) == (true));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 30l.toLong))) == (false));\n    assert(pairsSumToZero((List[Long](-3l.toLong, 9l.toLong, -1l.toLong, 4l.toLong, 2l.toLong, 31l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Change numerical base of input number x to base.\n    // return string representation after the conversion.\n    // base numbers are less than 10.\n    // >>> changeBase((8l), (3l))\n    // (\"22\")\n    // >>> changeBase((8l), (2l))\n    // (\"1000\")\n    // >>> changeBase((7l), (2l))\n    // (\"111\")\n    def changeBase(x : Long, base : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeBase((8l), (3l)).equals((\"22\")));\n    assert(changeBase((9l), (3l)).equals((\"100\")));\n    assert(changeBase((234l), (2l)).equals((\"11101010\")));\n    assert(changeBase((16l), (2l)).equals((\"10000\")));\n    assert(changeBase((8l), (2l)).equals((\"1000\")));\n    assert(changeBase((7l), (2l)).equals((\"111\")));\n    assert(changeBase((2l), (3l)).equals((\"2\")));\n    assert(changeBase((3l), (4l)).equals((\"3\")));\n    assert(changeBase((4l), (5l)).equals((\"4\")));\n    assert(changeBase((5l), (6l)).equals((\"5\")));\n    assert(changeBase((6l), (7l)).equals((\"6\")));\n    assert(changeBase((7l), (8l)).equals((\"7\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given length of a side and high return area for a triangle.\n    // >>> triangleArea((5l), (3l))\n    // (7.5f)\n    def triangleArea(a : Long, h : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((5l), (3l)) == (7.5f));\n    assert(triangleArea((2l), (2l)) == (2.0f));\n    assert(triangleArea((10l), (8l)) == (40.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fib4(0) -> 0\n    // fib4(1) -> 0\n    // fib4(2) -> 2\n    // fib4(3) -> 0\n    // fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n    // Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n    // >>> fib4((5l))\n    // (4l)\n    // >>> fib4((6l))\n    // (8l)\n    // >>> fib4((7l))\n    // (14l)\n    def fib4(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib4((5l)) == (4l));\n    assert(fib4((8l)) == (28l));\n    assert(fib4((10l)) == (104l));\n    assert(fib4((12l)) == (386l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return median of elements in the list l.\n    // >>> median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // 3l\n    // >>> median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong)))\n    // (15.0f)\n    def median(l : List[Long]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(median((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))) == 3l);\n    assert(median((List[Long](-10l.toLong, 4l.toLong, 6l.toLong, 1000l.toLong, 10l.toLong, 20l.toLong))) == (8.0f));\n    assert(median((List[Long](5l.toLong))) == 5l);\n    assert(median((List[Long](6l.toLong, 5l.toLong))) == (5.5f));\n    assert(median((List[Long](8l.toLong, 1l.toLong, 3l.toLong, 9l.toLong, 9l.toLong, 2l.toLong, 7l.toLong))) == 7l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Checks if given string is a palindrome\n    // >>> isPalindrome((\"\"))\n    // (true)\n    // >>> isPalindrome((\"aba\"))\n    // (true)\n    // >>> isPalindrome((\"aaaaa\"))\n    // (true)\n    // >>> isPalindrome((\"zbcd\"))\n    // (false)\n    def isPalindrome(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPalindrome((\"\")) == (true));\n    assert(isPalindrome((\"aba\")) == (true));\n    assert(isPalindrome((\"aaaaa\")) == (true));\n    assert(isPalindrome((\"zbcd\")) == (false));\n    assert(isPalindrome((\"xywyx\")) == (true));\n    assert(isPalindrome((\"xywyz\")) == (false));\n    assert(isPalindrome((\"xywzx\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return 2^n modulo p (be aware of numerics).\n    // >>> modp((3l), (5l))\n    // (3l)\n    // >>> modp((1101l), (101l))\n    // (2l)\n    // >>> modp((0l), (101l))\n    // (1l)\n    // >>> modp((3l), (11l))\n    // (8l)\n    // >>> modp((100l), (101l))\n    // (1l)\n    def modp(n : Long, p : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(modp((3l), (5l)) == (3l));\n    assert(modp((1101l), (101l)) == (2l));\n    assert(modp((0l), (101l)) == (1l));\n    assert(modp((3l), (11l)) == (8l));\n    assert(modp((100l), (101l)) == (1l));\n    assert(modp((30l), (5l)) == (4l));\n    assert(modp((31l), (5l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of input numbers, calculate Mean Absolute Deviation\n    // around the mean of this dataset.\n    // Mean Absolute Deviation is the average absolute difference between each\n    // element and a centerpoint (mean in this case):\n    // MAD = average | x - x_mean |\n    // >>> meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat)))\n    // (1.0f)\n    def meanAbsoluteDeviation(numbers : List[Float]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat))) == (0.5f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat))) == (1.0f));\n    assert(meanAbsoluteDeviation((List[Float](1.0f.toFloat, 2.0f.toFloat, 3.0f.toFloat, 4.0f.toFloat, 5.0f.toFloat))) == (1.2f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // remove_vowels is a function that takes string and returns string without vowels.\n    // >>> removeVowels((\"\"))\n    // (\"\")\n    // >>> removeVowels((\"abcdef\"))\n    // (\"bcdf\")\n    // >>> removeVowels((\"aaaaa\"))\n    // (\"\")\n    // >>> removeVowels((\"aaBAA\"))\n    // (\"B\")\n    // >>> removeVowels((\"zbcd\"))\n    // (\"zbcd\")\n    def removeVowels(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeVowels((\"\")).equals((\"\")));\n    assert(removeVowels((\"abcdef\\nghijklm\")).equals((\"bcdf\\nghjklm\")));\n    assert(removeVowels((\"fedcba\")).equals((\"fdcb\")));\n    assert(removeVowels((\"eeeee\")).equals((\"\")));\n    assert(removeVowels((\"acBAA\")).equals((\"cB\")));\n    assert(removeVowels((\"EcBOO\")).equals((\"cB\")));\n    assert(removeVowels((\"ybcd\")).equals((\"ybcd\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True if all numbers in the list l are below threshold t.\n    // >>> belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l))\n    // (true)\n    // >>> belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l))\n    // (false)\n    def belowThreshold(l : List[Long], t : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(belowThreshold((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong)), (100l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (5l)) == (false));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (21l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)), (22l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (11l)) == (true));\n    assert(belowThreshold((List[Long](1l.toLong, 8l.toLong, 4l.toLong, 10l.toLong)), (10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Add two numbers x and y\n    // >>> add((2l), (3l))\n    // (5l)\n    // >>> add((5l), (7l))\n    // (12l)\n    def add(x : Long, y : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((0l), (1l)) == (1l));\n    assert(add((1l), (0l)) == (1l));\n    assert(add((2l), (3l)) == (5l));\n    assert(add((5l), (7l)) == (12l));\n    assert(add((7l), (5l)) == (12l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1900,9 +1312,21 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Check if two words have the same characters.\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\"))\n    // (true)\n    // >>> sameChars((\"abcd\"), (\"dddddddabc\"))\n    // (true)\n    // >>> sameChars((\"dddddddabc\"), (\"abcd\"))\n    // (true)\n    // >>> sameChars((\"eabcd\"), (\"dddddddabc\"))\n    // (false)\n    // >>> sameChars((\"abcd\"), (\"dddddddabce\"))\n    // (false)\n    // >>> sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\"))\n    // (false)\n    def sameChars(s0 : String, s1 : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddeddabc\")) == (true));\n    assert(sameChars((\"abcd\"), (\"dddddddabc\")) == (true));\n    assert(sameChars((\"dddddddabc\"), (\"abcd\")) == (true));\n    assert(sameChars((\"eabcd\"), (\"dddddddabc\")) == (false));\n    assert(sameChars((\"abcd\"), (\"dddddddabcf\")) == (false));\n    assert(sameChars((\"eabcdzzzz\"), (\"dddzzzzzzzddddabc\")) == (false));\n    assert(sameChars((\"aabb\"), (\"aaccc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return n-th Fibonacci number.\n    // >>> fib((10l))\n    // (55l)\n    // >>> fib((1l))\n    // (1l)\n    // >>> fib((8l))\n    // (21l)\n    def fib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fib((10l)) == (55l));\n    assert(fib((1l)) == (1l));\n    assert(fib((8l)) == (21l));\n    assert(fib((11l)) == (89l));\n    assert(fib((12l)) == (144l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -1912,9 +1336,585 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"<\" and \">\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"<\"))\n    // (false)\n    // >>> correctBracketing((\"<>\"))\n    // (true)\n    // >>> correctBracketing((\"<<><>>\"))\n    // (true)\n    // >>> correctBracketing((\"><<>\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"<>\")) == (true));\n    assert(correctBracketing((\"<<><>>\")) == (true));\n    assert(correctBracketing((\"<><><<><>><>\")) == (true));\n    assert(correctBracketing((\"<><><<<><><>><>><<><><<>>>\")) == (true));\n    assert(correctBracketing((\"<<<><>>>>\")) == (false));\n    assert(correctBracketing((\"><<>\")) == (false));\n    assert(correctBracketing((\"<\")) == (false));\n    assert(correctBracketing((\"<<<<\")) == (false));\n    assert(correctBracketing((\">\")) == (false));\n    assert(correctBracketing((\"<<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>><<>\")) == (false));\n    assert(correctBracketing((\"<><><<><>><>>><>\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return True is list elements are monotonically increasing or decreasing.\n    // >>> monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong)))\n    // (true)\n    // >>> monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong)))\n    // (false)\n    // >>> monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong)))\n    // (true)\n    def monotonic(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 10l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 20l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 20l.toLong, 4l.toLong, 10l.toLong))) == (false));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 0l.toLong, -10l.toLong))) == (true));\n    assert(monotonic((List[Long](4l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))) == (true));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 60l.toLong))) == (false));\n    assert(monotonic((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 60l.toLong))) == (true));\n    assert(monotonic((List[Long](9l.toLong, 9l.toLong, 9l.toLong, 9l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return sorted unique common elements for two lists.\n    // >>> common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong)))\n    // (List[Long](1l.toLong, 5l.toLong, 653l.toLong))\n    // >>> common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong)))\n    // (List[Long](2l.toLong, 3l.toLong))\n    def common(l1 : List[Long], l2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(common((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 34l.toLong, 653l.toLong, 2l.toLong, 5l.toLong)), (List[Long](5l.toLong, 7l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 653l.toLong, 121l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 653l.toLong))));\n    assert(common((List[Long](5l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong))).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long](3l.toLong, 2l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(common((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 8l.toLong)), (List[Long]())).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Return the largest prime factor of n. Assume n > 1 and is not a prime.\n    // >>> largestPrimeFactor((13195l))\n    // (29l)\n    // >>> largestPrimeFactor((2048l))\n    // (2l)\n    def largestPrimeFactor(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestPrimeFactor((15l)) == (5l));\n    assert(largestPrimeFactor((27l)) == (3l));\n    assert(largestPrimeFactor((63l)) == (7l));\n    assert(largestPrimeFactor((330l)) == (11l));\n    assert(largestPrimeFactor((13195l)) == (29l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n    // >>> intersperse((List[Long]()), (4l))\n    // (List[Long]())\n    // >>> intersperse((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))\n    def intersperse(numbers : List[Long], delimeter : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersperse((List[Long]()), (7l)).equals((List[Long]())));\n    assert(intersperse((List[Long](5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong)), (8l)).equals((List[Long](5l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 8l.toLong, 2l.toLong))));\n    assert(intersperse((List[Long](2l.toLong, 2l.toLong, 2l.toLong)), (2l)).equals((List[Long](2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // sum_to_n is a function that sums numbers from 1 to n.\n    // >>> sumToN((30l))\n    // (465l)\n    // >>> sumToN((100l))\n    // (5050l)\n    // >>> sumToN((5l))\n    // (15l)\n    // >>> sumToN((10l))\n    // (55l)\n    // >>> sumToN((1l))\n    // (1l)\n    def sumToN(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumToN((1l)) == (1l));\n    assert(sumToN((6l)) == (21l));\n    assert(sumToN((11l)) == (66l));\n    assert(sumToN((30l)) == (465l));\n    assert(sumToN((100l)) == (5050l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // brackets is a string of \"(\" and \")\".\n    // return True if every opening bracket has a corresponding closing bracket.\n    // >>> correctBracketing((\"(\"))\n    // (false)\n    // >>> correctBracketing((\"()\"))\n    // (true)\n    // >>> correctBracketing((\"(()())\"))\n    // (true)\n    // >>> correctBracketing((\")(()\"))\n    // (false)\n    def correctBracketing(brackets : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(correctBracketing((\"()\")) == (true));\n    assert(correctBracketing((\"(()())\")) == (true));\n    assert(correctBracketing((\"()()(()())()\")) == (true));\n    assert(correctBracketing((\"()()((()()())())(()()(()))\")) == (true));\n    assert(correctBracketing((\"((()())))\")) == (false));\n    assert(correctBracketing((\")(()\")) == (false));\n    assert(correctBracketing((\"(\")) == (false));\n    assert(correctBracketing((\"((((\")) == (false));\n    assert(correctBracketing((\")\")) == (false));\n    assert(correctBracketing((\"(()\")) == (false));\n    assert(correctBracketing((\"()()(()())())(()\")) == (false));\n    assert(correctBracketing((\"()()(()())()))()\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // xs represent coefficients of a polynomial.\n    // xs[0] + xs[1] * x + xs[2] * x^2 + ....\n    // Return derivative of this polynomial in the same form.\n    // >>> derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))\n    // >>> derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 6l.toLong))\n    def derivative(xs : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(derivative((List[Long](3l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 12l.toLong, 20l.toLong))));\n    assert(derivative((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 6l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 2l.toLong))));\n    assert(derivative((List[Long](3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong, 4l.toLong))).equals((List[Long](2l.toLong, 2l.toLong, 0l.toLong, 16l.toLong))));\n    assert(derivative((List[Long](1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n    // fibfib(0) == 0\n    // fibfib(1) == 0\n    // fibfib(2) == 1\n    // fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n    // Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n    // >>> fibfib((1l))\n    // (0l)\n    // >>> fibfib((5l))\n    // (4l)\n    // >>> fibfib((8l))\n    // (24l)\n    def fibfib(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fibfib((2l)) == (1l));\n    assert(fibfib((1l)) == (0l));\n    assert(fibfib((5l)) == (4l));\n    assert(fibfib((8l)) == (24l));\n    assert(fibfib((10l)) == (81l));\n    assert(fibfib((12l)) == (274l));\n    assert(fibfib((14l)) == (927l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function vowels_count which takes a string representing\n    // a word as input and returns the number of vowels in the string.\n    // Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n    // vowel, but only when it is at the end of the given word.\n    // Example:\n    // >>> vowelsCount((\"abcde\"))\n    // (2l)\n    // >>> vowelsCount((\"ACEDY\"))\n    // (3l)\n    def vowelsCount(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(vowelsCount((\"abcde\")) == (2l));\n    assert(vowelsCount((\"Alone\")) == (3l));\n    assert(vowelsCount((\"key\")) == (2l));\n    assert(vowelsCount((\"bye\")) == (1l));\n    assert(vowelsCount((\"keY\")) == (2l));\n    assert(vowelsCount((\"bYe\")) == (1l));\n    assert(vowelsCount((\"ACEDY\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Circular shift the digits of the integer x, shift the digits right by shift\n    // and return the result as a string.\n    // If shift > number of digits, return digits reversed.\n    // >>> circularShift((12l), (1l))\n    // (\"21\")\n    // >>> circularShift((12l), (2l))\n    // (\"12\")\n    def circularShift(x : Long, shift : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(circularShift((100l), (2l)).equals((\"001\")));\n    assert(circularShift((12l), (2l)).equals((\"12\")));\n    assert(circularShift((97l), (8l)).equals((\"79\")));\n    assert(circularShift((12l), (1l)).equals((\"21\")));\n    assert(circularShift((11l), (101l)).equals((\"11\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Task\n    // Write a function that takes a string as input and returns the sum of the upper characters only'\n    // ASCII codes.\n    // Examples:\n    // >>> digitSum((\"\"))\n    // (0l)\n    // >>> digitSum((\"abAB\"))\n    // (131l)\n    // >>> digitSum((\"abcCd\"))\n    // (67l)\n    // >>> digitSum((\"helloE\"))\n    // (69l)\n    // >>> digitSum((\"woArBld\"))\n    // (131l)\n    // >>> digitSum((\"aAaaaXa\"))\n    // (153l)\n    def digitSum(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitSum((\"\")) == (0l));\n    assert(digitSum((\"abAB\")) == (131l));\n    assert(digitSum((\"abcCd\")) == (67l));\n    assert(digitSum((\"helloE\")) == (69l));\n    assert(digitSum((\"woArBld\")) == (131l));\n    assert(digitSum((\"aAaaaXa\")) == (153l));\n    assert(digitSum((\" How are yOu?\")) == (151l));\n    assert(digitSum((\"You arE Very Smart\")) == (327l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // In this task, you will be given a string that represents a number of apples and oranges \n    // that are distributed in a basket of fruit this basket contains \n    // apples, oranges, and mango fruits. Given the string that represents the total number of \n    // the oranges and apples and an integer that represent the total number of the fruits \n    // in the basket return the number of the mango fruits in the basket.\n    // for examble:\n    // >>> fruitDistribution((\"5 apples and 6 oranges\"), (19l))\n    // (8l)\n    // >>> fruitDistribution((\"0 apples and 1 oranges\"), (3l))\n    // (2l)\n    // >>> fruitDistribution((\"2 apples and 3 oranges\"), (100l))\n    // (95l)\n    // >>> fruitDistribution((\"100 apples and 1 oranges\"), (120l))\n    // (19l)\n    def fruitDistribution(s : String, n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (19l)) == (8l));\n    assert(fruitDistribution((\"5 apples and 6 oranges\"), (21l)) == (10l));\n    assert(fruitDistribution((\"0 apples and 1 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"1 apples and 0 oranges\"), (3l)) == (2l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (100l)) == (95l));\n    assert(fruitDistribution((\"2 apples and 3 oranges\"), (5l)) == (0l));\n    assert(fruitDistribution((\"1 apples and 100 oranges\"), (120l)) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // \"Given an array representing a branch of a tree that has non-negative integer nodes\n    // your task is to pluck one of the nodes and return it.\n    // The plucked node should be the node with the smallest even value.\n    // If multiple nodes with the same smallest even value are found return the node that has smallest index.\n    // The plucked node should be returned in a list, [ smalest_value, its index ],\n    // If there are no even values or the given array is empty, return [].\n    // Example 1:\n    // >>> pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 2:\n    // >>> pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong)))\n    // (List[Long](2l.toLong, 1l.toLong))\n    // Explanation: 2 has the smallest even value, and 2 has the smallest index.\n    // Example 3:\n    // >>> pluck((List[Long]()))\n    // (List[Long]())\n    // Example 4:\n    // >>> pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong))\n    // Explanation: 0 is the smallest value, but  there are two zeros,\n    // so we will choose the first zero, which has the smallest index.\n    // Constraints:\n    // * 1 <= nodes.length <= 10000\n    // * 0 <= node.value\n    def pluck(arr : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pluck((List[Long](4l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong, 1l.toLong))));\n    assert(pluck((List[Long]())).equals((List[Long]())));\n    assert(pluck((List[Long](5l.toLong, 0l.toLong, 3l.toLong, 0l.toLong, 4l.toLong, 2l.toLong))).equals((List[Long](0l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 0l.toLong, 5l.toLong, 3l.toLong))).equals((List[Long](0l.toLong, 3l.toLong))));\n    assert(pluck((List[Long](5l.toLong, 4l.toLong, 8l.toLong, 4l.toLong, 8l.toLong))).equals((List[Long](4l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](6l.toLong, 1l.toLong))));\n    assert(pluck((List[Long](7l.toLong, 9l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n    // zero, and has a frequency greater than or equal to the value of the integer itself. \n    // The frequency of an integer is the number of times it appears in the list.\n    // If no such a value exist, return -1.\n    // Examples:\n    // >>> search((List[Long](4l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong)))\n    // (2l)\n    // >>> search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (3l)\n    // >>> search((List[Long](5l.toLong, 5l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))\n    // (-1l)\n    def search(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](4l.toLong, 1l.toLong, 4l.toLong, 1l.toLong, 4l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](3l.toLong, 3l.toLong))) == (-1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](2l.toLong, 3l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](2l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 4l.toLong, 8l.toLong, 7l.toLong, 3l.toLong, 9l.toLong, 6l.toLong, 5l.toLong, 10l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 7l.toLong, 4l.toLong, 10l.toLong, 8l.toLong, 1l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 2l.toLong, 8l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](6l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 10l.toLong, 5l.toLong, 8l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 3l.toLong, 6l.toLong, 5l.toLong, 6l.toLong, 4l.toLong))) == (-1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 6l.toLong, 7l.toLong, 1l.toLong, 4l.toLong, 7l.toLong, 1l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 8l.toLong, 10l.toLong, 10l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))) == (1l));\n    assert(search((List[Long](1l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](6l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 3l.toLong, 7l.toLong, 5l.toLong, 10l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 9l.toLong, 5l.toLong, 3l.toLong, 10l.toLong))) == (5l));\n    assert(search((List[Long](1l.toLong))) == (1l));\n    assert(search((List[Long](8l.toLong, 8l.toLong, 10l.toLong, 6l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 6l.toLong, 10l.toLong, 4l.toLong, 2l.toLong, 1l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 5l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 8l.toLong, 2l.toLong, 10l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 9l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 10l.toLong))) == (2l));\n    assert(search((List[Long](1l.toLong, 6l.toLong, 10l.toLong, 1l.toLong, 6l.toLong, 9l.toLong, 10l.toLong, 8l.toLong, 6l.toLong, 8l.toLong, 7l.toLong, 3l.toLong))) == (1l));\n    assert(search((List[Long](9l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 1l.toLong, 5l.toLong, 2l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 7l.toLong, 3l.toLong, 10l.toLong, 1l.toLong, 5l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 4l.toLong, 1l.toLong, 9l.toLong, 10l.toLong, 7l.toLong, 10l.toLong, 2l.toLong, 8l.toLong, 10l.toLong, 9l.toLong, 4l.toLong))) == (4l));\n    assert(search((List[Long](2l.toLong, 6l.toLong, 4l.toLong, 2l.toLong, 8l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 4l.toLong, 10l.toLong, 4l.toLong, 6l.toLong, 3l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 3l.toLong, 1l.toLong, 4l.toLong, 2l.toLong, 2l.toLong, 10l.toLong, 7l.toLong))) == (4l));\n    assert(search((List[Long](9l.toLong, 8l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 6l.toLong, 10l.toLong, 2l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 3l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 5l.toLong, 3l.toLong, 9l.toLong, 5l.toLong, 6l.toLong, 3l.toLong, 2l.toLong, 8l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 10l.toLong, 6l.toLong, 8l.toLong, 4l.toLong, 10l.toLong, 7l.toLong, 7l.toLong, 10l.toLong, 8l.toLong))) == (-1l));\n    assert(search((List[Long](10l.toLong))) == (-1l));\n    assert(search((List[Long](9l.toLong, 7l.toLong, 7l.toLong, 2l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 10l.toLong, 9l.toLong, 7l.toLong, 5l.toLong, 7l.toLong, 2l.toLong))) == (2l));\n    assert(search((List[Long](5l.toLong, 4l.toLong, 10l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 3l.toLong, 6l.toLong, 1l.toLong, 8l.toLong))) == (1l));\n    assert(search((List[Long](7l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 1l.toLong, 10l.toLong, 7l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 6l.toLong))) == (1l));\n    assert(search((List[Long](3l.toLong, 10l.toLong, 10l.toLong, 9l.toLong, 2l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n    // For each of the group, output the deepest level of nesting of parentheses.\n    // E.g. (()()) has maximum two levels of nesting while ((())) has three.\n    // >>> parseNestedParens((\"(()()) ((())) () ((())()())\"))\n    // (List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))\n    def parseNestedParens(paren_string : String) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parseNestedParens((\"(()()) ((())) () ((())()())\")).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong, 3l.toLong))));\n    assert(parseNestedParens((\"() (()) ((())) (((())))\")).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(parseNestedParens((\"(()(())((())))\")).equals((List[Long](4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given list of integers, return list in strange order.\n    // Strange sorting, is when you start with the minimum value,\n    // then maximum of the remaining integers, then minimum and so on.\n    // Examples:\n    // >>> strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // (List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))\n    // >>> strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong)))\n    // (List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))\n    // >>> strangeSortList((List[Long]()))\n    // (List[Long]())\n    def strangeSortList(lst : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 2l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](5l.toLong, 9l.toLong, 6l.toLong, 8l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 2l.toLong, 4l.toLong, 3l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 9l.toLong, 5l.toLong, 8l.toLong, 6l.toLong, 7l.toLong))));\n    assert(strangeSortList((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))).equals((List[Long](5l.toLong, 5l.toLong, 5l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long]())).equals((List[Long]())));\n    assert(strangeSortList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 2l.toLong, 7l.toLong, 3l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))));\n    assert(strangeSortList((List[Long](0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 5l.toLong, 5l.toLong, -5l.toLong, -5l.toLong))).equals((List[Long](-5l.toLong, 5l.toLong, -5l.toLong, 5l.toLong, 0l.toLong, 2l.toLong, 2l.toLong, 2l.toLong))));\n    assert(strangeSortList((List[Long](111111l.toLong))).equals((List[Long](111111l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given the lengths of the three sides of a triangle. Return the area of\n    // the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n    // Otherwise return -1\n    // Three sides make a valid triangle when the sum of any two sides is greater \n    // than the third side.\n    // Example:\n    // >>> triangleArea((3l), (4l), (5l))\n    // (6.0f)\n    // >>> triangleArea((1l), (2l), (10l))\n    // -1l\n    def triangleArea(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((3l), (4l), (5l)) == (6.0f));\n    assert(triangleArea((1l), (2l), (10l)) == -1l);\n    assert(triangleArea((4l), (8l), (5l)) == (8.18f));\n    assert(triangleArea((2l), (2l), (2l)) == (1.73f));\n    assert(triangleArea((1l), (2l), (3l)) == -1l);\n    assert(triangleArea((10l), (5l), (7l)) == (16.25f));\n    assert(triangleArea((2l), (6l), (3l)) == -1l);\n    assert(triangleArea((1l), (1l), (1l)) == (0.43f));\n    assert(triangleArea((2l), (2l), (10l)) == -1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns True if the object q will fly, and False otherwise.\n    // The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n    // Example:\n    // >>> willItFly((List[Long](1l.toLong, 2l.toLong)), (5l))\n    // (false)\n    // # 1+2 is less than the maximum possible weight, but it's unbalanced.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l))\n    // (false)\n    // # it's balanced, but 3+2+3 is more than the maximum possible weight.\n    // >>> willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l))\n    // (true)\n    // # 3+2+3 is less than the maximum possible weight, and it's balanced.\n    // >>> willItFly((List[Long](3l.toLong)), (5l))\n    // (true)\n    // # 3 is less than the maximum possible weight, and it's balanced.\n    def willItFly(q : List[Long], w : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (9l)) == (true));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong)), (5l)) == (false));\n    assert(willItFly((List[Long](3l.toLong)), (5l)) == (true));\n    assert(willItFly((List[Long](3l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (false));\n    assert(willItFly((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (6l)) == (false));\n    assert(willItFly((List[Long](5l.toLong)), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array arr of integers, find the minimum number of elements that\n    // need to be changed to make the array palindromic. A palindromic array is an array that\n    // is read the same backwards and forwards. In one change, you can change one element to any other element.\n    // For example:\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong)))\n    // (4l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong)))\n    // (1l)\n    // >>> smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong)))\n    // (0l)\n    def smallestChange(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 6l.toLong))) == (4l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 4l.toLong, 4l.toLong, 2l.toLong))) == (1l));\n    assert(smallestChange((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](3l.toLong, 1l.toLong, 1l.toLong, 3l.toLong))) == (0l));\n    assert(smallestChange((List[Long](1l.toLong))) == (0l));\n    assert(smallestChange((List[Long](0l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that accepts two lists of strings and returns the list that has \n    // total number of chars in the all strings of the list less than the other list.\n    // if the two lists have the same number of chars, return the first list.\n    // Examples\n    // >>> totalMatch((List[String]()), (List[String]()))\n    // (List[String]())\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\")))\n    // (List[String](\"hI\", \"Hi\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\")))\n    // (List[String](\"hi\", \"admin\"))\n    // >>> totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\")))\n    // (List[String](\"hI\", \"hi\", \"hi\"))\n    // >>> totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\")))\n    // (List[String](\"4\"))\n    def totalMatch(lst1 : List[String], lst2 : List[String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(totalMatch((List[String]()), (List[String]())).equals((List[String]())));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\"))).equals((List[String](\"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hi\", \"hi\", \"admin\", \"project\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String](\"4\")), (List[String](\"1\", \"2\", \"3\", \"4\", \"5\"))).equals((List[String](\"4\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"Hi\"))).equals((List[String](\"hI\", \"Hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hi\"))).equals((List[String](\"hI\", \"hi\", \"hi\"))));\n    assert(totalMatch((List[String](\"hi\", \"admin\")), (List[String](\"hI\", \"hi\", \"hii\"))).equals((List[String](\"hi\", \"admin\"))));\n    assert(totalMatch((List[String]()), (List[String](\"this\"))).equals((List[String]())));\n    assert(totalMatch((List[String](\"this\")), (List[String]())).equals((List[String]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns true if the given number is the multiplication of 3 prime numbers\n    // and false otherwise.\n    // Knowing that (a) is less then 100. \n    // Example:\n    // >>> isMultiplyPrime((30l))\n    // (true)\n    // 30 = 2 * 3 * 5\n    def isMultiplyPrime(a : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMultiplyPrime((5l)) == (false));\n    assert(isMultiplyPrime((30l)) == (true));\n    assert(isMultiplyPrime((8l)) == (true));\n    assert(isMultiplyPrime((10l)) == (false));\n    assert(isMultiplyPrime((125l)) == (true));\n    assert(isMultiplyPrime((105l)) == (true));\n    assert(isMultiplyPrime((126l)) == (false));\n    assert(isMultiplyPrime((729l)) == (false));\n    assert(isMultiplyPrime((891l)) == (false));\n    assert(isMultiplyPrime((1001l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Your task is to write a function that returns true if a number x is a simple\n    // power of n and false in other cases.\n    // x is a simple power of n if n**int=x\n    // For example:\n    // >>> isSimplePower((1l), (4l))\n    // (true)\n    // >>> isSimplePower((2l), (2l))\n    // (true)\n    // >>> isSimplePower((8l), (2l))\n    // (true)\n    // >>> isSimplePower((3l), (2l))\n    // (false)\n    // >>> isSimplePower((3l), (1l))\n    // (false)\n    // >>> isSimplePower((5l), (3l))\n    // (false)\n    def isSimplePower(x : Long, n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSimplePower((16l), (2l)) == (true));\n    assert(isSimplePower((143214l), (16l)) == (false));\n    assert(isSimplePower((4l), (2l)) == (true));\n    assert(isSimplePower((9l), (3l)) == (true));\n    assert(isSimplePower((16l), (4l)) == (true));\n    assert(isSimplePower((24l), (2l)) == (false));\n    assert(isSimplePower((128l), (4l)) == (false));\n    assert(isSimplePower((12l), (6l)) == (false));\n    assert(isSimplePower((1l), (1l)) == (true));\n    assert(isSimplePower((1l), (12l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an integer a and returns True \n    // if this ingeger is a cube of some integer number.\n    // Note: you may assume the input is always valid.\n    // Examples:\n    // >>> iscube((1l))\n    // (true)\n    // >>> iscube((2l))\n    // (false)\n    // >>> iscube((-1l))\n    // (true)\n    // >>> iscube((64l))\n    // (true)\n    // >>> iscube((0l))\n    // (true)\n    // >>> iscube((180l))\n    // (false)\n    def iscube(a : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(iscube((1l)) == (true));\n    assert(iscube((2l)) == (false));\n    assert(iscube((-1l)) == (true));\n    assert(iscube((64l)) == (true));\n    assert(iscube((180l)) == (false));\n    assert(iscube((1000l)) == (true));\n    assert(iscube((0l)) == (true));\n    assert(iscube((1729l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You have been tasked to write a function that receives \n    // a hexadecimal number as a string and counts the number of hexadecimal \n    // digits that are primes (prime number, or a prime, is a natural number \n    // greater than 1 that is not a product of two smaller natural numbers).\n    // Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n    // Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n    // So you have to determine a number of the following digits: 2, 3, 5, 7, \n    // B (=decimal 11), D (=decimal 13).\n    // Note: you may assume the input is always correct or empty string, \n    // and symbols A,B,C,D,E,F are always uppercase.\n    // Examples:\n    // >>> hexKey((\"AB\"))\n    // (1l)\n    // >>> hexKey((\"1077E\"))\n    // (2l)\n    // >>> hexKey((\"ABED1A33\"))\n    // (4l)\n    // >>> hexKey((\"123456789ABCDEF0\"))\n    // (6l)\n    // >>> hexKey((\"2020\"))\n    // (2l)\n    def hexKey(num : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexKey((\"AB\")) == (1l));\n    assert(hexKey((\"1077E\")) == (2l));\n    assert(hexKey((\"ABED1A33\")) == (4l));\n    assert(hexKey((\"2020\")) == (2l));\n    assert(hexKey((\"123456789ABCDEF0\")) == (6l));\n    assert(hexKey((\"112233445566778899AABBCCDDEEFF00\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You will be given a number in decimal form and your task is to convert it to\n    // binary format. The function should return a string, with each character representing a binary\n    // number. Each character in the string will be '0' or '1'.\n    // There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n    // The extra characters are there to help with the format.\n    // Examples:\n    // >>> decimalToBinary((15l))\n    // (\"db1111db\")\n    // >>> decimalToBinary((32l))\n    // (\"db100000db\")\n    def decimalToBinary(decimal : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((0l)).equals((\"db0db\")));\n    assert(decimalToBinary((32l)).equals((\"db100000db\")));\n    assert(decimalToBinary((103l)).equals((\"db1100111db\")));\n    assert(decimalToBinary((15l)).equals((\"db1111db\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Filter an input list of strings only for ones that contain given substring\n    // >>> filterBySubstring((List[String]()), (\"a\"))\n    // (List[String]())\n    // >>> filterBySubstring((List[String](\"abc\", \"bacd\", \"cde\", \"array\")), (\"a\"))\n    // (List[String](\"abc\", \"bacd\", \"array\"))\n    def filterBySubstring(strings : List[String], substring : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterBySubstring((List[String]()), (\"john\")).equals((List[String]())));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xxx\")).equals((List[String](\"xxx\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\")), (\"xx\")).equals((List[String](\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"))));\n    assert(filterBySubstring((List[String](\"grunt\", \"trumpet\", \"prune\", \"gruesome\")), (\"run\")).equals((List[String](\"grunt\", \"prune\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a string s.\n    // Your task is to check if the string is happy or not.\n    // A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n    // For example:\n    // >>> isHappy((\"a\"))\n    // (false)\n    // >>> isHappy((\"aa\"))\n    // (false)\n    // >>> isHappy((\"abcd\"))\n    // (true)\n    // >>> isHappy((\"aabb\"))\n    // (false)\n    // >>> isHappy((\"adb\"))\n    // (true)\n    // >>> isHappy((\"xyy\"))\n    // (false)\n    def isHappy(s : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isHappy((\"a\")) == (false));\n    assert(isHappy((\"aa\")) == (false));\n    assert(isHappy((\"abcd\")) == (true));\n    assert(isHappy((\"aabb\")) == (false));\n    assert(isHappy((\"adb\")) == (true));\n    assert(isHappy((\"xyy\")) == (false));\n    assert(isHappy((\"iopaxpoi\")) == (true));\n    assert(isHappy((\"iopaxioi\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // It is the last week of the semester and the teacher has to give the grades\n    // to students. The teacher has been making her own algorithm for grading.\n    // The only problem is, she has lost the code she used for grading.\n    // She has given you a list of GPAs for some students and you have to write \n    // a function that can output a list of letter grades using the following table:\n    // GPA       |    Letter grade\n    // 4.0                A+\n    // > 3.7                A \n    // > 3.3                A- \n    // > 3.0                B+\n    // > 2.7                B \n    // > 2.3                B-\n    // > 2.0                C+\n    // > 1.7                C\n    // > 1.3                C-\n    // > 1.0                D+ \n    // > 0.7                D \n    // > 0.0                D-\n    // 0.0                E\n    // Example:\n    // >>> gradeEquation((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat)))\n    // (List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))\n    def numericalLetterGrade(grades : List[Float]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numericalLetterGrade((List[Float](4.0f.toFloat, 3l.toFloat, 1.7f.toFloat, 2l.toFloat, 3.5f.toFloat))).equals((List[String](\"A+\", \"B\", \"C-\", \"C\", \"A-\"))));\n    assert(numericalLetterGrade((List[Float](1.2f.toFloat))).equals((List[String](\"D+\"))));\n    assert(numericalLetterGrade((List[Float](0.5f.toFloat))).equals((List[String](\"D-\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat))).equals((List[String](\"E\"))));\n    assert(numericalLetterGrade((List[Float](1.0f.toFloat, 0.3f.toFloat, 1.5f.toFloat, 2.8f.toFloat, 3.3f.toFloat))).equals((List[String](\"D\", \"D-\", \"C-\", \"B\", \"B+\"))));\n    assert(numericalLetterGrade((List[Float](0.0f.toFloat, 0.7f.toFloat))).equals((List[String](\"E\", \"D-\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns True if the string\n    // length is a prime number or False otherwise\n    // Examples\n    // >>> primeLength((\"Hello\"))\n    // (true)\n    // >>> primeLength((\"abcdcba\"))\n    // (true)\n    // >>> primeLength((\"kittens\"))\n    // (true)\n    // >>> primeLength((\"orange\"))\n    // (false)\n    def primeLength(string : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeLength((\"Hello\")) == (true));\n    assert(primeLength((\"abcdcba\")) == (true));\n    assert(primeLength((\"kittens\")) == (true));\n    assert(primeLength((\"orange\")) == (false));\n    assert(primeLength((\"wow\")) == (true));\n    assert(primeLength((\"world\")) == (true));\n    assert(primeLength((\"MadaM\")) == (true));\n    assert(primeLength((\"Wow\")) == (true));\n    assert(primeLength((\"\")) == (false));\n    assert(primeLength((\"HI\")) == (true));\n    assert(primeLength((\"go\")) == (true));\n    assert(primeLength((\"gogo\")) == (false));\n    assert(primeLength((\"aaaaaaaaaaaaaaa\")) == (false));\n    assert(primeLength((\"Madam\")) == (true));\n    assert(primeLength((\"M\")) == (false));\n    assert(primeLength((\"0\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer n, return the count of the numbers of n-digit\n    // positive integers that start or end with 1.\n    def startsOneEnds(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startsOneEnds((1l)) == (1l));\n    assert(startsOneEnds((2l)) == (18l));\n    assert(startsOneEnds((3l)) == (180l));\n    assert(startsOneEnds((4l)) == (1800l));\n    assert(startsOneEnds((5l)) == (18000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a positive integer N, return the total sum of its digits in binary.\n    // Example\n    // >>> solve((1000l))\n    // (\"1\")\n    // >>> solve((150l))\n    // (\"110\")\n    // >>> solve((147l))\n    // (\"1100\")\n    // Variables:\n    // @N integer\n    // Constraints: 0 \u2264 N \u2264 10000.\n    // Output:\n    // a string of binary number\n    def solve(N : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(solve((1000l)).equals((\"1\")));\n    assert(solve((150l)).equals((\"110\")));\n    assert(solve((147l)).equals((\"1100\")));\n    assert(solve((333l)).equals((\"1001\")));\n    assert(solve((963l)).equals((\"10010\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a non-empty list of integers lst. add the even elements that are at odd indices..\n    // Examples:\n    // >>> add((List[Long](4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong)))\n    // (2l)\n    def add(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(add((List[Long](4l.toLong, 88l.toLong))) == (88l));\n    assert(add((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 2l.toLong, 122l.toLong))) == (122l));\n    assert(add((List[Long](4l.toLong, 0l.toLong, 6l.toLong, 7l.toLong))) == (0l));\n    assert(add((List[Long](4l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a string and returns an ordered version of it.\n    // Ordered version of string, is a string where all words (separated by space)\n    // are replaced by a new word where all the characters arranged in\n    // ascending order based on ascii value.\n    // Note: You should keep the order of words and blank spaces in the sentence.\n    // For example:\n    // >>> antiShuffle((\"Hi\"))\n    // (\"Hi\")\n    // >>> antiShuffle((\"hello\"))\n    // (\"ehllo\")\n    // >>> antiShuffle((\"Hello World!!!\"))\n    // (\"Hello !!!Wdlor\")\n    def antiShuffle(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(antiShuffle((\"Hi\")).equals((\"Hi\")));\n    assert(antiShuffle((\"hello\")).equals((\"ehllo\")));\n    assert(antiShuffle((\"number\")).equals((\"bemnru\")));\n    assert(antiShuffle((\"abcd\")).equals((\"abcd\")));\n    assert(antiShuffle((\"Hello World!!!\")).equals((\"Hello !!!Wdlor\")));\n    assert(antiShuffle((\"\")).equals((\"\")));\n    assert(antiShuffle((\"Hi. My name is Mister Robot. How are you?\")).equals((\".Hi My aemn is Meirst .Rboot How aer ?ouy\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a 2 dimensional data, as a nested lists,\n    // which is similar to matrix, however, unlike matrices,\n    // each row may contain a different number of columns.\n    // Given lst, and integer x, find integers x in the list,\n    // and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n    // each tuple is a coordinate - (row, columns), starting with 0.\n    // Sort coordinates initially by rows in ascending order.\n    // Also, sort coordinates of the row by columns in descending order.\n    // Examples:\n    // >>> getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l))\n    // (List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))\n    // >>> getRow((List[List[Long]]()), (1l))\n    // (List[Tuple2[Long, Long]]())\n    // >>> getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l))\n    // (List[Tuple2[Long, Long]]((2l, 2l)))\n    def getRow(lst : List[List[Long]], x : Long) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 4l), (1l, 0l), (2l, 5l), (2l, 0l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]((0l, 1l), (1l, 1l), (2l, 1l), (3l, 1l), (4l, 1l), (5l, 1l)))));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 5l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong, 6l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))), (1l)).equals((List[Tuple2[Long, Long]]((0l, 0l), (1l, 0l), (2l, 1l), (2l, 0l), (3l, 2l), (3l, 0l), (4l, 3l), (4l, 0l), (5l, 4l), (5l, 0l), (6l, 5l), (6l, 0l)))));\n    assert(getRow((List[List[Long]]()), (1l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](1l.toLong))), (2l)).equals((List[Tuple2[Long, Long]]())));\n    assert(getRow((List[List[Long]](List[Long](), List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong))), (3l)).equals((List[Tuple2[Long, Long]]((2l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given an array of non-negative integers, return a copy of the given array after sorting,\n    // you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n    // or sort it in descending order if the sum( first index value, last index value) is even.\n    // Note:\n    // * don't change the given array.\n    // Examples:\n    // >>> sortArray((List[Long]()))\n    // (List[Long]())\n    // >>> sortArray((List[Long](5l.toLong)))\n    // (List[Long](5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong)))\n    // (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))\n    // >>> sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong)))\n    // (List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))\n    def sortArray(array : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortArray((List[Long]())).equals((List[Long]())));\n    assert(sortArray((List[Long](5l.toLong))).equals((List[Long](5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 0l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 0l.toLong))));\n    assert(sortArray((List[Long](2l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 2l.toLong))));\n    assert(sortArray((List[Long](15l.toLong, 42l.toLong, 87l.toLong, 32l.toLong, 11l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 11l.toLong, 15l.toLong, 32l.toLong, 42l.toLong, 87l.toLong))));\n    assert(sortArray((List[Long](21l.toLong, 14l.toLong, 23l.toLong, 11l.toLong))).equals((List[Long](23l.toLong, 21l.toLong, 14l.toLong, 11l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function encrypt that takes a string as an argument and\n    // returns a string encrypted with the alphabet being rotated. \n    // The alphabet should be rotated in a manner such that the letters \n    // shift down by two multiplied to two places.\n    // For example:\n    // >>> encrypt((\"hi\"))\n    // (\"lm\")\n    // >>> encrypt((\"asdfghjkl\"))\n    // (\"ewhjklnop\")\n    // >>> encrypt((\"gf\"))\n    // (\"kj\")\n    // >>> encrypt((\"et\"))\n    // (\"ix\")\n    def encrypt(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encrypt((\"hi\")).equals((\"lm\")));\n    assert(encrypt((\"asdfghjkl\")).equals((\"ewhjklnop\")));\n    assert(encrypt((\"gf\")).equals((\"kj\")));\n    assert(encrypt((\"et\")).equals((\"ix\")));\n    assert(encrypt((\"faewfawefaewg\")).equals((\"jeiajeaijeiak\")));\n    assert(encrypt((\"hellomyfriend\")).equals((\"lippsqcjvmirh\")));\n    assert(encrypt((\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\")).equals((\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")));\n    assert(encrypt((\"a\")).equals((\"e\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n    // Empty sum should be equal to 0 and empty product should be equal to 1.\n    // >>> sumProduct((List[Long]()))\n    // ((0l, 1l))\n    // >>> sumProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))\n    // ((10l, 24l))\n    def sumProduct(numbers : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumProduct((List[Long]())).equals(((0l, 1l))));\n    assert(sumProduct((List[Long](1l.toLong, 1l.toLong, 1l.toLong))).equals(((3l, 1l))));\n    assert(sumProduct((List[Long](100l.toLong, 0l.toLong))).equals(((100l, 0l))));\n    assert(sumProduct((List[Long](3l.toLong, 5l.toLong, 7l.toLong))).equals(((15l, 105l))));\n    assert(sumProduct((List[Long](10l.toLong))).equals(((10l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // Write a function next_smallest() that returns the 2nd smallest element of the list.\n    // Return None if there is no such element.\n    // >>> nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))\n    // Some(2l)\n    // >>> nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong)))\n    // Some(2l)\n    // >>> nextSmallest((List[Long]()))\n    // None\n    // >>> nextSmallest((List[Long](1l.toLong, 1l.toLong)))\n    // None\n    def nextSmallest(lst : List[Long]) : Option[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallest((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long](5l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 2l.toLong))).equals(Some(2l)));\n    assert(nextSmallest((List[Long]())).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong))).equals(Some(1l)));\n    assert(nextSmallest((List[Long](1l.toLong, 1l.toLong))).equals(None));\n    assert(nextSmallest((List[Long](-35l.toLong, 34l.toLong, 12l.toLong, -45l.toLong))).equals(Some(-35l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You'll be given a string of words, and your task is to count the number\n    // of boredoms. A boredom is a sentence that starts with the word \"I\".\n    // Sentences are delimited by '.', '?' or '!'.\n    // For example:\n    // >>> isBored((\"Hello world\"))\n    // (0l)\n    // >>> isBored((\"The sky is blue. The sun is shining. I love this weather\"))\n    // (1l)\n    def isBored(S : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isBored((\"Hello world\")) == (0l));\n    assert(isBored((\"Is the sky blue?\")) == (0l));\n    assert(isBored((\"I love It !\")) == (1l));\n    assert(isBored((\"bIt\")) == (0l));\n    assert(isBored((\"I feel good today. I will be productive. will kill It\")) == (2l));\n    assert(isBored((\"You and I are going for a walk\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes 3 numbers.\n    // Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n    // Returns false in any other cases.\n    // Examples\n    // >>> anyInt(5l, 2l, 7l)\n    // (true)\n    // >>> anyInt(3l, 2l, 2l)\n    // (false)\n    // >>> anyInt(3l, -2l, 1l)\n    // (true)\n    // >>> anyInt((3.6f), (-2.2f), 2l)\n    // (false)\n    def anyInt(x : Float, y : Float, z : Float) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(anyInt(2l, 3l, 1l) == (true));\n    assert(anyInt((2.5f), 2l, 3l) == (false));\n    assert(anyInt((1.5f), 5l, (3.5f)) == (false));\n    assert(anyInt(2l, 6l, 2l) == (false));\n    assert(anyInt(4l, 2l, 2l) == (true));\n    assert(anyInt((2.2f), (2.2f), (2.2f)) == (false));\n    assert(anyInt(-4l, 6l, 2l) == (true));\n    assert(anyInt(2l, 1l, 1l) == (true));\n    assert(anyInt(3l, 4l, 7l) == (true));\n    assert(anyInt((3.0f), 4l, 7l) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a message, and encodes in such a \n    // way that it swaps case of all letters, replaces all vowels in \n    // the message with the letter that appears 2 places ahead of that \n    // vowel in the english alphabet. \n    // Assume only letters. \n    // Examples:\n    // >>> encode((\"test\"))\n    // (\"TGST\")\n    // >>> encode((\"This is a message\"))\n    // (\"tHKS KS C MGSSCGG\")\n    def encode(message : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(encode((\"TEST\")).equals((\"tgst\")));\n    assert(encode((\"Mudasir\")).equals((\"mWDCSKR\")));\n    assert(encode((\"YES\")).equals((\"ygs\")));\n    assert(encode((\"This is a message\")).equals((\"tHKS KS C MGSSCGG\")));\n    assert(encode((\"I DoNt KnOw WhAt tO WrItE\")).equals((\"k dQnT kNqW wHcT Tq wRkTg\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // You are given a list of integers.\n    // You need to find the largest prime value and return the sum of its digits.\n    // Examples:\n    // >>> skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong)))\n    // (10l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong)))\n    // (25l)\n    // >>> skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong)))\n    // (13l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong)))\n    // (11l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong)))\n    // (3l)\n    // >>> skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong)))\n    // (7l)\n    def skjkasdkd(lst : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(skjkasdkd((List[Long](0l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 2l.toLong, 181l.toLong, 32l.toLong, 4l.toLong, 32l.toLong, 3l.toLong, 2l.toLong, 32l.toLong, 324l.toLong, 4l.toLong, 3l.toLong))) == (10l));\n    assert(skjkasdkd((List[Long](1l.toLong, 0l.toLong, 1l.toLong, 8l.toLong, 2l.toLong, 4597l.toLong, 2l.toLong, 1l.toLong, 3l.toLong, 40l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (25l));\n    assert(skjkasdkd((List[Long](1l.toLong, 3l.toLong, 1l.toLong, 32l.toLong, 5107l.toLong, 34l.toLong, 83278l.toLong, 109l.toLong, 163l.toLong, 23l.toLong, 2323l.toLong, 32l.toLong, 30l.toLong, 1l.toLong, 9l.toLong, 3l.toLong))) == (13l));\n    assert(skjkasdkd((List[Long](0l.toLong, 724l.toLong, 32l.toLong, 71l.toLong, 99l.toLong, 32l.toLong, 6l.toLong, 0l.toLong, 5l.toLong, 91l.toLong, 83l.toLong, 0l.toLong, 5l.toLong, 6l.toLong))) == (11l));\n    assert(skjkasdkd((List[Long](0l.toLong, 81l.toLong, 12l.toLong, 3l.toLong, 1l.toLong, 21l.toLong))) == (3l));\n    assert(skjkasdkd((List[Long](0l.toLong, 8l.toLong, 1l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))) == (7l));\n    assert(skjkasdkd((List[Long](8191l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](8191l.toLong, 123456l.toLong, 127l.toLong, 7l.toLong))) == (19l));\n    assert(skjkasdkd((List[Long](127l.toLong, 97l.toLong, 8192l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a dictionary, return True if all keys are strings in lower \n    // case or all keys are strings in upper case, else return False.\n    // The function should return False is the given dictionary is empty.\n    // Examples:\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"b\" -> \"banana\")))\n    // (true)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", \"A\" -> \"banana\", \"B\" -> \"banana\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"a\" -> \"apple\", 8l -> \"banana\", \"a\" -> \"apple\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\")))\n    // (false)\n    // >>> checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\")))\n    // (true)\n    def checkDictCase(dict : Map[String,String]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"b\" -> \"banana\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"A\" -> \"banana\", \"B\" -> \"banana\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"p\" -> \"pineapple\", \"5\" -> \"banana\", \"a\" -> \"apple\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"Name\" -> \"John\", \"Age\" -> \"36\", \"City\" -> \"Houston\"))) == (false));\n    assert(checkDictCase((Map[String,String](\"STATE\" -> \"NC\", \"ZIP\" -> \"12345\"))) == (true));\n    assert(checkDictCase((Map[String,String](\"fruit\" -> \"Orange\", \"taste\" -> \"Sweet\"))) == (true));\n    assert(checkDictCase((Map[String,String]())) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Implement a function that takes an non-negative integer and returns an array of the first n\n    // integers that are prime numbers and less than n.\n    // for example:\n    // >>> countUpTo((5l))\n    // (List[Long](2l.toLong, 3l.toLong))\n    // >>> countUpTo((11l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))\n    // >>> countUpTo((0l))\n    // (List[Long]())\n    // >>> countUpTo((20l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))\n    // >>> countUpTo((1l))\n    // (List[Long]())\n    // >>> countUpTo((18l))\n    // (List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))\n    def countUpTo(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpTo((5l)).equals((List[Long](2l.toLong, 3l.toLong))));\n    assert(countUpTo((6l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((7l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong))));\n    assert(countUpTo((10l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(countUpTo((0l)).equals((List[Long]())));\n    assert(countUpTo((22l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong))));\n    assert(countUpTo((1l)).equals((List[Long]())));\n    assert(countUpTo((18l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong))));\n    assert(countUpTo((47l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    assert(countUpTo((101l)).equals((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 19l.toLong, 23l.toLong, 29l.toLong, 31l.toLong, 37l.toLong, 41l.toLong, 43l.toLong, 47l.toLong, 53l.toLong, 59l.toLong, 61l.toLong, 67l.toLong, 71l.toLong, 73l.toLong, 79l.toLong, 83l.toLong, 89l.toLong, 97l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Complete the function that takes two integers and returns \n    // the product of their unit digits.\n    // Assume the input is always valid.\n    // Examples:\n    // >>> multiply((148l), (412l))\n    // (16l)\n    // >>> multiply((19l), (28l))\n    // (72l)\n    // >>> multiply((2020l), (1851l))\n    // (0l)\n    // >>> multiply((14l), (-15l))\n    // (20l)\n    def multiply(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiply((148l), (412l)) == (16l));\n    assert(multiply((19l), (28l)) == (72l));\n    assert(multiply((2020l), (1851l)) == (0l));\n    assert(multiply((14l), (-15l)) == (20l));\n    assert(multiply((76l), (67l)) == (42l));\n    assert(multiply((17l), (27l)) == (49l));\n    assert(multiply((0l), (1l)) == (0l));\n    assert(multiply((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a string s, count the number of uppercase vowels in even indices.\n    // For example:\n    // >>> countUpper((\"aBCdEf\"))\n    // (1l)\n    // >>> countUpper((\"abcdefg\"))\n    // (0l)\n    // >>> countUpper((\"dBBE\"))\n    // (0l)\n    def countUpper(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countUpper((\"aBCdEf\")) == (1l));\n    assert(countUpper((\"abcdefg\")) == (0l));\n    assert(countUpper((\"dBBE\")) == (0l));\n    assert(countUpper((\"B\")) == (0l));\n    assert(countUpper((\"U\")) == (1l));\n    assert(countUpper((\"\")) == (0l));\n    assert(countUpper((\"EEEE\")) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Create a function that takes a value (string) representing a number\n    // and returns the closest integer to it. If the number is equidistant\n    // from two integers, round it away from zero.\n    // Examples\n    // >>> closestInteger((\"10\"))\n    // (10l)\n    // >>> closestInteger((\"15.3\"))\n    // (15l)\n    // Note:\n    // Rounding away from zero means that if the given number is equidistant\n    // from two integers, the one you should return is the one that is the\n    // farthest from zero. For example closest_integer(\"14.5\") should\n    // return 15 and closest_integer(\"-14.5\") should return -15.\n    def closestInteger(value : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestInteger((\"10\")) == (10l));\n    assert(closestInteger((\"14.5\")) == (15l));\n    assert(closestInteger((\"-15.5\")) == (-16l));\n    assert(closestInteger((\"15.3\")) == (15l));\n    assert(closestInteger((\"0\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // From a given list of integers, generate a list of rolling maximum element found until given moment\n    // in the sequence.\n    // >>> rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong)))\n    // (List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))\n    def rollingMax(numbers : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rollingMax((List[Long]())).equals((List[Long]())));\n    assert(rollingMax((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong))));\n    assert(rollingMax((List[Long](3l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 3l.toLong, 3l.toLong, 100l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/humaneval-sh-keep.json
+++ b/prompts/humaneval-sh-keep.json
@@ -1,1008 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\n#\n# $1 is an integer\niscube() {\n",
+    "prompt": "#!/bin/bash\n# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\n#\n# $1 is a space-separated list\n# $2 is a floating point\nhas_close_elements() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\n#\n# $1 is a string\nencode() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\n#\n# $1 is a space-separated list\nsolution() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\n#\n# $1 is an integer\nstring_sequence() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\n#\n# $1 is a string\nis_bored() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n#\n# $1 is an integer\nget_odd_collatz() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\n#\n# $1 is a string\nis_happy() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n#\n# $1 is a string\nfile_name_check() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\n#\n# $1 is a string\nhistogram() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n#\n# $1 is a string\n# $2 is a string\nreverse_delete() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    reverse_delete \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\" \"ae\") = \"bcd false\" ]]\n    [[ $(candidate \"abcdef\" \"b\") = \"acdef false\" ]]\n    [[ $(candidate \"abcdedcba\" \"ab\") = \"cdedc true\" ]]\n    [[ $(candidate \"dwik\" \"w\") = \"dik false\" ]]\n    [[ $(candidate \"a\" \"a\") = \" true\" ]]\n    [[ $(candidate \"abcdedcba\" \"\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"abcdedcba\" \"v\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"vabba\" \"v\") = \"abba true\" ]]\n    [[ $(candidate \"mamma\" \"mia\") = \" true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\n#\n# $1 is a space-separated list\nsum_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\n#\n# $1 is a string\nall_prefixes() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\n#\n# $1 is an integer\ndigits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\n#\n# $1 is a string\nstrlen() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\n#\n# $1 is an integer\nfibfib() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n#\n# $1 is a string\nwords_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\n#\n# $1 is a space-separated list\nmonotonic() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\n#\n# $1 is a floating point\ntruncate_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n#\n# $1 is a string\nparse_music() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\n#\n# $1 is a string\nremove_vowels() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\n#\n# $1 is a space-separated list\nsort_third() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\n#\n# $1 is an integer\ncount_up_to() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\n#\n# $1 is a space-separated list\nmax_element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\n#\n# $1 is a space-separated list\nunique() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\n#\n# $1 is an integer\nf() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\n#\n# $1 is a string\nencrypt() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\n#\n# $1 is a space-separated list\nsort_even() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 123 1 -10\") = \"-10 3 -5 2 -3 3 5 0 9 1 123\" ]]\n    [[ $(candidate \"5 8 -12 4 23 2 3 11 12 -10\") = \"-12 8 3 4 5 2 12 11 23 -10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\n#\n# $1 is a string\n# $2 is a string\nsame_chars() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    same_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") = \"true\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabc\") = \"true\" ]]\n    [[ $(candidate \"dddddddabc\" \"abcd\") = \"true\" ]]\n    [[ $(candidate \"eabcd\" \"dddddddabc\") = \"false\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabcf\") = \"false\" ]]\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") = \"false\" ]]\n    [[ $(candidate \"aabb\" \"aaccc\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\n#\n# $1 is a string\ncount_upper() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\n#\n# $1 is a space-separated list\nrolling_max() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\n#\n# $1 is a space-separated list\nadd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\n#\n# $1 is an integer\ntri() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    has_close_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.3\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.05\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.95\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.8\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\" \"0.1\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"1.0\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"0.5\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1012,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> make_a_pile(3)\n# [3, 5, 7]\n#\n# $1 is an integer\nmake_a_pile() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    make_a_pile \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"3 5 7\" ]]\n    [[ $(candidate \"4\") = \"4 6 8 10\" ]]\n    [[ $(candidate \"5\") = \"5 7 9 11 13\" ]]\n    [[ $(candidate \"6\") = \"6 8 10 12 14 16\" ]]\n    [[ $(candidate \"8\") = \"8 10 12 14 16 18 20 22\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1020,829 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
+    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n# words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\n#\n# $1 is a string\nwords_string() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\n#\n# $1 is a string\nis_palindrome() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\n#\n# $1 is an integer\nfactorize() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\n#\n# $1 is a string\nsort_numbers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\n#\n# $1 is a string\nflip_case() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\n#\n# $1 is a string\nis_nested() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\n#\n# $1 is a space-separated list\nby_length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\n#\n# $1 is an integer\nsum_to_n() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\n#\n# $1 is a space-separated list\nconcatenate() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n#\n# $1 is a space-separated list\nsort_array() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 2 3 4\") = \"1 2 4 3 5\" ]]\n    [[ $(candidate \"-2 -3 -4 -5 -6\") = \"-4 -2 -6 -5 -3\" ]]\n    [[ $(candidate \"1 0 2 3 4\") = \"0 1 2 4 3\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"2 5 77 4 5 3 5 7 2 3 4\") = \"2 2 4 4 3 3 5 5 5 7 77\" ]]\n    [[ $(candidate \"3 6 44 12 32 5\") = \"32 3 5 6 12 44\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\n#\n# $1 is a space-separated list\nlongest() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n#\n# $1 is a space-separated list\nis_sorted() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\n#\n# $1 is an integer\neven_odd_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\n#\n# $1 is a space-separated list\nderivative() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n#\n# $1 is a string\nanti_shuffle() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\n#\n# $1 is a string\nmake_palindrome() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\n#\n# $1 is a string\nprime_length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\n#\n# $1 is a space-separated list\nsearch() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\n#\n# $1 is an integer\nfizz_buzz() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\n#\n# $1 is a string\nparse_nested_parens() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n#\n# $1 is a space-separated list\nsort_array() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\n#\n# $1 is a string\nvowels_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n#\n# $1 is a string\nstring_to_md5() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\n#\n# $1 is an integer\nis_prime() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\n#\n# $1 is a string\nhex_key() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\n#\n# $1 is a space-separated list\nmedian() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\n#\n# $1 is a space-separated list\nspecialFilter() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    specialFilter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 -2 1 -5\") = \"0\" ]]\n    [[ $(candidate \"15 -73 14 -15\") = \"1\" ]]\n    [[ $(candidate \"33 -2 -3 45 21 109\") = \"2\" ]]\n    [[ $(candidate \"43 -12 93 125 121 109\") = \"4\" ]]\n    [[ $(candidate \"71 -2 -33 75 21 19\") = \"3\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\n#\n# $1 is an integer\nprime_fib() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\n#\n# $1 is a string\nvalid_date() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\n#\n# $1 is a space-separated list\ncount_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\n#\n# $1 is a string\ndigitSum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\n#\n# $1 is a string\nsplit_words() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\n#\n# $1 is an integer\nfib4() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n# False\n# >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n# True\n#\n# $1 is a space-separated list\n# $2 is a floating point\nhas_close_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    has_close_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.3\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.05\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.95\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.8\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\" \"0.1\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"1.0\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"0.5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\n#\n# $1 is an integer\nlargest_divisor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\n#\n# $1 is a string\ncorrect_bracketing() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\n#\n# $1 is a string\ncorrect_bracketing() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"<>\") = \"true\" ]]\n    [[ $(candidate \"<<><>>\") = \"true\" ]]\n    [[ $(candidate \"<><><<><>><>\") = \"true\" ]]\n    [[ $(candidate \"<><><<<><><>><>><<><><<>>>\") = \"true\" ]]\n    [[ $(candidate \"<<<><>>>>\") = \"false\" ]]\n    [[ $(candidate \"><<>\") = \"false\" ]]\n    [[ $(candidate \"<\") = \"false\" ]]\n    [[ $(candidate \"<<<<\") = \"false\" ]]\n    [[ $(candidate \">\") = \"false\" ]]\n    [[ $(candidate \"<<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>><<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>>><>\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\n#\n# $1 is an integer\nfib() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\n#\n# $1 is a space-separated list\nprod_signs() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\n#\n# $1 is a space-separated list\nincr_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\n#\n# $1 is a space-separated list\nget_positive() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1852,7 +40,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# choose_num(12, 15) = 14\n# choose_num(13, 12) = -1\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1860,13 +48,781 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
+    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# rounded_avg(1, 5) => \"0b11\"\n# rounded_avg(7, 5) => -1\n# rounded_avg(10, 20) => \"0b1111\"\n# rounded_avg(20, 33) => \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> unique_digits([15, 33, 1422, 1])\n# [1, 15, 33]\n# >>> unique_digits([152, 323, 1422, 10])\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n# -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n# -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n# return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n# If the array is empty, return an empty array:\n# arr = []\n# return []\n# If the array has any strange number ignore it:\n# arr = [1, -1 , 55] \n# -> sort arr -> [-1, 1, 55]\n# -> reverse arr -> [55, 1, -1]\n# return = ['One']\n#\n# $1 is a space-separated list\nby_length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# f(5) == [1, 2, 6, 24, 15]\n#\n# $1 is an integer\nf() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Input: 3\n# Output: (1, 2)\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Input: 12\n# Output: (4, 6)\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> count_nums([]) == 0\n# >>> count_nums([-1, 11, -11]) == 1\n# >>> count_nums([1, 1, 2]) == 3\n#\n# $1 is a space-separated list\ncount_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# move_one_ball([3, 4, 5, 1, 2])==>True\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# move_one_ball([3, 5, 4, 1, 2])==>False\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> make_palindrome('')\n# ''\n# >>> make_palindrome('cat')\n# 'catac'\n# >>> make_palindrome('cata')\n# 'catac'\n#\n# $1 is a string\nmake_palindrome() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n# exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n# histogram('a b b a') == {'a': 2, 'b': 2}\n# histogram('a b c a b') == {'a': 2, 'b': 2}\n# histogram('b b b b a') == {'b': 4}\n# histogram('') == {}\n#\n# $1 is a string\nhistogram() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n# For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n# For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\n#\n# $1 is a string\n# $2 is a string\nreverse_delete() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    reverse_delete \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\" \"ae\") = \"bcd false\" ]]\n    [[ $(candidate \"abcdef\" \"b\") = \"acdef false\" ]]\n    [[ $(candidate \"abcdedcba\" \"ab\") = \"cdedc true\" ]]\n    [[ $(candidate \"dwik\" \"w\") = \"dik false\" ]]\n    [[ $(candidate \"a\" \"a\") = \" true\" ]]\n    [[ $(candidate \"abcdedcba\" \"\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"abcdedcba\" \"v\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"vabba\" \"v\") = \"abba true\" ]]\n    [[ $(candidate \"mamma\" \"mia\") = \" true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n# minSubArraySum([-1, -2, -3]) == -6\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Input: \n# grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n# bucket_capacity : 1\n# Output: 6\n# Example 2:\n# Input: \n# grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n# bucket_capacity : 2\n# Output: 5\n# Example 3:\n# Input: \n# grid : [[0,0,0], [0,0,0]]\n# bucket_capacity : 5\n# Output: 0\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n# >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n# >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\n#\n# $1 is a space-separated list\nsort_array() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 2 3 4\") = \"1 2 4 3 5\" ]]\n    [[ $(candidate \"-2 -3 -4 -5 -6\") = \"-4 -2 -6 -5 -3\" ]]\n    [[ $(candidate \"1 0 2 3 4\") = \"0 1 2 4 3\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"2 5 77 4 5 3 5 7 2 3 4\") = \"2 2 4 4 3 3 5 5 5 7 77\" ]]\n    [[ $(candidate \"3 6 44 12 32 5\") = \"32 3 5 6 12 44\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n# select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n# select_words(\"simple white space\", 2) ==> []\n# select_words(\"Hello world\", 4) ==> [\"world\"]\n# select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# get_closest_vowel(\"yogurt\") ==> \"u\"\n# get_closest_vowel(\"FULL\") ==> \"U\"\n# get_closest_vowel(\"quick\") ==> \"\"\n# get_closest_vowel(\"ab\") ==> \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# match_parens(['()(', ')']) == 'Yes'\n# match_parens([')', ')']) == 'No'\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> string_xor('010', '110')\n# '100'\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Input: arr = [-3, -4, 5], k = 3\n# Output: [-4, -3, 5]\n# Example 2:\n# Input: arr = [4, -4, 4], k = 2\n# Output: [4, 4]\n# Example 3:\n# Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n# Output: [2]\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# solution([5, 8, 7, 1]) ==> 12\n# solution([3, 3, 3, 3, 3]) ==> 9\n# solution([30, 13, 24, 321]) ==>0\n#\n# $1 is a space-separated list\nsolution() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n# Output: 24 # sum of 21 + 3\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n#\n# $1 is an integer\nget_odd_collatz() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# for example: \n# valid_date('03-11-2000') => True\n# valid_date('15-01-2012') => False\n# valid_date('04-0-2040') => False\n# valid_date('06-04-2020') => True\n# valid_date('06/04/2020') => False\n#\n# $1 is a string\nvalid_date() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n# split_words(\"abcdef\") == 3\n#\n# $1 is a string\nsplit_words() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# is_sorted([5]) \u279e True\n# is_sorted([1, 2, 3, 4, 5]) \u279e True\n# is_sorted([1, 3, 2, 4, 5]) \u279e False\n# is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n# is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n# is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n# is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n# is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\n#\n# $1 is a space-separated list\nis_sorted() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# intersection((1, 2), (2, 3)) ==> \"NO\"\n# intersection((-1, 1), (0, 4)) ==> \"NO\"\n# intersection((-3, -1), (-5, 5)) ==> \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> prod_signs([1, 2, 2, -4]) == -9\n# >>> prod_signs([0, 1]) == 0\n# >>> prod_signs([]) == None\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n# Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n# Output: [1, 2, 1]\n# Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n# Output: [1]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> longest([])\n# >>> longest(['a', 'b', 'c'])\n# 'a'\n# >>> longest(['a', 'bb', 'ccc'])\n# 'ccc'\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# tri(3) = [1, 3, 2, 8]\n#\n# $1 is an integer\ntri() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# digits(1)  == 1\n# digits(4)  == 0\n# digits(235) == 15\n#\n# $1 is an integer\ndigits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# is_nested('[[]]') \u279e True\n# is_nested('[]]]]]]][[[[[]') \u279e False\n# is_nested('[][]') \u279e False\n# is_nested('[]') \u279e False\n# is_nested('[[][]]') \u279e True\n# is_nested('[[]][[') \u279e True\n#\n# $1 is a string\nis_nested() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# For lst = [1,2,3] the output should be 14\n# For lst = [1,4,9] the output should be 98\n# For lst = [1,3,5,7] the output should be 84\n# For lst = [1.4,4.2,0] the output should be 29\n# For lst = [-2.4,1,1] the output should be 6\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n# check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n# check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n# check_if_last_char_is_a_letter(\"\") \u279e False\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# can_arrange([1,2,4,3,5]) = 3\n# can_arrange([1,2,3]) = -1\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n# largest_smallest_integers([]) == (None, None)\n# largest_smallest_integers([0]) == (None, None)\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# compare_one(1, 2.5) \u279e 2.5\n# compare_one(1, \"2,3\") \u279e \"2,3\"\n# compare_one(\"5,1\", \"6\") \u279e \"6\"\n# compare_one(\"1\", 1) \u279e None\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# is_equal_to_sum_even(4) == False\n# is_equal_to_sum_even(6) == False\n# is_equal_to_sum_even(8) == True\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> special_factorial(4)\n# 288\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> greatest_common_divisor(3, 5)\n# 1\n# >>> greatest_common_divisor(25, 15)\n# 5\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# fix_spaces(\"Example\") == \"Example\"\n# fix_spaces(\"Example 1\") == \"Example_1\"\n# fix_spaces(\" Example 2\") == \"_Example_2\"\n# fix_spaces(\" Example   3\") == \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# file_name_check(\"example.txt\") # => 'Yes'\n# file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\n#\n# $1 is a string\nfile_name_check() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# For lst = [1,2,3] the output should be 6\n# For lst = []  the output should be 0\n# For lst = [-1,-5,2,-1,-5]  the output should be -126\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Input: sentence = \"This is a test\"\n# Output: \"is\"\n# Example 2:\n# Input: sentence = \"lets go for swimming\"\n# Output: \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# simplify(\"1/5\", \"5/1\") = True\n# simplify(\"1/6\", \"2/1\") = False\n# simplify(\"7/10\", \"10/2\") = False\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n# >>> order_by_points([]) == []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# specialFilter([15, -73, 14, -15]) => 1 \n# specialFilter([33, -2, -3, 45, 21, 109]) => 2\n#\n# $1 is a space-separated list\nspecialFilter() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    specialFilter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 -2 1 -5\") = \"0\" ]]\n    [[ $(candidate \"15 -73 14 -15\") = \"1\" ]]\n    [[ $(candidate \"33 -2 -3 45 21 109\") = \"2\" ]]\n    [[ $(candidate \"43 -12 93 125 121 109\") = \"4\" ]]\n    [[ $(candidate \"71 -2 -33 75 21 19\") = \"3\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Input: n = 5\n# Output: 1\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n# bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n# bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n# assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> all_prefixes('abc')\n# ['a', 'ab', 'abc']\n#\n# $1 is a string\nall_prefixes() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# for x_or_y(7, 34, 12) == 34\n# for x_or_y(15, 8, 5) == 5\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n# double_the_difference([-1, -2, 0]) == 0\n# double_the_difference([9, -2]) == 81\n# double_the_difference([0]) == 0  \n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n# compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# cycpattern_check(\"abcd\",\"abd\") => False\n# cycpattern_check(\"hello\",\"ell\") => True\n# cycpattern_check(\"whassup\",\"psus\") => False\n# cycpattern_check(\"abab\",\"baa\") => True\n# cycpattern_check(\"efef\",\"eeff\") => False\n# cycpattern_check(\"himenss\",\"simen\") => True\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# even_odd_count(-12) ==> (1, 1)\n# even_odd_count(123) ==> (1, 2)\n#\n# $1 is an integer\neven_odd_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> int_to_mini_roman(19) == 'xix'\n# >>> int_to_mini_roman(152) == 'clii'\n# >>> int_to_mini_roman(426) == 'cdxxvi'\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# right_angle_triangle(3, 4, 5) == True\n# right_angle_triangle(1, 2, 3) == False\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# find_max([\"name\", \"of\", \"string\"]) == \"string\"\n# find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n# find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# * eat(5, 6, 10) -> [11, 4]\n# * eat(4, 8, 9) -> [12, 1]\n# * eat(1, 10, 10) -> [11, 0]\n# * eat(2, 11, 5) -> [7, 0]\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> string_sequence(0)\n# '0'\n# >>> string_sequence(5)\n# '0 1 2 3 4 5'\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# solve(\"1234\") = \"4321\"\n# solve(\"ab\") = \"AB\"\n# solve(\"#a@C\") = \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,7 +832,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# generate_integers(2, 8) => [2, 4, 6, 8]\n# generate_integers(8, 2) => [2, 4, 6, 8]\n# generate_integers(10, 14) => []\n#\n# $1 is an integer\n# $2 is an integer\ngenerate_integers() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    generate_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"10\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"10\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"132\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"17\" \"89\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1888,9 +844,1053 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> count_distinct_characters('xyzXYZ')\n# 3\n# >>> count_distinct_characters('Jerry')\n# 4\n#\n# $1 is a string\ncount_distinct_characters() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n# [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\n#\n# $1 is a string\nparse_music() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> how_many_times('', 'a')\n# 0\n# >>> how_many_times('aaa', 'a')\n# 3\n# >>> how_many_times('aaaa', 'aa')\n# 3\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> sort_numbers('three one five')\n# 'one three five'\n#\n# $1 is a string\nsort_numbers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> separate_paren_groups('( ) (( )) (( )( ))')\n# ['()', '(())', '(()())']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n# (2.0, 2.2)\n# >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n# (2.0, 2.0)\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n# [0.0, 0.25, 0.5, 0.75, 1.0]\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n# >>> filter_integers(['a', 3.14, 5])\n# [5]\n# >>> filter_integers([1, 2, 3, 'abc', {}, []])\n# [1, 2, 3]\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> strlen('')\n# 0\n# >>> strlen('abc')\n# 3\n#\n# $1 is a string\nstrlen() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> largest_divisor(15)\n# 5\n#\n# $1 is an integer\nlargest_divisor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> factorize(8)\n# [2, 2, 2]\n# >>> factorize(25)\n# [5, 5]\n# >>> factorize(70)\n# [2, 5, 7]\n#\n# $1 is an integer\nfactorize() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> remove_duplicates([1, 2, 3, 2, 4])\n# [1, 3, 4]\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> flip_case('Hello')\n# 'hELLO'\n#\n# $1 is a string\nflip_case() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> concatenate([])\n# ''\n# >>> concatenate(['a', 'b', 'c'])\n# 'abc'\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> truncate_number(3.5)\n# 0.5\n#\n# $1 is a floating point\ntruncate_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> get_positive([-1, 2, -4, 5, 6])\n# [2, 5, 6]\n# >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# [5, 3, 2, 3, 9, 123, 1]\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> is_prime(6)\n# False\n# >>> is_prime(101)\n# True\n# >>> is_prime(11)\n# True\n# >>> is_prime(13441)\n# True\n# >>> is_prime(61)\n# True\n# >>> is_prime(4)\n# False\n# >>> is_prime(1)\n# False\n#\n# $1 is an integer\nis_prime() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> sort_third([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n# [2, 6, 3, 4, 8, 9, 5]\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [0, 2, 3, 5, 9, 123]\n#\n# $1 is a space-separated list\nunique() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> max_element([1, 2, 3])\n# 3\n# >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n# 123\n#\n# $1 is a space-separated list\nmax_element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> fizz_buzz(50)\n# 0\n# >>> fizz_buzz(78)\n# 2\n# >>> fizz_buzz(79)\n# 3\n#\n# $1 is an integer\nfizz_buzz() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> sort_even([1, 2, 3])\n# [1, 2, 3]\n# >>> sort_even([5, 6, 3, 4])\n# [3, 6, 5, 4]\n#\n# $1 is a space-separated list\nsort_even() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 123 1 -10\") = \"-10 3 -5 2 -3 3 5 0 9 1 123\" ]]\n    [[ $(candidate \"5 8 -12 4 23 2 3 11 12 -10\") = \"-12 8 3 4 5 2 12 11 23 -10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> prime_fib(1)\n# 2\n# >>> prime_fib(2)\n# 3\n# >>> prime_fib(3)\n# 5\n# >>> prime_fib(4)\n# 13\n# >>> prime_fib(5)\n# 89\n#\n# $1 is an integer\nprime_fib() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> below_zero([1, 2, 3])\n# False\n# >>> below_zero([1, 2, -4, 5])\n# True\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> triples_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> triples_sum_to_zero([1, 3, -2, 1])\n# True\n# >>> triples_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n# True\n# >>> triples_sum_to_zero([1])\n# False\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> incr_list([1, 2, 3])\n# [2, 3, 4]\n# >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n# [6, 4, 6, 3, 4, 4, 10, 1, 124]\n#\n# $1 is a space-separated list\nincr_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> pairs_sum_to_zero([1, 3, 5, 0])\n# False\n# >>> pairs_sum_to_zero([1, 3, -2, 1])\n# False\n# >>> pairs_sum_to_zero([1, 2, 3, 7])\n# False\n# >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n# True\n# >>> pairs_sum_to_zero([1])\n# False\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> change_base(8, 3)\n# '22'\n# >>> change_base(8, 2)\n# '1000'\n# >>> change_base(7, 2)\n# '111'\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> triangle_area(5, 3)\n# 7.5\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> fib4(5)\n# 4\n# >>> fib4(6)\n# 8\n# >>> fib4(7)\n# 14\n#\n# $1 is an integer\nfib4() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> median([3, 1, 2, 4, 5])\n# 3\n# >>> median([-10, 4, 6, 1000, 10, 20])\n# 15.0\n#\n# $1 is a space-separated list\nmedian() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> is_palindrome('')\n# True\n# >>> is_palindrome('aba')\n# True\n# >>> is_palindrome('aaaaa')\n# True\n# >>> is_palindrome('zbcd')\n# False\n#\n# $1 is a string\nis_palindrome() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> modp(3, 5)\n# 3\n# >>> modp(1101, 101)\n# 2\n# >>> modp(0, 101)\n# 1\n# >>> modp(3, 11)\n# 8\n# >>> modp(100, 101)\n# 1\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n# 1.0\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> remove_vowels('')\n# ''\n# >>> remove_vowels('abcdef')\n# 'bcdf'\n# >>> remove_vowels('aaaaa')\n# ''\n# >>> remove_vowels('aaBAA')\n# 'B'\n# >>> remove_vowels('zbcd')\n# 'zbcd'\n#\n# $1 is a string\nremove_vowels() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n# >>> below_threshold([1, 2, 4, 10], 100)\n# True\n# >>> below_threshold([1, 20, 4, 10], 5)\n# False\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> add(2, 3)\n# 5\n# >>> add(5, 7)\n# 12\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Check if two words have the same characters.\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n# True\n# >>> same_chars('abcd', 'dddddddabc')\n# True\n# >>> same_chars('dddddddabc', 'abcd')\n# True\n# >>> same_chars('eabcd', 'dddddddabc')\n# False\n# >>> same_chars('abcd', 'dddddddabce')\n# False\n# >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n# False\n#\n# $1 is a string\n# $2 is a string\nsame_chars() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    same_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") = \"true\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabc\") = \"true\" ]]\n    [[ $(candidate \"dddddddabc\" \"abcd\") = \"true\" ]]\n    [[ $(candidate \"eabcd\" \"dddddddabc\") = \"false\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabcf\") = \"false\" ]]\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") = \"false\" ]]\n    [[ $(candidate \"aabb\" \"aaccc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> fib(10)\n# 55\n# >>> fib(1)\n# 1\n# >>> fib(8)\n# 21\n#\n# $1 is an integer\nfib() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"<\")\n# False\n# >>> correct_bracketing(\"<>\")\n# True\n# >>> correct_bracketing(\"<<><>>\")\n# True\n# >>> correct_bracketing(\"><<>\")\n# False\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"<>\") = \"true\" ]]\n    [[ $(candidate \"<<><>>\") = \"true\" ]]\n    [[ $(candidate \"<><><<><>><>\") = \"true\" ]]\n    [[ $(candidate \"<><><<<><><>><>><<><><<>>>\") = \"true\" ]]\n    [[ $(candidate \"<<<><>>>>\") = \"false\" ]]\n    [[ $(candidate \"><<>\") = \"false\" ]]\n    [[ $(candidate \"<\") = \"false\" ]]\n    [[ $(candidate \"<<<<\") = \"false\" ]]\n    [[ $(candidate \">\") = \"false\" ]]\n    [[ $(candidate \"<<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>><<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>>><>\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n# >>> monotonic([1, 2, 4, 20])\n# True\n# >>> monotonic([1, 20, 4, 10])\n# False\n# >>> monotonic([4, 1, 0, -10])\n# True\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n# [1, 5, 653]\n# >>> common([5, 3, 2, 8], [3, 2])\n# [2, 3]\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> largest_prime_factor(13195)\n# 29\n# >>> largest_prime_factor(2048)\n# 2\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> intersperse([], 4)\n# []\n# >>> intersperse([1, 2, 3], 4)\n# [1, 4, 2, 4, 3]\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> sum_to_n(30)\n# 465\n# >>> sum_to_n(100)\n# 5050\n# >>> sum_to_n(5)\n# 15\n# >>> sum_to_n(10)\n# 55\n# >>> sum_to_n(1)\n# 1\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> correct_bracketing(\"(\")\n# False\n# >>> correct_bracketing(\"()\")\n# True\n# >>> correct_bracketing(\"(()())\")\n# True\n# >>> correct_bracketing(\")(()\")\n# False\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> derivative([3, 1, 2, 4, 5])\n# [1, 4, 12, 20]\n# >>> derivative([1, 2, 3])\n# [2, 6]\n#\n# $1 is a space-separated list\nderivative() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> fibfib(1)\n# 0\n# >>> fibfib(5)\n# 4\n# >>> fibfib(8)\n# 24\n#\n# $1 is an integer\nfibfib() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> vowels_count(\"abcde\")\n# 2\n# >>> vowels_count(\"ACEDY\")\n# 3\n#\n# $1 is a string\nvowels_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> circular_shift(12, 1)\n# \"21\"\n# >>> circular_shift(12, 2)\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# digitSum(\"\") => 0\n# digitSum(\"abAB\") => 131\n# digitSum(\"abcCd\") => 67\n# digitSum(\"helloE\") => 69\n# digitSum(\"woArBld\") => 131\n# digitSum(\"aAaaaXa\") => 153\n#\n# $1 is a string\ndigitSum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n# fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n# fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n# fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Input: [4,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Input: [1,2,3]\n# Output: [2, 1]\n# Explanation: 2 has the smallest even value, and 2 has the smallest index. \n# Example 3:\n# Input: []\n# Output: []\n# Example 4:\n# Input: [5, 0, 3, 0, 4, 2]\n# Output: [0, 1]\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# search([4, 1, 2, 2, 3, 1]) == 2\n# search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n# search([5, 5, 4, 4, 4]) == -1\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> parse_nested_parens('(()()) ((())) () ((())()())')\n# [2, 3, 1, 3]\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n# strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n# strange_sort_list([]) == []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# triangle_area(3, 4, 5) == 6.00\n# triangle_area(1, 2, 10) == -1\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# will_it_fly([1, 2], 5) \u279e False \n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# will_it_fly([3, 2, 3], 1) \u279e False\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# will_it_fly([3, 2, 3], 9) \u279e True\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# will_it_fly([3], 5) \u279e True\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# smallest_change([1,2,3,5,4,7,9,6]) == 4\n# smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n# smallest_change([1, 2, 3, 2, 1]) == 0\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# total_match([], []) \u279e []\n# total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n# total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n# total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n# total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# is_multiply_prime(30) == True\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# is_simple_power(1, 4) => true\n# is_simple_power(2, 2) => true\n# is_simple_power(8, 2) => true\n# is_simple_power(3, 2) => false\n# is_simple_power(3, 1) => false\n# is_simple_power(5, 3) => false\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# iscube(1) ==> True\n# iscube(2) ==> False\n# iscube(-1) ==> True\n# iscube(64) ==> True\n# iscube(0) ==> True\n# iscube(180) ==> False\n#\n# $1 is an integer\niscube() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# For num = \"AB\" the output should be 1.\n# For num = \"1077E\" the output should be 2.\n# For num = \"ABED1A33\" the output should be 4.\n# For num = \"123456789ABCDEF0\" the output should be 6.\n# For num = \"2020\" the output should be 2.\n#\n# $1 is a string\nhex_key() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# decimal_to_binary(15)   # returns \"db1111db\"\n# decimal_to_binary(32)   # returns \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# is_happy(a) => False\n# is_happy(aa) => False\n# is_happy(abcd) => True\n# is_happy(aabb) => False\n# is_happy(adb) => True\n# is_happy(xyy) => False\n#\n# $1 is a string\nis_happy() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# prime_length('Hello') == True\n# prime_length('abcdcba') == True\n# prime_length('kittens') == True\n# prime_length('orange') == False\n#\n# $1 is a string\nprime_length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# For N = 1000, the sum of digits will be 1 the output should be \"1\".\n# For N = 150, the sum of digits will be 6 the output should be \"110\".\n# For N = 147, the sum of digits will be 12 the output should be \"1100\".\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# add([4, 2, 6, 7]) ==> 2\n#\n# $1 is a space-separated list\nadd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# anti_shuffle('Hi') returns 'Hi'\n# anti_shuffle('hello') returns 'ehllo'\n# anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\n#\n# $1 is a string\nanti_shuffle() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# get_row([\n# [1,2,3,4,5,6],\n# [1,2,3,4,1,6],\n# [1,2,3,4,5,1]\n# ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n# get_row([], 1) == []\n# get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# * sort_array([]) => []\n# * sort_array([5]) => [5]\n# * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n# * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\n#\n# $1 is a space-separated list\nsort_array() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# encrypt('hi') returns 'lm'\n# encrypt('asdfghjkl') returns 'ewhjklnop'\n# encrypt('gf') returns 'kj'\n# encrypt('et') returns 'ix'\n#\n# $1 is a string\nencrypt() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> sum_product([])\n# (0, 1)\n# >>> sum_product([1, 2, 3, 4])\n# (10, 24)\n#\n# $1 is a space-separated list\nsum_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# next_smallest([1, 2, 3, 4, 5]) == 2\n# next_smallest([5, 1, 4, 3, 2]) == 2\n# next_smallest([]) == None\n# next_smallest([1, 1]) == None\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> is_bored(\"Hello world\")\n# 0\n# >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n# 1\n#\n# $1 is a string\nis_bored() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# any_int(5, 2, 7) \u279e True\n# any_int(3, 2, 2) \u279e False\n# any_int(3, -2, 1) \u279e True\n# any_int(3.6, -2.2, 2) \u279e False\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> encode('test')\n# 'TGST'\n# >>> encode('This is a message')\n# 'tHKS KS C MGSSCGG'\n#\n# $1 is a string\nencode() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n# For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n# For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n# For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n# For lst = [0,81,12,3,1,21] the output should be 3\n# For lst = [0,8,1,2,1,7] the output should be 7\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n# check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n# check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n# check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n# check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# count_up_to(5) => [2,3]\n# count_up_to(11) => [2,3,5,7]\n# count_up_to(0) => []\n# count_up_to(20) => [2,3,5,7,11,13,17,19]\n# count_up_to(1) => []\n# count_up_to(18) => [2,3,5,7,11,13,17]\n#\n# $1 is an integer\ncount_up_to() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# multiply(148, 412) should return 16.\n# multiply(19, 28) should return 72.\n# multiply(2020, 1851) should return 0.\n# multiply(14,-15) should return 20.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# count_upper('aBCdEf') returns 1\n# count_upper('abcdefg') returns 0\n# count_upper('dBBE') returns 0\n#\n# $1 is a string\ncount_upper() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> closest_integer(\"10\")\n# 10\n# >>> closest_integer(\"15.3\")\n# 15\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n# [1, 2, 3, 3, 3, 4, 4]\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-sh-remove.json
+++ b/prompts/humaneval-sh-remove.json
@@ -1,1344 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return length of given string\n#\n# $1 is a string\nstrlen() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n#\n# $1 is a string\nencrypt() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n#\n# $1 is a space-separated list\nadd() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\n#\n# $1 is a string\nfix_spaces() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n#\n# $1 is an integer\nfibfib() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n#\n# $1 is a string\nparse_music() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n#\n# $1 is a string\nall_prefixes() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Add two numbers x and y\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n#\n# $1 is a string\nflip_case() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\n#\n# $1 is a space-separated list\nby_length() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n#\n# $1 is an integer\nfactorize() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n#\n# $1 is an integer\ncount_up_to() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n#\n# $1 is a space-separated list\nunique() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n#\n# $1 is a space-separated list\nmax_element() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n#\n# $1 is a string\nis_nested() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n#\n# $1 is a space-separated list\nderivative() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n#\n# $1 is a space-separated list\nis_sorted() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n#\n# $1 is a string\nsolve() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n#\n# $1 is an integer\ntri() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n#\n# $1 is an integer\nfizz_buzz() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n#\n# $1 is a string\ncount_upper() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n#\n# $1 is an integer\nlargest_divisor() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n#\n# $1 is a space-separated list\nsort_array() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n#\n# $1 is an integer\nf() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n#\n# $1 is an integer\niscube() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n#\n# $1 is a string\nencode() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n#\n# $1 is a string\nis_bored() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n#\n# $1 is an integer\ndigits() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n#\n# $1 is a string\nwords_string() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n#\n# $1 is a string\nremove_vowels() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n#\n# $1 is an integer\nprime_fib() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n#\n# $1 is a space-separated list\norder_by_points() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n#\n# $1 is a space-separated list\n# $2 is a floating point\nhas_close_elements() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    has_close_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.3\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.05\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.95\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.8\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\" \"0.1\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"1.0\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"0.5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n#\n# $1 is a string\nmake_palindrome() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n#\n# $1 is an integer\nfib4() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n#\n# $1 is a space-separated list\nunique_digits() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n#\n# $1 is an integer\nfib() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n#\n# $1 is a floating point\ntruncate_number() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n#\n# $1 is a space-separated list\nincr_list() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n#\n# $1 is an integer\neven_odd_count() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n#\n# $1 is a string\nis_happy() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n#\n# $1 is a string\ndigitSum() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n#\n# $1 is a space-separated list\nsolution() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n#\n# $1 is a space-separated list\nmedian() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n#\n# $1 is a string\nprime_length() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n#\n# $1 is a string\nfile_name_check() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n#\n# $1 is a string\nseparate_paren_groups() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n#\n# $1 is a string\nvalid_date() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n#\n# $1 is a space-separated list\ncount_nums() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n#\n# $1 is a string\nanti_shuffle() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n#\n# $1 is a string\nis_palindrome() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n#\n# $1 is a string\nget_closest_vowel() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n#\n# $1 is an integer\nis_prime() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n#\n# $1 is a string\nhex_key() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n#\n# $1 is a string\nhistogram() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n#\n# $1 is an integer\nget_odd_collatz() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n#\n# $1 is a string\nsort_numbers() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n#\n# $1 is a space-separated list\nsum_product() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n#\n# $1 is a string\ncount_distinct_characters() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1348,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n#\n# $1 is an integer\nmake_a_pile() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    make_a_pile \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"3 5 7\" ]]\n    [[ $(candidate \"4\") = \"4 6 8 10\" ]]\n    [[ $(candidate \"5\") = \"5 7 9 11 13\" ]]\n    [[ $(candidate \"6\") = \"6 8 10 12 14 16\" ]]\n    [[ $(candidate \"8\") = \"8 10 12 14 16 18 20 22\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1356,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n#\n# $1 is a string\nwords_string() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
+    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n#\n# $1 is a space-separated list\nunique_digits() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# If the array is empty, return an empty array:\n# If the array has any strange number ignore it:\n#\n# $1 is a space-separated list\nby_length() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n#\n# $1 is an integer\nf() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n#\n# $1 is a space-separated list\ncount_nums() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n#\n# $1 is a string\nmake_palindrome() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n#\n# $1 is a string\nhistogram() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1564,7 +172,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n#\n# $1 is a string\n# $2 is a string\nreverse_delete() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    reverse_delete \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\" \"ae\") = \"bcd false\" ]]\n    [[ $(candidate \"abcdef\" \"b\") = \"acdef false\" ]]\n    [[ $(candidate \"abcdedcba\" \"ab\") = \"cdedc true\" ]]\n    [[ $(candidate \"dwik\" \"w\") = \"dik false\" ]]\n    [[ $(candidate \"a\" \"a\") = \" true\" ]]\n    [[ $(candidate \"abcdedcba\" \"\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"abcdedcba\" \"v\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"vabba\" \"v\") = \"abba true\" ]]\n    [[ $(candidate \"mamma\" \"mia\") = \" true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1572,25 +180,25 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_115_max_fill",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n#\n# $1 is a string\nsplit_words() {\n",
+    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# Example 2:\n# Example 3:\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1600,7 +208,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n#\n# $1 is a space-separated list\nsort_array() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 2 3 4\") = \"1 2 4 3 5\" ]]\n    [[ $(candidate \"-2 -3 -4 -5 -6\") = \"-4 -2 -6 -5 -3\" ]]\n    [[ $(candidate \"1 0 2 3 4\") = \"0 1 2 4 3\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"2 5 77 4 5 3 5 7 2 3 4\") = \"2 2 4 4 3 3 5 5 5 7 77\" ]]\n    [[ $(candidate \"3 6 44 12 32 5\") = \"32 3 5 6 12 44\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1608,121 +216,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n#\n# $1 is a string\nget_closest_vowel() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_119_match_parens",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_11_string_xor",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n#\n# $1 is a string\nvowels_count() {\n",
+    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_120_maximum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# Example 2:\n# Example 3:\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_121_solution",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n#\n# $1 is a space-separated list\nsolution() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n#\n# $1 is an integer\nget_odd_collatz() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n#\n# $1 is a string\nvalid_date() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_125_split_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n#\n# $1 is a string\nsplit_words() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n#\n# $1 is a space-separated list\nis_sorted() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n#\n# $1 is an integer\ntri() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n#\n# $1 is an integer\ndigits() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n#\n# $1 is a string\nis_nested() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with -\n#\n# $1 is a string\nfix_spaces() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n#\n# $1 is a string\nfile_name_check() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# Example 2:\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n#\n# $1 is a space-separated list\norder_by_points() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1732,7 +604,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n#\n# $1 is a space-separated list\nspecialFilter() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    specialFilter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 -2 1 -5\") = \"0\" ]]\n    [[ $(candidate \"15 -73 14 -15\") = \"1\" ]]\n    [[ $(candidate \"33 -2 -3 45 21 109\") = \"2\" ]]\n    [[ $(candidate \"43 -12 93 125 121 109\") = \"4\" ]]\n    [[ $(candidate \"71 -2 -33 75 21 19\") = \"3\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1740,25 +612,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n#\n# $1 is a string\nall_prefixes() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n#\n# $1 is an integer\neven_odd_count() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n#\n# $1 is a string\nsolve() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +820,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n#\n# $1 is an integer\n# $2 is an integer\ngenerate_integers() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    generate_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"10\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"10\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"132\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"17\" \"89\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1776,49 +828,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n#\n# $1 is a string\ncount_distinct_characters() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n#\n# $1 is a string\nparse_music() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n#\n# $1 is a string\nsort_numbers() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n#\n# $1 is a string\nseparate_paren_groups() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return length of given string\n#\n# $1 is a string\nstrlen() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n#\n# $1 is an integer\nlargest_divisor() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n#\n# $1 is an integer\nfactorize() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n#\n# $1 is a string\nflip_case() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n#\n# $1 is a floating point\ntruncate_number() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n#\n# $1 is an integer\nis_prime() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n#\n# $1 is a space-separated list\nunique() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n#\n# $1 is a space-separated list\nmax_element() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n#\n# $1 is an integer\nfizz_buzz() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1828,9 +1084,189 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n#\n# $1 is a space-separated list\nsort_even() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    sort_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 123 1 -10\") = \"-10 3 -5 2 -3 3 5 0 9 1 123\" ]]\n    [[ $(candidate \"5 8 -12 4 23 2 3 11 12 -10\") = \"-12 8 3 4 5 2 12 11 23 -10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n#\n# $1 is an integer\nprime_fib() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n#\n# $1 is a space-separated list\nincr_list() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n#\n# $1 is an integer\nfib4() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n#\n# $1 is a space-separated list\nmedian() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n#\n# $1 is a string\nis_palindrome() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n#\n# $1 is a string\nremove_vowels() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Add two numbers x and y\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1840,9 +1276,21 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if two words have the same characters.\n#\n# $1 is a string\n# $2 is a string\nsame_chars() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    same_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") = \"true\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabc\") = \"true\" ]]\n    [[ $(candidate \"dddddddabc\" \"abcd\") = \"true\" ]]\n    [[ $(candidate \"eabcd\" \"dddddddabc\") = \"false\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabcf\") = \"false\" ]]\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") = \"false\" ]]\n    [[ $(candidate \"aabb\" \"aaccc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n#\n# $1 is an integer\nfib() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1852,9 +1300,561 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n#\n# $1 is a string\ncorrect_bracketing() {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"<>\") = \"true\" ]]\n    [[ $(candidate \"<<><>>\") = \"true\" ]]\n    [[ $(candidate \"<><><<><>><>\") = \"true\" ]]\n    [[ $(candidate \"<><><<<><><>><>><<><><<>>>\") = \"true\" ]]\n    [[ $(candidate \"<<<><>>>>\") = \"false\" ]]\n    [[ $(candidate \"><<>\") = \"false\" ]]\n    [[ $(candidate \"<\") = \"false\" ]]\n    [[ $(candidate \"<<<<\") = \"false\" ]]\n    [[ $(candidate \">\") = \"false\" ]]\n    [[ $(candidate \"<<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>><<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>>><>\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n#\n# $1 is a space-separated list\nderivative() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n#\n# $1 is an integer\nfibfib() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n#\n# $1 is a string\nvowels_count() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n#\n# $1 is a string\ndigitSum() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# Example 4:\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n#\n# $1 is an integer\niscube() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n#\n# $1 is a string\nhex_key() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n#\n# $1 is a string\nis_happy() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n#\n# $1 is a string\nprime_length() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n#\n# $1 is a space-separated list\nadd() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n#\n# $1 is a string\nanti_shuffle() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n#\n# $1 is a space-separated list\nsort_array() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n#\n# $1 is a string\nencrypt() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n#\n# $1 is a space-separated list\nsum_product() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n#\n# $1 is a string\nis_bored() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n#\n# $1 is a string\nencode() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n#\n# $1 is an integer\ncount_up_to() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n#\n# $1 is a string\ncount_upper() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-sh-reworded.json
+++ b/prompts/humaneval-sh-reworded.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> $(strlen \"\")\n# \"0\"\n# >>> $(strlen \"abc\")\n# \"3\"\n#\n# $1 is a string\nstrlen() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> $(encrypt \"hi\")\n# \"lm\"\n# >>> $(encrypt \"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> $(encrypt \"gf\")\n# \"kj\"\n# >>> $(encrypt \"et\")\n# \"ix\"\n#\n# $1 is a string\nencrypt() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a CSV, return true if all keys are strings in lower \n# case or all keys are strings in upper case, else return false.\n# The function should return false is the given CSV is empty.\n# Examples:\n# >>> $(check_dict_case \"a,apple\\nb,banana\")\n# \"true\"\n# >>> $(check_dict_case \"a,apple\\nA,banana\\nB,banana\")\n# \"false\"\n# >>> $(check_dict_case \"a,apple\\n8,banana\")\n# \"false\"\n# >>> $(check_dict_case \"Name,John\\nAge,36\\nCity,Houston\")\n# \"false\"\n# >>> $(check_dict_case \"STATE,NC\\nZIP,12345\")\n# \"true\"\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> $(add \"4 2 6 7\")\n# \"2\"\n#\n# $1 is a space-separated list\nadd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> $(fix_spaces \" Example\")\n# \"Example\"\n# >>> $(fix_spaces \" Example 1\")\n# \"Example_1\"\n# >>> $(fix_spaces \" Example 2\")\n# \"_Example_2\"\n# >>> $(fix_spaces \" Example 3\")\n# \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> $(fibfib \"1\")\n# \"0\"\n# >>> $(fibfib \"5\")\n# \"4\"\n# >>> $(fibfib \"8\")\n# \"24\"\n#\n# $1 is an integer\nfibfib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> $(double_the_difference \"1 3 2 0\")\n# \"10\"\n# >>> $(double_the_difference \"-1 -2 0\")\n# \"0\"\n# >>> $(double_the_difference \"9 -2\")\n# \"81\"\n# >>> $(double_the_difference \"0\")\n# \"0\"\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Filter given list of any shthon values only for integers\n# >>> $(filter_integers \"a 3.14 5\")\n# ['\"5\"']\n# >>> $(filter_integers \"1 2 3 abc  \")\n# ['\"1\"', '\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> $(parse_music \"o o| .| o| o| .| .| .| .| o o\")\n# ['\"4\"', '\"2\"', '\"1\"', '\"2\"', '\"2\"', '\"1\"', '\"1\"', '\"1\"', '\"1\"', '\"4\"', '\"4\"']\n#\n# $1 is a string\nparse_music() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> $(decimal_to_binary \"15\")\n# \"db1111db\"\n# >>> $(decimal_to_binary \"32\")\n# \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> $(all_prefixes \"abc\")\n# ['\"a\"', '\"ab\"', '\"abc\"']\n#\n# $1 is a string\nall_prefixes() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> $(add \"2\" \"3\")\n# \"5\"\n# >>> $(add \"5\" \"7\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> $(eat \"5\" \"6\" \"10\")\n# ['\"11\"', '\"4\"']\n# >>> $(eat \"4\" \"8\" \"9\")\n# ['\"12\"', '\"1\"']\n# >>> $(eat \"1\" \"10\" \"10\")\n# ['\"11\"', '\"0\"']\n# >>> $(eat \"2\" \"11\" \"5\")\n# ['\"7\"', '\"0\"']\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> $(max_fill \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\")\n# \"6\"\n# Example 2:\n# >>> $(max_fill \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\")\n# \"5\"\n# Example 3:\n# >>> $(max_fill \"0 0 0\\n0 0 0\" \"5\")\n# \"0\"\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> $(flip_case \"Hello\")\n# \"hELLO\"\n#\n# $1 is a string\nflip_case() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> $(by_length \"2 1 1 4 5 8 2 3\")\n# ['\"Eight\"', '\"Five\"', '\"Four\"', '\"Three\"', '\"Two\"', '\"Two\"', '\"One\"', '\"One\"']\n# If the array is empty, return an empty array:\n# >>> $(by_length \"\")\n# []\n# If the array has any strange number ignore it:\n# >>> $(by_length \"1 -1 55\")\n# ['\"One\"']\n#\n# $1 is a space-separated list\nby_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> $(factorize \"8\")\n# ['\"2\"', '\"2\"', '\"2\"']\n# >>> $(factorize \"25\")\n# ['\"5\"', '\"5\"']\n# >>> $(factorize \"70\")\n# ['\"2\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nfactorize() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> $(count_up_to \"5\")\n# ['\"2\"', '\"3\"']\n# >>> $(count_up_to \"11\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"']\n# >>> $(count_up_to \"0\")\n# []\n# >>> $(count_up_to \"20\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"', '\"19\"']\n# >>> $(count_up_to \"1\")\n# []\n# >>> $(count_up_to \"18\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"']\n#\n# $1 is an integer\ncount_up_to() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> $(unique \"5 3 5 2 3 3 9 0 123\")\n# ['\"0\"', '\"2\"', '\"3\"', '\"5\"', '\"9\"', '\"123\"']\n#\n# $1 is a space-separated list\nunique() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> $(total_match \"\" \"\")\n# []\n# >>> $(total_match \"hi admin\" \"hI Hi\")\n# ['\"hI\"', '\"Hi\"']\n# >>> $(total_match \"hi admin\" \"hi hi admin project\")\n# ['\"hi\"', '\"admin\"']\n# >>> $(total_match \"hi admin\" \"hI hi hi\")\n# ['\"hI\"', '\"hi\"', '\"hi\"']\n# >>> $(total_match \"4\" \"1 2 3 4 5\")\n# ['\"4\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> $(max_element \"1 2 3\")\n# \"3\"\n# >>> $(max_element \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# \"123\"\n#\n# $1 is a space-separated list\nmax_element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return true if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> $(is_nested \"[[]]\")\n# \"true\"\n# >>> $(is_nested \"[]]]]]]][[[[[]\")\n# \"false\"\n# >>> $(is_nested \"[][]\")\n# \"false\"\n# >>> $(is_nested \"[]\")\n# \"false\"\n# >>> $(is_nested \"[[][]]\")\n# \"true\"\n# >>> $(is_nested \"[[]][[\")\n# \"true\"\n#\n# $1 is a string\nis_nested() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> $(rounded_avg \"1\" \"5\")\n# \"0b11\"\n# >>> $(rounded_avg \"7\" \"5\")\n# \"-1\"\n# >>> $(rounded_avg \"10\" \"20\")\n# \"0b1111\"\n# >>> $(rounded_avg \"20\" \"33\")\n# \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return true else return false.\n# If the given array is empty then return true.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> $(move_one_ball \"3 4 5 1 2\")\n# \"true\"\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> $(move_one_ball \"3 5 4 1 2\")\n# \"false\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a list that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> $(even_odd_palindrome \"3\")\n# ['\"1\"', '\"2\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> $(even_odd_palindrome \"12\")\n# ['\"4\"', '\"6\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned list has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> $(is_equal_to_sum_even \"4\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"6\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"8\")\n# \"true\"\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> $(derivative \"3 1 2 4 5\")\n# ['\"1\"', '\"4\"', '\"12\"', '\"20\"']\n# >>> $(derivative \"1 2 3\")\n# ['\"2\"', '\"6\"']\n#\n# $1 is a space-separated list\nderivative() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return false. Assume no negative numbers and only integers.\n# Examples\n# >>> $(is_sorted \"5\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5\")\n# \"false\"\n# >>> $(is_sorted \"1 2 3 4 5 6\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5 6 7\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5 6 7\")\n# \"false\"\n# >>> $(is_sorted \"1 2 2 3 3 4\")\n# \"true\"\n# >>> $(is_sorted \"1 2 2 2 3 4\")\n# \"false\"\n#\n# $1 is a space-separated list\nis_sorted() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> $(solve \"1234\")\n# \"4321\"\n# >>> $(solve \"ab\")\n# \"AB\"\n# >>> $(solve \"#a@C\")\n# \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> $(tri \"3\")\n# ['\"1\"', '\"3\"', '\"2\"', '\"8\"']\n#\n# $1 is an integer\ntri() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> $(fizz_buzz \"50\")\n# \"0\"\n# >>> $(fizz_buzz \"78\")\n# \"2\"\n# >>> $(fizz_buzz \"79\")\n# \"3\"\n#\n# $1 is an integer\nfizz_buzz() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> $(solve \"1000\")\n# \"1\"\n# >>> $(solve \"150\")\n# \"110\"\n# >>> $(solve \"147\")\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> $(minPath \"1 2 3\\n4 5 6\\n7 8 9\" \"3\")\n# ['\"1\"', '\"2\"', '\"1\"']\n# >>> $(minPath \"5 9 3\\n4 1 6\\n7 8 2\" \"1\")\n# ['\"1\"']\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> $(count_upper \"aBCdEf\")\n# \"1\"\n# >>> $(count_upper \"abcdefg\")\n# \"0\"\n# >>> $(count_upper \"dBBE\")\n# \"0\"\n#\n# $1 is a string\ncount_upper() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> $(maximum \"-3 -4 5\" \"3\")\n# ['\"-4\"', '\"-3\"', '\"5\"']\n# Example 2:\n# >>> $(maximum \"4 -4 4\" \"2\")\n# ['\"4\"', '\"4\"']\n# Example 3:\n# >>> $(maximum \"-3 2 1 2 -1 -2 1\" \"1\")\n# ['\"2\"']\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> $(largest_divisor \"15\")\n# \"5\"\n#\n# $1 is an integer\nlargest_divisor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a cosh of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> $(sort_array \"\")\n# []\n# >>> $(sort_array \"5\")\n# ['\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5 6\")\n# ['\"6\"', '\"5\"', '\"4\"', '\"3\"', '\"2\"', '\"1\"', '\"0\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> $(f \"5\")\n# ['\"1\"', '\"2\"', '\"6\"', '\"24\"', '\"15\"']\n#\n# $1 is an integer\nf() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns true \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> $(iscube \"1\")\n# \"true\"\n# >>> $(iscube \"2\")\n# \"false\"\n# >>> $(iscube \"-1\")\n# \"true\"\n# >>> $(iscube \"64\")\n# \"true\"\n# >>> $(iscube \"0\")\n# \"true\"\n# >>> $(iscube \"180\")\n# \"false\"\n#\n# $1 is an integer\niscube() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> $(encode \"test\")\n# \"TGST\"\n# >>> $(encode \"This is a message\")\n# \"tHKS KS C MGSSCGG\"\n#\n# $1 is a string\nencode() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> $(is_bored \"Hello world\")\n# \"0\"\n# >>> $(is_bored \"The sky is blue. The sun is shining. I love this weather\")\n# \"1\"\n#\n# $1 is a string\nis_bored() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns true if there are two distinct elements in the list that\n# sum to zero, and false otherwise.\n# >>> $(pairs_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 3 -2 1\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"2 4 -5 3 5 7\")\n# \"true\"\n# >>> $(pairs_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> $(triangle_area \"3\" \"4\" \"5\")\n# \"6.0\"\n# >>> $(triangle_area \"1\" \"2\" \"10\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a list containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty list if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> $(bf \"Jupiter\" \"Neptune\")\n# ['\"Saturn\"', '\"Uranus\"']\n# >>> $(bf \"Earth\" \"Mercury\")\n# \"Venus\"\n# >>> $(bf \"Mercury\" \"Uranus\")\n# ['\"Venus\"', '\"Earth\"', '\"Mars\"', '\"Jupiter\"', '\"Saturn\"']\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> $(digits \"1\")\n# \"1\"\n# >>> $(digits \"4\")\n# \"0\"\n# >>> $(digits \"235\")\n# \"15\"\n#\n# $1 is an integer\ndigits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> $(words_string \"Hi, my name is John\")\n# ['\"Hi\"', '\"my\"', '\"name\"', '\"is\"', '\"John\"']\n# >>> $(words_string \"One, two, three, four, five, six\")\n# ['\"One\"', '\"two\"', '\"three\"', '\"four\"', '\"five\"', '\"six\"']\n#\n# $1 is a string\nwords_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> $(how_many_times \"\" \"a\")\n# \"0\"\n# >>> $(how_many_times \"aaa\" \"a\")\n# \"3\"\n# >>> $(how_many_times \"aaaa\" \"aa\")\n# \"3\"\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> $(compare_one \"1\" \"2.5\")\n# \"2.5\"\n# >>> $(compare_one \"1\" \"2,3\")\n# \"2,3\"\n# >>> $(compare_one \"5,1\" \"6\")\n# \"6\"\n# >>> $(compare_one \"1\" \"1\")\n# \"None\"\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> $(remove_vowels \"\")\n# \"\"\n# >>> $(remove_vowels \"abcdef\")\n# \"bcdf\"\n# >>> $(remove_vowels \"aaaaa\")\n# \"\"\n# >>> $(remove_vowels \"aaBAA\")\n# \"B\"\n# >>> $(remove_vowels \"zbcd\")\n# \"zbcd\"\n#\n# $1 is a string\nremove_vowels() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> $(strange_sort_list \"1 2 3 4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"3\"']\n# >>> $(strange_sort_list \"5 5 5 5\")\n# ['\"5\"', '\"5\"', '\"5\"', '\"5\"']\n# >>> $(strange_sort_list \"\")\n# []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.2\")\n# ['\"2.0\"', '\"2.2\"']\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.0\")\n# ['\"2.0\"', '\"2.0\"']\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> $(is_simple_power \"1\" \"4\")\n# \"true\"\n# >>> $(is_simple_power \"2\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"8\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"3\" \"2\")\n# \"false\"\n# >>> $(is_simple_power \"3\" \"1\")\n# \"false\"\n# >>> $(is_simple_power \"5\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> $(prime_fib \"1\")\n# \"2\"\n# >>> $(prime_fib \"2\")\n# \"3\"\n# >>> $(prime_fib \"3\")\n# \"5\"\n# >>> $(prime_fib \"4\")\n# \"13\"\n# >>> $(prime_fib \"5\")\n# \"89\"\n#\n# $1 is an integer\nprime_fib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> $(order_by_points \"1 11 -1 -11 -12\")\n# ['\"-1\"', '\"-11\"', '\"1\"', '\"-12\"', '\"11\"']\n# >>> $(order_by_points \"\")\n# []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> $(has_close_elements \"1.0 2.0 3.0\" \"0.5\")\n# \"false\"\n# >>> $(has_close_elements \"1.0 2.8 3.0 4.0 5.0 2.0\" \"0.3\")\n# \"true\"\n#\n# $1 is a space-separated list\n# $2 is a floating point\nhas_close_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    has_close_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.3\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.05\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.95\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.8\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\" \"0.1\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"1.0\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"0.5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> $(make_palindrome \"\")\n# \"\"\n# >>> $(make_palindrome \"cat\")\n# \"catac\"\n# >>> $(make_palindrome \"cata\")\n# \"catac\"\n#\n# $1 is a string\nmake_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> $(string_xor \"010\" \"110\")\n# \"100\"\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> $(special_factorial \"4\")\n# \"288\"\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> $(add_elements \"111 21 3 4000 5 6 7 8 9\" \"4\")\n# \"24\"\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> $(fib4 \"5\")\n# \"4\"\n# >>> $(fib4 \"6\")\n# \"8\"\n# >>> $(fib4 \"7\")\n# \"14\"\n#\n# $1 is an integer\nfib4() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> $(unique_digits \"15 33 1422 1\")\n# ['\"1\"', '\"15\"', '\"33\"']\n# >>> $(unique_digits \"152 323 1422 10\")\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> $(select_words \"Mary had a little lamb\" \"4\")\n# ['\"little\"']\n# >>> $(select_words \"Mary had a little lamb\" \"3\")\n# ['\"Mary\"', '\"lamb\"']\n# >>> $(select_words \"simple white space\" \"2\")\n# []\n# >>> $(select_words \"Hello world\" \"4\")\n# ['\"world\"']\n# >>> $(select_words \"Uncle sam\" \"3\")\n# ['\"Uncle\"']\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns true if the object q will fly, and false otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> $(will_it_fly \"1 2\" \"5\")\n# \"false\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> $(will_it_fly \"3 2 3\" \"1\")\n# \"false\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> $(will_it_fly \"3 2 3\" \"9\")\n# \"true\"\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> $(will_it_fly \"3\" \"5\")\n# \"true\"\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> $(fib \"10\")\n# \"55\"\n# >>> $(fib \"1\")\n# \"1\"\n# >>> $(fib \"8\")\n# \"21\"\n#\n# $1 is an integer\nfib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> $(Strongest_Extension \"my_class\" \"AA Be CC\")\n# \"my_class.AA\"\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> $(match_parens \"()( )\")\n# \"Yes\"\n# >>> $(match_parens \") )\")\n# \"No\"\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> $(next_smallest \"1 2 3 4 5\")\n# \"2\"\n# >>> $(next_smallest \"5 1 4 3 2\")\n# \"2\"\n# >>> $(next_smallest \"\")\n# \"None\"\n# >>> $(next_smallest \"1 1\")\n# \"None\"\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> $(any_int \"5\" \"2\" \"7\")\n# \"true\"\n# >>> $(any_int \"3\" \"2\" \"2\")\n# \"false\"\n# >>> $(any_int \"3\" \"-2\" \"1\")\n# \"true\"\n# >>> $(any_int \"3.6\" \"-2.2\" \"2\")\n# \"false\"\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> $(truncate_number \"3.5\")\n# \"0.5\"\n#\n# $1 is a floating point\ntruncate_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> $(incr_list \"1 2 3\")\n# ['\"2\"', '\"3\"', '\"4\"']\n# >>> $(incr_list \"5 3 5 2 3 3 9 0 123\")\n# ['\"6\"', '\"4\"', '\"6\"', '\"3\"', '\"4\"', '\"4\"', '\"10\"', '\"1\"', '\"124\"']\n#\n# $1 is a space-separated list\nincr_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> $(x_or_y \"7\" \"34\" \"12\")\n# \"34\"\n# >>> $(x_or_y \"15\" \"8\" \"5\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> $(modp \"3\" \"5\")\n# \"3\"\n# >>> $(modp \"1101\" \"101\")\n# \"2\"\n# >>> $(modp \"0\" \"101\")\n# \"1\"\n# >>> $(modp \"3\" \"11\")\n# \"8\"\n# >>> $(modp \"100\" \"101\")\n# \"1\"\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an integer. return a list that has the number of even and odd digits respectively.\n# Example:\n# >>> $(even_odd_count \"-12\")\n# ['\"1\"', '\"1\"']\n# >>> $(even_odd_count \"123\")\n# ['\"1\"', '\"2\"']\n#\n# $1 is an integer\neven_odd_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is hapsh or not.\n# A string is hapsh if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> $(is_happy \"a\")\n# \"false\"\n# >>> $(is_happy \"aa\")\n# \"false\"\n# >>> $(is_happy \"abcd\")\n# \"true\"\n# >>> $(is_happy \"aabb\")\n# \"false\"\n# >>> $(is_happy \"adb\")\n# \"true\"\n# >>> $(is_happy \"xyy\")\n# \"false\"\n#\n# $1 is a string\nis_happy() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> $(largest_prime_factor \"13195\")\n# \"29\"\n# >>> $(largest_prime_factor \"2048\")\n# \"2\"\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> $(digitSum \"\")\n# \"0\"\n# >>> $(digitSum \"abAB\")\n# \"131\"\n# >>> $(digitSum \"abcCd\")\n# \"67\"\n# >>> $(digitSum \"helloE\")\n# \"69\"\n# >>> $(digitSum \"woArBld\")\n# \"131\"\n# >>> $(digitSum \"aAaaaXa\")\n# \"153\"\n#\n# $1 is a string\ndigitSum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> $(rescale_to_unit \"1.0 2.0 3.0 4.0 5.0\")\n# ['\"0.0\"', '\"0.25\"', '\"0.5\"', '\"0.75\"', '\"1.0\"']\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> $(solution \"5 8 7 1\")\n# \"12\"\n# >>> $(solution \"3 3 3 3 3\")\n# \"9\"\n# >>> $(solution \"30 13 24 321\")\n# \"0\"\n#\n# $1 is a space-separated list\nsolution() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> $(pluck \"4 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> $(pluck \"1 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> $(pluck \"\")\n# []\n# Example 4:\n# >>> $(pluck \"5 0 3 0 4 2\")\n# ['\"0\"', '\"1\"']\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> $(get_max_triples \"5\")\n# \"1\"\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> $(exchange \"1 2 3 4\" \"1 2 3 4\")\n# \"YES\"\n# >>> $(exchange \"1 2 3 4\" \"1 5 3 4\")\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> $(median \"3 1 2 4 5\")\n# \"3\"\n# >>> $(median \"-10 4 6 1000 10 20\")\n# \"15.0\"\n#\n# $1 is a space-separated list\nmedian() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns true if the string\n# length is a prime number or false otherwise\n# Examples\n# >>> $(prime_length \"Hello\")\n# \"true\"\n# >>> $(prime_length \"abcdcba\")\n# \"true\"\n# >>> $(prime_length \"kittens\")\n# \"true\"\n# >>> $(prime_length \"orange\")\n# \"false\"\n#\n# $1 is a string\nprime_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> $(smallest_change \"1 2 3 5 4 7 9 6\")\n# \"4\"\n# >>> $(smallest_change \"1 2 3 4 3 2 2\")\n# \"1\"\n# >>> $(smallest_change \"1 2 3 2 1\")\n# \"0\"\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> $(lst \"1.0 2.0 3.0\")\n# \"14\"\n# >>> $(lst \"1.0 4.0 9.0\")\n# \"98\"\n# >>> $(lst \"1.0 3.0 5.0 7.0\")\n# \"84\"\n# >>> $(lst \"1.4 4.2 0.0\")\n# \"29\"\n# >>> $(lst \"-2.4 1.0 1.0\")\n# \"6\"\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> $(file_name_check \"example.txt\")\n# \"Yes\"\n# >>> $(file_name_check \"1example.dll\")\n# \"No\"\n#\n# $1 is a string\nfile_name_check() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns true if there are three distinct elements in the list that\n# sum to zero, and false otherwise.\n# >>> $(triples_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"1 3 -2 1\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"2 4 -5 3 9 7\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> $(intersection \"1 2\" \"2 3\")\n# \"NO\"\n# >>> $(intersection \"-1 1\" \"0 4\")\n# \"NO\"\n# >>> $(intersection \"-3 -1\" \"-5 5\")\n# \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> $(separate_paren_groups \"( ) (( )) (( )( ))\")\n# ['\"()\"', '\"(())\"', '\"(()())\"']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> $(compare \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\")\n# ['\"0\"', '\"0\"', '\"0\"', '\"0\"', '\"3\"', '\"3\"']\n# >>> $(compare \"0 5 0 0 0 4\" \"4 1 1 0 0 -2\")\n# ['\"4\"', '\"4\"', '\"1\"', '\"0\"', '\"0\"', '\"6\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns true if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and false otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> $(check_if_last_char_is_a_letter \"apple pie\")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e\")\n# \"true\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e \")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"\")\n# \"false\"\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns true if the date is valid otherwise false.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> $(valid_date \"03-11-2000\")\n# \"true\"\n# >>> $(valid_date \"15-01-2012\")\n# \"false\"\n# >>> $(valid_date \"04-0-2040\")\n# \"false\"\n# >>> $(valid_date \"06-04-2020\")\n# \"true\"\n# >>> $(valid_date \"06/04/2020\")\n# \"false\"\n#\n# $1 is a string\nvalid_date() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> $(count_nums \"\")\n# \"0\"\n# >>> $(count_nums \"-1 11 -11\")\n# \"1\"\n# >>> $(count_nums \"1 1 2\")\n# \"3\"\n#\n# $1 is a space-separated list\ncount_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> $(anti_shuffle \"Hi\")\n# \"Hi\"\n# >>> $(anti_shuffle \"hello\")\n# \"ehllo\"\n# >>> $(anti_shuffle \"Hello World\\!\\!\\!\")\n# \"Hello \\!\\!\\!Wdlor\"\n#\n# $1 is a string\nanti_shuffle() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> $(is_palindrome \"\")\n# \"true\"\n# >>> $(is_palindrome \"aba\")\n# \"true\"\n# >>> $(is_palindrome \"aaaaa\")\n# \"true\"\n# >>> $(is_palindrome \"zbcd\")\n# \"false\"\n#\n# $1 is a string\nis_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> $(get_closest_vowel \"yogurt\")\n# \"u\"\n# >>> $(get_closest_vowel \"FULL\")\n# \"U\"\n# >>> $(get_closest_vowel \"quick\")\n# \"\"\n# >>> $(get_closest_vowel \"ab\")\n# \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> $(is_prime \"6\")\n# \"false\"\n# >>> $(is_prime \"101\")\n# \"true\"\n# >>> $(is_prime \"11\")\n# \"true\"\n# >>> $(is_prime \"13441\")\n# \"true\"\n# >>> $(is_prime \"61\")\n# \"true\"\n# >>> $(is_prime \"4\")\n# \"false\"\n# >>> $(is_prime \"1\")\n# \"false\"\n#\n# $1 is an integer\nis_prime() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns true if x * n evaluates to a whole number and false\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> $(simplify \"1/5\" \"5/1\")\n# \"true\"\n# >>> $(simplify \"1/6\" \"2/1\")\n# \"false\"\n# >>> $(simplify \"7/10\" \"10/2\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> $(hex_key \"AB\")\n# \"1\"\n# >>> $(hex_key \"1077E\")\n# \"2\"\n# >>> $(hex_key \"ABED1A33\")\n# \"4\"\n# >>> $(hex_key \"123456789ABCDEF0\")\n# \"6\"\n# >>> $(hex_key \"2020\")\n# \"2\"\n#\n# $1 is a string\nhex_key() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> $(words_in_sentence \"This is a test\")\n# \"is\"\n# Example 2:\n# >>> $(words_in_sentence \"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a CSV\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> $(histogram \"a b c\")\n# {'\"a\"': '\"1\"', '\"b\"': '\"1\"', '\"c\"': '\"1\"'}\n# >>> $(histogram \"a b b a\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"a b c a b\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"b b b b a\")\n# {'\"b\"': '\"4\"'}\n# >>> $(histogram \"\")\n# {}\n#\n# $1 is a string\nhistogram() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of lists, [(x1, y1), (x2, y2) ...] such that\n# each list is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> $(get_row \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\")\n# [['\"0\"', '\"0\"'], ['\"1\"', '\"4\"'], ['\"1\"', '\"0\"'], ['\"2\"', '\"5\"'], ['\"2\"', '\"0\"']]\n# >>> $(get_row \"\" \"1\")\n# []\n# >>> $(get_row \"\\n1\\n1 2 3\" \"3\")\n# [['\"2\"', '\"2\"']]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> $(get_odd_collatz \"5\")\n# ['\"1\"', '\"5\"']\n#\n# $1 is an integer\nget_odd_collatz() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> $(can_arrange \"1 2 4 3 5\")\n# \"3\"\n# >>> $(can_arrange \"1 2 3\")\n# \"-1\"\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> $(sort_numbers \"three one five\")\n# \"one three five\"\n#\n# $1 is a string\nsort_numbers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> $(circular_shift \"12\" \"1\")\n# \"21\"\n# >>> $(circular_shift \"12\" \"2\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> lst\n# []\n# >>> lst\n# ['\"-1\"', '\"-5\"', '\"2\"', '\"-1\"', '\"-5\"']\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> $(skjkasdkd \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\")\n# \"10\"\n# >>> $(skjkasdkd \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\")\n# \"25\"\n# >>> $(skjkasdkd \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\")\n# \"13\"\n# >>> $(skjkasdkd \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\")\n# \"11\"\n# >>> $(skjkasdkd \"0 81 12 3 1 21\")\n# \"3\"\n# >>> $(skjkasdkd \"0 8 1 2 1 7\")\n# \"7\"\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> $(sum_product \"\")\n# ['\"0\"', '\"1\"']\n# >>> $(sum_product \"1 2 3 4\")\n# ['\"10\"', '\"24\"']\n#\n# $1 is a space-separated list\nsum_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> $(choose_num \"12\" \"15\")\n# \"14\"\n# >>> $(choose_num \"13\" \"12\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns a list (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> $(largest_smallest_integers \"2 4 1 3 5 7\")\n# ['\"None\"', '\"1\"']\n# >>> $(largest_smallest_integers \"\")\n# ['\"None\"', '\"None\"']\n# >>> $(largest_smallest_integers \"0\")\n# ['\"None\"', '\"None\"']\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> $(count_distinct_characters \"xyzXYZ\")\n# \"3\"\n# >>> $(count_distinct_characters \"Jerry\")\n# \"4\"\n#\n# $1 is a string\ncount_distinct_characters() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1384,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> $(make_a_pile \"3\")\n# ['\"3\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nmake_a_pile() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    make_a_pile \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"3 5 7\" ]]\n    [[ $(candidate \"4\") = \"4 6 8 10\" ]]\n    [[ $(candidate \"5\") = \"5 7 9 11 13\" ]]\n    [[ $(candidate \"6\") = \"6 8 10 12 14 16\" ]]\n    [[ $(candidate \"8\") = \"8 10 12 14 16 18 20 22\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1392,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> $(prod_signs \"1 2 2 -4\")\n# \"9\"\n# >>> $(prod_signs \"0 1\")\n# \"0\"\n# >>> $(prod_signs \"\")\n# \"None\"\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> $(words_string \"Hi, my name is John\")\n# ['\"Hi\"', '\"my\"', '\"name\"', '\"is\"', '\"John\"']\n# >>> $(words_string \"One, two, three, four, five, six\")\n# ['\"One\"', '\"two\"', '\"three\"', '\"four\"', '\"five\"', '\"six\"']\n#\n# $1 is a string\nwords_string() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> $(minSubArraySum \"2 3 4 1 2 4\")\n# \"1\"\n# >>> $(minSubArraySum \"-1 -2 -3\")\n# \"-6\"\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
+    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> $(choose_num \"12\" \"15\")\n# \"14\"\n# >>> $(choose_num \"13\" \"12\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> $(string_sequence \"0\")\n# \"0\"\n# >>> $(string_sequence \"5\")\n# \"0 1 2 3 4 5\"\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> $(rounded_avg \"1\" \"5\")\n# \"0b11\"\n# >>> $(rounded_avg \"7\" \"5\")\n# \"-1\"\n# >>> $(rounded_avg \"10\" \"20\")\n# \"0b1111\"\n# >>> $(rounded_avg \"20\" \"33\")\n# \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n# >>> $(cycpattern_check \"abcd\" \"abd\")\n# \"false\"\n# >>> $(cycpattern_check \"hello\" \"ell\")\n# \"true\"\n# >>> $(cycpattern_check \"whassup\" \"psus\")\n# \"false\"\n# >>> $(cycpattern_check \"abab\" \"baa\")\n# \"true\"\n# >>> $(cycpattern_check \"efef\" \"eeff\")\n# \"false\"\n# >>> $(cycpattern_check \"himenss\" \"simen\")\n# \"true\"\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> $(unique_digits \"15 33 1422 1\")\n# ['\"1\"', '\"15\"', '\"33\"']\n# >>> $(unique_digits \"152 323 1422 10\")\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true is list elements are monotonically increasing or decreasing.\n# >>> $(monotonic \"1 2 4 20\")\n# \"true\"\n# >>> $(monotonic \"1 20 4 10\")\n# \"false\"\n# >>> $(monotonic \"4 1 0 -10\")\n# \"true\"\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> $(by_length \"2 1 1 4 5 8 2 3\")\n# ['\"Eight\"', '\"Five\"', '\"Four\"', '\"Three\"', '\"Two\"', '\"Two\"', '\"One\"', '\"One\"']\n# If the array is empty, return an empty array:\n# >>> $(by_length \"\")\n# []\n# If the array has any strange number ignore it:\n# >>> $(by_length \"1 -1 55\")\n# ['\"One\"']\n#\n# $1 is a space-separated list\nby_length() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> $(longest \"\")\n# \"None\"\n# >>> $(longest \"a b c\")\n# \"a\"\n# >>> $(longest \"a bb ccc\")\n# \"ccc\"\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> $(f \"5\")\n# ['\"1\"', '\"2\"', '\"6\"', '\"24\"', '\"15\"']\n#\n# $1 is an integer\nf() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true if all numbers in the list l are below threshold t.\n# >>> $(below_threshold \"1 2 4 10\" \"100\")\n# \"true\"\n# >>> $(below_threshold \"1 20 4 10\" \"5\")\n# \"false\"\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a list that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> $(even_odd_palindrome \"3\")\n# ['\"1\"', '\"2\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> $(even_odd_palindrome \"12\")\n# ['\"4\"', '\"6\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned list has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> $(is_multiply_prime \"30\")\n# \"true\"\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> $(count_nums \"\")\n# \"0\"\n# >>> $(count_nums \"-1 11 -11\")\n# \"1\"\n# >>> $(count_nums \"1 1 2\")\n# \"3\"\n#\n# $1 is a space-separated list\ncount_nums() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> $(get_positive \"-1 2 -4 5 6\")\n# ['\"2\"', '\"5\"', '\"6\"']\n# >>> $(get_positive \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# ['\"5\"', '\"3\"', '\"2\"', '\"3\"', '\"9\"', '\"123\"', '\"1\"']\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return true else return false.\n# If the given array is empty then return true.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> $(move_one_ball \"3 4 5 1 2\")\n# \"true\"\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> $(move_one_ball \"3 5 4 1 2\")\n# \"false\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> $(sort_third \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_third \"5 6 3 4 8 9 2\")\n# ['\"2\"', '\"6\"', '\"3\"', '\"4\"', '\"8\"', '\"9\"', '\"5\"']\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> $(make_palindrome \"\")\n# \"\"\n# >>> $(make_palindrome \"cat\")\n# \"catac\"\n# >>> $(make_palindrome \"cata\")\n# \"catac\"\n#\n# $1 is a string\nmake_palindrome() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> $(parse_nested_parens \"(()()) ((())) () ((())()())\")\n# ['\"2\"', '\"3\"', '\"1\"', '\"3\"']\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> $(exchange \"1 2 3 4\" \"1 2 3 4\")\n# \"YES\"\n# >>> $(exchange \"1 2 3 4\" \"1 5 3 4\")\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> $(triangle_area \"5\" \"3\")\n# \"7.5\"\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a CSV\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> $(histogram \"a b c\")\n# {'\"a\"': '\"1\"', '\"b\"': '\"1\"', '\"c\"': '\"1\"'}\n# >>> $(histogram \"a b b a\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"a b c a b\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"b b b b a\")\n# {'\"b\"': '\"4\"'}\n# >>> $(histogram \"\")\n# {}\n#\n# $1 is a string\nhistogram() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> $(multiply \"148\" \"412\")\n# \"16\"\n# >>> $(multiply \"19\" \"28\")\n# \"72\"\n# >>> $(multiply \"2020\" \"1851\")\n# \"0\"\n# >>> $(multiply \"14\" \"-15\")\n# \"20\"\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> $(mean_absolute_deviation \"1.0 2.0 3.0 4.0\")\n# \"1.0\"\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> $(common \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\")\n# ['\"1\"', '\"5\"', '\"653\"']\n# >>> $(common \"5 3 2 8\" \"3 2\")\n# ['\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> $(int_to_mini_roman \"19\")\n# \"xix\"\n# >>> $(int_to_mini_roman \"152\")\n# \"clii\"\n# >>> $(int_to_mini_roman \"426\")\n# \"cdxxvi\"\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> $(fruit_distribution \"5 apples and 6 oranges\" \"19\")\n# \"8\"\n# >>> $(fruit_distribution \"0 apples and 1 oranges\" \"3\")\n# \"2\"\n# >>> $(fruit_distribution \"2 apples and 3 oranges\" \"100\")\n# \"95\"\n# >>> $(fruit_distribution \"100 apples and 1 oranges\" \"120\")\n# \"19\"\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1600,7 +172,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a list containing the result string and true/false for the check.\n# Example\n# >>> $(reverse_delete \"abcde\" \"ae\")\n# ['\"bcd\"', '\"false\"']\n# >>> $(reverse_delete \"abcdef\" \"b\")\n# ['\"acdef\"', '\"false\"']\n# >>> $(reverse_delete \"abcdedcba\" \"ab\")\n# ['\"cdedc\"', '\"true\"']\n#\n# $1 is a string\n# $2 is a string\nreverse_delete() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    reverse_delete \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\" \"ae\") = \"bcd false\" ]]\n    [[ $(candidate \"abcdef\" \"b\") = \"acdef false\" ]]\n    [[ $(candidate \"abcdedcba\" \"ab\") = \"cdedc true\" ]]\n    [[ $(candidate \"dwik\" \"w\") = \"dik false\" ]]\n    [[ $(candidate \"a\" \"a\") = \" true\" ]]\n    [[ $(candidate \"abcdedcba\" \"\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"abcdedcba\" \"v\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"vabba\" \"v\") = \"abba true\" ]]\n    [[ $(candidate \"mamma\" \"mia\") = \" true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1608,25 +180,25 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> $(greatest_common_divisor \"3\" \"5\")\n# \"1\"\n# >>> $(greatest_common_divisor \"25\" \"15\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> $(minSubArraySum \"2 3 4 1 2 4\")\n# \"1\"\n# >>> $(minSubArraySum \"-1 -2 -3\")\n# \"-6\"\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_115_max_fill",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> $(split_words \"Hello world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"Hello,world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"abcdef\")\n# \"3\"\n#\n# $1 is a string\nsplit_words() {\n",
+    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> $(max_fill \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\")\n# \"6\"\n# Example 2:\n# >>> $(max_fill \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\")\n# \"5\"\n# Example 3:\n# >>> $(max_fill \"0 0 0\\n0 0 0\" \"5\")\n# \"0\"\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1636,7 +208,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> $(sort_array \"1 5 2 3 4\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"-2 -3 -4 -5 -6\")\n# ['\"-6\"', '\"-5\"', '\"-4\"', '\"-3\"', '\"-2\"']\n# >>> $(sort_array \"1 0 2 3 4\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 2 3 4\") = \"1 2 4 3 5\" ]]\n    [[ $(candidate \"-2 -3 -4 -5 -6\") = \"-4 -2 -6 -5 -3\" ]]\n    [[ $(candidate \"1 0 2 3 4\") = \"0 1 2 4 3\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"2 5 77 4 5 3 5 7 2 3 4\") = \"2 2 4 4 3 3 5 5 5 7 77\" ]]\n    [[ $(candidate \"3 6 44 12 32 5\") = \"32 3 5 6 12 44\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1644,121 +216,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> $(concatenate \"\")\n# \"\"\n# >>> $(concatenate \"a b c\")\n# \"abc\"\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> $(select_words \"Mary had a little lamb\" \"4\")\n# ['\"little\"']\n# >>> $(select_words \"Mary had a little lamb\" \"3\")\n# ['\"Mary\"', '\"lamb\"']\n# >>> $(select_words \"simple white space\" \"2\")\n# []\n# >>> $(select_words \"Hello world\" \"4\")\n# ['\"world\"']\n# >>> $(select_words \"Uncle sam\" \"3\")\n# ['\"Uncle\"']\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> $(list_sort \"aa a aaa\")\n# ['\"aa\"']\n# >>> $(list_sort \"ab a aaa cd\")\n# ['\"ab\"', '\"cd\"']\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> $(get_closest_vowel \"yogurt\")\n# \"u\"\n# >>> $(get_closest_vowel \"FULL\")\n# \"U\"\n# >>> $(get_closest_vowel \"quick\")\n# \"\"\n# >>> $(get_closest_vowel \"ab\")\n# \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_119_match_parens",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> $(closest_integer \"10\")\n# \"10\"\n# >>> $(closest_integer \"15.3\")\n# \"15\"\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> $(match_parens \"()( )\")\n# \"Yes\"\n# >>> $(match_parens \") )\")\n# \"No\"\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_11_string_xor",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> $(vowels_count \"abcde\")\n# \"2\"\n# >>> $(vowels_count \"ACEDY\")\n# \"3\"\n#\n# $1 is a string\nvowels_count() {\n",
+    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> $(string_xor \"010\" \"110\")\n# \"100\"\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_120_maximum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> $(find_max \"name of string\")\n# \"string\"\n# >>> $(find_max \"name enam game\")\n# \"enam\"\n# >>> $(find_max \"aaaaaaa bb cc\")\n# \"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> $(maximum \"-3 -4 5\" \"3\")\n# ['\"-4\"', '\"-3\"', '\"5\"']\n# Example 2:\n# >>> $(maximum \"4 -4 4\" \"2\")\n# ['\"4\"', '\"4\"']\n# Example 3:\n# >>> $(maximum \"-3 2 1 2 -1 -2 1\" \"1\")\n# ['\"2\"']\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_121_solution",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> $(string_to_md5 \"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> $(solution \"5 8 7 1\")\n# \"12\"\n# >>> $(solution \"3 3 3 3 3\")\n# \"9\"\n# >>> $(solution \"30 13 24 321\")\n# \"0\"\n#\n# $1 is a space-separated list\nsolution() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> $(change_base \"8\" \"3\")\n# \"22\"\n# >>> $(change_base \"8\" \"2\")\n# \"1000\"\n# >>> $(change_base \"7\" \"2\")\n# \"111\"\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> $(add_elements \"111 21 3 4000 5 6 7 8 9\" \"4\")\n# \"24\"\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return true if the three\n# sides form a right-angled triangle, false otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> $(right_angle_triangle \"3\" \"4\" \"5\")\n# \"true\"\n# >>> $(right_angle_triangle \"1\" \"2\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> $(get_odd_collatz \"5\")\n# ['\"1\"', '\"5\"']\n#\n# $1 is an integer\nget_odd_collatz() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> $(grade_equation \"4.0 3 1.7 2 3.5\")\n# ['\"A+\"', '\"B\"', '\"C-\"', '\"C\"', '\"A-\"']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns true if the date is valid otherwise false.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> $(valid_date \"03-11-2000\")\n# \"true\"\n# >>> $(valid_date \"15-01-2012\")\n# \"false\"\n# >>> $(valid_date \"04-0-2040\")\n# \"false\"\n# >>> $(valid_date \"06-04-2020\")\n# \"true\"\n# >>> $(valid_date \"06/04/2020\")\n# \"false\"\n#\n# $1 is a string\nvalid_date() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_125_split_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> $(intersperse \"\" \"4\")\n# []\n# >>> $(intersperse \"1 2 3\" \"4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"4\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> $(split_words \"Hello world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"Hello,world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"abcdef\")\n# \"3\"\n#\n# $1 is a string\nsplit_words() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return false. Assume no negative numbers and only integers.\n# Examples\n# >>> $(is_sorted \"5\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5\")\n# \"false\"\n# >>> $(is_sorted \"1 2 3 4 5 6\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5 6 7\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5 6 7\")\n# \"false\"\n# >>> $(is_sorted \"1 2 2 3 3 4\")\n# \"true\"\n# >>> $(is_sorted \"1 2 2 2 3 4\")\n# \"false\"\n#\n# $1 is a space-separated list\nis_sorted() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> $(intersection \"1 2\" \"2 3\")\n# \"NO\"\n# >>> $(intersection \"-1 1\" \"0 4\")\n# \"NO\"\n# >>> $(intersection \"-3 -1\" \"-5 5\")\n# \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> $(prod_signs \"1 2 2 -4\")\n# \"9\"\n# >>> $(prod_signs \"0 1\")\n# \"0\"\n# >>> $(prod_signs \"\")\n# \"None\"\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> $(minPath \"1 2 3\\n4 5 6\\n7 8 9\" \"3\")\n# ['\"1\"', '\"2\"', '\"1\"']\n# >>> $(minPath \"5 9 3\\n4 1 6\\n7 8 2\" \"1\")\n# ['\"1\"']\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> $(longest \"\")\n# \"None\"\n# >>> $(longest \"a b c\")\n# \"a\"\n# >>> $(longest \"a bb ccc\")\n# \"ccc\"\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> $(tri \"3\")\n# ['\"1\"', '\"3\"', '\"2\"', '\"8\"']\n#\n# $1 is an integer\ntri() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> $(digits \"1\")\n# \"1\"\n# >>> $(digits \"4\")\n# \"0\"\n# >>> $(digits \"235\")\n# \"15\"\n#\n# $1 is an integer\ndigits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return true if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> $(is_nested \"[[]]\")\n# \"true\"\n# >>> $(is_nested \"[]]]]]]][[[[[]\")\n# \"false\"\n# >>> $(is_nested \"[][]\")\n# \"false\"\n# >>> $(is_nested \"[]\")\n# \"false\"\n# >>> $(is_nested \"[[][]]\")\n# \"true\"\n# >>> $(is_nested \"[[]][[\")\n# \"true\"\n#\n# $1 is a string\nis_nested() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> $(lst \"1.0 2.0 3.0\")\n# \"14\"\n# >>> $(lst \"1.0 4.0 9.0\")\n# \"98\"\n# >>> $(lst \"1.0 3.0 5.0 7.0\")\n# \"84\"\n# >>> $(lst \"1.4 4.2 0.0\")\n# \"29\"\n# >>> $(lst \"-2.4 1.0 1.0\")\n# \"6\"\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns true if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and false otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> $(check_if_last_char_is_a_letter \"apple pie\")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e\")\n# \"true\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e \")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"\")\n# \"false\"\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> $(can_arrange \"1 2 4 3 5\")\n# \"3\"\n# >>> $(can_arrange \"1 2 3\")\n# \"-1\"\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns a list (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> $(largest_smallest_integers \"2 4 1 3 5 7\")\n# ['\"None\"', '\"1\"']\n# >>> $(largest_smallest_integers \"\")\n# ['\"None\"', '\"None\"']\n# >>> $(largest_smallest_integers \"0\")\n# ['\"None\"', '\"None\"']\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> $(compare_one \"1\" \"2.5\")\n# \"2.5\"\n# >>> $(compare_one \"1\" \"2,3\")\n# \"2,3\"\n# >>> $(compare_one \"5,1\" \"6\")\n# \"6\"\n# >>> $(compare_one \"1\" \"1\")\n# \"None\"\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> $(is_equal_to_sum_even \"4\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"6\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"8\")\n# \"true\"\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> $(special_factorial \"4\")\n# \"288\"\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> $(greatest_common_divisor \"3\" \"5\")\n# \"1\"\n# >>> $(greatest_common_divisor \"25\" \"15\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> $(fix_spaces \" Example\")\n# \"Example\"\n# >>> $(fix_spaces \" Example 1\")\n# \"Example_1\"\n# >>> $(fix_spaces \" Example 2\")\n# \"_Example_2\"\n# >>> $(fix_spaces \" Example 3\")\n# \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> $(file_name_check \"example.txt\")\n# \"Yes\"\n# >>> $(file_name_check \"1example.dll\")\n# \"No\"\n#\n# $1 is a string\nfile_name_check() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> lst\n# []\n# >>> lst\n# ['\"-1\"', '\"-5\"', '\"2\"', '\"-1\"', '\"-5\"']\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> $(words_in_sentence \"This is a test\")\n# \"is\"\n# Example 2:\n# >>> $(words_in_sentence \"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns true if x * n evaluates to a whole number and false\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> $(simplify \"1/5\" \"5/1\")\n# \"true\"\n# >>> $(simplify \"1/6\" \"2/1\")\n# \"false\"\n# >>> $(simplify \"7/10\" \"10/2\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> $(order_by_points \"1 11 -1 -11 -12\")\n# ['\"-1\"', '\"-11\"', '\"1\"', '\"-12\"', '\"11\"']\n# >>> $(order_by_points \"\")\n# []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +604,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> $(specialFilter \"15 -73 14 -15\")\n# \"1\"\n# >>> $(specialFilter \"33 -2 -3 45 21 109\")\n# \"2\"\n#\n# $1 is a space-separated list\nspecialFilter() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    specialFilter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 -2 1 -5\") = \"0\" ]]\n    [[ $(candidate \"15 -73 14 -15\") = \"1\" ]]\n    [[ $(candidate \"33 -2 -3 45 21 109\") = \"2\" ]]\n    [[ $(candidate \"43 -12 93 125 121 109\") = \"4\" ]]\n    [[ $(candidate \"71 -2 -33 75 21 19\") = \"3\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1776,25 +612,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> $(sum_to_n \"30\")\n# \"465\"\n# >>> $(sum_to_n \"100\")\n# \"5050\"\n# >>> $(sum_to_n \"5\")\n# \"15\"\n# >>> $(sum_to_n \"10\")\n# \"55\"\n# >>> $(sum_to_n \"1\")\n# \"1\"\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> $(get_max_triples \"5\")\n# \"1\"\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> $(remove_duplicates \"1 2 3 2 4\")\n# ['\"1\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a list containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty list if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> $(bf \"Jupiter\" \"Neptune\")\n# ['\"Saturn\"', '\"Uranus\"']\n# >>> $(bf \"Earth\" \"Mercury\")\n# \"Venus\"\n# >>> $(bf \"Mercury\" \"Uranus\")\n# ['\"Venus\"', '\"Earth\"', '\"Mars\"', '\"Jupiter\"', '\"Saturn\"']\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> $(list_sort \"aa a aaa\")\n# ['\"aa\"']\n# >>> $(list_sort \"ab a aaa cd\")\n# ['\"ab\"', '\"cd\"']\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> $(all_prefixes \"abc\")\n# ['\"a\"', '\"ab\"', '\"abc\"']\n#\n# $1 is a string\nall_prefixes() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> $(x_or_y \"7\" \"34\" \"12\")\n# \"34\"\n# >>> $(x_or_y \"15\" \"8\" \"5\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> $(double_the_difference \"1 3 2 0\")\n# \"10\"\n# >>> $(double_the_difference \"-1 -2 0\")\n# \"0\"\n# >>> $(double_the_difference \"9 -2\")\n# \"81\"\n# >>> $(double_the_difference \"0\")\n# \"0\"\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> $(compare \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\")\n# ['\"0\"', '\"0\"', '\"0\"', '\"0\"', '\"3\"', '\"3\"']\n# >>> $(compare \"0 5 0 0 0 4\" \"4 1 1 0 0 -2\")\n# ['\"4\"', '\"4\"', '\"1\"', '\"0\"', '\"0\"', '\"6\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> $(Strongest_Extension \"my_class\" \"AA Be CC\")\n# \"my_class.AA\"\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n# >>> $(cycpattern_check \"abcd\" \"abd\")\n# \"false\"\n# >>> $(cycpattern_check \"hello\" \"ell\")\n# \"true\"\n# >>> $(cycpattern_check \"whassup\" \"psus\")\n# \"false\"\n# >>> $(cycpattern_check \"abab\" \"baa\")\n# \"true\"\n# >>> $(cycpattern_check \"efef\" \"eeff\")\n# \"false\"\n# >>> $(cycpattern_check \"himenss\" \"simen\")\n# \"true\"\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an integer. return a list that has the number of even and odd digits respectively.\n# Example:\n# >>> $(even_odd_count \"-12\")\n# ['\"1\"', '\"1\"']\n# >>> $(even_odd_count \"123\")\n# ['\"1\"', '\"2\"']\n#\n# $1 is an integer\neven_odd_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> $(int_to_mini_roman \"19\")\n# \"xix\"\n# >>> $(int_to_mini_roman \"152\")\n# \"clii\"\n# >>> $(int_to_mini_roman \"426\")\n# \"cdxxvi\"\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return true if the three\n# sides form a right-angled triangle, false otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> $(right_angle_triangle \"3\" \"4\" \"5\")\n# \"true\"\n# >>> $(right_angle_triangle \"1\" \"2\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> $(find_max \"name of string\")\n# \"string\"\n# >>> $(find_max \"name enam game\")\n# \"enam\"\n# >>> $(find_max \"aaaaaaa bb cc\")\n# \"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> $(eat \"5\" \"6\" \"10\")\n# ['\"11\"', '\"4\"']\n# >>> $(eat \"4\" \"8\" \"9\")\n# ['\"12\"', '\"1\"']\n# >>> $(eat \"1\" \"10\" \"10\")\n# ['\"11\"', '\"0\"']\n# >>> $(eat \"2\" \"11\" \"5\")\n# ['\"7\"', '\"0\"']\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> $(string_sequence \"0\")\n# \"0\"\n# >>> $(string_sequence \"5\")\n# \"0 1 2 3 4 5\"\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> $(solve \"1234\")\n# \"4321\"\n# >>> $(solve \"ab\")\n# \"AB\"\n# >>> $(solve \"#a@C\")\n# \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> $(string_to_md5 \"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +832,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> $(generate_integers \"2\" \"8\")\n# ['\"2\"', '\"4\"', '\"6\"', '\"8\"']\n# >>> $(generate_integers \"8\" \"2\")\n# ['\"2\"', '\"4\"', '\"6\"', '\"8\"']\n# >>> $(generate_integers \"10\" \"14\")\n# []\n#\n# $1 is an integer\n# $2 is an integer\ngenerate_integers() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    generate_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"10\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"10\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"132\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"17\" \"89\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1812,49 +840,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> $(rolling_max \"1 2 3 2 3 4 2\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"3\"', '\"3\"', '\"4\"', '\"4\"']\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> $(count_distinct_characters \"xyzXYZ\")\n# \"3\"\n# >>> $(count_distinct_characters \"Jerry\")\n# \"4\"\n#\n# $1 is a string\ncount_distinct_characters() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return true. Otherwise it should return false.\n# >>> $(below_zero \"1 2 3\")\n# \"false\"\n# >>> $(below_zero \"1 2 -4 5\")\n# \"true\"\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> $(parse_music \"o o| .| o| o| .| .| .| .| o o\")\n# ['\"4\"', '\"2\"', '\"1\"', '\"2\"', '\"2\"', '\"1\"', '\"1\"', '\"1\"', '\"1\"', '\"4\"', '\"4\"']\n#\n# $1 is a string\nparse_music() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> $(search \"4 1 2 2 3 1\")\n# \"2\"\n# >>> $(search \"1 2 2 3 3 3 4 4 4\")\n# \"3\"\n# >>> $(search \"5 5 4 4 4\")\n# \"-1\"\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> $(how_many_times \"\" \"a\")\n# \"0\"\n# >>> $(how_many_times \"aaa\" \"a\")\n# \"3\"\n# >>> $(how_many_times \"aaaa\" \"aa\")\n# \"3\"\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"(\")\n# \"false\"\n# >>> $(correct_bracketing \"()\")\n# \"true\"\n# >>> $(correct_bracketing \"(()())\")\n# \"true\"\n# >>> $(correct_bracketing \")(()\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> $(sort_numbers \"three one five\")\n# \"one three five\"\n#\n# $1 is a string\nsort_numbers() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> $(separate_paren_groups \"( ) (( )) (( )( ))\")\n# ['\"()\"', '\"(())\"', '\"(()())\"']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.2\")\n# ['\"2.0\"', '\"2.2\"']\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.0\")\n# ['\"2.0\"', '\"2.0\"']\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> $(rescale_to_unit \"1.0 2.0 3.0 4.0 5.0\")\n# ['\"0.0\"', '\"0.25\"', '\"0.5\"', '\"0.75\"', '\"1.0\"']\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Filter given list of any shthon values only for integers\n# >>> $(filter_integers \"a 3.14 5\")\n# ['\"5\"']\n# >>> $(filter_integers \"1 2 3 abc  \")\n# ['\"1\"', '\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> $(strlen \"\")\n# \"0\"\n# >>> $(strlen \"abc\")\n# \"3\"\n#\n# $1 is a string\nstrlen() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> $(largest_divisor \"15\")\n# \"5\"\n#\n# $1 is an integer\nlargest_divisor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> $(factorize \"8\")\n# ['\"2\"', '\"2\"', '\"2\"']\n# >>> $(factorize \"25\")\n# ['\"5\"', '\"5\"']\n# >>> $(factorize \"70\")\n# ['\"2\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nfactorize() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> $(remove_duplicates \"1 2 3 2 4\")\n# ['\"1\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> $(flip_case \"Hello\")\n# \"hELLO\"\n#\n# $1 is a string\nflip_case() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> $(concatenate \"\")\n# \"\"\n# >>> $(concatenate \"a b c\")\n# \"abc\"\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> $(truncate_number \"3.5\")\n# \"0.5\"\n#\n# $1 is a floating point\ntruncate_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> $(get_positive \"-1 2 -4 5 6\")\n# ['\"2\"', '\"5\"', '\"6\"']\n# >>> $(get_positive \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# ['\"5\"', '\"3\"', '\"2\"', '\"3\"', '\"9\"', '\"123\"', '\"1\"']\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> $(is_prime \"6\")\n# \"false\"\n# >>> $(is_prime \"101\")\n# \"true\"\n# >>> $(is_prime \"11\")\n# \"true\"\n# >>> $(is_prime \"13441\")\n# \"true\"\n# >>> $(is_prime \"61\")\n# \"true\"\n# >>> $(is_prime \"4\")\n# \"false\"\n# >>> $(is_prime \"1\")\n# \"false\"\n#\n# $1 is an integer\nis_prime() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> $(sort_third \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_third \"5 6 3 4 8 9 2\")\n# ['\"2\"', '\"6\"', '\"3\"', '\"4\"', '\"8\"', '\"9\"', '\"5\"']\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> $(unique \"5 3 5 2 3 3 9 0 123\")\n# ['\"0\"', '\"2\"', '\"3\"', '\"5\"', '\"9\"', '\"123\"']\n#\n# $1 is a space-separated list\nunique() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> $(max_element \"1 2 3\")\n# \"3\"\n# >>> $(max_element \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# \"123\"\n#\n# $1 is a space-separated list\nmax_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> $(fizz_buzz \"50\")\n# \"0\"\n# >>> $(fizz_buzz \"78\")\n# \"2\"\n# >>> $(fizz_buzz \"79\")\n# \"3\"\n#\n# $1 is an integer\nfizz_buzz() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1096,201 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> $(sort_even \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_even \"5 6 3 4\")\n# ['\"3\"', '\"6\"', '\"5\"', '\"4\"']\n#\n# $1 is a space-separated list\nsort_even() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    sort_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 123 1 -10\") = \"-10 3 -5 2 -3 3 5 0 9 1 123\" ]]\n    [[ $(candidate \"5 8 -12 4 23 2 3 11 12 -10\") = \"-12 8 3 4 5 2 12 11 23 -10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> $(prime_fib \"1\")\n# \"2\"\n# >>> $(prime_fib \"2\")\n# \"3\"\n# >>> $(prime_fib \"3\")\n# \"5\"\n# >>> $(prime_fib \"4\")\n# \"13\"\n# >>> $(prime_fib \"5\")\n# \"89\"\n#\n# $1 is an integer\nprime_fib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return true. Otherwise it should return false.\n# >>> $(below_zero \"1 2 3\")\n# \"false\"\n# >>> $(below_zero \"1 2 -4 5\")\n# \"true\"\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns true if there are three distinct elements in the list that\n# sum to zero, and false otherwise.\n# >>> $(triples_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"1 3 -2 1\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"2 4 -5 3 9 7\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> $(incr_list \"1 2 3\")\n# ['\"2\"', '\"3\"', '\"4\"']\n# >>> $(incr_list \"5 3 5 2 3 3 9 0 123\")\n# ['\"6\"', '\"4\"', '\"6\"', '\"3\"', '\"4\"', '\"4\"', '\"10\"', '\"1\"', '\"124\"']\n#\n# $1 is a space-separated list\nincr_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns true if there are two distinct elements in the list that\n# sum to zero, and false otherwise.\n# >>> $(pairs_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 3 -2 1\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"2 4 -5 3 5 7\")\n# \"true\"\n# >>> $(pairs_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> $(change_base \"8\" \"3\")\n# \"22\"\n# >>> $(change_base \"8\" \"2\")\n# \"1000\"\n# >>> $(change_base \"7\" \"2\")\n# \"111\"\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> $(triangle_area \"5\" \"3\")\n# \"7.5\"\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> $(fib4 \"5\")\n# \"4\"\n# >>> $(fib4 \"6\")\n# \"8\"\n# >>> $(fib4 \"7\")\n# \"14\"\n#\n# $1 is an integer\nfib4() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> $(median \"3 1 2 4 5\")\n# \"3\"\n# >>> $(median \"-10 4 6 1000 10 20\")\n# \"15.0\"\n#\n# $1 is a space-separated list\nmedian() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> $(is_palindrome \"\")\n# \"true\"\n# >>> $(is_palindrome \"aba\")\n# \"true\"\n# >>> $(is_palindrome \"aaaaa\")\n# \"true\"\n# >>> $(is_palindrome \"zbcd\")\n# \"false\"\n#\n# $1 is a string\nis_palindrome() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> $(modp \"3\" \"5\")\n# \"3\"\n# >>> $(modp \"1101\" \"101\")\n# \"2\"\n# >>> $(modp \"0\" \"101\")\n# \"1\"\n# >>> $(modp \"3\" \"11\")\n# \"8\"\n# >>> $(modp \"100\" \"101\")\n# \"1\"\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> $(mean_absolute_deviation \"1.0 2.0 3.0 4.0\")\n# \"1.0\"\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> $(remove_vowels \"\")\n# \"\"\n# >>> $(remove_vowels \"abcdef\")\n# \"bcdf\"\n# >>> $(remove_vowels \"aaaaa\")\n# \"\"\n# >>> $(remove_vowels \"aaBAA\")\n# \"B\"\n# >>> $(remove_vowels \"zbcd\")\n# \"zbcd\"\n#\n# $1 is a string\nremove_vowels() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true if all numbers in the list l are below threshold t.\n# >>> $(below_threshold \"1 2 4 10\" \"100\")\n# \"true\"\n# >>> $(below_threshold \"1 20 4 10\" \"5\")\n# \"false\"\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> $(add \"2\" \"3\")\n# \"5\"\n# >>> $(add \"5\" \"7\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if two words have the same characters.\n# >>> $(same_chars \"eabcdzzzz\" \"dddzzzzzzzddeddabc\")\n# \"true\"\n# >>> $(same_chars \"abcd\" \"dddddddabc\")\n# \"true\"\n# >>> $(same_chars \"dddddddabc\" \"abcd\")\n# \"true\"\n# >>> $(same_chars \"eabcd\" \"dddddddabc\")\n# \"false\"\n# >>> $(same_chars \"abcd\" \"dddddddabce\")\n# \"false\"\n# >>> $(same_chars \"eabcdzzzz\" \"dddzzzzzzzddddabc\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsame_chars() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    same_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") = \"true\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabc\") = \"true\" ]]\n    [[ $(candidate \"dddddddabc\" \"abcd\") = \"true\" ]]\n    [[ $(candidate \"eabcd\" \"dddddddabc\") = \"false\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabcf\") = \"false\" ]]\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") = \"false\" ]]\n    [[ $(candidate \"aabb\" \"aaccc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> $(fib \"10\")\n# \"55\"\n# >>> $(fib \"1\")\n# \"1\"\n# >>> $(fib \"8\")\n# \"21\"\n#\n# $1 is an integer\nfib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# brackets is a string of \"<\" and \">\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"<\")\n# \"false\"\n# >>> $(correct_bracketing \"<>\")\n# \"true\"\n# >>> $(correct_bracketing \"<<><>>\")\n# \"true\"\n# >>> $(correct_bracketing \"><<>\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"<>\") = \"true\" ]]\n    [[ $(candidate \"<<><>>\") = \"true\" ]]\n    [[ $(candidate \"<><><<><>><>\") = \"true\" ]]\n    [[ $(candidate \"<><><<<><><>><>><<><><<>>>\") = \"true\" ]]\n    [[ $(candidate \"<<<><>>>>\") = \"false\" ]]\n    [[ $(candidate \"><<>\") = \"false\" ]]\n    [[ $(candidate \"<\") = \"false\" ]]\n    [[ $(candidate \"<<<<\") = \"false\" ]]\n    [[ $(candidate \">\") = \"false\" ]]\n    [[ $(candidate \"<<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>><<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>>><>\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true is list elements are monotonically increasing or decreasing.\n# >>> $(monotonic \"1 2 4 20\")\n# \"true\"\n# >>> $(monotonic \"1 20 4 10\")\n# \"false\"\n# >>> $(monotonic \"4 1 0 -10\")\n# \"true\"\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> $(common \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\")\n# ['\"1\"', '\"5\"', '\"653\"']\n# >>> $(common \"5 3 2 8\" \"3 2\")\n# ['\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> $(largest_prime_factor \"13195\")\n# \"29\"\n# >>> $(largest_prime_factor \"2048\")\n# \"2\"\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> $(intersperse \"\" \"4\")\n# []\n# >>> $(intersperse \"1 2 3\" \"4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"4\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> $(sum_to_n \"30\")\n# \"465\"\n# >>> $(sum_to_n \"100\")\n# \"5050\"\n# >>> $(sum_to_n \"5\")\n# \"15\"\n# >>> $(sum_to_n \"10\")\n# \"55\"\n# >>> $(sum_to_n \"1\")\n# \"1\"\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return true if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"(\")\n# \"false\"\n# >>> $(correct_bracketing \"()\")\n# \"true\"\n# >>> $(correct_bracketing \"(()())\")\n# \"true\"\n# >>> $(correct_bracketing \")(()\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> $(derivative \"3 1 2 4 5\")\n# ['\"1\"', '\"4\"', '\"12\"', '\"20\"']\n# >>> $(derivative \"1 2 3\")\n# ['\"2\"', '\"6\"']\n#\n# $1 is a space-separated list\nderivative() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> $(fibfib \"1\")\n# \"0\"\n# >>> $(fibfib \"5\")\n# \"4\"\n# >>> $(fibfib \"8\")\n# \"24\"\n#\n# $1 is an integer\nfibfib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> $(vowels_count \"abcde\")\n# \"2\"\n# >>> $(vowels_count \"ACEDY\")\n# \"3\"\n#\n# $1 is a string\nvowels_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> $(circular_shift \"12\" \"1\")\n# \"21\"\n# >>> $(circular_shift \"12\" \"2\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> $(digitSum \"\")\n# \"0\"\n# >>> $(digitSum \"abAB\")\n# \"131\"\n# >>> $(digitSum \"abcCd\")\n# \"67\"\n# >>> $(digitSum \"helloE\")\n# \"69\"\n# >>> $(digitSum \"woArBld\")\n# \"131\"\n# >>> $(digitSum \"aAaaaXa\")\n# \"153\"\n#\n# $1 is a string\ndigitSum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> $(fruit_distribution \"5 apples and 6 oranges\" \"19\")\n# \"8\"\n# >>> $(fruit_distribution \"0 apples and 1 oranges\" \"3\")\n# \"2\"\n# >>> $(fruit_distribution \"2 apples and 3 oranges\" \"100\")\n# \"95\"\n# >>> $(fruit_distribution \"100 apples and 1 oranges\" \"120\")\n# \"19\"\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> $(pluck \"4 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> $(pluck \"1 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> $(pluck \"\")\n# []\n# Example 4:\n# >>> $(pluck \"5 0 3 0 4 2\")\n# ['\"0\"', '\"1\"']\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> $(search \"4 1 2 2 3 1\")\n# \"2\"\n# >>> $(search \"1 2 2 3 3 3 4 4 4\")\n# \"3\"\n# >>> $(search \"5 5 4 4 4\")\n# \"-1\"\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> $(parse_nested_parens \"(()()) ((())) () ((())()())\")\n# ['\"2\"', '\"3\"', '\"1\"', '\"3\"']\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> $(strange_sort_list \"1 2 3 4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"3\"']\n# >>> $(strange_sort_list \"5 5 5 5\")\n# ['\"5\"', '\"5\"', '\"5\"', '\"5\"']\n# >>> $(strange_sort_list \"\")\n# []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> $(triangle_area \"3\" \"4\" \"5\")\n# \"6.0\"\n# >>> $(triangle_area \"1\" \"2\" \"10\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns true if the object q will fly, and false otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> $(will_it_fly \"1 2\" \"5\")\n# \"false\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> $(will_it_fly \"3 2 3\" \"1\")\n# \"false\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> $(will_it_fly \"3 2 3\" \"9\")\n# \"true\"\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> $(will_it_fly \"3\" \"5\")\n# \"true\"\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> $(smallest_change \"1 2 3 5 4 7 9 6\")\n# \"4\"\n# >>> $(smallest_change \"1 2 3 4 3 2 2\")\n# \"1\"\n# >>> $(smallest_change \"1 2 3 2 1\")\n# \"0\"\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> $(total_match \"\" \"\")\n# []\n# >>> $(total_match \"hi admin\" \"hI Hi\")\n# ['\"hI\"', '\"Hi\"']\n# >>> $(total_match \"hi admin\" \"hi hi admin project\")\n# ['\"hi\"', '\"admin\"']\n# >>> $(total_match \"hi admin\" \"hI hi hi\")\n# ['\"hI\"', '\"hi\"', '\"hi\"']\n# >>> $(total_match \"4\" \"1 2 3 4 5\")\n# ['\"4\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> $(is_multiply_prime \"30\")\n# \"true\"\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> $(is_simple_power \"1\" \"4\")\n# \"true\"\n# >>> $(is_simple_power \"2\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"8\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"3\" \"2\")\n# \"false\"\n# >>> $(is_simple_power \"3\" \"1\")\n# \"false\"\n# >>> $(is_simple_power \"5\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns true \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> $(iscube \"1\")\n# \"true\"\n# >>> $(iscube \"2\")\n# \"false\"\n# >>> $(iscube \"-1\")\n# \"true\"\n# >>> $(iscube \"64\")\n# \"true\"\n# >>> $(iscube \"0\")\n# \"true\"\n# >>> $(iscube \"180\")\n# \"false\"\n#\n# $1 is an integer\niscube() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> $(hex_key \"AB\")\n# \"1\"\n# >>> $(hex_key \"1077E\")\n# \"2\"\n# >>> $(hex_key \"ABED1A33\")\n# \"4\"\n# >>> $(hex_key \"123456789ABCDEF0\")\n# \"6\"\n# >>> $(hex_key \"2020\")\n# \"2\"\n#\n# $1 is a string\nhex_key() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> $(decimal_to_binary \"15\")\n# \"db1111db\"\n# >>> $(decimal_to_binary \"32\")\n# \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is hapsh or not.\n# A string is hapsh if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> $(is_happy \"a\")\n# \"false\"\n# >>> $(is_happy \"aa\")\n# \"false\"\n# >>> $(is_happy \"abcd\")\n# \"true\"\n# >>> $(is_happy \"aabb\")\n# \"false\"\n# >>> $(is_happy \"adb\")\n# \"true\"\n# >>> $(is_happy \"xyy\")\n# \"false\"\n#\n# $1 is a string\nis_happy() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> $(grade_equation \"4.0 3 1.7 2 3.5\")\n# ['\"A+\"', '\"B\"', '\"C-\"', '\"C\"', '\"A-\"']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns true if the string\n# length is a prime number or false otherwise\n# Examples\n# >>> $(prime_length \"Hello\")\n# \"true\"\n# >>> $(prime_length \"abcdcba\")\n# \"true\"\n# >>> $(prime_length \"kittens\")\n# \"true\"\n# >>> $(prime_length \"orange\")\n# \"false\"\n#\n# $1 is a string\nprime_length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> $(solve \"1000\")\n# \"1\"\n# >>> $(solve \"150\")\n# \"110\"\n# >>> $(solve \"147\")\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> $(add \"4 2 6 7\")\n# \"2\"\n#\n# $1 is a space-separated list\nadd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> $(anti_shuffle \"Hi\")\n# \"Hi\"\n# >>> $(anti_shuffle \"hello\")\n# \"ehllo\"\n# >>> $(anti_shuffle \"Hello World\\!\\!\\!\")\n# \"Hello \\!\\!\\!Wdlor\"\n#\n# $1 is a string\nanti_shuffle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of lists, [(x1, y1), (x2, y2) ...] such that\n# each list is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> $(get_row \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\")\n# [['\"0\"', '\"0\"'], ['\"1\"', '\"4\"'], ['\"1\"', '\"0\"'], ['\"2\"', '\"5\"'], ['\"2\"', '\"0\"']]\n# >>> $(get_row \"\" \"1\")\n# []\n# >>> $(get_row \"\\n1\\n1 2 3\" \"3\")\n# [['\"2\"', '\"2\"']]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a cosh of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> $(sort_array \"\")\n# []\n# >>> $(sort_array \"5\")\n# ['\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5 6\")\n# ['\"6\"', '\"5\"', '\"4\"', '\"3\"', '\"2\"', '\"1\"', '\"0\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> $(encrypt \"hi\")\n# \"lm\"\n# >>> $(encrypt \"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> $(encrypt \"gf\")\n# \"kj\"\n# >>> $(encrypt \"et\")\n# \"ix\"\n#\n# $1 is a string\nencrypt() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of integers, return a list consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> $(sum_product \"\")\n# ['\"0\"', '\"1\"']\n# >>> $(sum_product \"1 2 3 4\")\n# ['\"10\"', '\"24\"']\n#\n# $1 is a space-separated list\nsum_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> $(next_smallest \"1 2 3 4 5\")\n# \"2\"\n# >>> $(next_smallest \"5 1 4 3 2\")\n# \"2\"\n# >>> $(next_smallest \"\")\n# \"None\"\n# >>> $(next_smallest \"1 1\")\n# \"None\"\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> $(is_bored \"Hello world\")\n# \"0\"\n# >>> $(is_bored \"The sky is blue. The sun is shining. I love this weather\")\n# \"1\"\n#\n# $1 is a string\nis_bored() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> $(any_int \"5\" \"2\" \"7\")\n# \"true\"\n# >>> $(any_int \"3\" \"2\" \"2\")\n# \"false\"\n# >>> $(any_int \"3\" \"-2\" \"1\")\n# \"true\"\n# >>> $(any_int \"3.6\" \"-2.2\" \"2\")\n# \"false\"\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> $(encode \"test\")\n# \"TGST\"\n# >>> $(encode \"This is a message\")\n# \"tHKS KS C MGSSCGG\"\n#\n# $1 is a string\nencode() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> $(skjkasdkd \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\")\n# \"10\"\n# >>> $(skjkasdkd \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\")\n# \"25\"\n# >>> $(skjkasdkd \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\")\n# \"13\"\n# >>> $(skjkasdkd \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\")\n# \"11\"\n# >>> $(skjkasdkd \"0 81 12 3 1 21\")\n# \"3\"\n# >>> $(skjkasdkd \"0 8 1 2 1 7\")\n# \"7\"\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a CSV, return true if all keys are strings in lower \n# case or all keys are strings in upper case, else return false.\n# The function should return false is the given CSV is empty.\n# Examples:\n# >>> $(check_dict_case \"a,apple\\nb,banana\")\n# \"true\"\n# >>> $(check_dict_case \"a,apple\\nA,banana\\nB,banana\")\n# \"false\"\n# >>> $(check_dict_case \"a,apple\\n8,banana\")\n# \"false\"\n# >>> $(check_dict_case \"Name,John\\nAge,36\\nCity,Houston\")\n# \"false\"\n# >>> $(check_dict_case \"STATE,NC\\nZIP,12345\")\n# \"true\"\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> $(count_up_to \"5\")\n# ['\"2\"', '\"3\"']\n# >>> $(count_up_to \"11\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"']\n# >>> $(count_up_to \"0\")\n# []\n# >>> $(count_up_to \"20\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"', '\"19\"']\n# >>> $(count_up_to \"1\")\n# []\n# >>> $(count_up_to \"18\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"']\n#\n# $1 is an integer\ncount_up_to() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> $(multiply \"148\" \"412\")\n# \"16\"\n# >>> $(multiply \"19\" \"28\")\n# \"72\"\n# >>> $(multiply \"2020\" \"1851\")\n# \"0\"\n# >>> $(multiply \"14\" \"-15\")\n# \"20\"\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> $(count_upper \"aBCdEf\")\n# \"1\"\n# >>> $(count_upper \"abcdefg\")\n# \"0\"\n# >>> $(count_upper \"dBBE\")\n# \"0\"\n#\n# $1 is a string\ncount_upper() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> $(closest_integer \"10\")\n# \"10\"\n# >>> $(closest_integer \"15.3\")\n# \"15\"\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> $(rolling_max \"1 2 3 2 3 4 2\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"3\"', '\"3\"', '\"4\"', '\"4\"']\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-sh-transform.json
+++ b/prompts/humaneval-sh-transform.json
@@ -1,1380 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> $(strlen \"\")\n# \"0\"\n# >>> $(strlen \"abc\")\n# \"3\"\n#\n# $1 is a string\nstrlen() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> $(encrypt \"hi\")\n# \"lm\"\n# >>> $(encrypt \"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> $(encrypt \"gf\")\n# \"kj\"\n# >>> $(encrypt \"et\")\n# \"ix\"\n#\n# $1 is a string\nencrypt() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> $(check_dict_case \"a,apple\\nb,banana\")\n# \"true\"\n# >>> $(check_dict_case \"a,apple\\nA,banana\\nB,banana\")\n# \"false\"\n# >>> $(check_dict_case \"a,apple\\n8,banana\")\n# \"false\"\n# >>> $(check_dict_case \"Name,John\\nAge,36\\nCity,Houston\")\n# \"false\"\n# >>> $(check_dict_case \"STATE,NC\\nZIP,12345\")\n# \"true\"\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> $(add \"4 2 6 7\")\n# \"2\"\n#\n# $1 is a space-separated list\nadd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> $(fix_spaces \" Example\")\n# \"Example\"\n# >>> $(fix_spaces \" Example 1\")\n# \"Example_1\"\n# >>> $(fix_spaces \" Example 2\")\n# \"_Example_2\"\n# >>> $(fix_spaces \" Example 3\")\n# \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> $(fibfib \"1\")\n# \"0\"\n# >>> $(fibfib \"5\")\n# \"4\"\n# >>> $(fibfib \"8\")\n# \"24\"\n#\n# $1 is an integer\nfibfib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> $(double_the_difference \"1 3 2 0\")\n# \"10\"\n# >>> $(double_the_difference \"-1 -2 0\")\n# \"0\"\n# >>> $(double_the_difference \"9 -2\")\n# \"81\"\n# >>> $(double_the_difference \"0\")\n# \"0\"\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n# >>> $(filter_integers \"a 3.14 5\")\n# ['\"5\"']\n# >>> $(filter_integers \"1 2 3 abc  \")\n# ['\"1\"', '\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> $(parse_music \"o o| .| o| o| .| .| .| .| o o\")\n# ['\"4\"', '\"2\"', '\"1\"', '\"2\"', '\"2\"', '\"1\"', '\"1\"', '\"1\"', '\"1\"', '\"4\"', '\"4\"']\n#\n# $1 is a string\nparse_music() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> $(decimal_to_binary \"15\")\n# \"db1111db\"\n# >>> $(decimal_to_binary \"32\")\n# \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> $(all_prefixes \"abc\")\n# ['\"a\"', '\"ab\"', '\"abc\"']\n#\n# $1 is a string\nall_prefixes() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> $(add \"2\" \"3\")\n# \"5\"\n# >>> $(add \"5\" \"7\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> $(eat \"5\" \"6\" \"10\")\n# ['\"11\"', '\"4\"']\n# >>> $(eat \"4\" \"8\" \"9\")\n# ['\"12\"', '\"1\"']\n# >>> $(eat \"1\" \"10\" \"10\")\n# ['\"11\"', '\"0\"']\n# >>> $(eat \"2\" \"11\" \"5\")\n# ['\"7\"', '\"0\"']\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> $(max_fill \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\")\n# \"6\"\n# Example 2:\n# >>> $(max_fill \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\")\n# \"5\"\n# Example 3:\n# >>> $(max_fill \"0 0 0\\n0 0 0\" \"5\")\n# \"0\"\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> $(flip_case \"Hello\")\n# \"hELLO\"\n#\n# $1 is a string\nflip_case() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> $(by_length \"2 1 1 4 5 8 2 3\")\n# ['\"Eight\"', '\"Five\"', '\"Four\"', '\"Three\"', '\"Two\"', '\"Two\"', '\"One\"', '\"One\"']\n# If the array is empty, return an empty array:\n# >>> $(by_length \"\")\n# []\n# If the array has any strange number ignore it:\n# >>> $(by_length \"1 -1 55\")\n# ['\"One\"']\n#\n# $1 is a space-separated list\nby_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> $(factorize \"8\")\n# ['\"2\"', '\"2\"', '\"2\"']\n# >>> $(factorize \"25\")\n# ['\"5\"', '\"5\"']\n# >>> $(factorize \"70\")\n# ['\"2\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nfactorize() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> $(count_up_to \"5\")\n# ['\"2\"', '\"3\"']\n# >>> $(count_up_to \"11\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"']\n# >>> $(count_up_to \"0\")\n# []\n# >>> $(count_up_to \"20\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"', '\"19\"']\n# >>> $(count_up_to \"1\")\n# []\n# >>> $(count_up_to \"18\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"']\n#\n# $1 is an integer\ncount_up_to() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> $(unique \"5 3 5 2 3 3 9 0 123\")\n# ['\"0\"', '\"2\"', '\"3\"', '\"5\"', '\"9\"', '\"123\"']\n#\n# $1 is a space-separated list\nunique() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> $(total_match \"\" \"\")\n# []\n# >>> $(total_match \"hi admin\" \"hI Hi\")\n# ['\"hI\"', '\"Hi\"']\n# >>> $(total_match \"hi admin\" \"hi hi admin project\")\n# ['\"hi\"', '\"admin\"']\n# >>> $(total_match \"hi admin\" \"hI hi hi\")\n# ['\"hI\"', '\"hi\"', '\"hi\"']\n# >>> $(total_match \"4\" \"1 2 3 4 5\")\n# ['\"4\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> $(max_element \"1 2 3\")\n# \"3\"\n# >>> $(max_element \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# \"123\"\n#\n# $1 is a space-separated list\nmax_element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> $(is_nested \"[[]]\")\n# \"true\"\n# >>> $(is_nested \"[]]]]]]][[[[[]\")\n# \"false\"\n# >>> $(is_nested \"[][]\")\n# \"false\"\n# >>> $(is_nested \"[]\")\n# \"false\"\n# >>> $(is_nested \"[[][]]\")\n# \"true\"\n# >>> $(is_nested \"[[]][[\")\n# \"true\"\n#\n# $1 is a string\nis_nested() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> $(rounded_avg \"1\" \"5\")\n# \"0b11\"\n# >>> $(rounded_avg \"7\" \"5\")\n# \"-1\"\n# >>> $(rounded_avg \"10\" \"20\")\n# \"0b1111\"\n# >>> $(rounded_avg \"20\" \"33\")\n# \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> $(move_one_ball \"3 4 5 1 2\")\n# \"true\"\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> $(move_one_ball \"3 5 4 1 2\")\n# \"false\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> $(even_odd_palindrome \"3\")\n# ['\"1\"', '\"2\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> $(even_odd_palindrome \"12\")\n# ['\"4\"', '\"6\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> $(is_equal_to_sum_even \"4\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"6\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"8\")\n# \"true\"\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> $(derivative \"3 1 2 4 5\")\n# ['\"1\"', '\"4\"', '\"12\"', '\"20\"']\n# >>> $(derivative \"1 2 3\")\n# ['\"2\"', '\"6\"']\n#\n# $1 is a space-separated list\nderivative() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> $(is_sorted \"5\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5\")\n# \"false\"\n# >>> $(is_sorted \"1 2 3 4 5 6\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5 6 7\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5 6 7\")\n# \"false\"\n# >>> $(is_sorted \"1 2 2 3 3 4\")\n# \"true\"\n# >>> $(is_sorted \"1 2 2 2 3 4\")\n# \"false\"\n#\n# $1 is a space-separated list\nis_sorted() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> $(solve \"1234\")\n# \"4321\"\n# >>> $(solve \"ab\")\n# \"AB\"\n# >>> $(solve \"#a@C\")\n# \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> $(tri \"3\")\n# ['\"1\"', '\"3\"', '\"2\"', '\"8\"']\n#\n# $1 is an integer\ntri() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> $(fizz_buzz \"50\")\n# \"0\"\n# >>> $(fizz_buzz \"78\")\n# \"2\"\n# >>> $(fizz_buzz \"79\")\n# \"3\"\n#\n# $1 is an integer\nfizz_buzz() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> $(solve \"1000\")\n# \"1\"\n# >>> $(solve \"150\")\n# \"110\"\n# >>> $(solve \"147\")\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> $(minPath \"1 2 3\\n4 5 6\\n7 8 9\" \"3\")\n# ['\"1\"', '\"2\"', '\"1\"']\n# >>> $(minPath \"5 9 3\\n4 1 6\\n7 8 2\" \"1\")\n# ['\"1\"']\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> $(count_upper \"aBCdEf\")\n# \"1\"\n# >>> $(count_upper \"abcdefg\")\n# \"0\"\n# >>> $(count_upper \"dBBE\")\n# \"0\"\n#\n# $1 is a string\ncount_upper() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> $(maximum \"-3 -4 5\" \"3\")\n# ['\"-4\"', '\"-3\"', '\"5\"']\n# Example 2:\n# >>> $(maximum \"4 -4 4\" \"2\")\n# ['\"4\"', '\"4\"']\n# Example 3:\n# >>> $(maximum \"-3 2 1 2 -1 -2 1\" \"1\")\n# ['\"2\"']\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> $(largest_divisor \"15\")\n# \"5\"\n#\n# $1 is an integer\nlargest_divisor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> $(sort_array \"\")\n# []\n# >>> $(sort_array \"5\")\n# ['\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5 6\")\n# ['\"6\"', '\"5\"', '\"4\"', '\"3\"', '\"2\"', '\"1\"', '\"0\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> $(f \"5\")\n# ['\"1\"', '\"2\"', '\"6\"', '\"24\"', '\"15\"']\n#\n# $1 is an integer\nf() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> $(iscube \"1\")\n# \"true\"\n# >>> $(iscube \"2\")\n# \"false\"\n# >>> $(iscube \"-1\")\n# \"true\"\n# >>> $(iscube \"64\")\n# \"true\"\n# >>> $(iscube \"0\")\n# \"true\"\n# >>> $(iscube \"180\")\n# \"false\"\n#\n# $1 is an integer\niscube() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> $(encode \"test\")\n# \"TGST\"\n# >>> $(encode \"This is a message\")\n# \"tHKS KS C MGSSCGG\"\n#\n# $1 is a string\nencode() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> $(is_bored \"Hello world\")\n# \"0\"\n# >>> $(is_bored \"The sky is blue. The sun is shining. I love this weather\")\n# \"1\"\n#\n# $1 is a string\nis_bored() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> $(pairs_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 3 -2 1\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"2 4 -5 3 5 7\")\n# \"true\"\n# >>> $(pairs_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> $(triangle_area \"3\" \"4\" \"5\")\n# \"6.0\"\n# >>> $(triangle_area \"1\" \"2\" \"10\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> $(bf \"Jupiter\" \"Neptune\")\n# ['\"Saturn\"', '\"Uranus\"']\n# >>> $(bf \"Earth\" \"Mercury\")\n# \"Venus\"\n# >>> $(bf \"Mercury\" \"Uranus\")\n# ['\"Venus\"', '\"Earth\"', '\"Mars\"', '\"Jupiter\"', '\"Saturn\"']\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> $(digits \"1\")\n# \"1\"\n# >>> $(digits \"4\")\n# \"0\"\n# >>> $(digits \"235\")\n# \"15\"\n#\n# $1 is an integer\ndigits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> $(words_string \"Hi, my name is John\")\n# ['\"Hi\"', '\"my\"', '\"name\"', '\"is\"', '\"John\"']\n# >>> $(words_string \"One, two, three, four, five, six\")\n# ['\"One\"', '\"two\"', '\"three\"', '\"four\"', '\"five\"', '\"six\"']\n#\n# $1 is a string\nwords_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> $(how_many_times \"\" \"a\")\n# \"0\"\n# >>> $(how_many_times \"aaa\" \"a\")\n# \"3\"\n# >>> $(how_many_times \"aaaa\" \"aa\")\n# \"3\"\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> $(compare_one \"1\" \"2.5\")\n# \"2.5\"\n# >>> $(compare_one \"1\" \"2,3\")\n# \"2,3\"\n# >>> $(compare_one \"5,1\" \"6\")\n# \"6\"\n# >>> $(compare_one \"1\" \"1\")\n# \"None\"\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> $(remove_vowels \"\")\n# \"\"\n# >>> $(remove_vowels \"abcdef\")\n# \"bcdf\"\n# >>> $(remove_vowels \"aaaaa\")\n# \"\"\n# >>> $(remove_vowels \"aaBAA\")\n# \"B\"\n# >>> $(remove_vowels \"zbcd\")\n# \"zbcd\"\n#\n# $1 is a string\nremove_vowels() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> $(strange_sort_list \"1 2 3 4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"3\"']\n# >>> $(strange_sort_list \"5 5 5 5\")\n# ['\"5\"', '\"5\"', '\"5\"', '\"5\"']\n# >>> $(strange_sort_list \"\")\n# []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.2\")\n# ['\"2.0\"', '\"2.2\"']\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.0\")\n# ['\"2.0\"', '\"2.0\"']\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> $(is_simple_power \"1\" \"4\")\n# \"true\"\n# >>> $(is_simple_power \"2\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"8\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"3\" \"2\")\n# \"false\"\n# >>> $(is_simple_power \"3\" \"1\")\n# \"false\"\n# >>> $(is_simple_power \"5\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> $(prime_fib \"1\")\n# \"2\"\n# >>> $(prime_fib \"2\")\n# \"3\"\n# >>> $(prime_fib \"3\")\n# \"5\"\n# >>> $(prime_fib \"4\")\n# \"13\"\n# >>> $(prime_fib \"5\")\n# \"89\"\n#\n# $1 is an integer\nprime_fib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> $(order_by_points \"1 11 -1 -11 -12\")\n# ['\"-1\"', '\"-11\"', '\"1\"', '\"-12\"', '\"11\"']\n# >>> $(order_by_points \"\")\n# []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if in given list of numbers, are any two numbers closer to each other than\n# given threshold.\n# >>> $(has_close_elements \"1.0 2.0 3.0\" \"0.5\")\n# \"false\"\n# >>> $(has_close_elements \"1.0 2.8 3.0 4.0 5.0 2.0\" \"0.3\")\n# \"true\"\n#\n# $1 is a space-separated list\n# $2 is a floating point\nhas_close_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    has_close_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.3\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\" \"0.05\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.95\") = \"true\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\" \"0.8\") = \"false\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\" \"0.1\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"1.0\") = \"true\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\" \"0.5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> $(make_palindrome \"\")\n# \"\"\n# >>> $(make_palindrome \"cat\")\n# \"catac\"\n# >>> $(make_palindrome \"cata\")\n# \"catac\"\n#\n# $1 is a string\nmake_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> $(string_xor \"010\" \"110\")\n# \"100\"\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> $(special_factorial \"4\")\n# \"288\"\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> $(add_elements \"111 21 3 4000 5 6 7 8 9\" \"4\")\n# \"24\"\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> $(fib4 \"5\")\n# \"4\"\n# >>> $(fib4 \"6\")\n# \"8\"\n# >>> $(fib4 \"7\")\n# \"14\"\n#\n# $1 is an integer\nfib4() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> $(unique_digits \"15 33 1422 1\")\n# ['\"1\"', '\"15\"', '\"33\"']\n# >>> $(unique_digits \"152 323 1422 10\")\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> $(select_words \"Mary had a little lamb\" \"4\")\n# ['\"little\"']\n# >>> $(select_words \"Mary had a little lamb\" \"3\")\n# ['\"Mary\"', '\"lamb\"']\n# >>> $(select_words \"simple white space\" \"2\")\n# []\n# >>> $(select_words \"Hello world\" \"4\")\n# ['\"world\"']\n# >>> $(select_words \"Uncle sam\" \"3\")\n# ['\"Uncle\"']\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> $(will_it_fly \"1 2\" \"5\")\n# \"false\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> $(will_it_fly \"3 2 3\" \"1\")\n# \"false\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> $(will_it_fly \"3 2 3\" \"9\")\n# \"true\"\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> $(will_it_fly \"3\" \"5\")\n# \"true\"\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> $(fib \"10\")\n# \"55\"\n# >>> $(fib \"1\")\n# \"1\"\n# >>> $(fib \"8\")\n# \"21\"\n#\n# $1 is an integer\nfib() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> $(Strongest_Extension \"my_class\" \"AA Be CC\")\n# \"my_class.AA\"\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> $(match_parens \"()( )\")\n# \"Yes\"\n# >>> $(match_parens \") )\")\n# \"No\"\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> $(next_smallest \"1 2 3 4 5\")\n# \"2\"\n# >>> $(next_smallest \"5 1 4 3 2\")\n# \"2\"\n# >>> $(next_smallest \"\")\n# \"None\"\n# >>> $(next_smallest \"1 1\")\n# \"None\"\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> $(any_int \"5\" \"2\" \"7\")\n# \"true\"\n# >>> $(any_int \"3\" \"2\" \"2\")\n# \"false\"\n# >>> $(any_int \"3\" \"-2\" \"1\")\n# \"true\"\n# >>> $(any_int \"3.6\" \"-2.2\" \"2\")\n# \"false\"\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> $(truncate_number \"3.5\")\n# \"0.5\"\n#\n# $1 is a floating point\ntruncate_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> $(incr_list \"1 2 3\")\n# ['\"2\"', '\"3\"', '\"4\"']\n# >>> $(incr_list \"5 3 5 2 3 3 9 0 123\")\n# ['\"6\"', '\"4\"', '\"6\"', '\"3\"', '\"4\"', '\"4\"', '\"10\"', '\"1\"', '\"124\"']\n#\n# $1 is a space-separated list\nincr_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> $(x_or_y \"7\" \"34\" \"12\")\n# \"34\"\n# >>> $(x_or_y \"15\" \"8\" \"5\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> $(modp \"3\" \"5\")\n# \"3\"\n# >>> $(modp \"1101\" \"101\")\n# \"2\"\n# >>> $(modp \"0\" \"101\")\n# \"1\"\n# >>> $(modp \"3\" \"11\")\n# \"8\"\n# >>> $(modp \"100\" \"101\")\n# \"1\"\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> $(even_odd_count \"-12\")\n# ['\"1\"', '\"1\"']\n# >>> $(even_odd_count \"123\")\n# ['\"1\"', '\"2\"']\n#\n# $1 is an integer\neven_odd_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> $(is_happy \"a\")\n# \"false\"\n# >>> $(is_happy \"aa\")\n# \"false\"\n# >>> $(is_happy \"abcd\")\n# \"true\"\n# >>> $(is_happy \"aabb\")\n# \"false\"\n# >>> $(is_happy \"adb\")\n# \"true\"\n# >>> $(is_happy \"xyy\")\n# \"false\"\n#\n# $1 is a string\nis_happy() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> $(largest_prime_factor \"13195\")\n# \"29\"\n# >>> $(largest_prime_factor \"2048\")\n# \"2\"\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> $(digitSum \"\")\n# \"0\"\n# >>> $(digitSum \"abAB\")\n# \"131\"\n# >>> $(digitSum \"abcCd\")\n# \"67\"\n# >>> $(digitSum \"helloE\")\n# \"69\"\n# >>> $(digitSum \"woArBld\")\n# \"131\"\n# >>> $(digitSum \"aAaaaXa\")\n# \"153\"\n#\n# $1 is a string\ndigitSum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> $(rescale_to_unit \"1.0 2.0 3.0 4.0 5.0\")\n# ['\"0.0\"', '\"0.25\"', '\"0.5\"', '\"0.75\"', '\"1.0\"']\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> $(solution \"5 8 7 1\")\n# \"12\"\n# >>> $(solution \"3 3 3 3 3\")\n# \"9\"\n# >>> $(solution \"30 13 24 321\")\n# \"0\"\n#\n# $1 is a space-separated list\nsolution() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> $(pluck \"4 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> $(pluck \"1 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> $(pluck \"\")\n# []\n# Example 4:\n# >>> $(pluck \"5 0 3 0 4 2\")\n# ['\"0\"', '\"1\"']\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> $(get_max_triples \"5\")\n# \"1\"\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> $(exchange \"1 2 3 4\" \"1 2 3 4\")\n# \"YES\"\n# >>> $(exchange \"1 2 3 4\" \"1 5 3 4\")\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> $(median \"3 1 2 4 5\")\n# \"3\"\n# >>> $(median \"-10 4 6 1000 10 20\")\n# \"15.0\"\n#\n# $1 is a space-separated list\nmedian() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> $(prime_length \"Hello\")\n# \"true\"\n# >>> $(prime_length \"abcdcba\")\n# \"true\"\n# >>> $(prime_length \"kittens\")\n# \"true\"\n# >>> $(prime_length \"orange\")\n# \"false\"\n#\n# $1 is a string\nprime_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> $(smallest_change \"1 2 3 5 4 7 9 6\")\n# \"4\"\n# >>> $(smallest_change \"1 2 3 4 3 2 2\")\n# \"1\"\n# >>> $(smallest_change \"1 2 3 2 1\")\n# \"0\"\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> $(lst \"1.0 2.0 3.0\")\n# \"14\"\n# >>> $(lst \"1.0 4.0 9.0\")\n# \"98\"\n# >>> $(lst \"1.0 3.0 5.0 7.0\")\n# \"84\"\n# >>> $(lst \"1.4 4.2 0.0\")\n# \"29\"\n# >>> $(lst \"-2.4 1.0 1.0\")\n# \"6\"\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> $(file_name_check \"example.txt\")\n# \"Yes\"\n# >>> $(file_name_check \"1example.dll\")\n# \"No\"\n#\n# $1 is a string\nfile_name_check() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> $(triples_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"1 3 -2 1\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"2 4 -5 3 9 7\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> $(intersection \"1 2\" \"2 3\")\n# \"NO\"\n# >>> $(intersection \"-1 1\" \"0 4\")\n# \"NO\"\n# >>> $(intersection \"-3 -1\" \"-5 5\")\n# \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> $(separate_paren_groups \"( ) (( )) (( )( ))\")\n# ['\"()\"', '\"(())\"', '\"(()())\"']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> $(compare \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\")\n# ['\"0\"', '\"0\"', '\"0\"', '\"0\"', '\"3\"', '\"3\"']\n# >>> $(compare \"0 5 0 0 0 4\" \"4 1 1 0 0 -2\")\n# ['\"4\"', '\"4\"', '\"1\"', '\"0\"', '\"0\"', '\"6\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> $(check_if_last_char_is_a_letter \"apple pie\")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e\")\n# \"true\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e \")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"\")\n# \"false\"\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> $(valid_date \"03-11-2000\")\n# \"true\"\n# >>> $(valid_date \"15-01-2012\")\n# \"false\"\n# >>> $(valid_date \"04-0-2040\")\n# \"false\"\n# >>> $(valid_date \"06-04-2020\")\n# \"true\"\n# >>> $(valid_date \"06/04/2020\")\n# \"false\"\n#\n# $1 is a string\nvalid_date() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> $(count_nums \"\")\n# \"0\"\n# >>> $(count_nums \"-1 11 -11\")\n# \"1\"\n# >>> $(count_nums \"1 1 2\")\n# \"3\"\n#\n# $1 is a space-separated list\ncount_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> $(anti_shuffle \"Hi\")\n# \"Hi\"\n# >>> $(anti_shuffle \"hello\")\n# \"ehllo\"\n# >>> $(anti_shuffle \"Hello World\\!\\!\\!\")\n# \"Hello \\!\\!\\!Wdlor\"\n#\n# $1 is a string\nanti_shuffle() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> $(is_palindrome \"\")\n# \"true\"\n# >>> $(is_palindrome \"aba\")\n# \"true\"\n# >>> $(is_palindrome \"aaaaa\")\n# \"true\"\n# >>> $(is_palindrome \"zbcd\")\n# \"false\"\n#\n# $1 is a string\nis_palindrome() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> $(get_closest_vowel \"yogurt\")\n# \"u\"\n# >>> $(get_closest_vowel \"FULL\")\n# \"U\"\n# >>> $(get_closest_vowel \"quick\")\n# \"\"\n# >>> $(get_closest_vowel \"ab\")\n# \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> $(is_prime \"6\")\n# \"false\"\n# >>> $(is_prime \"101\")\n# \"true\"\n# >>> $(is_prime \"11\")\n# \"true\"\n# >>> $(is_prime \"13441\")\n# \"true\"\n# >>> $(is_prime \"61\")\n# \"true\"\n# >>> $(is_prime \"4\")\n# \"false\"\n# >>> $(is_prime \"1\")\n# \"false\"\n#\n# $1 is an integer\nis_prime() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> $(simplify \"1/5\" \"5/1\")\n# \"true\"\n# >>> $(simplify \"1/6\" \"2/1\")\n# \"false\"\n# >>> $(simplify \"7/10\" \"10/2\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> $(hex_key \"AB\")\n# \"1\"\n# >>> $(hex_key \"1077E\")\n# \"2\"\n# >>> $(hex_key \"ABED1A33\")\n# \"4\"\n# >>> $(hex_key \"123456789ABCDEF0\")\n# \"6\"\n# >>> $(hex_key \"2020\")\n# \"2\"\n#\n# $1 is a string\nhex_key() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> $(words_in_sentence \"This is a test\")\n# \"is\"\n# Example 2:\n# >>> $(words_in_sentence \"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> $(histogram \"a b c\")\n# {'\"a\"': '\"1\"', '\"b\"': '\"1\"', '\"c\"': '\"1\"'}\n# >>> $(histogram \"a b b a\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"a b c a b\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"b b b b a\")\n# {'\"b\"': '\"4\"'}\n# >>> $(histogram \"\")\n# {}\n#\n# $1 is a string\nhistogram() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> $(get_row \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\")\n# [['\"0\"', '\"0\"'], ['\"1\"', '\"4\"'], ['\"1\"', '\"0\"'], ['\"2\"', '\"5\"'], ['\"2\"', '\"0\"']]\n# >>> $(get_row \"\" \"1\")\n# []\n# >>> $(get_row \"\\n1\\n1 2 3\" \"3\")\n# [['\"2\"', '\"2\"']]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> $(get_odd_collatz \"5\")\n# ['\"1\"', '\"5\"']\n#\n# $1 is an integer\nget_odd_collatz() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> $(can_arrange \"1 2 4 3 5\")\n# \"3\"\n# >>> $(can_arrange \"1 2 3\")\n# \"-1\"\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> $(sort_numbers \"three one five\")\n# \"one three five\"\n#\n# $1 is a string\nsort_numbers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> $(circular_shift \"12\" \"1\")\n# \"21\"\n# >>> $(circular_shift \"12\" \"2\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> lst\n# []\n# >>> lst\n# ['\"-1\"', '\"-5\"', '\"2\"', '\"-1\"', '\"-5\"']\n#\n# $1 is a space-separated list\nsum_squares() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> $(skjkasdkd \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\")\n# \"10\"\n# >>> $(skjkasdkd \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\")\n# \"25\"\n# >>> $(skjkasdkd \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\")\n# \"13\"\n# >>> $(skjkasdkd \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\")\n# \"11\"\n# >>> $(skjkasdkd \"0 81 12 3 1 21\")\n# \"3\"\n# >>> $(skjkasdkd \"0 8 1 2 1 7\")\n# \"7\"\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> $(sum_product \"\")\n# ['\"0\"', '\"1\"']\n# >>> $(sum_product \"1 2 3 4\")\n# ['\"10\"', '\"24\"']\n#\n# $1 is a space-separated list\nsum_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> $(choose_num \"12\" \"15\")\n# \"14\"\n# >>> $(choose_num \"13\" \"12\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> $(largest_smallest_integers \"2 4 1 3 5 7\")\n# ['\"None\"', '\"1\"']\n# >>> $(largest_smallest_integers \"\")\n# ['\"None\"', '\"None\"']\n# >>> $(largest_smallest_integers \"0\")\n# ['\"None\"', '\"None\"']\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> $(count_distinct_characters \"xyzXYZ\")\n# \"3\"\n# >>> $(count_distinct_characters \"Jerry\")\n# \"4\"\n#\n# $1 is a string\ncount_distinct_characters() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1384,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given a positive integer n, you have to make a pile of n levels of stones.\n# The first level has n stones.\n# The number of stones in the next level is:\n# - the next odd number if n is odd.\n# - the next even number if n is even.\n# Return the number of stones in each level in a list, where element at index\n# i represents the number of stones in the level (i+1).\n# Examples:\n# >>> $(make_a_pile \"3\")\n# ['\"3\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nmake_a_pile() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    make_a_pile \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"3 5 7\" ]]\n    [[ $(candidate \"4\") = \"4 6 8 10\" ]]\n    [[ $(candidate \"5\") = \"5 7 9 11 13\" ]]\n    [[ $(candidate \"6\") = \"6 8 10 12 14 16\" ]]\n    [[ $(candidate \"8\") = \"8 10 12 14 16 18 20 22\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1392,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> $(prod_signs \"1 2 2 -4\")\n# \"9\"\n# >>> $(prod_signs \"0 1\")\n# \"0\"\n# >>> $(prod_signs \"\")\n# \"None\"\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "prompt": "#!/bin/bash\n# You will be given a string of words separated by commas or spaces. Your task is\n# to split the string into words and return an array of the words.\n# For example:\n# >>> $(words_string \"Hi, my name is John\")\n# ['\"Hi\"', '\"my\"', '\"name\"', '\"is\"', '\"John\"']\n# >>> $(words_string \"One, two, three, four, five, six\")\n# ['\"One\"', '\"two\"', '\"three\"', '\"four\"', '\"five\"', '\"six\"']\n#\n# $1 is a string\nwords_string() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    words_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi, my name is John\") = \"Hi my name is John\" ]]\n    [[ $(candidate \"One, two, three, four, five, six\") = \"One two three four five six\" ]]\n    [[ $(candidate \"Hi, my name\") = \"Hi my name\" ]]\n    [[ $(candidate \"One,, two, three, four, five, six,\") = \"One two three four five six\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"ahmed     , gamal\") = \"ahmed gamal\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> $(minSubArraySum \"2 3 4 1 2 4\")\n# \"1\"\n# >>> $(minSubArraySum \"-1 -2 -3\")\n# \"-6\"\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
+    "prompt": "#!/bin/bash\n# This function takes two positive numbers x and y and returns the\n# biggest even integer number that is in the range [x, y] inclusive. If \n# there's no such number, then the function should return -1.\n# For example:\n# >>> $(choose_num \"12\" \"15\")\n# \"14\"\n# >>> $(choose_num \"13\" \"12\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\nchoose_num() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    choose_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\" \"15\") = \"14\" ]]\n    [[ $(candidate \"13\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"33\" \"12354\") = \"12354\" ]]\n    [[ $(candidate \"5234\" \"5233\") = \"-1\" ]]\n    [[ $(candidate \"6\" \"29\") = \"28\" ]]\n    [[ $(candidate \"27\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"7\" \"7\") = \"-1\" ]]\n    [[ $(candidate \"546\" \"546\") = \"546\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> $(string_sequence \"0\")\n# \"0\"\n# >>> $(string_sequence \"5\")\n# \"0 1 2 3 4 5\"\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "prompt": "#!/bin/bash\n# You are given two positive integers n and m, and your task is to compute the\n# average of the integers from n through m (including n and m). \n# Round the answer to the nearest integer and convert that to binary.\n# If n is greater than m, return -1.\n# Example:\n# >>> $(rounded_avg \"1\" \"5\")\n# \"0b11\"\n# >>> $(rounded_avg \"7\" \"5\")\n# \"-1\"\n# >>> $(rounded_avg \"10\" \"20\")\n# \"0b1111\"\n# >>> $(rounded_avg \"20\" \"33\")\n# \"0b11010\"\n#\n# $1 is an integer\n# $2 is an integer\nrounded_avg() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    rounded_avg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"5\") = \"0b11\" ]]\n    [[ $(candidate \"7\" \"13\") = \"0b1010\" ]]\n    [[ $(candidate \"964\" \"977\") = \"0b1111001010\" ]]\n    [[ $(candidate \"996\" \"997\") = \"0b1111100100\" ]]\n    [[ $(candidate \"560\" \"851\") = \"0b1011000010\" ]]\n    [[ $(candidate \"185\" \"546\") = \"0b101101110\" ]]\n    [[ $(candidate \"362\" \"496\") = \"0b110101101\" ]]\n    [[ $(candidate \"350\" \"902\") = \"0b1001110010\" ]]\n    [[ $(candidate \"197\" \"233\") = \"0b11010111\" ]]\n    [[ $(candidate \"7\" \"5\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"1\") = \"-1\" ]]\n    [[ $(candidate \"5\" \"5\") = \"0b101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> $(cycpattern_check \"abcd\" \"abd\")\n# \"false\"\n# >>> $(cycpattern_check \"hello\" \"ell\")\n# \"true\"\n# >>> $(cycpattern_check \"whassup\" \"psus\")\n# \"false\"\n# >>> $(cycpattern_check \"abab\" \"baa\")\n# \"true\"\n# >>> $(cycpattern_check \"efef\" \"eeff\")\n# \"false\"\n# >>> $(cycpattern_check \"himenss\" \"simen\")\n# \"true\"\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "prompt": "#!/bin/bash\n# Given a list of positive integers x. return a sorted list of all \n# elements that hasn't any even digit.\n# Note: Returned list should be sorted in increasing order.\n# For example:\n# >>> $(unique_digits \"15 33 1422 1\")\n# ['\"1\"', '\"15\"', '\"33\"']\n# >>> $(unique_digits \"152 323 1422 10\")\n# []\n#\n# $1 is a space-separated list\nunique_digits() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    unique_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 33 1422 1\") = \"1 15 33\" ]]\n    [[ $(candidate \"152 323 1422 10\") = \"\" ]]\n    [[ $(candidate \"12345 2033 111 151\") = \"111 151\" ]]\n    [[ $(candidate \"135 103 31\") = \"31 135\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n# >>> $(monotonic \"1 2 4 20\")\n# \"true\"\n# >>> $(monotonic \"1 20 4 10\")\n# \"false\"\n# >>> $(monotonic \"4 1 0 -10\")\n# \"true\"\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n# reverse the resulting array, and then replace each digit by its corresponding name from\n# \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n# For example:\n# >>> $(by_length \"2 1 1 4 5 8 2 3\")\n# ['\"Eight\"', '\"Five\"', '\"Four\"', '\"Three\"', '\"Two\"', '\"Two\"', '\"One\"', '\"One\"']\n# If the array is empty, return an empty array:\n# >>> $(by_length \"\")\n# []\n# If the array has any strange number ignore it:\n# >>> $(by_length \"1 -1 55\")\n# ['\"One\"']\n#\n# $1 is a space-separated list\nby_length() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    by_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 1 4 5 8 2 3\") = \"Eight Five Four Three Two Two One One\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -1 55\") = \"One\" ]]\n    [[ $(candidate \"1 -1 3 2\") = \"Three Two One\" ]]\n    [[ $(candidate \"9 4 8\") = \"Nine Eight Four\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> $(longest \"\")\n# \"None\"\n# >>> $(longest \"a b c\")\n# \"a\"\n# >>> $(longest \"a bb ccc\")\n# \"ccc\"\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "prompt": "#!/bin/bash\n# Implement the function f that takes n as a parameter,\n# and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n# or the sum of numbers from 1 to i otherwise.\n# i starts from 1.\n# the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n# Example:\n# >>> $(f \"5\")\n# ['\"1\"', '\"2\"', '\"6\"', '\"24\"', '\"15\"']\n#\n# $1 is an integer\nf() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    f \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1 2 6 24 15\" ]]\n    [[ $(candidate \"7\") = \"1 2 6 24 15 720 28\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"1 2 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n# >>> $(below_threshold \"1 2 4 10\" \"100\")\n# \"true\"\n# >>> $(below_threshold \"1 20 4 10\" \"5\")\n# \"false\"\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a tuple that has the number of even and odd\n# integer palindromes that fall within the range(1, n), inclusive.\n# Example 1:\n# >>> $(even_odd_palindrome \"3\")\n# ['\"1\"', '\"2\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n# Example 2:\n# >>> $(even_odd_palindrome \"12\")\n# ['\"4\"', '\"6\"']\n# Explanation:\n# Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n# Note:\n# 1. 1 <= n <= 10^3\n# 2. returned tuple has the number of even and odd integer palindromes respectively.\n#\n# $1 is an integer\neven_odd_palindrome() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    even_odd_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"8 13\" ]]\n    [[ $(candidate \"12\") = \"4 6\" ]]\n    [[ $(candidate \"3\") = \"1 2\" ]]\n    [[ $(candidate \"63\") = \"6 8\" ]]\n    [[ $(candidate \"25\") = \"5 6\" ]]\n    [[ $(candidate \"19\") = \"4 6\" ]]\n    [[ $(candidate \"9\") = \"4 5\" ]]\n    [[ $(candidate \"1\") = \"0 1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> $(is_multiply_prime \"30\")\n# \"true\"\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "prompt": "#!/bin/bash\n# Write a function count_nums which takes an array of integers and returns\n# the number of elements which has a sum of digits > 0.\n# If a number is negative, then its first signed digit will be negative:\n# e.g. -123 has signed digits -1, 2, and 3.\n# >>> $(count_nums \"\")\n# \"0\"\n# >>> $(count_nums \"-1 11 -11\")\n# \"1\"\n# >>> $(count_nums \"1 1 2\")\n# \"3\"\n#\n# $1 is a space-separated list\ncount_nums() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 0\") = \"0\" ]]\n    [[ $(candidate \"1 1 2 -2 3 4 5\") = \"6\" ]]\n    [[ $(candidate \"1 6 9 -6 0 1 5\") = \"5\" ]]\n    [[ $(candidate \"1 100 98 -7 1 -1\") = \"4\" ]]\n    [[ $(candidate \"12 23 34 -45 -56 0\") = \"5\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> $(get_positive \"-1 2 -4 5 6\")\n# ['\"2\"', '\"5\"', '\"6\"']\n# >>> $(get_positive \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# ['\"5\"', '\"3\"', '\"2\"', '\"3\"', '\"9\"', '\"123\"', '\"1\"']\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "prompt": "#!/bin/bash\n# We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n# numbers in the array will be randomly ordered. Your task is to determine if\n# it is possible to get an array sorted in non-decreasing order by performing \n# the following operation on the given array:\n# You are allowed to perform right shift operation any number of times.\n# One right shift operation means shifting all elements of the array by one\n# position in the right direction. The last element of the array will be moved to\n# the starting position in the array i.e. 0th index. \n# If it is possible to obtain the sorted array by performing the above operation\n# then return True else return False.\n# If the given array is empty then return True.\n# Note: The given list is guaranteed to have unique elements.\n# For Example:\n# >>> $(move_one_ball \"3 4 5 1 2\")\n# \"true\"\n# Explanation: By performin 2 right shift operations, non-decreasing order can\n# be achieved for the given array.\n# >>> $(move_one_ball \"3 5 4 1 2\")\n# \"false\"\n# Explanation:It is not possible to get non-decreasing order for the given\n# array by performing any number of right shift operations.\n#\n# $1 is a space-separated list\nmove_one_ball() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    move_one_ball \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 1 2\") = \"true\" ]]\n    [[ $(candidate \"3 5 10 1 2\") = \"true\" ]]\n    [[ $(candidate \"4 3 1 2\") = \"false\" ]]\n    [[ $(candidate \"3 5 4 1 2\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> $(sort_third \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_third \"5 6 3 4 8 9 2\")\n# ['\"2\"', '\"6\"', '\"3\"', '\"4\"', '\"8\"', '\"9\"', '\"5\"']\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "prompt": "#!/bin/bash\n# Find the shortest palindrome that begins with a supplied string.\n# Algorithm idea is simple:\n# - Find the longest postfix of supplied string that is a palindrome.\n# - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n# >>> $(make_palindrome \"\")\n# \"\"\n# >>> $(make_palindrome \"cat\")\n# \"catac\"\n# >>> $(make_palindrome \"cata\")\n# \"catac\"\n#\n# $1 is a string\nmake_palindrome() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    make_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x\") = \"x\" ]]\n    [[ $(candidate \"xyz\") = \"xyzyx\" ]]\n    [[ $(candidate \"xyx\") = \"xyx\" ]]\n    [[ $(candidate \"jerry\") = \"jerryrrej\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> $(parse_nested_parens \"(()()) ((())) () ((())()())\")\n# ['\"2\"', '\"3\"', '\"1\"', '\"3\"']\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "prompt": "#!/bin/bash\n# In this problem, you will implement a function that takes two lists of numbers,\n# and determines whether it is possible to perform an exchange of elements\n# between them to make lst1 a list of only even numbers.\n# There is no limit on the number of exchanged elements between lst1 and lst2.\n# If it is possible to exchange elements between the lst1 and lst2 to make\n# all the elements of lst1 to be even, return \"YES\".\n# Otherwise, return \"NO\".\n# For example:\n# >>> $(exchange \"1 2 3 4\" \"1 2 3 4\")\n# \"YES\"\n# >>> $(exchange \"1 2 3 4\" \"1 5 3 4\")\n# \"NO\"\n# It is assumed that the input lists will be non-empty.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nexchange() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    exchange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"1 2 3 4\") = \"YES\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1 5 3 4\") = \"NO\" ]]\n    [[ $(candidate \"1 2 3 4\" \"2 1 4 3\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 4\") = \"YES\" ]]\n    [[ $(candidate \"5 7 3\" \"2 6 3\") = \"NO\" ]]\n    [[ $(candidate \"3 2 6 1 8 9\" \"3 5 5 1 1 1\") = \"NO\" ]]\n    [[ $(candidate \"100 200\" \"200 200\") = \"YES\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> $(triangle_area \"5\" \"3\")\n# \"7.5\"\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "prompt": "#!/bin/bash\n# Given a string representing a space separated lowercase letters, return a dictionary\n# of the letter with the most repetition and containing the corresponding count.\n# If several letters have the same occurrence, return all of them.\n# Example:\n# >>> $(histogram \"a b c\")\n# {'\"a\"': '\"1\"', '\"b\"': '\"1\"', '\"c\"': '\"1\"'}\n# >>> $(histogram \"a b b a\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"a b c a b\")\n# {'\"a\"': '\"2\"', '\"b\"': '\"2\"'}\n# >>> $(histogram \"b b b b a\")\n# {'\"b\"': '\"4\"'}\n# >>> $(histogram \"\")\n# {}\n#\n# $1 is a string\nhistogram() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> $(multiply \"148\" \"412\")\n# \"16\"\n# >>> $(multiply \"19\" \"28\")\n# \"72\"\n# >>> $(multiply \"2020\" \"1851\")\n# \"0\"\n# >>> $(multiply \"14\" \"-15\")\n# \"20\"\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> $(mean_absolute_deviation \"1.0 2.0 3.0 4.0\")\n# \"1.0\"\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> $(common \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\")\n# ['\"1\"', '\"5\"', '\"653\"']\n# >>> $(common \"5 3 2 8\" \"3 2\")\n# ['\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> $(int_to_mini_roman \"19\")\n# \"xix\"\n# >>> $(int_to_mini_roman \"152\")\n# \"clii\"\n# >>> $(int_to_mini_roman \"426\")\n# \"cdxxvi\"\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> $(fruit_distribution \"5 apples and 6 oranges\" \"19\")\n# \"8\"\n# >>> $(fruit_distribution \"0 apples and 1 oranges\" \"3\")\n# \"2\"\n# >>> $(fruit_distribution \"2 apples and 3 oranges\" \"100\")\n# \"95\"\n# >>> $(fruit_distribution \"100 apples and 1 oranges\" \"120\")\n# \"19\"\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    histogram \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b b a\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c a b\") = \"a,2\\nb,2\" ]]\n    [[ $(candidate \"a b c d g\") = \"a,1\\nb,1\\nc,1\\nd,1\\ng,1\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"b b b b a\") = \"b,4\" ]]\n    [[ $(candidate \"r t g\") = \"r,1\\nt,1\\ng,1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"a\") = \"a,1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1600,7 +172,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Task\n# We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n# then check if the result string is palindrome.\n# A string is called palindrome if it reads the same backward as forward.\n# You should return a tuple containing the result string and True/False for the check.\n# Example\n# >>> $(reverse_delete \"abcde\" \"ae\")\n# ['\"bcd\"', '\"false\"']\n# >>> $(reverse_delete \"abcdef\" \"b\")\n# ['\"acdef\"', '\"false\"']\n# >>> $(reverse_delete \"abcdedcba\" \"ab\")\n# ['\"cdedc\"', '\"true\"']\n#\n# $1 is a string\n# $2 is a string\nreverse_delete() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    reverse_delete \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\" \"ae\") = \"bcd false\" ]]\n    [[ $(candidate \"abcdef\" \"b\") = \"acdef false\" ]]\n    [[ $(candidate \"abcdedcba\" \"ab\") = \"cdedc true\" ]]\n    [[ $(candidate \"dwik\" \"w\") = \"dik false\" ]]\n    [[ $(candidate \"a\" \"a\") = \" true\" ]]\n    [[ $(candidate \"abcdedcba\" \"\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"abcdedcba\" \"v\") = \"abcdedcba true\" ]]\n    [[ $(candidate \"vabba\" \"v\") = \"abba true\" ]]\n    [[ $(candidate \"mamma\" \"mia\") = \" true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1608,25 +180,25 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> $(greatest_common_divisor \"3\" \"5\")\n# \"1\"\n# >>> $(greatest_common_divisor \"25\" \"15\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "prompt": "#!/bin/bash\n# Given an array of integers nums, find the minimum sum of any non-empty sub-array\n# of nums.\n# Example\n# >>> $(minSubArraySum \"2 3 4 1 2 4\")\n# \"1\"\n# >>> $(minSubArraySum \"-1 -2 -3\")\n# \"-6\"\n#\n# $1 is a space-separated list\nminSubArraySum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    minSubArraySum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 4 1 2 4\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 -3\") = \"-6\" ]]\n    [[ $(candidate \"-1 -2 -3 2 -10\") = \"-14\" ]]\n    [[ $(candidate \"-9999999999999999\") = \"-9999999999999999\" ]]\n    [[ $(candidate \"0 10 20 1000000\") = \"0\" ]]\n    [[ $(candidate \"-1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"100 -1 -2 -3 10 -5\") = \"-6\" ]]\n    [[ $(candidate \"10 11 13 8 3 4\") = \"3\" ]]\n    [[ $(candidate \"100 -33 32 -1 0 -2\") = \"-33\" ]]\n    [[ $(candidate \"-10\") = \"-10\" ]]\n    [[ $(candidate \"7\") = \"7\" ]]\n    [[ $(candidate \"1 -1\") = \"-1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_115_max_fill",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> $(split_words \"Hello world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"Hello,world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"abcdef\")\n# \"3\"\n#\n# $1 is a string\nsplit_words() {\n",
+    "prompt": "#!/bin/bash\n# You are given a rectangular grid of wells. Each row represents a single well,\n# and each 1 in a row represents a single unit of water.\n# Each well has a corresponding bucket that can be used to extract water from it, \n# and all buckets have the same capacity.\n# Your task is to use the buckets to empty the wells.\n# Output the number of times you need to lower the buckets.\n# Example 1:\n# >>> $(max_fill \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\")\n# \"6\"\n# Example 2:\n# >>> $(max_fill \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\")\n# \"5\"\n# Example 3:\n# >>> $(max_fill \"0 0 0\\n0 0 0\" \"5\")\n# \"0\"\n# Constraints:\n# * all wells have the same length\n# * 1 <= grid.length <= 10^2\n# * 1 <= grid[:,1].length <= 10^2\n# * grid[i][j] -> 0 | 1\n# * 1 <= capacity <= 10\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_fill() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_fill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 0\\n0 1 0 0\\n1 1 1 1\" \"1\") = \"6\" ]]\n    [[ $(candidate \"0 0 1 1\\n0 0 0 0\\n1 1 1 1\\n0 1 1 1\" \"2\") = \"5\" ]]\n    [[ $(candidate \"0 0 0\\n0 0 0\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"2\") = \"4\" ]]\n    [[ $(candidate \"1 1 1 1\\n1 1 1 1\" \"9\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1636,7 +208,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# In this Kata, you have to sort an array of non-negative integers according to\n# number of ones in their binary representation in ascending order.\n# For similar number of ones, sort based on decimal value.\n# It must be implemented like this:\n# >>> $(sort_array \"1 5 2 3 4\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"-2 -3 -4 -5 -6\")\n# ['\"-6\"', '\"-5\"', '\"-4\"', '\"-3\"', '\"-2\"']\n# >>> $(sort_array \"1 0 2 3 4\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 2 3 4\") = \"1 2 4 3 5\" ]]\n    [[ $(candidate \"-2 -3 -4 -5 -6\") = \"-4 -2 -6 -5 -3\" ]]\n    [[ $(candidate \"1 0 2 3 4\") = \"0 1 2 4 3\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"2 5 77 4 5 3 5 7 2 3 4\") = \"2 2 4 4 3 3 5 5 5 7 77\" ]]\n    [[ $(candidate \"3 6 44 12 32 5\") = \"32 3 5 6 12 44\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n    [[ $(candidate \"2 4 8 16 32\") = \"2 4 8 16 32\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1644,121 +216,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> $(concatenate \"\")\n# \"\"\n# >>> $(concatenate \"a b c\")\n# \"abc\"\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "prompt": "#!/bin/bash\n# Given a string s and a natural number n, you have been tasked to implement \n# a function that returns a list of all words from string s that contain exactly \n# n consonants, in order these words appear in the string s.\n# If the string s is empty then the function should return an empty list.\n# Note: you may assume the input string contains only letters and spaces.\n# Examples:\n# >>> $(select_words \"Mary had a little lamb\" \"4\")\n# ['\"little\"']\n# >>> $(select_words \"Mary had a little lamb\" \"3\")\n# ['\"Mary\"', '\"lamb\"']\n# >>> $(select_words \"simple white space\" \"2\")\n# []\n# >>> $(select_words \"Hello world\" \"4\")\n# ['\"world\"']\n# >>> $(select_words \"Uncle sam\" \"3\")\n# ['\"Uncle\"']\n#\n# $1 is a string\n# $2 is an integer\nselect_words() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    select_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mary had a little lamb\" \"4\") = \"little\" ]]\n    [[ $(candidate \"Mary had a little lamb\" \"3\") = \"Mary lamb\" ]]\n    [[ $(candidate \"simple white space\" \"2\") = \"\" ]]\n    [[ $(candidate \"Hello world\" \"4\") = \"world\" ]]\n    [[ $(candidate \"Uncle sam\" \"3\") = \"Uncle\" ]]\n    [[ $(candidate \"\" \"4\") = \"\" ]]\n    [[ $(candidate \"a b c d e f\" \"1\") = \"b c d f\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> $(list_sort \"aa a aaa\")\n# ['\"aa\"']\n# >>> $(list_sort \"ab a aaa cd\")\n# ['\"ab\"', '\"cd\"']\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "prompt": "#!/bin/bash\n# You are given a word. Your task is to find the closest vowel that stands between \n# two consonants from the right side of the word (case sensitive).\n# Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n# find any vowel met the above condition. \n# You may assume that the given string contains English letter only.\n# Example:\n# >>> $(get_closest_vowel \"yogurt\")\n# \"u\"\n# >>> $(get_closest_vowel \"FULL\")\n# \"U\"\n# >>> $(get_closest_vowel \"quick\")\n# \"\"\n# >>> $(get_closest_vowel \"ab\")\n# \"\"\n#\n# $1 is a string\nget_closest_vowel() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_closest_vowel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"yogurt\") = \"u\" ]]\n    [[ $(candidate \"full\") = \"u\" ]]\n    [[ $(candidate \"easy\") = \"\" ]]\n    [[ $(candidate \"eAsy\") = \"\" ]]\n    [[ $(candidate \"ali\") = \"\" ]]\n    [[ $(candidate \"bad\") = \"a\" ]]\n    [[ $(candidate \"most\") = \"o\" ]]\n    [[ $(candidate \"ab\") = \"\" ]]\n    [[ $(candidate \"ba\") = \"\" ]]\n    [[ $(candidate \"quick\") = \"\" ]]\n    [[ $(candidate \"anime\") = \"i\" ]]\n    [[ $(candidate \"Asia\") = \"\" ]]\n    [[ $(candidate \"Above\") = \"o\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_119_match_parens",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> $(closest_integer \"10\")\n# \"10\"\n# >>> $(closest_integer \"15.3\")\n# \"15\"\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "prompt": "#!/bin/bash\n# You are given a list of two strings, both strings consist of open\n# parentheses '(' or close parentheses ')' only.\n# Your job is to check if it is possible to concatenate the two strings in\n# some order, that the resulting string will be good.\n# A string S is considered to be good if and only if all parentheses in S\n# are balanced. For example: the string '(())()' is good, while the string\n# '())' is not.\n# Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n# Examples:\n# >>> $(match_parens \"()( )\")\n# \"Yes\"\n# >>> $(match_parens \") )\")\n# \"No\"\n#\n# $1 is a space-separated list\nmatch_parens() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    match_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()( )\") = \"Yes\" ]]\n    [[ $(candidate \") )\") = \"No\" ]]\n    [[ $(candidate \"(()(()) ())())\") = \"No\" ]]\n    [[ $(candidate \")()) (()()(\") = \"Yes\" ]]\n    [[ $(candidate \"(()))) (()())((\") = \"Yes\" ]]\n    [[ $(candidate \"() ())\") = \"No\" ]]\n    [[ $(candidate \"(()( ()))()\") = \"Yes\" ]]\n    [[ $(candidate \"(((( ((())\") = \"No\" ]]\n    [[ $(candidate \")(() (()(\") = \"No\" ]]\n    [[ $(candidate \")( )(\") = \"No\" ]]\n    [[ $(candidate \"( )\") = \"Yes\" ]]\n    [[ $(candidate \") (\") = \"Yes\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_11_string_xor",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> $(vowels_count \"abcde\")\n# \"2\"\n# >>> $(vowels_count \"ACEDY\")\n# \"3\"\n#\n# $1 is a string\nvowels_count() {\n",
+    "prompt": "#!/bin/bash\n# Input are two strings a and b consisting only of 1s and 0s.\n# Perform binary XOR on these inputs and return result also as a string.\n# >>> $(string_xor \"010\" \"110\")\n# \"100\"\n#\n# $1 is a string\n# $2 is a string\nstring_xor() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    string_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"111000\" \"101010\") = \"010010\" ]]\n    [[ $(candidate \"1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0101\" \"0000\") = \"0101\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_120_maximum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> $(find_max \"name of string\")\n# \"string\"\n# >>> $(find_max \"name enam game\")\n# \"enam\"\n# >>> $(find_max \"aaaaaaa bb cc\")\n# \"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers and a positive integer k, return a sorted list \n# of length k with the maximum k numbers in arr.\n# Example 1:\n# >>> $(maximum \"-3 -4 5\" \"3\")\n# ['\"-4\"', '\"-3\"', '\"5\"']\n# Example 2:\n# >>> $(maximum \"4 -4 4\" \"2\")\n# ['\"4\"', '\"4\"']\n# Example 3:\n# >>> $(maximum \"-3 2 1 2 -1 -2 1\" \"1\")\n# ['\"2\"']\n# Note:\n# 1. The length of the array will be in the range of [1, 1000].\n# 2. The elements in the array will be in the range of [-1000, 1000].\n# 3. 0 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nmaximum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-3 -4 5\" \"3\") = \"-4 -3 5\" ]]\n    [[ $(candidate \"4 -4 4\" \"2\") = \"4 4\" ]]\n    [[ $(candidate \"-3 2 1 2 -1 -2 1\" \"1\") = \"2\" ]]\n    [[ $(candidate \"123 -123 20 0 1 2 -3\" \"3\") = \"2 20 123\" ]]\n    [[ $(candidate \"-123 20 0 1 2 -3\" \"4\") = \"0 1 2 20\" ]]\n    [[ $(candidate \"5 15 0 3 -13 -8 0\" \"7\") = \"-13 -8 0 0 3 5 15\" ]]\n    [[ $(candidate \"-1 0 2 5 3 -10\" \"2\") = \"3 5\" ]]\n    [[ $(candidate \"1 0 5 -7\" \"1\") = \"5\" ]]\n    [[ $(candidate \"4 -4\" \"2\") = \"-4 4\" ]]\n    [[ $(candidate \"-10 10\" \"2\") = \"-10 10\" ]]\n    [[ $(candidate \"1 2 3 -23 243 -400 0\" \"0\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_121_solution",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> $(string_to_md5 \"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n# Examples\n# >>> $(solution \"5 8 7 1\")\n# \"12\"\n# >>> $(solution \"3 3 3 3 3\")\n# \"9\"\n# >>> $(solution \"30 13 24 321\")\n# \"0\"\n#\n# $1 is a space-separated list\nsolution() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 8 7 1\") = \"12\" ]]\n    [[ $(candidate \"3 3 3 3 3\") = \"9\" ]]\n    [[ $(candidate \"30 13 24 321\") = \"0\" ]]\n    [[ $(candidate \"5 9\") = \"5\" ]]\n    [[ $(candidate \"2 4 8\") = \"0\" ]]\n    [[ $(candidate \"30 13 23 32\") = \"23\" ]]\n    [[ $(candidate \"3 13 2 9\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_122_add_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> $(change_base \"8\" \"3\")\n# \"22\"\n# >>> $(change_base \"8\" \"2\")\n# \"1000\"\n# >>> $(change_base \"7\" \"2\")\n# \"111\"\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "prompt": "#!/bin/bash\n# Given a non-empty array of integers arr and an integer k, return\n# the sum of the elements with at most two digits from the first k elements of arr.\n# Example:\n# >>> $(add_elements \"111 21 3 4000 5 6 7 8 9\" \"4\")\n# \"24\"\n# Constraints:\n# 1. 1 <= len(arr) <= 100\n# 2. 1 <= k <= len(arr)\n#\n# $1 is a space-separated list\n# $2 is an integer\nadd_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    add_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 41 57 76 87 88 99\" \"3\") = \"-4\" ]]\n    [[ $(candidate \"111 121 3 4000 5 6\" \"2\") = \"0\" ]]\n    [[ $(candidate \"11 21 3 90 5 6 7 8 9\" \"4\") = \"125\" ]]\n    [[ $(candidate \"111 21 3 4000 5 6 7 8 9\" \"4\") = \"24\" ]]\n    [[ $(candidate \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> $(right_angle_triangle \"3\" \"4\" \"5\")\n# \"true\"\n# >>> $(right_angle_triangle \"1\" \"2\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n# The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n# as follows: start with any positive integer n. Then each term is obtained from the \n# previous term as follows: if the previous term is even, the next term is one half of \n# the previous term. If the previous term is odd, the next term is 3 times the previous\n# term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n# Note: \n# 1. Collatz(1) is [1].\n# 2. returned list sorted in increasing order.\n# For example:\n# get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n# >>> $(get_odd_collatz \"5\")\n# ['\"1\"', '\"5\"']\n#\n# $1 is an integer\nget_odd_collatz() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_odd_collatz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"14\") = \"1 5 7 11 13 17\" ]]\n    [[ $(candidate \"5\") = \"1 5\" ]]\n    [[ $(candidate \"12\") = \"1 3 5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_124_valid_date",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> $(grade_equation \"4.0 3 1.7 2 3.5\")\n# ['\"A+\"', '\"B\"', '\"C-\"', '\"C\"', '\"A-\"']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "prompt": "#!/bin/bash\n# You have to write a function which validates a given date string and\n# returns True if the date is valid otherwise False.\n# The date is valid if all of the following rules are satisfied:\n# 1. The date string is not empty.\n# 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n# 3. The months should not be less than 1 or higher than 12.\n# 4. The date should be in the format: mm-dd-yyyy\n# >>> $(valid_date \"03-11-2000\")\n# \"true\"\n# >>> $(valid_date \"15-01-2012\")\n# \"false\"\n# >>> $(valid_date \"04-0-2040\")\n# \"false\"\n# >>> $(valid_date \"06-04-2020\")\n# \"true\"\n# >>> $(valid_date \"06/04/2020\")\n# \"false\"\n#\n# $1 is a string\nvalid_date() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    valid_date \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"03-11-2000\") = \"true\" ]]\n    [[ $(candidate \"15-01-2012\") = \"false\" ]]\n    [[ $(candidate \"04-0-2040\") = \"false\" ]]\n    [[ $(candidate \"06-04-2020\") = \"true\" ]]\n    [[ $(candidate \"01-01-2007\") = \"true\" ]]\n    [[ $(candidate \"03-32-2011\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"04-31-3000\") = \"false\" ]]\n    [[ $(candidate \"06-06-2005\") = \"true\" ]]\n    [[ $(candidate \"21-31-2000\") = \"false\" ]]\n    [[ $(candidate \"04-12-2003\") = \"true\" ]]\n    [[ $(candidate \"04122003\") = \"false\" ]]\n    [[ $(candidate \"20030412\") = \"false\" ]]\n    [[ $(candidate \"2003-04\") = \"false\" ]]\n    [[ $(candidate \"2003-04-12\") = \"false\" ]]\n    [[ $(candidate \"04-2003\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_125_split_words",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> $(intersperse \"\" \"4\")\n# []\n# >>> $(intersperse \"1 2 3\" \"4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"4\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "prompt": "#!/bin/bash\n# Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n# should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n# alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n# Examples\n# >>> $(split_words \"Hello world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"Hello,world\\!\")\n# ['\"Hello\"', '\"world\\\\!\"']\n# >>> $(split_words \"abcdef\")\n# \"3\"\n#\n# $1 is a string\nsplit_words() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    split_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello,world\\!\") = \"Hello world\\!\" ]]\n    [[ $(candidate \"Hello world,\\!\") = \"Hello world,\\!\" ]]\n    [[ $(candidate \"Hello,Hello,world \\!\") = \"Hello,Hello,world \\!\" ]]\n    [[ $(candidate \"abcdef\") = \"3\" ]]\n    [[ $(candidate \"aaabb\") = \"2\" ]]\n    [[ $(candidate \"aaaBb\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return whether or not they are sorted\n# in ascending order. If list has more than 1 duplicate of the same\n# number, return False. Assume no negative numbers and only integers.\n# Examples\n# >>> $(is_sorted \"5\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5\")\n# \"false\"\n# >>> $(is_sorted \"1 2 3 4 5 6\")\n# \"true\"\n# >>> $(is_sorted \"1 2 3 4 5 6 7\")\n# \"true\"\n# >>> $(is_sorted \"1 3 2 4 5 6 7\")\n# \"false\"\n# >>> $(is_sorted \"1 2 2 3 3 4\")\n# \"true\"\n# >>> $(is_sorted \"1 2 2 2 3 4\")\n# \"false\"\n#\n# $1 is a space-separated list\nis_sorted() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_sorted \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7\") = \"true\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 2 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 3 3 4\") = \"false\" ]]\n    [[ $(candidate \"1 2 2 3 3 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given two intervals,\n# where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n# The given intervals are closed which means that the interval (start, end)\n# includes both start and end.\n# For each given interval, it is assumed that its start is less or equal its end.\n# Your task is to determine whether the length of intersection of these two \n# intervals is a prime number.\n# Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n# which its length is 1, which not a prime number.\n# If the length of the intersection is a prime number, return \"YES\",\n# otherwise, return \"NO\".\n# If the two intervals don't intersect, return \"NO\".\n# [input/output] samples:\n# >>> $(intersection \"1 2\" \"2 3\")\n# \"NO\"\n# >>> $(intersection \"-1 1\" \"0 4\")\n# \"NO\"\n# >>> $(intersection \"-3 -1\" \"-5 5\")\n# \"YES\"\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersection \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\" \"2 3\") = \"NO\" ]]\n    [[ $(candidate \"-1 1\" \"0 4\") = \"NO\" ]]\n    [[ $(candidate \"-3 -1\" \"-5 5\") = \"YES\" ]]\n    [[ $(candidate \"-2 2\" \"-4 0\") = \"YES\" ]]\n    [[ $(candidate \"-11 2\" \"-1 -1\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"3 5\") = \"NO\" ]]\n    [[ $(candidate \"1 2\" \"1 2\") = \"NO\" ]]\n    [[ $(candidate \"-2 -2\" \"-3 -2\") = \"NO\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given an array arr of integers and you need to return\n# sum of magnitudes of integers multiplied by product of all signs\n# of each number in the array, represented by 1, -1 or 0.\n# Note: return None for empty arr.\n# Example:\n# >>> $(prod_signs \"1 2 2 -4\")\n# \"9\"\n# >>> $(prod_signs \"0 1\")\n# \"0\"\n# >>> $(prod_signs \"\")\n# \"None\"\n#\n# $1 is a space-separated list\nprod_signs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prod_signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 2 -4\") = \"-9\" ]]\n    [[ $(candidate \"0 1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 -1 1\") = \"-10\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"2 4 1 2 -1 -1 9\") = \"20\" ]]\n    [[ $(candidate \"-1 1 -1 1\") = \"4\" ]]\n    [[ $(candidate \"-1 1 1 1\") = \"-4\" ]]\n    [[ $(candidate \"-1 1 1 0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n# each cell of the grid contains a value. Every integer in the range [1, N * N]\n# inclusive appears exactly once on the cells of the grid.\n# You have to find the minimum path of length k in the grid. You can start\n# from any cell, and in each step you can move to any of the neighbor cells,\n# in other words, you can go to cells which share an edge with you current\n# cell.\n# Please note that a path of length k means visiting exactly k cells (not\n# necessarily distinct).\n# You CANNOT go off the grid.\n# A path A (of length k) is considered less than a path B (of length k) if\n# after making the ordered lists of the values on the cells that A and B go\n# through (let's call them lst_A and lst_B), lst_A is lexicographically less\n# than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n# such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n# lst_A[j] = lst_B[j].\n# It is guaranteed that the answer is unique.\n# Return an ordered list of the values on the cells that the minimum path go through.\n# Examples:    \n# >>> $(minPath \"1 2 3\\n4 5 6\\n7 8 9\" \"3\")\n# ['\"1\"', '\"2\"', '\"1\"']\n# >>> $(minPath \"5 9 3\\n4 1 6\\n7 8 2\" \"1\")\n# ['\"1\"']\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nminPath() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    minPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\" \"3\") = \"1 2 1\" ]]\n    [[ $(candidate \"5 9 3\\n4 1 6\\n7 8 2\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\\n13 14 15 16\" \"4\") = \"1 2 1 2\" ]]\n    [[ $(candidate \"6 4 13 10\\n5 7 12 1\\n3 16 11 15\\n8 14 9 2\" \"7\") = \"1 10 1 10 1 10 1\" ]]\n    [[ $(candidate \"8 14 9 2\\n6 4 13 15\\n5 7 1 12\\n3 10 11 16\" \"5\") = \"1 7 1 7 1\" ]]\n    [[ $(candidate \"11 8 7 2\\n5 16 14 4\\n9 3 15 6\\n12 13 10 1\" \"9\") = \"1 6 1 6 1 6 1 6 1\" ]]\n    [[ $(candidate \"12 13 10 1\\n9 3 15 6\\n5 16 14 4\\n11 8 7 2\" \"12\") = \"1 6 1 6 1 6 1 6 1 6 1 6\" ]]\n    [[ $(candidate \"2 7 4\\n3 1 5\\n6 8 9\" \"8\") = \"1 3 1 3 1 3 1 3\" ]]\n    [[ $(candidate \"6 1 5\\n3 8 9\\n2 7 4\" \"8\") = \"1 5 1 5 1 5 1 5\" ]]\n    [[ $(candidate \"1 2\\n3 4\" \"10\") = \"1 2 1 2 1 2 1 2 1 2\" ]]\n    [[ $(candidate \"1 3\\n3 2\" \"10\") = \"1 3 1 3 1 3 1 3 1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Out of list of strings, return the longest one. Return the first one in case of multiple\n# strings of the same length. Return None in case the input list is empty.\n# >>> $(longest \"\")\n# \"None\"\n# >>> $(longest \"a b c\")\n# \"a\"\n# >>> $(longest \"a bb ccc\")\n# \"ccc\"\n#\n# $1 is a space-separated list\nlongest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    longest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"x y z\") = \"x\" ]]\n    [[ $(candidate \"x yyy zzzz www kkkk abc\") = \"zzzz\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n# the last couple centuries. However, what people don't know is Tribonacci sequence.\n# Tribonacci sequence is defined by the recurrence:\n# tri(1) = 3\n# tri(n) = 1 + n / 2, if n is even.\n# tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n# For example:\n# tri(2) = 1 + (2 / 2) = 2\n# tri(4) = 3\n# tri(3) = tri(2) + tri(1) + tri(4)\n# = 2 + 3 + 3 = 8 \n# You are given a non-negative integer number n, you have to a return a list of the \n# first n + 1 numbers of the Tribonacci sequence.\n# Examples:\n# >>> $(tri \"3\")\n# ['\"1\"', '\"3\"', '\"2\"', '\"8\"']\n#\n# $1 is an integer\ntri() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tri \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1 3 2 8\" ]]\n    [[ $(candidate \"4\") = \"1 3 2 8 3\" ]]\n    [[ $(candidate \"5\") = \"1 3 2 8 3 15\" ]]\n    [[ $(candidate \"6\") = \"1 3 2 8 3 15 4\" ]]\n    [[ $(candidate \"7\") = \"1 3 2 8 3 15 4 24\" ]]\n    [[ $(candidate \"8\") = \"1 3 2 8 3 15 4 24 5\" ]]\n    [[ $(candidate \"9\") = \"1 3 2 8 3 15 4 24 5 35\" ]]\n    [[ $(candidate \"20\") = \"1 3 2 8 3 15 4 24 5 35 6 48 7 63 8 80 9 99 10 120 11\" ]]\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"1 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the product of the odd digits.\n# Return 0 if all digits are even.\n# For example:\n# >>> $(digits \"1\")\n# \"1\"\n# >>> $(digits \"4\")\n# \"0\"\n# >>> $(digits \"235\")\n# \"15\"\n#\n# $1 is an integer\ndigits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"54\") = \"5\" ]]\n    [[ $(candidate \"120\") = \"1\" ]]\n    [[ $(candidate \"5014\") = \"5\" ]]\n    [[ $(candidate \"98765\") = \"315\" ]]\n    [[ $(candidate \"5576543\") = \"2625\" ]]\n    [[ $(candidate \"2468\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a string as input which contains only square brackets.\n# The function should return True if and only if there is a valid subsequence of brackets \n# where at least one bracket in the subsequence is nested.\n# >>> $(is_nested \"[[]]\")\n# \"true\"\n# >>> $(is_nested \"[]]]]]]][[[[[]\")\n# \"false\"\n# >>> $(is_nested \"[][]\")\n# \"false\"\n# >>> $(is_nested \"[]\")\n# \"false\"\n# >>> $(is_nested \"[[][]]\")\n# \"true\"\n# >>> $(is_nested \"[[]][[\")\n# \"true\"\n#\n# $1 is a string\nis_nested() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"[[]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]][[[[[]\") = \"false\" ]]\n    [[ $(candidate \"[][]\") = \"false\" ]]\n    [[ $(candidate \"[]\") = \"false\" ]]\n    [[ $(candidate \"[[[[]]]]\") = \"true\" ]]\n    [[ $(candidate \"[]]]]]]]]]]\") = \"false\" ]]\n    [[ $(candidate \"[][][[]]\") = \"true\" ]]\n    [[ $(candidate \"[[]\") = \"false\" ]]\n    [[ $(candidate \"[]]\") = \"false\" ]]\n    [[ $(candidate \"[[]][[\") = \"true\" ]]\n    [[ $(candidate \"[[][]]\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"[[[[[[[[\") = \"false\" ]]\n    [[ $(candidate \"]]]]]]]]\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of numbers.\n# You need to return the sum of squared numbers in the given list,\n# round each element in the list to the upper int(Ceiling) first.\n# Examples:\n# >>> $(lst \"1.0 2.0 3.0\")\n# \"14\"\n# >>> $(lst \"1.0 4.0 9.0\")\n# \"98\"\n# >>> $(lst \"1.0 3.0 5.0 7.0\")\n# \"84\"\n# >>> $(lst \"1.4 4.2 0.0\")\n# \"29\"\n# >>> $(lst \"-2.4 1.0 1.0\")\n# \"6\"\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 2.0 3.0\") = \"14\" ]]\n    [[ $(candidate \"1.0 3.0 5.0 7.0\") = \"84\" ]]\n    [[ $(candidate \"1.4 4.2 0.0\") = \"29\" ]]\n    [[ $(candidate \"-2.4 1.0 1.0\") = \"6\" ]]\n    [[ $(candidate \"100.0 1.0 15.0 2.0\") = \"10230\" ]]\n    [[ $(candidate \"10000.0 10000.0\") = \"200000000\" ]]\n    [[ $(candidate \"-1.4 4.6 6.3\") = \"75\" ]]\n    [[ $(candidate \"-1.4 17.9 18.9 19.9\") = \"1086\" ]]\n    [[ $(candidate \"0.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0\") = \"1\" ]]\n    [[ $(candidate \"-1.0 1.0 0.0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns True if the last character\n# of a given string is an alphabetical character and is not\n# a part of a word, and False otherwise.\n# Note: \"word\" is a group of characters separated by space.\n# Examples:\n# >>> $(check_if_last_char_is_a_letter \"apple pie\")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e\")\n# \"true\"\n# >>> $(check_if_last_char_is_a_letter \"apple pi e \")\n# \"false\"\n# >>> $(check_if_last_char_is_a_letter \"\")\n# \"false\"\n#\n# $1 is a string\ncheck_if_last_char_is_a_letter() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_if_last_char_is_a_letter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"apple\") = \"false\" ]]\n    [[ $(candidate \"apple pi e\") = \"true\" ]]\n    [[ $(candidate \"eeeee\") = \"false\" ]]\n    [[ $(candidate \"A\") = \"true\" ]]\n    [[ $(candidate \"Pumpkin pie \") = \"false\" ]]\n    [[ $(candidate \"Pumpkin pie 1\") = \"false\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"eeeee e \") = \"false\" ]]\n    [[ $(candidate \"apple pie\") = \"false\" ]]\n    [[ $(candidate \"apple pi e \") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which returns the largest index of an element which\n# is not greater than or equal to the element immediately preceding it. If\n# no such element exists then return -1. The given array will not contain\n# duplicate values.\n# Examples:\n# >>> $(can_arrange \"1 2 4 3 5\")\n# \"3\"\n# >>> $(can_arrange \"1 2 3\")\n# \"-1\"\n#\n# $1 is a space-separated list\ncan_arrange() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    can_arrange \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 3 5\") = \"3\" ]]\n    [[ $(candidate \"1 2 4 5\") = \"-1\" ]]\n    [[ $(candidate \"1 4 2 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"4 8 5 7 3\") = \"4\" ]]\n    [[ $(candidate \"\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that returns a tuple (a, b), where 'a' is\n# the largest of negative integers, and 'b' is the smallest\n# of positive integers in a list.\n# If there is no negative or positive integers, return them as None.\n# Examples:\n# >>> $(largest_smallest_integers \"2 4 1 3 5 7\")\n# ['\"None\"', '\"1\"']\n# >>> $(largest_smallest_integers \"\")\n# ['\"None\"', '\"None\"']\n# >>> $(largest_smallest_integers \"0\")\n# ['\"None\"', '\"None\"']\n#\n# $1 is a space-separated list\nlargest_smallest_integers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_smallest_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 1 3 5 7\") = \"None 1\" ]]\n    [[ $(candidate \"2 4 1 3 5 7 0\") = \"None 1\" ]]\n    [[ $(candidate \"1 3 2 4 5 6 -2\") = \"-2 1\" ]]\n    [[ $(candidate \"4 5 3 6 2 7 -7\") = \"-7 2\" ]]\n    [[ $(candidate \"7 3 8 4 9 2 5 -9\") = \"-9 2\" ]]\n    [[ $(candidate \"\") = \"None None\" ]]\n    [[ $(candidate \"0\") = \"None None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6\") = \"-1 None\" ]]\n    [[ $(candidate \"-1 -3 -5 -6 0\") = \"-1 None\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 1\") = \"-3 1\" ]]\n    [[ $(candidate \"-6 -4 -4 -3 -100 1\") = \"-3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes integers, floats, or strings representing\n# real numbers, and returns the larger variable in its given variable type.\n# Return None if the values are equal.\n# Note: If a real number is represented as a string, the floating point might be . or ,\n# >>> $(compare_one \"1\" \"2.5\")\n# \"2.5\"\n# >>> $(compare_one \"1\" \"2,3\")\n# \"2,3\"\n# >>> $(compare_one \"5,1\" \"6\")\n# \"6\"\n# >>> $(compare_one \"1\" \"1\")\n# \"None\"\n#\n# $1 is an argument\n# $2 is an argument\ncompare_one() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"2.5\") = \"2.5\" ]]\n    [[ $(candidate \"2\" \"3\") = \"3\" ]]\n    [[ $(candidate \"5\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2,3\") = \"2,3\" ]]\n    [[ $(candidate \"5,1\" \"6\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\") = \"2\" ]]\n    [[ $(candidate \"1\" \"1\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n# Example\n# >>> $(is_equal_to_sum_even \"4\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"6\")\n# \"false\"\n# >>> $(is_equal_to_sum_even \"8\")\n# \"true\"\n#\n# $1 is an integer\nis_equal_to_sum_even() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_equal_to_sum_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"true\" ]]\n    [[ $(candidate \"13\") = \"false\" ]]\n    [[ $(candidate \"16\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Brazilian factorial is defined as:\n# brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n# where n > 0\n# For example:\n# >>> $(special_factorial \"4\")\n# \"288\"\n# The function will receive an integer as input and should return the special\n# factorial of this integer.\n#\n# $1 is an integer\nspecial_factorial() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    special_factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"288\" ]]\n    [[ $(candidate \"5\") = \"34560\" ]]\n    [[ $(candidate \"7\") = \"125411328000\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a greatest common divisor of two integers a and b\n# >>> $(greatest_common_divisor \"3\" \"5\")\n# \"1\"\n# >>> $(greatest_common_divisor \"25\" \"15\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\ngreatest_common_divisor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    greatest_common_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"7\") = \"1\" ]]\n    [[ $(candidate \"10\" \"15\") = \"5\" ]]\n    [[ $(candidate \"49\" \"14\") = \"7\" ]]\n    [[ $(candidate \"144\" \"60\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string text, replace all spaces in it with underscores, \n# and if a string has more than 2 consecutive spaces, \n# then replace all consecutive spaces with - \n# >>> $(fix_spaces \" Example\")\n# \"Example\"\n# >>> $(fix_spaces \" Example 1\")\n# \"Example_1\"\n# >>> $(fix_spaces \" Example 2\")\n# \"_Example_2\"\n# >>> $(fix_spaces \" Example 3\")\n# \"_Example-3\"\n#\n# $1 is a string\nfix_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fix_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Example\") = \"Example\" ]]\n    [[ $(candidate \"Mudasir Hanif \") = \"Mudasir_Hanif_\" ]]\n    [[ $(candidate \"Yellow Yellow  Dirty  Fellow\") = \"Yellow_Yellow__Dirty__Fellow\" ]]\n    [[ $(candidate \"Exa   mple\") = \"Exa-mple\" ]]\n    [[ $(candidate \"   Exa 1 2 2 mple\") = \"-Exa_1_2_2_mple\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function which takes a string representing a file's name, and returns\n# 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n# A file's name is considered to be valid if and only if all the following conditions \n# are met:\n# - There should not be more than three digits ('0'-'9') in the file's name.\n# - The file's name contains exactly one dot '.'\n# - The substring before the dot should not be empty, and it starts with a letter from \n# the latin alphapet ('a'-'z' and 'A'-'Z').\n# - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n# Examples:\n# >>> $(file_name_check \"example.txt\")\n# \"Yes\"\n# >>> $(file_name_check \"1example.dll\")\n# \"No\"\n#\n# $1 is a string\nfile_name_check() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    file_name_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"example.txt\") = \"Yes\" ]]\n    [[ $(candidate \"1example.dll\") = \"No\" ]]\n    [[ $(candidate \"s1sdf3.asd\") = \"No\" ]]\n    [[ $(candidate \"K.dll\") = \"Yes\" ]]\n    [[ $(candidate \"MY16FILE3.exe\") = \"Yes\" ]]\n    [[ $(candidate \"His12FILE94.exe\") = \"No\" ]]\n    [[ $(candidate \"_Y.txt\") = \"No\" ]]\n    [[ $(candidate \"?aREYA.exe\") = \"No\" ]]\n    [[ $(candidate \"/this_is_valid.dll\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.wow\") = \"No\" ]]\n    [[ $(candidate \"this_is_valid.txt\") = \"Yes\" ]]\n    [[ $(candidate \"this_is_valid.txtexe\") = \"No\" ]]\n    [[ $(candidate \"#this2_i4s_5valid.ten\") = \"No\" ]]\n    [[ $(candidate \"@this1_is6_valid.exe\") = \"No\" ]]\n    [[ $(candidate \"this_is_12valid.6exe4.txt\") = \"No\" ]]\n    [[ $(candidate \"all.exe.txt\") = \"No\" ]]\n    [[ $(candidate \"I563_No.exe\") = \"Yes\" ]]\n    [[ $(candidate \"Is3youfault.txt\") = \"Yes\" ]]\n    [[ $(candidate \"no_one#knows.dll\") = \"Yes\" ]]\n    [[ $(candidate \"1I563_Yes3.exe\") = \"No\" ]]\n    [[ $(candidate \"I563_Yes3.txtt\") = \"No\" ]]\n    [[ $(candidate \"final..txt\") = \"No\" ]]\n    [[ $(candidate \"final132\") = \"No\" ]]\n    [[ $(candidate \"_f4indsartal132.\") = \"No\" ]]\n    [[ $(candidate \".txt\") = \"No\" ]]\n    [[ $(candidate \"s.\") = \"No\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"\n# This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n# multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n# change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n# Examples:\n# >>> lst\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> lst\n# []\n# >>> lst\n# ['\"-1\"', '\"-5\"', '\"2\"', '\"-1\"', '\"-5\"']\n#\n# $1 is a space-separated list\nsum_squares() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"1 4 9\") = \"14\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 1 1 1 1 1 1\") = \"9\" ]]\n    [[ $(candidate \"-1 -1 -1 -1 -1 -1 -1 -1 -1\") = \"-3\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"-1 -5 2 -1 -5\") = \"-126\" ]]\n    [[ $(candidate \"-56 -99 1 0 -2\") = \"3030\" ]]\n    [[ $(candidate \"-1 0 0 0 0 0 0 0 -1\") = \"0\" ]]\n    [[ $(candidate \"-16 -9 -2 36 36 26 -20 25 -40 20 -4 12 -26 35 37\") = \"-14196\" ]]\n    [[ $(candidate \"-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10\") = \"-1448\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string representing a sentence,\n# the sentence contains some words separated by a space,\n# and you have to return a string that contains the words from the original sentence,\n# whose lengths are prime numbers,\n# the order of the words in the new string should be the same as the original one.\n# Example 1:\n# >>> $(words_in_sentence \"This is a test\")\n# \"is\"\n# Example 2:\n# >>> $(words_in_sentence \"lets go for swimming\")\n# \"go for\"\n# Constraints:\n# * 1 <= len(sentence) <= 100\n# * sentence contains only letters\n#\n# $1 is a string\nwords_in_sentence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    words_in_sentence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"This is a test\") = \"is\" ]]\n    [[ $(candidate \"lets go for swimming\") = \"go for\" ]]\n    [[ $(candidate \"there is no place available here\") = \"there is no place\" ]]\n    [[ $(candidate \"Hi I am Hussein\") = \"Hi am Hussein\" ]]\n    [[ $(candidate \"go for it\") = \"go for it\" ]]\n    [[ $(candidate \"here\") = \"\" ]]\n    [[ $(candidate \"here is\") = \"is\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to implement a function that will simplify the expression\n# x * n. The function returns True if x * n evaluates to a whole number and False\n# otherwise. Both x and n, are string representation of a fraction, and have the following format,\n# <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n# You can assume that x, and n are valid fractions, and do not have zero as denominator.\n# >>> $(simplify \"1/5\" \"5/1\")\n# \"true\"\n# >>> $(simplify \"1/6\" \"2/1\")\n# \"false\"\n# >>> $(simplify \"7/10\" \"10/2\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsimplify() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    simplify \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/6\" \"2/1\") = \"false\" ]]\n    [[ $(candidate \"5/1\" \"3/1\") = \"true\" ]]\n    [[ $(candidate \"7/10\" \"10/2\") = \"false\" ]]\n    [[ $(candidate \"2/10\" \"50/10\") = \"true\" ]]\n    [[ $(candidate \"7/2\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"11/6\" \"6/1\") = \"true\" ]]\n    [[ $(candidate \"2/3\" \"5/2\") = \"false\" ]]\n    [[ $(candidate \"5/2\" \"3/5\") = \"false\" ]]\n    [[ $(candidate \"2/4\" \"8/4\") = \"true\" ]]\n    [[ $(candidate \"2/4\" \"4/2\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"5/1\") = \"true\" ]]\n    [[ $(candidate \"1/5\" \"1/5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which sorts the given list of integers\n# in ascending order according to the sum of their digits.\n# Note: if there are several items with similar sum of their digits,\n# order them based on their index in original list.\n# For example:\n# >>> $(order_by_points \"1 11 -1 -11 -12\")\n# ['\"-1\"', '\"-11\"', '\"1\"', '\"-12\"', '\"11\"']\n# >>> $(order_by_points \"\")\n# []\n#\n# $1 is a space-separated list\norder_by_points() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    order_by_points \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 11 -1 -11 -12\") = \"-1 -11 1 -12 11\" ]]\n    [[ $(candidate \"1234 423 463 145 2 423 423 53 6 37 3457 3 56 0 46\") = \"0 2 3 6 53 423 423 423 1234 145 37 46 56 463 3457\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 -11 -32 43 54 -98 2 -3\") = \"-3 -32 -98 -11 1 2 43 54\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11\") = \"1 10 2 11 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"0 6 6 -76 -21 23 4\") = \"-76 -21 0 4 23 6 6\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +604,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function that takes an array of numbers as input and returns \n# the number of elements in the array that are greater than 10 and both \n# first and last digits of a number are odd (1, 3, 5, 7, 9).\n# For example:\n# >>> $(specialFilter \"15 -73 14 -15\")\n# \"1\"\n# >>> $(specialFilter \"33 -2 -3 45 21 109\")\n# \"2\"\n#\n# $1 is a space-separated list\nspecialFilter() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    specialFilter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 -2 1 -5\") = \"0\" ]]\n    [[ $(candidate \"15 -73 14 -15\") = \"1\" ]]\n    [[ $(candidate \"33 -2 -3 45 21 109\") = \"2\" ]]\n    [[ $(candidate \"43 -12 93 125 121 109\") = \"4\" ]]\n    [[ $(candidate \"71 -2 -33 75 21 19\") = \"3\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1776,25 +612,217 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> $(sum_to_n \"30\")\n# \"465\"\n# >>> $(sum_to_n \"100\")\n# \"5050\"\n# >>> $(sum_to_n \"5\")\n# \"15\"\n# >>> $(sum_to_n \"10\")\n# \"55\"\n# >>> $(sum_to_n \"1\")\n# \"1\"\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "prompt": "#!/bin/bash\n# You are given a positive integer n. You have to create an integer array a of length n.\n# For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n# Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n# and a[i] + a[j] + a[k] is a multiple of 3.\n# Example :\n# >>> $(get_max_triples \"5\")\n# \"1\"\n# Explanation: \n# a = [1, 3, 7, 13, 21]\n# The only valid triple is (1, 7, 13).\n#\n# $1 is an integer\nget_max_triples() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    get_max_triples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"4\" ]]\n    [[ $(candidate \"10\") = \"36\" ]]\n    [[ $(candidate \"100\") = \"53361\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> $(remove_duplicates \"1 2 3 2 4\")\n# ['\"1\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "prompt": "#!/bin/bash\n# There are eight planets in our solar system: the closerst to the Sun \n# is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n# Uranus, Neptune.\n# Write a function that takes two planet names as strings planet1 and planet2. \n# The function should return a tuple containing all planets whose orbits are \n# located between the orbit of planet1 and the orbit of planet2, sorted by \n# the proximity to the sun. \n# The function should return an empty tuple if planet1 or planet2\n# are not correct planet names. \n# Examples\n# >>> $(bf \"Jupiter\" \"Neptune\")\n# ['\"Saturn\"', '\"Uranus\"']\n# >>> $(bf \"Earth\" \"Mercury\")\n# \"Venus\"\n# >>> $(bf \"Mercury\" \"Uranus\")\n# ['\"Venus\"', '\"Earth\"', '\"Mars\"', '\"Jupiter\"', '\"Saturn\"']\n#\n# $1 is a string\n# $2 is a string\nbf() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    bf \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jupiter\" \"Neptune\") = \"Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Mercury\") = \"Venus\" ]]\n    [[ $(candidate \"Mercury\" \"Uranus\") = \"Venus Earth Mars Jupiter Saturn\" ]]\n    [[ $(candidate \"Neptune\" \"Venus\") = \"Earth Mars Jupiter Saturn Uranus\" ]]\n    [[ $(candidate \"Earth\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Mars\" \"Earth\") = \"\" ]]\n    [[ $(candidate \"Jupiter\" \"Makemake\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings as a parameter,\n# deletes the strings that have odd lengths from it,\n# and returns the resulted list with a sorted order,\n# The list is always a list of strings and never an array of numbers,\n# and it may contain duplicates.\n# The order of the list should be ascending by length of each word, and you\n# should return the list sorted by that rule.\n# If two words have the same length, sort the list alphabetically.\n# The function should return a list of strings in sorted order.\n# You may assume that all words will have the same length.\n# For example:\n# >>> $(list_sort \"aa a aaa\")\n# ['\"aa\"']\n# >>> $(list_sort \"ab a aaa cd\")\n# ['\"ab\"', '\"cd\"']\n#\n# $1 is a space-separated list\nsorted_list_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sorted_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aa a aaa\") = \"aa\" ]]\n    [[ $(candidate \"school AI asdf b\") = \"AI asdf school\" ]]\n    [[ $(candidate \"d b c a\") = \"\" ]]\n    [[ $(candidate \"d dcba abcd a\") = \"abcd dcba\" ]]\n    [[ $(candidate \"AI ai au\") = \"AI ai au\" ]]\n    [[ $(candidate \"a b b c c a\") = \"\" ]]\n    [[ $(candidate \"aaaa bbbb dd cc\") = \"cc dd aaaa bbbb\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of all prefixes from shortest to longest of the input string\n# >>> $(all_prefixes \"abc\")\n# ['\"a\"', '\"ab\"', '\"abc\"']\n#\n# $1 is a string\nall_prefixes() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_prefixes \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"asdfgh\") = \"a as asd asdf asdfg asdfgh\" ]]\n    [[ $(candidate \"WWW\") = \"W WW WWW\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# A simple program which should return the value of x if n is \n# a prime number and should return the value of y otherwise.\n# Examples:\n# >>> $(x_or_y \"7\" \"34\" \"12\")\n# \"34\"\n# >>> $(x_or_y \"15\" \"8\" \"5\")\n# \"5\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nx_or_y() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    x_or_y \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"34\" \"12\") = \"34\" ]]\n    [[ $(candidate \"15\" \"8\" \"5\") = \"5\" ]]\n    [[ $(candidate \"3\" \"33\" \"5212\") = \"33\" ]]\n    [[ $(candidate \"1259\" \"3\" \"52\") = \"3\" ]]\n    [[ $(candidate \"7919\" \"-1\" \"12\") = \"-1\" ]]\n    [[ $(candidate \"3609\" \"1245\" \"583\") = \"583\" ]]\n    [[ $(candidate \"91\" \"56\" \"129\") = \"129\" ]]\n    [[ $(candidate \"6\" \"34\" \"1234\") = \"1234\" ]]\n    [[ $(candidate \"1\" \"2\" \"0\") = \"0\" ]]\n    [[ $(candidate \"2\" \"2\" \"0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of numbers, return the sum of squares of the numbers\n# in the list that are odd. Ignore numbers that are negative or not integers.\n# >>> $(double_the_difference \"1 3 2 0\")\n# \"10\"\n# >>> $(double_the_difference \"-1 -2 0\")\n# \"0\"\n# >>> $(double_the_difference \"9 -2\")\n# \"81\"\n# >>> $(double_the_difference \"0\")\n# \"0\"\n# If the input list is empty, return 0.\n#\n# $1 is a space-separated list\ndouble_the_difference() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    double_the_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"5.0 4.0\") = \"25\" ]]\n    [[ $(candidate \"0.1 0.2 0.3\") = \"0\" ]]\n    [[ $(candidate \"-10.0 -20.0 -30.0\") = \"0\" ]]\n    [[ $(candidate \"-1.0 -2.0 8.0\") = \"0\" ]]\n    [[ $(candidate \"0.2 3.0 5.0\") = \"34\" ]]\n    [[ $(candidate \"-9.0 -7.0 -5.0 -3.0 -1.0 1.0 3.0 5.0 7.0 9.0\") = \"165\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# I think we all remember that feeling when the result of some long-awaited\n# event is finally known. The feelings and thoughts you have at that moment are\n# definitely worth noting down and comparing.\n# Your task is to determine if a person correctly guessed the results of a number of matches.\n# You are given two arrays of scores and guesses of equal length, where each index shows a match. \n# Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n# the value is 0, and if not, the value is the absolute difference between the guess and the score.\n# example:\n# >>> $(compare \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\")\n# ['\"0\"', '\"0\"', '\"0\"', '\"0\"', '\"3\"', '\"3\"']\n# >>> $(compare \"0 5 0 0 0 4\" \"4 1 1 0 0 -2\")\n# ['\"4\"', '\"4\"', '\"1\"', '\"0\"', '\"0\"', '\"6\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncompare() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    compare \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 1\" \"1 2 3 4 2 -2\") = \"0 0 0 0 3 3\" ]]\n    [[ $(candidate \"0 0 0 0 0 0\" \"0 0 0 0 0 0\") = \"0 0 0 0 0 0\" ]]\n    [[ $(candidate \"1 2 3\" \"-1 -2 -3\") = \"2 4 6\" ]]\n    [[ $(candidate \"1 2 3 5\" \"-1 2 3 4\") = \"2 0 0 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given the name of a class (a string) and a list of extensions.\n# The extensions are to be used to load additional classes to the class. The\n# strength of the extension is as follows: Let CAP be the number of the uppercase\n# letters in the extension's name, and let SM be the number of lowercase letters \n# in the extension's name, the strength is given by the fraction CAP - SM. \n# You should find the strongest extension and return a string in this \n# format: ClassName.StrongestExtensionName.\n# If there are two or more extensions with the same strength, you should\n# choose the one that comes first in the list.\n# For example, if you are given \"Slices\" as the class and a list of the\n# extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n# return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n# (its strength is -1).\n# Example:\n# >>> $(Strongest_Extension \"my_class\" \"AA Be CC\")\n# \"my_class.AA\"\n#\n# $1 is a string\n# $2 is a space-separated list\nStrongest_Extension() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Strongest_Extension \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Watashi\" \"tEN niNE eIGHt8OKe\") = \"Watashi.eIGHt8OKe\" ]]\n    [[ $(candidate \"Boku123\" \"nani NazeDa YEs.WeCaNe 32145tggg\") = \"Boku123.YEs.WeCaNe\" ]]\n    [[ $(candidate \"__YESIMHERE\" \"t eMptY nothing zeR00 NuLl__ 123NoooneB321\") = \"__YESIMHERE.NuLl__\" ]]\n    [[ $(candidate \"K\" \"Ta TAR t234An cosSo\") = \"K.TAR\" ]]\n    [[ $(candidate \"__HAHA\" \"Tab 123 781345 -_-\") = \"__HAHA.123\" ]]\n    [[ $(candidate \"YameRore\" \"HhAas okIWILL123 WorkOut Fails -_-\") = \"YameRore.okIWILL123\" ]]\n    [[ $(candidate \"finNNalLLly\" \"Die NowW Wow WoW\") = \"finNNalLLly.WoW\" ]]\n    [[ $(candidate \"_\" \"Bb 91245\") = \"_.Bb\" ]]\n    [[ $(candidate \"Sp\" \"671235 Bb\") = \"Sp.671235\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n# >>> $(cycpattern_check \"abcd\" \"abd\")\n# \"false\"\n# >>> $(cycpattern_check \"hello\" \"ell\")\n# \"true\"\n# >>> $(cycpattern_check \"whassup\" \"psus\")\n# \"false\"\n# >>> $(cycpattern_check \"abab\" \"baa\")\n# \"true\"\n# >>> $(cycpattern_check \"efef\" \"eeff\")\n# \"false\"\n# >>> $(cycpattern_check \"himenss\" \"simen\")\n# \"true\"\n#\n# $1 is a string\n# $2 is a string\ncycpattern_check() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cycpattern_check \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xyzw\" \"xyw\") = \"false\" ]]\n    [[ $(candidate \"yello\" \"ell\") = \"true\" ]]\n    [[ $(candidate \"whattup\" \"ptut\") = \"false\" ]]\n    [[ $(candidate \"efef\" \"fee\") = \"true\" ]]\n    [[ $(candidate \"abab\" \"aabb\") = \"false\" ]]\n    [[ $(candidate \"winemtt\" \"tinem\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an integer. return a tuple that has the number of even and odd digits respectively.\n# Example:\n# >>> $(even_odd_count \"-12\")\n# ['\"1\"', '\"1\"']\n# >>> $(even_odd_count \"123\")\n# ['\"1\"', '\"2\"']\n#\n# $1 is an integer\neven_odd_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_odd_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"0 1\" ]]\n    [[ $(candidate \"-78\") = \"1 1\" ]]\n    [[ $(candidate \"3452\") = \"2 2\" ]]\n    [[ $(candidate \"346211\") = \"3 3\" ]]\n    [[ $(candidate \"-345821\") = \"3 3\" ]]\n    [[ $(candidate \"-2\") = \"1 0\" ]]\n    [[ $(candidate \"-45347\") = \"2 3\" ]]\n    [[ $(candidate \"0\") = \"1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer, obtain its roman numeral equivalent as a string,\n# and return it in lowercase.\n# Restrictions: 1 <= num <= 1000\n# Examples:\n# >>> $(int_to_mini_roman \"19\")\n# \"xix\"\n# >>> $(int_to_mini_roman \"152\")\n# \"clii\"\n# >>> $(int_to_mini_roman \"426\")\n# \"cdxxvi\"\n#\n# $1 is an integer\nint_to_mini_roman() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    int_to_mini_roman \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"19\") = \"xix\" ]]\n    [[ $(candidate \"152\") = \"clii\" ]]\n    [[ $(candidate \"251\") = \"ccli\" ]]\n    [[ $(candidate \"426\") = \"cdxxvi\" ]]\n    [[ $(candidate \"500\") = \"d\" ]]\n    [[ $(candidate \"1\") = \"i\" ]]\n    [[ $(candidate \"4\") = \"iv\" ]]\n    [[ $(candidate \"43\") = \"xliii\" ]]\n    [[ $(candidate \"90\") = \"xc\" ]]\n    [[ $(candidate \"94\") = \"xciv\" ]]\n    [[ $(candidate \"532\") = \"dxxxii\" ]]\n    [[ $(candidate \"900\") = \"cm\" ]]\n    [[ $(candidate \"994\") = \"cmxciv\" ]]\n    [[ $(candidate \"1000\") = \"m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return True if the three\n# sides form a right-angled triangle, False otherwise.\n# A right-angled triangle is a triangle in which one angle is right angle or \n# 90 degree.\n# Example:\n# >>> $(right_angle_triangle \"3\" \"4\" \"5\")\n# \"true\"\n# >>> $(right_angle_triangle \"1\" \"2\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nright_angle_triangle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    right_angle_triangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"true\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"10\" \"6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"false\" ]]\n    [[ $(candidate \"7\" \"24\" \"25\") = \"true\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"false\" ]]\n    [[ $(candidate \"5\" \"12\" \"13\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\" \"17\") = \"true\" ]]\n    [[ $(candidate \"48\" \"55\" \"73\") = \"true\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"false\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts a list of strings.\n# The list contains different words. Return the word with maximum number\n# of unique characters. If multiple strings have maximum number of unique\n# characters, return the one which comes first in lexicographical order.\n# >>> $(find_max \"name of string\")\n# \"string\"\n# >>> $(find_max \"name enam game\")\n# \"enam\"\n# >>> $(find_max \"aaaaaaa bb cc\")\n# \"aaaaaaa\"\n#\n# $1 is a space-separated list\nfind_max() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"name of string\") = \"string\" ]]\n    [[ $(candidate \"name enam game\") = \"enam\" ]]\n    [[ $(candidate \"aaaaaaa bb cc\") = \"aaaaaaa\" ]]\n    [[ $(candidate \"abc cba\") = \"abc\" ]]\n    [[ $(candidate \"play this game of footbott\") = \"footbott\" ]]\n    [[ $(candidate \"we are gonna rock\") = \"gonna\" ]]\n    [[ $(candidate \"we are a mad nation\") = \"nation\" ]]\n    [[ $(candidate \"this is a prrk\") = \"this\" ]]\n    [[ $(candidate \"b\") = \"b\" ]]\n    [[ $(candidate \"play play play\") = \"play\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're a hungry rabbit, and you already have eaten a certain number of carrots,\n# but now you need to eat more carrots to complete the day's meals.\n# you should return an array of [ total number of eaten carrots after your meals,\n# the number of carrots left after your meals ]\n# if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n# Example:\n# >>> $(eat \"5\" \"6\" \"10\")\n# ['\"11\"', '\"4\"']\n# >>> $(eat \"4\" \"8\" \"9\")\n# ['\"12\"', '\"1\"']\n# >>> $(eat \"1\" \"10\" \"10\")\n# ['\"11\"', '\"0\"']\n# >>> $(eat \"2\" \"11\" \"5\")\n# ['\"7\"', '\"0\"']\n# Variables:\n# @number : integer\n# the number of carrots that you have eaten.\n# @need : integer\n# the number of carrots that you need to eat.\n# @remaining : integer\n# the number of remaining carrots thet exist in stock\n# Constrain:\n# * 0 <= number <= 1000\n# * 0 <= need <= 1000\n# * 0 <= remaining <= 1000\n# Have fun :)\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\neat() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    eat \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"6\" \"10\") = \"11 4\" ]]\n    [[ $(candidate \"4\" \"8\" \"9\") = \"12 1\" ]]\n    [[ $(candidate \"1\" \"10\" \"10\") = \"11 0\" ]]\n    [[ $(candidate \"2\" \"11\" \"5\") = \"7 0\" ]]\n    [[ $(candidate \"4\" \"5\" \"7\") = \"9 2\" ]]\n    [[ $(candidate \"4\" \"5\" \"1\") = \"5 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n# >>> $(string_sequence \"0\")\n# \"0\"\n# >>> $(string_sequence \"5\")\n# \"0 1 2 3 4 5\"\n#\n# $1 is an integer\nstring_sequence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"3\") = \"0 1 2 3\" ]]\n    [[ $(candidate \"10\") = \"0 1 2 3 4 5 6 7 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given two lists operator, and operand. The first list has basic algebra operations, and \n# the second list is a list of integers. Use the two given lists to build the algebric \n# expression and return the evaluation of this expression.\n# The basic algebra operations:\n# Addition ( + ) \n# Subtraction ( - ) \n# Multiplication ( * ) \n# Floor division ( // ) \n# Exponentiation ( ** ) \n# Example:\n# operator['+', '*', '-']\n# array = [2, 3, 4, 5]\n# result = 2 + 3 * 4 - 5\n# => result = 9\n# Note:\n# The length of operator list is equal to the length of operand list minus one.\n# Operand is a list of of non-negative integers.\n# Operator list has at least one operator, and operand list has at least two operands.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndo_algebra() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    do_algebra \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"** * +\" \"2 3 4 5\") = \"37\" ]]\n    [[ $(candidate \"+ * -\" \"2 3 4 5\") = \"9\" ]]\n    [[ $(candidate \"// *\" \"7 3 4\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# if s[i] is a letter, reverse its case from lower to upper or vise versa, \n# otherwise keep it as it is.\n# If the string contains no letters, reverse the string.\n# The function should return the resulted string.\n# Examples\n# >>> $(solve \"1234\")\n# \"4321\"\n# >>> $(solve \"ab\")\n# \"AB\"\n# >>> $(solve \"#a@C\")\n# \"#A@c\"\n#\n# $1 is a string\nsolve() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AsDf\") = \"aSdF\" ]]\n    [[ $(candidate \"1234\") = \"4321\" ]]\n    [[ $(candidate \"ab\") = \"AB\" ]]\n    [[ $(candidate \"#a@C\") = \"#A@c\" ]]\n    [[ $(candidate \"#AsdfW^45\") = \"#aSDFw^45\" ]]\n    [[ $(candidate \"#6@2\") = \"2@6#\" ]]\n    [[ $(candidate \"#\\$a^D\") = \"#\\$A^d\" ]]\n    [[ $(candidate \"#ccc\") = \"#CCC\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string 'text', return its md5 hash equivalent string.\n# If 'text' is an empty string, return None.\n# >>> $(string_to_md5 \"Hello world\")\n# \"3e25960a79dbc69b674cd4ec67a72c62\"\n#\n# $1 is a string\nstring_to_md5() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_to_md5 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"3e25960a79dbc69b674cd4ec67a72c62\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"A B C\") = \"0ef78513b0cb8cef12743f5aeb35f888\" ]]\n    [[ $(candidate \"password\") = \"5f4dcc3b5aa765d61d8327deb882cf99\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +832,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Given two positive integers a and b, return the even digits between a\n# and b, in ascending order.\n# For example:\n# >>> $(generate_integers \"2\" \"8\")\n# ['\"2\"', '\"4\"', '\"6\"', '\"8\"']\n# >>> $(generate_integers \"8\" \"2\")\n# ['\"2\"', '\"4\"', '\"6\"', '\"8\"']\n# >>> $(generate_integers \"10\" \"14\")\n# []\n#\n# $1 is an integer\n# $2 is an integer\ngenerate_integers() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    generate_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"10\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"10\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"132\" \"2\") = \"2 4 6 8\" ]]\n    [[ $(candidate \"17\" \"89\") = \"\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -1812,49 +840,253 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> $(rolling_max \"1 2 3 2 3 4 2\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"3\"', '\"3\"', '\"4\"', '\"4\"']\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "prompt": "#!/bin/bash\n# Given a string, find out how many distinct characters (regardless of case) does it consist of\n# >>> $(count_distinct_characters \"xyzXYZ\")\n# \"3\"\n# >>> $(count_distinct_characters \"Jerry\")\n# \"4\"\n#\n# $1 is a string\ncount_distinct_characters() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count_distinct_characters \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abcde\") = \"5\" ]]\n    [[ $(candidate \"abcdecadeCADE\") = \"5\" ]]\n    [[ $(candidate \"aaaaAAAAaaaa\") = \"1\" ]]\n    [[ $(candidate \"Jerry jERRY JeRRRY\") = \"5\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> $(below_zero \"1 2 3\")\n# \"false\"\n# >>> $(below_zero \"1 2 -4 5\")\n# \"true\"\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "prompt": "#!/bin/bash\n# Input to this function is a string representing musical notes in a special ASCII format.\n# Your task is to parse this string and return list of integers corresponding to how many beats does each\n# not last.\n# Here is a legend:\n# 'o' - whole note, lasts four beats\n# 'o|' - half note, lasts two beats\n# '.|' - quater note, lasts one beat\n# >>> $(parse_music \"o o| .| o| o| .| .| .| .| o o\")\n# ['\"4\"', '\"2\"', '\"1\"', '\"2\"', '\"2\"', '\"1\"', '\"1\"', '\"1\"', '\"1\"', '\"4\"', '\"4\"']\n#\n# $1 is a string\nparse_music() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    parse_music \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"o o o o\") = \"4 4 4 4\" ]]\n    [[ $(candidate \".| .| .| .|\") = \"1 1 1 1\" ]]\n    [[ $(candidate \"o| o| .| .| o o o o\") = \"2 2 1 1 4 4 4 4\" ]]\n    [[ $(candidate \"o| .| o| .| o o| o o|\") = \"2 1 2 1 4 2 4 2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> $(search \"4 1 2 2 3 1\")\n# \"2\"\n# >>> $(search \"1 2 2 3 3 3 4 4 4\")\n# \"3\"\n# >>> $(search \"5 5 4 4 4\")\n# \"-1\"\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "prompt": "#!/bin/bash\n# Find how many times a given substring can be found in the original string. Count overlaping cases.\n# >>> $(how_many_times \"\" \"a\")\n# \"0\"\n# >>> $(how_many_times \"aaa\" \"a\")\n# \"3\"\n# >>> $(how_many_times \"aaaa\" \"aa\")\n# \"3\"\n#\n# $1 is a string\n# $2 is a string\nhow_many_times() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    how_many_times \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"x\") = \"0\" ]]\n    [[ $(candidate \"xyxyxyx\" \"x\") = \"4\" ]]\n    [[ $(candidate \"cacacacac\" \"cac\") = \"4\" ]]\n    [[ $(candidate \"john doe\" \"john\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"(\")\n# \"false\"\n# >>> $(correct_bracketing \"()\")\n# \"true\"\n# >>> $(correct_bracketing \"(()())\")\n# \"true\"\n# >>> $(correct_bracketing \")(()\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "prompt": "#!/bin/bash\n# Input is a space-delimited string of numberals from 'zero' to 'nine'.\n# Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n# Return the string with numbers sorted from smallest to largest\n# >>> $(sort_numbers \"three one five\")\n# \"one three five\"\n#\n# $1 is a string\nsort_numbers() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sort_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"three\") = \"three\" ]]\n    [[ $(candidate \"three five nine\") = \"three five nine\" ]]\n    [[ $(candidate \"five zero four seven nine eight\") = \"zero four five seven eight nine\" ]]\n    [[ $(candidate \"six five four three two one zero\") = \"zero one two three four five six\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n# separate those group into separate strings and return the list of those.\n# Separate groups are balanced (each open brace is properly closed) and not nested within each other\n# Ignore any spaces in the input string.\n# >>> $(separate_paren_groups \"( ) (( )) (( )( ))\")\n# ['\"()\"', '\"(())\"', '\"(()())\"']\n#\n# $1 is a string\nseparate_paren_groups() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    separate_paren_groups \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"(()()) ((())) () ((())()())\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"() (()) ((())) (((())))\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"(()(())((())))\" ]]\n    [[ $(candidate \"( ) (( )) (( )( ))\") = \"() (()) (()())\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n# other and return them in order (smaller number, larger number).\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.2\")\n# ['\"2.0\"', '\"2.2\"']\n# >>> $(find_closest_elements \"1.0 2.0 3.0 4.0 5.0 2.0\")\n# ['\"2.0\"', '\"2.0\"']\n#\n# $1 is a space-separated list\nfind_closest_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_closest_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0 3.9 4.0 5.0 2.2\") = \"3.9 4.0\" ]]\n    [[ $(candidate \"1.0 2.0 5.9 4.0 5.0\") = \"5.0 5.9\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.2\") = \"2.0 2.2\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0 2.0\") = \"2.0 2.0\" ]]\n    [[ $(candidate \"1.1 2.2 3.1 4.1 5.1\") = \"2.2 3.1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of numbers (of at least two elements), apply a linear transform to that list,\n# such that the smallest number will become 0 and the largest will become 1\n# >>> $(rescale_to_unit \"1.0 2.0 3.0 4.0 5.0\")\n# ['\"0.0\"', '\"0.25\"', '\"0.5\"', '\"0.75\"', '\"1.0\"']\n#\n# $1 is a space-separated list\nrescale_to_unit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rescale_to_unit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2.0 49.9\") = \"0.0 1.0\" ]]\n    [[ $(candidate \"100.0 49.9\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"0.0 0.25 0.5 0.75 1.0\" ]]\n    [[ $(candidate \"2.0 1.0 5.0 3.0 4.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n    [[ $(candidate \"12.0 11.0 15.0 13.0 14.0\") = \"0.25 0.0 1.0 0.5 0.75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Filter given list of any python values only for integers\n# >>> $(filter_integers \"a 3.14 5\")\n# ['\"5\"']\n# >>> $(filter_integers \"1 2 3 abc  \")\n# ['\"1\"', '\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\nfilter_integers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    filter_integers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"4   23.2 9 adasd\") = \"4 9\" ]]\n    [[ $(candidate \"3 c 3 3 a b\") = \"3 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return length of given string\n# >>> $(strlen \"\")\n# \"0\"\n# >>> $(strlen \"abc\")\n# \"3\"\n#\n# $1 is a string\nstrlen() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strlen \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"x\") = \"1\" ]]\n    [[ $(candidate \"asdasnakj\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given number n, find the largest number that divides n evenly, smaller than n\n# >>> $(largest_divisor \"15\")\n# \"5\"\n#\n# $1 is an integer\nlargest_divisor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"1\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n    [[ $(candidate \"10\") = \"5\" ]]\n    [[ $(candidate \"100\") = \"50\" ]]\n    [[ $(candidate \"49\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list of prime factors of given integer in the order from smallest to largest.\n# Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n# Input number should be equal to the product of all factors\n# >>> $(factorize \"8\")\n# ['\"2\"', '\"2\"', '\"2\"']\n# >>> $(factorize \"25\")\n# ['\"5\"', '\"5\"']\n# >>> $(factorize \"70\")\n# ['\"2\"', '\"5\"', '\"7\"']\n#\n# $1 is an integer\nfactorize() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    factorize \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"4\") = \"2 2\" ]]\n    [[ $(candidate \"8\") = \"2 2 2\" ]]\n    [[ $(candidate \"57\") = \"3 19\" ]]\n    [[ $(candidate \"3249\") = \"3 3 19 19\" ]]\n    [[ $(candidate \"185193\") = \"3 3 3 19 19 19\" ]]\n    [[ $(candidate \"20577\") = \"3 19 19 19\" ]]\n    [[ $(candidate \"18\") = \"2 3 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a list of integers, remove all elements that occur more than once.\n# Keep order of elements left the same as in the input.\n# >>> $(remove_duplicates \"1 2 3 2 4\")\n# ['\"1\"', '\"3\"', '\"4\"']\n#\n# $1 is a space-separated list\nremove_duplicates() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"1 2 3 2 4 3 5\") = \"1 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n# >>> $(flip_case \"Hello\")\n# \"hELLO\"\n#\n# $1 is a string\nflip_case() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    flip_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hello\\!\") = \"hELLO\\!\" ]]\n    [[ $(candidate \"These violent delights have violent ends\") = \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Concatenate list of strings into a single string\n# >>> $(concatenate \"\")\n# \"\"\n# >>> $(concatenate \"a b c\")\n# \"abc\"\n#\n# $1 is a space-separated list\nconcatenate() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    concatenate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"x y z\") = \"xyz\" ]]\n    [[ $(candidate \"x y z w k\") = \"xyzwk\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive floating point number, it can be decomposed into\n# and integer part (largest integer smaller than given number) and decimals\n# (leftover part always smaller than 1).\n# Return the decimal part of the number.\n# >>> $(truncate_number \"3.5\")\n# \"0.5\"\n#\n# $1 is a floating point\ntruncate_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    truncate_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3.5\") = \"0.5\" ]]\n    [[ $(candidate \"1.25\") = \"0.25\" ]]\n    [[ $(candidate \"123.0\") = \"0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return only positive numbers in the list.\n# >>> $(get_positive \"-1 2 -4 5 6\")\n# ['\"2\"', '\"5\"', '\"6\"']\n# >>> $(get_positive \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# ['\"5\"', '\"3\"', '\"2\"', '\"3\"', '\"9\"', '\"123\"', '\"1\"']\n#\n# $1 is a space-separated list\nget_positive() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_positive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 -2 4 5 6\") = \"4 5 6\" ]]\n    [[ $(candidate \"5 3 -5 2 3 3 9 0 123 1 -10\") = \"5 3 2 3 3 9 123 1\" ]]\n    [[ $(candidate \"-1 -2\") = \"\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return true if a given number is prime, and false otherwise.\n# >>> $(is_prime \"6\")\n# \"false\"\n# >>> $(is_prime \"101\")\n# \"true\"\n# >>> $(is_prime \"11\")\n# \"true\"\n# >>> $(is_prime \"13441\")\n# \"true\"\n# >>> $(is_prime \"61\")\n# \"true\"\n# >>> $(is_prime \"4\")\n# \"false\"\n# >>> $(is_prime \"1\")\n# \"false\"\n#\n# $1 is an integer\nis_prime() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"false\" ]]\n    [[ $(candidate \"101\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"13441\") = \"true\" ]]\n    [[ $(candidate \"61\") = \"true\" ]]\n    [[ $(candidate \"4\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"11\") = \"true\" ]]\n    [[ $(candidate \"17\") = \"true\" ]]\n    [[ $(candidate \"85\") = \"false\" ]]\n    [[ $(candidate \"77\") = \"false\" ]]\n    [[ $(candidate \"255379\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n# to the values of the corresponding indicies of l, but sorted.\n# >>> $(sort_third \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_third \"5 6 3 4 8 9 2\")\n# ['\"2\"', '\"6\"', '\"3\"', '\"4\"', '\"8\"', '\"9\"', '\"5\"']\n#\n# $1 is a space-separated list\nsort_third() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_third \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 3 4 8 9 2\") = \"2 6 3 4 8 9 5\" ]]\n    [[ $(candidate \"5 8 3 4 6 9 2\") = \"2 8 3 4 6 9 5\" ]]\n    [[ $(candidate \"5 6 9 4 8 3 2\") = \"2 6 9 4 8 3 5\" ]]\n    [[ $(candidate \"5 6 3 4 8 9 2 1\") = \"2 6 3 4 8 9 5 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique elements in a list\n# >>> $(unique \"5 3 5 2 3 3 9 0 123\")\n# ['\"0\"', '\"2\"', '\"3\"', '\"5\"', '\"9\"', '\"123\"']\n#\n# $1 is a space-separated list\nunique() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 5 2 3 3 9 0 123\") = \"0 2 3 5 9 123\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return maximum element in the list.\n# >>> $(max_element \"1 2 3\")\n# \"3\"\n# >>> $(max_element \"5 3 -5 2 -3 3 9 0 123 1 -10\")\n# \"123\"\n#\n# $1 is a space-separated list\nmax_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 124 1 -10\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n# >>> $(fizz_buzz \"50\")\n# \"0\"\n# >>> $(fizz_buzz \"78\")\n# \"2\"\n# >>> $(fizz_buzz \"79\")\n# \"3\"\n#\n# $1 is an integer\nfizz_buzz() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fizz_buzz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"50\") = \"0\" ]]\n    [[ $(candidate \"78\") = \"2\" ]]\n    [[ $(candidate \"79\") = \"3\" ]]\n    [[ $(candidate \"100\") = \"3\" ]]\n    [[ $(candidate \"200\") = \"6\" ]]\n    [[ $(candidate \"4000\") = \"192\" ]]\n    [[ $(candidate \"10000\") = \"639\" ]]\n    [[ $(candidate \"100000\") = \"8026\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1096,201 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# This function takes a list l and returns a list l' such that\n# l' is identical to l in the odd indicies, while its values at the even indicies are equal\n# to the values of the even indicies of l, but sorted.\n# >>> $(sort_even \"1 2 3\")\n# ['\"1\"', '\"2\"', '\"3\"']\n# >>> $(sort_even \"5 6 3 4\")\n# ['\"3\"', '\"6\"', '\"5\"', '\"4\"']\n#\n# $1 is a space-separated list\nsort_even() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    sort_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"5 3 -5 2 -3 3 9 0 123 1 -10\") = \"-10 3 -5 2 -3 3 5 0 9 1 123\" ]]\n    [[ $(candidate \"5 8 -12 4 23 2 3 11 12 -10\") = \"-12 8 3 4 5 2 12 11 23 -10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n# >>> $(prime_fib \"1\")\n# \"2\"\n# >>> $(prime_fib \"2\")\n# \"3\"\n# >>> $(prime_fib \"3\")\n# \"5\"\n# >>> $(prime_fib \"4\")\n# \"13\"\n# >>> $(prime_fib \"5\")\n# \"89\"\n#\n# $1 is an integer\nprime_fib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"2\" ]]\n    [[ $(candidate \"2\") = \"3\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"13\" ]]\n    [[ $(candidate \"5\") = \"89\" ]]\n    [[ $(candidate \"6\") = \"233\" ]]\n    [[ $(candidate \"7\") = \"1597\" ]]\n    [[ $(candidate \"8\") = \"28657\" ]]\n    [[ $(candidate \"9\") = \"514229\" ]]\n    [[ $(candidate \"10\") = \"433494437\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You're given a list of deposit and withdrawal operations on a bank account that starts with\n# zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n# at that point function should return True. Otherwise it should return False.\n# >>> $(below_zero \"1 2 3\")\n# \"false\"\n# >>> $(below_zero \"1 2 -4 5\")\n# \"true\"\n#\n# $1 is a space-separated list\nbelow_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"1 2 -3 1 2 -3\") = \"false\" ]]\n    [[ $(candidate \"1 2 -4 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -4\") = \"false\" ]]\n    [[ $(candidate \"1 -1 2 -2 5 -5 4 -5\") = \"true\" ]]\n    [[ $(candidate \"1 -2 2 -2 5 -5 4 -4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# triples_sum_to_zero takes a list of integers as an input.\n# it returns True if there are three distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> $(triples_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"1 3 -2 1\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(triples_sum_to_zero \"2 4 -5 3 9 7\")\n# \"true\"\n# >>> $(triples_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\ntriples_sum_to_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triples_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -1\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"1 2 5 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 9 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"1 3 5 -100\") = \"false\" ]]\n    [[ $(candidate \"100 3 5 -100\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Imagine a road that's a perfectly straight infinitely long line.\n# n cars are driving left to right;  simultaneously, a different set of n cars\n# are driving right to left.   The two sets of cars start out being very far from\n# each other.  All cars move in the same speed.  Two cars are said to collide\n# when a car that's moving left to right hits a car that's moving right to left.\n# However, the cars are infinitely sturdy and strong; as a result, they continue moving\n# in their trajectory as if they did not collide.\n# This function outputs the number of such collisions.\n#\n# $1 is an integer\ncar_race_collision() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    car_race_collision \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"9\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n    [[ $(candidate \"8\") = \"64\" ]]\n    [[ $(candidate \"10\") = \"100\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return list with elements incremented by 1.\n# >>> $(incr_list \"1 2 3\")\n# ['\"2\"', '\"3\"', '\"4\"']\n# >>> $(incr_list \"5 3 5 2 3 3 9 0 123\")\n# ['\"6\"', '\"4\"', '\"6\"', '\"3\"', '\"4\"', '\"4\"', '\"10\"', '\"1\"', '\"124\"']\n#\n# $1 is a space-separated list\nincr_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    incr_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"3 2 1\") = \"4 3 2\" ]]\n    [[ $(candidate \"5 2 5 2 3 3 9 0 123\") = \"6 3 6 3 4 4 10 1 124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# pairs_sum_to_zero takes a list of integers as an input.\n# it returns True if there are two distinct elements in the list that\n# sum to zero, and False otherwise.\n# >>> $(pairs_sum_to_zero \"1 3 5 0\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 3 -2 1\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"1 2 3 7\")\n# \"false\"\n# >>> $(pairs_sum_to_zero \"2 4 -5 3 5 7\")\n# \"true\"\n# >>> $(pairs_sum_to_zero \"1\")\n# \"false\"\n#\n# $1 is a space-separated list\npairs_sum_to_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pairs_sum_to_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 0\") = \"false\" ]]\n    [[ $(candidate \"1 3 -2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 -5 3 5 7\") = \"true\" ]]\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 30\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 3 2 31\") = \"true\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 30\") = \"false\" ]]\n    [[ $(candidate \"-3 9 -1 4 2 31\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Change numerical base of input number x to base.\n# return string representation after the conversion.\n# base numbers are less than 10.\n# >>> $(change_base \"8\" \"3\")\n# \"22\"\n# >>> $(change_base \"8\" \"2\")\n# \"1000\"\n# >>> $(change_base \"7\" \"2\")\n# \"111\"\n#\n# $1 is an integer\n# $2 is an integer\nchange_base() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    change_base \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\" \"3\") = \"22\" ]]\n    [[ $(candidate \"9\" \"3\") = \"100\" ]]\n    [[ $(candidate \"234\" \"2\") = \"11101010\" ]]\n    [[ $(candidate \"16\" \"2\") = \"10000\" ]]\n    [[ $(candidate \"8\" \"2\") = \"1000\" ]]\n    [[ $(candidate \"7\" \"2\") = \"111\" ]]\n    [[ $(candidate \"2\" \"3\") = \"2\" ]]\n    [[ $(candidate \"3\" \"4\") = \"3\" ]]\n    [[ $(candidate \"4\" \"5\") = \"4\" ]]\n    [[ $(candidate \"5\" \"6\") = \"5\" ]]\n    [[ $(candidate \"6\" \"7\") = \"6\" ]]\n    [[ $(candidate \"7\" \"8\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given length of a side and high return area for a triangle.\n# >>> $(triangle_area \"5\" \"3\")\n# \"7.5\"\n#\n# $1 is an integer\n# $2 is an integer\ntriangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\") = \"7.5\" ]]\n    [[ $(candidate \"2\" \"2\") = \"2.0\" ]]\n    [[ $(candidate \"10\" \"8\") = \"40.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fib4(0) -> 0\n# fib4(1) -> 0\n# fib4(2) -> 2\n# fib4(3) -> 0\n# fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n# Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n# >>> $(fib4 \"5\")\n# \"4\"\n# >>> $(fib4 \"6\")\n# \"8\"\n# >>> $(fib4 \"7\")\n# \"14\"\n#\n# $1 is an integer\nfib4() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib4 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"28\" ]]\n    [[ $(candidate \"10\") = \"104\" ]]\n    [[ $(candidate \"12\") = \"386\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return median of elements in the list l.\n# >>> $(median \"3 1 2 4 5\")\n# \"3\"\n# >>> $(median \"-10 4 6 1000 10 20\")\n# \"15.0\"\n#\n# $1 is a space-separated list\nmedian() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"3\" ]]\n    [[ $(candidate \"-10 4 6 1000 10 20\") = \"8.0\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"6 5\") = \"5.5\" ]]\n    [[ $(candidate \"8 1 3 9 9 2 7\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Checks if given string is a palindrome\n# >>> $(is_palindrome \"\")\n# \"true\"\n# >>> $(is_palindrome \"aba\")\n# \"true\"\n# >>> $(is_palindrome \"aaaaa\")\n# \"true\"\n# >>> $(is_palindrome \"zbcd\")\n# \"false\"\n#\n# $1 is a string\nis_palindrome() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"true\" ]]\n    [[ $(candidate \"aba\") = \"true\" ]]\n    [[ $(candidate \"aaaaa\") = \"true\" ]]\n    [[ $(candidate \"zbcd\") = \"false\" ]]\n    [[ $(candidate \"xywyx\") = \"true\" ]]\n    [[ $(candidate \"xywyz\") = \"false\" ]]\n    [[ $(candidate \"xywzx\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return 2^n modulo p (be aware of numerics).\n# >>> $(modp \"3\" \"5\")\n# \"3\"\n# >>> $(modp \"1101\" \"101\")\n# \"2\"\n# >>> $(modp \"0\" \"101\")\n# \"1\"\n# >>> $(modp \"3\" \"11\")\n# \"8\"\n# >>> $(modp \"100\" \"101\")\n# \"1\"\n#\n# $1 is an integer\n# $2 is an integer\nmodp() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    modp \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"5\") = \"3\" ]]\n    [[ $(candidate \"1101\" \"101\") = \"2\" ]]\n    [[ $(candidate \"0\" \"101\") = \"1\" ]]\n    [[ $(candidate \"3\" \"11\") = \"8\" ]]\n    [[ $(candidate \"100\" \"101\") = \"1\" ]]\n    [[ $(candidate \"30\" \"5\") = \"4\" ]]\n    [[ $(candidate \"31\" \"5\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of input numbers, calculate Mean Absolute Deviation\n# around the mean of this dataset.\n# Mean Absolute Deviation is the average absolute difference between each\n# element and a centerpoint (mean in this case):\n# MAD = average | x - x_mean |\n# >>> $(mean_absolute_deviation \"1.0 2.0 3.0 4.0\")\n# \"1.0\"\n#\n# $1 is a space-separated list\nmean_absolute_deviation() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    mean_absolute_deviation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1.0 2.0\") = \"0.5\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0\") = \"1.0\" ]]\n    [[ $(candidate \"1.0 2.0 3.0 4.0 5.0\") = \"1.2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# remove_vowels is a function that takes string and returns string without vowels.\n# >>> $(remove_vowels \"\")\n# \"\"\n# >>> $(remove_vowels \"abcdef\")\n# \"bcdf\"\n# >>> $(remove_vowels \"aaaaa\")\n# \"\"\n# >>> $(remove_vowels \"aaBAA\")\n# \"B\"\n# >>> $(remove_vowels \"zbcd\")\n# \"zbcd\"\n#\n# $1 is a string\nremove_vowels() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"abcdef\\nghijklm\") = \"bcdf\\nghjklm\" ]]\n    [[ $(candidate \"fedcba\") = \"fdcb\" ]]\n    [[ $(candidate \"eeeee\") = \"\" ]]\n    [[ $(candidate \"acBAA\") = \"cB\" ]]\n    [[ $(candidate \"EcBOO\") = \"cB\" ]]\n    [[ $(candidate \"ybcd\") = \"ybcd\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True if all numbers in the list l are below threshold t.\n# >>> $(below_threshold \"1 2 4 10\" \"100\")\n# \"true\"\n# >>> $(below_threshold \"1 20 4 10\" \"5\")\n# \"false\"\n#\n# $1 is a space-separated list\n# $2 is an integer\nbelow_threshold() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    below_threshold \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\" \"100\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"5\") = \"false\" ]]\n    [[ $(candidate \"1 20 4 10\" \"21\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\" \"22\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"11\") = \"true\" ]]\n    [[ $(candidate \"1 8 4 10\" \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Add two numbers x and y\n# >>> $(add \"2\" \"3\")\n# \"5\"\n# >>> $(add \"5\" \"7\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\nadd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\" \"1\") = \"1\" ]]\n    [[ $(candidate \"1\" \"0\") = \"1\" ]]\n    [[ $(candidate \"2\" \"3\") = \"5\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"5\") = \"12\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Check if two words have the same characters.\n# >>> $(same_chars \"eabcdzzzz\" \"dddzzzzzzzddeddabc\")\n# \"true\"\n# >>> $(same_chars \"abcd\" \"dddddddabc\")\n# \"true\"\n# >>> $(same_chars \"dddddddabc\" \"abcd\")\n# \"true\"\n# >>> $(same_chars \"eabcd\" \"dddddddabc\")\n# \"false\"\n# >>> $(same_chars \"abcd\" \"dddddddabce\")\n# \"false\"\n# >>> $(same_chars \"eabcdzzzz\" \"dddzzzzzzzddddabc\")\n# \"false\"\n#\n# $1 is a string\n# $2 is a string\nsame_chars() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    same_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddeddabc\") = \"true\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabc\") = \"true\" ]]\n    [[ $(candidate \"dddddddabc\" \"abcd\") = \"true\" ]]\n    [[ $(candidate \"eabcd\" \"dddddddabc\") = \"false\" ]]\n    [[ $(candidate \"abcd\" \"dddddddabcf\") = \"false\" ]]\n    [[ $(candidate \"eabcdzzzz\" \"dddzzzzzzzddddabc\") = \"false\" ]]\n    [[ $(candidate \"aabb\" \"aaccc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return n-th Fibonacci number.\n# >>> $(fib \"10\")\n# \"55\"\n# >>> $(fib \"1\")\n# \"1\"\n# >>> $(fib \"8\")\n# \"21\"\n#\n# $1 is an integer\nfib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"89\" ]]\n    [[ $(candidate \"12\") = \"144\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# brackets is a string of \"<\" and \">\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"<\")\n# \"false\"\n# >>> $(correct_bracketing \"<>\")\n# \"true\"\n# >>> $(correct_bracketing \"<<><>>\")\n# \"true\"\n# >>> $(correct_bracketing \"><<>\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"<>\") = \"true\" ]]\n    [[ $(candidate \"<<><>>\") = \"true\" ]]\n    [[ $(candidate \"<><><<><>><>\") = \"true\" ]]\n    [[ $(candidate \"<><><<<><><>><>><<><><<>>>\") = \"true\" ]]\n    [[ $(candidate \"<<<><>>>>\") = \"false\" ]]\n    [[ $(candidate \"><<>\") = \"false\" ]]\n    [[ $(candidate \"<\") = \"false\" ]]\n    [[ $(candidate \"<<<<\") = \"false\" ]]\n    [[ $(candidate \">\") = \"false\" ]]\n    [[ $(candidate \"<<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>><<>\") = \"false\" ]]\n    [[ $(candidate \"<><><<><>><>>><>\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return True is list elements are monotonically increasing or decreasing.\n# >>> $(monotonic \"1 2 4 20\")\n# \"true\"\n# >>> $(monotonic \"1 20 4 10\")\n# \"false\"\n# >>> $(monotonic \"4 1 0 -10\")\n# \"true\"\n#\n# $1 is a space-separated list\nmonotonic() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 10\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 20\") = \"true\" ]]\n    [[ $(candidate \"1 20 4 10\") = \"false\" ]]\n    [[ $(candidate \"4 1 0 -10\") = \"true\" ]]\n    [[ $(candidate \"4 1 1 0\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 2 5 60\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5 60\") = \"true\" ]]\n    [[ $(candidate \"9 9 9 9\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return sorted unique common elements for two lists.\n# >>> $(common \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\")\n# ['\"1\"', '\"5\"', '\"653\"']\n# >>> $(common \"5 3 2 8\" \"3 2\")\n# ['\"2\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    common \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 34 653 2 5\" \"5 7 1 5 9 653 121\") = \"1 5 653\" ]]\n    [[ $(candidate \"5 3 2 8\" \"3 2\") = \"2 3\" ]]\n    [[ $(candidate \"4 3 2 8\" \"3 2 4\") = \"2 3 4\" ]]\n    [[ $(candidate \"4 3 2 8\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Return the largest prime factor of n. Assume n > 1 and is not a prime.\n# >>> $(largest_prime_factor \"13195\")\n# \"29\"\n# >>> $(largest_prime_factor \"2048\")\n# \"2\"\n#\n# $1 is an integer\nlargest_prime_factor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_prime_factor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"5\" ]]\n    [[ $(candidate \"27\") = \"3\" ]]\n    [[ $(candidate \"63\") = \"7\" ]]\n    [[ $(candidate \"330\") = \"11\" ]]\n    [[ $(candidate \"13195\") = \"29\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n# >>> $(intersperse \"\" \"4\")\n# []\n# >>> $(intersperse \"1 2 3\" \"4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"4\"', '\"3\"']\n#\n# $1 is a space-separated list\n# $2 is an integer\nintersperse() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersperse \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"7\") = \"\" ]]\n    [[ $(candidate \"5 6 3 2\" \"8\") = \"5 8 6 8 3 8 2\" ]]\n    [[ $(candidate \"2 2 2\" \"2\") = \"2 2 2 2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# sum_to_n is a function that sums numbers from 1 to n.\n# >>> $(sum_to_n \"30\")\n# \"465\"\n# >>> $(sum_to_n \"100\")\n# \"5050\"\n# >>> $(sum_to_n \"5\")\n# \"15\"\n# >>> $(sum_to_n \"10\")\n# \"55\"\n# >>> $(sum_to_n \"1\")\n# \"1\"\n#\n# $1 is an integer\nsum_to_n() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_to_n \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"21\" ]]\n    [[ $(candidate \"11\") = \"66\" ]]\n    [[ $(candidate \"30\") = \"465\" ]]\n    [[ $(candidate \"100\") = \"5050\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# brackets is a string of \"(\" and \")\".\n# return True if every opening bracket has a corresponding closing bracket.\n# >>> $(correct_bracketing \"(\")\n# \"false\"\n# >>> $(correct_bracketing \"()\")\n# \"true\"\n# >>> $(correct_bracketing \"(()())\")\n# \"true\"\n# >>> $(correct_bracketing \")(()\")\n# \"false\"\n#\n# $1 is a string\ncorrect_bracketing() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    correct_bracketing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"()\") = \"true\" ]]\n    [[ $(candidate \"(()())\") = \"true\" ]]\n    [[ $(candidate \"()()(()())()\") = \"true\" ]]\n    [[ $(candidate \"()()((()()())())(()()(()))\") = \"true\" ]]\n    [[ $(candidate \"((()())))\") = \"false\" ]]\n    [[ $(candidate \")(()\") = \"false\" ]]\n    [[ $(candidate \"(\") = \"false\" ]]\n    [[ $(candidate \"((((\") = \"false\" ]]\n    [[ $(candidate \")\") = \"false\" ]]\n    [[ $(candidate \"(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())())(()\") = \"false\" ]]\n    [[ $(candidate \"()()(()())()))()\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# xs represent coefficients of a polynomial.\n# xs[0] + xs[1] * x + xs[2] * x^2 + ....\n# Return derivative of this polynomial in the same form.\n# >>> $(derivative \"3 1 2 4 5\")\n# ['\"1\"', '\"4\"', '\"12\"', '\"20\"']\n# >>> $(derivative \"1 2 3\")\n# ['\"2\"', '\"6\"']\n#\n# $1 is a space-separated list\nderivative() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    derivative \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 1 2 4 5\") = \"1 4 12 20\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 6\" ]]\n    [[ $(candidate \"3 2 1\") = \"2 2\" ]]\n    [[ $(candidate \"3 2 1 0 4\") = \"2 2 0 16\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n# fibfib(0) == 0\n# fibfib(1) == 0\n# fibfib(2) == 1\n# fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n# Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n# >>> $(fibfib \"1\")\n# \"0\"\n# >>> $(fibfib \"5\")\n# \"4\"\n# >>> $(fibfib \"8\")\n# \"24\"\n#\n# $1 is an integer\nfibfib() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fibfib \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"5\") = \"4\" ]]\n    [[ $(candidate \"8\") = \"24\" ]]\n    [[ $(candidate \"10\") = \"81\" ]]\n    [[ $(candidate \"12\") = \"274\" ]]\n    [[ $(candidate \"14\") = \"927\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function vowels_count which takes a string representing\n# a word as input and returns the number of vowels in the string.\n# Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n# vowel, but only when it is at the end of the given word.\n# Example:\n# >>> $(vowels_count \"abcde\")\n# \"2\"\n# >>> $(vowels_count \"ACEDY\")\n# \"3\"\n#\n# $1 is a string\nvowels_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    vowels_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcde\") = \"2\" ]]\n    [[ $(candidate \"Alone\") = \"3\" ]]\n    [[ $(candidate \"key\") = \"2\" ]]\n    [[ $(candidate \"bye\") = \"1\" ]]\n    [[ $(candidate \"keY\") = \"2\" ]]\n    [[ $(candidate \"bYe\") = \"1\" ]]\n    [[ $(candidate \"ACEDY\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Circular shift the digits of the integer x, shift the digits right by shift\n# and return the result as a string.\n# If shift > number of digits, return digits reversed.\n# >>> $(circular_shift \"12\" \"1\")\n# \"21\"\n# >>> $(circular_shift \"12\" \"2\")\n# \"12\"\n#\n# $1 is an integer\n# $2 is an integer\ncircular_shift() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    circular_shift \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100\" \"2\") = \"001\" ]]\n    [[ $(candidate \"12\" \"2\") = \"12\" ]]\n    [[ $(candidate \"97\" \"8\") = \"79\" ]]\n    [[ $(candidate \"12\" \"1\") = \"21\" ]]\n    [[ $(candidate \"11\" \"101\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Task\n# Write a function that takes a string as input and returns the sum of the upper characters only'\n# ASCII codes.\n# Examples:\n# >>> $(digitSum \"\")\n# \"0\"\n# >>> $(digitSum \"abAB\")\n# \"131\"\n# >>> $(digitSum \"abcCd\")\n# \"67\"\n# >>> $(digitSum \"helloE\")\n# \"69\"\n# >>> $(digitSum \"woArBld\")\n# \"131\"\n# >>> $(digitSum \"aAaaaXa\")\n# \"153\"\n#\n# $1 is a string\ndigitSum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digitSum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"abAB\") = \"131\" ]]\n    [[ $(candidate \"abcCd\") = \"67\" ]]\n    [[ $(candidate \"helloE\") = \"69\" ]]\n    [[ $(candidate \"woArBld\") = \"131\" ]]\n    [[ $(candidate \"aAaaaXa\") = \"153\" ]]\n    [[ $(candidate \" How are yOu?\") = \"151\" ]]\n    [[ $(candidate \"You arE Very Smart\") = \"327\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# In this task, you will be given a string that represents a number of apples and oranges \n# that are distributed in a basket of fruit this basket contains \n# apples, oranges, and mango fruits. Given the string that represents the total number of \n# the oranges and apples and an integer that represent the total number of the fruits \n# in the basket return the number of the mango fruits in the basket.\n# for examble:\n# >>> $(fruit_distribution \"5 apples and 6 oranges\" \"19\")\n# \"8\"\n# >>> $(fruit_distribution \"0 apples and 1 oranges\" \"3\")\n# \"2\"\n# >>> $(fruit_distribution \"2 apples and 3 oranges\" \"100\")\n# \"95\"\n# >>> $(fruit_distribution \"100 apples and 1 oranges\" \"120\")\n# \"19\"\n#\n# $1 is a string\n# $2 is an integer\nfruit_distribution() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    fruit_distribution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 apples and 6 oranges\" \"19\") = \"8\" ]]\n    [[ $(candidate \"5 apples and 6 oranges\" \"21\") = \"10\" ]]\n    [[ $(candidate \"0 apples and 1 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 apples and 0 oranges\" \"3\") = \"2\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"100\") = \"95\" ]]\n    [[ $(candidate \"2 apples and 3 oranges\" \"5\") = \"0\" ]]\n    [[ $(candidate \"1 apples and 100 oranges\" \"120\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# \"Given an array representing a branch of a tree that has non-negative integer nodes\n# your task is to pluck one of the nodes and return it.\n# The plucked node should be the node with the smallest even value.\n# If multiple nodes with the same smallest even value are found return the node that has smallest index.\n# The plucked node should be returned in a list, [ smalest_value, its index ],\n# If there are no even values or the given array is empty, return [].\n# Example 1:\n# >>> $(pluck \"4 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 2:\n# >>> $(pluck \"1 2 3\")\n# ['\"2\"', '\"1\"']\n# Explanation: 2 has the smallest even value, and 2 has the smallest index.\n# Example 3:\n# >>> $(pluck \"\")\n# []\n# Example 4:\n# >>> $(pluck \"5 0 3 0 4 2\")\n# ['\"0\"', '\"1\"']\n# Explanation: 0 is the smallest value, but  there are two zeros,\n# so we will choose the first zero, which has the smallest index.\n# Constraints:\n# * 1 <= nodes.length <= 10000\n# * 0 <= node.value\n#\n# $1 is a space-separated list\npluck() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pluck \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 1\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5 0 3 0 4 2\") = \"0 1\" ]]\n    [[ $(candidate \"1 2 3 0 5 3\") = \"0 3\" ]]\n    [[ $(candidate \"5 4 8 4 8\") = \"4 1\" ]]\n    [[ $(candidate \"7 6 7 1\") = \"6 1\" ]]\n    [[ $(candidate \"7 9 7 1\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n# zero, and has a frequency greater than or equal to the value of the integer itself. \n# The frequency of an integer is the number of times it appears in the list.\n# If no such a value exist, return -1.\n# Examples:\n# >>> $(search \"4 1 2 2 3 1\")\n# \"2\"\n# >>> $(search \"1 2 2 3 3 3 4 4 4\")\n# \"3\"\n# >>> $(search \"5 5 4 4 4\")\n# \"-1\"\n#\n# $1 is a space-separated list\nsearch() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 5 5 5 1\") = \"1\" ]]\n    [[ $(candidate \"4 1 4 1 4 4\") = \"4\" ]]\n    [[ $(candidate \"3 3\") = \"-1\" ]]\n    [[ $(candidate \"8 8 8 8 8 8 8 8\") = \"8\" ]]\n    [[ $(candidate \"2 3 3 2 2\") = \"2\" ]]\n    [[ $(candidate \"2 7 8 8 4 8 7 3 9 6 5 10 4 3 6 7 1 7 4 10 8 1\") = \"1\" ]]\n    [[ $(candidate \"3 2 8 2\") = \"2\" ]]\n    [[ $(candidate \"6 7 1 8 8 10 5 8 5 3 10\") = \"1\" ]]\n    [[ $(candidate \"8 8 3 6 5 6 4\") = \"-1\" ]]\n    [[ $(candidate \"6 9 6 7 1 4 7 1 8 8 9 8 10 10 8 4 10 4 10 1 2 9 5 7 9\") = \"1\" ]]\n    [[ $(candidate \"1 9 10 1 3\") = \"1\" ]]\n    [[ $(candidate \"6 9 7 5 8 7 5 3 7 5 10 10 3 6 10 2 8 6 5 4 9 5 3 10\") = \"5\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"8 8 10 6 4 3 5 8 2 4 2 8 4 6 10 4 2 1 10 2 1 1 5\") = \"4\" ]]\n    [[ $(candidate \"2 10 4 8 2 10 5 1 2 9 5 5 6 3 8 6 4 10\") = \"2\" ]]\n    [[ $(candidate \"1 6 10 1 6 9 10 8 6 8 7 3\") = \"1\" ]]\n    [[ $(candidate \"9 2 4 1 5 1 5 2 5 7 7 7 3 10 1 5 4 2 8 4 1 9 10 7 10 2 8 10 9 4\") = \"4\" ]]\n    [[ $(candidate \"2 6 4 2 8 7 5 6 4 10 4 6 3 7 8 8 3 1 4 2 2 10 7\") = \"4\" ]]\n    [[ $(candidate \"9 8 6 10 2 6 10 2 7 8 10 3 8 2 6 2 3 1\") = \"2\" ]]\n    [[ $(candidate \"5 5 3 9 5 6 3 2 8 5 6 10 10 6 8 4 10 7 7 10 8\") = \"-1\" ]]\n    [[ $(candidate \"10\") = \"-1\" ]]\n    [[ $(candidate \"9 7 7 2 4 7 2 10 9 7 5 7 2\") = \"2\" ]]\n    [[ $(candidate \"5 4 10 2 1 1 10 3 6 1 8\") = \"1\" ]]\n    [[ $(candidate \"7 9 9 9 3 4 1 5 9 1 2 1 1 10 7 5 6 7 6 7 7 6\") = \"1\" ]]\n    [[ $(candidate \"3 10 10 9 2\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n# For each of the group, output the deepest level of nesting of parentheses.\n# E.g. (()()) has maximum two levels of nesting while ((())) has three.\n# >>> $(parse_nested_parens \"(()()) ((())) () ((())()())\")\n# ['\"2\"', '\"3\"', '\"1\"', '\"3\"']\n#\n# $1 is a string\nparse_nested_parens() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    parse_nested_parens \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(()()) ((())) () ((())()())\") = \"2 3 1 3\" ]]\n    [[ $(candidate \"() (()) ((())) (((())))\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"(()(())((())))\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given list of integers, return list in strange order.\n# Strange sorting, is when you start with the minimum value,\n# then maximum of the remaining integers, then minimum and so on.\n# Examples:\n# >>> $(strange_sort_list \"1 2 3 4\")\n# ['\"1\"', '\"4\"', '\"2\"', '\"3\"']\n# >>> $(strange_sort_list \"5 5 5 5\")\n# ['\"5\"', '\"5\"', '\"5\"', '\"5\"']\n# >>> $(strange_sort_list \"\")\n# []\n#\n# $1 is a space-separated list\nstrange_sort_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    strange_sort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"1 4 2 3\" ]]\n    [[ $(candidate \"5 6 7 8 9\") = \"5 9 6 8 7\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 5 2 4 3\" ]]\n    [[ $(candidate \"5 6 7 8 9 1\") = \"1 9 5 8 6 7\" ]]\n    [[ $(candidate \"5 5 5 5\") = \"5 5 5 5\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\") = \"1 8 2 7 3 6 4 5\" ]]\n    [[ $(candidate \"0 2 2 2 5 5 -5 -5\") = \"-5 5 -5 5 0 2 2 2\" ]]\n    [[ $(candidate \"111111\") = \"111111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given the lengths of the three sides of a triangle. Return the area of\n# the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n# Otherwise return -1\n# Three sides make a valid triangle when the sum of any two sides is greater \n# than the third side.\n# Example:\n# >>> $(triangle_area \"3\" \"4\" \"5\")\n# \"6.0\"\n# >>> $(triangle_area \"1\" \"2\" \"10\")\n# \"-1\"\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntriangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\" \"5\") = \"6.0\" ]]\n    [[ $(candidate \"1\" \"2\" \"10\") = \"-1\" ]]\n    [[ $(candidate \"4\" \"8\" \"5\") = \"8.18\" ]]\n    [[ $(candidate \"2\" \"2\" \"2\") = \"1.73\" ]]\n    [[ $(candidate \"1\" \"2\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"10\" \"5\" \"7\") = \"16.25\" ]]\n    [[ $(candidate \"2\" \"6\" \"3\") = \"-1\" ]]\n    [[ $(candidate \"1\" \"1\" \"1\") = \"0.43\" ]]\n    [[ $(candidate \"2\" \"2\" \"10\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns True if the object q will fly, and False otherwise.\n# The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n# Example:\n# >>> $(will_it_fly \"1 2\" \"5\")\n# \"false\"\n# # 1+2 is less than the maximum possible weight, but it's unbalanced.\n# >>> $(will_it_fly \"3 2 3\" \"1\")\n# \"false\"\n# # it's balanced, but 3+2+3 is more than the maximum possible weight.\n# >>> $(will_it_fly \"3 2 3\" \"9\")\n# \"true\"\n# # 3+2+3 is less than the maximum possible weight, and it's balanced.\n# >>> $(will_it_fly \"3\" \"5\")\n# \"true\"\n# # 3 is less than the maximum possible weight, and it's balanced.\n#\n# $1 is a space-separated list\n# $2 is an integer\nwill_it_fly() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    will_it_fly \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 3\" \"9\") = \"true\" ]]\n    [[ $(candidate \"1 2\" \"5\") = \"false\" ]]\n    [[ $(candidate \"3\" \"5\") = \"true\" ]]\n    [[ $(candidate \"3 2 3\" \"1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"6\") = \"false\" ]]\n    [[ $(candidate \"5\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array arr of integers, find the minimum number of elements that\n# need to be changed to make the array palindromic. A palindromic array is an array that\n# is read the same backwards and forwards. In one change, you can change one element to any other element.\n# For example:\n# >>> $(smallest_change \"1 2 3 5 4 7 9 6\")\n# \"4\"\n# >>> $(smallest_change \"1 2 3 4 3 2 2\")\n# \"1\"\n# >>> $(smallest_change \"1 2 3 2 1\")\n# \"0\"\n#\n# $1 is a space-separated list\nsmallest_change() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    smallest_change \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 4 7 9 6\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 4 4 2\") = \"1\" ]]\n    [[ $(candidate \"1 2 3 2 1\") = \"0\" ]]\n    [[ $(candidate \"3 1 1 3\") = \"0\" ]]\n    [[ $(candidate \"1\") = \"0\" ]]\n    [[ $(candidate \"0 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that accepts two lists of strings and returns the list that has \n# total number of chars in the all strings of the list less than the other list.\n# if the two lists have the same number of chars, return the first list.\n# Examples\n# >>> $(total_match \"\" \"\")\n# []\n# >>> $(total_match \"hi admin\" \"hI Hi\")\n# ['\"hI\"', '\"Hi\"']\n# >>> $(total_match \"hi admin\" \"hi hi admin project\")\n# ['\"hi\"', '\"admin\"']\n# >>> $(total_match \"hi admin\" \"hI hi hi\")\n# ['\"hI\"', '\"hi\"', '\"hi\"']\n# >>> $(total_match \"4\" \"1 2 3 4 5\")\n# ['\"4\"']\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntotal_match() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    total_match \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\" \"\") = \"\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi\") = \"hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hi hi admin project\") = \"hi admin\" ]]\n    [[ $(candidate \"4\" \"1 2 3 4 5\") = \"4\" ]]\n    [[ $(candidate \"hi admin\" \"hI Hi\") = \"hI Hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hi\") = \"hI hi hi\" ]]\n    [[ $(candidate \"hi admin\" \"hI hi hii\") = \"hi admin\" ]]\n    [[ $(candidate \"\" \"this\") = \"\" ]]\n    [[ $(candidate \"this\" \"\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns true if the given number is the multiplication of 3 prime numbers\n# and false otherwise.\n# Knowing that (a) is less then 100. \n# Example:\n# >>> $(is_multiply_prime \"30\")\n# \"true\"\n# 30 = 2 * 3 * 5\n#\n# $1 is an integer\nis_multiply_prime() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_multiply_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"false\" ]]\n    [[ $(candidate \"30\") = \"true\" ]]\n    [[ $(candidate \"8\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n    [[ $(candidate \"105\") = \"true\" ]]\n    [[ $(candidate \"126\") = \"false\" ]]\n    [[ $(candidate \"729\") = \"false\" ]]\n    [[ $(candidate \"891\") = \"false\" ]]\n    [[ $(candidate \"1001\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Your task is to write a function that returns true if a number x is a simple\n# power of n and false in other cases.\n# x is a simple power of n if n**int=x\n# For example:\n# >>> $(is_simple_power \"1\" \"4\")\n# \"true\"\n# >>> $(is_simple_power \"2\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"8\" \"2\")\n# \"true\"\n# >>> $(is_simple_power \"3\" \"2\")\n# \"false\"\n# >>> $(is_simple_power \"3\" \"1\")\n# \"false\"\n# >>> $(is_simple_power \"5\" \"3\")\n# \"false\"\n#\n# $1 is an integer\n# $2 is an integer\nis_simple_power() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_simple_power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"true\" ]]\n    [[ $(candidate \"143214\" \"16\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\") = \"true\" ]]\n    [[ $(candidate \"9\" \"3\") = \"true\" ]]\n    [[ $(candidate \"16\" \"4\") = \"true\" ]]\n    [[ $(candidate \"24\" \"2\") = \"false\" ]]\n    [[ $(candidate \"128\" \"4\") = \"false\" ]]\n    [[ $(candidate \"12\" \"6\") = \"false\" ]]\n    [[ $(candidate \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an integer a and returns True \n# if this ingeger is a cube of some integer number.\n# Note: you may assume the input is always valid.\n# Examples:\n# >>> $(iscube \"1\")\n# \"true\"\n# >>> $(iscube \"2\")\n# \"false\"\n# >>> $(iscube \"-1\")\n# \"true\"\n# >>> $(iscube \"64\")\n# \"true\"\n# >>> $(iscube \"0\")\n# \"true\"\n# >>> $(iscube \"180\")\n# \"false\"\n#\n# $1 is an integer\niscube() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    iscube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"-1\") = \"true\" ]]\n    [[ $(candidate \"64\") = \"true\" ]]\n    [[ $(candidate \"180\") = \"false\" ]]\n    [[ $(candidate \"1000\") = \"true\" ]]\n    [[ $(candidate \"0\") = \"true\" ]]\n    [[ $(candidate \"1729\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You have been tasked to write a function that receives \n# a hexadecimal number as a string and counts the number of hexadecimal \n# digits that are primes (prime number, or a prime, is a natural number \n# greater than 1 that is not a product of two smaller natural numbers).\n# Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n# Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n# So you have to determine a number of the following digits: 2, 3, 5, 7, \n# B (=decimal 11), D (=decimal 13).\n# Note: you may assume the input is always correct or empty string, \n# and symbols A,B,C,D,E,F are always uppercase.\n# Examples:\n# >>> $(hex_key \"AB\")\n# \"1\"\n# >>> $(hex_key \"1077E\")\n# \"2\"\n# >>> $(hex_key \"ABED1A33\")\n# \"4\"\n# >>> $(hex_key \"123456789ABCDEF0\")\n# \"6\"\n# >>> $(hex_key \"2020\")\n# \"2\"\n#\n# $1 is a string\nhex_key() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    hex_key \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AB\") = \"1\" ]]\n    [[ $(candidate \"1077E\") = \"2\" ]]\n    [[ $(candidate \"ABED1A33\") = \"4\" ]]\n    [[ $(candidate \"2020\") = \"2\" ]]\n    [[ $(candidate \"123456789ABCDEF0\") = \"6\" ]]\n    [[ $(candidate \"112233445566778899AABBCCDDEEFF00\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You will be given a number in decimal form and your task is to convert it to\n# binary format. The function should return a string, with each character representing a binary\n# number. Each character in the string will be '0' or '1'.\n# There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n# The extra characters are there to help with the format.\n# Examples:\n# >>> $(decimal_to_binary \"15\")\n# \"db1111db\"\n# >>> $(decimal_to_binary \"32\")\n# \"db100000db\"\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"db0db\" ]]\n    [[ $(candidate \"32\") = \"db100000db\" ]]\n    [[ $(candidate \"103\") = \"db1100111db\" ]]\n    [[ $(candidate \"15\") = \"db1111db\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a string s.\n# Your task is to check if the string is happy or not.\n# A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n# For example:\n# >>> $(is_happy \"a\")\n# \"false\"\n# >>> $(is_happy \"aa\")\n# \"false\"\n# >>> $(is_happy \"abcd\")\n# \"true\"\n# >>> $(is_happy \"aabb\")\n# \"false\"\n# >>> $(is_happy \"adb\")\n# \"true\"\n# >>> $(is_happy \"xyy\")\n# \"false\"\n#\n# $1 is a string\nis_happy() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_happy \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a\") = \"false\" ]]\n    [[ $(candidate \"aa\") = \"false\" ]]\n    [[ $(candidate \"abcd\") = \"true\" ]]\n    [[ $(candidate \"aabb\") = \"false\" ]]\n    [[ $(candidate \"adb\") = \"true\" ]]\n    [[ $(candidate \"xyy\") = \"false\" ]]\n    [[ $(candidate \"iopaxpoi\") = \"true\" ]]\n    [[ $(candidate \"iopaxioi\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# It is the last week of the semester and the teacher has to give the grades\n# to students. The teacher has been making her own algorithm for grading.\n# The only problem is, she has lost the code she used for grading.\n# She has given you a list of GPAs for some students and you have to write \n# a function that can output a list of letter grades using the following table:\n# GPA       |    Letter grade\n# 4.0                A+\n# > 3.7                A \n# > 3.3                A- \n# > 3.0                B+\n# > 2.7                B \n# > 2.3                B-\n# > 2.0                C+\n# > 1.7                C\n# > 1.3                C-\n# > 1.0                D+ \n# > 0.7                D \n# > 0.0                D-\n# 0.0                E\n# Example:\n# >>> $(grade_equation \"4.0 3 1.7 2 3.5\")\n# ['\"A+\"', '\"B\"', '\"C-\"', '\"C\"', '\"A-\"']\n#\n# $1 is a space-separated list\nnumerical_letter_grade() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    numerical_letter_grade \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4.0 3 1.7 2 3.5\") = \"A+ B C- C A-\" ]]\n    [[ $(candidate \"1.2\") = \"D+\" ]]\n    [[ $(candidate \"0.5\") = \"D-\" ]]\n    [[ $(candidate \"0.0\") = \"E\" ]]\n    [[ $(candidate \"1.0 0.3 1.5 2.8 3.3\") = \"D D- C- B B+\" ]]\n    [[ $(candidate \"0.0 0.7\") = \"E D-\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns True if the string\n# length is a prime number or False otherwise\n# Examples\n# >>> $(prime_length \"Hello\")\n# \"true\"\n# >>> $(prime_length \"abcdcba\")\n# \"true\"\n# >>> $(prime_length \"kittens\")\n# \"true\"\n# >>> $(prime_length \"orange\")\n# \"false\"\n#\n# $1 is a string\nprime_length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello\") = \"true\" ]]\n    [[ $(candidate \"abcdcba\") = \"true\" ]]\n    [[ $(candidate \"kittens\") = \"true\" ]]\n    [[ $(candidate \"orange\") = \"false\" ]]\n    [[ $(candidate \"wow\") = \"true\" ]]\n    [[ $(candidate \"world\") = \"true\" ]]\n    [[ $(candidate \"MadaM\") = \"true\" ]]\n    [[ $(candidate \"Wow\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n    [[ $(candidate \"HI\") = \"true\" ]]\n    [[ $(candidate \"go\") = \"true\" ]]\n    [[ $(candidate \"gogo\") = \"false\" ]]\n    [[ $(candidate \"aaaaaaaaaaaaaaa\") = \"false\" ]]\n    [[ $(candidate \"Madam\") = \"true\" ]]\n    [[ $(candidate \"M\") = \"false\" ]]\n    [[ $(candidate \"0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer n, return the count of the numbers of n-digit\n# positive integers that start or end with 1.\n#\n# $1 is an integer\nstarts_one_ends() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    starts_one_ends \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1\" ]]\n    [[ $(candidate \"2\") = \"18\" ]]\n    [[ $(candidate \"3\") = \"180\" ]]\n    [[ $(candidate \"4\") = \"1800\" ]]\n    [[ $(candidate \"5\") = \"18000\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a positive integer N, return the total sum of its digits in binary.\n# Example\n# >>> $(solve \"1000\")\n# \"1\"\n# >>> $(solve \"150\")\n# \"110\"\n# >>> $(solve \"147\")\n# \"1100\"\n# Variables:\n# @N integer\n# Constraints: 0 \u2264 N \u2264 10000.\n# Output:\n# a string of binary number\n#\n# $1 is an integer\nsolve() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    solve \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1000\") = \"1\" ]]\n    [[ $(candidate \"150\") = \"110\" ]]\n    [[ $(candidate \"147\") = \"1100\" ]]\n    [[ $(candidate \"333\") = \"1001\" ]]\n    [[ $(candidate \"963\") = \"10010\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a non-empty list of integers lst. add the even elements that are at odd indices..\n# Examples:\n# >>> $(add \"4 2 6 7\")\n# \"2\"\n#\n# $1 is a space-separated list\nadd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 88\") = \"88\" ]]\n    [[ $(candidate \"4 5 6 7 2 122\") = \"122\" ]]\n    [[ $(candidate \"4 0 6 7\") = \"0\" ]]\n    [[ $(candidate \"4 4 6 8\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a string and returns an ordered version of it.\n# Ordered version of string, is a string where all words (separated by space)\n# are replaced by a new word where all the characters arranged in\n# ascending order based on ascii value.\n# Note: You should keep the order of words and blank spaces in the sentence.\n# For example:\n# >>> $(anti_shuffle \"Hi\")\n# \"Hi\"\n# >>> $(anti_shuffle \"hello\")\n# \"ehllo\"\n# >>> $(anti_shuffle \"Hello World\\!\\!\\!\")\n# \"Hello \\!\\!\\!Wdlor\"\n#\n# $1 is a string\nanti_shuffle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    anti_shuffle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hi\") = \"Hi\" ]]\n    [[ $(candidate \"hello\") = \"ehllo\" ]]\n    [[ $(candidate \"number\") = \"bemnru\" ]]\n    [[ $(candidate \"abcd\") = \"abcd\" ]]\n    [[ $(candidate \"Hello World\\!\\!\\!\") = \"Hello \\!\\!\\!Wdlor\" ]]\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"Hi. My name is Mister Robot. How are you?\") = \".Hi My aemn is Meirst .Rboot How aer ?ouy\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a 2 dimensional data, as a nested lists,\n# which is similar to matrix, however, unlike matrices,\n# each row may contain a different number of columns.\n# Given lst, and integer x, find integers x in the list,\n# and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n# each tuple is a coordinate - (row, columns), starting with 0.\n# Sort coordinates initially by rows in ascending order.\n# Also, sort coordinates of the row by columns in descending order.\n# Examples:\n# >>> $(get_row \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\")\n# [['\"0\"', '\"0\"'], ['\"1\"', '\"4\"'], ['\"1\"', '\"0\"'], ['\"2\"', '\"5\"'], ['\"2\"', '\"0\"']]\n# >>> $(get_row \"\" \"1\")\n# []\n# >>> $(get_row \"\\n1\\n1 2 3\" \"3\")\n# [['\"2\"', '\"2\"']]\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nget_row() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_row \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 4\\n1 0\\n2 5\\n2 0\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 2 3 4 5 6\" \"2\") = \"0 1\\n1 1\\n2 1\\n3 1\\n4 1\\n5 1\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\\n1 2 3 4 5 6\\n1 1 3 4 5 6\\n1 2 1 4 5 6\\n1 2 3 1 5 6\\n1 2 3 4 1 6\\n1 2 3 4 5 1\" \"1\") = \"0 0\\n1 0\\n2 1\\n2 0\\n3 2\\n3 0\\n4 3\\n4 0\\n5 4\\n5 0\\n6 5\\n6 0\" ]]\n    [[ $(candidate \"\" \"1\") = \"\" ]]\n    [[ $(candidate \"1\" \"2\") = \"\" ]]\n    [[ $(candidate \"\\n1\\n1 2 3\" \"3\") = \"2 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given an array of non-negative integers, return a copy of the given array after sorting,\n# you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n# or sort it in descending order if the sum( first index value, last index value) is even.\n# Note:\n# * don't change the given array.\n# Examples:\n# >>> $(sort_array \"\")\n# []\n# >>> $(sort_array \"5\")\n# ['\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5\")\n# ['\"0\"', '\"1\"', '\"2\"', '\"3\"', '\"4\"', '\"5\"']\n# >>> $(sort_array \"2 4 3 0 1 5 6\")\n# ['\"6\"', '\"5\"', '\"4\"', '\"3\"', '\"2\"', '\"1\"', '\"0\"']\n#\n# $1 is a space-separated list\nsort_array() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"5\") = \"5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5\") = \"0 1 2 3 4 5\" ]]\n    [[ $(candidate \"2 4 3 0 1 5 6\") = \"6 5 4 3 2 1 0\" ]]\n    [[ $(candidate \"2 1\") = \"1 2\" ]]\n    [[ $(candidate \"15 42 87 32 11 0\") = \"0 11 15 32 42 87\" ]]\n    [[ $(candidate \"21 14 23 11\") = \"23 21 14 11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function encrypt that takes a string as an argument and\n# returns a string encrypted with the alphabet being rotated. \n# The alphabet should be rotated in a manner such that the letters \n# shift down by two multiplied to two places.\n# For example:\n# >>> $(encrypt \"hi\")\n# \"lm\"\n# >>> $(encrypt \"asdfghjkl\")\n# \"ewhjklnop\"\n# >>> $(encrypt \"gf\")\n# \"kj\"\n# >>> $(encrypt \"et\")\n# \"ix\"\n#\n# $1 is a string\nencrypt() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encrypt \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hi\") = \"lm\" ]]\n    [[ $(candidate \"asdfghjkl\") = \"ewhjklnop\" ]]\n    [[ $(candidate \"gf\") = \"kj\" ]]\n    [[ $(candidate \"et\") = \"ix\" ]]\n    [[ $(candidate \"faewfawefaewg\") = \"jeiajeaijeiak\" ]]\n    [[ $(candidate \"hellomyfriend\") = \"lippsqcjvmirh\" ]]\n    [[ $(candidate \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") = \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\" ]]\n    [[ $(candidate \"a\") = \"e\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n# Empty sum should be equal to 0 and empty product should be equal to 1.\n# >>> $(sum_product \"\")\n# ['\"0\"', '\"1\"']\n# >>> $(sum_product \"1 2 3 4\")\n# ['\"10\"', '\"24\"']\n#\n# $1 is a space-separated list\nsum_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"0 1\" ]]\n    [[ $(candidate \"1 1 1\") = \"3 1\" ]]\n    [[ $(candidate \"100 0\") = \"100 0\" ]]\n    [[ $(candidate \"3 5 7\") = \"15 105\" ]]\n    [[ $(candidate \"10\") = \"10 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# Write a function next_smallest() that returns the 2nd smallest element of the list.\n# Return None if there is no such element.\n# >>> $(next_smallest \"1 2 3 4 5\")\n# \"2\"\n# >>> $(next_smallest \"5 1 4 3 2\")\n# \"2\"\n# >>> $(next_smallest \"\")\n# \"None\"\n# >>> $(next_smallest \"1 1\")\n# \"None\"\n#\n# $1 is a space-separated list\nnext_smallest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    next_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2\" ]]\n    [[ $(candidate \"5 1 4 3 2\") = \"2\" ]]\n    [[ $(candidate \"\") = \"None\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"1 1 1 1 0\") = \"1\" ]]\n    [[ $(candidate \"1 1\") = \"None\" ]]\n    [[ $(candidate \"-35 34 12 -45\") = \"-35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You'll be given a string of words, and your task is to count the number\n# of boredoms. A boredom is a sentence that starts with the word \"I\".\n# Sentences are delimited by '.', '?' or '!'.\n# For example:\n# >>> $(is_bored \"Hello world\")\n# \"0\"\n# >>> $(is_bored \"The sky is blue. The sun is shining. I love this weather\")\n# \"1\"\n#\n# $1 is a string\nis_bored() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_bored \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hello world\") = \"0\" ]]\n    [[ $(candidate \"Is the sky blue?\") = \"0\" ]]\n    [[ $(candidate \"I love It \\!\") = \"1\" ]]\n    [[ $(candidate \"bIt\") = \"0\" ]]\n    [[ $(candidate \"I feel good today. I will be productive. will kill It\") = \"2\" ]]\n    [[ $(candidate \"You and I are going for a walk\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes 3 numbers.\n# Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n# Returns false in any other cases.\n# Examples\n# >>> $(any_int \"5\" \"2\" \"7\")\n# \"true\"\n# >>> $(any_int \"3\" \"2\" \"2\")\n# \"false\"\n# >>> $(any_int \"3\" \"-2\" \"1\")\n# \"true\"\n# >>> $(any_int \"3.6\" \"-2.2\" \"2\")\n# \"false\"\n#\n# $1 is a floating point\n# $2 is a floating point\n# $3 is a floating point\nany_int() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    any_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"1\") = \"true\" ]]\n    [[ $(candidate \"2.5\" \"2\" \"3\") = \"false\" ]]\n    [[ $(candidate \"1.5\" \"5\" \"3.5\") = \"false\" ]]\n    [[ $(candidate \"2\" \"6\" \"2\") = \"false\" ]]\n    [[ $(candidate \"4\" \"2\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2.2\" \"2.2\" \"2.2\") = \"false\" ]]\n    [[ $(candidate \"-4\" \"6\" \"2\") = \"true\" ]]\n    [[ $(candidate \"2\" \"1\" \"1\") = \"true\" ]]\n    [[ $(candidate \"3\" \"4\" \"7\") = \"true\" ]]\n    [[ $(candidate \"3.0\" \"4\" \"7\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes a message, and encodes in such a \n# way that it swaps case of all letters, replaces all vowels in \n# the message with the letter that appears 2 places ahead of that \n# vowel in the english alphabet. \n# Assume only letters. \n# Examples:\n# >>> $(encode \"test\")\n# \"TGST\"\n# >>> $(encode \"This is a message\")\n# \"tHKS KS C MGSSCGG\"\n#\n# $1 is a string\nencode() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    encode \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TEST\") = \"tgst\" ]]\n    [[ $(candidate \"Mudasir\") = \"mWDCSKR\" ]]\n    [[ $(candidate \"YES\") = \"ygs\" ]]\n    [[ $(candidate \"This is a message\") = \"tHKS KS C MGSSCGG\" ]]\n    [[ $(candidate \"I DoNt KnOw WhAt tO WrItE\") = \"k dQnT kNqW wHcT Tq wRkTg\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# You are given a list of integers.\n# You need to find the largest prime value and return the sum of its digits.\n# Examples:\n# >>> $(skjkasdkd \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\")\n# \"10\"\n# >>> $(skjkasdkd \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\")\n# \"25\"\n# >>> $(skjkasdkd \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\")\n# \"13\"\n# >>> $(skjkasdkd \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\")\n# \"11\"\n# >>> $(skjkasdkd \"0 81 12 3 1 21\")\n# \"3\"\n# >>> $(skjkasdkd \"0 8 1 2 1 7\")\n# \"7\"\n#\n# $1 is a space-separated list\nskjkasdkd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    skjkasdkd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 3 2 1 3 5 7 4 5 5 5 2 181 32 4 32 3 2 32 324 4 3\") = \"10\" ]]\n    [[ $(candidate \"1 0 1 8 2 4597 2 1 3 40 1 2 1 2 4 2 5 1\") = \"25\" ]]\n    [[ $(candidate \"1 3 1 32 5107 34 83278 109 163 23 2323 32 30 1 9 3\") = \"13\" ]]\n    [[ $(candidate \"0 724 32 71 99 32 6 0 5 91 83 0 5 6\") = \"11\" ]]\n    [[ $(candidate \"0 81 12 3 1 21\") = \"3\" ]]\n    [[ $(candidate \"0 8 1 2 1 7\") = \"7\" ]]\n    [[ $(candidate \"8191\") = \"19\" ]]\n    [[ $(candidate \"8191 123456 127 7\") = \"19\" ]]\n    [[ $(candidate \"127 97 8192\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a dictionary, return True if all keys are strings in lower \n# case or all keys are strings in upper case, else return False.\n# The function should return False is the given dictionary is empty.\n# Examples:\n# >>> $(check_dict_case \"a,apple\\nb,banana\")\n# \"true\"\n# >>> $(check_dict_case \"a,apple\\nA,banana\\nB,banana\")\n# \"false\"\n# >>> $(check_dict_case \"a,apple\\n8,banana\")\n# \"false\"\n# >>> $(check_dict_case \"Name,John\\nAge,36\\nCity,Houston\")\n# \"false\"\n# >>> $(check_dict_case \"STATE,NC\\nZIP,12345\")\n# \"true\"\n#\n# $1 is a two column CSV in key,value order\ncheck_dict_case() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_dict_case \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"p,pineapple\\nb,banana\") = \"true\" ]]\n    [[ $(candidate \"p,pineapple\\nA,banana\\nB,banana\") = \"false\" ]]\n    [[ $(candidate \"p,pineapple\\n5,banana\\na,apple\") = \"false\" ]]\n    [[ $(candidate \"Name,John\\nAge,36\\nCity,Houston\") = \"false\" ]]\n    [[ $(candidate \"STATE,NC\\nZIP,12345\") = \"true\" ]]\n    [[ $(candidate \"fruit,Orange\\ntaste,Sweet\") = \"true\" ]]\n    [[ $(candidate \"\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Implement a function that takes an non-negative integer and returns an array of the first n\n# integers that are prime numbers and less than n.\n# for example:\n# >>> $(count_up_to \"5\")\n# ['\"2\"', '\"3\"']\n# >>> $(count_up_to \"11\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"']\n# >>> $(count_up_to \"0\")\n# []\n# >>> $(count_up_to \"20\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"', '\"19\"']\n# >>> $(count_up_to \"1\")\n# []\n# >>> $(count_up_to \"18\")\n# ['\"2\"', '\"3\"', '\"5\"', '\"7\"', '\"11\"', '\"13\"', '\"17\"']\n#\n# $1 is an integer\ncount_up_to() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_up_to \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2 3\" ]]\n    [[ $(candidate \"6\") = \"2 3 5\" ]]\n    [[ $(candidate \"7\") = \"2 3 5\" ]]\n    [[ $(candidate \"10\") = \"2 3 5 7\" ]]\n    [[ $(candidate \"0\") = \"\" ]]\n    [[ $(candidate \"22\") = \"2 3 5 7 11 13 17 19\" ]]\n    [[ $(candidate \"1\") = \"\" ]]\n    [[ $(candidate \"18\") = \"2 3 5 7 11 13 17\" ]]\n    [[ $(candidate \"47\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43\" ]]\n    [[ $(candidate \"101\") = \"2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Complete the function that takes two integers and returns \n# the product of their unit digits.\n# Assume the input is always valid.\n# Examples:\n# >>> $(multiply \"148\" \"412\")\n# \"16\"\n# >>> $(multiply \"19\" \"28\")\n# \"72\"\n# >>> $(multiply \"2020\" \"1851\")\n# \"0\"\n# >>> $(multiply \"14\" \"-15\")\n# \"20\"\n#\n# $1 is an integer\n# $2 is an integer\nmultiply() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    multiply \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"148\" \"412\") = \"16\" ]]\n    [[ $(candidate \"19\" \"28\") = \"72\" ]]\n    [[ $(candidate \"2020\" \"1851\") = \"0\" ]]\n    [[ $(candidate \"14\" \"-15\") = \"20\" ]]\n    [[ $(candidate \"76\" \"67\") = \"42\" ]]\n    [[ $(candidate \"17\" \"27\") = \"49\" ]]\n    [[ $(candidate \"0\" \"1\") = \"0\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a string s, count the number of uppercase vowels in even indices.\n# For example:\n# >>> $(count_upper \"aBCdEf\")\n# \"1\"\n# >>> $(count_upper \"abcdefg\")\n# \"0\"\n# >>> $(count_upper \"dBBE\")\n# \"0\"\n#\n# $1 is a string\ncount_upper() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aBCdEf\") = \"1\" ]]\n    [[ $(candidate \"abcdefg\") = \"0\" ]]\n    [[ $(candidate \"dBBE\") = \"0\" ]]\n    [[ $(candidate \"B\") = \"0\" ]]\n    [[ $(candidate \"U\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n    [[ $(candidate \"EEEE\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Create a function that takes a value (string) representing a number\n# and returns the closest integer to it. If the number is equidistant\n# from two integers, round it away from zero.\n# Examples\n# >>> $(closest_integer \"10\")\n# \"10\"\n# >>> $(closest_integer \"15.3\")\n# \"15\"\n# Note:\n# Rounding away from zero means that if the given number is equidistant\n# from two integers, the one you should return is the one that is the\n# farthest from zero. For example closest_integer(\"14.5\") should\n# return 15 and closest_integer(\"-14.5\") should return -15.\n#\n# $1 is a string\nclosest_integer() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    closest_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"10\" ]]\n    [[ $(candidate \"14.5\") = \"15\" ]]\n    [[ $(candidate \"-15.5\") = \"-16\" ]]\n    [[ $(candidate \"15.3\") = \"15\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# From a given list of integers, generate a list of rolling maximum element found until given moment\n# in the sequence.\n# >>> $(rolling_max \"1 2 3 2 3 4 2\")\n# ['\"1\"', '\"2\"', '\"3\"', '\"3\"', '\"3\"', '\"4\"', '\"4\"']\n#\n# $1 is a space-separated list\nrolling_max() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rolling_max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\") = \"\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"1 2 3 4\" ]]\n    [[ $(candidate \"4 3 2 1\") = \"4 4 4 4\" ]]\n    [[ $(candidate \"3 2 3 100 3\") = \"3 3 3 100 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-swift-keep.json
+++ b/prompts/humaneval-swift-keep.json
@@ -1,1008 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "swift",
-    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// iscube(1) ==> True\n/// iscube(2) ==> False\n/// iscube(-1) ==> True\n/// iscube(64) ==> True\n/// iscube(0) ==> True\n/// iscube(180) ==> False\nfunc iscube(a: Int) -> Bool {\n",
+    "prompt": "\n/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n/// False\n/// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// True\nfunc has_close_elements(numbers: [Double], threshold: Double) -> Bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode('test')\n/// 'TGST'\n/// >>> encode('This is a message')\n/// 'tHKS KS C MGSSCGG'\nfunc encode(message: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "swift",
-    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n/// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// solution([5, 8, 7, 1]) ==> 12\n/// solution([3, 3, 3, 3, 3]) ==> 9\n/// solution([30, 13, 24, 321]) ==>0\nfunc solution(lst: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "swift",
-    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "swift",
-    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// '0'\n/// >>> string_sequence(5)\n/// '0 1 2 3 4 5'\nfunc string_sequence(n: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "swift",
-    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n/// minSubArraySum([-1, -2, -3]) == -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// rounded_avg(1, 5) => \"0b11\"\n/// rounded_avg(7, 5) => -1\n/// rounded_avg(10, 20) => \"0b1111\"\n/// rounded_avg(20, 33) => \"0b11010\"\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "swift",
-    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(\"Hello world\")\n/// 0\n/// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "swift",
-    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "swift",
-    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold([1, 2, 4, 10], 100)\n/// True\n/// >>> below_threshold([1, 20, 4, 10], 5)\n/// False\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// any_int(5, 2, 7) \u279e True\n/// any_int(3, 2, 2) \u279e False\n/// any_int(3, -2, 1) \u279e True\n/// any_int(3.6, -2.2, 2) \u279e False\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "swift",
-    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// for x_or_y(7, 34, 12) == 34\n/// for x_or_y(15, 8, 5) == 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "swift",
-    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// move_one_ball([3, 4, 5, 1, 2])==>True\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// move_one_ball([3, 5, 4, 1, 2])==>False\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(\"10\")\n/// 10\n/// >>> closest_integer(\"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> triples_sum_to_zero([1, 3, -2, 1])\n/// True\n/// >>> triples_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n/// True\n/// >>> triples_sum_to_zero([1])\n/// False\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// will_it_fly([1, 2], 5) \u279e False \n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// will_it_fly([3, 2, 3], 1) \u279e False\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// will_it_fly([3, 2, 3], 9) \u279e True\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// will_it_fly([3], 5) \u279e True\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// is_happy(a) => False\n/// is_happy(aa) => False\n/// is_happy(abcd) => True\n/// is_happy(aabb) => False\n/// is_happy(adb) => True\n/// is_happy(xyy) => False\nfunc is_happy(s: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "swift",
-    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// file_name_check(\"example.txt\") # => 'Yes'\n/// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunc file_name_check(file_name: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "swift",
-    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n/// histogram('a b b a') == {'a': 2, 'b': 2}\n/// histogram('a b c a b') == {'a': 2, 'b': 2}\n/// histogram('b b b b a') == {'b': 4}\n/// histogram('') == {}\nfunc histogram(test: String) -> [String : Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n/// largest_smallest_integers([]) == (None, None)\n/// largest_smallest_integers([0]) == (None, None)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "swift",
-    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// simplify(\"1/5\", \"5/1\") = True\n/// simplify(\"1/6\", \"2/1\") = False\n/// simplify(\"7/10\", \"10/2\") = False\nfunc simplify(x: String, n: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "swift",
-    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Input: n = 5\n/// Output: 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "swift",
-    "prompt": "\n/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n/// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n/// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunc reverse_delete(s: String, c: String) -> (String, Bool) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_delete(s: \"abcde\", c: \"ae\") == (\"bcd\", false))\nassert(reverse_delete(s: \"abcdef\", c: \"b\") == (\"acdef\", false))\nassert(reverse_delete(s: \"abcdedcba\", c: \"ab\") == (\"cdedc\", true))\nassert(reverse_delete(s: \"dwik\", c: \"w\") == (\"dik\", false))\nassert(reverse_delete(s: \"a\", c: \"a\") == (\"\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"v\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"vabba\", c: \"v\") == (\"abba\", true))\nassert(reverse_delete(s: \"mamma\", c: \"mia\") == (\"\", true))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "swift",
-    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product([])\n/// (0, 1)\n/// >>> sum_product([1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n/// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n/// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n/// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n/// For lst = [0,81,12,3,1,21] the output should be 3\n/// For lst = [0,8,1,2,1,7] the output should be 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "swift",
-    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes('abc')\n/// ['a', 'ab', 'abc']\nfunc all_prefixes(string: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// digits(1)  == 1\n/// digits(4)  == 0\n/// digits(235) == 15\nfunc digits(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "swift",
-    "prompt": "\n/// Return length of given string\n/// >>> strlen('')\n/// 0\n/// >>> strlen('abc')\n/// 3\nfunc strlen(string: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "swift",
-    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Input: [4,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Input: [1,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n/// Example 3:\n/// Input: []\n/// Output: []\n/// Example 4:\n/// Input: [5, 0, 3, 0, 4, 2]\n/// Output: [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// is_multiply_prime(30) == True\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "swift",
-    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "swift",
-    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "swift",
-    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic([1, 2, 4, 20])\n/// True\n/// >>> monotonic([1, 20, 4, 10])\n/// False\n/// >>> monotonic([4, 1, 0, -10])\n/// True\nfunc monotonic(l: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "swift",
-    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// fix_spaces(\"Example\") == \"Example\"\n/// fix_spaces(\"Example 1\") == \"Example_1\"\n/// fix_spaces(\" Example 2\") == \"_Example_2\"\n/// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "swift",
-    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// cycpattern_check(\"abcd\",\"abd\") => False\n/// cycpattern_check(\"hello\",\"ell\") => True\n/// cycpattern_check(\"whassup\",\"psus\") => False\n/// cycpattern_check(\"abab\",\"baa\") => True\n/// cycpattern_check(\"efef\",\"eeff\") => False\n/// cycpattern_check(\"himenss\",\"simen\") => True\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n/// double_the_difference([-1, -2, 0]) == 0\n/// double_the_difference([9, -2]) == 81\n/// double_the_difference([0]) == 0  \n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "swift",
-    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "swift",
-    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels('')\n/// ''\n/// >>> remove_vowels('abcdef')\n/// 'bcdf'\n/// >>> remove_vowels('aaaaa')\n/// ''\n/// >>> remove_vowels('aaBAA')\n/// 'B'\n/// >>> remove_vowels('zbcd')\n/// 'zbcd'\nfunc remove_vowels(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "swift",
-    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "swift",
-    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "swift",
-    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// count_up_to(5) => [2,3]\n/// count_up_to(11) => [2,3,5,7]\n/// count_up_to(0) => []\n/// count_up_to(20) => [2,3,5,7,11,13,17,19]\n/// count_up_to(1) => []\n/// count_up_to(18) => [2,3,5,7,11,13,17]\nfunc count_up_to(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "swift",
-    "prompt": "\n/// Return maximum element in the list.\n/// >>> max_element([1, 2, 3])\n/// 3\n/// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n/// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// total_match([], []) \u279e []\n/// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n/// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n/// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n/// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// triangle_area(3, 4, 5) == 6.00\n/// triangle_area(1, 2, 10) == -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n/// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n/// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n/// check_if_last_char_is_a_letter(\"\") \u279e False\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "swift",
-    "prompt": "\n/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique elements in a list\n/// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// smallest_change([1,2,3,5,4,7,9,6]) == 4\n/// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n/// smallest_change([1, 2, 3, 2, 1]) == 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits([15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits([152, 323, 1422, 10])\n/// []\nfunc unique_digits(x: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "swift",
-    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// f(5) == [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// next_smallest([1, 2, 3, 4, 5]) == 2\n/// next_smallest([5, 1, 4, 3, 2]) == 2\n/// next_smallest([]) == None\n/// next_smallest([1, 1]) == None\nfunc next_smallest(lst: [Int]) -> Int? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "swift",
-    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\n/// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n/// Output: [1, 2, 1]\n/// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n/// Output: [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Input: arr = [-3, -4, 5], k = 3\n/// Output: [-4, -3, 5]\n/// Example 2:\n/// Input: arr = [4, -4, 4], k = 2\n/// Output: [4, 4]\n/// Example 3:\n/// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n/// Output: [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// compare_one(1, 2.5) \u279e 2.5\n/// compare_one(1, \"2,3\") \u279e \"2,3\"\n/// compare_one(\"5,1\", \"6\") \u279e \"6\"\n/// compare_one(\"1\", 1) \u279e None\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// match_parens(['()(', ')']) == 'Yes'\n/// match_parens([')', ')']) == 'No'\nfunc match_parens(lst: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "swift",
-    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// is_equal_to_sum_even(4) == False\n/// is_equal_to_sum_even(6) == False\n/// is_equal_to_sum_even(8) == True\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "swift",
-    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "swift",
-    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "swift",
-    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// encrypt('hi') returns 'lm'\n/// encrypt('asdfghjkl') returns 'ewhjklnop'\n/// encrypt('gf') returns 'kj'\n/// encrypt('et') returns 'ix'\nfunc encrypt(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "swift",
-    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times('', 'a')\n/// 0\n/// >>> how_many_times('aaa', 'a')\n/// 3\n/// >>> how_many_times('aaaa', 'aa')\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n/// Output: 24 # sum of 21 + 3\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "swift",
-    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse([], 4)\n/// []\n/// >>> intersperse([1, 2, 3], 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// solve(\"1234\") = \"4321\"\n/// solve(\"ab\") = \"AB\"\n/// solve(\"#a@C\") = \"#A@c\"\nfunc solve(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "swift",
-    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even([5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfunc sort_even(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_even(l: [1, 2, 3]) == [1, 2, 3])\nassert(sort_even(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\nassert(sort_even(l: [5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "swift",
-    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero([1, 2, 3])\n/// False\n/// >>> below_zero([1, 2, -4, 5])\n/// True\nfunc below_zero(operations: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "swift",
-    "prompt": "\n/// Check if two words have the same characters.\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n/// True\n/// >>> same_chars('abcd', 'dddddddabc')\n/// True\n/// >>> same_chars('dddddddabc', 'abcd')\n/// True\n/// >>> same_chars('eabcd', 'dddddddabc')\n/// False\n/// >>> same_chars('abcd', 'dddddddabce')\n/// False\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n/// False\nfunc same_chars(s0: String, s1: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\") == true)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabc\") == true)\nassert(same_chars(s0: \"dddddddabc\", s1: \"abcd\") == true)\nassert(same_chars(s0: \"eabcd\", s1: \"dddddddabc\") == false)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabcf\") == false)\nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\") == false)\nassert(same_chars(s0: \"aabb\", s1: \"aaccc\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups('( ) (( )) (( )( ))')\n/// ['()', '(())', '(()())']\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "swift",
-    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// count_upper('aBCdEf') returns 1\n/// count_upper('abcdefg') returns 0\n/// count_upper('dBBE') returns 0\nfunc count_upper(s: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "swift",
-    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "swift",
-    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates([1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "swift",
-    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n/// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n/// select_words(\"simple white space\", 2) ==> []\n/// select_words(\"Hello world\", 4) ==> [\"world\"]\n/// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n/// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n/// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "swift",
-    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Input: \n/// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n/// bucket_capacity : 1\n/// Output: 6\n/// Example 2:\n/// Input: \n/// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n/// bucket_capacity : 2\n/// Output: 5\n/// Example 3:\n/// Input: \n/// grid : [[0,0,0], [0,0,0]]\n/// bucket_capacity : 5\n/// Output: 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// For lst = [1,2,3] the output should be 6\n/// For lst = []  the output should be 0\n/// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunc sum_squares(lst: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1, 2, 3]) == 6)\nassert(sum_squares(lst: [1, 4, 9]) == 14)\nassert(sum_squares(lst: [] as [Int]) == 0)\nassert(sum_squares(lst: [1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\nassert(sum_squares(lst: [-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\nassert(sum_squares(lst: [0]) == 0)\nassert(sum_squares(lst: [-1, -5, 2, -1, -5]) == -126)\nassert(sum_squares(lst: [-56, -99, 1, 0, -2]) == 3030)\nassert(sum_squares(lst: [-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\nassert(sum_squares(lst: [-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\nassert(sum_squares(lst: [-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// add([4, 2, 6, 7]) ==> 2\nfunc add(lst: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "swift",
-    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// multiply(148, 412) should return 16.\n/// multiply(19, 28) should return 72.\n/// multiply(2020, 1851) should return 0.\n/// multiply(14,-15) should return 20.\nfunc multiply(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "swift",
-    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// intersection((1, 2), (2, 3)) ==> \"NO\"\n/// intersection((-1, 1), (0, 4)) ==> \"NO\"\n/// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "swift",
-    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// tri(3) = [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "swift",
-    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// is_simple_power(1, 4) => true\n/// is_simple_power(2, 2) => true\n/// is_simple_power(8, 2) => true\n/// is_simple_power(3, 2) => false\n/// is_simple_power(3, 1) => false\n/// is_simple_power(5, 3) => false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.3) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.05) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.95) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.8) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0], threshold: 0.1) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 1.0) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 0.5) == false)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1012,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(3)\n/// [3, 5, 7]\nfunc make_a_pile(n: Int) -> [Int] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_a_pile(n: 3) == [3, 5, 7])\nassert(make_a_pile(n: 4) == [4, 6, 8, 10])\nassert(make_a_pile(n: 5) == [5, 7, 9, 11, 13])\nassert(make_a_pile(n: 6) == [6, 8, 10, 12, 14, 16])\nassert(make_a_pile(n: 8) == [8, 10, 12, 14, 16, 18, 20, 22])",
     "stop_tokens": [
@@ -1020,865 +24,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "swift",
-    "prompt": "\n/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
+    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix([], 'a')\n/// []\n/// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n/// ['abc', 'array']\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// decimal_to_binary(15)   # returns \"db1111db\"\n/// decimal_to_binary(32)   # returns \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome('')\n/// True\n/// >>> is_palindrome('aba')\n/// True\n/// >>> is_palindrome('aaaaa')\n/// True\n/// >>> is_palindrome('zbcd')\n/// False\nfunc is_palindrome(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "swift",
-    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "swift",
-    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// [2, 2, 2]\n/// >>> factorize(25)\n/// [5, 5]\n/// >>> factorize(70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "swift",
-    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// \"21\"\n/// >>> circular_shift(12, 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "swift",
-    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// get_closest_vowel(\"yogurt\") ==> \"u\"\n/// get_closest_vowel(\"FULL\") ==> \"U\"\n/// get_closest_vowel(\"quick\") ==> \"\"\n/// get_closest_vowel(\"ab\") ==> \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "swift",
-    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "swift",
-    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers('three one five')\n/// 'one three five'\nfunc sort_numbers(numbers: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "swift",
-    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case('Hello')\n/// 'hELLO'\nfunc flip_case(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique common elements for two lists.\n/// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common([5, 3, 2, 8], [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "swift",
-    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// can_arrange([1,2,4,3,5]) = 3\n/// can_arrange([1,2,3]) = -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// is_nested('[[]]') \u279e True\n/// is_nested('[]]]]]]][[[[[]') \u279e False\n/// is_nested('[][]') \u279e False\n/// is_nested('[]') \u279e False\n/// is_nested('[[][]]') \u279e True\n/// is_nested('[[]][[') \u279e True\nfunc is_nested(string: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "swift",
-    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n/// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n/// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n/// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// arr = []\n/// return []\n/// If the array has any strange number ignore it:\n/// arr = [1, -1 , 55] \n/// -> sort arr -> [-1, 1, 55]\n/// -> reverse arr -> [55, 1, -1]\n/// return = ['One']\nfunc by_length(arr: [Int]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "swift",
-    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "swift",
-    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(['1234567'])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(['3',\"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n/// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "swift",
-    "prompt": "\n/// Concatenate list of strings into a single string\n/// >>> concatenate([])\n/// ''\n/// >>> concatenate(['a', 'b', 'c'])\n/// 'abc'\nfunc concatenate(strings: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// For lst = [1,2,3] the output should be 14\n/// For lst = [1,4,9] the output should be 98\n/// For lst = [1,3,5,7] the output should be 84\n/// For lst = [1.4,4.2,0] the output should be 29\n/// For lst = [-2.4,1,1] the output should be 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "swift",
-    "prompt": "\n/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n/// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n/// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunc sort_array(arr: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(arr: [1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\nassert(sort_array(arr: [-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\nassert(sort_array(arr: [1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\nassert(sort_array(arr: [] as [Int]) == [] as [Int])\nassert(sort_array(arr: [2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\nassert(sort_array(arr: [3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "swift",
-    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest([])\n/// >>> longest(['a', 'b', 'c'])\n/// 'a'\n/// >>> longest(['a', 'bb', 'ccc'])\n/// 'ccc'\nfunc longest(strings: [String]) -> String? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// is_sorted([5]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5]) \u279e False\n/// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n/// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n/// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunc is_sorted(lst: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// even_odd_count(-12) ==> (1, 1)\n/// even_odd_count(123) ==> (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "swift",
-    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative([3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative([1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// anti_shuffle('Hi') returns 'Hi'\n/// anti_shuffle('hello') returns 'ehllo'\n/// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunc anti_shuffle(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "swift",
-    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Input: sentence = \"This is a test\"\n/// Output: \"is\"\n/// Example 2:\n/// Input: sentence = \"lets go for swimming\"\n/// Output: \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome('')\n/// ''\n/// >>> make_palindrome('cat')\n/// 'catac'\n/// >>> make_palindrome('cata')\n/// 'catac'\nfunc make_palindrome(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "swift",
-    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// * eat(5, 6, 10) -> [11, 4]\n/// * eat(4, 8, 9) -> [12, 1]\n/// * eat(1, 10, 10) -> [11, 0]\n/// * eat(2, 11, 5) -> [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "swift",
-    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// '22'\n/// >>> change_base(8, 2)\n/// '1000'\n/// >>> change_base(7, 2)\n/// '111'\nfunc change_base(x: Int, base: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// prime_length('Hello') == True\n/// prime_length('abcdcba') == True\n/// prime_length('kittens') == True\n/// prime_length('orange') == False\nfunc prime_length(string: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "swift",
-    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "swift",
-    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// search([4, 1, 2, 2, 3, 1]) == 2\n/// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n/// search([5, 5, 4, 4, 4]) == -1\nfunc search(lst: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// right_angle_triangle(3, 4, 5) == True\n/// right_angle_triangle(1, 2, 3) == False\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "swift",
-    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Input: 3\n/// Output: (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Input: 12\n/// Output: (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "swift",
-    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n/// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "swift",
-    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// * sort_array([]) => []\n/// * sort_array([5]) => [5]\n/// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n/// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "swift",
-    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// get_row([\n/// [1,2,3,4,5,6],\n/// [1,2,3,4,1,6],\n/// [1,2,3,4,5,1]\n/// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// get_row([], 1) == []\n/// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "swift",
-    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(\"abcde\")\n/// 2\n/// >>> vowels_count(\"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "swift",
-    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunc string_to_md5(text: String) -> String? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "swift",
-    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// False\n/// >>> is_prime(101)\n/// True\n/// >>> is_prime(11)\n/// True\n/// >>> is_prime(13441)\n/// True\n/// >>> is_prime(61)\n/// True\n/// >>> is_prime(4)\n/// False\n/// >>> is_prime(1)\n/// False\nfunc is_prime(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "swift",
-    "prompt": "\n/// There are eight planets in our solar system: the closerst to the Sun \n/// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n/// Uranus, Neptune.\n/// Write a function that takes two planet names as strings planet1 and planet2. \n/// The function should return a tuple containing all planets whose orbits are \n/// located between the orbit of planet1 and the orbit of planet2, sorted by \n/// the proximity to the sun. \n/// The function should return an empty tuple if planet1 or planet2\n/// are not correct planet names. \n/// Examples\n/// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n/// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n/// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunc bf(planet1: String, planet2: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bf(planet1: \"Jupiter\", planet2: \"Neptune\") == [\"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Mercury\") == [\"Venus\"])\nassert(bf(planet1: \"Mercury\", planet2: \"Uranus\") == [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])\nassert(bf(planet1: \"Neptune\", planet2: \"Venus\") == [\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Mars\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Jupiter\", planet2: \"Makemake\") == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "swift",
-    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// For num = \"AB\" the output should be 1.\n/// For num = \"1077E\" the output should be 2.\n/// For num = \"ABED1A33\" the output should be 4.\n/// For num = \"123456789ABCDEF0\" the output should be 6.\n/// For num = \"2020\" the output should be 2.\nfunc hex_key(num: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "swift",
-    "prompt": "\n/// Return median of elements in the list l.\n/// >>> median([3, 1, 2, 4, 5])\n/// 3\n/// >>> median([-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// specialFilter([15, -73, 14, -15]) => 1 \n/// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunc specialFilter(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(specialFilter(nums: [5, -2, 1, -5]) == 0)\nassert(specialFilter(nums: [15, -73, 14, -15]) == 1)\nassert(specialFilter(nums: [33, -2, -3, 45, 21, 109]) == 2)\nassert(specialFilter(nums: [43, -12, 93, 125, 121, 109]) == 4)\nassert(specialFilter(nums: [71, -2, -33, 75, 21, 19]) == 3)\nassert(specialFilter(nums: [1]) == 0)\nassert(specialFilter(nums: [] as [Int]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "swift",
-    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> pairs_sum_to_zero([1, 3, -2, 1])\n/// False\n/// >>> pairs_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n/// True\n/// >>> pairs_sum_to_zero([1])\n/// False\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "swift",
-    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n/// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n/// strange_sort_list([]) == []\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "swift",
-    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "swift",
-    "prompt": "\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n/// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n/// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n/// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n/// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunc check_dict_case(dict: [String : String]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"b\" : \"banana\"]) == true)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"A\" : \"banana\", \"B\" : \"banana\"]) == false)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"5\" : \"banana\", \"a\" : \"apple\"]) == false)\nassert(check_dict_case(dict: [\"Name\" : \"John\", \"Age\" : \"36\", \"City\" : \"Houston\"]) == false)\nassert(check_dict_case(dict: [\"STATE\" : \"NC\", \"ZIP\" : \"12345\"]) == true)\nassert(check_dict_case(dict: [\"fruit\" : \"Orange\", \"taste\" : \"Sweet\"]) == true)\nassert(check_dict_case(dict: [:] as [String : String]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "swift",
-    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// for example: \n/// valid_date('03-11-2000') => True\n/// valid_date('15-01-2012') => False\n/// valid_date('04-0-2040') => False\n/// valid_date('06-04-2020') => True\n/// valid_date('06/04/2020') => False\nfunc valid_date(date: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums([]) == 0\n/// >>> count_nums([-1, 11, -11]) == 1\n/// >>> count_nums([1, 1, 2]) == 3\nfunc count_nums(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "swift",
-    "prompt": "\n/// Filter given list of any python values only for integers\n/// >>> filter_integers(['a', 3.14, 5])\n/// [5]\n/// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "swift",
-    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// digitSum(\"\") => 0\n/// digitSum(\"abAB\") => 131\n/// digitSum(\"abcCd\") => 67\n/// digitSum(\"helloE\") => 69\n/// digitSum(\"woArBld\") => 131\n/// digitSum(\"aAaaaXa\") => 153\nfunc digitSum(s: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "swift",
-    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n/// >>> order_by_points([]) == []\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n/// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n/// split_words(\"abcdef\") == 3\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "swift",
-    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "swift",
-    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor('010', '110')\n/// '100'\nfunc string_xor(a: String, b: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "swift",
-    "prompt": "\n/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n/// False\n/// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n/// True\nfunc has_close_elements(numbers: [Double], threshold: Double) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.3) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.05) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.95) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.8) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0], threshold: 0.1) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 1.0) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 0.5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "swift",
-    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n/// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n/// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n/// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "swift",
-    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19) == 'xix'\n/// >>> int_to_mini_roman(152) == 'clii'\n/// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunc int_to_mini_roman(number: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "swift",
-    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"(\")\n/// False\n/// >>> correct_bracketing(\"()\")\n/// True\n/// >>> correct_bracketing(\"(()())\")\n/// True\n/// >>> correct_bracketing(\")(()\")\n/// False\nfunc correct_bracketing(brackets: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "swift",
-    "prompt": "\n/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"<\")\n/// False\n/// >>> correct_bracketing(\"<>\")\n/// True\n/// >>> correct_bracketing(\"<<><>>\")\n/// True\n/// >>> correct_bracketing(\"><<>\")\n/// False\nfunc correct_bracketing(brackets: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"<>\") == true)\nassert(correct_bracketing(brackets: \"<<><>>\") == true)\nassert(correct_bracketing(brackets: \"<><><<><>><>\") == true)\nassert(correct_bracketing(brackets: \"<><><<<><><>><>><<><><<>>>\") == true)\nassert(correct_bracketing(brackets: \"<<<><>>>>\") == false)\nassert(correct_bracketing(brackets: \"><<>\") == false)\nassert(correct_bracketing(brackets: \"<\") == false)\nassert(correct_bracketing(brackets: \"<<<<\") == false)\nassert(correct_bracketing(brackets: \">\") == false)\nassert(correct_bracketing(brackets: \"<<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>><<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>>><>\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "swift",
-    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "swift",
-    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs([1, 2, 2, -4]) == -9\n/// >>> prod_signs([0, 1]) == 0\n/// >>> prod_signs([]) == None\nfunc prod_signs(arr: [Int]) -> Int? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring([], 'a')\n/// []\n/// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n/// ['abc', 'bacd', 'array']\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "swift",
-    "prompt": "\n/// Return list with elements incremented by 1.\n/// >>> incr_list([1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "swift",
-    "prompt": "\n/// Return only positive numbers in the list.\n/// >>> get_positive([-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,7 +40,7 @@
     "language": "swift",
     "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// choose_num(12, 15) = 14\n/// choose_num(13, 12) = -1\nfunc choose_num(x: Int, y: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
     "stop_tokens": [
@@ -1896,13 +48,793 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "swift",
-    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n/// For N = 150, the sum of digits will be 6 the output should be \"110\".\n/// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// rounded_avg(1, 5) => \"0b11\"\n/// rounded_avg(7, 5) => -1\n/// rounded_avg(10, 20) => \"0b1111\"\n/// rounded_avg(20, 33) => \"0b11010\"\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "swift",
+    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits([15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits([152, 323, 1422, 10])\n/// []\nfunc unique_digits(x: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "swift",
+    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n/// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n/// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n/// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// arr = []\n/// return []\n/// If the array has any strange number ignore it:\n/// arr = [1, -1 , 55] \n/// -> sort arr -> [-1, 1, 55]\n/// -> reverse arr -> [55, 1, -1]\n/// return = ['One']\nfunc by_length(arr: [Int]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "swift",
+    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// f(5) == [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Input: 3\n/// Output: (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Input: 12\n/// Output: (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums([]) == 0\n/// >>> count_nums([-1, 11, -11]) == 1\n/// >>> count_nums([1, 1, 2]) == 3\nfunc count_nums(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "swift",
+    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// move_one_ball([3, 4, 5, 1, 2])==>True\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// move_one_ball([3, 5, 4, 1, 2])==>False\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome('')\n/// ''\n/// >>> make_palindrome('cat')\n/// 'catac'\n/// >>> make_palindrome('cata')\n/// 'catac'\nfunc make_palindrome(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "swift",
+    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n/// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "swift",
+    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n/// histogram('a b b a') == {'a': 2, 'b': 2}\n/// histogram('a b c a b') == {'a': 2, 'b': 2}\n/// histogram('b b b b a') == {'b': 4}\n/// histogram('') == {}\nfunc histogram(test: String) -> [String : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "swift",
+    "prompt": "\n/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n/// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n/// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunc reverse_delete(s: String, c: String) -> (String, Bool) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_delete(s: \"abcde\", c: \"ae\") == (\"bcd\", false))\nassert(reverse_delete(s: \"abcdef\", c: \"b\") == (\"acdef\", false))\nassert(reverse_delete(s: \"abcdedcba\", c: \"ab\") == (\"cdedc\", true))\nassert(reverse_delete(s: \"dwik\", c: \"w\") == (\"dik\", false))\nassert(reverse_delete(s: \"a\", c: \"a\") == (\"\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"v\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"vabba\", c: \"v\") == (\"abba\", true))\nassert(reverse_delete(s: \"mamma\", c: \"mia\") == (\"\", true))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "swift",
+    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(['1234567'])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(['3',\"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n/// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "swift",
+    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n/// minSubArraySum([-1, -2, -3]) == -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "swift",
+    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Input: \n/// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n/// bucket_capacity : 1\n/// Output: 6\n/// Example 2:\n/// Input: \n/// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n/// bucket_capacity : 2\n/// Output: 5\n/// Example 3:\n/// Input: \n/// grid : [[0,0,0], [0,0,0]]\n/// bucket_capacity : 5\n/// Output: 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "swift",
+    "prompt": "\n/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n/// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n/// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunc sort_array(arr: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(arr: [1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\nassert(sort_array(arr: [-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\nassert(sort_array(arr: [1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\nassert(sort_array(arr: [] as [Int]) == [] as [Int])\nassert(sort_array(arr: [2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\nassert(sort_array(arr: [3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "swift",
+    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n/// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n/// select_words(\"simple white space\", 2) ==> []\n/// select_words(\"Hello world\", 4) ==> [\"world\"]\n/// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "swift",
+    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// get_closest_vowel(\"yogurt\") ==> \"u\"\n/// get_closest_vowel(\"FULL\") ==> \"U\"\n/// get_closest_vowel(\"quick\") ==> \"\"\n/// get_closest_vowel(\"ab\") ==> \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// match_parens(['()(', ')']) == 'Yes'\n/// match_parens([')', ')']) == 'No'\nfunc match_parens(lst: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "swift",
+    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor('010', '110')\n/// '100'\nfunc string_xor(a: String, b: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "swift",
+    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Input: arr = [-3, -4, 5], k = 3\n/// Output: [-4, -3, 5]\n/// Example 2:\n/// Input: arr = [4, -4, 4], k = 2\n/// Output: [4, 4]\n/// Example 3:\n/// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n/// Output: [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// solution([5, 8, 7, 1]) ==> 12\n/// solution([3, 3, 3, 3, 3]) ==> 9\n/// solution([30, 13, 24, 321]) ==>0\nfunc solution(lst: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n/// Output: 24 # sum of 21 + 3\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "swift",
+    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// for example: \n/// valid_date('03-11-2000') => True\n/// valid_date('15-01-2012') => False\n/// valid_date('04-0-2040') => False\n/// valid_date('06-04-2020') => True\n/// valid_date('06/04/2020') => False\nfunc valid_date(date: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n/// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n/// split_words(\"abcdef\") == 3\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "swift",
+    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// is_sorted([5]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5]) \u279e False\n/// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n/// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n/// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n/// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n/// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunc is_sorted(lst: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "swift",
+    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// intersection((1, 2), (2, 3)) ==> \"NO\"\n/// intersection((-1, 1), (0, 4)) ==> \"NO\"\n/// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "swift",
+    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs([1, 2, 2, -4]) == -9\n/// >>> prod_signs([0, 1]) == 0\n/// >>> prod_signs([]) == None\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "swift",
+    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\n/// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n/// Output: [1, 2, 1]\n/// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n/// Output: [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "swift",
+    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest([])\n/// >>> longest(['a', 'b', 'c'])\n/// 'a'\n/// >>> longest(['a', 'bb', 'ccc'])\n/// 'ccc'\nfunc longest(strings: [String]) -> String? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "swift",
+    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// tri(3) = [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// digits(1)  == 1\n/// digits(4)  == 0\n/// digits(235) == 15\nfunc digits(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// is_nested('[[]]') \u279e True\n/// is_nested('[]]]]]]][[[[[]') \u279e False\n/// is_nested('[][]') \u279e False\n/// is_nested('[]') \u279e False\n/// is_nested('[[][]]') \u279e True\n/// is_nested('[[]][[') \u279e True\nfunc is_nested(string: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// For lst = [1,2,3] the output should be 14\n/// For lst = [1,4,9] the output should be 98\n/// For lst = [1,3,5,7] the output should be 84\n/// For lst = [1.4,4.2,0] the output should be 29\n/// For lst = [-2.4,1,1] the output should be 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n/// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n/// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n/// check_if_last_char_is_a_letter(\"\") \u279e False\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "swift",
+    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// can_arrange([1,2,4,3,5]) = 3\n/// can_arrange([1,2,3]) = -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n/// largest_smallest_integers([]) == (None, None)\n/// largest_smallest_integers([0]) == (None, None)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// compare_one(1, 2.5) \u279e 2.5\n/// compare_one(1, \"2,3\") \u279e \"2,3\"\n/// compare_one(\"5,1\", \"6\") \u279e \"6\"\n/// compare_one(\"1\", 1) \u279e None\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "swift",
+    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// is_equal_to_sum_even(4) == False\n/// is_equal_to_sum_even(6) == False\n/// is_equal_to_sum_even(8) == True\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "swift",
+    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "swift",
+    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(3, 5)\n/// 1\n/// >>> greatest_common_divisor(25, 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "swift",
+    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// fix_spaces(\"Example\") == \"Example\"\n/// fix_spaces(\"Example 1\") == \"Example_1\"\n/// fix_spaces(\" Example 2\") == \"_Example_2\"\n/// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "swift",
+    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// file_name_check(\"example.txt\") # => 'Yes'\n/// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunc file_name_check(file_name: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\n/// For lst = [1,2,3] the output should be 6\n/// For lst = []  the output should be 0\n/// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunc sum_squares(lst: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1, 2, 3]) == 6)\nassert(sum_squares(lst: [1, 4, 9]) == 14)\nassert(sum_squares(lst: [] as [Int]) == 0)\nassert(sum_squares(lst: [1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\nassert(sum_squares(lst: [-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\nassert(sum_squares(lst: [0]) == 0)\nassert(sum_squares(lst: [-1, -5, 2, -1, -5]) == -126)\nassert(sum_squares(lst: [-56, -99, 1, 0, -2]) == 3030)\nassert(sum_squares(lst: [-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\nassert(sum_squares(lst: [-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\nassert(sum_squares(lst: [-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "swift",
+    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Input: sentence = \"This is a test\"\n/// Output: \"is\"\n/// Example 2:\n/// Input: sentence = \"lets go for swimming\"\n/// Output: \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "swift",
+    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// simplify(\"1/5\", \"5/1\") = True\n/// simplify(\"1/6\", \"2/1\") = False\n/// simplify(\"7/10\", \"10/2\") = False\nfunc simplify(x: String, n: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "swift",
+    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n/// >>> order_by_points([]) == []\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// specialFilter([15, -73, 14, -15]) => 1 \n/// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunc specialFilter(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(specialFilter(nums: [5, -2, 1, -5]) == 0)\nassert(specialFilter(nums: [15, -73, 14, -15]) == 1)\nassert(specialFilter(nums: [33, -2, -3, 45, 21, 109]) == 2)\nassert(specialFilter(nums: [43, -12, 93, 125, 121, 109]) == 4)\nassert(specialFilter(nums: [71, -2, -33, 75, 21, 19]) == 3)\nassert(specialFilter(nums: [1]) == 0)\nassert(specialFilter(nums: [] as [Int]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "swift",
+    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Input: n = 5\n/// Output: 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_148_bf",
+    "language": "swift",
+    "prompt": "\n/// There are eight planets in our solar system: the closerst to the Sun \n/// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n/// Uranus, Neptune.\n/// Write a function that takes two planet names as strings planet1 and planet2. \n/// The function should return a tuple containing all planets whose orbits are \n/// located between the orbit of planet1 and the orbit of planet2, sorted by \n/// the proximity to the sun. \n/// The function should return an empty tuple if planet1 or planet2\n/// are not correct planet names. \n/// Examples\n/// bf(\"Jupiter\", \"Neptune\") ==> (\"Saturn\", \"Uranus\")\n/// bf(\"Earth\", \"Mercury\") ==> (\"Venus\")\n/// bf(\"Mercury\", \"Uranus\") ==> (\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\")\nfunc bf(planet1: String, planet2: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_148_bf.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bf(planet1: \"Jupiter\", planet2: \"Neptune\") == [\"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Mercury\") == [\"Venus\"])\nassert(bf(planet1: \"Mercury\", planet2: \"Uranus\") == [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])\nassert(bf(planet1: \"Neptune\", planet2: \"Venus\") == [\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Mars\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Jupiter\", planet2: \"Makemake\") == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n/// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "swift",
+    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes('abc')\n/// ['a', 'ab', 'abc']\nfunc all_prefixes(string: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "swift",
+    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// for x_or_y(7, 34, 12) == 34\n/// for x_or_y(15, 8, 5) == 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "swift",
+    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n/// double_the_difference([-1, -2, 0]) == 0\n/// double_the_difference([9, -2]) == 81\n/// double_the_difference([0]) == 0  \n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "swift",
+    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n/// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "swift",
+    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "swift",
+    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// cycpattern_check(\"abcd\",\"abd\") => False\n/// cycpattern_check(\"hello\",\"ell\") => True\n/// cycpattern_check(\"whassup\",\"psus\") => False\n/// cycpattern_check(\"abab\",\"baa\") => True\n/// cycpattern_check(\"efef\",\"eeff\") => False\n/// cycpattern_check(\"himenss\",\"simen\") => True\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "swift",
+    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// even_odd_count(-12) ==> (1, 1)\n/// even_odd_count(123) ==> (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(19) == 'xix'\n/// >>> int_to_mini_roman(152) == 'clii'\n/// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunc int_to_mini_roman(number: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// right_angle_triangle(3, 4, 5) == True\n/// right_angle_triangle(1, 2, 3) == False\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n/// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n/// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "swift",
+    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// * eat(5, 6, 10) -> [11, 4]\n/// * eat(4, 8, 9) -> [12, 1]\n/// * eat(1, 10, 10) -> [11, 0]\n/// * eat(2, 11, 5) -> [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "swift",
+    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(0)\n/// '0'\n/// >>> string_sequence(5)\n/// '0 1 2 3 4 5'\nfunc string_sequence(n: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "swift",
+    "prompt": "\n/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// solve(\"1234\") = \"4321\"\n/// solve(\"ab\") = \"AB\"\n/// solve(\"#a@C\") = \"#A@c\"\nfunc solve(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "swift",
+    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunc string_to_md5(text: String) -> String? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
     "stop_tokens": [
       "\n}"
     ]
@@ -1912,7 +844,7 @@
     "language": "swift",
     "prompt": "\n/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// generate_integers(2, 8) => [2, 4, 6, 8]\n/// generate_integers(8, 2) => [2, 4, 6, 8]\n/// generate_integers(10, 14) => []\nfunc generate_integers(a: Int, b: Int) -> [Int] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(generate_integers(a: 2, b: 10) == [2, 4, 6, 8])\nassert(generate_integers(a: 10, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 132, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 17, b: 89) == [] as [Int])",
     "stop_tokens": [
@@ -1924,9 +856,1077 @@
     "language": "swift",
     "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters('xyzXYZ')\n/// 3\n/// >>> count_distinct_characters('Jerry')\n/// 4\nfunc count_distinct_characters(string: String) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "swift",
+    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times('', 'a')\n/// 0\n/// >>> how_many_times('aaa', 'a')\n/// 3\n/// >>> how_many_times('aaaa', 'aa')\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "swift",
+    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers('three one five')\n/// 'one three five'\nfunc sort_numbers(numbers: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups('( ) (( )) (( )( ))')\n/// ['()', '(())', '(()())']\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "swift",
+    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "swift",
+    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "swift",
+    "prompt": "\n/// Filter given list of any python values only for integers\n/// >>> filter_integers(['a', 3.14, 5])\n/// [5]\n/// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "swift",
+    "prompt": "\n/// Return length of given string\n/// >>> strlen('')\n/// 0\n/// >>> strlen('abc')\n/// 3\nfunc strlen(string: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "swift",
+    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "swift",
+    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(8)\n/// [2, 2, 2]\n/// >>> factorize(25)\n/// [5, 5]\n/// >>> factorize(70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "swift",
+    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates([1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "swift",
+    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case('Hello')\n/// 'hELLO'\nfunc flip_case(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "swift",
+    "prompt": "\n/// Concatenate list of strings into a single string\n/// >>> concatenate([])\n/// ''\n/// >>> concatenate(['a', 'b', 'c'])\n/// 'abc'\nfunc concatenate(strings: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix([], 'a')\n/// []\n/// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n/// ['abc', 'array']\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "swift",
+    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "swift",
+    "prompt": "\n/// Return only positive numbers in the list.\n/// >>> get_positive([-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "swift",
+    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(6)\n/// False\n/// >>> is_prime(101)\n/// True\n/// >>> is_prime(11)\n/// True\n/// >>> is_prime(13441)\n/// True\n/// >>> is_prime(61)\n/// True\n/// >>> is_prime(4)\n/// False\n/// >>> is_prime(1)\n/// False\nfunc is_prime(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "swift",
+    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique elements in a list\n/// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "swift",
+    "prompt": "\n/// Return maximum element in the list.\n/// >>> max_element([1, 2, 3])\n/// 3\n/// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "swift",
+    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(50)\n/// 0\n/// >>> fizz_buzz(78)\n/// 2\n/// >>> fizz_buzz(79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "swift",
+    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even([1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even([5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfunc sort_even(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_even(l: [1, 2, 3]) == [1, 2, 3])\nassert(sort_even(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\nassert(sort_even(l: [5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "swift",
+    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(1)\n/// 2\n/// >>> prime_fib(2)\n/// 3\n/// >>> prime_fib(3)\n/// 5\n/// >>> prime_fib(4)\n/// 13\n/// >>> prime_fib(5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "swift",
+    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero([1, 2, 3])\n/// False\n/// >>> below_zero([1, 2, -4, 5])\n/// True\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> triples_sum_to_zero([1, 3, -2, 1])\n/// True\n/// >>> triples_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n/// True\n/// >>> triples_sum_to_zero([1])\n/// False\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "swift",
+    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "swift",
+    "prompt": "\n/// Return list with elements incremented by 1.\n/// >>> incr_list([1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero([1, 3, 5, 0])\n/// False\n/// >>> pairs_sum_to_zero([1, 3, -2, 1])\n/// False\n/// >>> pairs_sum_to_zero([1, 2, 3, 7])\n/// False\n/// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n/// True\n/// >>> pairs_sum_to_zero([1])\n/// False\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "swift",
+    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(8, 3)\n/// '22'\n/// >>> change_base(8, 2)\n/// '1000'\n/// >>> change_base(7, 2)\n/// '111'\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(5, 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "swift",
+    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(5)\n/// 4\n/// >>> fib4(6)\n/// 8\n/// >>> fib4(7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "swift",
+    "prompt": "\n/// Return median of elements in the list l.\n/// >>> median([3, 1, 2, 4, 5])\n/// 3\n/// >>> median([-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome('')\n/// True\n/// >>> is_palindrome('aba')\n/// True\n/// >>> is_palindrome('aaaaa')\n/// True\n/// >>> is_palindrome('zbcd')\n/// False\nfunc is_palindrome(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "swift",
+    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(3, 5)\n/// 3\n/// >>> modp(1101, 101)\n/// 2\n/// >>> modp(0, 101)\n/// 1\n/// >>> modp(3, 11)\n/// 8\n/// >>> modp(100, 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "swift",
+    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "swift",
+    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels('')\n/// ''\n/// >>> remove_vowels('abcdef')\n/// 'bcdf'\n/// >>> remove_vowels('aaaaa')\n/// ''\n/// >>> remove_vowels('aaBAA')\n/// 'B'\n/// >>> remove_vowels('zbcd')\n/// 'zbcd'\nfunc remove_vowels(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "swift",
+    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold([1, 2, 4, 10], 100)\n/// True\n/// >>> below_threshold([1, 20, 4, 10], 5)\n/// False\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "swift",
+    "prompt": "\n/// Add two numbers x and y\n/// >>> add(2, 3)\n/// 5\n/// >>> add(5, 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "swift",
+    "prompt": "\n/// Check if two words have the same characters.\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n/// True\n/// >>> same_chars('abcd', 'dddddddabc')\n/// True\n/// >>> same_chars('dddddddabc', 'abcd')\n/// True\n/// >>> same_chars('eabcd', 'dddddddabc')\n/// False\n/// >>> same_chars('abcd', 'dddddddabce')\n/// False\n/// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n/// False\nfunc same_chars(s0: String, s1: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\") == true)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabc\") == true)\nassert(same_chars(s0: \"dddddddabc\", s1: \"abcd\") == true)\nassert(same_chars(s0: \"eabcd\", s1: \"dddddddabc\") == false)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabcf\") == false)\nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\") == false)\nassert(same_chars(s0: \"aabb\", s1: \"aaccc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "swift",
+    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(10)\n/// 55\n/// >>> fib(1)\n/// 1\n/// >>> fib(8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "swift",
+    "prompt": "\n/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"<\")\n/// False\n/// >>> correct_bracketing(\"<>\")\n/// True\n/// >>> correct_bracketing(\"<<><>>\")\n/// True\n/// >>> correct_bracketing(\"><<>\")\n/// False\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"<>\") == true)\nassert(correct_bracketing(brackets: \"<<><>>\") == true)\nassert(correct_bracketing(brackets: \"<><><<><>><>\") == true)\nassert(correct_bracketing(brackets: \"<><><<<><><>><>><<><><<>>>\") == true)\nassert(correct_bracketing(brackets: \"<<<><>>>>\") == false)\nassert(correct_bracketing(brackets: \"><<>\") == false)\nassert(correct_bracketing(brackets: \"<\") == false)\nassert(correct_bracketing(brackets: \"<<<<\") == false)\nassert(correct_bracketing(brackets: \">\") == false)\nassert(correct_bracketing(brackets: \"<<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>><<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>>><>\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "swift",
+    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic([1, 2, 4, 20])\n/// True\n/// >>> monotonic([1, 20, 4, 10])\n/// False\n/// >>> monotonic([4, 1, 0, -10])\n/// True\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique common elements for two lists.\n/// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common([5, 3, 2, 8], [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "swift",
+    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(13195)\n/// 29\n/// >>> largest_prime_factor(2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "swift",
+    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse([], 4)\n/// []\n/// >>> intersperse([1, 2, 3], 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "swift",
+    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(30)\n/// 465\n/// >>> sum_to_n(100)\n/// 5050\n/// >>> sum_to_n(5)\n/// 15\n/// >>> sum_to_n(10)\n/// 55\n/// >>> sum_to_n(1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "swift",
+    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(\"(\")\n/// False\n/// >>> correct_bracketing(\"()\")\n/// True\n/// >>> correct_bracketing(\"(()())\")\n/// True\n/// >>> correct_bracketing(\")(()\")\n/// False\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "swift",
+    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative([3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative([1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "swift",
+    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(1)\n/// 0\n/// >>> fibfib(5)\n/// 4\n/// >>> fibfib(8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(\"abcde\")\n/// 2\n/// >>> vowels_count(\"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "swift",
+    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(12, 1)\n/// \"21\"\n/// >>> circular_shift(12, 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "swift",
+    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// digitSum(\"\") => 0\n/// digitSum(\"abAB\") => 131\n/// digitSum(\"abcCd\") => 67\n/// digitSum(\"helloE\") => 69\n/// digitSum(\"woArBld\") => 131\n/// digitSum(\"aAaaaXa\") => 153\nfunc digitSum(s: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "swift",
+    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n/// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n/// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n/// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "swift",
+    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Input: [4,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Input: [1,2,3]\n/// Output: [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n/// Example 3:\n/// Input: []\n/// Output: []\n/// Example 4:\n/// Input: [5, 0, 3, 0, 4, 2]\n/// Output: [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "swift",
+    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// search([4, 1, 2, 2, 3, 1]) == 2\n/// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n/// search([5, 5, 4, 4, 4]) == -1\nfunc search(lst: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "swift",
+    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n/// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n/// strange_sort_list([]) == []\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// triangle_area(3, 4, 5) == 6.00\n/// triangle_area(1, 2, 10) == -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// will_it_fly([1, 2], 5) \u279e False \n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// will_it_fly([3, 2, 3], 1) \u279e False\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// will_it_fly([3, 2, 3], 9) \u279e True\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// will_it_fly([3], 5) \u279e True\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "swift",
+    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// smallest_change([1,2,3,5,4,7,9,6]) == 4\n/// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n/// smallest_change([1, 2, 3, 2, 1]) == 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// total_match([], []) \u279e []\n/// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n/// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n/// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n/// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// is_multiply_prime(30) == True\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "swift",
+    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// is_simple_power(1, 4) => true\n/// is_simple_power(2, 2) => true\n/// is_simple_power(8, 2) => true\n/// is_simple_power(3, 2) => false\n/// is_simple_power(3, 1) => false\n/// is_simple_power(5, 3) => false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// iscube(1) ==> True\n/// iscube(2) ==> False\n/// iscube(-1) ==> True\n/// iscube(64) ==> True\n/// iscube(0) ==> True\n/// iscube(180) ==> False\nfunc iscube(a: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "swift",
+    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// For num = \"AB\" the output should be 1.\n/// For num = \"1077E\" the output should be 2.\n/// For num = \"ABED1A33\" the output should be 4.\n/// For num = \"123456789ABCDEF0\" the output should be 6.\n/// For num = \"2020\" the output should be 2.\nfunc hex_key(num: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// decimal_to_binary(15)   # returns \"db1111db\"\n/// decimal_to_binary(32)   # returns \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring([], 'a')\n/// []\n/// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n/// ['abc', 'bacd', 'array']\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// is_happy(a) => False\n/// is_happy(aa) => False\n/// is_happy(abcd) => True\n/// is_happy(aabb) => False\n/// is_happy(adb) => True\n/// is_happy(xyy) => False\nfunc is_happy(s: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "swift",
+    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// prime_length('Hello') == True\n/// prime_length('abcdcba') == True\n/// prime_length('kittens') == True\n/// prime_length('orange') == False\nfunc prime_length(string: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n/// For N = 150, the sum of digits will be 6 the output should be \"110\".\n/// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// add([4, 2, 6, 7]) ==> 2\nfunc add(lst: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// anti_shuffle('Hi') returns 'Hi'\n/// anti_shuffle('hello') returns 'ehllo'\n/// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunc anti_shuffle(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "swift",
+    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// get_row([\n/// [1,2,3,4,5,6],\n/// [1,2,3,4,1,6],\n/// [1,2,3,4,5,1]\n/// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// get_row([], 1) == []\n/// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "swift",
+    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// * sort_array([]) => []\n/// * sort_array([5]) => [5]\n/// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n/// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "swift",
+    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// encrypt('hi') returns 'lm'\n/// encrypt('asdfghjkl') returns 'ewhjklnop'\n/// encrypt('gf') returns 'kj'\n/// encrypt('et') returns 'ix'\nfunc encrypt(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "swift",
+    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product([])\n/// (0, 1)\n/// >>> sum_product([1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// next_smallest([1, 2, 3, 4, 5]) == 2\n/// next_smallest([5, 1, 4, 3, 2]) == 2\n/// next_smallest([]) == None\n/// next_smallest([1, 1]) == None\nfunc next_smallest(lst: [Int]) -> Int? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "swift",
+    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(\"Hello world\")\n/// 0\n/// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// any_int(5, 2, 7) \u279e True\n/// any_int(3, 2, 2) \u279e False\n/// any_int(3, -2, 1) \u279e True\n/// any_int(3.6, -2.2, 2) \u279e False\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode('test')\n/// 'TGST'\n/// >>> encode('This is a message')\n/// 'tHKS KS C MGSSCGG'\nfunc encode(message: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n/// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n/// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n/// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n/// For lst = [0,81,12,3,1,21] the output should be 3\n/// For lst = [0,8,1,2,1,7] the output should be 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "swift",
+    "prompt": "\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\n/// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n/// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n/// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n/// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n/// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunc check_dict_case(dict: [String : String]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"b\" : \"banana\"]) == true)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"A\" : \"banana\", \"B\" : \"banana\"]) == false)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"5\" : \"banana\", \"a\" : \"apple\"]) == false)\nassert(check_dict_case(dict: [\"Name\" : \"John\", \"Age\" : \"36\", \"City\" : \"Houston\"]) == false)\nassert(check_dict_case(dict: [\"STATE\" : \"NC\", \"ZIP\" : \"12345\"]) == true)\nassert(check_dict_case(dict: [\"fruit\" : \"Orange\", \"taste\" : \"Sweet\"]) == true)\nassert(check_dict_case(dict: [:] as [String : String]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "swift",
+    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// count_up_to(5) => [2,3]\n/// count_up_to(11) => [2,3,5,7]\n/// count_up_to(0) => []\n/// count_up_to(20) => [2,3,5,7,11,13,17,19]\n/// count_up_to(1) => []\n/// count_up_to(18) => [2,3,5,7,11,13,17]\nfunc count_up_to(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "swift",
+    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// multiply(148, 412) should return 16.\n/// multiply(19, 28) should return 72.\n/// multiply(2020, 1851) should return 0.\n/// multiply(14,-15) should return 20.\nfunc multiply(a: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "swift",
+    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// count_upper('aBCdEf') returns 1\n/// count_upper('abcdefg') returns 0\n/// count_upper('dBBE') returns 0\nfunc count_upper(s: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(\"10\")\n/// 10\n/// >>> closest_integer(\"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "swift",
+    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-swift-remove.json
+++ b/prompts/humaneval-swift-remove.json
@@ -1,1368 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "swift",
-    "prompt": "\n/// Return length of given string\nfunc strlen(string: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "swift",
-    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\nfunc encrypt(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "swift",
-    "prompt": "\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\nfunc check_dict_case(dict: [String : String]) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"b\" : \"banana\"]) == true)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"A\" : \"banana\", \"B\" : \"banana\"]) == false)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"5\" : \"banana\", \"a\" : \"apple\"]) == false)\nassert(check_dict_case(dict: [\"Name\" : \"John\", \"Age\" : \"36\", \"City\" : \"Houston\"]) == false)\nassert(check_dict_case(dict: [\"STATE\" : \"NC\", \"ZIP\" : \"12345\"]) == true)\nassert(check_dict_case(dict: [\"fruit\" : \"Orange\", \"taste\" : \"Sweet\"]) == true)\nassert(check_dict_case(dict: [:] as [String : String]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\nfunc add(lst: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "swift",
-    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with -\nfunc fix_spaces(text: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "swift",
-    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunc fibfib(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "swift",
-    "prompt": "\n/// Filter given list of any python values only for integers\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\nfunc parse_music(music_string: String) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\nfunc decimal_to_binary(decimal: Int) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "swift",
-    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\nfunc all_prefixes(string: String) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "swift",
-    "prompt": "\n/// Add two numbers x and y\nfunc add(x: Int, y: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "swift",
-    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "swift",
-    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "swift",
-    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunc flip_case(string: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "swift",
-    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// If the array is empty, return an empty array:\n/// If the array has any strange number ignore it:\nfunc by_length(arr: [Int]) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "swift",
-    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\nfunc factorize(n: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "swift",
-    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\nfunc count_up_to(n: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique elements in a list\nfunc unique(l: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "swift",
-    "prompt": "\n/// Return maximum element in the list.\nfunc max_element(l: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\nfunc is_nested(string: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\nfunc odd_count(lst: [String]) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "swift",
-    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "swift",
-    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "swift",
-    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\nfunc derivative(xs: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\nfunc is_sorted(lst: [Int]) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\nfunc solve(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "swift",
-    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\nfunc tri(n: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "swift",
-    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunc fizz_buzz(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "swift",
-    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "swift",
-    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\nfunc count_upper(s: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "swift",
-    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\nfunc largest_divisor(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "swift",
-    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\nfunc sort_array(array: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "swift",
-    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\nfunc f(n: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\nfunc iscube(a: Int) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\nfunc encode(message: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "swift",
-    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\nfunc is_bored(S: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_148_bf",
-    "language": "swift",
-    "prompt": "\n/// There are eight planets in our solar system: the closerst to the Sun \n/// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n/// Uranus, Neptune.\n/// Write a function that takes two planet names as strings planet1 and planet2. \n/// The function should return a tuple containing all planets whose orbits are \n/// located between the orbit of planet1 and the orbit of planet2, sorted by \n/// the proximity to the sun. \n/// The function should return an empty tuple if planet1 or planet2\n/// are not correct planet names. \n/// Examples\nfunc bf(planet1: String, planet2: String) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bf(planet1: \"Jupiter\", planet2: \"Neptune\") == [\"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Mercury\") == [\"Venus\"])\nassert(bf(planet1: \"Mercury\", planet2: \"Uranus\") == [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])\nassert(bf(planet1: \"Neptune\", planet2: \"Venus\") == [\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Mars\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Jupiter\", planet2: \"Makemake\") == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\nfunc digits(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "swift",
-    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\nfunc words_string(s: String) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "swift",
-    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunc how_many_times(string: String, substring: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "swift",
-    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\nfunc remove_vowels(text: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "swift",
-    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "swift",
-    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "swift",
-    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "swift",
-    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunc prime_fib(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "swift",
-    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "swift",
     "prompt": "\n/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\nfunc has_close_elements(numbers: [Double], threshold: Double) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.3) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.05) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.95) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.8) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0], threshold: 0.1) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 1.0) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 0.5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunc make_palindrome(string: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "swift",
-    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\nfunc string_xor(a: String, b: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "swift",
-    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "swift",
-    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunc fib4(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\nfunc unique_digits(x: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "swift",
-    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\nfunc select_words(s: String, n: Int) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "swift",
-    "prompt": "\n/// Return n-th Fibonacci number.\nfunc fib(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "swift",
-    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\nfunc match_parens(lst: [String]) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\nfunc next_smallest(lst: [Int]) -> Int? {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "swift",
-    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\nfunc truncate_number(number: Double) -> Double {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "swift",
-    "prompt": "\n/// Return list with elements incremented by 1.\nfunc incr_list(l: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "swift",
-    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "swift",
-    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\nfunc modp(n: Int, p: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\nfunc is_happy(s: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "swift",
-    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunc largest_prime_factor(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "swift",
-    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\nfunc digitSum(s: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "swift",
-    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\nfunc solution(lst: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "swift",
-    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// Example 4:\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "swift",
-    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "swift",
-    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "swift",
-    "prompt": "\n/// Return median of elements in the list l.\nfunc median(l: [Int]) -> Double {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\nfunc prime_length(string: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\nfunc smallest_change(arr: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\nfunc sum_squares(lst: [Double]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "swift",
-    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\nfunc file_name_check(file_name: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "swift",
-    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "swift",
-    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "swift",
-    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\nfunc valid_date(date: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\nfunc count_nums(arr: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\nfunc anti_shuffle(s: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Checks if given string is a palindrome\nfunc is_palindrome(text: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "swift",
-    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\nfunc get_closest_vowel(word: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "swift",
-    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\nfunc is_prime(n: Int) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "swift",
-    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunc simplify(x: String, n: String) -> Bool {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "swift",
-    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\nfunc hex_key(num: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "swift",
-    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Example 2:\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "swift",
-    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\nfunc histogram(test: String) -> [String : Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "swift",
-    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "swift",
-    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\nfunc can_arrange(arr: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "swift",
-    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\nfunc sort_numbers(numbers: String) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "swift",
-    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\nfunc sum_squares(lst: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1, 2, 3]) == 6)\nassert(sum_squares(lst: [1, 4, 9]) == 14)\nassert(sum_squares(lst: [] as [Int]) == 0)\nassert(sum_squares(lst: [1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\nassert(sum_squares(lst: [-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\nassert(sum_squares(lst: [0]) == 0)\nassert(sum_squares(lst: [-1, -5, 2, -1, -5]) == -126)\nassert(sum_squares(lst: [-56, -99, 1, 0, -2]) == 3030)\nassert(sum_squares(lst: [-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\nassert(sum_squares(lst: [-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\nassert(sum_squares(lst: [-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "swift",
-    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "swift",
-    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\nfunc choose_num(x: Int, y: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "swift",
-    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunc count_distinct_characters(string: String) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1372,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\nfunc make_a_pile(n: Int) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_a_pile(n: 3) == [3, 5, 7])\nassert(make_a_pile(n: 4) == [4, 6, 8, 10])\nassert(make_a_pile(n: 5) == [5, 7, 9, 11, 13])\nassert(make_a_pile(n: 6) == [6, 8, 10, 12, 14, 16])\nassert(make_a_pile(n: 8) == [8, 10, 12, 14, 16, 18, 20, 22])",
     "stop_tokens": [
@@ -1380,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "swift",
-    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\nfunc words_string(s: String) -> [String] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "swift",
-    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
+    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\nfunc choose_num(x: Int, y: Int) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "swift",
-    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunc string_sequence(n: Int) -> String {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "swift",
-    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\nfunc unique_digits(x: [Int]) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "swift",
-    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// If the array is empty, return an empty array:\n/// If the array has any strange number ignore it:\nfunc by_length(arr: [Int]) -> [String] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "swift",
-    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\nfunc longest(strings: [String]) -> String? {\n",
+    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\nfunc f(n: Int) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "swift",
-    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "swift",
-    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\nfunc count_nums(arr: [Int]) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "swift",
-    "prompt": "\n/// Return only positive numbers in the list.\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "swift",
-    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunc make_palindrome(string: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "swift",
-    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "swift",
-    "prompt": "\n/// Given length of a side and high return area for a triangle.\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\nfunc histogram(test: String) -> [String : Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "swift",
-    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\nfunc multiply(a: Int, b: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "swift",
-    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique common elements for two lists.\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\nfunc int_to_mini_roman(number: Int) -> String {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "swift",
-    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1588,7 +172,7 @@
     "language": "swift",
     "prompt": "\n/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\nfunc reverse_delete(s: String, c: String) -> (String, Bool) {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_delete(s: \"abcde\", c: \"ae\") == (\"bcd\", false))\nassert(reverse_delete(s: \"abcdef\", c: \"b\") == (\"acdef\", false))\nassert(reverse_delete(s: \"abcdedcba\", c: \"ab\") == (\"cdedc\", true))\nassert(reverse_delete(s: \"dwik\", c: \"w\") == (\"dik\", false))\nassert(reverse_delete(s: \"a\", c: \"a\") == (\"\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"v\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"vabba\", c: \"v\") == (\"abba\", true))\nassert(reverse_delete(s: \"mamma\", c: \"mia\") == (\"\", true))",
     "stop_tokens": [
@@ -1596,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "swift",
-    "prompt": "\n/// Return a greatest common divisor of two integers a and b\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\nfunc odd_count(lst: [String]) -> [String] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
+    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "swift",
+    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +220,7 @@
     "language": "swift",
     "prompt": "\n/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\nfunc sort_array(arr: [Int]) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(arr: [1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\nassert(sort_array(arr: [-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\nassert(sort_array(arr: [1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\nassert(sort_array(arr: [] as [Int]) == [] as [Int])\nassert(sort_array(arr: [2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\nassert(sort_array(arr: [3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])",
     "stop_tokens": [
@@ -1632,133 +228,385 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "swift",
-    "prompt": "\n/// Concatenate list of strings into a single string\nfunc concatenate(strings: [String]) -> String {\n",
+    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\nfunc select_words(s: String, n: Int) -> [String] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
+    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\nfunc get_closest_vowel(word: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\nfunc match_parens(lst: [String]) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "swift",
-    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\nfunc string_xor(a: String, b: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "swift",
-    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\nfunc vowels_count(s: String) -> Int {\n",
+    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// Example 2:\n/// Example 3:\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\nfunc find_max(words: [String]) -> String {\n",
+    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\nfunc solution(lst: [Int]) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "swift",
-    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\nfunc string_to_md5(text: String) -> String? {\n",
+    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "swift",
-    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\nfunc valid_date(date: String) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "swift",
-    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "swift",
-    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\nfunc is_sorted(lst: [Int]) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "swift",
+    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "swift",
+    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "swift",
+    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "swift",
+    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\nfunc longest(strings: [String]) -> String? {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "swift",
+    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\nfunc tri(n: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\nfunc digits(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\nfunc is_nested(string: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\nfunc sum_squares(lst: [Double]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "swift",
+    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\nfunc can_arrange(arr: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "swift",
+    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "swift",
+    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "swift",
+    "prompt": "\n/// Return a greatest common divisor of two integers a and b\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "swift",
+    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with -\nfunc fix_spaces(text: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "swift",
+    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\nfunc file_name_check(file_name: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// \"\n/// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n/// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n/// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n/// Examples:\nfunc sum_squares(lst: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1, 2, 3]) == 6)\nassert(sum_squares(lst: [1, 4, 9]) == 14)\nassert(sum_squares(lst: [] as [Int]) == 0)\nassert(sum_squares(lst: [1, 1, 1, 1, 1, 1, 1, 1, 1]) == 9)\nassert(sum_squares(lst: [-1, -1, -1, -1, -1, -1, -1, -1, -1]) == -3)\nassert(sum_squares(lst: [0]) == 0)\nassert(sum_squares(lst: [-1, -5, 2, -1, -5]) == -126)\nassert(sum_squares(lst: [-56, -99, 1, 0, -2]) == 3030)\nassert(sum_squares(lst: [-1, 0, 0, 0, 0, 0, 0, 0, -1]) == 0)\nassert(sum_squares(lst: [-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196)\nassert(sum_squares(lst: [-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "swift",
+    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// Example 2:\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "swift",
+    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunc simplify(x: String, n: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "swift",
+    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +616,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\nfunc specialFilter(nums: [Int]) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(specialFilter(nums: [5, -2, 1, -5]) == 0)\nassert(specialFilter(nums: [15, -73, 14, -15]) == 1)\nassert(specialFilter(nums: [33, -2, -3, 45, 21, 109]) == 2)\nassert(specialFilter(nums: [43, -12, 93, 125, 121, 109]) == 4)\nassert(specialFilter(nums: [71, -2, -33, 75, 21, 19]) == 3)\nassert(specialFilter(nums: [1]) == 0)\nassert(specialFilter(nums: [] as [Int]) == 0)",
     "stop_tokens": [
@@ -1776,25 +624,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "swift",
-    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\nfunc sum_to_n(n: Int) -> Int {\n",
+    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_148_bf",
     "language": "swift",
-    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// There are eight planets in our solar system: the closerst to the Sun \n/// is Mercury, the next one is Venus, then Earth, Mars, Jupiter, Saturn, \n/// Uranus, Neptune.\n/// Write a function that takes two planet names as strings planet1 and planet2. \n/// The function should return a tuple containing all planets whose orbits are \n/// located between the orbit of planet1 and the orbit of planet2, sorted by \n/// the proximity to the sun. \n/// The function should return an empty tuple if planet1 or planet2\n/// are not correct planet names. \n/// Examples\nfunc bf(planet1: String, planet2: String) -> [String] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_148_bf.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bf(planet1: \"Jupiter\", planet2: \"Neptune\") == [\"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Mercury\") == [\"Venus\"])\nassert(bf(planet1: \"Mercury\", planet2: \"Uranus\") == [\"Venus\", \"Earth\", \"Mars\", \"Jupiter\", \"Saturn\"])\nassert(bf(planet1: \"Neptune\", planet2: \"Venus\") == [\"Earth\", \"Mars\", \"Jupiter\", \"Saturn\", \"Uranus\"])\nassert(bf(planet1: \"Earth\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Mars\", planet2: \"Earth\") == [] as [String])\nassert(bf(planet1: \"Jupiter\", planet2: \"Makemake\") == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "swift",
+    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\nfunc all_prefixes(string: String) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "swift",
+    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "swift",
+    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "swift",
+    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "swift",
+    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "swift",
+    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "swift",
+    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\nfunc int_to_mini_roman(number: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\nfunc find_max(words: [String]) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "swift",
+    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "swift",
+    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunc string_sequence(n: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\nfunc solve(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "swift",
+    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\nfunc string_to_md5(text: String) -> String? {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +832,7 @@
     "language": "swift",
     "prompt": "\n/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\nfunc generate_integers(a: Int, b: Int) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(generate_integers(a: 2, b: 10) == [2, 4, 6, 8])\nassert(generate_integers(a: 10, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 132, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 17, b: 89) == [] as [Int])",
     "stop_tokens": [
@@ -1812,49 +840,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "swift",
-    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunc count_distinct_characters(string: String) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "swift",
-    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\nfunc parse_music(music_string: String) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "swift",
-    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\nfunc search(lst: [Int]) -> Int {\n",
+    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunc how_many_times(string: String, substring: String) -> Int {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "swift",
-    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\nfunc sort_numbers(numbers: String) -> String {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "swift",
+    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "swift",
+    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "swift",
+    "prompt": "\n/// Filter given list of any python values only for integers\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "swift",
+    "prompt": "\n/// Return length of given string\nfunc strlen(string: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "swift",
+    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\nfunc largest_divisor(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "swift",
+    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\nfunc factorize(n: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "swift",
+    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "swift",
+    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunc flip_case(string: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "swift",
+    "prompt": "\n/// Concatenate list of strings into a single string\nfunc concatenate(strings: [String]) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "swift",
+    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\nfunc truncate_number(number: Double) -> Double {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "swift",
+    "prompt": "\n/// Return only positive numbers in the list.\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "swift",
+    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\nfunc is_prime(n: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "swift",
+    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique elements in a list\nfunc unique(l: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "swift",
+    "prompt": "\n/// Return maximum element in the list.\nfunc max_element(l: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "swift",
+    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunc fizz_buzz(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1108,189 @@
     "language": "swift",
     "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\nfunc sort_even(l: [Int]) -> [Int] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_even(l: [1, 2, 3]) == [1, 2, 3])\nassert(sort_even(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\nassert(sort_even(l: [5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "swift",
+    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunc prime_fib(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "swift",
+    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "swift",
+    "prompt": "\n/// Return list with elements incremented by 1.\nfunc incr_list(l: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "swift",
+    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given length of a side and high return area for a triangle.\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "swift",
+    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunc fib4(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "swift",
+    "prompt": "\n/// Return median of elements in the list l.\nfunc median(l: [Int]) -> Double {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Checks if given string is a palindrome\nfunc is_palindrome(text: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "swift",
+    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\nfunc modp(n: Int, p: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "swift",
+    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "swift",
+    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\nfunc remove_vowels(text: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "swift",
+    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "swift",
+    "prompt": "\n/// Add two numbers x and y\nfunc add(x: Int, y: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "swift",
     "prompt": "\n/// Check if two words have the same characters.\nfunc same_chars(s0: String, s1: String) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\") == true)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabc\") == true)\nassert(same_chars(s0: \"dddddddabc\", s1: \"abcd\") == true)\nassert(same_chars(s0: \"eabcd\", s1: \"dddddddabc\") == false)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabcf\") == false)\nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\") == false)\nassert(same_chars(s0: \"aabb\", s1: \"aaccc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "swift",
+    "prompt": "\n/// Return n-th Fibonacci number.\nfunc fib(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "swift",
     "prompt": "\n/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets: String) -> Bool {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"<>\") == true)\nassert(correct_bracketing(brackets: \"<<><>>\") == true)\nassert(correct_bracketing(brackets: \"<><><<><>><>\") == true)\nassert(correct_bracketing(brackets: \"<><><<<><><>><>><<><><<>>>\") == true)\nassert(correct_bracketing(brackets: \"<<<><>>>>\") == false)\nassert(correct_bracketing(brackets: \"><<>\") == false)\nassert(correct_bracketing(brackets: \"<\") == false)\nassert(correct_bracketing(brackets: \"<<<<\") == false)\nassert(correct_bracketing(brackets: \">\") == false)\nassert(correct_bracketing(brackets: \"<<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>><<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>>><>\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "swift",
+    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique common elements for two lists.\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "swift",
+    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunc largest_prime_factor(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "swift",
+    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "swift",
+    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\nfunc sum_to_n(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "swift",
+    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "swift",
+    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\nfunc derivative(xs: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "swift",
+    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunc fibfib(n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\nfunc vowels_count(s: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "swift",
+    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "swift",
+    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\nfunc digitSum(s: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "swift",
+    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "swift",
+    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// Example 4:\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "swift",
+    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\nfunc search(lst: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "swift",
+    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "swift",
+    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\nfunc smallest_change(arr: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "swift",
+    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\nfunc iscube(a: Int) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "swift",
+    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\nfunc hex_key(num: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\nfunc decimal_to_binary(decimal: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\nfunc is_happy(s: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "swift",
+    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\nfunc prime_length(string: String) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\nfunc add(lst: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\nfunc anti_shuffle(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "swift",
+    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "swift",
+    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\nfunc sort_array(array: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "swift",
+    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\nfunc encrypt(s: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "swift",
+    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\nfunc next_smallest(lst: [Int]) -> Int? {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "swift",
+    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\nfunc is_bored(S: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\nfunc encode(message: String) -> String {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "swift",
+    "prompt": "\n/// Given a dictionary, return True if all keys are strings in lower \n/// case or all keys are strings in upper case, else return False.\n/// The function should return False is the given dictionary is empty.\n/// Examples:\nfunc check_dict_case(dict: [String : String]) -> Bool {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"b\" : \"banana\"]) == true)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"A\" : \"banana\", \"B\" : \"banana\"]) == false)\nassert(check_dict_case(dict: [\"p\" : \"pineapple\", \"5\" : \"banana\", \"a\" : \"apple\"]) == false)\nassert(check_dict_case(dict: [\"Name\" : \"John\", \"Age\" : \"36\", \"City\" : \"Houston\"]) == false)\nassert(check_dict_case(dict: [\"STATE\" : \"NC\", \"ZIP\" : \"12345\"]) == true)\nassert(check_dict_case(dict: [\"fruit\" : \"Orange\", \"taste\" : \"Sweet\"]) == true)\nassert(check_dict_case(dict: [:] as [String : String]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "swift",
+    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\nfunc count_up_to(n: Int) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "swift",
+    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\nfunc multiply(a: Int, b: Int) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "swift",
+    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\nfunc count_upper(s: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "swift",
+    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-swift-reworded.json
+++ b/prompts/humaneval-swift-reworded.json
@@ -1,1368 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "swift",
-    "prompt": "\n/// Return length of given string\n/// >>> strlen(string: \"\")\n/// 0\n/// >>> strlen(string: \"abc\")\n/// 3\nfunc strlen(string: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "swift",
-    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(s: \"hi\")\n/// \"lm\"\n/// >>> encrypt(s: \"asdfghjkl\")\n/// \"ewhjklnop\"\n/// >>> encrypt(s: \"gf\")\n/// \"kj\"\n/// >>> encrypt(s: \"et\")\n/// \"ix\"\nfunc encrypt(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(lst: [4, 2, 6, 7])\n/// 2\nfunc add(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "swift",
-    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(text: \" Example\")\n/// \"Example\"\n/// >>> fix_spaces(text: \" Example 1\")\n/// \"Example_1\"\n/// >>> fix_spaces(text: \" Example 2\")\n/// \"_Example_2\"\n/// >>> fix_spaces(text: \" Example 3\")\n/// \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "swift",
-    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(n: 1)\n/// 0\n/// >>> fibfib(n: 5)\n/// 4\n/// >>> fibfib(n: 8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "swift",
-    "prompt": "\n/// Given an array of numbers, return the sum of squares of the numbers\n/// in the array that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(lst: [1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(lst: [-1, -2, 0])\n/// 0\n/// >>> double_the_difference(lst: [9, -2])\n/// 81\n/// >>> double_the_difference(lst: [0])\n/// 0\n/// If the input array is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "swift",
-    "prompt": "\n/// Filter given array of any swiftthon values only for integers\n/// >>> filter_integers(values: [\"a\", 3.14, 5])\n/// [5]\n/// >>> filter_integers(values: [1, 2, 3, \"abc\", [:] as [AnyHashable : AnyHashable], [] as [AnyHashable]])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "swift",
-    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return array of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(music_string: \"o o| .| o| o| .| .| .| .| o o\")\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(decimal: 15)\n/// \"db1111db\"\n/// >>> decimal_to_binary(decimal: 32)\n/// \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "swift",
-    "prompt": "\n/// Return array of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(string: \"abc\")\n/// [\"a\", \"ab\", \"abc\"]\nfunc all_prefixes(string: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "swift",
-    "prompt": "\n/// Add two numbers x and y\n/// >>> add(x: 2, y: 3)\n/// 5\n/// >>> add(x: 5, y: 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "swift",
-    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(number: 5, need: 6, remaining: 10)\n/// [11, 4]\n/// >>> eat(number: 4, need: 8, remaining: 9)\n/// [12, 1]\n/// >>> eat(number: 1, need: 10, remaining: 10)\n/// [11, 0]\n/// >>> eat(number: 2, need: 11, remaining: 5)\n/// [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "swift",
-    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "swift",
-    "prompt": "\n/// Given two arrays operator, and operand. The first array has basic algebra operations, and \n/// the second array is an array of integers. Use the two given arrays to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator array is equal to the length of operand array minus one.\n/// Operand is an array of of non-negative integers.\n/// Operator array has at least one operator, and operand array has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "swift",
-    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(string: \"Hello\")\n/// \"hELLO\"\nfunc flip_case(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "swift",
-    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3])\n/// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// >>> by_length(arr: [] as [Int])\n/// [] as [String]\n/// If the array has any strange number ignore it:\n/// >>> by_length(arr: [1, -1, 55])\n/// [\"One\"]\nfunc by_length(arr: [Int]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "swift",
-    "prompt": "\n/// Return array of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(n: 8)\n/// [2, 2, 2]\n/// >>> factorize(n: 25)\n/// [5, 5]\n/// >>> factorize(n: 70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "swift",
-    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(n: 5)\n/// [2, 3]\n/// >>> count_up_to(n: 11)\n/// [2, 3, 5, 7]\n/// >>> count_up_to(n: 0)\n/// [] as [Int]\n/// >>> count_up_to(n: 20)\n/// [2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(n: 1)\n/// [] as [Int]\n/// >>> count_up_to(n: 18)\n/// [2, 3, 5, 7, 11, 13, 17]\nfunc count_up_to(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique elements in an array\n/// >>> unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts two arrays of strings and returns the array that has \n/// total number of chars in the all strings of the array less than the other array.\n/// if the two arrays have the same number of chars, return the first array.\n/// Examples\n/// >>> total_match(lst1: [] as [String], lst2: [] as [String])\n/// [] as [String]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"])\n/// [\"hI\", \"Hi\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"])\n/// [\"hi\", \"admin\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"])\n/// [\"hI\", \"hi\", \"hi\"]\n/// >>> total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"])\n/// [\"4\"]\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "swift",
-    "prompt": "\n/// Return maximum element in the array.\n/// >>> max_element(l: [1, 2, 3])\n/// 3\n/// >>> max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return true if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(string: \"[[]]\")\n/// true\n/// >>> is_nested(string: \"[]]]]]]][[[[[]\")\n/// false\n/// >>> is_nested(string: \"[][]\")\n/// false\n/// >>> is_nested(string: \"[]\")\n/// false\n/// >>> is_nested(string: \"[[][]]\")\n/// true\n/// >>> is_nested(string: \"[[]][[\")\n/// true\nfunc is_nested(string: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// >>> rounded_avg(n: 1, m: 5)\n/// .success(\"0b11\")\n/// >>> rounded_avg(n: 7, m: 5)\n/// .failure(-1)\n/// >>> rounded_avg(n: 10, m: 20)\n/// .success(\"0b1111\")\n/// >>> rounded_avg(n: 20, m: 33)\n/// .success(\"0b11010\")\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given an array of strings, where each string consists of only digits, return an array.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(lst: [\"1234567\"])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(lst: [\"3\", \"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "swift",
-    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return true else return false.\n/// If the given array is empty then return true.\n/// Note: The given array is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(arr: [3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(arr: [3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(n: 3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(n: 12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "swift",
-    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(n: 4)\n/// false\n/// >>> is_equal_to_sum_even(n: 6)\n/// false\n/// >>> is_equal_to_sum_even(n: 8)\n/// true\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "swift",
-    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(xs: [3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative(xs: [1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "swift",
-    "prompt": "\n/// Given an array of numbers, return whether or not they are sorted\n/// in ascending order. If array has more than 1 duplicate of the same\n/// number, return false. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(lst: [5])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(lst: [1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(lst: [1, 2, 2, 2, 3, 4])\n/// false\nfunc is_sorted(lst: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(s: \"1234\")\n/// \"4321\"\n/// >>> solve(s: \"ab\")\n/// \"AB\"\n/// >>> solve(s: \"#a@C\")\n/// \"#A@c\"\nfunc solve(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "swift",
-    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return an array of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(n: 3)\n/// [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "swift",
-    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(n: 50)\n/// 0\n/// >>> fizz_buzz(n: 78)\n/// 2\n/// >>> fizz_buzz(n: 79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "swift",
-    "prompt": "\n/// Filter an input array of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(strings: [] as [String], prefix: \"a\")\n/// [] as [String]\n/// >>> filter_by_prefix(strings: [\"abc\", \"bcd\", \"cde\", \"array\"], prefix: \"a\")\n/// [\"abc\", \"array\"]\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(N: 1000)\n/// \"1\"\n/// >>> solve(N: 150)\n/// \"110\"\n/// >>> solve(N: 147)\n/// \"1100\"\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "swift",
-    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered arrays of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered array of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3)\n/// [1, 2, 1]\n/// >>> minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1)\n/// [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "swift",
-    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(s: \"aBCdEf\")\n/// 1\n/// >>> count_upper(s: \"abcdefg\")\n/// 0\n/// >>> count_upper(s: \"dBBE\")\n/// 0\nfunc count_upper(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted array \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(arr: [-3, -4, 5], k: 3)\n/// [-4, -3, 5]\n/// Example 2:\n/// >>> maximum(arr: [4, -4, 4], k: 2)\n/// [4, 4]\n/// Example 3:\n/// >>> maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1)\n/// [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "swift",
-    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(n: 15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "swift",
-    "prompt": "\n/// Given an array of non-negative integers, return a coswift of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(array: [] as [Int])\n/// [] as [Int]\n/// >>> sort_array(array: [5])\n/// [5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5])\n/// [0, 1, 2, 3, 4, 5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5, 6])\n/// [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "swift",
-    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(n: 5)\n/// [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an integer a and returns true \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(a: 1)\n/// true\n/// >>> iscube(a: 2)\n/// false\n/// >>> iscube(a: -1)\n/// true\n/// >>> iscube(a: 64)\n/// true\n/// >>> iscube(a: 0)\n/// true\n/// >>> iscube(a: 180)\n/// false\nfunc iscube(a: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(message: \"test\")\n/// \"TGST\"\n/// >>> encode(message: \"This is a message\")\n/// \"tHKS KS C MGSSCGG\"\nfunc encode(message: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "swift",
-    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(S: \"Hello world\")\n/// 0\n/// >>> is_bored(S: \"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// pairs_sum_to_zero takes an array of integers as an input.\n/// it returns true if there are two distinct elements in the array that\n/// sum to zero, and false otherwise.\n/// >>> pairs_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(l: [1])\n/// false\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(a: 3, b: 4, c: 5)\n/// 6.0\n/// >>> triangle_area(a: 1, b: 2, c: 10)\n/// -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(n: 1)\n/// 1\n/// >>> digits(n: 4)\n/// 0\n/// >>> digits(n: 235)\n/// 15\nfunc digits(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "swift",
-    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(s: \"Hi, my name is John\")\n/// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// >>> words_string(s: \"One, two, three, four, five, six\")\n/// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "swift",
-    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(string: \"\", substring: \"a\")\n/// 0\n/// >>> how_many_times(string: \"aaa\", substring: \"a\")\n/// 3\n/// >>> how_many_times(string: \"aaaa\", substring: \"aa\")\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return nil if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// >>> compare_one(a: .intValue(1), b: .doubleValue(2.5))\n/// .doubleValue(2.5)\n/// >>> compare_one(a: .intValue(1), b: .stringValue(\"2,3\"))\n/// .stringValue(\"2,3\")\n/// >>> compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\"))\n/// .stringValue(\"6\")\n/// >>> compare_one(a: .stringValue(\"1\"), b: .intValue(1))\n/// nil\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "swift",
-    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(text: \"\")\n/// \"\"\n/// >>> remove_vowels(text: \"abcdef\")\n/// \"bcdf\"\n/// >>> remove_vowels(text: \"aaaaa\")\n/// \"\"\n/// >>> remove_vowels(text: \"aaBAA\")\n/// \"B\"\n/// >>> remove_vowels(text: \"zbcd\")\n/// \"zbcd\"\nfunc remove_vowels(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "swift",
-    "prompt": "\n/// Given array of integers, return array in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(lst: [1, 2, 3, 4])\n/// [1, 4, 2, 3]\n/// >>> strange_sort_list(lst: [5, 5, 5, 5])\n/// [5, 5, 5, 5]\n/// >>> strange_sort_list(lst: [] as [Int])\n/// [] as [Int]\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "swift",
-    "prompt": "\n/// From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "swift",
-    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(x: 1, n: 4)\n/// true\n/// >>> is_simple_power(x: 2, n: 2)\n/// true\n/// >>> is_simple_power(x: 8, n: 2)\n/// true\n/// >>> is_simple_power(x: 3, n: 2)\n/// false\n/// >>> is_simple_power(x: 3, n: 1)\n/// false\n/// >>> is_simple_power(x: 5, n: 3)\n/// false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "swift",
-    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(n: 1)\n/// 2\n/// >>> prime_fib(n: 2)\n/// 3\n/// >>> prime_fib(n: 3)\n/// 5\n/// >>> prime_fib(n: 4)\n/// 13\n/// >>> prime_fib(n: 5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "swift",
-    "prompt": "\n/// Write a function which sorts the given array of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original array.\n/// For example:\n/// >>> order_by_points(nums: [1, 11, -1, -11, -12])\n/// [-1, -11, 1, -12, 11]\n/// >>> order_by_points(nums: [] as [Int])\n/// [] as [Int]\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "swift",
     "prompt": "\n/// Check if in given array of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements(numbers: [1.0, 2.0, 3.0], threshold: 0.5)\n/// false\n/// >>> has_close_elements(numbers: [1.0, 2.8, 3.0, 4.0, 5.0, 2.0], threshold: 0.3)\n/// true\nfunc has_close_elements(numbers: [Double], threshold: Double) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.3) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.05) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.95) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.8) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0], threshold: 0.1) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 1.0) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 0.5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(string: \"\")\n/// \"\"\n/// >>> make_palindrome(string: \"cat\")\n/// \"catac\"\n/// >>> make_palindrome(string: \"cata\")\n/// \"catac\"\nfunc make_palindrome(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "swift",
-    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(a: \"010\", b: \"110\")\n/// \"100\"\nfunc string_xor(a: String, b: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "swift",
-    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(n: 4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "swift",
-    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(n: 5)\n/// 4\n/// >>> fib4(n: 6)\n/// 8\n/// >>> fib4(n: 7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "swift",
-    "prompt": "\n/// Given an array of positive integers x. return a sorted array of all \n/// elements that hasn't any even digit.\n/// Note: Returned array should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(x: [15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits(x: [152, 323, 1422, 10])\n/// [] as [Int]\nfunc unique_digits(x: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "swift",
-    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns an array of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty array.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(s: \"Mary had a little lamb\", n: 4)\n/// [\"little\"]\n/// >>> select_words(s: \"Mary had a little lamb\", n: 3)\n/// [\"Mary\", \"lamb\"]\n/// >>> select_words(s: \"simple white space\", n: 2)\n/// [] as [String]\n/// >>> select_words(s: \"Hello world\", n: 4)\n/// [\"world\"]\n/// >>> select_words(s: \"Uncle sam\", n: 3)\n/// [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns true if the object q will fly, and false otherwise.\n/// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(q: [1, 2], w: 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(q: [3, 2, 3], w: 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(q: [3, 2, 3], w: 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(q: [3], w: 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "swift",
-    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(n: 10)\n/// 55\n/// >>> fib(n: 1)\n/// 1\n/// >>> fib(n: 8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "swift",
-    "prompt": "\n/// You will be given the name of a class (a string) and an array of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the array.\n/// For example, if you are given \"Slices\" as the class and an array of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(class_name: \"my_class\", extensions: [\"AA\", \"Be\", \"CC\"])\n/// \"my_class.AA\"\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "swift",
-    "prompt": "\n/// You are given an array of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(lst: [\"()(\", \")\"])\n/// \"Yes\"\n/// >>> match_parens(lst: [\")\", \")\"])\n/// \"No\"\nfunc match_parens(lst: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "swift",
-    "prompt": "\n/// You are given an array of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the array.\n/// Return nil if there is no such element.\n/// >>> next_smallest(lst: [1, 2, 3, 4, 5])\n/// 2\n/// >>> next_smallest(lst: [5, 1, 4, 3, 2])\n/// 2\n/// >>> next_smallest(lst: [] as [Int])\n/// nil\n/// >>> next_smallest(lst: [1, 1])\n/// nil\nfunc next_smallest(lst: [Int]) -> Int? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(x: 5, y: 2, z: 7)\n/// true\n/// >>> any_int(x: 3, y: 2, z: 2)\n/// false\n/// >>> any_int(x: 3, y: -2, z: 1)\n/// true\n/// >>> any_int(x: 3.6, y: -2.2, z: 2)\n/// false\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "swift",
-    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(number: 3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "swift",
-    "prompt": "\n/// Return array with elements incremented by 1.\n/// >>> incr_list(l: [1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "swift",
-    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(n: 7, x: 34, y: 12)\n/// 34\n/// >>> x_or_y(n: 15, x: 8, y: 5)\n/// 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "swift",
-    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(n: 3, p: 5)\n/// 3\n/// >>> modp(n: 1101, p: 101)\n/// 2\n/// >>> modp(n: 0, p: 101)\n/// 1\n/// >>> modp(n: 3, p: 11)\n/// 8\n/// >>> modp(n: 100, p: 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(num: -12)\n/// (1, 1)\n/// >>> even_odd_count(num: 123)\n/// (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is hapswift or not.\n/// A string is hapswift if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(s: \"a\")\n/// false\n/// >>> is_happy(s: \"aa\")\n/// false\n/// >>> is_happy(s: \"abcd\")\n/// true\n/// >>> is_happy(s: \"aabb\")\n/// false\n/// >>> is_happy(s: \"adb\")\n/// true\n/// >>> is_happy(s: \"xyy\")\n/// false\nfunc is_happy(s: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "swift",
-    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(n: 13195)\n/// 29\n/// >>> largest_prime_factor(n: 2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "swift",
-    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(s: \"\")\n/// 0\n/// >>> digitSum(s: \"abAB\")\n/// 131\n/// >>> digitSum(s: \"abcCd\")\n/// 67\n/// >>> digitSum(s: \"helloE\")\n/// 69\n/// >>> digitSum(s: \"woArBld\")\n/// 131\n/// >>> digitSum(s: \"aAaaaXa\")\n/// 153\nfunc digitSum(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "swift",
-    "prompt": "\n/// Given array of numbers (of at least two elements), apply a linear transform to that array,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(lst: [5, 8, 7, 1])\n/// 12\n/// >>> solution(lst: [3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(lst: [30, 13, 24, 321])\n/// 0\nfunc solution(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "swift",
-    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in an array, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(arr: [4, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(arr: [1, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(arr: [] as [Int])\n/// [] as [Int]\n/// Example 4:\n/// >>> pluck(arr: [5, 0, 3, 0, 4, 2])\n/// [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "swift",
-    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(n: 5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "swift",
-    "prompt": "\n/// In this problem, you will implement a function that takes two arrays of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 an array of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4])\n/// \"YES\"\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4])\n/// \"NO\"\n/// It is assumed that the input arrays will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "swift",
-    "prompt": "\n/// Return median of elements in the array l.\n/// >>> median(l: [3, 1, 2, 4, 5])\n/// 3\n/// >>> median(l: [-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns true if the string\n/// length is a prime number or false otherwise\n/// Examples\n/// >>> prime_length(string: \"Hello\")\n/// true\n/// >>> prime_length(string: \"abcdcba\")\n/// true\n/// >>> prime_length(string: \"kittens\")\n/// true\n/// >>> prime_length(string: \"orange\")\n/// false\nfunc prime_length(string: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(arr: [1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(arr: [1, 2, 3, 2, 1])\n/// 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// You are given an array of numbers.\n/// You need to return the sum of squared numbers in the given array,\n/// round each element in the array to the upper int(Ceiling) first.\n/// Examples:\n/// >>> sum_squares(lst: [1.0, 2.0, 3.0])\n/// 14\n/// >>> sum_squares(lst: [1.0, 4.0, 9.0])\n/// 98\n/// >>> sum_squares(lst: [1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> sum_squares(lst: [1.4, 4.2, 0.0])\n/// 29\n/// >>> sum_squares(lst: [-2.4, 1.0, 1.0])\n/// 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "swift",
-    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(file_name: \"example.txt\")\n/// \"Yes\"\n/// >>> file_name_check(file_name: \"1example.dll\")\n/// \"No\"\nfunc file_name_check(file_name: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// triples_sum_to_zero takes an array of integers as an input.\n/// it returns true if there are three distinct elements in the array that\n/// sum to zero, and false otherwise.\n/// >>> triples_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(l: [1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(l: [1])\n/// false\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "swift",
-    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection(interval1: (1, 2), interval2: (2, 3))\n/// \"NO\"\n/// >>> intersection(interval1: (-1, 1), interval2: (0, 4))\n/// \"NO\"\n/// >>> intersection(interval1: (-3, -1), interval2: (-5, 5))\n/// \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the array of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\")\n/// [\"()\", \"(())\", \"(()())\"]\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "swift",
-    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2])\n/// [0, 0, 0, 0, 3, 3]\n/// >>> compare(game: [0, 5, 0, 0, 0, 4], guess: [4, 1, 1, 0, 0, -2])\n/// [4, 4, 1, 0, 0, 6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns true if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and false otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pie\")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e\")\n/// true\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e \")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"\")\n/// false\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "swift",
-    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns true if the date is valid otherwise false.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(date: \"03-11-2000\")\n/// true\n/// >>> valid_date(date: \"15-01-2012\")\n/// false\n/// >>> valid_date(date: \"04-0-2040\")\n/// false\n/// >>> valid_date(date: \"06-04-2020\")\n/// true\n/// >>> valid_date(date: \"06/04/2020\")\n/// false\nfunc valid_date(date: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(arr: [] as [Int])\n/// 0\n/// >>> count_nums(arr: [-1, 11, -11])\n/// 1\n/// >>> count_nums(arr: [1, 1, 2])\n/// 3\nfunc count_nums(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(s: \"Hi\")\n/// \"Hi\"\n/// >>> anti_shuffle(s: \"hello\")\n/// \"ehllo\"\n/// >>> anti_shuffle(s: \"Hello World!!!\")\n/// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome(text: \"\")\n/// true\n/// >>> is_palindrome(text: \"aba\")\n/// true\n/// >>> is_palindrome(text: \"aaaaa\")\n/// true\n/// >>> is_palindrome(text: \"zbcd\")\n/// false\nfunc is_palindrome(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "swift",
-    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(word: \"yogurt\")\n/// \"u\"\n/// >>> get_closest_vowel(word: \"FULL\")\n/// \"U\"\n/// >>> get_closest_vowel(word: \"quick\")\n/// \"\"\n/// >>> get_closest_vowel(word: \"ab\")\n/// \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "swift",
-    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(n: 6)\n/// false\n/// >>> is_prime(n: 101)\n/// true\n/// >>> is_prime(n: 11)\n/// true\n/// >>> is_prime(n: 13441)\n/// true\n/// >>> is_prime(n: 61)\n/// true\n/// >>> is_prime(n: 4)\n/// false\n/// >>> is_prime(n: 1)\n/// false\nfunc is_prime(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "swift",
-    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns true if x * n evaluates to a whole number and false\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(x: \"1/5\", n: \"5/1\")\n/// true\n/// >>> simplify(x: \"1/6\", n: \"2/1\")\n/// false\n/// >>> simplify(x: \"7/10\", n: \"10/2\")\n/// false\nfunc simplify(x: String, n: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "swift",
-    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(num: \"AB\")\n/// 1\n/// >>> hex_key(num: \"1077E\")\n/// 2\n/// >>> hex_key(num: \"ABED1A33\")\n/// 4\n/// >>> hex_key(num: \"123456789ABCDEF0\")\n/// 6\n/// >>> hex_key(num: \"2020\")\n/// 2\nfunc hex_key(num: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "swift",
-    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(sentence: \"This is a test\")\n/// \"is\"\n/// Example 2:\n/// >>> words_in_sentence(sentence: \"lets go for swimming\")\n/// \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "swift",
-    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(test: \"a b c\")\n/// [\"a\" : 1, \"b\" : 1, \"c\" : 1]\n/// >>> histogram(test: \"a b b a\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"a b c a b\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"b b b b a\")\n/// [\"b\" : 4]\n/// >>> histogram(test: \"\")\n/// [:] as [String : Int]\nfunc histogram(test: String) -> [String : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "swift",
-    "prompt": "\n/// You are given a 2 dimensional data, as a nested arrays,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the array,\n/// and return array of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1)\n/// [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(lst: [] as [[Int]], x: 1)\n/// [] as [(Int, Int)]\n/// >>> get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3)\n/// [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned array sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(n: 5)\n/// [1, 5]\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "swift",
-    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(arr: [1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(arr: [1, 2, 3])\n/// -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "swift",
-    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(numbers: \"three one five\")\n/// \"one three five\"\nfunc sort_numbers(numbers: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "swift",
-    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(x: 12, shift: 1)\n/// \"21\"\n/// >>> circular_shift(x: 12, shift: 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "swift",
-    "prompt": "\n/// You are given an array of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(lst: [0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(lst: [0, 8, 1, 2, 1, 7])\n/// 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "swift",
-    "prompt": "\n/// For a given array of integers, return a tuple consisting of a sum and a product of all the integers in an array.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(numbers: [] as [Int])\n/// (0, 1)\n/// >>> sum_product(numbers: [1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "swift",
-    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(x: 12, y: 15)\n/// 14\n/// >>> choose_num(x: 13, y: 12)\n/// -1\nfunc choose_num(x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in an array.\n/// If there is no negative or positive integers, return them as nil.\n/// Examples:\n/// >>> largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7])\n/// (nil, 1)\n/// >>> largest_smallest_integers(lst: [] as [Int])\n/// (nil, nil)\n/// >>> largest_smallest_integers(lst: [0])\n/// (nil, nil)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "swift",
-    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(string: \"xyzXYZ\")\n/// 3\n/// >>> count_distinct_characters(string: \"Jerry\")\n/// 4\nfunc count_distinct_characters(string: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1372,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in an array, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(n: 3)\n/// [3, 5, 7]\nfunc make_a_pile(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_a_pile(n: 3) == [3, 5, 7])\nassert(make_a_pile(n: 4) == [4, 6, 8, 10])\nassert(make_a_pile(n: 5) == [5, 7, 9, 11, 13])\nassert(make_a_pile(n: 6) == [6, 8, 10, 12, 14, 16])\nassert(make_a_pile(n: 8) == [8, 10, 12, 14, 16, 18, 20, 22])",
     "stop_tokens": [
@@ -1380,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "swift",
-    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return nil for empty arr.\n/// Example:\n/// >>> prod_signs(arr: [1, 2, 2, -4])\n/// 9\n/// >>> prod_signs(arr: [0, 1])\n/// 0\n/// >>> prod_signs(arr: [] as [Int])\n/// nil\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(s: \"Hi, my name is John\")\n/// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// >>> words_string(s: \"One, two, three, four, five, six\")\n/// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "swift",
-    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(nums: [2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(nums: [-1, -2, -3])\n/// -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
+    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(x: 12, y: 15)\n/// 14\n/// >>> choose_num(x: 13, y: 12)\n/// -1\nfunc choose_num(x: Int, y: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "swift",
-    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(n: 0)\n/// \"0\"\n/// >>> string_sequence(n: 5)\n/// \"0 1 2 3 4 5\"\nfunc string_sequence(n: Int) -> String {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// >>> rounded_avg(n: 1, m: 5)\n/// .success(\"0b11\")\n/// >>> rounded_avg(n: 7, m: 5)\n/// .failure(-1)\n/// >>> rounded_avg(n: 10, m: 20)\n/// .success(\"0b1111\")\n/// >>> rounded_avg(n: 20, m: 33)\n/// .success(\"0b11010\")\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "swift",
-    "prompt": "\n/// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(a: \"abcd\", b: \"abd\")\n/// false\n/// >>> cycpattern_check(a: \"hello\", b: \"ell\")\n/// true\n/// >>> cycpattern_check(a: \"whassup\", b: \"psus\")\n/// false\n/// >>> cycpattern_check(a: \"abab\", b: \"baa\")\n/// true\n/// >>> cycpattern_check(a: \"efef\", b: \"eeff\")\n/// false\n/// >>> cycpattern_check(a: \"himenss\", b: \"simen\")\n/// true\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "prompt": "\n/// Given an array of positive integers x. return a sorted array of all \n/// elements that hasn't any even digit.\n/// Note: Returned array should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(x: [15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits(x: [152, 323, 1422, 10])\n/// [] as [Int]\nfunc unique_digits(x: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "swift",
-    "prompt": "\n/// Return true is array elements are monotonically increasing or decreasing.\n/// >>> monotonic(l: [1, 2, 4, 20])\n/// true\n/// >>> monotonic(l: [1, 20, 4, 10])\n/// false\n/// >>> monotonic(l: [4, 1, 0, -10])\n/// true\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3])\n/// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// >>> by_length(arr: [] as [Int])\n/// [] as [String]\n/// If the array has any strange number ignore it:\n/// >>> by_length(arr: [1, -1, 55])\n/// [\"One\"]\nfunc by_length(arr: [Int]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "swift",
-    "prompt": "\n/// Out of array of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return nil in case the input array is empty.\n/// >>> longest(strings: [] as [String])\n/// nil\n/// >>> longest(strings: [\"a\", \"b\", \"c\"])\n/// \"a\"\n/// >>> longest(strings: [\"a\", \"bb\", \"ccc\"])\n/// \"ccc\"\nfunc longest(strings: [String]) -> String? {\n",
+    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(n: 5)\n/// [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "swift",
-    "prompt": "\n/// Return true if all numbers in the array l are below threshold t.\n/// >>> below_threshold(l: [1, 2, 4, 10], t: 100)\n/// true\n/// >>> below_threshold(l: [1, 20, 4, 10], t: 5)\n/// false\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(n: 3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(n: 12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "swift",
-    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(a: 30)\n/// true\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(arr: [] as [Int])\n/// 0\n/// >>> count_nums(arr: [-1, 11, -11])\n/// 1\n/// >>> count_nums(arr: [1, 1, 2])\n/// 3\nfunc count_nums(arr: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "swift",
-    "prompt": "\n/// Return only positive numbers in the array.\n/// >>> get_positive(l: [-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return true else return false.\n/// If the given array is empty then return true.\n/// Note: The given array is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(arr: [3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(arr: [3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "swift",
-    "prompt": "\n/// This function takes an array l and returns an array l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third(l: [5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(string: \"\")\n/// \"\"\n/// >>> make_palindrome(string: \"cat\")\n/// \"catac\"\n/// >>> make_palindrome(string: \"cata\")\n/// \"catac\"\nfunc make_palindrome(string: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "swift",
-    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\")\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "prompt": "\n/// In this problem, you will implement a function that takes two arrays of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 an array of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4])\n/// \"YES\"\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4])\n/// \"NO\"\n/// It is assumed that the input arrays will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "swift",
-    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(a: 5, h: 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(test: \"a b c\")\n/// [\"a\" : 1, \"b\" : 1, \"c\" : 1]\n/// >>> histogram(test: \"a b b a\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"a b c a b\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"b b b b a\")\n/// [\"b\" : 4]\n/// >>> histogram(test: \"\")\n/// [:] as [String : Int]\nfunc histogram(test: String) -> [String : Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "swift",
-    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(a: 148, b: 412)\n/// 16\n/// >>> multiply(a: 19, b: 28)\n/// 72\n/// >>> multiply(a: 2020, b: 1851)\n/// 0\n/// >>> multiply(a: 14, b: -15)\n/// 20\nfunc multiply(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "swift",
-    "prompt": "\n/// For a given array of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique common elements for two arrays.\n/// >>> common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common(l1: [5, 3, 2, 8], l2: [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(number: 19)\n/// \"xix\"\n/// >>> int_to_mini_roman(number: 152)\n/// \"clii\"\n/// >>> int_to_mini_roman(number: 426)\n/// \"cdxxvi\"\nfunc int_to_mini_roman(number: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "swift",
-    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(s: \"5 apples and 6 oranges\", n: 19)\n/// 8\n/// >>> fruit_distribution(s: \"0 apples and 1 oranges\", n: 3)\n/// 2\n/// >>> fruit_distribution(s: \"2 apples and 3 oranges\", n: 100)\n/// 95\n/// >>> fruit_distribution(s: \"100 apples and 1 oranges\", n: 120)\n/// 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1588,7 +172,7 @@
     "language": "swift",
     "prompt": "\n/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and true/false for the check.\n/// Example\n/// >>> reverse_delete(s: \"abcde\", c: \"ae\")\n/// (\"bcd\", false)\n/// >>> reverse_delete(s: \"abcdef\", c: \"b\")\n/// (\"acdef\", false)\n/// >>> reverse_delete(s: \"abcdedcba\", c: \"ab\")\n/// (\"cdedc\", true)\nfunc reverse_delete(s: String, c: String) -> (String, Bool) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_delete(s: \"abcde\", c: \"ae\") == (\"bcd\", false))\nassert(reverse_delete(s: \"abcdef\", c: \"b\") == (\"acdef\", false))\nassert(reverse_delete(s: \"abcdedcba\", c: \"ab\") == (\"cdedc\", true))\nassert(reverse_delete(s: \"dwik\", c: \"w\") == (\"dik\", false))\nassert(reverse_delete(s: \"a\", c: \"a\") == (\"\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"v\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"vabba\", c: \"v\") == (\"abba\", true))\nassert(reverse_delete(s: \"mamma\", c: \"mia\") == (\"\", true))",
     "stop_tokens": [
@@ -1596,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "swift",
-    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(a: 3, b: 5)\n/// 1\n/// >>> greatest_common_divisor(a: 25, b: 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "prompt": "\n/// Given an array of strings, where each string consists of only digits, return an array.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(lst: [\"1234567\"])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(lst: [\"3\", \"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// >>> split_words(txt: \"Hello world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"Hello,world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"abcdef\")\n/// .failure(3)\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
+    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(nums: [2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(nums: [-1, -2, -3])\n/// -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "swift",
+    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +220,7 @@
     "language": "swift",
     "prompt": "\n/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array(arr: [1, 5, 2, 3, 4])\n/// [1, 2, 3, 4, 5]\n/// >>> sort_array(arr: [-2, -3, -4, -5, -6])\n/// [-6, -5, -4, -3, -2]\n/// >>> sort_array(arr: [1, 0, 2, 3, 4])\n/// [0, 1, 2, 3, 4]\nfunc sort_array(arr: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(arr: [1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\nassert(sort_array(arr: [-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\nassert(sort_array(arr: [1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\nassert(sort_array(arr: [] as [Int]) == [] as [Int])\nassert(sort_array(arr: [2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\nassert(sort_array(arr: [3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])",
     "stop_tokens": [
@@ -1632,133 +228,373 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "swift",
-    "prompt": "\n/// Concatenate array of strings into a single string\n/// >>> concatenate(strings: [] as [String])\n/// \"\"\n/// >>> concatenate(strings: [\"a\", \"b\", \"c\"])\n/// \"abc\"\nfunc concatenate(strings: [String]) -> String {\n",
+    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns an array of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty array.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(s: \"Mary had a little lamb\", n: 4)\n/// [\"little\"]\n/// >>> select_words(s: \"Mary had a little lamb\", n: 3)\n/// [\"Mary\", \"lamb\"]\n/// >>> select_words(s: \"simple white space\", n: 2)\n/// [] as [String]\n/// >>> select_words(s: \"Hello world\", n: 4)\n/// [\"world\"]\n/// >>> select_words(s: \"Uncle sam\", n: 3)\n/// [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts an array of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted array with a sorted order,\n/// The array is always an array of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the array should be ascending by length of each word, and you\n/// should return the array sorted by that rule.\n/// If two words have the same length, sort the array alphabetically.\n/// The function should return an array of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"])\n/// [\"aa\"]\n/// >>> sorted_list_sum(lst: [\"ab\", \"a\", \"aaa\", \"cd\"])\n/// [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
+    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(word: \"yogurt\")\n/// \"u\"\n/// >>> get_closest_vowel(word: \"FULL\")\n/// \"U\"\n/// >>> get_closest_vowel(word: \"quick\")\n/// \"\"\n/// >>> get_closest_vowel(word: \"ab\")\n/// \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "swift",
-    "prompt": "\n/// Filter an input array of strings only for ones that contain given substring\n/// >>> filter_by_substring(strings: [] as [String], substring: \"a\")\n/// [] as [String]\n/// >>> filter_by_substring(strings: [\"abc\", \"bacd\", \"cde\", \"array\"], substring: \"a\")\n/// [\"abc\", \"bacd\", \"array\"]\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "prompt": "\n/// You are given an array of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(lst: [\"()(\", \")\"])\n/// \"Yes\"\n/// >>> match_parens(lst: [\")\", \")\"])\n/// \"No\"\nfunc match_parens(lst: [String]) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "swift",
-    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(value: \"10\")\n/// 10\n/// >>> closest_integer(value: \"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(a: \"010\", b: \"110\")\n/// \"100\"\nfunc string_xor(a: String, b: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "swift",
-    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(s: \"abcde\")\n/// 2\n/// >>> vowels_count(s: \"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
+    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted array \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(arr: [-3, -4, 5], k: 3)\n/// [-4, -3, 5]\n/// Example 2:\n/// >>> maximum(arr: [4, -4, 4], k: 2)\n/// [4, 4]\n/// Example 3:\n/// >>> maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1)\n/// [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts an array of strings.\n/// The array contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(words: [\"name\", \"of\", \"string\"])\n/// \"string\"\n/// >>> find_max(words: [\"name\", \"enam\", \"game\"])\n/// \"enam\"\n/// >>> find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"])\n/// \"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
+    "prompt": "\n/// Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(lst: [5, 8, 7, 1])\n/// 12\n/// >>> solution(lst: [3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(lst: [30, 13, 24, 321])\n/// 0\nfunc solution(lst: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "swift",
-    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return nil.\n/// >>> string_to_md5(text: \"Hello world\")\n/// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunc string_to_md5(text: String) -> String? {\n",
+    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "swift",
-    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(x: 8, base: 3)\n/// \"22\"\n/// >>> change_base(x: 8, base: 2)\n/// \"1000\"\n/// >>> change_base(x: 7, base: 2)\n/// \"111\"\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "prompt": "\n/// Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned array sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(n: 5)\n/// [1, 5]\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return true if the three\n/// sides form a right-angled triangle, false otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(a: 3, b: 4, c: 5)\n/// true\n/// >>> right_angle_triangle(a: 1, b: 2, c: 3)\n/// false\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns true if the date is valid otherwise false.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(date: \"03-11-2000\")\n/// true\n/// >>> valid_date(date: \"15-01-2012\")\n/// false\n/// >>> valid_date(date: \"04-0-2040\")\n/// false\n/// >>> valid_date(date: \"06-04-2020\")\n/// true\n/// >>> valid_date(date: \"06/04/2020\")\n/// false\nfunc valid_date(date: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "swift",
-    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you an array of GPAs for some students and you have to write \n/// a function that can output an array of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5])\n/// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// >>> split_words(txt: \"Hello world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"Hello,world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"abcdef\")\n/// .failure(3)\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "swift",
-    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n/// >>> intersperse(numbers: [] as [Int], delimeter: 4)\n/// [] as [Int]\n/// >>> intersperse(numbers: [1, 2, 3], delimeter: 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "prompt": "\n/// Given an array of numbers, return whether or not they are sorted\n/// in ascending order. If array has more than 1 duplicate of the same\n/// number, return false. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(lst: [5])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(lst: [1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(lst: [1, 2, 2, 2, 3, 4])\n/// false\nfunc is_sorted(lst: [Int]) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "swift",
+    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection(interval1: (1, 2), interval2: (2, 3))\n/// \"NO\"\n/// >>> intersection(interval1: (-1, 1), interval2: (0, 4))\n/// \"NO\"\n/// >>> intersection(interval1: (-3, -1), interval2: (-5, 5))\n/// \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "swift",
+    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return nil for empty arr.\n/// Example:\n/// >>> prod_signs(arr: [1, 2, 2, -4])\n/// 9\n/// >>> prod_signs(arr: [0, 1])\n/// 0\n/// >>> prod_signs(arr: [] as [Int])\n/// nil\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "swift",
+    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered arrays of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered array of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3)\n/// [1, 2, 1]\n/// >>> minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1)\n/// [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "swift",
+    "prompt": "\n/// Out of array of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return nil in case the input array is empty.\n/// >>> longest(strings: [] as [String])\n/// nil\n/// >>> longest(strings: [\"a\", \"b\", \"c\"])\n/// \"a\"\n/// >>> longest(strings: [\"a\", \"bb\", \"ccc\"])\n/// \"ccc\"\nfunc longest(strings: [String]) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "swift",
+    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return an array of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(n: 3)\n/// [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(n: 1)\n/// 1\n/// >>> digits(n: 4)\n/// 0\n/// >>> digits(n: 235)\n/// 15\nfunc digits(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return true if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(string: \"[[]]\")\n/// true\n/// >>> is_nested(string: \"[]]]]]]][[[[[]\")\n/// false\n/// >>> is_nested(string: \"[][]\")\n/// false\n/// >>> is_nested(string: \"[]\")\n/// false\n/// >>> is_nested(string: \"[[][]]\")\n/// true\n/// >>> is_nested(string: \"[[]][[\")\n/// true\nfunc is_nested(string: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// You are given an array of numbers.\n/// You need to return the sum of squared numbers in the given array,\n/// round each element in the array to the upper int(Ceiling) first.\n/// Examples:\n/// >>> sum_squares(lst: [1.0, 2.0, 3.0])\n/// 14\n/// >>> sum_squares(lst: [1.0, 4.0, 9.0])\n/// 98\n/// >>> sum_squares(lst: [1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> sum_squares(lst: [1.4, 4.2, 0.0])\n/// 29\n/// >>> sum_squares(lst: [-2.4, 1.0, 1.0])\n/// 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns true if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and false otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pie\")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e\")\n/// true\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e \")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"\")\n/// false\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "swift",
+    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(arr: [1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(arr: [1, 2, 3])\n/// -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in an array.\n/// If there is no negative or positive integers, return them as nil.\n/// Examples:\n/// >>> largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7])\n/// (nil, 1)\n/// >>> largest_smallest_integers(lst: [] as [Int])\n/// (nil, nil)\n/// >>> largest_smallest_integers(lst: [0])\n/// (nil, nil)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return nil if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// >>> compare_one(a: .intValue(1), b: .doubleValue(2.5))\n/// .doubleValue(2.5)\n/// >>> compare_one(a: .intValue(1), b: .stringValue(\"2,3\"))\n/// .stringValue(\"2,3\")\n/// >>> compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\"))\n/// .stringValue(\"6\")\n/// >>> compare_one(a: .stringValue(\"1\"), b: .intValue(1))\n/// nil\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "swift",
+    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(n: 4)\n/// false\n/// >>> is_equal_to_sum_even(n: 6)\n/// false\n/// >>> is_equal_to_sum_even(n: 8)\n/// true\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "swift",
+    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(n: 4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "swift",
+    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(a: 3, b: 5)\n/// 1\n/// >>> greatest_common_divisor(a: 25, b: 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "swift",
+    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(text: \" Example\")\n/// \"Example\"\n/// >>> fix_spaces(text: \" Example 1\")\n/// \"Example_1\"\n/// >>> fix_spaces(text: \" Example 2\")\n/// \"_Example_2\"\n/// >>> fix_spaces(text: \" Example 3\")\n/// \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "swift",
+    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(file_name: \"example.txt\")\n/// \"Yes\"\n/// >>> file_name_check(file_name: \"1example.dll\")\n/// \"No\"\nfunc file_name_check(file_name: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "swift",
+    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(sentence: \"This is a test\")\n/// \"is\"\n/// Example 2:\n/// >>> words_in_sentence(sentence: \"lets go for swimming\")\n/// \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "swift",
+    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns true if x * n evaluates to a whole number and false\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(x: \"1/5\", n: \"5/1\")\n/// true\n/// >>> simplify(x: \"1/6\", n: \"2/1\")\n/// false\n/// >>> simplify(x: \"7/10\", n: \"10/2\")\n/// false\nfunc simplify(x: String, n: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "swift",
+    "prompt": "\n/// Write a function which sorts the given array of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original array.\n/// For example:\n/// >>> order_by_points(nums: [1, 11, -1, -11, -12])\n/// [-1, -11, 1, -12, 11]\n/// >>> order_by_points(nums: [] as [Int])\n/// [] as [Int]\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +604,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// >>> specialFilter(nums: [15, -73, 14, -15])\n/// 1\n/// >>> specialFilter(nums: [33, -2, -3, 45, 21, 109])\n/// 2\nfunc specialFilter(nums: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(specialFilter(nums: [5, -2, 1, -5]) == 0)\nassert(specialFilter(nums: [15, -73, 14, -15]) == 1)\nassert(specialFilter(nums: [33, -2, -3, 45, 21, 109]) == 2)\nassert(specialFilter(nums: [43, -12, 93, 125, 121, 109]) == 4)\nassert(specialFilter(nums: [71, -2, -33, 75, 21, 19]) == 3)\nassert(specialFilter(nums: [1]) == 0)\nassert(specialFilter(nums: [] as [Int]) == 0)",
     "stop_tokens": [
@@ -1776,25 +612,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "swift",
-    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(n: 30)\n/// 465\n/// >>> sum_to_n(n: 100)\n/// 5050\n/// >>> sum_to_n(n: 5)\n/// 15\n/// >>> sum_to_n(n: 10)\n/// 55\n/// >>> sum_to_n(n: 1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
+    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(n: 5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "swift",
-    "prompt": "\n/// From an array of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(numbers: [1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function that accepts an array of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted array with a sorted order,\n/// The array is always an array of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the array should be ascending by length of each word, and you\n/// should return the array sorted by that rule.\n/// If two words have the same length, sort the array alphabetically.\n/// The function should return an array of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"])\n/// [\"aa\"]\n/// >>> sorted_list_sum(lst: [\"ab\", \"a\", \"aaa\", \"cd\"])\n/// [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "swift",
+    "prompt": "\n/// Return array of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(string: \"abc\")\n/// [\"a\", \"ab\", \"abc\"]\nfunc all_prefixes(string: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "swift",
+    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(n: 7, x: 34, y: 12)\n/// 34\n/// >>> x_or_y(n: 15, x: 8, y: 5)\n/// 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "swift",
+    "prompt": "\n/// Given an array of numbers, return the sum of squares of the numbers\n/// in the array that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(lst: [1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(lst: [-1, -2, 0])\n/// 0\n/// >>> double_the_difference(lst: [9, -2])\n/// 81\n/// >>> double_the_difference(lst: [0])\n/// 0\n/// If the input array is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "swift",
+    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2])\n/// [0, 0, 0, 0, 3, 3]\n/// >>> compare(game: [0, 5, 0, 0, 0, 4], guess: [4, 1, 1, 0, 0, -2])\n/// [4, 4, 1, 0, 0, 6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "swift",
+    "prompt": "\n/// You will be given the name of a class (a string) and an array of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the array.\n/// For example, if you are given \"Slices\" as the class and an array of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(class_name: \"my_class\", extensions: [\"AA\", \"Be\", \"CC\"])\n/// \"my_class.AA\"\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "swift",
+    "prompt": "\n/// You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(a: \"abcd\", b: \"abd\")\n/// false\n/// >>> cycpattern_check(a: \"hello\", b: \"ell\")\n/// true\n/// >>> cycpattern_check(a: \"whassup\", b: \"psus\")\n/// false\n/// >>> cycpattern_check(a: \"abab\", b: \"baa\")\n/// true\n/// >>> cycpattern_check(a: \"efef\", b: \"eeff\")\n/// false\n/// >>> cycpattern_check(a: \"himenss\", b: \"simen\")\n/// true\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "swift",
+    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(num: -12)\n/// (1, 1)\n/// >>> even_odd_count(num: 123)\n/// (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(number: 19)\n/// \"xix\"\n/// >>> int_to_mini_roman(number: 152)\n/// \"clii\"\n/// >>> int_to_mini_roman(number: 426)\n/// \"cdxxvi\"\nfunc int_to_mini_roman(number: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return true if the three\n/// sides form a right-angled triangle, false otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(a: 3, b: 4, c: 5)\n/// true\n/// >>> right_angle_triangle(a: 1, b: 2, c: 3)\n/// false\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts an array of strings.\n/// The array contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(words: [\"name\", \"of\", \"string\"])\n/// \"string\"\n/// >>> find_max(words: [\"name\", \"enam\", \"game\"])\n/// \"enam\"\n/// >>> find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"])\n/// \"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "swift",
+    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(number: 5, need: 6, remaining: 10)\n/// [11, 4]\n/// >>> eat(number: 4, need: 8, remaining: 9)\n/// [12, 1]\n/// >>> eat(number: 1, need: 10, remaining: 10)\n/// [11, 0]\n/// >>> eat(number: 2, need: 11, remaining: 5)\n/// [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "swift",
+    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(n: 0)\n/// \"0\"\n/// >>> string_sequence(n: 5)\n/// \"0 1 2 3 4 5\"\nfunc string_sequence(n: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "swift",
+    "prompt": "\n/// Given two arrays operator, and operand. The first array has basic algebra operations, and \n/// the second array is an array of integers. Use the two given arrays to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator array is equal to the length of operand array minus one.\n/// Operand is an array of of non-negative integers.\n/// Operator array has at least one operator, and operand array has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(s: \"1234\")\n/// \"4321\"\n/// >>> solve(s: \"ab\")\n/// \"AB\"\n/// >>> solve(s: \"#a@C\")\n/// \"#A@c\"\nfunc solve(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "swift",
+    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return nil.\n/// >>> string_to_md5(text: \"Hello world\")\n/// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunc string_to_md5(text: String) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +820,7 @@
     "language": "swift",
     "prompt": "\n/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// >>> generate_integers(a: 2, b: 8)\n/// [2, 4, 6, 8]\n/// >>> generate_integers(a: 8, b: 2)\n/// [2, 4, 6, 8]\n/// >>> generate_integers(a: 10, b: 14)\n/// [] as [Int]\nfunc generate_integers(a: Int, b: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(generate_integers(a: 2, b: 10) == [2, 4, 6, 8])\nassert(generate_integers(a: 10, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 132, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 17, b: 89) == [] as [Int])",
     "stop_tokens": [
@@ -1812,49 +828,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "swift",
-    "prompt": "\n/// From a given array of integers, generate an array of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(numbers: [1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(string: \"xyzXYZ\")\n/// 3\n/// >>> count_distinct_characters(string: \"Jerry\")\n/// 4\nfunc count_distinct_characters(string: String) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "swift",
-    "prompt": "\n/// You're given an array of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return true. Otherwise it should return false.\n/// >>> below_zero(operations: [1, 2, 3])\n/// false\n/// >>> below_zero(operations: [1, 2, -4, 5])\n/// true\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return array of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(music_string: \"o o| .| o| o| .| .| .| .| o o\")\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "swift",
-    "prompt": "\n/// You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the array.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(lst: [4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(lst: [1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(lst: [5, 5, 4, 4, 4])\n/// -1\nfunc search(lst: [Int]) -> Int {\n",
+    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(string: \"\", substring: \"a\")\n/// 0\n/// >>> how_many_times(string: \"aaa\", substring: \"a\")\n/// 3\n/// >>> how_many_times(string: \"aaaa\", substring: \"aa\")\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "swift",
-    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"(\")\n/// false\n/// >>> correct_bracketing(brackets: \"()\")\n/// true\n/// >>> correct_bracketing(brackets: \"(()())\")\n/// true\n/// >>> correct_bracketing(brackets: \")(()\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(numbers: \"three one five\")\n/// \"one three five\"\nfunc sort_numbers(numbers: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the array of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\")\n/// [\"()\", \"(())\", \"(()())\"]\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "swift",
+    "prompt": "\n/// From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "swift",
+    "prompt": "\n/// Given array of numbers (of at least two elements), apply a linear transform to that array,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "swift",
+    "prompt": "\n/// Filter given array of any swiftthon values only for integers\n/// >>> filter_integers(values: [\"a\", 3.14, 5])\n/// [5]\n/// >>> filter_integers(values: [1, 2, 3, \"abc\", [:] as [AnyHashable : AnyHashable], [] as [AnyHashable]])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "swift",
+    "prompt": "\n/// Return length of given string\n/// >>> strlen(string: \"\")\n/// 0\n/// >>> strlen(string: \"abc\")\n/// 3\nfunc strlen(string: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "swift",
+    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(n: 15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "swift",
+    "prompt": "\n/// Return array of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(n: 8)\n/// [2, 2, 2]\n/// >>> factorize(n: 25)\n/// [5, 5]\n/// >>> factorize(n: 70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "swift",
+    "prompt": "\n/// From an array of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(numbers: [1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "swift",
+    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(string: \"Hello\")\n/// \"hELLO\"\nfunc flip_case(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "swift",
+    "prompt": "\n/// Concatenate array of strings into a single string\n/// >>> concatenate(strings: [] as [String])\n/// \"\"\n/// >>> concatenate(strings: [\"a\", \"b\", \"c\"])\n/// \"abc\"\nfunc concatenate(strings: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "swift",
+    "prompt": "\n/// Filter an input array of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(strings: [] as [String], prefix: \"a\")\n/// [] as [String]\n/// >>> filter_by_prefix(strings: [\"abc\", \"bcd\", \"cde\", \"array\"], prefix: \"a\")\n/// [\"abc\", \"array\"]\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "swift",
+    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(number: 3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "swift",
+    "prompt": "\n/// Return only positive numbers in the array.\n/// >>> get_positive(l: [-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "swift",
+    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(n: 6)\n/// false\n/// >>> is_prime(n: 101)\n/// true\n/// >>> is_prime(n: 11)\n/// true\n/// >>> is_prime(n: 13441)\n/// true\n/// >>> is_prime(n: 61)\n/// true\n/// >>> is_prime(n: 4)\n/// false\n/// >>> is_prime(n: 1)\n/// false\nfunc is_prime(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "swift",
+    "prompt": "\n/// This function takes an array l and returns an array l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third(l: [5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique elements in an array\n/// >>> unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "swift",
+    "prompt": "\n/// Return maximum element in the array.\n/// >>> max_element(l: [1, 2, 3])\n/// 3\n/// >>> max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "swift",
+    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(n: 50)\n/// 0\n/// >>> fizz_buzz(n: 78)\n/// 2\n/// >>> fizz_buzz(n: 79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1096,201 @@
     "language": "swift",
     "prompt": "\n/// This function takes an array l and returns an array l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even(l: [5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfunc sort_even(l: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_even(l: [1, 2, 3]) == [1, 2, 3])\nassert(sort_even(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\nassert(sort_even(l: [5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "swift",
+    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(n: 1)\n/// 2\n/// >>> prime_fib(n: 2)\n/// 3\n/// >>> prime_fib(n: 3)\n/// 5\n/// >>> prime_fib(n: 4)\n/// 13\n/// >>> prime_fib(n: 5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "swift",
+    "prompt": "\n/// You're given an array of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return true. Otherwise it should return false.\n/// >>> below_zero(operations: [1, 2, 3])\n/// false\n/// >>> below_zero(operations: [1, 2, -4, 5])\n/// true\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// triples_sum_to_zero takes an array of integers as an input.\n/// it returns true if there are three distinct elements in the array that\n/// sum to zero, and false otherwise.\n/// >>> triples_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(l: [1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(l: [1])\n/// false\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "swift",
+    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "swift",
+    "prompt": "\n/// Return array with elements incremented by 1.\n/// >>> incr_list(l: [1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// pairs_sum_to_zero takes an array of integers as an input.\n/// it returns true if there are two distinct elements in the array that\n/// sum to zero, and false otherwise.\n/// >>> pairs_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(l: [1])\n/// false\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "swift",
+    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(x: 8, base: 3)\n/// \"22\"\n/// >>> change_base(x: 8, base: 2)\n/// \"1000\"\n/// >>> change_base(x: 7, base: 2)\n/// \"111\"\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(a: 5, h: 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "swift",
+    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(n: 5)\n/// 4\n/// >>> fib4(n: 6)\n/// 8\n/// >>> fib4(n: 7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "swift",
+    "prompt": "\n/// Return median of elements in the array l.\n/// >>> median(l: [3, 1, 2, 4, 5])\n/// 3\n/// >>> median(l: [-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome(text: \"\")\n/// true\n/// >>> is_palindrome(text: \"aba\")\n/// true\n/// >>> is_palindrome(text: \"aaaaa\")\n/// true\n/// >>> is_palindrome(text: \"zbcd\")\n/// false\nfunc is_palindrome(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "swift",
+    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(n: 3, p: 5)\n/// 3\n/// >>> modp(n: 1101, p: 101)\n/// 2\n/// >>> modp(n: 0, p: 101)\n/// 1\n/// >>> modp(n: 3, p: 11)\n/// 8\n/// >>> modp(n: 100, p: 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "swift",
+    "prompt": "\n/// For a given array of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "swift",
+    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(text: \"\")\n/// \"\"\n/// >>> remove_vowels(text: \"abcdef\")\n/// \"bcdf\"\n/// >>> remove_vowels(text: \"aaaaa\")\n/// \"\"\n/// >>> remove_vowels(text: \"aaBAA\")\n/// \"B\"\n/// >>> remove_vowels(text: \"zbcd\")\n/// \"zbcd\"\nfunc remove_vowels(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "swift",
+    "prompt": "\n/// Return true if all numbers in the array l are below threshold t.\n/// >>> below_threshold(l: [1, 2, 4, 10], t: 100)\n/// true\n/// >>> below_threshold(l: [1, 20, 4, 10], t: 5)\n/// false\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "swift",
+    "prompt": "\n/// Add two numbers x and y\n/// >>> add(x: 2, y: 3)\n/// 5\n/// >>> add(x: 5, y: 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "swift",
     "prompt": "\n/// Check if two words have the same characters.\n/// >>> same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\")\n/// true\n/// >>> same_chars(s0: \"abcd\", s1: \"dddddddabc\")\n/// true\n/// >>> same_chars(s0: \"dddddddabc\", s1: \"abcd\")\n/// true\n/// >>> same_chars(s0: \"eabcd\", s1: \"dddddddabc\")\n/// false\n/// >>> same_chars(s0: \"abcd\", s1: \"dddddddabce\")\n/// false\n/// >>> same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\")\n/// false\nfunc same_chars(s0: String, s1: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\") == true)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabc\") == true)\nassert(same_chars(s0: \"dddddddabc\", s1: \"abcd\") == true)\nassert(same_chars(s0: \"eabcd\", s1: \"dddddddabc\") == false)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabcf\") == false)\nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\") == false)\nassert(same_chars(s0: \"aabb\", s1: \"aaccc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "swift",
+    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(n: 10)\n/// 55\n/// >>> fib(n: 1)\n/// 1\n/// >>> fib(n: 8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "swift",
     "prompt": "\n/// brackets is a string of \"<\" and \">\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"<\")\n/// false\n/// >>> correct_bracketing(brackets: \"<>\")\n/// true\n/// >>> correct_bracketing(brackets: \"<<><>>\")\n/// true\n/// >>> correct_bracketing(brackets: \"><<>\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"<>\") == true)\nassert(correct_bracketing(brackets: \"<<><>>\") == true)\nassert(correct_bracketing(brackets: \"<><><<><>><>\") == true)\nassert(correct_bracketing(brackets: \"<><><<<><><>><>><<><><<>>>\") == true)\nassert(correct_bracketing(brackets: \"<<<><>>>>\") == false)\nassert(correct_bracketing(brackets: \"><<>\") == false)\nassert(correct_bracketing(brackets: \"<\") == false)\nassert(correct_bracketing(brackets: \"<<<<\") == false)\nassert(correct_bracketing(brackets: \">\") == false)\nassert(correct_bracketing(brackets: \"<<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>><<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>>><>\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "swift",
+    "prompt": "\n/// Return true is array elements are monotonically increasing or decreasing.\n/// >>> monotonic(l: [1, 2, 4, 20])\n/// true\n/// >>> monotonic(l: [1, 20, 4, 10])\n/// false\n/// >>> monotonic(l: [4, 1, 0, -10])\n/// true\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique common elements for two arrays.\n/// >>> common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common(l1: [5, 3, 2, 8], l2: [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "swift",
+    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(n: 13195)\n/// 29\n/// >>> largest_prime_factor(n: 2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "swift",
+    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n/// >>> intersperse(numbers: [] as [Int], delimeter: 4)\n/// [] as [Int]\n/// >>> intersperse(numbers: [1, 2, 3], delimeter: 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "swift",
+    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(n: 30)\n/// 465\n/// >>> sum_to_n(n: 100)\n/// 5050\n/// >>> sum_to_n(n: 5)\n/// 15\n/// >>> sum_to_n(n: 10)\n/// 55\n/// >>> sum_to_n(n: 1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "swift",
+    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return true if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"(\")\n/// false\n/// >>> correct_bracketing(brackets: \"()\")\n/// true\n/// >>> correct_bracketing(brackets: \"(()())\")\n/// true\n/// >>> correct_bracketing(brackets: \")(()\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "swift",
+    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(xs: [3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative(xs: [1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "swift",
+    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(n: 1)\n/// 0\n/// >>> fibfib(n: 5)\n/// 4\n/// >>> fibfib(n: 8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(s: \"abcde\")\n/// 2\n/// >>> vowels_count(s: \"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "swift",
+    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(x: 12, shift: 1)\n/// \"21\"\n/// >>> circular_shift(x: 12, shift: 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "swift",
+    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(s: \"\")\n/// 0\n/// >>> digitSum(s: \"abAB\")\n/// 131\n/// >>> digitSum(s: \"abcCd\")\n/// 67\n/// >>> digitSum(s: \"helloE\")\n/// 69\n/// >>> digitSum(s: \"woArBld\")\n/// 131\n/// >>> digitSum(s: \"aAaaaXa\")\n/// 153\nfunc digitSum(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "swift",
+    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(s: \"5 apples and 6 oranges\", n: 19)\n/// 8\n/// >>> fruit_distribution(s: \"0 apples and 1 oranges\", n: 3)\n/// 2\n/// >>> fruit_distribution(s: \"2 apples and 3 oranges\", n: 100)\n/// 95\n/// >>> fruit_distribution(s: \"100 apples and 1 oranges\", n: 120)\n/// 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "swift",
+    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in an array, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(arr: [4, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(arr: [1, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(arr: [] as [Int])\n/// [] as [Int]\n/// Example 4:\n/// >>> pluck(arr: [5, 0, 3, 0, 4, 2])\n/// [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "swift",
+    "prompt": "\n/// You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the array.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(lst: [4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(lst: [1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(lst: [5, 5, 4, 4, 4])\n/// -1\nfunc search(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\")\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "swift",
+    "prompt": "\n/// Given array of integers, return array in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(lst: [1, 2, 3, 4])\n/// [1, 4, 2, 3]\n/// >>> strange_sort_list(lst: [5, 5, 5, 5])\n/// [5, 5, 5, 5]\n/// >>> strange_sort_list(lst: [] as [Int])\n/// [] as [Int]\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(a: 3, b: 4, c: 5)\n/// 6.0\n/// >>> triangle_area(a: 1, b: 2, c: 10)\n/// -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns true if the object q will fly, and false otherwise.\n/// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(q: [1, 2], w: 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(q: [3, 2, 3], w: 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(q: [3, 2, 3], w: 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(q: [3], w: 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "swift",
+    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(arr: [1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(arr: [1, 2, 3, 2, 1])\n/// 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts two arrays of strings and returns the array that has \n/// total number of chars in the all strings of the array less than the other array.\n/// if the two arrays have the same number of chars, return the first array.\n/// Examples\n/// >>> total_match(lst1: [] as [String], lst2: [] as [String])\n/// [] as [String]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"])\n/// [\"hI\", \"Hi\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"])\n/// [\"hi\", \"admin\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"])\n/// [\"hI\", \"hi\", \"hi\"]\n/// >>> total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"])\n/// [\"4\"]\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(a: 30)\n/// true\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "swift",
+    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(x: 1, n: 4)\n/// true\n/// >>> is_simple_power(x: 2, n: 2)\n/// true\n/// >>> is_simple_power(x: 8, n: 2)\n/// true\n/// >>> is_simple_power(x: 3, n: 2)\n/// false\n/// >>> is_simple_power(x: 3, n: 1)\n/// false\n/// >>> is_simple_power(x: 5, n: 3)\n/// false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an integer a and returns true \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(a: 1)\n/// true\n/// >>> iscube(a: 2)\n/// false\n/// >>> iscube(a: -1)\n/// true\n/// >>> iscube(a: 64)\n/// true\n/// >>> iscube(a: 0)\n/// true\n/// >>> iscube(a: 180)\n/// false\nfunc iscube(a: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "swift",
+    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(num: \"AB\")\n/// 1\n/// >>> hex_key(num: \"1077E\")\n/// 2\n/// >>> hex_key(num: \"ABED1A33\")\n/// 4\n/// >>> hex_key(num: \"123456789ABCDEF0\")\n/// 6\n/// >>> hex_key(num: \"2020\")\n/// 2\nfunc hex_key(num: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(decimal: 15)\n/// \"db1111db\"\n/// >>> decimal_to_binary(decimal: 32)\n/// \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "swift",
+    "prompt": "\n/// Filter an input array of strings only for ones that contain given substring\n/// >>> filter_by_substring(strings: [] as [String], substring: \"a\")\n/// [] as [String]\n/// >>> filter_by_substring(strings: [\"abc\", \"bacd\", \"cde\", \"array\"], substring: \"a\")\n/// [\"abc\", \"bacd\", \"array\"]\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is hapswift or not.\n/// A string is hapswift if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(s: \"a\")\n/// false\n/// >>> is_happy(s: \"aa\")\n/// false\n/// >>> is_happy(s: \"abcd\")\n/// true\n/// >>> is_happy(s: \"aabb\")\n/// false\n/// >>> is_happy(s: \"adb\")\n/// true\n/// >>> is_happy(s: \"xyy\")\n/// false\nfunc is_happy(s: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "swift",
+    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you an array of GPAs for some students and you have to write \n/// a function that can output an array of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5])\n/// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns true if the string\n/// length is a prime number or false otherwise\n/// Examples\n/// >>> prime_length(string: \"Hello\")\n/// true\n/// >>> prime_length(string: \"abcdcba\")\n/// true\n/// >>> prime_length(string: \"kittens\")\n/// true\n/// >>> prime_length(string: \"orange\")\n/// false\nfunc prime_length(string: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(N: 1000)\n/// \"1\"\n/// >>> solve(N: 150)\n/// \"110\"\n/// >>> solve(N: 147)\n/// \"1100\"\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty array of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(lst: [4, 2, 6, 7])\n/// 2\nfunc add(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(s: \"Hi\")\n/// \"Hi\"\n/// >>> anti_shuffle(s: \"hello\")\n/// \"ehllo\"\n/// >>> anti_shuffle(s: \"Hello World!!!\")\n/// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "swift",
+    "prompt": "\n/// You are given a 2 dimensional data, as a nested arrays,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the array,\n/// and return array of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1)\n/// [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(lst: [] as [[Int]], x: 1)\n/// [] as [(Int, Int)]\n/// >>> get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3)\n/// [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "swift",
+    "prompt": "\n/// Given an array of non-negative integers, return a coswift of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(array: [] as [Int])\n/// [] as [Int]\n/// >>> sort_array(array: [5])\n/// [5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5])\n/// [0, 1, 2, 3, 4, 5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5, 6])\n/// [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "swift",
+    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(s: \"hi\")\n/// \"lm\"\n/// >>> encrypt(s: \"asdfghjkl\")\n/// \"ewhjklnop\"\n/// >>> encrypt(s: \"gf\")\n/// \"kj\"\n/// >>> encrypt(s: \"et\")\n/// \"ix\"\nfunc encrypt(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "swift",
+    "prompt": "\n/// For a given array of integers, return a tuple consisting of a sum and a product of all the integers in an array.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(numbers: [] as [Int])\n/// (0, 1)\n/// >>> sum_product(numbers: [1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "swift",
+    "prompt": "\n/// You are given an array of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the array.\n/// Return nil if there is no such element.\n/// >>> next_smallest(lst: [1, 2, 3, 4, 5])\n/// 2\n/// >>> next_smallest(lst: [5, 1, 4, 3, 2])\n/// 2\n/// >>> next_smallest(lst: [] as [Int])\n/// nil\n/// >>> next_smallest(lst: [1, 1])\n/// nil\nfunc next_smallest(lst: [Int]) -> Int? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "swift",
+    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(S: \"Hello world\")\n/// 0\n/// >>> is_bored(S: \"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(x: 5, y: 2, z: 7)\n/// true\n/// >>> any_int(x: 3, y: 2, z: 2)\n/// false\n/// >>> any_int(x: 3, y: -2, z: 1)\n/// true\n/// >>> any_int(x: 3.6, y: -2.2, z: 2)\n/// false\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(message: \"test\")\n/// \"TGST\"\n/// >>> encode(message: \"This is a message\")\n/// \"tHKS KS C MGSSCGG\"\nfunc encode(message: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "swift",
+    "prompt": "\n/// You are given an array of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(lst: [0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(lst: [0, 8, 1, 2, 1, 7])\n/// 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "swift",
+    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(n: 5)\n/// [2, 3]\n/// >>> count_up_to(n: 11)\n/// [2, 3, 5, 7]\n/// >>> count_up_to(n: 0)\n/// [] as [Int]\n/// >>> count_up_to(n: 20)\n/// [2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(n: 1)\n/// [] as [Int]\n/// >>> count_up_to(n: 18)\n/// [2, 3, 5, 7, 11, 13, 17]\nfunc count_up_to(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "swift",
+    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(a: 148, b: 412)\n/// 16\n/// >>> multiply(a: 19, b: 28)\n/// 72\n/// >>> multiply(a: 2020, b: 1851)\n/// 0\n/// >>> multiply(a: 14, b: -15)\n/// 20\nfunc multiply(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "swift",
+    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(s: \"aBCdEf\")\n/// 1\n/// >>> count_upper(s: \"abcdefg\")\n/// 0\n/// >>> count_upper(s: \"dBBE\")\n/// 0\nfunc count_upper(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(value: \"10\")\n/// 10\n/// >>> closest_integer(value: \"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "swift",
+    "prompt": "\n/// From a given array of integers, generate an array of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(numbers: [1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-swift-transform.json
+++ b/prompts/humaneval-swift-transform.json
@@ -1,1368 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "swift",
-    "prompt": "\n/// Return length of given string\n/// >>> strlen(string: \"\")\n/// 0\n/// >>> strlen(string: \"abc\")\n/// 3\nfunc strlen(string: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "swift",
-    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(s: \"hi\")\n/// \"lm\"\n/// >>> encrypt(s: \"asdfghjkl\")\n/// \"ewhjklnop\"\n/// >>> encrypt(s: \"gf\")\n/// \"kj\"\n/// >>> encrypt(s: \"et\")\n/// \"ix\"\nfunc encrypt(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(lst: [4, 2, 6, 7])\n/// 2\nfunc add(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "swift",
-    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(text: \" Example\")\n/// \"Example\"\n/// >>> fix_spaces(text: \" Example 1\")\n/// \"Example_1\"\n/// >>> fix_spaces(text: \" Example 2\")\n/// \"_Example_2\"\n/// >>> fix_spaces(text: \" Example 3\")\n/// \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "swift",
-    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(n: 1)\n/// 0\n/// >>> fibfib(n: 5)\n/// 4\n/// >>> fibfib(n: 8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(lst: [1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(lst: [-1, -2, 0])\n/// 0\n/// >>> double_the_difference(lst: [9, -2])\n/// 81\n/// >>> double_the_difference(lst: [0])\n/// 0\n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "swift",
-    "prompt": "\n/// Filter given list of any python values only for integers\n/// >>> filter_integers(values: [\"a\", 3.14, 5])\n/// [5]\n/// >>> filter_integers(values: [1, 2, 3, \"abc\", [:] as [AnyHashable : AnyHashable], [] as [AnyHashable]])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "swift",
-    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(music_string: \"o o| .| o| o| .| .| .| .| o o\")\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(decimal: 15)\n/// \"db1111db\"\n/// >>> decimal_to_binary(decimal: 32)\n/// \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "swift",
-    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(string: \"abc\")\n/// [\"a\", \"ab\", \"abc\"]\nfunc all_prefixes(string: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "swift",
-    "prompt": "\n/// Add two numbers x and y\n/// >>> add(x: 2, y: 3)\n/// 5\n/// >>> add(x: 5, y: 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "swift",
-    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(number: 5, need: 6, remaining: 10)\n/// [11, 4]\n/// >>> eat(number: 4, need: 8, remaining: 9)\n/// [12, 1]\n/// >>> eat(number: 1, need: 10, remaining: 10)\n/// [11, 0]\n/// >>> eat(number: 2, need: 11, remaining: 5)\n/// [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "swift",
-    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "swift",
-    "prompt": "\n/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "swift",
-    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(string: \"Hello\")\n/// \"hELLO\"\nfunc flip_case(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "swift",
-    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3])\n/// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// >>> by_length(arr: [] as [Int])\n/// [] as [String]\n/// If the array has any strange number ignore it:\n/// >>> by_length(arr: [1, -1, 55])\n/// [\"One\"]\nfunc by_length(arr: [Int]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "swift",
-    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(n: 8)\n/// [2, 2, 2]\n/// >>> factorize(n: 25)\n/// [5, 5]\n/// >>> factorize(n: 70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "swift",
-    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(n: 5)\n/// [2, 3]\n/// >>> count_up_to(n: 11)\n/// [2, 3, 5, 7]\n/// >>> count_up_to(n: 0)\n/// [] as [Int]\n/// >>> count_up_to(n: 20)\n/// [2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(n: 1)\n/// [] as [Int]\n/// >>> count_up_to(n: 18)\n/// [2, 3, 5, 7, 11, 13, 17]\nfunc count_up_to(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique elements in a list\n/// >>> unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "swift",
-    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// >>> total_match(lst1: [] as [String], lst2: [] as [String])\n/// [] as [String]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"])\n/// [\"hI\", \"Hi\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"])\n/// [\"hi\", \"admin\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"])\n/// [\"hI\", \"hi\", \"hi\"]\n/// >>> total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"])\n/// [\"4\"]\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "swift",
-    "prompt": "\n/// Return maximum element in the list.\n/// >>> max_element(l: [1, 2, 3])\n/// 3\n/// >>> max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(string: \"[[]]\")\n/// true\n/// >>> is_nested(string: \"[]]]]]]][[[[[]\")\n/// false\n/// >>> is_nested(string: \"[][]\")\n/// false\n/// >>> is_nested(string: \"[]\")\n/// false\n/// >>> is_nested(string: \"[[][]]\")\n/// true\n/// >>> is_nested(string: \"[[]][[\")\n/// true\nfunc is_nested(string: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// >>> rounded_avg(n: 1, m: 5)\n/// .success(\"0b11\")\n/// >>> rounded_avg(n: 7, m: 5)\n/// .failure(-1)\n/// >>> rounded_avg(n: 10, m: 20)\n/// .success(\"0b1111\")\n/// >>> rounded_avg(n: 20, m: 33)\n/// .success(\"0b11010\")\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(lst: [\"1234567\"])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(lst: [\"3\", \"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "swift",
-    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(arr: [3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(arr: [3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(n: 3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(n: 12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "swift",
-    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(n: 4)\n/// false\n/// >>> is_equal_to_sum_even(n: 6)\n/// false\n/// >>> is_equal_to_sum_even(n: 8)\n/// true\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "swift",
-    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(xs: [3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative(xs: [1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "swift",
-    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(lst: [5])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(lst: [1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(lst: [1, 2, 2, 2, 3, 4])\n/// false\nfunc is_sorted(lst: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(s: \"1234\")\n/// \"4321\"\n/// >>> solve(s: \"ab\")\n/// \"AB\"\n/// >>> solve(s: \"#a@C\")\n/// \"#A@c\"\nfunc solve(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "swift",
-    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(n: 3)\n/// [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "swift",
-    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(n: 50)\n/// 0\n/// >>> fizz_buzz(n: 78)\n/// 2\n/// >>> fizz_buzz(n: 79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(strings: [] as [String], prefix: \"a\")\n/// [] as [String]\n/// >>> filter_by_prefix(strings: [\"abc\", \"bcd\", \"cde\", \"array\"], prefix: \"a\")\n/// [\"abc\", \"array\"]\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(N: 1000)\n/// \"1\"\n/// >>> solve(N: 150)\n/// \"110\"\n/// >>> solve(N: 147)\n/// \"1100\"\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "swift",
-    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3)\n/// [1, 2, 1]\n/// >>> minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1)\n/// [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "swift",
-    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(s: \"aBCdEf\")\n/// 1\n/// >>> count_upper(s: \"abcdefg\")\n/// 0\n/// >>> count_upper(s: \"dBBE\")\n/// 0\nfunc count_upper(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(arr: [-3, -4, 5], k: 3)\n/// [-4, -3, 5]\n/// Example 2:\n/// >>> maximum(arr: [4, -4, 4], k: 2)\n/// [4, 4]\n/// Example 3:\n/// >>> maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1)\n/// [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "swift",
-    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(n: 15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "swift",
-    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(array: [] as [Int])\n/// [] as [Int]\n/// >>> sort_array(array: [5])\n/// [5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5])\n/// [0, 1, 2, 3, 4, 5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5, 6])\n/// [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "swift",
-    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(n: 5)\n/// [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(a: 1)\n/// true\n/// >>> iscube(a: 2)\n/// false\n/// >>> iscube(a: -1)\n/// true\n/// >>> iscube(a: 64)\n/// true\n/// >>> iscube(a: 0)\n/// true\n/// >>> iscube(a: 180)\n/// false\nfunc iscube(a: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(message: \"test\")\n/// \"TGST\"\n/// >>> encode(message: \"This is a message\")\n/// \"tHKS KS C MGSSCGG\"\nfunc encode(message: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "swift",
-    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(S: \"Hello world\")\n/// 0\n/// >>> is_bored(S: \"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(l: [1])\n/// false\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(a: 3, b: 4, c: 5)\n/// 6.0\n/// >>> triangle_area(a: 1, b: 2, c: 10)\n/// -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(n: 1)\n/// 1\n/// >>> digits(n: 4)\n/// 0\n/// >>> digits(n: 235)\n/// 15\nfunc digits(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "swift",
-    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(s: \"Hi, my name is John\")\n/// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// >>> words_string(s: \"One, two, three, four, five, six\")\n/// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "swift",
-    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(string: \"\", substring: \"a\")\n/// 0\n/// >>> how_many_times(string: \"aaa\", substring: \"a\")\n/// 3\n/// >>> how_many_times(string: \"aaaa\", substring: \"aa\")\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_137_compare_one",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// >>> compare_one(a: .intValue(1), b: .doubleValue(2.5))\n/// .doubleValue(2.5)\n/// >>> compare_one(a: .intValue(1), b: .stringValue(\"2,3\"))\n/// .stringValue(\"2,3\")\n/// >>> compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\"))\n/// .stringValue(\"6\")\n/// >>> compare_one(a: .stringValue(\"1\"), b: .intValue(1))\n/// nil\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "swift",
-    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(text: \"\")\n/// \"\"\n/// >>> remove_vowels(text: \"abcdef\")\n/// \"bcdf\"\n/// >>> remove_vowels(text: \"aaaaa\")\n/// \"\"\n/// >>> remove_vowels(text: \"aaBAA\")\n/// \"B\"\n/// >>> remove_vowels(text: \"zbcd\")\n/// \"zbcd\"\nfunc remove_vowels(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "swift",
-    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(lst: [1, 2, 3, 4])\n/// [1, 4, 2, 3]\n/// >>> strange_sort_list(lst: [5, 5, 5, 5])\n/// [5, 5, 5, 5]\n/// >>> strange_sort_list(lst: [] as [Int])\n/// [] as [Int]\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "swift",
-    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "swift",
-    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(x: 1, n: 4)\n/// true\n/// >>> is_simple_power(x: 2, n: 2)\n/// true\n/// >>> is_simple_power(x: 8, n: 2)\n/// true\n/// >>> is_simple_power(x: 3, n: 2)\n/// false\n/// >>> is_simple_power(x: 3, n: 1)\n/// false\n/// >>> is_simple_power(x: 5, n: 3)\n/// false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "swift",
-    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(n: 1)\n/// 2\n/// >>> prime_fib(n: 2)\n/// 3\n/// >>> prime_fib(n: 3)\n/// 5\n/// >>> prime_fib(n: 4)\n/// 13\n/// >>> prime_fib(n: 5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "swift",
-    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points(nums: [1, 11, -1, -11, -12])\n/// [-1, -11, 1, -12, 11]\n/// >>> order_by_points(nums: [] as [Int])\n/// [] as [Int]\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "swift",
     "prompt": "\n/// Check if in given list of numbers, are any two numbers closer to each other than\n/// given threshold.\n/// >>> has_close_elements(numbers: [1.0, 2.0, 3.0], threshold: 0.5)\n/// false\n/// >>> has_close_elements(numbers: [1.0, 2.8, 3.0, 4.0, 5.0, 2.0], threshold: 0.3)\n/// true\nfunc has_close_elements(numbers: [Double], threshold: Double) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.3) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2], threshold: 0.05) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.95) == true)\nassert(has_close_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0], threshold: 0.8) == false)\nassert(has_close_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0], threshold: 0.1) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 1.0) == true)\nassert(has_close_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1], threshold: 0.5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(string: \"\")\n/// \"\"\n/// >>> make_palindrome(string: \"cat\")\n/// \"catac\"\n/// >>> make_palindrome(string: \"cata\")\n/// \"catac\"\nfunc make_palindrome(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "swift",
-    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(a: \"010\", b: \"110\")\n/// \"100\"\nfunc string_xor(a: String, b: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "swift",
-    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(n: 4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "swift",
-    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(n: 5)\n/// 4\n/// >>> fib4(n: 6)\n/// 8\n/// >>> fib4(n: 7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "swift",
-    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(x: [15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits(x: [152, 323, 1422, 10])\n/// [] as [Int]\nfunc unique_digits(x: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "swift",
-    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(s: \"Mary had a little lamb\", n: 4)\n/// [\"little\"]\n/// >>> select_words(s: \"Mary had a little lamb\", n: 3)\n/// [\"Mary\", \"lamb\"]\n/// >>> select_words(s: \"simple white space\", n: 2)\n/// [] as [String]\n/// >>> select_words(s: \"Hello world\", n: 4)\n/// [\"world\"]\n/// >>> select_words(s: \"Uncle sam\", n: 3)\n/// [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(q: [1, 2], w: 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(q: [3, 2, 3], w: 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(q: [3, 2, 3], w: 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(q: [3], w: 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "swift",
-    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(n: 10)\n/// 55\n/// >>> fib(n: 1)\n/// 1\n/// >>> fib(n: 8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "swift",
-    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(class_name: \"my_class\", extensions: [\"AA\", \"Be\", \"CC\"])\n/// \"my_class.AA\"\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(lst: [\"()(\", \")\"])\n/// \"Yes\"\n/// >>> match_parens(lst: [\")\", \")\"])\n/// \"No\"\nfunc match_parens(lst: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// >>> next_smallest(lst: [1, 2, 3, 4, 5])\n/// 2\n/// >>> next_smallest(lst: [5, 1, 4, 3, 2])\n/// 2\n/// >>> next_smallest(lst: [] as [Int])\n/// nil\n/// >>> next_smallest(lst: [1, 1])\n/// nil\nfunc next_smallest(lst: [Int]) -> Int? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "swift",
-    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(x: 5, y: 2, z: 7)\n/// true\n/// >>> any_int(x: 3, y: 2, z: 2)\n/// false\n/// >>> any_int(x: 3, y: -2, z: 1)\n/// true\n/// >>> any_int(x: 3.6, y: -2.2, z: 2)\n/// false\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "swift",
-    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(number: 3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "swift",
-    "prompt": "\n/// Return list with elements incremented by 1.\n/// >>> incr_list(l: [1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "swift",
-    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(n: 7, x: 34, y: 12)\n/// 34\n/// >>> x_or_y(n: 15, x: 8, y: 5)\n/// 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "swift",
-    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(n: 3, p: 5)\n/// 3\n/// >>> modp(n: 1101, p: 101)\n/// 2\n/// >>> modp(n: 0, p: 101)\n/// 1\n/// >>> modp(n: 3, p: 11)\n/// 8\n/// >>> modp(n: 100, p: 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "swift",
-    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(num: -12)\n/// (1, 1)\n/// >>> even_odd_count(num: 123)\n/// (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "swift",
-    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(s: \"a\")\n/// false\n/// >>> is_happy(s: \"aa\")\n/// false\n/// >>> is_happy(s: \"abcd\")\n/// true\n/// >>> is_happy(s: \"aabb\")\n/// false\n/// >>> is_happy(s: \"adb\")\n/// true\n/// >>> is_happy(s: \"xyy\")\n/// false\nfunc is_happy(s: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "swift",
-    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(n: 13195)\n/// 29\n/// >>> largest_prime_factor(n: 2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "swift",
-    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(s: \"\")\n/// 0\n/// >>> digitSum(s: \"abAB\")\n/// 131\n/// >>> digitSum(s: \"abcCd\")\n/// 67\n/// >>> digitSum(s: \"helloE\")\n/// 69\n/// >>> digitSum(s: \"woArBld\")\n/// 131\n/// >>> digitSum(s: \"aAaaaXa\")\n/// 153\nfunc digitSum(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "swift",
-    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "swift",
-    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(lst: [5, 8, 7, 1])\n/// 12\n/// >>> solution(lst: [3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(lst: [30, 13, 24, 321])\n/// 0\nfunc solution(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "swift",
-    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(arr: [4, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(arr: [1, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(arr: [] as [Int])\n/// [] as [Int]\n/// Example 4:\n/// >>> pluck(arr: [5, 0, 3, 0, 4, 2])\n/// [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "swift",
-    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(n: 5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "swift",
-    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4])\n/// \"YES\"\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4])\n/// \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "swift",
-    "prompt": "\n/// Return median of elements in the list l.\n/// >>> median(l: [3, 1, 2, 4, 5])\n/// 3\n/// >>> median(l: [-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// >>> prime_length(string: \"Hello\")\n/// true\n/// >>> prime_length(string: \"abcdcba\")\n/// true\n/// >>> prime_length(string: \"kittens\")\n/// true\n/// >>> prime_length(string: \"orange\")\n/// false\nfunc prime_length(string: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "swift",
-    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(arr: [1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(arr: [1, 2, 3, 2, 1])\n/// 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// >>> sum_squares(lst: [1.0, 2.0, 3.0])\n/// 14\n/// >>> sum_squares(lst: [1.0, 4.0, 9.0])\n/// 98\n/// >>> sum_squares(lst: [1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> sum_squares(lst: [1.4, 4.2, 0.0])\n/// 29\n/// >>> sum_squares(lst: [-2.4, 1.0, 1.0])\n/// 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "swift",
-    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(file_name: \"example.txt\")\n/// \"Yes\"\n/// >>> file_name_check(file_name: \"1example.dll\")\n/// \"No\"\nfunc file_name_check(file_name: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "swift",
-    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(l: [1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(l: [1])\n/// false\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "swift",
-    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection(interval1: (1, 2), interval2: (2, 3))\n/// \"NO\"\n/// >>> intersection(interval1: (-1, 1), interval2: (0, 4))\n/// \"NO\"\n/// >>> intersection(interval1: (-3, -1), interval2: (-5, 5))\n/// \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "swift",
-    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\")\n/// [\"()\", \"(())\", \"(()())\"]\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "swift",
-    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2])\n/// [0, 0, 0, 0, 3, 3]\n/// >>> compare(game: [0, 5, 0, 0, 0, 4], guess: [4, 1, 1, 0, 0, -2])\n/// [4, 4, 1, 0, 0, 6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pie\")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e\")\n/// true\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e \")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"\")\n/// false\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "swift",
-    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(date: \"03-11-2000\")\n/// true\n/// >>> valid_date(date: \"15-01-2012\")\n/// false\n/// >>> valid_date(date: \"04-0-2040\")\n/// false\n/// >>> valid_date(date: \"06-04-2020\")\n/// true\n/// >>> valid_date(date: \"06/04/2020\")\n/// false\nfunc valid_date(date: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(arr: [] as [Int])\n/// 0\n/// >>> count_nums(arr: [-1, 11, -11])\n/// 1\n/// >>> count_nums(arr: [1, 1, 2])\n/// 3\nfunc count_nums(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(s: \"Hi\")\n/// \"Hi\"\n/// >>> anti_shuffle(s: \"hello\")\n/// \"ehllo\"\n/// >>> anti_shuffle(s: \"Hello World!!!\")\n/// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "swift",
-    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome(text: \"\")\n/// true\n/// >>> is_palindrome(text: \"aba\")\n/// true\n/// >>> is_palindrome(text: \"aaaaa\")\n/// true\n/// >>> is_palindrome(text: \"zbcd\")\n/// false\nfunc is_palindrome(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "swift",
-    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(word: \"yogurt\")\n/// \"u\"\n/// >>> get_closest_vowel(word: \"FULL\")\n/// \"U\"\n/// >>> get_closest_vowel(word: \"quick\")\n/// \"\"\n/// >>> get_closest_vowel(word: \"ab\")\n/// \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "swift",
-    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(n: 6)\n/// false\n/// >>> is_prime(n: 101)\n/// true\n/// >>> is_prime(n: 11)\n/// true\n/// >>> is_prime(n: 13441)\n/// true\n/// >>> is_prime(n: 61)\n/// true\n/// >>> is_prime(n: 4)\n/// false\n/// >>> is_prime(n: 1)\n/// false\nfunc is_prime(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "swift",
-    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(x: \"1/5\", n: \"5/1\")\n/// true\n/// >>> simplify(x: \"1/6\", n: \"2/1\")\n/// false\n/// >>> simplify(x: \"7/10\", n: \"10/2\")\n/// false\nfunc simplify(x: String, n: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "swift",
-    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(num: \"AB\")\n/// 1\n/// >>> hex_key(num: \"1077E\")\n/// 2\n/// >>> hex_key(num: \"ABED1A33\")\n/// 4\n/// >>> hex_key(num: \"123456789ABCDEF0\")\n/// 6\n/// >>> hex_key(num: \"2020\")\n/// 2\nfunc hex_key(num: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "swift",
-    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(sentence: \"This is a test\")\n/// \"is\"\n/// Example 2:\n/// >>> words_in_sentence(sentence: \"lets go for swimming\")\n/// \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "swift",
-    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(test: \"a b c\")\n/// [\"a\" : 1, \"b\" : 1, \"c\" : 1]\n/// >>> histogram(test: \"a b b a\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"a b c a b\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"b b b b a\")\n/// [\"b\" : 4]\n/// >>> histogram(test: \"\")\n/// [:] as [String : Int]\nfunc histogram(test: String) -> [String : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "swift",
-    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1)\n/// [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(lst: [] as [[Int]], x: 1)\n/// [] as [(Int, Int)]\n/// >>> get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3)\n/// [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(n: 5)\n/// [1, 5]\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "swift",
-    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(arr: [1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(arr: [1, 2, 3])\n/// -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "swift",
-    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(numbers: \"three one five\")\n/// \"one three five\"\nfunc sort_numbers(numbers: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "swift",
-    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(x: 12, shift: 1)\n/// \"21\"\n/// >>> circular_shift(x: 12, shift: 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "swift",
-    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(lst: [0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(lst: [0, 8, 1, 2, 1, 7])\n/// 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "swift",
-    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(numbers: [] as [Int])\n/// (0, 1)\n/// >>> sum_product(numbers: [1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "swift",
-    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(x: 12, y: 15)\n/// 14\n/// >>> choose_num(x: 13, y: 12)\n/// -1\nfunc choose_num(x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "swift",
-    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7])\n/// (nil, 1)\n/// >>> largest_smallest_integers(lst: [] as [Int])\n/// (nil, nil)\n/// >>> largest_smallest_integers(lst: [0])\n/// (nil, nil)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "swift",
-    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(string: \"xyzXYZ\")\n/// 3\n/// >>> count_distinct_characters(string: \"Jerry\")\n/// 4\nfunc count_distinct_characters(string: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1372,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Given a positive integer n, you have to make a pile of n levels of stones.\n/// The first level has n stones.\n/// The number of stones in the next level is:\n/// - the next odd number if n is odd.\n/// - the next even number if n is even.\n/// Return the number of stones in each level in a list, where element at index\n/// i represents the number of stones in the level (i+1).\n/// Examples:\n/// >>> make_a_pile(n: 3)\n/// [3, 5, 7]\nfunc make_a_pile(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_a_pile(n: 3) == [3, 5, 7])\nassert(make_a_pile(n: 4) == [4, 6, 8, 10])\nassert(make_a_pile(n: 5) == [5, 7, 9, 11, 13])\nassert(make_a_pile(n: 6) == [6, 8, 10, 12, 14, 16])\nassert(make_a_pile(n: 8) == [8, 10, 12, 14, 16, 18, 20, 22])",
     "stop_tokens": [
@@ -1380,205 +24,145 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "swift",
-    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(arr: [1, 2, 2, -4])\n/// 9\n/// >>> prod_signs(arr: [0, 1])\n/// 0\n/// >>> prod_signs(arr: [] as [Int])\n/// nil\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "prompt": "\n/// You will be given a string of words separated by commas or spaces. Your task is\n/// to split the string into words and return an array of the words.\n/// For example:\n/// >>> words_string(s: \"Hi, my name is John\")\n/// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n/// >>> words_string(s: \"One, two, three, four, five, six\")\n/// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunc words_string(s: String) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_string(s: \"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"])\nassert(words_string(s: \"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"Hi, my name\") == [\"Hi\", \"my\", \"name\"])\nassert(words_string(s: \"One,, two, three, four, five, six,\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"])\nassert(words_string(s: \"\") == [] as [String])\nassert(words_string(s: \"ahmed     , gamal\") == [\"ahmed\", \"gamal\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "swift",
-    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(nums: [2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(nums: [-1, -2, -3])\n/// -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
+    "prompt": "\n/// This function takes two positive numbers x and y and returns the\n/// biggest even integer number that is in the range [x, y] inclusive. If \n/// there's no such number, then the function should return -1.\n/// For example:\n/// >>> choose_num(x: 12, y: 15)\n/// 14\n/// >>> choose_num(x: 13, y: 12)\n/// -1\nfunc choose_num(x: Int, y: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(choose_num(x: 12, y: 15) == 14)\nassert(choose_num(x: 13, y: 12) == -1)\nassert(choose_num(x: 33, y: 12354) == 12354)\nassert(choose_num(x: 5234, y: 5233) == -1)\nassert(choose_num(x: 6, y: 29) == 28)\nassert(choose_num(x: 27, y: 10) == -1)\nassert(choose_num(x: 7, y: 7) == -1)\nassert(choose_num(x: 546, y: 546) == 546)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "swift",
-    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(n: 0)\n/// \"0\"\n/// >>> string_sequence(n: 5)\n/// \"0 1 2 3 4 5\"\nfunc string_sequence(n: Int) -> String {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// You are given two positive integers n and m, and your task is to compute the\n/// average of the integers from n through m (including n and m). \n/// Round the answer to the nearest integer and convert that to binary.\n/// If n is greater than m, return -1.\n/// Example:\n/// >>> rounded_avg(n: 1, m: 5)\n/// .success(\"0b11\")\n/// >>> rounded_avg(n: 7, m: 5)\n/// .failure(-1)\n/// >>> rounded_avg(n: 10, m: 20)\n/// .success(\"0b1111\")\n/// >>> rounded_avg(n: 20, m: 33)\n/// .success(\"0b11010\")\nfunc rounded_avg(n: Int, m: Int) -> Result<String, Int> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rounded_avg(n: 1, m: 5) == .success(\"0b11\"))\nassert(rounded_avg(n: 7, m: 13) == .success(\"0b1010\"))\nassert(rounded_avg(n: 964, m: 977) == .success(\"0b1111001010\"))\nassert(rounded_avg(n: 996, m: 997) == .success(\"0b1111100100\"))\nassert(rounded_avg(n: 560, m: 851) == .success(\"0b1011000010\"))\nassert(rounded_avg(n: 185, m: 546) == .success(\"0b101101110\"))\nassert(rounded_avg(n: 362, m: 496) == .success(\"0b110101101\"))\nassert(rounded_avg(n: 350, m: 902) == .success(\"0b1001110010\"))\nassert(rounded_avg(n: 197, m: 233) == .success(\"0b11010111\"))\nassert(rounded_avg(n: 7, m: 5) == .failure(-1))\nassert(rounded_avg(n: 5, m: 1) == .failure(-1))\nassert(rounded_avg(n: 5, m: 5) == .success(\"0b101\"))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "swift",
-    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(a: \"abcd\", b: \"abd\")\n/// false\n/// >>> cycpattern_check(a: \"hello\", b: \"ell\")\n/// true\n/// >>> cycpattern_check(a: \"whassup\", b: \"psus\")\n/// false\n/// >>> cycpattern_check(a: \"abab\", b: \"baa\")\n/// true\n/// >>> cycpattern_check(a: \"efef\", b: \"eeff\")\n/// false\n/// >>> cycpattern_check(a: \"himenss\", b: \"simen\")\n/// true\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "prompt": "\n/// Given a list of positive integers x. return a sorted list of all \n/// elements that hasn't any even digit.\n/// Note: Returned list should be sorted in increasing order.\n/// For example:\n/// >>> unique_digits(x: [15, 33, 1422, 1])\n/// [1, 15, 33]\n/// >>> unique_digits(x: [152, 323, 1422, 10])\n/// [] as [Int]\nfunc unique_digits(x: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_digits(x: [15, 33, 1422, 1]) == [1, 15, 33])\nassert(unique_digits(x: [152, 323, 1422, 10]) == [] as [Int])\nassert(unique_digits(x: [12345, 2033, 111, 151]) == [111, 151])\nassert(unique_digits(x: [135, 103, 31]) == [31, 135])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "swift",
-    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic(l: [1, 2, 4, 20])\n/// true\n/// >>> monotonic(l: [1, 20, 4, 10])\n/// false\n/// >>> monotonic(l: [4, 1, 0, -10])\n/// true\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "prompt": "\n/// Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n/// reverse the resulting array, and then replace each digit by its corresponding name from\n/// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n/// For example:\n/// >>> by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3])\n/// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n/// If the array is empty, return an empty array:\n/// >>> by_length(arr: [] as [Int])\n/// [] as [String]\n/// If the array has any strange number ignore it:\n/// >>> by_length(arr: [1, -1, 55])\n/// [\"One\"]\nfunc by_length(arr: [Int]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(by_length(arr: [2, 1, 1, 4, 5, 8, 2, 3]) == [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"])\nassert(by_length(arr: [] as [Int]) == [] as [String])\nassert(by_length(arr: [1, -1, 55]) == [\"One\"])\nassert(by_length(arr: [1, -1, 3, 2]) == [\"Three\", \"Two\", \"One\"])\nassert(by_length(arr: [9, 4, 8]) == [\"Nine\", \"Eight\", \"Four\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "swift",
-    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest(strings: [] as [String])\n/// nil\n/// >>> longest(strings: [\"a\", \"b\", \"c\"])\n/// \"a\"\n/// >>> longest(strings: [\"a\", \"bb\", \"ccc\"])\n/// \"ccc\"\nfunc longest(strings: [String]) -> String? {\n",
+    "prompt": "\n/// Implement the function f that takes n as a parameter,\n/// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n/// or the sum of numbers from 1 to i otherwise.\n/// i starts from 1.\n/// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n/// Example:\n/// >>> f(n: 5)\n/// [1, 2, 6, 24, 15]\nfunc f(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(f(n: 5) == [1, 2, 6, 24, 15])\nassert(f(n: 7) == [1, 2, 6, 24, 15, 720, 28])\nassert(f(n: 1) == [1])\nassert(f(n: 3) == [1, 2, 6])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "swift",
-    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold(l: [1, 2, 4, 10], t: 100)\n/// true\n/// >>> below_threshold(l: [1, 20, 4, 10], t: 5)\n/// false\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "prompt": "\n/// Given a positive integer n, return a tuple that has the number of even and odd\n/// integer palindromes that fall within the range(1, n), inclusive.\n/// Example 1:\n/// >>> even_odd_palindrome(n: 3)\n/// (1, 2)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n/// Example 2:\n/// >>> even_odd_palindrome(n: 12)\n/// (4, 6)\n/// Explanation:\n/// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n/// Note:\n/// 1. 1 <= n <= 10^3\n/// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunc even_odd_palindrome(n: Int) -> (Int, Int) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_palindrome(n: 123) == (8, 13))\nassert(even_odd_palindrome(n: 12) == (4, 6))\nassert(even_odd_palindrome(n: 3) == (1, 2))\nassert(even_odd_palindrome(n: 63) == (6, 8))\nassert(even_odd_palindrome(n: 25) == (5, 6))\nassert(even_odd_palindrome(n: 19) == (4, 6))\nassert(even_odd_palindrome(n: 9) == (4, 5))\nassert(even_odd_palindrome(n: 1) == (0, 1))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "swift",
-    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(a: 30)\n/// true\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "prompt": "\n/// Write a function count_nums which takes an array of integers and returns\n/// the number of elements which has a sum of digits > 0.\n/// If a number is negative, then its first signed digit will be negative:\n/// e.g. -123 has signed digits -1, 2, and 3.\n/// >>> count_nums(arr: [] as [Int])\n/// 0\n/// >>> count_nums(arr: [-1, 11, -11])\n/// 1\n/// >>> count_nums(arr: [1, 1, 2])\n/// 3\nfunc count_nums(arr: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_nums(arr: [] as [Int]) == 0)\nassert(count_nums(arr: [-1, -2, 0]) == 0)\nassert(count_nums(arr: [1, 1, 2, -2, 3, 4, 5]) == 6)\nassert(count_nums(arr: [1, 6, 9, -6, 0, 1, 5]) == 5)\nassert(count_nums(arr: [1, 100, 98, -7, 1, -1]) == 4)\nassert(count_nums(arr: [12, 23, 34, -45, -56, 0]) == 5)\nassert(count_nums(arr: [0, 1]) == 1)\nassert(count_nums(arr: [1]) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "swift",
-    "prompt": "\n/// Return only positive numbers in the list.\n/// >>> get_positive(l: [-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n/// numbers in the array will be randomly ordered. Your task is to determine if\n/// it is possible to get an array sorted in non-decreasing order by performing \n/// the following operation on the given array:\n/// You are allowed to perform right shift operation any number of times.\n/// One right shift operation means shifting all elements of the array by one\n/// position in the right direction. The last element of the array will be moved to\n/// the starting position in the array i.e. 0th index. \n/// If it is possible to obtain the sorted array by performing the above operation\n/// then return True else return False.\n/// If the given array is empty then return True.\n/// Note: The given list is guaranteed to have unique elements.\n/// For Example:\n/// >>> move_one_ball(arr: [3, 4, 5, 1, 2])\n/// true\n/// Explanation: By performin 2 right shift operations, non-decreasing order can\n/// be achieved for the given array.\n/// >>> move_one_ball(arr: [3, 5, 4, 1, 2])\n/// false\n/// Explanation:It is not possible to get non-decreasing order for the given\n/// array by performing any number of right shift operations.\nfunc move_one_ball(arr: [Int]) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_one_ball(arr: [3, 4, 5, 1, 2]) == true)\nassert(move_one_ball(arr: [3, 5, 10, 1, 2]) == true)\nassert(move_one_ball(arr: [4, 3, 1, 2]) == false)\nassert(move_one_ball(arr: [3, 5, 4, 1, 2]) == false)\nassert(move_one_ball(arr: [] as [Int]) == true)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "swift",
-    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third(l: [5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Find the shortest palindrome that begins with a supplied string.\n/// Algorithm idea is simple:\n/// - Find the longest postfix of supplied string that is a palindrome.\n/// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n/// >>> make_palindrome(string: \"\")\n/// \"\"\n/// >>> make_palindrome(string: \"cat\")\n/// \"catac\"\n/// >>> make_palindrome(string: \"cata\")\n/// \"catac\"\nfunc make_palindrome(string: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(make_palindrome(string: \"\") == \"\")\nassert(make_palindrome(string: \"x\") == \"x\")\nassert(make_palindrome(string: \"xyz\") == \"xyzyx\")\nassert(make_palindrome(string: \"xyx\") == \"xyx\")\nassert(make_palindrome(string: \"jerry\") == \"jerryrrej\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "swift",
-    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\")\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "prompt": "\n/// In this problem, you will implement a function that takes two lists of numbers,\n/// and determines whether it is possible to perform an exchange of elements\n/// between them to make lst1 a list of only even numbers.\n/// There is no limit on the number of exchanged elements between lst1 and lst2.\n/// If it is possible to exchange elements between the lst1 and lst2 to make\n/// all the elements of lst1 to be even, return \"YES\".\n/// Otherwise, return \"NO\".\n/// For example:\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4])\n/// \"YES\"\n/// >>> exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4])\n/// \"NO\"\n/// It is assumed that the input lists will be non-empty.\nfunc exchange(lst1: [Int], lst2: [Int]) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 2, 3, 4]) == \"YES\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [1, 5, 3, 4]) == \"NO\")\nassert(exchange(lst1: [1, 2, 3, 4], lst2: [2, 1, 4, 3]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 4]) == \"YES\")\nassert(exchange(lst1: [5, 7, 3], lst2: [2, 6, 3]) == \"NO\")\nassert(exchange(lst1: [3, 2, 6, 1, 8, 9], lst2: [3, 5, 5, 1, 1, 1]) == \"NO\")\nassert(exchange(lst1: [100, 200], lst2: [200, 200]) == \"YES\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "swift",
-    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(a: 5, h: 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "prompt": "\n/// Given a string representing a space separated lowercase letters, return a dictionary\n/// of the letter with the most repetition and containing the corresponding count.\n/// If several letters have the same occurrence, return all of them.\n/// Example:\n/// >>> histogram(test: \"a b c\")\n/// [\"a\" : 1, \"b\" : 1, \"c\" : 1]\n/// >>> histogram(test: \"a b b a\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"a b c a b\")\n/// [\"a\" : 2, \"b\" : 2]\n/// >>> histogram(test: \"b b b b a\")\n/// [\"b\" : 4]\n/// >>> histogram(test: \"\")\n/// [:] as [String : Int]\nfunc histogram(test: String) -> [String : Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "swift",
-    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(a: 148, b: 412)\n/// 16\n/// >>> multiply(a: 19, b: 28)\n/// 72\n/// >>> multiply(a: 2020, b: 1851)\n/// 0\n/// >>> multiply(a: 14, b: -15)\n/// 20\nfunc multiply(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "swift",
-    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "swift",
-    "prompt": "\n/// Return sorted unique common elements for two lists.\n/// >>> common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common(l1: [5, 3, 2, 8], l2: [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "swift",
-    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(number: 19)\n/// \"xix\"\n/// >>> int_to_mini_roman(number: 152)\n/// \"clii\"\n/// >>> int_to_mini_roman(number: 426)\n/// \"cdxxvi\"\nfunc int_to_mini_roman(number: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "swift",
-    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(s: \"5 apples and 6 oranges\", n: 19)\n/// 8\n/// >>> fruit_distribution(s: \"0 apples and 1 oranges\", n: 3)\n/// 2\n/// >>> fruit_distribution(s: \"2 apples and 3 oranges\", n: 100)\n/// 95\n/// >>> fruit_distribution(s: \"100 apples and 1 oranges\", n: 120)\n/// 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(histogram(test: \"a b b a\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c a b\") == [\"a\" : 2, \"b\" : 2])\nassert(histogram(test: \"a b c d g\") == [\"a\" : 1, \"b\" : 1, \"c\" : 1, \"d\" : 1, \"g\" : 1])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"b b b b a\") == [\"b\" : 4])\nassert(histogram(test: \"r t g\") == [\"r\" : 1, \"t\" : 1, \"g\" : 1])\nassert(histogram(test: \"\") == [:] as [String : Int])\nassert(histogram(test: \"a\") == [\"a\" : 1])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1588,7 +172,7 @@
     "language": "swift",
     "prompt": "\n/// Task\n/// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n/// then check if the result string is palindrome.\n/// A string is called palindrome if it reads the same backward as forward.\n/// You should return a tuple containing the result string and True/False for the check.\n/// Example\n/// >>> reverse_delete(s: \"abcde\", c: \"ae\")\n/// (\"bcd\", false)\n/// >>> reverse_delete(s: \"abcdef\", c: \"b\")\n/// (\"acdef\", false)\n/// >>> reverse_delete(s: \"abcdedcba\", c: \"ab\")\n/// (\"cdedc\", true)\nfunc reverse_delete(s: String, c: String) -> (String, Bool) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_delete(s: \"abcde\", c: \"ae\") == (\"bcd\", false))\nassert(reverse_delete(s: \"abcdef\", c: \"b\") == (\"acdef\", false))\nassert(reverse_delete(s: \"abcdedcba\", c: \"ab\") == (\"cdedc\", true))\nassert(reverse_delete(s: \"dwik\", c: \"w\") == (\"dik\", false))\nassert(reverse_delete(s: \"a\", c: \"a\") == (\"\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"abcdedcba\", c: \"v\") == (\"abcdedcba\", true))\nassert(reverse_delete(s: \"vabba\", c: \"v\") == (\"abba\", true))\nassert(reverse_delete(s: \"mamma\", c: \"mia\") == (\"\", true))",
     "stop_tokens": [
@@ -1596,25 +180,37 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "swift",
-    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(a: 3, b: 5)\n/// 1\n/// >>> greatest_common_divisor(a: 25, b: 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "prompt": "\n/// Given a list of strings, where each string consists of only digits, return a list.\n/// Each element i of the output should be \"the number of odd elements in the\n/// string i of the input.\" where all the i's should be replaced by the number\n/// of odd digits in the i'th string of the input.\n/// >>> odd_count(lst: [\"1234567\"])\n/// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n/// >>> odd_count(lst: [\"3\", \"11111111\"])\n/// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunc odd_count(lst: [String]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_count(lst: [\"1234567\"]) == [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"])\nassert(odd_count(lst: [\"3\", \"11111111\"]) == [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"])\nassert(odd_count(lst: [\"271\", \"137\", \"314\"]) == [\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// >>> split_words(txt: \"Hello world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"Hello,world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"abcdef\")\n/// .failure(3)\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
+    "prompt": "\n/// Given an array of integers nums, find the minimum sum of any non-empty sub-array\n/// of nums.\n/// Example\n/// >>> minSubArraySum(nums: [2, 3, 4, 1, 2, 4])\n/// 1\n/// >>> minSubArraySum(nums: [-1, -2, -3])\n/// -6\nfunc minSubArraySum(nums: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minSubArraySum(nums: [2, 3, 4, 1, 2, 4]) == 1)\nassert(minSubArraySum(nums: [-1, -2, -3]) == -6)\nassert(minSubArraySum(nums: [-1, -2, -3, 2, -10]) == -14)\nassert(minSubArraySum(nums: [-9999999999999999]) == -9999999999999999)\nassert(minSubArraySum(nums: [0, 10, 20, 1000000]) == 0)\nassert(minSubArraySum(nums: [-1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [100, -1, -2, -3, 10, -5]) == -6)\nassert(minSubArraySum(nums: [10, 11, 13, 8, 3, 4]) == 3)\nassert(minSubArraySum(nums: [100, -33, 32, -1, 0, -2]) == -33)\nassert(minSubArraySum(nums: [-10]) == -10)\nassert(minSubArraySum(nums: [7]) == 7)\nassert(minSubArraySum(nums: [1, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "swift",
+    "prompt": "\n/// You are given a rectangular grid of wells. Each row represents a single well,\n/// and each 1 in a row represents a single unit of water.\n/// Each well has a corresponding bucket that can be used to extract water from it, \n/// and all buckets have the same capacity.\n/// Your task is to use the buckets to empty the wells.\n/// Output the number of times you need to lower the buckets.\n/// Example 1:\n/// >>> max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1)\n/// 6\n/// Example 2:\n/// >>> max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2)\n/// 5\n/// Example 3:\n/// >>> max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5)\n/// 0\n/// Constraints:\n/// * all wells have the same length\n/// * 1 <= grid.length <= 10^2\n/// * 1 <= grid[:,1].length <= 10^2\n/// * grid[i][j] -> 0 | 1\n/// * 1 <= capacity <= 10\nfunc max_fill(grid: [[Int]], capacity: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_fill(grid: [[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], capacity: 1) == 6)\nassert(max_fill(grid: [[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], capacity: 2) == 5)\nassert(max_fill(grid: [[0, 0, 0], [0, 0, 0]], capacity: 5) == 0)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 2) == 4)\nassert(max_fill(grid: [[1, 1, 1, 1], [1, 1, 1, 1]], capacity: 9) == 2)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1624,7 +220,7 @@
     "language": "swift",
     "prompt": "\n/// In this Kata, you have to sort an array of non-negative integers according to\n/// number of ones in their binary representation in ascending order.\n/// For similar number of ones, sort based on decimal value.\n/// It must be implemented like this:\n/// >>> sort_array(arr: [1, 5, 2, 3, 4])\n/// [1, 2, 3, 4, 5]\n/// >>> sort_array(arr: [-2, -3, -4, -5, -6])\n/// [-6, -5, -4, -3, -2]\n/// >>> sort_array(arr: [1, 0, 2, 3, 4])\n/// [0, 1, 2, 3, 4]\nfunc sort_array(arr: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(arr: [1, 5, 2, 3, 4]) == [1, 2, 4, 3, 5])\nassert(sort_array(arr: [-2, -3, -4, -5, -6]) == [-4, -2, -6, -5, -3])\nassert(sort_array(arr: [1, 0, 2, 3, 4]) == [0, 1, 2, 4, 3])\nassert(sort_array(arr: [] as [Int]) == [] as [Int])\nassert(sort_array(arr: [2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]) == [2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77])\nassert(sort_array(arr: [3, 6, 44, 12, 32, 5]) == [32, 3, 5, 6, 12, 44])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])\nassert(sort_array(arr: [2, 4, 8, 16, 32]) == [2, 4, 8, 16, 32])",
     "stop_tokens": [
@@ -1632,133 +228,373 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "swift",
-    "prompt": "\n/// Concatenate list of strings into a single string\n/// >>> concatenate(strings: [] as [String])\n/// \"\"\n/// >>> concatenate(strings: [\"a\", \"b\", \"c\"])\n/// \"abc\"\nfunc concatenate(strings: [String]) -> String {\n",
+    "prompt": "\n/// Given a string s and a natural number n, you have been tasked to implement \n/// a function that returns a list of all words from string s that contain exactly \n/// n consonants, in order these words appear in the string s.\n/// If the string s is empty then the function should return an empty list.\n/// Note: you may assume the input string contains only letters and spaces.\n/// Examples:\n/// >>> select_words(s: \"Mary had a little lamb\", n: 4)\n/// [\"little\"]\n/// >>> select_words(s: \"Mary had a little lamb\", n: 3)\n/// [\"Mary\", \"lamb\"]\n/// >>> select_words(s: \"simple white space\", n: 2)\n/// [] as [String]\n/// >>> select_words(s: \"Hello world\", n: 4)\n/// [\"world\"]\n/// >>> select_words(s: \"Uncle sam\", n: 3)\n/// [\"Uncle\"]\nfunc select_words(s: String, n: Int) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(select_words(s: \"Mary had a little lamb\", n: 4) == [\"little\"])\nassert(select_words(s: \"Mary had a little lamb\", n: 3) == [\"Mary\", \"lamb\"])\nassert(select_words(s: \"simple white space\", n: 2) == [] as [String])\nassert(select_words(s: \"Hello world\", n: 4) == [\"world\"])\nassert(select_words(s: \"Uncle sam\", n: 3) == [\"Uncle\"])\nassert(select_words(s: \"\", n: 4) == [] as [String])\nassert(select_words(s: \"a b c d e f\", n: 1) == [\"b\", \"c\", \"d\", \"f\"])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"])\n/// [\"aa\"]\n/// >>> sorted_list_sum(lst: [\"ab\", \"a\", \"aaa\", \"cd\"])\n/// [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
+    "prompt": "\n/// You are given a word. Your task is to find the closest vowel that stands between \n/// two consonants from the right side of the word (case sensitive).\n/// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n/// find any vowel met the above condition. \n/// You may assume that the given string contains English letter only.\n/// Example:\n/// >>> get_closest_vowel(word: \"yogurt\")\n/// \"u\"\n/// >>> get_closest_vowel(word: \"FULL\")\n/// \"U\"\n/// >>> get_closest_vowel(word: \"quick\")\n/// \"\"\n/// >>> get_closest_vowel(word: \"ab\")\n/// \"\"\nfunc get_closest_vowel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_closest_vowel(word: \"yogurt\") == \"u\")\nassert(get_closest_vowel(word: \"full\") == \"u\")\nassert(get_closest_vowel(word: \"easy\") == \"\")\nassert(get_closest_vowel(word: \"eAsy\") == \"\")\nassert(get_closest_vowel(word: \"ali\") == \"\")\nassert(get_closest_vowel(word: \"bad\") == \"a\")\nassert(get_closest_vowel(word: \"most\") == \"o\")\nassert(get_closest_vowel(word: \"ab\") == \"\")\nassert(get_closest_vowel(word: \"ba\") == \"\")\nassert(get_closest_vowel(word: \"quick\") == \"\")\nassert(get_closest_vowel(word: \"anime\") == \"i\")\nassert(get_closest_vowel(word: \"Asia\") == \"\")\nassert(get_closest_vowel(word: \"Above\") == \"o\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "swift",
-    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring(strings: [] as [String], substring: \"a\")\n/// [] as [String]\n/// >>> filter_by_substring(strings: [\"abc\", \"bacd\", \"cde\", \"array\"], substring: \"a\")\n/// [\"abc\", \"bacd\", \"array\"]\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "prompt": "\n/// You are given a list of two strings, both strings consist of open\n/// parentheses '(' or close parentheses ')' only.\n/// Your job is to check if it is possible to concatenate the two strings in\n/// some order, that the resulting string will be good.\n/// A string S is considered to be good if and only if all parentheses in S\n/// are balanced. For example: the string '(())()' is good, while the string\n/// '())' is not.\n/// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n/// Examples:\n/// >>> match_parens(lst: [\"()(\", \")\"])\n/// \"Yes\"\n/// >>> match_parens(lst: [\")\", \")\"])\n/// \"No\"\nfunc match_parens(lst: [String]) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(match_parens(lst: [\"()(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \")\"]) == \"No\")\nassert(match_parens(lst: [\"(()(())\", \"())())\"]) == \"No\")\nassert(match_parens(lst: [\")())\", \"(()()(\"]) == \"Yes\")\nassert(match_parens(lst: [\"(())))\", \"(()())((\"]) == \"Yes\")\nassert(match_parens(lst: [\"()\", \"())\"]) == \"No\")\nassert(match_parens(lst: [\"(()(\", \"()))()\"]) == \"Yes\")\nassert(match_parens(lst: [\"((((\", \"((())\"]) == \"No\")\nassert(match_parens(lst: [\")(()\", \"(()(\"]) == \"No\")\nassert(match_parens(lst: [\")(\", \")(\"]) == \"No\")\nassert(match_parens(lst: [\"(\", \")\"]) == \"Yes\")\nassert(match_parens(lst: [\")\", \"(\"]) == \"Yes\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "swift",
-    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(value: \"10\")\n/// 10\n/// >>> closest_integer(value: \"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "prompt": "\n/// Input are two strings a and b consisting only of 1s and 0s.\n/// Perform binary XOR on these inputs and return result also as a string.\n/// >>> string_xor(a: \"010\", b: \"110\")\n/// \"100\"\nfunc string_xor(a: String, b: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_xor(a: \"111000\", b: \"101010\") == \"010010\")\nassert(string_xor(a: \"1\", b: \"1\") == \"0\")\nassert(string_xor(a: \"0101\", b: \"0000\") == \"0101\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "swift",
-    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(s: \"abcde\")\n/// 2\n/// >>> vowels_count(s: \"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
+    "prompt": "\n/// Given an array arr of integers and a positive integer k, return a sorted list \n/// of length k with the maximum k numbers in arr.\n/// Example 1:\n/// >>> maximum(arr: [-3, -4, 5], k: 3)\n/// [-4, -3, 5]\n/// Example 2:\n/// >>> maximum(arr: [4, -4, 4], k: 2)\n/// [4, 4]\n/// Example 3:\n/// >>> maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1)\n/// [2]\n/// Note:\n/// 1. The length of the array will be in the range of [1, 1000].\n/// 2. The elements in the array will be in the range of [-1000, 1000].\n/// 3. 0 <= k <= len(arr)\nfunc maximum(arr: [Int], k: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(arr: [-3, -4, 5], k: 3) == [-4, -3, 5])\nassert(maximum(arr: [4, -4, 4], k: 2) == [4, 4])\nassert(maximum(arr: [-3, 2, 1, 2, -1, -2, 1], k: 1) == [2])\nassert(maximum(arr: [123, -123, 20, 0, 1, 2, -3], k: 3) == [2, 20, 123])\nassert(maximum(arr: [-123, 20, 0, 1, 2, -3], k: 4) == [0, 1, 2, 20])\nassert(maximum(arr: [5, 15, 0, 3, -13, -8, 0], k: 7) == [-13, -8, 0, 0, 3, 5, 15])\nassert(maximum(arr: [-1, 0, 2, 5, 3, -10], k: 2) == [3, 5])\nassert(maximum(arr: [1, 0, 5, -7], k: 1) == [5])\nassert(maximum(arr: [4, -4], k: 2) == [-4, 4])\nassert(maximum(arr: [-10, 10], k: 2) == [-10, 10])\nassert(maximum(arr: [1, 2, 3, -23, 243, -400, 0], k: 0) == [] as [Int])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "swift",
-    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(words: [\"name\", \"of\", \"string\"])\n/// \"string\"\n/// >>> find_max(words: [\"name\", \"enam\", \"game\"])\n/// \"enam\"\n/// >>> find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"])\n/// \"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
+    "prompt": "\n/// Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n/// Examples\n/// >>> solution(lst: [5, 8, 7, 1])\n/// 12\n/// >>> solution(lst: [3, 3, 3, 3, 3])\n/// 9\n/// >>> solution(lst: [30, 13, 24, 321])\n/// 0\nfunc solution(lst: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solution(lst: [5, 8, 7, 1]) == 12)\nassert(solution(lst: [3, 3, 3, 3, 3]) == 9)\nassert(solution(lst: [30, 13, 24, 321]) == 0)\nassert(solution(lst: [5, 9]) == 5)\nassert(solution(lst: [2, 4, 8]) == 0)\nassert(solution(lst: [30, 13, 23, 32]) == 23)\nassert(solution(lst: [3, 13, 2, 9]) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "swift",
-    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(text: \"Hello world\")\n/// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunc string_to_md5(text: String) -> String? {\n",
+    "prompt": "\n/// Given a non-empty array of integers arr and an integer k, return\n/// the sum of the elements with at most two digits from the first k elements of arr.\n/// Example:\n/// >>> add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4)\n/// 24\n/// Constraints:\n/// 1. 1 <= len(arr) <= 100\n/// 2. 1 <= k <= len(arr)\nfunc add_elements(arr: [Int], k: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_elements(arr: [1, -2, -3, 41, 57, 76, 87, 88, 99], k: 3) == -4)\nassert(add_elements(arr: [111, 121, 3, 4000, 5, 6], k: 2) == 0)\nassert(add_elements(arr: [11, 21, 3, 90, 5, 6, 7, 8, 9], k: 4) == 125)\nassert(add_elements(arr: [111, 21, 3, 4000, 5, 6, 7, 8, 9], k: 4) == 24)\nassert(add_elements(arr: [1], k: 1) == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "swift",
-    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(x: 8, base: 3)\n/// \"22\"\n/// >>> change_base(x: 8, base: 2)\n/// \"1000\"\n/// >>> change_base(x: 7, base: 2)\n/// \"111\"\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "prompt": "\n/// Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n/// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n/// as follows: start with any positive integer n. Then each term is obtained from the \n/// previous term as follows: if the previous term is even, the next term is one half of \n/// the previous term. If the previous term is odd, the next term is 3 times the previous\n/// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n/// Note: \n/// 1. Collatz(1) is [1].\n/// 2. returned list sorted in increasing order.\n/// For example:\n/// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n/// >>> get_odd_collatz(n: 5)\n/// [1, 5]\nfunc get_odd_collatz(n: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_odd_collatz(n: 14) == [1, 5, 7, 11, 13, 17])\nassert(get_odd_collatz(n: 5) == [1, 5])\nassert(get_odd_collatz(n: 12) == [1, 3, 5])\nassert(get_odd_collatz(n: 1) == [1])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "swift",
-    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(a: 3, b: 4, c: 5)\n/// true\n/// >>> right_angle_triangle(a: 1, b: 2, c: 3)\n/// false\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "prompt": "\n/// You have to write a function which validates a given date string and\n/// returns True if the date is valid otherwise False.\n/// The date is valid if all of the following rules are satisfied:\n/// 1. The date string is not empty.\n/// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n/// 3. The months should not be less than 1 or higher than 12.\n/// 4. The date should be in the format: mm-dd-yyyy\n/// >>> valid_date(date: \"03-11-2000\")\n/// true\n/// >>> valid_date(date: \"15-01-2012\")\n/// false\n/// >>> valid_date(date: \"04-0-2040\")\n/// false\n/// >>> valid_date(date: \"06-04-2020\")\n/// true\n/// >>> valid_date(date: \"06/04/2020\")\n/// false\nfunc valid_date(date: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(valid_date(date: \"03-11-2000\") == true)\nassert(valid_date(date: \"15-01-2012\") == false)\nassert(valid_date(date: \"04-0-2040\") == false)\nassert(valid_date(date: \"06-04-2020\") == true)\nassert(valid_date(date: \"01-01-2007\") == true)\nassert(valid_date(date: \"03-32-2011\") == false)\nassert(valid_date(date: \"\") == false)\nassert(valid_date(date: \"04-31-3000\") == false)\nassert(valid_date(date: \"06-06-2005\") == true)\nassert(valid_date(date: \"21-31-2000\") == false)\nassert(valid_date(date: \"04-12-2003\") == true)\nassert(valid_date(date: \"04122003\") == false)\nassert(valid_date(date: \"20030412\") == false)\nassert(valid_date(date: \"2003-04\") == false)\nassert(valid_date(date: \"2003-04-12\") == false)\nassert(valid_date(date: \"04-2003\") == false)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "swift",
-    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5])\n/// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "prompt": "\nextension Int: Error {}\n        \n/// Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n/// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n/// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n/// Examples\n/// >>> split_words(txt: \"Hello world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"Hello,world!\")\n/// .success([\"Hello\", \"world!\"])\n/// >>> split_words(txt: \"abcdef\")\n/// .failure(3)\nfunc split_words(txt: String) -> Result<[String], Int> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_words(txt: \"Hello world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello,world!\") == .success([\"Hello\", \"world!\"]))\nassert(split_words(txt: \"Hello world,!\") == .success([\"Hello\", \"world,!\"]))\nassert(split_words(txt: \"Hello,Hello,world !\") == .success([\"Hello,Hello,world\", \"!\"]))\nassert(split_words(txt: \"abcdef\") == .failure(3))\nassert(split_words(txt: \"aaabb\") == .failure(2))\nassert(split_words(txt: \"aaaBb\") == .failure(1))\nassert(split_words(txt: \"\") == .failure(0))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "swift",
-    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse(numbers: [] as [Int], delimeter: 4)\n/// [] as [Int]\n/// >>> intersperse(numbers: [1, 2, 3], delimeter: 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "prompt": "\n/// Given a list of numbers, return whether or not they are sorted\n/// in ascending order. If list has more than 1 duplicate of the same\n/// number, return False. Assume no negative numbers and only integers.\n/// Examples\n/// >>> is_sorted(lst: [5])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5])\n/// false\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6])\n/// true\n/// >>> is_sorted(lst: [1, 2, 3, 4, 5, 6, 7])\n/// true\n/// >>> is_sorted(lst: [1, 3, 2, 4, 5, 6, 7])\n/// false\n/// >>> is_sorted(lst: [1, 2, 2, 3, 3, 4])\n/// true\n/// >>> is_sorted(lst: [1, 2, 2, 2, 3, 4])\n/// false\nfunc is_sorted(lst: [Int]) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sorted(lst: [5]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5]) == false)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4, 5, 6, 7]) == true)\nassert(is_sorted(lst: [1, 3, 2, 4, 5, 6, 7]) == false)\nassert(is_sorted(lst: [] as [Int]) == true)\nassert(is_sorted(lst: [1]) == true)\nassert(is_sorted(lst: [3, 2, 1]) == false)\nassert(is_sorted(lst: [1, 2, 2, 2, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 3, 3, 3, 4]) == false)\nassert(is_sorted(lst: [1, 2, 2, 3, 3, 4]) == true)\nassert(is_sorted(lst: [1, 2, 3, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "swift",
+    "prompt": "\n/// You are given two intervals,\n/// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n/// The given intervals are closed which means that the interval (start, end)\n/// includes both start and end.\n/// For each given interval, it is assumed that its start is less or equal its end.\n/// Your task is to determine whether the length of intersection of these two \n/// intervals is a prime number.\n/// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n/// which its length is 1, which not a prime number.\n/// If the length of the intersection is a prime number, return \"YES\",\n/// otherwise, return \"NO\".\n/// If the two intervals don't intersect, return \"NO\".\n/// [input/output] samples:\n/// >>> intersection(interval1: (1, 2), interval2: (2, 3))\n/// \"NO\"\n/// >>> intersection(interval1: (-1, 1), interval2: (0, 4))\n/// \"NO\"\n/// >>> intersection(interval1: (-3, -1), interval2: (-5, 5))\n/// \"YES\"\nfunc intersection(interval1: (Int, Int), interval2: (Int, Int)) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection(interval1: (1, 2), interval2: (2, 3)) == \"NO\")\nassert(intersection(interval1: (-1, 1), interval2: (0, 4)) == \"NO\")\nassert(intersection(interval1: (-3, -1), interval2: (-5, 5)) == \"YES\")\nassert(intersection(interval1: (-2, 2), interval2: (-4, 0)) == \"YES\")\nassert(intersection(interval1: (-11, 2), interval2: (-1, -1)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (3, 5)) == \"NO\")\nassert(intersection(interval1: (1, 2), interval2: (1, 2)) == \"NO\")\nassert(intersection(interval1: (-2, -2), interval2: (-3, -2)) == \"NO\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "swift",
+    "prompt": "\n/// You are given an array arr of integers and you need to return\n/// sum of magnitudes of integers multiplied by product of all signs\n/// of each number in the array, represented by 1, -1 or 0.\n/// Note: return None for empty arr.\n/// Example:\n/// >>> prod_signs(arr: [1, 2, 2, -4])\n/// 9\n/// >>> prod_signs(arr: [0, 1])\n/// 0\n/// >>> prod_signs(arr: [] as [Int])\n/// nil\nfunc prod_signs(arr: [Int]) -> Int? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prod_signs(arr: [1, 2, 2, -4]) == -9)\nassert(prod_signs(arr: [0, 1]) == 0)\nassert(prod_signs(arr: [1, 1, 1, 2, 3, -1, 1]) == -10)\nassert(prod_signs(arr: [] as [Int]) == nil)\nassert(prod_signs(arr: [2, 4, 1, 2, -1, -1, 9]) == 20)\nassert(prod_signs(arr: [-1, 1, -1, 1]) == 4)\nassert(prod_signs(arr: [-1, 1, 1, 1]) == -4)\nassert(prod_signs(arr: [-1, 1, 1, 0]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "swift",
+    "prompt": "\n/// Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n/// each cell of the grid contains a value. Every integer in the range [1, N * N]\n/// inclusive appears exactly once on the cells of the grid.\n/// You have to find the minimum path of length k in the grid. You can start\n/// from any cell, and in each step you can move to any of the neighbor cells,\n/// in other words, you can go to cells which share an edge with you current\n/// cell.\n/// Please note that a path of length k means visiting exactly k cells (not\n/// necessarily distinct).\n/// You CANNOT go off the grid.\n/// A path A (of length k) is considered less than a path B (of length k) if\n/// after making the ordered lists of the values on the cells that A and B go\n/// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n/// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n/// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n/// lst_A[j] = lst_B[j].\n/// It is guaranteed that the answer is unique.\n/// Return an ordered list of the values on the cells that the minimum path go through.\n/// Examples:    \n/// >>> minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3)\n/// [1, 2, 1]\n/// >>> minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1)\n/// [1]\nfunc minPath(grid: [[Int]], k: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minPath(grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], k: 3) == [1, 2, 1])\nassert(minPath(grid: [[5, 9, 3], [4, 1, 6], [7, 8, 2]], k: 1) == [1])\nassert(minPath(grid: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], k: 4) == [1, 2, 1, 2])\nassert(minPath(grid: [[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], k: 7) == [1, 10, 1, 10, 1, 10, 1])\nassert(minPath(grid: [[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], k: 5) == [1, 7, 1, 7, 1])\nassert(minPath(grid: [[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], k: 9) == [1, 6, 1, 6, 1, 6, 1, 6, 1])\nassert(minPath(grid: [[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], k: 12) == [1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6])\nassert(minPath(grid: [[2, 7, 4], [3, 1, 5], [6, 8, 9]], k: 8) == [1, 3, 1, 3, 1, 3, 1, 3])\nassert(minPath(grid: [[6, 1, 5], [3, 8, 9], [2, 7, 4]], k: 8) == [1, 5, 1, 5, 1, 5, 1, 5])\nassert(minPath(grid: [[1, 2], [3, 4]], k: 10) == [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])\nassert(minPath(grid: [[1, 3], [3, 2]], k: 10) == [1, 3, 1, 3, 1, 3, 1, 3, 1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "swift",
+    "prompt": "\n/// Out of list of strings, return the longest one. Return the first one in case of multiple\n/// strings of the same length. Return None in case the input list is empty.\n/// >>> longest(strings: [] as [String])\n/// nil\n/// >>> longest(strings: [\"a\", \"b\", \"c\"])\n/// \"a\"\n/// >>> longest(strings: [\"a\", \"bb\", \"ccc\"])\n/// \"ccc\"\nfunc longest(strings: [String]) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(longest(strings: [] as [String]) == nil)\nassert(longest(strings: [\"x\", \"y\", \"z\"]) == \"x\")\nassert(longest(strings: [\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]) == \"zzzz\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "swift",
+    "prompt": "\n/// Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n/// the last couple centuries. However, what people don't know is Tribonacci sequence.\n/// Tribonacci sequence is defined by the recurrence:\n/// tri(1) = 3\n/// tri(n) = 1 + n / 2, if n is even.\n/// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n/// For example:\n/// tri(2) = 1 + (2 / 2) = 2\n/// tri(4) = 3\n/// tri(3) = tri(2) + tri(1) + tri(4)\n/// = 2 + 3 + 3 = 8 \n/// You are given a non-negative integer number n, you have to a return a list of the \n/// first n + 1 numbers of the Tribonacci sequence.\n/// Examples:\n/// >>> tri(n: 3)\n/// [1, 3, 2, 8]\nfunc tri(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tri(n: 3) == [1, 3, 2, 8])\nassert(tri(n: 4) == [1, 3, 2, 8, 3])\nassert(tri(n: 5) == [1, 3, 2, 8, 3, 15])\nassert(tri(n: 6) == [1, 3, 2, 8, 3, 15, 4])\nassert(tri(n: 7) == [1, 3, 2, 8, 3, 15, 4, 24])\nassert(tri(n: 8) == [1, 3, 2, 8, 3, 15, 4, 24, 5])\nassert(tri(n: 9) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35])\nassert(tri(n: 20) == [1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11])\nassert(tri(n: 0) == [1])\nassert(tri(n: 1) == [1, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the product of the odd digits.\n/// Return 0 if all digits are even.\n/// For example:\n/// >>> digits(n: 1)\n/// 1\n/// >>> digits(n: 4)\n/// 0\n/// >>> digits(n: 235)\n/// 15\nfunc digits(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digits(n: 5) == 5)\nassert(digits(n: 54) == 5)\nassert(digits(n: 120) == 1)\nassert(digits(n: 5014) == 5)\nassert(digits(n: 98765) == 315)\nassert(digits(n: 5576543) == 2625)\nassert(digits(n: 2468) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a string as input which contains only square brackets.\n/// The function should return True if and only if there is a valid subsequence of brackets \n/// where at least one bracket in the subsequence is nested.\n/// >>> is_nested(string: \"[[]]\")\n/// true\n/// >>> is_nested(string: \"[]]]]]]][[[[[]\")\n/// false\n/// >>> is_nested(string: \"[][]\")\n/// false\n/// >>> is_nested(string: \"[]\")\n/// false\n/// >>> is_nested(string: \"[[][]]\")\n/// true\n/// >>> is_nested(string: \"[[]][[\")\n/// true\nfunc is_nested(string: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nested(string: \"[[]]\") == true)\nassert(is_nested(string: \"[]]]]]]][[[[[]\") == false)\nassert(is_nested(string: \"[][]\") == false)\nassert(is_nested(string: \"[]\") == false)\nassert(is_nested(string: \"[[[[]]]]\") == true)\nassert(is_nested(string: \"[]]]]]]]]]]\") == false)\nassert(is_nested(string: \"[][][[]]\") == true)\nassert(is_nested(string: \"[[]\") == false)\nassert(is_nested(string: \"[]]\") == false)\nassert(is_nested(string: \"[[]][[\") == true)\nassert(is_nested(string: \"[[][]]\") == true)\nassert(is_nested(string: \"\") == false)\nassert(is_nested(string: \"[[[[[[[[\") == false)\nassert(is_nested(string: \"]]]]]]]]\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of numbers.\n/// You need to return the sum of squared numbers in the given list,\n/// round each element in the list to the upper int(Ceiling) first.\n/// Examples:\n/// >>> sum_squares(lst: [1.0, 2.0, 3.0])\n/// 14\n/// >>> sum_squares(lst: [1.0, 4.0, 9.0])\n/// 98\n/// >>> sum_squares(lst: [1.0, 3.0, 5.0, 7.0])\n/// 84\n/// >>> sum_squares(lst: [1.4, 4.2, 0.0])\n/// 29\n/// >>> sum_squares(lst: [-2.4, 1.0, 1.0])\n/// 6\nfunc sum_squares(lst: [Double]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 2.0, 3.0]) == 14)\nassert(sum_squares(lst: [1.0, 3.0, 5.0, 7.0]) == 84)\nassert(sum_squares(lst: [1.4, 4.2, 0.0]) == 29)\nassert(sum_squares(lst: [-2.4, 1.0, 1.0]) == 6)\nassert(sum_squares(lst: [100.0, 1.0, 15.0, 2.0]) == 10230)\nassert(sum_squares(lst: [10000.0, 10000.0]) == 200000000)\nassert(sum_squares(lst: [-1.4, 4.6, 6.3]) == 75)\nassert(sum_squares(lst: [-1.4, 17.9, 18.9, 19.9]) == 1086)\nassert(sum_squares(lst: [0.0]) == 0)\nassert(sum_squares(lst: [-1.0]) == 1)\nassert(sum_squares(lst: [-1.0, 1.0, 0.0]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns True if the last character\n/// of a given string is an alphabetical character and is not\n/// a part of a word, and False otherwise.\n/// Note: \"word\" is a group of characters separated by space.\n/// Examples:\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pie\")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e\")\n/// true\n/// >>> check_if_last_char_is_a_letter(txt: \"apple pi e \")\n/// false\n/// >>> check_if_last_char_is_a_letter(txt: \"\")\n/// false\nfunc check_if_last_char_is_a_letter(txt: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_if_last_char_is_a_letter(txt: \"apple\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"A\") == true)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"Pumpkin pie 1\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"eeeee e \") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pie\") == false)\nassert(check_if_last_char_is_a_letter(txt: \"apple pi e \") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "swift",
+    "prompt": "\n/// Create a function which returns the largest index of an element which\n/// is not greater than or equal to the element immediately preceding it. If\n/// no such element exists then return -1. The given array will not contain\n/// duplicate values.\n/// Examples:\n/// >>> can_arrange(arr: [1, 2, 4, 3, 5])\n/// 3\n/// >>> can_arrange(arr: [1, 2, 3])\n/// -1\nfunc can_arrange(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(can_arrange(arr: [1, 2, 4, 3, 5]) == 3)\nassert(can_arrange(arr: [1, 2, 4, 5]) == -1)\nassert(can_arrange(arr: [1, 4, 2, 5, 6, 7, 8, 9, 10]) == 2)\nassert(can_arrange(arr: [4, 8, 5, 7, 3]) == 4)\nassert(can_arrange(arr: [] as [Int]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "swift",
+    "prompt": "\n/// Create a function that returns a tuple (a, b), where 'a' is\n/// the largest of negative integers, and 'b' is the smallest\n/// of positive integers in a list.\n/// If there is no negative or positive integers, return them as None.\n/// Examples:\n/// >>> largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7])\n/// (nil, 1)\n/// >>> largest_smallest_integers(lst: [] as [Int])\n/// (nil, nil)\n/// >>> largest_smallest_integers(lst: [0])\n/// (nil, nil)\nfunc largest_smallest_integers(lst: [Int]) -> (Int?, Int?) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7]) == (nil, 1))\nassert(largest_smallest_integers(lst: [2, 4, 1, 3, 5, 7, 0]) == (nil, 1))\nassert(largest_smallest_integers(lst: [1, 3, 2, 4, 5, 6, -2]) == (-2, 1))\nassert(largest_smallest_integers(lst: [4, 5, 3, 6, 2, 7, -7]) == (-7, 2))\nassert(largest_smallest_integers(lst: [7, 3, 8, 4, 9, 2, 5, -9]) == (-9, 2))\nassert(largest_smallest_integers(lst: [] as [Int]) == (nil, nil))\nassert(largest_smallest_integers(lst: [0]) == (nil, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-1, -3, -5, -6, 0]) == (-1, nil))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, 1]) == (-3, 1))\nassert(largest_smallest_integers(lst: [-6, -4, -4, -3, -100, 1]) == (-3, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_137_compare_one",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case doubleValue(Double)\n    case stringValue(String)\n}\n\n            \n/// Create a function that takes integers, floats, or strings representing\n/// real numbers, and returns the larger variable in its given variable type.\n/// Return None if the values are equal.\n/// Note: If a real number is represented as a string, the floating point might be . or ,\n/// >>> compare_one(a: .intValue(1), b: .doubleValue(2.5))\n/// .doubleValue(2.5)\n/// >>> compare_one(a: .intValue(1), b: .stringValue(\"2,3\"))\n/// .stringValue(\"2,3\")\n/// >>> compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\"))\n/// .stringValue(\"6\")\n/// >>> compare_one(a: .stringValue(\"1\"), b: .intValue(1))\n/// nil\nfunc compare_one(a: Value, b: Value) -> Value? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_137_compare_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare_one(a: .intValue(1), b: .intValue(2)) == .intValue(2))\nassert(compare_one(a: .intValue(1), b: .doubleValue(2.5)) == .doubleValue(2.5))\nassert(compare_one(a: .intValue(2), b: .intValue(3)) == .intValue(3))\nassert(compare_one(a: .intValue(5), b: .intValue(6)) == .intValue(6))\nassert(compare_one(a: .intValue(1), b: .stringValue(\"2,3\")) == .stringValue(\"2,3\"))\nassert(compare_one(a: .stringValue(\"5,1\"), b: .stringValue(\"6\")) == .stringValue(\"6\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .stringValue(\"2\")) == .stringValue(\"2\"))\nassert(compare_one(a: .stringValue(\"1\"), b: .intValue(1)) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "swift",
+    "prompt": "\n/// Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n/// Example\n/// >>> is_equal_to_sum_even(n: 4)\n/// false\n/// >>> is_equal_to_sum_even(n: 6)\n/// false\n/// >>> is_equal_to_sum_even(n: 8)\n/// true\nfunc is_equal_to_sum_even(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_equal_to_sum_even(n: 4) == false)\nassert(is_equal_to_sum_even(n: 6) == false)\nassert(is_equal_to_sum_even(n: 8) == true)\nassert(is_equal_to_sum_even(n: 10) == true)\nassert(is_equal_to_sum_even(n: 11) == false)\nassert(is_equal_to_sum_even(n: 12) == true)\nassert(is_equal_to_sum_even(n: 13) == false)\nassert(is_equal_to_sum_even(n: 16) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "swift",
+    "prompt": "\n/// The Brazilian factorial is defined as:\n/// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n/// where n > 0\n/// For example:\n/// >>> special_factorial(n: 4)\n/// 288\n/// The function will receive an integer as input and should return the special\n/// factorial of this integer.\nfunc special_factorial(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(special_factorial(n: 4) == 288)\nassert(special_factorial(n: 5) == 34560)\nassert(special_factorial(n: 7) == 125411328000)\nassert(special_factorial(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "swift",
+    "prompt": "\n/// Return a greatest common divisor of two integers a and b\n/// >>> greatest_common_divisor(a: 3, b: 5)\n/// 1\n/// >>> greatest_common_divisor(a: 25, b: 15)\n/// 5\nfunc greatest_common_divisor(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(greatest_common_divisor(a: 3, b: 7) == 1)\nassert(greatest_common_divisor(a: 10, b: 15) == 5)\nassert(greatest_common_divisor(a: 49, b: 14) == 7)\nassert(greatest_common_divisor(a: 144, b: 60) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "swift",
+    "prompt": "\n/// Given a string text, replace all spaces in it with underscores, \n/// and if a string has more than 2 consecutive spaces, \n/// then replace all consecutive spaces with - \n/// >>> fix_spaces(text: \" Example\")\n/// \"Example\"\n/// >>> fix_spaces(text: \" Example 1\")\n/// \"Example_1\"\n/// >>> fix_spaces(text: \" Example 2\")\n/// \"_Example_2\"\n/// >>> fix_spaces(text: \" Example 3\")\n/// \"_Example-3\"\nfunc fix_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fix_spaces(text: \"Example\") == \"Example\")\nassert(fix_spaces(text: \"Mudasir Hanif \") == \"Mudasir_Hanif_\")\nassert(fix_spaces(text: \"Yellow Yellow  Dirty  Fellow\") == \"Yellow_Yellow__Dirty__Fellow\")\nassert(fix_spaces(text: \"Exa   mple\") == \"Exa-mple\")\nassert(fix_spaces(text: \"   Exa 1 2 2 mple\") == \"-Exa_1_2_2_mple\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "swift",
+    "prompt": "\n/// Create a function which takes a string representing a file's name, and returns\n/// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n/// A file's name is considered to be valid if and only if all the following conditions \n/// are met:\n/// - There should not be more than three digits ('0'-'9') in the file's name.\n/// - The file's name contains exactly one dot '.'\n/// - The substring before the dot should not be empty, and it starts with a letter from \n/// the latin alphapet ('a'-'z' and 'A'-'Z').\n/// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n/// Examples:\n/// >>> file_name_check(file_name: \"example.txt\")\n/// \"Yes\"\n/// >>> file_name_check(file_name: \"1example.dll\")\n/// \"No\"\nfunc file_name_check(file_name: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(file_name_check(file_name: \"example.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"1example.dll\") == \"No\")\nassert(file_name_check(file_name: \"s1sdf3.asd\") == \"No\")\nassert(file_name_check(file_name: \"K.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"MY16FILE3.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"His12FILE94.exe\") == \"No\")\nassert(file_name_check(file_name: \"_Y.txt\") == \"No\")\nassert(file_name_check(file_name: \"?aREYA.exe\") == \"No\")\nassert(file_name_check(file_name: \"/this_is_valid.dll\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.wow\") == \"No\")\nassert(file_name_check(file_name: \"this_is_valid.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"this_is_valid.txtexe\") == \"No\")\nassert(file_name_check(file_name: \"#this2_i4s_5valid.ten\") == \"No\")\nassert(file_name_check(file_name: \"@this1_is6_valid.exe\") == \"No\")\nassert(file_name_check(file_name: \"this_is_12valid.6exe4.txt\") == \"No\")\nassert(file_name_check(file_name: \"all.exe.txt\") == \"No\")\nassert(file_name_check(file_name: \"I563_No.exe\") == \"Yes\")\nassert(file_name_check(file_name: \"Is3youfault.txt\") == \"Yes\")\nassert(file_name_check(file_name: \"no_one#knows.dll\") == \"Yes\")\nassert(file_name_check(file_name: \"1I563_Yes3.exe\") == \"No\")\nassert(file_name_check(file_name: \"I563_Yes3.txtt\") == \"No\")\nassert(file_name_check(file_name: \"final..txt\") == \"No\")\nassert(file_name_check(file_name: \"final132\") == \"No\")\nassert(file_name_check(file_name: \"_f4indsartal132.\") == \"No\")\nassert(file_name_check(file_name: \".txt\") == \"No\")\nassert(file_name_check(file_name: \"s.\") == \"No\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "swift",
+    "prompt": "\n/// You are given a string representing a sentence,\n/// the sentence contains some words separated by a space,\n/// and you have to return a string that contains the words from the original sentence,\n/// whose lengths are prime numbers,\n/// the order of the words in the new string should be the same as the original one.\n/// Example 1:\n/// >>> words_in_sentence(sentence: \"This is a test\")\n/// \"is\"\n/// Example 2:\n/// >>> words_in_sentence(sentence: \"lets go for swimming\")\n/// \"go for\"\n/// Constraints:\n/// * 1 <= len(sentence) <= 100\n/// * sentence contains only letters\nfunc words_in_sentence(sentence: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(words_in_sentence(sentence: \"This is a test\") == \"is\")\nassert(words_in_sentence(sentence: \"lets go for swimming\") == \"go for\")\nassert(words_in_sentence(sentence: \"there is no place available here\") == \"there is no place\")\nassert(words_in_sentence(sentence: \"Hi I am Hussein\") == \"Hi am Hussein\")\nassert(words_in_sentence(sentence: \"go for it\") == \"go for it\")\nassert(words_in_sentence(sentence: \"here\") == \"\")\nassert(words_in_sentence(sentence: \"here is\") == \"is\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "swift",
+    "prompt": "\n/// Your task is to implement a function that will simplify the expression\n/// x * n. The function returns True if x * n evaluates to a whole number and False\n/// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n/// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n/// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n/// >>> simplify(x: \"1/5\", n: \"5/1\")\n/// true\n/// >>> simplify(x: \"1/6\", n: \"2/1\")\n/// false\n/// >>> simplify(x: \"7/10\", n: \"10/2\")\n/// false\nfunc simplify(x: String, n: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/6\", n: \"2/1\") == false)\nassert(simplify(x: \"5/1\", n: \"3/1\") == true)\nassert(simplify(x: \"7/10\", n: \"10/2\") == false)\nassert(simplify(x: \"2/10\", n: \"50/10\") == true)\nassert(simplify(x: \"7/2\", n: \"4/2\") == true)\nassert(simplify(x: \"11/6\", n: \"6/1\") == true)\nassert(simplify(x: \"2/3\", n: \"5/2\") == false)\nassert(simplify(x: \"5/2\", n: \"3/5\") == false)\nassert(simplify(x: \"2/4\", n: \"8/4\") == true)\nassert(simplify(x: \"2/4\", n: \"4/2\") == true)\nassert(simplify(x: \"1/5\", n: \"5/1\") == true)\nassert(simplify(x: \"1/5\", n: \"1/5\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "swift",
+    "prompt": "\n/// Write a function which sorts the given list of integers\n/// in ascending order according to the sum of their digits.\n/// Note: if there are several items with similar sum of their digits,\n/// order them based on their index in original list.\n/// For example:\n/// >>> order_by_points(nums: [1, 11, -1, -11, -12])\n/// [-1, -11, 1, -12, 11]\n/// >>> order_by_points(nums: [] as [Int])\n/// [] as [Int]\nfunc order_by_points(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(order_by_points(nums: [1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11])\nassert(order_by_points(nums: [1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]) == [0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457])\nassert(order_by_points(nums: [] as [Int]) == [] as [Int])\nassert(order_by_points(nums: [1, -11, -32, 43, 54, -98, 2, -3]) == [-3, -32, -98, -11, 1, 2, 43, 54])\nassert(order_by_points(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == [1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9])\nassert(order_by_points(nums: [0, 6, 6, -76, -21, 23, 4]) == [-76, -21, 0, 4, 23, 6, 6])",
     "stop_tokens": [
       "\n}"
     ]
@@ -1768,7 +604,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function that takes an array of numbers as input and returns \n/// the number of elements in the array that are greater than 10 and both \n/// first and last digits of a number are odd (1, 3, 5, 7, 9).\n/// For example:\n/// >>> specialFilter(nums: [15, -73, 14, -15])\n/// 1\n/// >>> specialFilter(nums: [33, -2, -3, 45, 21, 109])\n/// 2\nfunc specialFilter(nums: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(specialFilter(nums: [5, -2, 1, -5]) == 0)\nassert(specialFilter(nums: [15, -73, 14, -15]) == 1)\nassert(specialFilter(nums: [33, -2, -3, 45, 21, 109]) == 2)\nassert(specialFilter(nums: [43, -12, 93, 125, 121, 109]) == 4)\nassert(specialFilter(nums: [71, -2, -33, 75, 21, 19]) == 3)\nassert(specialFilter(nums: [1]) == 0)\nassert(specialFilter(nums: [] as [Int]) == 0)",
     "stop_tokens": [
@@ -1776,25 +612,205 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "swift",
-    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(n: 30)\n/// 465\n/// >>> sum_to_n(n: 100)\n/// 5050\n/// >>> sum_to_n(n: 5)\n/// 15\n/// >>> sum_to_n(n: 10)\n/// 55\n/// >>> sum_to_n(n: 1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
+    "prompt": "\n/// You are given a positive integer n. You have to create an integer array a of length n.\n/// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n/// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n/// and a[i] + a[j] + a[k] is a multiple of 3.\n/// Example :\n/// >>> get_max_triples(n: 5)\n/// 1\n/// Explanation: \n/// a = [1, 3, 7, 13, 21]\n/// The only valid triple is (1, 7, 13).\nfunc get_max_triples(n: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_triples(n: 5) == 1)\nassert(get_max_triples(n: 6) == 4)\nassert(get_max_triples(n: 10) == 36)\nassert(get_max_triples(n: 100) == 53361)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "swift",
-    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(numbers: [1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function that accepts a list of strings as a parameter,\n/// deletes the strings that have odd lengths from it,\n/// and returns the resulted list with a sorted order,\n/// The list is always a list of strings and never an array of numbers,\n/// and it may contain duplicates.\n/// The order of the list should be ascending by length of each word, and you\n/// should return the list sorted by that rule.\n/// If two words have the same length, sort the list alphabetically.\n/// The function should return a list of strings in sorted order.\n/// You may assume that all words will have the same length.\n/// For example:\n/// >>> sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"])\n/// [\"aa\"]\n/// >>> sorted_list_sum(lst: [\"ab\", \"a\", \"aaa\", \"cd\"])\n/// [\"ab\", \"cd\"]\nfunc sorted_list_sum(lst: [String]) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sorted_list_sum(lst: [\"aa\", \"a\", \"aaa\"]) == [\"aa\"])\nassert(sorted_list_sum(lst: [\"school\", \"AI\", \"asdf\", \"b\"]) == [\"AI\", \"asdf\", \"school\"])\nassert(sorted_list_sum(lst: [\"d\", \"b\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"d\", \"dcba\", \"abcd\", \"a\"]) == [\"abcd\", \"dcba\"])\nassert(sorted_list_sum(lst: [\"AI\", \"ai\", \"au\"]) == [\"AI\", \"ai\", \"au\"])\nassert(sorted_list_sum(lst: [\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]) == [] as [String])\nassert(sorted_list_sum(lst: [\"aaaa\", \"bbbb\", \"dd\", \"cc\"]) == [\"cc\", \"dd\", \"aaaa\", \"bbbb\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "swift",
+    "prompt": "\n/// Return list of all prefixes from shortest to longest of the input string\n/// >>> all_prefixes(string: \"abc\")\n/// [\"a\", \"ab\", \"abc\"]\nfunc all_prefixes(string: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_prefixes(string: \"\") == [] as [String])\nassert(all_prefixes(string: \"asdfgh\") == [\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"])\nassert(all_prefixes(string: \"WWW\") == [\"W\", \"WW\", \"WWW\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "swift",
+    "prompt": "\n/// A simple program which should return the value of x if n is \n/// a prime number and should return the value of y otherwise.\n/// Examples:\n/// >>> x_or_y(n: 7, x: 34, y: 12)\n/// 34\n/// >>> x_or_y(n: 15, x: 8, y: 5)\n/// 5\nfunc x_or_y(n: Int, x: Int, y: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(x_or_y(n: 7, x: 34, y: 12) == 34)\nassert(x_or_y(n: 15, x: 8, y: 5) == 5)\nassert(x_or_y(n: 3, x: 33, y: 5212) == 33)\nassert(x_or_y(n: 1259, x: 3, y: 52) == 3)\nassert(x_or_y(n: 7919, x: -1, y: 12) == -1)\nassert(x_or_y(n: 3609, x: 1245, y: 583) == 583)\nassert(x_or_y(n: 91, x: 56, y: 129) == 129)\nassert(x_or_y(n: 6, x: 34, y: 1234) == 1234)\nassert(x_or_y(n: 1, x: 2, y: 0) == 0)\nassert(x_or_y(n: 2, x: 2, y: 0) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "swift",
+    "prompt": "\n/// Given a list of numbers, return the sum of squares of the numbers\n/// in the list that are odd. Ignore numbers that are negative or not integers.\n/// >>> double_the_difference(lst: [1, 3, 2, 0])\n/// 10\n/// >>> double_the_difference(lst: [-1, -2, 0])\n/// 0\n/// >>> double_the_difference(lst: [9, -2])\n/// 81\n/// >>> double_the_difference(lst: [0])\n/// 0\n/// If the input list is empty, return 0.\nfunc double_the_difference(lst: [Double]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(double_the_difference(lst: [] as [Double]) == 0)\nassert(double_the_difference(lst: [5.0, 4.0]) == 25)\nassert(double_the_difference(lst: [0.1, 0.2, 0.3]) == 0)\nassert(double_the_difference(lst: [-10.0, -20.0, -30.0]) == 0)\nassert(double_the_difference(lst: [-1.0, -2.0, 8.0]) == 0)\nassert(double_the_difference(lst: [0.2, 3.0, 5.0]) == 34)\nassert(double_the_difference(lst: [-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]) == 165)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "swift",
+    "prompt": "\n/// I think we all remember that feeling when the result of some long-awaited\n/// event is finally known. The feelings and thoughts you have at that moment are\n/// definitely worth noting down and comparing.\n/// Your task is to determine if a person correctly guessed the results of a number of matches.\n/// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n/// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n/// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n/// example:\n/// >>> compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2])\n/// [0, 0, 0, 0, 3, 3]\n/// >>> compare(game: [0, 5, 0, 0, 0, 4], guess: [4, 1, 1, 0, 0, -2])\n/// [4, 4, 1, 0, 0, 6]\nfunc compare(game: [Int], guess: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(compare(game: [1, 2, 3, 4, 5, 1], guess: [1, 2, 3, 4, 2, -2]) == [0, 0, 0, 0, 3, 3])\nassert(compare(game: [0, 0, 0, 0, 0, 0], guess: [0, 0, 0, 0, 0, 0]) == [0, 0, 0, 0, 0, 0])\nassert(compare(game: [1, 2, 3], guess: [-1, -2, -3]) == [2, 4, 6])\nassert(compare(game: [1, 2, 3, 5], guess: [-1, 2, 3, 4]) == [2, 0, 0, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "swift",
+    "prompt": "\n/// You will be given the name of a class (a string) and a list of extensions.\n/// The extensions are to be used to load additional classes to the class. The\n/// strength of the extension is as follows: Let CAP be the number of the uppercase\n/// letters in the extension's name, and let SM be the number of lowercase letters \n/// in the extension's name, the strength is given by the fraction CAP - SM. \n/// You should find the strongest extension and return a string in this \n/// format: ClassName.StrongestExtensionName.\n/// If there are two or more extensions with the same strength, you should\n/// choose the one that comes first in the list.\n/// For example, if you are given \"Slices\" as the class and a list of the\n/// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n/// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n/// (its strength is -1).\n/// Example:\n/// >>> Strongest_Extension(class_name: \"my_class\", extensions: [\"AA\", \"Be\", \"CC\"])\n/// \"my_class.AA\"\nfunc Strongest_Extension(class_name: String, extensions: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Strongest_Extension(class_name: \"Watashi\", extensions: [\"tEN\", \"niNE\", \"eIGHt8OKe\"]) == \"Watashi.eIGHt8OKe\")\nassert(Strongest_Extension(class_name: \"Boku123\", extensions: [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]) == \"Boku123.YEs.WeCaNe\")\nassert(Strongest_Extension(class_name: \"__YESIMHERE\", extensions: [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]) == \"__YESIMHERE.NuLl__\")\nassert(Strongest_Extension(class_name: \"K\", extensions: [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]) == \"K.TAR\")\nassert(Strongest_Extension(class_name: \"__HAHA\", extensions: [\"Tab\", \"123\", \"781345\", \"-_-\"]) == \"__HAHA.123\")\nassert(Strongest_Extension(class_name: \"YameRore\", extensions: [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]) == \"YameRore.okIWILL123\")\nassert(Strongest_Extension(class_name: \"finNNalLLly\", extensions: [\"Die\", \"NowW\", \"Wow\", \"WoW\"]) == \"finNNalLLly.WoW\")\nassert(Strongest_Extension(class_name: \"_\", extensions: [\"Bb\", \"91245\"]) == \"_.Bb\")\nassert(Strongest_Extension(class_name: \"Sp\", extensions: [\"671235\", \"Bb\"]) == \"Sp.671235\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "swift",
+    "prompt": "\n/// You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n/// >>> cycpattern_check(a: \"abcd\", b: \"abd\")\n/// false\n/// >>> cycpattern_check(a: \"hello\", b: \"ell\")\n/// true\n/// >>> cycpattern_check(a: \"whassup\", b: \"psus\")\n/// false\n/// >>> cycpattern_check(a: \"abab\", b: \"baa\")\n/// true\n/// >>> cycpattern_check(a: \"efef\", b: \"eeff\")\n/// false\n/// >>> cycpattern_check(a: \"himenss\", b: \"simen\")\n/// true\nfunc cycpattern_check(a: String, b: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cycpattern_check(a: \"xyzw\", b: \"xyw\") == false)\nassert(cycpattern_check(a: \"yello\", b: \"ell\") == true)\nassert(cycpattern_check(a: \"whattup\", b: \"ptut\") == false)\nassert(cycpattern_check(a: \"efef\", b: \"fee\") == true)\nassert(cycpattern_check(a: \"abab\", b: \"aabb\") == false)\nassert(cycpattern_check(a: \"winemtt\", b: \"tinem\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "swift",
+    "prompt": "\n/// Given an integer. return a tuple that has the number of even and odd digits respectively.\n/// Example:\n/// >>> even_odd_count(num: -12)\n/// (1, 1)\n/// >>> even_odd_count(num: 123)\n/// (1, 2)\nfunc even_odd_count(num: Int) -> (Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_odd_count(num: 7) == (0, 1))\nassert(even_odd_count(num: -78) == (1, 1))\nassert(even_odd_count(num: 3452) == (2, 2))\nassert(even_odd_count(num: 346211) == (3, 3))\nassert(even_odd_count(num: -345821) == (3, 3))\nassert(even_odd_count(num: -2) == (1, 0))\nassert(even_odd_count(num: -45347) == (2, 3))\nassert(even_odd_count(num: 0) == (1, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer, obtain its roman numeral equivalent as a string,\n/// and return it in lowercase.\n/// Restrictions: 1 <= num <= 1000\n/// Examples:\n/// >>> int_to_mini_roman(number: 19)\n/// \"xix\"\n/// >>> int_to_mini_roman(number: 152)\n/// \"clii\"\n/// >>> int_to_mini_roman(number: 426)\n/// \"cdxxvi\"\nfunc int_to_mini_roman(number: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(int_to_mini_roman(number: 19) == \"xix\")\nassert(int_to_mini_roman(number: 152) == \"clii\")\nassert(int_to_mini_roman(number: 251) == \"ccli\")\nassert(int_to_mini_roman(number: 426) == \"cdxxvi\")\nassert(int_to_mini_roman(number: 500) == \"d\")\nassert(int_to_mini_roman(number: 1) == \"i\")\nassert(int_to_mini_roman(number: 4) == \"iv\")\nassert(int_to_mini_roman(number: 43) == \"xliii\")\nassert(int_to_mini_roman(number: 90) == \"xc\")\nassert(int_to_mini_roman(number: 94) == \"xciv\")\nassert(int_to_mini_roman(number: 532) == \"dxxxii\")\nassert(int_to_mini_roman(number: 900) == \"cm\")\nassert(int_to_mini_roman(number: 994) == \"cmxciv\")\nassert(int_to_mini_roman(number: 1000) == \"m\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return True if the three\n/// sides form a right-angled triangle, False otherwise.\n/// A right-angled triangle is a triangle in which one angle is right angle or \n/// 90 degree.\n/// Example:\n/// >>> right_angle_triangle(a: 3, b: 4, c: 5)\n/// true\n/// >>> right_angle_triangle(a: 1, b: 2, c: 3)\n/// false\nfunc right_angle_triangle(a: Int, b: Int, c: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_angle_triangle(a: 3, b: 4, c: 5) == true)\nassert(right_angle_triangle(a: 1, b: 2, c: 3) == false)\nassert(right_angle_triangle(a: 10, b: 6, c: 8) == true)\nassert(right_angle_triangle(a: 2, b: 2, c: 2) == false)\nassert(right_angle_triangle(a: 7, b: 24, c: 25) == true)\nassert(right_angle_triangle(a: 10, b: 5, c: 7) == false)\nassert(right_angle_triangle(a: 5, b: 12, c: 13) == true)\nassert(right_angle_triangle(a: 15, b: 8, c: 17) == true)\nassert(right_angle_triangle(a: 48, b: 55, c: 73) == true)\nassert(right_angle_triangle(a: 1, b: 1, c: 1) == false)\nassert(right_angle_triangle(a: 2, b: 2, c: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts a list of strings.\n/// The list contains different words. Return the word with maximum number\n/// of unique characters. If multiple strings have maximum number of unique\n/// characters, return the one which comes first in lexicographical order.\n/// >>> find_max(words: [\"name\", \"of\", \"string\"])\n/// \"string\"\n/// >>> find_max(words: [\"name\", \"enam\", \"game\"])\n/// \"enam\"\n/// >>> find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"])\n/// \"aaaaaaa\"\nfunc find_max(words: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_max(words: [\"name\", \"of\", \"string\"]) == \"string\")\nassert(find_max(words: [\"name\", \"enam\", \"game\"]) == \"enam\")\nassert(find_max(words: [\"aaaaaaa\", \"bb\", \"cc\"]) == \"aaaaaaa\")\nassert(find_max(words: [\"abc\", \"cba\"]) == \"abc\")\nassert(find_max(words: [\"play\", \"this\", \"game\", \"of\", \"footbott\"]) == \"footbott\")\nassert(find_max(words: [\"we\", \"are\", \"gonna\", \"rock\"]) == \"gonna\")\nassert(find_max(words: [\"we\", \"are\", \"a\", \"mad\", \"nation\"]) == \"nation\")\nassert(find_max(words: [\"this\", \"is\", \"a\", \"prrk\"]) == \"this\")\nassert(find_max(words: [\"b\"]) == \"b\")\nassert(find_max(words: [\"play\", \"play\", \"play\"]) == \"play\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "swift",
+    "prompt": "\n/// You're a hungry rabbit, and you already have eaten a certain number of carrots,\n/// but now you need to eat more carrots to complete the day's meals.\n/// you should return an array of [ total number of eaten carrots after your meals,\n/// the number of carrots left after your meals ]\n/// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n/// Example:\n/// >>> eat(number: 5, need: 6, remaining: 10)\n/// [11, 4]\n/// >>> eat(number: 4, need: 8, remaining: 9)\n/// [12, 1]\n/// >>> eat(number: 1, need: 10, remaining: 10)\n/// [11, 0]\n/// >>> eat(number: 2, need: 11, remaining: 5)\n/// [7, 0]\n/// Variables:\n/// @number : integer\n/// the number of carrots that you have eaten.\n/// @need : integer\n/// the number of carrots that you need to eat.\n/// @remaining : integer\n/// the number of remaining carrots thet exist in stock\n/// Constrain:\n/// * 0 <= number <= 1000\n/// * 0 <= need <= 1000\n/// * 0 <= remaining <= 1000\n/// Have fun :)\nfunc eat(number: Int, need: Int, remaining: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eat(number: 5, need: 6, remaining: 10) == [11, 4])\nassert(eat(number: 4, need: 8, remaining: 9) == [12, 1])\nassert(eat(number: 1, need: 10, remaining: 10) == [11, 0])\nassert(eat(number: 2, need: 11, remaining: 5) == [7, 0])\nassert(eat(number: 4, need: 5, remaining: 7) == [9, 2])\nassert(eat(number: 4, need: 5, remaining: 1) == [5, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "swift",
+    "prompt": "\n/// Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n/// >>> string_sequence(n: 0)\n/// \"0\"\n/// >>> string_sequence(n: 5)\n/// \"0 1 2 3 4 5\"\nfunc string_sequence(n: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_sequence(n: 0) == \"0\")\nassert(string_sequence(n: 3) == \"0 1 2 3\")\nassert(string_sequence(n: 10) == \"0 1 2 3 4 5 6 7 8 9 10\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "swift",
+    "prompt": "\n/// Given two lists operator, and operand. The first list has basic algebra operations, and \n/// the second list is a list of integers. Use the two given lists to build the algebric \n/// expression and return the evaluation of this expression.\n/// The basic algebra operations:\n/// Addition ( + ) \n/// Subtraction ( - ) \n/// Multiplication ( * ) \n/// Floor division ( // ) \n/// Exponentiation ( ** ) \n/// Example:\n/// operator['+', '*', '-']\n/// array = [2, 3, 4, 5]\n/// result = 2 + 3 * 4 - 5\n/// => result = 9\n/// Note:\n/// The length of operator list is equal to the length of operand list minus one.\n/// Operand is a list of of non-negative integers.\n/// Operator list has at least one operator, and operand list has at least two operands.\nfunc do_algebra(operator: [String], operand: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(do_algebra(operator: [\"**\", \"*\", \"+\"], operand: [2, 3, 4, 5]) == 37)\nassert(do_algebra(operator: [\"+\", \"*\", \"-\"], operand: [2, 3, 4, 5]) == 9)\nassert(do_algebra(operator: [\"//\", \"*\"], operand: [7, 3, 4]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n/// otherwise keep it as it is.\n/// If the string contains no letters, reverse the string.\n/// The function should return the resulted string.\n/// Examples\n/// >>> solve(s: \"1234\")\n/// \"4321\"\n/// >>> solve(s: \"ab\")\n/// \"AB\"\n/// >>> solve(s: \"#a@C\")\n/// \"#A@c\"\nfunc solve(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(s: \"AsDf\") == \"aSdF\")\nassert(solve(s: \"1234\") == \"4321\")\nassert(solve(s: \"ab\") == \"AB\")\nassert(solve(s: \"#a@C\") == \"#A@c\")\nassert(solve(s: \"#AsdfW^45\") == \"#aSDFw^45\")\nassert(solve(s: \"#6@2\") == \"2@6#\")\nassert(solve(s: \"#$a^D\") == \"#$A^d\")\nassert(solve(s: \"#ccc\") == \"#CCC\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "swift",
+    "prompt": "\n/// Given a string 'text', return its md5 hash equivalent string.\n/// If 'text' is an empty string, return None.\n/// >>> string_to_md5(text: \"Hello world\")\n/// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunc string_to_md5(text: String) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_md5(text: \"Hello world\") == \"3e25960a79dbc69b674cd4ec67a72c62\")\nassert(string_to_md5(text: \"\") == nil)\nassert(string_to_md5(text: \"A B C\") == \"0ef78513b0cb8cef12743f5aeb35f888\")\nassert(string_to_md5(text: \"password\") == \"5f4dcc3b5aa765d61d8327deb882cf99\")",
     "stop_tokens": [
       "\n}"
     ]
@@ -1804,7 +820,7 @@
     "language": "swift",
     "prompt": "\n/// Given two positive integers a and b, return the even digits between a\n/// and b, in ascending order.\n/// For example:\n/// >>> generate_integers(a: 2, b: 8)\n/// [2, 4, 6, 8]\n/// >>> generate_integers(a: 8, b: 2)\n/// [2, 4, 6, 8]\n/// >>> generate_integers(a: 10, b: 14)\n/// [] as [Int]\nfunc generate_integers(a: Int, b: Int) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(generate_integers(a: 2, b: 10) == [2, 4, 6, 8])\nassert(generate_integers(a: 10, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 132, b: 2) == [2, 4, 6, 8])\nassert(generate_integers(a: 17, b: 89) == [] as [Int])",
     "stop_tokens": [
@@ -1812,49 +828,265 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "swift",
-    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(numbers: [1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Given a string, find out how many distinct characters (regardless of case) does it consist of\n/// >>> count_distinct_characters(string: \"xyzXYZ\")\n/// 3\n/// >>> count_distinct_characters(string: \"Jerry\")\n/// 4\nfunc count_distinct_characters(string: String) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_distinct_characters(string: \"\") == 0)\nassert(count_distinct_characters(string: \"abcde\") == 5)\nassert(count_distinct_characters(string: \"abcdecadeCADE\") == 5)\nassert(count_distinct_characters(string: \"aaaaAAAAaaaa\") == 1)\nassert(count_distinct_characters(string: \"Jerry jERRY JeRRRY\") == 5)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "swift",
-    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero(operations: [1, 2, 3])\n/// false\n/// >>> below_zero(operations: [1, 2, -4, 5])\n/// true\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "prompt": "\n/// Input to this function is a string representing musical notes in a special ASCII format.\n/// Your task is to parse this string and return list of integers corresponding to how many beats does each\n/// not last.\n/// Here is a legend:\n/// 'o' - whole note, lasts four beats\n/// 'o|' - half note, lasts two beats\n/// '.|' - quater note, lasts one beat\n/// >>> parse_music(music_string: \"o o| .| o| o| .| .| .| .| o o\")\n/// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunc parse_music(music_string: String) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_music(music_string: \"\") == [] as [Int])\nassert(parse_music(music_string: \"o o o o\") == [4, 4, 4, 4])\nassert(parse_music(music_string: \".| .| .| .|\") == [1, 1, 1, 1])\nassert(parse_music(music_string: \"o| o| .| .| o o o o\") == [2, 2, 1, 1, 4, 4, 4, 4])\nassert(parse_music(music_string: \"o| .| o| .| o o| o o|\") == [2, 1, 2, 1, 4, 2, 4, 2])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "swift",
-    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(lst: [4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(lst: [1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(lst: [5, 5, 4, 4, 4])\n/// -1\nfunc search(lst: [Int]) -> Int {\n",
+    "prompt": "\n/// Find how many times a given substring can be found in the original string. Count overlaping cases.\n/// >>> how_many_times(string: \"\", substring: \"a\")\n/// 0\n/// >>> how_many_times(string: \"aaa\", substring: \"a\")\n/// 3\n/// >>> how_many_times(string: \"aaaa\", substring: \"aa\")\n/// 3\nfunc how_many_times(string: String, substring: String) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(how_many_times(string: \"\", substring: \"x\") == 0)\nassert(how_many_times(string: \"xyxyxyx\", substring: \"x\") == 4)\nassert(how_many_times(string: \"cacacacac\", substring: \"cac\") == 4)\nassert(how_many_times(string: \"john doe\", substring: \"john\") == 1)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "swift",
-    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"(\")\n/// false\n/// >>> correct_bracketing(brackets: \"()\")\n/// true\n/// >>> correct_bracketing(brackets: \"(()())\")\n/// true\n/// >>> correct_bracketing(brackets: \")(()\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "prompt": "\n/// Input is a space-delimited string of numberals from 'zero' to 'nine'.\n/// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n/// Return the string with numbers sorted from smallest to largest\n/// >>> sort_numbers(numbers: \"three one five\")\n/// \"one three five\"\nfunc sort_numbers(numbers: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numbers(numbers: \"\") == \"\")\nassert(sort_numbers(numbers: \"three\") == \"three\")\nassert(sort_numbers(numbers: \"three five nine\") == \"three five nine\")\nassert(sort_numbers(numbers: \"five zero four seven nine eight\") == \"zero four five seven eight nine\")\nassert(sort_numbers(numbers: \"six five four three two one zero\") == \"zero one two three four five six\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n/// separate those group into separate strings and return the list of those.\n/// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n/// Ignore any spaces in the input string.\n/// >>> separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\")\n/// [\"()\", \"(())\", \"(()())\"]\nfunc separate_paren_groups(paren_string: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(separate_paren_groups(paren_string: \"(()()) ((())) () ((())()())\") == [\"(()())\", \"((()))\", \"()\", \"((())()())\"])\nassert(separate_paren_groups(paren_string: \"() (()) ((())) (((())))\") == [\"()\", \"(())\", \"((()))\", \"(((())))\"])\nassert(separate_paren_groups(paren_string: \"(()(())((())))\") == [\"(()(())((())))\"])\nassert(separate_paren_groups(paren_string: \"( ) (( )) (( )( ))\") == [\"()\", \"(())\", \"(()())\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "swift",
+    "prompt": "\n/// From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n/// other and return them in order (smaller number, larger number).\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n/// (2.0, 2.2)\n/// >>> find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n/// (2.0, 2.0)\nfunc find_closest_elements(numbers: [Double]) -> (Double, Double) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_closest_elements(numbers: [1.0, 2.0, 3.9, 4.0, 5.0, 2.2]) == (3.9, 4.0))\nassert(find_closest_elements(numbers: [1.0, 2.0, 5.9, 4.0, 5.0]) == (5.0, 5.9))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.2]) == (2.0, 2.2))\nassert(find_closest_elements(numbers: [1.0, 2.0, 3.0, 4.0, 5.0, 2.0]) == (2.0, 2.0))\nassert(find_closest_elements(numbers: [1.1, 2.2, 3.1, 4.1, 5.1]) == (2.2, 3.1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "swift",
+    "prompt": "\n/// Given list of numbers (of at least two elements), apply a linear transform to that list,\n/// such that the smallest number will become 0 and the largest will become 1\n/// >>> rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0])\n/// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunc rescale_to_unit(numbers: [Double]) -> [Double] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rescale_to_unit(numbers: [2.0, 49.9]) == [0.0, 1.0])\nassert(rescale_to_unit(numbers: [100.0, 49.9]) == [1.0, 0.0])\nassert(rescale_to_unit(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == [0.0, 0.25, 0.5, 0.75, 1.0])\nassert(rescale_to_unit(numbers: [2.0, 1.0, 5.0, 3.0, 4.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])\nassert(rescale_to_unit(numbers: [12.0, 11.0, 15.0, 13.0, 14.0]) == [0.25, 0.0, 1.0, 0.5, 0.75])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "swift",
+    "prompt": "\n/// Filter given list of any python values only for integers\n/// >>> filter_integers(values: [\"a\", 3.14, 5])\n/// [5]\n/// >>> filter_integers(values: [1, 2, 3, \"abc\", [:] as [AnyHashable : AnyHashable], [] as [AnyHashable]])\n/// [1, 2, 3]\nfunc filter_integers(values: [AnyHashable]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_integers(values: [] as [AnyHashable]) == [] as [Int])\nassert(filter_integers(values: [4, [:] as [AnyHashable : AnyHashable], [] as [AnyHashable], 23.2, 9, \"adasd\"]) == [4, 9])\nassert(filter_integers(values: [3, \"c\", 3, 3, \"a\", \"b\"]) == [3, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "swift",
+    "prompt": "\n/// Return length of given string\n/// >>> strlen(string: \"\")\n/// 0\n/// >>> strlen(string: \"abc\")\n/// 3\nfunc strlen(string: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strlen(string: \"\") == 0)\nassert(strlen(string: \"x\") == 1)\nassert(strlen(string: \"asdasnakj\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "swift",
+    "prompt": "\n/// For a given number n, find the largest number that divides n evenly, smaller than n\n/// >>> largest_divisor(n: 15)\n/// 5\nfunc largest_divisor(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_divisor(n: 3) == 1)\nassert(largest_divisor(n: 7) == 1)\nassert(largest_divisor(n: 10) == 5)\nassert(largest_divisor(n: 100) == 50)\nassert(largest_divisor(n: 49) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "swift",
+    "prompt": "\n/// Return list of prime factors of given integer in the order from smallest to largest.\n/// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n/// Input number should be equal to the product of all factors\n/// >>> factorize(n: 8)\n/// [2, 2, 2]\n/// >>> factorize(n: 25)\n/// [5, 5]\n/// >>> factorize(n: 70)\n/// [2, 5, 7]\nfunc factorize(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(factorize(n: 2) == [2])\nassert(factorize(n: 4) == [2, 2])\nassert(factorize(n: 8) == [2, 2, 2])\nassert(factorize(n: 57) == [3, 19])\nassert(factorize(n: 3249) == [3, 3, 19, 19])\nassert(factorize(n: 185193) == [3, 3, 3, 19, 19, 19])\nassert(factorize(n: 20577) == [3, 19, 19, 19])\nassert(factorize(n: 18) == [2, 3, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "swift",
+    "prompt": "\n/// From a list of integers, remove all elements that occur more than once.\n/// Keep order of elements left the same as in the input.\n/// >>> remove_duplicates(numbers: [1, 2, 3, 2, 4])\n/// [1, 3, 4]\nfunc remove_duplicates(numbers: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_duplicates(numbers: [] as [Int]) == [] as [Int])\nassert(remove_duplicates(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(remove_duplicates(numbers: [1, 2, 3, 2, 4, 3, 5]) == [1, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "swift",
+    "prompt": "\n/// For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n/// >>> flip_case(string: \"Hello\")\n/// \"hELLO\"\nfunc flip_case(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flip_case(string: \"\") == \"\")\nassert(flip_case(string: \"Hello!\") == \"hELLO!\")\nassert(flip_case(string: \"These violent delights have violent ends\") == \"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "swift",
+    "prompt": "\n/// Concatenate list of strings into a single string\n/// >>> concatenate(strings: [] as [String])\n/// \"\"\n/// >>> concatenate(strings: [\"a\", \"b\", \"c\"])\n/// \"abc\"\nfunc concatenate(strings: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate(strings: [] as [String]) == \"\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\"]) == \"xyz\")\nassert(concatenate(strings: [\"x\", \"y\", \"z\", \"w\", \"k\"]) == \"xyzwk\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that start with a given prefix.\n/// >>> filter_by_prefix(strings: [] as [String], prefix: \"a\")\n/// [] as [String]\n/// >>> filter_by_prefix(strings: [\"abc\", \"bcd\", \"cde\", \"array\"], prefix: \"a\")\n/// [\"abc\", \"array\"]\nfunc filter_by_prefix(strings: [String], prefix: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_prefix(strings: [] as [String], prefix: \"john\") == [] as [String])\nassert(filter_by_prefix(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], prefix: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "swift",
+    "prompt": "\n/// Given a positive floating point number, it can be decomposed into\n/// and integer part (largest integer smaller than given number) and decimals\n/// (leftover part always smaller than 1).\n/// Return the decimal part of the number.\n/// >>> truncate_number(number: 3.5)\n/// 0.5\nfunc truncate_number(number: Double) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(truncate_number(number: 3.5) == 0.5)\nassert(truncate_number(number: 1.25) == 0.25)\nassert(truncate_number(number: 123.0) == 0.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "swift",
+    "prompt": "\n/// Return only positive numbers in the list.\n/// >>> get_positive(l: [-1, 2, -4, 5, 6])\n/// [2, 5, 6]\n/// >>> get_positive(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// [5, 3, 2, 3, 9, 123, 1]\nfunc get_positive(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_positive(l: [-1, -2, 4, 5, 6]) == [4, 5, 6])\nassert(get_positive(l: [5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]) == [5, 3, 2, 3, 3, 9, 123, 1])\nassert(get_positive(l: [-1, -2]) == [] as [Int])\nassert(get_positive(l: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "swift",
+    "prompt": "\n/// Return true if a given number is prime, and false otherwise.\n/// >>> is_prime(n: 6)\n/// false\n/// >>> is_prime(n: 101)\n/// true\n/// >>> is_prime(n: 11)\n/// true\n/// >>> is_prime(n: 13441)\n/// true\n/// >>> is_prime(n: 61)\n/// true\n/// >>> is_prime(n: 4)\n/// false\n/// >>> is_prime(n: 1)\n/// false\nfunc is_prime(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_prime(n: 6) == false)\nassert(is_prime(n: 101) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 13441) == true)\nassert(is_prime(n: 61) == true)\nassert(is_prime(n: 4) == false)\nassert(is_prime(n: 1) == false)\nassert(is_prime(n: 5) == true)\nassert(is_prime(n: 11) == true)\nassert(is_prime(n: 17) == true)\nassert(is_prime(n: 85) == false)\nassert(is_prime(n: 77) == false)\nassert(is_prime(n: 255379) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "swift",
+    "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n/// to the values of the corresponding indicies of l, but sorted.\n/// >>> sort_third(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_third(l: [5, 6, 3, 4, 8, 9, 2])\n/// [2, 6, 3, 4, 8, 9, 5]\nfunc sort_third(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2]) == [2, 6, 3, 4, 8, 9, 5])\nassert(sort_third(l: [5, 8, 3, 4, 6, 9, 2]) == [2, 8, 3, 4, 6, 9, 5])\nassert(sort_third(l: [5, 6, 9, 4, 8, 3, 2]) == [2, 6, 9, 4, 8, 3, 5])\nassert(sort_third(l: [5, 6, 3, 4, 8, 9, 2, 1]) == [2, 6, 3, 4, 8, 9, 5, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique elements in a list\n/// >>> unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [0, 2, 3, 5, 9, 123]\nfunc unique(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique(l: [5, 3, 5, 2, 3, 3, 9, 0, 123]) == [0, 2, 3, 5, 9, 123])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "swift",
+    "prompt": "\n/// Return maximum element in the list.\n/// >>> max_element(l: [1, 2, 3])\n/// 3\n/// >>> max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n/// 123\nfunc max_element(l: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_element(l: [1, 2, 3]) == 3)\nassert(max_element(l: [5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "swift",
+    "prompt": "\n/// Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n/// >>> fizz_buzz(n: 50)\n/// 0\n/// >>> fizz_buzz(n: 78)\n/// 2\n/// >>> fizz_buzz(n: 79)\n/// 3\nfunc fizz_buzz(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fizz_buzz(n: 50) == 0)\nassert(fizz_buzz(n: 78) == 2)\nassert(fizz_buzz(n: 79) == 3)\nassert(fizz_buzz(n: 100) == 3)\nassert(fizz_buzz(n: 200) == 6)\nassert(fizz_buzz(n: 4000) == 192)\nassert(fizz_buzz(n: 10000) == 639)\nassert(fizz_buzz(n: 100000) == 8026)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1864,9 +1096,201 @@
     "language": "swift",
     "prompt": "\n/// This function takes a list l and returns a list l' such that\n/// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n/// to the values of the even indicies of l, but sorted.\n/// >>> sort_even(l: [1, 2, 3])\n/// [1, 2, 3]\n/// >>> sort_even(l: [5, 6, 3, 4])\n/// [3, 6, 5, 4]\nfunc sort_even(l: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_even(l: [1, 2, 3]) == [1, 2, 3])\nassert(sort_even(l: [5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]) == [-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123])\nassert(sort_even(l: [5, 8, -12, 4, 23, 2, 3, 11, 12, -10]) == [-12, 8, 3, 4, 5, 2, 12, 11, 23, -10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "swift",
+    "prompt": "\n/// prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n/// >>> prime_fib(n: 1)\n/// 2\n/// >>> prime_fib(n: 2)\n/// 3\n/// >>> prime_fib(n: 3)\n/// 5\n/// >>> prime_fib(n: 4)\n/// 13\n/// >>> prime_fib(n: 5)\n/// 89\nfunc prime_fib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_fib(n: 1) == 2)\nassert(prime_fib(n: 2) == 3)\nassert(prime_fib(n: 3) == 5)\nassert(prime_fib(n: 4) == 13)\nassert(prime_fib(n: 5) == 89)\nassert(prime_fib(n: 6) == 233)\nassert(prime_fib(n: 7) == 1597)\nassert(prime_fib(n: 8) == 28657)\nassert(prime_fib(n: 9) == 514229)\nassert(prime_fib(n: 10) == 433494437)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "swift",
+    "prompt": "\n/// You're given a list of deposit and withdrawal operations on a bank account that starts with\n/// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n/// at that point function should return True. Otherwise it should return False.\n/// >>> below_zero(operations: [1, 2, 3])\n/// false\n/// >>> below_zero(operations: [1, 2, -4, 5])\n/// true\nfunc below_zero(operations: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_zero(operations: [] as [Int]) == false)\nassert(below_zero(operations: [1, 2, -3, 1, 2, -3]) == false)\nassert(below_zero(operations: [1, 2, -4, 5, 6]) == true)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -4]) == false)\nassert(below_zero(operations: [1, -1, 2, -2, 5, -5, 4, -5]) == true)\nassert(below_zero(operations: [1, -2, 2, -2, 5, -5, 4, -4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// triples_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are three distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> triples_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> triples_sum_to_zero(l: [1, 3, -2, 1])\n/// true\n/// >>> triples_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7])\n/// true\n/// >>> triples_sum_to_zero(l: [1])\n/// false\nfunc triples_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triples_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, -2, 1]) == true)\nassert(triples_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(triples_sum_to_zero(l: [1, 2, 5, 7]) == false)\nassert(triples_sum_to_zero(l: [2, 4, -5, 3, 9, 7]) == true)\nassert(triples_sum_to_zero(l: [1]) == false)\nassert(triples_sum_to_zero(l: [1, 3, 5, -100]) == false)\nassert(triples_sum_to_zero(l: [100, 3, 5, -100]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "swift",
+    "prompt": "\n/// Imagine a road that's a perfectly straight infinitely long line.\n/// n cars are driving left to right;  simultaneously, a different set of n cars\n/// are driving right to left.   The two sets of cars start out being very far from\n/// each other.  All cars move in the same speed.  Two cars are said to collide\n/// when a car that's moving left to right hits a car that's moving right to left.\n/// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n/// in their trajectory as if they did not collide.\n/// This function outputs the number of such collisions.\nfunc car_race_collision(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(car_race_collision(n: 2) == 4)\nassert(car_race_collision(n: 3) == 9)\nassert(car_race_collision(n: 4) == 16)\nassert(car_race_collision(n: 8) == 64)\nassert(car_race_collision(n: 10) == 100)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "swift",
+    "prompt": "\n/// Return list with elements incremented by 1.\n/// >>> incr_list(l: [1, 2, 3])\n/// [2, 3, 4]\n/// >>> incr_list(l: [5, 3, 5, 2, 3, 3, 9, 0, 123])\n/// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunc incr_list(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(incr_list(l: [] as [Int]) == [] as [Int])\nassert(incr_list(l: [3, 2, 1]) == [4, 3, 2])\nassert(incr_list(l: [5, 2, 5, 2, 3, 3, 9, 0, 123]) == [6, 3, 6, 3, 4, 4, 10, 1, 124])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "swift",
+    "prompt": "\n/// pairs_sum_to_zero takes a list of integers as an input.\n/// it returns True if there are two distinct elements in the list that\n/// sum to zero, and False otherwise.\n/// >>> pairs_sum_to_zero(l: [1, 3, 5, 0])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 3, -2, 1])\n/// false\n/// >>> pairs_sum_to_zero(l: [1, 2, 3, 7])\n/// false\n/// >>> pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7])\n/// true\n/// >>> pairs_sum_to_zero(l: [1])\n/// false\nfunc pairs_sum_to_zero(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pairs_sum_to_zero(l: [1, 3, 5, 0]) == false)\nassert(pairs_sum_to_zero(l: [1, 3, -2, 1]) == false)\nassert(pairs_sum_to_zero(l: [1, 2, 3, 7]) == false)\nassert(pairs_sum_to_zero(l: [2, 4, -5, 3, 5, 7]) == true)\nassert(pairs_sum_to_zero(l: [1]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 30]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 3, 2, 31]) == true)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 30]) == false)\nassert(pairs_sum_to_zero(l: [-3, 9, -1, 4, 2, 31]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "swift",
+    "prompt": "\n/// Change numerical base of input number x to base.\n/// return string representation after the conversion.\n/// base numbers are less than 10.\n/// >>> change_base(x: 8, base: 3)\n/// \"22\"\n/// >>> change_base(x: 8, base: 2)\n/// \"1000\"\n/// >>> change_base(x: 7, base: 2)\n/// \"111\"\nfunc change_base(x: Int, base: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_base(x: 8, base: 3) == \"22\")\nassert(change_base(x: 9, base: 3) == \"100\")\nassert(change_base(x: 234, base: 2) == \"11101010\")\nassert(change_base(x: 16, base: 2) == \"10000\")\nassert(change_base(x: 8, base: 2) == \"1000\")\nassert(change_base(x: 7, base: 2) == \"111\")\nassert(change_base(x: 2, base: 3) == \"2\")\nassert(change_base(x: 3, base: 4) == \"3\")\nassert(change_base(x: 4, base: 5) == \"4\")\nassert(change_base(x: 5, base: 6) == \"5\")\nassert(change_base(x: 6, base: 7) == \"6\")\nassert(change_base(x: 7, base: 8) == \"7\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given length of a side and high return area for a triangle.\n/// >>> triangle_area(a: 5, h: 3)\n/// 7.5\nfunc triangle_area(a: Int, h: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 5, h: 3) == 7.5)\nassert(triangle_area(a: 2, h: 2) == 2.0)\nassert(triangle_area(a: 10, h: 8) == 40.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "swift",
+    "prompt": "\n/// The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fib4(0) -> 0\n/// fib4(1) -> 0\n/// fib4(2) -> 2\n/// fib4(3) -> 0\n/// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n/// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n/// >>> fib4(n: 5)\n/// 4\n/// >>> fib4(n: 6)\n/// 8\n/// >>> fib4(n: 7)\n/// 14\nfunc fib4(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib4(n: 5) == 4)\nassert(fib4(n: 8) == 28)\nassert(fib4(n: 10) == 104)\nassert(fib4(n: 12) == 386)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "swift",
+    "prompt": "\n/// Return median of elements in the list l.\n/// >>> median(l: [3, 1, 2, 4, 5])\n/// 3\n/// >>> median(l: [-10, 4, 6, 1000, 10, 20])\n/// 15.0\nfunc median(l: [Int]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median(l: [3, 1, 2, 4, 5]) == 3)\nassert(median(l: [-10, 4, 6, 1000, 10, 20]) == 8.0)\nassert(median(l: [5]) == 5)\nassert(median(l: [6, 5]) == 5.5)\nassert(median(l: [8, 1, 3, 9, 9, 2, 7]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "swift",
+    "prompt": "\n/// Checks if given string is a palindrome\n/// >>> is_palindrome(text: \"\")\n/// true\n/// >>> is_palindrome(text: \"aba\")\n/// true\n/// >>> is_palindrome(text: \"aaaaa\")\n/// true\n/// >>> is_palindrome(text: \"zbcd\")\n/// false\nfunc is_palindrome(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_palindrome(text: \"\") == true)\nassert(is_palindrome(text: \"aba\") == true)\nassert(is_palindrome(text: \"aaaaa\") == true)\nassert(is_palindrome(text: \"zbcd\") == false)\nassert(is_palindrome(text: \"xywyx\") == true)\nassert(is_palindrome(text: \"xywyz\") == false)\nassert(is_palindrome(text: \"xywzx\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "swift",
+    "prompt": "\n/// Return 2^n modulo p (be aware of numerics).\n/// >>> modp(n: 3, p: 5)\n/// 3\n/// >>> modp(n: 1101, p: 101)\n/// 2\n/// >>> modp(n: 0, p: 101)\n/// 1\n/// >>> modp(n: 3, p: 11)\n/// 8\n/// >>> modp(n: 100, p: 101)\n/// 1\nfunc modp(n: Int, p: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(modp(n: 3, p: 5) == 3)\nassert(modp(n: 1101, p: 101) == 2)\nassert(modp(n: 0, p: 101) == 1)\nassert(modp(n: 3, p: 11) == 8)\nassert(modp(n: 100, p: 101) == 1)\nassert(modp(n: 30, p: 5) == 4)\nassert(modp(n: 31, p: 5) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "swift",
+    "prompt": "\n/// For a given list of input numbers, calculate Mean Absolute Deviation\n/// around the mean of this dataset.\n/// Mean Absolute Deviation is the average absolute difference between each\n/// element and a centerpoint (mean in this case):\n/// MAD = average | x - x_mean |\n/// >>> mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0])\n/// 1.0\nfunc mean_absolute_deviation(numbers: [Double]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mean_absolute_deviation(numbers: [1.0, 2.0]) == 0.5)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0]) == 1.0)\nassert(mean_absolute_deviation(numbers: [1.0, 2.0, 3.0, 4.0, 5.0]) == 1.2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "swift",
+    "prompt": "\n/// remove_vowels is a function that takes string and returns string without vowels.\n/// >>> remove_vowels(text: \"\")\n/// \"\"\n/// >>> remove_vowels(text: \"abcdef\")\n/// \"bcdf\"\n/// >>> remove_vowels(text: \"aaaaa\")\n/// \"\"\n/// >>> remove_vowels(text: \"aaBAA\")\n/// \"B\"\n/// >>> remove_vowels(text: \"zbcd\")\n/// \"zbcd\"\nfunc remove_vowels(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_vowels(text: \"\") == \"\")\nassert(remove_vowels(text: \"abcdef\\nghijklm\") == \"bcdf\\nghjklm\")\nassert(remove_vowels(text: \"fedcba\") == \"fdcb\")\nassert(remove_vowels(text: \"eeeee\") == \"\")\nassert(remove_vowels(text: \"acBAA\") == \"cB\")\nassert(remove_vowels(text: \"EcBOO\") == \"cB\")\nassert(remove_vowels(text: \"ybcd\") == \"ybcd\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "swift",
+    "prompt": "\n/// Return True if all numbers in the list l are below threshold t.\n/// >>> below_threshold(l: [1, 2, 4, 10], t: 100)\n/// true\n/// >>> below_threshold(l: [1, 20, 4, 10], t: 5)\n/// false\nfunc below_threshold(l: [Int], t: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(below_threshold(l: [1, 2, 4, 10], t: 100) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 5) == false)\nassert(below_threshold(l: [1, 20, 4, 10], t: 21) == true)\nassert(below_threshold(l: [1, 20, 4, 10], t: 22) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 11) == true)\nassert(below_threshold(l: [1, 8, 4, 10], t: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "swift",
+    "prompt": "\n/// Add two numbers x and y\n/// >>> add(x: 2, y: 3)\n/// 5\n/// >>> add(x: 5, y: 7)\n/// 12\nfunc add(x: Int, y: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(x: 0, y: 1) == 1)\nassert(add(x: 1, y: 0) == 1)\nassert(add(x: 2, y: 3) == 5)\nassert(add(x: 5, y: 7) == 12)\nassert(add(x: 7, y: 5) == 12)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1876,9 +1300,21 @@
     "language": "swift",
     "prompt": "\n/// Check if two words have the same characters.\n/// >>> same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\")\n/// true\n/// >>> same_chars(s0: \"abcd\", s1: \"dddddddabc\")\n/// true\n/// >>> same_chars(s0: \"dddddddabc\", s1: \"abcd\")\n/// true\n/// >>> same_chars(s0: \"eabcd\", s1: \"dddddddabc\")\n/// false\n/// >>> same_chars(s0: \"abcd\", s1: \"dddddddabce\")\n/// false\n/// >>> same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\")\n/// false\nfunc same_chars(s0: String, s1: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddeddabc\") == true)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabc\") == true)\nassert(same_chars(s0: \"dddddddabc\", s1: \"abcd\") == true)\nassert(same_chars(s0: \"eabcd\", s1: \"dddddddabc\") == false)\nassert(same_chars(s0: \"abcd\", s1: \"dddddddabcf\") == false)\nassert(same_chars(s0: \"eabcdzzzz\", s1: \"dddzzzzzzzddddabc\") == false)\nassert(same_chars(s0: \"aabb\", s1: \"aaccc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "swift",
+    "prompt": "\n/// Return n-th Fibonacci number.\n/// >>> fib(n: 10)\n/// 55\n/// >>> fib(n: 1)\n/// 1\n/// >>> fib(n: 8)\n/// 21\nfunc fib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fib(n: 10) == 55)\nassert(fib(n: 1) == 1)\nassert(fib(n: 8) == 21)\nassert(fib(n: 11) == 89)\nassert(fib(n: 12) == 144)",
     "stop_tokens": [
       "\n}"
     ]
@@ -1888,9 +1324,573 @@
     "language": "swift",
     "prompt": "\n/// brackets is a string of \"<\" and \">\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"<\")\n/// false\n/// >>> correct_bracketing(brackets: \"<>\")\n/// true\n/// >>> correct_bracketing(brackets: \"<<><>>\")\n/// true\n/// >>> correct_bracketing(brackets: \"><<>\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"<>\") == true)\nassert(correct_bracketing(brackets: \"<<><>>\") == true)\nassert(correct_bracketing(brackets: \"<><><<><>><>\") == true)\nassert(correct_bracketing(brackets: \"<><><<<><><>><>><<><><<>>>\") == true)\nassert(correct_bracketing(brackets: \"<<<><>>>>\") == false)\nassert(correct_bracketing(brackets: \"><<>\") == false)\nassert(correct_bracketing(brackets: \"<\") == false)\nassert(correct_bracketing(brackets: \"<<<<\") == false)\nassert(correct_bracketing(brackets: \">\") == false)\nassert(correct_bracketing(brackets: \"<<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>><<>\") == false)\nassert(correct_bracketing(brackets: \"<><><<><>><>>><>\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "swift",
+    "prompt": "\n/// Return True is list elements are monotonically increasing or decreasing.\n/// >>> monotonic(l: [1, 2, 4, 20])\n/// true\n/// >>> monotonic(l: [1, 20, 4, 10])\n/// false\n/// >>> monotonic(l: [4, 1, 0, -10])\n/// true\nfunc monotonic(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(monotonic(l: [1, 2, 4, 10]) == true)\nassert(monotonic(l: [1, 2, 4, 20]) == true)\nassert(monotonic(l: [1, 20, 4, 10]) == false)\nassert(monotonic(l: [4, 1, 0, -10]) == true)\nassert(monotonic(l: [4, 1, 1, 0]) == true)\nassert(monotonic(l: [1, 2, 3, 2, 5, 60]) == false)\nassert(monotonic(l: [1, 2, 3, 4, 5, 60]) == true)\nassert(monotonic(l: [9, 9, 9, 9]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "swift",
+    "prompt": "\n/// Return sorted unique common elements for two lists.\n/// >>> common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121])\n/// [1, 5, 653]\n/// >>> common(l1: [5, 3, 2, 8], l2: [3, 2])\n/// [2, 3]\nfunc common(l1: [Int], l2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common(l1: [1, 4, 3, 34, 653, 2, 5], l2: [5, 7, 1, 5, 9, 653, 121]) == [1, 5, 653])\nassert(common(l1: [5, 3, 2, 8], l2: [3, 2]) == [2, 3])\nassert(common(l1: [4, 3, 2, 8], l2: [3, 2, 4]) == [2, 3, 4])\nassert(common(l1: [4, 3, 2, 8], l2: [] as [Int]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "swift",
+    "prompt": "\n/// Return the largest prime factor of n. Assume n > 1 and is not a prime.\n/// >>> largest_prime_factor(n: 13195)\n/// 29\n/// >>> largest_prime_factor(n: 2048)\n/// 2\nfunc largest_prime_factor(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_prime_factor(n: 15) == 5)\nassert(largest_prime_factor(n: 27) == 3)\nassert(largest_prime_factor(n: 63) == 7)\nassert(largest_prime_factor(n: 330) == 11)\nassert(largest_prime_factor(n: 13195) == 29)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "swift",
+    "prompt": "\n/// Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n/// >>> intersperse(numbers: [] as [Int], delimeter: 4)\n/// [] as [Int]\n/// >>> intersperse(numbers: [1, 2, 3], delimeter: 4)\n/// [1, 4, 2, 4, 3]\nfunc intersperse(numbers: [Int], delimeter: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersperse(numbers: [] as [Int], delimeter: 7) == [] as [Int])\nassert(intersperse(numbers: [5, 6, 3, 2], delimeter: 8) == [5, 8, 6, 8, 3, 8, 2])\nassert(intersperse(numbers: [2, 2, 2], delimeter: 2) == [2, 2, 2, 2, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "swift",
+    "prompt": "\n/// sum_to_n is a function that sums numbers from 1 to n.\n/// >>> sum_to_n(n: 30)\n/// 465\n/// >>> sum_to_n(n: 100)\n/// 5050\n/// >>> sum_to_n(n: 5)\n/// 15\n/// >>> sum_to_n(n: 10)\n/// 55\n/// >>> sum_to_n(n: 1)\n/// 1\nfunc sum_to_n(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_to_n(n: 1) == 1)\nassert(sum_to_n(n: 6) == 21)\nassert(sum_to_n(n: 11) == 66)\nassert(sum_to_n(n: 30) == 465)\nassert(sum_to_n(n: 100) == 5050)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "swift",
+    "prompt": "\n/// brackets is a string of \"(\" and \")\".\n/// return True if every opening bracket has a corresponding closing bracket.\n/// >>> correct_bracketing(brackets: \"(\")\n/// false\n/// >>> correct_bracketing(brackets: \"()\")\n/// true\n/// >>> correct_bracketing(brackets: \"(()())\")\n/// true\n/// >>> correct_bracketing(brackets: \")(()\")\n/// false\nfunc correct_bracketing(brackets: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(correct_bracketing(brackets: \"()\") == true)\nassert(correct_bracketing(brackets: \"(()())\") == true)\nassert(correct_bracketing(brackets: \"()()(()())()\") == true)\nassert(correct_bracketing(brackets: \"()()((()()())())(()()(()))\") == true)\nassert(correct_bracketing(brackets: \"((()())))\") == false)\nassert(correct_bracketing(brackets: \")(()\") == false)\nassert(correct_bracketing(brackets: \"(\") == false)\nassert(correct_bracketing(brackets: \"((((\") == false)\nassert(correct_bracketing(brackets: \")\") == false)\nassert(correct_bracketing(brackets: \"(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())())(()\") == false)\nassert(correct_bracketing(brackets: \"()()(()())()))()\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "swift",
+    "prompt": "\n/// xs represent coefficients of a polynomial.\n/// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n/// Return derivative of this polynomial in the same form.\n/// >>> derivative(xs: [3, 1, 2, 4, 5])\n/// [1, 4, 12, 20]\n/// >>> derivative(xs: [1, 2, 3])\n/// [2, 6]\nfunc derivative(xs: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(derivative(xs: [3, 1, 2, 4, 5]) == [1, 4, 12, 20])\nassert(derivative(xs: [1, 2, 3]) == [2, 6])\nassert(derivative(xs: [3, 2, 1]) == [2, 2])\nassert(derivative(xs: [3, 2, 1, 0, 4]) == [2, 2, 0, 16])\nassert(derivative(xs: [1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "swift",
+    "prompt": "\n/// The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n/// fibfib(0) == 0\n/// fibfib(1) == 0\n/// fibfib(2) == 1\n/// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n/// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n/// >>> fibfib(n: 1)\n/// 0\n/// >>> fibfib(n: 5)\n/// 4\n/// >>> fibfib(n: 8)\n/// 24\nfunc fibfib(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fibfib(n: 2) == 1)\nassert(fibfib(n: 1) == 0)\nassert(fibfib(n: 5) == 4)\nassert(fibfib(n: 8) == 24)\nassert(fibfib(n: 10) == 81)\nassert(fibfib(n: 12) == 274)\nassert(fibfib(n: 14) == 927)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function vowels_count which takes a string representing\n/// a word as input and returns the number of vowels in the string.\n/// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n/// vowel, but only when it is at the end of the given word.\n/// Example:\n/// >>> vowels_count(s: \"abcde\")\n/// 2\n/// >>> vowels_count(s: \"ACEDY\")\n/// 3\nfunc vowels_count(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(vowels_count(s: \"abcde\") == 2)\nassert(vowels_count(s: \"Alone\") == 3)\nassert(vowels_count(s: \"key\") == 2)\nassert(vowels_count(s: \"bye\") == 1)\nassert(vowels_count(s: \"keY\") == 2)\nassert(vowels_count(s: \"bYe\") == 1)\nassert(vowels_count(s: \"ACEDY\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "swift",
+    "prompt": "\n/// Circular shift the digits of the integer x, shift the digits right by shift\n/// and return the result as a string.\n/// If shift > number of digits, return digits reversed.\n/// >>> circular_shift(x: 12, shift: 1)\n/// \"21\"\n/// >>> circular_shift(x: 12, shift: 2)\n/// \"12\"\nfunc circular_shift(x: Int, shift: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(circular_shift(x: 100, shift: 2) == \"001\")\nassert(circular_shift(x: 12, shift: 2) == \"12\")\nassert(circular_shift(x: 97, shift: 8) == \"79\")\nassert(circular_shift(x: 12, shift: 1) == \"21\")\nassert(circular_shift(x: 11, shift: 101) == \"11\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "swift",
+    "prompt": "\n/// Task\n/// Write a function that takes a string as input and returns the sum of the upper characters only'\n/// ASCII codes.\n/// Examples:\n/// >>> digitSum(s: \"\")\n/// 0\n/// >>> digitSum(s: \"abAB\")\n/// 131\n/// >>> digitSum(s: \"abcCd\")\n/// 67\n/// >>> digitSum(s: \"helloE\")\n/// 69\n/// >>> digitSum(s: \"woArBld\")\n/// 131\n/// >>> digitSum(s: \"aAaaaXa\")\n/// 153\nfunc digitSum(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digitSum(s: \"\") == 0)\nassert(digitSum(s: \"abAB\") == 131)\nassert(digitSum(s: \"abcCd\") == 67)\nassert(digitSum(s: \"helloE\") == 69)\nassert(digitSum(s: \"woArBld\") == 131)\nassert(digitSum(s: \"aAaaaXa\") == 153)\nassert(digitSum(s: \" How are yOu?\") == 151)\nassert(digitSum(s: \"You arE Very Smart\") == 327)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "swift",
+    "prompt": "\n/// In this task, you will be given a string that represents a number of apples and oranges \n/// that are distributed in a basket of fruit this basket contains \n/// apples, oranges, and mango fruits. Given the string that represents the total number of \n/// the oranges and apples and an integer that represent the total number of the fruits \n/// in the basket return the number of the mango fruits in the basket.\n/// for examble:\n/// >>> fruit_distribution(s: \"5 apples and 6 oranges\", n: 19)\n/// 8\n/// >>> fruit_distribution(s: \"0 apples and 1 oranges\", n: 3)\n/// 2\n/// >>> fruit_distribution(s: \"2 apples and 3 oranges\", n: 100)\n/// 95\n/// >>> fruit_distribution(s: \"100 apples and 1 oranges\", n: 120)\n/// 19\nfunc fruit_distribution(s: String, n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 19) == 8)\nassert(fruit_distribution(s: \"5 apples and 6 oranges\", n: 21) == 10)\nassert(fruit_distribution(s: \"0 apples and 1 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"1 apples and 0 oranges\", n: 3) == 2)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 100) == 95)\nassert(fruit_distribution(s: \"2 apples and 3 oranges\", n: 5) == 0)\nassert(fruit_distribution(s: \"1 apples and 100 oranges\", n: 120) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "swift",
+    "prompt": "\n/// \"Given an array representing a branch of a tree that has non-negative integer nodes\n/// your task is to pluck one of the nodes and return it.\n/// The plucked node should be the node with the smallest even value.\n/// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n/// The plucked node should be returned in a list, [ smalest_value, its index ],\n/// If there are no even values or the given array is empty, return [].\n/// Example 1:\n/// >>> pluck(arr: [4, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 2:\n/// >>> pluck(arr: [1, 2, 3])\n/// [2, 1]\n/// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n/// Example 3:\n/// >>> pluck(arr: [] as [Int])\n/// [] as [Int]\n/// Example 4:\n/// >>> pluck(arr: [5, 0, 3, 0, 4, 2])\n/// [0, 1]\n/// Explanation: 0 is the smallest value, but  there are two zeros,\n/// so we will choose the first zero, which has the smallest index.\n/// Constraints:\n/// * 1 <= nodes.length <= 10000\n/// * 0 <= node.value\nfunc pluck(arr: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pluck(arr: [4, 2, 3]) == [2, 1])\nassert(pluck(arr: [1, 2, 3]) == [2, 1])\nassert(pluck(arr: [] as [Int]) == [] as [Int])\nassert(pluck(arr: [5, 0, 3, 0, 4, 2]) == [0, 1])\nassert(pluck(arr: [1, 2, 3, 0, 5, 3]) == [0, 3])\nassert(pluck(arr: [5, 4, 8, 4, 8]) == [4, 1])\nassert(pluck(arr: [7, 6, 7, 1]) == [6, 1])\nassert(pluck(arr: [7, 9, 7, 1]) == [] as [Int])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "swift",
+    "prompt": "\n/// You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n/// zero, and has a frequency greater than or equal to the value of the integer itself. \n/// The frequency of an integer is the number of times it appears in the list.\n/// If no such a value exist, return -1.\n/// Examples:\n/// >>> search(lst: [4, 1, 2, 2, 3, 1])\n/// 2\n/// >>> search(lst: [1, 2, 2, 3, 3, 3, 4, 4, 4])\n/// 3\n/// >>> search(lst: [5, 5, 4, 4, 4])\n/// -1\nfunc search(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(lst: [5, 5, 5, 5, 1]) == 1)\nassert(search(lst: [4, 1, 4, 1, 4, 4]) == 4)\nassert(search(lst: [3, 3]) == -1)\nassert(search(lst: [8, 8, 8, 8, 8, 8, 8, 8]) == 8)\nassert(search(lst: [2, 3, 3, 2, 2]) == 2)\nassert(search(lst: [2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]) == 1)\nassert(search(lst: [3, 2, 8, 2]) == 2)\nassert(search(lst: [6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]) == 1)\nassert(search(lst: [8, 8, 3, 6, 5, 6, 4]) == -1)\nassert(search(lst: [6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]) == 1)\nassert(search(lst: [1, 9, 10, 1, 3]) == 1)\nassert(search(lst: [6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]) == 5)\nassert(search(lst: [1]) == 1)\nassert(search(lst: [8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]) == 4)\nassert(search(lst: [2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]) == 2)\nassert(search(lst: [1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]) == 1)\nassert(search(lst: [9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]) == 4)\nassert(search(lst: [2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]) == 4)\nassert(search(lst: [9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]) == 2)\nassert(search(lst: [5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]) == -1)\nassert(search(lst: [10]) == -1)\nassert(search(lst: [9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]) == 2)\nassert(search(lst: [5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]) == 1)\nassert(search(lst: [7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]) == 1)\nassert(search(lst: [3, 10, 10, 9, 2]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "swift",
+    "prompt": "\n/// Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n/// For each of the group, output the deepest level of nesting of parentheses.\n/// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n/// >>> parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\")\n/// [2, 3, 1, 3]\nfunc parse_nested_parens(paren_string: String) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parse_nested_parens(paren_string: \"(()()) ((())) () ((())()())\") == [2, 3, 1, 3])\nassert(parse_nested_parens(paren_string: \"() (()) ((())) (((())))\") == [1, 2, 3, 4])\nassert(parse_nested_parens(paren_string: \"(()(())((())))\") == [4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "swift",
+    "prompt": "\n/// Given list of integers, return list in strange order.\n/// Strange sorting, is when you start with the minimum value,\n/// then maximum of the remaining integers, then minimum and so on.\n/// Examples:\n/// >>> strange_sort_list(lst: [1, 2, 3, 4])\n/// [1, 4, 2, 3]\n/// >>> strange_sort_list(lst: [5, 5, 5, 5])\n/// [5, 5, 5, 5]\n/// >>> strange_sort_list(lst: [] as [Int])\n/// [] as [Int]\nfunc strange_sort_list(lst: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(strange_sort_list(lst: [1, 2, 3, 4]) == [1, 4, 2, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9]) == [5, 9, 6, 8, 7])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5]) == [1, 5, 2, 4, 3])\nassert(strange_sort_list(lst: [5, 6, 7, 8, 9, 1]) == [1, 9, 5, 8, 6, 7])\nassert(strange_sort_list(lst: [5, 5, 5, 5]) == [5, 5, 5, 5])\nassert(strange_sort_list(lst: [] as [Int]) == [] as [Int])\nassert(strange_sort_list(lst: [1, 2, 3, 4, 5, 6, 7, 8]) == [1, 8, 2, 7, 3, 6, 4, 5])\nassert(strange_sort_list(lst: [0, 2, 2, 2, 5, 5, -5, -5]) == [-5, 5, -5, 5, 0, 2, 2, 2])\nassert(strange_sort_list(lst: [111111]) == [111111])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Given the lengths of the three sides of a triangle. Return the area of\n/// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n/// Otherwise return -1\n/// Three sides make a valid triangle when the sum of any two sides is greater \n/// than the third side.\n/// Example:\n/// >>> triangle_area(a: 3, b: 4, c: 5)\n/// 6.0\n/// >>> triangle_area(a: 1, b: 2, c: 10)\n/// -1\nfunc triangle_area(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(a: 3, b: 4, c: 5) == 6.0)\nassert(triangle_area(a: 1, b: 2, c: 10) == -1)\nassert(triangle_area(a: 4, b: 8, c: 5) == 8.18)\nassert(triangle_area(a: 2, b: 2, c: 2) == 1.73)\nassert(triangle_area(a: 1, b: 2, c: 3) == -1)\nassert(triangle_area(a: 10, b: 5, c: 7) == 16.25)\nassert(triangle_area(a: 2, b: 6, c: 3) == -1)\nassert(triangle_area(a: 1, b: 1, c: 1) == 0.43)\nassert(triangle_area(a: 2, b: 2, c: 10) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns True if the object q will fly, and False otherwise.\n/// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n/// Example:\n/// >>> will_it_fly(q: [1, 2], w: 5)\n/// false\n/// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n/// >>> will_it_fly(q: [3, 2, 3], w: 1)\n/// false\n/// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n/// >>> will_it_fly(q: [3, 2, 3], w: 9)\n/// true\n/// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n/// >>> will_it_fly(q: [3], w: 5)\n/// true\n/// # 3 is less than the maximum possible weight, and it's balanced.\nfunc will_it_fly(q: [Int], w: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(will_it_fly(q: [3, 2, 3], w: 9) == true)\nassert(will_it_fly(q: [1, 2], w: 5) == false)\nassert(will_it_fly(q: [3], w: 5) == true)\nassert(will_it_fly(q: [3, 2, 3], w: 1) == false)\nassert(will_it_fly(q: [1, 2, 3], w: 6) == false)\nassert(will_it_fly(q: [5], w: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "swift",
+    "prompt": "\n/// Given an array arr of integers, find the minimum number of elements that\n/// need to be changed to make the array palindromic. A palindromic array is an array that\n/// is read the same backwards and forwards. In one change, you can change one element to any other element.\n/// For example:\n/// >>> smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6])\n/// 4\n/// >>> smallest_change(arr: [1, 2, 3, 4, 3, 2, 2])\n/// 1\n/// >>> smallest_change(arr: [1, 2, 3, 2, 1])\n/// 0\nfunc smallest_change(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_change(arr: [1, 2, 3, 5, 4, 7, 9, 6]) == 4)\nassert(smallest_change(arr: [1, 2, 3, 4, 3, 2, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 4, 4, 2]) == 1)\nassert(smallest_change(arr: [1, 2, 3, 2, 1]) == 0)\nassert(smallest_change(arr: [3, 1, 1, 3]) == 0)\nassert(smallest_change(arr: [1]) == 0)\nassert(smallest_change(arr: [0, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "swift",
+    "prompt": "\n/// Write a function that accepts two lists of strings and returns the list that has \n/// total number of chars in the all strings of the list less than the other list.\n/// if the two lists have the same number of chars, return the first list.\n/// Examples\n/// >>> total_match(lst1: [] as [String], lst2: [] as [String])\n/// [] as [String]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"])\n/// [\"hI\", \"Hi\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"])\n/// [\"hi\", \"admin\"]\n/// >>> total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"])\n/// [\"hI\", \"hi\", \"hi\"]\n/// >>> total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"])\n/// [\"4\"]\nfunc total_match(lst1: [String], lst2: [String]) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(total_match(lst1: [] as [String], lst2: [] as [String]) == [] as [String])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\"]) == [\"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hi\", \"hi\", \"admin\", \"project\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [\"4\"], lst2: [\"1\", \"2\", \"3\", \"4\", \"5\"]) == [\"4\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"Hi\"]) == [\"hI\", \"Hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hi\"]) == [\"hI\", \"hi\", \"hi\"])\nassert(total_match(lst1: [\"hi\", \"admin\"], lst2: [\"hI\", \"hi\", \"hii\"]) == [\"hi\", \"admin\"])\nassert(total_match(lst1: [] as [String], lst2: [\"this\"]) == [] as [String])\nassert(total_match(lst1: [\"this\"], lst2: [] as [String]) == [] as [String])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns true if the given number is the multiplication of 3 prime numbers\n/// and false otherwise.\n/// Knowing that (a) is less then 100. \n/// Example:\n/// >>> is_multiply_prime(a: 30)\n/// true\n/// 30 = 2 * 3 * 5\nfunc is_multiply_prime(a: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_multiply_prime(a: 5) == false)\nassert(is_multiply_prime(a: 30) == true)\nassert(is_multiply_prime(a: 8) == true)\nassert(is_multiply_prime(a: 10) == false)\nassert(is_multiply_prime(a: 125) == true)\nassert(is_multiply_prime(a: 105) == true)\nassert(is_multiply_prime(a: 126) == false)\nassert(is_multiply_prime(a: 729) == false)\nassert(is_multiply_prime(a: 891) == false)\nassert(is_multiply_prime(a: 1001) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "swift",
+    "prompt": "\n/// Your task is to write a function that returns true if a number x is a simple\n/// power of n and false in other cases.\n/// x is a simple power of n if n**int=x\n/// For example:\n/// >>> is_simple_power(x: 1, n: 4)\n/// true\n/// >>> is_simple_power(x: 2, n: 2)\n/// true\n/// >>> is_simple_power(x: 8, n: 2)\n/// true\n/// >>> is_simple_power(x: 3, n: 2)\n/// false\n/// >>> is_simple_power(x: 3, n: 1)\n/// false\n/// >>> is_simple_power(x: 5, n: 3)\n/// false\nfunc is_simple_power(x: Int, n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_simple_power(x: 16, n: 2) == true)\nassert(is_simple_power(x: 143214, n: 16) == false)\nassert(is_simple_power(x: 4, n: 2) == true)\nassert(is_simple_power(x: 9, n: 3) == true)\nassert(is_simple_power(x: 16, n: 4) == true)\nassert(is_simple_power(x: 24, n: 2) == false)\nassert(is_simple_power(x: 128, n: 4) == false)\nassert(is_simple_power(x: 12, n: 6) == false)\nassert(is_simple_power(x: 1, n: 1) == true)\nassert(is_simple_power(x: 1, n: 12) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an integer a and returns True \n/// if this ingeger is a cube of some integer number.\n/// Note: you may assume the input is always valid.\n/// Examples:\n/// >>> iscube(a: 1)\n/// true\n/// >>> iscube(a: 2)\n/// false\n/// >>> iscube(a: -1)\n/// true\n/// >>> iscube(a: 64)\n/// true\n/// >>> iscube(a: 0)\n/// true\n/// >>> iscube(a: 180)\n/// false\nfunc iscube(a: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(iscube(a: 1) == true)\nassert(iscube(a: 2) == false)\nassert(iscube(a: -1) == true)\nassert(iscube(a: 64) == true)\nassert(iscube(a: 180) == false)\nassert(iscube(a: 1000) == true)\nassert(iscube(a: 0) == true)\nassert(iscube(a: 1729) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "swift",
+    "prompt": "\n/// You have been tasked to write a function that receives \n/// a hexadecimal number as a string and counts the number of hexadecimal \n/// digits that are primes (prime number, or a prime, is a natural number \n/// greater than 1 that is not a product of two smaller natural numbers).\n/// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n/// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n/// So you have to determine a number of the following digits: 2, 3, 5, 7, \n/// B (=decimal 11), D (=decimal 13).\n/// Note: you may assume the input is always correct or empty string, \n/// and symbols A,B,C,D,E,F are always uppercase.\n/// Examples:\n/// >>> hex_key(num: \"AB\")\n/// 1\n/// >>> hex_key(num: \"1077E\")\n/// 2\n/// >>> hex_key(num: \"ABED1A33\")\n/// 4\n/// >>> hex_key(num: \"123456789ABCDEF0\")\n/// 6\n/// >>> hex_key(num: \"2020\")\n/// 2\nfunc hex_key(num: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hex_key(num: \"AB\") == 1)\nassert(hex_key(num: \"1077E\") == 2)\nassert(hex_key(num: \"ABED1A33\") == 4)\nassert(hex_key(num: \"2020\") == 2)\nassert(hex_key(num: \"123456789ABCDEF0\") == 6)\nassert(hex_key(num: \"112233445566778899AABBCCDDEEFF00\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// You will be given a number in decimal form and your task is to convert it to\n/// binary format. The function should return a string, with each character representing a binary\n/// number. Each character in the string will be '0' or '1'.\n/// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n/// The extra characters are there to help with the format.\n/// Examples:\n/// >>> decimal_to_binary(decimal: 15)\n/// \"db1111db\"\n/// >>> decimal_to_binary(decimal: 32)\n/// \"db100000db\"\nfunc decimal_to_binary(decimal: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(decimal: 0) == \"db0db\")\nassert(decimal_to_binary(decimal: 32) == \"db100000db\")\nassert(decimal_to_binary(decimal: 103) == \"db1100111db\")\nassert(decimal_to_binary(decimal: 15) == \"db1111db\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "swift",
+    "prompt": "\n/// Filter an input list of strings only for ones that contain given substring\n/// >>> filter_by_substring(strings: [] as [String], substring: \"a\")\n/// [] as [String]\n/// >>> filter_by_substring(strings: [\"abc\", \"bacd\", \"cde\", \"array\"], substring: \"a\")\n/// [\"abc\", \"bacd\", \"array\"]\nfunc filter_by_substring(strings: [String], substring: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_by_substring(strings: [] as [String], substring: \"john\") == [] as [String])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xxx\") == [\"xxx\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], substring: \"xx\") == [\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"])\nassert(filter_by_substring(strings: [\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], substring: \"run\") == [\"grunt\", \"prune\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "swift",
+    "prompt": "\n/// You are given a string s.\n/// Your task is to check if the string is happy or not.\n/// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n/// For example:\n/// >>> is_happy(s: \"a\")\n/// false\n/// >>> is_happy(s: \"aa\")\n/// false\n/// >>> is_happy(s: \"abcd\")\n/// true\n/// >>> is_happy(s: \"aabb\")\n/// false\n/// >>> is_happy(s: \"adb\")\n/// true\n/// >>> is_happy(s: \"xyy\")\n/// false\nfunc is_happy(s: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_happy(s: \"a\") == false)\nassert(is_happy(s: \"aa\") == false)\nassert(is_happy(s: \"abcd\") == true)\nassert(is_happy(s: \"aabb\") == false)\nassert(is_happy(s: \"adb\") == true)\nassert(is_happy(s: \"xyy\") == false)\nassert(is_happy(s: \"iopaxpoi\") == true)\nassert(is_happy(s: \"iopaxioi\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "swift",
+    "prompt": "\n/// It is the last week of the semester and the teacher has to give the grades\n/// to students. The teacher has been making her own algorithm for grading.\n/// The only problem is, she has lost the code she used for grading.\n/// She has given you a list of GPAs for some students and you have to write \n/// a function that can output a list of letter grades using the following table:\n/// GPA       |    Letter grade\n/// 4.0                A+\n/// > 3.7                A \n/// > 3.3                A- \n/// > 3.0                B+\n/// > 2.7                B \n/// > 2.3                B-\n/// > 2.0                C+\n/// > 1.7                C\n/// > 1.3                C-\n/// > 1.0                D+ \n/// > 0.7                D \n/// > 0.0                D-\n/// 0.0                E\n/// Example:\n/// >>> numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5])\n/// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunc numerical_letter_grade(grades: [Double]) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(numerical_letter_grade(grades: [4.0, 3, 1.7, 2, 3.5]) == [\"A+\", \"B\", \"C-\", \"C\", \"A-\"])\nassert(numerical_letter_grade(grades: [1.2]) == [\"D+\"])\nassert(numerical_letter_grade(grades: [0.5]) == [\"D-\"])\nassert(numerical_letter_grade(grades: [0.0]) == [\"E\"])\nassert(numerical_letter_grade(grades: [1.0, 0.3, 1.5, 2.8, 3.3]) == [\"D\", \"D-\", \"C-\", \"B\", \"B+\"])\nassert(numerical_letter_grade(grades: [0.0, 0.7]) == [\"E\", \"D-\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns True if the string\n/// length is a prime number or False otherwise\n/// Examples\n/// >>> prime_length(string: \"Hello\")\n/// true\n/// >>> prime_length(string: \"abcdcba\")\n/// true\n/// >>> prime_length(string: \"kittens\")\n/// true\n/// >>> prime_length(string: \"orange\")\n/// false\nfunc prime_length(string: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_length(string: \"Hello\") == true)\nassert(prime_length(string: \"abcdcba\") == true)\nassert(prime_length(string: \"kittens\") == true)\nassert(prime_length(string: \"orange\") == false)\nassert(prime_length(string: \"wow\") == true)\nassert(prime_length(string: \"world\") == true)\nassert(prime_length(string: \"MadaM\") == true)\nassert(prime_length(string: \"Wow\") == true)\nassert(prime_length(string: \"\") == false)\nassert(prime_length(string: \"HI\") == true)\nassert(prime_length(string: \"go\") == true)\nassert(prime_length(string: \"gogo\") == false)\nassert(prime_length(string: \"aaaaaaaaaaaaaaa\") == false)\nassert(prime_length(string: \"Madam\") == true)\nassert(prime_length(string: \"M\") == false)\nassert(prime_length(string: \"0\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer n, return the count of the numbers of n-digit\n/// positive integers that start or end with 1.\nfunc starts_one_ends(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(starts_one_ends(n: 1) == 1)\nassert(starts_one_ends(n: 2) == 18)\nassert(starts_one_ends(n: 3) == 180)\nassert(starts_one_ends(n: 4) == 1800)\nassert(starts_one_ends(n: 5) == 18000)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "swift",
+    "prompt": "\n/// Given a positive integer N, return the total sum of its digits in binary.\n/// Example\n/// >>> solve(N: 1000)\n/// \"1\"\n/// >>> solve(N: 150)\n/// \"110\"\n/// >>> solve(N: 147)\n/// \"1100\"\n/// Variables:\n/// @N integer\n/// Constraints: 0 \u2264 N \u2264 10000.\n/// Output:\n/// a string of binary number\nfunc solve(N: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(solve(N: 1000) == \"1\")\nassert(solve(N: 150) == \"110\")\nassert(solve(N: 147) == \"1100\")\nassert(solve(N: 333) == \"1001\")\nassert(solve(N: 963) == \"10010\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "swift",
+    "prompt": "\n/// Given a non-empty list of integers lst. add the even elements that are at odd indices..\n/// Examples:\n/// >>> add(lst: [4, 2, 6, 7])\n/// 2\nfunc add(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add(lst: [4, 88]) == 88)\nassert(add(lst: [4, 5, 6, 7, 2, 122]) == 122)\nassert(add(lst: [4, 0, 6, 7]) == 0)\nassert(add(lst: [4, 4, 6, 8]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a string and returns an ordered version of it.\n/// Ordered version of string, is a string where all words (separated by space)\n/// are replaced by a new word where all the characters arranged in\n/// ascending order based on ascii value.\n/// Note: You should keep the order of words and blank spaces in the sentence.\n/// For example:\n/// >>> anti_shuffle(s: \"Hi\")\n/// \"Hi\"\n/// >>> anti_shuffle(s: \"hello\")\n/// \"ehllo\"\n/// >>> anti_shuffle(s: \"Hello World!!!\")\n/// \"Hello !!!Wdlor\"\nfunc anti_shuffle(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(anti_shuffle(s: \"Hi\") == \"Hi\")\nassert(anti_shuffle(s: \"hello\") == \"ehllo\")\nassert(anti_shuffle(s: \"number\") == \"bemnru\")\nassert(anti_shuffle(s: \"abcd\") == \"abcd\")\nassert(anti_shuffle(s: \"Hello World!!!\") == \"Hello !!!Wdlor\")\nassert(anti_shuffle(s: \"\") == \"\")\nassert(anti_shuffle(s: \"Hi. My name is Mister Robot. How are you?\") == \".Hi My aemn is Meirst .Rboot How aer ?ouy\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "swift",
+    "prompt": "\n/// You are given a 2 dimensional data, as a nested lists,\n/// which is similar to matrix, however, unlike matrices,\n/// each row may contain a different number of columns.\n/// Given lst, and integer x, find integers x in the list,\n/// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n/// each tuple is a coordinate - (row, columns), starting with 0.\n/// Sort coordinates initially by rows in ascending order.\n/// Also, sort coordinates of the row by columns in descending order.\n/// Examples:\n/// >>> get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1)\n/// [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n/// >>> get_row(lst: [] as [[Int]], x: 1)\n/// [] as [(Int, Int)]\n/// >>> get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3)\n/// [(2, 2)]\nfunc get_row(lst: [[Int]], x: Int) -> [(Int, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], x: 2) == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)])\nassert(get_row(lst: [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], x: 1) == [(0, 0), (1, 0), (2, 1), (2, 0), (3, 2), (3, 0), (4, 3), (4, 0), (5, 4), (5, 0), (6, 5), (6, 0)])\nassert(get_row(lst: [] as [[Int]], x: 1) == [] as [(Int, Int)])\nassert(get_row(lst: [[1]], x: 2) == [] as [(Int, Int)])\nassert(get_row(lst: [[] as [Int], [1], [1, 2, 3]], x: 3) == [(2, 2)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "swift",
+    "prompt": "\n/// Given an array of non-negative integers, return a copy of the given array after sorting,\n/// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n/// or sort it in descending order if the sum( first index value, last index value) is even.\n/// Note:\n/// * don't change the given array.\n/// Examples:\n/// >>> sort_array(array: [] as [Int])\n/// [] as [Int]\n/// >>> sort_array(array: [5])\n/// [5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5])\n/// [0, 1, 2, 3, 4, 5]\n/// >>> sort_array(array: [2, 4, 3, 0, 1, 5, 6])\n/// [6, 5, 4, 3, 2, 1, 0]\nfunc sort_array(array: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_array(array: [] as [Int]) == [] as [Int])\nassert(sort_array(array: [5]) == [5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5]) == [0, 1, 2, 3, 4, 5])\nassert(sort_array(array: [2, 4, 3, 0, 1, 5, 6]) == [6, 5, 4, 3, 2, 1, 0])\nassert(sort_array(array: [2, 1]) == [1, 2])\nassert(sort_array(array: [15, 42, 87, 32, 11, 0]) == [0, 11, 15, 32, 42, 87])\nassert(sort_array(array: [21, 14, 23, 11]) == [23, 21, 14, 11])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "swift",
+    "prompt": "\n/// Create a function encrypt that takes a string as an argument and\n/// returns a string encrypted with the alphabet being rotated. \n/// The alphabet should be rotated in a manner such that the letters \n/// shift down by two multiplied to two places.\n/// For example:\n/// >>> encrypt(s: \"hi\")\n/// \"lm\"\n/// >>> encrypt(s: \"asdfghjkl\")\n/// \"ewhjklnop\"\n/// >>> encrypt(s: \"gf\")\n/// \"kj\"\n/// >>> encrypt(s: \"et\")\n/// \"ix\"\nfunc encrypt(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encrypt(s: \"hi\") == \"lm\")\nassert(encrypt(s: \"asdfghjkl\") == \"ewhjklnop\")\nassert(encrypt(s: \"gf\") == \"kj\")\nassert(encrypt(s: \"et\") == \"ix\")\nassert(encrypt(s: \"faewfawefaewg\") == \"jeiajeaijeiak\")\nassert(encrypt(s: \"hellomyfriend\") == \"lippsqcjvmirh\")\nassert(encrypt(s: \"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\") == \"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\")\nassert(encrypt(s: \"a\") == \"e\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "swift",
+    "prompt": "\n/// For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n/// Empty sum should be equal to 0 and empty product should be equal to 1.\n/// >>> sum_product(numbers: [] as [Int])\n/// (0, 1)\n/// >>> sum_product(numbers: [1, 2, 3, 4])\n/// (10, 24)\nfunc sum_product(numbers: [Int]) -> (Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_product(numbers: [] as [Int]) == (0, 1))\nassert(sum_product(numbers: [1, 1, 1]) == (3, 1))\nassert(sum_product(numbers: [100, 0]) == (100, 0))\nassert(sum_product(numbers: [3, 5, 7]) == (15, 105))\nassert(sum_product(numbers: [10]) == (10, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// Write a function next_smallest() that returns the 2nd smallest element of the list.\n/// Return None if there is no such element.\n/// >>> next_smallest(lst: [1, 2, 3, 4, 5])\n/// 2\n/// >>> next_smallest(lst: [5, 1, 4, 3, 2])\n/// 2\n/// >>> next_smallest(lst: [] as [Int])\n/// nil\n/// >>> next_smallest(lst: [1, 1])\n/// nil\nfunc next_smallest(lst: [Int]) -> Int? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest(lst: [1, 2, 3, 4, 5]) == 2)\nassert(next_smallest(lst: [5, 1, 4, 3, 2]) == 2)\nassert(next_smallest(lst: [] as [Int]) == nil)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [1, 1, 1, 1, 0]) == 1)\nassert(next_smallest(lst: [1, 1]) == nil)\nassert(next_smallest(lst: [-35, 34, 12, -45]) == -35)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "swift",
+    "prompt": "\n/// You'll be given a string of words, and your task is to count the number\n/// of boredoms. A boredom is a sentence that starts with the word \"I\".\n/// Sentences are delimited by '.', '?' or '!'.\n/// For example:\n/// >>> is_bored(S: \"Hello world\")\n/// 0\n/// >>> is_bored(S: \"The sky is blue. The sun is shining. I love this weather\")\n/// 1\nfunc is_bored(S: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_bored(S: \"Hello world\") == 0)\nassert(is_bored(S: \"Is the sky blue?\") == 0)\nassert(is_bored(S: \"I love It !\") == 1)\nassert(is_bored(S: \"bIt\") == 0)\nassert(is_bored(S: \"I feel good today. I will be productive. will kill It\") == 2)\nassert(is_bored(S: \"You and I are going for a walk\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes 3 numbers.\n/// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n/// Returns false in any other cases.\n/// Examples\n/// >>> any_int(x: 5, y: 2, z: 7)\n/// true\n/// >>> any_int(x: 3, y: 2, z: 2)\n/// false\n/// >>> any_int(x: 3, y: -2, z: 1)\n/// true\n/// >>> any_int(x: 3.6, y: -2.2, z: 2)\n/// false\nfunc any_int(x: Double, y: Double, z: Double) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(any_int(x: 2, y: 3, z: 1) == true)\nassert(any_int(x: 2.5, y: 2, z: 3) == false)\nassert(any_int(x: 1.5, y: 5, z: 3.5) == false)\nassert(any_int(x: 2, y: 6, z: 2) == false)\nassert(any_int(x: 4, y: 2, z: 2) == true)\nassert(any_int(x: 2.2, y: 2.2, z: 2.2) == false)\nassert(any_int(x: -4, y: 6, z: 2) == true)\nassert(any_int(x: 2, y: 1, z: 1) == true)\nassert(any_int(x: 3, y: 4, z: 7) == true)\nassert(any_int(x: 3.0, y: 4, z: 7) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes a message, and encodes in such a \n/// way that it swaps case of all letters, replaces all vowels in \n/// the message with the letter that appears 2 places ahead of that \n/// vowel in the english alphabet. \n/// Assume only letters. \n/// Examples:\n/// >>> encode(message: \"test\")\n/// \"TGST\"\n/// >>> encode(message: \"This is a message\")\n/// \"tHKS KS C MGSSCGG\"\nfunc encode(message: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(encode(message: \"TEST\") == \"tgst\")\nassert(encode(message: \"Mudasir\") == \"mWDCSKR\")\nassert(encode(message: \"YES\") == \"ygs\")\nassert(encode(message: \"This is a message\") == \"tHKS KS C MGSSCGG\")\nassert(encode(message: \"I DoNt KnOw WhAt tO WrItE\") == \"k dQnT kNqW wHcT Tq wRkTg\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "swift",
+    "prompt": "\n/// You are given a list of integers.\n/// You need to find the largest prime value and return the sum of its digits.\n/// Examples:\n/// >>> skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n/// 10\n/// >>> skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n/// 25\n/// >>> skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n/// 13\n/// >>> skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n/// 11\n/// >>> skjkasdkd(lst: [0, 81, 12, 3, 1, 21])\n/// 3\n/// >>> skjkasdkd(lst: [0, 8, 1, 2, 1, 7])\n/// 7\nfunc skjkasdkd(lst: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(skjkasdkd(lst: [0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]) == 10)\nassert(skjkasdkd(lst: [1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]) == 25)\nassert(skjkasdkd(lst: [1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]) == 13)\nassert(skjkasdkd(lst: [0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]) == 11)\nassert(skjkasdkd(lst: [0, 81, 12, 3, 1, 21]) == 3)\nassert(skjkasdkd(lst: [0, 8, 1, 2, 1, 7]) == 7)\nassert(skjkasdkd(lst: [8191]) == 19)\nassert(skjkasdkd(lst: [8191, 123456, 127, 7]) == 19)\nassert(skjkasdkd(lst: [127, 97, 8192]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "swift",
+    "prompt": "\n/// Implement a function that takes an non-negative integer and returns an array of the first n\n/// integers that are prime numbers and less than n.\n/// for example:\n/// >>> count_up_to(n: 5)\n/// [2, 3]\n/// >>> count_up_to(n: 11)\n/// [2, 3, 5, 7]\n/// >>> count_up_to(n: 0)\n/// [] as [Int]\n/// >>> count_up_to(n: 20)\n/// [2, 3, 5, 7, 11, 13, 17, 19]\n/// >>> count_up_to(n: 1)\n/// [] as [Int]\n/// >>> count_up_to(n: 18)\n/// [2, 3, 5, 7, 11, 13, 17]\nfunc count_up_to(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_up_to(n: 5) == [2, 3])\nassert(count_up_to(n: 6) == [2, 3, 5])\nassert(count_up_to(n: 7) == [2, 3, 5])\nassert(count_up_to(n: 10) == [2, 3, 5, 7])\nassert(count_up_to(n: 0) == [] as [Int])\nassert(count_up_to(n: 22) == [2, 3, 5, 7, 11, 13, 17, 19])\nassert(count_up_to(n: 1) == [] as [Int])\nassert(count_up_to(n: 18) == [2, 3, 5, 7, 11, 13, 17])\nassert(count_up_to(n: 47) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43])\nassert(count_up_to(n: 101) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "swift",
+    "prompt": "\n/// Complete the function that takes two integers and returns \n/// the product of their unit digits.\n/// Assume the input is always valid.\n/// Examples:\n/// >>> multiply(a: 148, b: 412)\n/// 16\n/// >>> multiply(a: 19, b: 28)\n/// 72\n/// >>> multiply(a: 2020, b: 1851)\n/// 0\n/// >>> multiply(a: 14, b: -15)\n/// 20\nfunc multiply(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply(a: 148, b: 412) == 16)\nassert(multiply(a: 19, b: 28) == 72)\nassert(multiply(a: 2020, b: 1851) == 0)\nassert(multiply(a: 14, b: -15) == 20)\nassert(multiply(a: 76, b: 67) == 42)\nassert(multiply(a: 17, b: 27) == 49)\nassert(multiply(a: 0, b: 1) == 0)\nassert(multiply(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "swift",
+    "prompt": "\n/// Given a string s, count the number of uppercase vowels in even indices.\n/// For example:\n/// >>> count_upper(s: \"aBCdEf\")\n/// 1\n/// >>> count_upper(s: \"abcdefg\")\n/// 0\n/// >>> count_upper(s: \"dBBE\")\n/// 0\nfunc count_upper(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_upper(s: \"aBCdEf\") == 1)\nassert(count_upper(s: \"abcdefg\") == 0)\nassert(count_upper(s: \"dBBE\") == 0)\nassert(count_upper(s: \"B\") == 0)\nassert(count_upper(s: \"U\") == 1)\nassert(count_upper(s: \"\") == 0)\nassert(count_upper(s: \"EEEE\") == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "swift",
+    "prompt": "\n/// Create a function that takes a value (string) representing a number\n/// and returns the closest integer to it. If the number is equidistant\n/// from two integers, round it away from zero.\n/// Examples\n/// >>> closest_integer(value: \"10\")\n/// 10\n/// >>> closest_integer(value: \"15.3\")\n/// 15\n/// Note:\n/// Rounding away from zero means that if the given number is equidistant\n/// from two integers, the one you should return is the one that is the\n/// farthest from zero. For example closest_integer(\"14.5\") should\n/// return 15 and closest_integer(\"-14.5\") should return -15.\nfunc closest_integer(value: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_integer(value: \"10\") == 10)\nassert(closest_integer(value: \"14.5\") == 15)\nassert(closest_integer(value: \"-15.5\") == -16)\nassert(closest_integer(value: \"15.3\") == 15)\nassert(closest_integer(value: \"0\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "swift",
+    "prompt": "\n/// From a given list of integers, generate a list of rolling maximum element found until given moment\n/// in the sequence.\n/// >>> rolling_max(numbers: [1, 2, 3, 2, 3, 4, 2])\n/// [1, 2, 3, 3, 3, 4, 4]\nfunc rolling_max(numbers: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rolling_max(numbers: [] as [Int]) == [] as [Int])\nassert(rolling_max(numbers: [1, 2, 3, 4]) == [1, 2, 3, 4])\nassert(rolling_max(numbers: [4, 3, 2, 1]) == [4, 4, 4, 4])\nassert(rolling_max(numbers: [3, 2, 3, 100, 3]) == [3, 3, 3, 100, 100])",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/humaneval-ts-keep.json
+++ b/prompts/humaneval-ts-keep.json
@@ -1,1242 +1,12 @@
 [
   {
-    "name": "HumanEval_77_iscube",
+    "name": "HumanEval_0_has_close_elements",
     "language": "ts",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube(a: number): boolean {\n",
+    "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements(numbers: number[], threshold: number): boolean {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "ts",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode(message: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "ts",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "ts",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_15_string_sequence",
-    "language": "ts",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence(n: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_114_minSubArraySum",
-    "language": "ts",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "ts",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "ts",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "ts",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_52_below_threshold",
-    "language": "ts",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold(l: number[], t: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "ts",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int(x: number, y: number, z: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "ts",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "ts",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_99_closest_integer",
-    "language": "ts",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "ts",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "ts",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy(s: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "ts",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check(file_name: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "ts",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram(test: string): {[key: string]: number} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "ts",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "ts",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify(x: string, n: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "ts",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_112_reverse_delete",
-    "language": "ts",
-    "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete(s: string, c: string): [string, boolean] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "ts",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product(numbers: number[]): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "ts",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes(string: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_23_strlen",
-    "language": "ts",
-    "prompt": "//Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen(string: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "ts",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_75_is_multiply_prime",
-    "language": "ts",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "ts",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "ts",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_57_monotonic",
-    "language": "ts",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic(l: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "ts",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_154_cycpattern_check",
-    "language": "ts",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check(a: string, b: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "ts",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "ts",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "ts",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_33_sort_third",
-    "language": "ts",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "ts",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "ts",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "ts",
-    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_149_sorted_list_sum",
-    "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "ts",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "ts",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "ts",
-    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "ts",
-    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "ts",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "ts",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest(lst: number[]): number | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "ts",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "ts",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens(lst: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "ts",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "ts",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "ts",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "ts",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt(s: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "ts",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_5_intersperse",
-    "language": "ts",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve(s: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_37_sort_even",
-    "language": "ts",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_3_below_zero",
-    "language": "ts",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero(operations: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_54_same_chars",
-    "language": "ts",
-    "prompt": "//Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars(s0: string, s1: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "ts",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups(paren_string: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "ts",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper(s: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_9_rolling_max",
-    "language": "ts",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_26_remove_duplicates",
-    "language": "ts",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "ts",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_158_find_max",
-    "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "ts",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "ts",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "ts",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "ts",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "ts",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "ts",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power(x: number, n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1249,7 +19,7 @@
     "language": "ts",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n: number): number[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1260,1063 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_53_add",
+    "name": "HumanEval_101_words_string",
     "language": "ts",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// words_string(\"Hi, my name is John\") == [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// words_string(\"One, two, three, four, five, six\") == [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "ts",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_13_greatest_common_divisor",
-    "language": "ts",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "ts",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "ts",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "ts",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel(word: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "ts",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "ts",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers(numbers: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "ts",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "ts",
-    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "ts",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "ts",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested(string: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "ts",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length(arr: number[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "ts",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_60_sum_to_n",
-    "language": "ts",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "ts",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_28_concatenate",
-    "language": "ts",
-    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate(strings: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "ts",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_116_sort_array",
-    "language": "ts",
-    "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array(arr: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_12_longest",
-    "language": "ts",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest(strings: string[]): string | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted(lst: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "ts",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count(num: number): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "ts",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle(s: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "ts",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "ts",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "ts",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_44_change_base",
-    "language": "ts",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base(x: number, base: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length(string: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_81_numerical_letter_grade",
-    "language": "ts",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_69_search",
-    "language": "ts",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search(lst: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_157_right_angle_triangle",
-    "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "ts",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_6_parse_nested_parens",
-    "language": "ts",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "ts",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "ts",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "ts",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_64_vowels_count",
-    "language": "ts",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_162_string_to_md5",
-    "language": "ts",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5(text: string): string | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "ts",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "ts",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key(num: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "ts",
-    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_146_specialFilter",
-    "language": "ts",
-    "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "ts",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "ts",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "ts",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list(lst: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "ts",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "ts",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "ts",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date(date: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "ts",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "ts",
-    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "ts",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum(s: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "ts",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_45_triangle_area",
-    "language": "ts",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_125_split_words",
-    "language": "ts",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words(txt: string): string[]| number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "ts",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "ts",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor(a: string, b: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_0_has_close_elements",
-    "language": "ts",
-    "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// False\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// True\nfunction has_close_elements(numbers: number[], threshold: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_0_has_close_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "ts",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution(s: string, n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "ts",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "ts",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman(number: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_61_correct_bracketing",
-    "language": "ts",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing(brackets: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_56_correct_bracketing",
-    "language": "ts",
-    "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing(brackets: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "ts",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_128_prod_signs",
-    "language": "ts",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs(arr: number[]): number | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_7_filter_by_substring",
-    "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "ts",
-    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_30_get_positive",
-    "language": "ts",
-    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2329,7 +49,7 @@
     "language": "ts",
     "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// choose_num(12, 15) = 14\n// choose_num(13, 12) = -1\nfunction choose_num(x: number, y: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
@@ -2340,13 +60,958 @@
     ]
   },
   {
-    "name": "HumanEval_84_solve",
+    "name": "HumanEval_103_rounded_avg",
     "language": "ts",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// rounded_avg(1, 5) => \"0b11\"\n// rounded_avg(7, 5) => -1\n// rounded_avg(10, 20) => \"0b1111\"\n// rounded_avg(20, 33) => \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_104_unique_digits",
+    "language": "ts",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_104_unique_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_105_by_length",
+    "language": "ts",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// arr = [2, 1, 1, 4, 5, 8, 2, 3]   \n// -> sort arr -> [1, 1, 2, 2, 3, 4, 5, 8] \n// -> reverse arr -> [8, 5, 4, 3, 2, 2, 1, 1]\n// return [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// arr = []\n// return []\n// If the array has any strange number ignore it:\n// arr = [1, -1 , 55] \n// -> sort arr -> [-1, 1, 55]\n// -> reverse arr -> [55, 1, -1]\n// return = ['One']\nfunction by_length(arr: number[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_105_by_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_106_f",
+    "language": "ts",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// f(5) == [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_106_f.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_107_even_odd_palindrome",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Input: 3\n// Output: (1, 2)\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Input: 12\n// Output: (4, 6)\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_107_even_odd_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_108_count_nums",
+    "language": "ts",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([]) == 0\n// >>> count_nums([-1, 11, -11]) == 1\n// >>> count_nums([1, 1, 2]) == 3\nfunction count_nums(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_108_count_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_109_move_one_ball",
+    "language": "ts",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// move_one_ball([3, 4, 5, 1, 2])==>True\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// move_one_ball([3, 5, 4, 1, 2])==>False\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_109_move_one_ball.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_10_make_palindrome",
+    "language": "ts",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome('')\n// ''\n// >>> make_palindrome('cat')\n// 'catac'\n// >>> make_palindrome('cata')\n// 'catac'\nfunction make_palindrome(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_10_make_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_110_exchange",
+    "language": "ts",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// exchange([1, 2, 3, 4], [1, 2, 3, 4]) => \"YES\"\n// exchange([1, 2, 3, 4], [1, 5, 3, 4]) => \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_110_exchange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_111_histogram",
+    "language": "ts",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// histogram('a b c') == {'a': 1, 'b': 1, 'c': 1}\n// histogram('a b b a') == {'a': 2, 'b': 2}\n// histogram('a b c a b') == {'a': 2, 'b': 2}\n// histogram('b b b b a') == {'b': 4}\n// histogram('') == {}\nfunction histogram(test: string): {[key: string]: number} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_111_histogram.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_112_reverse_delete",
+    "language": "ts",
+    "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// For s = \"abcde\", c = \"ae\", the result should be ('bcd',False)\n// For s = \"abcdef\", c = \"b\"  the result should be ('acdef',False)\n// For s = \"abcdedcba\", c = \"ab\", the result should be ('cdedc',True)\nfunction reverse_delete(s: string, c: string): [string, boolean] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_112_reverse_delete.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_113_odd_count",
+    "language": "ts",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count(['1234567'])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count(['3',\"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\",\n// \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_113_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_114_minSubArraySum",
+    "language": "ts",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// minSubArraySum([2, 3, 4, 1, 2, 4]) == 1\n// minSubArraySum([-1, -2, -3]) == -6\nfunction minSubArraySum(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_114_minSubArraySum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "ts",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Input: \n// grid : [[0,0,1,0], [0,1,0,0], [1,1,1,1]]\n// bucket_capacity : 1\n// Output: 6\n// Example 2:\n// Input: \n// grid : [[0,0,1,1], [0,0,0,0], [1,1,1,1], [0,1,1,1]]\n// bucket_capacity : 2\n// Output: 5\n// Example 3:\n// Input: \n// grid : [[0,0,0], [0,0,0]]\n// bucket_capacity : 5\n// Output: 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_116_sort_array",
+    "language": "ts",
+    "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4]) == [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6]) == [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4]) [0, 1, 2, 3, 4]\nfunction sort_array(arr: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_116_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_117_select_words",
+    "language": "ts",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// select_words(\"Mary had a little lamb\", 4) ==> [\"little\"]\n// select_words(\"Mary had a little lamb\", 3) ==> [\"Mary\", \"lamb\"]\n// select_words(\"simple white space\", 2) ==> []\n// select_words(\"Hello world\", 4) ==> [\"world\"]\n// select_words(\"Uncle sam\", 3) ==> [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_117_select_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_118_get_closest_vowel",
+    "language": "ts",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// get_closest_vowel(\"yogurt\") ==> \"u\"\n// get_closest_vowel(\"FULL\") ==> \"U\"\n// get_closest_vowel(\"quick\") ==> \"\"\n// get_closest_vowel(\"ab\") ==> \"\"\nfunction get_closest_vowel(word: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_118_get_closest_vowel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_119_match_parens",
+    "language": "ts",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// match_parens(['()(', ')']) == 'Yes'\n// match_parens([')', ')']) == 'No'\nfunction match_parens(lst: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_119_match_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_11_string_xor",
+    "language": "ts",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor('010', '110')\n// '100'\nfunction string_xor(a: string, b: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_11_string_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_120_maximum",
+    "language": "ts",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Input: arr = [-3, -4, 5], k = 3\n// Output: [-4, -3, 5]\n// Example 2:\n// Input: arr = [4, -4, 4], k = 2\n// Output: [4, 4]\n// Example 3:\n// Input: arr = [-3, 2, 1, 2, -1, -2, 1], k = 1\n// Output: [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_120_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_121_solution",
+    "language": "ts",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// solution([5, 8, 7, 1]) ==> 12\n// solution([3, 3, 3, 3, 3]) ==> 9\n// solution([30, 13, 24, 321]) ==>0\nfunction solution(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_121_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_122_add_elements",
+    "language": "ts",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Input: arr = [111,21,3,4000,5,6,7,8,9], k = 4\n// Output: 24 # sum of 21 + 3\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_122_add_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_123_get_odd_collatz",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_123_get_odd_collatz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_124_valid_date",
+    "language": "ts",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// for example: \n// valid_date('03-11-2000') => True\n// valid_date('15-01-2012') => False\n// valid_date('04-0-2040') => False\n// valid_date('06-04-2020') => True\n// valid_date('06/04/2020') => False\nfunction valid_date(date: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_124_valid_date.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_125_split_words",
+    "language": "ts",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// split_words(\"Hello world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"Hello,world!\") \u279e [\"Hello\", \"world!\"]\n// split_words(\"abcdef\") == 3\nfunction split_words(txt: string): string[]| number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_125_split_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_126_is_sorted",
+    "language": "ts",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// is_sorted([5]) \u279e True\n// is_sorted([1, 2, 3, 4, 5]) \u279e True\n// is_sorted([1, 3, 2, 4, 5]) \u279e False\n// is_sorted([1, 2, 3, 4, 5, 6]) \u279e True\n// is_sorted([1, 2, 3, 4, 5, 6, 7]) \u279e True\n// is_sorted([1, 3, 2, 4, 5, 6, 7]) \u279e False\n// is_sorted([1, 2, 2, 3, 3, 4]) \u279e True\n// is_sorted([1, 2, 2, 2, 3, 4]) \u279e False\nfunction is_sorted(lst: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_126_is_sorted.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "ts",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// intersection((1, 2), (2, 3)) ==> \"NO\"\n// intersection((-1, 1), (0, 4)) ==> \"NO\"\n// intersection((-3, -1), (-5, 5)) ==> \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "ts",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4]) == -9\n// >>> prod_signs([0, 1]) == 0\n// >>> prod_signs([]) == None\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "ts",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\n// Input: grid = [ [1,2,3], [4,5,6], [7,8,9]], k = 3\n// Output: [1, 2, 1]\n// Input: grid = [ [5,9,3], [4,1,6], [7,8,2]], k = 1\n// Output: [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "ts",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// >>> longest(['a', 'b', 'c'])\n// 'a'\n// >>> longest(['a', 'bb', 'ccc'])\n// 'ccc'\nfunction longest(strings: string[]): string | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "ts",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// tri(3) = [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// digits(1)  == 1\n// digits(4)  == 0\n// digits(235) == 15\nfunction digits(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "ts",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// is_nested('[[]]') \u279e True\n// is_nested('[]]]]]]][[[[[]') \u279e False\n// is_nested('[][]') \u279e False\n// is_nested('[]') \u279e False\n// is_nested('[[][]]') \u279e True\n// is_nested('[[]][[') \u279e True\nfunction is_nested(string: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "ts",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// For lst = [1,2,3] the output should be 14\n// For lst = [1,4,9] the output should be 98\n// For lst = [1,3,5,7] the output should be 84\n// For lst = [1.4,4.2,0] the output should be 29\n// For lst = [-2.4,1,1] the output should be 6\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "ts",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// check_if_last_char_is_a_letter(\"apple pie\") \u279e False\n// check_if_last_char_is_a_letter(\"apple pi e\") \u279e True\n// check_if_last_char_is_a_letter(\"apple pi e \") \u279e False\n// check_if_last_char_is_a_letter(\"\") \u279e False\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "ts",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// can_arrange([1,2,4,3,5]) = 3\n// can_arrange([1,2,3]) = -1\nfunction can_arrange(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "ts",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// largest_smallest_integers([2, 4, 1, 3, 5, 7]) == (None, 1)\n// largest_smallest_integers([]) == (None, None)\n// largest_smallest_integers([0]) == (None, None)\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "ts",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// is_equal_to_sum_even(4) == False\n// is_equal_to_sum_even(6) == False\n// is_equal_to_sum_even(8) == True\nfunction is_equal_to_sum_even(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "ts",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "ts",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "ts",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// fix_spaces(\"Example\") == \"Example\"\n// fix_spaces(\"Example 1\") == \"Example_1\"\n// fix_spaces(\" Example 2\") == \"_Example_2\"\n// fix_spaces(\" Example   3\") == \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "ts",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// file_name_check(\"example.txt\") # => 'Yes'\n// file_name_check(\"1example.dll\") # => 'No' (the name should start with a latin alphapet letter)\nfunction file_name_check(file_name: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "ts",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// For lst = [1,2,3] the output should be 6\n// For lst = []  the output should be 0\n// For lst = [-1,-5,2,-1,-5]  the output should be -126\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "ts",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Input: sentence = \"This is a test\"\n// Output: \"is\"\n// Example 2:\n// Input: sentence = \"lets go for swimming\"\n// Output: \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "ts",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// simplify(\"1/5\", \"5/1\") = True\n// simplify(\"1/6\", \"2/1\") = False\n// simplify(\"7/10\", \"10/2\") = False\nfunction simplify(x: string, n: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "ts",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12]) == [-1, -11, 1, -12, 11]\n// >>> order_by_points([]) == []\nfunction order_by_points(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_146_specialFilter",
+    "language": "ts",
+    "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// specialFilter([15, -73, 14, -15]) => 1 \n// specialFilter([33, -2, -3, 45, 21, 109]) => 2\nfunction specialFilter(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_146_specialFilter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_147_get_max_triples",
+    "language": "ts",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Input: n = 5\n// Output: 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_147_get_max_triples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_149_sorted_list_sum",
+    "language": "ts",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// assert list_sort([\"aa\", \"a\", \"aaa\"]) => [\"aa\"]\n// assert list_sort([\"ab\", \"a\", \"aaa\", \"cd\"]) => [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_149_sorted_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "ts",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes('abc')\n// ['a', 'ab', 'abc']\nfunction all_prefixes(string: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "ts",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// for x_or_y(7, 34, 12) == 34\n// for x_or_y(15, 8, 5) == 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "ts",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// double_the_difference([1, 3, 2, 0]) == 1 + 9 + 0 + 0 = 10\n// double_the_difference([-1, -2, 0]) == 0\n// double_the_difference([9, -2]) == 81\n// double_the_difference([0]) == 0  \n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "ts",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// compare([1,2,3,4,5,1],[1,2,3,4,2,-2]) -> [0,0,0,0,3,3]\n// compare([0,5,0,0,0,4],[4,1,1,0,0,-2]) -> [4,4,1,0,0,6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "ts",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// for Strongest_Extension('my_class', ['AA', 'Be', 'CC']) == 'my_class.AA'\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "ts",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// cycpattern_check(\"abcd\",\"abd\") => False\n// cycpattern_check(\"hello\",\"ell\") => True\n// cycpattern_check(\"whassup\",\"psus\") => False\n// cycpattern_check(\"abab\",\"baa\") => True\n// cycpattern_check(\"efef\",\"eeff\") => False\n// cycpattern_check(\"himenss\",\"simen\") => True\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "ts",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// even_odd_count(-12) ==> (1, 1)\n// even_odd_count(123) ==> (1, 2)\nfunction even_odd_count(num: number): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "ts",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19) == 'xix'\n// >>> int_to_mini_roman(152) == 'clii'\n// >>> int_to_mini_roman(426) == 'cdxxvi'\nfunction int_to_mini_roman(number: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// right_angle_triangle(3, 4, 5) == True\n// right_angle_triangle(1, 2, 3) == False\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "ts",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// find_max([\"name\", \"of\", \"string\"]) == \"string\"\n// find_max([\"name\", \"enam\", \"game\"]) == \"enam\"\n// find_max([\"aaaaaaa\", \"bb\" ,\"cc\"]) == \"\"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "ts",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// * eat(5, 6, 10) -> [11, 4]\n// * eat(4, 8, 9) -> [12, 1]\n// * eat(1, 10, 10) -> [11, 0]\n// * eat(2, 11, 5) -> [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "ts",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// '0'\n// >>> string_sequence(5)\n// '0 1 2 3 4 5'\nfunction string_sequence(n: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "ts",
+    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// solve(\"1234\") = \"4321\"\n// solve(\"ab\") = \"AB\"\n// solve(\"#a@C\") = \"#A@c\"\nfunction solve(s: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "ts",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5('Hello world') == '3e25960a79dbc69b674cd4ec67a72c62'\nfunction string_to_md5(text: string): string | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2359,7 +1024,7 @@
     "language": "ts",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// generate_integers(2, 8) => [2, 4, 6, 8]\n// generate_integers(8, 2) => [2, 4, 6, 8]\n// generate_integers(10, 14) => []\nfunction generate_integers(a: number, b: number): number[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2374,9 +1039,1344 @@
     "language": "ts",
     "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters('xyzXYZ')\n// 3\n// >>> count_distinct_characters('Jerry')\n// 4\nfunction count_distinct_characters(string: string): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_17_parse_music",
+    "language": "ts",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music('o o| .| o| o| .| .| .| .| o o')\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_17_parse_music.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_18_how_many_times",
+    "language": "ts",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times('', 'a')\n// 0\n// >>> how_many_times('aaa', 'a')\n// 3\n// >>> how_many_times('aaaa', 'aa')\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_18_how_many_times.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_19_sort_numbers",
+    "language": "ts",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers('three one five')\n// 'one three five'\nfunction sort_numbers(numbers: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_19_sort_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "ts",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups('( ) (( )) (( )( ))')\n// ['()', '(())', '(()())']\nfunction separate_paren_groups(paren_string: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "ts",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// (2.0, 2.2)\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// (2.0, 2.0)\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "ts",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "ts",
+    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers(['a', 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, 'abc', {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "ts",
+    "prompt": "//Return length of given string\n// >>> strlen('')\n// 0\n// >>> strlen('abc')\n// 3\nfunction strlen(string: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "ts",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "ts",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "ts",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "ts",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case('Hello')\n// 'hELLO'\nfunction flip_case(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "ts",
+    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// ''\n// >>> concatenate(['a', 'b', 'c'])\n// 'abc'\nfunction concatenate(strings: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], 'a')\n// []\n// >>> filter_by_prefix(['abc', 'bcd', 'cde', 'array'], 'a')\n// ['abc', 'array']\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "ts",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "ts",
+    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "ts",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// False\n// >>> is_prime(101)\n// True\n// >>> is_prime(11)\n// True\n// >>> is_prime(13441)\n// True\n// >>> is_prime(61)\n// True\n// >>> is_prime(4)\n// False\n// >>> is_prime(1)\n// False\nfunction is_prime(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "ts",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "ts",
+    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "ts",
+    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "ts",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_37_sort_even",
+    "language": "ts",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_37_sort_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "ts",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "ts",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// False\n// >>> below_zero([1, 2, -4, 5])\n// True\nfunction below_zero(operations: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "ts",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// True\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// True\n// >>> triples_sum_to_zero([1])\n// False\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "ts",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "ts",
+    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "ts",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// False\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// False\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// False\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// True\n// >>> pairs_sum_to_zero([1])\n// False\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "ts",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// '22'\n// >>> change_base(8, 2)\n// '1000'\n// >>> change_base(7, 2)\n// '111'\nfunction change_base(x: number, base: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "ts",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "ts",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "ts",
+    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "ts",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome('')\n// True\n// >>> is_palindrome('aba')\n// True\n// >>> is_palindrome('aaaaa')\n// True\n// >>> is_palindrome('zbcd')\n// False\nfunction is_palindrome(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "ts",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "ts",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "ts",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels('')\n// ''\n// >>> remove_vowels('abcdef')\n// 'bcdf'\n// >>> remove_vowels('aaaaa')\n// ''\n// >>> remove_vowels('aaBAA')\n// 'B'\n// >>> remove_vowels('zbcd')\n// 'zbcd'\nfunction remove_vowels(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "ts",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// True\n// >>> below_threshold([1, 20, 4, 10], 5)\n// False\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "ts",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_54_same_chars",
+    "language": "ts",
+    "prompt": "//Check if two words have the same characters.\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddeddabc')\n// True\n// >>> same_chars('abcd', 'dddddddabc')\n// True\n// >>> same_chars('dddddddabc', 'abcd')\n// True\n// >>> same_chars('eabcd', 'dddddddabc')\n// False\n// >>> same_chars('abcd', 'dddddddabce')\n// False\n// >>> same_chars('eabcdzzzz', 'dddzzzzzzzddddabc')\n// False\nfunction same_chars(s0: string, s1: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_54_same_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "ts",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_56_correct_bracketing",
+    "language": "ts",
+    "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// False\n// >>> correct_bracketing(\"<>\")\n// True\n// >>> correct_bracketing(\"<<><>>\")\n// True\n// >>> correct_bracketing(\"><<>\")\n// False\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_56_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "ts",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// True\n// >>> monotonic([1, 20, 4, 10])\n// False\n// >>> monotonic([4, 1, 0, -10])\n// True\nfunction monotonic(l: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "ts",
+    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "ts",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "ts",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "ts",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "ts",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// False\n// >>> correct_bracketing(\"()\")\n// True\n// >>> correct_bracketing(\"(()())\")\n// True\n// >>> correct_bracketing(\")(()\")\n// False\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "ts",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "ts",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "ts",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "ts",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "ts",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// digitSum(\"\") => 0\n// digitSum(\"abAB\") => 131\n// digitSum(\"abcCd\") => 67\n// digitSum(\"helloE\") => 69\n// digitSum(\"woArBld\") => 131\n// digitSum(\"aAaaaXa\") => 153\nfunction digitSum(s: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "ts",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// fruit_distribution(\"5 apples and 6 oranges\", 19) ->19 - 5 - 6 = 8\n// fruit_distribution(\"0 apples and 1 oranges\",3) -> 3 - 0 - 1 = 2\n// fruit_distribution(\"2 apples and 3 oranges\", 100) -> 100 - 2 - 3 = 95\n// fruit_distribution(\"100 apples and 1 oranges\",120) -> 120 - 100 - 1 = 19\nfunction fruit_distribution(s: string, n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "ts",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Input: [4,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Input: [1,2,3]\n// Output: [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index. \n// Example 3:\n// Input: []\n// Output: []\n// Example 4:\n// Input: [5, 0, 3, 0, 4, 2]\n// Output: [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "ts",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// search([4, 1, 2, 2, 3, 1]) == 2\n// search([1, 2, 2, 3, 3, 3, 4, 4, 4]) == 3\n// search([5, 5, 4, 4, 4]) == -1\nfunction search(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "ts",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens('(()()) ((())) () ((())()())')\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "ts",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// strange_sort_list([1, 2, 3, 4]) == [1, 4, 2, 3]\n// strange_sort_list([5, 5, 5, 5]) == [5, 5, 5, 5]\n// strange_sort_list([]) == []\nfunction strange_sort_list(lst: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// triangle_area(3, 4, 5) == 6.00\n// triangle_area(1, 2, 10) == -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "ts",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// will_it_fly([1, 2], 5) \u279e False \n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// will_it_fly([3, 2, 3], 1) \u279e False\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// will_it_fly([3, 2, 3], 9) \u279e True\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// will_it_fly([3], 5) \u279e True\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "ts",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// smallest_change([1,2,3,5,4,7,9,6]) == 4\n// smallest_change([1, 2, 3, 4, 3, 2, 2]) == 1\n// smallest_change([1, 2, 3, 2, 1]) == 0\nfunction smallest_change(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "ts",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// total_match([], []) \u279e []\n// total_match(['hi', 'admin'], ['hI', 'Hi']) \u279e ['hI', 'Hi']\n// total_match(['hi', 'admin'], ['hi', 'hi', 'admin', 'project']) \u279e ['hi', 'admin']\n// total_match(['hi', 'admin'], ['hI', 'hi', 'hi']) \u279e ['hI', 'hi', 'hi']\n// total_match(['4'], ['1', '2', '3', '4', '5']) \u279e ['4']\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "ts",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// is_multiply_prime(30) == True\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "ts",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// is_simple_power(1, 4) => true\n// is_simple_power(2, 2) => true\n// is_simple_power(8, 2) => true\n// is_simple_power(3, 2) => false\n// is_simple_power(3, 1) => false\n// is_simple_power(5, 3) => false\nfunction is_simple_power(x: number, n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "ts",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// iscube(1) ==> True\n// iscube(2) ==> False\n// iscube(-1) ==> True\n// iscube(64) ==> True\n// iscube(0) ==> True\n// iscube(180) ==> False\nfunction iscube(a: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "ts",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// For num = \"AB\" the output should be 1.\n// For num = \"1077E\" the output should be 2.\n// For num = \"ABED1A33\" the output should be 4.\n// For num = \"123456789ABCDEF0\" the output should be 6.\n// For num = \"2020\" the output should be 2.\nfunction hex_key(num: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// decimal_to_binary(15)   # returns \"db1111db\"\n// decimal_to_binary(32)   # returns \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], 'a')\n// []\n// >>> filter_by_substring(['abc', 'bacd', 'cde', 'array'], 'a')\n// ['abc', 'bacd', 'array']\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// is_happy(a) => False\n// is_happy(aa) => False\n// is_happy(abcd) => True\n// is_happy(aabb) => False\n// is_happy(adb) => True\n// is_happy(xyy) => False\nfunction is_happy(s: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "ts",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// grade_equation([4.0, 3, 1.7, 2, 3.5]) ==> ['A+', 'B', 'C-', 'C', 'A-']\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// prime_length('Hello') == True\n// prime_length('abcdcba') == True\n// prime_length('kittens') == True\n// prime_length('orange') == False\nfunction prime_length(string: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "ts",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// For N = 1000, the sum of digits will be 1 the output should be \"1\".\n// For N = 150, the sum of digits will be 6 the output should be \"110\".\n// For N = 147, the sum of digits will be 12 the output should be \"1100\".\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "ts",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// add([4, 2, 6, 7]) ==> 2\nfunction add(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// anti_shuffle('Hi') returns 'Hi'\n// anti_shuffle('hello') returns 'ehllo'\n// anti_shuffle('Hello World!!!') returns 'Hello !!!Wdlor'\nfunction anti_shuffle(s: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "ts",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// get_row([\n// [1,2,3,4,5,6],\n// [1,2,3,4,1,6],\n// [1,2,3,4,5,1]\n// ], 1) == [(0, 0), (1, 4), (1, 0), (2, 5), (2, 0)]\n// get_row([], 1) == []\n// get_row([[], [1], [1, 2, 3]], 3) == [(2, 2)]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "ts",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// * sort_array([]) => []\n// * sort_array([5]) => [5]\n// * sort_array([2, 4, 3, 0, 1, 5]) => [0, 1, 2, 3, 4, 5]\n// * sort_array([2, 4, 3, 0, 1, 5, 6]) => [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "ts",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// encrypt('hi') returns 'lm'\n// encrypt('asdfghjkl') returns 'ewhjklnop'\n// encrypt('gf') returns 'kj'\n// encrypt('et') returns 'ix'\nfunction encrypt(s: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "ts",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// (0, 1)\n// >>> sum_product([1, 2, 3, 4])\n// (10, 24)\nfunction sum_product(numbers: number[]): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// next_smallest([1, 2, 3, 4, 5]) == 2\n// next_smallest([5, 1, 4, 3, 2]) == 2\n// next_smallest([]) == None\n// next_smallest([1, 1]) == None\nfunction next_smallest(lst: number[]): number | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "ts",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "ts",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// any_int(5, 2, 7) \u279e True\n// any_int(3, 2, 2) \u279e False\n// any_int(3, -2, 1) \u279e True\n// any_int(3.6, -2.2, 2) \u279e False\nfunction any_int(x: number, y: number, z: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "ts",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode('test')\n// 'TGST'\n// >>> encode('This is a message')\n// 'tHKS KS C MGSSCGG'\nfunction encode(message: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// For lst = [0,3,2,1,3,5,7,4,5,5,5,2,181,32,4,32,3,2,32,324,4,3] the output should be 10\n// For lst = [1,0,1,8,2,4597,2,1,3,40,1,2,1,2,4,2,5,1] the output should be 25\n// For lst = [1,3,1,32,5107,34,83278,109,163,23,2323,32,30,1,9,3] the output should be 13\n// For lst = [0,724,32,71,99,32,6,0,5,91,83,0,5,6] the output should be 11\n// For lst = [0,81,12,3,1,21] the output should be 3\n// For lst = [0,8,1,2,1,7] the output should be 7\nfunction skjkasdkd(lst: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "ts",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// check_dict_case({\"a\":\"apple\", \"b\":\"banana\"}) should return True.\n// check_dict_case({\"a\":\"apple\", \"A\":\"banana\", \"B\":\"banana\"}) should return False.\n// check_dict_case({\"a\":\"apple\", \"8\":\"banana\", \"a\":\"apple\"}) should return False.\n// check_dict_case({\"Name\":\"John\", \"Age\":\"36\", \"City\":\"Houston\"}) should return False.\n// check_dict_case({\"STATE\":\"NC\", \"ZIP\":\"12345\" }) should return True.\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "ts",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// count_up_to(5) => [2,3]\n// count_up_to(11) => [2,3,5,7]\n// count_up_to(0) => []\n// count_up_to(20) => [2,3,5,7,11,13,17,19]\n// count_up_to(1) => []\n// count_up_to(18) => [2,3,5,7,11,13,17]\nfunction count_up_to(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "ts",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// multiply(148, 412) should return 16.\n// multiply(19, 28) should return 72.\n// multiply(2020, 1851) should return 0.\n// multiply(14,-15) should return 20.\nfunction multiply(a: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "ts",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// count_upper('aBCdEf') returns 1\n// count_upper('abcdefg') returns 0\n// count_upper('dBBE') returns 0\nfunction count_upper(s: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "ts",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "ts",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-ts-remove.json
+++ b/prompts/humaneval-ts-remove.json
@@ -1,1677 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "ts",
-    "prompt": "//Return length of given string\nfunction strlen(string: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "ts",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt(s: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "ts",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "ts",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces(text: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "ts",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "ts",
-    "prompt": "//Filter given list of any python values only for integers\nfunction filter_integers(values: any[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "ts",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music(music_string: string): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary(decimal: number): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "ts",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes(string: string): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "ts",
-    "prompt": "//Add two numbers x and y\nfunction add(x: number, y: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "ts",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "ts",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "ts",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case(string: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "ts",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length(arr: number[]): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "ts",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize(n: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "ts",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to(n: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "ts",
-    "prompt": "//Return sorted unique elements in a list\nfunction unique(l: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "ts",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "ts",
-    "prompt": "//Return maximum element in the list.\nfunction max_element(l: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "ts",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested(string: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "ts",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg(n: number, m: number): string| number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "ts",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count(lst: string[]): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "ts",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "ts",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even(n: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "ts",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative(xs: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted(lst: number[]): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve(s: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "ts",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri(n: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "ts",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "ts",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "ts",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath(grid: number[][], k: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "ts",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper(s: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "ts",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "ts",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array(array: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "ts",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f(n: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "ts",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube(a: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "ts",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode(message: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "ts",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored(S: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "ts",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area(a: number, b: number, c: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "ts",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string(s: string): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "ts",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times(string: string, substring: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "ts",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels(text: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "ts",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list(lst: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "ts",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "ts",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power(x: number, n: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "ts",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "ts",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points(nums: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "ts",
     "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\nfunction has_close_elements(numbers: number[], threshold: number): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "ts",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome(string: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "ts",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor(a: string, b: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "ts",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "ts",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "ts",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits(x: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "ts",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words(s: string, n: number): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "ts",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "ts",
-    "prompt": "//Return n-th Fibonacci number.\nfunction fib(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "ts",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "ts",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens(lst: string[]): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest(lst: number[]): number | undefined {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "ts",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int(x: number, y: number, z: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "ts",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number(number: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "ts",
-    "prompt": "//Return list with elements incremented by 1.\nfunction incr_list(l: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "ts",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y(n: number, x: number, y: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "ts",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\nfunction modp(n: number, p: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "ts",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count(num: number): [number, number] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy(s: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "ts",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "ts",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum(s: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "ts",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "ts",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "ts",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "ts",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "ts",
-    "prompt": "//Return median of elements in the list l.\nfunction median(l: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length(string: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change(arr: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "ts",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "ts",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check(file_name: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "ts",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "ts",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "ts",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups(paren_string: string): string[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "ts",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare(game: number[], guess: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "ts",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "ts",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date(date: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "ts",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums(arr: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle(s: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "ts",
-    "prompt": "//Checks if given string is a palindrome\nfunction is_palindrome(text: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "ts",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel(word: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "ts",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\nfunction is_prime(n: number): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "ts",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify(x: string, n: string): boolean {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "ts",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key(num: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "ts",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "ts",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram(test: string): {[key: string]: number} {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "ts",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n: number): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "ts",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange(arr: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "ts",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers(numbers: string): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "ts",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift(x: number, shift: number): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "ts",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd(lst: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "ts",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product(numbers: number[]): [number, number] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "ts",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num(x: number, y: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "ts",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "ts",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters(string: string): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1684,7 +19,7 @@
     "language": "ts",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\nfunction make_a_pile(n: number): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1695,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "ts",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\nfunction words_string(s: string): string[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1710,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "ts",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum(nums: number[]): number {\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\nfunction choose_num(x: number, y: number): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1725,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "ts",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence(n: number): string {\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\nfunction rounded_avg(n: number, m: number): string| number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1740,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "ts",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\nfunction unique_digits(x: number[]): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1755,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "ts",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic(l: number[]): boolean {\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// If the array is empty, return an empty array:\n// If the array has any strange number ignore it:\nfunction by_length(arr: number[]): string[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1770,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "ts",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest(strings: string[]): string | undefined {\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\nfunction f(n: number): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "ts",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "ts",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\nfunction count_nums(arr: number[]): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "ts",
-    "prompt": "//Return only positive numbers in the list.\nfunction get_positive(l: number[]): number[] {\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "ts",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third(l: number[]): number[] {\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\nfunction make_palindrome(string: string): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "ts",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "ts",
-    "prompt": "//Given length of a side and high return area for a triangle.\nfunction triangle_area(a: number, h: number): number {\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\nfunction histogram(test: string): {[key: string]: number} {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "ts",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply(a: number, b: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "ts",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "ts",
-    "prompt": "//Return sorted unique common elements for two lists.\nfunction common(l1: number[], l2: number[]): number[] {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "ts",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman(number: number): string {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "ts",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution(s: string, n: number): number {\n",
-    "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1954,7 +214,7 @@
     "language": "ts",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\nfunction reverse_delete(s: string, c: string): [string, boolean] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1965,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "ts",
-    "prompt": "//Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\nfunction odd_count(lst: string[]): string[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1980,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "ts",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words(txt: string): string[]| number {\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\nfunction minSubArraySum(nums: number[]): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "ts",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// Example 2:\n// Example 3:\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1999,7 +274,7 @@
     "language": "ts",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\nfunction sort_array(arr: number[]): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2010,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "ts",
-    "prompt": "//Concatenate list of strings into a single string\nfunction concatenate(strings: string[]): string {\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\nfunction select_words(s: string, n: number): string[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2025,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum(lst: string[]): string[] {\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\nfunction get_closest_vowel(word: string): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2040,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\nfunction match_parens(lst: string[]): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2055,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "ts",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\nfunction string_xor(a: string, b: string): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2070,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "ts",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count(s: string): number {\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// Example 2:\n// Example 3:\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2085,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max(words: string[]): string {\n",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\nfunction solution(lst: number[]): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "ts",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5(text: string): string | undefined {\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "ts",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base(x: number, base: number): string {\n",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\nfunction get_odd_collatz(n: number): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\nfunction valid_date(date: string): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "ts",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\nfunction split_words(txt: string): string[]| number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +435,313 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "ts",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\nfunction is_sorted(lst: number[]): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "ts",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "ts",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "ts",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:\nfunction minPath(grid: number[][], k: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "ts",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\nfunction longest(strings: string[]): string | undefined {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "ts",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\nfunction tri(n: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\nfunction digits(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "ts",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\nfunction is_nested(string: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "ts",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "ts",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "ts",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\nfunction can_arrange(arr: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "ts",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "ts",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\nfunction is_equal_to_sum_even(n: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "ts",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "ts",
+    "prompt": "//Return a greatest common divisor of two integers a and b\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "ts",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with -\nfunction fix_spaces(text: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "ts",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\nfunction file_name_check(file_name: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "ts",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "ts",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// Example 2:\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "ts",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\nfunction simplify(x: string, n: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "ts",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\nfunction order_by_points(nums: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2179,7 +754,7 @@
     "language": "ts",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\nfunction specialFilter(nums: number[]): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2190,13 +765,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "ts",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n(n: number): number {\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2205,13 +780,223 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "ts",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\nfunction sorted_list_sum(lst: string[]): string[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "ts",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\nfunction all_prefixes(string: string): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "ts",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\nfunction x_or_y(n: number, x: number, y: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "ts",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "ts",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\nfunction compare(game: number[], guess: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "ts",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "ts",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "ts",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\nfunction even_odd_count(num: number): [number, number] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "ts",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\nfunction int_to_mini_roman(number: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "ts",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\nfunction find_max(words: string[]): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "ts",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "ts",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\nfunction string_sequence(n: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\nfunction solve(s: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "ts",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\nfunction string_to_md5(text: string): string | undefined {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2224,7 +1009,7 @@
     "language": "ts",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\nfunction generate_integers(a: number, b: number): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2235,13 +1020,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "ts",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\nfunction count_distinct_characters(string: string): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2250,13 +1035,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "ts",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero(operations: number[]): boolean {\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\nfunction parse_music(music_string: string): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2265,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "ts",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search(lst: number[]): number {\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\nfunction how_many_times(string: string, substring: string): number {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2280,13 +1065,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "ts",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\nfunction sort_numbers(numbers: string): string {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "ts",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\nfunction separate_paren_groups(paren_string: string): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "ts",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "ts",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "ts",
+    "prompt": "//Filter given list of any python values only for integers\nfunction filter_integers(values: any[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "ts",
+    "prompt": "//Return length of given string\nfunction strlen(string: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "ts",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\nfunction largest_divisor(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "ts",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\nfunction factorize(n: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "ts",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "ts",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\nfunction flip_case(string: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "ts",
+    "prompt": "//Concatenate list of strings into a single string\nfunction concatenate(strings: string[]): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "ts",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\nfunction truncate_number(number: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "ts",
+    "prompt": "//Return only positive numbers in the list.\nfunction get_positive(l: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "ts",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\nfunction is_prime(n: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "ts",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\nfunction sort_third(l: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "ts",
+    "prompt": "//Return sorted unique elements in a list\nfunction unique(l: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "ts",
+    "prompt": "//Return maximum element in the list.\nfunction max_element(l: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "ts",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\nfunction fizz_buzz(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2299,9 +1354,234 @@
     "language": "ts",
     "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\nfunction sort_even(l: number[]): number[] {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "ts",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\nfunction prime_fib(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "ts",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\nfunction below_zero(operations: number[]): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "ts",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "ts",
+    "prompt": "//Return list with elements incremented by 1.\nfunction incr_list(l: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "ts",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "ts",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\nfunction change_base(x: number, base: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "ts",
+    "prompt": "//Given length of a side and high return area for a triangle.\nfunction triangle_area(a: number, h: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "ts",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\nfunction fib4(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "ts",
+    "prompt": "//Return median of elements in the list l.\nfunction median(l: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "ts",
+    "prompt": "//Checks if given string is a palindrome\nfunction is_palindrome(text: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "ts",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\nfunction modp(n: number, p: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "ts",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "ts",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\nfunction remove_vowels(text: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "ts",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "ts",
+    "prompt": "//Add two numbers x and y\nfunction add(x: number, y: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2314,9 +1594,24 @@
     "language": "ts",
     "prompt": "//Check if two words have the same characters.\nfunction same_chars(s0: string, s1: string): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "ts",
+    "prompt": "//Return n-th Fibonacci number.\nfunction fib(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2329,9 +1624,714 @@
     "language": "ts",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets: string): boolean {\n",
     "doctests": "remove",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "ts",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\nfunction monotonic(l: number[]): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "ts",
+    "prompt": "//Return sorted unique common elements for two lists.\nfunction common(l1: number[], l2: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "ts",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\nfunction largest_prime_factor(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "ts",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "ts",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\nfunction sum_to_n(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "ts",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "ts",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\nfunction derivative(xs: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "ts",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\nfunction fibfib(n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "ts",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\nfunction vowels_count(s: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "ts",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\nfunction circular_shift(x: number, shift: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "ts",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\nfunction digitSum(s: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "ts",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\nfunction fruit_distribution(s: string, n: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "ts",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// Example 4:\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "ts",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\nfunction search(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "ts",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "ts",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\nfunction strange_sort_list(lst: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\nfunction triangle_area(a: number, b: number, c: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "ts",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "ts",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\nfunction smallest_change(arr: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "ts",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "ts",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "ts",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\nfunction is_simple_power(x: number, n: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "ts",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\nfunction iscube(a: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "ts",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\nfunction hex_key(num: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\nfunction decimal_to_binary(decimal: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\nfunction is_happy(s: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "ts",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\nfunction prime_length(string: string): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "ts",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "ts",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\nfunction add(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\nfunction anti_shuffle(s: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "ts",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "ts",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\nfunction sort_array(array: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "ts",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\nfunction encrypt(s: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "ts",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\nfunction sum_product(numbers: number[]): [number, number] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\nfunction next_smallest(lst: number[]): number | undefined {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "ts",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\nfunction is_bored(S: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "ts",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\nfunction any_int(x: number, y: number, z: number): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "ts",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\nfunction encode(message: string): string {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\nfunction skjkasdkd(lst: number[]): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "ts",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "ts",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\nfunction count_up_to(n: number): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "ts",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\nfunction multiply(a: number, b: number): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "ts",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\nfunction count_upper(s: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "ts",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "ts",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "doctests": "remove",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-ts-reworded.json
+++ b/prompts/humaneval-ts-reworded.json
@@ -1,1722 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "ts",
-    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "ts",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "ts",
-    "prompt": "//Given an object, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given object is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "ts",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "ts",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "ts",
-    "prompt": "//Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "ts",
-    "prompt": "//Filter given array of any tsthon values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "ts",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "ts",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "ts",
-    "prompt": "//Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "ts",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "ts",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "ts",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "ts",
-    "prompt": "//Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "ts",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "ts",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr: number[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "ts",
-    "prompt": "//Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "ts",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "ts",
-    "prompt": "//Return sorted unique elements in an array\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "ts",
-    "prompt": "//Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "ts",
-    "prompt": "//Return maximum element in the array.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "ts",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "ts",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "ts",
-    "prompt": "//Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "ts",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "ts",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "ts",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "ts",
-    "prompt": "//Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "ts",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "ts",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "ts",
-    "prompt": "//Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "ts",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "ts",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "ts",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "ts",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "ts",
-    "prompt": "//Given an array of non-negative integers, return a cots of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "ts",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "ts",
-    "prompt": "//Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "ts",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "ts",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "ts",
-    "prompt": "//pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "ts",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "ts",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "ts",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "ts",
-    "prompt": "//Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "ts",
-    "prompt": "//From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "ts",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x: number, n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "ts",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "ts",
-    "prompt": "//Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "ts",
     "prompt": "//Check if in given array of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// false\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// true\nfunction has_close_elements(numbers: number[], threshold: number): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "ts",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "ts",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a: string, b: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "ts",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "ts",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "ts",
-    "prompt": "//Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "ts",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "ts",
-    "prompt": "//Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "ts",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "ts",
-    "prompt": "//You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "ts",
-    "prompt": "//You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "ts",
-    "prompt": "//You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return undefined if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst: number[]): number | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "ts",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x: number, y: number, z: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "ts",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "ts",
-    "prompt": "//Return array with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "ts",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "ts",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "ts",
-    "prompt": "//Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is hapts or not.\n// A string is hapts if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "ts",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "ts",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "ts",
-    "prompt": "//Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "ts",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "ts",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "ts",
-    "prompt": "//In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "ts",
-    "prompt": "//Return median of elements in the array l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "ts",
-    "prompt": "//You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "ts",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "ts",
-    "prompt": "//triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "ts",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "ts",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "ts",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "ts",
-    "prompt": "//Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "ts",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "ts",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "ts",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "ts",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "ts",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "ts",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x: string, n: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "ts",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "ts",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "ts",
-    "prompt": "//Given a string representing a space separated lowercase letters, return an object\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test: string): {[key: string]: number} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "ts",
-    "prompt": "//You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "ts",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "ts",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "ts",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "ts",
-    "prompt": "//\"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "ts",
-    "prompt": "//You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "ts",
-    "prompt": "//For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers: number[]): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "ts",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "ts",
-    "prompt": "//Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as undefined.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "ts",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1729,7 +19,7 @@
     "language": "ts",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in an array, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1740,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "ts",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return undefined for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1755,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "ts",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums: number[]): number {\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x: number, y: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1770,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "ts",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n: number): string {\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "ts",
-    "prompt": "//You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "prompt": "//Given an array of positive integers x. return a sorted array of all \n// elements that hasn't any even digit.\n// Note: Returned array should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "ts",
-    "prompt": "//Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l: number[]): boolean {\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr: number[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "ts",
-    "prompt": "//Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return undefined in case the input array is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings: string[]): string | undefined {\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns an array of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "ts",
-    "prompt": "//Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "prompt": "//Given a positive integer n, return an array that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned array has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "ts",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "ts",
-    "prompt": "//Return only positive numbers in the array.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return true else return false.\n// If the given array is empty then return true.\n// Note: The given array is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1875,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "ts",
-    "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1890,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "ts",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "prompt": "//In this problem, you will implement a function that takes two arrays of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 an array of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input arrays will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1905,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "ts",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return an object\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test: string): {[key: string]: number} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "ts",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "ts",
-    "prompt": "//For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "ts",
-    "prompt": "//Return sorted unique common elements for two arrays.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "ts",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "ts",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s: string, n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1999,7 +214,7 @@
     "language": "ts",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return an array containing the result string and true/false for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// [\"bcd\", false]\n// >>> reverse_delete(\"abcdef\", \"b\")\n// [\"acdef\", false]\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// [\"cdedc\", true]\nfunction reverse_delete(s: string, c: string): [string, boolean] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2010,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "ts",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "prompt": "//Given an array of strings, where each string consists of only digits, return an array.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2025,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "ts",
-    "prompt": "//Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt: string): string[]| number {\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "ts",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2044,7 +274,7 @@
     "language": "ts",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4])\n// [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6])\n// [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4])\n// [0, 1, 2, 3, 4]\nfunction sort_array(arr: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2055,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "ts",
-    "prompt": "//Concatenate array of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings: string[]): string {\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns an array of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty array.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2070,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "ts",
-    "prompt": "//Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2085,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "ts",
-    "prompt": "//Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "prompt": "//You are given an array of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst: string[]): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "ts",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a: string, b: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "ts",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted array \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "ts",
-    "prompt": "//Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
+    "prompt": "//Given a non-empty array of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "ts",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return undefined.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text: string): string | undefined {\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "ts",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x: number, base: number): string {\n",
+    "prompt": "//Given a positive integer n, return a sorted array that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned array sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2175,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns true if the date is valid otherwise false.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2190,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "ts",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "prompt": "//Given a string of words, return an array of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt: string): string[]| number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2205,13 +435,313 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "ts",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "prompt": "//Given an array of numbers, return whether or not they are sorted\n// in ascending order. If array has more than 1 duplicate of the same\n// number, return false. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst: number[]): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "ts",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "ts",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return undefined for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "ts",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered arrays of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered array of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "ts",
+    "prompt": "//Out of array of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return undefined in case the input array is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings: string[]): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "ts",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return an array of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "ts",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return true if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "ts",
+    "prompt": "//You are given an array of numbers.\n// You need to return the sum of squared numbers in the given array,\n// round each element in the array to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "ts",
+    "prompt": "//Create a function that returns true if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and false otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "ts",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "ts",
+    "prompt": "//Create a function that returns an array (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in an array.\n// If there is no negative or positive integers, return them as undefined.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "ts",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "ts",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "ts",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "ts",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "ts",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "ts",
+    "prompt": "//\"\n// This function will take an array of integers. For all entries in the array, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the array whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "ts",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "ts",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns true if x * n evaluates to a whole number and false\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x: string, n: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "ts",
+    "prompt": "//Write a function which sorts the given array of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original array.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2224,7 +754,7 @@
     "language": "ts",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([15, -73, 14, -15])\n// 1\n// >>> specialFilter([33, -2, -3, 45, 21, 109])\n// 2\nfunction specialFilter(nums: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2235,13 +765,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "ts",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2250,13 +780,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "ts",
-    "prompt": "//From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "prompt": "//Write a function that accepts an array of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted array with a sorted order,\n// The array is always an array of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the array should be ascending by length of each word, and you\n// should return the array sorted by that rule.\n// If two words have the same length, sort the array alphabetically.\n// The function should return an array of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "ts",
+    "prompt": "//Return array of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "ts",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "ts",
+    "prompt": "//Given an array of numbers, return the sum of squares of the numbers\n// in the array that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input array is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "ts",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "ts",
+    "prompt": "//You will be given the name of a class (a string) and an array of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the array.\n// For example, if you are given \"Slices\" as the class and an array of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "ts",
+    "prompt": "//You are given 2 words. You need to return true if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "ts",
+    "prompt": "//Given an integer. return an array that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num: number): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "ts",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return true if the three\n// sides form a right-angled triangle, false otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "ts",
+    "prompt": "//Write a function that accepts an array of strings.\n// The array contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "ts",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "ts",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "ts",
+    "prompt": "//Given two arrays operator, and operand. The first array has basic algebra operations, and \n// the second array is an array of integers. Use the two given arrays to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator array is equal to the length of operand array minus one.\n// Operand is an array of of non-negative integers.\n// Operator array has at least one operator, and operand array has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "ts",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return undefined.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text: string): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2269,7 +1024,7 @@
     "language": "ts",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// [2, 4, 6, 8]\n// >>> generate_integers(8, 2)\n// [2, 4, 6, 8]\n// >>> generate_integers(10, 14)\n// []\nfunction generate_integers(a: number, b: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2280,13 +1035,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "ts",
-    "prompt": "//From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string: string): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2295,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "ts",
-    "prompt": "//You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations: number[]): boolean {\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return array of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "ts",
-    "prompt": "//You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst: number[]): number {\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2325,13 +1080,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "ts",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "ts",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the array of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "ts",
+    "prompt": "//From a supplied array of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "ts",
+    "prompt": "//Given array of numbers (of at least two elements), apply a linear transform to that array,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "ts",
+    "prompt": "//Filter given array of any tsthon values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "ts",
+    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "ts",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "ts",
+    "prompt": "//Return array of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be arrayed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "ts",
+    "prompt": "//From an array of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "ts",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "ts",
+    "prompt": "//Concatenate array of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "ts",
+    "prompt": "//Filter an input array of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "ts",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "ts",
+    "prompt": "//Return only positive numbers in the array.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "ts",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "ts",
+    "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "ts",
+    "prompt": "//Return sorted unique elements in an array\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "ts",
+    "prompt": "//Return maximum element in the array.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "ts",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2344,9 +1369,249 @@
     "language": "ts",
     "prompt": "//This function takes an array l and returns an array l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "ts",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "ts",
+    "prompt": "//You're given an array of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return true. Otherwise it should return false.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "ts",
+    "prompt": "//triples_sum_to_zero takes an array of integers as an input.\n// it returns true if there are three distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "ts",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "ts",
+    "prompt": "//Return array with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "ts",
+    "prompt": "//pairs_sum_to_zero takes an array of integers as an input.\n// it returns true if there are two distinct elements in the array that\n// sum to zero, and false otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "ts",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x: number, base: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "ts",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "ts",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "ts",
+    "prompt": "//Return median of elements in the array l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "ts",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "ts",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "ts",
+    "prompt": "//For a given array of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "ts",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "ts",
+    "prompt": "//Return true if all numbers in the array l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "ts",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2359,9 +1624,24 @@
     "language": "ts",
     "prompt": "//Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars(s0: string, s1: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "ts",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2374,9 +1654,729 @@
     "language": "ts",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "ts",
+    "prompt": "//Return true is array elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "ts",
+    "prompt": "//Return sorted unique common elements for two arrays.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "ts",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "ts",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input array `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "ts",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "ts",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return true if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "ts",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "ts",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "ts",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "ts",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "ts",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "ts",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s: string, n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "ts",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in an array, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "ts",
+    "prompt": "//You are given a non-empty array of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the array.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "ts",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "ts",
+    "prompt": "//Given array of integers, return array in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "ts",
+    "prompt": "//Write a function that returns true if the object q will fly, and false otherwise.\n// The object q will fly if it's balanced (it is a palindromic array) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "ts",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "ts",
+    "prompt": "//Write a function that accepts two arrays of strings and returns the array that has \n// total number of chars in the all strings of the array less than the other array.\n// if the two arrays have the same number of chars, return the first array.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "ts",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "ts",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x: number, n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "ts",
+    "prompt": "//Write a function that takes an integer a and returns true \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "ts",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "ts",
+    "prompt": "//Filter an input array of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is hapts or not.\n// A string is hapts if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "ts",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you an array of GPAs for some students and you have to write \n// a function that can output an array of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns true if the string\n// length is a prime number or false otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "ts",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "ts",
+    "prompt": "//Given a non-empty array of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "ts",
+    "prompt": "//You are given a 2 dimensional data, as a nested arrays,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the array,\n// and return array of arrays, [(x1, y1), (x2, y2) ...] such that\n// each array is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "ts",
+    "prompt": "//Given an array of non-negative integers, return a cots of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "ts",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "ts",
+    "prompt": "//For a given array of integers, return an array consisting of a sum and a product of all the integers in an array.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers: number[]): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "ts",
+    "prompt": "//You are given an array of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the array.\n// Return undefined if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst: number[]): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "ts",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "ts",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x: number, y: number, z: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "ts",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "ts",
+    "prompt": "//You are given an array of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "ts",
+    "prompt": "//Given an object, return true if all keys are strings in lower \n// case or all keys are strings in upper case, else return false.\n// The function should return false is the given object is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "ts",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "ts",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "ts",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "ts",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "ts",
+    "prompt": "//From a given array of integers, generate an array of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/humaneval-ts-transform.json
+++ b/prompts/humaneval-ts-transform.json
@@ -1,1722 +1,12 @@
 [
   {
-    "name": "HumanEval_23_strlen",
-    "language": "ts",
-    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_89_encrypt",
-    "language": "ts",
-    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_95_check_dict_case",
-    "language": "ts",
-    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_85_add",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_140_fix_spaces",
-    "language": "ts",
-    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_63_fibfib",
-    "language": "ts",
-    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_151_double_the_difference",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_22_filter_integers",
-    "language": "ts",
-    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_41_car_race_collision",
-    "language": "ts",
-    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_17_parse_music",
-    "language": "ts",
-    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_79_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_14_all_prefixes",
-    "language": "ts",
-    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_53_add",
-    "language": "ts",
-    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_159_eat",
-    "language": "ts",
-    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_115_max_fill",
-    "language": "ts",
-    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_160_do_algebra",
-    "language": "ts",
-    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_27_flip_case",
-    "language": "ts",
-    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_105_by_length",
-    "language": "ts",
-    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr: number[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_25_factorize",
-    "language": "ts",
-    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_96_count_up_to",
-    "language": "ts",
-    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_34_unique",
-    "language": "ts",
-    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_74_total_match",
-    "language": "ts",
-    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_35_max_element",
-    "language": "ts",
-    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_132_is_nested",
-    "language": "ts",
-    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_103_rounded_avg",
-    "language": "ts",
-    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_113_odd_count",
-    "language": "ts",
-    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_109_move_one_ball",
-    "language": "ts",
-    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_107_even_odd_palindrome",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_138_is_equal_to_sum_even",
-    "language": "ts",
-    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_62_derivative",
-    "language": "ts",
-    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_126_is_sorted",
-    "language": "ts",
-    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_161_solve",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_130_tri",
-    "language": "ts",
-    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_36_fizz_buzz",
-    "language": "ts",
-    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_29_filter_by_prefix",
-    "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_84_solve",
-    "language": "ts",
-    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_129_minPath",
-    "language": "ts",
-    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_98_count_upper",
-    "language": "ts",
-    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_120_maximum",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_24_largest_divisor",
-    "language": "ts",
-    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_88_sort_array",
-    "language": "ts",
-    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_106_f",
-    "language": "ts",
-    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_77_iscube",
-    "language": "ts",
-    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_93_encode",
-    "language": "ts",
-    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_91_is_bored",
-    "language": "ts",
-    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_43_pairs_sum_to_zero",
-    "language": "ts",
-    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_71_triangle_area",
-    "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_131_digits",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_101_words_string",
-    "language": "ts",
-    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_18_how_many_times",
-    "language": "ts",
-    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_51_remove_vowels",
-    "language": "ts",
-    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_70_strange_sort_list",
-    "language": "ts",
-    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_20_find_closest_elements",
-    "language": "ts",
-    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_76_is_simple_power",
-    "language": "ts",
-    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x: number, n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_39_prime_fib",
-    "language": "ts",
-    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_145_order_by_points",
-    "language": "ts",
-    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
     "name": "HumanEval_0_has_close_elements",
     "language": "ts",
     "prompt": "//Check if in given list of numbers, are any two numbers closer to each other than\n// given threshold.\n// >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n// false\n// >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n// true\nfunction has_close_elements(numbers: number[], threshold: number): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_0_has_close_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = has_close_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3),true);\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05),false);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95),true);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8),false);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0),true);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_10_make_palindrome",
-    "language": "ts",
-    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_11_string_xor",
-    "language": "ts",
-    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a: string, b: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_139_special_factorial",
-    "language": "ts",
-    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_122_add_elements",
-    "language": "ts",
-    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_46_fib4",
-    "language": "ts",
-    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_104_unique_digits",
-    "language": "ts",
-    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_117_select_words",
-    "language": "ts",
-    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_72_will_it_fly",
-    "language": "ts",
-    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_55_fib",
-    "language": "ts",
-    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_153_Strongest_Extension",
-    "language": "ts",
-    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_119_match_parens",
-    "language": "ts",
-    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_90_next_smallest",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst: number[]): number | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_92_any_int",
-    "language": "ts",
-    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x: number, y: number, z: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_2_truncate_number",
-    "language": "ts",
-    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_42_incr_list",
-    "language": "ts",
-    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_150_x_or_y",
-    "language": "ts",
-    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_49_modp",
-    "language": "ts",
-    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_155_even_odd_count",
-    "language": "ts",
-    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_80_is_happy",
-    "language": "ts",
-    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_59_largest_prime_factor",
-    "language": "ts",
-    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_66_digitSum",
-    "language": "ts",
-    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_21_rescale_to_unit",
-    "language": "ts",
-    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_121_solution",
-    "language": "ts",
-    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_68_pluck",
-    "language": "ts",
-    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_147_get_max_triples",
-    "language": "ts",
-    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_110_exchange",
-    "language": "ts",
-    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_47_median",
-    "language": "ts",
-    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_82_prime_length",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_73_smallest_change",
-    "language": "ts",
-    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_133_sum_squares",
-    "language": "ts",
-    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_141_file_name_check",
-    "language": "ts",
-    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_40_triples_sum_to_zero",
-    "language": "ts",
-    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_127_intersection",
-    "language": "ts",
-    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_1_separate_paren_groups",
-    "language": "ts",
-    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_152_compare",
-    "language": "ts",
-    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_83_starts_one_ends",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_134_check_if_last_char_is_a_letter",
-    "language": "ts",
-    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_124_valid_date",
-    "language": "ts",
-    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_108_count_nums",
-    "language": "ts",
-    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_86_anti_shuffle",
-    "language": "ts",
-    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_48_is_palindrome",
-    "language": "ts",
-    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_118_get_closest_vowel",
-    "language": "ts",
-    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_31_is_prime",
-    "language": "ts",
-    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_144_simplify",
-    "language": "ts",
-    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x: string, n: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_78_hex_key",
-    "language": "ts",
-    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_143_words_in_sentence",
-    "language": "ts",
-    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_111_histogram",
-    "language": "ts",
-    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test: string): {[key: string]: number} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_87_get_row",
-    "language": "ts",
-    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_123_get_odd_collatz",
-    "language": "ts",
-    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_135_can_arrange",
-    "language": "ts",
-    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_19_sort_numbers",
-    "language": "ts",
-    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_65_circular_shift",
-    "language": "ts",
-    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_142_sum_squares",
-    "language": "ts",
-    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_94_skjkasdkd",
-    "language": "ts",
-    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_8_sum_product",
-    "language": "ts",
-    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers: number[]): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_102_choose_num",
-    "language": "ts",
-    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_136_largest_smallest_integers",
-    "language": "ts",
-    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_16_count_distinct_characters",
-    "language": "ts",
-    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1729,7 +19,7 @@
     "language": "ts",
     "prompt": "//Given a positive integer n, you have to make a pile of n levels of stones.\n// The first level has n stones.\n// The number of stones in the next level is:\n// - the next odd number if n is odd.\n// - the next even number if n is even.\n// Return the number of stones in each level in a list, where element at index\n// i represents the number of stones in the level (i+1).\n// Examples:\n// >>> make_a_pile(3)\n// [3, 5, 7]\nfunction make_a_pile(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_100_make_a_pile.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_a_pile;\n  assert.deepEqual(candidate(3),[3, 5, 7]);\n  assert.deepEqual(candidate(4),[4, 6, 8, 10]);\n  assert.deepEqual(candidate(5),[5, 7, 9, 11, 13]);\n  assert.deepEqual(candidate(6),[6, 8, 10, 12, 14, 16]);\n  assert.deepEqual(candidate(8),[8, 10, 12, 14, 16, 18, 20, 22]);\n}\n\ntest();",
     "stop_tokens": [
@@ -1740,13 +30,13 @@
     ]
   },
   {
-    "name": "HumanEval_128_prod_signs",
+    "name": "HumanEval_101_words_string",
     "language": "ts",
-    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "prompt": "//You will be given a string of words separated by commas or spaces. Your task is\n// to split the string into words and return an array of the words.\n// For example:\n// >>> words_string(\"Hi, my name is John\")\n// [\"Hi\", \"my\", \"name\", \"is\", \"John\"]\n// >>> words_string(\"One, two, three, four, five, six\")\n// [\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]\nfunction words_string(s: string): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_101_words_string.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_string;\n  assert.deepEqual(candidate(\"Hi, my name is John\"),[\"Hi\", \"my\", \"name\", \"is\", \"John\"]);\n  assert.deepEqual(candidate(\"One, two, three, four, five, six\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"Hi, my name\"),[\"Hi\", \"my\", \"name\"]);\n  assert.deepEqual(candidate(\"One,, two, three, four, five, six,\"),[\"One\", \"two\", \"three\", \"four\", \"five\", \"six\"]);\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"ahmed     , gamal\"),[\"ahmed\", \"gamal\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1755,13 +45,13 @@
     ]
   },
   {
-    "name": "HumanEval_114_minSubArraySum",
+    "name": "HumanEval_102_choose_num",
     "language": "ts",
-    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums: number[]): number {\n",
+    "prompt": "//This function takes two positive numbers x and y and returns the\n// biggest even integer number that is in the range [x, y] inclusive. If \n// there's no such number, then the function should return -1.\n// For example:\n// >>> choose_num(12, 15)\n// 14\n// >>> choose_num(13, 12)\n// -1\nfunction choose_num(x: number, y: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_102_choose_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = choose_num;\n  assert.deepEqual(candidate(12, 15),14);\n  assert.deepEqual(candidate(13, 12),-1);\n  assert.deepEqual(candidate(33, 12354),12354);\n  assert.deepEqual(candidate(5234, 5233),-1);\n  assert.deepEqual(candidate(6, 29),28);\n  assert.deepEqual(candidate(27, 10),-1);\n  assert.deepEqual(candidate(7, 7),-1);\n  assert.deepEqual(candidate(546, 546),546);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1770,13 +60,13 @@
     ]
   },
   {
-    "name": "HumanEval_15_string_sequence",
+    "name": "HumanEval_103_rounded_avg",
     "language": "ts",
-    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n: number): string {\n",
+    "prompt": "//You are given two positive integers n and m, and your task is to compute the\n// average of the integers from n through m (including n and m). \n// Round the answer to the nearest integer and convert that to binary.\n// If n is greater than m, return -1.\n// Example:\n// >>> rounded_avg(1, 5)\n// \"0b11\"\n// >>> rounded_avg(7, 5)\n// -1\n// >>> rounded_avg(10, 20)\n// \"0b1111\"\n// >>> rounded_avg(20, 33)\n// \"0b11010\"\nfunction rounded_avg(n: number, m: number): string| number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_103_rounded_avg.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rounded_avg;\n  assert.deepEqual(candidate(1, 5),\"0b11\");\n  assert.deepEqual(candidate(7, 13),\"0b1010\");\n  assert.deepEqual(candidate(964, 977),\"0b1111001010\");\n  assert.deepEqual(candidate(996, 997),\"0b1111100100\");\n  assert.deepEqual(candidate(560, 851),\"0b1011000010\");\n  assert.deepEqual(candidate(185, 546),\"0b101101110\");\n  assert.deepEqual(candidate(362, 496),\"0b110101101\");\n  assert.deepEqual(candidate(350, 902),\"0b1001110010\");\n  assert.deepEqual(candidate(197, 233),\"0b11010111\");\n  assert.deepEqual(candidate(7, 5),-1);\n  assert.deepEqual(candidate(5, 1),-1);\n  assert.deepEqual(candidate(5, 5),\"0b101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1785,13 +75,13 @@
     ]
   },
   {
-    "name": "HumanEval_154_cycpattern_check",
+    "name": "HumanEval_104_unique_digits",
     "language": "ts",
-    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "prompt": "//Given a list of positive integers x. return a sorted list of all \n// elements that hasn't any even digit.\n// Note: Returned list should be sorted in increasing order.\n// For example:\n// >>> unique_digits([15, 33, 1422, 1])\n// [1, 15, 33]\n// >>> unique_digits([152, 323, 1422, 10])\n// []\nfunction unique_digits(x: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_104_unique_digits.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_digits;\n  assert.deepEqual(candidate([15, 33, 1422, 1]),[1, 15, 33]);\n  assert.deepEqual(candidate([152, 323, 1422, 10]),[]);\n  assert.deepEqual(candidate([12345, 2033, 111, 151]),[111, 151]);\n  assert.deepEqual(candidate([135, 103, 31]),[31, 135]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1800,13 +90,13 @@
     ]
   },
   {
-    "name": "HumanEval_57_monotonic",
+    "name": "HumanEval_105_by_length",
     "language": "ts",
-    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l: number[]): boolean {\n",
+    "prompt": "//Given an array of integers, sort the integers that are between 1 and 9 inclusive,\n// reverse the resulting array, and then replace each digit by its corresponding name from\n// \"One\", \"Two\", \"Three\", \"Four\", \"Five\", \"Six\", \"Seven\", \"Eight\", \"Nine\".\n// For example:\n// >>> by_length([2, 1, 1, 4, 5, 8, 2, 3])\n// [\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]\n// If the array is empty, return an empty array:\n// >>> by_length([])\n// []\n// If the array has any strange number ignore it:\n// >>> by_length([1, -1, 55])\n// [\"One\"]\nfunction by_length(arr: number[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_105_by_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = by_length;\n  assert.deepEqual(candidate([2, 1, 1, 4, 5, 8, 2, 3]),[\"Eight\", \"Five\", \"Four\", \"Three\", \"Two\", \"Two\", \"One\", \"One\"]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -1, 55]),[\"One\"]);\n  assert.deepEqual(candidate([1, -1, 3, 2]),[\"Three\", \"Two\", \"One\"]);\n  assert.deepEqual(candidate([9, 4, 8]),[\"Nine\", \"Eight\", \"Four\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1815,13 +105,13 @@
     ]
   },
   {
-    "name": "HumanEval_12_longest",
+    "name": "HumanEval_106_f",
     "language": "ts",
-    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings: string[]): string | undefined {\n",
+    "prompt": "//Implement the function f that takes n as a parameter,\n// and returns a list of size n, such that the value of the element at index i is the factorial of i if i is even\n// or the sum of numbers from 1 to i otherwise.\n// i starts from 1.\n// the factorial of i is the multiplication of the numbers from 1 to i (1 * 2 * ... * i).\n// Example:\n// >>> f(5)\n// [1, 2, 6, 24, 15]\nfunction f(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_106_f.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = f;\n  assert.deepEqual(candidate(5),[1, 2, 6, 24, 15]);\n  assert.deepEqual(candidate(7),[1, 2, 6, 24, 15, 720, 28]);\n  assert.deepEqual(candidate(1),[1]);\n  assert.deepEqual(candidate(3),[1, 2, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1830,13 +120,13 @@
     ]
   },
   {
-    "name": "HumanEval_52_below_threshold",
+    "name": "HumanEval_107_even_odd_palindrome",
     "language": "ts",
-    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "prompt": "//Given a positive integer n, return a tuple that has the number of even and odd\n// integer palindromes that fall within the range(1, n), inclusive.\n// Example 1:\n// >>> even_odd_palindrome(3)\n// [1, 2]\n// Explanation:\n// Integer palindrome are 1, 2, 3. one of them is even, and two of them are odd.\n// Example 2:\n// >>> even_odd_palindrome(12)\n// [4, 6]\n// Explanation:\n// Integer palindrome are 1, 2, 3, 4, 5, 6, 7, 8, 9, 11. four of them are even, and 6 of them are odd.\n// Note:\n// 1. 1 <= n <= 10^3\n// 2. returned tuple has the number of even and odd integer palindromes respectively.\nfunction even_odd_palindrome(n: number): [number, number] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_107_even_odd_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_palindrome;\n  assert.deepEqual(candidate(123),[8, 13]);\n  assert.deepEqual(candidate(12),[4, 6]);\n  assert.deepEqual(candidate(3),[1, 2]);\n  assert.deepEqual(candidate(63),[6, 8]);\n  assert.deepEqual(candidate(25),[5, 6]);\n  assert.deepEqual(candidate(19),[4, 6]);\n  assert.deepEqual(candidate(9),[4, 5]);\n  assert.deepEqual(candidate(1),[0, 1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1845,13 +135,13 @@
     ]
   },
   {
-    "name": "HumanEval_75_is_multiply_prime",
+    "name": "HumanEval_108_count_nums",
     "language": "ts",
-    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "prompt": "//Write a function count_nums which takes an array of integers and returns\n// the number of elements which has a sum of digits > 0.\n// If a number is negative, then its first signed digit will be negative:\n// e.g. -123 has signed digits -1, 2, and 3.\n// >>> count_nums([])\n// 0\n// >>> count_nums([-1, 11, -11])\n// 1\n// >>> count_nums([1, 1, 2])\n// 3\nfunction count_nums(arr: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_108_count_nums.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_nums;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([-1, -2, 0]),0);\n  assert.deepEqual(candidate([1, 1, 2, -2, 3, 4, 5]),6);\n  assert.deepEqual(candidate([1, 6, 9, -6, 0, 1, 5]),5);\n  assert.deepEqual(candidate([1, 100, 98, -7, 1, -1]),4);\n  assert.deepEqual(candidate([12, 23, 34, -45, -56, 0]),5);\n  assert.deepEqual(candidate([0, 1]),1);\n  assert.deepEqual(candidate([1]),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1860,13 +150,13 @@
     ]
   },
   {
-    "name": "HumanEval_30_get_positive",
+    "name": "HumanEval_109_move_one_ball",
     "language": "ts",
-    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
+    "prompt": "//We have an array 'arr' of N integers arr[1], arr[2], ..., arr[N].The\n// numbers in the array will be randomly ordered. Your task is to determine if\n// it is possible to get an array sorted in non-decreasing order by performing \n// the following operation on the given array:\n// You are allowed to perform right shift operation any number of times.\n// One right shift operation means shifting all elements of the array by one\n// position in the right direction. The last element of the array will be moved to\n// the starting position in the array i.e. 0th index. \n// If it is possible to obtain the sorted array by performing the above operation\n// then return True else return False.\n// If the given array is empty then return True.\n// Note: The given list is guaranteed to have unique elements.\n// For Example:\n// >>> move_one_ball([3, 4, 5, 1, 2])\n// true\n// Explanation: By performin 2 right shift operations, non-decreasing order can\n// be achieved for the given array.\n// >>> move_one_ball([3, 5, 4, 1, 2])\n// false\n// Explanation:It is not possible to get non-decreasing order for the given\n// array by performing any number of right shift operations.\nfunction move_one_ball(arr: number[]): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_109_move_one_ball.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_one_ball;\n  assert.deepEqual(candidate([3, 4, 5, 1, 2]),true);\n  assert.deepEqual(candidate([3, 5, 10, 1, 2]),true);\n  assert.deepEqual(candidate([4, 3, 1, 2]),false);\n  assert.deepEqual(candidate([3, 5, 4, 1, 2]),false);\n  assert.deepEqual(candidate([]),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1875,13 +165,13 @@
     ]
   },
   {
-    "name": "HumanEval_33_sort_third",
+    "name": "HumanEval_10_make_palindrome",
     "language": "ts",
-    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
+    "prompt": "//Find the shortest palindrome that begins with a supplied string.\n// Algorithm idea is simple:\n// - Find the longest postfix of supplied string that is a palindrome.\n// - Append to the end of the string reverse of a string prefix that comes before the palindromic suffix.\n// >>> make_palindrome(\"\")\n// \"\"\n// >>> make_palindrome(\"cat\")\n// \"catac\"\n// >>> make_palindrome(\"cata\")\n// \"catac\"\nfunction make_palindrome(string: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_10_make_palindrome.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = make_palindrome;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"x\"),\"x\");\n  assert.deepEqual(candidate(\"xyz\"),\"xyzyx\");\n  assert.deepEqual(candidate(\"xyx\"),\"xyx\");\n  assert.deepEqual(candidate(\"jerry\"),\"jerryrrej\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1890,13 +180,13 @@
     ]
   },
   {
-    "name": "HumanEval_6_parse_nested_parens",
+    "name": "HumanEval_110_exchange",
     "language": "ts",
-    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "prompt": "//In this problem, you will implement a function that takes two lists of numbers,\n// and determines whether it is possible to perform an exchange of elements\n// between them to make lst1 a list of only even numbers.\n// There is no limit on the number of exchanged elements between lst1 and lst2.\n// If it is possible to exchange elements between the lst1 and lst2 to make\n// all the elements of lst1 to be even, return \"YES\".\n// Otherwise, return \"NO\".\n// For example:\n// >>> exchange([1, 2, 3, 4], [1, 2, 3, 4])\n// \"YES\"\n// >>> exchange([1, 2, 3, 4], [1, 5, 3, 4])\n// \"NO\"\n// It is assumed that the input lists will be non-empty.\nfunction exchange(lst1: number[], lst2: number[]): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_110_exchange.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = exchange;\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 2, 3, 4]),\"YES\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [1, 5, 3, 4]),\"NO\");\n  assert.deepEqual(candidate([1, 2, 3, 4], [2, 1, 4, 3]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 4]),\"YES\");\n  assert.deepEqual(candidate([5, 7, 3], [2, 6, 3]),\"NO\");\n  assert.deepEqual(candidate([3, 2, 6, 1, 8, 9], [3, 5, 5, 1, 1, 1]),\"NO\");\n  assert.deepEqual(candidate([100, 200], [200, 200]),\"YES\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1905,88 +195,13 @@
     ]
   },
   {
-    "name": "HumanEval_45_triangle_area",
+    "name": "HumanEval_111_histogram",
     "language": "ts",
-    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
+    "prompt": "//Given a string representing a space separated lowercase letters, return a dictionary\n// of the letter with the most repetition and containing the corresponding count.\n// If several letters have the same occurrence, return all of them.\n// Example:\n// >>> histogram(\"a b c\")\n// {\"a\": 1, \"b\": 1, \"c\": 1}\n// >>> histogram(\"a b b a\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"a b c a b\")\n// {\"a\": 2, \"b\": 2}\n// >>> histogram(\"b b b b a\")\n// {\"b\": 4}\n// >>> histogram(\"\")\n// {}\nfunction histogram(test: string): {[key: string]: number} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_111_histogram.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_97_multiply",
-    "language": "ts",
-    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_4_mean_absolute_deviation",
-    "language": "ts",
-    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_58_common",
-    "language": "ts",
-    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_156_int_to_mini_roman",
-    "language": "ts",
-    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "HumanEval_67_fruit_distribution",
-    "language": "ts",
-    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s: string, n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = histogram;\n  assert.deepEqual(candidate(\"a b b a\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c a b\"),{\"a\": 2, \"b\": 2});\n  assert.deepEqual(candidate(\"a b c d g\"),{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"b b b b a\"),{\"b\": 4});\n  assert.deepEqual(candidate(\"r t g\"),{\"r\": 1, \"t\": 1, \"g\": 1});\n  assert.deepEqual(candidate(\"\"),{});\n  assert.deepEqual(candidate(\"a\"),{\"a\": 1});\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -1999,7 +214,7 @@
     "language": "ts",
     "prompt": "//Task\n// We are given two strings s and c, you have to deleted all the characters in s that are equal to any character in c\n// then check if the result string is palindrome.\n// A string is called palindrome if it reads the same backward as forward.\n// You should return a tuple containing the result string and True/False for the check.\n// Example\n// >>> reverse_delete(\"abcde\", \"ae\")\n// [\"bcd\", false]\n// >>> reverse_delete(\"abcdef\", \"b\")\n// [\"acdef\", false]\n// >>> reverse_delete(\"abcdedcba\", \"ab\")\n// [\"cdedc\", true]\nfunction reverse_delete(s: string, c: string): [string, boolean] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_112_reverse_delete.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_delete;\n  assert.deepEqual(candidate(\"abcde\", \"ae\"),[\"bcd\", false]);\n  assert.deepEqual(candidate(\"abcdef\", \"b\"),[\"acdef\", false]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"ab\"),[\"cdedc\", true]);\n  assert.deepEqual(candidate(\"dwik\", \"w\"),[\"dik\", false]);\n  assert.deepEqual(candidate(\"a\", \"a\"),[\"\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"abcdedcba\", \"v\"),[\"abcdedcba\", true]);\n  assert.deepEqual(candidate(\"vabba\", \"v\"),[\"abba\", true]);\n  assert.deepEqual(candidate(\"mamma\", \"mia\"),[\"\", true]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2010,13 +225,13 @@
     ]
   },
   {
-    "name": "HumanEval_13_greatest_common_divisor",
+    "name": "HumanEval_113_odd_count",
     "language": "ts",
-    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "prompt": "//Given a list of strings, where each string consists of only digits, return a list.\n// Each element i of the output should be \"the number of odd elements in the\n// string i of the input.\" where all the i's should be replaced by the number\n// of odd digits in the i'th string of the input.\n// >>> odd_count([\"1234567\"])\n// [\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]\n// >>> odd_count([\"3\", \"11111111\"])\n// [\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]\nfunction odd_count(lst: string[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_113_odd_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_count;\n  assert.deepEqual(candidate([\"1234567\"]),[\"the number of odd elements 4n the str4ng 4 of the 4nput.\"]);\n  assert.deepEqual(candidate([\"3\", \"11111111\"]),[\"the number of odd elements 1n the str1ng 1 of the 1nput.\", \"the number of odd elements 8n the str8ng 8 of the 8nput.\"]);\n  assert.deepEqual(candidate([\"271\", \"137\", \"314\"]),[\"the number of odd elements 2n the str2ng 2 of the 2nput.\", \"the number of odd elements 3n the str3ng 3 of the 3nput.\", \"the number of odd elements 2n the str2ng 2 of the 2nput.\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2025,13 +240,28 @@
     ]
   },
   {
-    "name": "HumanEval_125_split_words",
+    "name": "HumanEval_114_minSubArraySum",
     "language": "ts",
-    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt: string): string[]| number {\n",
+    "prompt": "//Given an array of integers nums, find the minimum sum of any non-empty sub-array\n// of nums.\n// Example\n// >>> minSubArraySum([2, 3, 4, 1, 2, 4])\n// 1\n// >>> minSubArraySum([-1, -2, -3])\n// -6\nfunction minSubArraySum(nums: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_114_minSubArraySum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minSubArraySum;\n  assert.deepEqual(candidate([2, 3, 4, 1, 2, 4]),1);\n  assert.deepEqual(candidate([-1, -2, -3]),-6);\n  assert.deepEqual(candidate([-1, -2, -3, 2, -10]),-14);\n  assert.deepEqual(candidate([-9999999999999999]),-9999999999999999);\n  assert.deepEqual(candidate([0, 10, 20, 1000000]),0);\n  assert.deepEqual(candidate([-1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([100, -1, -2, -3, 10, -5]),-6);\n  assert.deepEqual(candidate([10, 11, 13, 8, 3, 4]),3);\n  assert.deepEqual(candidate([100, -33, 32, -1, 0, -2]),-33);\n  assert.deepEqual(candidate([-10]),-10);\n  assert.deepEqual(candidate([7]),7);\n  assert.deepEqual(candidate([1, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_115_max_fill",
+    "language": "ts",
+    "prompt": "//You are given a rectangular grid of wells. Each row represents a single well,\n// and each 1 in a row represents a single unit of water.\n// Each well has a corresponding bucket that can be used to extract water from it, \n// and all buckets have the same capacity.\n// Your task is to use the buckets to empty the wells.\n// Output the number of times you need to lower the buckets.\n// Example 1:\n// >>> max_fill([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1)\n// 6\n// Example 2:\n// >>> max_fill([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2)\n// 5\n// Example 3:\n// >>> max_fill([[0, 0, 0], [0, 0, 0]], 5)\n// 0\n// Constraints:\n// * all wells have the same length\n// * 1 <= grid.length <= 10^2\n// * 1 <= grid[:,1].length <= 10^2\n// * grid[i][j] -> 0 | 1\n// * 1 <= capacity <= 10\nfunction max_fill(grid: number[][], capacity: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_115_max_fill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_fill;\n  assert.deepEqual(candidate([[0, 0, 1, 0], [0, 1, 0, 0], [1, 1, 1, 1]], 1),6);\n  assert.deepEqual(candidate([[0, 0, 1, 1], [0, 0, 0, 0], [1, 1, 1, 1], [0, 1, 1, 1]], 2),5);\n  assert.deepEqual(candidate([[0, 0, 0], [0, 0, 0]], 5),0);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 2),4);\n  assert.deepEqual(candidate([[1, 1, 1, 1], [1, 1, 1, 1]], 9),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2044,7 +274,7 @@
     "language": "ts",
     "prompt": "//In this Kata, you have to sort an array of non-negative integers according to\n// number of ones in their binary representation in ascending order.\n// For similar number of ones, sort based on decimal value.\n// It must be implemented like this:\n// >>> sort_array([1, 5, 2, 3, 4])\n// [1, 2, 3, 4, 5]\n// >>> sort_array([-2, -3, -4, -5, -6])\n// [-6, -5, -4, -3, -2]\n// >>> sort_array([1, 0, 2, 3, 4])\n// [0, 1, 2, 3, 4]\nfunction sort_array(arr: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_116_sort_array.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([1, 5, 2, 3, 4]),[1, 2, 4, 3, 5]);\n  assert.deepEqual(candidate([-2, -3, -4, -5, -6]),[-4, -2, -6, -5, -3]);\n  assert.deepEqual(candidate([1, 0, 2, 3, 4]),[0, 1, 2, 4, 3]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([2, 5, 77, 4, 5, 3, 5, 7, 2, 3, 4]),[2, 2, 4, 4, 3, 3, 5, 5, 5, 7, 77]);\n  assert.deepEqual(candidate([3, 6, 44, 12, 32, 5]),[32, 3, 5, 6, 12, 44]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n  assert.deepEqual(candidate([2, 4, 8, 16, 32]),[2, 4, 8, 16, 32]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2055,13 +285,13 @@
     ]
   },
   {
-    "name": "HumanEval_28_concatenate",
+    "name": "HumanEval_117_select_words",
     "language": "ts",
-    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings: string[]): string {\n",
+    "prompt": "//Given a string s and a natural number n, you have been tasked to implement \n// a function that returns a list of all words from string s that contain exactly \n// n consonants, in order these words appear in the string s.\n// If the string s is empty then the function should return an empty list.\n// Note: you may assume the input string contains only letters and spaces.\n// Examples:\n// >>> select_words(\"Mary had a little lamb\", 4)\n// [\"little\"]\n// >>> select_words(\"Mary had a little lamb\", 3)\n// [\"Mary\", \"lamb\"]\n// >>> select_words(\"simple white space\", 2)\n// []\n// >>> select_words(\"Hello world\", 4)\n// [\"world\"]\n// >>> select_words(\"Uncle sam\", 3)\n// [\"Uncle\"]\nfunction select_words(s: string, n: number): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_117_select_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = select_words;\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 4),[\"little\"]);\n  assert.deepEqual(candidate(\"Mary had a little lamb\", 3),[\"Mary\", \"lamb\"]);\n  assert.deepEqual(candidate(\"simple white space\", 2),[]);\n  assert.deepEqual(candidate(\"Hello world\", 4),[\"world\"]);\n  assert.deepEqual(candidate(\"Uncle sam\", 3),[\"Uncle\"]);\n  assert.deepEqual(candidate(\"\", 4),[]);\n  assert.deepEqual(candidate(\"a b c d e f\", 1),[\"b\", \"c\", \"d\", \"f\"]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2070,13 +300,13 @@
     ]
   },
   {
-    "name": "HumanEval_149_sorted_list_sum",
+    "name": "HumanEval_118_get_closest_vowel",
     "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
+    "prompt": "//You are given a word. Your task is to find the closest vowel that stands between \n// two consonants from the right side of the word (case sensitive).\n// Vowels in the beginning and ending doesn't count. Return empty string if you didn't\n// find any vowel met the above condition. \n// You may assume that the given string contains English letter only.\n// Example:\n// >>> get_closest_vowel(\"yogurt\")\n// \"u\"\n// >>> get_closest_vowel(\"FULL\")\n// \"U\"\n// >>> get_closest_vowel(\"quick\")\n// \"\"\n// >>> get_closest_vowel(\"ab\")\n// \"\"\nfunction get_closest_vowel(word: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_118_get_closest_vowel.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_closest_vowel;\n  assert.deepEqual(candidate(\"yogurt\"),\"u\");\n  assert.deepEqual(candidate(\"full\"),\"u\");\n  assert.deepEqual(candidate(\"easy\"),\"\");\n  assert.deepEqual(candidate(\"eAsy\"),\"\");\n  assert.deepEqual(candidate(\"ali\"),\"\");\n  assert.deepEqual(candidate(\"bad\"),\"a\");\n  assert.deepEqual(candidate(\"most\"),\"o\");\n  assert.deepEqual(candidate(\"ab\"),\"\");\n  assert.deepEqual(candidate(\"ba\"),\"\");\n  assert.deepEqual(candidate(\"quick\"),\"\");\n  assert.deepEqual(candidate(\"anime\"),\"i\");\n  assert.deepEqual(candidate(\"Asia\"),\"\");\n  assert.deepEqual(candidate(\"Above\"),\"o\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2085,13 +315,13 @@
     ]
   },
   {
-    "name": "HumanEval_7_filter_by_substring",
+    "name": "HumanEval_119_match_parens",
     "language": "ts",
-    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "prompt": "//You are given a list of two strings, both strings consist of open\n// parentheses '(' or close parentheses ')' only.\n// Your job is to check if it is possible to concatenate the two strings in\n// some order, that the resulting string will be good.\n// A string S is considered to be good if and only if all parentheses in S\n// are balanced. For example: the string '(())()' is good, while the string\n// '())' is not.\n// Return 'Yes' if there's a way to make a good string, and return 'No' otherwise.\n// Examples:\n// >>> match_parens([\"()(\", \")\"])\n// \"Yes\"\n// >>> match_parens([\")\", \")\"])\n// \"No\"\nfunction match_parens(lst: string[]): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_119_match_parens.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = match_parens;\n  assert.deepEqual(candidate([\"()(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \")\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(())\", \"())())\"]),\"No\");\n  assert.deepEqual(candidate([\")())\", \"(()()(\"]),\"Yes\");\n  assert.deepEqual(candidate([\"(())))\", \"(()())((\"]),\"Yes\");\n  assert.deepEqual(candidate([\"()\", \"())\"]),\"No\");\n  assert.deepEqual(candidate([\"(()(\", \"()))()\"]),\"Yes\");\n  assert.deepEqual(candidate([\"((((\", \"((())\"]),\"No\");\n  assert.deepEqual(candidate([\")(()\", \"(()(\"]),\"No\");\n  assert.deepEqual(candidate([\")(\", \")(\"]),\"No\");\n  assert.deepEqual(candidate([\"(\", \")\"]),\"Yes\");\n  assert.deepEqual(candidate([\")\", \"(\"]),\"Yes\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2100,13 +330,13 @@
     ]
   },
   {
-    "name": "HumanEval_99_closest_integer",
+    "name": "HumanEval_11_string_xor",
     "language": "ts",
-    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "prompt": "//Input are two strings a and b consisting only of 1s and 0s.\n// Perform binary XOR on these inputs and return result also as a string.\n// >>> string_xor(\"010\", \"110\")\n// \"100\"\nfunction string_xor(a: string, b: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_11_string_xor.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_xor;\n  assert.deepEqual(candidate(\"111000\", \"101010\"),\"010010\");\n  assert.deepEqual(candidate(\"1\", \"1\"),\"0\");\n  assert.deepEqual(candidate(\"0101\", \"0000\"),\"0101\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2115,13 +345,13 @@
     ]
   },
   {
-    "name": "HumanEval_64_vowels_count",
+    "name": "HumanEval_120_maximum",
     "language": "ts",
-    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
+    "prompt": "//Given an array arr of integers and a positive integer k, return a sorted list \n// of length k with the maximum k numbers in arr.\n// Example 1:\n// >>> maximum([-3, -4, 5], 3)\n// [-4, -3, 5]\n// Example 2:\n// >>> maximum([4, -4, 4], 2)\n// [4, 4]\n// Example 3:\n// >>> maximum([-3, 2, 1, 2, -1, -2, 1], 1)\n// [2]\n// Note:\n// 1. The length of the array will be in the range of [1, 1000].\n// 2. The elements in the array will be in the range of [-1000, 1000].\n// 3. 0 <= k <= len(arr)\nfunction maximum(arr: number[], k: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_120_maximum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate([-3, -4, 5], 3),[-4, -3, 5]);\n  assert.deepEqual(candidate([4, -4, 4], 2),[4, 4]);\n  assert.deepEqual(candidate([-3, 2, 1, 2, -1, -2, 1], 1),[2]);\n  assert.deepEqual(candidate([123, -123, 20, 0, 1, 2, -3], 3),[2, 20, 123]);\n  assert.deepEqual(candidate([-123, 20, 0, 1, 2, -3], 4),[0, 1, 2, 20]);\n  assert.deepEqual(candidate([5, 15, 0, 3, -13, -8, 0], 7),[-13, -8, 0, 0, 3, 5, 15]);\n  assert.deepEqual(candidate([-1, 0, 2, 5, 3, -10], 2),[3, 5]);\n  assert.deepEqual(candidate([1, 0, 5, -7], 1),[5]);\n  assert.deepEqual(candidate([4, -4], 2),[-4, 4]);\n  assert.deepEqual(candidate([-10, 10], 2),[-10, 10]);\n  assert.deepEqual(candidate([1, 2, 3, -23, 243, -400, 0], 0),[]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2130,13 +360,13 @@
     ]
   },
   {
-    "name": "HumanEval_158_find_max",
+    "name": "HumanEval_121_solution",
     "language": "ts",
-    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
+    "prompt": "//Given a non-empty list of integers, return the sum of all of the odd elements that are in even positions.\n// Examples\n// >>> solution([5, 8, 7, 1])\n// 12\n// >>> solution([3, 3, 3, 3, 3])\n// 9\n// >>> solution([30, 13, 24, 321])\n// 0\nfunction solution(lst: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_121_solution.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solution;\n  assert.deepEqual(candidate([5, 8, 7, 1]),12);\n  assert.deepEqual(candidate([3, 3, 3, 3, 3]),9);\n  assert.deepEqual(candidate([30, 13, 24, 321]),0);\n  assert.deepEqual(candidate([5, 9]),5);\n  assert.deepEqual(candidate([2, 4, 8]),0);\n  assert.deepEqual(candidate([30, 13, 23, 32]),23);\n  assert.deepEqual(candidate([3, 13, 2, 9]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2145,13 +375,13 @@
     ]
   },
   {
-    "name": "HumanEval_162_string_to_md5",
+    "name": "HumanEval_122_add_elements",
     "language": "ts",
-    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text: string): string | undefined {\n",
+    "prompt": "//Given a non-empty array of integers arr and an integer k, return\n// the sum of the elements with at most two digits from the first k elements of arr.\n// Example:\n// >>> add_elements([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4)\n// 24\n// Constraints:\n// 1. 1 <= len(arr) <= 100\n// 2. 1 <= k <= len(arr)\nfunction add_elements(arr: number[], k: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_122_add_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_elements;\n  assert.deepEqual(candidate([1, -2, -3, 41, 57, 76, 87, 88, 99], 3),-4);\n  assert.deepEqual(candidate([111, 121, 3, 4000, 5, 6], 2),0);\n  assert.deepEqual(candidate([11, 21, 3, 90, 5, 6, 7, 8, 9], 4),125);\n  assert.deepEqual(candidate([111, 21, 3, 4000, 5, 6, 7, 8, 9], 4),24);\n  assert.deepEqual(candidate([1], 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2160,13 +390,13 @@
     ]
   },
   {
-    "name": "HumanEval_44_change_base",
+    "name": "HumanEval_123_get_odd_collatz",
     "language": "ts",
-    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x: number, base: number): string {\n",
+    "prompt": "//Given a positive integer n, return a sorted list that has the odd numbers in collatz sequence.\n// The Collatz conjecture is a conjecture in mathematics that concerns a sequence defined\n// as follows: start with any positive integer n. Then each term is obtained from the \n// previous term as follows: if the previous term is even, the next term is one half of \n// the previous term. If the previous term is odd, the next term is 3 times the previous\n// term plus 1. The conjecture is that no matter what value of n, the sequence will always reach 1.\n// Note: \n// 1. Collatz(1) is [1].\n// 2. returned list sorted in increasing order.\n// For example:\n// get_odd_collatz(5) returns [1, 5] # The collatz sequence for 5 is [5, 16, 8, 4, 2, 1], so the odd numbers are only 1, and 5.\n// >>> get_odd_collatz(5)\n// [1, 5]\nfunction get_odd_collatz(n: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_123_get_odd_collatz.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_odd_collatz;\n  assert.deepEqual(candidate(14),[1, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(5),[1, 5]);\n  assert.deepEqual(candidate(12),[1, 3, 5]);\n  assert.deepEqual(candidate(1),[1]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2175,13 +405,13 @@
     ]
   },
   {
-    "name": "HumanEval_157_right_angle_triangle",
+    "name": "HumanEval_124_valid_date",
     "language": "ts",
-    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "prompt": "//You have to write a function which validates a given date string and\n// returns True if the date is valid otherwise False.\n// The date is valid if all of the following rules are satisfied:\n// 1. The date string is not empty.\n// 2. The number of days is not less than 1 or higher than 31 days for months 1,3,5,7,8,10,12. And the number of days is not less than 1 or higher than 30 days for months 4,6,9,11. And, the number of days is not less than 1 or higher than 29 for the month 2.\n// 3. The months should not be less than 1 or higher than 12.\n// 4. The date should be in the format: mm-dd-yyyy\n// >>> valid_date(\"03-11-2000\")\n// true\n// >>> valid_date(\"15-01-2012\")\n// false\n// >>> valid_date(\"04-0-2040\")\n// false\n// >>> valid_date(\"06-04-2020\")\n// true\n// >>> valid_date(\"06/04/2020\")\n// false\nfunction valid_date(date: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_124_valid_date.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = valid_date;\n  assert.deepEqual(candidate(\"03-11-2000\"),true);\n  assert.deepEqual(candidate(\"15-01-2012\"),false);\n  assert.deepEqual(candidate(\"04-0-2040\"),false);\n  assert.deepEqual(candidate(\"06-04-2020\"),true);\n  assert.deepEqual(candidate(\"01-01-2007\"),true);\n  assert.deepEqual(candidate(\"03-32-2011\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"04-31-3000\"),false);\n  assert.deepEqual(candidate(\"06-06-2005\"),true);\n  assert.deepEqual(candidate(\"21-31-2000\"),false);\n  assert.deepEqual(candidate(\"04-12-2003\"),true);\n  assert.deepEqual(candidate(\"04122003\"),false);\n  assert.deepEqual(candidate(\"20030412\"),false);\n  assert.deepEqual(candidate(\"2003-04\"),false);\n  assert.deepEqual(candidate(\"2003-04-12\"),false);\n  assert.deepEqual(candidate(\"04-2003\"),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2190,13 +420,13 @@
     ]
   },
   {
-    "name": "HumanEval_81_numerical_letter_grade",
+    "name": "HumanEval_125_split_words",
     "language": "ts",
-    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "prompt": "//Given a string of words, return a list of words split on whitespace, if no whitespaces exists in the text you\n// should split on commas ',' if no commas exists you should return the number of lower-case letters with odd order in the\n// alphabet, ord('a') = 0, ord('b') = 1, ... ord('z') = 25\n// Examples\n// >>> split_words(\"Hello world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"Hello,world!\")\n// [\"Hello\", \"world!\"]\n// >>> split_words(\"abcdef\")\n// 3\nfunction split_words(txt: string): string[]| number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_125_split_words.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_words;\n  assert.deepEqual(candidate(\"Hello world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello,world!\"),[\"Hello\", \"world!\"]);\n  assert.deepEqual(candidate(\"Hello world,!\"),[\"Hello\", \"world,!\"]);\n  assert.deepEqual(candidate(\"Hello,Hello,world !\"),[\"Hello,Hello,world\", \"!\"]);\n  assert.deepEqual(candidate(\"abcdef\"),3);\n  assert.deepEqual(candidate(\"aaabb\"),2);\n  assert.deepEqual(candidate(\"aaaBb\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2205,13 +435,313 @@
     ]
   },
   {
-    "name": "HumanEval_5_intersperse",
+    "name": "HumanEval_126_is_sorted",
     "language": "ts",
-    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "prompt": "//Given a list of numbers, return whether or not they are sorted\n// in ascending order. If list has more than 1 duplicate of the same\n// number, return False. Assume no negative numbers and only integers.\n// Examples\n// >>> is_sorted([5])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5])\n// false\n// >>> is_sorted([1, 2, 3, 4, 5, 6])\n// true\n// >>> is_sorted([1, 2, 3, 4, 5, 6, 7])\n// true\n// >>> is_sorted([1, 3, 2, 4, 5, 6, 7])\n// false\n// >>> is_sorted([1, 2, 2, 3, 3, 4])\n// true\n// >>> is_sorted([1, 2, 2, 2, 3, 4])\n// false\nfunction is_sorted(lst: number[]): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_126_is_sorted.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sorted;\n  assert.deepEqual(candidate([5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7]),true);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, 7]),false);\n  assert.deepEqual(candidate([]),true);\n  assert.deepEqual(candidate([1]),true);\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 2, 2, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 4]),false);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_127_intersection",
+    "language": "ts",
+    "prompt": "//You are given two intervals,\n// where each interval is a pair of integers. For example, interval = (start, end) = (1, 2).\n// The given intervals are closed which means that the interval (start, end)\n// includes both start and end.\n// For each given interval, it is assumed that its start is less or equal its end.\n// Your task is to determine whether the length of intersection of these two \n// intervals is a prime number.\n// Example, the intersection of the intervals (1, 3), (2, 4) is (2, 3)\n// which its length is 1, which not a prime number.\n// If the length of the intersection is a prime number, return \"YES\",\n// otherwise, return \"NO\".\n// If the two intervals don't intersect, return \"NO\".\n// [input/output] samples:\n// >>> intersection([1, 2], [2, 3])\n// \"NO\"\n// >>> intersection([-1, 1], [0, 4])\n// \"NO\"\n// >>> intersection([-3, -1], [-5, 5])\n// \"YES\"\nfunction intersection(interval1: [number, number], interval2: [number, number]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_127_intersection.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection;\n  assert.deepEqual(candidate([1, 2], [2, 3]),\"NO\");\n  assert.deepEqual(candidate([-1, 1], [0, 4]),\"NO\");\n  assert.deepEqual(candidate([-3, -1], [-5, 5]),\"YES\");\n  assert.deepEqual(candidate([-2, 2], [-4, 0]),\"YES\");\n  assert.deepEqual(candidate([-11, 2], [-1, -1]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [3, 5]),\"NO\");\n  assert.deepEqual(candidate([1, 2], [1, 2]),\"NO\");\n  assert.deepEqual(candidate([-2, -2], [-3, -2]),\"NO\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_128_prod_signs",
+    "language": "ts",
+    "prompt": "//You are given an array arr of integers and you need to return\n// sum of magnitudes of integers multiplied by product of all signs\n// of each number in the array, represented by 1, -1 or 0.\n// Note: return None for empty arr.\n// Example:\n// >>> prod_signs([1, 2, 2, -4])\n// 9\n// >>> prod_signs([0, 1])\n// 0\n// >>> prod_signs([])\n// undefined\nfunction prod_signs(arr: number[]): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_128_prod_signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prod_signs;\n  assert.deepEqual(candidate([1, 2, 2, -4]),-9);\n  assert.deepEqual(candidate([0, 1]),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, -1, 1]),-10);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([2, 4, 1, 2, -1, -1, 9]),20);\n  assert.deepEqual(candidate([-1, 1, -1, 1]),4);\n  assert.deepEqual(candidate([-1, 1, 1, 1]),-4);\n  assert.deepEqual(candidate([-1, 1, 1, 0]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_129_minPath",
+    "language": "ts",
+    "prompt": "//Given a grid with N rows and N columns (N >= 2) and a positive integer k, \n// each cell of the grid contains a value. Every integer in the range [1, N * N]\n// inclusive appears exactly once on the cells of the grid.\n// You have to find the minimum path of length k in the grid. You can start\n// from any cell, and in each step you can move to any of the neighbor cells,\n// in other words, you can go to cells which share an edge with you current\n// cell.\n// Please note that a path of length k means visiting exactly k cells (not\n// necessarily distinct).\n// You CANNOT go off the grid.\n// A path A (of length k) is considered less than a path B (of length k) if\n// after making the ordered lists of the values on the cells that A and B go\n// through (let's call them lst_A and lst_B), lst_A is lexicographically less\n// than lst_B, in other words, there exist an integer index i (1 <= i <= k)\n// such that lst_A[i] < lst_B[i] and for any j (1 <= j < i) we have\n// lst_A[j] = lst_B[j].\n// It is guaranteed that the answer is unique.\n// Return an ordered list of the values on the cells that the minimum path go through.\n// Examples:    \n// >>> minPath([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3)\n// [1, 2, 1]\n// >>> minPath([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1)\n// [1]\nfunction minPath(grid: number[][], k: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_129_minPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minPath;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 3),[1, 2, 1]);\n  assert.deepEqual(candidate([[5, 9, 3], [4, 1, 6], [7, 8, 2]], 1),[1]);\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], 4),[1, 2, 1, 2]);\n  assert.deepEqual(candidate([[6, 4, 13, 10], [5, 7, 12, 1], [3, 16, 11, 15], [8, 14, 9, 2]], 7),[1, 10, 1, 10, 1, 10, 1]);\n  assert.deepEqual(candidate([[8, 14, 9, 2], [6, 4, 13, 15], [5, 7, 1, 12], [3, 10, 11, 16]], 5),[1, 7, 1, 7, 1]);\n  assert.deepEqual(candidate([[11, 8, 7, 2], [5, 16, 14, 4], [9, 3, 15, 6], [12, 13, 10, 1]], 9),[1, 6, 1, 6, 1, 6, 1, 6, 1]);\n  assert.deepEqual(candidate([[12, 13, 10, 1], [9, 3, 15, 6], [5, 16, 14, 4], [11, 8, 7, 2]], 12),[1, 6, 1, 6, 1, 6, 1, 6, 1, 6, 1, 6]);\n  assert.deepEqual(candidate([[2, 7, 4], [3, 1, 5], [6, 8, 9]], 8),[1, 3, 1, 3, 1, 3, 1, 3]);\n  assert.deepEqual(candidate([[6, 1, 5], [3, 8, 9], [2, 7, 4]], 8),[1, 5, 1, 5, 1, 5, 1, 5]);\n  assert.deepEqual(candidate([[1, 2], [3, 4]], 10),[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);\n  assert.deepEqual(candidate([[1, 3], [3, 2]], 10),[1, 3, 1, 3, 1, 3, 1, 3, 1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_12_longest",
+    "language": "ts",
+    "prompt": "//Out of list of strings, return the longest one. Return the first one in case of multiple\n// strings of the same length. Return None in case the input list is empty.\n// >>> longest([])\n// undefined\n// >>> longest([\"a\", \"b\", \"c\"])\n// \"a\"\n// >>> longest([\"a\", \"bb\", \"ccc\"])\n// \"ccc\"\nfunction longest(strings: string[]): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_12_longest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = longest;\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"x\");\n  assert.deepEqual(candidate([\"x\", \"yyy\", \"zzzz\", \"www\", \"kkkk\", \"abc\"]),\"zzzz\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_130_tri",
+    "language": "ts",
+    "prompt": "//Everyone knows Fibonacci sequence, it was studied deeply by mathematicians in \n// the last couple centuries. However, what people don't know is Tribonacci sequence.\n// Tribonacci sequence is defined by the recurrence:\n// tri(1) = 3\n// tri(n) = 1 + n / 2, if n is even.\n// tri(n) =  tri(n - 1) + tri(n - 2) + tri(n + 1), if n is odd.\n// For example:\n// tri(2) = 1 + (2 / 2) = 2\n// tri(4) = 3\n// tri(3) = tri(2) + tri(1) + tri(4)\n// = 2 + 3 + 3 = 8 \n// You are given a non-negative integer number n, you have to a return a list of the \n// first n + 1 numbers of the Tribonacci sequence.\n// Examples:\n// >>> tri(3)\n// [1, 3, 2, 8]\nfunction tri(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_130_tri.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tri;\n  assert.deepEqual(candidate(3),[1, 3, 2, 8]);\n  assert.deepEqual(candidate(4),[1, 3, 2, 8, 3]);\n  assert.deepEqual(candidate(5),[1, 3, 2, 8, 3, 15]);\n  assert.deepEqual(candidate(6),[1, 3, 2, 8, 3, 15, 4]);\n  assert.deepEqual(candidate(7),[1, 3, 2, 8, 3, 15, 4, 24]);\n  assert.deepEqual(candidate(8),[1, 3, 2, 8, 3, 15, 4, 24, 5]);\n  assert.deepEqual(candidate(9),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35]);\n  assert.deepEqual(candidate(20),[1, 3, 2, 8, 3, 15, 4, 24, 5, 35, 6, 48, 7, 63, 8, 80, 9, 99, 10, 120, 11]);\n  assert.deepEqual(candidate(0),[1]);\n  assert.deepEqual(candidate(1),[1, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_131_digits",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the product of the odd digits.\n// Return 0 if all digits are even.\n// For example:\n// >>> digits(1)\n// 1\n// >>> digits(4)\n// 0\n// >>> digits(235)\n// 15\nfunction digits(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_131_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digits;\n  assert.deepEqual(candidate(5),5);\n  assert.deepEqual(candidate(54),5);\n  assert.deepEqual(candidate(120),1);\n  assert.deepEqual(candidate(5014),5);\n  assert.deepEqual(candidate(98765),315);\n  assert.deepEqual(candidate(5576543),2625);\n  assert.deepEqual(candidate(2468),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_132_is_nested",
+    "language": "ts",
+    "prompt": "//Create a function that takes a string as input which contains only square brackets.\n// The function should return True if and only if there is a valid subsequence of brackets \n// where at least one bracket in the subsequence is nested.\n// >>> is_nested(\"[[]]\")\n// true\n// >>> is_nested(\"[]]]]]]][[[[[]\")\n// false\n// >>> is_nested(\"[][]\")\n// false\n// >>> is_nested(\"[]\")\n// false\n// >>> is_nested(\"[[][]]\")\n// true\n// >>> is_nested(\"[[]][[\")\n// true\nfunction is_nested(string: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_132_is_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nested;\n  assert.deepEqual(candidate(\"[[]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]][[[[[]\"),false);\n  assert.deepEqual(candidate(\"[][]\"),false);\n  assert.deepEqual(candidate(\"[]\"),false);\n  assert.deepEqual(candidate(\"[[[[]]]]\"),true);\n  assert.deepEqual(candidate(\"[]]]]]]]]]]\"),false);\n  assert.deepEqual(candidate(\"[][][[]]\"),true);\n  assert.deepEqual(candidate(\"[[]\"),false);\n  assert.deepEqual(candidate(\"[]]\"),false);\n  assert.deepEqual(candidate(\"[[]][[\"),true);\n  assert.deepEqual(candidate(\"[[][]]\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"[[[[[[[[\"),false);\n  assert.deepEqual(candidate(\"]]]]]]]]\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_133_sum_squares",
+    "language": "ts",
+    "prompt": "//You are given a list of numbers.\n// You need to return the sum of squared numbers in the given list,\n// round each element in the list to the upper int(Ceiling) first.\n// Examples:\n// >>> lst([1.0, 2.0, 3.0])\n// 14\n// >>> lst([1.0, 4.0, 9.0])\n// 98\n// >>> lst([1.0, 3.0, 5.0, 7.0])\n// 84\n// >>> lst([1.4, 4.2, 0.0])\n// 29\n// >>> lst([-2.4, 1.0, 1.0])\n// 6\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_133_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0]),14);\n  assert.deepEqual(candidate([1.0, 3.0, 5.0, 7.0]),84);\n  assert.deepEqual(candidate([1.4, 4.2, 0.0]),29);\n  assert.deepEqual(candidate([-2.4, 1.0, 1.0]),6);\n  assert.deepEqual(candidate([100.0, 1.0, 15.0, 2.0]),10230);\n  assert.deepEqual(candidate([10000.0, 10000.0]),200000000);\n  assert.deepEqual(candidate([-1.4, 4.6, 6.3]),75);\n  assert.deepEqual(candidate([-1.4, 17.9, 18.9, 19.9]),1086);\n  assert.deepEqual(candidate([0.0]),0);\n  assert.deepEqual(candidate([-1.0]),1);\n  assert.deepEqual(candidate([-1.0, 1.0, 0.0]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_134_check_if_last_char_is_a_letter",
+    "language": "ts",
+    "prompt": "//Create a function that returns True if the last character\n// of a given string is an alphabetical character and is not\n// a part of a word, and False otherwise.\n// Note: \"word\" is a group of characters separated by space.\n// Examples:\n// >>> check_if_last_char_is_a_letter(\"apple pie\")\n// false\n// >>> check_if_last_char_is_a_letter(\"apple pi e\")\n// true\n// >>> check_if_last_char_is_a_letter(\"apple pi e \")\n// false\n// >>> check_if_last_char_is_a_letter(\"\")\n// false\nfunction check_if_last_char_is_a_letter(txt: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_134_check_if_last_char_is_a_letter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_if_last_char_is_a_letter;\n  assert.deepEqual(candidate(\"apple\"),false);\n  assert.deepEqual(candidate(\"apple pi e\"),true);\n  assert.deepEqual(candidate(\"eeeee\"),false);\n  assert.deepEqual(candidate(\"A\"),true);\n  assert.deepEqual(candidate(\"Pumpkin pie \"),false);\n  assert.deepEqual(candidate(\"Pumpkin pie 1\"),false);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"eeeee e \"),false);\n  assert.deepEqual(candidate(\"apple pie\"),false);\n  assert.deepEqual(candidate(\"apple pi e \"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_135_can_arrange",
+    "language": "ts",
+    "prompt": "//Create a function which returns the largest index of an element which\n// is not greater than or equal to the element immediately preceding it. If\n// no such element exists then return -1. The given array will not contain\n// duplicate values.\n// Examples:\n// >>> can_arrange([1, 2, 4, 3, 5])\n// 3\n// >>> can_arrange([1, 2, 3])\n// -1\nfunction can_arrange(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_135_can_arrange.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = can_arrange;\n  assert.deepEqual(candidate([1, 2, 4, 3, 5]),3);\n  assert.deepEqual(candidate([1, 2, 4, 5]),-1);\n  assert.deepEqual(candidate([1, 4, 2, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([4, 8, 5, 7, 3]),4);\n  assert.deepEqual(candidate([]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_136_largest_smallest_integers",
+    "language": "ts",
+    "prompt": "//Create a function that returns a tuple (a, b), where 'a' is\n// the largest of negative integers, and 'b' is the smallest\n// of positive integers in a list.\n// If there is no negative or positive integers, return them as None.\n// Examples:\n// >>> largest_smallest_integers([2, 4, 1, 3, 5, 7])\n// [undefined, 1]\n// >>> largest_smallest_integers([])\n// [undefined, undefined]\n// >>> largest_smallest_integers([0])\n// [undefined, undefined]\nfunction largest_smallest_integers(lst: number[]): [number | undefined, number | undefined] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_136_largest_smallest_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_smallest_integers;\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7]),[undefined, 1]);\n  assert.deepEqual(candidate([2, 4, 1, 3, 5, 7, 0]),[undefined, 1]);\n  assert.deepEqual(candidate([1, 3, 2, 4, 5, 6, -2]),[-2, 1]);\n  assert.deepEqual(candidate([4, 5, 3, 6, 2, 7, -7]),[-7, 2]);\n  assert.deepEqual(candidate([7, 3, 8, 4, 9, 2, 5, -9]),[-9, 2]);\n  assert.deepEqual(candidate([]),[undefined, undefined]);\n  assert.deepEqual(candidate([0]),[undefined, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6]),[-1, undefined]);\n  assert.deepEqual(candidate([-1, -3, -5, -6, 0]),[-1, undefined]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, 1]),[-3, 1]);\n  assert.deepEqual(candidate([-6, -4, -4, -3, -100, 1]),[-3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_138_is_equal_to_sum_even",
+    "language": "ts",
+    "prompt": "//Evaluate whether the given number n can be written as the sum of exactly 4 positive even numbers\n// Example\n// >>> is_equal_to_sum_even(4)\n// false\n// >>> is_equal_to_sum_even(6)\n// false\n// >>> is_equal_to_sum_even(8)\n// true\nfunction is_equal_to_sum_even(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_138_is_equal_to_sum_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_equal_to_sum_even;\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(11),false);\n  assert.deepEqual(candidate(12),true);\n  assert.deepEqual(candidate(13),false);\n  assert.deepEqual(candidate(16),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_139_special_factorial",
+    "language": "ts",
+    "prompt": "//The Brazilian factorial is defined as:\n// brazilian_factorial(n) = n! * (n-1)! * (n-2)! * ... * 1!\n// where n > 0\n// For example:\n// >>> special_factorial(4)\n// 288\n// The function will receive an integer as input and should return the special\n// factorial of this integer.\nfunction special_factorial(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_139_special_factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = special_factorial;\n  assert.deepEqual(candidate(4),288);\n  assert.deepEqual(candidate(5),34560);\n  assert.deepEqual(candidate(7),125411328000);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_13_greatest_common_divisor",
+    "language": "ts",
+    "prompt": "//Return a greatest common divisor of two integers a and b\n// >>> greatest_common_divisor(3, 5)\n// 1\n// >>> greatest_common_divisor(25, 15)\n// 5\nfunction greatest_common_divisor(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_13_greatest_common_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = greatest_common_divisor;\n  assert.deepEqual(candidate(3, 7),1);\n  assert.deepEqual(candidate(10, 15),5);\n  assert.deepEqual(candidate(49, 14),7);\n  assert.deepEqual(candidate(144, 60),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_140_fix_spaces",
+    "language": "ts",
+    "prompt": "//Given a string text, replace all spaces in it with underscores, \n// and if a string has more than 2 consecutive spaces, \n// then replace all consecutive spaces with - \n// >>> fix_spaces(\" Example\")\n// \"Example\"\n// >>> fix_spaces(\" Example 1\")\n// \"Example_1\"\n// >>> fix_spaces(\" Example 2\")\n// \"_Example_2\"\n// >>> fix_spaces(\" Example 3\")\n// \"_Example-3\"\nfunction fix_spaces(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_140_fix_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fix_spaces;\n  assert.deepEqual(candidate(\"Example\"),\"Example\");\n  assert.deepEqual(candidate(\"Mudasir Hanif \"),\"Mudasir_Hanif_\");\n  assert.deepEqual(candidate(\"Yellow Yellow  Dirty  Fellow\"),\"Yellow_Yellow__Dirty__Fellow\");\n  assert.deepEqual(candidate(\"Exa   mple\"),\"Exa-mple\");\n  assert.deepEqual(candidate(\"   Exa 1 2 2 mple\"),\"-Exa_1_2_2_mple\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_141_file_name_check",
+    "language": "ts",
+    "prompt": "//Create a function which takes a string representing a file's name, and returns\n// 'Yes' if the the file's name is valid, and returns 'No' otherwise.\n// A file's name is considered to be valid if and only if all the following conditions \n// are met:\n// - There should not be more than three digits ('0'-'9') in the file's name.\n// - The file's name contains exactly one dot '.'\n// - The substring before the dot should not be empty, and it starts with a letter from \n// the latin alphapet ('a'-'z' and 'A'-'Z').\n// - The substring after the dot should be one of these: ['txt', 'exe', 'dll']\n// Examples:\n// >>> file_name_check(\"example.txt\")\n// \"Yes\"\n// >>> file_name_check(\"1example.dll\")\n// \"No\"\nfunction file_name_check(file_name: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_141_file_name_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = file_name_check;\n  assert.deepEqual(candidate(\"example.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"1example.dll\"),\"No\");\n  assert.deepEqual(candidate(\"s1sdf3.asd\"),\"No\");\n  assert.deepEqual(candidate(\"K.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"MY16FILE3.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"His12FILE94.exe\"),\"No\");\n  assert.deepEqual(candidate(\"_Y.txt\"),\"No\");\n  assert.deepEqual(candidate(\"?aREYA.exe\"),\"No\");\n  assert.deepEqual(candidate(\"/this_is_valid.dll\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.wow\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_valid.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"this_is_valid.txtexe\"),\"No\");\n  assert.deepEqual(candidate(\"#this2_i4s_5valid.ten\"),\"No\");\n  assert.deepEqual(candidate(\"@this1_is6_valid.exe\"),\"No\");\n  assert.deepEqual(candidate(\"this_is_12valid.6exe4.txt\"),\"No\");\n  assert.deepEqual(candidate(\"all.exe.txt\"),\"No\");\n  assert.deepEqual(candidate(\"I563_No.exe\"),\"Yes\");\n  assert.deepEqual(candidate(\"Is3youfault.txt\"),\"Yes\");\n  assert.deepEqual(candidate(\"no_one#knows.dll\"),\"Yes\");\n  assert.deepEqual(candidate(\"1I563_Yes3.exe\"),\"No\");\n  assert.deepEqual(candidate(\"I563_Yes3.txtt\"),\"No\");\n  assert.deepEqual(candidate(\"final..txt\"),\"No\");\n  assert.deepEqual(candidate(\"final132\"),\"No\");\n  assert.deepEqual(candidate(\"_f4indsartal132.\"),\"No\");\n  assert.deepEqual(candidate(\".txt\"),\"No\");\n  assert.deepEqual(candidate(\"s.\"),\"No\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_142_sum_squares",
+    "language": "ts",
+    "prompt": "//\"\n// This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a \n// multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not \n// change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. \n// Examples:\n// >>> lst\n// [1, 2, 3]\n// >>> lst\n// []\n// >>> lst\n// [-1, -5, 2, -1, -5]\nfunction sum_squares(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_squares;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([1, 4, 9]),14);\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([1, 1, 1, 1, 1, 1, 1, 1, 1]),9);\n  assert.deepEqual(candidate([-1, -1, -1, -1, -1, -1, -1, -1, -1]),-3);\n  assert.deepEqual(candidate([0]),0);\n  assert.deepEqual(candidate([-1, -5, 2, -1, -5]),-126);\n  assert.deepEqual(candidate([-56, -99, 1, 0, -2]),3030);\n  assert.deepEqual(candidate([-1, 0, 0, 0, 0, 0, 0, 0, -1]),0);\n  assert.deepEqual(candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]),-14196);\n  assert.deepEqual(candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]),-1448);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_143_words_in_sentence",
+    "language": "ts",
+    "prompt": "//You are given a string representing a sentence,\n// the sentence contains some words separated by a space,\n// and you have to return a string that contains the words from the original sentence,\n// whose lengths are prime numbers,\n// the order of the words in the new string should be the same as the original one.\n// Example 1:\n// >>> words_in_sentence(\"This is a test\")\n// \"is\"\n// Example 2:\n// >>> words_in_sentence(\"lets go for swimming\")\n// \"go for\"\n// Constraints:\n// * 1 <= len(sentence) <= 100\n// * sentence contains only letters\nfunction words_in_sentence(sentence: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_143_words_in_sentence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = words_in_sentence;\n  assert.deepEqual(candidate(\"This is a test\"),\"is\");\n  assert.deepEqual(candidate(\"lets go for swimming\"),\"go for\");\n  assert.deepEqual(candidate(\"there is no place available here\"),\"there is no place\");\n  assert.deepEqual(candidate(\"Hi I am Hussein\"),\"Hi am Hussein\");\n  assert.deepEqual(candidate(\"go for it\"),\"go for it\");\n  assert.deepEqual(candidate(\"here\"),\"\");\n  assert.deepEqual(candidate(\"here is\"),\"is\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_144_simplify",
+    "language": "ts",
+    "prompt": "//Your task is to implement a function that will simplify the expression\n// x * n. The function returns True if x * n evaluates to a whole number and False\n// otherwise. Both x and n, are string representation of a fraction, and have the following format,\n// <numerator>/<denominator> where both numerator and denominator are positive whole numbers.\n// You can assume that x, and n are valid fractions, and do not have zero as denominator.\n// >>> simplify(\"1/5\", \"5/1\")\n// true\n// >>> simplify(\"1/6\", \"2/1\")\n// false\n// >>> simplify(\"7/10\", \"10/2\")\n// false\nfunction simplify(x: string, n: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_144_simplify.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = simplify;\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/6\", \"2/1\"),false);\n  assert.deepEqual(candidate(\"5/1\", \"3/1\"),true);\n  assert.deepEqual(candidate(\"7/10\", \"10/2\"),false);\n  assert.deepEqual(candidate(\"2/10\", \"50/10\"),true);\n  assert.deepEqual(candidate(\"7/2\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"11/6\", \"6/1\"),true);\n  assert.deepEqual(candidate(\"2/3\", \"5/2\"),false);\n  assert.deepEqual(candidate(\"5/2\", \"3/5\"),false);\n  assert.deepEqual(candidate(\"2/4\", \"8/4\"),true);\n  assert.deepEqual(candidate(\"2/4\", \"4/2\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"5/1\"),true);\n  assert.deepEqual(candidate(\"1/5\", \"1/5\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_145_order_by_points",
+    "language": "ts",
+    "prompt": "//Write a function which sorts the given list of integers\n// in ascending order according to the sum of their digits.\n// Note: if there are several items with similar sum of their digits,\n// order them based on their index in original list.\n// For example:\n// >>> order_by_points([1, 11, -1, -11, -12])\n// [-1, -11, 1, -12, 11]\n// >>> order_by_points([])\n// []\nfunction order_by_points(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_145_order_by_points.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = order_by_points;\n  assert.deepEqual(candidate([1, 11, -1, -11, -12]),[-1, -11, 1, -12, 11]);\n  assert.deepEqual(candidate([1234, 423, 463, 145, 2, 423, 423, 53, 6, 37, 3457, 3, 56, 0, 46]),[0, 2, 3, 6, 53, 423, 423, 423, 1234, 145, 37, 46, 56, 463, 3457]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, -11, -32, 43, 54, -98, 2, -3]),[-3, -32, -98, -11, 1, 2, 43, 54]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),[1, 10, 2, 11, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([0, 6, 6, -76, -21, 23, 4]),[-76, -21, 0, 4, 23, 6, 6]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2224,7 +754,7 @@
     "language": "ts",
     "prompt": "//Write a function that takes an array of numbers as input and returns \n// the number of elements in the array that are greater than 10 and both \n// first and last digits of a number are odd (1, 3, 5, 7, 9).\n// For example:\n// >>> specialFilter([15, -73, 14, -15])\n// 1\n// >>> specialFilter([33, -2, -3, 45, 21, 109])\n// 2\nfunction specialFilter(nums: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_146_specialFilter.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = specialFilter;\n  assert.deepEqual(candidate([5, -2, 1, -5]),0);\n  assert.deepEqual(candidate([15, -73, 14, -15]),1);\n  assert.deepEqual(candidate([33, -2, -3, 45, 21, 109]),2);\n  assert.deepEqual(candidate([43, -12, 93, 125, 121, 109]),4);\n  assert.deepEqual(candidate([71, -2, -33, 75, 21, 19]),3);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([]),0);\n}\n\ntest();",
     "stop_tokens": [
@@ -2235,13 +765,13 @@
     ]
   },
   {
-    "name": "HumanEval_60_sum_to_n",
+    "name": "HumanEval_147_get_max_triples",
     "language": "ts",
-    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
+    "prompt": "//You are given a positive integer n. You have to create an integer array a of length n.\n// For each i (1 \u2264 i \u2264 n), the value of a[i] = i * i - i + 1.\n// Return the number of triples (a[i], a[j], a[k]) of a where i < j < k, \n// and a[i] + a[j] + a[k] is a multiple of 3.\n// Example :\n// >>> get_max_triples(5)\n// 1\n// Explanation: \n// a = [1, 3, 7, 13, 21]\n// The only valid triple is (1, 7, 13).\nfunction get_max_triples(n: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_147_get_max_triples.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_triples;\n  assert.deepEqual(candidate(5),1);\n  assert.deepEqual(candidate(6),4);\n  assert.deepEqual(candidate(10),36);\n  assert.deepEqual(candidate(100),53361);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2250,13 +780,238 @@
     ]
   },
   {
-    "name": "HumanEval_26_remove_duplicates",
+    "name": "HumanEval_149_sorted_list_sum",
     "language": "ts",
-    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "prompt": "//Write a function that accepts a list of strings as a parameter,\n// deletes the strings that have odd lengths from it,\n// and returns the resulted list with a sorted order,\n// The list is always a list of strings and never an array of numbers,\n// and it may contain duplicates.\n// The order of the list should be ascending by length of each word, and you\n// should return the list sorted by that rule.\n// If two words have the same length, sort the list alphabetically.\n// The function should return a list of strings in sorted order.\n// You may assume that all words will have the same length.\n// For example:\n// >>> list_sort([\"aa\", \"a\", \"aaa\"])\n// [\"aa\"]\n// >>> list_sort([\"ab\", \"a\", \"aaa\", \"cd\"])\n// [\"ab\", \"cd\"]\nfunction sorted_list_sum(lst: string[]): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_149_sorted_list_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sorted_list_sum;\n  assert.deepEqual(candidate([\"aa\", \"a\", \"aaa\"]),[\"aa\"]);\n  assert.deepEqual(candidate([\"school\", \"AI\", \"asdf\", \"b\"]),[\"AI\", \"asdf\", \"school\"]);\n  assert.deepEqual(candidate([\"d\", \"b\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"d\", \"dcba\", \"abcd\", \"a\"]),[\"abcd\", \"dcba\"]);\n  assert.deepEqual(candidate([\"AI\", \"ai\", \"au\"]),[\"AI\", \"ai\", \"au\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"b\", \"c\", \"c\", \"a\"]),[]);\n  assert.deepEqual(candidate([\"aaaa\", \"bbbb\", \"dd\", \"cc\"]),[\"cc\", \"dd\", \"aaaa\", \"bbbb\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_14_all_prefixes",
+    "language": "ts",
+    "prompt": "//Return list of all prefixes from shortest to longest of the input string\n// >>> all_prefixes(\"abc\")\n// [\"a\", \"ab\", \"abc\"]\nfunction all_prefixes(string: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_14_all_prefixes.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_prefixes;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"asdfgh\"),[\"a\", \"as\", \"asd\", \"asdf\", \"asdfg\", \"asdfgh\"]);\n  assert.deepEqual(candidate(\"WWW\"),[\"W\", \"WW\", \"WWW\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_150_x_or_y",
+    "language": "ts",
+    "prompt": "//A simple program which should return the value of x if n is \n// a prime number and should return the value of y otherwise.\n// Examples:\n// >>> x_or_y(7, 34, 12)\n// 34\n// >>> x_or_y(15, 8, 5)\n// 5\nfunction x_or_y(n: number, x: number, y: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_150_x_or_y.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = x_or_y;\n  assert.deepEqual(candidate(7, 34, 12),34);\n  assert.deepEqual(candidate(15, 8, 5),5);\n  assert.deepEqual(candidate(3, 33, 5212),33);\n  assert.deepEqual(candidate(1259, 3, 52),3);\n  assert.deepEqual(candidate(7919, -1, 12),-1);\n  assert.deepEqual(candidate(3609, 1245, 583),583);\n  assert.deepEqual(candidate(91, 56, 129),129);\n  assert.deepEqual(candidate(6, 34, 1234),1234);\n  assert.deepEqual(candidate(1, 2, 0),0);\n  assert.deepEqual(candidate(2, 2, 0),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_151_double_the_difference",
+    "language": "ts",
+    "prompt": "//Given a list of numbers, return the sum of squares of the numbers\n// in the list that are odd. Ignore numbers that are negative or not integers.\n// >>> double_the_difference([1, 3, 2, 0])\n// 10\n// >>> double_the_difference([-1, -2, 0])\n// 0\n// >>> double_the_difference([9, -2])\n// 81\n// >>> double_the_difference([0])\n// 0\n// If the input list is empty, return 0.\nfunction double_the_difference(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_151_double_the_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = double_the_difference;\n  assert.deepEqual(candidate([]),0);\n  assert.deepEqual(candidate([5.0, 4.0]),25);\n  assert.deepEqual(candidate([0.1, 0.2, 0.3]),0);\n  assert.deepEqual(candidate([-10.0, -20.0, -30.0]),0);\n  assert.deepEqual(candidate([-1.0, -2.0, 8.0]),0);\n  assert.deepEqual(candidate([0.2, 3.0, 5.0]),34);\n  assert.deepEqual(candidate([-9.0, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0, 9.0]),165);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_152_compare",
+    "language": "ts",
+    "prompt": "//I think we all remember that feeling when the result of some long-awaited\n// event is finally known. The feelings and thoughts you have at that moment are\n// definitely worth noting down and comparing.\n// Your task is to determine if a person correctly guessed the results of a number of matches.\n// You are given two arrays of scores and guesses of equal length, where each index shows a match. \n// Return an array of the same length denoting how far off each guess was. If they have guessed correctly,\n// the value is 0, and if not, the value is the absolute difference between the guess and the score.\n// example:\n// >>> compare([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2])\n// [0, 0, 0, 0, 3, 3]\n// >>> compare([0, 5, 0, 0, 0, 4], [4, 1, 1, 0, 0, -2])\n// [4, 4, 1, 0, 0, 6]\nfunction compare(game: number[], guess: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_152_compare.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = compare;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 1], [1, 2, 3, 4, 2, -2]),[0, 0, 0, 0, 3, 3]);\n  assert.deepEqual(candidate([0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]),[0, 0, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([1, 2, 3], [-1, -2, -3]),[2, 4, 6]);\n  assert.deepEqual(candidate([1, 2, 3, 5], [-1, 2, 3, 4]),[2, 0, 0, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_153_Strongest_Extension",
+    "language": "ts",
+    "prompt": "//You will be given the name of a class (a string) and a list of extensions.\n// The extensions are to be used to load additional classes to the class. The\n// strength of the extension is as follows: Let CAP be the number of the uppercase\n// letters in the extension's name, and let SM be the number of lowercase letters \n// in the extension's name, the strength is given by the fraction CAP - SM. \n// You should find the strongest extension and return a string in this \n// format: ClassName.StrongestExtensionName.\n// If there are two or more extensions with the same strength, you should\n// choose the one that comes first in the list.\n// For example, if you are given \"Slices\" as the class and a list of the\n// extensions: ['SErviNGSliCes', 'Cheese', 'StuFfed'] then you should\n// return 'Slices.SErviNGSliCes' since 'SErviNGSliCes' is the strongest extension \n// (its strength is -1).\n// Example:\n// >>> Strongest_Extension(\"my_class\", [\"AA\", \"Be\", \"CC\"])\n// \"my_class.AA\"\nfunction Strongest_Extension(class_name: string, extensions: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_153_Strongest_Extension.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Strongest_Extension;\n  assert.deepEqual(candidate(\"Watashi\", [\"tEN\", \"niNE\", \"eIGHt8OKe\"]),\"Watashi.eIGHt8OKe\");\n  assert.deepEqual(candidate(\"Boku123\", [\"nani\", \"NazeDa\", \"YEs.WeCaNe\", \"32145tggg\"]),\"Boku123.YEs.WeCaNe\");\n  assert.deepEqual(candidate(\"__YESIMHERE\", [\"t\", \"eMptY\", \"nothing\", \"zeR00\", \"NuLl__\", \"123NoooneB321\"]),\"__YESIMHERE.NuLl__\");\n  assert.deepEqual(candidate(\"K\", [\"Ta\", \"TAR\", \"t234An\", \"cosSo\"]),\"K.TAR\");\n  assert.deepEqual(candidate(\"__HAHA\", [\"Tab\", \"123\", \"781345\", \"-_-\"]),\"__HAHA.123\");\n  assert.deepEqual(candidate(\"YameRore\", [\"HhAas\", \"okIWILL123\", \"WorkOut\", \"Fails\", \"-_-\"]),\"YameRore.okIWILL123\");\n  assert.deepEqual(candidate(\"finNNalLLly\", [\"Die\", \"NowW\", \"Wow\", \"WoW\"]),\"finNNalLLly.WoW\");\n  assert.deepEqual(candidate(\"_\", [\"Bb\", \"91245\"]),\"_.Bb\");\n  assert.deepEqual(candidate(\"Sp\", [\"671235\", \"Bb\"]),\"Sp.671235\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_154_cycpattern_check",
+    "language": "ts",
+    "prompt": "//You are given 2 words. You need to return True if the second word or any of its rotations is a substring in the first word\n// >>> cycpattern_check(\"abcd\", \"abd\")\n// false\n// >>> cycpattern_check(\"hello\", \"ell\")\n// true\n// >>> cycpattern_check(\"whassup\", \"psus\")\n// false\n// >>> cycpattern_check(\"abab\", \"baa\")\n// true\n// >>> cycpattern_check(\"efef\", \"eeff\")\n// false\n// >>> cycpattern_check(\"himenss\", \"simen\")\n// true\nfunction cycpattern_check(a: string, b: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_154_cycpattern_check.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cycpattern_check;\n  assert.deepEqual(candidate(\"xyzw\", \"xyw\"),false);\n  assert.deepEqual(candidate(\"yello\", \"ell\"),true);\n  assert.deepEqual(candidate(\"whattup\", \"ptut\"),false);\n  assert.deepEqual(candidate(\"efef\", \"fee\"),true);\n  assert.deepEqual(candidate(\"abab\", \"aabb\"),false);\n  assert.deepEqual(candidate(\"winemtt\", \"tinem\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_155_even_odd_count",
+    "language": "ts",
+    "prompt": "//Given an integer. return a tuple that has the number of even and odd digits respectively.\n// Example:\n// >>> even_odd_count(-12)\n// [1, 1]\n// >>> even_odd_count(123)\n// [1, 2]\nfunction even_odd_count(num: number): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_155_even_odd_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_odd_count;\n  assert.deepEqual(candidate(7),[0, 1]);\n  assert.deepEqual(candidate(-78),[1, 1]);\n  assert.deepEqual(candidate(3452),[2, 2]);\n  assert.deepEqual(candidate(346211),[3, 3]);\n  assert.deepEqual(candidate(-345821),[3, 3]);\n  assert.deepEqual(candidate(-2),[1, 0]);\n  assert.deepEqual(candidate(-45347),[2, 3]);\n  assert.deepEqual(candidate(0),[1, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_156_int_to_mini_roman",
+    "language": "ts",
+    "prompt": "//Given a positive integer, obtain its roman numeral equivalent as a string,\n// and return it in lowercase.\n// Restrictions: 1 <= num <= 1000\n// Examples:\n// >>> int_to_mini_roman(19)\n// \"xix\"\n// >>> int_to_mini_roman(152)\n// \"clii\"\n// >>> int_to_mini_roman(426)\n// \"cdxxvi\"\nfunction int_to_mini_roman(number: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_156_int_to_mini_roman.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = int_to_mini_roman;\n  assert.deepEqual(candidate(19),\"xix\");\n  assert.deepEqual(candidate(152),\"clii\");\n  assert.deepEqual(candidate(251),\"ccli\");\n  assert.deepEqual(candidate(426),\"cdxxvi\");\n  assert.deepEqual(candidate(500),\"d\");\n  assert.deepEqual(candidate(1),\"i\");\n  assert.deepEqual(candidate(4),\"iv\");\n  assert.deepEqual(candidate(43),\"xliii\");\n  assert.deepEqual(candidate(90),\"xc\");\n  assert.deepEqual(candidate(94),\"xciv\");\n  assert.deepEqual(candidate(532),\"dxxxii\");\n  assert.deepEqual(candidate(900),\"cm\");\n  assert.deepEqual(candidate(994),\"cmxciv\");\n  assert.deepEqual(candidate(1000),\"m\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_157_right_angle_triangle",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return True if the three\n// sides form a right-angled triangle, False otherwise.\n// A right-angled triangle is a triangle in which one angle is right angle or \n// 90 degree.\n// Example:\n// >>> right_angle_triangle(3, 4, 5)\n// true\n// >>> right_angle_triangle(1, 2, 3)\n// false\nfunction right_angle_triangle(a: number, b: number, c: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_157_right_angle_triangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_angle_triangle;\n  assert.deepEqual(candidate(3, 4, 5),true);\n  assert.deepEqual(candidate(1, 2, 3),false);\n  assert.deepEqual(candidate(10, 6, 8),true);\n  assert.deepEqual(candidate(2, 2, 2),false);\n  assert.deepEqual(candidate(7, 24, 25),true);\n  assert.deepEqual(candidate(10, 5, 7),false);\n  assert.deepEqual(candidate(5, 12, 13),true);\n  assert.deepEqual(candidate(15, 8, 17),true);\n  assert.deepEqual(candidate(48, 55, 73),true);\n  assert.deepEqual(candidate(1, 1, 1),false);\n  assert.deepEqual(candidate(2, 2, 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_158_find_max",
+    "language": "ts",
+    "prompt": "//Write a function that accepts a list of strings.\n// The list contains different words. Return the word with maximum number\n// of unique characters. If multiple strings have maximum number of unique\n// characters, return the one which comes first in lexicographical order.\n// >>> find_max([\"name\", \"of\", \"string\"])\n// \"string\"\n// >>> find_max([\"name\", \"enam\", \"game\"])\n// \"enam\"\n// >>> find_max([\"aaaaaaa\", \"bb\", \"cc\"])\n// \"aaaaaaa\"\nfunction find_max(words: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_158_find_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_max;\n  assert.deepEqual(candidate([\"name\", \"of\", \"string\"]),\"string\");\n  assert.deepEqual(candidate([\"name\", \"enam\", \"game\"]),\"enam\");\n  assert.deepEqual(candidate([\"aaaaaaa\", \"bb\", \"cc\"]),\"aaaaaaa\");\n  assert.deepEqual(candidate([\"abc\", \"cba\"]),\"abc\");\n  assert.deepEqual(candidate([\"play\", \"this\", \"game\", \"of\", \"footbott\"]),\"footbott\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"gonna\", \"rock\"]),\"gonna\");\n  assert.deepEqual(candidate([\"we\", \"are\", \"a\", \"mad\", \"nation\"]),\"nation\");\n  assert.deepEqual(candidate([\"this\", \"is\", \"a\", \"prrk\"]),\"this\");\n  assert.deepEqual(candidate([\"b\"]),\"b\");\n  assert.deepEqual(candidate([\"play\", \"play\", \"play\"]),\"play\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_159_eat",
+    "language": "ts",
+    "prompt": "//You're a hungry rabbit, and you already have eaten a certain number of carrots,\n// but now you need to eat more carrots to complete the day's meals.\n// you should return an array of [ total number of eaten carrots after your meals,\n// the number of carrots left after your meals ]\n// if there are not enough remaining carrots, you will eat all remaining carrots, but will still be hungry.\n// Example:\n// >>> eat(5, 6, 10)\n// [11, 4]\n// >>> eat(4, 8, 9)\n// [12, 1]\n// >>> eat(1, 10, 10)\n// [11, 0]\n// >>> eat(2, 11, 5)\n// [7, 0]\n// Variables:\n// @number : integer\n// the number of carrots that you have eaten.\n// @need : integer\n// the number of carrots that you need to eat.\n// @remaining : integer\n// the number of remaining carrots thet exist in stock\n// Constrain:\n// * 0 <= number <= 1000\n// * 0 <= need <= 1000\n// * 0 <= remaining <= 1000\n// Have fun :)\nfunction eat(number: number, need: number, remaining: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_159_eat.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eat;\n  assert.deepEqual(candidate(5, 6, 10),[11, 4]);\n  assert.deepEqual(candidate(4, 8, 9),[12, 1]);\n  assert.deepEqual(candidate(1, 10, 10),[11, 0]);\n  assert.deepEqual(candidate(2, 11, 5),[7, 0]);\n  assert.deepEqual(candidate(4, 5, 7),[9, 2]);\n  assert.deepEqual(candidate(4, 5, 1),[5, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_15_string_sequence",
+    "language": "ts",
+    "prompt": "//Return a string containing space-delimited numbers starting from 0 upto n inclusive.\n// >>> string_sequence(0)\n// \"0\"\n// >>> string_sequence(5)\n// \"0 1 2 3 4 5\"\nfunction string_sequence(n: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_15_string_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_sequence;\n  assert.deepEqual(candidate(0),\"0\");\n  assert.deepEqual(candidate(3),\"0 1 2 3\");\n  assert.deepEqual(candidate(10),\"0 1 2 3 4 5 6 7 8 9 10\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_160_do_algebra",
+    "language": "ts",
+    "prompt": "//Given two lists operator, and operand. The first list has basic algebra operations, and \n// the second list is a list of integers. Use the two given lists to build the algebric \n// expression and return the evaluation of this expression.\n// The basic algebra operations:\n// Addition ( + ) \n// Subtraction ( - ) \n// Multiplication ( * ) \n// Floor division ( // ) \n// Exponentiation ( ** ) \n// Example:\n// operator['+', '*', '-']\n// array = [2, 3, 4, 5]\n// result = 2 + 3 * 4 - 5\n// => result = 9\n// Note:\n// The length of operator list is equal to the length of operand list minus one.\n// Operand is a list of of non-negative integers.\n// Operator list has at least one operator, and operand list has at least two operands.\nfunction do_algebra(operator: string[], operand: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_160_do_algebra.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = do_algebra;\n  assert.deepEqual(candidate([\"**\", \"*\", \"+\"], [2, 3, 4, 5]),37);\n  assert.deepEqual(candidate([\"+\", \"*\", \"-\"], [2, 3, 4, 5]),9);\n  assert.deepEqual(candidate([\"//\", \"*\"], [7, 3, 4]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_161_solve",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// if s[i] is a letter, reverse its case from lower to upper or vise versa, \n// otherwise keep it as it is.\n// If the string contains no letters, reverse the string.\n// The function should return the resulted string.\n// Examples\n// >>> solve(\"1234\")\n// \"4321\"\n// >>> solve(\"ab\")\n// \"AB\"\n// >>> solve(\"#a@C\")\n// \"#A@c\"\nfunction solve(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_161_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(\"AsDf\"),\"aSdF\");\n  assert.deepEqual(candidate(\"1234\"),\"4321\");\n  assert.deepEqual(candidate(\"ab\"),\"AB\");\n  assert.deepEqual(candidate(\"#a@C\"),\"#A@c\");\n  assert.deepEqual(candidate(\"#AsdfW^45\"),\"#aSDFw^45\");\n  assert.deepEqual(candidate(\"#6@2\"),\"2@6#\");\n  assert.deepEqual(candidate(\"#$a^D\"),\"#$A^d\");\n  assert.deepEqual(candidate(\"#ccc\"),\"#CCC\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_162_string_to_md5",
+    "language": "ts",
+    "prompt": "//Given a string 'text', return its md5 hash equivalent string.\n// If 'text' is an empty string, return None.\n// >>> string_to_md5(\"Hello world\")\n// \"3e25960a79dbc69b674cd4ec67a72c62\"\nfunction string_to_md5(text: string): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_162_string_to_md5.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_md5;\n  assert.deepEqual(candidate(\"Hello world\"),\"3e25960a79dbc69b674cd4ec67a72c62\");\n  assert.deepEqual(candidate(\"\"),undefined);\n  assert.deepEqual(candidate(\"A B C\"),\"0ef78513b0cb8cef12743f5aeb35f888\");\n  assert.deepEqual(candidate(\"password\"),\"5f4dcc3b5aa765d61d8327deb882cf99\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2269,7 +1024,7 @@
     "language": "ts",
     "prompt": "//Given two positive integers a and b, return the even digits between a\n// and b, in ascending order.\n// For example:\n// >>> generate_integers(2, 8)\n// [2, 4, 6, 8]\n// >>> generate_integers(8, 2)\n// [2, 4, 6, 8]\n// >>> generate_integers(10, 14)\n// []\nfunction generate_integers(a: number, b: number): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_163_generate_integers.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = generate_integers;\n  assert.deepEqual(candidate(2, 10),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(10, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(132, 2),[2, 4, 6, 8]);\n  assert.deepEqual(candidate(17, 89),[]);\n}\n\ntest();",
     "stop_tokens": [
@@ -2280,13 +1035,13 @@
     ]
   },
   {
-    "name": "HumanEval_9_rolling_max",
+    "name": "HumanEval_16_count_distinct_characters",
     "language": "ts",
-    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "prompt": "//Given a string, find out how many distinct characters (regardless of case) does it consist of\n// >>> count_distinct_characters(\"xyzXYZ\")\n// 3\n// >>> count_distinct_characters(\"Jerry\")\n// 4\nfunction count_distinct_characters(string: string): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_16_count_distinct_characters.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_distinct_characters;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abcde\"),5);\n  assert.deepEqual(candidate(\"abcdecadeCADE\"),5);\n  assert.deepEqual(candidate(\"aaaaAAAAaaaa\"),1);\n  assert.deepEqual(candidate(\"Jerry jERRY JeRRRY\"),5);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2295,13 +1050,13 @@
     ]
   },
   {
-    "name": "HumanEval_3_below_zero",
+    "name": "HumanEval_17_parse_music",
     "language": "ts",
-    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations: number[]): boolean {\n",
+    "prompt": "//Input to this function is a string representing musical notes in a special ASCII format.\n// Your task is to parse this string and return list of integers corresponding to how many beats does each\n// not last.\n// Here is a legend:\n// 'o' - whole note, lasts four beats\n// 'o|' - half note, lasts two beats\n// '.|' - quater note, lasts one beat\n// >>> parse_music(\"o o| .| o| o| .| .| .| .| o o\")\n// [4, 2, 1, 2, 2, 1, 1, 1, 1, 4, 4]\nfunction parse_music(music_string: string): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_17_parse_music.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_music;\n  assert.deepEqual(candidate(\"\"),[]);\n  assert.deepEqual(candidate(\"o o o o\"),[4, 4, 4, 4]);\n  assert.deepEqual(candidate(\".| .| .| .|\"),[1, 1, 1, 1]);\n  assert.deepEqual(candidate(\"o| o| .| .| o o o o\"),[2, 2, 1, 1, 4, 4, 4, 4]);\n  assert.deepEqual(candidate(\"o| .| o| .| o o| o o|\"),[2, 1, 2, 1, 4, 2, 4, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2310,13 +1065,13 @@
     ]
   },
   {
-    "name": "HumanEval_69_search",
+    "name": "HumanEval_18_how_many_times",
     "language": "ts",
-    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst: number[]): number {\n",
+    "prompt": "//Find how many times a given substring can be found in the original string. Count overlaping cases.\n// >>> how_many_times(\"\", \"a\")\n// 0\n// >>> how_many_times(\"aaa\", \"a\")\n// 3\n// >>> how_many_times(\"aaaa\", \"aa\")\n// 3\nfunction how_many_times(string: string, substring: string): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_18_how_many_times.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = how_many_times;\n  assert.deepEqual(candidate(\"\", \"x\"),0);\n  assert.deepEqual(candidate(\"xyxyxyx\", \"x\"),4);\n  assert.deepEqual(candidate(\"cacacacac\", \"cac\"),4);\n  assert.deepEqual(candidate(\"john doe\", \"john\"),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2325,13 +1080,283 @@
     ]
   },
   {
-    "name": "HumanEval_61_correct_bracketing",
+    "name": "HumanEval_19_sort_numbers",
     "language": "ts",
-    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "prompt": "//Input is a space-delimited string of numberals from 'zero' to 'nine'.\n// Valid choices are 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight' and 'nine'.\n// Return the string with numbers sorted from smallest to largest\n// >>> sort_numbers(\"three one five\")\n// \"one three five\"\nfunction sort_numbers(numbers: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_19_sort_numbers.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numbers;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"three\"),\"three\");\n  assert.deepEqual(candidate(\"three five nine\"),\"three five nine\");\n  assert.deepEqual(candidate(\"five zero four seven nine eight\"),\"zero four five seven eight nine\");\n  assert.deepEqual(candidate(\"six five four three two one zero\"),\"zero one two three four five six\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_1_separate_paren_groups",
+    "language": "ts",
+    "prompt": "//Input to this function is a string containing multiple groups of nested parentheses. Your goal is to\n// separate those group into separate strings and return the list of those.\n// Separate groups are balanced (each open brace is properly closed) and not nested within each other\n// Ignore any spaces in the input string.\n// >>> separate_paren_groups(\"( ) (( )) (( )( ))\")\n// [\"()\", \"(())\", \"(()())\"]\nfunction separate_paren_groups(paren_string: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_1_separate_paren_groups.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = separate_paren_groups;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[\"(()())\", \"((()))\", \"()\", \"((())()())\"]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[\"()\", \"(())\", \"((()))\", \"(((())))\"]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[\"(()(())((())))\"]);\n  assert.deepEqual(candidate(\"( ) (( )) (( )( ))\"),[\"()\", \"(())\", \"(()())\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_20_find_closest_elements",
+    "language": "ts",
+    "prompt": "//From a supplied list of numbers (of length at least two) select and return two that are the closest to each\n// other and return them in order (smaller number, larger number).\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.2])\n// [2.0, 2.2]\n// >>> find_closest_elements([1.0, 2.0, 3.0, 4.0, 5.0, 2.0])\n// [2.0, 2.0]\nfunction find_closest_elements(numbers: number[]): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_20_find_closest_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_closest_elements;\n  assert.deepEqual(candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2]),[3.9, 4.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 5.9, 4.0, 5.0]),[5.0, 5.9]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.2]),[2.0, 2.2]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0]),[2.0, 2.0]);\n  assert.deepEqual(candidate([1.1, 2.2, 3.1, 4.1, 5.1]),[2.2, 3.1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_21_rescale_to_unit",
+    "language": "ts",
+    "prompt": "//Given list of numbers (of at least two elements), apply a linear transform to that list,\n// such that the smallest number will become 0 and the largest will become 1\n// >>> rescale_to_unit([1.0, 2.0, 3.0, 4.0, 5.0])\n// [0.0, 0.25, 0.5, 0.75, 1.0]\nfunction rescale_to_unit(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_21_rescale_to_unit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rescale_to_unit;\n  assert.deepEqual(candidate([2.0, 49.9]),[0.0, 1.0]);\n  assert.deepEqual(candidate([100.0, 49.9]),[1.0, 0.0]);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),[0.0, 0.25, 0.5, 0.75, 1.0]);\n  assert.deepEqual(candidate([2.0, 1.0, 5.0, 3.0, 4.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n  assert.deepEqual(candidate([12.0, 11.0, 15.0, 13.0, 14.0]),[0.25, 0.0, 1.0, 0.5, 0.75]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_22_filter_integers",
+    "language": "ts",
+    "prompt": "//Filter given list of any python values only for integers\n// >>> filter_integers([\"a\", 3.14, 5])\n// [5]\n// >>> filter_integers([1, 2, 3, \"abc\", {}, []])\n// [1, 2, 3]\nfunction filter_integers(values: any[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_22_filter_integers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_integers;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([4, {}, [], 23.2, 9, \"adasd\"]),[4, 9]);\n  assert.deepEqual(candidate([3, \"c\", 3, 3, \"a\", \"b\"]),[3, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_23_strlen",
+    "language": "ts",
+    "prompt": "//Return length of given string\n// >>> strlen(\"\")\n// 0\n// >>> strlen(\"abc\")\n// 3\nfunction strlen(string: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_23_strlen.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strlen;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"x\"),1);\n  assert.deepEqual(candidate(\"asdasnakj\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_24_largest_divisor",
+    "language": "ts",
+    "prompt": "//For a given number n, find the largest number that divides n evenly, smaller than n\n// >>> largest_divisor(15)\n// 5\nfunction largest_divisor(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_24_largest_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_divisor;\n  assert.deepEqual(candidate(3),1);\n  assert.deepEqual(candidate(7),1);\n  assert.deepEqual(candidate(10),5);\n  assert.deepEqual(candidate(100),50);\n  assert.deepEqual(candidate(49),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_25_factorize",
+    "language": "ts",
+    "prompt": "//Return list of prime factors of given integer in the order from smallest to largest.\n// Each of the factors should be listed number of times corresponding to how many times it appeares in factorization.\n// Input number should be equal to the product of all factors\n// >>> factorize(8)\n// [2, 2, 2]\n// >>> factorize(25)\n// [5, 5]\n// >>> factorize(70)\n// [2, 5, 7]\nfunction factorize(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_25_factorize.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = factorize;\n  assert.deepEqual(candidate(2),[2]);\n  assert.deepEqual(candidate(4),[2, 2]);\n  assert.deepEqual(candidate(8),[2, 2, 2]);\n  assert.deepEqual(candidate(57),[3, 19]);\n  assert.deepEqual(candidate(3249),[3, 3, 19, 19]);\n  assert.deepEqual(candidate(185193),[3, 3, 3, 19, 19, 19]);\n  assert.deepEqual(candidate(20577),[3, 19, 19, 19]);\n  assert.deepEqual(candidate(18),[2, 3, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_26_remove_duplicates",
+    "language": "ts",
+    "prompt": "//From a list of integers, remove all elements that occur more than once.\n// Keep order of elements left the same as in the input.\n// >>> remove_duplicates([1, 2, 3, 2, 4])\n// [1, 3, 4]\nfunction remove_duplicates(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_26_remove_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_duplicates;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 3, 5]),[1, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_27_flip_case",
+    "language": "ts",
+    "prompt": "//For a given string, flip lowercase characters to uppercase and uppercase to lowercase.\n// >>> flip_case(\"Hello\")\n// \"hELLO\"\nfunction flip_case(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_27_flip_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flip_case;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hello!\"),\"hELLO!\");\n  assert.deepEqual(candidate(\"These violent delights have violent ends\"),\"tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_28_concatenate",
+    "language": "ts",
+    "prompt": "//Concatenate list of strings into a single string\n// >>> concatenate([])\n// \"\"\n// >>> concatenate([\"a\", \"b\", \"c\"])\n// \"abc\"\nfunction concatenate(strings: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_28_concatenate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate;\n  assert.deepEqual(candidate([]),\"\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\"]),\"xyz\");\n  assert.deepEqual(candidate([\"x\", \"y\", \"z\", \"w\", \"k\"]),\"xyzwk\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_29_filter_by_prefix",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that start with a given prefix.\n// >>> filter_by_prefix([], \"a\")\n// []\n// >>> filter_by_prefix([\"abc\", \"bcd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"array\"]\nfunction filter_by_prefix(strings: string[], prefix: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_29_filter_by_prefix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_prefix;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_2_truncate_number",
+    "language": "ts",
+    "prompt": "//Given a positive floating point number, it can be decomposed into\n// and integer part (largest integer smaller than given number) and decimals\n// (leftover part always smaller than 1).\n// Return the decimal part of the number.\n// >>> truncate_number(3.5)\n// 0.5\nfunction truncate_number(number: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_2_truncate_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = truncate_number;\n  assert.deepEqual(candidate(3.5),0.5);\n  assert.deepEqual(candidate(1.25),0.25);\n  assert.deepEqual(candidate(123.0),0.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_30_get_positive",
+    "language": "ts",
+    "prompt": "//Return only positive numbers in the list.\n// >>> get_positive([-1, 2, -4, 5, 6])\n// [2, 5, 6]\n// >>> get_positive([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// [5, 3, 2, 3, 9, 123, 1]\nfunction get_positive(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_30_get_positive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_positive;\n  assert.deepEqual(candidate([-1, -2, 4, 5, 6]),[4, 5, 6]);\n  assert.deepEqual(candidate([5, 3, -5, 2, 3, 3, 9, 0, 123, 1, -10]),[5, 3, 2, 3, 3, 9, 123, 1]);\n  assert.deepEqual(candidate([-1, -2]),[]);\n  assert.deepEqual(candidate([]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_31_is_prime",
+    "language": "ts",
+    "prompt": "//Return true if a given number is prime, and false otherwise.\n// >>> is_prime(6)\n// false\n// >>> is_prime(101)\n// true\n// >>> is_prime(11)\n// true\n// >>> is_prime(13441)\n// true\n// >>> is_prime(61)\n// true\n// >>> is_prime(4)\n// false\n// >>> is_prime(1)\n// false\nfunction is_prime(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_31_is_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_prime;\n  assert.deepEqual(candidate(6),false);\n  assert.deepEqual(candidate(101),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(13441),true);\n  assert.deepEqual(candidate(61),true);\n  assert.deepEqual(candidate(4),false);\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(11),true);\n  assert.deepEqual(candidate(17),true);\n  assert.deepEqual(candidate(85),false);\n  assert.deepEqual(candidate(77),false);\n  assert.deepEqual(candidate(255379),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_33_sort_third",
+    "language": "ts",
+    "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the indicies that are not divisible by three, while its values at the indicies that are divisible by three are equal\n// to the values of the corresponding indicies of l, but sorted.\n// >>> sort_third([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_third([5, 6, 3, 4, 8, 9, 2])\n// [2, 6, 3, 4, 8, 9, 5]\nfunction sort_third(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_33_sort_third.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_third;\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2]),[2, 6, 3, 4, 8, 9, 5]);\n  assert.deepEqual(candidate([5, 8, 3, 4, 6, 9, 2]),[2, 8, 3, 4, 6, 9, 5]);\n  assert.deepEqual(candidate([5, 6, 9, 4, 8, 3, 2]),[2, 6, 9, 4, 8, 3, 5]);\n  assert.deepEqual(candidate([5, 6, 3, 4, 8, 9, 2, 1]),[2, 6, 3, 4, 8, 9, 5, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_34_unique",
+    "language": "ts",
+    "prompt": "//Return sorted unique elements in a list\n// >>> unique([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [0, 2, 3, 5, 9, 123]\nfunction unique(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_34_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique;\n  assert.deepEqual(candidate([5, 3, 5, 2, 3, 3, 9, 0, 123]),[0, 2, 3, 5, 9, 123]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_35_max_element",
+    "language": "ts",
+    "prompt": "//Return maximum element in the list.\n// >>> max_element([1, 2, 3])\n// 3\n// >>> max_element([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10])\n// 123\nfunction max_element(l: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_35_max_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_element;\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 124, 1, -10]),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_36_fizz_buzz",
+    "language": "ts",
+    "prompt": "//Return the number of times the digit 7 appears in integers less than n which are divisible by 11 or 13.\n// >>> fizz_buzz(50)\n// 0\n// >>> fizz_buzz(78)\n// 2\n// >>> fizz_buzz(79)\n// 3\nfunction fizz_buzz(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_36_fizz_buzz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fizz_buzz;\n  assert.deepEqual(candidate(50),0);\n  assert.deepEqual(candidate(78),2);\n  assert.deepEqual(candidate(79),3);\n  assert.deepEqual(candidate(100),3);\n  assert.deepEqual(candidate(200),6);\n  assert.deepEqual(candidate(4000),192);\n  assert.deepEqual(candidate(10000),639);\n  assert.deepEqual(candidate(100000),8026);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2344,9 +1369,249 @@
     "language": "ts",
     "prompt": "//This function takes a list l and returns a list l' such that\n// l' is identical to l in the odd indicies, while its values at the even indicies are equal\n// to the values of the even indicies of l, but sorted.\n// >>> sort_even([1, 2, 3])\n// [1, 2, 3]\n// >>> sort_even([5, 6, 3, 4])\n// [3, 6, 5, 4]\nfunction sort_even(l: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_37_sort_even.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_even;\n  assert.deepEqual(candidate([1, 2, 3]),[1, 2, 3]);\n  assert.deepEqual(candidate([5, 3, -5, 2, -3, 3, 9, 0, 123, 1, -10]),[-10, 3, -5, 2, -3, 3, 5, 0, 9, 1, 123]);\n  assert.deepEqual(candidate([5, 8, -12, 4, 23, 2, 3, 11, 12, -10]),[-12, 8, 3, 4, 5, 2, 12, 11, 23, -10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_39_prime_fib",
+    "language": "ts",
+    "prompt": "//prime_fib returns n-th number that is a Fibonacci number and it's also prime.\n// >>> prime_fib(1)\n// 2\n// >>> prime_fib(2)\n// 3\n// >>> prime_fib(3)\n// 5\n// >>> prime_fib(4)\n// 13\n// >>> prime_fib(5)\n// 89\nfunction prime_fib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_39_prime_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_fib;\n  assert.deepEqual(candidate(1),2);\n  assert.deepEqual(candidate(2),3);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),13);\n  assert.deepEqual(candidate(5),89);\n  assert.deepEqual(candidate(6),233);\n  assert.deepEqual(candidate(7),1597);\n  assert.deepEqual(candidate(8),28657);\n  assert.deepEqual(candidate(9),514229);\n  assert.deepEqual(candidate(10),433494437);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_3_below_zero",
+    "language": "ts",
+    "prompt": "//You're given a list of deposit and withdrawal operations on a bank account that starts with\n// zero balance. Your task is to detect if at any point the balance of account fallls below zero, and\n// at that point function should return True. Otherwise it should return False.\n// >>> below_zero([1, 2, 3])\n// false\n// >>> below_zero([1, 2, -4, 5])\n// true\nfunction below_zero(operations: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_3_below_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_zero;\n  assert.deepEqual(candidate([]),false);\n  assert.deepEqual(candidate([1, 2, -3, 1, 2, -3]),false);\n  assert.deepEqual(candidate([1, 2, -4, 5, 6]),true);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -4]),false);\n  assert.deepEqual(candidate([1, -1, 2, -2, 5, -5, 4, -5]),true);\n  assert.deepEqual(candidate([1, -2, 2, -2, 5, -5, 4, -4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_40_triples_sum_to_zero",
+    "language": "ts",
+    "prompt": "//triples_sum_to_zero takes a list of integers as an input.\n// it returns True if there are three distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> triples_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> triples_sum_to_zero([1, 3, -2, 1])\n// true\n// >>> triples_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> triples_sum_to_zero([2, 4, -5, 3, 9, 7])\n// true\n// >>> triples_sum_to_zero([1])\n// false\nfunction triples_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_40_triples_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triples_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, 5, -1]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),true);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([1, 2, 5, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 9, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([1, 3, 5, -100]),false);\n  assert.deepEqual(candidate([100, 3, 5, -100]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_41_car_race_collision",
+    "language": "ts",
+    "prompt": "//Imagine a road that's a perfectly straight infinitely long line.\n// n cars are driving left to right;  simultaneously, a different set of n cars\n// are driving right to left.   The two sets of cars start out being very far from\n// each other.  All cars move in the same speed.  Two cars are said to collide\n// when a car that's moving left to right hits a car that's moving right to left.\n// However, the cars are infinitely sturdy and strong; as a result, they continue moving\n// in their trajectory as if they did not collide.\n// This function outputs the number of such collisions.\nfunction car_race_collision(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_41_car_race_collision.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = car_race_collision;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),9);\n  assert.deepEqual(candidate(4),16);\n  assert.deepEqual(candidate(8),64);\n  assert.deepEqual(candidate(10),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_42_incr_list",
+    "language": "ts",
+    "prompt": "//Return list with elements incremented by 1.\n// >>> incr_list([1, 2, 3])\n// [2, 3, 4]\n// >>> incr_list([5, 3, 5, 2, 3, 3, 9, 0, 123])\n// [6, 4, 6, 3, 4, 4, 10, 1, 124]\nfunction incr_list(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_42_incr_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = incr_list;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([3, 2, 1]),[4, 3, 2]);\n  assert.deepEqual(candidate([5, 2, 5, 2, 3, 3, 9, 0, 123]),[6, 3, 6, 3, 4, 4, 10, 1, 124]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_43_pairs_sum_to_zero",
+    "language": "ts",
+    "prompt": "//pairs_sum_to_zero takes a list of integers as an input.\n// it returns True if there are two distinct elements in the list that\n// sum to zero, and False otherwise.\n// >>> pairs_sum_to_zero([1, 3, 5, 0])\n// false\n// >>> pairs_sum_to_zero([1, 3, -2, 1])\n// false\n// >>> pairs_sum_to_zero([1, 2, 3, 7])\n// false\n// >>> pairs_sum_to_zero([2, 4, -5, 3, 5, 7])\n// true\n// >>> pairs_sum_to_zero([1])\n// false\nfunction pairs_sum_to_zero(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_43_pairs_sum_to_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pairs_sum_to_zero;\n  assert.deepEqual(candidate([1, 3, 5, 0]),false);\n  assert.deepEqual(candidate([1, 3, -2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3, 7]),false);\n  assert.deepEqual(candidate([2, 4, -5, 3, 5, 7]),true);\n  assert.deepEqual(candidate([1]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 30]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 3, 2, 31]),true);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 30]),false);\n  assert.deepEqual(candidate([-3, 9, -1, 4, 2, 31]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_44_change_base",
+    "language": "ts",
+    "prompt": "//Change numerical base of input number x to base.\n// return string representation after the conversion.\n// base numbers are less than 10.\n// >>> change_base(8, 3)\n// \"22\"\n// >>> change_base(8, 2)\n// \"1000\"\n// >>> change_base(7, 2)\n// \"111\"\nfunction change_base(x: number, base: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_44_change_base.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_base;\n  assert.deepEqual(candidate(8, 3),\"22\");\n  assert.deepEqual(candidate(9, 3),\"100\");\n  assert.deepEqual(candidate(234, 2),\"11101010\");\n  assert.deepEqual(candidate(16, 2),\"10000\");\n  assert.deepEqual(candidate(8, 2),\"1000\");\n  assert.deepEqual(candidate(7, 2),\"111\");\n  assert.deepEqual(candidate(2, 3),\"2\");\n  assert.deepEqual(candidate(3, 4),\"3\");\n  assert.deepEqual(candidate(4, 5),\"4\");\n  assert.deepEqual(candidate(5, 6),\"5\");\n  assert.deepEqual(candidate(6, 7),\"6\");\n  assert.deepEqual(candidate(7, 8),\"7\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_45_triangle_area",
+    "language": "ts",
+    "prompt": "//Given length of a side and high return area for a triangle.\n// >>> triangle_area(5, 3)\n// 7.5\nfunction triangle_area(a: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_45_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(5, 3),7.5);\n  assert.deepEqual(candidate(2, 2),2.0);\n  assert.deepEqual(candidate(10, 8),40.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_46_fib4",
+    "language": "ts",
+    "prompt": "//The Fib4 number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fib4(0) -> 0\n// fib4(1) -> 0\n// fib4(2) -> 2\n// fib4(3) -> 0\n// fib4(n) -> fib4(n-1) + fib4(n-2) + fib4(n-3) + fib4(n-4).\n// Please write a function to efficiently compute the n-th element of the fib4 number sequence.  Do not use recursion.\n// >>> fib4(5)\n// 4\n// >>> fib4(6)\n// 8\n// >>> fib4(7)\n// 14\nfunction fib4(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_46_fib4.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib4;\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),28);\n  assert.deepEqual(candidate(10),104);\n  assert.deepEqual(candidate(12),386);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_47_median",
+    "language": "ts",
+    "prompt": "//Return median of elements in the list l.\n// >>> median([3, 1, 2, 4, 5])\n// 3\n// >>> median([-10, 4, 6, 1000, 10, 20])\n// 15.0\nfunction median(l: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_47_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),3);\n  assert.deepEqual(candidate([-10, 4, 6, 1000, 10, 20]),8.0);\n  assert.deepEqual(candidate([5]),5);\n  assert.deepEqual(candidate([6, 5]),5.5);\n  assert.deepEqual(candidate([8, 1, 3, 9, 9, 2, 7]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_48_is_palindrome",
+    "language": "ts",
+    "prompt": "//Checks if given string is a palindrome\n// >>> is_palindrome(\"\")\n// true\n// >>> is_palindrome(\"aba\")\n// true\n// >>> is_palindrome(\"aaaaa\")\n// true\n// >>> is_palindrome(\"zbcd\")\n// false\nfunction is_palindrome(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_48_is_palindrome.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_palindrome;\n  assert.deepEqual(candidate(\"\"),true);\n  assert.deepEqual(candidate(\"aba\"),true);\n  assert.deepEqual(candidate(\"aaaaa\"),true);\n  assert.deepEqual(candidate(\"zbcd\"),false);\n  assert.deepEqual(candidate(\"xywyx\"),true);\n  assert.deepEqual(candidate(\"xywyz\"),false);\n  assert.deepEqual(candidate(\"xywzx\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_49_modp",
+    "language": "ts",
+    "prompt": "//Return 2^n modulo p (be aware of numerics).\n// >>> modp(3, 5)\n// 3\n// >>> modp(1101, 101)\n// 2\n// >>> modp(0, 101)\n// 1\n// >>> modp(3, 11)\n// 8\n// >>> modp(100, 101)\n// 1\nfunction modp(n: number, p: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_49_modp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = modp;\n  assert.deepEqual(candidate(3, 5),3);\n  assert.deepEqual(candidate(1101, 101),2);\n  assert.deepEqual(candidate(0, 101),1);\n  assert.deepEqual(candidate(3, 11),8);\n  assert.deepEqual(candidate(100, 101),1);\n  assert.deepEqual(candidate(30, 5),4);\n  assert.deepEqual(candidate(31, 5),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_4_mean_absolute_deviation",
+    "language": "ts",
+    "prompt": "//For a given list of input numbers, calculate Mean Absolute Deviation\n// around the mean of this dataset.\n// Mean Absolute Deviation is the average absolute difference between each\n// element and a centerpoint (mean in this case):\n// MAD = average | x - x_mean |\n// >>> mean_absolute_deviation([1.0, 2.0, 3.0, 4.0])\n// 1.0\nfunction mean_absolute_deviation(numbers: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_4_mean_absolute_deviation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mean_absolute_deviation;\n  assert.deepEqual(candidate([1.0, 2.0]),0.5);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0]),1.0);\n  assert.deepEqual(candidate([1.0, 2.0, 3.0, 4.0, 5.0]),1.2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_51_remove_vowels",
+    "language": "ts",
+    "prompt": "//remove_vowels is a function that takes string and returns string without vowels.\n// >>> remove_vowels(\"\")\n// \"\"\n// >>> remove_vowels(\"abcdef\")\n// \"bcdf\"\n// >>> remove_vowels(\"aaaaa\")\n// \"\"\n// >>> remove_vowels(\"aaBAA\")\n// \"B\"\n// >>> remove_vowels(\"zbcd\")\n// \"zbcd\"\nfunction remove_vowels(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_51_remove_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_vowels;\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"abcdef\\nghijklm\"),\"bcdf\\nghjklm\");\n  assert.deepEqual(candidate(\"fedcba\"),\"fdcb\");\n  assert.deepEqual(candidate(\"eeeee\"),\"\");\n  assert.deepEqual(candidate(\"acBAA\"),\"cB\");\n  assert.deepEqual(candidate(\"EcBOO\"),\"cB\");\n  assert.deepEqual(candidate(\"ybcd\"),\"ybcd\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_52_below_threshold",
+    "language": "ts",
+    "prompt": "//Return True if all numbers in the list l are below threshold t.\n// >>> below_threshold([1, 2, 4, 10], 100)\n// true\n// >>> below_threshold([1, 20, 4, 10], 5)\n// false\nfunction below_threshold(l: number[], t: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_52_below_threshold.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = below_threshold;\n  assert.deepEqual(candidate([1, 2, 4, 10], 100),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 5),false);\n  assert.deepEqual(candidate([1, 20, 4, 10], 21),true);\n  assert.deepEqual(candidate([1, 20, 4, 10], 22),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 11),true);\n  assert.deepEqual(candidate([1, 8, 4, 10], 10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_53_add",
+    "language": "ts",
+    "prompt": "//Add two numbers x and y\n// >>> add(2, 3)\n// 5\n// >>> add(5, 7)\n// 12\nfunction add(x: number, y: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_53_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate(0, 1),1);\n  assert.deepEqual(candidate(1, 0),1);\n  assert.deepEqual(candidate(2, 3),5);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 5),12);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2359,9 +1624,24 @@
     "language": "ts",
     "prompt": "//Check if two words have the same characters.\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\")\n// true\n// >>> same_chars(\"abcd\", \"dddddddabc\")\n// true\n// >>> same_chars(\"dddddddabc\", \"abcd\")\n// true\n// >>> same_chars(\"eabcd\", \"dddddddabc\")\n// false\n// >>> same_chars(\"abcd\", \"dddddddabce\")\n// false\n// >>> same_chars(\"eabcdzzzz\", \"dddzzzzzzzddddabc\")\n// false\nfunction same_chars(s0: string, s1: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_54_same_chars.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = same_chars;\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddeddabc\"),true);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabc\"),true);\n  assert.deepEqual(candidate(\"dddddddabc\", \"abcd\"),true);\n  assert.deepEqual(candidate(\"eabcd\", \"dddddddabc\"),false);\n  assert.deepEqual(candidate(\"abcd\", \"dddddddabcf\"),false);\n  assert.deepEqual(candidate(\"eabcdzzzz\", \"dddzzzzzzzddddabc\"),false);\n  assert.deepEqual(candidate(\"aabb\", \"aaccc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_55_fib",
+    "language": "ts",
+    "prompt": "//Return n-th Fibonacci number.\n// >>> fib(10)\n// 55\n// >>> fib(1)\n// 1\n// >>> fib(8)\n// 21\nfunction fib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_55_fib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fib;\n  assert.deepEqual(candidate(10),55);\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(8),21);\n  assert.deepEqual(candidate(11),89);\n  assert.deepEqual(candidate(12),144);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -2374,9 +1654,729 @@
     "language": "ts",
     "prompt": "//brackets is a string of \"<\" and \">\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"<\")\n// false\n// >>> correct_bracketing(\"<>\")\n// true\n// >>> correct_bracketing(\"<<><>>\")\n// true\n// >>> correct_bracketing(\"><<>\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_56_correct_bracketing.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"<>\"),true);\n  assert.deepEqual(candidate(\"<<><>>\"),true);\n  assert.deepEqual(candidate(\"<><><<><>><>\"),true);\n  assert.deepEqual(candidate(\"<><><<<><><>><>><<><><<>>>\"),true);\n  assert.deepEqual(candidate(\"<<<><>>>>\"),false);\n  assert.deepEqual(candidate(\"><<>\"),false);\n  assert.deepEqual(candidate(\"<\"),false);\n  assert.deepEqual(candidate(\"<<<<\"),false);\n  assert.deepEqual(candidate(\">\"),false);\n  assert.deepEqual(candidate(\"<<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>><<>\"),false);\n  assert.deepEqual(candidate(\"<><><<><>><>>><>\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_57_monotonic",
+    "language": "ts",
+    "prompt": "//Return True is list elements are monotonically increasing or decreasing.\n// >>> monotonic([1, 2, 4, 20])\n// true\n// >>> monotonic([1, 20, 4, 10])\n// false\n// >>> monotonic([4, 1, 0, -10])\n// true\nfunction monotonic(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_57_monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = monotonic;\n  assert.deepEqual(candidate([1, 2, 4, 10]),true);\n  assert.deepEqual(candidate([1, 2, 4, 20]),true);\n  assert.deepEqual(candidate([1, 20, 4, 10]),false);\n  assert.deepEqual(candidate([4, 1, 0, -10]),true);\n  assert.deepEqual(candidate([4, 1, 1, 0]),true);\n  assert.deepEqual(candidate([1, 2, 3, 2, 5, 60]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 60]),true);\n  assert.deepEqual(candidate([9, 9, 9, 9]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_58_common",
+    "language": "ts",
+    "prompt": "//Return sorted unique common elements for two lists.\n// >>> common([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121])\n// [1, 5, 653]\n// >>> common([5, 3, 2, 8], [3, 2])\n// [2, 3]\nfunction common(l1: number[], l2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_58_common.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common;\n  assert.deepEqual(candidate([1, 4, 3, 34, 653, 2, 5], [5, 7, 1, 5, 9, 653, 121]),[1, 5, 653]);\n  assert.deepEqual(candidate([5, 3, 2, 8], [3, 2]),[2, 3]);\n  assert.deepEqual(candidate([4, 3, 2, 8], [3, 2, 4]),[2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 8], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_59_largest_prime_factor",
+    "language": "ts",
+    "prompt": "//Return the largest prime factor of n. Assume n > 1 and is not a prime.\n// >>> largest_prime_factor(13195)\n// 29\n// >>> largest_prime_factor(2048)\n// 2\nfunction largest_prime_factor(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_59_largest_prime_factor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_prime_factor;\n  assert.deepEqual(candidate(15),5);\n  assert.deepEqual(candidate(27),3);\n  assert.deepEqual(candidate(63),7);\n  assert.deepEqual(candidate(330),11);\n  assert.deepEqual(candidate(13195),29);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_5_intersperse",
+    "language": "ts",
+    "prompt": "//Insert a number 'delimeter' between every two consecutive elements of input list `numbers'\n// >>> intersperse([], 4)\n// []\n// >>> intersperse([1, 2, 3], 4)\n// [1, 4, 2, 4, 3]\nfunction intersperse(numbers: number[], delimeter: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_5_intersperse.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersperse;\n  assert.deepEqual(candidate([], 7),[]);\n  assert.deepEqual(candidate([5, 6, 3, 2], 8),[5, 8, 6, 8, 3, 8, 2]);\n  assert.deepEqual(candidate([2, 2, 2], 2),[2, 2, 2, 2, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_60_sum_to_n",
+    "language": "ts",
+    "prompt": "//sum_to_n is a function that sums numbers from 1 to n.\n// >>> sum_to_n(30)\n// 465\n// >>> sum_to_n(100)\n// 5050\n// >>> sum_to_n(5)\n// 15\n// >>> sum_to_n(10)\n// 55\n// >>> sum_to_n(1)\n// 1\nfunction sum_to_n(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_60_sum_to_n.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_to_n;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(6),21);\n  assert.deepEqual(candidate(11),66);\n  assert.deepEqual(candidate(30),465);\n  assert.deepEqual(candidate(100),5050);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_61_correct_bracketing",
+    "language": "ts",
+    "prompt": "//brackets is a string of \"(\" and \")\".\n// return True if every opening bracket has a corresponding closing bracket.\n// >>> correct_bracketing(\"(\")\n// false\n// >>> correct_bracketing(\"()\")\n// true\n// >>> correct_bracketing(\"(()())\")\n// true\n// >>> correct_bracketing(\")(()\")\n// false\nfunction correct_bracketing(brackets: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_61_correct_bracketing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = correct_bracketing;\n  assert.deepEqual(candidate(\"()\"),true);\n  assert.deepEqual(candidate(\"(()())\"),true);\n  assert.deepEqual(candidate(\"()()(()())()\"),true);\n  assert.deepEqual(candidate(\"()()((()()())())(()()(()))\"),true);\n  assert.deepEqual(candidate(\"((()())))\"),false);\n  assert.deepEqual(candidate(\")(()\"),false);\n  assert.deepEqual(candidate(\"(\"),false);\n  assert.deepEqual(candidate(\"((((\"),false);\n  assert.deepEqual(candidate(\")\"),false);\n  assert.deepEqual(candidate(\"(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())())(()\"),false);\n  assert.deepEqual(candidate(\"()()(()())()))()\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_62_derivative",
+    "language": "ts",
+    "prompt": "//xs represent coefficients of a polynomial.\n// xs[0] + xs[1] * x + xs[2] * x^2 + ....\n// Return derivative of this polynomial in the same form.\n// >>> derivative([3, 1, 2, 4, 5])\n// [1, 4, 12, 20]\n// >>> derivative([1, 2, 3])\n// [2, 6]\nfunction derivative(xs: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_62_derivative.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = derivative;\n  assert.deepEqual(candidate([3, 1, 2, 4, 5]),[1, 4, 12, 20]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 6]);\n  assert.deepEqual(candidate([3, 2, 1]),[2, 2]);\n  assert.deepEqual(candidate([3, 2, 1, 0, 4]),[2, 2, 0, 16]);\n  assert.deepEqual(candidate([1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_63_fibfib",
+    "language": "ts",
+    "prompt": "//The FibFib number sequence is a sequence similar to the Fibbonacci sequnece that's defined as follows:\n// fibfib(0) == 0\n// fibfib(1) == 0\n// fibfib(2) == 1\n// fibfib(n) == fibfib(n-1) + fibfib(n-2) + fibfib(n-3).\n// Please write a function to efficiently compute the n-th element of the fibfib number sequence.\n// >>> fibfib(1)\n// 0\n// >>> fibfib(5)\n// 4\n// >>> fibfib(8)\n// 24\nfunction fibfib(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_63_fibfib.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fibfib;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(1),0);\n  assert.deepEqual(candidate(5),4);\n  assert.deepEqual(candidate(8),24);\n  assert.deepEqual(candidate(10),81);\n  assert.deepEqual(candidate(12),274);\n  assert.deepEqual(candidate(14),927);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_64_vowels_count",
+    "language": "ts",
+    "prompt": "//Write a function vowels_count which takes a string representing\n// a word as input and returns the number of vowels in the string.\n// Vowels in this case are 'a', 'e', 'i', 'o', 'u'. Here, 'y' is also a\n// vowel, but only when it is at the end of the given word.\n// Example:\n// >>> vowels_count(\"abcde\")\n// 2\n// >>> vowels_count(\"ACEDY\")\n// 3\nfunction vowels_count(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_64_vowels_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = vowels_count;\n  assert.deepEqual(candidate(\"abcde\"),2);\n  assert.deepEqual(candidate(\"Alone\"),3);\n  assert.deepEqual(candidate(\"key\"),2);\n  assert.deepEqual(candidate(\"bye\"),1);\n  assert.deepEqual(candidate(\"keY\"),2);\n  assert.deepEqual(candidate(\"bYe\"),1);\n  assert.deepEqual(candidate(\"ACEDY\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_65_circular_shift",
+    "language": "ts",
+    "prompt": "//Circular shift the digits of the integer x, shift the digits right by shift\n// and return the result as a string.\n// If shift > number of digits, return digits reversed.\n// >>> circular_shift(12, 1)\n// \"21\"\n// >>> circular_shift(12, 2)\n// \"12\"\nfunction circular_shift(x: number, shift: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_65_circular_shift.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = circular_shift;\n  assert.deepEqual(candidate(100, 2),\"001\");\n  assert.deepEqual(candidate(12, 2),\"12\");\n  assert.deepEqual(candidate(97, 8),\"79\");\n  assert.deepEqual(candidate(12, 1),\"21\");\n  assert.deepEqual(candidate(11, 101),\"11\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_66_digitSum",
+    "language": "ts",
+    "prompt": "//Task\n// Write a function that takes a string as input and returns the sum of the upper characters only'\n// ASCII codes.\n// Examples:\n// >>> digitSum(\"\")\n// 0\n// >>> digitSum(\"abAB\")\n// 131\n// >>> digitSum(\"abcCd\")\n// 67\n// >>> digitSum(\"helloE\")\n// 69\n// >>> digitSum(\"woArBld\")\n// 131\n// >>> digitSum(\"aAaaaXa\")\n// 153\nfunction digitSum(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_66_digitSum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digitSum;\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"abAB\"),131);\n  assert.deepEqual(candidate(\"abcCd\"),67);\n  assert.deepEqual(candidate(\"helloE\"),69);\n  assert.deepEqual(candidate(\"woArBld\"),131);\n  assert.deepEqual(candidate(\"aAaaaXa\"),153);\n  assert.deepEqual(candidate(\" How are yOu?\"),151);\n  assert.deepEqual(candidate(\"You arE Very Smart\"),327);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_67_fruit_distribution",
+    "language": "ts",
+    "prompt": "//In this task, you will be given a string that represents a number of apples and oranges \n// that are distributed in a basket of fruit this basket contains \n// apples, oranges, and mango fruits. Given the string that represents the total number of \n// the oranges and apples and an integer that represent the total number of the fruits \n// in the basket return the number of the mango fruits in the basket.\n// for examble:\n// >>> fruit_distribution(\"5 apples and 6 oranges\", 19)\n// 8\n// >>> fruit_distribution(\"0 apples and 1 oranges\", 3)\n// 2\n// >>> fruit_distribution(\"2 apples and 3 oranges\", 100)\n// 95\n// >>> fruit_distribution(\"100 apples and 1 oranges\", 120)\n// 19\nfunction fruit_distribution(s: string, n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_67_fruit_distribution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = fruit_distribution;\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 19),8);\n  assert.deepEqual(candidate(\"5 apples and 6 oranges\", 21),10);\n  assert.deepEqual(candidate(\"0 apples and 1 oranges\", 3),2);\n  assert.deepEqual(candidate(\"1 apples and 0 oranges\", 3),2);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 100),95);\n  assert.deepEqual(candidate(\"2 apples and 3 oranges\", 5),0);\n  assert.deepEqual(candidate(\"1 apples and 100 oranges\", 120),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_68_pluck",
+    "language": "ts",
+    "prompt": "//\"Given an array representing a branch of a tree that has non-negative integer nodes\n// your task is to pluck one of the nodes and return it.\n// The plucked node should be the node with the smallest even value.\n// If multiple nodes with the same smallest even value are found return the node that has smallest index.\n// The plucked node should be returned in a list, [ smalest_value, its index ],\n// If there are no even values or the given array is empty, return [].\n// Example 1:\n// >>> pluck([4, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 2:\n// >>> pluck([1, 2, 3])\n// [2, 1]\n// Explanation: 2 has the smallest even value, and 2 has the smallest index.\n// Example 3:\n// >>> pluck([])\n// []\n// Example 4:\n// >>> pluck([5, 0, 3, 0, 4, 2])\n// [0, 1]\n// Explanation: 0 is the smallest value, but  there are two zeros,\n// so we will choose the first zero, which has the smallest index.\n// Constraints:\n// * 1 <= nodes.length <= 10000\n// * 0 <= node.value\nfunction pluck(arr: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_68_pluck.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pluck;\n  assert.deepEqual(candidate([4, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 1]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5, 0, 3, 0, 4, 2]),[0, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 0, 5, 3]),[0, 3]);\n  assert.deepEqual(candidate([5, 4, 8, 4, 8]),[4, 1]);\n  assert.deepEqual(candidate([7, 6, 7, 1]),[6, 1]);\n  assert.deepEqual(candidate([7, 9, 7, 1]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_69_search",
+    "language": "ts",
+    "prompt": "//You are given a non-empty list of positive integers. Return the greatest integer that is greater than \n// zero, and has a frequency greater than or equal to the value of the integer itself. \n// The frequency of an integer is the number of times it appears in the list.\n// If no such a value exist, return -1.\n// Examples:\n// >>> search([4, 1, 2, 2, 3, 1])\n// 2\n// >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])\n// 3\n// >>> search([5, 5, 4, 4, 4])\n// -1\nfunction search(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_69_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([5, 5, 5, 5, 1]),1);\n  assert.deepEqual(candidate([4, 1, 4, 1, 4, 4]),4);\n  assert.deepEqual(candidate([3, 3]),-1);\n  assert.deepEqual(candidate([8, 8, 8, 8, 8, 8, 8, 8]),8);\n  assert.deepEqual(candidate([2, 3, 3, 2, 2]),2);\n  assert.deepEqual(candidate([2, 7, 8, 8, 4, 8, 7, 3, 9, 6, 5, 10, 4, 3, 6, 7, 1, 7, 4, 10, 8, 1]),1);\n  assert.deepEqual(candidate([3, 2, 8, 2]),2);\n  assert.deepEqual(candidate([6, 7, 1, 8, 8, 10, 5, 8, 5, 3, 10]),1);\n  assert.deepEqual(candidate([8, 8, 3, 6, 5, 6, 4]),-1);\n  assert.deepEqual(candidate([6, 9, 6, 7, 1, 4, 7, 1, 8, 8, 9, 8, 10, 10, 8, 4, 10, 4, 10, 1, 2, 9, 5, 7, 9]),1);\n  assert.deepEqual(candidate([1, 9, 10, 1, 3]),1);\n  assert.deepEqual(candidate([6, 9, 7, 5, 8, 7, 5, 3, 7, 5, 10, 10, 3, 6, 10, 2, 8, 6, 5, 4, 9, 5, 3, 10]),5);\n  assert.deepEqual(candidate([1]),1);\n  assert.deepEqual(candidate([8, 8, 10, 6, 4, 3, 5, 8, 2, 4, 2, 8, 4, 6, 10, 4, 2, 1, 10, 2, 1, 1, 5]),4);\n  assert.deepEqual(candidate([2, 10, 4, 8, 2, 10, 5, 1, 2, 9, 5, 5, 6, 3, 8, 6, 4, 10]),2);\n  assert.deepEqual(candidate([1, 6, 10, 1, 6, 9, 10, 8, 6, 8, 7, 3]),1);\n  assert.deepEqual(candidate([9, 2, 4, 1, 5, 1, 5, 2, 5, 7, 7, 7, 3, 10, 1, 5, 4, 2, 8, 4, 1, 9, 10, 7, 10, 2, 8, 10, 9, 4]),4);\n  assert.deepEqual(candidate([2, 6, 4, 2, 8, 7, 5, 6, 4, 10, 4, 6, 3, 7, 8, 8, 3, 1, 4, 2, 2, 10, 7]),4);\n  assert.deepEqual(candidate([9, 8, 6, 10, 2, 6, 10, 2, 7, 8, 10, 3, 8, 2, 6, 2, 3, 1]),2);\n  assert.deepEqual(candidate([5, 5, 3, 9, 5, 6, 3, 2, 8, 5, 6, 10, 10, 6, 8, 4, 10, 7, 7, 10, 8]),-1);\n  assert.deepEqual(candidate([10]),-1);\n  assert.deepEqual(candidate([9, 7, 7, 2, 4, 7, 2, 10, 9, 7, 5, 7, 2]),2);\n  assert.deepEqual(candidate([5, 4, 10, 2, 1, 1, 10, 3, 6, 1, 8]),1);\n  assert.deepEqual(candidate([7, 9, 9, 9, 3, 4, 1, 5, 9, 1, 2, 1, 1, 10, 7, 5, 6, 7, 6, 7, 7, 6]),1);\n  assert.deepEqual(candidate([3, 10, 10, 9, 2]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_6_parse_nested_parens",
+    "language": "ts",
+    "prompt": "//Input to this function is a string represented multiple groups for nested parentheses separated by spaces.\n// For each of the group, output the deepest level of nesting of parentheses.\n// E.g. (()()) has maximum two levels of nesting while ((())) has three.\n// >>> parse_nested_parens(\"(()()) ((())) () ((())()())\")\n// [2, 3, 1, 3]\nfunction parse_nested_parens(paren_string: string): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_6_parse_nested_parens.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parse_nested_parens;\n  assert.deepEqual(candidate(\"(()()) ((())) () ((())()())\"),[2, 3, 1, 3]);\n  assert.deepEqual(candidate(\"() (()) ((())) (((())))\"),[1, 2, 3, 4]);\n  assert.deepEqual(candidate(\"(()(())((())))\"),[4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_70_strange_sort_list",
+    "language": "ts",
+    "prompt": "//Given list of integers, return list in strange order.\n// Strange sorting, is when you start with the minimum value,\n// then maximum of the remaining integers, then minimum and so on.\n// Examples:\n// >>> strange_sort_list([1, 2, 3, 4])\n// [1, 4, 2, 3]\n// >>> strange_sort_list([5, 5, 5, 5])\n// [5, 5, 5, 5]\n// >>> strange_sort_list([])\n// []\nfunction strange_sort_list(lst: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_70_strange_sort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = strange_sort_list;\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 4, 2, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9]),[5, 9, 6, 8, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 5, 2, 4, 3]);\n  assert.deepEqual(candidate([5, 6, 7, 8, 9, 1]),[1, 9, 5, 8, 6, 7]);\n  assert.deepEqual(candidate([5, 5, 5, 5]),[5, 5, 5, 5]);\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8]),[1, 8, 2, 7, 3, 6, 4, 5]);\n  assert.deepEqual(candidate([0, 2, 2, 2, 5, 5, -5, -5]),[-5, 5, -5, 5, 0, 2, 2, 2]);\n  assert.deepEqual(candidate([111111]),[111111]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_71_triangle_area",
+    "language": "ts",
+    "prompt": "//Given the lengths of the three sides of a triangle. Return the area of\n// the triangle rounded to 2 decimal points if the three sides form a valid triangle. \n// Otherwise return -1\n// Three sides make a valid triangle when the sum of any two sides is greater \n// than the third side.\n// Example:\n// >>> triangle_area(3, 4, 5)\n// 6.0\n// >>> triangle_area(1, 2, 10)\n// -1\nfunction triangle_area(a: number, b: number, c: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_71_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(3, 4, 5),6.0);\n  assert.deepEqual(candidate(1, 2, 10),-1);\n  assert.deepEqual(candidate(4, 8, 5),8.18);\n  assert.deepEqual(candidate(2, 2, 2),1.73);\n  assert.deepEqual(candidate(1, 2, 3),-1);\n  assert.deepEqual(candidate(10, 5, 7),16.25);\n  assert.deepEqual(candidate(2, 6, 3),-1);\n  assert.deepEqual(candidate(1, 1, 1),0.43);\n  assert.deepEqual(candidate(2, 2, 10),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_72_will_it_fly",
+    "language": "ts",
+    "prompt": "//Write a function that returns True if the object q will fly, and False otherwise.\n// The object q will fly if it's balanced (it is a palindromic list) and the sum of its elements is less than or equal the maximum possible weight w.\n// Example:\n// >>> will_it_fly([1, 2], 5)\n// false\n// # 1+2 is less than the maximum possible weight, but it's unbalanced.\n// >>> will_it_fly([3, 2, 3], 1)\n// false\n// # it's balanced, but 3+2+3 is more than the maximum possible weight.\n// >>> will_it_fly([3, 2, 3], 9)\n// true\n// # 3+2+3 is less than the maximum possible weight, and it's balanced.\n// >>> will_it_fly([3], 5)\n// true\n// # 3 is less than the maximum possible weight, and it's balanced.\nfunction will_it_fly(q: number[], w: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_72_will_it_fly.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = will_it_fly;\n  assert.deepEqual(candidate([3, 2, 3], 9),true);\n  assert.deepEqual(candidate([1, 2], 5),false);\n  assert.deepEqual(candidate([3], 5),true);\n  assert.deepEqual(candidate([3, 2, 3], 1),false);\n  assert.deepEqual(candidate([1, 2, 3], 6),false);\n  assert.deepEqual(candidate([5], 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_73_smallest_change",
+    "language": "ts",
+    "prompt": "//Given an array arr of integers, find the minimum number of elements that\n// need to be changed to make the array palindromic. A palindromic array is an array that\n// is read the same backwards and forwards. In one change, you can change one element to any other element.\n// For example:\n// >>> smallest_change([1, 2, 3, 5, 4, 7, 9, 6])\n// 4\n// >>> smallest_change([1, 2, 3, 4, 3, 2, 2])\n// 1\n// >>> smallest_change([1, 2, 3, 2, 1])\n// 0\nfunction smallest_change(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_73_smallest_change.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_change;\n  assert.deepEqual(candidate([1, 2, 3, 5, 4, 7, 9, 6]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 2]),1);\n  assert.deepEqual(candidate([1, 4, 2]),1);\n  assert.deepEqual(candidate([1, 4, 4, 2]),1);\n  assert.deepEqual(candidate([1, 2, 3, 2, 1]),0);\n  assert.deepEqual(candidate([3, 1, 1, 3]),0);\n  assert.deepEqual(candidate([1]),0);\n  assert.deepEqual(candidate([0, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_74_total_match",
+    "language": "ts",
+    "prompt": "//Write a function that accepts two lists of strings and returns the list that has \n// total number of chars in the all strings of the list less than the other list.\n// if the two lists have the same number of chars, return the first list.\n// Examples\n// >>> total_match([], [])\n// []\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"Hi\"])\n// [\"hI\", \"Hi\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"])\n// [\"hi\", \"admin\"]\n// >>> total_match([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"])\n// [\"hI\", \"hi\", \"hi\"]\n// >>> total_match([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"])\n// [\"4\"]\nfunction total_match(lst1: string[], lst2: string[]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_74_total_match.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = total_match;\n  assert.deepEqual(candidate([], []),[]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\"]),[\"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hi\", \"hi\", \"admin\", \"project\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([\"4\"], [\"1\", \"2\", \"3\", \"4\", \"5\"]),[\"4\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"Hi\"]),[\"hI\", \"Hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hi\"]),[\"hI\", \"hi\", \"hi\"]);\n  assert.deepEqual(candidate([\"hi\", \"admin\"], [\"hI\", \"hi\", \"hii\"]),[\"hi\", \"admin\"]);\n  assert.deepEqual(candidate([], [\"this\"]),[]);\n  assert.deepEqual(candidate([\"this\"], []),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_75_is_multiply_prime",
+    "language": "ts",
+    "prompt": "//Write a function that returns true if the given number is the multiplication of 3 prime numbers\n// and false otherwise.\n// Knowing that (a) is less then 100. \n// Example:\n// >>> is_multiply_prime(30)\n// true\n// 30 = 2 * 3 * 5\nfunction is_multiply_prime(a: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_75_is_multiply_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_multiply_prime;\n  assert.deepEqual(candidate(5),false);\n  assert.deepEqual(candidate(30),true);\n  assert.deepEqual(candidate(8),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(125),true);\n  assert.deepEqual(candidate(105),true);\n  assert.deepEqual(candidate(126),false);\n  assert.deepEqual(candidate(729),false);\n  assert.deepEqual(candidate(891),false);\n  assert.deepEqual(candidate(1001),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_76_is_simple_power",
+    "language": "ts",
+    "prompt": "//Your task is to write a function that returns true if a number x is a simple\n// power of n and false in other cases.\n// x is a simple power of n if n**int=x\n// For example:\n// >>> is_simple_power(1, 4)\n// true\n// >>> is_simple_power(2, 2)\n// true\n// >>> is_simple_power(8, 2)\n// true\n// >>> is_simple_power(3, 2)\n// false\n// >>> is_simple_power(3, 1)\n// false\n// >>> is_simple_power(5, 3)\n// false\nfunction is_simple_power(x: number, n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_76_is_simple_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_simple_power;\n  assert.deepEqual(candidate(16, 2),true);\n  assert.deepEqual(candidate(143214, 16),false);\n  assert.deepEqual(candidate(4, 2),true);\n  assert.deepEqual(candidate(9, 3),true);\n  assert.deepEqual(candidate(16, 4),true);\n  assert.deepEqual(candidate(24, 2),false);\n  assert.deepEqual(candidate(128, 4),false);\n  assert.deepEqual(candidate(12, 6),false);\n  assert.deepEqual(candidate(1, 1),true);\n  assert.deepEqual(candidate(1, 12),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_77_iscube",
+    "language": "ts",
+    "prompt": "//Write a function that takes an integer a and returns True \n// if this ingeger is a cube of some integer number.\n// Note: you may assume the input is always valid.\n// Examples:\n// >>> iscube(1)\n// true\n// >>> iscube(2)\n// false\n// >>> iscube(-1)\n// true\n// >>> iscube(64)\n// true\n// >>> iscube(0)\n// true\n// >>> iscube(180)\n// false\nfunction iscube(a: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_77_iscube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = iscube;\n  assert.deepEqual(candidate(1),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(-1),true);\n  assert.deepEqual(candidate(64),true);\n  assert.deepEqual(candidate(180),false);\n  assert.deepEqual(candidate(1000),true);\n  assert.deepEqual(candidate(0),true);\n  assert.deepEqual(candidate(1729),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_78_hex_key",
+    "language": "ts",
+    "prompt": "//You have been tasked to write a function that receives \n// a hexadecimal number as a string and counts the number of hexadecimal \n// digits that are primes (prime number, or a prime, is a natural number \n// greater than 1 that is not a product of two smaller natural numbers).\n// Hexadecimal digits are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F.\n// Prime numbers are 2, 3, 5, 7, 11, 13, 17,...\n// So you have to determine a number of the following digits: 2, 3, 5, 7, \n// B (=decimal 11), D (=decimal 13).\n// Note: you may assume the input is always correct or empty string, \n// and symbols A,B,C,D,E,F are always uppercase.\n// Examples:\n// >>> hex_key(\"AB\")\n// 1\n// >>> hex_key(\"1077E\")\n// 2\n// >>> hex_key(\"ABED1A33\")\n// 4\n// >>> hex_key(\"123456789ABCDEF0\")\n// 6\n// >>> hex_key(\"2020\")\n// 2\nfunction hex_key(num: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_78_hex_key.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hex_key;\n  assert.deepEqual(candidate(\"AB\"),1);\n  assert.deepEqual(candidate(\"1077E\"),2);\n  assert.deepEqual(candidate(\"ABED1A33\"),4);\n  assert.deepEqual(candidate(\"2020\"),2);\n  assert.deepEqual(candidate(\"123456789ABCDEF0\"),6);\n  assert.deepEqual(candidate(\"112233445566778899AABBCCDDEEFF00\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_79_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//You will be given a number in decimal form and your task is to convert it to\n// binary format. The function should return a string, with each character representing a binary\n// number. Each character in the string will be '0' or '1'.\n// There will be an extra couple of characters 'db' at the beginning and at the end of the string.\n// The extra characters are there to help with the format.\n// Examples:\n// >>> decimal_to_binary(15)\n// \"db1111db\"\n// >>> decimal_to_binary(32)\n// \"db100000db\"\nfunction decimal_to_binary(decimal: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_79_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(0),\"db0db\");\n  assert.deepEqual(candidate(32),\"db100000db\");\n  assert.deepEqual(candidate(103),\"db1100111db\");\n  assert.deepEqual(candidate(15),\"db1111db\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_7_filter_by_substring",
+    "language": "ts",
+    "prompt": "//Filter an input list of strings only for ones that contain given substring\n// >>> filter_by_substring([], \"a\")\n// []\n// >>> filter_by_substring([\"abc\", \"bacd\", \"cde\", \"array\"], \"a\")\n// [\"abc\", \"bacd\", \"array\"]\nfunction filter_by_substring(strings: string[], substring: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_7_filter_by_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_by_substring;\n  assert.deepEqual(candidate([], \"john\"),[]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"xxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xxx\"),[\"xxx\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"xxx\", \"asd\", \"aaaxxy\", \"john doe\", \"xxxAAA\", \"xxx\"], \"xx\"),[\"xxx\", \"aaaxxy\", \"xxxAAA\", \"xxx\"]);\n  assert.deepEqual(candidate([\"grunt\", \"trumpet\", \"prune\", \"gruesome\"], \"run\"),[\"grunt\", \"prune\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_80_is_happy",
+    "language": "ts",
+    "prompt": "//You are given a string s.\n// Your task is to check if the string is happy or not.\n// A string is happy if its length is at least 3 and every 3 consecutive letters are distinct\n// For example:\n// >>> is_happy(\"a\")\n// false\n// >>> is_happy(\"aa\")\n// false\n// >>> is_happy(\"abcd\")\n// true\n// >>> is_happy(\"aabb\")\n// false\n// >>> is_happy(\"adb\")\n// true\n// >>> is_happy(\"xyy\")\n// false\nfunction is_happy(s: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_80_is_happy.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_happy;\n  assert.deepEqual(candidate(\"a\"),false);\n  assert.deepEqual(candidate(\"aa\"),false);\n  assert.deepEqual(candidate(\"abcd\"),true);\n  assert.deepEqual(candidate(\"aabb\"),false);\n  assert.deepEqual(candidate(\"adb\"),true);\n  assert.deepEqual(candidate(\"xyy\"),false);\n  assert.deepEqual(candidate(\"iopaxpoi\"),true);\n  assert.deepEqual(candidate(\"iopaxioi\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_81_numerical_letter_grade",
+    "language": "ts",
+    "prompt": "//It is the last week of the semester and the teacher has to give the grades\n// to students. The teacher has been making her own algorithm for grading.\n// The only problem is, she has lost the code she used for grading.\n// She has given you a list of GPAs for some students and you have to write \n// a function that can output a list of letter grades using the following table:\n// GPA       |    Letter grade\n// 4.0                A+\n// > 3.7                A \n// > 3.3                A- \n// > 3.0                B+\n// > 2.7                B \n// > 2.3                B-\n// > 2.0                C+\n// > 1.7                C\n// > 1.3                C-\n// > 1.0                D+ \n// > 0.7                D \n// > 0.0                D-\n// 0.0                E\n// Example:\n// >>> grade_equation([4.0, 3, 1.7, 2, 3.5])\n// [\"A+\", \"B\", \"C-\", \"C\", \"A-\"]\nfunction numerical_letter_grade(grades: number[]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_81_numerical_letter_grade.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = numerical_letter_grade;\n  assert.deepEqual(candidate([4.0, 3, 1.7, 2, 3.5]),[\"A+\", \"B\", \"C-\", \"C\", \"A-\"]);\n  assert.deepEqual(candidate([1.2]),[\"D+\"]);\n  assert.deepEqual(candidate([0.5]),[\"D-\"]);\n  assert.deepEqual(candidate([0.0]),[\"E\"]);\n  assert.deepEqual(candidate([1.0, 0.3, 1.5, 2.8, 3.3]),[\"D\", \"D-\", \"C-\", \"B\", \"B+\"]);\n  assert.deepEqual(candidate([0.0, 0.7]),[\"E\", \"D-\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_82_prime_length",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns True if the string\n// length is a prime number or False otherwise\n// Examples\n// >>> prime_length(\"Hello\")\n// true\n// >>> prime_length(\"abcdcba\")\n// true\n// >>> prime_length(\"kittens\")\n// true\n// >>> prime_length(\"orange\")\n// false\nfunction prime_length(string: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_82_prime_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_length;\n  assert.deepEqual(candidate(\"Hello\"),true);\n  assert.deepEqual(candidate(\"abcdcba\"),true);\n  assert.deepEqual(candidate(\"kittens\"),true);\n  assert.deepEqual(candidate(\"orange\"),false);\n  assert.deepEqual(candidate(\"wow\"),true);\n  assert.deepEqual(candidate(\"world\"),true);\n  assert.deepEqual(candidate(\"MadaM\"),true);\n  assert.deepEqual(candidate(\"Wow\"),true);\n  assert.deepEqual(candidate(\"\"),false);\n  assert.deepEqual(candidate(\"HI\"),true);\n  assert.deepEqual(candidate(\"go\"),true);\n  assert.deepEqual(candidate(\"gogo\"),false);\n  assert.deepEqual(candidate(\"aaaaaaaaaaaaaaa\"),false);\n  assert.deepEqual(candidate(\"Madam\"),true);\n  assert.deepEqual(candidate(\"M\"),false);\n  assert.deepEqual(candidate(\"0\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_83_starts_one_ends",
+    "language": "ts",
+    "prompt": "//Given a positive integer n, return the count of the numbers of n-digit\n// positive integers that start or end with 1.\nfunction starts_one_ends(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_83_starts_one_ends.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = starts_one_ends;\n  assert.deepEqual(candidate(1),1);\n  assert.deepEqual(candidate(2),18);\n  assert.deepEqual(candidate(3),180);\n  assert.deepEqual(candidate(4),1800);\n  assert.deepEqual(candidate(5),18000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_84_solve",
+    "language": "ts",
+    "prompt": "//Given a positive integer N, return the total sum of its digits in binary.\n// Example\n// >>> solve(1000)\n// \"1\"\n// >>> solve(150)\n// \"110\"\n// >>> solve(147)\n// \"1100\"\n// Variables:\n// @N integer\n// Constraints: 0 \u2264 N \u2264 10000.\n// Output:\n// a string of binary number\nfunction solve(N: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_84_solve.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = solve;\n  assert.deepEqual(candidate(1000),\"1\");\n  assert.deepEqual(candidate(150),\"110\");\n  assert.deepEqual(candidate(147),\"1100\");\n  assert.deepEqual(candidate(333),\"1001\");\n  assert.deepEqual(candidate(963),\"10010\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_85_add",
+    "language": "ts",
+    "prompt": "//Given a non-empty list of integers lst. add the even elements that are at odd indices..\n// Examples:\n// >>> add([4, 2, 6, 7])\n// 2\nfunction add(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_85_add.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add;\n  assert.deepEqual(candidate([4, 88]),88);\n  assert.deepEqual(candidate([4, 5, 6, 7, 2, 122]),122);\n  assert.deepEqual(candidate([4, 0, 6, 7]),0);\n  assert.deepEqual(candidate([4, 4, 6, 8]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_86_anti_shuffle",
+    "language": "ts",
+    "prompt": "//Write a function that takes a string and returns an ordered version of it.\n// Ordered version of string, is a string where all words (separated by space)\n// are replaced by a new word where all the characters arranged in\n// ascending order based on ascii value.\n// Note: You should keep the order of words and blank spaces in the sentence.\n// For example:\n// >>> anti_shuffle(\"Hi\")\n// \"Hi\"\n// >>> anti_shuffle(\"hello\")\n// \"ehllo\"\n// >>> anti_shuffle(\"Hello World!!!\")\n// \"Hello !!!Wdlor\"\nfunction anti_shuffle(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_86_anti_shuffle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = anti_shuffle;\n  assert.deepEqual(candidate(\"Hi\"),\"Hi\");\n  assert.deepEqual(candidate(\"hello\"),\"ehllo\");\n  assert.deepEqual(candidate(\"number\"),\"bemnru\");\n  assert.deepEqual(candidate(\"abcd\"),\"abcd\");\n  assert.deepEqual(candidate(\"Hello World!!!\"),\"Hello !!!Wdlor\");\n  assert.deepEqual(candidate(\"\"),\"\");\n  assert.deepEqual(candidate(\"Hi. My name is Mister Robot. How are you?\"),\".Hi My aemn is Meirst .Rboot How aer ?ouy\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_87_get_row",
+    "language": "ts",
+    "prompt": "//You are given a 2 dimensional data, as a nested lists,\n// which is similar to matrix, however, unlike matrices,\n// each row may contain a different number of columns.\n// Given lst, and integer x, find integers x in the list,\n// and return list of tuples, [(x1, y1), (x2, y2) ...] such that\n// each tuple is a coordinate - (row, columns), starting with 0.\n// Sort coordinates initially by rows in ascending order.\n// Also, sort coordinates of the row by columns in descending order.\n// Examples:\n// >>> get_row([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1)\n// [[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]\n// >>> get_row([], 1)\n// []\n// >>> get_row([[], [1], [1, 2, 3]], 3)\n// [[2, 2]]\nfunction get_row(lst: number[][], x: number): [number, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_87_get_row.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_row;\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 4], [1, 0], [2, 5], [2, 0]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]], 2),[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 2, 1, 4, 5, 6], [1, 2, 3, 1, 5, 6], [1, 2, 3, 4, 1, 6], [1, 2, 3, 4, 5, 1]], 1),[[0, 0], [1, 0], [2, 1], [2, 0], [3, 2], [3, 0], [4, 3], [4, 0], [5, 4], [5, 0], [6, 5], [6, 0]]);\n  assert.deepEqual(candidate([], 1),[]);\n  assert.deepEqual(candidate([[1]], 2),[]);\n  assert.deepEqual(candidate([[], [1], [1, 2, 3]], 3),[[2, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_88_sort_array",
+    "language": "ts",
+    "prompt": "//Given an array of non-negative integers, return a copy of the given array after sorting,\n// you will sort the given array in ascending order if the sum( first index value, last index value) is odd,\n// or sort it in descending order if the sum( first index value, last index value) is even.\n// Note:\n// * don't change the given array.\n// Examples:\n// >>> sort_array([])\n// []\n// >>> sort_array([5])\n// [5]\n// >>> sort_array([2, 4, 3, 0, 1, 5])\n// [0, 1, 2, 3, 4, 5]\n// >>> sort_array([2, 4, 3, 0, 1, 5, 6])\n// [6, 5, 4, 3, 2, 1, 0]\nfunction sort_array(array: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_88_sort_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_array;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([5]),[5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5]),[0, 1, 2, 3, 4, 5]);\n  assert.deepEqual(candidate([2, 4, 3, 0, 1, 5, 6]),[6, 5, 4, 3, 2, 1, 0]);\n  assert.deepEqual(candidate([2, 1]),[1, 2]);\n  assert.deepEqual(candidate([15, 42, 87, 32, 11, 0]),[0, 11, 15, 32, 42, 87]);\n  assert.deepEqual(candidate([21, 14, 23, 11]),[23, 21, 14, 11]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_89_encrypt",
+    "language": "ts",
+    "prompt": "//Create a function encrypt that takes a string as an argument and\n// returns a string encrypted with the alphabet being rotated. \n// The alphabet should be rotated in a manner such that the letters \n// shift down by two multiplied to two places.\n// For example:\n// >>> encrypt(\"hi\")\n// \"lm\"\n// >>> encrypt(\"asdfghjkl\")\n// \"ewhjklnop\"\n// >>> encrypt(\"gf\")\n// \"kj\"\n// >>> encrypt(\"et\")\n// \"ix\"\nfunction encrypt(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_89_encrypt.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encrypt;\n  assert.deepEqual(candidate(\"hi\"),\"lm\");\n  assert.deepEqual(candidate(\"asdfghjkl\"),\"ewhjklnop\");\n  assert.deepEqual(candidate(\"gf\"),\"kj\");\n  assert.deepEqual(candidate(\"et\"),\"ix\");\n  assert.deepEqual(candidate(\"faewfawefaewg\"),\"jeiajeaijeiak\");\n  assert.deepEqual(candidate(\"hellomyfriend\"),\"lippsqcjvmirh\");\n  assert.deepEqual(candidate(\"dxzdlmnilfuhmilufhlihufnmlimnufhlimnufhfucufh\"),\"hbdhpqrmpjylqmpyjlpmlyjrqpmqryjlpmqryjljygyjl\");\n  assert.deepEqual(candidate(\"a\"),\"e\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_8_sum_product",
+    "language": "ts",
+    "prompt": "//For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.\n// Empty sum should be equal to 0 and empty product should be equal to 1.\n// >>> sum_product([])\n// [0, 1]\n// >>> sum_product([1, 2, 3, 4])\n// [10, 24]\nfunction sum_product(numbers: number[]): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_8_sum_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_product;\n  assert.deepEqual(candidate([]),[0, 1]);\n  assert.deepEqual(candidate([1, 1, 1]),[3, 1]);\n  assert.deepEqual(candidate([100, 0]),[100, 0]);\n  assert.deepEqual(candidate([3, 5, 7]),[15, 105]);\n  assert.deepEqual(candidate([10]),[10, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_90_next_smallest",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// Write a function next_smallest() that returns the 2nd smallest element of the list.\n// Return None if there is no such element.\n// >>> next_smallest([1, 2, 3, 4, 5])\n// 2\n// >>> next_smallest([5, 1, 4, 3, 2])\n// 2\n// >>> next_smallest([])\n// undefined\n// >>> next_smallest([1, 1])\n// undefined\nfunction next_smallest(lst: number[]): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_90_next_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),2);\n  assert.deepEqual(candidate([5, 1, 4, 3, 2]),2);\n  assert.deepEqual(candidate([]),undefined);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([1, 1, 1, 1, 0]),1);\n  assert.deepEqual(candidate([1, 1]),undefined);\n  assert.deepEqual(candidate([-35, 34, 12, -45]),-35);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_91_is_bored",
+    "language": "ts",
+    "prompt": "//You'll be given a string of words, and your task is to count the number\n// of boredoms. A boredom is a sentence that starts with the word \"I\".\n// Sentences are delimited by '.', '?' or '!'.\n// For example:\n// >>> is_bored(\"Hello world\")\n// 0\n// >>> is_bored(\"The sky is blue. The sun is shining. I love this weather\")\n// 1\nfunction is_bored(S: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_91_is_bored.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_bored;\n  assert.deepEqual(candidate(\"Hello world\"),0);\n  assert.deepEqual(candidate(\"Is the sky blue?\"),0);\n  assert.deepEqual(candidate(\"I love It !\"),1);\n  assert.deepEqual(candidate(\"bIt\"),0);\n  assert.deepEqual(candidate(\"I feel good today. I will be productive. will kill It\"),2);\n  assert.deepEqual(candidate(\"You and I are going for a walk\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_92_any_int",
+    "language": "ts",
+    "prompt": "//Create a function that takes 3 numbers.\n// Returns true if one of the numbers is equal to the sum of the other two, and all numbers are integers.\n// Returns false in any other cases.\n// Examples\n// >>> any_int(5, 2, 7)\n// true\n// >>> any_int(3, 2, 2)\n// false\n// >>> any_int(3, -2, 1)\n// true\n// >>> any_int(3.6, -2.2, 2)\n// false\nfunction any_int(x: number, y: number, z: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_92_any_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = any_int;\n  assert.deepEqual(candidate(2, 3, 1),true);\n  assert.deepEqual(candidate(2.5, 2, 3),false);\n  assert.deepEqual(candidate(1.5, 5, 3.5),false);\n  assert.deepEqual(candidate(2, 6, 2),false);\n  assert.deepEqual(candidate(4, 2, 2),true);\n  assert.deepEqual(candidate(2.2, 2.2, 2.2),false);\n  assert.deepEqual(candidate(-4, 6, 2),true);\n  assert.deepEqual(candidate(2, 1, 1),true);\n  assert.deepEqual(candidate(3, 4, 7),true);\n  assert.deepEqual(candidate(3.0, 4, 7),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_93_encode",
+    "language": "ts",
+    "prompt": "//Write a function that takes a message, and encodes in such a \n// way that it swaps case of all letters, replaces all vowels in \n// the message with the letter that appears 2 places ahead of that \n// vowel in the english alphabet. \n// Assume only letters. \n// Examples:\n// >>> encode(\"test\")\n// \"TGST\"\n// >>> encode(\"This is a message\")\n// \"tHKS KS C MGSSCGG\"\nfunction encode(message: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_93_encode.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = encode;\n  assert.deepEqual(candidate(\"TEST\"),\"tgst\");\n  assert.deepEqual(candidate(\"Mudasir\"),\"mWDCSKR\");\n  assert.deepEqual(candidate(\"YES\"),\"ygs\");\n  assert.deepEqual(candidate(\"This is a message\"),\"tHKS KS C MGSSCGG\");\n  assert.deepEqual(candidate(\"I DoNt KnOw WhAt tO WrItE\"),\"k dQnT kNqW wHcT Tq wRkTg\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_94_skjkasdkd",
+    "language": "ts",
+    "prompt": "//You are given a list of integers.\n// You need to find the largest prime value and return the sum of its digits.\n// Examples:\n// >>> skjkasdkd([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3])\n// 10\n// >>> skjkasdkd([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1])\n// 25\n// >>> skjkasdkd([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3])\n// 13\n// >>> skjkasdkd([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6])\n// 11\n// >>> skjkasdkd([0, 81, 12, 3, 1, 21])\n// 3\n// >>> skjkasdkd([0, 8, 1, 2, 1, 7])\n// 7\nfunction skjkasdkd(lst: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_94_skjkasdkd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = skjkasdkd;\n  assert.deepEqual(candidate([0, 3, 2, 1, 3, 5, 7, 4, 5, 5, 5, 2, 181, 32, 4, 32, 3, 2, 32, 324, 4, 3]),10);\n  assert.deepEqual(candidate([1, 0, 1, 8, 2, 4597, 2, 1, 3, 40, 1, 2, 1, 2, 4, 2, 5, 1]),25);\n  assert.deepEqual(candidate([1, 3, 1, 32, 5107, 34, 83278, 109, 163, 23, 2323, 32, 30, 1, 9, 3]),13);\n  assert.deepEqual(candidate([0, 724, 32, 71, 99, 32, 6, 0, 5, 91, 83, 0, 5, 6]),11);\n  assert.deepEqual(candidate([0, 81, 12, 3, 1, 21]),3);\n  assert.deepEqual(candidate([0, 8, 1, 2, 1, 7]),7);\n  assert.deepEqual(candidate([8191]),19);\n  assert.deepEqual(candidate([8191, 123456, 127, 7]),19);\n  assert.deepEqual(candidate([127, 97, 8192]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_95_check_dict_case",
+    "language": "ts",
+    "prompt": "//Given a dictionary, return True if all keys are strings in lower \n// case or all keys are strings in upper case, else return False.\n// The function should return False is the given dictionary is empty.\n// Examples:\n// >>> check_dict_case({\"a\": \"apple\", \"b\": \"banana\"})\n// true\n// >>> check_dict_case({\"a\": \"apple\", \"A\": \"banana\", \"B\": \"banana\"})\n// false\n// >>> check_dict_case({\"a\": \"apple\", 8: \"banana\", \"a\": \"apple\"})\n// false\n// >>> check_dict_case({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"})\n// false\n// >>> check_dict_case({\"STATE\": \"NC\", \"ZIP\": \"12345\"})\n// true\nfunction check_dict_case(dict: {[key: string]: string}): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_95_check_dict_case.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_dict_case;\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"b\": \"banana\"}),true);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"A\": \"banana\", \"B\": \"banana\"}),false);\n  assert.deepEqual(candidate({\"p\": \"pineapple\", \"5\": \"banana\", \"a\": \"apple\"}),false);\n  assert.deepEqual(candidate({\"Name\": \"John\", \"Age\": \"36\", \"City\": \"Houston\"}),false);\n  assert.deepEqual(candidate({\"STATE\": \"NC\", \"ZIP\": \"12345\"}),true);\n  assert.deepEqual(candidate({\"fruit\": \"Orange\", \"taste\": \"Sweet\"}),true);\n  assert.deepEqual(candidate({}),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_96_count_up_to",
+    "language": "ts",
+    "prompt": "//Implement a function that takes an non-negative integer and returns an array of the first n\n// integers that are prime numbers and less than n.\n// for example:\n// >>> count_up_to(5)\n// [2, 3]\n// >>> count_up_to(11)\n// [2, 3, 5, 7]\n// >>> count_up_to(0)\n// []\n// >>> count_up_to(20)\n// [2, 3, 5, 7, 11, 13, 17, 19]\n// >>> count_up_to(1)\n// []\n// >>> count_up_to(18)\n// [2, 3, 5, 7, 11, 13, 17]\nfunction count_up_to(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_96_count_up_to.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_up_to;\n  assert.deepEqual(candidate(5),[2, 3]);\n  assert.deepEqual(candidate(6),[2, 3, 5]);\n  assert.deepEqual(candidate(7),[2, 3, 5]);\n  assert.deepEqual(candidate(10),[2, 3, 5, 7]);\n  assert.deepEqual(candidate(0),[]);\n  assert.deepEqual(candidate(22),[2, 3, 5, 7, 11, 13, 17, 19]);\n  assert.deepEqual(candidate(1),[]);\n  assert.deepEqual(candidate(18),[2, 3, 5, 7, 11, 13, 17]);\n  assert.deepEqual(candidate(47),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]);\n  assert.deepEqual(candidate(101),[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_97_multiply",
+    "language": "ts",
+    "prompt": "//Complete the function that takes two integers and returns \n// the product of their unit digits.\n// Assume the input is always valid.\n// Examples:\n// >>> multiply(148, 412)\n// 16\n// >>> multiply(19, 28)\n// 72\n// >>> multiply(2020, 1851)\n// 0\n// >>> multiply(14, -15)\n// 20\nfunction multiply(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_97_multiply.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply;\n  assert.deepEqual(candidate(148, 412),16);\n  assert.deepEqual(candidate(19, 28),72);\n  assert.deepEqual(candidate(2020, 1851),0);\n  assert.deepEqual(candidate(14, -15),20);\n  assert.deepEqual(candidate(76, 67),42);\n  assert.deepEqual(candidate(17, 27),49);\n  assert.deepEqual(candidate(0, 1),0);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_98_count_upper",
+    "language": "ts",
+    "prompt": "//Given a string s, count the number of uppercase vowels in even indices.\n// For example:\n// >>> count_upper(\"aBCdEf\")\n// 1\n// >>> count_upper(\"abcdefg\")\n// 0\n// >>> count_upper(\"dBBE\")\n// 0\nfunction count_upper(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_98_count_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_upper;\n  assert.deepEqual(candidate(\"aBCdEf\"),1);\n  assert.deepEqual(candidate(\"abcdefg\"),0);\n  assert.deepEqual(candidate(\"dBBE\"),0);\n  assert.deepEqual(candidate(\"B\"),0);\n  assert.deepEqual(candidate(\"U\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n  assert.deepEqual(candidate(\"EEEE\"),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_99_closest_integer",
+    "language": "ts",
+    "prompt": "//Create a function that takes a value (string) representing a number\n// and returns the closest integer to it. If the number is equidistant\n// from two integers, round it away from zero.\n// Examples\n// >>> closest_integer(\"10\")\n// 10\n// >>> closest_integer(\"15.3\")\n// 15\n// Note:\n// Rounding away from zero means that if the given number is equidistant\n// from two integers, the one you should return is the one that is the\n// farthest from zero. For example closest_integer(\"14.5\") should\n// return 15 and closest_integer(\"-14.5\") should return -15.\nfunction closest_integer(value: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_99_closest_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_integer;\n  assert.deepEqual(candidate(\"10\"),10);\n  assert.deepEqual(candidate(\"14.5\"),15);\n  assert.deepEqual(candidate(\"-15.5\"),-16);\n  assert.deepEqual(candidate(\"15.3\"),15);\n  assert.deepEqual(candidate(\"0\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "HumanEval_9_rolling_max",
+    "language": "ts",
+    "prompt": "//From a given list of integers, generate a list of rolling maximum element found until given moment\n// in the sequence.\n// >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n// [1, 2, 3, 3, 3, 4, 4]\nfunction rolling_max(numbers: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/originals-with-cleaned-doctests/HumanEval_9_rolling_max.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rolling_max;\n  assert.deepEqual(candidate([]),[]);\n  assert.deepEqual(candidate([1, 2, 3, 4]),[1, 2, 3, 4]);\n  assert.deepEqual(candidate([4, 3, 2, 1]),[4, 4, 4, 4]);\n  assert.deepEqual(candidate([3, 2, 3, 100, 3]),[3, 3, 3, 100, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/mbpp-cpp-keep.json
+++ b/prompts/mbpp-cpp-keep.json
@@ -1,3540 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nlong lps(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = lps;\n    assert(candidate((\"TENS FOR TENS\")) == (5));\n    assert(candidate((\"CARDIO FOR CARDS\")) == (7));\n    assert(candidate((\"PART OF THE JOURNEY IS PART\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from the given string.\nstd::string remove_whitespaces(std::string text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_whitespaces;\n    assert(candidate((\" Google    Flutter \")) == (\"GoogleFlutter\"));\n    assert(candidate((\" Google    Dart \")) == (\"GoogleDart\"));\n    assert(candidate((\" iOS    Swift \")) == (\"iOSSwift\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a specified list is sorted or not.\nbool issort_list(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = issort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)16, (long)17}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)20, (long)17}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)15, (long)14, (long)20}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count bidirectional tuple pairs.\nlong count_bidirectional(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_bidirectional;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (2));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cube of a given size.\nlong surfacearea_cube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = surfacearea_cube;\n    assert(candidate((5)) == (150));\n    assert(candidate((3)) == (54));\n    assert(candidate((10)) == (600));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nlong next_smallest_palindrome(long num) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = next_smallest_palindrome;\n    assert(candidate((99)) == (101));\n    assert(candidate((1221)) == (1331));\n    assert(candidate((120)) == (121));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the cube sum of first n even natural numbers.\nlong cube_Sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cube_Sum;\n    assert(candidate((2)) == (72));\n    assert(candidate((3)) == (288));\n    assert(candidate((4)) == (800));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nlong pair_xor_Sum(std::vector<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pair_xor_Sum;\n    assert(candidate((std::vector<long>({(long)5, (long)9, (long)7, (long)6})), (4)) == (47));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)5})), (3)) == (12));\n    assert(candidate((std::vector<long>({(long)7, (long)3})), (2)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nbool check_min_heap(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_min_heap;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)10, (long)15}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)5, (long)3, (long)15}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first digit of a given number.\nlong first_Digit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = first_Digit;\n    assert(candidate((123)) == (1));\n    assert(candidate((456)) == (4));\n    assert(candidate((12)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first non-repeated character in a given string.\nstd::optional<std::string> first_non_repeating_character(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = first_non_repeating_character;\n    assert(candidate((\"abcabc\")) == std::nullopt);\n    assert(candidate((\"abc\")) == \"a\");\n    assert(candidate((\"ababc\")) == \"c\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert degrees to radians.\nfloat radian_degree(long degree) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = radian_degree;\n    assert(candidate((90)) == (1.5707963267948966f));\n    assert(candidate((60)) == (1.0471975511965976f));\n    assert(candidate((120)) == (2.0943951023931953f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product subarray of the given array.\nlong max_subarray_product(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_subarray_product;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)0, (long)7, (long)-8, (long)-2}))) == (112));\n    assert(candidate((std::vector<long>({(long)6, (long)-3, (long)-10, (long)0, (long)2}))) == (180));\n    assert(candidate((std::vector<long>({(long)-2, (long)-40, (long)0, (long)-2, (long)-3}))) == (80));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert more than one list to nested dictionary.\nstd::vector<std::map<std::string,std::map<std::string,long>>> convert_list_dictionary(std::vector<std::string> l1, std::vector<std::string> l2, std::vector<long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = convert_list_dictionary;\n    assert(candidate((std::vector<std::string>({(std::string)\"S001\", (std::string)\"S002\", (std::string)\"S003\", (std::string)\"S004\"})), (std::vector<std::string>({(std::string)\"Adina Park\", (std::string)\"Leyton Marsh\", (std::string)\"Duncan Boyle\", (std::string)\"Saim Richards\"})), (std::vector<long>({(long)85, (long)98, (long)89, (long)92}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S001\", std::map<std::string,long>({{\"Adina Park\", 85}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S002\", std::map<std::string,long>({{\"Leyton Marsh\", 98}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S003\", std::map<std::string,long>({{\"Duncan Boyle\", 89}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S004\", std::map<std::string,long>({{\"Saim Richards\", 92}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"def\", (std::string)\"ghi\", (std::string)\"jkl\"})), (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\", (std::string)\"programs\"})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"abc\", std::map<std::string,long>({{\"python\", 100}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"def\", std::map<std::string,long>({{\"program\", 200}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"ghi\", std::map<std::string,long>({{\"language\", 300}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"jkl\", std::map<std::string,long>({{\"programs\", 400}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"A1\", (std::string)\"A2\", (std::string)\"A3\", (std::string)\"A4\"})), (std::vector<std::string>({(std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\"})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A1\", std::map<std::string,long>({{\"java\", 10}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A2\", std::map<std::string,long>({{\"C\", 20}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A3\", std::map<std::string,long>({{\"C++\", 30}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A4\", std::map<std::string,long>({{\"DBMS\", 40}})}})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find smallest number in a list.\nlong smallest_num(std::vector<long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = smallest_num;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)1, (long)45, (long)99}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)45, (long)46, (long)50, (long)60}))) == (45));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nbool text_match_zero_one(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_zero_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"dsabbbba\")) == (true));\n    assert(candidate((\"asbbbba\")) == (false));\n    assert(candidate((\"abaaa\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find nth bell number.\nlong bell_Number(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bell_Number;\n    assert(candidate((2)) == (2));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (15));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find cubes of individual elements in a list.\nstd::vector<long> cube_nums(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cube_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)8, (long)27, (long)64, (long)125, (long)216, (long)343, (long)512, (long)729, (long)1000})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)1728, (long)3375})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last digit in factorial of a given number.\nlong last_Digit_Factorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = last_Digit_Factorial;\n    assert(candidate((4)) == (4));\n    assert(candidate((21)) == (0));\n    assert(candidate((30)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find even numbers from a list of numbers.\nstd::vector<long> Split(std::vector<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)2, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)8, (long)0, (long)1}))) == (std::vector<long>({(long)4, (long)6, (long)8, (long)0})));\n    assert(candidate((std::vector<long>({(long)8, (long)12, (long)15, (long)19}))) == (std::vector<long>({(long)8, (long)12})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given integer is a prime number.\nbool prime_num(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = prime_num;\n    assert(candidate((13)) == (true));\n    assert(candidate((7)) == (true));\n    assert(candidate((-1010)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nstd::vector<std::tuple<long, long, long>> find_tuples(std::vector<std::tuple<long, long, long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_tuples;\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12), (std::tuple<long, long, long>)std::make_tuple(7, 9, 6), (std::tuple<long, long, long>)std::make_tuple(12, 18, 21)})), (6)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30), (std::tuple<long, long, long>)std::make_tuple(4, 2, 3), (std::tuple<long, long, long>)std::make_tuple(7, 8, 9)})), (5)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(7, 9, 16), (std::tuple<long, long, long>)std::make_tuple(8, 16, 4), (std::tuple<long, long, long>)std::make_tuple(19, 17, 18)})), (4)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(8, 16, 4)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to caluclate the area of a tetrahedron.\nfloat area_tetrahedron(long side) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = area_tetrahedron;\n    assert(candidate((3)) == (15.588457268119894f));\n    assert(candidate((20)) == (692.8203230275509f));\n    assert(candidate((10)) == (173.20508075688772f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number is even or not.\nbool is_Even(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_Even;\n    assert(candidate((1)) == (false));\n    assert(candidate((2)) == (true));\n    assert(candidate((3)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of positive numbers in a list.\nlong pos_count(std::vector<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pos_count;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3, (long)-4}))) == (2));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)-1}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nstd::vector<long> get_ludic(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_ludic;\n    assert(candidate((10)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((25)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25})));\n    assert(candidate((45)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25, (long)29, (long)37, (long)41, (long)43})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlong find_Index(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Index;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (14));\n    assert(candidate((4)) == (45));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to reverse an array upto a given position.\nstd::vector<long> reverse_Array_Upto_K(std::vector<long> input, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = reverse_Array_Upto_K;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (4)) == (std::vector<long>({(long)4, (long)3, (long)2, (long)1, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7})), (2)) == (std::vector<long>({(long)5, (long)4, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)7, (long)6, (long)5})), (3)) == (std::vector<long>({(long)7, (long)8, (long)9, (long)6, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of tuples using the second value of each tuple.\nstd::vector<std::tuple<std::string, long>> subject_marks(std::vector<std::tuple<std::string, long>> subjectmarks) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = subject_marks;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82), (std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54), (std::tuple<std::string, long>)std::make_tuple(\"Social\", 33)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social\", 33), (std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove characters from the first string which are present in the second string.\nstd::string remove_dirty_chars(std::string string, std::string second_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_dirty_chars;\n    assert(candidate((\"probasscurve\"), (\"pros\")) == (\"bacuve\"));\n    assert(candidate((\"digitalindia\"), (\"talent\")) == (\"digiidi\"));\n    assert(candidate((\"exoticmiles\"), (\"toxic\")) == (\"emles\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_float_long{\n    float f0;\n    long f1;    Union_float_long(float _f0) : f0(_f0) {}\n    Union_float_long(long _f1) : f1(_f1) {}\n    ~Union_float_long() {}\n    bool operator==(float f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nlong round_and_sum(std::vector<Union_float_long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = round_and_sum;\n    assert(candidate((std::vector<Union_float_long>({(float)22.4f, (float)4.0f, (float)-16.22f, (float)-9.1f, (float)11.0f, (float)-12.22f, (float)14.2f, (float)-5.2f, (float)17.5f}))) == (243));\n    assert(candidate((std::vector<Union_float_long>({(long)5, (long)2, (long)9, (long)24.3f, (long)29}))) == (345));\n    assert(candidate((std::vector<Union_float_long>({(float)25.0f, (float)56.7f, (float)89.2f}))) == (513));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the item with maximum frequency in a given list.\nlong max_occurrences(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_occurrences;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)2, (long)6, (long)5, (long)1, (long)6, (long)1, (long)2, (long)3, (long)2, (long)4, (long)6, (long)9, (long)1, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)7, (long)9, (long)15, (long)14, (long)10, (long)12, (long)13, (long)16, (long)18}))) == (8));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)20, (long)30, (long)40, (long)90, (long)80, (long)50, (long)30, (long)20, (long)50, (long)10}))) == (20));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nbool is_decimal(std::string num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_decimal;\n    assert(candidate((\"123.11\")) == (true));\n    assert(candidate((\"e666.86\")) == (false));\n    assert(candidate((\"3.124587\")) == (false));\n    assert(candidate((\"1.11\")) == (true));\n    assert(candidate((\"1.1.11\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nstd::map<std::string,long> dict_filter(std::map<std::string,long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = dict_filter;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (170)) == (std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (180)) == (std::map<std::string,long>({{\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (190)) == (std::map<std::string,long>({{\"Pierre Cox\", 190}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of even numbers at even positions of a list.\nlong sum_even_and_even_index(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_even_and_even_index;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1, (long)18, (long)8}))) == (30));\n    assert(candidate((std::vector<long>({(long)3, (long)20, (long)17, (long)9, (long)2, (long)10, (long)18, (long)13, (long)6, (long)18}))) == (26));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nlong max_sub_array_sum(std::vector<long> a, long size) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum;\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)4, (long)-1, (long)-2, (long)1, (long)5, (long)-3})), (8)) == (7));\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5, (long)-2, (long)-3, (long)2, (long)6, (long)-4})), (8)) == (8));\n    assert(candidate((std::vector<long>({(long)-4, (long)-5, (long)6, (long)-3, (long)-4, (long)3, (long)7, (long)-5})), (8)) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the intersection of two arrays.\nstd::vector<long> intersection_array(std::vector<long> array_nums1, std::vector<long> array_nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = intersection_array;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)2, (long)4, (long)8, (long)9}))) == (std::vector<long>({(long)1, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)3, (long)5, (long)7, (long)9}))) == (std::vector<long>({(long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<long>({(long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nstd::any split_two_parts(std::vector<std::any> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split_two_parts;\n    assert(candidate((std::vector<std::any>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == std::make_tuple(std::vector<long>({(long)1, (long)1, (long)2}), std::vector<long>({(long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (2)) == std::make_tuple(std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})), (4)) == std::make_tuple(std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\"}), std::vector<std::string>({(std::string)\"o\", (std::string)\"n\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nstd::tuple<std::string, long, long> find_literals(std::string text, std::string pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_literals;\n    assert(candidate((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")) == (std::make_tuple(\"fox\", 16, 19)));\n    assert(candidate((\"Its been a very crazy procedure right\"), (\"crazy\")) == (std::make_tuple(\"crazy\", 16, 21)));\n    assert(candidate((\"Hardest choices required strongest will\"), (\"will\")) == (std::make_tuple(\"will\", 35, 39)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the volume of a triangular prism.\nlong find_Volume(long l, long b, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Volume;\n    assert(candidate((10), (8), (6)) == (240));\n    assert(candidate((3), (2), (2)) == (6));\n    assert(candidate((1), (2), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlong wind_chill(long v, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = wind_chill;\n    assert(candidate((120), (35)) == (40));\n    assert(candidate((40), (20)) == (19));\n    assert(candidate((10), (8)) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ascii value of a character.\nlong ascii_value(std::string k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = ascii_value;\n    assert(candidate((\"A\")) == (65));\n    assert(candidate((\"R\")) == (82));\n    assert(candidate((\"S\")) == (83));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether all the characters are same or not.\nbool all_Characters_Same(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_Characters_Same;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"aaa\")) == (true));\n    assert(candidate((\"data\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to move all the numbers to the end of the given string.\nstd::string move_num(std::string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = move_num;\n    assert(candidate((\"I1love143you55three3000thousand\")) == (\"Iloveyouthreethousand1143553000\"));\n    assert(candidate((\"Avengers124Assemble\")) == (\"AvengersAssemble124\"));\n    assert(candidate((\"Its11our12path13to14see15things16do17things\")) == (\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the length of the word is odd or not.\nbool word_len(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = word_len;\n    assert(candidate((\"Hadoop\")) == (false));\n    assert(candidate((\"great\")) == (true));\n    assert(candidate((\"structure\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to drop empty items from a given dictionary.\nstd::map<std::string,std::string> drop_empty(std::map<std::string,std::optional<std::string>> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = drop_empty;\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", std::nullopt}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}})));\n    assert(candidate(std::map<std::string,std::nullopt>({{\"c1\", std::nullopt}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c2\", \"Green\"}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nstd::vector<std::string> insert_element(std::vector<std::string> list, std::string element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = insert_element;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Black\"})), (\"c\")) == (std::vector<std::string>({(std::string)\"c\", (std::string)\"Red\", (std::string)\"c\", (std::string)\"Green\", (std::string)\"c\", (std::string)\"Black\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"java\"})), (\"program\")) == (std::vector<std::string>({(std::string)\"program\", (std::string)\"python\", (std::string)\"program\", (std::string)\"java\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"happy\", (std::string)\"sad\"})), (\"laugh\")) == (std::vector<std::string>({(std::string)\"laugh\", (std::string)\"happy\", (std::string)\"laugh\", (std::string)\"sad\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove lowercase substrings from a given string.\nstd::string remove_lowercase(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_lowercase;\n    assert(candidate((\"PYTHon\")) == (\"PYTH\"));\n    assert(candidate((\"FInD\")) == (\"FID\"));\n    assert(candidate((\"STRinG\")) == (\"STRG\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nlong count_Set_Bits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_Set_Bits;\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (1));\n    assert(candidate((6)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract only the rear index element of each string in the given tuple.\nstd::vector<std::string> extract_rear(std::tuple<std::string, std::string, std::string> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_rear;\n    assert(candidate((std::make_tuple(\"Mers\", \"for\", \"Vers\"))) == (std::vector<std::string>({(std::string)\"s\", (std::string)\"r\", (std::string)\"s\"})));\n    assert(candidate((std::make_tuple(\"Avenge\", \"for\", \"People\"))) == (std::vector<std::string>({(std::string)\"e\", (std::string)\"r\", (std::string)\"e\"})));\n    assert(candidate((std::make_tuple(\"Gotta\", \"get\", \"go\"))) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"t\", (std::string)\"o\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurence of the string 'std' in a given string.\nlong count_occurance(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_occurance;\n    assert(candidate((\"letstdlenstdporstd\")) == (3));\n    assert(candidate((\"truststdsolensporsd\")) == (1));\n    assert(candidate((\"makestdsostdworthit\")) == (2));\n    assert(candidate((\"stds\")) == (1));\n    assert(candidate((\"\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuples contain the k or not.\nbool check_K(std::vector<long> test_tup, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_K;\n    assert(candidate((std::vector<long>({(long)10, (long)4, (long)5, (long)6, (long)8})), (6)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (7)) == (false));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)44, (long)11, (long)12})), (11)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to interleave 3 lists of the same length into a single flat list.\nstd::vector<long> interleave_lists(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = interleave_lists;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400, (long)500, (long)600, (long)700}))) == (std::vector<long>({(long)1, (long)10, (long)100, (long)2, (long)20, (long)200, (long)3, (long)30, (long)300, (long)4, (long)40, (long)400, (long)5, (long)50, (long)500, (long)6, (long)60, (long)600, (long)7, (long)70, (long)700})));\n    assert(candidate((std::vector<long>({(long)10, (long)20})), (std::vector<long>({(long)15, (long)2})), (std::vector<long>({(long)5, (long)10}))) == (std::vector<long>({(long)10, (long)15, (long)5, (long)20, (long)2, (long)10})));\n    assert(candidate((std::vector<long>({(long)11, (long)44})), (std::vector<long>({(long)10, (long)15})), (std::vector<long>({(long)20, (long)5}))) == (std::vector<long>({(long)11, (long)10, (long)20, (long)44, (long)15, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"python_program\")) == (\"PythonProgram\"));\n    assert(candidate((\"python_language\")) == (\"PythonLanguage\"));\n    assert(candidate((\"programming_language\")) == (\"ProgrammingLanguage\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of equal numbers from three given integers.\nlong test_three_equal(long x, long y, long z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = test_three_equal;\n    assert(candidate((1), (1), (1)) == (3));\n    assert(candidate((-1), (-2), (-3)) == (0));\n    assert(candidate((1), (2), (2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nlong odd_length_sum(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_length_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4}))) == (14));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (15));\n    assert(candidate((std::vector<long>({(long)1, (long)7}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the number of ways to partition a set of Bell numbers.\nlong bell_number(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bell_number;\n    assert(candidate((2)) == (2));\n    assert(candidate((10)) == (115975));\n    assert(candidate((56)) == (6775685320645824322581483068371419745979053216268760300));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the area of a rectangle.\nlong rectangle_area(long l, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rectangle_area;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((10), (5)) == (50));\n    assert(candidate((4), (2)) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find sum and average of first n natural numbers.\nstd::tuple<long, float> sum_average(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_average;\n    assert(candidate((10)) == (std::make_tuple(55, 5.5f)));\n    assert(candidate((15)) == (std::make_tuple(120, 8.0f)));\n    assert(candidate((20)) == (std::make_tuple(210, 10.5f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nstd::tuple<long, long, long, long> division_elements(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = division_elements;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(2, 2, 2, 3)));\n    assert(candidate((std::make_tuple(12, 6, 8, 16)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(2, 2, 2, 4)));\n    assert(candidate((std::make_tuple(20, 14, 36, 18)), (std::make_tuple(5, 7, 6, 9))) == (std::make_tuple(4, 2, 6, 2)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the sum of the digits of a non-negative integer.\nlong sum_digits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_digits;\n    assert(candidate((345)) == (12));\n    assert(candidate((12)) == (3));\n    assert(candidate((97)) == (16));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nstd::string index_minimum(std::vector<std::tuple<std::string, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = index_minimum;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Rash\", 143), (std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 200), (std::tuple<std::string, long>)std::make_tuple(\"Varsha\", 100)}))) == (\"Varsha\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Yash\", 185), (std::tuple<std::string, long>)std::make_tuple(\"Dawood\", 125), (std::tuple<std::string, long>)std::make_tuple(\"Sanya\", 175)}))) == (\"Dawood\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sai\", 345), (std::tuple<std::string, long>)std::make_tuple(\"Salman\", 145), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 96)}))) == (\"Ayesha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to divide two lists element wise.\nstd::vector<float> div_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = div_list;\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6})), (std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<float>({(float)4.0f, (float)2.5f, (float)2.0f})));\n    assert(candidate((std::vector<long>({(long)3, (long)2})), (std::vector<long>({(long)1, (long)4}))) == (std::vector<float>({(float)3.0f, (float)0.5f})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<float>({(float)1.8f, (float)1.7142857142857142f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the list with maximum length.\nstd::tuple<long, std::vector<long>> max_length_list(std::vector<std::vector<long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_length_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1})}))) == (std::make_tuple(5, std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12})}))) == (std::make_tuple(4, std::vector<long>({(long)6, (long)7, (long)8, (long)9}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_nullopt__std_vector_std_string_{\n    std::vector<std::nullopt> f0;\n    std::vector<std::string> f1;    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::nullopt> _f0) : f0(_f0) {}\n    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::string> _f1) : f1(_f1) {}\n    ~Union_std_vector_std_nullopt__std_vector_std_string_() {}\n    bool operator==(std::vector<std::nullopt> f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<std::string> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find all possible combinations of the elements of a given list.\nstd::vector<Union_std_vector_std_nullopt__std_vector_std_string_> combinations_list(std::vector<std::string> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = combinations_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\", (std::string)\"green\", (std::string)\"blue\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"blue\", (std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the largest and smallest value in a given array.\nlong big_sum(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = big_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to return the negative numbers in a list.\nstd::vector<long> neg_nos(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = neg_nos;\n    assert(candidate((std::vector<long>({(long)-1, (long)4, (long)5, (long)-6}))) == (std::vector<long>({(long)-1, (long)-6})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3, (long)4}))) == (std::vector<long>({(long)-1, (long)-2})));\n    assert(candidate((std::vector<long>({(long)-7, (long)-6, (long)8, (long)9}))) == (std::vector<long>({(long)-7, (long)-6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nlong highest_Power_of_2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = highest_Power_of_2;\n    assert(candidate((10)) == (8));\n    assert(candidate((19)) == (16));\n    assert(candidate((32)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a list contains the given sublist or not.\nbool is_sublist(std::vector<long> l, std::vector<long> s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_sublist;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)4, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)1, (long)6}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to subtract two lists element-wise.\nstd::vector<long> sub_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sub_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)-3, (long)-3, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (std::vector<long>({(long)3, (long)4}))) == (std::vector<long>({(long)-2, (long)-2})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<long>({(long)40, (long)50})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given two integers have opposite sign or not.\nbool opposite_Signs(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = opposite_Signs;\n    assert(candidate((1), (-2)) == (true));\n    assert(candidate((3), (2)) == (false));\n    assert(candidate((-10), (-10)) == (false));\n    assert(candidate((-2), (2)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nstd::tuple<long, long, long, long> tuple_modulo(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tuple_modulo;\n    assert(candidate((std::make_tuple(10, 4, 5, 6)), (std::make_tuple(5, 6, 7, 5))) == (std::make_tuple(0, 4, 5, 1)));\n    assert(candidate((std::make_tuple(11, 5, 6, 7)), (std::make_tuple(6, 7, 8, 6))) == (std::make_tuple(5, 5, 6, 1)));\n    assert(candidate((std::make_tuple(12, 6, 7, 8)), (std::make_tuple(7, 8, 9, 7))) == (std::make_tuple(5, 6, 7, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the difference of the first even and first odd number of a given list.\nlong diff_even_odd(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = diff_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each sublist of strings in a given list of lists.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"e\", (std::string)\"f\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last digit of a given number.\nlong last_Digit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = last_Digit;\n    assert(candidate((123)) == (3));\n    assert(candidate((25)) == (5));\n    assert(candidate((30)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nlong odd_num_sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_num_sum;\n    assert(candidate((2)) == (82));\n    assert(candidate((3)) == (707));\n    assert(candidate((4)) == (3108));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a list to a string.\nstd::string tup_string(std::vector<std::string> tup1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tup_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"e\", (std::string)\"x\", (std::string)\"e\", (std::string)\"r\", (std::string)\"c\", (std::string)\"i\", (std::string)\"s\", (std::string)\"e\", (std::string)\"s\"}))) == (\"exercises\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"}))) == (\"program\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all elements from a given list present in another list.\nstd::vector<long> remove_elements(std::vector<long> list1, std::vector<long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)3, (long)5, (long)7}))) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)5, (long)7}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)8, (long)9, (long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nbool overlapping(std::vector<long> list1, std::vector<long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = overlapping;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)8, (long)9}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5})), (std::vector<long>({(long)1, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to identify non-prime numbers.\nbool is_not_prime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_not_prime;\n    assert(candidate((2)) == (false));\n    assert(candidate((10)) == (true));\n    assert(candidate((35)) == (true));\n    assert(candidate((37)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the maximum value in a given heterogeneous list.\nlong max_val(std::vector<Union_std_string_long> listval) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (5));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (25));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (50));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nlong sum_negativenum(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_negativenum;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (-32));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)-14, (long)13, (long)-18, (long)12, (long)-20}))) == (-52));\n    assert(candidate((std::vector<long>({(long)19, (long)-65, (long)57, (long)39, (long)152, (long)-639, (long)121, (long)44, (long)90, (long)-190}))) == (-894));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nlong find_Rotations(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Rotations;\n    assert(candidate((\"aaaa\")) == (1));\n    assert(candidate((\"ab\")) == (2));\n    assert(candidate((\"abc\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nstd::string change_date_format(std::string dt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = change_date_format;\n    assert(candidate((\"2026-01-02\")) == (\"02-01-2026\"));\n    assert(candidate((\"2020-11-13\")) == (\"13-11-2020\"));\n    assert(candidate((\"2021-04-26\")) == (\"26-04-2021\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of integers and only returns the odd ones.\nstd::vector<long> Split(std::vector<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)12, (long)13}))) == (std::vector<long>({(long)11, (long)13})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)7, (long)9, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlong toggle_middle_bits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = toggle_middle_bits;\n    assert(candidate((9)) == (15));\n    assert(candidate((10)) == (12));\n    assert(candidate((11)) == (13));\n    assert(candidate((65)) == (127));\n    assert(candidate((77)) == (115));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlong count_char_position(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_char_position;\n    assert(candidate((\"xbcefg\")) == (2));\n    assert(candidate((\"ABcED\")) == (3));\n    assert(candidate((\"AbgdeF\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nstd::vector<long> large_product(std::vector<long> nums1, std::vector<long> nums2, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = large_product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (3)) == (std::vector<long>({(long)60, (long)54, (long)50})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (4)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (5)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48, (long)45})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nlong cummulative_sum(std::vector<std::vector<long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cummulative_sum;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)6})}))) == (30));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)7})}))) == (37));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)8})}))) == (44));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlong find_min_diff(std::vector<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_min_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)3, (long)19, (long)18, (long)25})), (6)) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)6})), (4)) == (1));\n    assert(candidate((std::vector<long>({(long)30, (long)5, (long)20, (long)9})), (4)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nbool text_starta_endb(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_starta_endb;\n    assert(candidate((\"aabbbb\")) == (true));\n    assert(candidate((\"aabAbbbc\")) == (false));\n    assert(candidate((\"accddbbjjj\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlong left_rotate(long n, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = left_rotate;\n    assert(candidate((16), (2)) == (64));\n    assert(candidate((10), (2)) == (40));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((1), (3)) == (8));\n    assert(candidate((5), (3)) == (40));\n    assert(candidate((29), (3)) == (232));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first repeated character in a given string.\nstd::optional<std::string> first_repeated_char(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = first_repeated_char;\n    assert(candidate((\"abcabc\")) == \"a\");\n    assert(candidate((\"abc\")) == std::nullopt);\n    assert(candidate((\"123123\")) == \"1\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count inversions in an array.\nlong get_Inv_Count(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_Inv_Count;\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)6, (long)4, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)6, (long)1}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlong even_Power_Sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_Power_Sum;\n    assert(candidate((2)) == (1056));\n    assert(candidate((3)) == (8832));\n    assert(candidate((1)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether all the given lists have equal length or not.\nbool get_equal(std::vector<std::vector<long>> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_equal;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)22, (long)33}), (std::vector<long>)std::vector<long>({(long)44, (long)55, (long)66})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)7})}))) == (false));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string represents an integer or not.\nbool check_integer(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_integer;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"1\")) == (true));\n    assert(candidate((\"12345\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nlong count_reverse_pairs(std::vector<std::string> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_reverse_pairs;\n    assert(candidate((std::vector<std::string>({(std::string)\"julia\", (std::string)\"best\", (std::string)\"tseb\", (std::string)\"for\", (std::string)\"ailuj\"}))) == (2));\n    assert(candidate((std::vector<std::string>({(std::string)\"geeks\", (std::string)\"best\", (std::string)\"for\", (std::string)\"skeeg\"}))) == (1));\n    assert(candidate((std::vector<std::string>({(std::string)\"makes\", (std::string)\"best\", (std::string)\"sekam\", (std::string)\"for\", (std::string)\"rof\"}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to move all zeroes to the end of the given list.\nstd::vector<long> move_zero(std::vector<long> num_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = move_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)0, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)0, (long)0, (long)4, (long)0, (long)5, (long)0}))) == (std::vector<long>({(long)2, (long)3, (long)2, (long)4, (long)5, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)0, (long)1, (long)1}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)0, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if given list contains no duplicates.\nbool check_distinct(std::vector<long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_distinct;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6, (long)1, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given amount has no profit and no loss\nbool noprofit_noloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = noprofit_noloss;\n    assert(candidate((1500), (1200)) == (false));\n    assert(candidate((100), (100)) == (true));\n    assert(candidate((2000), (5000)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all the words with k length in the given string.\nstd::string remove_length(std::string test_str, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_length;\n    assert(candidate((\"The person is most value tet\"), (3)) == (\"person is most value\"));\n    assert(candidate((\"If you told me about this ok\"), (4)) == (\"If you me about ok\"));\n    assert(candidate((\"Forces of darkeness is come into the play\"), (4)) == (\"Forces of darkeness is the\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count number of digits in a given string.\nlong number_ctr(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = number_ctr;\n    assert(candidate((\"program2bedone\")) == (1));\n    assert(candidate((\"3wonders\")) == (1));\n    assert(candidate((\"123\")) == (3));\n    assert(candidate((\"3wond-1ers2\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the total number of characters in a string.\nlong count_charac(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_charac;\n    assert(candidate((\"python programming\")) == (18));\n    assert(candidate((\"language\")) == (8));\n    assert(candidate((\"words\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlong get_total_number_of_sequences(long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_total_number_of_sequences;\n    assert(candidate((10), (4)) == (4));\n    assert(candidate((5), (2)) == (6));\n    assert(candidate((16), (3)) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nlong left_insertion(std::vector<long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = left_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nstd::vector<long> swap_numbers(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = swap_numbers;\n    assert(candidate((10), (20)) == (std::vector<long>({(long)20, (long)10})));\n    assert(candidate((15), (17)) == (std::vector<long>({(long)17, (long)15})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)200, (long)100})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nbool is_majority(std::vector<long> arr, long n, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_majority;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)3, (long)10})), (7), (3)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)4, (long)4, (long)4, (long)6, (long)6})), (8), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2})), (5), (1)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2})), (5), (1)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nstd::tuple<long, long, long> substract_elements(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = substract_elements;\n    assert(candidate((std::make_tuple(10, 4, 5)), (std::make_tuple(2, 5, 18))) == (std::make_tuple(8, -1, -13)));\n    assert(candidate((std::make_tuple(11, 2, 3)), (std::make_tuple(24, 45, 16))) == (std::make_tuple(-13, -43, -13)));\n    assert(candidate((std::make_tuple(7, 18, 9)), (std::make_tuple(10, 11, 12))) == (std::make_tuple(-3, 7, -3)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to put spaces between words starting with capital letters in a given string.\nstd::string capital_words_spaces(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = capital_words_spaces;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"PythonProgrammingExamples\")) == (\"Python Programming Examples\"));\n    assert(candidate((\"GetReadyToBeCodingFreak\")) == (\"Get Ready To Be Coding Freak\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the average of cubes of first n natural numbers.\nfloat find_Average_Of_Cube(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Average_Of_Cube;\n    assert(candidate((2)) == (4.5f));\n    assert(candidate((3)) == (float(12)));\n    assert(candidate((1)) == (float(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all values are same in a dictionary.\nbool check_value(std::map<std::string,long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_value;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (10)) == (false));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (12)) == (true));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (5)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth tetrahedral number.\nlong tetrahedral_number(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tetrahedral_number;\n    assert(candidate((5)) == (35));\n    assert(candidate((6)) == (56));\n    assert(candidate((7)) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate whether the matrix is a magic square.\nbool magic_square_test(std::vector<std::vector<long>> my_matrix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = magic_square_test;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)12, (long)1, (long)14}), (std::vector<long>)std::vector<long>({(long)2, (long)13, (long)8, (long)11}), (std::vector<long>)std::vector<long>({(long)16, (long)3, (long)10, (long)5}), (std::vector<long>)std::vector<long>({(long)9, (long)6, (long)15, (long)4})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)8})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)7})}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uppercase substrings from a given string.\nstd::string remove_uppercase(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_uppercase;\n    assert(candidate((\"cAstyoUrFavoRitETVshoWs\")) == (\"cstyoravoitshos\"));\n    assert(candidate((\"wAtchTheinTernEtrAdIo\")) == (\"wtchheinerntrdo\"));\n    assert(candidate((\"VoicESeaRchAndreComMendaTionS\")) == (\"oiceachndreomendaion\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to check whether an element exists within a tuple.\nbool check_tuplex(std::vector<Union_std_string_long> tuplex, std::any tuple1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_tuplex;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"r\"))) == (true));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"5\"))) == (false));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(3))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate a dog's age in dog's years.\nlong dog_age(long h_age) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = dog_age;\n    assert(candidate((12)) == (61));\n    assert(candidate((15)) == (73));\n    assert(candidate((24)) == (109));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the next perfect square greater than a given number.\nlong next_Perfect_Square(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = next_Perfect_Square;\n    assert(candidate((35)) == (36));\n    assert(candidate((6)) == (9));\n    assert(candidate((9)) == (16));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a list of N empty dictionaries.\nstd::vector<std::map<std::nullopt,std::nullopt>> empty_list(long length) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = empty_list;\n    assert(candidate((5)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((6)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((7)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert a given string to uppercase.\nstd::string is_upper(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_upper;\n    assert(candidate((\"person\")) == (\"PERSON\"));\n    assert(candidate((\"final\")) == (\"FINAL\"));\n    assert(candidate((\"Valid\")) == (\"VALID\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlong odd_Equivalent(std::string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_Equivalent;\n    assert(candidate((\"011001\"), (6)) == (3));\n    assert(candidate((\"11011\"), (5)) == (4));\n    assert(candidate((\"1010\"), (4)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nstd::vector<long> re_arrange_array(std::vector<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = re_arrange_array;\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)-3, (long)4, (long)5, (long)6, (long)-7, (long)8, (long)9})), (9)) == (std::vector<long>({(long)-1, (long)-3, (long)-7, (long)4, (long)5, (long)6, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)12, (long)-14, (long)-26, (long)13, (long)15})), (5)) == (std::vector<long>({(long)-14, (long)-26, (long)12, (long)13, (long)15})));\n    assert(candidate((std::vector<long>({(long)10, (long)24, (long)36, (long)-42, (long)-39, (long)-78, (long)85})), (7)) == (std::vector<long>({(long)-42, (long)-39, (long)-78, (long)10, (long)24, (long)36, (long)85})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nbool unique_Element(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks from a string.\nstd::vector<std::string> extract_values(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_values;\n    assert(candidate((\"\"Python\", \"PHP\", \"Java\"\")) == (std::vector<std::string>({(std::string)\"Python\", (std::string)\"PHP\", (std::string)\"Java\"})));\n    assert(candidate((\"\"python\",\"program\",\"language\"\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\"})));\n    assert(candidate((\"\"red\",\"blue\",\"green\",\"yellow\"\")) == (std::vector<std::string>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"yellow\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count true booleans in the given list.\nlong count(std::vector<bool> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count;\n    assert(candidate((std::vector<bool>({(bool)true, (bool)false, (bool)true}))) == (2));\n    assert(candidate((std::vector<bool>({(bool)false, (bool)false}))) == (0));\n    assert(candidate((std::vector<bool>({(bool)true, (bool)true, (bool)true}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nlong find_even_pair(std::vector<long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_even_pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1}))) == (4));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11}))) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is armstrong or not.\nbool armstrong_number(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = armstrong_number;\n    assert(candidate((153)) == (true));\n    assert(candidate((259)) == (false));\n    assert(candidate((4458)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the upper case characters in a given string.\nlong upper_ctr(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = upper_ctr;\n    assert(candidate((\"PYthon\")) == (1));\n    assert(candidate((\"BigData\")) == (1));\n    assert(candidate((\"program\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the elementwise and tuples from the given two tuples.\nstd::tuple<long, long, long, long> and_tuples(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = and_tuples;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(0, 0, 2, 1)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(5, 6, 7, 8))) == (std::make_tuple(1, 2, 3, 0)));\n    assert(candidate((std::make_tuple(8, 9, 11, 12)), (std::make_tuple(7, 13, 14, 17))) == (std::make_tuple(0, 9, 10, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether it follows the sequence given in the patterns array.\nbool is_samepatterns(std::vector<std::string> colors, std::vector<std::string> patterns) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_samepatterns;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"green\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of lists in a given number of lists.\nlong count_list(std::vector<std::vector<long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)2, (long)0})}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nstd::vector<float> average_tuple(std::vector<std::vector<long>> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = average_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)10, (long)10, (long)10, (long)12}), (std::vector<long>)std::vector<long>({(long)30, (long)45, (long)56, (long)45}), (std::vector<long>)std::vector<long>({(long)81, (long)80, (long)39, (long)32}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (std::vector<float>({(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)-5}), (std::vector<long>)std::vector<long>({(long)30, (long)-15, (long)56}), (std::vector<long>)std::vector<long>({(long)81, (long)-60, (long)-39}), (std::vector<long>)std::vector<long>({(long)-10, (long)2, (long)3})}))) == (std::vector<float>({(float)25.5f, (float)-18.0f, (float)3.75f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)100, (long)100, (long)100, (long)120}), (std::vector<long>)std::vector<long>({(long)300, (long)450, (long)560, (long)450}), (std::vector<long>)std::vector<long>({(long)810, (long)800, (long)390, (long)320}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::vector<float>({(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlong lcs_of_three(std::string X, std::string Y, std::string Z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = lcs_of_three;\n    assert(candidate((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2));\n    assert(candidate((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5));\n    assert(candidate((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th star number.\nlong find_star_num(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_star_num;\n    assert(candidate((3)) == (37));\n    assert(candidate((4)) == (73));\n    assert(candidate((5)) == (121));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of an array.\nlong _sum(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = _sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)15, (long)12, (long)13, (long)10}))) == (50));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given list contains consecutive numbers or not.\nbool check_Consecutive(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_Consecutive;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb and their positions in a given sentence.\nstd::tuple<long, long, std::string> find_adverb_position(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_adverb_position;\n    assert(candidate((\"clearly!! we can see the sky\")) == (std::make_tuple(0, 7, \"clearly\")));\n    assert(candidate((\"seriously!! there are many roses\")) == (std::make_tuple(0, 9, \"seriously\")));\n    assert(candidate((\"unfortunately!! sita is going to home\")) == (std::make_tuple(0, 13, \"unfortunately\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nstd::vector<long> rotate_right(std::vector<long> list, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rotate_right;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (3)) == (std::vector<long>({(long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (5)) == (std::vector<long>({(long)6, (long)7, (long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of non-empty substrings of a given string.\nlong number_of_substrings(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = number_of_substrings;\n    assert(candidate((\"abc\")) == (6));\n    assert(candidate((\"abcd\")) == (10));\n    assert(candidate((\"abcde\")) == (15));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nstd::vector<std::vector<std::any>> list_split(std::vector<std::any> S, long step) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = list_split;\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"e\", (std::string)\"f\", (std::string)\"g\", (std::string)\"h\", (std::string)\"i\", (std::string)\"j\", (std::string)\"k\", (std::string)\"l\", (std::string)\"m\", (std::string)\"n\"})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"d\", (std::string)\"g\", (std::string)\"j\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\", (std::string)\"e\", (std::string)\"h\", (std::string)\"k\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"f\", (std::string)\"i\", (std::string)\"l\"})})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11, (long)12, (long)13, (long)14})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)4, (long)7, (long)10, (long)13}), (std::vector<long>)std::vector<long>({(long)2, (long)5, (long)8, (long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)12})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"python\", (std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\", (std::string)\"SQL\"})), (2)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"python\", (std::string)\"C\", (std::string)\"DBMS\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"java\", (std::string)\"C++\", (std::string)\"SQL\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check if the elements of a given list are unique or not.\nbool all_unique(std::vector<long> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_unique;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert complex numbers to polar coordinates.\nstd::tuple<float, float> convert(long numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = convert;\n    assert(candidate((1)) == (std::make_tuple(1.0f, 0.0f)));\n    assert(candidate((4)) == (std::make_tuple(4.0f, 0.0f)));\n    assert(candidate((5)) == (std::make_tuple(5.0f, 0.0f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nstd::map<std::string,std::tuple<float, long>> filter_data(std::map<std::string,std::tuple<float, long>> students, float h, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_data;\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (6.0f), (70)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.9f), (67)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.7f), (64)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert the given string to lower case.\nstd::string is_lower(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_lower;\n    assert(candidate((\"InValid\")) == (\"invalid\"));\n    assert(candidate((\"TruE\")) == (\"true\"));\n    assert(candidate((\"SenTenCE\")) == (\"sentence\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nlong next_power_of_2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = next_power_of_2;\n    assert(candidate((0)) == (1));\n    assert(candidate((5)) == (8));\n    assert(candidate((17)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string is present as a substring in a given list of string values.\nbool find_substring(std::vector<std::string> str1, std::string sub_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_substring;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ack\")) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"abc\")) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ange\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace characters in a string.\nstd::string replace_char(std::string str1, std::string ch, std::string newch) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_char;\n    assert(candidate((\"polygon\"), (\"y\"), (\"l\")) == (\"pollgon\"));\n    assert(candidate((\"character\"), (\"c\"), (\"a\")) == (\"aharaater\"));\n    assert(candidate((\"python\"), (\"l\"), (\"a\")) == (\"python\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the product of first even and odd number of a given list.\nlong mul_even_odd(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = mul_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a list to a tuple.\nstd::any list_tuple(std::vector<long> listx) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = list_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)10, (long)7, (long)4, (long)15, (long)3}))) == std::make_tuple(5, 10, 7, 4, 15, 3));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)2, (long)3, (long)4, (long)4, (long)7}))) == std::make_tuple(2, 4, 5, 6, 2, 3, 4, 4, 7));\n    assert(candidate((std::vector<long>({(long)58, (long)44, (long)56}))) == std::make_tuple(58, 44, 56));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlong even_binomial_Coeff_Sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_binomial_Coeff_Sum;\n    assert(candidate((4)) == (8));\n    assert(candidate((6)) == (32));\n    assert(candidate((2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nstd::tuple<long, long, long, long> bitwise_xor(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = bitwise_xor;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(15, 6, 5, 10)));\n    assert(candidate((std::make_tuple(11, 5, 7, 10)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(13, 6, 3, 14)));\n    assert(candidate((std::make_tuple(12, 6, 8, 11)), (std::make_tuple(7, 4, 5, 6))) == (std::make_tuple(11, 2, 13, 13)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether a list is sublist of another or not.\nbool is_Sub_Array(std::vector<long> A, std::vector<long> B) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_Sub_Array;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)5})), (std::vector<long>({(long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (std::vector<long>({(long)1, (long)2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)2})), (std::vector<long>({(long)2, (long)2, (long)0}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nlong max_sub_array_sum_repeated(std::vector<long> a, long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum_repeated;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)-30, (long)-1})), (4), (3)) == (30));\n    assert(candidate((std::vector<long>({(long)-1, (long)10, (long)20})), (3), (2)) == (59));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3})), (3), (3)) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nlong min_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (8));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (30));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (100));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nbool count_divisors(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_divisors;\n    assert(candidate((10)) == (true));\n    assert(candidate((100)) == (false));\n    assert(candidate((125)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nstd::optional<long> triangle_area(long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((-1)) == std::nullopt);\n    assert(candidate((0)) == 0);\n    assert(candidate((2)) == 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given string to a list of characters.\nstd::vector<std::string> string_to_tuple(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = string_to_tuple;\n    assert(candidate((\"python 3.0\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\", (std::string)\"3\", (std::string)\".\", (std::string)\"0\"})));\n    assert(candidate((\"item1\")) == (std::vector<std::string>({(std::string)\"i\", (std::string)\"t\", (std::string)\"e\", (std::string)\"m\", (std::string)\"1\"})));\n    assert(candidate((\"15.10\")) == (std::vector<std::string>({(std::string)\"1\", (std::string)\"5\", (std::string)\".\", (std::string)\"1\", (std::string)\"0\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlong find_length(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_length;\n    assert(candidate((\"11000010001\")) == (6));\n    assert(candidate((\"10111\")) == (1));\n    assert(candidate((\"11011101100101\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlong count_Primes_nums(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_Primes_nums;\n    assert(candidate((5)) == (2));\n    assert(candidate((10)) == (4));\n    assert(candidate((100)) == (25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nlong sum_Of_product(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_Of_product;\n    assert(candidate((3)) == (15));\n    assert(candidate((4)) == (56));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the maximum aggregate from the list of tuples.\nstd::tuple<std::string, long> max_aggregate(std::vector<std::tuple<std::string, long>> stdata) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_aggregate;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 7), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 122), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 84)}))) == (std::make_tuple(\"Juan Whelan\", 212)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 50), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 48), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 37), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 22), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 14)}))) == (std::make_tuple(\"Juan Whelan\", 72)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 20), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 30), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 40), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 50)}))) == (std::make_tuple(\"Sabah Colley\", 70)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of elements.\nstd::vector<long> comb_sort(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = comb_sort;\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)37, (long)25, (long)79}))) == (std::vector<long>({(long)5, (long)15, (long)25, (long)37, (long)79})));\n    assert(candidate((std::vector<long>({(long)41, (long)32, (long)15, (long)19, (long)22}))) == (std::vector<long>({(long)15, (long)19, (long)22, (long)32, (long)41})));\n    assert(candidate((std::vector<long>({(long)99, (long)15, (long)13, (long)47}))) == (std::vector<long>({(long)13, (long)15, (long)47, (long)99})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nbool check_expression(std::string exp) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_expression;\n    assert(candidate((\"{()}[{}]\")) == (true));\n    assert(candidate((\"{()}[{]\")) == (false));\n    assert(candidate((\"{()}[{}][]({})\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a word containing 'z'.\nbool text_match_wordz(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_wordz;\n    assert(candidate((\"pythonz.\")) == (true));\n    assert(candidate((\"xyz.\")) == (true));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nstd::vector<long> sum_list(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_list;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (std::vector<long>({(long)15, (long)25, (long)35}))) == (std::vector<long>({(long)25, (long)45, (long)65})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)5, (long)6, (long)7}))) == (std::vector<long>({(long)6, (long)8, (long)10})));\n    assert(candidate((std::vector<long>({(long)15, (long)20, (long)30})), (std::vector<long>({(long)15, (long)45, (long)75}))) == (std::vector<long>({(long)30, (long)65, (long)105})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlong newman_prime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = newman_prime;\n    assert(candidate((3)) == (7));\n    assert(candidate((4)) == (17));\n    assert(candidate((5)) == (41));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to apply a given format string to all of the elements in a list.\nstd::vector<std::string> add_string(std::vector<std::any> list_, std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_string;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (\"temp{0}\")) == (std::vector<std::string>({(std::string)\"temp1\", (std::string)\"temp2\", (std::string)\"temp3\", (std::string)\"temp4\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (\"python{0}\")) == (std::vector<std::string>({(std::string)\"pythona\", (std::string)\"pythonb\", (std::string)\"pythonc\", (std::string)\"pythond\"})));\n    assert(candidate((std::vector<std::any>({(long)5, (long)6, (long)7, (long)8})), (\"string{0}\")) == (std::vector<std::string>({(std::string)\"string5\", (std::string)\"string6\", (std::string)\"string7\", (std::string)\"string8\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nlong surface_Area(long b, long s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = surface_Area;\n    assert(candidate((3), (4)) == (33));\n    assert(candidate((4), (5)) == (56));\n    assert(candidate((1), (2)) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the smallest list in a list of lists.\nlong Find_Min_Length(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Find_Min_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (1));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (2));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4, (long)4, (long)4})}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nbool validate(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = validate;\n    assert(candidate((1234)) == (true));\n    assert(candidate((51241)) == (false));\n    assert(candidate((321)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth hexagonal number.\nlong hexagonal_num(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = hexagonal_num;\n    assert(candidate((10)) == (190));\n    assert(candidate((5)) == (45));\n    assert(candidate((7)) == (91));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th lucas number.\nlong find_lucas(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_lucas;\n    assert(candidate((9)) == (76));\n    assert(candidate((4)) == (7));\n    assert(candidate((3)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to get the difference between two lists.\nstd::vector<long> Diff(std::vector<long> li1, std::vector<long> li2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Diff;\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25, (long)30, (long)35, (long)40})), (std::vector<long>({(long)25, (long)40, (long)35}))) == (std::vector<long>({(long)10, (long)20, (long)30, (long)15})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)6, (long)7})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks \" \" of the given string.\nstd::vector<std::any> extract_quotation(std::string text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_quotation;\n    assert(candidate((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")) == (std::vector<std::any>({(std::string)\"A53\", (std::string)\"multi\", (std::string)\"Processor\"})));\n    assert(candidate((\"Cast your \"favorite\" entertainment \"apps\"\")) == (std::vector<std::any>({(std::string)\"favorite\", (std::string)\"apps\"})));\n    assert(candidate((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")) == (std::vector<std::any>({(std::string)\"4k Ultra HD\", (std::string)\"HDR 10\"})));\n    assert(candidate((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a list and sum all of its elements.\nlong recursive_list_sum(std::vector<Union_long_std_vector_long_> data_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = recursive_list_sum;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({1, 2, std::vector<long>({(long)3, (long)4}), std::vector<long>({(long)5, (long)6})}))) == (21));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({7, 10, std::vector<long>({(long)15, (long)14}), std::vector<long>({(long)19, (long)41})}))) == (106));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({10, 20, std::vector<long>({(long)30, (long)40}), std::vector<long>({(long)50, (long)60})}))) == (210));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nbool differ_At_One_Bit_Pos(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = differ_At_One_Bit_Pos;\n    assert(candidate((13), (9)) == (true));\n    assert(candidate((15), (8)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((2), (3)) == (true));\n    assert(candidate((5), (1)) == (true));\n    assert(candidate((1), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by three 'b'.\nbool text_match_three(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"caacabbbba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nlong max_product(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_product;\n    assert(candidate((std::vector<long>({(long)3, (long)100, (long)4, (long)5, (long)150, (long)6}))) == (3000));\n    assert(candidate((std::vector<long>({(long)4, (long)42, (long)55, (long)68, (long)80}))) == (50265600));\n    assert(candidate((std::vector<long>({(long)10, (long)22, (long)9, (long)33, (long)21, (long)50, (long)41, (long)60}))) == (2460));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nstd::vector<long> split_Arr(std::vector<long> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split_Arr;\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)5, (long)6, (long)52, (long)36})), (2)) == (std::vector<long>({(long)5, (long)6, (long)52, (long)36, (long)12, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (1)) == (std::vector<long>({(long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (3)) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)0, (long)1, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the number of divisors of a given integer.\nlong divisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = divisor;\n    assert(candidate((15)) == (4));\n    assert(candidate((12)) == (6));\n    assert(candidate((9)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the difference between largest and smallest value in a given list.\nlong big_diff(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = big_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)12}))) == (8));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)3}))) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find squares of individual elements in a list.\nstd::vector<long> square_nums(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = square_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)100, (long)400, (long)900})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)144, (long)225})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuple has any none value or not.\nbool check_none(std::any test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_none;\n    assert(candidate(std::make_tuple(std::optional<long>(10), std::optional<long>(4), std::optional<long>(5), std::optional<long>(6), std::optional<long>(std::nullopt))) == (true));\n    assert(candidate(std::make_tuple(7, 8, 9, 11, 14)) == (false));\n    assert(candidate(std::make_tuple(std::optional<long>(1), std::optional<long>(2), std::optional<long>(3), std::optional<long>(4), std::optional<long>(std::nullopt))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given array is monotonic or not.\nbool is_Monotonic(std::vector<long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_Monotonic;\n    assert(candidate((std::vector<long>({(long)6, (long)5, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nbool is_perfect_square(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_perfect_square;\n    assert(candidate((10)) == (false));\n    assert(candidate((36)) == (true));\n    assert(candidate((14)) == (false));\n    assert(candidate((196)) == (true));\n    assert(candidate((125)) == (false));\n    assert(candidate((15625)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of common divisors of two given numbers.\nlong sum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum;\n    assert(candidate((10), (15)) == (6));\n    assert(candidate((100), (150)) == (93));\n    assert(candidate((4), (6)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the list of maximum length in a list of lists.\nstd::tuple<long, std::vector<long>> max_length(std::vector<std::vector<long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)12, (long)14, (long)15})}))) == (std::make_tuple(4, std::vector<long>({(long)10, (long)12, (long)14, (long)15}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)15, (long)20, (long)25})}))) == (std::make_tuple(3, std::vector<long>({(long)15, (long)20, (long)25}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nstd::map<std::tuple<long, long>,long> check_occurences(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_occurences;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(5, 2), (std::tuple<long, long>)std::make_tuple(6, 3)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(1, 3), 2}, {std::make_tuple(2, 5), 2}, {std::make_tuple(3, 6), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 2), (std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(3, 6), (std::tuple<long, long>)std::make_tuple(6, 3), (std::tuple<long, long>)std::make_tuple(7, 4)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 4), 2}, {std::make_tuple(3, 6), 2}, {std::make_tuple(4, 7), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(13, 2), (std::tuple<long, long>)std::make_tuple(11, 23), (std::tuple<long, long>)std::make_tuple(12, 25), (std::tuple<long, long>)std::make_tuple(25, 12), (std::tuple<long, long>)std::make_tuple(16, 23)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 13), 1}, {std::make_tuple(11, 23), 1}, {std::make_tuple(12, 25), 2}, {std::make_tuple(16, 23), 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the directrix of a parabola.\nlong parabola_directrix(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = parabola_directrix;\n    assert(candidate((5), (3), (2)) == (-198));\n    assert(candidate((9), (8), (4)) == (-2336));\n    assert(candidate((2), (4), (6)) == (-130));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nstd::optional<std::tuple<std::string, long, long>> occurance_substring(std::string text, std::string pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = occurance_substring;\n    assert(candidate((\"python programming, python language\"), (\"python\")) == std::make_tuple(\"python\", 0, 6));\n    assert(candidate((\"python programming,programming language\"), (\"programming\")) == std::make_tuple(\"programming\", 7, 18));\n    assert(candidate((\"python programming,programming language\"), (\"language\")) == std::make_tuple(\"language\", 31, 39));\n    assert(candidate((\"c++ programming, c++ language\"), (\"python\")) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove tuples from the given tuple.\nstd::tuple<long, long, long, long> remove_nested(std::any test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_nested;\n    assert(candidate(std::make_tuple(1, 5, 7, std::make_tuple(4, 6), 10)) == (std::make_tuple(1, 5, 7, 10)));\n    assert(candidate(std::make_tuple(2, 6, 8, std::make_tuple(5, 7), 11)) == (std::make_tuple(2, 6, 8, 11)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), 12)) == (std::make_tuple(3, 7, 9, 12)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), std::make_tuple(5, 12), 12)) == (std::make_tuple(3, 7, 9, 12)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each sublist of strings in a given list of lists.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"blue \", (std::string)\" black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" black\", (std::string)\"blue \"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"zilver\", (std::string)\"gold\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"magnesium\", (std::string)\"aluminium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"steel\", (std::string)\"bronze\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"gold\", (std::string)\"zilver\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"aluminium\", (std::string)\"magnesium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"bronze\", (std::string)\"steel\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nstd::vector<long> remove_kth_element(std::vector<long> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_kth_element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == (std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})), (4)) == (std::vector<long>({(long)0, (long)0, (long)1, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})), (5)) == (std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nstd::tuple<long, long, long, std::map<std::string,long>> add_dict_to_tuple(std::tuple<long, long, long> test_tup, std::map<std::string,long> test_dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_dict_to_tuple;\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))) == (std::make_tuple(4, 5, 6, std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))));\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))) == (std::make_tuple(1, 2, 3, std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))));\n    assert(candidate((std::make_tuple(8, 9, 10)), (std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))) == (std::make_tuple(8, 9, 10, std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nlong find(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find;\n    assert(candidate((10), (3)) == (3));\n    assert(candidate((4), (2)) == (2));\n    assert(candidate((20), (5)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nbool text_match_two_three(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_two_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the occurence of all elements of list in a tuple.\nlong count_Occurrence(std::any tup, std::vector<std::any> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_Occurrence;\n    assert(candidate(std::make_tuple(\"a\", \"a\", \"c\", \"b\", \"d\"), (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\"}))) == (3));\n    assert(candidate(std::make_tuple(1, 2, 3, 1, 4, 6, 7, 1, 4), (std::vector<std::any>({(long)1, (long)4, (long)7}))) == (6));\n    assert(candidate(std::make_tuple(1, 2, 3, 4, 5, 6), (std::vector<std::any>({(long)1, (long)2}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count number items that are identical in the same position of three given lists.\nlong count_samepair(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_samepair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by one or more b's.\nbool text_match_one(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlong difference(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = difference;\n    assert(candidate((3)) == (30));\n    assert(candidate((5)) == (210));\n    assert(candidate((2)) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to toggle the case of all characters in a string.\nstd::string toggle_string(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = toggle_string;\n    assert(candidate((\"Python\")) == (\"pYTHON\"));\n    assert(candidate((\"Pangram\")) == (\"pANGRAM\"));\n    assert(candidate((\"LIttLE\")) == (\"liTTle\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the element of a list having maximum length.\nstd::vector<std::any> Find_Max(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Find_Max;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})}))) == (std::vector<std::any>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)5, (long)6, (long)1})}))) == (std::vector<std::any>({(long)1, (long)5, (long)6, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the Eulerian number a(n, m).\nlong eulerian_num(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = eulerian_num;\n    assert(candidate((3), (1)) == (4));\n    assert(candidate((4), (1)) == (11));\n    assert(candidate((5), (3)) == (26));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurrences of a number in a given list.\nlong frequency(std::vector<long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = frequency;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4})), (3)) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)1, (long)2})), (1)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nstd::vector<long> sort_numeric_strings(std::vector<std::string> nums_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_numeric_strings;\n    assert(candidate((std::vector<std::string>({(std::string)\"4\", (std::string)\"12\", (std::string)\"45\", (std::string)\"7\", (std::string)\"0\", (std::string)\"100\", (std::string)\"200\", (std::string)\"-12\", (std::string)\"-500\"}))) == (std::vector<long>({(long)-500, (long)-12, (long)0, (long)4, (long)7, (long)12, (long)45, (long)100, (long)200})));\n    assert(candidate((std::vector<std::string>({(std::string)\"2\", (std::string)\"3\", (std::string)\"8\", (std::string)\"4\", (std::string)\"7\", (std::string)\"9\", (std::string)\"8\", (std::string)\"2\", (std::string)\"6\", (std::string)\"5\", (std::string)\"1\", (std::string)\"6\", (std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"6\", (std::string)\"9\", (std::string)\"1\", (std::string)\"2\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)8, (long)9, (long)9})));\n    assert(candidate((std::vector<std::string>({(std::string)\"1\", (std::string)\"3\", (std::string)\"5\", (std::string)\"7\", (std::string)\"1\", (std::string)\"3\", (std::string)\"13\", (std::string)\"15\", (std::string)\"17\", (std::string)\"5\", (std::string)\"7 \", (std::string)\"9\", (std::string)\"1\", (std::string)\"11\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)3, (long)3, (long)5, (long)5, (long)7, (long)7, (long)9, (long)11, (long)13, (long)15, (long)17})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfloat geometric_sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = geometric_sum;\n    assert(candidate((7)) == (1.9921875f));\n    assert(candidate((4)) == (1.9375f));\n    assert(candidate((8)) == (1.99609375f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nstd::vector<long> divisible_by_digits(long startnum, long endnum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = divisible_by_digits;\n    assert(candidate((1), (22)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15, (long)22})));\n    assert(candidate((1), (15)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15})));\n    assert(candidate((20), (25)) == (std::vector<long>({(long)22, (long)24})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to calculate the product of the unique numbers in a given list.\nlong unique_product(std::vector<long> list_data) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = unique_product;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)20, (long)50, (long)60, (long)40}))) == (720000000));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1}))) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)0, (long)1, (long)1}))) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the largest negative number from the given list.\nlong largest_neg(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = largest_neg;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-4, (long)-6}))) == (-6));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-8, (long)-9}))) == (-9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)-1}))) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove consecutive duplicates of a given list.\nstd::vector<std::any> consecutive_duplicates(std::vector<std::any> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::any>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)4})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::any>({(long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)17, (long)18, (long)10})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\", (std::string)\"a\", (std::string)\"a\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"a\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfloat min_Jumps(std::tuple<long, long> steps, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_Jumps;\n    assert(candidate((std::make_tuple(3, 4)), (11)) == (3.5f));\n    assert(candidate((std::make_tuple(3, 4)), (0)) == (float(0)));\n    assert(candidate((std::make_tuple(11, 14)), (11)) == (float(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find a pair with highest product from a given array of integers.\nstd::tuple<long, long> max_Product(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_Product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)0, (long)8, (long)4}))) == (std::make_tuple(7, 8)));\n    assert(candidate((std::vector<long>({(long)0, (long)-1, (long)-2, (long)-4, (long)5, (long)0, (long)-6}))) == (std::make_tuple(-4, -6)));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::make_tuple(2, 3)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the nth element from a given list of tuples.\nstd::vector<std::any> extract_nth_element(std::vector<std::tuple<std::string, long, long>> list1, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_nth_element;\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (0)) == (std::vector<std::any>({(std::string)\"Greyson Fulton\", (std::string)\"Brady Kent\", (std::string)\"Wyatt Knott\", (std::string)\"Beau Turnbull\"})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (2)) == (std::vector<std::any>({(long)99, (long)96, (long)94, (long)98})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (1)) == (std::vector<std::any>({(long)98, (long)97, (long)91, (long)94})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth nonagonal number.\nlong is_nonagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_nonagonal;\n    assert(candidate((10)) == (325));\n    assert(candidate((15)) == (750));\n    assert(candidate((18)) == (1089));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the maximum difference between any two elements in a given array.\nlong max_Abs_Diff(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_Abs_Diff;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)3, (long)2, (long)5, (long)1}))) == (8));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nstd::vector<std::vector<std::any>> pack_consecutive_duplicates(std::vector<std::any> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pack_consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)8}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)4})})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)10, (long)10}), (std::vector<long>)std::vector<long>({(long)15}), (std::vector<long>)std::vector<long>({(long)19}), (std::vector<long>)std::vector<long>({(long)18, (long)18}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)26, (long)26}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)18}), (std::vector<long>)std::vector<long>({(long)10})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"a\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"d\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of perrin numbers.\nlong cal_sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = cal_sum;\n    assert(candidate((9)) == (49));\n    assert(candidate((10)) == (66));\n    assert(candidate((11)) == (88));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove the characters which have odd index values of a given string.\nstd::string odd_values_string(std::string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_values_string;\n    assert(candidate((\"abcdef\")) == (\"ace\"));\n    assert(candidate((\"python\")) == (\"pto\"));\n    assert(candidate((\"data\")) == (\"dt\"));\n    assert(candidate((\"lambs\")) == (\"lms\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find kth element from the given two sorted arrays.\nlong find_kth(std::vector<long> arr1, std::vector<long> arr2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_kth;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6, (long)7, (long)9})), (std::vector<long>({(long)1, (long)4, (long)8, (long)10})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)100, (long)112, (long)256, (long)349, (long)770})), (std::vector<long>({(long)72, (long)86, (long)113, (long)119, (long)265, (long)445, (long)892})), (7)) == (256));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)7, (long)8, (long)10})), (std::vector<long>({(long)2, (long)5, (long)9, (long)11})), (6)) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlong jacobsthal_num(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = jacobsthal_num;\n    assert(candidate((5)) == (11));\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (5));\n    assert(candidate((13)) == (2731));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nstd::map<long,long> frequency_lists(std::vector<std::vector<long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = frequency_lists;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)2}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9, (long)5})}))) == (std::map<long,long>({{1, 1}, {2, 3}, {3, 1}, {4, 1}, {5, 2}, {6, 1}, {7, 1}, {8, 1}, {9, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12})}))) == (std::map<long,long>({{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)20, (long)30, (long)40, (long)17}), (std::vector<long>)std::vector<long>({(long)18, (long)16, (long)14, (long)13}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::map<long,long>({{20, 2}, {30, 2}, {40, 2}, {17, 1}, {18, 1}, {16, 1}, {14, 1}, {13, 1}, {10, 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find perfect squares between two given numbers.\nstd::vector<long> perfect_squares(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = perfect_squares;\n    assert(candidate((1), (30)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25})));\n    assert(candidate((50), (100)) == (std::vector<long>({(long)64, (long)81, (long)100})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)100, (long)121, (long)144, (long)169, (long)196})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nlong sum_Of_Subarray_Prod(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_Of_Subarray_Prod;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (20));\n    assert(candidate((std::vector<long>({(long)1, (long)2}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first odd number in a given list of numbers.\nlong first_odd(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = first_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5}))) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)9, (long)1}))) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nstd::vector<std::vector<long>> add_nested_tuples(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_nested_tuples;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)10}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)13})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)12}), (std::vector<long>)std::vector<long>({(long)9, (long)16}), (std::vector<long>)std::vector<long>({(long)5, (long)12}), (std::vector<long>)std::vector<long>({(long)10, (long)15})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)11, (long)18}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)12, (long)17})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nstd::vector<std::vector<std::any>> merge(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = merge;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8})}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6, (long)8})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\", (std::string)\"o\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"z\", (std::string)\"c\", (std::string)\"o\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nbool dif_Square(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = dif_Square;\n    assert(candidate((5)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((15)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nbool check_smaller(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_smaller;\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::make_tuple(2, 3, 4))) == (false));\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::make_tuple(3, 4, 5))) == (true));\n    assert(candidate((std::make_tuple(11, 12, 13)), (std::make_tuple(10, 11, 12))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nstd::map<long,long> freq_count(std::vector<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = freq_count;\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)10, (long)10, (long)20, (long)20, (long)20, (long)20, (long)40, (long)40, (long)50, (long)50, (long)30}))) == (std::map<long,long>({{10, 4}, {20, 4}, {40, 2}, {50, 2}, {30, 1}})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)4, (long)1, (long)3, (long)1, (long)4}))) == (std::map<long,long>({{1, 3}, {2, 2}, {3, 3}, {4, 3}})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)4, (long)9, (long)10, (long)4, (long)5, (long)6, (long)7, (long)9, (long)5}))) == (std::map<long,long>({{10, 1}, {5, 3}, {6, 2}, {7, 2}, {4, 2}, {9, 2}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nstd::vector<float> rgb_to_hsv(long r, long g, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rgb_to_hsv;\n    assert(candidate((255), (255), (255)) == (std::vector<float>({(float)0.0f, (float)0.0f, (float)100.0f})));\n    assert(candidate((0), (215), (0)) == (std::vector<float>({(float)120.0f, (float)100.0f, (float)84.31372549019608f})));\n    assert(candidate((10), (215), (110)) == (std::vector<float>({(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a given nested list structure.\nstd::vector<long> flatten_list(std::vector<Union_long_std_vector_long_> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = flatten_list;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({0, 10, std::vector<long>({(long)20, (long)30}), 40, 50, std::vector<long>({(long)60, (long)70, (long)80}), std::vector<long>({(long)90, (long)100, (long)110, (long)120})}))) == (std::vector<long>({(long)0, (long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70, (long)80, (long)90, (long)100, (long)110, (long)120})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)40}), (std::vector<long>)std::vector<long>({(long)30, (long)56, (long)25}), (std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)33}), (std::vector<long>)std::vector<long>({(long)40})}))) == (std::vector<long>({(long)10, (long)20, (long)40, (long)30, (long)56, (long)25, (long)10, (long)20, (long)33, (long)40})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)10, (long)11, (long)12, (long)7, (long)8, (long)9})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nbool check_str(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_str;\n    assert(candidate((\"annie\")) == (true));\n    assert(candidate((\"dawood\")) == (false));\n    assert(candidate((\"Else\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nbool check_monthnumber_number(long monthnum3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_monthnumber_number;\n    assert(candidate((6)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((12)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given list.\nstd::vector<long> heap_sort(std::vector<long> iterable) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = heap_sort;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8, (long)0}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58}))) == (std::vector<long>({(long)14, (long)22, (long)25, (long)25, (long)35, (long)58, (long)65, (long)75, (long)85})));\n    assert(candidate((std::vector<long>({(long)7, (long)1, (long)9, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)7, (long)9})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nstd::vector<std::vector<long>> k_smallest_pairs(std::vector<long> nums1, std::vector<long> nums2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = k_smallest_pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (7)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)2})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nstd::optional<std::tuple<long, long>> find_solution(long a, long b, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_solution;\n    assert(candidate((2), (3), (7)) == std::make_tuple(2, 1));\n    assert(candidate((4), (2), (7)) == std::nullopt);\n    assert(candidate((1), (13), (17)) == std::make_tuple(4, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the largest number that can be formed with the given list of digits.\nlong find_Max_Num(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Max_Num;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (321));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)1}))) == (6541));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)9}))) == (9321));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nstd::vector<long> max_sum_list(std::vector<std::vector<long>> lists) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_sum_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)10, (long)11, (long)12})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)12, (long)11, (long)10})}))) == (std::vector<long>({(long)12, (long)11, (long)10})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)1})}))) == (std::vector<long>({(long)2, (long)3, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to interchange the first and last elements in a list.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)12, (long)35, (long)9, (long)56, (long)24}))) == (std::vector<long>({(long)24, (long)35, (long)9, (long)56, (long)12})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of two sorted lists of same size.\nfloat get_median(std::vector<long> arr1, std::vector<long> arr2, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_median;\n    assert(candidate((std::vector<long>({(long)1, (long)12, (long)15, (long)26, (long)38})), (std::vector<long>({(long)2, (long)13, (long)17, (long)30, (long)45})), (5)) == (16.0f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)9})), (std::vector<long>({(long)7, (long)13, (long)19, (long)28})), (4)) == (8.5f));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)14, (long)23, (long)36, (long)42})), (std::vector<long>({(long)2, (long)18, (long)27, (long)39, (long)49, (long)55})), (6)) == (25.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nstd::string replace_spaces(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"Jumanji The Jungle\")) == (\"Jumanji_The_Jungle\"));\n    assert(candidate((\"The_Avengers\")) == (\"The Avengers\"));\n    assert(candidate((\"Fast and Furious\")) == (\"Fast_and_Furious\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to determine if the sum of the divisors of two integers are the same.\nbool are_equivalent(long num1, long num2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = are_equivalent;\n    assert(candidate((36), (57)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((23), (47)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse each string in a given list of string values.\nstd::vector<std::string> reverse_string_list(std::vector<std::string> stringlist) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = reverse_string_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\", (std::string)\"White\", (std::string)\"Black\"}))) == (std::vector<std::string>({(std::string)\"deR\", (std::string)\"neerG\", (std::string)\"eulB\", (std::string)\"etihW\", (std::string)\"kcalB\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"john\", (std::string)\"amal\", (std::string)\"joel\", (std::string)\"george\"}))) == (std::vector<std::string>({(std::string)\"nhoj\", (std::string)\"lama\", (std::string)\"leoj\", (std::string)\"egroeg\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"jack\", (std::string)\"john\", (std::string)\"mary\"}))) == (std::vector<std::string>({(std::string)\"kcaj\", (std::string)\"nhoj\", (std::string)\"yram\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the sum of digits of each number of a given list.\nlong sum_of_digits(std::vector<std::any> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_of_digits;\n    assert(candidate((std::vector<std::any>({(long)10, (long)2, (long)56}))) == (14));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<std::any>({10, 20, 4, 5, \"b\", 70, \"a\"})}))) == (19));\n    assert(candidate((std::vector<std::any>({(long)10, (long)20, (long)-4, (long)5, (long)-70}))) == (19));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth number in the newman conway sequence.\nlong sequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sequence;\n    assert(candidate((10)) == (6));\n    assert(candidate((2)) == (1));\n    assert(candidate((3)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nstd::vector<long> heap_queue_largest(std::vector<long> nums, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = heap_queue_largest;\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (3)) == (std::vector<long>({(long)85, (long)75, (long)65})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (2)) == (std::vector<long>({(long)85, (long)75})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (5)) == (std::vector<long>({(long)85, (long)75, (long)65, (long)58, (long)35})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlong loss_amount(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = loss_amount;\n    assert(candidate((1500), (1200)) == (0));\n    assert(candidate((100), (200)) == (100));\n    assert(candidate((2000), (5000)) == (3000));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nstd::vector<long> union_elements(std::vector<long> test_tup1, std::vector<long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = union_elements;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)5, (long)7, (long)4, (long)10}))) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)11, (long)12, (long)13, (long)14})), (std::vector<long>({(long)13, (long)15, (long)16, (long)17}))) == (std::vector<long>({(long)11, (long)12, (long)13, (long)14, (long)15, (long)16, (long)17})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the longest sublists.\nlong Find_Max_Length(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Find_Max_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)22, (long)23}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50})}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nstd::string remove_parenthesis(std::vector<std::string> items) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_parenthesis;\n    assert(candidate((std::vector<std::string>({(std::string)\"python (chrome)\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"string(.abc)\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"alpha(num)\"}))) == (\"alpha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find whether the parity of a given number is odd.\nbool find_Parity(long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Parity;\n    assert(candidate((12)) == (false));\n    assert(candidate((7)) == (true));\n    assert(candidate((10)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median length of a trapezium.\nfloat median_trapezium(long base1, long base2, long height) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = median_trapezium;\n    assert(candidate((15), (25), (35)) == (float(20)));\n    assert(candidate((10), (20), (30)) == (float(15)));\n    assert(candidate((6), (9), (4)) == (7.5f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth centered hexagonal number.\nlong centered_hexagonal_number(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = centered_hexagonal_number;\n    assert(candidate((10)) == (271));\n    assert(candidate((2)) == (7));\n    assert(candidate((9)) == (217));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find number of lists present in the given list.\nlong find_lists(std::vector<std::any> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_lists;\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (2));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6})}))) == (3));\n    assert(candidate((std::vector<std::any>({(long)9, (long)8, (long)7, (long)6, (long)5, (long)4, (long)3, (long)2, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlong get_max_sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_max_sum;\n    assert(candidate((60)) == (106));\n    assert(candidate((10)) == (12));\n    assert(candidate((2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the longest word.\nlong len_log(std::vector<std::string> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = len_log;\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"PHP\", (std::string)\"bigdata\"}))) == (7));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))) == (3));\n    assert(candidate((std::vector<std::string>({(std::string)\"small\", (std::string)\"big\", (std::string)\"tall\"}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nstd::optional<float> sector_area(long r, long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sector_area;\n    assert(candidate((4), (45)) == 6.283185307179586f);\n    assert(candidate((9), (45)) == 31.808625617596654f);\n    assert(candidate((9), (361)) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nbool odd_position(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = odd_position;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4, (long)3, (long)6, (long)7, (long)6, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to join a list of multiple integers into a single integer.\nlong multiple_to_single(std::vector<long> L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiple_to_single;\n    assert(candidate((std::vector<long>({(long)11, (long)33, (long)50}))) == (113350));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (-123456));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25}))) == (10152025));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find whether a number is divisible by 11.\nbool is_Diff(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_Diff;\n    assert(candidate((12345)) == (false));\n    assert(candidate((1212112)) == (true));\n    assert(candidate((1212)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nstd::vector<std::vector<long>> index_multiplication(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = index_multiplication;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)21}), (std::vector<long>)std::vector<long>({(long)12, (long)45}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)30})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)14, (long)32}), (std::vector<long>)std::vector<long>({(long)20, (long)60}), (std::vector<long>)std::vector<long>({(long)6, (long)20}), (std::vector<long>)std::vector<long>({(long)16, (long)44})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)24, (long)45}), (std::vector<long>)std::vector<long>({(long)30, (long)77}), (std::vector<long>)std::vector<long>({(long)12, (long)33}), (std::vector<long>)std::vector<long>({(long)27, (long)60})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert tuple string to integer tuple.\nstd::tuple<long, long, long> tuple_str_int(std::string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tuple_str_int;\n    assert(candidate((\"(7, 8, 9)\")) == (std::make_tuple(7, 8, 9)));\n    assert(candidate((\"(1, 2, 3)\")) == (std::make_tuple(1, 2, 3)));\n    assert(candidate((\"(4, 5, 6)\")) == (std::make_tuple(4, 5, 6)));\n    assert(candidate((\"(7, 81, 19)\")) == (std::make_tuple(7, 81, 19)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum all amicable numbers from 1 to a specified number.\nlong amicable_numbers_sum(long limit) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = amicable_numbers_sum;\n    assert(candidate((999)) == (504));\n    assert(candidate((9999)) == (31626));\n    assert(candidate((99)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove odd characters in a string.\nstd::string remove_odd(std::string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((\"python\")) == (\"yhn\"));\n    assert(candidate((\"program\")) == (\"rga\"));\n    assert(candidate((\"language\")) == (\"agae\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nstd::vector<std::any> multiply_elements(std::vector<long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiply_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)8, (long)10}))) == (std::vector<std::any>({(long)5, (long)35, (long)56, (long)80})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)7}))) == (std::vector<std::any>({(long)8, (long)20, (long)30, (long)42})));\n    assert(candidate((std::vector<long>({(long)12, (long)13, (long)14, (long)9, (long)15}))) == (std::vector<std::any>({(long)156, (long)182, (long)126, (long)135})));\n    assert(candidate((std::vector<long>({(long)12}))) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nlong count_rotation(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_rotation;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)1, (long)2, (long)3}))) == (2));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the number of unique tuples in the given list.\nlong extract_freq(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_freq;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(5, 6)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 15), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(6, 7)}))) == (4));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 16), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 9)}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nlong count_same_pair(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_same_pair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (11));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)1, (long)2})), (std::vector<long>({(long)0, (long)1, (long)2, (long)2}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the value of 'a' to the power 'b'.\nlong power(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = power;\n    assert(candidate((3), (4)) == (81));\n    assert(candidate((2), (3)) == (8));\n    assert(candidate((5), (5)) == (3125));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write function to find the sum of all items in the given dictionary.\nlong return_sum(std::map<std::string,long> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = return_sum;\n    assert(candidate((std::map<std::string,long>({{\"a\", 100}, {\"b\", 200}, {\"c\", 300}}))) == (600));\n    assert(candidate((std::map<std::string,long>({{\"a\", 25}, {\"b\", 18}, {\"c\", 45}}))) == (88));\n    assert(candidate((std::map<std::string,long>({{\"a\", 36}, {\"b\", 39}, {\"c\", 49}}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return a list of all pairs of consecutive items in a given list.\nstd::vector<std::tuple<long, long>> pair_wise(std::vector<long> l1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pair_wise;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 4), (std::tuple<long, long>)std::make_tuple(4, 5)})));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 5), (std::tuple<long, long>)std::make_tuple(5, 7), (std::tuple<long, long>)std::make_tuple(7, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)9, (long)7, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(1, 9), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(7, 10)})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 5), (std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to split a string into characters.\nstd::vector<std::string> split(std::string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = split;\n    assert(candidate((\"python\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})));\n    assert(candidate((\"Name\")) == (std::vector<std::string>({(std::string)\"N\", (std::string)\"a\", (std::string)\"m\", (std::string)\"e\"})));\n    assert(candidate((\"program\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum of three numbers.\nlong min_of_three(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_of_three;\n    assert(candidate((10), (20), (0)) == (0));\n    assert(candidate((19), (15), (18)) == (15));\n    assert(candidate((-10), (-20), (-30)) == (-30));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nbool is_Sum_Of_Powers_Of_Two(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_Sum_Of_Powers_Of_Two;\n    assert(candidate((10)) == (true));\n    assert(candidate((7)) == (false));\n    assert(candidate((14)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nstd::string get_Char(std::string strr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_Char;\n    assert(candidate((\"abc\")) == (\"f\"));\n    assert(candidate((\"gfg\")) == (\"t\"));\n    assert(candidate((\"ab\")) == (\"c\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return the sum of all divisors of a number.\nlong sum_div(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_div;\n    assert(candidate((8)) == (7));\n    assert(candidate((12)) == (16));\n    assert(candidate((7)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_string_float{\n    long f0;\n    std::string f1;\n    float f2;    Union_long_std_string_float(long _f0) : f0(_f0) {}\n    Union_long_std_string_float(std::string _f1) : f1(_f1) {}\n    Union_long_std_string_float(float _f2) : f2(_f2) {}\n    ~Union_long_std_string_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::string f) {\n        return f1 == f ;\n    }    bool operator==(float f) {\n        return f2 == f ;\n    }\n};\n// Write a python function that returns the number of integer elements in a given list.\nlong count_integer(std::vector<Union_long_std_string_float> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_integer;\n    assert(candidate((std::vector<Union_long_std_string_float>({1, 2, \"abc\", 1.2f}))) == (2));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)1.2f, (long)4, (long)5.1f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove duplicate numbers from a given number of lists.\nstd::vector<long> two_unique_nums(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = two_unique_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether a given array of integers contains any duplicate element.\nbool test_duplicate(std::vector<long> arraynums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = test_duplicate;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which returns nth catalan number.\nlong catalan_number(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = catalan_number;\n    assert(candidate((10)) == (16796));\n    assert(candidate((9)) == (4862));\n    assert(candidate((7)) == (429));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlong power_base_sum(long base, long power) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = power_base_sum;\n    assert(candidate((2), (100)) == (115));\n    assert(candidate((8), (10)) == (37));\n    assert(candidate((8), (15)) == (62));\n    assert(candidate((3), (3)) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nstd::vector<std::any> replace_list(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_list;\n    assert(candidate((std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})), (std::vector<std::any>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8}))) == (std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\"})), (std::vector<std::any>({(std::string)\"yellow\"}))) == (std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"yellow\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth octagonal number.\nlong is_octagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_octagonal;\n    assert(candidate((5)) == (65));\n    assert(candidate((10)) == (280));\n    assert(candidate((15)) == (645));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nstd::string replace_blank(std::string str1, std::string char) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_blank;\n    assert(candidate((\"hello people\"), (\"@\")) == (\"hello@people\"));\n    assert(candidate((\"python program language\"), (\"$\")) == (\"python$program$language\"));\n    assert(candidate((\"blank space\"), (\"-\")) == (\"blank-space\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nstd::string replace_specialchar(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_specialchar;\n    assert(candidate((\"Python language, Programming language.\")) == (\"Python:language::Programming:language:\"));\n    assert(candidate((\"a b c,d e f\")) == (\"a:b:c:d:e:f\"));\n    assert(candidate((\"ram reshma,ram rahim\")) == (\"ram:reshma:ram:rahim\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given tuple of positive integers into a single integer.\nlong tuple_to_int(std::tuple<long, long, long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tuple_to_int;\n    assert(candidate((std::make_tuple(1, 2, 3))) == (123));\n    assert(candidate((std::make_tuple(4, 5, 6))) == (456));\n    assert(candidate((std::make_tuple(5, 6, 7))) == (567));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the third side of a right angled triangle.\nfloat otherside_rightangle(long w, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = otherside_rightangle;\n    assert(candidate((7), (8)) == (10.63014581273465f));\n    assert(candidate((3), (4)) == (float(5)));\n    assert(candidate((7), (15)) == (16.55294535724685f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_float{\n    std::string f0;\n    float f1;    Union_std_string_float(std::string _f0) : f0(_f0) {}\n    Union_std_string_float(float _f1) : f1(_f1) {}\n    ~Union_std_string_float() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the n most expensive items in a given dataset.\nstd::vector<std::map<std::string,Union_std_string_float>> expensive_items(std::vector<std::map<std::string,Union_std_string_float>> items, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = expensive_items;\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}})})), (2)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-4\"}, {\"price\", 22.75f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the per-digit difference between two integers.\nlong digit_distance_nums(long n1, long n2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = digit_distance_nums;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((23), (56)) == (6));\n    assert(candidate((123), (256)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nbool text_match_wordz_middle(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_match_wordz_middle;\n    assert(candidate((\"pythonzabc.\")) == (true));\n    assert(candidate((\"zxyabc.\")) == (false));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove leading zeroes from an ip address.\nstd::string removezero_ip(std::string ip) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = removezero_ip;\n    assert(candidate((\"216.08.094.196\")) == (\"216.8.94.196\"));\n    assert(candidate((\"12.01.024\")) == (\"12.1.24\"));\n    assert(candidate((\"216.08.094.0196\")) == (\"216.8.94.196\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of sublists containing a particular element.\nlong count_element_in_list(std::vector<std::vector<std::any>> list1, std::any x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_element_in_list;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)11}), (std::vector<long>)std::vector<long>({(long)1, (long)15, (long)7})})), (std::any(1))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"A\"))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"E\"))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to multiply two integers.\nlong multiply_int(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = multiply_int;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((5), (10)) == (50));\n    assert(candidate((4), (8)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nstd::tuple<long, long, long, long> add_pairwise(std::tuple<long, long, long, long, long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_pairwise;\n    assert(candidate((std::make_tuple(1, 5, 7, 8, 10))) == (std::make_tuple(6, 12, 15, 18)));\n    assert(candidate((std::make_tuple(2, 6, 8, 9, 11))) == (std::make_tuple(8, 14, 17, 20)));\n    assert(candidate((std::make_tuple(3, 7, 9, 10, 12))) == (std::make_tuple(10, 16, 19, 22)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nlong max_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (36));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (200));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (484));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3544,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the kth element in the given array using 1-based indexing.\nlong kth_element(std::vector<long> arr, long k) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = kth_element;\n    assert(candidate((std::vector<long>({(long)12, (long)3, (long)5, (long)7, (long)19})), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)17, (long)24, (long)8, (long)23})), (3)) == (8));\n    assert(candidate((std::vector<long>({(long)16, (long)21, (long)25, (long)36, (long)4})), (4)) == (36));\n}\n",
     "stop_tokens": [
@@ -3552,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to interchange the first and last element in a given list.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (std::vector<long>({(long)4, (long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"python_program\")) == (\"PythonProgram\"));\n    assert(candidate((\"python_language\")) == (\"PythonLanguage\"));\n    assert(candidate((\"programming_language\")) == (\"ProgrammingLanguage\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_tuple_long, long_{\n    long f0;\n    std::tuple<long, long> f1;    Union_long_std_tuple_long, long_(long _f0) : f0(_f0) {}\n    Union_long_std_tuple_long, long_(std::tuple<long, long> _f1) : f1(_f1) {}\n    ~Union_long_std_tuple_long, long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::tuple<long, long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the number of elements that occurs before the list element in the given tuple.\nlong count_first_elements(std::vector<Union_long_std_tuple_long, long_> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the Eulerian number a(n, m).\nlong eulerian_num(long n, long m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_first_elements;\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({1, 5, 7, std::make_tuple(4, 6), 10}))) == (3));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({2, 9, std::make_tuple(5, 7), 11}))) == (2));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({11, 15, 5, 8, std::make_tuple(2, 3), 8}))) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = eulerian_num;\n    assert(candidate((3), (1)) == (4));\n    assert(candidate((4), (1)) == (11));\n    assert(candidate((5), (3)) == (26));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the right insertion point for a specified value in sorted order.\nlong right_insertion(std::vector<long> a, long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each sublist of strings in a given list of lists.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> input_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = right_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"blue \", (std::string)\" black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" black\", (std::string)\"blue \"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"zilver\", (std::string)\"gold\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"magnesium\", (std::string)\"aluminium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"steel\", (std::string)\"bronze\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"gold\", (std::string)\"zilver\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"aluminium\", (std::string)\"magnesium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"bronze\", (std::string)\"steel\"})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given number is woodball or not.\nbool is_woodall(long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count true booleans in the given list.\nlong count(std::vector<bool> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_woodall;\n    assert(candidate((383)) == (true));\n    assert(candidate((254)) == (false));\n    assert(candidate((200)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count;\n    assert(candidate((std::vector<bool>({(bool)true, (bool)false, (bool)true}))) == (2));\n    assert(candidate((std::vector<bool>({(bool)false, (bool)false}))) == (0));\n    assert(candidate((std::vector<bool>({(bool)true, (bool)true, (bool)true}))) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given array by using shell sort.\nstd::vector<long> shell_sort(std::vector<long> my_list) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to append the given list to the given tuples.\nstd::tuple<long, long, long, long, long> add_lists(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = shell_sort;\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)4, (long)5, (long)3, (long)2, (long)12, (long)81, (long)56, (long)95}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)12, (long)12, (long)23, (long)56, (long)81, (long)95})));\n    assert(candidate((std::vector<long>({(long)24, (long)22, (long)39, (long)34, (long)87, (long)73, (long)68}))) == (std::vector<long>({(long)22, (long)24, (long)34, (long)39, (long)68, (long)73, (long)87})));\n    assert(candidate((std::vector<long>({(long)32, (long)30, (long)16, (long)96, (long)82, (long)83, (long)74}))) == (std::vector<long>({(long)16, (long)30, (long)32, (long)74, (long)82, (long)83, (long)96})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = add_lists;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::make_tuple(9, 10, 5, 6, 7)));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::make_tuple(10, 11, 6, 7, 8)));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::make_tuple(11, 12, 7, 8, 9)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of pairs whose xor value is odd.\nlong find_Odd_Pair(std::vector<long> A, long N) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three lists into a single sorted list.\nstd::vector<long> merge_sorted_list(std::vector<long> num1, std::vector<long> num2, std::vector<long> num3) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Odd_Pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11})), (7)) == (12));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (3)) == (2));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = merge_sorted_list;\n    assert(candidate((std::vector<long>({(long)25, (long)24, (long)15, (long)4, (long)5, (long)29, (long)110})), (std::vector<long>({(long)19, (long)20, (long)11, (long)56, (long)25, (long)233, (long)154})), (std::vector<long>({(long)24, (long)26, (long)54, (long)48}))) == (std::vector<long>({(long)4, (long)5, (long)11, (long)15, (long)19, (long)20, (long)24, (long)24, (long)25, (long)25, (long)26, (long)29, (long)48, (long)54, (long)56, (long)110, (long)154, (long)233})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)6, (long)8, (long)9})), (std::vector<long>({(long)2, (long)5, (long)7, (long)11})), (std::vector<long>({(long)1, (long)4, (long)7, (long)8, (long)12}))) == (std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)5, (long)5, (long)6, (long)7, (long)7, (long)8, (long)8, (long)9, (long)11, (long)12})));\n    assert(candidate((std::vector<long>({(long)18, (long)14, (long)10, (long)9, (long)8, (long)7, (long)9, (long)3, (long)2, (long)4, (long)1})), (std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58})), (std::vector<long>({(long)12, (long)74, (long)9, (long)50, (long)61, (long)41}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)8, (long)9, (long)9, (long)9, (long)10, (long)12, (long)14, (long)14, (long)18, (long)22, (long)25, (long)25, (long)35, (long)41, (long)50, (long)58, (long)61, (long)65, (long)74, (long)75, (long)85})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nlong sum_in_range(long l, long r) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlong odd_Equivalent(std::string s, long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_in_range;\n    assert(candidate((2), (5)) == (8));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (13)) == (40));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = odd_Equivalent;\n    assert(candidate((\"011001\"), (6)) == (3));\n    assert(candidate((\"11011\"), (5)) == (4));\n    assert(candidate((\"1010\"), (4)) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the perimeter of a square given its side length as input.\nlong square_perimeter(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string represents an integer or not.\nbool check_integer(std::string text) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = square_perimeter;\n    assert(candidate((10)) == (40));\n    assert(candidate((5)) == (20));\n    assert(candidate((4)) == (16));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = check_integer;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"1\")) == (true));\n    assert(candidate((\"12345\")) == (true));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlong is_polite(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given tuple of positive integers into a single integer.\nlong tuple_to_int(std::tuple<long, long, long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_polite;\n    assert(candidate((7)) == (11));\n    assert(candidate((4)) == (7));\n    assert(candidate((9)) == (13));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlong sum_series(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_series;\n    assert(candidate((6)) == (12));\n    assert(candidate((10)) == (30));\n    assert(candidate((9)) == (25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the dissimilar elements in the given two tuples.\nstd::tuple<long, long, long, long> find_dissimilar(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_dissimilar;\n    assert(candidate((std::make_tuple(3, 4, 5, 6)), (std::make_tuple(5, 7, 4, 10))) == (std::make_tuple(3, 6, 7, 10)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(7, 2, 3, 9))) == (std::make_tuple(1, 4, 7, 9)));\n    assert(candidate((std::make_tuple(21, 11, 25, 26)), (std::make_tuple(26, 34, 21, 36))) == (std::make_tuple(34, 36, 11, 25)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return two words from a list of words starting with letter 'p'.\nstd::tuple<std::string, std::string> start_withp(std::vector<std::string> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = start_withp;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python PHP\", (std::string)\"Java JavaScript\", (std::string)\"c c++\"}))) == (std::make_tuple(\"Python\", \"PHP\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python Programming\", (std::string)\"Java Programming\"}))) == (std::make_tuple(\"Python\", \"Programming\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Pqrst Pqr\", (std::string)\"qrstuv\"}))) == (std::make_tuple(\"Pqrst\", \"Pqr\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"android_tv\")) == (\"AndroidTv\"));\n    assert(candidate((\"google_pixel\")) == (\"GooglePixel\"));\n    assert(candidate((\"apple_watch\")) == (\"AppleWatch\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the volume of a cube given its side length.\nlong volume_cube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = volume_cube;\n    assert(candidate((3)) == (27));\n    assert(candidate((2)) == (8));\n    assert(candidate((5)) == (125));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 31 days or not.\nbool check_monthnumb_number(long monthnum2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_monthnumb_number;\n    assert(candidate((5)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((6)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether all the bits are unset in the given range or not.\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = all_Bits_Set_In_The_Given_Range;\n    assert(candidate((4), (1), (2)) == (true));\n    assert(candidate((17), (2), (4)) == (true));\n    assert(candidate((39), (4), (6)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to get the first element of each sublist.\nstd::vector<long> Extract(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Extract;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)3, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (std::vector<long>({(long)1, (long)4})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)8, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (std::vector<long>({(long)9, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cylinder.\nfloat surfacearea_cylinder(long r, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = surfacearea_cylinder;\n    assert(candidate((10), (5)) == (942.45f));\n    assert(candidate((4), (5)) == (226.18800000000002f));\n    assert(candidate((4), (10)) == (351.848f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nlong sample_nam(std::vector<std::string> sample_names) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sample_nam;\n    assert(candidate((std::vector<std::string>({(std::string)\"sally\", (std::string)\"Dylan\", (std::string)\"rebecca\", (std::string)\"Diana\", (std::string)\"Joanne\", (std::string)\"keith\"}))) == (16));\n    assert(candidate((std::vector<std::string>({(std::string)\"php\", (std::string)\"res\", (std::string)\"Python\", (std::string)\"abcd\", (std::string)\"Java\", (std::string)\"aaa\"}))) == (10));\n    assert(candidate((std::vector<std::string>({(std::string)\"abcd\", (std::string)\"Python\", (std::string)\"abba\", (std::string)\"aba\"}))) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nstd::any rearrange_bigger(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rearrange_bigger;\n    assert(candidate((12)) == (std::any(21)));\n    assert(candidate((10)) == (std::any(false)));\n    assert(candidate((102)) == (std::any(120)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlong perimeter_pentagon(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = perimeter_pentagon;\n    assert(candidate((5)) == (25));\n    assert(candidate((10)) == (50));\n    assert(candidate((15)) == (75));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nlong max_sum(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)15, (long)51, (long)45, (long)33, (long)100, (long)12, (long)18, (long)9}))) == (194));\n    assert(candidate((std::vector<long>({(long)80, (long)60, (long)30, (long)40, (long)20, (long)10}))) == (210));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)14, (long)16, (long)21, (long)23, (long)29, (long)30}))) == (138));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uneven elements in the nested mixed tuple.\nstd::any extract_even(std::tuple<long, long, std::tuple<long, long, std::tuple<long, long>>, long, long> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_even;\n    assert(candidate((std::make_tuple(4, 5, std::make_tuple(7, 6, std::make_tuple(2, 4)), 6, 8))) == std::make_tuple(4, std::make_tuple(6, std::make_tuple(2, 4)), 6, 8));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(8, 7, std::make_tuple(4, 8)), 7, 9))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 8))));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(9, 8, std::make_tuple(4, 6)), 8, 10))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 6)), 8, 10));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = tuple_to_int;\n    assert(candidate((std::make_tuple(1, 2, 3))) == (123));\n    assert(candidate((std::make_tuple(4, 5, 6))) == (456));\n    assert(candidate((std::make_tuple(5, 6, 7))) == (567));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3832,201 +136,9 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert all possible convertible elements in a list of lists to floats.\nstd::vector<std::tuple<float, float>> list_to_float(std::vector<std::tuple<std::string, std::string>> test_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = list_to_float;\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"3\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"1\", \"26.45\"), (std::tuple<std::string, std::string>)std::make_tuple(\"7.32\", \"8\"), (std::tuple<std::string, std::string>)std::make_tuple(\"4\", \"8\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(3.0f, 4.0f), (std::tuple<float, float>)std::make_tuple(1.0f, 26.45f), (std::tuple<float, float>)std::make_tuple(7.32f, 8.0f), (std::tuple<float, float>)std::make_tuple(4.0f, 8.0f)})));\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"4\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"2\", \"27\"), (std::tuple<std::string, std::string>)std::make_tuple(\"4.12\", \"9\"), (std::tuple<std::string, std::string>)std::make_tuple(\"7\", \"11\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(4.0f, 4.0f), (std::tuple<float, float>)std::make_tuple(2.0f, 27.0f), (std::tuple<float, float>)std::make_tuple(4.12f, 9.0f), (std::tuple<float, float>)std::make_tuple(7.0f, 11.0f)})));\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"6\", \"78\"), (std::tuple<std::string, std::string>)std::make_tuple(\"5\", \"26.45\"), (std::tuple<std::string, std::string>)std::make_tuple(\"1.33\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"82\", \"13\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(6.0f, 78.0f), (std::tuple<float, float>)std::make_tuple(5.0f, 26.45f), (std::tuple<float, float>)std::make_tuple(1.33f, 4.0f), (std::tuple<float, float>)std::make_tuple(82.0f, 13.0f)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlong square_Sum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (20));\n    assert(candidate((3)) == (56));\n    assert(candidate((4)) == (120));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nlong get_pairs_count(std::vector<long> arr, long sum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_pairs_count;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (2)) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)-1, (long)5})), (6)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3})), (1)) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3})), (-3)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlong count_no_of_ways(long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_no_of_ways;\n    assert(candidate((2), (4)) == (16));\n    assert(candidate((3), (2)) == (6));\n    assert(candidate((4), (4)) == (228));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse words seperated by spaces in a given string.\nstd::string reverse_words(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = reverse_words;\n    assert(candidate((\"python program\")) == (\"program python\"));\n    assert(candidate((\"java language\")) == (\"language java\"));\n    assert(candidate((\"indian man\")) == (\"man indian\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check if a given number is one less than twice its reverse.\nbool checks(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = checks;\n    assert(candidate((70)) == (false));\n    assert(candidate((23)) == (false));\n    assert(candidate((73)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last position of an element in a sorted array.\nlong last(std::vector<long> arr, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = last;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)4})), (1)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)3, (long)6, (long)8, (long)9})), (3)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nlong count_X(std::vector<long> tup, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_X;\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (10)) == (3));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (8)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nstd::vector<std::any> extract_index_list(std::vector<long> l1, std::vector<long> l2, std::vector<long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_index_list;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)5})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)7}))) == (std::vector<std::any>({(long)1, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)6, (long)5, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)6, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float{\n    long f0;\n    float f1;    Union_long_float(long _f0) : f0(_f0) {}\n    Union_long_float(float _f1) : f1(_f1) {}\n    ~Union_long_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the second smallest number in a list.\nstd::optional<float> second_smallest(std::vector<Union_long_float> numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = second_smallest;\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)2, (long)-8, (long)-2, (long)0, (long)-2}))) == -2);\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)1, (long)-0.5f, (long)0, (long)2, (long)-2, (long)-2}))) == -0.5f);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2}))) == std::nullopt);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2, (long)2}))) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to concatenate each element of tuple by the delimiter.\nstd::string concatenate_tuple(std::tuple<std::string, std::string, long, std::string> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = concatenate_tuple;\n    assert(candidate((std::make_tuple(\"ID\", \"is\", 4, \"UTS\"))) == (\"ID-is-4-UTS\"));\n    assert(candidate((std::make_tuple(\"QWE\", \"is\", 4, \"RTY\"))) == (\"QWE-is-4-RTY\"));\n    assert(candidate((std::make_tuple(\"ZEN\", \"is\", 4, \"OP\"))) == (\"ZEN-is-4-OP\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all spaces in the given string with '%20'.\nstd::string replace_spaces(std::string string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"My Name is Dawood\")) == (\"My%20Name%20is%20Dawood\"));\n    assert(candidate((\"I am a Programmer\")) == (\"I%20am%20a%20Programmer\"));\n    assert(candidate((\"I love Coding\")) == (\"I%20love%20Coding\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nlong sum_range_list(std::vector<long> list1, long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sum_range_list;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (8), (10)) == (29));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (5), (7)) == (16));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (7), (10)) == (38));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three dictionaries into a single dictionary.\nstd::map<std::string,std::string> merge_dictionaries_three(std::map<std::string,std::string> dict1, std::map<std::string,std::string> dict2, std::map<std::string,std::string> dict3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = merge_dictionaries_three;\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}))) == (std::map<std::string,std::string>({{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum of two numbers.\nlong minimum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = minimum;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((-5), (-4)) == (-5));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nlong max_difference(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_difference;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(1, 7), (std::tuple<long, long>)std::make_tuple(10, 3), (std::tuple<long, long>)std::make_tuple(1, 2)}))) == (7));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(2, 17), (std::tuple<long, long>)std::make_tuple(9, 13), (std::tuple<long, long>)std::make_tuple(11, 12)}))) == (15));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 35), (std::tuple<long, long>)std::make_tuple(21, 27), (std::tuple<long, long>)std::make_tuple(13, 23), (std::tuple<long, long>)std::make_tuple(41, 22)}))) == (23));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find element at a given index after number of rotations.\nlong find_Element(std::vector<long> arr, std::vector<std::vector<long>> ranges, long rotations, long index) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)2}), (std::vector<long>)std::vector<long>({(long)0, (long)3})})), (2), (1)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (1)) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4036,7 +148,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a string to a list of strings split on the space character.\nstd::vector<std::string> string_to_list(std::string string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = string_to_list;\n    assert(candidate((\"python programming\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"programming\"})));\n    assert(candidate((\"lists tuples strings\")) == (std::vector<std::string>({(std::string)\"lists\", (std::string)\"tuples\", (std::string)\"strings\"})));\n    assert(candidate((\"write a program\")) == (std::vector<std::string>({(std::string)\"write\", (std::string)\"a\", (std::string)\"program\"})));\n}\n",
     "stop_tokens": [
@@ -4048,21 +160,9 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the element that appears only once in a sorted array.\nlong search(std::vector<long> arr) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)3, (long)4, (long)4, (long)5, (long)5, (long)7, (long)7, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a dictionary by value.\nstd::vector<std::tuple<std::string, long>> sort_counter(std::map<std::string,long> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_counter;\n    assert(candidate((std::map<std::string,long>({{\"Math\", 81}, {\"Physics\", 83}, {\"Chemistry\", 87}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 87), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 83), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 81)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 400}, {\"Physics\", 300}, {\"Chemistry\", 250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Math\", 400), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 300), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 250)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 900}, {\"Physics\", 1000}, {\"Chemistry\", 1250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 1250), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 1000), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 900)})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4072,7 +172,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove first and last occurrence of a given character from the string.\nstd::string remove_Occ(std::string s, std::string ch) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = remove_Occ;\n    assert(candidate((\"hello\"), (\"l\")) == (\"heo\"));\n    assert(candidate((\"abcda\"), (\"a\")) == (\"bcd\"));\n    assert(candidate((\"PHP\"), (\"P\")) == (\"H\"));\n}\n",
     "stop_tokens": [
@@ -4080,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cube given its side length.\nlong lateralsurface_cube(long l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nlong max_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cube;\n    assert(candidate((5)) == (100));\n    assert(candidate((9)) == (324));\n    assert(candidate((10)) == (400));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = max_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (36));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (200));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (484));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes two lists and returns true if they have at least one common element.\nstd::optional<bool> common_element(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum all amicable numbers from 1 to a specified number.\nlong amicable_numbers_sum(long limit) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = common_element;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == true);\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)6, (long)7, (long)8, (long)9}))) == std::nullopt);\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})), (std::vector<std::any>({(std::string)\"d\", (std::string)\"b\", (std::string)\"e\"}))) == true);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = amicable_numbers_sum;\n    assert(candidate((999)) == (504));\n    assert(candidate((9999)) == (31626));\n    assert(candidate((99)) == (0));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to append the given list to the given tuples.\nstd::tuple<long, long, long, long, long> add_lists(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlong find_length(std::string string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_lists;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::make_tuple(9, 10, 5, 6, 7)));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::make_tuple(10, 11, 6, 7, 8)));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::make_tuple(11, 12, 7, 8, 9)));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = find_length;\n    assert(candidate((\"11000010001\")) == (6));\n    assert(candidate((\"10111\")) == (1));\n    assert(candidate((\"11011101100101\")) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the n-th power of each number in a list.\nstd::vector<long> nth_nums(std::vector<long> nums, long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of common divisors of two given numbers.\nlong sum(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = nth_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (3)) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15})), (5)) == (std::vector<long>({(long)248832, (long)759375})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sum;\n    assert(candidate((10), (15)) == (6));\n    assert(candidate((100), (150)) == (93));\n    assert(candidate((4), (6)) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of elements.\nstd::vector<long> pancake_sort(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to multiply two integers.\nlong multiply_int(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = pancake_sort;\n    assert(candidate((std::vector<long>({(long)15, (long)79, (long)25, (long)38, (long)69}))) == (std::vector<long>({(long)15, (long)25, (long)38, (long)69, (long)79})));\n    assert(candidate((std::vector<long>({(long)98, (long)12, (long)54, (long)36, (long)85}))) == (std::vector<long>({(long)12, (long)36, (long)54, (long)85, (long)98})));\n    assert(candidate((std::vector<long>({(long)41, (long)42, (long)32, (long)12, (long)23}))) == (std::vector<long>({(long)12, (long)23, (long)32, (long)41, (long)42})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of three numbers.\nfloat median_numbers(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = median_numbers;\n    assert(candidate((25), (55), (65)) == (55.0f));\n    assert(candidate((20), (10), (30)) == (20.0f));\n    assert(candidate((15), (45), (75)) == (45.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the entered number is greater than the elements of the given array.\nbool check_greater(std::vector<long> arr, long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_greater;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6})), (8)) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)4, (long)8, (long)6, (long)1})), (11)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nbool check_element(std::vector<std::any> list, std::any element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_element;\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"})), (std::any(\"blue\"))) == (false));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (std::any(7))) == (false));\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"green\", (std::string)\"green\", (std::string)\"green\"})), (std::any(\"green\"))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract specified size of strings from a given list of string values.\nstd::vector<std::string> extract_string(std::vector<std::string> str, long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = extract_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (8)) == (std::vector<std::string>({(std::string)\"practice\", (std::string)\"solution\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (6)) == (std::vector<std::string>({(std::string)\"Python\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (9)) == (std::vector<std::string>({(std::string)\"exercises\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nbool text_lowercase_underscore(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = text_lowercase_underscore;\n    assert(candidate((\"aab_cbbbc\")) == (true));\n    assert(candidate((\"aab_Abbbc\")) == (false));\n    assert(candidate((\"Aaab_abbbc\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to trim each list by k in the given lists.\nstd::vector<std::vector<long>> trim_tuple(std::vector<std::vector<long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = trim_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)2})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)8, (long)2, (long)1})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)12, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)4}), (std::vector<long>)std::vector<long>({(long)8, (long)12}), (std::vector<long>)std::vector<long>({(long)1, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)9})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sublist having minimum length.\nstd::vector<std::any> Find_Min(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = Find_Min;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)7, (long)8})}))) == (std::vector<std::any>({(long)1, (long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"})}))) == (std::vector<std::any>({(std::string)\"x\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to filter odd numbers.\nstd::vector<long> filter_oddnumbers(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = filter_oddnumbers;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)45, (long)67, (long)84, (long)93}))) == (std::vector<long>({(long)45, (long)67, (long)93})));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)9, (long)8, (long)6, (long)4, (long)3}))) == (std::vector<long>({(long)5, (long)7, (long)9, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nstd::string find_adverbs(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_adverbs;\n    assert(candidate((\"Clearly, he has no excuse for such behavior.\")) == (\"0-7: Clearly\"));\n    assert(candidate((\"Please handle the situation carefuly\")) == (\"28-36: carefuly\"));\n    assert(candidate((\"Complete the task quickly\")) == (\"18-25: quickly\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nlong max_of_nth(std::vector<std::vector<long>> test_list, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_of_nth;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)9, (long)19})})), (2)) == (19));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)20})})), (1)) == (10));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)21})})), (1)) == (11));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nstd::string decimal_to_binary(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((8)) == (\"1000\"));\n    assert(candidate((18)) == (\"10010\"));\n    assert(candidate((7)) == (\"111\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nstd::vector<std::vector<std::string>> combinations_colors(std::vector<std::string> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = combinations_colors;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (1)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (2)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (3)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\", (std::string)\"Blue\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from a string.\nstd::string remove_all_spaces(std::string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_all_spaces;\n    assert(candidate((\"python  program\")) == (\"pythonprogram\"));\n    assert(candidate((\"python   programming    language\")) == (\"pythonprogramminglanguage\"));\n    assert(candidate((\"python                     program\")) == (\"pythonprogram\"));\n    assert(candidate((\"   python                     program\")) == (\"pythonprogram\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nstd::any min_Swaps(std::string str1, std::string str2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_Swaps;\n    assert(candidate((\"1101\"), (\"1110\")) == (std::any(1)));\n    assert(candidate((\"111\"), (\"000\")) == (std::any(\"Not Possible\")));\n    assert(candidate((\"111\"), (\"110\")) == (std::any(\"Not Possible\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a new tuple from the given string and list.\nstd::tuple<std::string, std::string, std::string> new_tuple(std::vector<std::string> test_list, std::string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = new_tuple;\n    assert(candidate((std::vector<std::string>({(std::string)\"WEB\", (std::string)\"is\"})), (\"best\")) == (std::make_tuple(\"WEB\", \"is\", \"best\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"We\", (std::string)\"are\"})), (\"Developers\")) == (std::make_tuple(\"We\", \"are\", \"Developers\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Part\", (std::string)\"is\"})), (\"Wrong\")) == (std::make_tuple(\"Part\", \"is\", \"Wrong\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the product of the array multiplication modulo n.\nlong find_remainder(std::vector<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_remainder;\n    assert(candidate((std::vector<long>({(long)100, (long)10, (long)5, (long)25, (long)35, (long)14})), (11)) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (2)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the minimum value in a given heterogeneous list.\nlong min_val(std::vector<Union_std_string_long> listval) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (2));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (15));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (20));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ration of positive numbers in an array of integers.\nfloat positive_count(std::vector<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = positive_count;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.54f));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.69f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (0.56f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add the given tuple to the given list.\nstd::vector<long> add_tuple(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = add_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::vector<long>({(long)5, (long)6, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::vector<long>({(long)6, (long)7, (long)8, (long)10, (long)11})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::vector<long>({(long)7, (long)8, (long)9, (long)11, (long)12})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find maximum run of uppercase characters in the given string.\nlong max_run_uppercase(std::string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_run_uppercase;\n    assert(candidate((\"GeMKSForGERksISBESt\")) == (5));\n    assert(candidate((\"PrECIOusMOVemENTSYT\")) == (6));\n    assert(candidate((\"GooGLEFluTTER\")) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nstd::vector<std::vector<long>> sort_matrix(std::vector<std::vector<long>> M) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sort_matrix;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nlong count_vowels(std::string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_vowels;\n    assert(candidate((\"bestinstareels\")) == (7));\n    assert(candidate((\"partofthejourneyistheend\")) == (12));\n    assert(candidate((\"amazonprime\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlong max_sum_increasing_subseq(std::vector<long> a, long n, long index, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = max_sum_increasing_subseq;\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (4), (6)) == (11));\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (2), (5)) == (7));\n    assert(candidate((std::vector<long>({(long)11, (long)15, (long)19, (long)21, (long)26, (long)28, (long)31})), (7), (2), (4)) == (71));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = multiply_int;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((5), (10)) == (50));\n    assert(candidate((4), (8)) == (32));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4420,7 +244,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find words that are longer than n characters from a given list of words.\nstd::vector<std::string> long_words(long n, std::string str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = long_words;\n    assert(candidate((3), (\"python is a programming language\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"programming\", (std::string)\"language\"})));\n    assert(candidate((2), (\"writing a program\")) == (std::vector<std::string>({(std::string)\"writing\", (std::string)\"program\"})));\n    assert(candidate((5), (\"sorting list\")) == (std::vector<std::string>({(std::string)\"sorting\"})));\n}\n",
     "stop_tokens": [
@@ -4428,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of non-repeated elements in a given list.\nlong find_sum(std::vector<long> arr) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate whether the matrix is a magic square.\nbool magic_square_test(std::vector<std::vector<long>> my_matrix) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)1, (long)4, (long)5, (long)6}))) == (21));\n    assert(candidate((std::vector<long>({(long)1, (long)10, (long)9, (long)4, (long)2, (long)10, (long)10, (long)45, (long)4}))) == (71));\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)9, (long)45, (long)2, (long)10, (long)10, (long)45, (long)10}))) == (78));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = magic_square_test;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)12, (long)1, (long)14}), (std::vector<long>)std::vector<long>({(long)2, (long)13, (long)8, (long)11}), (std::vector<long>)std::vector<long>({(long)16, (long)3, (long)10, (long)5}), (std::vector<long>)std::vector<long>({(long)9, (long)6, (long)15, (long)4})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)8})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)7})}))) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nstd::map<long,long> tuple_to_dict(std::tuple<long, long, long, long, long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nstd::vector<std::vector<long>> sort_matrix(std::vector<std::vector<long>> M) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = tuple_to_dict;\n    assert(candidate((std::make_tuple(1, 5, 7, 10, 13, 5))) == (std::map<long,long>({{1, 5}, {7, 10}, {13, 5}})));\n    assert(candidate((std::make_tuple(1, 2, 3, 4, 5, 6))) == (std::map<long,long>({{1, 2}, {3, 4}, {5, 6}})));\n    assert(candidate((std::make_tuple(7, 8, 9, 10, 11, 12))) == (std::map<long,long>({{7, 8}, {9, 10}, {11, 12}})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_matrix;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nstd::vector<std::vector<long>> get_coordinates(std::tuple<long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the item with maximum frequency in a given list.\nlong max_occurrences(std::vector<long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = get_coordinates;\n    assert(candidate((std::make_tuple(3, 4))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)2, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5})})));\n    assert(candidate((std::make_tuple(4, 5))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6})})));\n    assert(candidate((std::make_tuple(5, 6))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)7}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)6, (long)7})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all the elements in tuple have same data type or not.\nbool check_type(std::any test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_type;\n    assert(candidate(std::make_tuple(5, 6, 7, 3, 5, 6)) == (true));\n    assert(candidate(std::make_tuple(1, 2, \"4\")) == (false));\n    assert(candidate(std::make_tuple(3, 2, 1, 4, 5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nlong find_First_Missing(std::vector<long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_First_Missing;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)6, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)8, (long)9}))) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is undulating or not.\nbool is_undulating(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_undulating;\n    assert(candidate((1212121)) == (true));\n    assert(candidate((1991)) == (false));\n    assert(candidate((121)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nstd::vector<std::tuple<std::string, long>> min_k(std::vector<std::tuple<std::string, long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = min_k;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Nikhil\", 8)})), (2)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sanjeev\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})), (3)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"tanmay\", 14), (std::tuple<std::string, long>)std::make_tuple(\"Amer\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9), (std::tuple<std::string, long>)std::make_tuple(\"SKD\", 16)})), (1)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nlong count_Substrings(std::string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_Substrings;\n    assert(candidate((\"112112\")) == (6));\n    assert(candidate((\"111\")) == (6));\n    assert(candidate((\"1101112\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth decagonal number.\nlong is_num_decagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_num_decagonal;\n    assert(candidate((3)) == (27));\n    assert(candidate((7)) == (175));\n    assert(candidate((10)) == (370));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nstd::vector<long> rear_extract(std::vector<std::tuple<long, std::string, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = rear_extract;\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Rash\", 21), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Varsha\", 20), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Kil\", 19)}))) == (std::vector<long>({(long)21, (long)20, (long)19})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sai\", 36), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Ayesha\", 25), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Salman\", 45)}))) == (std::vector<long>({(long)36, (long)25, (long)45})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sudeep\", 14), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Vandana\", 36), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Dawood\", 56)}))) == (std::vector<long>({(long)14, (long)36, (long)56})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the closest smaller number than n.\nlong closest_num(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = closest_num;\n    assert(candidate((11)) == (10));\n    assert(candidate((7)) == (6));\n    assert(candidate((12)) == (11));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nstd::vector<std::tuple<long, long>> find_combinations(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_combinations;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(6, 10)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(8, 11), (std::tuple<long, long>)std::make_tuple(7, 5), (std::tuple<long, long>)std::make_tuple(8, 14), (std::tuple<long, long>)std::make_tuple(11, 8), (std::tuple<long, long>)std::make_tuple(12, 17), (std::tuple<long, long>)std::make_tuple(11, 11)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(6, 2), (std::tuple<long, long>)std::make_tuple(7, 11)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 13), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(10, 16), (std::tuple<long, long>)std::make_tuple(13, 10), (std::tuple<long, long>)std::make_tuple(14, 19), (std::tuple<long, long>)std::make_tuple(13, 13)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(7, 3), (std::tuple<long, long>)std::make_tuple(8, 12)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 15), (std::tuple<long, long>)std::make_tuple(11, 9), (std::tuple<long, long>)std::make_tuple(12, 18), (std::tuple<long, long>)std::make_tuple(15, 12), (std::tuple<long, long>)std::make_tuple(16, 21), (std::tuple<long, long>)std::make_tuple(15, 15)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfloat maxAverageOfPath(std::vector<std::vector<long>> cost) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = maxAverageOfPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)3, (long)9})}))) == (5.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)4, (long)10})}))) == (6.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)11})}))) == (7.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (5.8f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nstd::tuple<bool, long> sequential_search(std::vector<long> dlist, long item) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sequential_search;\n    assert(candidate((std::vector<long>({(long)11, (long)23, (long)58, (long)31, (long)56, (long)77, (long)43, (long)12, (long)65, (long)19})), (31)) == (std::make_tuple(true, 3)));\n    assert(candidate((std::vector<long>({(long)12, (long)32, (long)45, (long)62, (long)35, (long)47, (long)44, (long)61})), (61)) == (std::make_tuple(true, 7)));\n    assert(candidate((std::vector<long>({(long)9, (long)10, (long)17, (long)19, (long)22, (long)39, (long)48, (long)56})), (48)) == (std::make_tuple(true, 6)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove odd numbers from a given list.\nstd::vector<long> remove_odd(std::vector<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)6}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)3}))) == (std::vector<long>({(long)10, (long)20})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the product of numbers in a list is even or not.\nbool is_product_even(std::vector<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = is_product_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the maximum of two numbers.\nlong maximum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((5), (10)) == (10));\n    assert(candidate((-1), (-2)) == (-1));\n    assert(candidate((9), (7)) == (9));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = max_occurrences;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)2, (long)6, (long)5, (long)1, (long)6, (long)1, (long)2, (long)3, (long)2, (long)4, (long)6, (long)9, (long)1, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)7, (long)9, (long)15, (long)14, (long)10, (long)12, (long)13, (long)16, (long)18}))) == (8));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)20, (long)30, (long)40, (long)90, (long)80, (long)50, (long)30, (long)20, (long)50, (long)10}))) == (20));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4636,9 +292,609 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nstd::string reverse_vowels(std::string str1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = reverse_vowels;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"USA\")) == (\"ASU\"));\n    assert(candidate((\"ab\")) == (\"ab\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a list to a string.\nstd::string tup_string(std::vector<std::string> tup1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tup_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"e\", (std::string)\"x\", (std::string)\"e\", (std::string)\"r\", (std::string)\"c\", (std::string)\"i\", (std::string)\"s\", (std::string)\"e\", (std::string)\"s\"}))) == (\"exercises\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"}))) == (\"program\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nlong sum_negativenum(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_negativenum;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (-32));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)-14, (long)13, (long)-18, (long)12, (long)-20}))) == (-52));\n    assert(candidate((std::vector<long>({(long)19, (long)-65, (long)57, (long)39, (long)152, (long)-639, (long)121, (long)44, (long)90, (long)-190}))) == (-894));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth hexagonal number.\nlong hexagonal_num(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = hexagonal_num;\n    assert(candidate((10)) == (190));\n    assert(candidate((5)) == (45));\n    assert(candidate((7)) == (91));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nbool is_Sum_Of_Powers_Of_Two(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_Sum_Of_Powers_Of_Two;\n    assert(candidate((10)) == (true));\n    assert(candidate((7)) == (false));\n    assert(candidate((14)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of elements.\nstd::vector<long> pancake_sort(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pancake_sort;\n    assert(candidate((std::vector<long>({(long)15, (long)79, (long)25, (long)38, (long)69}))) == (std::vector<long>({(long)15, (long)25, (long)38, (long)69, (long)79})));\n    assert(candidate((std::vector<long>({(long)98, (long)12, (long)54, (long)36, (long)85}))) == (std::vector<long>({(long)12, (long)36, (long)54, (long)85, (long)98})));\n    assert(candidate((std::vector<long>({(long)41, (long)42, (long)32, (long)12, (long)23}))) == (std::vector<long>({(long)12, (long)23, (long)32, (long)41, (long)42})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count number items that are identical in the same position of three given lists.\nlong count_samepair(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_samepair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find number of lists present in the given list.\nlong find_lists(std::vector<std::any> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_lists;\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (2));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6})}))) == (3));\n    assert(candidate((std::vector<std::any>({(long)9, (long)8, (long)7, (long)6, (long)5, (long)4, (long)3, (long)2, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the maximum difference between any two elements in a given array.\nlong max_Abs_Diff(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_Abs_Diff;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)3, (long)2, (long)5, (long)1}))) == (8));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the volume of a triangular prism.\nlong find_Volume(long l, long b, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Volume;\n    assert(candidate((10), (8), (6)) == (240));\n    assert(candidate((3), (2), (2)) == (6));\n    assert(candidate((1), (2), (1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nstd::optional<std::tuple<long, long>> find_solution(long a, long b, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_solution;\n    assert(candidate((2), (3), (7)) == std::make_tuple(2, 1));\n    assert(candidate((4), (2), (7)) == std::nullopt);\n    assert(candidate((1), (13), (17)) == std::make_tuple(4, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all elements from a given list present in another list.\nstd::vector<long> remove_elements(std::vector<long> list1, std::vector<long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)3, (long)5, (long)7}))) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)5, (long)7}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)8, (long)9, (long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlong sum_series(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_series;\n    assert(candidate((6)) == (12));\n    assert(candidate((10)) == (30));\n    assert(candidate((9)) == (25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to determine if the sum of the divisors of two integers are the same.\nbool are_equivalent(long num1, long num2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = are_equivalent;\n    assert(candidate((36), (57)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((23), (47)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlong count_char_position(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_char_position;\n    assert(candidate((\"xbcefg\")) == (2));\n    assert(candidate((\"ABcED\")) == (3));\n    assert(candidate((\"AbgdeF\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nlong find_even_pair(std::vector<long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_even_pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1}))) == (4));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11}))) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nlong next_power_of_2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = next_power_of_2;\n    assert(candidate((0)) == (1));\n    assert(candidate((5)) == (8));\n    assert(candidate((17)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurrences of a number in a given list.\nlong frequency(std::vector<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = frequency;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4})), (3)) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)1, (long)2})), (1)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nbool text_lowercase_underscore(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_lowercase_underscore;\n    assert(candidate((\"aab_cbbbc\")) == (true));\n    assert(candidate((\"aab_Abbbc\")) == (false));\n    assert(candidate((\"Aaab_abbbc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nlong sum_range_list(std::vector<long> list1, long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_range_list;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (8), (10)) == (29));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (5), (7)) == (16));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (7), (10)) == (38));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlong perimeter_pentagon(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = perimeter_pentagon;\n    assert(candidate((5)) == (25));\n    assert(candidate((10)) == (50));\n    assert(candidate((15)) == (75));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurence of the string 'std' in a given string.\nlong count_occurance(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_occurance;\n    assert(candidate((\"letstdlenstdporstd\")) == (3));\n    assert(candidate((\"truststdsolensporsd\")) == (1));\n    assert(candidate((\"makestdsostdworthit\")) == (2));\n    assert(candidate((\"stds\")) == (1));\n    assert(candidate((\"\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the perimeter of a square given its side length as input.\nlong square_perimeter(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = square_perimeter;\n    assert(candidate((10)) == (40));\n    assert(candidate((5)) == (20));\n    assert(candidate((4)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove characters from the first string which are present in the second string.\nstd::string remove_dirty_chars(std::string string, std::string second_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_dirty_chars;\n    assert(candidate((\"probasscurve\"), (\"pros\")) == (\"bacuve\"));\n    assert(candidate((\"digitalindia\"), (\"talent\")) == (\"digiidi\"));\n    assert(candidate((\"exoticmiles\"), (\"toxic\")) == (\"emles\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether a given array of integers contains any duplicate element.\nbool test_duplicate(std::vector<long> arraynums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = test_duplicate;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given number is woodball or not.\nbool is_woodall(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_woodall;\n    assert(candidate((383)) == (true));\n    assert(candidate((254)) == (false));\n    assert(candidate((200)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all the elements in tuple have same data type or not.\nbool check_type(std::any test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_type;\n    assert(candidate(std::make_tuple(5, 6, 7, 3, 5, 6)) == (true));\n    assert(candidate(std::make_tuple(1, 2, \"4\")) == (false));\n    assert(candidate(std::make_tuple(3, 2, 1, 4, 5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nbool is_majority(std::vector<long> arr, long n, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_majority;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)3, (long)10})), (7), (3)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)4, (long)4, (long)4, (long)6, (long)6})), (8), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2})), (5), (1)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2})), (5), (1)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nlong count_Set_Bits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_Set_Bits;\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (1));\n    assert(candidate((6)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove the characters which have odd index values of a given string.\nstd::string odd_values_string(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = odd_values_string;\n    assert(candidate((\"abcdef\")) == (\"ace\"));\n    assert(candidate((\"python\")) == (\"pto\"));\n    assert(candidate((\"data\")) == (\"dt\"));\n    assert(candidate((\"lambs\")) == (\"lms\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum of three numbers.\nlong min_of_three(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_of_three;\n    assert(candidate((10), (20), (0)) == (0));\n    assert(candidate((19), (15), (18)) == (15));\n    assert(candidate((-10), (-20), (-30)) == (-30));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether all the bits are unset in the given range or not.\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_Bits_Set_In_The_Given_Range;\n    assert(candidate((4), (1), (2)) == (true));\n    assert(candidate((17), (2), (4)) == (true));\n    assert(candidate((39), (4), (6)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nstd::vector<long> re_arrange_array(std::vector<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = re_arrange_array;\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)-3, (long)4, (long)5, (long)6, (long)-7, (long)8, (long)9})), (9)) == (std::vector<long>({(long)-1, (long)-3, (long)-7, (long)4, (long)5, (long)6, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)12, (long)-14, (long)-26, (long)13, (long)15})), (5)) == (std::vector<long>({(long)-14, (long)-26, (long)12, (long)13, (long)15})));\n    assert(candidate((std::vector<long>({(long)10, (long)24, (long)36, (long)-42, (long)-39, (long)-78, (long)85})), (7)) == (std::vector<long>({(long)-42, (long)-39, (long)-78, (long)10, (long)24, (long)36, (long)85})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nstd::string replace_blank(std::string str1, std::string char) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_blank;\n    assert(candidate((\"hello people\"), (\"@\")) == (\"hello@people\"));\n    assert(candidate((\"python program language\"), (\"$\")) == (\"python$program$language\"));\n    assert(candidate((\"blank space\"), (\"-\")) == (\"blank-space\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the volume of a cube given its side length.\nlong volume_cube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = volume_cube;\n    assert(candidate((3)) == (27));\n    assert(candidate((2)) == (8));\n    assert(candidate((5)) == (125));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nstd::map<std::tuple<long, long>,long> check_occurences(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_occurences;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(5, 2), (std::tuple<long, long>)std::make_tuple(6, 3)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(1, 3), 2}, {std::make_tuple(2, 5), 2}, {std::make_tuple(3, 6), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 2), (std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(3, 6), (std::tuple<long, long>)std::make_tuple(6, 3), (std::tuple<long, long>)std::make_tuple(7, 4)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 4), 2}, {std::make_tuple(3, 6), 2}, {std::make_tuple(4, 7), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(13, 2), (std::tuple<long, long>)std::make_tuple(11, 23), (std::tuple<long, long>)std::make_tuple(12, 25), (std::tuple<long, long>)std::make_tuple(25, 12), (std::tuple<long, long>)std::make_tuple(16, 23)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 13), 1}, {std::make_tuple(11, 23), 1}, {std::make_tuple(12, 25), 2}, {std::make_tuple(16, 23), 1}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of non-empty substrings of a given string.\nlong number_of_substrings(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = number_of_substrings;\n    assert(candidate((\"abc\")) == (6));\n    assert(candidate((\"abcd\")) == (10));\n    assert(candidate((\"abcde\")) == (15));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlong get_total_number_of_sequences(long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_total_number_of_sequences;\n    assert(candidate((10), (4)) == (4));\n    assert(candidate((5), (2)) == (6));\n    assert(candidate((16), (3)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nstd::vector<std::any> replace_list(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_list;\n    assert(candidate((std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})), (std::vector<std::any>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8}))) == (std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\"})), (std::vector<std::any>({(std::string)\"yellow\"}))) == (std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"yellow\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the total number of characters in a string.\nlong count_charac(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_charac;\n    assert(candidate((\"python programming\")) == (18));\n    assert(candidate((\"language\")) == (8));\n    assert(candidate((\"words\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the next perfect square greater than a given number.\nlong next_Perfect_Square(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = next_Perfect_Square;\n    assert(candidate((35)) == (36));\n    assert(candidate((6)) == (9));\n    assert(candidate((9)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nlong max_sum(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)15, (long)51, (long)45, (long)33, (long)100, (long)12, (long)18, (long)9}))) == (194));\n    assert(candidate((std::vector<long>({(long)80, (long)60, (long)30, (long)40, (long)20, (long)10}))) == (210));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)14, (long)16, (long)21, (long)23, (long)29, (long)30}))) == (138));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nlong lps(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = lps;\n    assert(candidate((\"TENS FOR TENS\")) == (5));\n    assert(candidate((\"CARDIO FOR CARDS\")) == (7));\n    assert(candidate((\"PART OF THE JOURNEY IS PART\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the intersection of two arrays.\nstd::vector<long> intersection_array(std::vector<long> array_nums1, std::vector<long> array_nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = intersection_array;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)2, (long)4, (long)8, (long)9}))) == (std::vector<long>({(long)1, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)3, (long)5, (long)7, (long)9}))) == (std::vector<long>({(long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<long>({(long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nlong count_X(std::vector<long> tup, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_X;\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (10)) == (3));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (8)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nstd::vector<std::string> insert_element(std::vector<std::string> list, std::string element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = insert_element;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Black\"})), (\"c\")) == (std::vector<std::string>({(std::string)\"c\", (std::string)\"Red\", (std::string)\"c\", (std::string)\"Green\", (std::string)\"c\", (std::string)\"Black\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"java\"})), (\"program\")) == (std::vector<std::string>({(std::string)\"program\", (std::string)\"python\", (std::string)\"program\", (std::string)\"java\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"happy\", (std::string)\"sad\"})), (\"laugh\")) == (std::vector<std::string>({(std::string)\"laugh\", (std::string)\"happy\", (std::string)\"laugh\", (std::string)\"sad\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert complex numbers to polar coordinates.\nstd::tuple<float, float> convert(long numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = convert;\n    assert(candidate((1)) == (std::make_tuple(1.0f, 0.0f)));\n    assert(candidate((4)) == (std::make_tuple(4.0f, 0.0f)));\n    assert(candidate((5)) == (std::make_tuple(5.0f, 0.0f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_string_float{\n    long f0;\n    std::string f1;\n    float f2;    Union_long_std_string_float(long _f0) : f0(_f0) {}\n    Union_long_std_string_float(std::string _f1) : f1(_f1) {}\n    Union_long_std_string_float(float _f2) : f2(_f2) {}\n    ~Union_long_std_string_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::string f) {\n        return f1 == f ;\n    }    bool operator==(float f) {\n        return f2 == f ;\n    }\n};\n// Write a python function that returns the number of integer elements in a given list.\nlong count_integer(std::vector<Union_long_std_string_float> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_integer;\n    assert(candidate((std::vector<Union_long_std_string_float>({1, 2, \"abc\", 1.2f}))) == (2));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)1.2f, (long)4, (long)5.1f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nstd::vector<std::vector<std::string>> combinations_colors(std::vector<std::string> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = combinations_colors;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (1)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (2)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (3)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\", (std::string)\"Blue\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlong count_Primes_nums(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_Primes_nums;\n    assert(candidate((5)) == (2));\n    assert(candidate((10)) == (4));\n    assert(candidate((100)) == (25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nstd::vector<long> swap_numbers(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = swap_numbers;\n    assert(candidate((10), (20)) == (std::vector<long>({(long)20, (long)10})));\n    assert(candidate((15), (17)) == (std::vector<long>({(long)17, (long)15})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)200, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4648,7 +904,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to maximize the given two lists.\nstd::vector<std::vector<long>> maximize_elements(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = maximize_elements;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)10})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)5, (long)10}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)11})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)11}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)9, (long)12})})));\n}\n",
     "stop_tokens": [
@@ -4656,73 +912,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether every even index contains even numbers of a given list.\nbool even_position(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlong newman_prime(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = even_position;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = newman_prime;\n    assert(candidate((3)) == (7));\n    assert(candidate((4)) == (17));\n    assert(candidate((5)) == (41));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string starts and ends with the same character or not.\nstd::string check_char(std::string string) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nstd::tuple<long, long, long, long> division_elements(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = check_char;\n    assert(candidate((\"abba\")) == (\"Valid\"));\n    assert(candidate((\"a\")) == (\"Valid\"));\n    assert(candidate((\"abcd\")) == (\"Invalid\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = division_elements;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(2, 2, 2, 3)));\n    assert(candidate((std::make_tuple(12, 6, 8, 16)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(2, 2, 2, 4)));\n    assert(candidate((std::make_tuple(20, 14, 36, 18)), (std::make_tuple(5, 7, 6, 9))) == (std::make_tuple(4, 2, 6, 2)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of even factors of a number.\nlong sumofFactors(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nstd::any split_two_parts(std::vector<std::any> list1, long L) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = sumofFactors;\n    assert(candidate((18)) == (26));\n    assert(candidate((30)) == (48));\n    assert(candidate((6)) == (8));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = split_two_parts;\n    assert(candidate((std::vector<std::any>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == std::make_tuple(std::vector<long>({(long)1, (long)1, (long)2}), std::vector<long>({(long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (2)) == std::make_tuple(std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})), (4)) == std::make_tuple(std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\"}), std::vector<std::string>({(std::string)\"o\", (std::string)\"n\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfloat lateralsurface_cone(long r, long h) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate a dog's age in dog's years.\nlong dog_age(long h_age) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cone;\n    assert(candidate((5), (12)) == (204.20352248333654f));\n    assert(candidate((10), (15)) == (566.3586699569488f));\n    assert(candidate((19), (17)) == (1521.8090132193388f));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = dog_age;\n    assert(candidate((12)) == (61));\n    assert(candidate((15)) == (73));\n    assert(candidate((24)) == (109));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nlong count_Pairs(std::vector<long> arr, long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nstd::vector<std::vector<std::any>> list_split(std::vector<std::any> S, long step) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = count_Pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (5)) == (10));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = list_split;\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"e\", (std::string)\"f\", (std::string)\"g\", (std::string)\"h\", (std::string)\"i\", (std::string)\"j\", (std::string)\"k\", (std::string)\"l\", (std::string)\"m\", (std::string)\"n\"})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"d\", (std::string)\"g\", (std::string)\"j\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\", (std::string)\"e\", (std::string)\"h\", (std::string)\"k\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"f\", (std::string)\"i\", (std::string)\"l\"})})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11, (long)12, (long)13, (long)14})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)4, (long)7, (long)10, (long)13}), (std::vector<long>)std::vector<long>({(long)2, (long)5, (long)8, (long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)12})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"python\", (std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\", (std::string)\"SQL\"})), (2)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"python\", (std::string)\"C\", (std::string)\"DBMS\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"java\", (std::string)\"C++\", (std::string)\"SQL\"})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nlong find_first_occurrence(std::vector<long> A, long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cube given its side length.\nlong lateralsurface_cube(long l) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = find_first_occurrence;\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (6)) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cube;\n    assert(candidate((5)) == (100));\n    assert(candidate((9)) == (324));\n    assert(candidate((10)) == (400));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4732,9 +988,729 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nlong square_Sum(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (10));\n    assert(candidate((3)) == (35));\n    assert(candidate((4)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th star number.\nlong find_star_num(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_star_num;\n    assert(candidate((3)) == (37));\n    assert(candidate((4)) == (73));\n    assert(candidate((5)) == (121));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ascii value of a character.\nlong ascii_value(std::string k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = ascii_value;\n    assert(candidate((\"A\")) == (65));\n    assert(candidate((\"R\")) == (82));\n    assert(candidate((\"S\")) == (83));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of even numbers at even positions of a list.\nlong sum_even_and_even_index(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_even_and_even_index;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1, (long)18, (long)8}))) == (30));\n    assert(candidate((std::vector<long>({(long)3, (long)20, (long)17, (long)9, (long)2, (long)10, (long)18, (long)13, (long)6, (long)18}))) == (26));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlong even_Power_Sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_Power_Sum;\n    assert(candidate((2)) == (1056));\n    assert(candidate((3)) == (8832));\n    assert(candidate((1)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nstd::vector<long> rear_extract(std::vector<std::tuple<long, std::string, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rear_extract;\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Rash\", 21), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Varsha\", 20), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Kil\", 19)}))) == (std::vector<long>({(long)21, (long)20, (long)19})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sai\", 36), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Ayesha\", 25), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Salman\", 45)}))) == (std::vector<long>({(long)36, (long)25, (long)45})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sudeep\", 14), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Vandana\", 36), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Dawood\", 56)}))) == (std::vector<long>({(long)14, (long)36, (long)56})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nstd::tuple<long, long, long> substract_elements(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = substract_elements;\n    assert(candidate((std::make_tuple(10, 4, 5)), (std::make_tuple(2, 5, 18))) == (std::make_tuple(8, -1, -13)));\n    assert(candidate((std::make_tuple(11, 2, 3)), (std::make_tuple(24, 45, 16))) == (std::make_tuple(-13, -43, -13)));\n    assert(candidate((std::make_tuple(7, 18, 9)), (std::make_tuple(10, 11, 12))) == (std::make_tuple(-3, 7, -3)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlong even_binomial_Coeff_Sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_binomial_Coeff_Sum;\n    assert(candidate((4)) == (8));\n    assert(candidate((6)) == (32));\n    assert(candidate((2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nstd::map<std::string,long> dict_filter(std::map<std::string,long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = dict_filter;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (170)) == (std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (180)) == (std::map<std::string,long>({{\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (190)) == (std::map<std::string,long>({{\"Pierre Cox\", 190}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_tuple_long, long_{\n    long f0;\n    std::tuple<long, long> f1;    Union_long_std_tuple_long, long_(long _f0) : f0(_f0) {}\n    Union_long_std_tuple_long, long_(std::tuple<long, long> _f1) : f1(_f1) {}\n    ~Union_long_std_tuple_long, long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::tuple<long, long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the number of elements that occurs before the list element in the given tuple.\nlong count_first_elements(std::vector<Union_long_std_tuple_long, long_> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_first_elements;\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({1, 5, 7, std::make_tuple(4, 6), 10}))) == (3));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({2, 9, std::make_tuple(5, 7), 11}))) == (2));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({11, 15, 5, 8, std::make_tuple(2, 3), 8}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth decagonal number.\nlong is_num_decagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_num_decagonal;\n    assert(candidate((3)) == (27));\n    assert(candidate((7)) == (175));\n    assert(candidate((10)) == (370));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nstd::tuple<bool, long> sequential_search(std::vector<long> dlist, long item) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sequential_search;\n    assert(candidate((std::vector<long>({(long)11, (long)23, (long)58, (long)31, (long)56, (long)77, (long)43, (long)12, (long)65, (long)19})), (31)) == (std::make_tuple(true, 3)));\n    assert(candidate((std::vector<long>({(long)12, (long)32, (long)45, (long)62, (long)35, (long)47, (long)44, (long)61})), (61)) == (std::make_tuple(true, 7)));\n    assert(candidate((std::vector<long>({(long)9, (long)10, (long)17, (long)19, (long)22, (long)39, (long)48, (long)56})), (48)) == (std::make_tuple(true, 6)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check if the elements of a given list are unique or not.\nbool all_unique(std::vector<long> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_unique;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to subtract two lists element-wise.\nstd::vector<long> sub_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sub_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)-3, (long)-3, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (std::vector<long>({(long)3, (long)4}))) == (std::vector<long>({(long)-2, (long)-2})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<long>({(long)40, (long)50})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nbool validate(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = validate;\n    assert(candidate((1234)) == (true));\n    assert(candidate((51241)) == (false));\n    assert(candidate((321)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nbool check_element(std::vector<std::any> list, std::any element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_element;\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"})), (std::any(\"blue\"))) == (false));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (std::any(7))) == (false));\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"green\", (std::string)\"green\", (std::string)\"green\"})), (std::any(\"green\"))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nbool text_match_two_three(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_two_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nlong max_sub_array_sum_repeated(std::vector<long> a, long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum_repeated;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)-30, (long)-1})), (4), (3)) == (30));\n    assert(candidate((std::vector<long>({(long)-1, (long)10, (long)20})), (3), (2)) == (59));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3})), (3), (3)) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlong square_Sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (20));\n    assert(candidate((3)) == (56));\n    assert(candidate((4)) == (120));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the list of maximum length in a list of lists.\nstd::tuple<long, std::vector<long>> max_length(std::vector<std::vector<long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)12, (long)14, (long)15})}))) == (std::make_tuple(4, std::vector<long>({(long)10, (long)12, (long)14, (long)15}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)15, (long)20, (long)25})}))) == (std::make_tuple(3, std::vector<long>({(long)15, (long)20, (long)25}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlong count_no_of_ways(long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_no_of_ways;\n    assert(candidate((2), (4)) == (16));\n    assert(candidate((3), (2)) == (6));\n    assert(candidate((4), (4)) == (228));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nlong find(long n, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find;\n    assert(candidate((10), (3)) == (3));\n    assert(candidate((4), (2)) == (2));\n    assert(candidate((20), (5)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the third side of a right angled triangle.\nfloat otherside_rightangle(long w, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = otherside_rightangle;\n    assert(candidate((7), (8)) == (10.63014581273465f));\n    assert(candidate((3), (4)) == (float(5)));\n    assert(candidate((7), (15)) == (16.55294535724685f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the maximum value in a given heterogeneous list.\nlong max_val(std::vector<Union_std_string_long> listval) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (5));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (25));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (50));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return the sum of all divisors of a number.\nlong sum_div(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_div;\n    assert(candidate((8)) == (7));\n    assert(candidate((12)) == (16));\n    assert(candidate((7)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count inversions in an array.\nlong get_Inv_Count(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_Inv_Count;\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)6, (long)4, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)6, (long)1}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a given nested list structure.\nstd::vector<long> flatten_list(std::vector<Union_long_std_vector_long_> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = flatten_list;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({0, 10, std::vector<long>({(long)20, (long)30}), 40, 50, std::vector<long>({(long)60, (long)70, (long)80}), std::vector<long>({(long)90, (long)100, (long)110, (long)120})}))) == (std::vector<long>({(long)0, (long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70, (long)80, (long)90, (long)100, (long)110, (long)120})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)40}), (std::vector<long>)std::vector<long>({(long)30, (long)56, (long)25}), (std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)33}), (std::vector<long>)std::vector<long>({(long)40})}))) == (std::vector<long>({(long)10, (long)20, (long)40, (long)30, (long)56, (long)25, (long)10, (long)20, (long)33, (long)40})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)10, (long)11, (long)12, (long)7, (long)8, (long)9})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the maximum aggregate from the list of tuples.\nstd::tuple<std::string, long> max_aggregate(std::vector<std::tuple<std::string, long>> stdata) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_aggregate;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 7), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 122), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 84)}))) == (std::make_tuple(\"Juan Whelan\", 212)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 50), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 48), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 37), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 22), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 14)}))) == (std::make_tuple(\"Juan Whelan\", 72)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 20), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 30), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 40), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 50)}))) == (std::make_tuple(\"Sabah Colley\", 70)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find element at a given index after number of rotations.\nlong find_Element(std::vector<long> arr, std::vector<std::vector<long>> ranges, long rotations, long index) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)2}), (std::vector<long>)std::vector<long>({(long)0, (long)3})})), (2), (1)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return two words from a list of words starting with letter 'p'.\nstd::tuple<std::string, std::string> start_withp(std::vector<std::string> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = start_withp;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python PHP\", (std::string)\"Java JavaScript\", (std::string)\"c c++\"}))) == (std::make_tuple(\"Python\", \"PHP\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python Programming\", (std::string)\"Java Programming\"}))) == (std::make_tuple(\"Python\", \"Programming\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Pqrst Pqr\", (std::string)\"qrstuv\"}))) == (std::make_tuple(\"Pqrst\", \"Pqr\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlong max_sum_increasing_subseq(std::vector<long> a, long n, long index, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_sum_increasing_subseq;\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (4), (6)) == (11));\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (2), (5)) == (7));\n    assert(candidate((std::vector<long>({(long)11, (long)15, (long)19, (long)21, (long)26, (long)28, (long)31})), (7), (2), (4)) == (71));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nstd::vector<long> large_product(std::vector<long> nums1, std::vector<long> nums2, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = large_product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (3)) == (std::vector<long>({(long)60, (long)54, (long)50})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (4)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (5)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48, (long)45})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the maximum of two numbers.\nlong maximum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((5), (10)) == (10));\n    assert(candidate((-1), (-2)) == (-1));\n    assert(candidate((9), (7)) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given string to a list of characters.\nstd::vector<std::string> string_to_tuple(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = string_to_tuple;\n    assert(candidate((\"python 3.0\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\", (std::string)\"3\", (std::string)\".\", (std::string)\"0\"})));\n    assert(candidate((\"item1\")) == (std::vector<std::string>({(std::string)\"i\", (std::string)\"t\", (std::string)\"e\", (std::string)\"m\", (std::string)\"1\"})));\n    assert(candidate((\"15.10\")) == (std::vector<std::string>({(std::string)\"1\", (std::string)\"5\", (std::string)\".\", (std::string)\"1\", (std::string)\"0\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nlong highest_Power_of_2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = highest_Power_of_2;\n    assert(candidate((10)) == (8));\n    assert(candidate((19)) == (16));\n    assert(candidate((32)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th lucas number.\nlong find_lucas(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_lucas;\n    assert(candidate((9)) == (76));\n    assert(candidate((4)) == (7));\n    assert(candidate((3)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to apply a given format string to all of the elements in a list.\nstd::vector<std::string> add_string(std::vector<std::any> list_, std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_string;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (\"temp{0}\")) == (std::vector<std::string>({(std::string)\"temp1\", (std::string)\"temp2\", (std::string)\"temp3\", (std::string)\"temp4\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (\"python{0}\")) == (std::vector<std::string>({(std::string)\"pythona\", (std::string)\"pythonb\", (std::string)\"pythonc\", (std::string)\"pythond\"})));\n    assert(candidate((std::vector<std::any>({(long)5, (long)6, (long)7, (long)8})), (\"string{0}\")) == (std::vector<std::string>({(std::string)\"string5\", (std::string)\"string6\", (std::string)\"string7\", (std::string)\"string8\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert more than one list to nested dictionary.\nstd::vector<std::map<std::string,std::map<std::string,long>>> convert_list_dictionary(std::vector<std::string> l1, std::vector<std::string> l2, std::vector<long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = convert_list_dictionary;\n    assert(candidate((std::vector<std::string>({(std::string)\"S001\", (std::string)\"S002\", (std::string)\"S003\", (std::string)\"S004\"})), (std::vector<std::string>({(std::string)\"Adina Park\", (std::string)\"Leyton Marsh\", (std::string)\"Duncan Boyle\", (std::string)\"Saim Richards\"})), (std::vector<long>({(long)85, (long)98, (long)89, (long)92}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S001\", std::map<std::string,long>({{\"Adina Park\", 85}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S002\", std::map<std::string,long>({{\"Leyton Marsh\", 98}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S003\", std::map<std::string,long>({{\"Duncan Boyle\", 89}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S004\", std::map<std::string,long>({{\"Saim Richards\", 92}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"def\", (std::string)\"ghi\", (std::string)\"jkl\"})), (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\", (std::string)\"programs\"})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"abc\", std::map<std::string,long>({{\"python\", 100}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"def\", std::map<std::string,long>({{\"program\", 200}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"ghi\", std::map<std::string,long>({{\"language\", 300}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"jkl\", std::map<std::string,long>({{\"programs\", 400}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"A1\", (std::string)\"A2\", (std::string)\"A3\", (std::string)\"A4\"})), (std::vector<std::string>({(std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\"})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A1\", std::map<std::string,long>({{\"java\", 10}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A2\", std::map<std::string,long>({{\"C\", 20}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A3\", std::map<std::string,long>({{\"C++\", 30}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A4\", std::map<std::string,long>({{\"DBMS\", 40}})}})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlong get_max_sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_max_sum;\n    assert(candidate((60)) == (106));\n    assert(candidate((10)) == (12));\n    assert(candidate((2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the list with maximum length.\nstd::tuple<long, std::vector<long>> max_length_list(std::vector<std::vector<long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_length_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1})}))) == (std::make_tuple(5, std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12})}))) == (std::make_tuple(4, std::vector<long>({(long)6, (long)7, (long)8, (long)9}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if given list contains no duplicates.\nbool check_distinct(std::vector<long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_distinct;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6, (long)1, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first non-repeated character in a given string.\nstd::optional<std::string> first_non_repeating_character(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = first_non_repeating_character;\n    assert(candidate((\"abcabc\")) == std::nullopt);\n    assert(candidate((\"abc\")) == \"a\");\n    assert(candidate((\"ababc\")) == \"c\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string starts and ends with the same character or not.\nstd::string check_char(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_char;\n    assert(candidate((\"abba\")) == (\"Valid\"));\n    assert(candidate((\"a\")) == (\"Valid\"));\n    assert(candidate((\"abcd\")) == (\"Invalid\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of three numbers.\nfloat median_numbers(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = median_numbers;\n    assert(candidate((25), (55), (65)) == (55.0f));\n    assert(candidate((20), (10), (30)) == (20.0f));\n    assert(candidate((15), (45), (75)) == (45.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the sum of digits of each number of a given list.\nlong sum_of_digits(std::vector<std::any> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_of_digits;\n    assert(candidate((std::vector<std::any>({(long)10, (long)2, (long)56}))) == (14));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<std::any>({10, 20, 4, 5, \"b\", 70, \"a\"})}))) == (19));\n    assert(candidate((std::vector<std::any>({(long)10, (long)20, (long)-4, (long)5, (long)-70}))) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nstd::tuple<long, long, long, long> bitwise_xor(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = bitwise_xor;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(15, 6, 5, 10)));\n    assert(candidate((std::make_tuple(11, 5, 7, 10)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(13, 6, 3, 14)));\n    assert(candidate((std::make_tuple(12, 6, 8, 11)), (std::make_tuple(7, 4, 5, 6))) == (std::make_tuple(11, 2, 13, 13)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to identify non-prime numbers.\nbool is_not_prime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_not_prime;\n    assert(candidate((2)) == (false));\n    assert(candidate((10)) == (true));\n    assert(candidate((35)) == (true));\n    assert(candidate((37)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the number of unique tuples in the given list.\nlong extract_freq(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_freq;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(5, 6)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 15), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(6, 7)}))) == (4));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 16), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 9)}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nstd::vector<std::vector<long>> add_nested_tuples(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_nested_tuples;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)10}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)13})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)12}), (std::vector<long>)std::vector<long>({(long)9, (long)16}), (std::vector<long>)std::vector<long>({(long)5, (long)12}), (std::vector<long>)std::vector<long>({(long)10, (long)15})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)11, (long)18}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)12, (long)17})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum of two numbers.\nlong minimum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = minimum;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((-5), (-4)) == (-5));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to check whether an element exists within a tuple.\nbool check_tuplex(std::vector<Union_std_string_long> tuplex, std::any tuple1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_tuplex;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"r\"))) == (true));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"5\"))) == (false));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(3))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find whether the parity of a given number is odd.\nbool find_Parity(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Parity;\n    assert(candidate((12)) == (false));\n    assert(candidate((7)) == (true));\n    assert(candidate((10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nstd::any rearrange_bigger(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rearrange_bigger;\n    assert(candidate((12)) == (std::any(21)));\n    assert(candidate((10)) == (std::any(false)));\n    assert(candidate((102)) == (std::any(120)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nstd::vector<std::vector<long>> k_smallest_pairs(std::vector<long> nums1, std::vector<long> nums2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = k_smallest_pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (7)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)2})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nlong min_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (8));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (30));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (100));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the minimum value in a given heterogeneous list.\nlong min_val(std::vector<Union_std_string_long> listval) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (2));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (15));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (20));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"android_tv\")) == (\"AndroidTv\"));\n    assert(candidate((\"google_pixel\")) == (\"GooglePixel\"));\n    assert(candidate((\"apple_watch\")) == (\"AppleWatch\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove odd numbers from a given list.\nstd::vector<long> remove_odd(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)6}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)3}))) == (std::vector<long>({(long)10, (long)20})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the nth element from a given list of tuples.\nstd::vector<std::any> extract_nth_element(std::vector<std::tuple<std::string, long, long>> list1, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_nth_element;\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (0)) == (std::vector<std::any>({(std::string)\"Greyson Fulton\", (std::string)\"Brady Kent\", (std::string)\"Wyatt Knott\", (std::string)\"Beau Turnbull\"})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (2)) == (std::vector<std::any>({(long)99, (long)96, (long)94, (long)98})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (1)) == (std::vector<std::any>({(long)98, (long)97, (long)91, (long)94})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nbool overlapping(std::vector<long> list1, std::vector<long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = overlapping;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)8, (long)9}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5})), (std::vector<long>({(long)1, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find a pair with highest product from a given array of integers.\nstd::tuple<long, long> max_Product(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_Product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)0, (long)8, (long)4}))) == (std::make_tuple(7, 8)));\n    assert(candidate((std::vector<long>({(long)0, (long)-1, (long)-2, (long)-4, (long)5, (long)0, (long)-6}))) == (std::make_tuple(-4, -6)));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::make_tuple(2, 3)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4744,7 +1720,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find common first element in given list of lists.\nstd::vector<std::vector<std::string>> group_tuples(std::vector<std::vector<std::string>> Input) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "}\nint main() {\n    auto candidate = group_tuples;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"w\", (std::string)\"t\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"w\", (std::string)\"t\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"e\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"h\", (std::string)\"i\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"h\", (std::string)\"i\"})})));\n}\n",
     "stop_tokens": [
@@ -4752,13 +1728,3037 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three lists into a single sorted list.\nstd::vector<long> merge_sorted_list(std::vector<long> num1, std::vector<long> num2, std::vector<long> num3) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the element of a list having maximum length.\nstd::vector<std::any> Find_Max(std::vector<std::vector<std::any>> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\nint main() {\n    auto candidate = merge_sorted_list;\n    assert(candidate((std::vector<long>({(long)25, (long)24, (long)15, (long)4, (long)5, (long)29, (long)110})), (std::vector<long>({(long)19, (long)20, (long)11, (long)56, (long)25, (long)233, (long)154})), (std::vector<long>({(long)24, (long)26, (long)54, (long)48}))) == (std::vector<long>({(long)4, (long)5, (long)11, (long)15, (long)19, (long)20, (long)24, (long)24, (long)25, (long)25, (long)26, (long)29, (long)48, (long)54, (long)56, (long)110, (long)154, (long)233})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)6, (long)8, (long)9})), (std::vector<long>({(long)2, (long)5, (long)7, (long)11})), (std::vector<long>({(long)1, (long)4, (long)7, (long)8, (long)12}))) == (std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)5, (long)5, (long)6, (long)7, (long)7, (long)8, (long)8, (long)9, (long)11, (long)12})));\n    assert(candidate((std::vector<long>({(long)18, (long)14, (long)10, (long)9, (long)8, (long)7, (long)9, (long)3, (long)2, (long)4, (long)1})), (std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58})), (std::vector<long>({(long)12, (long)74, (long)9, (long)50, (long)61, (long)41}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)8, (long)9, (long)9, (long)9, (long)10, (long)12, (long)14, (long)14, (long)18, (long)22, (long)25, (long)25, (long)35, (long)41, (long)50, (long)58, (long)61, (long)65, (long)74, (long)75, (long)85})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = Find_Max;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})}))) == (std::vector<std::any>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)5, (long)6, (long)1})}))) == (std::vector<std::any>({(long)1, (long)5, (long)6, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_float_long{\n    float f0;\n    long f1;    Union_float_long(float _f0) : f0(_f0) {}\n    Union_float_long(long _f1) : f1(_f1) {}\n    ~Union_float_long() {}\n    bool operator==(float f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nlong round_and_sum(std::vector<Union_float_long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = round_and_sum;\n    assert(candidate((std::vector<Union_float_long>({(float)22.4f, (float)4.0f, (float)-16.22f, (float)-9.1f, (float)11.0f, (float)-12.22f, (float)14.2f, (float)-5.2f, (float)17.5f}))) == (243));\n    assert(candidate((std::vector<Union_float_long>({(long)5, (long)2, (long)9, (long)24.3f, (long)29}))) == (345));\n    assert(candidate((std::vector<Union_float_long>({(float)25.0f, (float)56.7f, (float)89.2f}))) == (513));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the cube sum of first n even natural numbers.\nlong cube_Sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cube_Sum;\n    assert(candidate((2)) == (72));\n    assert(candidate((3)) == (288));\n    assert(candidate((4)) == (800));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to concatenate each element of tuple by the delimiter.\nstd::string concatenate_tuple(std::tuple<std::string, std::string, long, std::string> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = concatenate_tuple;\n    assert(candidate((std::make_tuple(\"ID\", \"is\", 4, \"UTS\"))) == (\"ID-is-4-UTS\"));\n    assert(candidate((std::make_tuple(\"QWE\", \"is\", 4, \"RTY\"))) == (\"QWE-is-4-RTY\"));\n    assert(candidate((std::make_tuple(\"ZEN\", \"is\", 4, \"OP\"))) == (\"ZEN-is-4-OP\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the average of cubes of first n natural numbers.\nfloat find_Average_Of_Cube(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Average_Of_Cube;\n    assert(candidate((2)) == (4.5f));\n    assert(candidate((3)) == (float(12)));\n    assert(candidate((1)) == (float(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract only the rear index element of each string in the given tuple.\nstd::vector<std::string> extract_rear(std::tuple<std::string, std::string, std::string> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_rear;\n    assert(candidate((std::make_tuple(\"Mers\", \"for\", \"Vers\"))) == (std::vector<std::string>({(std::string)\"s\", (std::string)\"r\", (std::string)\"s\"})));\n    assert(candidate((std::make_tuple(\"Avenge\", \"for\", \"People\"))) == (std::vector<std::string>({(std::string)\"e\", (std::string)\"r\", (std::string)\"e\"})));\n    assert(candidate((std::make_tuple(\"Gotta\", \"get\", \"go\"))) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"t\", (std::string)\"o\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of sublists containing a particular element.\nlong count_element_in_list(std::vector<std::vector<std::any>> list1, std::any x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_element_in_list;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)11}), (std::vector<long>)std::vector<long>({(long)1, (long)15, (long)7})})), (std::any(1))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"A\"))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"E\"))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to filter odd numbers.\nstd::vector<long> filter_oddnumbers(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_oddnumbers;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)45, (long)67, (long)84, (long)93}))) == (std::vector<long>({(long)45, (long)67, (long)93})));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)9, (long)8, (long)6, (long)4, (long)3}))) == (std::vector<long>({(long)5, (long)7, (long)9, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nstd::string change_date_format(std::string dt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = change_date_format;\n    assert(candidate((\"2026-01-02\")) == (\"02-01-2026\"));\n    assert(candidate((\"2020-11-13\")) == (\"13-11-2020\"));\n    assert(candidate((\"2021-04-26\")) == (\"26-04-2021\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given array by using shell sort.\nstd::vector<long> shell_sort(std::vector<long> my_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = shell_sort;\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)4, (long)5, (long)3, (long)2, (long)12, (long)81, (long)56, (long)95}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)12, (long)12, (long)23, (long)56, (long)81, (long)95})));\n    assert(candidate((std::vector<long>({(long)24, (long)22, (long)39, (long)34, (long)87, (long)73, (long)68}))) == (std::vector<long>({(long)22, (long)24, (long)34, (long)39, (long)68, (long)73, (long)87})));\n    assert(candidate((std::vector<long>({(long)32, (long)30, (long)16, (long)96, (long)82, (long)83, (long)74}))) == (std::vector<long>({(long)16, (long)30, (long)32, (long)74, (long)82, (long)83, (long)96})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the elementwise and tuples from the given two tuples.\nstd::tuple<long, long, long, long> and_tuples(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = and_tuples;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(0, 0, 2, 1)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(5, 6, 7, 8))) == (std::make_tuple(1, 2, 3, 0)));\n    assert(candidate((std::make_tuple(8, 9, 11, 12)), (std::make_tuple(7, 13, 14, 17))) == (std::make_tuple(0, 9, 10, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the directrix of a parabola.\nlong parabola_directrix(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = parabola_directrix;\n    assert(candidate((5), (3), (2)) == (-198));\n    assert(candidate((9), (8), (4)) == (-2336));\n    assert(candidate((2), (4), (6)) == (-130));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes two lists and returns true if they have at least one common element.\nstd::optional<bool> common_element(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = common_element;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == true);\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)6, (long)7, (long)8, (long)9}))) == std::nullopt);\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})), (std::vector<std::any>({(std::string)\"d\", (std::string)\"b\", (std::string)\"e\"}))) == true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median length of a trapezium.\nfloat median_trapezium(long base1, long base2, long height) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = median_trapezium;\n    assert(candidate((15), (25), (35)) == (float(20)));\n    assert(candidate((10), (20), (30)) == (float(15)));\n    assert(candidate((6), (9), (4)) == (7.5f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the entered number is greater than the elements of the given array.\nbool check_greater(std::vector<long> arr, long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_greater;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6})), (8)) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)4, (long)8, (long)6, (long)1})), (11)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by one or more b's.\nbool text_match_one(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last digit of a given number.\nlong last_Digit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = last_Digit;\n    assert(candidate((123)) == (3));\n    assert(candidate((25)) == (5));\n    assert(candidate((30)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to return the negative numbers in a list.\nstd::vector<long> neg_nos(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = neg_nos;\n    assert(candidate((std::vector<long>({(long)-1, (long)4, (long)5, (long)-6}))) == (std::vector<long>({(long)-1, (long)-6})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3, (long)4}))) == (std::vector<long>({(long)-1, (long)-2})));\n    assert(candidate((std::vector<long>({(long)-7, (long)-6, (long)8, (long)9}))) == (std::vector<long>({(long)-7, (long)-6})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove odd characters in a string.\nstd::string remove_odd(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((\"python\")) == (\"yhn\"));\n    assert(candidate((\"program\")) == (\"rga\"));\n    assert(candidate((\"language\")) == (\"agae\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count bidirectional tuple pairs.\nlong count_bidirectional(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_bidirectional;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (2));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to join a list of multiple integers into a single integer.\nlong multiple_to_single(std::vector<long> L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = multiple_to_single;\n    assert(candidate((std::vector<long>({(long)11, (long)33, (long)50}))) == (113350));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (-123456));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25}))) == (10152025));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb and their positions in a given sentence.\nstd::tuple<long, long, std::string> find_adverb_position(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_adverb_position;\n    assert(candidate((\"clearly!! we can see the sky\")) == (std::make_tuple(0, 7, \"clearly\")));\n    assert(candidate((\"seriously!! there are many roses\")) == (std::make_tuple(0, 9, \"seriously\")));\n    assert(candidate((\"unfortunately!! sita is going to home\")) == (std::make_tuple(0, 13, \"unfortunately\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cube of a given size.\nlong surfacearea_cube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = surfacearea_cube;\n    assert(candidate((5)) == (150));\n    assert(candidate((3)) == (54));\n    assert(candidate((10)) == (600));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ration of positive numbers in an array of integers.\nfloat positive_count(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = positive_count;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.54f));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.69f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (0.56f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the largest negative number from the given list.\nlong largest_neg(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = largest_neg;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-4, (long)-6}))) == (-6));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-8, (long)-9}))) == (-9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to trim each list by k in the given lists.\nstd::vector<std::vector<long>> trim_tuple(std::vector<std::vector<long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = trim_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)2})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)8, (long)2, (long)1})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)12, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)4}), (std::vector<long>)std::vector<long>({(long)8, (long)12}), (std::vector<long>)std::vector<long>({(long)1, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)9})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nstd::vector<std::vector<long>> index_multiplication(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = index_multiplication;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)21}), (std::vector<long>)std::vector<long>({(long)12, (long)45}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)30})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)14, (long)32}), (std::vector<long>)std::vector<long>({(long)20, (long)60}), (std::vector<long>)std::vector<long>({(long)6, (long)20}), (std::vector<long>)std::vector<long>({(long)16, (long)44})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)24, (long)45}), (std::vector<long>)std::vector<long>({(long)30, (long)77}), (std::vector<long>)std::vector<long>({(long)12, (long)33}), (std::vector<long>)std::vector<long>({(long)27, (long)60})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the occurence of all elements of list in a tuple.\nlong count_Occurrence(std::any tup, std::vector<std::any> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_Occurrence;\n    assert(candidate(std::make_tuple(\"a\", \"a\", \"c\", \"b\", \"d\"), (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\"}))) == (3));\n    assert(candidate(std::make_tuple(1, 2, 3, 1, 4, 6, 7, 1, 4), (std::vector<std::any>({(long)1, (long)4, (long)7}))) == (6));\n    assert(candidate(std::make_tuple(1, 2, 3, 4, 5, 6), (std::vector<std::any>({(long)1, (long)2}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find cubes of individual elements in a list.\nstd::vector<long> cube_nums(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cube_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)8, (long)27, (long)64, (long)125, (long)216, (long)343, (long)512, (long)729, (long)1000})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)1728, (long)3375})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of perrin numbers.\nlong cal_sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cal_sum;\n    assert(candidate((9)) == (49));\n    assert(candidate((10)) == (66));\n    assert(candidate((11)) == (88));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract specified size of strings from a given list of string values.\nstd::vector<std::string> extract_string(std::vector<std::string> str, long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (8)) == (std::vector<std::string>({(std::string)\"practice\", (std::string)\"solution\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (6)) == (std::vector<std::string>({(std::string)\"Python\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (9)) == (std::vector<std::string>({(std::string)\"exercises\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from the given string.\nstd::string remove_whitespaces(std::string text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_whitespaces;\n    assert(candidate((\" Google    Flutter \")) == (\"GoogleFlutter\"));\n    assert(candidate((\" Google    Dart \")) == (\"GoogleDart\"));\n    assert(candidate((\" iOS    Swift \")) == (\"iOSSwift\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlong loss_amount(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = loss_amount;\n    assert(candidate((1500), (1200)) == (0));\n    assert(candidate((100), (200)) == (100));\n    assert(candidate((2000), (5000)) == (3000));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of even factors of a number.\nlong sumofFactors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sumofFactors;\n    assert(candidate((18)) == (26));\n    assert(candidate((30)) == (48));\n    assert(candidate((6)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a word containing 'z'.\nbool text_match_wordz(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_wordz;\n    assert(candidate((\"pythonz.\")) == (true));\n    assert(candidate((\"xyz.\")) == (true));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 31 days or not.\nbool check_monthnumb_number(long monthnum2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_monthnumb_number;\n    assert(candidate((5)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((6)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse each string in a given list of string values.\nstd::vector<std::string> reverse_string_list(std::vector<std::string> stringlist) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = reverse_string_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\", (std::string)\"White\", (std::string)\"Black\"}))) == (std::vector<std::string>({(std::string)\"deR\", (std::string)\"neerG\", (std::string)\"eulB\", (std::string)\"etihW\", (std::string)\"kcalB\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"john\", (std::string)\"amal\", (std::string)\"joel\", (std::string)\"george\"}))) == (std::vector<std::string>({(std::string)\"nhoj\", (std::string)\"lama\", (std::string)\"leoj\", (std::string)\"egroeg\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"jack\", (std::string)\"john\", (std::string)\"mary\"}))) == (std::vector<std::string>({(std::string)\"kcaj\", (std::string)\"nhoj\", (std::string)\"yram\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sublist having minimum length.\nstd::vector<std::any> Find_Min(std::vector<std::vector<std::any>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Find_Min;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)7, (long)8})}))) == (std::vector<std::any>({(long)1, (long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"})}))) == (std::vector<std::any>({(std::string)\"x\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the area of a rectangle.\nlong rectangle_area(long l, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rectangle_area;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((10), (5)) == (50));\n    assert(candidate((4), (2)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uppercase substrings from a given string.\nstd::string remove_uppercase(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_uppercase;\n    assert(candidate((\"cAstyoUrFavoRitETVshoWs\")) == (\"cstyoravoitshos\"));\n    assert(candidate((\"wAtchTheinTernEtrAdIo\")) == (\"wtchheinerntrdo\"));\n    assert(candidate((\"VoicESeaRchAndreComMendaTionS\")) == (\"oiceachndreomendaion\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to get the first element of each sublist.\nstd::vector<long> Extract(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Extract;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)3, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (std::vector<long>({(long)1, (long)4})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)8, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (std::vector<long>({(long)9, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the upper case characters in a given string.\nlong upper_ctr(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = upper_ctr;\n    assert(candidate((\"PYthon\")) == (1));\n    assert(candidate((\"BigData\")) == (1));\n    assert(candidate((\"program\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_nullopt__std_vector_std_string_{\n    std::vector<std::nullopt> f0;\n    std::vector<std::string> f1;    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::nullopt> _f0) : f0(_f0) {}\n    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::string> _f1) : f1(_f1) {}\n    ~Union_std_vector_std_nullopt__std_vector_std_string_() {}\n    bool operator==(std::vector<std::nullopt> f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<std::string> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find all possible combinations of the elements of a given list.\nstd::vector<Union_std_vector_std_nullopt__std_vector_std_string_> combinations_list(std::vector<std::string> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = combinations_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\", (std::string)\"green\", (std::string)\"blue\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"blue\", (std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product subarray of the given array.\nlong max_subarray_product(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_subarray_product;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)0, (long)7, (long)-8, (long)-2}))) == (112));\n    assert(candidate((std::vector<long>({(long)6, (long)-3, (long)-10, (long)0, (long)2}))) == (180));\n    assert(candidate((std::vector<long>({(long)-2, (long)-40, (long)0, (long)-2, (long)-3}))) == (80));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all values are same in a dictionary.\nbool check_value(std::map<std::string,long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_value;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (10)) == (false));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (12)) == (true));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (5)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to drop empty items from a given dictionary.\nstd::map<std::string,std::string> drop_empty(std::map<std::string,std::optional<std::string>> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = drop_empty;\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", std::nullopt}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}})));\n    assert(candidate(std::map<std::string,std::nullopt>({{\"c1\", std::nullopt}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c2\", \"Green\"}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nlong max_product(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_product;\n    assert(candidate((std::vector<long>({(long)3, (long)100, (long)4, (long)5, (long)150, (long)6}))) == (3000));\n    assert(candidate((std::vector<long>({(long)4, (long)42, (long)55, (long)68, (long)80}))) == (50265600));\n    assert(candidate((std::vector<long>({(long)10, (long)22, (long)9, (long)33, (long)21, (long)50, (long)41, (long)60}))) == (2460));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nstd::tuple<long, long, long, long> add_pairwise(std::tuple<long, long, long, long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_pairwise;\n    assert(candidate((std::make_tuple(1, 5, 7, 8, 10))) == (std::make_tuple(6, 12, 15, 18)));\n    assert(candidate((std::make_tuple(2, 6, 8, 9, 11))) == (std::make_tuple(8, 14, 17, 20)));\n    assert(candidate((std::make_tuple(3, 7, 9, 10, 12))) == (std::make_tuple(10, 16, 19, 22)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the product of the array multiplication modulo n.\nlong find_remainder(std::vector<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_remainder;\n    assert(candidate((std::vector<long>({(long)100, (long)10, (long)5, (long)25, (long)35, (long)14})), (11)) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (2)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given list contains consecutive numbers or not.\nbool check_Consecutive(std::vector<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_Consecutive;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace characters in a string.\nstd::string replace_char(std::string str1, std::string ch, std::string newch) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_char;\n    assert(candidate((\"polygon\"), (\"y\"), (\"l\")) == (\"pollgon\"));\n    assert(candidate((\"character\"), (\"c\"), (\"a\")) == (\"aharaater\"));\n    assert(candidate((\"python\"), (\"l\"), (\"a\")) == (\"python\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a dictionary by value.\nstd::vector<std::tuple<std::string, long>> sort_counter(std::map<std::string,long> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_counter;\n    assert(candidate((std::map<std::string,long>({{\"Math\", 81}, {\"Physics\", 83}, {\"Chemistry\", 87}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 87), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 83), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 81)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 400}, {\"Physics\", 300}, {\"Chemistry\", 250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Math\", 400), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 300), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 250)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 900}, {\"Physics\", 1000}, {\"Chemistry\", 1250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 1250), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 1000), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 900)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the largest and smallest value in a given array.\nlong big_sum(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = big_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert the given string to lower case.\nstd::string is_lower(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_lower;\n    assert(candidate((\"InValid\")) == (\"invalid\"));\n    assert(candidate((\"TruE\")) == (\"true\"));\n    assert(candidate((\"SenTenCE\")) == (\"sentence\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove lowercase substrings from a given string.\nstd::string remove_lowercase(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_lowercase;\n    assert(candidate((\"PYTHon\")) == (\"PYTH\"));\n    assert(candidate((\"FInD\")) == (\"FID\"));\n    assert(candidate((\"STRinG\")) == (\"STRG\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first digit of a given number.\nlong first_Digit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = first_Digit;\n    assert(candidate((123)) == (1));\n    assert(candidate((456)) == (4));\n    assert(candidate((12)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nstd::vector<long> heap_queue_largest(std::vector<long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = heap_queue_largest;\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (3)) == (std::vector<long>({(long)85, (long)75, (long)65})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (2)) == (std::vector<long>({(long)85, (long)75})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (5)) == (std::vector<long>({(long)85, (long)75, (long)65, (long)58, (long)35})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of integers and only returns the odd ones.\nstd::vector<long> Split(std::vector<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)12, (long)13}))) == (std::vector<long>({(long)11, (long)13})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)7, (long)9, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlong difference(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = difference;\n    assert(candidate((3)) == (30));\n    assert(candidate((5)) == (210));\n    assert(candidate((2)) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of pairs whose xor value is odd.\nlong find_Odd_Pair(std::vector<long> A, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Odd_Pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11})), (7)) == (12));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (3)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to toggle the case of all characters in a string.\nstd::string toggle_string(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = toggle_string;\n    assert(candidate((\"Python\")) == (\"pYTHON\"));\n    assert(candidate((\"Pangram\")) == (\"pANGRAM\"));\n    assert(candidate((\"LIttLE\")) == (\"liTTle\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the per-digit difference between two integers.\nlong digit_distance_nums(long n1, long n2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = digit_distance_nums;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((23), (56)) == (6));\n    assert(candidate((123), (256)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nlong max_sub_array_sum(std::vector<long> a, long size) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum;\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)4, (long)-1, (long)-2, (long)1, (long)5, (long)-3})), (8)) == (7));\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5, (long)-2, (long)-3, (long)2, (long)6, (long)-4})), (8)) == (8));\n    assert(candidate((std::vector<long>({(long)-4, (long)-5, (long)6, (long)-3, (long)-4, (long)3, (long)7, (long)-5})), (8)) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nstd::vector<long> union_elements(std::vector<long> test_tup1, std::vector<long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = union_elements;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)5, (long)7, (long)4, (long)10}))) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)11, (long)12, (long)13, (long)14})), (std::vector<long>({(long)13, (long)15, (long)16, (long)17}))) == (std::vector<long>({(long)11, (long)12, (long)13, (long)14, (long)15, (long)16, (long)17})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the longest sublists.\nlong Find_Max_Length(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Find_Max_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)22, (long)23}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50})}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks from a string.\nstd::vector<std::string> extract_values(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_values;\n    assert(candidate((\"\"Python\", \"PHP\", \"Java\"\")) == (std::vector<std::string>({(std::string)\"Python\", (std::string)\"PHP\", (std::string)\"Java\"})));\n    assert(candidate((\"\"python\",\"program\",\"language\"\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\"})));\n    assert(candidate((\"\"red\",\"blue\",\"green\",\"yellow\"\")) == (std::vector<std::string>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"yellow\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nlong count_Pairs(std::vector<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_Pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (5)) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to split a string into characters.\nstd::vector<std::string> split(std::string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = split;\n    assert(candidate((\"python\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})));\n    assert(candidate((\"Name\")) == (std::vector<std::string>({(std::string)\"N\", (std::string)\"a\", (std::string)\"m\", (std::string)\"e\"})));\n    assert(candidate((\"program\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the sum of the digits of a non-negative integer.\nlong sum_digits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_digits;\n    assert(candidate((345)) == (12));\n    assert(candidate((12)) == (3));\n    assert(candidate((97)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a specified list is sorted or not.\nbool issort_list(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = issort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)16, (long)17}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)20, (long)17}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)15, (long)14, (long)20}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a list of N empty dictionaries.\nstd::vector<std::map<std::nullopt,std::nullopt>> empty_list(long length) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = empty_list;\n    assert(candidate((5)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((6)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((7)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each sublist of strings in a given list of lists.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"e\", (std::string)\"f\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check if a given number is one less than twice its reverse.\nbool checks(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = checks;\n    assert(candidate((70)) == (false));\n    assert(candidate((23)) == (false));\n    assert(candidate((73)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to remove duplicate numbers from a given number of lists.\nstd::vector<long> two_unique_nums(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = two_unique_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to calculate the product of the unique numbers in a given list.\nlong unique_product(std::vector<long> list_data) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique_product;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)20, (long)50, (long)60, (long)40}))) == (720000000));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1}))) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)0, (long)1, (long)1}))) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cylinder.\nfloat surfacearea_cylinder(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = surfacearea_cylinder;\n    assert(candidate((10), (5)) == (942.45f));\n    assert(candidate((4), (5)) == (226.18800000000002f));\n    assert(candidate((4), (10)) == (351.848f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether a list is sublist of another or not.\nbool is_Sub_Array(std::vector<long> A, std::vector<long> B) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_Sub_Array;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)5})), (std::vector<long>({(long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (std::vector<long>({(long)1, (long)2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)2})), (std::vector<long>({(long)2, (long)2, (long)0}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last digit in factorial of a given number.\nlong last_Digit_Factorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = last_Digit_Factorial;\n    assert(candidate((4)) == (4));\n    assert(candidate((21)) == (0));\n    assert(candidate((30)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to interleave 3 lists of the same length into a single flat list.\nstd::vector<long> interleave_lists(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = interleave_lists;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400, (long)500, (long)600, (long)700}))) == (std::vector<long>({(long)1, (long)10, (long)100, (long)2, (long)20, (long)200, (long)3, (long)30, (long)300, (long)4, (long)40, (long)400, (long)5, (long)50, (long)500, (long)6, (long)60, (long)600, (long)7, (long)70, (long)700})));\n    assert(candidate((std::vector<long>({(long)10, (long)20})), (std::vector<long>({(long)15, (long)2})), (std::vector<long>({(long)5, (long)10}))) == (std::vector<long>({(long)10, (long)15, (long)5, (long)20, (long)2, (long)10})));\n    assert(candidate((std::vector<long>({(long)11, (long)44})), (std::vector<long>({(long)10, (long)15})), (std::vector<long>({(long)20, (long)5}))) == (std::vector<long>({(long)11, (long)10, (long)20, (long)44, (long)15, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the dissimilar elements in the given two tuples.\nstd::tuple<long, long, long, long> find_dissimilar(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_dissimilar;\n    assert(candidate((std::make_tuple(3, 4, 5, 6)), (std::make_tuple(5, 7, 4, 10))) == (std::make_tuple(3, 6, 7, 10)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(7, 2, 3, 9))) == (std::make_tuple(1, 4, 7, 9)));\n    assert(candidate((std::make_tuple(21, 11, 25, 26)), (std::make_tuple(26, 34, 21, 36))) == (std::make_tuple(34, 36, 11, 25)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the largest number that can be formed with the given list of digits.\nlong find_Max_Num(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Max_Num;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (321));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)1}))) == (6541));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)9}))) == (9321));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uneven elements in the nested mixed tuple.\nstd::any extract_even(std::tuple<long, long, std::tuple<long, long, std::tuple<long, long>>, long, long> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_even;\n    assert(candidate((std::make_tuple(4, 5, std::make_tuple(7, 6, std::make_tuple(2, 4)), 6, 8))) == std::make_tuple(4, std::make_tuple(6, std::make_tuple(2, 4)), 6, 8));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(8, 7, std::make_tuple(4, 8)), 7, 9))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 8))));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(9, 8, std::make_tuple(4, 6)), 8, 10))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 6)), 8, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nlong surface_Area(long b, long s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = surface_Area;\n    assert(candidate((3), (4)) == (33));\n    assert(candidate((4), (5)) == (56));\n    assert(candidate((1), (2)) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which returns nth catalan number.\nlong catalan_number(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = catalan_number;\n    assert(candidate((10)) == (16796));\n    assert(candidate((9)) == (4862));\n    assert(candidate((7)) == (429));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nstd::string find_adverbs(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_adverbs;\n    assert(candidate((\"Clearly, he has no excuse for such behavior.\")) == (\"0-7: Clearly\"));\n    assert(candidate((\"Please handle the situation carefuly\")) == (\"28-36: carefuly\"));\n    assert(candidate((\"Complete the task quickly\")) == (\"18-25: quickly\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_float{\n    std::string f0;\n    float f1;    Union_std_string_float(std::string _f0) : f0(_f0) {}\n    Union_std_string_float(float _f1) : f1(_f1) {}\n    ~Union_std_string_float() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the n most expensive items in a given dataset.\nstd::vector<std::map<std::string,Union_std_string_float>> expensive_items(std::vector<std::map<std::string,Union_std_string_float>> items, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = expensive_items;\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}})})), (2)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-4\"}, {\"price\", 22.75f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nstd::vector<long> split_Arr(std::vector<long> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = split_Arr;\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)5, (long)6, (long)52, (long)36})), (2)) == (std::vector<long>({(long)5, (long)6, (long)52, (long)36, (long)12, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (1)) == (std::vector<long>({(long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (3)) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)0, (long)1, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a list to a tuple.\nstd::any list_tuple(std::vector<long> listx) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = list_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)10, (long)7, (long)4, (long)15, (long)3}))) == std::make_tuple(5, 10, 7, 4, 15, 3));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)2, (long)3, (long)4, (long)4, (long)7}))) == std::make_tuple(2, 4, 5, 6, 2, 3, 4, 4, 7));\n    assert(candidate((std::vector<long>({(long)58, (long)44, (long)56}))) == std::make_tuple(58, 44, 56));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the difference between largest and smallest value in a given list.\nlong big_diff(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = big_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)12}))) == (8));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)3}))) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find perfect squares between two given numbers.\nstd::vector<long> perfect_squares(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = perfect_squares;\n    assert(candidate((1), (30)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25})));\n    assert(candidate((50), (100)) == (std::vector<long>({(long)64, (long)81, (long)100})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)100, (long)121, (long)144, (long)169, (long)196})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given two integers have opposite sign or not.\nbool opposite_Signs(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = opposite_Signs;\n    assert(candidate((1), (-2)) == (true));\n    assert(candidate((3), (2)) == (false));\n    assert(candidate((-10), (-10)) == (false));\n    assert(candidate((-2), (2)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to interchange the first and last elements in a list.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)12, (long)35, (long)9, (long)56, (long)24}))) == (std::vector<long>({(long)24, (long)35, (long)9, (long)56, (long)12})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nlong sum_Of_product(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_Of_product;\n    assert(candidate((3)) == (15));\n    assert(candidate((4)) == (56));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove leading zeroes from an ip address.\nstd::string removezero_ip(std::string ip) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = removezero_ip;\n    assert(candidate((\"216.08.094.196\")) == (\"216.8.94.196\"));\n    assert(candidate((\"12.01.024\")) == (\"12.1.24\"));\n    assert(candidate((\"216.08.094.0196\")) == (\"216.8.94.196\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the difference of the first even and first odd number of a given list.\nlong diff_even_odd(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = diff_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nstd::any min_Swaps(std::string str1, std::string str2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_Swaps;\n    assert(candidate((\"1101\"), (\"1110\")) == (std::any(1)));\n    assert(candidate((\"111\"), (\"000\")) == (std::any(\"Not Possible\")));\n    assert(candidate((\"111\"), (\"110\")) == (std::any(\"Not Possible\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find kth element from the given two sorted arrays.\nlong find_kth(std::vector<long> arr1, std::vector<long> arr2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_kth;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6, (long)7, (long)9})), (std::vector<long>({(long)1, (long)4, (long)8, (long)10})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)100, (long)112, (long)256, (long)349, (long)770})), (std::vector<long>({(long)72, (long)86, (long)113, (long)119, (long)265, (long)445, (long)892})), (7)) == (256));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)7, (long)8, (long)10})), (std::vector<long>({(long)2, (long)5, (long)9, (long)11})), (6)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is armstrong or not.\nbool armstrong_number(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = armstrong_number;\n    assert(candidate((153)) == (true));\n    assert(candidate((259)) == (false));\n    assert(candidate((4458)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find sum and average of first n natural numbers.\nstd::tuple<long, float> sum_average(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_average;\n    assert(candidate((10)) == (std::make_tuple(55, 5.5f)));\n    assert(candidate((15)) == (std::make_tuple(120, 8.0f)));\n    assert(candidate((20)) == (std::make_tuple(210, 10.5f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth octagonal number.\nlong is_octagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_octagonal;\n    assert(candidate((5)) == (65));\n    assert(candidate((10)) == (280));\n    assert(candidate((15)) == (645));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number is even or not.\nbool is_Even(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_Even;\n    assert(candidate((1)) == (false));\n    assert(candidate((2)) == (true));\n    assert(candidate((3)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first repeated character in a given string.\nstd::optional<std::string> first_repeated_char(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = first_repeated_char;\n    assert(candidate((\"abcabc\")) == \"a\");\n    assert(candidate((\"abc\")) == std::nullopt);\n    assert(candidate((\"123123\")) == \"1\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nstd::vector<long> get_ludic(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_ludic;\n    assert(candidate((10)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((25)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25})));\n    assert(candidate((45)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25, (long)29, (long)37, (long)41, (long)43})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse words seperated by spaces in a given string.\nstd::string reverse_words(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = reverse_words;\n    assert(candidate((\"python program\")) == (\"program python\"));\n    assert(candidate((\"java language\")) == (\"language java\"));\n    assert(candidate((\"indian man\")) == (\"man indian\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given integer is a prime number.\nbool prime_num(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = prime_num;\n    assert(candidate((13)) == (true));\n    assert(candidate((7)) == (true));\n    assert(candidate((-1010)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert degrees to radians.\nfloat radian_degree(long degree) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = radian_degree;\n    assert(candidate((90)) == (1.5707963267948966f));\n    assert(candidate((60)) == (1.0471975511965976f));\n    assert(candidate((120)) == (2.0943951023931953f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nstd::tuple<std::string, long, long> find_literals(std::string text, std::string pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_literals;\n    assert(candidate((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")) == (std::make_tuple(\"fox\", 16, 19)));\n    assert(candidate((\"Its been a very crazy procedure right\"), (\"crazy\")) == (std::make_tuple(\"crazy\", 16, 21)));\n    assert(candidate((\"Hardest choices required strongest will\"), (\"will\")) == (std::make_tuple(\"will\", 35, 39)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find nth bell number.\nlong bell_Number(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = bell_Number;\n    assert(candidate((2)) == (2));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (15));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nstd::vector<long> remove_kth_element(std::vector<long> list1, long L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_kth_element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == (std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})), (4)) == (std::vector<long>({(long)0, (long)0, (long)1, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})), (5)) == (std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nlong max_of_nth(std::vector<std::vector<long>> test_list, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_of_nth;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)9, (long)19})})), (2)) == (19));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)20})})), (1)) == (10));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)21})})), (1)) == (11));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nstd::vector<std::vector<std::any>> merge(std::vector<std::vector<std::any>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = merge;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8})}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6, (long)8})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\", (std::string)\"o\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"z\", (std::string)\"c\", (std::string)\"o\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nlong cummulative_sum(std::vector<std::vector<long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = cummulative_sum;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)6})}))) == (30));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)7})}))) == (37));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)8})}))) == (44));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nstd::vector<float> average_tuple(std::vector<std::vector<long>> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = average_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)10, (long)10, (long)10, (long)12}), (std::vector<long>)std::vector<long>({(long)30, (long)45, (long)56, (long)45}), (std::vector<long>)std::vector<long>({(long)81, (long)80, (long)39, (long)32}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (std::vector<float>({(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)-5}), (std::vector<long>)std::vector<long>({(long)30, (long)-15, (long)56}), (std::vector<long>)std::vector<long>({(long)81, (long)-60, (long)-39}), (std::vector<long>)std::vector<long>({(long)-10, (long)2, (long)3})}))) == (std::vector<float>({(float)25.5f, (float)-18.0f, (float)3.75f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)100, (long)100, (long)100, (long)120}), (std::vector<long>)std::vector<long>({(long)300, (long)450, (long)560, (long)450}), (std::vector<long>)std::vector<long>({(long)810, (long)800, (long)390, (long)320}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::vector<float>({(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nstd::tuple<long, long, long, long> tuple_modulo(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tuple_modulo;\n    assert(candidate((std::make_tuple(10, 4, 5, 6)), (std::make_tuple(5, 6, 7, 5))) == (std::make_tuple(0, 4, 5, 1)));\n    assert(candidate((std::make_tuple(11, 5, 6, 7)), (std::make_tuple(6, 7, 8, 6))) == (std::make_tuple(5, 5, 6, 1)));\n    assert(candidate((std::make_tuple(12, 6, 7, 8)), (std::make_tuple(7, 8, 9, 7))) == (std::make_tuple(5, 6, 7, 1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfloat min_Jumps(std::tuple<long, long> steps, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_Jumps;\n    assert(candidate((std::make_tuple(3, 4)), (11)) == (3.5f));\n    assert(candidate((std::make_tuple(3, 4)), (0)) == (float(0)));\n    assert(candidate((std::make_tuple(11, 14)), (11)) == (float(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to divide two lists element wise.\nstd::vector<float> div_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = div_list;\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6})), (std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<float>({(float)4.0f, (float)2.5f, (float)2.0f})));\n    assert(candidate((std::vector<long>({(long)3, (long)2})), (std::vector<long>({(long)1, (long)4}))) == (std::vector<float>({(float)3.0f, (float)0.5f})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<float>({(float)1.8f, (float)1.7142857142857142f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to move all the numbers to the end of the given string.\nstd::string move_num(std::string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = move_num;\n    assert(candidate((\"I1love143you55three3000thousand\")) == (\"Iloveyouthreethousand1143553000\"));\n    assert(candidate((\"Avengers124Assemble\")) == (\"AvengersAssemble124\"));\n    assert(candidate((\"Its11our12path13to14see15things16do17things\")) == (\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nlong count_Substrings(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_Substrings;\n    assert(candidate((\"112112\")) == (6));\n    assert(candidate((\"111\")) == (6));\n    assert(candidate((\"1101112\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of two sorted lists of same size.\nfloat get_median(std::vector<long> arr1, std::vector<long> arr2, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_median;\n    assert(candidate((std::vector<long>({(long)1, (long)12, (long)15, (long)26, (long)38})), (std::vector<long>({(long)2, (long)13, (long)17, (long)30, (long)45})), (5)) == (16.0f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)9})), (std::vector<long>({(long)7, (long)13, (long)19, (long)28})), (4)) == (8.5f));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)14, (long)23, (long)36, (long)42})), (std::vector<long>({(long)2, (long)18, (long)27, (long)39, (long)49, (long)55})), (6)) == (25.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the n-th power of each number in a list.\nstd::vector<long> nth_nums(std::vector<long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = nth_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (3)) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15})), (5)) == (std::vector<long>({(long)248832, (long)759375})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to convert a given string to uppercase.\nstd::string is_upper(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_upper;\n    assert(candidate((\"person\")) == (\"PERSON\"));\n    assert(candidate((\"final\")) == (\"FINAL\"));\n    assert(candidate((\"Valid\")) == (\"VALID\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to interchange the first and last element in a given list.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (std::vector<long>({(long)4, (long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nstd::optional<long> triangle_area(long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((-1)) == std::nullopt);\n    assert(candidate((0)) == 0);\n    assert(candidate((2)) == 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nlong find_First_Missing(std::vector<long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_First_Missing;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)6, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)8, (long)9}))) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all spaces in the given string with '%20'.\nstd::string replace_spaces(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"My Name is Dawood\")) == (\"My%20Name%20is%20Dawood\"));\n    assert(candidate((\"I am a Programmer\")) == (\"I%20am%20a%20Programmer\"));\n    assert(candidate((\"I love Coding\")) == (\"I%20love%20Coding\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find even numbers from a list of numbers.\nstd::vector<long> Split(std::vector<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)2, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)8, (long)0, (long)1}))) == (std::vector<long>({(long)4, (long)6, (long)8, (long)0})));\n    assert(candidate((std::vector<long>({(long)8, (long)12, (long)15, (long)19}))) == (std::vector<long>({(long)8, (long)12})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find smallest number in a list.\nlong smallest_num(std::vector<long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = smallest_num;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)1, (long)45, (long)99}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)45, (long)46, (long)50, (long)60}))) == (45));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nstd::vector<std::vector<long>> get_coordinates(std::tuple<long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_coordinates;\n    assert(candidate((std::make_tuple(3, 4))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)2, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5})})));\n    assert(candidate((std::make_tuple(4, 5))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6})})));\n    assert(candidate((std::make_tuple(5, 6))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)7}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)6, (long)7})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nstd::string replace_spaces(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"Jumanji The Jungle\")) == (\"Jumanji_The_Jungle\"));\n    assert(candidate((\"The_Avengers\")) == (\"The Avengers\"));\n    assert(candidate((\"Fast and Furious\")) == (\"Fast_and_Furious\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to move all zeroes to the end of the given list.\nstd::vector<long> move_zero(std::vector<long> num_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = move_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)0, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)0, (long)0, (long)4, (long)0, (long)5, (long)0}))) == (std::vector<long>({(long)2, (long)3, (long)2, (long)4, (long)5, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)0, (long)1, (long)1}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)0, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nlong pair_xor_Sum(std::vector<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pair_xor_Sum;\n    assert(candidate((std::vector<long>({(long)5, (long)9, (long)7, (long)6})), (4)) == (47));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)5})), (3)) == (12));\n    assert(candidate((std::vector<long>({(long)7, (long)3})), (2)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given list.\nstd::vector<long> heap_sort(std::vector<long> iterable) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = heap_sort;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8, (long)0}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58}))) == (std::vector<long>({(long)14, (long)22, (long)25, (long)25, (long)35, (long)58, (long)65, (long)75, (long)85})));\n    assert(candidate((std::vector<long>({(long)7, (long)1, (long)9, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)7, (long)9})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given amount has no profit and no loss\nbool noprofit_noloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = noprofit_noloss;\n    assert(candidate((1500), (1200)) == (false));\n    assert(candidate((100), (100)) == (true));\n    assert(candidate((2000), (5000)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlong wind_chill(long v, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = wind_chill;\n    assert(candidate((120), (35)) == (40));\n    assert(candidate((40), (20)) == (19));\n    assert(candidate((10), (8)) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nlong sample_nam(std::vector<std::string> sample_names) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sample_nam;\n    assert(candidate((std::vector<std::string>({(std::string)\"sally\", (std::string)\"Dylan\", (std::string)\"rebecca\", (std::string)\"Diana\", (std::string)\"Joanne\", (std::string)\"keith\"}))) == (16));\n    assert(candidate((std::vector<std::string>({(std::string)\"php\", (std::string)\"res\", (std::string)\"Python\", (std::string)\"abcd\", (std::string)\"Java\", (std::string)\"aaa\"}))) == (10));\n    assert(candidate((std::vector<std::string>({(std::string)\"abcd\", (std::string)\"Python\", (std::string)\"abba\", (std::string)\"aba\"}))) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nlong max_difference(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_difference;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(1, 7), (std::tuple<long, long>)std::make_tuple(10, 3), (std::tuple<long, long>)std::make_tuple(1, 2)}))) == (7));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(2, 17), (std::tuple<long, long>)std::make_tuple(9, 13), (std::tuple<long, long>)std::make_tuple(11, 12)}))) == (15));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 35), (std::tuple<long, long>)std::make_tuple(21, 27), (std::tuple<long, long>)std::make_tuple(13, 23), (std::tuple<long, long>)std::make_tuple(41, 22)}))) == (23));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nstd::string remove_parenthesis(std::vector<std::string> items) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_parenthesis;\n    assert(candidate((std::vector<std::string>({(std::string)\"python (chrome)\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"string(.abc)\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"alpha(num)\"}))) == (\"alpha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth nonagonal number.\nlong is_nonagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_nonagonal;\n    assert(candidate((10)) == (325));\n    assert(candidate((15)) == (750));\n    assert(candidate((18)) == (1089));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nbool text_match_wordz_middle(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_wordz_middle;\n    assert(candidate((\"pythonzabc.\")) == (true));\n    assert(candidate((\"zxyabc.\")) == (false));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to reverse an array upto a given position.\nstd::vector<long> reverse_Array_Upto_K(std::vector<long> input, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = reverse_Array_Upto_K;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (4)) == (std::vector<long>({(long)4, (long)3, (long)2, (long)1, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7})), (2)) == (std::vector<long>({(long)5, (long)4, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)7, (long)6, (long)5})), (3)) == (std::vector<long>({(long)7, (long)8, (long)9, (long)6, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of tuples using the second value of each tuple.\nstd::vector<std::tuple<std::string, long>> subject_marks(std::vector<std::tuple<std::string, long>> subjectmarks) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = subject_marks;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82), (std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54), (std::tuple<std::string, long>)std::make_tuple(\"Social\", 33)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social\", 33), (std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a list and sum all of its elements.\nlong recursive_list_sum(std::vector<Union_long_std_vector_long_> data_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = recursive_list_sum;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({1, 2, std::vector<long>({(long)3, (long)4}), std::vector<long>({(long)5, (long)6})}))) == (21));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({7, 10, std::vector<long>({(long)15, (long)14}), std::vector<long>({(long)19, (long)41})}))) == (106));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({10, 20, std::vector<long>({(long)30, (long)40}), std::vector<long>({(long)50, (long)60})}))) == (210));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of positive numbers in a list.\nlong pos_count(std::vector<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pos_count;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3, (long)-4}))) == (2));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)-1}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the number of ways to partition a set of Bell numbers.\nlong bell_number(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = bell_number;\n    assert(candidate((2)) == (2));\n    assert(candidate((10)) == (115975));\n    assert(candidate((56)) == (6775685320645824322581483068371419745979053216268760300));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given array is monotonic or not.\nbool is_Monotonic(std::vector<long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_Monotonic;\n    assert(candidate((std::vector<long>({(long)6, (long)5, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a list contains the given sublist or not.\nbool is_sublist(std::vector<long> l, std::vector<long> s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_sublist;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)4, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)1, (long)6}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nbool differ_At_One_Bit_Pos(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = differ_At_One_Bit_Pos;\n    assert(candidate((13), (9)) == (true));\n    assert(candidate((15), (8)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((2), (3)) == (true));\n    assert(candidate((5), (1)) == (true));\n    assert(candidate((1), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether all the given lists have equal length or not.\nbool get_equal(std::vector<std::vector<long>> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_equal;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)22, (long)33}), (std::vector<long>)std::vector<long>({(long)44, (long)55, (long)66})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)7})}))) == (false));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a list of elements.\nstd::vector<long> comb_sort(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = comb_sort;\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)37, (long)25, (long)79}))) == (std::vector<long>({(long)5, (long)15, (long)25, (long)37, (long)79})));\n    assert(candidate((std::vector<long>({(long)41, (long)32, (long)15, (long)19, (long)22}))) == (std::vector<long>({(long)15, (long)19, (long)22, (long)32, (long)41})));\n    assert(candidate((std::vector<long>({(long)99, (long)15, (long)13, (long)47}))) == (std::vector<long>({(long)13, (long)15, (long)47, (long)99})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nstd::tuple<long, long, long, std::map<std::string,long>> add_dict_to_tuple(std::tuple<long, long, long> test_tup, std::map<std::string,long> test_dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_dict_to_tuple;\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))) == (std::make_tuple(4, 5, 6, std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))));\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))) == (std::make_tuple(1, 2, 3, std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))));\n    assert(candidate((std::make_tuple(8, 9, 10)), (std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))) == (std::make_tuple(8, 9, 10, std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfloat maxAverageOfPath(std::vector<std::vector<long>> cost) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = maxAverageOfPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)3, (long)9})}))) == (5.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)4, (long)10})}))) == (6.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)11})}))) == (7.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (5.8f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nstd::map<std::string,std::tuple<float, long>> filter_data(std::map<std::string,std::tuple<float, long>> students, float h, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = filter_data;\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (6.0f), (70)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.9f), (67)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.7f), (64)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nlong count_same_pair(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_same_pair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (11));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)1, (long)2})), (std::vector<long>({(long)0, (long)1, (long)2, (long)2}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlong power_base_sum(long base, long power) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = power_base_sum;\n    assert(candidate((2), (100)) == (115));\n    assert(candidate((8), (10)) == (37));\n    assert(candidate((8), (15)) == (62));\n    assert(candidate((3), (3)) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks \" \" of the given string.\nstd::vector<std::any> extract_quotation(std::string text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_quotation;\n    assert(candidate((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")) == (std::vector<std::any>({(std::string)\"A53\", (std::string)\"multi\", (std::string)\"Processor\"})));\n    assert(candidate((\"Cast your \"favorite\" entertainment \"apps\"\")) == (std::vector<std::any>({(std::string)\"favorite\", (std::string)\"apps\"})));\n    assert(candidate((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")) == (std::vector<std::any>({(std::string)\"4k Ultra HD\", (std::string)\"HDR 10\"})));\n    assert(candidate((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nstd::vector<std::any> multiply_elements(std::vector<long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = multiply_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)8, (long)10}))) == (std::vector<std::any>({(long)5, (long)35, (long)56, (long)80})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)7}))) == (std::vector<std::any>({(long)8, (long)20, (long)30, (long)42})));\n    assert(candidate((std::vector<long>({(long)12, (long)13, (long)14, (long)9, (long)15}))) == (std::vector<std::any>({(long)156, (long)182, (long)126, (long)135})));\n    assert(candidate((std::vector<long>({(long)12}))) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nstd::vector<long> sum_list(std::vector<long> lst1, std::vector<long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_list;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (std::vector<long>({(long)15, (long)25, (long)35}))) == (std::vector<long>({(long)25, (long)45, (long)65})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)5, (long)6, (long)7}))) == (std::vector<long>({(long)6, (long)8, (long)10})));\n    assert(candidate((std::vector<long>({(long)15, (long)20, (long)30})), (std::vector<long>({(long)15, (long)45, (long)75}))) == (std::vector<long>({(long)30, (long)65, (long)105})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nbool dif_Square(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = dif_Square;\n    assert(candidate((5)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((15)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove consecutive duplicates of a given list.\nstd::vector<std::any> consecutive_duplicates(std::vector<std::any> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::any>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)4})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::any>({(long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)17, (long)18, (long)10})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\", (std::string)\"a\", (std::string)\"a\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"a\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfloat lateralsurface_cone(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cone;\n    assert(candidate((5), (12)) == (204.20352248333654f));\n    assert(candidate((10), (15)) == (566.3586699569488f));\n    assert(candidate((19), (17)) == (1521.8090132193388f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nstd::string replace_specialchar(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = replace_specialchar;\n    assert(candidate((\"Python language, Programming language.\")) == (\"Python:language::Programming:language:\"));\n    assert(candidate((\"a b c,d e f\")) == (\"a:b:c:d:e:f\"));\n    assert(candidate((\"ram reshma,ram rahim\")) == (\"ram:reshma:ram:rahim\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nlong find_first_occurrence(std::vector<long> A, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_first_occurrence;\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (6)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nlong sum_Of_Subarray_Prod(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_Of_Subarray_Prod;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (20));\n    assert(candidate((std::vector<long>({(long)1, (long)2}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlong toggle_middle_bits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = toggle_middle_bits;\n    assert(candidate((9)) == (15));\n    assert(candidate((10)) == (12));\n    assert(candidate((11)) == (13));\n    assert(candidate((65)) == (127));\n    assert(candidate((77)) == (115));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nlong left_insertion(std::vector<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = left_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nbool check_str(std::string string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_str;\n    assert(candidate((\"annie\")) == (true));\n    assert(candidate((\"dawood\")) == (false));\n    assert(candidate((\"Else\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfloat geometric_sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = geometric_sum;\n    assert(candidate((7)) == (1.9921875f));\n    assert(candidate((4)) == (1.9375f));\n    assert(candidate((8)) == (1.99609375f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlong find_Index(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Index;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (14));\n    assert(candidate((4)) == (45));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nstd::map<long,long> tuple_to_dict(std::tuple<long, long, long, long, long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tuple_to_dict;\n    assert(candidate((std::make_tuple(1, 5, 7, 10, 13, 5))) == (std::map<long,long>({{1, 5}, {7, 10}, {13, 5}})));\n    assert(candidate((std::make_tuple(1, 2, 3, 4, 5, 6))) == (std::map<long,long>({{1, 2}, {3, 4}, {5, 6}})));\n    assert(candidate((std::make_tuple(7, 8, 9, 10, 11, 12))) == (std::map<long,long>({{7, 8}, {9, 10}, {11, 12}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether all the characters are same or not.\nbool all_Characters_Same(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = all_Characters_Same;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"aaa\")) == (true));\n    assert(candidate((\"data\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to caluclate the area of a tetrahedron.\nfloat area_tetrahedron(long side) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = area_tetrahedron;\n    assert(candidate((3)) == (15.588457268119894f));\n    assert(candidate((20)) == (692.8203230275509f));\n    assert(candidate((10)) == (173.20508075688772f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nstd::vector<long> rotate_right(std::vector<long> list, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rotate_right;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (3)) == (std::vector<long>({(long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (5)) == (std::vector<long>({(long)6, (long)7, (long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuple has any none value or not.\nbool check_none(std::any test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_none;\n    assert(candidate(std::make_tuple(std::optional<long>(10), std::optional<long>(4), std::optional<long>(5), std::optional<long>(6), std::optional<long>(std::nullopt))) == (true));\n    assert(candidate(std::make_tuple(7, 8, 9, 11, 14)) == (false));\n    assert(candidate(std::make_tuple(std::optional<long>(1), std::optional<long>(2), std::optional<long>(3), std::optional<long>(4), std::optional<long>(std::nullopt))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nstd::vector<long> divisible_by_digits(long startnum, long endnum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = divisible_by_digits;\n    assert(candidate((1), (22)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15, (long)22})));\n    assert(candidate((1), (15)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15})));\n    assert(candidate((20), (25)) == (std::vector<long>({(long)22, (long)24})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nstd::optional<float> sector_area(long r, long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sector_area;\n    assert(candidate((4), (45)) == 6.283185307179586f);\n    assert(candidate((9), (45)) == 31.808625617596654f);\n    assert(candidate((9), (361)) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlong lcs_of_three(std::string X, std::string Y, std::string Z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = lcs_of_three;\n    assert(candidate((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2));\n    assert(candidate((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5));\n    assert(candidate((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to put spaces between words starting with capital letters in a given string.\nstd::string capital_words_spaces(std::string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = capital_words_spaces;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"PythonProgrammingExamples\")) == (\"Python Programming Examples\"));\n    assert(candidate((\"GetReadyToBeCodingFreak\")) == (\"Get Ready To Be Coding Freak\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nstd::vector<long> sort_numeric_strings(std::vector<std::string> nums_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sort_numeric_strings;\n    assert(candidate((std::vector<std::string>({(std::string)\"4\", (std::string)\"12\", (std::string)\"45\", (std::string)\"7\", (std::string)\"0\", (std::string)\"100\", (std::string)\"200\", (std::string)\"-12\", (std::string)\"-500\"}))) == (std::vector<long>({(long)-500, (long)-12, (long)0, (long)4, (long)7, (long)12, (long)45, (long)100, (long)200})));\n    assert(candidate((std::vector<std::string>({(std::string)\"2\", (std::string)\"3\", (std::string)\"8\", (std::string)\"4\", (std::string)\"7\", (std::string)\"9\", (std::string)\"8\", (std::string)\"2\", (std::string)\"6\", (std::string)\"5\", (std::string)\"1\", (std::string)\"6\", (std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"6\", (std::string)\"9\", (std::string)\"1\", (std::string)\"2\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)8, (long)9, (long)9})));\n    assert(candidate((std::vector<std::string>({(std::string)\"1\", (std::string)\"3\", (std::string)\"5\", (std::string)\"7\", (std::string)\"1\", (std::string)\"3\", (std::string)\"13\", (std::string)\"15\", (std::string)\"17\", (std::string)\"5\", (std::string)\"7 \", (std::string)\"9\", (std::string)\"1\", (std::string)\"11\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)3, (long)3, (long)5, (long)5, (long)7, (long)7, (long)9, (long)11, (long)13, (long)15, (long)17})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether it follows the sequence given in the patterns array.\nbool is_samepatterns(std::vector<std::string> colors, std::vector<std::string> patterns) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_samepatterns;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"green\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add the given tuple to the given list.\nstd::vector<long> add_tuple(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = add_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::vector<long>({(long)5, (long)6, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::vector<long>({(long)6, (long)7, (long)8, (long)10, (long)11})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::vector<long>({(long)7, (long)8, (long)9, (long)11, (long)12})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nbool check_min_heap(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_min_heap;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)10, (long)15}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)5, (long)3, (long)15}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlong jacobsthal_num(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = jacobsthal_num;\n    assert(candidate((5)) == (11));\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (5));\n    assert(candidate((13)) == (2731));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nstd::vector<std::tuple<std::string, long>> min_k(std::vector<std::tuple<std::string, long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = min_k;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Nikhil\", 8)})), (2)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sanjeev\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})), (3)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"tanmay\", 14), (std::tuple<std::string, long>)std::make_tuple(\"Amer\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9), (std::tuple<std::string, long>)std::make_tuple(\"SKD\", 16)})), (1)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nstd::vector<std::any> extract_index_list(std::vector<long> l1, std::vector<long> l2, std::vector<long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = extract_index_list;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)5})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)7}))) == (std::vector<std::any>({(long)1, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)6, (long)5, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)6, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float{\n    long f0;\n    float f1;    Union_long_float(long _f0) : f0(_f0) {}\n    Union_long_float(float _f1) : f1(_f1) {}\n    ~Union_long_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the second smallest number in a list.\nstd::optional<float> second_smallest(std::vector<Union_long_float> numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = second_smallest;\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)2, (long)-8, (long)-2, (long)0, (long)-2}))) == -2);\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)1, (long)-0.5f, (long)0, (long)2, (long)-2, (long)-2}))) == -0.5f);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2}))) == std::nullopt);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2, (long)2}))) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nbool text_match_zero_one(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_zero_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"dsabbbba\")) == (true));\n    assert(candidate((\"asbbbba\")) == (false));\n    assert(candidate((\"abaaa\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nlong count_reverse_pairs(std::vector<std::string> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_reverse_pairs;\n    assert(candidate((std::vector<std::string>({(std::string)\"julia\", (std::string)\"best\", (std::string)\"tseb\", (std::string)\"for\", (std::string)\"ailuj\"}))) == (2));\n    assert(candidate((std::vector<std::string>({(std::string)\"geeks\", (std::string)\"best\", (std::string)\"for\", (std::string)\"skeeg\"}))) == (1));\n    assert(candidate((std::vector<std::string>({(std::string)\"makes\", (std::string)\"best\", (std::string)\"sekam\", (std::string)\"for\", (std::string)\"rof\"}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nbool is_decimal(std::string num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_decimal;\n    assert(candidate((\"123.11\")) == (true));\n    assert(candidate((\"e666.86\")) == (false));\n    assert(candidate((\"3.124587\")) == (false));\n    assert(candidate((\"1.11\")) == (true));\n    assert(candidate((\"1.1.11\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nstd::vector<std::tuple<long, long, long>> find_tuples(std::vector<std::tuple<long, long, long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_tuples;\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12), (std::tuple<long, long, long>)std::make_tuple(7, 9, 6), (std::tuple<long, long, long>)std::make_tuple(12, 18, 21)})), (6)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30), (std::tuple<long, long, long>)std::make_tuple(4, 2, 3), (std::tuple<long, long, long>)std::make_tuple(7, 8, 9)})), (5)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(7, 9, 16), (std::tuple<long, long, long>)std::make_tuple(8, 16, 4), (std::tuple<long, long, long>)std::make_tuple(19, 17, 18)})), (4)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(8, 16, 4)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nbool unique_Element(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = unique_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nbool check_monthnumber_number(long monthnum3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_monthnumber_number;\n    assert(candidate((6)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((12)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlong find_min_diff(std::vector<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_min_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)3, (long)19, (long)18, (long)25})), (6)) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)6})), (4)) == (1));\n    assert(candidate((std::vector<long>({(long)30, (long)5, (long)20, (long)9})), (4)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count number of digits in a given string.\nlong number_ctr(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = number_ctr;\n    assert(candidate((\"program2bedone\")) == (1));\n    assert(candidate((\"3wonders\")) == (1));\n    assert(candidate((\"123\")) == (3));\n    assert(candidate((\"3wond-1ers2\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlong is_polite(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_polite;\n    assert(candidate((7)) == (11));\n    assert(candidate((4)) == (7));\n    assert(candidate((9)) == (13));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return a list of all pairs of consecutive items in a given list.\nstd::vector<std::tuple<long, long>> pair_wise(std::vector<long> l1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pair_wise;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 4), (std::tuple<long, long>)std::make_tuple(4, 5)})));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 5), (std::tuple<long, long>)std::make_tuple(5, 7), (std::tuple<long, long>)std::make_tuple(7, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)9, (long)7, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(1, 9), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(7, 10)})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 5), (std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nlong get_pairs_count(std::vector<long> arr, long sum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_pairs_count;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (2)) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)-1, (long)5})), (6)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3})), (1)) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3})), (-3)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to get the difference between two lists.\nstd::vector<long> Diff(std::vector<long> li1, std::vector<long> li2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Diff;\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25, (long)30, (long)35, (long)40})), (std::vector<long>({(long)25, (long)40, (long)35}))) == (std::vector<long>({(long)10, (long)20, (long)30, (long)15})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)6, (long)7})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nlong odd_num_sum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = odd_num_sum;\n    assert(candidate((2)) == (82));\n    assert(candidate((3)) == (707));\n    assert(candidate((4)) == (3108));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nbool check_expression(std::string exp) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_expression;\n    assert(candidate((\"{()}[{}]\")) == (true));\n    assert(candidate((\"{()}[{]\")) == (false));\n    assert(candidate((\"{()}[{}][]({})\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all the words with k length in the given string.\nstd::string remove_length(std::string test_str, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_length;\n    assert(candidate((\"The person is most value tet\"), (3)) == (\"person is most value\"));\n    assert(candidate((\"If you told me about this ok\"), (4)) == (\"If you me about ok\"));\n    assert(candidate((\"Forces of darkeness is come into the play\"), (4)) == (\"Forces of darkeness is the\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nstd::optional<std::tuple<std::string, long, long>> occurance_substring(std::string text, std::string pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = occurance_substring;\n    assert(candidate((\"python programming, python language\"), (\"python\")) == std::make_tuple(\"python\", 0, 6));\n    assert(candidate((\"python programming,programming language\"), (\"programming\")) == std::make_tuple(\"programming\", 7, 18));\n    assert(candidate((\"python programming,programming language\"), (\"language\")) == std::make_tuple(\"language\", 31, 39));\n    assert(candidate((\"c++ programming, c++ language\"), (\"python\")) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nbool odd_position(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = odd_position;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4, (long)3, (long)6, (long)7, (long)6, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nlong count_vowels(std::string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_vowels;\n    assert(candidate((\"bestinstareels\")) == (7));\n    assert(candidate((\"partofthejourneyistheend\")) == (12));\n    assert(candidate((\"amazonprime\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of non-repeated elements in a given list.\nlong find_sum(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)1, (long)4, (long)5, (long)6}))) == (21));\n    assert(candidate((std::vector<long>({(long)1, (long)10, (long)9, (long)4, (long)2, (long)10, (long)10, (long)45, (long)4}))) == (71));\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)9, (long)45, (long)2, (long)10, (long)10, (long)45, (long)10}))) == (78));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nstd::vector<std::vector<std::any>> pack_consecutive_duplicates(std::vector<std::any> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = pack_consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)8}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)4})})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)10, (long)10}), (std::vector<long>)std::vector<long>({(long)15}), (std::vector<long>)std::vector<long>({(long)19}), (std::vector<long>)std::vector<long>({(long)18, (long)18}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)26, (long)26}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)18}), (std::vector<long>)std::vector<long>({(long)10})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"a\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"d\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find whether a number is divisible by 11.\nbool is_Diff(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_Diff;\n    assert(candidate((12345)) == (false));\n    assert(candidate((1212112)) == (true));\n    assert(candidate((1212)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nstd::vector<std::tuple<long, long>> find_combinations(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_combinations;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(6, 10)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(8, 11), (std::tuple<long, long>)std::make_tuple(7, 5), (std::tuple<long, long>)std::make_tuple(8, 14), (std::tuple<long, long>)std::make_tuple(11, 8), (std::tuple<long, long>)std::make_tuple(12, 17), (std::tuple<long, long>)std::make_tuple(11, 11)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(6, 2), (std::tuple<long, long>)std::make_tuple(7, 11)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 13), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(10, 16), (std::tuple<long, long>)std::make_tuple(13, 10), (std::tuple<long, long>)std::make_tuple(14, 19), (std::tuple<long, long>)std::make_tuple(13, 13)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(7, 3), (std::tuple<long, long>)std::make_tuple(8, 12)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 15), (std::tuple<long, long>)std::make_tuple(11, 9), (std::tuple<long, long>)std::make_tuple(12, 18), (std::tuple<long, long>)std::make_tuple(15, 12), (std::tuple<long, long>)std::make_tuple(16, 21), (std::tuple<long, long>)std::make_tuple(15, 15)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nbool count_divisors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_divisors;\n    assert(candidate((10)) == (true));\n    assert(candidate((100)) == (false));\n    assert(candidate((125)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nlong odd_length_sum(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = odd_length_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4}))) == (14));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (15));\n    assert(candidate((std::vector<long>({(long)1, (long)7}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nstd::vector<float> rgb_to_hsv(long r, long g, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = rgb_to_hsv;\n    assert(candidate((255), (255), (255)) == (std::vector<float>({(float)0.0f, (float)0.0f, (float)100.0f})));\n    assert(candidate((0), (215), (0)) == (std::vector<float>({(float)120.0f, (float)100.0f, (float)84.31372549019608f})));\n    assert(candidate((10), (215), (110)) == (std::vector<float>({(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the product of first even and odd number of a given list.\nlong mul_even_odd(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = mul_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert tuple string to integer tuple.\nstd::tuple<long, long, long> tuple_str_int(std::string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tuple_str_int;\n    assert(candidate((\"(7, 8, 9)\")) == (std::make_tuple(7, 8, 9)));\n    assert(candidate((\"(1, 2, 3)\")) == (std::make_tuple(1, 2, 3)));\n    assert(candidate((\"(4, 5, 6)\")) == (std::make_tuple(4, 5, 6)));\n    assert(candidate((\"(7, 81, 19)\")) == (std::make_tuple(7, 81, 19)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the right insertion point for a specified value in sorted order.\nlong right_insertion(std::vector<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = right_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by three 'b'.\nbool text_match_three(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_match_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"caacabbbba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a new tuple from the given string and list.\nstd::tuple<std::string, std::string, std::string> new_tuple(std::vector<std::string> test_list, std::string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = new_tuple;\n    assert(candidate((std::vector<std::string>({(std::string)\"WEB\", (std::string)\"is\"})), (\"best\")) == (std::make_tuple(\"WEB\", \"is\", \"best\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"We\", (std::string)\"are\"})), (\"Developers\")) == (std::make_tuple(\"We\", \"are\", \"Developers\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Part\", (std::string)\"is\"})), (\"Wrong\")) == (std::make_tuple(\"Part\", \"is\", \"Wrong\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether every even index contains even numbers of a given list.\nbool even_position(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = even_position;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove tuples from the given tuple.\nstd::tuple<long, long, long, long> remove_nested(std::any test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_nested;\n    assert(candidate(std::make_tuple(1, 5, 7, std::make_tuple(4, 6), 10)) == (std::make_tuple(1, 5, 7, 10)));\n    assert(candidate(std::make_tuple(2, 6, 8, std::make_tuple(5, 7), 11)) == (std::make_tuple(2, 6, 8, 11)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), 12)) == (std::make_tuple(3, 7, 9, 12)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), std::make_tuple(5, 12), 12)) == (std::make_tuple(3, 7, 9, 12)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of lists in a given number of lists.\nlong count_list(std::vector<std::vector<long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)2, (long)0})}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the last position of an element in a sorted array.\nlong last(std::vector<long> arr, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = last;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)4})), (1)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)3, (long)6, (long)8, (long)9})), (3)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nbool text_starta_endb(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = text_starta_endb;\n    assert(candidate((\"aabbbb\")) == (true));\n    assert(candidate((\"aabAbbbc\")) == (false));\n    assert(candidate((\"accddbbjjj\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write function to find the sum of all items in the given dictionary.\nlong return_sum(std::map<std::string,long> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = return_sum;\n    assert(candidate((std::map<std::string,long>({{\"a\", 100}, {\"b\", 200}, {\"c\", 300}}))) == (600));\n    assert(candidate((std::map<std::string,long>({{\"a\", 25}, {\"b\", 18}, {\"c\", 45}}))) == (88));\n    assert(candidate((std::map<std::string,long>({{\"a\", 36}, {\"b\", 39}, {\"c\", 49}}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nlong sum_in_range(long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sum_in_range;\n    assert(candidate((2), (5)) == (8));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (13)) == (40));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the sum of an array.\nlong _sum(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = _sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)15, (long)12, (long)13, (long)10}))) == (50));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlong left_rotate(long n, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = left_rotate;\n    assert(candidate((16), (2)) == (64));\n    assert(candidate((10), (2)) == (40));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((1), (3)) == (8));\n    assert(candidate((5), (3)) == (40));\n    assert(candidate((29), (3)) == (232));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to check whether the length of the word is odd or not.\nbool word_len(std::string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = word_len;\n    assert(candidate((\"Hadoop\")) == (false));\n    assert(candidate((\"great\")) == (true));\n    assert(candidate((\"structure\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from a string.\nstd::string remove_all_spaces(std::string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = remove_all_spaces;\n    assert(candidate((\"python  program\")) == (\"pythonprogram\"));\n    assert(candidate((\"python   programming    language\")) == (\"pythonprogramminglanguage\"));\n    assert(candidate((\"python                     program\")) == (\"pythonprogram\"));\n    assert(candidate((\"   python                     program\")) == (\"pythonprogram\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of equal numbers from three given integers.\nlong test_three_equal(long x, long y, long z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = test_three_equal;\n    assert(candidate((1), (1), (1)) == (3));\n    assert(candidate((-1), (-2), (-3)) == (0));\n    assert(candidate((1), (2), (2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nlong count_rotation(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = count_rotation;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)1, (long)2, (long)3}))) == (2));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nbool is_perfect_square(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_perfect_square;\n    assert(candidate((10)) == (false));\n    assert(candidate((36)) == (true));\n    assert(candidate((14)) == (false));\n    assert(candidate((196)) == (true));\n    assert(candidate((125)) == (false));\n    assert(candidate((15625)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the product of numbers in a list is even or not.\nbool is_product_even(std::vector<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_product_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nstd::vector<long> max_sum_list(std::vector<std::vector<long>> lists) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_sum_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)10, (long)11, (long)12})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)12, (long)11, (long)10})}))) == (std::vector<long>({(long)12, (long)11, (long)10})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)1})}))) == (std::vector<long>({(long)2, (long)3, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find maximum run of uppercase characters in the given string.\nlong max_run_uppercase(std::string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = max_run_uppercase;\n    assert(candidate((\"GeMKSForGERksISBESt\")) == (5));\n    assert(candidate((\"PrECIOusMOVemENTSYT\")) == (6));\n    assert(candidate((\"GooGLEFluTTER\")) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the first odd number in a given list of numbers.\nlong first_odd(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = first_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5}))) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)9, (long)1}))) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuples contain the k or not.\nbool check_K(std::vector<long> test_tup, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_K;\n    assert(candidate((std::vector<long>({(long)10, (long)4, (long)5, (long)6, (long)8})), (6)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (7)) == (false));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)44, (long)11, (long)12})), (11)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nbool check_smaller(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = check_smaller;\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::make_tuple(2, 3, 4))) == (false));\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::make_tuple(3, 4, 5))) == (true));\n    assert(candidate((std::make_tuple(11, 12, 13)), (std::make_tuple(10, 11, 12))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth tetrahedral number.\nlong tetrahedral_number(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = tetrahedral_number;\n    assert(candidate((5)) == (35));\n    assert(candidate((6)) == (56));\n    assert(candidate((7)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nstd::string get_Char(std::string strr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = get_Char;\n    assert(candidate((\"abc\")) == (\"f\"));\n    assert(candidate((\"gfg\")) == (\"t\"));\n    assert(candidate((\"ab\")) == (\"c\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth number in the newman conway sequence.\nlong sequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = sequence;\n    assert(candidate((10)) == (6));\n    assert(candidate((2)) == (1));\n    assert(candidate((3)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth centered hexagonal number.\nlong centered_hexagonal_number(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = centered_hexagonal_number;\n    assert(candidate((10)) == (271));\n    assert(candidate((2)) == (7));\n    assert(candidate((9)) == (217));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three dictionaries into a single dictionary.\nstd::map<std::string,std::string> merge_dictionaries_three(std::map<std::string,std::string> dict1, std::map<std::string,std::string> dict2, std::map<std::string,std::string> dict3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = merge_dictionaries_three;\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}))) == (std::map<std::string,std::string>({{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nstd::map<long,long> freq_count(std::vector<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = freq_count;\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)10, (long)10, (long)20, (long)20, (long)20, (long)20, (long)40, (long)40, (long)50, (long)50, (long)30}))) == (std::map<long,long>({{10, 4}, {20, 4}, {40, 2}, {50, 2}, {30, 1}})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)4, (long)1, (long)3, (long)1, (long)4}))) == (std::map<long,long>({{1, 3}, {2, 2}, {3, 3}, {4, 3}})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)4, (long)9, (long)10, (long)4, (long)5, (long)6, (long)7, (long)9, (long)5}))) == (std::map<long,long>({{10, 1}, {5, 3}, {6, 2}, {7, 2}, {4, 2}, {9, 2}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the closest smaller number than n.\nlong closest_num(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = closest_num;\n    assert(candidate((11)) == (10));\n    assert(candidate((7)) == (6));\n    assert(candidate((12)) == (11));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find squares of individual elements in a list.\nstd::vector<long> square_nums(std::vector<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = square_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)100, (long)400, (long)900})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)144, (long)225})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the longest word.\nlong len_log(std::vector<std::string> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = len_log;\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"PHP\", (std::string)\"bigdata\"}))) == (7));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))) == (3));\n    assert(candidate((std::vector<std::string>({(std::string)\"small\", (std::string)\"big\", (std::string)\"tall\"}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string is present as a substring in a given list of string values.\nbool find_substring(std::vector<std::string> str1, std::string sub_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_substring;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ack\")) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"abc\")) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ange\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is undulating or not.\nbool is_undulating(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = is_undulating;\n    assert(candidate((1212121)) == (true));\n    assert(candidate((1991)) == (false));\n    assert(candidate((121)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the value of 'a' to the power 'b'.\nlong power(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = power;\n    assert(candidate((3), (4)) == (81));\n    assert(candidate((2), (3)) == (8));\n    assert(candidate((5), (5)) == (3125));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nstd::string index_minimum(std::vector<std::tuple<std::string, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = index_minimum;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Rash\", 143), (std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 200), (std::tuple<std::string, long>)std::make_tuple(\"Varsha\", 100)}))) == (\"Varsha\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Yash\", 185), (std::tuple<std::string, long>)std::make_tuple(\"Dawood\", 125), (std::tuple<std::string, long>)std::make_tuple(\"Sanya\", 175)}))) == (\"Dawood\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sai\", 345), (std::tuple<std::string, long>)std::make_tuple(\"Salman\", 145), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 96)}))) == (\"Ayesha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the length of the smallest list in a list of lists.\nlong Find_Min_Length(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = Find_Min_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (1));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (2));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4, (long)4, (long)4})}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the number of divisors of a given integer.\nlong divisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = divisor;\n    assert(candidate((15)) == (4));\n    assert(candidate((12)) == (6));\n    assert(candidate((9)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nstd::map<long,long> frequency_lists(std::vector<std::vector<long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = frequency_lists;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)2}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9, (long)5})}))) == (std::map<long,long>({{1, 1}, {2, 3}, {3, 1}, {4, 1}, {5, 2}, {6, 1}, {7, 1}, {8, 1}, {9, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12})}))) == (std::map<long,long>({{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)20, (long)30, (long)40, (long)17}), (std::vector<long>)std::vector<long>({(long)18, (long)16, (long)14, (long)13}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::map<long,long>({{20, 2}, {30, 2}, {40, 2}, {17, 1}, {18, 1}, {16, 1}, {14, 1}, {13, 1}, {10, 1}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nstd::string decimal_to_binary(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((8)) == (\"1000\"));\n    assert(candidate((18)) == (\"10010\"));\n    assert(candidate((7)) == (\"111\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nlong find_Rotations(std::string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\nint main() {\n    auto candidate = find_Rotations;\n    assert(candidate((\"aaaa\")) == (1));\n    assert(candidate((\"ab\")) == (2));\n    assert(candidate((\"abc\")) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-cpp-reworded.json
+++ b/prompts/mbpp-cpp-reworded.json
@@ -1,3540 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nlong lps(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = lps;\n    assert(candidate((\"TENS FOR TENS\")) == (5));\n    assert(candidate((\"CARDIO FOR CARDS\")) == (7));\n    assert(candidate((\"PART OF THE JOURNEY IS PART\")) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from the given string.\nstd::string remove_whitespaces(std::string text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_whitespaces;\n    assert(candidate((\" Google    Flutter \")) == (\"GoogleFlutter\"));\n    assert(candidate((\" Google    Dart \")) == (\"GoogleDart\"));\n    assert(candidate((\" iOS    Swift \")) == (\"iOSSwift\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a specified vector is sorted or not.\nbool issort_list(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = issort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)16, (long)17}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)20, (long)17}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)15, (long)14, (long)20}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count bidirectional tuple pairs.\nlong count_bidirectional(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_bidirectional;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (2));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cube of a given size.\nlong surfacearea_cube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = surfacearea_cube;\n    assert(candidate((5)) == (150));\n    assert(candidate((3)) == (54));\n    assert(candidate((10)) == (600));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nlong next_smallest_palindrome(long num) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = next_smallest_palindrome;\n    assert(candidate((99)) == (101));\n    assert(candidate((1221)) == (1331));\n    assert(candidate((120)) == (121));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the cube sum of first n even natural numbers.\nlong cube_Sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = cube_Sum;\n    assert(candidate((2)) == (72));\n    assert(candidate((3)) == (288));\n    assert(candidate((4)) == (800));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of xor of all pairs of numbers in the given vector.\nlong pair_xor_Sum(std::vector<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pair_xor_Sum;\n    assert(candidate((std::vector<long>({(long)5, (long)9, (long)7, (long)6})), (4)) == (47));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)5})), (3)) == (12));\n    assert(candidate((std::vector<long>({(long)7, (long)3})), (2)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\nbool check_min_heap(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_min_heap;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)10, (long)15}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)5, (long)3, (long)15}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first digit of a given number.\nlong first_Digit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = first_Digit;\n    assert(candidate((123)) == (1));\n    assert(candidate((456)) == (4));\n    assert(candidate((12)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first non-repeated character in a given string.\nstd::optional<std::string> first_non_repeating_character(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = first_non_repeating_character;\n    assert(candidate((\"abcabc\")) == std::nullopt);\n    assert(candidate((\"abc\")) == \"a\");\n    assert(candidate((\"ababc\")) == \"c\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert degrees to radians.\nfloat radian_degree(long degree) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = radian_degree;\n    assert(candidate((90)) == (1.5707963267948966f));\n    assert(candidate((60)) == (1.0471975511965976f));\n    assert(candidate((120)) == (2.0943951023931953f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product subvector of the given vector.\nlong max_subarray_product(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_subarray_product;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)0, (long)7, (long)-8, (long)-2}))) == (112));\n    assert(candidate((std::vector<long>({(long)6, (long)-3, (long)-10, (long)0, (long)2}))) == (180));\n    assert(candidate((std::vector<long>({(long)-2, (long)-40, (long)0, (long)-2, (long)-3}))) == (80));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert more than one vector to nested map.\nstd::vector<std::map<std::string,std::map<std::string,long>>> convert_list_dictionary(std::vector<std::string> l1, std::vector<std::string> l2, std::vector<long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = convert_list_dictionary;\n    assert(candidate((std::vector<std::string>({(std::string)\"S001\", (std::string)\"S002\", (std::string)\"S003\", (std::string)\"S004\"})), (std::vector<std::string>({(std::string)\"Adina Park\", (std::string)\"Leyton Marsh\", (std::string)\"Duncan Boyle\", (std::string)\"Saim Richards\"})), (std::vector<long>({(long)85, (long)98, (long)89, (long)92}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S001\", std::map<std::string,long>({{\"Adina Park\", 85}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S002\", std::map<std::string,long>({{\"Leyton Marsh\", 98}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S003\", std::map<std::string,long>({{\"Duncan Boyle\", 89}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S004\", std::map<std::string,long>({{\"Saim Richards\", 92}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"def\", (std::string)\"ghi\", (std::string)\"jkl\"})), (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\", (std::string)\"programs\"})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"abc\", std::map<std::string,long>({{\"python\", 100}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"def\", std::map<std::string,long>({{\"program\", 200}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"ghi\", std::map<std::string,long>({{\"language\", 300}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"jkl\", std::map<std::string,long>({{\"programs\", 400}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"A1\", (std::string)\"A2\", (std::string)\"A3\", (std::string)\"A4\"})), (std::vector<std::string>({(std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\"})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A1\", std::map<std::string,long>({{\"java\", 10}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A2\", std::map<std::string,long>({{\"C\", 20}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A3\", std::map<std::string,long>({{\"C++\", 30}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A4\", std::map<std::string,long>({{\"DBMS\", 40}})}})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find smallest number in a vector.\nlong smallest_num(std::vector<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = smallest_num;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)1, (long)45, (long)99}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)45, (long)46, (long)50, (long)60}))) == (45));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/cppthon-exercises/re/cppthon-re-exercise-3.php\nbool text_match_zero_one(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_zero_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"dsabbbba\")) == (true));\n    assert(candidate((\"asbbbba\")) == (false));\n    assert(candidate((\"abaaa\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find nth bell number.\nlong bell_Number(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = bell_Number;\n    assert(candidate((2)) == (2));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (15));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find cubes of individual elements in a vector.\nstd::vector<long> cube_nums(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = cube_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)8, (long)27, (long)64, (long)125, (long)216, (long)343, (long)512, (long)729, (long)1000})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)1728, (long)3375})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last digit in factorial of a given number.\nlong last_Digit_Factorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = last_Digit_Factorial;\n    assert(candidate((4)) == (4));\n    assert(candidate((21)) == (0));\n    assert(candidate((30)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find even numbers from a vector of numbers.\nstd::vector<long> Split(std::vector<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)2, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)8, (long)0, (long)1}))) == (std::vector<long>({(long)4, (long)6, (long)8, (long)0})));\n    assert(candidate((std::vector<long>({(long)8, (long)12, (long)15, (long)19}))) == (std::vector<long>({(long)8, (long)12})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given integer is a prime number.\nbool prime_num(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = prime_num;\n    assert(candidate((13)) == (true));\n    assert(candidate((7)) == (true));\n    assert(candidate((-1010)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find tuples which have all elements divisible by k from the given vector of tuples.\nstd::vector<std::tuple<long, long, long>> find_tuples(std::vector<std::tuple<long, long, long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_tuples;\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12), (std::tuple<long, long, long>)std::make_tuple(7, 9, 6), (std::tuple<long, long, long>)std::make_tuple(12, 18, 21)})), (6)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30), (std::tuple<long, long, long>)std::make_tuple(4, 2, 3), (std::tuple<long, long, long>)std::make_tuple(7, 8, 9)})), (5)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(7, 9, 16), (std::tuple<long, long, long>)std::make_tuple(8, 16, 4), (std::tuple<long, long, long>)std::make_tuple(19, 17, 18)})), (4)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(8, 16, 4)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to caluclate the area of a tetrahedron.\nfloat area_tetrahedron(long side) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = area_tetrahedron;\n    assert(candidate((3)) == (15.588457268119894f));\n    assert(candidate((20)) == (692.8203230275509f));\n    assert(candidate((10)) == (173.20508075688772f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number is even or not.\nbool is_Even(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_Even;\n    assert(candidate((1)) == (false));\n    assert(candidate((2)) == (true));\n    assert(candidate((3)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of positive numbers in a vector.\nlong pos_count(std::vector<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pos_count;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3, (long)-4}))) == (2));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)-1}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nstd::vector<long> get_ludic(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_ludic;\n    assert(candidate((10)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((25)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25})));\n    assert(candidate((45)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25, (long)29, (long)37, (long)41, (long)43})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlong find_Index(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Index;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (14));\n    assert(candidate((4)) == (45));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to reverse a vector upto a given position.\nstd::vector<long> reverse_Array_Upto_K(std::vector<long> input, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = reverse_Array_Upto_K;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (4)) == (std::vector<long>({(long)4, (long)3, (long)2, (long)1, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7})), (2)) == (std::vector<long>({(long)5, (long)4, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)7, (long)6, (long)5})), (3)) == (std::vector<long>({(long)7, (long)8, (long)9, (long)6, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of tuples using the second value of each tuple.\nstd::vector<std::tuple<std::string, long>> subject_marks(std::vector<std::tuple<std::string, long>> subjectmarks) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = subject_marks;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82), (std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54), (std::tuple<std::string, long>)std::make_tuple(\"Social\", 33)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social\", 33), (std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove characters from the first string which are present in the second string.\nstd::string remove_dirty_chars(std::string string, std::string second_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_dirty_chars;\n    assert(candidate((\"probasscurve\"), (\"pros\")) == (\"bacuve\"));\n    assert(candidate((\"digitalindia\"), (\"talent\")) == (\"digiidi\"));\n    assert(candidate((\"exoticmiles\"), (\"toxic\")) == (\"emles\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_float_long{\n    float f0;\n    long f1;    Union_float_long(float _f0) : f0(_f0) {}\n    Union_float_long(long _f1) : f1(_f1) {}\n    ~Union_float_long() {}\n    bool operator==(float f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to round every number of a given vector of numbers and print the total sum multiplied by the length of the vector.\nlong round_and_sum(std::vector<Union_float_long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = round_and_sum;\n    assert(candidate((std::vector<Union_float_long>({(float)22.4f, (float)4.0f, (float)-16.22f, (float)-9.1f, (float)11.0f, (float)-12.22f, (float)14.2f, (float)-5.2f, (float)17.5f}))) == (243));\n    assert(candidate((std::vector<Union_float_long>({(long)5, (long)2, (long)9, (long)24.3f, (long)29}))) == (345));\n    assert(candidate((std::vector<Union_float_long>({(float)25.0f, (float)56.7f, (float)89.2f}))) == (513));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the item with maximum frequency in a given vector.\nlong max_occurrences(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_occurrences;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)2, (long)6, (long)5, (long)1, (long)6, (long)1, (long)2, (long)3, (long)2, (long)4, (long)6, (long)9, (long)1, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)7, (long)9, (long)15, (long)14, (long)10, (long)12, (long)13, (long)16, (long)18}))) == (8));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)20, (long)30, (long)40, (long)90, (long)80, (long)50, (long)30, (long)20, (long)50, (long)10}))) == (20));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nbool is_decimal(std::string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_decimal;\n    assert(candidate((\"123.11\")) == (true));\n    assert(candidate((\"e666.86\")) == (false));\n    assert(candidate((\"3.124587\")) == (false));\n    assert(candidate((\"1.11\")) == (true));\n    assert(candidate((\"1.1.11\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\nstd::map<std::string,long> dict_filter(std::map<std::string,long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = dict_filter;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (170)) == (std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (180)) == (std::map<std::string,long>({{\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (190)) == (std::map<std::string,long>({{\"Pierre Cox\", 190}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of even numbers at even positions of a vector.\nlong sum_even_and_even_index(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_even_and_even_index;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1, (long)18, (long)8}))) == (30));\n    assert(candidate((std::vector<long>({(long)3, (long)20, (long)17, (long)9, (long)2, (long)10, (long)18, (long)13, (long)6, (long)18}))) == (26));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1}))) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of the largest contiguous subvector in the given vector.\nlong max_sub_array_sum(std::vector<long> a, long size) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum;\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)4, (long)-1, (long)-2, (long)1, (long)5, (long)-3})), (8)) == (7));\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5, (long)-2, (long)-3, (long)2, (long)6, (long)-4})), (8)) == (8));\n    assert(candidate((std::vector<long>({(long)-4, (long)-5, (long)6, (long)-3, (long)-4, (long)3, (long)7, (long)-5})), (8)) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the intersection of two vectors.\nstd::vector<long> intersection_array(std::vector<long> array_nums1, std::vector<long> array_nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = intersection_array;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)2, (long)4, (long)8, (long)9}))) == (std::vector<long>({(long)1, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)3, (long)5, (long)7, (long)9}))) == (std::vector<long>({(long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<long>({(long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer L and splits the given vector into two parts where the length of the first part of the vector is L, and returns the resulting vectors in a tuple.\nstd::any split_two_parts(std::vector<std::any> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = split_two_parts;\n    assert(candidate((std::vector<std::any>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == std::make_tuple(std::vector<long>({(long)1, (long)1, (long)2}), std::vector<long>({(long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (2)) == std::make_tuple(std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})), (4)) == std::make_tuple(std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\"}), std::vector<std::string>({(std::string)\"o\", (std::string)\"n\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nstd::tuple<std::string, long, long> find_literals(std::string text, std::string pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_literals;\n    assert(candidate((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")) == (std::make_tuple(\"fox\", 16, 19)));\n    assert(candidate((\"Its been a very crazy procedure right\"), (\"crazy\")) == (std::make_tuple(\"crazy\", 16, 21)));\n    assert(candidate((\"Hardest choices required strongest will\"), (\"will\")) == (std::make_tuple(\"will\", 35, 39)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the volume of a triangular prism.\nlong find_Volume(long l, long b, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Volume;\n    assert(candidate((10), (8), (6)) == (240));\n    assert(candidate((3), (2), (2)) == (6));\n    assert(candidate((1), (2), (1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlong wind_chill(long v, long t) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = wind_chill;\n    assert(candidate((120), (35)) == (40));\n    assert(candidate((40), (20)) == (19));\n    assert(candidate((10), (8)) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ascii value of a character.\nlong ascii_value(std::string k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = ascii_value;\n    assert(candidate((\"A\")) == (65));\n    assert(candidate((\"R\")) == (82));\n    assert(candidate((\"S\")) == (83));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether all the characters are same or not.\nbool all_Characters_Same(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = all_Characters_Same;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"aaa\")) == (true));\n    assert(candidate((\"data\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to move all the numbers to the end of the given string.\nstd::string move_num(std::string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = move_num;\n    assert(candidate((\"I1love143you55three3000thousand\")) == (\"Iloveyouthreethousand1143553000\"));\n    assert(candidate((\"Avengers124Assemble\")) == (\"AvengersAssemble124\"));\n    assert(candidate((\"Its11our12path13to14see15things16do17things\")) == (\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the length of the word is odd or not.\nbool word_len(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = word_len;\n    assert(candidate((\"Hadoop\")) == (false));\n    assert(candidate((\"great\")) == (true));\n    assert(candidate((\"structure\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to drop empty items from a given map.\nstd::map<std::string,std::string> drop_empty(std::map<std::string,std::optional<std::string>> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = drop_empty;\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", std::nullopt}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}})));\n    assert(candidate(std::map<std::string,std::nullopt>({{\"c1\", std::nullopt}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c2\", \"Green\"}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\nstd::vector<std::string> insert_element(std::vector<std::string> list, std::string element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = insert_element;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Black\"})), (\"c\")) == (std::vector<std::string>({(std::string)\"c\", (std::string)\"Red\", (std::string)\"c\", (std::string)\"Green\", (std::string)\"c\", (std::string)\"Black\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"java\"})), (\"program\")) == (std::vector<std::string>({(std::string)\"program\", (std::string)\"python\", (std::string)\"program\", (std::string)\"java\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"happy\", (std::string)\"sad\"})), (\"laugh\")) == (std::vector<std::string>({(std::string)\"laugh\", (std::string)\"happy\", (std::string)\"laugh\", (std::string)\"sad\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove lowercase substrings from a given string.\nstd::string remove_lowercase(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_lowercase;\n    assert(candidate((\"PYTHon\")) == (\"PYTH\"));\n    assert(candidate((\"FInD\")) == (\"FID\"));\n    assert(candidate((\"STRinG\")) == (\"STRG\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of set bits (binary digits with value 1) in a given number.\nlong count_Set_Bits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_Set_Bits;\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (1));\n    assert(candidate((6)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract only the rear index element of each string in the given tuple.\nstd::vector<std::string> extract_rear(std::tuple<std::string, std::string, std::string> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_rear;\n    assert(candidate((std::make_tuple(\"Mers\", \"for\", \"Vers\"))) == (std::vector<std::string>({(std::string)\"s\", (std::string)\"r\", (std::string)\"s\"})));\n    assert(candidate((std::make_tuple(\"Avenge\", \"for\", \"People\"))) == (std::vector<std::string>({(std::string)\"e\", (std::string)\"r\", (std::string)\"e\"})));\n    assert(candidate((std::make_tuple(\"Gotta\", \"get\", \"go\"))) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"t\", (std::string)\"o\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurence of the string 'std' in a given string.\nlong count_occurance(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_occurance;\n    assert(candidate((\"letstdlenstdporstd\")) == (3));\n    assert(candidate((\"truststdsolensporsd\")) == (1));\n    assert(candidate((\"makestdsostdworthit\")) == (2));\n    assert(candidate((\"stds\")) == (1));\n    assert(candidate((\"\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuples contain the k or not.\nbool check_K(std::vector<long> test_tup, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_K;\n    assert(candidate((std::vector<long>({(long)10, (long)4, (long)5, (long)6, (long)8})), (6)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (7)) == (false));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)44, (long)11, (long)12})), (11)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to interleave 3 vectors of the same length into a single flat vector.\nstd::vector<long> interleave_lists(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = interleave_lists;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400, (long)500, (long)600, (long)700}))) == (std::vector<long>({(long)1, (long)10, (long)100, (long)2, (long)20, (long)200, (long)3, (long)30, (long)300, (long)4, (long)40, (long)400, (long)5, (long)50, (long)500, (long)6, (long)60, (long)600, (long)7, (long)70, (long)700})));\n    assert(candidate((std::vector<long>({(long)10, (long)20})), (std::vector<long>({(long)15, (long)2})), (std::vector<long>({(long)5, (long)10}))) == (std::vector<long>({(long)10, (long)15, (long)5, (long)20, (long)2, (long)10})));\n    assert(candidate((std::vector<long>({(long)11, (long)44})), (std::vector<long>({(long)10, (long)15})), (std::vector<long>({(long)20, (long)5}))) == (std::vector<long>({(long)11, (long)10, (long)20, (long)44, (long)15, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"python_program\")) == (\"PythonProgram\"));\n    assert(candidate((\"python_language\")) == (\"PythonLanguage\"));\n    assert(candidate((\"programming_language\")) == (\"ProgrammingLanguage\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of equal numbers from three given integers.\nlong test_three_equal(long x, long y, long z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = test_three_equal;\n    assert(candidate((1), (1), (1)) == (3));\n    assert(candidate((-1), (-2), (-3)) == (0));\n    assert(candidate((1), (2), (2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nlong odd_length_sum(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_length_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4}))) == (14));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (15));\n    assert(candidate((std::vector<long>({(long)1, (long)7}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the number of ways to partition a set of Bell numbers.\nlong bell_number(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = bell_number;\n    assert(candidate((2)) == (2));\n    assert(candidate((10)) == (115975));\n    assert(candidate((56)) == (6775685320645824322581483068371419745979053216268760300));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the area of a rectangle.\nlong rectangle_area(long l, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rectangle_area;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((10), (5)) == (50));\n    assert(candidate((4), (2)) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find sum and average of first n natural numbers.\nstd::tuple<long, float> sum_average(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_average;\n    assert(candidate((10)) == (std::make_tuple(55, 5.5f)));\n    assert(candidate((15)) == (std::make_tuple(120, 8.0f)));\n    assert(candidate((20)) == (std::make_tuple(210, 10.5f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nstd::tuple<long, long, long, long> division_elements(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = division_elements;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(2, 2, 2, 3)));\n    assert(candidate((std::make_tuple(12, 6, 8, 16)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(2, 2, 2, 4)));\n    assert(candidate((std::make_tuple(20, 14, 36, 18)), (std::make_tuple(5, 7, 6, 9))) == (std::make_tuple(4, 2, 6, 2)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the sum of the digits of a non-negative integer.\nlong sum_digits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_digits;\n    assert(candidate((345)) == (12));\n    assert(candidate((12)) == (3));\n    assert(candidate((97)) == (16));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\nstd::string index_minimum(std::vector<std::tuple<std::string, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = index_minimum;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Rash\", 143), (std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 200), (std::tuple<std::string, long>)std::make_tuple(\"Varsha\", 100)}))) == (\"Varsha\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Yash\", 185), (std::tuple<std::string, long>)std::make_tuple(\"Dawood\", 125), (std::tuple<std::string, long>)std::make_tuple(\"Sanya\", 175)}))) == (\"Dawood\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sai\", 345), (std::tuple<std::string, long>)std::make_tuple(\"Salman\", 145), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 96)}))) == (\"Ayesha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to divide two vectors element wise.\nstd::vector<float> div_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = div_list;\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6})), (std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<float>({(float)4.0f, (float)2.5f, (float)2.0f})));\n    assert(candidate((std::vector<long>({(long)3, (long)2})), (std::vector<long>({(long)1, (long)4}))) == (std::vector<float>({(float)3.0f, (float)0.5f})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<float>({(float)1.8f, (float)1.7142857142857142f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the vector with maximum length.\nstd::tuple<long, std::vector<long>> max_length_list(std::vector<std::vector<long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_length_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1})}))) == (std::make_tuple(5, std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12})}))) == (std::make_tuple(4, std::vector<long>({(long)6, (long)7, (long)8, (long)9}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_nullopt__std_vector_std_string_{\n    std::vector<std::nullopt> f0;\n    std::vector<std::string> f1;    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::nullopt> _f0) : f0(_f0) {}\n    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::string> _f1) : f1(_f1) {}\n    ~Union_std_vector_std_nullopt__std_vector_std_string_() {}\n    bool operator==(std::vector<std::nullopt> f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<std::string> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find all possible combinations of the elements of a given vector.\nstd::vector<Union_std_vector_std_nullopt__std_vector_std_string_> combinations_list(std::vector<std::string> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = combinations_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\", (std::string)\"green\", (std::string)\"blue\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"blue\", (std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the largest and smallest value in a given vector.\nlong big_sum(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = big_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6}))) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to return the negative numbers in a vector.\nstd::vector<long> neg_nos(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = neg_nos;\n    assert(candidate((std::vector<long>({(long)-1, (long)4, (long)5, (long)-6}))) == (std::vector<long>({(long)-1, (long)-6})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3, (long)4}))) == (std::vector<long>({(long)-1, (long)-2})));\n    assert(candidate((std::vector<long>({(long)-7, (long)-6, (long)8, (long)9}))) == (std::vector<long>({(long)-7, (long)-6})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the highest power of 2 that is less than or equal to n.\nlong highest_Power_of_2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = highest_Power_of_2;\n    assert(candidate((10)) == (8));\n    assert(candidate((19)) == (16));\n    assert(candidate((32)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a vector contains the given subvector or not.\nbool is_sublist(std::vector<long> l, std::vector<long> s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_sublist;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)4, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)1, (long)6}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to subtract two vectors element-wise.\nstd::vector<long> sub_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sub_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)-3, (long)-3, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (std::vector<long>({(long)3, (long)4}))) == (std::vector<long>({(long)-2, (long)-2})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<long>({(long)40, (long)50})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given two integers have opposite sign or not.\nbool opposite_Signs(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = opposite_Signs;\n    assert(candidate((1), (-2)) == (true));\n    assert(candidate((3), (2)) == (false));\n    assert(candidate((-10), (-10)) == (false));\n    assert(candidate((-2), (2)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nstd::tuple<long, long, long, long> tuple_modulo(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tuple_modulo;\n    assert(candidate((std::make_tuple(10, 4, 5, 6)), (std::make_tuple(5, 6, 7, 5))) == (std::make_tuple(0, 4, 5, 1)));\n    assert(candidate((std::make_tuple(11, 5, 6, 7)), (std::make_tuple(6, 7, 8, 6))) == (std::make_tuple(5, 5, 6, 1)));\n    assert(candidate((std::make_tuple(12, 6, 7, 8)), (std::make_tuple(7, 8, 9, 7))) == (std::make_tuple(5, 6, 7, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the difference of the first even and first odd number of a given vector.\nlong diff_even_odd(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = diff_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each subvector of strings in a given vector of vectors.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"e\", (std::string)\"f\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last digit of a given number.\nlong last_Digit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = last_Digit;\n    assert(candidate((123)) == (3));\n    assert(candidate((25)) == (5));\n    assert(candidate((30)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of fourth power of first n odd natural numbers.\nlong odd_num_sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_num_sum;\n    assert(candidate((2)) == (82));\n    assert(candidate((3)) == (707));\n    assert(candidate((4)) == (3108));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a vector to a string.\nstd::string tup_string(std::vector<std::string> tup1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tup_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"e\", (std::string)\"x\", (std::string)\"e\", (std::string)\"r\", (std::string)\"c\", (std::string)\"i\", (std::string)\"s\", (std::string)\"e\", (std::string)\"s\"}))) == (\"exercises\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"}))) == (\"program\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all elements from a given vector present in another vector.\nstd::vector<long> remove_elements(std::vector<long> list1, std::vector<long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)3, (long)5, (long)7}))) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)5, (long)7}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)8, (long)9, (long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether any value in a sequence exists in a sequence or not.\nbool overlapping(std::vector<long> list1, std::vector<long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = overlapping;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)8, (long)9}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5})), (std::vector<long>({(long)1, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to identify non-prime numbers.\nbool is_not_prime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_not_prime;\n    assert(candidate((2)) == (false));\n    assert(candidate((10)) == (true));\n    assert(candidate((35)) == (true));\n    assert(candidate((37)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the maximum value in a given heterogeneous vector.\nlong max_val(std::vector<Union_std_string_long> listval) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (5));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (25));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (50));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of the negative numbers of a given vector of numbers.\nlong sum_negativenum(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_negativenum;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (-32));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)-14, (long)13, (long)-18, (long)12, (long)-20}))) == (-52));\n    assert(candidate((std::vector<long>({(long)19, (long)-65, (long)57, (long)39, (long)152, (long)-639, (long)121, (long)44, (long)90, (long)-190}))) == (-894));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nlong find_Rotations(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Rotations;\n    assert(candidate((\"aaaa\")) == (1));\n    assert(candidate((\"ab\")) == (2));\n    assert(candidate((\"abc\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nstd::string change_date_format(std::string dt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = change_date_format;\n    assert(candidate((\"2026-01-02\")) == (\"02-01-2026\"));\n    assert(candidate((\"2020-11-13\")) == (\"13-11-2020\"));\n    assert(candidate((\"2021-04-26\")) == (\"26-04-2021\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of integers and only returns the odd ones.\nstd::vector<long> Split(std::vector<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)12, (long)13}))) == (std::vector<long>({(long)11, (long)13})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)7, (long)9, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlong toggle_middle_bits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = toggle_middle_bits;\n    assert(candidate((9)) == (15));\n    assert(candidate((10)) == (12));\n    assert(candidate((11)) == (13));\n    assert(candidate((65)) == (127));\n    assert(candidate((77)) == (115));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlong count_char_position(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_char_position;\n    assert(candidate((\"xbcefg\")) == (2));\n    assert(candidate((\"ABcED\")) == (3));\n    assert(candidate((\"AbgdeF\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\nstd::vector<long> large_product(std::vector<long> nums1, std::vector<long> nums2, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = large_product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (3)) == (std::vector<long>({(long)60, (long)54, (long)50})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (4)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (5)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48, (long)45})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the cumulative sum of all the values that are present in the given vector of vectors.\nlong cummulative_sum(std::vector<std::vector<long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = cummulative_sum;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)6})}))) == (30));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)7})}))) == (37));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)8})}))) == (44));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlong find_min_diff(std::vector<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_min_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)3, (long)19, (long)18, (long)25})), (6)) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)6})), (4)) == (1));\n    assert(candidate((std::vector<long>({(long)30, (long)5, (long)20, (long)9})), (4)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nbool text_starta_endb(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_starta_endb;\n    assert(candidate((\"aabbbb\")) == (true));\n    assert(candidate((\"aabAbbbc\")) == (false));\n    assert(candidate((\"accddbbjjj\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlong left_rotate(long n, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = left_rotate;\n    assert(candidate((16), (2)) == (64));\n    assert(candidate((10), (2)) == (40));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((1), (3)) == (8));\n    assert(candidate((5), (3)) == (40));\n    assert(candidate((29), (3)) == (232));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first repeated character in a given string.\nstd::optional<std::string> first_repeated_char(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = first_repeated_char;\n    assert(candidate((\"abcabc\")) == \"a\");\n    assert(candidate((\"abc\")) == std::nullopt);\n    assert(candidate((\"123123\")) == \"1\");\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count inversions in a vector.\nlong get_Inv_Count(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_Inv_Count;\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)6, (long)4, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)6, (long)1}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlong even_Power_Sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = even_Power_Sum;\n    assert(candidate((2)) == (1056));\n    assert(candidate((3)) == (8832));\n    assert(candidate((1)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether all the given vectors have equal length or not.\nbool get_equal(std::vector<std::vector<long>> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_equal;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)22, (long)33}), (std::vector<long>)std::vector<long>({(long)44, (long)55, (long)66})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)7})}))) == (false));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string represents an integer or not.\nbool check_integer(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_integer;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"1\")) == (true));\n    assert(candidate((\"12345\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/cppthon-program-to-count-the-pairs-of-reverse-strings/\nlong count_reverse_pairs(std::vector<std::string> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_reverse_pairs;\n    assert(candidate((std::vector<std::string>({(std::string)\"julia\", (std::string)\"best\", (std::string)\"tseb\", (std::string)\"for\", (std::string)\"ailuj\"}))) == (2));\n    assert(candidate((std::vector<std::string>({(std::string)\"geeks\", (std::string)\"best\", (std::string)\"for\", (std::string)\"skeeg\"}))) == (1));\n    assert(candidate((std::vector<std::string>({(std::string)\"makes\", (std::string)\"best\", (std::string)\"sekam\", (std::string)\"for\", (std::string)\"rof\"}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to move all zeroes to the end of the given vector.\nstd::vector<long> move_zero(std::vector<long> num_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = move_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)0, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)0, (long)0, (long)4, (long)0, (long)5, (long)0}))) == (std::vector<long>({(long)2, (long)3, (long)2, (long)4, (long)5, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)0, (long)1, (long)1}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)0, (long)0})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if given vector contains no duplicates.\nbool check_distinct(std::vector<long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_distinct;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6, (long)1, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given amount has no profit and no loss\nbool noprofit_noloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = noprofit_noloss;\n    assert(candidate((1500), (1200)) == (false));\n    assert(candidate((100), (100)) == (true));\n    assert(candidate((2000), (5000)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all the words with k length in the given string.\nstd::string remove_length(std::string test_str, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_length;\n    assert(candidate((\"The person is most value tet\"), (3)) == (\"person is most value\"));\n    assert(candidate((\"If you told me about this ok\"), (4)) == (\"If you me about ok\"));\n    assert(candidate((\"Forces of darkeness is come into the play\"), (4)) == (\"Forces of darkeness is the\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count number of digits in a given string.\nlong number_ctr(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = number_ctr;\n    assert(candidate((\"program2bedone\")) == (1));\n    assert(candidate((\"3wonders\")) == (1));\n    assert(candidate((\"123\")) == (3));\n    assert(candidate((\"3wond-1ers2\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the total number of characters in a string.\nlong count_charac(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_charac;\n    assert(candidate((\"python programming\")) == (18));\n    assert(candidate((\"language\")) == (8));\n    assert(candidate((\"words\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlong get_total_number_of_sequences(long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_total_number_of_sequences;\n    assert(candidate((10), (4)) == (4));\n    assert(candidate((5), (2)) == (6));\n    assert(candidate((16), (3)) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/cppthon-exercises/data-structures-and-algorithms/cppthon-data-structure-exercise-24.php\nlong left_insertion(std::vector<long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = left_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two numbers and returns a vector with the second number and then the first number.\nstd::vector<long> swap_numbers(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = swap_numbers;\n    assert(candidate((10), (20)) == (std::vector<long>({(long)20, (long)10})));\n    assert(candidate((15), (17)) == (std::vector<long>({(long)17, (long)15})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)200, (long)100})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nbool is_majority(std::vector<long> arr, long n, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_majority;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)3, (long)10})), (7), (3)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)4, (long)4, (long)4, (long)6, (long)6})), (8), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2})), (5), (1)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2})), (5), (1)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nstd::tuple<long, long, long> substract_elements(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = substract_elements;\n    assert(candidate((std::make_tuple(10, 4, 5)), (std::make_tuple(2, 5, 18))) == (std::make_tuple(8, -1, -13)));\n    assert(candidate((std::make_tuple(11, 2, 3)), (std::make_tuple(24, 45, 16))) == (std::make_tuple(-13, -43, -13)));\n    assert(candidate((std::make_tuple(7, 18, 9)), (std::make_tuple(10, 11, 12))) == (std::make_tuple(-3, 7, -3)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to put spaces between words starting with capital letters in a given string.\nstd::string capital_words_spaces(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = capital_words_spaces;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"PythonProgrammingExamples\")) == (\"Python Programming Examples\"));\n    assert(candidate((\"GetReadyToBeCodingFreak\")) == (\"Get Ready To Be Coding Freak\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the average of cubes of first n natural numbers.\nfloat find_Average_Of_Cube(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Average_Of_Cube;\n    assert(candidate((2)) == (4.5f));\n    assert(candidate((3)) == (float(12)));\n    assert(candidate((1)) == (float(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all values are same in a map.\nbool check_value(std::map<std::string,long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_value;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (10)) == (false));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (12)) == (true));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (5)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth tetrahedral number.\nlong tetrahedral_number(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tetrahedral_number;\n    assert(candidate((5)) == (35));\n    assert(candidate((6)) == (56));\n    assert(candidate((7)) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate whether the matrix is a magic square.\nbool magic_square_test(std::vector<std::vector<long>> my_matrix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = magic_square_test;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)12, (long)1, (long)14}), (std::vector<long>)std::vector<long>({(long)2, (long)13, (long)8, (long)11}), (std::vector<long>)std::vector<long>({(long)16, (long)3, (long)10, (long)5}), (std::vector<long>)std::vector<long>({(long)9, (long)6, (long)15, (long)4})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)8})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)7})}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uppercase substrings from a given string.\nstd::string remove_uppercase(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_uppercase;\n    assert(candidate((\"cAstyoUrFavoRitETVshoWs\")) == (\"cstyoravoitshos\"));\n    assert(candidate((\"wAtchTheinTernEtrAdIo\")) == (\"wtchheinerntrdo\"));\n    assert(candidate((\"VoicESeaRchAndreComMendaTionS\")) == (\"oiceachndreomendaion\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to check whether an element exists within a tuple.\nbool check_tuplex(std::vector<Union_std_string_long> tuplex, std::any tuple1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_tuplex;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"r\"))) == (true));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"5\"))) == (false));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(3))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate a dog's age in dog's years.\nlong dog_age(long h_age) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = dog_age;\n    assert(candidate((12)) == (61));\n    assert(candidate((15)) == (73));\n    assert(candidate((24)) == (109));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the next perfect square greater than a given number.\nlong next_Perfect_Square(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = next_Perfect_Square;\n    assert(candidate((35)) == (36));\n    assert(candidate((6)) == (9));\n    assert(candidate((9)) == (16));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a vector of N empty dictionaries.\nstd::vector<std::map<std::nullopt,std::nullopt>> empty_list(long length) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = empty_list;\n    assert(candidate((5)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((6)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((7)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert a given string to uppercase.\nstd::string is_upper(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_upper;\n    assert(candidate((\"person\")) == (\"PERSON\"));\n    assert(candidate((\"final\")) == (\"FINAL\"));\n    assert(candidate((\"Valid\")) == (\"VALID\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlong odd_Equivalent(std::string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_Equivalent;\n    assert(candidate((\"011001\"), (6)) == (3));\n    assert(candidate((\"11011\"), (5)) == (4));\n    assert(candidate((\"1010\"), (4)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nstd::vector<long> re_arrange_array(std::vector<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = re_arrange_array;\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)-3, (long)4, (long)5, (long)6, (long)-7, (long)8, (long)9})), (9)) == (std::vector<long>({(long)-1, (long)-3, (long)-7, (long)4, (long)5, (long)6, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)12, (long)-14, (long)-26, (long)13, (long)15})), (5)) == (std::vector<long>({(long)-14, (long)-26, (long)12, (long)13, (long)15})));\n    assert(candidate((std::vector<long>({(long)10, (long)24, (long)36, (long)-42, (long)-39, (long)-78, (long)85})), (7)) == (std::vector<long>({(long)-42, (long)-39, (long)-78, (long)10, (long)24, (long)36, (long)85})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether a vector of numbers contains only one distinct element or not.\nbool unique_Element(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = unique_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks from a string.\nstd::vector<std::string> extract_values(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_values;\n    assert(candidate((\"\"Python\", \"PHP\", \"Java\"\")) == (std::vector<std::string>({(std::string)\"Python\", (std::string)\"PHP\", (std::string)\"Java\"})));\n    assert(candidate((\"\"python\",\"program\",\"language\"\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\"})));\n    assert(candidate((\"\"red\",\"blue\",\"green\",\"yellow\"\")) == (std::vector<std::string>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"yellow\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count true booleans in the given vector.\nlong count(std::vector<bool> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count;\n    assert(candidate((std::vector<bool>({(bool)true, (bool)false, (bool)true}))) == (2));\n    assert(candidate((std::vector<bool>({(bool)false, (bool)false}))) == (0));\n    assert(candidate((std::vector<bool>({(bool)true, (bool)true, (bool)true}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that counts the number of pairs of integers in a vector that xor to an even number.\nlong find_even_pair(std::vector<long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_even_pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1}))) == (4));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11}))) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is armstrong or not.\nbool armstrong_number(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = armstrong_number;\n    assert(candidate((153)) == (true));\n    assert(candidate((259)) == (false));\n    assert(candidate((4458)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the upper case characters in a given string.\nlong upper_ctr(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = upper_ctr;\n    assert(candidate((\"PYthon\")) == (1));\n    assert(candidate((\"BigData\")) == (1));\n    assert(candidate((\"program\")) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the elementwise and tuples from the given two tuples.\nstd::tuple<long, long, long, long> and_tuples(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = and_tuples;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(0, 0, 2, 1)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(5, 6, 7, 8))) == (std::make_tuple(1, 2, 3, 0)));\n    assert(candidate((std::make_tuple(8, 9, 11, 12)), (std::make_tuple(7, 13, 14, 17))) == (std::make_tuple(0, 9, 10, 0)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether it follows the sequence given in the patterns vector.\nbool is_samepatterns(std::vector<std::string> colors, std::vector<std::string> patterns) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_samepatterns;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"green\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of vectors in a given number of vectors.\nlong count_list(std::vector<std::vector<long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)2, (long)0})}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\nstd::vector<float> average_tuple(std::vector<std::vector<long>> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = average_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)10, (long)10, (long)10, (long)12}), (std::vector<long>)std::vector<long>({(long)30, (long)45, (long)56, (long)45}), (std::vector<long>)std::vector<long>({(long)81, (long)80, (long)39, (long)32}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (std::vector<float>({(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)-5}), (std::vector<long>)std::vector<long>({(long)30, (long)-15, (long)56}), (std::vector<long>)std::vector<long>({(long)81, (long)-60, (long)-39}), (std::vector<long>)std::vector<long>({(long)-10, (long)2, (long)3})}))) == (std::vector<float>({(float)25.5f, (float)-18.0f, (float)3.75f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)100, (long)100, (long)100, (long)120}), (std::vector<long>)std::vector<long>({(long)300, (long)450, (long)560, (long)450}), (std::vector<long>)std::vector<long>({(long)810, (long)800, (long)390, (long)320}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::vector<float>({(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlong lcs_of_three(std::string X, std::string Y, std::string Z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = lcs_of_three;\n    assert(candidate((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2));\n    assert(candidate((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5));\n    assert(candidate((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th star number.\nlong find_star_num(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_star_num;\n    assert(candidate((3)) == (37));\n    assert(candidate((4)) == (73));\n    assert(candidate((5)) == (121));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of a vector.\nlong _sum(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = _sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)15, (long)12, (long)13, (long)10}))) == (50));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given vector contains consecutive numbers or not.\nbool check_Consecutive(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_Consecutive;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb and their positions in a given sentence.\nstd::tuple<long, long, std::string> find_adverb_position(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_adverb_position;\n    assert(candidate((\"clearly!! we can see the sky\")) == (std::make_tuple(0, 7, \"clearly\")));\n    assert(candidate((\"seriously!! there are many roses\")) == (std::make_tuple(0, 9, \"seriously\")));\n    assert(candidate((\"unfortunately!! sita is going to home\")) == (std::make_tuple(0, 13, \"unfortunately\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/cppthon-program-right-rotate-vector-n/\nstd::vector<long> rotate_right(std::vector<long> list, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rotate_right;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (3)) == (std::vector<long>({(long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (5)) == (std::vector<long>({(long)6, (long)7, (long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of non-empty substrings of a given string.\nlong number_of_substrings(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = number_of_substrings;\n    assert(candidate((\"abc\")) == (6));\n    assert(candidate((\"abcd\")) == (10));\n    assert(candidate((\"abcde\")) == (15));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer n and splits a vector for every nth element, returning a vector of the resulting vectors.\nstd::vector<std::vector<std::any>> list_split(std::vector<std::any> S, long step) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = list_split;\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"e\", (std::string)\"f\", (std::string)\"g\", (std::string)\"h\", (std::string)\"i\", (std::string)\"j\", (std::string)\"k\", (std::string)\"l\", (std::string)\"m\", (std::string)\"n\"})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"d\", (std::string)\"g\", (std::string)\"j\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\", (std::string)\"e\", (std::string)\"h\", (std::string)\"k\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"f\", (std::string)\"i\", (std::string)\"l\"})})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11, (long)12, (long)13, (long)14})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)4, (long)7, (long)10, (long)13}), (std::vector<long>)std::vector<long>({(long)2, (long)5, (long)8, (long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)12})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"python\", (std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\", (std::string)\"SQL\"})), (2)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"python\", (std::string)\"C\", (std::string)\"DBMS\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"java\", (std::string)\"C++\", (std::string)\"SQL\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check if the elements of a given vector are unique or not.\nbool all_unique(std::vector<long> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = all_unique;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert complex numbers to polar coordinates.\nstd::tuple<float, float> convert(long numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = convert;\n    assert(candidate((1)) == (std::make_tuple(1.0f, 0.0f)));\n    assert(candidate((4)) == (std::make_tuple(4.0f, 0.0f)));\n    assert(candidate((5)) == (std::make_tuple(5.0f, 0.0f)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is given as - a map with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nstd::map<std::string,std::tuple<float, long>> filter_data(std::map<std::string,std::tuple<float, long>> students, float h, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = filter_data;\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (6.0f), (70)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.9f), (67)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.7f), (64)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert the given string to lower case.\nstd::string is_lower(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_lower;\n    assert(candidate((\"InValid\")) == (\"invalid\"));\n    assert(candidate((\"TruE\")) == (\"true\"));\n    assert(candidate((\"SenTenCE\")) == (\"sentence\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the smallest power of 2 greater than or equal to n.\nlong next_power_of_2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = next_power_of_2;\n    assert(candidate((0)) == (1));\n    assert(candidate((5)) == (8));\n    assert(candidate((17)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string is present as a substring in a given vector of string values.\nbool find_substring(std::vector<std::string> str1, std::string sub_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_substring;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ack\")) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"abc\")) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ange\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace characters in a string.\nstd::string replace_char(std::string str1, std::string ch, std::string newch) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_char;\n    assert(candidate((\"polygon\"), (\"y\"), (\"l\")) == (\"pollgon\"));\n    assert(candidate((\"character\"), (\"c\"), (\"a\")) == (\"aharaater\"));\n    assert(candidate((\"python\"), (\"l\"), (\"a\")) == (\"python\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the product of first even and odd number of a given vector.\nlong mul_even_odd(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = mul_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (10));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a vector to a tuple.\nstd::any list_tuple(std::vector<long> listx) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = list_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)10, (long)7, (long)4, (long)15, (long)3}))) == std::make_tuple(5, 10, 7, 4, 15, 3));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)2, (long)3, (long)4, (long)4, (long)7}))) == std::make_tuple(2, 4, 5, 6, 2, 3, 4, 4, 7));\n    assert(candidate((std::vector<long>({(long)58, (long)44, (long)56}))) == std::make_tuple(58, 44, 56));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlong even_binomial_Coeff_Sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = even_binomial_Coeff_Sum;\n    assert(candidate((4)) == (8));\n    assert(candidate((6)) == (32));\n    assert(candidate((2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nstd::tuple<long, long, long, long> bitwise_xor(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = bitwise_xor;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(15, 6, 5, 10)));\n    assert(candidate((std::make_tuple(11, 5, 7, 10)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(13, 6, 3, 14)));\n    assert(candidate((std::make_tuple(12, 6, 8, 11)), (std::make_tuple(7, 4, 5, 6))) == (std::make_tuple(11, 2, 13, 13)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether a vector is subvector of another or not.\nbool is_Sub_Array(std::vector<long> A, std::vector<long> B) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_Sub_Array;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)5})), (std::vector<long>({(long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (std::vector<long>({(long)1, (long)2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)2})), (std::vector<long>({(long)2, (long)2, (long)0}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nlong max_sub_array_sum_repeated(std::vector<long> a, long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum_repeated;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)-30, (long)-1})), (4), (3)) == (30));\n    assert(candidate((std::vector<long>({(long)-1, (long)10, (long)20})), (3), (2)) == (59));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3})), (3), (3)) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the minimum product from the pairs of tuples within a given vector.\nlong min_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (8));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (30));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (100));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the count of divisors is even. https://www.w3resource.com/cppthon-exercises/basic/cppthon-basic-1-exercise-24.php\nbool count_divisors(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_divisors;\n    assert(candidate((10)) == (true));\n    assert(candidate((100)) == (false));\n    assert(candidate((125)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nstd::optional<long> triangle_area(long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((-1)) == std::nullopt);\n    assert(candidate((0)) == 0);\n    assert(candidate((2)) == 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given string to a vector of characters.\nstd::vector<std::string> string_to_tuple(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = string_to_tuple;\n    assert(candidate((\"python 3.0\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\", (std::string)\"3\", (std::string)\".\", (std::string)\"0\"})));\n    assert(candidate((\"item1\")) == (std::vector<std::string>({(std::string)\"i\", (std::string)\"t\", (std::string)\"e\", (std::string)\"m\", (std::string)\"1\"})));\n    assert(candidate((\"15.10\")) == (std::vector<std::string>({(std::string)\"1\", (std::string)\"5\", (std::string)\".\", (std::string)\"1\", (std::string)\"0\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlong find_length(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_length;\n    assert(candidate((\"11000010001\")) == (6));\n    assert(candidate((\"10111\")) == (1));\n    assert(candidate((\"11011101100101\")) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlong count_Primes_nums(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_Primes_nums;\n    assert(candidate((5)) == (2));\n    assert(candidate((10)) == (4));\n    assert(candidate((100)) == (25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the product of consecutive binomial co-efficients.\nlong sum_Of_product(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_Of_product;\n    assert(candidate((3)) == (15));\n    assert(candidate((4)) == (56));\n    assert(candidate((1)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the maximum aggregate from the vector of tuples.\nstd::tuple<std::string, long> max_aggregate(std::vector<std::tuple<std::string, long>> stdata) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_aggregate;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 7), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 122), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 84)}))) == (std::make_tuple(\"Juan Whelan\", 212)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 50), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 48), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 37), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 22), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 14)}))) == (std::make_tuple(\"Juan Whelan\", 72)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 20), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 30), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 40), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 50)}))) == (std::make_tuple(\"Sabah Colley\", 70)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of elements.\nstd::vector<long> comb_sort(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = comb_sort;\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)37, (long)25, (long)79}))) == (std::vector<long>({(long)5, (long)15, (long)25, (long)37, (long)79})));\n    assert(candidate((std::vector<long>({(long)41, (long)32, (long)15, (long)19, (long)22}))) == (std::vector<long>({(long)15, (long)19, (long)22, (long)32, (long)41})));\n    assert(candidate((std::vector<long>({(long)99, (long)15, (long)13, (long)47}))) == (std::vector<long>({(long)13, (long)15, (long)47, (long)99})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nbool check_expression(std::string exp) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_expression;\n    assert(candidate((\"{()}[{}]\")) == (true));\n    assert(candidate((\"{()}[{]\")) == (false));\n    assert(candidate((\"{()}[{}][]({})\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a word containing 'z'.\nbool text_match_wordz(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_wordz;\n    assert(candidate((\"pythonz.\")) == (true));\n    assert(candidate((\"xyz.\")) == (true));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nstd::vector<long> sum_list(std::vector<long> lst1, std::vector<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_list;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (std::vector<long>({(long)15, (long)25, (long)35}))) == (std::vector<long>({(long)25, (long)45, (long)65})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)5, (long)6, (long)7}))) == (std::vector<long>({(long)6, (long)8, (long)10})));\n    assert(candidate((std::vector<long>({(long)15, (long)20, (long)30})), (std::vector<long>({(long)15, (long)45, (long)75}))) == (std::vector<long>({(long)30, (long)65, (long)105})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlong newman_prime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = newman_prime;\n    assert(candidate((3)) == (7));\n    assert(candidate((4)) == (17));\n    assert(candidate((5)) == (41));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to apply a given format string to all of the elements in a vector.\nstd::vector<std::string> add_string(std::vector<std::any> list_, std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_string;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (\"temp{0}\")) == (std::vector<std::string>({(std::string)\"temp1\", (std::string)\"temp2\", (std::string)\"temp3\", (std::string)\"temp4\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (\"python{0}\")) == (std::vector<std::string>({(std::string)\"pythona\", (std::string)\"pythonb\", (std::string)\"pythonc\", (std::string)\"pythond\"})));\n    assert(candidate((std::vector<std::any>({(long)5, (long)6, (long)7, (long)8})), (\"string{0}\")) == (std::vector<std::string>({(std::string)\"string5\", (std::string)\"string6\", (std::string)\"string7\", (std::string)\"string8\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the surface area of a square cppramid with a given base edge and height.\nlong surface_Area(long b, long s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = surface_Area;\n    assert(candidate((3), (4)) == (33));\n    assert(candidate((4), (5)) == (56));\n    assert(candidate((1), (2)) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the smallest vector in a vector of vectors.\nlong Find_Min_Length(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Find_Min_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (1));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (2));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4, (long)4, (long)4})}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nbool validate(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = validate;\n    assert(candidate((1234)) == (true));\n    assert(candidate((51241)) == (false));\n    assert(candidate((321)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth hexagonal number.\nlong hexagonal_num(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = hexagonal_num;\n    assert(candidate((10)) == (190));\n    assert(candidate((5)) == (45));\n    assert(candidate((7)) == (91));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th lucas number.\nlong find_lucas(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_lucas;\n    assert(candidate((9)) == (76));\n    assert(candidate((4)) == (7));\n    assert(candidate((3)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to get the difference between two vectors.\nstd::vector<long> Diff(std::vector<long> li1, std::vector<long> li2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Diff;\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25, (long)30, (long)35, (long)40})), (std::vector<long>({(long)25, (long)40, (long)35}))) == (std::vector<long>({(long)10, (long)20, (long)30, (long)15})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)6, (long)7})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks \" \" of the given string.\nstd::vector<std::any> extract_quotation(std::string text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_quotation;\n    assert(candidate((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")) == (std::vector<std::any>({(std::string)\"A53\", (std::string)\"multi\", (std::string)\"Processor\"})));\n    assert(candidate((\"Cast your \"favorite\" entertainment \"apps\"\")) == (std::vector<std::any>({(std::string)\"favorite\", (std::string)\"apps\"})));\n    assert(candidate((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")) == (std::vector<std::any>({(std::string)\"4k Ultra HD\", (std::string)\"HDR 10\"})));\n    assert(candidate((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a vector and sum all of its elements.\nlong recursive_list_sum(std::vector<Union_long_std_vector_long_> data_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = recursive_list_sum;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({1, 2, std::vector<long>({(long)3, (long)4}), std::vector<long>({(long)5, (long)6})}))) == (21));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({7, 10, std::vector<long>({(long)15, (long)14}), std::vector<long>({(long)19, (long)41})}))) == (106));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({10, 20, std::vector<long>({(long)30, (long)40}), std::vector<long>({(long)50, (long)60})}))) == (210));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the two numbers differ at one bit position only or not.\nbool differ_At_One_Bit_Pos(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = differ_At_One_Bit_Pos;\n    assert(candidate((13), (9)) == (true));\n    assert(candidate((15), (8)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((2), (3)) == (true));\n    assert(candidate((5), (1)) == (true));\n    assert(candidate((1), (5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by three 'b'.\nbool text_match_three(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"caacabbbba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nlong max_product(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_product;\n    assert(candidate((std::vector<long>({(long)3, (long)100, (long)4, (long)5, (long)150, (long)6}))) == (3000));\n    assert(candidate((std::vector<long>({(long)4, (long)42, (long)55, (long)68, (long)80}))) == (50265600));\n    assert(candidate((std::vector<long>({(long)10, (long)22, (long)9, (long)33, (long)21, (long)50, (long)41, (long)60}))) == (2460));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to split a vector at the nth eelment and add the first part to the end.\nstd::vector<long> split_Arr(std::vector<long> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = split_Arr;\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)5, (long)6, (long)52, (long)36})), (2)) == (std::vector<long>({(long)5, (long)6, (long)52, (long)36, (long)12, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (1)) == (std::vector<long>({(long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (3)) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)0, (long)1, (long)2})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the number of divisors of a given integer.\nlong divisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = divisor;\n    assert(candidate((15)) == (4));\n    assert(candidate((12)) == (6));\n    assert(candidate((9)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the difference between largest and smallest value in a given vector.\nlong big_diff(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = big_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)12}))) == (8));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)3}))) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find squares of individual elements in a vector.\nstd::vector<long> square_nums(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = square_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)100, (long)400, (long)900})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)144, (long)225})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuple has any none value or not.\nbool check_none(std::any test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_none;\n    assert(candidate(std::make_tuple(std::optional<long>(10), std::optional<long>(4), std::optional<long>(5), std::optional<long>(6), std::optional<long>(std::nullopt))) == (true));\n    assert(candidate(std::make_tuple(7, 8, 9, 11, 14)) == (false));\n    assert(candidate(std::make_tuple(std::optional<long>(1), std::optional<long>(2), std::optional<long>(3), std::optional<long>(4), std::optional<long>(std::nullopt))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given vector is monotonic or not.\nbool is_Monotonic(std::vector<long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_Monotonic;\n    assert(candidate((std::vector<long>({(long)6, (long)5, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nbool is_perfect_square(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_perfect_square;\n    assert(candidate((10)) == (false));\n    assert(candidate((36)) == (true));\n    assert(candidate((14)) == (false));\n    assert(candidate((196)) == (true));\n    assert(candidate((125)) == (false));\n    assert(candidate((15625)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of common divisors of two given numbers.\nlong sum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum;\n    assert(candidate((10), (15)) == (6));\n    assert(candidate((100), (150)) == (93));\n    assert(candidate((4), (6)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the vector of maximum length in a vector of vectors.\nstd::tuple<long, std::vector<long>> max_length(std::vector<std::vector<long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)12, (long)14, (long)15})}))) == (std::make_tuple(4, std::vector<long>({(long)10, (long)12, (long)14, (long)15}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)15, (long)20, (long)25})}))) == (std::make_tuple(3, std::vector<long>({(long)15, (long)20, (long)25}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector of tuples and returns a map mapping each unique tuple to the number of times it occurs in the vector.\nstd::map<std::tuple<long, long>,long> check_occurences(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_occurences;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(5, 2), (std::tuple<long, long>)std::make_tuple(6, 3)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(1, 3), 2}, {std::make_tuple(2, 5), 2}, {std::make_tuple(3, 6), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 2), (std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(3, 6), (std::tuple<long, long>)std::make_tuple(6, 3), (std::tuple<long, long>)std::make_tuple(7, 4)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 4), 2}, {std::make_tuple(3, 6), 2}, {std::make_tuple(4, 7), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(13, 2), (std::tuple<long, long>)std::make_tuple(11, 23), (std::tuple<long, long>)std::make_tuple(12, 25), (std::tuple<long, long>)std::make_tuple(25, 12), (std::tuple<long, long>)std::make_tuple(16, 23)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 13), 1}, {std::make_tuple(11, 23), 1}, {std::make_tuple(12, 25), 2}, {std::make_tuple(16, 23), 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the directrix of a parabola.\nlong parabola_directrix(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = parabola_directrix;\n    assert(candidate((5), (3), (2)) == (-198));\n    assert(candidate((9), (8), (4)) == (-2336));\n    assert(candidate((2), (4), (6)) == (-130));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nstd::optional<std::tuple<std::string, long, long>> occurance_substring(std::string text, std::string pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = occurance_substring;\n    assert(candidate((\"python programming, python language\"), (\"python\")) == std::make_tuple(\"python\", 0, 6));\n    assert(candidate((\"python programming,programming language\"), (\"programming\")) == std::make_tuple(\"programming\", 7, 18));\n    assert(candidate((\"python programming,programming language\"), (\"language\")) == std::make_tuple(\"language\", 31, 39));\n    assert(candidate((\"c++ programming, c++ language\"), (\"python\")) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove tuples from the given tuple.\nstd::tuple<long, long, long, long> remove_nested(std::any test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_nested;\n    assert(candidate(std::make_tuple(1, 5, 7, std::make_tuple(4, 6), 10)) == (std::make_tuple(1, 5, 7, 10)));\n    assert(candidate(std::make_tuple(2, 6, 8, std::make_tuple(5, 7), 11)) == (std::make_tuple(2, 6, 8, 11)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), 12)) == (std::make_tuple(3, 7, 9, 12)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), std::make_tuple(5, 12), 12)) == (std::make_tuple(3, 7, 9, 12)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each subvector of strings in a given vector of vectors.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"blue \", (std::string)\" black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" black\", (std::string)\"blue \"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"zilver\", (std::string)\"gold\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"magnesium\", (std::string)\"aluminium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"steel\", (std::string)\"bronze\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"gold\", (std::string)\"zilver\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"aluminium\", (std::string)\"magnesium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"bronze\", (std::string)\"steel\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\nstd::vector<long> remove_kth_element(std::vector<long> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_kth_element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == (std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})), (4)) == (std::vector<long>({(long)0, (long)0, (long)1, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})), (5)) == (std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add a map to the tuple. The output should be a tuple.\nstd::tuple<long, long, long, std::map<std::string,long>> add_dict_to_tuple(std::tuple<long, long, long> test_tup, std::map<std::string,long> test_dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_dict_to_tuple;\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))) == (std::make_tuple(4, 5, 6, std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))));\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))) == (std::make_tuple(1, 2, 3, std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))));\n    assert(candidate((std::make_tuple(8, 9, 10)), (std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))) == (std::make_tuple(8, 9, 10, std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find quotient of two numbers (rounded down to the nearest integer).\nlong find(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find;\n    assert(candidate((10), (3)) == (3));\n    assert(candidate((4), (2)) == (2));\n    assert(candidate((20), (5)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nbool text_match_two_three(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_two_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the occurence of all elements of vector in a tuple.\nlong count_Occurrence(std::any tup, std::vector<std::any> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_Occurrence;\n    assert(candidate(std::make_tuple(\"a\", \"a\", \"c\", \"b\", \"d\"), (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\"}))) == (3));\n    assert(candidate(std::make_tuple(1, 2, 3, 1, 4, 6, 7, 1, 4), (std::vector<std::any>({(long)1, (long)4, (long)7}))) == (6));\n    assert(candidate(std::make_tuple(1, 2, 3, 4, 5, 6), (std::vector<std::any>({(long)1, (long)2}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count number items that are identical in the same position of three given vectors.\nlong count_samepair(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_samepair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by one or more b's.\nbool text_match_one(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abba\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlong difference(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = difference;\n    assert(candidate((3)) == (30));\n    assert(candidate((5)) == (210));\n    assert(candidate((2)) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to toggle the case of all characters in a string.\nstd::string toggle_string(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = toggle_string;\n    assert(candidate((\"Python\")) == (\"pYTHON\"));\n    assert(candidate((\"Pangram\")) == (\"pANGRAM\"));\n    assert(candidate((\"LIttLE\")) == (\"liTTle\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the element of a vector having maximum length.\nstd::vector<std::any> Find_Max(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Find_Max;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})}))) == (std::vector<std::any>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)5, (long)6, (long)1})}))) == (std::vector<std::any>({(long)1, (long)5, (long)6, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the Eulerian number a(n, m).\nlong eulerian_num(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = eulerian_num;\n    assert(candidate((3), (1)) == (4));\n    assert(candidate((4), (1)) == (11));\n    assert(candidate((5), (3)) == (26));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurrences of a number in a given vector.\nlong frequency(std::vector<long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = frequency;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4})), (3)) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)1, (long)2})), (1)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/cppthon-sort-numeric-strings-in-a-vector/\nstd::vector<long> sort_numeric_strings(std::vector<std::string> nums_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_numeric_strings;\n    assert(candidate((std::vector<std::string>({(std::string)\"4\", (std::string)\"12\", (std::string)\"45\", (std::string)\"7\", (std::string)\"0\", (std::string)\"100\", (std::string)\"200\", (std::string)\"-12\", (std::string)\"-500\"}))) == (std::vector<long>({(long)-500, (long)-12, (long)0, (long)4, (long)7, (long)12, (long)45, (long)100, (long)200})));\n    assert(candidate((std::vector<std::string>({(std::string)\"2\", (std::string)\"3\", (std::string)\"8\", (std::string)\"4\", (std::string)\"7\", (std::string)\"9\", (std::string)\"8\", (std::string)\"2\", (std::string)\"6\", (std::string)\"5\", (std::string)\"1\", (std::string)\"6\", (std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"6\", (std::string)\"9\", (std::string)\"1\", (std::string)\"2\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)8, (long)9, (long)9})));\n    assert(candidate((std::vector<std::string>({(std::string)\"1\", (std::string)\"3\", (std::string)\"5\", (std::string)\"7\", (std::string)\"1\", (std::string)\"3\", (std::string)\"13\", (std::string)\"15\", (std::string)\"17\", (std::string)\"5\", (std::string)\"7 \", (std::string)\"9\", (std::string)\"1\", (std::string)\"11\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)3, (long)3, (long)5, (long)5, (long)7, (long)7, (long)9, (long)11, (long)13, (long)15, (long)17})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/cppthon-exercises/data-structures-and-algorithms/cppthon-recursion-exercise-9.php\nfloat geometric_sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = geometric_sum;\n    assert(candidate((7)) == (1.9921875f));\n    assert(candidate((4)) == (1.9375f));\n    assert(candidate((8)) == (1.99609375f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/cppthon-exercises/lambda/cppthon-lambda-exercise-24.php\nstd::vector<long> divisible_by_digits(long startnum, long endnum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = divisible_by_digits;\n    assert(candidate((1), (22)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15, (long)22})));\n    assert(candidate((1), (15)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15})));\n    assert(candidate((20), (25)) == (std::vector<long>({(long)22, (long)24})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to calculate the product of the unique numbers in a given vector.\nlong unique_product(std::vector<long> list_data) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = unique_product;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)20, (long)50, (long)60, (long)40}))) == (720000000));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1}))) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)0, (long)1, (long)1}))) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the largest negative number from the given vector.\nlong largest_neg(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = largest_neg;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-4, (long)-6}))) == (-6));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-8, (long)-9}))) == (-9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)-1}))) == (-1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove consecutive duplicates of a given vector.\nstd::vector<std::any> consecutive_duplicates(std::vector<std::any> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::any>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)4})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::any>({(long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)17, (long)18, (long)10})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\", (std::string)\"a\", (std::string)\"a\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"a\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfloat min_Jumps(std::tuple<long, long> steps, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_Jumps;\n    assert(candidate((std::make_tuple(3, 4)), (11)) == (3.5f));\n    assert(candidate((std::make_tuple(3, 4)), (0)) == (float(0)));\n    assert(candidate((std::make_tuple(11, 14)), (11)) == (float(1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find a pair with highest product from a given vector of integers.\nstd::tuple<long, long> max_Product(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_Product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)0, (long)8, (long)4}))) == (std::make_tuple(7, 8)));\n    assert(candidate((std::vector<long>({(long)0, (long)-1, (long)-2, (long)-4, (long)5, (long)0, (long)-6}))) == (std::make_tuple(-4, -6)));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::make_tuple(2, 3)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the nth element from a given vector of tuples.\nstd::vector<std::any> extract_nth_element(std::vector<std::tuple<std::string, long, long>> list1, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_nth_element;\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (0)) == (std::vector<std::any>({(std::string)\"Greyson Fulton\", (std::string)\"Brady Kent\", (std::string)\"Wyatt Knott\", (std::string)\"Beau Turnbull\"})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (2)) == (std::vector<std::any>({(long)99, (long)96, (long)94, (long)98})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (1)) == (std::vector<std::any>({(long)98, (long)97, (long)91, (long)94})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth nonagonal number.\nlong is_nonagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_nonagonal;\n    assert(candidate((10)) == (325));\n    assert(candidate((15)) == (750));\n    assert(candidate((18)) == (1089));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the maximum difference between any two elements in a given vector.\nlong max_Abs_Diff(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_Abs_Diff;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)3, (long)2, (long)5, (long)1}))) == (8));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to pack consecutive duplicates of a given vector elements into subvectors.\nstd::vector<std::vector<std::any>> pack_consecutive_duplicates(std::vector<std::any> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pack_consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)8}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)4})})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)10, (long)10}), (std::vector<long>)std::vector<long>({(long)15}), (std::vector<long>)std::vector<long>({(long)19}), (std::vector<long>)std::vector<long>({(long)18, (long)18}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)26, (long)26}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)18}), (std::vector<long>)std::vector<long>({(long)10})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"a\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"d\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of perrin numbers.\nlong cal_sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = cal_sum;\n    assert(candidate((9)) == (49));\n    assert(candidate((10)) == (66));\n    assert(candidate((11)) == (88));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove the characters which have odd index values of a given string.\nstd::string odd_values_string(std::string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_values_string;\n    assert(candidate((\"abcdef\")) == (\"ace\"));\n    assert(candidate((\"python\")) == (\"pto\"));\n    assert(candidate((\"data\")) == (\"dt\"));\n    assert(candidate((\"lambs\")) == (\"lms\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find kth element from the given two sorted vectors.\nlong find_kth(std::vector<long> arr1, std::vector<long> arr2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_kth;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6, (long)7, (long)9})), (std::vector<long>({(long)1, (long)4, (long)8, (long)10})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)100, (long)112, (long)256, (long)349, (long)770})), (std::vector<long>({(long)72, (long)86, (long)113, (long)119, (long)265, (long)445, (long)892})), (7)) == (256));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)7, (long)8, (long)10})), (std::vector<long>({(long)2, (long)5, (long)9, (long)11})), (6)) == (8));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlong jacobsthal_num(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = jacobsthal_num;\n    assert(candidate((5)) == (11));\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (5));\n    assert(candidate((13)) == (2731));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find frequency of each element in a flattened vector of vectors, returned in a map.\nstd::map<long,long> frequency_lists(std::vector<std::vector<long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = frequency_lists;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)2}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9, (long)5})}))) == (std::map<long,long>({{1, 1}, {2, 3}, {3, 1}, {4, 1}, {5, 2}, {6, 1}, {7, 1}, {8, 1}, {9, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12})}))) == (std::map<long,long>({{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)20, (long)30, (long)40, (long)17}), (std::vector<long>)std::vector<long>({(long)18, (long)16, (long)14, (long)13}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::map<long,long>({{20, 2}, {30, 2}, {40, 2}, {17, 1}, {18, 1}, {16, 1}, {14, 1}, {13, 1}, {10, 1}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find perfect squares between two given numbers.\nstd::vector<long> perfect_squares(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = perfect_squares;\n    assert(candidate((1), (30)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25})));\n    assert(candidate((50), (100)) == (std::vector<long>({(long)64, (long)81, (long)100})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)100, (long)121, (long)144, (long)169, (long)196})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nlong sum_Of_Subarray_Prod(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_Of_Subarray_Prod;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (20));\n    assert(candidate((std::vector<long>({(long)1, (long)2}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (84));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first odd number in a given vector of numbers.\nlong first_odd(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = first_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5}))) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)9, (long)1}))) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise addition of vector elements in the given two nested vectors.\nstd::vector<std::vector<long>> add_nested_tuples(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_nested_tuples;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)10}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)13})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)12}), (std::vector<long>)std::vector<long>({(long)9, (long)16}), (std::vector<long>)std::vector<long>({(long)5, (long)12}), (std::vector<long>)std::vector<long>({(long)10, (long)15})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)11, (long)18}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)12, (long)17})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of vectors, where each subvector has two elements, and returns a vector of two vectors where the first vector has the first element of each subvector and the second one has the second.\nstd::vector<std::vector<std::any>> merge(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = merge;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8})}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6, (long)8})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\", (std::string)\"o\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"z\", (std::string)\"c\", (std::string)\"o\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number can be represented as the difference of two squares or not.\nbool dif_Square(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = dif_Square;\n    assert(candidate((5)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((15)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nbool check_smaller(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_smaller;\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::make_tuple(2, 3, 4))) == (false));\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::make_tuple(3, 4, 5))) == (true));\n    assert(candidate((std::make_tuple(11, 12, 13)), (std::make_tuple(10, 11, 12))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the frequency of all the elements in a vector, returned as a map.\nstd::map<long,long> freq_count(std::vector<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = freq_count;\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)10, (long)10, (long)20, (long)20, (long)20, (long)20, (long)40, (long)40, (long)50, (long)50, (long)30}))) == (std::map<long,long>({{10, 4}, {20, 4}, {40, 2}, {50, 2}, {30, 1}})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)4, (long)1, (long)3, (long)1, (long)4}))) == (std::map<long,long>({{1, 3}, {2, 2}, {3, 3}, {4, 3}})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)4, (long)9, (long)10, (long)4, (long)5, (long)6, (long)7, (long)9, (long)5}))) == (std::map<long,long>({{10, 1}, {5, 3}, {6, 2}, {7, 2}, {4, 2}, {9, 2}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nstd::vector<float> rgb_to_hsv(long r, long g, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rgb_to_hsv;\n    assert(candidate((255), (255), (255)) == (std::vector<float>({(float)0.0f, (float)0.0f, (float)100.0f})));\n    assert(candidate((0), (215), (0)) == (std::vector<float>({(float)120.0f, (float)100.0f, (float)84.31372549019608f})));\n    assert(candidate((10), (215), (110)) == (std::vector<float>({(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a given nested vector structure.\nstd::vector<long> flatten_list(std::vector<Union_long_std_vector_long_> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = flatten_list;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({0, 10, std::vector<long>({(long)20, (long)30}), 40, 50, std::vector<long>({(long)60, (long)70, (long)80}), std::vector<long>({(long)90, (long)100, (long)110, (long)120})}))) == (std::vector<long>({(long)0, (long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70, (long)80, (long)90, (long)100, (long)110, (long)120})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)40}), (std::vector<long>)std::vector<long>({(long)30, (long)56, (long)25}), (std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)33}), (std::vector<long>)std::vector<long>({(long)40})}))) == (std::vector<long>({(long)10, (long)20, (long)40, (long)30, (long)56, (long)25, (long)10, (long)20, (long)33, (long)40})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)10, (long)11, (long)12, (long)7, (long)8, (long)9})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nbool check_str(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_str;\n    assert(candidate((\"annie\")) == (true));\n    assert(candidate((\"dawood\")) == (false));\n    assert(candidate((\"Else\")) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nbool check_monthnumber_number(long monthnum3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_monthnumber_number;\n    assert(candidate((6)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((12)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given vector.\nstd::vector<long> heap_sort(std::vector<long> iterable) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = heap_sort;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8, (long)0}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58}))) == (std::vector<long>({(long)14, (long)22, (long)25, (long)25, (long)35, (long)58, (long)65, (long)75, (long)85})));\n    assert(candidate((std::vector<long>({(long)7, (long)1, (long)9, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)7, (long)9})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nstd::vector<std::vector<long>> k_smallest_pairs(std::vector<long> nums1, std::vector<long> nums2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = k_smallest_pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (7)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)2})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nstd::optional<std::tuple<long, long>> find_solution(long a, long b, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_solution;\n    assert(candidate((2), (3), (7)) == std::make_tuple(2, 1));\n    assert(candidate((4), (2), (7)) == std::nullopt);\n    assert(candidate((1), (13), (17)) == std::make_tuple(4, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the largest number that can be formed with the given vector of digits.\nlong find_Max_Num(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Max_Num;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (321));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)1}))) == (6541));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)9}))) == (9321));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the vector in a vector of vectors whose sum of elements is the highest.\nstd::vector<long> max_sum_list(std::vector<std::vector<long>> lists) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_sum_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)10, (long)11, (long)12})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)12, (long)11, (long)10})}))) == (std::vector<long>({(long)12, (long)11, (long)10})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)1})}))) == (std::vector<long>({(long)2, (long)3, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to interchange the first and last elements in a vector.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)12, (long)35, (long)9, (long)56, (long)24}))) == (std::vector<long>({(long)24, (long)35, (long)9, (long)56, (long)12})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of two sorted vectors of same size.\nfloat get_median(std::vector<long> arr1, std::vector<long> arr2, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_median;\n    assert(candidate((std::vector<long>({(long)1, (long)12, (long)15, (long)26, (long)38})), (std::vector<long>({(long)2, (long)13, (long)17, (long)30, (long)45})), (5)) == (16.0f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)9})), (std::vector<long>({(long)7, (long)13, (long)19, (long)28})), (4)) == (8.5f));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)14, (long)23, (long)36, (long)42})), (std::vector<long>({(long)2, (long)18, (long)27, (long)39, (long)49, (long)55})), (6)) == (25.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nstd::string replace_spaces(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"Jumanji The Jungle\")) == (\"Jumanji_The_Jungle\"));\n    assert(candidate((\"The_Avengers\")) == (\"The Avengers\"));\n    assert(candidate((\"Fast and Furious\")) == (\"Fast_and_Furious\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to determine if the sum of the divisors of two integers are the same.\nbool are_equivalent(long num1, long num2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = are_equivalent;\n    assert(candidate((36), (57)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((23), (47)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse each string in a given vector of string values.\nstd::vector<std::string> reverse_string_list(std::vector<std::string> stringlist) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = reverse_string_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\", (std::string)\"White\", (std::string)\"Black\"}))) == (std::vector<std::string>({(std::string)\"deR\", (std::string)\"neerG\", (std::string)\"eulB\", (std::string)\"etihW\", (std::string)\"kcalB\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"john\", (std::string)\"amal\", (std::string)\"joel\", (std::string)\"george\"}))) == (std::vector<std::string>({(std::string)\"nhoj\", (std::string)\"lama\", (std::string)\"leoj\", (std::string)\"egroeg\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"jack\", (std::string)\"john\", (std::string)\"mary\"}))) == (std::vector<std::string>({(std::string)\"kcaj\", (std::string)\"nhoj\", (std::string)\"yram\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the sum of digits of each number of a given vector.\nlong sum_of_digits(std::vector<std::any> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_of_digits;\n    assert(candidate((std::vector<std::any>({(long)10, (long)2, (long)56}))) == (14));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<std::any>({10, 20, 4, 5, \"b\", 70, \"a\"})}))) == (19));\n    assert(candidate((std::vector<std::any>({(long)10, (long)20, (long)-4, (long)5, (long)-70}))) == (19));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth number in the newman conway sequence.\nlong sequence(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sequence;\n    assert(candidate((10)) == (6));\n    assert(candidate((2)) == (1));\n    assert(candidate((3)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n largest integers from a given vector of numbers, returned in descending order.\nstd::vector<long> heap_queue_largest(std::vector<long> nums, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = heap_queue_largest;\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (3)) == (std::vector<long>({(long)85, (long)75, (long)65})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (2)) == (std::vector<long>({(long)85, (long)75})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (5)) == (std::vector<long>({(long)85, (long)75, (long)65, (long)58, (long)35})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlong loss_amount(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = loss_amount;\n    assert(candidate((1500), (1200)) == (0));\n    assert(candidate((100), (200)) == (100));\n    assert(candidate((2000), (5000)) == (3000));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the union of the elements of two given vectors and output them in sorted order.\nstd::vector<long> union_elements(std::vector<long> test_tup1, std::vector<long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = union_elements;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)5, (long)7, (long)4, (long)10}))) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)11, (long)12, (long)13, (long)14})), (std::vector<long>({(long)13, (long)15, (long)16, (long)17}))) == (std::vector<long>({(long)11, (long)12, (long)13, (long)14, (long)15, (long)16, (long)17})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the longest subvectors.\nlong Find_Max_Length(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Find_Max_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)22, (long)23}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50})}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nstd::string remove_parenthesis(std::vector<std::string> items) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_parenthesis;\n    assert(candidate((std::vector<std::string>({(std::string)\"python (chrome)\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"string(.abc)\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"alpha(num)\"}))) == (\"alpha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find whether the parity of a given number is odd.\nbool find_Parity(long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Parity;\n    assert(candidate((12)) == (false));\n    assert(candidate((7)) == (true));\n    assert(candidate((10)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median length of a trapezium.\nfloat median_trapezium(long base1, long base2, long height) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = median_trapezium;\n    assert(candidate((15), (25), (35)) == (float(20)));\n    assert(candidate((10), (20), (30)) == (float(15)));\n    assert(candidate((6), (9), (4)) == (7.5f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth centered hexagonal number.\nlong centered_hexagonal_number(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = centered_hexagonal_number;\n    assert(candidate((10)) == (271));\n    assert(candidate((2)) == (7));\n    assert(candidate((9)) == (217));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find number of vectors present in the given vector.\nlong find_lists(std::vector<std::any> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_lists;\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (2));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6})}))) == (3));\n    assert(candidate((std::vector<std::any>({(long)9, (long)8, (long)7, (long)6, (long)5, (long)4, (long)3, (long)2, (long)1}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlong get_max_sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_max_sum;\n    assert(candidate((60)) == (106));\n    assert(candidate((10)) == (12));\n    assert(candidate((2)) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the longest word.\nlong len_log(std::vector<std::string> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = len_log;\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"PHP\", (std::string)\"bigdata\"}))) == (7));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))) == (3));\n    assert(candidate((std::vector<std::string>({(std::string)\"small\", (std::string)\"big\", (std::string)\"tall\"}))) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nstd::optional<float> sector_area(long r, long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sector_area;\n    assert(candidate((4), (45)) == 6.283185307179586f);\n    assert(candidate((9), (45)) == 31.808625617596654f);\n    assert(candidate((9), (361)) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether every odd index contains odd numbers of a given vector.\nbool odd_position(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = odd_position;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4, (long)3, (long)6, (long)7, (long)6, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to join a vector of multiple integers into a single integer.\nlong multiple_to_single(std::vector<long> L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = multiple_to_single;\n    assert(candidate((std::vector<long>({(long)11, (long)33, (long)50}))) == (113350));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (-123456));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25}))) == (10152025));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find whether a number is divisible by 11.\nbool is_Diff(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_Diff;\n    assert(candidate((12345)) == (false));\n    assert(candidate((1212112)) == (true));\n    assert(candidate((1212)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise multiplication of vector elements in the given two vectors.\nstd::vector<std::vector<long>> index_multiplication(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = index_multiplication;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)21}), (std::vector<long>)std::vector<long>({(long)12, (long)45}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)30})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)14, (long)32}), (std::vector<long>)std::vector<long>({(long)20, (long)60}), (std::vector<long>)std::vector<long>({(long)6, (long)20}), (std::vector<long>)std::vector<long>({(long)16, (long)44})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)24, (long)45}), (std::vector<long>)std::vector<long>({(long)30, (long)77}), (std::vector<long>)std::vector<long>({(long)12, (long)33}), (std::vector<long>)std::vector<long>({(long)27, (long)60})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert tuple string to integer tuple.\nstd::tuple<long, long, long> tuple_str_int(std::string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tuple_str_int;\n    assert(candidate((\"(7, 8, 9)\")) == (std::make_tuple(7, 8, 9)));\n    assert(candidate((\"(1, 2, 3)\")) == (std::make_tuple(1, 2, 3)));\n    assert(candidate((\"(4, 5, 6)\")) == (std::make_tuple(4, 5, 6)));\n    assert(candidate((\"(7, 81, 19)\")) == (std::make_tuple(7, 81, 19)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum all amicable numbers from 1 to a specified number.\nlong amicable_numbers_sum(long limit) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = amicable_numbers_sum;\n    assert(candidate((999)) == (504));\n    assert(candidate((9999)) == (31626));\n    assert(candidate((99)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove odd characters in a string.\nstd::string remove_odd(std::string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((\"python\")) == (\"yhn\"));\n    assert(candidate((\"program\")) == (\"rga\"));\n    assert(candidate((\"language\")) == (\"agae\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes as input a vector of numbers (t_1,...,t_{N+1}) and returns a vector of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nstd::vector<std::any> multiply_elements(std::vector<long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = multiply_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)8, (long)10}))) == (std::vector<std::any>({(long)5, (long)35, (long)56, (long)80})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)7}))) == (std::vector<std::any>({(long)8, (long)20, (long)30, (long)42})));\n    assert(candidate((std::vector<long>({(long)12, (long)13, (long)14, (long)9, (long)15}))) == (std::vector<std::any>({(long)156, (long)182, (long)126, (long)135})));\n    assert(candidate((std::vector<long>({(long)12}))) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\nlong count_rotation(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_rotation;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)1, (long)2, (long)3}))) == (2));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the number of unique tuples in the given vector.\nlong extract_freq(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_freq;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(5, 6)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 15), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(6, 7)}))) == (4));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 16), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 9)}))) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\nlong count_same_pair(std::vector<long> nums1, std::vector<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_same_pair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (11));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)1, (long)2})), (std::vector<long>({(long)0, (long)1, (long)2, (long)2}))) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the value of 'a' to the power 'b'.\nlong power(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = power;\n    assert(candidate((3), (4)) == (81));\n    assert(candidate((2), (3)) == (8));\n    assert(candidate((5), (5)) == (3125));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write function to find the sum of all items in the given map.\nlong return_sum(std::map<std::string,long> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = return_sum;\n    assert(candidate((std::map<std::string,long>({{\"a\", 100}, {\"b\", 200}, {\"c\", 300}}))) == (600));\n    assert(candidate((std::map<std::string,long>({{\"a\", 25}, {\"b\", 18}, {\"c\", 45}}))) == (88));\n    assert(candidate((std::map<std::string,long>({{\"a\", 36}, {\"b\", 39}, {\"c\", 49}}))) == (124));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return a vector of all pairs of consecutive items in a given vector.\nstd::vector<std::tuple<long, long>> pair_wise(std::vector<long> l1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pair_wise;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 4), (std::tuple<long, long>)std::make_tuple(4, 5)})));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 5), (std::tuple<long, long>)std::make_tuple(5, 7), (std::tuple<long, long>)std::make_tuple(7, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)9, (long)7, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(1, 9), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(7, 10)})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 5), (std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to split a string into characters.\nstd::vector<std::string> split(std::string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = split;\n    assert(candidate((\"python\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})));\n    assert(candidate((\"Name\")) == (std::vector<std::string>({(std::string)\"N\", (std::string)\"a\", (std::string)\"m\", (std::string)\"e\"})));\n    assert(candidate((\"program\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum of three numbers.\nlong min_of_three(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_of_three;\n    assert(candidate((10), (20), (0)) == (0));\n    assert(candidate((19), (15), (18)) == (15));\n    assert(candidate((-10), (-20), (-30)) == (-30));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nbool is_Sum_Of_Powers_Of_Two(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_Sum_Of_Powers_Of_Two;\n    assert(candidate((10)) == (true));\n    assert(candidate((7)) == (false));\n    assert(candidate((14)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nstd::string get_Char(std::string strr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_Char;\n    assert(candidate((\"abc\")) == (\"f\"));\n    assert(candidate((\"gfg\")) == (\"t\"));\n    assert(candidate((\"ab\")) == (\"c\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return the sum of all divisors of a number.\nlong sum_div(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_div;\n    assert(candidate((8)) == (7));\n    assert(candidate((12)) == (16));\n    assert(candidate((7)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_string_float{\n    long f0;\n    std::string f1;\n    float f2;    Union_long_std_string_float(long _f0) : f0(_f0) {}\n    Union_long_std_string_float(std::string _f1) : f1(_f1) {}\n    Union_long_std_string_float(float _f2) : f2(_f2) {}\n    ~Union_long_std_string_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::string f) {\n        return f1 == f ;\n    }    bool operator==(float f) {\n        return f2 == f ;\n    }\n};\n// Write a cppthon function that returns the number of integer elements in a given vector.\nlong count_integer(std::vector<Union_long_std_string_float> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_integer;\n    assert(candidate((std::vector<Union_long_std_string_float>({1, 2, \"abc\", 1.2f}))) == (2));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)1.2f, (long)4, (long)5.1f}))) == (2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove duplicate numbers from a given number of vectors.\nstd::vector<long> two_unique_nums(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = two_unique_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether a given vector of integers contains any duplicate element.\nbool test_duplicate(std::vector<long> arraynums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = test_duplicate;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which returns nth catalan number.\nlong catalan_number(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = catalan_number;\n    assert(candidate((10)) == (16796));\n    assert(candidate((9)) == (4862));\n    assert(candidate((7)) == (429));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlong power_base_sum(long base, long power) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = power_base_sum;\n    assert(candidate((2), (100)) == (115));\n    assert(candidate((8), (10)) == (37));\n    assert(candidate((8), (15)) == (62));\n    assert(candidate((3), (3)) == (9));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two vectors and replaces the last element of the first vector with the elements of the second vector.\nstd::vector<std::any> replace_list(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_list;\n    assert(candidate((std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})), (std::vector<std::any>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8}))) == (std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\"})), (std::vector<std::any>({(std::string)\"yellow\"}))) == (std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"yellow\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth octagonal number.\nlong is_octagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_octagonal;\n    assert(candidate((5)) == (65));\n    assert(candidate((10)) == (280));\n    assert(candidate((15)) == (645));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nstd::string replace_blank(std::string str1, std::string char) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_blank;\n    assert(candidate((\"hello people\"), (\"@\")) == (\"hello@people\"));\n    assert(candidate((\"python program language\"), (\"$\")) == (\"python$program$language\"));\n    assert(candidate((\"blank space\"), (\"-\")) == (\"blank-space\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nstd::string replace_specialchar(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_specialchar;\n    assert(candidate((\"Python language, Programming language.\")) == (\"Python:language::Programming:language:\"));\n    assert(candidate((\"a b c,d e f\")) == (\"a:b:c:d:e:f\"));\n    assert(candidate((\"ram reshma,ram rahim\")) == (\"ram:reshma:ram:rahim\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given tuple of positive integers into a single integer.\nlong tuple_to_int(std::tuple<long, long, long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tuple_to_int;\n    assert(candidate((std::make_tuple(1, 2, 3))) == (123));\n    assert(candidate((std::make_tuple(4, 5, 6))) == (456));\n    assert(candidate((std::make_tuple(5, 6, 7))) == (567));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the third side of a right angled triangle.\nfloat otherside_rightangle(long w, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = otherside_rightangle;\n    assert(candidate((7), (8)) == (10.63014581273465f));\n    assert(candidate((3), (4)) == (float(5)));\n    assert(candidate((7), (15)) == (16.55294535724685f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_float{\n    std::string f0;\n    float f1;    Union_std_string_float(std::string _f0) : f0(_f0) {}\n    Union_std_string_float(float _f1) : f1(_f1) {}\n    ~Union_std_string_float() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the n most expensive items in a given dataset.\nstd::vector<std::map<std::string,Union_std_string_float>> expensive_items(std::vector<std::map<std::string,Union_std_string_float>> items, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = expensive_items;\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}})})), (2)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-4\"}, {\"price\", 22.75f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the per-digit difference between two integers.\nlong digit_distance_nums(long n1, long n2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = digit_distance_nums;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((23), (56)) == (6));\n    assert(candidate((123), (256)) == (7));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nbool text_match_wordz_middle(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_match_wordz_middle;\n    assert(candidate((\"pythonzabc.\")) == (true));\n    assert(candidate((\"zxyabc.\")) == (false));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove leading zeroes from an ip address.\nstd::string removezero_ip(std::string ip) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = removezero_ip;\n    assert(candidate((\"216.08.094.196\")) == (\"216.8.94.196\"));\n    assert(candidate((\"12.01.024\")) == (\"12.1.24\"));\n    assert(candidate((\"216.08.094.0196\")) == (\"216.8.94.196\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of subvectors containing a particular element.\nlong count_element_in_list(std::vector<std::vector<std::any>> list1, std::any x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_element_in_list;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)11}), (std::vector<long>)std::vector<long>({(long)1, (long)15, (long)7})})), (std::any(1))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"A\"))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"E\"))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to multiply two integers.\nlong multiply_int(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = multiply_int;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((5), (10)) == (50));\n    assert(candidate((4), (8)) == (32));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nstd::tuple<long, long, long, long> add_pairwise(std::tuple<long, long, long, long, long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_pairwise;\n    assert(candidate((std::make_tuple(1, 5, 7, 8, 10))) == (std::make_tuple(6, 12, 15, 18)));\n    assert(candidate((std::make_tuple(2, 6, 8, 9, 11))) == (std::make_tuple(8, 14, 17, 20)));\n    assert(candidate((std::make_tuple(3, 7, 9, 10, 12))) == (std::make_tuple(10, 16, 19, 22)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\nlong max_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (36));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (200));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (484));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3544,7 +16,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the kth element in the given vector using 1-based indexing.\nlong kth_element(std::vector<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = kth_element;\n    assert(candidate((std::vector<long>({(long)12, (long)3, (long)5, (long)7, (long)19})), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)17, (long)24, (long)8, (long)23})), (3)) == (8));\n    assert(candidate((std::vector<long>({(long)16, (long)21, (long)25, (long)36, (long)4})), (4)) == (36));\n}\n",
     "stop_tokens": [
@@ -3552,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to interchange the first and last element in a given vector.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (std::vector<long>({(long)4, (long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"python_program\")) == (\"PythonProgram\"));\n    assert(candidate((\"python_language\")) == (\"PythonLanguage\"));\n    assert(candidate((\"programming_language\")) == (\"ProgrammingLanguage\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_tuple_long, long_{\n    long f0;\n    std::tuple<long, long> f1;    Union_long_std_tuple_long, long_(long _f0) : f0(_f0) {}\n    Union_long_std_tuple_long, long_(std::tuple<long, long> _f1) : f1(_f1) {}\n    ~Union_long_std_tuple_long, long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::tuple<long, long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the number of elements that occurs before the vector element in the given tuple.\nlong count_first_elements(std::vector<Union_long_std_tuple_long, long_> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the Eulerian number a(n, m).\nlong eulerian_num(long n, long m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_first_elements;\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({1, 5, 7, std::make_tuple(4, 6), 10}))) == (3));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({2, 9, std::make_tuple(5, 7), 11}))) == (2));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({11, 15, 5, 8, std::make_tuple(2, 3), 8}))) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = eulerian_num;\n    assert(candidate((3), (1)) == (4));\n    assert(candidate((4), (1)) == (11));\n    assert(candidate((5), (3)) == (26));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the right insertion point for a specified value in sorted order.\nlong right_insertion(std::vector<long> a, long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each subvector of strings in a given vector of vectors.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> input_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = right_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"blue \", (std::string)\" black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\" red \", (std::string)\"green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" black\", (std::string)\"blue \"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\" orange\", (std::string)\"brown\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"zilver\", (std::string)\"gold\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"magnesium\", (std::string)\"aluminium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"steel\", (std::string)\"bronze\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"gold\", (std::string)\"zilver\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"aluminium\", (std::string)\"magnesium\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"bronze\", (std::string)\"steel\"})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given number is woodball or not.\nbool is_woodall(long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count true booleans in the given vector.\nlong count(std::vector<bool> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_woodall;\n    assert(candidate((383)) == (true));\n    assert(candidate((254)) == (false));\n    assert(candidate((200)) == (false));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = count;\n    assert(candidate((std::vector<bool>({(bool)true, (bool)false, (bool)true}))) == (2));\n    assert(candidate((std::vector<bool>({(bool)false, (bool)false}))) == (0));\n    assert(candidate((std::vector<bool>({(bool)true, (bool)true, (bool)true}))) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given vector by using shell sort.\nstd::vector<long> shell_sort(std::vector<long> my_list) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to append the given vector to the given tuples.\nstd::tuple<long, long, long, long, long> add_lists(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = shell_sort;\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)4, (long)5, (long)3, (long)2, (long)12, (long)81, (long)56, (long)95}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)12, (long)12, (long)23, (long)56, (long)81, (long)95})));\n    assert(candidate((std::vector<long>({(long)24, (long)22, (long)39, (long)34, (long)87, (long)73, (long)68}))) == (std::vector<long>({(long)22, (long)24, (long)34, (long)39, (long)68, (long)73, (long)87})));\n    assert(candidate((std::vector<long>({(long)32, (long)30, (long)16, (long)96, (long)82, (long)83, (long)74}))) == (std::vector<long>({(long)16, (long)30, (long)32, (long)74, (long)82, (long)83, (long)96})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = add_lists;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::make_tuple(9, 10, 5, 6, 7)));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::make_tuple(10, 11, 6, 7, 8)));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::make_tuple(11, 12, 7, 8, 9)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of pairs whose xor value is odd.\nlong find_Odd_Pair(std::vector<long> A, long N) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three vectors into a single sorted vector.\nstd::vector<long> merge_sorted_list(std::vector<long> num1, std::vector<long> num2, std::vector<long> num3) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Odd_Pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11})), (7)) == (12));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (3)) == (2));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = merge_sorted_list;\n    assert(candidate((std::vector<long>({(long)25, (long)24, (long)15, (long)4, (long)5, (long)29, (long)110})), (std::vector<long>({(long)19, (long)20, (long)11, (long)56, (long)25, (long)233, (long)154})), (std::vector<long>({(long)24, (long)26, (long)54, (long)48}))) == (std::vector<long>({(long)4, (long)5, (long)11, (long)15, (long)19, (long)20, (long)24, (long)24, (long)25, (long)25, (long)26, (long)29, (long)48, (long)54, (long)56, (long)110, (long)154, (long)233})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)6, (long)8, (long)9})), (std::vector<long>({(long)2, (long)5, (long)7, (long)11})), (std::vector<long>({(long)1, (long)4, (long)7, (long)8, (long)12}))) == (std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)5, (long)5, (long)6, (long)7, (long)7, (long)8, (long)8, (long)9, (long)11, (long)12})));\n    assert(candidate((std::vector<long>({(long)18, (long)14, (long)10, (long)9, (long)8, (long)7, (long)9, (long)3, (long)2, (long)4, (long)1})), (std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58})), (std::vector<long>({(long)12, (long)74, (long)9, (long)50, (long)61, (long)41}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)8, (long)9, (long)9, (long)9, (long)10, (long)12, (long)14, (long)14, (long)18, (long)22, (long)25, (long)25, (long)35, (long)41, (long)50, (long)58, (long)61, (long)65, (long)74, (long)75, (long)85})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of all odd natural numbers within the range l and r.\nlong sum_in_range(long l, long r) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlong odd_Equivalent(std::string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_in_range;\n    assert(candidate((2), (5)) == (8));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (13)) == (40));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = odd_Equivalent;\n    assert(candidate((\"011001\"), (6)) == (3));\n    assert(candidate((\"11011\"), (5)) == (4));\n    assert(candidate((\"1010\"), (4)) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the perimeter of a square given its side length as input.\nlong square_perimeter(long a) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string represents an integer or not.\nbool check_integer(std::string text) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = square_perimeter;\n    assert(candidate((10)) == (40));\n    assert(candidate((5)) == (20));\n    assert(candidate((4)) == (16));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = check_integer;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"1\")) == (true));\n    assert(candidate((\"12345\")) == (true));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlong is_polite(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given tuple of positive integers into a single integer.\nlong tuple_to_int(std::tuple<long, long, long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_polite;\n    assert(candidate((7)) == (11));\n    assert(candidate((4)) == (7));\n    assert(candidate((9)) == (13));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlong sum_series(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_series;\n    assert(candidate((6)) == (12));\n    assert(candidate((10)) == (30));\n    assert(candidate((9)) == (25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the dissimilar elements in the given two tuples.\nstd::tuple<long, long, long, long> find_dissimilar(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_dissimilar;\n    assert(candidate((std::make_tuple(3, 4, 5, 6)), (std::make_tuple(5, 7, 4, 10))) == (std::make_tuple(3, 6, 7, 10)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(7, 2, 3, 9))) == (std::make_tuple(1, 4, 7, 9)));\n    assert(candidate((std::make_tuple(21, 11, 25, 26)), (std::make_tuple(26, 34, 21, 36))) == (std::make_tuple(34, 36, 11, 25)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return two words from a vector of words starting with letter 'p'.\nstd::tuple<std::string, std::string> start_withp(std::vector<std::string> words) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = start_withp;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python PHP\", (std::string)\"Java JavaScript\", (std::string)\"c c++\"}))) == (std::make_tuple(\"Python\", \"PHP\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python Programming\", (std::string)\"Java Programming\"}))) == (std::make_tuple(\"Python\", \"Programming\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Pqrst Pqr\", (std::string)\"qrstuv\"}))) == (std::make_tuple(\"Pqrst\", \"Pqr\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"android_tv\")) == (\"AndroidTv\"));\n    assert(candidate((\"google_pixel\")) == (\"GooglePixel\"));\n    assert(candidate((\"apple_watch\")) == (\"AppleWatch\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the volume of a cube given its side length.\nlong volume_cube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = volume_cube;\n    assert(candidate((3)) == (27));\n    assert(candidate((2)) == (8));\n    assert(candidate((5)) == (125));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 31 days or not.\nbool check_monthnumb_number(long monthnum2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_monthnumb_number;\n    assert(candidate((5)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((6)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether all the bits are unset in the given range or not.\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = all_Bits_Set_In_The_Given_Range;\n    assert(candidate((4), (1), (2)) == (true));\n    assert(candidate((17), (2), (4)) == (true));\n    assert(candidate((39), (4), (6)) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to get the first element of each subvector.\nstd::vector<long> Extract(std::vector<std::vector<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Extract;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)3, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (std::vector<long>({(long)1, (long)4})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)8, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (std::vector<long>({(long)9, (long)1})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cylinder.\nfloat surfacearea_cylinder(long r, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = surfacearea_cylinder;\n    assert(candidate((10), (5)) == (942.45f));\n    assert(candidate((4), (5)) == (226.18800000000002f));\n    assert(candidate((4), (10)) == (351.848f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\nlong sample_nam(std::vector<std::string> sample_names) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sample_nam;\n    assert(candidate((std::vector<std::string>({(std::string)\"sally\", (std::string)\"Dylan\", (std::string)\"rebecca\", (std::string)\"Diana\", (std::string)\"Joanne\", (std::string)\"keith\"}))) == (16));\n    assert(candidate((std::vector<std::string>({(std::string)\"php\", (std::string)\"res\", (std::string)\"Python\", (std::string)\"abcd\", (std::string)\"Java\", (std::string)\"aaa\"}))) == (10));\n    assert(candidate((std::vector<std::string>({(std::string)\"abcd\", (std::string)\"Python\", (std::string)\"abba\", (std::string)\"aba\"}))) == (6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nstd::any rearrange_bigger(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rearrange_bigger;\n    assert(candidate((12)) == (std::any(21)));\n    assert(candidate((10)) == (std::any(false)));\n    assert(candidate((102)) == (std::any(120)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlong perimeter_pentagon(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = perimeter_pentagon;\n    assert(candidate((5)) == (25));\n    assert(candidate((10)) == (50));\n    assert(candidate((15)) == (75));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nlong max_sum(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)15, (long)51, (long)45, (long)33, (long)100, (long)12, (long)18, (long)9}))) == (194));\n    assert(candidate((std::vector<long>({(long)80, (long)60, (long)30, (long)40, (long)20, (long)10}))) == (210));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)14, (long)16, (long)21, (long)23, (long)29, (long)30}))) == (138));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uneven elements in the nested mixed tuple.\nstd::any extract_even(std::tuple<long, long, std::tuple<long, long, std::tuple<long, long>>, long, long> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_even;\n    assert(candidate((std::make_tuple(4, 5, std::make_tuple(7, 6, std::make_tuple(2, 4)), 6, 8))) == std::make_tuple(4, std::make_tuple(6, std::make_tuple(2, 4)), 6, 8));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(8, 7, std::make_tuple(4, 8)), 7, 9))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 8))));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(9, 8, std::make_tuple(4, 6)), 8, 10))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 6)), 8, 10));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = tuple_to_int;\n    assert(candidate((std::make_tuple(1, 2, 3))) == (123));\n    assert(candidate((std::make_tuple(4, 5, 6))) == (456));\n    assert(candidate((std::make_tuple(5, 6, 7))) == (567));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3832,201 +136,9 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert all possible convertible elements in a vector of vectors to floats.\nstd::vector<std::tuple<float, float>> list_to_float(std::vector<std::tuple<std::string, std::string>> test_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = list_to_float;\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"3\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"1\", \"26.45\"), (std::tuple<std::string, std::string>)std::make_tuple(\"7.32\", \"8\"), (std::tuple<std::string, std::string>)std::make_tuple(\"4\", \"8\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(3.0f, 4.0f), (std::tuple<float, float>)std::make_tuple(1.0f, 26.45f), (std::tuple<float, float>)std::make_tuple(7.32f, 8.0f), (std::tuple<float, float>)std::make_tuple(4.0f, 8.0f)})));\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"4\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"2\", \"27\"), (std::tuple<std::string, std::string>)std::make_tuple(\"4.12\", \"9\"), (std::tuple<std::string, std::string>)std::make_tuple(\"7\", \"11\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(4.0f, 4.0f), (std::tuple<float, float>)std::make_tuple(2.0f, 27.0f), (std::tuple<float, float>)std::make_tuple(4.12f, 9.0f), (std::tuple<float, float>)std::make_tuple(7.0f, 11.0f)})));\n    assert(candidate((std::vector<std::tuple<std::string, std::string>>({(std::tuple<std::string, std::string>)std::make_tuple(\"6\", \"78\"), (std::tuple<std::string, std::string>)std::make_tuple(\"5\", \"26.45\"), (std::tuple<std::string, std::string>)std::make_tuple(\"1.33\", \"4\"), (std::tuple<std::string, std::string>)std::make_tuple(\"82\", \"13\")}))) == (std::vector<std::tuple<float, float>>({(std::tuple<float, float>)std::make_tuple(6.0f, 78.0f), (std::tuple<float, float>)std::make_tuple(5.0f, 26.45f), (std::tuple<float, float>)std::make_tuple(1.33f, 4.0f), (std::tuple<float, float>)std::make_tuple(82.0f, 13.0f)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlong square_Sum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (20));\n    assert(candidate((3)) == (56));\n    assert(candidate((4)) == (120));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\nlong get_pairs_count(std::vector<long> arr, long sum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_pairs_count;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (2)) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)-1, (long)5})), (6)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3})), (1)) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3})), (-3)) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlong count_no_of_ways(long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_no_of_ways;\n    assert(candidate((2), (4)) == (16));\n    assert(candidate((3), (2)) == (6));\n    assert(candidate((4), (4)) == (228));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse words seperated by spaces in a given string.\nstd::string reverse_words(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = reverse_words;\n    assert(candidate((\"python program\")) == (\"program python\"));\n    assert(candidate((\"java language\")) == (\"language java\"));\n    assert(candidate((\"indian man\")) == (\"man indian\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check if a given number is one less than twice its reverse.\nbool checks(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = checks;\n    assert(candidate((70)) == (false));\n    assert(candidate((23)) == (false));\n    assert(candidate((73)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last position of an element in a sorted vector.\nlong last(std::vector<long> arr, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = last;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)4})), (1)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)3, (long)6, (long)8, (long)9})), (3)) == (3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\nlong count_X(std::vector<long> tup, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_X;\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (10)) == (3));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (8)) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We say that an element is common for vectors l1, l2, l3 if it appears in all three vectors under the same index. Write a function to find common elements from three vectors. The function should return a vector.\nstd::vector<std::any> extract_index_list(std::vector<long> l1, std::vector<long> l2, std::vector<long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_index_list;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)5})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)7}))) == (std::vector<std::any>({(long)1, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)6, (long)5, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)6, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>()));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float{\n    long f0;\n    float f1;    Union_long_float(long _f0) : f0(_f0) {}\n    Union_long_float(float _f1) : f1(_f1) {}\n    ~Union_long_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the second smallest number in a vector.\nstd::optional<float> second_smallest(std::vector<Union_long_float> numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = second_smallest;\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)2, (long)-8, (long)-2, (long)0, (long)-2}))) == -2);\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)1, (long)-0.5f, (long)0, (long)2, (long)-2, (long)-2}))) == -0.5f);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2}))) == std::nullopt);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2, (long)2}))) == std::nullopt);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to concatenate each element of tuple by the delimiter.\nstd::string concatenate_tuple(std::tuple<std::string, std::string, long, std::string> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = concatenate_tuple;\n    assert(candidate((std::make_tuple(\"ID\", \"is\", 4, \"UTS\"))) == (\"ID-is-4-UTS\"));\n    assert(candidate((std::make_tuple(\"QWE\", \"is\", 4, \"RTY\"))) == (\"QWE-is-4-RTY\"));\n    assert(candidate((std::make_tuple(\"ZEN\", \"is\", 4, \"OP\"))) == (\"ZEN-is-4-OP\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all spaces in the given string with '%20'.\nstd::string replace_spaces(std::string string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"My Name is Dawood\")) == (\"My%20Name%20is%20Dawood\"));\n    assert(candidate((\"I am a Programmer\")) == (\"I%20am%20a%20Programmer\"));\n    assert(candidate((\"I love Coding\")) == (\"I%20love%20Coding\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of numbers in a vector within a range specified by two indices.\nlong sum_range_list(std::vector<long> list1, long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sum_range_list;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (8), (10)) == (29));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (5), (7)) == (16));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (7), (10)) == (38));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three dictionaries into a single map.\nstd::map<std::string,std::string> merge_dictionaries_three(std::map<std::string,std::string> dict1, std::map<std::string,std::string> dict2, std::map<std::string,std::string> dict3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = merge_dictionaries_three;\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}))) == (std::map<std::string,std::string>({{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum of two numbers.\nlong minimum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = minimum;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((-5), (-4)) == (-5));\n    assert(candidate((0), (0)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between available pairs in the given tuple vector.\nlong max_difference(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_difference;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(1, 7), (std::tuple<long, long>)std::make_tuple(10, 3), (std::tuple<long, long>)std::make_tuple(1, 2)}))) == (7));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(2, 17), (std::tuple<long, long>)std::make_tuple(9, 13), (std::tuple<long, long>)std::make_tuple(11, 12)}))) == (15));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 35), (std::tuple<long, long>)std::make_tuple(21, 27), (std::tuple<long, long>)std::make_tuple(13, 23), (std::tuple<long, long>)std::make_tuple(41, 22)}))) == (23));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find element at a given index after number of rotations.\nlong find_Element(std::vector<long> arr, std::vector<std::vector<long>> ranges, long rotations, long index) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)2}), (std::vector<long>)std::vector<long>({(long)0, (long)3})})), (2), (1)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (1)) == (1));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4036,7 +148,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a string to a vector of strings split on the space character.\nstd::vector<std::string> string_to_list(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = string_to_list;\n    assert(candidate((\"python programming\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"programming\"})));\n    assert(candidate((\"lists tuples strings\")) == (std::vector<std::string>({(std::string)\"lists\", (std::string)\"tuples\", (std::string)\"strings\"})));\n    assert(candidate((\"write a program\")) == (std::vector<std::string>({(std::string)\"write\", (std::string)\"a\", (std::string)\"program\"})));\n}\n",
     "stop_tokens": [
@@ -4048,21 +160,9 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the element that appears only once in a sorted vector.\nlong search(std::vector<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = search;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)3, (long)4, (long)4, (long)5, (long)5, (long)7, (long)7, (long)8}))) == (8));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4}))) == (1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a map by value.\nstd::vector<std::tuple<std::string, long>> sort_counter(std::map<std::string,long> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_counter;\n    assert(candidate((std::map<std::string,long>({{\"Math\", 81}, {\"Physics\", 83}, {\"Chemistry\", 87}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 87), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 83), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 81)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 400}, {\"Physics\", 300}, {\"Chemistry\", 250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Math\", 400), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 300), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 250)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 900}, {\"Physics\", 1000}, {\"Chemistry\", 1250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 1250), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 1000), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 900)})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4072,7 +172,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove first and last occurrence of a given character from the string.\nstd::string remove_Occ(std::string s, std::string ch) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = remove_Occ;\n    assert(candidate((\"hello\"), (\"l\")) == (\"heo\"));\n    assert(candidate((\"abcda\"), (\"a\")) == (\"bcd\"));\n    assert(candidate((\"PHP\"), (\"P\")) == (\"H\"));\n}\n",
     "stop_tokens": [
@@ -4080,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cube given its side length.\nlong lateralsurface_cube(long l) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\nlong max_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cube;\n    assert(candidate((5)) == (100));\n    assert(candidate((9)) == (324));\n    assert(candidate((10)) == (400));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = max_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (36));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (200));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (484));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes two vectors and returns true if they have at least one common element.\nstd::optional<bool> common_element(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum all amicable numbers from 1 to a specified number.\nlong amicable_numbers_sum(long limit) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = common_element;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == true);\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)6, (long)7, (long)8, (long)9}))) == std::nullopt);\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})), (std::vector<std::any>({(std::string)\"d\", (std::string)\"b\", (std::string)\"e\"}))) == true);\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = amicable_numbers_sum;\n    assert(candidate((999)) == (504));\n    assert(candidate((9999)) == (31626));\n    assert(candidate((99)) == (0));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to append the given vector to the given tuples.\nstd::tuple<long, long, long, long, long> add_lists(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlong find_length(std::string string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_lists;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::make_tuple(9, 10, 5, 6, 7)));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::make_tuple(10, 11, 6, 7, 8)));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::make_tuple(11, 12, 7, 8, 9)));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = find_length;\n    assert(candidate((\"11000010001\")) == (6));\n    assert(candidate((\"10111\")) == (1));\n    assert(candidate((\"11011101100101\")) == (2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the n-th power of each number in a vector.\nstd::vector<long> nth_nums(std::vector<long> nums, long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of common divisors of two given numbers.\nlong sum(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = nth_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (3)) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15})), (5)) == (std::vector<long>({(long)248832, (long)759375})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sum;\n    assert(candidate((10), (15)) == (6));\n    assert(candidate((100), (150)) == (93));\n    assert(candidate((4), (6)) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of elements.\nstd::vector<long> pancake_sort(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to multiply two integers.\nlong multiply_int(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = pancake_sort;\n    assert(candidate((std::vector<long>({(long)15, (long)79, (long)25, (long)38, (long)69}))) == (std::vector<long>({(long)15, (long)25, (long)38, (long)69, (long)79})));\n    assert(candidate((std::vector<long>({(long)98, (long)12, (long)54, (long)36, (long)85}))) == (std::vector<long>({(long)12, (long)36, (long)54, (long)85, (long)98})));\n    assert(candidate((std::vector<long>({(long)41, (long)42, (long)32, (long)12, (long)23}))) == (std::vector<long>({(long)12, (long)23, (long)32, (long)41, (long)42})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of three numbers.\nfloat median_numbers(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = median_numbers;\n    assert(candidate((25), (55), (65)) == (55.0f));\n    assert(candidate((20), (10), (30)) == (20.0f));\n    assert(candidate((15), (45), (75)) == (45.0f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the entered number is greater than the elements of the given vector.\nbool check_greater(std::vector<long> arr, long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_greater;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6})), (8)) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)4, (long)8, (long)6, (long)1})), (11)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and element and checks whether all items in the vector are equal to the given element.\nbool check_element(std::vector<std::any> list, std::any element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_element;\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"})), (std::any(\"blue\"))) == (false));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (std::any(7))) == (false));\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"green\", (std::string)\"green\", (std::string)\"green\"})), (std::any(\"green\"))) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract specified size of strings from a given vector of string values.\nstd::vector<std::string> extract_string(std::vector<std::string> str, long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = extract_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (8)) == (std::vector<std::string>({(std::string)\"practice\", (std::string)\"solution\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (6)) == (std::vector<std::string>({(std::string)\"Python\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (9)) == (std::vector<std::string>({(std::string)\"exercises\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nbool text_lowercase_underscore(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = text_lowercase_underscore;\n    assert(candidate((\"aab_cbbbc\")) == (true));\n    assert(candidate((\"aab_Abbbc\")) == (false));\n    assert(candidate((\"Aaab_abbbc\")) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to trim each vector by k in the given vectors.\nstd::vector<std::vector<long>> trim_tuple(std::vector<std::vector<long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = trim_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)2})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)8, (long)2, (long)1})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)12, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)4}), (std::vector<long>)std::vector<long>({(long)8, (long)12}), (std::vector<long>)std::vector<long>({(long)1, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)9})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the subvector having minimum length.\nstd::vector<std::any> Find_Min(std::vector<std::vector<std::any>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = Find_Min;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)7, (long)8})}))) == (std::vector<std::any>({(long)1, (long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"})}))) == (std::vector<std::any>({(std::string)\"x\"})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to filter odd numbers.\nstd::vector<long> filter_oddnumbers(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = filter_oddnumbers;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)45, (long)67, (long)84, (long)93}))) == (std::vector<long>({(long)45, (long)67, (long)93})));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)9, (long)8, (long)6, (long)4, (long)3}))) == (std::vector<long>({(long)5, (long)7, (long)9, (long)3})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nstd::string find_adverbs(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_adverbs;\n    assert(candidate((\"Clearly, he has no excuse for such behavior.\")) == (\"0-7: Clearly\"));\n    assert(candidate((\"Please handle the situation carefuly\")) == (\"28-36: carefuly\"));\n    assert(candidate((\"Complete the task quickly\")) == (\"18-25: quickly\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\nlong max_of_nth(std::vector<std::vector<long>> test_list, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_of_nth;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)9, (long)19})})), (2)) == (19));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)20})})), (1)) == (10));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)21})})), (1)) == (11));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nstd::string decimal_to_binary(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((8)) == (\"1000\"));\n    assert(candidate((18)) == (\"10010\"));\n    assert(candidate((7)) == (\"111\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\nstd::vector<std::vector<std::string>> combinations_colors(std::vector<std::string> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = combinations_colors;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (1)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (2)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (3)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\", (std::string)\"Blue\"})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from a string.\nstd::string remove_all_spaces(std::string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_all_spaces;\n    assert(candidate((\"python  program\")) == (\"pythonprogram\"));\n    assert(candidate((\"python   programming    language\")) == (\"pythonprogramminglanguage\"));\n    assert(candidate((\"python                     program\")) == (\"pythonprogram\"));\n    assert(candidate((\"   python                     program\")) == (\"pythonprogram\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nstd::any min_Swaps(std::string str1, std::string str2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_Swaps;\n    assert(candidate((\"1101\"), (\"1110\")) == (std::any(1)));\n    assert(candidate((\"111\"), (\"000\")) == (std::any(\"Not Possible\")));\n    assert(candidate((\"111\"), (\"110\")) == (std::any(\"Not Possible\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a new tuple from the given string and vector.\nstd::tuple<std::string, std::string, std::string> new_tuple(std::vector<std::string> test_list, std::string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = new_tuple;\n    assert(candidate((std::vector<std::string>({(std::string)\"WEB\", (std::string)\"is\"})), (\"best\")) == (std::make_tuple(\"WEB\", \"is\", \"best\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"We\", (std::string)\"are\"})), (\"Developers\")) == (std::make_tuple(\"We\", \"are\", \"Developers\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Part\", (std::string)\"is\"})), (\"Wrong\")) == (std::make_tuple(\"Part\", \"is\", \"Wrong\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the product of the vector multiplication modulo n.\nlong find_remainder(std::vector<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_remainder;\n    assert(candidate((std::vector<long>({(long)100, (long)10, (long)5, (long)25, (long)35, (long)14})), (11)) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (2)) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the minimum value in a given heterogeneous vector.\nlong min_val(std::vector<Union_std_string_long> listval) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (2));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (15));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (20));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ration of positive numbers in a vector of integers.\nfloat positive_count(std::vector<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = positive_count;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.54f));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.69f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (0.56f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add the given tuple to the given vector.\nstd::vector<long> add_tuple(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = add_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::vector<long>({(long)5, (long)6, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::vector<long>({(long)6, (long)7, (long)8, (long)10, (long)11})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::vector<long>({(long)7, (long)8, (long)9, (long)11, (long)12})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find maximum run of uppercase characters in the given string.\nlong max_run_uppercase(std::string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_run_uppercase;\n    assert(candidate((\"GeMKSForGERksISBESt\")) == (5));\n    assert(candidate((\"PrECIOusMOVemENTSYT\")) == (6));\n    assert(candidate((\"GooGLEFluTTER\")) == (4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nstd::vector<std::vector<long>> sort_matrix(std::vector<std::vector<long>> M) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sort_matrix;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nlong count_vowels(std::string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_vowels;\n    assert(candidate((\"bestinstareels\")) == (7));\n    assert(candidate((\"partofthejourneyistheend\")) == (12));\n    assert(candidate((\"amazonprime\")) == (5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlong max_sum_increasing_subseq(std::vector<long> a, long n, long index, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = max_sum_increasing_subseq;\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (4), (6)) == (11));\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (2), (5)) == (7));\n    assert(candidate((std::vector<long>({(long)11, (long)15, (long)19, (long)21, (long)26, (long)28, (long)31})), (7), (2), (4)) == (71));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = multiply_int;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((5), (10)) == (50));\n    assert(candidate((4), (8)) == (32));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4420,7 +244,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find words that are longer than n characters from a given vector of words.\nstd::vector<std::string> long_words(long n, std::string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = long_words;\n    assert(candidate((3), (\"python is a programming language\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"programming\", (std::string)\"language\"})));\n    assert(candidate((2), (\"writing a program\")) == (std::vector<std::string>({(std::string)\"writing\", (std::string)\"program\"})));\n    assert(candidate((5), (\"sorting list\")) == (std::vector<std::string>({(std::string)\"sorting\"})));\n}\n",
     "stop_tokens": [
@@ -4428,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of non-repeated elements in a given vector.\nlong find_sum(std::vector<long> arr) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate whether the matrix is a magic square.\nbool magic_square_test(std::vector<std::vector<long>> my_matrix) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)1, (long)4, (long)5, (long)6}))) == (21));\n    assert(candidate((std::vector<long>({(long)1, (long)10, (long)9, (long)4, (long)2, (long)10, (long)10, (long)45, (long)4}))) == (71));\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)9, (long)45, (long)2, (long)10, (long)10, (long)45, (long)10}))) == (78));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = magic_square_test;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)12, (long)1, (long)14}), (std::vector<long>)std::vector<long>({(long)2, (long)13, (long)8, (long)11}), (std::vector<long>)std::vector<long>({(long)16, (long)3, (long)10, (long)5}), (std::vector<long>)std::vector<long>({(long)9, (long)6, (long)15, (long)4})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)8})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)3, (long)7})}))) == (false));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given tuple to a key-value map using adjacent elements. https://www.geeksforgeeks.org/cppthon-convert-tuple-to-adjacent-pair-map/\nstd::map<long,long> tuple_to_dict(std::tuple<long, long, long, long, long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nstd::vector<std::vector<long>> sort_matrix(std::vector<std::vector<long>> M) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = tuple_to_dict;\n    assert(candidate((std::make_tuple(1, 5, 7, 10, 13, 5))) == (std::map<long,long>({{1, 5}, {7, 10}, {13, 5}})));\n    assert(candidate((std::make_tuple(1, 2, 3, 4, 5, 6))) == (std::map<long,long>({{1, 2}, {3, 4}, {5, 6}})));\n    assert(candidate((std::make_tuple(7, 8, 9, 10, 11, 12))) == (std::map<long,long>({{7, 8}, {9, 10}, {11, 12}})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = sort_matrix;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)5})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)-2, (long)4, (long)-5}), (std::vector<long>)std::vector<long>({(long)1, (long)-1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)8, (long)9})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nstd::vector<std::vector<long>> get_coordinates(std::tuple<long, long> test_tup) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the item with maximum frequency in a given vector.\nlong max_occurrences(std::vector<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = get_coordinates;\n    assert(candidate((std::make_tuple(3, 4))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)2, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5})})));\n    assert(candidate((std::make_tuple(4, 5))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6})})));\n    assert(candidate((std::make_tuple(5, 6))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)7}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)6, (long)7})})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all the elements in tuple have same data type or not.\nbool check_type(std::any test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_type;\n    assert(candidate(std::make_tuple(5, 6, 7, 3, 5, 6)) == (true));\n    assert(candidate(std::make_tuple(1, 2, \"4\")) == (false));\n    assert(candidate(std::make_tuple(3, 2, 1, 4, 5)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the smallest missing number from a sorted vector of natural numbers.\nlong find_First_Missing(std::vector<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_First_Missing;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)6, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)8, (long)9}))) == (0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is undulating or not.\nbool is_undulating(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_undulating;\n    assert(candidate((1212121)) == (true));\n    assert(candidate((1991)) == (false));\n    assert(candidate((121)) == (true));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/cppthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cocpp of test cases\nstd::vector<std::tuple<std::string, long>> min_k(std::vector<std::tuple<std::string, long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = min_k;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Nikhil\", 8)})), (2)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sanjeev\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})), (3)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"tanmay\", 14), (std::tuple<std::string, long>)std::make_tuple(\"Amer\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9), (std::tuple<std::string, long>)std::make_tuple(\"SKD\", 16)})), (1)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of substrings with the sum of digits equal to their length.\nlong count_Substrings(std::string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_Substrings;\n    assert(candidate((\"112112\")) == (6));\n    assert(candidate((\"111\")) == (6));\n    assert(candidate((\"1101112\")) == (12));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth decagonal number.\nlong is_num_decagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_num_decagonal;\n    assert(candidate((3)) == (27));\n    assert(candidate((7)) == (175));\n    assert(candidate((10)) == (370));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\nstd::vector<long> rear_extract(std::vector<std::tuple<long, std::string, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = rear_extract;\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Rash\", 21), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Varsha\", 20), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Kil\", 19)}))) == (std::vector<long>({(long)21, (long)20, (long)19})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sai\", 36), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Ayesha\", 25), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Salman\", 45)}))) == (std::vector<long>({(long)36, (long)25, (long)45})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sudeep\", 14), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Vandana\", 36), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Dawood\", 56)}))) == (std::vector<long>({(long)14, (long)36, (long)56})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the closest smaller number than n.\nlong closest_num(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = closest_num;\n    assert(candidate((11)) == (10));\n    assert(candidate((7)) == (6));\n    assert(candidate((12)) == (11));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/cppthon-combinations-of-sum-with-tuples-in-tuple-vector/\nstd::vector<std::tuple<long, long>> find_combinations(std::vector<std::tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_combinations;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(6, 10)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(8, 11), (std::tuple<long, long>)std::make_tuple(7, 5), (std::tuple<long, long>)std::make_tuple(8, 14), (std::tuple<long, long>)std::make_tuple(11, 8), (std::tuple<long, long>)std::make_tuple(12, 17), (std::tuple<long, long>)std::make_tuple(11, 11)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(6, 2), (std::tuple<long, long>)std::make_tuple(7, 11)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 13), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(10, 16), (std::tuple<long, long>)std::make_tuple(13, 10), (std::tuple<long, long>)std::make_tuple(14, 19), (std::tuple<long, long>)std::make_tuple(13, 13)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(7, 3), (std::tuple<long, long>)std::make_tuple(8, 12)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 15), (std::tuple<long, long>)std::make_tuple(11, 9), (std::tuple<long, long>)std::make_tuple(12, 18), (std::tuple<long, long>)std::make_tuple(15, 12), (std::tuple<long, long>)std::make_tuple(16, 21), (std::tuple<long, long>)std::make_tuple(15, 15)})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfloat maxAverageOfPath(std::vector<std::vector<long>> cost) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = maxAverageOfPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)3, (long)9})}))) == (5.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)4, (long)10})}))) == (6.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)11})}))) == (7.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (5.8f));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nstd::tuple<bool, long> sequential_search(std::vector<long> dlist, long item) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sequential_search;\n    assert(candidate((std::vector<long>({(long)11, (long)23, (long)58, (long)31, (long)56, (long)77, (long)43, (long)12, (long)65, (long)19})), (31)) == (std::make_tuple(true, 3)));\n    assert(candidate((std::vector<long>({(long)12, (long)32, (long)45, (long)62, (long)35, (long)47, (long)44, (long)61})), (61)) == (std::make_tuple(true, 7)));\n    assert(candidate((std::vector<long>({(long)9, (long)10, (long)17, (long)19, (long)22, (long)39, (long)48, (long)56})), (48)) == (std::make_tuple(true, 6)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove odd numbers from a given vector.\nstd::vector<long> remove_odd(std::vector<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)6}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)3}))) == (std::vector<long>({(long)10, (long)20})));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the product of numbers in a vector is even or not.\nbool is_product_even(std::vector<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = is_product_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == (false));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the maximum of two numbers.\nlong maximum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((5), (10)) == (10));\n    assert(candidate((-1), (-2)) == (-1));\n    assert(candidate((9), (7)) == (9));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = max_occurrences;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)2, (long)6, (long)5, (long)1, (long)6, (long)1, (long)2, (long)3, (long)2, (long)4, (long)6, (long)9, (long)1, (long)2}))) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)8, (long)4, (long)7, (long)9, (long)8, (long)7, (long)9, (long)15, (long)14, (long)10, (long)12, (long)13, (long)16, (long)18}))) == (8));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)20, (long)30, (long)40, (long)90, (long)80, (long)50, (long)30, (long)20, (long)50, (long)10}))) == (20));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4636,9 +292,609 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to reverse only the vowels of a given string (where y is not a vowel).\nstd::string reverse_vowels(std::string str1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = reverse_vowels;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"USA\")) == (\"ASU\"));\n    assert(candidate((\"ab\")) == (\"ab\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a vector to a string.\nstd::string tup_string(std::vector<std::string> tup1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tup_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"e\", (std::string)\"x\", (std::string)\"e\", (std::string)\"r\", (std::string)\"c\", (std::string)\"i\", (std::string)\"s\", (std::string)\"e\", (std::string)\"s\"}))) == (\"exercises\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"}))) == (\"program\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of the negative numbers of a given vector of numbers.\nlong sum_negativenum(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_negativenum;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (-32));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)-14, (long)13, (long)-18, (long)12, (long)-20}))) == (-52));\n    assert(candidate((std::vector<long>({(long)19, (long)-65, (long)57, (long)39, (long)152, (long)-639, (long)121, (long)44, (long)90, (long)-190}))) == (-894));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth hexagonal number.\nlong hexagonal_num(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = hexagonal_num;\n    assert(candidate((10)) == (190));\n    assert(candidate((5)) == (45));\n    assert(candidate((7)) == (91));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nbool is_Sum_Of_Powers_Of_Two(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_Sum_Of_Powers_Of_Two;\n    assert(candidate((10)) == (true));\n    assert(candidate((7)) == (false));\n    assert(candidate((14)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of elements.\nstd::vector<long> pancake_sort(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pancake_sort;\n    assert(candidate((std::vector<long>({(long)15, (long)79, (long)25, (long)38, (long)69}))) == (std::vector<long>({(long)15, (long)25, (long)38, (long)69, (long)79})));\n    assert(candidate((std::vector<long>({(long)98, (long)12, (long)54, (long)36, (long)85}))) == (std::vector<long>({(long)12, (long)36, (long)54, (long)85, (long)98})));\n    assert(candidate((std::vector<long>({(long)41, (long)42, (long)32, (long)12, (long)23}))) == (std::vector<long>({(long)12, (long)23, (long)32, (long)41, (long)42})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count number items that are identical in the same position of three given vectors.\nlong count_samepair(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_samepair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)1, (long)3, (long)1, (long)2, (long)6, (long)7, (long)8}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find number of vectors present in the given vector.\nlong find_lists(std::vector<std::any> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_lists;\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (2));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6})}))) == (3));\n    assert(candidate((std::vector<std::any>({(long)9, (long)8, (long)7, (long)6, (long)5, (long)4, (long)3, (long)2, (long)1}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the maximum difference between any two elements in a given vector.\nlong max_Abs_Diff(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_Abs_Diff;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)9, (long)3, (long)2, (long)5, (long)1}))) == (8));\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the volume of a triangular prism.\nlong find_Volume(long l, long b, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Volume;\n    assert(candidate((10), (8), (6)) == (240));\n    assert(candidate((3), (2), (2)) == (6));\n    assert(candidate((1), (2), (1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nstd::optional<std::tuple<long, long>> find_solution(long a, long b, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_solution;\n    assert(candidate((2), (3), (7)) == std::make_tuple(2, 1));\n    assert(candidate((4), (2), (7)) == std::nullopt);\n    assert(candidate((1), (13), (17)) == std::make_tuple(4, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all elements from a given vector present in another vector.\nstd::vector<long> remove_elements(std::vector<long> list1, std::vector<long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)3, (long)5, (long)7}))) == (std::vector<long>({(long)2, (long)4, (long)6, (long)8, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)5, (long)7}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)8, (long)9, (long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlong sum_series(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_series;\n    assert(candidate((6)) == (12));\n    assert(candidate((10)) == (30));\n    assert(candidate((9)) == (25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to determine if the sum of the divisors of two integers are the same.\nbool are_equivalent(long num1, long num2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = are_equivalent;\n    assert(candidate((36), (57)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((23), (47)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlong count_char_position(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_char_position;\n    assert(candidate((\"xbcefg\")) == (2));\n    assert(candidate((\"ABcED\")) == (3));\n    assert(candidate((\"AbgdeF\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that counts the number of pairs of integers in a vector that xor to an even number.\nlong find_even_pair(std::vector<long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_even_pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1}))) == (4));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11}))) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the smallest power of 2 greater than or equal to n.\nlong next_power_of_2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = next_power_of_2;\n    assert(candidate((0)) == (1));\n    assert(candidate((5)) == (8));\n    assert(candidate((17)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurrences of a number in a given vector.\nlong frequency(std::vector<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = frequency;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3, (long)3, (long)3, (long)4})), (3)) == (3));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)1, (long)2})), (1)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nbool text_lowercase_underscore(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_lowercase_underscore;\n    assert(candidate((\"aab_cbbbc\")) == (true));\n    assert(candidate((\"aab_Abbbc\")) == (false));\n    assert(candidate((\"Aaab_abbbc\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of numbers in a vector within a range specified by two indices.\nlong sum_range_list(std::vector<long> list1, long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_range_list;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (8), (10)) == (29));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (5), (7)) == (16));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)5, (long)6, (long)8, (long)3, (long)4, (long)9, (long)10, (long)11, (long)8, (long)12})), (7), (10)) == (38));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlong perimeter_pentagon(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = perimeter_pentagon;\n    assert(candidate((5)) == (25));\n    assert(candidate((10)) == (50));\n    assert(candidate((15)) == (75));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of occurence of the string 'std' in a given string.\nlong count_occurance(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_occurance;\n    assert(candidate((\"letstdlenstdporstd\")) == (3));\n    assert(candidate((\"truststdsolensporsd\")) == (1));\n    assert(candidate((\"makestdsostdworthit\")) == (2));\n    assert(candidate((\"stds\")) == (1));\n    assert(candidate((\"\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the perimeter of a square given its side length as input.\nlong square_perimeter(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = square_perimeter;\n    assert(candidate((10)) == (40));\n    assert(candidate((5)) == (20));\n    assert(candidate((4)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove characters from the first string which are present in the second string.\nstd::string remove_dirty_chars(std::string string, std::string second_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_dirty_chars;\n    assert(candidate((\"probasscurve\"), (\"pros\")) == (\"bacuve\"));\n    assert(candidate((\"digitalindia\"), (\"talent\")) == (\"digiidi\"));\n    assert(candidate((\"exoticmiles\"), (\"toxic\")) == (\"emles\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether a given vector of integers contains any duplicate element.\nbool test_duplicate(std::vector<long> arraynums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = test_duplicate;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given number is woodball or not.\nbool is_woodall(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_woodall;\n    assert(candidate((383)) == (true));\n    assert(candidate((254)) == (false));\n    assert(candidate((200)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all the elements in tuple have same data type or not.\nbool check_type(std::any test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_type;\n    assert(candidate(std::make_tuple(5, 6, 7, 3, 5, 6)) == (true));\n    assert(candidate(std::make_tuple(1, 2, \"4\")) == (false));\n    assert(candidate(std::make_tuple(3, 2, 1, 4, 5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nbool is_majority(std::vector<long> arr, long n, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_majority;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)3, (long)3, (long)3, (long)10})), (7), (3)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)4, (long)4, (long)4, (long)6, (long)6})), (8), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2})), (5), (1)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)2})), (5), (1)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of set bits (binary digits with value 1) in a given number.\nlong count_Set_Bits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_Set_Bits;\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (1));\n    assert(candidate((6)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove the characters which have odd index values of a given string.\nstd::string odd_values_string(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = odd_values_string;\n    assert(candidate((\"abcdef\")) == (\"ace\"));\n    assert(candidate((\"python\")) == (\"pto\"));\n    assert(candidate((\"data\")) == (\"dt\"));\n    assert(candidate((\"lambs\")) == (\"lms\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum of three numbers.\nlong min_of_three(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_of_three;\n    assert(candidate((10), (20), (0)) == (0));\n    assert(candidate((19), (15), (18)) == (15));\n    assert(candidate((-10), (-20), (-30)) == (-30));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether all the bits are unset in the given range or not.\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = all_Bits_Set_In_The_Given_Range;\n    assert(candidate((4), (1), (2)) == (true));\n    assert(candidate((17), (2), (4)) == (true));\n    assert(candidate((39), (4), (6)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nstd::vector<long> re_arrange_array(std::vector<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = re_arrange_array;\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)-3, (long)4, (long)5, (long)6, (long)-7, (long)8, (long)9})), (9)) == (std::vector<long>({(long)-1, (long)-3, (long)-7, (long)4, (long)5, (long)6, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)12, (long)-14, (long)-26, (long)13, (long)15})), (5)) == (std::vector<long>({(long)-14, (long)-26, (long)12, (long)13, (long)15})));\n    assert(candidate((std::vector<long>({(long)10, (long)24, (long)36, (long)-42, (long)-39, (long)-78, (long)85})), (7)) == (std::vector<long>({(long)-42, (long)-39, (long)-78, (long)10, (long)24, (long)36, (long)85})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nstd::string replace_blank(std::string str1, std::string char) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_blank;\n    assert(candidate((\"hello people\"), (\"@\")) == (\"hello@people\"));\n    assert(candidate((\"python program language\"), (\"$\")) == (\"python$program$language\"));\n    assert(candidate((\"blank space\"), (\"-\")) == (\"blank-space\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the volume of a cube given its side length.\nlong volume_cube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = volume_cube;\n    assert(candidate((3)) == (27));\n    assert(candidate((2)) == (8));\n    assert(candidate((5)) == (125));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector of tuples and returns a map mapping each unique tuple to the number of times it occurs in the vector.\nstd::map<std::tuple<long, long>,long> check_occurences(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_occurences;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 1), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(2, 5), (std::tuple<long, long>)std::make_tuple(5, 2), (std::tuple<long, long>)std::make_tuple(6, 3)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(1, 3), 2}, {std::make_tuple(2, 5), 2}, {std::make_tuple(3, 6), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 2), (std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(3, 6), (std::tuple<long, long>)std::make_tuple(6, 3), (std::tuple<long, long>)std::make_tuple(7, 4)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 4), 2}, {std::make_tuple(3, 6), 2}, {std::make_tuple(4, 7), 1}})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(13, 2), (std::tuple<long, long>)std::make_tuple(11, 23), (std::tuple<long, long>)std::make_tuple(12, 25), (std::tuple<long, long>)std::make_tuple(25, 12), (std::tuple<long, long>)std::make_tuple(16, 23)}))) == (std::map<std::tuple<long, long>,long>({{std::make_tuple(2, 13), 1}, {std::make_tuple(11, 23), 1}, {std::make_tuple(12, 25), 2}, {std::make_tuple(16, 23), 1}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of non-empty substrings of a given string.\nlong number_of_substrings(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = number_of_substrings;\n    assert(candidate((\"abc\")) == (6));\n    assert(candidate((\"abcd\")) == (10));\n    assert(candidate((\"abcde\")) == (15));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlong get_total_number_of_sequences(long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_total_number_of_sequences;\n    assert(candidate((10), (4)) == (4));\n    assert(candidate((5), (2)) == (6));\n    assert(candidate((16), (3)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two vectors and replaces the last element of the first vector with the elements of the second vector.\nstd::vector<std::any> replace_list(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_list;\n    assert(candidate((std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)10})), (std::vector<std::any>({(long)2, (long)4, (long)6, (long)8}))) == (std::vector<std::any>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8}))) == (std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\"})), (std::vector<std::any>({(std::string)\"yellow\"}))) == (std::vector<std::any>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"yellow\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the total number of characters in a string.\nlong count_charac(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_charac;\n    assert(candidate((\"python programming\")) == (18));\n    assert(candidate((\"language\")) == (8));\n    assert(candidate((\"words\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the next perfect square greater than a given number.\nlong next_Perfect_Square(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = next_Perfect_Square;\n    assert(candidate((35)) == (36));\n    assert(candidate((6)) == (9));\n    assert(candidate((9)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nlong max_sum(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)15, (long)51, (long)45, (long)33, (long)100, (long)12, (long)18, (long)9}))) == (194));\n    assert(candidate((std::vector<long>({(long)80, (long)60, (long)30, (long)40, (long)20, (long)10}))) == (210));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)14, (long)16, (long)21, (long)23, (long)29, (long)30}))) == (138));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nlong lps(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = lps;\n    assert(candidate((\"TENS FOR TENS\")) == (5));\n    assert(candidate((\"CARDIO FOR CARDS\")) == (7));\n    assert(candidate((\"PART OF THE JOURNEY IS PART\")) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the intersection of two vectors.\nstd::vector<long> intersection_array(std::vector<long> array_nums1, std::vector<long> array_nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = intersection_array;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)1, (long)2, (long)4, (long)8, (long)9}))) == (std::vector<long>({(long)1, (long)2, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)3, (long)5, (long)7, (long)9}))) == (std::vector<long>({(long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)8, (long)9, (long)10})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<long>({(long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\nlong count_X(std::vector<long> tup, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_X;\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (10)) == (3));\n    assert(candidate((std::vector<long>({(long)10, (long)8, (long)5, (long)2, (long)10, (long)15, (long)10, (long)8, (long)5, (long)8, (long)8, (long)2})), (8)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\nstd::vector<std::string> insert_element(std::vector<std::string> list, std::string element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = insert_element;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Black\"})), (\"c\")) == (std::vector<std::string>({(std::string)\"c\", (std::string)\"Red\", (std::string)\"c\", (std::string)\"Green\", (std::string)\"c\", (std::string)\"Black\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"java\"})), (\"program\")) == (std::vector<std::string>({(std::string)\"program\", (std::string)\"python\", (std::string)\"program\", (std::string)\"java\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"happy\", (std::string)\"sad\"})), (\"laugh\")) == (std::vector<std::string>({(std::string)\"laugh\", (std::string)\"happy\", (std::string)\"laugh\", (std::string)\"sad\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert complex numbers to polar coordinates.\nstd::tuple<float, float> convert(long numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = convert;\n    assert(candidate((1)) == (std::make_tuple(1.0f, 0.0f)));\n    assert(candidate((4)) == (std::make_tuple(4.0f, 0.0f)));\n    assert(candidate((5)) == (std::make_tuple(5.0f, 0.0f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_string_float{\n    long f0;\n    std::string f1;\n    float f2;    Union_long_std_string_float(long _f0) : f0(_f0) {}\n    Union_long_std_string_float(std::string _f1) : f1(_f1) {}\n    Union_long_std_string_float(float _f2) : f2(_f2) {}\n    ~Union_long_std_string_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::string f) {\n        return f1 == f ;\n    }    bool operator==(float f) {\n        return f2 == f ;\n    }\n};\n// Write a cppthon function that returns the number of integer elements in a given vector.\nlong count_integer(std::vector<Union_long_std_string_float> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_integer;\n    assert(candidate((std::vector<Union_long_std_string_float>({1, 2, \"abc\", 1.2f}))) == (2));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<Union_long_std_string_float>({(long)1, (long)1.2f, (long)4, (long)5.1f}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\nstd::vector<std::vector<std::string>> combinations_colors(std::vector<std::string> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = combinations_colors;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (1)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (2)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"})), (3)) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Red\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Red\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Red\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Green\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Green\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Green\", (std::string)\"Blue\", (std::string)\"Blue\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"Blue\", (std::string)\"Blue\", (std::string)\"Blue\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlong count_Primes_nums(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_Primes_nums;\n    assert(candidate((5)) == (2));\n    assert(candidate((10)) == (4));\n    assert(candidate((100)) == (25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two numbers and returns a vector with the second number and then the first number.\nstd::vector<long> swap_numbers(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = swap_numbers;\n    assert(candidate((10), (20)) == (std::vector<long>({(long)20, (long)10})));\n    assert(candidate((15), (17)) == (std::vector<long>({(long)17, (long)15})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)200, (long)100})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4648,7 +904,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to maximize the given two vectors.\nstd::vector<std::vector<long>> maximize_elements(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = maximize_elements;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)10})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)5, (long)10}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)11})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)6, (long)11}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)9, (long)12})})));\n}\n",
     "stop_tokens": [
@@ -4656,73 +912,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether every even index contains even numbers of a given vector.\nbool even_position(std::vector<long> nums) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlong newman_prime(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = even_position;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4}))) == (true));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = newman_prime;\n    assert(candidate((3)) == (7));\n    assert(candidate((4)) == (17));\n    assert(candidate((5)) == (41));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string starts and ends with the same character or not.\nstd::string check_char(std::string string) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nstd::tuple<long, long, long, long> division_elements(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = check_char;\n    assert(candidate((\"abba\")) == (\"Valid\"));\n    assert(candidate((\"a\")) == (\"Valid\"));\n    assert(candidate((\"abcd\")) == (\"Invalid\"));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = division_elements;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(2, 2, 2, 3)));\n    assert(candidate((std::make_tuple(12, 6, 8, 16)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(2, 2, 2, 4)));\n    assert(candidate((std::make_tuple(20, 14, 36, 18)), (std::make_tuple(5, 7, 6, 9))) == (std::make_tuple(4, 2, 6, 2)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of even factors of a number.\nlong sumofFactors(long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer L and splits the given vector into two parts where the length of the first part of the vector is L, and returns the resulting vectors in a tuple.\nstd::any split_two_parts(std::vector<std::any> list1, long L) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = sumofFactors;\n    assert(candidate((18)) == (26));\n    assert(candidate((30)) == (48));\n    assert(candidate((6)) == (8));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = split_two_parts;\n    assert(candidate((std::vector<std::any>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == std::make_tuple(std::vector<long>({(long)1, (long)1, (long)2}), std::vector<long>({(long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (2)) == std::make_tuple(std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})), (4)) == std::make_tuple(std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\"}), std::vector<std::string>({(std::string)\"o\", (std::string)\"n\"})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfloat lateralsurface_cone(long r, long h) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate a dog's age in dog's years.\nlong dog_age(long h_age) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cone;\n    assert(candidate((5), (12)) == (204.20352248333654f));\n    assert(candidate((10), (15)) == (566.3586699569488f));\n    assert(candidate((19), (17)) == (1521.8090132193388f));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = dog_age;\n    assert(candidate((12)) == (61));\n    assert(candidate((15)) == (73));\n    assert(candidate((24)) == (109));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\nlong count_Pairs(std::vector<long> arr, long n) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and an integer n and splits a vector for every nth element, returning a vector of the resulting vectors.\nstd::vector<std::vector<std::any>> list_split(std::vector<std::any> S, long step) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = count_Pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (5)) == (10));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = list_split;\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"e\", (std::string)\"f\", (std::string)\"g\", (std::string)\"h\", (std::string)\"i\", (std::string)\"j\", (std::string)\"k\", (std::string)\"l\", (std::string)\"m\", (std::string)\"n\"})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"d\", (std::string)\"g\", (std::string)\"j\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\", (std::string)\"e\", (std::string)\"h\", (std::string)\"k\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"f\", (std::string)\"i\", (std::string)\"l\"})})));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10, (long)11, (long)12, (long)13, (long)14})), (3)) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)4, (long)7, (long)10, (long)13}), (std::vector<long>)std::vector<long>({(long)2, (long)5, (long)8, (long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)12})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"python\", (std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\", (std::string)\"SQL\"})), (2)) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"python\", (std::string)\"C\", (std::string)\"DBMS\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"java\", (std::string)\"C++\", (std::string)\"SQL\"})})));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the index of the first occurrence of a given number in a sorted vector.\nlong find_first_occurrence(std::vector<long> A, long x) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cube given its side length.\nlong lateralsurface_cube(long l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = find_first_occurrence;\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (6)) == (4));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cube;\n    assert(candidate((5)) == (100));\n    assert(candidate((9)) == (324));\n    assert(candidate((10)) == (400));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4732,9 +988,729 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nlong square_Sum(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (10));\n    assert(candidate((3)) == (35));\n    assert(candidate((4)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th star number.\nlong find_star_num(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_star_num;\n    assert(candidate((3)) == (37));\n    assert(candidate((4)) == (73));\n    assert(candidate((5)) == (121));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ascii value of a character.\nlong ascii_value(std::string k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = ascii_value;\n    assert(candidate((\"A\")) == (65));\n    assert(candidate((\"R\")) == (82));\n    assert(candidate((\"S\")) == (83));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of even numbers at even positions of a vector.\nlong sum_even_and_even_index(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_even_and_even_index;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1, (long)18, (long)8}))) == (30));\n    assert(candidate((std::vector<long>({(long)3, (long)20, (long)17, (long)9, (long)2, (long)10, (long)18, (long)13, (long)6, (long)18}))) == (26));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)12, (long)1}))) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlong even_Power_Sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = even_Power_Sum;\n    assert(candidate((2)) == (1056));\n    assert(candidate((3)) == (8832));\n    assert(candidate((1)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\nstd::vector<long> rear_extract(std::vector<std::tuple<long, std::string, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rear_extract;\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Rash\", 21), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Varsha\", 20), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Kil\", 19)}))) == (std::vector<long>({(long)21, (long)20, (long)19})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sai\", 36), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Ayesha\", 25), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Salman\", 45)}))) == (std::vector<long>({(long)36, (long)25, (long)45})));\n    assert(candidate((std::vector<std::tuple<long, std::string, long>>({(std::tuple<long, std::string, long>)std::make_tuple(1, \"Sudeep\", 14), (std::tuple<long, std::string, long>)std::make_tuple(2, \"Vandana\", 36), (std::tuple<long, std::string, long>)std::make_tuple(3, \"Dawood\", 56)}))) == (std::vector<long>({(long)14, (long)36, (long)56})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nstd::tuple<long, long, long> substract_elements(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = substract_elements;\n    assert(candidate((std::make_tuple(10, 4, 5)), (std::make_tuple(2, 5, 18))) == (std::make_tuple(8, -1, -13)));\n    assert(candidate((std::make_tuple(11, 2, 3)), (std::make_tuple(24, 45, 16))) == (std::make_tuple(-13, -43, -13)));\n    assert(candidate((std::make_tuple(7, 18, 9)), (std::make_tuple(10, 11, 12))) == (std::make_tuple(-3, 7, -3)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlong even_binomial_Coeff_Sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = even_binomial_Coeff_Sum;\n    assert(candidate((4)) == (8));\n    assert(candidate((6)) == (32));\n    assert(candidate((2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\nstd::map<std::string,long> dict_filter(std::map<std::string,long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = dict_filter;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (170)) == (std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (180)) == (std::map<std::string,long>({{\"Alden Cantrell\", 180}, {\"Pierre Cox\", 190}})));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 175}, {\"Alden Cantrell\", 180}, {\"Kierra Gentry\", 165}, {\"Pierre Cox\", 190}})), (190)) == (std::map<std::string,long>({{\"Pierre Cox\", 190}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_tuple_long, long_{\n    long f0;\n    std::tuple<long, long> f1;    Union_long_std_tuple_long, long_(long _f0) : f0(_f0) {}\n    Union_long_std_tuple_long, long_(std::tuple<long, long> _f1) : f1(_f1) {}\n    ~Union_long_std_tuple_long, long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::tuple<long, long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the number of elements that occurs before the vector element in the given tuple.\nlong count_first_elements(std::vector<Union_long_std_tuple_long, long_> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_first_elements;\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({1, 5, 7, std::make_tuple(4, 6), 10}))) == (3));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({2, 9, std::make_tuple(5, 7), 11}))) == (2));\n    assert(candidate((std::vector<Union_long_std_tuple_long, long_>({11, 15, 5, 8, std::make_tuple(2, 3), 8}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth decagonal number.\nlong is_num_decagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_num_decagonal;\n    assert(candidate((3)) == (27));\n    assert(candidate((7)) == (175));\n    assert(candidate((10)) == (370));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nstd::tuple<bool, long> sequential_search(std::vector<long> dlist, long item) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sequential_search;\n    assert(candidate((std::vector<long>({(long)11, (long)23, (long)58, (long)31, (long)56, (long)77, (long)43, (long)12, (long)65, (long)19})), (31)) == (std::make_tuple(true, 3)));\n    assert(candidate((std::vector<long>({(long)12, (long)32, (long)45, (long)62, (long)35, (long)47, (long)44, (long)61})), (61)) == (std::make_tuple(true, 7)));\n    assert(candidate((std::vector<long>({(long)9, (long)10, (long)17, (long)19, (long)22, (long)39, (long)48, (long)56})), (48)) == (std::make_tuple(true, 6)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check if the elements of a given vector are unique or not.\nbool all_unique(std::vector<long> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = all_unique;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to subtract two vectors element-wise.\nstd::vector<long> sub_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sub_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)-3, (long)-3, (long)-3})));\n    assert(candidate((std::vector<long>({(long)1, (long)2})), (std::vector<long>({(long)3, (long)4}))) == (std::vector<long>({(long)-2, (long)-2})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<long>({(long)40, (long)50})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nbool validate(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = validate;\n    assert(candidate((1234)) == (true));\n    assert(candidate((51241)) == (false));\n    assert(candidate((321)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes in a vector and element and checks whether all items in the vector are equal to the given element.\nbool check_element(std::vector<std::any> list, std::any element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_element;\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"})), (std::any(\"blue\"))) == (false));\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (std::any(7))) == (false));\n    assert(candidate((std::vector<std::any>({(std::string)\"green\", (std::string)\"green\", (std::string)\"green\", (std::string)\"green\"})), (std::any(\"green\"))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nbool text_match_two_three(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_two_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nlong max_sub_array_sum_repeated(std::vector<long> a, long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum_repeated;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)-30, (long)-1})), (4), (3)) == (30));\n    assert(candidate((std::vector<long>({(long)-1, (long)10, (long)20})), (3), (2)) == (59));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)-3})), (3), (3)) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlong square_Sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = square_Sum;\n    assert(candidate((2)) == (20));\n    assert(candidate((3)) == (56));\n    assert(candidate((4)) == (120));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the vector of maximum length in a vector of vectors.\nstd::tuple<long, std::vector<long>> max_length(std::vector<std::vector<long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)12, (long)14, (long)15})}))) == (std::make_tuple(4, std::vector<long>({(long)10, (long)12, (long)14, (long)15}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)15, (long)20, (long)25})}))) == (std::make_tuple(3, std::vector<long>({(long)15, (long)20, (long)25}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlong count_no_of_ways(long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_no_of_ways;\n    assert(candidate((2), (4)) == (16));\n    assert(candidate((3), (2)) == (6));\n    assert(candidate((4), (4)) == (228));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find quotient of two numbers (rounded down to the nearest integer).\nlong find(long n, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find;\n    assert(candidate((10), (3)) == (3));\n    assert(candidate((4), (2)) == (2));\n    assert(candidate((20), (5)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the third side of a right angled triangle.\nfloat otherside_rightangle(long w, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = otherside_rightangle;\n    assert(candidate((7), (8)) == (10.63014581273465f));\n    assert(candidate((3), (4)) == (float(5)));\n    assert(candidate((7), (15)) == (16.55294535724685f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the maximum value in a given heterogeneous vector.\nlong max_val(std::vector<Union_std_string_long> listval) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (5));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (25));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (50));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return the sum of all divisors of a number.\nlong sum_div(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_div;\n    assert(candidate((8)) == (7));\n    assert(candidate((12)) == (16));\n    assert(candidate((7)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count inversions in a vector.\nlong get_Inv_Count(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_Inv_Count;\n    assert(candidate((std::vector<long>({(long)1, (long)20, (long)6, (long)4, (long)5}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)5, (long)6, (long)1}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a given nested vector structure.\nstd::vector<long> flatten_list(std::vector<Union_long_std_vector_long_> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = flatten_list;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({0, 10, std::vector<long>({(long)20, (long)30}), 40, 50, std::vector<long>({(long)60, (long)70, (long)80}), std::vector<long>({(long)90, (long)100, (long)110, (long)120})}))) == (std::vector<long>({(long)0, (long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70, (long)80, (long)90, (long)100, (long)110, (long)120})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)40}), (std::vector<long>)std::vector<long>({(long)30, (long)56, (long)25}), (std::vector<long>)std::vector<long>({(long)10, (long)20}), (std::vector<long>)std::vector<long>({(long)33}), (std::vector<long>)std::vector<long>({(long)40})}))) == (std::vector<long>({(long)10, (long)20, (long)40, (long)30, (long)56, (long)25, (long)10, (long)20, (long)33, (long)40})));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)10, (long)11, (long)12, (long)7, (long)8, (long)9})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the maximum aggregate from the vector of tuples.\nstd::tuple<std::string, long> max_aggregate(std::vector<std::tuple<std::string, long>> stdata) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_aggregate;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 7), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 122), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 84)}))) == (std::make_tuple(\"Juan Whelan\", 212)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 50), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 48), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 37), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 22), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 14)}))) == (std::make_tuple(\"Juan Whelan\", 72)));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 20), (std::tuple<std::string, long>)std::make_tuple(\"Peter Nichols\", 30), (std::tuple<std::string, long>)std::make_tuple(\"Juan Whelan\", 40), (std::tuple<std::string, long>)std::make_tuple(\"Sabah Colley\", 50)}))) == (std::make_tuple(\"Sabah Colley\", 70)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find element at a given index after number of rotations.\nlong find_Element(std::vector<long> arr, std::vector<std::vector<long>> ranges, long rotations, long index) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)2}), (std::vector<long>)std::vector<long>({(long)0, (long)3})})), (2), (1)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (2)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)0, (long)2})})), (1), (1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return two words from a vector of words starting with letter 'p'.\nstd::tuple<std::string, std::string> start_withp(std::vector<std::string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = start_withp;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python PHP\", (std::string)\"Java JavaScript\", (std::string)\"c c++\"}))) == (std::make_tuple(\"Python\", \"PHP\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python Programming\", (std::string)\"Java Programming\"}))) == (std::make_tuple(\"Python\", \"Programming\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Pqrst Pqr\", (std::string)\"qrstuv\"}))) == (std::make_tuple(\"Pqrst\", \"Pqr\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlong max_sum_increasing_subseq(std::vector<long> a, long n, long index, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_sum_increasing_subseq;\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (4), (6)) == (11));\n    assert(candidate((std::vector<long>({(long)1, (long)101, (long)2, (long)3, (long)100, (long)4, (long)5})), (7), (2), (5)) == (7));\n    assert(candidate((std::vector<long>({(long)11, (long)15, (long)19, (long)21, (long)26, (long)28, (long)31})), (7), (2), (4)) == (71));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\nstd::vector<long> large_product(std::vector<long> nums1, std::vector<long> nums2, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = large_product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (3)) == (std::vector<long>({(long)60, (long)54, (long)50})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (4)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)3, (long)6, (long)8, (long)9, (long)10, (long)6})), (5)) == (std::vector<long>({(long)60, (long)54, (long)50, (long)48, (long)45})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the maximum of two numbers.\nlong maximum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = maximum;\n    assert(candidate((5), (10)) == (10));\n    assert(candidate((-1), (-2)) == (-1));\n    assert(candidate((9), (7)) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a given string to a vector of characters.\nstd::vector<std::string> string_to_tuple(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = string_to_tuple;\n    assert(candidate((\"python 3.0\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\", (std::string)\"3\", (std::string)\".\", (std::string)\"0\"})));\n    assert(candidate((\"item1\")) == (std::vector<std::string>({(std::string)\"i\", (std::string)\"t\", (std::string)\"e\", (std::string)\"m\", (std::string)\"1\"})));\n    assert(candidate((\"15.10\")) == (std::vector<std::string>({(std::string)\"1\", (std::string)\"5\", (std::string)\".\", (std::string)\"1\", (std::string)\"0\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the highest power of 2 that is less than or equal to n.\nlong highest_Power_of_2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = highest_Power_of_2;\n    assert(candidate((10)) == (8));\n    assert(candidate((19)) == (16));\n    assert(candidate((32)) == (32));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n'th lucas number.\nlong find_lucas(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_lucas;\n    assert(candidate((9)) == (76));\n    assert(candidate((4)) == (7));\n    assert(candidate((3)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to apply a given format string to all of the elements in a vector.\nstd::vector<std::string> add_string(std::vector<std::any> list_, std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add_string;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4})), (\"temp{0}\")) == (std::vector<std::string>({(std::string)\"temp1\", (std::string)\"temp2\", (std::string)\"temp3\", (std::string)\"temp4\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})), (\"python{0}\")) == (std::vector<std::string>({(std::string)\"pythona\", (std::string)\"pythonb\", (std::string)\"pythonc\", (std::string)\"pythond\"})));\n    assert(candidate((std::vector<std::any>({(long)5, (long)6, (long)7, (long)8})), (\"string{0}\")) == (std::vector<std::string>({(std::string)\"string5\", (std::string)\"string6\", (std::string)\"string7\", (std::string)\"string8\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert more than one vector to nested map.\nstd::vector<std::map<std::string,std::map<std::string,long>>> convert_list_dictionary(std::vector<std::string> l1, std::vector<std::string> l2, std::vector<long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = convert_list_dictionary;\n    assert(candidate((std::vector<std::string>({(std::string)\"S001\", (std::string)\"S002\", (std::string)\"S003\", (std::string)\"S004\"})), (std::vector<std::string>({(std::string)\"Adina Park\", (std::string)\"Leyton Marsh\", (std::string)\"Duncan Boyle\", (std::string)\"Saim Richards\"})), (std::vector<long>({(long)85, (long)98, (long)89, (long)92}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S001\", std::map<std::string,long>({{\"Adina Park\", 85}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S002\", std::map<std::string,long>({{\"Leyton Marsh\", 98}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S003\", std::map<std::string,long>({{\"Duncan Boyle\", 89}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"S004\", std::map<std::string,long>({{\"Saim Richards\", 92}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"abc\", (std::string)\"def\", (std::string)\"ghi\", (std::string)\"jkl\"})), (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\", (std::string)\"programs\"})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"abc\", std::map<std::string,long>({{\"python\", 100}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"def\", std::map<std::string,long>({{\"program\", 200}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"ghi\", std::map<std::string,long>({{\"language\", 300}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"jkl\", std::map<std::string,long>({{\"programs\", 400}})}})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"A1\", (std::string)\"A2\", (std::string)\"A3\", (std::string)\"A4\"})), (std::vector<std::string>({(std::string)\"java\", (std::string)\"C\", (std::string)\"C++\", (std::string)\"DBMS\"})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40}))) == (std::vector<std::map<std::string,std::map<std::string,long>>>({(std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A1\", std::map<std::string,long>({{\"java\", 10}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A2\", std::map<std::string,long>({{\"C\", 20}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A3\", std::map<std::string,long>({{\"C++\", 30}})}}), (std::map<std::string,std::map<std::string,long>>)std::map<std::string,std::map<std::string,long>>({{\"A4\", std::map<std::string,long>({{\"DBMS\", 40}})}})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlong get_max_sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_max_sum;\n    assert(candidate((60)) == (106));\n    assert(candidate((10)) == (12));\n    assert(candidate((2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the vector with maximum length.\nstd::tuple<long, std::vector<long>> max_length_list(std::vector<std::vector<long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_length_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0}), (std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (std::make_tuple(3, std::vector<long>({(long)13, (long)15, (long)17}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1})}))) == (std::make_tuple(5, std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12})}))) == (std::make_tuple(4, std::vector<long>({(long)6, (long)7, (long)8, (long)9}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if given vector contains no duplicates.\nbool check_distinct(std::vector<long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_distinct;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6, (long)1, (long)4}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first non-repeated character in a given string.\nstd::optional<std::string> first_non_repeating_character(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = first_non_repeating_character;\n    assert(candidate((\"abcabc\")) == std::nullopt);\n    assert(candidate((\"abc\")) == \"a\");\n    assert(candidate((\"ababc\")) == \"c\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string starts and ends with the same character or not.\nstd::string check_char(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_char;\n    assert(candidate((\"abba\")) == (\"Valid\"));\n    assert(candidate((\"a\")) == (\"Valid\"));\n    assert(candidate((\"abcd\")) == (\"Invalid\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of three numbers.\nfloat median_numbers(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = median_numbers;\n    assert(candidate((25), (55), (65)) == (55.0f));\n    assert(candidate((20), (10), (30)) == (20.0f));\n    assert(candidate((15), (45), (75)) == (45.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the sum of digits of each number of a given vector.\nlong sum_of_digits(std::vector<std::any> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_of_digits;\n    assert(candidate((std::vector<std::any>({(long)10, (long)2, (long)56}))) == (14));\n    assert(candidate((std::vector<std::any>({(std::vector<long>)std::vector<std::any>({10, 20, 4, 5, \"b\", 70, \"a\"})}))) == (19));\n    assert(candidate((std::vector<std::any>({(long)10, (long)20, (long)-4, (long)5, (long)-70}))) == (19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nstd::tuple<long, long, long, long> bitwise_xor(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = bitwise_xor;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(15, 6, 5, 10)));\n    assert(candidate((std::make_tuple(11, 5, 7, 10)), (std::make_tuple(6, 3, 4, 4))) == (std::make_tuple(13, 6, 3, 14)));\n    assert(candidate((std::make_tuple(12, 6, 8, 11)), (std::make_tuple(7, 4, 5, 6))) == (std::make_tuple(11, 2, 13, 13)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to identify non-prime numbers.\nbool is_not_prime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_not_prime;\n    assert(candidate((2)) == (false));\n    assert(candidate((10)) == (true));\n    assert(candidate((35)) == (true));\n    assert(candidate((37)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the number of unique tuples in the given vector.\nlong extract_freq(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_freq;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(4, 3), (std::tuple<long, long>)std::make_tuple(5, 6)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 15), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(5, 4), (std::tuple<long, long>)std::make_tuple(6, 7)}))) == (4));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 16), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(6, 9)}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise addition of vector elements in the given two nested vectors.\nstd::vector<std::vector<long>> add_nested_tuples(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add_nested_tuples;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)10}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)8, (long)13})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)12}), (std::vector<long>)std::vector<long>({(long)9, (long)16}), (std::vector<long>)std::vector<long>({(long)5, (long)12}), (std::vector<long>)std::vector<long>({(long)10, (long)15})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)14}), (std::vector<long>)std::vector<long>({(long)11, (long)18}), (std::vector<long>)std::vector<long>({(long)7, (long)14}), (std::vector<long>)std::vector<long>({(long)12, (long)17})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum of two numbers.\nlong minimum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = minimum;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((-5), (-4)) == (-5));\n    assert(candidate((0), (0)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to check whether an element exists within a tuple.\nbool check_tuplex(std::vector<Union_std_string_long> tuplex, std::any tuple1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_tuplex;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"r\"))) == (true));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(\"5\"))) == (false));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"w\", (std::string)3, (std::string)\"r\", (std::string)\"e\", (std::string)\"s\", (std::string)\"o\", (std::string)\"u\", (std::string)\"r\", (std::string)\"c\", (std::string)\"e\"})), (std::any(3))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find whether the parity of a given number is odd.\nbool find_Parity(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Parity;\n    assert(candidate((12)) == (false));\n    assert(candidate((7)) == (true));\n    assert(candidate((10)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nstd::any rearrange_bigger(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rearrange_bigger;\n    assert(candidate((12)) == (std::any(21)));\n    assert(candidate((10)) == (std::any(false)));\n    assert(candidate((102)) == (std::any(120)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nstd::vector<std::vector<long>> k_smallest_pairs(std::vector<long> nums1, std::vector<long> nums2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = k_smallest_pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2})})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)7})), (std::vector<long>({(long)2, (long)4, (long)6})), (7)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)2})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the minimum product from the pairs of tuples within a given vector.\nlong min_product_tuple(std::vector<std::tuple<long, long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_product_tuple;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 7), (std::tuple<long, long>)std::make_tuple(2, 6), (std::tuple<long, long>)std::make_tuple(1, 8), (std::tuple<long, long>)std::make_tuple(4, 9)}))) == (8));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 20), (std::tuple<long, long>)std::make_tuple(15, 2), (std::tuple<long, long>)std::make_tuple(5, 10)}))) == (30));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(11, 44), (std::tuple<long, long>)std::make_tuple(10, 15), (std::tuple<long, long>)std::make_tuple(20, 5), (std::tuple<long, long>)std::make_tuple(12, 9)}))) == (100));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_long{\n    std::string f0;\n    long f1;    Union_std_string_long(std::string _f0) : f0(_f0) {}\n    Union_std_string_long(long _f1) : f1(_f1) {}\n    ~Union_std_string_long() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the minimum value in a given heterogeneous vector.\nlong min_val(std::vector<Union_std_string_long> listval) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_val;\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)3, (std::string)2, (std::string)4, (std::string)5, (std::string)\"version\"}))) == (2));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)15, (std::string)20, (std::string)25}))) == (15));\n    assert(candidate((std::vector<Union_std_string_long>({(std::string)\"Python\", (std::string)30, (std::string)20, (std::string)40, (std::string)50, (std::string)\"version\"}))) == (20));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given snake case string to camel case string.\nstd::string snake_to_camel(std::string word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = snake_to_camel;\n    assert(candidate((\"android_tv\")) == (\"AndroidTv\"));\n    assert(candidate((\"google_pixel\")) == (\"GooglePixel\"));\n    assert(candidate((\"apple_watch\")) == (\"AppleWatch\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove odd numbers from a given vector.\nstd::vector<long> remove_odd(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)2})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)6}))) == (std::vector<long>({(long)2, (long)4, (long)6})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)3}))) == (std::vector<long>({(long)10, (long)20})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the nth element from a given vector of tuples.\nstd::vector<std::any> extract_nth_element(std::vector<std::tuple<std::string, long, long>> list1, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_nth_element;\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (0)) == (std::vector<std::any>({(std::string)\"Greyson Fulton\", (std::string)\"Brady Kent\", (std::string)\"Wyatt Knott\", (std::string)\"Beau Turnbull\"})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (2)) == (std::vector<std::any>({(long)99, (long)96, (long)94, (long)98})));\n    assert(candidate((std::vector<std::tuple<std::string, long, long>>({(std::tuple<std::string, long, long>)std::make_tuple(\"Greyson Fulton\", 98, 99), (std::tuple<std::string, long, long>)std::make_tuple(\"Brady Kent\", 97, 96), (std::tuple<std::string, long, long>)std::make_tuple(\"Wyatt Knott\", 91, 94), (std::tuple<std::string, long, long>)std::make_tuple(\"Beau Turnbull\", 94, 98)})), (1)) == (std::vector<std::any>({(long)98, (long)97, (long)91, (long)94})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether any value in a sequence exists in a sequence or not.\nbool overlapping(std::vector<long> list1, std::vector<long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = overlapping;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)8, (long)9}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)4, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)5})), (std::vector<long>({(long)1, (long)4, (long)5}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find a pair with highest product from a given vector of integers.\nstd::tuple<long, long> max_Product(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_Product;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)0, (long)8, (long)4}))) == (std::make_tuple(7, 8)));\n    assert(candidate((std::vector<long>({(long)0, (long)-1, (long)-2, (long)-4, (long)5, (long)0, (long)-6}))) == (std::make_tuple(-4, -6)));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::make_tuple(2, 3)));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4744,7 +1720,7 @@
     "language": "cpp",
     "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find common first element in given vector of vectors.\nstd::vector<std::vector<std::string>> group_tuples(std::vector<std::vector<std::string>> Input) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "}\nint main() {\n    auto candidate = group_tuples;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"w\", (std::string)\"t\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"w\", (std::string)\"t\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"e\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"h\", (std::string)\"i\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"g\", (std::string)\"g\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"h\", (std::string)\"i\"})})));\n}\n",
     "stop_tokens": [
@@ -4752,13 +1728,3037 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "cpp",
-    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three vectors into a single sorted vector.\nstd::vector<long> merge_sorted_list(std::vector<long> num1, std::vector<long> num2, std::vector<long> num3) {\n",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the element of a vector having maximum length.\nstd::vector<std::any> Find_Max(std::vector<std::vector<std::any>> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "}\nint main() {\n    auto candidate = merge_sorted_list;\n    assert(candidate((std::vector<long>({(long)25, (long)24, (long)15, (long)4, (long)5, (long)29, (long)110})), (std::vector<long>({(long)19, (long)20, (long)11, (long)56, (long)25, (long)233, (long)154})), (std::vector<long>({(long)24, (long)26, (long)54, (long)48}))) == (std::vector<long>({(long)4, (long)5, (long)11, (long)15, (long)19, (long)20, (long)24, (long)24, (long)25, (long)25, (long)26, (long)29, (long)48, (long)54, (long)56, (long)110, (long)154, (long)233})));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)6, (long)8, (long)9})), (std::vector<long>({(long)2, (long)5, (long)7, (long)11})), (std::vector<long>({(long)1, (long)4, (long)7, (long)8, (long)12}))) == (std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)5, (long)5, (long)6, (long)7, (long)7, (long)8, (long)8, (long)9, (long)11, (long)12})));\n    assert(candidate((std::vector<long>({(long)18, (long)14, (long)10, (long)9, (long)8, (long)7, (long)9, (long)3, (long)2, (long)4, (long)1})), (std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58})), (std::vector<long>({(long)12, (long)74, (long)9, (long)50, (long)61, (long)41}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)7, (long)8, (long)9, (long)9, (long)9, (long)10, (long)12, (long)14, (long)14, (long)18, (long)22, (long)25, (long)25, (long)35, (long)41, (long)50, (long)58, (long)61, (long)65, (long)74, (long)75, (long)85})));\n}\n",
+    "tests": "}\nint main() {\n    auto candidate = Find_Max;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})}))) == (std::vector<std::any>({(std::string)\"A\", (std::string)\"B\", (std::string)\"C\"})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1, (long)2, (long)3})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)5, (long)6, (long)1})}))) == (std::vector<std::any>({(long)1, (long)5, (long)6, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_float_long{\n    float f0;\n    long f1;    Union_float_long(float _f0) : f0(_f0) {}\n    Union_float_long(long _f1) : f1(_f1) {}\n    ~Union_float_long() {}\n    bool operator==(float f) {\n        return f0 == f ;\n    }    bool operator==(long f) {\n        return f1 == f ;\n    }\n};\n// Write a function to round every number of a given vector of numbers and print the total sum multiplied by the length of the vector.\nlong round_and_sum(std::vector<Union_float_long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = round_and_sum;\n    assert(candidate((std::vector<Union_float_long>({(float)22.4f, (float)4.0f, (float)-16.22f, (float)-9.1f, (float)11.0f, (float)-12.22f, (float)14.2f, (float)-5.2f, (float)17.5f}))) == (243));\n    assert(candidate((std::vector<Union_float_long>({(long)5, (long)2, (long)9, (long)24.3f, (long)29}))) == (345));\n    assert(candidate((std::vector<Union_float_long>({(float)25.0f, (float)56.7f, (float)89.2f}))) == (513));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the cube sum of first n even natural numbers.\nlong cube_Sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = cube_Sum;\n    assert(candidate((2)) == (72));\n    assert(candidate((3)) == (288));\n    assert(candidate((4)) == (800));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to concatenate each element of tuple by the delimiter.\nstd::string concatenate_tuple(std::tuple<std::string, std::string, long, std::string> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = concatenate_tuple;\n    assert(candidate((std::make_tuple(\"ID\", \"is\", 4, \"UTS\"))) == (\"ID-is-4-UTS\"));\n    assert(candidate((std::make_tuple(\"QWE\", \"is\", 4, \"RTY\"))) == (\"QWE-is-4-RTY\"));\n    assert(candidate((std::make_tuple(\"ZEN\", \"is\", 4, \"OP\"))) == (\"ZEN-is-4-OP\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the average of cubes of first n natural numbers.\nfloat find_Average_Of_Cube(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Average_Of_Cube;\n    assert(candidate((2)) == (4.5f));\n    assert(candidate((3)) == (float(12)));\n    assert(candidate((1)) == (float(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract only the rear index element of each string in the given tuple.\nstd::vector<std::string> extract_rear(std::tuple<std::string, std::string, std::string> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_rear;\n    assert(candidate((std::make_tuple(\"Mers\", \"for\", \"Vers\"))) == (std::vector<std::string>({(std::string)\"s\", (std::string)\"r\", (std::string)\"s\"})));\n    assert(candidate((std::make_tuple(\"Avenge\", \"for\", \"People\"))) == (std::vector<std::string>({(std::string)\"e\", (std::string)\"r\", (std::string)\"e\"})));\n    assert(candidate((std::make_tuple(\"Gotta\", \"get\", \"go\"))) == (std::vector<std::string>({(std::string)\"a\", (std::string)\"t\", (std::string)\"o\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the number of subvectors containing a particular element.\nlong count_element_in_list(std::vector<std::vector<std::any>> list1, std::any x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_element_in_list;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)11}), (std::vector<long>)std::vector<long>({(long)1, (long)15, (long)7})})), (std::any(1))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"A\"))) == (3));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"B\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"C\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"A\", (std::string)\"D\", (std::string)\"E\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"B\", (std::string)\"C\", (std::string)\"D\"})})), (std::any(\"E\"))) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to filter odd numbers.\nstd::vector<long> filter_oddnumbers(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = filter_oddnumbers;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)45, (long)67, (long)84, (long)93}))) == (std::vector<long>({(long)45, (long)67, (long)93})));\n    assert(candidate((std::vector<long>({(long)5, (long)7, (long)9, (long)8, (long)6, (long)4, (long)3}))) == (std::vector<long>({(long)5, (long)7, (long)9, (long)3})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nstd::string change_date_format(std::string dt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = change_date_format;\n    assert(candidate((\"2026-01-02\")) == (\"02-01-2026\"));\n    assert(candidate((\"2020-11-13\")) == (\"13-11-2020\"));\n    assert(candidate((\"2021-04-26\")) == (\"26-04-2021\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given vector by using shell sort.\nstd::vector<long> shell_sort(std::vector<long> my_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = shell_sort;\n    assert(candidate((std::vector<long>({(long)12, (long)23, (long)4, (long)5, (long)3, (long)2, (long)12, (long)81, (long)56, (long)95}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)12, (long)12, (long)23, (long)56, (long)81, (long)95})));\n    assert(candidate((std::vector<long>({(long)24, (long)22, (long)39, (long)34, (long)87, (long)73, (long)68}))) == (std::vector<long>({(long)22, (long)24, (long)34, (long)39, (long)68, (long)73, (long)87})));\n    assert(candidate((std::vector<long>({(long)32, (long)30, (long)16, (long)96, (long)82, (long)83, (long)74}))) == (std::vector<long>({(long)16, (long)30, (long)32, (long)74, (long)82, (long)83, (long)96})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract the elementwise and tuples from the given two tuples.\nstd::tuple<long, long, long, long> and_tuples(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = and_tuples;\n    assert(candidate((std::make_tuple(10, 4, 6, 9)), (std::make_tuple(5, 2, 3, 3))) == (std::make_tuple(0, 0, 2, 1)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(5, 6, 7, 8))) == (std::make_tuple(1, 2, 3, 0)));\n    assert(candidate((std::make_tuple(8, 9, 11, 12)), (std::make_tuple(7, 13, 14, 17))) == (std::make_tuple(0, 9, 10, 0)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the directrix of a parabola.\nlong parabola_directrix(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = parabola_directrix;\n    assert(candidate((5), (3), (2)) == (-198));\n    assert(candidate((9), (8), (4)) == (-2336));\n    assert(candidate((2), (4), (6)) == (-130));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes two vectors and returns true if they have at least one common element.\nstd::optional<bool> common_element(std::vector<std::any> list1, std::vector<std::any> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = common_element;\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)5, (long)6, (long)7, (long)8, (long)9}))) == true);\n    assert(candidate((std::vector<std::any>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<std::any>({(long)6, (long)7, (long)8, (long)9}))) == std::nullopt);\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"})), (std::vector<std::any>({(std::string)\"d\", (std::string)\"b\", (std::string)\"e\"}))) == true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median length of a trapezium.\nfloat median_trapezium(long base1, long base2, long height) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = median_trapezium;\n    assert(candidate((15), (25), (35)) == (float(20)));\n    assert(candidate((10), (20), (30)) == (float(15)));\n    assert(candidate((6), (9), (4)) == (7.5f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the entered number is greater than the elements of the given vector.\nbool check_greater(std::vector<long> arr, long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_greater;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (4)) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6})), (8)) == (true));\n    assert(candidate((std::vector<long>({(long)9, (long)7, (long)4, (long)8, (long)6, (long)1})), (11)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by one or more b's.\nbool text_match_one(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last digit of a given number.\nlong last_Digit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = last_Digit;\n    assert(candidate((123)) == (3));\n    assert(candidate((25)) == (5));\n    assert(candidate((30)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to return the negative numbers in a vector.\nstd::vector<long> neg_nos(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = neg_nos;\n    assert(candidate((std::vector<long>({(long)-1, (long)4, (long)5, (long)-6}))) == (std::vector<long>({(long)-1, (long)-6})));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3, (long)4}))) == (std::vector<long>({(long)-1, (long)-2})));\n    assert(candidate((std::vector<long>({(long)-7, (long)-6, (long)8, (long)9}))) == (std::vector<long>({(long)-7, (long)-6})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove odd characters in a string.\nstd::string remove_odd(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_odd;\n    assert(candidate((\"python\")) == (\"yhn\"));\n    assert(candidate((\"program\")) == (\"rga\"));\n    assert(candidate((\"language\")) == (\"agae\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count bidirectional tuple pairs.\nlong count_bidirectional(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_bidirectional;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (3));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 3), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 1), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (2));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(9, 2), (std::tuple<long, long>)std::make_tuple(6, 5), (std::tuple<long, long>)std::make_tuple(2, 1)}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to join a vector of multiple integers into a single integer.\nlong multiple_to_single(std::vector<long> L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = multiple_to_single;\n    assert(candidate((std::vector<long>({(long)11, (long)33, (long)50}))) == (113350));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (-123456));\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25}))) == (10152025));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb and their positions in a given sentence.\nstd::tuple<long, long, std::string> find_adverb_position(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_adverb_position;\n    assert(candidate((\"clearly!! we can see the sky\")) == (std::make_tuple(0, 7, \"clearly\")));\n    assert(candidate((\"seriously!! there are many roses\")) == (std::make_tuple(0, 9, \"seriously\")));\n    assert(candidate((\"unfortunately!! sita is going to home\")) == (std::make_tuple(0, 13, \"unfortunately\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cube of a given size.\nlong surfacearea_cube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = surfacearea_cube;\n    assert(candidate((5)) == (150));\n    assert(candidate((3)) == (54));\n    assert(candidate((10)) == (600));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the ration of positive numbers in a vector of integers.\nfloat positive_count(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = positive_count;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.54f));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (0.69f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17}))) == (0.56f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the largest negative number from the given vector.\nlong largest_neg(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = largest_neg;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-4, (long)-6}))) == (-6));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)-8, (long)-9}))) == (-9));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)-1}))) == (-1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to trim each vector by k in the given vectors.\nstd::vector<std::vector<long>> trim_tuple(std::vector<std::vector<long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = trim_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (2)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)2})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)3, (long)2, (long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)9, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)9, (long)1, (long)2, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)8, (long)2, (long)1, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)4, (long)9, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)8, (long)2, (long)1})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)4, (long)9}), (std::vector<long>)std::vector<long>({(long)11, (long)8, (long)12, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)1, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)6, (long)9, (long)7})})), (1)) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)4}), (std::vector<long>)std::vector<long>({(long)8, (long)12}), (std::vector<long>)std::vector<long>({(long)1, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)9})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to perform index wise multiplication of vector elements in the given two vectors.\nstd::vector<std::vector<long>> index_multiplication(std::vector<std::vector<long>> test_tup1, std::vector<std::vector<long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = index_multiplication;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)10})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)3, (long)9}), (std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)7, (long)3})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)21}), (std::vector<long>)std::vector<long>({(long)12, (long)45}), (std::vector<long>)std::vector<long>({(long)2, (long)9}), (std::vector<long>)std::vector<long>({(long)7, (long)30})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)3, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)11})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)4, (long)10}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)8, (long)4})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)14, (long)32}), (std::vector<long>)std::vector<long>({(long)20, (long)60}), (std::vector<long>)std::vector<long>({(long)6, (long)20}), (std::vector<long>)std::vector<long>({(long)16, (long)44})})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)4, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)12})})), (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)5, (long)11}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)9, (long)5})}))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)24, (long)45}), (std::vector<long>)std::vector<long>({(long)30, (long)77}), (std::vector<long>)std::vector<long>({(long)12, (long)33}), (std::vector<long>)std::vector<long>({(long)27, (long)60})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the occurence of all elements of vector in a tuple.\nlong count_Occurrence(std::any tup, std::vector<std::any> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_Occurrence;\n    assert(candidate(std::make_tuple(\"a\", \"a\", \"c\", \"b\", \"d\"), (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\"}))) == (3));\n    assert(candidate(std::make_tuple(1, 2, 3, 1, 4, 6, 7, 1, 4), (std::vector<std::any>({(long)1, (long)4, (long)7}))) == (6));\n    assert(candidate(std::make_tuple(1, 2, 3, 4, 5, 6), (std::vector<std::any>({(long)1, (long)2}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find cubes of individual elements in a vector.\nstd::vector<long> cube_nums(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = cube_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)8, (long)27, (long)64, (long)125, (long)216, (long)343, (long)512, (long)729, (long)1000})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)1728, (long)3375})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the sum of perrin numbers.\nlong cal_sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = cal_sum;\n    assert(candidate((9)) == (49));\n    assert(candidate((10)) == (66));\n    assert(candidate((11)) == (88));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract specified size of strings from a given vector of string values.\nstd::vector<std::string> extract_string(std::vector<std::string> str, long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_string;\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (8)) == (std::vector<std::string>({(std::string)\"practice\", (std::string)\"solution\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (6)) == (std::vector<std::string>({(std::string)\"Python\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"Python\", (std::string)\"list\", (std::string)\"exercises\", (std::string)\"practice\", (std::string)\"solution\"})), (9)) == (std::vector<std::string>({(std::string)\"exercises\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from the given string.\nstd::string remove_whitespaces(std::string text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_whitespaces;\n    assert(candidate((\" Google    Flutter \")) == (\"GoogleFlutter\"));\n    assert(candidate((\" Google    Dart \")) == (\"GoogleDart\"));\n    assert(candidate((\" iOS    Swift \")) == (\"iOSSwift\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlong loss_amount(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = loss_amount;\n    assert(candidate((1500), (1200)) == (0));\n    assert(candidate((100), (200)) == (100));\n    assert(candidate((2000), (5000)) == (3000));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of even factors of a number.\nlong sumofFactors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sumofFactors;\n    assert(candidate((18)) == (26));\n    assert(candidate((30)) == (48));\n    assert(candidate((6)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a word containing 'z'.\nbool text_match_wordz(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_wordz;\n    assert(candidate((\"pythonz.\")) == (true));\n    assert(candidate((\"xyz.\")) == (true));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 31 days or not.\nbool check_monthnumb_number(long monthnum2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_monthnumb_number;\n    assert(candidate((5)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((6)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse each string in a given vector of string values.\nstd::vector<std::string> reverse_string_list(std::vector<std::string> stringlist) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = reverse_string_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"Red\", (std::string)\"Green\", (std::string)\"Blue\", (std::string)\"White\", (std::string)\"Black\"}))) == (std::vector<std::string>({(std::string)\"deR\", (std::string)\"neerG\", (std::string)\"eulB\", (std::string)\"etihW\", (std::string)\"kcalB\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"john\", (std::string)\"amal\", (std::string)\"joel\", (std::string)\"george\"}))) == (std::vector<std::string>({(std::string)\"nhoj\", (std::string)\"lama\", (std::string)\"leoj\", (std::string)\"egroeg\"})));\n    assert(candidate((std::vector<std::string>({(std::string)\"jack\", (std::string)\"john\", (std::string)\"mary\"}))) == (std::vector<std::string>({(std::string)\"kcaj\", (std::string)\"nhoj\", (std::string)\"yram\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the subvector having minimum length.\nstd::vector<std::any> Find_Min(std::vector<std::vector<std::any>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Find_Min;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3})}))) == (std::vector<std::any>({(long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)1, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)7, (long)8})}))) == (std::vector<std::any>({(long)1, (long)1})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"})}))) == (std::vector<std::any>({(std::string)\"x\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the area of a rectangle.\nlong rectangle_area(long l, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rectangle_area;\n    assert(candidate((10), (20)) == (200));\n    assert(candidate((10), (5)) == (50));\n    assert(candidate((4), (2)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uppercase substrings from a given string.\nstd::string remove_uppercase(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_uppercase;\n    assert(candidate((\"cAstyoUrFavoRitETVshoWs\")) == (\"cstyoravoitshos\"));\n    assert(candidate((\"wAtchTheinTernEtrAdIo\")) == (\"wtchheinerntrdo\"));\n    assert(candidate((\"VoicESeaRchAndreComMendaTionS\")) == (\"oiceachndreomendaion\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to get the first element of each subvector.\nstd::vector<long> Extract(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Extract;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)1, (long)3, (long)6})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (std::vector<long>({(long)1, (long)4})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)9, (long)8, (long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (std::vector<long>({(long)9, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the upper case characters in a given string.\nlong upper_ctr(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = upper_ctr;\n    assert(candidate((\"PYthon\")) == (1));\n    assert(candidate((\"BigData\")) == (1));\n    assert(candidate((\"program\")) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_vector_std_nullopt__std_vector_std_string_{\n    std::vector<std::nullopt> f0;\n    std::vector<std::string> f1;    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::nullopt> _f0) : f0(_f0) {}\n    Union_std_vector_std_nullopt__std_vector_std_string_(std::vector<std::string> _f1) : f1(_f1) {}\n    ~Union_std_vector_std_nullopt__std_vector_std_string_() {}\n    bool operator==(std::vector<std::nullopt> f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<std::string> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find all possible combinations of the elements of a given vector.\nstd::vector<Union_std_vector_std_nullopt__std_vector_std_string_> combinations_list(std::vector<std::string> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = combinations_list;\n    assert(candidate((std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\", (std::string)\"green\", (std::string)\"blue\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"orange\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\", (std::string)\"orange\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"blue\", (std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"white\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"red\"})})));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"black\", (std::string)\"orange\"}))) == (std::vector<Union_std_vector_std_nullopt__std_vector_std_string_>({std::vector<long>(), std::vector<std::string>({(std::string)\"red\"}), std::vector<std::string>({(std::string)\"green\"}), std::vector<std::string>({(std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"black\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"green\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"red\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\"}), std::vector<std::string>({(std::string)\"orange\", (std::string)\"black\", (std::string)\"green\", (std::string)\"red\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product subvector of the given vector.\nlong max_subarray_product(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_subarray_product;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)-3, (long)0, (long)7, (long)-8, (long)-2}))) == (112));\n    assert(candidate((std::vector<long>({(long)6, (long)-3, (long)-10, (long)0, (long)2}))) == (180));\n    assert(candidate((std::vector<long>({(long)-2, (long)-40, (long)0, (long)-2, (long)-3}))) == (80));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if all values are same in a map.\nbool check_value(std::map<std::string,long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_value;\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (10)) == (false));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (12)) == (true));\n    assert(candidate((std::map<std::string,long>({{\"Cierra Vega\", 12}, {\"Alden Cantrell\", 12}, {\"Kierra Gentry\", 12}, {\"Pierre Cox\", 12}})), (5)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to drop empty items from a given map.\nstd::map<std::string,std::string> drop_empty(std::map<std::string,std::optional<std::string>> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = drop_empty;\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    assert(candidate(std::map<std::string,std::string>({{\"c1\", \"Red\"}, {\"c2\", std::nullopt}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c1\", \"Red\"}})));\n    assert(candidate(std::map<std::string,std::nullopt>({{\"c1\", std::nullopt}, {\"c2\", \"Green\"}, {\"c3\", std::nullopt}})) == (std::map<std::string,std::string>({{\"c2\", \"Green\"}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nlong max_product(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_product;\n    assert(candidate((std::vector<long>({(long)3, (long)100, (long)4, (long)5, (long)150, (long)6}))) == (3000));\n    assert(candidate((std::vector<long>({(long)4, (long)42, (long)55, (long)68, (long)80}))) == (50265600));\n    assert(candidate((std::vector<long>({(long)10, (long)22, (long)9, (long)33, (long)21, (long)50, (long)41, (long)60}))) == (2460));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nstd::tuple<long, long, long, long> add_pairwise(std::tuple<long, long, long, long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add_pairwise;\n    assert(candidate((std::make_tuple(1, 5, 7, 8, 10))) == (std::make_tuple(6, 12, 15, 18)));\n    assert(candidate((std::make_tuple(2, 6, 8, 9, 11))) == (std::make_tuple(8, 14, 17, 20)));\n    assert(candidate((std::make_tuple(3, 7, 9, 10, 12))) == (std::make_tuple(10, 16, 19, 22)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the product of the vector multiplication modulo n.\nlong find_remainder(std::vector<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_remainder;\n    assert(candidate((std::vector<long>({(long)100, (long)10, (long)5, (long)25, (long)35, (long)14})), (11)) == (9));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (2)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given vector contains consecutive numbers or not.\nbool check_Consecutive(std::vector<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_Consecutive;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)6}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace characters in a string.\nstd::string replace_char(std::string str1, std::string ch, std::string newch) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_char;\n    assert(candidate((\"polygon\"), (\"y\"), (\"l\")) == (\"pollgon\"));\n    assert(candidate((\"character\"), (\"c\"), (\"a\")) == (\"aharaater\"));\n    assert(candidate((\"python\"), (\"l\"), (\"a\")) == (\"python\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a map by value.\nstd::vector<std::tuple<std::string, long>> sort_counter(std::map<std::string,long> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sort_counter;\n    assert(candidate((std::map<std::string,long>({{\"Math\", 81}, {\"Physics\", 83}, {\"Chemistry\", 87}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 87), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 83), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 81)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 400}, {\"Physics\", 300}, {\"Chemistry\", 250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Math\", 400), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 300), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 250)})));\n    assert(candidate((std::map<std::string,long>({{\"Math\", 900}, {\"Physics\", 1000}, {\"Chemistry\", 1250}}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 1250), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 1000), (std::tuple<std::string, long>)std::make_tuple(\"Math\", 900)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the largest and smallest value in a given vector.\nlong big_sum(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = big_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)-1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert the given string to lower case.\nstd::string is_lower(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_lower;\n    assert(candidate((\"InValid\")) == (\"invalid\"));\n    assert(candidate((\"TruE\")) == (\"true\"));\n    assert(candidate((\"SenTenCE\")) == (\"sentence\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove lowercase substrings from a given string.\nstd::string remove_lowercase(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_lowercase;\n    assert(candidate((\"PYTHon\")) == (\"PYTH\"));\n    assert(candidate((\"FInD\")) == (\"FID\"));\n    assert(candidate((\"STRinG\")) == (\"STRG\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first digit of a given number.\nlong first_Digit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = first_Digit;\n    assert(candidate((123)) == (1));\n    assert(candidate((456)) == (4));\n    assert(candidate((12)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the n largest integers from a given vector of numbers, returned in descending order.\nstd::vector<long> heap_queue_largest(std::vector<long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = heap_queue_largest;\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (3)) == (std::vector<long>({(long)85, (long)75, (long)65})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (2)) == (std::vector<long>({(long)85, (long)75})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)22, (long)58})), (5)) == (std::vector<long>({(long)85, (long)75, (long)65, (long)58, (long)35})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of integers and only returns the odd ones.\nstd::vector<long> Split(std::vector<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)3, (long)5})));\n    assert(candidate((std::vector<long>({(long)10, (long)11, (long)12, (long)13}))) == (std::vector<long>({(long)11, (long)13})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1}))) == (std::vector<long>({(long)7, (long)9, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlong difference(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = difference;\n    assert(candidate((3)) == (30));\n    assert(candidate((5)) == (210));\n    assert(candidate((2)) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of pairs whose xor value is odd.\nlong find_Odd_Pair(std::vector<long> A, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Odd_Pair;\n    assert(candidate((std::vector<long>({(long)5, (long)4, (long)7, (long)2, (long)1})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)2, (long)8, (long)1, (long)0, (long)5, (long)11})), (7)) == (12));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (3)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to toggle the case of all characters in a string.\nstd::string toggle_string(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = toggle_string;\n    assert(candidate((\"Python\")) == (\"pYTHON\"));\n    assert(candidate((\"Pangram\")) == (\"pANGRAM\"));\n    assert(candidate((\"LIttLE\")) == (\"liTTle\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the per-digit difference between two integers.\nlong digit_distance_nums(long n1, long n2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = digit_distance_nums;\n    assert(candidate((1), (2)) == (1));\n    assert(candidate((23), (56)) == (6));\n    assert(candidate((123), (256)) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the sum of the largest contiguous subvector in the given vector.\nlong max_sub_array_sum(std::vector<long> a, long size) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_sub_array_sum;\n    assert(candidate((std::vector<long>({(long)-2, (long)-3, (long)4, (long)-1, (long)-2, (long)1, (long)5, (long)-3})), (8)) == (7));\n    assert(candidate((std::vector<long>({(long)-3, (long)-4, (long)5, (long)-2, (long)-3, (long)2, (long)6, (long)-4})), (8)) == (8));\n    assert(candidate((std::vector<long>({(long)-4, (long)-5, (long)6, (long)-3, (long)-4, (long)3, (long)7, (long)-5})), (8)) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the union of the elements of two given vectors and output them in sorted order.\nstd::vector<long> union_elements(std::vector<long> test_tup1, std::vector<long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = union_elements;\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)6})), (std::vector<long>({(long)5, (long)7, (long)4, (long)10}))) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (std::vector<long>({(long)3, (long)4, (long)5, (long)6}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)11, (long)12, (long)13, (long)14})), (std::vector<long>({(long)13, (long)15, (long)16, (long)17}))) == (std::vector<long>({(long)11, (long)12, (long)13, (long)14, (long)15, (long)16, (long)17})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the longest subvectors.\nlong Find_Max_Length(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Find_Max_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)0, (long)1}), (std::vector<long>)std::vector<long>({(long)2, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)22, (long)23}), (std::vector<long>)std::vector<long>({(long)13, (long)14, (long)15}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50})}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks from a string.\nstd::vector<std::string> extract_values(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_values;\n    assert(candidate((\"\"Python\", \"PHP\", \"Java\"\")) == (std::vector<std::string>({(std::string)\"Python\", (std::string)\"PHP\", (std::string)\"Java\"})));\n    assert(candidate((\"\"python\",\"program\",\"language\"\")) == (std::vector<std::string>({(std::string)\"python\", (std::string)\"program\", (std::string)\"language\"})));\n    assert(candidate((\"\"red\",\"blue\",\"green\",\"yellow\"\")) == (std::vector<std::string>({(std::string)\"red\", (std::string)\"blue\", (std::string)\"green\", (std::string)\"yellow\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\nlong count_Pairs(std::vector<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_Pairs;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (4)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (5)) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to split a string into characters.\nstd::vector<std::string> split(std::string word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = split;\n    assert(candidate((\"python\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"y\", (std::string)\"t\", (std::string)\"h\", (std::string)\"o\", (std::string)\"n\"})));\n    assert(candidate((\"Name\")) == (std::vector<std::string>({(std::string)\"N\", (std::string)\"a\", (std::string)\"m\", (std::string)\"e\"})));\n    assert(candidate((\"program\")) == (std::vector<std::string>({(std::string)\"p\", (std::string)\"r\", (std::string)\"o\", (std::string)\"g\", (std::string)\"r\", (std::string)\"a\", (std::string)\"m\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the sum of the digits of a non-negative integer.\nlong sum_digits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_digits;\n    assert(candidate((345)) == (12));\n    assert(candidate((12)) == (3));\n    assert(candidate((97)) == (16));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a specified vector is sorted or not.\nbool issort_list(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = issort_list;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)16, (long)17}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)12, (long)14, (long)20, (long)17}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)6, (long)8, (long)10, (long)15, (long)14, (long)20}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a vector of N empty dictionaries.\nstd::vector<std::map<std::nullopt,std::nullopt>> empty_list(long length) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = empty_list;\n    assert(candidate((5)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((6)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n    assert(candidate((7)) == (std::vector<std::map<std::nullopt,std::nullopt>>({(std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>(), (std::map<long,long>)std::map<long,long>()})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort each subvector of strings in a given vector of vectors.\nstd::vector<std::vector<std::string>> sort_sublists(std::vector<std::vector<std::string>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sort_sublists;\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\", (std::string)\"black\", (std::string)\"orange\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"white\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\", (std::string)\"orange\", (std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"black\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"green\", (std::string)\"orange\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"white\"})})));\n    assert(candidate((std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"f\", (std::string)\"e\"})}))) == (std::vector<std::vector<std::string>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\", (std::string)\"d\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"g\", (std::string)\"h\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"e\", (std::string)\"f\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check if a given number is one less than twice its reverse.\nbool checks(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = checks;\n    assert(candidate((70)) == (false));\n    assert(candidate((23)) == (false));\n    assert(candidate((73)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to remove duplicate numbers from a given number of vectors.\nstd::vector<long> two_unique_nums(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = two_unique_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)2, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)3, (long)4, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to calculate the product of the unique numbers in a given vector.\nlong unique_product(std::vector<long> list_data) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = unique_product;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)20, (long)50, (long)60, (long)40}))) == (720000000));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1}))) == (6));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)0, (long)1, (long)1}))) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the surface area of a cylinder.\nfloat surfacearea_cylinder(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = surfacearea_cylinder;\n    assert(candidate((10), (5)) == (942.45f));\n    assert(candidate((4), (5)) == (226.18800000000002f));\n    assert(candidate((4), (10)) == (351.848f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether a vector is subvector of another or not.\nbool is_Sub_Array(std::vector<long> A, std::vector<long> B) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_Sub_Array;\n    assert(candidate((std::vector<long>({(long)1, (long)4, (long)3, (long)5})), (std::vector<long>({(long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1})), (std::vector<long>({(long)1, (long)2, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)2})), (std::vector<long>({(long)2, (long)2, (long)0}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last digit in factorial of a given number.\nlong last_Digit_Factorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = last_Digit_Factorial;\n    assert(candidate((4)) == (4));\n    assert(candidate((21)) == (0));\n    assert(candidate((30)) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to interleave 3 vectors of the same length into a single flat vector.\nstd::vector<long> interleave_lists(std::vector<long> list1, std::vector<long> list2, std::vector<long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = interleave_lists;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)10, (long)20, (long)30, (long)40, (long)50, (long)60, (long)70})), (std::vector<long>({(long)100, (long)200, (long)300, (long)400, (long)500, (long)600, (long)700}))) == (std::vector<long>({(long)1, (long)10, (long)100, (long)2, (long)20, (long)200, (long)3, (long)30, (long)300, (long)4, (long)40, (long)400, (long)5, (long)50, (long)500, (long)6, (long)60, (long)600, (long)7, (long)70, (long)700})));\n    assert(candidate((std::vector<long>({(long)10, (long)20})), (std::vector<long>({(long)15, (long)2})), (std::vector<long>({(long)5, (long)10}))) == (std::vector<long>({(long)10, (long)15, (long)5, (long)20, (long)2, (long)10})));\n    assert(candidate((std::vector<long>({(long)11, (long)44})), (std::vector<long>({(long)10, (long)15})), (std::vector<long>({(long)20, (long)5}))) == (std::vector<long>({(long)11, (long)10, (long)20, (long)44, (long)15, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the dissimilar elements in the given two tuples.\nstd::tuple<long, long, long, long> find_dissimilar(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_dissimilar;\n    assert(candidate((std::make_tuple(3, 4, 5, 6)), (std::make_tuple(5, 7, 4, 10))) == (std::make_tuple(3, 6, 7, 10)));\n    assert(candidate((std::make_tuple(1, 2, 3, 4)), (std::make_tuple(7, 2, 3, 9))) == (std::make_tuple(1, 4, 7, 9)));\n    assert(candidate((std::make_tuple(21, 11, 25, 26)), (std::make_tuple(26, 34, 21, 36))) == (std::make_tuple(34, 36, 11, 25)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the largest number that can be formed with the given vector of digits.\nlong find_Max_Num(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Max_Num;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (321));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)1}))) == (6541));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)9}))) == (9321));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove uneven elements in the nested mixed tuple.\nstd::any extract_even(std::tuple<long, long, std::tuple<long, long, std::tuple<long, long>>, long, long> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_even;\n    assert(candidate((std::make_tuple(4, 5, std::make_tuple(7, 6, std::make_tuple(2, 4)), 6, 8))) == std::make_tuple(4, std::make_tuple(6, std::make_tuple(2, 4)), 6, 8));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(8, 7, std::make_tuple(4, 8)), 7, 9))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 8))));\n    assert(candidate((std::make_tuple(5, 6, std::make_tuple(9, 8, std::make_tuple(4, 6)), 8, 10))) == std::make_tuple(6, std::make_tuple(8, std::make_tuple(4, 6)), 8, 10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the surface area of a square cppramid with a given base edge and height.\nlong surface_Area(long b, long s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = surface_Area;\n    assert(candidate((3), (4)) == (33));\n    assert(candidate((4), (5)) == (56));\n    assert(candidate((1), (2)) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which returns nth catalan number.\nlong catalan_number(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = catalan_number;\n    assert(candidate((10)) == (16796));\n    assert(candidate((9)) == (4862));\n    assert(candidate((7)) == (429));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nstd::string find_adverbs(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_adverbs;\n    assert(candidate((\"Clearly, he has no excuse for such behavior.\")) == (\"0-7: Clearly\"));\n    assert(candidate((\"Please handle the situation carefuly\")) == (\"28-36: carefuly\"));\n    assert(candidate((\"Complete the task quickly\")) == (\"18-25: quickly\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_std_string_float{\n    std::string f0;\n    float f1;    Union_std_string_float(std::string _f0) : f0(_f0) {}\n    Union_std_string_float(float _f1) : f1(_f1) {}\n    ~Union_std_string_float() {}\n    bool operator==(std::string f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the n most expensive items in a given dataset.\nstd::vector<std::map<std::string,Union_std_string_float>> expensive_items(std::vector<std::map<std::string,Union_std_string_float>> items, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = expensive_items;\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}})})), (2)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}})})));\n    assert(candidate((std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-1\"}, {\"price\", 101.1f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-3\"}, {\"price\", 45.09f}}), (std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-4\"}, {\"price\", 22.75f}})})), (1)) == (std::vector<std::map<std::string,Union_std_string_float>>({(std::map<std::string,std::string>)std::map<std::string,std::string>({{\"name\", \"Item-2\"}, {\"price\", 555.22f}})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to split a vector at the nth eelment and add the first part to the end.\nstd::vector<long> split_Arr(std::vector<long> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = split_Arr;\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)5, (long)6, (long)52, (long)36})), (2)) == (std::vector<long>({(long)5, (long)6, (long)52, (long)36, (long)12, (long)10})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4})), (1)) == (std::vector<long>({(long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})), (3)) == (std::vector<long>({(long)3, (long)4, (long)5, (long)6, (long)7, (long)0, (long)1, (long)2})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert a vector to a tuple.\nstd::any list_tuple(std::vector<long> listx) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = list_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)10, (long)7, (long)4, (long)15, (long)3}))) == std::make_tuple(5, 10, 7, 4, 15, 3));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)2, (long)3, (long)4, (long)4, (long)7}))) == std::make_tuple(2, 4, 5, 6, 2, 3, 4, 4, 7));\n    assert(candidate((std::vector<long>({(long)58, (long)44, (long)56}))) == std::make_tuple(58, 44, 56));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the difference between largest and smallest value in a given vector.\nlong big_diff(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = big_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (3));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)12}))) == (8));\n    assert(candidate((std::vector<long>({(long)9, (long)2, (long)3}))) == (7));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find perfect squares between two given numbers.\nstd::vector<long> perfect_squares(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = perfect_squares;\n    assert(candidate((1), (30)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25})));\n    assert(candidate((50), (100)) == (std::vector<long>({(long)64, (long)81, (long)100})));\n    assert(candidate((100), (200)) == (std::vector<long>({(long)100, (long)121, (long)144, (long)169, (long)196})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given two integers have opposite sign or not.\nbool opposite_Signs(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = opposite_Signs;\n    assert(candidate((1), (-2)) == (true));\n    assert(candidate((3), (2)) == (false));\n    assert(candidate((-10), (-10)) == (false));\n    assert(candidate((-2), (2)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to interchange the first and last elements in a vector.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)12, (long)35, (long)9, (long)56, (long)24}))) == (std::vector<long>({(long)24, (long)35, (long)9, (long)56, (long)12})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of the product of consecutive binomial co-efficients.\nlong sum_Of_product(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_Of_product;\n    assert(candidate((3)) == (15));\n    assert(candidate((4)) == (56));\n    assert(candidate((1)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove leading zeroes from an ip address.\nstd::string removezero_ip(std::string ip) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = removezero_ip;\n    assert(candidate((\"216.08.094.196\")) == (\"216.8.94.196\"));\n    assert(candidate((\"12.01.024\")) == (\"12.1.24\"));\n    assert(candidate((\"216.08.094.0196\")) == (\"216.8.94.196\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the difference of the first even and first odd number of a given vector.\nlong diff_even_odd(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = diff_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nstd::any min_Swaps(std::string str1, std::string str2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_Swaps;\n    assert(candidate((\"1101\"), (\"1110\")) == (std::any(1)));\n    assert(candidate((\"111\"), (\"000\")) == (std::any(\"Not Possible\")));\n    assert(candidate((\"111\"), (\"110\")) == (std::any(\"Not Possible\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find kth element from the given two sorted vectors.\nlong find_kth(std::vector<long> arr1, std::vector<long> arr2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_kth;\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)6, (long)7, (long)9})), (std::vector<long>({(long)1, (long)4, (long)8, (long)10})), (5)) == (6));\n    assert(candidate((std::vector<long>({(long)100, (long)112, (long)256, (long)349, (long)770})), (std::vector<long>({(long)72, (long)86, (long)113, (long)119, (long)265, (long)445, (long)892})), (7)) == (256));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)7, (long)8, (long)10})), (std::vector<long>({(long)2, (long)5, (long)9, (long)11})), (6)) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is armstrong or not.\nbool armstrong_number(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = armstrong_number;\n    assert(candidate((153)) == (true));\n    assert(candidate((259)) == (false));\n    assert(candidate((4458)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find sum and average of first n natural numbers.\nstd::tuple<long, float> sum_average(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_average;\n    assert(candidate((10)) == (std::make_tuple(55, 5.5f)));\n    assert(candidate((15)) == (std::make_tuple(120, 8.0f)));\n    assert(candidate((20)) == (std::make_tuple(210, 10.5f)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth octagonal number.\nlong is_octagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_octagonal;\n    assert(candidate((5)) == (65));\n    assert(candidate((10)) == (280));\n    assert(candidate((15)) == (645));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number is even or not.\nbool is_Even(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_Even;\n    assert(candidate((1)) == (false));\n    assert(candidate((2)) == (true));\n    assert(candidate((3)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first repeated character in a given string.\nstd::optional<std::string> first_repeated_char(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = first_repeated_char;\n    assert(candidate((\"abcabc\")) == \"a\");\n    assert(candidate((\"abc\")) == std::nullopt);\n    assert(candidate((\"123123\")) == \"1\");\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nstd::vector<long> get_ludic(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_ludic;\n    assert(candidate((10)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7})));\n    assert(candidate((25)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25})));\n    assert(candidate((45)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)5, (long)7, (long)11, (long)13, (long)17, (long)23, (long)25, (long)29, (long)37, (long)41, (long)43})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to reverse words seperated by spaces in a given string.\nstd::string reverse_words(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = reverse_words;\n    assert(candidate((\"python program\")) == (\"program python\"));\n    assert(candidate((\"java language\")) == (\"language java\"));\n    assert(candidate((\"indian man\")) == (\"man indian\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given integer is a prime number.\nbool prime_num(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = prime_num;\n    assert(candidate((13)) == (true));\n    assert(candidate((7)) == (true));\n    assert(candidate((-1010)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert degrees to radians.\nfloat radian_degree(long degree) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = radian_degree;\n    assert(candidate((90)) == (1.5707963267948966f));\n    assert(candidate((60)) == (1.0471975511965976f));\n    assert(candidate((120)) == (2.0943951023931953f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nstd::tuple<std::string, long, long> find_literals(std::string text, std::string pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_literals;\n    assert(candidate((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")) == (std::make_tuple(\"fox\", 16, 19)));\n    assert(candidate((\"Its been a very crazy procedure right\"), (\"crazy\")) == (std::make_tuple(\"crazy\", 16, 21)));\n    assert(candidate((\"Hardest choices required strongest will\"), (\"will\")) == (std::make_tuple(\"will\", 35, 39)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find nth bell number.\nlong bell_Number(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = bell_Number;\n    assert(candidate((2)) == (2));\n    assert(candidate((3)) == (5));\n    assert(candidate((4)) == (15));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\nstd::vector<long> remove_kth_element(std::vector<long> list1, long L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_kth_element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)1})), (3)) == (std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)4, (long)5, (long)1})));\n    assert(candidate((std::vector<long>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})), (4)) == (std::vector<long>({(long)0, (long)0, (long)1, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4})));\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})), (5)) == (std::vector<long>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\nlong max_of_nth(std::vector<std::vector<long>> test_list, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_of_nth;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)9, (long)19})})), (2)) == (19));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)20})})), (1)) == (10));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)21})})), (1)) == (11));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function which takes a vector of vectors, where each subvector has two elements, and returns a vector of two vectors where the first vector has the first element of each subvector and the second one has the second.\nstd::vector<std::vector<std::any>> merge(std::vector<std::vector<std::any>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = merge;\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8})}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)1, (long)3, (long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)4, (long)6, (long)8})})));\n    assert(candidate((std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"y\", (std::string)\"z\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"m\", (std::string)\"n\", (std::string)\"o\"})}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"x\", (std::string)\"a\", (std::string)\"m\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"y\", (std::string)\"b\", (std::string)\"n\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"z\", (std::string)\"c\", (std::string)\"o\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the cumulative sum of all the values that are present in the given vector of vectors.\nlong cummulative_sum(std::vector<std::vector<long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = cummulative_sum;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7}), (std::vector<long>)std::vector<long>({(long)2, (long)6})}))) == (30));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)3, (long)7})}))) == (37));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)8})}))) == (44));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\nstd::vector<float> average_tuple(std::vector<std::vector<long>> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = average_tuple;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)10, (long)10, (long)10, (long)12}), (std::vector<long>)std::vector<long>({(long)30, (long)45, (long)56, (long)45}), (std::vector<long>)std::vector<long>({(long)81, (long)80, (long)39, (long)32}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (std::vector<float>({(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)1, (long)-5}), (std::vector<long>)std::vector<long>({(long)30, (long)-15, (long)56}), (std::vector<long>)std::vector<long>({(long)81, (long)-60, (long)-39}), (std::vector<long>)std::vector<long>({(long)-10, (long)2, (long)3})}))) == (std::vector<float>({(float)25.5f, (float)-18.0f, (float)3.75f})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)100, (long)100, (long)100, (long)120}), (std::vector<long>)std::vector<long>({(long)300, (long)450, (long)560, (long)450}), (std::vector<long>)std::vector<long>({(long)810, (long)800, (long)390, (long)320}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::vector<float>({(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nstd::tuple<long, long, long, long> tuple_modulo(std::tuple<long, long, long, long> test_tup1, std::tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tuple_modulo;\n    assert(candidate((std::make_tuple(10, 4, 5, 6)), (std::make_tuple(5, 6, 7, 5))) == (std::make_tuple(0, 4, 5, 1)));\n    assert(candidate((std::make_tuple(11, 5, 6, 7)), (std::make_tuple(6, 7, 8, 6))) == (std::make_tuple(5, 5, 6, 1)));\n    assert(candidate((std::make_tuple(12, 6, 7, 8)), (std::make_tuple(7, 8, 9, 7))) == (std::make_tuple(5, 6, 7, 1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfloat min_Jumps(std::tuple<long, long> steps, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_Jumps;\n    assert(candidate((std::make_tuple(3, 4)), (11)) == (3.5f));\n    assert(candidate((std::make_tuple(3, 4)), (0)) == (float(0)));\n    assert(candidate((std::make_tuple(11, 14)), (11)) == (float(1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to divide two vectors element wise.\nstd::vector<float> div_list(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = div_list;\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6})), (std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<float>({(float)4.0f, (float)2.5f, (float)2.0f})));\n    assert(candidate((std::vector<long>({(long)3, (long)2})), (std::vector<long>({(long)1, (long)4}))) == (std::vector<float>({(float)3.0f, (float)0.5f})));\n    assert(candidate((std::vector<long>({(long)90, (long)120})), (std::vector<long>({(long)50, (long)70}))) == (std::vector<float>({(float)1.8f, (float)1.7142857142857142f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to move all the numbers to the end of the given string.\nstd::string move_num(std::string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = move_num;\n    assert(candidate((\"I1love143you55three3000thousand\")) == (\"Iloveyouthreethousand1143553000\"));\n    assert(candidate((\"Avengers124Assemble\")) == (\"AvengersAssemble124\"));\n    assert(candidate((\"Its11our12path13to14see15things16do17things\")) == (\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of substrings with the sum of digits equal to their length.\nlong count_Substrings(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_Substrings;\n    assert(candidate((\"112112\")) == (6));\n    assert(candidate((\"111\")) == (6));\n    assert(candidate((\"1101112\")) == (12));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the median of two sorted vectors of same size.\nfloat get_median(std::vector<long> arr1, std::vector<long> arr2, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_median;\n    assert(candidate((std::vector<long>({(long)1, (long)12, (long)15, (long)26, (long)38})), (std::vector<long>({(long)2, (long)13, (long)17, (long)30, (long)45})), (5)) == (16.0f));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)8, (long)9})), (std::vector<long>({(long)7, (long)13, (long)19, (long)28})), (4)) == (8.5f));\n    assert(candidate((std::vector<long>({(long)3, (long)6, (long)14, (long)23, (long)36, (long)42})), (std::vector<long>({(long)2, (long)18, (long)27, (long)39, (long)49, (long)55})), (6)) == (25.0f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to compute the n-th power of each number in a vector.\nstd::vector<long> nth_nums(std::vector<long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = nth_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (3)) == (std::vector<long>({(long)1000, (long)8000, (long)27000})));\n    assert(candidate((std::vector<long>({(long)12, (long)15})), (5)) == (std::vector<long>({(long)248832, (long)759375})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to convert a given string to uppercase.\nstd::string is_upper(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_upper;\n    assert(candidate((\"person\")) == (\"PERSON\"));\n    assert(candidate((\"final\")) == (\"FINAL\"));\n    assert(candidate((\"Valid\")) == (\"VALID\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to interchange the first and last element in a given vector.\nstd::vector<long> swap_List(std::vector<long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = swap_List;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (std::vector<long>({(long)3, (long)2, (long)1})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)4}))) == (std::vector<long>({(long)4, (long)2, (long)3, (long)4, (long)1})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6}))) == (std::vector<long>({(long)6, (long)5, (long)4})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nstd::optional<long> triangle_area(long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = triangle_area;\n    assert(candidate((-1)) == std::nullopt);\n    assert(candidate((0)) == 0);\n    assert(candidate((2)) == 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the smallest missing number from a sorted vector of natural numbers.\nlong find_First_Missing(std::vector<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_First_Missing;\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)3}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)6, (long)9}))) == (3));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)8, (long)9}))) == (0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all spaces in the given string with '%20'.\nstd::string replace_spaces(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"My Name is Dawood\")) == (\"My%20Name%20is%20Dawood\"));\n    assert(candidate((\"I am a Programmer\")) == (\"I%20am%20a%20Programmer\"));\n    assert(candidate((\"I love Coding\")) == (\"I%20love%20Coding\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find even numbers from a vector of numbers.\nstd::vector<long> Split(std::vector<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Split;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (std::vector<long>({(long)2, (long)4})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7, (long)8, (long)0, (long)1}))) == (std::vector<long>({(long)4, (long)6, (long)8, (long)0})));\n    assert(candidate((std::vector<long>({(long)8, (long)12, (long)15, (long)19}))) == (std::vector<long>({(long)8, (long)12})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find smallest number in a vector.\nlong smallest_num(std::vector<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = smallest_num;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)1, (long)45, (long)99}))) == (1));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)45, (long)46, (long)50, (long)60}))) == (45));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nstd::vector<std::vector<long>> get_coordinates(std::tuple<long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_coordinates;\n    assert(candidate((std::make_tuple(3, 4))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)2, (long)4}), (std::vector<long>)std::vector<long>({(long)2, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5})})));\n    assert(candidate((std::make_tuple(4, 5))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)3, (long)5}), (std::vector<long>)std::vector<long>({(long)3, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6})})));\n    assert(candidate((std::make_tuple(5, 6))) == (std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)4, (long)6}), (std::vector<long>)std::vector<long>({(long)4, (long)7}), (std::vector<long>)std::vector<long>({(long)5, (long)5}), (std::vector<long>)std::vector<long>({(long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)6, (long)7})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nstd::string replace_spaces(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_spaces;\n    assert(candidate((\"Jumanji The Jungle\")) == (\"Jumanji_The_Jungle\"));\n    assert(candidate((\"The_Avengers\")) == (\"The Avengers\"));\n    assert(candidate((\"Fast and Furious\")) == (\"Fast_and_Furious\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to move all zeroes to the end of the given vector.\nstd::vector<long> move_zero(std::vector<long> num_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = move_zero;\n    assert(candidate((std::vector<long>({(long)1, (long)0, (long)2, (long)0, (long)3, (long)4}))) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)0, (long)0, (long)4, (long)0, (long)5, (long)0}))) == (std::vector<long>({(long)2, (long)3, (long)2, (long)4, (long)5, (long)0, (long)0, (long)0, (long)0})));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)0, (long)1, (long)1}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)0, (long)0})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of xor of all pairs of numbers in the given vector.\nlong pair_xor_Sum(std::vector<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pair_xor_Sum;\n    assert(candidate((std::vector<long>({(long)5, (long)9, (long)7, (long)6})), (4)) == (47));\n    assert(candidate((std::vector<long>({(long)7, (long)3, (long)5})), (3)) == (12));\n    assert(candidate((std::vector<long>({(long)7, (long)3})), (2)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort the given vector.\nstd::vector<long> heap_sort(std::vector<long> iterable) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = heap_sort;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)9, (long)2, (long)4, (long)6, (long)8, (long)0}))) == (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9})));\n    assert(candidate((std::vector<long>({(long)25, (long)35, (long)22, (long)85, (long)14, (long)65, (long)75, (long)25, (long)58}))) == (std::vector<long>({(long)14, (long)22, (long)25, (long)25, (long)35, (long)58, (long)65, (long)75, (long)85})));\n    assert(candidate((std::vector<long>({(long)7, (long)1, (long)9, (long)5}))) == (std::vector<long>({(long)1, (long)5, (long)7, (long)9})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given amount has no profit and no loss\nbool noprofit_noloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = noprofit_noloss;\n    assert(candidate((1500), (1200)) == (false));\n    assert(candidate((100), (100)) == (true));\n    assert(candidate((2000), (5000)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlong wind_chill(long v, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = wind_chill;\n    assert(candidate((120), (35)) == (40));\n    assert(candidate((40), (20)) == (19));\n    assert(candidate((10), (8)) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\nlong sample_nam(std::vector<std::string> sample_names) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sample_nam;\n    assert(candidate((std::vector<std::string>({(std::string)\"sally\", (std::string)\"Dylan\", (std::string)\"rebecca\", (std::string)\"Diana\", (std::string)\"Joanne\", (std::string)\"keith\"}))) == (16));\n    assert(candidate((std::vector<std::string>({(std::string)\"php\", (std::string)\"res\", (std::string)\"Python\", (std::string)\"abcd\", (std::string)\"Java\", (std::string)\"aaa\"}))) == (10));\n    assert(candidate((std::vector<std::string>({(std::string)\"abcd\", (std::string)\"Python\", (std::string)\"abba\", (std::string)\"aba\"}))) == (6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the maximum difference between available pairs in the given tuple vector.\nlong max_difference(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_difference;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(1, 7), (std::tuple<long, long>)std::make_tuple(10, 3), (std::tuple<long, long>)std::make_tuple(1, 2)}))) == (7));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(2, 17), (std::tuple<long, long>)std::make_tuple(9, 13), (std::tuple<long, long>)std::make_tuple(11, 12)}))) == (15));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 35), (std::tuple<long, long>)std::make_tuple(21, 27), (std::tuple<long, long>)std::make_tuple(13, 23), (std::tuple<long, long>)std::make_tuple(41, 22)}))) == (23));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nstd::string remove_parenthesis(std::vector<std::string> items) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_parenthesis;\n    assert(candidate((std::vector<std::string>({(std::string)\"python (chrome)\"}))) == (\"python\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"string(.abc)\"}))) == (\"string\"));\n    assert(candidate((std::vector<std::string>({(std::string)\"alpha(num)\"}))) == (\"alpha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth nonagonal number.\nlong is_nonagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_nonagonal;\n    assert(candidate((10)) == (325));\n    assert(candidate((15)) == (750));\n    assert(candidate((18)) == (1089));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nbool text_match_wordz_middle(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_wordz_middle;\n    assert(candidate((\"pythonzabc.\")) == (true));\n    assert(candidate((\"zxyabc.\")) == (false));\n    assert(candidate((\"  lang  .\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to reverse a vector upto a given position.\nstd::vector<long> reverse_Array_Upto_K(std::vector<long> input, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = reverse_Array_Upto_K;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (4)) == (std::vector<long>({(long)4, (long)3, (long)2, (long)1, (long)5, (long)6})));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)6, (long)7})), (2)) == (std::vector<long>({(long)5, (long)4, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)9, (long)8, (long)7, (long)6, (long)5})), (3)) == (std::vector<long>({(long)7, (long)8, (long)9, (long)6, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of tuples using the second value of each tuple.\nstd::vector<std::tuple<std::string, long>> subject_marks(std::vector<std::tuple<std::string, long>> subjectmarks) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = subject_marks;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social sciences\", 82), (std::tuple<std::string, long>)std::make_tuple(\"English\", 88), (std::tuple<std::string, long>)std::make_tuple(\"Science\", 90), (std::tuple<std::string, long>)std::make_tuple(\"Maths\", 97)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54), (std::tuple<std::string, long>)std::make_tuple(\"Social\", 33)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Social\", 33), (std::tuple<std::string, long>)std::make_tuple(\"Telugu\", 49), (std::tuple<std::string, long>)std::make_tuple(\"Hindhi\", 54)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97), (std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45)}))) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Biology\", 45), (std::tuple<std::string, long>)std::make_tuple(\"Physics\", 96), (std::tuple<std::string, long>)std::make_tuple(\"Chemistry\", 97)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_std_vector_long_{\n    long f0;\n    std::vector<long> f1;    Union_long_std_vector_long_(long _f0) : f0(_f0) {}\n    Union_long_std_vector_long_(std::vector<long> _f1) : f1(_f1) {}\n    ~Union_long_std_vector_long_() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(std::vector<long> f) {\n        return f1 == f ;\n    }\n};\n// Write a function to flatten a vector and sum all of its elements.\nlong recursive_list_sum(std::vector<Union_long_std_vector_long_> data_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = recursive_list_sum;\n    assert(candidate((std::vector<Union_long_std_vector_long_>({1, 2, std::vector<long>({(long)3, (long)4}), std::vector<long>({(long)5, (long)6})}))) == (21));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({7, 10, std::vector<long>({(long)15, (long)14}), std::vector<long>({(long)19, (long)41})}))) == (106));\n    assert(candidate((std::vector<Union_long_std_vector_long_>({10, 20, std::vector<long>({(long)30, (long)40}), std::vector<long>({(long)50, (long)60})}))) == (210));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of positive numbers in a vector.\nlong pos_count(std::vector<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pos_count;\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3, (long)-4}))) == (2));\n    assert(candidate((std::vector<long>({(long)3, (long)4, (long)5, (long)-1}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the number of ways to partition a set of Bell numbers.\nlong bell_number(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = bell_number;\n    assert(candidate((2)) == (2));\n    assert(candidate((10)) == (115975));\n    assert(candidate((56)) == (6775685320645824322581483068371419745979053216268760300));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given vector is monotonic or not.\nbool is_Monotonic(std::vector<long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_Monotonic;\n    assert(candidate((std::vector<long>({(long)6, (long)5, (long)4, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a vector contains the given subvector or not.\nbool is_sublist(std::vector<long> l, std::vector<long> s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_sublist;\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)3, (long)7}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)4, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)3, (long)5, (long)7})), (std::vector<long>({(long)1, (long)6}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the two numbers differ at one bit position only or not.\nbool differ_At_One_Bit_Pos(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = differ_At_One_Bit_Pos;\n    assert(candidate((13), (9)) == (true));\n    assert(candidate((15), (8)) == (false));\n    assert(candidate((2), (4)) == (false));\n    assert(candidate((2), (3)) == (true));\n    assert(candidate((5), (1)) == (true));\n    assert(candidate((1), (5)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find whether all the given vectors have equal length or not.\nbool get_equal(std::vector<std::vector<long>> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_equal;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)11, (long)22, (long)33}), (std::vector<long>)std::vector<long>({(long)44, (long)55, (long)66})}))) == (true));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)7})}))) == (false));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)3, (long)4})}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a vector of elements.\nstd::vector<long> comb_sort(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = comb_sort;\n    assert(candidate((std::vector<long>({(long)5, (long)15, (long)37, (long)25, (long)79}))) == (std::vector<long>({(long)5, (long)15, (long)25, (long)37, (long)79})));\n    assert(candidate((std::vector<long>({(long)41, (long)32, (long)15, (long)19, (long)22}))) == (std::vector<long>({(long)15, (long)19, (long)22, (long)32, (long)41})));\n    assert(candidate((std::vector<long>({(long)99, (long)15, (long)13, (long)47}))) == (std::vector<long>({(long)13, (long)15, (long)47, (long)99})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add a map to the tuple. The output should be a tuple.\nstd::tuple<long, long, long, std::map<std::string,long>> add_dict_to_tuple(std::tuple<long, long, long> test_tup, std::map<std::string,long> test_dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add_dict_to_tuple;\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))) == (std::make_tuple(4, 5, 6, std::map<std::string,long>({{\"MSAM\", 1}, {\"is\", 2}, {\"best\", 3}}))));\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))) == (std::make_tuple(1, 2, 3, std::map<std::string,long>({{\"UTS\", 2}, {\"is\", 3}, {\"Worst\", 4}}))));\n    assert(candidate((std::make_tuple(8, 9, 10)), (std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))) == (std::make_tuple(8, 9, 10, std::map<std::string,long>({{\"POS\", 3}, {\"is\", 4}, {\"Okay\", 5}}))));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfloat maxAverageOfPath(std::vector<std::vector<long>> cost) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = maxAverageOfPath;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)3, (long)9})}))) == (5.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)7, (long)6, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)4, (long)10})}))) == (6.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)4, (long)5}), (std::vector<long>)std::vector<long>({(long)8, (long)7, (long)6}), (std::vector<long>)std::vector<long>({(long)9, (long)5, (long)11})}))) == (7.2f));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (5.8f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is given as - a map with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nstd::map<std::string,std::tuple<float, long>> filter_data(std::map<std::string,std::tuple<float, long>> students, float h, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = filter_data;\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (6.0f), (70)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.9f), (67)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}})));\n    assert(candidate((std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})), (5.7f), (64)) == (std::map<std::string,std::tuple<float, long>>({{\"Cierra Vega\", std::make_tuple(6.2f, 70)}, {\"Alden Cantrell\", std::make_tuple(5.9f, 65)}, {\"Kierra Gentry\", std::make_tuple(6.0f, 68)}, {\"Pierre Cox\", std::make_tuple(5.8f, 66)}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// The input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\nlong count_same_pair(std::vector<long> nums1, std::vector<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_same_pair;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})), (std::vector<long>({(long)2, (long)2, (long)3, (long)1, (long)2, (long)6, (long)7, (long)9}))) == (4));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)0, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (11));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)-6, (long)-9, (long)11, (long)-12, (long)14, (long)-5, (long)17})), (std::vector<long>({(long)2, (long)1, (long)2, (long)-1, (long)-5, (long)6, (long)4, (long)-3, (long)-2, (long)3, (long)4, (long)6, (long)8}))) == (1));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)1, (long)2})), (std::vector<long>({(long)0, (long)1, (long)2, (long)2}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlong power_base_sum(long base, long power) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = power_base_sum;\n    assert(candidate((2), (100)) == (115));\n    assert(candidate((8), (10)) == (37));\n    assert(candidate((8), (15)) == (62));\n    assert(candidate((3), (3)) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to extract values between quotation marks \" \" of the given string.\nstd::vector<std::any> extract_quotation(std::string text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_quotation;\n    assert(candidate((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")) == (std::vector<std::any>({(std::string)\"A53\", (std::string)\"multi\", (std::string)\"Processor\"})));\n    assert(candidate((\"Cast your \"favorite\" entertainment \"apps\"\")) == (std::vector<std::any>({(std::string)\"favorite\", (std::string)\"apps\"})));\n    assert(candidate((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")) == (std::vector<std::any>({(std::string)\"4k Ultra HD\", (std::string)\"HDR 10\"})));\n    assert(candidate((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that takes as input a vector of numbers (t_1,...,t_{N+1}) and returns a vector of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nstd::vector<std::any> multiply_elements(std::vector<long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = multiply_elements;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)8, (long)10}))) == (std::vector<std::any>({(long)5, (long)35, (long)56, (long)80})));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)5, (long)6, (long)7}))) == (std::vector<std::any>({(long)8, (long)20, (long)30, (long)42})));\n    assert(candidate((std::vector<long>({(long)12, (long)13, (long)14, (long)9, (long)15}))) == (std::vector<std::any>({(long)156, (long)182, (long)126, (long)135})));\n    assert(candidate((std::vector<long>({(long)12}))) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nstd::vector<long> sum_list(std::vector<long> lst1, std::vector<long> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_list;\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30})), (std::vector<long>({(long)15, (long)25, (long)35}))) == (std::vector<long>({(long)25, (long)45, (long)65})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)5, (long)6, (long)7}))) == (std::vector<long>({(long)6, (long)8, (long)10})));\n    assert(candidate((std::vector<long>({(long)15, (long)20, (long)30})), (std::vector<long>({(long)15, (long)45, (long)75}))) == (std::vector<long>({(long)30, (long)65, (long)105})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the given number can be represented as the difference of two squares or not.\nbool dif_Square(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = dif_Square;\n    assert(candidate((5)) == (true));\n    assert(candidate((10)) == (false));\n    assert(candidate((15)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove consecutive duplicates of a given vector.\nstd::vector<std::any> consecutive_duplicates(std::vector<std::any> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::any>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)4})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::any>({(long)10, (long)15, (long)19, (long)18, (long)17, (long)26, (long)17, (long)18, (long)10})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\"})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\", (std::string)\"a\", (std::string)\"a\"}))) == (std::vector<std::any>({(std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"a\"})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfloat lateralsurface_cone(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = lateralsurface_cone;\n    assert(candidate((5), (12)) == (204.20352248333654f));\n    assert(candidate((10), (15)) == (566.3586699569488f));\n    assert(candidate((19), (17)) == (1521.8090132193388f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nstd::string replace_specialchar(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = replace_specialchar;\n    assert(candidate((\"Python language, Programming language.\")) == (\"Python:language::Programming:language:\"));\n    assert(candidate((\"a b c,d e f\")) == (\"a:b:c:d:e:f\"));\n    assert(candidate((\"ram reshma,ram rahim\")) == (\"ram:reshma:ram:rahim\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the index of the first occurrence of a given number in a sorted vector.\nlong find_first_occurrence(std::vector<long> A, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_first_occurrence;\n    assert(candidate((std::vector<long>({(long)2, (long)5, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)5, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (5)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)5, (long)6, (long)6, (long)8, (long)9, (long)9, (long)9})), (6)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nlong sum_Of_Subarray_Prod(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_Of_Subarray_Prod;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (20));\n    assert(candidate((std::vector<long>({(long)1, (long)2}))) == (5));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4}))) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlong toggle_middle_bits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = toggle_middle_bits;\n    assert(candidate((9)) == (15));\n    assert(candidate((10)) == (12));\n    assert(candidate((11)) == (13));\n    assert(candidate((65)) == (127));\n    assert(candidate((77)) == (115));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/cppthon-exercises/data-structures-and-algorithms/cppthon-data-structure-exercise-24.php\nlong left_insertion(std::vector<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = left_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nbool check_str(std::string string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_str;\n    assert(candidate((\"annie\")) == (true));\n    assert(candidate((\"dawood\")) == (false));\n    assert(candidate((\"Else\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/cppthon-exercises/data-structures-and-algorithms/cppthon-recursion-exercise-9.php\nfloat geometric_sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = geometric_sum;\n    assert(candidate((7)) == (1.9921875f));\n    assert(candidate((4)) == (1.9375f));\n    assert(candidate((8)) == (1.99609375f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlong find_Index(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Index;\n    assert(candidate((2)) == (4));\n    assert(candidate((3)) == (14));\n    assert(candidate((4)) == (45));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given tuple to a key-value map using adjacent elements. https://www.geeksforgeeks.org/cppthon-convert-tuple-to-adjacent-pair-map/\nstd::map<long,long> tuple_to_dict(std::tuple<long, long, long, long, long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tuple_to_dict;\n    assert(candidate((std::make_tuple(1, 5, 7, 10, 13, 5))) == (std::map<long,long>({{1, 5}, {7, 10}, {13, 5}})));\n    assert(candidate((std::make_tuple(1, 2, 3, 4, 5, 6))) == (std::map<long,long>({{1, 2}, {3, 4}, {5, 6}})));\n    assert(candidate((std::make_tuple(7, 8, 9, 10, 11, 12))) == (std::map<long,long>({{7, 8}, {9, 10}, {11, 12}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether all the characters are same or not.\nbool all_Characters_Same(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = all_Characters_Same;\n    assert(candidate((\"python\")) == (false));\n    assert(candidate((\"aaa\")) == (true));\n    assert(candidate((\"data\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to caluclate the area of a tetrahedron.\nfloat area_tetrahedron(long side) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = area_tetrahedron;\n    assert(candidate((3)) == (15.588457268119894f));\n    assert(candidate((20)) == (692.8203230275509f));\n    assert(candidate((10)) == (173.20508075688772f));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/cppthon-program-right-rotate-vector-n/\nstd::vector<long> rotate_right(std::vector<long> list, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rotate_right;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (3)) == (std::vector<long>({(long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (2)) == (std::vector<long>({(long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10})), (5)) == (std::vector<long>({(long)6, (long)7, (long)8, (long)9, (long)10, (long)1, (long)2, (long)3, (long)4, (long)5})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuple has any none value or not.\nbool check_none(std::any test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_none;\n    assert(candidate(std::make_tuple(std::optional<long>(10), std::optional<long>(4), std::optional<long>(5), std::optional<long>(6), std::optional<long>(std::nullopt))) == (true));\n    assert(candidate(std::make_tuple(7, 8, 9, 11, 14)) == (false));\n    assert(candidate(std::make_tuple(std::optional<long>(1), std::optional<long>(2), std::optional<long>(3), std::optional<long>(4), std::optional<long>(std::nullopt))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/cppthon-exercises/lambda/cppthon-lambda-exercise-24.php\nstd::vector<long> divisible_by_digits(long startnum, long endnum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = divisible_by_digits;\n    assert(candidate((1), (22)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15, (long)22})));\n    assert(candidate((1), (15)) == (std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)11, (long)12, (long)15})));\n    assert(candidate((20), (25)) == (std::vector<long>({(long)22, (long)24})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nstd::optional<float> sector_area(long r, long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sector_area;\n    assert(candidate((4), (45)) == 6.283185307179586f);\n    assert(candidate((9), (45)) == 31.808625617596654f);\n    assert(candidate((9), (361)) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlong lcs_of_three(std::string X, std::string Y, std::string Z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = lcs_of_three;\n    assert(candidate((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2));\n    assert(candidate((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5));\n    assert(candidate((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to put spaces between words starting with capital letters in a given string.\nstd::string capital_words_spaces(std::string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = capital_words_spaces;\n    assert(candidate((\"Python\")) == (\"Python\"));\n    assert(candidate((\"PythonProgrammingExamples\")) == (\"Python Programming Examples\"));\n    assert(candidate((\"GetReadyToBeCodingFreak\")) == (\"Get Ready To Be Coding Freak\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/cppthon-sort-numeric-strings-in-a-vector/\nstd::vector<long> sort_numeric_strings(std::vector<std::string> nums_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sort_numeric_strings;\n    assert(candidate((std::vector<std::string>({(std::string)\"4\", (std::string)\"12\", (std::string)\"45\", (std::string)\"7\", (std::string)\"0\", (std::string)\"100\", (std::string)\"200\", (std::string)\"-12\", (std::string)\"-500\"}))) == (std::vector<long>({(long)-500, (long)-12, (long)0, (long)4, (long)7, (long)12, (long)45, (long)100, (long)200})));\n    assert(candidate((std::vector<std::string>({(std::string)\"2\", (std::string)\"3\", (std::string)\"8\", (std::string)\"4\", (std::string)\"7\", (std::string)\"9\", (std::string)\"8\", (std::string)\"2\", (std::string)\"6\", (std::string)\"5\", (std::string)\"1\", (std::string)\"6\", (std::string)\"1\", (std::string)\"2\", (std::string)\"3\", (std::string)\"4\", (std::string)\"6\", (std::string)\"9\", (std::string)\"1\", (std::string)\"2\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)2, (long)2, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)8, (long)9, (long)9})));\n    assert(candidate((std::vector<std::string>({(std::string)\"1\", (std::string)\"3\", (std::string)\"5\", (std::string)\"7\", (std::string)\"1\", (std::string)\"3\", (std::string)\"13\", (std::string)\"15\", (std::string)\"17\", (std::string)\"5\", (std::string)\"7 \", (std::string)\"9\", (std::string)\"1\", (std::string)\"11\"}))) == (std::vector<long>({(long)1, (long)1, (long)1, (long)3, (long)3, (long)5, (long)5, (long)7, (long)7, (long)9, (long)11, (long)13, (long)15, (long)17})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether it follows the sequence given in the patterns vector.\nbool is_samepatterns(std::vector<std::string> colors, std::vector<std::string> patterns) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_samepatterns;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"green\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\", (std::string)\"b\"}))) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"green\", (std::string)\"greenn\"})), (std::vector<std::string>({(std::string)\"a\", (std::string)\"b\"}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to add the given tuple to the given vector.\nstd::vector<long> add_tuple(std::vector<long> test_list, std::tuple<long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = add_tuple;\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7})), (std::make_tuple(9, 10))) == (std::vector<long>({(long)5, (long)6, (long)7, (long)9, (long)10})));\n    assert(candidate((std::vector<long>({(long)6, (long)7, (long)8})), (std::make_tuple(10, 11))) == (std::vector<long>({(long)6, (long)7, (long)8, (long)10, (long)11})));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9})), (std::make_tuple(11, 12))) == (std::vector<long>({(long)7, (long)8, (long)9, (long)11, (long)12})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\nbool check_min_heap(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_min_heap;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)10, (long)15}))) == (true));\n    assert(candidate((std::vector<long>({(long)2, (long)10, (long)4, (long)5, (long)3, (long)15}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlong jacobsthal_num(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = jacobsthal_num;\n    assert(candidate((5)) == (11));\n    assert(candidate((2)) == (1));\n    assert(candidate((4)) == (5));\n    assert(candidate((13)) == (2731));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/cppthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cocpp of test cases\nstd::vector<std::tuple<std::string, long>> min_k(std::vector<std::tuple<std::string, long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = min_k;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 10), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Nikhil\", 8)})), (2)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 2), (std::tuple<std::string, long>)std::make_tuple(\"Akshat\", 4)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sanjeev\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})), (3)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Akash\", 3), (std::tuple<std::string, long>)std::make_tuple(\"Angat\", 5), (std::tuple<std::string, long>)std::make_tuple(\"Nepin\", 9)})));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"tanmay\", 14), (std::tuple<std::string, long>)std::make_tuple(\"Amer\", 11), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9), (std::tuple<std::string, long>)std::make_tuple(\"SKD\", 16)})), (1)) == (std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 9)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// We say that an element is common for vectors l1, l2, l3 if it appears in all three vectors under the same index. Write a function to find common elements from three vectors. The function should return a vector.\nstd::vector<std::any> extract_index_list(std::vector<long> l1, std::vector<long> l2, std::vector<long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = extract_index_list;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)5, (long)6, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)5})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)6, (long)7}))) == (std::vector<std::any>({(long)1, (long)6})));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)3, (long)4, (long)6, (long)5, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>({(long)1, (long)5})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)6, (long)6, (long)6})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7})), (std::vector<long>({(long)0, (long)1, (long)2, (long)3, (long)4, (long)5, (long)7}))) == (std::vector<std::any>()));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\nunion Union_long_float{\n    long f0;\n    float f1;    Union_long_float(long _f0) : f0(_f0) {}\n    Union_long_float(float _f1) : f1(_f1) {}\n    ~Union_long_float() {}\n    bool operator==(long f) {\n        return f0 == f ;\n    }    bool operator==(float f) {\n        return f1 == f ;\n    }\n};\n// Write a function to find the second smallest number in a vector.\nstd::optional<float> second_smallest(std::vector<Union_long_float> numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = second_smallest;\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)2, (long)-8, (long)-2, (long)0, (long)-2}))) == -2);\n    assert(candidate((std::vector<Union_long_float>({(long)1, (long)1, (long)-0.5f, (long)0, (long)2, (long)-2, (long)-2}))) == -0.5f);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2}))) == std::nullopt);\n    assert(candidate((std::vector<Union_long_float>({(long)2, (long)2, (long)2}))) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/cppthon-exercises/re/cppthon-re-exercise-3.php\nbool text_match_zero_one(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_zero_one;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"dsabbbba\")) == (true));\n    assert(candidate((\"asbbbba\")) == (false));\n    assert(candidate((\"abaaa\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/cppthon-program-to-count-the-pairs-of-reverse-strings/\nlong count_reverse_pairs(std::vector<std::string> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_reverse_pairs;\n    assert(candidate((std::vector<std::string>({(std::string)\"julia\", (std::string)\"best\", (std::string)\"tseb\", (std::string)\"for\", (std::string)\"ailuj\"}))) == (2));\n    assert(candidate((std::vector<std::string>({(std::string)\"geeks\", (std::string)\"best\", (std::string)\"for\", (std::string)\"skeeg\"}))) == (1));\n    assert(candidate((std::vector<std::string>({(std::string)\"makes\", (std::string)\"best\", (std::string)\"sekam\", (std::string)\"for\", (std::string)\"rof\"}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nbool is_decimal(std::string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_decimal;\n    assert(candidate((\"123.11\")) == (true));\n    assert(candidate((\"e666.86\")) == (false));\n    assert(candidate((\"3.124587\")) == (false));\n    assert(candidate((\"1.11\")) == (true));\n    assert(candidate((\"1.1.11\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find tuples which have all elements divisible by k from the given vector of tuples.\nstd::vector<std::tuple<long, long, long>> find_tuples(std::vector<std::tuple<long, long, long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_tuples;\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12), (std::tuple<long, long, long>)std::make_tuple(7, 9, 6), (std::tuple<long, long, long>)std::make_tuple(12, 18, 21)})), (6)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(6, 24, 12)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30), (std::tuple<long, long, long>)std::make_tuple(4, 2, 3), (std::tuple<long, long, long>)std::make_tuple(7, 8, 9)})), (5)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(5, 25, 30)})));\n    assert(candidate((std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(7, 9, 16), (std::tuple<long, long, long>)std::make_tuple(8, 16, 4), (std::tuple<long, long, long>)std::make_tuple(19, 17, 18)})), (4)) == (std::vector<std::tuple<long, long, long>>({(std::tuple<long, long, long>)std::make_tuple(8, 16, 4)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether a vector of numbers contains only one distinct element or not.\nbool unique_Element(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = unique_Element;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nbool check_monthnumber_number(long monthnum3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_monthnumber_number;\n    assert(candidate((6)) == (true));\n    assert(candidate((2)) == (false));\n    assert(candidate((12)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlong find_min_diff(std::vector<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_min_diff;\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)3, (long)19, (long)18, (long)25})), (6)) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)3, (long)2, (long)6})), (4)) == (1));\n    assert(candidate((std::vector<long>({(long)30, (long)5, (long)20, (long)9})), (4)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count number of digits in a given string.\nlong number_ctr(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = number_ctr;\n    assert(candidate((\"program2bedone\")) == (1));\n    assert(candidate((\"3wonders\")) == (1));\n    assert(candidate((\"123\")) == (3));\n    assert(candidate((\"3wond-1ers2\")) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlong is_polite(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_polite;\n    assert(candidate((7)) == (11));\n    assert(candidate((4)) == (7));\n    assert(candidate((9)) == (13));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to return a vector of all pairs of consecutive items in a given vector.\nstd::vector<std::tuple<long, long>> pair_wise(std::vector<long> l1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pair_wise;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)2, (long)3, (long)3, (long)4, (long)4, (long)5}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 1), (std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 4), (std::tuple<long, long>)std::make_tuple(4, 5)})));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 5), (std::tuple<long, long>)std::make_tuple(5, 7), (std::tuple<long, long>)std::make_tuple(7, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n    assert(candidate((std::vector<long>({(long)5, (long)1, (long)9, (long)7, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(1, 9), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(7, 10)})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(1, 2), (std::tuple<long, long>)std::make_tuple(2, 3), (std::tuple<long, long>)std::make_tuple(3, 4), (std::tuple<long, long>)std::make_tuple(4, 5), (std::tuple<long, long>)std::make_tuple(5, 6), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(9, 10)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\nlong get_pairs_count(std::vector<long> arr, long sum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_pairs_count;\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)1})), (2)) == (6));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)-1, (long)5})), (6)) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)-2, (long)3})), (1)) == (1));\n    assert(candidate((std::vector<long>({(long)-1, (long)-2, (long)3})), (-3)) == (1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to get the difference between two vectors.\nstd::vector<long> Diff(std::vector<long> li1, std::vector<long> li2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Diff;\n    assert(candidate((std::vector<long>({(long)10, (long)15, (long)20, (long)25, (long)30, (long)35, (long)40})), (std::vector<long>({(long)25, (long)40, (long)35}))) == (std::vector<long>({(long)10, (long)20, (long)30, (long)15})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)4, (long)5, (long)6, (long)7})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (std::vector<long>({(long)6, (long)7, (long)1}))) == (std::vector<long>({(long)2, (long)3, (long)6, (long)7})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of fourth power of first n odd natural numbers.\nlong odd_num_sum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = odd_num_sum;\n    assert(candidate((2)) == (82));\n    assert(candidate((3)) == (707));\n    assert(candidate((4)) == (3108));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nbool check_expression(std::string exp) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_expression;\n    assert(candidate((\"{()}[{}]\")) == (true));\n    assert(candidate((\"{()}[{]\")) == (false));\n    assert(candidate((\"{()}[{}][]({})\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all the words with k length in the given string.\nstd::string remove_length(std::string test_str, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_length;\n    assert(candidate((\"The person is most value tet\"), (3)) == (\"person is most value\"));\n    assert(candidate((\"If you told me about this ok\"), (4)) == (\"If you me about ok\"));\n    assert(candidate((\"Forces of darkeness is come into the play\"), (4)) == (\"Forces of darkeness is the\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nstd::optional<std::tuple<std::string, long, long>> occurance_substring(std::string text, std::string pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = occurance_substring;\n    assert(candidate((\"python programming, python language\"), (\"python\")) == std::make_tuple(\"python\", 0, 6));\n    assert(candidate((\"python programming,programming language\"), (\"programming\")) == std::make_tuple(\"programming\", 7, 18));\n    assert(candidate((\"python programming,programming language\"), (\"language\")) == std::make_tuple(\"language\", 31, 39));\n    assert(candidate((\"c++ programming, c++ language\"), (\"python\")) == std::nullopt);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether every odd index contains odd numbers of a given vector.\nbool odd_position(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = odd_position;\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4, (long)3, (long)6, (long)7, (long)6, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)4, (long)1, (long)2}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nlong count_vowels(std::string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_vowels;\n    assert(candidate((\"bestinstareels\")) == (7));\n    assert(candidate((\"partofthejourneyistheend\")) == (12));\n    assert(candidate((\"amazonprime\")) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of non-repeated elements in a given vector.\nlong find_sum(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)1, (long)1, (long)4, (long)5, (long)6}))) == (21));\n    assert(candidate((std::vector<long>({(long)1, (long)10, (long)9, (long)4, (long)2, (long)10, (long)10, (long)45, (long)4}))) == (71));\n    assert(candidate((std::vector<long>({(long)12, (long)10, (long)9, (long)45, (long)2, (long)10, (long)10, (long)45, (long)10}))) == (78));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to pack consecutive duplicates of a given vector elements into subvectors.\nstd::vector<std::vector<std::any>> pack_consecutive_duplicates(std::vector<std::any> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = pack_consecutive_duplicates;\n    assert(candidate((std::vector<std::any>({(long)0, (long)0, (long)1, (long)2, (long)3, (long)4, (long)4, (long)5, (long)6, (long)6, (long)6, (long)7, (long)8, (long)9, (long)4, (long)4}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)0, (long)0}), (std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)2}), (std::vector<long>)std::vector<long>({(long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4}), (std::vector<long>)std::vector<long>({(long)5}), (std::vector<long>)std::vector<long>({(long)6, (long)6, (long)6}), (std::vector<long>)std::vector<long>({(long)7}), (std::vector<long>)std::vector<long>({(long)8}), (std::vector<long>)std::vector<long>({(long)9}), (std::vector<long>)std::vector<long>({(long)4, (long)4})})));\n    assert(candidate((std::vector<std::any>({(long)10, (long)10, (long)15, (long)19, (long)18, (long)18, (long)17, (long)26, (long)26, (long)17, (long)18, (long)10}))) == (std::vector<std::vector<std::any>>({(std::vector<long>)std::vector<long>({(long)10, (long)10}), (std::vector<long>)std::vector<long>({(long)15}), (std::vector<long>)std::vector<long>({(long)19}), (std::vector<long>)std::vector<long>({(long)18, (long)18}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)26, (long)26}), (std::vector<long>)std::vector<long>({(long)17}), (std::vector<long>)std::vector<long>({(long)18}), (std::vector<long>)std::vector<long>({(long)10})})));\n    assert(candidate((std::vector<std::any>({(std::string)\"a\", (std::string)\"a\", (std::string)\"b\", (std::string)\"c\", (std::string)\"d\", (std::string)\"d\"}))) == (std::vector<std::vector<std::any>>({(std::vector<std::string>)std::vector<std::string>({(std::string)\"a\", (std::string)\"a\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"b\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"c\"}), (std::vector<std::string>)std::vector<std::string>({(std::string)\"d\", (std::string)\"d\"})})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find whether a number is divisible by 11.\nbool is_Diff(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_Diff;\n    assert(candidate((12345)) == (false));\n    assert(candidate((1212112)) == (true));\n    assert(candidate((1212)) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/cppthon-combinations-of-sum-with-tuples-in-tuple-vector/\nstd::vector<std::tuple<long, long>> find_combinations(std::vector<std::tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_combinations;\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(2, 4), (std::tuple<long, long>)std::make_tuple(6, 7), (std::tuple<long, long>)std::make_tuple(5, 1), (std::tuple<long, long>)std::make_tuple(6, 10)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(8, 11), (std::tuple<long, long>)std::make_tuple(7, 5), (std::tuple<long, long>)std::make_tuple(8, 14), (std::tuple<long, long>)std::make_tuple(11, 8), (std::tuple<long, long>)std::make_tuple(12, 17), (std::tuple<long, long>)std::make_tuple(11, 11)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(3, 5), (std::tuple<long, long>)std::make_tuple(7, 8), (std::tuple<long, long>)std::make_tuple(6, 2), (std::tuple<long, long>)std::make_tuple(7, 11)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(10, 13), (std::tuple<long, long>)std::make_tuple(9, 7), (std::tuple<long, long>)std::make_tuple(10, 16), (std::tuple<long, long>)std::make_tuple(13, 10), (std::tuple<long, long>)std::make_tuple(14, 19), (std::tuple<long, long>)std::make_tuple(13, 13)})));\n    assert(candidate((std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(4, 6), (std::tuple<long, long>)std::make_tuple(8, 9), (std::tuple<long, long>)std::make_tuple(7, 3), (std::tuple<long, long>)std::make_tuple(8, 12)}))) == (std::vector<std::tuple<long, long>>({(std::tuple<long, long>)std::make_tuple(12, 15), (std::tuple<long, long>)std::make_tuple(11, 9), (std::tuple<long, long>)std::make_tuple(12, 18), (std::tuple<long, long>)std::make_tuple(15, 12), (std::tuple<long, long>)std::make_tuple(16, 21), (std::tuple<long, long>)std::make_tuple(15, 15)})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the count of divisors is even. https://www.w3resource.com/cppthon-exercises/basic/cppthon-basic-1-exercise-24.php\nbool count_divisors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_divisors;\n    assert(candidate((10)) == (true));\n    assert(candidate((100)) == (false));\n    assert(candidate((125)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nlong odd_length_sum(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = odd_length_sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4}))) == (14));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)2}))) == (15));\n    assert(candidate((std::vector<long>({(long)1, (long)7}))) == (8));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nstd::vector<float> rgb_to_hsv(long r, long g, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = rgb_to_hsv;\n    assert(candidate((255), (255), (255)) == (std::vector<float>({(float)0.0f, (float)0.0f, (float)100.0f})));\n    assert(candidate((0), (215), (0)) == (std::vector<float>({(float)120.0f, (float)100.0f, (float)84.31372549019608f})));\n    assert(candidate((10), (215), (110)) == (std::vector<float>({(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the product of first even and odd number of a given vector.\nlong mul_even_odd(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = mul_even_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5, (long)7, (long)4, (long)1, (long)6, (long)8}))) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)5, (long)7, (long)9, (long)10}))) == (10));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert tuple string to integer tuple.\nstd::tuple<long, long, long> tuple_str_int(std::string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tuple_str_int;\n    assert(candidate((\"(7, 8, 9)\")) == (std::make_tuple(7, 8, 9)));\n    assert(candidate((\"(1, 2, 3)\")) == (std::make_tuple(1, 2, 3)));\n    assert(candidate((\"(4, 5, 6)\")) == (std::make_tuple(4, 5, 6)));\n    assert(candidate((\"(7, 81, 19)\")) == (std::make_tuple(7, 81, 19)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to locate the right insertion point for a specified value in sorted order.\nlong right_insertion(std::vector<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = right_insertion;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (6)) == (4));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (3)) == (2));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)4, (long)5})), (7)) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an a followed by three 'b'.\nbool text_match_three(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_match_three;\n    assert(candidate((\"ac\")) == (false));\n    assert(candidate((\"dc\")) == (false));\n    assert(candidate((\"abbbba\")) == (true));\n    assert(candidate((\"caacabbbba\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to create a new tuple from the given string and vector.\nstd::tuple<std::string, std::string, std::string> new_tuple(std::vector<std::string> test_list, std::string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = new_tuple;\n    assert(candidate((std::vector<std::string>({(std::string)\"WEB\", (std::string)\"is\"})), (\"best\")) == (std::make_tuple(\"WEB\", \"is\", \"best\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"We\", (std::string)\"are\"})), (\"Developers\")) == (std::make_tuple(\"We\", \"are\", \"Developers\")));\n    assert(candidate((std::vector<std::string>({(std::string)\"Part\", (std::string)\"is\"})), (\"Wrong\")) == (std::make_tuple(\"Part\", \"is\", \"Wrong\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether every even index contains even numbers of a given vector.\nbool even_position(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = even_position;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (false));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (false));\n    assert(candidate((std::vector<long>({(long)2, (long)1, (long)4}))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove tuples from the given tuple.\nstd::tuple<long, long, long, long> remove_nested(std::any test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_nested;\n    assert(candidate(std::make_tuple(1, 5, 7, std::make_tuple(4, 6), 10)) == (std::make_tuple(1, 5, 7, 10)));\n    assert(candidate(std::make_tuple(2, 6, 8, std::make_tuple(5, 7), 11)) == (std::make_tuple(2, 6, 8, 11)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), 12)) == (std::make_tuple(3, 7, 9, 12)));\n    assert(candidate(std::make_tuple(3, 7, 9, std::make_tuple(6, 8), std::make_tuple(5, 12), 12)) == (std::make_tuple(3, 7, 9, 12)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of vectors in a given number of vectors.\nlong count_list(std::vector<std::vector<long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)3}), (std::vector<long>)std::vector<long>({(long)5, (long)7}), (std::vector<long>)std::vector<long>({(long)9, (long)11}), (std::vector<long>)std::vector<long>({(long)13, (long)15, (long)17})}))) == (4));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5})}))) == (3));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)0}), (std::vector<long>)std::vector<long>({(long)2, (long)0})}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the last position of an element in a sorted vector.\nlong last(std::vector<long> arr, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = last;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3})), (1)) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)1, (long)1, (long)2, (long)3, (long)4})), (1)) == (2));\n    assert(candidate((std::vector<long>({(long)2, (long)3, (long)2, (long)3, (long)6, (long)8, (long)9})), (3)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nbool text_starta_endb(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = text_starta_endb;\n    assert(candidate((\"aabbbb\")) == (true));\n    assert(candidate((\"aabAbbbc\")) == (false));\n    assert(candidate((\"accddbbjjj\")) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write function to find the sum of all items in the given map.\nlong return_sum(std::map<std::string,long> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = return_sum;\n    assert(candidate((std::map<std::string,long>({{\"a\", 100}, {\"b\", 200}, {\"c\", 300}}))) == (600));\n    assert(candidate((std::map<std::string,long>({{\"a\", 25}, {\"b\", 18}, {\"c\", 45}}))) == (88));\n    assert(candidate((std::map<std::string,long>({{\"a\", 36}, {\"b\", 39}, {\"c\", 49}}))) == (124));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of all odd natural numbers within the range l and r.\nlong sum_in_range(long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sum_in_range;\n    assert(candidate((2), (5)) == (8));\n    assert(candidate((5), (7)) == (12));\n    assert(candidate((7), (13)) == (40));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the sum of a vector.\nlong _sum(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = _sum;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (6));\n    assert(candidate((std::vector<long>({(long)15, (long)12, (long)13, (long)10}))) == (50));\n    assert(candidate((std::vector<long>({(long)0, (long)1, (long)2}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlong left_rotate(long n, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = left_rotate;\n    assert(candidate((16), (2)) == (64));\n    assert(candidate((10), (2)) == (40));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((99), (3)) == (792));\n    assert(candidate((1), (3)) == (8));\n    assert(candidate((5), (3)) == (40));\n    assert(candidate((29), (3)) == (232));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to check whether the length of the word is odd or not.\nbool word_len(std::string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = word_len;\n    assert(candidate((\"Hadoop\")) == (false));\n    assert(candidate((\"great\")) == (true));\n    assert(candidate((\"structure\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to remove all whitespaces from a string.\nstd::string remove_all_spaces(std::string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = remove_all_spaces;\n    assert(candidate((\"python  program\")) == (\"pythonprogram\"));\n    assert(candidate((\"python   programming    language\")) == (\"pythonprogramminglanguage\"));\n    assert(candidate((\"python                     program\")) == (\"pythonprogram\"));\n    assert(candidate((\"   python                     program\")) == (\"pythonprogram\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of equal numbers from three given integers.\nlong test_three_equal(long x, long y, long z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = test_three_equal;\n    assert(candidate((1), (1), (1)) == (3));\n    assert(candidate((-1), (-2), (-3)) == (0));\n    assert(candidate((1), (2), (2)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\nlong count_rotation(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = count_rotation;\n    assert(candidate((std::vector<long>({(long)3, (long)2, (long)1}))) == (1));\n    assert(candidate((std::vector<long>({(long)4, (long)5, (long)1, (long)2, (long)3}))) == (2));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)1, (long)2, (long)3}))) == (3));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (0));\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)2}))) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nbool is_perfect_square(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_perfect_square;\n    assert(candidate((10)) == (false));\n    assert(candidate((36)) == (true));\n    assert(candidate((14)) == (false));\n    assert(candidate((196)) == (true));\n    assert(candidate((125)) == (false));\n    assert(candidate((15625)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the product of numbers in a vector is even or not.\nbool is_product_even(std::vector<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_product_even;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)1, (long)4}))) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)1}))) == (false));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function that returns the vector in a vector of vectors whose sum of elements is the highest.\nstd::vector<long> max_sum_list(std::vector<std::vector<long>> lists) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_sum_list;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6}), (std::vector<long>)std::vector<long>({(long)10, (long)11, (long)12}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9})}))) == (std::vector<long>({(long)10, (long)11, (long)12})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)2, (long)1}), (std::vector<long>)std::vector<long>({(long)6, (long)5, (long)4}), (std::vector<long>)std::vector<long>({(long)12, (long)11, (long)10})}))) == (std::vector<long>({(long)12, (long)11, (long)10})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)2, (long)3, (long)1})}))) == (std::vector<long>({(long)2, (long)3, (long)1})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find maximum run of uppercase characters in the given string.\nlong max_run_uppercase(std::string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = max_run_uppercase;\n    assert(candidate((\"GeMKSForGERksISBESt\")) == (5));\n    assert(candidate((\"PrECIOusMOVemENTSYT\")) == (6));\n    assert(candidate((\"GooGLEFluTTER\")) == (4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the first odd number in a given vector of numbers.\nlong first_odd(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = first_odd;\n    assert(candidate((std::vector<long>({(long)1, (long)3, (long)5}))) == (1));\n    assert(candidate((std::vector<long>({(long)2, (long)4, (long)1, (long)3}))) == (1));\n    assert(candidate((std::vector<long>({(long)8, (long)9, (long)1}))) == (9));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if the given tuples contain the k or not.\nbool check_K(std::vector<long> test_tup, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_K;\n    assert(candidate((std::vector<long>({(long)10, (long)4, (long)5, (long)6, (long)8})), (6)) == (true));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6})), (7)) == (false));\n    assert(candidate((std::vector<long>({(long)7, (long)8, (long)9, (long)44, (long)11, (long)12})), (11)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nbool check_smaller(std::tuple<long, long, long> test_tup1, std::tuple<long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = check_smaller;\n    assert(candidate((std::make_tuple(1, 2, 3)), (std::make_tuple(2, 3, 4))) == (false));\n    assert(candidate((std::make_tuple(4, 5, 6)), (std::make_tuple(3, 4, 5))) == (true));\n    assert(candidate((std::make_tuple(11, 12, 13)), (std::make_tuple(10, 11, 12))) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth tetrahedral number.\nlong tetrahedral_number(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = tetrahedral_number;\n    assert(candidate((5)) == (35));\n    assert(candidate((6)) == (56));\n    assert(candidate((7)) == (84));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nstd::string get_Char(std::string strr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = get_Char;\n    assert(candidate((\"abc\")) == (\"f\"));\n    assert(candidate((\"gfg\")) == (\"t\"));\n    assert(candidate((\"ab\")) == (\"c\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the nth number in the newman conway sequence.\nlong sequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = sequence;\n    assert(candidate((10)) == (6));\n    assert(candidate((2)) == (1));\n    assert(candidate((3)) == (2));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find nth centered hexagonal number.\nlong centered_hexagonal_number(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = centered_hexagonal_number;\n    assert(candidate((10)) == (271));\n    assert(candidate((2)) == (7));\n    assert(candidate((9)) == (217));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to merge three dictionaries into a single map.\nstd::map<std::string,std::string> merge_dictionaries_three(std::map<std::string,std::string> dict1, std::map<std::string,std::string> dict2, std::map<std::string,std::string> dict3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = merge_dictionaries_three;\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}))) == (std::map<std::string,std::string>({{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    assert(candidate((std::map<std::string,std::string>({{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}})), (std::map<std::string,std::string>({{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})), (std::map<std::string,std::string>({{\"G\", \"Green\"}, {\"W\", \"White\"}}))) == (std::map<std::string,std::string>({{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to get the frequency of all the elements in a vector, returned as a map.\nstd::map<long,long> freq_count(std::vector<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = freq_count;\n    assert(candidate((std::vector<long>({(long)10, (long)10, (long)10, (long)10, (long)20, (long)20, (long)20, (long)20, (long)40, (long)40, (long)50, (long)50, (long)30}))) == (std::map<long,long>({{10, 4}, {20, 4}, {40, 2}, {50, 2}, {30, 1}})));\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)3, (long)2, (long)4, (long)1, (long)3, (long)1, (long)4}))) == (std::map<long,long>({{1, 3}, {2, 2}, {3, 3}, {4, 3}})));\n    assert(candidate((std::vector<long>({(long)5, (long)6, (long)7, (long)4, (long)9, (long)10, (long)4, (long)5, (long)6, (long)7, (long)9, (long)5}))) == (std::map<long,long>({{10, 1}, {5, 3}, {6, 2}, {7, 2}, {4, 2}, {9, 2}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find the closest smaller number than n.\nlong closest_num(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = closest_num;\n    assert(candidate((11)) == (10));\n    assert(candidate((7)) == (6));\n    assert(candidate((12)) == (11));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find squares of individual elements in a vector.\nstd::vector<long> square_nums(std::vector<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = square_nums;\n    assert(candidate((std::vector<long>({(long)1, (long)2, (long)3, (long)4, (long)5, (long)6, (long)7, (long)8, (long)9, (long)10}))) == (std::vector<long>({(long)1, (long)4, (long)9, (long)16, (long)25, (long)36, (long)49, (long)64, (long)81, (long)100})));\n    assert(candidate((std::vector<long>({(long)10, (long)20, (long)30}))) == (std::vector<long>({(long)100, (long)400, (long)900})));\n    assert(candidate((std::vector<long>({(long)12, (long)15}))) == (std::vector<long>({(long)144, (long)225})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the longest word.\nlong len_log(std::vector<std::string> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = len_log;\n    assert(candidate((std::vector<std::string>({(std::string)\"python\", (std::string)\"PHP\", (std::string)\"bigdata\"}))) == (7));\n    assert(candidate((std::vector<std::string>({(std::string)\"a\", (std::string)\"ab\", (std::string)\"abc\"}))) == (3));\n    assert(candidate((std::vector<std::string>({(std::string)\"small\", (std::string)\"big\", (std::string)\"tall\"}))) == (5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check if a string is present as a substring in a given vector of string values.\nbool find_substring(std::vector<std::string> str1, std::string sub_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_substring;\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ack\")) == (true));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"abc\")) == (false));\n    assert(candidate((std::vector<std::string>({(std::string)\"red\", (std::string)\"black\", (std::string)\"white\", (std::string)\"green\", (std::string)\"orange\"})), (\"ange\")) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to check whether the given number is undulating or not.\nbool is_undulating(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = is_undulating;\n    assert(candidate((1212121)) == (true));\n    assert(candidate((1991)) == (false));\n    assert(candidate((121)) == (true));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to calculate the value of 'a' to the power 'b'.\nlong power(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = power;\n    assert(candidate((3), (4)) == (81));\n    assert(candidate((2), (3)) == (8));\n    assert(candidate((5), (5)) == (3125));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Given a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\nstd::string index_minimum(std::vector<std::tuple<std::string, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = index_minimum;\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Rash\", 143), (std::tuple<std::string, long>)std::make_tuple(\"Manjeet\", 200), (std::tuple<std::string, long>)std::make_tuple(\"Varsha\", 100)}))) == (\"Varsha\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Yash\", 185), (std::tuple<std::string, long>)std::make_tuple(\"Dawood\", 125), (std::tuple<std::string, long>)std::make_tuple(\"Sanya\", 175)}))) == (\"Dawood\"));\n    assert(candidate((std::vector<std::tuple<std::string, long>>({(std::tuple<std::string, long>)std::make_tuple(\"Sai\", 345), (std::tuple<std::string, long>)std::make_tuple(\"Salman\", 145), (std::tuple<std::string, long>)std::make_tuple(\"Ayesha\", 96)}))) == (\"Ayesha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the length of the smallest vector in a vector of vectors.\nlong Find_Min_Length(std::vector<std::vector<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = Find_Min_Length;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1}), (std::vector<long>)std::vector<long>({(long)1, (long)2})}))) == (1));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3}), (std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4})}))) == (2));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)3, (long)3, (long)3}), (std::vector<long>)std::vector<long>({(long)4, (long)4, (long)4, (long)4})}))) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the number of divisors of a given integer.\nlong divisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = divisor;\n    assert(candidate((15)) == (4));\n    assert(candidate((12)) == (6));\n    assert(candidate((9)) == (3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to find frequency of each element in a flattened vector of vectors, returned in a map.\nstd::map<long,long> frequency_lists(std::vector<std::vector<long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = frequency_lists;\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)2}), (std::vector<long>)std::vector<long>({(long)4, (long)5, (long)6, (long)2}), (std::vector<long>)std::vector<long>({(long)7, (long)8, (long)9, (long)5})}))) == (std::map<long,long>({{1, 1}, {2, 3}, {3, 1}, {4, 1}, {5, 2}, {6, 1}, {7, 1}, {8, 1}, {9, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)1, (long)2, (long)3, (long)4}), (std::vector<long>)std::vector<long>({(long)5, (long)6, (long)7, (long)8}), (std::vector<long>)std::vector<long>({(long)9, (long)10, (long)11, (long)12})}))) == (std::map<long,long>({{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, 1}})));\n    assert(candidate((std::vector<std::vector<long>>({(std::vector<long>)std::vector<long>({(long)20, (long)30, (long)40, (long)17}), (std::vector<long>)std::vector<long>({(long)18, (long)16, (long)14, (long)13}), (std::vector<long>)std::vector<long>({(long)10, (long)20, (long)30, (long)40})}))) == (std::map<long,long>({{20, 2}, {30, 2}, {40, 2}, {17, 1}, {18, 1}, {16, 1}, {14, 1}, {13, 1}, {10, 1}})));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nstd::string decimal_to_binary(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = decimal_to_binary;\n    assert(candidate((8)) == (\"1000\"));\n    assert(candidate((18)) == (\"10010\"));\n    assert(candidate((7)) == (\"111\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "cpp",
+    "prompt": "#include<assert.h>\n#include<bits/stdc++.h>\n// Write a cppthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nlong find_Rotations(std::string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\nint main() {\n    auto candidate = find_Rotations;\n    assert(candidate((\"aaaa\")) == (1));\n    assert(candidate((\"ab\")) == (2));\n    assert(candidate((\"abc\")) == (3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-cs-keep.json
+++ b/prompts/mbpp-cs-keep.json
@@ -1,3444 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long Lps(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Lps((\"TENS FOR TENS\")) == (5L));\n    Debug.Assert(Lps((\"CARDIO FOR CARDS\")) == (7L));\n    Debug.Assert(Lps((\"PART OF THE JOURNEY IS PART\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static string RemoveWhitespaces(string text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveWhitespaces((\" Google    Flutter \")).Equals((\"GoogleFlutter\")));\n    Debug.Assert(RemoveWhitespaces((\" Google    Dart \")).Equals((\"GoogleDart\")));\n    Debug.Assert(RemoveWhitespaces((\" iOS    Swift \")).Equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static bool IssortList(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)17L}))) == (true));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)20L, (long)17L}))) == (false));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)15L, (long)14L, (long)20L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long CountBidirectional(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (3L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (2L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long SurfaceareaCube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCube((5L)) == (150L));\n    Debug.Assert(SurfaceareaCube((3L)) == (54L));\n    Debug.Assert(SurfaceareaCube((10L)) == (600L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    public static long NextSmallestPalindrome(long num) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallestPalindrome((99L)) == (101L));\n    Debug.Assert(NextSmallestPalindrome((1221L)) == (1331L));\n    Debug.Assert(NextSmallestPalindrome((120L)) == (121L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    public static long CubeSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeSum((2L)) == (72L));\n    Debug.Assert(CubeSum((3L)) == (288L));\n    Debug.Assert(CubeSum((4L)) == (800L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    public static long PairXorSum(List<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)5L, (long)9L, (long)7L, (long)6L})), (4L)) == (47L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L, (long)5L})), (3L)) == (12L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L})), (2L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    public static bool CheckMinHeap(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)10L, (long)15L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)5L, (long)3L, (long)15L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first digit of a given number.\n    public static long FirstDigit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstDigit((123L)) == (1L));\n    Debug.Assert(FirstDigit((456L)) == (4L));\n    Debug.Assert(FirstDigit((12L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    public static string FirstNonRepeatingCharacter(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstNonRepeatingCharacter((\"abcabc\")).Equals(null));\n    Debug.Assert(FirstNonRepeatingCharacter((\"abc\")).Equals((\"a\")));\n    Debug.Assert(FirstNonRepeatingCharacter((\"ababc\")).Equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float RadianDegree(long degree) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RadianDegree((90L)) == (1.5707963267948966f));\n    Debug.Assert(RadianDegree((60L)) == (1.0471975511965976f));\n    Debug.Assert(RadianDegree((120L)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    public static long MaxSubarrayProduct(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)0L, (long)7L, (long)-8L, (long)-2L}))) == (112L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)6L, (long)-3L, (long)-10L, (long)0L, (long)2L}))) == (180L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)-2L, (long)-40L, (long)0L, (long)-2L, (long)-3L}))) == (80L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static List<Dictionary<string,Dictionary<string,long>>> ConvertListDictionary(List<string> l1, List<string> l2, List<long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"S001\", (string)\"S002\", (string)\"S003\", (string)\"S004\"})), (new List<string>(new string[]{(string)\"Adina Park\", (string)\"Leyton Marsh\", (string)\"Duncan Boyle\", (string)\"Saim Richards\"})), (new List<long>(new long[]{(long)85L, (long)98L, (long)89L, (long)92L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S001\", new Dictionary<string,long>(){{\"Adina Park\", 85L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S002\", new Dictionary<string,long>(){{\"Leyton Marsh\", 98L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S003\", new Dictionary<string,long>(){{\"Duncan Boyle\", 89L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S004\", new Dictionary<string,long>(){{\"Saim Richards\", 92L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"abc\", (string)\"def\", (string)\"ghi\", (string)\"jkl\"})), (new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\", (string)\"programs\"})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"abc\", new Dictionary<string,long>(){{\"python\", 100L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"def\", new Dictionary<string,long>(){{\"program\", 200L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"ghi\", new Dictionary<string,long>(){{\"language\", 300L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"jkl\", new Dictionary<string,long>(){{\"programs\", 400L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"A1\", (string)\"A2\", (string)\"A3\", (string)\"A4\"})), (new List<string>(new string[]{(string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\"})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A1\", new Dictionary<string,long>(){{\"java\", 10L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A2\", new Dictionary<string,long>(){{\"C\", 20L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A3\", new Dictionary<string,long>(){{\"C++\", 30L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A4\", new Dictionary<string,long>(){{\"DBMS\", 40L}}}}}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find smallest number in a list.\n    public static long SmallestNum(List<long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)10L, (long)20L, (long)1L, (long)45L, (long)99L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)45L, (long)46L, (long)50L, (long)60L}))) == (45L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    public static bool TextMatchZeroOne(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchZeroOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"dsabbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"asbbbba\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find nth bell number.\n    public static long BellNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((3L)) == (5L));\n    Debug.Assert(BellNumber((4L)) == (15L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static List<long> CubeNums(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)27L, (long)64L, (long)125L, (long)216L, (long)343L, (long)512L, (long)729L, (long)1000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)1728L, (long)3375L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    public static long LastDigitFactorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigitFactorial((4L)) == (4L));\n    Debug.Assert(LastDigitFactorial((21L)) == (0L));\n    Debug.Assert(LastDigitFactorial((30L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    public static List<long> Split(List<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)0L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)0L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)8L, (long)12L, (long)15L, (long)19L}))).Equals((new List<long>(new long[]{(long)8L, (long)12L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static bool PrimeNum(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeNum((13L)) == (true));\n    Debug.Assert(PrimeNum((7L)) == (true));\n    Debug.Assert(PrimeNum((-1010L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static List<Tuple<long, long, long>> FindTuples(List<Tuple<long, long, long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L), (Tuple<long, long, long>)Tuple.Create(7L, 9L, 6L), (Tuple<long, long, long>)Tuple.Create(12L, 18L, 21L)})), (6L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L), (Tuple<long, long, long>)Tuple.Create(4L, 2L, 3L), (Tuple<long, long, long>)Tuple.Create(7L, 8L, 9L)})), (5L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(7L, 9L, 16L), (Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L), (Tuple<long, long, long>)Tuple.Create(19L, 17L, 18L)})), (4L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float AreaTetrahedron(long side) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreaTetrahedron((3L)) == (15.588457268119894f));\n    Debug.Assert(AreaTetrahedron((20L)) == (692.8203230275509f));\n    Debug.Assert(AreaTetrahedron((10L)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number is even or not.\n    public static bool IsEven(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEven((1L)) == (false));\n    Debug.Assert(IsEven((2L)) == (true));\n    Debug.Assert(IsEven((3L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    public static long PosCount(List<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L, (long)-4L}))) == (2L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)-1L}))) == (3L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static List<long> GetLudic(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetLudic((10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(GetLudic((25L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L}))));\n    Debug.Assert(GetLudic((45L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L, (long)29L, (long)37L, (long)41L, (long)43L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long FindIndex(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindIndex((2L)) == (4L));\n    Debug.Assert(FindIndex((3L)) == (14L));\n    Debug.Assert(FindIndex((4L)) == (45L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to reverse an array upto a given position.\n    public static List<long> ReverseArrayUptoK(List<long> input, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L, (long)5L, (long)6L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)4L, (long)6L, (long)7L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)6L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static List<Tuple<string, long>> SubjectMarks(List<Tuple<string, long>> subjectmarks) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L), (Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L), (Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L), (Tuple<string, long>)Tuple.Create(\"Social\", 33L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social\", 33L), (Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L), (Tuple<string, long>)Tuple.Create(\"Biology\", 45L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Biology\", 45L), (Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static string RemoveDirtyChars(string str, string second_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDirtyChars((\"probasscurve\"), (\"pros\")).Equals((\"bacuve\")));\n    Debug.Assert(RemoveDirtyChars((\"digitalindia\"), (\"talent\")).Equals((\"digiidi\")));\n    Debug.Assert(RemoveDirtyChars((\"exoticmiles\"), (\"toxic\")).Equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long MaxOccurrences(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)2L, (long)6L, (long)5L, (long)1L, (long)6L, (long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)6L, (long)9L, (long)1L, (long)2L}))) == (2L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)7L, (long)9L, (long)15L, (long)14L, (long)10L, (long)12L, (long)13L, (long)16L, (long)18L}))) == (8L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)10L, (long)20L, (long)20L, (long)30L, (long)40L, (long)90L, (long)80L, (long)50L, (long)30L, (long)20L, (long)50L, (long)10L}))) == (20L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static bool IsDecimal(string num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDecimal((\"123.11\")) == (true));\n    Debug.Assert(IsDecimal((\"e666.86\")) == (false));\n    Debug.Assert(IsDecimal((\"3.124587\")) == (false));\n    Debug.Assert(IsDecimal((\"1.11\")) == (true));\n    Debug.Assert(IsDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static Dictionary<string,long> DictFilter(Dictionary<string,long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (170L)).Equals((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (180L)).Equals((new Dictionary<string,long>(){{\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (190L)).Equals((new Dictionary<string,long>(){{\"Pierre Cox\", 190L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    public static long SumEvenAndEvenIndex(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L, (long)18L, (long)8L}))) == (30L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)3L, (long)20L, (long)17L, (long)9L, (long)2L, (long)10L, (long)18L, (long)13L, (long)6L, (long)18L}))) == (26L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long MaxSubArraySum(List<long> a, long size) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-2L, (long)-3L, (long)4L, (long)-1L, (long)-2L, (long)1L, (long)5L, (long)-3L})), (8L)) == (7L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L, (long)-2L, (long)-3L, (long)2L, (long)6L, (long)-4L})), (8L)) == (8L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-4L, (long)-5L, (long)6L, (long)-3L, (long)-4L, (long)3L, (long)7L, (long)-5L})), (8L)) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the intersection of two arrays.\n    public static List<long> IntersectionArray(List<long> array_nums1, List<long> array_nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<long>(new long[]{(long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static object SplitTwoParts(List<object> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitTwoParts((new List<object>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals(Tuple.Create(new List<long>(new long[]{(long)1L, (long)1L, (long)2L}), new List<long>(new long[]{(long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (2L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"a\", (string)\"b\"}), new List<string>(new string[]{(string)\"c\", (string)\"d\"}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"})), (4L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\"}), new List<string>(new string[]{(string)\"o\", (string)\"n\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Tuple<string, long, long> FindLiterals(string text, string pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).Equals((Tuple.Create(\"fox\", 16L, 19L))));\n    Debug.Assert(FindLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).Equals((Tuple.Create(\"crazy\", 16L, 21L))));\n    Debug.Assert(FindLiterals((\"Hardest choices required strongest will\"), (\"will\")).Equals((Tuple.Create(\"will\", 35L, 39L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the volume of a triangular prism.\n    public static long FindVolume(long l, long b, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindVolume((10L), (8L), (6L)) == (240L));\n    Debug.Assert(FindVolume((3L), (2L), (2L)) == (6L));\n    Debug.Assert(FindVolume((1L), (2L), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long WindChill(long v, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WindChill((120L), (35L)) == (40L));\n    Debug.Assert(WindChill((40L), (20L)) == (19L));\n    Debug.Assert(WindChill((10L), (8L)) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long AsciiValue(string k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AsciiValue((\"A\")) == (65L));\n    Debug.Assert(AsciiValue((\"R\")) == (82L));\n    Debug.Assert(AsciiValue((\"S\")) == (83L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether all the characters are same or not.\n    public static bool AllCharactersSame(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllCharactersSame((\"python\")) == (false));\n    Debug.Assert(AllCharactersSame((\"aaa\")) == (true));\n    Debug.Assert(AllCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static string MoveNum(string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveNum((\"I1love143you55three3000thousand\")).Equals((\"Iloveyouthreethousand1143553000\")));\n    Debug.Assert(MoveNum((\"Avengers124Assemble\")).Equals((\"AvengersAssemble124\")));\n    Debug.Assert(MoveNum((\"Its11our12path13to14see15things16do17things\")).Equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    public static bool WordLen(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordLen((\"Hadoop\")) == (false));\n    Debug.Assert(WordLen((\"great\")) == (true));\n    Debug.Assert(WordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static Dictionary<string,string> DropEmpty(Dictionary<string,string> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", null}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", null}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c2\", \"Green\"}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static List<string> InsertElement(List<string> list, string element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Black\"})), (\"c\")).Equals((new List<string>(new string[]{(string)\"c\", (string)\"Red\", (string)\"c\", (string)\"Green\", (string)\"c\", (string)\"Black\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"python\", (string)\"java\"})), (\"program\")).Equals((new List<string>(new string[]{(string)\"program\", (string)\"python\", (string)\"program\", (string)\"java\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"happy\", (string)\"sad\"})), (\"laugh\")).Equals((new List<string>(new string[]{(string)\"laugh\", (string)\"happy\", (string)\"laugh\", (string)\"sad\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static string RemoveLowercase(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLowercase((\"PYTHon\")).Equals((\"PYTH\")));\n    Debug.Assert(RemoveLowercase((\"FInD\")).Equals((\"FID\")));\n    Debug.Assert(RemoveLowercase((\"STRinG\")).Equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long CountSetBits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSetBits((2L)) == (1L));\n    Debug.Assert(CountSetBits((4L)) == (1L));\n    Debug.Assert(CountSetBits((6L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static List<string> ExtractRear(Tuple<string, string, string> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractRear((Tuple.Create(\"Mers\", \"for\", \"Vers\"))).Equals((new List<string>(new string[]{(string)\"s\", (string)\"r\", (string)\"s\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Avenge\", \"for\", \"People\"))).Equals((new List<string>(new string[]{(string)\"e\", (string)\"r\", (string)\"e\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Gotta\", \"get\", \"go\"))).Equals((new List<string>(new string[]{(string)\"a\", (string)\"t\", (string)\"o\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long CountOccurance(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurance((\"letstdlenstdporstd\")) == (3L));\n    Debug.Assert(CountOccurance((\"truststdsolensporsd\")) == (1L));\n    Debug.Assert(CountOccurance((\"makestdsostdworthit\")) == (2L));\n    Debug.Assert(CountOccurance((\"stds\")) == (1L));\n    Debug.Assert(CountOccurance((\"\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static bool CheckK(List<long> test_tup, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)10L, (long)4L, (long)5L, (long)6L, (long)8L})), (6L)) == (true));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (7L)) == (false));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)44L, (long)11L, (long)12L})), (11L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static List<long> InterleaveLists(List<long> list1, List<long> list2, List<long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L, (long)60L, (long)70L})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L, (long)500L, (long)600L, (long)700L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)100L, (long)2L, (long)20L, (long)200L, (long)3L, (long)30L, (long)300L, (long)4L, (long)40L, (long)400L, (long)5L, (long)50L, (long)500L, (long)6L, (long)60L, (long)600L, (long)7L, (long)70L, (long)700L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)10L, (long)20L})), (new List<long>(new long[]{(long)15L, (long)2L})), (new List<long>(new long[]{(long)5L, (long)10L}))).Equals((new List<long>(new long[]{(long)10L, (long)15L, (long)5L, (long)20L, (long)2L, (long)10L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)11L, (long)44L})), (new List<long>(new long[]{(long)10L, (long)15L})), (new List<long>(new long[]{(long)20L, (long)5L}))).Equals((new List<long>(new long[]{(long)11L, (long)10L, (long)20L, (long)44L, (long)15L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"python_program\")).Equals((\"PythonProgram\")));\n    Debug.Assert(SnakeToCamel((\"python_language\")).Equals((\"PythonLanguage\")));\n    Debug.Assert(SnakeToCamel((\"programming_language\")).Equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    public static long TestThreeEqual(long x, long y, long z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestThreeEqual((1L), (1L), (1L)) == (3L));\n    Debug.Assert(TestThreeEqual((-1L), (-2L), (-3L)) == (0L));\n    Debug.Assert(TestThreeEqual((1L), (2L), (2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    public static long OddLengthSum(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)4L}))) == (14L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (15L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)7L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long BellNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((10L)) == (115975L));\n    Debug.Assert(BellNumber((56L)) == (6775685320645824322581483068371419745979053216268760300L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long RectangleArea(long l, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RectangleArea((10L), (20L)) == (200L));\n    Debug.Assert(RectangleArea((10L), (5L)) == (50L));\n    Debug.Assert(RectangleArea((4L), (2L)) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Tuple<long, float> SumAverage(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumAverage((10L)).Equals((Tuple.Create(55L, 5.5f))));\n    Debug.Assert(SumAverage((15L)).Equals((Tuple.Create(120L, 8.0f))));\n    Debug.Assert(SumAverage((20L)).Equals((Tuple.Create(210L, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Tuple<long, long, long, long> DivisionElements(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisionElements((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(2L, 2L, 2L, 3L))));\n    Debug.Assert(DivisionElements((Tuple.Create(12L, 6L, 8L, 16L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(2L, 2L, 2L, 4L))));\n    Debug.Assert(DivisionElements((Tuple.Create(20L, 14L, 36L, 18L)), (Tuple.Create(5L, 7L, 6L, 9L))).Equals((Tuple.Create(4L, 2L, 6L, 2L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long SumDigits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDigits((345L)) == (12L));\n    Debug.Assert(SumDigits((12L)) == (3L));\n    Debug.Assert(SumDigits((97L)) == (16L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static string IndexMinimum(List<Tuple<string, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Rash\", 143L), (Tuple<string, long>)Tuple.Create(\"Manjeet\", 200L), (Tuple<string, long>)Tuple.Create(\"Varsha\", 100L)}))).Equals((\"Varsha\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Yash\", 185L), (Tuple<string, long>)Tuple.Create(\"Dawood\", 125L), (Tuple<string, long>)Tuple.Create(\"Sanya\", 175L)}))).Equals((\"Dawood\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sai\", 345L), (Tuple<string, long>)Tuple.Create(\"Salman\", 145L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 96L)}))).Equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static List<float> DivList(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<float>(new float[]{(float)4.0f, (float)2.5f, (float)2.0f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)3L, (long)2L})), (new List<long>(new long[]{(long)1L, (long)4L}))).Equals((new List<float>(new float[]{(float)3.0f, (float)0.5f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<float>(new float[]{(float)1.8f, (float)1.7142857142857142f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Tuple<long, List<long>> MaxLengthList(List<List<long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L})}))).Equals((Tuple.Create(5L, new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    public static long BigSum(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)2L, (long)3L, (long)6L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to return the negative numbers in a list.\n    public static List<long> NegNos(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)4L, (long)5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-6L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-2L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-7L, (long)-6L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)-7L, (long)-6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    public static long HighestPowerOf2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HighestPowerOf2((10L)) == (8L));\n    Debug.Assert(HighestPowerOf2((19L)) == (16L));\n    Debug.Assert(HighestPowerOf2((32L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static bool IsSublist(List<long> l, List<long> s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)3L, (long)7L}))) == (false));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)4L, (long)3L}))) == (true));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)1L, (long)6L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static List<long> SubList(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-3L, (long)-3L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L})), (new List<long>(new long[]{(long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-2L, (long)-2L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<long>(new long[]{(long)40L, (long)50L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    public static bool OppositeSigns(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OppositeSigns((1L), (-2L)) == (true));\n    Debug.Assert(OppositeSigns((3L), (2L)) == (false));\n    Debug.Assert(OppositeSigns((-10L), (-10L)) == (false));\n    Debug.Assert(OppositeSigns((-2L), (2L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Tuple<long, long, long, long> TupleModulo(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleModulo((Tuple.Create(10L, 4L, 5L, 6L)), (Tuple.Create(5L, 6L, 7L, 5L))).Equals((Tuple.Create(0L, 4L, 5L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(11L, 5L, 6L, 7L)), (Tuple.Create(6L, 7L, 8L, 6L))).Equals((Tuple.Create(5L, 5L, 6L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(12L, 6L, 7L, 8L)), (Tuple.Create(7L, 8L, 9L, 7L))).Equals((Tuple.Create(5L, 6L, 7L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long DiffEvenOdd(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (3L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (1L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"d\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"e\", (string)\"f\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last digit of a given number.\n    public static long LastDigit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigit((123L)) == (3L));\n    Debug.Assert(LastDigit((25L)) == (5L));\n    Debug.Assert(LastDigit((30L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    public static long OddNumSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddNumSum((2L)) == (82L));\n    Debug.Assert(OddNumSum((3L)) == (707L));\n    Debug.Assert(OddNumSum((4L)) == (3108L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static string TupString(List<string> tup1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"e\", (string)\"x\", (string)\"e\", (string)\"r\", (string)\"c\", (string)\"i\", (string)\"s\", (string)\"e\", (string)\"s\"}))).Equals((\"exercises\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))).Equals((\"python\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))).Equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static List<long> RemoveElements(List<long> list1, List<long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    public static bool Overlapping(List<long> list1, List<long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to identify non-prime numbers.\n    public static bool IsNotPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNotPrime((2L)) == (false));\n    Debug.Assert(IsNotPrime((10L)) == (true));\n    Debug.Assert(IsNotPrime((35L)) == (true));\n    Debug.Assert(IsNotPrime((37L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long SumNegativenum(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (-32L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)10L, (long)15L, (long)-14L, (long)13L, (long)-18L, (long)12L, (long)-20L}))) == (-52L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)19L, (long)-65L, (long)57L, (long)39L, (long)152L, (long)-639L, (long)121L, (long)44L, (long)90L, (long)-190L}))) == (-894L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long FindRotations(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRotations((\"aaaa\")) == (1L));\n    Debug.Assert(FindRotations((\"ab\")) == (2L));\n    Debug.Assert(FindRotations((\"abc\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static string ChangeDateFormat(string dt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeDateFormat((\"2026-01-02\")).Equals((\"02-01-2026\")));\n    Debug.Assert(ChangeDateFormat((\"2020-11-13\")).Equals((\"13-11-2020\")));\n    Debug.Assert(ChangeDateFormat((\"2021-04-26\")).Equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    public static List<long> Split(List<long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)10L, (long)11L, (long)12L, (long)13L}))).Equals((new List<long>(new long[]{(long)11L, (long)13L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)7L, (long)9L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long ToggleMiddleBits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleMiddleBits((9L)) == (15L));\n    Debug.Assert(ToggleMiddleBits((10L)) == (12L));\n    Debug.Assert(ToggleMiddleBits((11L)) == (13L));\n    Debug.Assert(ToggleMiddleBits((65L)) == (127L));\n    Debug.Assert(ToggleMiddleBits((77L)) == (115L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long CountCharPosition(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharPosition((\"xbcefg\")) == (2L));\n    Debug.Assert(CountCharPosition((\"ABcED\")) == (3L));\n    Debug.Assert(CountCharPosition((\"AbgdeF\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static List<long> LargeProduct(List<long> nums1, List<long> nums2, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (3L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (5L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L, (long)45L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long CummulativeSum(List<List<long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)6L})}))) == (30L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)7L})}))) == (37L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L})}))) == (44L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long FindMinDiff(List<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)19L, (long)18L, (long)25L})), (6L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)6L})), (4L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)30L, (long)5L, (long)20L, (long)9L})), (4L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static bool TextStartaEndb(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextStartaEndb((\"aabbbb\")) == (true));\n    Debug.Assert(TextStartaEndb((\"aabAbbbc\")) == (false));\n    Debug.Assert(TextStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long LeftRotate(long n, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftRotate((16L), (2L)) == (64L));\n    Debug.Assert(LeftRotate((10L), (2L)) == (40L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((1L), (3L)) == (8L));\n    Debug.Assert(LeftRotate((5L), (3L)) == (40L));\n    Debug.Assert(LeftRotate((29L), (3L)) == (232L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first repeated character in a given string.\n    public static string FirstRepeatedChar(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstRepeatedChar((\"abcabc\")).Equals((\"a\")));\n    Debug.Assert(FirstRepeatedChar((\"abc\")).Equals(null));\n    Debug.Assert(FirstRepeatedChar((\"123123\")).Equals((\"1\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count inversions in an array.\n    public static long GetInvCount(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)20L, (long)6L, (long)4L, (long)5L}))) == (5L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)6L, (long)1L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long EvenPowerSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPowerSum((2L)) == (1056L));\n    Debug.Assert(EvenPowerSum((3L)) == (8832L));\n    Debug.Assert(EvenPowerSum((1L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static bool GetEqual(List<List<long>> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)22L, (long)33L}), (List<long>)new List<long>(new long[]{(long)44L, (long)55L, (long)66L})}))) == (true));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})}))) == (false));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static bool CheckInteger(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckInteger((\"python\")) == (false));\n    Debug.Assert(CheckInteger((\"1\")) == (true));\n    Debug.Assert(CheckInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    public static long CountReversePairs(List<string> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"julia\", (string)\"best\", (string)\"tseb\", (string)\"for\", (string)\"ailuj\"}))) == (2L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"geeks\", (string)\"best\", (string)\"for\", (string)\"skeeg\"}))) == (1L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"makes\", (string)\"best\", (string)\"sekam\", (string)\"for\", (string)\"rof\"}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    public static List<long> MoveZero(List<long> num_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)0L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)0L, (long)0L, (long)4L, (long)0L, (long)5L, (long)0L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)4L, (long)5L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)1L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)0L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static bool CheckDistinct(List<long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L, (long)1L, (long)4L}))) == (false));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static bool NoprofitNoloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NoprofitNoloss((1500L), (1200L)) == (false));\n    Debug.Assert(NoprofitNoloss((100L), (100L)) == (true));\n    Debug.Assert(NoprofitNoloss((2000L), (5000L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static string RemoveLength(string test_str, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLength((\"The person is most value tet\"), (3L)).Equals((\"person is most value\")));\n    Debug.Assert(RemoveLength((\"If you told me about this ok\"), (4L)).Equals((\"If you me about ok\")));\n    Debug.Assert(RemoveLength((\"Forces of darkeness is come into the play\"), (4L)).Equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count number of digits in a given string.\n    public static long NumberCtr(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberCtr((\"program2bedone\")) == (1L));\n    Debug.Assert(NumberCtr((\"3wonders\")) == (1L));\n    Debug.Assert(NumberCtr((\"123\")) == (3L));\n    Debug.Assert(NumberCtr((\"3wond-1ers2\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long CountCharac(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharac((\"python programming\")) == (18L));\n    Debug.Assert(CountCharac((\"language\")) == (8L));\n    Debug.Assert(CountCharac((\"words\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long GetTotalNumberOfSequences(long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetTotalNumberOfSequences((10L), (4L)) == (4L));\n    Debug.Assert(GetTotalNumberOfSequences((5L), (2L)) == (6L));\n    Debug.Assert(GetTotalNumberOfSequences((16L), (3L)) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    public static long LeftInsertion(List<long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static List<long> SwapNumbers(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapNumbers((10L), (20L)).Equals((new List<long>(new long[]{(long)20L, (long)10L}))));\n    Debug.Assert(SwapNumbers((15L), (17L)).Equals((new List<long>(new long[]{(long)17L, (long)15L}))));\n    Debug.Assert(SwapNumbers((100L), (200L)).Equals((new List<long>(new long[]{(long)200L, (long)100L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    public static bool IsMajority(List<long> arr, long n, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)3L, (long)10L})), (7L), (3L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)4L, (long)4L, (long)4L, (long)6L, (long)6L})), (8L), (4L)) == (false));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Tuple<long, long, long> SubstractElements(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubstractElements((Tuple.Create(10L, 4L, 5L)), (Tuple.Create(2L, 5L, 18L))).Equals((Tuple.Create(8L, -1L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(11L, 2L, 3L)), (Tuple.Create(24L, 45L, 16L))).Equals((Tuple.Create(-13L, -43L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(7L, 18L, 9L)), (Tuple.Create(10L, 11L, 12L))).Equals((Tuple.Create(-3L, 7L, -3L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static string CapitalWordsSpaces(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CapitalWordsSpaces((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(CapitalWordsSpaces((\"PythonProgrammingExamples\")).Equals((\"Python Programming Examples\")));\n    Debug.Assert(CapitalWordsSpaces((\"GetReadyToBeCodingFreak\")).Equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    public static float FindAverageOfCube(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAverageOfCube((2L)) == (4.5f));\n    Debug.Assert(FindAverageOfCube((3L)) == (float)12L);\n    Debug.Assert(FindAverageOfCube((1L)) == (float)1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static bool CheckValue(Dictionary<string,long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (10L)) == (false));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (12L)) == (true));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (5L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long TetrahedralNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TetrahedralNumber((5L)) == (35L));\n    Debug.Assert(TetrahedralNumber((6L)) == (56L));\n    Debug.Assert(TetrahedralNumber((7L)) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static bool MagicSquareTest(List<List<long>> my_matrix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)12L, (long)1L, (long)14L}), (List<long>)new List<long>(new long[]{(long)2L, (long)13L, (long)8L, (long)11L}), (List<long>)new List<long>(new long[]{(long)16L, (long)3L, (long)10L, (long)5L}), (List<long>)new List<long>(new long[]{(long)9L, (long)6L, (long)15L, (long)4L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)8L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)7L})}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static string RemoveUppercase(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveUppercase((\"cAstyoUrFavoRitETVshoWs\")).Equals((\"cstyoravoitshos\")));\n    Debug.Assert(RemoveUppercase((\"wAtchTheinTernEtrAdIo\")).Equals((\"wtchheinerntrdo\")));\n    Debug.Assert(RemoveUppercase((\"VoicESeaRchAndreComMendaTionS\")).Equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long DogAge(long h_age) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DogAge((12L)) == (61L));\n    Debug.Assert(DogAge((15L)) == (73L));\n    Debug.Assert(DogAge((24L)) == (109L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    public static long NextPerfectSquare(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPerfectSquare((35L)) == (36L));\n    Debug.Assert(NextPerfectSquare((6L)) == (9L));\n    Debug.Assert(NextPerfectSquare((9L)) == (16L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static List<Dictionary<null,null>> EmptyList(long length) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EmptyList((5L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((6L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((7L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert a given string to uppercase.\n    public static string IsUpper(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUpper((\"person\")).Equals((\"PERSON\")));\n    Debug.Assert(IsUpper((\"final\")).Equals((\"FINAL\")));\n    Debug.Assert(IsUpper((\"Valid\")).Equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long OddEquivalent(string s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddEquivalent((\"011001\"), (6L)) == (3L));\n    Debug.Assert(OddEquivalent((\"11011\"), (5L)) == (4L));\n    Debug.Assert(OddEquivalent((\"1010\"), (4L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static List<long> ReArrangeArray(List<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)-1L, (long)2L, (long)-3L, (long)4L, (long)5L, (long)6L, (long)-7L, (long)8L, (long)9L})), (9L)).Equals((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-7L, (long)4L, (long)5L, (long)6L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)12L, (long)-14L, (long)-26L, (long)13L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)-14L, (long)-26L, (long)12L, (long)13L, (long)15L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)10L, (long)24L, (long)36L, (long)-42L, (long)-39L, (long)-78L, (long)85L})), (7L)).Equals((new List<long>(new long[]{(long)-42L, (long)-39L, (long)-78L, (long)10L, (long)24L, (long)36L, (long)85L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    public static bool UniqueElement(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))) == (true));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static List<string> ExtractValues(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractValues((\"\"Python\", \"PHP\", \"Java\"\")).Equals((new List<string>(new string[]{(string)\"Python\", (string)\"PHP\", (string)\"Java\"}))));\n    Debug.Assert(ExtractValues((\"\"python\",\"program\",\"language\"\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\"}))));\n    Debug.Assert(ExtractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).Equals((new List<string>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\", (string)\"yellow\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count true booleans in the given list.\n    public static long Count(List<bool> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)false, (bool)true}))) == (2L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)false, (bool)false}))) == (0L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)true, (bool)true}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long FindEvenPair(List<long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L}))) == (4L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L}))) == (9L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static bool ArmstrongNumber(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ArmstrongNumber((153L)) == (true));\n    Debug.Assert(ArmstrongNumber((259L)) == (false));\n    Debug.Assert(ArmstrongNumber((4458L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the upper case characters in a given string.\n    public static long UpperCtr(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UpperCtr((\"PYthon\")) == (1L));\n    Debug.Assert(UpperCtr((\"BigData\")) == (1L));\n    Debug.Assert(UpperCtr((\"program\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Tuple<long, long, long, long> AndTuples(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AndTuples((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(0L, 0L, 2L, 1L))));\n    Debug.Assert(AndTuples((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(5L, 6L, 7L, 8L))).Equals((Tuple.Create(1L, 2L, 3L, 0L))));\n    Debug.Assert(AndTuples((Tuple.Create(8L, 9L, 11L, 12L)), (Tuple.Create(7L, 13L, 14L, 17L))).Equals((Tuple.Create(0L, 9L, 10L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    public static bool IsSamepatterns(List<string> colors, List<string> patterns) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"green\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (true));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (false));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\"}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    public static long CountList(List<List<long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))) == (4L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))) == (3L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)2L, (long)0L})}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static List<float> AverageTuple(List<List<long>> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)12L}), (List<long>)new List<long>(new long[]{(long)30L, (long)45L, (long)56L, (long)45L}), (List<long>)new List<long>(new long[]{(long)81L, (long)80L, (long)39L, (long)32L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))).Equals((new List<float>(new float[]{(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)30L, (long)-15L, (long)56L}), (List<long>)new List<long>(new long[]{(long)81L, (long)-60L, (long)-39L}), (List<long>)new List<long>(new long[]{(long)-10L, (long)2L, (long)3L})}))).Equals((new List<float>(new float[]{(float)25.5f, (float)-18.0f, (float)3.75f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)100L, (long)100L, (long)100L, (long)120L}), (List<long>)new List<long>(new long[]{(long)300L, (long)450L, (long)560L, (long)450L}), (List<long>)new List<long>(new long[]{(long)810L, (long)800L, (long)390L, (long)320L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new List<float>(new float[]{(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long LcsOfThree(string X, string Y, string Z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2L));\n    Debug.Assert(LcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5L));\n    Debug.Assert(LcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long FindStarNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindStarNum((3L)) == (37L));\n    Debug.Assert(FindStarNum((4L)) == (73L));\n    Debug.Assert(FindStarNum((5L)) == (121L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of an array.\n    public static long Sum(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)15L, (long)12L, (long)13L, (long)10L}))) == (50L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)0L, (long)1L, (long)2L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    public static bool CheckConsecutive(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Tuple<long, long, string> FindAdverbPosition(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbPosition((\"clearly!! we can see the sky\")).Equals((Tuple.Create(0L, 7L, \"clearly\"))));\n    Debug.Assert(FindAdverbPosition((\"seriously!! there are many roses\")).Equals((Tuple.Create(0L, 9L, \"seriously\"))));\n    Debug.Assert(FindAdverbPosition((\"unfortunately!! sita is going to home\")).Equals((Tuple.Create(0L, 13L, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    public static List<long> RotateRight(List<long> list, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (3L)).Equals((new List<long>(new long[]{(long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    public static long NumberOfSubstrings(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberOfSubstrings((\"abc\")) == (6L));\n    Debug.Assert(NumberOfSubstrings((\"abcd\")) == (10L));\n    Debug.Assert(NumberOfSubstrings((\"abcde\")) == (15L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static List<List<object>> ListSplit(List<object> S, long step) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"e\", (string)\"f\", (string)\"g\", (string)\"h\", (string)\"i\", (string)\"j\", (string)\"k\", (string)\"l\", (string)\"m\", (string)\"n\"})), (3L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"d\", (string)\"g\", (string)\"j\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"b\", (string)\"e\", (string)\"h\", (string)\"k\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"f\", (string)\"i\", (string)\"l\"})}))));\n    Debug.Assert(ListSplit((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L, (long)12L, (long)13L, (long)14L})), (3L)).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)10L, (long)13L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L, (long)8L, (long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)12L})}))));\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"python\", (string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\", (string)\"SQL\"})), (2L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"python\", (string)\"C\", (string)\"DBMS\"}), (List<string>)new List<string>(new string[]{(string)\"java\", (string)\"C++\", (string)\"SQL\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    public static bool AllUnique(List<long> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    public static Tuple<float, float> Convert(long numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Convert((1L)).Equals((Tuple.Create(1.0f, 0.0f))));\n    Debug.Assert(Convert((4L)).Equals((Tuple.Create(4.0f, 0.0f))));\n    Debug.Assert(Convert((5L)).Equals((Tuple.Create(5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static Dictionary<string,Tuple<float, long>> FilterData(Dictionary<string,Tuple<float, long>> students, float h, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (6.0f), (70L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.9f), (67L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.7f), (64L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert the given string to lower case.\n    public static string IsLower(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsLower((\"InValid\")).Equals((\"invalid\")));\n    Debug.Assert(IsLower((\"TruE\")).Equals((\"true\")));\n    Debug.Assert(IsLower((\"SenTenCE\")).Equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    public static long NextPowerOf2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPowerOf2((0L)) == (1L));\n    Debug.Assert(NextPowerOf2((5L)) == (8L));\n    Debug.Assert(NextPowerOf2((17L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static bool FindSubstring(List<string> str1, string sub_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ack\")) == (true));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"abc\")) == (false));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static string ReplaceChar(string str1, string ch, string newch) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceChar((\"polygon\"), (\"y\"), (\"l\")).Equals((\"pollgon\")));\n    Debug.Assert(ReplaceChar((\"character\"), (\"c\"), (\"a\")).Equals((\"aharaater\")));\n    Debug.Assert(ReplaceChar((\"python\"), (\"l\"), (\"a\")).Equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long MulEvenOdd(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (4L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static object ListTuple(List<long> listx) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)5L, (long)10L, (long)7L, (long)4L, (long)15L, (long)3L}))).Equals(Tuple.Create(5L, 10L, 7L, 4L, 15L, 3L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)2L, (long)3L, (long)4L, (long)4L, (long)7L}))).Equals(Tuple.Create(2L, 4L, 5L, 6L, 2L, 3L, 4L, 4L, 7L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)58L, (long)44L, (long)56L}))).Equals(Tuple.Create(58L, 44L, 56L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long EvenBinomialCoeffSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenBinomialCoeffSum((4L)) == (8L));\n    Debug.Assert(EvenBinomialCoeffSum((6L)) == (32L));\n    Debug.Assert(EvenBinomialCoeffSum((2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Tuple<long, long, long, long> BitwiseXor(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BitwiseXor((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(15L, 6L, 5L, 10L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(11L, 5L, 7L, 10L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(13L, 6L, 3L, 14L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(12L, 6L, 8L, 11L)), (Tuple.Create(7L, 4L, 5L, 6L))).Equals((Tuple.Create(11L, 2L, 13L, 13L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    public static bool IsSubArray(List<long> A, List<long> B) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)2L}))) == (false));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (true));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)2L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)0L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    public static long MaxSubArraySumRepeated(List<long> a, long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)10L, (long)20L, (long)-30L, (long)-1L})), (4L), (3L)) == (30L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)10L, (long)20L})), (3L), (2L)) == (59L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})), (3L), (3L)) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long MinProductTuple(List<Tuple<long, long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (8L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (30L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (100L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    public static bool CountDivisors(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDivisors((10L)) == (true));\n    Debug.Assert(CountDivisors((100L)) == (false));\n    Debug.Assert(CountDivisors((125L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Nullable<long> TriangleArea(long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((-1L)).Equals(null));\n    Debug.Assert(TriangleArea((0L)).Equals(0L));\n    Debug.Assert(TriangleArea((2L)).Equals(4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static List<string> StringToTuple(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToTuple((\"python 3.0\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\", (string)\"3\", (string)\".\", (string)\"0\"}))));\n    Debug.Assert(StringToTuple((\"item1\")).Equals((new List<string>(new string[]{(string)\"i\", (string)\"t\", (string)\"e\", (string)\"m\", (string)\"1\"}))));\n    Debug.Assert(StringToTuple((\"15.10\")).Equals((new List<string>(new string[]{(string)\"1\", (string)\"5\", (string)\".\", (string)\"1\", (string)\"0\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long FindLength(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLength((\"11000010001\")) == (6L));\n    Debug.Assert(FindLength((\"10111\")) == (1L));\n    Debug.Assert(FindLength((\"11011101100101\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long CountPrimesNums(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPrimesNums((5L)) == (2L));\n    Debug.Assert(CountPrimesNums((10L)) == (4L));\n    Debug.Assert(CountPrimesNums((100L)) == (25L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    public static long SumOfProduct(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfProduct((3L)) == (15L));\n    Debug.Assert(SumOfProduct((4L)) == (56L));\n    Debug.Assert(SumOfProduct((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Tuple<string, long> MaxAggregate(List<Tuple<string, long>> stdata) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 90L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 88L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 7L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 122L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 84L)}))).Equals((Tuple.Create(\"Juan Whelan\", 212L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 50L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 48L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 37L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 22L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 14L)}))).Equals((Tuple.Create(\"Juan Whelan\", 72L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 10L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 20L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 30L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 40L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 50L)}))).Equals((Tuple.Create(\"Sabah Colley\", 70L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> CombSort(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)5L, (long)15L, (long)37L, (long)25L, (long)79L}))).Equals((new List<long>(new long[]{(long)5L, (long)15L, (long)25L, (long)37L, (long)79L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)41L, (long)32L, (long)15L, (long)19L, (long)22L}))).Equals((new List<long>(new long[]{(long)15L, (long)19L, (long)22L, (long)32L, (long)41L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)99L, (long)15L, (long)13L, (long)47L}))).Equals((new List<long>(new long[]{(long)13L, (long)15L, (long)47L, (long)99L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static bool CheckExpression(string exp) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckExpression((\"{()}[{}]\")) == (true));\n    Debug.Assert(CheckExpression((\"{()}[{]\")) == (false));\n    Debug.Assert(CheckExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static bool TextMatchWordz(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordz((\"pythonz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"xyz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static List<long> SumList(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumList((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)25L, (long)35L}))).Equals((new List<long>(new long[]{(long)25L, (long)45L, (long)65L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)5L, (long)6L, (long)7L}))).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)15L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)45L, (long)75L}))).Equals((new List<long>(new long[]{(long)30L, (long)65L, (long)105L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long NewmanPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewmanPrime((3L)) == (7L));\n    Debug.Assert(NewmanPrime((4L)) == (17L));\n    Debug.Assert(NewmanPrime((5L)) == (41L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static List<string> AddString(List<object> list_, string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddString((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (\"temp{0}\")).Equals((new List<string>(new string[]{(string)\"temp1\", (string)\"temp2\", (string)\"temp3\", (string)\"temp4\"}))));\n    Debug.Assert(AddString((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (\"python{0}\")).Equals((new List<string>(new string[]{(string)\"pythona\", (string)\"pythonb\", (string)\"pythonc\", (string)\"pythond\"}))));\n    Debug.Assert(AddString((new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})), (\"string{0}\")).Equals((new List<string>(new string[]{(string)\"string5\", (string)\"string6\", (string)\"string7\", (string)\"string8\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    public static long SurfaceArea(long b, long s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceArea((3L), (4L)) == (33L));\n    Debug.Assert(SurfaceArea((4L), (5L)) == (56L));\n    Debug.Assert(SurfaceArea((1L), (2L)) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(List<List<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))) == (1L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))) == (2L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L})}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static bool Validate(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Validate((1234L)) == (true));\n    Debug.Assert(Validate((51241L)) == (false));\n    Debug.Assert(Validate((321L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long HexagonalNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexagonalNum((10L)) == (190L));\n    Debug.Assert(HexagonalNum((5L)) == (45L));\n    Debug.Assert(HexagonalNum((7L)) == (91L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long FindLucas(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLucas((9L)) == (76L));\n    Debug.Assert(FindLucas((4L)) == (7L));\n    Debug.Assert(FindLucas((3L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to get the difference between two lists.\n    public static List<long> Diff(List<long> li1, List<long> li2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Diff((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L, (long)30L, (long)35L, (long)40L})), (new List<long>(new long[]{(long)25L, (long)40L, (long)35L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)15L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static List<object> ExtractQuotation(string text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).Equals((new List<object>(new string[]{(string)\"A53\", (string)\"multi\", (string)\"Processor\"}))));\n    Debug.Assert(ExtractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).Equals((new List<object>(new string[]{(string)\"favorite\", (string)\"apps\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).Equals((new List<object>(new string[]{(string)\"4k Ultra HD\", (string)\"HDR 10\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    public static bool DifferAtOneBitPos(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifferAtOneBitPos((13L), (9L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((15L), (8L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (4L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (3L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((5L), (1L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((1L), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static bool TextMatchThree(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchThree((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    public static long MaxProduct(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)3L, (long)100L, (long)4L, (long)5L, (long)150L, (long)6L}))) == (3000L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)4L, (long)42L, (long)55L, (long)68L, (long)80L}))) == (50265600L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)10L, (long)22L, (long)9L, (long)33L, (long)21L, (long)50L, (long)41L, (long)60L}))) == (2460L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    public static List<long> SplitArr(List<long> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)12L, (long)10L, (long)5L, (long)6L, (long)52L, (long)36L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)52L, (long)36L, (long)12L, (long)10L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (1L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (3L)).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)0L, (long)1L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    public static long Divisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Divisor((15L)) == (4L));\n    Debug.Assert(Divisor((12L)) == (6L));\n    Debug.Assert(Divisor((9L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    public static long BigDiff(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)4L, (long)5L, (long)12L}))) == (8L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)9L, (long)2L, (long)3L}))) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static List<long> SquareNums(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)100L, (long)400L, (long)900L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)144L, (long)225L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static bool CheckNone(object test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckNone(Tuple.Create(10L, 4L, 5L, 6L, (Nullable<long>)null)) == (true));\n    Debug.Assert(CheckNone(Tuple.Create(7L, 8L, 9L, 11L, 14L)) == (false));\n    Debug.Assert(CheckNone(Tuple.Create(1L, 2L, 3L, 4L, (Nullable<long>)null)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    public static bool IsMonotonic(List<long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static bool IsPerfectSquare(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPerfectSquare((10L)) == (false));\n    Debug.Assert(IsPerfectSquare((36L)) == (true));\n    Debug.Assert(IsPerfectSquare((14L)) == (false));\n    Debug.Assert(IsPerfectSquare((196L)) == (true));\n    Debug.Assert(IsPerfectSquare((125L)) == (false));\n    Debug.Assert(IsPerfectSquare((15625L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    public static long Sum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((10L), (15L)) == (6L));\n    Debug.Assert(Sum((100L), (150L)) == (93L));\n    Debug.Assert(Sum((4L), (6L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Tuple<long, List<long>> MaxLength(List<List<long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)15L, (long)20L, (long)25L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)15L, (long)20L, (long)25L})))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static Dictionary<Tuple<long, long>,long> CheckOccurences(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(5L, 2L), (Tuple<long, long>)Tuple.Create(6L, 3L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(1L, 3L), 2L}, {Tuple.Create(2L, 5L), 2L}, {Tuple.Create(3L, 6L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 2L), (Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(3L, 6L), (Tuple<long, long>)Tuple.Create(6L, 3L), (Tuple<long, long>)Tuple.Create(7L, 4L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 4L), 2L}, {Tuple.Create(3L, 6L), 2L}, {Tuple.Create(4L, 7L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(13L, 2L), (Tuple<long, long>)Tuple.Create(11L, 23L), (Tuple<long, long>)Tuple.Create(12L, 25L), (Tuple<long, long>)Tuple.Create(25L, 12L), (Tuple<long, long>)Tuple.Create(16L, 23L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 13L), 1L}, {Tuple.Create(11L, 23L), 1L}, {Tuple.Create(12L, 25L), 2L}, {Tuple.Create(16L, 23L), 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long ParabolaDirectrix(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParabolaDirectrix((5L), (3L), (2L)) == (-198L));\n    Debug.Assert(ParabolaDirectrix((9L), (8L), (4L)) == (-2336L));\n    Debug.Assert(ParabolaDirectrix((2L), (4L), (6L)) == (-130L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    public static Tuple<string, long, long> OccuranceSubstring(string text, string pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OccuranceSubstring((\"python programming, python language\"), (\"python\")).Equals((Tuple.Create(\"python\", 0L, 6L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"programming\")).Equals((Tuple.Create(\"programming\", 7L, 18L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"language\")).Equals((Tuple.Create(\"language\", 31L, 39L))));\n    Debug.Assert(OccuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).Equals(null));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Tuple<long, long, long, long> RemoveNested(object test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveNested(Tuple.Create(1L, 5L, 7L, Tuple.Create(4L, 6L), 10L)).Equals((Tuple.Create(1L, 5L, 7L, 10L))));\n    Debug.Assert(RemoveNested(Tuple.Create(2L, 6L, 8L, Tuple.Create(5L, 7L), 11L)).Equals((Tuple.Create(2L, 6L, 8L, 11L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), Tuple.Create(5L, 12L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\"blue \", (string)\" black\"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\" black\", (string)\"blue \"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"zilver\", (string)\"gold\"}), (List<string>)new List<string>(new string[]{(string)\"magnesium\", (string)\"aluminium\"}), (List<string>)new List<string>(new string[]{(string)\"steel\", (string)\"bronze\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"gold\", (string)\"zilver\"}), (List<string>)new List<string>(new string[]{(string)\"aluminium\", (string)\"magnesium\"}), (List<string>)new List<string>(new string[]{(string)\"bronze\", (string)\"steel\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static List<long> RemoveKthElement(List<long> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Tuple<long, long, long, Dictionary<string,long>> AddDictToTuple(Tuple<long, long, long> test_tup, Dictionary<string,long> test_dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddDictToTuple((Tuple.Create(4L, 5L, 6L)), (new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}})).Equals((Tuple.Create(4L, 5L, 6L, new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(1L, 2L, 3L)), (new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}})).Equals((Tuple.Create(1L, 2L, 3L, new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(8L, 9L, 10L)), (new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}})).Equals((Tuple.Create(8L, 9L, 10L, new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long Find(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Find((10L), (3L)) == (3L));\n    Debug.Assert(Find((4L), (2L)) == (2L));\n    Debug.Assert(Find((20L), (5L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static bool TextMatchTwoThree(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchTwoThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    public static long CountOccurrence(object tup, List<object> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurrence(Tuple.Create(\"a\", \"a\", \"c\", \"b\", \"d\"), (new List<object>(new string[]{(string)\"a\", (string)\"b\"}))) == (3L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 1L, 4L, 6L, 7L, 1L, 4L), (new List<object>(new long[]{(long)1L, (long)4L, (long)7L}))) == (6L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L), (new List<object>(new long[]{(long)1L, (long)2L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long CountSamepair(List<long> list1, List<long> list2, List<long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (3L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (4L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static bool TextMatchOne(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long Difference(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Difference((3L)) == (30L));\n    Debug.Assert(Difference((5L)) == (210L));\n    Debug.Assert(Difference((2L)) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static string ToggleString(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleString((\"Python\")).Equals((\"pYTHON\")));\n    Debug.Assert(ToggleString((\"Pangram\")).Equals((\"pANGRAM\")));\n    Debug.Assert(ToggleString((\"LIttLE\")).Equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the element of a list having maximum length.\n    public static List<object> FindMax(List<List<object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"})}))).Equals((new List<object>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L})}))).Equals((new List<object>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long EulerianNum(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EulerianNum((3L), (1L)) == (4L));\n    Debug.Assert(EulerianNum((4L), (1L)) == (11L));\n    Debug.Assert(EulerianNum((5L), (3L)) == (26L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long Frequency(List<long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L)) == (0L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L})), (3L)) == (3L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)1L, (long)2L})), (1L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    public static List<long> SortNumericStrings(List<string> nums_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"4\", (string)\"12\", (string)\"45\", (string)\"7\", (string)\"0\", (string)\"100\", (string)\"200\", (string)\"-12\", (string)\"-500\"}))).Equals((new List<long>(new long[]{(long)-500L, (long)-12L, (long)0L, (long)4L, (long)7L, (long)12L, (long)45L, (long)100L, (long)200L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"2\", (string)\"3\", (string)\"8\", (string)\"4\", (string)\"7\", (string)\"9\", (string)\"8\", (string)\"2\", (string)\"6\", (string)\"5\", (string)\"1\", (string)\"6\", (string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"6\", (string)\"9\", (string)\"1\", (string)\"2\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)8L, (long)9L, (long)9L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"1\", (string)\"3\", (string)\"5\", (string)\"7\", (string)\"1\", (string)\"3\", (string)\"13\", (string)\"15\", (string)\"17\", (string)\"5\", (string)\"7 \", (string)\"9\", (string)\"1\", (string)\"11\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)3L, (long)3L, (long)5L, (long)5L, (long)7L, (long)7L, (long)9L, (long)11L, (long)13L, (long)15L, (long)17L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    public static float GeometricSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GeometricSum((7L)) == (1.9921875f));\n    Debug.Assert(GeometricSum((4L)) == (1.9375f));\n    Debug.Assert(GeometricSum((8L)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    public static List<long> DivisibleByDigits(long startnum, long endnum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisibleByDigits((1L), (22L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L, (long)22L}))));\n    Debug.Assert(DivisibleByDigits((1L), (15L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L}))));\n    Debug.Assert(DivisibleByDigits((20L), (25L)).Equals((new List<long>(new long[]{(long)22L, (long)24L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    public static long UniqueProduct(List<long> list_data) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)20L, (long)50L, (long)60L, (long)40L}))) == (720000000L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L}))) == (6L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)0L, (long)1L, (long)1L}))) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the largest negative number from the given list.\n    public static long LargestNeg(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-4L, (long)-6L}))) == (-6L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-8L, (long)-9L}))) == (-9L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static List<object> ConsecutiveDuplicates(List<object> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<object>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<object>(new long[]{(long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\", (string)\"a\", (string)\"a\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"a\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float MinJumps(Tuple<long, long> steps, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (11L)) == (3.5f));\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (0L)) == (float)0L);\n    Debug.Assert(MinJumps((Tuple.Create(11L, 14L)), (11L)) == (float)1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    public static Tuple<long, long> MaxProduct(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)0L, (long)8L, (long)4L}))).Equals((Tuple.Create(7L, 8L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)0L, (long)-1L, (long)-2L, (long)-4L, (long)5L, (long)0L, (long)-6L}))).Equals((Tuple.Create(-4L, -6L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((Tuple.Create(2L, 3L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static List<object> ExtractNthElement(List<Tuple<string, long, long>> list1, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (0L)).Equals((new List<object>(new string[]{(string)\"Greyson Fulton\", (string)\"Brady Kent\", (string)\"Wyatt Knott\", (string)\"Beau Turnbull\"}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (2L)).Equals((new List<object>(new long[]{(long)99L, (long)96L, (long)94L, (long)98L}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (1L)).Equals((new List<object>(new long[]{(long)98L, (long)97L, (long)91L, (long)94L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long IsNonagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNonagonal((10L)) == (325L));\n    Debug.Assert(IsNonagonal((15L)) == (750L));\n    Debug.Assert(IsNonagonal((18L)) == (1089L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    public static long MaxAbsDiff(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)3L}))) == (4L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)9L, (long)3L, (long)2L, (long)5L, (long)1L}))) == (8L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static List<List<object>> PackConsecutiveDuplicates(List<object> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)8L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L}), (List<long>)new List<long>(new long[]{(long)15L}), (List<long>)new List<long>(new long[]{(long)19L}), (List<long>)new List<long>(new long[]{(long)18L, (long)18L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)26L, (long)26L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)18L}), (List<long>)new List<long>(new long[]{(long)10L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"a\"}), (List<string>)new List<string>(new string[]{(string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"d\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long CalSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CalSum((9L)) == (49L));\n    Debug.Assert(CalSum((10L)) == (66L));\n    Debug.Assert(CalSum((11L)) == (88L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    public static string OddValuesString(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddValuesString((\"abcdef\")).Equals((\"ace\")));\n    Debug.Assert(OddValuesString((\"python\")).Equals((\"pto\")));\n    Debug.Assert(OddValuesString((\"data\")).Equals((\"dt\")));\n    Debug.Assert(OddValuesString((\"lambs\")).Equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    public static long FindKth(List<long> arr1, List<long> arr2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)8L, (long)10L})), (5L)) == (6L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)100L, (long)112L, (long)256L, (long)349L, (long)770L})), (new List<long>(new long[]{(long)72L, (long)86L, (long)113L, (long)119L, (long)265L, (long)445L, (long)892L})), (7L)) == (256L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)3L, (long)4L, (long)7L, (long)8L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)9L, (long)11L})), (6L)) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long JacobsthalNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(JacobsthalNum((5L)) == (11L));\n    Debug.Assert(JacobsthalNum((2L)) == (1L));\n    Debug.Assert(JacobsthalNum((4L)) == (5L));\n    Debug.Assert(JacobsthalNum((13L)) == (2731L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static Dictionary<long,long> FrequencyLists(List<List<long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)2L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)5L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 3L}, {3L, 1L}, {4L, 1L}, {5L, 2L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 1L}, {3L, 1L}, {4L, 1L}, {5L, 1L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}, {10L, 1L}, {11L, 1L}, {12L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)20L, (long)30L, (long)40L, (long)17L}), (List<long>)new List<long>(new long[]{(long)18L, (long)16L, (long)14L, (long)13L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new Dictionary<long,long>(){{20L, 2L}, {30L, 2L}, {40L, 2L}, {17L, 1L}, {18L, 1L}, {16L, 1L}, {14L, 1L}, {13L, 1L}, {10L, 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static List<long> PerfectSquares(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerfectSquares((1L), (30L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L}))));\n    Debug.Assert(PerfectSquares((50L), (100L)).Equals((new List<long>(new long[]{(long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(PerfectSquares((100L), (200L)).Equals((new List<long>(new long[]{(long)100L, (long)121L, (long)144L, (long)169L, (long)196L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    public static long SumOfSubarrayProd(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (20L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L}))) == (5L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    public static long FirstOdd(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)8L, (long)9L, (long)1L}))) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static List<List<long>> AddNestedTuples(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)10L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)13L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)12L}), (List<long>)new List<long>(new long[]{(long)9L, (long)16L}), (List<long>)new List<long>(new long[]{(long)5L, (long)12L}), (List<long>)new List<long>(new long[]{(long)10L, (long)15L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)11L, (long)18L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)12L, (long)17L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static List<List<object>> Merge(List<List<object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L})}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\", (string)\"o\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"z\", (string)\"c\", (string)\"o\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    public static bool DifSquare(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifSquare((5L)) == (true));\n    Debug.Assert(DifSquare((10L)) == (false));\n    Debug.Assert(DifSquare((15L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static bool CheckSmaller(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckSmaller((Tuple.Create(1L, 2L, 3L)), (Tuple.Create(2L, 3L, 4L))) == (false));\n    Debug.Assert(CheckSmaller((Tuple.Create(4L, 5L, 6L)), (Tuple.Create(3L, 4L, 5L))) == (true));\n    Debug.Assert(CheckSmaller((Tuple.Create(11L, 12L, 13L)), (Tuple.Create(10L, 11L, 12L))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static Dictionary<long,long> FreqCount(List<long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)10L, (long)20L, (long)20L, (long)20L, (long)20L, (long)40L, (long)40L, (long)50L, (long)50L, (long)30L}))).Equals((new Dictionary<long,long>(){{10L, 4L}, {20L, 4L}, {40L, 2L}, {50L, 2L}, {30L, 1L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)4L, (long)1L, (long)3L, (long)1L, (long)4L}))).Equals((new Dictionary<long,long>(){{1L, 3L}, {2L, 2L}, {3L, 3L}, {4L, 3L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)4L, (long)9L, (long)10L, (long)4L, (long)5L, (long)6L, (long)7L, (long)9L, (long)5L}))).Equals((new Dictionary<long,long>(){{10L, 1L}, {5L, 3L}, {6L, 2L}, {7L, 2L}, {4L, 2L}, {9L, 2L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static List<float> RgbToHsv(long r, long g, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RgbToHsv((255L), (255L), (255L)).Equals((new List<float>(new float[]{(float)0.0f, (float)0.0f, (float)100.0f}))));\n    Debug.Assert(RgbToHsv((0L), (215L), (0L)).Equals((new List<float>(new float[]{(float)120.0f, (float)100.0f, (float)84.31372549019608f}))));\n    Debug.Assert(RgbToHsv((10L), (215L), (110L)).Equals((new List<float>(new float[]{(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static bool CheckStr(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckStr((\"annie\")) == (true));\n    Debug.Assert(CheckStr((\"dawood\")) == (false));\n    Debug.Assert(CheckStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static bool CheckMonthnumberNumber(long monthnum3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumberNumber((6L)) == (true));\n    Debug.Assert(CheckMonthnumberNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumberNumber((12L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list.\n    public static List<long> HeapSort(List<long> iterable) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L}))).Equals((new List<long>(new long[]{(long)14L, (long)22L, (long)25L, (long)25L, (long)35L, (long)58L, (long)65L, (long)75L, (long)85L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)7L, (long)1L, (long)9L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    public static List<List<long>> KSmallestPairs(List<long> nums1, List<long> nums2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (7L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)2L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    public static Tuple<long, long> FindSolution(long a, long b, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSolution((2L), (3L), (7L)).Equals((Tuple.Create(2L, 1L))));\n    Debug.Assert(FindSolution((4L), (2L), (7L)).Equals(null));\n    Debug.Assert(FindSolution((1L), (13L), (17L)).Equals((Tuple.Create(4L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    public static long FindMaxNum(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (321L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)1L}))) == (6541L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)9L}))) == (9321L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static List<long> MaxSumList(List<List<long>> lists) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)10L, (long)11L, (long)12L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)12L, (long)11L, (long)10L})}))).Equals((new List<long>(new long[]{(long)12L, (long)11L, (long)10L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)1L})}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    public static List<long> SwapList(List<long> newList) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)12L, (long)35L, (long)9L, (long)56L, (long)24L}))).Equals((new List<long>(new long[]{(long)24L, (long)35L, (long)9L, (long)56L, (long)12L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float GetMedian(List<long> arr1, List<long> arr2, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)1L, (long)12L, (long)15L, (long)26L, (long)38L})), (new List<long>(new long[]{(long)2L, (long)13L, (long)17L, (long)30L, (long)45L})), (5L)) == (16.0f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)7L, (long)13L, (long)19L, (long)28L})), (4L)) == (8.5f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)3L, (long)6L, (long)14L, (long)23L, (long)36L, (long)42L})), (new List<long>(new long[]{(long)2L, (long)18L, (long)27L, (long)39L, (long)49L, (long)55L})), (6L)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static string ReplaceSpaces(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"Jumanji The Jungle\")).Equals((\"Jumanji_The_Jungle\")));\n    Debug.Assert(ReplaceSpaces((\"The_Avengers\")).Equals((\"The Avengers\")));\n    Debug.Assert(ReplaceSpaces((\"Fast and Furious\")).Equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static bool AreEquivalent(long num1, long num2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreEquivalent((36L), (57L)) == (false));\n    Debug.Assert(AreEquivalent((2L), (4L)) == (false));\n    Debug.Assert(AreEquivalent((23L), (47L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static List<string> ReverseStringList(List<string> stringlist) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\", (string)\"White\", (string)\"Black\"}))).Equals((new List<string>(new string[]{(string)\"deR\", (string)\"neerG\", (string)\"eulB\", (string)\"etihW\", (string)\"kcalB\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"john\", (string)\"amal\", (string)\"joel\", (string)\"george\"}))).Equals((new List<string>(new string[]{(string)\"nhoj\", (string)\"lama\", (string)\"leoj\", (string)\"egroeg\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"jack\", (string)\"john\", (string)\"mary\"}))).Equals((new List<string>(new string[]{(string)\"kcaj\", (string)\"nhoj\", (string)\"yram\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long SumOfDigits(List<object> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)2L, (long)56L}))) == (14L));\n    Debug.Assert(SumOfDigits((new List<object>(new List<long>[]{(List<long>)new List<object>(new object[]{10L, 20L, 4L, 5L, \"b\", 70L, \"a\"})}))) == (19L));\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)20L, (long)-4L, (long)5L, (long)-70L}))) == (19L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long Sequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sequence((10L)) == (6L));\n    Debug.Assert(Sequence((2L)) == (1L));\n    Debug.Assert(Sequence((3L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static List<long> HeapQueueLargest(List<long> nums, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (3L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (2L)).Equals((new List<long>(new long[]{(long)85L, (long)75L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (5L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L, (long)58L, (long)35L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long LossAmount(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LossAmount((1500L), (1200L)) == (0L));\n    Debug.Assert(LossAmount((100L), (200L)) == (100L));\n    Debug.Assert(LossAmount((2000L), (5000L)) == (3000L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static List<long> UnionElements(List<long> test_tup1, List<long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)4L, (long)10L}))).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)10L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L})), (new List<long>(new long[]{(long)13L, (long)15L, (long)16L, (long)17L}))).Equals((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L, (long)15L, (long)16L, (long)17L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the longest sublists.\n    public static long FindMaxLength(List<List<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (4L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L})}))) == (3L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)22L, (long)23L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L})}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static string RemoveParenthesis(List<string> items) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"python (chrome)\"}))).Equals((\"python\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"string(.abc)\"}))).Equals((\"string\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"alpha(num)\"}))).Equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    public static bool FindParity(long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindParity((12L)) == (false));\n    Debug.Assert(FindParity((7L)) == (true));\n    Debug.Assert(FindParity((10L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float MedianTrapezium(long base1, long base2, long height) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianTrapezium((15L), (25L), (35L)) == (float)20L);\n    Debug.Assert(MedianTrapezium((10L), (20L), (30L)) == (float)15L);\n    Debug.Assert(MedianTrapezium((6L), (9L), (4L)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long CenteredHexagonalNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CenteredHexagonalNumber((10L)) == (271L));\n    Debug.Assert(CenteredHexagonalNumber((2L)) == (7L));\n    Debug.Assert(CenteredHexagonalNumber((9L)) == (217L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long FindLists(List<object> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (2L));\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))) == (3L));\n    Debug.Assert(FindLists((new List<object>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long GetMaxSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxSum((60L)) == (106L));\n    Debug.Assert(GetMaxSum((10L)) == (12L));\n    Debug.Assert(GetMaxSum((2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the longest word.\n    public static long LenLog(List<string> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"python\", (string)\"PHP\", (string)\"bigdata\"}))) == (7L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))) == (3L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"small\", (string)\"big\", (string)\"tall\"}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    public static Nullable<float> SectorArea(long r, long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SectorArea((4L), (45L)).Equals(6.283185307179586f));\n    Debug.Assert(SectorArea((9L), (45L)).Equals(31.808625617596654f));\n    Debug.Assert(SectorArea((9L), (361L)).Equals(null));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    public static bool OddPosition(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L, (long)6L, (long)7L, (long)6L, (long)3L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)4L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long MultipleToSingle(List<long> L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)11L, (long)33L, (long)50L}))) == (113350L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (-123456L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L}))) == (10152025L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    public static bool IsDiff(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDiff((12345L)) == (false));\n    Debug.Assert(IsDiff((1212112L)) == (true));\n    Debug.Assert(IsDiff((1212L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static List<List<long>> IndexMultiplication(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)21L}), (List<long>)new List<long>(new long[]{(long)12L, (long)45L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)30L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)14L, (long)32L}), (List<long>)new List<long>(new long[]{(long)20L, (long)60L}), (List<long>)new List<long>(new long[]{(long)6L, (long)20L}), (List<long>)new List<long>(new long[]{(long)16L, (long)44L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)24L, (long)45L}), (List<long>)new List<long>(new long[]{(long)30L, (long)77L}), (List<long>)new List<long>(new long[]{(long)12L, (long)33L}), (List<long>)new List<long>(new long[]{(long)27L, (long)60L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Tuple<long, long, long> TupleStrInt(string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleStrInt((\"(7, 8, 9)\")).Equals((Tuple.Create(7L, 8L, 9L))));\n    Debug.Assert(TupleStrInt((\"(1, 2, 3)\")).Equals((Tuple.Create(1L, 2L, 3L))));\n    Debug.Assert(TupleStrInt((\"(4, 5, 6)\")).Equals((Tuple.Create(4L, 5L, 6L))));\n    Debug.Assert(TupleStrInt((\"(7, 81, 19)\")).Equals((Tuple.Create(7L, 81L, 19L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long AmicableNumbersSum(long limit) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AmicableNumbersSum((999L)) == (504L));\n    Debug.Assert(AmicableNumbersSum((9999L)) == (31626L));\n    Debug.Assert(AmicableNumbersSum((99L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static string RemoveOdd(string str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((\"python\")).Equals((\"yhn\")));\n    Debug.Assert(RemoveOdd((\"program\")).Equals((\"rga\")));\n    Debug.Assert(RemoveOdd((\"language\")).Equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static List<object> MultiplyElements(List<long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)8L, (long)10L}))).Equals((new List<object>(new long[]{(long)5L, (long)35L, (long)56L, (long)80L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)8L, (long)20L, (long)30L, (long)42L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L, (long)13L, (long)14L, (long)9L, (long)15L}))).Equals((new List<object>(new long[]{(long)156L, (long)182L, (long)126L, (long)135L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L}))).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    public static long CountRotation(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)4L, (long)5L, (long)1L, (long)2L, (long)3L}))) == (2L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (0L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long ExtractFreq(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(5L, 6L)}))) == (3L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 15L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L)}))) == (4L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 16L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 9L)}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long CountSamePair(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (4L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (11L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (1L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)2L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)2L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long Power(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Power((3L), (4L)) == (81L));\n    Debug.Assert(Power((2L), (3L)) == (8L));\n    Debug.Assert(Power((5L), (5L)) == (3125L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long ReturnSum(Dictionary<string,long> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 100L}, {\"b\", 200L}, {\"c\", 300L}})) == (600L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 25L}, {\"b\", 18L}, {\"c\", 45L}})) == (88L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 36L}, {\"b\", 39L}, {\"c\", 49L}})) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static List<Tuple<long, long>> PairWise(List<long> l1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 5L), (Tuple<long, long>)Tuple.Create(5L, 7L), (Tuple<long, long>)Tuple.Create(7L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)5L, (long)1L, (long)9L, (long)7L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(1L, 9L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(7L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L), (Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to split a string into characters.\n    public static List<string> Split(string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((\"python\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))));\n    Debug.Assert(Split((\"Name\")).Equals((new List<string>(new string[]{(string)\"N\", (string)\"a\", (string)\"m\", (string)\"e\"}))));\n    Debug.Assert(Split((\"program\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long MinOfThree(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinOfThree((10L), (20L), (0L)) == (0L));\n    Debug.Assert(MinOfThree((19L), (15L), (18L)) == (15L));\n    Debug.Assert(MinOfThree((-10L), (-20L), (-30L)) == (-30L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static bool IsSumOfPowersOfTwo(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSumOfPowersOfTwo((10L)) == (true));\n    Debug.Assert(IsSumOfPowersOfTwo((7L)) == (false));\n    Debug.Assert(IsSumOfPowersOfTwo((14L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static string GetChar(string strr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetChar((\"abc\")).Equals((\"f\")));\n    Debug.Assert(GetChar((\"gfg\")).Equals((\"t\")));\n    Debug.Assert(GetChar((\"ab\")).Equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long SumDiv(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDiv((8L)) == (7L));\n    Debug.Assert(SumDiv((12L)) == (16L));\n    Debug.Assert(SumDiv((7L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    public static List<long> TwoUniqueNums(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    public static bool TestDuplicate(List<long> arraynums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long CatalanNumber(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CatalanNumber((10L)) == (16796L));\n    Debug.Assert(CatalanNumber((9L)) == (4862L));\n    Debug.Assert(CatalanNumber((7L)) == (429L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long PowerBaseSum(long numBase, long power) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PowerBaseSum((2L), (100L)) == (115L));\n    Debug.Assert(PowerBaseSum((8L), (10L)) == (37L));\n    Debug.Assert(PowerBaseSum((8L), (15L)) == (62L));\n    Debug.Assert(PowerBaseSum((3L), (3L)) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static List<object> ReplaceList(List<object> list1, List<object> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L})), (new List<object>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\"})), (new List<object>(new string[]{(string)\"yellow\"}))).Equals((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"yellow\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long IsOctagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsOctagonal((5L)) == (65L));\n    Debug.Assert(IsOctagonal((10L)) == (280L));\n    Debug.Assert(IsOctagonal((15L)) == (645L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static string ReplaceBlank(string str1, string char) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceBlank((\"hello people\"), (\"@\")).Equals((\"hello@people\")));\n    Debug.Assert(ReplaceBlank((\"python program language\"), (\"$\")).Equals((\"python$program$language\")));\n    Debug.Assert(ReplaceBlank((\"blank space\"), (\"-\")).Equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static string ReplaceSpecialchar(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpecialchar((\"Python language, Programming language.\")).Equals((\"Python:language::Programming:language:\")));\n    Debug.Assert(ReplaceSpecialchar((\"a b c,d e f\")).Equals((\"a:b:c:d:e:f\")));\n    Debug.Assert(ReplaceSpecialchar((\"ram reshma,ram rahim\")).Equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long TupleToInt(Tuple<long, long, long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToInt((Tuple.Create(1L, 2L, 3L))) == (123L));\n    Debug.Assert(TupleToInt((Tuple.Create(4L, 5L, 6L))) == (456L));\n    Debug.Assert(TupleToInt((Tuple.Create(5L, 6L, 7L))) == (567L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float OthersideRightangle(long w, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OthersideRightangle((7L), (8L)) == (10.63014581273465f));\n    Debug.Assert(OthersideRightangle((3L), (4L)) == (float)5L);\n    Debug.Assert(OthersideRightangle((7L), (15L)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    public static long DigitDistanceNums(long n1, long n2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DigitDistanceNums((1L), (2L)) == (1L));\n    Debug.Assert(DigitDistanceNums((23L), (56L)) == (6L));\n    Debug.Assert(DigitDistanceNums((123L), (256L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static bool TextMatchWordzMiddle(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    Debug.Assert(TextMatchWordzMiddle((\"zxyabc.\")) == (false));\n    Debug.Assert(TextMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static string RemovezeroIp(string ip) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemovezeroIp((\"216.08.094.196\")).Equals((\"216.8.94.196\")));\n    Debug.Assert(RemovezeroIp((\"12.01.024\")).Equals((\"12.1.24\")));\n    Debug.Assert(RemovezeroIp((\"216.08.094.0196\")).Equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long CountElementInList(List<List<object>> list1, object x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)11L}), (List<long>)new List<long>(new long[]{(long)1L, (long)15L, (long)7L})})), (object(1L))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"A\"))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"E\"))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long MultiplyInt(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyInt((10L), (20L)) == (200L));\n    Debug.Assert(MultiplyInt((5L), (10L)) == (50L));\n    Debug.Assert(MultiplyInt((4L), (8L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Tuple<long, long, long, long> AddPairwise(Tuple<long, long, long, long, long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddPairwise((Tuple.Create(1L, 5L, 7L, 8L, 10L))).Equals((Tuple.Create(6L, 12L, 15L, 18L))));\n    Debug.Assert(AddPairwise((Tuple.Create(2L, 6L, 8L, 9L, 11L))).Equals((Tuple.Create(8L, 14L, 17L, 20L))));\n    Debug.Assert(AddPairwise((Tuple.Create(3L, 7L, 9L, 10L, 12L))).Equals((Tuple.Create(10L, 16L, 19L, 22L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long MaxProductTuple(List<Tuple<long, long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (36L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (200L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (484L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3448,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the kth element in the given array using 1-based indexing.\n    public static long KthElement(List<long> arr, long k) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)12L, (long)3L, (long)5L, (long)7L, (long)19L})), (2L)) == (3L));\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)17L, (long)24L, (long)8L, (long)23L})), (3L)) == (8L));\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)16L, (long)21L, (long)25L, (long)36L, (long)4L})), (4L)) == (36L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3456,265 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))).Equals((new List<long>(new long[]{(long)4L, (long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"python_program\")).Equals((\"PythonProgram\")));\n    Debug.Assert(SnakeToCamel((\"python_language\")).Equals((\"PythonLanguage\")));\n    Debug.Assert(SnakeToCamel((\"programming_language\")).Equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long RightInsertion(List<long> a, long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long EulerianNum(long n, long m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EulerianNum((3L), (1L)) == (4L));\n    Debug.Assert(EulerianNum((4L), (1L)) == (11L));\n    Debug.Assert(EulerianNum((5L), (3L)) == (26L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static bool IsWoodall(long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> input_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsWoodall((383L)) == (true));\n    Debug.Assert(IsWoodall((254L)) == (false));\n    Debug.Assert(IsWoodall((200L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\"blue \", (string)\" black\"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\" black\", (string)\"blue \"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"zilver\", (string)\"gold\"}), (List<string>)new List<string>(new string[]{(string)\"magnesium\", (string)\"aluminium\"}), (List<string>)new List<string>(new string[]{(string)\"steel\", (string)\"bronze\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"gold\", (string)\"zilver\"}), (List<string>)new List<string>(new string[]{(string)\"aluminium\", (string)\"magnesium\"}), (List<string>)new List<string>(new string[]{(string)\"bronze\", (string)\"steel\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given array by using shell sort.\n    public static List<long> ShellSort(List<long> my_list) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count true booleans in the given list.\n    public static long Count(List<bool> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)12L, (long)23L, (long)4L, (long)5L, (long)3L, (long)2L, (long)12L, (long)81L, (long)56L, (long)95L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)12L, (long)12L, (long)23L, (long)56L, (long)81L, (long)95L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)24L, (long)22L, (long)39L, (long)34L, (long)87L, (long)73L, (long)68L}))).Equals((new List<long>(new long[]{(long)22L, (long)24L, (long)34L, (long)39L, (long)68L, (long)73L, (long)87L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)32L, (long)30L, (long)16L, (long)96L, (long)82L, (long)83L, (long)74L}))).Equals((new List<long>(new long[]{(long)16L, (long)30L, (long)32L, (long)74L, (long)82L, (long)83L, (long)96L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)false, (bool)true}))) == (2L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)false, (bool)false}))) == (0L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)true, (bool)true}))) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    public static long FindOddPair(List<long> A, long N) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Tuple<long, long, long, long, long> AddLists(List<long> test_list, Tuple<long, long> test_tup) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L})), (5L)) == (6L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L})), (7L)) == (12L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (3L)) == (2L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((Tuple.Create(9L, 10L, 5L, 6L, 7L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((Tuple.Create(10L, 11L, 6L, 7L, 8L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((Tuple.Create(11L, 12L, 7L, 8L, 9L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    public static long SumInRange(long l, long r) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static List<long> MergeSortedList(List<long> num1, List<long> num2, List<long> num3) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumInRange((2L), (5L)) == (8L));\n    Debug.Assert(SumInRange((5L), (7L)) == (12L));\n    Debug.Assert(SumInRange((7L), (13L)) == (40L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)25L, (long)24L, (long)15L, (long)4L, (long)5L, (long)29L, (long)110L})), (new List<long>(new long[]{(long)19L, (long)20L, (long)11L, (long)56L, (long)25L, (long)233L, (long)154L})), (new List<long>(new long[]{(long)24L, (long)26L, (long)54L, (long)48L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)11L, (long)15L, (long)19L, (long)20L, (long)24L, (long)24L, (long)25L, (long)25L, (long)26L, (long)29L, (long)48L, (long)54L, (long)56L, (long)110L, (long)154L, (long)233L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)6L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)7L, (long)11L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)8L, (long)12L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)5L, (long)6L, (long)7L, (long)7L, (long)8L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)18L, (long)14L, (long)10L, (long)9L, (long)8L, (long)7L, (long)9L, (long)3L, (long)2L, (long)4L, (long)1L})), (new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L})), (new List<long>(new long[]{(long)12L, (long)74L, (long)9L, (long)50L, (long)61L, (long)41L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)8L, (long)9L, (long)9L, (long)9L, (long)10L, (long)12L, (long)14L, (long)14L, (long)18L, (long)22L, (long)25L, (long)25L, (long)35L, (long)41L, (long)50L, (long)58L, (long)61L, (long)65L, (long)74L, (long)75L, (long)85L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long SquarePerimeter(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long OddEquivalent(string s, long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquarePerimeter((10L)) == (40L));\n    Debug.Assert(SquarePerimeter((5L)) == (20L));\n    Debug.Assert(SquarePerimeter((4L)) == (16L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddEquivalent((\"011001\"), (6L)) == (3L));\n    Debug.Assert(OddEquivalent((\"11011\"), (5L)) == (4L));\n    Debug.Assert(OddEquivalent((\"1010\"), (4L)) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long IsPolite(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static bool CheckInteger(string text) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPolite((7L)) == (11L));\n    Debug.Assert(IsPolite((4L)) == (7L));\n    Debug.Assert(IsPolite((9L)) == (13L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckInteger((\"python\")) == (false));\n    Debug.Assert(CheckInteger((\"1\")) == (true));\n    Debug.Assert(CheckInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long SumSeries(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long TupleToInt(Tuple<long, long, long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSeries((6L)) == (12L));\n    Debug.Assert(SumSeries((10L)) == (30L));\n    Debug.Assert(SumSeries((9L)) == (25L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Tuple<long, long, long, long> FindDissimilar(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindDissimilar((Tuple.Create(3L, 4L, 5L, 6L)), (Tuple.Create(5L, 7L, 4L, 10L))).Equals((Tuple.Create(3L, 6L, 7L, 10L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(7L, 2L, 3L, 9L))).Equals((Tuple.Create(1L, 4L, 7L, 9L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(21L, 11L, 25L, 26L)), (Tuple.Create(26L, 34L, 21L, 36L))).Equals((Tuple.Create(34L, 36L, 11L, 25L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Tuple<string, string> StartWithp(List<string> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python PHP\", (string)\"Java JavaScript\", (string)\"c c++\"}))).Equals((Tuple.Create(\"Python\", \"PHP\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python Programming\", (string)\"Java Programming\"}))).Equals((Tuple.Create(\"Python\", \"Programming\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Pqrst Pqr\", (string)\"qrstuv\"}))).Equals((Tuple.Create(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"android_tv\")).Equals((\"AndroidTv\")));\n    Debug.Assert(SnakeToCamel((\"google_pixel\")).Equals((\"GooglePixel\")));\n    Debug.Assert(SnakeToCamel((\"apple_watch\")).Equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long VolumeCube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VolumeCube((3L)) == (27L));\n    Debug.Assert(VolumeCube((2L)) == (8L));\n    Debug.Assert(VolumeCube((5L)) == (125L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static bool CheckMonthnumbNumber(long monthnum2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumbNumber((5L)) == (true));\n    Debug.Assert(CheckMonthnumbNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumbNumber((6L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    public static bool AllBitsSetInTheGivenRange(long n, long l, long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllBitsSetInTheGivenRange((4L), (1L), (2L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((17L), (2L), (4L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((39L), (4L), (6L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to get the first element of each sublist.\n    public static List<long> Extract(List<List<long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)6L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))).Equals((new List<long>(new long[]{(long)1L, (long)4L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)8L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))).Equals((new List<long>(new long[]{(long)9L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float SurfaceareaCylinder(long r, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCylinder((10L), (5L)) == (942.45f));\n    Debug.Assert(SurfaceareaCylinder((4L), (5L)) == (226.18800000000002f));\n    Debug.Assert(SurfaceareaCylinder((4L), (10L)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long SampleNam(List<string> sample_names) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"sally\", (string)\"Dylan\", (string)\"rebecca\", (string)\"Diana\", (string)\"Joanne\", (string)\"keith\"}))) == (16L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"php\", (string)\"res\", (string)\"Python\", (string)\"abcd\", (string)\"Java\", (string)\"aaa\"}))) == (10L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"abcd\", (string)\"Python\", (string)\"abba\", (string)\"aba\"}))) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static object RearrangeBigger(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearrangeBigger((12L)).Equals((object(21L))));\n    Debug.Assert(RearrangeBigger((10L)).Equals((object(false))));\n    Debug.Assert(RearrangeBigger((102L)).Equals((object(120L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long PerimeterPentagon(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerimeterPentagon((5L)) == (25L));\n    Debug.Assert(PerimeterPentagon((10L)) == (50L));\n    Debug.Assert(PerimeterPentagon((15L)) == (75L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long MaxSum(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)1L, (long)15L, (long)51L, (long)45L, (long)33L, (long)100L, (long)12L, (long)18L, (long)9L}))) == (194L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)80L, (long)60L, (long)30L, (long)40L, (long)20L, (long)10L}))) == (210L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)2L, (long)3L, (long)14L, (long)16L, (long)21L, (long)23L, (long)29L, (long)30L}))) == (138L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static object ExtractEven(Tuple<long, long, Tuple<long, long, Tuple<long, long>>, long, long> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractEven((Tuple.Create(4L, 5L, Tuple.Create(7L, 6L, Tuple.Create(2L, 4L)), 6L, 8L))).Equals(Tuple.Create(4L, Tuple.Create(6L, Tuple.Create(2L, 4L)), 6L, 8L)));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(8L, 7L, Tuple.Create(4L, 8L)), 7L, 9L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 8L)))));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(9L, 8L, Tuple.Create(4L, 6L)), 8L, 10L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 6L)), 8L, 10L)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToInt((Tuple.Create(1L, 2L, 3L))) == (123L));\n    Debug.Assert(TupleToInt((Tuple.Create(4L, 5L, 6L))) == (456L));\n    Debug.Assert(TupleToInt((Tuple.Create(5L, 6L, 7L))) == (567L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3724,189 +136,9 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert all possible convertible elements in a list of lists to floats.\n    public static List<Tuple<float, float>> ListToFloat(List<Tuple<string, string>> test_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"3\", \"4\"), (Tuple<string, string>)Tuple.Create(\"1\", \"26.45\"), (Tuple<string, string>)Tuple.Create(\"7.32\", \"8\"), (Tuple<string, string>)Tuple.Create(\"4\", \"8\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(3.0f, 4.0f), (Tuple<float, float>)Tuple.Create(1.0f, 26.45f), (Tuple<float, float>)Tuple.Create(7.32f, 8.0f), (Tuple<float, float>)Tuple.Create(4.0f, 8.0f)}))));\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"4\", \"4\"), (Tuple<string, string>)Tuple.Create(\"2\", \"27\"), (Tuple<string, string>)Tuple.Create(\"4.12\", \"9\"), (Tuple<string, string>)Tuple.Create(\"7\", \"11\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(4.0f, 4.0f), (Tuple<float, float>)Tuple.Create(2.0f, 27.0f), (Tuple<float, float>)Tuple.Create(4.12f, 9.0f), (Tuple<float, float>)Tuple.Create(7.0f, 11.0f)}))));\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"6\", \"78\"), (Tuple<string, string>)Tuple.Create(\"5\", \"26.45\"), (Tuple<string, string>)Tuple.Create(\"1.33\", \"4\"), (Tuple<string, string>)Tuple.Create(\"82\", \"13\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(6.0f, 78.0f), (Tuple<float, float>)Tuple.Create(5.0f, 26.45f), (Tuple<float, float>)Tuple.Create(1.33f, 4.0f), (Tuple<float, float>)Tuple.Create(82.0f, 13.0f)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long SquareSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (20L));\n    Debug.Assert(SquareSum((3L)) == (56L));\n    Debug.Assert(SquareSum((4L)) == (120L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long GetPairsCount(List<long> arr, long sum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (2L)) == (6L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)-1L, (long)5L})), (6L)) == (3L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L})), (1L)) == (1L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L})), (-3L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long CountNoOfWays(long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNoOfWays((2L), (4L)) == (16L));\n    Debug.Assert(CountNoOfWays((3L), (2L)) == (6L));\n    Debug.Assert(CountNoOfWays((4L), (4L)) == (228L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static string ReverseWords(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseWords((\"python program\")).Equals((\"program python\")));\n    Debug.Assert(ReverseWords((\"java language\")).Equals((\"language java\")));\n    Debug.Assert(ReverseWords((\"indian man\")).Equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    public static bool Checks(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Checks((70L)) == (false));\n    Debug.Assert(Checks((23L)) == (false));\n    Debug.Assert(Checks((73L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    public static long Last(List<long> arr, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (1L)) == (0L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)4L})), (1L)) == (2L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)3L, (long)6L, (long)8L, (long)9L})), (3L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long CountX(List<long> tup, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (4L)) == (0L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (10L)) == (3L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (8L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static List<object> ExtractIndexList(List<long> l1, List<long> l2, List<long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)7L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)5L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)6L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)6L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)6L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static string ConcatenateTuple(Tuple<string, string, long, string> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ID\", \"is\", 4L, \"UTS\"))).Equals((\"ID-is-4-UTS\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"QWE\", \"is\", 4L, \"RTY\"))).Equals((\"QWE-is-4-RTY\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ZEN\", \"is\", 4L, \"OP\"))).Equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static string ReplaceSpaces(string str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"My Name is Dawood\")).Equals((\"My%20Name%20is%20Dawood\")));\n    Debug.Assert(ReplaceSpaces((\"I am a Programmer\")).Equals((\"I%20am%20a%20Programmer\")));\n    Debug.Assert(ReplaceSpaces((\"I love Coding\")).Equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long SumRangeList(List<long> list1, long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (8L), (10L)) == (29L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (5L), (7L)) == (16L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (7L), (10L)) == (38L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static Dictionary<string,string> MergeDictionariesThree(Dictionary<string,string> dict1, Dictionary<string,string> dict2, Dictionary<string,string> dict3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})).Equals((new Dictionary<string,string>(){{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum of two numbers.\n    public static long Minimum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minimum((1L), (2L)) == (1L));\n    Debug.Assert(Minimum((-5L), (-4L)) == (-5L));\n    Debug.Assert(Minimum((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long MaxDifference(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(1L, 7L), (Tuple<long, long>)Tuple.Create(10L, 3L), (Tuple<long, long>)Tuple.Create(1L, 2L)}))) == (7L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(2L, 17L), (Tuple<long, long>)Tuple.Create(9L, 13L), (Tuple<long, long>)Tuple.Create(11L, 12L)}))) == (15L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 35L), (Tuple<long, long>)Tuple.Create(21L, 27L), (Tuple<long, long>)Tuple.Create(13L, 23L), (Tuple<long, long>)Tuple.Create(41L, 22L)}))) == (23L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    public static long FindElement(List<long> arr, List<List<long>> ranges, long rotations, long index) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)2L}), (List<long>)new List<long>(new long[]{(long)0L, (long)3L})})), (2L), (1L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (2L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (1L)) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3916,7 +148,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a string to a list of strings split on the space character.\n    public static List<string> StringToList(string str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToList((\"python programming\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"programming\"}))));\n    Debug.Assert(StringToList((\"lists tuples strings\")).Equals((new List<string>(new string[]{(string)\"lists\", (string)\"tuples\", (string)\"strings\"}))));\n    Debug.Assert(StringToList((\"write a program\")).Equals((new List<string>(new string[]{(string)\"write\", (string)\"a\", (string)\"program\"}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3928,21 +160,9 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the element that appears only once in a sorted array.\n    public static long Search(List<long> arr) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)5L, (long)7L, (long)7L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static List<Tuple<string, long>> SortCounter(Dictionary<string,long> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 81L}, {\"Physics\", 83L}, {\"Chemistry\", 87L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 87L), (Tuple<string, long>)Tuple.Create(\"Physics\", 83L), (Tuple<string, long>)Tuple.Create(\"Math\", 81L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 400L}, {\"Physics\", 300L}, {\"Chemistry\", 250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Math\", 400L), (Tuple<string, long>)Tuple.Create(\"Physics\", 300L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 250L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 900L}, {\"Physics\", 1000L}, {\"Chemistry\", 1250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 1250L), (Tuple<string, long>)Tuple.Create(\"Physics\", 1000L), (Tuple<string, long>)Tuple.Create(\"Math\", 900L)}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3952,7 +172,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove first and last occurrence of a given character from the string.\n    public static string RemoveOcc(string s, string ch) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOcc((\"hello\"), (\"l\")).Equals((\"heo\")));\n    Debug.Assert(RemoveOcc((\"abcda\"), (\"a\")).Equals((\"bcd\")));\n    Debug.Assert(RemoveOcc((\"PHP\"), (\"P\")).Equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3960,325 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long LateralsurfaceCube(long l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long MaxProductTuple(List<Tuple<long, long>> list1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCube((5L)) == (100L));\n    Debug.Assert(LateralsurfaceCube((9L)) == (324L));\n    Debug.Assert(LateralsurfaceCube((10L)) == (400L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (36L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (200L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (484L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Nullable<bool> CommonElement(List<object> list1, List<object> list2) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long AmicableNumbersSum(long limit) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals(true));\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))).Equals(null));\n    Debug.Assert(CommonElement((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})), (new List<object>(new string[]{(string)\"d\", (string)\"b\", (string)\"e\"}))).Equals(true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AmicableNumbersSum((999L)) == (504L));\n    Debug.Assert(AmicableNumbersSum((9999L)) == (31626L));\n    Debug.Assert(AmicableNumbersSum((99L)) == (0L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Tuple<long, long, long, long, long> AddLists(List<long> test_list, Tuple<long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long FindLength(string str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((Tuple.Create(9L, 10L, 5L, 6L, 7L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((Tuple.Create(10L, 11L, 6L, 7L, 8L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((Tuple.Create(11L, 12L, 7L, 8L, 9L))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLength((\"11000010001\")) == (6L));\n    Debug.Assert(FindLength((\"10111\")) == (1L));\n    Debug.Assert(FindLength((\"11011101100101\")) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static List<long> NthNums(List<long> nums, long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    public static long Sum(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (3L)).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)12L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)248832L, (long)759375L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((10L), (15L)) == (6L));\n    Debug.Assert(Sum((100L), (150L)) == (93L));\n    Debug.Assert(Sum((4L), (6L)) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> PancakeSort(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long MultiplyInt(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)15L, (long)79L, (long)25L, (long)38L, (long)69L}))).Equals((new List<long>(new long[]{(long)15L, (long)25L, (long)38L, (long)69L, (long)79L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)98L, (long)12L, (long)54L, (long)36L, (long)85L}))).Equals((new List<long>(new long[]{(long)12L, (long)36L, (long)54L, (long)85L, (long)98L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)41L, (long)42L, (long)32L, (long)12L, (long)23L}))).Equals((new List<long>(new long[]{(long)12L, (long)23L, (long)32L, (long)41L, (long)42L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float MedianNumbers(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianNumbers((25L), (55L), (65L)) == (55.0f));\n    Debug.Assert(MedianNumbers((20L), (10L), (30L)) == (20.0f));\n    Debug.Assert(MedianNumbers((15L), (45L), (75L)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    public static bool CheckGreater(List<long> arr, long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (4L)) == (false));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (8L)) == (true));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)9L, (long)7L, (long)4L, (long)8L, (long)6L, (long)1L})), (11L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static bool CheckElement(List<object> list, object element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"orange\", (string)\"black\", (string)\"white\"})), (object(\"blue\"))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (object(7L))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"green\", (string)\"green\", (string)\"green\"})), (object(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static List<string> ExtractString(List<string> str, long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (8L)).Equals((new List<string>(new string[]{(string)\"practice\", (string)\"solution\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (6L)).Equals((new List<string>(new string[]{(string)\"Python\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (9L)).Equals((new List<string>(new string[]{(string)\"exercises\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static bool TextLowercaseUnderscore(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    Debug.Assert(TextLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    Debug.Assert(TextLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static List<List<long>> TrimTuple(List<List<long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)2L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)8L, (long)2L, (long)1L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)12L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)4L}), (List<long>)new List<long>(new long[]{(long)8L, (long)12L}), (List<long>)new List<long>(new long[]{(long)1L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)9L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sublist having minimum length.\n    public static List<object> FindMin(List<List<object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)7L, (long)8L})}))).Equals((new List<object>(new long[]{(long)1L, (long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"})}))).Equals((new List<object>(new string[]{(string)\"x\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static List<long> FilterOddnumbers(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)10L, (long)20L, (long)45L, (long)67L, (long)84L, (long)93L}))).Equals((new List<long>(new long[]{(long)45L, (long)67L, (long)93L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)8L, (long)6L, (long)4L, (long)3L}))).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static string FindAdverbs(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbs((\"Clearly, he has no excuse for such behavior.\")).Equals((\"0-7: Clearly\")));\n    Debug.Assert(FindAdverbs((\"Please handle the situation carefuly\")).Equals((\"28-36: carefuly\")));\n    Debug.Assert(FindAdverbs((\"Complete the task quickly\")).Equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long MaxOfNth(List<List<long>> test_list, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)9L, (long)19L})})), (2L)) == (19L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)20L})})), (1L)) == (10L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)21L})})), (1L)) == (11L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static string DecimalToBinary(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((8L)).Equals((\"1000\")));\n    Debug.Assert(DecimalToBinary((18L)).Equals((\"10010\")));\n    Debug.Assert(DecimalToBinary((7L)).Equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static List<List<string>> CombinationsColors(List<string> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (1L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (2L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (3L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\", (string)\"Blue\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static string RemoveAllSpaces(string text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveAllSpaces((\"python  program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"python   programming    language\")).Equals((\"pythonprogramminglanguage\")));\n    Debug.Assert(RemoveAllSpaces((\"python                     program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"   python                     program\")).Equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static object MinSwaps(string str1, string str2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinSwaps((\"1101\"), (\"1110\")).Equals((object(1L))));\n    Debug.Assert(MinSwaps((\"111\"), (\"000\")).Equals((object(\"Not Possible\"))));\n    Debug.Assert(MinSwaps((\"111\"), (\"110\")).Equals((object(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Tuple<string, string, string> NewTuple(List<string> test_list, string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"WEB\", (string)\"is\"})), (\"best\")).Equals((Tuple.Create(\"WEB\", \"is\", \"best\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"We\", (string)\"are\"})), (\"Developers\")).Equals((Tuple.Create(\"We\", \"are\", \"Developers\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"Part\", (string)\"is\"})), (\"Wrong\")).Equals((Tuple.Create(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    public static long FindRemainder(List<long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)100L, (long)10L, (long)5L, (long)25L, (long)35L, (long)14L})), (11L)) == (9L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)1L, (long)1L})), (1L)) == (0L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (2L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    public static float PositiveCount(List<long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.54f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.69f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static List<long> AddTuple(List<long> test_list, Tuple<long, long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)10L, (long)11L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long MaxRunUppercase(string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxRunUppercase((\"GeMKSForGERksISBESt\")) == (5L));\n    Debug.Assert(MaxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6L));\n    Debug.Assert(MaxRunUppercase((\"GooGLEFluTTER\")) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static List<List<long>> SortMatrix(List<List<long>> M) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long CountVowels(string test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountVowels((\"bestinstareels\")) == (7L));\n    Debug.Assert(CountVowels((\"partofthejourneyistheend\")) == (12L));\n    Debug.Assert(CountVowels((\"amazonprime\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long MaxSumIncreasingSubseq(List<long> a, long n, long index, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (4L), (6L)) == (11L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (2L), (5L)) == (7L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)11L, (long)15L, (long)19L, (long)21L, (long)26L, (long)28L, (long)31L})), (7L), (2L), (4L)) == (71L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyInt((10L), (20L)) == (200L));\n    Debug.Assert(MultiplyInt((5L), (10L)) == (50L));\n    Debug.Assert(MultiplyInt((4L), (8L)) == (32L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4288,7 +244,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find words that are longer than n characters from a given list of words.\n    public static List<string> LongWords(long n, string str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LongWords((3L), (\"python is a programming language\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"programming\", (string)\"language\"}))));\n    Debug.Assert(LongWords((2L), (\"writing a program\")).Equals((new List<string>(new string[]{(string)\"writing\", (string)\"program\"}))));\n    Debug.Assert(LongWords((5L), (\"sorting list\")).Equals((new List<string>(new string[]{(string)\"sorting\"}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4296,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    public static long FindSum(List<long> arr) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static bool MagicSquareTest(List<List<long>> my_matrix) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)1L, (long)4L, (long)5L, (long)6L}))) == (21L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)10L, (long)9L, (long)4L, (long)2L, (long)10L, (long)10L, (long)45L, (long)4L}))) == (71L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)12L, (long)10L, (long)9L, (long)45L, (long)2L, (long)10L, (long)10L, (long)45L, (long)10L}))) == (78L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)12L, (long)1L, (long)14L}), (List<long>)new List<long>(new long[]{(long)2L, (long)13L, (long)8L, (long)11L}), (List<long>)new List<long>(new long[]{(long)16L, (long)3L, (long)10L, (long)5L}), (List<long>)new List<long>(new long[]{(long)9L, (long)6L, (long)15L, (long)4L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)8L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)7L})}))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    public static Dictionary<long,long> TupleToDict(Tuple<long, long, long, long, long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static List<List<long>> SortMatrix(List<List<long>> M) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 5L, 7L, 10L, 13L, 5L))).Equals((new Dictionary<long,long>(){{1L, 5L}, {7L, 10L}, {13L, 5L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L))).Equals((new Dictionary<long,long>(){{1L, 2L}, {3L, 4L}, {5L, 6L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(7L, 8L, 9L, 10L, 11L, 12L))).Equals((new Dictionary<long,long>(){{7L, 8L}, {9L, 10L}, {11L, 12L}})));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static List<List<long>> GetCoordinates(Tuple<long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long MaxOccurrences(List<long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetCoordinates((Tuple.Create(3L, 4L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(4L, 5L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(5L, 6L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)7L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static bool CheckType(object test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckType(Tuple.Create(5L, 6L, 7L, 3L, 5L, 6L)) == (true));\n    Debug.Assert(CheckType(Tuple.Create(1L, 2L, \"4\")) == (false));\n    Debug.Assert(CheckType(Tuple.Create(3L, 2L, 1L, 4L, 5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    public static long FindFirstMissing(List<long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)6L, (long)9L}))) == (3L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)8L, (long)9L}))) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static bool IsUndulating(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUndulating((1212121L)) == (true));\n    Debug.Assert(IsUndulating((1991L)) == (false));\n    Debug.Assert(IsUndulating((121L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    public static List<Tuple<string, long>> MinK(List<Tuple<string, long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Manjeet\", 10L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L), (Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Nikhil\", 8L)})), (2L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sanjeev\", 11L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)})), (3L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"tanmay\", 14L), (Tuple<string, long>)Tuple.Create(\"Amer\", 11L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L), (Tuple<string, long>)Tuple.Create(\"SKD\", 16L)})), (1L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    public static long CountSubstrings(string s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSubstrings((\"112112\")) == (6L));\n    Debug.Assert(CountSubstrings((\"111\")) == (6L));\n    Debug.Assert(CountSubstrings((\"1101112\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long IsNumDecagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNumDecagonal((3L)) == (27L));\n    Debug.Assert(IsNumDecagonal((7L)) == (175L));\n    Debug.Assert(IsNumDecagonal((10L)) == (370L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static List<long> RearExtract(List<Tuple<long, string, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Rash\", 21L), (Tuple<long, string, long>)Tuple.Create(2L, \"Varsha\", 20L), (Tuple<long, string, long>)Tuple.Create(3L, \"Kil\", 19L)}))).Equals((new List<long>(new long[]{(long)21L, (long)20L, (long)19L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sai\", 36L), (Tuple<long, string, long>)Tuple.Create(2L, \"Ayesha\", 25L), (Tuple<long, string, long>)Tuple.Create(3L, \"Salman\", 45L)}))).Equals((new List<long>(new long[]{(long)36L, (long)25L, (long)45L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sudeep\", 14L), (Tuple<long, string, long>)Tuple.Create(2L, \"Vandana\", 36L), (Tuple<long, string, long>)Tuple.Create(3L, \"Dawood\", 56L)}))).Equals((new List<long>(new long[]{(long)14L, (long)36L, (long)56L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long ClosestNum(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestNum((11L)) == (10L));\n    Debug.Assert(ClosestNum((7L)) == (6L));\n    Debug.Assert(ClosestNum((12L)) == (11L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    public static List<Tuple<long, long>> FindCombinations(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(6L, 10L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(8L, 11L), (Tuple<long, long>)Tuple.Create(7L, 5L), (Tuple<long, long>)Tuple.Create(8L, 14L), (Tuple<long, long>)Tuple.Create(11L, 8L), (Tuple<long, long>)Tuple.Create(12L, 17L), (Tuple<long, long>)Tuple.Create(11L, 11L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(6L, 2L), (Tuple<long, long>)Tuple.Create(7L, 11L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 13L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(10L, 16L), (Tuple<long, long>)Tuple.Create(13L, 10L), (Tuple<long, long>)Tuple.Create(14L, 19L), (Tuple<long, long>)Tuple.Create(13L, 13L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(7L, 3L), (Tuple<long, long>)Tuple.Create(8L, 12L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 15L), (Tuple<long, long>)Tuple.Create(11L, 9L), (Tuple<long, long>)Tuple.Create(12L, 18L), (Tuple<long, long>)Tuple.Create(15L, 12L), (Tuple<long, long>)Tuple.Create(16L, 21L), (Tuple<long, long>)Tuple.Create(15L, 15L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float Maxaverageofpath(List<List<long>> cost) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L, (long)9L})}))) == (5.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L, (long)10L})}))) == (6.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)11L})}))) == (7.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    public static Tuple<bool, long> SequentialSearch(List<long> dlist, long item) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)11L, (long)23L, (long)58L, (long)31L, (long)56L, (long)77L, (long)43L, (long)12L, (long)65L, (long)19L})), (31L)).Equals((Tuple.Create(true, 3L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)12L, (long)32L, (long)45L, (long)62L, (long)35L, (long)47L, (long)44L, (long)61L})), (61L)).Equals((Tuple.Create(true, 7L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)9L, (long)10L, (long)17L, (long)19L, (long)22L, (long)39L, (long)48L, (long)56L})), (48L)).Equals((Tuple.Create(true, 6L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove odd numbers from a given list.\n    public static List<long> RemoveOdd(List<long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)10L, (long)20L, (long)3L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static bool IsProductEven(List<long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)1L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the maximum of two numbers.\n    public static long Maximum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((5L), (10L)) == (10L));\n    Debug.Assert(Maximum((-1L), (-2L)) == (-1L));\n    Debug.Assert(Maximum((9L), (7L)) == (9L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)2L, (long)6L, (long)5L, (long)1L, (long)6L, (long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)6L, (long)9L, (long)1L, (long)2L}))) == (2L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)7L, (long)9L, (long)15L, (long)14L, (long)10L, (long)12L, (long)13L, (long)16L, (long)18L}))) == (8L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)10L, (long)20L, (long)20L, (long)30L, (long)40L, (long)90L, (long)80L, (long)50L, (long)30L, (long)20L, (long)50L, (long)10L}))) == (20L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4504,9 +292,597 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to reverse only the vowels of a given string (where y is not a vowel).\n    public static string ReverseVowels(string str1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseVowels((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(ReverseVowels((\"USA\")).Equals((\"ASU\")));\n    Debug.Assert(ReverseVowels((\"ab\")).Equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static string TupString(List<string> tup1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"e\", (string)\"x\", (string)\"e\", (string)\"r\", (string)\"c\", (string)\"i\", (string)\"s\", (string)\"e\", (string)\"s\"}))).Equals((\"exercises\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))).Equals((\"python\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))).Equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long SumNegativenum(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (-32L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)10L, (long)15L, (long)-14L, (long)13L, (long)-18L, (long)12L, (long)-20L}))) == (-52L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)19L, (long)-65L, (long)57L, (long)39L, (long)152L, (long)-639L, (long)121L, (long)44L, (long)90L, (long)-190L}))) == (-894L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long HexagonalNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexagonalNum((10L)) == (190L));\n    Debug.Assert(HexagonalNum((5L)) == (45L));\n    Debug.Assert(HexagonalNum((7L)) == (91L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static bool IsSumOfPowersOfTwo(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSumOfPowersOfTwo((10L)) == (true));\n    Debug.Assert(IsSumOfPowersOfTwo((7L)) == (false));\n    Debug.Assert(IsSumOfPowersOfTwo((14L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> PancakeSort(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)15L, (long)79L, (long)25L, (long)38L, (long)69L}))).Equals((new List<long>(new long[]{(long)15L, (long)25L, (long)38L, (long)69L, (long)79L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)98L, (long)12L, (long)54L, (long)36L, (long)85L}))).Equals((new List<long>(new long[]{(long)12L, (long)36L, (long)54L, (long)85L, (long)98L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)41L, (long)42L, (long)32L, (long)12L, (long)23L}))).Equals((new List<long>(new long[]{(long)12L, (long)23L, (long)32L, (long)41L, (long)42L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long CountSamepair(List<long> list1, List<long> list2, List<long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (3L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (4L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long FindLists(List<object> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (2L));\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))) == (3L));\n    Debug.Assert(FindLists((new List<object>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    public static long MaxAbsDiff(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)3L}))) == (4L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)9L, (long)3L, (long)2L, (long)5L, (long)1L}))) == (8L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the volume of a triangular prism.\n    public static long FindVolume(long l, long b, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindVolume((10L), (8L), (6L)) == (240L));\n    Debug.Assert(FindVolume((3L), (2L), (2L)) == (6L));\n    Debug.Assert(FindVolume((1L), (2L), (1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    public static Tuple<long, long> FindSolution(long a, long b, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSolution((2L), (3L), (7L)).Equals((Tuple.Create(2L, 1L))));\n    Debug.Assert(FindSolution((4L), (2L), (7L)).Equals(null));\n    Debug.Assert(FindSolution((1L), (13L), (17L)).Equals((Tuple.Create(4L, 1L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static List<long> RemoveElements(List<long> list1, List<long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long SumSeries(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSeries((6L)) == (12L));\n    Debug.Assert(SumSeries((10L)) == (30L));\n    Debug.Assert(SumSeries((9L)) == (25L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static bool AreEquivalent(long num1, long num2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreEquivalent((36L), (57L)) == (false));\n    Debug.Assert(AreEquivalent((2L), (4L)) == (false));\n    Debug.Assert(AreEquivalent((23L), (47L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long CountCharPosition(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharPosition((\"xbcefg\")) == (2L));\n    Debug.Assert(CountCharPosition((\"ABcED\")) == (3L));\n    Debug.Assert(CountCharPosition((\"AbgdeF\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long FindEvenPair(List<long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L}))) == (4L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L}))) == (9L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    public static long NextPowerOf2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPowerOf2((0L)) == (1L));\n    Debug.Assert(NextPowerOf2((5L)) == (8L));\n    Debug.Assert(NextPowerOf2((17L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long Frequency(List<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L)) == (0L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L})), (3L)) == (3L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)1L, (long)2L})), (1L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static bool TextLowercaseUnderscore(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    Debug.Assert(TextLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    Debug.Assert(TextLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long SumRangeList(List<long> list1, long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (8L), (10L)) == (29L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (5L), (7L)) == (16L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (7L), (10L)) == (38L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long PerimeterPentagon(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerimeterPentagon((5L)) == (25L));\n    Debug.Assert(PerimeterPentagon((10L)) == (50L));\n    Debug.Assert(PerimeterPentagon((15L)) == (75L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long CountOccurance(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurance((\"letstdlenstdporstd\")) == (3L));\n    Debug.Assert(CountOccurance((\"truststdsolensporsd\")) == (1L));\n    Debug.Assert(CountOccurance((\"makestdsostdworthit\")) == (2L));\n    Debug.Assert(CountOccurance((\"stds\")) == (1L));\n    Debug.Assert(CountOccurance((\"\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long SquarePerimeter(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquarePerimeter((10L)) == (40L));\n    Debug.Assert(SquarePerimeter((5L)) == (20L));\n    Debug.Assert(SquarePerimeter((4L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static string RemoveDirtyChars(string str, string second_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDirtyChars((\"probasscurve\"), (\"pros\")).Equals((\"bacuve\")));\n    Debug.Assert(RemoveDirtyChars((\"digitalindia\"), (\"talent\")).Equals((\"digiidi\")));\n    Debug.Assert(RemoveDirtyChars((\"exoticmiles\"), (\"toxic\")).Equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    public static bool TestDuplicate(List<long> arraynums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static bool IsWoodall(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsWoodall((383L)) == (true));\n    Debug.Assert(IsWoodall((254L)) == (false));\n    Debug.Assert(IsWoodall((200L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static bool CheckType(object test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckType(Tuple.Create(5L, 6L, 7L, 3L, 5L, 6L)) == (true));\n    Debug.Assert(CheckType(Tuple.Create(1L, 2L, \"4\")) == (false));\n    Debug.Assert(CheckType(Tuple.Create(3L, 2L, 1L, 4L, 5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    public static bool IsMajority(List<long> arr, long n, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)3L, (long)10L})), (7L), (3L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)4L, (long)4L, (long)4L, (long)6L, (long)6L})), (8L), (4L)) == (false));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long CountSetBits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSetBits((2L)) == (1L));\n    Debug.Assert(CountSetBits((4L)) == (1L));\n    Debug.Assert(CountSetBits((6L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    public static string OddValuesString(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddValuesString((\"abcdef\")).Equals((\"ace\")));\n    Debug.Assert(OddValuesString((\"python\")).Equals((\"pto\")));\n    Debug.Assert(OddValuesString((\"data\")).Equals((\"dt\")));\n    Debug.Assert(OddValuesString((\"lambs\")).Equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long MinOfThree(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinOfThree((10L), (20L), (0L)) == (0L));\n    Debug.Assert(MinOfThree((19L), (15L), (18L)) == (15L));\n    Debug.Assert(MinOfThree((-10L), (-20L), (-30L)) == (-30L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    public static bool AllBitsSetInTheGivenRange(long n, long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllBitsSetInTheGivenRange((4L), (1L), (2L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((17L), (2L), (4L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((39L), (4L), (6L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static List<long> ReArrangeArray(List<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)-1L, (long)2L, (long)-3L, (long)4L, (long)5L, (long)6L, (long)-7L, (long)8L, (long)9L})), (9L)).Equals((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-7L, (long)4L, (long)5L, (long)6L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)12L, (long)-14L, (long)-26L, (long)13L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)-14L, (long)-26L, (long)12L, (long)13L, (long)15L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)10L, (long)24L, (long)36L, (long)-42L, (long)-39L, (long)-78L, (long)85L})), (7L)).Equals((new List<long>(new long[]{(long)-42L, (long)-39L, (long)-78L, (long)10L, (long)24L, (long)36L, (long)85L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static string ReplaceBlank(string str1, string char) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceBlank((\"hello people\"), (\"@\")).Equals((\"hello@people\")));\n    Debug.Assert(ReplaceBlank((\"python program language\"), (\"$\")).Equals((\"python$program$language\")));\n    Debug.Assert(ReplaceBlank((\"blank space\"), (\"-\")).Equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long VolumeCube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VolumeCube((3L)) == (27L));\n    Debug.Assert(VolumeCube((2L)) == (8L));\n    Debug.Assert(VolumeCube((5L)) == (125L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static Dictionary<Tuple<long, long>,long> CheckOccurences(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(5L, 2L), (Tuple<long, long>)Tuple.Create(6L, 3L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(1L, 3L), 2L}, {Tuple.Create(2L, 5L), 2L}, {Tuple.Create(3L, 6L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 2L), (Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(3L, 6L), (Tuple<long, long>)Tuple.Create(6L, 3L), (Tuple<long, long>)Tuple.Create(7L, 4L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 4L), 2L}, {Tuple.Create(3L, 6L), 2L}, {Tuple.Create(4L, 7L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(13L, 2L), (Tuple<long, long>)Tuple.Create(11L, 23L), (Tuple<long, long>)Tuple.Create(12L, 25L), (Tuple<long, long>)Tuple.Create(25L, 12L), (Tuple<long, long>)Tuple.Create(16L, 23L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 13L), 1L}, {Tuple.Create(11L, 23L), 1L}, {Tuple.Create(12L, 25L), 2L}, {Tuple.Create(16L, 23L), 1L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    public static long NumberOfSubstrings(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberOfSubstrings((\"abc\")) == (6L));\n    Debug.Assert(NumberOfSubstrings((\"abcd\")) == (10L));\n    Debug.Assert(NumberOfSubstrings((\"abcde\")) == (15L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long GetTotalNumberOfSequences(long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetTotalNumberOfSequences((10L), (4L)) == (4L));\n    Debug.Assert(GetTotalNumberOfSequences((5L), (2L)) == (6L));\n    Debug.Assert(GetTotalNumberOfSequences((16L), (3L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static List<object> ReplaceList(List<object> list1, List<object> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L})), (new List<object>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\"})), (new List<object>(new string[]{(string)\"yellow\"}))).Equals((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"yellow\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long CountCharac(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharac((\"python programming\")) == (18L));\n    Debug.Assert(CountCharac((\"language\")) == (8L));\n    Debug.Assert(CountCharac((\"words\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    public static long NextPerfectSquare(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPerfectSquare((35L)) == (36L));\n    Debug.Assert(NextPerfectSquare((6L)) == (9L));\n    Debug.Assert(NextPerfectSquare((9L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long MaxSum(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)1L, (long)15L, (long)51L, (long)45L, (long)33L, (long)100L, (long)12L, (long)18L, (long)9L}))) == (194L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)80L, (long)60L, (long)30L, (long)40L, (long)20L, (long)10L}))) == (210L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)2L, (long)3L, (long)14L, (long)16L, (long)21L, (long)23L, (long)29L, (long)30L}))) == (138L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long Lps(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Lps((\"TENS FOR TENS\")) == (5L));\n    Debug.Assert(Lps((\"CARDIO FOR CARDS\")) == (7L));\n    Debug.Assert(Lps((\"PART OF THE JOURNEY IS PART\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the intersection of two arrays.\n    public static List<long> IntersectionArray(List<long> array_nums1, List<long> array_nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<long>(new long[]{(long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long CountX(List<long> tup, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (4L)) == (0L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (10L)) == (3L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (8L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static List<string> InsertElement(List<string> list, string element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Black\"})), (\"c\")).Equals((new List<string>(new string[]{(string)\"c\", (string)\"Red\", (string)\"c\", (string)\"Green\", (string)\"c\", (string)\"Black\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"python\", (string)\"java\"})), (\"program\")).Equals((new List<string>(new string[]{(string)\"program\", (string)\"python\", (string)\"program\", (string)\"java\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"happy\", (string)\"sad\"})), (\"laugh\")).Equals((new List<string>(new string[]{(string)\"laugh\", (string)\"happy\", (string)\"laugh\", (string)\"sad\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    public static Tuple<float, float> Convert(long numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Convert((1L)).Equals((Tuple.Create(1.0f, 0.0f))));\n    Debug.Assert(Convert((4L)).Equals((Tuple.Create(4.0f, 0.0f))));\n    Debug.Assert(Convert((5L)).Equals((Tuple.Create(5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static List<List<string>> CombinationsColors(List<string> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (1L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (2L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (3L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\", (string)\"Blue\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long CountPrimesNums(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPrimesNums((5L)) == (2L));\n    Debug.Assert(CountPrimesNums((10L)) == (4L));\n    Debug.Assert(CountPrimesNums((100L)) == (25L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static List<long> SwapNumbers(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapNumbers((10L), (20L)).Equals((new List<long>(new long[]{(long)20L, (long)10L}))));\n    Debug.Assert(SwapNumbers((15L), (17L)).Equals((new List<long>(new long[]{(long)17L, (long)15L}))));\n    Debug.Assert(SwapNumbers((100L), (200L)).Equals((new List<long>(new long[]{(long)200L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4516,7 +892,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to maximize the given two lists.\n    public static List<List<long>> MaximizeElements(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)10L})}))));\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)5L, (long)10L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)11L})}))));\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)11L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)9L, (long)12L})}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4524,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    public static bool EvenPosition(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long NewmanPrime(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewmanPrime((3L)) == (7L));\n    Debug.Assert(NewmanPrime((4L)) == (17L));\n    Debug.Assert(NewmanPrime((5L)) == (41L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static string CheckChar(string str) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Tuple<long, long, long, long> DivisionElements(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckChar((\"abba\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"a\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"abcd\")).Equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisionElements((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(2L, 2L, 2L, 3L))));\n    Debug.Assert(DivisionElements((Tuple.Create(12L, 6L, 8L, 16L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(2L, 2L, 2L, 4L))));\n    Debug.Assert(DivisionElements((Tuple.Create(20L, 14L, 36L, 18L)), (Tuple.Create(5L, 7L, 6L, 9L))).Equals((Tuple.Create(4L, 2L, 6L, 2L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of even factors of a number.\n    public static long Sumoffactors(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static object SplitTwoParts(List<object> list1, long L) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sumoffactors((18L)) == (26L));\n    Debug.Assert(Sumoffactors((30L)) == (48L));\n    Debug.Assert(Sumoffactors((6L)) == (8L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitTwoParts((new List<object>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals(Tuple.Create(new List<long>(new long[]{(long)1L, (long)1L, (long)2L}), new List<long>(new long[]{(long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (2L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"a\", (string)\"b\"}), new List<string>(new string[]{(string)\"c\", (string)\"d\"}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"})), (4L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\"}), new List<string>(new string[]{(string)\"o\", (string)\"n\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float LateralsurfaceCone(long r, long h) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long DogAge(long h_age) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCone((5L), (12L)) == (204.20352248333654f));\n    Debug.Assert(LateralsurfaceCone((10L), (15L)) == (566.3586699569488f));\n    Debug.Assert(LateralsurfaceCone((19L), (17L)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DogAge((12L)) == (61L));\n    Debug.Assert(DogAge((15L)) == (73L));\n    Debug.Assert(DogAge((24L)) == (109L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long CountPairs(List<long> arr, long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static List<List<object>> ListSplit(List<object> S, long step) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (3L)) == (2L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (4L)) == (0L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (5L)) == (10L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"e\", (string)\"f\", (string)\"g\", (string)\"h\", (string)\"i\", (string)\"j\", (string)\"k\", (string)\"l\", (string)\"m\", (string)\"n\"})), (3L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"d\", (string)\"g\", (string)\"j\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"b\", (string)\"e\", (string)\"h\", (string)\"k\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"f\", (string)\"i\", (string)\"l\"})}))));\n    Debug.Assert(ListSplit((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L, (long)12L, (long)13L, (long)14L})), (3L)).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)10L, (long)13L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L, (long)8L, (long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)12L})}))));\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"python\", (string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\", (string)\"SQL\"})), (2L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"python\", (string)\"C\", (string)\"DBMS\"}), (List<string>)new List<string>(new string[]{(string)\"java\", (string)\"C++\", (string)\"SQL\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    public static long FindFirstOccurrence(List<long> A, long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long LateralsurfaceCube(long l) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)5L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (1L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (2L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (6L)) == (4L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCube((5L)) == (100L));\n    Debug.Assert(LateralsurfaceCube((9L)) == (324L));\n    Debug.Assert(LateralsurfaceCube((10L)) == (400L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4600,9 +976,669 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    public static long SquareSum(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (10L));\n    Debug.Assert(SquareSum((3L)) == (35L));\n    Debug.Assert(SquareSum((4L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long FindStarNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindStarNum((3L)) == (37L));\n    Debug.Assert(FindStarNum((4L)) == (73L));\n    Debug.Assert(FindStarNum((5L)) == (121L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long AsciiValue(string k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AsciiValue((\"A\")) == (65L));\n    Debug.Assert(AsciiValue((\"R\")) == (82L));\n    Debug.Assert(AsciiValue((\"S\")) == (83L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    public static long SumEvenAndEvenIndex(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L, (long)18L, (long)8L}))) == (30L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)3L, (long)20L, (long)17L, (long)9L, (long)2L, (long)10L, (long)18L, (long)13L, (long)6L, (long)18L}))) == (26L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long EvenPowerSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPowerSum((2L)) == (1056L));\n    Debug.Assert(EvenPowerSum((3L)) == (8832L));\n    Debug.Assert(EvenPowerSum((1L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static List<long> RearExtract(List<Tuple<long, string, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Rash\", 21L), (Tuple<long, string, long>)Tuple.Create(2L, \"Varsha\", 20L), (Tuple<long, string, long>)Tuple.Create(3L, \"Kil\", 19L)}))).Equals((new List<long>(new long[]{(long)21L, (long)20L, (long)19L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sai\", 36L), (Tuple<long, string, long>)Tuple.Create(2L, \"Ayesha\", 25L), (Tuple<long, string, long>)Tuple.Create(3L, \"Salman\", 45L)}))).Equals((new List<long>(new long[]{(long)36L, (long)25L, (long)45L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sudeep\", 14L), (Tuple<long, string, long>)Tuple.Create(2L, \"Vandana\", 36L), (Tuple<long, string, long>)Tuple.Create(3L, \"Dawood\", 56L)}))).Equals((new List<long>(new long[]{(long)14L, (long)36L, (long)56L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Tuple<long, long, long> SubstractElements(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubstractElements((Tuple.Create(10L, 4L, 5L)), (Tuple.Create(2L, 5L, 18L))).Equals((Tuple.Create(8L, -1L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(11L, 2L, 3L)), (Tuple.Create(24L, 45L, 16L))).Equals((Tuple.Create(-13L, -43L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(7L, 18L, 9L)), (Tuple.Create(10L, 11L, 12L))).Equals((Tuple.Create(-3L, 7L, -3L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long EvenBinomialCoeffSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenBinomialCoeffSum((4L)) == (8L));\n    Debug.Assert(EvenBinomialCoeffSum((6L)) == (32L));\n    Debug.Assert(EvenBinomialCoeffSum((2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static Dictionary<string,long> DictFilter(Dictionary<string,long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (170L)).Equals((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (180L)).Equals((new Dictionary<string,long>(){{\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (190L)).Equals((new Dictionary<string,long>(){{\"Pierre Cox\", 190L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long IsNumDecagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNumDecagonal((3L)) == (27L));\n    Debug.Assert(IsNumDecagonal((7L)) == (175L));\n    Debug.Assert(IsNumDecagonal((10L)) == (370L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    public static Tuple<bool, long> SequentialSearch(List<long> dlist, long item) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)11L, (long)23L, (long)58L, (long)31L, (long)56L, (long)77L, (long)43L, (long)12L, (long)65L, (long)19L})), (31L)).Equals((Tuple.Create(true, 3L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)12L, (long)32L, (long)45L, (long)62L, (long)35L, (long)47L, (long)44L, (long)61L})), (61L)).Equals((Tuple.Create(true, 7L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)9L, (long)10L, (long)17L, (long)19L, (long)22L, (long)39L, (long)48L, (long)56L})), (48L)).Equals((Tuple.Create(true, 6L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    public static bool AllUnique(List<long> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static List<long> SubList(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-3L, (long)-3L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L})), (new List<long>(new long[]{(long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-2L, (long)-2L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<long>(new long[]{(long)40L, (long)50L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static bool Validate(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Validate((1234L)) == (true));\n    Debug.Assert(Validate((51241L)) == (false));\n    Debug.Assert(Validate((321L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static bool CheckElement(List<object> list, object element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"orange\", (string)\"black\", (string)\"white\"})), (object(\"blue\"))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (object(7L))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"green\", (string)\"green\", (string)\"green\"})), (object(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static bool TextMatchTwoThree(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchTwoThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    public static long MaxSubArraySumRepeated(List<long> a, long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)10L, (long)20L, (long)-30L, (long)-1L})), (4L), (3L)) == (30L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)10L, (long)20L})), (3L), (2L)) == (59L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})), (3L), (3L)) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long SquareSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (20L));\n    Debug.Assert(SquareSum((3L)) == (56L));\n    Debug.Assert(SquareSum((4L)) == (120L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Tuple<long, List<long>> MaxLength(List<List<long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)15L, (long)20L, (long)25L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)15L, (long)20L, (long)25L})))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long CountNoOfWays(long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNoOfWays((2L), (4L)) == (16L));\n    Debug.Assert(CountNoOfWays((3L), (2L)) == (6L));\n    Debug.Assert(CountNoOfWays((4L), (4L)) == (228L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long Find(long n, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Find((10L), (3L)) == (3L));\n    Debug.Assert(Find((4L), (2L)) == (2L));\n    Debug.Assert(Find((20L), (5L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float OthersideRightangle(long w, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OthersideRightangle((7L), (8L)) == (10.63014581273465f));\n    Debug.Assert(OthersideRightangle((3L), (4L)) == (float)5L);\n    Debug.Assert(OthersideRightangle((7L), (15L)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long SumDiv(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDiv((8L)) == (7L));\n    Debug.Assert(SumDiv((12L)) == (16L));\n    Debug.Assert(SumDiv((7L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count inversions in an array.\n    public static long GetInvCount(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)20L, (long)6L, (long)4L, (long)5L}))) == (5L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)6L, (long)1L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Tuple<string, long> MaxAggregate(List<Tuple<string, long>> stdata) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 90L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 88L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 7L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 122L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 84L)}))).Equals((Tuple.Create(\"Juan Whelan\", 212L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 50L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 48L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 37L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 22L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 14L)}))).Equals((Tuple.Create(\"Juan Whelan\", 72L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 10L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 20L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 30L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 40L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 50L)}))).Equals((Tuple.Create(\"Sabah Colley\", 70L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    public static long FindElement(List<long> arr, List<List<long>> ranges, long rotations, long index) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)2L}), (List<long>)new List<long>(new long[]{(long)0L, (long)3L})})), (2L), (1L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (2L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Tuple<string, string> StartWithp(List<string> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python PHP\", (string)\"Java JavaScript\", (string)\"c c++\"}))).Equals((Tuple.Create(\"Python\", \"PHP\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python Programming\", (string)\"Java Programming\"}))).Equals((Tuple.Create(\"Python\", \"Programming\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Pqrst Pqr\", (string)\"qrstuv\"}))).Equals((Tuple.Create(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long MaxSumIncreasingSubseq(List<long> a, long n, long index, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (4L), (6L)) == (11L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (2L), (5L)) == (7L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)11L, (long)15L, (long)19L, (long)21L, (long)26L, (long)28L, (long)31L})), (7L), (2L), (4L)) == (71L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static List<long> LargeProduct(List<long> nums1, List<long> nums2, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (3L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (5L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L, (long)45L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the maximum of two numbers.\n    public static long Maximum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((5L), (10L)) == (10L));\n    Debug.Assert(Maximum((-1L), (-2L)) == (-1L));\n    Debug.Assert(Maximum((9L), (7L)) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static List<string> StringToTuple(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToTuple((\"python 3.0\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\", (string)\"3\", (string)\".\", (string)\"0\"}))));\n    Debug.Assert(StringToTuple((\"item1\")).Equals((new List<string>(new string[]{(string)\"i\", (string)\"t\", (string)\"e\", (string)\"m\", (string)\"1\"}))));\n    Debug.Assert(StringToTuple((\"15.10\")).Equals((new List<string>(new string[]{(string)\"1\", (string)\"5\", (string)\".\", (string)\"1\", (string)\"0\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    public static long HighestPowerOf2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HighestPowerOf2((10L)) == (8L));\n    Debug.Assert(HighestPowerOf2((19L)) == (16L));\n    Debug.Assert(HighestPowerOf2((32L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long FindLucas(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLucas((9L)) == (76L));\n    Debug.Assert(FindLucas((4L)) == (7L));\n    Debug.Assert(FindLucas((3L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static List<string> AddString(List<object> list_, string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddString((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (\"temp{0}\")).Equals((new List<string>(new string[]{(string)\"temp1\", (string)\"temp2\", (string)\"temp3\", (string)\"temp4\"}))));\n    Debug.Assert(AddString((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (\"python{0}\")).Equals((new List<string>(new string[]{(string)\"pythona\", (string)\"pythonb\", (string)\"pythonc\", (string)\"pythond\"}))));\n    Debug.Assert(AddString((new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})), (\"string{0}\")).Equals((new List<string>(new string[]{(string)\"string5\", (string)\"string6\", (string)\"string7\", (string)\"string8\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static List<Dictionary<string,Dictionary<string,long>>> ConvertListDictionary(List<string> l1, List<string> l2, List<long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"S001\", (string)\"S002\", (string)\"S003\", (string)\"S004\"})), (new List<string>(new string[]{(string)\"Adina Park\", (string)\"Leyton Marsh\", (string)\"Duncan Boyle\", (string)\"Saim Richards\"})), (new List<long>(new long[]{(long)85L, (long)98L, (long)89L, (long)92L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S001\", new Dictionary<string,long>(){{\"Adina Park\", 85L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S002\", new Dictionary<string,long>(){{\"Leyton Marsh\", 98L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S003\", new Dictionary<string,long>(){{\"Duncan Boyle\", 89L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S004\", new Dictionary<string,long>(){{\"Saim Richards\", 92L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"abc\", (string)\"def\", (string)\"ghi\", (string)\"jkl\"})), (new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\", (string)\"programs\"})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"abc\", new Dictionary<string,long>(){{\"python\", 100L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"def\", new Dictionary<string,long>(){{\"program\", 200L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"ghi\", new Dictionary<string,long>(){{\"language\", 300L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"jkl\", new Dictionary<string,long>(){{\"programs\", 400L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"A1\", (string)\"A2\", (string)\"A3\", (string)\"A4\"})), (new List<string>(new string[]{(string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\"})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A1\", new Dictionary<string,long>(){{\"java\", 10L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A2\", new Dictionary<string,long>(){{\"C\", 20L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A3\", new Dictionary<string,long>(){{\"C++\", 30L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A4\", new Dictionary<string,long>(){{\"DBMS\", 40L}}}}}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long GetMaxSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxSum((60L)) == (106L));\n    Debug.Assert(GetMaxSum((10L)) == (12L));\n    Debug.Assert(GetMaxSum((2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Tuple<long, List<long>> MaxLengthList(List<List<long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L})}))).Equals((Tuple.Create(5L, new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static bool CheckDistinct(List<long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L, (long)1L, (long)4L}))) == (false));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    public static string FirstNonRepeatingCharacter(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstNonRepeatingCharacter((\"abcabc\")).Equals(null));\n    Debug.Assert(FirstNonRepeatingCharacter((\"abc\")).Equals((\"a\")));\n    Debug.Assert(FirstNonRepeatingCharacter((\"ababc\")).Equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static string CheckChar(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckChar((\"abba\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"a\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"abcd\")).Equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float MedianNumbers(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianNumbers((25L), (55L), (65L)) == (55.0f));\n    Debug.Assert(MedianNumbers((20L), (10L), (30L)) == (20.0f));\n    Debug.Assert(MedianNumbers((15L), (45L), (75L)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long SumOfDigits(List<object> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)2L, (long)56L}))) == (14L));\n    Debug.Assert(SumOfDigits((new List<object>(new List<long>[]{(List<long>)new List<object>(new object[]{10L, 20L, 4L, 5L, \"b\", 70L, \"a\"})}))) == (19L));\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)20L, (long)-4L, (long)5L, (long)-70L}))) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Tuple<long, long, long, long> BitwiseXor(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BitwiseXor((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(15L, 6L, 5L, 10L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(11L, 5L, 7L, 10L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(13L, 6L, 3L, 14L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(12L, 6L, 8L, 11L)), (Tuple.Create(7L, 4L, 5L, 6L))).Equals((Tuple.Create(11L, 2L, 13L, 13L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to identify non-prime numbers.\n    public static bool IsNotPrime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNotPrime((2L)) == (false));\n    Debug.Assert(IsNotPrime((10L)) == (true));\n    Debug.Assert(IsNotPrime((35L)) == (true));\n    Debug.Assert(IsNotPrime((37L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long ExtractFreq(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(5L, 6L)}))) == (3L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 15L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L)}))) == (4L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 16L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 9L)}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static List<List<long>> AddNestedTuples(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)10L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)13L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)12L}), (List<long>)new List<long>(new long[]{(long)9L, (long)16L}), (List<long>)new List<long>(new long[]{(long)5L, (long)12L}), (List<long>)new List<long>(new long[]{(long)10L, (long)15L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)11L, (long)18L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)12L, (long)17L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum of two numbers.\n    public static long Minimum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minimum((1L), (2L)) == (1L));\n    Debug.Assert(Minimum((-5L), (-4L)) == (-5L));\n    Debug.Assert(Minimum((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    public static bool FindParity(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindParity((12L)) == (false));\n    Debug.Assert(FindParity((7L)) == (true));\n    Debug.Assert(FindParity((10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static object RearrangeBigger(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearrangeBigger((12L)).Equals((object(21L))));\n    Debug.Assert(RearrangeBigger((10L)).Equals((object(false))));\n    Debug.Assert(RearrangeBigger((102L)).Equals((object(120L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    public static List<List<long>> KSmallestPairs(List<long> nums1, List<long> nums2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (7L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)2L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long MinProductTuple(List<Tuple<long, long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (8L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (30L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (100L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"android_tv\")).Equals((\"AndroidTv\")));\n    Debug.Assert(SnakeToCamel((\"google_pixel\")).Equals((\"GooglePixel\")));\n    Debug.Assert(SnakeToCamel((\"apple_watch\")).Equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove odd numbers from a given list.\n    public static List<long> RemoveOdd(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)10L, (long)20L, (long)3L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static List<object> ExtractNthElement(List<Tuple<string, long, long>> list1, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (0L)).Equals((new List<object>(new string[]{(string)\"Greyson Fulton\", (string)\"Brady Kent\", (string)\"Wyatt Knott\", (string)\"Beau Turnbull\"}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (2L)).Equals((new List<object>(new long[]{(long)99L, (long)96L, (long)94L, (long)98L}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (1L)).Equals((new List<object>(new long[]{(long)98L, (long)97L, (long)91L, (long)94L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    public static bool Overlapping(List<long> list1, List<long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    public static Tuple<long, long> MaxProduct(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)0L, (long)8L, (long)4L}))).Equals((Tuple.Create(7L, 8L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)0L, (long)-1L, (long)-2L, (long)-4L, (long)5L, (long)0L, (long)-6L}))).Equals((Tuple.Create(-4L, -6L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((Tuple.Create(2L, 3L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4612,7 +1648,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find common first element in given list of lists.\n    public static List<List<string>> GroupTuples(List<List<string>> Input) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"w\", (string)\"t\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"w\", (string)\"t\"})}))));\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"e\"})}))));\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"h\", (string)\"i\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"h\", (string)\"i\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4620,13 +1656,2977 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static List<long> MergeSortedList(List<long> num1, List<long> num2, List<long> num3) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the element of a list having maximum length.\n    public static List<object> FindMax(List<List<object>> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)25L, (long)24L, (long)15L, (long)4L, (long)5L, (long)29L, (long)110L})), (new List<long>(new long[]{(long)19L, (long)20L, (long)11L, (long)56L, (long)25L, (long)233L, (long)154L})), (new List<long>(new long[]{(long)24L, (long)26L, (long)54L, (long)48L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)11L, (long)15L, (long)19L, (long)20L, (long)24L, (long)24L, (long)25L, (long)25L, (long)26L, (long)29L, (long)48L, (long)54L, (long)56L, (long)110L, (long)154L, (long)233L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)6L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)7L, (long)11L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)8L, (long)12L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)5L, (long)6L, (long)7L, (long)7L, (long)8L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)18L, (long)14L, (long)10L, (long)9L, (long)8L, (long)7L, (long)9L, (long)3L, (long)2L, (long)4L, (long)1L})), (new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L})), (new List<long>(new long[]{(long)12L, (long)74L, (long)9L, (long)50L, (long)61L, (long)41L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)8L, (long)9L, (long)9L, (long)9L, (long)10L, (long)12L, (long)14L, (long)14L, (long)18L, (long)22L, (long)25L, (long)25L, (long)35L, (long)41L, (long)50L, (long)58L, (long)61L, (long)65L, (long)74L, (long)75L, (long)85L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"})}))).Equals((new List<object>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L})}))).Equals((new List<object>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    public static long CubeSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeSum((2L)) == (72L));\n    Debug.Assert(CubeSum((3L)) == (288L));\n    Debug.Assert(CubeSum((4L)) == (800L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static string ConcatenateTuple(Tuple<string, string, long, string> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ID\", \"is\", 4L, \"UTS\"))).Equals((\"ID-is-4-UTS\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"QWE\", \"is\", 4L, \"RTY\"))).Equals((\"QWE-is-4-RTY\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ZEN\", \"is\", 4L, \"OP\"))).Equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    public static float FindAverageOfCube(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAverageOfCube((2L)) == (4.5f));\n    Debug.Assert(FindAverageOfCube((3L)) == (float)12L);\n    Debug.Assert(FindAverageOfCube((1L)) == (float)1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static List<string> ExtractRear(Tuple<string, string, string> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractRear((Tuple.Create(\"Mers\", \"for\", \"Vers\"))).Equals((new List<string>(new string[]{(string)\"s\", (string)\"r\", (string)\"s\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Avenge\", \"for\", \"People\"))).Equals((new List<string>(new string[]{(string)\"e\", (string)\"r\", (string)\"e\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Gotta\", \"get\", \"go\"))).Equals((new List<string>(new string[]{(string)\"a\", (string)\"t\", (string)\"o\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long CountElementInList(List<List<object>> list1, object x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)11L}), (List<long>)new List<long>(new long[]{(long)1L, (long)15L, (long)7L})})), (object(1L))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"A\"))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"E\"))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static List<long> FilterOddnumbers(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)10L, (long)20L, (long)45L, (long)67L, (long)84L, (long)93L}))).Equals((new List<long>(new long[]{(long)45L, (long)67L, (long)93L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)8L, (long)6L, (long)4L, (long)3L}))).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static string ChangeDateFormat(string dt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeDateFormat((\"2026-01-02\")).Equals((\"02-01-2026\")));\n    Debug.Assert(ChangeDateFormat((\"2020-11-13\")).Equals((\"13-11-2020\")));\n    Debug.Assert(ChangeDateFormat((\"2021-04-26\")).Equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given array by using shell sort.\n    public static List<long> ShellSort(List<long> my_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)12L, (long)23L, (long)4L, (long)5L, (long)3L, (long)2L, (long)12L, (long)81L, (long)56L, (long)95L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)12L, (long)12L, (long)23L, (long)56L, (long)81L, (long)95L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)24L, (long)22L, (long)39L, (long)34L, (long)87L, (long)73L, (long)68L}))).Equals((new List<long>(new long[]{(long)22L, (long)24L, (long)34L, (long)39L, (long)68L, (long)73L, (long)87L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)32L, (long)30L, (long)16L, (long)96L, (long)82L, (long)83L, (long)74L}))).Equals((new List<long>(new long[]{(long)16L, (long)30L, (long)32L, (long)74L, (long)82L, (long)83L, (long)96L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Tuple<long, long, long, long> AndTuples(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AndTuples((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(0L, 0L, 2L, 1L))));\n    Debug.Assert(AndTuples((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(5L, 6L, 7L, 8L))).Equals((Tuple.Create(1L, 2L, 3L, 0L))));\n    Debug.Assert(AndTuples((Tuple.Create(8L, 9L, 11L, 12L)), (Tuple.Create(7L, 13L, 14L, 17L))).Equals((Tuple.Create(0L, 9L, 10L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long ParabolaDirectrix(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParabolaDirectrix((5L), (3L), (2L)) == (-198L));\n    Debug.Assert(ParabolaDirectrix((9L), (8L), (4L)) == (-2336L));\n    Debug.Assert(ParabolaDirectrix((2L), (4L), (6L)) == (-130L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Nullable<bool> CommonElement(List<object> list1, List<object> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals(true));\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))).Equals(null));\n    Debug.Assert(CommonElement((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})), (new List<object>(new string[]{(string)\"d\", (string)\"b\", (string)\"e\"}))).Equals(true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float MedianTrapezium(long base1, long base2, long height) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianTrapezium((15L), (25L), (35L)) == (float)20L);\n    Debug.Assert(MedianTrapezium((10L), (20L), (30L)) == (float)15L);\n    Debug.Assert(MedianTrapezium((6L), (9L), (4L)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    public static bool CheckGreater(List<long> arr, long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (4L)) == (false));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (8L)) == (true));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)9L, (long)7L, (long)4L, (long)8L, (long)6L, (long)1L})), (11L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static bool TextMatchOne(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last digit of a given number.\n    public static long LastDigit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigit((123L)) == (3L));\n    Debug.Assert(LastDigit((25L)) == (5L));\n    Debug.Assert(LastDigit((30L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to return the negative numbers in a list.\n    public static List<long> NegNos(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)4L, (long)5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-6L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-2L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-7L, (long)-6L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)-7L, (long)-6L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static string RemoveOdd(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((\"python\")).Equals((\"yhn\")));\n    Debug.Assert(RemoveOdd((\"program\")).Equals((\"rga\")));\n    Debug.Assert(RemoveOdd((\"language\")).Equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long CountBidirectional(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (3L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (2L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long MultipleToSingle(List<long> L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)11L, (long)33L, (long)50L}))) == (113350L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (-123456L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L}))) == (10152025L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Tuple<long, long, string> FindAdverbPosition(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbPosition((\"clearly!! we can see the sky\")).Equals((Tuple.Create(0L, 7L, \"clearly\"))));\n    Debug.Assert(FindAdverbPosition((\"seriously!! there are many roses\")).Equals((Tuple.Create(0L, 9L, \"seriously\"))));\n    Debug.Assert(FindAdverbPosition((\"unfortunately!! sita is going to home\")).Equals((Tuple.Create(0L, 13L, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long SurfaceareaCube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCube((5L)) == (150L));\n    Debug.Assert(SurfaceareaCube((3L)) == (54L));\n    Debug.Assert(SurfaceareaCube((10L)) == (600L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    public static float PositiveCount(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.54f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.69f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the largest negative number from the given list.\n    public static long LargestNeg(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-4L, (long)-6L}))) == (-6L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-8L, (long)-9L}))) == (-9L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static List<List<long>> TrimTuple(List<List<long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)2L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)8L, (long)2L, (long)1L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)12L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)4L}), (List<long>)new List<long>(new long[]{(long)8L, (long)12L}), (List<long>)new List<long>(new long[]{(long)1L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)9L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static List<List<long>> IndexMultiplication(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)21L}), (List<long>)new List<long>(new long[]{(long)12L, (long)45L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)30L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)14L, (long)32L}), (List<long>)new List<long>(new long[]{(long)20L, (long)60L}), (List<long>)new List<long>(new long[]{(long)6L, (long)20L}), (List<long>)new List<long>(new long[]{(long)16L, (long)44L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)24L, (long)45L}), (List<long>)new List<long>(new long[]{(long)30L, (long)77L}), (List<long>)new List<long>(new long[]{(long)12L, (long)33L}), (List<long>)new List<long>(new long[]{(long)27L, (long)60L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    public static long CountOccurrence(object tup, List<object> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurrence(Tuple.Create(\"a\", \"a\", \"c\", \"b\", \"d\"), (new List<object>(new string[]{(string)\"a\", (string)\"b\"}))) == (3L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 1L, 4L, 6L, 7L, 1L, 4L), (new List<object>(new long[]{(long)1L, (long)4L, (long)7L}))) == (6L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L), (new List<object>(new long[]{(long)1L, (long)2L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static List<long> CubeNums(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)27L, (long)64L, (long)125L, (long)216L, (long)343L, (long)512L, (long)729L, (long)1000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)1728L, (long)3375L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long CalSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CalSum((9L)) == (49L));\n    Debug.Assert(CalSum((10L)) == (66L));\n    Debug.Assert(CalSum((11L)) == (88L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static List<string> ExtractString(List<string> str, long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (8L)).Equals((new List<string>(new string[]{(string)\"practice\", (string)\"solution\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (6L)).Equals((new List<string>(new string[]{(string)\"Python\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (9L)).Equals((new List<string>(new string[]{(string)\"exercises\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static string RemoveWhitespaces(string text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveWhitespaces((\" Google    Flutter \")).Equals((\"GoogleFlutter\")));\n    Debug.Assert(RemoveWhitespaces((\" Google    Dart \")).Equals((\"GoogleDart\")));\n    Debug.Assert(RemoveWhitespaces((\" iOS    Swift \")).Equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long LossAmount(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LossAmount((1500L), (1200L)) == (0L));\n    Debug.Assert(LossAmount((100L), (200L)) == (100L));\n    Debug.Assert(LossAmount((2000L), (5000L)) == (3000L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of even factors of a number.\n    public static long Sumoffactors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sumoffactors((18L)) == (26L));\n    Debug.Assert(Sumoffactors((30L)) == (48L));\n    Debug.Assert(Sumoffactors((6L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static bool TextMatchWordz(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordz((\"pythonz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"xyz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static bool CheckMonthnumbNumber(long monthnum2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumbNumber((5L)) == (true));\n    Debug.Assert(CheckMonthnumbNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumbNumber((6L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static List<string> ReverseStringList(List<string> stringlist) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\", (string)\"White\", (string)\"Black\"}))).Equals((new List<string>(new string[]{(string)\"deR\", (string)\"neerG\", (string)\"eulB\", (string)\"etihW\", (string)\"kcalB\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"john\", (string)\"amal\", (string)\"joel\", (string)\"george\"}))).Equals((new List<string>(new string[]{(string)\"nhoj\", (string)\"lama\", (string)\"leoj\", (string)\"egroeg\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"jack\", (string)\"john\", (string)\"mary\"}))).Equals((new List<string>(new string[]{(string)\"kcaj\", (string)\"nhoj\", (string)\"yram\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sublist having minimum length.\n    public static List<object> FindMin(List<List<object>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)7L, (long)8L})}))).Equals((new List<object>(new long[]{(long)1L, (long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"})}))).Equals((new List<object>(new string[]{(string)\"x\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long RectangleArea(long l, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RectangleArea((10L), (20L)) == (200L));\n    Debug.Assert(RectangleArea((10L), (5L)) == (50L));\n    Debug.Assert(RectangleArea((4L), (2L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static string RemoveUppercase(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveUppercase((\"cAstyoUrFavoRitETVshoWs\")).Equals((\"cstyoravoitshos\")));\n    Debug.Assert(RemoveUppercase((\"wAtchTheinTernEtrAdIo\")).Equals((\"wtchheinerntrdo\")));\n    Debug.Assert(RemoveUppercase((\"VoicESeaRchAndreComMendaTionS\")).Equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to get the first element of each sublist.\n    public static List<long> Extract(List<List<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)6L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))).Equals((new List<long>(new long[]{(long)1L, (long)4L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)8L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))).Equals((new List<long>(new long[]{(long)9L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the upper case characters in a given string.\n    public static long UpperCtr(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UpperCtr((\"PYthon\")) == (1L));\n    Debug.Assert(UpperCtr((\"BigData\")) == (1L));\n    Debug.Assert(UpperCtr((\"program\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    public static long MaxSubarrayProduct(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)0L, (long)7L, (long)-8L, (long)-2L}))) == (112L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)6L, (long)-3L, (long)-10L, (long)0L, (long)2L}))) == (180L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)-2L, (long)-40L, (long)0L, (long)-2L, (long)-3L}))) == (80L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static bool CheckValue(Dictionary<string,long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (10L)) == (false));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (12L)) == (true));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (5L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static Dictionary<string,string> DropEmpty(Dictionary<string,string> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", null}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", null}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c2\", \"Green\"}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    public static long MaxProduct(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)3L, (long)100L, (long)4L, (long)5L, (long)150L, (long)6L}))) == (3000L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)4L, (long)42L, (long)55L, (long)68L, (long)80L}))) == (50265600L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)10L, (long)22L, (long)9L, (long)33L, (long)21L, (long)50L, (long)41L, (long)60L}))) == (2460L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Tuple<long, long, long, long> AddPairwise(Tuple<long, long, long, long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddPairwise((Tuple.Create(1L, 5L, 7L, 8L, 10L))).Equals((Tuple.Create(6L, 12L, 15L, 18L))));\n    Debug.Assert(AddPairwise((Tuple.Create(2L, 6L, 8L, 9L, 11L))).Equals((Tuple.Create(8L, 14L, 17L, 20L))));\n    Debug.Assert(AddPairwise((Tuple.Create(3L, 7L, 9L, 10L, 12L))).Equals((Tuple.Create(10L, 16L, 19L, 22L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    public static long FindRemainder(List<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)100L, (long)10L, (long)5L, (long)25L, (long)35L, (long)14L})), (11L)) == (9L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)1L, (long)1L})), (1L)) == (0L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (2L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    public static bool CheckConsecutive(List<long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static string ReplaceChar(string str1, string ch, string newch) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceChar((\"polygon\"), (\"y\"), (\"l\")).Equals((\"pollgon\")));\n    Debug.Assert(ReplaceChar((\"character\"), (\"c\"), (\"a\")).Equals((\"aharaater\")));\n    Debug.Assert(ReplaceChar((\"python\"), (\"l\"), (\"a\")).Equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static List<Tuple<string, long>> SortCounter(Dictionary<string,long> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 81L}, {\"Physics\", 83L}, {\"Chemistry\", 87L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 87L), (Tuple<string, long>)Tuple.Create(\"Physics\", 83L), (Tuple<string, long>)Tuple.Create(\"Math\", 81L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 400L}, {\"Physics\", 300L}, {\"Chemistry\", 250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Math\", 400L), (Tuple<string, long>)Tuple.Create(\"Physics\", 300L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 250L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 900L}, {\"Physics\", 1000L}, {\"Chemistry\", 1250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 1250L), (Tuple<string, long>)Tuple.Create(\"Physics\", 1000L), (Tuple<string, long>)Tuple.Create(\"Math\", 900L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    public static long BigSum(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)2L, (long)3L, (long)6L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert the given string to lower case.\n    public static string IsLower(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsLower((\"InValid\")).Equals((\"invalid\")));\n    Debug.Assert(IsLower((\"TruE\")).Equals((\"true\")));\n    Debug.Assert(IsLower((\"SenTenCE\")).Equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static string RemoveLowercase(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLowercase((\"PYTHon\")).Equals((\"PYTH\")));\n    Debug.Assert(RemoveLowercase((\"FInD\")).Equals((\"FID\")));\n    Debug.Assert(RemoveLowercase((\"STRinG\")).Equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first digit of a given number.\n    public static long FirstDigit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstDigit((123L)) == (1L));\n    Debug.Assert(FirstDigit((456L)) == (4L));\n    Debug.Assert(FirstDigit((12L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static List<long> HeapQueueLargest(List<long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (3L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (2L)).Equals((new List<long>(new long[]{(long)85L, (long)75L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (5L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L, (long)58L, (long)35L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    public static List<long> Split(List<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)10L, (long)11L, (long)12L, (long)13L}))).Equals((new List<long>(new long[]{(long)11L, (long)13L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)7L, (long)9L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long Difference(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Difference((3L)) == (30L));\n    Debug.Assert(Difference((5L)) == (210L));\n    Debug.Assert(Difference((2L)) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    public static long FindOddPair(List<long> A, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L})), (5L)) == (6L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L})), (7L)) == (12L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (3L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static string ToggleString(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleString((\"Python\")).Equals((\"pYTHON\")));\n    Debug.Assert(ToggleString((\"Pangram\")).Equals((\"pANGRAM\")));\n    Debug.Assert(ToggleString((\"LIttLE\")).Equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    public static long DigitDistanceNums(long n1, long n2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DigitDistanceNums((1L), (2L)) == (1L));\n    Debug.Assert(DigitDistanceNums((23L), (56L)) == (6L));\n    Debug.Assert(DigitDistanceNums((123L), (256L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long MaxSubArraySum(List<long> a, long size) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-2L, (long)-3L, (long)4L, (long)-1L, (long)-2L, (long)1L, (long)5L, (long)-3L})), (8L)) == (7L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L, (long)-2L, (long)-3L, (long)2L, (long)6L, (long)-4L})), (8L)) == (8L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-4L, (long)-5L, (long)6L, (long)-3L, (long)-4L, (long)3L, (long)7L, (long)-5L})), (8L)) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static List<long> UnionElements(List<long> test_tup1, List<long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)4L, (long)10L}))).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)10L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L})), (new List<long>(new long[]{(long)13L, (long)15L, (long)16L, (long)17L}))).Equals((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L, (long)15L, (long)16L, (long)17L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the longest sublists.\n    public static long FindMaxLength(List<List<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (4L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L})}))) == (3L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)22L, (long)23L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L})}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static List<string> ExtractValues(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractValues((\"\"Python\", \"PHP\", \"Java\"\")).Equals((new List<string>(new string[]{(string)\"Python\", (string)\"PHP\", (string)\"Java\"}))));\n    Debug.Assert(ExtractValues((\"\"python\",\"program\",\"language\"\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\"}))));\n    Debug.Assert(ExtractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).Equals((new List<string>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\", (string)\"yellow\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long CountPairs(List<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (3L)) == (2L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (4L)) == (0L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (5L)) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to split a string into characters.\n    public static List<string> Split(string word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((\"python\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))));\n    Debug.Assert(Split((\"Name\")).Equals((new List<string>(new string[]{(string)\"N\", (string)\"a\", (string)\"m\", (string)\"e\"}))));\n    Debug.Assert(Split((\"program\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long SumDigits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDigits((345L)) == (12L));\n    Debug.Assert(SumDigits((12L)) == (3L));\n    Debug.Assert(SumDigits((97L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static bool IssortList(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)17L}))) == (true));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)20L, (long)17L}))) == (false));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)15L, (long)14L, (long)20L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static List<Dictionary<null,null>> EmptyList(long length) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EmptyList((5L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((6L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((7L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"d\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"e\", (string)\"f\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    public static bool Checks(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Checks((70L)) == (false));\n    Debug.Assert(Checks((23L)) == (false));\n    Debug.Assert(Checks((73L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    public static List<long> TwoUniqueNums(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    public static long UniqueProduct(List<long> list_data) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)20L, (long)50L, (long)60L, (long)40L}))) == (720000000L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L}))) == (6L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)0L, (long)1L, (long)1L}))) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float SurfaceareaCylinder(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCylinder((10L), (5L)) == (942.45f));\n    Debug.Assert(SurfaceareaCylinder((4L), (5L)) == (226.18800000000002f));\n    Debug.Assert(SurfaceareaCylinder((4L), (10L)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    public static bool IsSubArray(List<long> A, List<long> B) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)2L}))) == (false));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (true));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)2L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)0L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    public static long LastDigitFactorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigitFactorial((4L)) == (4L));\n    Debug.Assert(LastDigitFactorial((21L)) == (0L));\n    Debug.Assert(LastDigitFactorial((30L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static List<long> InterleaveLists(List<long> list1, List<long> list2, List<long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L, (long)60L, (long)70L})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L, (long)500L, (long)600L, (long)700L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)100L, (long)2L, (long)20L, (long)200L, (long)3L, (long)30L, (long)300L, (long)4L, (long)40L, (long)400L, (long)5L, (long)50L, (long)500L, (long)6L, (long)60L, (long)600L, (long)7L, (long)70L, (long)700L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)10L, (long)20L})), (new List<long>(new long[]{(long)15L, (long)2L})), (new List<long>(new long[]{(long)5L, (long)10L}))).Equals((new List<long>(new long[]{(long)10L, (long)15L, (long)5L, (long)20L, (long)2L, (long)10L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)11L, (long)44L})), (new List<long>(new long[]{(long)10L, (long)15L})), (new List<long>(new long[]{(long)20L, (long)5L}))).Equals((new List<long>(new long[]{(long)11L, (long)10L, (long)20L, (long)44L, (long)15L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Tuple<long, long, long, long> FindDissimilar(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindDissimilar((Tuple.Create(3L, 4L, 5L, 6L)), (Tuple.Create(5L, 7L, 4L, 10L))).Equals((Tuple.Create(3L, 6L, 7L, 10L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(7L, 2L, 3L, 9L))).Equals((Tuple.Create(1L, 4L, 7L, 9L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(21L, 11L, 25L, 26L)), (Tuple.Create(26L, 34L, 21L, 36L))).Equals((Tuple.Create(34L, 36L, 11L, 25L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    public static long FindMaxNum(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (321L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)1L}))) == (6541L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)9L}))) == (9321L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static object ExtractEven(Tuple<long, long, Tuple<long, long, Tuple<long, long>>, long, long> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractEven((Tuple.Create(4L, 5L, Tuple.Create(7L, 6L, Tuple.Create(2L, 4L)), 6L, 8L))).Equals(Tuple.Create(4L, Tuple.Create(6L, Tuple.Create(2L, 4L)), 6L, 8L)));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(8L, 7L, Tuple.Create(4L, 8L)), 7L, 9L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 8L)))));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(9L, 8L, Tuple.Create(4L, 6L)), 8L, 10L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 6L)), 8L, 10L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    public static long SurfaceArea(long b, long s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceArea((3L), (4L)) == (33L));\n    Debug.Assert(SurfaceArea((4L), (5L)) == (56L));\n    Debug.Assert(SurfaceArea((1L), (2L)) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long CatalanNumber(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CatalanNumber((10L)) == (16796L));\n    Debug.Assert(CatalanNumber((9L)) == (4862L));\n    Debug.Assert(CatalanNumber((7L)) == (429L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static string FindAdverbs(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbs((\"Clearly, he has no excuse for such behavior.\")).Equals((\"0-7: Clearly\")));\n    Debug.Assert(FindAdverbs((\"Please handle the situation carefuly\")).Equals((\"28-36: carefuly\")));\n    Debug.Assert(FindAdverbs((\"Complete the task quickly\")).Equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    public static List<long> SplitArr(List<long> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)12L, (long)10L, (long)5L, (long)6L, (long)52L, (long)36L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)52L, (long)36L, (long)12L, (long)10L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (1L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (3L)).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)0L, (long)1L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static object ListTuple(List<long> listx) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)5L, (long)10L, (long)7L, (long)4L, (long)15L, (long)3L}))).Equals(Tuple.Create(5L, 10L, 7L, 4L, 15L, 3L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)2L, (long)3L, (long)4L, (long)4L, (long)7L}))).Equals(Tuple.Create(2L, 4L, 5L, 6L, 2L, 3L, 4L, 4L, 7L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)58L, (long)44L, (long)56L}))).Equals(Tuple.Create(58L, 44L, 56L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    public static long BigDiff(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)4L, (long)5L, (long)12L}))) == (8L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)9L, (long)2L, (long)3L}))) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static List<long> PerfectSquares(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerfectSquares((1L), (30L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L}))));\n    Debug.Assert(PerfectSquares((50L), (100L)).Equals((new List<long>(new long[]{(long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(PerfectSquares((100L), (200L)).Equals((new List<long>(new long[]{(long)100L, (long)121L, (long)144L, (long)169L, (long)196L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    public static bool OppositeSigns(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OppositeSigns((1L), (-2L)) == (true));\n    Debug.Assert(OppositeSigns((3L), (2L)) == (false));\n    Debug.Assert(OppositeSigns((-10L), (-10L)) == (false));\n    Debug.Assert(OppositeSigns((-2L), (2L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)12L, (long)35L, (long)9L, (long)56L, (long)24L}))).Equals((new List<long>(new long[]{(long)24L, (long)35L, (long)9L, (long)56L, (long)12L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    public static long SumOfProduct(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfProduct((3L)) == (15L));\n    Debug.Assert(SumOfProduct((4L)) == (56L));\n    Debug.Assert(SumOfProduct((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static string RemovezeroIp(string ip) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemovezeroIp((\"216.08.094.196\")).Equals((\"216.8.94.196\")));\n    Debug.Assert(RemovezeroIp((\"12.01.024\")).Equals((\"12.1.24\")));\n    Debug.Assert(RemovezeroIp((\"216.08.094.0196\")).Equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long DiffEvenOdd(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (3L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (1L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static object MinSwaps(string str1, string str2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinSwaps((\"1101\"), (\"1110\")).Equals((object(1L))));\n    Debug.Assert(MinSwaps((\"111\"), (\"000\")).Equals((object(\"Not Possible\"))));\n    Debug.Assert(MinSwaps((\"111\"), (\"110\")).Equals((object(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    public static long FindKth(List<long> arr1, List<long> arr2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)8L, (long)10L})), (5L)) == (6L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)100L, (long)112L, (long)256L, (long)349L, (long)770L})), (new List<long>(new long[]{(long)72L, (long)86L, (long)113L, (long)119L, (long)265L, (long)445L, (long)892L})), (7L)) == (256L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)3L, (long)4L, (long)7L, (long)8L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)9L, (long)11L})), (6L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static bool ArmstrongNumber(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ArmstrongNumber((153L)) == (true));\n    Debug.Assert(ArmstrongNumber((259L)) == (false));\n    Debug.Assert(ArmstrongNumber((4458L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Tuple<long, float> SumAverage(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumAverage((10L)).Equals((Tuple.Create(55L, 5.5f))));\n    Debug.Assert(SumAverage((15L)).Equals((Tuple.Create(120L, 8.0f))));\n    Debug.Assert(SumAverage((20L)).Equals((Tuple.Create(210L, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long IsOctagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsOctagonal((5L)) == (65L));\n    Debug.Assert(IsOctagonal((10L)) == (280L));\n    Debug.Assert(IsOctagonal((15L)) == (645L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number is even or not.\n    public static bool IsEven(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEven((1L)) == (false));\n    Debug.Assert(IsEven((2L)) == (true));\n    Debug.Assert(IsEven((3L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first repeated character in a given string.\n    public static string FirstRepeatedChar(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstRepeatedChar((\"abcabc\")).Equals((\"a\")));\n    Debug.Assert(FirstRepeatedChar((\"abc\")).Equals(null));\n    Debug.Assert(FirstRepeatedChar((\"123123\")).Equals((\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static List<long> GetLudic(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetLudic((10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(GetLudic((25L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L}))));\n    Debug.Assert(GetLudic((45L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L, (long)29L, (long)37L, (long)41L, (long)43L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static string ReverseWords(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseWords((\"python program\")).Equals((\"program python\")));\n    Debug.Assert(ReverseWords((\"java language\")).Equals((\"language java\")));\n    Debug.Assert(ReverseWords((\"indian man\")).Equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static bool PrimeNum(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeNum((13L)) == (true));\n    Debug.Assert(PrimeNum((7L)) == (true));\n    Debug.Assert(PrimeNum((-1010L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float RadianDegree(long degree) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RadianDegree((90L)) == (1.5707963267948966f));\n    Debug.Assert(RadianDegree((60L)) == (1.0471975511965976f));\n    Debug.Assert(RadianDegree((120L)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Tuple<string, long, long> FindLiterals(string text, string pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).Equals((Tuple.Create(\"fox\", 16L, 19L))));\n    Debug.Assert(FindLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).Equals((Tuple.Create(\"crazy\", 16L, 21L))));\n    Debug.Assert(FindLiterals((\"Hardest choices required strongest will\"), (\"will\")).Equals((Tuple.Create(\"will\", 35L, 39L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find nth bell number.\n    public static long BellNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((3L)) == (5L));\n    Debug.Assert(BellNumber((4L)) == (15L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static List<long> RemoveKthElement(List<long> list1, long L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long MaxOfNth(List<List<long>> test_list, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)9L, (long)19L})})), (2L)) == (19L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)20L})})), (1L)) == (10L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)21L})})), (1L)) == (11L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static List<List<object>> Merge(List<List<object>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L})}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\", (string)\"o\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"z\", (string)\"c\", (string)\"o\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long CummulativeSum(List<List<long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)6L})}))) == (30L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)7L})}))) == (37L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L})}))) == (44L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static List<float> AverageTuple(List<List<long>> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)12L}), (List<long>)new List<long>(new long[]{(long)30L, (long)45L, (long)56L, (long)45L}), (List<long>)new List<long>(new long[]{(long)81L, (long)80L, (long)39L, (long)32L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))).Equals((new List<float>(new float[]{(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)30L, (long)-15L, (long)56L}), (List<long>)new List<long>(new long[]{(long)81L, (long)-60L, (long)-39L}), (List<long>)new List<long>(new long[]{(long)-10L, (long)2L, (long)3L})}))).Equals((new List<float>(new float[]{(float)25.5f, (float)-18.0f, (float)3.75f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)100L, (long)100L, (long)100L, (long)120L}), (List<long>)new List<long>(new long[]{(long)300L, (long)450L, (long)560L, (long)450L}), (List<long>)new List<long>(new long[]{(long)810L, (long)800L, (long)390L, (long)320L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new List<float>(new float[]{(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Tuple<long, long, long, long> TupleModulo(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleModulo((Tuple.Create(10L, 4L, 5L, 6L)), (Tuple.Create(5L, 6L, 7L, 5L))).Equals((Tuple.Create(0L, 4L, 5L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(11L, 5L, 6L, 7L)), (Tuple.Create(6L, 7L, 8L, 6L))).Equals((Tuple.Create(5L, 5L, 6L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(12L, 6L, 7L, 8L)), (Tuple.Create(7L, 8L, 9L, 7L))).Equals((Tuple.Create(5L, 6L, 7L, 1L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float MinJumps(Tuple<long, long> steps, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (11L)) == (3.5f));\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (0L)) == (float)0L);\n    Debug.Assert(MinJumps((Tuple.Create(11L, 14L)), (11L)) == (float)1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static List<float> DivList(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<float>(new float[]{(float)4.0f, (float)2.5f, (float)2.0f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)3L, (long)2L})), (new List<long>(new long[]{(long)1L, (long)4L}))).Equals((new List<float>(new float[]{(float)3.0f, (float)0.5f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<float>(new float[]{(float)1.8f, (float)1.7142857142857142f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static string MoveNum(string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveNum((\"I1love143you55three3000thousand\")).Equals((\"Iloveyouthreethousand1143553000\")));\n    Debug.Assert(MoveNum((\"Avengers124Assemble\")).Equals((\"AvengersAssemble124\")));\n    Debug.Assert(MoveNum((\"Its11our12path13to14see15things16do17things\")).Equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    public static long CountSubstrings(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSubstrings((\"112112\")) == (6L));\n    Debug.Assert(CountSubstrings((\"111\")) == (6L));\n    Debug.Assert(CountSubstrings((\"1101112\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float GetMedian(List<long> arr1, List<long> arr2, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)1L, (long)12L, (long)15L, (long)26L, (long)38L})), (new List<long>(new long[]{(long)2L, (long)13L, (long)17L, (long)30L, (long)45L})), (5L)) == (16.0f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)7L, (long)13L, (long)19L, (long)28L})), (4L)) == (8.5f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)3L, (long)6L, (long)14L, (long)23L, (long)36L, (long)42L})), (new List<long>(new long[]{(long)2L, (long)18L, (long)27L, (long)39L, (long)49L, (long)55L})), (6L)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static List<long> NthNums(List<long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (3L)).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)12L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)248832L, (long)759375L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to convert a given string to uppercase.\n    public static string IsUpper(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUpper((\"person\")).Equals((\"PERSON\")));\n    Debug.Assert(IsUpper((\"final\")).Equals((\"FINAL\")));\n    Debug.Assert(IsUpper((\"Valid\")).Equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))).Equals((new List<long>(new long[]{(long)4L, (long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Nullable<long> TriangleArea(long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((-1L)).Equals(null));\n    Debug.Assert(TriangleArea((0L)).Equals(0L));\n    Debug.Assert(TriangleArea((2L)).Equals(4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    public static long FindFirstMissing(List<long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)6L, (long)9L}))) == (3L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)8L, (long)9L}))) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static string ReplaceSpaces(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"My Name is Dawood\")).Equals((\"My%20Name%20is%20Dawood\")));\n    Debug.Assert(ReplaceSpaces((\"I am a Programmer\")).Equals((\"I%20am%20a%20Programmer\")));\n    Debug.Assert(ReplaceSpaces((\"I love Coding\")).Equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    public static List<long> Split(List<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)0L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)0L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)8L, (long)12L, (long)15L, (long)19L}))).Equals((new List<long>(new long[]{(long)8L, (long)12L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find smallest number in a list.\n    public static long SmallestNum(List<long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)10L, (long)20L, (long)1L, (long)45L, (long)99L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)45L, (long)46L, (long)50L, (long)60L}))) == (45L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static List<List<long>> GetCoordinates(Tuple<long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetCoordinates((Tuple.Create(3L, 4L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(4L, 5L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(5L, 6L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)7L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static string ReplaceSpaces(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"Jumanji The Jungle\")).Equals((\"Jumanji_The_Jungle\")));\n    Debug.Assert(ReplaceSpaces((\"The_Avengers\")).Equals((\"The Avengers\")));\n    Debug.Assert(ReplaceSpaces((\"Fast and Furious\")).Equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    public static List<long> MoveZero(List<long> num_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)0L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)0L, (long)0L, (long)4L, (long)0L, (long)5L, (long)0L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)4L, (long)5L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)1L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)0L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    public static long PairXorSum(List<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)5L, (long)9L, (long)7L, (long)6L})), (4L)) == (47L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L, (long)5L})), (3L)) == (12L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L})), (2L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list.\n    public static List<long> HeapSort(List<long> iterable) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L}))).Equals((new List<long>(new long[]{(long)14L, (long)22L, (long)25L, (long)25L, (long)35L, (long)58L, (long)65L, (long)75L, (long)85L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)7L, (long)1L, (long)9L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static bool NoprofitNoloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NoprofitNoloss((1500L), (1200L)) == (false));\n    Debug.Assert(NoprofitNoloss((100L), (100L)) == (true));\n    Debug.Assert(NoprofitNoloss((2000L), (5000L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long WindChill(long v, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WindChill((120L), (35L)) == (40L));\n    Debug.Assert(WindChill((40L), (20L)) == (19L));\n    Debug.Assert(WindChill((10L), (8L)) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long SampleNam(List<string> sample_names) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"sally\", (string)\"Dylan\", (string)\"rebecca\", (string)\"Diana\", (string)\"Joanne\", (string)\"keith\"}))) == (16L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"php\", (string)\"res\", (string)\"Python\", (string)\"abcd\", (string)\"Java\", (string)\"aaa\"}))) == (10L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"abcd\", (string)\"Python\", (string)\"abba\", (string)\"aba\"}))) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long MaxDifference(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(1L, 7L), (Tuple<long, long>)Tuple.Create(10L, 3L), (Tuple<long, long>)Tuple.Create(1L, 2L)}))) == (7L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(2L, 17L), (Tuple<long, long>)Tuple.Create(9L, 13L), (Tuple<long, long>)Tuple.Create(11L, 12L)}))) == (15L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 35L), (Tuple<long, long>)Tuple.Create(21L, 27L), (Tuple<long, long>)Tuple.Create(13L, 23L), (Tuple<long, long>)Tuple.Create(41L, 22L)}))) == (23L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static string RemoveParenthesis(List<string> items) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"python (chrome)\"}))).Equals((\"python\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"string(.abc)\"}))).Equals((\"string\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"alpha(num)\"}))).Equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long IsNonagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNonagonal((10L)) == (325L));\n    Debug.Assert(IsNonagonal((15L)) == (750L));\n    Debug.Assert(IsNonagonal((18L)) == (1089L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static bool TextMatchWordzMiddle(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    Debug.Assert(TextMatchWordzMiddle((\"zxyabc.\")) == (false));\n    Debug.Assert(TextMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to reverse an array upto a given position.\n    public static List<long> ReverseArrayUptoK(List<long> input, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L, (long)5L, (long)6L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)4L, (long)6L, (long)7L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)6L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static List<Tuple<string, long>> SubjectMarks(List<Tuple<string, long>> subjectmarks) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L), (Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L), (Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L), (Tuple<string, long>)Tuple.Create(\"Social\", 33L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social\", 33L), (Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L), (Tuple<string, long>)Tuple.Create(\"Biology\", 45L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Biology\", 45L), (Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    public static long PosCount(List<long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L, (long)-4L}))) == (2L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)-1L}))) == (3L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long BellNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((10L)) == (115975L));\n    Debug.Assert(BellNumber((56L)) == (6775685320645824322581483068371419745979053216268760300L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    public static bool IsMonotonic(List<long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static bool IsSublist(List<long> l, List<long> s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)3L, (long)7L}))) == (false));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)4L, (long)3L}))) == (true));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)1L, (long)6L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    public static bool DifferAtOneBitPos(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifferAtOneBitPos((13L), (9L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((15L), (8L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (4L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (3L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((5L), (1L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((1L), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static bool GetEqual(List<List<long>> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)22L, (long)33L}), (List<long>)new List<long>(new long[]{(long)44L, (long)55L, (long)66L})}))) == (true));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})}))) == (false));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> CombSort(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)5L, (long)15L, (long)37L, (long)25L, (long)79L}))).Equals((new List<long>(new long[]{(long)5L, (long)15L, (long)25L, (long)37L, (long)79L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)41L, (long)32L, (long)15L, (long)19L, (long)22L}))).Equals((new List<long>(new long[]{(long)15L, (long)19L, (long)22L, (long)32L, (long)41L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)99L, (long)15L, (long)13L, (long)47L}))).Equals((new List<long>(new long[]{(long)13L, (long)15L, (long)47L, (long)99L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Tuple<long, long, long, Dictionary<string,long>> AddDictToTuple(Tuple<long, long, long> test_tup, Dictionary<string,long> test_dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddDictToTuple((Tuple.Create(4L, 5L, 6L)), (new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}})).Equals((Tuple.Create(4L, 5L, 6L, new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(1L, 2L, 3L)), (new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}})).Equals((Tuple.Create(1L, 2L, 3L, new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(8L, 9L, 10L)), (new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}})).Equals((Tuple.Create(8L, 9L, 10L, new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float Maxaverageofpath(List<List<long>> cost) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L, (long)9L})}))) == (5.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L, (long)10L})}))) == (6.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)11L})}))) == (7.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static Dictionary<string,Tuple<float, long>> FilterData(Dictionary<string,Tuple<float, long>> students, float h, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (6.0f), (70L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.9f), (67L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.7f), (64L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long CountSamePair(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (4L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (11L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (1L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)2L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)2L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long PowerBaseSum(long numBase, long power) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PowerBaseSum((2L), (100L)) == (115L));\n    Debug.Assert(PowerBaseSum((8L), (10L)) == (37L));\n    Debug.Assert(PowerBaseSum((8L), (15L)) == (62L));\n    Debug.Assert(PowerBaseSum((3L), (3L)) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static List<object> ExtractQuotation(string text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).Equals((new List<object>(new string[]{(string)\"A53\", (string)\"multi\", (string)\"Processor\"}))));\n    Debug.Assert(ExtractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).Equals((new List<object>(new string[]{(string)\"favorite\", (string)\"apps\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).Equals((new List<object>(new string[]{(string)\"4k Ultra HD\", (string)\"HDR 10\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static List<object> MultiplyElements(List<long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)8L, (long)10L}))).Equals((new List<object>(new long[]{(long)5L, (long)35L, (long)56L, (long)80L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)8L, (long)20L, (long)30L, (long)42L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L, (long)13L, (long)14L, (long)9L, (long)15L}))).Equals((new List<object>(new long[]{(long)156L, (long)182L, (long)126L, (long)135L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L}))).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static List<long> SumList(List<long> lst1, List<long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumList((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)25L, (long)35L}))).Equals((new List<long>(new long[]{(long)25L, (long)45L, (long)65L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)5L, (long)6L, (long)7L}))).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)15L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)45L, (long)75L}))).Equals((new List<long>(new long[]{(long)30L, (long)65L, (long)105L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    public static bool DifSquare(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifSquare((5L)) == (true));\n    Debug.Assert(DifSquare((10L)) == (false));\n    Debug.Assert(DifSquare((15L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static List<object> ConsecutiveDuplicates(List<object> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<object>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<object>(new long[]{(long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\", (string)\"a\", (string)\"a\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"a\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float LateralsurfaceCone(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCone((5L), (12L)) == (204.20352248333654f));\n    Debug.Assert(LateralsurfaceCone((10L), (15L)) == (566.3586699569488f));\n    Debug.Assert(LateralsurfaceCone((19L), (17L)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static string ReplaceSpecialchar(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpecialchar((\"Python language, Programming language.\")).Equals((\"Python:language::Programming:language:\")));\n    Debug.Assert(ReplaceSpecialchar((\"a b c,d e f\")).Equals((\"a:b:c:d:e:f\")));\n    Debug.Assert(ReplaceSpecialchar((\"ram reshma,ram rahim\")).Equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    public static long FindFirstOccurrence(List<long> A, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)5L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (1L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (2L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (6L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    public static long SumOfSubarrayProd(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (20L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L}))) == (5L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long ToggleMiddleBits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleMiddleBits((9L)) == (15L));\n    Debug.Assert(ToggleMiddleBits((10L)) == (12L));\n    Debug.Assert(ToggleMiddleBits((11L)) == (13L));\n    Debug.Assert(ToggleMiddleBits((65L)) == (127L));\n    Debug.Assert(ToggleMiddleBits((77L)) == (115L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    public static long LeftInsertion(List<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static bool CheckStr(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckStr((\"annie\")) == (true));\n    Debug.Assert(CheckStr((\"dawood\")) == (false));\n    Debug.Assert(CheckStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    public static float GeometricSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GeometricSum((7L)) == (1.9921875f));\n    Debug.Assert(GeometricSum((4L)) == (1.9375f));\n    Debug.Assert(GeometricSum((8L)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long FindIndex(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindIndex((2L)) == (4L));\n    Debug.Assert(FindIndex((3L)) == (14L));\n    Debug.Assert(FindIndex((4L)) == (45L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    public static Dictionary<long,long> TupleToDict(Tuple<long, long, long, long, long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 5L, 7L, 10L, 13L, 5L))).Equals((new Dictionary<long,long>(){{1L, 5L}, {7L, 10L}, {13L, 5L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L))).Equals((new Dictionary<long,long>(){{1L, 2L}, {3L, 4L}, {5L, 6L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(7L, 8L, 9L, 10L, 11L, 12L))).Equals((new Dictionary<long,long>(){{7L, 8L}, {9L, 10L}, {11L, 12L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether all the characters are same or not.\n    public static bool AllCharactersSame(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllCharactersSame((\"python\")) == (false));\n    Debug.Assert(AllCharactersSame((\"aaa\")) == (true));\n    Debug.Assert(AllCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float AreaTetrahedron(long side) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreaTetrahedron((3L)) == (15.588457268119894f));\n    Debug.Assert(AreaTetrahedron((20L)) == (692.8203230275509f));\n    Debug.Assert(AreaTetrahedron((10L)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    public static List<long> RotateRight(List<long> list, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (3L)).Equals((new List<long>(new long[]{(long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static bool CheckNone(object test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckNone(Tuple.Create(10L, 4L, 5L, 6L, (Nullable<long>)null)) == (true));\n    Debug.Assert(CheckNone(Tuple.Create(7L, 8L, 9L, 11L, 14L)) == (false));\n    Debug.Assert(CheckNone(Tuple.Create(1L, 2L, 3L, 4L, (Nullable<long>)null)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    public static List<long> DivisibleByDigits(long startnum, long endnum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisibleByDigits((1L), (22L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L, (long)22L}))));\n    Debug.Assert(DivisibleByDigits((1L), (15L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L}))));\n    Debug.Assert(DivisibleByDigits((20L), (25L)).Equals((new List<long>(new long[]{(long)22L, (long)24L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    public static Nullable<float> SectorArea(long r, long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SectorArea((4L), (45L)).Equals(6.283185307179586f));\n    Debug.Assert(SectorArea((9L), (45L)).Equals(31.808625617596654f));\n    Debug.Assert(SectorArea((9L), (361L)).Equals(null));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long LcsOfThree(string X, string Y, string Z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2L));\n    Debug.Assert(LcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5L));\n    Debug.Assert(LcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static string CapitalWordsSpaces(string str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CapitalWordsSpaces((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(CapitalWordsSpaces((\"PythonProgrammingExamples\")).Equals((\"Python Programming Examples\")));\n    Debug.Assert(CapitalWordsSpaces((\"GetReadyToBeCodingFreak\")).Equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    public static List<long> SortNumericStrings(List<string> nums_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"4\", (string)\"12\", (string)\"45\", (string)\"7\", (string)\"0\", (string)\"100\", (string)\"200\", (string)\"-12\", (string)\"-500\"}))).Equals((new List<long>(new long[]{(long)-500L, (long)-12L, (long)0L, (long)4L, (long)7L, (long)12L, (long)45L, (long)100L, (long)200L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"2\", (string)\"3\", (string)\"8\", (string)\"4\", (string)\"7\", (string)\"9\", (string)\"8\", (string)\"2\", (string)\"6\", (string)\"5\", (string)\"1\", (string)\"6\", (string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"6\", (string)\"9\", (string)\"1\", (string)\"2\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)8L, (long)9L, (long)9L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"1\", (string)\"3\", (string)\"5\", (string)\"7\", (string)\"1\", (string)\"3\", (string)\"13\", (string)\"15\", (string)\"17\", (string)\"5\", (string)\"7 \", (string)\"9\", (string)\"1\", (string)\"11\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)3L, (long)3L, (long)5L, (long)5L, (long)7L, (long)7L, (long)9L, (long)11L, (long)13L, (long)15L, (long)17L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    public static bool IsSamepatterns(List<string> colors, List<string> patterns) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"green\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (true));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (false));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\"}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static List<long> AddTuple(List<long> test_list, Tuple<long, long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)10L, (long)11L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    public static bool CheckMinHeap(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)10L, (long)15L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)5L, (long)3L, (long)15L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long JacobsthalNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(JacobsthalNum((5L)) == (11L));\n    Debug.Assert(JacobsthalNum((2L)) == (1L));\n    Debug.Assert(JacobsthalNum((4L)) == (5L));\n    Debug.Assert(JacobsthalNum((13L)) == (2731L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    public static List<Tuple<string, long>> MinK(List<Tuple<string, long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Manjeet\", 10L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L), (Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Nikhil\", 8L)})), (2L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sanjeev\", 11L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)})), (3L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"tanmay\", 14L), (Tuple<string, long>)Tuple.Create(\"Amer\", 11L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L), (Tuple<string, long>)Tuple.Create(\"SKD\", 16L)})), (1L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static List<object> ExtractIndexList(List<long> l1, List<long> l2, List<long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)7L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)5L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)6L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)6L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)6L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    public static bool TextMatchZeroOne(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchZeroOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"dsabbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"asbbbba\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    public static long CountReversePairs(List<string> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"julia\", (string)\"best\", (string)\"tseb\", (string)\"for\", (string)\"ailuj\"}))) == (2L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"geeks\", (string)\"best\", (string)\"for\", (string)\"skeeg\"}))) == (1L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"makes\", (string)\"best\", (string)\"sekam\", (string)\"for\", (string)\"rof\"}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static bool IsDecimal(string num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDecimal((\"123.11\")) == (true));\n    Debug.Assert(IsDecimal((\"e666.86\")) == (false));\n    Debug.Assert(IsDecimal((\"3.124587\")) == (false));\n    Debug.Assert(IsDecimal((\"1.11\")) == (true));\n    Debug.Assert(IsDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static List<Tuple<long, long, long>> FindTuples(List<Tuple<long, long, long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L), (Tuple<long, long, long>)Tuple.Create(7L, 9L, 6L), (Tuple<long, long, long>)Tuple.Create(12L, 18L, 21L)})), (6L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L), (Tuple<long, long, long>)Tuple.Create(4L, 2L, 3L), (Tuple<long, long, long>)Tuple.Create(7L, 8L, 9L)})), (5L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(7L, 9L, 16L), (Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L), (Tuple<long, long, long>)Tuple.Create(19L, 17L, 18L)})), (4L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    public static bool UniqueElement(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))) == (true));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static bool CheckMonthnumberNumber(long monthnum3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumberNumber((6L)) == (true));\n    Debug.Assert(CheckMonthnumberNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumberNumber((12L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long FindMinDiff(List<long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)19L, (long)18L, (long)25L})), (6L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)6L})), (4L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)30L, (long)5L, (long)20L, (long)9L})), (4L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count number of digits in a given string.\n    public static long NumberCtr(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberCtr((\"program2bedone\")) == (1L));\n    Debug.Assert(NumberCtr((\"3wonders\")) == (1L));\n    Debug.Assert(NumberCtr((\"123\")) == (3L));\n    Debug.Assert(NumberCtr((\"3wond-1ers2\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long IsPolite(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPolite((7L)) == (11L));\n    Debug.Assert(IsPolite((4L)) == (7L));\n    Debug.Assert(IsPolite((9L)) == (13L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static List<Tuple<long, long>> PairWise(List<long> l1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 5L), (Tuple<long, long>)Tuple.Create(5L, 7L), (Tuple<long, long>)Tuple.Create(7L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)5L, (long)1L, (long)9L, (long)7L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(1L, 9L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(7L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L), (Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long GetPairsCount(List<long> arr, long sum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (2L)) == (6L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)-1L, (long)5L})), (6L)) == (3L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L})), (1L)) == (1L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L})), (-3L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to get the difference between two lists.\n    public static List<long> Diff(List<long> li1, List<long> li2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Diff((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L, (long)30L, (long)35L, (long)40L})), (new List<long>(new long[]{(long)25L, (long)40L, (long)35L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)15L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    public static long OddNumSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddNumSum((2L)) == (82L));\n    Debug.Assert(OddNumSum((3L)) == (707L));\n    Debug.Assert(OddNumSum((4L)) == (3108L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static bool CheckExpression(string exp) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckExpression((\"{()}[{}]\")) == (true));\n    Debug.Assert(CheckExpression((\"{()}[{]\")) == (false));\n    Debug.Assert(CheckExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static string RemoveLength(string test_str, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLength((\"The person is most value tet\"), (3L)).Equals((\"person is most value\")));\n    Debug.Assert(RemoveLength((\"If you told me about this ok\"), (4L)).Equals((\"If you me about ok\")));\n    Debug.Assert(RemoveLength((\"Forces of darkeness is come into the play\"), (4L)).Equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    public static Tuple<string, long, long> OccuranceSubstring(string text, string pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OccuranceSubstring((\"python programming, python language\"), (\"python\")).Equals((Tuple.Create(\"python\", 0L, 6L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"programming\")).Equals((Tuple.Create(\"programming\", 7L, 18L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"language\")).Equals((Tuple.Create(\"language\", 31L, 39L))));\n    Debug.Assert(OccuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).Equals(null));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    public static bool OddPosition(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L, (long)6L, (long)7L, (long)6L, (long)3L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)4L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long CountVowels(string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountVowels((\"bestinstareels\")) == (7L));\n    Debug.Assert(CountVowels((\"partofthejourneyistheend\")) == (12L));\n    Debug.Assert(CountVowels((\"amazonprime\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    public static long FindSum(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)1L, (long)4L, (long)5L, (long)6L}))) == (21L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)10L, (long)9L, (long)4L, (long)2L, (long)10L, (long)10L, (long)45L, (long)4L}))) == (71L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)12L, (long)10L, (long)9L, (long)45L, (long)2L, (long)10L, (long)10L, (long)45L, (long)10L}))) == (78L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static List<List<object>> PackConsecutiveDuplicates(List<object> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)8L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L}), (List<long>)new List<long>(new long[]{(long)15L}), (List<long>)new List<long>(new long[]{(long)19L}), (List<long>)new List<long>(new long[]{(long)18L, (long)18L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)26L, (long)26L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)18L}), (List<long>)new List<long>(new long[]{(long)10L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"a\"}), (List<string>)new List<string>(new string[]{(string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"d\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    public static bool IsDiff(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDiff((12345L)) == (false));\n    Debug.Assert(IsDiff((1212112L)) == (true));\n    Debug.Assert(IsDiff((1212L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    public static List<Tuple<long, long>> FindCombinations(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(6L, 10L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(8L, 11L), (Tuple<long, long>)Tuple.Create(7L, 5L), (Tuple<long, long>)Tuple.Create(8L, 14L), (Tuple<long, long>)Tuple.Create(11L, 8L), (Tuple<long, long>)Tuple.Create(12L, 17L), (Tuple<long, long>)Tuple.Create(11L, 11L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(6L, 2L), (Tuple<long, long>)Tuple.Create(7L, 11L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 13L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(10L, 16L), (Tuple<long, long>)Tuple.Create(13L, 10L), (Tuple<long, long>)Tuple.Create(14L, 19L), (Tuple<long, long>)Tuple.Create(13L, 13L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(7L, 3L), (Tuple<long, long>)Tuple.Create(8L, 12L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 15L), (Tuple<long, long>)Tuple.Create(11L, 9L), (Tuple<long, long>)Tuple.Create(12L, 18L), (Tuple<long, long>)Tuple.Create(15L, 12L), (Tuple<long, long>)Tuple.Create(16L, 21L), (Tuple<long, long>)Tuple.Create(15L, 15L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    public static bool CountDivisors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDivisors((10L)) == (true));\n    Debug.Assert(CountDivisors((100L)) == (false));\n    Debug.Assert(CountDivisors((125L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    public static long OddLengthSum(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)4L}))) == (14L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (15L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)7L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static List<float> RgbToHsv(long r, long g, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RgbToHsv((255L), (255L), (255L)).Equals((new List<float>(new float[]{(float)0.0f, (float)0.0f, (float)100.0f}))));\n    Debug.Assert(RgbToHsv((0L), (215L), (0L)).Equals((new List<float>(new float[]{(float)120.0f, (float)100.0f, (float)84.31372549019608f}))));\n    Debug.Assert(RgbToHsv((10L), (215L), (110L)).Equals((new List<float>(new float[]{(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long MulEvenOdd(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (4L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Tuple<long, long, long> TupleStrInt(string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleStrInt((\"(7, 8, 9)\")).Equals((Tuple.Create(7L, 8L, 9L))));\n    Debug.Assert(TupleStrInt((\"(1, 2, 3)\")).Equals((Tuple.Create(1L, 2L, 3L))));\n    Debug.Assert(TupleStrInt((\"(4, 5, 6)\")).Equals((Tuple.Create(4L, 5L, 6L))));\n    Debug.Assert(TupleStrInt((\"(7, 81, 19)\")).Equals((Tuple.Create(7L, 81L, 19L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long RightInsertion(List<long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static bool TextMatchThree(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchThree((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Tuple<string, string, string> NewTuple(List<string> test_list, string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"WEB\", (string)\"is\"})), (\"best\")).Equals((Tuple.Create(\"WEB\", \"is\", \"best\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"We\", (string)\"are\"})), (\"Developers\")).Equals((Tuple.Create(\"We\", \"are\", \"Developers\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"Part\", (string)\"is\"})), (\"Wrong\")).Equals((Tuple.Create(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    public static bool EvenPosition(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Tuple<long, long, long, long> RemoveNested(object test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveNested(Tuple.Create(1L, 5L, 7L, Tuple.Create(4L, 6L), 10L)).Equals((Tuple.Create(1L, 5L, 7L, 10L))));\n    Debug.Assert(RemoveNested(Tuple.Create(2L, 6L, 8L, Tuple.Create(5L, 7L), 11L)).Equals((Tuple.Create(2L, 6L, 8L, 11L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), Tuple.Create(5L, 12L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    public static long CountList(List<List<long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))) == (4L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))) == (3L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)2L, (long)0L})}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    public static long Last(List<long> arr, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (1L)) == (0L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)4L})), (1L)) == (2L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)3L, (long)6L, (long)8L, (long)9L})), (3L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static bool TextStartaEndb(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextStartaEndb((\"aabbbb\")) == (true));\n    Debug.Assert(TextStartaEndb((\"aabAbbbc\")) == (false));\n    Debug.Assert(TextStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long ReturnSum(Dictionary<string,long> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 100L}, {\"b\", 200L}, {\"c\", 300L}})) == (600L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 25L}, {\"b\", 18L}, {\"c\", 45L}})) == (88L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 36L}, {\"b\", 39L}, {\"c\", 49L}})) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    public static long SumInRange(long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumInRange((2L), (5L)) == (8L));\n    Debug.Assert(SumInRange((5L), (7L)) == (12L));\n    Debug.Assert(SumInRange((7L), (13L)) == (40L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the sum of an array.\n    public static long Sum(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)15L, (long)12L, (long)13L, (long)10L}))) == (50L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)0L, (long)1L, (long)2L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long LeftRotate(long n, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftRotate((16L), (2L)) == (64L));\n    Debug.Assert(LeftRotate((10L), (2L)) == (40L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((1L), (3L)) == (8L));\n    Debug.Assert(LeftRotate((5L), (3L)) == (40L));\n    Debug.Assert(LeftRotate((29L), (3L)) == (232L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    public static bool WordLen(string s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordLen((\"Hadoop\")) == (false));\n    Debug.Assert(WordLen((\"great\")) == (true));\n    Debug.Assert(WordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static string RemoveAllSpaces(string text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveAllSpaces((\"python  program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"python   programming    language\")).Equals((\"pythonprogramminglanguage\")));\n    Debug.Assert(RemoveAllSpaces((\"python                     program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"   python                     program\")).Equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    public static long TestThreeEqual(long x, long y, long z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestThreeEqual((1L), (1L), (1L)) == (3L));\n    Debug.Assert(TestThreeEqual((-1L), (-2L), (-3L)) == (0L));\n    Debug.Assert(TestThreeEqual((1L), (2L), (2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    public static long CountRotation(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)4L, (long)5L, (long)1L, (long)2L, (long)3L}))) == (2L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (0L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static bool IsPerfectSquare(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPerfectSquare((10L)) == (false));\n    Debug.Assert(IsPerfectSquare((36L)) == (true));\n    Debug.Assert(IsPerfectSquare((14L)) == (false));\n    Debug.Assert(IsPerfectSquare((196L)) == (true));\n    Debug.Assert(IsPerfectSquare((125L)) == (false));\n    Debug.Assert(IsPerfectSquare((15625L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static bool IsProductEven(List<long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)1L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static List<long> MaxSumList(List<List<long>> lists) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)10L, (long)11L, (long)12L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)12L, (long)11L, (long)10L})}))).Equals((new List<long>(new long[]{(long)12L, (long)11L, (long)10L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)1L})}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long MaxRunUppercase(string test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxRunUppercase((\"GeMKSForGERksISBESt\")) == (5L));\n    Debug.Assert(MaxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6L));\n    Debug.Assert(MaxRunUppercase((\"GooGLEFluTTER\")) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    public static long FirstOdd(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)8L, (long)9L, (long)1L}))) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static bool CheckK(List<long> test_tup, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)10L, (long)4L, (long)5L, (long)6L, (long)8L})), (6L)) == (true));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (7L)) == (false));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)44L, (long)11L, (long)12L})), (11L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static bool CheckSmaller(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckSmaller((Tuple.Create(1L, 2L, 3L)), (Tuple.Create(2L, 3L, 4L))) == (false));\n    Debug.Assert(CheckSmaller((Tuple.Create(4L, 5L, 6L)), (Tuple.Create(3L, 4L, 5L))) == (true));\n    Debug.Assert(CheckSmaller((Tuple.Create(11L, 12L, 13L)), (Tuple.Create(10L, 11L, 12L))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long TetrahedralNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TetrahedralNumber((5L)) == (35L));\n    Debug.Assert(TetrahedralNumber((6L)) == (56L));\n    Debug.Assert(TetrahedralNumber((7L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static string GetChar(string strr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetChar((\"abc\")).Equals((\"f\")));\n    Debug.Assert(GetChar((\"gfg\")).Equals((\"t\")));\n    Debug.Assert(GetChar((\"ab\")).Equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long Sequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sequence((10L)) == (6L));\n    Debug.Assert(Sequence((2L)) == (1L));\n    Debug.Assert(Sequence((3L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long CenteredHexagonalNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CenteredHexagonalNumber((10L)) == (271L));\n    Debug.Assert(CenteredHexagonalNumber((2L)) == (7L));\n    Debug.Assert(CenteredHexagonalNumber((9L)) == (217L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static Dictionary<string,string> MergeDictionariesThree(Dictionary<string,string> dict1, Dictionary<string,string> dict2, Dictionary<string,string> dict3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})).Equals((new Dictionary<string,string>(){{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static Dictionary<long,long> FreqCount(List<long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)10L, (long)20L, (long)20L, (long)20L, (long)20L, (long)40L, (long)40L, (long)50L, (long)50L, (long)30L}))).Equals((new Dictionary<long,long>(){{10L, 4L}, {20L, 4L}, {40L, 2L}, {50L, 2L}, {30L, 1L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)4L, (long)1L, (long)3L, (long)1L, (long)4L}))).Equals((new Dictionary<long,long>(){{1L, 3L}, {2L, 2L}, {3L, 3L}, {4L, 3L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)4L, (long)9L, (long)10L, (long)4L, (long)5L, (long)6L, (long)7L, (long)9L, (long)5L}))).Equals((new Dictionary<long,long>(){{10L, 1L}, {5L, 3L}, {6L, 2L}, {7L, 2L}, {4L, 2L}, {9L, 2L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long ClosestNum(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestNum((11L)) == (10L));\n    Debug.Assert(ClosestNum((7L)) == (6L));\n    Debug.Assert(ClosestNum((12L)) == (11L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static List<long> SquareNums(List<long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)100L, (long)400L, (long)900L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)144L, (long)225L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the longest word.\n    public static long LenLog(List<string> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"python\", (string)\"PHP\", (string)\"bigdata\"}))) == (7L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))) == (3L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"small\", (string)\"big\", (string)\"tall\"}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static bool FindSubstring(List<string> str1, string sub_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ack\")) == (true));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"abc\")) == (false));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static bool IsUndulating(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUndulating((1212121L)) == (true));\n    Debug.Assert(IsUndulating((1991L)) == (false));\n    Debug.Assert(IsUndulating((121L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long Power(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Power((3L), (4L)) == (81L));\n    Debug.Assert(Power((2L), (3L)) == (8L));\n    Debug.Assert(Power((5L), (5L)) == (3125L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static string IndexMinimum(List<Tuple<string, long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Rash\", 143L), (Tuple<string, long>)Tuple.Create(\"Manjeet\", 200L), (Tuple<string, long>)Tuple.Create(\"Varsha\", 100L)}))).Equals((\"Varsha\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Yash\", 185L), (Tuple<string, long>)Tuple.Create(\"Dawood\", 125L), (Tuple<string, long>)Tuple.Create(\"Sanya\", 175L)}))).Equals((\"Dawood\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sai\", 345L), (Tuple<string, long>)Tuple.Create(\"Salman\", 145L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 96L)}))).Equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(List<List<long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))) == (1L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))) == (2L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L})}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    public static long Divisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Divisor((15L)) == (4L));\n    Debug.Assert(Divisor((12L)) == (6L));\n    Debug.Assert(Divisor((9L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static Dictionary<long,long> FrequencyLists(List<List<long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)2L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)5L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 3L}, {3L, 1L}, {4L, 1L}, {5L, 2L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 1L}, {3L, 1L}, {4L, 1L}, {5L, 1L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}, {10L, 1L}, {11L, 1L}, {12L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)20L, (long)30L, (long)40L, (long)17L}), (List<long>)new List<long>(new long[]{(long)18L, (long)16L, (long)14L, (long)13L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new Dictionary<long,long>(){{20L, 2L}, {30L, 2L}, {40L, 2L}, {17L, 1L}, {18L, 1L}, {16L, 1L}, {14L, 1L}, {13L, 1L}, {10L, 1L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static string DecimalToBinary(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((8L)).Equals((\"1000\")));\n    Debug.Assert(DecimalToBinary((18L)).Equals((\"10010\")));\n    Debug.Assert(DecimalToBinary((7L)).Equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long FindRotations(string str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRotations((\"aaaa\")) == (1L));\n    Debug.Assert(FindRotations((\"ab\")) == (2L));\n    Debug.Assert(FindRotations((\"abc\")) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-cs-reworded.json
+++ b/prompts/mbpp-cs-reworded.json
@@ -1,3444 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long Lps(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Lps((\"TENS FOR TENS\")) == (5L));\n    Debug.Assert(Lps((\"CARDIO FOR CARDS\")) == (7L));\n    Debug.Assert(Lps((\"PART OF THE JOURNEY IS PART\")) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static string RemoveWhitespaces(string text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveWhitespaces((\" Google    Flutter \")).Equals((\"GoogleFlutter\")));\n    Debug.Assert(RemoveWhitespaces((\" Google    Dart \")).Equals((\"GoogleDart\")));\n    Debug.Assert(RemoveWhitespaces((\" iOS    Swift \")).Equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static bool IssortList(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)17L}))) == (true));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)20L, (long)17L}))) == (false));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)15L, (long)14L, (long)20L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long CountBidirectional(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (3L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (2L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long SurfaceareaCube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCube((5L)) == (150L));\n    Debug.Assert(SurfaceareaCube((3L)) == (54L));\n    Debug.Assert(SurfaceareaCube((10L)) == (600L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    public static long NextSmallestPalindrome(long num) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextSmallestPalindrome((99L)) == (101L));\n    Debug.Assert(NextSmallestPalindrome((1221L)) == (1331L));\n    Debug.Assert(NextSmallestPalindrome((120L)) == (121L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the cube sum of first n even natural numbers.\n    public static long CubeSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeSum((2L)) == (72L));\n    Debug.Assert(CubeSum((3L)) == (288L));\n    Debug.Assert(CubeSum((4L)) == (800L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of xor of all pairs of numbers in the given list.\n    public static long PairXorSum(List<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)5L, (long)9L, (long)7L, (long)6L})), (4L)) == (47L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L, (long)5L})), (3L)) == (12L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L})), (2L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n    public static bool CheckMinHeap(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)10L, (long)15L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)5L, (long)3L, (long)15L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first digit of a given number.\n    public static long FirstDigit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstDigit((123L)) == (1L));\n    Debug.Assert(FirstDigit((456L)) == (4L));\n    Debug.Assert(FirstDigit((12L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first non-repeated character in a given string.\n    public static string FirstNonRepeatingCharacter(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstNonRepeatingCharacter((\"abcabc\")).Equals(null));\n    Debug.Assert(FirstNonRepeatingCharacter((\"abc\")).Equals((\"a\")));\n    Debug.Assert(FirstNonRepeatingCharacter((\"ababc\")).Equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float RadianDegree(long degree) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RadianDegree((90L)) == (1.5707963267948966f));\n    Debug.Assert(RadianDegree((60L)) == (1.0471975511965976f));\n    Debug.Assert(RadianDegree((120L)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product sublist of the given list.\n    public static long MaxSubarrayProduct(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)0L, (long)7L, (long)-8L, (long)-2L}))) == (112L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)6L, (long)-3L, (long)-10L, (long)0L, (long)2L}))) == (180L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)-2L, (long)-40L, (long)0L, (long)-2L, (long)-3L}))) == (80L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static List<Dictionary<string,Dictionary<string,long>>> ConvertListDictionary(List<string> l1, List<string> l2, List<long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"S001\", (string)\"S002\", (string)\"S003\", (string)\"S004\"})), (new List<string>(new string[]{(string)\"Adina Park\", (string)\"Leyton Marsh\", (string)\"Duncan Boyle\", (string)\"Saim Richards\"})), (new List<long>(new long[]{(long)85L, (long)98L, (long)89L, (long)92L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S001\", new Dictionary<string,long>(){{\"Adina Park\", 85L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S002\", new Dictionary<string,long>(){{\"Leyton Marsh\", 98L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S003\", new Dictionary<string,long>(){{\"Duncan Boyle\", 89L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S004\", new Dictionary<string,long>(){{\"Saim Richards\", 92L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"abc\", (string)\"def\", (string)\"ghi\", (string)\"jkl\"})), (new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\", (string)\"programs\"})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"abc\", new Dictionary<string,long>(){{\"python\", 100L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"def\", new Dictionary<string,long>(){{\"program\", 200L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"ghi\", new Dictionary<string,long>(){{\"language\", 300L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"jkl\", new Dictionary<string,long>(){{\"programs\", 400L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"A1\", (string)\"A2\", (string)\"A3\", (string)\"A4\"})), (new List<string>(new string[]{(string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\"})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A1\", new Dictionary<string,long>(){{\"java\", 10L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A2\", new Dictionary<string,long>(){{\"C\", 20L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A3\", new Dictionary<string,long>(){{\"C++\", 30L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A4\", new Dictionary<string,long>(){{\"DBMS\", 40L}}}}}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find smallest number in a list.\n    public static long SmallestNum(List<long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)10L, (long)20L, (long)1L, (long)45L, (long)99L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)45L, (long)46L, (long)50L, (long)60L}))) == (45L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/csthon-exercises/re/csthon-re-exercise-3.php\n    public static bool TextMatchZeroOne(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchZeroOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"dsabbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"asbbbba\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find nth bell number.\n    public static long BellNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((3L)) == (5L));\n    Debug.Assert(BellNumber((4L)) == (15L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static List<long> CubeNums(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)27L, (long)64L, (long)125L, (long)216L, (long)343L, (long)512L, (long)729L, (long)1000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)1728L, (long)3375L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last digit in factorial of a given number.\n    public static long LastDigitFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigitFactorial((4L)) == (4L));\n    Debug.Assert(LastDigitFactorial((21L)) == (0L));\n    Debug.Assert(LastDigitFactorial((30L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find even numbers from a list of numbers.\n    public static List<long> Split(List<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)0L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)0L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)8L, (long)12L, (long)15L, (long)19L}))).Equals((new List<long>(new long[]{(long)8L, (long)12L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static bool PrimeNum(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeNum((13L)) == (true));\n    Debug.Assert(PrimeNum((7L)) == (true));\n    Debug.Assert(PrimeNum((-1010L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static List<Tuple<long, long, long>> FindTuples(List<Tuple<long, long, long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L), (Tuple<long, long, long>)Tuple.Create(7L, 9L, 6L), (Tuple<long, long, long>)Tuple.Create(12L, 18L, 21L)})), (6L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L), (Tuple<long, long, long>)Tuple.Create(4L, 2L, 3L), (Tuple<long, long, long>)Tuple.Create(7L, 8L, 9L)})), (5L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(7L, 9L, 16L), (Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L), (Tuple<long, long, long>)Tuple.Create(19L, 17L, 18L)})), (4L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float AreaTetrahedron(long side) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreaTetrahedron((3L)) == (15.588457268119894f));\n    Debug.Assert(AreaTetrahedron((20L)) == (692.8203230275509f));\n    Debug.Assert(AreaTetrahedron((10L)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number is even or not.\n    public static bool IsEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEven((1L)) == (false));\n    Debug.Assert(IsEven((2L)) == (true));\n    Debug.Assert(IsEven((3L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of positive numbers in a list.\n    public static long PosCount(List<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L, (long)-4L}))) == (2L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)-1L}))) == (3L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static List<long> GetLudic(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetLudic((10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(GetLudic((25L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L}))));\n    Debug.Assert(GetLudic((45L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L, (long)29L, (long)37L, (long)41L, (long)43L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long FindIndex(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindIndex((2L)) == (4L));\n    Debug.Assert(FindIndex((3L)) == (14L));\n    Debug.Assert(FindIndex((4L)) == (45L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to reverse a list upto a given position.\n    public static List<long> ReverseArrayUptoK(List<long> input, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L, (long)5L, (long)6L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)4L, (long)6L, (long)7L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)6L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static List<Tuple<string, long>> SubjectMarks(List<Tuple<string, long>> subjectmarks) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L), (Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L), (Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L), (Tuple<string, long>)Tuple.Create(\"Social\", 33L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social\", 33L), (Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L), (Tuple<string, long>)Tuple.Create(\"Biology\", 45L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Biology\", 45L), (Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static string RemoveDirtyChars(string str, string second_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDirtyChars((\"probasscurve\"), (\"pros\")).Equals((\"bacuve\")));\n    Debug.Assert(RemoveDirtyChars((\"digitalindia\"), (\"talent\")).Equals((\"digiidi\")));\n    Debug.Assert(RemoveDirtyChars((\"exoticmiles\"), (\"toxic\")).Equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long MaxOccurrences(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)2L, (long)6L, (long)5L, (long)1L, (long)6L, (long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)6L, (long)9L, (long)1L, (long)2L}))) == (2L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)7L, (long)9L, (long)15L, (long)14L, (long)10L, (long)12L, (long)13L, (long)16L, (long)18L}))) == (8L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)10L, (long)20L, (long)20L, (long)30L, (long)40L, (long)90L, (long)80L, (long)50L, (long)30L, (long)20L, (long)50L, (long)10L}))) == (20L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static bool IsDecimal(string num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDecimal((\"123.11\")) == (true));\n    Debug.Assert(IsDecimal((\"e666.86\")) == (false));\n    Debug.Assert(IsDecimal((\"3.124587\")) == (false));\n    Debug.Assert(IsDecimal((\"1.11\")) == (true));\n    Debug.Assert(IsDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static Dictionary<string,long> DictFilter(Dictionary<string,long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (170L)).Equals((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (180L)).Equals((new Dictionary<string,long>(){{\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (190L)).Equals((new Dictionary<string,long>(){{\"Pierre Cox\", 190L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of even numbers at even positions of a list.\n    public static long SumEvenAndEvenIndex(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L, (long)18L, (long)8L}))) == (30L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)3L, (long)20L, (long)17L, (long)9L, (long)2L, (long)10L, (long)18L, (long)13L, (long)6L, (long)18L}))) == (26L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L}))) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long MaxSubArraySum(List<long> a, long size) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-2L, (long)-3L, (long)4L, (long)-1L, (long)-2L, (long)1L, (long)5L, (long)-3L})), (8L)) == (7L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L, (long)-2L, (long)-3L, (long)2L, (long)6L, (long)-4L})), (8L)) == (8L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-4L, (long)-5L, (long)6L, (long)-3L, (long)-4L, (long)3L, (long)7L, (long)-5L})), (8L)) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the intersection of two lists.\n    public static List<long> IntersectionArray(List<long> array_nums1, List<long> array_nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<long>(new long[]{(long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static object SplitTwoParts(List<object> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitTwoParts((new List<object>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals(Tuple.Create(new List<long>(new long[]{(long)1L, (long)1L, (long)2L}), new List<long>(new long[]{(long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (2L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"a\", (string)\"b\"}), new List<string>(new string[]{(string)\"c\", (string)\"d\"}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"})), (4L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\"}), new List<string>(new string[]{(string)\"o\", (string)\"n\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Tuple<string, long, long> FindLiterals(string text, string pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).Equals((Tuple.Create(\"fox\", 16L, 19L))));\n    Debug.Assert(FindLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).Equals((Tuple.Create(\"crazy\", 16L, 21L))));\n    Debug.Assert(FindLiterals((\"Hardest choices required strongest will\"), (\"will\")).Equals((Tuple.Create(\"will\", 35L, 39L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the volume of a triangular prism.\n    public static long FindVolume(long l, long b, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindVolume((10L), (8L), (6L)) == (240L));\n    Debug.Assert(FindVolume((3L), (2L), (2L)) == (6L));\n    Debug.Assert(FindVolume((1L), (2L), (1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long WindChill(long v, long t) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WindChill((120L), (35L)) == (40L));\n    Debug.Assert(WindChill((40L), (20L)) == (19L));\n    Debug.Assert(WindChill((10L), (8L)) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long AsciiValue(string k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AsciiValue((\"A\")) == (65L));\n    Debug.Assert(AsciiValue((\"R\")) == (82L));\n    Debug.Assert(AsciiValue((\"S\")) == (83L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether all the characters are same or not.\n    public static bool AllCharactersSame(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllCharactersSame((\"python\")) == (false));\n    Debug.Assert(AllCharactersSame((\"aaa\")) == (true));\n    Debug.Assert(AllCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static string MoveNum(string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveNum((\"I1love143you55three3000thousand\")).Equals((\"Iloveyouthreethousand1143553000\")));\n    Debug.Assert(MoveNum((\"Avengers124Assemble\")).Equals((\"AvengersAssemble124\")));\n    Debug.Assert(MoveNum((\"Its11our12path13to14see15things16do17things\")).Equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the length of the word is odd or not.\n    public static bool WordLen(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordLen((\"Hadoop\")) == (false));\n    Debug.Assert(WordLen((\"great\")) == (true));\n    Debug.Assert(WordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static Dictionary<string,string> DropEmpty(Dictionary<string,string> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", null}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", null}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c2\", \"Green\"}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static List<string> InsertElement(List<string> list, string element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Black\"})), (\"c\")).Equals((new List<string>(new string[]{(string)\"c\", (string)\"Red\", (string)\"c\", (string)\"Green\", (string)\"c\", (string)\"Black\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"python\", (string)\"java\"})), (\"program\")).Equals((new List<string>(new string[]{(string)\"program\", (string)\"python\", (string)\"program\", (string)\"java\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"happy\", (string)\"sad\"})), (\"laugh\")).Equals((new List<string>(new string[]{(string)\"laugh\", (string)\"happy\", (string)\"laugh\", (string)\"sad\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static string RemoveLowercase(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLowercase((\"PYTHon\")).Equals((\"PYTH\")));\n    Debug.Assert(RemoveLowercase((\"FInD\")).Equals((\"FID\")));\n    Debug.Assert(RemoveLowercase((\"STRinG\")).Equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long CountSetBits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSetBits((2L)) == (1L));\n    Debug.Assert(CountSetBits((4L)) == (1L));\n    Debug.Assert(CountSetBits((6L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static List<string> ExtractRear(Tuple<string, string, string> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractRear((Tuple.Create(\"Mers\", \"for\", \"Vers\"))).Equals((new List<string>(new string[]{(string)\"s\", (string)\"r\", (string)\"s\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Avenge\", \"for\", \"People\"))).Equals((new List<string>(new string[]{(string)\"e\", (string)\"r\", (string)\"e\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Gotta\", \"get\", \"go\"))).Equals((new List<string>(new string[]{(string)\"a\", (string)\"t\", (string)\"o\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long CountOccurance(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurance((\"letstdlenstdporstd\")) == (3L));\n    Debug.Assert(CountOccurance((\"truststdsolensporsd\")) == (1L));\n    Debug.Assert(CountOccurance((\"makestdsostdworthit\")) == (2L));\n    Debug.Assert(CountOccurance((\"stds\")) == (1L));\n    Debug.Assert(CountOccurance((\"\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static bool CheckK(List<long> test_tup, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)10L, (long)4L, (long)5L, (long)6L, (long)8L})), (6L)) == (true));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (7L)) == (false));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)44L, (long)11L, (long)12L})), (11L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static List<long> InterleaveLists(List<long> list1, List<long> list2, List<long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L, (long)60L, (long)70L})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L, (long)500L, (long)600L, (long)700L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)100L, (long)2L, (long)20L, (long)200L, (long)3L, (long)30L, (long)300L, (long)4L, (long)40L, (long)400L, (long)5L, (long)50L, (long)500L, (long)6L, (long)60L, (long)600L, (long)7L, (long)70L, (long)700L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)10L, (long)20L})), (new List<long>(new long[]{(long)15L, (long)2L})), (new List<long>(new long[]{(long)5L, (long)10L}))).Equals((new List<long>(new long[]{(long)10L, (long)15L, (long)5L, (long)20L, (long)2L, (long)10L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)11L, (long)44L})), (new List<long>(new long[]{(long)10L, (long)15L})), (new List<long>(new long[]{(long)20L, (long)5L}))).Equals((new List<long>(new long[]{(long)11L, (long)10L, (long)20L, (long)44L, (long)15L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"python_program\")).Equals((\"PythonProgram\")));\n    Debug.Assert(SnakeToCamel((\"python_language\")).Equals((\"PythonLanguage\")));\n    Debug.Assert(SnakeToCamel((\"programming_language\")).Equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of equal numbers from three given integers.\n    public static long TestThreeEqual(long x, long y, long z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestThreeEqual((1L), (1L), (1L)) == (3L));\n    Debug.Assert(TestThreeEqual((-1L), (-2L), (-3L)) == (0L));\n    Debug.Assert(TestThreeEqual((1L), (2L), (2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n    public static long OddLengthSum(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)4L}))) == (14L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (15L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)7L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long BellNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((10L)) == (115975L));\n    Debug.Assert(BellNumber((56L)) == (6775685320645824322581483068371419745979053216268760300L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long RectangleArea(long l, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RectangleArea((10L), (20L)) == (200L));\n    Debug.Assert(RectangleArea((10L), (5L)) == (50L));\n    Debug.Assert(RectangleArea((4L), (2L)) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Tuple<long, float> SumAverage(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumAverage((10L)).Equals((Tuple.Create(55L, 5.5f))));\n    Debug.Assert(SumAverage((15L)).Equals((Tuple.Create(120L, 8.0f))));\n    Debug.Assert(SumAverage((20L)).Equals((Tuple.Create(210L, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Tuple<long, long, long, long> DivisionElements(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisionElements((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(2L, 2L, 2L, 3L))));\n    Debug.Assert(DivisionElements((Tuple.Create(12L, 6L, 8L, 16L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(2L, 2L, 2L, 4L))));\n    Debug.Assert(DivisionElements((Tuple.Create(20L, 14L, 36L, 18L)), (Tuple.Create(5L, 7L, 6L, 9L))).Equals((Tuple.Create(4L, 2L, 6L, 2L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long SumDigits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDigits((345L)) == (12L));\n    Debug.Assert(SumDigits((12L)) == (3L));\n    Debug.Assert(SumDigits((97L)) == (16L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static string IndexMinimum(List<Tuple<string, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Rash\", 143L), (Tuple<string, long>)Tuple.Create(\"Manjeet\", 200L), (Tuple<string, long>)Tuple.Create(\"Varsha\", 100L)}))).Equals((\"Varsha\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Yash\", 185L), (Tuple<string, long>)Tuple.Create(\"Dawood\", 125L), (Tuple<string, long>)Tuple.Create(\"Sanya\", 175L)}))).Equals((\"Dawood\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sai\", 345L), (Tuple<string, long>)Tuple.Create(\"Salman\", 145L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 96L)}))).Equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static List<float> DivList(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<float>(new float[]{(float)4.0f, (float)2.5f, (float)2.0f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)3L, (long)2L})), (new List<long>(new long[]{(long)1L, (long)4L}))).Equals((new List<float>(new float[]{(float)3.0f, (float)0.5f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<float>(new float[]{(float)1.8f, (float)1.7142857142857142f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Tuple<long, List<long>> MaxLengthList(List<List<long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L})}))).Equals((Tuple.Create(5L, new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the largest and smallest value in a given list.\n    public static long BigSum(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)2L, (long)3L, (long)6L}))) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to return the negative numbers in a list.\n    public static List<long> NegNos(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)4L, (long)5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-6L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-2L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-7L, (long)-6L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)-7L, (long)-6L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the highest power of 2 that is less than or equal to n.\n    public static long HighestPowerOf2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HighestPowerOf2((10L)) == (8L));\n    Debug.Assert(HighestPowerOf2((19L)) == (16L));\n    Debug.Assert(HighestPowerOf2((32L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static bool IsSublist(List<long> l, List<long> s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)3L, (long)7L}))) == (false));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)4L, (long)3L}))) == (true));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)1L, (long)6L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static List<long> SubList(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-3L, (long)-3L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L})), (new List<long>(new long[]{(long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-2L, (long)-2L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<long>(new long[]{(long)40L, (long)50L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given two integers have opposite sign or not.\n    public static bool OppositeSigns(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OppositeSigns((1L), (-2L)) == (true));\n    Debug.Assert(OppositeSigns((3L), (2L)) == (false));\n    Debug.Assert(OppositeSigns((-10L), (-10L)) == (false));\n    Debug.Assert(OppositeSigns((-2L), (2L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Tuple<long, long, long, long> TupleModulo(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleModulo((Tuple.Create(10L, 4L, 5L, 6L)), (Tuple.Create(5L, 6L, 7L, 5L))).Equals((Tuple.Create(0L, 4L, 5L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(11L, 5L, 6L, 7L)), (Tuple.Create(6L, 7L, 8L, 6L))).Equals((Tuple.Create(5L, 5L, 6L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(12L, 6L, 7L, 8L)), (Tuple.Create(7L, 8L, 9L, 7L))).Equals((Tuple.Create(5L, 6L, 7L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long DiffEvenOdd(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (3L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (1L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"d\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"e\", (string)\"f\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last digit of a given number.\n    public static long LastDigit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigit((123L)) == (3L));\n    Debug.Assert(LastDigit((25L)) == (5L));\n    Debug.Assert(LastDigit((30L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of fourth power of first n odd natural numbers.\n    public static long OddNumSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddNumSum((2L)) == (82L));\n    Debug.Assert(OddNumSum((3L)) == (707L));\n    Debug.Assert(OddNumSum((4L)) == (3108L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static string TupString(List<string> tup1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"e\", (string)\"x\", (string)\"e\", (string)\"r\", (string)\"c\", (string)\"i\", (string)\"s\", (string)\"e\", (string)\"s\"}))).Equals((\"exercises\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))).Equals((\"python\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))).Equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static List<long> RemoveElements(List<long> list1, List<long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether any value in a sequence exists in a sequence or not.\n    public static bool Overlapping(List<long> list1, List<long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to identify non-prime numbers.\n    public static bool IsNotPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNotPrime((2L)) == (false));\n    Debug.Assert(IsNotPrime((10L)) == (true));\n    Debug.Assert(IsNotPrime((35L)) == (true));\n    Debug.Assert(IsNotPrime((37L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long SumNegativenum(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (-32L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)10L, (long)15L, (long)-14L, (long)13L, (long)-18L, (long)12L, (long)-20L}))) == (-52L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)19L, (long)-65L, (long)57L, (long)39L, (long)152L, (long)-639L, (long)121L, (long)44L, (long)90L, (long)-190L}))) == (-894L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long FindRotations(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRotations((\"aaaa\")) == (1L));\n    Debug.Assert(FindRotations((\"ab\")) == (2L));\n    Debug.Assert(FindRotations((\"abc\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static string ChangeDateFormat(string dt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeDateFormat((\"2026-01-02\")).Equals((\"02-01-2026\")));\n    Debug.Assert(ChangeDateFormat((\"2020-11-13\")).Equals((\"13-11-2020\")));\n    Debug.Assert(ChangeDateFormat((\"2021-04-26\")).Equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of integers and only returns the odd ones.\n    public static List<long> Split(List<long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)10L, (long)11L, (long)12L, (long)13L}))).Equals((new List<long>(new long[]{(long)11L, (long)13L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)7L, (long)9L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long ToggleMiddleBits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleMiddleBits((9L)) == (15L));\n    Debug.Assert(ToggleMiddleBits((10L)) == (12L));\n    Debug.Assert(ToggleMiddleBits((11L)) == (13L));\n    Debug.Assert(ToggleMiddleBits((65L)) == (127L));\n    Debug.Assert(ToggleMiddleBits((77L)) == (115L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long CountCharPosition(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharPosition((\"xbcefg\")) == (2L));\n    Debug.Assert(CountCharPosition((\"ABcED\")) == (3L));\n    Debug.Assert(CountCharPosition((\"AbgdeF\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static List<long> LargeProduct(List<long> nums1, List<long> nums2, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (3L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (5L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L, (long)45L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long CummulativeSum(List<List<long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)6L})}))) == (30L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)7L})}))) == (37L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L})}))) == (44L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long FindMinDiff(List<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)19L, (long)18L, (long)25L})), (6L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)6L})), (4L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)30L, (long)5L, (long)20L, (long)9L})), (4L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static bool TextStartaEndb(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextStartaEndb((\"aabbbb\")) == (true));\n    Debug.Assert(TextStartaEndb((\"aabAbbbc\")) == (false));\n    Debug.Assert(TextStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long LeftRotate(long n, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftRotate((16L), (2L)) == (64L));\n    Debug.Assert(LeftRotate((10L), (2L)) == (40L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((1L), (3L)) == (8L));\n    Debug.Assert(LeftRotate((5L), (3L)) == (40L));\n    Debug.Assert(LeftRotate((29L), (3L)) == (232L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first repeated character in a given string.\n    public static string FirstRepeatedChar(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstRepeatedChar((\"abcabc\")).Equals((\"a\")));\n    Debug.Assert(FirstRepeatedChar((\"abc\")).Equals(null));\n    Debug.Assert(FirstRepeatedChar((\"123123\")).Equals((\"1\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count inversions in a list.\n    public static long GetInvCount(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)20L, (long)6L, (long)4L, (long)5L}))) == (5L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)6L, (long)1L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long EvenPowerSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPowerSum((2L)) == (1056L));\n    Debug.Assert(EvenPowerSum((3L)) == (8832L));\n    Debug.Assert(EvenPowerSum((1L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static bool GetEqual(List<List<long>> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)22L, (long)33L}), (List<long>)new List<long>(new long[]{(long)44L, (long)55L, (long)66L})}))) == (true));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})}))) == (false));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static bool CheckInteger(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckInteger((\"python\")) == (false));\n    Debug.Assert(CheckInteger((\"1\")) == (true));\n    Debug.Assert(CheckInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/csthon-program-to-count-the-pairs-of-reverse-strings/\n    public static long CountReversePairs(List<string> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"julia\", (string)\"best\", (string)\"tseb\", (string)\"for\", (string)\"ailuj\"}))) == (2L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"geeks\", (string)\"best\", (string)\"for\", (string)\"skeeg\"}))) == (1L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"makes\", (string)\"best\", (string)\"sekam\", (string)\"for\", (string)\"rof\"}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to move all zeroes to the end of the given list.\n    public static List<long> MoveZero(List<long> num_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)0L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)0L, (long)0L, (long)4L, (long)0L, (long)5L, (long)0L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)4L, (long)5L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)1L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)0L, (long)0L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static bool CheckDistinct(List<long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L, (long)1L, (long)4L}))) == (false));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static bool NoprofitNoloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NoprofitNoloss((1500L), (1200L)) == (false));\n    Debug.Assert(NoprofitNoloss((100L), (100L)) == (true));\n    Debug.Assert(NoprofitNoloss((2000L), (5000L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static string RemoveLength(string test_str, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLength((\"The person is most value tet\"), (3L)).Equals((\"person is most value\")));\n    Debug.Assert(RemoveLength((\"If you told me about this ok\"), (4L)).Equals((\"If you me about ok\")));\n    Debug.Assert(RemoveLength((\"Forces of darkeness is come into the play\"), (4L)).Equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count number of digits in a given string.\n    public static long NumberCtr(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberCtr((\"program2bedone\")) == (1L));\n    Debug.Assert(NumberCtr((\"3wonders\")) == (1L));\n    Debug.Assert(NumberCtr((\"123\")) == (3L));\n    Debug.Assert(NumberCtr((\"3wond-1ers2\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long CountCharac(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharac((\"python programming\")) == (18L));\n    Debug.Assert(CountCharac((\"language\")) == (8L));\n    Debug.Assert(CountCharac((\"words\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long GetTotalNumberOfSequences(long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetTotalNumberOfSequences((10L), (4L)) == (4L));\n    Debug.Assert(GetTotalNumberOfSequences((5L), (2L)) == (6L));\n    Debug.Assert(GetTotalNumberOfSequences((16L), (3L)) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/csthon-exercises/data-structures-and-algorithms/csthon-data-structure-exercise-24.php\n    public static long LeftInsertion(List<long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static List<long> SwapNumbers(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapNumbers((10L), (20L)).Equals((new List<long>(new long[]{(long)20L, (long)10L}))));\n    Debug.Assert(SwapNumbers((15L), (17L)).Equals((new List<long>(new long[]{(long)17L, (long)15L}))));\n    Debug.Assert(SwapNumbers((100L), (200L)).Equals((new List<long>(new long[]{(long)200L, (long)100L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n    public static bool IsMajority(List<long> arr, long n, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)3L, (long)10L})), (7L), (3L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)4L, (long)4L, (long)4L, (long)6L, (long)6L})), (8L), (4L)) == (false));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Tuple<long, long, long> SubstractElements(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubstractElements((Tuple.Create(10L, 4L, 5L)), (Tuple.Create(2L, 5L, 18L))).Equals((Tuple.Create(8L, -1L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(11L, 2L, 3L)), (Tuple.Create(24L, 45L, 16L))).Equals((Tuple.Create(-13L, -43L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(7L, 18L, 9L)), (Tuple.Create(10L, 11L, 12L))).Equals((Tuple.Create(-3L, 7L, -3L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static string CapitalWordsSpaces(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CapitalWordsSpaces((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(CapitalWordsSpaces((\"PythonProgrammingExamples\")).Equals((\"Python Programming Examples\")));\n    Debug.Assert(CapitalWordsSpaces((\"GetReadyToBeCodingFreak\")).Equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the average of cubes of first n natural numbers.\n    public static float FindAverageOfCube(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAverageOfCube((2L)) == (4.5f));\n    Debug.Assert(FindAverageOfCube((3L)) == (float)12L);\n    Debug.Assert(FindAverageOfCube((1L)) == (float)1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static bool CheckValue(Dictionary<string,long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (10L)) == (false));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (12L)) == (true));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (5L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long TetrahedralNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TetrahedralNumber((5L)) == (35L));\n    Debug.Assert(TetrahedralNumber((6L)) == (56L));\n    Debug.Assert(TetrahedralNumber((7L)) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static bool MagicSquareTest(List<List<long>> my_matrix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)12L, (long)1L, (long)14L}), (List<long>)new List<long>(new long[]{(long)2L, (long)13L, (long)8L, (long)11L}), (List<long>)new List<long>(new long[]{(long)16L, (long)3L, (long)10L, (long)5L}), (List<long>)new List<long>(new long[]{(long)9L, (long)6L, (long)15L, (long)4L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)8L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)7L})}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static string RemoveUppercase(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveUppercase((\"cAstyoUrFavoRitETVshoWs\")).Equals((\"cstyoravoitshos\")));\n    Debug.Assert(RemoveUppercase((\"wAtchTheinTernEtrAdIo\")).Equals((\"wtchheinerntrdo\")));\n    Debug.Assert(RemoveUppercase((\"VoicESeaRchAndreComMendaTionS\")).Equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long DogAge(long h_age) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DogAge((12L)) == (61L));\n    Debug.Assert(DogAge((15L)) == (73L));\n    Debug.Assert(DogAge((24L)) == (109L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the next perfect square greater than a given number.\n    public static long NextPerfectSquare(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPerfectSquare((35L)) == (36L));\n    Debug.Assert(NextPerfectSquare((6L)) == (9L));\n    Debug.Assert(NextPerfectSquare((9L)) == (16L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static List<Dictionary<null,null>> EmptyList(long length) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EmptyList((5L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((6L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((7L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert a given string to uppercase.\n    public static string IsUpper(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUpper((\"person\")).Equals((\"PERSON\")));\n    Debug.Assert(IsUpper((\"final\")).Equals((\"FINAL\")));\n    Debug.Assert(IsUpper((\"Valid\")).Equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long OddEquivalent(string s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddEquivalent((\"011001\"), (6L)) == (3L));\n    Debug.Assert(OddEquivalent((\"11011\"), (5L)) == (4L));\n    Debug.Assert(OddEquivalent((\"1010\"), (4L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static List<long> ReArrangeArray(List<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)-1L, (long)2L, (long)-3L, (long)4L, (long)5L, (long)6L, (long)-7L, (long)8L, (long)9L})), (9L)).Equals((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-7L, (long)4L, (long)5L, (long)6L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)12L, (long)-14L, (long)-26L, (long)13L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)-14L, (long)-26L, (long)12L, (long)13L, (long)15L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)10L, (long)24L, (long)36L, (long)-42L, (long)-39L, (long)-78L, (long)85L})), (7L)).Equals((new List<long>(new long[]{(long)-42L, (long)-39L, (long)-78L, (long)10L, (long)24L, (long)36L, (long)85L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether a list of numbers contains only one distinct element or not.\n    public static bool UniqueElement(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))) == (true));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static List<string> ExtractValues(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractValues((\"\"Python\", \"PHP\", \"Java\"\")).Equals((new List<string>(new string[]{(string)\"Python\", (string)\"PHP\", (string)\"Java\"}))));\n    Debug.Assert(ExtractValues((\"\"python\",\"program\",\"language\"\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\"}))));\n    Debug.Assert(ExtractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).Equals((new List<string>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\", (string)\"yellow\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count true booleans in the given list.\n    public static long Count(List<bool> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)false, (bool)true}))) == (2L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)false, (bool)false}))) == (0L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)true, (bool)true}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long FindEvenPair(List<long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L}))) == (4L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L}))) == (9L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static bool ArmstrongNumber(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ArmstrongNumber((153L)) == (true));\n    Debug.Assert(ArmstrongNumber((259L)) == (false));\n    Debug.Assert(ArmstrongNumber((4458L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the upper case characters in a given string.\n    public static long UpperCtr(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UpperCtr((\"PYthon\")) == (1L));\n    Debug.Assert(UpperCtr((\"BigData\")) == (1L));\n    Debug.Assert(UpperCtr((\"program\")) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Tuple<long, long, long, long> AndTuples(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AndTuples((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(0L, 0L, 2L, 1L))));\n    Debug.Assert(AndTuples((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(5L, 6L, 7L, 8L))).Equals((Tuple.Create(1L, 2L, 3L, 0L))));\n    Debug.Assert(AndTuples((Tuple.Create(8L, 9L, 11L, 12L)), (Tuple.Create(7L, 13L, 14L, 17L))).Equals((Tuple.Create(0L, 9L, 10L, 0L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns list.\n    public static bool IsSamepatterns(List<string> colors, List<string> patterns) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"green\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (true));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (false));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\"}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of lists in a given number of lists.\n    public static long CountList(List<List<long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))) == (4L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))) == (3L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)2L, (long)0L})}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static List<float> AverageTuple(List<List<long>> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)12L}), (List<long>)new List<long>(new long[]{(long)30L, (long)45L, (long)56L, (long)45L}), (List<long>)new List<long>(new long[]{(long)81L, (long)80L, (long)39L, (long)32L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))).Equals((new List<float>(new float[]{(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)30L, (long)-15L, (long)56L}), (List<long>)new List<long>(new long[]{(long)81L, (long)-60L, (long)-39L}), (List<long>)new List<long>(new long[]{(long)-10L, (long)2L, (long)3L})}))).Equals((new List<float>(new float[]{(float)25.5f, (float)-18.0f, (float)3.75f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)100L, (long)100L, (long)100L, (long)120L}), (List<long>)new List<long>(new long[]{(long)300L, (long)450L, (long)560L, (long)450L}), (List<long>)new List<long>(new long[]{(long)810L, (long)800L, (long)390L, (long)320L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new List<float>(new float[]{(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long LcsOfThree(string X, string Y, string Z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2L));\n    Debug.Assert(LcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5L));\n    Debug.Assert(LcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long FindStarNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindStarNum((3L)) == (37L));\n    Debug.Assert(FindStarNum((4L)) == (73L));\n    Debug.Assert(FindStarNum((5L)) == (121L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of a list.\n    public static long Sum(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)15L, (long)12L, (long)13L, (long)10L}))) == (50L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)0L, (long)1L, (long)2L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given list contains consecutive numbers or not.\n    public static bool CheckConsecutive(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Tuple<long, long, string> FindAdverbPosition(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbPosition((\"clearly!! we can see the sky\")).Equals((Tuple.Create(0L, 7L, \"clearly\"))));\n    Debug.Assert(FindAdverbPosition((\"seriously!! there are many roses\")).Equals((Tuple.Create(0L, 9L, \"seriously\"))));\n    Debug.Assert(FindAdverbPosition((\"unfortunately!! sita is going to home\")).Equals((Tuple.Create(0L, 13L, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/csthon-program-right-rotate-list-n/\n    public static List<long> RotateRight(List<long> list, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (3L)).Equals((new List<long>(new long[]{(long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of non-empty substrings of a given string.\n    public static long NumberOfSubstrings(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberOfSubstrings((\"abc\")) == (6L));\n    Debug.Assert(NumberOfSubstrings((\"abcd\")) == (10L));\n    Debug.Assert(NumberOfSubstrings((\"abcde\")) == (15L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static List<List<object>> ListSplit(List<object> S, long step) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"e\", (string)\"f\", (string)\"g\", (string)\"h\", (string)\"i\", (string)\"j\", (string)\"k\", (string)\"l\", (string)\"m\", (string)\"n\"})), (3L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"d\", (string)\"g\", (string)\"j\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"b\", (string)\"e\", (string)\"h\", (string)\"k\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"f\", (string)\"i\", (string)\"l\"})}))));\n    Debug.Assert(ListSplit((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L, (long)12L, (long)13L, (long)14L})), (3L)).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)10L, (long)13L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L, (long)8L, (long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)12L})}))));\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"python\", (string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\", (string)\"SQL\"})), (2L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"python\", (string)\"C\", (string)\"DBMS\"}), (List<string>)new List<string>(new string[]{(string)\"java\", (string)\"C++\", (string)\"SQL\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check if the elements of a given list are unique or not.\n    public static bool AllUnique(List<long> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert complex numbers to polar coordinates.\n    public static Tuple<float, float> Convert(long numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Convert((1L)).Equals((Tuple.Create(1.0f, 0.0f))));\n    Debug.Assert(Convert((4L)).Equals((Tuple.Create(4.0f, 0.0f))));\n    Debug.Assert(Convert((5L)).Equals((Tuple.Create(5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static Dictionary<string,Tuple<float, long>> FilterData(Dictionary<string,Tuple<float, long>> students, float h, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (6.0f), (70L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.9f), (67L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.7f), (64L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert the given string to lower case.\n    public static string IsLower(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsLower((\"InValid\")).Equals((\"invalid\")));\n    Debug.Assert(IsLower((\"TruE\")).Equals((\"true\")));\n    Debug.Assert(IsLower((\"SenTenCE\")).Equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the smallest power of 2 greater than or equal to n.\n    public static long NextPowerOf2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPowerOf2((0L)) == (1L));\n    Debug.Assert(NextPowerOf2((5L)) == (8L));\n    Debug.Assert(NextPowerOf2((17L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static bool FindSubstring(List<string> str1, string sub_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ack\")) == (true));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"abc\")) == (false));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static string ReplaceChar(string str1, string ch, string newch) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceChar((\"polygon\"), (\"y\"), (\"l\")).Equals((\"pollgon\")));\n    Debug.Assert(ReplaceChar((\"character\"), (\"c\"), (\"a\")).Equals((\"aharaater\")));\n    Debug.Assert(ReplaceChar((\"python\"), (\"l\"), (\"a\")).Equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long MulEvenOdd(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (4L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (10L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static object ListTuple(List<long> listx) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)5L, (long)10L, (long)7L, (long)4L, (long)15L, (long)3L}))).Equals(Tuple.Create(5L, 10L, 7L, 4L, 15L, 3L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)2L, (long)3L, (long)4L, (long)4L, (long)7L}))).Equals(Tuple.Create(2L, 4L, 5L, 6L, 2L, 3L, 4L, 4L, 7L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)58L, (long)44L, (long)56L}))).Equals(Tuple.Create(58L, 44L, 56L)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long EvenBinomialCoeffSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenBinomialCoeffSum((4L)) == (8L));\n    Debug.Assert(EvenBinomialCoeffSum((6L)) == (32L));\n    Debug.Assert(EvenBinomialCoeffSum((2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Tuple<long, long, long, long> BitwiseXor(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BitwiseXor((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(15L, 6L, 5L, 10L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(11L, 5L, 7L, 10L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(13L, 6L, 3L, 14L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(12L, 6L, 8L, 11L)), (Tuple.Create(7L, 4L, 5L, 6L))).Equals((Tuple.Create(11L, 2L, 13L, 13L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether a list is sublist of another or not.\n    public static bool IsSubArray(List<long> A, List<long> B) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)2L}))) == (false));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (true));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)2L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)0L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n    public static long MaxSubArraySumRepeated(List<long> a, long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)10L, (long)20L, (long)-30L, (long)-1L})), (4L), (3L)) == (30L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)10L, (long)20L})), (3L), (2L)) == (59L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})), (3L), (3L)) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long MinProductTuple(List<Tuple<long, long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (8L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (30L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (100L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the count of divisors is even. https://www.w3resource.com/csthon-exercises/basic/csthon-basic-1-exercise-24.php\n    public static bool CountDivisors(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDivisors((10L)) == (true));\n    Debug.Assert(CountDivisors((100L)) == (false));\n    Debug.Assert(CountDivisors((125L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Nullable<long> TriangleArea(long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((-1L)).Equals(null));\n    Debug.Assert(TriangleArea((0L)).Equals(0L));\n    Debug.Assert(TriangleArea((2L)).Equals(4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static List<string> StringToTuple(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToTuple((\"python 3.0\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\", (string)\"3\", (string)\".\", (string)\"0\"}))));\n    Debug.Assert(StringToTuple((\"item1\")).Equals((new List<string>(new string[]{(string)\"i\", (string)\"t\", (string)\"e\", (string)\"m\", (string)\"1\"}))));\n    Debug.Assert(StringToTuple((\"15.10\")).Equals((new List<string>(new string[]{(string)\"1\", (string)\"5\", (string)\".\", (string)\"1\", (string)\"0\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long FindLength(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLength((\"11000010001\")) == (6L));\n    Debug.Assert(FindLength((\"10111\")) == (1L));\n    Debug.Assert(FindLength((\"11011101100101\")) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long CountPrimesNums(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPrimesNums((5L)) == (2L));\n    Debug.Assert(CountPrimesNums((10L)) == (4L));\n    Debug.Assert(CountPrimesNums((100L)) == (25L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the product of consecutive binomial co-efficients.\n    public static long SumOfProduct(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfProduct((3L)) == (15L));\n    Debug.Assert(SumOfProduct((4L)) == (56L));\n    Debug.Assert(SumOfProduct((1L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Tuple<string, long> MaxAggregate(List<Tuple<string, long>> stdata) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 90L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 88L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 7L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 122L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 84L)}))).Equals((Tuple.Create(\"Juan Whelan\", 212L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 50L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 48L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 37L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 22L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 14L)}))).Equals((Tuple.Create(\"Juan Whelan\", 72L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 10L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 20L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 30L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 40L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 50L)}))).Equals((Tuple.Create(\"Sabah Colley\", 70L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> CombSort(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)5L, (long)15L, (long)37L, (long)25L, (long)79L}))).Equals((new List<long>(new long[]{(long)5L, (long)15L, (long)25L, (long)37L, (long)79L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)41L, (long)32L, (long)15L, (long)19L, (long)22L}))).Equals((new List<long>(new long[]{(long)15L, (long)19L, (long)22L, (long)32L, (long)41L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)99L, (long)15L, (long)13L, (long)47L}))).Equals((new List<long>(new long[]{(long)13L, (long)15L, (long)47L, (long)99L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static bool CheckExpression(string exp) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckExpression((\"{()}[{}]\")) == (true));\n    Debug.Assert(CheckExpression((\"{()}[{]\")) == (false));\n    Debug.Assert(CheckExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static bool TextMatchWordz(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordz((\"pythonz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"xyz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static List<long> SumList(List<long> lst1, List<long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumList((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)25L, (long)35L}))).Equals((new List<long>(new long[]{(long)25L, (long)45L, (long)65L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)5L, (long)6L, (long)7L}))).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)15L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)45L, (long)75L}))).Equals((new List<long>(new long[]{(long)30L, (long)65L, (long)105L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long NewmanPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewmanPrime((3L)) == (7L));\n    Debug.Assert(NewmanPrime((4L)) == (17L));\n    Debug.Assert(NewmanPrime((5L)) == (41L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static List<string> AddString(List<object> list_, string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddString((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (\"temp{0}\")).Equals((new List<string>(new string[]{(string)\"temp1\", (string)\"temp2\", (string)\"temp3\", (string)\"temp4\"}))));\n    Debug.Assert(AddString((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (\"python{0}\")).Equals((new List<string>(new string[]{(string)\"pythona\", (string)\"pythonb\", (string)\"pythonc\", (string)\"pythond\"}))));\n    Debug.Assert(AddString((new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})), (\"string{0}\")).Equals((new List<string>(new string[]{(string)\"string5\", (string)\"string6\", (string)\"string7\", (string)\"string8\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the surface area of a square csramid with a given base edge and height.\n    public static long SurfaceArea(long b, long s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceArea((3L), (4L)) == (33L));\n    Debug.Assert(SurfaceArea((4L), (5L)) == (56L));\n    Debug.Assert(SurfaceArea((1L), (2L)) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(List<List<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))) == (1L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))) == (2L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L})}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static bool Validate(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Validate((1234L)) == (true));\n    Debug.Assert(Validate((51241L)) == (false));\n    Debug.Assert(Validate((321L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long HexagonalNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexagonalNum((10L)) == (190L));\n    Debug.Assert(HexagonalNum((5L)) == (45L));\n    Debug.Assert(HexagonalNum((7L)) == (91L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long FindLucas(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLucas((9L)) == (76L));\n    Debug.Assert(FindLucas((4L)) == (7L));\n    Debug.Assert(FindLucas((3L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to get the difference between two lists.\n    public static List<long> Diff(List<long> li1, List<long> li2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Diff((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L, (long)30L, (long)35L, (long)40L})), (new List<long>(new long[]{(long)25L, (long)40L, (long)35L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)15L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static List<object> ExtractQuotation(string text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).Equals((new List<object>(new string[]{(string)\"A53\", (string)\"multi\", (string)\"Processor\"}))));\n    Debug.Assert(ExtractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).Equals((new List<object>(new string[]{(string)\"favorite\", (string)\"apps\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).Equals((new List<object>(new string[]{(string)\"4k Ultra HD\", (string)\"HDR 10\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the two numbers differ at one bit position only or not.\n    public static bool DifferAtOneBitPos(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifferAtOneBitPos((13L), (9L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((15L), (8L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (4L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (3L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((5L), (1L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((1L), (5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static bool TextMatchThree(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchThree((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n    public static long MaxProduct(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)3L, (long)100L, (long)4L, (long)5L, (long)150L, (long)6L}))) == (3000L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)4L, (long)42L, (long)55L, (long)68L, (long)80L}))) == (50265600L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)10L, (long)22L, (long)9L, (long)33L, (long)21L, (long)50L, (long)41L, (long)60L}))) == (2460L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to split a list at the nth eelment and add the first part to the end.\n    public static List<long> SplitArr(List<long> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)12L, (long)10L, (long)5L, (long)6L, (long)52L, (long)36L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)52L, (long)36L, (long)12L, (long)10L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (1L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (3L)).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)0L, (long)1L, (long)2L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the number of divisors of a given integer.\n    public static long Divisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Divisor((15L)) == (4L));\n    Debug.Assert(Divisor((12L)) == (6L));\n    Debug.Assert(Divisor((9L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the difference between largest and smallest value in a given list.\n    public static long BigDiff(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)4L, (long)5L, (long)12L}))) == (8L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)9L, (long)2L, (long)3L}))) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static List<long> SquareNums(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)100L, (long)400L, (long)900L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)144L, (long)225L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static bool CheckNone(object test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckNone(Tuple.Create(10L, 4L, 5L, 6L, (Nullable<long>)null)) == (true));\n    Debug.Assert(CheckNone(Tuple.Create(7L, 8L, 9L, 11L, 14L)) == (false));\n    Debug.Assert(CheckNone(Tuple.Create(1L, 2L, 3L, 4L, (Nullable<long>)null)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given list is monotonic or not.\n    public static bool IsMonotonic(List<long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static bool IsPerfectSquare(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPerfectSquare((10L)) == (false));\n    Debug.Assert(IsPerfectSquare((36L)) == (true));\n    Debug.Assert(IsPerfectSquare((14L)) == (false));\n    Debug.Assert(IsPerfectSquare((196L)) == (true));\n    Debug.Assert(IsPerfectSquare((125L)) == (false));\n    Debug.Assert(IsPerfectSquare((15625L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of common divisors of two given numbers.\n    public static long Sum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((10L), (15L)) == (6L));\n    Debug.Assert(Sum((100L), (150L)) == (93L));\n    Debug.Assert(Sum((4L), (6L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Tuple<long, List<long>> MaxLength(List<List<long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)15L, (long)20L, (long)25L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)15L, (long)20L, (long)25L})))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static Dictionary<Tuple<long, long>,long> CheckOccurences(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(5L, 2L), (Tuple<long, long>)Tuple.Create(6L, 3L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(1L, 3L), 2L}, {Tuple.Create(2L, 5L), 2L}, {Tuple.Create(3L, 6L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 2L), (Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(3L, 6L), (Tuple<long, long>)Tuple.Create(6L, 3L), (Tuple<long, long>)Tuple.Create(7L, 4L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 4L), 2L}, {Tuple.Create(3L, 6L), 2L}, {Tuple.Create(4L, 7L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(13L, 2L), (Tuple<long, long>)Tuple.Create(11L, 23L), (Tuple<long, long>)Tuple.Create(12L, 25L), (Tuple<long, long>)Tuple.Create(25L, 12L), (Tuple<long, long>)Tuple.Create(16L, 23L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 13L), 1L}, {Tuple.Create(11L, 23L), 1L}, {Tuple.Create(12L, 25L), 2L}, {Tuple.Create(16L, 23L), 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long ParabolaDirectrix(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParabolaDirectrix((5L), (3L), (2L)) == (-198L));\n    Debug.Assert(ParabolaDirectrix((9L), (8L), (4L)) == (-2336L));\n    Debug.Assert(ParabolaDirectrix((2L), (4L), (6L)) == (-130L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n    public static Tuple<string, long, long> OccuranceSubstring(string text, string pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OccuranceSubstring((\"python programming, python language\"), (\"python\")).Equals((Tuple.Create(\"python\", 0L, 6L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"programming\")).Equals((Tuple.Create(\"programming\", 7L, 18L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"language\")).Equals((Tuple.Create(\"language\", 31L, 39L))));\n    Debug.Assert(OccuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).Equals(null));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Tuple<long, long, long, long> RemoveNested(object test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveNested(Tuple.Create(1L, 5L, 7L, Tuple.Create(4L, 6L), 10L)).Equals((Tuple.Create(1L, 5L, 7L, 10L))));\n    Debug.Assert(RemoveNested(Tuple.Create(2L, 6L, 8L, Tuple.Create(5L, 7L), 11L)).Equals((Tuple.Create(2L, 6L, 8L, 11L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), Tuple.Create(5L, 12L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\"blue \", (string)\" black\"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\" black\", (string)\"blue \"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"zilver\", (string)\"gold\"}), (List<string>)new List<string>(new string[]{(string)\"magnesium\", (string)\"aluminium\"}), (List<string>)new List<string>(new string[]{(string)\"steel\", (string)\"bronze\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"gold\", (string)\"zilver\"}), (List<string>)new List<string>(new string[]{(string)\"aluminium\", (string)\"magnesium\"}), (List<string>)new List<string>(new string[]{(string)\"bronze\", (string)\"steel\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static List<long> RemoveKthElement(List<long> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Tuple<long, long, long, Dictionary<string,long>> AddDictToTuple(Tuple<long, long, long> test_tup, Dictionary<string,long> test_dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddDictToTuple((Tuple.Create(4L, 5L, 6L)), (new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}})).Equals((Tuple.Create(4L, 5L, 6L, new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(1L, 2L, 3L)), (new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}})).Equals((Tuple.Create(1L, 2L, 3L, new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(8L, 9L, 10L)), (new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}})).Equals((Tuple.Create(8L, 9L, 10L, new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long Find(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Find((10L), (3L)) == (3L));\n    Debug.Assert(Find((4L), (2L)) == (2L));\n    Debug.Assert(Find((20L), (5L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static bool TextMatchTwoThree(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchTwoThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the occurence of all elements of list in a tuple.\n    public static long CountOccurrence(object tup, List<object> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurrence(Tuple.Create(\"a\", \"a\", \"c\", \"b\", \"d\"), (new List<object>(new string[]{(string)\"a\", (string)\"b\"}))) == (3L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 1L, 4L, 6L, 7L, 1L, 4L), (new List<object>(new long[]{(long)1L, (long)4L, (long)7L}))) == (6L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L), (new List<object>(new long[]{(long)1L, (long)2L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long CountSamepair(List<long> list1, List<long> list2, List<long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (3L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (4L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static bool TextMatchOne(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long Difference(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Difference((3L)) == (30L));\n    Debug.Assert(Difference((5L)) == (210L));\n    Debug.Assert(Difference((2L)) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static string ToggleString(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleString((\"Python\")).Equals((\"pYTHON\")));\n    Debug.Assert(ToggleString((\"Pangram\")).Equals((\"pANGRAM\")));\n    Debug.Assert(ToggleString((\"LIttLE\")).Equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the element of a list having maximum length.\n    public static List<object> FindMax(List<List<object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"})}))).Equals((new List<object>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L})}))).Equals((new List<object>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long EulerianNum(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EulerianNum((3L), (1L)) == (4L));\n    Debug.Assert(EulerianNum((4L), (1L)) == (11L));\n    Debug.Assert(EulerianNum((5L), (3L)) == (26L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long Frequency(List<long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L)) == (0L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L})), (3L)) == (3L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)1L, (long)2L})), (1L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/csthon-sort-numeric-strings-in-a-list/\n    public static List<long> SortNumericStrings(List<string> nums_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"4\", (string)\"12\", (string)\"45\", (string)\"7\", (string)\"0\", (string)\"100\", (string)\"200\", (string)\"-12\", (string)\"-500\"}))).Equals((new List<long>(new long[]{(long)-500L, (long)-12L, (long)0L, (long)4L, (long)7L, (long)12L, (long)45L, (long)100L, (long)200L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"2\", (string)\"3\", (string)\"8\", (string)\"4\", (string)\"7\", (string)\"9\", (string)\"8\", (string)\"2\", (string)\"6\", (string)\"5\", (string)\"1\", (string)\"6\", (string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"6\", (string)\"9\", (string)\"1\", (string)\"2\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)8L, (long)9L, (long)9L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"1\", (string)\"3\", (string)\"5\", (string)\"7\", (string)\"1\", (string)\"3\", (string)\"13\", (string)\"15\", (string)\"17\", (string)\"5\", (string)\"7 \", (string)\"9\", (string)\"1\", (string)\"11\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)3L, (long)3L, (long)5L, (long)5L, (long)7L, (long)7L, (long)9L, (long)11L, (long)13L, (long)15L, (long)17L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/csthon-exercises/data-structures-and-algorithms/csthon-recursion-exercise-9.php\n    public static float GeometricSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GeometricSum((7L)) == (1.9921875f));\n    Debug.Assert(GeometricSum((4L)) == (1.9375f));\n    Debug.Assert(GeometricSum((8L)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/csthon-exercises/lambda/csthon-lambda-exercise-24.php\n    public static List<long> DivisibleByDigits(long startnum, long endnum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisibleByDigits((1L), (22L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L, (long)22L}))));\n    Debug.Assert(DivisibleByDigits((1L), (15L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L}))));\n    Debug.Assert(DivisibleByDigits((20L), (25L)).Equals((new List<long>(new long[]{(long)22L, (long)24L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to calculate the product of the unique numbers in a given list.\n    public static long UniqueProduct(List<long> list_data) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)20L, (long)50L, (long)60L, (long)40L}))) == (720000000L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L}))) == (6L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)0L, (long)1L, (long)1L}))) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the largest negative number from the given list.\n    public static long LargestNeg(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-4L, (long)-6L}))) == (-6L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-8L, (long)-9L}))) == (-9L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static List<object> ConsecutiveDuplicates(List<object> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<object>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<object>(new long[]{(long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\", (string)\"a\", (string)\"a\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"a\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float MinJumps(Tuple<long, long> steps, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (11L)) == (3.5f));\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (0L)) == (float)0L);\n    Debug.Assert(MinJumps((Tuple.Create(11L, 14L)), (11L)) == (float)1L);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find a pair with highest product from a given list of integers.\n    public static Tuple<long, long> MaxProduct(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)0L, (long)8L, (long)4L}))).Equals((Tuple.Create(7L, 8L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)0L, (long)-1L, (long)-2L, (long)-4L, (long)5L, (long)0L, (long)-6L}))).Equals((Tuple.Create(-4L, -6L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((Tuple.Create(2L, 3L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static List<object> ExtractNthElement(List<Tuple<string, long, long>> list1, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (0L)).Equals((new List<object>(new string[]{(string)\"Greyson Fulton\", (string)\"Brady Kent\", (string)\"Wyatt Knott\", (string)\"Beau Turnbull\"}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (2L)).Equals((new List<object>(new long[]{(long)99L, (long)96L, (long)94L, (long)98L}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (1L)).Equals((new List<object>(new long[]{(long)98L, (long)97L, (long)91L, (long)94L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long IsNonagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNonagonal((10L)) == (325L));\n    Debug.Assert(IsNonagonal((15L)) == (750L));\n    Debug.Assert(IsNonagonal((18L)) == (1089L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the maximum difference between any two elements in a given list.\n    public static long MaxAbsDiff(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)3L}))) == (4L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)9L, (long)3L, (long)2L, (long)5L, (long)1L}))) == (8L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static List<List<object>> PackConsecutiveDuplicates(List<object> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)8L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L}), (List<long>)new List<long>(new long[]{(long)15L}), (List<long>)new List<long>(new long[]{(long)19L}), (List<long>)new List<long>(new long[]{(long)18L, (long)18L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)26L, (long)26L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)18L}), (List<long>)new List<long>(new long[]{(long)10L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"a\"}), (List<string>)new List<string>(new string[]{(string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"d\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long CalSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CalSum((9L)) == (49L));\n    Debug.Assert(CalSum((10L)) == (66L));\n    Debug.Assert(CalSum((11L)) == (88L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove the characters which have odd index values of a given string.\n    public static string OddValuesString(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddValuesString((\"abcdef\")).Equals((\"ace\")));\n    Debug.Assert(OddValuesString((\"python\")).Equals((\"pto\")));\n    Debug.Assert(OddValuesString((\"data\")).Equals((\"dt\")));\n    Debug.Assert(OddValuesString((\"lambs\")).Equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find kth element from the given two sorted lists.\n    public static long FindKth(List<long> arr1, List<long> arr2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)8L, (long)10L})), (5L)) == (6L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)100L, (long)112L, (long)256L, (long)349L, (long)770L})), (new List<long>(new long[]{(long)72L, (long)86L, (long)113L, (long)119L, (long)265L, (long)445L, (long)892L})), (7L)) == (256L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)3L, (long)4L, (long)7L, (long)8L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)9L, (long)11L})), (6L)) == (8L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long JacobsthalNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(JacobsthalNum((5L)) == (11L));\n    Debug.Assert(JacobsthalNum((2L)) == (1L));\n    Debug.Assert(JacobsthalNum((4L)) == (5L));\n    Debug.Assert(JacobsthalNum((13L)) == (2731L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static Dictionary<long,long> FrequencyLists(List<List<long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)2L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)5L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 3L}, {3L, 1L}, {4L, 1L}, {5L, 2L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 1L}, {3L, 1L}, {4L, 1L}, {5L, 1L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}, {10L, 1L}, {11L, 1L}, {12L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)20L, (long)30L, (long)40L, (long)17L}), (List<long>)new List<long>(new long[]{(long)18L, (long)16L, (long)14L, (long)13L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new Dictionary<long,long>(){{20L, 2L}, {30L, 2L}, {40L, 2L}, {17L, 1L}, {18L, 1L}, {16L, 1L}, {14L, 1L}, {13L, 1L}, {10L, 1L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static List<long> PerfectSquares(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerfectSquares((1L), (30L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L}))));\n    Debug.Assert(PerfectSquares((50L), (100L)).Equals((new List<long>(new long[]{(long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(PerfectSquares((100L), (200L)).Equals((new List<long>(new long[]{(long)100L, (long)121L, (long)144L, (long)169L, (long)196L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n    public static long SumOfSubarrayProd(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (20L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L}))) == (5L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (84L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first odd number in a given list of numbers.\n    public static long FirstOdd(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)8L, (long)9L, (long)1L}))) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static List<List<long>> AddNestedTuples(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)10L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)13L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)12L}), (List<long>)new List<long>(new long[]{(long)9L, (long)16L}), (List<long>)new List<long>(new long[]{(long)5L, (long)12L}), (List<long>)new List<long>(new long[]{(long)10L, (long)15L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)11L, (long)18L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)12L, (long)17L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static List<List<object>> Merge(List<List<object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L})}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\", (string)\"o\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"z\", (string)\"c\", (string)\"o\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number can be represented as the difference of two squares or not.\n    public static bool DifSquare(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifSquare((5L)) == (true));\n    Debug.Assert(DifSquare((10L)) == (false));\n    Debug.Assert(DifSquare((15L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static bool CheckSmaller(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckSmaller((Tuple.Create(1L, 2L, 3L)), (Tuple.Create(2L, 3L, 4L))) == (false));\n    Debug.Assert(CheckSmaller((Tuple.Create(4L, 5L, 6L)), (Tuple.Create(3L, 4L, 5L))) == (true));\n    Debug.Assert(CheckSmaller((Tuple.Create(11L, 12L, 13L)), (Tuple.Create(10L, 11L, 12L))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static Dictionary<long,long> FreqCount(List<long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)10L, (long)20L, (long)20L, (long)20L, (long)20L, (long)40L, (long)40L, (long)50L, (long)50L, (long)30L}))).Equals((new Dictionary<long,long>(){{10L, 4L}, {20L, 4L}, {40L, 2L}, {50L, 2L}, {30L, 1L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)4L, (long)1L, (long)3L, (long)1L, (long)4L}))).Equals((new Dictionary<long,long>(){{1L, 3L}, {2L, 2L}, {3L, 3L}, {4L, 3L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)4L, (long)9L, (long)10L, (long)4L, (long)5L, (long)6L, (long)7L, (long)9L, (long)5L}))).Equals((new Dictionary<long,long>(){{10L, 1L}, {5L, 3L}, {6L, 2L}, {7L, 2L}, {4L, 2L}, {9L, 2L}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static List<float> RgbToHsv(long r, long g, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RgbToHsv((255L), (255L), (255L)).Equals((new List<float>(new float[]{(float)0.0f, (float)0.0f, (float)100.0f}))));\n    Debug.Assert(RgbToHsv((0L), (215L), (0L)).Equals((new List<float>(new float[]{(float)120.0f, (float)100.0f, (float)84.31372549019608f}))));\n    Debug.Assert(RgbToHsv((10L), (215L), (110L)).Equals((new List<float>(new float[]{(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static bool CheckStr(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckStr((\"annie\")) == (true));\n    Debug.Assert(CheckStr((\"dawood\")) == (false));\n    Debug.Assert(CheckStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static bool CheckMonthnumberNumber(long monthnum3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumberNumber((6L)) == (true));\n    Debug.Assert(CheckMonthnumberNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumberNumber((12L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list.\n    public static List<long> HeapSort(List<long> iterable) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L}))).Equals((new List<long>(new long[]{(long)14L, (long)22L, (long)25L, (long)25L, (long)35L, (long)58L, (long)65L, (long)75L, (long)85L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)7L, (long)1L, (long)9L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n    public static List<List<long>> KSmallestPairs(List<long> nums1, List<long> nums2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (7L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)2L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return null if no solution exists.\n    public static Tuple<long, long> FindSolution(long a, long b, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSolution((2L), (3L), (7L)).Equals((Tuple.Create(2L, 1L))));\n    Debug.Assert(FindSolution((4L), (2L), (7L)).Equals(null));\n    Debug.Assert(FindSolution((1L), (13L), (17L)).Equals((Tuple.Create(4L, 1L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the largest number that can be formed with the given list of digits.\n    public static long FindMaxNum(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (321L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)1L}))) == (6541L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)9L}))) == (9321L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static List<long> MaxSumList(List<List<long>> lists) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)10L, (long)11L, (long)12L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)12L, (long)11L, (long)10L})}))).Equals((new List<long>(new long[]{(long)12L, (long)11L, (long)10L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)1L})}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to interchange the first and last elements in a list.\n    public static List<long> SwapList(List<long> newList) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)12L, (long)35L, (long)9L, (long)56L, (long)24L}))).Equals((new List<long>(new long[]{(long)24L, (long)35L, (long)9L, (long)56L, (long)12L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float GetMedian(List<long> arr1, List<long> arr2, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)1L, (long)12L, (long)15L, (long)26L, (long)38L})), (new List<long>(new long[]{(long)2L, (long)13L, (long)17L, (long)30L, (long)45L})), (5L)) == (16.0f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)7L, (long)13L, (long)19L, (long)28L})), (4L)) == (8.5f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)3L, (long)6L, (long)14L, (long)23L, (long)36L, (long)42L})), (new List<long>(new long[]{(long)2L, (long)18L, (long)27L, (long)39L, (long)49L, (long)55L})), (6L)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static string ReplaceSpaces(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"Jumanji The Jungle\")).Equals((\"Jumanji_The_Jungle\")));\n    Debug.Assert(ReplaceSpaces((\"The_Avengers\")).Equals((\"The Avengers\")));\n    Debug.Assert(ReplaceSpaces((\"Fast and Furious\")).Equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static bool AreEquivalent(long num1, long num2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreEquivalent((36L), (57L)) == (false));\n    Debug.Assert(AreEquivalent((2L), (4L)) == (false));\n    Debug.Assert(AreEquivalent((23L), (47L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static List<string> ReverseStringList(List<string> stringlist) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\", (string)\"White\", (string)\"Black\"}))).Equals((new List<string>(new string[]{(string)\"deR\", (string)\"neerG\", (string)\"eulB\", (string)\"etihW\", (string)\"kcalB\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"john\", (string)\"amal\", (string)\"joel\", (string)\"george\"}))).Equals((new List<string>(new string[]{(string)\"nhoj\", (string)\"lama\", (string)\"leoj\", (string)\"egroeg\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"jack\", (string)\"john\", (string)\"mary\"}))).Equals((new List<string>(new string[]{(string)\"kcaj\", (string)\"nhoj\", (string)\"yram\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long SumOfDigits(List<object> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)2L, (long)56L}))) == (14L));\n    Debug.Assert(SumOfDigits((new List<object>(new List<long>[]{(List<long>)new List<object>(new object[]{10L, 20L, 4L, 5L, \"b\", 70L, \"a\"})}))) == (19L));\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)20L, (long)-4L, (long)5L, (long)-70L}))) == (19L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long Sequence(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sequence((10L)) == (6L));\n    Debug.Assert(Sequence((2L)) == (1L));\n    Debug.Assert(Sequence((3L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static List<long> HeapQueueLargest(List<long> nums, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (3L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (2L)).Equals((new List<long>(new long[]{(long)85L, (long)75L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (5L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L, (long)58L, (long)35L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long LossAmount(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LossAmount((1500L), (1200L)) == (0L));\n    Debug.Assert(LossAmount((100L), (200L)) == (100L));\n    Debug.Assert(LossAmount((2000L), (5000L)) == (3000L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static List<long> UnionElements(List<long> test_tup1, List<long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)4L, (long)10L}))).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)10L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L})), (new List<long>(new long[]{(long)13L, (long)15L, (long)16L, (long)17L}))).Equals((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L, (long)15L, (long)16L, (long)17L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the longest sublists.\n    public static long FindMaxLength(List<List<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (4L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L})}))) == (3L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)22L, (long)23L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L})}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static string RemoveParenthesis(List<string> items) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"python (chrome)\"}))).Equals((\"python\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"string(.abc)\"}))).Equals((\"string\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"alpha(num)\"}))).Equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find whether the parity of a given number is odd.\n    public static bool FindParity(long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindParity((12L)) == (false));\n    Debug.Assert(FindParity((7L)) == (true));\n    Debug.Assert(FindParity((10L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float MedianTrapezium(long base1, long base2, long height) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianTrapezium((15L), (25L), (35L)) == (float)20L);\n    Debug.Assert(MedianTrapezium((10L), (20L), (30L)) == (float)15L);\n    Debug.Assert(MedianTrapezium((6L), (9L), (4L)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long CenteredHexagonalNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CenteredHexagonalNumber((10L)) == (271L));\n    Debug.Assert(CenteredHexagonalNumber((2L)) == (7L));\n    Debug.Assert(CenteredHexagonalNumber((9L)) == (217L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long FindLists(List<object> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (2L));\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))) == (3L));\n    Debug.Assert(FindLists((new List<object>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long GetMaxSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxSum((60L)) == (106L));\n    Debug.Assert(GetMaxSum((10L)) == (12L));\n    Debug.Assert(GetMaxSum((2L)) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the longest word.\n    public static long LenLog(List<string> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"python\", (string)\"PHP\", (string)\"bigdata\"}))) == (7L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))) == (3L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"small\", (string)\"big\", (string)\"tall\"}))) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n    public static Nullable<float> SectorArea(long r, long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SectorArea((4L), (45L)).Equals(6.283185307179586f));\n    Debug.Assert(SectorArea((9L), (45L)).Equals(31.808625617596654f));\n    Debug.Assert(SectorArea((9L), (361L)).Equals(null));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether every odd index contains odd numbers of a given list.\n    public static bool OddPosition(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L, (long)6L, (long)7L, (long)6L, (long)3L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)4L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long MultipleToSingle(List<long> L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)11L, (long)33L, (long)50L}))) == (113350L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (-123456L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L}))) == (10152025L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find whether a number is divisible by 11.\n    public static bool IsDiff(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDiff((12345L)) == (false));\n    Debug.Assert(IsDiff((1212112L)) == (true));\n    Debug.Assert(IsDiff((1212L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static List<List<long>> IndexMultiplication(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)21L}), (List<long>)new List<long>(new long[]{(long)12L, (long)45L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)30L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)14L, (long)32L}), (List<long>)new List<long>(new long[]{(long)20L, (long)60L}), (List<long>)new List<long>(new long[]{(long)6L, (long)20L}), (List<long>)new List<long>(new long[]{(long)16L, (long)44L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)24L, (long)45L}), (List<long>)new List<long>(new long[]{(long)30L, (long)77L}), (List<long>)new List<long>(new long[]{(long)12L, (long)33L}), (List<long>)new List<long>(new long[]{(long)27L, (long)60L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Tuple<long, long, long> TupleStrInt(string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleStrInt((\"(7, 8, 9)\")).Equals((Tuple.Create(7L, 8L, 9L))));\n    Debug.Assert(TupleStrInt((\"(1, 2, 3)\")).Equals((Tuple.Create(1L, 2L, 3L))));\n    Debug.Assert(TupleStrInt((\"(4, 5, 6)\")).Equals((Tuple.Create(4L, 5L, 6L))));\n    Debug.Assert(TupleStrInt((\"(7, 81, 19)\")).Equals((Tuple.Create(7L, 81L, 19L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long AmicableNumbersSum(long limit) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AmicableNumbersSum((999L)) == (504L));\n    Debug.Assert(AmicableNumbersSum((9999L)) == (31626L));\n    Debug.Assert(AmicableNumbersSum((99L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static string RemoveOdd(string str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((\"python\")).Equals((\"yhn\")));\n    Debug.Assert(RemoveOdd((\"program\")).Equals((\"rga\")));\n    Debug.Assert(RemoveOdd((\"language\")).Equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static List<object> MultiplyElements(List<long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)8L, (long)10L}))).Equals((new List<object>(new long[]{(long)5L, (long)35L, (long)56L, (long)80L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)8L, (long)20L, (long)30L, (long)42L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L, (long)13L, (long)14L, (long)9L, (long)15L}))).Equals((new List<object>(new long[]{(long)156L, (long)182L, (long)126L, (long)135L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L}))).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n    public static long CountRotation(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)4L, (long)5L, (long)1L, (long)2L, (long)3L}))) == (2L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (0L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (2L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long ExtractFreq(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(5L, 6L)}))) == (3L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 15L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L)}))) == (4L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 16L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 9L)}))) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long CountSamePair(List<long> nums1, List<long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (4L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (11L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (1L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)2L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)2L}))) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long Power(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Power((3L), (4L)) == (81L));\n    Debug.Assert(Power((2L), (3L)) == (8L));\n    Debug.Assert(Power((5L), (5L)) == (3125L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long ReturnSum(Dictionary<string,long> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 100L}, {\"b\", 200L}, {\"c\", 300L}})) == (600L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 25L}, {\"b\", 18L}, {\"c\", 45L}})) == (88L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 36L}, {\"b\", 39L}, {\"c\", 49L}})) == (124L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static List<Tuple<long, long>> PairWise(List<long> l1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 5L), (Tuple<long, long>)Tuple.Create(5L, 7L), (Tuple<long, long>)Tuple.Create(7L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)5L, (long)1L, (long)9L, (long)7L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(1L, 9L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(7L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L), (Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to split a string into characters.\n    public static List<string> Split(string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((\"python\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))));\n    Debug.Assert(Split((\"Name\")).Equals((new List<string>(new string[]{(string)\"N\", (string)\"a\", (string)\"m\", (string)\"e\"}))));\n    Debug.Assert(Split((\"program\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long MinOfThree(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinOfThree((10L), (20L), (0L)) == (0L));\n    Debug.Assert(MinOfThree((19L), (15L), (18L)) == (15L));\n    Debug.Assert(MinOfThree((-10L), (-20L), (-30L)) == (-30L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static bool IsSumOfPowersOfTwo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSumOfPowersOfTwo((10L)) == (true));\n    Debug.Assert(IsSumOfPowersOfTwo((7L)) == (false));\n    Debug.Assert(IsSumOfPowersOfTwo((14L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static string GetChar(string strr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetChar((\"abc\")).Equals((\"f\")));\n    Debug.Assert(GetChar((\"gfg\")).Equals((\"t\")));\n    Debug.Assert(GetChar((\"ab\")).Equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long SumDiv(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDiv((8L)) == (7L));\n    Debug.Assert(SumDiv((12L)) == (16L));\n    Debug.Assert(SumDiv((7L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove duplicate numbers from a given number of lists.\n    public static List<long> TwoUniqueNums(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether a given list of integers contains any duplicate element.\n    public static bool TestDuplicate(List<long> arraynums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long CatalanNumber(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CatalanNumber((10L)) == (16796L));\n    Debug.Assert(CatalanNumber((9L)) == (4862L));\n    Debug.Assert(CatalanNumber((7L)) == (429L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long PowerBaseSum(long numBase, long power) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PowerBaseSum((2L), (100L)) == (115L));\n    Debug.Assert(PowerBaseSum((8L), (10L)) == (37L));\n    Debug.Assert(PowerBaseSum((8L), (15L)) == (62L));\n    Debug.Assert(PowerBaseSum((3L), (3L)) == (9L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static List<object> ReplaceList(List<object> list1, List<object> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L})), (new List<object>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\"})), (new List<object>(new string[]{(string)\"yellow\"}))).Equals((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"yellow\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long IsOctagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsOctagonal((5L)) == (65L));\n    Debug.Assert(IsOctagonal((10L)) == (280L));\n    Debug.Assert(IsOctagonal((15L)) == (645L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static string ReplaceBlank(string str1, string char) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceBlank((\"hello people\"), (\"@\")).Equals((\"hello@people\")));\n    Debug.Assert(ReplaceBlank((\"python program language\"), (\"$\")).Equals((\"python$program$language\")));\n    Debug.Assert(ReplaceBlank((\"blank space\"), (\"-\")).Equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static string ReplaceSpecialchar(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpecialchar((\"Python language, Programming language.\")).Equals((\"Python:language::Programming:language:\")));\n    Debug.Assert(ReplaceSpecialchar((\"a b c,d e f\")).Equals((\"a:b:c:d:e:f\")));\n    Debug.Assert(ReplaceSpecialchar((\"ram reshma,ram rahim\")).Equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long TupleToInt(Tuple<long, long, long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToInt((Tuple.Create(1L, 2L, 3L))) == (123L));\n    Debug.Assert(TupleToInt((Tuple.Create(4L, 5L, 6L))) == (456L));\n    Debug.Assert(TupleToInt((Tuple.Create(5L, 6L, 7L))) == (567L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float OthersideRightangle(long w, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OthersideRightangle((7L), (8L)) == (10.63014581273465f));\n    Debug.Assert(OthersideRightangle((3L), (4L)) == (float)5L);\n    Debug.Assert(OthersideRightangle((7L), (15L)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the per-digit difference between two integers.\n    public static long DigitDistanceNums(long n1, long n2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DigitDistanceNums((1L), (2L)) == (1L));\n    Debug.Assert(DigitDistanceNums((23L), (56L)) == (6L));\n    Debug.Assert(DigitDistanceNums((123L), (256L)) == (7L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static bool TextMatchWordzMiddle(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    Debug.Assert(TextMatchWordzMiddle((\"zxyabc.\")) == (false));\n    Debug.Assert(TextMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static string RemovezeroIp(string ip) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemovezeroIp((\"216.08.094.196\")).Equals((\"216.8.94.196\")));\n    Debug.Assert(RemovezeroIp((\"12.01.024\")).Equals((\"12.1.24\")));\n    Debug.Assert(RemovezeroIp((\"216.08.094.0196\")).Equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long CountElementInList(List<List<object>> list1, object x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)11L}), (List<long>)new List<long>(new long[]{(long)1L, (long)15L, (long)7L})})), (object(1L))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"A\"))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"E\"))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long MultiplyInt(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyInt((10L), (20L)) == (200L));\n    Debug.Assert(MultiplyInt((5L), (10L)) == (50L));\n    Debug.Assert(MultiplyInt((4L), (8L)) == (32L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Tuple<long, long, long, long> AddPairwise(Tuple<long, long, long, long, long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddPairwise((Tuple.Create(1L, 5L, 7L, 8L, 10L))).Equals((Tuple.Create(6L, 12L, 15L, 18L))));\n    Debug.Assert(AddPairwise((Tuple.Create(2L, 6L, 8L, 9L, 11L))).Equals((Tuple.Create(8L, 14L, 17L, 20L))));\n    Debug.Assert(AddPairwise((Tuple.Create(3L, 7L, 9L, 10L, 12L))).Equals((Tuple.Create(10L, 16L, 19L, 22L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long MaxProductTuple(List<Tuple<long, long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (36L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (200L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (484L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3448,7 +16,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the kth element in the given list using 1-based indexing.\n    public static long KthElement(List<long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)12L, (long)3L, (long)5L, (long)7L, (long)19L})), (2L)) == (3L));\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)17L, (long)24L, (long)8L, (long)23L})), (3L)) == (8L));\n    Debug.Assert(KthElement((new List<long>(new long[]{(long)16L, (long)21L, (long)25L, (long)36L, (long)4L})), (4L)) == (36L));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3456,265 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to interchange the first and last element in a given list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))).Equals((new List<long>(new long[]{(long)4L, (long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"python_program\")).Equals((\"PythonProgram\")));\n    Debug.Assert(SnakeToCamel((\"python_language\")).Equals((\"PythonLanguage\")));\n    Debug.Assert(SnakeToCamel((\"programming_language\")).Equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long RightInsertion(List<long> a, long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long EulerianNum(long n, long m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EulerianNum((3L), (1L)) == (4L));\n    Debug.Assert(EulerianNum((4L), (1L)) == (11L));\n    Debug.Assert(EulerianNum((5L), (3L)) == (26L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static bool IsWoodall(long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> input_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsWoodall((383L)) == (true));\n    Debug.Assert(IsWoodall((254L)) == (false));\n    Debug.Assert(IsWoodall((200L)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\"blue \", (string)\" black\"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\" red \", (string)\"green\"}), (List<string>)new List<string>(new string[]{(string)\" black\", (string)\"blue \"}), (List<string>)new List<string>(new string[]{(string)\" orange\", (string)\"brown\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"zilver\", (string)\"gold\"}), (List<string>)new List<string>(new string[]{(string)\"magnesium\", (string)\"aluminium\"}), (List<string>)new List<string>(new string[]{(string)\"steel\", (string)\"bronze\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"gold\", (string)\"zilver\"}), (List<string>)new List<string>(new string[]{(string)\"aluminium\", (string)\"magnesium\"}), (List<string>)new List<string>(new string[]{(string)\"bronze\", (string)\"steel\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list by using shell sort.\n    public static List<long> ShellSort(List<long> my_list) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count true booleans in the given list.\n    public static long Count(List<bool> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)12L, (long)23L, (long)4L, (long)5L, (long)3L, (long)2L, (long)12L, (long)81L, (long)56L, (long)95L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)12L, (long)12L, (long)23L, (long)56L, (long)81L, (long)95L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)24L, (long)22L, (long)39L, (long)34L, (long)87L, (long)73L, (long)68L}))).Equals((new List<long>(new long[]{(long)22L, (long)24L, (long)34L, (long)39L, (long)68L, (long)73L, (long)87L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)32L, (long)30L, (long)16L, (long)96L, (long)82L, (long)83L, (long)74L}))).Equals((new List<long>(new long[]{(long)16L, (long)30L, (long)32L, (long)74L, (long)82L, (long)83L, (long)96L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)false, (bool)true}))) == (2L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)false, (bool)false}))) == (0L));\n    Debug.Assert(Count((new List<bool>(new bool[]{(bool)true, (bool)true, (bool)true}))) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of pairs whose xor value is odd.\n    public static long FindOddPair(List<long> A, long N) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Tuple<long, long, long, long, long> AddLists(List<long> test_list, Tuple<long, long> test_tup) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L})), (5L)) == (6L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L})), (7L)) == (12L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (3L)) == (2L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((Tuple.Create(9L, 10L, 5L, 6L, 7L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((Tuple.Create(10L, 11L, 6L, 7L, 8L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((Tuple.Create(11L, 12L, 7L, 8L, 9L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of all odd natural numbers within the range l and r.\n    public static long SumInRange(long l, long r) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static List<long> MergeSortedList(List<long> num1, List<long> num2, List<long> num3) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumInRange((2L), (5L)) == (8L));\n    Debug.Assert(SumInRange((5L), (7L)) == (12L));\n    Debug.Assert(SumInRange((7L), (13L)) == (40L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)25L, (long)24L, (long)15L, (long)4L, (long)5L, (long)29L, (long)110L})), (new List<long>(new long[]{(long)19L, (long)20L, (long)11L, (long)56L, (long)25L, (long)233L, (long)154L})), (new List<long>(new long[]{(long)24L, (long)26L, (long)54L, (long)48L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)11L, (long)15L, (long)19L, (long)20L, (long)24L, (long)24L, (long)25L, (long)25L, (long)26L, (long)29L, (long)48L, (long)54L, (long)56L, (long)110L, (long)154L, (long)233L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)6L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)7L, (long)11L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)8L, (long)12L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)5L, (long)6L, (long)7L, (long)7L, (long)8L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)18L, (long)14L, (long)10L, (long)9L, (long)8L, (long)7L, (long)9L, (long)3L, (long)2L, (long)4L, (long)1L})), (new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L})), (new List<long>(new long[]{(long)12L, (long)74L, (long)9L, (long)50L, (long)61L, (long)41L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)8L, (long)9L, (long)9L, (long)9L, (long)10L, (long)12L, (long)14L, (long)14L, (long)18L, (long)22L, (long)25L, (long)25L, (long)35L, (long)41L, (long)50L, (long)58L, (long)61L, (long)65L, (long)74L, (long)75L, (long)85L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long SquarePerimeter(long a) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long OddEquivalent(string s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquarePerimeter((10L)) == (40L));\n    Debug.Assert(SquarePerimeter((5L)) == (20L));\n    Debug.Assert(SquarePerimeter((4L)) == (16L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddEquivalent((\"011001\"), (6L)) == (3L));\n    Debug.Assert(OddEquivalent((\"11011\"), (5L)) == (4L));\n    Debug.Assert(OddEquivalent((\"1010\"), (4L)) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long IsPolite(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static bool CheckInteger(string text) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPolite((7L)) == (11L));\n    Debug.Assert(IsPolite((4L)) == (7L));\n    Debug.Assert(IsPolite((9L)) == (13L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckInteger((\"python\")) == (false));\n    Debug.Assert(CheckInteger((\"1\")) == (true));\n    Debug.Assert(CheckInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long SumSeries(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long TupleToInt(Tuple<long, long, long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSeries((6L)) == (12L));\n    Debug.Assert(SumSeries((10L)) == (30L));\n    Debug.Assert(SumSeries((9L)) == (25L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Tuple<long, long, long, long> FindDissimilar(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindDissimilar((Tuple.Create(3L, 4L, 5L, 6L)), (Tuple.Create(5L, 7L, 4L, 10L))).Equals((Tuple.Create(3L, 6L, 7L, 10L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(7L, 2L, 3L, 9L))).Equals((Tuple.Create(1L, 4L, 7L, 9L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(21L, 11L, 25L, 26L)), (Tuple.Create(26L, 34L, 21L, 36L))).Equals((Tuple.Create(34L, 36L, 11L, 25L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Tuple<string, string> StartWithp(List<string> words) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python PHP\", (string)\"Java JavaScript\", (string)\"c c++\"}))).Equals((Tuple.Create(\"Python\", \"PHP\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python Programming\", (string)\"Java Programming\"}))).Equals((Tuple.Create(\"Python\", \"Programming\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Pqrst Pqr\", (string)\"qrstuv\"}))).Equals((Tuple.Create(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"android_tv\")).Equals((\"AndroidTv\")));\n    Debug.Assert(SnakeToCamel((\"google_pixel\")).Equals((\"GooglePixel\")));\n    Debug.Assert(SnakeToCamel((\"apple_watch\")).Equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long VolumeCube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VolumeCube((3L)) == (27L));\n    Debug.Assert(VolumeCube((2L)) == (8L));\n    Debug.Assert(VolumeCube((5L)) == (125L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static bool CheckMonthnumbNumber(long monthnum2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumbNumber((5L)) == (true));\n    Debug.Assert(CheckMonthnumbNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumbNumber((6L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether all the bits are unset in the given range or not.\n    public static bool AllBitsSetInTheGivenRange(long n, long l, long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllBitsSetInTheGivenRange((4L), (1L), (2L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((17L), (2L), (4L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((39L), (4L), (6L)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to get the first element of each sublist.\n    public static List<long> Extract(List<List<long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)6L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))).Equals((new List<long>(new long[]{(long)1L, (long)4L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)8L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))).Equals((new List<long>(new long[]{(long)9L, (long)1L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float SurfaceareaCylinder(long r, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCylinder((10L), (5L)) == (942.45f));\n    Debug.Assert(SurfaceareaCylinder((4L), (5L)) == (226.18800000000002f));\n    Debug.Assert(SurfaceareaCylinder((4L), (10L)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long SampleNam(List<string> sample_names) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"sally\", (string)\"Dylan\", (string)\"rebecca\", (string)\"Diana\", (string)\"Joanne\", (string)\"keith\"}))) == (16L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"php\", (string)\"res\", (string)\"Python\", (string)\"abcd\", (string)\"Java\", (string)\"aaa\"}))) == (10L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"abcd\", (string)\"Python\", (string)\"abba\", (string)\"aba\"}))) == (6L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static object RearrangeBigger(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearrangeBigger((12L)).Equals((object(21L))));\n    Debug.Assert(RearrangeBigger((10L)).Equals((object(false))));\n    Debug.Assert(RearrangeBigger((102L)).Equals((object(120L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long PerimeterPentagon(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerimeterPentagon((5L)) == (25L));\n    Debug.Assert(PerimeterPentagon((10L)) == (50L));\n    Debug.Assert(PerimeterPentagon((15L)) == (75L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long MaxSum(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)1L, (long)15L, (long)51L, (long)45L, (long)33L, (long)100L, (long)12L, (long)18L, (long)9L}))) == (194L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)80L, (long)60L, (long)30L, (long)40L, (long)20L, (long)10L}))) == (210L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)2L, (long)3L, (long)14L, (long)16L, (long)21L, (long)23L, (long)29L, (long)30L}))) == (138L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static object ExtractEven(Tuple<long, long, Tuple<long, long, Tuple<long, long>>, long, long> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractEven((Tuple.Create(4L, 5L, Tuple.Create(7L, 6L, Tuple.Create(2L, 4L)), 6L, 8L))).Equals(Tuple.Create(4L, Tuple.Create(6L, Tuple.Create(2L, 4L)), 6L, 8L)));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(8L, 7L, Tuple.Create(4L, 8L)), 7L, 9L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 8L)))));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(9L, 8L, Tuple.Create(4L, 6L)), 8L, 10L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 6L)), 8L, 10L)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToInt((Tuple.Create(1L, 2L, 3L))) == (123L));\n    Debug.Assert(TupleToInt((Tuple.Create(4L, 5L, 6L))) == (456L));\n    Debug.Assert(TupleToInt((Tuple.Create(5L, 6L, 7L))) == (567L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3724,189 +136,9 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert all possible convertible elements in a list of lists to floats.\n    public static List<Tuple<float, float>> ListToFloat(List<Tuple<string, string>> test_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"3\", \"4\"), (Tuple<string, string>)Tuple.Create(\"1\", \"26.45\"), (Tuple<string, string>)Tuple.Create(\"7.32\", \"8\"), (Tuple<string, string>)Tuple.Create(\"4\", \"8\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(3.0f, 4.0f), (Tuple<float, float>)Tuple.Create(1.0f, 26.45f), (Tuple<float, float>)Tuple.Create(7.32f, 8.0f), (Tuple<float, float>)Tuple.Create(4.0f, 8.0f)}))));\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"4\", \"4\"), (Tuple<string, string>)Tuple.Create(\"2\", \"27\"), (Tuple<string, string>)Tuple.Create(\"4.12\", \"9\"), (Tuple<string, string>)Tuple.Create(\"7\", \"11\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(4.0f, 4.0f), (Tuple<float, float>)Tuple.Create(2.0f, 27.0f), (Tuple<float, float>)Tuple.Create(4.12f, 9.0f), (Tuple<float, float>)Tuple.Create(7.0f, 11.0f)}))));\n    Debug.Assert(ListToFloat((new List<Tuple<string, string>>(new Tuple<string, string>[]{(Tuple<string, string>)Tuple.Create(\"6\", \"78\"), (Tuple<string, string>)Tuple.Create(\"5\", \"26.45\"), (Tuple<string, string>)Tuple.Create(\"1.33\", \"4\"), (Tuple<string, string>)Tuple.Create(\"82\", \"13\")}))).Equals((new List<Tuple<float, float>>(new Tuple<float, float>[]{(Tuple<float, float>)Tuple.Create(6.0f, 78.0f), (Tuple<float, float>)Tuple.Create(5.0f, 26.45f), (Tuple<float, float>)Tuple.Create(1.33f, 4.0f), (Tuple<float, float>)Tuple.Create(82.0f, 13.0f)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long SquareSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (20L));\n    Debug.Assert(SquareSum((3L)) == (56L));\n    Debug.Assert(SquareSum((4L)) == (120L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long GetPairsCount(List<long> arr, long sum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (2L)) == (6L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)-1L, (long)5L})), (6L)) == (3L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L})), (1L)) == (1L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L})), (-3L)) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long CountNoOfWays(long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNoOfWays((2L), (4L)) == (16L));\n    Debug.Assert(CountNoOfWays((3L), (2L)) == (6L));\n    Debug.Assert(CountNoOfWays((4L), (4L)) == (228L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static string ReverseWords(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseWords((\"python program\")).Equals((\"program python\")));\n    Debug.Assert(ReverseWords((\"java language\")).Equals((\"language java\")));\n    Debug.Assert(ReverseWords((\"indian man\")).Equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check if a given number is one less than twice its reverse.\n    public static bool Checks(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Checks((70L)) == (false));\n    Debug.Assert(Checks((23L)) == (false));\n    Debug.Assert(Checks((73L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last position of an element in a sorted list.\n    public static long Last(List<long> arr, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (1L)) == (0L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)4L})), (1L)) == (2L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)3L, (long)6L, (long)8L, (long)9L})), (3L)) == (3L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long CountX(List<long> tup, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (4L)) == (0L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (10L)) == (3L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (8L)) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static List<object> ExtractIndexList(List<long> l1, List<long> l2, List<long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)7L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)5L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)6L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)6L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)6L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static string ConcatenateTuple(Tuple<string, string, long, string> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ID\", \"is\", 4L, \"UTS\"))).Equals((\"ID-is-4-UTS\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"QWE\", \"is\", 4L, \"RTY\"))).Equals((\"QWE-is-4-RTY\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ZEN\", \"is\", 4L, \"OP\"))).Equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static string ReplaceSpaces(string str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"My Name is Dawood\")).Equals((\"My%20Name%20is%20Dawood\")));\n    Debug.Assert(ReplaceSpaces((\"I am a Programmer\")).Equals((\"I%20am%20a%20Programmer\")));\n    Debug.Assert(ReplaceSpaces((\"I love Coding\")).Equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long SumRangeList(List<long> list1, long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (8L), (10L)) == (29L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (5L), (7L)) == (16L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (7L), (10L)) == (38L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static Dictionary<string,string> MergeDictionariesThree(Dictionary<string,string> dict1, Dictionary<string,string> dict2, Dictionary<string,string> dict3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})).Equals((new Dictionary<string,string>(){{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum of two numbers.\n    public static long Minimum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minimum((1L), (2L)) == (1L));\n    Debug.Assert(Minimum((-5L), (-4L)) == (-5L));\n    Debug.Assert(Minimum((0L), (0L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long MaxDifference(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(1L, 7L), (Tuple<long, long>)Tuple.Create(10L, 3L), (Tuple<long, long>)Tuple.Create(1L, 2L)}))) == (7L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(2L, 17L), (Tuple<long, long>)Tuple.Create(9L, 13L), (Tuple<long, long>)Tuple.Create(11L, 12L)}))) == (15L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 35L), (Tuple<long, long>)Tuple.Create(21L, 27L), (Tuple<long, long>)Tuple.Create(13L, 23L), (Tuple<long, long>)Tuple.Create(41L, 22L)}))) == (23L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find element at a given index after number of rotations.\n    public static long FindElement(List<long> arr, List<List<long>> ranges, long rotations, long index) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)2L}), (List<long>)new List<long>(new long[]{(long)0L, (long)3L})})), (2L), (1L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (2L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (1L)) == (1L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3916,7 +148,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a string to a list of strings split on the space character.\n    public static List<string> StringToList(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToList((\"python programming\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"programming\"}))));\n    Debug.Assert(StringToList((\"lists tuples strings\")).Equals((new List<string>(new string[]{(string)\"lists\", (string)\"tuples\", (string)\"strings\"}))));\n    Debug.Assert(StringToList((\"write a program\")).Equals((new List<string>(new string[]{(string)\"write\", (string)\"a\", (string)\"program\"}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3928,21 +160,9 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the element that appears only once in a sorted list.\n    public static long Search(List<long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)5L, (long)7L, (long)7L, (long)8L}))) == (8L));\n    Debug.Assert(Search((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L}))) == (1L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static List<Tuple<string, long>> SortCounter(Dictionary<string,long> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 81L}, {\"Physics\", 83L}, {\"Chemistry\", 87L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 87L), (Tuple<string, long>)Tuple.Create(\"Physics\", 83L), (Tuple<string, long>)Tuple.Create(\"Math\", 81L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 400L}, {\"Physics\", 300L}, {\"Chemistry\", 250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Math\", 400L), (Tuple<string, long>)Tuple.Create(\"Physics\", 300L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 250L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 900L}, {\"Physics\", 1000L}, {\"Chemistry\", 1250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 1250L), (Tuple<string, long>)Tuple.Create(\"Physics\", 1000L), (Tuple<string, long>)Tuple.Create(\"Math\", 900L)}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3952,7 +172,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove first and last occurrence of a given character from the string.\n    public static string RemoveOcc(string s, string ch) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOcc((\"hello\"), (\"l\")).Equals((\"heo\")));\n    Debug.Assert(RemoveOcc((\"abcda\"), (\"a\")).Equals((\"bcd\")));\n    Debug.Assert(RemoveOcc((\"PHP\"), (\"P\")).Equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3960,325 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long LateralsurfaceCube(long l) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long MaxProductTuple(List<Tuple<long, long>> list1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCube((5L)) == (100L));\n    Debug.Assert(LateralsurfaceCube((9L)) == (324L));\n    Debug.Assert(LateralsurfaceCube((10L)) == (400L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (36L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (200L));\n    Debug.Assert(MaxProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (484L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Nullable<bool> CommonElement(List<object> list1, List<object> list2) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long AmicableNumbersSum(long limit) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals(true));\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))).Equals(null));\n    Debug.Assert(CommonElement((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})), (new List<object>(new string[]{(string)\"d\", (string)\"b\", (string)\"e\"}))).Equals(true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AmicableNumbersSum((999L)) == (504L));\n    Debug.Assert(AmicableNumbersSum((9999L)) == (31626L));\n    Debug.Assert(AmicableNumbersSum((99L)) == (0L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Tuple<long, long, long, long, long> AddLists(List<long> test_list, Tuple<long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long FindLength(string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((Tuple.Create(9L, 10L, 5L, 6L, 7L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((Tuple.Create(10L, 11L, 6L, 7L, 8L))));\n    Debug.Assert(AddLists((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((Tuple.Create(11L, 12L, 7L, 8L, 9L))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLength((\"11000010001\")) == (6L));\n    Debug.Assert(FindLength((\"10111\")) == (1L));\n    Debug.Assert(FindLength((\"11011101100101\")) == (2L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static List<long> NthNums(List<long> nums, long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of common divisors of two given numbers.\n    public static long Sum(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (3L)).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)12L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)248832L, (long)759375L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((10L), (15L)) == (6L));\n    Debug.Assert(Sum((100L), (150L)) == (93L));\n    Debug.Assert(Sum((4L), (6L)) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> PancakeSort(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long MultiplyInt(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)15L, (long)79L, (long)25L, (long)38L, (long)69L}))).Equals((new List<long>(new long[]{(long)15L, (long)25L, (long)38L, (long)69L, (long)79L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)98L, (long)12L, (long)54L, (long)36L, (long)85L}))).Equals((new List<long>(new long[]{(long)12L, (long)36L, (long)54L, (long)85L, (long)98L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)41L, (long)42L, (long)32L, (long)12L, (long)23L}))).Equals((new List<long>(new long[]{(long)12L, (long)23L, (long)32L, (long)41L, (long)42L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float MedianNumbers(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianNumbers((25L), (55L), (65L)) == (55.0f));\n    Debug.Assert(MedianNumbers((20L), (10L), (30L)) == (20.0f));\n    Debug.Assert(MedianNumbers((15L), (45L), (75L)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given list.\n    public static bool CheckGreater(List<long> arr, long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (4L)) == (false));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (8L)) == (true));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)9L, (long)7L, (long)4L, (long)8L, (long)6L, (long)1L})), (11L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static bool CheckElement(List<object> list, object element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"orange\", (string)\"black\", (string)\"white\"})), (object(\"blue\"))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (object(7L))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"green\", (string)\"green\", (string)\"green\"})), (object(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static List<string> ExtractString(List<string> str, long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (8L)).Equals((new List<string>(new string[]{(string)\"practice\", (string)\"solution\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (6L)).Equals((new List<string>(new string[]{(string)\"Python\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (9L)).Equals((new List<string>(new string[]{(string)\"exercises\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static bool TextLowercaseUnderscore(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    Debug.Assert(TextLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    Debug.Assert(TextLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static List<List<long>> TrimTuple(List<List<long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)2L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)8L, (long)2L, (long)1L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)12L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)4L}), (List<long>)new List<long>(new long[]{(long)8L, (long)12L}), (List<long>)new List<long>(new long[]{(long)1L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)9L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sublist having minimum length.\n    public static List<object> FindMin(List<List<object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)7L, (long)8L})}))).Equals((new List<object>(new long[]{(long)1L, (long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"})}))).Equals((new List<object>(new string[]{(string)\"x\"}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static List<long> FilterOddnumbers(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)10L, (long)20L, (long)45L, (long)67L, (long)84L, (long)93L}))).Equals((new List<long>(new long[]{(long)45L, (long)67L, (long)93L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)8L, (long)6L, (long)4L, (long)3L}))).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)3L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static string FindAdverbs(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbs((\"Clearly, he has no excuse for such behavior.\")).Equals((\"0-7: Clearly\")));\n    Debug.Assert(FindAdverbs((\"Please handle the situation carefuly\")).Equals((\"28-36: carefuly\")));\n    Debug.Assert(FindAdverbs((\"Complete the task quickly\")).Equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long MaxOfNth(List<List<long>> test_list, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)9L, (long)19L})})), (2L)) == (19L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)20L})})), (1L)) == (10L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)21L})})), (1L)) == (11L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static string DecimalToBinary(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((8L)).Equals((\"1000\")));\n    Debug.Assert(DecimalToBinary((18L)).Equals((\"10010\")));\n    Debug.Assert(DecimalToBinary((7L)).Equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static List<List<string>> CombinationsColors(List<string> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (1L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (2L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (3L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\", (string)\"Blue\"})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static string RemoveAllSpaces(string text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveAllSpaces((\"python  program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"python   programming    language\")).Equals((\"pythonprogramminglanguage\")));\n    Debug.Assert(RemoveAllSpaces((\"python                     program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"   python                     program\")).Equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static object MinSwaps(string str1, string str2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinSwaps((\"1101\"), (\"1110\")).Equals((object(1L))));\n    Debug.Assert(MinSwaps((\"111\"), (\"000\")).Equals((object(\"Not Possible\"))));\n    Debug.Assert(MinSwaps((\"111\"), (\"110\")).Equals((object(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Tuple<string, string, string> NewTuple(List<string> test_list, string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"WEB\", (string)\"is\"})), (\"best\")).Equals((Tuple.Create(\"WEB\", \"is\", \"best\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"We\", (string)\"are\"})), (\"Developers\")).Equals((Tuple.Create(\"We\", \"are\", \"Developers\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"Part\", (string)\"is\"})), (\"Wrong\")).Equals((Tuple.Create(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the product of the list multiplication modulo n.\n    public static long FindRemainder(List<long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)100L, (long)10L, (long)5L, (long)25L, (long)35L, (long)14L})), (11L)) == (9L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)1L, (long)1L})), (1L)) == (0L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (2L)) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ration of positive numbers in a list of integers.\n    public static float PositiveCount(List<long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.54f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.69f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static List<long> AddTuple(List<long> test_list, Tuple<long, long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)10L, (long)11L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long MaxRunUppercase(string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxRunUppercase((\"GeMKSForGERksISBESt\")) == (5L));\n    Debug.Assert(MaxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6L));\n    Debug.Assert(MaxRunUppercase((\"GooGLEFluTTER\")) == (4L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static List<List<long>> SortMatrix(List<List<long>> M) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long CountVowels(string test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountVowels((\"bestinstareels\")) == (7L));\n    Debug.Assert(CountVowels((\"partofthejourneyistheend\")) == (12L));\n    Debug.Assert(CountVowels((\"amazonprime\")) == (5L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long MaxSumIncreasingSubseq(List<long> a, long n, long index, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (4L), (6L)) == (11L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (2L), (5L)) == (7L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)11L, (long)15L, (long)19L, (long)21L, (long)26L, (long)28L, (long)31L})), (7L), (2L), (4L)) == (71L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyInt((10L), (20L)) == (200L));\n    Debug.Assert(MultiplyInt((5L), (10L)) == (50L));\n    Debug.Assert(MultiplyInt((4L), (8L)) == (32L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4288,7 +244,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find words that are longer than n characters from a given list of words.\n    public static List<string> LongWords(long n, string str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LongWords((3L), (\"python is a programming language\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"programming\", (string)\"language\"}))));\n    Debug.Assert(LongWords((2L), (\"writing a program\")).Equals((new List<string>(new string[]{(string)\"writing\", (string)\"program\"}))));\n    Debug.Assert(LongWords((5L), (\"sorting list\")).Equals((new List<string>(new string[]{(string)\"sorting\"}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4296,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of non-repeated elements in a given list.\n    public static long FindSum(List<long> arr) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static bool MagicSquareTest(List<List<long>> my_matrix) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)1L, (long)4L, (long)5L, (long)6L}))) == (21L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)10L, (long)9L, (long)4L, (long)2L, (long)10L, (long)10L, (long)45L, (long)4L}))) == (71L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)12L, (long)10L, (long)9L, (long)45L, (long)2L, (long)10L, (long)10L, (long)45L, (long)10L}))) == (78L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)12L, (long)1L, (long)14L}), (List<long>)new List<long>(new long[]{(long)2L, (long)13L, (long)8L, (long)11L}), (List<long>)new List<long>(new long[]{(long)16L, (long)3L, (long)10L, (long)5L}), (List<long>)new List<long>(new long[]{(long)9L, (long)6L, (long)15L, (long)4L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)8L})}))) == (true));\n    Debug.Assert(MagicSquareTest((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L, (long)7L})}))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/csthon-convert-tuple-to-adjacent-pair-dictionary/\n    public static Dictionary<long,long> TupleToDict(Tuple<long, long, long, long, long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static List<List<long>> SortMatrix(List<List<long>> M) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 5L, 7L, 10L, 13L, 5L))).Equals((new Dictionary<long,long>(){{1L, 5L}, {7L, 10L}, {13L, 5L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L))).Equals((new Dictionary<long,long>(){{1L, 2L}, {3L, 4L}, {5L, 6L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(7L, 8L, 9L, 10L, 11L, 12L))).Equals((new Dictionary<long,long>(){{7L, 8L}, {9L, 10L}, {11L, 12L}})));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)5L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)-2L, (long)4L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)-1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))));\n    Debug.Assert(SortMatrix((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)8L, (long)9L})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static List<List<long>> GetCoordinates(Tuple<long, long> test_tup) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long MaxOccurrences(List<long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetCoordinates((Tuple.Create(3L, 4L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(4L, 5L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(5L, 6L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)7L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L})}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static bool CheckType(object test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckType(Tuple.Create(5L, 6L, 7L, 3L, 5L, 6L)) == (true));\n    Debug.Assert(CheckType(Tuple.Create(1L, 2L, \"4\")) == (false));\n    Debug.Assert(CheckType(Tuple.Create(3L, 2L, 1L, 4L, 5L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the smallest missing number from a sorted list of natural numbers.\n    public static long FindFirstMissing(List<long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)6L, (long)9L}))) == (3L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)8L, (long)9L}))) == (0L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static bool IsUndulating(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUndulating((1212121L)) == (true));\n    Debug.Assert(IsUndulating((1991L)) == (false));\n    Debug.Assert(IsUndulating((121L)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/csthon-find-minimum-k-records-from-tuple-list/ - in this case a verbatim cocs of test cases\n    public static List<Tuple<string, long>> MinK(List<Tuple<string, long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Manjeet\", 10L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L), (Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Nikhil\", 8L)})), (2L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sanjeev\", 11L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)})), (3L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"tanmay\", 14L), (Tuple<string, long>)Tuple.Create(\"Amer\", 11L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L), (Tuple<string, long>)Tuple.Create(\"SKD\", 16L)})), (1L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of substrings with the sum of digits equal to their length.\n    public static long CountSubstrings(string s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSubstrings((\"112112\")) == (6L));\n    Debug.Assert(CountSubstrings((\"111\")) == (6L));\n    Debug.Assert(CountSubstrings((\"1101112\")) == (12L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long IsNumDecagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNumDecagonal((3L)) == (27L));\n    Debug.Assert(IsNumDecagonal((7L)) == (175L));\n    Debug.Assert(IsNumDecagonal((10L)) == (370L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static List<long> RearExtract(List<Tuple<long, string, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Rash\", 21L), (Tuple<long, string, long>)Tuple.Create(2L, \"Varsha\", 20L), (Tuple<long, string, long>)Tuple.Create(3L, \"Kil\", 19L)}))).Equals((new List<long>(new long[]{(long)21L, (long)20L, (long)19L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sai\", 36L), (Tuple<long, string, long>)Tuple.Create(2L, \"Ayesha\", 25L), (Tuple<long, string, long>)Tuple.Create(3L, \"Salman\", 45L)}))).Equals((new List<long>(new long[]{(long)36L, (long)25L, (long)45L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sudeep\", 14L), (Tuple<long, string, long>)Tuple.Create(2L, \"Vandana\", 36L), (Tuple<long, string, long>)Tuple.Create(3L, \"Dawood\", 56L)}))).Equals((new List<long>(new long[]{(long)14L, (long)36L, (long)56L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long ClosestNum(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestNum((11L)) == (10L));\n    Debug.Assert(ClosestNum((7L)) == (6L));\n    Debug.Assert(ClosestNum((12L)) == (11L));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/csthon-combinations-of-sum-with-tuples-in-tuple-list/\n    public static List<Tuple<long, long>> FindCombinations(List<Tuple<long, long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(6L, 10L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(8L, 11L), (Tuple<long, long>)Tuple.Create(7L, 5L), (Tuple<long, long>)Tuple.Create(8L, 14L), (Tuple<long, long>)Tuple.Create(11L, 8L), (Tuple<long, long>)Tuple.Create(12L, 17L), (Tuple<long, long>)Tuple.Create(11L, 11L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(6L, 2L), (Tuple<long, long>)Tuple.Create(7L, 11L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 13L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(10L, 16L), (Tuple<long, long>)Tuple.Create(13L, 10L), (Tuple<long, long>)Tuple.Create(14L, 19L), (Tuple<long, long>)Tuple.Create(13L, 13L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(7L, 3L), (Tuple<long, long>)Tuple.Create(8L, 12L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 15L), (Tuple<long, long>)Tuple.Create(11L, 9L), (Tuple<long, long>)Tuple.Create(12L, 18L), (Tuple<long, long>)Tuple.Create(15L, 12L), (Tuple<long, long>)Tuple.Create(16L, 21L), (Tuple<long, long>)Tuple.Create(15L, 15L)}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float Maxaverageofpath(List<List<long>> cost) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L, (long)9L})}))) == (5.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L, (long)10L})}))) == (6.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)11L})}))) == (7.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and returns a tuple containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n    public static Tuple<bool, long> SequentialSearch(List<long> dlist, long item) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)11L, (long)23L, (long)58L, (long)31L, (long)56L, (long)77L, (long)43L, (long)12L, (long)65L, (long)19L})), (31L)).Equals((Tuple.Create(true, 3L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)12L, (long)32L, (long)45L, (long)62L, (long)35L, (long)47L, (long)44L, (long)61L})), (61L)).Equals((Tuple.Create(true, 7L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)9L, (long)10L, (long)17L, (long)19L, (long)22L, (long)39L, (long)48L, (long)56L})), (48L)).Equals((Tuple.Create(true, 6L))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove odd numbers from a given list.\n    public static List<long> RemoveOdd(List<long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)10L, (long)20L, (long)3L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L}))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static bool IsProductEven(List<long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)1L}))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the maximum of two numbers.\n    public static long Maximum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((5L), (10L)) == (10L));\n    Debug.Assert(Maximum((-1L), (-2L)) == (-1L));\n    Debug.Assert(Maximum((9L), (7L)) == (9L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)2L, (long)6L, (long)5L, (long)1L, (long)6L, (long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)6L, (long)9L, (long)1L, (long)2L}))) == (2L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)2L, (long)3L, (long)8L, (long)4L, (long)7L, (long)9L, (long)8L, (long)7L, (long)9L, (long)15L, (long)14L, (long)10L, (long)12L, (long)13L, (long)16L, (long)18L}))) == (8L));\n    Debug.Assert(MaxOccurrences((new List<long>(new long[]{(long)10L, (long)20L, (long)20L, (long)30L, (long)40L, (long)90L, (long)80L, (long)50L, (long)30L, (long)20L, (long)50L, (long)10L}))) == (20L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4504,9 +292,597 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to reverse only the vowels of a given string (where y is not a vowel).\n    public static string ReverseVowels(string str1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseVowels((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(ReverseVowels((\"USA\")).Equals((\"ASU\")));\n    Debug.Assert(ReverseVowels((\"ab\")).Equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static string TupString(List<string> tup1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"e\", (string)\"x\", (string)\"e\", (string)\"r\", (string)\"c\", (string)\"i\", (string)\"s\", (string)\"e\", (string)\"s\"}))).Equals((\"exercises\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))).Equals((\"python\")));\n    Debug.Assert(TupString((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))).Equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long SumNegativenum(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (-32L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)10L, (long)15L, (long)-14L, (long)13L, (long)-18L, (long)12L, (long)-20L}))) == (-52L));\n    Debug.Assert(SumNegativenum((new List<long>(new long[]{(long)19L, (long)-65L, (long)57L, (long)39L, (long)152L, (long)-639L, (long)121L, (long)44L, (long)90L, (long)-190L}))) == (-894L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long HexagonalNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HexagonalNum((10L)) == (190L));\n    Debug.Assert(HexagonalNum((5L)) == (45L));\n    Debug.Assert(HexagonalNum((7L)) == (91L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static bool IsSumOfPowersOfTwo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSumOfPowersOfTwo((10L)) == (true));\n    Debug.Assert(IsSumOfPowersOfTwo((7L)) == (false));\n    Debug.Assert(IsSumOfPowersOfTwo((14L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> PancakeSort(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)15L, (long)79L, (long)25L, (long)38L, (long)69L}))).Equals((new List<long>(new long[]{(long)15L, (long)25L, (long)38L, (long)69L, (long)79L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)98L, (long)12L, (long)54L, (long)36L, (long)85L}))).Equals((new List<long>(new long[]{(long)12L, (long)36L, (long)54L, (long)85L, (long)98L}))));\n    Debug.Assert(PancakeSort((new List<long>(new long[]{(long)41L, (long)42L, (long)32L, (long)12L, (long)23L}))).Equals((new List<long>(new long[]{(long)12L, (long)23L, (long)32L, (long)41L, (long)42L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long CountSamepair(List<long> list1, List<long> list2, List<long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (3L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (4L));\n    Debug.Assert(CountSamepair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)8L}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long FindLists(List<object> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (2L));\n    Debug.Assert(FindLists((new List<object>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))) == (3L));\n    Debug.Assert(FindLists((new List<object>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L, (long)4L, (long)3L, (long)2L, (long)1L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the maximum difference between any two elements in a given list.\n    public static long MaxAbsDiff(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)3L}))) == (4L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)9L, (long)3L, (long)2L, (long)5L, (long)1L}))) == (8L));\n    Debug.Assert(MaxAbsDiff((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the volume of a triangular prism.\n    public static long FindVolume(long l, long b, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindVolume((10L), (8L), (6L)) == (240L));\n    Debug.Assert(FindVolume((3L), (2L), (2L)) == (6L));\n    Debug.Assert(FindVolume((1L), (2L), (1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return null if no solution exists.\n    public static Tuple<long, long> FindSolution(long a, long b, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSolution((2L), (3L), (7L)).Equals((Tuple.Create(2L, 1L))));\n    Debug.Assert(FindSolution((4L), (2L), (7L)).Equals(null));\n    Debug.Assert(FindSolution((1L), (13L), (17L)).Equals((Tuple.Create(4L, 1L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static List<long> RemoveElements(List<long> list1, List<long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    Debug.Assert(RemoveElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)5L, (long)7L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)8L, (long)9L, (long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long SumSeries(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumSeries((6L)) == (12L));\n    Debug.Assert(SumSeries((10L)) == (30L));\n    Debug.Assert(SumSeries((9L)) == (25L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static bool AreEquivalent(long num1, long num2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreEquivalent((36L), (57L)) == (false));\n    Debug.Assert(AreEquivalent((2L), (4L)) == (false));\n    Debug.Assert(AreEquivalent((23L), (47L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long CountCharPosition(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharPosition((\"xbcefg\")) == (2L));\n    Debug.Assert(CountCharPosition((\"ABcED\")) == (3L));\n    Debug.Assert(CountCharPosition((\"AbgdeF\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long FindEvenPair(List<long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L}))) == (4L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L}))) == (9L));\n    Debug.Assert(FindEvenPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the smallest power of 2 greater than or equal to n.\n    public static long NextPowerOf2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPowerOf2((0L)) == (1L));\n    Debug.Assert(NextPowerOf2((5L)) == (8L));\n    Debug.Assert(NextPowerOf2((17L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long Frequency(List<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (4L)) == (0L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)3L, (long)4L})), (3L)) == (3L));\n    Debug.Assert(Frequency((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)1L, (long)2L})), (1L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static bool TextLowercaseUnderscore(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    Debug.Assert(TextLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    Debug.Assert(TextLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long SumRangeList(List<long> list1, long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (8L), (10L)) == (29L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (5L), (7L)) == (16L));\n    Debug.Assert(SumRangeList((new List<long>(new long[]{(long)2L, (long)1L, (long)5L, (long)6L, (long)8L, (long)3L, (long)4L, (long)9L, (long)10L, (long)11L, (long)8L, (long)12L})), (7L), (10L)) == (38L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long PerimeterPentagon(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerimeterPentagon((5L)) == (25L));\n    Debug.Assert(PerimeterPentagon((10L)) == (50L));\n    Debug.Assert(PerimeterPentagon((15L)) == (75L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long CountOccurance(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurance((\"letstdlenstdporstd\")) == (3L));\n    Debug.Assert(CountOccurance((\"truststdsolensporsd\")) == (1L));\n    Debug.Assert(CountOccurance((\"makestdsostdworthit\")) == (2L));\n    Debug.Assert(CountOccurance((\"stds\")) == (1L));\n    Debug.Assert(CountOccurance((\"\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long SquarePerimeter(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquarePerimeter((10L)) == (40L));\n    Debug.Assert(SquarePerimeter((5L)) == (20L));\n    Debug.Assert(SquarePerimeter((4L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static string RemoveDirtyChars(string str, string second_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveDirtyChars((\"probasscurve\"), (\"pros\")).Equals((\"bacuve\")));\n    Debug.Assert(RemoveDirtyChars((\"digitalindia\"), (\"talent\")).Equals((\"digiidi\")));\n    Debug.Assert(RemoveDirtyChars((\"exoticmiles\"), (\"toxic\")).Equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether a given list of integers contains any duplicate element.\n    public static bool TestDuplicate(List<long> arraynums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(TestDuplicate((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static bool IsWoodall(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsWoodall((383L)) == (true));\n    Debug.Assert(IsWoodall((254L)) == (false));\n    Debug.Assert(IsWoodall((200L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static bool CheckType(object test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckType(Tuple.Create(5L, 6L, 7L, 3L, 5L, 6L)) == (true));\n    Debug.Assert(CheckType(Tuple.Create(1L, 2L, \"4\")) == (false));\n    Debug.Assert(CheckType(Tuple.Create(3L, 2L, 1L, 4L, 5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n    public static bool IsMajority(List<long> arr, long n, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)3L, (long)3L, (long)3L, (long)10L})), (7L), (3L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)4L, (long)4L, (long)4L, (long)6L, (long)6L})), (8L), (4L)) == (false));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (true));\n    Debug.Assert(IsMajority((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)2L})), (5L), (1L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long CountSetBits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSetBits((2L)) == (1L));\n    Debug.Assert(CountSetBits((4L)) == (1L));\n    Debug.Assert(CountSetBits((6L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove the characters which have odd index values of a given string.\n    public static string OddValuesString(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddValuesString((\"abcdef\")).Equals((\"ace\")));\n    Debug.Assert(OddValuesString((\"python\")).Equals((\"pto\")));\n    Debug.Assert(OddValuesString((\"data\")).Equals((\"dt\")));\n    Debug.Assert(OddValuesString((\"lambs\")).Equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long MinOfThree(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinOfThree((10L), (20L), (0L)) == (0L));\n    Debug.Assert(MinOfThree((19L), (15L), (18L)) == (15L));\n    Debug.Assert(MinOfThree((-10L), (-20L), (-30L)) == (-30L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether all the bits are unset in the given range or not.\n    public static bool AllBitsSetInTheGivenRange(long n, long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllBitsSetInTheGivenRange((4L), (1L), (2L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((17L), (2L), (4L)) == (true));\n    Debug.Assert(AllBitsSetInTheGivenRange((39L), (4L), (6L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static List<long> ReArrangeArray(List<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)-1L, (long)2L, (long)-3L, (long)4L, (long)5L, (long)6L, (long)-7L, (long)8L, (long)9L})), (9L)).Equals((new List<long>(new long[]{(long)-1L, (long)-3L, (long)-7L, (long)4L, (long)5L, (long)6L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)12L, (long)-14L, (long)-26L, (long)13L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)-14L, (long)-26L, (long)12L, (long)13L, (long)15L}))));\n    Debug.Assert(ReArrangeArray((new List<long>(new long[]{(long)10L, (long)24L, (long)36L, (long)-42L, (long)-39L, (long)-78L, (long)85L})), (7L)).Equals((new List<long>(new long[]{(long)-42L, (long)-39L, (long)-78L, (long)10L, (long)24L, (long)36L, (long)85L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static string ReplaceBlank(string str1, string char) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceBlank((\"hello people\"), (\"@\")).Equals((\"hello@people\")));\n    Debug.Assert(ReplaceBlank((\"python program language\"), (\"$\")).Equals((\"python$program$language\")));\n    Debug.Assert(ReplaceBlank((\"blank space\"), (\"-\")).Equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long VolumeCube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(VolumeCube((3L)) == (27L));\n    Debug.Assert(VolumeCube((2L)) == (8L));\n    Debug.Assert(VolumeCube((5L)) == (125L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static Dictionary<Tuple<long, long>,long> CheckOccurences(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 1L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(2L, 5L), (Tuple<long, long>)Tuple.Create(5L, 2L), (Tuple<long, long>)Tuple.Create(6L, 3L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(1L, 3L), 2L}, {Tuple.Create(2L, 5L), 2L}, {Tuple.Create(3L, 6L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 2L), (Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(3L, 6L), (Tuple<long, long>)Tuple.Create(6L, 3L), (Tuple<long, long>)Tuple.Create(7L, 4L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 4L), 2L}, {Tuple.Create(3L, 6L), 2L}, {Tuple.Create(4L, 7L), 1L}})));\n    Debug.Assert(CheckOccurences((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(13L, 2L), (Tuple<long, long>)Tuple.Create(11L, 23L), (Tuple<long, long>)Tuple.Create(12L, 25L), (Tuple<long, long>)Tuple.Create(25L, 12L), (Tuple<long, long>)Tuple.Create(16L, 23L)}))).Equals((new Dictionary<Tuple<long, long>,long>(){{Tuple.Create(2L, 13L), 1L}, {Tuple.Create(11L, 23L), 1L}, {Tuple.Create(12L, 25L), 2L}, {Tuple.Create(16L, 23L), 1L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of non-empty substrings of a given string.\n    public static long NumberOfSubstrings(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberOfSubstrings((\"abc\")) == (6L));\n    Debug.Assert(NumberOfSubstrings((\"abcd\")) == (10L));\n    Debug.Assert(NumberOfSubstrings((\"abcde\")) == (15L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long GetTotalNumberOfSequences(long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetTotalNumberOfSequences((10L), (4L)) == (4L));\n    Debug.Assert(GetTotalNumberOfSequences((5L), (2L)) == (6L));\n    Debug.Assert(GetTotalNumberOfSequences((16L), (3L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static List<object> ReplaceList(List<object> list1, List<object> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)10L})), (new List<object>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(ReplaceList((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\"})), (new List<object>(new string[]{(string)\"yellow\"}))).Equals((new List<object>(new string[]{(string)\"red\", (string)\"blue\", (string)\"yellow\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long CountCharac(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountCharac((\"python programming\")) == (18L));\n    Debug.Assert(CountCharac((\"language\")) == (8L));\n    Debug.Assert(CountCharac((\"words\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the next perfect square greater than a given number.\n    public static long NextPerfectSquare(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NextPerfectSquare((35L)) == (36L));\n    Debug.Assert(NextPerfectSquare((6L)) == (9L));\n    Debug.Assert(NextPerfectSquare((9L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long MaxSum(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)1L, (long)15L, (long)51L, (long)45L, (long)33L, (long)100L, (long)12L, (long)18L, (long)9L}))) == (194L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)80L, (long)60L, (long)30L, (long)40L, (long)20L, (long)10L}))) == (210L));\n    Debug.Assert(MaxSum((new List<long>(new long[]{(long)2L, (long)3L, (long)14L, (long)16L, (long)21L, (long)23L, (long)29L, (long)30L}))) == (138L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long Lps(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Lps((\"TENS FOR TENS\")) == (5L));\n    Debug.Assert(Lps((\"CARDIO FOR CARDS\")) == (7L));\n    Debug.Assert(Lps((\"PART OF THE JOURNEY IS PART\")) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the intersection of two lists.\n    public static List<long> IntersectionArray(List<long> array_nums1, List<long> array_nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)8L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))).Equals((new List<long>(new long[]{(long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(IntersectionArray((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)8L, (long)9L, (long)10L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<long>(new long[]{(long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long CountX(List<long> tup, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (4L)) == (0L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (10L)) == (3L));\n    Debug.Assert(CountX((new List<long>(new long[]{(long)10L, (long)8L, (long)5L, (long)2L, (long)10L, (long)15L, (long)10L, (long)8L, (long)5L, (long)8L, (long)8L, (long)2L})), (8L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static List<string> InsertElement(List<string> list, string element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Black\"})), (\"c\")).Equals((new List<string>(new string[]{(string)\"c\", (string)\"Red\", (string)\"c\", (string)\"Green\", (string)\"c\", (string)\"Black\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"python\", (string)\"java\"})), (\"program\")).Equals((new List<string>(new string[]{(string)\"program\", (string)\"python\", (string)\"program\", (string)\"java\"}))));\n    Debug.Assert(InsertElement((new List<string>(new string[]{(string)\"happy\", (string)\"sad\"})), (\"laugh\")).Equals((new List<string>(new string[]{(string)\"laugh\", (string)\"happy\", (string)\"laugh\", (string)\"sad\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert complex numbers to polar coordinates.\n    public static Tuple<float, float> Convert(long numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Convert((1L)).Equals((Tuple.Create(1.0f, 0.0f))));\n    Debug.Assert(Convert((4L)).Equals((Tuple.Create(4.0f, 0.0f))));\n    Debug.Assert(Convert((5L)).Equals((Tuple.Create(5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static List<List<string>> CombinationsColors(List<string> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (1L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (2L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\"})}))));\n    Debug.Assert(CombinationsColors((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"})), (3L)).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Red\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Red\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Red\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Green\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Green\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Green\", (string)\"Blue\", (string)\"Blue\"}), (List<string>)new List<string>(new string[]{(string)\"Blue\", (string)\"Blue\", (string)\"Blue\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long CountPrimesNums(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPrimesNums((5L)) == (2L));\n    Debug.Assert(CountPrimesNums((10L)) == (4L));\n    Debug.Assert(CountPrimesNums((100L)) == (25L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static List<long> SwapNumbers(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapNumbers((10L), (20L)).Equals((new List<long>(new long[]{(long)20L, (long)10L}))));\n    Debug.Assert(SwapNumbers((15L), (17L)).Equals((new List<long>(new long[]{(long)17L, (long)15L}))));\n    Debug.Assert(SwapNumbers((100L), (200L)).Equals((new List<long>(new long[]{(long)200L, (long)100L}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4516,7 +892,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to maximize the given two lists.\n    public static List<List<long>> MaximizeElements(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)10L})}))));\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)5L, (long)10L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)11L})}))));\n    Debug.Assert(MaximizeElements((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)6L, (long)11L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)9L, (long)12L})}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4524,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether every even index contains even numbers of a given list.\n    public static bool EvenPosition(List<long> nums) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long NewmanPrime(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L}))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewmanPrime((3L)) == (7L));\n    Debug.Assert(NewmanPrime((4L)) == (17L));\n    Debug.Assert(NewmanPrime((5L)) == (41L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static string CheckChar(string str) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Tuple<long, long, long, long> DivisionElements(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckChar((\"abba\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"a\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"abcd\")).Equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisionElements((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(2L, 2L, 2L, 3L))));\n    Debug.Assert(DivisionElements((Tuple.Create(12L, 6L, 8L, 16L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(2L, 2L, 2L, 4L))));\n    Debug.Assert(DivisionElements((Tuple.Create(20L, 14L, 36L, 18L)), (Tuple.Create(5L, 7L, 6L, 9L))).Equals((Tuple.Create(4L, 2L, 6L, 2L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of even factors of a number.\n    public static long Sumoffactors(long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static object SplitTwoParts(List<object> list1, long L) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sumoffactors((18L)) == (26L));\n    Debug.Assert(Sumoffactors((30L)) == (48L));\n    Debug.Assert(Sumoffactors((6L)) == (8L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitTwoParts((new List<object>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals(Tuple.Create(new List<long>(new long[]{(long)1L, (long)1L, (long)2L}), new List<long>(new long[]{(long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (2L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"a\", (string)\"b\"}), new List<string>(new string[]{(string)\"c\", (string)\"d\"}))));\n    Debug.Assert(SplitTwoParts((new List<object>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"})), (4L)).Equals(Tuple.Create(new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\"}), new List<string>(new string[]{(string)\"o\", (string)\"n\"}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float LateralsurfaceCone(long r, long h) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long DogAge(long h_age) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCone((5L), (12L)) == (204.20352248333654f));\n    Debug.Assert(LateralsurfaceCone((10L), (15L)) == (566.3586699569488f));\n    Debug.Assert(LateralsurfaceCone((19L), (17L)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DogAge((12L)) == (61L));\n    Debug.Assert(DogAge((15L)) == (73L));\n    Debug.Assert(DogAge((24L)) == (109L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long CountPairs(List<long> arr, long n) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static List<List<object>> ListSplit(List<object> S, long step) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (3L)) == (2L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (4L)) == (0L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (5L)) == (10L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"e\", (string)\"f\", (string)\"g\", (string)\"h\", (string)\"i\", (string)\"j\", (string)\"k\", (string)\"l\", (string)\"m\", (string)\"n\"})), (3L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"d\", (string)\"g\", (string)\"j\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"b\", (string)\"e\", (string)\"h\", (string)\"k\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"f\", (string)\"i\", (string)\"l\"})}))));\n    Debug.Assert(ListSplit((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)11L, (long)12L, (long)13L, (long)14L})), (3L)).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)10L, (long)13L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L, (long)8L, (long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)12L})}))));\n    Debug.Assert(ListSplit((new List<object>(new string[]{(string)\"python\", (string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\", (string)\"SQL\"})), (2L)).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"python\", (string)\"C\", (string)\"DBMS\"}), (List<string>)new List<string>(new string[]{(string)\"java\", (string)\"C++\", (string)\"SQL\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted list.\n    public static long FindFirstOccurrence(List<long> A, long x) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long LateralsurfaceCube(long l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)5L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (1L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (2L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (6L)) == (4L));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCube((5L)) == (100L));\n    Debug.Assert(LateralsurfaceCube((9L)) == (324L));\n    Debug.Assert(LateralsurfaceCube((10L)) == (400L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4600,9 +976,669 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    public static long SquareSum(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (10L));\n    Debug.Assert(SquareSum((3L)) == (35L));\n    Debug.Assert(SquareSum((4L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long FindStarNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindStarNum((3L)) == (37L));\n    Debug.Assert(FindStarNum((4L)) == (73L));\n    Debug.Assert(FindStarNum((5L)) == (121L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long AsciiValue(string k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AsciiValue((\"A\")) == (65L));\n    Debug.Assert(AsciiValue((\"R\")) == (82L));\n    Debug.Assert(AsciiValue((\"S\")) == (83L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of even numbers at even positions of a list.\n    public static long SumEvenAndEvenIndex(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L, (long)18L, (long)8L}))) == (30L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)3L, (long)20L, (long)17L, (long)9L, (long)2L, (long)10L, (long)18L, (long)13L, (long)6L, (long)18L}))) == (26L));\n    Debug.Assert(SumEvenAndEvenIndex((new List<long>(new long[]{(long)5L, (long)6L, (long)12L, (long)1L}))) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long EvenPowerSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPowerSum((2L)) == (1056L));\n    Debug.Assert(EvenPowerSum((3L)) == (8832L));\n    Debug.Assert(EvenPowerSum((1L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static List<long> RearExtract(List<Tuple<long, string, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Rash\", 21L), (Tuple<long, string, long>)Tuple.Create(2L, \"Varsha\", 20L), (Tuple<long, string, long>)Tuple.Create(3L, \"Kil\", 19L)}))).Equals((new List<long>(new long[]{(long)21L, (long)20L, (long)19L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sai\", 36L), (Tuple<long, string, long>)Tuple.Create(2L, \"Ayesha\", 25L), (Tuple<long, string, long>)Tuple.Create(3L, \"Salman\", 45L)}))).Equals((new List<long>(new long[]{(long)36L, (long)25L, (long)45L}))));\n    Debug.Assert(RearExtract((new List<Tuple<long, string, long>>(new Tuple<long, string, long>[]{(Tuple<long, string, long>)Tuple.Create(1L, \"Sudeep\", 14L), (Tuple<long, string, long>)Tuple.Create(2L, \"Vandana\", 36L), (Tuple<long, string, long>)Tuple.Create(3L, \"Dawood\", 56L)}))).Equals((new List<long>(new long[]{(long)14L, (long)36L, (long)56L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Tuple<long, long, long> SubstractElements(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubstractElements((Tuple.Create(10L, 4L, 5L)), (Tuple.Create(2L, 5L, 18L))).Equals((Tuple.Create(8L, -1L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(11L, 2L, 3L)), (Tuple.Create(24L, 45L, 16L))).Equals((Tuple.Create(-13L, -43L, -13L))));\n    Debug.Assert(SubstractElements((Tuple.Create(7L, 18L, 9L)), (Tuple.Create(10L, 11L, 12L))).Equals((Tuple.Create(-3L, 7L, -3L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long EvenBinomialCoeffSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenBinomialCoeffSum((4L)) == (8L));\n    Debug.Assert(EvenBinomialCoeffSum((6L)) == (32L));\n    Debug.Assert(EvenBinomialCoeffSum((2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static Dictionary<string,long> DictFilter(Dictionary<string,long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (170L)).Equals((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (180L)).Equals((new Dictionary<string,long>(){{\"Alden Cantrell\", 180L}, {\"Pierre Cox\", 190L}})));\n    Debug.Assert(DictFilter((new Dictionary<string,long>(){{\"Cierra Vega\", 175L}, {\"Alden Cantrell\", 180L}, {\"Kierra Gentry\", 165L}, {\"Pierre Cox\", 190L}}), (190L)).Equals((new Dictionary<string,long>(){{\"Pierre Cox\", 190L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long IsNumDecagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNumDecagonal((3L)) == (27L));\n    Debug.Assert(IsNumDecagonal((7L)) == (175L));\n    Debug.Assert(IsNumDecagonal((10L)) == (370L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and returns a tuple containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n    public static Tuple<bool, long> SequentialSearch(List<long> dlist, long item) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)11L, (long)23L, (long)58L, (long)31L, (long)56L, (long)77L, (long)43L, (long)12L, (long)65L, (long)19L})), (31L)).Equals((Tuple.Create(true, 3L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)12L, (long)32L, (long)45L, (long)62L, (long)35L, (long)47L, (long)44L, (long)61L})), (61L)).Equals((Tuple.Create(true, 7L))));\n    Debug.Assert(SequentialSearch((new List<long>(new long[]{(long)9L, (long)10L, (long)17L, (long)19L, (long)22L, (long)39L, (long)48L, (long)56L})), (48L)).Equals((Tuple.Create(true, 6L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check if the elements of a given list are unique or not.\n    public static bool AllUnique(List<long> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(AllUnique((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static List<long> SubList(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)-3L, (long)-3L, (long)-3L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)1L, (long)2L})), (new List<long>(new long[]{(long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-2L, (long)-2L}))));\n    Debug.Assert(SubList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<long>(new long[]{(long)40L, (long)50L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static bool Validate(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Validate((1234L)) == (true));\n    Debug.Assert(Validate((51241L)) == (false));\n    Debug.Assert(Validate((321L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static bool CheckElement(List<object> list, object element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"orange\", (string)\"black\", (string)\"white\"})), (object(\"blue\"))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (object(7L))) == (false));\n    Debug.Assert(CheckElement((new List<object>(new string[]{(string)\"green\", (string)\"green\", (string)\"green\", (string)\"green\"})), (object(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static bool TextMatchTwoThree(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchTwoThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n    public static long MaxSubArraySumRepeated(List<long> a, long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)10L, (long)20L, (long)-30L, (long)-1L})), (4L), (3L)) == (30L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)10L, (long)20L})), (3L), (2L)) == (59L));\n    Debug.Assert(MaxSubArraySumRepeated((new List<long>(new long[]{(long)-1L, (long)-2L, (long)-3L})), (3L), (3L)) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long SquareSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareSum((2L)) == (20L));\n    Debug.Assert(SquareSum((3L)) == (56L));\n    Debug.Assert(SquareSum((4L)) == (120L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Tuple<long, List<long>> MaxLength(List<List<long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)10L, (long)12L, (long)14L, (long)15L})))));\n    Debug.Assert(MaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)15L, (long)20L, (long)25L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)15L, (long)20L, (long)25L})))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long CountNoOfWays(long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountNoOfWays((2L), (4L)) == (16L));\n    Debug.Assert(CountNoOfWays((3L), (2L)) == (6L));\n    Debug.Assert(CountNoOfWays((4L), (4L)) == (228L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long Find(long n, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Find((10L), (3L)) == (3L));\n    Debug.Assert(Find((4L), (2L)) == (2L));\n    Debug.Assert(Find((20L), (5L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float OthersideRightangle(long w, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OthersideRightangle((7L), (8L)) == (10.63014581273465f));\n    Debug.Assert(OthersideRightangle((3L), (4L)) == (float)5L);\n    Debug.Assert(OthersideRightangle((7L), (15L)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long SumDiv(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDiv((8L)) == (7L));\n    Debug.Assert(SumDiv((12L)) == (16L));\n    Debug.Assert(SumDiv((7L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count inversions in a list.\n    public static long GetInvCount(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)20L, (long)6L, (long)4L, (long)5L}))) == (5L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(GetInvCount((new List<long>(new long[]{(long)1L, (long)2L, (long)5L, (long)6L, (long)1L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Tuple<string, long> MaxAggregate(List<Tuple<string, long>> stdata) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 90L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 88L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 7L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 122L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 84L)}))).Equals((Tuple.Create(\"Juan Whelan\", 212L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 50L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 48L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 37L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 22L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 14L)}))).Equals((Tuple.Create(\"Juan Whelan\", 72L))));\n    Debug.Assert(MaxAggregate((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 10L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 20L), (Tuple<string, long>)Tuple.Create(\"Peter Nichols\", 30L), (Tuple<string, long>)Tuple.Create(\"Juan Whelan\", 40L), (Tuple<string, long>)Tuple.Create(\"Sabah Colley\", 50L)}))).Equals((Tuple.Create(\"Sabah Colley\", 70L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find element at a given index after number of rotations.\n    public static long FindElement(List<long> arr, List<List<long>> ranges, long rotations, long index) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)2L}), (List<long>)new List<long>(new long[]{(long)0L, (long)3L})})), (2L), (1L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (2L)) == (3L));\n    Debug.Assert(FindElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)0L, (long)2L})})), (1L), (1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Tuple<string, string> StartWithp(List<string> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python PHP\", (string)\"Java JavaScript\", (string)\"c c++\"}))).Equals((Tuple.Create(\"Python\", \"PHP\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Python Programming\", (string)\"Java Programming\"}))).Equals((Tuple.Create(\"Python\", \"Programming\"))));\n    Debug.Assert(StartWithp((new List<string>(new string[]{(string)\"Pqrst Pqr\", (string)\"qrstuv\"}))).Equals((Tuple.Create(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long MaxSumIncreasingSubseq(List<long> a, long n, long index, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (4L), (6L)) == (11L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)1L, (long)101L, (long)2L, (long)3L, (long)100L, (long)4L, (long)5L})), (7L), (2L), (5L)) == (7L));\n    Debug.Assert(MaxSumIncreasingSubseq((new List<long>(new long[]{(long)11L, (long)15L, (long)19L, (long)21L, (long)26L, (long)28L, (long)31L})), (7L), (2L), (4L)) == (71L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static List<long> LargeProduct(List<long> nums1, List<long> nums2, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (3L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L}))));\n    Debug.Assert(LargeProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)3L, (long)6L, (long)8L, (long)9L, (long)10L, (long)6L})), (5L)).Equals((new List<long>(new long[]{(long)60L, (long)54L, (long)50L, (long)48L, (long)45L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the maximum of two numbers.\n    public static long Maximum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maximum((5L), (10L)) == (10L));\n    Debug.Assert(Maximum((-1L), (-2L)) == (-1L));\n    Debug.Assert(Maximum((9L), (7L)) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static List<string> StringToTuple(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(StringToTuple((\"python 3.0\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\", (string)\"3\", (string)\".\", (string)\"0\"}))));\n    Debug.Assert(StringToTuple((\"item1\")).Equals((new List<string>(new string[]{(string)\"i\", (string)\"t\", (string)\"e\", (string)\"m\", (string)\"1\"}))));\n    Debug.Assert(StringToTuple((\"15.10\")).Equals((new List<string>(new string[]{(string)\"1\", (string)\"5\", (string)\".\", (string)\"1\", (string)\"0\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the highest power of 2 that is less than or equal to n.\n    public static long HighestPowerOf2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HighestPowerOf2((10L)) == (8L));\n    Debug.Assert(HighestPowerOf2((19L)) == (16L));\n    Debug.Assert(HighestPowerOf2((32L)) == (32L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long FindLucas(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLucas((9L)) == (76L));\n    Debug.Assert(FindLucas((4L)) == (7L));\n    Debug.Assert(FindLucas((3L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static List<string> AddString(List<object> list_, string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddString((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (\"temp{0}\")).Equals((new List<string>(new string[]{(string)\"temp1\", (string)\"temp2\", (string)\"temp3\", (string)\"temp4\"}))));\n    Debug.Assert(AddString((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"})), (\"python{0}\")).Equals((new List<string>(new string[]{(string)\"pythona\", (string)\"pythonb\", (string)\"pythonc\", (string)\"pythond\"}))));\n    Debug.Assert(AddString((new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})), (\"string{0}\")).Equals((new List<string>(new string[]{(string)\"string5\", (string)\"string6\", (string)\"string7\", (string)\"string8\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static List<Dictionary<string,Dictionary<string,long>>> ConvertListDictionary(List<string> l1, List<string> l2, List<long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"S001\", (string)\"S002\", (string)\"S003\", (string)\"S004\"})), (new List<string>(new string[]{(string)\"Adina Park\", (string)\"Leyton Marsh\", (string)\"Duncan Boyle\", (string)\"Saim Richards\"})), (new List<long>(new long[]{(long)85L, (long)98L, (long)89L, (long)92L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S001\", new Dictionary<string,long>(){{\"Adina Park\", 85L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S002\", new Dictionary<string,long>(){{\"Leyton Marsh\", 98L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S003\", new Dictionary<string,long>(){{\"Duncan Boyle\", 89L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"S004\", new Dictionary<string,long>(){{\"Saim Richards\", 92L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"abc\", (string)\"def\", (string)\"ghi\", (string)\"jkl\"})), (new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\", (string)\"programs\"})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"abc\", new Dictionary<string,long>(){{\"python\", 100L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"def\", new Dictionary<string,long>(){{\"program\", 200L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"ghi\", new Dictionary<string,long>(){{\"language\", 300L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"jkl\", new Dictionary<string,long>(){{\"programs\", 400L}}}}}))));\n    Debug.Assert(ConvertListDictionary((new List<string>(new string[]{(string)\"A1\", (string)\"A2\", (string)\"A3\", (string)\"A4\"})), (new List<string>(new string[]{(string)\"java\", (string)\"C\", (string)\"C++\", (string)\"DBMS\"})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L}))).Equals((new List<Dictionary<string,Dictionary<string,long>>>(new Dictionary<string,Dictionary<string,long>>[]{(Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A1\", new Dictionary<string,long>(){{\"java\", 10L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A2\", new Dictionary<string,long>(){{\"C\", 20L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A3\", new Dictionary<string,long>(){{\"C++\", 30L}}}}, (Dictionary<string,Dictionary<string,long>>)new Dictionary<string,Dictionary<string,long>>(){{\"A4\", new Dictionary<string,long>(){{\"DBMS\", 40L}}}}}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long GetMaxSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMaxSum((60L)) == (106L));\n    Debug.Assert(GetMaxSum((10L)) == (12L));\n    Debug.Assert(GetMaxSum((2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Tuple<long, List<long>> MaxLengthList(List<List<long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))).Equals((Tuple.Create(3L, new List<long>(new long[]{(long)13L, (long)15L, (long)17L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L})}))).Equals((Tuple.Create(5L, new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})))));\n    Debug.Assert(MaxLengthList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L})}))).Equals((Tuple.Create(4L, new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static bool CheckDistinct(List<long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L, (long)1L, (long)4L}))) == (false));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)1L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckDistinct((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first non-repeated character in a given string.\n    public static string FirstNonRepeatingCharacter(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstNonRepeatingCharacter((\"abcabc\")).Equals(null));\n    Debug.Assert(FirstNonRepeatingCharacter((\"abc\")).Equals((\"a\")));\n    Debug.Assert(FirstNonRepeatingCharacter((\"ababc\")).Equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static string CheckChar(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckChar((\"abba\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"a\")).Equals((\"Valid\")));\n    Debug.Assert(CheckChar((\"abcd\")).Equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float MedianNumbers(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianNumbers((25L), (55L), (65L)) == (55.0f));\n    Debug.Assert(MedianNumbers((20L), (10L), (30L)) == (20.0f));\n    Debug.Assert(MedianNumbers((15L), (45L), (75L)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long SumOfDigits(List<object> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)2L, (long)56L}))) == (14L));\n    Debug.Assert(SumOfDigits((new List<object>(new List<long>[]{(List<long>)new List<object>(new object[]{10L, 20L, 4L, 5L, \"b\", 70L, \"a\"})}))) == (19L));\n    Debug.Assert(SumOfDigits((new List<object>(new long[]{(long)10L, (long)20L, (long)-4L, (long)5L, (long)-70L}))) == (19L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Tuple<long, long, long, long> BitwiseXor(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BitwiseXor((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(15L, 6L, 5L, 10L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(11L, 5L, 7L, 10L)), (Tuple.Create(6L, 3L, 4L, 4L))).Equals((Tuple.Create(13L, 6L, 3L, 14L))));\n    Debug.Assert(BitwiseXor((Tuple.Create(12L, 6L, 8L, 11L)), (Tuple.Create(7L, 4L, 5L, 6L))).Equals((Tuple.Create(11L, 2L, 13L, 13L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to identify non-prime numbers.\n    public static bool IsNotPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNotPrime((2L)) == (false));\n    Debug.Assert(IsNotPrime((10L)) == (true));\n    Debug.Assert(IsNotPrime((35L)) == (true));\n    Debug.Assert(IsNotPrime((37L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long ExtractFreq(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(4L, 3L), (Tuple<long, long>)Tuple.Create(5L, 6L)}))) == (3L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 15L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(5L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L)}))) == (4L));\n    Debug.Assert(ExtractFreq((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 16L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(6L, 9L)}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static List<List<long>> AddNestedTuples(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)10L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)8L, (long)13L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)12L}), (List<long>)new List<long>(new long[]{(long)9L, (long)16L}), (List<long>)new List<long>(new long[]{(long)5L, (long)12L}), (List<long>)new List<long>(new long[]{(long)10L, (long)15L})}))));\n    Debug.Assert(AddNestedTuples((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)14L}), (List<long>)new List<long>(new long[]{(long)11L, (long)18L}), (List<long>)new List<long>(new long[]{(long)7L, (long)14L}), (List<long>)new List<long>(new long[]{(long)12L, (long)17L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum of two numbers.\n    public static long Minimum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Minimum((1L), (2L)) == (1L));\n    Debug.Assert(Minimum((-5L), (-4L)) == (-5L));\n    Debug.Assert(Minimum((0L), (0L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find whether the parity of a given number is odd.\n    public static bool FindParity(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindParity((12L)) == (false));\n    Debug.Assert(FindParity((7L)) == (true));\n    Debug.Assert(FindParity((10L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static object RearrangeBigger(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RearrangeBigger((12L)).Equals((object(21L))));\n    Debug.Assert(RearrangeBigger((10L)).Equals((object(false))));\n    Debug.Assert(RearrangeBigger((102L)).Equals((object(120L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n    public static List<List<long>> KSmallestPairs(List<long> nums1, List<long> nums2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))));\n    Debug.Assert(KSmallestPairs((new List<long>(new long[]{(long)1L, (long)3L, (long)7L})), (new List<long>(new long[]{(long)2L, (long)4L, (long)6L})), (7L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)2L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long MinProductTuple(List<Tuple<long, long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 7L), (Tuple<long, long>)Tuple.Create(2L, 6L), (Tuple<long, long>)Tuple.Create(1L, 8L), (Tuple<long, long>)Tuple.Create(4L, 9L)}))) == (8L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 20L), (Tuple<long, long>)Tuple.Create(15L, 2L), (Tuple<long, long>)Tuple.Create(5L, 10L)}))) == (30L));\n    Debug.Assert(MinProductTuple((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(11L, 44L), (Tuple<long, long>)Tuple.Create(10L, 15L), (Tuple<long, long>)Tuple.Create(20L, 5L), (Tuple<long, long>)Tuple.Create(12L, 9L)}))) == (100L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static string SnakeToCamel(string word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SnakeToCamel((\"android_tv\")).Equals((\"AndroidTv\")));\n    Debug.Assert(SnakeToCamel((\"google_pixel\")).Equals((\"GooglePixel\")));\n    Debug.Assert(SnakeToCamel((\"apple_watch\")).Equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove odd numbers from a given list.\n    public static List<long> RemoveOdd(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)2L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L, (long)6L}))));\n    Debug.Assert(RemoveOdd((new List<long>(new long[]{(long)10L, (long)20L, (long)3L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static List<object> ExtractNthElement(List<Tuple<string, long, long>> list1, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (0L)).Equals((new List<object>(new string[]{(string)\"Greyson Fulton\", (string)\"Brady Kent\", (string)\"Wyatt Knott\", (string)\"Beau Turnbull\"}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (2L)).Equals((new List<object>(new long[]{(long)99L, (long)96L, (long)94L, (long)98L}))));\n    Debug.Assert(ExtractNthElement((new List<Tuple<string, long, long>>(new Tuple<string, long, long>[]{(Tuple<string, long, long>)Tuple.Create(\"Greyson Fulton\", 98L, 99L), (Tuple<string, long, long>)Tuple.Create(\"Brady Kent\", 97L, 96L), (Tuple<string, long, long>)Tuple.Create(\"Wyatt Knott\", 91L, 94L), (Tuple<string, long, long>)Tuple.Create(\"Beau Turnbull\", 94L, 98L)})), (1L)).Equals((new List<object>(new long[]{(long)98L, (long)97L, (long)91L, (long)94L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether any value in a sequence exists in a sequence or not.\n    public static bool Overlapping(List<long> list1, List<long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(Overlapping((new List<long>(new long[]{(long)1L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find a pair with highest product from a given list of integers.\n    public static Tuple<long, long> MaxProduct(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)0L, (long)8L, (long)4L}))).Equals((Tuple.Create(7L, 8L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)0L, (long)-1L, (long)-2L, (long)-4L, (long)5L, (long)0L, (long)-6L}))).Equals((Tuple.Create(-4L, -6L))));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((Tuple.Create(2L, 3L))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4612,7 +1648,7 @@
     "language": "cs",
     "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find common first element in given list of lists.\n    public static List<List<string>> GroupTuples(List<List<string>> Input) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"w\", (string)\"t\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"w\", (string)\"t\"})}))));\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"e\"})}))));\n    Debug.Assert(GroupTuples((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"h\", (string)\"i\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"f\", (string)\"g\", (string)\"g\"}), (List<string>)new List<string>(new string[]{(string)\"h\", (string)\"i\"})}))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4620,13 +1656,2977 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "cs",
-    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static List<long> MergeSortedList(List<long> num1, List<long> num2, List<long> num3) {\n",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the element of a list having maximum length.\n    public static List<object> FindMax(List<List<object>> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)25L, (long)24L, (long)15L, (long)4L, (long)5L, (long)29L, (long)110L})), (new List<long>(new long[]{(long)19L, (long)20L, (long)11L, (long)56L, (long)25L, (long)233L, (long)154L})), (new List<long>(new long[]{(long)24L, (long)26L, (long)54L, (long)48L}))).Equals((new List<long>(new long[]{(long)4L, (long)5L, (long)11L, (long)15L, (long)19L, (long)20L, (long)24L, (long)24L, (long)25L, (long)25L, (long)26L, (long)29L, (long)48L, (long)54L, (long)56L, (long)110L, (long)154L, (long)233L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)6L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)7L, (long)11L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)7L, (long)8L, (long)12L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)5L, (long)6L, (long)7L, (long)7L, (long)8L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    Debug.Assert(MergeSortedList((new List<long>(new long[]{(long)18L, (long)14L, (long)10L, (long)9L, (long)8L, (long)7L, (long)9L, (long)3L, (long)2L, (long)4L, (long)1L})), (new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L})), (new List<long>(new long[]{(long)12L, (long)74L, (long)9L, (long)50L, (long)61L, (long)41L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)7L, (long)8L, (long)9L, (long)9L, (long)9L, (long)10L, (long)12L, (long)14L, (long)14L, (long)18L, (long)22L, (long)25L, (long)25L, (long)35L, (long)41L, (long)50L, (long)58L, (long)61L, (long)65L, (long)74L, (long)75L, (long)85L}))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMax((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"})}))).Equals((new List<object>(new string[]{(string)\"A\", (string)\"B\", (string)\"C\"}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L, (long)2L, (long)3L}))));\n    Debug.Assert(FindMax((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L})}))).Equals((new List<object>(new long[]{(long)1L, (long)5L, (long)6L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the cube sum of first n even natural numbers.\n    public static long CubeSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeSum((2L)) == (72L));\n    Debug.Assert(CubeSum((3L)) == (288L));\n    Debug.Assert(CubeSum((4L)) == (800L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static string ConcatenateTuple(Tuple<string, string, long, string> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ID\", \"is\", 4L, \"UTS\"))).Equals((\"ID-is-4-UTS\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"QWE\", \"is\", 4L, \"RTY\"))).Equals((\"QWE-is-4-RTY\")));\n    Debug.Assert(ConcatenateTuple((Tuple.Create(\"ZEN\", \"is\", 4L, \"OP\"))).Equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the average of cubes of first n natural numbers.\n    public static float FindAverageOfCube(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAverageOfCube((2L)) == (4.5f));\n    Debug.Assert(FindAverageOfCube((3L)) == (float)12L);\n    Debug.Assert(FindAverageOfCube((1L)) == (float)1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static List<string> ExtractRear(Tuple<string, string, string> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractRear((Tuple.Create(\"Mers\", \"for\", \"Vers\"))).Equals((new List<string>(new string[]{(string)\"s\", (string)\"r\", (string)\"s\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Avenge\", \"for\", \"People\"))).Equals((new List<string>(new string[]{(string)\"e\", (string)\"r\", (string)\"e\"}))));\n    Debug.Assert(ExtractRear((Tuple.Create(\"Gotta\", \"get\", \"go\"))).Equals((new List<string>(new string[]{(string)\"a\", (string)\"t\", (string)\"o\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long CountElementInList(List<List<object>> list1, object x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)11L}), (List<long>)new List<long>(new long[]{(long)1L, (long)15L, (long)7L})})), (object(1L))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"A\"))) == (3L));\n    Debug.Assert(CountElementInList((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"A\", (string)\"B\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"C\"}), (List<string>)new List<string>(new string[]{(string)\"A\", (string)\"D\", (string)\"E\"}), (List<string>)new List<string>(new string[]{(string)\"B\", (string)\"C\", (string)\"D\"})})), (object(\"E\"))) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static List<long> FilterOddnumbers(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)10L, (long)20L, (long)45L, (long)67L, (long)84L, (long)93L}))).Equals((new List<long>(new long[]{(long)45L, (long)67L, (long)93L}))));\n    Debug.Assert(FilterOddnumbers((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)8L, (long)6L, (long)4L, (long)3L}))).Equals((new List<long>(new long[]{(long)5L, (long)7L, (long)9L, (long)3L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static string ChangeDateFormat(string dt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ChangeDateFormat((\"2026-01-02\")).Equals((\"02-01-2026\")));\n    Debug.Assert(ChangeDateFormat((\"2020-11-13\")).Equals((\"13-11-2020\")));\n    Debug.Assert(ChangeDateFormat((\"2021-04-26\")).Equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list by using shell sort.\n    public static List<long> ShellSort(List<long> my_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)12L, (long)23L, (long)4L, (long)5L, (long)3L, (long)2L, (long)12L, (long)81L, (long)56L, (long)95L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)12L, (long)12L, (long)23L, (long)56L, (long)81L, (long)95L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)24L, (long)22L, (long)39L, (long)34L, (long)87L, (long)73L, (long)68L}))).Equals((new List<long>(new long[]{(long)22L, (long)24L, (long)34L, (long)39L, (long)68L, (long)73L, (long)87L}))));\n    Debug.Assert(ShellSort((new List<long>(new long[]{(long)32L, (long)30L, (long)16L, (long)96L, (long)82L, (long)83L, (long)74L}))).Equals((new List<long>(new long[]{(long)16L, (long)30L, (long)32L, (long)74L, (long)82L, (long)83L, (long)96L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Tuple<long, long, long, long> AndTuples(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AndTuples((Tuple.Create(10L, 4L, 6L, 9L)), (Tuple.Create(5L, 2L, 3L, 3L))).Equals((Tuple.Create(0L, 0L, 2L, 1L))));\n    Debug.Assert(AndTuples((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(5L, 6L, 7L, 8L))).Equals((Tuple.Create(1L, 2L, 3L, 0L))));\n    Debug.Assert(AndTuples((Tuple.Create(8L, 9L, 11L, 12L)), (Tuple.Create(7L, 13L, 14L, 17L))).Equals((Tuple.Create(0L, 9L, 10L, 0L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long ParabolaDirectrix(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ParabolaDirectrix((5L), (3L), (2L)) == (-198L));\n    Debug.Assert(ParabolaDirectrix((9L), (8L), (4L)) == (-2336L));\n    Debug.Assert(ParabolaDirectrix((2L), (4L), (6L)) == (-130L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Nullable<bool> CommonElement(List<object> list1, List<object> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))).Equals(true));\n    Debug.Assert(CommonElement((new List<object>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<object>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L}))).Equals(null));\n    Debug.Assert(CommonElement((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"})), (new List<object>(new string[]{(string)\"d\", (string)\"b\", (string)\"e\"}))).Equals(true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float MedianTrapezium(long base1, long base2, long height) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MedianTrapezium((15L), (25L), (35L)) == (float)20L);\n    Debug.Assert(MedianTrapezium((10L), (20L), (30L)) == (float)15L);\n    Debug.Assert(MedianTrapezium((6L), (9L), (4L)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given list.\n    public static bool CheckGreater(List<long> arr, long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (4L)) == (false));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (8L)) == (true));\n    Debug.Assert(CheckGreater((new List<long>(new long[]{(long)9L, (long)7L, (long)4L, (long)8L, (long)6L, (long)1L})), (11L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static bool TextMatchOne(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last digit of a given number.\n    public static long LastDigit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigit((123L)) == (3L));\n    Debug.Assert(LastDigit((25L)) == (5L));\n    Debug.Assert(LastDigit((30L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to return the negative numbers in a list.\n    public static List<long> NegNos(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)4L, (long)5L, (long)-6L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-6L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)-1L, (long)-2L}))));\n    Debug.Assert(NegNos((new List<long>(new long[]{(long)-7L, (long)-6L, (long)8L, (long)9L}))).Equals((new List<long>(new long[]{(long)-7L, (long)-6L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static string RemoveOdd(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveOdd((\"python\")).Equals((\"yhn\")));\n    Debug.Assert(RemoveOdd((\"program\")).Equals((\"rga\")));\n    Debug.Assert(RemoveOdd((\"language\")).Equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long CountBidirectional(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (3L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 3L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 1L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (2L));\n    Debug.Assert(CountBidirectional((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(9L, 2L), (Tuple<long, long>)Tuple.Create(6L, 5L), (Tuple<long, long>)Tuple.Create(2L, 1L)}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long MultipleToSingle(List<long> L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)11L, (long)33L, (long)50L}))) == (113350L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (-123456L));\n    Debug.Assert(MultipleToSingle((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L}))) == (10152025L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Tuple<long, long, string> FindAdverbPosition(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbPosition((\"clearly!! we can see the sky\")).Equals((Tuple.Create(0L, 7L, \"clearly\"))));\n    Debug.Assert(FindAdverbPosition((\"seriously!! there are many roses\")).Equals((Tuple.Create(0L, 9L, \"seriously\"))));\n    Debug.Assert(FindAdverbPosition((\"unfortunately!! sita is going to home\")).Equals((Tuple.Create(0L, 13L, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long SurfaceareaCube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCube((5L)) == (150L));\n    Debug.Assert(SurfaceareaCube((3L)) == (54L));\n    Debug.Assert(SurfaceareaCube((10L)) == (600L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the ration of positive numbers in a list of integers.\n    public static float PositiveCount(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.54f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (0.69f));\n    Debug.Assert(PositiveCount((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L}))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the largest negative number from the given list.\n    public static long LargestNeg(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-4L, (long)-6L}))) == (-6L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)-8L, (long)-9L}))) == (-9L));\n    Debug.Assert(LargestNeg((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)-1L}))) == (-1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static List<List<long>> TrimTuple(List<List<long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (2L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)2L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)3L, (long)2L, (long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)9L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)9L, (long)1L, (long)2L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L, (long)2L, (long)1L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)4L, (long)9L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)8L, (long)2L, (long)1L})}))));\n    Debug.Assert(TrimTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)4L, (long)9L}), (List<long>)new List<long>(new long[]{(long)11L, (long)8L, (long)12L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)1L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L, (long)9L, (long)7L})})), (1L)).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)4L}), (List<long>)new List<long>(new long[]{(long)8L, (long)12L}), (List<long>)new List<long>(new long[]{(long)1L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)9L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static List<List<long>> IndexMultiplication(List<List<long>> test_tup1, List<List<long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)10L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)3L, (long)9L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)21L}), (List<long>)new List<long>(new long[]{(long)12L, (long)45L}), (List<long>)new List<long>(new long[]{(long)2L, (long)9L}), (List<long>)new List<long>(new long[]{(long)7L, (long)30L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)3L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)11L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)4L, (long)10L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)14L, (long)32L}), (List<long>)new List<long>(new long[]{(long)20L, (long)60L}), (List<long>)new List<long>(new long[]{(long)6L, (long)20L}), (List<long>)new List<long>(new long[]{(long)16L, (long)44L})}))));\n    Debug.Assert(IndexMultiplication((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)4L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)12L})})), (new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)5L, (long)11L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L})}))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)24L, (long)45L}), (List<long>)new List<long>(new long[]{(long)30L, (long)77L}), (List<long>)new List<long>(new long[]{(long)12L, (long)33L}), (List<long>)new List<long>(new long[]{(long)27L, (long)60L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the occurence of all elements of list in a tuple.\n    public static long CountOccurrence(object tup, List<object> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountOccurrence(Tuple.Create(\"a\", \"a\", \"c\", \"b\", \"d\"), (new List<object>(new string[]{(string)\"a\", (string)\"b\"}))) == (3L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 1L, 4L, 6L, 7L, 1L, 4L), (new List<object>(new long[]{(long)1L, (long)4L, (long)7L}))) == (6L));\n    Debug.Assert(CountOccurrence(Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L), (new List<object>(new long[]{(long)1L, (long)2L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static List<long> CubeNums(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)8L, (long)27L, (long)64L, (long)125L, (long)216L, (long)343L, (long)512L, (long)729L, (long)1000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(CubeNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)1728L, (long)3375L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long CalSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CalSum((9L)) == (49L));\n    Debug.Assert(CalSum((10L)) == (66L));\n    Debug.Assert(CalSum((11L)) == (88L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static List<string> ExtractString(List<string> str, long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (8L)).Equals((new List<string>(new string[]{(string)\"practice\", (string)\"solution\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (6L)).Equals((new List<string>(new string[]{(string)\"Python\"}))));\n    Debug.Assert(ExtractString((new List<string>(new string[]{(string)\"Python\", (string)\"list\", (string)\"exercises\", (string)\"practice\", (string)\"solution\"})), (9L)).Equals((new List<string>(new string[]{(string)\"exercises\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static string RemoveWhitespaces(string text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveWhitespaces((\" Google    Flutter \")).Equals((\"GoogleFlutter\")));\n    Debug.Assert(RemoveWhitespaces((\" Google    Dart \")).Equals((\"GoogleDart\")));\n    Debug.Assert(RemoveWhitespaces((\" iOS    Swift \")).Equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long LossAmount(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LossAmount((1500L), (1200L)) == (0L));\n    Debug.Assert(LossAmount((100L), (200L)) == (100L));\n    Debug.Assert(LossAmount((2000L), (5000L)) == (3000L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of even factors of a number.\n    public static long Sumoffactors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sumoffactors((18L)) == (26L));\n    Debug.Assert(Sumoffactors((30L)) == (48L));\n    Debug.Assert(Sumoffactors((6L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static bool TextMatchWordz(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordz((\"pythonz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"xyz.\")) == (true));\n    Debug.Assert(TextMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static bool CheckMonthnumbNumber(long monthnum2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumbNumber((5L)) == (true));\n    Debug.Assert(CheckMonthnumbNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumbNumber((6L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static List<string> ReverseStringList(List<string> stringlist) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"Red\", (string)\"Green\", (string)\"Blue\", (string)\"White\", (string)\"Black\"}))).Equals((new List<string>(new string[]{(string)\"deR\", (string)\"neerG\", (string)\"eulB\", (string)\"etihW\", (string)\"kcalB\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"john\", (string)\"amal\", (string)\"joel\", (string)\"george\"}))).Equals((new List<string>(new string[]{(string)\"nhoj\", (string)\"lama\", (string)\"leoj\", (string)\"egroeg\"}))));\n    Debug.Assert(ReverseStringList((new List<string>(new string[]{(string)\"jack\", (string)\"john\", (string)\"mary\"}))).Equals((new List<string>(new string[]{(string)\"kcaj\", (string)\"nhoj\", (string)\"yram\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sublist having minimum length.\n    public static List<object> FindMin(List<List<object>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L})}))).Equals((new List<object>(new long[]{(long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)7L, (long)8L})}))).Equals((new List<object>(new long[]{(long)1L, (long)1L}))));\n    Debug.Assert(FindMin((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"})}))).Equals((new List<object>(new string[]{(string)\"x\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long RectangleArea(long l, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RectangleArea((10L), (20L)) == (200L));\n    Debug.Assert(RectangleArea((10L), (5L)) == (50L));\n    Debug.Assert(RectangleArea((4L), (2L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static string RemoveUppercase(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveUppercase((\"cAstyoUrFavoRitETVshoWs\")).Equals((\"cstyoravoitshos\")));\n    Debug.Assert(RemoveUppercase((\"wAtchTheinTernEtrAdIo\")).Equals((\"wtchheinerntrdo\")));\n    Debug.Assert(RemoveUppercase((\"VoicESeaRchAndreComMendaTionS\")).Equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to get the first element of each sublist.\n    public static List<long> Extract(List<List<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)6L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))).Equals((new List<long>(new long[]{(long)1L, (long)4L}))));\n    Debug.Assert(Extract((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)9L, (long)8L, (long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))).Equals((new List<long>(new long[]{(long)9L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the upper case characters in a given string.\n    public static long UpperCtr(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UpperCtr((\"PYthon\")) == (1L));\n    Debug.Assert(UpperCtr((\"BigData\")) == (1L));\n    Debug.Assert(UpperCtr((\"program\")) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product sublist of the given list.\n    public static long MaxSubarrayProduct(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)1L, (long)-2L, (long)-3L, (long)0L, (long)7L, (long)-8L, (long)-2L}))) == (112L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)6L, (long)-3L, (long)-10L, (long)0L, (long)2L}))) == (180L));\n    Debug.Assert(MaxSubarrayProduct((new List<long>(new long[]{(long)-2L, (long)-40L, (long)0L, (long)-2L, (long)-3L}))) == (80L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static bool CheckValue(Dictionary<string,long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (10L)) == (false));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (12L)) == (true));\n    Debug.Assert(CheckValue((new Dictionary<string,long>(){{\"Cierra Vega\", 12L}, {\"Alden Cantrell\", 12L}, {\"Kierra Gentry\", 12L}, {\"Pierre Cox\", 12L}}), (5L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static Dictionary<string,string> DropEmpty(Dictionary<string,string> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", \"Green\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", \"Red\"}, {\"c2\", null}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c1\", \"Red\"}})));\n    Debug.Assert(DropEmpty((new Dictionary<string,string>(){{\"c1\", null}, {\"c2\", \"Green\"}, {\"c3\", null}})).Equals((new Dictionary<string,string>(){{\"c2\", \"Green\"}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n    public static long MaxProduct(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)3L, (long)100L, (long)4L, (long)5L, (long)150L, (long)6L}))) == (3000L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)4L, (long)42L, (long)55L, (long)68L, (long)80L}))) == (50265600L));\n    Debug.Assert(MaxProduct((new List<long>(new long[]{(long)10L, (long)22L, (long)9L, (long)33L, (long)21L, (long)50L, (long)41L, (long)60L}))) == (2460L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Tuple<long, long, long, long> AddPairwise(Tuple<long, long, long, long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddPairwise((Tuple.Create(1L, 5L, 7L, 8L, 10L))).Equals((Tuple.Create(6L, 12L, 15L, 18L))));\n    Debug.Assert(AddPairwise((Tuple.Create(2L, 6L, 8L, 9L, 11L))).Equals((Tuple.Create(8L, 14L, 17L, 20L))));\n    Debug.Assert(AddPairwise((Tuple.Create(3L, 7L, 9L, 10L, 12L))).Equals((Tuple.Create(10L, 16L, 19L, 22L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the product of the list multiplication modulo n.\n    public static long FindRemainder(List<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)100L, (long)10L, (long)5L, (long)25L, (long)35L, (long)14L})), (11L)) == (9L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)1L, (long)1L})), (1L)) == (0L));\n    Debug.Assert(FindRemainder((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (2L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given list contains consecutive numbers or not.\n    public static bool CheckConsecutive(List<long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (true));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)6L}))) == (false));\n    Debug.Assert(CheckConsecutive((new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static string ReplaceChar(string str1, string ch, string newch) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceChar((\"polygon\"), (\"y\"), (\"l\")).Equals((\"pollgon\")));\n    Debug.Assert(ReplaceChar((\"character\"), (\"c\"), (\"a\")).Equals((\"aharaater\")));\n    Debug.Assert(ReplaceChar((\"python\"), (\"l\"), (\"a\")).Equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static List<Tuple<string, long>> SortCounter(Dictionary<string,long> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 81L}, {\"Physics\", 83L}, {\"Chemistry\", 87L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 87L), (Tuple<string, long>)Tuple.Create(\"Physics\", 83L), (Tuple<string, long>)Tuple.Create(\"Math\", 81L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 400L}, {\"Physics\", 300L}, {\"Chemistry\", 250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Math\", 400L), (Tuple<string, long>)Tuple.Create(\"Physics\", 300L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 250L)}))));\n    Debug.Assert(SortCounter((new Dictionary<string,long>(){{\"Math\", 900L}, {\"Physics\", 1000L}, {\"Chemistry\", 1250L}})).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Chemistry\", 1250L), (Tuple<string, long>)Tuple.Create(\"Physics\", 1000L), (Tuple<string, long>)Tuple.Create(\"Math\", 900L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the largest and smallest value in a given list.\n    public static long BigSum(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)-1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigSum((new List<long>(new long[]{(long)2L, (long)3L, (long)6L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert the given string to lower case.\n    public static string IsLower(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsLower((\"InValid\")).Equals((\"invalid\")));\n    Debug.Assert(IsLower((\"TruE\")).Equals((\"true\")));\n    Debug.Assert(IsLower((\"SenTenCE\")).Equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static string RemoveLowercase(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLowercase((\"PYTHon\")).Equals((\"PYTH\")));\n    Debug.Assert(RemoveLowercase((\"FInD\")).Equals((\"FID\")));\n    Debug.Assert(RemoveLowercase((\"STRinG\")).Equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first digit of a given number.\n    public static long FirstDigit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstDigit((123L)) == (1L));\n    Debug.Assert(FirstDigit((456L)) == (4L));\n    Debug.Assert(FirstDigit((12L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static List<long> HeapQueueLargest(List<long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (3L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (2L)).Equals((new List<long>(new long[]{(long)85L, (long)75L}))));\n    Debug.Assert(HeapQueueLargest((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)22L, (long)58L})), (5L)).Equals((new List<long>(new long[]{(long)85L, (long)75L, (long)65L, (long)58L, (long)35L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of integers and only returns the odd ones.\n    public static List<long> Split(List<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)10L, (long)11L, (long)12L, (long)13L}))).Equals((new List<long>(new long[]{(long)11L, (long)13L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L}))).Equals((new List<long>(new long[]{(long)7L, (long)9L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long Difference(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Difference((3L)) == (30L));\n    Debug.Assert(Difference((5L)) == (210L));\n    Debug.Assert(Difference((2L)) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of pairs whose xor value is odd.\n    public static long FindOddPair(List<long> A, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)5L, (long)4L, (long)7L, (long)2L, (long)1L})), (5L)) == (6L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)7L, (long)2L, (long)8L, (long)1L, (long)0L, (long)5L, (long)11L})), (7L)) == (12L));\n    Debug.Assert(FindOddPair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (3L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static string ToggleString(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleString((\"Python\")).Equals((\"pYTHON\")));\n    Debug.Assert(ToggleString((\"Pangram\")).Equals((\"pANGRAM\")));\n    Debug.Assert(ToggleString((\"LIttLE\")).Equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the per-digit difference between two integers.\n    public static long DigitDistanceNums(long n1, long n2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DigitDistanceNums((1L), (2L)) == (1L));\n    Debug.Assert(DigitDistanceNums((23L), (56L)) == (6L));\n    Debug.Assert(DigitDistanceNums((123L), (256L)) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long MaxSubArraySum(List<long> a, long size) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-2L, (long)-3L, (long)4L, (long)-1L, (long)-2L, (long)1L, (long)5L, (long)-3L})), (8L)) == (7L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-3L, (long)-4L, (long)5L, (long)-2L, (long)-3L, (long)2L, (long)6L, (long)-4L})), (8L)) == (8L));\n    Debug.Assert(MaxSubArraySum((new List<long>(new long[]{(long)-4L, (long)-5L, (long)6L, (long)-3L, (long)-4L, (long)3L, (long)7L, (long)-5L})), (8L)) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static List<long> UnionElements(List<long> test_tup1, List<long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)5L, (long)7L, (long)4L, (long)10L}))).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)10L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))));\n    Debug.Assert(UnionElements((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L})), (new List<long>(new long[]{(long)13L, (long)15L, (long)16L, (long)17L}))).Equals((new List<long>(new long[]{(long)11L, (long)12L, (long)13L, (long)14L, (long)15L, (long)16L, (long)17L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the longest sublists.\n    public static long FindMaxLength(List<List<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L})}))) == (4L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)1L}), (List<long>)new List<long>(new long[]{(long)2L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L})}))) == (3L));\n    Debug.Assert(FindMaxLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)22L, (long)23L}), (List<long>)new List<long>(new long[]{(long)13L, (long)14L, (long)15L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L})}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static List<string> ExtractValues(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractValues((\"\"Python\", \"PHP\", \"Java\"\")).Equals((new List<string>(new string[]{(string)\"Python\", (string)\"PHP\", (string)\"Java\"}))));\n    Debug.Assert(ExtractValues((\"\"python\",\"program\",\"language\"\")).Equals((new List<string>(new string[]{(string)\"python\", (string)\"program\", (string)\"language\"}))));\n    Debug.Assert(ExtractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).Equals((new List<string>(new string[]{(string)\"red\", (string)\"blue\", (string)\"green\", (string)\"yellow\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long CountPairs(List<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (3L)) == (2L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (4L)) == (0L));\n    Debug.Assert(CountPairs((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (5L)) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to split a string into characters.\n    public static List<string> Split(string word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((\"python\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"y\", (string)\"t\", (string)\"h\", (string)\"o\", (string)\"n\"}))));\n    Debug.Assert(Split((\"Name\")).Equals((new List<string>(new string[]{(string)\"N\", (string)\"a\", (string)\"m\", (string)\"e\"}))));\n    Debug.Assert(Split((\"program\")).Equals((new List<string>(new string[]{(string)\"p\", (string)\"r\", (string)\"o\", (string)\"g\", (string)\"r\", (string)\"a\", (string)\"m\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long SumDigits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumDigits((345L)) == (12L));\n    Debug.Assert(SumDigits((12L)) == (3L));\n    Debug.Assert(SumDigits((97L)) == (16L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static bool IssortList(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)16L, (long)17L}))) == (true));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)12L, (long)14L, (long)20L, (long)17L}))) == (false));\n    Debug.Assert(IssortList((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)6L, (long)8L, (long)10L, (long)15L, (long)14L, (long)20L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static List<Dictionary<null,null>> EmptyList(long length) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EmptyList((5L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((6L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    Debug.Assert(EmptyList((7L)).Equals((new List<List<Dictionary<null,null>>()}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static List<List<string>> SortSublists(List<List<string>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"white\", (string)\"black\", (string)\"orange\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"white\"}), (List<string>)new List<string>(new string[]{(string)\"black\", (string)\"orange\", (string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"black\"}), (List<string>)new List<string>(new string[]{(string)\"green\", (string)\"orange\"}), (List<string>)new List<string>(new string[]{(string)\"white\"})}))));\n    Debug.Assert(SortSublists((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"f\", (string)\"e\"})}))).Equals((new List<List<string>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\", (string)\"d\"}), (List<string>)new List<string>(new string[]{(string)\"g\", (string)\"h\"}), (List<string>)new List<string>(new string[]{(string)\"e\", (string)\"f\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check if a given number is one less than twice its reverse.\n    public static bool Checks(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Checks((70L)) == (false));\n    Debug.Assert(Checks((23L)) == (false));\n    Debug.Assert(Checks((73L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to remove duplicate numbers from a given number of lists.\n    public static List<long> TwoUniqueNums(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)3L, (long)4L, (long)5L}))));\n    Debug.Assert(TwoUniqueNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to calculate the product of the unique numbers in a given list.\n    public static long UniqueProduct(List<long> list_data) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)20L, (long)50L, (long)60L, (long)40L}))) == (720000000L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L}))) == (6L));\n    Debug.Assert(UniqueProduct((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)0L, (long)1L, (long)1L}))) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float SurfaceareaCylinder(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceareaCylinder((10L), (5L)) == (942.45f));\n    Debug.Assert(SurfaceareaCylinder((4L), (5L)) == (226.18800000000002f));\n    Debug.Assert(SurfaceareaCylinder((4L), (10L)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether a list is sublist of another or not.\n    public static bool IsSubArray(List<long> A, List<long> B) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)4L, (long)3L, (long)5L})), (new List<long>(new long[]{(long)1L, (long)2L}))) == (false));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)2L, (long)1L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)1L}))) == (true));\n    Debug.Assert(IsSubArray((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)2L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)0L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last digit in factorial of a given number.\n    public static long LastDigitFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LastDigitFactorial((4L)) == (4L));\n    Debug.Assert(LastDigitFactorial((21L)) == (0L));\n    Debug.Assert(LastDigitFactorial((30L)) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static List<long> InterleaveLists(List<long> list1, List<long> list2, List<long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L, (long)50L, (long)60L, (long)70L})), (new List<long>(new long[]{(long)100L, (long)200L, (long)300L, (long)400L, (long)500L, (long)600L, (long)700L}))).Equals((new List<long>(new long[]{(long)1L, (long)10L, (long)100L, (long)2L, (long)20L, (long)200L, (long)3L, (long)30L, (long)300L, (long)4L, (long)40L, (long)400L, (long)5L, (long)50L, (long)500L, (long)6L, (long)60L, (long)600L, (long)7L, (long)70L, (long)700L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)10L, (long)20L})), (new List<long>(new long[]{(long)15L, (long)2L})), (new List<long>(new long[]{(long)5L, (long)10L}))).Equals((new List<long>(new long[]{(long)10L, (long)15L, (long)5L, (long)20L, (long)2L, (long)10L}))));\n    Debug.Assert(InterleaveLists((new List<long>(new long[]{(long)11L, (long)44L})), (new List<long>(new long[]{(long)10L, (long)15L})), (new List<long>(new long[]{(long)20L, (long)5L}))).Equals((new List<long>(new long[]{(long)11L, (long)10L, (long)20L, (long)44L, (long)15L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Tuple<long, long, long, long> FindDissimilar(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindDissimilar((Tuple.Create(3L, 4L, 5L, 6L)), (Tuple.Create(5L, 7L, 4L, 10L))).Equals((Tuple.Create(3L, 6L, 7L, 10L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(1L, 2L, 3L, 4L)), (Tuple.Create(7L, 2L, 3L, 9L))).Equals((Tuple.Create(1L, 4L, 7L, 9L))));\n    Debug.Assert(FindDissimilar((Tuple.Create(21L, 11L, 25L, 26L)), (Tuple.Create(26L, 34L, 21L, 36L))).Equals((Tuple.Create(34L, 36L, 11L, 25L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the largest number that can be formed with the given list of digits.\n    public static long FindMaxNum(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (321L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)1L}))) == (6541L));\n    Debug.Assert(FindMaxNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)9L}))) == (9321L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static object ExtractEven(Tuple<long, long, Tuple<long, long, Tuple<long, long>>, long, long> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractEven((Tuple.Create(4L, 5L, Tuple.Create(7L, 6L, Tuple.Create(2L, 4L)), 6L, 8L))).Equals(Tuple.Create(4L, Tuple.Create(6L, Tuple.Create(2L, 4L)), 6L, 8L)));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(8L, 7L, Tuple.Create(4L, 8L)), 7L, 9L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 8L)))));\n    Debug.Assert(ExtractEven((Tuple.Create(5L, 6L, Tuple.Create(9L, 8L, Tuple.Create(4L, 6L)), 8L, 10L))).Equals(Tuple.Create(6L, Tuple.Create(8L, Tuple.Create(4L, 6L)), 8L, 10L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the surface area of a square csramid with a given base edge and height.\n    public static long SurfaceArea(long b, long s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SurfaceArea((3L), (4L)) == (33L));\n    Debug.Assert(SurfaceArea((4L), (5L)) == (56L));\n    Debug.Assert(SurfaceArea((1L), (2L)) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long CatalanNumber(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CatalanNumber((10L)) == (16796L));\n    Debug.Assert(CatalanNumber((9L)) == (4862L));\n    Debug.Assert(CatalanNumber((7L)) == (429L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static string FindAdverbs(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindAdverbs((\"Clearly, he has no excuse for such behavior.\")).Equals((\"0-7: Clearly\")));\n    Debug.Assert(FindAdverbs((\"Please handle the situation carefuly\")).Equals((\"28-36: carefuly\")));\n    Debug.Assert(FindAdverbs((\"Complete the task quickly\")).Equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to split a list at the nth eelment and add the first part to the end.\n    public static List<long> SplitArr(List<long> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)12L, (long)10L, (long)5L, (long)6L, (long)52L, (long)36L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)52L, (long)36L, (long)12L, (long)10L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})), (1L)).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SplitArr((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (3L)).Equals((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)0L, (long)1L, (long)2L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static object ListTuple(List<long> listx) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)5L, (long)10L, (long)7L, (long)4L, (long)15L, (long)3L}))).Equals(Tuple.Create(5L, 10L, 7L, 4L, 15L, 3L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)2L, (long)3L, (long)4L, (long)4L, (long)7L}))).Equals(Tuple.Create(2L, 4L, 5L, 6L, 2L, 3L, 4L, 4L, 7L)));\n    Debug.Assert(ListTuple((new List<long>(new long[]{(long)58L, (long)44L, (long)56L}))).Equals(Tuple.Create(58L, 44L, 56L)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the difference between largest and smallest value in a given list.\n    public static long BigDiff(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (3L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)4L, (long)5L, (long)12L}))) == (8L));\n    Debug.Assert(BigDiff((new List<long>(new long[]{(long)9L, (long)2L, (long)3L}))) == (7L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static List<long> PerfectSquares(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PerfectSquares((1L), (30L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L}))));\n    Debug.Assert(PerfectSquares((50L), (100L)).Equals((new List<long>(new long[]{(long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(PerfectSquares((100L), (200L)).Equals((new List<long>(new long[]{(long)100L, (long)121L, (long)144L, (long)169L, (long)196L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given two integers have opposite sign or not.\n    public static bool OppositeSigns(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OppositeSigns((1L), (-2L)) == (true));\n    Debug.Assert(OppositeSigns((3L), (2L)) == (false));\n    Debug.Assert(OppositeSigns((-10L), (-10L)) == (false));\n    Debug.Assert(OppositeSigns((-2L), (2L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to interchange the first and last elements in a list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)12L, (long)35L, (long)9L, (long)56L, (long)24L}))).Equals((new List<long>(new long[]{(long)24L, (long)35L, (long)9L, (long)56L, (long)12L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of the product of consecutive binomial co-efficients.\n    public static long SumOfProduct(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfProduct((3L)) == (15L));\n    Debug.Assert(SumOfProduct((4L)) == (56L));\n    Debug.Assert(SumOfProduct((1L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static string RemovezeroIp(string ip) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemovezeroIp((\"216.08.094.196\")).Equals((\"216.8.94.196\")));\n    Debug.Assert(RemovezeroIp((\"12.01.024\")).Equals((\"12.1.24\")));\n    Debug.Assert(RemovezeroIp((\"216.08.094.0196\")).Equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long DiffEvenOdd(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (3L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (1L));\n    Debug.Assert(DiffEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static object MinSwaps(string str1, string str2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinSwaps((\"1101\"), (\"1110\")).Equals((object(1L))));\n    Debug.Assert(MinSwaps((\"111\"), (\"000\")).Equals((object(\"Not Possible\"))));\n    Debug.Assert(MinSwaps((\"111\"), (\"110\")).Equals((object(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find kth element from the given two sorted lists.\n    public static long FindKth(List<long> arr1, List<long> arr2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L, (long)9L})), (new List<long>(new long[]{(long)1L, (long)4L, (long)8L, (long)10L})), (5L)) == (6L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)100L, (long)112L, (long)256L, (long)349L, (long)770L})), (new List<long>(new long[]{(long)72L, (long)86L, (long)113L, (long)119L, (long)265L, (long)445L, (long)892L})), (7L)) == (256L));\n    Debug.Assert(FindKth((new List<long>(new long[]{(long)3L, (long)4L, (long)7L, (long)8L, (long)10L})), (new List<long>(new long[]{(long)2L, (long)5L, (long)9L, (long)11L})), (6L)) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static bool ArmstrongNumber(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ArmstrongNumber((153L)) == (true));\n    Debug.Assert(ArmstrongNumber((259L)) == (false));\n    Debug.Assert(ArmstrongNumber((4458L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Tuple<long, float> SumAverage(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumAverage((10L)).Equals((Tuple.Create(55L, 5.5f))));\n    Debug.Assert(SumAverage((15L)).Equals((Tuple.Create(120L, 8.0f))));\n    Debug.Assert(SumAverage((20L)).Equals((Tuple.Create(210L, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long IsOctagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsOctagonal((5L)) == (65L));\n    Debug.Assert(IsOctagonal((10L)) == (280L));\n    Debug.Assert(IsOctagonal((15L)) == (645L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number is even or not.\n    public static bool IsEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsEven((1L)) == (false));\n    Debug.Assert(IsEven((2L)) == (true));\n    Debug.Assert(IsEven((3L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first repeated character in a given string.\n    public static string FirstRepeatedChar(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstRepeatedChar((\"abcabc\")).Equals((\"a\")));\n    Debug.Assert(FirstRepeatedChar((\"abc\")).Equals(null));\n    Debug.Assert(FirstRepeatedChar((\"123123\")).Equals((\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static List<long> GetLudic(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetLudic((10L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L}))));\n    Debug.Assert(GetLudic((25L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L}))));\n    Debug.Assert(GetLudic((45L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)5L, (long)7L, (long)11L, (long)13L, (long)17L, (long)23L, (long)25L, (long)29L, (long)37L, (long)41L, (long)43L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static string ReverseWords(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseWords((\"python program\")).Equals((\"program python\")));\n    Debug.Assert(ReverseWords((\"java language\")).Equals((\"language java\")));\n    Debug.Assert(ReverseWords((\"indian man\")).Equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static bool PrimeNum(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PrimeNum((13L)) == (true));\n    Debug.Assert(PrimeNum((7L)) == (true));\n    Debug.Assert(PrimeNum((-1010L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float RadianDegree(long degree) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RadianDegree((90L)) == (1.5707963267948966f));\n    Debug.Assert(RadianDegree((60L)) == (1.0471975511965976f));\n    Debug.Assert(RadianDegree((120L)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Tuple<string, long, long> FindLiterals(string text, string pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).Equals((Tuple.Create(\"fox\", 16L, 19L))));\n    Debug.Assert(FindLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).Equals((Tuple.Create(\"crazy\", 16L, 21L))));\n    Debug.Assert(FindLiterals((\"Hardest choices required strongest will\"), (\"will\")).Equals((Tuple.Create(\"will\", 35L, 39L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find nth bell number.\n    public static long BellNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((3L)) == (5L));\n    Debug.Assert(BellNumber((4L)) == (15L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static List<long> RemoveKthElement(List<long> list1, long L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L})), (3L)).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)1L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L})), (4L)).Equals((new List<long>(new long[]{(long)0L, (long)0L, (long)1L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))));\n    Debug.Assert(RemoveKthElement((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long MaxOfNth(List<List<long>> test_list, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)9L, (long)19L})})), (2L)) == (19L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)20L})})), (1L)) == (10L));\n    Debug.Assert(MaxOfNth((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)21L})})), (1L)) == (11L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static List<List<object>> Merge(List<List<object>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L})}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L, (long)6L, (long)8L})}))));\n    Debug.Assert(Merge((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"y\", (string)\"z\"}), (List<string>)new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"m\", (string)\"n\", (string)\"o\"})}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"x\", (string)\"a\", (string)\"m\"}), (List<string>)new List<string>(new string[]{(string)\"y\", (string)\"b\", (string)\"n\"}), (List<string>)new List<string>(new string[]{(string)\"z\", (string)\"c\", (string)\"o\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long CummulativeSum(List<List<long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L}), (List<long>)new List<long>(new long[]{(long)2L, (long)6L})}))) == (30L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)3L, (long)7L})}))) == (37L));\n    Debug.Assert(CummulativeSum((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)8L})}))) == (44L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static List<float> AverageTuple(List<List<long>> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)12L}), (List<long>)new List<long>(new long[]{(long)30L, (long)45L, (long)56L, (long)45L}), (List<long>)new List<long>(new long[]{(long)81L, (long)80L, (long)39L, (long)32L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))).Equals((new List<float>(new float[]{(float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)1L, (long)-5L}), (List<long>)new List<long>(new long[]{(long)30L, (long)-15L, (long)56L}), (List<long>)new List<long>(new long[]{(long)81L, (long)-60L, (long)-39L}), (List<long>)new List<long>(new long[]{(long)-10L, (long)2L, (long)3L})}))).Equals((new List<float>(new float[]{(float)25.5f, (float)-18.0f, (float)3.75f}))));\n    Debug.Assert(AverageTuple((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)100L, (long)100L, (long)100L, (long)120L}), (List<long>)new List<long>(new long[]{(long)300L, (long)450L, (long)560L, (long)450L}), (List<long>)new List<long>(new long[]{(long)810L, (long)800L, (long)390L, (long)320L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new List<float>(new float[]{(float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Tuple<long, long, long, long> TupleModulo(Tuple<long, long, long, long> test_tup1, Tuple<long, long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleModulo((Tuple.Create(10L, 4L, 5L, 6L)), (Tuple.Create(5L, 6L, 7L, 5L))).Equals((Tuple.Create(0L, 4L, 5L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(11L, 5L, 6L, 7L)), (Tuple.Create(6L, 7L, 8L, 6L))).Equals((Tuple.Create(5L, 5L, 6L, 1L))));\n    Debug.Assert(TupleModulo((Tuple.Create(12L, 6L, 7L, 8L)), (Tuple.Create(7L, 8L, 9L, 7L))).Equals((Tuple.Create(5L, 6L, 7L, 1L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float MinJumps(Tuple<long, long> steps, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (11L)) == (3.5f));\n    Debug.Assert(MinJumps((Tuple.Create(3L, 4L)), (0L)) == (float)0L);\n    Debug.Assert(MinJumps((Tuple.Create(11L, 14L)), (11L)) == (float)1L);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static List<float> DivList(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<float>(new float[]{(float)4.0f, (float)2.5f, (float)2.0f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)3L, (long)2L})), (new List<long>(new long[]{(long)1L, (long)4L}))).Equals((new List<float>(new float[]{(float)3.0f, (float)0.5f}))));\n    Debug.Assert(DivList((new List<long>(new long[]{(long)90L, (long)120L})), (new List<long>(new long[]{(long)50L, (long)70L}))).Equals((new List<float>(new float[]{(float)1.8f, (float)1.7142857142857142f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static string MoveNum(string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveNum((\"I1love143you55three3000thousand\")).Equals((\"Iloveyouthreethousand1143553000\")));\n    Debug.Assert(MoveNum((\"Avengers124Assemble\")).Equals((\"AvengersAssemble124\")));\n    Debug.Assert(MoveNum((\"Its11our12path13to14see15things16do17things\")).Equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of substrings with the sum of digits equal to their length.\n    public static long CountSubstrings(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSubstrings((\"112112\")) == (6L));\n    Debug.Assert(CountSubstrings((\"111\")) == (6L));\n    Debug.Assert(CountSubstrings((\"1101112\")) == (12L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float GetMedian(List<long> arr1, List<long> arr2, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)1L, (long)12L, (long)15L, (long)26L, (long)38L})), (new List<long>(new long[]{(long)2L, (long)13L, (long)17L, (long)30L, (long)45L})), (5L)) == (16.0f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)2L, (long)4L, (long)8L, (long)9L})), (new List<long>(new long[]{(long)7L, (long)13L, (long)19L, (long)28L})), (4L)) == (8.5f));\n    Debug.Assert(GetMedian((new List<long>(new long[]{(long)3L, (long)6L, (long)14L, (long)23L, (long)36L, (long)42L})), (new List<long>(new long[]{(long)2L, (long)18L, (long)27L, (long)39L, (long)49L, (long)55L})), (6L)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static List<long> NthNums(List<long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (3L)).Equals((new List<long>(new long[]{(long)1000L, (long)8000L, (long)27000L}))));\n    Debug.Assert(NthNums((new List<long>(new long[]{(long)12L, (long)15L})), (5L)).Equals((new List<long>(new long[]{(long)248832L, (long)759375L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to convert a given string to uppercase.\n    public static string IsUpper(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUpper((\"person\")).Equals((\"PERSON\")));\n    Debug.Assert(IsUpper((\"final\")).Equals((\"FINAL\")));\n    Debug.Assert(IsUpper((\"Valid\")).Equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to interchange the first and last element in a given list.\n    public static List<long> SwapList(List<long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))).Equals((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)4L}))).Equals((new List<long>(new long[]{(long)4L, (long)2L, (long)3L, (long)4L, (long)1L}))));\n    Debug.Assert(SwapList((new List<long>(new long[]{(long)4L, (long)5L, (long)6L}))).Equals((new List<long>(new long[]{(long)6L, (long)5L, (long)4L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Nullable<long> TriangleArea(long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TriangleArea((-1L)).Equals(null));\n    Debug.Assert(TriangleArea((0L)).Equals(0L));\n    Debug.Assert(TriangleArea((2L)).Equals(4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the smallest missing number from a sorted list of natural numbers.\n    public static long FindFirstMissing(List<long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L}))) == (4L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)6L, (long)9L}))) == (3L));\n    Debug.Assert(FindFirstMissing((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)8L, (long)9L}))) == (0L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static string ReplaceSpaces(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"My Name is Dawood\")).Equals((\"My%20Name%20is%20Dawood\")));\n    Debug.Assert(ReplaceSpaces((\"I am a Programmer\")).Equals((\"I%20am%20a%20Programmer\")));\n    Debug.Assert(ReplaceSpaces((\"I love Coding\")).Equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find even numbers from a list of numbers.\n    public static List<long> Split(List<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Split((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))).Equals((new List<long>(new long[]{(long)2L, (long)4L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)0L, (long)1L}))).Equals((new List<long>(new long[]{(long)4L, (long)6L, (long)8L, (long)0L}))));\n    Debug.Assert(Split((new List<long>(new long[]{(long)8L, (long)12L, (long)15L, (long)19L}))).Equals((new List<long>(new long[]{(long)8L, (long)12L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find smallest number in a list.\n    public static long SmallestNum(List<long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)10L, (long)20L, (long)1L, (long)45L, (long)99L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (1L));\n    Debug.Assert(SmallestNum((new List<long>(new long[]{(long)45L, (long)46L, (long)50L, (long)60L}))) == (45L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static List<List<long>> GetCoordinates(Tuple<long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetCoordinates((Tuple.Create(3L, 4L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)2L, (long)4L}), (List<long>)new List<long>(new long[]{(long)2L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(4L, 5L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)3L, (long)5L}), (List<long>)new List<long>(new long[]{(long)3L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L})}))));\n    Debug.Assert(GetCoordinates((Tuple.Create(5L, 6L))).Equals((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)4L, (long)6L}), (List<long>)new List<long>(new long[]{(long)4L, (long)7L}), (List<long>)new List<long>(new long[]{(long)5L, (long)5L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)6L, (long)7L})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static string ReplaceSpaces(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpaces((\"Jumanji The Jungle\")).Equals((\"Jumanji_The_Jungle\")));\n    Debug.Assert(ReplaceSpaces((\"The_Avengers\")).Equals((\"The Avengers\")));\n    Debug.Assert(ReplaceSpaces((\"Fast and Furious\")).Equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to move all zeroes to the end of the given list.\n    public static List<long> MoveZero(List<long> num_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)1L, (long)0L, (long)2L, (long)0L, (long)3L, (long)4L}))).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)0L, (long)0L, (long)4L, (long)0L, (long)5L, (long)0L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)4L, (long)5L, (long)0L, (long)0L, (long)0L, (long)0L}))));\n    Debug.Assert(MoveZero((new List<long>(new long[]{(long)0L, (long)1L, (long)0L, (long)1L, (long)1L}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)0L, (long)0L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of xor of all pairs of numbers in the given list.\n    public static long PairXorSum(List<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)5L, (long)9L, (long)7L, (long)6L})), (4L)) == (47L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L, (long)5L})), (3L)) == (12L));\n    Debug.Assert(PairXorSum((new List<long>(new long[]{(long)7L, (long)3L})), (2L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort the given list.\n    public static List<long> HeapSort(List<long> iterable) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)9L, (long)2L, (long)4L, (long)6L, (long)8L, (long)0L}))).Equals((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)25L, (long)35L, (long)22L, (long)85L, (long)14L, (long)65L, (long)75L, (long)25L, (long)58L}))).Equals((new List<long>(new long[]{(long)14L, (long)22L, (long)25L, (long)25L, (long)35L, (long)58L, (long)65L, (long)75L, (long)85L}))));\n    Debug.Assert(HeapSort((new List<long>(new long[]{(long)7L, (long)1L, (long)9L, (long)5L}))).Equals((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static bool NoprofitNoloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NoprofitNoloss((1500L), (1200L)) == (false));\n    Debug.Assert(NoprofitNoloss((100L), (100L)) == (true));\n    Debug.Assert(NoprofitNoloss((2000L), (5000L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long WindChill(long v, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WindChill((120L), (35L)) == (40L));\n    Debug.Assert(WindChill((40L), (20L)) == (19L));\n    Debug.Assert(WindChill((10L), (8L)) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long SampleNam(List<string> sample_names) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"sally\", (string)\"Dylan\", (string)\"rebecca\", (string)\"Diana\", (string)\"Joanne\", (string)\"keith\"}))) == (16L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"php\", (string)\"res\", (string)\"Python\", (string)\"abcd\", (string)\"Java\", (string)\"aaa\"}))) == (10L));\n    Debug.Assert(SampleNam((new List<string>(new string[]{(string)\"abcd\", (string)\"Python\", (string)\"abba\", (string)\"aba\"}))) == (6L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long MaxDifference(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(1L, 7L), (Tuple<long, long>)Tuple.Create(10L, 3L), (Tuple<long, long>)Tuple.Create(1L, 2L)}))) == (7L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(2L, 17L), (Tuple<long, long>)Tuple.Create(9L, 13L), (Tuple<long, long>)Tuple.Create(11L, 12L)}))) == (15L));\n    Debug.Assert(MaxDifference((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 35L), (Tuple<long, long>)Tuple.Create(21L, 27L), (Tuple<long, long>)Tuple.Create(13L, 23L), (Tuple<long, long>)Tuple.Create(41L, 22L)}))) == (23L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static string RemoveParenthesis(List<string> items) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"python (chrome)\"}))).Equals((\"python\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"string(.abc)\"}))).Equals((\"string\")));\n    Debug.Assert(RemoveParenthesis((new List<string>(new string[]{(string)\"alpha(num)\"}))).Equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long IsNonagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsNonagonal((10L)) == (325L));\n    Debug.Assert(IsNonagonal((15L)) == (750L));\n    Debug.Assert(IsNonagonal((18L)) == (1089L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static bool TextMatchWordzMiddle(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    Debug.Assert(TextMatchWordzMiddle((\"zxyabc.\")) == (false));\n    Debug.Assert(TextMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to reverse a list upto a given position.\n    public static List<long> ReverseArrayUptoK(List<long> input, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (4L)).Equals((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)1L, (long)5L, (long)6L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})), (2L)).Equals((new List<long>(new long[]{(long)5L, (long)4L, (long)6L, (long)7L}))));\n    Debug.Assert(ReverseArrayUptoK((new List<long>(new long[]{(long)9L, (long)8L, (long)7L, (long)6L, (long)5L})), (3L)).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)6L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static List<Tuple<string, long>> SubjectMarks(List<Tuple<string, long>> subjectmarks) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L), (Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social sciences\", 82L), (Tuple<string, long>)Tuple.Create(\"English\", 88L), (Tuple<string, long>)Tuple.Create(\"Science\", 90L), (Tuple<string, long>)Tuple.Create(\"Maths\", 97L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L), (Tuple<string, long>)Tuple.Create(\"Social\", 33L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Social\", 33L), (Tuple<string, long>)Tuple.Create(\"Telugu\", 49L), (Tuple<string, long>)Tuple.Create(\"Hindhi\", 54L)}))));\n    Debug.Assert(SubjectMarks((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L), (Tuple<string, long>)Tuple.Create(\"Biology\", 45L)}))).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Biology\", 45L), (Tuple<string, long>)Tuple.Create(\"Physics\", 96L), (Tuple<string, long>)Tuple.Create(\"Chemistry\", 97L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of positive numbers in a list.\n    public static long PosCount(List<long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L, (long)-4L}))) == (2L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)3L, (long)4L, (long)5L, (long)-1L}))) == (3L));\n    Debug.Assert(PosCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long BellNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(BellNumber((2L)) == (2L));\n    Debug.Assert(BellNumber((10L)) == (115975L));\n    Debug.Assert(BellNumber((56L)) == (6775685320645824322581483068371419745979053216268760300L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given list is monotonic or not.\n    public static bool IsMonotonic(List<long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)6L, (long)5L, (long)4L, (long)4L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)2L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsMonotonic((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static bool IsSublist(List<long> l, List<long> s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)3L, (long)7L}))) == (false));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)4L, (long)3L}))) == (true));\n    Debug.Assert(IsSublist((new List<long>(new long[]{(long)2L, (long)4L, (long)3L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)1L, (long)6L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the two numbers differ at one bit position only or not.\n    public static bool DifferAtOneBitPos(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifferAtOneBitPos((13L), (9L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((15L), (8L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (4L)) == (false));\n    Debug.Assert(DifferAtOneBitPos((2L), (3L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((5L), (1L)) == (true));\n    Debug.Assert(DifferAtOneBitPos((1L), (5L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static bool GetEqual(List<List<long>> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)11L, (long)22L, (long)33L}), (List<long>)new List<long>(new long[]{(long)44L, (long)55L, (long)66L})}))) == (true));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)7L})}))) == (false));\n    Debug.Assert(GetEqual((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)3L, (long)4L})}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static List<long> CombSort(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)5L, (long)15L, (long)37L, (long)25L, (long)79L}))).Equals((new List<long>(new long[]{(long)5L, (long)15L, (long)25L, (long)37L, (long)79L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)41L, (long)32L, (long)15L, (long)19L, (long)22L}))).Equals((new List<long>(new long[]{(long)15L, (long)19L, (long)22L, (long)32L, (long)41L}))));\n    Debug.Assert(CombSort((new List<long>(new long[]{(long)99L, (long)15L, (long)13L, (long)47L}))).Equals((new List<long>(new long[]{(long)13L, (long)15L, (long)47L, (long)99L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Tuple<long, long, long, Dictionary<string,long>> AddDictToTuple(Tuple<long, long, long> test_tup, Dictionary<string,long> test_dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddDictToTuple((Tuple.Create(4L, 5L, 6L)), (new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}})).Equals((Tuple.Create(4L, 5L, 6L, new Dictionary<string,long>(){{\"MSAM\", 1L}, {\"is\", 2L}, {\"best\", 3L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(1L, 2L, 3L)), (new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}})).Equals((Tuple.Create(1L, 2L, 3L, new Dictionary<string,long>(){{\"UTS\", 2L}, {\"is\", 3L}, {\"Worst\", 4L}}))));\n    Debug.Assert(AddDictToTuple((Tuple.Create(8L, 9L, 10L)), (new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}})).Equals((Tuple.Create(8L, 9L, 10L, new Dictionary<string,long>(){{\"POS\", 3L}, {\"is\", 4L}, {\"Okay\", 5L}}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float Maxaverageofpath(List<List<long>> cost) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)3L, (long)9L})}))) == (5.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)7L, (long)6L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)4L, (long)10L})}))) == (6.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)4L, (long)5L}), (List<long>)new List<long>(new long[]{(long)8L, (long)7L, (long)6L}), (List<long>)new List<long>(new long[]{(long)9L, (long)5L, (long)11L})}))) == (7.2f));\n    Debug.Assert(Maxaverageofpath((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static Dictionary<string,Tuple<float, long>> FilterData(Dictionary<string,Tuple<float, long>> students, float h, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (6.0f), (70L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.9f), (67L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}})));\n    Debug.Assert(FilterData((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}}), (5.7f), (64L)).Equals((new Dictionary<string,Tuple<float, long>>(){{\"Cierra Vega\", Tuple.Create(6.2f, 70L)}, {\"Alden Cantrell\", Tuple.Create(5.9f, 65L)}, {\"Kierra Gentry\", Tuple.Create(6.0f, 68L)}, {\"Pierre Cox\", Tuple.Create(5.8f, 66L)}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long CountSamePair(List<long> nums1, List<long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)2L, (long)3L, (long)1L, (long)2L, (long)6L, (long)7L, (long)9L}))) == (4L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)0L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (11L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)2L, (long)4L, (long)-6L, (long)-9L, (long)11L, (long)-12L, (long)14L, (long)-5L, (long)17L})), (new List<long>(new long[]{(long)2L, (long)1L, (long)2L, (long)-1L, (long)-5L, (long)6L, (long)4L, (long)-3L, (long)-2L, (long)3L, (long)4L, (long)6L, (long)8L}))) == (1L));\n    Debug.Assert(CountSamePair((new List<long>(new long[]{(long)0L, (long)1L, (long)1L, (long)2L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)2L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long PowerBaseSum(long numBase, long power) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PowerBaseSum((2L), (100L)) == (115L));\n    Debug.Assert(PowerBaseSum((8L), (10L)) == (37L));\n    Debug.Assert(PowerBaseSum((8L), (15L)) == (62L));\n    Debug.Assert(PowerBaseSum((3L), (3L)) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static List<object> ExtractQuotation(string text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).Equals((new List<object>(new string[]{(string)\"A53\", (string)\"multi\", (string)\"Processor\"}))));\n    Debug.Assert(ExtractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).Equals((new List<object>(new string[]{(string)\"favorite\", (string)\"apps\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).Equals((new List<object>(new string[]{(string)\"4k Ultra HD\", (string)\"HDR 10\"}))));\n    Debug.Assert(ExtractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static List<object> MultiplyElements(List<long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)8L, (long)10L}))).Equals((new List<object>(new long[]{(long)5L, (long)35L, (long)56L, (long)80L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)2L, (long)4L, (long)5L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)8L, (long)20L, (long)30L, (long)42L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L, (long)13L, (long)14L, (long)9L, (long)15L}))).Equals((new List<object>(new long[]{(long)156L, (long)182L, (long)126L, (long)135L}))));\n    Debug.Assert(MultiplyElements((new List<long>(new long[]{(long)12L}))).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static List<long> SumList(List<long> lst1, List<long> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumList((new List<long>(new long[]{(long)10L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)25L, (long)35L}))).Equals((new List<long>(new long[]{(long)25L, (long)45L, (long)65L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)5L, (long)6L, (long)7L}))).Equals((new List<long>(new long[]{(long)6L, (long)8L, (long)10L}))));\n    Debug.Assert(SumList((new List<long>(new long[]{(long)15L, (long)20L, (long)30L})), (new List<long>(new long[]{(long)15L, (long)45L, (long)75L}))).Equals((new List<long>(new long[]{(long)30L, (long)65L, (long)105L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the given number can be represented as the difference of two squares or not.\n    public static bool DifSquare(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DifSquare((5L)) == (true));\n    Debug.Assert(DifSquare((10L)) == (false));\n    Debug.Assert(DifSquare((15L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static List<object> ConsecutiveDuplicates(List<object> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<object>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<object>(new long[]{(long)10L, (long)15L, (long)19L, (long)18L, (long)17L, (long)26L, (long)17L, (long)18L, (long)10L}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\"}))));\n    Debug.Assert(ConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\", (string)\"a\", (string)\"a\"}))).Equals((new List<object>(new string[]{(string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"a\"}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float LateralsurfaceCone(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LateralsurfaceCone((5L), (12L)) == (204.20352248333654f));\n    Debug.Assert(LateralsurfaceCone((10L), (15L)) == (566.3586699569488f));\n    Debug.Assert(LateralsurfaceCone((19L), (17L)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static string ReplaceSpecialchar(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReplaceSpecialchar((\"Python language, Programming language.\")).Equals((\"Python:language::Programming:language:\")));\n    Debug.Assert(ReplaceSpecialchar((\"a b c,d e f\")).Equals((\"a:b:c:d:e:f\")));\n    Debug.Assert(ReplaceSpecialchar((\"ram reshma,ram rahim\")).Equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted list.\n    public static long FindFirstOccurrence(List<long> A, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)5L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (1L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)3L, (long)5L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (5L)) == (2L));\n    Debug.Assert(FindFirstOccurrence((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)5L, (long)6L, (long)6L, (long)8L, (long)9L, (long)9L, (long)9L})), (6L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n    public static long SumOfSubarrayProd(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (20L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L}))) == (5L));\n    Debug.Assert(SumOfSubarrayProd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}))) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long ToggleMiddleBits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ToggleMiddleBits((9L)) == (15L));\n    Debug.Assert(ToggleMiddleBits((10L)) == (12L));\n    Debug.Assert(ToggleMiddleBits((11L)) == (13L));\n    Debug.Assert(ToggleMiddleBits((65L)) == (127L));\n    Debug.Assert(ToggleMiddleBits((77L)) == (115L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/csthon-exercises/data-structures-and-algorithms/csthon-data-structure-exercise-24.php\n    public static long LeftInsertion(List<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(LeftInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static bool CheckStr(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckStr((\"annie\")) == (true));\n    Debug.Assert(CheckStr((\"dawood\")) == (false));\n    Debug.Assert(CheckStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/csthon-exercises/data-structures-and-algorithms/csthon-recursion-exercise-9.php\n    public static float GeometricSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GeometricSum((7L)) == (1.9921875f));\n    Debug.Assert(GeometricSum((4L)) == (1.9375f));\n    Debug.Assert(GeometricSum((8L)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long FindIndex(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindIndex((2L)) == (4L));\n    Debug.Assert(FindIndex((3L)) == (14L));\n    Debug.Assert(FindIndex((4L)) == (45L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/csthon-convert-tuple-to-adjacent-pair-dictionary/\n    public static Dictionary<long,long> TupleToDict(Tuple<long, long, long, long, long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 5L, 7L, 10L, 13L, 5L))).Equals((new Dictionary<long,long>(){{1L, 5L}, {7L, 10L}, {13L, 5L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(1L, 2L, 3L, 4L, 5L, 6L))).Equals((new Dictionary<long,long>(){{1L, 2L}, {3L, 4L}, {5L, 6L}})));\n    Debug.Assert(TupleToDict((Tuple.Create(7L, 8L, 9L, 10L, 11L, 12L))).Equals((new Dictionary<long,long>(){{7L, 8L}, {9L, 10L}, {11L, 12L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether all the characters are same or not.\n    public static bool AllCharactersSame(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AllCharactersSame((\"python\")) == (false));\n    Debug.Assert(AllCharactersSame((\"aaa\")) == (true));\n    Debug.Assert(AllCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float AreaTetrahedron(long side) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AreaTetrahedron((3L)) == (15.588457268119894f));\n    Debug.Assert(AreaTetrahedron((20L)) == (692.8203230275509f));\n    Debug.Assert(AreaTetrahedron((10L)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/csthon-program-right-rotate-list-n/\n    public static List<long> RotateRight(List<long> list, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (3L)).Equals((new List<long>(new long[]{(long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (2L)).Equals((new List<long>(new long[]{(long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L}))));\n    Debug.Assert(RotateRight((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L})), (5L)).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)9L, (long)10L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static bool CheckNone(object test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckNone(Tuple.Create(10L, 4L, 5L, 6L, (Nullable<long>)null)) == (true));\n    Debug.Assert(CheckNone(Tuple.Create(7L, 8L, 9L, 11L, 14L)) == (false));\n    Debug.Assert(CheckNone(Tuple.Create(1L, 2L, 3L, 4L, (Nullable<long>)null)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/csthon-exercises/lambda/csthon-lambda-exercise-24.php\n    public static List<long> DivisibleByDigits(long startnum, long endnum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DivisibleByDigits((1L), (22L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L, (long)22L}))));\n    Debug.Assert(DivisibleByDigits((1L), (15L)).Equals((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)11L, (long)12L, (long)15L}))));\n    Debug.Assert(DivisibleByDigits((20L), (25L)).Equals((new List<long>(new long[]{(long)22L, (long)24L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n    public static Nullable<float> SectorArea(long r, long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SectorArea((4L), (45L)).Equals(6.283185307179586f));\n    Debug.Assert(SectorArea((9L), (45L)).Equals(31.808625617596654f));\n    Debug.Assert(SectorArea((9L), (361L)).Equals(null));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long LcsOfThree(string X, string Y, string Z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2L));\n    Debug.Assert(LcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5L));\n    Debug.Assert(LcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static string CapitalWordsSpaces(string str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CapitalWordsSpaces((\"Python\")).Equals((\"Python\")));\n    Debug.Assert(CapitalWordsSpaces((\"PythonProgrammingExamples\")).Equals((\"Python Programming Examples\")));\n    Debug.Assert(CapitalWordsSpaces((\"GetReadyToBeCodingFreak\")).Equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/csthon-sort-numeric-strings-in-a-list/\n    public static List<long> SortNumericStrings(List<string> nums_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"4\", (string)\"12\", (string)\"45\", (string)\"7\", (string)\"0\", (string)\"100\", (string)\"200\", (string)\"-12\", (string)\"-500\"}))).Equals((new List<long>(new long[]{(long)-500L, (long)-12L, (long)0L, (long)4L, (long)7L, (long)12L, (long)45L, (long)100L, (long)200L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"2\", (string)\"3\", (string)\"8\", (string)\"4\", (string)\"7\", (string)\"9\", (string)\"8\", (string)\"2\", (string)\"6\", (string)\"5\", (string)\"1\", (string)\"6\", (string)\"1\", (string)\"2\", (string)\"3\", (string)\"4\", (string)\"6\", (string)\"9\", (string)\"1\", (string)\"2\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)2L, (long)2L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)8L, (long)9L, (long)9L}))));\n    Debug.Assert(SortNumericStrings((new List<string>(new string[]{(string)\"1\", (string)\"3\", (string)\"5\", (string)\"7\", (string)\"1\", (string)\"3\", (string)\"13\", (string)\"15\", (string)\"17\", (string)\"5\", (string)\"7 \", (string)\"9\", (string)\"1\", (string)\"11\"}))).Equals((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)3L, (long)3L, (long)5L, (long)5L, (long)7L, (long)7L, (long)9L, (long)11L, (long)13L, (long)15L, (long)17L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns list.\n    public static bool IsSamepatterns(List<string> colors, List<string> patterns) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"green\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (true));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\", (string)\"b\"}))) == (false));\n    Debug.Assert(IsSamepatterns((new List<string>(new string[]{(string)\"red\", (string)\"green\", (string)\"greenn\"})), (new List<string>(new string[]{(string)\"a\", (string)\"b\"}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static List<long> AddTuple(List<long> test_list, Tuple<long, long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)5L, (long)6L, (long)7L})), (Tuple.Create(9L, 10L))).Equals((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)9L, (long)10L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)6L, (long)7L, (long)8L})), (Tuple.Create(10L, 11L))).Equals((new List<long>(new long[]{(long)6L, (long)7L, (long)8L, (long)10L, (long)11L}))));\n    Debug.Assert(AddTuple((new List<long>(new long[]{(long)7L, (long)8L, (long)9L})), (Tuple.Create(11L, 12L))).Equals((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)11L, (long)12L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n    public static bool CheckMinHeap(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)10L, (long)15L}))) == (true));\n    Debug.Assert(CheckMinHeap((new List<long>(new long[]{(long)2L, (long)10L, (long)4L, (long)5L, (long)3L, (long)15L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long JacobsthalNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(JacobsthalNum((5L)) == (11L));\n    Debug.Assert(JacobsthalNum((2L)) == (1L));\n    Debug.Assert(JacobsthalNum((4L)) == (5L));\n    Debug.Assert(JacobsthalNum((13L)) == (2731L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/csthon-find-minimum-k-records-from-tuple-list/ - in this case a verbatim cocs of test cases\n    public static List<Tuple<string, long>> MinK(List<Tuple<string, long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Manjeet\", 10L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L), (Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Nikhil\", 8L)})), (2L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 2L), (Tuple<string, long>)Tuple.Create(\"Akshat\", 4L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sanjeev\", 11L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)})), (3L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Akash\", 3L), (Tuple<string, long>)Tuple.Create(\"Angat\", 5L), (Tuple<string, long>)Tuple.Create(\"Nepin\", 9L)}))));\n    Debug.Assert(MinK((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"tanmay\", 14L), (Tuple<string, long>)Tuple.Create(\"Amer\", 11L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L), (Tuple<string, long>)Tuple.Create(\"SKD\", 16L)})), (1L)).Equals((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Ayesha\", 9L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static List<object> ExtractIndexList(List<long> l1, List<long> l2, List<long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)7L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)5L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)6L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)1L, (long)3L, (long)4L, (long)6L, (long)5L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>(new long[]{(long)1L, (long)5L}))));\n    Debug.Assert(ExtractIndexList((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)6L, (long)6L, (long)6L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L})), (new List<long>(new long[]{(long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)7L}))).Equals((new List<object>())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/csthon-exercises/re/csthon-re-exercise-3.php\n    public static bool TextMatchZeroOne(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchZeroOne((\"ac\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"dc\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"dsabbbba\")) == (true));\n    Debug.Assert(TextMatchZeroOne((\"asbbbba\")) == (false));\n    Debug.Assert(TextMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/csthon-program-to-count-the-pairs-of-reverse-strings/\n    public static long CountReversePairs(List<string> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"julia\", (string)\"best\", (string)\"tseb\", (string)\"for\", (string)\"ailuj\"}))) == (2L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"geeks\", (string)\"best\", (string)\"for\", (string)\"skeeg\"}))) == (1L));\n    Debug.Assert(CountReversePairs((new List<string>(new string[]{(string)\"makes\", (string)\"best\", (string)\"sekam\", (string)\"for\", (string)\"rof\"}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static bool IsDecimal(string num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDecimal((\"123.11\")) == (true));\n    Debug.Assert(IsDecimal((\"e666.86\")) == (false));\n    Debug.Assert(IsDecimal((\"3.124587\")) == (false));\n    Debug.Assert(IsDecimal((\"1.11\")) == (true));\n    Debug.Assert(IsDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static List<Tuple<long, long, long>> FindTuples(List<Tuple<long, long, long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L), (Tuple<long, long, long>)Tuple.Create(7L, 9L, 6L), (Tuple<long, long, long>)Tuple.Create(12L, 18L, 21L)})), (6L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(6L, 24L, 12L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L), (Tuple<long, long, long>)Tuple.Create(4L, 2L, 3L), (Tuple<long, long, long>)Tuple.Create(7L, 8L, 9L)})), (5L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(5L, 25L, 30L)}))));\n    Debug.Assert(FindTuples((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(7L, 9L, 16L), (Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L), (Tuple<long, long, long>)Tuple.Create(19L, 17L, 18L)})), (4L)).Equals((new List<Tuple<long, long, long>>(new Tuple<long, long, long>[]{(Tuple<long, long, long>)Tuple.Create(8L, 16L, 4L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether a list of numbers contains only one distinct element or not.\n    public static bool UniqueElement(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)1L, (long)1L}))) == (true));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (false));\n    Debug.Assert(UniqueElement((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static bool CheckMonthnumberNumber(long monthnum3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckMonthnumberNumber((6L)) == (true));\n    Debug.Assert(CheckMonthnumberNumber((2L)) == (false));\n    Debug.Assert(CheckMonthnumberNumber((12L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long FindMinDiff(List<long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)1L, (long)5L, (long)3L, (long)19L, (long)18L, (long)25L})), (6L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)4L, (long)3L, (long)2L, (long)6L})), (4L)) == (1L));\n    Debug.Assert(FindMinDiff((new List<long>(new long[]{(long)30L, (long)5L, (long)20L, (long)9L})), (4L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count number of digits in a given string.\n    public static long NumberCtr(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NumberCtr((\"program2bedone\")) == (1L));\n    Debug.Assert(NumberCtr((\"3wonders\")) == (1L));\n    Debug.Assert(NumberCtr((\"123\")) == (3L));\n    Debug.Assert(NumberCtr((\"3wond-1ers2\")) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long IsPolite(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPolite((7L)) == (11L));\n    Debug.Assert(IsPolite((4L)) == (7L));\n    Debug.Assert(IsPolite((9L)) == (13L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static List<Tuple<long, long>> PairWise(List<long> l1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)1L, (long)2L, (long)3L, (long)3L, (long)4L, (long)4L, (long)5L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 1L), (Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 5L), (Tuple<long, long>)Tuple.Create(5L, 7L), (Tuple<long, long>)Tuple.Create(7L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)5L, (long)1L, (long)9L, (long)7L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(1L, 9L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(7L, 10L)}))));\n    Debug.Assert(PairWise((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(1L, 2L), (Tuple<long, long>)Tuple.Create(2L, 3L), (Tuple<long, long>)Tuple.Create(3L, 4L), (Tuple<long, long>)Tuple.Create(4L, 5L), (Tuple<long, long>)Tuple.Create(5L, 6L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(9L, 10L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long GetPairsCount(List<long> arr, long sum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)1L})), (2L)) == (6L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)-1L, (long)5L})), (6L)) == (3L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)1L, (long)-2L, (long)3L})), (1L)) == (1L));\n    Debug.Assert(GetPairsCount((new List<long>(new long[]{(long)-1L, (long)-2L, (long)3L})), (-3L)) == (1L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to get the difference between two lists.\n    public static List<long> Diff(List<long> li1, List<long> li2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Diff((new List<long>(new long[]{(long)10L, (long)15L, (long)20L, (long)25L, (long)30L, (long)35L, (long)40L})), (new List<long>(new long[]{(long)25L, (long)40L, (long)35L}))).Equals((new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)15L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L}))));\n    Debug.Assert(Diff((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (new List<long>(new long[]{(long)6L, (long)7L, (long)1L}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)6L, (long)7L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of fourth power of first n odd natural numbers.\n    public static long OddNumSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddNumSum((2L)) == (82L));\n    Debug.Assert(OddNumSum((3L)) == (707L));\n    Debug.Assert(OddNumSum((4L)) == (3108L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static bool CheckExpression(string exp) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckExpression((\"{()}[{}]\")) == (true));\n    Debug.Assert(CheckExpression((\"{()}[{]\")) == (false));\n    Debug.Assert(CheckExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static string RemoveLength(string test_str, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveLength((\"The person is most value tet\"), (3L)).Equals((\"person is most value\")));\n    Debug.Assert(RemoveLength((\"If you told me about this ok\"), (4L)).Equals((\"If you me about ok\")));\n    Debug.Assert(RemoveLength((\"Forces of darkeness is come into the play\"), (4L)).Equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n    public static Tuple<string, long, long> OccuranceSubstring(string text, string pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OccuranceSubstring((\"python programming, python language\"), (\"python\")).Equals((Tuple.Create(\"python\", 0L, 6L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"programming\")).Equals((Tuple.Create(\"programming\", 7L, 18L))));\n    Debug.Assert(OccuranceSubstring((\"python programming,programming language\"), (\"language\")).Equals((Tuple.Create(\"language\", 31L, 39L))));\n    Debug.Assert(OccuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).Equals(null));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether every odd index contains odd numbers of a given list.\n    public static bool OddPosition(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L, (long)3L, (long)6L, (long)7L, (long)6L, (long)3L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)4L, (long)1L, (long)2L}))) == (true));\n    Debug.Assert(OddPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long CountVowels(string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountVowels((\"bestinstareels\")) == (7L));\n    Debug.Assert(CountVowels((\"partofthejourneyistheend\")) == (12L));\n    Debug.Assert(CountVowels((\"amazonprime\")) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of non-repeated elements in a given list.\n    public static long FindSum(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)1L, (long)1L, (long)4L, (long)5L, (long)6L}))) == (21L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)1L, (long)10L, (long)9L, (long)4L, (long)2L, (long)10L, (long)10L, (long)45L, (long)4L}))) == (71L));\n    Debug.Assert(FindSum((new List<long>(new long[]{(long)12L, (long)10L, (long)9L, (long)45L, (long)2L, (long)10L, (long)10L, (long)45L, (long)10L}))) == (78L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static List<List<object>> PackConsecutiveDuplicates(List<object> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)0L, (long)0L, (long)1L, (long)2L, (long)3L, (long)4L, (long)4L, (long)5L, (long)6L, (long)6L, (long)6L, (long)7L, (long)8L, (long)9L, (long)4L, (long)4L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)0L, (long)0L}), (List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)2L}), (List<long>)new List<long>(new long[]{(long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L}), (List<long>)new List<long>(new long[]{(long)6L, (long)6L, (long)6L}), (List<long>)new List<long>(new long[]{(long)7L}), (List<long>)new List<long>(new long[]{(long)8L}), (List<long>)new List<long>(new long[]{(long)9L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new long[]{(long)10L, (long)10L, (long)15L, (long)19L, (long)18L, (long)18L, (long)17L, (long)26L, (long)26L, (long)17L, (long)18L, (long)10L}))).Equals((new List<List<object>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)10L, (long)10L}), (List<long>)new List<long>(new long[]{(long)15L}), (List<long>)new List<long>(new long[]{(long)19L}), (List<long>)new List<long>(new long[]{(long)18L, (long)18L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)26L, (long)26L}), (List<long>)new List<long>(new long[]{(long)17L}), (List<long>)new List<long>(new long[]{(long)18L}), (List<long>)new List<long>(new long[]{(long)10L})}))));\n    Debug.Assert(PackConsecutiveDuplicates((new List<object>(new string[]{(string)\"a\", (string)\"a\", (string)\"b\", (string)\"c\", (string)\"d\", (string)\"d\"}))).Equals((new List<List<object>>(new List<string>[]{(List<string>)new List<string>(new string[]{(string)\"a\", (string)\"a\"}), (List<string>)new List<string>(new string[]{(string)\"b\"}), (List<string>)new List<string>(new string[]{(string)\"c\"}), (List<string>)new List<string>(new string[]{(string)\"d\", (string)\"d\"})}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find whether a number is divisible by 11.\n    public static bool IsDiff(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsDiff((12345L)) == (false));\n    Debug.Assert(IsDiff((1212112L)) == (true));\n    Debug.Assert(IsDiff((1212L)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/csthon-combinations-of-sum-with-tuples-in-tuple-list/\n    public static List<Tuple<long, long>> FindCombinations(List<Tuple<long, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(2L, 4L), (Tuple<long, long>)Tuple.Create(6L, 7L), (Tuple<long, long>)Tuple.Create(5L, 1L), (Tuple<long, long>)Tuple.Create(6L, 10L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(8L, 11L), (Tuple<long, long>)Tuple.Create(7L, 5L), (Tuple<long, long>)Tuple.Create(8L, 14L), (Tuple<long, long>)Tuple.Create(11L, 8L), (Tuple<long, long>)Tuple.Create(12L, 17L), (Tuple<long, long>)Tuple.Create(11L, 11L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(3L, 5L), (Tuple<long, long>)Tuple.Create(7L, 8L), (Tuple<long, long>)Tuple.Create(6L, 2L), (Tuple<long, long>)Tuple.Create(7L, 11L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(10L, 13L), (Tuple<long, long>)Tuple.Create(9L, 7L), (Tuple<long, long>)Tuple.Create(10L, 16L), (Tuple<long, long>)Tuple.Create(13L, 10L), (Tuple<long, long>)Tuple.Create(14L, 19L), (Tuple<long, long>)Tuple.Create(13L, 13L)}))));\n    Debug.Assert(FindCombinations((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(4L, 6L), (Tuple<long, long>)Tuple.Create(8L, 9L), (Tuple<long, long>)Tuple.Create(7L, 3L), (Tuple<long, long>)Tuple.Create(8L, 12L)}))).Equals((new List<Tuple<long, long>>(new Tuple<long, long>[]{(Tuple<long, long>)Tuple.Create(12L, 15L), (Tuple<long, long>)Tuple.Create(11L, 9L), (Tuple<long, long>)Tuple.Create(12L, 18L), (Tuple<long, long>)Tuple.Create(15L, 12L), (Tuple<long, long>)Tuple.Create(16L, 21L), (Tuple<long, long>)Tuple.Create(15L, 15L)}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the count of divisors is even. https://www.w3resource.com/csthon-exercises/basic/csthon-basic-1-exercise-24.php\n    public static bool CountDivisors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountDivisors((10L)) == (true));\n    Debug.Assert(CountDivisors((100L)) == (false));\n    Debug.Assert(CountDivisors((125L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n    public static long OddLengthSum(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)4L}))) == (14L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)2L}))) == (15L));\n    Debug.Assert(OddLengthSum((new List<long>(new long[]{(long)1L, (long)7L}))) == (8L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static List<float> RgbToHsv(long r, long g, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RgbToHsv((255L), (255L), (255L)).Equals((new List<float>(new float[]{(float)0.0f, (float)0.0f, (float)100.0f}))));\n    Debug.Assert(RgbToHsv((0L), (215L), (0L)).Equals((new List<float>(new float[]{(float)120.0f, (float)100.0f, (float)84.31372549019608f}))));\n    Debug.Assert(RgbToHsv((10L), (215L), (110L)).Equals((new List<float>(new float[]{(float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long MulEvenOdd(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L, (long)7L, (long)4L, (long)1L, (long)6L, (long)8L}))) == (4L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))) == (2L));\n    Debug.Assert(MulEvenOdd((new List<long>(new long[]{(long)1L, (long)5L, (long)7L, (long)9L, (long)10L}))) == (10L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Tuple<long, long, long> TupleStrInt(string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TupleStrInt((\"(7, 8, 9)\")).Equals((Tuple.Create(7L, 8L, 9L))));\n    Debug.Assert(TupleStrInt((\"(1, 2, 3)\")).Equals((Tuple.Create(1L, 2L, 3L))));\n    Debug.Assert(TupleStrInt((\"(4, 5, 6)\")).Equals((Tuple.Create(4L, 5L, 6L))));\n    Debug.Assert(TupleStrInt((\"(7, 81, 19)\")).Equals((Tuple.Create(7L, 81L, 19L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long RightInsertion(List<long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (6L)) == (4L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (3L)) == (2L));\n    Debug.Assert(RightInsertion((new List<long>(new long[]{(long)1L, (long)2L, (long)4L, (long)5L})), (7L)) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static bool TextMatchThree(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextMatchThree((\"ac\")) == (false));\n    Debug.Assert(TextMatchThree((\"dc\")) == (false));\n    Debug.Assert(TextMatchThree((\"abbbba\")) == (true));\n    Debug.Assert(TextMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Tuple<string, string, string> NewTuple(List<string> test_list, string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"WEB\", (string)\"is\"})), (\"best\")).Equals((Tuple.Create(\"WEB\", \"is\", \"best\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"We\", (string)\"are\"})), (\"Developers\")).Equals((Tuple.Create(\"We\", \"are\", \"Developers\"))));\n    Debug.Assert(NewTuple((new List<string>(new string[]{(string)\"Part\", (string)\"is\"})), (\"Wrong\")).Equals((Tuple.Create(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether every even index contains even numbers of a given list.\n    public static bool EvenPosition(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (false));\n    Debug.Assert(EvenPosition((new List<long>(new long[]{(long)2L, (long)1L, (long)4L}))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Tuple<long, long, long, long> RemoveNested(object test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveNested(Tuple.Create(1L, 5L, 7L, Tuple.Create(4L, 6L), 10L)).Equals((Tuple.Create(1L, 5L, 7L, 10L))));\n    Debug.Assert(RemoveNested(Tuple.Create(2L, 6L, 8L, Tuple.Create(5L, 7L), 11L)).Equals((Tuple.Create(2L, 6L, 8L, 11L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    Debug.Assert(RemoveNested(Tuple.Create(3L, 7L, 9L, Tuple.Create(6L, 8L), Tuple.Create(5L, 12L), 12L)).Equals((Tuple.Create(3L, 7L, 9L, 12L))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of lists in a given number of lists.\n    public static long CountList(List<List<long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)3L}), (List<long>)new List<long>(new long[]{(long)5L, (long)7L}), (List<long>)new List<long>(new long[]{(long)9L, (long)11L}), (List<long>)new List<long>(new long[]{(long)13L, (long)15L, (long)17L})}))) == (4L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L})}))) == (3L));\n    Debug.Assert(CountList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)0L}), (List<long>)new List<long>(new long[]{(long)2L, (long)0L})}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the last position of an element in a sorted list.\n    public static long Last(List<long> arr, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)2L, (long)3L})), (1L)) == (0L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)1L, (long)1L, (long)1L, (long)2L, (long)3L, (long)4L})), (1L)) == (2L));\n    Debug.Assert(Last((new List<long>(new long[]{(long)2L, (long)3L, (long)2L, (long)3L, (long)6L, (long)8L, (long)9L})), (3L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static bool TextStartaEndb(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TextStartaEndb((\"aabbbb\")) == (true));\n    Debug.Assert(TextStartaEndb((\"aabAbbbc\")) == (false));\n    Debug.Assert(TextStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long ReturnSum(Dictionary<string,long> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 100L}, {\"b\", 200L}, {\"c\", 300L}})) == (600L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 25L}, {\"b\", 18L}, {\"c\", 45L}})) == (88L));\n    Debug.Assert(ReturnSum((new Dictionary<string,long>(){{\"a\", 36L}, {\"b\", 39L}, {\"c\", 49L}})) == (124L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of all odd natural numbers within the range l and r.\n    public static long SumInRange(long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SumInRange((2L), (5L)) == (8L));\n    Debug.Assert(SumInRange((5L), (7L)) == (12L));\n    Debug.Assert(SumInRange((7L), (13L)) == (40L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the sum of a list.\n    public static long Sum(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sum((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (6L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)15L, (long)12L, (long)13L, (long)10L}))) == (50L));\n    Debug.Assert(Sum((new List<long>(new long[]{(long)0L, (long)1L, (long)2L}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long LeftRotate(long n, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LeftRotate((16L), (2L)) == (64L));\n    Debug.Assert(LeftRotate((10L), (2L)) == (40L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((99L), (3L)) == (792L));\n    Debug.Assert(LeftRotate((1L), (3L)) == (8L));\n    Debug.Assert(LeftRotate((5L), (3L)) == (40L));\n    Debug.Assert(LeftRotate((29L), (3L)) == (232L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to check whether the length of the word is odd or not.\n    public static bool WordLen(string s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(WordLen((\"Hadoop\")) == (false));\n    Debug.Assert(WordLen((\"great\")) == (true));\n    Debug.Assert(WordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static string RemoveAllSpaces(string text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(RemoveAllSpaces((\"python  program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"python   programming    language\")).Equals((\"pythonprogramminglanguage\")));\n    Debug.Assert(RemoveAllSpaces((\"python                     program\")).Equals((\"pythonprogram\")));\n    Debug.Assert(RemoveAllSpaces((\"   python                     program\")).Equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of equal numbers from three given integers.\n    public static long TestThreeEqual(long x, long y, long z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TestThreeEqual((1L), (1L), (1L)) == (3L));\n    Debug.Assert(TestThreeEqual((-1L), (-2L), (-3L)) == (0L));\n    Debug.Assert(TestThreeEqual((1L), (2L), (2L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n    public static long CountRotation(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)3L, (long)2L, (long)1L}))) == (1L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)4L, (long)5L, (long)1L, (long)2L, (long)3L}))) == (2L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)1L, (long)2L, (long)3L}))) == (3L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (0L));\n    Debug.Assert(CountRotation((new List<long>(new long[]{(long)1L, (long)3L, (long)2L}))) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static bool IsPerfectSquare(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsPerfectSquare((10L)) == (false));\n    Debug.Assert(IsPerfectSquare((36L)) == (true));\n    Debug.Assert(IsPerfectSquare((14L)) == (false));\n    Debug.Assert(IsPerfectSquare((196L)) == (true));\n    Debug.Assert(IsPerfectSquare((125L)) == (false));\n    Debug.Assert(IsPerfectSquare((15625L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static bool IsProductEven(List<long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)3L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)2L, (long)1L, (long)4L}))) == (true));\n    Debug.Assert(IsProductEven((new List<long>(new long[]{(long)1L, (long)1L}))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static List<long> MaxSumList(List<List<long>> lists) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L}), (List<long>)new List<long>(new long[]{(long)10L, (long)11L, (long)12L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L})}))).Equals((new List<long>(new long[]{(long)10L, (long)11L, (long)12L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)2L, (long)1L}), (List<long>)new List<long>(new long[]{(long)6L, (long)5L, (long)4L}), (List<long>)new List<long>(new long[]{(long)12L, (long)11L, (long)10L})}))).Equals((new List<long>(new long[]{(long)12L, (long)11L, (long)10L}))));\n    Debug.Assert(MaxSumList((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)2L, (long)3L, (long)1L})}))).Equals((new List<long>(new long[]{(long)2L, (long)3L, (long)1L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long MaxRunUppercase(string test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MaxRunUppercase((\"GeMKSForGERksISBESt\")) == (5L));\n    Debug.Assert(MaxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6L));\n    Debug.Assert(MaxRunUppercase((\"GooGLEFluTTER\")) == (4L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the first odd number in a given list of numbers.\n    public static long FirstOdd(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)1L, (long)3L, (long)5L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)2L, (long)4L, (long)1L, (long)3L}))) == (1L));\n    Debug.Assert(FirstOdd((new List<long>(new long[]{(long)8L, (long)9L, (long)1L}))) == (9L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static bool CheckK(List<long> test_tup, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)10L, (long)4L, (long)5L, (long)6L, (long)8L})), (6L)) == (true));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L})), (7L)) == (false));\n    Debug.Assert(CheckK((new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)44L, (long)11L, (long)12L})), (11L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static bool CheckSmaller(Tuple<long, long, long> test_tup1, Tuple<long, long, long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CheckSmaller((Tuple.Create(1L, 2L, 3L)), (Tuple.Create(2L, 3L, 4L))) == (false));\n    Debug.Assert(CheckSmaller((Tuple.Create(4L, 5L, 6L)), (Tuple.Create(3L, 4L, 5L))) == (true));\n    Debug.Assert(CheckSmaller((Tuple.Create(11L, 12L, 13L)), (Tuple.Create(10L, 11L, 12L))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long TetrahedralNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(TetrahedralNumber((5L)) == (35L));\n    Debug.Assert(TetrahedralNumber((6L)) == (56L));\n    Debug.Assert(TetrahedralNumber((7L)) == (84L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static string GetChar(string strr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(GetChar((\"abc\")).Equals((\"f\")));\n    Debug.Assert(GetChar((\"gfg\")).Equals((\"t\")));\n    Debug.Assert(GetChar((\"ab\")).Equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long Sequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Sequence((10L)) == (6L));\n    Debug.Assert(Sequence((2L)) == (1L));\n    Debug.Assert(Sequence((3L)) == (2L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long CenteredHexagonalNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(CenteredHexagonalNumber((10L)) == (271L));\n    Debug.Assert(CenteredHexagonalNumber((2L)) == (7L));\n    Debug.Assert(CenteredHexagonalNumber((9L)) == (217L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static Dictionary<string,string> MergeDictionariesThree(Dictionary<string,string> dict1, Dictionary<string,string> dict2, Dictionary<string,string> dict3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"O\", \"Orange\"}, {\"W\", \"White\"}, {\"B\", \"Black\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"P\", \"Pink\"}, {\"G\", \"Green\"}, {\"W\", \"White\"}, {\"O\", \"Orange\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}})).Equals((new Dictionary<string,string>(){{\"W\", \"White\"}, {\"P\", \"Pink\"}, {\"B\", \"Black\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}})));\n    Debug.Assert(MergeDictionariesThree((new Dictionary<string,string>(){{\"R\", \"Red\"}, {\"B\", \"Black\"}, {\"P\", \"Pink\"}}), (new Dictionary<string,string>(){{\"L\", \"lavender\"}, {\"B\", \"Blue\"}}), (new Dictionary<string,string>(){{\"G\", \"Green\"}, {\"W\", \"White\"}})).Equals((new Dictionary<string,string>(){{\"B\", \"Black\"}, {\"P\", \"Pink\"}, {\"R\", \"Red\"}, {\"G\", \"Green\"}, {\"L\", \"lavender\"}, {\"W\", \"White\"}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static Dictionary<long,long> FreqCount(List<long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)10L, (long)10L, (long)10L, (long)10L, (long)20L, (long)20L, (long)20L, (long)20L, (long)40L, (long)40L, (long)50L, (long)50L, (long)30L}))).Equals((new Dictionary<long,long>(){{10L, 4L}, {20L, 4L}, {40L, 2L}, {50L, 2L}, {30L, 1L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)3L, (long)2L, (long)4L, (long)1L, (long)3L, (long)1L, (long)4L}))).Equals((new Dictionary<long,long>(){{1L, 3L}, {2L, 2L}, {3L, 3L}, {4L, 3L}})));\n    Debug.Assert(FreqCount((new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)4L, (long)9L, (long)10L, (long)4L, (long)5L, (long)6L, (long)7L, (long)9L, (long)5L}))).Equals((new Dictionary<long,long>(){{10L, 1L}, {5L, 3L}, {6L, 2L}, {7L, 2L}, {4L, 2L}, {9L, 2L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long ClosestNum(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(ClosestNum((11L)) == (10L));\n    Debug.Assert(ClosestNum((7L)) == (6L));\n    Debug.Assert(ClosestNum((12L)) == (11L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static List<long> SquareNums(List<long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L, (long)5L, (long)6L, (long)7L, (long)8L, (long)9L, (long)10L}))).Equals((new List<long>(new long[]{(long)1L, (long)4L, (long)9L, (long)16L, (long)25L, (long)36L, (long)49L, (long)64L, (long)81L, (long)100L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)10L, (long)20L, (long)30L}))).Equals((new List<long>(new long[]{(long)100L, (long)400L, (long)900L}))));\n    Debug.Assert(SquareNums((new List<long>(new long[]{(long)12L, (long)15L}))).Equals((new List<long>(new long[]{(long)144L, (long)225L}))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the longest word.\n    public static long LenLog(List<string> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"python\", (string)\"PHP\", (string)\"bigdata\"}))) == (7L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"a\", (string)\"ab\", (string)\"abc\"}))) == (3L));\n    Debug.Assert(LenLog((new List<string>(new string[]{(string)\"small\", (string)\"big\", (string)\"tall\"}))) == (5L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static bool FindSubstring(List<string> str1, string sub_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ack\")) == (true));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"abc\")) == (false));\n    Debug.Assert(FindSubstring((new List<string>(new string[]{(string)\"red\", (string)\"black\", (string)\"white\", (string)\"green\", (string)\"orange\"})), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static bool IsUndulating(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IsUndulating((1212121L)) == (true));\n    Debug.Assert(IsUndulating((1991L)) == (false));\n    Debug.Assert(IsUndulating((121L)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long Power(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Power((3L), (4L)) == (81L));\n    Debug.Assert(Power((2L), (3L)) == (8L));\n    Debug.Assert(Power((5L), (5L)) == (3125L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static string IndexMinimum(List<Tuple<string, long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Rash\", 143L), (Tuple<string, long>)Tuple.Create(\"Manjeet\", 200L), (Tuple<string, long>)Tuple.Create(\"Varsha\", 100L)}))).Equals((\"Varsha\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Yash\", 185L), (Tuple<string, long>)Tuple.Create(\"Dawood\", 125L), (Tuple<string, long>)Tuple.Create(\"Sanya\", 175L)}))).Equals((\"Dawood\")));\n    Debug.Assert(IndexMinimum((new List<Tuple<string, long>>(new Tuple<string, long>[]{(Tuple<string, long>)Tuple.Create(\"Sai\", 345L), (Tuple<string, long>)Tuple.Create(\"Salman\", 145L), (Tuple<string, long>)Tuple.Create(\"Ayesha\", 96L)}))).Equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(List<List<long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L})}))) == (1L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L}), (List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L})}))) == (2L));\n    Debug.Assert(FindMinLength((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)3L, (long)3L, (long)3L}), (List<long>)new List<long>(new long[]{(long)4L, (long)4L, (long)4L, (long)4L})}))) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the number of divisors of a given integer.\n    public static long Divisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(Divisor((15L)) == (4L));\n    Debug.Assert(Divisor((12L)) == (6L));\n    Debug.Assert(Divisor((9L)) == (3L));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static Dictionary<long,long> FrequencyLists(List<List<long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)2L}), (List<long>)new List<long>(new long[]{(long)4L, (long)5L, (long)6L, (long)2L}), (List<long>)new List<long>(new long[]{(long)7L, (long)8L, (long)9L, (long)5L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 3L}, {3L, 1L}, {4L, 1L}, {5L, 2L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)1L, (long)2L, (long)3L, (long)4L}), (List<long>)new List<long>(new long[]{(long)5L, (long)6L, (long)7L, (long)8L}), (List<long>)new List<long>(new long[]{(long)9L, (long)10L, (long)11L, (long)12L})}))).Equals((new Dictionary<long,long>(){{1L, 1L}, {2L, 1L}, {3L, 1L}, {4L, 1L}, {5L, 1L}, {6L, 1L}, {7L, 1L}, {8L, 1L}, {9L, 1L}, {10L, 1L}, {11L, 1L}, {12L, 1L}})));\n    Debug.Assert(FrequencyLists((new List<List<long>>(new List<long>[]{(List<long>)new List<long>(new long[]{(long)20L, (long)30L, (long)40L, (long)17L}), (List<long>)new List<long>(new long[]{(long)18L, (long)16L, (long)14L, (long)13L}), (List<long>)new List<long>(new long[]{(long)10L, (long)20L, (long)30L, (long)40L})}))).Equals((new Dictionary<long,long>(){{20L, 2L}, {30L, 2L}, {40L, 2L}, {17L, 1L}, {18L, 1L}, {16L, 1L}, {14L, 1L}, {13L, 1L}, {10L, 1L}})));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static string DecimalToBinary(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(DecimalToBinary((8L)).Equals((\"1000\")));\n    Debug.Assert(DecimalToBinary((18L)).Equals((\"10010\")));\n    Debug.Assert(DecimalToBinary((7L)).Equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "cs",
+    "prompt": "using System;\nusing System.Numerics;\nusing System.Diagnostics;\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text;\nusing System.Security.Cryptography;\nclass Problem {\n    // Write a csthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long FindRotations(string str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void Main(string[] args) {\n    Debug.Assert(FindRotations((\"aaaa\")) == (1L));\n    Debug.Assert(FindRotations((\"ab\")) == (2L));\n    Debug.Assert(FindRotations((\"abc\")) == (3L));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-d-keep.json
+++ b/prompts/mbpp-d-keep.json
@@ -1,85 +1,10 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\n*/\nlong lps(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = lps;\n\n    assert(candidate(\"TENS FOR TENS\") == 5L);\n    assert(candidate(\"CARDIO FOR CARDS\") == 7L);\n    assert(candidate(\"PART OF THE JOURNEY IS PART\") == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to remove all whitespaces from the given string.\n\t\n*/\nstring remove_whitespaces(string text1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_whitespaces;\n\n    assert(candidate(\" Google    Flutter \") == \"GoogleFlutter\");\n    assert(candidate(\" Google    Dart \") == \"GoogleDart\");\n    assert(candidate(\" iOS    Swift \") == \"iOSSwift\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to check whether a specified list is sorted or not.\n\t\n*/\nbool issort_list(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = issort_list;\n\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 16L, 17L]) == true);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 20L, 17L]) == false);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 15L, 14L, 20L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count bidirectional tuple pairs.\n\t\n*/\nlong count_bidirectional(Tuple!(long, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_bidirectional;\n\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 3L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 3L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 2L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 2L), tuple(6L, 5L), tuple(2L, 1L)]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the surface area of a cube of a given size.\n\t\n*/\nlong surfacearea_cube(long l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = surfacearea_cube;\n\n    assert(candidate(5L) == 150L);\n    assert(candidate(3L) == 54L);\n    assert(candidate(10L) == 600L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\n*/\nlong next_smallest_palindrome(long num) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\n*/\nlong next_smallest_palindrome(long num) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = next_smallest_palindrome;\n\n    assert(candidate(99L) == 101L);\n    assert(candidate(1221L) == 1331L);\n    assert(candidate(120L) == 121L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -90,3926 +15,11 @@
     ]
   },
   {
-    "name": "mbpp_420_cube_Sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\n*/\nlong cube_Sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cube_Sum;\n\n    assert(candidate(2L) == 72L);\n    assert(candidate(3L) == 288L);\n    assert(candidate(4L) == 800L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\n*/\nlong pair_xor_Sum(long[] arr, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pair_xor_Sum;\n\n    assert(candidate([5L, 9L, 7L, 6L], 4L) == 47L);\n    assert(candidate([7L, 3L, 5L], 3L) == 12L);\n    assert(candidate([7L, 3L], 2L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\n*/\nbool check_min_heap(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_min_heap;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 10L, 15L]) == true);\n    assert(candidate([2L, 10L, 4L, 5L, 3L, 15L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the first digit of a given number.\n\t\n*/\nlong first_Digit(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = first_Digit;\n\n    assert(candidate(123L) == 1L);\n    assert(candidate(456L) == 4L);\n    assert(candidate(12L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\n*/\nNullable!(string) first_non_repeating_character(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = first_non_repeating_character;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"ababc\");\n        assert(!result.isNull && result.get == \"c\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert degrees to radians.\n\t\n*/\nfloat radian_degree(long degree) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = radian_degree;\n\n    assert(candidate(90L) == 1.5707963267948966);\n    assert(candidate(60L) == 1.0471975511965976);\n    assert(candidate(120L) == 2.0943951023931953);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum product subarray of the given array.\n\t\n*/\nlong max_subarray_product(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_subarray_product;\n\n    assert(candidate([1L, -2L, -3L, 0L, 7L, -8L, -2L]) == 112L);\n    assert(candidate([6L, -3L, -10L, 0L, 2L]) == 180L);\n    assert(candidate([-2L, -40L, 0L, -2L, -3L]) == 80L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert more than one list to nested dictionary.\n\t\n*/\nNone[] convert_list_dictionary(string[] l1, string[] l2, long[] l3) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = convert_list_dictionary;\n\n    assert(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85L, 98L, 89L, 92L]) == [[\"S001\": [\"Adina Park\": 85L].nullable].nullable, [\"S002\": [\"Leyton Marsh\": 98L].nullable].nullable, [\"S003\": [\"Duncan Boyle\": 89L].nullable].nullable, [\"S004\": [\"Saim Richards\": 92L].nullable].nullable]);\n    assert(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100L, 200L, 300L, 400L]) == [[\"abc\": [\"python\": 100L].nullable].nullable, [\"def\": [\"program\": 200L].nullable].nullable, [\"ghi\": [\"language\": 300L].nullable].nullable, [\"jkl\": [\"programs\": 400L].nullable].nullable]);\n    assert(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10L, 20L, 30L, 40L]) == [[\"A1\": [\"java\": 10L].nullable].nullable, [\"A2\": [\"C\": 20L].nullable].nullable, [\"A3\": [\"C++\": 30L].nullable].nullable, [\"A4\": [\"DBMS\": 40L].nullable].nullable]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find smallest number in a list.\n\t\n*/\nlong smallest_num(long[] xs) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = smallest_num;\n\n    assert(candidate([10L, 20L, 1L, 45L, 99L]) == 1L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n    assert(candidate([45L, 46L, 50L, 60L]) == 45L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\n*/\nbool text_match_zero_one(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_zero_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"dsabbbba\") == true);\n    assert(candidate(\"asbbbba\") == false);\n    assert(candidate(\"abaaa\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find nth bell number.\n\t\n*/\nlong bell_Number(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = bell_Number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 15L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find cubes of individual elements in a list.\n\t\n*/\nlong[] cube_nums(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cube_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 8L, 27L, 64L, 125L, 216L, 343L, 512L, 729L, 1000L]);\n    assert(candidate([10L, 20L, 30L]) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L]) == [1728L, 3375L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\n*/\nlong last_Digit_Factorial(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = last_Digit_Factorial;\n\n    assert(candidate(4L) == 4L);\n    assert(candidate(21L) == 0L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find even numbers from a list of numbers.\n\t\n*/\nlong[] Split(long[] list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [2L, 4L]);\n    assert(candidate([4L, 5L, 6L, 7L, 8L, 0L, 1L]) == [4L, 6L, 8L, 0L]);\n    assert(candidate([8L, 12L, 15L, 19L]) == [8L, 12L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if the given integer is a prime number.\n\t\n*/\nbool prime_num(long num) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = prime_num;\n\n    assert(candidate(13L) == true);\n    assert(candidate(7L) == true);\n    assert(candidate(-1010L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\n*/\nTuple!(long, long, long)[] find_tuples(Tuple!(long, long, long)[] test_list, long K) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_tuples;\n\n    assert(candidate([tuple(6L, 24L, 12L), tuple(7L, 9L, 6L), tuple(12L, 18L, 21L)], 6L) == [tuple(6L, 24L, 12L)]);\n    assert(candidate([tuple(5L, 25L, 30L), tuple(4L, 2L, 3L), tuple(7L, 8L, 9L)], 5L) == [tuple(5L, 25L, 30L)]);\n    assert(candidate([tuple(7L, 9L, 16L), tuple(8L, 16L, 4L), tuple(19L, 17L, 18L)], 4L) == [tuple(8L, 16L, 4L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\n*/\nfloat area_tetrahedron(long side) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = area_tetrahedron;\n\n    assert(candidate(3L) == 15.588457268119894);\n    assert(candidate(20L) == 692.8203230275509);\n    assert(candidate(10L) == 173.20508075688772);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given number is even or not.\n\t\n*/\nbool is_Even(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_Even;\n\n    assert(candidate(1L) == false);\n    assert(candidate(2L) == true);\n    assert(candidate(3L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of positive numbers in a list.\n\t\n*/\nlong pos_count(long[] list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pos_count;\n\n    assert(candidate([1L, -2L, 3L, -4L]) == 2L);\n    assert(candidate([3L, 4L, 5L, -1L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\n*/\nlong[] get_ludic(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_ludic;\n\n    assert(candidate(10L) == [1L, 2L, 3L, 5L, 7L]);\n    assert(candidate(25L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L]);\n    assert(candidate(45L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L, 29L, 37L, 41L, 43L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\n*/\nlong find_Index(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Index;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 14L);\n    assert(candidate(4L) == 45L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to reverse an array upto a given position.\n\t\n*/\nlong[] reverse_Array_Upto_K(long[] input, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = reverse_Array_Upto_K;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 4L) == [4L, 3L, 2L, 1L, 5L, 6L]);\n    assert(candidate([4L, 5L, 6L, 7L], 2L) == [5L, 4L, 6L, 7L]);\n    assert(candidate([9L, 8L, 7L, 6L, 5L], 3L) == [7L, 8L, 9L, 6L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\n*/\nTuple!(string, long)[] subject_marks(Tuple!(string, long)[] subjectmarks) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = subject_marks;\n\n    assert(candidate([tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L), tuple(\"Social sciences\", 82L)]) == [tuple(\"Social sciences\", 82L), tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L)]);\n    assert(candidate([tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L), tuple(\"Social\", 33L)]) == [tuple(\"Social\", 33L), tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L)]);\n    assert(candidate([tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L), tuple(\"Biology\", 45L)]) == [tuple(\"Biology\", 45L), tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\n*/\nstring remove_dirty_chars(string string, string second_string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_dirty_chars;\n\n    assert(candidate(\"probasscurve\", \"pros\") == \"bacuve\");\n    assert(candidate(\"digitalindia\", \"talent\") == \"digiidi\");\n    assert(candidate(\"exoticmiles\", \"toxic\") == \"emles\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\n*/\nlong max_occurrences(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_occurrences;\n\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 2L, 6L, 5L, 1L, 6L, 1L, 2L, 3L, 2L, 4L, 6L, 9L, 1L, 2L]) == 2L);\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 7L, 9L, 15L, 14L, 10L, 12L, 13L, 16L, 18L]) == 8L);\n    assert(candidate([10L, 20L, 20L, 30L, 40L, 90L, 80L, 50L, 30L, 20L, 50L, 10L]) == 20L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\n*/\nbool is_decimal(string num) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_decimal;\n\n    assert(candidate(\"123.11\") == true);\n    assert(candidate(\"e666.86\") == false);\n    assert(candidate(\"3.124587\") == false);\n    assert(candidate(\"1.11\") == true);\n    assert(candidate(\"1.1.11\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\n*/\nNullable!(long[string]) dict_filter(Nullable!(long[string]) dict, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = dict_filter;\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 170L);\n        assert(!result.isNull && result.get == [\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 180L);\n        assert(!result.isNull && result.get == [\"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 190L);\n        assert(!result.isNull && result.get == [\"Pierre Cox\": 190L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\n*/\nlong sum_even_and_even_index(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_even_and_even_index;\n\n    assert(candidate([5L, 6L, 12L, 1L, 18L, 8L]) == 30L);\n    assert(candidate([3L, 20L, 17L, 9L, 2L, 10L, 18L, 13L, 6L, 18L]) == 26L);\n    assert(candidate([5L, 6L, 12L, 1L]) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\n*/\nlong max_sub_array_sum(long[] a, long size) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum;\n\n    assert(candidate([-2L, -3L, 4L, -1L, -2L, 1L, 5L, -3L], 8L) == 7L);\n    assert(candidate([-3L, -4L, 5L, -2L, -3L, 2L, 6L, -4L], 8L) == 8L);\n    assert(candidate([-4L, -5L, 6L, -3L, -4L, 3L, 7L, -5L], 8L) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the intersection of two arrays.\n\t\n*/\nlong[] intersection_array(long[] array_nums1, long[] array_nums2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = intersection_array;\n\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [1L, 2L, 4L, 8L, 9L]) == [1L, 2L, 8L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [3L, 5L, 7L, 9L]) == [3L, 5L, 7L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [10L, 20L, 30L, 40L]) == [10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\n*/\nTuple!(string, long, long) find_literals(string text, string pattern) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_literals;\n\n    assert(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == tuple(\"fox\", 16L, 19L));\n    assert(candidate(\"Its been a very crazy procedure right\", \"crazy\") == tuple(\"crazy\", 16L, 21L));\n    assert(candidate(\"Hardest choices required strongest will\", \"will\") == tuple(\"will\", 35L, 39L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the volume of a triangular prism.\n\t\n*/\nlong find_Volume(long l, long b, long h) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Volume;\n\n    assert(candidate(10L, 8L, 6L) == 240L);\n    assert(candidate(3L, 2L, 2L) == 6L);\n    assert(candidate(1L, 2L, 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\n*/\nlong wind_chill(long v, long t) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = wind_chill;\n\n    assert(candidate(120L, 35L) == 40L);\n    assert(candidate(40L, 20L) == 19L);\n    assert(candidate(10L, 8L) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the ascii value of a character.\n\t\n*/\nlong ascii_value(string k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = ascii_value;\n\n    assert(candidate(\"A\") == 65L);\n    assert(candidate(\"R\") == 82L);\n    assert(candidate(\"S\") == 83L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether all the characters are same or not.\n\t\n*/\nbool all_Characters_Same(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_Characters_Same;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"aaa\") == true);\n    assert(candidate(\"data\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to move all the numbers to the end of the given string.\n\t\n*/\nstring move_num(string test_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = move_num;\n\n    assert(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\");\n    assert(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\");\n    assert(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\n*/\nbool word_len(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = word_len;\n\n    assert(candidate(\"Hadoop\") == false);\n    assert(candidate(\"great\") == true);\n    assert(candidate(\"structure\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\n*/\nstring[] insert_element(string[] list, string element) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = insert_element;\n\n    assert(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n    assert(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"]);\n    assert(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove lowercase substrings from a given string.\n\t\n*/\nstring remove_lowercase(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_lowercase;\n\n    assert(candidate(\"PYTHon\") == \"PYTH\");\n    assert(candidate(\"FInD\") == \"FID\");\n    assert(candidate(\"STRinG\") == \"STRG\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\n*/\nlong count_Set_Bits(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_Set_Bits;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 1L);\n    assert(candidate(6L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\n*/\nstring[] extract_rear(Tuple!(string, string, string) test_tuple) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = extract_rear;\n\n    assert(candidate(tuple(\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"]);\n    assert(candidate(tuple(\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"]);\n    assert(candidate(tuple(\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\n*/\nlong count_occurance(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_occurance;\n\n    assert(candidate(\"letstdlenstdporstd\") == 3L);\n    assert(candidate(\"truststdsolensporsd\") == 1L);\n    assert(candidate(\"makestdsostdworthit\") == 2L);\n    assert(candidate(\"stds\") == 1L);\n    assert(candidate(\"\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if the given tuples contain the k or not.\n\t\n*/\nbool check_K(long[] test_tup, long K) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_K;\n\n    assert(candidate([10L, 4L, 5L, 6L, 8L], 6L) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 7L) == false);\n    assert(candidate([7L, 8L, 9L, 44L, 11L, 12L], 11L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\n*/\nlong[] interleave_lists(long[] list1, long[] list2, long[] list3) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = interleave_lists;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L], [10L, 20L, 30L, 40L, 50L, 60L, 70L], [100L, 200L, 300L, 400L, 500L, 600L, 700L]) == [1L, 10L, 100L, 2L, 20L, 200L, 3L, 30L, 300L, 4L, 40L, 400L, 5L, 50L, 500L, 6L, 60L, 600L, 7L, 70L, 700L]);\n    assert(candidate([10L, 20L], [15L, 2L], [5L, 10L]) == [10L, 15L, 5L, 20L, 2L, 10L]);\n    assert(candidate([11L, 44L], [10L, 15L], [20L, 5L]) == [11L, 10L, 20L, 44L, 15L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"python_program\") == \"PythonProgram\");\n    assert(candidate(\"python_language\") == \"PythonLanguage\");\n    assert(candidate(\"programming_language\") == \"ProgrammingLanguage\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\n*/\nlong test_three_equal(long x, long y, long z) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = test_three_equal;\n\n    assert(candidate(1L, 1L, 1L) == 3L);\n    assert(candidate(-1L, -2L, -3L) == 0L);\n    assert(candidate(1L, 2L, 2L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\n*/\nlong odd_length_sum(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_length_sum;\n\n    assert(candidate([1L, 2L, 4L]) == 14L);\n    assert(candidate([1L, 2L, 1L, 2L]) == 15L);\n    assert(candidate([1L, 7L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\n*/\nlong bell_number(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = bell_number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(10L) == 115975L);\n    assert(candidate(56L) == 6775685320645824322581483068371419745979053216268760300L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the area of a rectangle.\n\t\n*/\nlong rectangle_area(long l, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rectangle_area;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(10L, 5L) == 50L);\n    assert(candidate(4L, 2L) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find sum and average of first n natural numbers.\n\t\n*/\nTuple!(long, float) sum_average(long number) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_average;\n\n    assert(candidate(10L) == tuple(55L, 5.5));\n    assert(candidate(15L) == tuple(120L, 8.0));\n    assert(candidate(20L) == tuple(210L, 10.5));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) division_elements(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = division_elements;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(2L, 2L, 2L, 3L));\n    assert(candidate(tuple(12L, 6L, 8L, 16L), tuple(6L, 3L, 4L, 4L)) == tuple(2L, 2L, 2L, 4L));\n    assert(candidate(tuple(20L, 14L, 36L, 18L), tuple(5L, 7L, 6L, 9L)) == tuple(4L, 2L, 6L, 2L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\n*/\nlong sum_digits(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_digits;\n\n    assert(candidate(345L) == 12L);\n    assert(candidate(12L) == 3L);\n    assert(candidate(97L) == 16L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\n*/\nstring index_minimum(Tuple!(string, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = index_minimum;\n\n    assert(candidate([tuple(\"Rash\", 143L), tuple(\"Manjeet\", 200L), tuple(\"Varsha\", 100L)]) == \"Varsha\");\n    assert(candidate([tuple(\"Yash\", 185L), tuple(\"Dawood\", 125L), tuple(\"Sanya\", 175L)]) == \"Dawood\");\n    assert(candidate([tuple(\"Sai\", 345L), tuple(\"Salman\", 145L), tuple(\"Ayesha\", 96L)]) == \"Ayesha\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to divide two lists element wise.\n\t\n*/\nfloat[] div_list(long[] nums1, long[] nums2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = div_list;\n\n    assert(candidate([4L, 5L, 6L], [1L, 2L, 3L]) == [4.0, 2.5, 2.0]);\n    assert(candidate([3L, 2L], [1L, 4L]) == [3.0, 0.5]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [1.8, 1.7142857142857142]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the list with maximum length.\n\t\n*/\nTuple!(long, long[]) max_length_list(long[][] input_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_length_list;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L, 2L, 3L, 4L, 5L], [1L, 2L, 3L, 4L], [1L, 2L, 3L], [1L, 2L], [1L]]) == tuple(5L, [1L, 2L, 3L, 4L, 5L]));\n    assert(candidate([[3L, 4L, 5L], [6L, 7L, 8L, 9L], [10L, 11L, 12L]]) == tuple(4L, [6L, 7L, 8L, 9L]));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\n*/\nlong big_sum(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = big_sum;\n\n    assert(candidate([1L, 2L, 3L]) == 4L);\n    assert(candidate([-1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([2L, 3L, 6L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to return the negative numbers in a list.\n\t\n*/\nlong[] neg_nos(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = neg_nos;\n\n    assert(candidate([-1L, 4L, 5L, -6L]) == [-1L, -6L]);\n    assert(candidate([-1L, -2L, 3L, 4L]) == [-1L, -2L]);\n    assert(candidate([-7L, -6L, 8L, 9L]) == [-7L, -6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\n*/\nlong highest_Power_of_2(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = highest_Power_of_2;\n\n    assert(candidate(10L) == 8L);\n    assert(candidate(19L) == 16L);\n    assert(candidate(32L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\n*/\nbool is_sublist(long[] l, long[] s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_sublist;\n\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [3L, 7L]) == false);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [4L, 3L]) == true);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [1L, 6L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to subtract two lists element-wise.\n\t\n*/\nlong[] sub_list(long[] nums1, long[] nums2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sub_list;\n\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == [-3L, -3L, -3L]);\n    assert(candidate([1L, 2L], [3L, 4L]) == [-2L, -2L]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [40L, 50L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\n*/\nbool opposite_Signs(long x, long y) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = opposite_Signs;\n\n    assert(candidate(1L, -2L) == true);\n    assert(candidate(3L, 2L) == false);\n    assert(candidate(-10L, -10L) == false);\n    assert(candidate(-2L, 2L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\n*/\nTuple!(long, long, long, long) tuple_modulo(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tuple_modulo;\n\n    assert(candidate(tuple(10L, 4L, 5L, 6L), tuple(5L, 6L, 7L, 5L)) == tuple(0L, 4L, 5L, 1L));\n    assert(candidate(tuple(11L, 5L, 6L, 7L), tuple(6L, 7L, 8L, 6L)) == tuple(5L, 5L, 6L, 1L));\n    assert(candidate(tuple(12L, 6L, 7L, 8L), tuple(7L, 8L, 9L, 7L)) == tuple(5L, 6L, 7L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\n*/\nlong diff_even_odd(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = diff_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 1L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\n*/\nstring[][] sort_sublists(string[][] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the last digit of a given number.\n\t\n*/\nlong last_Digit(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = last_Digit;\n\n    assert(candidate(123L) == 3L);\n    assert(candidate(25L) == 5L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\n*/\nlong odd_num_sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_num_sum;\n\n    assert(candidate(2L) == 82L);\n    assert(candidate(3L) == 707L);\n    assert(candidate(4L) == 3108L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a list to a string.\n\t\n*/\nstring tup_string(string[] tup1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tup_string;\n\n    assert(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\");\n    assert(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\");\n    assert(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove all elements from a given list present in another list.\n\t\n*/\nlong[] remove_elements(long[] list1, long[] list2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_elements;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [2L, 4L, 6L, 8L]) == [1L, 3L, 5L, 7L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [1L, 3L, 5L, 7L]) == [2L, 4L, 6L, 8L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [5L, 7L]) == [1L, 2L, 3L, 4L, 6L, 8L, 9L, 10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\n*/\nbool overlapping(long[] list1, long[] list2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = overlapping;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 8L, 9L]) == false);\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == false);\n    assert(candidate([1L, 4L, 5L], [1L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to identify non-prime numbers.\n\t\n*/\nbool is_not_prime(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_not_prime;\n\n    assert(candidate(2L) == false);\n    assert(candidate(10L) == true);\n    assert(candidate(35L) == true);\n    assert(candidate(37L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\n*/\nlong sum_negativenum(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_negativenum;\n\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == -32L);\n    assert(candidate([10L, 15L, -14L, 13L, -18L, 12L, -20L]) == -52L);\n    assert(candidate([19L, -65L, 57L, 39L, 152L, -639L, 121L, 44L, 90L, -190L]) == -894L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\n*/\nlong find_Rotations(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Rotations;\n\n    assert(candidate(\"aaaa\") == 1L);\n    assert(candidate(\"ab\") == 2L);\n    assert(candidate(\"abc\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\n*/\nstring change_date_format(string dt) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = change_date_format;\n\n    assert(candidate(\"2026-01-02\") == \"02-01-2026\");\n    assert(candidate(\"2020-11-13\") == \"13-11-2020\");\n    assert(candidate(\"2021-04-26\") == \"26-04-2021\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\n*/\nlong[] Split(long[] list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == [1L, 3L, 5L]);\n    assert(candidate([10L, 11L, 12L, 13L]) == [11L, 13L]);\n    assert(candidate([7L, 8L, 9L, 1L]) == [7L, 9L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\n*/\nlong toggle_middle_bits(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = toggle_middle_bits;\n\n    assert(candidate(9L) == 15L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(11L) == 13L);\n    assert(candidate(65L) == 127L);\n    assert(candidate(77L) == 115L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\n*/\nlong count_char_position(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_char_position;\n\n    assert(candidate(\"xbcefg\") == 2L);\n    assert(candidate(\"ABcED\") == 3L);\n    assert(candidate(\"AbgdeF\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\n*/\nlong[] large_product(long[] nums1, long[] nums2, long N) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = large_product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 3L) == [60L, 54L, 50L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 4L) == [60L, 54L, 50L, 48L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 5L) == [60L, 54L, 50L, 48L, 45L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\n*/\nlong cummulative_sum(long[][] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cummulative_sum;\n\n    assert(candidate([[1L, 3L], [5L, 6L, 7L], [2L, 6L]]) == 30L);\n    assert(candidate([[2L, 4L], [6L, 7L, 8L], [3L, 7L]]) == 37L);\n    assert(candidate([[3L, 5L], [7L, 8L, 9L], [4L, 8L]]) == 44L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\n*/\nlong find_min_diff(long[] arr, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_min_diff;\n\n    assert(candidate([1L, 5L, 3L, 19L, 18L, 25L], 6L) == 1L);\n    assert(candidate([4L, 3L, 2L, 6L], 4L) == 1L);\n    assert(candidate([30L, 5L, 20L, 9L], 4L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\n*/\nbool text_starta_endb(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_starta_endb;\n\n    assert(candidate(\"aabbbb\") == true);\n    assert(candidate(\"aabAbbbc\") == false);\n    assert(candidate(\"accddbbjjj\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\n*/\nlong left_rotate(long n, long d) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = left_rotate;\n\n    assert(candidate(16L, 2L) == 64L);\n    assert(candidate(10L, 2L) == 40L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(1L, 3L) == 8L);\n    assert(candidate(5L, 3L) == 40L);\n    assert(candidate(29L, 3L) == 232L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the first repeated character in a given string.\n\t\n*/\nNullable!(string) first_repeated_char(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = first_repeated_char;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"123123\");\n        assert(!result.isNull && result.get == \"1\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count inversions in an array.\n\t\n*/\nlong get_Inv_Count(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_Inv_Count;\n\n    assert(candidate([1L, 20L, 6L, 4L, 5L]) == 5L);\n    assert(candidate([1L, 2L, 1L]) == 1L);\n    assert(candidate([1L, 2L, 5L, 6L, 1L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\n*/\nlong even_Power_Sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_Power_Sum;\n\n    assert(candidate(2L) == 1056L);\n    assert(candidate(3L) == 8832L);\n    assert(candidate(1L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\n*/\nbool get_equal(long[][] Input) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_equal;\n\n    assert(candidate([[11L, 22L, 33L], [44L, 55L, 66L]]) == true);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L, 7L]]) == false);\n    assert(candidate([[1L, 2L], [3L, 4L]]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if a string represents an integer or not.\n\t\n*/\nbool check_integer(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_integer;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"1\") == true);\n    assert(candidate(\"12345\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\n*/\nlong count_reverse_pairs(string[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_reverse_pairs;\n\n    assert(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2L);\n    assert(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1L);\n    assert(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\n*/\nlong[] move_zero(long[] num_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = move_zero;\n\n    assert(candidate([1L, 0L, 2L, 0L, 3L, 4L]) == [1L, 2L, 3L, 4L, 0L, 0L]);\n    assert(candidate([2L, 3L, 2L, 0L, 0L, 4L, 0L, 5L, 0L]) == [2L, 3L, 2L, 4L, 5L, 0L, 0L, 0L, 0L]);\n    assert(candidate([0L, 1L, 0L, 1L, 1L]) == [1L, 1L, 1L, 0L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if given list contains no duplicates.\n\t\n*/\nbool check_distinct(long[] test_tup) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_distinct;\n\n    assert(candidate([1L, 4L, 5L, 6L, 1L, 4L]) == false);\n    assert(candidate([1L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 6L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\n*/\nbool noprofit_noloss(long actual_cost, long sale_amount) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = noprofit_noloss;\n\n    assert(candidate(1500L, 1200L) == false);\n    assert(candidate(100L, 100L) == true);\n    assert(candidate(2000L, 5000L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove all the words with k length in the given string.\n\t\n*/\nstring remove_length(string test_str, long K) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_length;\n\n    assert(candidate(\"The person is most value tet\", 3L) == \"person is most value\");\n    assert(candidate(\"If you told me about this ok\", 4L) == \"If you me about ok\");\n    assert(candidate(\"Forces of darkeness is come into the play\", 4L) == \"Forces of darkeness is the\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count number of digits in a given string.\n\t\n*/\nlong number_ctr(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = number_ctr;\n\n    assert(candidate(\"program2bedone\") == 1L);\n    assert(candidate(\"3wonders\") == 1L);\n    assert(candidate(\"123\") == 3L);\n    assert(candidate(\"3wond-1ers2\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count the total number of characters in a string.\n\t\n*/\nlong count_charac(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_charac;\n\n    assert(candidate(\"python programming\") == 18L);\n    assert(candidate(\"language\") == 8L);\n    assert(candidate(\"words\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\n*/\nlong get_total_number_of_sequences(long m, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_total_number_of_sequences;\n\n    assert(candidate(10L, 4L) == 4L);\n    assert(candidate(5L, 2L) == 6L);\n    assert(candidate(16L, 3L) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\n*/\nlong left_insertion(long[] a, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = left_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\n*/\nlong[] swap_numbers(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = swap_numbers;\n\n    assert(candidate(10L, 20L) == [20L, 10L]);\n    assert(candidate(15L, 17L) == [17L, 15L]);\n    assert(candidate(100L, 200L) == [200L, 100L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\n*/\nbool is_majority(long[] arr, long n, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_majority;\n\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 3L, 10L], 7L, 3L) == true);\n    assert(candidate([1L, 1L, 2L, 4L, 4L, 4L, 6L, 6L], 8L, 4L) == false);\n    assert(candidate([1L, 1L, 1L, 2L, 2L], 5L, 1L) == true);\n    assert(candidate([1L, 1L, 2L, 2L], 5L, 1L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\n*/\nTuple!(long, long, long) substract_elements(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = substract_elements;\n\n    assert(candidate(tuple(10L, 4L, 5L), tuple(2L, 5L, 18L)) == tuple(8L, -1L, -13L));\n    assert(candidate(tuple(11L, 2L, 3L), tuple(24L, 45L, 16L)) == tuple(-13L, -43L, -13L));\n    assert(candidate(tuple(7L, 18L, 9L), tuple(10L, 11L, 12L)) == tuple(-3L, 7L, -3L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\n*/\nstring capital_words_spaces(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = capital_words_spaces;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\");\n    assert(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\n*/\nfloat find_Average_Of_Cube(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Average_Of_Cube;\n\n    assert(candidate(2L) == 4.5);\n    assert(candidate(3L) == 12L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if all values are same in a dictionary.\n\t\n*/\nbool check_value(Nullable!(long[string]) dict, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_value;\n\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 10L) == false);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 12L) == true);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 5L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth tetrahedral number.\n\t\n*/\nlong tetrahedral_number(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tetrahedral_number;\n\n    assert(candidate(5L) == 35L);\n    assert(candidate(6L) == 56L);\n    assert(candidate(7L) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\n*/\nbool magic_square_test(long[][] my_matrix) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = magic_square_test;\n\n    assert(candidate([[7L, 12L, 1L, 14L], [2L, 13L, 8L, 11L], [16L, 3L, 10L, 5L], [9L, 6L, 15L, 4L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 8L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 7L]]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove uppercase substrings from a given string.\n\t\n*/\nstring remove_uppercase(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_uppercase;\n\n    assert(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\");\n    assert(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\");\n    assert(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate a dog's age in dog's years.\n\t\n*/\nlong dog_age(long h_age) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = dog_age;\n\n    assert(candidate(12L) == 61L);\n    assert(candidate(15L) == 73L);\n    assert(candidate(24L) == 109L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\n*/\nlong next_Perfect_Square(long N) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = next_Perfect_Square;\n\n    assert(candidate(35L) == 36L);\n    assert(candidate(6L) == 9L);\n    assert(candidate(9L) == 16L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to create a list of N empty dictionaries.\n\t\n*/\nNone[] empty_list(long length) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = empty_list;\n\n    assert(candidate(5L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(6L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(7L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to convert a given string to uppercase.\n\t\n*/\nstring is_upper(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_upper;\n\n    assert(candidate(\"person\") == \"PERSON\");\n    assert(candidate(\"final\") == \"FINAL\");\n    assert(candidate(\"Valid\") == \"VALID\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\n*/\nlong odd_Equivalent(string s, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_Equivalent;\n\n    assert(candidate(\"011001\", 6L) == 3L);\n    assert(candidate(\"11011\", 5L) == 4L);\n    assert(candidate(\"1010\", 4L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\n*/\nlong[] re_arrange_array(long[] arr, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = re_arrange_array;\n\n    assert(candidate([-1L, 2L, -3L, 4L, 5L, 6L, -7L, 8L, 9L], 9L) == [-1L, -3L, -7L, 4L, 5L, 6L, 2L, 8L, 9L]);\n    assert(candidate([12L, -14L, -26L, 13L, 15L], 5L) == [-14L, -26L, 12L, 13L, 15L]);\n    assert(candidate([10L, 24L, 36L, -42L, -39L, -78L, 85L], 7L) == [-42L, -39L, -78L, 10L, 24L, 36L, 85L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\n*/\nbool unique_Element(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique_Element;\n\n    assert(candidate([1L, 1L, 1L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract values between quotation marks from a string.\n\t\n*/\nstring[] extract_values(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = extract_values;\n\n    assert(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"]);\n    assert(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"]);\n    assert(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count true booleans in the given list.\n\t\n*/\nlong count(bool[] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count;\n\n    assert(candidate([true, false, true]) == 2L);\n    assert(candidate([false, false]) == 0L);\n    assert(candidate([true, true, true]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\n*/\nlong find_even_pair(long[] A) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_even_pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L]) == 4L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L]) == 9L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given number is armstrong or not.\n\t\n*/\nbool armstrong_number(long number) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = armstrong_number;\n\n    assert(candidate(153L) == true);\n    assert(candidate(259L) == false);\n    assert(candidate(4458L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the upper case characters in a given string.\n\t\n*/\nlong upper_ctr(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = upper_ctr;\n\n    assert(candidate(\"PYthon\") == 1L);\n    assert(candidate(\"BigData\") == 1L);\n    assert(candidate(\"program\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) and_tuples(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = and_tuples;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(0L, 0L, 2L, 1L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(5L, 6L, 7L, 8L)) == tuple(1L, 2L, 3L, 0L));\n    assert(candidate(tuple(8L, 9L, 11L, 12L), tuple(7L, 13L, 14L, 17L)) == tuple(0L, 9L, 10L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\n*/\nbool is_samepatterns(string[] colors, string[] patterns) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_samepatterns;\n\n    assert(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\n*/\nlong count_list(long[][] input_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_list;\n\n    assert(candidate([[1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == 4L);\n    assert(candidate([[1L, 2L], [2L, 3L], [4L, 5L]]) == 3L);\n    assert(candidate([[1L, 0L], [2L, 0L]]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\n*/\nfloat[] average_tuple(long[][] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = average_tuple;\n\n    assert(candidate([[10L, 10L, 10L, 12L], [30L, 45L, 56L, 45L], [81L, 80L, 39L, 32L], [1L, 2L, 3L, 4L]]) == [30.5, 34.25, 27.0, 23.25]);\n    assert(candidate([[1L, 1L, -5L], [30L, -15L, 56L], [81L, -60L, -39L], [-10L, 2L, 3L]]) == [25.5, -18.0, 3.75]);\n    assert(candidate([[100L, 100L, 100L, 120L], [300L, 450L, 560L, 450L], [810L, 800L, 390L, 320L], [10L, 20L, 30L, 40L]]) == [305.0, 342.5, 270.0, 232.5]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\n*/\nlong lcs_of_three(string X, string Y, string Z) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = lcs_of_three;\n\n    assert(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2L);\n    assert(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5L);\n    assert(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the n'th star number.\n\t\n*/\nlong find_star_num(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_star_num;\n\n    assert(candidate(3L) == 37L);\n    assert(candidate(4L) == 73L);\n    assert(candidate(5L) == 121L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of an array.\n\t\n*/\nlong _sum(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = _sum;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([15L, 12L, 13L, 10L]) == 50L);\n    assert(candidate([0L, 1L, 2L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\n*/\nbool check_Consecutive(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_Consecutive;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 2L, 3L, 5L, 6L]) == false);\n    assert(candidate([1L, 2L, 1L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\n*/\nTuple!(long, long, string) find_adverb_position(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_adverb_position;\n\n    assert(candidate(\"clearly!! we can see the sky\") == tuple(0L, 7L, \"clearly\"));\n    assert(candidate(\"seriously!! there are many roses\") == tuple(0L, 9L, \"seriously\"));\n    assert(candidate(\"unfortunately!! sita is going to home\") == tuple(0L, 13L, \"unfortunately\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\n*/\nlong[] rotate_right(long[] list, long m) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rotate_right;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 3L) == [8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 5L) == [6L, 7L, 8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\n*/\nlong number_of_substrings(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = number_of_substrings;\n\n    assert(candidate(\"abc\") == 6L);\n    assert(candidate(\"abcd\") == 10L);\n    assert(candidate(\"abcde\") == 15L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\n*/\nbool all_unique(long[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_unique;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\n*/\nTuple!(float, float) convert(long numbers) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = convert;\n\n    assert(candidate(1L) == tuple(1.0, 0.0));\n    assert(candidate(4L) == tuple(4.0, 0.0));\n    assert(candidate(5L) == tuple(5.0, 0.0));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to convert the given string to lower case.\n\t\n*/\nstring is_lower(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_lower;\n\n    assert(candidate(\"InValid\") == \"invalid\");\n    assert(candidate(\"TruE\") == \"true\");\n    assert(candidate(\"SenTenCE\") == \"sentence\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\n*/\nlong next_power_of_2(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = next_power_of_2;\n\n    assert(candidate(0L) == 1L);\n    assert(candidate(5L) == 8L);\n    assert(candidate(17L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\n*/\nbool find_substring(string[] str1, string sub_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_substring;\n\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to replace characters in a string.\n\t\n*/\nstring replace_char(string str1, string ch, string newch) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = replace_char;\n\n    assert(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\");\n    assert(candidate(\"character\", \"c\", \"a\") == \"aharaater\");\n    assert(candidate(\"python\", \"l\", \"a\") == \"python\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\n*/\nlong mul_even_odd(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = mul_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\n*/\nlong even_binomial_Coeff_Sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_binomial_Coeff_Sum;\n\n    assert(candidate(4L) == 8L);\n    assert(candidate(6L) == 32L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) bitwise_xor(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = bitwise_xor;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(15L, 6L, 5L, 10L));\n    assert(candidate(tuple(11L, 5L, 7L, 10L), tuple(6L, 3L, 4L, 4L)) == tuple(13L, 6L, 3L, 14L));\n    assert(candidate(tuple(12L, 6L, 8L, 11L), tuple(7L, 4L, 5L, 6L)) == tuple(11L, 2L, 13L, 13L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\n*/\nbool is_Sub_Array(long[] A, long[] B) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_Sub_Array;\n\n    assert(candidate([1L, 4L, 3L, 5L], [1L, 2L]) == false);\n    assert(candidate([1L, 2L, 1L], [1L, 2L, 1L]) == true);\n    assert(candidate([1L, 0L, 2L, 2L], [2L, 2L, 0L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\n*/\nlong max_sub_array_sum_repeated(long[] a, long n, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum_repeated;\n\n    assert(candidate([10L, 20L, -30L, -1L], 4L, 3L) == 30L);\n    assert(candidate([-1L, 10L, 20L], 3L, 2L) == 59L);\n    assert(candidate([-1L, -2L, -3L], 3L, 3L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\n*/\nlong min_product_tuple(Tuple!(long, long)[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = min_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 8L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 30L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 100L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\n*/\nbool count_divisors(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_divisors;\n\n    assert(candidate(10L) == true);\n    assert(candidate(100L) == false);\n    assert(candidate(125L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\n*/\nNullable!(long) triangle_area(long r) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n{\n        auto result = candidate(-1L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(0L);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate(2L);\n        assert(!result.isNull && result.get == 4L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a given string to a list of characters.\n\t\n*/\nstring[] string_to_tuple(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = string_to_tuple;\n\n    assert(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n    assert(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"]);\n    assert(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\n*/\nlong find_length(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_length;\n\n    assert(candidate(\"11000010001\") == 6L);\n    assert(candidate(\"10111\") == 1L);\n    assert(candidate(\"11011101100101\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\n*/\nlong count_Primes_nums(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_Primes_nums;\n\n    assert(candidate(5L) == 2L);\n    assert(candidate(10L) == 4L);\n    assert(candidate(100L) == 25L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\n*/\nlong sum_Of_product(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_Of_product;\n\n    assert(candidate(3L) == 15L);\n    assert(candidate(4L) == 56L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\n*/\nTuple!(string, long) max_aggregate(Tuple!(string, long)[] stdata) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_aggregate;\n\n    assert(candidate([tuple(\"Juan Whelan\", 90L), tuple(\"Sabah Colley\", 88L), tuple(\"Peter Nichols\", 7L), tuple(\"Juan Whelan\", 122L), tuple(\"Sabah Colley\", 84L)]) == tuple(\"Juan Whelan\", 212L));\n    assert(candidate([tuple(\"Juan Whelan\", 50L), tuple(\"Sabah Colley\", 48L), tuple(\"Peter Nichols\", 37L), tuple(\"Juan Whelan\", 22L), tuple(\"Sabah Colley\", 14L)]) == tuple(\"Juan Whelan\", 72L));\n    assert(candidate([tuple(\"Juan Whelan\", 10L), tuple(\"Sabah Colley\", 20L), tuple(\"Peter Nichols\", 30L), tuple(\"Juan Whelan\", 40L), tuple(\"Sabah Colley\", 50L)]) == tuple(\"Sabah Colley\", 70L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a list of elements.\n\t\n*/\nlong[] comb_sort(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = comb_sort;\n\n    assert(candidate([5L, 15L, 37L, 25L, 79L]) == [5L, 15L, 25L, 37L, 79L]);\n    assert(candidate([41L, 32L, 15L, 19L, 22L]) == [15L, 19L, 22L, 32L, 41L]);\n    assert(candidate([99L, 15L, 13L, 47L]) == [13L, 15L, 47L, 99L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\n*/\nbool check_expression(string exp) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_expression;\n\n    assert(candidate(\"{()}[{}]\") == true);\n    assert(candidate(\"{()}[{]\") == false);\n    assert(candidate(\"{()}[{}][]({})\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that matches a word containing 'z'.\n\t\n*/\nbool text_match_wordz(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_wordz;\n\n    assert(candidate(\"pythonz.\") == true);\n    assert(candidate(\"xyz.\") == true);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\n*/\nlong[] sum_list(long[] lst1, long[] lst2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_list;\n\n    assert(candidate([10L, 20L, 30L], [15L, 25L, 35L]) == [25L, 45L, 65L]);\n    assert(candidate([1L, 2L, 3L], [5L, 6L, 7L]) == [6L, 8L, 10L]);\n    assert(candidate([15L, 20L, 30L], [15L, 45L, 75L]) == [30L, 65L, 105L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\n*/\nlong newman_prime(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = newman_prime;\n\n    assert(candidate(3L) == 7L);\n    assert(candidate(4L) == 17L);\n    assert(candidate(5L) == 41L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\n*/\nlong surface_Area(long b, long s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = surface_Area;\n\n    assert(candidate(3L, 4L) == 33L);\n    assert(candidate(4L, 5L) == 56L);\n    assert(candidate(1L, 2L) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\n*/\nlong Find_Min_Length(long[][] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Find_Min_Length;\n\n    assert(candidate([[1L], [1L, 2L]]) == 1L);\n    assert(candidate([[1L, 2L], [1L, 2L, 3L], [1L, 2L, 3L, 4L]]) == 2L);\n    assert(candidate([[3L, 3L, 3L], [4L, 4L, 4L, 4L]]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\n*/\nbool validate(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = validate;\n\n    assert(candidate(1234L) == true);\n    assert(candidate(51241L) == false);\n    assert(candidate(321L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth hexagonal number.\n\t\n*/\nlong hexagonal_num(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = hexagonal_num;\n\n    assert(candidate(10L) == 190L);\n    assert(candidate(5L) == 45L);\n    assert(candidate(7L) == 91L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the n'th lucas number.\n\t\n*/\nlong find_lucas(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_lucas;\n\n    assert(candidate(9L) == 76L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(3L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to get the difference between two lists.\n\t\n*/\nlong[] Diff(long[] li1, long[] li2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Diff;\n\n    assert(candidate([10L, 15L, 20L, 25L, 30L, 35L, 40L], [25L, 40L, 35L]) == [10L, 20L, 30L, 15L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 1L]) == [2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L], [6L, 7L, 1L]) == [2L, 3L, 6L, 7L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\n*/\nbool differ_At_One_Bit_Pos(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = differ_At_One_Bit_Pos;\n\n    assert(candidate(13L, 9L) == true);\n    assert(candidate(15L, 8L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(2L, 3L) == true);\n    assert(candidate(5L, 1L) == true);\n    assert(candidate(1L, 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\n*/\nbool text_match_three(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"caacabbbba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\n*/\nlong max_product(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_product;\n\n    assert(candidate([3L, 100L, 4L, 5L, 150L, 6L]) == 3000L);\n    assert(candidate([4L, 42L, 55L, 68L, 80L]) == 50265600L);\n    assert(candidate([10L, 22L, 9L, 33L, 21L, 50L, 41L, 60L]) == 2460L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\n*/\nlong[] split_Arr(long[] l, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = split_Arr;\n\n    assert(candidate([12L, 10L, 5L, 6L, 52L, 36L], 2L) == [5L, 6L, 52L, 36L, 12L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], 1L) == [2L, 3L, 4L, 1L]);\n    assert(candidate([0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L], 3L) == [3L, 4L, 5L, 6L, 7L, 0L, 1L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the number of divisors of a given integer.\n\t\n*/\nlong divisor(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = divisor;\n\n    assert(candidate(15L) == 4L);\n    assert(candidate(12L) == 6L);\n    assert(candidate(9L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\n*/\nlong big_diff(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = big_diff;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([4L, 5L, 12L]) == 8L);\n    assert(candidate([9L, 2L, 3L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find squares of individual elements in a list.\n\t\n*/\nlong[] square_nums(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = square_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L]) == [100L, 400L, 900L]);\n    assert(candidate([12L, 15L]) == [144L, 225L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\n*/\nbool is_Monotonic(long[] A) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_Monotonic;\n\n    assert(candidate([6L, 5L, 4L, 4L]) == true);\n    assert(candidate([1L, 2L, 2L, 3L]) == true);\n    assert(candidate([1L, 3L, 2L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\n*/\nbool is_perfect_square(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_perfect_square;\n\n    assert(candidate(10L) == false);\n    assert(candidate(36L) == true);\n    assert(candidate(14L) == false);\n    assert(candidate(196L) == true);\n    assert(candidate(125L) == false);\n    assert(candidate(15625L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\n*/\nlong sum(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum;\n\n    assert(candidate(10L, 15L) == 6L);\n    assert(candidate(100L, 150L) == 93L);\n    assert(candidate(4L, 6L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\n*/\nTuple!(long, long[]) max_length(long[][] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_length;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L], [5L, 7L], [10L, 12L, 14L, 15L]]) == tuple(4L, [10L, 12L, 14L, 15L]));\n    assert(candidate([[5L], [15L, 20L, 25L]]) == tuple(3L, [15L, 20L, 25L]));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the directrix of a parabola.\n\t\n*/\nlong parabola_directrix(long a, long b, long c) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = parabola_directrix;\n\n    assert(candidate(5L, 3L, 2L) == -198L);\n    assert(candidate(9L, 8L, 4L) == -2336L);\n    assert(candidate(2L, 4L, 6L) == -130L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\n*/\nNullable!(Tuple!(string, long, long)) occurance_substring(string text, string pattern) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = occurance_substring;\n\n{\n        auto result = candidate(\"python programming, python language\", \"python\");\n        assert(!result.isNull && result.get == tuple(\"python\", 0L, 6L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"programming\");\n        assert(!result.isNull && result.get == tuple(\"programming\", 7L, 18L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"language\");\n        assert(!result.isNull && result.get == tuple(\"language\", 31L, 39L));\n}\n\n{\n        auto result = candidate(\"c++ programming, c++ language\", \"python\");\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\n*/\nstring[][] sort_sublists(string[][] input_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n    assert(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\n*/\nlong[] remove_kth_element(long[] list1, long L) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_kth_element;\n\n    assert(candidate([1L, 1L, 2L, 3L, 4L, 4L, 5L, 1L], 3L) == [1L, 1L, 3L, 4L, 4L, 5L, 1L]);\n    assert(candidate([0L, 0L, 1L, 2L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L], 4L) == [0L, 0L, 1L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L]);\n    assert(candidate([10L, 10L, 15L, 19L, 18L, 18L, 17L, 26L, 26L, 17L, 18L, 10L], 5L) == [10L, 10L, 15L, 19L, 18L, 17L, 26L, 26L, 17L, 18L, 10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\n*/\nTuple!(long, long, long, Nullable!(long[string])) add_dict_to_tuple(Tuple!(long, long, long) test_tup, Nullable!(long[string]) test_dict) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_dict_to_tuple;\n\n    assert(candidate(tuple(4L, 5L, 6L), [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable) == tuple(4L, 5L, 6L, [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable));\n    assert(candidate(tuple(1L, 2L, 3L), [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable) == tuple(1L, 2L, 3L, [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable));\n    assert(candidate(tuple(8L, 9L, 10L), [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable) == tuple(8L, 9L, 10L, [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\n*/\nlong find(long n, long m) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find;\n\n    assert(candidate(10L, 3L) == 3L);\n    assert(candidate(4L, 2L) == 2L);\n    assert(candidate(20L, 5L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\n*/\nbool text_match_two_three(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_two_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\n*/\nlong count_samepair(long[] list1, long[] list2, long[] list3) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_samepair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 9L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 2L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\n*/\nbool text_match_one(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\n*/\nlong difference(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = difference;\n\n    assert(candidate(3L) == 30L);\n    assert(candidate(5L) == 210L);\n    assert(candidate(2L) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to toggle the case of all characters in a string.\n\t\n*/\nstring toggle_string(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = toggle_string;\n\n    assert(candidate(\"Python\") == \"pYTHON\");\n    assert(candidate(\"Pangram\") == \"pANGRAM\");\n    assert(candidate(\"LIttLE\") == \"liTTle\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the Eulerian number a(n, m).\n\t\n*/\nlong eulerian_num(long n, long m) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = eulerian_num;\n\n    assert(candidate(3L, 1L) == 4L);\n    assert(candidate(4L, 1L) == 11L);\n    assert(candidate(5L, 3L) == 26L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\n*/\nlong frequency(long[] a, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = frequency;\n\n    assert(candidate([1L, 2L, 3L], 4L) == 0L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 3L, 4L], 3L) == 3L);\n    assert(candidate([0L, 1L, 2L, 3L, 1L, 2L], 1L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\n*/\nlong[] sort_numeric_strings(string[] nums_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_numeric_strings;\n\n    assert(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500L, -12L, 0L, 4L, 7L, 12L, 45L, 100L, 200L]);\n    assert(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1L, 1L, 1L, 2L, 2L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 8L, 9L, 9L]);\n    assert(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1L, 1L, 1L, 3L, 3L, 5L, 5L, 7L, 7L, 9L, 11L, 13L, 15L, 17L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\n*/\nfloat geometric_sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = geometric_sum;\n\n    assert(candidate(7L) == 1.9921875);\n    assert(candidate(4L) == 1.9375);\n    assert(candidate(8L) == 1.99609375);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\n*/\nlong[] divisible_by_digits(long startnum, long endnum) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = divisible_by_digits;\n\n    assert(candidate(1L, 22L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L, 22L]);\n    assert(candidate(1L, 15L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L]);\n    assert(candidate(20L, 25L) == [22L, 24L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\n*/\nlong unique_product(long[] list_data) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = unique_product;\n\n    assert(candidate([10L, 20L, 30L, 40L, 20L, 50L, 60L, 40L]) == 720000000L);\n    assert(candidate([1L, 2L, 3L, 1L]) == 6L);\n    assert(candidate([7L, 8L, 9L, 0L, 1L, 1L]) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the largest negative number from the given list.\n\t\n*/\nlong largest_neg(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = largest_neg;\n\n    assert(candidate([1L, 2L, 3L, -4L, -6L]) == -6L);\n    assert(candidate([1L, 2L, 3L, -8L, -9L]) == -9L);\n    assert(candidate([1L, 2L, 3L, 4L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\n*/\nfloat min_Jumps(Tuple!(long, long) steps, long d) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = min_Jumps;\n\n    assert(candidate(tuple(3L, 4L), 11L) == 3.5);\n    assert(candidate(tuple(3L, 4L), 0L) == 0L);\n    assert(candidate(tuple(11L, 14L), 11L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\n*/\nTuple!(long, long) max_Product(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_Product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 7L, 0L, 8L, 4L]) == tuple(7L, 8L));\n    assert(candidate([0L, -1L, -2L, -4L, 5L, 0L, -6L]) == tuple(-4L, -6L));\n    assert(candidate([1L, 2L, 3L]) == tuple(2L, 3L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth nonagonal number.\n\t\n*/\nlong is_nonagonal(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_nonagonal;\n\n    assert(candidate(10L) == 325L);\n    assert(candidate(15L) == 750L);\n    assert(candidate(18L) == 1089L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\n*/\nlong max_Abs_Diff(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_Abs_Diff;\n\n    assert(candidate([2L, 1L, 5L, 3L]) == 4L);\n    assert(candidate([9L, 3L, 2L, 5L, 1L]) == 8L);\n    assert(candidate([3L, 2L, 1L]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the sum of perrin numbers.\n\t\n*/\nlong cal_sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = cal_sum;\n\n    assert(candidate(9L) == 49L);\n    assert(candidate(10L) == 66L);\n    assert(candidate(11L) == 88L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\n*/\nstring odd_values_string(string str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_values_string;\n\n    assert(candidate(\"abcdef\") == \"ace\");\n    assert(candidate(\"python\") == \"pto\");\n    assert(candidate(\"data\") == \"dt\");\n    assert(candidate(\"lambs\") == \"lms\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\n*/\nlong find_kth(long[] arr1, long[] arr2, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_kth;\n\n    assert(candidate([2L, 3L, 6L, 7L, 9L], [1L, 4L, 8L, 10L], 5L) == 6L);\n    assert(candidate([100L, 112L, 256L, 349L, 770L], [72L, 86L, 113L, 119L, 265L, 445L, 892L], 7L) == 256L);\n    assert(candidate([3L, 4L, 7L, 8L, 10L], [2L, 5L, 9L, 11L], 6L) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\n*/\nlong jacobsthal_num(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = jacobsthal_num;\n\n    assert(candidate(5L) == 11L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 5L);\n    assert(candidate(13L) == 2731L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\n*/\nNullable!(long[long]) frequency_lists(long[][] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = frequency_lists;\n\n{\n        auto result = candidate([[1L, 2L, 3L, 2L], [4L, 5L, 6L, 2L], [7L, 8L, 9L, 5L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 3L, 3L: 1L, 4L: 1L, 5L: 2L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L]);\n}\n\n{\n        auto result = candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 1L, 3L: 1L, 4L: 1L, 5L: 1L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L, 10L: 1L, 11L: 1L, 12L: 1L]);\n}\n\n{\n        auto result = candidate([[20L, 30L, 40L, 17L], [18L, 16L, 14L, 13L], [10L, 20L, 30L, 40L]]);\n        assert(!result.isNull && result.get == [20L: 2L, 30L: 2L, 40L: 2L, 17L: 1L, 18L: 1L, 16L: 1L, 14L: 1L, 13L: 1L, 10L: 1L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find perfect squares between two given numbers.\n\t\n*/\nlong[] perfect_squares(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = perfect_squares;\n\n    assert(candidate(1L, 30L) == [1L, 4L, 9L, 16L, 25L]);\n    assert(candidate(50L, 100L) == [64L, 81L, 100L]);\n    assert(candidate(100L, 200L) == [100L, 121L, 144L, 169L, 196L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\n*/\nlong sum_Of_Subarray_Prod(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_Of_Subarray_Prod;\n\n    assert(candidate([1L, 2L, 3L]) == 20L);\n    assert(candidate([1L, 2L]) == 5L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\n*/\nlong first_odd(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = first_odd;\n\n    assert(candidate([1L, 3L, 5L]) == 1L);\n    assert(candidate([2L, 4L, 1L, 3L]) == 1L);\n    assert(candidate([8L, 9L, 1L]) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\n*/\nlong[][] add_nested_tuples(long[][] test_tup1, long[][] test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_nested_tuples;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[7L, 10L], [7L, 14L], [3L, 10L], [8L, 13L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[9L, 12L], [9L, 16L], [5L, 12L], [10L, 15L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[11L, 14L], [11L, 18L], [7L, 14L], [12L, 17L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\n*/\nbool dif_Square(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = dif_Square;\n\n    assert(candidate(5L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(15L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\n*/\nbool check_smaller(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_smaller;\n\n    assert(candidate(tuple(1L, 2L, 3L), tuple(2L, 3L, 4L)) == false);\n    assert(candidate(tuple(4L, 5L, 6L), tuple(3L, 4L, 5L)) == true);\n    assert(candidate(tuple(11L, 12L, 13L), tuple(10L, 11L, 12L)) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\n*/\nNullable!(long[long]) freq_count(long[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = freq_count;\n\n{\n        auto result = candidate([10L, 10L, 10L, 10L, 20L, 20L, 20L, 20L, 40L, 40L, 50L, 50L, 30L]);\n        assert(!result.isNull && result.get == [10L: 4L, 20L: 4L, 40L: 2L, 50L: 2L, 30L: 1L]);\n}\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 3L, 2L, 4L, 1L, 3L, 1L, 4L]);\n        assert(!result.isNull && result.get == [1L: 3L, 2L: 2L, 3L: 3L, 4L: 3L]);\n}\n\n{\n        auto result = candidate([5L, 6L, 7L, 4L, 9L, 10L, 4L, 5L, 6L, 7L, 9L, 5L]);\n        assert(!result.isNull && result.get == [10L: 1L, 5L: 3L, 6L: 2L, 7L: 2L, 4L: 2L, 9L: 2L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\n*/\nfloat[] rgb_to_hsv(long r, long g, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rgb_to_hsv;\n\n    assert(candidate(255L, 255L, 255L) == [0.0, 0.0, 100.0]);\n    assert(candidate(0L, 215L, 0L) == [120.0, 100.0, 84.31372549019608]);\n    assert(candidate(10L, 215L, 110L) == [149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\n*/\nbool check_str(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_str;\n\n    assert(candidate(\"annie\") == true);\n    assert(candidate(\"dawood\") == false);\n    assert(candidate(\"Else\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\n*/\nbool check_monthnumber_number(long monthnum3) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_monthnumber_number;\n\n    assert(candidate(6L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(12L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort the given list.\n\t\n*/\nlong[] heap_sort(long[] iterable) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = heap_sort;\n\n    assert(candidate([1L, 3L, 5L, 7L, 9L, 2L, 4L, 6L, 8L, 0L]) == [0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L]) == [14L, 22L, 25L, 25L, 35L, 58L, 65L, 75L, 85L]);\n    assert(candidate([7L, 1L, 9L, 5L]) == [1L, 5L, 7L, 9L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\n*/\nlong[][] k_smallest_pairs(long[] nums1, long[] nums2, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = k_smallest_pairs;\n\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 2L) == [[1L, 2L], [1L, 4L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 1L) == [[1L, 2L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 7L) == [[1L, 2L], [1L, 4L], [3L, 2L], [1L, 6L], [3L, 4L], [3L, 6L], [7L, 2L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\n*/\nNullable!(Tuple!(long, long)) find_solution(long a, long b, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_solution;\n\n{\n        auto result = candidate(2L, 3L, 7L);\n        assert(!result.isNull && result.get == tuple(2L, 1L));\n}\n\n{\n        auto result = candidate(4L, 2L, 7L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(1L, 13L, 17L);\n        assert(!result.isNull && result.get == tuple(4L, 1L));\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\n*/\nlong find_Max_Num(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Max_Num;\n\n    assert(candidate([1L, 2L, 3L]) == 321L);\n    assert(candidate([4L, 5L, 6L, 1L]) == 6541L);\n    assert(candidate([1L, 2L, 3L, 9L]) == 9321L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\n*/\nlong[] max_sum_list(long[][] lists) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_sum_list;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [10L, 11L, 12L], [7L, 8L, 9L]]) == [10L, 11L, 12L]);\n    assert(candidate([[3L, 2L, 1L], [6L, 5L, 4L], [12L, 11L, 10L]]) == [12L, 11L, 10L]);\n    assert(candidate([[2L, 3L, 1L]]) == [2L, 3L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to interchange the first and last elements in a list.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([12L, 35L, 9L, 56L, 24L]) == [24L, 35L, 9L, 56L, 12L]);\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the median of two sorted lists of same size.\n\t\n*/\nfloat get_median(long[] arr1, long[] arr2, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_median;\n\n    assert(candidate([1L, 12L, 15L, 26L, 38L], [2L, 13L, 17L, 30L, 45L], 5L) == 16.0);\n    assert(candidate([2L, 4L, 8L, 9L], [7L, 13L, 19L, 28L], 4L) == 8.5);\n    assert(candidate([3L, 6L, 14L, 23L, 36L, 42L], [2L, 18L, 27L, 39L, 49L, 55L], 6L) == 25.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\n*/\nstring replace_spaces(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\");\n    assert(candidate(\"The_Avengers\") == \"The Avengers\");\n    assert(candidate(\"Fast and Furious\") == \"Fast_and_Furious\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\n*/\nbool are_equivalent(long num1, long num2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = are_equivalent;\n\n    assert(candidate(36L, 57L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(23L, 47L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to reverse each string in a given list of string values.\n\t\n*/\nstring[] reverse_string_list(string[] stringlist) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = reverse_string_list;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n    assert(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n    assert(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\n*/\nlong sequence(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sequence;\n\n    assert(candidate(10L) == 6L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(3L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\n*/\nlong[] heap_queue_largest(long[] nums, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = heap_queue_largest;\n\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 3L) == [85L, 75L, 65L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 2L) == [85L, 75L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 5L) == [85L, 75L, 65L, 58L, 35L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\n*/\nlong loss_amount(long actual_cost, long sale_amount) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = loss_amount;\n\n    assert(candidate(1500L, 1200L) == 0L);\n    assert(candidate(100L, 200L) == 100L);\n    assert(candidate(2000L, 5000L) == 3000L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\n*/\nlong[] union_elements(long[] test_tup1, long[] test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = union_elements;\n\n    assert(candidate([3L, 4L, 5L, 6L], [5L, 7L, 4L, 10L]) == [3L, 4L, 5L, 6L, 7L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], [3L, 4L, 5L, 6L]) == [1L, 2L, 3L, 4L, 5L, 6L]);\n    assert(candidate([11L, 12L, 13L, 14L], [13L, 15L, 16L, 17L]) == [11L, 12L, 13L, 14L, 15L, 16L, 17L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the length of the longest sublists.\n\t\n*/\nlong Find_Max_Length(long[][] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Find_Max_Length;\n\n    assert(candidate([[1L], [1L, 4L], [5L, 6L, 7L, 8L]]) == 4L);\n    assert(candidate([[0L, 1L], [2L, 2L], [3L, 2L, 1L]]) == 3L);\n    assert(candidate([[7L], [22L, 23L], [13L, 14L, 15L], [10L, 20L, 30L, 40L, 50L]]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\n*/\nstring remove_parenthesis(string[] items) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_parenthesis;\n\n    assert(candidate([\"python (chrome)\"]) == \"python\");\n    assert(candidate([\"string(.abc)\"]) == \"string\");\n    assert(candidate([\"alpha(num)\"]) == \"alpha\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\n*/\nbool find_Parity(long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Parity;\n\n    assert(candidate(12L) == false);\n    assert(candidate(7L) == true);\n    assert(candidate(10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the median length of a trapezium.\n\t\n*/\nfloat median_trapezium(long base1, long base2, long height) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = median_trapezium;\n\n    assert(candidate(15L, 25L, 35L) == 20L);\n    assert(candidate(10L, 20L, 30L) == 15L);\n    assert(candidate(6L, 9L, 4L) == 7.5);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find nth centered hexagonal number.\n\t\n*/\nlong centered_hexagonal_number(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = centered_hexagonal_number;\n\n    assert(candidate(10L) == 271L);\n    assert(candidate(2L) == 7L);\n    assert(candidate(9L) == 217L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\n*/\nlong get_max_sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_max_sum;\n\n    assert(candidate(60L) == 106L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the length of the longest word.\n\t\n*/\nlong len_log(string[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = len_log;\n\n    assert(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7L);\n    assert(candidate([\"a\", \"ab\", \"abc\"]) == 3L);\n    assert(candidate([\"small\", \"big\", \"tall\"]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\n*/\nNullable!(float) sector_area(long r, long a) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sector_area;\n\n{\n        auto result = candidate(4L, 45L);\n        assert(!result.isNull && result.get == 6.283185307179586);\n}\n\n{\n        auto result = candidate(9L, 45L);\n        assert(!result.isNull && result.get == 31.808625617596654);\n}\n\n{\n        auto result = candidate(9L, 361L);\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\n*/\nbool odd_position(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = odd_position;\n\n    assert(candidate([2L, 1L, 4L, 3L, 6L, 7L, 6L, 3L]) == true);\n    assert(candidate([4L, 1L, 2L]) == true);\n    assert(candidate([1L, 2L, 3L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\n*/\nlong multiple_to_single(long[] L) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = multiple_to_single;\n\n    assert(candidate([11L, 33L, 50L]) == 113350L);\n    assert(candidate([-1L, 2L, 3L, 4L, 5L, 6L]) == -123456L);\n    assert(candidate([10L, 15L, 20L, 25L]) == 10152025L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find whether a number is divisible by 11.\n\t\n*/\nbool is_Diff(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_Diff;\n\n    assert(candidate(12345L) == false);\n    assert(candidate(1212112L) == true);\n    assert(candidate(1212L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\n*/\nlong[][] index_multiplication(long[][] test_tup1, long[][] test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = index_multiplication;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 21L], [12L, 45L], [2L, 9L], [7L, 30L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[14L, 32L], [20L, 60L], [6L, 20L], [16L, 44L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[24L, 45L], [30L, 77L], [12L, 33L], [27L, 60L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert tuple string to integer tuple.\n\t\n*/\nTuple!(long, long, long) tuple_str_int(string test_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tuple_str_int;\n\n    assert(candidate(\"(7, 8, 9)\") == tuple(7L, 8L, 9L));\n    assert(candidate(\"(1, 2, 3)\") == tuple(1L, 2L, 3L));\n    assert(candidate(\"(4, 5, 6)\") == tuple(4L, 5L, 6L));\n    assert(candidate(\"(7, 81, 19)\") == tuple(7L, 81L, 19L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\n*/\nlong amicable_numbers_sum(long limit) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = amicable_numbers_sum;\n\n    assert(candidate(999L) == 504L);\n    assert(candidate(9999L) == 31626L);\n    assert(candidate(99L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove odd characters in a string.\n\t\n*/\nstring remove_odd(string str1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate(\"python\") == \"yhn\");\n    assert(candidate(\"program\") == \"rga\");\n    assert(candidate(\"language\") == \"agae\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\n*/\nlong count_rotation(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_rotation;\n\n    assert(candidate([3L, 2L, 1L]) == 1L);\n    assert(candidate([4L, 5L, 1L, 2L, 3L]) == 2L);\n    assert(candidate([7L, 8L, 9L, 1L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 2L, 3L]) == 0L);\n    assert(candidate([1L, 3L, 2L]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\n*/\nlong extract_freq(Tuple!(long, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = extract_freq;\n\n    assert(candidate([tuple(3L, 4L), tuple(1L, 2L), tuple(4L, 3L), tuple(5L, 6L)]) == 3L);\n    assert(candidate([tuple(4L, 15L), tuple(2L, 3L), tuple(5L, 4L), tuple(6L, 7L)]) == 4L);\n    assert(candidate([tuple(5L, 16L), tuple(2L, 3L), tuple(6L, 5L), tuple(6L, 9L)]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\n*/\nlong count_same_pair(long[] nums1, long[] nums2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_same_pair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L]) == 4L);\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 11L);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 1L);\n    assert(candidate([0L, 1L, 1L, 2L], [0L, 1L, 2L, 2L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\n*/\nlong power(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = power;\n\n    assert(candidate(3L, 4L) == 81L);\n    assert(candidate(2L, 3L) == 8L);\n    assert(candidate(5L, 5L) == 3125L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite function to find the sum of all items in the given dictionary.\n\t\n*/\nlong return_sum(Nullable!(long[string]) dict) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = return_sum;\n\n    assert(candidate([\"a\": 100L, \"b\": 200L, \"c\": 300L].nullable) == 600L);\n    assert(candidate([\"a\": 25L, \"b\": 18L, \"c\": 45L].nullable) == 88L);\n    assert(candidate([\"a\": 36L, \"b\": 39L, \"c\": 49L].nullable) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\n*/\nTuple!(long, long)[] pair_wise(long[] l1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pair_wise;\n\n    assert(candidate([1L, 1L, 2L, 3L, 3L, 4L, 4L, 5L]) == [tuple(1L, 1L), tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 3L), tuple(3L, 4L), tuple(4L, 4L), tuple(4L, 5L)]);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == [tuple(1L, 5L), tuple(5L, 7L), tuple(7L, 9L), tuple(9L, 10L)]);\n    assert(candidate([5L, 1L, 9L, 7L, 10L]) == [tuple(5L, 1L), tuple(1L, 9L), tuple(9L, 7L), tuple(7L, 10L)]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 4L), tuple(4L, 5L), tuple(5L, 6L), tuple(6L, 7L), tuple(7L, 8L), tuple(8L, 9L), tuple(9L, 10L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to split a string into characters.\n\t\n*/\nstring[] split(string word) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = split;\n\n    assert(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n    assert(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"]);\n    assert(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find minimum of three numbers.\n\t\n*/\nlong min_of_three(long a, long b, long c) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = min_of_three;\n\n    assert(candidate(10L, 20L, 0L) == 0L);\n    assert(candidate(19L, 15L, 18L) == 15L);\n    assert(candidate(-10L, -20L, -30L) == -30L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\n*/\nbool is_Sum_Of_Powers_Of_Two(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_Sum_Of_Powers_Of_Two;\n\n    assert(candidate(10L) == true);\n    assert(candidate(7L) == false);\n    assert(candidate(14L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\n*/\nstring get_Char(string strr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_Char;\n\n    assert(candidate(\"abc\") == \"f\");\n    assert(candidate(\"gfg\") == \"t\");\n    assert(candidate(\"ab\") == \"c\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to return the sum of all divisors of a number.\n\t\n*/\nlong sum_div(long number) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_div;\n\n    assert(candidate(8L) == 7L);\n    assert(candidate(12L) == 16L);\n    assert(candidate(7L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\n*/\nlong[] two_unique_nums(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = two_unique_nums;\n\n    assert(candidate([1L, 2L, 3L, 2L, 3L, 4L, 5L]) == [1L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 5L]) == [1L, 3L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\n*/\nbool test_duplicate(long[] arraynums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = test_duplicate;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == true);\n    assert(candidate([1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function which returns nth catalan number.\n\t\n*/\nlong catalan_number(long num) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = catalan_number;\n\n    assert(candidate(10L) == 16796L);\n    assert(candidate(9L) == 4862L);\n    assert(candidate(7L) == 429L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\n*/\nlong power_base_sum(long base, long power) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = power_base_sum;\n\n    assert(candidate(2L, 100L) == 115L);\n    assert(candidate(8L, 10L) == 37L);\n    assert(candidate(8L, 15L) == 62L);\n    assert(candidate(3L, 3L) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth octagonal number.\n\t\n*/\nlong is_octagonal(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_octagonal;\n\n    assert(candidate(5L) == 65L);\n    assert(candidate(10L) == 280L);\n    assert(candidate(15L) == 645L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\n*/\nstring replace_blank(string str1, string char) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = replace_blank;\n\n    assert(candidate(\"hello people\", \"@\") == \"hello@people\");\n    assert(candidate(\"python program language\", \"$\") == \"python$program$language\");\n    assert(candidate(\"blank space\", \"-\") == \"blank-space\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\n*/\nstring replace_specialchar(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = replace_specialchar;\n\n    assert(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\");\n    assert(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\");\n    assert(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\n*/\nlong tuple_to_int(Tuple!(long, long, long) nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tuple_to_int;\n\n    assert(candidate(tuple(1L, 2L, 3L)) == 123L);\n    assert(candidate(tuple(4L, 5L, 6L)) == 456L);\n    assert(candidate(tuple(5L, 6L, 7L)) == 567L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the third side of a right angled triangle.\n\t\n*/\nfloat otherside_rightangle(long w, long h) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = otherside_rightangle;\n\n    assert(candidate(7L, 8L) == 10.63014581273465);\n    assert(candidate(3L, 4L) == 5L);\n    assert(candidate(7L, 15L) == 16.55294535724685);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\n*/\nNone[] expensive_items(None[] items, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = expensive_items;\n\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable], 2L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-1\", \"price\": 101.1].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable, [\"name\": \"Item-4\", \"price\": 22.75].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\n*/\nlong digit_distance_nums(long n1, long n2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = digit_distance_nums;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(23L, 56L) == 6L);\n    assert(candidate(123L, 256L) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\n*/\nbool text_match_wordz_middle(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_match_wordz_middle;\n\n    assert(candidate(\"pythonzabc.\") == true);\n    assert(candidate(\"zxyabc.\") == false);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove leading zeroes from an ip address.\n\t\n*/\nstring removezero_ip(string ip) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = removezero_ip;\n\n    assert(candidate(\"216.08.094.196\") == \"216.8.94.196\");\n    assert(candidate(\"12.01.024\") == \"12.1.24\");\n    assert(candidate(\"216.08.094.0196\") == \"216.8.94.196\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to multiply two integers.\n\t\n*/\nlong multiply_int(long x, long y) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = multiply_int;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(5L, 10L) == 50L);\n    assert(candidate(4L, 8L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\n*/\nTuple!(long, long, long, long) add_pairwise(Tuple!(long, long, long, long, long) test_tup) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_pairwise;\n\n    assert(candidate(tuple(1L, 5L, 7L, 8L, 10L)) == tuple(6L, 12L, 15L, 18L));\n    assert(candidate(tuple(2L, 6L, 8L, 9L, 11L)) == tuple(8L, 14L, 17L, 20L));\n    assert(candidate(tuple(3L, 7L, 9L, 10L, 12L)) == tuple(10L, 16L, 19L, 22L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\n*/\nlong max_product_tuple(Tuple!(long, long)[] list1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 36L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 200L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 484L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "mbpp_101_kth_element",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\n*/\nlong kth_element(long[] arr, long k) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\n*/\nlong kth_element(long[] arr, long k) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = kth_element;\n\n    assert(candidate([12L, 3L, 5L, 7L, 19L], 2L) == 3L);\n    assert(candidate([17L, 24L, 8L, 23L], 3L) == 8L);\n    assert(candidate([16L, 21L, 25L, 36L, 4L], 4L) == 36L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4020,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to interchange the first and last element in a given list.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to convert a snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == [4L, 2L, 3L, 4L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"python_program\") == \"PythonProgram\");\n    assert(candidate(\"python_language\") == \"PythonLanguage\");\n    assert(candidate(\"programming_language\") == \"ProgrammingLanguage\");\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4035,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\n*/\nlong right_insertion(long[] a, long x) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the Eulerian number a(n, m).\n\t\n*/\nlong eulerian_num(long n, long m) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = right_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = eulerian_num;\n\n    assert(candidate(3L, 1L) == 4L);\n    assert(candidate(4L, 1L) == 11L);\n    assert(candidate(5L, 3L) == 26L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4050,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check if the given number is woodball or not.\n\t\n*/\nbool is_woodall(long x) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\n*/\nstring[][] sort_sublists(string[][] input_list) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_woodall;\n\n    assert(candidate(383L) == true);\n    assert(candidate(254L) == false);\n    assert(candidate(200L) == false);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n    assert(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4065,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort the given array by using shell sort.\n\t\n*/\nlong[] shell_sort(long[] my_list) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a python function to count true booleans in the given list.\n\t\n*/\nlong count(bool[] lst) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = shell_sort;\n\n    assert(candidate([12L, 23L, 4L, 5L, 3L, 2L, 12L, 81L, 56L, 95L]) == [2L, 3L, 4L, 5L, 12L, 12L, 23L, 56L, 81L, 95L]);\n    assert(candidate([24L, 22L, 39L, 34L, 87L, 73L, 68L]) == [22L, 24L, 34L, 39L, 68L, 73L, 87L]);\n    assert(candidate([32L, 30L, 16L, 96L, 82L, 83L, 74L]) == [16L, 30L, 32L, 74L, 82L, 83L, 96L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = count;\n\n    assert(candidate([true, false, true]) == 2L);\n    assert(candidate([false, false]) == 0L);\n    assert(candidate([true, true, true]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4080,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\n*/\nlong find_Odd_Pair(long[] A, long N) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to append the given list to the given tuples.\n\t\n*/\nTuple!(long, long, long, long, long) add_lists(long[] test_list, Tuple!(long, long) test_tup) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Odd_Pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L], 5L) == 6L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L], 7L) == 12L);\n    assert(candidate([1L, 2L, 3L], 3L) == 2L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_lists;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == tuple(9L, 10L, 5L, 6L, 7L));\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == tuple(10L, 11L, 6L, 7L, 8L));\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == tuple(11L, 12L, 7L, 8L, 9L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4095,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\n*/\nlong sum_in_range(long l, long r) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three lists into a single sorted list.\n\t\n*/\nlong[] merge_sorted_list(long[] num1, long[] num2, long[] num3) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_in_range;\n\n    assert(candidate(2L, 5L) == 8L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 13L) == 40L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = merge_sorted_list;\n\n    assert(candidate([25L, 24L, 15L, 4L, 5L, 29L, 110L], [19L, 20L, 11L, 56L, 25L, 233L, 154L], [24L, 26L, 54L, 48L]) == [4L, 5L, 11L, 15L, 19L, 20L, 24L, 24L, 25L, 25L, 26L, 29L, 48L, 54L, 56L, 110L, 154L, 233L]);\n    assert(candidate([1L, 3L, 5L, 6L, 8L, 9L], [2L, 5L, 7L, 11L], [1L, 4L, 7L, 8L, 12L]) == [1L, 1L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L, 8L, 8L, 9L, 11L, 12L]);\n    assert(candidate([18L, 14L, 10L, 9L, 8L, 7L, 9L, 3L, 2L, 4L, 1L], [25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L], [12L, 74L, 9L, 50L, 61L, 41L]) == [1L, 2L, 3L, 4L, 7L, 8L, 9L, 9L, 9L, 10L, 12L, 14L, 14L, 18L, 22L, 25L, 25L, 35L, 41L, 50L, 58L, 61L, 65L, 74L, 75L, 85L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4110,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\n*/\nlong square_perimeter(long a) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\n*/\nlong odd_Equivalent(string s, long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = square_perimeter;\n\n    assert(candidate(10L) == 40L);\n    assert(candidate(5L) == 20L);\n    assert(candidate(4L) == 16L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = odd_Equivalent;\n\n    assert(candidate(\"011001\", 6L) == 3L);\n    assert(candidate(\"11011\", 5L) == 4L);\n    assert(candidate(\"1010\", 4L) == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4125,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\n*/\nlong is_polite(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string represents an integer or not.\n\t\n*/\nbool check_integer(string text) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_polite;\n\n    assert(candidate(7L) == 11L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(9L) == 13L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = check_integer;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"1\") == true);\n    assert(candidate(\"12345\") == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4140,178 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\n*/\nlong sum_series(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\n*/\nlong tuple_to_int(Tuple!(long, long, long) nums) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_series;\n\n    assert(candidate(6L) == 12L);\n    assert(candidate(10L) == 30L);\n    assert(candidate(9L) == 25L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) find_dissimilar(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_dissimilar;\n\n    assert(candidate(tuple(3L, 4L, 5L, 6L), tuple(5L, 7L, 4L, 10L)) == tuple(3L, 6L, 7L, 10L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(7L, 2L, 3L, 9L)) == tuple(1L, 4L, 7L, 9L));\n    assert(candidate(tuple(21L, 11L, 25L, 26L), tuple(26L, 34L, 21L, 36L)) == tuple(34L, 36L, 11L, 25L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\n*/\nTuple!(string, string) start_withp(string[] words) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = start_withp;\n\n    assert(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == tuple(\"Python\", \"PHP\"));\n    assert(candidate([\"Python Programming\", \"Java Programming\"]) == tuple(\"Python\", \"Programming\"));\n    assert(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == tuple(\"Pqrst\", \"Pqr\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert the given snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"android_tv\") == \"AndroidTv\");\n    assert(candidate(\"google_pixel\") == \"GooglePixel\");\n    assert(candidate(\"apple_watch\") == \"AppleWatch\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the volume of a cube given its side length.\n\t\n*/\nlong volume_cube(long l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = volume_cube;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(2L) == 8L);\n    assert(candidate(5L) == 125L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\n*/\nbool check_monthnumb_number(long monthnum2) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_monthnumb_number;\n\n    assert(candidate(5L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(6L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\n*/\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = all_Bits_Set_In_The_Given_Range;\n\n    assert(candidate(4L, 1L, 2L) == true);\n    assert(candidate(17L, 2L, 4L) == true);\n    assert(candidate(39L, 4L, 6L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to get the first element of each sublist.\n\t\n*/\nlong[] Extract(long[][] lst) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = Extract;\n\n    assert(candidate([[1L, 2L], [3L, 4L, 5L], [6L, 7L, 8L, 9L]]) == [1L, 3L, 6L]);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L]]) == [1L, 4L]);\n    assert(candidate([[9L, 8L, 1L], [1L, 2L]]) == [9L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the surface area of a cylinder.\n\t\n*/\nfloat surfacearea_cylinder(long r, long h) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = surfacearea_cylinder;\n\n    assert(candidate(10L, 5L) == 942.45);\n    assert(candidate(4L, 5L) == 226.18800000000002);\n    assert(candidate(4L, 10L) == 351.848);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\n*/\nlong sample_nam(string[] sample_names) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sample_nam;\n\n    assert(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16L);\n    assert(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10L);\n    assert(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\n*/\nlong perimeter_pentagon(long a) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = perimeter_pentagon;\n\n    assert(candidate(5L) == 25L);\n    assert(candidate(10L) == 50L);\n    assert(candidate(15L) == 75L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\n*/\nlong max_sum(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_sum;\n\n    assert(candidate([1L, 15L, 51L, 45L, 33L, 100L, 12L, 18L, 9L]) == 194L);\n    assert(candidate([80L, 60L, 30L, 40L, 20L, 10L]) == 210L);\n    assert(candidate([2L, 3L, 14L, 16L, 21L, 23L, 29L, 30L]) == 138L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = tuple_to_int;\n\n    assert(candidate(tuple(1L, 2L, 3L)) == 123L);\n    assert(candidate(tuple(4L, 5L, 6L)) == 456L);\n    assert(candidate(tuple(5L, 6L, 7L)) == 567L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4322,9 +167,9 @@
   {
     "name": "mbpp_117_list_to_float",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert all possible convertible elements in a list of lists to floats.\n\t\n*/\nTuple!(float, float)[] list_to_float(Tuple!(string, string)[] test_list) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert all possible convertible elements in a list of lists to floats.\n\t\n*/\nTuple!(float, float)[] list_to_float(Tuple!(string, string)[] test_list) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = list_to_float;\n\n    assert(candidate([tuple(\"3\", \"4\"), tuple(\"1\", \"26.45\"), tuple(\"7.32\", \"8\"), tuple(\"4\", \"8\")]) == [tuple(3.0, 4.0), tuple(1.0, 26.45), tuple(7.32, 8.0), tuple(4.0, 8.0)]);\n    assert(candidate([tuple(\"4\", \"4\"), tuple(\"2\", \"27\"), tuple(\"4.12\", \"9\"), tuple(\"7\", \"11\")]) == [tuple(4.0, 4.0), tuple(2.0, 27.0), tuple(4.12, 9.0), tuple(7.0, 11.0)]);\n    assert(candidate([tuple(\"6\", \"78\"), tuple(\"5\", \"26.45\"), tuple(\"1.33\", \"4\"), tuple(\"82\", \"13\")]) == [tuple(6.0, 78.0), tuple(5.0, 26.45), tuple(1.33, 4.0), tuple(82.0, 13.0)]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4335,221 +180,11 @@
     ]
   },
   {
-    "name": "mbpp_287_square_Sum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 20L);\n    assert(candidate(3L) == 56L);\n    assert(candidate(4L) == 120L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\n*/\nlong get_pairs_count(long[] arr, long sum) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_pairs_count;\n\n    assert(candidate([1L, 1L, 1L, 1L], 2L) == 6L);\n    assert(candidate([1L, 5L, 7L, -1L, 5L], 6L) == 3L);\n    assert(candidate([1L, -2L, 3L], 1L) == 1L);\n    assert(candidate([-1L, -2L, 3L], -3L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\n*/\nlong count_no_of_ways(long n, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_no_of_ways;\n\n    assert(candidate(2L, 4L) == 16L);\n    assert(candidate(3L, 2L) == 6L);\n    assert(candidate(4L, 4L) == 228L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\n*/\nstring reverse_words(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = reverse_words;\n\n    assert(candidate(\"python program\") == \"program python\");\n    assert(candidate(\"java language\") == \"language java\");\n    assert(candidate(\"indian man\") == \"man indian\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\n*/\nbool checks(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = checks;\n\n    assert(candidate(70L) == false);\n    assert(candidate(23L) == false);\n    assert(candidate(73L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\n*/\nlong last(long[] arr, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = last;\n\n    assert(candidate([1L, 2L, 3L], 1L) == 0L);\n    assert(candidate([1L, 1L, 1L, 2L, 3L, 4L], 1L) == 2L);\n    assert(candidate([2L, 3L, 2L, 3L, 6L, 8L, 9L], 3L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\n*/\nlong count_X(long[] tup, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_X;\n\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 4L) == 0L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 10L) == 3L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 8L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\n*/\nstring concatenate_tuple(Tuple!(string, string, long, string) test_tup) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = concatenate_tuple;\n\n    assert(candidate(tuple(\"ID\", \"is\", 4L, \"UTS\")) == \"ID-is-4-UTS\");\n    assert(candidate(tuple(\"QWE\", \"is\", 4L, \"RTY\")) == \"QWE-is-4-RTY\");\n    assert(candidate(tuple(\"ZEN\", \"is\", 4L, \"OP\")) == \"ZEN-is-4-OP\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\n*/\nstring replace_spaces(string string) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\");\n    assert(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\");\n    assert(candidate(\"I love Coding\") == \"I%20love%20Coding\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\n*/\nlong sum_range_list(long[] list1, long m, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sum_range_list;\n\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 8L, 10L) == 29L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 5L, 7L) == 16L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 7L, 10L) == 38L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\n*/\nNullable!(string[string]) merge_dictionaries_three(Nullable!(string[string]) dict1, Nullable!(string[string]) dict2, Nullable!(string[string]) dict3) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = merge_dictionaries_three;\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable);\n        assert(!result.isNull && result.get == [\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the minimum of two numbers.\n\t\n*/\nlong minimum(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = minimum;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(-5L, -4L) == -5L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\n*/\nlong max_difference(Tuple!(long, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_difference;\n\n    assert(candidate([tuple(3L, 5L), tuple(1L, 7L), tuple(10L, 3L), tuple(1L, 2L)]) == 7L);\n    assert(candidate([tuple(4L, 6L), tuple(2L, 17L), tuple(9L, 13L), tuple(11L, 12L)]) == 15L);\n    assert(candidate([tuple(12L, 35L), tuple(21L, 27L), tuple(13L, 23L), tuple(41L, 22L)]) == 23L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find element at a given index after number of rotations.\n\t\n*/\nlong find_Element(long[] arr, long[][] ranges, long rotations, long index) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_Element;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [[0L, 2L], [0L, 3L]], 2L, 1L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L], [[0L, 1L], [0L, 2L]], 1L, 2L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [[0L, 1L], [0L, 2L]], 1L, 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "mbpp_118_string_to_list",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert a string to a list of strings split on the space character.\n\t\n*/\nstring[] string_to_list(string string) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a string to a list of strings split on the space character.\n\t\n*/\nstring[] string_to_list(string string) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = string_to_list;\n\n    assert(candidate(\"python programming\") == [\"python\", \"programming\"]);\n    assert(candidate(\"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"]);\n    assert(candidate(\"write a program\") == [\"write\", \"a\", \"program\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4562,9 +197,9 @@
   {
     "name": "mbpp_119_search",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the element that appears only once in a sorted array.\n\t\n*/\nlong search(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the element that appears only once in a sorted array.\n\t\n*/\nlong search(long[] arr) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([1L, 1L, 2L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 1L, 3L, 3L, 4L, 4L, 5L, 5L, 7L, 7L, 8L]) == 8L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L, 4L]) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4575,26 +210,11 @@
     ]
   },
   {
-    "name": "mbpp_475_sort_counter",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a dictionary by value.\n\t\n*/\nTuple!(string, long)[] sort_counter(Nullable!(long[string]) dict1) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_counter;\n\n    assert(candidate([\"Math\": 81L, \"Physics\": 83L, \"Chemistry\": 87L].nullable) == [tuple(\"Chemistry\", 87L), tuple(\"Physics\", 83L), tuple(\"Math\", 81L)]);\n    assert(candidate([\"Math\": 400L, \"Physics\": 300L, \"Chemistry\": 250L].nullable) == [tuple(\"Math\", 400L), tuple(\"Physics\", 300L), tuple(\"Chemistry\", 250L)]);\n    assert(candidate([\"Math\": 900L, \"Physics\": 1000L, \"Chemistry\": 1250L].nullable) == [tuple(\"Chemistry\", 1250L), tuple(\"Physics\", 1000L), tuple(\"Math\", 900L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "mbpp_11_remove_Occ",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to remove first and last occurrence of a given character from the string.\n\t\n*/\nstring remove_Occ(string s, string ch) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to remove first and last occurrence of a given character from the string.\n\t\n*/\nstring remove_Occ(string s, string ch) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = remove_Occ;\n\n    assert(candidate(\"hello\", \"l\") == \"heo\");\n    assert(candidate(\"abcda\", \"a\") == \"bcd\");\n    assert(candidate(\"PHP\", \"P\") == \"H\");\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4605,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\n*/\nlong lateralsurface_cube(long l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\n*/\nlong max_product_tuple(Tuple!(long, long)[] list1) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = lateralsurface_cube;\n\n    assert(candidate(5L) == 100L);\n    assert(candidate(9L) == 324L);\n    assert(candidate(10L) == 400L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = max_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 36L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 200L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 484L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4620,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to append the given list to the given tuples.\n\t\n*/\nTuple!(long, long, long, long, long) add_lists(long[] test_list, Tuple!(long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\n*/\nlong amicable_numbers_sum(long limit) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_lists;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == tuple(9L, 10L, 5L, 6L, 7L));\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == tuple(10L, 11L, 6L, 7L, 8L));\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == tuple(11L, 12L, 7L, 8L, 9L));\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = amicable_numbers_sum;\n\n    assert(candidate(999L) == 504L);\n    assert(candidate(9999L) == 31626L);\n    assert(candidate(99L) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4635,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to compute the n-th power of each number in a list.\n\t\n*/\nlong[] nth_nums(long[] nums, long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\n*/\nlong find_length(string string) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = nth_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L], 3L) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L], 5L) == [248832L, 759375L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = find_length;\n\n    assert(candidate(\"11000010001\") == 6L);\n    assert(candidate(\"10111\") == 1L);\n    assert(candidate(\"11011101100101\") == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4650,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a list of elements.\n\t\n*/\nlong[] pancake_sort(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\n*/\nlong sum(long a, long b) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = pancake_sort;\n\n    assert(candidate([15L, 79L, 25L, 38L, 69L]) == [15L, 25L, 38L, 69L, 79L]);\n    assert(candidate([98L, 12L, 54L, 36L, 85L]) == [12L, 36L, 54L, 85L, 98L]);\n    assert(candidate([41L, 42L, 32L, 12L, 23L]) == [12L, 23L, 32L, 41L, 42L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sum;\n\n    assert(candidate(10L, 15L) == 6L);\n    assert(candidate(100L, 150L) == 93L);\n    assert(candidate(4L, 6L) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4665,283 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the median of three numbers.\n\t\n*/\nfloat median_numbers(long a, long b, long c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to multiply two integers.\n\t\n*/\nlong multiply_int(long x, long y) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = median_numbers;\n\n    assert(candidate(25L, 55L, 65L) == 55.0);\n    assert(candidate(20L, 10L, 30L) == 20.0);\n    assert(candidate(15L, 45L, 75L) == 45.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\n*/\nbool check_greater(long[] arr, long number) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_greater;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 4L) == false);\n    assert(candidate([2L, 3L, 4L, 5L, 6L], 8L) == true);\n    assert(candidate([9L, 7L, 4L, 8L, 6L, 1L], 11L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\n*/\nstring[] extract_string(string[] str, long l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = extract_string;\n\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8L) == [\"practice\", \"solution\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6L) == [\"Python\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9L) == [\"exercises\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\n*/\nbool text_lowercase_underscore(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = text_lowercase_underscore;\n\n    assert(candidate(\"aab_cbbbc\") == true);\n    assert(candidate(\"aab_Abbbc\") == false);\n    assert(candidate(\"Aaab_abbbc\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to trim each list by k in the given lists.\n\t\n*/\nlong[][] trim_tuple(long[][] test_list, long K) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = trim_tuple;\n\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 2L) == [[2L], [9L], [2L], [2L]]);\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 1L) == [[3L, 2L, 1L], [4L, 9L, 2L], [1L, 2L, 3L], [8L, 2L, 1L]]);\n    assert(candidate([[7L, 8L, 4L, 9L], [11L, 8L, 12L, 4L], [4L, 1L, 7L, 8L], [3L, 6L, 9L, 7L]], 1L) == [[8L, 4L], [8L, 12L], [1L, 7L], [6L, 9L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to filter odd numbers.\n\t\n*/\nlong[] filter_oddnumbers(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = filter_oddnumbers;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 3L, 5L, 7L, 9L]);\n    assert(candidate([10L, 20L, 45L, 67L, 84L, 93L]) == [45L, 67L, 93L]);\n    assert(candidate([5L, 7L, 9L, 8L, 6L, 4L, 3L]) == [5L, 7L, 9L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\n*/\nstring find_adverbs(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_adverbs;\n\n    assert(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\");\n    assert(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\");\n    assert(candidate(\"Complete the task quickly\") == \"18-25: quickly\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\n*/\nlong max_of_nth(long[][] test_list, long N) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_of_nth;\n\n    assert(candidate([[5L, 6L, 7L], [1L, 3L, 5L], [8L, 9L, 19L]], 2L) == 19L);\n    assert(candidate([[6L, 7L, 8L], [2L, 4L, 6L], [9L, 10L, 20L]], 1L) == 10L);\n    assert(candidate([[7L, 8L, 9L], [3L, 5L, 7L], [10L, 11L, 21L]], 1L) == 11L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\n*/\nstring decimal_to_binary(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(8L) == \"1000\");\n    assert(candidate(18L) == \"10010\");\n    assert(candidate(7L) == \"111\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\n*/\nstring[][] combinations_colors(string[] l, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = combinations_colors;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 1L) == [[\"Red\"], [\"Green\"], [\"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 2L) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 3L) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to remove all whitespaces from a string.\n\t\n*/\nstring remove_all_spaces(string text) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_all_spaces;\n\n    assert(candidate(\"python  program\") == \"pythonprogram\");\n    assert(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\");\n    assert(candidate(\"python                     program\") == \"pythonprogram\");\n    assert(candidate(\"   python                     program\") == \"pythonprogram\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to create a new tuple from the given string and list.\n\t\n*/\nTuple!(string, string, string) new_tuple(string[] test_list, string test_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = new_tuple;\n\n    assert(candidate([\"WEB\", \"is\"], \"best\") == tuple(\"WEB\", \"is\", \"best\"));\n    assert(candidate([\"We\", \"are\"], \"Developers\") == tuple(\"We\", \"are\", \"Developers\"));\n    assert(candidate([\"Part\", \"is\"], \"Wrong\") == tuple(\"Part\", \"is\", \"Wrong\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\n*/\nlong find_remainder(long[] arr, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_remainder;\n\n    assert(candidate([100L, 10L, 5L, 25L, 35L, 14L], 11L) == 9L);\n    assert(candidate([1L, 1L, 1L], 1L) == 0L);\n    assert(candidate([1L, 2L, 1L], 2L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\n*/\nfloat positive_count(long[] nums) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = positive_count;\n\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.54);\n    assert(candidate([2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.69);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == 0.56);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to add the given tuple to the given list.\n\t\n*/\nlong[] add_tuple(long[] test_list, Tuple!(long, long) test_tup) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = add_tuple;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == [5L, 6L, 7L, 9L, 10L]);\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == [6L, 7L, 8L, 10L, 11L]);\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == [7L, 8L, 9L, 11L, 12L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\n*/\nlong max_run_uppercase(string test_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_run_uppercase;\n\n    assert(candidate(\"GeMKSForGERksISBESt\") == 5L);\n    assert(candidate(\"PrECIOusMOVemENTSYT\") == 6L);\n    assert(candidate(\"GooGLEFluTTER\") == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\n*/\nlong[][] sort_matrix(long[][] M) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sort_matrix;\n\n    assert(candidate([[1L, 2L, 3L], [2L, 4L, 5L], [1L, 1L, 1L]]) == [[1L, 1L, 1L], [1L, 2L, 3L], [2L, 4L, 5L]]);\n    assert(candidate([[1L, 2L, 3L], [-2L, 4L, -5L], [1L, -1L, 1L]]) == [[-2L, 4L, -5L], [1L, -1L, 1L], [1L, 2L, 3L]]);\n    assert(candidate([[5L, 8L, 9L], [6L, 4L, 3L], [2L, 1L, 4L]]) == [[2L, 1L, 4L], [6L, 4L, 3L], [5L, 8L, 9L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\n*/\nlong count_vowels(string test_str) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_vowels;\n\n    assert(candidate(\"bestinstareels\") == 7L);\n    assert(candidate(\"partofthejourneyistheend\") == 12L);\n    assert(candidate(\"amazonprime\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\n*/\nlong max_sum_increasing_subseq(long[] a, long n, long index, long k) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = max_sum_increasing_subseq;\n\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 4L, 6L) == 11L);\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 2L, 5L) == 7L);\n    assert(candidate([11L, 15L, 19L, 21L, 26L, 28L, 31L], 7L, 2L, 4L) == 71L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = multiply_int;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(5L, 10L) == 50L);\n    assert(candidate(4L, 8L) == 32L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4952,9 +302,9 @@
   {
     "name": "mbpp_128_long_words",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find words that are longer than n characters from a given list of words.\n\t\n*/\nstring[] long_words(long n, string str) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find words that are longer than n characters from a given list of words.\n\t\n*/\nstring[] long_words(long n, string str) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = long_words;\n\n    assert(candidate(3L, \"python is a programming language\") == [\"python\", \"programming\", \"language\"]);\n    assert(candidate(2L, \"writing a program\") == [\"writing\", \"program\"]);\n    assert(candidate(5L, \"sorting list\") == [\"sorting\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4965,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\n*/\nlong find_sum(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\n*/\nbool magic_square_test(long[][] my_matrix) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_sum;\n\n    assert(candidate([1L, 2L, 3L, 1L, 1L, 4L, 5L, 6L]) == 21L);\n    assert(candidate([1L, 10L, 9L, 4L, 2L, 10L, 10L, 45L, 4L]) == 71L);\n    assert(candidate([12L, 10L, 9L, 45L, 2L, 10L, 10L, 45L, 10L]) == 78L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = magic_square_test;\n\n    assert(candidate([[7L, 12L, 1L, 14L], [2L, 13L, 8L, 11L], [16L, 3L, 10L, 5L], [9L, 6L, 15L, 4L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 8L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 7L]]) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4980,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\n*/\nNullable!(long[long]) tuple_to_dict(Tuple!(long, long, long, long, long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\n*/\nlong[][] sort_matrix(long[][] M) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = tuple_to_dict;\n\n{\n        auto result = candidate(tuple(1L, 5L, 7L, 10L, 13L, 5L));\n        assert(!result.isNull && result.get == [1L: 5L, 7L: 10L, 13L: 5L]);\n}\n\n{\n        auto result = candidate(tuple(1L, 2L, 3L, 4L, 5L, 6L));\n        assert(!result.isNull && result.get == [1L: 2L, 3L: 4L, 5L: 6L]);\n}\n\n{\n        auto result = candidate(tuple(7L, 8L, 9L, 10L, 11L, 12L));\n        assert(!result.isNull && result.get == [7L: 8L, 9L: 10L, 11L: 12L]);\n}\n\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_matrix;\n\n    assert(candidate([[1L, 2L, 3L], [2L, 4L, 5L], [1L, 1L, 1L]]) == [[1L, 1L, 1L], [1L, 2L, 3L], [2L, 4L, 5L]]);\n    assert(candidate([[1L, 2L, 3L], [-2L, 4L, -5L], [1L, -1L, 1L]]) == [[-2L, 4L, -5L], [1L, -1L, 1L], [1L, 2L, 3L]]);\n    assert(candidate([[5L, 8L, 9L], [6L, 4L, 3L], [2L, 1L, 4L]]) == [[2L, 1L, 4L], [6L, 4L, 3L], [5L, 8L, 9L]]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4995,208 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\n*/\nlong[][] get_coordinates(Tuple!(long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\n*/\nlong max_occurrences(long[] nums) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = get_coordinates;\n\n    assert(candidate(tuple(3L, 4L)) == [[2L, 3L], [2L, 4L], [2L, 5L], [3L, 3L], [3L, 4L], [3L, 5L], [4L, 3L], [4L, 4L], [4L, 5L]]);\n    assert(candidate(tuple(4L, 5L)) == [[3L, 4L], [3L, 5L], [3L, 6L], [4L, 4L], [4L, 5L], [4L, 6L], [5L, 4L], [5L, 5L], [5L, 6L]]);\n    assert(candidate(tuple(5L, 6L)) == [[4L, 5L], [4L, 6L], [4L, 7L], [5L, 5L], [5L, 6L], [5L, 7L], [6L, 5L], [6L, 6L], [6L, 7L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\n*/\nlong find_First_Missing(long[] array) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_First_Missing;\n\n    assert(candidate([0L, 1L, 2L, 3L]) == 4L);\n    assert(candidate([0L, 1L, 2L, 6L, 9L]) == 3L);\n    assert(candidate([2L, 3L, 5L, 8L, 9L]) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given number is undulating or not.\n\t\n*/\nbool is_undulating(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_undulating;\n\n    assert(candidate(1212121L) == true);\n    assert(candidate(1991L) == false);\n    assert(candidate(121L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\n*/\nTuple!(string, long)[] min_k(Tuple!(string, long)[] test_list, long K) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = min_k;\n\n    assert(candidate([tuple(\"Manjeet\", 10L), tuple(\"Akshat\", 4L), tuple(\"Akash\", 2L), tuple(\"Nikhil\", 8L)], 2L) == [tuple(\"Akash\", 2L), tuple(\"Akshat\", 4L)]);\n    assert(candidate([tuple(\"Sanjeev\", 11L), tuple(\"Angat\", 5L), tuple(\"Akash\", 3L), tuple(\"Nepin\", 9L)], 3L) == [tuple(\"Akash\", 3L), tuple(\"Angat\", 5L), tuple(\"Nepin\", 9L)]);\n    assert(candidate([tuple(\"tanmay\", 14L), tuple(\"Amer\", 11L), tuple(\"Ayesha\", 9L), tuple(\"SKD\", 16L)], 1L) == [tuple(\"Ayesha\", 9L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\n*/\nlong count_Substrings(string s) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_Substrings;\n\n    assert(candidate(\"112112\") == 6L);\n    assert(candidate(\"111\") == 6L);\n    assert(candidate(\"1101112\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the nth decagonal number.\n\t\n*/\nlong is_num_decagonal(long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_num_decagonal;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(7L) == 175L);\n    assert(candidate(10L) == 370L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\n*/\nlong[] rear_extract(Tuple!(long, string, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = rear_extract;\n\n    assert(candidate([tuple(1L, \"Rash\", 21L), tuple(2L, \"Varsha\", 20L), tuple(3L, \"Kil\", 19L)]) == [21L, 20L, 19L]);\n    assert(candidate([tuple(1L, \"Sai\", 36L), tuple(2L, \"Ayesha\", 25L), tuple(3L, \"Salman\", 45L)]) == [36L, 25L, 45L]);\n    assert(candidate([tuple(1L, \"Sudeep\", 14L), tuple(2L, \"Vandana\", 36L), tuple(3L, \"Dawood\", 56L)]) == [14L, 36L, 56L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the closest smaller number than n.\n\t\n*/\nlong closest_num(long N) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = closest_num;\n\n    assert(candidate(11L) == 10L);\n    assert(candidate(7L) == 6L);\n    assert(candidate(12L) == 11L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\n*/\nTuple!(long, long)[] find_combinations(Tuple!(long, long)[] test_list) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_combinations;\n\n    assert(candidate([tuple(2L, 4L), tuple(6L, 7L), tuple(5L, 1L), tuple(6L, 10L)]) == [tuple(8L, 11L), tuple(7L, 5L), tuple(8L, 14L), tuple(11L, 8L), tuple(12L, 17L), tuple(11L, 11L)]);\n    assert(candidate([tuple(3L, 5L), tuple(7L, 8L), tuple(6L, 2L), tuple(7L, 11L)]) == [tuple(10L, 13L), tuple(9L, 7L), tuple(10L, 16L), tuple(13L, 10L), tuple(14L, 19L), tuple(13L, 13L)]);\n    assert(candidate([tuple(4L, 6L), tuple(8L, 9L), tuple(7L, 3L), tuple(8L, 12L)]) == [tuple(12L, 15L), tuple(11L, 9L), tuple(12L, 18L), tuple(15L, 12L), tuple(16L, 21L), tuple(15L, 15L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\n*/\nfloat maxAverageOfPath(long[][] cost) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = maxAverageOfPath;\n\n    assert(candidate([[1L, 2L, 3L], [6L, 5L, 4L], [7L, 3L, 9L]]) == 5.2);\n    assert(candidate([[2L, 3L, 4L], [7L, 6L, 5L], [8L, 4L, 10L]]) == 6.2);\n    assert(candidate([[3L, 4L, 5L], [8L, 7L, 6L], [9L, 5L, 11L]]) == 7.2);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]]) == 5.8);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\n*/\nTuple!(bool, long) sequential_search(long[] dlist, long item) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sequential_search;\n\n    assert(candidate([11L, 23L, 58L, 31L, 56L, 77L, 43L, 12L, 65L, 19L], 31L) == tuple(true, 3L));\n    assert(candidate([12L, 32L, 45L, 62L, 35L, 47L, 44L, 61L], 61L) == tuple(true, 7L));\n    assert(candidate([9L, 10L, 17L, 19L, 22L, 39L, 48L, 56L], 48L) == tuple(true, 6L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to remove odd numbers from a given list.\n\t\n*/\nlong[] remove_odd(long[] l) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate([1L, 2L, 3L]) == [2L]);\n    assert(candidate([2L, 4L, 6L]) == [2L, 4L, 6L]);\n    assert(candidate([10L, 20L, 3L]) == [10L, 20L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\n*/\nbool is_product_even(long[] arr) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = is_product_even;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 4L]) == true);\n    assert(candidate([1L, 1L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the maximum of two numbers.\n\t\n*/\nlong maximum(long a, long b) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate(5L, 10L) == 10L);\n    assert(candidate(-1L, -2L) == -1L);\n    assert(candidate(9L, 7L) == 9L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = max_occurrences;\n\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 2L, 6L, 5L, 1L, 6L, 1L, 2L, 3L, 2L, 4L, 6L, 9L, 1L, 2L]) == 2L);\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 7L, 9L, 15L, 14L, 10L, 12L, 13L, 16L, 18L]) == 8L);\n    assert(candidate([10L, 20L, 20L, 30L, 40L, 90L, 80L, 50L, 30L, 20L, 50L, 10L]) == 20L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5207,9 +362,9 @@
   {
     "name": "mbpp_131_reverse_vowels",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to reverse only the vowels of a given string (where y is not a vowel).\n\t\n*/\nstring reverse_vowels(string str1) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to reverse only the vowels of a given string (where y is not a vowel).\n\t\n*/\nstring reverse_vowels(string str1) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = reverse_vowels;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"USA\") == \"ASU\");\n    assert(candidate(\"ab\") == \"ab\");\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5220,11 +375,686 @@
     ]
   },
   {
+    "name": "mbpp_132_tup_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a list to a string.\n\t\n*/\nstring tup_string(string[] tup1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tup_string;\n\n    assert(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\");\n    assert(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\");\n    assert(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\n*/\nlong sum_negativenum(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_negativenum;\n\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == -32L);\n    assert(candidate([10L, 15L, -14L, 13L, -18L, 12L, -20L]) == -52L);\n    assert(candidate([19L, -65L, 57L, 39L, 152L, -639L, 121L, 44L, 90L, -190L]) == -894L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth hexagonal number.\n\t\n*/\nlong hexagonal_num(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = hexagonal_num;\n\n    assert(candidate(10L) == 190L);\n    assert(candidate(5L) == 45L);\n    assert(candidate(7L) == 91L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\n*/\nbool is_Sum_Of_Powers_Of_Two(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_Sum_Of_Powers_Of_Two;\n\n    assert(candidate(10L) == true);\n    assert(candidate(7L) == false);\n    assert(candidate(14L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a list of elements.\n\t\n*/\nlong[] pancake_sort(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pancake_sort;\n\n    assert(candidate([15L, 79L, 25L, 38L, 69L]) == [15L, 25L, 38L, 69L, 79L]);\n    assert(candidate([98L, 12L, 54L, 36L, 85L]) == [12L, 36L, 54L, 85L, 98L]);\n    assert(candidate([41L, 42L, 32L, 12L, 23L]) == [12L, 23L, 32L, 41L, 42L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\n*/\nlong count_samepair(long[] list1, long[] list2, long[] list3) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_samepair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 9L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 2L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\n*/\nlong max_Abs_Diff(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_Abs_Diff;\n\n    assert(candidate([2L, 1L, 5L, 3L]) == 4L);\n    assert(candidate([9L, 3L, 2L, 5L, 1L]) == 8L);\n    assert(candidate([3L, 2L, 1L]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the volume of a triangular prism.\n\t\n*/\nlong find_Volume(long l, long b, long h) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Volume;\n\n    assert(candidate(10L, 8L, 6L) == 240L);\n    assert(candidate(3L, 2L, 2L) == 6L);\n    assert(candidate(1L, 2L, 1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\n*/\nNullable!(Tuple!(long, long)) find_solution(long a, long b, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_solution;\n\n{\n        auto result = candidate(2L, 3L, 7L);\n        assert(!result.isNull && result.get == tuple(2L, 1L));\n}\n\n{\n        auto result = candidate(4L, 2L, 7L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(1L, 13L, 17L);\n        assert(!result.isNull && result.get == tuple(4L, 1L));\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all elements from a given list present in another list.\n\t\n*/\nlong[] remove_elements(long[] list1, long[] list2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_elements;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [2L, 4L, 6L, 8L]) == [1L, 3L, 5L, 7L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [1L, 3L, 5L, 7L]) == [2L, 4L, 6L, 8L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [5L, 7L]) == [1L, 2L, 3L, 4L, 6L, 8L, 9L, 10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\n*/\nlong sum_series(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_series;\n\n    assert(candidate(6L) == 12L);\n    assert(candidate(10L) == 30L);\n    assert(candidate(9L) == 25L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\n*/\nbool are_equivalent(long num1, long num2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = are_equivalent;\n\n    assert(candidate(36L, 57L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(23L, 47L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\n*/\nlong count_char_position(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_char_position;\n\n    assert(candidate(\"xbcefg\") == 2L);\n    assert(candidate(\"ABcED\") == 3L);\n    assert(candidate(\"AbgdeF\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\n*/\nlong find_even_pair(long[] A) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_even_pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L]) == 4L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L]) == 9L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\n*/\nlong next_power_of_2(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = next_power_of_2;\n\n    assert(candidate(0L) == 1L);\n    assert(candidate(5L) == 8L);\n    assert(candidate(17L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\n*/\nlong frequency(long[] a, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = frequency;\n\n    assert(candidate([1L, 2L, 3L], 4L) == 0L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 3L, 4L], 3L) == 3L);\n    assert(candidate([0L, 1L, 2L, 3L, 1L, 2L], 1L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\n*/\nbool text_lowercase_underscore(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_lowercase_underscore;\n\n    assert(candidate(\"aab_cbbbc\") == true);\n    assert(candidate(\"aab_Abbbc\") == false);\n    assert(candidate(\"Aaab_abbbc\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\n*/\nlong sum_range_list(long[] list1, long m, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_range_list;\n\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 8L, 10L) == 29L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 5L, 7L) == 16L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 7L, 10L) == 38L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\n*/\nlong perimeter_pentagon(long a) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = perimeter_pentagon;\n\n    assert(candidate(5L) == 25L);\n    assert(candidate(10L) == 50L);\n    assert(candidate(15L) == 75L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\n*/\nlong count_occurance(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_occurance;\n\n    assert(candidate(\"letstdlenstdporstd\") == 3L);\n    assert(candidate(\"truststdsolensporsd\") == 1L);\n    assert(candidate(\"makestdsostdworthit\") == 2L);\n    assert(candidate(\"stds\") == 1L);\n    assert(candidate(\"\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\n*/\nlong square_perimeter(long a) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = square_perimeter;\n\n    assert(candidate(10L) == 40L);\n    assert(candidate(5L) == 20L);\n    assert(candidate(4L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\n*/\nstring remove_dirty_chars(string string, string second_string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_dirty_chars;\n\n    assert(candidate(\"probasscurve\", \"pros\") == \"bacuve\");\n    assert(candidate(\"digitalindia\", \"talent\") == \"digiidi\");\n    assert(candidate(\"exoticmiles\", \"toxic\") == \"emles\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\n*/\nbool test_duplicate(long[] arraynums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = test_duplicate;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == true);\n    assert(candidate([1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given number is woodball or not.\n\t\n*/\nbool is_woodall(long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_woodall;\n\n    assert(candidate(383L) == true);\n    assert(candidate(254L) == false);\n    assert(candidate(200L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\n*/\nbool is_majority(long[] arr, long n, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_majority;\n\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 3L, 10L], 7L, 3L) == true);\n    assert(candidate([1L, 1L, 2L, 4L, 4L, 4L, 6L, 6L], 8L, 4L) == false);\n    assert(candidate([1L, 1L, 1L, 2L, 2L], 5L, 1L) == true);\n    assert(candidate([1L, 1L, 2L, 2L], 5L, 1L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\n*/\nlong count_Set_Bits(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_Set_Bits;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 1L);\n    assert(candidate(6L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\n*/\nstring odd_values_string(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = odd_values_string;\n\n    assert(candidate(\"abcdef\") == \"ace\");\n    assert(candidate(\"python\") == \"pto\");\n    assert(candidate(\"data\") == \"dt\");\n    assert(candidate(\"lambs\") == \"lms\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum of three numbers.\n\t\n*/\nlong min_of_three(long a, long b, long c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = min_of_three;\n\n    assert(candidate(10L, 20L, 0L) == 0L);\n    assert(candidate(19L, 15L, 18L) == 15L);\n    assert(candidate(-10L, -20L, -30L) == -30L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\n*/\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_Bits_Set_In_The_Given_Range;\n\n    assert(candidate(4L, 1L, 2L) == true);\n    assert(candidate(17L, 2L, 4L) == true);\n    assert(candidate(39L, 4L, 6L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\n*/\nlong[] re_arrange_array(long[] arr, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = re_arrange_array;\n\n    assert(candidate([-1L, 2L, -3L, 4L, 5L, 6L, -7L, 8L, 9L], 9L) == [-1L, -3L, -7L, 4L, 5L, 6L, 2L, 8L, 9L]);\n    assert(candidate([12L, -14L, -26L, 13L, 15L], 5L) == [-14L, -26L, 12L, 13L, 15L]);\n    assert(candidate([10L, 24L, 36L, -42L, -39L, -78L, 85L], 7L) == [-42L, -39L, -78L, 10L, 24L, 36L, 85L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\n*/\nstring replace_blank(string str1, string char) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = replace_blank;\n\n    assert(candidate(\"hello people\", \"@\") == \"hello@people\");\n    assert(candidate(\"python program language\", \"$\") == \"python$program$language\");\n    assert(candidate(\"blank space\", \"-\") == \"blank-space\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the volume of a cube given its side length.\n\t\n*/\nlong volume_cube(long l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = volume_cube;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(2L) == 8L);\n    assert(candidate(5L) == 125L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\n*/\nlong number_of_substrings(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = number_of_substrings;\n\n    assert(candidate(\"abc\") == 6L);\n    assert(candidate(\"abcd\") == 10L);\n    assert(candidate(\"abcde\") == 15L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\n*/\nlong get_total_number_of_sequences(long m, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_total_number_of_sequences;\n\n    assert(candidate(10L, 4L) == 4L);\n    assert(candidate(5L, 2L) == 6L);\n    assert(candidate(16L, 3L) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the total number of characters in a string.\n\t\n*/\nlong count_charac(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_charac;\n\n    assert(candidate(\"python programming\") == 18L);\n    assert(candidate(\"language\") == 8L);\n    assert(candidate(\"words\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\n*/\nlong next_Perfect_Square(long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = next_Perfect_Square;\n\n    assert(candidate(35L) == 36L);\n    assert(candidate(6L) == 9L);\n    assert(candidate(9L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\n*/\nlong max_sum(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_sum;\n\n    assert(candidate([1L, 15L, 51L, 45L, 33L, 100L, 12L, 18L, 9L]) == 194L);\n    assert(candidate([80L, 60L, 30L, 40L, 20L, 10L]) == 210L);\n    assert(candidate([2L, 3L, 14L, 16L, 21L, 23L, 29L, 30L]) == 138L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\n*/\nlong lps(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = lps;\n\n    assert(candidate(\"TENS FOR TENS\") == 5L);\n    assert(candidate(\"CARDIO FOR CARDS\") == 7L);\n    assert(candidate(\"PART OF THE JOURNEY IS PART\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the intersection of two arrays.\n\t\n*/\nlong[] intersection_array(long[] array_nums1, long[] array_nums2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = intersection_array;\n\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [1L, 2L, 4L, 8L, 9L]) == [1L, 2L, 8L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [3L, 5L, 7L, 9L]) == [3L, 5L, 7L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [10L, 20L, 30L, 40L]) == [10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\n*/\nlong count_X(long[] tup, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_X;\n\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 4L) == 0L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 10L) == 3L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 8L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\n*/\nstring[] insert_element(string[] list, string element) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = insert_element;\n\n    assert(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n    assert(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"]);\n    assert(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\n*/\nTuple!(float, float) convert(long numbers) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = convert;\n\n    assert(candidate(1L) == tuple(1.0, 0.0));\n    assert(candidate(4L) == tuple(4.0, 0.0));\n    assert(candidate(5L) == tuple(5.0, 0.0));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\n*/\nstring[][] combinations_colors(string[] l, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = combinations_colors;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 1L) == [[\"Red\"], [\"Green\"], [\"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 2L) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 3L) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\n*/\nlong count_Primes_nums(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_Primes_nums;\n\n    assert(candidate(5L) == 2L);\n    assert(candidate(10L) == 4L);\n    assert(candidate(100L) == 25L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\n*/\nlong[] swap_numbers(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = swap_numbers;\n\n    assert(candidate(10L, 20L) == [20L, 10L]);\n    assert(candidate(15L, 17L) == [17L, 15L]);\n    assert(candidate(100L, 200L) == [200L, 100L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "mbpp_259_maximize_elements",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to maximize the given two lists.\n\t\n*/\nlong[][] maximize_elements(long[][] test_tup1, long[][] test_tup2) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to maximize the given two lists.\n\t\n*/\nlong[][] maximize_elements(long[][] test_tup1, long[][] test_tup2) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = maximize_elements;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 7L], [4L, 9L], [2L, 9L], [7L, 10L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[7L, 8L], [5L, 10L], [3L, 10L], [8L, 11L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[8L, 9L], [6L, 11L], [4L, 11L], [9L, 12L]]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5235,13 +1065,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\n*/\nbool even_position(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\n*/\nlong newman_prime(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = even_position;\n\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L]) == false);\n    assert(candidate([2L, 1L, 4L]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = newman_prime;\n\n    assert(candidate(3L) == 7L);\n    assert(candidate(4L) == 17L);\n    assert(candidate(5L) == 41L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5250,13 +1080,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\n*/\nstring check_char(string string) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) division_elements(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = check_char;\n\n    assert(candidate(\"abba\") == \"Valid\");\n    assert(candidate(\"a\") == \"Valid\");\n    assert(candidate(\"abcd\") == \"Invalid\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = division_elements;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(2L, 2L, 2L, 3L));\n    assert(candidate(tuple(12L, 6L, 8L, 16L), tuple(6L, 3L, 4L, 4L)) == tuple(2L, 2L, 2L, 4L));\n    assert(candidate(tuple(20L, 14L, 36L, 18L), tuple(5L, 7L, 6L, 9L)) == tuple(4L, 2L, 6L, 2L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5265,13 +1095,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_264_dog_age",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function to find the sum of even factors of a number.\n\t\n*/\nlong sumofFactors(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate a dog's age in dog's years.\n\t\n*/\nlong dog_age(long h_age) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = sumofFactors;\n\n    assert(candidate(18L) == 26L);\n    assert(candidate(30L) == 48L);\n    assert(candidate(6L) == 8L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = dog_age;\n\n    assert(candidate(12L) == 61L);\n    assert(candidate(15L) == 73L);\n    assert(candidate(24L) == 109L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5280,43 +1110,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\n*/\nfloat lateralsurface_cone(long r, long h) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\n*/\nlong lateralsurface_cube(long l) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = lateralsurface_cone;\n\n    assert(candidate(5L, 12L) == 204.20352248333654);\n    assert(candidate(10L, 15L) == 566.3586699569488);\n    assert(candidate(19L, 17L) == 1521.8090132193388);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_564_count_Pairs",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\n*/\nlong count_Pairs(long[] arr, long n) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = count_Pairs;\n\n    assert(candidate([1L, 2L, 1L], 3L) == 2L);\n    assert(candidate([1L, 1L, 1L, 1L], 4L) == 0L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 5L) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_733_find_first_occurrence",
-    "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\n*/\nlong find_first_occurrence(long[] A, long x) \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = find_first_occurrence;\n\n    assert(candidate([2L, 5L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 1L);\n    assert(candidate([2L, 3L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 2L);\n    assert(candidate([2L, 4L, 1L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 6L) == 4L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = lateralsurface_cube;\n\n    assert(candidate(5L) == 100L);\n    assert(candidate(9L) == 324L);\n    assert(candidate(10L) == 400L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5327,9 +1127,9 @@
   {
     "name": "mbpp_267_square_Sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 10L);\n    assert(candidate(3L) == 35L);\n    assert(candidate(4L) == 84L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5340,11 +1140,761 @@
     ]
   },
   {
+    "name": "mbpp_268_find_star_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th star number.\n\t\n*/\nlong find_star_num(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_star_num;\n\n    assert(candidate(3L) == 37L);\n    assert(candidate(4L) == 73L);\n    assert(candidate(5L) == 121L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ascii value of a character.\n\t\n*/\nlong ascii_value(string k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = ascii_value;\n\n    assert(candidate(\"A\") == 65L);\n    assert(candidate(\"R\") == 82L);\n    assert(candidate(\"S\") == 83L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\n*/\nlong sum_even_and_even_index(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_even_and_even_index;\n\n    assert(candidate([5L, 6L, 12L, 1L, 18L, 8L]) == 30L);\n    assert(candidate([3L, 20L, 17L, 9L, 2L, 10L, 18L, 13L, 6L, 18L]) == 26L);\n    assert(candidate([5L, 6L, 12L, 1L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\n*/\nlong even_Power_Sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_Power_Sum;\n\n    assert(candidate(2L) == 1056L);\n    assert(candidate(3L) == 8832L);\n    assert(candidate(1L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\n*/\nlong[] rear_extract(Tuple!(long, string, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rear_extract;\n\n    assert(candidate([tuple(1L, \"Rash\", 21L), tuple(2L, \"Varsha\", 20L), tuple(3L, \"Kil\", 19L)]) == [21L, 20L, 19L]);\n    assert(candidate([tuple(1L, \"Sai\", 36L), tuple(2L, \"Ayesha\", 25L), tuple(3L, \"Salman\", 45L)]) == [36L, 25L, 45L]);\n    assert(candidate([tuple(1L, \"Sudeep\", 14L), tuple(2L, \"Vandana\", 36L), tuple(3L, \"Dawood\", 56L)]) == [14L, 36L, 56L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\n*/\nTuple!(long, long, long) substract_elements(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = substract_elements;\n\n    assert(candidate(tuple(10L, 4L, 5L), tuple(2L, 5L, 18L)) == tuple(8L, -1L, -13L));\n    assert(candidate(tuple(11L, 2L, 3L), tuple(24L, 45L, 16L)) == tuple(-13L, -43L, -13L));\n    assert(candidate(tuple(7L, 18L, 9L), tuple(10L, 11L, 12L)) == tuple(-3L, 7L, -3L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\n*/\nlong even_binomial_Coeff_Sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_binomial_Coeff_Sum;\n\n    assert(candidate(4L) == 8L);\n    assert(candidate(6L) == 32L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\n*/\nNullable!(long[string]) dict_filter(Nullable!(long[string]) dict, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = dict_filter;\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 170L);\n        assert(!result.isNull && result.get == [\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 180L);\n        assert(!result.isNull && result.get == [\"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 190L);\n        assert(!result.isNull && result.get == [\"Pierre Cox\": 190L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth decagonal number.\n\t\n*/\nlong is_num_decagonal(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_num_decagonal;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(7L) == 175L);\n    assert(candidate(10L) == 370L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\n*/\nTuple!(bool, long) sequential_search(long[] dlist, long item) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sequential_search;\n\n    assert(candidate([11L, 23L, 58L, 31L, 56L, 77L, 43L, 12L, 65L, 19L], 31L) == tuple(true, 3L));\n    assert(candidate([12L, 32L, 45L, 62L, 35L, 47L, 44L, 61L], 61L) == tuple(true, 7L));\n    assert(candidate([9L, 10L, 17L, 19L, 22L, 39L, 48L, 56L], 48L) == tuple(true, 6L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\n*/\nbool all_unique(long[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_unique;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to subtract two lists element-wise.\n\t\n*/\nlong[] sub_list(long[] nums1, long[] nums2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sub_list;\n\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == [-3L, -3L, -3L]);\n    assert(candidate([1L, 2L], [3L, 4L]) == [-2L, -2L]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [40L, 50L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\n*/\nbool validate(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = validate;\n\n    assert(candidate(1234L) == true);\n    assert(candidate(51241L) == false);\n    assert(candidate(321L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\n*/\nbool text_match_two_three(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_two_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\n*/\nlong max_sub_array_sum_repeated(long[] a, long n, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum_repeated;\n\n    assert(candidate([10L, 20L, -30L, -1L], 4L, 3L) == 30L);\n    assert(candidate([-1L, 10L, 20L], 3L, 2L) == 59L);\n    assert(candidate([-1L, -2L, -3L], 3L, 3L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 20L);\n    assert(candidate(3L) == 56L);\n    assert(candidate(4L) == 120L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\n*/\nTuple!(long, long[]) max_length(long[][] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_length;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L], [5L, 7L], [10L, 12L, 14L, 15L]]) == tuple(4L, [10L, 12L, 14L, 15L]));\n    assert(candidate([[5L], [15L, 20L, 25L]]) == tuple(3L, [15L, 20L, 25L]));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\n*/\nlong count_no_of_ways(long n, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_no_of_ways;\n\n    assert(candidate(2L, 4L) == 16L);\n    assert(candidate(3L, 2L) == 6L);\n    assert(candidate(4L, 4L) == 228L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\n*/\nlong find(long n, long m) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find;\n\n    assert(candidate(10L, 3L) == 3L);\n    assert(candidate(4L, 2L) == 2L);\n    assert(candidate(20L, 5L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the third side of a right angled triangle.\n\t\n*/\nfloat otherside_rightangle(long w, long h) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = otherside_rightangle;\n\n    assert(candidate(7L, 8L) == 10.63014581273465);\n    assert(candidate(3L, 4L) == 5L);\n    assert(candidate(7L, 15L) == 16.55294535724685);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return the sum of all divisors of a number.\n\t\n*/\nlong sum_div(long number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_div;\n\n    assert(candidate(8L) == 7L);\n    assert(candidate(12L) == 16L);\n    assert(candidate(7L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count inversions in an array.\n\t\n*/\nlong get_Inv_Count(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_Inv_Count;\n\n    assert(candidate([1L, 20L, 6L, 4L, 5L]) == 5L);\n    assert(candidate([1L, 2L, 1L]) == 1L);\n    assert(candidate([1L, 2L, 5L, 6L, 1L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\n*/\nTuple!(string, long) max_aggregate(Tuple!(string, long)[] stdata) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_aggregate;\n\n    assert(candidate([tuple(\"Juan Whelan\", 90L), tuple(\"Sabah Colley\", 88L), tuple(\"Peter Nichols\", 7L), tuple(\"Juan Whelan\", 122L), tuple(\"Sabah Colley\", 84L)]) == tuple(\"Juan Whelan\", 212L));\n    assert(candidate([tuple(\"Juan Whelan\", 50L), tuple(\"Sabah Colley\", 48L), tuple(\"Peter Nichols\", 37L), tuple(\"Juan Whelan\", 22L), tuple(\"Sabah Colley\", 14L)]) == tuple(\"Juan Whelan\", 72L));\n    assert(candidate([tuple(\"Juan Whelan\", 10L), tuple(\"Sabah Colley\", 20L), tuple(\"Peter Nichols\", 30L), tuple(\"Juan Whelan\", 40L), tuple(\"Sabah Colley\", 50L)]) == tuple(\"Sabah Colley\", 70L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find element at a given index after number of rotations.\n\t\n*/\nlong find_Element(long[] arr, long[][] ranges, long rotations, long index) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Element;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [[0L, 2L], [0L, 3L]], 2L, 1L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L], [[0L, 1L], [0L, 2L]], 1L, 2L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [[0L, 1L], [0L, 2L]], 1L, 1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\n*/\nTuple!(string, string) start_withp(string[] words) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = start_withp;\n\n    assert(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == tuple(\"Python\", \"PHP\"));\n    assert(candidate([\"Python Programming\", \"Java Programming\"]) == tuple(\"Python\", \"Programming\"));\n    assert(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == tuple(\"Pqrst\", \"Pqr\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\n*/\nlong max_sum_increasing_subseq(long[] a, long n, long index, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_sum_increasing_subseq;\n\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 4L, 6L) == 11L);\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 2L, 5L) == 7L);\n    assert(candidate([11L, 15L, 19L, 21L, 26L, 28L, 31L], 7L, 2L, 4L) == 71L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\n*/\nlong[] large_product(long[] nums1, long[] nums2, long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = large_product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 3L) == [60L, 54L, 50L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 4L) == [60L, 54L, 50L, 48L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 5L) == [60L, 54L, 50L, 48L, 45L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the maximum of two numbers.\n\t\n*/\nlong maximum(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate(5L, 10L) == 10L);\n    assert(candidate(-1L, -2L) == -1L);\n    assert(candidate(9L, 7L) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a given string to a list of characters.\n\t\n*/\nstring[] string_to_tuple(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = string_to_tuple;\n\n    assert(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n    assert(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"]);\n    assert(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\n*/\nlong highest_Power_of_2(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = highest_Power_of_2;\n\n    assert(candidate(10L) == 8L);\n    assert(candidate(19L) == 16L);\n    assert(candidate(32L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th lucas number.\n\t\n*/\nlong find_lucas(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_lucas;\n\n    assert(candidate(9L) == 76L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(3L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert more than one list to nested dictionary.\n\t\n*/\nNone[] convert_list_dictionary(string[] l1, string[] l2, long[] l3) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = convert_list_dictionary;\n\n    assert(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85L, 98L, 89L, 92L]) == [[\"S001\": [\"Adina Park\": 85L].nullable].nullable, [\"S002\": [\"Leyton Marsh\": 98L].nullable].nullable, [\"S003\": [\"Duncan Boyle\": 89L].nullable].nullable, [\"S004\": [\"Saim Richards\": 92L].nullable].nullable]);\n    assert(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100L, 200L, 300L, 400L]) == [[\"abc\": [\"python\": 100L].nullable].nullable, [\"def\": [\"program\": 200L].nullable].nullable, [\"ghi\": [\"language\": 300L].nullable].nullable, [\"jkl\": [\"programs\": 400L].nullable].nullable]);\n    assert(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10L, 20L, 30L, 40L]) == [[\"A1\": [\"java\": 10L].nullable].nullable, [\"A2\": [\"C\": 20L].nullable].nullable, [\"A3\": [\"C++\": 30L].nullable].nullable, [\"A4\": [\"DBMS\": 40L].nullable].nullable]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\n*/\nlong get_max_sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_max_sum;\n\n    assert(candidate(60L) == 106L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the list with maximum length.\n\t\n*/\nTuple!(long, long[]) max_length_list(long[][] input_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_length_list;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L, 2L, 3L, 4L, 5L], [1L, 2L, 3L, 4L], [1L, 2L, 3L], [1L, 2L], [1L]]) == tuple(5L, [1L, 2L, 3L, 4L, 5L]));\n    assert(candidate([[3L, 4L, 5L], [6L, 7L, 8L, 9L], [10L, 11L, 12L]]) == tuple(4L, [6L, 7L, 8L, 9L]));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if given list contains no duplicates.\n\t\n*/\nbool check_distinct(long[] test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_distinct;\n\n    assert(candidate([1L, 4L, 5L, 6L, 1L, 4L]) == false);\n    assert(candidate([1L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 6L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\n*/\nNullable!(string) first_non_repeating_character(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = first_non_repeating_character;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"ababc\");\n        assert(!result.isNull && result.get == \"c\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\n*/\nstring check_char(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_char;\n\n    assert(candidate(\"abba\") == \"Valid\");\n    assert(candidate(\"a\") == \"Valid\");\n    assert(candidate(\"abcd\") == \"Invalid\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of three numbers.\n\t\n*/\nfloat median_numbers(long a, long b, long c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = median_numbers;\n\n    assert(candidate(25L, 55L, 65L) == 55.0);\n    assert(candidate(20L, 10L, 30L) == 20.0);\n    assert(candidate(15L, 45L, 75L) == 45.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) bitwise_xor(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = bitwise_xor;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(15L, 6L, 5L, 10L));\n    assert(candidate(tuple(11L, 5L, 7L, 10L), tuple(6L, 3L, 4L, 4L)) == tuple(13L, 6L, 3L, 14L));\n    assert(candidate(tuple(12L, 6L, 8L, 11L), tuple(7L, 4L, 5L, 6L)) == tuple(11L, 2L, 13L, 13L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to identify non-prime numbers.\n\t\n*/\nbool is_not_prime(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_not_prime;\n\n    assert(candidate(2L) == false);\n    assert(candidate(10L) == true);\n    assert(candidate(35L) == true);\n    assert(candidate(37L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\n*/\nlong extract_freq(Tuple!(long, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = extract_freq;\n\n    assert(candidate([tuple(3L, 4L), tuple(1L, 2L), tuple(4L, 3L), tuple(5L, 6L)]) == 3L);\n    assert(candidate([tuple(4L, 15L), tuple(2L, 3L), tuple(5L, 4L), tuple(6L, 7L)]) == 4L);\n    assert(candidate([tuple(5L, 16L), tuple(2L, 3L), tuple(6L, 5L), tuple(6L, 9L)]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\n*/\nlong[][] add_nested_tuples(long[][] test_tup1, long[][] test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add_nested_tuples;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[7L, 10L], [7L, 14L], [3L, 10L], [8L, 13L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[9L, 12L], [9L, 16L], [5L, 12L], [10L, 15L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[11L, 14L], [11L, 18L], [7L, 14L], [12L, 17L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the minimum of two numbers.\n\t\n*/\nlong minimum(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = minimum;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(-5L, -4L) == -5L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\n*/\nbool find_Parity(long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Parity;\n\n    assert(candidate(12L) == false);\n    assert(candidate(7L) == true);\n    assert(candidate(10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\n*/\nlong[][] k_smallest_pairs(long[] nums1, long[] nums2, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = k_smallest_pairs;\n\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 2L) == [[1L, 2L], [1L, 4L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 1L) == [[1L, 2L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 7L) == [[1L, 2L], [1L, 4L], [3L, 2L], [1L, 6L], [3L, 4L], [3L, 6L], [7L, 2L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\n*/\nlong min_product_tuple(Tuple!(long, long)[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = min_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 8L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 30L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 100L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"android_tv\") == \"AndroidTv\");\n    assert(candidate(\"google_pixel\") == \"GooglePixel\");\n    assert(candidate(\"apple_watch\") == \"AppleWatch\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to remove odd numbers from a given list.\n\t\n*/\nlong[] remove_odd(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate([1L, 2L, 3L]) == [2L]);\n    assert(candidate([2L, 4L, 6L]) == [2L, 4L, 6L]);\n    assert(candidate([10L, 20L, 3L]) == [10L, 20L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\n*/\nbool overlapping(long[] list1, long[] list2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = overlapping;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 8L, 9L]) == false);\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == false);\n    assert(candidate([1L, 4L, 5L], [1L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\n*/\nTuple!(long, long) max_Product(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_Product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 7L, 0L, 8L, 4L]) == tuple(7L, 8L));\n    assert(candidate([0L, -1L, -2L, -4L, 5L, 0L, -6L]) == tuple(-4L, -6L));\n    assert(candidate([1L, 2L, 3L]) == tuple(2L, 3L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
     "name": "mbpp_417_group_tuples",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to find common first element in given list of lists.\n\t\n*/\nstring[][] group_tuples(string[][] Input) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find common first element in given list of lists.\n\t\n*/\nstring[][] group_tuples(string[][] Input) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "unittest\n{\n    alias candidate = group_tuples;\n\n    assert(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n    assert(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5355,13 +1905,3463 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_420_cube_Sum",
     "language": "d",
-    "prompt": "import std.typecons;\nimport std.math;\n/*\n\n\tWrite a function to merge three lists into a single sorted list.\n\t\n*/\nlong[] merge_sorted_list(long[] num1, long[] num2, long[] num3) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\n*/\nlong cube_Sum(long n) \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "unittest\n{\n    alias candidate = merge_sorted_list;\n\n    assert(candidate([25L, 24L, 15L, 4L, 5L, 29L, 110L], [19L, 20L, 11L, 56L, 25L, 233L, 154L], [24L, 26L, 54L, 48L]) == [4L, 5L, 11L, 15L, 19L, 20L, 24L, 24L, 25L, 25L, 26L, 29L, 48L, 54L, 56L, 110L, 154L, 233L]);\n    assert(candidate([1L, 3L, 5L, 6L, 8L, 9L], [2L, 5L, 7L, 11L], [1L, 4L, 7L, 8L, 12L]) == [1L, 1L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L, 8L, 8L, 9L, 11L, 12L]);\n    assert(candidate([18L, 14L, 10L, 9L, 8L, 7L, 9L, 3L, 2L, 4L, 1L], [25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L], [12L, 74L, 9L, 50L, 61L, 41L]) == [1L, 2L, 3L, 4L, 7L, 8L, 9L, 9L, 9L, 10L, 12L, 14L, 14L, 18L, 22L, 25L, 25L, 35L, 41L, 50L, 58L, 61L, 65L, 74L, 75L, 85L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = cube_Sum;\n\n    assert(candidate(2L) == 72L);\n    assert(candidate(3L) == 288L);\n    assert(candidate(4L) == 800L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\n*/\nstring concatenate_tuple(Tuple!(string, string, long, string) test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = concatenate_tuple;\n\n    assert(candidate(tuple(\"ID\", \"is\", 4L, \"UTS\")) == \"ID-is-4-UTS\");\n    assert(candidate(tuple(\"QWE\", \"is\", 4L, \"RTY\")) == \"QWE-is-4-RTY\");\n    assert(candidate(tuple(\"ZEN\", \"is\", 4L, \"OP\")) == \"ZEN-is-4-OP\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\n*/\nfloat find_Average_Of_Cube(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Average_Of_Cube;\n\n    assert(candidate(2L) == 4.5);\n    assert(candidate(3L) == 12L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\n*/\nstring[] extract_rear(Tuple!(string, string, string) test_tuple) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = extract_rear;\n\n    assert(candidate(tuple(\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"]);\n    assert(candidate(tuple(\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"]);\n    assert(candidate(tuple(\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to filter odd numbers.\n\t\n*/\nlong[] filter_oddnumbers(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = filter_oddnumbers;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 3L, 5L, 7L, 9L]);\n    assert(candidate([10L, 20L, 45L, 67L, 84L, 93L]) == [45L, 67L, 93L]);\n    assert(candidate([5L, 7L, 9L, 8L, 6L, 4L, 3L]) == [5L, 7L, 9L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\n*/\nstring change_date_format(string dt) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = change_date_format;\n\n    assert(candidate(\"2026-01-02\") == \"02-01-2026\");\n    assert(candidate(\"2020-11-13\") == \"13-11-2020\");\n    assert(candidate(\"2021-04-26\") == \"26-04-2021\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given array by using shell sort.\n\t\n*/\nlong[] shell_sort(long[] my_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = shell_sort;\n\n    assert(candidate([12L, 23L, 4L, 5L, 3L, 2L, 12L, 81L, 56L, 95L]) == [2L, 3L, 4L, 5L, 12L, 12L, 23L, 56L, 81L, 95L]);\n    assert(candidate([24L, 22L, 39L, 34L, 87L, 73L, 68L]) == [22L, 24L, 34L, 39L, 68L, 73L, 87L]);\n    assert(candidate([32L, 30L, 16L, 96L, 82L, 83L, 74L]) == [16L, 30L, 32L, 74L, 82L, 83L, 96L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) and_tuples(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = and_tuples;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(0L, 0L, 2L, 1L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(5L, 6L, 7L, 8L)) == tuple(1L, 2L, 3L, 0L));\n    assert(candidate(tuple(8L, 9L, 11L, 12L), tuple(7L, 13L, 14L, 17L)) == tuple(0L, 9L, 10L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the directrix of a parabola.\n\t\n*/\nlong parabola_directrix(long a, long b, long c) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = parabola_directrix;\n\n    assert(candidate(5L, 3L, 2L) == -198L);\n    assert(candidate(9L, 8L, 4L) == -2336L);\n    assert(candidate(2L, 4L, 6L) == -130L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median length of a trapezium.\n\t\n*/\nfloat median_trapezium(long base1, long base2, long height) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = median_trapezium;\n\n    assert(candidate(15L, 25L, 35L) == 20L);\n    assert(candidate(10L, 20L, 30L) == 15L);\n    assert(candidate(6L, 9L, 4L) == 7.5);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\n*/\nbool check_greater(long[] arr, long number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_greater;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 4L) == false);\n    assert(candidate([2L, 3L, 4L, 5L, 6L], 8L) == true);\n    assert(candidate([9L, 7L, 4L, 8L, 6L, 1L], 11L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\n*/\nbool text_match_one(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the last digit of a given number.\n\t\n*/\nlong last_Digit(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = last_Digit;\n\n    assert(candidate(123L) == 3L);\n    assert(candidate(25L) == 5L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to return the negative numbers in a list.\n\t\n*/\nlong[] neg_nos(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = neg_nos;\n\n    assert(candidate([-1L, 4L, 5L, -6L]) == [-1L, -6L]);\n    assert(candidate([-1L, -2L, 3L, 4L]) == [-1L, -2L]);\n    assert(candidate([-7L, -6L, 8L, 9L]) == [-7L, -6L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove odd characters in a string.\n\t\n*/\nstring remove_odd(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate(\"python\") == \"yhn\");\n    assert(candidate(\"program\") == \"rga\");\n    assert(candidate(\"language\") == \"agae\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count bidirectional tuple pairs.\n\t\n*/\nlong count_bidirectional(Tuple!(long, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_bidirectional;\n\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 3L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 3L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 2L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 2L), tuple(6L, 5L), tuple(2L, 1L)]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\n*/\nlong multiple_to_single(long[] L) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = multiple_to_single;\n\n    assert(candidate([11L, 33L, 50L]) == 113350L);\n    assert(candidate([-1L, 2L, 3L, 4L, 5L, 6L]) == -123456L);\n    assert(candidate([10L, 15L, 20L, 25L]) == 10152025L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\n*/\nTuple!(long, long, string) find_adverb_position(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_adverb_position;\n\n    assert(candidate(\"clearly!! we can see the sky\") == tuple(0L, 7L, \"clearly\"));\n    assert(candidate(\"seriously!! there are many roses\") == tuple(0L, 9L, \"seriously\"));\n    assert(candidate(\"unfortunately!! sita is going to home\") == tuple(0L, 13L, \"unfortunately\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cube of a given size.\n\t\n*/\nlong surfacearea_cube(long l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = surfacearea_cube;\n\n    assert(candidate(5L) == 150L);\n    assert(candidate(3L) == 54L);\n    assert(candidate(10L) == 600L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\n*/\nfloat positive_count(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = positive_count;\n\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.54);\n    assert(candidate([2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.69);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == 0.56);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the largest negative number from the given list.\n\t\n*/\nlong largest_neg(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = largest_neg;\n\n    assert(candidate([1L, 2L, 3L, -4L, -6L]) == -6L);\n    assert(candidate([1L, 2L, 3L, -8L, -9L]) == -9L);\n    assert(candidate([1L, 2L, 3L, 4L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to trim each list by k in the given lists.\n\t\n*/\nlong[][] trim_tuple(long[][] test_list, long K) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = trim_tuple;\n\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 2L) == [[2L], [9L], [2L], [2L]]);\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 1L) == [[3L, 2L, 1L], [4L, 9L, 2L], [1L, 2L, 3L], [8L, 2L, 1L]]);\n    assert(candidate([[7L, 8L, 4L, 9L], [11L, 8L, 12L, 4L], [4L, 1L, 7L, 8L], [3L, 6L, 9L, 7L]], 1L) == [[8L, 4L], [8L, 12L], [1L, 7L], [6L, 9L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\n*/\nlong[][] index_multiplication(long[][] test_tup1, long[][] test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = index_multiplication;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 21L], [12L, 45L], [2L, 9L], [7L, 30L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[14L, 32L], [20L, 60L], [6L, 20L], [16L, 44L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[24L, 45L], [30L, 77L], [12L, 33L], [27L, 60L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find cubes of individual elements in a list.\n\t\n*/\nlong[] cube_nums(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cube_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 8L, 27L, 64L, 125L, 216L, 343L, 512L, 729L, 1000L]);\n    assert(candidate([10L, 20L, 30L]) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L]) == [1728L, 3375L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of perrin numbers.\n\t\n*/\nlong cal_sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cal_sum;\n\n    assert(candidate(9L) == 49L);\n    assert(candidate(10L) == 66L);\n    assert(candidate(11L) == 88L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\n*/\nstring[] extract_string(string[] str, long l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = extract_string;\n\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8L) == [\"practice\", \"solution\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6L) == [\"Python\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9L) == [\"exercises\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all whitespaces from the given string.\n\t\n*/\nstring remove_whitespaces(string text1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_whitespaces;\n\n    assert(candidate(\" Google    Flutter \") == \"GoogleFlutter\");\n    assert(candidate(\" Google    Dart \") == \"GoogleDart\");\n    assert(candidate(\" iOS    Swift \") == \"iOSSwift\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\n*/\nlong loss_amount(long actual_cost, long sale_amount) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = loss_amount;\n\n    assert(candidate(1500L, 1200L) == 0L);\n    assert(candidate(100L, 200L) == 100L);\n    assert(candidate(2000L, 5000L) == 3000L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of even factors of a number.\n\t\n*/\nlong sumofFactors(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sumofFactors;\n\n    assert(candidate(18L) == 26L);\n    assert(candidate(30L) == 48L);\n    assert(candidate(6L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a word containing 'z'.\n\t\n*/\nbool text_match_wordz(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_wordz;\n\n    assert(candidate(\"pythonz.\") == true);\n    assert(candidate(\"xyz.\") == true);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\n*/\nbool check_monthnumb_number(long monthnum2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_monthnumb_number;\n\n    assert(candidate(5L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(6L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse each string in a given list of string values.\n\t\n*/\nstring[] reverse_string_list(string[] stringlist) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = reverse_string_list;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n    assert(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n    assert(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the area of a rectangle.\n\t\n*/\nlong rectangle_area(long l, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rectangle_area;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(10L, 5L) == 50L);\n    assert(candidate(4L, 2L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove uppercase substrings from a given string.\n\t\n*/\nstring remove_uppercase(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_uppercase;\n\n    assert(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\");\n    assert(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\");\n    assert(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to get the first element of each sublist.\n\t\n*/\nlong[] Extract(long[][] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Extract;\n\n    assert(candidate([[1L, 2L], [3L, 4L, 5L], [6L, 7L, 8L, 9L]]) == [1L, 3L, 6L]);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L]]) == [1L, 4L]);\n    assert(candidate([[9L, 8L, 1L], [1L, 2L]]) == [9L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the upper case characters in a given string.\n\t\n*/\nlong upper_ctr(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = upper_ctr;\n\n    assert(candidate(\"PYthon\") == 1L);\n    assert(candidate(\"BigData\") == 1L);\n    assert(candidate(\"program\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product subarray of the given array.\n\t\n*/\nlong max_subarray_product(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_subarray_product;\n\n    assert(candidate([1L, -2L, -3L, 0L, 7L, -8L, -2L]) == 112L);\n    assert(candidate([6L, -3L, -10L, 0L, 2L]) == 180L);\n    assert(candidate([-2L, -40L, 0L, -2L, -3L]) == 80L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if all values are same in a dictionary.\n\t\n*/\nbool check_value(Nullable!(long[string]) dict, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_value;\n\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 10L) == false);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 12L) == true);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 5L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\n*/\nlong max_product(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_product;\n\n    assert(candidate([3L, 100L, 4L, 5L, 150L, 6L]) == 3000L);\n    assert(candidate([4L, 42L, 55L, 68L, 80L]) == 50265600L);\n    assert(candidate([10L, 22L, 9L, 33L, 21L, 50L, 41L, 60L]) == 2460L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\n*/\nTuple!(long, long, long, long) add_pairwise(Tuple!(long, long, long, long, long) test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add_pairwise;\n\n    assert(candidate(tuple(1L, 5L, 7L, 8L, 10L)) == tuple(6L, 12L, 15L, 18L));\n    assert(candidate(tuple(2L, 6L, 8L, 9L, 11L)) == tuple(8L, 14L, 17L, 20L));\n    assert(candidate(tuple(3L, 7L, 9L, 10L, 12L)) == tuple(10L, 16L, 19L, 22L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\n*/\nlong find_remainder(long[] arr, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_remainder;\n\n    assert(candidate([100L, 10L, 5L, 25L, 35L, 14L], 11L) == 9L);\n    assert(candidate([1L, 1L, 1L], 1L) == 0L);\n    assert(candidate([1L, 2L, 1L], 2L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\n*/\nbool check_Consecutive(long[] l) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_Consecutive;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 2L, 3L, 5L, 6L]) == false);\n    assert(candidate([1L, 2L, 1L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace characters in a string.\n\t\n*/\nstring replace_char(string str1, string ch, string newch) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = replace_char;\n\n    assert(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\");\n    assert(candidate(\"character\", \"c\", \"a\") == \"aharaater\");\n    assert(candidate(\"python\", \"l\", \"a\") == \"python\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a dictionary by value.\n\t\n*/\nTuple!(string, long)[] sort_counter(Nullable!(long[string]) dict1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_counter;\n\n    assert(candidate([\"Math\": 81L, \"Physics\": 83L, \"Chemistry\": 87L].nullable) == [tuple(\"Chemistry\", 87L), tuple(\"Physics\", 83L), tuple(\"Math\", 81L)]);\n    assert(candidate([\"Math\": 400L, \"Physics\": 300L, \"Chemistry\": 250L].nullable) == [tuple(\"Math\", 400L), tuple(\"Physics\", 300L), tuple(\"Chemistry\", 250L)]);\n    assert(candidate([\"Math\": 900L, \"Physics\": 1000L, \"Chemistry\": 1250L].nullable) == [tuple(\"Chemistry\", 1250L), tuple(\"Physics\", 1000L), tuple(\"Math\", 900L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\n*/\nlong big_sum(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = big_sum;\n\n    assert(candidate([1L, 2L, 3L]) == 4L);\n    assert(candidate([-1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([2L, 3L, 6L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to convert the given string to lower case.\n\t\n*/\nstring is_lower(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_lower;\n\n    assert(candidate(\"InValid\") == \"invalid\");\n    assert(candidate(\"TruE\") == \"true\");\n    assert(candidate(\"SenTenCE\") == \"sentence\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove lowercase substrings from a given string.\n\t\n*/\nstring remove_lowercase(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_lowercase;\n\n    assert(candidate(\"PYTHon\") == \"PYTH\");\n    assert(candidate(\"FInD\") == \"FID\");\n    assert(candidate(\"STRinG\") == \"STRG\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the first digit of a given number.\n\t\n*/\nlong first_Digit(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = first_Digit;\n\n    assert(candidate(123L) == 1L);\n    assert(candidate(456L) == 4L);\n    assert(candidate(12L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\n*/\nlong[] heap_queue_largest(long[] nums, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = heap_queue_largest;\n\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 3L) == [85L, 75L, 65L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 2L) == [85L, 75L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 5L) == [85L, 75L, 65L, 58L, 35L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\n*/\nlong[] Split(long[] list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == [1L, 3L, 5L]);\n    assert(candidate([10L, 11L, 12L, 13L]) == [11L, 13L]);\n    assert(candidate([7L, 8L, 9L, 1L]) == [7L, 9L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\n*/\nlong difference(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = difference;\n\n    assert(candidate(3L) == 30L);\n    assert(candidate(5L) == 210L);\n    assert(candidate(2L) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\n*/\nlong find_Odd_Pair(long[] A, long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Odd_Pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L], 5L) == 6L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L], 7L) == 12L);\n    assert(candidate([1L, 2L, 3L], 3L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to toggle the case of all characters in a string.\n\t\n*/\nstring toggle_string(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = toggle_string;\n\n    assert(candidate(\"Python\") == \"pYTHON\");\n    assert(candidate(\"Pangram\") == \"pANGRAM\");\n    assert(candidate(\"LIttLE\") == \"liTTle\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\n*/\nlong digit_distance_nums(long n1, long n2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = digit_distance_nums;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(23L, 56L) == 6L);\n    assert(candidate(123L, 256L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\n*/\nlong max_sub_array_sum(long[] a, long size) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum;\n\n    assert(candidate([-2L, -3L, 4L, -1L, -2L, 1L, 5L, -3L], 8L) == 7L);\n    assert(candidate([-3L, -4L, 5L, -2L, -3L, 2L, 6L, -4L], 8L) == 8L);\n    assert(candidate([-4L, -5L, 6L, -3L, -4L, 3L, 7L, -5L], 8L) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\n*/\nlong[] union_elements(long[] test_tup1, long[] test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = union_elements;\n\n    assert(candidate([3L, 4L, 5L, 6L], [5L, 7L, 4L, 10L]) == [3L, 4L, 5L, 6L, 7L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], [3L, 4L, 5L, 6L]) == [1L, 2L, 3L, 4L, 5L, 6L]);\n    assert(candidate([11L, 12L, 13L, 14L], [13L, 15L, 16L, 17L]) == [11L, 12L, 13L, 14L, 15L, 16L, 17L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the length of the longest sublists.\n\t\n*/\nlong Find_Max_Length(long[][] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Find_Max_Length;\n\n    assert(candidate([[1L], [1L, 4L], [5L, 6L, 7L, 8L]]) == 4L);\n    assert(candidate([[0L, 1L], [2L, 2L], [3L, 2L, 1L]]) == 3L);\n    assert(candidate([[7L], [22L, 23L], [13L, 14L, 15L], [10L, 20L, 30L, 40L, 50L]]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract values between quotation marks from a string.\n\t\n*/\nstring[] extract_values(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = extract_values;\n\n    assert(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"]);\n    assert(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"]);\n    assert(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\n*/\nlong count_Pairs(long[] arr, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_Pairs;\n\n    assert(candidate([1L, 2L, 1L], 3L) == 2L);\n    assert(candidate([1L, 1L, 1L, 1L], 4L) == 0L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 5L) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to split a string into characters.\n\t\n*/\nstring[] split(string word) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = split;\n\n    assert(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n    assert(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"]);\n    assert(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\n*/\nlong sum_digits(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_digits;\n\n    assert(candidate(345L) == 12L);\n    assert(candidate(12L) == 3L);\n    assert(candidate(97L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a specified list is sorted or not.\n\t\n*/\nbool issort_list(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = issort_list;\n\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 16L, 17L]) == true);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 20L, 17L]) == false);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 15L, 14L, 20L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create a list of N empty dictionaries.\n\t\n*/\nNone[] empty_list(long length) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = empty_list;\n\n    assert(candidate(5L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(6L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(7L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\n*/\nstring[][] sort_sublists(string[][] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\n*/\nbool checks(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = checks;\n\n    assert(candidate(70L) == false);\n    assert(candidate(23L) == false);\n    assert(candidate(73L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\n*/\nlong[] two_unique_nums(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = two_unique_nums;\n\n    assert(candidate([1L, 2L, 3L, 2L, 3L, 4L, 5L]) == [1L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 5L]) == [1L, 3L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\n*/\nlong unique_product(long[] list_data) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = unique_product;\n\n    assert(candidate([10L, 20L, 30L, 40L, 20L, 50L, 60L, 40L]) == 720000000L);\n    assert(candidate([1L, 2L, 3L, 1L]) == 6L);\n    assert(candidate([7L, 8L, 9L, 0L, 1L, 1L]) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cylinder.\n\t\n*/\nfloat surfacearea_cylinder(long r, long h) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = surfacearea_cylinder;\n\n    assert(candidate(10L, 5L) == 942.45);\n    assert(candidate(4L, 5L) == 226.18800000000002);\n    assert(candidate(4L, 10L) == 351.848);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\n*/\nbool is_Sub_Array(long[] A, long[] B) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_Sub_Array;\n\n    assert(candidate([1L, 4L, 3L, 5L], [1L, 2L]) == false);\n    assert(candidate([1L, 2L, 1L], [1L, 2L, 1L]) == true);\n    assert(candidate([1L, 0L, 2L, 2L], [2L, 2L, 0L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\n*/\nlong last_Digit_Factorial(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = last_Digit_Factorial;\n\n    assert(candidate(4L) == 4L);\n    assert(candidate(21L) == 0L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\n*/\nlong[] interleave_lists(long[] list1, long[] list2, long[] list3) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = interleave_lists;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L], [10L, 20L, 30L, 40L, 50L, 60L, 70L], [100L, 200L, 300L, 400L, 500L, 600L, 700L]) == [1L, 10L, 100L, 2L, 20L, 200L, 3L, 30L, 300L, 4L, 40L, 400L, 5L, 50L, 500L, 6L, 60L, 600L, 7L, 70L, 700L]);\n    assert(candidate([10L, 20L], [15L, 2L], [5L, 10L]) == [10L, 15L, 5L, 20L, 2L, 10L]);\n    assert(candidate([11L, 44L], [10L, 15L], [20L, 5L]) == [11L, 10L, 20L, 44L, 15L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) find_dissimilar(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_dissimilar;\n\n    assert(candidate(tuple(3L, 4L, 5L, 6L), tuple(5L, 7L, 4L, 10L)) == tuple(3L, 6L, 7L, 10L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(7L, 2L, 3L, 9L)) == tuple(1L, 4L, 7L, 9L));\n    assert(candidate(tuple(21L, 11L, 25L, 26L), tuple(26L, 34L, 21L, 36L)) == tuple(34L, 36L, 11L, 25L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\n*/\nlong find_Max_Num(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Max_Num;\n\n    assert(candidate([1L, 2L, 3L]) == 321L);\n    assert(candidate([4L, 5L, 6L, 1L]) == 6541L);\n    assert(candidate([1L, 2L, 3L, 9L]) == 9321L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\n*/\nlong surface_Area(long b, long s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = surface_Area;\n\n    assert(candidate(3L, 4L) == 33L);\n    assert(candidate(4L, 5L) == 56L);\n    assert(candidate(1L, 2L) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which returns nth catalan number.\n\t\n*/\nlong catalan_number(long num) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = catalan_number;\n\n    assert(candidate(10L) == 16796L);\n    assert(candidate(9L) == 4862L);\n    assert(candidate(7L) == 429L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\n*/\nstring find_adverbs(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_adverbs;\n\n    assert(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\");\n    assert(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\");\n    assert(candidate(\"Complete the task quickly\") == \"18-25: quickly\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\n*/\nNone[] expensive_items(None[] items, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = expensive_items;\n\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable], 2L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-1\", \"price\": 101.1].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable, [\"name\": \"Item-4\", \"price\": 22.75].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\n*/\nlong[] split_Arr(long[] l, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = split_Arr;\n\n    assert(candidate([12L, 10L, 5L, 6L, 52L, 36L], 2L) == [5L, 6L, 52L, 36L, 12L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], 1L) == [2L, 3L, 4L, 1L]);\n    assert(candidate([0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L], 3L) == [3L, 4L, 5L, 6L, 7L, 0L, 1L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\n*/\nlong big_diff(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = big_diff;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([4L, 5L, 12L]) == 8L);\n    assert(candidate([9L, 2L, 3L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find perfect squares between two given numbers.\n\t\n*/\nlong[] perfect_squares(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = perfect_squares;\n\n    assert(candidate(1L, 30L) == [1L, 4L, 9L, 16L, 25L]);\n    assert(candidate(50L, 100L) == [64L, 81L, 100L]);\n    assert(candidate(100L, 200L) == [100L, 121L, 144L, 169L, 196L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\n*/\nbool opposite_Signs(long x, long y) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = opposite_Signs;\n\n    assert(candidate(1L, -2L) == true);\n    assert(candidate(3L, 2L) == false);\n    assert(candidate(-10L, -10L) == false);\n    assert(candidate(-2L, 2L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to interchange the first and last elements in a list.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([12L, 35L, 9L, 56L, 24L]) == [24L, 35L, 9L, 56L, 12L]);\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\n*/\nlong sum_Of_product(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_Of_product;\n\n    assert(candidate(3L) == 15L);\n    assert(candidate(4L) == 56L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove leading zeroes from an ip address.\n\t\n*/\nstring removezero_ip(string ip) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = removezero_ip;\n\n    assert(candidate(\"216.08.094.196\") == \"216.8.94.196\");\n    assert(candidate(\"12.01.024\") == \"12.1.24\");\n    assert(candidate(\"216.08.094.0196\") == \"216.8.94.196\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\n*/\nlong diff_even_odd(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = diff_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 1L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\n*/\nlong find_kth(long[] arr1, long[] arr2, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_kth;\n\n    assert(candidate([2L, 3L, 6L, 7L, 9L], [1L, 4L, 8L, 10L], 5L) == 6L);\n    assert(candidate([100L, 112L, 256L, 349L, 770L], [72L, 86L, 113L, 119L, 265L, 445L, 892L], 7L) == 256L);\n    assert(candidate([3L, 4L, 7L, 8L, 10L], [2L, 5L, 9L, 11L], 6L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is armstrong or not.\n\t\n*/\nbool armstrong_number(long number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = armstrong_number;\n\n    assert(candidate(153L) == true);\n    assert(candidate(259L) == false);\n    assert(candidate(4458L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find sum and average of first n natural numbers.\n\t\n*/\nTuple!(long, float) sum_average(long number) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_average;\n\n    assert(candidate(10L) == tuple(55L, 5.5));\n    assert(candidate(15L) == tuple(120L, 8.0));\n    assert(candidate(20L) == tuple(210L, 10.5));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth octagonal number.\n\t\n*/\nlong is_octagonal(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_octagonal;\n\n    assert(candidate(5L) == 65L);\n    assert(candidate(10L) == 280L);\n    assert(candidate(15L) == 645L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given number is even or not.\n\t\n*/\nbool is_Even(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_Even;\n\n    assert(candidate(1L) == false);\n    assert(candidate(2L) == true);\n    assert(candidate(3L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the first repeated character in a given string.\n\t\n*/\nNullable!(string) first_repeated_char(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = first_repeated_char;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"123123\");\n        assert(!result.isNull && result.get == \"1\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\n*/\nlong[] get_ludic(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_ludic;\n\n    assert(candidate(10L) == [1L, 2L, 3L, 5L, 7L]);\n    assert(candidate(25L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L]);\n    assert(candidate(45L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L, 29L, 37L, 41L, 43L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\n*/\nstring reverse_words(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = reverse_words;\n\n    assert(candidate(\"python program\") == \"program python\");\n    assert(candidate(\"java language\") == \"language java\");\n    assert(candidate(\"indian man\") == \"man indian\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given integer is a prime number.\n\t\n*/\nbool prime_num(long num) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = prime_num;\n\n    assert(candidate(13L) == true);\n    assert(candidate(7L) == true);\n    assert(candidate(-1010L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert degrees to radians.\n\t\n*/\nfloat radian_degree(long degree) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = radian_degree;\n\n    assert(candidate(90L) == 1.5707963267948966);\n    assert(candidate(60L) == 1.0471975511965976);\n    assert(candidate(120L) == 2.0943951023931953);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\n*/\nTuple!(string, long, long) find_literals(string text, string pattern) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_literals;\n\n    assert(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == tuple(\"fox\", 16L, 19L));\n    assert(candidate(\"Its been a very crazy procedure right\", \"crazy\") == tuple(\"crazy\", 16L, 21L));\n    assert(candidate(\"Hardest choices required strongest will\", \"will\") == tuple(\"will\", 35L, 39L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find nth bell number.\n\t\n*/\nlong bell_Number(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = bell_Number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 15L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\n*/\nlong[] remove_kth_element(long[] list1, long L) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_kth_element;\n\n    assert(candidate([1L, 1L, 2L, 3L, 4L, 4L, 5L, 1L], 3L) == [1L, 1L, 3L, 4L, 4L, 5L, 1L]);\n    assert(candidate([0L, 0L, 1L, 2L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L], 4L) == [0L, 0L, 1L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L]);\n    assert(candidate([10L, 10L, 15L, 19L, 18L, 18L, 17L, 26L, 26L, 17L, 18L, 10L], 5L) == [10L, 10L, 15L, 19L, 18L, 17L, 26L, 26L, 17L, 18L, 10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\n*/\nlong max_of_nth(long[][] test_list, long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_of_nth;\n\n    assert(candidate([[5L, 6L, 7L], [1L, 3L, 5L], [8L, 9L, 19L]], 2L) == 19L);\n    assert(candidate([[6L, 7L, 8L], [2L, 4L, 6L], [9L, 10L, 20L]], 1L) == 10L);\n    assert(candidate([[7L, 8L, 9L], [3L, 5L, 7L], [10L, 11L, 21L]], 1L) == 11L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\n*/\nlong cummulative_sum(long[][] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = cummulative_sum;\n\n    assert(candidate([[1L, 3L], [5L, 6L, 7L], [2L, 6L]]) == 30L);\n    assert(candidate([[2L, 4L], [6L, 7L, 8L], [3L, 7L]]) == 37L);\n    assert(candidate([[3L, 5L], [7L, 8L, 9L], [4L, 8L]]) == 44L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\n*/\nfloat[] average_tuple(long[][] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = average_tuple;\n\n    assert(candidate([[10L, 10L, 10L, 12L], [30L, 45L, 56L, 45L], [81L, 80L, 39L, 32L], [1L, 2L, 3L, 4L]]) == [30.5, 34.25, 27.0, 23.25]);\n    assert(candidate([[1L, 1L, -5L], [30L, -15L, 56L], [81L, -60L, -39L], [-10L, 2L, 3L]]) == [25.5, -18.0, 3.75]);\n    assert(candidate([[100L, 100L, 100L, 120L], [300L, 450L, 560L, 450L], [810L, 800L, 390L, 320L], [10L, 20L, 30L, 40L]]) == [305.0, 342.5, 270.0, 232.5]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\n*/\nTuple!(long, long, long, long) tuple_modulo(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tuple_modulo;\n\n    assert(candidate(tuple(10L, 4L, 5L, 6L), tuple(5L, 6L, 7L, 5L)) == tuple(0L, 4L, 5L, 1L));\n    assert(candidate(tuple(11L, 5L, 6L, 7L), tuple(6L, 7L, 8L, 6L)) == tuple(5L, 5L, 6L, 1L));\n    assert(candidate(tuple(12L, 6L, 7L, 8L), tuple(7L, 8L, 9L, 7L)) == tuple(5L, 6L, 7L, 1L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\n*/\nfloat min_Jumps(Tuple!(long, long) steps, long d) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = min_Jumps;\n\n    assert(candidate(tuple(3L, 4L), 11L) == 3.5);\n    assert(candidate(tuple(3L, 4L), 0L) == 0L);\n    assert(candidate(tuple(11L, 14L), 11L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to divide two lists element wise.\n\t\n*/\nfloat[] div_list(long[] nums1, long[] nums2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = div_list;\n\n    assert(candidate([4L, 5L, 6L], [1L, 2L, 3L]) == [4.0, 2.5, 2.0]);\n    assert(candidate([3L, 2L], [1L, 4L]) == [3.0, 0.5]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [1.8, 1.7142857142857142]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to move all the numbers to the end of the given string.\n\t\n*/\nstring move_num(string test_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = move_num;\n\n    assert(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\");\n    assert(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\");\n    assert(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\n*/\nlong count_Substrings(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_Substrings;\n\n    assert(candidate(\"112112\") == 6L);\n    assert(candidate(\"111\") == 6L);\n    assert(candidate(\"1101112\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of two sorted lists of same size.\n\t\n*/\nfloat get_median(long[] arr1, long[] arr2, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_median;\n\n    assert(candidate([1L, 12L, 15L, 26L, 38L], [2L, 13L, 17L, 30L, 45L], 5L) == 16.0);\n    assert(candidate([2L, 4L, 8L, 9L], [7L, 13L, 19L, 28L], 4L) == 8.5);\n    assert(candidate([3L, 6L, 14L, 23L, 36L, 42L], [2L, 18L, 27L, 39L, 49L, 55L], 6L) == 25.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to compute the n-th power of each number in a list.\n\t\n*/\nlong[] nth_nums(long[] nums, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = nth_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L], 3L) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L], 5L) == [248832L, 759375L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to convert a given string to uppercase.\n\t\n*/\nstring is_upper(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_upper;\n\n    assert(candidate(\"person\") == \"PERSON\");\n    assert(candidate(\"final\") == \"FINAL\");\n    assert(candidate(\"Valid\") == \"VALID\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to interchange the first and last element in a given list.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == [4L, 2L, 3L, 4L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\n*/\nNullable!(long) triangle_area(long r) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n{\n        auto result = candidate(-1L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(0L);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate(2L);\n        assert(!result.isNull && result.get == 4L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\n*/\nlong find_First_Missing(long[] array) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_First_Missing;\n\n    assert(candidate([0L, 1L, 2L, 3L]) == 4L);\n    assert(candidate([0L, 1L, 2L, 6L, 9L]) == 3L);\n    assert(candidate([2L, 3L, 5L, 8L, 9L]) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\n*/\nstring replace_spaces(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\");\n    assert(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\");\n    assert(candidate(\"I love Coding\") == \"I%20love%20Coding\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find even numbers from a list of numbers.\n\t\n*/\nlong[] Split(long[] list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [2L, 4L]);\n    assert(candidate([4L, 5L, 6L, 7L, 8L, 0L, 1L]) == [4L, 6L, 8L, 0L]);\n    assert(candidate([8L, 12L, 15L, 19L]) == [8L, 12L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find smallest number in a list.\n\t\n*/\nlong smallest_num(long[] xs) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = smallest_num;\n\n    assert(candidate([10L, 20L, 1L, 45L, 99L]) == 1L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n    assert(candidate([45L, 46L, 50L, 60L]) == 45L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\n*/\nlong[][] get_coordinates(Tuple!(long, long) test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_coordinates;\n\n    assert(candidate(tuple(3L, 4L)) == [[2L, 3L], [2L, 4L], [2L, 5L], [3L, 3L], [3L, 4L], [3L, 5L], [4L, 3L], [4L, 4L], [4L, 5L]]);\n    assert(candidate(tuple(4L, 5L)) == [[3L, 4L], [3L, 5L], [3L, 6L], [4L, 4L], [4L, 5L], [4L, 6L], [5L, 4L], [5L, 5L], [5L, 6L]]);\n    assert(candidate(tuple(5L, 6L)) == [[4L, 5L], [4L, 6L], [4L, 7L], [5L, 5L], [5L, 6L], [5L, 7L], [6L, 5L], [6L, 6L], [6L, 7L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\n*/\nstring replace_spaces(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\");\n    assert(candidate(\"The_Avengers\") == \"The Avengers\");\n    assert(candidate(\"Fast and Furious\") == \"Fast_and_Furious\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\n*/\nlong[] move_zero(long[] num_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = move_zero;\n\n    assert(candidate([1L, 0L, 2L, 0L, 3L, 4L]) == [1L, 2L, 3L, 4L, 0L, 0L]);\n    assert(candidate([2L, 3L, 2L, 0L, 0L, 4L, 0L, 5L, 0L]) == [2L, 3L, 2L, 4L, 5L, 0L, 0L, 0L, 0L]);\n    assert(candidate([0L, 1L, 0L, 1L, 1L]) == [1L, 1L, 1L, 0L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\n*/\nlong pair_xor_Sum(long[] arr, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pair_xor_Sum;\n\n    assert(candidate([5L, 9L, 7L, 6L], 4L) == 47L);\n    assert(candidate([7L, 3L, 5L], 3L) == 12L);\n    assert(candidate([7L, 3L], 2L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given list.\n\t\n*/\nlong[] heap_sort(long[] iterable) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = heap_sort;\n\n    assert(candidate([1L, 3L, 5L, 7L, 9L, 2L, 4L, 6L, 8L, 0L]) == [0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L]) == [14L, 22L, 25L, 25L, 35L, 58L, 65L, 75L, 85L]);\n    assert(candidate([7L, 1L, 9L, 5L]) == [1L, 5L, 7L, 9L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\n*/\nbool noprofit_noloss(long actual_cost, long sale_amount) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = noprofit_noloss;\n\n    assert(candidate(1500L, 1200L) == false);\n    assert(candidate(100L, 100L) == true);\n    assert(candidate(2000L, 5000L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\n*/\nlong wind_chill(long v, long t) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = wind_chill;\n\n    assert(candidate(120L, 35L) == 40L);\n    assert(candidate(40L, 20L) == 19L);\n    assert(candidate(10L, 8L) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\n*/\nlong sample_nam(string[] sample_names) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sample_nam;\n\n    assert(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16L);\n    assert(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10L);\n    assert(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\n*/\nlong max_difference(Tuple!(long, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_difference;\n\n    assert(candidate([tuple(3L, 5L), tuple(1L, 7L), tuple(10L, 3L), tuple(1L, 2L)]) == 7L);\n    assert(candidate([tuple(4L, 6L), tuple(2L, 17L), tuple(9L, 13L), tuple(11L, 12L)]) == 15L);\n    assert(candidate([tuple(12L, 35L), tuple(21L, 27L), tuple(13L, 23L), tuple(41L, 22L)]) == 23L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\n*/\nstring remove_parenthesis(string[] items) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_parenthesis;\n\n    assert(candidate([\"python (chrome)\"]) == \"python\");\n    assert(candidate([\"string(.abc)\"]) == \"string\");\n    assert(candidate([\"alpha(num)\"]) == \"alpha\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth nonagonal number.\n\t\n*/\nlong is_nonagonal(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_nonagonal;\n\n    assert(candidate(10L) == 325L);\n    assert(candidate(15L) == 750L);\n    assert(candidate(18L) == 1089L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\n*/\nbool text_match_wordz_middle(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_wordz_middle;\n\n    assert(candidate(\"pythonzabc.\") == true);\n    assert(candidate(\"zxyabc.\") == false);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to reverse an array upto a given position.\n\t\n*/\nlong[] reverse_Array_Upto_K(long[] input, long k) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = reverse_Array_Upto_K;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 4L) == [4L, 3L, 2L, 1L, 5L, 6L]);\n    assert(candidate([4L, 5L, 6L, 7L], 2L) == [5L, 4L, 6L, 7L]);\n    assert(candidate([9L, 8L, 7L, 6L, 5L], 3L) == [7L, 8L, 9L, 6L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\n*/\nTuple!(string, long)[] subject_marks(Tuple!(string, long)[] subjectmarks) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = subject_marks;\n\n    assert(candidate([tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L), tuple(\"Social sciences\", 82L)]) == [tuple(\"Social sciences\", 82L), tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L)]);\n    assert(candidate([tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L), tuple(\"Social\", 33L)]) == [tuple(\"Social\", 33L), tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L)]);\n    assert(candidate([tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L), tuple(\"Biology\", 45L)]) == [tuple(\"Biology\", 45L), tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of positive numbers in a list.\n\t\n*/\nlong pos_count(long[] list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pos_count;\n\n    assert(candidate([1L, -2L, 3L, -4L]) == 2L);\n    assert(candidate([3L, 4L, 5L, -1L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\n*/\nlong bell_number(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = bell_number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(10L) == 115975L);\n    assert(candidate(56L) == 6775685320645824322581483068371419745979053216268760300L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\n*/\nbool is_Monotonic(long[] A) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_Monotonic;\n\n    assert(candidate([6L, 5L, 4L, 4L]) == true);\n    assert(candidate([1L, 2L, 2L, 3L]) == true);\n    assert(candidate([1L, 3L, 2L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\n*/\nbool is_sublist(long[] l, long[] s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_sublist;\n\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [3L, 7L]) == false);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [4L, 3L]) == true);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [1L, 6L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\n*/\nbool differ_At_One_Bit_Pos(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = differ_At_One_Bit_Pos;\n\n    assert(candidate(13L, 9L) == true);\n    assert(candidate(15L, 8L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(2L, 3L) == true);\n    assert(candidate(5L, 1L) == true);\n    assert(candidate(1L, 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\n*/\nbool get_equal(long[][] Input) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_equal;\n\n    assert(candidate([[11L, 22L, 33L], [44L, 55L, 66L]]) == true);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L, 7L]]) == false);\n    assert(candidate([[1L, 2L], [3L, 4L]]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a list of elements.\n\t\n*/\nlong[] comb_sort(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = comb_sort;\n\n    assert(candidate([5L, 15L, 37L, 25L, 79L]) == [5L, 15L, 25L, 37L, 79L]);\n    assert(candidate([41L, 32L, 15L, 19L, 22L]) == [15L, 19L, 22L, 32L, 41L]);\n    assert(candidate([99L, 15L, 13L, 47L]) == [13L, 15L, 47L, 99L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\n*/\nTuple!(long, long, long, Nullable!(long[string])) add_dict_to_tuple(Tuple!(long, long, long) test_tup, Nullable!(long[string]) test_dict) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add_dict_to_tuple;\n\n    assert(candidate(tuple(4L, 5L, 6L), [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable) == tuple(4L, 5L, 6L, [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable));\n    assert(candidate(tuple(1L, 2L, 3L), [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable) == tuple(1L, 2L, 3L, [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable));\n    assert(candidate(tuple(8L, 9L, 10L), [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable) == tuple(8L, 9L, 10L, [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\n*/\nfloat maxAverageOfPath(long[][] cost) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = maxAverageOfPath;\n\n    assert(candidate([[1L, 2L, 3L], [6L, 5L, 4L], [7L, 3L, 9L]]) == 5.2);\n    assert(candidate([[2L, 3L, 4L], [7L, 6L, 5L], [8L, 4L, 10L]]) == 6.2);\n    assert(candidate([[3L, 4L, 5L], [8L, 7L, 6L], [9L, 5L, 11L]]) == 7.2);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]]) == 5.8);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\n*/\nlong count_same_pair(long[] nums1, long[] nums2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_same_pair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L]) == 4L);\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 11L);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 1L);\n    assert(candidate([0L, 1L, 1L, 2L], [0L, 1L, 2L, 2L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\n*/\nlong power_base_sum(long base, long power) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = power_base_sum;\n\n    assert(candidate(2L, 100L) == 115L);\n    assert(candidate(8L, 10L) == 37L);\n    assert(candidate(8L, 15L) == 62L);\n    assert(candidate(3L, 3L) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\n*/\nlong[] sum_list(long[] lst1, long[] lst2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_list;\n\n    assert(candidate([10L, 20L, 30L], [15L, 25L, 35L]) == [25L, 45L, 65L]);\n    assert(candidate([1L, 2L, 3L], [5L, 6L, 7L]) == [6L, 8L, 10L]);\n    assert(candidate([15L, 20L, 30L], [15L, 45L, 75L]) == [30L, 65L, 105L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\n*/\nbool dif_Square(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = dif_Square;\n\n    assert(candidate(5L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(15L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\n*/\nfloat lateralsurface_cone(long r, long h) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = lateralsurface_cone;\n\n    assert(candidate(5L, 12L) == 204.20352248333654);\n    assert(candidate(10L, 15L) == 566.3586699569488);\n    assert(candidate(19L, 17L) == 1521.8090132193388);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\n*/\nstring replace_specialchar(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = replace_specialchar;\n\n    assert(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\");\n    assert(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\");\n    assert(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\n*/\nlong find_first_occurrence(long[] A, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_first_occurrence;\n\n    assert(candidate([2L, 5L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 1L);\n    assert(candidate([2L, 3L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 2L);\n    assert(candidate([2L, 4L, 1L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 6L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\n*/\nlong sum_Of_Subarray_Prod(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_Of_Subarray_Prod;\n\n    assert(candidate([1L, 2L, 3L]) == 20L);\n    assert(candidate([1L, 2L]) == 5L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\n*/\nlong toggle_middle_bits(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = toggle_middle_bits;\n\n    assert(candidate(9L) == 15L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(11L) == 13L);\n    assert(candidate(65L) == 127L);\n    assert(candidate(77L) == 115L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\n*/\nlong left_insertion(long[] a, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = left_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\n*/\nbool check_str(string string) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_str;\n\n    assert(candidate(\"annie\") == true);\n    assert(candidate(\"dawood\") == false);\n    assert(candidate(\"Else\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\n*/\nfloat geometric_sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = geometric_sum;\n\n    assert(candidate(7L) == 1.9921875);\n    assert(candidate(4L) == 1.9375);\n    assert(candidate(8L) == 1.99609375);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\n*/\nlong find_Index(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Index;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 14L);\n    assert(candidate(4L) == 45L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\n*/\nNullable!(long[long]) tuple_to_dict(Tuple!(long, long, long, long, long, long) test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tuple_to_dict;\n\n{\n        auto result = candidate(tuple(1L, 5L, 7L, 10L, 13L, 5L));\n        assert(!result.isNull && result.get == [1L: 5L, 7L: 10L, 13L: 5L]);\n}\n\n{\n        auto result = candidate(tuple(1L, 2L, 3L, 4L, 5L, 6L));\n        assert(!result.isNull && result.get == [1L: 2L, 3L: 4L, 5L: 6L]);\n}\n\n{\n        auto result = candidate(tuple(7L, 8L, 9L, 10L, 11L, 12L));\n        assert(!result.isNull && result.get == [7L: 8L, 9L: 10L, 11L: 12L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether all the characters are same or not.\n\t\n*/\nbool all_Characters_Same(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = all_Characters_Same;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"aaa\") == true);\n    assert(candidate(\"data\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\n*/\nfloat area_tetrahedron(long side) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = area_tetrahedron;\n\n    assert(candidate(3L) == 15.588457268119894);\n    assert(candidate(20L) == 692.8203230275509);\n    assert(candidate(10L) == 173.20508075688772);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\n*/\nlong[] rotate_right(long[] list, long m) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rotate_right;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 3L) == [8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 5L) == [6L, 7L, 8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\n*/\nlong[] divisible_by_digits(long startnum, long endnum) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = divisible_by_digits;\n\n    assert(candidate(1L, 22L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L, 22L]);\n    assert(candidate(1L, 15L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L]);\n    assert(candidate(20L, 25L) == [22L, 24L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\n*/\nNullable!(float) sector_area(long r, long a) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sector_area;\n\n{\n        auto result = candidate(4L, 45L);\n        assert(!result.isNull && result.get == 6.283185307179586);\n}\n\n{\n        auto result = candidate(9L, 45L);\n        assert(!result.isNull && result.get == 31.808625617596654);\n}\n\n{\n        auto result = candidate(9L, 361L);\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\n*/\nlong lcs_of_three(string X, string Y, string Z) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = lcs_of_three;\n\n    assert(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2L);\n    assert(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5L);\n    assert(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\n*/\nstring capital_words_spaces(string str1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = capital_words_spaces;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\");\n    assert(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\n*/\nlong[] sort_numeric_strings(string[] nums_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sort_numeric_strings;\n\n    assert(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500L, -12L, 0L, 4L, 7L, 12L, 45L, 100L, 200L]);\n    assert(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1L, 1L, 1L, 2L, 2L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 8L, 9L, 9L]);\n    assert(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1L, 1L, 1L, 3L, 3L, 5L, 5L, 7L, 7L, 9L, 11L, 13L, 15L, 17L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\n*/\nbool is_samepatterns(string[] colors, string[] patterns) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_samepatterns;\n\n    assert(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add the given tuple to the given list.\n\t\n*/\nlong[] add_tuple(long[] test_list, Tuple!(long, long) test_tup) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = add_tuple;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == [5L, 6L, 7L, 9L, 10L]);\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == [6L, 7L, 8L, 10L, 11L]);\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == [7L, 8L, 9L, 11L, 12L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\n*/\nbool check_min_heap(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_min_heap;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 10L, 15L]) == true);\n    assert(candidate([2L, 10L, 4L, 5L, 3L, 15L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\n*/\nlong jacobsthal_num(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = jacobsthal_num;\n\n    assert(candidate(5L) == 11L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 5L);\n    assert(candidate(13L) == 2731L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\n*/\nTuple!(string, long)[] min_k(Tuple!(string, long)[] test_list, long K) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = min_k;\n\n    assert(candidate([tuple(\"Manjeet\", 10L), tuple(\"Akshat\", 4L), tuple(\"Akash\", 2L), tuple(\"Nikhil\", 8L)], 2L) == [tuple(\"Akash\", 2L), tuple(\"Akshat\", 4L)]);\n    assert(candidate([tuple(\"Sanjeev\", 11L), tuple(\"Angat\", 5L), tuple(\"Akash\", 3L), tuple(\"Nepin\", 9L)], 3L) == [tuple(\"Akash\", 3L), tuple(\"Angat\", 5L), tuple(\"Nepin\", 9L)]);\n    assert(candidate([tuple(\"tanmay\", 14L), tuple(\"Amer\", 11L), tuple(\"Ayesha\", 9L), tuple(\"SKD\", 16L)], 1L) == [tuple(\"Ayesha\", 9L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\n*/\nbool text_match_zero_one(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_zero_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"dsabbbba\") == true);\n    assert(candidate(\"asbbbba\") == false);\n    assert(candidate(\"abaaa\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\n*/\nlong count_reverse_pairs(string[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_reverse_pairs;\n\n    assert(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2L);\n    assert(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1L);\n    assert(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\n*/\nbool is_decimal(string num) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_decimal;\n\n    assert(candidate(\"123.11\") == true);\n    assert(candidate(\"e666.86\") == false);\n    assert(candidate(\"3.124587\") == false);\n    assert(candidate(\"1.11\") == true);\n    assert(candidate(\"1.1.11\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\n*/\nTuple!(long, long, long)[] find_tuples(Tuple!(long, long, long)[] test_list, long K) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_tuples;\n\n    assert(candidate([tuple(6L, 24L, 12L), tuple(7L, 9L, 6L), tuple(12L, 18L, 21L)], 6L) == [tuple(6L, 24L, 12L)]);\n    assert(candidate([tuple(5L, 25L, 30L), tuple(4L, 2L, 3L), tuple(7L, 8L, 9L)], 5L) == [tuple(5L, 25L, 30L)]);\n    assert(candidate([tuple(7L, 9L, 16L), tuple(8L, 16L, 4L), tuple(19L, 17L, 18L)], 4L) == [tuple(8L, 16L, 4L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\n*/\nbool unique_Element(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = unique_Element;\n\n    assert(candidate([1L, 1L, 1L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\n*/\nbool check_monthnumber_number(long monthnum3) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_monthnumber_number;\n\n    assert(candidate(6L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(12L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\n*/\nlong find_min_diff(long[] arr, long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_min_diff;\n\n    assert(candidate([1L, 5L, 3L, 19L, 18L, 25L], 6L) == 1L);\n    assert(candidate([4L, 3L, 2L, 6L], 4L) == 1L);\n    assert(candidate([30L, 5L, 20L, 9L], 4L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count number of digits in a given string.\n\t\n*/\nlong number_ctr(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = number_ctr;\n\n    assert(candidate(\"program2bedone\") == 1L);\n    assert(candidate(\"3wonders\") == 1L);\n    assert(candidate(\"123\") == 3L);\n    assert(candidate(\"3wond-1ers2\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\n*/\nlong is_polite(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_polite;\n\n    assert(candidate(7L) == 11L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(9L) == 13L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\n*/\nTuple!(long, long)[] pair_wise(long[] l1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = pair_wise;\n\n    assert(candidate([1L, 1L, 2L, 3L, 3L, 4L, 4L, 5L]) == [tuple(1L, 1L), tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 3L), tuple(3L, 4L), tuple(4L, 4L), tuple(4L, 5L)]);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == [tuple(1L, 5L), tuple(5L, 7L), tuple(7L, 9L), tuple(9L, 10L)]);\n    assert(candidate([5L, 1L, 9L, 7L, 10L]) == [tuple(5L, 1L), tuple(1L, 9L), tuple(9L, 7L), tuple(7L, 10L)]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 4L), tuple(4L, 5L), tuple(5L, 6L), tuple(6L, 7L), tuple(7L, 8L), tuple(8L, 9L), tuple(9L, 10L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\n*/\nlong get_pairs_count(long[] arr, long sum) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_pairs_count;\n\n    assert(candidate([1L, 1L, 1L, 1L], 2L) == 6L);\n    assert(candidate([1L, 5L, 7L, -1L, 5L], 6L) == 3L);\n    assert(candidate([1L, -2L, 3L], 1L) == 1L);\n    assert(candidate([-1L, -2L, 3L], -3L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to get the difference between two lists.\n\t\n*/\nlong[] Diff(long[] li1, long[] li2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Diff;\n\n    assert(candidate([10L, 15L, 20L, 25L, 30L, 35L, 40L], [25L, 40L, 35L]) == [10L, 20L, 30L, 15L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 1L]) == [2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L], [6L, 7L, 1L]) == [2L, 3L, 6L, 7L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\n*/\nlong odd_num_sum(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = odd_num_sum;\n\n    assert(candidate(2L) == 82L);\n    assert(candidate(3L) == 707L);\n    assert(candidate(4L) == 3108L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\n*/\nbool check_expression(string exp) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_expression;\n\n    assert(candidate(\"{()}[{}]\") == true);\n    assert(candidate(\"{()}[{]\") == false);\n    assert(candidate(\"{()}[{}][]({})\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all the words with k length in the given string.\n\t\n*/\nstring remove_length(string test_str, long K) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_length;\n\n    assert(candidate(\"The person is most value tet\", 3L) == \"person is most value\");\n    assert(candidate(\"If you told me about this ok\", 4L) == \"If you me about ok\");\n    assert(candidate(\"Forces of darkeness is come into the play\", 4L) == \"Forces of darkeness is the\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\n*/\nNullable!(Tuple!(string, long, long)) occurance_substring(string text, string pattern) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = occurance_substring;\n\n{\n        auto result = candidate(\"python programming, python language\", \"python\");\n        assert(!result.isNull && result.get == tuple(\"python\", 0L, 6L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"programming\");\n        assert(!result.isNull && result.get == tuple(\"programming\", 7L, 18L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"language\");\n        assert(!result.isNull && result.get == tuple(\"language\", 31L, 39L));\n}\n\n{\n        auto result = candidate(\"c++ programming, c++ language\", \"python\");\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\n*/\nbool odd_position(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = odd_position;\n\n    assert(candidate([2L, 1L, 4L, 3L, 6L, 7L, 6L, 3L]) == true);\n    assert(candidate([4L, 1L, 2L]) == true);\n    assert(candidate([1L, 2L, 3L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\n*/\nlong count_vowels(string test_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_vowels;\n\n    assert(candidate(\"bestinstareels\") == 7L);\n    assert(candidate(\"partofthejourneyistheend\") == 12L);\n    assert(candidate(\"amazonprime\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\n*/\nlong find_sum(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_sum;\n\n    assert(candidate([1L, 2L, 3L, 1L, 1L, 4L, 5L, 6L]) == 21L);\n    assert(candidate([1L, 10L, 9L, 4L, 2L, 10L, 10L, 45L, 4L]) == 71L);\n    assert(candidate([12L, 10L, 9L, 45L, 2L, 10L, 10L, 45L, 10L]) == 78L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find whether a number is divisible by 11.\n\t\n*/\nbool is_Diff(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_Diff;\n\n    assert(candidate(12345L) == false);\n    assert(candidate(1212112L) == true);\n    assert(candidate(1212L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\n*/\nTuple!(long, long)[] find_combinations(Tuple!(long, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_combinations;\n\n    assert(candidate([tuple(2L, 4L), tuple(6L, 7L), tuple(5L, 1L), tuple(6L, 10L)]) == [tuple(8L, 11L), tuple(7L, 5L), tuple(8L, 14L), tuple(11L, 8L), tuple(12L, 17L), tuple(11L, 11L)]);\n    assert(candidate([tuple(3L, 5L), tuple(7L, 8L), tuple(6L, 2L), tuple(7L, 11L)]) == [tuple(10L, 13L), tuple(9L, 7L), tuple(10L, 16L), tuple(13L, 10L), tuple(14L, 19L), tuple(13L, 13L)]);\n    assert(candidate([tuple(4L, 6L), tuple(8L, 9L), tuple(7L, 3L), tuple(8L, 12L)]) == [tuple(12L, 15L), tuple(11L, 9L), tuple(12L, 18L), tuple(15L, 12L), tuple(16L, 21L), tuple(15L, 15L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\n*/\nbool count_divisors(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_divisors;\n\n    assert(candidate(10L) == true);\n    assert(candidate(100L) == false);\n    assert(candidate(125L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\n*/\nlong odd_length_sum(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = odd_length_sum;\n\n    assert(candidate([1L, 2L, 4L]) == 14L);\n    assert(candidate([1L, 2L, 1L, 2L]) == 15L);\n    assert(candidate([1L, 7L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\n*/\nfloat[] rgb_to_hsv(long r, long g, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = rgb_to_hsv;\n\n    assert(candidate(255L, 255L, 255L) == [0.0, 0.0, 100.0]);\n    assert(candidate(0L, 215L, 0L) == [120.0, 100.0, 84.31372549019608]);\n    assert(candidate(10L, 215L, 110L) == [149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\n*/\nlong mul_even_odd(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = mul_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert tuple string to integer tuple.\n\t\n*/\nTuple!(long, long, long) tuple_str_int(string test_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tuple_str_int;\n\n    assert(candidate(\"(7, 8, 9)\") == tuple(7L, 8L, 9L));\n    assert(candidate(\"(1, 2, 3)\") == tuple(1L, 2L, 3L));\n    assert(candidate(\"(4, 5, 6)\") == tuple(4L, 5L, 6L));\n    assert(candidate(\"(7, 81, 19)\") == tuple(7L, 81L, 19L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\n*/\nlong right_insertion(long[] a, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = right_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\n*/\nbool text_match_three(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_match_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"caacabbbba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create a new tuple from the given string and list.\n\t\n*/\nTuple!(string, string, string) new_tuple(string[] test_list, string test_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = new_tuple;\n\n    assert(candidate([\"WEB\", \"is\"], \"best\") == tuple(\"WEB\", \"is\", \"best\"));\n    assert(candidate([\"We\", \"are\"], \"Developers\") == tuple(\"We\", \"are\", \"Developers\"));\n    assert(candidate([\"Part\", \"is\"], \"Wrong\") == tuple(\"Part\", \"is\", \"Wrong\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\n*/\nbool even_position(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = even_position;\n\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L]) == false);\n    assert(candidate([2L, 1L, 4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\n*/\nlong count_list(long[][] input_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_list;\n\n    assert(candidate([[1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == 4L);\n    assert(candidate([[1L, 2L], [2L, 3L], [4L, 5L]]) == 3L);\n    assert(candidate([[1L, 0L], [2L, 0L]]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\n*/\nlong last(long[] arr, long x) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = last;\n\n    assert(candidate([1L, 2L, 3L], 1L) == 0L);\n    assert(candidate([1L, 1L, 1L, 2L, 3L, 4L], 1L) == 2L);\n    assert(candidate([2L, 3L, 2L, 3L, 6L, 8L, 9L], 3L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\n*/\nbool text_starta_endb(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = text_starta_endb;\n\n    assert(candidate(\"aabbbb\") == true);\n    assert(candidate(\"aabAbbbc\") == false);\n    assert(candidate(\"accddbbjjj\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite function to find the sum of all items in the given dictionary.\n\t\n*/\nlong return_sum(Nullable!(long[string]) dict) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = return_sum;\n\n    assert(candidate([\"a\": 100L, \"b\": 200L, \"c\": 300L].nullable) == 600L);\n    assert(candidate([\"a\": 25L, \"b\": 18L, \"c\": 45L].nullable) == 88L);\n    assert(candidate([\"a\": 36L, \"b\": 39L, \"c\": 49L].nullable) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\n*/\nlong sum_in_range(long l, long r) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sum_in_range;\n\n    assert(candidate(2L, 5L) == 8L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 13L) == 40L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the sum of an array.\n\t\n*/\nlong _sum(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = _sum;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([15L, 12L, 13L, 10L]) == 50L);\n    assert(candidate([0L, 1L, 2L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\n*/\nlong left_rotate(long n, long d) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = left_rotate;\n\n    assert(candidate(16L, 2L) == 64L);\n    assert(candidate(10L, 2L) == 40L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(1L, 3L) == 8L);\n    assert(candidate(5L, 3L) == 40L);\n    assert(candidate(29L, 3L) == 232L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\n*/\nbool word_len(string s) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = word_len;\n\n    assert(candidate(\"Hadoop\") == false);\n    assert(candidate(\"great\") == true);\n    assert(candidate(\"structure\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all whitespaces from a string.\n\t\n*/\nstring remove_all_spaces(string text) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = remove_all_spaces;\n\n    assert(candidate(\"python  program\") == \"pythonprogram\");\n    assert(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\");\n    assert(candidate(\"python                     program\") == \"pythonprogram\");\n    assert(candidate(\"   python                     program\") == \"pythonprogram\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\n*/\nlong test_three_equal(long x, long y, long z) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = test_three_equal;\n\n    assert(candidate(1L, 1L, 1L) == 3L);\n    assert(candidate(-1L, -2L, -3L) == 0L);\n    assert(candidate(1L, 2L, 2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\n*/\nlong count_rotation(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = count_rotation;\n\n    assert(candidate([3L, 2L, 1L]) == 1L);\n    assert(candidate([4L, 5L, 1L, 2L, 3L]) == 2L);\n    assert(candidate([7L, 8L, 9L, 1L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 2L, 3L]) == 0L);\n    assert(candidate([1L, 3L, 2L]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\n*/\nbool is_perfect_square(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_perfect_square;\n\n    assert(candidate(10L) == false);\n    assert(candidate(36L) == true);\n    assert(candidate(14L) == false);\n    assert(candidate(196L) == true);\n    assert(candidate(125L) == false);\n    assert(candidate(15625L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\n*/\nbool is_product_even(long[] arr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_product_even;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 4L]) == true);\n    assert(candidate([1L, 1L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\n*/\nlong[] max_sum_list(long[][] lists) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_sum_list;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [10L, 11L, 12L], [7L, 8L, 9L]]) == [10L, 11L, 12L]);\n    assert(candidate([[3L, 2L, 1L], [6L, 5L, 4L], [12L, 11L, 10L]]) == [12L, 11L, 10L]);\n    assert(candidate([[2L, 3L, 1L]]) == [2L, 3L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\n*/\nlong max_run_uppercase(string test_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = max_run_uppercase;\n\n    assert(candidate(\"GeMKSForGERksISBESt\") == 5L);\n    assert(candidate(\"PrECIOusMOVemENTSYT\") == 6L);\n    assert(candidate(\"GooGLEFluTTER\") == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\n*/\nlong first_odd(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = first_odd;\n\n    assert(candidate([1L, 3L, 5L]) == 1L);\n    assert(candidate([2L, 4L, 1L, 3L]) == 1L);\n    assert(candidate([8L, 9L, 1L]) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given tuples contain the k or not.\n\t\n*/\nbool check_K(long[] test_tup, long K) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_K;\n\n    assert(candidate([10L, 4L, 5L, 6L, 8L], 6L) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 7L) == false);\n    assert(candidate([7L, 8L, 9L, 44L, 11L, 12L], 11L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\n*/\nbool check_smaller(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = check_smaller;\n\n    assert(candidate(tuple(1L, 2L, 3L), tuple(2L, 3L, 4L)) == false);\n    assert(candidate(tuple(4L, 5L, 6L), tuple(3L, 4L, 5L)) == true);\n    assert(candidate(tuple(11L, 12L, 13L), tuple(10L, 11L, 12L)) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth tetrahedral number.\n\t\n*/\nlong tetrahedral_number(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = tetrahedral_number;\n\n    assert(candidate(5L) == 35L);\n    assert(candidate(6L) == 56L);\n    assert(candidate(7L) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\n*/\nstring get_Char(string strr) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = get_Char;\n\n    assert(candidate(\"abc\") == \"f\");\n    assert(candidate(\"gfg\") == \"t\");\n    assert(candidate(\"ab\") == \"c\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\n*/\nlong sequence(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = sequence;\n\n    assert(candidate(10L) == 6L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(3L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth centered hexagonal number.\n\t\n*/\nlong centered_hexagonal_number(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = centered_hexagonal_number;\n\n    assert(candidate(10L) == 271L);\n    assert(candidate(2L) == 7L);\n    assert(candidate(9L) == 217L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\n*/\nNullable!(string[string]) merge_dictionaries_three(Nullable!(string[string]) dict1, Nullable!(string[string]) dict2, Nullable!(string[string]) dict3) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = merge_dictionaries_three;\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable);\n        assert(!result.isNull && result.get == [\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\n*/\nNullable!(long[long]) freq_count(long[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = freq_count;\n\n{\n        auto result = candidate([10L, 10L, 10L, 10L, 20L, 20L, 20L, 20L, 40L, 40L, 50L, 50L, 30L]);\n        assert(!result.isNull && result.get == [10L: 4L, 20L: 4L, 40L: 2L, 50L: 2L, 30L: 1L]);\n}\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 3L, 2L, 4L, 1L, 3L, 1L, 4L]);\n        assert(!result.isNull && result.get == [1L: 3L, 2L: 2L, 3L: 3L, 4L: 3L]);\n}\n\n{\n        auto result = candidate([5L, 6L, 7L, 4L, 9L, 10L, 4L, 5L, 6L, 7L, 9L, 5L]);\n        assert(!result.isNull && result.get == [10L: 1L, 5L: 3L, 6L: 2L, 7L: 2L, 4L: 2L, 9L: 2L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the closest smaller number than n.\n\t\n*/\nlong closest_num(long N) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = closest_num;\n\n    assert(candidate(11L) == 10L);\n    assert(candidate(7L) == 6L);\n    assert(candidate(12L) == 11L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find squares of individual elements in a list.\n\t\n*/\nlong[] square_nums(long[] nums) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = square_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L]) == [100L, 400L, 900L]);\n    assert(candidate([12L, 15L]) == [144L, 225L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the length of the longest word.\n\t\n*/\nlong len_log(string[] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = len_log;\n\n    assert(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7L);\n    assert(candidate([\"a\", \"ab\", \"abc\"]) == 3L);\n    assert(candidate([\"small\", \"big\", \"tall\"]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\n*/\nbool find_substring(string[] str1, string sub_str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_substring;\n\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is undulating or not.\n\t\n*/\nbool is_undulating(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = is_undulating;\n\n    assert(candidate(1212121L) == true);\n    assert(candidate(1991L) == false);\n    assert(candidate(121L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\n*/\nlong power(long a, long b) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = power;\n\n    assert(candidate(3L, 4L) == 81L);\n    assert(candidate(2L, 3L) == 8L);\n    assert(candidate(5L, 5L) == 3125L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\n*/\nstring index_minimum(Tuple!(string, long)[] test_list) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = index_minimum;\n\n    assert(candidate([tuple(\"Rash\", 143L), tuple(\"Manjeet\", 200L), tuple(\"Varsha\", 100L)]) == \"Varsha\");\n    assert(candidate([tuple(\"Yash\", 185L), tuple(\"Dawood\", 125L), tuple(\"Sanya\", 175L)]) == \"Dawood\");\n    assert(candidate([tuple(\"Sai\", 345L), tuple(\"Salman\", 145L), tuple(\"Ayesha\", 96L)]) == \"Ayesha\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\n*/\nlong Find_Min_Length(long[][] lst) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = Find_Min_Length;\n\n    assert(candidate([[1L], [1L, 2L]]) == 1L);\n    assert(candidate([[1L, 2L], [1L, 2L, 3L], [1L, 2L, 3L, 4L]]) == 2L);\n    assert(candidate([[3L, 3L, 3L], [4L, 4L, 4L, 4L]]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the number of divisors of a given integer.\n\t\n*/\nlong divisor(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = divisor;\n\n    assert(candidate(15L) == 4L);\n    assert(candidate(12L) == 6L);\n    assert(candidate(9L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\n*/\nNullable!(long[long]) frequency_lists(long[][] list1) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = frequency_lists;\n\n{\n        auto result = candidate([[1L, 2L, 3L, 2L], [4L, 5L, 6L, 2L], [7L, 8L, 9L, 5L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 3L, 3L: 1L, 4L: 1L, 5L: 2L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L]);\n}\n\n{\n        auto result = candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 1L, 3L: 1L, 4L: 1L, 5L: 1L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L, 10L: 1L, 11L: 1L, 12L: 1L]);\n}\n\n{\n        auto result = candidate([[20L, 30L, 40L, 17L], [18L, 16L, 14L, 13L], [10L, 20L, 30L, 40L]]);\n        assert(!result.isNull && result.get == [20L: 2L, 30L: 2L, 40L: 2L, 17L: 1L, 18L: 1L, 16L: 1L, 14L: 1L, 13L: 1L, 10L: 1L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\n*/\nstring decimal_to_binary(long n) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(8L) == \"1000\");\n    assert(candidate(18L) == \"10010\");\n    assert(candidate(7L) == \"111\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\n*/\nlong find_Rotations(string str) \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "unittest\n{\n    alias candidate = find_Rotations;\n\n    assert(candidate(\"aaaa\") == 1L);\n    assert(candidate(\"ab\") == 2L);\n    assert(candidate(\"abc\") == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/mbpp-d-reworded.json
+++ b/prompts/mbpp-d-reworded.json
@@ -1,85 +1,10 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\n*/\nlong lps(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = lps;\n\n    assert(candidate(\"TENS FOR TENS\") == 5L);\n    assert(candidate(\"CARDIO FOR CARDS\") == 7L);\n    assert(candidate(\"PART OF THE JOURNEY IS PART\") == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to remove all whitespaces from the given string.\n\t\n*/\nstring remove_whitespaces(string text1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_whitespaces;\n\n    assert(candidate(\" Google    Flutter \") == \"GoogleFlutter\");\n    assert(candidate(\" Google    Dart \") == \"GoogleDart\");\n    assert(candidate(\" iOS    Swift \") == \"iOSSwift\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "d",
-    "prompt": "import std.math;\n/*\n\n\tWrite a function to check whether a specified array is sorted or not.\n\t\n*/\nbool issort_list(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = issort_list;\n\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 16L, 17L]) == true);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 20L, 17L]) == false);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 15L, 14L, 20L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count bidirectional tuple pairs.\n\t\n*/\nlong count_bidirectional(Tuple!(long, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_bidirectional;\n\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 3L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 3L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 2L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 2L), tuple(6L, 5L), tuple(2L, 1L)]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cube of a given size.\n\t\n*/\nlong surfacearea_cube(long l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = surfacearea_cube;\n\n    assert(candidate(5L) == 150L);\n    assert(candidate(3L) == 54L);\n    assert(candidate(10L) == 600L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\n*/\nlong next_smallest_palindrome(long num) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\n*/\nlong next_smallest_palindrome(long num) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = next_smallest_palindrome;\n\n    assert(candidate(99L) == 101L);\n    assert(candidate(1221L) == 1331L);\n    assert(candidate(120L) == 121L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -90,658 +15,13 @@
     ]
   },
   {
-    "name": "mbpp_420_cube_Sum",
+    "name": "mbpp_101_kth_element",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the cube sum of first n even natural numbers.\n\t\n*/\nlong cube_Sum(long n) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\n*/\nlong kth_element(long[] arr, long k) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = cube_Sum;\n\n    assert(candidate(2L) == 72L);\n    assert(candidate(3L) == 288L);\n    assert(candidate(4L) == 800L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of xor of all pairs of numbers in the given array.\n\t\n*/\nlong pair_xor_Sum(long[] arr, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pair_xor_Sum;\n\n    assert(candidate([5L, 9L, 7L, 6L], 4L) == 47L);\n    assert(candidate([7L, 3L, 5L], 3L) == 12L);\n    assert(candidate([7L, 3L], 2L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\n*/\nbool check_min_heap(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_min_heap;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 10L, 15L]) == true);\n    assert(candidate([2L, 10L, 4L, 5L, 3L, 15L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first digit of a given number.\n\t\n*/\nlong first_Digit(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = first_Digit;\n\n    assert(candidate(123L) == 1L);\n    assert(candidate(456L) == 4L);\n    assert(candidate(12L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first non-repeated character in a given string.\n\t\n*/\nNullable!(string) first_non_repeating_character(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = first_non_repeating_character;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"ababc\");\n        assert(!result.isNull && result.get == \"c\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert degrees to radians.\n\t\n*/\nfloat radian_degree(long degree) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = radian_degree;\n\n    assert(candidate(90L) == 1.5707963267948966);\n    assert(candidate(60L) == 1.0471975511965976);\n    assert(candidate(120L) == 2.0943951023931953);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product subarray of the given array.\n\t\n*/\nlong max_subarray_product(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_subarray_product;\n\n    assert(candidate([1L, -2L, -3L, 0L, 7L, -8L, -2L]) == 112L);\n    assert(candidate([6L, -3L, -10L, 0L, 2L]) == 180L);\n    assert(candidate([-2L, -40L, 0L, -2L, -3L]) == 80L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert more than one array to nested associative array.\n\t\n*/\nNone[] convert_list_dictionary(string[] l1, string[] l2, long[] l3) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = convert_list_dictionary;\n\n    assert(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85L, 98L, 89L, 92L]) == [[\"S001\": [\"Adina Park\": 85L].nullable].nullable, [\"S002\": [\"Leyton Marsh\": 98L].nullable].nullable, [\"S003\": [\"Duncan Boyle\": 89L].nullable].nullable, [\"S004\": [\"Saim Richards\": 92L].nullable].nullable]);\n    assert(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100L, 200L, 300L, 400L]) == [[\"abc\": [\"python\": 100L].nullable].nullable, [\"def\": [\"program\": 200L].nullable].nullable, [\"ghi\": [\"language\": 300L].nullable].nullable, [\"jkl\": [\"programs\": 400L].nullable].nullable]);\n    assert(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10L, 20L, 30L, 40L]) == [[\"A1\": [\"java\": 10L].nullable].nullable, [\"A2\": [\"C\": 20L].nullable].nullable, [\"A3\": [\"C++\": 30L].nullable].nullable, [\"A4\": [\"DBMS\": 40L].nullable].nullable]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find smallest number in an array.\n\t\n*/\nlong smallest_num(long[] xs) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = smallest_num;\n\n    assert(candidate([10L, 20L, 1L, 45L, 99L]) == 1L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n    assert(candidate([45L, 46L, 50L, 60L]) == 45L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/dthon-exercises/re/dthon-re-exercise-3.php\n\t\n*/\nbool text_match_zero_one(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_zero_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"dsabbbba\") == true);\n    assert(candidate(\"asbbbba\") == false);\n    assert(candidate(\"abaaa\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find nth bell number.\n\t\n*/\nlong bell_Number(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = bell_Number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 15L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find cubes of individual elements in an array.\n\t\n*/\nlong[] cube_nums(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = cube_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 8L, 27L, 64L, 125L, 216L, 343L, 512L, 729L, 1000L]);\n    assert(candidate([10L, 20L, 30L]) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L]) == [1728L, 3375L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last digit in factorial of a given number.\n\t\n*/\nlong last_Digit_Factorial(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = last_Digit_Factorial;\n\n    assert(candidate(4L) == 4L);\n    assert(candidate(21L) == 0L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find even numbers from an array of numbers.\n\t\n*/\nlong[] Split(long[] list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [2L, 4L]);\n    assert(candidate([4L, 5L, 6L, 7L, 8L, 0L, 1L]) == [4L, 6L, 8L, 0L]);\n    assert(candidate([8L, 12L, 15L, 19L]) == [8L, 12L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given integer is a prime number.\n\t\n*/\nbool prime_num(long num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = prime_num;\n\n    assert(candidate(13L) == true);\n    assert(candidate(7L) == true);\n    assert(candidate(-1010L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find tuples which have all elements divisible by k from the given array of tuples.\n\t\n*/\nTuple!(long, long, long)[] find_tuples(Tuple!(long, long, long)[] test_list, long K) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_tuples;\n\n    assert(candidate([tuple(6L, 24L, 12L), tuple(7L, 9L, 6L), tuple(12L, 18L, 21L)], 6L) == [tuple(6L, 24L, 12L)]);\n    assert(candidate([tuple(5L, 25L, 30L), tuple(4L, 2L, 3L), tuple(7L, 8L, 9L)], 5L) == [tuple(5L, 25L, 30L)]);\n    assert(candidate([tuple(7L, 9L, 16L), tuple(8L, 16L, 4L), tuple(19L, 17L, 18L)], 4L) == [tuple(8L, 16L, 4L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\n*/\nfloat area_tetrahedron(long side) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = area_tetrahedron;\n\n    assert(candidate(3L) == 15.588457268119894);\n    assert(candidate(20L) == 692.8203230275509);\n    assert(candidate(10L) == 173.20508075688772);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number is even or not.\n\t\n*/\nbool is_Even(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_Even;\n\n    assert(candidate(1L) == false);\n    assert(candidate(2L) == true);\n    assert(candidate(3L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of positive numbers in an array.\n\t\n*/\nlong pos_count(long[] list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pos_count;\n\n    assert(candidate([1L, -2L, 3L, -4L]) == 2L);\n    assert(candidate([3L, 4L, 5L, -1L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\n*/\nlong[] get_ludic(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_ludic;\n\n    assert(candidate(10L) == [1L, 2L, 3L, 5L, 7L]);\n    assert(candidate(25L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L]);\n    assert(candidate(45L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L, 29L, 37L, 41L, 43L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\n*/\nlong find_Index(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Index;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 14L);\n    assert(candidate(4L) == 45L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to reverse an array upto a given position.\n\t\n*/\nlong[] reverse_Array_Upto_K(long[] input, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = reverse_Array_Upto_K;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 4L) == [4L, 3L, 2L, 1L, 5L, 6L]);\n    assert(candidate([4L, 5L, 6L, 7L], 2L) == [5L, 4L, 6L, 7L]);\n    assert(candidate([9L, 8L, 7L, 6L, 5L], 3L) == [7L, 8L, 9L, 6L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of tuples using the second value of each tuple.\n\t\n*/\nTuple!(string, long)[] subject_marks(Tuple!(string, long)[] subjectmarks) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = subject_marks;\n\n    assert(candidate([tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L), tuple(\"Social sciences\", 82L)]) == [tuple(\"Social sciences\", 82L), tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L)]);\n    assert(candidate([tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L), tuple(\"Social\", 33L)]) == [tuple(\"Social\", 33L), tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L)]);\n    assert(candidate([tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L), tuple(\"Biology\", 45L)]) == [tuple(\"Biology\", 45L), tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\n*/\nstring remove_dirty_chars(string string, string second_string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_dirty_chars;\n\n    assert(candidate(\"probasscurve\", \"pros\") == \"bacuve\");\n    assert(candidate(\"digitalindia\", \"talent\") == \"digiidi\");\n    assert(candidate(\"exoticmiles\", \"toxic\") == \"emles\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the item with maximum frequency in a given array.\n\t\n*/\nlong max_occurrences(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_occurrences;\n\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 2L, 6L, 5L, 1L, 6L, 1L, 2L, 3L, 2L, 4L, 6L, 9L, 1L, 2L]) == 2L);\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 7L, 9L, 15L, 14L, 10L, 12L, 13L, 16L, 18L]) == 8L);\n    assert(candidate([10L, 20L, 20L, 30L, 40L, 90L, 80L, 50L, 30L, 20L, 50L, 10L]) == 20L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\n*/\nbool is_decimal(string num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_decimal;\n\n    assert(candidate(\"123.11\") == true);\n    assert(candidate(\"e666.86\") == false);\n    assert(candidate(\"3.124587\") == false);\n    assert(candidate(\"1.11\") == true);\n    assert(candidate(\"1.1.11\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an associative array and integer n and filters the associative array to only include entries with values greater than or equal to n.\n\t\n*/\nNullable!(long[string]) dict_filter(Nullable!(long[string]) dict, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = dict_filter;\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 170L);\n        assert(!result.isNull && result.get == [\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 180L);\n        assert(!result.isNull && result.get == [\"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 190L);\n        assert(!result.isNull && result.get == [\"Pierre Cox\": 190L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of even numbers at even positions of an array.\n\t\n*/\nlong sum_even_and_even_index(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_even_and_even_index;\n\n    assert(candidate([5L, 6L, 12L, 1L, 18L, 8L]) == 30L);\n    assert(candidate([3L, 20L, 17L, 9L, 2L, 10L, 18L, 13L, 6L, 18L]) == 26L);\n    assert(candidate([5L, 6L, 12L, 1L]) == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of the largest contiguous subarray in the given array.\n\t\n*/\nlong max_sub_array_sum(long[] a, long size) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum;\n\n    assert(candidate([-2L, -3L, 4L, -1L, -2L, 1L, 5L, -3L], 8L) == 7L);\n    assert(candidate([-3L, -4L, 5L, -2L, -3L, 2L, 6L, -4L], 8L) == 8L);\n    assert(candidate([-4L, -5L, 6L, -3L, -4L, 3L, 7L, -5L], 8L) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the intersection of two arrays.\n\t\n*/\nlong[] intersection_array(long[] array_nums1, long[] array_nums2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = intersection_array;\n\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [1L, 2L, 4L, 8L, 9L]) == [1L, 2L, 8L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [3L, 5L, 7L, 9L]) == [3L, 5L, 7L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [10L, 20L, 30L, 40L]) == [10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\n*/\nTuple!(string, long, long) find_literals(string text, string pattern) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_literals;\n\n    assert(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == tuple(\"fox\", 16L, 19L));\n    assert(candidate(\"Its been a very crazy procedure right\", \"crazy\") == tuple(\"crazy\", 16L, 21L));\n    assert(candidate(\"Hardest choices required strongest will\", \"will\") == tuple(\"will\", 35L, 39L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the volume of a triangular prism.\n\t\n*/\nlong find_Volume(long l, long b, long h) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Volume;\n\n    assert(candidate(10L, 8L, 6L) == 240L);\n    assert(candidate(3L, 2L, 2L) == 6L);\n    assert(candidate(1L, 2L, 1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\n*/\nlong wind_chill(long v, long t) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = wind_chill;\n\n    assert(candidate(120L, 35L) == 40L);\n    assert(candidate(40L, 20L) == 19L);\n    assert(candidate(10L, 8L) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ascii value of a character.\n\t\n*/\nlong ascii_value(string k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = ascii_value;\n\n    assert(candidate(\"A\") == 65L);\n    assert(candidate(\"R\") == 82L);\n    assert(candidate(\"S\") == 83L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether all the characters are same or not.\n\t\n*/\nbool all_Characters_Same(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = all_Characters_Same;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"aaa\") == true);\n    assert(candidate(\"data\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to move all the numbers to the end of the given string.\n\t\n*/\nstring move_num(string test_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = move_num;\n\n    assert(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\");\n    assert(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\");\n    assert(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the length of the word is odd or not.\n\t\n*/\nbool word_len(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = word_len;\n\n    assert(candidate(\"Hadoop\") == false);\n    assert(candidate(\"great\") == true);\n    assert(candidate(\"structure\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\n\t\n*/\nstring[] insert_element(string[] list, string element) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = insert_element;\n\n    assert(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n    assert(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"]);\n    assert(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove lowercase substrings from a given string.\n\t\n*/\nstring remove_lowercase(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_lowercase;\n\n    assert(candidate(\"PYTHon\") == \"PYTH\");\n    assert(candidate(\"FInD\") == \"FID\");\n    assert(candidate(\"STRinG\") == \"STRG\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of set bits (binary digits with value 1) in a given number.\n\t\n*/\nlong count_Set_Bits(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_Set_Bits;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 1L);\n    assert(candidate(6L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\n*/\nstring[] extract_rear(Tuple!(string, string, string) test_tuple) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = extract_rear;\n\n    assert(candidate(tuple(\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"]);\n    assert(candidate(tuple(\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"]);\n    assert(candidate(tuple(\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\n*/\nlong count_occurance(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_occurance;\n\n    assert(candidate(\"letstdlenstdporstd\") == 3L);\n    assert(candidate(\"truststdsolensporsd\") == 1L);\n    assert(candidate(\"makestdsostdworthit\") == 2L);\n    assert(candidate(\"stds\") == 1L);\n    assert(candidate(\"\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given tuples contain the k or not.\n\t\n*/\nbool check_K(long[] test_tup, long K) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_K;\n\n    assert(candidate([10L, 4L, 5L, 6L, 8L], 6L) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 7L) == false);\n    assert(candidate([7L, 8L, 9L, 44L, 11L, 12L], 11L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to interleave 3 arrays of the same length into a single flat array.\n\t\n*/\nlong[] interleave_lists(long[] list1, long[] list2, long[] list3) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = interleave_lists;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L], [10L, 20L, 30L, 40L, 50L, 60L, 70L], [100L, 200L, 300L, 400L, 500L, 600L, 700L]) == [1L, 10L, 100L, 2L, 20L, 200L, 3L, 30L, 300L, 4L, 40L, 400L, 5L, 50L, 500L, 6L, 60L, 600L, 7L, 70L, 700L]);\n    assert(candidate([10L, 20L], [15L, 2L], [5L, 10L]) == [10L, 15L, 5L, 20L, 2L, 10L]);\n    assert(candidate([11L, 44L], [10L, 15L], [20L, 5L]) == [11L, 10L, 20L, 44L, 15L, 5L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = kth_element;\n\n    assert(candidate([12L, 3L, 5L, 7L, 19L], 2L) == 3L);\n    assert(candidate([17L, 24L, 8L, 23L], 3L) == 8L);\n    assert(candidate([16L, 21L, 25L, 36L, 4L], 4L) == 36L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -752,9 +32,9 @@
   {
     "name": "mbpp_102_snake_to_camel",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to convert a snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"python_program\") == \"PythonProgram\");\n    assert(candidate(\"python_language\") == \"PythonLanguage\");\n    assert(candidate(\"programming_language\") == \"ProgrammingLanguage\");\n}\nvoid main(){}",
     "stop_tokens": [
@@ -765,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_801_test_three_equal",
+    "name": "mbpp_103_eulerian_num",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of equal numbers from three given integers.\n\t\n*/\nlong test_three_equal(long x, long y, long z) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to find the Eulerian number a(n, m).\n\t\n*/\nlong eulerian_num(long n, long m) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = test_three_equal;\n\n    assert(candidate(1L, 1L, 1L) == 3L);\n    assert(candidate(-1L, -2L, -3L) == 0L);\n    assert(candidate(1L, 2L, 2L) == 2L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = eulerian_num;\n\n    assert(candidate(3L, 1L) == 4L);\n    assert(candidate(4L, 1L) == 11L);\n    assert(candidate(5L, 3L) == 26L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -780,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_782_odd_length_sum",
+    "name": "mbpp_104_sort_sublists",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\n*/\nlong odd_length_sum(long[] arr) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a function to sort each subarray of strings in a given array of arrays.\n\t\n*/\nstring[][] sort_sublists(string[][] input_list) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = odd_length_sum;\n\n    assert(candidate([1L, 2L, 4L]) == 14L);\n    assert(candidate([1L, 2L, 1L, 2L]) == 15L);\n    assert(candidate([1L, 7L]) == 8L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n    assert(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -795,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_67_bell_number",
+    "name": "mbpp_105_count",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\n*/\nlong bell_number(long n) \n",
+    "prompt": "import std.math;\n/*\n\n\tWrite a dthon function to count true booleans in the given array.\n\t\n*/\nlong count(bool[] lst) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = bell_number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(10L) == 115975L);\n    assert(candidate(56L) == 6775685320645824322581483068371419745979053216268760300L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = count;\n\n    assert(candidate([true, false, true]) == 2L);\n    assert(candidate([false, false]) == 0L);\n    assert(candidate([true, true, true]) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -810,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_458_rectangle_area",
+    "name": "mbpp_106_add_lists",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the area of a rectangle.\n\t\n*/\nlong rectangle_area(long l, long b) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to append the given array to the given tuples.\n\t\n*/\nTuple!(long, long, long, long, long) add_lists(long[] test_list, Tuple!(long, long) test_tup) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rectangle_area;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(10L, 5L) == 50L);\n    assert(candidate(4L, 2L) == 8L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = add_lists;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == tuple(9L, 10L, 5L, 6L, 7L));\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == tuple(10L, 11L, 6L, 7L, 8L));\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == tuple(11L, 12L, 7L, 8L, 9L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -825,883 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_599_sum_average",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find sum and average of first n natural numbers.\n\t\n*/\nTuple!(long, float) sum_average(long number) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three arrays into a single sorted array.\n\t\n*/\nlong[] merge_sorted_list(long[] num1, long[] num2, long[] num3) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_average;\n\n    assert(candidate(10L) == tuple(55L, 5.5));\n    assert(candidate(15L) == tuple(120L, 8.0));\n    assert(candidate(20L) == tuple(210L, 10.5));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) division_elements(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = division_elements;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(2L, 2L, 2L, 3L));\n    assert(candidate(tuple(12L, 6L, 8L, 16L), tuple(6L, 3L, 4L, 4L)) == tuple(2L, 2L, 2L, 4L));\n    assert(candidate(tuple(20L, 14L, 36L, 18L), tuple(5L, 7L, 6L, 9L)) == tuple(4L, 2L, 6L, 2L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\n*/\nlong sum_digits(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_digits;\n\n    assert(candidate(345L) == 12L);\n    assert(candidate(12L) == 3L);\n    assert(candidate(97L) == 16L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven an array of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\n*/\nstring index_minimum(Tuple!(string, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = index_minimum;\n\n    assert(candidate([tuple(\"Rash\", 143L), tuple(\"Manjeet\", 200L), tuple(\"Varsha\", 100L)]) == \"Varsha\");\n    assert(candidate([tuple(\"Yash\", 185L), tuple(\"Dawood\", 125L), tuple(\"Sanya\", 175L)]) == \"Dawood\");\n    assert(candidate([tuple(\"Sai\", 345L), tuple(\"Salman\", 145L), tuple(\"Ayesha\", 96L)]) == \"Ayesha\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to divide two arrays element wise.\n\t\n*/\nfloat[] div_list(long[] nums1, long[] nums2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = div_list;\n\n    assert(candidate([4L, 5L, 6L], [1L, 2L, 3L]) == [4.0, 2.5, 2.0]);\n    assert(candidate([3L, 2L], [1L, 4L]) == [3.0, 0.5]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [1.8, 1.7142857142857142]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the array with maximum length.\n\t\n*/\nTuple!(long, long[]) max_length_list(long[][] input_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_length_list;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L, 2L, 3L, 4L, 5L], [1L, 2L, 3L, 4L], [1L, 2L, 3L], [1L, 2L], [1L]]) == tuple(5L, [1L, 2L, 3L, 4L, 5L]));\n    assert(candidate([[3L, 4L, 5L], [6L, 7L, 8L, 9L], [10L, 11L, 12L]]) == tuple(4L, [6L, 7L, 8L, 9L]));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the largest and smallest value in a given array.\n\t\n*/\nlong big_sum(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = big_sum;\n\n    assert(candidate([1L, 2L, 3L]) == 4L);\n    assert(candidate([-1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([2L, 3L, 6L]) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to return the negative numbers in an array.\n\t\n*/\nlong[] neg_nos(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = neg_nos;\n\n    assert(candidate([-1L, 4L, 5L, -6L]) == [-1L, -6L]);\n    assert(candidate([-1L, -2L, 3L, 4L]) == [-1L, -2L]);\n    assert(candidate([-7L, -6L, 8L, 9L]) == [-7L, -6L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the highest power of 2 that is less than or equal to n.\n\t\n*/\nlong highest_Power_of_2(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = highest_Power_of_2;\n\n    assert(candidate(10L) == 8L);\n    assert(candidate(19L) == 16L);\n    assert(candidate(32L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether an array contains the given subarray or not.\n\t\n*/\nbool is_sublist(long[] l, long[] s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_sublist;\n\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [3L, 7L]) == false);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [4L, 3L]) == true);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [1L, 6L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to subtract two arrays element-wise.\n\t\n*/\nlong[] sub_list(long[] nums1, long[] nums2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sub_list;\n\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == [-3L, -3L, -3L]);\n    assert(candidate([1L, 2L], [3L, 4L]) == [-2L, -2L]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [40L, 50L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given two integers have opposite sign or not.\n\t\n*/\nbool opposite_Signs(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = opposite_Signs;\n\n    assert(candidate(1L, -2L) == true);\n    assert(candidate(3L, 2L) == false);\n    assert(candidate(-10L, -10L) == false);\n    assert(candidate(-2L, 2L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\n*/\nTuple!(long, long, long, long) tuple_modulo(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tuple_modulo;\n\n    assert(candidate(tuple(10L, 4L, 5L, 6L), tuple(5L, 6L, 7L, 5L)) == tuple(0L, 4L, 5L, 1L));\n    assert(candidate(tuple(11L, 5L, 6L, 7L), tuple(6L, 7L, 8L, 6L)) == tuple(5L, 5L, 6L, 1L));\n    assert(candidate(tuple(12L, 6L, 7L, 8L), tuple(7L, 8L, 9L, 7L)) == tuple(5L, 6L, 7L, 1L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the difference of the first even and first odd number of a given array.\n\t\n*/\nlong diff_even_odd(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = diff_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 1L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort each subarray of strings in a given array of arrays.\n\t\n*/\nstring[][] sort_sublists(string[][] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last digit of a given number.\n\t\n*/\nlong last_Digit(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = last_Digit;\n\n    assert(candidate(123L) == 3L);\n    assert(candidate(25L) == 5L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of fourth power of first n odd natural numbers.\n\t\n*/\nlong odd_num_sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = odd_num_sum;\n\n    assert(candidate(2L) == 82L);\n    assert(candidate(3L) == 707L);\n    assert(candidate(4L) == 3108L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert an array to a string.\n\t\n*/\nstring tup_string(string[] tup1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tup_string;\n\n    assert(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\");\n    assert(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\");\n    assert(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all elements from a given array present in another array.\n\t\n*/\nlong[] remove_elements(long[] list1, long[] list2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_elements;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [2L, 4L, 6L, 8L]) == [1L, 3L, 5L, 7L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [1L, 3L, 5L, 7L]) == [2L, 4L, 6L, 8L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [5L, 7L]) == [1L, 2L, 3L, 4L, 6L, 8L, 9L, 10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether any value in a sequence exists in a sequence or not.\n\t\n*/\nbool overlapping(long[] list1, long[] list2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = overlapping;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 8L, 9L]) == false);\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == false);\n    assert(candidate([1L, 4L, 5L], [1L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to identify non-prime numbers.\n\t\n*/\nbool is_not_prime(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_not_prime;\n\n    assert(candidate(2L) == false);\n    assert(candidate(10L) == true);\n    assert(candidate(35L) == true);\n    assert(candidate(37L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of the negative numbers of a given array of numbers.\n\t\n*/\nlong sum_negativenum(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_negativenum;\n\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == -32L);\n    assert(candidate([10L, 15L, -14L, 13L, -18L, 12L, -20L]) == -52L);\n    assert(candidate([19L, -65L, 57L, 39L, 152L, -639L, 121L, 44L, 90L, -190L]) == -894L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\n*/\nlong find_Rotations(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Rotations;\n\n    assert(candidate(\"aaaa\") == 1L);\n    assert(candidate(\"ab\") == 2L);\n    assert(candidate(\"abc\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\n*/\nstring change_date_format(string dt) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = change_date_format;\n\n    assert(candidate(\"2026-01-02\") == \"02-01-2026\");\n    assert(candidate(\"2020-11-13\") == \"13-11-2020\");\n    assert(candidate(\"2021-04-26\") == \"26-04-2021\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array of integers and only returns the odd ones.\n\t\n*/\nlong[] Split(long[] list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == [1L, 3L, 5L]);\n    assert(candidate([10L, 11L, 12L, 13L]) == [11L, 13L]);\n    assert(candidate([7L, 8L, 9L, 1L]) == [7L, 9L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\n*/\nlong toggle_middle_bits(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = toggle_middle_bits;\n\n    assert(candidate(9L) == 15L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(11L) == 13L);\n    assert(candidate(65L) == 127L);\n    assert(candidate(77L) == 115L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\n*/\nlong count_char_position(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_char_position;\n\n    assert(candidate(\"xbcefg\") == 2L);\n    assert(candidate(\"ABcED\") == 3L);\n    assert(candidate(\"AbgdeF\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\n\t\n*/\nlong[] large_product(long[] nums1, long[] nums2, long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = large_product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 3L) == [60L, 54L, 50L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 4L) == [60L, 54L, 50L, 48L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 5L) == [60L, 54L, 50L, 48L, 45L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the cumulative sum of all the values that are present in the given array of arrays.\n\t\n*/\nlong cummulative_sum(long[][] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = cummulative_sum;\n\n    assert(candidate([[1L, 3L], [5L, 6L, 7L], [2L, 6L]]) == 30L);\n    assert(candidate([[2L, 4L], [6L, 7L, 8L], [3L, 7L]]) == 37L);\n    assert(candidate([[3L, 5L], [7L, 8L, 9L], [4L, 8L]]) == 44L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\n*/\nlong find_min_diff(long[] arr, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_min_diff;\n\n    assert(candidate([1L, 5L, 3L, 19L, 18L, 25L], 6L) == 1L);\n    assert(candidate([4L, 3L, 2L, 6L], 4L) == 1L);\n    assert(candidate([30L, 5L, 20L, 9L], 4L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\n*/\nbool text_starta_endb(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_starta_endb;\n\n    assert(candidate(\"aabbbb\") == true);\n    assert(candidate(\"aabAbbbc\") == false);\n    assert(candidate(\"accddbbjjj\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\n*/\nlong left_rotate(long n, long d) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = left_rotate;\n\n    assert(candidate(16L, 2L) == 64L);\n    assert(candidate(10L, 2L) == 40L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(1L, 3L) == 8L);\n    assert(candidate(5L, 3L) == 40L);\n    assert(candidate(29L, 3L) == 232L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first repeated character in a given string.\n\t\n*/\nNullable!(string) first_repeated_char(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = first_repeated_char;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"123123\");\n        assert(!result.isNull && result.get == \"1\");\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count inversions in an array.\n\t\n*/\nlong get_Inv_Count(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_Inv_Count;\n\n    assert(candidate([1L, 20L, 6L, 4L, 5L]) == 5L);\n    assert(candidate([1L, 2L, 1L]) == 1L);\n    assert(candidate([1L, 2L, 5L, 6L, 1L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\n*/\nlong even_Power_Sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = even_Power_Sum;\n\n    assert(candidate(2L) == 1056L);\n    assert(candidate(3L) == 8832L);\n    assert(candidate(1L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether all the given arrays have equal length or not.\n\t\n*/\nbool get_equal(long[][] Input) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_equal;\n\n    assert(candidate([[11L, 22L, 33L], [44L, 55L, 66L]]) == true);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L, 7L]]) == false);\n    assert(candidate([[1L, 2L], [3L, 4L]]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string represents an integer or not.\n\t\n*/\nbool check_integer(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_integer;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"1\") == true);\n    assert(candidate(\"12345\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/dthon-program-to-count-the-pairs-of-reverse-strings/\n\t\n*/\nlong count_reverse_pairs(string[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_reverse_pairs;\n\n    assert(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2L);\n    assert(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1L);\n    assert(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to move all zeroes to the end of the given array.\n\t\n*/\nlong[] move_zero(long[] num_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = move_zero;\n\n    assert(candidate([1L, 0L, 2L, 0L, 3L, 4L]) == [1L, 2L, 3L, 4L, 0L, 0L]);\n    assert(candidate([2L, 3L, 2L, 0L, 0L, 4L, 0L, 5L, 0L]) == [2L, 3L, 2L, 4L, 5L, 0L, 0L, 0L, 0L]);\n    assert(candidate([0L, 1L, 0L, 1L, 1L]) == [1L, 1L, 1L, 0L, 0L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if given array contains no duplicates.\n\t\n*/\nbool check_distinct(long[] test_tup) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_distinct;\n\n    assert(candidate([1L, 4L, 5L, 6L, 1L, 4L]) == false);\n    assert(candidate([1L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 6L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\n*/\nbool noprofit_noloss(long actual_cost, long sale_amount) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = noprofit_noloss;\n\n    assert(candidate(1500L, 1200L) == false);\n    assert(candidate(100L, 100L) == true);\n    assert(candidate(2000L, 5000L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all the words with k length in the given string.\n\t\n*/\nstring remove_length(string test_str, long K) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_length;\n\n    assert(candidate(\"The person is most value tet\", 3L) == \"person is most value\");\n    assert(candidate(\"If you told me about this ok\", 4L) == \"If you me about ok\");\n    assert(candidate(\"Forces of darkeness is come into the play\", 4L) == \"Forces of darkeness is the\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count number of digits in a given string.\n\t\n*/\nlong number_ctr(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = number_ctr;\n\n    assert(candidate(\"program2bedone\") == 1L);\n    assert(candidate(\"3wonders\") == 1L);\n    assert(candidate(\"123\") == 3L);\n    assert(candidate(\"3wond-1ers2\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the total number of characters in a string.\n\t\n*/\nlong count_charac(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_charac;\n\n    assert(candidate(\"python programming\") == 18L);\n    assert(candidate(\"language\") == 8L);\n    assert(candidate(\"words\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\n*/\nlong get_total_number_of_sequences(long m, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_total_number_of_sequences;\n\n    assert(candidate(10L, 4L) == 4L);\n    assert(candidate(5L, 2L) == 6L);\n    assert(candidate(16L, 3L) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/dthon-exercises/data-structures-and-algorithms/dthon-data-structure-exercise-24.php\n\t\n*/\nlong left_insertion(long[] a, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = left_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two numbers and returns an array with the second number and then the first number.\n\t\n*/\nlong[] swap_numbers(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = swap_numbers;\n\n    assert(candidate(10L, 20L) == [20L, 10L]);\n    assert(candidate(15L, 17L) == [17L, 15L]);\n    assert(candidate(100L, 200L) == [200L, 100L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\n*/\nbool is_majority(long[] arr, long n, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_majority;\n\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 3L, 10L], 7L, 3L) == true);\n    assert(candidate([1L, 1L, 2L, 4L, 4L, 4L, 6L, 6L], 8L, 4L) == false);\n    assert(candidate([1L, 1L, 1L, 2L, 2L], 5L, 1L) == true);\n    assert(candidate([1L, 1L, 2L, 2L], 5L, 1L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\n*/\nTuple!(long, long, long) substract_elements(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = substract_elements;\n\n    assert(candidate(tuple(10L, 4L, 5L), tuple(2L, 5L, 18L)) == tuple(8L, -1L, -13L));\n    assert(candidate(tuple(11L, 2L, 3L), tuple(24L, 45L, 16L)) == tuple(-13L, -43L, -13L));\n    assert(candidate(tuple(7L, 18L, 9L), tuple(10L, 11L, 12L)) == tuple(-3L, 7L, -3L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\n*/\nstring capital_words_spaces(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = capital_words_spaces;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\");\n    assert(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the average of cubes of first n natural numbers.\n\t\n*/\nfloat find_Average_Of_Cube(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Average_Of_Cube;\n\n    assert(candidate(2L) == 4.5);\n    assert(candidate(3L) == 12L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if all values are same in an associative array.\n\t\n*/\nbool check_value(Nullable!(long[string]) dict, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_value;\n\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 10L) == false);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 12L) == true);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 5L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth tetrahedral number.\n\t\n*/\nlong tetrahedral_number(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tetrahedral_number;\n\n    assert(candidate(5L) == 35L);\n    assert(candidate(6L) == 56L);\n    assert(candidate(7L) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\n*/\nbool magic_square_test(long[][] my_matrix) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = magic_square_test;\n\n    assert(candidate([[7L, 12L, 1L, 14L], [2L, 13L, 8L, 11L], [16L, 3L, 10L, 5L], [9L, 6L, 15L, 4L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 8L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 7L]]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove uppercase substrings from a given string.\n\t\n*/\nstring remove_uppercase(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_uppercase;\n\n    assert(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\");\n    assert(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\");\n    assert(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate a dog's age in dog's years.\n\t\n*/\nlong dog_age(long h_age) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = dog_age;\n\n    assert(candidate(12L) == 61L);\n    assert(candidate(15L) == 73L);\n    assert(candidate(24L) == 109L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the next perfect square greater than a given number.\n\t\n*/\nlong next_Perfect_Square(long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = next_Perfect_Square;\n\n    assert(candidate(35L) == 36L);\n    assert(candidate(6L) == 9L);\n    assert(candidate(9L) == 16L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create an array of N empty dictionaries.\n\t\n*/\nNone[] empty_list(long length) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = empty_list;\n\n    assert(candidate(5L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(6L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(7L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert a given string to uppercase.\n\t\n*/\nstring is_upper(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_upper;\n\n    assert(candidate(\"person\") == \"PERSON\");\n    assert(candidate(\"final\") == \"FINAL\");\n    assert(candidate(\"Valid\") == \"VALID\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = merge_sorted_list;\n\n    assert(candidate([25L, 24L, 15L, 4L, 5L, 29L, 110L], [19L, 20L, 11L, 56L, 25L, 233L, 154L], [24L, 26L, 54L, 48L]) == [4L, 5L, 11L, 15L, 19L, 20L, 24L, 24L, 25L, 25L, 26L, 29L, 48L, 54L, 56L, 110L, 154L, 233L]);\n    assert(candidate([1L, 3L, 5L, 6L, 8L, 9L], [2L, 5L, 7L, 11L], [1L, 4L, 7L, 8L, 12L]) == [1L, 1L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L, 8L, 8L, 9L, 11L, 12L]);\n    assert(candidate([18L, 14L, 10L, 9L, 8L, 7L, 9L, 3L, 2L, 4L, 1L], [25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L], [12L, 74L, 9L, 50L, 61L, 41L]) == [1L, 2L, 3L, 4L, 7L, 8L, 9L, 9L, 9L, 10L, 12L, 14L, 14L, 18L, 22L, 25L, 25L, 35L, 41L, 50L, 58L, 61L, 65L, 74L, 75L, 85L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -1714,7 +124,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\n*/\nlong odd_Equivalent(string s, long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = odd_Equivalent;\n\n    assert(candidate(\"011001\", 6L) == 3L);\n    assert(candidate(\"11011\", 5L) == 4L);\n    assert(candidate(\"1010\", 4L) == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -1725,2143 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_229_re_arrange_array",
+    "name": "mbpp_113_check_integer",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\n*/\nlong[] re_arrange_array(long[] arr, long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string represents an integer or not.\n\t\n*/\nbool check_integer(string text) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = re_arrange_array;\n\n    assert(candidate([-1L, 2L, -3L, 4L, 5L, 6L, -7L, 8L, 9L], 9L) == [-1L, -3L, -7L, 4L, 5L, 6L, 2L, 8L, 9L]);\n    assert(candidate([12L, -14L, -26L, 13L, 15L], 5L) == [-14L, -26L, 12L, 13L, 15L]);\n    assert(candidate([10L, 24L, 36L, -42L, -39L, -78L, 85L], 7L) == [-42L, -39L, -78L, 10L, 24L, 36L, 85L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether an array of numbers contains only one distinct element or not.\n\t\n*/\nbool unique_Element(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = unique_Element;\n\n    assert(candidate([1L, 1L, 1L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract values between quotation marks from a string.\n\t\n*/\nstring[] extract_values(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = extract_values;\n\n    assert(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"]);\n    assert(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"]);\n    assert(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count true booleans in the given array.\n\t\n*/\nlong count(bool[] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count;\n\n    assert(candidate([true, false, true]) == 2L);\n    assert(candidate([false, false]) == 0L);\n    assert(candidate([true, true, true]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that counts the number of pairs of integers in an array that xor to an even number.\n\t\n*/\nlong find_even_pair(long[] A) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_even_pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L]) == 4L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L]) == 9L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is armstrong or not.\n\t\n*/\nbool armstrong_number(long number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = armstrong_number;\n\n    assert(candidate(153L) == true);\n    assert(candidate(259L) == false);\n    assert(candidate(4458L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the upper case characters in a given string.\n\t\n*/\nlong upper_ctr(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = upper_ctr;\n\n    assert(candidate(\"PYthon\") == 1L);\n    assert(candidate(\"BigData\") == 1L);\n    assert(candidate(\"program\") == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) and_tuples(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = and_tuples;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(0L, 0L, 2L, 1L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(5L, 6L, 7L, 8L)) == tuple(1L, 2L, 3L, 0L));\n    assert(candidate(tuple(8L, 9L, 11L, 12L), tuple(7L, 13L, 14L, 17L)) == tuple(0L, 9L, 10L, 0L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\n*/\nbool is_samepatterns(string[] colors, string[] patterns) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_samepatterns;\n\n    assert(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of arrays in a given number of arrays.\n\t\n*/\nlong count_list(long[][] input_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_list;\n\n    assert(candidate([[1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == 4L);\n    assert(candidate([[1L, 2L], [2L, 3L], [4L, 5L]]) == 3L);\n    assert(candidate([[1L, 0L], [2L, 0L]]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes an arrays of arrays and returns the average value for each subarray as an array.\n\t\n*/\nfloat[] average_tuple(long[][] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = average_tuple;\n\n    assert(candidate([[10L, 10L, 10L, 12L], [30L, 45L, 56L, 45L], [81L, 80L, 39L, 32L], [1L, 2L, 3L, 4L]]) == [30.5, 34.25, 27.0, 23.25]);\n    assert(candidate([[1L, 1L, -5L], [30L, -15L, 56L], [81L, -60L, -39L], [-10L, 2L, 3L]]) == [25.5, -18.0, 3.75]);\n    assert(candidate([[100L, 100L, 100L, 120L], [300L, 450L, 560L, 450L], [810L, 800L, 390L, 320L], [10L, 20L, 30L, 40L]]) == [305.0, 342.5, 270.0, 232.5]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\n*/\nlong lcs_of_three(string X, string Y, string Z) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = lcs_of_three;\n\n    assert(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2L);\n    assert(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5L);\n    assert(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th star number.\n\t\n*/\nlong find_star_num(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_star_num;\n\n    assert(candidate(3L) == 37L);\n    assert(candidate(4L) == 73L);\n    assert(candidate(5L) == 121L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of an array.\n\t\n*/\nlong _sum(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = _sum;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([15L, 12L, 13L, 10L]) == 50L);\n    assert(candidate([0L, 1L, 2L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given array contains consecutive numbers or not.\n\t\n*/\nbool check_Consecutive(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_Consecutive;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 2L, 3L, 5L, 6L]) == false);\n    assert(candidate([1L, 2L, 1L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\n*/\nTuple!(long, long, string) find_adverb_position(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_adverb_position;\n\n    assert(candidate(\"clearly!! we can see the sky\") == tuple(0L, 7L, \"clearly\"));\n    assert(candidate(\"seriously!! there are many roses\") == tuple(0L, 9L, \"seriously\"));\n    assert(candidate(\"unfortunately!! sita is going to home\") == tuple(0L, 13L, \"unfortunately\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/dthon-program-right-rotate-array-n/\n\t\n*/\nlong[] rotate_right(long[] list, long m) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rotate_right;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 3L) == [8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 5L) == [6L, 7L, 8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of non-empty substrings of a given string.\n\t\n*/\nlong number_of_substrings(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = number_of_substrings;\n\n    assert(candidate(\"abc\") == 6L);\n    assert(candidate(\"abcd\") == 10L);\n    assert(candidate(\"abcde\") == 15L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check if the elements of a given array are unique or not.\n\t\n*/\nbool all_unique(long[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = all_unique;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert complex numbers to polar coordinates.\n\t\n*/\nTuple!(float, float) convert(long numbers) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = convert;\n\n    assert(candidate(1L) == tuple(1.0, 0.0));\n    assert(candidate(4L) == tuple(4.0, 0.0));\n    assert(candidate(5L) == tuple(5.0, 0.0));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert the given string to lower case.\n\t\n*/\nstring is_lower(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_lower;\n\n    assert(candidate(\"InValid\") == \"invalid\");\n    assert(candidate(\"TruE\") == \"true\");\n    assert(candidate(\"SenTenCE\") == \"sentence\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the smallest power of 2 greater than or equal to n.\n\t\n*/\nlong next_power_of_2(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = next_power_of_2;\n\n    assert(candidate(0L) == 1L);\n    assert(candidate(5L) == 8L);\n    assert(candidate(17L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string is present as a substring in a given array of string values.\n\t\n*/\nbool find_substring(string[] str1, string sub_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_substring;\n\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace characters in a string.\n\t\n*/\nstring replace_char(string str1, string ch, string newch) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = replace_char;\n\n    assert(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\");\n    assert(candidate(\"character\", \"c\", \"a\") == \"aharaater\");\n    assert(candidate(\"python\", \"l\", \"a\") == \"python\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the product of first even and odd number of a given array.\n\t\n*/\nlong mul_even_odd(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = mul_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\n*/\nlong even_binomial_Coeff_Sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = even_binomial_Coeff_Sum;\n\n    assert(candidate(4L) == 8L);\n    assert(candidate(6L) == 32L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) bitwise_xor(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = bitwise_xor;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(15L, 6L, 5L, 10L));\n    assert(candidate(tuple(11L, 5L, 7L, 10L), tuple(6L, 3L, 4L, 4L)) == tuple(13L, 6L, 3L, 14L));\n    assert(candidate(tuple(12L, 6L, 8L, 11L), tuple(7L, 4L, 5L, 6L)) == tuple(11L, 2L, 13L, 13L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether an array is subarray of another or not.\n\t\n*/\nbool is_Sub_Array(long[] A, long[] B) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_Sub_Array;\n\n    assert(candidate([1L, 4L, 3L, 5L], [1L, 2L]) == false);\n    assert(candidate([1L, 2L, 1L], [1L, 2L, 1L]) == true);\n    assert(candidate([1L, 0L, 2L, 2L], [2L, 2L, 0L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\n*/\nlong max_sub_array_sum_repeated(long[] a, long n, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum_repeated;\n\n    assert(candidate([10L, 20L, -30L, -1L], 4L, 3L) == 30L);\n    assert(candidate([-1L, 10L, 20L], 3L, 2L) == 59L);\n    assert(candidate([-1L, -2L, -3L], 3L, 3L) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the minimum product from the pairs of tuples within a given array.\n\t\n*/\nlong min_product_tuple(Tuple!(long, long)[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = min_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 8L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 30L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 100L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the count of divisors is even. https://www.w3resource.com/dthon-exercises/basic/dthon-basic-1-exercise-24.php\n\t\n*/\nbool count_divisors(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_divisors;\n\n    assert(candidate(10L) == true);\n    assert(candidate(100L) == false);\n    assert(candidate(125L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\n*/\nNullable!(long) triangle_area(long r) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n{\n        auto result = candidate(-1L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(0L);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate(2L);\n        assert(!result.isNull && result.get == 4L);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a given string to an array of characters.\n\t\n*/\nstring[] string_to_tuple(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = string_to_tuple;\n\n    assert(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n    assert(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"]);\n    assert(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\n*/\nlong find_length(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_length;\n\n    assert(candidate(\"11000010001\") == 6L);\n    assert(candidate(\"10111\") == 1L);\n    assert(candidate(\"11011101100101\") == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\n*/\nlong count_Primes_nums(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_Primes_nums;\n\n    assert(candidate(5L) == 2L);\n    assert(candidate(10L) == 4L);\n    assert(candidate(100L) == 25L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the product of consecutive binomial co-efficients.\n\t\n*/\nlong sum_Of_product(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_Of_product;\n\n    assert(candidate(3L) == 15L);\n    assert(candidate(4L) == 56L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the maximum aggregate from the array of tuples.\n\t\n*/\nTuple!(string, long) max_aggregate(Tuple!(string, long)[] stdata) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_aggregate;\n\n    assert(candidate([tuple(\"Juan Whelan\", 90L), tuple(\"Sabah Colley\", 88L), tuple(\"Peter Nichols\", 7L), tuple(\"Juan Whelan\", 122L), tuple(\"Sabah Colley\", 84L)]) == tuple(\"Juan Whelan\", 212L));\n    assert(candidate([tuple(\"Juan Whelan\", 50L), tuple(\"Sabah Colley\", 48L), tuple(\"Peter Nichols\", 37L), tuple(\"Juan Whelan\", 22L), tuple(\"Sabah Colley\", 14L)]) == tuple(\"Juan Whelan\", 72L));\n    assert(candidate([tuple(\"Juan Whelan\", 10L), tuple(\"Sabah Colley\", 20L), tuple(\"Peter Nichols\", 30L), tuple(\"Juan Whelan\", 40L), tuple(\"Sabah Colley\", 50L)]) == tuple(\"Sabah Colley\", 70L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of elements.\n\t\n*/\nlong[] comb_sort(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = comb_sort;\n\n    assert(candidate([5L, 15L, 37L, 25L, 79L]) == [5L, 15L, 25L, 37L, 79L]);\n    assert(candidate([41L, 32L, 15L, 19L, 22L]) == [15L, 19L, 22L, 32L, 41L]);\n    assert(candidate([99L, 15L, 13L, 47L]) == [13L, 15L, 47L, 99L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\n*/\nbool check_expression(string exp) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_expression;\n\n    assert(candidate(\"{()}[{}]\") == true);\n    assert(candidate(\"{()}[{]\") == false);\n    assert(candidate(\"{()}[{}][]({})\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a word containing 'z'.\n\t\n*/\nbool text_match_wordz(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_wordz;\n\n    assert(candidate(\"pythonz.\") == true);\n    assert(candidate(\"xyz.\") == true);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\n*/\nlong[] sum_list(long[] lst1, long[] lst2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_list;\n\n    assert(candidate([10L, 20L, 30L], [15L, 25L, 35L]) == [25L, 45L, 65L]);\n    assert(candidate([1L, 2L, 3L], [5L, 6L, 7L]) == [6L, 8L, 10L]);\n    assert(candidate([15L, 20L, 30L], [15L, 45L, 75L]) == [30L, 65L, 105L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\n*/\nlong newman_prime(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = newman_prime;\n\n    assert(candidate(3L) == 7L);\n    assert(candidate(4L) == 17L);\n    assert(candidate(5L) == 41L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the surface area of a square dramid with a given base edge and height.\n\t\n*/\nlong surface_Area(long b, long s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = surface_Area;\n\n    assert(candidate(3L, 4L) == 33L);\n    assert(candidate(4L, 5L) == 56L);\n    assert(candidate(1L, 2L) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the smallest array in an array of arrays.\n\t\n*/\nlong Find_Min_Length(long[][] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Find_Min_Length;\n\n    assert(candidate([[1L], [1L, 2L]]) == 1L);\n    assert(candidate([[1L, 2L], [1L, 2L, 3L], [1L, 2L, 3L, 4L]]) == 2L);\n    assert(candidate([[3L, 3L, 3L], [4L, 4L, 4L, 4L]]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\n*/\nbool validate(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = validate;\n\n    assert(candidate(1234L) == true);\n    assert(candidate(51241L) == false);\n    assert(candidate(321L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth hexagonal number.\n\t\n*/\nlong hexagonal_num(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = hexagonal_num;\n\n    assert(candidate(10L) == 190L);\n    assert(candidate(5L) == 45L);\n    assert(candidate(7L) == 91L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th lucas number.\n\t\n*/\nlong find_lucas(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_lucas;\n\n    assert(candidate(9L) == 76L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(3L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to get the difference between two arrays.\n\t\n*/\nlong[] Diff(long[] li1, long[] li2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Diff;\n\n    assert(candidate([10L, 15L, 20L, 25L, 30L, 35L, 40L], [25L, 40L, 35L]) == [10L, 20L, 30L, 15L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 1L]) == [2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L], [6L, 7L, 1L]) == [2L, 3L, 6L, 7L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the two numbers differ at one bit position only or not.\n\t\n*/\nbool differ_At_One_Bit_Pos(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = differ_At_One_Bit_Pos;\n\n    assert(candidate(13L, 9L) == true);\n    assert(candidate(15L, 8L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(2L, 3L) == true);\n    assert(candidate(5L, 1L) == true);\n    assert(candidate(1L, 5L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\n*/\nbool text_match_three(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"caacabbbba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\n*/\nlong max_product(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_product;\n\n    assert(candidate([3L, 100L, 4L, 5L, 150L, 6L]) == 3000L);\n    assert(candidate([4L, 42L, 55L, 68L, 80L]) == 50265600L);\n    assert(candidate([10L, 22L, 9L, 33L, 21L, 50L, 41L, 60L]) == 2460L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to split an array at the nth eelment and add the first part to the end.\n\t\n*/\nlong[] split_Arr(long[] l, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = split_Arr;\n\n    assert(candidate([12L, 10L, 5L, 6L, 52L, 36L], 2L) == [5L, 6L, 52L, 36L, 12L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], 1L) == [2L, 3L, 4L, 1L]);\n    assert(candidate([0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L], 3L) == [3L, 4L, 5L, 6L, 7L, 0L, 1L, 2L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the number of divisors of a given integer.\n\t\n*/\nlong divisor(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = divisor;\n\n    assert(candidate(15L) == 4L);\n    assert(candidate(12L) == 6L);\n    assert(candidate(9L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the difference between largest and smallest value in a given array.\n\t\n*/\nlong big_diff(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = big_diff;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([4L, 5L, 12L]) == 8L);\n    assert(candidate([9L, 2L, 3L]) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find squares of individual elements in an array.\n\t\n*/\nlong[] square_nums(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = square_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L]) == [100L, 400L, 900L]);\n    assert(candidate([12L, 15L]) == [144L, 225L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given array is monotonic or not.\n\t\n*/\nbool is_Monotonic(long[] A) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_Monotonic;\n\n    assert(candidate([6L, 5L, 4L, 4L]) == true);\n    assert(candidate([1L, 2L, 2L, 3L]) == true);\n    assert(candidate([1L, 3L, 2L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\n*/\nbool is_perfect_square(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_perfect_square;\n\n    assert(candidate(10L) == false);\n    assert(candidate(36L) == true);\n    assert(candidate(14L) == false);\n    assert(candidate(196L) == true);\n    assert(candidate(125L) == false);\n    assert(candidate(15625L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of common divisors of two given numbers.\n\t\n*/\nlong sum(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum;\n\n    assert(candidate(10L, 15L) == 6L);\n    assert(candidate(100L, 150L) == 93L);\n    assert(candidate(4L, 6L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the array of maximum length in an array of arrays.\n\t\n*/\nTuple!(long, long[]) max_length(long[][] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_length;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L], [5L, 7L], [10L, 12L, 14L, 15L]]) == tuple(4L, [10L, 12L, 14L, 15L]));\n    assert(candidate([[5L], [15L, 20L, 25L]]) == tuple(3L, [15L, 20L, 25L]));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the directrix of a parabola.\n\t\n*/\nlong parabola_directrix(long a, long b, long c) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = parabola_directrix;\n\n    assert(candidate(5L, 3L, 2L) == -198L);\n    assert(candidate(9L, 8L, 4L) == -2336L);\n    assert(candidate(2L, 4L, 6L) == -130L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n\t\n*/\nNullable!(Tuple!(string, long, long)) occurance_substring(string text, string pattern) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = occurance_substring;\n\n{\n        auto result = candidate(\"python programming, python language\", \"python\");\n        assert(!result.isNull && result.get == tuple(\"python\", 0L, 6L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"programming\");\n        assert(!result.isNull && result.get == tuple(\"programming\", 7L, 18L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"language\");\n        assert(!result.isNull && result.get == tuple(\"language\", 31L, 39L));\n}\n\n{\n        auto result = candidate(\"c++ programming, c++ language\", \"python\");\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort each subarray of strings in a given array of arrays.\n\t\n*/\nstring[][] sort_sublists(string[][] input_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n    assert(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array and returns an array with the same elements, but the k'th element removed.\n\t\n*/\nlong[] remove_kth_element(long[] list1, long L) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_kth_element;\n\n    assert(candidate([1L, 1L, 2L, 3L, 4L, 4L, 5L, 1L], 3L) == [1L, 1L, 3L, 4L, 4L, 5L, 1L]);\n    assert(candidate([0L, 0L, 1L, 2L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L], 4L) == [0L, 0L, 1L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L]);\n    assert(candidate([10L, 10L, 15L, 19L, 18L, 18L, 17L, 26L, 26L, 17L, 18L, 10L], 5L) == [10L, 10L, 15L, 19L, 18L, 17L, 26L, 26L, 17L, 18L, 10L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add an associative array to the tuple. The output should be a tuple.\n\t\n*/\nTuple!(long, long, long, Nullable!(long[string])) add_dict_to_tuple(Tuple!(long, long, long) test_tup, Nullable!(long[string]) test_dict) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_dict_to_tuple;\n\n    assert(candidate(tuple(4L, 5L, 6L), [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable) == tuple(4L, 5L, 6L, [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable));\n    assert(candidate(tuple(1L, 2L, 3L), [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable) == tuple(1L, 2L, 3L, [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable));\n    assert(candidate(tuple(8L, 9L, 10L), [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable) == tuple(8L, 9L, 10L, [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find quotient of two numbers (rounded down to the nearest integer).\n\t\n*/\nlong find(long n, long m) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find;\n\n    assert(candidate(10L, 3L) == 3L);\n    assert(candidate(4L, 2L) == 2L);\n    assert(candidate(20L, 5L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\n*/\nbool text_match_two_three(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_two_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count number items that are identical in the same position of three given arrays.\n\t\n*/\nlong count_samepair(long[] list1, long[] list2, long[] list3) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_samepair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 9L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 2L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\n*/\nbool text_match_one(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abba\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\n*/\nlong difference(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = difference;\n\n    assert(candidate(3L) == 30L);\n    assert(candidate(5L) == 210L);\n    assert(candidate(2L) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to toggle the case of all characters in a string.\n\t\n*/\nstring toggle_string(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = toggle_string;\n\n    assert(candidate(\"Python\") == \"pYTHON\");\n    assert(candidate(\"Pangram\") == \"pANGRAM\");\n    assert(candidate(\"LIttLE\") == \"liTTle\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the Eulerian number a(n, m).\n\t\n*/\nlong eulerian_num(long n, long m) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = eulerian_num;\n\n    assert(candidate(3L, 1L) == 4L);\n    assert(candidate(4L, 1L) == 11L);\n    assert(candidate(5L, 3L) == 26L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurrences of a number in a given array.\n\t\n*/\nlong frequency(long[] a, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = frequency;\n\n    assert(candidate([1L, 2L, 3L], 4L) == 0L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 3L, 4L], 3L) == 3L);\n    assert(candidate([0L, 1L, 2L, 3L, 1L, 2L], 1L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/dthon-sort-numeric-strings-in-a-array/\n\t\n*/\nlong[] sort_numeric_strings(string[] nums_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_numeric_strings;\n\n    assert(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500L, -12L, 0L, 4L, 7L, 12L, 45L, 100L, 200L]);\n    assert(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1L, 1L, 1L, 2L, 2L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 8L, 9L, 9L]);\n    assert(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1L, 1L, 1L, 3L, 3L, 5L, 5L, 7L, 7L, 9L, 11L, 13L, 15L, 17L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/dthon-exercises/data-structures-and-algorithms/dthon-recursion-exercise-9.php\n\t\n*/\nfloat geometric_sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = geometric_sum;\n\n    assert(candidate(7L) == 1.9921875);\n    assert(candidate(4L) == 1.9375);\n    assert(candidate(8L) == 1.99609375);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/dthon-exercises/lambda/dthon-lambda-exercise-24.php\n\t\n*/\nlong[] divisible_by_digits(long startnum, long endnum) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = divisible_by_digits;\n\n    assert(candidate(1L, 22L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L, 22L]);\n    assert(candidate(1L, 15L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L]);\n    assert(candidate(20L, 25L) == [22L, 24L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to calculate the product of the unique numbers in a given array.\n\t\n*/\nlong unique_product(long[] list_data) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = unique_product;\n\n    assert(candidate([10L, 20L, 30L, 40L, 20L, 50L, 60L, 40L]) == 720000000L);\n    assert(candidate([1L, 2L, 3L, 1L]) == 6L);\n    assert(candidate([7L, 8L, 9L, 0L, 1L, 1L]) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the largest negative number from the given array.\n\t\n*/\nlong largest_neg(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = largest_neg;\n\n    assert(candidate([1L, 2L, 3L, -4L, -6L]) == -6L);\n    assert(candidate([1L, 2L, 3L, -8L, -9L]) == -9L);\n    assert(candidate([1L, 2L, 3L, 4L, -1L]) == -1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\n*/\nfloat min_Jumps(Tuple!(long, long) steps, long d) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = min_Jumps;\n\n    assert(candidate(tuple(3L, 4L), 11L) == 3.5);\n    assert(candidate(tuple(3L, 4L), 0L) == 0L);\n    assert(candidate(tuple(11L, 14L), 11L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find a pair with highest product from a given array of integers.\n\t\n*/\nTuple!(long, long) max_Product(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_Product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 7L, 0L, 8L, 4L]) == tuple(7L, 8L));\n    assert(candidate([0L, -1L, -2L, -4L, 5L, 0L, -6L]) == tuple(-4L, -6L));\n    assert(candidate([1L, 2L, 3L]) == tuple(2L, 3L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth nonagonal number.\n\t\n*/\nlong is_nonagonal(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_nonagonal;\n\n    assert(candidate(10L) == 325L);\n    assert(candidate(15L) == 750L);\n    assert(candidate(18L) == 1089L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the maximum difference between any two elements in a given array.\n\t\n*/\nlong max_Abs_Diff(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_Abs_Diff;\n\n    assert(candidate([2L, 1L, 5L, 3L]) == 4L);\n    assert(candidate([9L, 3L, 2L, 5L, 1L]) == 8L);\n    assert(candidate([3L, 2L, 1L]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of perrin numbers.\n\t\n*/\nlong cal_sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = cal_sum;\n\n    assert(candidate(9L) == 49L);\n    assert(candidate(10L) == 66L);\n    assert(candidate(11L) == 88L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove the characters which have odd index values of a given string.\n\t\n*/\nstring odd_values_string(string str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = odd_values_string;\n\n    assert(candidate(\"abcdef\") == \"ace\");\n    assert(candidate(\"python\") == \"pto\");\n    assert(candidate(\"data\") == \"dt\");\n    assert(candidate(\"lambs\") == \"lms\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\n*/\nlong find_kth(long[] arr1, long[] arr2, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_kth;\n\n    assert(candidate([2L, 3L, 6L, 7L, 9L], [1L, 4L, 8L, 10L], 5L) == 6L);\n    assert(candidate([100L, 112L, 256L, 349L, 770L], [72L, 86L, 113L, 119L, 265L, 445L, 892L], 7L) == 256L);\n    assert(candidate([3L, 4L, 7L, 8L, 10L], [2L, 5L, 9L, 11L], 6L) == 8L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\n*/\nlong jacobsthal_num(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = jacobsthal_num;\n\n    assert(candidate(5L) == 11L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 5L);\n    assert(candidate(13L) == 2731L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find frequency of each element in a flattened array of arrays, returned in an associative array.\n\t\n*/\nNullable!(long[long]) frequency_lists(long[][] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = frequency_lists;\n\n{\n        auto result = candidate([[1L, 2L, 3L, 2L], [4L, 5L, 6L, 2L], [7L, 8L, 9L, 5L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 3L, 3L: 1L, 4L: 1L, 5L: 2L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L]);\n}\n\n{\n        auto result = candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 1L, 3L: 1L, 4L: 1L, 5L: 1L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L, 10L: 1L, 11L: 1L, 12L: 1L]);\n}\n\n{\n        auto result = candidate([[20L, 30L, 40L, 17L], [18L, 16L, 14L, 13L], [10L, 20L, 30L, 40L]]);\n        assert(!result.isNull && result.get == [20L: 2L, 30L: 2L, 40L: 2L, 17L: 1L, 18L: 1L, 16L: 1L, 14L: 1L, 13L: 1L, 10L: 1L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find perfect squares between two given numbers.\n\t\n*/\nlong[] perfect_squares(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = perfect_squares;\n\n    assert(candidate(1L, 30L) == [1L, 4L, 9L, 16L, 25L]);\n    assert(candidate(50L, 100L) == [64L, 81L, 100L]);\n    assert(candidate(100L, 200L) == [100L, 121L, 144L, 169L, 196L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\n*/\nlong sum_Of_Subarray_Prod(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_Of_Subarray_Prod;\n\n    assert(candidate([1L, 2L, 3L]) == 20L);\n    assert(candidate([1L, 2L]) == 5L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 84L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first odd number in a given array of numbers.\n\t\n*/\nlong first_odd(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = first_odd;\n\n    assert(candidate([1L, 3L, 5L]) == 1L);\n    assert(candidate([2L, 4L, 1L, 3L]) == 1L);\n    assert(candidate([8L, 9L, 1L]) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise addition of array elements in the given two nested arrays.\n\t\n*/\nlong[][] add_nested_tuples(long[][] test_tup1, long[][] test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_nested_tuples;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[7L, 10L], [7L, 14L], [3L, 10L], [8L, 13L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[9L, 12L], [9L, 16L], [5L, 12L], [10L, 15L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[11L, 14L], [11L, 18L], [7L, 14L], [12L, 17L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number can be represented as the difference of two squares or not.\n\t\n*/\nbool dif_Square(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = dif_Square;\n\n    assert(candidate(5L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(15L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\n*/\nbool check_smaller(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_smaller;\n\n    assert(candidate(tuple(1L, 2L, 3L), tuple(2L, 3L, 4L)) == false);\n    assert(candidate(tuple(4L, 5L, 6L), tuple(3L, 4L, 5L)) == true);\n    assert(candidate(tuple(11L, 12L, 13L), tuple(10L, 11L, 12L)) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the frequency of all the elements in an array, returned as an associative array.\n\t\n*/\nNullable!(long[long]) freq_count(long[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = freq_count;\n\n{\n        auto result = candidate([10L, 10L, 10L, 10L, 20L, 20L, 20L, 20L, 40L, 40L, 50L, 50L, 30L]);\n        assert(!result.isNull && result.get == [10L: 4L, 20L: 4L, 40L: 2L, 50L: 2L, 30L: 1L]);\n}\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 3L, 2L, 4L, 1L, 3L, 1L, 4L]);\n        assert(!result.isNull && result.get == [1L: 3L, 2L: 2L, 3L: 3L, 4L: 3L]);\n}\n\n{\n        auto result = candidate([5L, 6L, 7L, 4L, 9L, 10L, 4L, 5L, 6L, 7L, 9L, 5L]);\n        assert(!result.isNull && result.get == [10L: 1L, 5L: 3L, 6L: 2L, 7L: 2L, 4L: 2L, 9L: 2L]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\n*/\nfloat[] rgb_to_hsv(long r, long g, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rgb_to_hsv;\n\n    assert(candidate(255L, 255L, 255L) == [0.0, 0.0, 100.0]);\n    assert(candidate(0L, 215L, 0L) == [120.0, 100.0, 84.31372549019608]);\n    assert(candidate(10L, 215L, 110L) == [149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\n*/\nbool check_str(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_str;\n\n    assert(candidate(\"annie\") == true);\n    assert(candidate(\"dawood\") == false);\n    assert(candidate(\"Else\") == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\n*/\nbool check_monthnumber_number(long monthnum3) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_monthnumber_number;\n\n    assert(candidate(6L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(12L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given array.\n\t\n*/\nlong[] heap_sort(long[] iterable) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = heap_sort;\n\n    assert(candidate([1L, 3L, 5L, 7L, 9L, 2L, 4L, 6L, 8L, 0L]) == [0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L]) == [14L, 22L, 25L, 25L, 35L, 58L, 65L, 75L, 85L]);\n    assert(candidate([7L, 1L, 9L, 5L]) == [1L, 5L, 7L, 9L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\n*/\nlong[][] k_smallest_pairs(long[] nums1, long[] nums2, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = k_smallest_pairs;\n\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 2L) == [[1L, 2L], [1L, 4L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 1L) == [[1L, 2L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 7L) == [[1L, 2L], [1L, 4L], [3L, 2L], [1L, 6L], [3L, 4L], [3L, 6L], [7L, 2L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return null if no solution exists.\n\t\n*/\nNullable!(Tuple!(long, long)) find_solution(long a, long b, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_solution;\n\n{\n        auto result = candidate(2L, 3L, 7L);\n        assert(!result.isNull && result.get == tuple(2L, 1L));\n}\n\n{\n        auto result = candidate(4L, 2L, 7L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(1L, 13L, 17L);\n        assert(!result.isNull && result.get == tuple(4L, 1L));\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the largest number that can be formed with the given array of digits.\n\t\n*/\nlong find_Max_Num(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Max_Num;\n\n    assert(candidate([1L, 2L, 3L]) == 321L);\n    assert(candidate([4L, 5L, 6L, 1L]) == 6541L);\n    assert(candidate([1L, 2L, 3L, 9L]) == 9321L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the array in an array of arrays whose sum of elements is the highest.\n\t\n*/\nlong[] max_sum_list(long[][] lists) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_sum_list;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [10L, 11L, 12L], [7L, 8L, 9L]]) == [10L, 11L, 12L]);\n    assert(candidate([[3L, 2L, 1L], [6L, 5L, 4L], [12L, 11L, 10L]]) == [12L, 11L, 10L]);\n    assert(candidate([[2L, 3L, 1L]]) == [2L, 3L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to interchange the first and last elements in an array.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([12L, 35L, 9L, 56L, 24L]) == [24L, 35L, 9L, 56L, 12L]);\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of two sorted arrays of same size.\n\t\n*/\nfloat get_median(long[] arr1, long[] arr2, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_median;\n\n    assert(candidate([1L, 12L, 15L, 26L, 38L], [2L, 13L, 17L, 30L, 45L], 5L) == 16.0);\n    assert(candidate([2L, 4L, 8L, 9L], [7L, 13L, 19L, 28L], 4L) == 8.5);\n    assert(candidate([3L, 6L, 14L, 23L, 36L, 42L], [2L, 18L, 27L, 39L, 49L, 55L], 6L) == 25.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\n*/\nstring replace_spaces(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\");\n    assert(candidate(\"The_Avengers\") == \"The Avengers\");\n    assert(candidate(\"Fast and Furious\") == \"Fast_and_Furious\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\n*/\nbool are_equivalent(long num1, long num2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = are_equivalent;\n\n    assert(candidate(36L, 57L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(23L, 47L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse each string in a given array of string values.\n\t\n*/\nstring[] reverse_string_list(string[] stringlist) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = reverse_string_list;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n    assert(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n    assert(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\n*/\nlong sequence(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sequence;\n\n    assert(candidate(10L) == 6L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(3L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n largest integers from a given array of numbers, returned in descending order.\n\t\n*/\nlong[] heap_queue_largest(long[] nums, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = heap_queue_largest;\n\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 3L) == [85L, 75L, 65L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 2L) == [85L, 75L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 5L) == [85L, 75L, 65L, 58L, 35L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\n*/\nlong loss_amount(long actual_cost, long sale_amount) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = loss_amount;\n\n    assert(candidate(1500L, 1200L) == 0L);\n    assert(candidate(100L, 200L) == 100L);\n    assert(candidate(2000L, 5000L) == 3000L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the union of the elements of two given arrays and output them in sorted order.\n\t\n*/\nlong[] union_elements(long[] test_tup1, long[] test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = union_elements;\n\n    assert(candidate([3L, 4L, 5L, 6L], [5L, 7L, 4L, 10L]) == [3L, 4L, 5L, 6L, 7L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], [3L, 4L, 5L, 6L]) == [1L, 2L, 3L, 4L, 5L, 6L]);\n    assert(candidate([11L, 12L, 13L, 14L], [13L, 15L, 16L, 17L]) == [11L, 12L, 13L, 14L, 15L, 16L, 17L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the longest subarrays.\n\t\n*/\nlong Find_Max_Length(long[][] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Find_Max_Length;\n\n    assert(candidate([[1L], [1L, 4L], [5L, 6L, 7L, 8L]]) == 4L);\n    assert(candidate([[0L, 1L], [2L, 2L], [3L, 2L, 1L]]) == 3L);\n    assert(candidate([[7L], [22L, 23L], [13L, 14L, 15L], [10L, 20L, 30L, 40L, 50L]]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\n*/\nstring remove_parenthesis(string[] items) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_parenthesis;\n\n    assert(candidate([\"python (chrome)\"]) == \"python\");\n    assert(candidate([\"string(.abc)\"]) == \"string\");\n    assert(candidate([\"alpha(num)\"]) == \"alpha\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find whether the parity of a given number is odd.\n\t\n*/\nbool find_Parity(long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Parity;\n\n    assert(candidate(12L) == false);\n    assert(candidate(7L) == true);\n    assert(candidate(10L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median length of a trapezium.\n\t\n*/\nfloat median_trapezium(long base1, long base2, long height) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = median_trapezium;\n\n    assert(candidate(15L, 25L, 35L) == 20L);\n    assert(candidate(10L, 20L, 30L) == 15L);\n    assert(candidate(6L, 9L, 4L) == 7.5);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth centered hexagonal number.\n\t\n*/\nlong centered_hexagonal_number(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = centered_hexagonal_number;\n\n    assert(candidate(10L) == 271L);\n    assert(candidate(2L) == 7L);\n    assert(candidate(9L) == 217L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\n*/\nlong get_max_sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_max_sum;\n\n    assert(candidate(60L) == 106L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the longest word.\n\t\n*/\nlong len_log(string[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = len_log;\n\n    assert(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7L);\n    assert(candidate([\"a\", \"ab\", \"abc\"]) == 3L);\n    assert(candidate([\"small\", \"big\", \"tall\"]) == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n\t\n*/\nNullable!(float) sector_area(long r, long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sector_area;\n\n{\n        auto result = candidate(4L, 45L);\n        assert(!result.isNull && result.get == 6.283185307179586);\n}\n\n{\n        auto result = candidate(9L, 45L);\n        assert(!result.isNull && result.get == 31.808625617596654);\n}\n\n{\n        auto result = candidate(9L, 361L);\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether every odd index contains odd numbers of a given array.\n\t\n*/\nbool odd_position(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = odd_position;\n\n    assert(candidate([2L, 1L, 4L, 3L, 6L, 7L, 6L, 3L]) == true);\n    assert(candidate([4L, 1L, 2L]) == true);\n    assert(candidate([1L, 2L, 3L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to join an array of multiple integers into a single integer.\n\t\n*/\nlong multiple_to_single(long[] L) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = multiple_to_single;\n\n    assert(candidate([11L, 33L, 50L]) == 113350L);\n    assert(candidate([-1L, 2L, 3L, 4L, 5L, 6L]) == -123456L);\n    assert(candidate([10L, 15L, 20L, 25L]) == 10152025L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find whether a number is divisible by 11.\n\t\n*/\nbool is_Diff(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_Diff;\n\n    assert(candidate(12345L) == false);\n    assert(candidate(1212112L) == true);\n    assert(candidate(1212L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise multiplication of array elements in the given two arrays.\n\t\n*/\nlong[][] index_multiplication(long[][] test_tup1, long[][] test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = index_multiplication;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 21L], [12L, 45L], [2L, 9L], [7L, 30L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[14L, 32L], [20L, 60L], [6L, 20L], [16L, 44L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[24L, 45L], [30L, 77L], [12L, 33L], [27L, 60L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert tuple string to integer tuple.\n\t\n*/\nTuple!(long, long, long) tuple_str_int(string test_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tuple_str_int;\n\n    assert(candidate(\"(7, 8, 9)\") == tuple(7L, 8L, 9L));\n    assert(candidate(\"(1, 2, 3)\") == tuple(1L, 2L, 3L));\n    assert(candidate(\"(4, 5, 6)\") == tuple(4L, 5L, 6L));\n    assert(candidate(\"(7, 81, 19)\") == tuple(7L, 81L, 19L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\n*/\nlong amicable_numbers_sum(long limit) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = amicable_numbers_sum;\n\n    assert(candidate(999L) == 504L);\n    assert(candidate(9999L) == 31626L);\n    assert(candidate(99L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove odd characters in a string.\n\t\n*/\nstring remove_odd(string str1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate(\"python\") == \"yhn\");\n    assert(candidate(\"program\") == \"rga\");\n    assert(candidate(\"language\") == \"agae\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\n*/\nlong count_rotation(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_rotation;\n\n    assert(candidate([3L, 2L, 1L]) == 1L);\n    assert(candidate([4L, 5L, 1L, 2L, 3L]) == 2L);\n    assert(candidate([7L, 8L, 9L, 1L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 2L, 3L]) == 0L);\n    assert(candidate([1L, 3L, 2L]) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the number of unique tuples in the given array.\n\t\n*/\nlong extract_freq(Tuple!(long, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = extract_freq;\n\n    assert(candidate([tuple(3L, 4L), tuple(1L, 2L), tuple(4L, 3L), tuple(5L, 6L)]) == 3L);\n    assert(candidate([tuple(4L, 15L), tuple(2L, 3L), tuple(5L, 4L), tuple(6L, 7L)]) == 4L);\n    assert(candidate([tuple(5L, 16L), tuple(2L, 3L), tuple(6L, 5L), tuple(6L, 9L)]) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tThe input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\n\t\n*/\nlong count_same_pair(long[] nums1, long[] nums2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_same_pair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L]) == 4L);\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 11L);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 1L);\n    assert(candidate([0L, 1L, 1L, 2L], [0L, 1L, 2L, 2L]) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\n*/\nlong power(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = power;\n\n    assert(candidate(3L, 4L) == 81L);\n    assert(candidate(2L, 3L) == 8L);\n    assert(candidate(5L, 5L) == 3125L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite function to find the sum of all items in the given associative array.\n\t\n*/\nlong return_sum(Nullable!(long[string]) dict) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = return_sum;\n\n    assert(candidate([\"a\": 100L, \"b\": 200L, \"c\": 300L].nullable) == 600L);\n    assert(candidate([\"a\": 25L, \"b\": 18L, \"c\": 45L].nullable) == 88L);\n    assert(candidate([\"a\": 36L, \"b\": 39L, \"c\": 49L].nullable) == 124L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return an array of all pairs of consecutive items in a given array.\n\t\n*/\nTuple!(long, long)[] pair_wise(long[] l1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pair_wise;\n\n    assert(candidate([1L, 1L, 2L, 3L, 3L, 4L, 4L, 5L]) == [tuple(1L, 1L), tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 3L), tuple(3L, 4L), tuple(4L, 4L), tuple(4L, 5L)]);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == [tuple(1L, 5L), tuple(5L, 7L), tuple(7L, 9L), tuple(9L, 10L)]);\n    assert(candidate([5L, 1L, 9L, 7L, 10L]) == [tuple(5L, 1L), tuple(1L, 9L), tuple(9L, 7L), tuple(7L, 10L)]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 4L), tuple(4L, 5L), tuple(5L, 6L), tuple(6L, 7L), tuple(7L, 8L), tuple(8L, 9L), tuple(9L, 10L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to split a string into characters.\n\t\n*/\nstring[] split(string word) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = split;\n\n    assert(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n    assert(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"]);\n    assert(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum of three numbers.\n\t\n*/\nlong min_of_three(long a, long b, long c) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = min_of_three;\n\n    assert(candidate(10L, 20L, 0L) == 0L);\n    assert(candidate(19L, 15L, 18L) == 15L);\n    assert(candidate(-10L, -20L, -30L) == -30L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\n*/\nbool is_Sum_Of_Powers_Of_Two(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_Sum_Of_Powers_Of_Two;\n\n    assert(candidate(10L) == true);\n    assert(candidate(7L) == false);\n    assert(candidate(14L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\n*/\nstring get_Char(string strr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_Char;\n\n    assert(candidate(\"abc\") == \"f\");\n    assert(candidate(\"gfg\") == \"t\");\n    assert(candidate(\"ab\") == \"c\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return the sum of all divisors of a number.\n\t\n*/\nlong sum_div(long number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_div;\n\n    assert(candidate(8L) == 7L);\n    assert(candidate(12L) == 16L);\n    assert(candidate(7L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove duplicate numbers from a given number of arrays.\n\t\n*/\nlong[] two_unique_nums(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = two_unique_nums;\n\n    assert(candidate([1L, 2L, 3L, 2L, 3L, 4L, 5L]) == [1L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 5L]) == [1L, 3L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\n*/\nbool test_duplicate(long[] arraynums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = test_duplicate;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == true);\n    assert(candidate([1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L]) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which returns nth catalan number.\n\t\n*/\nlong catalan_number(long num) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = catalan_number;\n\n    assert(candidate(10L) == 16796L);\n    assert(candidate(9L) == 4862L);\n    assert(candidate(7L) == 429L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\n*/\nlong power_base_sum(long base, long power) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = power_base_sum;\n\n    assert(candidate(2L, 100L) == 115L);\n    assert(candidate(8L, 10L) == 37L);\n    assert(candidate(8L, 15L) == 62L);\n    assert(candidate(3L, 3L) == 9L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth octagonal number.\n\t\n*/\nlong is_octagonal(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_octagonal;\n\n    assert(candidate(5L) == 65L);\n    assert(candidate(10L) == 280L);\n    assert(candidate(15L) == 645L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\n*/\nstring replace_blank(string str1, string char) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = replace_blank;\n\n    assert(candidate(\"hello people\", \"@\") == \"hello@people\");\n    assert(candidate(\"python program language\", \"$\") == \"python$program$language\");\n    assert(candidate(\"blank space\", \"-\") == \"blank-space\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\n*/\nstring replace_specialchar(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = replace_specialchar;\n\n    assert(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\");\n    assert(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\");\n    assert(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = check_integer;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"1\") == true);\n    assert(candidate(\"12345\") == true);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -3874,444 +154,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\n*/\nlong tuple_to_int(Tuple!(long, long, long) nums) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = tuple_to_int;\n\n    assert(candidate(tuple(1L, 2L, 3L)) == 123L);\n    assert(candidate(tuple(4L, 5L, 6L)) == 456L);\n    assert(candidate(tuple(5L, 6L, 7L)) == 567L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the third side of a right angled triangle.\n\t\n*/\nfloat otherside_rightangle(long w, long h) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = otherside_rightangle;\n\n    assert(candidate(7L, 8L) == 10.63014581273465);\n    assert(candidate(3L, 4L) == 5L);\n    assert(candidate(7L, 15L) == 16.55294535724685);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\n*/\nNone[] expensive_items(None[] items, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = expensive_items;\n\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable], 2L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-1\", \"price\": 101.1].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable, [\"name\": \"Item-4\", \"price\": 22.75].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the per-digit difference between two integers.\n\t\n*/\nlong digit_distance_nums(long n1, long n2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = digit_distance_nums;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(23L, 56L) == 6L);\n    assert(candidate(123L, 256L) == 7L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\n*/\nbool text_match_wordz_middle(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_match_wordz_middle;\n\n    assert(candidate(\"pythonzabc.\") == true);\n    assert(candidate(\"zxyabc.\") == false);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove leading zeroes from an ip address.\n\t\n*/\nstring removezero_ip(string ip) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = removezero_ip;\n\n    assert(candidate(\"216.08.094.196\") == \"216.8.94.196\");\n    assert(candidate(\"12.01.024\") == \"12.1.24\");\n    assert(candidate(\"216.08.094.0196\") == \"216.8.94.196\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to multiply two integers.\n\t\n*/\nlong multiply_int(long x, long y) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = multiply_int;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(5L, 10L) == 50L);\n    assert(candidate(4L, 8L) == 32L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\n*/\nTuple!(long, long, long, long) add_pairwise(Tuple!(long, long, long, long, long) test_tup) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_pairwise;\n\n    assert(candidate(tuple(1L, 5L, 7L, 8L, 10L)) == tuple(6L, 12L, 15L, 18L));\n    assert(candidate(tuple(2L, 6L, 8L, 9L, 11L)) == tuple(8L, 14L, 17L, 20L));\n    assert(candidate(tuple(3L, 7L, 9L, 10L, 12L)) == tuple(10L, 16L, 19L, 22L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given array.\n\t\n*/\nlong max_product_tuple(Tuple!(long, long)[] list1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 36L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 200L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 484L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_101_kth_element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\n*/\nlong kth_element(long[] arr, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = kth_element;\n\n    assert(candidate([12L, 3L, 5L, 7L, 19L], 2L) == 3L);\n    assert(candidate([17L, 24L, 8L, 23L], 3L) == 8L);\n    assert(candidate([16L, 21L, 25L, 36L, 4L], 4L) == 36L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_625_swap_List",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to interchange the first and last element in a given array.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == [4L, 2L, 3L, 4L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_786_right_insertion",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\n*/\nlong right_insertion(long[] a, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = right_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_20_is_woodall",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given number is woodball or not.\n\t\n*/\nbool is_woodall(long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_woodall;\n\n    assert(candidate(383L) == true);\n    assert(candidate(254L) == false);\n    assert(candidate(200L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_428_shell_sort",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given array by using shell sort.\n\t\n*/\nlong[] shell_sort(long[] my_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = shell_sort;\n\n    assert(candidate([12L, 23L, 4L, 5L, 3L, 2L, 12L, 81L, 56L, 95L]) == [2L, 3L, 4L, 5L, 12L, 12L, 23L, 56L, 81L, 95L]);\n    assert(candidate([24L, 22L, 39L, 34L, 87L, 73L, 68L]) == [22L, 24L, 34L, 39L, 68L, 73L, 87L]);\n    assert(candidate([32L, 30L, 16L, 96L, 82L, 83L, 74L]) == [16L, 30L, 32L, 74L, 82L, 83L, 96L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_556_find_Odd_Pair",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of pairs whose xor value is odd.\n\t\n*/\nlong find_Odd_Pair(long[] A, long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Odd_Pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L], 5L) == 6L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L], 7L) == 12L);\n    assert(candidate([1L, 2L, 3L], 3L) == 2L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_797_sum_in_range",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of all odd natural numbers within the range l and r.\n\t\n*/\nlong sum_in_range(long l, long r) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_in_range;\n\n    assert(candidate(2L, 5L) == 8L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 13L) == 40L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_17_square_perimeter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\n*/\nlong square_perimeter(long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = square_perimeter;\n\n    assert(candidate(10L) == 40L);\n    assert(candidate(5L) == 20L);\n    assert(candidate(4L) == 16L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_765_is_polite",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\n*/\nlong is_polite(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_polite;\n\n    assert(candidate(7L) == 11L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(9L) == 13L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\n*/\nlong sum_series(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_series;\n\n    assert(candidate(6L) == 12L);\n    assert(candidate(10L) == 30L);\n    assert(candidate(9L) == 25L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) find_dissimilar(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_dissimilar;\n\n    assert(candidate(tuple(3L, 4L, 5L, 6L), tuple(5L, 7L, 4L, 10L)) == tuple(3L, 6L, 7L, 10L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(7L, 2L, 3L, 9L)) == tuple(1L, 4L, 7L, 9L));\n    assert(candidate(tuple(21L, 11L, 25L, 26L), tuple(26L, 34L, 21L, 36L)) == tuple(34L, 36L, 11L, 25L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return two words from an array of words starting with letter 'p'.\n\t\n*/\nTuple!(string, string) start_withp(string[] words) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = start_withp;\n\n    assert(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == tuple(\"Python\", \"PHP\"));\n    assert(candidate([\"Python Programming\", \"Java Programming\"]) == tuple(\"Python\", \"Programming\"));\n    assert(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == tuple(\"Pqrst\", \"Pqr\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"android_tv\") == \"AndroidTv\");\n    assert(candidate(\"google_pixel\") == \"GooglePixel\");\n    assert(candidate(\"apple_watch\") == \"AppleWatch\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the volume of a cube given its side length.\n\t\n*/\nlong volume_cube(long l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = volume_cube;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(2L) == 8L);\n    assert(candidate(5L) == 125L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\n*/\nbool check_monthnumb_number(long monthnum2) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_monthnumb_number;\n\n    assert(candidate(5L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(6L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether all the bits are unset in the given range or not.\n\t\n*/\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = all_Bits_Set_In_The_Given_Range;\n\n    assert(candidate(4L, 1L, 2L) == true);\n    assert(candidate(17L, 2L, 4L) == true);\n    assert(candidate(39L, 4L, 6L) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to get the first element of each subarray.\n\t\n*/\nlong[] Extract(long[][] lst) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = Extract;\n\n    assert(candidate([[1L, 2L], [3L, 4L, 5L], [6L, 7L, 8L, 9L]]) == [1L, 3L, 6L]);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L]]) == [1L, 4L]);\n    assert(candidate([[9L, 8L, 1L], [1L, 2L]]) == [9L, 1L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cylinder.\n\t\n*/\nfloat surfacearea_cylinder(long r, long h) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = surfacearea_cylinder;\n\n    assert(candidate(10L, 5L) == 942.45);\n    assert(candidate(4L, 5L) == 226.18800000000002);\n    assert(candidate(4L, 10L) == 351.848);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\n\t\n*/\nlong sample_nam(string[] sample_names) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sample_nam;\n\n    assert(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16L);\n    assert(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10L);\n    assert(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\n*/\nlong perimeter_pentagon(long a) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = perimeter_pentagon;\n\n    assert(candidate(5L) == 25L);\n    assert(candidate(10L) == 50L);\n    assert(candidate(15L) == 75L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\n*/\nlong max_sum(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_sum;\n\n    assert(candidate([1L, 15L, 51L, 45L, 33L, 100L, 12L, 18L, 9L]) == 194L);\n    assert(candidate([80L, 60L, 30L, 40L, 20L, 10L]) == 210L);\n    assert(candidate([2L, 3L, 14L, 16L, 21L, 23L, 29L, 30L]) == 138L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4324,219 +169,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert all possible convertible elements in an array of arrays to floats.\n\t\n*/\nTuple!(float, float)[] list_to_float(Tuple!(string, string)[] test_list) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = list_to_float;\n\n    assert(candidate([tuple(\"3\", \"4\"), tuple(\"1\", \"26.45\"), tuple(\"7.32\", \"8\"), tuple(\"4\", \"8\")]) == [tuple(3.0, 4.0), tuple(1.0, 26.45), tuple(7.32, 8.0), tuple(4.0, 8.0)]);\n    assert(candidate([tuple(\"4\", \"4\"), tuple(\"2\", \"27\"), tuple(\"4.12\", \"9\"), tuple(\"7\", \"11\")]) == [tuple(4.0, 4.0), tuple(2.0, 27.0), tuple(4.12, 9.0), tuple(7.0, 11.0)]);\n    assert(candidate([tuple(\"6\", \"78\"), tuple(\"5\", \"26.45\"), tuple(\"1.33\", \"4\"), tuple(\"82\", \"13\")]) == [tuple(6.0, 78.0), tuple(5.0, 26.45), tuple(1.33, 4.0), tuple(82.0, 13.0)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 20L);\n    assert(candidate(3L) == 56L);\n    assert(candidate(4L) == 120L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\n\t\n*/\nlong get_pairs_count(long[] arr, long sum) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_pairs_count;\n\n    assert(candidate([1L, 1L, 1L, 1L], 2L) == 6L);\n    assert(candidate([1L, 5L, 7L, -1L, 5L], 6L) == 3L);\n    assert(candidate([1L, -2L, 3L], 1L) == 1L);\n    assert(candidate([-1L, -2L, 3L], -3L) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\n*/\nlong count_no_of_ways(long n, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_no_of_ways;\n\n    assert(candidate(2L, 4L) == 16L);\n    assert(candidate(3L, 2L) == 6L);\n    assert(candidate(4L, 4L) == 228L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\n*/\nstring reverse_words(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = reverse_words;\n\n    assert(candidate(\"python program\") == \"program python\");\n    assert(candidate(\"java language\") == \"language java\");\n    assert(candidate(\"indian man\") == \"man indian\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check if a given number is one less than twice its reverse.\n\t\n*/\nbool checks(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = checks;\n\n    assert(candidate(70L) == false);\n    assert(candidate(23L) == false);\n    assert(candidate(73L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last position of an element in a sorted array.\n\t\n*/\nlong last(long[] arr, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = last;\n\n    assert(candidate([1L, 2L, 3L], 1L) == 0L);\n    assert(candidate([1L, 1L, 1L, 2L, 3L, 4L], 1L) == 2L);\n    assert(candidate([2L, 3L, 2L, 3L, 6L, 8L, 9L], 3L) == 3L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a tuple and an element and counts the occcurences of the element in the array.\n\t\n*/\nlong count_X(long[] tup, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_X;\n\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 4L) == 0L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 10L) == 3L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 8L) == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\n*/\nstring concatenate_tuple(Tuple!(string, string, long, string) test_tup) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = concatenate_tuple;\n\n    assert(candidate(tuple(\"ID\", \"is\", 4L, \"UTS\")) == \"ID-is-4-UTS\");\n    assert(candidate(tuple(\"QWE\", \"is\", 4L, \"RTY\")) == \"QWE-is-4-RTY\");\n    assert(candidate(tuple(\"ZEN\", \"is\", 4L, \"OP\")) == \"ZEN-is-4-OP\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\n*/\nstring replace_spaces(string string) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\");\n    assert(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\");\n    assert(candidate(\"I love Coding\") == \"I%20love%20Coding\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of numbers in an array within a range specified by two indices.\n\t\n*/\nlong sum_range_list(long[] list1, long m, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sum_range_list;\n\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 8L, 10L) == 29L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 5L, 7L) == 16L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 7L, 10L) == 38L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three dictionaries into a single associative array.\n\t\n*/\nNullable!(string[string]) merge_dictionaries_three(Nullable!(string[string]) dict1, Nullable!(string[string]) dict2, Nullable!(string[string]) dict3) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = merge_dictionaries_three;\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable);\n        assert(!result.isNull && result.get == [\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"]);\n}\n\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum of two numbers.\n\t\n*/\nlong minimum(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = minimum;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(-5L, -4L) == -5L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between available pairs in the given tuple array.\n\t\n*/\nlong max_difference(Tuple!(long, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_difference;\n\n    assert(candidate([tuple(3L, 5L), tuple(1L, 7L), tuple(10L, 3L), tuple(1L, 2L)]) == 7L);\n    assert(candidate([tuple(4L, 6L), tuple(2L, 17L), tuple(9L, 13L), tuple(11L, 12L)]) == 15L);\n    assert(candidate([tuple(12L, 35L), tuple(21L, 27L), tuple(13L, 23L), tuple(41L, 22L)]) == 23L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find element at a given index after number of rotations.\n\t\n*/\nlong find_Element(long[] arr, long[][] ranges, long rotations, long index) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_Element;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [[0L, 2L], [0L, 3L]], 2L, 1L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L], [[0L, 1L], [0L, 2L]], 1L, 2L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [[0L, 1L], [0L, 2L]], 1L, 1L) == 1L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4549,7 +184,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a string to an array of strings split on the space character.\n\t\n*/\nstring[] string_to_list(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = string_to_list;\n\n    assert(candidate(\"python programming\") == [\"python\", \"programming\"]);\n    assert(candidate(\"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"]);\n    assert(candidate(\"write a program\") == [\"write\", \"a\", \"program\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4564,24 +199,9 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the element that appears only once in a sorted array.\n\t\n*/\nlong search(long[] arr) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = search;\n\n    assert(candidate([1L, 1L, 2L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 1L, 3L, 3L, 4L, 4L, 5L, 5L, 7L, 7L, 8L]) == 8L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 4L, 4L]) == 1L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an associative array by value.\n\t\n*/\nTuple!(string, long)[] sort_counter(Nullable!(long[string]) dict1) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_counter;\n\n    assert(candidate([\"Math\": 81L, \"Physics\": 83L, \"Chemistry\": 87L].nullable) == [tuple(\"Chemistry\", 87L), tuple(\"Physics\", 83L), tuple(\"Math\", 81L)]);\n    assert(candidate([\"Math\": 400L, \"Physics\": 300L, \"Chemistry\": 250L].nullable) == [tuple(\"Math\", 400L), tuple(\"Physics\", 300L), tuple(\"Chemistry\", 250L)]);\n    assert(candidate([\"Math\": 900L, \"Physics\": 1000L, \"Chemistry\": 1250L].nullable) == [tuple(\"Chemistry\", 1250L), tuple(\"Physics\", 1000L), tuple(\"Math\", 900L)]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4594,7 +214,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove first and last occurrence of a given character from the string.\n\t\n*/\nstring remove_Occ(string s, string ch) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = remove_Occ;\n\n    assert(candidate(\"hello\", \"l\") == \"heo\");\n    assert(candidate(\"abcda\", \"a\") == \"bcd\");\n    assert(candidate(\"PHP\", \"P\") == \"H\");\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4605,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\n*/\nlong lateralsurface_cube(long l) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given array.\n\t\n*/\nlong max_product_tuple(Tuple!(long, long)[] list1) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = lateralsurface_cube;\n\n    assert(candidate(5L) == 100L);\n    assert(candidate(9L) == 324L);\n    assert(candidate(10L) == 400L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = max_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 36L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 200L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 484L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4620,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to append the given array to the given tuples.\n\t\n*/\nTuple!(long, long, long, long, long) add_lists(long[] test_list, Tuple!(long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\n*/\nlong amicable_numbers_sum(long limit) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_lists;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == tuple(9L, 10L, 5L, 6L, 7L));\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == tuple(10L, 11L, 6L, 7L, 8L));\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == tuple(11L, 12L, 7L, 8L, 9L));\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = amicable_numbers_sum;\n\n    assert(candidate(999L) == 504L);\n    assert(candidate(9999L) == 31626L);\n    assert(candidate(99L) == 0L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4635,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to compute the n-th power of each number in an array.\n\t\n*/\nlong[] nth_nums(long[] nums, long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\n*/\nlong find_length(string string) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = nth_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L], 3L) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L], 5L) == [248832L, 759375L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = find_length;\n\n    assert(candidate(\"11000010001\") == 6L);\n    assert(candidate(\"10111\") == 1L);\n    assert(candidate(\"11011101100101\") == 2L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4650,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of elements.\n\t\n*/\nlong[] pancake_sort(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of common divisors of two given numbers.\n\t\n*/\nlong sum(long a, long b) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = pancake_sort;\n\n    assert(candidate([15L, 79L, 25L, 38L, 69L]) == [15L, 25L, 38L, 69L, 79L]);\n    assert(candidate([98L, 12L, 54L, 36L, 85L]) == [12L, 36L, 54L, 85L, 98L]);\n    assert(candidate([41L, 42L, 32L, 12L, 23L]) == [12L, 23L, 32L, 41L, 42L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sum;\n\n    assert(candidate(10L, 15L) == 6L);\n    assert(candidate(100L, 150L) == 93L);\n    assert(candidate(4L, 6L) == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4665,283 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of three numbers.\n\t\n*/\nfloat median_numbers(long a, long b, long c) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to multiply two integers.\n\t\n*/\nlong multiply_int(long x, long y) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = median_numbers;\n\n    assert(candidate(25L, 55L, 65L) == 55.0);\n    assert(candidate(20L, 10L, 30L) == 20.0);\n    assert(candidate(15L, 45L, 75L) == 45.0);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\n*/\nbool check_greater(long[] arr, long number) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_greater;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 4L) == false);\n    assert(candidate([2L, 3L, 4L, 5L, 6L], 8L) == true);\n    assert(candidate([9L, 7L, 4L, 8L, 6L, 1L], 11L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract specified size of strings from a given array of string values.\n\t\n*/\nstring[] extract_string(string[] str, long l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = extract_string;\n\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8L) == [\"practice\", \"solution\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6L) == [\"Python\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9L) == [\"exercises\"]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\n*/\nbool text_lowercase_underscore(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = text_lowercase_underscore;\n\n    assert(candidate(\"aab_cbbbc\") == true);\n    assert(candidate(\"aab_Abbbc\") == false);\n    assert(candidate(\"Aaab_abbbc\") == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to trim each array by k in the given arrays.\n\t\n*/\nlong[][] trim_tuple(long[][] test_list, long K) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = trim_tuple;\n\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 2L) == [[2L], [9L], [2L], [2L]]);\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 1L) == [[3L, 2L, 1L], [4L, 9L, 2L], [1L, 2L, 3L], [8L, 2L, 1L]]);\n    assert(candidate([[7L, 8L, 4L, 9L], [11L, 8L, 12L, 4L], [4L, 1L, 7L, 8L], [3L, 6L, 9L, 7L]], 1L) == [[8L, 4L], [8L, 12L], [1L, 7L], [6L, 9L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to filter odd numbers.\n\t\n*/\nlong[] filter_oddnumbers(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = filter_oddnumbers;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 3L, 5L, 7L, 9L]);\n    assert(candidate([10L, 20L, 45L, 67L, 84L, 93L]) == [45L, 67L, 93L]);\n    assert(candidate([5L, 7L, 9L, 8L, 6L, 4L, 3L]) == [5L, 7L, 9L, 3L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\n*/\nstring find_adverbs(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_adverbs;\n\n    assert(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\");\n    assert(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\");\n    assert(candidate(\"Complete the task quickly\") == \"18-25: quickly\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which given a matrix represented as an array of arrays returns the max of the n'th column.\n\t\n*/\nlong max_of_nth(long[][] test_list, long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_of_nth;\n\n    assert(candidate([[5L, 6L, 7L], [1L, 3L, 5L], [8L, 9L, 19L]], 2L) == 19L);\n    assert(candidate([[6L, 7L, 8L], [2L, 4L, 6L], [9L, 10L, 20L]], 1L) == 10L);\n    assert(candidate([[7L, 8L, 9L], [3L, 5L, 7L], [10L, 11L, 21L]], 1L) == 11L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\n*/\nstring decimal_to_binary(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(8L) == \"1000\");\n    assert(candidate(18L) == \"10010\");\n    assert(candidate(7L) == \"111\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\n\t\n*/\nstring[][] combinations_colors(string[] l, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = combinations_colors;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 1L) == [[\"Red\"], [\"Green\"], [\"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 2L) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 3L) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all whitespaces from a string.\n\t\n*/\nstring remove_all_spaces(string text) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_all_spaces;\n\n    assert(candidate(\"python  program\") == \"pythonprogram\");\n    assert(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\");\n    assert(candidate(\"python                     program\") == \"pythonprogram\");\n    assert(candidate(\"   python                     program\") == \"pythonprogram\");\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create a new tuple from the given string and array.\n\t\n*/\nTuple!(string, string, string) new_tuple(string[] test_list, string test_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = new_tuple;\n\n    assert(candidate([\"WEB\", \"is\"], \"best\") == tuple(\"WEB\", \"is\", \"best\"));\n    assert(candidate([\"We\", \"are\"], \"Developers\") == tuple(\"We\", \"are\", \"Developers\"));\n    assert(candidate([\"Part\", \"is\"], \"Wrong\") == tuple(\"Part\", \"is\", \"Wrong\"));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the product of the array multiplication modulo n.\n\t\n*/\nlong find_remainder(long[] arr, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_remainder;\n\n    assert(candidate([100L, 10L, 5L, 25L, 35L, 14L], 11L) == 9L);\n    assert(candidate([1L, 1L, 1L], 1L) == 0L);\n    assert(candidate([1L, 2L, 1L], 2L) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\n*/\nfloat positive_count(long[] nums) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = positive_count;\n\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.54);\n    assert(candidate([2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.69);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == 0.56);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add the given tuple to the given array.\n\t\n*/\nlong[] add_tuple(long[] test_list, Tuple!(long, long) test_tup) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = add_tuple;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == [5L, 6L, 7L, 9L, 10L]);\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == [6L, 7L, 8L, 10L, 11L]);\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == [7L, 8L, 9L, 11L, 12L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\n*/\nlong max_run_uppercase(string test_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_run_uppercase;\n\n    assert(candidate(\"GeMKSForGERksISBESt\") == 5L);\n    assert(candidate(\"PrECIOusMOVemENTSYT\") == 6L);\n    assert(candidate(\"GooGLEFluTTER\") == 4L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\n*/\nlong[][] sort_matrix(long[][] M) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sort_matrix;\n\n    assert(candidate([[1L, 2L, 3L], [2L, 4L, 5L], [1L, 1L, 1L]]) == [[1L, 1L, 1L], [1L, 2L, 3L], [2L, 4L, 5L]]);\n    assert(candidate([[1L, 2L, 3L], [-2L, 4L, -5L], [1L, -1L, 1L]]) == [[-2L, 4L, -5L], [1L, -1L, 1L], [1L, 2L, 3L]]);\n    assert(candidate([[5L, 8L, 9L], [6L, 4L, 3L], [2L, 1L, 4L]]) == [[2L, 1L, 4L], [6L, 4L, 3L], [5L, 8L, 9L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\n*/\nlong count_vowels(string test_str) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_vowels;\n\n    assert(candidate(\"bestinstareels\") == 7L);\n    assert(candidate(\"partofthejourneyistheend\") == 12L);\n    assert(candidate(\"amazonprime\") == 5L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\n*/\nlong max_sum_increasing_subseq(long[] a, long n, long index, long k) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = max_sum_increasing_subseq;\n\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 4L, 6L) == 11L);\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 2L, 5L) == 7L);\n    assert(candidate([11L, 15L, 19L, 21L, 26L, 28L, 31L], 7L, 2L, 4L) == 71L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = multiply_int;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(5L, 10L) == 50L);\n    assert(candidate(4L, 8L) == 32L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4954,7 +304,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find words that are longer than n characters from a given array of words.\n\t\n*/\nstring[] long_words(long n, string str) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = long_words;\n\n    assert(candidate(3L, \"python is a programming language\") == [\"python\", \"programming\", \"language\"]);\n    assert(candidate(2L, \"writing a program\") == [\"writing\", \"program\"]);\n    assert(candidate(5L, \"sorting list\") == [\"sorting\"]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -4965,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of non-repeated elements in a given array.\n\t\n*/\nlong find_sum(long[] arr) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\n*/\nbool magic_square_test(long[][] my_matrix) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_sum;\n\n    assert(candidate([1L, 2L, 3L, 1L, 1L, 4L, 5L, 6L]) == 21L);\n    assert(candidate([1L, 10L, 9L, 4L, 2L, 10L, 10L, 45L, 4L]) == 71L);\n    assert(candidate([12L, 10L, 9L, 45L, 2L, 10L, 10L, 45L, 10L]) == 78L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = magic_square_test;\n\n    assert(candidate([[7L, 12L, 1L, 14L], [2L, 13L, 8L, 11L], [16L, 3L, 10L, 5L], [9L, 6L, 15L, 4L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 8L]]) == true);\n    assert(candidate([[2L, 7L, 6L], [9L, 5L, 1L], [4L, 3L, 7L]]) == false);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4980,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given tuple to a key-value associative array using adjacent elements. https://www.geeksforgeeks.org/dthon-convert-tuple-to-adjacent-pair-associative array/\n\t\n*/\nNullable!(long[long]) tuple_to_dict(Tuple!(long, long, long, long, long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\n*/\nlong[][] sort_matrix(long[][] M) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = tuple_to_dict;\n\n{\n        auto result = candidate(tuple(1L, 5L, 7L, 10L, 13L, 5L));\n        assert(!result.isNull && result.get == [1L: 5L, 7L: 10L, 13L: 5L]);\n}\n\n{\n        auto result = candidate(tuple(1L, 2L, 3L, 4L, 5L, 6L));\n        assert(!result.isNull && result.get == [1L: 2L, 3L: 4L, 5L: 6L]);\n}\n\n{\n        auto result = candidate(tuple(7L, 8L, 9L, 10L, 11L, 12L));\n        assert(!result.isNull && result.get == [7L: 8L, 9L: 10L, 11L: 12L]);\n}\n\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = sort_matrix;\n\n    assert(candidate([[1L, 2L, 3L], [2L, 4L, 5L], [1L, 1L, 1L]]) == [[1L, 1L, 1L], [1L, 2L, 3L], [2L, 4L, 5L]]);\n    assert(candidate([[1L, 2L, 3L], [-2L, 4L, -5L], [1L, -1L, 1L]]) == [[-2L, 4L, -5L], [1L, -1L, 1L], [1L, 2L, 3L]]);\n    assert(candidate([[5L, 8L, 9L], [6L, 4L, 3L], [2L, 1L, 4L]]) == [[2L, 1L, 4L], [6L, 4L, 3L], [5L, 8L, 9L]]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -4995,208 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\n*/\nlong[][] get_coordinates(Tuple!(long, long) test_tup) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the item with maximum frequency in a given array.\n\t\n*/\nlong max_occurrences(long[] nums) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = get_coordinates;\n\n    assert(candidate(tuple(3L, 4L)) == [[2L, 3L], [2L, 4L], [2L, 5L], [3L, 3L], [3L, 4L], [3L, 5L], [4L, 3L], [4L, 4L], [4L, 5L]]);\n    assert(candidate(tuple(4L, 5L)) == [[3L, 4L], [3L, 5L], [3L, 6L], [4L, 4L], [4L, 5L], [4L, 6L], [5L, 4L], [5L, 5L], [5L, 6L]]);\n    assert(candidate(tuple(5L, 6L)) == [[4L, 5L], [4L, 6L], [4L, 7L], [5L, 5L], [5L, 6L], [5L, 7L], [6L, 5L], [6L, 6L], [6L, 7L]]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the smallest missing number from a sorted array of natural numbers.\n\t\n*/\nlong find_First_Missing(long[] array) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_First_Missing;\n\n    assert(candidate([0L, 1L, 2L, 3L]) == 4L);\n    assert(candidate([0L, 1L, 2L, 6L, 9L]) == 3L);\n    assert(candidate([2L, 3L, 5L, 8L, 9L]) == 0L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is undulating or not.\n\t\n*/\nbool is_undulating(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_undulating;\n\n    assert(candidate(1212121L) == true);\n    assert(candidate(1991L) == false);\n    assert(candidate(121L) == true);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum k records from tuple array. https://www.geeksforgeeks.org/dthon-find-minimum-k-records-from-tuple-array/ - in this case a verbatim cod of test cases\n\t\n*/\nTuple!(string, long)[] min_k(Tuple!(string, long)[] test_list, long K) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = min_k;\n\n    assert(candidate([tuple(\"Manjeet\", 10L), tuple(\"Akshat\", 4L), tuple(\"Akash\", 2L), tuple(\"Nikhil\", 8L)], 2L) == [tuple(\"Akash\", 2L), tuple(\"Akshat\", 4L)]);\n    assert(candidate([tuple(\"Sanjeev\", 11L), tuple(\"Angat\", 5L), tuple(\"Akash\", 3L), tuple(\"Nepin\", 9L)], 3L) == [tuple(\"Akash\", 3L), tuple(\"Angat\", 5L), tuple(\"Nepin\", 9L)]);\n    assert(candidate([tuple(\"tanmay\", 14L), tuple(\"Amer\", 11L), tuple(\"Ayesha\", 9L), tuple(\"SKD\", 16L)], 1L) == [tuple(\"Ayesha\", 9L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of substrings with the sum of digits equal to their length.\n\t\n*/\nlong count_Substrings(string s) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_Substrings;\n\n    assert(candidate(\"112112\") == 6L);\n    assert(candidate(\"111\") == 6L);\n    assert(candidate(\"1101112\") == 12L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth decagonal number.\n\t\n*/\nlong is_num_decagonal(long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_num_decagonal;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(7L) == 175L);\n    assert(candidate(10L) == 370L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array of tuples and returns an array containing the rear element of each tuple.\n\t\n*/\nlong[] rear_extract(Tuple!(long, string, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = rear_extract;\n\n    assert(candidate([tuple(1L, \"Rash\", 21L), tuple(2L, \"Varsha\", 20L), tuple(3L, \"Kil\", 19L)]) == [21L, 20L, 19L]);\n    assert(candidate([tuple(1L, \"Sai\", 36L), tuple(2L, \"Ayesha\", 25L), tuple(3L, \"Salman\", 45L)]) == [36L, 25L, 45L]);\n    assert(candidate([tuple(1L, \"Sudeep\", 14L), tuple(2L, \"Vandana\", 36L), tuple(3L, \"Dawood\", 56L)]) == [14L, 36L, 56L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the closest smaller number than n.\n\t\n*/\nlong closest_num(long N) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = closest_num;\n\n    assert(candidate(11L) == 10L);\n    assert(candidate(7L) == 6L);\n    assert(candidate(12L) == 11L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the combinations of sums with tuples in the given tuple array. https://www.geeksforgeeks.org/dthon-combinations-of-sum-with-tuples-in-tuple-array/\n\t\n*/\nTuple!(long, long)[] find_combinations(Tuple!(long, long)[] test_list) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_combinations;\n\n    assert(candidate([tuple(2L, 4L), tuple(6L, 7L), tuple(5L, 1L), tuple(6L, 10L)]) == [tuple(8L, 11L), tuple(7L, 5L), tuple(8L, 14L), tuple(11L, 8L), tuple(12L, 17L), tuple(11L, 11L)]);\n    assert(candidate([tuple(3L, 5L), tuple(7L, 8L), tuple(6L, 2L), tuple(7L, 11L)]) == [tuple(10L, 13L), tuple(9L, 7L), tuple(10L, 16L), tuple(13L, 10L), tuple(14L, 19L), tuple(13L, 13L)]);\n    assert(candidate([tuple(4L, 6L), tuple(8L, 9L), tuple(7L, 3L), tuple(8L, 12L)]) == [tuple(12L, 15L), tuple(11L, 9L), tuple(12L, 18L), tuple(15L, 12L), tuple(16L, 21L), tuple(15L, 15L)]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\n*/\nfloat maxAverageOfPath(long[][] cost) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = maxAverageOfPath;\n\n    assert(candidate([[1L, 2L, 3L], [6L, 5L, 4L], [7L, 3L, 9L]]) == 5.2);\n    assert(candidate([[2L, 3L, 4L], [7L, 6L, 5L], [8L, 4L, 10L]]) == 6.2);\n    assert(candidate([[3L, 4L, 5L], [8L, 7L, 6L], [9L, 5L, 11L]]) == 7.2);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]]) == 5.8);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\n*/\nTuple!(bool, long) sequential_search(long[] dlist, long item) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sequential_search;\n\n    assert(candidate([11L, 23L, 58L, 31L, 56L, 77L, 43L, 12L, 65L, 19L], 31L) == tuple(true, 3L));\n    assert(candidate([12L, 32L, 45L, 62L, 35L, 47L, 44L, 61L], 61L) == tuple(true, 7L));\n    assert(candidate([9L, 10L, 17L, 19L, 22L, 39L, 48L, 56L], 48L) == tuple(true, 6L));\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove odd numbers from a given array.\n\t\n*/\nlong[] remove_odd(long[] l) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate([1L, 2L, 3L]) == [2L]);\n    assert(candidate([2L, 4L, 6L]) == [2L, 4L, 6L]);\n    assert(candidate([10L, 20L, 3L]) == [10L, 20L]);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the product of numbers in an array is even or not.\n\t\n*/\nbool is_product_even(long[] arr) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = is_product_even;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 4L]) == true);\n    assert(candidate([1L, 1L]) == false);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the maximum of two numbers.\n\t\n*/\nlong maximum(long a, long b) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate(5L, 10L) == 10L);\n    assert(candidate(-1L, -2L) == -1L);\n    assert(candidate(9L, 7L) == 9L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = max_occurrences;\n\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 2L, 6L, 5L, 1L, 6L, 1L, 2L, 3L, 2L, 4L, 6L, 9L, 1L, 2L]) == 2L);\n    assert(candidate([2L, 3L, 8L, 4L, 7L, 9L, 8L, 7L, 9L, 15L, 14L, 10L, 12L, 13L, 16L, 18L]) == 8L);\n    assert(candidate([10L, 20L, 20L, 30L, 40L, 90L, 80L, 50L, 30L, 20L, 50L, 10L]) == 20L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5209,9 +364,684 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to reverse only the vowels of a given string (where y is not a vowel).\n\t\n*/\nstring reverse_vowels(string str1) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = reverse_vowels;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"USA\") == \"ASU\");\n    assert(candidate(\"ab\") == \"ab\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert an array to a string.\n\t\n*/\nstring tup_string(string[] tup1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tup_string;\n\n    assert(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\");\n    assert(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\");\n    assert(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of the negative numbers of a given array of numbers.\n\t\n*/\nlong sum_negativenum(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_negativenum;\n\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == -32L);\n    assert(candidate([10L, 15L, -14L, 13L, -18L, 12L, -20L]) == -52L);\n    assert(candidate([19L, -65L, 57L, 39L, 152L, -639L, 121L, 44L, 90L, -190L]) == -894L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth hexagonal number.\n\t\n*/\nlong hexagonal_num(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = hexagonal_num;\n\n    assert(candidate(10L) == 190L);\n    assert(candidate(5L) == 45L);\n    assert(candidate(7L) == 91L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\n*/\nbool is_Sum_Of_Powers_Of_Two(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_Sum_Of_Powers_Of_Two;\n\n    assert(candidate(10L) == true);\n    assert(candidate(7L) == false);\n    assert(candidate(14L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of elements.\n\t\n*/\nlong[] pancake_sort(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pancake_sort;\n\n    assert(candidate([15L, 79L, 25L, 38L, 69L]) == [15L, 25L, 38L, 69L, 79L]);\n    assert(candidate([98L, 12L, 54L, 36L, 85L]) == [12L, 36L, 54L, 85L, 98L]);\n    assert(candidate([41L, 42L, 32L, 12L, 23L]) == [12L, 23L, 32L, 41L, 42L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count number items that are identical in the same position of three given arrays.\n\t\n*/\nlong count_samepair(long[] list1, long[] list2, long[] list3) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_samepair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 9L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 2L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 8L], [2L, 1L, 3L, 1L, 2L, 6L, 7L, 8L]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the maximum difference between any two elements in a given array.\n\t\n*/\nlong max_Abs_Diff(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_Abs_Diff;\n\n    assert(candidate([2L, 1L, 5L, 3L]) == 4L);\n    assert(candidate([9L, 3L, 2L, 5L, 1L]) == 8L);\n    assert(candidate([3L, 2L, 1L]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the volume of a triangular prism.\n\t\n*/\nlong find_Volume(long l, long b, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Volume;\n\n    assert(candidate(10L, 8L, 6L) == 240L);\n    assert(candidate(3L, 2L, 2L) == 6L);\n    assert(candidate(1L, 2L, 1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return null if no solution exists.\n\t\n*/\nNullable!(Tuple!(long, long)) find_solution(long a, long b, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_solution;\n\n{\n        auto result = candidate(2L, 3L, 7L);\n        assert(!result.isNull && result.get == tuple(2L, 1L));\n}\n\n{\n        auto result = candidate(4L, 2L, 7L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(1L, 13L, 17L);\n        assert(!result.isNull && result.get == tuple(4L, 1L));\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all elements from a given array present in another array.\n\t\n*/\nlong[] remove_elements(long[] list1, long[] list2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_elements;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [2L, 4L, 6L, 8L]) == [1L, 3L, 5L, 7L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [1L, 3L, 5L, 7L]) == [2L, 4L, 6L, 8L, 9L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], [5L, 7L]) == [1L, 2L, 3L, 4L, 6L, 8L, 9L, 10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\n*/\nlong sum_series(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_series;\n\n    assert(candidate(6L) == 12L);\n    assert(candidate(10L) == 30L);\n    assert(candidate(9L) == 25L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\n*/\nbool are_equivalent(long num1, long num2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = are_equivalent;\n\n    assert(candidate(36L, 57L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(23L, 47L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\n*/\nlong count_char_position(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_char_position;\n\n    assert(candidate(\"xbcefg\") == 2L);\n    assert(candidate(\"ABcED\") == 3L);\n    assert(candidate(\"AbgdeF\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that counts the number of pairs of integers in an array that xor to an even number.\n\t\n*/\nlong find_even_pair(long[] A) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_even_pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L]) == 4L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L]) == 9L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the smallest power of 2 greater than or equal to n.\n\t\n*/\nlong next_power_of_2(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = next_power_of_2;\n\n    assert(candidate(0L) == 1L);\n    assert(candidate(5L) == 8L);\n    assert(candidate(17L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurrences of a number in a given array.\n\t\n*/\nlong frequency(long[] a, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = frequency;\n\n    assert(candidate([1L, 2L, 3L], 4L) == 0L);\n    assert(candidate([1L, 2L, 2L, 3L, 3L, 3L, 4L], 3L) == 3L);\n    assert(candidate([0L, 1L, 2L, 3L, 1L, 2L], 1L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\n*/\nbool text_lowercase_underscore(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_lowercase_underscore;\n\n    assert(candidate(\"aab_cbbbc\") == true);\n    assert(candidate(\"aab_Abbbc\") == false);\n    assert(candidate(\"Aaab_abbbc\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of numbers in an array within a range specified by two indices.\n\t\n*/\nlong sum_range_list(long[] list1, long m, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_range_list;\n\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 8L, 10L) == 29L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 5L, 7L) == 16L);\n    assert(candidate([2L, 1L, 5L, 6L, 8L, 3L, 4L, 9L, 10L, 11L, 8L, 12L], 7L, 10L) == 38L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\n*/\nlong perimeter_pentagon(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = perimeter_pentagon;\n\n    assert(candidate(5L) == 25L);\n    assert(candidate(10L) == 50L);\n    assert(candidate(15L) == 75L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\n*/\nlong count_occurance(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_occurance;\n\n    assert(candidate(\"letstdlenstdporstd\") == 3L);\n    assert(candidate(\"truststdsolensporsd\") == 1L);\n    assert(candidate(\"makestdsostdworthit\") == 2L);\n    assert(candidate(\"stds\") == 1L);\n    assert(candidate(\"\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\n*/\nlong square_perimeter(long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = square_perimeter;\n\n    assert(candidate(10L) == 40L);\n    assert(candidate(5L) == 20L);\n    assert(candidate(4L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\n*/\nstring remove_dirty_chars(string string, string second_string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_dirty_chars;\n\n    assert(candidate(\"probasscurve\", \"pros\") == \"bacuve\");\n    assert(candidate(\"digitalindia\", \"talent\") == \"digiidi\");\n    assert(candidate(\"exoticmiles\", \"toxic\") == \"emles\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\n*/\nbool test_duplicate(long[] arraynums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = test_duplicate;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == true);\n    assert(candidate([1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given number is woodball or not.\n\t\n*/\nbool is_woodall(long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_woodall;\n\n    assert(candidate(383L) == true);\n    assert(candidate(254L) == false);\n    assert(candidate(200L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\n*/\nbool is_majority(long[] arr, long n, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_majority;\n\n    assert(candidate([1L, 2L, 3L, 3L, 3L, 3L, 10L], 7L, 3L) == true);\n    assert(candidate([1L, 1L, 2L, 4L, 4L, 4L, 6L, 6L], 8L, 4L) == false);\n    assert(candidate([1L, 1L, 1L, 2L, 2L], 5L, 1L) == true);\n    assert(candidate([1L, 1L, 2L, 2L], 5L, 1L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of set bits (binary digits with value 1) in a given number.\n\t\n*/\nlong count_Set_Bits(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_Set_Bits;\n\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 1L);\n    assert(candidate(6L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove the characters which have odd index values of a given string.\n\t\n*/\nstring odd_values_string(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = odd_values_string;\n\n    assert(candidate(\"abcdef\") == \"ace\");\n    assert(candidate(\"python\") == \"pto\");\n    assert(candidate(\"data\") == \"dt\");\n    assert(candidate(\"lambs\") == \"lms\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum of three numbers.\n\t\n*/\nlong min_of_three(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = min_of_three;\n\n    assert(candidate(10L, 20L, 0L) == 0L);\n    assert(candidate(19L, 15L, 18L) == 15L);\n    assert(candidate(-10L, -20L, -30L) == -30L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether all the bits are unset in the given range or not.\n\t\n*/\nbool all_Bits_Set_In_The_Given_Range(long n, long l, long r) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = all_Bits_Set_In_The_Given_Range;\n\n    assert(candidate(4L, 1L, 2L) == true);\n    assert(candidate(17L, 2L, 4L) == true);\n    assert(candidate(39L, 4L, 6L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\n*/\nlong[] re_arrange_array(long[] arr, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = re_arrange_array;\n\n    assert(candidate([-1L, 2L, -3L, 4L, 5L, 6L, -7L, 8L, 9L], 9L) == [-1L, -3L, -7L, 4L, 5L, 6L, 2L, 8L, 9L]);\n    assert(candidate([12L, -14L, -26L, 13L, 15L], 5L) == [-14L, -26L, 12L, 13L, 15L]);\n    assert(candidate([10L, 24L, 36L, -42L, -39L, -78L, 85L], 7L) == [-42L, -39L, -78L, 10L, 24L, 36L, 85L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\n*/\nstring replace_blank(string str1, string char) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = replace_blank;\n\n    assert(candidate(\"hello people\", \"@\") == \"hello@people\");\n    assert(candidate(\"python program language\", \"$\") == \"python$program$language\");\n    assert(candidate(\"blank space\", \"-\") == \"blank-space\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the volume of a cube given its side length.\n\t\n*/\nlong volume_cube(long l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = volume_cube;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(2L) == 8L);\n    assert(candidate(5L) == 125L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of non-empty substrings of a given string.\n\t\n*/\nlong number_of_substrings(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = number_of_substrings;\n\n    assert(candidate(\"abc\") == 6L);\n    assert(candidate(\"abcd\") == 10L);\n    assert(candidate(\"abcde\") == 15L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\n*/\nlong get_total_number_of_sequences(long m, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_total_number_of_sequences;\n\n    assert(candidate(10L, 4L) == 4L);\n    assert(candidate(5L, 2L) == 6L);\n    assert(candidate(16L, 3L) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the total number of characters in a string.\n\t\n*/\nlong count_charac(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_charac;\n\n    assert(candidate(\"python programming\") == 18L);\n    assert(candidate(\"language\") == 8L);\n    assert(candidate(\"words\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the next perfect square greater than a given number.\n\t\n*/\nlong next_Perfect_Square(long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = next_Perfect_Square;\n\n    assert(candidate(35L) == 36L);\n    assert(candidate(6L) == 9L);\n    assert(candidate(9L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\n*/\nlong max_sum(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_sum;\n\n    assert(candidate([1L, 15L, 51L, 45L, 33L, 100L, 12L, 18L, 9L]) == 194L);\n    assert(candidate([80L, 60L, 30L, 40L, 20L, 10L]) == 210L);\n    assert(candidate([2L, 3L, 14L, 16L, 21L, 23L, 29L, 30L]) == 138L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\n*/\nlong lps(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = lps;\n\n    assert(candidate(\"TENS FOR TENS\") == 5L);\n    assert(candidate(\"CARDIO FOR CARDS\") == 7L);\n    assert(candidate(\"PART OF THE JOURNEY IS PART\") == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the intersection of two arrays.\n\t\n*/\nlong[] intersection_array(long[] array_nums1, long[] array_nums2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = intersection_array;\n\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [1L, 2L, 4L, 8L, 9L]) == [1L, 2L, 8L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [3L, 5L, 7L, 9L]) == [3L, 5L, 7L, 9L]);\n    assert(candidate([1L, 2L, 3L, 5L, 7L, 8L, 9L, 10L], [10L, 20L, 30L, 40L]) == [10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a tuple and an element and counts the occcurences of the element in the array.\n\t\n*/\nlong count_X(long[] tup, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_X;\n\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 4L) == 0L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 10L) == 3L);\n    assert(candidate([10L, 8L, 5L, 2L, 10L, 15L, 10L, 8L, 5L, 8L, 8L, 2L], 8L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\n\t\n*/\nstring[] insert_element(string[] list, string element) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = insert_element;\n\n    assert(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n    assert(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"]);\n    assert(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert complex numbers to polar coordinates.\n\t\n*/\nTuple!(float, float) convert(long numbers) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = convert;\n\n    assert(candidate(1L) == tuple(1.0, 0.0));\n    assert(candidate(4L) == tuple(4.0, 0.0));\n    assert(candidate(5L) == tuple(5.0, 0.0));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\n\t\n*/\nstring[][] combinations_colors(string[] l, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = combinations_colors;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 1L) == [[\"Red\"], [\"Green\"], [\"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 2L) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n    assert(candidate([\"Red\", \"Green\", \"Blue\"], 3L) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\n*/\nlong count_Primes_nums(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_Primes_nums;\n\n    assert(candidate(5L) == 2L);\n    assert(candidate(10L) == 4L);\n    assert(candidate(100L) == 25L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two numbers and returns an array with the second number and then the first number.\n\t\n*/\nlong[] swap_numbers(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = swap_numbers;\n\n    assert(candidate(10L, 20L) == [20L, 10L]);\n    assert(candidate(15L, 17L) == [17L, 15L]);\n    assert(candidate(100L, 200L) == [200L, 100L]);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5224,7 +1054,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to maximize the given two arrays.\n\t\n*/\nlong[][] maximize_elements(long[][] test_tup1, long[][] test_tup2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = maximize_elements;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 7L], [4L, 9L], [2L, 9L], [7L, 10L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[7L, 8L], [5L, 10L], [3L, 10L], [8L, 11L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[8L, 9L], [6L, 11L], [4L, 11L], [9L, 12L]]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5235,13 +1065,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether every even index contains even numbers of a given array.\n\t\n*/\nbool even_position(long[] nums) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\n*/\nlong newman_prime(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = even_position;\n\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L]) == false);\n    assert(candidate([2L, 1L, 4L]) == true);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = newman_prime;\n\n    assert(candidate(3L) == 7L);\n    assert(candidate(4L) == 17L);\n    assert(candidate(5L) == 41L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5250,13 +1080,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\n*/\nstring check_char(string string) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) division_elements(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = check_char;\n\n    assert(candidate(\"abba\") == \"Valid\");\n    assert(candidate(\"a\") == \"Valid\");\n    assert(candidate(\"abcd\") == \"Invalid\");\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = division_elements;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(2L, 2L, 2L, 3L));\n    assert(candidate(tuple(12L, 6L, 8L, 16L), tuple(6L, 3L, 4L, 4L)) == tuple(2L, 2L, 2L, 4L));\n    assert(candidate(tuple(20L, 14L, 36L, 18L), tuple(5L, 7L, 6L, 9L)) == tuple(4L, 2L, 6L, 2L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5265,13 +1095,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_264_dog_age",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of even factors of a number.\n\t\n*/\nlong sumofFactors(long n) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate a dog's age in dog's years.\n\t\n*/\nlong dog_age(long h_age) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = sumofFactors;\n\n    assert(candidate(18L) == 26L);\n    assert(candidate(30L) == 48L);\n    assert(candidate(6L) == 8L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = dog_age;\n\n    assert(candidate(12L) == 61L);\n    assert(candidate(15L) == 73L);\n    assert(candidate(24L) == 109L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5280,43 +1110,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\n*/\nfloat lateralsurface_cone(long r, long h) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\n*/\nlong lateralsurface_cube(long l) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = lateralsurface_cone;\n\n    assert(candidate(5L, 12L) == 204.20352248333654);\n    assert(candidate(10L, 15L) == 566.3586699569488);\n    assert(candidate(19L, 17L) == 1521.8090132193388);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_564_count_Pairs",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\n*/\nlong count_Pairs(long[] arr, long n) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = count_Pairs;\n\n    assert(candidate([1L, 2L, 1L], 3L) == 2L);\n    assert(candidate([1L, 1L, 1L, 1L], 4L) == 0L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 5L) == 10L);\n}\nvoid main(){}",
-    "stop_tokens": [
-      "\n\n",
-      "\nvoid",
-      "\nbool",
-      "\nint"
-    ]
-  },
-  {
-    "name": "mbpp_733_find_first_occurrence",
-    "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\n*/\nlong find_first_occurrence(long[] A, long x) \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = find_first_occurrence;\n\n    assert(candidate([2L, 5L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 1L);\n    assert(candidate([2L, 3L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 2L);\n    assert(candidate([2L, 4L, 1L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 6L) == 4L);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = lateralsurface_cube;\n\n    assert(candidate(5L) == 100L);\n    assert(candidate(9L) == 324L);\n    assert(candidate(10L) == 400L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5329,9 +1129,759 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 10L);\n    assert(candidate(3L) == 35L);\n    assert(candidate(4L) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th star number.\n\t\n*/\nlong find_star_num(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_star_num;\n\n    assert(candidate(3L) == 37L);\n    assert(candidate(4L) == 73L);\n    assert(candidate(5L) == 121L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ascii value of a character.\n\t\n*/\nlong ascii_value(string k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = ascii_value;\n\n    assert(candidate(\"A\") == 65L);\n    assert(candidate(\"R\") == 82L);\n    assert(candidate(\"S\") == 83L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of even numbers at even positions of an array.\n\t\n*/\nlong sum_even_and_even_index(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_even_and_even_index;\n\n    assert(candidate([5L, 6L, 12L, 1L, 18L, 8L]) == 30L);\n    assert(candidate([3L, 20L, 17L, 9L, 2L, 10L, 18L, 13L, 6L, 18L]) == 26L);\n    assert(candidate([5L, 6L, 12L, 1L]) == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\n*/\nlong even_Power_Sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = even_Power_Sum;\n\n    assert(candidate(2L) == 1056L);\n    assert(candidate(3L) == 8832L);\n    assert(candidate(1L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array of tuples and returns an array containing the rear element of each tuple.\n\t\n*/\nlong[] rear_extract(Tuple!(long, string, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rear_extract;\n\n    assert(candidate([tuple(1L, \"Rash\", 21L), tuple(2L, \"Varsha\", 20L), tuple(3L, \"Kil\", 19L)]) == [21L, 20L, 19L]);\n    assert(candidate([tuple(1L, \"Sai\", 36L), tuple(2L, \"Ayesha\", 25L), tuple(3L, \"Salman\", 45L)]) == [36L, 25L, 45L]);\n    assert(candidate([tuple(1L, \"Sudeep\", 14L), tuple(2L, \"Vandana\", 36L), tuple(3L, \"Dawood\", 56L)]) == [14L, 36L, 56L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\n*/\nTuple!(long, long, long) substract_elements(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = substract_elements;\n\n    assert(candidate(tuple(10L, 4L, 5L), tuple(2L, 5L, 18L)) == tuple(8L, -1L, -13L));\n    assert(candidate(tuple(11L, 2L, 3L), tuple(24L, 45L, 16L)) == tuple(-13L, -43L, -13L));\n    assert(candidate(tuple(7L, 18L, 9L), tuple(10L, 11L, 12L)) == tuple(-3L, 7L, -3L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\n*/\nlong even_binomial_Coeff_Sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = even_binomial_Coeff_Sum;\n\n    assert(candidate(4L) == 8L);\n    assert(candidate(6L) == 32L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an associative array and integer n and filters the associative array to only include entries with values greater than or equal to n.\n\t\n*/\nNullable!(long[string]) dict_filter(Nullable!(long[string]) dict, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = dict_filter;\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 170L);\n        assert(!result.isNull && result.get == [\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 180L);\n        assert(!result.isNull && result.get == [\"Alden Cantrell\": 180L, \"Pierre Cox\": 190L]);\n}\n\n{\n        auto result = candidate([\"Cierra Vega\": 175L, \"Alden Cantrell\": 180L, \"Kierra Gentry\": 165L, \"Pierre Cox\": 190L].nullable, 190L);\n        assert(!result.isNull && result.get == [\"Pierre Cox\": 190L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth decagonal number.\n\t\n*/\nlong is_num_decagonal(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_num_decagonal;\n\n    assert(candidate(3L) == 27L);\n    assert(candidate(7L) == 175L);\n    assert(candidate(10L) == 370L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\n*/\nTuple!(bool, long) sequential_search(long[] dlist, long item) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sequential_search;\n\n    assert(candidate([11L, 23L, 58L, 31L, 56L, 77L, 43L, 12L, 65L, 19L], 31L) == tuple(true, 3L));\n    assert(candidate([12L, 32L, 45L, 62L, 35L, 47L, 44L, 61L], 61L) == tuple(true, 7L));\n    assert(candidate([9L, 10L, 17L, 19L, 22L, 39L, 48L, 56L], 48L) == tuple(true, 6L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check if the elements of a given array are unique or not.\n\t\n*/\nbool all_unique(long[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = all_unique;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to subtract two arrays element-wise.\n\t\n*/\nlong[] sub_list(long[] nums1, long[] nums2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sub_list;\n\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == [-3L, -3L, -3L]);\n    assert(candidate([1L, 2L], [3L, 4L]) == [-2L, -2L]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [40L, 50L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\n*/\nbool validate(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = validate;\n\n    assert(candidate(1234L) == true);\n    assert(candidate(51241L) == false);\n    assert(candidate(321L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\n*/\nbool text_match_two_three(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_two_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\n*/\nlong max_sub_array_sum_repeated(long[] a, long n, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum_repeated;\n\n    assert(candidate([10L, 20L, -30L, -1L], 4L, 3L) == 30L);\n    assert(candidate([-1L, 10L, 20L], 3L, 2L) == 59L);\n    assert(candidate([-1L, -2L, -3L], 3L, 3L) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\n*/\nlong square_Sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = square_Sum;\n\n    assert(candidate(2L) == 20L);\n    assert(candidate(3L) == 56L);\n    assert(candidate(4L) == 120L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the array of maximum length in an array of arrays.\n\t\n*/\nTuple!(long, long[]) max_length(long[][] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_length;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L], [5L, 7L], [10L, 12L, 14L, 15L]]) == tuple(4L, [10L, 12L, 14L, 15L]));\n    assert(candidate([[5L], [15L, 20L, 25L]]) == tuple(3L, [15L, 20L, 25L]));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\n*/\nlong count_no_of_ways(long n, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_no_of_ways;\n\n    assert(candidate(2L, 4L) == 16L);\n    assert(candidate(3L, 2L) == 6L);\n    assert(candidate(4L, 4L) == 228L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find quotient of two numbers (rounded down to the nearest integer).\n\t\n*/\nlong find(long n, long m) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find;\n\n    assert(candidate(10L, 3L) == 3L);\n    assert(candidate(4L, 2L) == 2L);\n    assert(candidate(20L, 5L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the third side of a right angled triangle.\n\t\n*/\nfloat otherside_rightangle(long w, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = otherside_rightangle;\n\n    assert(candidate(7L, 8L) == 10.63014581273465);\n    assert(candidate(3L, 4L) == 5L);\n    assert(candidate(7L, 15L) == 16.55294535724685);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return the sum of all divisors of a number.\n\t\n*/\nlong sum_div(long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_div;\n\n    assert(candidate(8L) == 7L);\n    assert(candidate(12L) == 16L);\n    assert(candidate(7L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count inversions in an array.\n\t\n*/\nlong get_Inv_Count(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_Inv_Count;\n\n    assert(candidate([1L, 20L, 6L, 4L, 5L]) == 5L);\n    assert(candidate([1L, 2L, 1L]) == 1L);\n    assert(candidate([1L, 2L, 5L, 6L, 1L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the maximum aggregate from the array of tuples.\n\t\n*/\nTuple!(string, long) max_aggregate(Tuple!(string, long)[] stdata) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_aggregate;\n\n    assert(candidate([tuple(\"Juan Whelan\", 90L), tuple(\"Sabah Colley\", 88L), tuple(\"Peter Nichols\", 7L), tuple(\"Juan Whelan\", 122L), tuple(\"Sabah Colley\", 84L)]) == tuple(\"Juan Whelan\", 212L));\n    assert(candidate([tuple(\"Juan Whelan\", 50L), tuple(\"Sabah Colley\", 48L), tuple(\"Peter Nichols\", 37L), tuple(\"Juan Whelan\", 22L), tuple(\"Sabah Colley\", 14L)]) == tuple(\"Juan Whelan\", 72L));\n    assert(candidate([tuple(\"Juan Whelan\", 10L), tuple(\"Sabah Colley\", 20L), tuple(\"Peter Nichols\", 30L), tuple(\"Juan Whelan\", 40L), tuple(\"Sabah Colley\", 50L)]) == tuple(\"Sabah Colley\", 70L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find element at a given index after number of rotations.\n\t\n*/\nlong find_Element(long[] arr, long[][] ranges, long rotations, long index) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Element;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [[0L, 2L], [0L, 3L]], 2L, 1L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L], [[0L, 1L], [0L, 2L]], 1L, 2L) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [[0L, 1L], [0L, 2L]], 1L, 1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return two words from an array of words starting with letter 'p'.\n\t\n*/\nTuple!(string, string) start_withp(string[] words) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = start_withp;\n\n    assert(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == tuple(\"Python\", \"PHP\"));\n    assert(candidate([\"Python Programming\", \"Java Programming\"]) == tuple(\"Python\", \"Programming\"));\n    assert(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == tuple(\"Pqrst\", \"Pqr\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\n*/\nlong max_sum_increasing_subseq(long[] a, long n, long index, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_sum_increasing_subseq;\n\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 4L, 6L) == 11L);\n    assert(candidate([1L, 101L, 2L, 3L, 100L, 4L, 5L], 7L, 2L, 5L) == 7L);\n    assert(candidate([11L, 15L, 19L, 21L, 26L, 28L, 31L], 7L, 2L, 4L) == 71L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\n\t\n*/\nlong[] large_product(long[] nums1, long[] nums2, long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = large_product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 3L) == [60L, 54L, 50L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 4L) == [60L, 54L, 50L, 48L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], [3L, 6L, 8L, 9L, 10L, 6L], 5L) == [60L, 54L, 50L, 48L, 45L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the maximum of two numbers.\n\t\n*/\nlong maximum(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = maximum;\n\n    assert(candidate(5L, 10L) == 10L);\n    assert(candidate(-1L, -2L) == -1L);\n    assert(candidate(9L, 7L) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a given string to an array of characters.\n\t\n*/\nstring[] string_to_tuple(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = string_to_tuple;\n\n    assert(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n    assert(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"]);\n    assert(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the highest power of 2 that is less than or equal to n.\n\t\n*/\nlong highest_Power_of_2(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = highest_Power_of_2;\n\n    assert(candidate(10L) == 8L);\n    assert(candidate(19L) == 16L);\n    assert(candidate(32L) == 32L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n'th lucas number.\n\t\n*/\nlong find_lucas(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_lucas;\n\n    assert(candidate(9L) == 76L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(3L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert more than one array to nested associative array.\n\t\n*/\nNone[] convert_list_dictionary(string[] l1, string[] l2, long[] l3) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = convert_list_dictionary;\n\n    assert(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85L, 98L, 89L, 92L]) == [[\"S001\": [\"Adina Park\": 85L].nullable].nullable, [\"S002\": [\"Leyton Marsh\": 98L].nullable].nullable, [\"S003\": [\"Duncan Boyle\": 89L].nullable].nullable, [\"S004\": [\"Saim Richards\": 92L].nullable].nullable]);\n    assert(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100L, 200L, 300L, 400L]) == [[\"abc\": [\"python\": 100L].nullable].nullable, [\"def\": [\"program\": 200L].nullable].nullable, [\"ghi\": [\"language\": 300L].nullable].nullable, [\"jkl\": [\"programs\": 400L].nullable].nullable]);\n    assert(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10L, 20L, 30L, 40L]) == [[\"A1\": [\"java\": 10L].nullable].nullable, [\"A2\": [\"C\": 20L].nullable].nullable, [\"A3\": [\"C++\": 30L].nullable].nullable, [\"A4\": [\"DBMS\": 40L].nullable].nullable]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\n*/\nlong get_max_sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_max_sum;\n\n    assert(candidate(60L) == 106L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the array with maximum length.\n\t\n*/\nTuple!(long, long[]) max_length_list(long[][] input_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_length_list;\n\n    assert(candidate([[0L], [1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == tuple(3L, [13L, 15L, 17L]));\n    assert(candidate([[1L, 2L, 3L, 4L, 5L], [1L, 2L, 3L, 4L], [1L, 2L, 3L], [1L, 2L], [1L]]) == tuple(5L, [1L, 2L, 3L, 4L, 5L]));\n    assert(candidate([[3L, 4L, 5L], [6L, 7L, 8L, 9L], [10L, 11L, 12L]]) == tuple(4L, [6L, 7L, 8L, 9L]));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if given array contains no duplicates.\n\t\n*/\nbool check_distinct(long[] test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_distinct;\n\n    assert(candidate([1L, 4L, 5L, 6L, 1L, 4L]) == false);\n    assert(candidate([1L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 6L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first non-repeated character in a given string.\n\t\n*/\nNullable!(string) first_non_repeating_character(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = first_non_repeating_character;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"ababc\");\n        assert(!result.isNull && result.get == \"c\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\n*/\nstring check_char(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_char;\n\n    assert(candidate(\"abba\") == \"Valid\");\n    assert(candidate(\"a\") == \"Valid\");\n    assert(candidate(\"abcd\") == \"Invalid\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of three numbers.\n\t\n*/\nfloat median_numbers(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = median_numbers;\n\n    assert(candidate(25L, 55L, 65L) == 55.0);\n    assert(candidate(20L, 10L, 30L) == 20.0);\n    assert(candidate(15L, 45L, 75L) == 45.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\n*/\nTuple!(long, long, long, long) bitwise_xor(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = bitwise_xor;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(15L, 6L, 5L, 10L));\n    assert(candidate(tuple(11L, 5L, 7L, 10L), tuple(6L, 3L, 4L, 4L)) == tuple(13L, 6L, 3L, 14L));\n    assert(candidate(tuple(12L, 6L, 8L, 11L), tuple(7L, 4L, 5L, 6L)) == tuple(11L, 2L, 13L, 13L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to identify non-prime numbers.\n\t\n*/\nbool is_not_prime(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_not_prime;\n\n    assert(candidate(2L) == false);\n    assert(candidate(10L) == true);\n    assert(candidate(35L) == true);\n    assert(candidate(37L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the number of unique tuples in the given array.\n\t\n*/\nlong extract_freq(Tuple!(long, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = extract_freq;\n\n    assert(candidate([tuple(3L, 4L), tuple(1L, 2L), tuple(4L, 3L), tuple(5L, 6L)]) == 3L);\n    assert(candidate([tuple(4L, 15L), tuple(2L, 3L), tuple(5L, 4L), tuple(6L, 7L)]) == 4L);\n    assert(candidate([tuple(5L, 16L), tuple(2L, 3L), tuple(6L, 5L), tuple(6L, 9L)]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise addition of array elements in the given two nested arrays.\n\t\n*/\nlong[][] add_nested_tuples(long[][] test_tup1, long[][] test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add_nested_tuples;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[7L, 10L], [7L, 14L], [3L, 10L], [8L, 13L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[9L, 12L], [9L, 16L], [5L, 12L], [10L, 15L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[11L, 14L], [11L, 18L], [7L, 14L], [12L, 17L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum of two numbers.\n\t\n*/\nlong minimum(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = minimum;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(-5L, -4L) == -5L);\n    assert(candidate(0L, 0L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find whether the parity of a given number is odd.\n\t\n*/\nbool find_Parity(long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Parity;\n\n    assert(candidate(12L) == false);\n    assert(candidate(7L) == true);\n    assert(candidate(10L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\n*/\nlong[][] k_smallest_pairs(long[] nums1, long[] nums2, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = k_smallest_pairs;\n\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 2L) == [[1L, 2L], [1L, 4L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 1L) == [[1L, 2L]]);\n    assert(candidate([1L, 3L, 7L], [2L, 4L, 6L], 7L) == [[1L, 2L], [1L, 4L], [3L, 2L], [1L, 6L], [3L, 4L], [3L, 6L], [7L, 2L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the minimum product from the pairs of tuples within a given array.\n\t\n*/\nlong min_product_tuple(Tuple!(long, long)[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = min_product_tuple;\n\n    assert(candidate([tuple(2L, 7L), tuple(2L, 6L), tuple(1L, 8L), tuple(4L, 9L)]) == 8L);\n    assert(candidate([tuple(10L, 20L), tuple(15L, 2L), tuple(5L, 10L)]) == 30L);\n    assert(candidate([tuple(11L, 44L), tuple(10L, 15L), tuple(20L, 5L), tuple(12L, 9L)]) == 100L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given snake case string to camel case string.\n\t\n*/\nstring snake_to_camel(string word) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = snake_to_camel;\n\n    assert(candidate(\"android_tv\") == \"AndroidTv\");\n    assert(candidate(\"google_pixel\") == \"GooglePixel\");\n    assert(candidate(\"apple_watch\") == \"AppleWatch\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove odd numbers from a given array.\n\t\n*/\nlong[] remove_odd(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate([1L, 2L, 3L]) == [2L]);\n    assert(candidate([2L, 4L, 6L]) == [2L, 4L, 6L]);\n    assert(candidate([10L, 20L, 3L]) == [10L, 20L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether any value in a sequence exists in a sequence or not.\n\t\n*/\nbool overlapping(long[] list1, long[] list2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = overlapping;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 8L, 9L]) == false);\n    assert(candidate([1L, 2L, 3L], [4L, 5L, 6L]) == false);\n    assert(candidate([1L, 4L, 5L], [1L, 4L, 5L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find a pair with highest product from a given array of integers.\n\t\n*/\nTuple!(long, long) max_Product(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_Product;\n\n    assert(candidate([1L, 2L, 3L, 4L, 7L, 0L, 8L, 4L]) == tuple(7L, 8L));\n    assert(candidate([0L, -1L, -2L, -4L, 5L, 0L, -6L]) == tuple(-4L, -6L));\n    assert(candidate([1L, 2L, 3L]) == tuple(2L, 3L));\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",
@@ -5344,7 +1894,7 @@
     "language": "d",
     "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find common first element in given array of arrays.\n\t\n*/\nstring[][] group_tuples(string[][] Input) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "unittest\n{\n    alias candidate = group_tuples;\n\n    assert(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n    assert(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\nvoid main(){}",
     "stop_tokens": [
@@ -5355,13 +1905,3463 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_420_cube_Sum",
     "language": "d",
-    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three arrays into a single sorted array.\n\t\n*/\nlong[] merge_sorted_list(long[] num1, long[] num2, long[] num3) \n",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the cube sum of first n even natural numbers.\n\t\n*/\nlong cube_Sum(long n) \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
     "prompt_terminology": "reworded",
-    "tests": "unittest\n{\n    alias candidate = merge_sorted_list;\n\n    assert(candidate([25L, 24L, 15L, 4L, 5L, 29L, 110L], [19L, 20L, 11L, 56L, 25L, 233L, 154L], [24L, 26L, 54L, 48L]) == [4L, 5L, 11L, 15L, 19L, 20L, 24L, 24L, 25L, 25L, 26L, 29L, 48L, 54L, 56L, 110L, 154L, 233L]);\n    assert(candidate([1L, 3L, 5L, 6L, 8L, 9L], [2L, 5L, 7L, 11L], [1L, 4L, 7L, 8L, 12L]) == [1L, 1L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L, 8L, 8L, 9L, 11L, 12L]);\n    assert(candidate([18L, 14L, 10L, 9L, 8L, 7L, 9L, 3L, 2L, 4L, 1L], [25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L], [12L, 74L, 9L, 50L, 61L, 41L]) == [1L, 2L, 3L, 4L, 7L, 8L, 9L, 9L, 9L, 10L, 12L, 14L, 14L, 18L, 22L, 25L, 25L, 35L, 41L, 50L, 58L, 61L, 65L, 74L, 75L, 85L]);\n}\nvoid main(){}",
+    "tests": "unittest\n{\n    alias candidate = cube_Sum;\n\n    assert(candidate(2L) == 72L);\n    assert(candidate(3L) == 288L);\n    assert(candidate(4L) == 800L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\n*/\nstring concatenate_tuple(Tuple!(string, string, long, string) test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = concatenate_tuple;\n\n    assert(candidate(tuple(\"ID\", \"is\", 4L, \"UTS\")) == \"ID-is-4-UTS\");\n    assert(candidate(tuple(\"QWE\", \"is\", 4L, \"RTY\")) == \"QWE-is-4-RTY\");\n    assert(candidate(tuple(\"ZEN\", \"is\", 4L, \"OP\")) == \"ZEN-is-4-OP\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the average of cubes of first n natural numbers.\n\t\n*/\nfloat find_Average_Of_Cube(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Average_Of_Cube;\n\n    assert(candidate(2L) == 4.5);\n    assert(candidate(3L) == 12L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\n*/\nstring[] extract_rear(Tuple!(string, string, string) test_tuple) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = extract_rear;\n\n    assert(candidate(tuple(\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"]);\n    assert(candidate(tuple(\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"]);\n    assert(candidate(tuple(\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to filter odd numbers.\n\t\n*/\nlong[] filter_oddnumbers(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = filter_oddnumbers;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 3L, 5L, 7L, 9L]);\n    assert(candidate([10L, 20L, 45L, 67L, 84L, 93L]) == [45L, 67L, 93L]);\n    assert(candidate([5L, 7L, 9L, 8L, 6L, 4L, 3L]) == [5L, 7L, 9L, 3L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\n*/\nstring change_date_format(string dt) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = change_date_format;\n\n    assert(candidate(\"2026-01-02\") == \"02-01-2026\");\n    assert(candidate(\"2020-11-13\") == \"13-11-2020\");\n    assert(candidate(\"2021-04-26\") == \"26-04-2021\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given array by using shell sort.\n\t\n*/\nlong[] shell_sort(long[] my_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = shell_sort;\n\n    assert(candidate([12L, 23L, 4L, 5L, 3L, 2L, 12L, 81L, 56L, 95L]) == [2L, 3L, 4L, 5L, 12L, 12L, 23L, 56L, 81L, 95L]);\n    assert(candidate([24L, 22L, 39L, 34L, 87L, 73L, 68L]) == [22L, 24L, 34L, 39L, 68L, 73L, 87L]);\n    assert(candidate([32L, 30L, 16L, 96L, 82L, 83L, 74L]) == [16L, 30L, 32L, 74L, 82L, 83L, 96L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) and_tuples(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = and_tuples;\n\n    assert(candidate(tuple(10L, 4L, 6L, 9L), tuple(5L, 2L, 3L, 3L)) == tuple(0L, 0L, 2L, 1L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(5L, 6L, 7L, 8L)) == tuple(1L, 2L, 3L, 0L));\n    assert(candidate(tuple(8L, 9L, 11L, 12L), tuple(7L, 13L, 14L, 17L)) == tuple(0L, 9L, 10L, 0L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the directrix of a parabola.\n\t\n*/\nlong parabola_directrix(long a, long b, long c) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = parabola_directrix;\n\n    assert(candidate(5L, 3L, 2L) == -198L);\n    assert(candidate(9L, 8L, 4L) == -2336L);\n    assert(candidate(2L, 4L, 6L) == -130L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median length of a trapezium.\n\t\n*/\nfloat median_trapezium(long base1, long base2, long height) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = median_trapezium;\n\n    assert(candidate(15L, 25L, 35L) == 20L);\n    assert(candidate(10L, 20L, 30L) == 15L);\n    assert(candidate(6L, 9L, 4L) == 7.5);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\n*/\nbool check_greater(long[] arr, long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_greater;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 4L) == false);\n    assert(candidate([2L, 3L, 4L, 5L, 6L], 8L) == true);\n    assert(candidate([9L, 7L, 4L, 8L, 6L, 1L], 11L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\n*/\nbool text_match_one(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last digit of a given number.\n\t\n*/\nlong last_Digit(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = last_Digit;\n\n    assert(candidate(123L) == 3L);\n    assert(candidate(25L) == 5L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to return the negative numbers in an array.\n\t\n*/\nlong[] neg_nos(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = neg_nos;\n\n    assert(candidate([-1L, 4L, 5L, -6L]) == [-1L, -6L]);\n    assert(candidate([-1L, -2L, 3L, 4L]) == [-1L, -2L]);\n    assert(candidate([-7L, -6L, 8L, 9L]) == [-7L, -6L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove odd characters in a string.\n\t\n*/\nstring remove_odd(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_odd;\n\n    assert(candidate(\"python\") == \"yhn\");\n    assert(candidate(\"program\") == \"rga\");\n    assert(candidate(\"language\") == \"agae\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count bidirectional tuple pairs.\n\t\n*/\nlong count_bidirectional(Tuple!(long, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_bidirectional;\n\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 3L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 3L), tuple(6L, 5L), tuple(9L, 1L), tuple(6L, 5L), tuple(2L, 1L)]) == 2L);\n    assert(candidate([tuple(5L, 6L), tuple(1L, 2L), tuple(6L, 5L), tuple(9L, 2L), tuple(6L, 5L), tuple(2L, 1L)]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to join an array of multiple integers into a single integer.\n\t\n*/\nlong multiple_to_single(long[] L) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = multiple_to_single;\n\n    assert(candidate([11L, 33L, 50L]) == 113350L);\n    assert(candidate([-1L, 2L, 3L, 4L, 5L, 6L]) == -123456L);\n    assert(candidate([10L, 15L, 20L, 25L]) == 10152025L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\n*/\nTuple!(long, long, string) find_adverb_position(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_adverb_position;\n\n    assert(candidate(\"clearly!! we can see the sky\") == tuple(0L, 7L, \"clearly\"));\n    assert(candidate(\"seriously!! there are many roses\") == tuple(0L, 9L, \"seriously\"));\n    assert(candidate(\"unfortunately!! sita is going to home\") == tuple(0L, 13L, \"unfortunately\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cube of a given size.\n\t\n*/\nlong surfacearea_cube(long l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = surfacearea_cube;\n\n    assert(candidate(5L) == 150L);\n    assert(candidate(3L) == 54L);\n    assert(candidate(10L) == 600L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\n*/\nfloat positive_count(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = positive_count;\n\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.54);\n    assert(candidate([2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 0.69);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L]) == 0.56);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the largest negative number from the given array.\n\t\n*/\nlong largest_neg(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = largest_neg;\n\n    assert(candidate([1L, 2L, 3L, -4L, -6L]) == -6L);\n    assert(candidate([1L, 2L, 3L, -8L, -9L]) == -9L);\n    assert(candidate([1L, 2L, 3L, 4L, -1L]) == -1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to trim each array by k in the given arrays.\n\t\n*/\nlong[][] trim_tuple(long[][] test_list, long K) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = trim_tuple;\n\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 2L) == [[2L], [9L], [2L], [2L]]);\n    assert(candidate([[5L, 3L, 2L, 1L, 4L], [3L, 4L, 9L, 2L, 1L], [9L, 1L, 2L, 3L, 5L], [4L, 8L, 2L, 1L, 7L]], 1L) == [[3L, 2L, 1L], [4L, 9L, 2L], [1L, 2L, 3L], [8L, 2L, 1L]]);\n    assert(candidate([[7L, 8L, 4L, 9L], [11L, 8L, 12L, 4L], [4L, 1L, 7L, 8L], [3L, 6L, 9L, 7L]], 1L) == [[8L, 4L], [8L, 12L], [1L, 7L], [6L, 9L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to perform index wise multiplication of array elements in the given two arrays.\n\t\n*/\nlong[][] index_multiplication(long[][] test_tup1, long[][] test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = index_multiplication;\n\n    assert(candidate([[1L, 3L], [4L, 5L], [2L, 9L], [1L, 10L]], [[6L, 7L], [3L, 9L], [1L, 1L], [7L, 3L]]) == [[6L, 21L], [12L, 45L], [2L, 9L], [7L, 30L]]);\n    assert(candidate([[2L, 4L], [5L, 6L], [3L, 10L], [2L, 11L]], [[7L, 8L], [4L, 10L], [2L, 2L], [8L, 4L]]) == [[14L, 32L], [20L, 60L], [6L, 20L], [16L, 44L]]);\n    assert(candidate([[3L, 5L], [6L, 7L], [4L, 11L], [3L, 12L]], [[8L, 9L], [5L, 11L], [3L, 3L], [9L, 5L]]) == [[24L, 45L], [30L, 77L], [12L, 33L], [27L, 60L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find cubes of individual elements in an array.\n\t\n*/\nlong[] cube_nums(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = cube_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 8L, 27L, 64L, 125L, 216L, 343L, 512L, 729L, 1000L]);\n    assert(candidate([10L, 20L, 30L]) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L]) == [1728L, 3375L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the sum of perrin numbers.\n\t\n*/\nlong cal_sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = cal_sum;\n\n    assert(candidate(9L) == 49L);\n    assert(candidate(10L) == 66L);\n    assert(candidate(11L) == 88L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract specified size of strings from a given array of string values.\n\t\n*/\nstring[] extract_string(string[] str, long l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = extract_string;\n\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8L) == [\"practice\", \"solution\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6L) == [\"Python\"]);\n    assert(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9L) == [\"exercises\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all whitespaces from the given string.\n\t\n*/\nstring remove_whitespaces(string text1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_whitespaces;\n\n    assert(candidate(\" Google    Flutter \") == \"GoogleFlutter\");\n    assert(candidate(\" Google    Dart \") == \"GoogleDart\");\n    assert(candidate(\" iOS    Swift \") == \"iOSSwift\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\n*/\nlong loss_amount(long actual_cost, long sale_amount) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = loss_amount;\n\n    assert(candidate(1500L, 1200L) == 0L);\n    assert(candidate(100L, 200L) == 100L);\n    assert(candidate(2000L, 5000L) == 3000L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of even factors of a number.\n\t\n*/\nlong sumofFactors(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sumofFactors;\n\n    assert(candidate(18L) == 26L);\n    assert(candidate(30L) == 48L);\n    assert(candidate(6L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a word containing 'z'.\n\t\n*/\nbool text_match_wordz(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_wordz;\n\n    assert(candidate(\"pythonz.\") == true);\n    assert(candidate(\"xyz.\") == true);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\n*/\nbool check_monthnumb_number(long monthnum2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_monthnumb_number;\n\n    assert(candidate(5L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(6L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse each string in a given array of string values.\n\t\n*/\nstring[] reverse_string_list(string[] stringlist) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = reverse_string_list;\n\n    assert(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n    assert(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n    assert(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the area of a rectangle.\n\t\n*/\nlong rectangle_area(long l, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rectangle_area;\n\n    assert(candidate(10L, 20L) == 200L);\n    assert(candidate(10L, 5L) == 50L);\n    assert(candidate(4L, 2L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove uppercase substrings from a given string.\n\t\n*/\nstring remove_uppercase(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_uppercase;\n\n    assert(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\");\n    assert(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\");\n    assert(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to get the first element of each subarray.\n\t\n*/\nlong[] Extract(long[][] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Extract;\n\n    assert(candidate([[1L, 2L], [3L, 4L, 5L], [6L, 7L, 8L, 9L]]) == [1L, 3L, 6L]);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L]]) == [1L, 4L]);\n    assert(candidate([[9L, 8L, 1L], [1L, 2L]]) == [9L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the upper case characters in a given string.\n\t\n*/\nlong upper_ctr(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = upper_ctr;\n\n    assert(candidate(\"PYthon\") == 1L);\n    assert(candidate(\"BigData\") == 1L);\n    assert(candidate(\"program\") == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product subarray of the given array.\n\t\n*/\nlong max_subarray_product(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_subarray_product;\n\n    assert(candidate([1L, -2L, -3L, 0L, 7L, -8L, -2L]) == 112L);\n    assert(candidate([6L, -3L, -10L, 0L, 2L]) == 180L);\n    assert(candidate([-2L, -40L, 0L, -2L, -3L]) == 80L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if all values are same in an associative array.\n\t\n*/\nbool check_value(Nullable!(long[string]) dict, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_value;\n\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 10L) == false);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 12L) == true);\n    assert(candidate([\"Cierra Vega\": 12L, \"Alden Cantrell\": 12L, \"Kierra Gentry\": 12L, \"Pierre Cox\": 12L].nullable, 5L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\n*/\nlong max_product(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_product;\n\n    assert(candidate([3L, 100L, 4L, 5L, 150L, 6L]) == 3000L);\n    assert(candidate([4L, 42L, 55L, 68L, 80L]) == 50265600L);\n    assert(candidate([10L, 22L, 9L, 33L, 21L, 50L, 41L, 60L]) == 2460L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\n*/\nTuple!(long, long, long, long) add_pairwise(Tuple!(long, long, long, long, long) test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add_pairwise;\n\n    assert(candidate(tuple(1L, 5L, 7L, 8L, 10L)) == tuple(6L, 12L, 15L, 18L));\n    assert(candidate(tuple(2L, 6L, 8L, 9L, 11L)) == tuple(8L, 14L, 17L, 20L));\n    assert(candidate(tuple(3L, 7L, 9L, 10L, 12L)) == tuple(10L, 16L, 19L, 22L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the product of the array multiplication modulo n.\n\t\n*/\nlong find_remainder(long[] arr, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_remainder;\n\n    assert(candidate([100L, 10L, 5L, 25L, 35L, 14L], 11L) == 9L);\n    assert(candidate([1L, 1L, 1L], 1L) == 0L);\n    assert(candidate([1L, 2L, 1L], 2L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given array contains consecutive numbers or not.\n\t\n*/\nbool check_Consecutive(long[] l) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_Consecutive;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == true);\n    assert(candidate([1L, 2L, 3L, 5L, 6L]) == false);\n    assert(candidate([1L, 2L, 1L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace characters in a string.\n\t\n*/\nstring replace_char(string str1, string ch, string newch) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = replace_char;\n\n    assert(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\");\n    assert(candidate(\"character\", \"c\", \"a\") == \"aharaater\");\n    assert(candidate(\"python\", \"l\", \"a\") == \"python\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an associative array by value.\n\t\n*/\nTuple!(string, long)[] sort_counter(Nullable!(long[string]) dict1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sort_counter;\n\n    assert(candidate([\"Math\": 81L, \"Physics\": 83L, \"Chemistry\": 87L].nullable) == [tuple(\"Chemistry\", 87L), tuple(\"Physics\", 83L), tuple(\"Math\", 81L)]);\n    assert(candidate([\"Math\": 400L, \"Physics\": 300L, \"Chemistry\": 250L].nullable) == [tuple(\"Math\", 400L), tuple(\"Physics\", 300L), tuple(\"Chemistry\", 250L)]);\n    assert(candidate([\"Math\": 900L, \"Physics\": 1000L, \"Chemistry\": 1250L].nullable) == [tuple(\"Chemistry\", 1250L), tuple(\"Physics\", 1000L), tuple(\"Math\", 900L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the largest and smallest value in a given array.\n\t\n*/\nlong big_sum(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = big_sum;\n\n    assert(candidate([1L, 2L, 3L]) == 4L);\n    assert(candidate([-1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([2L, 3L, 6L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert the given string to lower case.\n\t\n*/\nstring is_lower(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_lower;\n\n    assert(candidate(\"InValid\") == \"invalid\");\n    assert(candidate(\"TruE\") == \"true\");\n    assert(candidate(\"SenTenCE\") == \"sentence\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove lowercase substrings from a given string.\n\t\n*/\nstring remove_lowercase(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_lowercase;\n\n    assert(candidate(\"PYTHon\") == \"PYTH\");\n    assert(candidate(\"FInD\") == \"FID\");\n    assert(candidate(\"STRinG\") == \"STRG\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first digit of a given number.\n\t\n*/\nlong first_Digit(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = first_Digit;\n\n    assert(candidate(123L) == 1L);\n    assert(candidate(456L) == 4L);\n    assert(candidate(12L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n largest integers from a given array of numbers, returned in descending order.\n\t\n*/\nlong[] heap_queue_largest(long[] nums, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = heap_queue_largest;\n\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 3L) == [85L, 75L, 65L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 2L) == [85L, 75L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 22L, 58L], 5L) == [85L, 75L, 65L, 58L, 35L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array of integers and only returns the odd ones.\n\t\n*/\nlong[] Split(long[] list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == [1L, 3L, 5L]);\n    assert(candidate([10L, 11L, 12L, 13L]) == [11L, 13L]);\n    assert(candidate([7L, 8L, 9L, 1L]) == [7L, 9L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\n*/\nlong difference(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = difference;\n\n    assert(candidate(3L) == 30L);\n    assert(candidate(5L) == 210L);\n    assert(candidate(2L) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of pairs whose xor value is odd.\n\t\n*/\nlong find_Odd_Pair(long[] A, long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Odd_Pair;\n\n    assert(candidate([5L, 4L, 7L, 2L, 1L], 5L) == 6L);\n    assert(candidate([7L, 2L, 8L, 1L, 0L, 5L, 11L], 7L) == 12L);\n    assert(candidate([1L, 2L, 3L], 3L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to toggle the case of all characters in a string.\n\t\n*/\nstring toggle_string(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = toggle_string;\n\n    assert(candidate(\"Python\") == \"pYTHON\");\n    assert(candidate(\"Pangram\") == \"pANGRAM\");\n    assert(candidate(\"LIttLE\") == \"liTTle\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the per-digit difference between two integers.\n\t\n*/\nlong digit_distance_nums(long n1, long n2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = digit_distance_nums;\n\n    assert(candidate(1L, 2L) == 1L);\n    assert(candidate(23L, 56L) == 6L);\n    assert(candidate(123L, 256L) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the sum of the largest contiguous subarray in the given array.\n\t\n*/\nlong max_sub_array_sum(long[] a, long size) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_sub_array_sum;\n\n    assert(candidate([-2L, -3L, 4L, -1L, -2L, 1L, 5L, -3L], 8L) == 7L);\n    assert(candidate([-3L, -4L, 5L, -2L, -3L, 2L, 6L, -4L], 8L) == 8L);\n    assert(candidate([-4L, -5L, 6L, -3L, -4L, 3L, 7L, -5L], 8L) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the union of the elements of two given arrays and output them in sorted order.\n\t\n*/\nlong[] union_elements(long[] test_tup1, long[] test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = union_elements;\n\n    assert(candidate([3L, 4L, 5L, 6L], [5L, 7L, 4L, 10L]) == [3L, 4L, 5L, 6L, 7L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], [3L, 4L, 5L, 6L]) == [1L, 2L, 3L, 4L, 5L, 6L]);\n    assert(candidate([11L, 12L, 13L, 14L], [13L, 15L, 16L, 17L]) == [11L, 12L, 13L, 14L, 15L, 16L, 17L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the longest subarrays.\n\t\n*/\nlong Find_Max_Length(long[][] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Find_Max_Length;\n\n    assert(candidate([[1L], [1L, 4L], [5L, 6L, 7L, 8L]]) == 4L);\n    assert(candidate([[0L, 1L], [2L, 2L], [3L, 2L, 1L]]) == 3L);\n    assert(candidate([[7L], [22L, 23L], [13L, 14L, 15L], [10L, 20L, 30L, 40L, 50L]]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract values between quotation marks from a string.\n\t\n*/\nstring[] extract_values(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = extract_values;\n\n    assert(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"]);\n    assert(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"]);\n    assert(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\n*/\nlong count_Pairs(long[] arr, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_Pairs;\n\n    assert(candidate([1L, 2L, 1L], 3L) == 2L);\n    assert(candidate([1L, 1L, 1L, 1L], 4L) == 0L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], 5L) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to split a string into characters.\n\t\n*/\nstring[] split(string word) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = split;\n\n    assert(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n    assert(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"]);\n    assert(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\n*/\nlong sum_digits(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_digits;\n\n    assert(candidate(345L) == 12L);\n    assert(candidate(12L) == 3L);\n    assert(candidate(97L) == 16L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a specified array is sorted or not.\n\t\n*/\nbool issort_list(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = issort_list;\n\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 16L, 17L]) == true);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 12L, 14L, 20L, 17L]) == false);\n    assert(candidate([1L, 2L, 4L, 6L, 8L, 10L, 15L, 14L, 20L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create an array of N empty dictionaries.\n\t\n*/\nNone[] empty_list(long length) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = empty_list;\n\n    assert(candidate(5L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(6L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n    assert(candidate(7L) == [___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___, ___null_dict___]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort each subarray of strings in a given array of arrays.\n\t\n*/\nstring[][] sort_sublists(string[][] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sort_sublists;\n\n    assert(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n    assert(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n    assert(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check if a given number is one less than twice its reverse.\n\t\n*/\nbool checks(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = checks;\n\n    assert(candidate(70L) == false);\n    assert(candidate(23L) == false);\n    assert(candidate(73L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to remove duplicate numbers from a given number of arrays.\n\t\n*/\nlong[] two_unique_nums(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = two_unique_nums;\n\n    assert(candidate([1L, 2L, 3L, 2L, 3L, 4L, 5L]) == [1L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 2L, 4L, 5L]) == [1L, 3L, 4L, 5L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to calculate the product of the unique numbers in a given array.\n\t\n*/\nlong unique_product(long[] list_data) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = unique_product;\n\n    assert(candidate([10L, 20L, 30L, 40L, 20L, 50L, 60L, 40L]) == 720000000L);\n    assert(candidate([1L, 2L, 3L, 1L]) == 6L);\n    assert(candidate([7L, 8L, 9L, 0L, 1L, 1L]) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the surface area of a cylinder.\n\t\n*/\nfloat surfacearea_cylinder(long r, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = surfacearea_cylinder;\n\n    assert(candidate(10L, 5L) == 942.45);\n    assert(candidate(4L, 5L) == 226.18800000000002);\n    assert(candidate(4L, 10L) == 351.848);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether an array is subarray of another or not.\n\t\n*/\nbool is_Sub_Array(long[] A, long[] B) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_Sub_Array;\n\n    assert(candidate([1L, 4L, 3L, 5L], [1L, 2L]) == false);\n    assert(candidate([1L, 2L, 1L], [1L, 2L, 1L]) == true);\n    assert(candidate([1L, 0L, 2L, 2L], [2L, 2L, 0L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last digit in factorial of a given number.\n\t\n*/\nlong last_Digit_Factorial(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = last_Digit_Factorial;\n\n    assert(candidate(4L) == 4L);\n    assert(candidate(21L) == 0L);\n    assert(candidate(30L) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to interleave 3 arrays of the same length into a single flat array.\n\t\n*/\nlong[] interleave_lists(long[] list1, long[] list2, long[] list3) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = interleave_lists;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L], [10L, 20L, 30L, 40L, 50L, 60L, 70L], [100L, 200L, 300L, 400L, 500L, 600L, 700L]) == [1L, 10L, 100L, 2L, 20L, 200L, 3L, 30L, 300L, 4L, 40L, 400L, 5L, 50L, 500L, 6L, 60L, 600L, 7L, 70L, 700L]);\n    assert(candidate([10L, 20L], [15L, 2L], [5L, 10L]) == [10L, 15L, 5L, 20L, 2L, 10L]);\n    assert(candidate([11L, 44L], [10L, 15L], [20L, 5L]) == [11L, 10L, 20L, 44L, 15L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\n*/\nTuple!(long, long, long, long) find_dissimilar(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_dissimilar;\n\n    assert(candidate(tuple(3L, 4L, 5L, 6L), tuple(5L, 7L, 4L, 10L)) == tuple(3L, 6L, 7L, 10L));\n    assert(candidate(tuple(1L, 2L, 3L, 4L), tuple(7L, 2L, 3L, 9L)) == tuple(1L, 4L, 7L, 9L));\n    assert(candidate(tuple(21L, 11L, 25L, 26L), tuple(26L, 34L, 21L, 36L)) == tuple(34L, 36L, 11L, 25L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the largest number that can be formed with the given array of digits.\n\t\n*/\nlong find_Max_Num(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Max_Num;\n\n    assert(candidate([1L, 2L, 3L]) == 321L);\n    assert(candidate([4L, 5L, 6L, 1L]) == 6541L);\n    assert(candidate([1L, 2L, 3L, 9L]) == 9321L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the surface area of a square dramid with a given base edge and height.\n\t\n*/\nlong surface_Area(long b, long s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = surface_Area;\n\n    assert(candidate(3L, 4L) == 33L);\n    assert(candidate(4L, 5L) == 56L);\n    assert(candidate(1L, 2L) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which returns nth catalan number.\n\t\n*/\nlong catalan_number(long num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = catalan_number;\n\n    assert(candidate(10L) == 16796L);\n    assert(candidate(9L) == 4862L);\n    assert(candidate(7L) == 429L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\n*/\nstring find_adverbs(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_adverbs;\n\n    assert(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\");\n    assert(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\");\n    assert(candidate(\"Complete the task quickly\") == \"18-25: quickly\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\n*/\nNone[] expensive_items(None[] items, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = expensive_items;\n\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable], 2L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-1\", \"price\": 101.1].nullable]);\n    assert(candidate([[\"name\": \"Item-1\", \"price\": 101.1].nullable, [\"name\": \"Item-2\", \"price\": 555.22].nullable, [\"name\": \"Item-3\", \"price\": 45.09].nullable, [\"name\": \"Item-4\", \"price\": 22.75].nullable], 1L) == [[\"name\": \"Item-2\", \"price\": 555.22].nullable]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to split an array at the nth eelment and add the first part to the end.\n\t\n*/\nlong[] split_Arr(long[] l, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = split_Arr;\n\n    assert(candidate([12L, 10L, 5L, 6L, 52L, 36L], 2L) == [5L, 6L, 52L, 36L, 12L, 10L]);\n    assert(candidate([1L, 2L, 3L, 4L], 1L) == [2L, 3L, 4L, 1L]);\n    assert(candidate([0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L], 3L) == [3L, 4L, 5L, 6L, 7L, 0L, 1L, 2L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the difference between largest and smallest value in a given array.\n\t\n*/\nlong big_diff(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = big_diff;\n\n    assert(candidate([1L, 2L, 3L, 4L]) == 3L);\n    assert(candidate([4L, 5L, 12L]) == 8L);\n    assert(candidate([9L, 2L, 3L]) == 7L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find perfect squares between two given numbers.\n\t\n*/\nlong[] perfect_squares(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = perfect_squares;\n\n    assert(candidate(1L, 30L) == [1L, 4L, 9L, 16L, 25L]);\n    assert(candidate(50L, 100L) == [64L, 81L, 100L]);\n    assert(candidate(100L, 200L) == [100L, 121L, 144L, 169L, 196L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given two integers have opposite sign or not.\n\t\n*/\nbool opposite_Signs(long x, long y) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = opposite_Signs;\n\n    assert(candidate(1L, -2L) == true);\n    assert(candidate(3L, 2L) == false);\n    assert(candidate(-10L, -10L) == false);\n    assert(candidate(-2L, 2L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to interchange the first and last elements in an array.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([12L, 35L, 9L, 56L, 24L]) == [24L, 35L, 9L, 56L, 12L]);\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of the product of consecutive binomial co-efficients.\n\t\n*/\nlong sum_Of_product(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_Of_product;\n\n    assert(candidate(3L) == 15L);\n    assert(candidate(4L) == 56L);\n    assert(candidate(1L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove leading zeroes from an ip address.\n\t\n*/\nstring removezero_ip(string ip) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = removezero_ip;\n\n    assert(candidate(\"216.08.094.196\") == \"216.8.94.196\");\n    assert(candidate(\"12.01.024\") == \"12.1.24\");\n    assert(candidate(\"216.08.094.0196\") == \"216.8.94.196\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the difference of the first even and first odd number of a given array.\n\t\n*/\nlong diff_even_odd(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = diff_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 1L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\n*/\nlong find_kth(long[] arr1, long[] arr2, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_kth;\n\n    assert(candidate([2L, 3L, 6L, 7L, 9L], [1L, 4L, 8L, 10L], 5L) == 6L);\n    assert(candidate([100L, 112L, 256L, 349L, 770L], [72L, 86L, 113L, 119L, 265L, 445L, 892L], 7L) == 256L);\n    assert(candidate([3L, 4L, 7L, 8L, 10L], [2L, 5L, 9L, 11L], 6L) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is armstrong or not.\n\t\n*/\nbool armstrong_number(long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = armstrong_number;\n\n    assert(candidate(153L) == true);\n    assert(candidate(259L) == false);\n    assert(candidate(4458L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find sum and average of first n natural numbers.\n\t\n*/\nTuple!(long, float) sum_average(long number) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_average;\n\n    assert(candidate(10L) == tuple(55L, 5.5));\n    assert(candidate(15L) == tuple(120L, 8.0));\n    assert(candidate(20L) == tuple(210L, 10.5));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth octagonal number.\n\t\n*/\nlong is_octagonal(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_octagonal;\n\n    assert(candidate(5L) == 65L);\n    assert(candidate(10L) == 280L);\n    assert(candidate(15L) == 645L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number is even or not.\n\t\n*/\nbool is_Even(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_Even;\n\n    assert(candidate(1L) == false);\n    assert(candidate(2L) == true);\n    assert(candidate(3L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first repeated character in a given string.\n\t\n*/\nNullable!(string) first_repeated_char(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = first_repeated_char;\n\n{\n        auto result = candidate(\"abcabc\");\n        assert(!result.isNull && result.get == \"a\");\n}\n\n{\n        auto result = candidate(\"abc\");\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(\"123123\");\n        assert(!result.isNull && result.get == \"1\");\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\n*/\nlong[] get_ludic(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_ludic;\n\n    assert(candidate(10L) == [1L, 2L, 3L, 5L, 7L]);\n    assert(candidate(25L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L]);\n    assert(candidate(45L) == [1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 23L, 25L, 29L, 37L, 41L, 43L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\n*/\nstring reverse_words(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = reverse_words;\n\n    assert(candidate(\"python program\") == \"program python\");\n    assert(candidate(\"java language\") == \"language java\");\n    assert(candidate(\"indian man\") == \"man indian\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given integer is a prime number.\n\t\n*/\nbool prime_num(long num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = prime_num;\n\n    assert(candidate(13L) == true);\n    assert(candidate(7L) == true);\n    assert(candidate(-1010L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert degrees to radians.\n\t\n*/\nfloat radian_degree(long degree) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = radian_degree;\n\n    assert(candidate(90L) == 1.5707963267948966);\n    assert(candidate(60L) == 1.0471975511965976);\n    assert(candidate(120L) == 2.0943951023931953);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\n*/\nTuple!(string, long, long) find_literals(string text, string pattern) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_literals;\n\n    assert(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == tuple(\"fox\", 16L, 19L));\n    assert(candidate(\"Its been a very crazy procedure right\", \"crazy\") == tuple(\"crazy\", 16L, 21L));\n    assert(candidate(\"Hardest choices required strongest will\", \"will\") == tuple(\"will\", 35L, 39L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find nth bell number.\n\t\n*/\nlong bell_Number(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = bell_Number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(3L) == 5L);\n    assert(candidate(4L) == 15L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function which takes an array and returns an array with the same elements, but the k'th element removed.\n\t\n*/\nlong[] remove_kth_element(long[] list1, long L) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_kth_element;\n\n    assert(candidate([1L, 1L, 2L, 3L, 4L, 4L, 5L, 1L], 3L) == [1L, 1L, 3L, 4L, 4L, 5L, 1L]);\n    assert(candidate([0L, 0L, 1L, 2L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L], 4L) == [0L, 0L, 1L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 9L, 4L, 4L]);\n    assert(candidate([10L, 10L, 15L, 19L, 18L, 18L, 17L, 26L, 26L, 17L, 18L, 10L], 5L) == [10L, 10L, 15L, 19L, 18L, 17L, 26L, 26L, 17L, 18L, 10L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which given a matrix represented as an array of arrays returns the max of the n'th column.\n\t\n*/\nlong max_of_nth(long[][] test_list, long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_of_nth;\n\n    assert(candidate([[5L, 6L, 7L], [1L, 3L, 5L], [8L, 9L, 19L]], 2L) == 19L);\n    assert(candidate([[6L, 7L, 8L], [2L, 4L, 6L], [9L, 10L, 20L]], 1L) == 10L);\n    assert(candidate([[7L, 8L, 9L], [3L, 5L, 7L], [10L, 11L, 21L]], 1L) == 11L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the cumulative sum of all the values that are present in the given array of arrays.\n\t\n*/\nlong cummulative_sum(long[][] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = cummulative_sum;\n\n    assert(candidate([[1L, 3L], [5L, 6L, 7L], [2L, 6L]]) == 30L);\n    assert(candidate([[2L, 4L], [6L, 7L, 8L], [3L, 7L]]) == 37L);\n    assert(candidate([[3L, 5L], [7L, 8L, 9L], [4L, 8L]]) == 44L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes an arrays of arrays and returns the average value for each subarray as an array.\n\t\n*/\nfloat[] average_tuple(long[][] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = average_tuple;\n\n    assert(candidate([[10L, 10L, 10L, 12L], [30L, 45L, 56L, 45L], [81L, 80L, 39L, 32L], [1L, 2L, 3L, 4L]]) == [30.5, 34.25, 27.0, 23.25]);\n    assert(candidate([[1L, 1L, -5L], [30L, -15L, 56L], [81L, -60L, -39L], [-10L, 2L, 3L]]) == [25.5, -18.0, 3.75]);\n    assert(candidate([[100L, 100L, 100L, 120L], [300L, 450L, 560L, 450L], [810L, 800L, 390L, 320L], [10L, 20L, 30L, 40L]]) == [305.0, 342.5, 270.0, 232.5]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\n*/\nTuple!(long, long, long, long) tuple_modulo(Tuple!(long, long, long, long) test_tup1, Tuple!(long, long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tuple_modulo;\n\n    assert(candidate(tuple(10L, 4L, 5L, 6L), tuple(5L, 6L, 7L, 5L)) == tuple(0L, 4L, 5L, 1L));\n    assert(candidate(tuple(11L, 5L, 6L, 7L), tuple(6L, 7L, 8L, 6L)) == tuple(5L, 5L, 6L, 1L));\n    assert(candidate(tuple(12L, 6L, 7L, 8L), tuple(7L, 8L, 9L, 7L)) == tuple(5L, 6L, 7L, 1L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\n*/\nfloat min_Jumps(Tuple!(long, long) steps, long d) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = min_Jumps;\n\n    assert(candidate(tuple(3L, 4L), 11L) == 3.5);\n    assert(candidate(tuple(3L, 4L), 0L) == 0L);\n    assert(candidate(tuple(11L, 14L), 11L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to divide two arrays element wise.\n\t\n*/\nfloat[] div_list(long[] nums1, long[] nums2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = div_list;\n\n    assert(candidate([4L, 5L, 6L], [1L, 2L, 3L]) == [4.0, 2.5, 2.0]);\n    assert(candidate([3L, 2L], [1L, 4L]) == [3.0, 0.5]);\n    assert(candidate([90L, 120L], [50L, 70L]) == [1.8, 1.7142857142857142]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to move all the numbers to the end of the given string.\n\t\n*/\nstring move_num(string test_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = move_num;\n\n    assert(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\");\n    assert(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\");\n    assert(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of substrings with the sum of digits equal to their length.\n\t\n*/\nlong count_Substrings(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_Substrings;\n\n    assert(candidate(\"112112\") == 6L);\n    assert(candidate(\"111\") == 6L);\n    assert(candidate(\"1101112\") == 12L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the median of two sorted arrays of same size.\n\t\n*/\nfloat get_median(long[] arr1, long[] arr2, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_median;\n\n    assert(candidate([1L, 12L, 15L, 26L, 38L], [2L, 13L, 17L, 30L, 45L], 5L) == 16.0);\n    assert(candidate([2L, 4L, 8L, 9L], [7L, 13L, 19L, 28L], 4L) == 8.5);\n    assert(candidate([3L, 6L, 14L, 23L, 36L, 42L], [2L, 18L, 27L, 39L, 49L, 55L], 6L) == 25.0);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to compute the n-th power of each number in an array.\n\t\n*/\nlong[] nth_nums(long[] nums, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = nth_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L], 3L) == [1000L, 8000L, 27000L]);\n    assert(candidate([12L, 15L], 5L) == [248832L, 759375L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to convert a given string to uppercase.\n\t\n*/\nstring is_upper(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_upper;\n\n    assert(candidate(\"person\") == \"PERSON\");\n    assert(candidate(\"final\") == \"FINAL\");\n    assert(candidate(\"Valid\") == \"VALID\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to interchange the first and last element in a given array.\n\t\n*/\nlong[] swap_List(long[] newList) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = swap_List;\n\n    assert(candidate([1L, 2L, 3L]) == [3L, 2L, 1L]);\n    assert(candidate([1L, 2L, 3L, 4L, 4L]) == [4L, 2L, 3L, 4L, 1L]);\n    assert(candidate([4L, 5L, 6L]) == [6L, 5L, 4L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\n*/\nNullable!(long) triangle_area(long r) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = triangle_area;\n\n{\n        auto result = candidate(-1L);\n        assert(result.isNull);\n}\n\n{\n        auto result = candidate(0L);\n        assert(!result.isNull && result.get == 0L);\n}\n\n{\n        auto result = candidate(2L);\n        assert(!result.isNull && result.get == 4L);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the smallest missing number from a sorted array of natural numbers.\n\t\n*/\nlong find_First_Missing(long[] array) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_First_Missing;\n\n    assert(candidate([0L, 1L, 2L, 3L]) == 4L);\n    assert(candidate([0L, 1L, 2L, 6L, 9L]) == 3L);\n    assert(candidate([2L, 3L, 5L, 8L, 9L]) == 0L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\n*/\nstring replace_spaces(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\");\n    assert(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\");\n    assert(candidate(\"I love Coding\") == \"I%20love%20Coding\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find even numbers from an array of numbers.\n\t\n*/\nlong[] Split(long[] list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Split;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == [2L, 4L]);\n    assert(candidate([4L, 5L, 6L, 7L, 8L, 0L, 1L]) == [4L, 6L, 8L, 0L]);\n    assert(candidate([8L, 12L, 15L, 19L]) == [8L, 12L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find smallest number in an array.\n\t\n*/\nlong smallest_num(long[] xs) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = smallest_num;\n\n    assert(candidate([10L, 20L, 1L, 45L, 99L]) == 1L);\n    assert(candidate([1L, 2L, 3L]) == 1L);\n    assert(candidate([45L, 46L, 50L, 60L]) == 45L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\n*/\nlong[][] get_coordinates(Tuple!(long, long) test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_coordinates;\n\n    assert(candidate(tuple(3L, 4L)) == [[2L, 3L], [2L, 4L], [2L, 5L], [3L, 3L], [3L, 4L], [3L, 5L], [4L, 3L], [4L, 4L], [4L, 5L]]);\n    assert(candidate(tuple(4L, 5L)) == [[3L, 4L], [3L, 5L], [3L, 6L], [4L, 4L], [4L, 5L], [4L, 6L], [5L, 4L], [5L, 5L], [5L, 6L]]);\n    assert(candidate(tuple(5L, 6L)) == [[4L, 5L], [4L, 6L], [4L, 7L], [5L, 5L], [5L, 6L], [5L, 7L], [6L, 5L], [6L, 6L], [6L, 7L]]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\n*/\nstring replace_spaces(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = replace_spaces;\n\n    assert(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\");\n    assert(candidate(\"The_Avengers\") == \"The Avengers\");\n    assert(candidate(\"Fast and Furious\") == \"Fast_and_Furious\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to move all zeroes to the end of the given array.\n\t\n*/\nlong[] move_zero(long[] num_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = move_zero;\n\n    assert(candidate([1L, 0L, 2L, 0L, 3L, 4L]) == [1L, 2L, 3L, 4L, 0L, 0L]);\n    assert(candidate([2L, 3L, 2L, 0L, 0L, 4L, 0L, 5L, 0L]) == [2L, 3L, 2L, 4L, 5L, 0L, 0L, 0L, 0L]);\n    assert(candidate([0L, 1L, 0L, 1L, 1L]) == [1L, 1L, 1L, 0L, 0L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of xor of all pairs of numbers in the given array.\n\t\n*/\nlong pair_xor_Sum(long[] arr, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pair_xor_Sum;\n\n    assert(candidate([5L, 9L, 7L, 6L], 4L) == 47L);\n    assert(candidate([7L, 3L, 5L], 3L) == 12L);\n    assert(candidate([7L, 3L], 2L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort the given array.\n\t\n*/\nlong[] heap_sort(long[] iterable) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = heap_sort;\n\n    assert(candidate([1L, 3L, 5L, 7L, 9L, 2L, 4L, 6L, 8L, 0L]) == [0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L]);\n    assert(candidate([25L, 35L, 22L, 85L, 14L, 65L, 75L, 25L, 58L]) == [14L, 22L, 25L, 25L, 35L, 58L, 65L, 75L, 85L]);\n    assert(candidate([7L, 1L, 9L, 5L]) == [1L, 5L, 7L, 9L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\n*/\nbool noprofit_noloss(long actual_cost, long sale_amount) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = noprofit_noloss;\n\n    assert(candidate(1500L, 1200L) == false);\n    assert(candidate(100L, 100L) == true);\n    assert(candidate(2000L, 5000L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\n*/\nlong wind_chill(long v, long t) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = wind_chill;\n\n    assert(candidate(120L, 35L) == 40L);\n    assert(candidate(40L, 20L) == 19L);\n    assert(candidate(10L, 8L) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\n\t\n*/\nlong sample_nam(string[] sample_names) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sample_nam;\n\n    assert(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16L);\n    assert(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10L);\n    assert(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the maximum difference between available pairs in the given tuple array.\n\t\n*/\nlong max_difference(Tuple!(long, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_difference;\n\n    assert(candidate([tuple(3L, 5L), tuple(1L, 7L), tuple(10L, 3L), tuple(1L, 2L)]) == 7L);\n    assert(candidate([tuple(4L, 6L), tuple(2L, 17L), tuple(9L, 13L), tuple(11L, 12L)]) == 15L);\n    assert(candidate([tuple(12L, 35L), tuple(21L, 27L), tuple(13L, 23L), tuple(41L, 22L)]) == 23L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\n*/\nstring remove_parenthesis(string[] items) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_parenthesis;\n\n    assert(candidate([\"python (chrome)\"]) == \"python\");\n    assert(candidate([\"string(.abc)\"]) == \"string\");\n    assert(candidate([\"alpha(num)\"]) == \"alpha\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth nonagonal number.\n\t\n*/\nlong is_nonagonal(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_nonagonal;\n\n    assert(candidate(10L) == 325L);\n    assert(candidate(15L) == 750L);\n    assert(candidate(18L) == 1089L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\n*/\nbool text_match_wordz_middle(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_wordz_middle;\n\n    assert(candidate(\"pythonzabc.\") == true);\n    assert(candidate(\"zxyabc.\") == false);\n    assert(candidate(\"  lang  .\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to reverse an array upto a given position.\n\t\n*/\nlong[] reverse_Array_Upto_K(long[] input, long k) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = reverse_Array_Upto_K;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 4L) == [4L, 3L, 2L, 1L, 5L, 6L]);\n    assert(candidate([4L, 5L, 6L, 7L], 2L) == [5L, 4L, 6L, 7L]);\n    assert(candidate([9L, 8L, 7L, 6L, 5L], 3L) == [7L, 8L, 9L, 6L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of tuples using the second value of each tuple.\n\t\n*/\nTuple!(string, long)[] subject_marks(Tuple!(string, long)[] subjectmarks) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = subject_marks;\n\n    assert(candidate([tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L), tuple(\"Social sciences\", 82L)]) == [tuple(\"Social sciences\", 82L), tuple(\"English\", 88L), tuple(\"Science\", 90L), tuple(\"Maths\", 97L)]);\n    assert(candidate([tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L), tuple(\"Social\", 33L)]) == [tuple(\"Social\", 33L), tuple(\"Telugu\", 49L), tuple(\"Hindhi\", 54L)]);\n    assert(candidate([tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L), tuple(\"Biology\", 45L)]) == [tuple(\"Biology\", 45L), tuple(\"Physics\", 96L), tuple(\"Chemistry\", 97L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of positive numbers in an array.\n\t\n*/\nlong pos_count(long[] list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pos_count;\n\n    assert(candidate([1L, -2L, 3L, -4L]) == 2L);\n    assert(candidate([3L, 4L, 5L, -1L]) == 3L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\n*/\nlong bell_number(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = bell_number;\n\n    assert(candidate(2L) == 2L);\n    assert(candidate(10L) == 115975L);\n    assert(candidate(56L) == 6775685320645824322581483068371419745979053216268760300L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given array is monotonic or not.\n\t\n*/\nbool is_Monotonic(long[] A) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_Monotonic;\n\n    assert(candidate([6L, 5L, 4L, 4L]) == true);\n    assert(candidate([1L, 2L, 2L, 3L]) == true);\n    assert(candidate([1L, 3L, 2L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether an array contains the given subarray or not.\n\t\n*/\nbool is_sublist(long[] l, long[] s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_sublist;\n\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [3L, 7L]) == false);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [4L, 3L]) == true);\n    assert(candidate([2L, 4L, 3L, 5L, 7L], [1L, 6L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the two numbers differ at one bit position only or not.\n\t\n*/\nbool differ_At_One_Bit_Pos(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = differ_At_One_Bit_Pos;\n\n    assert(candidate(13L, 9L) == true);\n    assert(candidate(15L, 8L) == false);\n    assert(candidate(2L, 4L) == false);\n    assert(candidate(2L, 3L) == true);\n    assert(candidate(5L, 1L) == true);\n    assert(candidate(1L, 5L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find whether all the given arrays have equal length or not.\n\t\n*/\nbool get_equal(long[][] Input) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_equal;\n\n    assert(candidate([[11L, 22L, 33L], [44L, 55L, 66L]]) == true);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L, 7L]]) == false);\n    assert(candidate([[1L, 2L], [3L, 4L]]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort an array of elements.\n\t\n*/\nlong[] comb_sort(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = comb_sort;\n\n    assert(candidate([5L, 15L, 37L, 25L, 79L]) == [5L, 15L, 25L, 37L, 79L]);\n    assert(candidate([41L, 32L, 15L, 19L, 22L]) == [15L, 19L, 22L, 32L, 41L]);\n    assert(candidate([99L, 15L, 13L, 47L]) == [13L, 15L, 47L, 99L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add an associative array to the tuple. The output should be a tuple.\n\t\n*/\nTuple!(long, long, long, Nullable!(long[string])) add_dict_to_tuple(Tuple!(long, long, long) test_tup, Nullable!(long[string]) test_dict) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add_dict_to_tuple;\n\n    assert(candidate(tuple(4L, 5L, 6L), [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable) == tuple(4L, 5L, 6L, [\"MSAM\": 1L, \"is\": 2L, \"best\": 3L].nullable));\n    assert(candidate(tuple(1L, 2L, 3L), [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable) == tuple(1L, 2L, 3L, [\"UTS\": 2L, \"is\": 3L, \"Worst\": 4L].nullable));\n    assert(candidate(tuple(8L, 9L, 10L), [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable) == tuple(8L, 9L, 10L, [\"POS\": 3L, \"is\": 4L, \"Okay\": 5L].nullable));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\n*/\nfloat maxAverageOfPath(long[][] cost) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = maxAverageOfPath;\n\n    assert(candidate([[1L, 2L, 3L], [6L, 5L, 4L], [7L, 3L, 9L]]) == 5.2);\n    assert(candidate([[2L, 3L, 4L], [7L, 6L, 5L], [8L, 4L, 10L]]) == 6.2);\n    assert(candidate([[3L, 4L, 5L], [8L, 7L, 6L], [9L, 5L, 11L]]) == 7.2);\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [7L, 8L, 9L]]) == 5.8);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tThe input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\n\t\n*/\nlong count_same_pair(long[] nums1, long[] nums2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_same_pair;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L], [2L, 2L, 3L, 1L, 2L, 6L, 7L, 9L]) == 4L);\n    assert(candidate([0L, 1L, 2L, -1L, -5L, 6L, 0L, -3L, -2L, 3L, 4L, 6L, 8L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 11L);\n    assert(candidate([2L, 4L, -6L, -9L, 11L, -12L, 14L, -5L, 17L], [2L, 1L, 2L, -1L, -5L, 6L, 4L, -3L, -2L, 3L, 4L, 6L, 8L]) == 1L);\n    assert(candidate([0L, 1L, 1L, 2L], [0L, 1L, 2L, 2L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\n*/\nlong power_base_sum(long base, long power) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = power_base_sum;\n\n    assert(candidate(2L, 100L) == 115L);\n    assert(candidate(8L, 10L) == 37L);\n    assert(candidate(8L, 15L) == 62L);\n    assert(candidate(3L, 3L) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\n*/\nlong[] sum_list(long[] lst1, long[] lst2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_list;\n\n    assert(candidate([10L, 20L, 30L], [15L, 25L, 35L]) == [25L, 45L, 65L]);\n    assert(candidate([1L, 2L, 3L], [5L, 6L, 7L]) == [6L, 8L, 10L]);\n    assert(candidate([15L, 20L, 30L], [15L, 45L, 75L]) == [30L, 65L, 105L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the given number can be represented as the difference of two squares or not.\n\t\n*/\nbool dif_Square(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = dif_Square;\n\n    assert(candidate(5L) == true);\n    assert(candidate(10L) == false);\n    assert(candidate(15L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\n*/\nfloat lateralsurface_cone(long r, long h) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = lateralsurface_cone;\n\n    assert(candidate(5L, 12L) == 204.20352248333654);\n    assert(candidate(10L, 15L) == 566.3586699569488);\n    assert(candidate(19L, 17L) == 1521.8090132193388);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\n*/\nstring replace_specialchar(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = replace_specialchar;\n\n    assert(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\");\n    assert(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\");\n    assert(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\n*/\nlong find_first_occurrence(long[] A, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_first_occurrence;\n\n    assert(candidate([2L, 5L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 1L);\n    assert(candidate([2L, 3L, 5L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 5L) == 2L);\n    assert(candidate([2L, 4L, 1L, 5L, 6L, 6L, 8L, 9L, 9L, 9L], 6L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\n*/\nlong sum_Of_Subarray_Prod(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_Of_Subarray_Prod;\n\n    assert(candidate([1L, 2L, 3L]) == 20L);\n    assert(candidate([1L, 2L]) == 5L);\n    assert(candidate([1L, 2L, 3L, 4L]) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\n*/\nlong toggle_middle_bits(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = toggle_middle_bits;\n\n    assert(candidate(9L) == 15L);\n    assert(candidate(10L) == 12L);\n    assert(candidate(11L) == 13L);\n    assert(candidate(65L) == 127L);\n    assert(candidate(77L) == 115L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/dthon-exercises/data-structures-and-algorithms/dthon-data-structure-exercise-24.php\n\t\n*/\nlong left_insertion(long[] a, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = left_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\n*/\nbool check_str(string string) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_str;\n\n    assert(candidate(\"annie\") == true);\n    assert(candidate(\"dawood\") == false);\n    assert(candidate(\"Else\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/dthon-exercises/data-structures-and-algorithms/dthon-recursion-exercise-9.php\n\t\n*/\nfloat geometric_sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = geometric_sum;\n\n    assert(candidate(7L) == 1.9921875);\n    assert(candidate(4L) == 1.9375);\n    assert(candidate(8L) == 1.99609375);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\n*/\nlong find_Index(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Index;\n\n    assert(candidate(2L) == 4L);\n    assert(candidate(3L) == 14L);\n    assert(candidate(4L) == 45L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given tuple to a key-value associative array using adjacent elements. https://www.geeksforgeeks.org/dthon-convert-tuple-to-adjacent-pair-associative array/\n\t\n*/\nNullable!(long[long]) tuple_to_dict(Tuple!(long, long, long, long, long, long) test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tuple_to_dict;\n\n{\n        auto result = candidate(tuple(1L, 5L, 7L, 10L, 13L, 5L));\n        assert(!result.isNull && result.get == [1L: 5L, 7L: 10L, 13L: 5L]);\n}\n\n{\n        auto result = candidate(tuple(1L, 2L, 3L, 4L, 5L, 6L));\n        assert(!result.isNull && result.get == [1L: 2L, 3L: 4L, 5L: 6L]);\n}\n\n{\n        auto result = candidate(tuple(7L, 8L, 9L, 10L, 11L, 12L));\n        assert(!result.isNull && result.get == [7L: 8L, 9L: 10L, 11L: 12L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether all the characters are same or not.\n\t\n*/\nbool all_Characters_Same(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = all_Characters_Same;\n\n    assert(candidate(\"python\") == false);\n    assert(candidate(\"aaa\") == true);\n    assert(candidate(\"data\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\n*/\nfloat area_tetrahedron(long side) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = area_tetrahedron;\n\n    assert(candidate(3L) == 15.588457268119894);\n    assert(candidate(20L) == 692.8203230275509);\n    assert(candidate(10L) == 173.20508075688772);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/dthon-program-right-rotate-array-n/\n\t\n*/\nlong[] rotate_right(long[] list, long m) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rotate_right;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 3L) == [8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 2L) == [9L, 10L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L], 5L) == [6L, 7L, 8L, 9L, 10L, 1L, 2L, 3L, 4L, 5L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/dthon-exercises/lambda/dthon-lambda-exercise-24.php\n\t\n*/\nlong[] divisible_by_digits(long startnum, long endnum) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = divisible_by_digits;\n\n    assert(candidate(1L, 22L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L, 22L]);\n    assert(candidate(1L, 15L) == [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 11L, 12L, 15L]);\n    assert(candidate(20L, 25L) == [22L, 24L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n\t\n*/\nNullable!(float) sector_area(long r, long a) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sector_area;\n\n{\n        auto result = candidate(4L, 45L);\n        assert(!result.isNull && result.get == 6.283185307179586);\n}\n\n{\n        auto result = candidate(9L, 45L);\n        assert(!result.isNull && result.get == 31.808625617596654);\n}\n\n{\n        auto result = candidate(9L, 361L);\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\n*/\nlong lcs_of_three(string X, string Y, string Z) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = lcs_of_three;\n\n    assert(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2L);\n    assert(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5L);\n    assert(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\n*/\nstring capital_words_spaces(string str1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = capital_words_spaces;\n\n    assert(candidate(\"Python\") == \"Python\");\n    assert(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\");\n    assert(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/dthon-sort-numeric-strings-in-a-array/\n\t\n*/\nlong[] sort_numeric_strings(string[] nums_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sort_numeric_strings;\n\n    assert(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500L, -12L, 0L, 4L, 7L, 12L, 45L, 100L, 200L]);\n    assert(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1L, 1L, 1L, 2L, 2L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 6L, 6L, 6L, 7L, 8L, 8L, 9L, 9L]);\n    assert(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1L, 1L, 1L, 3L, 3L, 5L, 5L, 7L, 7L, 9L, 11L, 13L, 15L, 17L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\n*/\nbool is_samepatterns(string[] colors, string[] patterns) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_samepatterns;\n\n    assert(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false);\n    assert(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to add the given tuple to the given array.\n\t\n*/\nlong[] add_tuple(long[] test_list, Tuple!(long, long) test_tup) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = add_tuple;\n\n    assert(candidate([5L, 6L, 7L], tuple(9L, 10L)) == [5L, 6L, 7L, 9L, 10L]);\n    assert(candidate([6L, 7L, 8L], tuple(10L, 11L)) == [6L, 7L, 8L, 10L, 11L]);\n    assert(candidate([7L, 8L, 9L], tuple(11L, 12L)) == [7L, 8L, 9L, 11L, 12L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\n*/\nbool check_min_heap(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_min_heap;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L]) == true);\n    assert(candidate([2L, 3L, 4L, 5L, 10L, 15L]) == true);\n    assert(candidate([2L, 10L, 4L, 5L, 3L, 15L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\n*/\nlong jacobsthal_num(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = jacobsthal_num;\n\n    assert(candidate(5L) == 11L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(4L) == 5L);\n    assert(candidate(13L) == 2731L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find minimum k records from tuple array. https://www.geeksforgeeks.org/dthon-find-minimum-k-records-from-tuple-array/ - in this case a verbatim cod of test cases\n\t\n*/\nTuple!(string, long)[] min_k(Tuple!(string, long)[] test_list, long K) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = min_k;\n\n    assert(candidate([tuple(\"Manjeet\", 10L), tuple(\"Akshat\", 4L), tuple(\"Akash\", 2L), tuple(\"Nikhil\", 8L)], 2L) == [tuple(\"Akash\", 2L), tuple(\"Akshat\", 4L)]);\n    assert(candidate([tuple(\"Sanjeev\", 11L), tuple(\"Angat\", 5L), tuple(\"Akash\", 3L), tuple(\"Nepin\", 9L)], 3L) == [tuple(\"Akash\", 3L), tuple(\"Angat\", 5L), tuple(\"Nepin\", 9L)]);\n    assert(candidate([tuple(\"tanmay\", 14L), tuple(\"Amer\", 11L), tuple(\"Ayesha\", 9L), tuple(\"SKD\", 16L)], 1L) == [tuple(\"Ayesha\", 9L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/dthon-exercises/re/dthon-re-exercise-3.php\n\t\n*/\nbool text_match_zero_one(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_zero_one;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"dsabbbba\") == true);\n    assert(candidate(\"asbbbba\") == false);\n    assert(candidate(\"abaaa\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/dthon-program-to-count-the-pairs-of-reverse-strings/\n\t\n*/\nlong count_reverse_pairs(string[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_reverse_pairs;\n\n    assert(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2L);\n    assert(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1L);\n    assert(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\n*/\nbool is_decimal(string num) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_decimal;\n\n    assert(candidate(\"123.11\") == true);\n    assert(candidate(\"e666.86\") == false);\n    assert(candidate(\"3.124587\") == false);\n    assert(candidate(\"1.11\") == true);\n    assert(candidate(\"1.1.11\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find tuples which have all elements divisible by k from the given array of tuples.\n\t\n*/\nTuple!(long, long, long)[] find_tuples(Tuple!(long, long, long)[] test_list, long K) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_tuples;\n\n    assert(candidate([tuple(6L, 24L, 12L), tuple(7L, 9L, 6L), tuple(12L, 18L, 21L)], 6L) == [tuple(6L, 24L, 12L)]);\n    assert(candidate([tuple(5L, 25L, 30L), tuple(4L, 2L, 3L), tuple(7L, 8L, 9L)], 5L) == [tuple(5L, 25L, 30L)]);\n    assert(candidate([tuple(7L, 9L, 16L), tuple(8L, 16L, 4L), tuple(19L, 17L, 18L)], 4L) == [tuple(8L, 16L, 4L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether an array of numbers contains only one distinct element or not.\n\t\n*/\nbool unique_Element(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = unique_Element;\n\n    assert(candidate([1L, 1L, 1L]) == true);\n    assert(candidate([1L, 2L, 1L, 2L]) == false);\n    assert(candidate([1L, 2L, 3L, 4L, 5L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\n*/\nbool check_monthnumber_number(long monthnum3) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_monthnumber_number;\n\n    assert(candidate(6L) == true);\n    assert(candidate(2L) == false);\n    assert(candidate(12L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\n*/\nlong find_min_diff(long[] arr, long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_min_diff;\n\n    assert(candidate([1L, 5L, 3L, 19L, 18L, 25L], 6L) == 1L);\n    assert(candidate([4L, 3L, 2L, 6L], 4L) == 1L);\n    assert(candidate([30L, 5L, 20L, 9L], 4L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count number of digits in a given string.\n\t\n*/\nlong number_ctr(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = number_ctr;\n\n    assert(candidate(\"program2bedone\") == 1L);\n    assert(candidate(\"3wonders\") == 1L);\n    assert(candidate(\"123\") == 3L);\n    assert(candidate(\"3wond-1ers2\") == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\n*/\nlong is_polite(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_polite;\n\n    assert(candidate(7L) == 11L);\n    assert(candidate(4L) == 7L);\n    assert(candidate(9L) == 13L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to return an array of all pairs of consecutive items in a given array.\n\t\n*/\nTuple!(long, long)[] pair_wise(long[] l1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = pair_wise;\n\n    assert(candidate([1L, 1L, 2L, 3L, 3L, 4L, 4L, 5L]) == [tuple(1L, 1L), tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 3L), tuple(3L, 4L), tuple(4L, 4L), tuple(4L, 5L)]);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == [tuple(1L, 5L), tuple(5L, 7L), tuple(7L, 9L), tuple(9L, 10L)]);\n    assert(candidate([5L, 1L, 9L, 7L, 10L]) == [tuple(5L, 1L), tuple(1L, 9L), tuple(9L, 7L), tuple(7L, 10L)]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [tuple(1L, 2L), tuple(2L, 3L), tuple(3L, 4L), tuple(4L, 5L), tuple(5L, 6L), tuple(6L, 7L), tuple(7L, 8L), tuple(8L, 9L), tuple(9L, 10L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\n\t\n*/\nlong get_pairs_count(long[] arr, long sum) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_pairs_count;\n\n    assert(candidate([1L, 1L, 1L, 1L], 2L) == 6L);\n    assert(candidate([1L, 5L, 7L, -1L, 5L], 6L) == 3L);\n    assert(candidate([1L, -2L, 3L], 1L) == 1L);\n    assert(candidate([-1L, -2L, 3L], -3L) == 1L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to get the difference between two arrays.\n\t\n*/\nlong[] Diff(long[] li1, long[] li2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Diff;\n\n    assert(candidate([10L, 15L, 20L, 25L, 30L, 35L, 40L], [25L, 40L, 35L]) == [10L, 20L, 30L, 15L]);\n    assert(candidate([1L, 2L, 3L, 4L, 5L], [6L, 7L, 1L]) == [2L, 3L, 4L, 5L, 6L, 7L]);\n    assert(candidate([1L, 2L, 3L], [6L, 7L, 1L]) == [2L, 3L, 6L, 7L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of fourth power of first n odd natural numbers.\n\t\n*/\nlong odd_num_sum(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = odd_num_sum;\n\n    assert(candidate(2L) == 82L);\n    assert(candidate(3L) == 707L);\n    assert(candidate(4L) == 3108L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\n*/\nbool check_expression(string exp) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_expression;\n\n    assert(candidate(\"{()}[{}]\") == true);\n    assert(candidate(\"{()}[{]\") == false);\n    assert(candidate(\"{()}[{}][]({})\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all the words with k length in the given string.\n\t\n*/\nstring remove_length(string test_str, long K) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_length;\n\n    assert(candidate(\"The person is most value tet\", 3L) == \"person is most value\");\n    assert(candidate(\"If you told me about this ok\", 4L) == \"If you me about ok\");\n    assert(candidate(\"Forces of darkeness is come into the play\", 4L) == \"Forces of darkeness is the\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n\t\n*/\nNullable!(Tuple!(string, long, long)) occurance_substring(string text, string pattern) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = occurance_substring;\n\n{\n        auto result = candidate(\"python programming, python language\", \"python\");\n        assert(!result.isNull && result.get == tuple(\"python\", 0L, 6L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"programming\");\n        assert(!result.isNull && result.get == tuple(\"programming\", 7L, 18L));\n}\n\n{\n        auto result = candidate(\"python programming,programming language\", \"language\");\n        assert(!result.isNull && result.get == tuple(\"language\", 31L, 39L));\n}\n\n{\n        auto result = candidate(\"c++ programming, c++ language\", \"python\");\n        assert(result.isNull);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether every odd index contains odd numbers of a given array.\n\t\n*/\nbool odd_position(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = odd_position;\n\n    assert(candidate([2L, 1L, 4L, 3L, 6L, 7L, 6L, 3L]) == true);\n    assert(candidate([4L, 1L, 2L]) == true);\n    assert(candidate([1L, 2L, 3L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\n*/\nlong count_vowels(string test_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_vowels;\n\n    assert(candidate(\"bestinstareels\") == 7L);\n    assert(candidate(\"partofthejourneyistheend\") == 12L);\n    assert(candidate(\"amazonprime\") == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of non-repeated elements in a given array.\n\t\n*/\nlong find_sum(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_sum;\n\n    assert(candidate([1L, 2L, 3L, 1L, 1L, 4L, 5L, 6L]) == 21L);\n    assert(candidate([1L, 10L, 9L, 4L, 2L, 10L, 10L, 45L, 4L]) == 71L);\n    assert(candidate([12L, 10L, 9L, 45L, 2L, 10L, 10L, 45L, 10L]) == 78L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find whether a number is divisible by 11.\n\t\n*/\nbool is_Diff(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_Diff;\n\n    assert(candidate(12345L) == false);\n    assert(candidate(1212112L) == true);\n    assert(candidate(1212L) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the combinations of sums with tuples in the given tuple array. https://www.geeksforgeeks.org/dthon-combinations-of-sum-with-tuples-in-tuple-array/\n\t\n*/\nTuple!(long, long)[] find_combinations(Tuple!(long, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_combinations;\n\n    assert(candidate([tuple(2L, 4L), tuple(6L, 7L), tuple(5L, 1L), tuple(6L, 10L)]) == [tuple(8L, 11L), tuple(7L, 5L), tuple(8L, 14L), tuple(11L, 8L), tuple(12L, 17L), tuple(11L, 11L)]);\n    assert(candidate([tuple(3L, 5L), tuple(7L, 8L), tuple(6L, 2L), tuple(7L, 11L)]) == [tuple(10L, 13L), tuple(9L, 7L), tuple(10L, 16L), tuple(13L, 10L), tuple(14L, 19L), tuple(13L, 13L)]);\n    assert(candidate([tuple(4L, 6L), tuple(8L, 9L), tuple(7L, 3L), tuple(8L, 12L)]) == [tuple(12L, 15L), tuple(11L, 9L), tuple(12L, 18L), tuple(15L, 12L), tuple(16L, 21L), tuple(15L, 15L)]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the count of divisors is even. https://www.w3resource.com/dthon-exercises/basic/dthon-basic-1-exercise-24.php\n\t\n*/\nbool count_divisors(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_divisors;\n\n    assert(candidate(10L) == true);\n    assert(candidate(100L) == false);\n    assert(candidate(125L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\n*/\nlong odd_length_sum(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = odd_length_sum;\n\n    assert(candidate([1L, 2L, 4L]) == 14L);\n    assert(candidate([1L, 2L, 1L, 2L]) == 15L);\n    assert(candidate([1L, 7L]) == 8L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\n*/\nfloat[] rgb_to_hsv(long r, long g, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = rgb_to_hsv;\n\n    assert(candidate(255L, 255L, 255L) == [0.0, 0.0, 100.0]);\n    assert(candidate(0L, 215L, 0L) == [120.0, 100.0, 84.31372549019608]);\n    assert(candidate(10L, 215L, 110L) == [149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the product of first even and odd number of a given array.\n\t\n*/\nlong mul_even_odd(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = mul_even_odd;\n\n    assert(candidate([1L, 3L, 5L, 7L, 4L, 1L, 6L, 8L]) == 4L);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == 2L);\n    assert(candidate([1L, 5L, 7L, 9L, 10L]) == 10L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert tuple string to integer tuple.\n\t\n*/\nTuple!(long, long, long) tuple_str_int(string test_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tuple_str_int;\n\n    assert(candidate(\"(7, 8, 9)\") == tuple(7L, 8L, 9L));\n    assert(candidate(\"(1, 2, 3)\") == tuple(1L, 2L, 3L));\n    assert(candidate(\"(4, 5, 6)\") == tuple(4L, 5L, 6L));\n    assert(candidate(\"(7, 81, 19)\") == tuple(7L, 81L, 19L));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\n*/\nlong right_insertion(long[] a, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = right_insertion;\n\n    assert(candidate([1L, 2L, 4L, 5L], 6L) == 4L);\n    assert(candidate([1L, 2L, 4L, 5L], 3L) == 2L);\n    assert(candidate([1L, 2L, 4L, 5L], 7L) == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\n*/\nbool text_match_three(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_match_three;\n\n    assert(candidate(\"ac\") == false);\n    assert(candidate(\"dc\") == false);\n    assert(candidate(\"abbbba\") == true);\n    assert(candidate(\"caacabbbba\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to create a new tuple from the given string and array.\n\t\n*/\nTuple!(string, string, string) new_tuple(string[] test_list, string test_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = new_tuple;\n\n    assert(candidate([\"WEB\", \"is\"], \"best\") == tuple(\"WEB\", \"is\", \"best\"));\n    assert(candidate([\"We\", \"are\"], \"Developers\") == tuple(\"We\", \"are\", \"Developers\"));\n    assert(candidate([\"Part\", \"is\"], \"Wrong\") == tuple(\"Part\", \"is\", \"Wrong\"));\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether every even index contains even numbers of a given array.\n\t\n*/\nbool even_position(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = even_position;\n\n    assert(candidate([3L, 2L, 1L]) == false);\n    assert(candidate([1L, 2L, 3L]) == false);\n    assert(candidate([2L, 1L, 4L]) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of arrays in a given number of arrays.\n\t\n*/\nlong count_list(long[][] input_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_list;\n\n    assert(candidate([[1L, 3L], [5L, 7L], [9L, 11L], [13L, 15L, 17L]]) == 4L);\n    assert(candidate([[1L, 2L], [2L, 3L], [4L, 5L]]) == 3L);\n    assert(candidate([[1L, 0L], [2L, 0L]]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the last position of an element in a sorted array.\n\t\n*/\nlong last(long[] arr, long x) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = last;\n\n    assert(candidate([1L, 2L, 3L], 1L) == 0L);\n    assert(candidate([1L, 1L, 1L, 2L, 3L, 4L], 1L) == 2L);\n    assert(candidate([2L, 3L, 2L, 3L, 6L, 8L, 9L], 3L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\n*/\nbool text_starta_endb(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = text_starta_endb;\n\n    assert(candidate(\"aabbbb\") == true);\n    assert(candidate(\"aabAbbbc\") == false);\n    assert(candidate(\"accddbbjjj\") == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite function to find the sum of all items in the given associative array.\n\t\n*/\nlong return_sum(Nullable!(long[string]) dict) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = return_sum;\n\n    assert(candidate([\"a\": 100L, \"b\": 200L, \"c\": 300L].nullable) == 600L);\n    assert(candidate([\"a\": 25L, \"b\": 18L, \"c\": 45L].nullable) == 88L);\n    assert(candidate([\"a\": 36L, \"b\": 39L, \"c\": 49L].nullable) == 124L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of all odd natural numbers within the range l and r.\n\t\n*/\nlong sum_in_range(long l, long r) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sum_in_range;\n\n    assert(candidate(2L, 5L) == 8L);\n    assert(candidate(5L, 7L) == 12L);\n    assert(candidate(7L, 13L) == 40L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the sum of an array.\n\t\n*/\nlong _sum(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = _sum;\n\n    assert(candidate([1L, 2L, 3L]) == 6L);\n    assert(candidate([15L, 12L, 13L, 10L]) == 50L);\n    assert(candidate([0L, 1L, 2L]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\n*/\nlong left_rotate(long n, long d) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = left_rotate;\n\n    assert(candidate(16L, 2L) == 64L);\n    assert(candidate(10L, 2L) == 40L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(99L, 3L) == 792L);\n    assert(candidate(1L, 3L) == 8L);\n    assert(candidate(5L, 3L) == 40L);\n    assert(candidate(29L, 3L) == 232L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to check whether the length of the word is odd or not.\n\t\n*/\nbool word_len(string s) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = word_len;\n\n    assert(candidate(\"Hadoop\") == false);\n    assert(candidate(\"great\") == true);\n    assert(candidate(\"structure\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to remove all whitespaces from a string.\n\t\n*/\nstring remove_all_spaces(string text) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = remove_all_spaces;\n\n    assert(candidate(\"python  program\") == \"pythonprogram\");\n    assert(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\");\n    assert(candidate(\"python                     program\") == \"pythonprogram\");\n    assert(candidate(\"   python                     program\") == \"pythonprogram\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of equal numbers from three given integers.\n\t\n*/\nlong test_three_equal(long x, long y, long z) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = test_three_equal;\n\n    assert(candidate(1L, 1L, 1L) == 3L);\n    assert(candidate(-1L, -2L, -3L) == 0L);\n    assert(candidate(1L, 2L, 2L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\n*/\nlong count_rotation(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = count_rotation;\n\n    assert(candidate([3L, 2L, 1L]) == 1L);\n    assert(candidate([4L, 5L, 1L, 2L, 3L]) == 2L);\n    assert(candidate([7L, 8L, 9L, 1L, 2L, 3L]) == 3L);\n    assert(candidate([1L, 2L, 3L]) == 0L);\n    assert(candidate([1L, 3L, 2L]) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\n*/\nbool is_perfect_square(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_perfect_square;\n\n    assert(candidate(10L) == false);\n    assert(candidate(36L) == true);\n    assert(candidate(14L) == false);\n    assert(candidate(196L) == true);\n    assert(candidate(125L) == false);\n    assert(candidate(15625L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the product of numbers in an array is even or not.\n\t\n*/\nbool is_product_even(long[] arr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_product_even;\n\n    assert(candidate([1L, 2L, 3L]) == true);\n    assert(candidate([1L, 2L, 1L, 4L]) == true);\n    assert(candidate([1L, 1L]) == false);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function that returns the array in an array of arrays whose sum of elements is the highest.\n\t\n*/\nlong[] max_sum_list(long[][] lists) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_sum_list;\n\n    assert(candidate([[1L, 2L, 3L], [4L, 5L, 6L], [10L, 11L, 12L], [7L, 8L, 9L]]) == [10L, 11L, 12L]);\n    assert(candidate([[3L, 2L, 1L], [6L, 5L, 4L], [12L, 11L, 10L]]) == [12L, 11L, 10L]);\n    assert(candidate([[2L, 3L, 1L]]) == [2L, 3L, 1L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\n*/\nlong max_run_uppercase(string test_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = max_run_uppercase;\n\n    assert(candidate(\"GeMKSForGERksISBESt\") == 5L);\n    assert(candidate(\"PrECIOusMOVemENTSYT\") == 6L);\n    assert(candidate(\"GooGLEFluTTER\") == 4L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the first odd number in a given array of numbers.\n\t\n*/\nlong first_odd(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = first_odd;\n\n    assert(candidate([1L, 3L, 5L]) == 1L);\n    assert(candidate([2L, 4L, 1L, 3L]) == 1L);\n    assert(candidate([8L, 9L, 1L]) == 9L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if the given tuples contain the k or not.\n\t\n*/\nbool check_K(long[] test_tup, long K) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_K;\n\n    assert(candidate([10L, 4L, 5L, 6L, 8L], 6L) == true);\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L], 7L) == false);\n    assert(candidate([7L, 8L, 9L, 44L, 11L, 12L], 11L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\n*/\nbool check_smaller(Tuple!(long, long, long) test_tup1, Tuple!(long, long, long) test_tup2) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = check_smaller;\n\n    assert(candidate(tuple(1L, 2L, 3L), tuple(2L, 3L, 4L)) == false);\n    assert(candidate(tuple(4L, 5L, 6L), tuple(3L, 4L, 5L)) == true);\n    assert(candidate(tuple(11L, 12L, 13L), tuple(10L, 11L, 12L)) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth tetrahedral number.\n\t\n*/\nlong tetrahedral_number(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = tetrahedral_number;\n\n    assert(candidate(5L) == 35L);\n    assert(candidate(6L) == 56L);\n    assert(candidate(7L) == 84L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\n*/\nstring get_Char(string strr) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = get_Char;\n\n    assert(candidate(\"abc\") == \"f\");\n    assert(candidate(\"gfg\") == \"t\");\n    assert(candidate(\"ab\") == \"c\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\n*/\nlong sequence(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = sequence;\n\n    assert(candidate(10L) == 6L);\n    assert(candidate(2L) == 1L);\n    assert(candidate(3L) == 2L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find nth centered hexagonal number.\n\t\n*/\nlong centered_hexagonal_number(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = centered_hexagonal_number;\n\n    assert(candidate(10L) == 271L);\n    assert(candidate(2L) == 7L);\n    assert(candidate(9L) == 217L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to merge three dictionaries into a single associative array.\n\t\n*/\nNullable!(string[string]) merge_dictionaries_three(Nullable!(string[string]) dict1, Nullable!(string[string]) dict2, Nullable!(string[string]) dict3) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = merge_dictionaries_three;\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable);\n        assert(!result.isNull && result.get == [\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"]);\n}\n\n{\n        auto result = candidate([\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"].nullable, [\"L\": \"lavender\", \"B\": \"Blue\"].nullable, [\"G\": \"Green\", \"W\": \"White\"].nullable);\n        assert(!result.isNull && result.get == [\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to get the frequency of all the elements in an array, returned as an associative array.\n\t\n*/\nNullable!(long[long]) freq_count(long[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = freq_count;\n\n{\n        auto result = candidate([10L, 10L, 10L, 10L, 20L, 20L, 20L, 20L, 40L, 40L, 50L, 50L, 30L]);\n        assert(!result.isNull && result.get == [10L: 4L, 20L: 4L, 40L: 2L, 50L: 2L, 30L: 1L]);\n}\n\n{\n        auto result = candidate([1L, 2L, 3L, 4L, 3L, 2L, 4L, 1L, 3L, 1L, 4L]);\n        assert(!result.isNull && result.get == [1L: 3L, 2L: 2L, 3L: 3L, 4L: 3L]);\n}\n\n{\n        auto result = candidate([5L, 6L, 7L, 4L, 9L, 10L, 4L, 5L, 6L, 7L, 9L, 5L]);\n        assert(!result.isNull && result.get == [10L: 1L, 5L: 3L, 6L: 2L, 7L: 2L, 4L: 2L, 9L: 2L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find the closest smaller number than n.\n\t\n*/\nlong closest_num(long N) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = closest_num;\n\n    assert(candidate(11L) == 10L);\n    assert(candidate(7L) == 6L);\n    assert(candidate(12L) == 11L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find squares of individual elements in an array.\n\t\n*/\nlong[] square_nums(long[] nums) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = square_nums;\n\n    assert(candidate([1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L]) == [1L, 4L, 9L, 16L, 25L, 36L, 49L, 64L, 81L, 100L]);\n    assert(candidate([10L, 20L, 30L]) == [100L, 400L, 900L]);\n    assert(candidate([12L, 15L]) == [144L, 225L]);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the longest word.\n\t\n*/\nlong len_log(string[] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = len_log;\n\n    assert(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7L);\n    assert(candidate([\"a\", \"ab\", \"abc\"]) == 3L);\n    assert(candidate([\"small\", \"big\", \"tall\"]) == 5L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check if a string is present as a substring in a given array of string values.\n\t\n*/\nbool find_substring(string[] str1, string sub_str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_substring;\n\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false);\n    assert(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to check whether the given number is undulating or not.\n\t\n*/\nbool is_undulating(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = is_undulating;\n\n    assert(candidate(1212121L) == true);\n    assert(candidate(1991L) == false);\n    assert(candidate(121L) == true);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\n*/\nlong power(long a, long b) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = power;\n\n    assert(candidate(3L, 4L) == 81L);\n    assert(candidate(2L, 3L) == 8L);\n    assert(candidate(5L, 5L) == 3125L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tGiven an array of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\n*/\nstring index_minimum(Tuple!(string, long)[] test_list) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = index_minimum;\n\n    assert(candidate([tuple(\"Rash\", 143L), tuple(\"Manjeet\", 200L), tuple(\"Varsha\", 100L)]) == \"Varsha\");\n    assert(candidate([tuple(\"Yash\", 185L), tuple(\"Dawood\", 125L), tuple(\"Sanya\", 175L)]) == \"Dawood\");\n    assert(candidate([tuple(\"Sai\", 345L), tuple(\"Salman\", 145L), tuple(\"Ayesha\", 96L)]) == \"Ayesha\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the length of the smallest array in an array of arrays.\n\t\n*/\nlong Find_Min_Length(long[][] lst) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = Find_Min_Length;\n\n    assert(candidate([[1L], [1L, 2L]]) == 1L);\n    assert(candidate([[1L, 2L], [1L, 2L, 3L], [1L, 2L, 3L, 4L]]) == 2L);\n    assert(candidate([[3L, 3L, 3L], [4L, 4L, 4L, 4L]]) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the number of divisors of a given integer.\n\t\n*/\nlong divisor(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = divisor;\n\n    assert(candidate(15L) == 4L);\n    assert(candidate(12L) == 6L);\n    assert(candidate(9L) == 3L);\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to find frequency of each element in a flattened array of arrays, returned in an associative array.\n\t\n*/\nNullable!(long[long]) frequency_lists(long[][] list1) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = frequency_lists;\n\n{\n        auto result = candidate([[1L, 2L, 3L, 2L], [4L, 5L, 6L, 2L], [7L, 8L, 9L, 5L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 3L, 3L: 1L, 4L: 1L, 5L: 2L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L]);\n}\n\n{\n        auto result = candidate([[1L, 2L, 3L, 4L], [5L, 6L, 7L, 8L], [9L, 10L, 11L, 12L]]);\n        assert(!result.isNull && result.get == [1L: 1L, 2L: 1L, 3L: 1L, 4L: 1L, 5L: 1L, 6L: 1L, 7L: 1L, 8L: 1L, 9L: 1L, 10L: 1L, 11L: 1L, 12L: 1L]);\n}\n\n{\n        auto result = candidate([[20L, 30L, 40L, 17L], [18L, 16L, 14L, 13L], [10L, 20L, 30L, 40L]]);\n        assert(!result.isNull && result.get == [20L: 2L, 30L: 2L, 40L: 2L, 17L: 1L, 18L: 1L, 16L: 1L, 14L: 1L, 13L: 1L, 10L: 1L]);\n}\n\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\n*/\nstring decimal_to_binary(long n) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = decimal_to_binary;\n\n    assert(candidate(8L) == \"1000\");\n    assert(candidate(18L) == \"10010\");\n    assert(candidate(7L) == \"111\");\n}\nvoid main(){}",
+    "stop_tokens": [
+      "\n\n",
+      "\nvoid",
+      "\nbool",
+      "\nint"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "d",
+    "prompt": "import std.math;\nimport std.typecons;\n/*\n\n\tWrite a dthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\n*/\nlong find_Rotations(string str) \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "unittest\n{\n    alias candidate = find_Rotations;\n\n    assert(candidate(\"aaaa\") == 1L);\n    assert(candidate(\"ab\") == 2L);\n    assert(candidate(\"abc\") == 3L);\n}\nvoid main(){}",
     "stop_tokens": [
       "\n\n",
       "\nvoid",

--- a/prompts/mbpp-go-keep.json
+++ b/prompts/mbpp-go-keep.json
@@ -1,3862 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "go_test.go",
-    "prompt": "package lps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLps(t *testing.T) {\n  candidate := lps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TENS FOR TENS\"), expected: 5 },\n     { actual: candidate(\"CARDIO FOR CARDS\"), expected: 7 },\n     { actual: candidate(\"PART OF THE JOURNEY IS PART\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "go_test.go",
-    "prompt": "package remove_whitespaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1 string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Whitespaces(t *testing.T) {\n  candidate := remove_whitespaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\" Google    Flutter \"), expected: \"GoogleFlutter\" },\n     { actual: candidate(\" Google    Dart \"), expected: \"GoogleDart\" },\n     { actual: candidate(\" iOS    Swift \"), expected: \"iOSSwift\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "go_test.go",
-    "prompt": "package issort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1 []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIssort_List(t *testing.T) {\n  candidate := issort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), expected: false },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 15, 14, 20}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "go_test.go",
-    "prompt": "package count_bidirectional_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list [][]interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Bidirectional(t *testing.T) {\n  candidate := count_bidirectional\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 3}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 2 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 2}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "go_test.go",
-    "prompt": "package surfacearea_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSurfacearea_Cube(t *testing.T) {\n  candidate := surfacearea_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 150 },\n     { actual: candidate(3), expected: 54 },\n     { actual: candidate(10), expected: 600 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "go_test.go",
     "prompt": "package next_smallest_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunc next_smallest_palindrome(num int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestNext_Smallest_Palindrome(t *testing.T) {\n  candidate := next_smallest_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(99), expected: 101 },\n     { actual: candidate(1221), expected: 1331 },\n     { actual: candidate(120), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "go_test.go",
-    "prompt": "package cube_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCube_Sum(t *testing.T) {\n  candidate := cube_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 72 },\n     { actual: candidate(3), expected: 288 },\n     { actual: candidate(4), expected: 800 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "go_test.go",
-    "prompt": "package pair_xor_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr []int, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPair_Xor_Sum(t *testing.T) {\n  candidate := pair_xor_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 9, 7, 6}, 4), expected: 47 },\n     { actual: candidate([]int{7, 3, 5}, 3), expected: 12 },\n     { actual: candidate([]int{7, 3}, 2), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "go_test.go",
-    "prompt": "package check_min_heap_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Min_Heap(t *testing.T) {\n  candidate := check_min_heap\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 10, 15}), expected: true },\n     { actual: candidate([]int{2, 10, 4, 5, 3, 15}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "go_test.go",
-    "prompt": "package first_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the first digit of a given number.\nfunc first_Digit(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFirst_Digit(t *testing.T) {\n  candidate := first_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 1 },\n     { actual: candidate(456), expected: 4 },\n     { actual: candidate(12), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "go_test.go",
-    "prompt": "package radian_degree_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert degrees to radians.\nfunc radian_degree(degree int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRadian_Degree(t *testing.T) {\n  candidate := radian_degree\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(90), expected: 1.5707963267948966 },\n     { actual: candidate(60), expected: 1.0471975511965976 },\n     { actual: candidate(120), expected: 2.0943951023931953 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "go_test.go",
-    "prompt": "package max_subarray_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Subarray_Product(t *testing.T) {\n  candidate := max_subarray_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 0, 7, -8, -2}), expected: 112 },\n     { actual: candidate([]int{6, -3, -10, 0, 2}), expected: 180 },\n     { actual: candidate([]int{-2, -40, 0, -2, -3}), expected: 80 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "go_test.go",
-    "prompt": "package smallest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find smallest number in a list.\nfunc smallest_num(xs []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSmallest_Num(t *testing.T) {\n  candidate := smallest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 1, 45, 99}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n     { actual: candidate([]int{45, 46, 50, 60}), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "go_test.go",
-    "prompt": "package text_match_zero_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunc text_match_zero_one(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_Zero_One(t *testing.T) {\n  candidate := text_match_zero_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"dsabbbba\"), expected: true },\n     { actual: candidate(\"asbbbba\"), expected: false },\n     { actual: candidate(\"abaaa\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "go_test.go",
-    "prompt": "package bell_Number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find nth bell number.\nfunc bell_Number(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_Number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "go_test.go",
-    "prompt": "package cube_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCube_Nums(t *testing.T) {\n  candidate := cube_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 8, 27, 64, 125, 216, 343, 512, 729, 1000} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}), expected: []int{1728, 3375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "go_test.go",
-    "prompt": "package last_Digit_Factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLast_Digit_Factorial(t *testing.T) {\n  candidate := last_Digit_Factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 4 },\n     { actual: candidate(21), expected: 0 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "go_test.go",
-    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find even numbers from a list of numbers.\nfunc Split(list []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{2, 4} },\n     { actual: candidate([]int{4, 5, 6, 7, 8, 0, 1}), expected: []int{4, 6, 8, 0} },\n     { actual: candidate([]int{8, 12, 15, 19}), expected: []int{8, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "go_test.go",
-    "prompt": "package prime_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given integer is a prime number.\nfunc prime_num(num int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPrime_Num(t *testing.T) {\n  candidate := prime_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13), expected: true },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(-1010), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "go_test.go",
-    "prompt": "package find_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunc find_tuples(test_list [][]interface{}, K int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Tuples(t *testing.T) {\n  candidate := find_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{6, 24, 12}, []interface{}{7, 9, 6}, []interface{}{12, 18, 21}}, 6), expected: [][]int{[]interface{}{6, 24, 12}} },\n     { actual: candidate([][]int{[]interface{}{5, 25, 30}, []interface{}{4, 2, 3}, []interface{}{7, 8, 9}}, 5), expected: [][]int{[]interface{}{5, 25, 30}} },\n     { actual: candidate([][]int{[]interface{}{7, 9, 16}, []interface{}{8, 16, 4}, []interface{}{19, 17, 18}}, 4), expected: [][]int{[]interface{}{8, 16, 4}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "go_test.go",
-    "prompt": "package area_tetrahedron_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestArea_Tetrahedron(t *testing.T) {\n  candidate := area_tetrahedron\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15.588457268119894 },\n     { actual: candidate(20), expected: 692.8203230275509 },\n     { actual: candidate(10), expected: 173.20508075688772 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "go_test.go",
-    "prompt": "package is_Even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number is even or not.\nfunc is_Even(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Even(t *testing.T) {\n  candidate := is_Even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: false },\n     { actual: candidate(2), expected: true },\n     { actual: candidate(3), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "go_test.go",
-    "prompt": "package pos_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of positive numbers in a list.\nfunc pos_count(list []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPos_Count(t *testing.T) {\n  candidate := pos_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, 3, -4}), expected: 2 },\n     { actual: candidate([]int{3, 4, 5, -1}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "go_test.go",
-    "prompt": "package get_ludic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Ludic(t *testing.T) {\n  candidate := get_ludic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []int{1, 2, 3, 5, 7} },\n     { actual: candidate(25), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25} },\n     { actual: candidate(45), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "go_test.go",
-    "prompt": "package find_Index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Index(t *testing.T) {\n  candidate := find_Index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 14 },\n     { actual: candidate(4), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "go_test.go",
-    "prompt": "package reverse_Array_Upto_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input []int, k int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReverse_Array_Upto_K(t *testing.T) {\n  candidate := reverse_Array_Upto_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 4), expected: []int{4, 3, 2, 1, 5, 6} },\n     { actual: candidate([]int{4, 5, 6, 7}, 2), expected: []int{5, 4, 6, 7} },\n     { actual: candidate([]int{9, 8, 7, 6, 5}, 3), expected: []int{7, 8, 9, 6, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "go_test.go",
-    "prompt": "package subject_marks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks [][]interface{}) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSubject_Marks(t *testing.T) {\n  candidate := subject_marks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}, []interface{}{\"Social sciences\", 82}}), expected: [][]int{[]interface{}{\"Social sciences\", 82}, []interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}} },\n     { actual: candidate([][]int{[]interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}, []interface{}{\"Social\", 33}}), expected: [][]int{[]interface{}{\"Social\", 33}, []interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}} },\n     { actual: candidate([][]int{[]interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}, []interface{}{\"Biology\", 45}}), expected: [][]int{[]interface{}{\"Biology\", 45}, []interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "go_test.go",
-    "prompt": "package remove_dirty_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(myString string, second_string string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Dirty_Chars(t *testing.T) {\n  candidate := remove_dirty_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"probasscurve\", \"pros\"), expected: \"bacuve\" },\n     { actual: candidate(\"digitalindia\", \"talent\"), expected: \"digiidi\" },\n     { actual: candidate(\"exoticmiles\", \"toxic\"), expected: \"emles\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "go_test.go",
-    "prompt": "package max_occurrences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Occurrences(t *testing.T) {\n  candidate := max_occurrences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), expected: 2 },\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), expected: 8 },\n     { actual: candidate([]int{10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), expected: 20 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "go_test.go",
-    "prompt": "package is_decimal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Decimal(t *testing.T) {\n  candidate := is_decimal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"123.11\"), expected: true },\n     { actual: candidate(\"e666.86\"), expected: false },\n     { actual: candidate(\"3.124587\"), expected: false },\n     { actual: candidate(\"1.11\"), expected: true },\n     { actual: candidate(\"1.1.11\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "go_test.go",
-    "prompt": "package dict_filter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict map[string]int, n int) map[string]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDict_Filter(t *testing.T) {\n  candidate := dict_filter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170), expected: map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180), expected: map[string]int{\"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190), expected: map[string]int{\"Pierre Cox\": 190} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "go_test.go",
-    "prompt": "package sum_even_and_even_index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Even_And_Even_Index(t *testing.T) {\n  candidate := sum_even_and_even_index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 12, 1, 18, 8}), expected: 30 },\n     { actual: candidate([]int{3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), expected: 26 },\n     { actual: candidate([]int{5, 6, 12, 1}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "go_test.go",
-    "prompt": "package max_sub_array_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a []int, size int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Sub_Array_Sum(t *testing.T) {\n  candidate := max_sub_array_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-2, -3, 4, -1, -2, 1, 5, -3}, 8), expected: 7 },\n     { actual: candidate([]int{-3, -4, 5, -2, -3, 2, 6, -4}, 8), expected: 8 },\n     { actual: candidate([]int{-4, -5, 6, -3, -4, 3, 7, -5}, 8), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "go_test.go",
-    "prompt": "package intersection_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1 []int, array_nums2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIntersection_Array(t *testing.T) {\n  candidate := intersection_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{1, 2, 4, 8, 9}), expected: []int{1, 2, 8, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{3, 5, 7, 9}), expected: []int{3, 5, 7, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{10, 20, 30, 40}), expected: []int{10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "go_test.go",
-    "prompt": "package split_two_parts_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunc split_two_parts(list1 []interface{}, L int) interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSplit_Two_Parts(t *testing.T) {\n  candidate := split_two_parts\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []interface{}{[]int{1, 1, 2}, []int{3, 4, 4, 5, 1}} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, 2), expected: []interface{}{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}} },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}, 4), expected: []interface{}{[]string{\"p\", \"y\", \"t\", \"h\"}, []string{\"o\", \"n\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "go_test.go",
-    "prompt": "package find_literals_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text string, pattern string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Literals(t *testing.T) {\n  candidate := find_literals\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"), expected: []interface{}{\"fox\", 16, 19} },\n     { actual: candidate(\"Its been a very crazy procedure right\", \"crazy\"), expected: []interface{}{\"crazy\", 16, 21} },\n     { actual: candidate(\"Hardest choices required strongest will\", \"will\"), expected: []interface{}{\"will\", 35, 39} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "go_test.go",
-    "prompt": "package find_Volume_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the volume of a triangular prism.\nfunc find_Volume(l int, b int, h int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Volume(t *testing.T) {\n  candidate := find_Volume\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 8, 6), expected: 240 },\n     { actual: candidate(3, 2, 2), expected: 6 },\n     { actual: candidate(1, 2, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "go_test.go",
-    "prompt": "package wind_chill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v int, t int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWind_Chill(t *testing.T) {\n  candidate := wind_chill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(120, 35), expected: 40 },\n     { actual: candidate(40, 20), expected: 19 },\n     { actual: candidate(10, 8), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "go_test.go",
-    "prompt": "package ascii_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ascii value of a character.\nfunc ascii_value(k string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAscii_Value(t *testing.T) {\n  candidate := ascii_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"A\"), expected: 65 },\n     { actual: candidate(\"R\"), expected: 82 },\n     { actual: candidate(\"S\"), expected: 83 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "go_test.go",
-    "prompt": "package all_Characters_Same_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether all the characters are same or not.\nfunc all_Characters_Same(s string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Characters_Same(t *testing.T) {\n  candidate := all_Characters_Same\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"aaa\"), expected: true },\n     { actual: candidate(\"data\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "go_test.go",
-    "prompt": "package move_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMove_Num(t *testing.T) {\n  candidate := move_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"I1love143you55three3000thousand\"), expected: \"Iloveyouthreethousand1143553000\" },\n     { actual: candidate(\"Avengers124Assemble\"), expected: \"AvengersAssemble124\" },\n     { actual: candidate(\"Its11our12path13to14see15things16do17things\"), expected: \"Itsourpathtoseethingsdothings11121314151617\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "go_test.go",
-    "prompt": "package word_len_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the length of the word is odd or not.\nfunc word_len(s string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestWord_Len(t *testing.T) {\n  candidate := word_len\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hadoop\"), expected: false },\n     { actual: candidate(\"great\"), expected: true },\n     { actual: candidate(\"structure\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "go_test.go",
-    "prompt": "package insert_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list []string, element string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestInsert_Element(t *testing.T) {\n  candidate := insert_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Black\"}, \"c\"), expected: []string{\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"} },\n     { actual: candidate([]string{\"python\", \"java\"}, \"program\"), expected: []string{\"program\", \"python\", \"program\", \"java\"} },\n     { actual: candidate([]string{\"happy\", \"sad\"}, \"laugh\"), expected: []string{\"laugh\", \"happy\", \"laugh\", \"sad\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "go_test.go",
-    "prompt": "package remove_lowercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1 string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Lowercase(t *testing.T) {\n  candidate := remove_lowercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYTHon\"), expected: \"PYTH\" },\n     { actual: candidate(\"FInD\"), expected: \"FID\" },\n     { actual: candidate(\"STRinG\"), expected: \"STRG\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "go_test.go",
-    "prompt": "package count_Set_Bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Set_Bits(t *testing.T) {\n  candidate := count_Set_Bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 1 },\n     { actual: candidate(6), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "go_test.go",
-    "prompt": "package extract_rear_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple []interface{}) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Rear(t *testing.T) {\n  candidate := extract_rear\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"Mers\", \"for\", \"Vers\"}), expected: []string{\"s\", \"r\", \"s\"} },\n     { actual: candidate([]interface{}{\"Avenge\", \"for\", \"People\"}), expected: []string{\"e\", \"r\", \"e\"} },\n     { actual: candidate([]interface{}{\"Gotta\", \"get\", \"go\"}), expected: []string{\"a\", \"t\", \"o\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "go_test.go",
-    "prompt": "package count_occurance_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Occurance(t *testing.T) {\n  candidate := count_occurance\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"letstdlenstdporstd\"), expected: 3 },\n     { actual: candidate(\"truststdsolensporsd\"), expected: 1 },\n     { actual: candidate(\"makestdsostdworthit\"), expected: 2 },\n     { actual: candidate(\"stds\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "go_test.go",
-    "prompt": "package check_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup []int, K int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_K(t *testing.T) {\n  candidate := check_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 4, 5, 6, 8}, 6), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 7), expected: false },\n     { actual: candidate([]int{7, 8, 9, 44, 11, 12}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "go_test.go",
-    "prompt": "package interleave_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1 []int, list2 []int, list3 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestInterleave_Lists(t *testing.T) {\n  candidate := interleave_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}, []int{10, 20, 30, 40, 50, 60, 70}, []int{100, 200, 300, 400, 500, 600, 700}), expected: []int{1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700} },\n     { actual: candidate([]int{10, 20}, []int{15, 2}, []int{5, 10}), expected: []int{10, 15, 5, 20, 2, 10} },\n     { actual: candidate([]int{11, 44}, []int{10, 15}, []int{20, 5}), expected: []int{11, 10, 20, 44, 15, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "go_test.go",
-    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python_program\"), expected: \"PythonProgram\" },\n     { actual: candidate(\"python_language\"), expected: \"PythonLanguage\" },\n     { actual: candidate(\"programming_language\"), expected: \"ProgrammingLanguage\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "go_test.go",
-    "prompt": "package test_three_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x int, y int, z int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTest_Three_Equal(t *testing.T) {\n  candidate := test_three_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 1, 1), expected: 3 },\n     { actual: candidate(-1, -2, -3), expected: 0 },\n     { actual: candidate(1, 2, 2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "go_test.go",
-    "prompt": "package odd_length_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Length_Sum(t *testing.T) {\n  candidate := odd_length_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4}), expected: 14 },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: 15 },\n     { actual: candidate([]int{1, 7}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "go_test.go",
-    "prompt": "package bell_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(10), expected: 115975 },\n     { actual: candidate(56), expected: 6775685320645824322581483068371419745979053216268760300 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "go_test.go",
-    "prompt": "package rectangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the area of a rectangle.\nfunc rectangle_area(l int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRectangle_Area(t *testing.T) {\n  candidate := rectangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(10, 5), expected: 50 },\n     { actual: candidate(4, 2), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "go_test.go",
-    "prompt": "package sum_average_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Average(t *testing.T) {\n  candidate := sum_average\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []interface{}{55, 5.5} },\n     { actual: candidate(15), expected: []interface{}{120, 8.0} },\n     { actual: candidate(20), expected: []interface{}{210, 10.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "go_test.go",
-    "prompt": "package division_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDivision_Elements(t *testing.T) {\n  candidate := division_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{2, 2, 2, 3} },\n     { actual: candidate([]interface{}{12, 6, 8, 16}, []interface{}{6, 3, 4, 4}), expected: []interface{}{2, 2, 2, 4} },\n     { actual: candidate([]interface{}{20, 14, 36, 18}, []interface{}{5, 7, 6, 9}), expected: []interface{}{4, 2, 6, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "go_test.go",
-    "prompt": "package sum_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Digits(t *testing.T) {\n  candidate := sum_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(345), expected: 12 },\n     { actual: candidate(12), expected: 3 },\n     { actual: candidate(97), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "go_test.go",
-    "prompt": "package index_minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list [][]interface{}) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIndex_Minimum(t *testing.T) {\n  candidate := index_minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Rash\", 143}, []interface{}{\"Manjeet\", 200}, []interface{}{\"Varsha\", 100}}), expected: \"Varsha\" },\n     { actual: candidate([][]int{[]interface{}{\"Yash\", 185}, []interface{}{\"Dawood\", 125}, []interface{}{\"Sanya\", 175}}), expected: \"Dawood\" },\n     { actual: candidate([][]int{[]interface{}{\"Sai\", 345}, []interface{}{\"Salman\", 145}, []interface{}{\"Ayesha\", 96}}), expected: \"Ayesha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "go_test.go",
-    "prompt": "package div_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to divide two lists element wise.\nfunc div_list(nums1 []int, nums2 []int) []float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDiv_List(t *testing.T) {\n  candidate := div_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 5, 6}, []int{1, 2, 3}), expected: []float64{4.0, 2.5, 2.0} },\n     { actual: candidate([]int{3, 2}, []int{1, 4}), expected: []float64{3.0, 0.5} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []float64{1.8, 1.7142857142857142} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "go_test.go",
-    "prompt": "package max_length_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list with maximum length.\nfunc max_length_list(input_list [][]int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Length_List(t *testing.T) {\n  candidate := max_length_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}, []int{1, 2, 3}, []int{1, 2}, []int{1}}), expected: []interface{}{5, []int{1, 2, 3, 4, 5}} },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{6, 7, 8, 9}, []int{10, 11, 12}}), expected: []interface{}{4, []int{6, 7, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "go_test.go",
-    "prompt": "package big_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBig_Sum(t *testing.T) {\n  candidate := big_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{-1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{2, 3, 6}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "go_test.go",
-    "prompt": "package neg_nos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to return the negative numbers in a list.\nfunc neg_nos(list1 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNeg_Nos(t *testing.T) {\n  candidate := neg_nos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 4, 5, -6}), expected: []int{-1, -6} },\n     { actual: candidate([]int{-1, -2, 3, 4}), expected: []int{-1, -2} },\n     { actual: candidate([]int{-7, -6, 8, 9}), expected: []int{-7, -6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "go_test.go",
-    "prompt": "package highest_Power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHighest_Power_Of_2(t *testing.T) {\n  candidate := highest_Power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 8 },\n     { actual: candidate(19), expected: 16 },\n     { actual: candidate(32), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "go_test.go",
-    "prompt": "package is_sublist_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l []int, s []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sublist(t *testing.T) {\n  candidate := is_sublist\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{4, 3}), expected: true },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{1, 6}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "go_test.go",
-    "prompt": "package sub_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1 []int, nums2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSub_List(t *testing.T) {\n  candidate := sub_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: []int{-3, -3, -3} },\n     { actual: candidate([]int{1, 2}, []int{3, 4}), expected: []int{-2, -2} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []int{40, 50} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "go_test.go",
-    "prompt": "package opposite_Signs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x int, y int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOpposite_Signs(t *testing.T) {\n  candidate := opposite_Signs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, -2), expected: true },\n     { actual: candidate(3, 2), expected: false },\n     { actual: candidate(-10, -10), expected: false },\n     { actual: candidate(-2, 2), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "go_test.go",
-    "prompt": "package tuple_modulo_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTuple_Modulo(t *testing.T) {\n  candidate := tuple_modulo\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6}, []interface{}{5, 6, 7, 5}), expected: []interface{}{0, 4, 5, 1} },\n     { actual: candidate([]interface{}{11, 5, 6, 7}, []interface{}{6, 7, 8, 6}), expected: []interface{}{5, 5, 6, 1} },\n     { actual: candidate([]interface{}{12, 6, 7, 8}, []interface{}{7, 8, 9, 7}), expected: []interface{}{5, 6, 7, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "go_test.go",
-    "prompt": "package diff_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1 []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDiff_Even_Odd(t *testing.T) {\n  candidate := diff_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 1 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "go_test.go",
-    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1 [][]string) [][]string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"d\", \"c\"}, []string{\"g\", \"h\"}, []string{\"f\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}, []string{\"g\", \"h\"}, []string{\"e\", \"f\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "go_test.go",
-    "prompt": "package last_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last digit of a given number.\nfunc last_Digit(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLast_Digit(t *testing.T) {\n  candidate := last_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 3 },\n     { actual: candidate(25), expected: 5 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "go_test.go",
-    "prompt": "package odd_num_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Num_Sum(t *testing.T) {\n  candidate := odd_num_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 82 },\n     { actual: candidate(3), expected: 707 },\n     { actual: candidate(4), expected: 3108 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "go_test.go",
-    "prompt": "package tup_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a string.\nfunc tup_string(tup1 []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTup_String(t *testing.T) {\n  candidate := tup_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"}), expected: \"exercises\" },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}), expected: \"python\" },\n     { actual: candidate([]string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"}), expected: \"program\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "go_test.go",
-    "prompt": "package remove_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1 []int, list2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Elements(t *testing.T) {\n  candidate := remove_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{1, 3, 5, 7}), expected: []int{2, 4, 6, 8, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{5, 7}), expected: []int{1, 2, 3, 4, 6, 8, 9, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "go_test.go",
-    "prompt": "package overlapping_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1 []int, list2 []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOverlapping(t *testing.T) {\n  candidate := overlapping\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 8, 9}), expected: false },\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 4, 5}, []int{1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "go_test.go",
-    "prompt": "package is_not_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to identify non-prime numbers.\nfunc is_not_prime(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Not_Prime(t *testing.T) {\n  candidate := is_not_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: false },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(35), expected: true },\n     { actual: candidate(37), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "go_test.go",
-    "prompt": "package sum_negativenum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Negativenum(t *testing.T) {\n  candidate := sum_negativenum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: -32 },\n     { actual: candidate([]int{10, 15, -14, 13, -18, 12, -20}), expected: -52 },\n     { actual: candidate([]int{19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), expected: -894 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "go_test.go",
-    "prompt": "package find_Rotations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Rotations(t *testing.T) {\n  candidate := find_Rotations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aaaa\"), expected: 1 },\n     { actual: candidate(\"ab\"), expected: 2 },\n     { actual: candidate(\"abc\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "go_test.go",
-    "prompt": "package change_date_format_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestChange_Date_Format(t *testing.T) {\n  candidate := change_date_format\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"2026-01-02\"), expected: \"02-01-2026\" },\n     { actual: candidate(\"2020-11-13\"), expected: \"13-11-2020\" },\n     { actual: candidate(\"2021-04-26\"), expected: \"26-04-2021\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "go_test.go",
-    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of integers and only returns the odd ones.\nfunc Split(list []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: []int{1, 3, 5} },\n     { actual: candidate([]int{10, 11, 12, 13}), expected: []int{11, 13} },\n     { actual: candidate([]int{7, 8, 9, 1}), expected: []int{7, 9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "go_test.go",
-    "prompt": "package toggle_middle_bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestToggle_Middle_Bits(t *testing.T) {\n  candidate := toggle_middle_bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 15 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(11), expected: 13 },\n     { actual: candidate(65), expected: 127 },\n     { actual: candidate(77), expected: 115 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "go_test.go",
-    "prompt": "package count_char_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1 string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Char_Position(t *testing.T) {\n  candidate := count_char_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xbcefg\"), expected: 2 },\n     { actual: candidate(\"ABcED\"), expected: 3 },\n     { actual: candidate(\"AbgdeF\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "go_test.go",
-    "prompt": "package large_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1 []int, nums2 []int, N int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLarge_Product(t *testing.T) {\n  candidate := large_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 3), expected: []int{60, 54, 50} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 4), expected: []int{60, 54, 50, 48} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 5), expected: []int{60, 54, 50, 48, 45} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "go_test.go",
-    "prompt": "package cummulative_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list [][]int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCummulative_Sum(t *testing.T) {\n  candidate := cummulative_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 6, 7}, []int{2, 6}}), expected: 30 },\n     { actual: candidate([][]int{[]int{2, 4}, []int{6, 7, 8}, []int{3, 7}}), expected: 37 },\n     { actual: candidate([][]int{[]int{3, 5}, []int{7, 8, 9}, []int{4, 8}}), expected: 44 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "go_test.go",
-    "prompt": "package find_min_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr []int, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Min_Diff(t *testing.T) {\n  candidate := find_min_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 3, 19, 18, 25}, 6), expected: 1 },\n     { actual: candidate([]int{4, 3, 2, 6}, 4), expected: 1 },\n     { actual: candidate([]int{30, 5, 20, 9}, 4), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "go_test.go",
-    "prompt": "package text_starta_endb_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Starta_Endb(t *testing.T) {\n  candidate := text_starta_endb\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aabbbb\"), expected: true },\n     { actual: candidate(\"aabAbbbc\"), expected: false },\n     { actual: candidate(\"accddbbjjj\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "go_test.go",
-    "prompt": "package left_rotate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n int, d int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLeft_Rotate(t *testing.T) {\n  candidate := left_rotate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: 64 },\n     { actual: candidate(10, 2), expected: 40 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(1, 3), expected: 8 },\n     { actual: candidate(5, 3), expected: 40 },\n     { actual: candidate(29, 3), expected: 232 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "go_test.go",
-    "prompt": "package get_Inv_Count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count inversions in an array.\nfunc get_Inv_Count(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Inv_Count(t *testing.T) {\n  candidate := get_Inv_Count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 20, 6, 4, 5}), expected: 5 },\n     { actual: candidate([]int{1, 2, 1}), expected: 1 },\n     { actual: candidate([]int{1, 2, 5, 6, 1}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "go_test.go",
-    "prompt": "package even_Power_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Power_Sum(t *testing.T) {\n  candidate := even_Power_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1056 },\n     { actual: candidate(3), expected: 8832 },\n     { actual: candidate(1), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "go_test.go",
-    "prompt": "package get_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input [][]int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Equal(t *testing.T) {\n  candidate := get_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{11, 22, 33}, []int{44, 55, 66}}), expected: true },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6, 7}}), expected: false },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "go_test.go",
-    "prompt": "package check_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string represents an integer or not.\nfunc check_integer(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Integer(t *testing.T) {\n  candidate := check_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"1\"), expected: true },\n     { actual: candidate(\"12345\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "go_test.go",
-    "prompt": "package count_reverse_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list []string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Reverse_Pairs(t *testing.T) {\n  candidate := count_reverse_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"}), expected: 2 },\n     { actual: candidate([]string{\"geeks\", \"best\", \"for\", \"skeeg\"}), expected: 1 },\n     { actual: candidate([]string{\"makes\", \"best\", \"sekam\", \"for\", \"rof\"}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "go_test.go",
-    "prompt": "package move_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to move all zeroes to the end of the given list.\nfunc move_zero(num_list []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMove_Zero(t *testing.T) {\n  candidate := move_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 0, 2, 0, 3, 4}), expected: []int{1, 2, 3, 4, 0, 0} },\n     { actual: candidate([]int{2, 3, 2, 0, 0, 4, 0, 5, 0}), expected: []int{2, 3, 2, 4, 5, 0, 0, 0, 0} },\n     { actual: candidate([]int{0, 1, 0, 1, 1}), expected: []int{1, 1, 1, 0, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "go_test.go",
-    "prompt": "package check_distinct_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Distinct(t *testing.T) {\n  candidate := check_distinct\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 5, 6, 1, 4}), expected: false },\n     { actual: candidate([]int{1, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 6}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "go_test.go",
-    "prompt": "package noprofit_noloss_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost int, sale_amount int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNoprofit_Noloss(t *testing.T) {\n  candidate := noprofit_noloss\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: false },\n     { actual: candidate(100, 100), expected: true },\n     { actual: candidate(2000, 5000), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "go_test.go",
-    "prompt": "package remove_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str string, K int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Length(t *testing.T) {\n  candidate := remove_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The person is most value tet\", 3), expected: \"person is most value\" },\n     { actual: candidate(\"If you told me about this ok\", 4), expected: \"If you me about ok\" },\n     { actual: candidate(\"Forces of darkeness is come into the play\", 4), expected: \"Forces of darkeness is the\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "go_test.go",
-    "prompt": "package number_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count number of digits in a given string.\nfunc number_ctr(str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNumber_Ctr(t *testing.T) {\n  candidate := number_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"program2bedone\"), expected: 1 },\n     { actual: candidate(\"3wonders\"), expected: 1 },\n     { actual: candidate(\"123\"), expected: 3 },\n     { actual: candidate(\"3wond-1ers2\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "go_test.go",
-    "prompt": "package count_charac_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the total number of characters in a string.\nfunc count_charac(str1 string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Charac(t *testing.T) {\n  candidate := count_charac\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: 18 },\n     { actual: candidate(\"language\"), expected: 8 },\n     { actual: candidate(\"words\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "go_test.go",
-    "prompt": "package get_total_number_of_sequences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m int, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Total_Number_Of_Sequences(t *testing.T) {\n  candidate := get_total_number_of_sequences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 4), expected: 4 },\n     { actual: candidate(5, 2), expected: 6 },\n     { actual: candidate(16, 3), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "go_test.go",
-    "prompt": "package left_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunc left_insertion(a []int, x int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLeft_Insertion(t *testing.T) {\n  candidate := left_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "go_test.go",
-    "prompt": "package swap_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a int, b int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSwap_Numbers(t *testing.T) {\n  candidate := swap_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: []int{20, 10} },\n     { actual: candidate(15, 17), expected: []int{17, 15} },\n     { actual: candidate(100, 200), expected: []int{200, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "go_test.go",
-    "prompt": "package is_majority_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr []int, n int, x int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Majority(t *testing.T) {\n  candidate := is_majority\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 3, 3, 3, 10}, 7, 3), expected: true },\n     { actual: candidate([]int{1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), expected: false },\n     { actual: candidate([]int{1, 1, 1, 2, 2}, 5, 1), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2}, 5, 1), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "go_test.go",
-    "prompt": "package substract_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSubstract_Elements(t *testing.T) {\n  candidate := substract_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5}, []interface{}{2, 5, 18}), expected: []interface{}{8, -1, -13} },\n     { actual: candidate([]interface{}{11, 2, 3}, []interface{}{24, 45, 16}), expected: []interface{}{-13, -43, -13} },\n     { actual: candidate([]interface{}{7, 18, 9}, []interface{}{10, 11, 12}), expected: []interface{}{-3, 7, -3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "go_test.go",
-    "prompt": "package capital_words_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1 string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCapital_Words_Spaces(t *testing.T) {\n  candidate := capital_words_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"PythonProgrammingExamples\"), expected: \"Python Programming Examples\" },\n     { actual: candidate(\"GetReadyToBeCodingFreak\"), expected: \"Get Ready To Be Coding Freak\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "go_test.go",
-    "prompt": "package find_Average_Of_Cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Average_Of_Cube(t *testing.T) {\n  candidate := find_Average_Of_Cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4.5 },\n     { actual: candidate(3), expected: 12 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "go_test.go",
-    "prompt": "package check_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict map[string]int, n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Value(t *testing.T) {\n  candidate := check_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10), expected: false },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12), expected: true },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "go_test.go",
-    "prompt": "package tetrahedral_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTetrahedral_Number(t *testing.T) {\n  candidate := tetrahedral_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 35 },\n     { actual: candidate(6), expected: 56 },\n     { actual: candidate(7), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "go_test.go",
-    "prompt": "package magic_square_test_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix [][]int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMagic_Square_Test(t *testing.T) {\n  candidate := magic_square_test\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{7, 12, 1, 14}, []int{2, 13, 8, 11}, []int{16, 3, 10, 5}, []int{9, 6, 15, 4}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 8}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 7}}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "go_test.go",
-    "prompt": "package remove_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1 string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Uppercase(t *testing.T) {\n  candidate := remove_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"cAstyoUrFavoRitETVshoWs\"), expected: \"cstyoravoitshos\" },\n     { actual: candidate(\"wAtchTheinTernEtrAdIo\"), expected: \"wtchheinerntrdo\" },\n     { actual: candidate(\"VoicESeaRchAndreComMendaTionS\"), expected: \"oiceachndreomendaion\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "go_test.go",
-    "prompt": "package dog_age_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDog_Age(t *testing.T) {\n  candidate := dog_age\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 61 },\n     { actual: candidate(15), expected: 73 },\n     { actual: candidate(24), expected: 109 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "go_test.go",
-    "prompt": "package next_Perfect_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNext_Perfect_Square(t *testing.T) {\n  candidate := next_Perfect_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(35), expected: 36 },\n     { actual: candidate(6), expected: 9 },\n     { actual: candidate(9), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "go_test.go",
-    "prompt": "package is_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert a given string to uppercase.\nfunc is_upper(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Upper(t *testing.T) {\n  candidate := is_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"person\"), expected: \"PERSON\" },\n     { actual: candidate(\"final\"), expected: \"FINAL\" },\n     { actual: candidate(\"Valid\"), expected: \"VALID\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "go_test.go",
-    "prompt": "package odd_Equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s string, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Equivalent(t *testing.T) {\n  candidate := odd_Equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"011001\", 6), expected: 3 },\n     { actual: candidate(\"11011\", 5), expected: 4 },\n     { actual: candidate(\"1010\", 4), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "go_test.go",
-    "prompt": "package re_arrange_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr []int, n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRe_Arrange_Array(t *testing.T) {\n  candidate := re_arrange_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), expected: []int{-1, -3, -7, 4, 5, 6, 2, 8, 9} },\n     { actual: candidate([]int{12, -14, -26, 13, 15}, 5), expected: []int{-14, -26, 12, 13, 15} },\n     { actual: candidate([]int{10, 24, 36, -42, -39, -78, 85}, 7), expected: []int{-42, -39, -78, 10, 24, 36, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "go_test.go",
-    "prompt": "package unique_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique_Element(t *testing.T) {\n  candidate := unique_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "go_test.go",
-    "prompt": "package extract_values_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Values(t *testing.T) {\n  candidate := extract_values\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"Python\", \"PHP\", \"Java\"\"), expected: []string{\"Python\", \"PHP\", \"Java\"} },\n     { actual: candidate(\"\"python\",\"program\",\"language\"\"), expected: []string{\"python\", \"program\", \"language\"} },\n     { actual: candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"), expected: []string{\"red\", \"blue\", \"green\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "go_test.go",
-    "prompt": "package count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count true booleans in the given list.\nfunc count(lst []bool) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount(t *testing.T) {\n  candidate := count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]UNKNOWN{true, false, true}), expected: 2 },\n     { actual: candidate([]UNKNOWN{false, false}), expected: 0 },\n     { actual: candidate([]UNKNOWN{true, true, true}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "go_test.go",
-    "prompt": "package find_even_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Even_Pair(t *testing.T) {\n  candidate := find_even_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}), expected: 4 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}), expected: 9 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "go_test.go",
-    "prompt": "package armstrong_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestArmstrong_Number(t *testing.T) {\n  candidate := armstrong_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(153), expected: true },\n     { actual: candidate(259), expected: false },\n     { actual: candidate(4458), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "go_test.go",
-    "prompt": "package upper_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the upper case characters in a given string.\nfunc upper_ctr(str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUpper_Ctr(t *testing.T) {\n  candidate := upper_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYthon\"), expected: 1 },\n     { actual: candidate(\"BigData\"), expected: 1 },\n     { actual: candidate(\"program\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "go_test.go",
-    "prompt": "package and_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAnd_Tuples(t *testing.T) {\n  candidate := and_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{0, 0, 2, 1} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{5, 6, 7, 8}), expected: []interface{}{1, 2, 3, 0} },\n     { actual: candidate([]interface{}{8, 9, 11, 12}, []interface{}{7, 13, 14, 17}), expected: []interface{}{0, 9, 10, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "go_test.go",
-    "prompt": "package is_samepatterns_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors []string, patterns []string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Samepatterns(t *testing.T) {\n  candidate := is_samepatterns\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"green\", \"green\"}, []string{\"a\", \"b\", \"b\"}), expected: true },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\", \"b\"}), expected: false },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\"}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "go_test.go",
-    "prompt": "package count_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of lists in a given number of lists.\nfunc count_list(input_list [][]int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_List(t *testing.T) {\n  candidate := count_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{2, 3}, []int{4, 5}}), expected: 3 },\n     { actual: candidate([][]int{[]int{1, 0}, []int{2, 0}}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "go_test.go",
-    "prompt": "package average_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums [][]int) []float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAverage_Tuple(t *testing.T) {\n  candidate := average_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{10, 10, 10, 12}, []int{30, 45, 56, 45}, []int{81, 80, 39, 32}, []int{1, 2, 3, 4}}), expected: []float64{30.5, 34.25, 27.0, 23.25} },\n     { actual: candidate([][]int{[]int{1, 1, -5}, []int{30, -15, 56}, []int{81, -60, -39}, []int{-10, 2, 3}}), expected: []float64{25.5, -18.0, 3.75} },\n     { actual: candidate([][]int{[]int{100, 100, 100, 120}, []int{300, 450, 560, 450}, []int{810, 800, 390, 320}, []int{10, 20, 30, 40}}), expected: []float64{305.0, 342.5, 270.0, 232.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "go_test.go",
-    "prompt": "package lcs_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X string, Y string, Z string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLcs_Of_Three(t *testing.T) {\n  candidate := lcs_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"), expected: 2 },\n     { actual: candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"), expected: 5 },\n     { actual: candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "go_test.go",
-    "prompt": "package find_star_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th star number.\nfunc find_star_num(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Star_Num(t *testing.T) {\n  candidate := find_star_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 37 },\n     { actual: candidate(4), expected: 73 },\n     { actual: candidate(5), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "go_test.go",
-    "prompt": "package _sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of an array.\nfunc _sum(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func Test_Sum(t *testing.T) {\n  candidate := _sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{15, 12, 13, 10}), expected: 50 },\n     { actual: candidate([]int{0, 1, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "go_test.go",
-    "prompt": "package check_Consecutive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Consecutive(t *testing.T) {\n  candidate := check_Consecutive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 2, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "go_test.go",
-    "prompt": "package find_adverb_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Adverb_Position(t *testing.T) {\n  candidate := find_adverb_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"clearly!! we can see the sky\"), expected: []interface{}{0, 7, \"clearly\"} },\n     { actual: candidate(\"seriously!! there are many roses\"), expected: []interface{}{0, 9, \"seriously\"} },\n     { actual: candidate(\"unfortunately!! sita is going to home\"), expected: []interface{}{0, 13, \"unfortunately\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "go_test.go",
-    "prompt": "package rotate_right_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunc rotate_right(list []int, m int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRotate_Right(t *testing.T) {\n  candidate := rotate_right\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), expected: []int{8, 9, 10, 1, 2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{9, 10, 1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), expected: []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "go_test.go",
-    "prompt": "package number_of_substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNumber_Of_Substrings(t *testing.T) {\n  candidate := number_of_substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: 6 },\n     { actual: candidate(\"abcd\"), expected: 10 },\n     { actual: candidate(\"abcde\"), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "go_test.go",
-    "prompt": "package list_split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S []interface{}, step int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestList_Split(t *testing.T) {\n  candidate := list_split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"}, 3), expected: [][]int{[]string{\"a\", \"d\", \"g\", \"j\", \"m\"}, []string{\"b\", \"e\", \"h\", \"k\", \"n\"}, []string{\"c\", \"f\", \"i\", \"l\"}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), expected: [][]int{[]int{1, 4, 7, 10, 13}, []int{2, 5, 8, 11, 14}, []int{3, 6, 9, 12}} },\n     { actual: candidate([]string{\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"}, 2), expected: [][]int{[]string{\"python\", \"C\", \"DBMS\"}, []string{\"java\", \"C++\", \"SQL\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "go_test.go",
-    "prompt": "package all_unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Unique(t *testing.T) {\n  candidate := all_unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "go_test.go",
-    "prompt": "package convert_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert complex numbers to polar coordinates.\nfunc convert(numbers int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestConvert(t *testing.T) {\n  candidate := convert\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: []interface{}{1.0, 0.0} },\n     { actual: candidate(4), expected: []interface{}{4.0, 0.0} },\n     { actual: candidate(5), expected: []interface{}{5.0, 0.0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "go_test.go",
-    "prompt": "package is_lower_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert the given string to lower case.\nfunc is_lower(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Lower(t *testing.T) {\n  candidate := is_lower\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"InValid\"), expected: \"invalid\" },\n     { actual: candidate(\"TruE\"), expected: \"true\" },\n     { actual: candidate(\"SenTenCE\"), expected: \"sentence\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "go_test.go",
-    "prompt": "package next_power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNext_Power_Of_2(t *testing.T) {\n  candidate := next_power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: 1 },\n     { actual: candidate(5), expected: 8 },\n     { actual: candidate(17), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "go_test.go",
-    "prompt": "package find_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1 []string, sub_str string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Substring(t *testing.T) {\n  candidate := find_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ack\"), expected: true },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"abc\"), expected: false },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ange\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "go_test.go",
-    "prompt": "package replace_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace characters in a string.\nfunc replace_char(str1 string, ch string, newch string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_Char(t *testing.T) {\n  candidate := replace_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"polygon\", \"y\", \"l\"), expected: \"pollgon\" },\n     { actual: candidate(\"character\", \"c\", \"a\"), expected: \"aharaater\" },\n     { actual: candidate(\"python\", \"l\", \"a\"), expected: \"python\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "go_test.go",
-    "prompt": "package mul_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1 []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMul_Even_Odd(t *testing.T) {\n  candidate := mul_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "go_test.go",
-    "prompt": "package list_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a tuple.\nfunc list_tuple(listx []int) interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestList_Tuple(t *testing.T) {\n  candidate := list_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 10, 7, 4, 15, 3}), expected: []interface{}{5, 10, 7, 4, 15, 3} },\n     { actual: candidate([]int{2, 4, 5, 6, 2, 3, 4, 4, 7}), expected: []interface{}{2, 4, 5, 6, 2, 3, 4, 4, 7} },\n     { actual: candidate([]int{58, 44, 56}), expected: []interface{}{58, 44, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "go_test.go",
-    "prompt": "package even_binomial_Coeff_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Binomial_Coeff_Sum(t *testing.T) {\n  candidate := even_binomial_Coeff_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 8 },\n     { actual: candidate(6), expected: 32 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "go_test.go",
-    "prompt": "package bitwise_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBitwise_Xor(t *testing.T) {\n  candidate := bitwise_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{15, 6, 5, 10} },\n     { actual: candidate([]interface{}{11, 5, 7, 10}, []interface{}{6, 3, 4, 4}), expected: []interface{}{13, 6, 3, 14} },\n     { actual: candidate([]interface{}{12, 6, 8, 11}, []interface{}{7, 4, 5, 6}), expected: []interface{}{11, 2, 13, 13} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "go_test.go",
-    "prompt": "package is_Sub_Array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A []int, B []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sub_Array(t *testing.T) {\n  candidate := is_Sub_Array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 5}, []int{1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 1}, []int{1, 2, 1}), expected: true },\n     { actual: candidate([]int{1, 0, 2, 2}, []int{2, 2, 0}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "go_test.go",
-    "prompt": "package max_sub_array_sum_repeated_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a []int, n int, k int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Sub_Array_Sum_Repeated(t *testing.T) {\n  candidate := max_sub_array_sum_repeated\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, -30, -1}, 4, 3), expected: 30 },\n     { actual: candidate([]int{-1, 10, 20}, 3, 2), expected: 59 },\n     { actual: candidate([]int{-1, -2, -3}, 3, 3), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "go_test.go",
-    "prompt": "package min_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunc min_product_tuple(list1 [][]interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMin_Product_Tuple(t *testing.T) {\n  candidate := min_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 8 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 30 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "go_test.go",
-    "prompt": "package count_divisors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunc count_divisors(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Divisors(t *testing.T) {\n  candidate := count_divisors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(100), expected: false },\n     { actual: candidate(125), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "go_test.go",
-    "prompt": "package string_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1 string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestString_To_Tuple(t *testing.T) {\n  candidate := string_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python 3.0\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"} },\n     { actual: candidate(\"item1\"), expected: []string{\"i\", \"t\", \"e\", \"m\", \"1\"} },\n     { actual: candidate(\"15.10\"), expected: []string{\"1\", \"5\", \".\", \"1\", \"0\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "go_test.go",
-    "prompt": "package find_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(myString string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Length(t *testing.T) {\n  candidate := find_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"11000010001\"), expected: 6 },\n     { actual: candidate(\"10111\"), expected: 1 },\n     { actual: candidate(\"11011101100101\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "go_test.go",
-    "prompt": "package count_Primes_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Primes_Nums(t *testing.T) {\n  candidate := count_Primes_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 2 },\n     { actual: candidate(10), expected: 4 },\n     { actual: candidate(100), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "go_test.go",
-    "prompt": "package sum_Of_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Of_Product(t *testing.T) {\n  candidate := sum_Of_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15 },\n     { actual: candidate(4), expected: 56 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "go_test.go",
-    "prompt": "package max_aggregate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the maximum aggregate from the list of tuples.\nfunc max_aggregate(stdata [][]interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Aggregate(t *testing.T) {\n  candidate := max_aggregate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 90}, []interface{}{\"Sabah Colley\", 88}, []interface{}{\"Peter Nichols\", 7}, []interface{}{\"Juan Whelan\", 122}, []interface{}{\"Sabah Colley\", 84}}), expected: []interface{}{\"Juan Whelan\", 212} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 50}, []interface{}{\"Sabah Colley\", 48}, []interface{}{\"Peter Nichols\", 37}, []interface{}{\"Juan Whelan\", 22}, []interface{}{\"Sabah Colley\", 14}}), expected: []interface{}{\"Juan Whelan\", 72} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 10}, []interface{}{\"Sabah Colley\", 20}, []interface{}{\"Peter Nichols\", 30}, []interface{}{\"Juan Whelan\", 40}, []interface{}{\"Sabah Colley\", 50}}), expected: []interface{}{\"Sabah Colley\", 70} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "go_test.go",
-    "prompt": "package comb_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc comb_sort(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestComb_Sort(t *testing.T) {\n  candidate := comb_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 15, 37, 25, 79}), expected: []int{5, 15, 25, 37, 79} },\n     { actual: candidate([]int{41, 32, 15, 19, 22}), expected: []int{15, 19, 22, 32, 41} },\n     { actual: candidate([]int{99, 15, 13, 47}), expected: []int{13, 15, 47, 99} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "go_test.go",
-    "prompt": "package check_expression_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Expression(t *testing.T) {\n  candidate := check_expression\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"{()}[{}]\"), expected: true },\n     { actual: candidate(\"{()}[{]\"), expected: false },\n     { actual: candidate(\"{()}[{}][]({})\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "go_test.go",
-    "prompt": "package text_match_wordz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_Wordz(t *testing.T) {\n  candidate := text_match_wordz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonz.\"), expected: true },\n     { actual: candidate(\"xyz.\"), expected: true },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "go_test.go",
-    "prompt": "package sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1 []int, lst2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_List(t *testing.T) {\n  candidate := sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30}, []int{15, 25, 35}), expected: []int{25, 45, 65} },\n     { actual: candidate([]int{1, 2, 3}, []int{5, 6, 7}), expected: []int{6, 8, 10} },\n     { actual: candidate([]int{15, 20, 30}, []int{15, 45, 75}), expected: []int{30, 65, 105} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "go_test.go",
-    "prompt": "package newman_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNewman_Prime(t *testing.T) {\n  candidate := newman_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 7 },\n     { actual: candidate(4), expected: 17 },\n     { actual: candidate(5), expected: 41 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "go_test.go",
-    "prompt": "package add_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_ []interface{}, myString string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_String(t *testing.T) {\n  candidate := add_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, \"temp{0}\"), expected: []string{\"temp1\", \"temp2\", \"temp3\", \"temp4\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, \"python{0}\"), expected: []string{\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"} },\n     { actual: candidate([]int{5, 6, 7, 8}, \"string{0}\"), expected: []string{\"string5\", \"string6\", \"string7\", \"string8\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "go_test.go",
-    "prompt": "package surface_Area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunc surface_Area(b int, s int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSurface_Area(t *testing.T) {\n  candidate := surface_Area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 33 },\n     { actual: candidate(4, 5), expected: 56 },\n     { actual: candidate(1, 2), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "go_test.go",
-    "prompt": "package Find_Min_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst [][]int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Min_Length(t *testing.T) {\n  candidate := Find_Min_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}}), expected: 1 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{1, 2, 3}, []int{1, 2, 3, 4}}), expected: 2 },\n     { actual: candidate([][]int{[]int{3, 3, 3}, []int{4, 4, 4, 4}}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "go_test.go",
-    "prompt": "package validate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestValidate(t *testing.T) {\n  candidate := validate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1234), expected: true },\n     { actual: candidate(51241), expected: false },\n     { actual: candidate(321), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "go_test.go",
-    "prompt": "package hexagonal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHexagonal_Num(t *testing.T) {\n  candidate := hexagonal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 190 },\n     { actual: candidate(5), expected: 45 },\n     { actual: candidate(7), expected: 91 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "go_test.go",
-    "prompt": "package find_lucas_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th lucas number.\nfunc find_lucas(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Lucas(t *testing.T) {\n  candidate := find_lucas\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 76 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(3), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "go_test.go",
-    "prompt": "package Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to get the difference between two lists.\nfunc Diff(li1 []int, li2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDiff(t *testing.T) {\n  candidate := Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 15, 20, 25, 30, 35, 40}, []int{25, 40, 35}), expected: []int{10, 20, 30, 15} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 1}), expected: []int{2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3}, []int{6, 7, 1}), expected: []int{2, 3, 6, 7} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "go_test.go",
-    "prompt": "package extract_quotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1 string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Quotation(t *testing.T) {\n  candidate := extract_quotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"), expected: []string{\"A53\", \"multi\", \"Processor\"} },\n     { actual: candidate(\"Cast your \"favorite\" entertainment \"apps\"\"), expected: []string{\"favorite\", \"apps\"} },\n     { actual: candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"), expected: []string{\"4k Ultra HD\", \"HDR 10\"} },\n     { actual: candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "go_test.go",
-    "prompt": "package differ_At_One_Bit_Pos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a int, b int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDiffer_At_One_Bit_Pos(t *testing.T) {\n  candidate := differ_At_One_Bit_Pos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13, 9), expected: true },\n     { actual: candidate(15, 8), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(2, 3), expected: true },\n     { actual: candidate(5, 1), expected: true },\n     { actual: candidate(1, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "go_test.go",
-    "prompt": "package text_match_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_Three(t *testing.T) {\n  candidate := text_match_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"caacabbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "go_test.go",
-    "prompt": "package max_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 100, 4, 5, 150, 6}), expected: 3000 },\n     { actual: candidate([]int{4, 42, 55, 68, 80}), expected: 50265600 },\n     { actual: candidate([]int{10, 22, 9, 33, 21, 50, 41, 60}), expected: 2460 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "go_test.go",
-    "prompt": "package split_Arr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l []int, n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSplit_Arr(t *testing.T) {\n  candidate := split_Arr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 10, 5, 6, 52, 36}, 2), expected: []int{5, 6, 52, 36, 12, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, 1), expected: []int{2, 3, 4, 1} },\n     { actual: candidate([]int{0, 1, 2, 3, 4, 5, 6, 7}, 3), expected: []int{3, 4, 5, 6, 7, 0, 1, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "go_test.go",
-    "prompt": "package divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the number of divisors of a given integer.\nfunc divisor(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDivisor(t *testing.T) {\n  candidate := divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 4 },\n     { actual: candidate(12), expected: 6 },\n     { actual: candidate(9), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "go_test.go",
-    "prompt": "package big_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestBig_Diff(t *testing.T) {\n  candidate := big_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{4, 5, 12}), expected: 8 },\n     { actual: candidate([]int{9, 2, 3}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "go_test.go",
-    "prompt": "package square_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSquare_Nums(t *testing.T) {\n  candidate := square_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{100, 400, 900} },\n     { actual: candidate([]int{12, 15}), expected: []int{144, 225} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "go_test.go",
-    "prompt": "package check_none_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given tuple has any none value or not.\nfunc check_none(test_tup interface{}) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_None(t *testing.T) {\n  candidate := check_none\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6, nil}), expected: true },\n     { actual: candidate([]interface{}{7, 8, 9, 11, 14}), expected: false },\n     { actual: candidate([]interface{}{1, 2, 3, 4, nil}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "go_test.go",
-    "prompt": "package is_Monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Monotonic(t *testing.T) {\n  candidate := is_Monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{6, 5, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 3, 2}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "go_test.go",
-    "prompt": "package is_perfect_square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Perfect_Square(t *testing.T) {\n  candidate := is_perfect_square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: false },\n     { actual: candidate(36), expected: true },\n     { actual: candidate(14), expected: false },\n     { actual: candidate(196), expected: true },\n     { actual: candidate(125), expected: false },\n     { actual: candidate(15625), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "go_test.go",
-    "prompt": "package sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of common divisors of two given numbers.\nfunc sum(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum(t *testing.T) {\n  candidate := sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 15), expected: 6 },\n     { actual: candidate(100, 150), expected: 93 },\n     { actual: candidate(4, 6), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "go_test.go",
-    "prompt": "package max_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1 [][]int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Length(t *testing.T) {\n  candidate := max_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1}, []int{5, 7}, []int{10, 12, 14, 15}}), expected: []interface{}{4, []int{10, 12, 14, 15}} },\n     { actual: candidate([][]int{[]int{5}, []int{15, 20, 25}}), expected: []interface{}{3, []int{15, 20, 25}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "go_test.go",
-    "prompt": "package parabola_directrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a int, b int, c int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestParabola_Directrix(t *testing.T) {\n  candidate := parabola_directrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3, 2), expected: -198 },\n     { actual: candidate(9, 8, 4), expected: -2336 },\n     { actual: candidate(2, 4, 6), expected: -130 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "go_test.go",
-    "prompt": "package remove_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Nested(t *testing.T) {\n  candidate := remove_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, []interface{}{4, 6}, 10}), expected: []interface{}{1, 5, 7, 10} },\n     { actual: candidate([]interface{}{2, 6, 8, []interface{}{5, 7}, 11}), expected: []interface{}{2, 6, 8, 11} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, 12}), expected: []interface{}{3, 7, 9, 12} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, []interface{}{5, 12}, 12}), expected: []interface{}{3, 7, 9, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "go_test.go",
-    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list [][]string) [][]string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\" red \", \"green\"}, []string{\"blue \", \" black\"}, []string{\" orange\", \"brown\"}}), expected: [][]int{[]string{\" red \", \"green\"}, []string{\" black\", \"blue \"}, []string{\" orange\", \"brown\"}} },\n     { actual: candidate([][]int{[]string{\"zilver\", \"gold\"}, []string{\"magnesium\", \"aluminium\"}, []string{\"steel\", \"bronze\"}}), expected: [][]int{[]string{\"gold\", \"zilver\"}, []string{\"aluminium\", \"magnesium\"}, []string{\"bronze\", \"steel\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "go_test.go",
-    "prompt": "package remove_kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1 []int, L int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Kth_Element(t *testing.T) {\n  candidate := remove_kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []int{1, 1, 3, 4, 4, 5, 1} },\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), expected: []int{0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), expected: []int{10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "go_test.go",
-    "prompt": "package add_dict_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup []interface{}, test_dict map[string]int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Dict_To_Tuple(t *testing.T) {\n  candidate := add_dict_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, 6}, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}), expected: []interface{}{4, 5, 6, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}} },\n     { actual: candidate([]interface{}{1, 2, 3}, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}), expected: []interface{}{1, 2, 3, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}} },\n     { actual: candidate([]interface{}{8, 9, 10}, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}), expected: []interface{}{8, 9, 10, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "go_test.go",
-    "prompt": "package find_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n int, m int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind(t *testing.T) {\n  candidate := find\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 3), expected: 3 },\n     { actual: candidate(4, 2), expected: 2 },\n     { actual: candidate(20, 5), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "go_test.go",
-    "prompt": "package text_match_two_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_Two_Three(t *testing.T) {\n  candidate := text_match_two_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "go_test.go",
-    "prompt": "package count_Occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the occurence of all elements of list in a tuple.\nfunc count_Occurrence(tup interface{}, lst []interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Occurrence(t *testing.T) {\n  candidate := count_Occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"a\", \"a\", \"c\", \"b\", \"d\"}, []string{\"a\", \"b\"}), expected: 3 },\n     { actual: candidate([]interface{}{1, 2, 3, 1, 4, 6, 7, 1, 4}, []int{1, 4, 7}), expected: 6 },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}, []int{1, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "go_test.go",
-    "prompt": "package count_samepair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1 []int, list2 []int, list3 []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Samepair(t *testing.T) {\n  candidate := count_samepair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}, []int{2, 1, 3, 1, 2, 6, 7, 9}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 2, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "go_test.go",
-    "prompt": "package text_match_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_One(t *testing.T) {\n  candidate := text_match_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "go_test.go",
-    "prompt": "package difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDifference(t *testing.T) {\n  candidate := difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 30 },\n     { actual: candidate(5), expected: 210 },\n     { actual: candidate(2), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "go_test.go",
-    "prompt": "package toggle_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestToggle_String(t *testing.T) {\n  candidate := toggle_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"pYTHON\" },\n     { actual: candidate(\"Pangram\"), expected: \"pANGRAM\" },\n     { actual: candidate(\"LIttLE\"), expected: \"liTTle\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "go_test.go",
-    "prompt": "package Find_Max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the element of a list having maximum length.\nfunc Find_Max(lst [][]interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := Find_Max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"A\"}, []string{\"A\", \"B\"}, []string{\"A\", \"B\", \"C\"}}), expected: []string{\"A\", \"B\", \"C\"} },\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1, 2, 3} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 2, 3}, []int{1, 5, 6, 1}}), expected: []int{1, 5, 6, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "go_test.go",
-    "prompt": "package eulerian_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n int, m int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestEulerian_Num(t *testing.T) {\n  candidate := eulerian_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 1), expected: 4 },\n     { actual: candidate(4, 1), expected: 11 },\n     { actual: candidate(5, 3), expected: 26 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "go_test.go",
-    "prompt": "package frequency_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a []int, x int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFrequency(t *testing.T) {\n  candidate := frequency\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 3, 4}, 3), expected: 3 },\n     { actual: candidate([]int{0, 1, 2, 3, 1, 2}, 1), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "go_test.go",
-    "prompt": "package sort_numeric_strings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str []string) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Numeric_Strings(t *testing.T) {\n  candidate := sort_numeric_strings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"}), expected: []int{-500, -12, 0, 4, 7, 12, 45, 100, 200} },\n     { actual: candidate([]string{\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"}), expected: []int{1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9} },\n     { actual: candidate([]string{\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"}), expected: []int{1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "go_test.go",
-    "prompt": "package geometric_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunc geometric_sum(n int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGeometric_Sum(t *testing.T) {\n  candidate := geometric_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 1.9921875 },\n     { actual: candidate(4), expected: 1.9375 },\n     { actual: candidate(8), expected: 1.99609375 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "go_test.go",
-    "prompt": "package divisible_by_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunc divisible_by_digits(startnum int, endnum int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDivisible_By_Digits(t *testing.T) {\n  candidate := divisible_by_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 22), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22} },\n     { actual: candidate(1, 15), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15} },\n     { actual: candidate(20, 25), expected: []int{22, 24} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "go_test.go",
-    "prompt": "package unique_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnique_Product(t *testing.T) {\n  candidate := unique_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30, 40, 20, 50, 60, 40}), expected: 720000000 },\n     { actual: candidate([]int{1, 2, 3, 1}), expected: 6 },\n     { actual: candidate([]int{7, 8, 9, 0, 1, 1}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "go_test.go",
-    "prompt": "package largest_neg_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the largest negative number from the given list.\nfunc largest_neg(list1 []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLargest_Neg(t *testing.T) {\n  candidate := largest_neg\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, -4, -6}), expected: -6 },\n     { actual: candidate([]int{1, 2, 3, -8, -9}), expected: -9 },\n     { actual: candidate([]int{1, 2, 3, 4, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "go_test.go",
-    "prompt": "package consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestConsecutive_Duplicates(t *testing.T) {\n  candidate := consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: []int{10, 15, 19, 18, 17, 26, 17, 18, 10} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: []string{\"a\", \"b\", \"c\", \"d\"} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"}), expected: []string{\"a\", \"b\", \"c\", \"d\", \"a\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "go_test.go",
-    "prompt": "package min_Jumps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps []interface{}, d int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMin_Jumps(t *testing.T) {\n  candidate := min_Jumps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}, 11), expected: 3.5 },\n     { actual: candidate([]interface{}{3, 4}, 0), expected: 0 },\n     { actual: candidate([]interface{}{11, 14}, 11), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "go_test.go",
-    "prompt": "package max_Product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr []int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_Product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 7, 0, 8, 4}), expected: []interface{}{7, 8} },\n     { actual: candidate([]int{0, -1, -2, -4, 5, 0, -6}), expected: []interface{}{-4, -6} },\n     { actual: candidate([]int{1, 2, 3}), expected: []interface{}{2, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "go_test.go",
-    "prompt": "package extract_nth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the nth element from a given list of tuples.\nfunc extract_nth_element(list1 [][]interface{}, n int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Nth_Element(t *testing.T) {\n  candidate := extract_nth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 0), expected: []string{\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 2), expected: []int{99, 96, 94, 98} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 1), expected: []int{98, 97, 91, 94} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "go_test.go",
-    "prompt": "package is_nonagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Nonagonal(t *testing.T) {\n  candidate := is_nonagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 325 },\n     { actual: candidate(15), expected: 750 },\n     { actual: candidate(18), expected: 1089 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "go_test.go",
-    "prompt": "package max_Abs_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Abs_Diff(t *testing.T) {\n  candidate := max_Abs_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 3}), expected: 4 },\n     { actual: candidate([]int{9, 3, 2, 5, 1}), expected: 8 },\n     { actual: candidate([]int{3, 2, 1}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "go_test.go",
-    "prompt": "package pack_consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1 []interface{}) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPack_Consecutive_Duplicates(t *testing.T) {\n  candidate := pack_consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: [][]int{[]int{0, 0}, []int{1}, []int{2}, []int{3}, []int{4, 4}, []int{5}, []int{6, 6, 6}, []int{7}, []int{8}, []int{9}, []int{4, 4}} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: [][]int{[]int{10, 10}, []int{15}, []int{19}, []int{18, 18}, []int{17}, []int{26, 26}, []int{17}, []int{18}, []int{10}} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: [][]int{[]string{\"a\", \"a\"}, []string{\"b\"}, []string{\"c\"}, []string{\"d\", \"d\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "go_test.go",
-    "prompt": "package cal_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCal_Sum(t *testing.T) {\n  candidate := cal_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 49 },\n     { actual: candidate(10), expected: 66 },\n     { actual: candidate(11), expected: 88 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "go_test.go",
-    "prompt": "package odd_values_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Values_String(t *testing.T) {\n  candidate := odd_values_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcdef\"), expected: \"ace\" },\n     { actual: candidate(\"python\"), expected: \"pto\" },\n     { actual: candidate(\"data\"), expected: \"dt\" },\n     { actual: candidate(\"lambs\"), expected: \"lms\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "go_test.go",
-    "prompt": "package find_kth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1 []int, arr2 []int, k int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Kth(t *testing.T) {\n  candidate := find_kth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 6, 7, 9}, []int{1, 4, 8, 10}, 5), expected: 6 },\n     { actual: candidate([]int{100, 112, 256, 349, 770}, []int{72, 86, 113, 119, 265, 445, 892}, 7), expected: 256 },\n     { actual: candidate([]int{3, 4, 7, 8, 10}, []int{2, 5, 9, 11}, 6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "go_test.go",
-    "prompt": "package jacobsthal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestJacobsthal_Num(t *testing.T) {\n  candidate := jacobsthal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 11 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 5 },\n     { actual: candidate(13), expected: 2731 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "go_test.go",
-    "prompt": "package frequency_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunc frequency_lists(list1 [][]int) map[int]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFrequency_Lists(t *testing.T) {\n  candidate := frequency_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 2}, []int{4, 5, 6, 2}, []int{7, 8, 9, 5}}), expected: map[int]int{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}}), expected: map[int]int{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1} },\n     { actual: candidate([][]int{[]int{20, 30, 40, 17}, []int{18, 16, 14, 13}, []int{10, 20, 30, 40}}), expected: map[int]int{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "go_test.go",
-    "prompt": "package perfect_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a int, b int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPerfect_Squares(t *testing.T) {\n  candidate := perfect_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 30), expected: []int{1, 4, 9, 16, 25} },\n     { actual: candidate(50, 100), expected: []int{64, 81, 100} },\n     { actual: candidate(100, 200), expected: []int{100, 121, 144, 169, 196} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "go_test.go",
-    "prompt": "package sum_Of_Subarray_Prod_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Of_Subarray_Prod(t *testing.T) {\n  candidate := sum_Of_Subarray_Prod\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 20 },\n     { actual: candidate([]int{1, 2}), expected: 5 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "go_test.go",
-    "prompt": "package first_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the first odd number in a given list of numbers.\nfunc first_odd(nums []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFirst_Odd(t *testing.T) {\n  candidate := first_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5}), expected: 1 },\n     { actual: candidate([]int{2, 4, 1, 3}), expected: 1 },\n     { actual: candidate([]int{8, 9, 1}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "go_test.go",
-    "prompt": "package add_nested_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Nested_Tuples(t *testing.T) {\n  candidate := add_nested_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{7, 10}, []int{7, 14}, []int{3, 10}, []int{8, 13}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{9, 12}, []int{9, 16}, []int{5, 12}, []int{10, 15}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{11, 14}, []int{11, 18}, []int{7, 14}, []int{12, 17}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "go_test.go",
-    "prompt": "package merge_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst [][]interface{}) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMerge(t *testing.T) {\n  candidate := merge\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"a\", \"b\"}, []string{\"m\", \"n\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}, []int{7, 8}}), expected: [][]int{[]int{1, 3, 5, 7}, []int{2, 4, 6, 8}} },\n     { actual: candidate([][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"a\", \"b\", \"c\"}, []string{\"m\", \"n\", \"o\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}, []string{\"z\", \"c\", \"o\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "go_test.go",
-    "prompt": "package dif_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDif_Square(t *testing.T) {\n  candidate := dif_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(15), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "go_test.go",
-    "prompt": "package check_smaller_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1 []interface{}, test_tup2 []interface{}) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Smaller(t *testing.T) {\n  candidate := check_smaller\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}, []interface{}{2, 3, 4}), expected: false },\n     { actual: candidate([]interface{}{4, 5, 6}, []interface{}{3, 4, 5}), expected: true },\n     { actual: candidate([]interface{}{11, 12, 13}, []interface{}{10, 11, 12}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "go_test.go",
-    "prompt": "package freq_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunc freq_count(list1 []int) map[int]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFreq_Count(t *testing.T) {\n  candidate := freq_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), expected: map[int]int{10: 4, 20: 4, 40: 2, 50: 2, 30: 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), expected: map[int]int{1: 3, 2: 2, 3: 3, 4: 3} },\n     { actual: candidate([]int{5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), expected: map[int]int{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "go_test.go",
-    "prompt": "package rgb_to_hsv_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r int, g int, b int) []float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRgb_To_Hsv(t *testing.T) {\n  candidate := rgb_to_hsv\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(255, 255, 255), expected: []float64{0.0, 0.0, 100.0} },\n     { actual: candidate(0, 215, 0), expected: []float64{120.0, 100.0, 84.31372549019608} },\n     { actual: candidate(10, 215, 110), expected: []float64{149.26829268292684, 95.34883720930233, 84.31372549019608} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "go_test.go",
-    "prompt": "package check_str_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(myString string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Str(t *testing.T) {\n  candidate := check_str\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"annie\"), expected: true },\n     { actual: candidate(\"dawood\"), expected: false },\n     { actual: candidate(\"Else\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "go_test.go",
-    "prompt": "package check_monthnumber_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3 int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Monthnumber_Number(t *testing.T) {\n  candidate := check_monthnumber_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(12), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "go_test.go",
-    "prompt": "package heap_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list.\nfunc heap_sort(iterable []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHeap_Sort(t *testing.T) {\n  candidate := heap_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 25, 58}), expected: []int{14, 22, 25, 25, 35, 58, 65, 75, 85} },\n     { actual: candidate([]int{7, 1, 9, 5}), expected: []int{1, 5, 7, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "go_test.go",
-    "prompt": "package k_smallest_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1 []int, nums2 []int, k int) [][]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestK_Smallest_Pairs(t *testing.T) {\n  candidate := k_smallest_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 2), expected: [][]int{[]int{1, 2}, []int{1, 4}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 1), expected: [][]int{[]int{1, 2}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 7), expected: [][]int{[]int{1, 2}, []int{1, 4}, []int{3, 2}, []int{1, 6}, []int{3, 4}, []int{3, 6}, []int{7, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "go_test.go",
-    "prompt": "package find_Max_Num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max_Num(t *testing.T) {\n  candidate := find_Max_Num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 321 },\n     { actual: candidate([]int{4, 5, 6, 1}), expected: 6541 },\n     { actual: candidate([]int{1, 2, 3, 9}), expected: 9321 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "go_test.go",
-    "prompt": "package max_sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists [][]int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Sum_List(t *testing.T) {\n  candidate := max_sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{10, 11, 12}, []int{7, 8, 9}}), expected: []int{10, 11, 12} },\n     { actual: candidate([][]int{[]int{3, 2, 1}, []int{6, 5, 4}, []int{12, 11, 10}}), expected: []int{12, 11, 10} },\n     { actual: candidate([][]int{[]int{2, 3, 1}}), expected: []int{2, 3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "go_test.go",
-    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to interchange the first and last elements in a list.\nfunc swap_List(newList []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 35, 9, 56, 24}), expected: []int{24, 35, 9, 56, 12} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "go_test.go",
-    "prompt": "package get_median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1 []int, arr2 []int, n int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Median(t *testing.T) {\n  candidate := get_median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 12, 15, 26, 38}, []int{2, 13, 17, 30, 45}, 5), expected: 16.0 },\n     { actual: candidate([]int{2, 4, 8, 9}, []int{7, 13, 19, 28}, 4), expected: 8.5 },\n     { actual: candidate([]int{3, 6, 14, 23, 36, 42}, []int{2, 18, 27, 39, 49, 55}, 6), expected: 25.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "go_test.go",
-    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jumanji The Jungle\"), expected: \"Jumanji_The_Jungle\" },\n     { actual: candidate(\"The_Avengers\"), expected: \"The Avengers\" },\n     { actual: candidate(\"Fast and Furious\"), expected: \"Fast_and_Furious\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "go_test.go",
-    "prompt": "package are_equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1 int, num2 int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAre_Equivalent(t *testing.T) {\n  candidate := are_equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(36, 57), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(23, 47), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "go_test.go",
-    "prompt": "package reverse_string_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist []string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReverse_String_List(t *testing.T) {\n  candidate := reverse_string_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"}), expected: []string{\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"} },\n     { actual: candidate([]string{\"john\", \"amal\", \"joel\", \"george\"}), expected: []string{\"nhoj\", \"lama\", \"leoj\", \"egroeg\"} },\n     { actual: candidate([]string{\"jack\", \"john\", \"mary\"}), expected: []string{\"kcaj\", \"nhoj\", \"yram\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "go_test.go",
-    "prompt": "package sum_of_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums []interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Of_Digits(t *testing.T) {\n  candidate := sum_of_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 2, 56}), expected: 14 },\n     { actual: candidate([][]int{[]interface{}{10, 20, 4, 5, \"b\", 70, \"a\"}}), expected: 19 },\n     { actual: candidate([]int{10, 20, -4, 5, -70}), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "go_test.go",
-    "prompt": "package sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSequence(t *testing.T) {\n  candidate := sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 6 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "go_test.go",
-    "prompt": "package heap_queue_largest_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums []int, n int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestHeap_Queue_Largest(t *testing.T) {\n  candidate := heap_queue_largest\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), expected: []int{85, 75, 65} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), expected: []int{85, 75} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), expected: []int{85, 75, 65, 58, 35} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "go_test.go",
-    "prompt": "package loss_amount_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost int, sale_amount int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLoss_Amount(t *testing.T) {\n  candidate := loss_amount\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: 0 },\n     { actual: candidate(100, 200), expected: 100 },\n     { actual: candidate(2000, 5000), expected: 3000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "go_test.go",
-    "prompt": "package union_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1 []int, test_tup2 []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestUnion_Elements(t *testing.T) {\n  candidate := union_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 6}, []int{5, 7, 4, 10}), expected: []int{3, 4, 5, 6, 7, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{3, 4, 5, 6}), expected: []int{1, 2, 3, 4, 5, 6} },\n     { actual: candidate([]int{11, 12, 13, 14}, []int{13, 15, 16, 17}), expected: []int{11, 12, 13, 14, 15, 16, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "go_test.go",
-    "prompt": "package Find_Max_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the longest sublists.\nfunc Find_Max_Length(lst [][]int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Max_Length(t *testing.T) {\n  candidate := Find_Max_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 4}, []int{5, 6, 7, 8}}), expected: 4 },\n     { actual: candidate([][]int{[]int{0, 1}, []int{2, 2}, []int{3, 2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]int{7}, []int{22, 23}, []int{13, 14, 15}, []int{10, 20, 30, 40, 50}}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "go_test.go",
-    "prompt": "package remove_parenthesis_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items []string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Parenthesis(t *testing.T) {\n  candidate := remove_parenthesis\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python (chrome)\"}), expected: \"python\" },\n     { actual: candidate([]string{\"string(.abc)\"}), expected: \"string\" },\n     { actual: candidate([]string{\"alpha(num)\"}), expected: \"alpha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "go_test.go",
-    "prompt": "package find_Parity_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find whether the parity of a given number is odd.\nfunc find_Parity(x int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Parity(t *testing.T) {\n  candidate := find_Parity\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: false },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "go_test.go",
-    "prompt": "package median_trapezium_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1 int, base2 int, height int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMedian_Trapezium(t *testing.T) {\n  candidate := median_trapezium\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15, 25, 35), expected: 20 },\n     { actual: candidate(10, 20, 30), expected: 15 },\n     { actual: candidate(6, 9, 4), expected: 7.5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "go_test.go",
-    "prompt": "package centered_hexagonal_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCentered_Hexagonal_Number(t *testing.T) {\n  candidate := centered_hexagonal_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 271 },\n     { actual: candidate(2), expected: 7 },\n     { actual: candidate(9), expected: 217 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "go_test.go",
-    "prompt": "package find_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find number of lists present in the given list.\nfunc find_lists(Input []interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Lists(t *testing.T) {\n  candidate := find_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}}), expected: 2 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}), expected: 3 },\n     { actual: candidate([]int{9, 8, 7, 6, 5, 4, 3, 2, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "go_test.go",
-    "prompt": "package get_max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Max_Sum(t *testing.T) {\n  candidate := get_max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(60), expected: 106 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "go_test.go",
-    "prompt": "package len_log_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the longest word.\nfunc len_log(list1 []string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLen_Log(t *testing.T) {\n  candidate := len_log\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python\", \"PHP\", \"bigdata\"}), expected: 7 },\n     { actual: candidate([]string{\"a\", \"ab\", \"abc\"}), expected: 3 },\n     { actual: candidate([]string{\"small\", \"big\", \"tall\"}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "go_test.go",
-    "prompt": "package odd_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOdd_Position(t *testing.T) {\n  candidate := odd_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 4, 3, 6, 7, 6, 3}), expected: true },\n     { actual: candidate([]int{4, 1, 2}), expected: true },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "go_test.go",
-    "prompt": "package multiple_to_single_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMultiple_To_Single(t *testing.T) {\n  candidate := multiple_to_single\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 33, 50}), expected: 113350 },\n     { actual: candidate([]int{-1, 2, 3, 4, 5, 6}), expected: -123456 },\n     { actual: candidate([]int{10, 15, 20, 25}), expected: 10152025 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "go_test.go",
-    "prompt": "package is_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find whether a number is divisible by 11.\nfunc is_Diff(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Diff(t *testing.T) {\n  candidate := is_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12345), expected: false },\n     { actual: candidate(1212112), expected: true },\n     { actual: candidate(1212), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "go_test.go",
-    "prompt": "package index_multiplication_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIndex_Multiplication(t *testing.T) {\n  candidate := index_multiplication\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 21}, []int{12, 45}, []int{2, 9}, []int{7, 30}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{14, 32}, []int{20, 60}, []int{6, 20}, []int{16, 44}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{24, 45}, []int{30, 77}, []int{12, 33}, []int{27, 60}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "go_test.go",
-    "prompt": "package tuple_str_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTuple_Str_Int(t *testing.T) {\n  candidate := tuple_str_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(7, 8, 9)\"), expected: []interface{}{7, 8, 9} },\n     { actual: candidate(\"(1, 2, 3)\"), expected: []interface{}{1, 2, 3} },\n     { actual: candidate(\"(4, 5, 6)\"), expected: []interface{}{4, 5, 6} },\n     { actual: candidate(\"(7, 81, 19)\"), expected: []interface{}{7, 81, 19} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "go_test.go",
-    "prompt": "package amicable_numbers_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAmicable_Numbers_Sum(t *testing.T) {\n  candidate := amicable_numbers_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(999), expected: 504 },\n     { actual: candidate(9999), expected: 31626 },\n     { actual: candidate(99), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "go_test.go",
-    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove odd characters in a string.\nfunc remove_odd(str1 string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: \"yhn\" },\n     { actual: candidate(\"program\"), expected: \"rga\" },\n     { actual: candidate(\"language\"), expected: \"agae\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "go_test.go",
-    "prompt": "package multiply_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup []int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMultiply_Elements(t *testing.T) {\n  candidate := multiply_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 7, 8, 10}), expected: []int{5, 35, 56, 80} },\n     { actual: candidate([]int{2, 4, 5, 6, 7}), expected: []int{8, 20, 30, 42} },\n     { actual: candidate([]int{12, 13, 14, 9, 15}), expected: []int{156, 182, 126, 135} },\n     { actual: candidate([]int{12}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "go_test.go",
-    "prompt": "package count_rotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Rotation(t *testing.T) {\n  candidate := count_rotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: 1 },\n     { actual: candidate([]int{4, 5, 1, 2, 3}), expected: 2 },\n     { actual: candidate([]int{7, 8, 9, 1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3}), expected: 0 },\n     { actual: candidate([]int{1, 3, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "go_test.go",
-    "prompt": "package extract_freq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the number of unique tuples in the given list.\nfunc extract_freq(test_list [][]interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Freq(t *testing.T) {\n  candidate := extract_freq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 4}, []interface{}{1, 2}, []interface{}{4, 3}, []interface{}{5, 6}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{4, 15}, []interface{}{2, 3}, []interface{}{5, 4}, []interface{}{6, 7}}), expected: 4 },\n     { actual: candidate([][]int{[]interface{}{5, 16}, []interface{}{2, 3}, []interface{}{6, 5}, []interface{}{6, 9}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "go_test.go",
-    "prompt": "package count_same_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1 []int, nums2 []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Same_Pair(t *testing.T) {\n  candidate := count_same_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 11 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 1 },\n     { actual: candidate([]int{0, 1, 1, 2}, []int{0, 1, 2, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "go_test.go",
-    "prompt": "package power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPower(t *testing.T) {\n  candidate := power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 81 },\n     { actual: candidate(2, 3), expected: 8 },\n     { actual: candidate(5, 5), expected: 3125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "go_test.go",
-    "prompt": "package return_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict map[string]int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReturn_Sum(t *testing.T) {\n  candidate := return_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"a\": 100, \"b\": 200, \"c\": 300}), expected: 600 },\n     { actual: candidate(map[string]int{\"a\": 25, \"b\": 18, \"c\": 45}), expected: 88 },\n     { actual: candidate(map[string]int{\"a\": 36, \"b\": 39, \"c\": 49}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "go_test.go",
-    "prompt": "package pair_wise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1 []int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPair_Wise(t *testing.T) {\n  candidate := pair_wise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 3, 4, 4, 5}), expected: [][]int{[]interface{}{1, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 3}, []interface{}{3, 4}, []interface{}{4, 4}, []interface{}{4, 5}} },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: [][]int{[]interface{}{1, 5}, []interface{}{5, 7}, []interface{}{7, 9}, []interface{}{9, 10}} },\n     { actual: candidate([]int{5, 1, 9, 7, 10}), expected: [][]int{[]interface{}{5, 1}, []interface{}{1, 9}, []interface{}{9, 7}, []interface{}{7, 10}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: [][]int{[]interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}, []interface{}{4, 5}, []interface{}{5, 6}, []interface{}{6, 7}, []interface{}{7, 8}, []interface{}{8, 9}, []interface{}{9, 10}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "go_test.go",
-    "prompt": "package split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to split a string into characters.\nfunc split(word string) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"} },\n     { actual: candidate(\"Name\"), expected: []string{\"N\", \"a\", \"m\", \"e\"} },\n     { actual: candidate(\"program\"), expected: []string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "go_test.go",
-    "prompt": "package min_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum of three numbers.\nfunc min_of_three(a int, b int, c int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMin_Of_Three(t *testing.T) {\n  candidate := min_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20, 0), expected: 0 },\n     { actual: candidate(19, 15, 18), expected: 15 },\n     { actual: candidate(-10, -20, -30), expected: -30 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "go_test.go",
-    "prompt": "package is_Sum_Of_Powers_Of_Two_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Sum_Of_Powers_Of_Two(t *testing.T) {\n  candidate := is_Sum_Of_Powers_Of_Two\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(7), expected: false },\n     { actual: candidate(14), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "go_test.go",
-    "prompt": "package get_Char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Char(t *testing.T) {\n  candidate := get_Char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: \"f\" },\n     { actual: candidate(\"gfg\"), expected: \"t\" },\n     { actual: candidate(\"ab\"), expected: \"c\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "go_test.go",
-    "prompt": "package sum_div_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Div(t *testing.T) {\n  candidate := sum_div\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: 7 },\n     { actual: candidate(12), expected: 16 },\n     { actual: candidate(7), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "go_test.go",
-    "prompt": "package two_unique_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTwo_Unique_Nums(t *testing.T) {\n  candidate := two_unique_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 2, 3, 4, 5}), expected: []int{1, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 5}), expected: []int{1, 3, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "go_test.go",
-    "prompt": "package test_duplicate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTest_Duplicate(t *testing.T) {\n  candidate := test_duplicate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2, 3, 3, 4, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "go_test.go",
-    "prompt": "package catalan_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which returns nth catalan number.\nfunc catalan_number(num int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCatalan_Number(t *testing.T) {\n  candidate := catalan_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 16796 },\n     { actual: candidate(9), expected: 4862 },\n     { actual: candidate(7), expected: 429 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "go_test.go",
-    "prompt": "package power_base_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base int, power int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPower_Base_Sum(t *testing.T) {\n  candidate := power_base_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 100), expected: 115 },\n     { actual: candidate(8, 10), expected: 37 },\n     { actual: candidate(8, 15), expected: 62 },\n     { actual: candidate(3, 3), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "go_test.go",
-    "prompt": "package replace_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1 []interface{}, list2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_List(t *testing.T) {\n  candidate := replace_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 2, 4, 6, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{5, 6, 7, 8}), expected: []int{1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]string{\"red\", \"blue\", \"green\"}, []string{\"yellow\"}), expected: []string{\"red\", \"blue\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "go_test.go",
-    "prompt": "package is_octagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth octagonal number.\nfunc is_octagonal(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Octagonal(t *testing.T) {\n  candidate := is_octagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 65 },\n     { actual: candidate(10), expected: 280 },\n     { actual: candidate(15), expected: 645 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "go_test.go",
-    "prompt": "package replace_blank_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1 string, char string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_Blank(t *testing.T) {\n  candidate := replace_blank\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello people\", \"@\"), expected: \"hello@people\" },\n     { actual: candidate(\"python program language\", \"$\"), expected: \"python$program$language\" },\n     { actual: candidate(\"blank space\", \"-\"), expected: \"blank-space\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "go_test.go",
-    "prompt": "package replace_specialchar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_Specialchar(t *testing.T) {\n  candidate := replace_specialchar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python language, Programming language.\"), expected: \"Python:language::Programming:language:\" },\n     { actual: candidate(\"a b c,d e f\"), expected: \"a:b:c:d:e:f\" },\n     { actual: candidate(\"ram reshma,ram rahim\"), expected: \"ram:reshma:ram:rahim\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "go_test.go",
-    "prompt": "package tuple_to_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums []interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTuple_To_Int(t *testing.T) {\n  candidate := tuple_to_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}), expected: 123 },\n     { actual: candidate([]interface{}{4, 5, 6}), expected: 456 },\n     { actual: candidate([]interface{}{5, 6, 7}), expected: 567 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "go_test.go",
-    "prompt": "package otherside_rightangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w int, h int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestOtherside_Rightangle(t *testing.T) {\n  candidate := otherside_rightangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 8), expected: 10.63014581273465 },\n     { actual: candidate(3, 4), expected: 5 },\n     { actual: candidate(7, 15), expected: 16.55294535724685 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "go_test.go",
-    "prompt": "package digit_distance_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1 int, n2 int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDigit_Distance_Nums(t *testing.T) {\n  candidate := digit_distance_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(23, 56), expected: 6 },\n     { actual: candidate(123, 256), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "go_test.go",
-    "prompt": "package text_match_wordz_middle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Match_Wordz_Middle(t *testing.T) {\n  candidate := text_match_wordz_middle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonzabc.\"), expected: true },\n     { actual: candidate(\"zxyabc.\"), expected: false },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "go_test.go",
-    "prompt": "package removezero_ip_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemovezero_Ip(t *testing.T) {\n  candidate := removezero_ip\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"216.08.094.196\"), expected: \"216.8.94.196\" },\n     { actual: candidate(\"12.01.024\"), expected: \"12.1.24\" },\n     { actual: candidate(\"216.08.094.0196\"), expected: \"216.8.94.196\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "go_test.go",
-    "prompt": "package count_element_in_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1 [][]interface{}, x interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Element_In_List(t *testing.T) {\n  candidate := count_element_in_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{1, 11}, []int{1, 15, 7}}, 1), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"A\"), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"E\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "go_test.go",
-    "prompt": "package multiply_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to multiply two integers.\nfunc multiply_int(x int, y int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMultiply_Int(t *testing.T) {\n  candidate := multiply_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(5, 10), expected: 50 },\n     { actual: candidate(4, 8), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "go_test.go",
-    "prompt": "package add_pairwise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Pairwise(t *testing.T) {\n  candidate := add_pairwise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 8, 10}), expected: []interface{}{6, 12, 15, 18} },\n     { actual: candidate([]interface{}{2, 6, 8, 9, 11}), expected: []interface{}{8, 14, 17, 20} },\n     { actual: candidate([]interface{}{3, 7, 9, 10, 12}), expected: []interface{}{10, 16, 19, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "go_test.go",
-    "prompt": "package max_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunc max_product_tuple(list1 [][]interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Product_Tuple(t *testing.T) {\n  candidate := max_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 36 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 200 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 484 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3868,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the kth element in the given array using 1-based indexing.\nfunc kth_element(arr []int, k int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestKth_Element(t *testing.T) {\n  candidate := kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 3, 5, 7, 19}, 2), expected: 3 },\n     { actual: candidate([]int{17, 24, 8, 23}, 3), expected: 8 },\n     { actual: candidate([]int{16, 21, 25, 36, 4}, 4), expected: 36 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -3878,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "go_test.go",
-    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to interchange the first and last element in a given list.\nfunc swap_List(newList []int) []int {\n",
+    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: []int{4, 2, 3, 4, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python_program\"), expected: \"PythonProgram\" },\n     { actual: candidate(\"python_language\"), expected: \"PythonLanguage\" },\n     { actual: candidate(\"programming_language\"), expected: \"ProgrammingLanguage\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3892,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "go_test.go",
-    "prompt": "package right_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a []int, x int) int {\n",
+    "prompt": "package eulerian_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n int, m int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestRight_Insertion(t *testing.T) {\n  candidate := right_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestEulerian_Num(t *testing.T) {\n  candidate := eulerian_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 1), expected: 4 },\n     { actual: candidate(4, 1), expected: 11 },\n     { actual: candidate(5, 3), expected: 26 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3906,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "go_test.go",
-    "prompt": "package is_woodall_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x int) bool {\n",
+    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list [][]string) [][]string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Woodall(t *testing.T) {\n  candidate := is_woodall\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(383), expected: true },\n     { actual: candidate(254), expected: false },\n     { actual: candidate(200), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\" red \", \"green\"}, []string{\"blue \", \" black\"}, []string{\" orange\", \"brown\"}}), expected: [][]int{[]string{\" red \", \"green\"}, []string{\" black\", \"blue \"}, []string{\" orange\", \"brown\"}} },\n     { actual: candidate([][]int{[]string{\"zilver\", \"gold\"}, []string{\"magnesium\", \"aluminium\"}, []string{\"steel\", \"bronze\"}}), expected: [][]int{[]string{\"gold\", \"zilver\"}, []string{\"aluminium\", \"magnesium\"}, []string{\"bronze\", \"steel\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3920,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "go_test.go",
-    "prompt": "package shell_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list []int) []int {\n",
+    "prompt": "package count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count true booleans in the given list.\nfunc count(lst []bool) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestShell_Sort(t *testing.T) {\n  candidate := shell_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), expected: []int{2, 3, 4, 5, 12, 12, 23, 56, 81, 95} },\n     { actual: candidate([]int{24, 22, 39, 34, 87, 73, 68}), expected: []int{22, 24, 34, 39, 68, 73, 87} },\n     { actual: candidate([]int{32, 30, 16, 96, 82, 83, 74}), expected: []int{16, 30, 32, 74, 82, 83, 96} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount(t *testing.T) {\n  candidate := count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]UNKNOWN{true, false, true}), expected: 2 },\n     { actual: candidate([]UNKNOWN{false, false}), expected: 0 },\n     { actual: candidate([]UNKNOWN{true, true, true}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3934,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "go_test.go",
-    "prompt": "package find_Odd_Pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A []int, N int) int {\n",
+    "prompt": "package add_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to append the given list to the given tuples.\nfunc add_lists(test_list []int, test_tup []interface{}) []interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Odd_Pair(t *testing.T) {\n  candidate := find_Odd_Pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}, 5), expected: 6 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}, 7), expected: 12 },\n     { actual: candidate([]int{1, 2, 3}, 3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAdd_Lists(t *testing.T) {\n  candidate := add_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []interface{}{9, 10, 5, 6, 7} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []interface{}{10, 11, 6, 7, 8} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []interface{}{11, 12, 7, 8, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3948,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "go_test.go",
-    "prompt": "package sum_in_range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l int, r int) int {\n",
+    "prompt": "package merge_sorted_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1 []int, num2 []int, num3 []int) []int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSum_In_Range(t *testing.T) {\n  candidate := sum_in_range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 5), expected: 8 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 13), expected: 40 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMerge_Sorted_List(t *testing.T) {\n  candidate := merge_sorted_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 24, 15, 4, 5, 29, 110}, []int{19, 20, 11, 56, 25, 233, 154}, []int{24, 26, 54, 48}), expected: []int{4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233} },\n     { actual: candidate([]int{1, 3, 5, 6, 8, 9}, []int{2, 5, 7, 11}, []int{1, 4, 7, 8, 12}), expected: []int{1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12} },\n     { actual: candidate([]int{18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, []int{25, 35, 22, 85, 14, 65, 75, 25, 58}, []int{12, 74, 9, 50, 61, 41}), expected: []int{1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3962,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "go_test.go",
-    "prompt": "package square_perimeter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a int) int {\n",
+    "prompt": "package odd_Equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s string, n int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSquare_Perimeter(t *testing.T) {\n  candidate := square_perimeter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 40 },\n     { actual: candidate(5), expected: 20 },\n     { actual: candidate(4), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestOdd_Equivalent(t *testing.T) {\n  candidate := odd_Equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"011001\", 6), expected: 3 },\n     { actual: candidate(\"11011\", 5), expected: 4 },\n     { actual: candidate(\"1010\", 4), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3976,13 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "go_test.go",
-    "prompt": "package is_polite_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n int) int {\n",
+    "prompt": "package check_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string represents an integer or not.\nfunc check_integer(text string) bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Polite(t *testing.T) {\n  candidate := is_polite\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 11 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(9), expected: 13 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCheck_Integer(t *testing.T) {\n  candidate := check_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"1\"), expected: true },\n     { actual: candidate(\"12345\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3990,195 +140,13 @@
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "go_test.go",
-    "prompt": "package sum_series_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n int) int {\n",
+    "prompt": "package tuple_to_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums []interface{}) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Series(t *testing.T) {\n  candidate := sum_series\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: 12 },\n     { actual: candidate(10), expected: 30 },\n     { actual: candidate(9), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "go_test.go",
-    "prompt": "package find_dissimilar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Dissimilar(t *testing.T) {\n  candidate := find_dissimilar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4, 5, 6}, []interface{}{5, 7, 4, 10}), expected: []interface{}{3, 6, 7, 10} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{7, 2, 3, 9}), expected: []interface{}{1, 4, 7, 9} },\n     { actual: candidate([]interface{}{21, 11, 25, 26}, []interface{}{26, 34, 21, 36}), expected: []interface{}{34, 36, 11, 25} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "go_test.go",
-    "prompt": "package start_withp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words []string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestStart_Withp(t *testing.T) {\n  candidate := start_withp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python PHP\", \"Java JavaScript\", \"c c++\"}), expected: []interface{}{\"Python\", \"PHP\"} },\n     { actual: candidate([]string{\"Python Programming\", \"Java Programming\"}), expected: []interface{}{\"Python\", \"Programming\"} },\n     { actual: candidate([]string{\"Pqrst Pqr\", \"qrstuv\"}), expected: []interface{}{\"Pqrst\", \"Pqr\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "go_test.go",
-    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"android_tv\"), expected: \"AndroidTv\" },\n     { actual: candidate(\"google_pixel\"), expected: \"GooglePixel\" },\n     { actual: candidate(\"apple_watch\"), expected: \"AppleWatch\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "go_test.go",
-    "prompt": "package volume_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestVolume_Cube(t *testing.T) {\n  candidate := volume_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(2), expected: 8 },\n     { actual: candidate(5), expected: 125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "go_test.go",
-    "prompt": "package check_monthnumb_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2 int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Monthnumb_Number(t *testing.T) {\n  candidate := check_monthnumb_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "go_test.go",
-    "prompt": "package all_Bits_Set_In_The_Given_Range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n int, l int, r int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAll_Bits_Set_In_The_Given_Range(t *testing.T) {\n  candidate := all_Bits_Set_In_The_Given_Range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4, 1, 2), expected: true },\n     { actual: candidate(17, 2, 4), expected: true },\n     { actual: candidate(39, 4, 6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "go_test.go",
-    "prompt": "package Extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to get the first element of each sublist.\nfunc Extract(lst [][]int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract(t *testing.T) {\n  candidate := Extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4, 5}, []int{6, 7, 8, 9}}), expected: []int{1, 3, 6} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5}}), expected: []int{1, 4} },\n     { actual: candidate([][]int{[]int{9, 8, 1}, []int{1, 2}}), expected: []int{9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "go_test.go",
-    "prompt": "package surfacearea_cylinder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r int, h int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSurfacearea_Cylinder(t *testing.T) {\n  candidate := surfacearea_cylinder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 5), expected: 942.45 },\n     { actual: candidate(4, 5), expected: 226.18800000000002 },\n     { actual: candidate(4, 10), expected: 351.848 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "go_test.go",
-    "prompt": "package sample_nam_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names []string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSample_Nam(t *testing.T) {\n  candidate := sample_nam\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"}), expected: 16 },\n     { actual: candidate([]string{\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"}), expected: 10 },\n     { actual: candidate([]string{\"abcd\", \"Python\", \"abba\", \"aba\"}), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "go_test.go",
-    "prompt": "package rearrange_bigger_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n int) interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRearrange_Bigger(t *testing.T) {\n  candidate := rearrange_bigger\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 21 },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(102), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "go_test.go",
-    "prompt": "package perimeter_pentagon_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPerimeter_Pentagon(t *testing.T) {\n  candidate := perimeter_pentagon\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 25 },\n     { actual: candidate(10), expected: 50 },\n     { actual: candidate(15), expected: 75 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "go_test.go",
-    "prompt": "package max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Sum(t *testing.T) {\n  candidate := max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 15, 51, 45, 33, 100, 12, 18, 9}), expected: 194 },\n     { actual: candidate([]int{80, 60, 30, 40, 20, 10}), expected: 210 },\n     { actual: candidate([]int{2, 3, 14, 16, 21, 23, 29, 30}), expected: 138 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "go_test.go",
-    "prompt": "package extract_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple []interface{}) interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Even(t *testing.T) {\n  candidate := extract_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, []interface{}{7, 6, []interface{}{2, 4}}, 6, 8}), expected: []interface{}{4, []interface{}{6, []interface{}{2, 4}}, 6, 8} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{8, 7, []interface{}{4, 8}}, 7, 9}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 8}}} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{9, 8, []interface{}{4, 6}}, 8, 10}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 6}}, 8, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestTuple_To_Int(t *testing.T) {\n  candidate := tuple_to_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}), expected: 123 },\n     { actual: candidate([]interface{}{4, 5, 6}), expected: 456 },\n     { actual: candidate([]interface{}{5, 6, 7}), expected: 567 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4190,219 +158,9 @@
     "language": "go_test.go",
     "prompt": "package list_to_float_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert all possible convertible elements in a list of lists to floats.\nfunc list_to_float(test_list [][]interface{}) [][]interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestList_To_Float(t *testing.T) {\n  candidate := list_to_float\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"3\", \"4\"}, []interface{}{\"1\", \"26.45\"}, []interface{}{\"7.32\", \"8\"}, []interface{}{\"4\", \"8\"}}), expected: [][]int{[]interface{}{3.0, 4.0}, []interface{}{1.0, 26.45}, []interface{}{7.32, 8.0}, []interface{}{4.0, 8.0}} },\n     { actual: candidate([][]int{[]interface{}{\"4\", \"4\"}, []interface{}{\"2\", \"27\"}, []interface{}{\"4.12\", \"9\"}, []interface{}{\"7\", \"11\"}}), expected: [][]int{[]interface{}{4.0, 4.0}, []interface{}{2.0, 27.0}, []interface{}{4.12, 9.0}, []interface{}{7.0, 11.0}} },\n     { actual: candidate([][]int{[]interface{}{\"6\", \"78\"}, []interface{}{\"5\", \"26.45\"}, []interface{}{\"1.33\", \"4\"}, []interface{}{\"82\", \"13\"}}), expected: [][]int{[]interface{}{6.0, 78.0}, []interface{}{5.0, 26.45}, []interface{}{1.33, 4.0}, []interface{}{82.0, 13.0}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "go_test.go",
-    "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 20 },\n     { actual: candidate(3), expected: 56 },\n     { actual: candidate(4), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "go_test.go",
-    "prompt": "package get_pairs_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr []int, sum int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Pairs_Count(t *testing.T) {\n  candidate := get_pairs_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1, 1}, 2), expected: 6 },\n     { actual: candidate([]int{1, 5, 7, -1, 5}, 6), expected: 3 },\n     { actual: candidate([]int{1, -2, 3}, 1), expected: 1 },\n     { actual: candidate([]int{-1, -2, 3}, -3), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "go_test.go",
-    "prompt": "package count_no_of_ways_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n int, k int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_No_Of_Ways(t *testing.T) {\n  candidate := count_no_of_ways\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 4), expected: 16 },\n     { actual: candidate(3, 2), expected: 6 },\n     { actual: candidate(4, 4), expected: 228 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "go_test.go",
-    "prompt": "package reverse_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReverse_Words(t *testing.T) {\n  candidate := reverse_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python program\"), expected: \"program python\" },\n     { actual: candidate(\"java language\"), expected: \"language java\" },\n     { actual: candidate(\"indian man\"), expected: \"man indian\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "go_test.go",
-    "prompt": "package checks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check if a given number is one less than twice its reverse.\nfunc checks(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestChecks(t *testing.T) {\n  candidate := checks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(70), expected: false },\n     { actual: candidate(23), expected: false },\n     { actual: candidate(73), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "go_test.go",
-    "prompt": "package last_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last position of an element in a sorted array.\nfunc last(arr []int, x int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestLast(t *testing.T) {\n  candidate := last\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 1), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 2, 3, 4}, 1), expected: 2 },\n     { actual: candidate([]int{2, 3, 2, 3, 6, 8, 9}, 3), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "go_test.go",
-    "prompt": "package count_X_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunc count_X(tup []int, x int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_X(t *testing.T) {\n  candidate := count_X\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), expected: 0 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), expected: 3 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "go_test.go",
-    "prompt": "package extract_index_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1 []int, l2 []int, l3 []int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_Index_List(t *testing.T) {\n  candidate := extract_index_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 7} },\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 6, 5}, []int{0, 1, 2, 3, 4, 6, 7}), expected: []int{1, 6} },\n     { actual: candidate([]int{1, 1, 3, 4, 6, 5, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 6, 6, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "go_test.go",
-    "prompt": "package concatenate_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup []interface{}) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestConcatenate_Tuple(t *testing.T) {\n  candidate := concatenate_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"ID\", \"is\", 4, \"UTS\"}), expected: \"ID-is-4-UTS\" },\n     { actual: candidate([]interface{}{\"QWE\", \"is\", 4, \"RTY\"}), expected: \"QWE-is-4-RTY\" },\n     { actual: candidate([]interface{}{\"ZEN\", \"is\", 4, \"OP\"}), expected: \"ZEN-is-4-OP\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "go_test.go",
-    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(myString string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"My Name is Dawood\"), expected: \"My%20Name%20is%20Dawood\" },\n     { actual: candidate(\"I am a Programmer\"), expected: \"I%20am%20a%20Programmer\" },\n     { actual: candidate(\"I love Coding\"), expected: \"I%20love%20Coding\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "go_test.go",
-    "prompt": "package sum_range_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1 []int, m int, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSum_Range_List(t *testing.T) {\n  candidate := sum_range_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), expected: 29 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), expected: 16 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), expected: 38 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "go_test.go",
-    "prompt": "package merge_dictionaries_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1 map[string]string, dict2 map[string]string, dict3 map[string]string) map[string]string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMerge_Dictionaries_Three(t *testing.T) {\n  candidate := merge_dictionaries_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}), expected: map[string]string{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}), expected: map[string]string{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}), expected: map[string]string{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "go_test.go",
-    "prompt": "package minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum of two numbers.\nfunc minimum(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMinimum(t *testing.T) {\n  candidate := minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(-5, -4), expected: -5 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "go_test.go",
-    "prompt": "package max_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunc max_difference(test_list [][]interface{}) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Difference(t *testing.T) {\n  candidate := max_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{1, 7}, []interface{}{10, 3}, []interface{}{1, 2}}), expected: 7 },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{2, 17}, []interface{}{9, 13}, []interface{}{11, 12}}), expected: 15 },\n     { actual: candidate([][]int{[]interface{}{12, 35}, []interface{}{21, 27}, []interface{}{13, 23}, []interface{}{41, 22}}), expected: 23 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "go_test.go",
-    "prompt": "package find_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find element at a given index after number of rotations.\nfunc find_Element(arr []int, ranges [][]int, rotations int, index int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Element(t *testing.T) {\n  candidate := find_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, [][]int{[]int{0, 2}, []int{0, 3}}, 2, 1), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 2), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4414,7 +172,7 @@
     "language": "go_test.go",
     "prompt": "package string_to_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a string to a list of strings split on the space character.\nfunc string_to_list(myString string) []string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestString_To_List(t *testing.T) {\n  candidate := string_to_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: []string{\"python\", \"programming\"} },\n     { actual: candidate(\"lists tuples strings\"), expected: []string{\"lists\", \"tuples\", \"strings\"} },\n     { actual: candidate(\"write a program\"), expected: []string{\"write\", \"a\", \"program\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4428,23 +186,9 @@
     "language": "go_test.go",
     "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the element that appears only once in a sorted array.\nfunc search(arr []int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8}), expected: 8 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4, 4}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "go_test.go",
-    "prompt": "package sort_counter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1 map[string]int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Counter(t *testing.T) {\n  candidate := sort_counter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}), expected: [][]int{[]interface{}{\"Chemistry\", 87}, []interface{}{\"Physics\", 83}, []interface{}{\"Math\", 81}} },\n     { actual: candidate(map[string]int{\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}), expected: [][]int{[]interface{}{\"Math\", 400}, []interface{}{\"Physics\", 300}, []interface{}{\"Chemistry\", 250}} },\n     { actual: candidate(map[string]int{\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}), expected: [][]int{[]interface{}{\"Chemistry\", 1250}, []interface{}{\"Physics\", 1000}, []interface{}{\"Math\", 900}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4456,7 +200,7 @@
     "language": "go_test.go",
     "prompt": "package remove_Occ_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove first and last occurrence of a given character from the string.\nfunc remove_Occ(s string, ch string) string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestRemove_Occ(t *testing.T) {\n  candidate := remove_Occ\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello\", \"l\"), expected: \"heo\" },\n     { actual: candidate(\"abcda\", \"a\"), expected: \"bcd\" },\n     { actual: candidate(\"PHP\", \"P\"), expected: \"H\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4466,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "go_test.go",
-    "prompt": "package lateralsurface_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l int) int {\n",
+    "prompt": "package max_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunc max_product_tuple(list1 [][]interface{}) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestLateralsurface_Cube(t *testing.T) {\n  candidate := lateralsurface_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 100 },\n     { actual: candidate(9), expected: 324 },\n     { actual: candidate(10), expected: 400 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMax_Product_Tuple(t *testing.T) {\n  candidate := max_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 36 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 200 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 484 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4480,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "go_test.go",
-    "prompt": "package add_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to append the given list to the given tuples.\nfunc add_lists(test_list []int, test_tup []interface{}) []interface{} {\n",
+    "prompt": "package amicable_numbers_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Lists(t *testing.T) {\n  candidate := add_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []interface{}{9, 10, 5, 6, 7} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []interface{}{10, 11, 6, 7, 8} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []interface{}{11, 12, 7, 8, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAmicable_Numbers_Sum(t *testing.T) {\n  candidate := amicable_numbers_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(999), expected: 504 },\n     { actual: candidate(9999), expected: 31626 },\n     { actual: candidate(99), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4494,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "go_test.go",
-    "prompt": "package nth_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums []int, n int) []int {\n",
+    "prompt": "package find_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(myString string) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestNth_Nums(t *testing.T) {\n  candidate := nth_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}, 3), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}, 5), expected: []int{248832, 759375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestFind_Length(t *testing.T) {\n  candidate := find_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"11000010001\"), expected: 6 },\n     { actual: candidate(\"10111\"), expected: 1 },\n     { actual: candidate(\"11011101100101\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4508,13 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "go_test.go",
-    "prompt": "package pancake_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc pancake_sort(nums []int) []int {\n",
+    "prompt": "package sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of common divisors of two given numbers.\nfunc sum(a int, b int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestPancake_Sort(t *testing.T) {\n  candidate := pancake_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 79, 25, 38, 69}), expected: []int{15, 25, 38, 69, 79} },\n     { actual: candidate([]int{98, 12, 54, 36, 85}), expected: []int{12, 36, 54, 85, 98} },\n     { actual: candidate([]int{41, 42, 32, 12, 23}), expected: []int{12, 23, 32, 41, 42} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSum(t *testing.T) {\n  candidate := sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 15), expected: 6 },\n     { actual: candidate(100, 150), expected: 93 },\n     { actual: candidate(4, 6), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4522,307 +266,13 @@
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "go_test.go",
-    "prompt": "package median_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of three numbers.\nfunc median_numbers(a int, b int, c int) float64 {\n",
+    "prompt": "package multiply_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to multiply two integers.\nfunc multiply_int(x int, y int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMedian_Numbers(t *testing.T) {\n  candidate := median_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(25, 55, 65), expected: 55.0 },\n     { actual: candidate(20, 10, 30), expected: 20.0 },\n     { actual: candidate(15, 45, 75), expected: 45.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "go_test.go",
-    "prompt": "package check_greater_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr []int, number int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Greater(t *testing.T) {\n  candidate := check_greater\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 4), expected: false },\n     { actual: candidate([]int{2, 3, 4, 5, 6}, 8), expected: true },\n     { actual: candidate([]int{9, 7, 4, 8, 6, 1}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "go_test.go",
-    "prompt": "package check_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list []interface{}, element interface{}) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Element(t *testing.T) {\n  candidate := check_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"green\", \"orange\", \"black\", \"white\"}, \"blue\"), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4}, 7), expected: false },\n     { actual: candidate([]string{\"green\", \"green\", \"green\", \"green\"}, \"green\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "go_test.go",
-    "prompt": "package extract_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str []string, l int) []string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestExtract_String(t *testing.T) {\n  candidate := extract_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 8), expected: []string{\"practice\", \"solution\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 6), expected: []string{\"Python\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 9), expected: []string{\"exercises\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "go_test.go",
-    "prompt": "package text_lowercase_underscore_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text string) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestText_Lowercase_Underscore(t *testing.T) {\n  candidate := text_lowercase_underscore\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aab_cbbbc\"), expected: true },\n     { actual: candidate(\"aab_Abbbc\"), expected: false },\n     { actual: candidate(\"Aaab_abbbc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "go_test.go",
-    "prompt": "package trim_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list [][]int, K int) [][]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestTrim_Tuple(t *testing.T) {\n  candidate := trim_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 2), expected: [][]int{[]int{2}, []int{9}, []int{2}, []int{2}} },\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 1), expected: [][]int{[]int{3, 2, 1}, []int{4, 9, 2}, []int{1, 2, 3}, []int{8, 2, 1}} },\n     { actual: candidate([][]int{[]int{7, 8, 4, 9}, []int{11, 8, 12, 4}, []int{4, 1, 7, 8}, []int{3, 6, 9, 7}}, 1), expected: [][]int{[]int{8, 4}, []int{8, 12}, []int{1, 7}, []int{6, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "go_test.go",
-    "prompt": "package Find_Min_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sublist having minimum length.\nfunc Find_Min(lst [][]interface{}) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Min(t *testing.T) {\n  candidate := Find_Min\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 1, 1}, []int{1, 2, 7, 8}}), expected: []int{1, 1} },\n     { actual: candidate([][]int{[]string{\"x\"}, []string{\"x\", \"y\"}, []string{\"x\", \"y\", \"z\"}}), expected: []string{\"x\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "go_test.go",
-    "prompt": "package filter_oddnumbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFilter_Oddnumbers(t *testing.T) {\n  candidate := filter_oddnumbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 3, 5, 7, 9} },\n     { actual: candidate([]int{10, 20, 45, 67, 84, 93}), expected: []int{45, 67, 93} },\n     { actual: candidate([]int{5, 7, 9, 8, 6, 4, 3}), expected: []int{5, 7, 9, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "go_test.go",
-    "prompt": "package find_adverbs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Adverbs(t *testing.T) {\n  candidate := find_adverbs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Clearly, he has no excuse for such behavior.\"), expected: \"0-7: Clearly\" },\n     { actual: candidate(\"Please handle the situation carefuly\"), expected: \"28-36: carefuly\" },\n     { actual: candidate(\"Complete the task quickly\"), expected: \"18-25: quickly\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "go_test.go",
-    "prompt": "package max_of_nth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list [][]int, N int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Of_Nth(t *testing.T) {\n  candidate := max_of_nth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 6, 7}, []int{1, 3, 5}, []int{8, 9, 19}}, 2), expected: 19 },\n     { actual: candidate([][]int{[]int{6, 7, 8}, []int{2, 4, 6}, []int{9, 10, 20}}, 1), expected: 10 },\n     { actual: candidate([][]int{[]int{7, 8, 9}, []int{3, 5, 7}, []int{10, 11, 21}}, 1), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n int) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: \"1000\" },\n     { actual: candidate(18), expected: \"10010\" },\n     { actual: candidate(7), expected: \"111\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "go_test.go",
-    "prompt": "package combinations_colors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l []string, n int) [][]string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCombinations_Colors(t *testing.T) {\n  candidate := combinations_colors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 1), expected: [][]int{[]string{\"Red\"}, []string{\"Green\"}, []string{\"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 2), expected: [][]int{[]string{\"Red\", \"Red\"}, []string{\"Red\", \"Green\"}, []string{\"Red\", \"Blue\"}, []string{\"Green\", \"Green\"}, []string{\"Green\", \"Blue\"}, []string{\"Blue\", \"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 3), expected: [][]int{[]string{\"Red\", \"Red\", \"Red\"}, []string{\"Red\", \"Red\", \"Green\"}, []string{\"Red\", \"Red\", \"Blue\"}, []string{\"Red\", \"Green\", \"Green\"}, []string{\"Red\", \"Green\", \"Blue\"}, []string{\"Red\", \"Blue\", \"Blue\"}, []string{\"Green\", \"Green\", \"Green\"}, []string{\"Green\", \"Green\", \"Blue\"}, []string{\"Green\", \"Blue\", \"Blue\"}, []string{\"Blue\", \"Blue\", \"Blue\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "go_test.go",
-    "prompt": "package remove_all_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text string) string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_All_Spaces(t *testing.T) {\n  candidate := remove_all_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python  program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"python   programming    language\"), expected: \"pythonprogramminglanguage\" },\n     { actual: candidate(\"python                     program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"   python                     program\"), expected: \"pythonprogram\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "go_test.go",
-    "prompt": "package min_Swaps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1 string, str2 string) interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMin_Swaps(t *testing.T) {\n  candidate := min_Swaps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1101\", \"1110\"), expected: 1 },\n     { actual: candidate(\"111\", \"000\"), expected: \"Not Possible\" },\n     { actual: candidate(\"111\", \"110\"), expected: \"Not Possible\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "go_test.go",
-    "prompt": "package new_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create a new tuple from the given string and list.\nfunc new_tuple(test_list []string, test_str string) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestNew_Tuple(t *testing.T) {\n  candidate := new_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"WEB\", \"is\"}, \"best\"), expected: []interface{}{\"WEB\", \"is\", \"best\"} },\n     { actual: candidate([]string{\"We\", \"are\"}, \"Developers\"), expected: []interface{}{\"We\", \"are\", \"Developers\"} },\n     { actual: candidate([]string{\"Part\", \"is\"}, \"Wrong\"), expected: []interface{}{\"Part\", \"is\", \"Wrong\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "go_test.go",
-    "prompt": "package find_remainder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr []int, n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Remainder(t *testing.T) {\n  candidate := find_remainder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{100, 10, 5, 25, 35, 14}, 11), expected: 9 },\n     { actual: candidate([]int{1, 1, 1}, 1), expected: 0 },\n     { actual: candidate([]int{1, 2, 1}, 2), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "go_test.go",
-    "prompt": "package positive_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums []int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestPositive_Count(t *testing.T) {\n  candidate := positive_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), expected: 0.54 },\n     { actual: candidate([]int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 0.69 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: 0.56 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "go_test.go",
-    "prompt": "package add_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add the given tuple to the given list.\nfunc add_tuple(test_list []int, test_tup []interface{}) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestAdd_Tuple(t *testing.T) {\n  candidate := add_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []int{5, 6, 7, 9, 10} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []int{6, 7, 8, 10, 11} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []int{7, 8, 9, 11, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "go_test.go",
-    "prompt": "package max_run_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Run_Uppercase(t *testing.T) {\n  candidate := max_run_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"GeMKSForGERksISBESt\"), expected: 5 },\n     { actual: candidate(\"PrECIOusMOVemENTSYT\"), expected: 6 },\n     { actual: candidate(\"GooGLEFluTTER\"), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "go_test.go",
-    "prompt": "package sort_matrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M [][]int) [][]int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSort_Matrix(t *testing.T) {\n  candidate := sort_matrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{2, 4, 5}, []int{1, 1, 1}}), expected: [][]int{[]int{1, 1, 1}, []int{1, 2, 3}, []int{2, 4, 5}} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{-2, 4, -5}, []int{1, -1, 1}}), expected: [][]int{[]int{-2, 4, -5}, []int{1, -1, 1}, []int{1, 2, 3}} },\n     { actual: candidate([][]int{[]int{5, 8, 9}, []int{6, 4, 3}, []int{2, 1, 4}}), expected: [][]int{[]int{2, 1, 4}, []int{6, 4, 3}, []int{5, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "go_test.go",
-    "prompt": "package count_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Vowels(t *testing.T) {\n  candidate := count_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"bestinstareels\"), expected: 7 },\n     { actual: candidate(\"partofthejourneyistheend\"), expected: 12 },\n     { actual: candidate(\"amazonprime\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "go_test.go",
-    "prompt": "package max_sum_increasing_subseq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a []int, n int, index int, k int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMax_Sum_Increasing_Subseq(t *testing.T) {\n  candidate := max_sum_increasing_subseq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), expected: 11 },\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), expected: 7 },\n     { actual: candidate([]int{11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), expected: 71 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMultiply_Int(t *testing.T) {\n  candidate := multiply_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(5, 10), expected: 50 },\n     { actual: candidate(4, 8), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4834,7 +284,7 @@
     "language": "go_test.go",
     "prompt": "package long_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find words that are longer than n characters from a given list of words.\nfunc long_words(n int, str string) []string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestLong_Words(t *testing.T) {\n  candidate := long_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, \"python is a programming language\"), expected: []string{\"python\", \"programming\", \"language\"} },\n     { actual: candidate(2, \"writing a program\"), expected: []string{\"writing\", \"program\"} },\n     { actual: candidate(5, \"sorting list\"), expected: []string{\"sorting\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4844,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "go_test.go",
-    "prompt": "package find_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr []int) int {\n",
+    "prompt": "package magic_square_test_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix [][]int) bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Sum(t *testing.T) {\n  candidate := find_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 1, 1, 4, 5, 6}), expected: 21 },\n     { actual: candidate([]int{1, 10, 9, 4, 2, 10, 10, 45, 4}), expected: 71 },\n     { actual: candidate([]int{12, 10, 9, 45, 2, 10, 10, 45, 10}), expected: 78 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMagic_Square_Test(t *testing.T) {\n  candidate := magic_square_test\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{7, 12, 1, 14}, []int{2, 13, 8, 11}, []int{16, 3, 10, 5}, []int{9, 6, 15, 4}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 8}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 7}}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4858,13 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "go_test.go",
-    "prompt": "package tuple_to_dict_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup []interface{}) map[int]int {\n",
+    "prompt": "package sort_matrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M [][]int) [][]int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestTuple_To_Dict(t *testing.T) {\n  candidate := tuple_to_dict\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 10, 13, 5}), expected: map[int]int{1: 5, 7: 10, 13: 5} },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}), expected: map[int]int{1: 2, 3: 4, 5: 6} },\n     { actual: candidate([]interface{}{7, 8, 9, 10, 11, 12}), expected: map[int]int{7: 8, 9: 10, 11: 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Matrix(t *testing.T) {\n  candidate := sort_matrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{2, 4, 5}, []int{1, 1, 1}}), expected: [][]int{[]int{1, 1, 1}, []int{1, 2, 3}, []int{2, 4, 5}} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{-2, 4, -5}, []int{1, -1, 1}}), expected: [][]int{[]int{-2, 4, -5}, []int{1, -1, 1}, []int{1, 2, 3}} },\n     { actual: candidate([][]int{[]int{5, 8, 9}, []int{6, 4, 3}, []int{2, 1, 4}}), expected: [][]int{[]int{2, 1, 4}, []int{6, 4, 3}, []int{5, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4872,209 +322,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "go_test.go",
-    "prompt": "package get_coordinates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup []interface{}) [][]int {\n",
+    "prompt": "package max_occurrences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums []int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestGet_Coordinates(t *testing.T) {\n  candidate := get_coordinates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}), expected: [][]int{[]int{2, 3}, []int{2, 4}, []int{2, 5}, []int{3, 3}, []int{3, 4}, []int{3, 5}, []int{4, 3}, []int{4, 4}, []int{4, 5}} },\n     { actual: candidate([]interface{}{4, 5}), expected: [][]int{[]int{3, 4}, []int{3, 5}, []int{3, 6}, []int{4, 4}, []int{4, 5}, []int{4, 6}, []int{5, 4}, []int{5, 5}, []int{5, 6}} },\n     { actual: candidate([]interface{}{5, 6}), expected: [][]int{[]int{4, 5}, []int{4, 6}, []int{4, 7}, []int{5, 5}, []int{5, 6}, []int{5, 7}, []int{6, 5}, []int{6, 6}, []int{6, 7}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "go_test.go",
-    "prompt": "package check_type_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple interface{}) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Type(t *testing.T) {\n  candidate := check_type\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{5, 6, 7, 3, 5, 6}), expected: true },\n     { actual: candidate([]interface{}{1, 2, \"4\"}), expected: false },\n     { actual: candidate([]interface{}{3, 2, 1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "go_test.go",
-    "prompt": "package find_First_Missing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array []int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_First_Missing(t *testing.T) {\n  candidate := find_First_Missing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, 6, 9}), expected: 3 },\n     { actual: candidate([]int{2, 3, 5, 8, 9}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "go_test.go",
-    "prompt": "package is_undulating_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Undulating(t *testing.T) {\n  candidate := is_undulating\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1212121), expected: true },\n     { actual: candidate(1991), expected: false },\n     { actual: candidate(121), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "go_test.go",
-    "prompt": "package min_k_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunc min_k(test_list [][]interface{}, K int) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMin_K(t *testing.T) {\n  candidate := min_k\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Manjeet\", 10}, []interface{}{\"Akshat\", 4}, []interface{}{\"Akash\", 2}, []interface{}{\"Nikhil\", 8}}, 2), expected: [][]int{[]interface{}{\"Akash\", 2}, []interface{}{\"Akshat\", 4}} },\n     { actual: candidate([][]int{[]interface{}{\"Sanjeev\", 11}, []interface{}{\"Angat\", 5}, []interface{}{\"Akash\", 3}, []interface{}{\"Nepin\", 9}}, 3), expected: [][]int{[]interface{}{\"Akash\", 3}, []interface{}{\"Angat\", 5}, []interface{}{\"Nepin\", 9}} },\n     { actual: candidate([][]int{[]interface{}{\"tanmay\", 14}, []interface{}{\"Amer\", 11}, []interface{}{\"Ayesha\", 9}, []interface{}{\"SKD\", 16}}, 1), expected: [][]int{[]interface{}{\"Ayesha\", 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "go_test.go",
-    "prompt": "package count_Substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s string) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Substrings(t *testing.T) {\n  candidate := count_Substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"112112\"), expected: 6 },\n     { actual: candidate(\"111\"), expected: 6 },\n     { actual: candidate(\"1101112\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "go_test.go",
-    "prompt": "package is_num_decagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Num_Decagonal(t *testing.T) {\n  candidate := is_num_decagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(7), expected: 175 },\n     { actual: candidate(10), expected: 370 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "go_test.go",
-    "prompt": "package rear_extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunc rear_extract(test_list [][]interface{}) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRear_Extract(t *testing.T) {\n  candidate := rear_extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{1, \"Rash\", 21}, []interface{}{2, \"Varsha\", 20}, []interface{}{3, \"Kil\", 19}}), expected: []int{21, 20, 19} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sai\", 36}, []interface{}{2, \"Ayesha\", 25}, []interface{}{3, \"Salman\", 45}}), expected: []int{36, 25, 45} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sudeep\", 14}, []interface{}{2, \"Vandana\", 36}, []interface{}{3, \"Dawood\", 56}}), expected: []int{14, 36, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "go_test.go",
-    "prompt": "package closest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the closest smaller number than n.\nfunc closest_num(N int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestClosest_Num(t *testing.T) {\n  candidate := closest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(11), expected: 10 },\n     { actual: candidate(7), expected: 6 },\n     { actual: candidate(12), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "go_test.go",
-    "prompt": "package find_combinations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunc find_combinations(test_list [][]interface{}) [][]interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestFind_Combinations(t *testing.T) {\n  candidate := find_combinations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 4}, []interface{}{6, 7}, []interface{}{5, 1}, []interface{}{6, 10}}), expected: [][]int{[]interface{}{8, 11}, []interface{}{7, 5}, []interface{}{8, 14}, []interface{}{11, 8}, []interface{}{12, 17}, []interface{}{11, 11}} },\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{7, 8}, []interface{}{6, 2}, []interface{}{7, 11}}), expected: [][]int{[]interface{}{10, 13}, []interface{}{9, 7}, []interface{}{10, 16}, []interface{}{13, 10}, []interface{}{14, 19}, []interface{}{13, 13}} },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{8, 9}, []interface{}{7, 3}, []interface{}{8, 12}}), expected: [][]int{[]interface{}{12, 15}, []interface{}{11, 9}, []interface{}{12, 18}, []interface{}{15, 12}, []interface{}{16, 21}, []interface{}{15, 15}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "go_test.go",
-    "prompt": "package maxAverageOfPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost [][]int) float64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMaxaverageofpath(t *testing.T) {\n  candidate := maxAverageOfPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{6, 5, 4}, []int{7, 3, 9}}), expected: 5.2 },\n     { actual: candidate([][]int{[]int{2, 3, 4}, []int{7, 6, 5}, []int{8, 4, 10}}), expected: 6.2 },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{8, 7, 6}, []int{9, 5, 11}}), expected: 7.2 },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}), expected: 5.8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "go_test.go",
-    "prompt": "package sequential_search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist []int, item int) []interface{} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestSequential_Search(t *testing.T) {\n  candidate := sequential_search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), expected: []interface{}{true, 3} },\n     { actual: candidate([]int{12, 32, 45, 62, 35, 47, 44, 61}, 61), expected: []interface{}{true, 7} },\n     { actual: candidate([]int{9, 10, 17, 19, 22, 39, 48, 56}, 48), expected: []interface{}{true, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "go_test.go",
-    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove odd numbers from a given list.\nfunc remove_odd(l []int) []int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2} },\n     { actual: candidate([]int{2, 4, 6}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{10, 20, 3}), expected: []int{10, 20} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "go_test.go",
-    "prompt": "package is_product_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr []int) bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestIs_Product_Even(t *testing.T) {\n  candidate := is_product_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 4}), expected: true },\n     { actual: candidate([]int{1, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the maximum of two numbers.\nfunc maximum(a int, b int) int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 10), expected: 10 },\n     { actual: candidate(-1, -2), expected: -1 },\n     { actual: candidate(9, 7), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMax_Occurrences(t *testing.T) {\n  candidate := max_occurrences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), expected: 2 },\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), expected: 8 },\n     { actual: candidate([]int{10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), expected: 20 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5086,9 +340,667 @@
     "language": "go_test.go",
     "prompt": "package reverse_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfunc reverse_vowels(str1 string) string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestReverse_Vowels(t *testing.T) {\n  candidate := reverse_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"USA\"), expected: \"ASU\" },\n     { actual: candidate(\"ab\"), expected: \"ab\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "go_test.go",
+    "prompt": "package tup_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a string.\nfunc tup_string(tup1 []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTup_String(t *testing.T) {\n  candidate := tup_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"}), expected: \"exercises\" },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}), expected: \"python\" },\n     { actual: candidate([]string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"}), expected: \"program\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "go_test.go",
+    "prompt": "package sum_negativenum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Negativenum(t *testing.T) {\n  candidate := sum_negativenum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: -32 },\n     { actual: candidate([]int{10, 15, -14, 13, -18, 12, -20}), expected: -52 },\n     { actual: candidate([]int{19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), expected: -894 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "go_test.go",
+    "prompt": "package hexagonal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHexagonal_Num(t *testing.T) {\n  candidate := hexagonal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 190 },\n     { actual: candidate(5), expected: 45 },\n     { actual: candidate(7), expected: 91 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "go_test.go",
+    "prompt": "package is_Sum_Of_Powers_Of_Two_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Sum_Of_Powers_Of_Two(t *testing.T) {\n  candidate := is_Sum_Of_Powers_Of_Two\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(7), expected: false },\n     { actual: candidate(14), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "go_test.go",
+    "prompt": "package pancake_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc pancake_sort(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPancake_Sort(t *testing.T) {\n  candidate := pancake_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 79, 25, 38, 69}), expected: []int{15, 25, 38, 69, 79} },\n     { actual: candidate([]int{98, 12, 54, 36, 85}), expected: []int{12, 36, 54, 85, 98} },\n     { actual: candidate([]int{41, 42, 32, 12, 23}), expected: []int{12, 23, 32, 41, 42} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "go_test.go",
+    "prompt": "package count_samepair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1 []int, list2 []int, list3 []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Samepair(t *testing.T) {\n  candidate := count_samepair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}, []int{2, 1, 3, 1, 2, 6, 7, 9}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 2, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "go_test.go",
+    "prompt": "package find_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find number of lists present in the given list.\nfunc find_lists(Input []interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Lists(t *testing.T) {\n  candidate := find_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}}), expected: 2 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}), expected: 3 },\n     { actual: candidate([]int{9, 8, 7, 6, 5, 4, 3, 2, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "go_test.go",
+    "prompt": "package max_Abs_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Abs_Diff(t *testing.T) {\n  candidate := max_Abs_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 3}), expected: 4 },\n     { actual: candidate([]int{9, 3, 2, 5, 1}), expected: 8 },\n     { actual: candidate([]int{3, 2, 1}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "go_test.go",
+    "prompt": "package find_Volume_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the volume of a triangular prism.\nfunc find_Volume(l int, b int, h int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Volume(t *testing.T) {\n  candidate := find_Volume\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 8, 6), expected: 240 },\n     { actual: candidate(3, 2, 2), expected: 6 },\n     { actual: candidate(1, 2, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "go_test.go",
+    "prompt": "package remove_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1 []int, list2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Elements(t *testing.T) {\n  candidate := remove_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{1, 3, 5, 7}), expected: []int{2, 4, 6, 8, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{5, 7}), expected: []int{1, 2, 3, 4, 6, 8, 9, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "go_test.go",
+    "prompt": "package sum_series_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Series(t *testing.T) {\n  candidate := sum_series\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: 12 },\n     { actual: candidate(10), expected: 30 },\n     { actual: candidate(9), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "go_test.go",
+    "prompt": "package are_equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1 int, num2 int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAre_Equivalent(t *testing.T) {\n  candidate := are_equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(36, 57), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(23, 47), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "go_test.go",
+    "prompt": "package count_char_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1 string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Char_Position(t *testing.T) {\n  candidate := count_char_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xbcefg\"), expected: 2 },\n     { actual: candidate(\"ABcED\"), expected: 3 },\n     { actual: candidate(\"AbgdeF\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "go_test.go",
+    "prompt": "package find_even_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Even_Pair(t *testing.T) {\n  candidate := find_even_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}), expected: 4 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}), expected: 9 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "go_test.go",
+    "prompt": "package next_power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNext_Power_Of_2(t *testing.T) {\n  candidate := next_power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: 1 },\n     { actual: candidate(5), expected: 8 },\n     { actual: candidate(17), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "go_test.go",
+    "prompt": "package frequency_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFrequency(t *testing.T) {\n  candidate := frequency\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 3, 4}, 3), expected: 3 },\n     { actual: candidate([]int{0, 1, 2, 3, 1, 2}, 1), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "go_test.go",
+    "prompt": "package text_lowercase_underscore_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Lowercase_Underscore(t *testing.T) {\n  candidate := text_lowercase_underscore\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aab_cbbbc\"), expected: true },\n     { actual: candidate(\"aab_Abbbc\"), expected: false },\n     { actual: candidate(\"Aaab_abbbc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "go_test.go",
+    "prompt": "package sum_range_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1 []int, m int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Range_List(t *testing.T) {\n  candidate := sum_range_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), expected: 29 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), expected: 16 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), expected: 38 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "go_test.go",
+    "prompt": "package perimeter_pentagon_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPerimeter_Pentagon(t *testing.T) {\n  candidate := perimeter_pentagon\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 25 },\n     { actual: candidate(10), expected: 50 },\n     { actual: candidate(15), expected: 75 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "go_test.go",
+    "prompt": "package count_occurance_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Occurance(t *testing.T) {\n  candidate := count_occurance\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"letstdlenstdporstd\"), expected: 3 },\n     { actual: candidate(\"truststdsolensporsd\"), expected: 1 },\n     { actual: candidate(\"makestdsostdworthit\"), expected: 2 },\n     { actual: candidate(\"stds\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "go_test.go",
+    "prompt": "package square_perimeter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSquare_Perimeter(t *testing.T) {\n  candidate := square_perimeter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 40 },\n     { actual: candidate(5), expected: 20 },\n     { actual: candidate(4), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "go_test.go",
+    "prompt": "package remove_dirty_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(myString string, second_string string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Dirty_Chars(t *testing.T) {\n  candidate := remove_dirty_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"probasscurve\", \"pros\"), expected: \"bacuve\" },\n     { actual: candidate(\"digitalindia\", \"talent\"), expected: \"digiidi\" },\n     { actual: candidate(\"exoticmiles\", \"toxic\"), expected: \"emles\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "go_test.go",
+    "prompt": "package test_duplicate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTest_Duplicate(t *testing.T) {\n  candidate := test_duplicate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2, 3, 3, 4, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "go_test.go",
+    "prompt": "package is_woodall_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Woodall(t *testing.T) {\n  candidate := is_woodall\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(383), expected: true },\n     { actual: candidate(254), expected: false },\n     { actual: candidate(200), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "go_test.go",
+    "prompt": "package check_type_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple interface{}) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Type(t *testing.T) {\n  candidate := check_type\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{5, 6, 7, 3, 5, 6}), expected: true },\n     { actual: candidate([]interface{}{1, 2, \"4\"}), expected: false },\n     { actual: candidate([]interface{}{3, 2, 1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "go_test.go",
+    "prompt": "package is_majority_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr []int, n int, x int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Majority(t *testing.T) {\n  candidate := is_majority\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 3, 3, 3, 10}, 7, 3), expected: true },\n     { actual: candidate([]int{1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), expected: false },\n     { actual: candidate([]int{1, 1, 1, 2, 2}, 5, 1), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2}, 5, 1), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "go_test.go",
+    "prompt": "package count_Set_Bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Set_Bits(t *testing.T) {\n  candidate := count_Set_Bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 1 },\n     { actual: candidate(6), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "go_test.go",
+    "prompt": "package odd_values_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOdd_Values_String(t *testing.T) {\n  candidate := odd_values_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcdef\"), expected: \"ace\" },\n     { actual: candidate(\"python\"), expected: \"pto\" },\n     { actual: candidate(\"data\"), expected: \"dt\" },\n     { actual: candidate(\"lambs\"), expected: \"lms\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "go_test.go",
+    "prompt": "package min_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum of three numbers.\nfunc min_of_three(a int, b int, c int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMin_Of_Three(t *testing.T) {\n  candidate := min_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20, 0), expected: 0 },\n     { actual: candidate(19, 15, 18), expected: 15 },\n     { actual: candidate(-10, -20, -30), expected: -30 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "go_test.go",
+    "prompt": "package all_Bits_Set_In_The_Given_Range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n int, l int, r int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Bits_Set_In_The_Given_Range(t *testing.T) {\n  candidate := all_Bits_Set_In_The_Given_Range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4, 1, 2), expected: true },\n     { actual: candidate(17, 2, 4), expected: true },\n     { actual: candidate(39, 4, 6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "go_test.go",
+    "prompt": "package re_arrange_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr []int, n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRe_Arrange_Array(t *testing.T) {\n  candidate := re_arrange_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), expected: []int{-1, -3, -7, 4, 5, 6, 2, 8, 9} },\n     { actual: candidate([]int{12, -14, -26, 13, 15}, 5), expected: []int{-14, -26, 12, 13, 15} },\n     { actual: candidate([]int{10, 24, 36, -42, -39, -78, 85}, 7), expected: []int{-42, -39, -78, 10, 24, 36, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "go_test.go",
+    "prompt": "package replace_blank_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1 string, char string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_Blank(t *testing.T) {\n  candidate := replace_blank\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello people\", \"@\"), expected: \"hello@people\" },\n     { actual: candidate(\"python program language\", \"$\"), expected: \"python$program$language\" },\n     { actual: candidate(\"blank space\", \"-\"), expected: \"blank-space\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "go_test.go",
+    "prompt": "package volume_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestVolume_Cube(t *testing.T) {\n  candidate := volume_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(2), expected: 8 },\n     { actual: candidate(5), expected: 125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "go_test.go",
+    "prompt": "package number_of_substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNumber_Of_Substrings(t *testing.T) {\n  candidate := number_of_substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: 6 },\n     { actual: candidate(\"abcd\"), expected: 10 },\n     { actual: candidate(\"abcde\"), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "go_test.go",
+    "prompt": "package get_total_number_of_sequences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Total_Number_Of_Sequences(t *testing.T) {\n  candidate := get_total_number_of_sequences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 4), expected: 4 },\n     { actual: candidate(5, 2), expected: 6 },\n     { actual: candidate(16, 3), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "go_test.go",
+    "prompt": "package replace_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1 []interface{}, list2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_List(t *testing.T) {\n  candidate := replace_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 2, 4, 6, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{5, 6, 7, 8}), expected: []int{1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]string{\"red\", \"blue\", \"green\"}, []string{\"yellow\"}), expected: []string{\"red\", \"blue\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "go_test.go",
+    "prompt": "package count_charac_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the total number of characters in a string.\nfunc count_charac(str1 string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Charac(t *testing.T) {\n  candidate := count_charac\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: 18 },\n     { actual: candidate(\"language\"), expected: 8 },\n     { actual: candidate(\"words\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "go_test.go",
+    "prompt": "package next_Perfect_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNext_Perfect_Square(t *testing.T) {\n  candidate := next_Perfect_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(35), expected: 36 },\n     { actual: candidate(6), expected: 9 },\n     { actual: candidate(9), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "go_test.go",
+    "prompt": "package max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Sum(t *testing.T) {\n  candidate := max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 15, 51, 45, 33, 100, 12, 18, 9}), expected: 194 },\n     { actual: candidate([]int{80, 60, 30, 40, 20, 10}), expected: 210 },\n     { actual: candidate([]int{2, 3, 14, 16, 21, 23, 29, 30}), expected: 138 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "go_test.go",
+    "prompt": "package lps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLps(t *testing.T) {\n  candidate := lps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TENS FOR TENS\"), expected: 5 },\n     { actual: candidate(\"CARDIO FOR CARDS\"), expected: 7 },\n     { actual: candidate(\"PART OF THE JOURNEY IS PART\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "go_test.go",
+    "prompt": "package intersection_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1 []int, array_nums2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIntersection_Array(t *testing.T) {\n  candidate := intersection_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{1, 2, 4, 8, 9}), expected: []int{1, 2, 8, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{3, 5, 7, 9}), expected: []int{3, 5, 7, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{10, 20, 30, 40}), expected: []int{10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "go_test.go",
+    "prompt": "package count_X_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunc count_X(tup []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_X(t *testing.T) {\n  candidate := count_X\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), expected: 0 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), expected: 3 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "go_test.go",
+    "prompt": "package insert_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list []string, element string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestInsert_Element(t *testing.T) {\n  candidate := insert_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Black\"}, \"c\"), expected: []string{\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"} },\n     { actual: candidate([]string{\"python\", \"java\"}, \"program\"), expected: []string{\"program\", \"python\", \"program\", \"java\"} },\n     { actual: candidate([]string{\"happy\", \"sad\"}, \"laugh\"), expected: []string{\"laugh\", \"happy\", \"laugh\", \"sad\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "go_test.go",
+    "prompt": "package convert_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert complex numbers to polar coordinates.\nfunc convert(numbers int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConvert(t *testing.T) {\n  candidate := convert\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: []interface{}{1.0, 0.0} },\n     { actual: candidate(4), expected: []interface{}{4.0, 0.0} },\n     { actual: candidate(5), expected: []interface{}{5.0, 0.0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "go_test.go",
+    "prompt": "package combinations_colors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l []string, n int) [][]string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCombinations_Colors(t *testing.T) {\n  candidate := combinations_colors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 1), expected: [][]int{[]string{\"Red\"}, []string{\"Green\"}, []string{\"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 2), expected: [][]int{[]string{\"Red\", \"Red\"}, []string{\"Red\", \"Green\"}, []string{\"Red\", \"Blue\"}, []string{\"Green\", \"Green\"}, []string{\"Green\", \"Blue\"}, []string{\"Blue\", \"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 3), expected: [][]int{[]string{\"Red\", \"Red\", \"Red\"}, []string{\"Red\", \"Red\", \"Green\"}, []string{\"Red\", \"Red\", \"Blue\"}, []string{\"Red\", \"Green\", \"Green\"}, []string{\"Red\", \"Green\", \"Blue\"}, []string{\"Red\", \"Blue\", \"Blue\"}, []string{\"Green\", \"Green\", \"Green\"}, []string{\"Green\", \"Green\", \"Blue\"}, []string{\"Green\", \"Blue\", \"Blue\"}, []string{\"Blue\", \"Blue\", \"Blue\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "go_test.go",
+    "prompt": "package count_Primes_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Primes_Nums(t *testing.T) {\n  candidate := count_Primes_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 2 },\n     { actual: candidate(10), expected: 4 },\n     { actual: candidate(100), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "go_test.go",
+    "prompt": "package swap_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a int, b int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSwap_Numbers(t *testing.T) {\n  candidate := swap_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: []int{20, 10} },\n     { actual: candidate(15, 17), expected: []int{17, 15} },\n     { actual: candidate(100, 200), expected: []int{200, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5100,7 +1012,7 @@
     "language": "go_test.go",
     "prompt": "package maximize_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to maximize the given two lists.\nfunc maximize_elements(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestMaximize_Elements(t *testing.T) {\n  candidate := maximize_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 7}, []int{4, 9}, []int{2, 9}, []int{7, 10}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{7, 8}, []int{5, 10}, []int{3, 10}, []int{8, 11}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{8, 9}, []int{6, 11}, []int{4, 11}, []int{9, 12}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -5110,13 +1022,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "go_test.go",
-    "prompt": "package even_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums []int) bool {\n",
+    "prompt": "package newman_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestEven_Position(t *testing.T) {\n  candidate := even_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n     { actual: candidate([]int{2, 1, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestNewman_Prime(t *testing.T) {\n  candidate := newman_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 7 },\n     { actual: candidate(4), expected: 17 },\n     { actual: candidate(5), expected: 41 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5124,13 +1036,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "go_test.go",
-    "prompt": "package check_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(myString string) string {\n",
+    "prompt": "package division_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCheck_Char(t *testing.T) {\n  candidate := check_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abba\"), expected: \"Valid\" },\n     { actual: candidate(\"a\"), expected: \"Valid\" },\n     { actual: candidate(\"abcd\"), expected: \"Invalid\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestDivision_Elements(t *testing.T) {\n  candidate := division_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{2, 2, 2, 3} },\n     { actual: candidate([]interface{}{12, 6, 8, 16}, []interface{}{6, 3, 4, 4}), expected: []interface{}{2, 2, 2, 4} },\n     { actual: candidate([]interface{}{20, 14, 36, 18}, []interface{}{5, 7, 6, 9}), expected: []interface{}{4, 2, 6, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5138,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "go_test.go",
-    "prompt": "package sumofFactors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of even factors of a number.\nfunc sumofFactors(n int) int {\n",
+    "prompt": "package split_two_parts_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunc split_two_parts(list1 []interface{}, L int) interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestSumoffactors(t *testing.T) {\n  candidate := sumofFactors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(18), expected: 26 },\n     { actual: candidate(30), expected: 48 },\n     { actual: candidate(6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSplit_Two_Parts(t *testing.T) {\n  candidate := split_two_parts\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []interface{}{[]int{1, 1, 2}, []int{3, 4, 4, 5, 1}} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, 2), expected: []interface{}{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}} },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}, 4), expected: []interface{}{[]string{\"p\", \"y\", \"t\", \"h\"}, []string{\"o\", \"n\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5152,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "go_test.go",
-    "prompt": "package lateralsurface_cone_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r int, h int) float64 {\n",
+    "prompt": "package dog_age_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestLateralsurface_Cone(t *testing.T) {\n  candidate := lateralsurface_cone\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 12), expected: 204.20352248333654 },\n     { actual: candidate(10, 15), expected: 566.3586699569488 },\n     { actual: candidate(19, 17), expected: 1521.8090132193388 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestDog_Age(t *testing.T) {\n  candidate := dog_age\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 61 },\n     { actual: candidate(15), expected: 73 },\n     { actual: candidate(24), expected: 109 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5166,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "go_test.go",
-    "prompt": "package count_Pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr []int, n int) int {\n",
+    "prompt": "package list_split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S []interface{}, step int) [][]interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestCount_Pairs(t *testing.T) {\n  candidate := count_Pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 1}, 3), expected: 2 },\n     { actual: candidate([]int{1, 1, 1, 1}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 5), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestList_Split(t *testing.T) {\n  candidate := list_split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"}, 3), expected: [][]int{[]string{\"a\", \"d\", \"g\", \"j\", \"m\"}, []string{\"b\", \"e\", \"h\", \"k\", \"n\"}, []string{\"c\", \"f\", \"i\", \"l\"}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), expected: [][]int{[]int{1, 4, 7, 10, 13}, []int{2, 5, 8, 11, 14}, []int{3, 6, 9, 12}} },\n     { actual: candidate([]string{\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"}, 2), expected: [][]int{[]string{\"python\", \"C\", \"DBMS\"}, []string{\"java\", \"C++\", \"SQL\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5180,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "go_test.go",
-    "prompt": "package find_first_occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A []int, x int) int {\n",
+    "prompt": "package lateralsurface_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestFind_First_Occurrence(t *testing.T) {\n  candidate := find_first_occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 1 },\n     { actual: candidate([]int{2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 2 },\n     { actual: candidate([]int{2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestLateralsurface_Cube(t *testing.T) {\n  candidate := lateralsurface_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 100 },\n     { actual: candidate(9), expected: 324 },\n     { actual: candidate(10), expected: 400 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5198,9 +1110,751 @@
     "language": "go_test.go",
     "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunc square_Sum(n int) int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 10 },\n     { actual: candidate(3), expected: 35 },\n     { actual: candidate(4), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "go_test.go",
+    "prompt": "package find_star_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th star number.\nfunc find_star_num(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Star_Num(t *testing.T) {\n  candidate := find_star_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 37 },\n     { actual: candidate(4), expected: 73 },\n     { actual: candidate(5), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "go_test.go",
+    "prompt": "package ascii_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ascii value of a character.\nfunc ascii_value(k string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAscii_Value(t *testing.T) {\n  candidate := ascii_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"A\"), expected: 65 },\n     { actual: candidate(\"R\"), expected: 82 },\n     { actual: candidate(\"S\"), expected: 83 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "go_test.go",
+    "prompt": "package sum_even_and_even_index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Even_And_Even_Index(t *testing.T) {\n  candidate := sum_even_and_even_index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 12, 1, 18, 8}), expected: 30 },\n     { actual: candidate([]int{3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), expected: 26 },\n     { actual: candidate([]int{5, 6, 12, 1}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "go_test.go",
+    "prompt": "package even_Power_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Power_Sum(t *testing.T) {\n  candidate := even_Power_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1056 },\n     { actual: candidate(3), expected: 8832 },\n     { actual: candidate(1), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "go_test.go",
+    "prompt": "package rear_extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunc rear_extract(test_list [][]interface{}) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRear_Extract(t *testing.T) {\n  candidate := rear_extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{1, \"Rash\", 21}, []interface{}{2, \"Varsha\", 20}, []interface{}{3, \"Kil\", 19}}), expected: []int{21, 20, 19} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sai\", 36}, []interface{}{2, \"Ayesha\", 25}, []interface{}{3, \"Salman\", 45}}), expected: []int{36, 25, 45} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sudeep\", 14}, []interface{}{2, \"Vandana\", 36}, []interface{}{3, \"Dawood\", 56}}), expected: []int{14, 36, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "go_test.go",
+    "prompt": "package substract_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSubstract_Elements(t *testing.T) {\n  candidate := substract_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5}, []interface{}{2, 5, 18}), expected: []interface{}{8, -1, -13} },\n     { actual: candidate([]interface{}{11, 2, 3}, []interface{}{24, 45, 16}), expected: []interface{}{-13, -43, -13} },\n     { actual: candidate([]interface{}{7, 18, 9}, []interface{}{10, 11, 12}), expected: []interface{}{-3, 7, -3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "go_test.go",
+    "prompt": "package even_binomial_Coeff_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Binomial_Coeff_Sum(t *testing.T) {\n  candidate := even_binomial_Coeff_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 8 },\n     { actual: candidate(6), expected: 32 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "go_test.go",
+    "prompt": "package dict_filter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict map[string]int, n int) map[string]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDict_Filter(t *testing.T) {\n  candidate := dict_filter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170), expected: map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180), expected: map[string]int{\"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190), expected: map[string]int{\"Pierre Cox\": 190} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "go_test.go",
+    "prompt": "package is_num_decagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Num_Decagonal(t *testing.T) {\n  candidate := is_num_decagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(7), expected: 175 },\n     { actual: candidate(10), expected: 370 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "go_test.go",
+    "prompt": "package sequential_search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist []int, item int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSequential_Search(t *testing.T) {\n  candidate := sequential_search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), expected: []interface{}{true, 3} },\n     { actual: candidate([]int{12, 32, 45, 62, 35, 47, 44, 61}, 61), expected: []interface{}{true, 7} },\n     { actual: candidate([]int{9, 10, 17, 19, 22, 39, 48, 56}, 48), expected: []interface{}{true, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "go_test.go",
+    "prompt": "package all_unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Unique(t *testing.T) {\n  candidate := all_unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "go_test.go",
+    "prompt": "package sub_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1 []int, nums2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSub_List(t *testing.T) {\n  candidate := sub_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: []int{-3, -3, -3} },\n     { actual: candidate([]int{1, 2}, []int{3, 4}), expected: []int{-2, -2} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []int{40, 50} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "go_test.go",
+    "prompt": "package validate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestValidate(t *testing.T) {\n  candidate := validate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1234), expected: true },\n     { actual: candidate(51241), expected: false },\n     { actual: candidate(321), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "go_test.go",
+    "prompt": "package check_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list []interface{}, element interface{}) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Element(t *testing.T) {\n  candidate := check_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"green\", \"orange\", \"black\", \"white\"}, \"blue\"), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4}, 7), expected: false },\n     { actual: candidate([]string{\"green\", \"green\", \"green\", \"green\"}, \"green\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "go_test.go",
+    "prompt": "package text_match_two_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_Two_Three(t *testing.T) {\n  candidate := text_match_two_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "go_test.go",
+    "prompt": "package max_sub_array_sum_repeated_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a []int, n int, k int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Sub_Array_Sum_Repeated(t *testing.T) {\n  candidate := max_sub_array_sum_repeated\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, -30, -1}, 4, 3), expected: 30 },\n     { actual: candidate([]int{-1, 10, 20}, 3, 2), expected: 59 },\n     { actual: candidate([]int{-1, -2, -3}, 3, 3), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "go_test.go",
+    "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 20 },\n     { actual: candidate(3), expected: 56 },\n     { actual: candidate(4), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "go_test.go",
+    "prompt": "package max_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1 [][]int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Length(t *testing.T) {\n  candidate := max_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1}, []int{5, 7}, []int{10, 12, 14, 15}}), expected: []interface{}{4, []int{10, 12, 14, 15}} },\n     { actual: candidate([][]int{[]int{5}, []int{15, 20, 25}}), expected: []interface{}{3, []int{15, 20, 25}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "go_test.go",
+    "prompt": "package count_no_of_ways_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n int, k int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_No_Of_Ways(t *testing.T) {\n  candidate := count_no_of_ways\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 4), expected: 16 },\n     { actual: candidate(3, 2), expected: 6 },\n     { actual: candidate(4, 4), expected: 228 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "go_test.go",
+    "prompt": "package find_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n int, m int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind(t *testing.T) {\n  candidate := find\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 3), expected: 3 },\n     { actual: candidate(4, 2), expected: 2 },\n     { actual: candidate(20, 5), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "go_test.go",
+    "prompt": "package otherside_rightangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w int, h int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOtherside_Rightangle(t *testing.T) {\n  candidate := otherside_rightangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 8), expected: 10.63014581273465 },\n     { actual: candidate(3, 4), expected: 5 },\n     { actual: candidate(7, 15), expected: 16.55294535724685 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "go_test.go",
+    "prompt": "package sum_div_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Div(t *testing.T) {\n  candidate := sum_div\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: 7 },\n     { actual: candidate(12), expected: 16 },\n     { actual: candidate(7), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "go_test.go",
+    "prompt": "package get_Inv_Count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count inversions in an array.\nfunc get_Inv_Count(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Inv_Count(t *testing.T) {\n  candidate := get_Inv_Count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 20, 6, 4, 5}), expected: 5 },\n     { actual: candidate([]int{1, 2, 1}), expected: 1 },\n     { actual: candidate([]int{1, 2, 5, 6, 1}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "go_test.go",
+    "prompt": "package max_aggregate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the maximum aggregate from the list of tuples.\nfunc max_aggregate(stdata [][]interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Aggregate(t *testing.T) {\n  candidate := max_aggregate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 90}, []interface{}{\"Sabah Colley\", 88}, []interface{}{\"Peter Nichols\", 7}, []interface{}{\"Juan Whelan\", 122}, []interface{}{\"Sabah Colley\", 84}}), expected: []interface{}{\"Juan Whelan\", 212} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 50}, []interface{}{\"Sabah Colley\", 48}, []interface{}{\"Peter Nichols\", 37}, []interface{}{\"Juan Whelan\", 22}, []interface{}{\"Sabah Colley\", 14}}), expected: []interface{}{\"Juan Whelan\", 72} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 10}, []interface{}{\"Sabah Colley\", 20}, []interface{}{\"Peter Nichols\", 30}, []interface{}{\"Juan Whelan\", 40}, []interface{}{\"Sabah Colley\", 50}}), expected: []interface{}{\"Sabah Colley\", 70} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "go_test.go",
+    "prompt": "package find_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find element at a given index after number of rotations.\nfunc find_Element(arr []int, ranges [][]int, rotations int, index int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Element(t *testing.T) {\n  candidate := find_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, [][]int{[]int{0, 2}, []int{0, 3}}, 2, 1), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 2), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "go_test.go",
+    "prompt": "package start_withp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words []string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestStart_Withp(t *testing.T) {\n  candidate := start_withp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python PHP\", \"Java JavaScript\", \"c c++\"}), expected: []interface{}{\"Python\", \"PHP\"} },\n     { actual: candidate([]string{\"Python Programming\", \"Java Programming\"}), expected: []interface{}{\"Python\", \"Programming\"} },\n     { actual: candidate([]string{\"Pqrst Pqr\", \"qrstuv\"}), expected: []interface{}{\"Pqrst\", \"Pqr\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "go_test.go",
+    "prompt": "package max_sum_increasing_subseq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a []int, n int, index int, k int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Sum_Increasing_Subseq(t *testing.T) {\n  candidate := max_sum_increasing_subseq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), expected: 11 },\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), expected: 7 },\n     { actual: candidate([]int{11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), expected: 71 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "go_test.go",
+    "prompt": "package large_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1 []int, nums2 []int, N int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLarge_Product(t *testing.T) {\n  candidate := large_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 3), expected: []int{60, 54, 50} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 4), expected: []int{60, 54, 50, 48} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 5), expected: []int{60, 54, 50, 48, 45} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "go_test.go",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the maximum of two numbers.\nfunc maximum(a int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 10), expected: 10 },\n     { actual: candidate(-1, -2), expected: -1 },\n     { actual: candidate(9, 7), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "go_test.go",
+    "prompt": "package string_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1 string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestString_To_Tuple(t *testing.T) {\n  candidate := string_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python 3.0\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"} },\n     { actual: candidate(\"item1\"), expected: []string{\"i\", \"t\", \"e\", \"m\", \"1\"} },\n     { actual: candidate(\"15.10\"), expected: []string{\"1\", \"5\", \".\", \"1\", \"0\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "go_test.go",
+    "prompt": "package highest_Power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHighest_Power_Of_2(t *testing.T) {\n  candidate := highest_Power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 8 },\n     { actual: candidate(19), expected: 16 },\n     { actual: candidate(32), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "go_test.go",
+    "prompt": "package find_lucas_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th lucas number.\nfunc find_lucas(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Lucas(t *testing.T) {\n  candidate := find_lucas\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 76 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(3), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "go_test.go",
+    "prompt": "package add_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_ []interface{}, myString string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_String(t *testing.T) {\n  candidate := add_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, \"temp{0}\"), expected: []string{\"temp1\", \"temp2\", \"temp3\", \"temp4\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, \"python{0}\"), expected: []string{\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"} },\n     { actual: candidate([]int{5, 6, 7, 8}, \"string{0}\"), expected: []string{\"string5\", \"string6\", \"string7\", \"string8\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "go_test.go",
+    "prompt": "package get_max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Max_Sum(t *testing.T) {\n  candidate := get_max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(60), expected: 106 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "go_test.go",
+    "prompt": "package max_length_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list with maximum length.\nfunc max_length_list(input_list [][]int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Length_List(t *testing.T) {\n  candidate := max_length_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}, []int{1, 2, 3}, []int{1, 2}, []int{1}}), expected: []interface{}{5, []int{1, 2, 3, 4, 5}} },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{6, 7, 8, 9}, []int{10, 11, 12}}), expected: []interface{}{4, []int{6, 7, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "go_test.go",
+    "prompt": "package check_distinct_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Distinct(t *testing.T) {\n  candidate := check_distinct\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 5, 6, 1, 4}), expected: false },\n     { actual: candidate([]int{1, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 6}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "go_test.go",
+    "prompt": "package check_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Char(t *testing.T) {\n  candidate := check_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abba\"), expected: \"Valid\" },\n     { actual: candidate(\"a\"), expected: \"Valid\" },\n     { actual: candidate(\"abcd\"), expected: \"Invalid\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "go_test.go",
+    "prompt": "package median_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of three numbers.\nfunc median_numbers(a int, b int, c int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMedian_Numbers(t *testing.T) {\n  candidate := median_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(25, 55, 65), expected: 55.0 },\n     { actual: candidate(20, 10, 30), expected: 20.0 },\n     { actual: candidate(15, 45, 75), expected: 45.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "go_test.go",
+    "prompt": "package sum_of_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums []interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Of_Digits(t *testing.T) {\n  candidate := sum_of_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 2, 56}), expected: 14 },\n     { actual: candidate([][]int{[]interface{}{10, 20, 4, 5, \"b\", 70, \"a\"}}), expected: 19 },\n     { actual: candidate([]int{10, 20, -4, 5, -70}), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "go_test.go",
+    "prompt": "package bitwise_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBitwise_Xor(t *testing.T) {\n  candidate := bitwise_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{15, 6, 5, 10} },\n     { actual: candidate([]interface{}{11, 5, 7, 10}, []interface{}{6, 3, 4, 4}), expected: []interface{}{13, 6, 3, 14} },\n     { actual: candidate([]interface{}{12, 6, 8, 11}, []interface{}{7, 4, 5, 6}), expected: []interface{}{11, 2, 13, 13} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "go_test.go",
+    "prompt": "package is_not_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to identify non-prime numbers.\nfunc is_not_prime(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Not_Prime(t *testing.T) {\n  candidate := is_not_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: false },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(35), expected: true },\n     { actual: candidate(37), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "go_test.go",
+    "prompt": "package extract_freq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the number of unique tuples in the given list.\nfunc extract_freq(test_list [][]interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Freq(t *testing.T) {\n  candidate := extract_freq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 4}, []interface{}{1, 2}, []interface{}{4, 3}, []interface{}{5, 6}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{4, 15}, []interface{}{2, 3}, []interface{}{5, 4}, []interface{}{6, 7}}), expected: 4 },\n     { actual: candidate([][]int{[]interface{}{5, 16}, []interface{}{2, 3}, []interface{}{6, 5}, []interface{}{6, 9}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "go_test.go",
+    "prompt": "package add_nested_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_Nested_Tuples(t *testing.T) {\n  candidate := add_nested_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{7, 10}, []int{7, 14}, []int{3, 10}, []int{8, 13}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{9, 12}, []int{9, 16}, []int{5, 12}, []int{10, 15}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{11, 14}, []int{11, 18}, []int{7, 14}, []int{12, 17}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "go_test.go",
+    "prompt": "package minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum of two numbers.\nfunc minimum(a int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMinimum(t *testing.T) {\n  candidate := minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(-5, -4), expected: -5 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "go_test.go",
+    "prompt": "package find_Parity_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find whether the parity of a given number is odd.\nfunc find_Parity(x int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Parity(t *testing.T) {\n  candidate := find_Parity\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: false },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "go_test.go",
+    "prompt": "package rearrange_bigger_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n int) interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRearrange_Bigger(t *testing.T) {\n  candidate := rearrange_bigger\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 21 },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(102), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "go_test.go",
+    "prompt": "package k_smallest_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1 []int, nums2 []int, k int) [][]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestK_Smallest_Pairs(t *testing.T) {\n  candidate := k_smallest_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 2), expected: [][]int{[]int{1, 2}, []int{1, 4}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 1), expected: [][]int{[]int{1, 2}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 7), expected: [][]int{[]int{1, 2}, []int{1, 4}, []int{3, 2}, []int{1, 6}, []int{3, 4}, []int{3, 6}, []int{7, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "go_test.go",
+    "prompt": "package min_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunc min_product_tuple(list1 [][]interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMin_Product_Tuple(t *testing.T) {\n  candidate := min_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 8 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 30 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "go_test.go",
+    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"android_tv\"), expected: \"AndroidTv\" },\n     { actual: candidate(\"google_pixel\"), expected: \"GooglePixel\" },\n     { actual: candidate(\"apple_watch\"), expected: \"AppleWatch\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "go_test.go",
+    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove odd numbers from a given list.\nfunc remove_odd(l []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2} },\n     { actual: candidate([]int{2, 4, 6}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{10, 20, 3}), expected: []int{10, 20} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "go_test.go",
+    "prompt": "package extract_nth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the nth element from a given list of tuples.\nfunc extract_nth_element(list1 [][]interface{}, n int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Nth_Element(t *testing.T) {\n  candidate := extract_nth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 0), expected: []string{\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 2), expected: []int{99, 96, 94, 98} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 1), expected: []int{98, 97, 91, 94} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "go_test.go",
+    "prompt": "package overlapping_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1 []int, list2 []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOverlapping(t *testing.T) {\n  candidate := overlapping\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 8, 9}), expected: false },\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 4, 5}, []int{1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "go_test.go",
+    "prompt": "package max_Product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr []int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_Product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 7, 0, 8, 4}), expected: []interface{}{7, 8} },\n     { actual: candidate([]int{0, -1, -2, -4, 5, 0, -6}), expected: []interface{}{-4, -6} },\n     { actual: candidate([]int{1, 2, 3}), expected: []interface{}{2, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5212,7 +1866,7 @@
     "language": "go_test.go",
     "prompt": "package group_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find common first element in given list of lists.\nfunc group_tuples(Input [][]string) [][]string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "func TestGroup_Tuples(t *testing.T) {\n  candidate := group_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"x\", \"z\"}, []string{\"w\", \"t\"}}), expected: [][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"w\", \"t\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"a\", \"c\"}, []string{\"d\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\", \"c\"}, []string{\"d\", \"e\"}} },\n     { actual: candidate([][]int{[]string{\"f\", \"g\"}, []string{\"f\", \"g\"}, []string{\"h\", \"i\"}}), expected: [][]int{[]string{\"f\", \"g\", \"g\"}, []string{\"h\", \"i\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -5222,13 +1876,3359 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "go_test.go",
-    "prompt": "package merge_sorted_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1 []int, num2 []int, num3 []int) []int {\n",
+    "prompt": "package Find_Max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the element of a list having maximum length.\nfunc Find_Max(lst [][]interface{}) []interface{} {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "func TestMerge_Sorted_List(t *testing.T) {\n  candidate := merge_sorted_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 24, 15, 4, 5, 29, 110}, []int{19, 20, 11, 56, 25, 233, 154}, []int{24, 26, 54, 48}), expected: []int{4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233} },\n     { actual: candidate([]int{1, 3, 5, 6, 8, 9}, []int{2, 5, 7, 11}, []int{1, 4, 7, 8, 12}), expected: []int{1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12} },\n     { actual: candidate([]int{18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, []int{25, 35, 22, 85, 14, 65, 75, 25, 58}, []int{12, 74, 9, 50, 61, 41}), expected: []int{1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := Find_Max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"A\"}, []string{\"A\", \"B\"}, []string{\"A\", \"B\", \"C\"}}), expected: []string{\"A\", \"B\", \"C\"} },\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1, 2, 3} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 2, 3}, []int{1, 5, 6, 1}}), expected: []int{1, 5, 6, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "go_test.go",
+    "prompt": "package cube_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCube_Sum(t *testing.T) {\n  candidate := cube_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 72 },\n     { actual: candidate(3), expected: 288 },\n     { actual: candidate(4), expected: 800 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "go_test.go",
+    "prompt": "package concatenate_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup []interface{}) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConcatenate_Tuple(t *testing.T) {\n  candidate := concatenate_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"ID\", \"is\", 4, \"UTS\"}), expected: \"ID-is-4-UTS\" },\n     { actual: candidate([]interface{}{\"QWE\", \"is\", 4, \"RTY\"}), expected: \"QWE-is-4-RTY\" },\n     { actual: candidate([]interface{}{\"ZEN\", \"is\", 4, \"OP\"}), expected: \"ZEN-is-4-OP\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "go_test.go",
+    "prompt": "package find_Average_Of_Cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Average_Of_Cube(t *testing.T) {\n  candidate := find_Average_Of_Cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4.5 },\n     { actual: candidate(3), expected: 12 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "go_test.go",
+    "prompt": "package extract_rear_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple []interface{}) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Rear(t *testing.T) {\n  candidate := extract_rear\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"Mers\", \"for\", \"Vers\"}), expected: []string{\"s\", \"r\", \"s\"} },\n     { actual: candidate([]interface{}{\"Avenge\", \"for\", \"People\"}), expected: []string{\"e\", \"r\", \"e\"} },\n     { actual: candidate([]interface{}{\"Gotta\", \"get\", \"go\"}), expected: []string{\"a\", \"t\", \"o\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "go_test.go",
+    "prompt": "package count_element_in_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1 [][]interface{}, x interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Element_In_List(t *testing.T) {\n  candidate := count_element_in_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{1, 11}, []int{1, 15, 7}}, 1), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"A\"), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"E\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "go_test.go",
+    "prompt": "package filter_oddnumbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFilter_Oddnumbers(t *testing.T) {\n  candidate := filter_oddnumbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 3, 5, 7, 9} },\n     { actual: candidate([]int{10, 20, 45, 67, 84, 93}), expected: []int{45, 67, 93} },\n     { actual: candidate([]int{5, 7, 9, 8, 6, 4, 3}), expected: []int{5, 7, 9, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "go_test.go",
+    "prompt": "package change_date_format_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestChange_Date_Format(t *testing.T) {\n  candidate := change_date_format\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"2026-01-02\"), expected: \"02-01-2026\" },\n     { actual: candidate(\"2020-11-13\"), expected: \"13-11-2020\" },\n     { actual: candidate(\"2021-04-26\"), expected: \"26-04-2021\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "go_test.go",
+    "prompt": "package shell_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestShell_Sort(t *testing.T) {\n  candidate := shell_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), expected: []int{2, 3, 4, 5, 12, 12, 23, 56, 81, 95} },\n     { actual: candidate([]int{24, 22, 39, 34, 87, 73, 68}), expected: []int{22, 24, 34, 39, 68, 73, 87} },\n     { actual: candidate([]int{32, 30, 16, 96, 82, 83, 74}), expected: []int{16, 30, 32, 74, 82, 83, 96} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "go_test.go",
+    "prompt": "package and_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAnd_Tuples(t *testing.T) {\n  candidate := and_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{0, 0, 2, 1} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{5, 6, 7, 8}), expected: []interface{}{1, 2, 3, 0} },\n     { actual: candidate([]interface{}{8, 9, 11, 12}, []interface{}{7, 13, 14, 17}), expected: []interface{}{0, 9, 10, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "go_test.go",
+    "prompt": "package parabola_directrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a int, b int, c int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestParabola_Directrix(t *testing.T) {\n  candidate := parabola_directrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3, 2), expected: -198 },\n     { actual: candidate(9, 8, 4), expected: -2336 },\n     { actual: candidate(2, 4, 6), expected: -130 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "go_test.go",
+    "prompt": "package median_trapezium_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1 int, base2 int, height int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMedian_Trapezium(t *testing.T) {\n  candidate := median_trapezium\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15, 25, 35), expected: 20 },\n     { actual: candidate(10, 20, 30), expected: 15 },\n     { actual: candidate(6, 9, 4), expected: 7.5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "go_test.go",
+    "prompt": "package check_greater_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr []int, number int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Greater(t *testing.T) {\n  candidate := check_greater\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 4), expected: false },\n     { actual: candidate([]int{2, 3, 4, 5, 6}, 8), expected: true },\n     { actual: candidate([]int{9, 7, 4, 8, 6, 1}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "go_test.go",
+    "prompt": "package text_match_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_One(t *testing.T) {\n  candidate := text_match_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "go_test.go",
+    "prompt": "package last_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last digit of a given number.\nfunc last_Digit(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLast_Digit(t *testing.T) {\n  candidate := last_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 3 },\n     { actual: candidate(25), expected: 5 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "go_test.go",
+    "prompt": "package neg_nos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to return the negative numbers in a list.\nfunc neg_nos(list1 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNeg_Nos(t *testing.T) {\n  candidate := neg_nos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 4, 5, -6}), expected: []int{-1, -6} },\n     { actual: candidate([]int{-1, -2, 3, 4}), expected: []int{-1, -2} },\n     { actual: candidate([]int{-7, -6, 8, 9}), expected: []int{-7, -6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "go_test.go",
+    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove odd characters in a string.\nfunc remove_odd(str1 string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: \"yhn\" },\n     { actual: candidate(\"program\"), expected: \"rga\" },\n     { actual: candidate(\"language\"), expected: \"agae\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "go_test.go",
+    "prompt": "package count_bidirectional_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list [][]interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Bidirectional(t *testing.T) {\n  candidate := count_bidirectional\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 3}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 2 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 2}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "go_test.go",
+    "prompt": "package multiple_to_single_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMultiple_To_Single(t *testing.T) {\n  candidate := multiple_to_single\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 33, 50}), expected: 113350 },\n     { actual: candidate([]int{-1, 2, 3, 4, 5, 6}), expected: -123456 },\n     { actual: candidate([]int{10, 15, 20, 25}), expected: 10152025 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "go_test.go",
+    "prompt": "package find_adverb_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Adverb_Position(t *testing.T) {\n  candidate := find_adverb_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"clearly!! we can see the sky\"), expected: []interface{}{0, 7, \"clearly\"} },\n     { actual: candidate(\"seriously!! there are many roses\"), expected: []interface{}{0, 9, \"seriously\"} },\n     { actual: candidate(\"unfortunately!! sita is going to home\"), expected: []interface{}{0, 13, \"unfortunately\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "go_test.go",
+    "prompt": "package surfacearea_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSurfacearea_Cube(t *testing.T) {\n  candidate := surfacearea_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 150 },\n     { actual: candidate(3), expected: 54 },\n     { actual: candidate(10), expected: 600 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "go_test.go",
+    "prompt": "package positive_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums []int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPositive_Count(t *testing.T) {\n  candidate := positive_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), expected: 0.54 },\n     { actual: candidate([]int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 0.69 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: 0.56 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "go_test.go",
+    "prompt": "package largest_neg_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the largest negative number from the given list.\nfunc largest_neg(list1 []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLargest_Neg(t *testing.T) {\n  candidate := largest_neg\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, -4, -6}), expected: -6 },\n     { actual: candidate([]int{1, 2, 3, -8, -9}), expected: -9 },\n     { actual: candidate([]int{1, 2, 3, 4, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "go_test.go",
+    "prompt": "package trim_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list [][]int, K int) [][]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTrim_Tuple(t *testing.T) {\n  candidate := trim_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 2), expected: [][]int{[]int{2}, []int{9}, []int{2}, []int{2}} },\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 1), expected: [][]int{[]int{3, 2, 1}, []int{4, 9, 2}, []int{1, 2, 3}, []int{8, 2, 1}} },\n     { actual: candidate([][]int{[]int{7, 8, 4, 9}, []int{11, 8, 12, 4}, []int{4, 1, 7, 8}, []int{3, 6, 9, 7}}, 1), expected: [][]int{[]int{8, 4}, []int{8, 12}, []int{1, 7}, []int{6, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "go_test.go",
+    "prompt": "package index_multiplication_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIndex_Multiplication(t *testing.T) {\n  candidate := index_multiplication\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 21}, []int{12, 45}, []int{2, 9}, []int{7, 30}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{14, 32}, []int{20, 60}, []int{6, 20}, []int{16, 44}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{24, 45}, []int{30, 77}, []int{12, 33}, []int{27, 60}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "go_test.go",
+    "prompt": "package count_Occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the occurence of all elements of list in a tuple.\nfunc count_Occurrence(tup interface{}, lst []interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Occurrence(t *testing.T) {\n  candidate := count_Occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"a\", \"a\", \"c\", \"b\", \"d\"}, []string{\"a\", \"b\"}), expected: 3 },\n     { actual: candidate([]interface{}{1, 2, 3, 1, 4, 6, 7, 1, 4}, []int{1, 4, 7}), expected: 6 },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}, []int{1, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "go_test.go",
+    "prompt": "package cube_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCube_Nums(t *testing.T) {\n  candidate := cube_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 8, 27, 64, 125, 216, 343, 512, 729, 1000} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}), expected: []int{1728, 3375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "go_test.go",
+    "prompt": "package cal_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCal_Sum(t *testing.T) {\n  candidate := cal_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 49 },\n     { actual: candidate(10), expected: 66 },\n     { actual: candidate(11), expected: 88 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "go_test.go",
+    "prompt": "package extract_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str []string, l int) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_String(t *testing.T) {\n  candidate := extract_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 8), expected: []string{\"practice\", \"solution\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 6), expected: []string{\"Python\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 9), expected: []string{\"exercises\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "go_test.go",
+    "prompt": "package remove_whitespaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1 string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Whitespaces(t *testing.T) {\n  candidate := remove_whitespaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\" Google    Flutter \"), expected: \"GoogleFlutter\" },\n     { actual: candidate(\" Google    Dart \"), expected: \"GoogleDart\" },\n     { actual: candidate(\" iOS    Swift \"), expected: \"iOSSwift\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "go_test.go",
+    "prompt": "package loss_amount_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost int, sale_amount int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLoss_Amount(t *testing.T) {\n  candidate := loss_amount\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: 0 },\n     { actual: candidate(100, 200), expected: 100 },\n     { actual: candidate(2000, 5000), expected: 3000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "go_test.go",
+    "prompt": "package sumofFactors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of even factors of a number.\nfunc sumofFactors(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSumoffactors(t *testing.T) {\n  candidate := sumofFactors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(18), expected: 26 },\n     { actual: candidate(30), expected: 48 },\n     { actual: candidate(6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "go_test.go",
+    "prompt": "package text_match_wordz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_Wordz(t *testing.T) {\n  candidate := text_match_wordz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonz.\"), expected: true },\n     { actual: candidate(\"xyz.\"), expected: true },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "go_test.go",
+    "prompt": "package check_monthnumb_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2 int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Monthnumb_Number(t *testing.T) {\n  candidate := check_monthnumb_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "go_test.go",
+    "prompt": "package reverse_string_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist []string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReverse_String_List(t *testing.T) {\n  candidate := reverse_string_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"}), expected: []string{\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"} },\n     { actual: candidate([]string{\"john\", \"amal\", \"joel\", \"george\"}), expected: []string{\"nhoj\", \"lama\", \"leoj\", \"egroeg\"} },\n     { actual: candidate([]string{\"jack\", \"john\", \"mary\"}), expected: []string{\"kcaj\", \"nhoj\", \"yram\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "go_test.go",
+    "prompt": "package Find_Min_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sublist having minimum length.\nfunc Find_Min(lst [][]interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Min(t *testing.T) {\n  candidate := Find_Min\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 1, 1}, []int{1, 2, 7, 8}}), expected: []int{1, 1} },\n     { actual: candidate([][]int{[]string{\"x\"}, []string{\"x\", \"y\"}, []string{\"x\", \"y\", \"z\"}}), expected: []string{\"x\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "go_test.go",
+    "prompt": "package rectangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the area of a rectangle.\nfunc rectangle_area(l int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRectangle_Area(t *testing.T) {\n  candidate := rectangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(10, 5), expected: 50 },\n     { actual: candidate(4, 2), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "go_test.go",
+    "prompt": "package remove_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1 string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Uppercase(t *testing.T) {\n  candidate := remove_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"cAstyoUrFavoRitETVshoWs\"), expected: \"cstyoravoitshos\" },\n     { actual: candidate(\"wAtchTheinTernEtrAdIo\"), expected: \"wtchheinerntrdo\" },\n     { actual: candidate(\"VoicESeaRchAndreComMendaTionS\"), expected: \"oiceachndreomendaion\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "go_test.go",
+    "prompt": "package Extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to get the first element of each sublist.\nfunc Extract(lst [][]int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract(t *testing.T) {\n  candidate := Extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4, 5}, []int{6, 7, 8, 9}}), expected: []int{1, 3, 6} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5}}), expected: []int{1, 4} },\n     { actual: candidate([][]int{[]int{9, 8, 1}, []int{1, 2}}), expected: []int{9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "go_test.go",
+    "prompt": "package upper_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the upper case characters in a given string.\nfunc upper_ctr(str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUpper_Ctr(t *testing.T) {\n  candidate := upper_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYthon\"), expected: 1 },\n     { actual: candidate(\"BigData\"), expected: 1 },\n     { actual: candidate(\"program\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "go_test.go",
+    "prompt": "package max_subarray_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Subarray_Product(t *testing.T) {\n  candidate := max_subarray_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 0, 7, -8, -2}), expected: 112 },\n     { actual: candidate([]int{6, -3, -10, 0, 2}), expected: 180 },\n     { actual: candidate([]int{-2, -40, 0, -2, -3}), expected: 80 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "go_test.go",
+    "prompt": "package check_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict map[string]int, n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Value(t *testing.T) {\n  candidate := check_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10), expected: false },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12), expected: true },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "go_test.go",
+    "prompt": "package max_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 100, 4, 5, 150, 6}), expected: 3000 },\n     { actual: candidate([]int{4, 42, 55, 68, 80}), expected: 50265600 },\n     { actual: candidate([]int{10, 22, 9, 33, 21, 50, 41, 60}), expected: 2460 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "go_test.go",
+    "prompt": "package add_pairwise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_Pairwise(t *testing.T) {\n  candidate := add_pairwise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 8, 10}), expected: []interface{}{6, 12, 15, 18} },\n     { actual: candidate([]interface{}{2, 6, 8, 9, 11}), expected: []interface{}{8, 14, 17, 20} },\n     { actual: candidate([]interface{}{3, 7, 9, 10, 12}), expected: []interface{}{10, 16, 19, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "go_test.go",
+    "prompt": "package find_remainder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr []int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Remainder(t *testing.T) {\n  candidate := find_remainder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{100, 10, 5, 25, 35, 14}, 11), expected: 9 },\n     { actual: candidate([]int{1, 1, 1}, 1), expected: 0 },\n     { actual: candidate([]int{1, 2, 1}, 2), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "go_test.go",
+    "prompt": "package check_Consecutive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Consecutive(t *testing.T) {\n  candidate := check_Consecutive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 2, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "go_test.go",
+    "prompt": "package replace_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace characters in a string.\nfunc replace_char(str1 string, ch string, newch string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_Char(t *testing.T) {\n  candidate := replace_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"polygon\", \"y\", \"l\"), expected: \"pollgon\" },\n     { actual: candidate(\"character\", \"c\", \"a\"), expected: \"aharaater\" },\n     { actual: candidate(\"python\", \"l\", \"a\"), expected: \"python\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "go_test.go",
+    "prompt": "package sort_counter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1 map[string]int) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Counter(t *testing.T) {\n  candidate := sort_counter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}), expected: [][]int{[]interface{}{\"Chemistry\", 87}, []interface{}{\"Physics\", 83}, []interface{}{\"Math\", 81}} },\n     { actual: candidate(map[string]int{\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}), expected: [][]int{[]interface{}{\"Math\", 400}, []interface{}{\"Physics\", 300}, []interface{}{\"Chemistry\", 250}} },\n     { actual: candidate(map[string]int{\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}), expected: [][]int{[]interface{}{\"Chemistry\", 1250}, []interface{}{\"Physics\", 1000}, []interface{}{\"Math\", 900}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "go_test.go",
+    "prompt": "package big_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBig_Sum(t *testing.T) {\n  candidate := big_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{-1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{2, 3, 6}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "go_test.go",
+    "prompt": "package is_lower_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert the given string to lower case.\nfunc is_lower(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Lower(t *testing.T) {\n  candidate := is_lower\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"InValid\"), expected: \"invalid\" },\n     { actual: candidate(\"TruE\"), expected: \"true\" },\n     { actual: candidate(\"SenTenCE\"), expected: \"sentence\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "go_test.go",
+    "prompt": "package remove_lowercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1 string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Lowercase(t *testing.T) {\n  candidate := remove_lowercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYTHon\"), expected: \"PYTH\" },\n     { actual: candidate(\"FInD\"), expected: \"FID\" },\n     { actual: candidate(\"STRinG\"), expected: \"STRG\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "go_test.go",
+    "prompt": "package first_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the first digit of a given number.\nfunc first_Digit(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFirst_Digit(t *testing.T) {\n  candidate := first_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 1 },\n     { actual: candidate(456), expected: 4 },\n     { actual: candidate(12), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "go_test.go",
+    "prompt": "package heap_queue_largest_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums []int, n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHeap_Queue_Largest(t *testing.T) {\n  candidate := heap_queue_largest\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), expected: []int{85, 75, 65} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), expected: []int{85, 75} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), expected: []int{85, 75, 65, 58, 35} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "go_test.go",
+    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of integers and only returns the odd ones.\nfunc Split(list []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: []int{1, 3, 5} },\n     { actual: candidate([]int{10, 11, 12, 13}), expected: []int{11, 13} },\n     { actual: candidate([]int{7, 8, 9, 1}), expected: []int{7, 9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "go_test.go",
+    "prompt": "package difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDifference(t *testing.T) {\n  candidate := difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 30 },\n     { actual: candidate(5), expected: 210 },\n     { actual: candidate(2), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "go_test.go",
+    "prompt": "package find_Odd_Pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A []int, N int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Odd_Pair(t *testing.T) {\n  candidate := find_Odd_Pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}, 5), expected: 6 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}, 7), expected: 12 },\n     { actual: candidate([]int{1, 2, 3}, 3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "go_test.go",
+    "prompt": "package toggle_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestToggle_String(t *testing.T) {\n  candidate := toggle_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"pYTHON\" },\n     { actual: candidate(\"Pangram\"), expected: \"pANGRAM\" },\n     { actual: candidate(\"LIttLE\"), expected: \"liTTle\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "go_test.go",
+    "prompt": "package digit_distance_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1 int, n2 int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDigit_Distance_Nums(t *testing.T) {\n  candidate := digit_distance_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(23, 56), expected: 6 },\n     { actual: candidate(123, 256), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "go_test.go",
+    "prompt": "package max_sub_array_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a []int, size int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Sub_Array_Sum(t *testing.T) {\n  candidate := max_sub_array_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-2, -3, 4, -1, -2, 1, 5, -3}, 8), expected: 7 },\n     { actual: candidate([]int{-3, -4, 5, -2, -3, 2, 6, -4}, 8), expected: 8 },\n     { actual: candidate([]int{-4, -5, 6, -3, -4, 3, 7, -5}, 8), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "go_test.go",
+    "prompt": "package union_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1 []int, test_tup2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnion_Elements(t *testing.T) {\n  candidate := union_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 6}, []int{5, 7, 4, 10}), expected: []int{3, 4, 5, 6, 7, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{3, 4, 5, 6}), expected: []int{1, 2, 3, 4, 5, 6} },\n     { actual: candidate([]int{11, 12, 13, 14}, []int{13, 15, 16, 17}), expected: []int{11, 12, 13, 14, 15, 16, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "go_test.go",
+    "prompt": "package Find_Max_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the longest sublists.\nfunc Find_Max_Length(lst [][]int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Max_Length(t *testing.T) {\n  candidate := Find_Max_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 4}, []int{5, 6, 7, 8}}), expected: 4 },\n     { actual: candidate([][]int{[]int{0, 1}, []int{2, 2}, []int{3, 2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]int{7}, []int{22, 23}, []int{13, 14, 15}, []int{10, 20, 30, 40, 50}}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "go_test.go",
+    "prompt": "package extract_values_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Values(t *testing.T) {\n  candidate := extract_values\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"Python\", \"PHP\", \"Java\"\"), expected: []string{\"Python\", \"PHP\", \"Java\"} },\n     { actual: candidate(\"\"python\",\"program\",\"language\"\"), expected: []string{\"python\", \"program\", \"language\"} },\n     { actual: candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"), expected: []string{\"red\", \"blue\", \"green\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "go_test.go",
+    "prompt": "package count_Pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr []int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Pairs(t *testing.T) {\n  candidate := count_Pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 1}, 3), expected: 2 },\n     { actual: candidate([]int{1, 1, 1, 1}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 5), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "go_test.go",
+    "prompt": "package split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to split a string into characters.\nfunc split(word string) []string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"} },\n     { actual: candidate(\"Name\"), expected: []string{\"N\", \"a\", \"m\", \"e\"} },\n     { actual: candidate(\"program\"), expected: []string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "go_test.go",
+    "prompt": "package sum_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Digits(t *testing.T) {\n  candidate := sum_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(345), expected: 12 },\n     { actual: candidate(12), expected: 3 },\n     { actual: candidate(97), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "go_test.go",
+    "prompt": "package issort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1 []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIssort_List(t *testing.T) {\n  candidate := issort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), expected: false },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 15, 14, 20}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "go_test.go",
+    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1 [][]string) [][]string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"d\", \"c\"}, []string{\"g\", \"h\"}, []string{\"f\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}, []string{\"g\", \"h\"}, []string{\"e\", \"f\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "go_test.go",
+    "prompt": "package checks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check if a given number is one less than twice its reverse.\nfunc checks(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestChecks(t *testing.T) {\n  candidate := checks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(70), expected: false },\n     { actual: candidate(23), expected: false },\n     { actual: candidate(73), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "go_test.go",
+    "prompt": "package two_unique_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTwo_Unique_Nums(t *testing.T) {\n  candidate := two_unique_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 2, 3, 4, 5}), expected: []int{1, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 5}), expected: []int{1, 3, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "go_test.go",
+    "prompt": "package unique_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnique_Product(t *testing.T) {\n  candidate := unique_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30, 40, 20, 50, 60, 40}), expected: 720000000 },\n     { actual: candidate([]int{1, 2, 3, 1}), expected: 6 },\n     { actual: candidate([]int{7, 8, 9, 0, 1, 1}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "go_test.go",
+    "prompt": "package surfacearea_cylinder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r int, h int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSurfacearea_Cylinder(t *testing.T) {\n  candidate := surfacearea_cylinder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 5), expected: 942.45 },\n     { actual: candidate(4, 5), expected: 226.18800000000002 },\n     { actual: candidate(4, 10), expected: 351.848 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "go_test.go",
+    "prompt": "package is_Sub_Array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A []int, B []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Sub_Array(t *testing.T) {\n  candidate := is_Sub_Array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 5}, []int{1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 1}, []int{1, 2, 1}), expected: true },\n     { actual: candidate([]int{1, 0, 2, 2}, []int{2, 2, 0}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "go_test.go",
+    "prompt": "package last_Digit_Factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLast_Digit_Factorial(t *testing.T) {\n  candidate := last_Digit_Factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 4 },\n     { actual: candidate(21), expected: 0 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "go_test.go",
+    "prompt": "package interleave_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1 []int, list2 []int, list3 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestInterleave_Lists(t *testing.T) {\n  candidate := interleave_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}, []int{10, 20, 30, 40, 50, 60, 70}, []int{100, 200, 300, 400, 500, 600, 700}), expected: []int{1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700} },\n     { actual: candidate([]int{10, 20}, []int{15, 2}, []int{5, 10}), expected: []int{10, 15, 5, 20, 2, 10} },\n     { actual: candidate([]int{11, 44}, []int{10, 15}, []int{20, 5}), expected: []int{11, 10, 20, 44, 15, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "go_test.go",
+    "prompt": "package find_dissimilar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Dissimilar(t *testing.T) {\n  candidate := find_dissimilar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4, 5, 6}, []interface{}{5, 7, 4, 10}), expected: []interface{}{3, 6, 7, 10} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{7, 2, 3, 9}), expected: []interface{}{1, 4, 7, 9} },\n     { actual: candidate([]interface{}{21, 11, 25, 26}, []interface{}{26, 34, 21, 36}), expected: []interface{}{34, 36, 11, 25} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "go_test.go",
+    "prompt": "package find_Max_Num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Max_Num(t *testing.T) {\n  candidate := find_Max_Num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 321 },\n     { actual: candidate([]int{4, 5, 6, 1}), expected: 6541 },\n     { actual: candidate([]int{1, 2, 3, 9}), expected: 9321 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "go_test.go",
+    "prompt": "package extract_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple []interface{}) interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Even(t *testing.T) {\n  candidate := extract_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, []interface{}{7, 6, []interface{}{2, 4}}, 6, 8}), expected: []interface{}{4, []interface{}{6, []interface{}{2, 4}}, 6, 8} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{8, 7, []interface{}{4, 8}}, 7, 9}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 8}}} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{9, 8, []interface{}{4, 6}}, 8, 10}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 6}}, 8, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "go_test.go",
+    "prompt": "package surface_Area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunc surface_Area(b int, s int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSurface_Area(t *testing.T) {\n  candidate := surface_Area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 33 },\n     { actual: candidate(4, 5), expected: 56 },\n     { actual: candidate(1, 2), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "go_test.go",
+    "prompt": "package catalan_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which returns nth catalan number.\nfunc catalan_number(num int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCatalan_Number(t *testing.T) {\n  candidate := catalan_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 16796 },\n     { actual: candidate(9), expected: 4862 },\n     { actual: candidate(7), expected: 429 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "go_test.go",
+    "prompt": "package find_adverbs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Adverbs(t *testing.T) {\n  candidate := find_adverbs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Clearly, he has no excuse for such behavior.\"), expected: \"0-7: Clearly\" },\n     { actual: candidate(\"Please handle the situation carefuly\"), expected: \"28-36: carefuly\" },\n     { actual: candidate(\"Complete the task quickly\"), expected: \"18-25: quickly\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "go_test.go",
+    "prompt": "package split_Arr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l []int, n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSplit_Arr(t *testing.T) {\n  candidate := split_Arr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 10, 5, 6, 52, 36}, 2), expected: []int{5, 6, 52, 36, 12, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, 1), expected: []int{2, 3, 4, 1} },\n     { actual: candidate([]int{0, 1, 2, 3, 4, 5, 6, 7}, 3), expected: []int{3, 4, 5, 6, 7, 0, 1, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "go_test.go",
+    "prompt": "package list_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a tuple.\nfunc list_tuple(listx []int) interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestList_Tuple(t *testing.T) {\n  candidate := list_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 10, 7, 4, 15, 3}), expected: []interface{}{5, 10, 7, 4, 15, 3} },\n     { actual: candidate([]int{2, 4, 5, 6, 2, 3, 4, 4, 7}), expected: []interface{}{2, 4, 5, 6, 2, 3, 4, 4, 7} },\n     { actual: candidate([]int{58, 44, 56}), expected: []interface{}{58, 44, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "go_test.go",
+    "prompt": "package big_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBig_Diff(t *testing.T) {\n  candidate := big_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{4, 5, 12}), expected: 8 },\n     { actual: candidate([]int{9, 2, 3}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "go_test.go",
+    "prompt": "package perfect_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a int, b int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPerfect_Squares(t *testing.T) {\n  candidate := perfect_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 30), expected: []int{1, 4, 9, 16, 25} },\n     { actual: candidate(50, 100), expected: []int{64, 81, 100} },\n     { actual: candidate(100, 200), expected: []int{100, 121, 144, 169, 196} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "go_test.go",
+    "prompt": "package opposite_Signs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x int, y int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOpposite_Signs(t *testing.T) {\n  candidate := opposite_Signs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, -2), expected: true },\n     { actual: candidate(3, 2), expected: false },\n     { actual: candidate(-10, -10), expected: false },\n     { actual: candidate(-2, 2), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "go_test.go",
+    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to interchange the first and last elements in a list.\nfunc swap_List(newList []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 35, 9, 56, 24}), expected: []int{24, 35, 9, 56, 12} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "go_test.go",
+    "prompt": "package sum_Of_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Of_Product(t *testing.T) {\n  candidate := sum_Of_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15 },\n     { actual: candidate(4), expected: 56 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "go_test.go",
+    "prompt": "package removezero_ip_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemovezero_Ip(t *testing.T) {\n  candidate := removezero_ip\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"216.08.094.196\"), expected: \"216.8.94.196\" },\n     { actual: candidate(\"12.01.024\"), expected: \"12.1.24\" },\n     { actual: candidate(\"216.08.094.0196\"), expected: \"216.8.94.196\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "go_test.go",
+    "prompt": "package diff_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1 []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDiff_Even_Odd(t *testing.T) {\n  candidate := diff_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 1 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "go_test.go",
+    "prompt": "package min_Swaps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1 string, str2 string) interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMin_Swaps(t *testing.T) {\n  candidate := min_Swaps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1101\", \"1110\"), expected: 1 },\n     { actual: candidate(\"111\", \"000\"), expected: \"Not Possible\" },\n     { actual: candidate(\"111\", \"110\"), expected: \"Not Possible\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "go_test.go",
+    "prompt": "package find_kth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1 []int, arr2 []int, k int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Kth(t *testing.T) {\n  candidate := find_kth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 6, 7, 9}, []int{1, 4, 8, 10}, 5), expected: 6 },\n     { actual: candidate([]int{100, 112, 256, 349, 770}, []int{72, 86, 113, 119, 265, 445, 892}, 7), expected: 256 },\n     { actual: candidate([]int{3, 4, 7, 8, 10}, []int{2, 5, 9, 11}, 6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "go_test.go",
+    "prompt": "package armstrong_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestArmstrong_Number(t *testing.T) {\n  candidate := armstrong_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(153), expected: true },\n     { actual: candidate(259), expected: false },\n     { actual: candidate(4458), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "go_test.go",
+    "prompt": "package sum_average_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Average(t *testing.T) {\n  candidate := sum_average\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []interface{}{55, 5.5} },\n     { actual: candidate(15), expected: []interface{}{120, 8.0} },\n     { actual: candidate(20), expected: []interface{}{210, 10.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "go_test.go",
+    "prompt": "package is_octagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth octagonal number.\nfunc is_octagonal(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Octagonal(t *testing.T) {\n  candidate := is_octagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 65 },\n     { actual: candidate(10), expected: 280 },\n     { actual: candidate(15), expected: 645 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "go_test.go",
+    "prompt": "package is_Even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number is even or not.\nfunc is_Even(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Even(t *testing.T) {\n  candidate := is_Even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: false },\n     { actual: candidate(2), expected: true },\n     { actual: candidate(3), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "go_test.go",
+    "prompt": "package get_ludic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Ludic(t *testing.T) {\n  candidate := get_ludic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []int{1, 2, 3, 5, 7} },\n     { actual: candidate(25), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25} },\n     { actual: candidate(45), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "go_test.go",
+    "prompt": "package reverse_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReverse_Words(t *testing.T) {\n  candidate := reverse_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python program\"), expected: \"program python\" },\n     { actual: candidate(\"java language\"), expected: \"language java\" },\n     { actual: candidate(\"indian man\"), expected: \"man indian\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "go_test.go",
+    "prompt": "package prime_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given integer is a prime number.\nfunc prime_num(num int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPrime_Num(t *testing.T) {\n  candidate := prime_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13), expected: true },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(-1010), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "go_test.go",
+    "prompt": "package radian_degree_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert degrees to radians.\nfunc radian_degree(degree int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRadian_Degree(t *testing.T) {\n  candidate := radian_degree\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(90), expected: 1.5707963267948966 },\n     { actual: candidate(60), expected: 1.0471975511965976 },\n     { actual: candidate(120), expected: 2.0943951023931953 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "go_test.go",
+    "prompt": "package find_literals_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text string, pattern string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Literals(t *testing.T) {\n  candidate := find_literals\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"), expected: []interface{}{\"fox\", 16, 19} },\n     { actual: candidate(\"Its been a very crazy procedure right\", \"crazy\"), expected: []interface{}{\"crazy\", 16, 21} },\n     { actual: candidate(\"Hardest choices required strongest will\", \"will\"), expected: []interface{}{\"will\", 35, 39} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "go_test.go",
+    "prompt": "package bell_Number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find nth bell number.\nfunc bell_Number(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_Number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "go_test.go",
+    "prompt": "package remove_kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1 []int, L int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Kth_Element(t *testing.T) {\n  candidate := remove_kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []int{1, 1, 3, 4, 4, 5, 1} },\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), expected: []int{0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), expected: []int{10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "go_test.go",
+    "prompt": "package max_of_nth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list [][]int, N int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Of_Nth(t *testing.T) {\n  candidate := max_of_nth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 6, 7}, []int{1, 3, 5}, []int{8, 9, 19}}, 2), expected: 19 },\n     { actual: candidate([][]int{[]int{6, 7, 8}, []int{2, 4, 6}, []int{9, 10, 20}}, 1), expected: 10 },\n     { actual: candidate([][]int{[]int{7, 8, 9}, []int{3, 5, 7}, []int{10, 11, 21}}, 1), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "go_test.go",
+    "prompt": "package merge_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst [][]interface{}) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMerge(t *testing.T) {\n  candidate := merge\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"a\", \"b\"}, []string{\"m\", \"n\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}, []int{7, 8}}), expected: [][]int{[]int{1, 3, 5, 7}, []int{2, 4, 6, 8}} },\n     { actual: candidate([][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"a\", \"b\", \"c\"}, []string{\"m\", \"n\", \"o\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}, []string{\"z\", \"c\", \"o\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "go_test.go",
+    "prompt": "package cummulative_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list [][]int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCummulative_Sum(t *testing.T) {\n  candidate := cummulative_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 6, 7}, []int{2, 6}}), expected: 30 },\n     { actual: candidate([][]int{[]int{2, 4}, []int{6, 7, 8}, []int{3, 7}}), expected: 37 },\n     { actual: candidate([][]int{[]int{3, 5}, []int{7, 8, 9}, []int{4, 8}}), expected: 44 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "go_test.go",
+    "prompt": "package average_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums [][]int) []float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAverage_Tuple(t *testing.T) {\n  candidate := average_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{10, 10, 10, 12}, []int{30, 45, 56, 45}, []int{81, 80, 39, 32}, []int{1, 2, 3, 4}}), expected: []float64{30.5, 34.25, 27.0, 23.25} },\n     { actual: candidate([][]int{[]int{1, 1, -5}, []int{30, -15, 56}, []int{81, -60, -39}, []int{-10, 2, 3}}), expected: []float64{25.5, -18.0, 3.75} },\n     { actual: candidate([][]int{[]int{100, 100, 100, 120}, []int{300, 450, 560, 450}, []int{810, 800, 390, 320}, []int{10, 20, 30, 40}}), expected: []float64{305.0, 342.5, 270.0, 232.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "go_test.go",
+    "prompt": "package tuple_modulo_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTuple_Modulo(t *testing.T) {\n  candidate := tuple_modulo\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6}, []interface{}{5, 6, 7, 5}), expected: []interface{}{0, 4, 5, 1} },\n     { actual: candidate([]interface{}{11, 5, 6, 7}, []interface{}{6, 7, 8, 6}), expected: []interface{}{5, 5, 6, 1} },\n     { actual: candidate([]interface{}{12, 6, 7, 8}, []interface{}{7, 8, 9, 7}), expected: []interface{}{5, 6, 7, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "go_test.go",
+    "prompt": "package min_Jumps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps []interface{}, d int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMin_Jumps(t *testing.T) {\n  candidate := min_Jumps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}, 11), expected: 3.5 },\n     { actual: candidate([]interface{}{3, 4}, 0), expected: 0 },\n     { actual: candidate([]interface{}{11, 14}, 11), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "go_test.go",
+    "prompt": "package div_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to divide two lists element wise.\nfunc div_list(nums1 []int, nums2 []int) []float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDiv_List(t *testing.T) {\n  candidate := div_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 5, 6}, []int{1, 2, 3}), expected: []float64{4.0, 2.5, 2.0} },\n     { actual: candidate([]int{3, 2}, []int{1, 4}), expected: []float64{3.0, 0.5} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []float64{1.8, 1.7142857142857142} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "go_test.go",
+    "prompt": "package move_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMove_Num(t *testing.T) {\n  candidate := move_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"I1love143you55three3000thousand\"), expected: \"Iloveyouthreethousand1143553000\" },\n     { actual: candidate(\"Avengers124Assemble\"), expected: \"AvengersAssemble124\" },\n     { actual: candidate(\"Its11our12path13to14see15things16do17things\"), expected: \"Itsourpathtoseethingsdothings11121314151617\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "go_test.go",
+    "prompt": "package count_Substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Substrings(t *testing.T) {\n  candidate := count_Substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"112112\"), expected: 6 },\n     { actual: candidate(\"111\"), expected: 6 },\n     { actual: candidate(\"1101112\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "go_test.go",
+    "prompt": "package get_median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1 []int, arr2 []int, n int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Median(t *testing.T) {\n  candidate := get_median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 12, 15, 26, 38}, []int{2, 13, 17, 30, 45}, 5), expected: 16.0 },\n     { actual: candidate([]int{2, 4, 8, 9}, []int{7, 13, 19, 28}, 4), expected: 8.5 },\n     { actual: candidate([]int{3, 6, 14, 23, 36, 42}, []int{2, 18, 27, 39, 49, 55}, 6), expected: 25.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "go_test.go",
+    "prompt": "package nth_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums []int, n int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNth_Nums(t *testing.T) {\n  candidate := nth_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}, 3), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}, 5), expected: []int{248832, 759375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "go_test.go",
+    "prompt": "package is_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to convert a given string to uppercase.\nfunc is_upper(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Upper(t *testing.T) {\n  candidate := is_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"person\"), expected: \"PERSON\" },\n     { actual: candidate(\"final\"), expected: \"FINAL\" },\n     { actual: candidate(\"Valid\"), expected: \"VALID\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "go_test.go",
+    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to interchange the first and last element in a given list.\nfunc swap_List(newList []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: []int{4, 2, 3, 4, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "go_test.go",
+    "prompt": "package find_First_Missing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_First_Missing(t *testing.T) {\n  candidate := find_First_Missing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, 6, 9}), expected: 3 },\n     { actual: candidate([]int{2, 3, 5, 8, 9}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "go_test.go",
+    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(myString string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"My Name is Dawood\"), expected: \"My%20Name%20is%20Dawood\" },\n     { actual: candidate(\"I am a Programmer\"), expected: \"I%20am%20a%20Programmer\" },\n     { actual: candidate(\"I love Coding\"), expected: \"I%20love%20Coding\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "go_test.go",
+    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find even numbers from a list of numbers.\nfunc Split(list []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{2, 4} },\n     { actual: candidate([]int{4, 5, 6, 7, 8, 0, 1}), expected: []int{4, 6, 8, 0} },\n     { actual: candidate([]int{8, 12, 15, 19}), expected: []int{8, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "go_test.go",
+    "prompt": "package smallest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find smallest number in a list.\nfunc smallest_num(xs []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSmallest_Num(t *testing.T) {\n  candidate := smallest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 1, 45, 99}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n     { actual: candidate([]int{45, 46, 50, 60}), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "go_test.go",
+    "prompt": "package get_coordinates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup []interface{}) [][]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Coordinates(t *testing.T) {\n  candidate := get_coordinates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}), expected: [][]int{[]int{2, 3}, []int{2, 4}, []int{2, 5}, []int{3, 3}, []int{3, 4}, []int{3, 5}, []int{4, 3}, []int{4, 4}, []int{4, 5}} },\n     { actual: candidate([]interface{}{4, 5}), expected: [][]int{[]int{3, 4}, []int{3, 5}, []int{3, 6}, []int{4, 4}, []int{4, 5}, []int{4, 6}, []int{5, 4}, []int{5, 5}, []int{5, 6}} },\n     { actual: candidate([]interface{}{5, 6}), expected: [][]int{[]int{4, 5}, []int{4, 6}, []int{4, 7}, []int{5, 5}, []int{5, 6}, []int{5, 7}, []int{6, 5}, []int{6, 6}, []int{6, 7}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "go_test.go",
+    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jumanji The Jungle\"), expected: \"Jumanji_The_Jungle\" },\n     { actual: candidate(\"The_Avengers\"), expected: \"The Avengers\" },\n     { actual: candidate(\"Fast and Furious\"), expected: \"Fast_and_Furious\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "go_test.go",
+    "prompt": "package move_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to move all zeroes to the end of the given list.\nfunc move_zero(num_list []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMove_Zero(t *testing.T) {\n  candidate := move_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 0, 2, 0, 3, 4}), expected: []int{1, 2, 3, 4, 0, 0} },\n     { actual: candidate([]int{2, 3, 2, 0, 0, 4, 0, 5, 0}), expected: []int{2, 3, 2, 4, 5, 0, 0, 0, 0} },\n     { actual: candidate([]int{0, 1, 0, 1, 1}), expected: []int{1, 1, 1, 0, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "go_test.go",
+    "prompt": "package pair_xor_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr []int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPair_Xor_Sum(t *testing.T) {\n  candidate := pair_xor_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 9, 7, 6}, 4), expected: 47 },\n     { actual: candidate([]int{7, 3, 5}, 3), expected: 12 },\n     { actual: candidate([]int{7, 3}, 2), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "go_test.go",
+    "prompt": "package heap_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list.\nfunc heap_sort(iterable []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestHeap_Sort(t *testing.T) {\n  candidate := heap_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 25, 58}), expected: []int{14, 22, 25, 25, 35, 58, 65, 75, 85} },\n     { actual: candidate([]int{7, 1, 9, 5}), expected: []int{1, 5, 7, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "go_test.go",
+    "prompt": "package noprofit_noloss_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost int, sale_amount int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNoprofit_Noloss(t *testing.T) {\n  candidate := noprofit_noloss\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: false },\n     { actual: candidate(100, 100), expected: true },\n     { actual: candidate(2000, 5000), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "go_test.go",
+    "prompt": "package wind_chill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v int, t int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWind_Chill(t *testing.T) {\n  candidate := wind_chill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(120, 35), expected: 40 },\n     { actual: candidate(40, 20), expected: 19 },\n     { actual: candidate(10, 8), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "go_test.go",
+    "prompt": "package sample_nam_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names []string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSample_Nam(t *testing.T) {\n  candidate := sample_nam\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"}), expected: 16 },\n     { actual: candidate([]string{\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"}), expected: 10 },\n     { actual: candidate([]string{\"abcd\", \"Python\", \"abba\", \"aba\"}), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "go_test.go",
+    "prompt": "package max_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunc max_difference(test_list [][]interface{}) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Difference(t *testing.T) {\n  candidate := max_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{1, 7}, []interface{}{10, 3}, []interface{}{1, 2}}), expected: 7 },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{2, 17}, []interface{}{9, 13}, []interface{}{11, 12}}), expected: 15 },\n     { actual: candidate([][]int{[]interface{}{12, 35}, []interface{}{21, 27}, []interface{}{13, 23}, []interface{}{41, 22}}), expected: 23 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "go_test.go",
+    "prompt": "package remove_parenthesis_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items []string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Parenthesis(t *testing.T) {\n  candidate := remove_parenthesis\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python (chrome)\"}), expected: \"python\" },\n     { actual: candidate([]string{\"string(.abc)\"}), expected: \"string\" },\n     { actual: candidate([]string{\"alpha(num)\"}), expected: \"alpha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "go_test.go",
+    "prompt": "package is_nonagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Nonagonal(t *testing.T) {\n  candidate := is_nonagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 325 },\n     { actual: candidate(15), expected: 750 },\n     { actual: candidate(18), expected: 1089 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "go_test.go",
+    "prompt": "package text_match_wordz_middle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_Wordz_Middle(t *testing.T) {\n  candidate := text_match_wordz_middle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonzabc.\"), expected: true },\n     { actual: candidate(\"zxyabc.\"), expected: false },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "go_test.go",
+    "prompt": "package reverse_Array_Upto_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input []int, k int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReverse_Array_Upto_K(t *testing.T) {\n  candidate := reverse_Array_Upto_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 4), expected: []int{4, 3, 2, 1, 5, 6} },\n     { actual: candidate([]int{4, 5, 6, 7}, 2), expected: []int{5, 4, 6, 7} },\n     { actual: candidate([]int{9, 8, 7, 6, 5}, 3), expected: []int{7, 8, 9, 6, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "go_test.go",
+    "prompt": "package subject_marks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks [][]interface{}) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSubject_Marks(t *testing.T) {\n  candidate := subject_marks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}, []interface{}{\"Social sciences\", 82}}), expected: [][]int{[]interface{}{\"Social sciences\", 82}, []interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}} },\n     { actual: candidate([][]int{[]interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}, []interface{}{\"Social\", 33}}), expected: [][]int{[]interface{}{\"Social\", 33}, []interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}} },\n     { actual: candidate([][]int{[]interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}, []interface{}{\"Biology\", 45}}), expected: [][]int{[]interface{}{\"Biology\", 45}, []interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "go_test.go",
+    "prompt": "package pos_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of positive numbers in a list.\nfunc pos_count(list []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPos_Count(t *testing.T) {\n  candidate := pos_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, 3, -4}), expected: 2 },\n     { actual: candidate([]int{3, 4, 5, -1}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "go_test.go",
+    "prompt": "package bell_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(10), expected: 115975 },\n     { actual: candidate(56), expected: 6775685320645824322581483068371419745979053216268760300 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "go_test.go",
+    "prompt": "package is_Monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Monotonic(t *testing.T) {\n  candidate := is_Monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{6, 5, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 3, 2}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "go_test.go",
+    "prompt": "package is_sublist_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l []int, s []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Sublist(t *testing.T) {\n  candidate := is_sublist\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{4, 3}), expected: true },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{1, 6}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "go_test.go",
+    "prompt": "package differ_At_One_Bit_Pos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a int, b int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDiffer_At_One_Bit_Pos(t *testing.T) {\n  candidate := differ_At_One_Bit_Pos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13, 9), expected: true },\n     { actual: candidate(15, 8), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(2, 3), expected: true },\n     { actual: candidate(5, 1), expected: true },\n     { actual: candidate(1, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "go_test.go",
+    "prompt": "package get_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input [][]int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Equal(t *testing.T) {\n  candidate := get_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{11, 22, 33}, []int{44, 55, 66}}), expected: true },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6, 7}}), expected: false },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "go_test.go",
+    "prompt": "package comb_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc comb_sort(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestComb_Sort(t *testing.T) {\n  candidate := comb_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 15, 37, 25, 79}), expected: []int{5, 15, 25, 37, 79} },\n     { actual: candidate([]int{41, 32, 15, 19, 22}), expected: []int{15, 19, 22, 32, 41} },\n     { actual: candidate([]int{99, 15, 13, 47}), expected: []int{13, 15, 47, 99} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "go_test.go",
+    "prompt": "package add_dict_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup []interface{}, test_dict map[string]int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_Dict_To_Tuple(t *testing.T) {\n  candidate := add_dict_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, 6}, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}), expected: []interface{}{4, 5, 6, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}} },\n     { actual: candidate([]interface{}{1, 2, 3}, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}), expected: []interface{}{1, 2, 3, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}} },\n     { actual: candidate([]interface{}{8, 9, 10}, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}), expected: []interface{}{8, 9, 10, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "go_test.go",
+    "prompt": "package maxAverageOfPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost [][]int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMaxaverageofpath(t *testing.T) {\n  candidate := maxAverageOfPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{6, 5, 4}, []int{7, 3, 9}}), expected: 5.2 },\n     { actual: candidate([][]int{[]int{2, 3, 4}, []int{7, 6, 5}, []int{8, 4, 10}}), expected: 6.2 },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{8, 7, 6}, []int{9, 5, 11}}), expected: 7.2 },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}), expected: 5.8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "go_test.go",
+    "prompt": "package count_same_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1 []int, nums2 []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Same_Pair(t *testing.T) {\n  candidate := count_same_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 11 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 1 },\n     { actual: candidate([]int{0, 1, 1, 2}, []int{0, 1, 2, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "go_test.go",
+    "prompt": "package power_base_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base int, power int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPower_Base_Sum(t *testing.T) {\n  candidate := power_base_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 100), expected: 115 },\n     { actual: candidate(8, 10), expected: 37 },\n     { actual: candidate(8, 15), expected: 62 },\n     { actual: candidate(3, 3), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "go_test.go",
+    "prompt": "package extract_quotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1 string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Quotation(t *testing.T) {\n  candidate := extract_quotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"), expected: []string{\"A53\", \"multi\", \"Processor\"} },\n     { actual: candidate(\"Cast your \"favorite\" entertainment \"apps\"\"), expected: []string{\"favorite\", \"apps\"} },\n     { actual: candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"), expected: []string{\"4k Ultra HD\", \"HDR 10\"} },\n     { actual: candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "go_test.go",
+    "prompt": "package multiply_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup []int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMultiply_Elements(t *testing.T) {\n  candidate := multiply_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 7, 8, 10}), expected: []int{5, 35, 56, 80} },\n     { actual: candidate([]int{2, 4, 5, 6, 7}), expected: []int{8, 20, 30, 42} },\n     { actual: candidate([]int{12, 13, 14, 9, 15}), expected: []int{156, 182, 126, 135} },\n     { actual: candidate([]int{12}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "go_test.go",
+    "prompt": "package sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1 []int, lst2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_List(t *testing.T) {\n  candidate := sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30}, []int{15, 25, 35}), expected: []int{25, 45, 65} },\n     { actual: candidate([]int{1, 2, 3}, []int{5, 6, 7}), expected: []int{6, 8, 10} },\n     { actual: candidate([]int{15, 20, 30}, []int{15, 45, 75}), expected: []int{30, 65, 105} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "go_test.go",
+    "prompt": "package dif_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDif_Square(t *testing.T) {\n  candidate := dif_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(15), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "go_test.go",
+    "prompt": "package consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums []interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestConsecutive_Duplicates(t *testing.T) {\n  candidate := consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: []int{10, 15, 19, 18, 17, 26, 17, 18, 10} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: []string{\"a\", \"b\", \"c\", \"d\"} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"}), expected: []string{\"a\", \"b\", \"c\", \"d\", \"a\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "go_test.go",
+    "prompt": "package lateralsurface_cone_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r int, h int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLateralsurface_Cone(t *testing.T) {\n  candidate := lateralsurface_cone\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 12), expected: 204.20352248333654 },\n     { actual: candidate(10, 15), expected: 566.3586699569488 },\n     { actual: candidate(19, 17), expected: 1521.8090132193388 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "go_test.go",
+    "prompt": "package replace_specialchar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReplace_Specialchar(t *testing.T) {\n  candidate := replace_specialchar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python language, Programming language.\"), expected: \"Python:language::Programming:language:\" },\n     { actual: candidate(\"a b c,d e f\"), expected: \"a:b:c:d:e:f\" },\n     { actual: candidate(\"ram reshma,ram rahim\"), expected: \"ram:reshma:ram:rahim\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "go_test.go",
+    "prompt": "package find_first_occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_First_Occurrence(t *testing.T) {\n  candidate := find_first_occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 1 },\n     { actual: candidate([]int{2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 2 },\n     { actual: candidate([]int{2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "go_test.go",
+    "prompt": "package sum_Of_Subarray_Prod_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_Of_Subarray_Prod(t *testing.T) {\n  candidate := sum_Of_Subarray_Prod\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 20 },\n     { actual: candidate([]int{1, 2}), expected: 5 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "go_test.go",
+    "prompt": "package toggle_middle_bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestToggle_Middle_Bits(t *testing.T) {\n  candidate := toggle_middle_bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 15 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(11), expected: 13 },\n     { actual: candidate(65), expected: 127 },\n     { actual: candidate(77), expected: 115 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "go_test.go",
+    "prompt": "package left_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunc left_insertion(a []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLeft_Insertion(t *testing.T) {\n  candidate := left_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "go_test.go",
+    "prompt": "package check_str_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(myString string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Str(t *testing.T) {\n  candidate := check_str\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"annie\"), expected: true },\n     { actual: candidate(\"dawood\"), expected: false },\n     { actual: candidate(\"Else\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "go_test.go",
+    "prompt": "package geometric_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunc geometric_sum(n int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGeometric_Sum(t *testing.T) {\n  candidate := geometric_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 1.9921875 },\n     { actual: candidate(4), expected: 1.9375 },\n     { actual: candidate(8), expected: 1.99609375 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "go_test.go",
+    "prompt": "package find_Index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Index(t *testing.T) {\n  candidate := find_Index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 14 },\n     { actual: candidate(4), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "go_test.go",
+    "prompt": "package tuple_to_dict_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup []interface{}) map[int]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTuple_To_Dict(t *testing.T) {\n  candidate := tuple_to_dict\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 10, 13, 5}), expected: map[int]int{1: 5, 7: 10, 13: 5} },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}), expected: map[int]int{1: 2, 3: 4, 5: 6} },\n     { actual: candidate([]interface{}{7, 8, 9, 10, 11, 12}), expected: map[int]int{7: 8, 9: 10, 11: 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "go_test.go",
+    "prompt": "package all_Characters_Same_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether all the characters are same or not.\nfunc all_Characters_Same(s string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAll_Characters_Same(t *testing.T) {\n  candidate := all_Characters_Same\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"aaa\"), expected: true },\n     { actual: candidate(\"data\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "go_test.go",
+    "prompt": "package area_tetrahedron_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side int) float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestArea_Tetrahedron(t *testing.T) {\n  candidate := area_tetrahedron\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15.588457268119894 },\n     { actual: candidate(20), expected: 692.8203230275509 },\n     { actual: candidate(10), expected: 173.20508075688772 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "go_test.go",
+    "prompt": "package rotate_right_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunc rotate_right(list []int, m int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRotate_Right(t *testing.T) {\n  candidate := rotate_right\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), expected: []int{8, 9, 10, 1, 2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{9, 10, 1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), expected: []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "go_test.go",
+    "prompt": "package check_none_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given tuple has any none value or not.\nfunc check_none(test_tup interface{}) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_None(t *testing.T) {\n  candidate := check_none\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6, nil}), expected: true },\n     { actual: candidate([]interface{}{7, 8, 9, 11, 14}), expected: false },\n     { actual: candidate([]interface{}{1, 2, 3, 4, nil}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "go_test.go",
+    "prompt": "package divisible_by_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunc divisible_by_digits(startnum int, endnum int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDivisible_By_Digits(t *testing.T) {\n  candidate := divisible_by_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 22), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22} },\n     { actual: candidate(1, 15), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15} },\n     { actual: candidate(20, 25), expected: []int{22, 24} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "go_test.go",
+    "prompt": "package lcs_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X string, Y string, Z string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLcs_Of_Three(t *testing.T) {\n  candidate := lcs_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"), expected: 2 },\n     { actual: candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"), expected: 5 },\n     { actual: candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "go_test.go",
+    "prompt": "package capital_words_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1 string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCapital_Words_Spaces(t *testing.T) {\n  candidate := capital_words_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"PythonProgrammingExamples\"), expected: \"Python Programming Examples\" },\n     { actual: candidate(\"GetReadyToBeCodingFreak\"), expected: \"Get Ready To Be Coding Freak\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "go_test.go",
+    "prompt": "package sort_numeric_strings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str []string) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSort_Numeric_Strings(t *testing.T) {\n  candidate := sort_numeric_strings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"}), expected: []int{-500, -12, 0, 4, 7, 12, 45, 100, 200} },\n     { actual: candidate([]string{\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"}), expected: []int{1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9} },\n     { actual: candidate([]string{\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"}), expected: []int{1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "go_test.go",
+    "prompt": "package is_samepatterns_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors []string, patterns []string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Samepatterns(t *testing.T) {\n  candidate := is_samepatterns\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"green\", \"green\"}, []string{\"a\", \"b\", \"b\"}), expected: true },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\", \"b\"}), expected: false },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\"}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "go_test.go",
+    "prompt": "package add_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add the given tuple to the given list.\nfunc add_tuple(test_list []int, test_tup []interface{}) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestAdd_Tuple(t *testing.T) {\n  candidate := add_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []int{5, 6, 7, 9, 10} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []int{6, 7, 8, 10, 11} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []int{7, 8, 9, 11, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "go_test.go",
+    "prompt": "package check_min_heap_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Min_Heap(t *testing.T) {\n  candidate := check_min_heap\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 10, 15}), expected: true },\n     { actual: candidate([]int{2, 10, 4, 5, 3, 15}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "go_test.go",
+    "prompt": "package jacobsthal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestJacobsthal_Num(t *testing.T) {\n  candidate := jacobsthal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 11 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 5 },\n     { actual: candidate(13), expected: 2731 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "go_test.go",
+    "prompt": "package min_k_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunc min_k(test_list [][]interface{}, K int) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMin_K(t *testing.T) {\n  candidate := min_k\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Manjeet\", 10}, []interface{}{\"Akshat\", 4}, []interface{}{\"Akash\", 2}, []interface{}{\"Nikhil\", 8}}, 2), expected: [][]int{[]interface{}{\"Akash\", 2}, []interface{}{\"Akshat\", 4}} },\n     { actual: candidate([][]int{[]interface{}{\"Sanjeev\", 11}, []interface{}{\"Angat\", 5}, []interface{}{\"Akash\", 3}, []interface{}{\"Nepin\", 9}}, 3), expected: [][]int{[]interface{}{\"Akash\", 3}, []interface{}{\"Angat\", 5}, []interface{}{\"Nepin\", 9}} },\n     { actual: candidate([][]int{[]interface{}{\"tanmay\", 14}, []interface{}{\"Amer\", 11}, []interface{}{\"Ayesha\", 9}, []interface{}{\"SKD\", 16}}, 1), expected: [][]int{[]interface{}{\"Ayesha\", 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "go_test.go",
+    "prompt": "package extract_index_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1 []int, l2 []int, l3 []int) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestExtract_Index_List(t *testing.T) {\n  candidate := extract_index_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 7} },\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 6, 5}, []int{0, 1, 2, 3, 4, 6, 7}), expected: []int{1, 6} },\n     { actual: candidate([]int{1, 1, 3, 4, 6, 5, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 6, 6, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "go_test.go",
+    "prompt": "package text_match_zero_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunc text_match_zero_one(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_Zero_One(t *testing.T) {\n  candidate := text_match_zero_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"dsabbbba\"), expected: true },\n     { actual: candidate(\"asbbbba\"), expected: false },\n     { actual: candidate(\"abaaa\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "go_test.go",
+    "prompt": "package count_reverse_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list []string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Reverse_Pairs(t *testing.T) {\n  candidate := count_reverse_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"}), expected: 2 },\n     { actual: candidate([]string{\"geeks\", \"best\", \"for\", \"skeeg\"}), expected: 1 },\n     { actual: candidate([]string{\"makes\", \"best\", \"sekam\", \"for\", \"rof\"}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "go_test.go",
+    "prompt": "package is_decimal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Decimal(t *testing.T) {\n  candidate := is_decimal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"123.11\"), expected: true },\n     { actual: candidate(\"e666.86\"), expected: false },\n     { actual: candidate(\"3.124587\"), expected: false },\n     { actual: candidate(\"1.11\"), expected: true },\n     { actual: candidate(\"1.1.11\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "go_test.go",
+    "prompt": "package find_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunc find_tuples(test_list [][]interface{}, K int) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Tuples(t *testing.T) {\n  candidate := find_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{6, 24, 12}, []interface{}{7, 9, 6}, []interface{}{12, 18, 21}}, 6), expected: [][]int{[]interface{}{6, 24, 12}} },\n     { actual: candidate([][]int{[]interface{}{5, 25, 30}, []interface{}{4, 2, 3}, []interface{}{7, 8, 9}}, 5), expected: [][]int{[]interface{}{5, 25, 30}} },\n     { actual: candidate([][]int{[]interface{}{7, 9, 16}, []interface{}{8, 16, 4}, []interface{}{19, 17, 18}}, 4), expected: [][]int{[]interface{}{8, 16, 4}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "go_test.go",
+    "prompt": "package unique_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestUnique_Element(t *testing.T) {\n  candidate := unique_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "go_test.go",
+    "prompt": "package check_monthnumber_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3 int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Monthnumber_Number(t *testing.T) {\n  candidate := check_monthnumber_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(12), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "go_test.go",
+    "prompt": "package find_min_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr []int, n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Min_Diff(t *testing.T) {\n  candidate := find_min_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 3, 19, 18, 25}, 6), expected: 1 },\n     { actual: candidate([]int{4, 3, 2, 6}, 4), expected: 1 },\n     { actual: candidate([]int{30, 5, 20, 9}, 4), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "go_test.go",
+    "prompt": "package number_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count number of digits in a given string.\nfunc number_ctr(str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNumber_Ctr(t *testing.T) {\n  candidate := number_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"program2bedone\"), expected: 1 },\n     { actual: candidate(\"3wonders\"), expected: 1 },\n     { actual: candidate(\"123\"), expected: 3 },\n     { actual: candidate(\"3wond-1ers2\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "go_test.go",
+    "prompt": "package is_polite_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Polite(t *testing.T) {\n  candidate := is_polite\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 11 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(9), expected: 13 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "go_test.go",
+    "prompt": "package pair_wise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1 []int) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPair_Wise(t *testing.T) {\n  candidate := pair_wise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 3, 4, 4, 5}), expected: [][]int{[]interface{}{1, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 3}, []interface{}{3, 4}, []interface{}{4, 4}, []interface{}{4, 5}} },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: [][]int{[]interface{}{1, 5}, []interface{}{5, 7}, []interface{}{7, 9}, []interface{}{9, 10}} },\n     { actual: candidate([]int{5, 1, 9, 7, 10}), expected: [][]int{[]interface{}{5, 1}, []interface{}{1, 9}, []interface{}{9, 7}, []interface{}{7, 10}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: [][]int{[]interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}, []interface{}{4, 5}, []interface{}{5, 6}, []interface{}{6, 7}, []interface{}{7, 8}, []interface{}{8, 9}, []interface{}{9, 10}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "go_test.go",
+    "prompt": "package get_pairs_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr []int, sum int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Pairs_Count(t *testing.T) {\n  candidate := get_pairs_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1, 1}, 2), expected: 6 },\n     { actual: candidate([]int{1, 5, 7, -1, 5}, 6), expected: 3 },\n     { actual: candidate([]int{1, -2, 3}, 1), expected: 1 },\n     { actual: candidate([]int{-1, -2, 3}, -3), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "go_test.go",
+    "prompt": "package Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to get the difference between two lists.\nfunc Diff(li1 []int, li2 []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDiff(t *testing.T) {\n  candidate := Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 15, 20, 25, 30, 35, 40}, []int{25, 40, 35}), expected: []int{10, 20, 30, 15} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 1}), expected: []int{2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3}, []int{6, 7, 1}), expected: []int{2, 3, 6, 7} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "go_test.go",
+    "prompt": "package odd_num_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOdd_Num_Sum(t *testing.T) {\n  candidate := odd_num_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 82 },\n     { actual: candidate(3), expected: 707 },\n     { actual: candidate(4), expected: 3108 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "go_test.go",
+    "prompt": "package check_expression_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Expression(t *testing.T) {\n  candidate := check_expression\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"{()}[{}]\"), expected: true },\n     { actual: candidate(\"{()}[{]\"), expected: false },\n     { actual: candidate(\"{()}[{}][]({})\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "go_test.go",
+    "prompt": "package remove_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str string, K int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Length(t *testing.T) {\n  candidate := remove_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The person is most value tet\", 3), expected: \"person is most value\" },\n     { actual: candidate(\"If you told me about this ok\", 4), expected: \"If you me about ok\" },\n     { actual: candidate(\"Forces of darkeness is come into the play\", 4), expected: \"Forces of darkeness is the\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "go_test.go",
+    "prompt": "package odd_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOdd_Position(t *testing.T) {\n  candidate := odd_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 4, 3, 6, 7, 6, 3}), expected: true },\n     { actual: candidate([]int{4, 1, 2}), expected: true },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "go_test.go",
+    "prompt": "package count_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Vowels(t *testing.T) {\n  candidate := count_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"bestinstareels\"), expected: 7 },\n     { actual: candidate(\"partofthejourneyistheend\"), expected: 12 },\n     { actual: candidate(\"amazonprime\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "go_test.go",
+    "prompt": "package find_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Sum(t *testing.T) {\n  candidate := find_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 1, 1, 4, 5, 6}), expected: 21 },\n     { actual: candidate([]int{1, 10, 9, 4, 2, 10, 10, 45, 4}), expected: 71 },\n     { actual: candidate([]int{12, 10, 9, 45, 2, 10, 10, 45, 10}), expected: 78 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "go_test.go",
+    "prompt": "package pack_consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1 []interface{}) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPack_Consecutive_Duplicates(t *testing.T) {\n  candidate := pack_consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: [][]int{[]int{0, 0}, []int{1}, []int{2}, []int{3}, []int{4, 4}, []int{5}, []int{6, 6, 6}, []int{7}, []int{8}, []int{9}, []int{4, 4}} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: [][]int{[]int{10, 10}, []int{15}, []int{19}, []int{18, 18}, []int{17}, []int{26, 26}, []int{17}, []int{18}, []int{10}} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: [][]int{[]string{\"a\", \"a\"}, []string{\"b\"}, []string{\"c\"}, []string{\"d\", \"d\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "go_test.go",
+    "prompt": "package is_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find whether a number is divisible by 11.\nfunc is_Diff(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Diff(t *testing.T) {\n  candidate := is_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12345), expected: false },\n     { actual: candidate(1212112), expected: true },\n     { actual: candidate(1212), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "go_test.go",
+    "prompt": "package find_combinations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunc find_combinations(test_list [][]interface{}) [][]interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Combinations(t *testing.T) {\n  candidate := find_combinations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 4}, []interface{}{6, 7}, []interface{}{5, 1}, []interface{}{6, 10}}), expected: [][]int{[]interface{}{8, 11}, []interface{}{7, 5}, []interface{}{8, 14}, []interface{}{11, 8}, []interface{}{12, 17}, []interface{}{11, 11}} },\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{7, 8}, []interface{}{6, 2}, []interface{}{7, 11}}), expected: [][]int{[]interface{}{10, 13}, []interface{}{9, 7}, []interface{}{10, 16}, []interface{}{13, 10}, []interface{}{14, 19}, []interface{}{13, 13}} },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{8, 9}, []interface{}{7, 3}, []interface{}{8, 12}}), expected: [][]int{[]interface{}{12, 15}, []interface{}{11, 9}, []interface{}{12, 18}, []interface{}{15, 12}, []interface{}{16, 21}, []interface{}{15, 15}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "go_test.go",
+    "prompt": "package count_divisors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunc count_divisors(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Divisors(t *testing.T) {\n  candidate := count_divisors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(100), expected: false },\n     { actual: candidate(125), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "go_test.go",
+    "prompt": "package odd_length_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestOdd_Length_Sum(t *testing.T) {\n  candidate := odd_length_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4}), expected: 14 },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: 15 },\n     { actual: candidate([]int{1, 7}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "go_test.go",
+    "prompt": "package rgb_to_hsv_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r int, g int, b int) []float64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRgb_To_Hsv(t *testing.T) {\n  candidate := rgb_to_hsv\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(255, 255, 255), expected: []float64{0.0, 0.0, 100.0} },\n     { actual: candidate(0, 215, 0), expected: []float64{120.0, 100.0, 84.31372549019608} },\n     { actual: candidate(10, 215, 110), expected: []float64{149.26829268292684, 95.34883720930233, 84.31372549019608} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "go_test.go",
+    "prompt": "package mul_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1 []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMul_Even_Odd(t *testing.T) {\n  candidate := mul_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "go_test.go",
+    "prompt": "package tuple_str_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTuple_Str_Int(t *testing.T) {\n  candidate := tuple_str_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(7, 8, 9)\"), expected: []interface{}{7, 8, 9} },\n     { actual: candidate(\"(1, 2, 3)\"), expected: []interface{}{1, 2, 3} },\n     { actual: candidate(\"(4, 5, 6)\"), expected: []interface{}{4, 5, 6} },\n     { actual: candidate(\"(7, 81, 19)\"), expected: []interface{}{7, 81, 19} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "go_test.go",
+    "prompt": "package right_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRight_Insertion(t *testing.T) {\n  candidate := right_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "go_test.go",
+    "prompt": "package text_match_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Match_Three(t *testing.T) {\n  candidate := text_match_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"caacabbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "go_test.go",
+    "prompt": "package new_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create a new tuple from the given string and list.\nfunc new_tuple(test_list []string, test_str string) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestNew_Tuple(t *testing.T) {\n  candidate := new_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"WEB\", \"is\"}, \"best\"), expected: []interface{}{\"WEB\", \"is\", \"best\"} },\n     { actual: candidate([]string{\"We\", \"are\"}, \"Developers\"), expected: []interface{}{\"We\", \"are\", \"Developers\"} },\n     { actual: candidate([]string{\"Part\", \"is\"}, \"Wrong\"), expected: []interface{}{\"Part\", \"is\", \"Wrong\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "go_test.go",
+    "prompt": "package even_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestEven_Position(t *testing.T) {\n  candidate := even_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n     { actual: candidate([]int{2, 1, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "go_test.go",
+    "prompt": "package remove_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup interface{}) []interface{} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_Nested(t *testing.T) {\n  candidate := remove_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, []interface{}{4, 6}, 10}), expected: []interface{}{1, 5, 7, 10} },\n     { actual: candidate([]interface{}{2, 6, 8, []interface{}{5, 7}, 11}), expected: []interface{}{2, 6, 8, 11} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, 12}), expected: []interface{}{3, 7, 9, 12} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, []interface{}{5, 12}, 12}), expected: []interface{}{3, 7, 9, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "go_test.go",
+    "prompt": "package count_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of lists in a given number of lists.\nfunc count_list(input_list [][]int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_List(t *testing.T) {\n  candidate := count_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{2, 3}, []int{4, 5}}), expected: 3 },\n     { actual: candidate([][]int{[]int{1, 0}, []int{2, 0}}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "go_test.go",
+    "prompt": "package last_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the last position of an element in a sorted array.\nfunc last(arr []int, x int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLast(t *testing.T) {\n  candidate := last\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 1), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 2, 3, 4}, 1), expected: 2 },\n     { actual: candidate([]int{2, 3, 2, 3, 6, 8, 9}, 3), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "go_test.go",
+    "prompt": "package text_starta_endb_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestText_Starta_Endb(t *testing.T) {\n  candidate := text_starta_endb\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aabbbb\"), expected: true },\n     { actual: candidate(\"aabAbbbc\"), expected: false },\n     { actual: candidate(\"accddbbjjj\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "go_test.go",
+    "prompt": "package return_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict map[string]int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestReturn_Sum(t *testing.T) {\n  candidate := return_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"a\": 100, \"b\": 200, \"c\": 300}), expected: 600 },\n     { actual: candidate(map[string]int{\"a\": 25, \"b\": 18, \"c\": 45}), expected: 88 },\n     { actual: candidate(map[string]int{\"a\": 36, \"b\": 39, \"c\": 49}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "go_test.go",
+    "prompt": "package sum_in_range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l int, r int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSum_In_Range(t *testing.T) {\n  candidate := sum_in_range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 5), expected: 8 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 13), expected: 40 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "go_test.go",
+    "prompt": "package _sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the sum of an array.\nfunc _sum(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func Test_Sum(t *testing.T) {\n  candidate := _sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{15, 12, 13, 10}), expected: 50 },\n     { actual: candidate([]int{0, 1, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "go_test.go",
+    "prompt": "package left_rotate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n int, d int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLeft_Rotate(t *testing.T) {\n  candidate := left_rotate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: 64 },\n     { actual: candidate(10, 2), expected: 40 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(1, 3), expected: 8 },\n     { actual: candidate(5, 3), expected: 40 },\n     { actual: candidate(29, 3), expected: 232 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "go_test.go",
+    "prompt": "package word_len_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to check whether the length of the word is odd or not.\nfunc word_len(s string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestWord_Len(t *testing.T) {\n  candidate := word_len\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hadoop\"), expected: false },\n     { actual: candidate(\"great\"), expected: true },\n     { actual: candidate(\"structure\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "go_test.go",
+    "prompt": "package remove_all_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestRemove_All_Spaces(t *testing.T) {\n  candidate := remove_all_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python  program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"python   programming    language\"), expected: \"pythonprogramminglanguage\" },\n     { actual: candidate(\"python                     program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"   python                     program\"), expected: \"pythonprogram\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "go_test.go",
+    "prompt": "package test_three_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x int, y int, z int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTest_Three_Equal(t *testing.T) {\n  candidate := test_three_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 1, 1), expected: 3 },\n     { actual: candidate(-1, -2, -3), expected: 0 },\n     { actual: candidate(1, 2, 2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "go_test.go",
+    "prompt": "package count_rotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCount_Rotation(t *testing.T) {\n  candidate := count_rotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: 1 },\n     { actual: candidate([]int{4, 5, 1, 2, 3}), expected: 2 },\n     { actual: candidate([]int{7, 8, 9, 1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3}), expected: 0 },\n     { actual: candidate([]int{1, 3, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "go_test.go",
+    "prompt": "package is_perfect_square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Perfect_Square(t *testing.T) {\n  candidate := is_perfect_square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: false },\n     { actual: candidate(36), expected: true },\n     { actual: candidate(14), expected: false },\n     { actual: candidate(196), expected: true },\n     { actual: candidate(125), expected: false },\n     { actual: candidate(15625), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "go_test.go",
+    "prompt": "package is_product_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr []int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Product_Even(t *testing.T) {\n  candidate := is_product_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 4}), expected: true },\n     { actual: candidate([]int{1, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "go_test.go",
+    "prompt": "package max_sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists [][]int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Sum_List(t *testing.T) {\n  candidate := max_sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{10, 11, 12}, []int{7, 8, 9}}), expected: []int{10, 11, 12} },\n     { actual: candidate([][]int{[]int{3, 2, 1}, []int{6, 5, 4}, []int{12, 11, 10}}), expected: []int{12, 11, 10} },\n     { actual: candidate([][]int{[]int{2, 3, 1}}), expected: []int{2, 3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "go_test.go",
+    "prompt": "package max_run_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMax_Run_Uppercase(t *testing.T) {\n  candidate := max_run_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"GeMKSForGERksISBESt\"), expected: 5 },\n     { actual: candidate(\"PrECIOusMOVemENTSYT\"), expected: 6 },\n     { actual: candidate(\"GooGLEFluTTER\"), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "go_test.go",
+    "prompt": "package first_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the first odd number in a given list of numbers.\nfunc first_odd(nums []int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFirst_Odd(t *testing.T) {\n  candidate := first_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5}), expected: 1 },\n     { actual: candidate([]int{2, 4, 1, 3}), expected: 1 },\n     { actual: candidate([]int{8, 9, 1}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "go_test.go",
+    "prompt": "package check_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup []int, K int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_K(t *testing.T) {\n  candidate := check_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 4, 5, 6, 8}, 6), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 7), expected: false },\n     { actual: candidate([]int{7, 8, 9, 44, 11, 12}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "go_test.go",
+    "prompt": "package check_smaller_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1 []interface{}, test_tup2 []interface{}) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCheck_Smaller(t *testing.T) {\n  candidate := check_smaller\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}, []interface{}{2, 3, 4}), expected: false },\n     { actual: candidate([]interface{}{4, 5, 6}, []interface{}{3, 4, 5}), expected: true },\n     { actual: candidate([]interface{}{11, 12, 13}, []interface{}{10, 11, 12}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "go_test.go",
+    "prompt": "package tetrahedral_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestTetrahedral_Number(t *testing.T) {\n  candidate := tetrahedral_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 35 },\n     { actual: candidate(6), expected: 56 },\n     { actual: candidate(7), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "go_test.go",
+    "prompt": "package get_Char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr string) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestGet_Char(t *testing.T) {\n  candidate := get_Char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: \"f\" },\n     { actual: candidate(\"gfg\"), expected: \"t\" },\n     { actual: candidate(\"ab\"), expected: \"c\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "go_test.go",
+    "prompt": "package sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSequence(t *testing.T) {\n  candidate := sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 6 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "go_test.go",
+    "prompt": "package centered_hexagonal_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestCentered_Hexagonal_Number(t *testing.T) {\n  candidate := centered_hexagonal_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 271 },\n     { actual: candidate(2), expected: 7 },\n     { actual: candidate(9), expected: 217 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "go_test.go",
+    "prompt": "package merge_dictionaries_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1 map[string]string, dict2 map[string]string, dict3 map[string]string) map[string]string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestMerge_Dictionaries_Three(t *testing.T) {\n  candidate := merge_dictionaries_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}), expected: map[string]string{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}), expected: map[string]string{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}), expected: map[string]string{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "go_test.go",
+    "prompt": "package freq_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunc freq_count(list1 []int) map[int]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFreq_Count(t *testing.T) {\n  candidate := freq_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), expected: map[int]int{10: 4, 20: 4, 40: 2, 50: 2, 30: 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), expected: map[int]int{1: 3, 2: 2, 3: 3, 4: 3} },\n     { actual: candidate([]int{5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), expected: map[int]int{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "go_test.go",
+    "prompt": "package closest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the closest smaller number than n.\nfunc closest_num(N int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestClosest_Num(t *testing.T) {\n  candidate := closest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(11), expected: 10 },\n     { actual: candidate(7), expected: 6 },\n     { actual: candidate(12), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "go_test.go",
+    "prompt": "package square_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums []int) []int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestSquare_Nums(t *testing.T) {\n  candidate := square_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{100, 400, 900} },\n     { actual: candidate([]int{12, 15}), expected: []int{144, 225} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "go_test.go",
+    "prompt": "package len_log_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the longest word.\nfunc len_log(list1 []string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestLen_Log(t *testing.T) {\n  candidate := len_log\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python\", \"PHP\", \"bigdata\"}), expected: 7 },\n     { actual: candidate([]string{\"a\", \"ab\", \"abc\"}), expected: 3 },\n     { actual: candidate([]string{\"small\", \"big\", \"tall\"}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "go_test.go",
+    "prompt": "package find_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1 []string, sub_str string) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Substring(t *testing.T) {\n  candidate := find_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ack\"), expected: true },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"abc\"), expected: false },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ange\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "go_test.go",
+    "prompt": "package is_undulating_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n int) bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIs_Undulating(t *testing.T) {\n  candidate := is_undulating\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1212121), expected: true },\n     { actual: candidate(1991), expected: false },\n     { actual: candidate(121), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "go_test.go",
+    "prompt": "package power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a int, b int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestPower(t *testing.T) {\n  candidate := power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 81 },\n     { actual: candidate(2, 3), expected: 8 },\n     { actual: candidate(5, 5), expected: 3125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "go_test.go",
+    "prompt": "package index_minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list [][]interface{}) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestIndex_Minimum(t *testing.T) {\n  candidate := index_minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Rash\", 143}, []interface{}{\"Manjeet\", 200}, []interface{}{\"Varsha\", 100}}), expected: \"Varsha\" },\n     { actual: candidate([][]int{[]interface{}{\"Yash\", 185}, []interface{}{\"Dawood\", 125}, []interface{}{\"Sanya\", 175}}), expected: \"Dawood\" },\n     { actual: candidate([][]int{[]interface{}{\"Sai\", 345}, []interface{}{\"Salman\", 145}, []interface{}{\"Ayesha\", 96}}), expected: \"Ayesha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "go_test.go",
+    "prompt": "package Find_Min_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst [][]int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Min_Length(t *testing.T) {\n  candidate := Find_Min_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}}), expected: 1 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{1, 2, 3}, []int{1, 2, 3, 4}}), expected: 2 },\n     { actual: candidate([][]int{[]int{3, 3, 3}, []int{4, 4, 4, 4}}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "go_test.go",
+    "prompt": "package divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the number of divisors of a given integer.\nfunc divisor(n int) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDivisor(t *testing.T) {\n  candidate := divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 4 },\n     { actual: candidate(12), expected: 6 },\n     { actual: candidate(9), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "go_test.go",
+    "prompt": "package frequency_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunc frequency_lists(list1 [][]int) map[int]int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFrequency_Lists(t *testing.T) {\n  candidate := frequency_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 2}, []int{4, 5, 6, 2}, []int{7, 8, 9, 5}}), expected: map[int]int{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}}), expected: map[int]int{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1} },\n     { actual: candidate([][]int{[]int{20, 30, 40, 17}, []int{18, 16, 14, 13}, []int{10, 20, 30, 40}}), expected: map[int]int{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n int) string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: \"1000\" },\n     { actual: candidate(18), expected: \"10010\" },\n     { actual: candidate(7), expected: \"111\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "go_test.go",
+    "prompt": "package find_Rotations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str string) int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "func TestFind_Rotations(t *testing.T) {\n  candidate := find_Rotations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aaaa\"), expected: 1 },\n     { actual: candidate(\"ab\"), expected: 2 },\n     { actual: candidate(\"abc\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/mbpp-go-reworded.json
+++ b/prompts/mbpp-go-reworded.json
@@ -1,3862 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "go_test.go",
-    "prompt": "package lps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLps(t *testing.T) {\n  candidate := lps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TENS FOR TENS\"), expected: 5 },\n     { actual: candidate(\"CARDIO FOR CARDS\"), expected: 7 },\n     { actual: candidate(\"PART OF THE JOURNEY IS PART\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "go_test.go",
-    "prompt": "package remove_whitespaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1 string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Whitespaces(t *testing.T) {\n  candidate := remove_whitespaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\" Google    Flutter \"), expected: \"GoogleFlutter\" },\n     { actual: candidate(\" Google    Dart \"), expected: \"GoogleDart\" },\n     { actual: candidate(\" iOS    Swift \"), expected: \"iOSSwift\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "go_test.go",
-    "prompt": "package issort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1 []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIssort_List(t *testing.T) {\n  candidate := issort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), expected: false },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 15, 14, 20}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "go_test.go",
-    "prompt": "package count_bidirectional_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count bidirectional list pairs.\nfunc count_bidirectional(test_list [][]interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Bidirectional(t *testing.T) {\n  candidate := count_bidirectional\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 3}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 2 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 2}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "go_test.go",
-    "prompt": "package surfacearea_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSurfacearea_Cube(t *testing.T) {\n  candidate := surfacearea_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 150 },\n     { actual: candidate(3), expected: 54 },\n     { actual: candidate(10), expected: 600 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "go_test.go",
     "prompt": "package next_smallest_palindrome_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunc next_smallest_palindrome(num int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "func TestNext_Smallest_Palindrome(t *testing.T) {\n  candidate := next_smallest_palindrome\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(99), expected: 101 },\n     { actual: candidate(1221), expected: 1331 },\n     { actual: candidate(120), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "go_test.go",
-    "prompt": "package cube_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCube_Sum(t *testing.T) {\n  candidate := cube_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 72 },\n     { actual: candidate(3), expected: 288 },\n     { actual: candidate(4), expected: 800 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "go_test.go",
-    "prompt": "package pair_xor_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr []int, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPair_Xor_Sum(t *testing.T) {\n  candidate := pair_xor_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 9, 7, 6}, 4), expected: 47 },\n     { actual: candidate([]int{7, 3, 5}, 3), expected: 12 },\n     { actual: candidate([]int{7, 3}, 2), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "go_test.go",
-    "prompt": "package check_min_heap_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\nfunc check_min_heap(arr []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Min_Heap(t *testing.T) {\n  candidate := check_min_heap\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 10, 15}), expected: true },\n     { actual: candidate([]int{2, 10, 4, 5, 3, 15}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "go_test.go",
-    "prompt": "package first_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the first digit of a given number.\nfunc first_Digit(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFirst_Digit(t *testing.T) {\n  candidate := first_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 1 },\n     { actual: candidate(456), expected: 4 },\n     { actual: candidate(12), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "go_test.go",
-    "prompt": "package radian_degree_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert degrees to radians.\nfunc radian_degree(degree int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRadian_Degree(t *testing.T) {\n  candidate := radian_degree\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(90), expected: 1.5707963267948966 },\n     { actual: candidate(60), expected: 1.0471975511965976 },\n     { actual: candidate(120), expected: 2.0943951023931953 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "go_test.go",
-    "prompt": "package max_subarray_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product sublist of the given list.\nfunc max_subarray_product(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Subarray_Product(t *testing.T) {\n  candidate := max_subarray_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 0, 7, -8, -2}), expected: 112 },\n     { actual: candidate([]int{6, -3, -10, 0, 2}), expected: 180 },\n     { actual: candidate([]int{-2, -40, 0, -2, -3}), expected: 80 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "go_test.go",
-    "prompt": "package smallest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find smallest number in a list.\nfunc smallest_num(xs []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSmallest_Num(t *testing.T) {\n  candidate := smallest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 1, 45, 99}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n     { actual: candidate([]int{45, 46, 50, 60}), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "go_test.go",
-    "prompt": "package text_match_zero_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/gothon-exercises/re/gothon-re-exercise-3.php\nfunc text_match_zero_one(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_Zero_One(t *testing.T) {\n  candidate := text_match_zero_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"dsabbbba\"), expected: true },\n     { actual: candidate(\"asbbbba\"), expected: false },\n     { actual: candidate(\"abaaa\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "go_test.go",
-    "prompt": "package bell_Number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find nth bell number.\nfunc bell_Number(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_Number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "go_test.go",
-    "prompt": "package cube_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCube_Nums(t *testing.T) {\n  candidate := cube_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 8, 27, 64, 125, 216, 343, 512, 729, 1000} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}), expected: []int{1728, 3375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "go_test.go",
-    "prompt": "package last_Digit_Factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLast_Digit_Factorial(t *testing.T) {\n  candidate := last_Digit_Factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 4 },\n     { actual: candidate(21), expected: 0 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "go_test.go",
-    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find even numbers from a list of numbers.\nfunc Split(list []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{2, 4} },\n     { actual: candidate([]int{4, 5, 6, 7, 8, 0, 1}), expected: []int{4, 6, 8, 0} },\n     { actual: candidate([]int{8, 12, 15, 19}), expected: []int{8, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "go_test.go",
-    "prompt": "package prime_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given integer is a prime number.\nfunc prime_num(num int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPrime_Num(t *testing.T) {\n  candidate := prime_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13), expected: true },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(-1010), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "go_test.go",
-    "prompt": "package find_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find lists which have all elements divisible by k from the given list of lists.\nfunc find_tuples(test_list [][]interface{}, K int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Tuples(t *testing.T) {\n  candidate := find_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{6, 24, 12}, []interface{}{7, 9, 6}, []interface{}{12, 18, 21}}, 6), expected: [][]int{[]interface{}{6, 24, 12}} },\n     { actual: candidate([][]int{[]interface{}{5, 25, 30}, []interface{}{4, 2, 3}, []interface{}{7, 8, 9}}, 5), expected: [][]int{[]interface{}{5, 25, 30}} },\n     { actual: candidate([][]int{[]interface{}{7, 9, 16}, []interface{}{8, 16, 4}, []interface{}{19, 17, 18}}, 4), expected: [][]int{[]interface{}{8, 16, 4}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "go_test.go",
-    "prompt": "package area_tetrahedron_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestArea_Tetrahedron(t *testing.T) {\n  candidate := area_tetrahedron\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15.588457268119894 },\n     { actual: candidate(20), expected: 692.8203230275509 },\n     { actual: candidate(10), expected: 173.20508075688772 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "go_test.go",
-    "prompt": "package is_Even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number is even or not.\nfunc is_Even(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Even(t *testing.T) {\n  candidate := is_Even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: false },\n     { actual: candidate(2), expected: true },\n     { actual: candidate(3), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "go_test.go",
-    "prompt": "package pos_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of positive numbers in a list.\nfunc pos_count(list []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPos_Count(t *testing.T) {\n  candidate := pos_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, 3, -4}), expected: 2 },\n     { actual: candidate([]int{3, 4, 5, -1}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "go_test.go",
-    "prompt": "package get_ludic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Ludic(t *testing.T) {\n  candidate := get_ludic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []int{1, 2, 3, 5, 7} },\n     { actual: candidate(25), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25} },\n     { actual: candidate(45), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "go_test.go",
-    "prompt": "package find_Index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Index(t *testing.T) {\n  candidate := find_Index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 14 },\n     { actual: candidate(4), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "go_test.go",
-    "prompt": "package reverse_Array_Upto_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to reverse a list upto a given position.\nfunc reverse_Array_Upto_K(input []int, k int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReverse_Array_Upto_K(t *testing.T) {\n  candidate := reverse_Array_Upto_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 4), expected: []int{4, 3, 2, 1, 5, 6} },\n     { actual: candidate([]int{4, 5, 6, 7}, 2), expected: []int{5, 4, 6, 7} },\n     { actual: candidate([]int{9, 8, 7, 6, 5}, 3), expected: []int{7, 8, 9, 6, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "go_test.go",
-    "prompt": "package subject_marks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of lists using the second value of each list.\nfunc subject_marks(subjectmarks [][]interface{}) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSubject_Marks(t *testing.T) {\n  candidate := subject_marks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}, []interface{}{\"Social sciences\", 82}}), expected: [][]int{[]interface{}{\"Social sciences\", 82}, []interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}} },\n     { actual: candidate([][]int{[]interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}, []interface{}{\"Social\", 33}}), expected: [][]int{[]interface{}{\"Social\", 33}, []interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}} },\n     { actual: candidate([][]int{[]interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}, []interface{}{\"Biology\", 45}}), expected: [][]int{[]interface{}{\"Biology\", 45}, []interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "go_test.go",
-    "prompt": "package remove_dirty_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(myString string, second_string string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Dirty_Chars(t *testing.T) {\n  candidate := remove_dirty_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"probasscurve\", \"pros\"), expected: \"bacuve\" },\n     { actual: candidate(\"digitalindia\", \"talent\"), expected: \"digiidi\" },\n     { actual: candidate(\"exoticmiles\", \"toxic\"), expected: \"emles\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "go_test.go",
-    "prompt": "package max_occurrences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Occurrences(t *testing.T) {\n  candidate := max_occurrences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), expected: 2 },\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), expected: 8 },\n     { actual: candidate([]int{10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), expected: 20 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "go_test.go",
-    "prompt": "package is_decimal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Decimal(t *testing.T) {\n  candidate := is_decimal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"123.11\"), expected: true },\n     { actual: candidate(\"e666.86\"), expected: false },\n     { actual: candidate(\"3.124587\"), expected: false },\n     { actual: candidate(\"1.11\"), expected: true },\n     { actual: candidate(\"1.1.11\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "go_test.go",
-    "prompt": "package dict_filter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\nfunc dict_filter(dict map[string]int, n int) map[string]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDict_Filter(t *testing.T) {\n  candidate := dict_filter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170), expected: map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180), expected: map[string]int{\"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190), expected: map[string]int{\"Pierre Cox\": 190} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "go_test.go",
-    "prompt": "package sum_even_and_even_index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Even_And_Even_Index(t *testing.T) {\n  candidate := sum_even_and_even_index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 12, 1, 18, 8}), expected: 30 },\n     { actual: candidate([]int{3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), expected: 26 },\n     { actual: candidate([]int{5, 6, 12, 1}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "go_test.go",
-    "prompt": "package max_sub_array_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a []int, size int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Sub_Array_Sum(t *testing.T) {\n  candidate := max_sub_array_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-2, -3, 4, -1, -2, 1, 5, -3}, 8), expected: 7 },\n     { actual: candidate([]int{-3, -4, 5, -2, -3, 2, 6, -4}, 8), expected: 8 },\n     { actual: candidate([]int{-4, -5, 6, -3, -4, 3, 7, -5}, 8), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "go_test.go",
-    "prompt": "package intersection_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the intersection of two lists.\nfunc intersection_array(array_nums1 []int, array_nums2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIntersection_Array(t *testing.T) {\n  candidate := intersection_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{1, 2, 4, 8, 9}), expected: []int{1, 2, 8, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{3, 5, 7, 9}), expected: []int{3, 5, 7, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{10, 20, 30, 40}), expected: []int{10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "go_test.go",
-    "prompt": "package split_two_parts_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\nfunc split_two_parts(list1 []interface{}, L int) interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSplit_Two_Parts(t *testing.T) {\n  candidate := split_two_parts\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []interface{}{[]int{1, 1, 2}, []int{3, 4, 4, 5, 1}} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, 2), expected: []interface{}{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}} },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}, 4), expected: []interface{}{[]string{\"p\", \"y\", \"t\", \"h\"}, []string{\"o\", \"n\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "go_test.go",
-    "prompt": "package find_literals_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text string, pattern string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Literals(t *testing.T) {\n  candidate := find_literals\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"), expected: []interface{}{\"fox\", 16, 19} },\n     { actual: candidate(\"Its been a very crazy procedure right\", \"crazy\"), expected: []interface{}{\"crazy\", 16, 21} },\n     { actual: candidate(\"Hardest choices required strongest will\", \"will\"), expected: []interface{}{\"will\", 35, 39} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "go_test.go",
-    "prompt": "package find_Volume_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the volume of a triangular prism.\nfunc find_Volume(l int, b int, h int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Volume(t *testing.T) {\n  candidate := find_Volume\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 8, 6), expected: 240 },\n     { actual: candidate(3, 2, 2), expected: 6 },\n     { actual: candidate(1, 2, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "go_test.go",
-    "prompt": "package wind_chill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v int, t int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestWind_Chill(t *testing.T) {\n  candidate := wind_chill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(120, 35), expected: 40 },\n     { actual: candidate(40, 20), expected: 19 },\n     { actual: candidate(10, 8), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "go_test.go",
-    "prompt": "package ascii_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ascii value of a character.\nfunc ascii_value(k string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAscii_Value(t *testing.T) {\n  candidate := ascii_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"A\"), expected: 65 },\n     { actual: candidate(\"R\"), expected: 82 },\n     { actual: candidate(\"S\"), expected: 83 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "go_test.go",
-    "prompt": "package all_Characters_Same_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether all the characters are same or not.\nfunc all_Characters_Same(s string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAll_Characters_Same(t *testing.T) {\n  candidate := all_Characters_Same\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"aaa\"), expected: true },\n     { actual: candidate(\"data\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "go_test.go",
-    "prompt": "package move_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMove_Num(t *testing.T) {\n  candidate := move_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"I1love143you55three3000thousand\"), expected: \"Iloveyouthreethousand1143553000\" },\n     { actual: candidate(\"Avengers124Assemble\"), expected: \"AvengersAssemble124\" },\n     { actual: candidate(\"Its11our12path13to14see15things16do17things\"), expected: \"Itsourpathtoseethingsdothings11121314151617\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "go_test.go",
-    "prompt": "package word_len_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the length of the word is odd or not.\nfunc word_len(s string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestWord_Len(t *testing.T) {\n  candidate := word_len\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hadoop\"), expected: false },\n     { actual: candidate(\"great\"), expected: true },\n     { actual: candidate(\"structure\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "go_test.go",
-    "prompt": "package insert_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list []string, element string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestInsert_Element(t *testing.T) {\n  candidate := insert_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Black\"}, \"c\"), expected: []string{\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"} },\n     { actual: candidate([]string{\"python\", \"java\"}, \"program\"), expected: []string{\"program\", \"python\", \"program\", \"java\"} },\n     { actual: candidate([]string{\"happy\", \"sad\"}, \"laugh\"), expected: []string{\"laugh\", \"happy\", \"laugh\", \"sad\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "go_test.go",
-    "prompt": "package remove_lowercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1 string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Lowercase(t *testing.T) {\n  candidate := remove_lowercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYTHon\"), expected: \"PYTH\" },\n     { actual: candidate(\"FInD\"), expected: \"FID\" },\n     { actual: candidate(\"STRinG\"), expected: \"STRG\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "go_test.go",
-    "prompt": "package count_Set_Bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Set_Bits(t *testing.T) {\n  candidate := count_Set_Bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 1 },\n     { actual: candidate(6), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "go_test.go",
-    "prompt": "package extract_rear_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract only the rear index element of each string in the given list.\nfunc extract_rear(test_tuple []interface{}) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Rear(t *testing.T) {\n  candidate := extract_rear\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"Mers\", \"for\", \"Vers\"}), expected: []string{\"s\", \"r\", \"s\"} },\n     { actual: candidate([]interface{}{\"Avenge\", \"for\", \"People\"}), expected: []string{\"e\", \"r\", \"e\"} },\n     { actual: candidate([]interface{}{\"Gotta\", \"get\", \"go\"}), expected: []string{\"a\", \"t\", \"o\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "go_test.go",
-    "prompt": "package count_occurance_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Occurance(t *testing.T) {\n  candidate := count_occurance\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"letstdlenstdporstd\"), expected: 3 },\n     { actual: candidate(\"truststdsolensporsd\"), expected: 1 },\n     { actual: candidate(\"makestdsostdworthit\"), expected: 2 },\n     { actual: candidate(\"stds\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "go_test.go",
-    "prompt": "package check_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given lists contain the k or not.\nfunc check_K(test_tup []int, K int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_K(t *testing.T) {\n  candidate := check_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 4, 5, 6, 8}, 6), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 7), expected: false },\n     { actual: candidate([]int{7, 8, 9, 44, 11, 12}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "go_test.go",
-    "prompt": "package interleave_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1 []int, list2 []int, list3 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestInterleave_Lists(t *testing.T) {\n  candidate := interleave_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}, []int{10, 20, 30, 40, 50, 60, 70}, []int{100, 200, 300, 400, 500, 600, 700}), expected: []int{1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700} },\n     { actual: candidate([]int{10, 20}, []int{15, 2}, []int{5, 10}), expected: []int{10, 15, 5, 20, 2, 10} },\n     { actual: candidate([]int{11, 44}, []int{10, 15}, []int{20, 5}), expected: []int{11, 10, 20, 44, 15, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "go_test.go",
-    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python_program\"), expected: \"PythonProgram\" },\n     { actual: candidate(\"python_language\"), expected: \"PythonLanguage\" },\n     { actual: candidate(\"programming_language\"), expected: \"ProgrammingLanguage\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "go_test.go",
-    "prompt": "package test_three_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x int, y int, z int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTest_Three_Equal(t *testing.T) {\n  candidate := test_three_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 1, 1), expected: 3 },\n     { actual: candidate(-1, -2, -3), expected: 0 },\n     { actual: candidate(1, 2, 2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "go_test.go",
-    "prompt": "package odd_length_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\nfunc odd_length_sum(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Length_Sum(t *testing.T) {\n  candidate := odd_length_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4}), expected: 14 },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: 15 },\n     { actual: candidate([]int{1, 7}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "go_test.go",
-    "prompt": "package bell_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(10), expected: 115975 },\n     { actual: candidate(56), expected: 6775685320645824322581483068371419745979053216268760300 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "go_test.go",
-    "prompt": "package rectangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the area of a rectangle.\nfunc rectangle_area(l int, b int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRectangle_Area(t *testing.T) {\n  candidate := rectangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(10, 5), expected: 50 },\n     { actual: candidate(4, 2), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "go_test.go",
-    "prompt": "package sum_average_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Average(t *testing.T) {\n  candidate := sum_average\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []interface{}{55, 5.5} },\n     { actual: candidate(15), expected: []interface{}{120, 8.0} },\n     { actual: candidate(20), expected: []interface{}{210, 10.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "go_test.go",
-    "prompt": "package division_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\nfunc division_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDivision_Elements(t *testing.T) {\n  candidate := division_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{2, 2, 2, 3} },\n     { actual: candidate([]interface{}{12, 6, 8, 16}, []interface{}{6, 3, 4, 4}), expected: []interface{}{2, 2, 2, 4} },\n     { actual: candidate([]interface{}{20, 14, 36, 18}, []interface{}{5, 7, 6, 9}), expected: []interface{}{4, 2, 6, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "go_test.go",
-    "prompt": "package sum_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Digits(t *testing.T) {\n  candidate := sum_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(345), expected: 12 },\n     { actual: candidate(12), expected: 3 },\n     { actual: candidate(97), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "go_test.go",
-    "prompt": "package index_minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of lists, write a function that returns the first value of the list with the smallest second value.\nfunc index_minimum(test_list [][]interface{}) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIndex_Minimum(t *testing.T) {\n  candidate := index_minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Rash\", 143}, []interface{}{\"Manjeet\", 200}, []interface{}{\"Varsha\", 100}}), expected: \"Varsha\" },\n     { actual: candidate([][]int{[]interface{}{\"Yash\", 185}, []interface{}{\"Dawood\", 125}, []interface{}{\"Sanya\", 175}}), expected: \"Dawood\" },\n     { actual: candidate([][]int{[]interface{}{\"Sai\", 345}, []interface{}{\"Salman\", 145}, []interface{}{\"Ayesha\", 96}}), expected: \"Ayesha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "go_test.go",
-    "prompt": "package div_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to divide two lists element wise.\nfunc div_list(nums1 []int, nums2 []int) []float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDiv_List(t *testing.T) {\n  candidate := div_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 5, 6}, []int{1, 2, 3}), expected: []float64{4.0, 2.5, 2.0} },\n     { actual: candidate([]int{3, 2}, []int{1, 4}), expected: []float64{3.0, 0.5} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []float64{1.8, 1.7142857142857142} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "go_test.go",
-    "prompt": "package max_length_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list with maximum length.\nfunc max_length_list(input_list [][]int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Length_List(t *testing.T) {\n  candidate := max_length_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}, []int{1, 2, 3}, []int{1, 2}, []int{1}}), expected: []interface{}{5, []int{1, 2, 3, 4, 5}} },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{6, 7, 8, 9}, []int{10, 11, 12}}), expected: []interface{}{4, []int{6, 7, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "go_test.go",
-    "prompt": "package big_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the largest and smallest value in a given list.\nfunc big_sum(nums []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBig_Sum(t *testing.T) {\n  candidate := big_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{-1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{2, 3, 6}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "go_test.go",
-    "prompt": "package neg_nos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to return the negative numbers in a list.\nfunc neg_nos(list1 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNeg_Nos(t *testing.T) {\n  candidate := neg_nos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 4, 5, -6}), expected: []int{-1, -6} },\n     { actual: candidate([]int{-1, -2, 3, 4}), expected: []int{-1, -2} },\n     { actual: candidate([]int{-7, -6, 8, 9}), expected: []int{-7, -6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "go_test.go",
-    "prompt": "package highest_Power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHighest_Power_Of_2(t *testing.T) {\n  candidate := highest_Power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 8 },\n     { actual: candidate(19), expected: 16 },\n     { actual: candidate(32), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "go_test.go",
-    "prompt": "package is_sublist_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l []int, s []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Sublist(t *testing.T) {\n  candidate := is_sublist\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{4, 3}), expected: true },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{1, 6}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "go_test.go",
-    "prompt": "package sub_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1 []int, nums2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSub_List(t *testing.T) {\n  candidate := sub_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: []int{-3, -3, -3} },\n     { actual: candidate([]int{1, 2}, []int{3, 4}), expected: []int{-2, -2} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []int{40, 50} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "go_test.go",
-    "prompt": "package opposite_Signs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x int, y int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOpposite_Signs(t *testing.T) {\n  candidate := opposite_Signs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, -2), expected: true },\n     { actual: candidate(3, 2), expected: false },\n     { actual: candidate(-10, -10), expected: false },\n     { actual: candidate(-2, 2), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "go_test.go",
-    "prompt": "package tuple_modulo_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes two lists of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTuple_Modulo(t *testing.T) {\n  candidate := tuple_modulo\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6}, []interface{}{5, 6, 7, 5}), expected: []interface{}{0, 4, 5, 1} },\n     { actual: candidate([]interface{}{11, 5, 6, 7}, []interface{}{6, 7, 8, 6}), expected: []interface{}{5, 5, 6, 1} },\n     { actual: candidate([]interface{}{12, 6, 7, 8}, []interface{}{7, 8, 9, 7}), expected: []interface{}{5, 6, 7, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "go_test.go",
-    "prompt": "package diff_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1 []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDiff_Even_Odd(t *testing.T) {\n  candidate := diff_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 1 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "go_test.go",
-    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1 [][]string) [][]string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"d\", \"c\"}, []string{\"g\", \"h\"}, []string{\"f\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}, []string{\"g\", \"h\"}, []string{\"e\", \"f\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "go_test.go",
-    "prompt": "package last_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last digit of a given number.\nfunc last_Digit(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLast_Digit(t *testing.T) {\n  candidate := last_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 3 },\n     { actual: candidate(25), expected: 5 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "go_test.go",
-    "prompt": "package odd_num_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Num_Sum(t *testing.T) {\n  candidate := odd_num_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 82 },\n     { actual: candidate(3), expected: 707 },\n     { actual: candidate(4), expected: 3108 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "go_test.go",
-    "prompt": "package tup_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a string.\nfunc tup_string(tup1 []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTup_String(t *testing.T) {\n  candidate := tup_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"}), expected: \"exercises\" },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}), expected: \"python\" },\n     { actual: candidate([]string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"}), expected: \"program\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "go_test.go",
-    "prompt": "package remove_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1 []int, list2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Elements(t *testing.T) {\n  candidate := remove_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{1, 3, 5, 7}), expected: []int{2, 4, 6, 8, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{5, 7}), expected: []int{1, 2, 3, 4, 6, 8, 9, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "go_test.go",
-    "prompt": "package overlapping_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1 []int, list2 []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOverlapping(t *testing.T) {\n  candidate := overlapping\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 8, 9}), expected: false },\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 4, 5}, []int{1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "go_test.go",
-    "prompt": "package is_not_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to identify non-prime numbers.\nfunc is_not_prime(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Not_Prime(t *testing.T) {\n  candidate := is_not_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: false },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(35), expected: true },\n     { actual: candidate(37), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "go_test.go",
-    "prompt": "package sum_negativenum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Negativenum(t *testing.T) {\n  candidate := sum_negativenum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: -32 },\n     { actual: candidate([]int{10, 15, -14, 13, -18, 12, -20}), expected: -52 },\n     { actual: candidate([]int{19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), expected: -894 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "go_test.go",
-    "prompt": "package find_Rotations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Rotations(t *testing.T) {\n  candidate := find_Rotations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aaaa\"), expected: 1 },\n     { actual: candidate(\"ab\"), expected: 2 },\n     { actual: candidate(\"abc\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "go_test.go",
-    "prompt": "package change_date_format_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestChange_Date_Format(t *testing.T) {\n  candidate := change_date_format\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"2026-01-02\"), expected: \"02-01-2026\" },\n     { actual: candidate(\"2020-11-13\"), expected: \"13-11-2020\" },\n     { actual: candidate(\"2021-04-26\"), expected: \"26-04-2021\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "go_test.go",
-    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of integers and only returns the odd ones.\nfunc Split(list []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: []int{1, 3, 5} },\n     { actual: candidate([]int{10, 11, 12, 13}), expected: []int{11, 13} },\n     { actual: candidate([]int{7, 8, 9, 1}), expected: []int{7, 9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "go_test.go",
-    "prompt": "package toggle_middle_bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestToggle_Middle_Bits(t *testing.T) {\n  candidate := toggle_middle_bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 15 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(11), expected: 13 },\n     { actual: candidate(65), expected: 127 },\n     { actual: candidate(77), expected: 115 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "go_test.go",
-    "prompt": "package count_char_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1 string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Char_Position(t *testing.T) {\n  candidate := count_char_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xbcefg\"), expected: 2 },\n     { actual: candidate(\"ABcED\"), expected: 3 },\n     { actual: candidate(\"AbgdeF\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "go_test.go",
-    "prompt": "package large_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1 []int, nums2 []int, N int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLarge_Product(t *testing.T) {\n  candidate := large_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 3), expected: []int{60, 54, 50} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 4), expected: []int{60, 54, 50, 48} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 5), expected: []int{60, 54, 50, 48, 45} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "go_test.go",
-    "prompt": "package cummulative_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list [][]int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCummulative_Sum(t *testing.T) {\n  candidate := cummulative_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 6, 7}, []int{2, 6}}), expected: 30 },\n     { actual: candidate([][]int{[]int{2, 4}, []int{6, 7, 8}, []int{3, 7}}), expected: 37 },\n     { actual: candidate([][]int{[]int{3, 5}, []int{7, 8, 9}, []int{4, 8}}), expected: 44 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "go_test.go",
-    "prompt": "package find_min_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr []int, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Min_Diff(t *testing.T) {\n  candidate := find_min_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 3, 19, 18, 25}, 6), expected: 1 },\n     { actual: candidate([]int{4, 3, 2, 6}, 4), expected: 1 },\n     { actual: candidate([]int{30, 5, 20, 9}, 4), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "go_test.go",
-    "prompt": "package text_starta_endb_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Starta_Endb(t *testing.T) {\n  candidate := text_starta_endb\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aabbbb\"), expected: true },\n     { actual: candidate(\"aabAbbbc\"), expected: false },\n     { actual: candidate(\"accddbbjjj\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "go_test.go",
-    "prompt": "package left_rotate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n int, d int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLeft_Rotate(t *testing.T) {\n  candidate := left_rotate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: 64 },\n     { actual: candidate(10, 2), expected: 40 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(1, 3), expected: 8 },\n     { actual: candidate(5, 3), expected: 40 },\n     { actual: candidate(29, 3), expected: 232 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "go_test.go",
-    "prompt": "package get_Inv_Count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count inversions in a list.\nfunc get_Inv_Count(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Inv_Count(t *testing.T) {\n  candidate := get_Inv_Count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 20, 6, 4, 5}), expected: 5 },\n     { actual: candidate([]int{1, 2, 1}), expected: 1 },\n     { actual: candidate([]int{1, 2, 5, 6, 1}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "go_test.go",
-    "prompt": "package even_Power_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEven_Power_Sum(t *testing.T) {\n  candidate := even_Power_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1056 },\n     { actual: candidate(3), expected: 8832 },\n     { actual: candidate(1), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "go_test.go",
-    "prompt": "package get_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input [][]int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Equal(t *testing.T) {\n  candidate := get_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{11, 22, 33}, []int{44, 55, 66}}), expected: true },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6, 7}}), expected: false },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "go_test.go",
-    "prompt": "package check_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string represents an integer or not.\nfunc check_integer(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Integer(t *testing.T) {\n  candidate := check_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"1\"), expected: true },\n     { actual: candidate(\"12345\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "go_test.go",
-    "prompt": "package count_reverse_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/gothon-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list []string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Reverse_Pairs(t *testing.T) {\n  candidate := count_reverse_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"}), expected: 2 },\n     { actual: candidate([]string{\"geeks\", \"best\", \"for\", \"skeeg\"}), expected: 1 },\n     { actual: candidate([]string{\"makes\", \"best\", \"sekam\", \"for\", \"rof\"}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "go_test.go",
-    "prompt": "package move_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to move all zeroes to the end of the given list.\nfunc move_zero(num_list []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMove_Zero(t *testing.T) {\n  candidate := move_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 0, 2, 0, 3, 4}), expected: []int{1, 2, 3, 4, 0, 0} },\n     { actual: candidate([]int{2, 3, 2, 0, 0, 4, 0, 5, 0}), expected: []int{2, 3, 2, 4, 5, 0, 0, 0, 0} },\n     { actual: candidate([]int{0, 1, 0, 1, 1}), expected: []int{1, 1, 1, 0, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "go_test.go",
-    "prompt": "package check_distinct_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Distinct(t *testing.T) {\n  candidate := check_distinct\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 5, 6, 1, 4}), expected: false },\n     { actual: candidate([]int{1, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 6}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "go_test.go",
-    "prompt": "package noprofit_noloss_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost int, sale_amount int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNoprofit_Noloss(t *testing.T) {\n  candidate := noprofit_noloss\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: false },\n     { actual: candidate(100, 100), expected: true },\n     { actual: candidate(2000, 5000), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "go_test.go",
-    "prompt": "package remove_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str string, K int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Length(t *testing.T) {\n  candidate := remove_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The person is most value tet\", 3), expected: \"person is most value\" },\n     { actual: candidate(\"If you told me about this ok\", 4), expected: \"If you me about ok\" },\n     { actual: candidate(\"Forces of darkeness is come into the play\", 4), expected: \"Forces of darkeness is the\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "go_test.go",
-    "prompt": "package number_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count number of digits in a given string.\nfunc number_ctr(str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNumber_Ctr(t *testing.T) {\n  candidate := number_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"program2bedone\"), expected: 1 },\n     { actual: candidate(\"3wonders\"), expected: 1 },\n     { actual: candidate(\"123\"), expected: 3 },\n     { actual: candidate(\"3wond-1ers2\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "go_test.go",
-    "prompt": "package count_charac_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the total number of characters in a string.\nfunc count_charac(str1 string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Charac(t *testing.T) {\n  candidate := count_charac\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: 18 },\n     { actual: candidate(\"language\"), expected: 8 },\n     { actual: candidate(\"words\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "go_test.go",
-    "prompt": "package get_total_number_of_sequences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m int, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Total_Number_Of_Sequences(t *testing.T) {\n  candidate := get_total_number_of_sequences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 4), expected: 4 },\n     { actual: candidate(5, 2), expected: 6 },\n     { actual: candidate(16, 3), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "go_test.go",
-    "prompt": "package left_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/gothon-exercises/data-structures-and-algorithms/gothon-data-structure-exercise-24.php\nfunc left_insertion(a []int, x int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLeft_Insertion(t *testing.T) {\n  candidate := left_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "go_test.go",
-    "prompt": "package swap_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a int, b int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSwap_Numbers(t *testing.T) {\n  candidate := swap_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: []int{20, 10} },\n     { actual: candidate(15, 17), expected: []int{17, 15} },\n     { actual: candidate(100, 200), expected: []int{200, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "go_test.go",
-    "prompt": "package is_majority_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr []int, n int, x int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Majority(t *testing.T) {\n  candidate := is_majority\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 3, 3, 3, 10}, 7, 3), expected: true },\n     { actual: candidate([]int{1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), expected: false },\n     { actual: candidate([]int{1, 1, 1, 2, 2}, 5, 1), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2}, 5, 1), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "go_test.go",
-    "prompt": "package substract_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\nfunc substract_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSubstract_Elements(t *testing.T) {\n  candidate := substract_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5}, []interface{}{2, 5, 18}), expected: []interface{}{8, -1, -13} },\n     { actual: candidate([]interface{}{11, 2, 3}, []interface{}{24, 45, 16}), expected: []interface{}{-13, -43, -13} },\n     { actual: candidate([]interface{}{7, 18, 9}, []interface{}{10, 11, 12}), expected: []interface{}{-3, 7, -3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "go_test.go",
-    "prompt": "package capital_words_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1 string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCapital_Words_Spaces(t *testing.T) {\n  candidate := capital_words_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"PythonProgrammingExamples\"), expected: \"Python Programming Examples\" },\n     { actual: candidate(\"GetReadyToBeCodingFreak\"), expected: \"Get Ready To Be Coding Freak\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "go_test.go",
-    "prompt": "package find_Average_Of_Cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Average_Of_Cube(t *testing.T) {\n  candidate := find_Average_Of_Cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4.5 },\n     { actual: candidate(3), expected: 12 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "go_test.go",
-    "prompt": "package check_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all values are same in a map.\nfunc check_value(dict map[string]int, n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Value(t *testing.T) {\n  candidate := check_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10), expected: false },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12), expected: true },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "go_test.go",
-    "prompt": "package tetrahedral_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTetrahedral_Number(t *testing.T) {\n  candidate := tetrahedral_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 35 },\n     { actual: candidate(6), expected: 56 },\n     { actual: candidate(7), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "go_test.go",
-    "prompt": "package magic_square_test_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix [][]int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMagic_Square_Test(t *testing.T) {\n  candidate := magic_square_test\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{7, 12, 1, 14}, []int{2, 13, 8, 11}, []int{16, 3, 10, 5}, []int{9, 6, 15, 4}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 8}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 7}}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "go_test.go",
-    "prompt": "package remove_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1 string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Uppercase(t *testing.T) {\n  candidate := remove_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"cAstyoUrFavoRitETVshoWs\"), expected: \"cstyoravoitshos\" },\n     { actual: candidate(\"wAtchTheinTernEtrAdIo\"), expected: \"wtchheinerntrdo\" },\n     { actual: candidate(\"VoicESeaRchAndreComMendaTionS\"), expected: \"oiceachndreomendaion\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "go_test.go",
-    "prompt": "package dog_age_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDog_Age(t *testing.T) {\n  candidate := dog_age\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 61 },\n     { actual: candidate(15), expected: 73 },\n     { actual: candidate(24), expected: 109 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "go_test.go",
-    "prompt": "package next_Perfect_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNext_Perfect_Square(t *testing.T) {\n  candidate := next_Perfect_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(35), expected: 36 },\n     { actual: candidate(6), expected: 9 },\n     { actual: candidate(9), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "go_test.go",
-    "prompt": "package is_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert a given string to uppercase.\nfunc is_upper(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Upper(t *testing.T) {\n  candidate := is_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"person\"), expected: \"PERSON\" },\n     { actual: candidate(\"final\"), expected: \"FINAL\" },\n     { actual: candidate(\"Valid\"), expected: \"VALID\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "go_test.go",
-    "prompt": "package odd_Equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s string, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Equivalent(t *testing.T) {\n  candidate := odd_Equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"011001\", 6), expected: 3 },\n     { actual: candidate(\"11011\", 5), expected: 4 },\n     { actual: candidate(\"1010\", 4), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "go_test.go",
-    "prompt": "package re_arrange_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr []int, n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRe_Arrange_Array(t *testing.T) {\n  candidate := re_arrange_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), expected: []int{-1, -3, -7, 4, 5, 6, 2, 8, 9} },\n     { actual: candidate([]int{12, -14, -26, 13, 15}, 5), expected: []int{-14, -26, 12, 13, 15} },\n     { actual: candidate([]int{10, 24, 36, -42, -39, -78, 85}, 7), expected: []int{-42, -39, -78, 10, 24, 36, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "go_test.go",
-    "prompt": "package unique_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUnique_Element(t *testing.T) {\n  candidate := unique_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "go_test.go",
-    "prompt": "package extract_values_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Values(t *testing.T) {\n  candidate := extract_values\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"Python\", \"PHP\", \"Java\"\"), expected: []string{\"Python\", \"PHP\", \"Java\"} },\n     { actual: candidate(\"\"python\",\"program\",\"language\"\"), expected: []string{\"python\", \"program\", \"language\"} },\n     { actual: candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"), expected: []string{\"red\", \"blue\", \"green\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "go_test.go",
-    "prompt": "package count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count true booleans in the given list.\nfunc count(lst []bool) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount(t *testing.T) {\n  candidate := count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]UNKNOWN{true, false, true}), expected: 2 },\n     { actual: candidate([]UNKNOWN{false, false}), expected: 0 },\n     { actual: candidate([]UNKNOWN{true, true, true}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "go_test.go",
-    "prompt": "package find_even_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Even_Pair(t *testing.T) {\n  candidate := find_even_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}), expected: 4 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}), expected: 9 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "go_test.go",
-    "prompt": "package armstrong_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestArmstrong_Number(t *testing.T) {\n  candidate := armstrong_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(153), expected: true },\n     { actual: candidate(259), expected: false },\n     { actual: candidate(4458), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "go_test.go",
-    "prompt": "package upper_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the upper case characters in a given string.\nfunc upper_ctr(str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUpper_Ctr(t *testing.T) {\n  candidate := upper_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYthon\"), expected: 1 },\n     { actual: candidate(\"BigData\"), expected: 1 },\n     { actual: candidate(\"program\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "go_test.go",
-    "prompt": "package and_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the elementwise and lists from the given two lists.\nfunc and_tuples(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAnd_Tuples(t *testing.T) {\n  candidate := and_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{0, 0, 2, 1} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{5, 6, 7, 8}), expected: []interface{}{1, 2, 3, 0} },\n     { actual: candidate([]interface{}{8, 9, 11, 12}, []interface{}{7, 13, 14, 17}), expected: []interface{}{0, 9, 10, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "go_test.go",
-    "prompt": "package is_samepatterns_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether it follows the sequence given in the patterns list.\nfunc is_samepatterns(colors []string, patterns []string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Samepatterns(t *testing.T) {\n  candidate := is_samepatterns\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"green\", \"green\"}, []string{\"a\", \"b\", \"b\"}), expected: true },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\", \"b\"}), expected: false },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\"}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "go_test.go",
-    "prompt": "package count_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of lists in a given number of lists.\nfunc count_list(input_list [][]int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_List(t *testing.T) {\n  candidate := count_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{2, 3}, []int{4, 5}}), expected: 3 },\n     { actual: candidate([][]int{[]int{1, 0}, []int{2, 0}}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "go_test.go",
-    "prompt": "package average_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums [][]int) []float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAverage_Tuple(t *testing.T) {\n  candidate := average_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{10, 10, 10, 12}, []int{30, 45, 56, 45}, []int{81, 80, 39, 32}, []int{1, 2, 3, 4}}), expected: []float64{30.5, 34.25, 27.0, 23.25} },\n     { actual: candidate([][]int{[]int{1, 1, -5}, []int{30, -15, 56}, []int{81, -60, -39}, []int{-10, 2, 3}}), expected: []float64{25.5, -18.0, 3.75} },\n     { actual: candidate([][]int{[]int{100, 100, 100, 120}, []int{300, 450, 560, 450}, []int{810, 800, 390, 320}, []int{10, 20, 30, 40}}), expected: []float64{305.0, 342.5, 270.0, 232.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "go_test.go",
-    "prompt": "package lcs_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X string, Y string, Z string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLcs_Of_Three(t *testing.T) {\n  candidate := lcs_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"), expected: 2 },\n     { actual: candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"), expected: 5 },\n     { actual: candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "go_test.go",
-    "prompt": "package find_star_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th star number.\nfunc find_star_num(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Star_Num(t *testing.T) {\n  candidate := find_star_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 37 },\n     { actual: candidate(4), expected: 73 },\n     { actual: candidate(5), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "go_test.go",
-    "prompt": "package _sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of a list.\nfunc _sum(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func Test_Sum(t *testing.T) {\n  candidate := _sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{15, 12, 13, 10}), expected: 50 },\n     { actual: candidate([]int{0, 1, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "go_test.go",
-    "prompt": "package check_Consecutive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Consecutive(t *testing.T) {\n  candidate := check_Consecutive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 2, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "go_test.go",
-    "prompt": "package find_adverb_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Adverb_Position(t *testing.T) {\n  candidate := find_adverb_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"clearly!! we can see the sky\"), expected: []interface{}{0, 7, \"clearly\"} },\n     { actual: candidate(\"seriously!! there are many roses\"), expected: []interface{}{0, 9, \"seriously\"} },\n     { actual: candidate(\"unfortunately!! sita is going to home\"), expected: []interface{}{0, 13, \"unfortunately\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "go_test.go",
-    "prompt": "package rotate_right_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/gothon-program-right-rotate-list-n/\nfunc rotate_right(list []int, m int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRotate_Right(t *testing.T) {\n  candidate := rotate_right\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), expected: []int{8, 9, 10, 1, 2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{9, 10, 1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), expected: []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "go_test.go",
-    "prompt": "package number_of_substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNumber_Of_Substrings(t *testing.T) {\n  candidate := number_of_substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: 6 },\n     { actual: candidate(\"abcd\"), expected: 10 },\n     { actual: candidate(\"abcde\"), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "go_test.go",
-    "prompt": "package list_split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S []interface{}, step int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestList_Split(t *testing.T) {\n  candidate := list_split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"}, 3), expected: [][]int{[]string{\"a\", \"d\", \"g\", \"j\", \"m\"}, []string{\"b\", \"e\", \"h\", \"k\", \"n\"}, []string{\"c\", \"f\", \"i\", \"l\"}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), expected: [][]int{[]int{1, 4, 7, 10, 13}, []int{2, 5, 8, 11, 14}, []int{3, 6, 9, 12}} },\n     { actual: candidate([]string{\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"}, 2), expected: [][]int{[]string{\"python\", \"C\", \"DBMS\"}, []string{\"java\", \"C++\", \"SQL\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "go_test.go",
-    "prompt": "package all_unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAll_Unique(t *testing.T) {\n  candidate := all_unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "go_test.go",
-    "prompt": "package convert_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert complex numbers to polar coordinates.\nfunc convert(numbers int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestConvert(t *testing.T) {\n  candidate := convert\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: []interface{}{1.0, 0.0} },\n     { actual: candidate(4), expected: []interface{}{4.0, 0.0} },\n     { actual: candidate(5), expected: []interface{}{5.0, 0.0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "go_test.go",
-    "prompt": "package is_lower_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert the given string to lower case.\nfunc is_lower(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Lower(t *testing.T) {\n  candidate := is_lower\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"InValid\"), expected: \"invalid\" },\n     { actual: candidate(\"TruE\"), expected: \"true\" },\n     { actual: candidate(\"SenTenCE\"), expected: \"sentence\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "go_test.go",
-    "prompt": "package next_power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNext_Power_Of_2(t *testing.T) {\n  candidate := next_power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: 1 },\n     { actual: candidate(5), expected: 8 },\n     { actual: candidate(17), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "go_test.go",
-    "prompt": "package find_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1 []string, sub_str string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Substring(t *testing.T) {\n  candidate := find_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ack\"), expected: true },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"abc\"), expected: false },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ange\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "go_test.go",
-    "prompt": "package replace_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace characters in a string.\nfunc replace_char(str1 string, ch string, newch string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_Char(t *testing.T) {\n  candidate := replace_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"polygon\", \"y\", \"l\"), expected: \"pollgon\" },\n     { actual: candidate(\"character\", \"c\", \"a\"), expected: \"aharaater\" },\n     { actual: candidate(\"python\", \"l\", \"a\"), expected: \"python\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "go_test.go",
-    "prompt": "package mul_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1 []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMul_Even_Odd(t *testing.T) {\n  candidate := mul_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "go_test.go",
-    "prompt": "package list_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a list.\nfunc list_tuple(listx []int) interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestList_Tuple(t *testing.T) {\n  candidate := list_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 10, 7, 4, 15, 3}), expected: []interface{}{5, 10, 7, 4, 15, 3} },\n     { actual: candidate([]int{2, 4, 5, 6, 2, 3, 4, 4, 7}), expected: []interface{}{2, 4, 5, 6, 2, 3, 4, 4, 7} },\n     { actual: candidate([]int{58, 44, 56}), expected: []interface{}{58, 44, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "go_test.go",
-    "prompt": "package even_binomial_Coeff_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEven_Binomial_Coeff_Sum(t *testing.T) {\n  candidate := even_binomial_Coeff_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 8 },\n     { actual: candidate(6), expected: 32 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "go_test.go",
-    "prompt": "package bitwise_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform the mathematical bitwise xor operation across the given lists.\nfunc bitwise_xor(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBitwise_Xor(t *testing.T) {\n  candidate := bitwise_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{15, 6, 5, 10} },\n     { actual: candidate([]interface{}{11, 5, 7, 10}, []interface{}{6, 3, 4, 4}), expected: []interface{}{13, 6, 3, 14} },\n     { actual: candidate([]interface{}{12, 6, 8, 11}, []interface{}{7, 4, 5, 6}), expected: []interface{}{11, 2, 13, 13} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "go_test.go",
-    "prompt": "package is_Sub_Array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A []int, B []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Sub_Array(t *testing.T) {\n  candidate := is_Sub_Array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 5}, []int{1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 1}, []int{1, 2, 1}), expected: true },\n     { actual: candidate([]int{1, 0, 2, 2}, []int{2, 2, 0}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "go_test.go",
-    "prompt": "package max_sub_array_sum_repeated_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\nfunc max_sub_array_sum_repeated(a []int, n int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Sub_Array_Sum_Repeated(t *testing.T) {\n  candidate := max_sub_array_sum_repeated\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, -30, -1}, 4, 3), expected: 30 },\n     { actual: candidate([]int{-1, 10, 20}, 3, 2), expected: 59 },\n     { actual: candidate([]int{-1, -2, -3}, 3, 3), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "go_test.go",
-    "prompt": "package min_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the minimum product from the pairs of lists within a given list.\nfunc min_product_tuple(list1 [][]interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMin_Product_Tuple(t *testing.T) {\n  candidate := min_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 8 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 30 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "go_test.go",
-    "prompt": "package count_divisors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the count of divisors is even. https://www.w3resource.com/gothon-exercises/basic/gothon-basic-1-exercise-24.php\nfunc count_divisors(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Divisors(t *testing.T) {\n  candidate := count_divisors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(100), expected: false },\n     { actual: candidate(125), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "go_test.go",
-    "prompt": "package string_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1 string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestString_To_Tuple(t *testing.T) {\n  candidate := string_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python 3.0\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"} },\n     { actual: candidate(\"item1\"), expected: []string{\"i\", \"t\", \"e\", \"m\", \"1\"} },\n     { actual: candidate(\"15.10\"), expected: []string{\"1\", \"5\", \".\", \"1\", \"0\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "go_test.go",
-    "prompt": "package find_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(myString string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Length(t *testing.T) {\n  candidate := find_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"11000010001\"), expected: 6 },\n     { actual: candidate(\"10111\"), expected: 1 },\n     { actual: candidate(\"11011101100101\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "go_test.go",
-    "prompt": "package count_Primes_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Primes_Nums(t *testing.T) {\n  candidate := count_Primes_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 2 },\n     { actual: candidate(10), expected: 4 },\n     { actual: candidate(100), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "go_test.go",
-    "prompt": "package sum_Of_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Of_Product(t *testing.T) {\n  candidate := sum_Of_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15 },\n     { actual: candidate(4), expected: 56 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "go_test.go",
-    "prompt": "package max_aggregate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the maximum aggregate from the list of lists.\nfunc max_aggregate(stdata [][]interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Aggregate(t *testing.T) {\n  candidate := max_aggregate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 90}, []interface{}{\"Sabah Colley\", 88}, []interface{}{\"Peter Nichols\", 7}, []interface{}{\"Juan Whelan\", 122}, []interface{}{\"Sabah Colley\", 84}}), expected: []interface{}{\"Juan Whelan\", 212} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 50}, []interface{}{\"Sabah Colley\", 48}, []interface{}{\"Peter Nichols\", 37}, []interface{}{\"Juan Whelan\", 22}, []interface{}{\"Sabah Colley\", 14}}), expected: []interface{}{\"Juan Whelan\", 72} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 10}, []interface{}{\"Sabah Colley\", 20}, []interface{}{\"Peter Nichols\", 30}, []interface{}{\"Juan Whelan\", 40}, []interface{}{\"Sabah Colley\", 50}}), expected: []interface{}{\"Sabah Colley\", 70} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "go_test.go",
-    "prompt": "package comb_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc comb_sort(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestComb_Sort(t *testing.T) {\n  candidate := comb_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 15, 37, 25, 79}), expected: []int{5, 15, 25, 37, 79} },\n     { actual: candidate([]int{41, 32, 15, 19, 22}), expected: []int{15, 19, 22, 32, 41} },\n     { actual: candidate([]int{99, 15, 13, 47}), expected: []int{13, 15, 47, 99} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "go_test.go",
-    "prompt": "package check_expression_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Expression(t *testing.T) {\n  candidate := check_expression\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"{()}[{}]\"), expected: true },\n     { actual: candidate(\"{()}[{]\"), expected: false },\n     { actual: candidate(\"{()}[{}][]({})\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "go_test.go",
-    "prompt": "package text_match_wordz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_Wordz(t *testing.T) {\n  candidate := text_match_wordz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonz.\"), expected: true },\n     { actual: candidate(\"xyz.\"), expected: true },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "go_test.go",
-    "prompt": "package sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1 []int, lst2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_List(t *testing.T) {\n  candidate := sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30}, []int{15, 25, 35}), expected: []int{25, 45, 65} },\n     { actual: candidate([]int{1, 2, 3}, []int{5, 6, 7}), expected: []int{6, 8, 10} },\n     { actual: candidate([]int{15, 20, 30}, []int{15, 45, 75}), expected: []int{30, 65, 105} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "go_test.go",
-    "prompt": "package newman_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNewman_Prime(t *testing.T) {\n  candidate := newman_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 7 },\n     { actual: candidate(4), expected: 17 },\n     { actual: candidate(5), expected: 41 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "go_test.go",
-    "prompt": "package add_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_ []interface{}, myString string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_String(t *testing.T) {\n  candidate := add_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, \"temp{0}\"), expected: []string{\"temp1\", \"temp2\", \"temp3\", \"temp4\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, \"python{0}\"), expected: []string{\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"} },\n     { actual: candidate([]int{5, 6, 7, 8}, \"string{0}\"), expected: []string{\"string5\", \"string6\", \"string7\", \"string8\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "go_test.go",
-    "prompt": "package surface_Area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the surface area of a square goramid with a given base edge and height.\nfunc surface_Area(b int, s int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSurface_Area(t *testing.T) {\n  candidate := surface_Area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 33 },\n     { actual: candidate(4, 5), expected: 56 },\n     { actual: candidate(1, 2), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "go_test.go",
-    "prompt": "package Find_Min_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst [][]int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Min_Length(t *testing.T) {\n  candidate := Find_Min_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}}), expected: 1 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{1, 2, 3}, []int{1, 2, 3, 4}}), expected: 2 },\n     { actual: candidate([][]int{[]int{3, 3, 3}, []int{4, 4, 4, 4}}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "go_test.go",
-    "prompt": "package validate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestValidate(t *testing.T) {\n  candidate := validate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1234), expected: true },\n     { actual: candidate(51241), expected: false },\n     { actual: candidate(321), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "go_test.go",
-    "prompt": "package hexagonal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHexagonal_Num(t *testing.T) {\n  candidate := hexagonal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 190 },\n     { actual: candidate(5), expected: 45 },\n     { actual: candidate(7), expected: 91 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "go_test.go",
-    "prompt": "package find_lucas_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th lucas number.\nfunc find_lucas(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Lucas(t *testing.T) {\n  candidate := find_lucas\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 76 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(3), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "go_test.go",
-    "prompt": "package Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to get the difference between two lists.\nfunc Diff(li1 []int, li2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDiff(t *testing.T) {\n  candidate := Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 15, 20, 25, 30, 35, 40}, []int{25, 40, 35}), expected: []int{10, 20, 30, 15} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 1}), expected: []int{2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3}, []int{6, 7, 1}), expected: []int{2, 3, 6, 7} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "go_test.go",
-    "prompt": "package extract_quotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1 string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Quotation(t *testing.T) {\n  candidate := extract_quotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"), expected: []string{\"A53\", \"multi\", \"Processor\"} },\n     { actual: candidate(\"Cast your \"favorite\" entertainment \"apps\"\"), expected: []string{\"favorite\", \"apps\"} },\n     { actual: candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"), expected: []string{\"4k Ultra HD\", \"HDR 10\"} },\n     { actual: candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "go_test.go",
-    "prompt": "package differ_At_One_Bit_Pos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a int, b int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDiffer_At_One_Bit_Pos(t *testing.T) {\n  candidate := differ_At_One_Bit_Pos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13, 9), expected: true },\n     { actual: candidate(15, 8), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(2, 3), expected: true },\n     { actual: candidate(5, 1), expected: true },\n     { actual: candidate(1, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "go_test.go",
-    "prompt": "package text_match_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_Three(t *testing.T) {\n  candidate := text_match_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"caacabbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "go_test.go",
-    "prompt": "package max_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\nfunc max_product(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 100, 4, 5, 150, 6}), expected: 3000 },\n     { actual: candidate([]int{4, 42, 55, 68, 80}), expected: 50265600 },\n     { actual: candidate([]int{10, 22, 9, 33, 21, 50, 41, 60}), expected: 2460 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "go_test.go",
-    "prompt": "package split_Arr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l []int, n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSplit_Arr(t *testing.T) {\n  candidate := split_Arr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 10, 5, 6, 52, 36}, 2), expected: []int{5, 6, 52, 36, 12, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, 1), expected: []int{2, 3, 4, 1} },\n     { actual: candidate([]int{0, 1, 2, 3, 4, 5, 6, 7}, 3), expected: []int{3, 4, 5, 6, 7, 0, 1, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "go_test.go",
-    "prompt": "package divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the number of divisors of a given integer.\nfunc divisor(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDivisor(t *testing.T) {\n  candidate := divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 4 },\n     { actual: candidate(12), expected: 6 },\n     { actual: candidate(9), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "go_test.go",
-    "prompt": "package big_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestBig_Diff(t *testing.T) {\n  candidate := big_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{4, 5, 12}), expected: 8 },\n     { actual: candidate([]int{9, 2, 3}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "go_test.go",
-    "prompt": "package square_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSquare_Nums(t *testing.T) {\n  candidate := square_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{100, 400, 900} },\n     { actual: candidate([]int{12, 15}), expected: []int{144, 225} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "go_test.go",
-    "prompt": "package check_none_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given list has any none value or not.\nfunc check_none(test_tup interface{}) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_None(t *testing.T) {\n  candidate := check_none\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6, nil}), expected: true },\n     { actual: candidate([]interface{}{7, 8, 9, 11, 14}), expected: false },\n     { actual: candidate([]interface{}{1, 2, 3, 4, nil}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "go_test.go",
-    "prompt": "package is_Monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given list is monotonic or not.\nfunc is_Monotonic(A []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Monotonic(t *testing.T) {\n  candidate := is_Monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{6, 5, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 3, 2}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "go_test.go",
-    "prompt": "package is_perfect_square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Perfect_Square(t *testing.T) {\n  candidate := is_perfect_square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: false },\n     { actual: candidate(36), expected: true },\n     { actual: candidate(14), expected: false },\n     { actual: candidate(196), expected: true },\n     { actual: candidate(125), expected: false },\n     { actual: candidate(15625), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "go_test.go",
-    "prompt": "package sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of common divisors of two given numbers.\nfunc sum(a int, b int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum(t *testing.T) {\n  candidate := sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 15), expected: 6 },\n     { actual: candidate(100, 150), expected: 93 },\n     { actual: candidate(4, 6), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "go_test.go",
-    "prompt": "package max_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1 [][]int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Length(t *testing.T) {\n  candidate := max_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1}, []int{5, 7}, []int{10, 12, 14, 15}}), expected: []interface{}{4, []int{10, 12, 14, 15}} },\n     { actual: candidate([][]int{[]int{5}, []int{15, 20, 25}}), expected: []interface{}{3, []int{15, 20, 25}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "go_test.go",
-    "prompt": "package parabola_directrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a int, b int, c int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestParabola_Directrix(t *testing.T) {\n  candidate := parabola_directrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3, 2), expected: -198 },\n     { actual: candidate(9, 8, 4), expected: -2336 },\n     { actual: candidate(2, 4, 6), expected: -130 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "go_test.go",
-    "prompt": "package remove_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lists from the given list.\nfunc remove_nested(test_tup interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Nested(t *testing.T) {\n  candidate := remove_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, []interface{}{4, 6}, 10}), expected: []interface{}{1, 5, 7, 10} },\n     { actual: candidate([]interface{}{2, 6, 8, []interface{}{5, 7}, 11}), expected: []interface{}{2, 6, 8, 11} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, 12}), expected: []interface{}{3, 7, 9, 12} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, []interface{}{5, 12}, 12}), expected: []interface{}{3, 7, 9, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "go_test.go",
-    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list [][]string) [][]string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\" red \", \"green\"}, []string{\"blue \", \" black\"}, []string{\" orange\", \"brown\"}}), expected: [][]int{[]string{\" red \", \"green\"}, []string{\" black\", \"blue \"}, []string{\" orange\", \"brown\"}} },\n     { actual: candidate([][]int{[]string{\"zilver\", \"gold\"}, []string{\"magnesium\", \"aluminium\"}, []string{\"steel\", \"bronze\"}}), expected: [][]int{[]string{\"gold\", \"zilver\"}, []string{\"aluminium\", \"magnesium\"}, []string{\"bronze\", \"steel\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "go_test.go",
-    "prompt": "package remove_kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1 []int, L int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Kth_Element(t *testing.T) {\n  candidate := remove_kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []int{1, 1, 3, 4, 4, 5, 1} },\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), expected: []int{0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), expected: []int{10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "go_test.go",
-    "prompt": "package add_dict_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add a map to the list. The output should be a list.\nfunc add_dict_to_tuple(test_tup []interface{}, test_dict map[string]int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Dict_To_Tuple(t *testing.T) {\n  candidate := add_dict_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, 6}, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}), expected: []interface{}{4, 5, 6, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}} },\n     { actual: candidate([]interface{}{1, 2, 3}, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}), expected: []interface{}{1, 2, 3, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}} },\n     { actual: candidate([]interface{}{8, 9, 10}, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}), expected: []interface{}{8, 9, 10, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "go_test.go",
-    "prompt": "package find_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n int, m int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind(t *testing.T) {\n  candidate := find\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 3), expected: 3 },\n     { actual: candidate(4, 2), expected: 2 },\n     { actual: candidate(20, 5), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "go_test.go",
-    "prompt": "package text_match_two_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_Two_Three(t *testing.T) {\n  candidate := text_match_two_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "go_test.go",
-    "prompt": "package count_Occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the occurence of all elements of list in a list.\nfunc count_Occurrence(tup interface{}, lst []interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Occurrence(t *testing.T) {\n  candidate := count_Occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"a\", \"a\", \"c\", \"b\", \"d\"}, []string{\"a\", \"b\"}), expected: 3 },\n     { actual: candidate([]interface{}{1, 2, 3, 1, 4, 6, 7, 1, 4}, []int{1, 4, 7}), expected: 6 },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}, []int{1, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "go_test.go",
-    "prompt": "package count_samepair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1 []int, list2 []int, list3 []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Samepair(t *testing.T) {\n  candidate := count_samepair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}, []int{2, 1, 3, 1, 2, 6, 7, 9}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 2, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "go_test.go",
-    "prompt": "package text_match_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_One(t *testing.T) {\n  candidate := text_match_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "go_test.go",
-    "prompt": "package difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDifference(t *testing.T) {\n  candidate := difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 30 },\n     { actual: candidate(5), expected: 210 },\n     { actual: candidate(2), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "go_test.go",
-    "prompt": "package toggle_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestToggle_String(t *testing.T) {\n  candidate := toggle_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"pYTHON\" },\n     { actual: candidate(\"Pangram\"), expected: \"pANGRAM\" },\n     { actual: candidate(\"LIttLE\"), expected: \"liTTle\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "go_test.go",
-    "prompt": "package Find_Max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the element of a list having maximum length.\nfunc Find_Max(lst [][]interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := Find_Max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"A\"}, []string{\"A\", \"B\"}, []string{\"A\", \"B\", \"C\"}}), expected: []string{\"A\", \"B\", \"C\"} },\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1, 2, 3} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 2, 3}, []int{1, 5, 6, 1}}), expected: []int{1, 5, 6, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "go_test.go",
-    "prompt": "package eulerian_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n int, m int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestEulerian_Num(t *testing.T) {\n  candidate := eulerian_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 1), expected: 4 },\n     { actual: candidate(4, 1), expected: 11 },\n     { actual: candidate(5, 3), expected: 26 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "go_test.go",
-    "prompt": "package frequency_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a []int, x int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFrequency(t *testing.T) {\n  candidate := frequency\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 3, 4}, 3), expected: 3 },\n     { actual: candidate([]int{0, 1, 2, 3, 1, 2}, 1), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "go_test.go",
-    "prompt": "package sort_numeric_strings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/gothon-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str []string) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Numeric_Strings(t *testing.T) {\n  candidate := sort_numeric_strings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"}), expected: []int{-500, -12, 0, 4, 7, 12, 45, 100, 200} },\n     { actual: candidate([]string{\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"}), expected: []int{1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9} },\n     { actual: candidate([]string{\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"}), expected: []int{1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "go_test.go",
-    "prompt": "package geometric_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/gothon-exercises/data-structures-and-algorithms/gothon-recursion-exercise-9.php\nfunc geometric_sum(n int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGeometric_Sum(t *testing.T) {\n  candidate := geometric_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 1.9921875 },\n     { actual: candidate(4), expected: 1.9375 },\n     { actual: candidate(8), expected: 1.99609375 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "go_test.go",
-    "prompt": "package divisible_by_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/gothon-exercises/lambda/gothon-lambda-exercise-24.php\nfunc divisible_by_digits(startnum int, endnum int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDivisible_By_Digits(t *testing.T) {\n  candidate := divisible_by_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 22), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22} },\n     { actual: candidate(1, 15), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15} },\n     { actual: candidate(20, 25), expected: []int{22, 24} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "go_test.go",
-    "prompt": "package unique_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUnique_Product(t *testing.T) {\n  candidate := unique_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30, 40, 20, 50, 60, 40}), expected: 720000000 },\n     { actual: candidate([]int{1, 2, 3, 1}), expected: 6 },\n     { actual: candidate([]int{7, 8, 9, 0, 1, 1}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "go_test.go",
-    "prompt": "package largest_neg_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the largest negative number from the given list.\nfunc largest_neg(list1 []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLargest_Neg(t *testing.T) {\n  candidate := largest_neg\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, -4, -6}), expected: -6 },\n     { actual: candidate([]int{1, 2, 3, -8, -9}), expected: -9 },\n     { actual: candidate([]int{1, 2, 3, 4, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "go_test.go",
-    "prompt": "package consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestConsecutive_Duplicates(t *testing.T) {\n  candidate := consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: []int{10, 15, 19, 18, 17, 26, 17, 18, 10} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: []string{\"a\", \"b\", \"c\", \"d\"} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"}), expected: []string{\"a\", \"b\", \"c\", \"d\", \"a\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "go_test.go",
-    "prompt": "package min_Jumps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps []interface{}, d int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMin_Jumps(t *testing.T) {\n  candidate := min_Jumps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}, 11), expected: 3.5 },\n     { actual: candidate([]interface{}{3, 4}, 0), expected: 0 },\n     { actual: candidate([]interface{}{11, 14}, 11), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "go_test.go",
-    "prompt": "package max_Product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find a pair with highest product from a given list of integers.\nfunc max_Product(arr []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_Product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 7, 0, 8, 4}), expected: []interface{}{7, 8} },\n     { actual: candidate([]int{0, -1, -2, -4, 5, 0, -6}), expected: []interface{}{-4, -6} },\n     { actual: candidate([]int{1, 2, 3}), expected: []interface{}{2, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "go_test.go",
-    "prompt": "package extract_nth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the nth element from a given list of lists.\nfunc extract_nth_element(list1 [][]interface{}, n int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Nth_Element(t *testing.T) {\n  candidate := extract_nth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 0), expected: []string{\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 2), expected: []int{99, 96, 94, 98} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 1), expected: []int{98, 97, 91, 94} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "go_test.go",
-    "prompt": "package is_nonagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Nonagonal(t *testing.T) {\n  candidate := is_nonagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 325 },\n     { actual: candidate(15), expected: 750 },\n     { actual: candidate(18), expected: 1089 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "go_test.go",
-    "prompt": "package max_Abs_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the maximum difference between any two elements in a given list.\nfunc max_Abs_Diff(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Abs_Diff(t *testing.T) {\n  candidate := max_Abs_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 3}), expected: 4 },\n     { actual: candidate([]int{9, 3, 2, 5, 1}), expected: 8 },\n     { actual: candidate([]int{3, 2, 1}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "go_test.go",
-    "prompt": "package pack_consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1 []interface{}) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPack_Consecutive_Duplicates(t *testing.T) {\n  candidate := pack_consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: [][]int{[]int{0, 0}, []int{1}, []int{2}, []int{3}, []int{4, 4}, []int{5}, []int{6, 6, 6}, []int{7}, []int{8}, []int{9}, []int{4, 4}} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: [][]int{[]int{10, 10}, []int{15}, []int{19}, []int{18, 18}, []int{17}, []int{26, 26}, []int{17}, []int{18}, []int{10}} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: [][]int{[]string{\"a\", \"a\"}, []string{\"b\"}, []string{\"c\"}, []string{\"d\", \"d\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "go_test.go",
-    "prompt": "package cal_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCal_Sum(t *testing.T) {\n  candidate := cal_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 49 },\n     { actual: candidate(10), expected: 66 },\n     { actual: candidate(11), expected: 88 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "go_test.go",
-    "prompt": "package odd_values_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Values_String(t *testing.T) {\n  candidate := odd_values_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcdef\"), expected: \"ace\" },\n     { actual: candidate(\"python\"), expected: \"pto\" },\n     { actual: candidate(\"data\"), expected: \"dt\" },\n     { actual: candidate(\"lambs\"), expected: \"lms\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "go_test.go",
-    "prompt": "package find_kth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find kth element from the given two sorted lists.\nfunc find_kth(arr1 []int, arr2 []int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Kth(t *testing.T) {\n  candidate := find_kth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 6, 7, 9}, []int{1, 4, 8, 10}, 5), expected: 6 },\n     { actual: candidate([]int{100, 112, 256, 349, 770}, []int{72, 86, 113, 119, 265, 445, 892}, 7), expected: 256 },\n     { actual: candidate([]int{3, 4, 7, 8, 10}, []int{2, 5, 9, 11}, 6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "go_test.go",
-    "prompt": "package jacobsthal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestJacobsthal_Num(t *testing.T) {\n  candidate := jacobsthal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 11 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 5 },\n     { actual: candidate(13), expected: 2731 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "go_test.go",
-    "prompt": "package frequency_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find frequency of each element in a flattened list of lists, returned in a map.\nfunc frequency_lists(list1 [][]int) map[int]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFrequency_Lists(t *testing.T) {\n  candidate := frequency_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 2}, []int{4, 5, 6, 2}, []int{7, 8, 9, 5}}), expected: map[int]int{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}}), expected: map[int]int{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1} },\n     { actual: candidate([][]int{[]int{20, 30, 40, 17}, []int{18, 16, 14, 13}, []int{10, 20, 30, 40}}), expected: map[int]int{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "go_test.go",
-    "prompt": "package perfect_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a int, b int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPerfect_Squares(t *testing.T) {\n  candidate := perfect_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 30), expected: []int{1, 4, 9, 16, 25} },\n     { actual: candidate(50, 100), expected: []int{64, 81, 100} },\n     { actual: candidate(100, 200), expected: []int{100, 121, 144, 169, 196} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "go_test.go",
-    "prompt": "package sum_Of_Subarray_Prod_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\nfunc sum_Of_Subarray_Prod(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Of_Subarray_Prod(t *testing.T) {\n  candidate := sum_Of_Subarray_Prod\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 20 },\n     { actual: candidate([]int{1, 2}), expected: 5 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "go_test.go",
-    "prompt": "package first_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the first odd number in a given list of numbers.\nfunc first_odd(nums []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFirst_Odd(t *testing.T) {\n  candidate := first_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5}), expected: 1 },\n     { actual: candidate([]int{2, 4, 1, 3}), expected: 1 },\n     { actual: candidate([]int{8, 9, 1}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "go_test.go",
-    "prompt": "package add_nested_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Nested_Tuples(t *testing.T) {\n  candidate := add_nested_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{7, 10}, []int{7, 14}, []int{3, 10}, []int{8, 13}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{9, 12}, []int{9, 16}, []int{5, 12}, []int{10, 15}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{11, 14}, []int{11, 18}, []int{7, 14}, []int{12, 17}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "go_test.go",
-    "prompt": "package merge_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst [][]interface{}) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMerge(t *testing.T) {\n  candidate := merge\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"a\", \"b\"}, []string{\"m\", \"n\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}, []int{7, 8}}), expected: [][]int{[]int{1, 3, 5, 7}, []int{2, 4, 6, 8}} },\n     { actual: candidate([][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"a\", \"b\", \"c\"}, []string{\"m\", \"n\", \"o\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}, []string{\"z\", \"c\", \"o\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "go_test.go",
-    "prompt": "package dif_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDif_Square(t *testing.T) {\n  candidate := dif_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(15), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "go_test.go",
-    "prompt": "package check_smaller_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if each element of second list is smaller than its corresponding element in the first list.\nfunc check_smaller(test_tup1 []interface{}, test_tup2 []interface{}) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Smaller(t *testing.T) {\n  candidate := check_smaller\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}, []interface{}{2, 3, 4}), expected: false },\n     { actual: candidate([]interface{}{4, 5, 6}, []interface{}{3, 4, 5}), expected: true },\n     { actual: candidate([]interface{}{11, 12, 13}, []interface{}{10, 11, 12}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "go_test.go",
-    "prompt": "package freq_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the frequency of all the elements in a list, returned as a map.\nfunc freq_count(list1 []int) map[int]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFreq_Count(t *testing.T) {\n  candidate := freq_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), expected: map[int]int{10: 4, 20: 4, 40: 2, 50: 2, 30: 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), expected: map[int]int{1: 3, 2: 2, 3: 3, 4: 3} },\n     { actual: candidate([]int{5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), expected: map[int]int{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "go_test.go",
-    "prompt": "package rgb_to_hsv_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r int, g int, b int) []float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRgb_To_Hsv(t *testing.T) {\n  candidate := rgb_to_hsv\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(255, 255, 255), expected: []float64{0.0, 0.0, 100.0} },\n     { actual: candidate(0, 215, 0), expected: []float64{120.0, 100.0, 84.31372549019608} },\n     { actual: candidate(10, 215, 110), expected: []float64{149.26829268292684, 95.34883720930233, 84.31372549019608} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "go_test.go",
-    "prompt": "package check_str_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(myString string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Str(t *testing.T) {\n  candidate := check_str\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"annie\"), expected: true },\n     { actual: candidate(\"dawood\"), expected: false },\n     { actual: candidate(\"Else\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "go_test.go",
-    "prompt": "package check_monthnumber_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3 int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Monthnumber_Number(t *testing.T) {\n  candidate := check_monthnumber_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(12), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "go_test.go",
-    "prompt": "package heap_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list.\nfunc heap_sort(iterable []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHeap_Sort(t *testing.T) {\n  candidate := heap_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 25, 58}), expected: []int{14, 22, 25, 25, 35, 58, 65, 75, 85} },\n     { actual: candidate([]int{7, 1, 9, 5}), expected: []int{1, 5, 7, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "go_test.go",
-    "prompt": "package k_smallest_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\nfunc k_smallest_pairs(nums1 []int, nums2 []int, k int) [][]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestK_Smallest_Pairs(t *testing.T) {\n  candidate := k_smallest_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 2), expected: [][]int{[]int{1, 2}, []int{1, 4}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 1), expected: [][]int{[]int{1, 2}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 7), expected: [][]int{[]int{1, 2}, []int{1, 4}, []int{3, 2}, []int{1, 6}, []int{3, 4}, []int{3, 6}, []int{7, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "go_test.go",
-    "prompt": "package find_Max_Num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Max_Num(t *testing.T) {\n  candidate := find_Max_Num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 321 },\n     { actual: candidate([]int{4, 5, 6, 1}), expected: 6541 },\n     { actual: candidate([]int{1, 2, 3, 9}), expected: 9321 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "go_test.go",
-    "prompt": "package max_sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists [][]int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Sum_List(t *testing.T) {\n  candidate := max_sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{10, 11, 12}, []int{7, 8, 9}}), expected: []int{10, 11, 12} },\n     { actual: candidate([][]int{[]int{3, 2, 1}, []int{6, 5, 4}, []int{12, 11, 10}}), expected: []int{12, 11, 10} },\n     { actual: candidate([][]int{[]int{2, 3, 1}}), expected: []int{2, 3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "go_test.go",
-    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to interchange the first and last elements in a list.\nfunc swap_List(newList []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 35, 9, 56, 24}), expected: []int{24, 35, 9, 56, 12} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "go_test.go",
-    "prompt": "package get_median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1 []int, arr2 []int, n int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Median(t *testing.T) {\n  candidate := get_median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 12, 15, 26, 38}, []int{2, 13, 17, 30, 45}, 5), expected: 16.0 },\n     { actual: candidate([]int{2, 4, 8, 9}, []int{7, 13, 19, 28}, 4), expected: 8.5 },\n     { actual: candidate([]int{3, 6, 14, 23, 36, 42}, []int{2, 18, 27, 39, 49, 55}, 6), expected: 25.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "go_test.go",
-    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jumanji The Jungle\"), expected: \"Jumanji_The_Jungle\" },\n     { actual: candidate(\"The_Avengers\"), expected: \"The Avengers\" },\n     { actual: candidate(\"Fast and Furious\"), expected: \"Fast_and_Furious\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "go_test.go",
-    "prompt": "package are_equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1 int, num2 int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAre_Equivalent(t *testing.T) {\n  candidate := are_equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(36, 57), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(23, 47), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "go_test.go",
-    "prompt": "package reverse_string_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist []string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReverse_String_List(t *testing.T) {\n  candidate := reverse_string_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"}), expected: []string{\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"} },\n     { actual: candidate([]string{\"john\", \"amal\", \"joel\", \"george\"}), expected: []string{\"nhoj\", \"lama\", \"leoj\", \"egroeg\"} },\n     { actual: candidate([]string{\"jack\", \"john\", \"mary\"}), expected: []string{\"kcaj\", \"nhoj\", \"yram\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "go_test.go",
-    "prompt": "package sum_of_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums []interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Of_Digits(t *testing.T) {\n  candidate := sum_of_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 2, 56}), expected: 14 },\n     { actual: candidate([][]int{[]interface{}{10, 20, 4, 5, \"b\", 70, \"a\"}}), expected: 19 },\n     { actual: candidate([]int{10, 20, -4, 5, -70}), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "go_test.go",
-    "prompt": "package sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSequence(t *testing.T) {\n  candidate := sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 6 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "go_test.go",
-    "prompt": "package heap_queue_largest_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums []int, n int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestHeap_Queue_Largest(t *testing.T) {\n  candidate := heap_queue_largest\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), expected: []int{85, 75, 65} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), expected: []int{85, 75} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), expected: []int{85, 75, 65, 58, 35} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "go_test.go",
-    "prompt": "package loss_amount_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost int, sale_amount int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLoss_Amount(t *testing.T) {\n  candidate := loss_amount\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: 0 },\n     { actual: candidate(100, 200), expected: 100 },\n     { actual: candidate(2000, 5000), expected: 3000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "go_test.go",
-    "prompt": "package union_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1 []int, test_tup2 []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestUnion_Elements(t *testing.T) {\n  candidate := union_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 6}, []int{5, 7, 4, 10}), expected: []int{3, 4, 5, 6, 7, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{3, 4, 5, 6}), expected: []int{1, 2, 3, 4, 5, 6} },\n     { actual: candidate([]int{11, 12, 13, 14}, []int{13, 15, 16, 17}), expected: []int{11, 12, 13, 14, 15, 16, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "go_test.go",
-    "prompt": "package Find_Max_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the longest sublists.\nfunc Find_Max_Length(lst [][]int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Max_Length(t *testing.T) {\n  candidate := Find_Max_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 4}, []int{5, 6, 7, 8}}), expected: 4 },\n     { actual: candidate([][]int{[]int{0, 1}, []int{2, 2}, []int{3, 2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]int{7}, []int{22, 23}, []int{13, 14, 15}, []int{10, 20, 30, 40, 50}}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "go_test.go",
-    "prompt": "package remove_parenthesis_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items []string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Parenthesis(t *testing.T) {\n  candidate := remove_parenthesis\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python (chrome)\"}), expected: \"python\" },\n     { actual: candidate([]string{\"string(.abc)\"}), expected: \"string\" },\n     { actual: candidate([]string{\"alpha(num)\"}), expected: \"alpha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "go_test.go",
-    "prompt": "package find_Parity_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find whether the parity of a given number is odd.\nfunc find_Parity(x int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Parity(t *testing.T) {\n  candidate := find_Parity\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: false },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "go_test.go",
-    "prompt": "package median_trapezium_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1 int, base2 int, height int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMedian_Trapezium(t *testing.T) {\n  candidate := median_trapezium\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15, 25, 35), expected: 20 },\n     { actual: candidate(10, 20, 30), expected: 15 },\n     { actual: candidate(6, 9, 4), expected: 7.5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "go_test.go",
-    "prompt": "package centered_hexagonal_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCentered_Hexagonal_Number(t *testing.T) {\n  candidate := centered_hexagonal_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 271 },\n     { actual: candidate(2), expected: 7 },\n     { actual: candidate(9), expected: 217 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "go_test.go",
-    "prompt": "package find_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find number of lists present in the given list.\nfunc find_lists(Input []interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Lists(t *testing.T) {\n  candidate := find_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}}), expected: 2 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}), expected: 3 },\n     { actual: candidate([]int{9, 8, 7, 6, 5, 4, 3, 2, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "go_test.go",
-    "prompt": "package get_max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Max_Sum(t *testing.T) {\n  candidate := get_max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(60), expected: 106 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "go_test.go",
-    "prompt": "package len_log_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the longest word.\nfunc len_log(list1 []string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLen_Log(t *testing.T) {\n  candidate := len_log\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python\", \"PHP\", \"bigdata\"}), expected: 7 },\n     { actual: candidate([]string{\"a\", \"ab\", \"abc\"}), expected: 3 },\n     { actual: candidate([]string{\"small\", \"big\", \"tall\"}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "go_test.go",
-    "prompt": "package odd_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOdd_Position(t *testing.T) {\n  candidate := odd_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 4, 3, 6, 7, 6, 3}), expected: true },\n     { actual: candidate([]int{4, 1, 2}), expected: true },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "go_test.go",
-    "prompt": "package multiple_to_single_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMultiple_To_Single(t *testing.T) {\n  candidate := multiple_to_single\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 33, 50}), expected: 113350 },\n     { actual: candidate([]int{-1, 2, 3, 4, 5, 6}), expected: -123456 },\n     { actual: candidate([]int{10, 15, 20, 25}), expected: 10152025 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "go_test.go",
-    "prompt": "package is_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find whether a number is divisible by 11.\nfunc is_Diff(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Diff(t *testing.T) {\n  candidate := is_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12345), expected: false },\n     { actual: candidate(1212112), expected: true },\n     { actual: candidate(1212), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "go_test.go",
-    "prompt": "package index_multiplication_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIndex_Multiplication(t *testing.T) {\n  candidate := index_multiplication\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 21}, []int{12, 45}, []int{2, 9}, []int{7, 30}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{14, 32}, []int{20, 60}, []int{6, 20}, []int{16, 44}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{24, 45}, []int{30, 77}, []int{12, 33}, []int{27, 60}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "go_test.go",
-    "prompt": "package tuple_str_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert list string to integer list.\nfunc tuple_str_int(test_str string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTuple_Str_Int(t *testing.T) {\n  candidate := tuple_str_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(7, 8, 9)\"), expected: []interface{}{7, 8, 9} },\n     { actual: candidate(\"(1, 2, 3)\"), expected: []interface{}{1, 2, 3} },\n     { actual: candidate(\"(4, 5, 6)\"), expected: []interface{}{4, 5, 6} },\n     { actual: candidate(\"(7, 81, 19)\"), expected: []interface{}{7, 81, 19} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "go_test.go",
-    "prompt": "package amicable_numbers_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAmicable_Numbers_Sum(t *testing.T) {\n  candidate := amicable_numbers_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(999), expected: 504 },\n     { actual: candidate(9999), expected: 31626 },\n     { actual: candidate(99), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "go_test.go",
-    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove odd characters in a string.\nfunc remove_odd(str1 string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: \"yhn\" },\n     { actual: candidate(\"program\"), expected: \"rga\" },\n     { actual: candidate(\"language\"), expected: \"agae\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "go_test.go",
-    "prompt": "package multiply_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMultiply_Elements(t *testing.T) {\n  candidate := multiply_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 7, 8, 10}), expected: []int{5, 35, 56, 80} },\n     { actual: candidate([]int{2, 4, 5, 6, 7}), expected: []int{8, 20, 30, 42} },\n     { actual: candidate([]int{12, 13, 14, 9, 15}), expected: []int{156, 182, 126, 135} },\n     { actual: candidate([]int{12}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "go_test.go",
-    "prompt": "package count_rotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\nfunc count_rotation(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Rotation(t *testing.T) {\n  candidate := count_rotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: 1 },\n     { actual: candidate([]int{4, 5, 1, 2, 3}), expected: 2 },\n     { actual: candidate([]int{7, 8, 9, 1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3}), expected: 0 },\n     { actual: candidate([]int{1, 3, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "go_test.go",
-    "prompt": "package extract_freq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the number of unique lists in the given list.\nfunc extract_freq(test_list [][]interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Freq(t *testing.T) {\n  candidate := extract_freq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 4}, []interface{}{1, 2}, []interface{}{4, 3}, []interface{}{5, 6}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{4, 15}, []interface{}{2, 3}, []interface{}{5, 4}, []interface{}{6, 7}}), expected: 4 },\n     { actual: candidate([][]int{[]interface{}{5, 16}, []interface{}{2, 3}, []interface{}{6, 5}, []interface{}{6, 9}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "go_test.go",
-    "prompt": "package count_same_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1 []int, nums2 []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Same_Pair(t *testing.T) {\n  candidate := count_same_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 11 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 1 },\n     { actual: candidate([]int{0, 1, 1, 2}, []int{0, 1, 2, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "go_test.go",
-    "prompt": "package power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a int, b int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPower(t *testing.T) {\n  candidate := power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 81 },\n     { actual: candidate(2, 3), expected: 8 },\n     { actual: candidate(5, 5), expected: 3125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "go_test.go",
-    "prompt": "package return_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write function to find the sum of all items in the given map.\nfunc return_sum(dict map[string]int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReturn_Sum(t *testing.T) {\n  candidate := return_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"a\": 100, \"b\": 200, \"c\": 300}), expected: 600 },\n     { actual: candidate(map[string]int{\"a\": 25, \"b\": 18, \"c\": 45}), expected: 88 },\n     { actual: candidate(map[string]int{\"a\": 36, \"b\": 39, \"c\": 49}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "go_test.go",
-    "prompt": "package pair_wise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1 []int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPair_Wise(t *testing.T) {\n  candidate := pair_wise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 3, 4, 4, 5}), expected: [][]int{[]interface{}{1, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 3}, []interface{}{3, 4}, []interface{}{4, 4}, []interface{}{4, 5}} },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: [][]int{[]interface{}{1, 5}, []interface{}{5, 7}, []interface{}{7, 9}, []interface{}{9, 10}} },\n     { actual: candidate([]int{5, 1, 9, 7, 10}), expected: [][]int{[]interface{}{5, 1}, []interface{}{1, 9}, []interface{}{9, 7}, []interface{}{7, 10}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: [][]int{[]interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}, []interface{}{4, 5}, []interface{}{5, 6}, []interface{}{6, 7}, []interface{}{7, 8}, []interface{}{8, 9}, []interface{}{9, 10}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "go_test.go",
-    "prompt": "package split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to split a string into characters.\nfunc split(word string) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSplit(t *testing.T) {\n  candidate := split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"} },\n     { actual: candidate(\"Name\"), expected: []string{\"N\", \"a\", \"m\", \"e\"} },\n     { actual: candidate(\"program\"), expected: []string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "go_test.go",
-    "prompt": "package min_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum of three numbers.\nfunc min_of_three(a int, b int, c int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMin_Of_Three(t *testing.T) {\n  candidate := min_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20, 0), expected: 0 },\n     { actual: candidate(19, 15, 18), expected: 15 },\n     { actual: candidate(-10, -20, -30), expected: -30 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "go_test.go",
-    "prompt": "package is_Sum_Of_Powers_Of_Two_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Sum_Of_Powers_Of_Two(t *testing.T) {\n  candidate := is_Sum_Of_Powers_Of_Two\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(7), expected: false },\n     { actual: candidate(14), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "go_test.go",
-    "prompt": "package get_Char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Char(t *testing.T) {\n  candidate := get_Char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: \"f\" },\n     { actual: candidate(\"gfg\"), expected: \"t\" },\n     { actual: candidate(\"ab\"), expected: \"c\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "go_test.go",
-    "prompt": "package sum_div_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Div(t *testing.T) {\n  candidate := sum_div\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: 7 },\n     { actual: candidate(12), expected: 16 },\n     { actual: candidate(7), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "go_test.go",
-    "prompt": "package two_unique_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTwo_Unique_Nums(t *testing.T) {\n  candidate := two_unique_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 2, 3, 4, 5}), expected: []int{1, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 5}), expected: []int{1, 3, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "go_test.go",
-    "prompt": "package test_duplicate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether a given list of integers contains any duplicate element.\nfunc test_duplicate(arraynums []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTest_Duplicate(t *testing.T) {\n  candidate := test_duplicate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2, 3, 3, 4, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "go_test.go",
-    "prompt": "package catalan_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which returns nth catalan number.\nfunc catalan_number(num int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCatalan_Number(t *testing.T) {\n  candidate := catalan_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 16796 },\n     { actual: candidate(9), expected: 4862 },\n     { actual: candidate(7), expected: 429 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "go_test.go",
-    "prompt": "package power_base_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base int, power int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPower_Base_Sum(t *testing.T) {\n  candidate := power_base_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 100), expected: 115 },\n     { actual: candidate(8, 10), expected: 37 },\n     { actual: candidate(8, 15), expected: 62 },\n     { actual: candidate(3, 3), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "go_test.go",
-    "prompt": "package replace_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1 []interface{}, list2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_List(t *testing.T) {\n  candidate := replace_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 2, 4, 6, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{5, 6, 7, 8}), expected: []int{1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]string{\"red\", \"blue\", \"green\"}, []string{\"yellow\"}), expected: []string{\"red\", \"blue\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "go_test.go",
-    "prompt": "package is_octagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth octagonal number.\nfunc is_octagonal(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Octagonal(t *testing.T) {\n  candidate := is_octagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 65 },\n     { actual: candidate(10), expected: 280 },\n     { actual: candidate(15), expected: 645 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "go_test.go",
-    "prompt": "package replace_blank_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1 string, char string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_Blank(t *testing.T) {\n  candidate := replace_blank\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello people\", \"@\"), expected: \"hello@people\" },\n     { actual: candidate(\"python program language\", \"$\"), expected: \"python$program$language\" },\n     { actual: candidate(\"blank space\", \"-\"), expected: \"blank-space\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "go_test.go",
-    "prompt": "package replace_specialchar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_Specialchar(t *testing.T) {\n  candidate := replace_specialchar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python language, Programming language.\"), expected: \"Python:language::Programming:language:\" },\n     { actual: candidate(\"a b c,d e f\"), expected: \"a:b:c:d:e:f\" },\n     { actual: candidate(\"ram reshma,ram rahim\"), expected: \"ram:reshma:ram:rahim\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "go_test.go",
-    "prompt": "package tuple_to_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given list of positive integers into a single integer.\nfunc tuple_to_int(nums []interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTuple_To_Int(t *testing.T) {\n  candidate := tuple_to_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}), expected: 123 },\n     { actual: candidate([]interface{}{4, 5, 6}), expected: 456 },\n     { actual: candidate([]interface{}{5, 6, 7}), expected: 567 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "go_test.go",
-    "prompt": "package otherside_rightangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w int, h int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestOtherside_Rightangle(t *testing.T) {\n  candidate := otherside_rightangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 8), expected: 10.63014581273465 },\n     { actual: candidate(3, 4), expected: 5 },\n     { actual: candidate(7, 15), expected: 16.55294535724685 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "go_test.go",
-    "prompt": "package digit_distance_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1 int, n2 int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDigit_Distance_Nums(t *testing.T) {\n  candidate := digit_distance_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(23, 56), expected: 6 },\n     { actual: candidate(123, 256), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "go_test.go",
-    "prompt": "package text_match_wordz_middle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Match_Wordz_Middle(t *testing.T) {\n  candidate := text_match_wordz_middle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonzabc.\"), expected: true },\n     { actual: candidate(\"zxyabc.\"), expected: false },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "go_test.go",
-    "prompt": "package removezero_ip_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemovezero_Ip(t *testing.T) {\n  candidate := removezero_ip\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"216.08.094.196\"), expected: \"216.8.94.196\" },\n     { actual: candidate(\"12.01.024\"), expected: \"12.1.24\" },\n     { actual: candidate(\"216.08.094.0196\"), expected: \"216.8.94.196\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "go_test.go",
-    "prompt": "package count_element_in_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1 [][]interface{}, x interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Element_In_List(t *testing.T) {\n  candidate := count_element_in_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{1, 11}, []int{1, 15, 7}}, 1), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"A\"), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"E\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "go_test.go",
-    "prompt": "package multiply_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to multiply two integers.\nfunc multiply_int(x int, y int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMultiply_Int(t *testing.T) {\n  candidate := multiply_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(5, 10), expected: 50 },\n     { actual: candidate(4, 8), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "go_test.go",
-    "prompt": "package add_pairwise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the pairwise addition of the neighboring elements of the given list.\nfunc add_pairwise(test_tup []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Pairwise(t *testing.T) {\n  candidate := add_pairwise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 8, 10}), expected: []interface{}{6, 12, 15, 18} },\n     { actual: candidate([]interface{}{2, 6, 8, 9, 11}), expected: []interface{}{8, 14, 17, 20} },\n     { actual: candidate([]interface{}{3, 7, 9, 10, 12}), expected: []interface{}{10, 16, 19, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "go_test.go",
-    "prompt": "package max_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\nfunc max_product_tuple(list1 [][]interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Product_Tuple(t *testing.T) {\n  candidate := max_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 36 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 200 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 484 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3868,7 +18,7 @@
     "language": "go_test.go",
     "prompt": "package kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the kth element in the given list using 1-based indexing.\nfunc kth_element(arr []int, k int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "func TestKth_Element(t *testing.T) {\n  candidate := kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 3, 5, 7, 19}, 2), expected: 3 },\n     { actual: candidate([]int{17, 24, 8, 23}, 3), expected: 8 },\n     { actual: candidate([]int{16, 21, 25, 36, 4}, 4), expected: 36 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -3878,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "go_test.go",
-    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to interchange the first and last element in a given list.\nfunc swap_List(newList []int) []int {\n",
+    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: []int{4, 2, 3, 4, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python_program\"), expected: \"PythonProgram\" },\n     { actual: candidate(\"python_language\"), expected: \"PythonLanguage\" },\n     { actual: candidate(\"programming_language\"), expected: \"ProgrammingLanguage\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3892,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "go_test.go",
-    "prompt": "package right_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a []int, x int) int {\n",
+    "prompt": "package eulerian_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n int, m int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestRight_Insertion(t *testing.T) {\n  candidate := right_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestEulerian_Num(t *testing.T) {\n  candidate := eulerian_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 1), expected: 4 },\n     { actual: candidate(4, 1), expected: 11 },\n     { actual: candidate(5, 3), expected: 26 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3906,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "go_test.go",
-    "prompt": "package is_woodall_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x int) bool {\n",
+    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list [][]string) [][]string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestIs_Woodall(t *testing.T) {\n  candidate := is_woodall\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(383), expected: true },\n     { actual: candidate(254), expected: false },\n     { actual: candidate(200), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\" red \", \"green\"}, []string{\"blue \", \" black\"}, []string{\" orange\", \"brown\"}}), expected: [][]int{[]string{\" red \", \"green\"}, []string{\" black\", \"blue \"}, []string{\" orange\", \"brown\"}} },\n     { actual: candidate([][]int{[]string{\"zilver\", \"gold\"}, []string{\"magnesium\", \"aluminium\"}, []string{\"steel\", \"bronze\"}}), expected: [][]int{[]string{\"gold\", \"zilver\"}, []string{\"aluminium\", \"magnesium\"}, []string{\"bronze\", \"steel\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3920,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "go_test.go",
-    "prompt": "package shell_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list by using shell sort.\nfunc shell_sort(my_list []int) []int {\n",
+    "prompt": "package count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count true booleans in the given list.\nfunc count(lst []bool) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestShell_Sort(t *testing.T) {\n  candidate := shell_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), expected: []int{2, 3, 4, 5, 12, 12, 23, 56, 81, 95} },\n     { actual: candidate([]int{24, 22, 39, 34, 87, 73, 68}), expected: []int{22, 24, 34, 39, 68, 73, 87} },\n     { actual: candidate([]int{32, 30, 16, 96, 82, 83, 74}), expected: []int{16, 30, 32, 74, 82, 83, 96} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCount(t *testing.T) {\n  candidate := count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]UNKNOWN{true, false, true}), expected: 2 },\n     { actual: candidate([]UNKNOWN{false, false}), expected: 0 },\n     { actual: candidate([]UNKNOWN{true, true, true}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3934,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "go_test.go",
-    "prompt": "package find_Odd_Pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A []int, N int) int {\n",
+    "prompt": "package add_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to append the given list to the given lists.\nfunc add_lists(test_list []int, test_tup []interface{}) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestFind_Odd_Pair(t *testing.T) {\n  candidate := find_Odd_Pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}, 5), expected: 6 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}, 7), expected: 12 },\n     { actual: candidate([]int{1, 2, 3}, 3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAdd_Lists(t *testing.T) {\n  candidate := add_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []interface{}{9, 10, 5, 6, 7} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []interface{}{10, 11, 6, 7, 8} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []interface{}{11, 12, 7, 8, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3948,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "go_test.go",
-    "prompt": "package sum_in_range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l int, r int) int {\n",
+    "prompt": "package merge_sorted_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1 []int, num2 []int, num3 []int) []int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSum_In_Range(t *testing.T) {\n  candidate := sum_in_range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 5), expected: 8 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 13), expected: 40 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMerge_Sorted_List(t *testing.T) {\n  candidate := merge_sorted_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 24, 15, 4, 5, 29, 110}, []int{19, 20, 11, 56, 25, 233, 154}, []int{24, 26, 54, 48}), expected: []int{4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233} },\n     { actual: candidate([]int{1, 3, 5, 6, 8, 9}, []int{2, 5, 7, 11}, []int{1, 4, 7, 8, 12}), expected: []int{1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12} },\n     { actual: candidate([]int{18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, []int{25, 35, 22, 85, 14, 65, 75, 25, 58}, []int{12, 74, 9, 50, 61, 41}), expected: []int{1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3962,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "go_test.go",
-    "prompt": "package square_perimeter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a int) int {\n",
+    "prompt": "package odd_Equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s string, n int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSquare_Perimeter(t *testing.T) {\n  candidate := square_perimeter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 40 },\n     { actual: candidate(5), expected: 20 },\n     { actual: candidate(4), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestOdd_Equivalent(t *testing.T) {\n  candidate := odd_Equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"011001\", 6), expected: 3 },\n     { actual: candidate(\"11011\", 5), expected: 4 },\n     { actual: candidate(\"1010\", 4), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3976,13 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "go_test.go",
-    "prompt": "package is_polite_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n int) int {\n",
+    "prompt": "package check_integer_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string represents an integer or not.\nfunc check_integer(text string) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestIs_Polite(t *testing.T) {\n  candidate := is_polite\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 11 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(9), expected: 13 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestCheck_Integer(t *testing.T) {\n  candidate := check_integer\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"1\"), expected: true },\n     { actual: candidate(\"12345\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -3990,195 +140,13 @@
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "go_test.go",
-    "prompt": "package sum_series_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n int) int {\n",
+    "prompt": "package tuple_to_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given list of positive integers into a single integer.\nfunc tuple_to_int(nums []interface{}) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSum_Series(t *testing.T) {\n  candidate := sum_series\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: 12 },\n     { actual: candidate(10), expected: 30 },\n     { actual: candidate(9), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "go_test.go",
-    "prompt": "package find_dissimilar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the dissimilar elements in the given two lists.\nfunc find_dissimilar(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Dissimilar(t *testing.T) {\n  candidate := find_dissimilar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4, 5, 6}, []interface{}{5, 7, 4, 10}), expected: []interface{}{3, 6, 7, 10} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{7, 2, 3, 9}), expected: []interface{}{1, 4, 7, 9} },\n     { actual: candidate([]interface{}{21, 11, 25, 26}, []interface{}{26, 34, 21, 36}), expected: []interface{}{34, 36, 11, 25} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "go_test.go",
-    "prompt": "package start_withp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words []string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestStart_Withp(t *testing.T) {\n  candidate := start_withp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python PHP\", \"Java JavaScript\", \"c c++\"}), expected: []interface{}{\"Python\", \"PHP\"} },\n     { actual: candidate([]string{\"Python Programming\", \"Java Programming\"}), expected: []interface{}{\"Python\", \"Programming\"} },\n     { actual: candidate([]string{\"Pqrst Pqr\", \"qrstuv\"}), expected: []interface{}{\"Pqrst\", \"Pqr\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "go_test.go",
-    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"android_tv\"), expected: \"AndroidTv\" },\n     { actual: candidate(\"google_pixel\"), expected: \"GooglePixel\" },\n     { actual: candidate(\"apple_watch\"), expected: \"AppleWatch\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "go_test.go",
-    "prompt": "package volume_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestVolume_Cube(t *testing.T) {\n  candidate := volume_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(2), expected: 8 },\n     { actual: candidate(5), expected: 125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "go_test.go",
-    "prompt": "package check_monthnumb_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2 int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Monthnumb_Number(t *testing.T) {\n  candidate := check_monthnumb_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "go_test.go",
-    "prompt": "package all_Bits_Set_In_The_Given_Range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n int, l int, r int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAll_Bits_Set_In_The_Given_Range(t *testing.T) {\n  candidate := all_Bits_Set_In_The_Given_Range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4, 1, 2), expected: true },\n     { actual: candidate(17, 2, 4), expected: true },\n     { actual: candidate(39, 4, 6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "go_test.go",
-    "prompt": "package Extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to get the first element of each sublist.\nfunc Extract(lst [][]int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract(t *testing.T) {\n  candidate := Extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4, 5}, []int{6, 7, 8, 9}}), expected: []int{1, 3, 6} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5}}), expected: []int{1, 4} },\n     { actual: candidate([][]int{[]int{9, 8, 1}, []int{1, 2}}), expected: []int{9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "go_test.go",
-    "prompt": "package surfacearea_cylinder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r int, h int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSurfacearea_Cylinder(t *testing.T) {\n  candidate := surfacearea_cylinder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 5), expected: 942.45 },\n     { actual: candidate(4, 5), expected: 226.18800000000002 },\n     { actual: candidate(4, 10), expected: 351.848 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "go_test.go",
-    "prompt": "package sample_nam_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names []string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSample_Nam(t *testing.T) {\n  candidate := sample_nam\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"}), expected: 16 },\n     { actual: candidate([]string{\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"}), expected: 10 },\n     { actual: candidate([]string{\"abcd\", \"Python\", \"abba\", \"aba\"}), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "go_test.go",
-    "prompt": "package rearrange_bigger_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n int) interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRearrange_Bigger(t *testing.T) {\n  candidate := rearrange_bigger\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 21 },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(102), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "go_test.go",
-    "prompt": "package perimeter_pentagon_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPerimeter_Pentagon(t *testing.T) {\n  candidate := perimeter_pentagon\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 25 },\n     { actual: candidate(10), expected: 50 },\n     { actual: candidate(15), expected: 75 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "go_test.go",
-    "prompt": "package max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Sum(t *testing.T) {\n  candidate := max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 15, 51, 45, 33, 100, 12, 18, 9}), expected: 194 },\n     { actual: candidate([]int{80, 60, 30, 40, 20, 10}), expected: 210 },\n     { actual: candidate([]int{2, 3, 14, 16, 21, 23, 29, 30}), expected: 138 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "go_test.go",
-    "prompt": "package extract_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uneven elements in the nested mixed list.\nfunc extract_even(test_tuple []interface{}) interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Even(t *testing.T) {\n  candidate := extract_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, []interface{}{7, 6, []interface{}{2, 4}}, 6, 8}), expected: []interface{}{4, []interface{}{6, []interface{}{2, 4}}, 6, 8} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{8, 7, []interface{}{4, 8}}, 7, 9}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 8}}} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{9, 8, []interface{}{4, 6}}, 8, 10}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 6}}, 8, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestTuple_To_Int(t *testing.T) {\n  candidate := tuple_to_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}), expected: 123 },\n     { actual: candidate([]interface{}{4, 5, 6}), expected: 456 },\n     { actual: candidate([]interface{}{5, 6, 7}), expected: 567 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4190,219 +158,9 @@
     "language": "go_test.go",
     "prompt": "package list_to_float_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert all possible convertible elements in a list of lists to floats.\nfunc list_to_float(test_list [][]interface{}) [][]interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "func TestList_To_Float(t *testing.T) {\n  candidate := list_to_float\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"3\", \"4\"}, []interface{}{\"1\", \"26.45\"}, []interface{}{\"7.32\", \"8\"}, []interface{}{\"4\", \"8\"}}), expected: [][]int{[]interface{}{3.0, 4.0}, []interface{}{1.0, 26.45}, []interface{}{7.32, 8.0}, []interface{}{4.0, 8.0}} },\n     { actual: candidate([][]int{[]interface{}{\"4\", \"4\"}, []interface{}{\"2\", \"27\"}, []interface{}{\"4.12\", \"9\"}, []interface{}{\"7\", \"11\"}}), expected: [][]int{[]interface{}{4.0, 4.0}, []interface{}{2.0, 27.0}, []interface{}{4.12, 9.0}, []interface{}{7.0, 11.0}} },\n     { actual: candidate([][]int{[]interface{}{\"6\", \"78\"}, []interface{}{\"5\", \"26.45\"}, []interface{}{\"1.33\", \"4\"}, []interface{}{\"82\", \"13\"}}), expected: [][]int{[]interface{}{6.0, 78.0}, []interface{}{5.0, 26.45}, []interface{}{1.33, 4.0}, []interface{}{82.0, 13.0}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "go_test.go",
-    "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 20 },\n     { actual: candidate(3), expected: 56 },\n     { actual: candidate(4), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "go_test.go",
-    "prompt": "package get_pairs_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr []int, sum int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestGet_Pairs_Count(t *testing.T) {\n  candidate := get_pairs_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1, 1}, 2), expected: 6 },\n     { actual: candidate([]int{1, 5, 7, -1, 5}, 6), expected: 3 },\n     { actual: candidate([]int{1, -2, 3}, 1), expected: 1 },\n     { actual: candidate([]int{-1, -2, 3}, -3), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "go_test.go",
-    "prompt": "package count_no_of_ways_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_No_Of_Ways(t *testing.T) {\n  candidate := count_no_of_ways\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 4), expected: 16 },\n     { actual: candidate(3, 2), expected: 6 },\n     { actual: candidate(4, 4), expected: 228 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "go_test.go",
-    "prompt": "package reverse_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReverse_Words(t *testing.T) {\n  candidate := reverse_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python program\"), expected: \"program python\" },\n     { actual: candidate(\"java language\"), expected: \"language java\" },\n     { actual: candidate(\"indian man\"), expected: \"man indian\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "go_test.go",
-    "prompt": "package checks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check if a given number is one less than twice its reverse.\nfunc checks(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestChecks(t *testing.T) {\n  candidate := checks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(70), expected: false },\n     { actual: candidate(23), expected: false },\n     { actual: candidate(73), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "go_test.go",
-    "prompt": "package last_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last position of an element in a sorted list.\nfunc last(arr []int, x int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestLast(t *testing.T) {\n  candidate := last\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 1), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 2, 3, 4}, 1), expected: 2 },\n     { actual: candidate([]int{2, 3, 2, 3, 6, 8, 9}, 3), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "go_test.go",
-    "prompt": "package count_X_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a list and an element and counts the occcurences of the element in the list.\nfunc count_X(tup []int, x int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_X(t *testing.T) {\n  candidate := count_X\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), expected: 0 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), expected: 3 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "go_test.go",
-    "prompt": "package extract_index_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1 []int, l2 []int, l3 []int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_Index_List(t *testing.T) {\n  candidate := extract_index_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 7} },\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 6, 5}, []int{0, 1, 2, 3, 4, 6, 7}), expected: []int{1, 6} },\n     { actual: candidate([]int{1, 1, 3, 4, 6, 5, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 6, 6, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "go_test.go",
-    "prompt": "package concatenate_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to concatenate each element of list by the delimiter.\nfunc concatenate_tuple(test_tup []interface{}) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestConcatenate_Tuple(t *testing.T) {\n  candidate := concatenate_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"ID\", \"is\", 4, \"UTS\"}), expected: \"ID-is-4-UTS\" },\n     { actual: candidate([]interface{}{\"QWE\", \"is\", 4, \"RTY\"}), expected: \"QWE-is-4-RTY\" },\n     { actual: candidate([]interface{}{\"ZEN\", \"is\", 4, \"OP\"}), expected: \"ZEN-is-4-OP\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "go_test.go",
-    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(myString string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"My Name is Dawood\"), expected: \"My%20Name%20is%20Dawood\" },\n     { actual: candidate(\"I am a Programmer\"), expected: \"I%20am%20a%20Programmer\" },\n     { actual: candidate(\"I love Coding\"), expected: \"I%20love%20Coding\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "go_test.go",
-    "prompt": "package sum_range_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1 []int, m int, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSum_Range_List(t *testing.T) {\n  candidate := sum_range_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), expected: 29 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), expected: 16 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), expected: 38 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "go_test.go",
-    "prompt": "package merge_dictionaries_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three dictionaries into a single map.\nfunc merge_dictionaries_three(dict1 map[string]string, dict2 map[string]string, dict3 map[string]string) map[string]string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMerge_Dictionaries_Three(t *testing.T) {\n  candidate := merge_dictionaries_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}), expected: map[string]string{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}), expected: map[string]string{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}), expected: map[string]string{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "go_test.go",
-    "prompt": "package minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum of two numbers.\nfunc minimum(a int, b int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMinimum(t *testing.T) {\n  candidate := minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(-5, -4), expected: -5 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "go_test.go",
-    "prompt": "package max_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between available pairs in the given list list.\nfunc max_difference(test_list [][]interface{}) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Difference(t *testing.T) {\n  candidate := max_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{1, 7}, []interface{}{10, 3}, []interface{}{1, 2}}), expected: 7 },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{2, 17}, []interface{}{9, 13}, []interface{}{11, 12}}), expected: 15 },\n     { actual: candidate([][]int{[]interface{}{12, 35}, []interface{}{21, 27}, []interface{}{13, 23}, []interface{}{41, 22}}), expected: 23 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "go_test.go",
-    "prompt": "package find_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find element at a given index after number of rotations.\nfunc find_Element(arr []int, ranges [][]int, rotations int, index int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Element(t *testing.T) {\n  candidate := find_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, [][]int{[]int{0, 2}, []int{0, 3}}, 2, 1), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 2), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4414,7 +172,7 @@
     "language": "go_test.go",
     "prompt": "package string_to_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a string to a list of strings split on the space character.\nfunc string_to_list(myString string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "func TestString_To_List(t *testing.T) {\n  candidate := string_to_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: []string{\"python\", \"programming\"} },\n     { actual: candidate(\"lists tuples strings\"), expected: []string{\"lists\", \"tuples\", \"strings\"} },\n     { actual: candidate(\"write a program\"), expected: []string{\"write\", \"a\", \"program\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4428,23 +186,9 @@
     "language": "go_test.go",
     "prompt": "package search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the element that appears only once in a sorted list.\nfunc search(arr []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSearch(t *testing.T) {\n  candidate := search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8}), expected: 8 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 4, 4}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "go_test.go",
-    "prompt": "package sort_counter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a map by value.\nfunc sort_counter(dict1 map[string]int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Counter(t *testing.T) {\n  candidate := sort_counter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}), expected: [][]int{[]interface{}{\"Chemistry\", 87}, []interface{}{\"Physics\", 83}, []interface{}{\"Math\", 81}} },\n     { actual: candidate(map[string]int{\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}), expected: [][]int{[]interface{}{\"Math\", 400}, []interface{}{\"Physics\", 300}, []interface{}{\"Chemistry\", 250}} },\n     { actual: candidate(map[string]int{\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}), expected: [][]int{[]interface{}{\"Chemistry\", 1250}, []interface{}{\"Physics\", 1000}, []interface{}{\"Math\", 900}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4456,7 +200,7 @@
     "language": "go_test.go",
     "prompt": "package remove_Occ_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove first and last occurrence of a given character from the string.\nfunc remove_Occ(s string, ch string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "func TestRemove_Occ(t *testing.T) {\n  candidate := remove_Occ\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello\", \"l\"), expected: \"heo\" },\n     { actual: candidate(\"abcda\", \"a\"), expected: \"bcd\" },\n     { actual: candidate(\"PHP\", \"P\"), expected: \"H\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4466,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "go_test.go",
-    "prompt": "package lateralsurface_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l int) int {\n",
+    "prompt": "package max_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\nfunc max_product_tuple(list1 [][]interface{}) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestLateralsurface_Cube(t *testing.T) {\n  candidate := lateralsurface_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 100 },\n     { actual: candidate(9), expected: 324 },\n     { actual: candidate(10), expected: 400 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMax_Product_Tuple(t *testing.T) {\n  candidate := max_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 36 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 200 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 484 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4480,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "go_test.go",
-    "prompt": "package add_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to append the given list to the given lists.\nfunc add_lists(test_list []int, test_tup []interface{}) []interface{} {\n",
+    "prompt": "package amicable_numbers_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Lists(t *testing.T) {\n  candidate := add_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []interface{}{9, 10, 5, 6, 7} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []interface{}{10, 11, 6, 7, 8} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []interface{}{11, 12, 7, 8, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestAmicable_Numbers_Sum(t *testing.T) {\n  candidate := amicable_numbers_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(999), expected: 504 },\n     { actual: candidate(9999), expected: 31626 },\n     { actual: candidate(99), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4494,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "go_test.go",
-    "prompt": "package nth_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums []int, n int) []int {\n",
+    "prompt": "package find_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(myString string) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestNth_Nums(t *testing.T) {\n  candidate := nth_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}, 3), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}, 5), expected: []int{248832, 759375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestFind_Length(t *testing.T) {\n  candidate := find_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"11000010001\"), expected: 6 },\n     { actual: candidate(\"10111\"), expected: 1 },\n     { actual: candidate(\"11011101100101\"), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4508,13 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "go_test.go",
-    "prompt": "package pancake_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc pancake_sort(nums []int) []int {\n",
+    "prompt": "package sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of common divisors of two given numbers.\nfunc sum(a int, b int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestPancake_Sort(t *testing.T) {\n  candidate := pancake_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 79, 25, 38, 69}), expected: []int{15, 25, 38, 69, 79} },\n     { actual: candidate([]int{98, 12, 54, 36, 85}), expected: []int{12, 36, 54, 85, 98} },\n     { actual: candidate([]int{41, 42, 32, 12, 23}), expected: []int{12, 23, 32, 41, 42} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSum(t *testing.T) {\n  candidate := sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 15), expected: 6 },\n     { actual: candidate(100, 150), expected: 93 },\n     { actual: candidate(4, 6), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4522,307 +266,13 @@
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "go_test.go",
-    "prompt": "package median_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of three numbers.\nfunc median_numbers(a int, b int, c int) float64 {\n",
+    "prompt": "package multiply_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to multiply two integers.\nfunc multiply_int(x int, y int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestMedian_Numbers(t *testing.T) {\n  candidate := median_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(25, 55, 65), expected: 55.0 },\n     { actual: candidate(20, 10, 30), expected: 20.0 },\n     { actual: candidate(15, 45, 75), expected: 45.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "go_test.go",
-    "prompt": "package check_greater_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the entered number is greater than the elements of the given list.\nfunc check_greater(arr []int, number int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Greater(t *testing.T) {\n  candidate := check_greater\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 4), expected: false },\n     { actual: candidate([]int{2, 3, 4, 5, 6}, 8), expected: true },\n     { actual: candidate([]int{9, 7, 4, 8, 6, 1}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "go_test.go",
-    "prompt": "package check_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list []interface{}, element interface{}) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Element(t *testing.T) {\n  candidate := check_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"green\", \"orange\", \"black\", \"white\"}, \"blue\"), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4}, 7), expected: false },\n     { actual: candidate([]string{\"green\", \"green\", \"green\", \"green\"}, \"green\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "go_test.go",
-    "prompt": "package extract_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str []string, l int) []string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestExtract_String(t *testing.T) {\n  candidate := extract_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 8), expected: []string{\"practice\", \"solution\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 6), expected: []string{\"Python\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 9), expected: []string{\"exercises\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "go_test.go",
-    "prompt": "package text_lowercase_underscore_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text string) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestText_Lowercase_Underscore(t *testing.T) {\n  candidate := text_lowercase_underscore\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aab_cbbbc\"), expected: true },\n     { actual: candidate(\"aab_Abbbc\"), expected: false },\n     { actual: candidate(\"Aaab_abbbc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "go_test.go",
-    "prompt": "package trim_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list [][]int, K int) [][]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestTrim_Tuple(t *testing.T) {\n  candidate := trim_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 2), expected: [][]int{[]int{2}, []int{9}, []int{2}, []int{2}} },\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 1), expected: [][]int{[]int{3, 2, 1}, []int{4, 9, 2}, []int{1, 2, 3}, []int{8, 2, 1}} },\n     { actual: candidate([][]int{[]int{7, 8, 4, 9}, []int{11, 8, 12, 4}, []int{4, 1, 7, 8}, []int{3, 6, 9, 7}}, 1), expected: [][]int{[]int{8, 4}, []int{8, 12}, []int{1, 7}, []int{6, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "go_test.go",
-    "prompt": "package Find_Min_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sublist having minimum length.\nfunc Find_Min(lst [][]interface{}) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Min(t *testing.T) {\n  candidate := Find_Min\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 1, 1}, []int{1, 2, 7, 8}}), expected: []int{1, 1} },\n     { actual: candidate([][]int{[]string{\"x\"}, []string{\"x\", \"y\"}, []string{\"x\", \"y\", \"z\"}}), expected: []string{\"x\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "go_test.go",
-    "prompt": "package filter_oddnumbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFilter_Oddnumbers(t *testing.T) {\n  candidate := filter_oddnumbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 3, 5, 7, 9} },\n     { actual: candidate([]int{10, 20, 45, 67, 84, 93}), expected: []int{45, 67, 93} },\n     { actual: candidate([]int{5, 7, 9, 8, 6, 4, 3}), expected: []int{5, 7, 9, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "go_test.go",
-    "prompt": "package find_adverbs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Adverbs(t *testing.T) {\n  candidate := find_adverbs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Clearly, he has no excuse for such behavior.\"), expected: \"0-7: Clearly\" },\n     { actual: candidate(\"Please handle the situation carefuly\"), expected: \"28-36: carefuly\" },\n     { actual: candidate(\"Complete the task quickly\"), expected: \"18-25: quickly\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "go_test.go",
-    "prompt": "package max_of_nth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list [][]int, N int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Of_Nth(t *testing.T) {\n  candidate := max_of_nth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 6, 7}, []int{1, 3, 5}, []int{8, 9, 19}}, 2), expected: 19 },\n     { actual: candidate([][]int{[]int{6, 7, 8}, []int{2, 4, 6}, []int{9, 10, 20}}, 1), expected: 10 },\n     { actual: candidate([][]int{[]int{7, 8, 9}, []int{3, 5, 7}, []int{10, 11, 21}}, 1), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "go_test.go",
-    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n int) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: \"1000\" },\n     { actual: candidate(18), expected: \"10010\" },\n     { actual: candidate(7), expected: \"111\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "go_test.go",
-    "prompt": "package combinations_colors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l []string, n int) [][]string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCombinations_Colors(t *testing.T) {\n  candidate := combinations_colors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 1), expected: [][]int{[]string{\"Red\"}, []string{\"Green\"}, []string{\"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 2), expected: [][]int{[]string{\"Red\", \"Red\"}, []string{\"Red\", \"Green\"}, []string{\"Red\", \"Blue\"}, []string{\"Green\", \"Green\"}, []string{\"Green\", \"Blue\"}, []string{\"Blue\", \"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 3), expected: [][]int{[]string{\"Red\", \"Red\", \"Red\"}, []string{\"Red\", \"Red\", \"Green\"}, []string{\"Red\", \"Red\", \"Blue\"}, []string{\"Red\", \"Green\", \"Green\"}, []string{\"Red\", \"Green\", \"Blue\"}, []string{\"Red\", \"Blue\", \"Blue\"}, []string{\"Green\", \"Green\", \"Green\"}, []string{\"Green\", \"Green\", \"Blue\"}, []string{\"Green\", \"Blue\", \"Blue\"}, []string{\"Blue\", \"Blue\", \"Blue\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "go_test.go",
-    "prompt": "package remove_all_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text string) string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_All_Spaces(t *testing.T) {\n  candidate := remove_all_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python  program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"python   programming    language\"), expected: \"pythonprogramminglanguage\" },\n     { actual: candidate(\"python                     program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"   python                     program\"), expected: \"pythonprogram\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "go_test.go",
-    "prompt": "package min_Swaps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1 string, str2 string) interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMin_Swaps(t *testing.T) {\n  candidate := min_Swaps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1101\", \"1110\"), expected: 1 },\n     { actual: candidate(\"111\", \"000\"), expected: \"Not Possible\" },\n     { actual: candidate(\"111\", \"110\"), expected: \"Not Possible\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "go_test.go",
-    "prompt": "package new_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create a new list from the given string and list.\nfunc new_tuple(test_list []string, test_str string) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestNew_Tuple(t *testing.T) {\n  candidate := new_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"WEB\", \"is\"}, \"best\"), expected: []interface{}{\"WEB\", \"is\", \"best\"} },\n     { actual: candidate([]string{\"We\", \"are\"}, \"Developers\"), expected: []interface{}{\"We\", \"are\", \"Developers\"} },\n     { actual: candidate([]string{\"Part\", \"is\"}, \"Wrong\"), expected: []interface{}{\"Part\", \"is\", \"Wrong\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "go_test.go",
-    "prompt": "package find_remainder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the product of the list multiplication modulo n.\nfunc find_remainder(arr []int, n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Remainder(t *testing.T) {\n  candidate := find_remainder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{100, 10, 5, 25, 35, 14}, 11), expected: 9 },\n     { actual: candidate([]int{1, 1, 1}, 1), expected: 0 },\n     { actual: candidate([]int{1, 2, 1}, 2), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "go_test.go",
-    "prompt": "package positive_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ration of positive numbers in a list of integers.\nfunc positive_count(nums []int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestPositive_Count(t *testing.T) {\n  candidate := positive_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), expected: 0.54 },\n     { actual: candidate([]int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 0.69 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: 0.56 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "go_test.go",
-    "prompt": "package add_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add the given list to the given list.\nfunc add_tuple(test_list []int, test_tup []interface{}) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestAdd_Tuple(t *testing.T) {\n  candidate := add_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []int{5, 6, 7, 9, 10} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []int{6, 7, 8, 10, 11} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []int{7, 8, 9, 11, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "go_test.go",
-    "prompt": "package max_run_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Run_Uppercase(t *testing.T) {\n  candidate := max_run_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"GeMKSForGERksISBESt\"), expected: 5 },\n     { actual: candidate(\"PrECIOusMOVemENTSYT\"), expected: 6 },\n     { actual: candidate(\"GooGLEFluTTER\"), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "go_test.go",
-    "prompt": "package sort_matrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M [][]int) [][]int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSort_Matrix(t *testing.T) {\n  candidate := sort_matrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{2, 4, 5}, []int{1, 1, 1}}), expected: [][]int{[]int{1, 1, 1}, []int{1, 2, 3}, []int{2, 4, 5}} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{-2, 4, -5}, []int{1, -1, 1}}), expected: [][]int{[]int{-2, 4, -5}, []int{1, -1, 1}, []int{1, 2, 3}} },\n     { actual: candidate([][]int{[]int{5, 8, 9}, []int{6, 4, 3}, []int{2, 1, 4}}), expected: [][]int{[]int{2, 1, 4}, []int{6, 4, 3}, []int{5, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "go_test.go",
-    "prompt": "package count_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Vowels(t *testing.T) {\n  candidate := count_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"bestinstareels\"), expected: 7 },\n     { actual: candidate(\"partofthejourneyistheend\"), expected: 12 },\n     { actual: candidate(\"amazonprime\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "go_test.go",
-    "prompt": "package max_sum_increasing_subseq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a []int, n int, index int, k int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMax_Sum_Increasing_Subseq(t *testing.T) {\n  candidate := max_sum_increasing_subseq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), expected: 11 },\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), expected: 7 },\n     { actual: candidate([]int{11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), expected: 71 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMultiply_Int(t *testing.T) {\n  candidate := multiply_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(5, 10), expected: 50 },\n     { actual: candidate(4, 8), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4834,7 +284,7 @@
     "language": "go_test.go",
     "prompt": "package long_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find words that are longer than n characters from a given list of words.\nfunc long_words(n int, str string) []string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "func TestLong_Words(t *testing.T) {\n  candidate := long_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, \"python is a programming language\"), expected: []string{\"python\", \"programming\", \"language\"} },\n     { actual: candidate(2, \"writing a program\"), expected: []string{\"writing\", \"program\"} },\n     { actual: candidate(5, \"sorting list\"), expected: []string{\"sorting\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -4844,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "go_test.go",
-    "prompt": "package find_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr []int) int {\n",
+    "prompt": "package magic_square_test_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix [][]int) bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestFind_Sum(t *testing.T) {\n  candidate := find_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 1, 1, 4, 5, 6}), expected: 21 },\n     { actual: candidate([]int{1, 10, 9, 4, 2, 10, 10, 45, 4}), expected: 71 },\n     { actual: candidate([]int{12, 10, 9, 45, 2, 10, 10, 45, 10}), expected: 78 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMagic_Square_Test(t *testing.T) {\n  candidate := magic_square_test\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{7, 12, 1, 14}, []int{2, 13, 8, 11}, []int{16, 3, 10, 5}, []int{9, 6, 15, 4}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 8}}), expected: true },\n     { actual: candidate([][]int{[]int{2, 7, 6}, []int{9, 5, 1}, []int{4, 3, 7}}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4858,13 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "go_test.go",
-    "prompt": "package tuple_to_dict_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given list to a key-value map using adjacent elements. https://www.geeksforgeeks.org/gothon-convert-list-to-adjacent-pair-map/\nfunc tuple_to_dict(test_tup []interface{}) map[int]int {\n",
+    "prompt": "package sort_matrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M [][]int) [][]int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestTuple_To_Dict(t *testing.T) {\n  candidate := tuple_to_dict\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 10, 13, 5}), expected: map[int]int{1: 5, 7: 10, 13: 5} },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}), expected: map[int]int{1: 2, 3: 4, 5: 6} },\n     { actual: candidate([]interface{}{7, 8, 9, 10, 11, 12}), expected: map[int]int{7: 8, 9: 10, 11: 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSort_Matrix(t *testing.T) {\n  candidate := sort_matrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{2, 4, 5}, []int{1, 1, 1}}), expected: [][]int{[]int{1, 1, 1}, []int{1, 2, 3}, []int{2, 4, 5}} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{-2, 4, -5}, []int{1, -1, 1}}), expected: [][]int{[]int{-2, 4, -5}, []int{1, -1, 1}, []int{1, 2, 3}} },\n     { actual: candidate([][]int{[]int{5, 8, 9}, []int{6, 4, 3}, []int{2, 1, 4}}), expected: [][]int{[]int{2, 1, 4}, []int{6, 4, 3}, []int{5, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -4872,209 +322,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "go_test.go",
-    "prompt": "package get_coordinates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract all the adjacent coordinates of the given coordinate list.\nfunc get_coordinates(test_tup []interface{}) [][]int {\n",
+    "prompt": "package max_occurrences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums []int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestGet_Coordinates(t *testing.T) {\n  candidate := get_coordinates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}), expected: [][]int{[]int{2, 3}, []int{2, 4}, []int{2, 5}, []int{3, 3}, []int{3, 4}, []int{3, 5}, []int{4, 3}, []int{4, 4}, []int{4, 5}} },\n     { actual: candidate([]interface{}{4, 5}), expected: [][]int{[]int{3, 4}, []int{3, 5}, []int{3, 6}, []int{4, 4}, []int{4, 5}, []int{4, 6}, []int{5, 4}, []int{5, 5}, []int{5, 6}} },\n     { actual: candidate([]interface{}{5, 6}), expected: [][]int{[]int{4, 5}, []int{4, 6}, []int{4, 7}, []int{5, 5}, []int{5, 6}, []int{5, 7}, []int{6, 5}, []int{6, 6}, []int{6, 7}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "go_test.go",
-    "prompt": "package check_type_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all the elements in list have same data type or not.\nfunc check_type(test_tuple interface{}) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Type(t *testing.T) {\n  candidate := check_type\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{5, 6, 7, 3, 5, 6}), expected: true },\n     { actual: candidate([]interface{}{1, 2, \"4\"}), expected: false },\n     { actual: candidate([]interface{}{3, 2, 1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "go_test.go",
-    "prompt": "package find_First_Missing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array []int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_First_Missing(t *testing.T) {\n  candidate := find_First_Missing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, 6, 9}), expected: 3 },\n     { actual: candidate([]int{2, 3, 5, 8, 9}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "go_test.go",
-    "prompt": "package is_undulating_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Undulating(t *testing.T) {\n  candidate := is_undulating\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1212121), expected: true },\n     { actual: candidate(1991), expected: false },\n     { actual: candidate(121), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "go_test.go",
-    "prompt": "package min_k_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/gothon-find-minimum-k-records-from-list-list/ - in this case a verbatim cogo of test cases\nfunc min_k(test_list [][]interface{}, K int) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMin_K(t *testing.T) {\n  candidate := min_k\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Manjeet\", 10}, []interface{}{\"Akshat\", 4}, []interface{}{\"Akash\", 2}, []interface{}{\"Nikhil\", 8}}, 2), expected: [][]int{[]interface{}{\"Akash\", 2}, []interface{}{\"Akshat\", 4}} },\n     { actual: candidate([][]int{[]interface{}{\"Sanjeev\", 11}, []interface{}{\"Angat\", 5}, []interface{}{\"Akash\", 3}, []interface{}{\"Nepin\", 9}}, 3), expected: [][]int{[]interface{}{\"Akash\", 3}, []interface{}{\"Angat\", 5}, []interface{}{\"Nepin\", 9}} },\n     { actual: candidate([][]int{[]interface{}{\"tanmay\", 14}, []interface{}{\"Amer\", 11}, []interface{}{\"Ayesha\", 9}, []interface{}{\"SKD\", 16}}, 1), expected: [][]int{[]interface{}{\"Ayesha\", 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "go_test.go",
-    "prompt": "package count_Substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s string) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestCount_Substrings(t *testing.T) {\n  candidate := count_Substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"112112\"), expected: 6 },\n     { actual: candidate(\"111\"), expected: 6 },\n     { actual: candidate(\"1101112\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "go_test.go",
-    "prompt": "package is_num_decagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Num_Decagonal(t *testing.T) {\n  candidate := is_num_decagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(7), expected: 175 },\n     { actual: candidate(10), expected: 370 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "go_test.go",
-    "prompt": "package rear_extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list of lists and returns a list containing the rear element of each list.\nfunc rear_extract(test_list [][]interface{}) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRear_Extract(t *testing.T) {\n  candidate := rear_extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{1, \"Rash\", 21}, []interface{}{2, \"Varsha\", 20}, []interface{}{3, \"Kil\", 19}}), expected: []int{21, 20, 19} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sai\", 36}, []interface{}{2, \"Ayesha\", 25}, []interface{}{3, \"Salman\", 45}}), expected: []int{36, 25, 45} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sudeep\", 14}, []interface{}{2, \"Vandana\", 36}, []interface{}{3, \"Dawood\", 56}}), expected: []int{14, 36, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "go_test.go",
-    "prompt": "package closest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the closest smaller number than n.\nfunc closest_num(N int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestClosest_Num(t *testing.T) {\n  candidate := closest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(11), expected: 10 },\n     { actual: candidate(7), expected: 6 },\n     { actual: candidate(12), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "go_test.go",
-    "prompt": "package find_combinations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/gothon-combinations-of-sum-with-lists-in-list-list/\nfunc find_combinations(test_list [][]interface{}) [][]interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestFind_Combinations(t *testing.T) {\n  candidate := find_combinations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 4}, []interface{}{6, 7}, []interface{}{5, 1}, []interface{}{6, 10}}), expected: [][]int{[]interface{}{8, 11}, []interface{}{7, 5}, []interface{}{8, 14}, []interface{}{11, 8}, []interface{}{12, 17}, []interface{}{11, 11}} },\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{7, 8}, []interface{}{6, 2}, []interface{}{7, 11}}), expected: [][]int{[]interface{}{10, 13}, []interface{}{9, 7}, []interface{}{10, 16}, []interface{}{13, 10}, []interface{}{14, 19}, []interface{}{13, 13}} },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{8, 9}, []interface{}{7, 3}, []interface{}{8, 12}}), expected: [][]int{[]interface{}{12, 15}, []interface{}{11, 9}, []interface{}{12, 18}, []interface{}{15, 12}, []interface{}{16, 21}, []interface{}{15, 15}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "go_test.go",
-    "prompt": "package maxAverageOfPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost [][]int) float64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMaxaverageofpath(t *testing.T) {\n  candidate := maxAverageOfPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{6, 5, 4}, []int{7, 3, 9}}), expected: 5.2 },\n     { actual: candidate([][]int{[]int{2, 3, 4}, []int{7, 6, 5}, []int{8, 4, 10}}), expected: 6.2 },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{8, 7, 6}, []int{9, 5, 11}}), expected: 7.2 },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}), expected: 5.8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "go_test.go",
-    "prompt": "package sequential_search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and returns a list containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist []int, item int) []interface{} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestSequential_Search(t *testing.T) {\n  candidate := sequential_search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), expected: []interface{}{true, 3} },\n     { actual: candidate([]int{12, 32, 45, 62, 35, 47, 44, 61}, 61), expected: []interface{}{true, 7} },\n     { actual: candidate([]int{9, 10, 17, 19, 22, 39, 48, 56}, 48), expected: []interface{}{true, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "go_test.go",
-    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove odd numbers from a given list.\nfunc remove_odd(l []int) []int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2} },\n     { actual: candidate([]int{2, 4, 6}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{10, 20, 3}), expected: []int{10, 20} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "go_test.go",
-    "prompt": "package is_product_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr []int) bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestIs_Product_Even(t *testing.T) {\n  candidate := is_product_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 4}), expected: true },\n     { actual: candidate([]int{1, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
-    "stop_tokens": [
-      "\nfunc",
-      "struct",
-      "\n// "
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "go_test.go",
-    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the maximum of two numbers.\nfunc maximum(a int, b int) int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 10), expected: 10 },\n     { actual: candidate(-1, -2), expected: -1 },\n     { actual: candidate(9, 7), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestMax_Occurrences(t *testing.T) {\n  candidate := max_occurrences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), expected: 2 },\n     { actual: candidate([]int{2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), expected: 8 },\n     { actual: candidate([]int{10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), expected: 20 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5086,9 +340,667 @@
     "language": "go_test.go",
     "prompt": "package reverse_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to reverse only the vowels of a given string (where y is not a vowel).\nfunc reverse_vowels(str1 string) string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "func TestReverse_Vowels(t *testing.T) {\n  candidate := reverse_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"USA\"), expected: \"ASU\" },\n     { actual: candidate(\"ab\"), expected: \"ab\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "go_test.go",
+    "prompt": "package tup_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a string.\nfunc tup_string(tup1 []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTup_String(t *testing.T) {\n  candidate := tup_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"}), expected: \"exercises\" },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}), expected: \"python\" },\n     { actual: candidate([]string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"}), expected: \"program\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "go_test.go",
+    "prompt": "package sum_negativenum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Negativenum(t *testing.T) {\n  candidate := sum_negativenum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: -32 },\n     { actual: candidate([]int{10, 15, -14, 13, -18, 12, -20}), expected: -52 },\n     { actual: candidate([]int{19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), expected: -894 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "go_test.go",
+    "prompt": "package hexagonal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestHexagonal_Num(t *testing.T) {\n  candidate := hexagonal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 190 },\n     { actual: candidate(5), expected: 45 },\n     { actual: candidate(7), expected: 91 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "go_test.go",
+    "prompt": "package is_Sum_Of_Powers_Of_Two_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Sum_Of_Powers_Of_Two(t *testing.T) {\n  candidate := is_Sum_Of_Powers_Of_Two\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(7), expected: false },\n     { actual: candidate(14), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "go_test.go",
+    "prompt": "package pancake_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc pancake_sort(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPancake_Sort(t *testing.T) {\n  candidate := pancake_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{15, 79, 25, 38, 69}), expected: []int{15, 25, 38, 69, 79} },\n     { actual: candidate([]int{98, 12, 54, 36, 85}), expected: []int{12, 36, 54, 85, 98} },\n     { actual: candidate([]int{41, 42, 32, 12, 23}), expected: []int{12, 23, 32, 41, 42} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "go_test.go",
+    "prompt": "package count_samepair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1 []int, list2 []int, list3 []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Samepair(t *testing.T) {\n  candidate := count_samepair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}, []int{2, 1, 3, 1, 2, 6, 7, 9}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 2, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 8}, []int{2, 1, 3, 1, 2, 6, 7, 8}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "go_test.go",
+    "prompt": "package find_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find number of lists present in the given list.\nfunc find_lists(Input []interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Lists(t *testing.T) {\n  candidate := find_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}}), expected: 2 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}), expected: 3 },\n     { actual: candidate([]int{9, 8, 7, 6, 5, 4, 3, 2, 1}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "go_test.go",
+    "prompt": "package max_Abs_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the maximum difference between any two elements in a given list.\nfunc max_Abs_Diff(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Abs_Diff(t *testing.T) {\n  candidate := max_Abs_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 3}), expected: 4 },\n     { actual: candidate([]int{9, 3, 2, 5, 1}), expected: 8 },\n     { actual: candidate([]int{3, 2, 1}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "go_test.go",
+    "prompt": "package find_Volume_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the volume of a triangular prism.\nfunc find_Volume(l int, b int, h int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Volume(t *testing.T) {\n  candidate := find_Volume\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 8, 6), expected: 240 },\n     { actual: candidate(3, 2, 2), expected: 6 },\n     { actual: candidate(1, 2, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "go_test.go",
+    "prompt": "package remove_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1 []int, list2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Elements(t *testing.T) {\n  candidate := remove_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{1, 3, 5, 7}), expected: []int{2, 4, 6, 8, 9, 10} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, []int{5, 7}), expected: []int{1, 2, 3, 4, 6, 8, 9, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "go_test.go",
+    "prompt": "package sum_series_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Series(t *testing.T) {\n  candidate := sum_series\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: 12 },\n     { actual: candidate(10), expected: 30 },\n     { actual: candidate(9), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "go_test.go",
+    "prompt": "package are_equivalent_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1 int, num2 int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAre_Equivalent(t *testing.T) {\n  candidate := are_equivalent\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(36, 57), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(23, 47), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "go_test.go",
+    "prompt": "package count_char_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1 string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Char_Position(t *testing.T) {\n  candidate := count_char_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"xbcefg\"), expected: 2 },\n     { actual: candidate(\"ABcED\"), expected: 3 },\n     { actual: candidate(\"AbgdeF\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "go_test.go",
+    "prompt": "package find_even_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Even_Pair(t *testing.T) {\n  candidate := find_even_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}), expected: 4 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}), expected: 9 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "go_test.go",
+    "prompt": "package next_power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNext_Power_Of_2(t *testing.T) {\n  candidate := next_power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(0), expected: 1 },\n     { actual: candidate(5), expected: 8 },\n     { actual: candidate(17), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "go_test.go",
+    "prompt": "package frequency_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFrequency(t *testing.T) {\n  candidate := frequency\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 2, 3, 3, 3, 4}, 3), expected: 3 },\n     { actual: candidate([]int{0, 1, 2, 3, 1, 2}, 1), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "go_test.go",
+    "prompt": "package text_lowercase_underscore_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Lowercase_Underscore(t *testing.T) {\n  candidate := text_lowercase_underscore\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aab_cbbbc\"), expected: true },\n     { actual: candidate(\"aab_Abbbc\"), expected: false },\n     { actual: candidate(\"Aaab_abbbc\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "go_test.go",
+    "prompt": "package sum_range_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1 []int, m int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Range_List(t *testing.T) {\n  candidate := sum_range_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), expected: 29 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), expected: 16 },\n     { actual: candidate([]int{2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), expected: 38 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "go_test.go",
+    "prompt": "package perimeter_pentagon_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPerimeter_Pentagon(t *testing.T) {\n  candidate := perimeter_pentagon\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 25 },\n     { actual: candidate(10), expected: 50 },\n     { actual: candidate(15), expected: 75 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "go_test.go",
+    "prompt": "package count_occurance_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Occurance(t *testing.T) {\n  candidate := count_occurance\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"letstdlenstdporstd\"), expected: 3 },\n     { actual: candidate(\"truststdsolensporsd\"), expected: 1 },\n     { actual: candidate(\"makestdsostdworthit\"), expected: 2 },\n     { actual: candidate(\"stds\"), expected: 1 },\n     { actual: candidate(\"\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "go_test.go",
+    "prompt": "package square_perimeter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSquare_Perimeter(t *testing.T) {\n  candidate := square_perimeter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 40 },\n     { actual: candidate(5), expected: 20 },\n     { actual: candidate(4), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "go_test.go",
+    "prompt": "package remove_dirty_chars_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(myString string, second_string string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Dirty_Chars(t *testing.T) {\n  candidate := remove_dirty_chars\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"probasscurve\", \"pros\"), expected: \"bacuve\" },\n     { actual: candidate(\"digitalindia\", \"talent\"), expected: \"digiidi\" },\n     { actual: candidate(\"exoticmiles\", \"toxic\"), expected: \"emles\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "go_test.go",
+    "prompt": "package test_duplicate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether a given list of integers contains any duplicate element.\nfunc test_duplicate(arraynums []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTest_Duplicate(t *testing.T) {\n  candidate := test_duplicate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2, 3, 3, 4, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "go_test.go",
+    "prompt": "package is_woodall_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Woodall(t *testing.T) {\n  candidate := is_woodall\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(383), expected: true },\n     { actual: candidate(254), expected: false },\n     { actual: candidate(200), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "go_test.go",
+    "prompt": "package check_type_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all the elements in list have same data type or not.\nfunc check_type(test_tuple interface{}) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Type(t *testing.T) {\n  candidate := check_type\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{5, 6, 7, 3, 5, 6}), expected: true },\n     { actual: candidate([]interface{}{1, 2, \"4\"}), expected: false },\n     { actual: candidate([]interface{}{3, 2, 1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "go_test.go",
+    "prompt": "package is_majority_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr []int, n int, x int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Majority(t *testing.T) {\n  candidate := is_majority\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 3, 3, 3, 10}, 7, 3), expected: true },\n     { actual: candidate([]int{1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), expected: false },\n     { actual: candidate([]int{1, 1, 1, 2, 2}, 5, 1), expected: true },\n     { actual: candidate([]int{1, 1, 2, 2}, 5, 1), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "go_test.go",
+    "prompt": "package count_Set_Bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Set_Bits(t *testing.T) {\n  candidate := count_Set_Bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 1 },\n     { actual: candidate(6), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "go_test.go",
+    "prompt": "package odd_values_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOdd_Values_String(t *testing.T) {\n  candidate := odd_values_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abcdef\"), expected: \"ace\" },\n     { actual: candidate(\"python\"), expected: \"pto\" },\n     { actual: candidate(\"data\"), expected: \"dt\" },\n     { actual: candidate(\"lambs\"), expected: \"lms\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "go_test.go",
+    "prompt": "package min_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum of three numbers.\nfunc min_of_three(a int, b int, c int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMin_Of_Three(t *testing.T) {\n  candidate := min_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20, 0), expected: 0 },\n     { actual: candidate(19, 15, 18), expected: 15 },\n     { actual: candidate(-10, -20, -30), expected: -30 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "go_test.go",
+    "prompt": "package all_Bits_Set_In_The_Given_Range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n int, l int, r int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAll_Bits_Set_In_The_Given_Range(t *testing.T) {\n  candidate := all_Bits_Set_In_The_Given_Range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4, 1, 2), expected: true },\n     { actual: candidate(17, 2, 4), expected: true },\n     { actual: candidate(39, 4, 6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "go_test.go",
+    "prompt": "package re_arrange_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr []int, n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRe_Arrange_Array(t *testing.T) {\n  candidate := re_arrange_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), expected: []int{-1, -3, -7, 4, 5, 6, 2, 8, 9} },\n     { actual: candidate([]int{12, -14, -26, 13, 15}, 5), expected: []int{-14, -26, 12, 13, 15} },\n     { actual: candidate([]int{10, 24, 36, -42, -39, -78, 85}, 7), expected: []int{-42, -39, -78, 10, 24, 36, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "go_test.go",
+    "prompt": "package replace_blank_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1 string, char string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_Blank(t *testing.T) {\n  candidate := replace_blank\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"hello people\", \"@\"), expected: \"hello@people\" },\n     { actual: candidate(\"python program language\", \"$\"), expected: \"python$program$language\" },\n     { actual: candidate(\"blank space\", \"-\"), expected: \"blank-space\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "go_test.go",
+    "prompt": "package volume_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestVolume_Cube(t *testing.T) {\n  candidate := volume_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(2), expected: 8 },\n     { actual: candidate(5), expected: 125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "go_test.go",
+    "prompt": "package number_of_substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNumber_Of_Substrings(t *testing.T) {\n  candidate := number_of_substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: 6 },\n     { actual: candidate(\"abcd\"), expected: 10 },\n     { actual: candidate(\"abcde\"), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "go_test.go",
+    "prompt": "package get_total_number_of_sequences_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Total_Number_Of_Sequences(t *testing.T) {\n  candidate := get_total_number_of_sequences\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 4), expected: 4 },\n     { actual: candidate(5, 2), expected: 6 },\n     { actual: candidate(16, 3), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "go_test.go",
+    "prompt": "package replace_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1 []interface{}, list2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_List(t *testing.T) {\n  candidate := replace_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 10}, []int{2, 4, 6, 8}), expected: []int{1, 3, 5, 7, 9, 2, 4, 6, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{5, 6, 7, 8}), expected: []int{1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]string{\"red\", \"blue\", \"green\"}, []string{\"yellow\"}), expected: []string{\"red\", \"blue\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "go_test.go",
+    "prompt": "package count_charac_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the total number of characters in a string.\nfunc count_charac(str1 string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Charac(t *testing.T) {\n  candidate := count_charac\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python programming\"), expected: 18 },\n     { actual: candidate(\"language\"), expected: 8 },\n     { actual: candidate(\"words\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "go_test.go",
+    "prompt": "package next_Perfect_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNext_Perfect_Square(t *testing.T) {\n  candidate := next_Perfect_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(35), expected: 36 },\n     { actual: candidate(6), expected: 9 },\n     { actual: candidate(9), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "go_test.go",
+    "prompt": "package max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Sum(t *testing.T) {\n  candidate := max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 15, 51, 45, 33, 100, 12, 18, 9}), expected: 194 },\n     { actual: candidate([]int{80, 60, 30, 40, 20, 10}), expected: 210 },\n     { actual: candidate([]int{2, 3, 14, 16, 21, 23, 29, 30}), expected: 138 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "go_test.go",
+    "prompt": "package lps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLps(t *testing.T) {\n  candidate := lps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"TENS FOR TENS\"), expected: 5 },\n     { actual: candidate(\"CARDIO FOR CARDS\"), expected: 7 },\n     { actual: candidate(\"PART OF THE JOURNEY IS PART\"), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "go_test.go",
+    "prompt": "package intersection_array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the intersection of two lists.\nfunc intersection_array(array_nums1 []int, array_nums2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIntersection_Array(t *testing.T) {\n  candidate := intersection_array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{1, 2, 4, 8, 9}), expected: []int{1, 2, 8, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{3, 5, 7, 9}), expected: []int{3, 5, 7, 9} },\n     { actual: candidate([]int{1, 2, 3, 5, 7, 8, 9, 10}, []int{10, 20, 30, 40}), expected: []int{10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "go_test.go",
+    "prompt": "package count_X_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a list and an element and counts the occcurences of the element in the list.\nfunc count_X(tup []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_X(t *testing.T) {\n  candidate := count_X\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), expected: 0 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), expected: 3 },\n     { actual: candidate([]int{10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "go_test.go",
+    "prompt": "package insert_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list []string, element string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestInsert_Element(t *testing.T) {\n  candidate := insert_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Black\"}, \"c\"), expected: []string{\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"} },\n     { actual: candidate([]string{\"python\", \"java\"}, \"program\"), expected: []string{\"program\", \"python\", \"program\", \"java\"} },\n     { actual: candidate([]string{\"happy\", \"sad\"}, \"laugh\"), expected: []string{\"laugh\", \"happy\", \"laugh\", \"sad\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "go_test.go",
+    "prompt": "package convert_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert complex numbers to polar coordinates.\nfunc convert(numbers int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestConvert(t *testing.T) {\n  candidate := convert\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: []interface{}{1.0, 0.0} },\n     { actual: candidate(4), expected: []interface{}{4.0, 0.0} },\n     { actual: candidate(5), expected: []interface{}{5.0, 0.0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "go_test.go",
+    "prompt": "package combinations_colors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l []string, n int) [][]string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCombinations_Colors(t *testing.T) {\n  candidate := combinations_colors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 1), expected: [][]int{[]string{\"Red\"}, []string{\"Green\"}, []string{\"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 2), expected: [][]int{[]string{\"Red\", \"Red\"}, []string{\"Red\", \"Green\"}, []string{\"Red\", \"Blue\"}, []string{\"Green\", \"Green\"}, []string{\"Green\", \"Blue\"}, []string{\"Blue\", \"Blue\"}} },\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\"}, 3), expected: [][]int{[]string{\"Red\", \"Red\", \"Red\"}, []string{\"Red\", \"Red\", \"Green\"}, []string{\"Red\", \"Red\", \"Blue\"}, []string{\"Red\", \"Green\", \"Green\"}, []string{\"Red\", \"Green\", \"Blue\"}, []string{\"Red\", \"Blue\", \"Blue\"}, []string{\"Green\", \"Green\", \"Green\"}, []string{\"Green\", \"Green\", \"Blue\"}, []string{\"Green\", \"Blue\", \"Blue\"}, []string{\"Blue\", \"Blue\", \"Blue\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "go_test.go",
+    "prompt": "package count_Primes_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Primes_Nums(t *testing.T) {\n  candidate := count_Primes_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 2 },\n     { actual: candidate(10), expected: 4 },\n     { actual: candidate(100), expected: 25 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "go_test.go",
+    "prompt": "package swap_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a int, b int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSwap_Numbers(t *testing.T) {\n  candidate := swap_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: []int{20, 10} },\n     { actual: candidate(15, 17), expected: []int{17, 15} },\n     { actual: candidate(100, 200), expected: []int{200, 100} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5100,7 +1012,7 @@
     "language": "go_test.go",
     "prompt": "package maximize_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to maximize the given two lists.\nfunc maximize_elements(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "func TestMaximize_Elements(t *testing.T) {\n  candidate := maximize_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 7}, []int{4, 9}, []int{2, 9}, []int{7, 10}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{7, 8}, []int{5, 10}, []int{3, 10}, []int{8, 11}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{8, 9}, []int{6, 11}, []int{4, 11}, []int{9, 12}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -5110,13 +1022,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "go_test.go",
-    "prompt": "package even_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums []int) bool {\n",
+    "prompt": "package newman_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestEven_Position(t *testing.T) {\n  candidate := even_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n     { actual: candidate([]int{2, 1, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestNewman_Prime(t *testing.T) {\n  candidate := newman_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 7 },\n     { actual: candidate(4), expected: 17 },\n     { actual: candidate(5), expected: 41 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5124,13 +1036,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "go_test.go",
-    "prompt": "package check_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(myString string) string {\n",
+    "prompt": "package division_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\nfunc division_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestCheck_Char(t *testing.T) {\n  candidate := check_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abba\"), expected: \"Valid\" },\n     { actual: candidate(\"a\"), expected: \"Valid\" },\n     { actual: candidate(\"abcd\"), expected: \"Invalid\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestDivision_Elements(t *testing.T) {\n  candidate := division_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{2, 2, 2, 3} },\n     { actual: candidate([]interface{}{12, 6, 8, 16}, []interface{}{6, 3, 4, 4}), expected: []interface{}{2, 2, 2, 4} },\n     { actual: candidate([]interface{}{20, 14, 36, 18}, []interface{}{5, 7, 6, 9}), expected: []interface{}{4, 2, 6, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5138,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "go_test.go",
-    "prompt": "package sumofFactors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of even factors of a number.\nfunc sumofFactors(n int) int {\n",
+    "prompt": "package split_two_parts_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\nfunc split_two_parts(list1 []interface{}, L int) interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestSumoffactors(t *testing.T) {\n  candidate := sumofFactors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(18), expected: 26 },\n     { actual: candidate(30), expected: 48 },\n     { actual: candidate(6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestSplit_Two_Parts(t *testing.T) {\n  candidate := split_two_parts\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []interface{}{[]int{1, 1, 2}, []int{3, 4, 4, 5, 1}} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, 2), expected: []interface{}{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}} },\n     { actual: candidate([]string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"}, 4), expected: []interface{}{[]string{\"p\", \"y\", \"t\", \"h\"}, []string{\"o\", \"n\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5152,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "go_test.go",
-    "prompt": "package lateralsurface_cone_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r int, h int) float64 {\n",
+    "prompt": "package dog_age_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestLateralsurface_Cone(t *testing.T) {\n  candidate := lateralsurface_cone\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 12), expected: 204.20352248333654 },\n     { actual: candidate(10, 15), expected: 566.3586699569488 },\n     { actual: candidate(19, 17), expected: 1521.8090132193388 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestDog_Age(t *testing.T) {\n  candidate := dog_age\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 61 },\n     { actual: candidate(15), expected: 73 },\n     { actual: candidate(24), expected: 109 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5166,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "go_test.go",
-    "prompt": "package count_Pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr []int, n int) int {\n",
+    "prompt": "package list_split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S []interface{}, step int) [][]interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestCount_Pairs(t *testing.T) {\n  candidate := count_Pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 1}, 3), expected: 2 },\n     { actual: candidate([]int{1, 1, 1, 1}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 5), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestList_Split(t *testing.T) {\n  candidate := list_split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"}, 3), expected: [][]int{[]string{\"a\", \"d\", \"g\", \"j\", \"m\"}, []string{\"b\", \"e\", \"h\", \"k\", \"n\"}, []string{\"c\", \"f\", \"i\", \"l\"}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), expected: [][]int{[]int{1, 4, 7, 10, 13}, []int{2, 5, 8, 11, 14}, []int{3, 6, 9, 12}} },\n     { actual: candidate([]string{\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"}, 2), expected: [][]int{[]string{\"python\", \"C\", \"DBMS\"}, []string{\"java\", \"C++\", \"SQL\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5180,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "go_test.go",
-    "prompt": "package find_first_occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the index of the first occurrence of a given number in a sorted list.\nfunc find_first_occurrence(A []int, x int) int {\n",
+    "prompt": "package lateralsurface_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestFind_First_Occurrence(t *testing.T) {\n  candidate := find_first_occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 1 },\n     { actual: candidate([]int{2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 2 },\n     { actual: candidate([]int{2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestLateralsurface_Cube(t *testing.T) {\n  candidate := lateralsurface_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 100 },\n     { actual: candidate(9), expected: 324 },\n     { actual: candidate(10), expected: 400 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5198,9 +1110,751 @@
     "language": "go_test.go",
     "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunc square_Sum(n int) int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 10 },\n     { actual: candidate(3), expected: 35 },\n     { actual: candidate(4), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "go_test.go",
+    "prompt": "package find_star_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th star number.\nfunc find_star_num(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Star_Num(t *testing.T) {\n  candidate := find_star_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 37 },\n     { actual: candidate(4), expected: 73 },\n     { actual: candidate(5), expected: 121 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "go_test.go",
+    "prompt": "package ascii_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ascii value of a character.\nfunc ascii_value(k string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAscii_Value(t *testing.T) {\n  candidate := ascii_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"A\"), expected: 65 },\n     { actual: candidate(\"R\"), expected: 82 },\n     { actual: candidate(\"S\"), expected: 83 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "go_test.go",
+    "prompt": "package sum_even_and_even_index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Even_And_Even_Index(t *testing.T) {\n  candidate := sum_even_and_even_index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 12, 1, 18, 8}), expected: 30 },\n     { actual: candidate([]int{3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), expected: 26 },\n     { actual: candidate([]int{5, 6, 12, 1}), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "go_test.go",
+    "prompt": "package even_Power_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEven_Power_Sum(t *testing.T) {\n  candidate := even_Power_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 1056 },\n     { actual: candidate(3), expected: 8832 },\n     { actual: candidate(1), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "go_test.go",
+    "prompt": "package rear_extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list of lists and returns a list containing the rear element of each list.\nfunc rear_extract(test_list [][]interface{}) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRear_Extract(t *testing.T) {\n  candidate := rear_extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{1, \"Rash\", 21}, []interface{}{2, \"Varsha\", 20}, []interface{}{3, \"Kil\", 19}}), expected: []int{21, 20, 19} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sai\", 36}, []interface{}{2, \"Ayesha\", 25}, []interface{}{3, \"Salman\", 45}}), expected: []int{36, 25, 45} },\n     { actual: candidate([][]int{[]interface{}{1, \"Sudeep\", 14}, []interface{}{2, \"Vandana\", 36}, []interface{}{3, \"Dawood\", 56}}), expected: []int{14, 36, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "go_test.go",
+    "prompt": "package substract_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\nfunc substract_elements(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSubstract_Elements(t *testing.T) {\n  candidate := substract_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5}, []interface{}{2, 5, 18}), expected: []interface{}{8, -1, -13} },\n     { actual: candidate([]interface{}{11, 2, 3}, []interface{}{24, 45, 16}), expected: []interface{}{-13, -43, -13} },\n     { actual: candidate([]interface{}{7, 18, 9}, []interface{}{10, 11, 12}), expected: []interface{}{-3, 7, -3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "go_test.go",
+    "prompt": "package even_binomial_Coeff_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEven_Binomial_Coeff_Sum(t *testing.T) {\n  candidate := even_binomial_Coeff_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 8 },\n     { actual: candidate(6), expected: 32 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "go_test.go",
+    "prompt": "package dict_filter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\nfunc dict_filter(dict map[string]int, n int) map[string]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDict_Filter(t *testing.T) {\n  candidate := dict_filter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170), expected: map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180), expected: map[string]int{\"Alden Cantrell\": 180, \"Pierre Cox\": 190} },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190), expected: map[string]int{\"Pierre Cox\": 190} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "go_test.go",
+    "prompt": "package is_num_decagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Num_Decagonal(t *testing.T) {\n  candidate := is_num_decagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 27 },\n     { actual: candidate(7), expected: 175 },\n     { actual: candidate(10), expected: 370 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "go_test.go",
+    "prompt": "package sequential_search_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and returns a list containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist []int, item int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSequential_Search(t *testing.T) {\n  candidate := sequential_search\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), expected: []interface{}{true, 3} },\n     { actual: candidate([]int{12, 32, 45, 62, 35, 47, 44, 61}, 61), expected: []interface{}{true, 7} },\n     { actual: candidate([]int{9, 10, 17, 19, 22, 39, 48, 56}, 48), expected: []interface{}{true, 6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "go_test.go",
+    "prompt": "package all_unique_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAll_Unique(t *testing.T) {\n  candidate := all_unique\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "go_test.go",
+    "prompt": "package sub_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1 []int, nums2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSub_List(t *testing.T) {\n  candidate := sub_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: []int{-3, -3, -3} },\n     { actual: candidate([]int{1, 2}, []int{3, 4}), expected: []int{-2, -2} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []int{40, 50} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "go_test.go",
+    "prompt": "package validate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestValidate(t *testing.T) {\n  candidate := validate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1234), expected: true },\n     { actual: candidate(51241), expected: false },\n     { actual: candidate(321), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "go_test.go",
+    "prompt": "package check_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list []interface{}, element interface{}) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Element(t *testing.T) {\n  candidate := check_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"green\", \"orange\", \"black\", \"white\"}, \"blue\"), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4}, 7), expected: false },\n     { actual: candidate([]string{\"green\", \"green\", \"green\", \"green\"}, \"green\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "go_test.go",
+    "prompt": "package text_match_two_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_Two_Three(t *testing.T) {\n  candidate := text_match_two_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "go_test.go",
+    "prompt": "package max_sub_array_sum_repeated_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\nfunc max_sub_array_sum_repeated(a []int, n int, k int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Sub_Array_Sum_Repeated(t *testing.T) {\n  candidate := max_sub_array_sum_repeated\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, -30, -1}, 4, 3), expected: 30 },\n     { actual: candidate([]int{-1, 10, 20}, 3, 2), expected: 59 },\n     { actual: candidate([]int{-1, -2, -3}, 3, 3), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "go_test.go",
+    "prompt": "package square_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSquare_Sum(t *testing.T) {\n  candidate := square_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 20 },\n     { actual: candidate(3), expected: 56 },\n     { actual: candidate(4), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "go_test.go",
+    "prompt": "package max_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1 [][]int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Length(t *testing.T) {\n  candidate := max_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1}, []int{5, 7}, []int{10, 12, 14, 15}}), expected: []interface{}{4, []int{10, 12, 14, 15}} },\n     { actual: candidate([][]int{[]int{5}, []int{15, 20, 25}}), expected: []interface{}{3, []int{15, 20, 25}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "go_test.go",
+    "prompt": "package count_no_of_ways_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n int, k int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_No_Of_Ways(t *testing.T) {\n  candidate := count_no_of_ways\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 4), expected: 16 },\n     { actual: candidate(3, 2), expected: 6 },\n     { actual: candidate(4, 4), expected: 228 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "go_test.go",
+    "prompt": "package find_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n int, m int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind(t *testing.T) {\n  candidate := find\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 3), expected: 3 },\n     { actual: candidate(4, 2), expected: 2 },\n     { actual: candidate(20, 5), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "go_test.go",
+    "prompt": "package otherside_rightangle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w int, h int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOtherside_Rightangle(t *testing.T) {\n  candidate := otherside_rightangle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7, 8), expected: 10.63014581273465 },\n     { actual: candidate(3, 4), expected: 5 },\n     { actual: candidate(7, 15), expected: 16.55294535724685 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "go_test.go",
+    "prompt": "package sum_div_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Div(t *testing.T) {\n  candidate := sum_div\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: 7 },\n     { actual: candidate(12), expected: 16 },\n     { actual: candidate(7), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "go_test.go",
+    "prompt": "package get_Inv_Count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count inversions in a list.\nfunc get_Inv_Count(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Inv_Count(t *testing.T) {\n  candidate := get_Inv_Count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 20, 6, 4, 5}), expected: 5 },\n     { actual: candidate([]int{1, 2, 1}), expected: 1 },\n     { actual: candidate([]int{1, 2, 5, 6, 1}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "go_test.go",
+    "prompt": "package max_aggregate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the maximum aggregate from the list of lists.\nfunc max_aggregate(stdata [][]interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Aggregate(t *testing.T) {\n  candidate := max_aggregate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 90}, []interface{}{\"Sabah Colley\", 88}, []interface{}{\"Peter Nichols\", 7}, []interface{}{\"Juan Whelan\", 122}, []interface{}{\"Sabah Colley\", 84}}), expected: []interface{}{\"Juan Whelan\", 212} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 50}, []interface{}{\"Sabah Colley\", 48}, []interface{}{\"Peter Nichols\", 37}, []interface{}{\"Juan Whelan\", 22}, []interface{}{\"Sabah Colley\", 14}}), expected: []interface{}{\"Juan Whelan\", 72} },\n     { actual: candidate([][]int{[]interface{}{\"Juan Whelan\", 10}, []interface{}{\"Sabah Colley\", 20}, []interface{}{\"Peter Nichols\", 30}, []interface{}{\"Juan Whelan\", 40}, []interface{}{\"Sabah Colley\", 50}}), expected: []interface{}{\"Sabah Colley\", 70} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "go_test.go",
+    "prompt": "package find_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find element at a given index after number of rotations.\nfunc find_Element(arr []int, ranges [][]int, rotations int, index int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Element(t *testing.T) {\n  candidate := find_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, [][]int{[]int{0, 2}, []int{0, 3}}, 2, 1), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 2), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, [][]int{[]int{0, 1}, []int{0, 2}}, 1, 1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "go_test.go",
+    "prompt": "package start_withp_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words []string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestStart_Withp(t *testing.T) {\n  candidate := start_withp\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python PHP\", \"Java JavaScript\", \"c c++\"}), expected: []interface{}{\"Python\", \"PHP\"} },\n     { actual: candidate([]string{\"Python Programming\", \"Java Programming\"}), expected: []interface{}{\"Python\", \"Programming\"} },\n     { actual: candidate([]string{\"Pqrst Pqr\", \"qrstuv\"}), expected: []interface{}{\"Pqrst\", \"Pqr\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "go_test.go",
+    "prompt": "package max_sum_increasing_subseq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a []int, n int, index int, k int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Sum_Increasing_Subseq(t *testing.T) {\n  candidate := max_sum_increasing_subseq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), expected: 11 },\n     { actual: candidate([]int{1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), expected: 7 },\n     { actual: candidate([]int{11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), expected: 71 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "go_test.go",
+    "prompt": "package large_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1 []int, nums2 []int, N int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLarge_Product(t *testing.T) {\n  candidate := large_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 3), expected: []int{60, 54, 50} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 4), expected: []int{60, 54, 50, 48} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, []int{3, 6, 8, 9, 10, 6}, 5), expected: []int{60, 54, 50, 48, 45} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "go_test.go",
+    "prompt": "package maximum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the maximum of two numbers.\nfunc maximum(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMaximum(t *testing.T) {\n  candidate := maximum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 10), expected: 10 },\n     { actual: candidate(-1, -2), expected: -1 },\n     { actual: candidate(9, 7), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "go_test.go",
+    "prompt": "package string_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1 string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestString_To_Tuple(t *testing.T) {\n  candidate := string_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python 3.0\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"} },\n     { actual: candidate(\"item1\"), expected: []string{\"i\", \"t\", \"e\", \"m\", \"1\"} },\n     { actual: candidate(\"15.10\"), expected: []string{\"1\", \"5\", \".\", \"1\", \"0\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "go_test.go",
+    "prompt": "package highest_Power_of_2_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestHighest_Power_Of_2(t *testing.T) {\n  candidate := highest_Power_of_2\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 8 },\n     { actual: candidate(19), expected: 16 },\n     { actual: candidate(32), expected: 32 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "go_test.go",
+    "prompt": "package find_lucas_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n'th lucas number.\nfunc find_lucas(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Lucas(t *testing.T) {\n  candidate := find_lucas\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 76 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(3), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "go_test.go",
+    "prompt": "package add_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_ []interface{}, myString string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd_String(t *testing.T) {\n  candidate := add_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}, \"temp{0}\"), expected: []string{\"temp1\", \"temp2\", \"temp3\", \"temp4\"} },\n     { actual: candidate([]string{\"a\", \"b\", \"c\", \"d\"}, \"python{0}\"), expected: []string{\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"} },\n     { actual: candidate([]int{5, 6, 7, 8}, \"string{0}\"), expected: []string{\"string5\", \"string6\", \"string7\", \"string8\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "go_test.go",
+    "prompt": "package get_max_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Max_Sum(t *testing.T) {\n  candidate := get_max_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(60), expected: 106 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "go_test.go",
+    "prompt": "package max_length_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the list with maximum length.\nfunc max_length_list(input_list [][]int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Length_List(t *testing.T) {\n  candidate := max_length_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{0}, []int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: []interface{}{3, []int{13, 15, 17}} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}, []int{1, 2, 3}, []int{1, 2}, []int{1}}), expected: []interface{}{5, []int{1, 2, 3, 4, 5}} },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{6, 7, 8, 9}, []int{10, 11, 12}}), expected: []interface{}{4, []int{6, 7, 8, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "go_test.go",
+    "prompt": "package check_distinct_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Distinct(t *testing.T) {\n  candidate := check_distinct\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 5, 6, 1, 4}), expected: false },\n     { actual: candidate([]int{1, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 6}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "go_test.go",
+    "prompt": "package check_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Char(t *testing.T) {\n  candidate := check_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abba\"), expected: \"Valid\" },\n     { actual: candidate(\"a\"), expected: \"Valid\" },\n     { actual: candidate(\"abcd\"), expected: \"Invalid\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "go_test.go",
+    "prompt": "package median_numbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of three numbers.\nfunc median_numbers(a int, b int, c int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMedian_Numbers(t *testing.T) {\n  candidate := median_numbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(25, 55, 65), expected: 55.0 },\n     { actual: candidate(20, 10, 30), expected: 20.0 },\n     { actual: candidate(15, 45, 75), expected: 45.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "go_test.go",
+    "prompt": "package sum_of_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums []interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Of_Digits(t *testing.T) {\n  candidate := sum_of_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 2, 56}), expected: 14 },\n     { actual: candidate([][]int{[]interface{}{10, 20, 4, 5, \"b\", 70, \"a\"}}), expected: 19 },\n     { actual: candidate([]int{10, 20, -4, 5, -70}), expected: 19 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "go_test.go",
+    "prompt": "package bitwise_xor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform the mathematical bitwise xor operation across the given lists.\nfunc bitwise_xor(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBitwise_Xor(t *testing.T) {\n  candidate := bitwise_xor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{15, 6, 5, 10} },\n     { actual: candidate([]interface{}{11, 5, 7, 10}, []interface{}{6, 3, 4, 4}), expected: []interface{}{13, 6, 3, 14} },\n     { actual: candidate([]interface{}{12, 6, 8, 11}, []interface{}{7, 4, 5, 6}), expected: []interface{}{11, 2, 13, 13} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "go_test.go",
+    "prompt": "package is_not_prime_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to identify non-prime numbers.\nfunc is_not_prime(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Not_Prime(t *testing.T) {\n  candidate := is_not_prime\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: false },\n     { actual: candidate(10), expected: true },\n     { actual: candidate(35), expected: true },\n     { actual: candidate(37), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "go_test.go",
+    "prompt": "package extract_freq_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the number of unique lists in the given list.\nfunc extract_freq(test_list [][]interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Freq(t *testing.T) {\n  candidate := extract_freq\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 4}, []interface{}{1, 2}, []interface{}{4, 3}, []interface{}{5, 6}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{4, 15}, []interface{}{2, 3}, []interface{}{5, 4}, []interface{}{6, 7}}), expected: 4 },\n     { actual: candidate([][]int{[]interface{}{5, 16}, []interface{}{2, 3}, []interface{}{6, 5}, []interface{}{6, 9}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "go_test.go",
+    "prompt": "package add_nested_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd_Nested_Tuples(t *testing.T) {\n  candidate := add_nested_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{7, 10}, []int{7, 14}, []int{3, 10}, []int{8, 13}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{9, 12}, []int{9, 16}, []int{5, 12}, []int{10, 15}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{11, 14}, []int{11, 18}, []int{7, 14}, []int{12, 17}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "go_test.go",
+    "prompt": "package minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum of two numbers.\nfunc minimum(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMinimum(t *testing.T) {\n  candidate := minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(-5, -4), expected: -5 },\n     { actual: candidate(0, 0), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "go_test.go",
+    "prompt": "package find_Parity_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find whether the parity of a given number is odd.\nfunc find_Parity(x int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Parity(t *testing.T) {\n  candidate := find_Parity\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: false },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(10), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "go_test.go",
+    "prompt": "package rearrange_bigger_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n int) interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRearrange_Bigger(t *testing.T) {\n  candidate := rearrange_bigger\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12), expected: 21 },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(102), expected: 120 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "go_test.go",
+    "prompt": "package k_smallest_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\nfunc k_smallest_pairs(nums1 []int, nums2 []int, k int) [][]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestK_Smallest_Pairs(t *testing.T) {\n  candidate := k_smallest_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 2), expected: [][]int{[]int{1, 2}, []int{1, 4}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 1), expected: [][]int{[]int{1, 2}} },\n     { actual: candidate([]int{1, 3, 7}, []int{2, 4, 6}, 7), expected: [][]int{[]int{1, 2}, []int{1, 4}, []int{3, 2}, []int{1, 6}, []int{3, 4}, []int{3, 6}, []int{7, 2}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "go_test.go",
+    "prompt": "package min_product_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the minimum product from the pairs of lists within a given list.\nfunc min_product_tuple(list1 [][]interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMin_Product_Tuple(t *testing.T) {\n  candidate := min_product_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 7}, []interface{}{2, 6}, []interface{}{1, 8}, []interface{}{4, 9}}), expected: 8 },\n     { actual: candidate([][]int{[]interface{}{10, 20}, []interface{}{15, 2}, []interface{}{5, 10}}), expected: 30 },\n     { actual: candidate([][]int{[]interface{}{11, 44}, []interface{}{10, 15}, []interface{}{20, 5}, []interface{}{12, 9}}), expected: 100 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "go_test.go",
+    "prompt": "package snake_to_camel_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSnake_To_Camel(t *testing.T) {\n  candidate := snake_to_camel\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"android_tv\"), expected: \"AndroidTv\" },\n     { actual: candidate(\"google_pixel\"), expected: \"GooglePixel\" },\n     { actual: candidate(\"apple_watch\"), expected: \"AppleWatch\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "go_test.go",
+    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove odd numbers from a given list.\nfunc remove_odd(l []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{2} },\n     { actual: candidate([]int{2, 4, 6}), expected: []int{2, 4, 6} },\n     { actual: candidate([]int{10, 20, 3}), expected: []int{10, 20} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "go_test.go",
+    "prompt": "package extract_nth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the nth element from a given list of lists.\nfunc extract_nth_element(list1 [][]interface{}, n int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Nth_Element(t *testing.T) {\n  candidate := extract_nth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 0), expected: []string{\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 2), expected: []int{99, 96, 94, 98} },\n     { actual: candidate([][]int{[]interface{}{\"Greyson Fulton\", 98, 99}, []interface{}{\"Brady Kent\", 97, 96}, []interface{}{\"Wyatt Knott\", 91, 94}, []interface{}{\"Beau Turnbull\", 94, 98}}, 1), expected: []int{98, 97, 91, 94} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "go_test.go",
+    "prompt": "package overlapping_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1 []int, list2 []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOverlapping(t *testing.T) {\n  candidate := overlapping\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 8, 9}), expected: false },\n     { actual: candidate([]int{1, 2, 3}, []int{4, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 4, 5}, []int{1, 4, 5}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "go_test.go",
+    "prompt": "package max_Product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find a pair with highest product from a given list of integers.\nfunc max_Product(arr []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_Product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 7, 0, 8, 4}), expected: []interface{}{7, 8} },\n     { actual: candidate([]int{0, -1, -2, -4, 5, 0, -6}), expected: []interface{}{-4, -6} },\n     { actual: candidate([]int{1, 2, 3}), expected: []interface{}{2, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",
@@ -5212,7 +1866,7 @@
     "language": "go_test.go",
     "prompt": "package group_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find common first element in given list of lists.\nfunc group_tuples(Input [][]string) [][]string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "func TestGroup_Tuples(t *testing.T) {\n  candidate := group_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"x\", \"z\"}, []string{\"w\", \"t\"}}), expected: [][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"w\", \"t\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"a\", \"c\"}, []string{\"d\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\", \"c\"}, []string{\"d\", \"e\"}} },\n     { actual: candidate([][]int{[]string{\"f\", \"g\"}, []string{\"f\", \"g\"}, []string{\"h\", \"i\"}}), expected: [][]int{[]string{\"f\", \"g\", \"g\"}, []string{\"h\", \"i\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
@@ -5222,13 +1876,3359 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "go_test.go",
-    "prompt": "package merge_sorted_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1 []int, num2 []int, num3 []int) []int {\n",
+    "prompt": "package Find_Max_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the element of a list having maximum length.\nfunc Find_Max(lst [][]interface{}) []interface{} {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "func TestMerge_Sorted_List(t *testing.T) {\n  candidate := merge_sorted_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 24, 15, 4, 5, 29, 110}, []int{19, 20, 11, 56, 25, 233, 154}, []int{24, 26, 54, 48}), expected: []int{4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233} },\n     { actual: candidate([]int{1, 3, 5, 6, 8, 9}, []int{2, 5, 7, 11}, []int{1, 4, 7, 8, 12}), expected: []int{1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12} },\n     { actual: candidate([]int{18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, []int{25, 35, 22, 85, 14, 65, 75, 25, 58}, []int{12, 74, 9, 50, 61, 41}), expected: []int{1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "tests": "func TestFind_Max(t *testing.T) {\n  candidate := Find_Max\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"A\"}, []string{\"A\", \"B\"}, []string{\"A\", \"B\", \"C\"}}), expected: []string{\"A\", \"B\", \"C\"} },\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1, 2, 3} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 2, 3}, []int{1, 5, 6, 1}}), expected: []int{1, 5, 6, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "go_test.go",
+    "prompt": "package cube_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCube_Sum(t *testing.T) {\n  candidate := cube_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 72 },\n     { actual: candidate(3), expected: 288 },\n     { actual: candidate(4), expected: 800 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "go_test.go",
+    "prompt": "package concatenate_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to concatenate each element of list by the delimiter.\nfunc concatenate_tuple(test_tup []interface{}) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestConcatenate_Tuple(t *testing.T) {\n  candidate := concatenate_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"ID\", \"is\", 4, \"UTS\"}), expected: \"ID-is-4-UTS\" },\n     { actual: candidate([]interface{}{\"QWE\", \"is\", 4, \"RTY\"}), expected: \"QWE-is-4-RTY\" },\n     { actual: candidate([]interface{}{\"ZEN\", \"is\", 4, \"OP\"}), expected: \"ZEN-is-4-OP\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "go_test.go",
+    "prompt": "package find_Average_Of_Cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Average_Of_Cube(t *testing.T) {\n  candidate := find_Average_Of_Cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4.5 },\n     { actual: candidate(3), expected: 12 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "go_test.go",
+    "prompt": "package extract_rear_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract only the rear index element of each string in the given list.\nfunc extract_rear(test_tuple []interface{}) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Rear(t *testing.T) {\n  candidate := extract_rear\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"Mers\", \"for\", \"Vers\"}), expected: []string{\"s\", \"r\", \"s\"} },\n     { actual: candidate([]interface{}{\"Avenge\", \"for\", \"People\"}), expected: []string{\"e\", \"r\", \"e\"} },\n     { actual: candidate([]interface{}{\"Gotta\", \"get\", \"go\"}), expected: []string{\"a\", \"t\", \"o\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "go_test.go",
+    "prompt": "package count_element_in_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1 [][]interface{}, x interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Element_In_List(t *testing.T) {\n  candidate := count_element_in_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{1, 11}, []int{1, 15, 7}}, 1), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"A\"), expected: 3 },\n     { actual: candidate([][]int{[]string{\"A\", \"B\"}, []string{\"A\", \"C\"}, []string{\"A\", \"D\", \"E\"}, []string{\"B\", \"C\", \"D\"}}, \"E\"), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "go_test.go",
+    "prompt": "package filter_oddnumbers_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFilter_Oddnumbers(t *testing.T) {\n  candidate := filter_oddnumbers\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 3, 5, 7, 9} },\n     { actual: candidate([]int{10, 20, 45, 67, 84, 93}), expected: []int{45, 67, 93} },\n     { actual: candidate([]int{5, 7, 9, 8, 6, 4, 3}), expected: []int{5, 7, 9, 3} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "go_test.go",
+    "prompt": "package change_date_format_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestChange_Date_Format(t *testing.T) {\n  candidate := change_date_format\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"2026-01-02\"), expected: \"02-01-2026\" },\n     { actual: candidate(\"2020-11-13\"), expected: \"13-11-2020\" },\n     { actual: candidate(\"2021-04-26\"), expected: \"26-04-2021\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "go_test.go",
+    "prompt": "package shell_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list by using shell sort.\nfunc shell_sort(my_list []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestShell_Sort(t *testing.T) {\n  candidate := shell_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), expected: []int{2, 3, 4, 5, 12, 12, 23, 56, 81, 95} },\n     { actual: candidate([]int{24, 22, 39, 34, 87, 73, 68}), expected: []int{22, 24, 34, 39, 68, 73, 87} },\n     { actual: candidate([]int{32, 30, 16, 96, 82, 83, 74}), expected: []int{16, 30, 32, 74, 82, 83, 96} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "go_test.go",
+    "prompt": "package and_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract the elementwise and lists from the given two lists.\nfunc and_tuples(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAnd_Tuples(t *testing.T) {\n  candidate := and_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 6, 9}, []interface{}{5, 2, 3, 3}), expected: []interface{}{0, 0, 2, 1} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{5, 6, 7, 8}), expected: []interface{}{1, 2, 3, 0} },\n     { actual: candidate([]interface{}{8, 9, 11, 12}, []interface{}{7, 13, 14, 17}), expected: []interface{}{0, 9, 10, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "go_test.go",
+    "prompt": "package parabola_directrix_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a int, b int, c int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestParabola_Directrix(t *testing.T) {\n  candidate := parabola_directrix\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 3, 2), expected: -198 },\n     { actual: candidate(9, 8, 4), expected: -2336 },\n     { actual: candidate(2, 4, 6), expected: -130 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "go_test.go",
+    "prompt": "package median_trapezium_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1 int, base2 int, height int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMedian_Trapezium(t *testing.T) {\n  candidate := median_trapezium\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15, 25, 35), expected: 20 },\n     { actual: candidate(10, 20, 30), expected: 15 },\n     { actual: candidate(6, 9, 4), expected: 7.5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "go_test.go",
+    "prompt": "package check_greater_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the entered number is greater than the elements of the given list.\nfunc check_greater(arr []int, number int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Greater(t *testing.T) {\n  candidate := check_greater\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 4), expected: false },\n     { actual: candidate([]int{2, 3, 4, 5, 6}, 8), expected: true },\n     { actual: candidate([]int{9, 7, 4, 8, 6, 1}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "go_test.go",
+    "prompt": "package text_match_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_One(t *testing.T) {\n  candidate := text_match_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "go_test.go",
+    "prompt": "package last_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last digit of a given number.\nfunc last_Digit(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLast_Digit(t *testing.T) {\n  candidate := last_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 3 },\n     { actual: candidate(25), expected: 5 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "go_test.go",
+    "prompt": "package neg_nos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to return the negative numbers in a list.\nfunc neg_nos(list1 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNeg_Nos(t *testing.T) {\n  candidate := neg_nos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-1, 4, 5, -6}), expected: []int{-1, -6} },\n     { actual: candidate([]int{-1, -2, 3, 4}), expected: []int{-1, -2} },\n     { actual: candidate([]int{-7, -6, 8, 9}), expected: []int{-7, -6} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "go_test.go",
+    "prompt": "package remove_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove odd characters in a string.\nfunc remove_odd(str1 string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Odd(t *testing.T) {\n  candidate := remove_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: \"yhn\" },\n     { actual: candidate(\"program\"), expected: \"rga\" },\n     { actual: candidate(\"language\"), expected: \"agae\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "go_test.go",
+    "prompt": "package count_bidirectional_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count bidirectional list pairs.\nfunc count_bidirectional(test_list [][]interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Bidirectional(t *testing.T) {\n  candidate := count_bidirectional\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 3}, []interface{}{6, 5}, []interface{}{9, 1}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 2 },\n     { actual: candidate([][]int{[]interface{}{5, 6}, []interface{}{1, 2}, []interface{}{6, 5}, []interface{}{9, 2}, []interface{}{6, 5}, []interface{}{2, 1}}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "go_test.go",
+    "prompt": "package multiple_to_single_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMultiple_To_Single(t *testing.T) {\n  candidate := multiple_to_single\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{11, 33, 50}), expected: 113350 },\n     { actual: candidate([]int{-1, 2, 3, 4, 5, 6}), expected: -123456 },\n     { actual: candidate([]int{10, 15, 20, 25}), expected: 10152025 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "go_test.go",
+    "prompt": "package find_adverb_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Adverb_Position(t *testing.T) {\n  candidate := find_adverb_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"clearly!! we can see the sky\"), expected: []interface{}{0, 7, \"clearly\"} },\n     { actual: candidate(\"seriously!! there are many roses\"), expected: []interface{}{0, 9, \"seriously\"} },\n     { actual: candidate(\"unfortunately!! sita is going to home\"), expected: []interface{}{0, 13, \"unfortunately\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "go_test.go",
+    "prompt": "package surfacearea_cube_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSurfacearea_Cube(t *testing.T) {\n  candidate := surfacearea_cube\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 150 },\n     { actual: candidate(3), expected: 54 },\n     { actual: candidate(10), expected: 600 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "go_test.go",
+    "prompt": "package positive_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the ration of positive numbers in a list of integers.\nfunc positive_count(nums []int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPositive_Count(t *testing.T) {\n  candidate := positive_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), expected: 0.54 },\n     { actual: candidate([]int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 0.69 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}), expected: 0.56 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "go_test.go",
+    "prompt": "package largest_neg_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the largest negative number from the given list.\nfunc largest_neg(list1 []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLargest_Neg(t *testing.T) {\n  candidate := largest_neg\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, -4, -6}), expected: -6 },\n     { actual: candidate([]int{1, 2, 3, -8, -9}), expected: -9 },\n     { actual: candidate([]int{1, 2, 3, 4, -1}), expected: -1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "go_test.go",
+    "prompt": "package trim_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list [][]int, K int) [][]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTrim_Tuple(t *testing.T) {\n  candidate := trim_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 2), expected: [][]int{[]int{2}, []int{9}, []int{2}, []int{2}} },\n     { actual: candidate([][]int{[]int{5, 3, 2, 1, 4}, []int{3, 4, 9, 2, 1}, []int{9, 1, 2, 3, 5}, []int{4, 8, 2, 1, 7}}, 1), expected: [][]int{[]int{3, 2, 1}, []int{4, 9, 2}, []int{1, 2, 3}, []int{8, 2, 1}} },\n     { actual: candidate([][]int{[]int{7, 8, 4, 9}, []int{11, 8, 12, 4}, []int{4, 1, 7, 8}, []int{3, 6, 9, 7}}, 1), expected: [][]int{[]int{8, 4}, []int{8, 12}, []int{1, 7}, []int{6, 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "go_test.go",
+    "prompt": "package index_multiplication_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1 [][]int, test_tup2 [][]int) [][]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIndex_Multiplication(t *testing.T) {\n  candidate := index_multiplication\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{4, 5}, []int{2, 9}, []int{1, 10}}, [][]int{[]int{6, 7}, []int{3, 9}, []int{1, 1}, []int{7, 3}}), expected: [][]int{[]int{6, 21}, []int{12, 45}, []int{2, 9}, []int{7, 30}} },\n     { actual: candidate([][]int{[]int{2, 4}, []int{5, 6}, []int{3, 10}, []int{2, 11}}, [][]int{[]int{7, 8}, []int{4, 10}, []int{2, 2}, []int{8, 4}}), expected: [][]int{[]int{14, 32}, []int{20, 60}, []int{6, 20}, []int{16, 44}} },\n     { actual: candidate([][]int{[]int{3, 5}, []int{6, 7}, []int{4, 11}, []int{3, 12}}, [][]int{[]int{8, 9}, []int{5, 11}, []int{3, 3}, []int{9, 5}}), expected: [][]int{[]int{24, 45}, []int{30, 77}, []int{12, 33}, []int{27, 60}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "go_test.go",
+    "prompt": "package count_Occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the occurence of all elements of list in a list.\nfunc count_Occurrence(tup interface{}, lst []interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Occurrence(t *testing.T) {\n  candidate := count_Occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{\"a\", \"a\", \"c\", \"b\", \"d\"}, []string{\"a\", \"b\"}), expected: 3 },\n     { actual: candidate([]interface{}{1, 2, 3, 1, 4, 6, 7, 1, 4}, []int{1, 4, 7}), expected: 6 },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}, []int{1, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "go_test.go",
+    "prompt": "package cube_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCube_Nums(t *testing.T) {\n  candidate := cube_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 8, 27, 64, 125, 216, 343, 512, 729, 1000} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}), expected: []int{1728, 3375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "go_test.go",
+    "prompt": "package cal_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCal_Sum(t *testing.T) {\n  candidate := cal_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 49 },\n     { actual: candidate(10), expected: 66 },\n     { actual: candidate(11), expected: 88 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "go_test.go",
+    "prompt": "package extract_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str []string, l int) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_String(t *testing.T) {\n  candidate := extract_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 8), expected: []string{\"practice\", \"solution\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 6), expected: []string{\"Python\"} },\n     { actual: candidate([]string{\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"}, 9), expected: []string{\"exercises\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "go_test.go",
+    "prompt": "package remove_whitespaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1 string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Whitespaces(t *testing.T) {\n  candidate := remove_whitespaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\" Google    Flutter \"), expected: \"GoogleFlutter\" },\n     { actual: candidate(\" Google    Dart \"), expected: \"GoogleDart\" },\n     { actual: candidate(\" iOS    Swift \"), expected: \"iOSSwift\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "go_test.go",
+    "prompt": "package loss_amount_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost int, sale_amount int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLoss_Amount(t *testing.T) {\n  candidate := loss_amount\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: 0 },\n     { actual: candidate(100, 200), expected: 100 },\n     { actual: candidate(2000, 5000), expected: 3000 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "go_test.go",
+    "prompt": "package sumofFactors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of even factors of a number.\nfunc sumofFactors(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSumoffactors(t *testing.T) {\n  candidate := sumofFactors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(18), expected: 26 },\n     { actual: candidate(30), expected: 48 },\n     { actual: candidate(6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "go_test.go",
+    "prompt": "package text_match_wordz_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_Wordz(t *testing.T) {\n  candidate := text_match_wordz\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonz.\"), expected: true },\n     { actual: candidate(\"xyz.\"), expected: true },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "go_test.go",
+    "prompt": "package check_monthnumb_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2 int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Monthnumb_Number(t *testing.T) {\n  candidate := check_monthnumb_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(6), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "go_test.go",
+    "prompt": "package reverse_string_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist []string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReverse_String_List(t *testing.T) {\n  candidate := reverse_string_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"}), expected: []string{\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"} },\n     { actual: candidate([]string{\"john\", \"amal\", \"joel\", \"george\"}), expected: []string{\"nhoj\", \"lama\", \"leoj\", \"egroeg\"} },\n     { actual: candidate([]string{\"jack\", \"john\", \"mary\"}), expected: []string{\"kcaj\", \"nhoj\", \"yram\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "go_test.go",
+    "prompt": "package Find_Min_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sublist having minimum length.\nfunc Find_Min(lst [][]interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Min(t *testing.T) {\n  candidate := Find_Min\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}, []int{1, 2, 3}}), expected: []int{1} },\n     { actual: candidate([][]int{[]int{1, 1}, []int{1, 1, 1}, []int{1, 2, 7, 8}}), expected: []int{1, 1} },\n     { actual: candidate([][]int{[]string{\"x\"}, []string{\"x\", \"y\"}, []string{\"x\", \"y\", \"z\"}}), expected: []string{\"x\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "go_test.go",
+    "prompt": "package rectangle_area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the area of a rectangle.\nfunc rectangle_area(l int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRectangle_Area(t *testing.T) {\n  candidate := rectangle_area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 20), expected: 200 },\n     { actual: candidate(10, 5), expected: 50 },\n     { actual: candidate(4, 2), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "go_test.go",
+    "prompt": "package remove_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1 string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Uppercase(t *testing.T) {\n  candidate := remove_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"cAstyoUrFavoRitETVshoWs\"), expected: \"cstyoravoitshos\" },\n     { actual: candidate(\"wAtchTheinTernEtrAdIo\"), expected: \"wtchheinerntrdo\" },\n     { actual: candidate(\"VoicESeaRchAndreComMendaTionS\"), expected: \"oiceachndreomendaion\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "go_test.go",
+    "prompt": "package Extract_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to get the first element of each sublist.\nfunc Extract(lst [][]int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract(t *testing.T) {\n  candidate := Extract\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4, 5}, []int{6, 7, 8, 9}}), expected: []int{1, 3, 6} },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5}}), expected: []int{1, 4} },\n     { actual: candidate([][]int{[]int{9, 8, 1}, []int{1, 2}}), expected: []int{9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "go_test.go",
+    "prompt": "package upper_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the upper case characters in a given string.\nfunc upper_ctr(str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestUpper_Ctr(t *testing.T) {\n  candidate := upper_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYthon\"), expected: 1 },\n     { actual: candidate(\"BigData\"), expected: 1 },\n     { actual: candidate(\"program\"), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "go_test.go",
+    "prompt": "package max_subarray_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product sublist of the given list.\nfunc max_subarray_product(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Subarray_Product(t *testing.T) {\n  candidate := max_subarray_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, -3, 0, 7, -8, -2}), expected: 112 },\n     { actual: candidate([]int{6, -3, -10, 0, 2}), expected: 180 },\n     { actual: candidate([]int{-2, -40, 0, -2, -3}), expected: 80 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "go_test.go",
+    "prompt": "package check_value_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if all values are same in a map.\nfunc check_value(dict map[string]int, n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Value(t *testing.T) {\n  candidate := check_value\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10), expected: false },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12), expected: true },\n     { actual: candidate(map[string]int{\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "go_test.go",
+    "prompt": "package max_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\nfunc max_product(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Product(t *testing.T) {\n  candidate := max_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 100, 4, 5, 150, 6}), expected: 3000 },\n     { actual: candidate([]int{4, 42, 55, 68, 80}), expected: 50265600 },\n     { actual: candidate([]int{10, 22, 9, 33, 21, 50, 41, 60}), expected: 2460 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "go_test.go",
+    "prompt": "package add_pairwise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the pairwise addition of the neighboring elements of the given list.\nfunc add_pairwise(test_tup []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd_Pairwise(t *testing.T) {\n  candidate := add_pairwise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 8, 10}), expected: []interface{}{6, 12, 15, 18} },\n     { actual: candidate([]interface{}{2, 6, 8, 9, 11}), expected: []interface{}{8, 14, 17, 20} },\n     { actual: candidate([]interface{}{3, 7, 9, 10, 12}), expected: []interface{}{10, 16, 19, 22} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "go_test.go",
+    "prompt": "package find_remainder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the product of the list multiplication modulo n.\nfunc find_remainder(arr []int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Remainder(t *testing.T) {\n  candidate := find_remainder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{100, 10, 5, 25, 35, 14}, 11), expected: 9 },\n     { actual: candidate([]int{1, 1, 1}, 1), expected: 0 },\n     { actual: candidate([]int{1, 2, 1}, 2), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "go_test.go",
+    "prompt": "package check_Consecutive_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Consecutive(t *testing.T) {\n  candidate := check_Consecutive\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: true },\n     { actual: candidate([]int{1, 2, 3, 5, 6}), expected: false },\n     { actual: candidate([]int{1, 2, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "go_test.go",
+    "prompt": "package replace_char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace characters in a string.\nfunc replace_char(str1 string, ch string, newch string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_Char(t *testing.T) {\n  candidate := replace_char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"polygon\", \"y\", \"l\"), expected: \"pollgon\" },\n     { actual: candidate(\"character\", \"c\", \"a\"), expected: \"aharaater\" },\n     { actual: candidate(\"python\", \"l\", \"a\"), expected: \"python\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "go_test.go",
+    "prompt": "package sort_counter_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a map by value.\nfunc sort_counter(dict1 map[string]int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSort_Counter(t *testing.T) {\n  candidate := sort_counter\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}), expected: [][]int{[]interface{}{\"Chemistry\", 87}, []interface{}{\"Physics\", 83}, []interface{}{\"Math\", 81}} },\n     { actual: candidate(map[string]int{\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}), expected: [][]int{[]interface{}{\"Math\", 400}, []interface{}{\"Physics\", 300}, []interface{}{\"Chemistry\", 250}} },\n     { actual: candidate(map[string]int{\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}), expected: [][]int{[]interface{}{\"Chemistry\", 1250}, []interface{}{\"Physics\", 1000}, []interface{}{\"Math\", 900}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "go_test.go",
+    "prompt": "package big_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the largest and smallest value in a given list.\nfunc big_sum(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBig_Sum(t *testing.T) {\n  candidate := big_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{-1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{2, 3, 6}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "go_test.go",
+    "prompt": "package is_lower_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert the given string to lower case.\nfunc is_lower(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Lower(t *testing.T) {\n  candidate := is_lower\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"InValid\"), expected: \"invalid\" },\n     { actual: candidate(\"TruE\"), expected: \"true\" },\n     { actual: candidate(\"SenTenCE\"), expected: \"sentence\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "go_test.go",
+    "prompt": "package remove_lowercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1 string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Lowercase(t *testing.T) {\n  candidate := remove_lowercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"PYTHon\"), expected: \"PYTH\" },\n     { actual: candidate(\"FInD\"), expected: \"FID\" },\n     { actual: candidate(\"STRinG\"), expected: \"STRG\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "go_test.go",
+    "prompt": "package first_Digit_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the first digit of a given number.\nfunc first_Digit(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFirst_Digit(t *testing.T) {\n  candidate := first_Digit\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(123), expected: 1 },\n     { actual: candidate(456), expected: 4 },\n     { actual: candidate(12), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "go_test.go",
+    "prompt": "package heap_queue_largest_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums []int, n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestHeap_Queue_Largest(t *testing.T) {\n  candidate := heap_queue_largest\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), expected: []int{85, 75, 65} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), expected: []int{85, 75} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), expected: []int{85, 75, 65, 58, 35} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "go_test.go",
+    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of integers and only returns the odd ones.\nfunc Split(list []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: []int{1, 3, 5} },\n     { actual: candidate([]int{10, 11, 12, 13}), expected: []int{11, 13} },\n     { actual: candidate([]int{7, 8, 9, 1}), expected: []int{7, 9, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "go_test.go",
+    "prompt": "package difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDifference(t *testing.T) {\n  candidate := difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 30 },\n     { actual: candidate(5), expected: 210 },\n     { actual: candidate(2), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "go_test.go",
+    "prompt": "package find_Odd_Pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A []int, N int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Odd_Pair(t *testing.T) {\n  candidate := find_Odd_Pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 4, 7, 2, 1}, 5), expected: 6 },\n     { actual: candidate([]int{7, 2, 8, 1, 0, 5, 11}, 7), expected: 12 },\n     { actual: candidate([]int{1, 2, 3}, 3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "go_test.go",
+    "prompt": "package toggle_string_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestToggle_String(t *testing.T) {\n  candidate := toggle_string\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"pYTHON\" },\n     { actual: candidate(\"Pangram\"), expected: \"pANGRAM\" },\n     { actual: candidate(\"LIttLE\"), expected: \"liTTle\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "go_test.go",
+    "prompt": "package digit_distance_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1 int, n2 int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDigit_Distance_Nums(t *testing.T) {\n  candidate := digit_distance_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 2), expected: 1 },\n     { actual: candidate(23, 56), expected: 6 },\n     { actual: candidate(123, 256), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "go_test.go",
+    "prompt": "package max_sub_array_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a []int, size int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Sub_Array_Sum(t *testing.T) {\n  candidate := max_sub_array_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{-2, -3, 4, -1, -2, 1, 5, -3}, 8), expected: 7 },\n     { actual: candidate([]int{-3, -4, 5, -2, -3, 2, 6, -4}, 8), expected: 8 },\n     { actual: candidate([]int{-4, -5, 6, -3, -4, 3, 7, -5}, 8), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "go_test.go",
+    "prompt": "package union_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1 []int, test_tup2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestUnion_Elements(t *testing.T) {\n  candidate := union_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 4, 5, 6}, []int{5, 7, 4, 10}), expected: []int{3, 4, 5, 6, 7, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, []int{3, 4, 5, 6}), expected: []int{1, 2, 3, 4, 5, 6} },\n     { actual: candidate([]int{11, 12, 13, 14}, []int{13, 15, 16, 17}), expected: []int{11, 12, 13, 14, 15, 16, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "go_test.go",
+    "prompt": "package Find_Max_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the longest sublists.\nfunc Find_Max_Length(lst [][]int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Max_Length(t *testing.T) {\n  candidate := Find_Max_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 4}, []int{5, 6, 7, 8}}), expected: 4 },\n     { actual: candidate([][]int{[]int{0, 1}, []int{2, 2}, []int{3, 2, 1}}), expected: 3 },\n     { actual: candidate([][]int{[]int{7}, []int{22, 23}, []int{13, 14, 15}, []int{10, 20, 30, 40, 50}}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "go_test.go",
+    "prompt": "package extract_values_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Values(t *testing.T) {\n  candidate := extract_values\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"\"Python\", \"PHP\", \"Java\"\"), expected: []string{\"Python\", \"PHP\", \"Java\"} },\n     { actual: candidate(\"\"python\",\"program\",\"language\"\"), expected: []string{\"python\", \"program\", \"language\"} },\n     { actual: candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"), expected: []string{\"red\", \"blue\", \"green\", \"yellow\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "go_test.go",
+    "prompt": "package count_Pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr []int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Pairs(t *testing.T) {\n  candidate := count_Pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 1}, 3), expected: 2 },\n     { actual: candidate([]int{1, 1, 1, 1}, 4), expected: 0 },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, 5), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "go_test.go",
+    "prompt": "package split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to split a string into characters.\nfunc split(word string) []string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: []string{\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"} },\n     { actual: candidate(\"Name\"), expected: []string{\"N\", \"a\", \"m\", \"e\"} },\n     { actual: candidate(\"program\"), expected: []string{\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "go_test.go",
+    "prompt": "package sum_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Digits(t *testing.T) {\n  candidate := sum_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(345), expected: 12 },\n     { actual: candidate(12), expected: 3 },\n     { actual: candidate(97), expected: 16 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "go_test.go",
+    "prompt": "package issort_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1 []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIssort_List(t *testing.T) {\n  candidate := issort_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), expected: true },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), expected: false },\n     { actual: candidate([]int{1, 2, 4, 6, 8, 10, 15, 14, 20}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "go_test.go",
+    "prompt": "package sort_sublists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1 [][]string) [][]string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSort_Sublists(t *testing.T) {\n  candidate := sort_sublists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"white\", \"black\", \"orange\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\", \"white\"}, []string{\"black\", \"orange\", \"white\"}} },\n     { actual: candidate([][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}}), expected: [][]int{[]string{\"green\", \"orange\"}, []string{\"black\"}, []string{\"green\", \"orange\"}, []string{\"white\"}} },\n     { actual: candidate([][]int{[]string{\"a\", \"b\"}, []string{\"d\", \"c\"}, []string{\"g\", \"h\"}, []string{\"f\", \"e\"}}), expected: [][]int{[]string{\"a\", \"b\"}, []string{\"c\", \"d\"}, []string{\"g\", \"h\"}, []string{\"e\", \"f\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "go_test.go",
+    "prompt": "package checks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check if a given number is one less than twice its reverse.\nfunc checks(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestChecks(t *testing.T) {\n  candidate := checks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(70), expected: false },\n     { actual: candidate(23), expected: false },\n     { actual: candidate(73), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "go_test.go",
+    "prompt": "package two_unique_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTwo_Unique_Nums(t *testing.T) {\n  candidate := two_unique_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 2, 3, 4, 5}), expected: []int{1, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 2, 4, 5}), expected: []int{1, 3, 4, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "go_test.go",
+    "prompt": "package unique_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestUnique_Product(t *testing.T) {\n  candidate := unique_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30, 40, 20, 50, 60, 40}), expected: 720000000 },\n     { actual: candidate([]int{1, 2, 3, 1}), expected: 6 },\n     { actual: candidate([]int{7, 8, 9, 0, 1, 1}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "go_test.go",
+    "prompt": "package surfacearea_cylinder_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r int, h int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSurfacearea_Cylinder(t *testing.T) {\n  candidate := surfacearea_cylinder\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10, 5), expected: 942.45 },\n     { actual: candidate(4, 5), expected: 226.18800000000002 },\n     { actual: candidate(4, 10), expected: 351.848 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "go_test.go",
+    "prompt": "package is_Sub_Array_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A []int, B []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Sub_Array(t *testing.T) {\n  candidate := is_Sub_Array\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 4, 3, 5}, []int{1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 1}, []int{1, 2, 1}), expected: true },\n     { actual: candidate([]int{1, 0, 2, 2}, []int{2, 2, 0}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "go_test.go",
+    "prompt": "package last_Digit_Factorial_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLast_Digit_Factorial(t *testing.T) {\n  candidate := last_Digit_Factorial\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(4), expected: 4 },\n     { actual: candidate(21), expected: 0 },\n     { actual: candidate(30), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "go_test.go",
+    "prompt": "package interleave_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1 []int, list2 []int, list3 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestInterleave_Lists(t *testing.T) {\n  candidate := interleave_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7}, []int{10, 20, 30, 40, 50, 60, 70}, []int{100, 200, 300, 400, 500, 600, 700}), expected: []int{1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700} },\n     { actual: candidate([]int{10, 20}, []int{15, 2}, []int{5, 10}), expected: []int{10, 15, 5, 20, 2, 10} },\n     { actual: candidate([]int{11, 44}, []int{10, 15}, []int{20, 5}), expected: []int{11, 10, 20, 44, 15, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "go_test.go",
+    "prompt": "package find_dissimilar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the dissimilar elements in the given two lists.\nfunc find_dissimilar(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Dissimilar(t *testing.T) {\n  candidate := find_dissimilar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4, 5, 6}, []interface{}{5, 7, 4, 10}), expected: []interface{}{3, 6, 7, 10} },\n     { actual: candidate([]interface{}{1, 2, 3, 4}, []interface{}{7, 2, 3, 9}), expected: []interface{}{1, 4, 7, 9} },\n     { actual: candidate([]interface{}{21, 11, 25, 26}, []interface{}{26, 34, 21, 36}), expected: []interface{}{34, 36, 11, 25} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "go_test.go",
+    "prompt": "package find_Max_Num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Max_Num(t *testing.T) {\n  candidate := find_Max_Num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 321 },\n     { actual: candidate([]int{4, 5, 6, 1}), expected: 6541 },\n     { actual: candidate([]int{1, 2, 3, 9}), expected: 9321 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "go_test.go",
+    "prompt": "package extract_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove uneven elements in the nested mixed list.\nfunc extract_even(test_tuple []interface{}) interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Even(t *testing.T) {\n  candidate := extract_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, []interface{}{7, 6, []interface{}{2, 4}}, 6, 8}), expected: []interface{}{4, []interface{}{6, []interface{}{2, 4}}, 6, 8} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{8, 7, []interface{}{4, 8}}, 7, 9}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 8}}} },\n     { actual: candidate([]interface{}{5, 6, []interface{}{9, 8, []interface{}{4, 6}}, 8, 10}), expected: []interface{}{6, []interface{}{8, []interface{}{4, 6}}, 8, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "go_test.go",
+    "prompt": "package surface_Area_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the surface area of a square goramid with a given base edge and height.\nfunc surface_Area(b int, s int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSurface_Area(t *testing.T) {\n  candidate := surface_Area\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 33 },\n     { actual: candidate(4, 5), expected: 56 },\n     { actual: candidate(1, 2), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "go_test.go",
+    "prompt": "package catalan_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which returns nth catalan number.\nfunc catalan_number(num int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCatalan_Number(t *testing.T) {\n  candidate := catalan_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 16796 },\n     { actual: candidate(9), expected: 4862 },\n     { actual: candidate(7), expected: 429 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "go_test.go",
+    "prompt": "package find_adverbs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Adverbs(t *testing.T) {\n  candidate := find_adverbs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Clearly, he has no excuse for such behavior.\"), expected: \"0-7: Clearly\" },\n     { actual: candidate(\"Please handle the situation carefuly\"), expected: \"28-36: carefuly\" },\n     { actual: candidate(\"Complete the task quickly\"), expected: \"18-25: quickly\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "go_test.go",
+    "prompt": "package split_Arr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l []int, n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSplit_Arr(t *testing.T) {\n  candidate := split_Arr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 10, 5, 6, 52, 36}, 2), expected: []int{5, 6, 52, 36, 12, 10} },\n     { actual: candidate([]int{1, 2, 3, 4}, 1), expected: []int{2, 3, 4, 1} },\n     { actual: candidate([]int{0, 1, 2, 3, 4, 5, 6, 7}, 3), expected: []int{3, 4, 5, 6, 7, 0, 1, 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "go_test.go",
+    "prompt": "package list_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert a list to a list.\nfunc list_tuple(listx []int) interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestList_Tuple(t *testing.T) {\n  candidate := list_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 10, 7, 4, 15, 3}), expected: []interface{}{5, 10, 7, 4, 15, 3} },\n     { actual: candidate([]int{2, 4, 5, 6, 2, 3, 4, 4, 7}), expected: []interface{}{2, 4, 5, 6, 2, 3, 4, 4, 7} },\n     { actual: candidate([]int{58, 44, 56}), expected: []interface{}{58, 44, 56} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "go_test.go",
+    "prompt": "package big_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBig_Diff(t *testing.T) {\n  candidate := big_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 3 },\n     { actual: candidate([]int{4, 5, 12}), expected: 8 },\n     { actual: candidate([]int{9, 2, 3}), expected: 7 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "go_test.go",
+    "prompt": "package perfect_squares_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a int, b int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPerfect_Squares(t *testing.T) {\n  candidate := perfect_squares\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 30), expected: []int{1, 4, 9, 16, 25} },\n     { actual: candidate(50, 100), expected: []int{64, 81, 100} },\n     { actual: candidate(100, 200), expected: []int{100, 121, 144, 169, 196} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "go_test.go",
+    "prompt": "package opposite_Signs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x int, y int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOpposite_Signs(t *testing.T) {\n  candidate := opposite_Signs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, -2), expected: true },\n     { actual: candidate(3, 2), expected: false },\n     { actual: candidate(-10, -10), expected: false },\n     { actual: candidate(-2, 2), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "go_test.go",
+    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to interchange the first and last elements in a list.\nfunc swap_List(newList []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{12, 35, 9, 56, 24}), expected: []int{24, 35, 9, 56, 12} },\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "go_test.go",
+    "prompt": "package sum_Of_product_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Of_Product(t *testing.T) {\n  candidate := sum_Of_product\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15 },\n     { actual: candidate(4), expected: 56 },\n     { actual: candidate(1), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "go_test.go",
+    "prompt": "package removezero_ip_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemovezero_Ip(t *testing.T) {\n  candidate := removezero_ip\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"216.08.094.196\"), expected: \"216.8.94.196\" },\n     { actual: candidate(\"12.01.024\"), expected: \"12.1.24\" },\n     { actual: candidate(\"216.08.094.0196\"), expected: \"216.8.94.196\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "go_test.go",
+    "prompt": "package diff_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1 []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDiff_Even_Odd(t *testing.T) {\n  candidate := diff_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 1 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "go_test.go",
+    "prompt": "package min_Swaps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1 string, str2 string) interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMin_Swaps(t *testing.T) {\n  candidate := min_Swaps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"1101\", \"1110\"), expected: 1 },\n     { actual: candidate(\"111\", \"000\"), expected: \"Not Possible\" },\n     { actual: candidate(\"111\", \"110\"), expected: \"Not Possible\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "go_test.go",
+    "prompt": "package find_kth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find kth element from the given two sorted lists.\nfunc find_kth(arr1 []int, arr2 []int, k int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Kth(t *testing.T) {\n  candidate := find_kth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 3, 6, 7, 9}, []int{1, 4, 8, 10}, 5), expected: 6 },\n     { actual: candidate([]int{100, 112, 256, 349, 770}, []int{72, 86, 113, 119, 265, 445, 892}, 7), expected: 256 },\n     { actual: candidate([]int{3, 4, 7, 8, 10}, []int{2, 5, 9, 11}, 6), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "go_test.go",
+    "prompt": "package armstrong_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestArmstrong_Number(t *testing.T) {\n  candidate := armstrong_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(153), expected: true },\n     { actual: candidate(259), expected: false },\n     { actual: candidate(4458), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "go_test.go",
+    "prompt": "package sum_average_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Average(t *testing.T) {\n  candidate := sum_average\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []interface{}{55, 5.5} },\n     { actual: candidate(15), expected: []interface{}{120, 8.0} },\n     { actual: candidate(20), expected: []interface{}{210, 10.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "go_test.go",
+    "prompt": "package is_octagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth octagonal number.\nfunc is_octagonal(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Octagonal(t *testing.T) {\n  candidate := is_octagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 65 },\n     { actual: candidate(10), expected: 280 },\n     { actual: candidate(15), expected: 645 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "go_test.go",
+    "prompt": "package is_Even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number is even or not.\nfunc is_Even(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Even(t *testing.T) {\n  candidate := is_Even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1), expected: false },\n     { actual: candidate(2), expected: true },\n     { actual: candidate(3), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "go_test.go",
+    "prompt": "package get_ludic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Ludic(t *testing.T) {\n  candidate := get_ludic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: []int{1, 2, 3, 5, 7} },\n     { actual: candidate(25), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25} },\n     { actual: candidate(45), expected: []int{1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "go_test.go",
+    "prompt": "package reverse_words_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReverse_Words(t *testing.T) {\n  candidate := reverse_words\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python program\"), expected: \"program python\" },\n     { actual: candidate(\"java language\"), expected: \"language java\" },\n     { actual: candidate(\"indian man\"), expected: \"man indian\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "go_test.go",
+    "prompt": "package prime_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given integer is a prime number.\nfunc prime_num(num int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPrime_Num(t *testing.T) {\n  candidate := prime_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13), expected: true },\n     { actual: candidate(7), expected: true },\n     { actual: candidate(-1010), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "go_test.go",
+    "prompt": "package radian_degree_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert degrees to radians.\nfunc radian_degree(degree int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRadian_Degree(t *testing.T) {\n  candidate := radian_degree\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(90), expected: 1.5707963267948966 },\n     { actual: candidate(60), expected: 1.0471975511965976 },\n     { actual: candidate(120), expected: 2.0943951023931953 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "go_test.go",
+    "prompt": "package find_literals_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text string, pattern string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Literals(t *testing.T) {\n  candidate := find_literals\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"), expected: []interface{}{\"fox\", 16, 19} },\n     { actual: candidate(\"Its been a very crazy procedure right\", \"crazy\"), expected: []interface{}{\"crazy\", 16, 21} },\n     { actual: candidate(\"Hardest choices required strongest will\", \"will\"), expected: []interface{}{\"will\", 35, 39} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "go_test.go",
+    "prompt": "package bell_Number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find nth bell number.\nfunc bell_Number(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_Number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(3), expected: 5 },\n     { actual: candidate(4), expected: 15 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "go_test.go",
+    "prompt": "package remove_kth_element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1 []int, L int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Kth_Element(t *testing.T) {\n  candidate := remove_kth_element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 4, 4, 5, 1}, 3), expected: []int{1, 1, 3, 4, 4, 5, 1} },\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), expected: []int{0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), expected: []int{10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "go_test.go",
+    "prompt": "package max_of_nth_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list [][]int, N int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Of_Nth(t *testing.T) {\n  candidate := max_of_nth\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{5, 6, 7}, []int{1, 3, 5}, []int{8, 9, 19}}, 2), expected: 19 },\n     { actual: candidate([][]int{[]int{6, 7, 8}, []int{2, 4, 6}, []int{9, 10, 20}}, 1), expected: 10 },\n     { actual: candidate([][]int{[]int{7, 8, 9}, []int{3, 5, 7}, []int{10, 11, 21}}, 1), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "go_test.go",
+    "prompt": "package merge_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst [][]interface{}) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMerge(t *testing.T) {\n  candidate := merge\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]string{\"x\", \"y\"}, []string{\"a\", \"b\"}, []string{\"m\", \"n\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}} },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}, []int{7, 8}}), expected: [][]int{[]int{1, 3, 5, 7}, []int{2, 4, 6, 8}} },\n     { actual: candidate([][]int{[]string{\"x\", \"y\", \"z\"}, []string{\"a\", \"b\", \"c\"}, []string{\"m\", \"n\", \"o\"}}), expected: [][]int{[]string{\"x\", \"a\", \"m\"}, []string{\"y\", \"b\", \"n\"}, []string{\"z\", \"c\", \"o\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "go_test.go",
+    "prompt": "package cummulative_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list [][]int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCummulative_Sum(t *testing.T) {\n  candidate := cummulative_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 6, 7}, []int{2, 6}}), expected: 30 },\n     { actual: candidate([][]int{[]int{2, 4}, []int{6, 7, 8}, []int{3, 7}}), expected: 37 },\n     { actual: candidate([][]int{[]int{3, 5}, []int{7, 8, 9}, []int{4, 8}}), expected: 44 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "go_test.go",
+    "prompt": "package average_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums [][]int) []float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAverage_Tuple(t *testing.T) {\n  candidate := average_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{10, 10, 10, 12}, []int{30, 45, 56, 45}, []int{81, 80, 39, 32}, []int{1, 2, 3, 4}}), expected: []float64{30.5, 34.25, 27.0, 23.25} },\n     { actual: candidate([][]int{[]int{1, 1, -5}, []int{30, -15, 56}, []int{81, -60, -39}, []int{-10, 2, 3}}), expected: []float64{25.5, -18.0, 3.75} },\n     { actual: candidate([][]int{[]int{100, 100, 100, 120}, []int{300, 450, 560, 450}, []int{810, 800, 390, 320}, []int{10, 20, 30, 40}}), expected: []float64{305.0, 342.5, 270.0, 232.5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "go_test.go",
+    "prompt": "package tuple_modulo_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function which takes two lists of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1 []interface{}, test_tup2 []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTuple_Modulo(t *testing.T) {\n  candidate := tuple_modulo\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6}, []interface{}{5, 6, 7, 5}), expected: []interface{}{0, 4, 5, 1} },\n     { actual: candidate([]interface{}{11, 5, 6, 7}, []interface{}{6, 7, 8, 6}), expected: []interface{}{5, 5, 6, 1} },\n     { actual: candidate([]interface{}{12, 6, 7, 8}, []interface{}{7, 8, 9, 7}), expected: []interface{}{5, 6, 7, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "go_test.go",
+    "prompt": "package min_Jumps_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps []interface{}, d int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMin_Jumps(t *testing.T) {\n  candidate := min_Jumps\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}, 11), expected: 3.5 },\n     { actual: candidate([]interface{}{3, 4}, 0), expected: 0 },\n     { actual: candidate([]interface{}{11, 14}, 11), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "go_test.go",
+    "prompt": "package div_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to divide two lists element wise.\nfunc div_list(nums1 []int, nums2 []int) []float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDiv_List(t *testing.T) {\n  candidate := div_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{4, 5, 6}, []int{1, 2, 3}), expected: []float64{4.0, 2.5, 2.0} },\n     { actual: candidate([]int{3, 2}, []int{1, 4}), expected: []float64{3.0, 0.5} },\n     { actual: candidate([]int{90, 120}, []int{50, 70}), expected: []float64{1.8, 1.7142857142857142} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "go_test.go",
+    "prompt": "package move_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMove_Num(t *testing.T) {\n  candidate := move_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"I1love143you55three3000thousand\"), expected: \"Iloveyouthreethousand1143553000\" },\n     { actual: candidate(\"Avengers124Assemble\"), expected: \"AvengersAssemble124\" },\n     { actual: candidate(\"Its11our12path13to14see15things16do17things\"), expected: \"Itsourpathtoseethingsdothings11121314151617\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "go_test.go",
+    "prompt": "package count_Substrings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Substrings(t *testing.T) {\n  candidate := count_Substrings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"112112\"), expected: 6 },\n     { actual: candidate(\"111\"), expected: 6 },\n     { actual: candidate(\"1101112\"), expected: 12 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "go_test.go",
+    "prompt": "package get_median_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1 []int, arr2 []int, n int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Median(t *testing.T) {\n  candidate := get_median\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 12, 15, 26, 38}, []int{2, 13, 17, 30, 45}, 5), expected: 16.0 },\n     { actual: candidate([]int{2, 4, 8, 9}, []int{7, 13, 19, 28}, 4), expected: 8.5 },\n     { actual: candidate([]int{3, 6, 14, 23, 36, 42}, []int{2, 18, 27, 39, 49, 55}, 6), expected: 25.0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "go_test.go",
+    "prompt": "package nth_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums []int, n int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNth_Nums(t *testing.T) {\n  candidate := nth_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}, 3), expected: []int{1000, 8000, 27000} },\n     { actual: candidate([]int{12, 15}, 5), expected: []int{248832, 759375} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "go_test.go",
+    "prompt": "package is_upper_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to convert a given string to uppercase.\nfunc is_upper(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Upper(t *testing.T) {\n  candidate := is_upper\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"person\"), expected: \"PERSON\" },\n     { actual: candidate(\"final\"), expected: \"FINAL\" },\n     { actual: candidate(\"Valid\"), expected: \"VALID\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "go_test.go",
+    "prompt": "package swap_List_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to interchange the first and last element in a given list.\nfunc swap_List(newList []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSwap_List(t *testing.T) {\n  candidate := swap_List\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: []int{3, 2, 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 4}), expected: []int{4, 2, 3, 4, 1} },\n     { actual: candidate([]int{4, 5, 6}), expected: []int{6, 5, 4} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "go_test.go",
+    "prompt": "package find_First_Missing_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_First_Missing(t *testing.T) {\n  candidate := find_First_Missing\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 1, 2, 3}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, 6, 9}), expected: 3 },\n     { actual: candidate([]int{2, 3, 5, 8, 9}), expected: 0 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "go_test.go",
+    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(myString string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"My Name is Dawood\"), expected: \"My%20Name%20is%20Dawood\" },\n     { actual: candidate(\"I am a Programmer\"), expected: \"I%20am%20a%20Programmer\" },\n     { actual: candidate(\"I love Coding\"), expected: \"I%20love%20Coding\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "go_test.go",
+    "prompt": "package Split_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find even numbers from a list of numbers.\nfunc Split(list []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSplit(t *testing.T) {\n  candidate := Split\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: []int{2, 4} },\n     { actual: candidate([]int{4, 5, 6, 7, 8, 0, 1}), expected: []int{4, 6, 8, 0} },\n     { actual: candidate([]int{8, 12, 15, 19}), expected: []int{8, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "go_test.go",
+    "prompt": "package smallest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find smallest number in a list.\nfunc smallest_num(xs []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSmallest_Num(t *testing.T) {\n  candidate := smallest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 1, 45, 99}), expected: 1 },\n     { actual: candidate([]int{1, 2, 3}), expected: 1 },\n     { actual: candidate([]int{45, 46, 50, 60}), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "go_test.go",
+    "prompt": "package get_coordinates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract all the adjacent coordinates of the given coordinate list.\nfunc get_coordinates(test_tup []interface{}) [][]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Coordinates(t *testing.T) {\n  candidate := get_coordinates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{3, 4}), expected: [][]int{[]int{2, 3}, []int{2, 4}, []int{2, 5}, []int{3, 3}, []int{3, 4}, []int{3, 5}, []int{4, 3}, []int{4, 4}, []int{4, 5}} },\n     { actual: candidate([]interface{}{4, 5}), expected: [][]int{[]int{3, 4}, []int{3, 5}, []int{3, 6}, []int{4, 4}, []int{4, 5}, []int{4, 6}, []int{5, 4}, []int{5, 5}, []int{5, 6}} },\n     { actual: candidate([]interface{}{5, 6}), expected: [][]int{[]int{4, 5}, []int{4, 6}, []int{4, 7}, []int{5, 5}, []int{5, 6}, []int{5, 7}, []int{6, 5}, []int{6, 6}, []int{6, 7}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "go_test.go",
+    "prompt": "package replace_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_Spaces(t *testing.T) {\n  candidate := replace_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Jumanji The Jungle\"), expected: \"Jumanji_The_Jungle\" },\n     { actual: candidate(\"The_Avengers\"), expected: \"The Avengers\" },\n     { actual: candidate(\"Fast and Furious\"), expected: \"Fast_and_Furious\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "go_test.go",
+    "prompt": "package move_zero_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to move all zeroes to the end of the given list.\nfunc move_zero(num_list []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMove_Zero(t *testing.T) {\n  candidate := move_zero\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 0, 2, 0, 3, 4}), expected: []int{1, 2, 3, 4, 0, 0} },\n     { actual: candidate([]int{2, 3, 2, 0, 0, 4, 0, 5, 0}), expected: []int{2, 3, 2, 4, 5, 0, 0, 0, 0} },\n     { actual: candidate([]int{0, 1, 0, 1, 1}), expected: []int{1, 1, 1, 0, 0} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "go_test.go",
+    "prompt": "package pair_xor_Sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr []int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPair_Xor_Sum(t *testing.T) {\n  candidate := pair_xor_Sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 9, 7, 6}, 4), expected: 47 },\n     { actual: candidate([]int{7, 3, 5}, 3), expected: 12 },\n     { actual: candidate([]int{7, 3}, 2), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "go_test.go",
+    "prompt": "package heap_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort the given list.\nfunc heap_sort(iterable []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestHeap_Sort(t *testing.T) {\n  candidate := heap_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} },\n     { actual: candidate([]int{25, 35, 22, 85, 14, 65, 75, 25, 58}), expected: []int{14, 22, 25, 25, 35, 58, 65, 75, 85} },\n     { actual: candidate([]int{7, 1, 9, 5}), expected: []int{1, 5, 7, 9} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "go_test.go",
+    "prompt": "package noprofit_noloss_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost int, sale_amount int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNoprofit_Noloss(t *testing.T) {\n  candidate := noprofit_noloss\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1500, 1200), expected: false },\n     { actual: candidate(100, 100), expected: true },\n     { actual: candidate(2000, 5000), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "go_test.go",
+    "prompt": "package wind_chill_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v int, t int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestWind_Chill(t *testing.T) {\n  candidate := wind_chill\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(120, 35), expected: 40 },\n     { actual: candidate(40, 20), expected: 19 },\n     { actual: candidate(10, 8), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "go_test.go",
+    "prompt": "package sample_nam_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names []string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSample_Nam(t *testing.T) {\n  candidate := sample_nam\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"}), expected: 16 },\n     { actual: candidate([]string{\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"}), expected: 10 },\n     { actual: candidate([]string{\"abcd\", \"Python\", \"abba\", \"aba\"}), expected: 6 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "go_test.go",
+    "prompt": "package max_difference_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the maximum difference between available pairs in the given list list.\nfunc max_difference(test_list [][]interface{}) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Difference(t *testing.T) {\n  candidate := max_difference\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{1, 7}, []interface{}{10, 3}, []interface{}{1, 2}}), expected: 7 },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{2, 17}, []interface{}{9, 13}, []interface{}{11, 12}}), expected: 15 },\n     { actual: candidate([][]int{[]interface{}{12, 35}, []interface{}{21, 27}, []interface{}{13, 23}, []interface{}{41, 22}}), expected: 23 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "go_test.go",
+    "prompt": "package remove_parenthesis_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items []string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Parenthesis(t *testing.T) {\n  candidate := remove_parenthesis\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python (chrome)\"}), expected: \"python\" },\n     { actual: candidate([]string{\"string(.abc)\"}), expected: \"string\" },\n     { actual: candidate([]string{\"alpha(num)\"}), expected: \"alpha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "go_test.go",
+    "prompt": "package is_nonagonal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Nonagonal(t *testing.T) {\n  candidate := is_nonagonal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 325 },\n     { actual: candidate(15), expected: 750 },\n     { actual: candidate(18), expected: 1089 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "go_test.go",
+    "prompt": "package text_match_wordz_middle_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_Wordz_Middle(t *testing.T) {\n  candidate := text_match_wordz_middle\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"pythonzabc.\"), expected: true },\n     { actual: candidate(\"zxyabc.\"), expected: false },\n     { actual: candidate(\"  lang  .\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "go_test.go",
+    "prompt": "package reverse_Array_Upto_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to reverse a list upto a given position.\nfunc reverse_Array_Upto_K(input []int, k int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReverse_Array_Upto_K(t *testing.T) {\n  candidate := reverse_Array_Upto_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 4), expected: []int{4, 3, 2, 1, 5, 6} },\n     { actual: candidate([]int{4, 5, 6, 7}, 2), expected: []int{5, 4, 6, 7} },\n     { actual: candidate([]int{9, 8, 7, 6, 5}, 3), expected: []int{7, 8, 9, 6, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "go_test.go",
+    "prompt": "package subject_marks_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of lists using the second value of each list.\nfunc subject_marks(subjectmarks [][]interface{}) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSubject_Marks(t *testing.T) {\n  candidate := subject_marks\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}, []interface{}{\"Social sciences\", 82}}), expected: [][]int{[]interface{}{\"Social sciences\", 82}, []interface{}{\"English\", 88}, []interface{}{\"Science\", 90}, []interface{}{\"Maths\", 97}} },\n     { actual: candidate([][]int{[]interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}, []interface{}{\"Social\", 33}}), expected: [][]int{[]interface{}{\"Social\", 33}, []interface{}{\"Telugu\", 49}, []interface{}{\"Hindhi\", 54}} },\n     { actual: candidate([][]int{[]interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}, []interface{}{\"Biology\", 45}}), expected: [][]int{[]interface{}{\"Biology\", 45}, []interface{}{\"Physics\", 96}, []interface{}{\"Chemistry\", 97}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "go_test.go",
+    "prompt": "package pos_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of positive numbers in a list.\nfunc pos_count(list []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPos_Count(t *testing.T) {\n  candidate := pos_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, -2, 3, -4}), expected: 2 },\n     { actual: candidate([]int{3, 4, 5, -1}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "go_test.go",
+    "prompt": "package bell_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestBell_Number(t *testing.T) {\n  candidate := bell_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 2 },\n     { actual: candidate(10), expected: 115975 },\n     { actual: candidate(56), expected: 6775685320645824322581483068371419745979053216268760300 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "go_test.go",
+    "prompt": "package is_Monotonic_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given list is monotonic or not.\nfunc is_Monotonic(A []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Monotonic(t *testing.T) {\n  candidate := is_Monotonic\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{6, 5, 4, 4}), expected: true },\n     { actual: candidate([]int{1, 2, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 3, 2}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "go_test.go",
+    "prompt": "package is_sublist_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l []int, s []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Sublist(t *testing.T) {\n  candidate := is_sublist\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{3, 7}), expected: false },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{4, 3}), expected: true },\n     { actual: candidate([]int{2, 4, 3, 5, 7}, []int{1, 6}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "go_test.go",
+    "prompt": "package differ_At_One_Bit_Pos_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a int, b int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDiffer_At_One_Bit_Pos(t *testing.T) {\n  candidate := differ_At_One_Bit_Pos\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(13, 9), expected: true },\n     { actual: candidate(15, 8), expected: false },\n     { actual: candidate(2, 4), expected: false },\n     { actual: candidate(2, 3), expected: true },\n     { actual: candidate(5, 1), expected: true },\n     { actual: candidate(1, 5), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "go_test.go",
+    "prompt": "package get_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input [][]int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Equal(t *testing.T) {\n  candidate := get_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{11, 22, 33}, []int{44, 55, 66}}), expected: true },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6, 7}}), expected: false },\n     { actual: candidate([][]int{[]int{1, 2}, []int{3, 4}}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "go_test.go",
+    "prompt": "package comb_sort_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a list of elements.\nfunc comb_sort(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestComb_Sort(t *testing.T) {\n  candidate := comb_sort\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 15, 37, 25, 79}), expected: []int{5, 15, 25, 37, 79} },\n     { actual: candidate([]int{41, 32, 15, 19, 22}), expected: []int{15, 19, 22, 32, 41} },\n     { actual: candidate([]int{99, 15, 13, 47}), expected: []int{13, 15, 47, 99} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "go_test.go",
+    "prompt": "package add_dict_to_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add a map to the list. The output should be a list.\nfunc add_dict_to_tuple(test_tup []interface{}, test_dict map[string]int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd_Dict_To_Tuple(t *testing.T) {\n  candidate := add_dict_to_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{4, 5, 6}, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}), expected: []interface{}{4, 5, 6, map[string]int{\"MSAM\": 1, \"is\": 2, \"best\": 3}} },\n     { actual: candidate([]interface{}{1, 2, 3}, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}), expected: []interface{}{1, 2, 3, map[string]int{\"UTS\": 2, \"is\": 3, \"Worst\": 4}} },\n     { actual: candidate([]interface{}{8, 9, 10}, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}), expected: []interface{}{8, 9, 10, map[string]int{\"POS\": 3, \"is\": 4, \"Okay\": 5}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "go_test.go",
+    "prompt": "package maxAverageOfPath_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost [][]int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMaxaverageofpath(t *testing.T) {\n  candidate := maxAverageOfPath\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{6, 5, 4}, []int{7, 3, 9}}), expected: 5.2 },\n     { actual: candidate([][]int{[]int{2, 3, 4}, []int{7, 6, 5}, []int{8, 4, 10}}), expected: 6.2 },\n     { actual: candidate([][]int{[]int{3, 4, 5}, []int{8, 7, 6}, []int{9, 5, 11}}), expected: 7.2 },\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}), expected: 5.8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "go_test.go",
+    "prompt": "package count_same_pair_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1 []int, nums2 []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Same_Pair(t *testing.T) {\n  candidate := count_same_pair\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8}, []int{2, 2, 3, 1, 2, 6, 7, 9}), expected: 4 },\n     { actual: candidate([]int{0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 11 },\n     { actual: candidate([]int{2, 4, -6, -9, 11, -12, 14, -5, 17}, []int{2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), expected: 1 },\n     { actual: candidate([]int{0, 1, 1, 2}, []int{0, 1, 2, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "go_test.go",
+    "prompt": "package power_base_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base int, power int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPower_Base_Sum(t *testing.T) {\n  candidate := power_base_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 100), expected: 115 },\n     { actual: candidate(8, 10), expected: 37 },\n     { actual: candidate(8, 15), expected: 62 },\n     { actual: candidate(3, 3), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "go_test.go",
+    "prompt": "package extract_quotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1 string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Quotation(t *testing.T) {\n  candidate := extract_quotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"), expected: []string{\"A53\", \"multi\", \"Processor\"} },\n     { actual: candidate(\"Cast your \"favorite\" entertainment \"apps\"\"), expected: []string{\"favorite\", \"apps\"} },\n     { actual: candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"), expected: []string{\"4k Ultra HD\", \"HDR 10\"} },\n     { actual: candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "go_test.go",
+    "prompt": "package multiply_elements_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMultiply_Elements(t *testing.T) {\n  candidate := multiply_elements\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 7, 8, 10}), expected: []int{5, 35, 56, 80} },\n     { actual: candidate([]int{2, 4, 5, 6, 7}), expected: []int{8, 20, 30, 42} },\n     { actual: candidate([]int{12, 13, 14, 9, 15}), expected: []int{156, 182, 126, 135} },\n     { actual: candidate([]int{12}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "go_test.go",
+    "prompt": "package sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1 []int, lst2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_List(t *testing.T) {\n  candidate := sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 20, 30}, []int{15, 25, 35}), expected: []int{25, 45, 65} },\n     { actual: candidate([]int{1, 2, 3}, []int{5, 6, 7}), expected: []int{6, 8, 10} },\n     { actual: candidate([]int{15, 20, 30}, []int{15, 45, 75}), expected: []int{30, 65, 105} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "go_test.go",
+    "prompt": "package dif_Square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDif_Square(t *testing.T) {\n  candidate := dif_Square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: true },\n     { actual: candidate(10), expected: false },\n     { actual: candidate(15), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "go_test.go",
+    "prompt": "package consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums []interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestConsecutive_Duplicates(t *testing.T) {\n  candidate := consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: []int{10, 15, 19, 18, 17, 26, 17, 18, 10} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: []string{\"a\", \"b\", \"c\", \"d\"} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"}), expected: []string{\"a\", \"b\", \"c\", \"d\", \"a\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "go_test.go",
+    "prompt": "package lateralsurface_cone_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r int, h int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLateralsurface_Cone(t *testing.T) {\n  candidate := lateralsurface_cone\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5, 12), expected: 204.20352248333654 },\n     { actual: candidate(10, 15), expected: 566.3586699569488 },\n     { actual: candidate(19, 17), expected: 1521.8090132193388 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "go_test.go",
+    "prompt": "package replace_specialchar_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReplace_Specialchar(t *testing.T) {\n  candidate := replace_specialchar\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python language, Programming language.\"), expected: \"Python:language::Programming:language:\" },\n     { actual: candidate(\"a b c,d e f\"), expected: \"a:b:c:d:e:f\" },\n     { actual: candidate(\"ram reshma,ram rahim\"), expected: \"ram:reshma:ram:rahim\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "go_test.go",
+    "prompt": "package find_first_occurrence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the index of the first occurrence of a given number in a sorted list.\nfunc find_first_occurrence(A []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_First_Occurrence(t *testing.T) {\n  candidate := find_first_occurrence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 1 },\n     { actual: candidate([]int{2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), expected: 2 },\n     { actual: candidate([]int{2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "go_test.go",
+    "prompt": "package sum_Of_Subarray_Prod_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\nfunc sum_Of_Subarray_Prod(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_Of_Subarray_Prod(t *testing.T) {\n  candidate := sum_Of_Subarray_Prod\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 20 },\n     { actual: candidate([]int{1, 2}), expected: 5 },\n     { actual: candidate([]int{1, 2, 3, 4}), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "go_test.go",
+    "prompt": "package toggle_middle_bits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestToggle_Middle_Bits(t *testing.T) {\n  candidate := toggle_middle_bits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(9), expected: 15 },\n     { actual: candidate(10), expected: 12 },\n     { actual: candidate(11), expected: 13 },\n     { actual: candidate(65), expected: 127 },\n     { actual: candidate(77), expected: 115 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "go_test.go",
+    "prompt": "package left_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/gothon-exercises/data-structures-and-algorithms/gothon-data-structure-exercise-24.php\nfunc left_insertion(a []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLeft_Insertion(t *testing.T) {\n  candidate := left_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "go_test.go",
+    "prompt": "package check_str_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(myString string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Str(t *testing.T) {\n  candidate := check_str\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"annie\"), expected: true },\n     { actual: candidate(\"dawood\"), expected: false },\n     { actual: candidate(\"Else\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "go_test.go",
+    "prompt": "package geometric_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/gothon-exercises/data-structures-and-algorithms/gothon-recursion-exercise-9.php\nfunc geometric_sum(n int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGeometric_Sum(t *testing.T) {\n  candidate := geometric_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 1.9921875 },\n     { actual: candidate(4), expected: 1.9375 },\n     { actual: candidate(8), expected: 1.99609375 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "go_test.go",
+    "prompt": "package find_Index_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Index(t *testing.T) {\n  candidate := find_Index\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 4 },\n     { actual: candidate(3), expected: 14 },\n     { actual: candidate(4), expected: 45 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "go_test.go",
+    "prompt": "package tuple_to_dict_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given list to a key-value map using adjacent elements. https://www.geeksforgeeks.org/gothon-convert-list-to-adjacent-pair-map/\nfunc tuple_to_dict(test_tup []interface{}) map[int]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTuple_To_Dict(t *testing.T) {\n  candidate := tuple_to_dict\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, 10, 13, 5}), expected: map[int]int{1: 5, 7: 10, 13: 5} },\n     { actual: candidate([]interface{}{1, 2, 3, 4, 5, 6}), expected: map[int]int{1: 2, 3: 4, 5: 6} },\n     { actual: candidate([]interface{}{7, 8, 9, 10, 11, 12}), expected: map[int]int{7: 8, 9: 10, 11: 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "go_test.go",
+    "prompt": "package all_Characters_Same_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether all the characters are same or not.\nfunc all_Characters_Same(s string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAll_Characters_Same(t *testing.T) {\n  candidate := all_Characters_Same\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python\"), expected: false },\n     { actual: candidate(\"aaa\"), expected: true },\n     { actual: candidate(\"data\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "go_test.go",
+    "prompt": "package area_tetrahedron_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side int) float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestArea_Tetrahedron(t *testing.T) {\n  candidate := area_tetrahedron\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3), expected: 15.588457268119894 },\n     { actual: candidate(20), expected: 692.8203230275509 },\n     { actual: candidate(10), expected: 173.20508075688772 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "go_test.go",
+    "prompt": "package rotate_right_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/gothon-program-right-rotate-list-n/\nfunc rotate_right(list []int, m int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRotate_Right(t *testing.T) {\n  candidate := rotate_right\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), expected: []int{8, 9, 10, 1, 2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), expected: []int{9, 10, 1, 2, 3, 4, 5, 6, 7, 8} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), expected: []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "go_test.go",
+    "prompt": "package check_none_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given list has any none value or not.\nfunc check_none(test_tup interface{}) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_None(t *testing.T) {\n  candidate := check_none\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{10, 4, 5, 6, nil}), expected: true },\n     { actual: candidate([]interface{}{7, 8, 9, 11, 14}), expected: false },\n     { actual: candidate([]interface{}{1, 2, 3, 4, nil}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "go_test.go",
+    "prompt": "package divisible_by_digits_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/gothon-exercises/lambda/gothon-lambda-exercise-24.php\nfunc divisible_by_digits(startnum int, endnum int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDivisible_By_Digits(t *testing.T) {\n  candidate := divisible_by_digits\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 22), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22} },\n     { actual: candidate(1, 15), expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15} },\n     { actual: candidate(20, 25), expected: []int{22, 24} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "go_test.go",
+    "prompt": "package lcs_of_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X string, Y string, Z string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLcs_Of_Three(t *testing.T) {\n  candidate := lcs_of_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"), expected: 2 },\n     { actual: candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"), expected: 5 },\n     { actual: candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "go_test.go",
+    "prompt": "package capital_words_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1 string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCapital_Words_Spaces(t *testing.T) {\n  candidate := capital_words_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Python\"), expected: \"Python\" },\n     { actual: candidate(\"PythonProgrammingExamples\"), expected: \"Python Programming Examples\" },\n     { actual: candidate(\"GetReadyToBeCodingFreak\"), expected: \"Get Ready To Be Coding Freak\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "go_test.go",
+    "prompt": "package sort_numeric_strings_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/gothon-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str []string) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSort_Numeric_Strings(t *testing.T) {\n  candidate := sort_numeric_strings\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"}), expected: []int{-500, -12, 0, 4, 7, 12, 45, 100, 200} },\n     { actual: candidate([]string{\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"}), expected: []int{1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9} },\n     { actual: candidate([]string{\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"}), expected: []int{1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "go_test.go",
+    "prompt": "package is_samepatterns_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether it follows the sequence given in the patterns list.\nfunc is_samepatterns(colors []string, patterns []string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Samepatterns(t *testing.T) {\n  candidate := is_samepatterns\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"green\", \"green\"}, []string{\"a\", \"b\", \"b\"}), expected: true },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\", \"b\"}), expected: false },\n     { actual: candidate([]string{\"red\", \"green\", \"greenn\"}, []string{\"a\", \"b\"}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "go_test.go",
+    "prompt": "package add_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to add the given list to the given list.\nfunc add_tuple(test_list []int, test_tup []interface{}) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestAdd_Tuple(t *testing.T) {\n  candidate := add_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{5, 6, 7}, []interface{}{9, 10}), expected: []int{5, 6, 7, 9, 10} },\n     { actual: candidate([]int{6, 7, 8}, []interface{}{10, 11}), expected: []int{6, 7, 8, 10, 11} },\n     { actual: candidate([]int{7, 8, 9}, []interface{}{11, 12}), expected: []int{7, 8, 9, 11, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "go_test.go",
+    "prompt": "package check_min_heap_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\nfunc check_min_heap(arr []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Min_Heap(t *testing.T) {\n  candidate := check_min_heap\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}), expected: true },\n     { actual: candidate([]int{2, 3, 4, 5, 10, 15}), expected: true },\n     { actual: candidate([]int{2, 10, 4, 5, 3, 15}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "go_test.go",
+    "prompt": "package jacobsthal_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestJacobsthal_Num(t *testing.T) {\n  candidate := jacobsthal_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 11 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(4), expected: 5 },\n     { actual: candidate(13), expected: 2731 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "go_test.go",
+    "prompt": "package min_k_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/gothon-find-minimum-k-records-from-list-list/ - in this case a verbatim cogo of test cases\nfunc min_k(test_list [][]interface{}, K int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMin_K(t *testing.T) {\n  candidate := min_k\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Manjeet\", 10}, []interface{}{\"Akshat\", 4}, []interface{}{\"Akash\", 2}, []interface{}{\"Nikhil\", 8}}, 2), expected: [][]int{[]interface{}{\"Akash\", 2}, []interface{}{\"Akshat\", 4}} },\n     { actual: candidate([][]int{[]interface{}{\"Sanjeev\", 11}, []interface{}{\"Angat\", 5}, []interface{}{\"Akash\", 3}, []interface{}{\"Nepin\", 9}}, 3), expected: [][]int{[]interface{}{\"Akash\", 3}, []interface{}{\"Angat\", 5}, []interface{}{\"Nepin\", 9}} },\n     { actual: candidate([][]int{[]interface{}{\"tanmay\", 14}, []interface{}{\"Amer\", 11}, []interface{}{\"Ayesha\", 9}, []interface{}{\"SKD\", 16}}, 1), expected: [][]int{[]interface{}{\"Ayesha\", 9}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "go_test.go",
+    "prompt": "package extract_index_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1 []int, l2 []int, l3 []int) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestExtract_Index_List(t *testing.T) {\n  candidate := extract_index_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 7} },\n     { actual: candidate([]int{1, 1, 3, 4, 5, 6, 7}, []int{0, 1, 2, 3, 4, 6, 5}, []int{0, 1, 2, 3, 4, 6, 7}), expected: []int{1, 6} },\n     { actual: candidate([]int{1, 1, 3, 4, 6, 5, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []int{1, 5} },\n     { actual: candidate([]int{1, 2, 3, 4, 6, 6, 6}, []int{0, 1, 2, 3, 4, 5, 7}, []int{0, 1, 2, 3, 4, 5, 7}), expected: []interface{}{} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "go_test.go",
+    "prompt": "package text_match_zero_one_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/gothon-exercises/re/gothon-re-exercise-3.php\nfunc text_match_zero_one(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_Zero_One(t *testing.T) {\n  candidate := text_match_zero_one\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"dsabbbba\"), expected: true },\n     { actual: candidate(\"asbbbba\"), expected: false },\n     { actual: candidate(\"abaaa\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "go_test.go",
+    "prompt": "package count_reverse_pairs_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/gothon-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list []string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Reverse_Pairs(t *testing.T) {\n  candidate := count_reverse_pairs\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"}), expected: 2 },\n     { actual: candidate([]string{\"geeks\", \"best\", \"for\", \"skeeg\"}), expected: 1 },\n     { actual: candidate([]string{\"makes\", \"best\", \"sekam\", \"for\", \"rof\"}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "go_test.go",
+    "prompt": "package is_decimal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Decimal(t *testing.T) {\n  candidate := is_decimal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"123.11\"), expected: true },\n     { actual: candidate(\"e666.86\"), expected: false },\n     { actual: candidate(\"3.124587\"), expected: false },\n     { actual: candidate(\"1.11\"), expected: true },\n     { actual: candidate(\"1.1.11\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "go_test.go",
+    "prompt": "package find_tuples_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find lists which have all elements divisible by k from the given list of lists.\nfunc find_tuples(test_list [][]interface{}, K int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Tuples(t *testing.T) {\n  candidate := find_tuples\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{6, 24, 12}, []interface{}{7, 9, 6}, []interface{}{12, 18, 21}}, 6), expected: [][]int{[]interface{}{6, 24, 12}} },\n     { actual: candidate([][]int{[]interface{}{5, 25, 30}, []interface{}{4, 2, 3}, []interface{}{7, 8, 9}}, 5), expected: [][]int{[]interface{}{5, 25, 30}} },\n     { actual: candidate([][]int{[]interface{}{7, 9, 16}, []interface{}{8, 16, 4}, []interface{}{19, 17, 18}}, 4), expected: [][]int{[]interface{}{8, 16, 4}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "go_test.go",
+    "prompt": "package unique_Element_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestUnique_Element(t *testing.T) {\n  candidate := unique_Element\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: false },\n     { actual: candidate([]int{1, 2, 3, 4, 5}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "go_test.go",
+    "prompt": "package check_monthnumber_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3 int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Monthnumber_Number(t *testing.T) {\n  candidate := check_monthnumber_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(6), expected: true },\n     { actual: candidate(2), expected: false },\n     { actual: candidate(12), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "go_test.go",
+    "prompt": "package find_min_diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr []int, n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Min_Diff(t *testing.T) {\n  candidate := find_min_diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 5, 3, 19, 18, 25}, 6), expected: 1 },\n     { actual: candidate([]int{4, 3, 2, 6}, 4), expected: 1 },\n     { actual: candidate([]int{30, 5, 20, 9}, 4), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "go_test.go",
+    "prompt": "package number_ctr_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count number of digits in a given string.\nfunc number_ctr(str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNumber_Ctr(t *testing.T) {\n  candidate := number_ctr\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"program2bedone\"), expected: 1 },\n     { actual: candidate(\"3wonders\"), expected: 1 },\n     { actual: candidate(\"123\"), expected: 3 },\n     { actual: candidate(\"3wond-1ers2\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "go_test.go",
+    "prompt": "package is_polite_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Polite(t *testing.T) {\n  candidate := is_polite\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(7), expected: 11 },\n     { actual: candidate(4), expected: 7 },\n     { actual: candidate(9), expected: 13 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "go_test.go",
+    "prompt": "package pair_wise_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1 []int) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPair_Wise(t *testing.T) {\n  candidate := pair_wise\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 2, 3, 3, 4, 4, 5}), expected: [][]int{[]interface{}{1, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 3}, []interface{}{3, 4}, []interface{}{4, 4}, []interface{}{4, 5}} },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: [][]int{[]interface{}{1, 5}, []interface{}{5, 7}, []interface{}{7, 9}, []interface{}{9, 10}} },\n     { actual: candidate([]int{5, 1, 9, 7, 10}), expected: [][]int{[]interface{}{5, 1}, []interface{}{1, 9}, []interface{}{9, 7}, []interface{}{7, 10}} },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: [][]int{[]interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}, []interface{}{4, 5}, []interface{}{5, 6}, []interface{}{6, 7}, []interface{}{7, 8}, []interface{}{8, 9}, []interface{}{9, 10}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "go_test.go",
+    "prompt": "package get_pairs_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr []int, sum int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Pairs_Count(t *testing.T) {\n  candidate := get_pairs_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 1, 1, 1}, 2), expected: 6 },\n     { actual: candidate([]int{1, 5, 7, -1, 5}, 6), expected: 3 },\n     { actual: candidate([]int{1, -2, 3}, 1), expected: 1 },\n     { actual: candidate([]int{-1, -2, 3}, -3), expected: 1 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "go_test.go",
+    "prompt": "package Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to get the difference between two lists.\nfunc Diff(li1 []int, li2 []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDiff(t *testing.T) {\n  candidate := Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 15, 20, 25, 30, 35, 40}, []int{25, 40, 35}), expected: []int{10, 20, 30, 15} },\n     { actual: candidate([]int{1, 2, 3, 4, 5}, []int{6, 7, 1}), expected: []int{2, 3, 4, 5, 6, 7} },\n     { actual: candidate([]int{1, 2, 3}, []int{6, 7, 1}), expected: []int{2, 3, 6, 7} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "go_test.go",
+    "prompt": "package odd_num_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOdd_Num_Sum(t *testing.T) {\n  candidate := odd_num_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2), expected: 82 },\n     { actual: candidate(3), expected: 707 },\n     { actual: candidate(4), expected: 3108 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "go_test.go",
+    "prompt": "package check_expression_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Expression(t *testing.T) {\n  candidate := check_expression\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"{()}[{}]\"), expected: true },\n     { actual: candidate(\"{()}[{]\"), expected: false },\n     { actual: candidate(\"{()}[{}][]({})\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "go_test.go",
+    "prompt": "package remove_length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str string, K int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Length(t *testing.T) {\n  candidate := remove_length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"The person is most value tet\", 3), expected: \"person is most value\" },\n     { actual: candidate(\"If you told me about this ok\", 4), expected: \"If you me about ok\" },\n     { actual: candidate(\"Forces of darkeness is come into the play\", 4), expected: \"Forces of darkeness is the\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "go_test.go",
+    "prompt": "package odd_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOdd_Position(t *testing.T) {\n  candidate := odd_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{2, 1, 4, 3, 6, 7, 6, 3}), expected: true },\n     { actual: candidate([]int{4, 1, 2}), expected: true },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "go_test.go",
+    "prompt": "package count_vowels_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Vowels(t *testing.T) {\n  candidate := count_vowels\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"bestinstareels\"), expected: 7 },\n     { actual: candidate(\"partofthejourneyistheend\"), expected: 12 },\n     { actual: candidate(\"amazonprime\"), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "go_test.go",
+    "prompt": "package find_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Sum(t *testing.T) {\n  candidate := find_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 1, 1, 4, 5, 6}), expected: 21 },\n     { actual: candidate([]int{1, 10, 9, 4, 2, 10, 10, 45, 4}), expected: 71 },\n     { actual: candidate([]int{12, 10, 9, 45, 2, 10, 10, 45, 10}), expected: 78 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "go_test.go",
+    "prompt": "package pack_consecutive_duplicates_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1 []interface{}) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPack_Consecutive_Duplicates(t *testing.T) {\n  candidate := pack_consecutive_duplicates\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), expected: [][]int{[]int{0, 0}, []int{1}, []int{2}, []int{3}, []int{4, 4}, []int{5}, []int{6, 6, 6}, []int{7}, []int{8}, []int{9}, []int{4, 4}} },\n     { actual: candidate([]int{10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), expected: [][]int{[]int{10, 10}, []int{15}, []int{19}, []int{18, 18}, []int{17}, []int{26, 26}, []int{17}, []int{18}, []int{10}} },\n     { actual: candidate([]string{\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"}), expected: [][]int{[]string{\"a\", \"a\"}, []string{\"b\"}, []string{\"c\"}, []string{\"d\", \"d\"}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "go_test.go",
+    "prompt": "package is_Diff_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find whether a number is divisible by 11.\nfunc is_Diff(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Diff(t *testing.T) {\n  candidate := is_Diff\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(12345), expected: false },\n     { actual: candidate(1212112), expected: true },\n     { actual: candidate(1212), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "go_test.go",
+    "prompt": "package find_combinations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/gothon-combinations-of-sum-with-lists-in-list-list/\nfunc find_combinations(test_list [][]interface{}) [][]interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Combinations(t *testing.T) {\n  candidate := find_combinations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{2, 4}, []interface{}{6, 7}, []interface{}{5, 1}, []interface{}{6, 10}}), expected: [][]int{[]interface{}{8, 11}, []interface{}{7, 5}, []interface{}{8, 14}, []interface{}{11, 8}, []interface{}{12, 17}, []interface{}{11, 11}} },\n     { actual: candidate([][]int{[]interface{}{3, 5}, []interface{}{7, 8}, []interface{}{6, 2}, []interface{}{7, 11}}), expected: [][]int{[]interface{}{10, 13}, []interface{}{9, 7}, []interface{}{10, 16}, []interface{}{13, 10}, []interface{}{14, 19}, []interface{}{13, 13}} },\n     { actual: candidate([][]int{[]interface{}{4, 6}, []interface{}{8, 9}, []interface{}{7, 3}, []interface{}{8, 12}}), expected: [][]int{[]interface{}{12, 15}, []interface{}{11, 9}, []interface{}{12, 18}, []interface{}{15, 12}, []interface{}{16, 21}, []interface{}{15, 15}} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "go_test.go",
+    "prompt": "package count_divisors_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the count of divisors is even. https://www.w3resource.com/gothon-exercises/basic/gothon-basic-1-exercise-24.php\nfunc count_divisors(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Divisors(t *testing.T) {\n  candidate := count_divisors\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: true },\n     { actual: candidate(100), expected: false },\n     { actual: candidate(125), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "go_test.go",
+    "prompt": "package odd_length_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\nfunc odd_length_sum(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestOdd_Length_Sum(t *testing.T) {\n  candidate := odd_length_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4}), expected: 14 },\n     { actual: candidate([]int{1, 2, 1, 2}), expected: 15 },\n     { actual: candidate([]int{1, 7}), expected: 8 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "go_test.go",
+    "prompt": "package rgb_to_hsv_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r int, g int, b int) []float64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRgb_To_Hsv(t *testing.T) {\n  candidate := rgb_to_hsv\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(255, 255, 255), expected: []float64{0.0, 0.0, 100.0} },\n     { actual: candidate(0, 215, 0), expected: []float64{120.0, 100.0, 84.31372549019608} },\n     { actual: candidate(10, 215, 110), expected: []float64{149.26829268292684, 95.34883720930233, 84.31372549019608} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "go_test.go",
+    "prompt": "package mul_even_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1 []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMul_Even_Odd(t *testing.T) {\n  candidate := mul_even_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5, 7, 4, 1, 6, 8}), expected: 4 },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: 2 },\n     { actual: candidate([]int{1, 5, 7, 9, 10}), expected: 10 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "go_test.go",
+    "prompt": "package tuple_str_int_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert list string to integer list.\nfunc tuple_str_int(test_str string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTuple_Str_Int(t *testing.T) {\n  candidate := tuple_str_int\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"(7, 8, 9)\"), expected: []interface{}{7, 8, 9} },\n     { actual: candidate(\"(1, 2, 3)\"), expected: []interface{}{1, 2, 3} },\n     { actual: candidate(\"(4, 5, 6)\"), expected: []interface{}{4, 5, 6} },\n     { actual: candidate(\"(7, 81, 19)\"), expected: []interface{}{7, 81, 19} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "go_test.go",
+    "prompt": "package right_insertion_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRight_Insertion(t *testing.T) {\n  candidate := right_insertion\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 4, 5}, 6), expected: 4 },\n     { actual: candidate([]int{1, 2, 4, 5}, 3), expected: 2 },\n     { actual: candidate([]int{1, 2, 4, 5}, 7), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "go_test.go",
+    "prompt": "package text_match_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Match_Three(t *testing.T) {\n  candidate := text_match_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"ac\"), expected: false },\n     { actual: candidate(\"dc\"), expected: false },\n     { actual: candidate(\"abbbba\"), expected: true },\n     { actual: candidate(\"caacabbbba\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "go_test.go",
+    "prompt": "package new_tuple_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to create a new list from the given string and list.\nfunc new_tuple(test_list []string, test_str string) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestNew_Tuple(t *testing.T) {\n  candidate := new_tuple\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"WEB\", \"is\"}, \"best\"), expected: []interface{}{\"WEB\", \"is\", \"best\"} },\n     { actual: candidate([]string{\"We\", \"are\"}, \"Developers\"), expected: []interface{}{\"We\", \"are\", \"Developers\"} },\n     { actual: candidate([]string{\"Part\", \"is\"}, \"Wrong\"), expected: []interface{}{\"Part\", \"is\", \"Wrong\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "go_test.go",
+    "prompt": "package even_position_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestEven_Position(t *testing.T) {\n  candidate := even_position\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: false },\n     { actual: candidate([]int{1, 2, 3}), expected: false },\n     { actual: candidate([]int{2, 1, 4}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "go_test.go",
+    "prompt": "package remove_nested_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove lists from the given list.\nfunc remove_nested(test_tup interface{}) []interface{} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_Nested(t *testing.T) {\n  candidate := remove_nested\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 5, 7, []interface{}{4, 6}, 10}), expected: []interface{}{1, 5, 7, 10} },\n     { actual: candidate([]interface{}{2, 6, 8, []interface{}{5, 7}, 11}), expected: []interface{}{2, 6, 8, 11} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, 12}), expected: []interface{}{3, 7, 9, 12} },\n     { actual: candidate([]interface{}{3, 7, 9, []interface{}{6, 8}, []interface{}{5, 12}, 12}), expected: []interface{}{3, 7, 9, 12} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "go_test.go",
+    "prompt": "package count_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of lists in a given number of lists.\nfunc count_list(input_list [][]int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_List(t *testing.T) {\n  candidate := count_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 3}, []int{5, 7}, []int{9, 11}, []int{13, 15, 17}}), expected: 4 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{2, 3}, []int{4, 5}}), expected: 3 },\n     { actual: candidate([][]int{[]int{1, 0}, []int{2, 0}}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "go_test.go",
+    "prompt": "package last_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the last position of an element in a sorted list.\nfunc last(arr []int, x int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLast(t *testing.T) {\n  candidate := last\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}, 1), expected: 0 },\n     { actual: candidate([]int{1, 1, 1, 2, 3, 4}, 1), expected: 2 },\n     { actual: candidate([]int{2, 3, 2, 3, 6, 8, 9}, 3), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "go_test.go",
+    "prompt": "package text_starta_endb_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestText_Starta_Endb(t *testing.T) {\n  candidate := text_starta_endb\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aabbbb\"), expected: true },\n     { actual: candidate(\"aabAbbbc\"), expected: false },\n     { actual: candidate(\"accddbbjjj\"), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "go_test.go",
+    "prompt": "package return_sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write function to find the sum of all items in the given map.\nfunc return_sum(dict map[string]int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestReturn_Sum(t *testing.T) {\n  candidate := return_sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]int{\"a\": 100, \"b\": 200, \"c\": 300}), expected: 600 },\n     { actual: candidate(map[string]int{\"a\": 25, \"b\": 18, \"c\": 45}), expected: 88 },\n     { actual: candidate(map[string]int{\"a\": 36, \"b\": 39, \"c\": 49}), expected: 124 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "go_test.go",
+    "prompt": "package sum_in_range_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l int, r int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSum_In_Range(t *testing.T) {\n  candidate := sum_in_range\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(2, 5), expected: 8 },\n     { actual: candidate(5, 7), expected: 12 },\n     { actual: candidate(7, 13), expected: 40 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "go_test.go",
+    "prompt": "package _sum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the sum of a list.\nfunc _sum(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func Test_Sum(t *testing.T) {\n  candidate := _sum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: 6 },\n     { actual: candidate([]int{15, 12, 13, 10}), expected: 50 },\n     { actual: candidate([]int{0, 1, 2}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "go_test.go",
+    "prompt": "package left_rotate_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n int, d int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLeft_Rotate(t *testing.T) {\n  candidate := left_rotate\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(16, 2), expected: 64 },\n     { actual: candidate(10, 2), expected: 40 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(99, 3), expected: 792 },\n     { actual: candidate(1, 3), expected: 8 },\n     { actual: candidate(5, 3), expected: 40 },\n     { actual: candidate(29, 3), expected: 232 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "go_test.go",
+    "prompt": "package word_len_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to check whether the length of the word is odd or not.\nfunc word_len(s string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestWord_Len(t *testing.T) {\n  candidate := word_len\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"Hadoop\"), expected: false },\n     { actual: candidate(\"great\"), expected: true },\n     { actual: candidate(\"structure\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "go_test.go",
+    "prompt": "package remove_all_spaces_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestRemove_All_Spaces(t *testing.T) {\n  candidate := remove_all_spaces\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"python  program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"python   programming    language\"), expected: \"pythonprogramminglanguage\" },\n     { actual: candidate(\"python                     program\"), expected: \"pythonprogram\" },\n     { actual: candidate(\"   python                     program\"), expected: \"pythonprogram\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "go_test.go",
+    "prompt": "package test_three_equal_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x int, y int, z int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTest_Three_Equal(t *testing.T) {\n  candidate := test_three_equal\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1, 1, 1), expected: 3 },\n     { actual: candidate(-1, -2, -3), expected: 0 },\n     { actual: candidate(1, 2, 2), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "go_test.go",
+    "prompt": "package count_rotation_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\nfunc count_rotation(arr []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCount_Rotation(t *testing.T) {\n  candidate := count_rotation\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{3, 2, 1}), expected: 1 },\n     { actual: candidate([]int{4, 5, 1, 2, 3}), expected: 2 },\n     { actual: candidate([]int{7, 8, 9, 1, 2, 3}), expected: 3 },\n     { actual: candidate([]int{1, 2, 3}), expected: 0 },\n     { actual: candidate([]int{1, 3, 2}), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "go_test.go",
+    "prompt": "package is_perfect_square_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Perfect_Square(t *testing.T) {\n  candidate := is_perfect_square\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: false },\n     { actual: candidate(36), expected: true },\n     { actual: candidate(14), expected: false },\n     { actual: candidate(196), expected: true },\n     { actual: candidate(125), expected: false },\n     { actual: candidate(15625), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "go_test.go",
+    "prompt": "package is_product_even_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr []int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Product_Even(t *testing.T) {\n  candidate := is_product_even\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3}), expected: true },\n     { actual: candidate([]int{1, 2, 1, 4}), expected: true },\n     { actual: candidate([]int{1, 1}), expected: false },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "go_test.go",
+    "prompt": "package max_sum_list_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists [][]int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Sum_List(t *testing.T) {\n  candidate := max_sum_list\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{10, 11, 12}, []int{7, 8, 9}}), expected: []int{10, 11, 12} },\n     { actual: candidate([][]int{[]int{3, 2, 1}, []int{6, 5, 4}, []int{12, 11, 10}}), expected: []int{12, 11, 10} },\n     { actual: candidate([][]int{[]int{2, 3, 1}}), expected: []int{2, 3, 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "go_test.go",
+    "prompt": "package max_run_uppercase_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMax_Run_Uppercase(t *testing.T) {\n  candidate := max_run_uppercase\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"GeMKSForGERksISBESt\"), expected: 5 },\n     { actual: candidate(\"PrECIOusMOVemENTSYT\"), expected: 6 },\n     { actual: candidate(\"GooGLEFluTTER\"), expected: 4 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "go_test.go",
+    "prompt": "package first_odd_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the first odd number in a given list of numbers.\nfunc first_odd(nums []int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFirst_Odd(t *testing.T) {\n  candidate := first_odd\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 3, 5}), expected: 1 },\n     { actual: candidate([]int{2, 4, 1, 3}), expected: 1 },\n     { actual: candidate([]int{8, 9, 1}), expected: 9 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "go_test.go",
+    "prompt": "package check_K_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if the given lists contain the k or not.\nfunc check_K(test_tup []int, K int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_K(t *testing.T) {\n  candidate := check_K\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 4, 5, 6, 8}, 6), expected: true },\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6}, 7), expected: false },\n     { actual: candidate([]int{7, 8, 9, 44, 11, 12}, 11), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "go_test.go",
+    "prompt": "package check_smaller_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if each element of second list is smaller than its corresponding element in the first list.\nfunc check_smaller(test_tup1 []interface{}, test_tup2 []interface{}) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCheck_Smaller(t *testing.T) {\n  candidate := check_smaller\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]interface{}{1, 2, 3}, []interface{}{2, 3, 4}), expected: false },\n     { actual: candidate([]interface{}{4, 5, 6}, []interface{}{3, 4, 5}), expected: true },\n     { actual: candidate([]interface{}{11, 12, 13}, []interface{}{10, 11, 12}), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "go_test.go",
+    "prompt": "package tetrahedral_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestTetrahedral_Number(t *testing.T) {\n  candidate := tetrahedral_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(5), expected: 35 },\n     { actual: candidate(6), expected: 56 },\n     { actual: candidate(7), expected: 84 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "go_test.go",
+    "prompt": "package get_Char_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr string) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestGet_Char(t *testing.T) {\n  candidate := get_Char\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"abc\"), expected: \"f\" },\n     { actual: candidate(\"gfg\"), expected: \"t\" },\n     { actual: candidate(\"ab\"), expected: \"c\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "go_test.go",
+    "prompt": "package sequence_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSequence(t *testing.T) {\n  candidate := sequence\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 6 },\n     { actual: candidate(2), expected: 1 },\n     { actual: candidate(3), expected: 2 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "go_test.go",
+    "prompt": "package centered_hexagonal_number_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestCentered_Hexagonal_Number(t *testing.T) {\n  candidate := centered_hexagonal_number\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(10), expected: 271 },\n     { actual: candidate(2), expected: 7 },\n     { actual: candidate(9), expected: 217 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "go_test.go",
+    "prompt": "package merge_dictionaries_three_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to merge three dictionaries into a single map.\nfunc merge_dictionaries_three(dict1 map[string]string, dict2 map[string]string, dict3 map[string]string) map[string]string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestMerge_Dictionaries_Three(t *testing.T) {\n  candidate := merge_dictionaries_three\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}), expected: map[string]string{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}), expected: map[string]string{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"} },\n     { actual: candidate(map[string]string{\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, map[string]string{\"L\": \"lavender\", \"B\": \"Blue\"}, map[string]string{\"G\": \"Green\", \"W\": \"White\"}), expected: map[string]string{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "go_test.go",
+    "prompt": "package freq_count_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to get the frequency of all the elements in a list, returned as a map.\nfunc freq_count(list1 []int) map[int]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFreq_Count(t *testing.T) {\n  candidate := freq_count\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), expected: map[int]int{10: 4, 20: 4, 40: 2, 50: 2, 30: 1} },\n     { actual: candidate([]int{1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), expected: map[int]int{1: 3, 2: 2, 3: 3, 4: 3} },\n     { actual: candidate([]int{5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), expected: map[int]int{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "go_test.go",
+    "prompt": "package closest_num_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find the closest smaller number than n.\nfunc closest_num(N int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestClosest_Num(t *testing.T) {\n  candidate := closest_num\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(11), expected: 10 },\n     { actual: candidate(7), expected: 6 },\n     { actual: candidate(12), expected: 11 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "go_test.go",
+    "prompt": "package square_nums_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums []int) []int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestSquare_Nums(t *testing.T) {\n  candidate := square_nums\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), expected: []int{1, 4, 9, 16, 25, 36, 49, 64, 81, 100} },\n     { actual: candidate([]int{10, 20, 30}), expected: []int{100, 400, 900} },\n     { actual: candidate([]int{12, 15}), expected: []int{144, 225} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "go_test.go",
+    "prompt": "package len_log_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the longest word.\nfunc len_log(list1 []string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestLen_Log(t *testing.T) {\n  candidate := len_log\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"python\", \"PHP\", \"bigdata\"}), expected: 7 },\n     { actual: candidate([]string{\"a\", \"ab\", \"abc\"}), expected: 3 },\n     { actual: candidate([]string{\"small\", \"big\", \"tall\"}), expected: 5 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "go_test.go",
+    "prompt": "package find_substring_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1 []string, sub_str string) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Substring(t *testing.T) {\n  candidate := find_substring\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ack\"), expected: true },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"abc\"), expected: false },\n     { actual: candidate([]string{\"red\", \"black\", \"white\", \"green\", \"orange\"}, \"ange\"), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "go_test.go",
+    "prompt": "package is_undulating_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n int) bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIs_Undulating(t *testing.T) {\n  candidate := is_undulating\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(1212121), expected: true },\n     { actual: candidate(1991), expected: false },\n     { actual: candidate(121), expected: true },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "go_test.go",
+    "prompt": "package power_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a int, b int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestPower(t *testing.T) {\n  candidate := power\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(3, 4), expected: 81 },\n     { actual: candidate(2, 3), expected: 8 },\n     { actual: candidate(5, 5), expected: 3125 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "go_test.go",
+    "prompt": "package index_minimum_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Given a list of lists, write a function that returns the first value of the list with the smallest second value.\nfunc index_minimum(test_list [][]interface{}) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestIndex_Minimum(t *testing.T) {\n  candidate := index_minimum\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]interface{}{\"Rash\", 143}, []interface{}{\"Manjeet\", 200}, []interface{}{\"Varsha\", 100}}), expected: \"Varsha\" },\n     { actual: candidate([][]int{[]interface{}{\"Yash\", 185}, []interface{}{\"Dawood\", 125}, []interface{}{\"Sanya\", 175}}), expected: \"Dawood\" },\n     { actual: candidate([][]int{[]interface{}{\"Sai\", 345}, []interface{}{\"Salman\", 145}, []interface{}{\"Ayesha\", 96}}), expected: \"Ayesha\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "go_test.go",
+    "prompt": "package Find_Min_Length_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst [][]int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Min_Length(t *testing.T) {\n  candidate := Find_Min_Length\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1}, []int{1, 2}}), expected: 1 },\n     { actual: candidate([][]int{[]int{1, 2}, []int{1, 2, 3}, []int{1, 2, 3, 4}}), expected: 2 },\n     { actual: candidate([][]int{[]int{3, 3, 3}, []int{4, 4, 4, 4}}), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "go_test.go",
+    "prompt": "package divisor_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the number of divisors of a given integer.\nfunc divisor(n int) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDivisor(t *testing.T) {\n  candidate := divisor\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(15), expected: 4 },\n     { actual: candidate(12), expected: 6 },\n     { actual: candidate(9), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "go_test.go",
+    "prompt": "package frequency_lists_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to find frequency of each element in a flattened list of lists, returned in a map.\nfunc frequency_lists(list1 [][]int) map[int]int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFrequency_Lists(t *testing.T) {\n  candidate := frequency_lists\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate([][]int{[]int{1, 2, 3, 2}, []int{4, 5, 6, 2}, []int{7, 8, 9, 5}}), expected: map[int]int{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1} },\n     { actual: candidate([][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}}), expected: map[int]int{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1} },\n     { actual: candidate([][]int{[]int{20, 30, 40, 17}, []int{18, 16, 14, 13}, []int{10, 20, 30, 40}}), expected: map[int]int{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1} },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "go_test.go",
+    "prompt": "package decimal_to_binary_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n int) string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestDecimal_To_Binary(t *testing.T) {\n  candidate := decimal_to_binary\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(8), expected: \"1000\" },\n     { actual: candidate(18), expected: \"10010\" },\n     { actual: candidate(7), expected: \"111\" },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
+    "stop_tokens": [
+      "\nfunc",
+      "struct",
+      "\n// "
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "go_test.go",
+    "prompt": "package find_Rotations_test\n\nimport (\n    \"testing\"\n    \"fmt\"\n)\n\n// Write a gothon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str string) int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "func TestFind_Rotations(t *testing.T) {\n  candidate := find_Rotations\n\ttype test struct {\n\t\tactual   interface{}\n\t\texpected interface{}\n\t}\n   tests := []test{\n     { actual: candidate(\"aaaa\"), expected: 1 },\n     { actual: candidate(\"ab\"), expected: 2 },\n     { actual: candidate(\"abc\"), expected: 3 },\n   }\n\n\tfor i, tc := range tests {\n\t\tt.Run(fmt.Sprintf(\"test num % d\", i), func(t *testing.T) {\n\t\t\tif fmt.Sprintf(\"%v\", tc.actual) != fmt.Sprintf(\"%v\", tc.expected) {\n\t\t\t\tt.Errorf(\"expected '%s', got '%s'\", tc.expected, tc.actual)\n\t\t\t}\n\t\t})\n\t}\n}\n",
     "stop_tokens": [
       "\nfunc",
       "struct",

--- a/prompts/mbpp-java-keep.json
+++ b/prompts/mbpp-java-keep.json
@@ -1,3444 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long lps(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static String removeWhitespaces(String text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static boolean issortList(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)17l)))) == (true));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)20l, (long)17l)))) == (false));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)15l, (long)14l, (long)20l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long countBidirectional(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (3l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (2l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long surfaceareaCube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    public static long nextSmallestPalindrome(long num) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallestPalindrome((99l)) == (101l));\n    assert(nextSmallestPalindrome((1221l)) == (1331l));\n    assert(nextSmallestPalindrome((120l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    public static long cubeSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    public static long pairXorSum(ArrayList<Long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)7l, (long)6l))), (4l)) == (47l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)5l))), (3l)) == (12l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l))), (2l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    public static boolean checkMinHeap(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)10l, (long)15l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)5l, (long)3l, (long)15l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first digit of a given number.\n    public static long firstDigit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    public static Optional<String> firstNonRepeatingCharacter(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(Optional.empty()));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Optional.of(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Optional.of(\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float radianDegree(long degree) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    public static long maxSubarrayProduct(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)0l, (long)7l, (long)-8l, (long)-2l)))) == (112l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)6l, (long)-3l, (long)-10l, (long)0l, (long)2l)))) == (180l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-40l, (long)0l, (long)-2l, (long)-3l)))) == (80l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static ArrayList<HashMap<String,HashMap<String,Long>>> convertListDictionary(ArrayList<String> l1, ArrayList<String> l2, ArrayList<Long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"S001\", (String)\"S002\", (String)\"S003\", (String)\"S004\"))), (new ArrayList<String>(Arrays.asList((String)\"Adina Park\", (String)\"Leyton Marsh\", (String)\"Duncan Boyle\", (String)\"Saim Richards\"))), (new ArrayList<Long>(Arrays.asList((long)85l, (long)98l, (long)89l, (long)92l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S001\", new HashMap<String,Long>(Map.of(\"Adina Park\", 85l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S002\", new HashMap<String,Long>(Map.of(\"Leyton Marsh\", 98l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S003\", new HashMap<String,Long>(Map.of(\"Duncan Boyle\", 89l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S004\", new HashMap<String,Long>(Map.of(\"Saim Richards\", 92l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"def\", (String)\"ghi\", (String)\"jkl\"))), (new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\", (String)\"programs\"))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"abc\", new HashMap<String,Long>(Map.of(\"python\", 100l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"def\", new HashMap<String,Long>(Map.of(\"program\", 200l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"ghi\", new HashMap<String,Long>(Map.of(\"language\", 300l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"jkl\", new HashMap<String,Long>(Map.of(\"programs\", 400l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"A1\", (String)\"A2\", (String)\"A3\", (String)\"A4\"))), (new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\"))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A1\", new HashMap<String,Long>(Map.of(\"java\", 10l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A2\", new HashMap<String,Long>(Map.of(\"C\", 20l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A3\", new HashMap<String,Long>(Map.of(\"C++\", 30l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A4\", new HashMap<String,Long>(Map.of(\"DBMS\", 40l)))))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find smallest number in a list.\n    public static long smallestNum(ArrayList<Long> xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)1l, (long)45l, (long)99l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)45l, (long)46l, (long)50l, (long)60l)))) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    public static boolean textMatchZeroOne(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find nth bell number.\n    public static long bellNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static ArrayList<Long> cubeNums(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)27l, (long)64l, (long)125l, (long)216l, (long)343l, (long)512l, (long)729l, (long)1000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)1728l, (long)3375l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    public static long lastDigitFactorial(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)0l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)0l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l, (long)15l, (long)19l)))).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static boolean primeNum(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static ArrayList<Pair<Long, Long, Long>> findTuples(ArrayList<Pair<Long, Long, Long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l), (Pair<Long, Long, Long>)Pair.with(7l, 9l, 6l), (Pair<Long, Long, Long>)Pair.with(12l, 18l, 21l)))), (6l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l), (Pair<Long, Long, Long>)Pair.with(4l, 2l, 3l), (Pair<Long, Long, Long>)Pair.with(7l, 8l, 9l)))), (5l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(7l, 9l, 16l), (Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l), (Pair<Long, Long, Long>)Pair.with(19l, 17l, 18l)))), (4l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float areaTetrahedron(long side) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number is even or not.\n    public static boolean isEven(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    public static long posCount(ArrayList<Long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l, (long)-4l)))) == (2l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)-1l)))) == (3l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static ArrayList<Long> getLudic(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getLudic((10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(getLudic((25l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l)))));\n    assert(getLudic((45l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l, (long)29l, (long)37l, (long)41l, (long)43l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long findIndex(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to reverse an array upto a given position.\n    public static ArrayList<Long> reverseArrayUptoK(ArrayList<Long> input, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l, (long)5l, (long)6l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)6l, (long)7l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)6l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static ArrayList<Pair<String, Long>> subjectMarks(ArrayList<Pair<String, Long>> subjectmarks) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l), (Pair<String, Long>)Pair.with(\"Social sciences\", 82l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social sciences\", 82l), (Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l), (Pair<String, Long>)Pair.with(\"Social\", 33l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social\", 33l), (Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l), (Pair<String, Long>)Pair.with(\"Biology\", 45l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Biology\", 45l), (Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static String removeDirtyChars(String string, String second_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long maxOccurrences(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)2l, (long)6l, (long)5l, (long)1l, (long)6l, (long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)6l, (long)9l, (long)1l, (long)2l)))) == (2l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)7l, (long)9l, (long)15l, (long)14l, (long)10l, (long)12l, (long)13l, (long)16l, (long)18l)))) == (8l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)20l, (long)30l, (long)40l, (long)90l, (long)80l, (long)50l, (long)30l, (long)20l, (long)50l, (long)10l)))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static boolean isDecimal(String num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static HashMap<String,Long> dictFilter(HashMap<String,Long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (170l)).equals((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (180l)).equals((new HashMap<String,Long>(Map.of(\"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (190l)).equals((new HashMap<String,Long>(Map.of(\"Pierre Cox\", 190l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    public static long sumEvenAndEvenIndex(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l, (long)18l, (long)8l)))) == (30l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)3l, (long)20l, (long)17l, (long)9l, (long)2l, (long)10l, (long)18l, (long)13l, (long)6l, (long)18l)))) == (26l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long maxSubArraySum(ArrayList<Long> a, long size) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)4l, (long)-1l, (long)-2l, (long)1l, (long)5l, (long)-3l))), (8l)) == (7l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l, (long)-2l, (long)-3l, (long)2l, (long)6l, (long)-4l))), (8l)) == (8l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-5l, (long)6l, (long)-3l, (long)-4l, (long)3l, (long)7l, (long)-5l))), (8l)) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the intersection of two arrays.\n    public static ArrayList<Long> intersectionArray(ArrayList<Long> array_nums1, ArrayList<Long> array_nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)8l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static Object splitTwoParts(ArrayList<Object> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals(Pair.with(new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l)), new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (2l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\"))), (4l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\")), new ArrayList<String>(Arrays.asList((String)\"o\", (String)\"n\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Pair<String, Long, Long> findLiterals(String text, String pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals((Pair.with(\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals((Pair.with(\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals((Pair.with(\"will\", 35l, 39l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the volume of a triangular prism.\n    public static long findVolume(long l, long b, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long windChill(long v, long t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long asciiValue(String k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether all the characters are same or not.\n    public static boolean allCharactersSame(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static String moveNum(String test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    public static boolean wordLen(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static HashMap<String,String> dropEmpty(HashMap<String,Optional<String>> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\")))));\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", Optional.empty(), \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\")))));\n    assert(dropEmpty(new HashMap<String,Optional.empty()>(Map.of(\"c1\", Optional.empty(), \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c2\", \"Green\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static ArrayList<String> insertElement(ArrayList<String> list, String element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Black\"))), (\"c\")).equals((new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"Red\", (String)\"c\", (String)\"Green\", (String)\"c\", (String)\"Black\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"java\"))), (\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"program\", (String)\"python\", (String)\"program\", (String)\"java\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"happy\", (String)\"sad\"))), (\"laugh\")).equals((new ArrayList<String>(Arrays.asList((String)\"laugh\", (String)\"happy\", (String)\"laugh\", (String)\"sad\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static String removeLowercase(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long countSetBits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static ArrayList<String> extractRear(Pair<String, String, String> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractRear((Pair.with(\"Mers\", \"for\", \"Vers\"))).equals((new ArrayList<String>(Arrays.asList((String)\"s\", (String)\"r\", (String)\"s\")))));\n    assert(extractRear((Pair.with(\"Avenge\", \"for\", \"People\"))).equals((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"r\", (String)\"e\")))));\n    assert(extractRear((Pair.with(\"Gotta\", \"get\", \"go\"))).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"t\", (String)\"o\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long countOccurance(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static boolean checkK(ArrayList<Long> test_tup, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)10l, (long)4l, (long)5l, (long)6l, (long)8l))), (6l)) == (true));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (7l)) == (false));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)44l, (long)11l, (long)12l))), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static ArrayList<Long> interleaveLists(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l, (long)60l, (long)70l))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l, (long)500l, (long)600l, (long)700l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)100l, (long)2l, (long)20l, (long)200l, (long)3l, (long)30l, (long)300l, (long)4l, (long)40l, (long)400l, (long)5l, (long)50l, (long)500l, (long)6l, (long)60l, (long)600l, (long)7l, (long)70l, (long)700l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)5l, (long)20l, (long)2l, (long)10l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)11l, (long)44l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)15l))), (new ArrayList<Long>(Arrays.asList((long)20l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)10l, (long)20l, (long)44l, (long)15l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    public static long testThreeEqual(long x, long y, long z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    public static long oddLengthSum(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l)))) == (14l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (15l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long bellNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long rectangleArea(long l, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Pair<Long, Float> sumAverage(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumAverage((10l)).equals((Pair.with(55l, 5.5f))));\n    assert(sumAverage((15l)).equals((Pair.with(120l, 8.0f))));\n    assert(sumAverage((20l)).equals((Pair.with(210l, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Pair<Long, Long, Long, Long> divisionElements(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisionElements((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(2l, 2l, 2l, 3l))));\n    assert(divisionElements((Pair.with(12l, 6l, 8l, 16l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(2l, 2l, 2l, 4l))));\n    assert(divisionElements((Pair.with(20l, 14l, 36l, 18l)), (Pair.with(5l, 7l, 6l, 9l))).equals((Pair.with(4l, 2l, 6l, 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long sumDigits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static String indexMinimum(ArrayList<Pair<String, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Rash\", 143l), (Pair<String, Long>)Pair.with(\"Manjeet\", 200l), (Pair<String, Long>)Pair.with(\"Varsha\", 100l))))).equals((\"Varsha\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Yash\", 185l), (Pair<String, Long>)Pair.with(\"Dawood\", 125l), (Pair<String, Long>)Pair.with(\"Sanya\", 175l))))).equals((\"Dawood\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sai\", 345l), (Pair<String, Long>)Pair.with(\"Salman\", 145l), (Pair<String, Long>)Pair.with(\"Ayesha\", 96l))))).equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static ArrayList<Float> divList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)2.5f, (float)2.0f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))).equals((new ArrayList<Float>(Arrays.asList((float)3.0f, (float)0.5f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Float>(Arrays.asList((float)1.8f, (float)1.7142857142857142f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Pair<Long, ArrayList<Long>> maxLengthList(ArrayList<ArrayList<Long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)))))).equals((Pair.with(5l, new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    public static long bigSum(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to return the negative numbers in a list.\n    public static ArrayList<Long> negNos(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)4l, (long)5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-6l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    public static long highestPowerOf2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static boolean isSublist(ArrayList<Long> l, ArrayList<Long> s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))) == (false));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)))) == (true));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static ArrayList<Long> subList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-3l, (long)-3l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-2l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Long>(Arrays.asList((long)40l, (long)50l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    public static boolean oppositeSigns(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Pair<Long, Long, Long, Long> tupleModulo(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleModulo((Pair.with(10l, 4l, 5l, 6l)), (Pair.with(5l, 6l, 7l, 5l))).equals((Pair.with(0l, 4l, 5l, 1l))));\n    assert(tupleModulo((Pair.with(11l, 5l, 6l, 7l)), (Pair.with(6l, 7l, 8l, 6l))).equals((Pair.with(5l, 5l, 6l, 1l))));\n    assert(tupleModulo((Pair.with(12l, 6l, 7l, 8l)), (Pair.with(7l, 8l, 9l, 7l))).equals((Pair.with(5l, 6l, 7l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long diffEvenOdd(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (3l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (1l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"f\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last digit of a given number.\n    public static long lastDigit(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    public static long oddNumSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static String tupString(ArrayList<String> tup1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"x\", (String)\"e\", (String)\"r\", (String)\"c\", (String)\"i\", (String)\"s\", (String)\"e\", (String)\"s\")))).equals((\"exercises\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))).equals((\"python\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))).equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static ArrayList<Long> removeElements(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    public static boolean overlapping(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to identify non-prime numbers.\n    public static boolean isNotPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long sumNegativenum(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (-32l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)-14l, (long)13l, (long)-18l, (long)12l, (long)-20l)))) == (-52l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)19l, (long)-65l, (long)57l, (long)39l, (long)152l, (long)-639l, (long)121l, (long)44l, (long)90l, (long)-190l)))) == (-894l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long findRotations(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static String changeDateFormat(String dt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l, (long)13l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)13l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long toggleMiddleBits(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long countCharPosition(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static ArrayList<Long> largeProduct(ArrayList<Long> nums1, ArrayList<Long> nums2, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l, (long)45l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long cummulativeSum(ArrayList<ArrayList<Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))))) == (30l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))))) == (37l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l)))))) == (44l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long findMinDiff(ArrayList<Long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)19l, (long)18l, (long)25l))), (6l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)6l))), (4l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)30l, (long)5l, (long)20l, (long)9l))), (4l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static boolean textStartaEndb(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long leftRotate(long n, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first repeated character in a given string.\n    public static Optional<String> firstRepeatedChar(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Optional.of(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(Optional.empty()));\n    assert(firstRepeatedChar((\"123123\")).equals(Optional.of(\"1\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count inversions in an array.\n    public static long getInvCount(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)6l, (long)4l, (long)5l)))) == (5l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (1l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)6l, (long)1l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long evenPowerSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static boolean getEqual(ArrayList<ArrayList<Long>> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)22l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)44l, (long)55l, (long)66l)))))) == (true));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l)))))) == (false));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static boolean checkInteger(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    public static long countReversePairs(ArrayList<String> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"julia\", (String)\"best\", (String)\"tseb\", (String)\"for\", (String)\"ailuj\")))) == (2l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"geeks\", (String)\"best\", (String)\"for\", (String)\"skeeg\")))) == (1l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"makes\", (String)\"best\", (String)\"sekam\", (String)\"for\", (String)\"rof\")))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    public static ArrayList<Long> moveZero(ArrayList<Long> num_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)0l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)0l, (long)0l, (long)4l, (long)0l, (long)5l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)4l, (long)5l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)1l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)0l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static boolean checkDistinct(ArrayList<Long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l, (long)1l, (long)4l)))) == (false));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static boolean noprofitNoloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static String removeLength(String test_str, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count number of digits in a given string.\n    public static long numberCtr(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long countCharac(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long getTotalNumberOfSequences(long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    public static long leftInsertion(ArrayList<Long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static ArrayList<Long> swapNumbers(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapNumbers((10l), (20l)).equals((new ArrayList<Long>(Arrays.asList((long)20l, (long)10l)))));\n    assert(swapNumbers((15l), (17l)).equals((new ArrayList<Long>(Arrays.asList((long)17l, (long)15l)))));\n    assert(swapNumbers((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)200l, (long)100l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    public static boolean isMajority(ArrayList<Long> arr, long n, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)3l, (long)10l))), (7l), (3l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)4l, (long)4l, (long)4l, (long)6l, (long)6l))), (8l), (4l)) == (false));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Pair<Long, Long, Long> substractElements(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(substractElements((Pair.with(10l, 4l, 5l)), (Pair.with(2l, 5l, 18l))).equals((Pair.with(8l, -1l, -13l))));\n    assert(substractElements((Pair.with(11l, 2l, 3l)), (Pair.with(24l, 45l, 16l))).equals((Pair.with(-13l, -43l, -13l))));\n    assert(substractElements((Pair.with(7l, 18l, 9l)), (Pair.with(10l, 11l, 12l))).equals((Pair.with(-3l, 7l, -3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static String capitalWordsSpaces(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    public static float findAverageOfCube(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == (float)12l);\n    assert(findAverageOfCube((1l)) == (float)1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static boolean checkValue(HashMap<String,Long> dict, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (10l)) == (false));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (12l)) == (true));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (5l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long tetrahedralNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static boolean magicSquareTest(ArrayList<ArrayList<Long>> my_matrix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)12l, (long)1l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)8l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)3l, (long)10l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)6l, (long)15l, (long)4l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)8l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)7l)))))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static String removeUppercase(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long dogAge(long h_age) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    public static long nextPerfectSquare(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static ArrayList<HashMap<Optional.empty(),Optional.empty()>> emptyList(long length) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(emptyList((5l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((6l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((7l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert a given string to uppercase.\n    public static String isUpper(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long oddEquivalent(String s, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static ArrayList<Long> reArrangeArray(ArrayList<Long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-3l, (long)4l, (long)5l, (long)6l, (long)-7l, (long)8l, (long)9l))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-7l, (long)4l, (long)5l, (long)6l, (long)2l, (long)8l, (long)9l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)12l, (long)-14l, (long)-26l, (long)13l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)-14l, (long)-26l, (long)12l, (long)13l, (long)15l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)10l, (long)24l, (long)36l, (long)-42l, (long)-39l, (long)-78l, (long)85l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-42l, (long)-39l, (long)-78l, (long)10l, (long)24l, (long)36l, (long)85l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    public static boolean uniqueElement(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))) == (true));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static ArrayList<String> extractValues(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"PHP\", (String)\"Java\")))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\")))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\", (String)\"yellow\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count true booleans in the given list.\n    public static long count(ArrayList<Boolean> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)false, (boolean)true)))) == (2l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)false, (boolean)false)))) == (0l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)true, (boolean)true)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long findEvenPair(ArrayList<Long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l)))) == (4l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l)))) == (9l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static boolean armstrongNumber(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the upper case characters in a given string.\n    public static long upperCtr(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Pair<Long, Long, Long, Long> andTuples(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(andTuples((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(0l, 0l, 2l, 1l))));\n    assert(andTuples((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(5l, 6l, 7l, 8l))).equals((Pair.with(1l, 2l, 3l, 0l))));\n    assert(andTuples((Pair.with(8l, 9l, 11l, 12l)), (Pair.with(7l, 13l, 14l, 17l))).equals((Pair.with(0l, 9l, 10l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    public static boolean isSamepatterns(ArrayList<String> colors, ArrayList<String> patterns) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"green\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (true));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (false));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    public static long countList(ArrayList<ArrayList<Long>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))) == (4l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))) == (3l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)0l)))))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static ArrayList<Float> averageTuple(ArrayList<ArrayList<Long>> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)45l, (long)56l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)80l, (long)39l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))).equals((new ArrayList<Float>(Arrays.asList((float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)-15l, (long)56l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)-60l, (long)-39l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-10l, (long)2l, (long)3l)))))).equals((new ArrayList<Float>(Arrays.asList((float)25.5f, (float)-18.0f, (float)3.75f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)100l, (long)100l, (long)100l, (long)120l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)300l, (long)450l, (long)560l, (long)450l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)810l, (long)800l, (long)390l, (long)320l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new ArrayList<Float>(Arrays.asList((float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long lcsOfThree(String X, String Y, String Z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long findStarNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of an array.\n    public static long Sum(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)15l, (long)12l, (long)13l, (long)10l)))) == (50l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    public static boolean checkConsecutive(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)6l)))) == (false));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Pair<Long, Long, String> findAdverbPosition(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals((Pair.with(0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals((Pair.with(0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals((Pair.with(0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    public static ArrayList<Long> rotateRight(ArrayList<Long> list, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    public static long numberOfSubstrings(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static ArrayList<ArrayList<Object>> listSplit(ArrayList<Object> S, long step) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"e\", (String)\"f\", (String)\"g\", (String)\"h\", (String)\"i\", (String)\"j\", (String)\"k\", (String)\"l\", (String)\"m\", (String)\"n\"))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"d\", (String)\"g\", (String)\"j\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"e\", (String)\"h\", (String)\"k\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"f\", (String)\"i\", (String)\"l\")))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l, (long)12l, (long)13l, (long)14l))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)10l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)8l, (long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)12l)))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"python\", (String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\", (String)\"SQL\"))), (2l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"C\", (String)\"DBMS\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C++\", (String)\"SQL\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    public static boolean allUnique(ArrayList<Long> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    public static Pair<Float, Float> convert(long numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(convert((1l)).equals((Pair.with(1.0f, 0.0f))));\n    assert(convert((4l)).equals((Pair.with(4.0f, 0.0f))));\n    assert(convert((5l)).equals((Pair.with(5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static HashMap<String,Pair<Float, Long>> filterData(HashMap<String,Pair<Float, Long>> students, float h, long w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (6.0f), (70l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.9f), (67l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Kierra Gentry\", Pair.with(6.0f, 68l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.7f), (64l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert the given string to lower case.\n    public static String isLower(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    public static long nextPowerOf2(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static boolean findSubstring(ArrayList<String> str1, String sub_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ack\")) == (true));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"abc\")) == (false));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static String replaceChar(String str1, String ch, String newch) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long mulEvenOdd(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (4l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static Object listTuple(ArrayList<Long> listx) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)10l, (long)7l, (long)4l, (long)15l, (long)3l)))).equals(Pair.with(5l, 10l, 7l, 4l, 15l, 3l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)2l, (long)3l, (long)4l, (long)4l, (long)7l)))).equals(Pair.with(2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)58l, (long)44l, (long)56l)))).equals(Pair.with(58l, 44l, 56l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long evenBinomialCoeffSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Pair<Long, Long, Long, Long> bitwiseXor(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bitwiseXor((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(15l, 6l, 5l, 10l))));\n    assert(bitwiseXor((Pair.with(11l, 5l, 7l, 10l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(13l, 6l, 3l, 14l))));\n    assert(bitwiseXor((Pair.with(12l, 6l, 8l, 11l)), (Pair.with(7l, 4l, 5l, 6l))).equals((Pair.with(11l, 2l, 13l, 13l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    public static boolean isSubArray(ArrayList<Long> A, ArrayList<Long> B) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (false));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (true));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    public static long maxSubArraySumRepeated(ArrayList<Long> a, long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)-30l, (long)-1l))), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)10l, (long)20l))), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))), (3l), (3l)) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long minProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (8l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (30l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    public static boolean countDivisors(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Optional<Long> triangleArea(long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((-1l)).equals(Optional.empty()));\n    assert(triangleArea((0l)).equals(Optional.of(0l)));\n    assert(triangleArea((2l)).equals(Optional.of(4l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static ArrayList<String> stringToTuple(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToTuple((\"python 3.0\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\", (String)\"3\", (String)\".\", (String)\"0\")))));\n    assert(stringToTuple((\"item1\")).equals((new ArrayList<String>(Arrays.asList((String)\"i\", (String)\"t\", (String)\"e\", (String)\"m\", (String)\"1\")))));\n    assert(stringToTuple((\"15.10\")).equals((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"5\", (String)\".\", (String)\"1\", (String)\"0\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long findLength(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long countPrimesNums(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    public static long sumOfProduct(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Pair<String, Long> maxAggregate(ArrayList<Pair<String, Long>> stdata) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 90l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 88l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 7l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 122l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 84l))))).equals((Pair.with(\"Juan Whelan\", 212l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 50l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 48l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 37l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 22l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 14l))))).equals((Pair.with(\"Juan Whelan\", 72l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 10l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 20l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 30l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 40l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 50l))))).equals((Pair.with(\"Sabah Colley\", 70l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static ArrayList<Long> combSort(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)37l, (long)25l, (long)79l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)25l, (long)37l, (long)79l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)32l, (long)15l, (long)19l, (long)22l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)19l, (long)22l, (long)32l, (long)41l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)99l, (long)15l, (long)13l, (long)47l)))).equals((new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)47l, (long)99l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static boolean checkExpression(String exp) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static boolean textMatchWordz(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static ArrayList<Long> sumList(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)25l, (long)45l, (long)65l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)45l, (long)75l)))).equals((new ArrayList<Long>(Arrays.asList((long)30l, (long)65l, (long)105l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long newmanPrime(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static ArrayList<String> addString(ArrayList<Object> list_, String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (\"temp{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"temp1\", (String)\"temp2\", (String)\"temp3\", (String)\"temp4\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (\"python{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"pythona\", (String)\"pythonb\", (String)\"pythonc\", (String)\"pythond\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l))), (\"string{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"string5\", (String)\"string6\", (String)\"string7\", (String)\"string8\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    public static long surfaceArea(long b, long s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))) == (1l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))) == (2l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static boolean validate(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long hexagonalNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long findLucas(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to get the difference between two lists.\n    public static ArrayList<Long> Diff(ArrayList<Long> li1, ArrayList<Long> li2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l, (long)30l, (long)35l, (long)40l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)40l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)15l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static ArrayList<Object> extractQuotation(String text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"A53\", (String)\"multi\", (String)\"Processor\")))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"favorite\", (String)\"apps\")))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((new ArrayList<Object>(Arrays.asList((String)\"4k Ultra HD\", (String)\"HDR 10\")))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    public static boolean differAtOneBitPos(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static boolean textMatchThree(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    public static long maxProduct(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)100l, (long)4l, (long)5l, (long)150l, (long)6l)))) == (3000l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)4l, (long)42l, (long)55l, (long)68l, (long)80l)))) == (50265600l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)22l, (long)9l, (long)33l, (long)21l, (long)50l, (long)41l, (long)60l)))) == (2460l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    public static ArrayList<Long> splitArr(ArrayList<Long> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)5l, (long)6l, (long)52l, (long)36l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)52l, (long)36l, (long)12l, (long)10l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)0l, (long)1l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    public static long divisor(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    public static long bigDiff(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)12l)))) == (8l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)3l)))) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static ArrayList<Long> squareNums(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)400l, (long)900l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)144l, (long)225l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static boolean checkNone(Object test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkNone(Pair.with(Optional.of(10l), Optional.of(4l), Optional.of(5l), Optional.of(6l), Optional.of(Optional.empty()))) == (true));\n    assert(checkNone(Pair.with(7l, 8l, 9l, 11l, 14l)) == (false));\n    assert(checkNone(Pair.with(Optional.of(1l), Optional.of(2l), Optional.of(3l), Optional.of(4l), Optional.of(Optional.empty()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    public static boolean isMonotonic(ArrayList<Long> A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)4l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static boolean isPerfectSquare(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    public static long sum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Pair<Long, ArrayList<Long>> maxLength(ArrayList<ArrayList<Long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static HashMap<Pair<Long, Long>,Long> checkOccurences(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(5l, 2l), (Pair<Long, Long>)Pair.with(6l, 3l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(1l, 3l), 2l, Pair.with(2l, 5l), 2l, Pair.with(3l, 6l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 2l), (Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(3l, 6l), (Pair<Long, Long>)Pair.with(6l, 3l), (Pair<Long, Long>)Pair.with(7l, 4l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 4l), 2l, Pair.with(3l, 6l), 2l, Pair.with(4l, 7l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(13l, 2l), (Pair<Long, Long>)Pair.with(11l, 23l), (Pair<Long, Long>)Pair.with(12l, 25l), (Pair<Long, Long>)Pair.with(25l, 12l), (Pair<Long, Long>)Pair.with(16l, 23l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 13l), 1l, Pair.with(11l, 23l), 1l, Pair.with(12l, 25l), 2l, Pair.with(16l, 23l), 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long parabolaDirectrix(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    public static Optional<Pair<String, Long, Long>> occuranceSubstring(String text, String pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Optional.of(Pair.with(\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Optional.of(Pair.with(\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Optional.of(Pair.with(\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(Optional.empty()));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Pair<Long, Long, Long, Long> removeNested(Object test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeNested(Pair.with(1l, 5l, 7l, Pair.with(4l, 6l), 10l)).equals((Pair.with(1l, 5l, 7l, 10l))));\n    assert(removeNested(Pair.with(2l, 6l, 8l, Pair.with(5l, 7l), 11l)).equals((Pair.with(2l, 6l, 8l, 11l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), Pair.with(5l, 12l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"blue \", (String)\" black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" black\", (String)\"blue \")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"zilver\", (String)\"gold\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"magnesium\", (String)\"aluminium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"steel\", (String)\"bronze\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"gold\", (String)\"zilver\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"aluminium\", (String)\"magnesium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"bronze\", (String)\"steel\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static ArrayList<Long> removeKthElement(ArrayList<Long> list1, long L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Pair<Long, Long, Long, HashMap<String,Long>> addDictToTuple(Pair<Long, Long, Long> test_tup, HashMap<String,Long> test_dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addDictToTuple((Pair.with(4l, 5l, 6l)), (new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l)))).equals((Pair.with(4l, 5l, 6l, new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l))))));\n    assert(addDictToTuple((Pair.with(1l, 2l, 3l)), (new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l)))).equals((Pair.with(1l, 2l, 3l, new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l))))));\n    assert(addDictToTuple((Pair.with(8l, 9l, 10l)), (new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l)))).equals((Pair.with(8l, 9l, 10l, new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long find(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static boolean textMatchTwoThree(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    public static long countOccurrence(Object tup, ArrayList<Object> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurrence(Pair.with(\"a\", \"a\", \"c\", \"b\", \"d\"), (new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\")))) == (3l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)4l, (long)7l)))) == (6l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 4l, 5l, 6l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)2l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long countSamepair(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (3l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (4l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static boolean textMatchOne(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long difference(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static String toggleString(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the element of a list having maximum length.\n    public static ArrayList<Object> FindMax(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long eulerianNum(long n, long m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long frequency(ArrayList<Long> a, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l)) == (0l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l))), (3l)) == (3l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)1l, (long)2l))), (1l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    public static ArrayList<Long> sortNumericStrings(ArrayList<String> nums_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"4\", (String)\"12\", (String)\"45\", (String)\"7\", (String)\"0\", (String)\"100\", (String)\"200\", (String)\"-12\", (String)\"-500\")))).equals((new ArrayList<Long>(Arrays.asList((long)-500l, (long)-12l, (long)0l, (long)4l, (long)7l, (long)12l, (long)45l, (long)100l, (long)200l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"2\", (String)\"3\", (String)\"8\", (String)\"4\", (String)\"7\", (String)\"9\", (String)\"8\", (String)\"2\", (String)\"6\", (String)\"5\", (String)\"1\", (String)\"6\", (String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"6\", (String)\"9\", (String)\"1\", (String)\"2\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)8l, (long)9l, (long)9l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"3\", (String)\"5\", (String)\"7\", (String)\"1\", (String)\"3\", (String)\"13\", (String)\"15\", (String)\"17\", (String)\"5\", (String)\"7 \", (String)\"9\", (String)\"1\", (String)\"11\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)3l, (long)3l, (long)5l, (long)5l, (long)7l, (long)7l, (long)9l, (long)11l, (long)13l, (long)15l, (long)17l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    public static float geometricSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    public static ArrayList<Long> divisibleByDigits(long startnum, long endnum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisibleByDigits((1l), (22l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l, (long)22l)))));\n    assert(divisibleByDigits((1l), (15l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l)))));\n    assert(divisibleByDigits((20l), (25l)).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    public static long uniqueProduct(ArrayList<Long> list_data) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)20l, (long)50l, (long)60l, (long)40l)))) == (720000000l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l)))) == (6l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)0l, (long)1l, (long)1l)))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the largest negative number from the given list.\n    public static long largestNeg(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-4l, (long)-6l)))) == (-6l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-8l, (long)-9l)))) == (-9l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static ArrayList<Object> consecutiveDuplicates(ArrayList<Object> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<Object>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\")))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\", (String)\"a\", (String)\"a\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"a\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float minJumps(Pair<Long, Long> steps, long d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minJumps((Pair.with(3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps((Pair.with(3l, 4l)), (0l)) == (float)0l);\n    assert(minJumps((Pair.with(11l, 14l)), (11l)) == (float)1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    public static Pair<Long, Long> maxProduct(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)0l, (long)8l, (long)4l)))).equals((Pair.with(7l, 8l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)0l, (long)-1l, (long)-2l, (long)-4l, (long)5l, (long)0l, (long)-6l)))).equals((Pair.with(-4l, -6l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((Pair.with(2l, 3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static ArrayList<Object> extractNthElement(ArrayList<Pair<String, Long, Long>> list1, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (0l)).equals((new ArrayList<Object>(Arrays.asList((String)\"Greyson Fulton\", (String)\"Brady Kent\", (String)\"Wyatt Knott\", (String)\"Beau Turnbull\")))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (2l)).equals((new ArrayList<Object>(Arrays.asList((long)99l, (long)96l, (long)94l, (long)98l)))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (1l)).equals((new ArrayList<Object>(Arrays.asList((long)98l, (long)97l, (long)91l, (long)94l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long isNonagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    public static long maxAbsDiff(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)3l)))) == (4l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)2l, (long)5l, (long)1l)))) == (8l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static ArrayList<ArrayList<Object>> packConsecutiveDuplicates(ArrayList<Object> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)19l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)26l, (long)26l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"a\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"d\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long calSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    public static String oddValuesString(String str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    public static long findKth(ArrayList<Long> arr1, ArrayList<Long> arr2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)8l, (long)10l))), (5l)) == (6l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)100l, (long)112l, (long)256l, (long)349l, (long)770l))), (new ArrayList<Long>(Arrays.asList((long)72l, (long)86l, (long)113l, (long)119l, (long)265l, (long)445l, (long)892l))), (7l)) == (256l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)7l, (long)8l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)9l, (long)11l))), (6l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long jacobsthalNum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static HashMap<Long,Long> frequencyLists(ArrayList<ArrayList<Long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)5l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 3l, 3l, 1l, 4l, 1l, 5l, 2l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 1l, 3l, 1l, 4l, 1l, 5l, 1l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l, 10l, 1l, 11l, 1l, 12l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)30l, (long)40l, (long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)16l, (long)14l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new HashMap<Long,Long>(Map.of(20l, 2l, 30l, 2l, 40l, 2l, 17l, 1l, 18l, 1l, 16l, 1l, 14l, 1l, 13l, 1l, 10l, 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static ArrayList<Long> perfectSquares(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(perfectSquares((1l), (30l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l)))));\n    assert(perfectSquares((50l), (100l)).equals((new ArrayList<Long>(Arrays.asList((long)64l, (long)81l, (long)100l)))));\n    assert(perfectSquares((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)121l, (long)144l, (long)169l, (long)196l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    public static long sumOfSubarrayProd(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (20l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (5l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    public static long firstOdd(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)1l)))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static ArrayList<ArrayList<Long>> addNestedTuples(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)13l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)16l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)15l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)17l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static ArrayList<ArrayList<Object>> merge(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\", (String)\"o\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"z\", (String)\"c\", (String)\"o\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    public static boolean difSquare(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static boolean checkSmaller(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkSmaller((Pair.with(1l, 2l, 3l)), (Pair.with(2l, 3l, 4l))) == (false));\n    assert(checkSmaller((Pair.with(4l, 5l, 6l)), (Pair.with(3l, 4l, 5l))) == (true));\n    assert(checkSmaller((Pair.with(11l, 12l, 13l)), (Pair.with(10l, 11l, 12l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static HashMap<Long,Long> freqCount(ArrayList<Long> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)10l, (long)20l, (long)20l, (long)20l, (long)20l, (long)40l, (long)40l, (long)50l, (long)50l, (long)30l)))).equals((new HashMap<Long,Long>(Map.of(10l, 4l, 20l, 4l, 40l, 2l, 50l, 2l, 30l, 1l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)4l, (long)1l, (long)3l, (long)1l, (long)4l)))).equals((new HashMap<Long,Long>(Map.of(1l, 3l, 2l, 2l, 3l, 3l, 4l, 3l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)4l, (long)9l, (long)10l, (long)4l, (long)5l, (long)6l, (long)7l, (long)9l, (long)5l)))).equals((new HashMap<Long,Long>(Map.of(10l, 1l, 5l, 3l, 6l, 2l, 7l, 2l, 4l, 2l, 9l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static ArrayList<Float> rgbToHsv(long r, long g, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.0f, (float)100.0f)))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((new ArrayList<Float>(Arrays.asList((float)120.0f, (float)100.0f, (float)84.31372549019608f)))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((new ArrayList<Float>(Arrays.asList((float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static boolean checkStr(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static boolean checkMonthnumberNumber(long monthnum3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given list.\n    public static ArrayList<Long> heapSort(ArrayList<Long> iterable) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l)))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)22l, (long)25l, (long)25l, (long)35l, (long)58l, (long)65l, (long)75l, (long)85l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)7l, (long)1l, (long)9l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    public static ArrayList<ArrayList<Long>> kSmallestPairs(ArrayList<Long> nums1, ArrayList<Long> nums2, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (7l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)2l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    public static Optional<Pair<Long, Long>> findSolution(long a, long b, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSolution((2l), (3l), (7l)).equals(Optional.of(Pair.with(2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(Optional.empty()));\n    assert(findSolution((1l), (13l), (17l)).equals(Optional.of(Pair.with(4l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    public static long findMaxNum(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (321l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)1l)))) == (6541l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)9l)))) == (9321l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static ArrayList<Long> maxSumList(ArrayList<ArrayList<Long>> lists) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)12l, (long)35l, (long)9l, (long)56l, (long)24l)))).equals((new ArrayList<Long>(Arrays.asList((long)24l, (long)35l, (long)9l, (long)56l, (long)12l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float getMedian(ArrayList<Long> arr1, ArrayList<Long> arr2, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)1l, (long)12l, (long)15l, (long)26l, (long)38l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)17l, (long)30l, (long)45l))), (5l)) == (16.0f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)13l, (long)19l, (long)28l))), (4l)) == (8.5f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)14l, (long)23l, (long)36l, (long)42l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)18l, (long)27l, (long)39l, (long)49l, (long)55l))), (6l)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static String replaceSpaces(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static boolean areEquivalent(long num1, long num2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static ArrayList<String> reverseStringList(ArrayList<String> stringlist) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\", (String)\"White\", (String)\"Black\")))).equals((new ArrayList<String>(Arrays.asList((String)\"deR\", (String)\"neerG\", (String)\"eulB\", (String)\"etihW\", (String)\"kcalB\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"john\", (String)\"amal\", (String)\"joel\", (String)\"george\")))).equals((new ArrayList<String>(Arrays.asList((String)\"nhoj\", (String)\"lama\", (String)\"leoj\", (String)\"egroeg\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"jack\", (String)\"john\", (String)\"mary\")))).equals((new ArrayList<String>(Arrays.asList((String)\"kcaj\", (String)\"nhoj\", (String)\"yram\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long sumOfDigits(ArrayList<Object> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)2l, (long)56l)))) == (14l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Object>(Arrays.asList(10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))))) == (19l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)20l, (long)-4l, (long)5l, (long)-70l)))) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long sequence(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static ArrayList<Long> heapQueueLargest(ArrayList<Long> nums, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l, (long)58l, (long)35l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long lossAmount(long actual_cost, long sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static ArrayList<Long> unionElements(ArrayList<Long> test_tup1, ArrayList<Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)4l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)10l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l))), (new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)16l, (long)17l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l, (long)15l, (long)16l, (long)17l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the longest sublists.\n    public static long FindMaxLength(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (4l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))))) == (3l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)22l, (long)23l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l)))))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static String removeParenthesis(ArrayList<String> items) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"python (chrome)\")))).equals((\"python\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"string(.abc)\")))).equals((\"string\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"alpha(num)\")))).equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    public static boolean findParity(long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float medianTrapezium(long base1, long base2, long height) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianTrapezium((15l), (25l), (35l)) == (float)20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == (float)15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long centeredHexagonalNumber(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long findLists(ArrayList<Object> Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (2l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))) == (3l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long getMaxSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the longest word.\n    public static long lenLog(ArrayList<String> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"PHP\", (String)\"bigdata\")))) == (7l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))) == (3l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"small\", (String)\"big\", (String)\"tall\")))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    public static Optional<Float> sectorArea(long r, long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sectorArea((4l), (45l)).equals(Optional.of(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Optional.of(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(Optional.empty()));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    public static boolean oddPosition(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l, (long)6l, (long)7l, (long)6l, (long)3l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long multipleToSingle(ArrayList<Long> L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)11l, (long)33l, (long)50l)))) == (113350l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (-123456l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l)))) == (10152025l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    public static boolean isDiff(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static ArrayList<ArrayList<Long>> indexMultiplication(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)21l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)30l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)14l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)60l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)20l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)44l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)24l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)77l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)27l, (long)60l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Pair<Long, Long, Long> tupleStrInt(String test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals((Pair.with(7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals((Pair.with(1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals((Pair.with(4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals((Pair.with(7l, 81l, 19l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long amicableNumbersSum(long limit) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static String removeOdd(String str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static ArrayList<Object> multiplyElements(ArrayList<Long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)8l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)5l, (long)35l, (long)56l, (long)80l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)8l, (long)20l, (long)30l, (long)42l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)14l, (long)9l, (long)15l)))).equals((new ArrayList<Object>(Arrays.asList((long)156l, (long)182l, (long)126l, (long)135l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    public static long countRotation(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (1l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)1l, (long)2l, (long)3l)))) == (2l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (0l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long extractFreq(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(5l, 6l))))) == (3l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 15l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l))))) == (4l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 16l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 9l))))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long countSamePair(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (4l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (11l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (1l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)2l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long power(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long returnSum(HashMap<String,Long> dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 100l, \"b\", 200l, \"c\", 300l)))) == (600l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 25l, \"b\", 18l, \"c\", 45l)))) == (88l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 36l, \"b\", 39l, \"c\", 49l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static ArrayList<Pair<Long, Long>> pairWise(ArrayList<Long> l1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 5l), (Pair<Long, Long>)Pair.with(5l, 7l), (Pair<Long, Long>)Pair.with(7l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)9l, (long)7l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(1l, 9l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(7l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l), (Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to split a string into characters.\n    public static ArrayList<String> split(String word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(split((\"python\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))));\n    assert(split((\"Name\")).equals((new ArrayList<String>(Arrays.asList((String)\"N\", (String)\"a\", (String)\"m\", (String)\"e\")))));\n    assert(split((\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long minOfThree(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static boolean isSumOfPowersOfTwo(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static String getChar(String strr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long sumDiv(long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    public static ArrayList<Long> twoUniqueNums(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    public static boolean testDuplicate(ArrayList<Long> arraynums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))) == (true));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long catalanNumber(long num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long powerBaseSum(long base, long power) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static ArrayList<Object> replaceList(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l))), (new ArrayList<Object>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\"))), (new ArrayList<Object>(Arrays.asList((String)\"yellow\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"yellow\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long isOctagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static String replaceBlank(String str1, String char) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static String replaceSpecialchar(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long tupleToInt(Pair<Long, Long, Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToInt((Pair.with(1l, 2l, 3l))) == (123l));\n    assert(tupleToInt((Pair.with(4l, 5l, 6l))) == (456l));\n    assert(tupleToInt((Pair.with(5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float othersideRightangle(long w, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == (float)5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    public static long digitDistanceNums(long n1, long n2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static boolean textMatchWordzMiddle(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static String removezeroIp(String ip) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long countElementInList(ArrayList<ArrayList<Object>> list1, Object x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)7l))))), (Object(1l))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"A\"))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"E\"))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long multiplyInt(long x, long y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Pair<Long, Long, Long, Long> addPairwise(Pair<Long, Long, Long, Long, Long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addPairwise((Pair.with(1l, 5l, 7l, 8l, 10l))).equals((Pair.with(6l, 12l, 15l, 18l))));\n    assert(addPairwise((Pair.with(2l, 6l, 8l, 9l, 11l))).equals((Pair.with(8l, 14l, 17l, 20l))));\n    assert(addPairwise((Pair.with(3l, 7l, 9l, 10l, 12l))).equals((Pair.with(10l, 16l, 19l, 22l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long maxProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (36l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (200l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3448,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the kth element in the given array using 1-based indexing.\n    public static long kthElement(ArrayList<Long> arr, long k) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)12l, (long)3l, (long)5l, (long)7l, (long)19l))), (2l)) == (3l));\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)17l, (long)24l, (long)8l, (long)23l))), (3l)) == (8l));\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)16l, (long)21l, (long)25l, (long)36l, (long)4l))), (4l)) == (36l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3456,265 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long rightInsertion(ArrayList<Long> a, long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long eulerianNum(long n, long m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static boolean isWoodall(long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> input_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"blue \", (String)\" black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" black\", (String)\"blue \")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"zilver\", (String)\"gold\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"magnesium\", (String)\"aluminium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"steel\", (String)\"bronze\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"gold\", (String)\"zilver\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"aluminium\", (String)\"magnesium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"bronze\", (String)\"steel\")))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array by using shell sort.\n    public static ArrayList<Long> shellSort(ArrayList<Long> my_list) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count true booleans in the given list.\n    public static long count(ArrayList<Boolean> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)4l, (long)5l, (long)3l, (long)2l, (long)12l, (long)81l, (long)56l, (long)95l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)12l, (long)12l, (long)23l, (long)56l, (long)81l, (long)95l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)24l, (long)22l, (long)39l, (long)34l, (long)87l, (long)73l, (long)68l)))).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l, (long)34l, (long)39l, (long)68l, (long)73l, (long)87l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)32l, (long)30l, (long)16l, (long)96l, (long)82l, (long)83l, (long)74l)))).equals((new ArrayList<Long>(Arrays.asList((long)16l, (long)30l, (long)32l, (long)74l, (long)82l, (long)83l, (long)96l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)false, (boolean)true)))) == (2l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)false, (boolean)false)))) == (0l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)true, (boolean)true)))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    public static long findOddPair(ArrayList<Long> A, long N) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Pair<Long, Long, Long, Long, Long> addLists(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l))), (5l)) == (6l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l))), (7l)) == (12l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (3l)) == (2l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((Pair.with(9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((Pair.with(10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((Pair.with(11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    public static long sumInRange(long l, long r) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static ArrayList<Long> mergeSortedList(ArrayList<Long> num1, ArrayList<Long> num2, ArrayList<Long> num3) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)25l, (long)24l, (long)15l, (long)4l, (long)5l, (long)29l, (long)110l))), (new ArrayList<Long>(Arrays.asList((long)19l, (long)20l, (long)11l, (long)56l, (long)25l, (long)233l, (long)154l))), (new ArrayList<Long>(Arrays.asList((long)24l, (long)26l, (long)54l, (long)48l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)11l, (long)15l, (long)19l, (long)20l, (long)24l, (long)24l, (long)25l, (long)25l, (long)26l, (long)29l, (long)48l, (long)54l, (long)56l, (long)110l, (long)154l, (long)233l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)6l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l, (long)11l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)8l, (long)12l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)5l, (long)6l, (long)7l, (long)7l, (long)8l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)18l, (long)14l, (long)10l, (long)9l, (long)8l, (long)7l, (long)9l, (long)3l, (long)2l, (long)4l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l))), (new ArrayList<Long>(Arrays.asList((long)12l, (long)74l, (long)9l, (long)50l, (long)61l, (long)41l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)8l, (long)9l, (long)9l, (long)9l, (long)10l, (long)12l, (long)14l, (long)14l, (long)18l, (long)22l, (long)25l, (long)25l, (long)35l, (long)41l, (long)50l, (long)58l, (long)61l, (long)65l, (long)74l, (long)75l, (long)85l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long squarePerimeter(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long oddEquivalent(String s, long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long isPolite(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static boolean checkInteger(String text) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long sumSeries(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    public static long tupleToInt(Pair<Long, Long, Long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Pair<Long, Long, Long, Long> findDissimilar(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findDissimilar((Pair.with(3l, 4l, 5l, 6l)), (Pair.with(5l, 7l, 4l, 10l))).equals((Pair.with(3l, 6l, 7l, 10l))));\n    assert(findDissimilar((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(7l, 2l, 3l, 9l))).equals((Pair.with(1l, 4l, 7l, 9l))));\n    assert(findDissimilar((Pair.with(21l, 11l, 25l, 26l)), (Pair.with(26l, 34l, 21l, 36l))).equals((Pair.with(34l, 36l, 11l, 25l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Pair<String, String> startWithp(ArrayList<String> words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python PHP\", (String)\"Java JavaScript\", (String)\"c c++\")))).equals((Pair.with(\"Python\", \"PHP\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python Programming\", (String)\"Java Programming\")))).equals((Pair.with(\"Python\", \"Programming\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Pqrst Pqr\", (String)\"qrstuv\")))).equals((Pair.with(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long volumeCube(long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static boolean checkMonthnumbNumber(long monthnum2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    public static boolean allBitsSetInTheGivenRange(long n, long l, long r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to get the first element of each sublist.\n    public static ArrayList<Long> Extract(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)6l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float surfaceareaCylinder(long r, long h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long sampleNam(ArrayList<String> sample_names) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"sally\", (String)\"Dylan\", (String)\"rebecca\", (String)\"Diana\", (String)\"Joanne\", (String)\"keith\")))) == (16l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"php\", (String)\"res\", (String)\"Python\", (String)\"abcd\", (String)\"Java\", (String)\"aaa\")))) == (10l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"Python\", (String)\"abba\", (String)\"aba\")))) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static Object rearrangeBigger(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearrangeBigger((12l)).equals((Object(21l))));\n    assert(rearrangeBigger((10l)).equals((Object(false))));\n    assert(rearrangeBigger((102l)).equals((Object(120l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long perimeterPentagon(long a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long maxSum(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)51l, (long)45l, (long)33l, (long)100l, (long)12l, (long)18l, (long)9l)))) == (194l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)80l, (long)60l, (long)30l, (long)40l, (long)20l, (long)10l)))) == (210l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)14l, (long)16l, (long)21l, (long)23l, (long)29l, (long)30l)))) == (138l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static Object extractEven(Pair<Long, Long, Pair<Long, Long, Pair<Long, Long>>, Long, Long> test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractEven((Pair.with(4l, 5l, Pair.with(7l, 6l, Pair.with(2l, 4l)), 6l, 8l))).equals(Pair.with(4l, Pair.with(6l, Pair.with(2l, 4l)), 6l, 8l)));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(8l, 7l, Pair.with(4l, 8l)), 7l, 9l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 8l)))));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(9l, 8l, Pair.with(4l, 6l)), 8l, 10l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 6l)), 8l, 10l)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToInt((Pair.with(1l, 2l, 3l))) == (123l));\n    assert(tupleToInt((Pair.with(4l, 5l, 6l))) == (456l));\n    assert(tupleToInt((Pair.with(5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3724,189 +136,9 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert all possible convertible elements in a list of lists to floats.\n    public static ArrayList<Pair<Float, Float>> listToFloat(ArrayList<Pair<String, String>> test_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"3\", \"4\"), (Pair<String, String>)Pair.with(\"1\", \"26.45\"), (Pair<String, String>)Pair.with(\"7.32\", \"8\"), (Pair<String, String>)Pair.with(\"4\", \"8\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(3.0f, 4.0f), (Pair<Float, Float>)Pair.with(1.0f, 26.45f), (Pair<Float, Float>)Pair.with(7.32f, 8.0f), (Pair<Float, Float>)Pair.with(4.0f, 8.0f))))));\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"4\", \"4\"), (Pair<String, String>)Pair.with(\"2\", \"27\"), (Pair<String, String>)Pair.with(\"4.12\", \"9\"), (Pair<String, String>)Pair.with(\"7\", \"11\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(4.0f, 4.0f), (Pair<Float, Float>)Pair.with(2.0f, 27.0f), (Pair<Float, Float>)Pair.with(4.12f, 9.0f), (Pair<Float, Float>)Pair.with(7.0f, 11.0f))))));\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"6\", \"78\"), (Pair<String, String>)Pair.with(\"5\", \"26.45\"), (Pair<String, String>)Pair.with(\"1.33\", \"4\"), (Pair<String, String>)Pair.with(\"82\", \"13\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(6.0f, 78.0f), (Pair<Float, Float>)Pair.with(5.0f, 26.45f), (Pair<Float, Float>)Pair.with(1.33f, 4.0f), (Pair<Float, Float>)Pair.with(82.0f, 13.0f))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long squareSum(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long getPairsCount(ArrayList<Long> arr, long sum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (2l)) == (6l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)-1l, (long)5l))), (6l)) == (3l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l))), (1l)) == (1l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l))), (-3l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long countNoOfWays(long n, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static String reverseWords(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    public static boolean checks(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    public static long last(ArrayList<Long> arr, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (1l)) == (0l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)4l))), (1l)) == (2l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)3l, (long)6l, (long)8l, (long)9l))), (3l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long countX(ArrayList<Long> tup, long x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (4l)) == (0l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (10l)) == (3l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (8l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static ArrayList<Object> extractIndexList(ArrayList<Long> l1, ArrayList<Long> l2, ArrayList<Long> l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)7l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)6l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)6l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)6l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static String concatenateTuple(Pair<String, String, Long, String> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenateTuple((Pair.with(\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple((Pair.with(\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple((Pair.with(\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static String replaceSpaces(String string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long sumRangeList(ArrayList<Long> list1, long m, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (8l), (10l)) == (29l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (5l), (7l)) == (16l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (7l), (10l)) == (38l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static HashMap<String,String> mergeDictionariesThree(HashMap<String,String> dict1, HashMap<String,String> dict2, HashMap<String,String> dict3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"O\", \"Orange\", \"W\", \"White\", \"B\", \"Black\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"R\", \"Red\", \"P\", \"Pink\", \"G\", \"Green\", \"W\", \"White\", \"O\", \"Orange\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\")))).equals((new HashMap<String,String>(Map.of(\"W\", \"White\", \"P\", \"Pink\", \"B\", \"Black\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"P\", \"Pink\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\", \"W\", \"White\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum of two numbers.\n    public static long minimum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long maxDifference(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(1l, 7l), (Pair<Long, Long>)Pair.with(10l, 3l), (Pair<Long, Long>)Pair.with(1l, 2l))))) == (7l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(2l, 17l), (Pair<Long, Long>)Pair.with(9l, 13l), (Pair<Long, Long>)Pair.with(11l, 12l))))) == (15l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 35l), (Pair<Long, Long>)Pair.with(21l, 27l), (Pair<Long, Long>)Pair.with(13l, 23l), (Pair<Long, Long>)Pair.with(41l, 22l))))) == (23l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    public static long findElement(ArrayList<Long> arr, ArrayList<ArrayList<Long>> ranges, long rotations, long index) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)3l))))), (2l), (1l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (2l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3916,7 +148,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a string to a list of strings split on the space character.\n    public static ArrayList<String> stringToList(String string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToList((\"python programming\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"programming\")))));\n    assert(stringToList((\"lists tuples strings\")).equals((new ArrayList<String>(Arrays.asList((String)\"lists\", (String)\"tuples\", (String)\"strings\")))));\n    assert(stringToList((\"write a program\")).equals((new ArrayList<String>(Arrays.asList((String)\"write\", (String)\"a\", (String)\"program\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3928,21 +160,9 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the element that appears only once in a sorted array.\n    public static long search(ArrayList<Long> arr) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l)))) == (3l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)5l, (long)7l, (long)7l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static ArrayList<Pair<String, Long>> sortCounter(HashMap<String,Long> dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 81l, \"Physics\", 83l, \"Chemistry\", 87l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 87l), (Pair<String, Long>)Pair.with(\"Physics\", 83l), (Pair<String, Long>)Pair.with(\"Math\", 81l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 400l, \"Physics\", 300l, \"Chemistry\", 250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Math\", 400l), (Pair<String, Long>)Pair.with(\"Physics\", 300l), (Pair<String, Long>)Pair.with(\"Chemistry\", 250l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 900l, \"Physics\", 1000l, \"Chemistry\", 1250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 1250l), (Pair<String, Long>)Pair.with(\"Physics\", 1000l), (Pair<String, Long>)Pair.with(\"Math\", 900l))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3952,7 +172,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove first and last occurrence of a given character from the string.\n    public static String removeOcc(String s, String ch) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOcc((\"hello\"), (\"l\")).equals((\"heo\")));\n    assert(removeOcc((\"abcda\"), (\"a\")).equals((\"bcd\")));\n    assert(removeOcc((\"PHP\"), (\"P\")).equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3960,325 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long lateralsurfaceCube(long l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    public static long maxProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (36l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (200l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Optional<Boolean> commonElement(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long amicableNumbersSum(long limit) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.of(true)));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.empty()));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))), (new ArrayList<Object>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"e\")))).equals(Optional.of(true)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to append the given list to the given tuples.\n    public static Pair<Long, Long, Long, Long, Long> addLists(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long findLength(String string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((Pair.with(9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((Pair.with(10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((Pair.with(11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static ArrayList<Long> nthNums(ArrayList<Long> nums, long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    public static long sum(long a, long b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)248832l, (long)759375l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static ArrayList<Long> pancakeSort(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long multiplyInt(long x, long y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)15l, (long)79l, (long)25l, (long)38l, (long)69l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)38l, (long)69l, (long)79l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)98l, (long)12l, (long)54l, (long)36l, (long)85l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)36l, (long)54l, (long)85l, (long)98l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)42l, (long)32l, (long)12l, (long)23l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)32l, (long)41l, (long)42l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float medianNumbers(long a, long b, long c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    public static boolean checkGreater(ArrayList<Long> arr, long number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (4l)) == (false));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (8l)) == (true));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)4l, (long)8l, (long)6l, (long)1l))), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static boolean checkElement(ArrayList<Object> list, Object element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"orange\", (String)\"black\", (String)\"white\"))), (Object(\"blue\"))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (Object(7l))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"green\", (String)\"green\", (String)\"green\"))), (Object(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static ArrayList<String> extractString(ArrayList<String> str, long l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (8l)).equals((new ArrayList<String>(Arrays.asList((String)\"practice\", (String)\"solution\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (6l)).equals((new ArrayList<String>(Arrays.asList((String)\"Python\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (9l)).equals((new ArrayList<String>(Arrays.asList((String)\"exercises\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static boolean textLowercaseUnderscore(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static ArrayList<ArrayList<Long>> trimTuple(ArrayList<ArrayList<Long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)2l, (long)1l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)12l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)9l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sublist having minimum length.\n    public static ArrayList<Object> FindMin(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)7l, (long)8l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"x\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static ArrayList<Long> filterOddnumbers(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)45l, (long)67l, (long)84l, (long)93l)))).equals((new ArrayList<Long>(Arrays.asList((long)45l, (long)67l, (long)93l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)8l, (long)6l, (long)4l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static String findAdverbs(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long maxOfNth(ArrayList<ArrayList<Long>> test_list, long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)19l))))), (2l)) == (19l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)20l))))), (1l)) == (10l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)21l))))), (1l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static String decimalToBinary(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static ArrayList<ArrayList<String>> combinationsColors(ArrayList<String> l, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (1l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (2l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (3l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\", (String)\"Blue\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static String removeAllSpaces(String text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static Object minSwaps(String str1, String str2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Object(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Object(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Object(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Pair<String, String, String> newTuple(ArrayList<String> test_list, String test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"WEB\", (String)\"is\"))), (\"best\")).equals((Pair.with(\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"We\", (String)\"are\"))), (\"Developers\")).equals((Pair.with(\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"Part\", (String)\"is\"))), (\"Wrong\")).equals((Pair.with(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    public static long findRemainder(ArrayList<Long> arr, long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)100l, (long)10l, (long)5l, (long)25l, (long)35l, (long)14l))), (11l)) == (9l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l))), (1l)) == (0l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (2l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    public static float positiveCount(ArrayList<Long> nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.54f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.69f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static ArrayList<Long> addTuple(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)9l, (long)10l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)10l, (long)11l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long maxRunUppercase(String test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static ArrayList<ArrayList<Long>> sortMatrix(ArrayList<ArrayList<Long>> M) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long countVowels(String test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long maxSumIncreasingSubseq(ArrayList<Long> a, long n, long index, long k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)11l, (long)15l, (long)19l, (long)21l, (long)26l, (long)28l, (long)31l))), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4288,7 +244,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find words that are longer than n characters from a given list of words.\n    public static ArrayList<String> longWords(long n, String str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(longWords((3l), (\"python is a programming language\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"programming\", (String)\"language\")))));\n    assert(longWords((2l), (\"writing a program\")).equals((new ArrayList<String>(Arrays.asList((String)\"writing\", (String)\"program\")))));\n    assert(longWords((5l), (\"sorting list\")).equals((new ArrayList<String>(Arrays.asList((String)\"sorting\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4296,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    public static long findSum(ArrayList<Long> arr) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static boolean magicSquareTest(ArrayList<ArrayList<Long>> my_matrix) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)1l, (long)4l, (long)5l, (long)6l)))) == (21l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)9l, (long)4l, (long)2l, (long)10l, (long)10l, (long)45l, (long)4l)))) == (71l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)9l, (long)45l, (long)2l, (long)10l, (long)10l, (long)45l, (long)10l)))) == (78l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)12l, (long)1l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)8l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)3l, (long)10l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)6l, (long)15l, (long)4l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)8l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)7l)))))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    public static HashMap<Long,Long> tupleToDict(Pair<Long, Long, Long, Long, Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static ArrayList<ArrayList<Long>> sortMatrix(ArrayList<ArrayList<Long>> M) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToDict((Pair.with(1l, 5l, 7l, 10l, 13l, 5l))).equals((new HashMap<Long,Long>(Map.of(1l, 5l, 7l, 10l, 13l, 5l)))));\n    assert(tupleToDict((Pair.with(1l, 2l, 3l, 4l, 5l, 6l))).equals((new HashMap<Long,Long>(Map.of(1l, 2l, 3l, 4l, 5l, 6l)))));\n    assert(tupleToDict((Pair.with(7l, 8l, 9l, 10l, 11l, 12l))).equals((new HashMap<Long,Long>(Map.of(7l, 8l, 9l, 10l, 11l, 12l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static ArrayList<ArrayList<Long>> getCoordinates(Pair<Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    public static long maxOccurrences(ArrayList<Long> nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getCoordinates((Pair.with(3l, 4l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))));\n    assert(getCoordinates((Pair.with(4l, 5l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))));\n    assert(getCoordinates((Pair.with(5l, 6l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static boolean checkType(Object test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkType(Pair.with(5l, 6l, 7l, 3l, 5l, 6l)) == (true));\n    assert(checkType(Pair.with(1l, 2l, \"4\")) == (false));\n    assert(checkType(Pair.with(3l, 2l, 1l, 4l, 5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    public static long findFirstMissing(ArrayList<Long> array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)6l, (long)9l)))) == (3l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)8l, (long)9l)))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static boolean isUndulating(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    public static ArrayList<Pair<String, Long>> minK(ArrayList<Pair<String, Long>> test_list, long K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Manjeet\", 10l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l), (Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Nikhil\", 8l)))), (2l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sanjeev\", 11l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l)))), (3l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"tanmay\", 14l), (Pair<String, Long>)Pair.with(\"Amer\", 11l), (Pair<String, Long>)Pair.with(\"Ayesha\", 9l), (Pair<String, Long>)Pair.with(\"SKD\", 16l)))), (1l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Ayesha\", 9l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    public static long countSubstrings(String s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long isNumDecagonal(long n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static ArrayList<Long> rearExtract(ArrayList<Pair<Long, String, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Rash\", 21l), (Pair<Long, String, Long>)Pair.with(2l, \"Varsha\", 20l), (Pair<Long, String, Long>)Pair.with(3l, \"Kil\", 19l))))).equals((new ArrayList<Long>(Arrays.asList((long)21l, (long)20l, (long)19l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sai\", 36l), (Pair<Long, String, Long>)Pair.with(2l, \"Ayesha\", 25l), (Pair<Long, String, Long>)Pair.with(3l, \"Salman\", 45l))))).equals((new ArrayList<Long>(Arrays.asList((long)36l, (long)25l, (long)45l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sudeep\", 14l), (Pair<Long, String, Long>)Pair.with(2l, \"Vandana\", 36l), (Pair<Long, String, Long>)Pair.with(3l, \"Dawood\", 56l))))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)36l, (long)56l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long closestNum(long N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    public static ArrayList<Pair<Long, Long>> findCombinations(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(6l, 10l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(8l, 11l), (Pair<Long, Long>)Pair.with(7l, 5l), (Pair<Long, Long>)Pair.with(8l, 14l), (Pair<Long, Long>)Pair.with(11l, 8l), (Pair<Long, Long>)Pair.with(12l, 17l), (Pair<Long, Long>)Pair.with(11l, 11l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(6l, 2l), (Pair<Long, Long>)Pair.with(7l, 11l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 13l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(10l, 16l), (Pair<Long, Long>)Pair.with(13l, 10l), (Pair<Long, Long>)Pair.with(14l, 19l), (Pair<Long, Long>)Pair.with(13l, 13l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(7l, 3l), (Pair<Long, Long>)Pair.with(8l, 12l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 15l), (Pair<Long, Long>)Pair.with(11l, 9l), (Pair<Long, Long>)Pair.with(12l, 18l), (Pair<Long, Long>)Pair.with(15l, 12l), (Pair<Long, Long>)Pair.with(16l, 21l), (Pair<Long, Long>)Pair.with(15l, 15l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float maxAverageOfPath(ArrayList<ArrayList<Long>> cost) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)9l)))))) == (5.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l, (long)10l)))))) == (6.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)11l)))))) == (7.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    public static Pair<Boolean, Long> sequentialSearch(ArrayList<Long> dlist, long item) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)11l, (long)23l, (long)58l, (long)31l, (long)56l, (long)77l, (long)43l, (long)12l, (long)65l, (long)19l))), (31l)).equals((Pair.with(true, 3l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)12l, (long)32l, (long)45l, (long)62l, (long)35l, (long)47l, (long)44l, (long)61l))), (61l)).equals((Pair.with(true, 7l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)17l, (long)19l, (long)22l, (long)39l, (long)48l, (long)56l))), (48l)).equals((Pair.with(true, 6l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove odd numbers from a given list.\n    public static ArrayList<Long> removeOdd(ArrayList<Long> l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static boolean isProductEven(ArrayList<Long> arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the maximum of two numbers.\n    public static long maximum(long a, long b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)2l, (long)6l, (long)5l, (long)1l, (long)6l, (long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)6l, (long)9l, (long)1l, (long)2l)))) == (2l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)7l, (long)9l, (long)15l, (long)14l, (long)10l, (long)12l, (long)13l, (long)16l, (long)18l)))) == (8l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)20l, (long)30l, (long)40l, (long)90l, (long)80l, (long)50l, (long)30l, (long)20l, (long)50l, (long)10l)))) == (20l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4504,9 +292,597 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to reverse only the vowels of a given string (where y is not a vowel).\n    public static String reverseVowels(String str1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseVowels((\"Python\")).equals((\"Python\")));\n    assert(reverseVowels((\"USA\")).equals((\"ASU\")));\n    assert(reverseVowels((\"ab\")).equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a list to a string.\n    public static String tupString(ArrayList<String> tup1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"x\", (String)\"e\", (String)\"r\", (String)\"c\", (String)\"i\", (String)\"s\", (String)\"e\", (String)\"s\")))).equals((\"exercises\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))).equals((\"python\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))).equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    public static long sumNegativenum(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (-32l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)-14l, (long)13l, (long)-18l, (long)12l, (long)-20l)))) == (-52l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)19l, (long)-65l, (long)57l, (long)39l, (long)152l, (long)-639l, (long)121l, (long)44l, (long)90l, (long)-190l)))) == (-894l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long hexagonalNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static boolean isSumOfPowersOfTwo(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static ArrayList<Long> pancakeSort(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)15l, (long)79l, (long)25l, (long)38l, (long)69l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)38l, (long)69l, (long)79l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)98l, (long)12l, (long)54l, (long)36l, (long)85l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)36l, (long)54l, (long)85l, (long)98l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)42l, (long)32l, (long)12l, (long)23l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)32l, (long)41l, (long)42l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    public static long countSamepair(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (3l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (4l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find number of lists present in the given list.\n    public static long findLists(ArrayList<Object> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (2l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))) == (3l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    public static long maxAbsDiff(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)3l)))) == (4l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)2l, (long)5l, (long)1l)))) == (8l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the volume of a triangular prism.\n    public static long findVolume(long l, long b, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    public static Optional<Pair<Long, Long>> findSolution(long a, long b, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSolution((2l), (3l), (7l)).equals(Optional.of(Pair.with(2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(Optional.empty()));\n    assert(findSolution((1l), (13l), (17l)).equals(Optional.of(Pair.with(4l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    public static ArrayList<Long> removeElements(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long sumSeries(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static boolean areEquivalent(long num1, long num2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long countCharPosition(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    public static long findEvenPair(ArrayList<Long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l)))) == (4l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l)))) == (9l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    public static long nextPowerOf2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    public static long frequency(ArrayList<Long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l)) == (0l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l))), (3l)) == (3l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)1l, (long)2l))), (1l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static boolean textLowercaseUnderscore(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    public static long sumRangeList(ArrayList<Long> list1, long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (8l), (10l)) == (29l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (5l), (7l)) == (16l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (7l), (10l)) == (38l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long perimeterPentagon(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long countOccurance(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long squarePerimeter(long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static String removeDirtyChars(String string, String second_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    public static boolean testDuplicate(ArrayList<Long> arraynums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))) == (true));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static boolean isWoodall(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    public static boolean checkType(Object test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkType(Pair.with(5l, 6l, 7l, 3l, 5l, 6l)) == (true));\n    assert(checkType(Pair.with(1l, 2l, \"4\")) == (false));\n    assert(checkType(Pair.with(3l, 2l, 1l, 4l, 5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    public static boolean isMajority(ArrayList<Long> arr, long n, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)3l, (long)10l))), (7l), (3l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)4l, (long)4l, (long)4l, (long)6l, (long)6l))), (8l), (4l)) == (false));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long countSetBits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    public static String oddValuesString(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long minOfThree(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    public static boolean allBitsSetInTheGivenRange(long n, long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static ArrayList<Long> reArrangeArray(ArrayList<Long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-3l, (long)4l, (long)5l, (long)6l, (long)-7l, (long)8l, (long)9l))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-7l, (long)4l, (long)5l, (long)6l, (long)2l, (long)8l, (long)9l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)12l, (long)-14l, (long)-26l, (long)13l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)-14l, (long)-26l, (long)12l, (long)13l, (long)15l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)10l, (long)24l, (long)36l, (long)-42l, (long)-39l, (long)-78l, (long)85l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-42l, (long)-39l, (long)-78l, (long)10l, (long)24l, (long)36l, (long)85l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static String replaceBlank(String str1, String char) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long volumeCube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    public static HashMap<Pair<Long, Long>,Long> checkOccurences(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(5l, 2l), (Pair<Long, Long>)Pair.with(6l, 3l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(1l, 3l), 2l, Pair.with(2l, 5l), 2l, Pair.with(3l, 6l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 2l), (Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(3l, 6l), (Pair<Long, Long>)Pair.with(6l, 3l), (Pair<Long, Long>)Pair.with(7l, 4l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 4l), 2l, Pair.with(3l, 6l), 2l, Pair.with(4l, 7l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(13l, 2l), (Pair<Long, Long>)Pair.with(11l, 23l), (Pair<Long, Long>)Pair.with(12l, 25l), (Pair<Long, Long>)Pair.with(25l, 12l), (Pair<Long, Long>)Pair.with(16l, 23l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 13l), 1l, Pair.with(11l, 23l), 1l, Pair.with(12l, 25l), 2l, Pair.with(16l, 23l), 1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    public static long numberOfSubstrings(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long getTotalNumberOfSequences(long m, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    public static ArrayList<Object> replaceList(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l))), (new ArrayList<Object>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\"))), (new ArrayList<Object>(Arrays.asList((String)\"yellow\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"yellow\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long countCharac(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    public static long nextPerfectSquare(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long maxSum(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)51l, (long)45l, (long)33l, (long)100l, (long)12l, (long)18l, (long)9l)))) == (194l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)80l, (long)60l, (long)30l, (long)40l, (long)20l, (long)10l)))) == (210l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)14l, (long)16l, (long)21l, (long)23l, (long)29l, (long)30l)))) == (138l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long lps(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the intersection of two arrays.\n    public static ArrayList<Long> intersectionArray(ArrayList<Long> array_nums1, ArrayList<Long> array_nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)8l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    public static long countX(ArrayList<Long> tup, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (4l)) == (0l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (10l)) == (3l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (8l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    public static ArrayList<String> insertElement(ArrayList<String> list, String element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Black\"))), (\"c\")).equals((new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"Red\", (String)\"c\", (String)\"Green\", (String)\"c\", (String)\"Black\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"java\"))), (\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"program\", (String)\"python\", (String)\"program\", (String)\"java\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"happy\", (String)\"sad\"))), (\"laugh\")).equals((new ArrayList<String>(Arrays.asList((String)\"laugh\", (String)\"happy\", (String)\"laugh\", (String)\"sad\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    public static Pair<Float, Float> convert(long numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(convert((1l)).equals((Pair.with(1.0f, 0.0f))));\n    assert(convert((4l)).equals((Pair.with(4.0f, 0.0f))));\n    assert(convert((5l)).equals((Pair.with(5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    public static ArrayList<ArrayList<String>> combinationsColors(ArrayList<String> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (1l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (2l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (3l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\", (String)\"Blue\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long countPrimesNums(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    public static ArrayList<Long> swapNumbers(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapNumbers((10l), (20l)).equals((new ArrayList<Long>(Arrays.asList((long)20l, (long)10l)))));\n    assert(swapNumbers((15l), (17l)).equals((new ArrayList<Long>(Arrays.asList((long)17l, (long)15l)))));\n    assert(swapNumbers((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)200l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4516,7 +892,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to maximize the given two lists.\n    public static ArrayList<ArrayList<Long>> maximizeElements(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)))))));\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)11l)))))));\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)))))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4524,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    public static boolean evenPosition(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long newmanPrime(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static String checkChar(String string) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    public static Pair<Long, Long, Long, Long> divisionElements(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisionElements((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(2l, 2l, 2l, 3l))));\n    assert(divisionElements((Pair.with(12l, 6l, 8l, 16l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(2l, 2l, 2l, 4l))));\n    assert(divisionElements((Pair.with(20l, 14l, 36l, 18l)), (Pair.with(5l, 7l, 6l, 9l))).equals((Pair.with(4l, 2l, 6l, 2l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of even factors of a number.\n    public static long sumofFactors(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    public static Object splitTwoParts(ArrayList<Object> list1, long L) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals(Pair.with(new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l)), new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (2l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\"))), (4l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\")), new ArrayList<String>(Arrays.asList((String)\"o\", (String)\"n\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float lateralsurfaceCone(long r, long h) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long dogAge(long h_age) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long countPairs(ArrayList<Long> arr, long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    public static ArrayList<ArrayList<Object>> listSplit(ArrayList<Object> S, long step) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (3l)) == (2l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (4l)) == (0l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (5l)) == (10l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"e\", (String)\"f\", (String)\"g\", (String)\"h\", (String)\"i\", (String)\"j\", (String)\"k\", (String)\"l\", (String)\"m\", (String)\"n\"))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"d\", (String)\"g\", (String)\"j\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"e\", (String)\"h\", (String)\"k\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"f\", (String)\"i\", (String)\"l\")))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l, (long)12l, (long)13l, (long)14l))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)10l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)8l, (long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)12l)))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"python\", (String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\", (String)\"SQL\"))), (2l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"C\", (String)\"DBMS\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C++\", (String)\"SQL\")))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    public static long findFirstOccurrence(ArrayList<Long> A, long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long lateralsurfaceCube(long l) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (1l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (2l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (6l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4600,9 +976,669 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    public static long squareSum(long n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (10l));\n    assert(squareSum((3l)) == (35l));\n    assert(squareSum((4l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long findStarNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long asciiValue(String k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    public static long sumEvenAndEvenIndex(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l, (long)18l, (long)8l)))) == (30l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)3l, (long)20l, (long)17l, (long)9l, (long)2l, (long)10l, (long)18l, (long)13l, (long)6l, (long)18l)))) == (26l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long evenPowerSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    public static ArrayList<Long> rearExtract(ArrayList<Pair<Long, String, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Rash\", 21l), (Pair<Long, String, Long>)Pair.with(2l, \"Varsha\", 20l), (Pair<Long, String, Long>)Pair.with(3l, \"Kil\", 19l))))).equals((new ArrayList<Long>(Arrays.asList((long)21l, (long)20l, (long)19l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sai\", 36l), (Pair<Long, String, Long>)Pair.with(2l, \"Ayesha\", 25l), (Pair<Long, String, Long>)Pair.with(3l, \"Salman\", 45l))))).equals((new ArrayList<Long>(Arrays.asList((long)36l, (long)25l, (long)45l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sudeep\", 14l), (Pair<Long, String, Long>)Pair.with(2l, \"Vandana\", 36l), (Pair<Long, String, Long>)Pair.with(3l, \"Dawood\", 56l))))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)36l, (long)56l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    public static Pair<Long, Long, Long> substractElements(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(substractElements((Pair.with(10l, 4l, 5l)), (Pair.with(2l, 5l, 18l))).equals((Pair.with(8l, -1l, -13l))));\n    assert(substractElements((Pair.with(11l, 2l, 3l)), (Pair.with(24l, 45l, 16l))).equals((Pair.with(-13l, -43l, -13l))));\n    assert(substractElements((Pair.with(7l, 18l, 9l)), (Pair.with(10l, 11l, 12l))).equals((Pair.with(-3l, 7l, -3l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long evenBinomialCoeffSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    public static HashMap<String,Long> dictFilter(HashMap<String,Long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (170l)).equals((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (180l)).equals((new HashMap<String,Long>(Map.of(\"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (190l)).equals((new HashMap<String,Long>(Map.of(\"Pierre Cox\", 190l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long isNumDecagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    public static Pair<Boolean, Long> sequentialSearch(ArrayList<Long> dlist, long item) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)11l, (long)23l, (long)58l, (long)31l, (long)56l, (long)77l, (long)43l, (long)12l, (long)65l, (long)19l))), (31l)).equals((Pair.with(true, 3l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)12l, (long)32l, (long)45l, (long)62l, (long)35l, (long)47l, (long)44l, (long)61l))), (61l)).equals((Pair.with(true, 7l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)17l, (long)19l, (long)22l, (long)39l, (long)48l, (long)56l))), (48l)).equals((Pair.with(true, 6l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    public static boolean allUnique(ArrayList<Long> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to subtract two lists element-wise.\n    public static ArrayList<Long> subList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-3l, (long)-3l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-2l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Long>(Arrays.asList((long)40l, (long)50l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static boolean validate(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    public static boolean checkElement(ArrayList<Object> list, Object element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"orange\", (String)\"black\", (String)\"white\"))), (Object(\"blue\"))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (Object(7l))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"green\", (String)\"green\", (String)\"green\"))), (Object(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static boolean textMatchTwoThree(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    public static long maxSubArraySumRepeated(ArrayList<Long> a, long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)-30l, (long)-1l))), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)10l, (long)20l))), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))), (3l), (3l)) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long squareSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    public static Pair<Long, ArrayList<Long>> maxLength(ArrayList<ArrayList<Long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long countNoOfWays(long n, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long find(long n, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float othersideRightangle(long w, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == (float)5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long sumDiv(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count inversions in an array.\n    public static long getInvCount(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)6l, (long)4l, (long)5l)))) == (5l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (1l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)6l, (long)1l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    public static Pair<String, Long> maxAggregate(ArrayList<Pair<String, Long>> stdata) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 90l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 88l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 7l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 122l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 84l))))).equals((Pair.with(\"Juan Whelan\", 212l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 50l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 48l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 37l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 22l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 14l))))).equals((Pair.with(\"Juan Whelan\", 72l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 10l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 20l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 30l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 40l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 50l))))).equals((Pair.with(\"Sabah Colley\", 70l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    public static long findElement(ArrayList<Long> arr, ArrayList<ArrayList<Long>> ranges, long rotations, long index) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)3l))))), (2l), (1l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (2l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    public static Pair<String, String> startWithp(ArrayList<String> words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python PHP\", (String)\"Java JavaScript\", (String)\"c c++\")))).equals((Pair.with(\"Python\", \"PHP\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python Programming\", (String)\"Java Programming\")))).equals((Pair.with(\"Python\", \"Programming\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Pqrst Pqr\", (String)\"qrstuv\")))).equals((Pair.with(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long maxSumIncreasingSubseq(ArrayList<Long> a, long n, long index, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)11l, (long)15l, (long)19l, (long)21l, (long)26l, (long)28l, (long)31l))), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    public static ArrayList<Long> largeProduct(ArrayList<Long> nums1, ArrayList<Long> nums2, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l, (long)45l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the maximum of two numbers.\n    public static long maximum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given string to a list of characters.\n    public static ArrayList<String> stringToTuple(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToTuple((\"python 3.0\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\", (String)\"3\", (String)\".\", (String)\"0\")))));\n    assert(stringToTuple((\"item1\")).equals((new ArrayList<String>(Arrays.asList((String)\"i\", (String)\"t\", (String)\"e\", (String)\"m\", (String)\"1\")))));\n    assert(stringToTuple((\"15.10\")).equals((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"5\", (String)\".\", (String)\"1\", (String)\"0\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    public static long highestPowerOf2(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long findLucas(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    public static ArrayList<String> addString(ArrayList<Object> list_, String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (\"temp{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"temp1\", (String)\"temp2\", (String)\"temp3\", (String)\"temp4\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (\"python{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"pythona\", (String)\"pythonb\", (String)\"pythonc\", (String)\"pythond\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l))), (\"string{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"string5\", (String)\"string6\", (String)\"string7\", (String)\"string8\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    public static ArrayList<HashMap<String,HashMap<String,Long>>> convertListDictionary(ArrayList<String> l1, ArrayList<String> l2, ArrayList<Long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"S001\", (String)\"S002\", (String)\"S003\", (String)\"S004\"))), (new ArrayList<String>(Arrays.asList((String)\"Adina Park\", (String)\"Leyton Marsh\", (String)\"Duncan Boyle\", (String)\"Saim Richards\"))), (new ArrayList<Long>(Arrays.asList((long)85l, (long)98l, (long)89l, (long)92l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S001\", new HashMap<String,Long>(Map.of(\"Adina Park\", 85l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S002\", new HashMap<String,Long>(Map.of(\"Leyton Marsh\", 98l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S003\", new HashMap<String,Long>(Map.of(\"Duncan Boyle\", 89l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S004\", new HashMap<String,Long>(Map.of(\"Saim Richards\", 92l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"def\", (String)\"ghi\", (String)\"jkl\"))), (new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\", (String)\"programs\"))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"abc\", new HashMap<String,Long>(Map.of(\"python\", 100l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"def\", new HashMap<String,Long>(Map.of(\"program\", 200l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"ghi\", new HashMap<String,Long>(Map.of(\"language\", 300l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"jkl\", new HashMap<String,Long>(Map.of(\"programs\", 400l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"A1\", (String)\"A2\", (String)\"A3\", (String)\"A4\"))), (new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\"))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A1\", new HashMap<String,Long>(Map.of(\"java\", 10l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A2\", new HashMap<String,Long>(Map.of(\"C\", 20l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A3\", new HashMap<String,Long>(Map.of(\"C++\", 30l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A4\", new HashMap<String,Long>(Map.of(\"DBMS\", 40l)))))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long getMaxSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the list with maximum length.\n    public static Pair<Long, ArrayList<Long>> maxLengthList(ArrayList<ArrayList<Long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)))))).equals((Pair.with(5l, new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if given list contains no duplicates.\n    public static boolean checkDistinct(ArrayList<Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l, (long)1l, (long)4l)))) == (false));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    public static Optional<String> firstNonRepeatingCharacter(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(Optional.empty()));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Optional.of(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Optional.of(\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static String checkChar(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float medianNumbers(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    public static long sumOfDigits(ArrayList<Object> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)2l, (long)56l)))) == (14l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Object>(Arrays.asList(10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))))) == (19l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)20l, (long)-4l, (long)5l, (long)-70l)))) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    public static Pair<Long, Long, Long, Long> bitwiseXor(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bitwiseXor((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(15l, 6l, 5l, 10l))));\n    assert(bitwiseXor((Pair.with(11l, 5l, 7l, 10l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(13l, 6l, 3l, 14l))));\n    assert(bitwiseXor((Pair.with(12l, 6l, 8l, 11l)), (Pair.with(7l, 4l, 5l, 6l))).equals((Pair.with(11l, 2l, 13l, 13l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to identify non-prime numbers.\n    public static boolean isNotPrime(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    public static long extractFreq(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(5l, 6l))))) == (3l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 15l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l))))) == (4l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 16l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 9l))))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    public static ArrayList<ArrayList<Long>> addNestedTuples(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)13l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)16l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)15l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)17l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum of two numbers.\n    public static long minimum(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    public static boolean findParity(long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static Object rearrangeBigger(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearrangeBigger((12l)).equals((Object(21l))));\n    assert(rearrangeBigger((10l)).equals((Object(false))));\n    assert(rearrangeBigger((102l)).equals((Object(120l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    public static ArrayList<ArrayList<Long>> kSmallestPairs(ArrayList<Long> nums1, ArrayList<Long> nums2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (7l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)2l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    public static long minProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (8l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (30l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove odd numbers from a given list.\n    public static ArrayList<Long> removeOdd(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    public static ArrayList<Object> extractNthElement(ArrayList<Pair<String, Long, Long>> list1, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (0l)).equals((new ArrayList<Object>(Arrays.asList((String)\"Greyson Fulton\", (String)\"Brady Kent\", (String)\"Wyatt Knott\", (String)\"Beau Turnbull\")))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (2l)).equals((new ArrayList<Object>(Arrays.asList((long)99l, (long)96l, (long)94l, (long)98l)))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (1l)).equals((new ArrayList<Object>(Arrays.asList((long)98l, (long)97l, (long)91l, (long)94l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    public static boolean overlapping(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    public static Pair<Long, Long> maxProduct(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)0l, (long)8l, (long)4l)))).equals((Pair.with(7l, 8l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)0l, (long)-1l, (long)-2l, (long)-4l, (long)5l, (long)0l, (long)-6l)))).equals((Pair.with(-4l, -6l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((Pair.with(2l, 3l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4612,7 +1648,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find common first element in given list of lists.\n    public static ArrayList<ArrayList<String>> groupTuples(ArrayList<ArrayList<String>> Input) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"w\", (String)\"t\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"w\", (String)\"t\")))))));\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"e\")))))));\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"h\", (String)\"i\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"h\", (String)\"i\")))))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4620,13 +1656,2977 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three lists into a single sorted list.\n    public static ArrayList<Long> mergeSortedList(ArrayList<Long> num1, ArrayList<Long> num2, ArrayList<Long> num3) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the element of a list having maximum length.\n    public static ArrayList<Object> FindMax(ArrayList<ArrayList<Object>> lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)25l, (long)24l, (long)15l, (long)4l, (long)5l, (long)29l, (long)110l))), (new ArrayList<Long>(Arrays.asList((long)19l, (long)20l, (long)11l, (long)56l, (long)25l, (long)233l, (long)154l))), (new ArrayList<Long>(Arrays.asList((long)24l, (long)26l, (long)54l, (long)48l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)11l, (long)15l, (long)19l, (long)20l, (long)24l, (long)24l, (long)25l, (long)25l, (long)26l, (long)29l, (long)48l, (long)54l, (long)56l, (long)110l, (long)154l, (long)233l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)6l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l, (long)11l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)8l, (long)12l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)5l, (long)6l, (long)7l, (long)7l, (long)8l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)18l, (long)14l, (long)10l, (long)9l, (long)8l, (long)7l, (long)9l, (long)3l, (long)2l, (long)4l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l))), (new ArrayList<Long>(Arrays.asList((long)12l, (long)74l, (long)9l, (long)50l, (long)61l, (long)41l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)8l, (long)9l, (long)9l, (long)9l, (long)10l, (long)12l, (long)14l, (long)14l, (long)18l, (long)22l, (long)25l, (long)25l, (long)35l, (long)41l, (long)50l, (long)58l, (long)61l, (long)65l, (long)74l, (long)75l, (long)85l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    public static long cubeSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    public static String concatenateTuple(Pair<String, String, Long, String> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenateTuple((Pair.with(\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple((Pair.with(\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple((Pair.with(\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    public static float findAverageOfCube(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == (float)12l);\n    assert(findAverageOfCube((1l)) == (float)1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    public static ArrayList<String> extractRear(Pair<String, String, String> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractRear((Pair.with(\"Mers\", \"for\", \"Vers\"))).equals((new ArrayList<String>(Arrays.asList((String)\"s\", (String)\"r\", (String)\"s\")))));\n    assert(extractRear((Pair.with(\"Avenge\", \"for\", \"People\"))).equals((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"r\", (String)\"e\")))));\n    assert(extractRear((Pair.with(\"Gotta\", \"get\", \"go\"))).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"t\", (String)\"o\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    public static long countElementInList(ArrayList<ArrayList<Object>> list1, Object x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)7l))))), (Object(1l))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"A\"))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"E\"))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static ArrayList<Long> filterOddnumbers(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)45l, (long)67l, (long)84l, (long)93l)))).equals((new ArrayList<Long>(Arrays.asList((long)45l, (long)67l, (long)93l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)8l, (long)6l, (long)4l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static String changeDateFormat(String dt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array by using shell sort.\n    public static ArrayList<Long> shellSort(ArrayList<Long> my_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)4l, (long)5l, (long)3l, (long)2l, (long)12l, (long)81l, (long)56l, (long)95l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)12l, (long)12l, (long)23l, (long)56l, (long)81l, (long)95l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)24l, (long)22l, (long)39l, (long)34l, (long)87l, (long)73l, (long)68l)))).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l, (long)34l, (long)39l, (long)68l, (long)73l, (long)87l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)32l, (long)30l, (long)16l, (long)96l, (long)82l, (long)83l, (long)74l)))).equals((new ArrayList<Long>(Arrays.asList((long)16l, (long)30l, (long)32l, (long)74l, (long)82l, (long)83l, (long)96l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    public static Pair<Long, Long, Long, Long> andTuples(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(andTuples((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(0l, 0l, 2l, 1l))));\n    assert(andTuples((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(5l, 6l, 7l, 8l))).equals((Pair.with(1l, 2l, 3l, 0l))));\n    assert(andTuples((Pair.with(8l, 9l, 11l, 12l)), (Pair.with(7l, 13l, 14l, 17l))).equals((Pair.with(0l, 9l, 10l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long parabolaDirectrix(long a, long b, long c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    public static Optional<Boolean> commonElement(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.of(true)));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.empty()));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))), (new ArrayList<Object>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"e\")))).equals(Optional.of(true)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float medianTrapezium(long base1, long base2, long height) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianTrapezium((15l), (25l), (35l)) == (float)20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == (float)15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    public static boolean checkGreater(ArrayList<Long> arr, long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (4l)) == (false));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (8l)) == (true));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)4l, (long)8l, (long)6l, (long)1l))), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static boolean textMatchOne(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last digit of a given number.\n    public static long lastDigit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to return the negative numbers in a list.\n    public static ArrayList<Long> negNos(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)4l, (long)5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-6l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static String removeOdd(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count bidirectional tuple pairs.\n    public static long countBidirectional(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (3l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (2l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    public static long multipleToSingle(ArrayList<Long> L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)11l, (long)33l, (long)50l)))) == (113350l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (-123456l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l)))) == (10152025l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Pair<Long, Long, String> findAdverbPosition(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals((Pair.with(0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals((Pair.with(0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals((Pair.with(0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long surfaceareaCube(long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    public static float positiveCount(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.54f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.69f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the largest negative number from the given list.\n    public static long largestNeg(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-4l, (long)-6l)))) == (-6l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-8l, (long)-9l)))) == (-9l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to trim each list by k in the given lists.\n    public static ArrayList<ArrayList<Long>> trimTuple(ArrayList<ArrayList<Long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)2l, (long)1l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)12l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)9l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    public static ArrayList<ArrayList<Long>> indexMultiplication(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)21l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)30l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)14l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)60l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)20l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)44l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)24l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)77l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)27l, (long)60l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    public static long countOccurrence(Object tup, ArrayList<Object> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurrence(Pair.with(\"a\", \"a\", \"c\", \"b\", \"d\"), (new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\")))) == (3l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)4l, (long)7l)))) == (6l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 4l, 5l, 6l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)2l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find cubes of individual elements in a list.\n    public static ArrayList<Long> cubeNums(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)27l, (long)64l, (long)125l, (long)216l, (long)343l, (long)512l, (long)729l, (long)1000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)1728l, (long)3375l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long calSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    public static ArrayList<String> extractString(ArrayList<String> str, long l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (8l)).equals((new ArrayList<String>(Arrays.asList((String)\"practice\", (String)\"solution\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (6l)).equals((new ArrayList<String>(Arrays.asList((String)\"Python\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (9l)).equals((new ArrayList<String>(Arrays.asList((String)\"exercises\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static String removeWhitespaces(String text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long lossAmount(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of even factors of a number.\n    public static long sumofFactors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static boolean textMatchWordz(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static boolean checkMonthnumbNumber(long monthnum2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse each string in a given list of string values.\n    public static ArrayList<String> reverseStringList(ArrayList<String> stringlist) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\", (String)\"White\", (String)\"Black\")))).equals((new ArrayList<String>(Arrays.asList((String)\"deR\", (String)\"neerG\", (String)\"eulB\", (String)\"etihW\", (String)\"kcalB\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"john\", (String)\"amal\", (String)\"joel\", (String)\"george\")))).equals((new ArrayList<String>(Arrays.asList((String)\"nhoj\", (String)\"lama\", (String)\"leoj\", (String)\"egroeg\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"jack\", (String)\"john\", (String)\"mary\")))).equals((new ArrayList<String>(Arrays.asList((String)\"kcaj\", (String)\"nhoj\", (String)\"yram\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sublist having minimum length.\n    public static ArrayList<Object> FindMin(ArrayList<ArrayList<Object>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)7l, (long)8l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"x\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long rectangleArea(long l, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static String removeUppercase(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to get the first element of each sublist.\n    public static ArrayList<Long> Extract(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)6l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the upper case characters in a given string.\n    public static long upperCtr(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    public static long maxSubarrayProduct(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)0l, (long)7l, (long)-8l, (long)-2l)))) == (112l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)6l, (long)-3l, (long)-10l, (long)0l, (long)2l)))) == (180l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-40l, (long)0l, (long)-2l, (long)-3l)))) == (80l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all values are same in a dictionary.\n    public static boolean checkValue(HashMap<String,Long> dict, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (10l)) == (false));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (12l)) == (true));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (5l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to drop empty items from a given dictionary.\n    public static HashMap<String,String> dropEmpty(HashMap<String,Optional<String>> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\")))));\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", Optional.empty(), \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\")))));\n    assert(dropEmpty(new HashMap<String,Optional.empty()>(Map.of(\"c1\", Optional.empty(), \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c2\", \"Green\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    public static long maxProduct(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)100l, (long)4l, (long)5l, (long)150l, (long)6l)))) == (3000l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)4l, (long)42l, (long)55l, (long)68l, (long)80l)))) == (50265600l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)22l, (long)9l, (long)33l, (long)21l, (long)50l, (long)41l, (long)60l)))) == (2460l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    public static Pair<Long, Long, Long, Long> addPairwise(Pair<Long, Long, Long, Long, Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addPairwise((Pair.with(1l, 5l, 7l, 8l, 10l))).equals((Pair.with(6l, 12l, 15l, 18l))));\n    assert(addPairwise((Pair.with(2l, 6l, 8l, 9l, 11l))).equals((Pair.with(8l, 14l, 17l, 20l))));\n    assert(addPairwise((Pair.with(3l, 7l, 9l, 10l, 12l))).equals((Pair.with(10l, 16l, 19l, 22l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    public static long findRemainder(ArrayList<Long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)100l, (long)10l, (long)5l, (long)25l, (long)35l, (long)14l))), (11l)) == (9l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l))), (1l)) == (0l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (2l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    public static boolean checkConsecutive(ArrayList<Long> l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)6l)))) == (false));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static String replaceChar(String str1, String ch, String newch) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a dictionary by value.\n    public static ArrayList<Pair<String, Long>> sortCounter(HashMap<String,Long> dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 81l, \"Physics\", 83l, \"Chemistry\", 87l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 87l), (Pair<String, Long>)Pair.with(\"Physics\", 83l), (Pair<String, Long>)Pair.with(\"Math\", 81l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 400l, \"Physics\", 300l, \"Chemistry\", 250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Math\", 400l), (Pair<String, Long>)Pair.with(\"Physics\", 300l), (Pair<String, Long>)Pair.with(\"Chemistry\", 250l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 900l, \"Physics\", 1000l, \"Chemistry\", 1250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 1250l), (Pair<String, Long>)Pair.with(\"Physics\", 1000l), (Pair<String, Long>)Pair.with(\"Math\", 900l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    public static long bigSum(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert the given string to lower case.\n    public static String isLower(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static String removeLowercase(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first digit of a given number.\n    public static long firstDigit(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    public static ArrayList<Long> heapQueueLargest(ArrayList<Long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l, (long)58l, (long)35l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l, (long)13l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)13l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long difference(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    public static long findOddPair(ArrayList<Long> A, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l))), (5l)) == (6l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l))), (7l)) == (12l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static String toggleString(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    public static long digitDistanceNums(long n1, long n2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    public static long maxSubArraySum(ArrayList<Long> a, long size) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)4l, (long)-1l, (long)-2l, (long)1l, (long)5l, (long)-3l))), (8l)) == (7l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l, (long)-2l, (long)-3l, (long)2l, (long)6l, (long)-4l))), (8l)) == (8l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-5l, (long)6l, (long)-3l, (long)-4l, (long)3l, (long)7l, (long)-5l))), (8l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    public static ArrayList<Long> unionElements(ArrayList<Long> test_tup1, ArrayList<Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)4l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)10l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l))), (new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)16l, (long)17l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l, (long)15l, (long)16l, (long)17l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the longest sublists.\n    public static long FindMaxLength(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (4l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))))) == (3l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)22l, (long)23l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l)))))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static ArrayList<String> extractValues(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"PHP\", (String)\"Java\")))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\")))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\", (String)\"yellow\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long countPairs(ArrayList<Long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (3l)) == (2l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (4l)) == (0l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (5l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to split a string into characters.\n    public static ArrayList<String> split(String word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(split((\"python\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))));\n    assert(split((\"Name\")).equals((new ArrayList<String>(Arrays.asList((String)\"N\", (String)\"a\", (String)\"m\", (String)\"e\")))));\n    assert(split((\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long sumDigits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    public static boolean issortList(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)17l)))) == (true));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)20l, (long)17l)))) == (false));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)15l, (long)14l, (long)20l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a list of N empty dictionaries.\n    public static ArrayList<HashMap<Optional.empty(),Optional.empty()>> emptyList(long length) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(emptyList((5l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((6l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((7l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"f\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    public static boolean checks(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    public static ArrayList<Long> twoUniqueNums(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    public static long uniqueProduct(ArrayList<Long> list_data) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)20l, (long)50l, (long)60l, (long)40l)))) == (720000000l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l)))) == (6l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)0l, (long)1l, (long)1l)))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float surfaceareaCylinder(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    public static boolean isSubArray(ArrayList<Long> A, ArrayList<Long> B) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (false));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (true));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    public static long lastDigitFactorial(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    public static ArrayList<Long> interleaveLists(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l, (long)60l, (long)70l))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l, (long)500l, (long)600l, (long)700l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)100l, (long)2l, (long)20l, (long)200l, (long)3l, (long)30l, (long)300l, (long)4l, (long)40l, (long)400l, (long)5l, (long)50l, (long)500l, (long)6l, (long)60l, (long)600l, (long)7l, (long)70l, (long)700l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)5l, (long)20l, (long)2l, (long)10l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)11l, (long)44l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)15l))), (new ArrayList<Long>(Arrays.asList((long)20l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)10l, (long)20l, (long)44l, (long)15l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    public static Pair<Long, Long, Long, Long> findDissimilar(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findDissimilar((Pair.with(3l, 4l, 5l, 6l)), (Pair.with(5l, 7l, 4l, 10l))).equals((Pair.with(3l, 6l, 7l, 10l))));\n    assert(findDissimilar((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(7l, 2l, 3l, 9l))).equals((Pair.with(1l, 4l, 7l, 9l))));\n    assert(findDissimilar((Pair.with(21l, 11l, 25l, 26l)), (Pair.with(26l, 34l, 21l, 36l))).equals((Pair.with(34l, 36l, 11l, 25l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    public static long findMaxNum(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (321l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)1l)))) == (6541l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)9l)))) == (9321l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    public static Object extractEven(Pair<Long, Long, Pair<Long, Long, Pair<Long, Long>>, Long, Long> test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractEven((Pair.with(4l, 5l, Pair.with(7l, 6l, Pair.with(2l, 4l)), 6l, 8l))).equals(Pair.with(4l, Pair.with(6l, Pair.with(2l, 4l)), 6l, 8l)));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(8l, 7l, Pair.with(4l, 8l)), 7l, 9l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 8l)))));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(9l, 8l, Pair.with(4l, 6l)), 8l, 10l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 6l)), 8l, 10l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    public static long surfaceArea(long b, long s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long catalanNumber(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static String findAdverbs(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    public static ArrayList<Long> splitArr(ArrayList<Long> l, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)5l, (long)6l, (long)52l, (long)36l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)52l, (long)36l, (long)12l, (long)10l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)0l, (long)1l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a list to a tuple.\n    public static Object listTuple(ArrayList<Long> listx) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)10l, (long)7l, (long)4l, (long)15l, (long)3l)))).equals(Pair.with(5l, 10l, 7l, 4l, 15l, 3l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)2l, (long)3l, (long)4l, (long)4l, (long)7l)))).equals(Pair.with(2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)58l, (long)44l, (long)56l)))).equals(Pair.with(58l, 44l, 56l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    public static long bigDiff(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)12l)))) == (8l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)3l)))) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static ArrayList<Long> perfectSquares(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(perfectSquares((1l), (30l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l)))));\n    assert(perfectSquares((50l), (100l)).equals((new ArrayList<Long>(Arrays.asList((long)64l, (long)81l, (long)100l)))));\n    assert(perfectSquares((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)121l, (long)144l, (long)169l, (long)196l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    public static boolean oppositeSigns(long x, long y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)12l, (long)35l, (long)9l, (long)56l, (long)24l)))).equals((new ArrayList<Long>(Arrays.asList((long)24l, (long)35l, (long)9l, (long)56l, (long)12l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    public static long sumOfProduct(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static String removezeroIp(String ip) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    public static long diffEvenOdd(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (3l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (1l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static Object minSwaps(String str1, String str2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Object(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Object(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Object(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    public static long findKth(ArrayList<Long> arr1, ArrayList<Long> arr2, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)8l, (long)10l))), (5l)) == (6l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)100l, (long)112l, (long)256l, (long)349l, (long)770l))), (new ArrayList<Long>(Arrays.asList((long)72l, (long)86l, (long)113l, (long)119l, (long)265l, (long)445l, (long)892l))), (7l)) == (256l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)7l, (long)8l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)9l, (long)11l))), (6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static boolean armstrongNumber(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Pair<Long, Float> sumAverage(long number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumAverage((10l)).equals((Pair.with(55l, 5.5f))));\n    assert(sumAverage((15l)).equals((Pair.with(120l, 8.0f))));\n    assert(sumAverage((20l)).equals((Pair.with(210l, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long isOctagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number is even or not.\n    public static boolean isEven(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first repeated character in a given string.\n    public static Optional<String> firstRepeatedChar(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Optional.of(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(Optional.empty()));\n    assert(firstRepeatedChar((\"123123\")).equals(Optional.of(\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static ArrayList<Long> getLudic(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getLudic((10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(getLudic((25l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l)))));\n    assert(getLudic((45l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l, (long)29l, (long)37l, (long)41l, (long)43l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static String reverseWords(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static boolean primeNum(long num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float radianDegree(long degree) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Pair<String, Long, Long> findLiterals(String text, String pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals((Pair.with(\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals((Pair.with(\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals((Pair.with(\"will\", 35l, 39l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find nth bell number.\n    public static long bellNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    public static ArrayList<Long> removeKthElement(ArrayList<Long> list1, long L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    public static long maxOfNth(ArrayList<ArrayList<Long>> test_list, long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)19l))))), (2l)) == (19l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)20l))))), (1l)) == (10l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)21l))))), (1l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    public static ArrayList<ArrayList<Object>> merge(ArrayList<ArrayList<Object>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\", (String)\"o\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"z\", (String)\"c\", (String)\"o\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    public static long cummulativeSum(ArrayList<ArrayList<Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))))) == (30l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))))) == (37l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l)))))) == (44l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    public static ArrayList<Float> averageTuple(ArrayList<ArrayList<Long>> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)45l, (long)56l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)80l, (long)39l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))).equals((new ArrayList<Float>(Arrays.asList((float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)-15l, (long)56l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)-60l, (long)-39l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-10l, (long)2l, (long)3l)))))).equals((new ArrayList<Float>(Arrays.asList((float)25.5f, (float)-18.0f, (float)3.75f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)100l, (long)100l, (long)100l, (long)120l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)300l, (long)450l, (long)560l, (long)450l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)810l, (long)800l, (long)390l, (long)320l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new ArrayList<Float>(Arrays.asList((float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    public static Pair<Long, Long, Long, Long> tupleModulo(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleModulo((Pair.with(10l, 4l, 5l, 6l)), (Pair.with(5l, 6l, 7l, 5l))).equals((Pair.with(0l, 4l, 5l, 1l))));\n    assert(tupleModulo((Pair.with(11l, 5l, 6l, 7l)), (Pair.with(6l, 7l, 8l, 6l))).equals((Pair.with(5l, 5l, 6l, 1l))));\n    assert(tupleModulo((Pair.with(12l, 6l, 7l, 8l)), (Pair.with(7l, 8l, 9l, 7l))).equals((Pair.with(5l, 6l, 7l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float minJumps(Pair<Long, Long> steps, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minJumps((Pair.with(3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps((Pair.with(3l, 4l)), (0l)) == (float)0l);\n    assert(minJumps((Pair.with(11l, 14l)), (11l)) == (float)1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to divide two lists element wise.\n    public static ArrayList<Float> divList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)2.5f, (float)2.0f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))).equals((new ArrayList<Float>(Arrays.asList((float)3.0f, (float)0.5f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Float>(Arrays.asList((float)1.8f, (float)1.7142857142857142f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static String moveNum(String test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    public static long countSubstrings(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    public static float getMedian(ArrayList<Long> arr1, ArrayList<Long> arr2, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)1l, (long)12l, (long)15l, (long)26l, (long)38l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)17l, (long)30l, (long)45l))), (5l)) == (16.0f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)13l, (long)19l, (long)28l))), (4l)) == (8.5f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)14l, (long)23l, (long)36l, (long)42l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)18l, (long)27l, (long)39l, (long)49l, (long)55l))), (6l)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    public static ArrayList<Long> nthNums(ArrayList<Long> nums, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)248832l, (long)759375l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to convert a given string to uppercase.\n    public static String isUpper(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Optional<Long> triangleArea(long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((-1l)).equals(Optional.empty()));\n    assert(triangleArea((0l)).equals(Optional.of(0l)));\n    assert(triangleArea((2l)).equals(Optional.of(4l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    public static long findFirstMissing(ArrayList<Long> array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)6l, (long)9l)))) == (3l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)8l, (long)9l)))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static String replaceSpaces(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)0l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)0l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l, (long)15l, (long)19l)))).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find smallest number in a list.\n    public static long smallestNum(ArrayList<Long> xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)1l, (long)45l, (long)99l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)45l, (long)46l, (long)50l, (long)60l)))) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    public static ArrayList<ArrayList<Long>> getCoordinates(Pair<Long, Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getCoordinates((Pair.with(3l, 4l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))));\n    assert(getCoordinates((Pair.with(4l, 5l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))));\n    assert(getCoordinates((Pair.with(5l, 6l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static String replaceSpaces(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    public static ArrayList<Long> moveZero(ArrayList<Long> num_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)0l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)0l, (long)0l, (long)4l, (long)0l, (long)5l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)4l, (long)5l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)1l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)0l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    public static long pairXorSum(ArrayList<Long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)7l, (long)6l))), (4l)) == (47l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)5l))), (3l)) == (12l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l))), (2l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given list.\n    public static ArrayList<Long> heapSort(ArrayList<Long> iterable) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l)))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)22l, (long)25l, (long)25l, (long)35l, (long)58l, (long)65l, (long)75l, (long)85l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)7l, (long)1l, (long)9l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static boolean noprofitNoloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long windChill(long v, long t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    public static long sampleNam(ArrayList<String> sample_names) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"sally\", (String)\"Dylan\", (String)\"rebecca\", (String)\"Diana\", (String)\"Joanne\", (String)\"keith\")))) == (16l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"php\", (String)\"res\", (String)\"Python\", (String)\"abcd\", (String)\"Java\", (String)\"aaa\")))) == (10l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"Python\", (String)\"abba\", (String)\"aba\")))) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    public static long maxDifference(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(1l, 7l), (Pair<Long, Long>)Pair.with(10l, 3l), (Pair<Long, Long>)Pair.with(1l, 2l))))) == (7l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(2l, 17l), (Pair<Long, Long>)Pair.with(9l, 13l), (Pair<Long, Long>)Pair.with(11l, 12l))))) == (15l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 35l), (Pair<Long, Long>)Pair.with(21l, 27l), (Pair<Long, Long>)Pair.with(13l, 23l), (Pair<Long, Long>)Pair.with(41l, 22l))))) == (23l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static String removeParenthesis(ArrayList<String> items) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"python (chrome)\")))).equals((\"python\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"string(.abc)\")))).equals((\"string\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"alpha(num)\")))).equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long isNonagonal(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static boolean textMatchWordzMiddle(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to reverse an array upto a given position.\n    public static ArrayList<Long> reverseArrayUptoK(ArrayList<Long> input, long k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l, (long)5l, (long)6l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)6l, (long)7l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)6l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    public static ArrayList<Pair<String, Long>> subjectMarks(ArrayList<Pair<String, Long>> subjectmarks) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l), (Pair<String, Long>)Pair.with(\"Social sciences\", 82l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social sciences\", 82l), (Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l), (Pair<String, Long>)Pair.with(\"Social\", 33l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social\", 33l), (Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l), (Pair<String, Long>)Pair.with(\"Biology\", 45l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Biology\", 45l), (Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    public static long posCount(ArrayList<Long> list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l, (long)-4l)))) == (2l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)-1l)))) == (3l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long bellNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    public static boolean isMonotonic(ArrayList<Long> A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)4l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    public static boolean isSublist(ArrayList<Long> l, ArrayList<Long> s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))) == (false));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)))) == (true));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    public static boolean differAtOneBitPos(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    public static boolean getEqual(ArrayList<ArrayList<Long>> Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)22l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)44l, (long)55l, (long)66l)))))) == (true));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l)))))) == (false));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a list of elements.\n    public static ArrayList<Long> combSort(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)37l, (long)25l, (long)79l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)25l, (long)37l, (long)79l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)32l, (long)15l, (long)19l, (long)22l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)19l, (long)22l, (long)32l, (long)41l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)99l, (long)15l, (long)13l, (long)47l)))).equals((new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)47l, (long)99l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    public static Pair<Long, Long, Long, HashMap<String,Long>> addDictToTuple(Pair<Long, Long, Long> test_tup, HashMap<String,Long> test_dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addDictToTuple((Pair.with(4l, 5l, 6l)), (new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l)))).equals((Pair.with(4l, 5l, 6l, new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l))))));\n    assert(addDictToTuple((Pair.with(1l, 2l, 3l)), (new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l)))).equals((Pair.with(1l, 2l, 3l, new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l))))));\n    assert(addDictToTuple((Pair.with(8l, 9l, 10l)), (new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l)))).equals((Pair.with(8l, 9l, 10l, new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float maxAverageOfPath(ArrayList<ArrayList<Long>> cost) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)9l)))))) == (5.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l, (long)10l)))))) == (6.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)11l)))))) == (7.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static HashMap<String,Pair<Float, Long>> filterData(HashMap<String,Pair<Float, Long>> students, float h, long w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (6.0f), (70l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.9f), (67l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Kierra Gentry\", Pair.with(6.0f, 68l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.7f), (64l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    public static long countSamePair(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (4l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (11l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (1l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)2l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long powerBaseSum(long base, long power) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static ArrayList<Object> extractQuotation(String text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"A53\", (String)\"multi\", (String)\"Processor\")))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"favorite\", (String)\"apps\")))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((new ArrayList<Object>(Arrays.asList((String)\"4k Ultra HD\", (String)\"HDR 10\")))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    public static ArrayList<Object> multiplyElements(ArrayList<Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)8l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)5l, (long)35l, (long)56l, (long)80l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)8l, (long)20l, (long)30l, (long)42l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)14l, (long)9l, (long)15l)))).equals((new ArrayList<Object>(Arrays.asList((long)156l, (long)182l, (long)126l, (long)135l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static ArrayList<Long> sumList(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)25l, (long)45l, (long)65l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)45l, (long)75l)))).equals((new ArrayList<Long>(Arrays.asList((long)30l, (long)65l, (long)105l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    public static boolean difSquare(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    public static ArrayList<Object> consecutiveDuplicates(ArrayList<Object> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<Object>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\")))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\", (String)\"a\", (String)\"a\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"a\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float lateralsurfaceCone(long r, long h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static String replaceSpecialchar(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    public static long findFirstOccurrence(ArrayList<Long> A, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (1l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (2l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (6l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    public static long sumOfSubarrayProd(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (20l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (5l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long toggleMiddleBits(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    public static long leftInsertion(ArrayList<Long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static boolean checkStr(String string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    public static float geometricSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long findIndex(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    public static HashMap<Long,Long> tupleToDict(Pair<Long, Long, Long, Long, Long, Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToDict((Pair.with(1l, 5l, 7l, 10l, 13l, 5l))).equals((new HashMap<Long,Long>(Map.of(1l, 5l, 7l, 10l, 13l, 5l)))));\n    assert(tupleToDict((Pair.with(1l, 2l, 3l, 4l, 5l, 6l))).equals((new HashMap<Long,Long>(Map.of(1l, 2l, 3l, 4l, 5l, 6l)))));\n    assert(tupleToDict((Pair.with(7l, 8l, 9l, 10l, 11l, 12l))).equals((new HashMap<Long,Long>(Map.of(7l, 8l, 9l, 10l, 11l, 12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether all the characters are same or not.\n    public static boolean allCharactersSame(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float areaTetrahedron(long side) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    public static ArrayList<Long> rotateRight(ArrayList<Long> list, long m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    public static boolean checkNone(Object test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkNone(Pair.with(Optional.of(10l), Optional.of(4l), Optional.of(5l), Optional.of(6l), Optional.of(Optional.empty()))) == (true));\n    assert(checkNone(Pair.with(7l, 8l, 9l, 11l, 14l)) == (false));\n    assert(checkNone(Pair.with(Optional.of(1l), Optional.of(2l), Optional.of(3l), Optional.of(4l), Optional.of(Optional.empty()))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    public static ArrayList<Long> divisibleByDigits(long startnum, long endnum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisibleByDigits((1l), (22l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l, (long)22l)))));\n    assert(divisibleByDigits((1l), (15l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l)))));\n    assert(divisibleByDigits((20l), (25l)).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    public static Optional<Float> sectorArea(long r, long a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sectorArea((4l), (45l)).equals(Optional.of(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Optional.of(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(Optional.empty()));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long lcsOfThree(String X, String Y, String Z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static String capitalWordsSpaces(String str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    public static ArrayList<Long> sortNumericStrings(ArrayList<String> nums_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"4\", (String)\"12\", (String)\"45\", (String)\"7\", (String)\"0\", (String)\"100\", (String)\"200\", (String)\"-12\", (String)\"-500\")))).equals((new ArrayList<Long>(Arrays.asList((long)-500l, (long)-12l, (long)0l, (long)4l, (long)7l, (long)12l, (long)45l, (long)100l, (long)200l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"2\", (String)\"3\", (String)\"8\", (String)\"4\", (String)\"7\", (String)\"9\", (String)\"8\", (String)\"2\", (String)\"6\", (String)\"5\", (String)\"1\", (String)\"6\", (String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"6\", (String)\"9\", (String)\"1\", (String)\"2\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)8l, (long)9l, (long)9l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"3\", (String)\"5\", (String)\"7\", (String)\"1\", (String)\"3\", (String)\"13\", (String)\"15\", (String)\"17\", (String)\"5\", (String)\"7 \", (String)\"9\", (String)\"1\", (String)\"11\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)3l, (long)3l, (long)5l, (long)5l, (long)7l, (long)7l, (long)9l, (long)11l, (long)13l, (long)15l, (long)17l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    public static boolean isSamepatterns(ArrayList<String> colors, ArrayList<String> patterns) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"green\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (true));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (false));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add the given tuple to the given list.\n    public static ArrayList<Long> addTuple(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)9l, (long)10l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)10l, (long)11l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    public static boolean checkMinHeap(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)10l, (long)15l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)5l, (long)3l, (long)15l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long jacobsthalNum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    public static ArrayList<Pair<String, Long>> minK(ArrayList<Pair<String, Long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Manjeet\", 10l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l), (Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Nikhil\", 8l)))), (2l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sanjeev\", 11l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l)))), (3l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"tanmay\", 14l), (Pair<String, Long>)Pair.with(\"Amer\", 11l), (Pair<String, Long>)Pair.with(\"Ayesha\", 9l), (Pair<String, Long>)Pair.with(\"SKD\", 16l)))), (1l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Ayesha\", 9l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    public static ArrayList<Object> extractIndexList(ArrayList<Long> l1, ArrayList<Long> l2, ArrayList<Long> l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)7l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)6l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)6l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)6l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    public static boolean textMatchZeroOne(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    public static long countReversePairs(ArrayList<String> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"julia\", (String)\"best\", (String)\"tseb\", (String)\"for\", (String)\"ailuj\")))) == (2l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"geeks\", (String)\"best\", (String)\"for\", (String)\"skeeg\")))) == (1l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"makes\", (String)\"best\", (String)\"sekam\", (String)\"for\", (String)\"rof\")))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static boolean isDecimal(String num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    public static ArrayList<Pair<Long, Long, Long>> findTuples(ArrayList<Pair<Long, Long, Long>> test_list, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l), (Pair<Long, Long, Long>)Pair.with(7l, 9l, 6l), (Pair<Long, Long, Long>)Pair.with(12l, 18l, 21l)))), (6l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l), (Pair<Long, Long, Long>)Pair.with(4l, 2l, 3l), (Pair<Long, Long, Long>)Pair.with(7l, 8l, 9l)))), (5l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(7l, 9l, 16l), (Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l), (Pair<Long, Long, Long>)Pair.with(19l, 17l, 18l)))), (4l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    public static boolean uniqueElement(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))) == (true));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static boolean checkMonthnumberNumber(long monthnum3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long findMinDiff(ArrayList<Long> arr, long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)19l, (long)18l, (long)25l))), (6l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)6l))), (4l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)30l, (long)5l, (long)20l, (long)9l))), (4l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count number of digits in a given string.\n    public static long numberCtr(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long isPolite(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    public static ArrayList<Pair<Long, Long>> pairWise(ArrayList<Long> l1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 5l), (Pair<Long, Long>)Pair.with(5l, 7l), (Pair<Long, Long>)Pair.with(7l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)9l, (long)7l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(1l, 9l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(7l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l), (Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    public static long getPairsCount(ArrayList<Long> arr, long sum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (2l)) == (6l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)-1l, (long)5l))), (6l)) == (3l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l))), (1l)) == (1l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l))), (-3l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to get the difference between two lists.\n    public static ArrayList<Long> Diff(ArrayList<Long> li1, ArrayList<Long> li2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l, (long)30l, (long)35l, (long)40l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)40l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)15l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    public static long oddNumSum(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static boolean checkExpression(String exp) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static String removeLength(String test_str, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    public static Optional<Pair<String, Long, Long>> occuranceSubstring(String text, String pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Optional.of(Pair.with(\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Optional.of(Pair.with(\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Optional.of(Pair.with(\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(Optional.empty()));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    public static boolean oddPosition(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l, (long)6l, (long)7l, (long)6l, (long)3l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long countVowels(String test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    public static long findSum(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)1l, (long)4l, (long)5l, (long)6l)))) == (21l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)9l, (long)4l, (long)2l, (long)10l, (long)10l, (long)45l, (long)4l)))) == (71l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)9l, (long)45l, (long)2l, (long)10l, (long)10l, (long)45l, (long)10l)))) == (78l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    public static ArrayList<ArrayList<Object>> packConsecutiveDuplicates(ArrayList<Object> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)19l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)26l, (long)26l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"a\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"d\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    public static boolean isDiff(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    public static ArrayList<Pair<Long, Long>> findCombinations(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(6l, 10l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(8l, 11l), (Pair<Long, Long>)Pair.with(7l, 5l), (Pair<Long, Long>)Pair.with(8l, 14l), (Pair<Long, Long>)Pair.with(11l, 8l), (Pair<Long, Long>)Pair.with(12l, 17l), (Pair<Long, Long>)Pair.with(11l, 11l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(6l, 2l), (Pair<Long, Long>)Pair.with(7l, 11l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 13l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(10l, 16l), (Pair<Long, Long>)Pair.with(13l, 10l), (Pair<Long, Long>)Pair.with(14l, 19l), (Pair<Long, Long>)Pair.with(13l, 13l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(7l, 3l), (Pair<Long, Long>)Pair.with(8l, 12l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 15l), (Pair<Long, Long>)Pair.with(11l, 9l), (Pair<Long, Long>)Pair.with(12l, 18l), (Pair<Long, Long>)Pair.with(15l, 12l), (Pair<Long, Long>)Pair.with(16l, 21l), (Pair<Long, Long>)Pair.with(15l, 15l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    public static boolean countDivisors(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    public static long oddLengthSum(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l)))) == (14l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (15l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static ArrayList<Float> rgbToHsv(long r, long g, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.0f, (float)100.0f)))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((new ArrayList<Float>(Arrays.asList((float)120.0f, (float)100.0f, (float)84.31372549019608f)))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((new ArrayList<Float>(Arrays.asList((float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    public static long mulEvenOdd(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (4l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert tuple string to integer tuple.\n    public static Pair<Long, Long, Long> tupleStrInt(String test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals((Pair.with(7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals((Pair.with(1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals((Pair.with(4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals((Pair.with(7l, 81l, 19l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long rightInsertion(ArrayList<Long> a, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static boolean textMatchThree(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a new tuple from the given string and list.\n    public static Pair<String, String, String> newTuple(ArrayList<String> test_list, String test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"WEB\", (String)\"is\"))), (\"best\")).equals((Pair.with(\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"We\", (String)\"are\"))), (\"Developers\")).equals((Pair.with(\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"Part\", (String)\"is\"))), (\"Wrong\")).equals((Pair.with(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    public static boolean evenPosition(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove tuples from the given tuple.\n    public static Pair<Long, Long, Long, Long> removeNested(Object test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeNested(Pair.with(1l, 5l, 7l, Pair.with(4l, 6l), 10l)).equals((Pair.with(1l, 5l, 7l, 10l))));\n    assert(removeNested(Pair.with(2l, 6l, 8l, Pair.with(5l, 7l), 11l)).equals((Pair.with(2l, 6l, 8l, 11l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), Pair.with(5l, 12l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    public static long countList(ArrayList<ArrayList<Long>> input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))) == (4l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))) == (3l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)0l)))))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    public static long last(ArrayList<Long> arr, long x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (1l)) == (0l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)4l))), (1l)) == (2l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)3l, (long)6l, (long)8l, (long)9l))), (3l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static boolean textStartaEndb(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    public static long returnSum(HashMap<String,Long> dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 100l, \"b\", 200l, \"c\", 300l)))) == (600l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 25l, \"b\", 18l, \"c\", 45l)))) == (88l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 36l, \"b\", 39l, \"c\", 49l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    public static long sumInRange(long l, long r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the sum of an array.\n    public static long Sum(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)15l, (long)12l, (long)13l, (long)10l)))) == (50l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long leftRotate(long n, long d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    public static boolean wordLen(String s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static String removeAllSpaces(String text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    public static long testThreeEqual(long x, long y, long z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    public static long countRotation(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (1l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)1l, (long)2l, (long)3l)))) == (2l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (0l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static boolean isPerfectSquare(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    public static boolean isProductEven(ArrayList<Long> arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    public static ArrayList<Long> maxSumList(ArrayList<ArrayList<Long>> lists) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long maxRunUppercase(String test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    public static long firstOdd(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)1l)))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    public static boolean checkK(ArrayList<Long> test_tup, long K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)10l, (long)4l, (long)5l, (long)6l, (long)8l))), (6l)) == (true));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (7l)) == (false));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)44l, (long)11l, (long)12l))), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    public static boolean checkSmaller(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkSmaller((Pair.with(1l, 2l, 3l)), (Pair.with(2l, 3l, 4l))) == (false));\n    assert(checkSmaller((Pair.with(4l, 5l, 6l)), (Pair.with(3l, 4l, 5l))) == (true));\n    assert(checkSmaller((Pair.with(11l, 12l, 13l)), (Pair.with(10l, 11l, 12l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long tetrahedralNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static String getChar(String strr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long sequence(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long centeredHexagonalNumber(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    public static HashMap<String,String> mergeDictionariesThree(HashMap<String,String> dict1, HashMap<String,String> dict2, HashMap<String,String> dict3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"O\", \"Orange\", \"W\", \"White\", \"B\", \"Black\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"R\", \"Red\", \"P\", \"Pink\", \"G\", \"Green\", \"W\", \"White\", \"O\", \"Orange\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\")))).equals((new HashMap<String,String>(Map.of(\"W\", \"White\", \"P\", \"Pink\", \"B\", \"Black\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"P\", \"Pink\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\", \"W\", \"White\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    public static HashMap<Long,Long> freqCount(ArrayList<Long> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)10l, (long)20l, (long)20l, (long)20l, (long)20l, (long)40l, (long)40l, (long)50l, (long)50l, (long)30l)))).equals((new HashMap<Long,Long>(Map.of(10l, 4l, 20l, 4l, 40l, 2l, 50l, 2l, 30l, 1l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)4l, (long)1l, (long)3l, (long)1l, (long)4l)))).equals((new HashMap<Long,Long>(Map.of(1l, 3l, 2l, 2l, 3l, 3l, 4l, 3l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)4l, (long)9l, (long)10l, (long)4l, (long)5l, (long)6l, (long)7l, (long)9l, (long)5l)))).equals((new HashMap<Long,Long>(Map.of(10l, 1l, 5l, 3l, 6l, 2l, 7l, 2l, 4l, 2l, 9l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long closestNum(long N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find squares of individual elements in a list.\n    public static ArrayList<Long> squareNums(ArrayList<Long> nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)400l, (long)900l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)144l, (long)225l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the longest word.\n    public static long lenLog(ArrayList<String> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"PHP\", (String)\"bigdata\")))) == (7l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))) == (3l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"small\", (String)\"big\", (String)\"tall\")))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    public static boolean findSubstring(ArrayList<String> str1, String sub_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ack\")) == (true));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"abc\")) == (false));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static boolean isUndulating(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long power(long a, long b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    public static String indexMinimum(ArrayList<Pair<String, Long>> test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Rash\", 143l), (Pair<String, Long>)Pair.with(\"Manjeet\", 200l), (Pair<String, Long>)Pair.with(\"Varsha\", 100l))))).equals((\"Varsha\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Yash\", 185l), (Pair<String, Long>)Pair.with(\"Dawood\", 125l), (Pair<String, Long>)Pair.with(\"Sanya\", 175l))))).equals((\"Dawood\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sai\", 345l), (Pair<String, Long>)Pair.with(\"Salman\", 145l), (Pair<String, Long>)Pair.with(\"Ayesha\", 96l))))).equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    public static long FindMinLength(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))) == (1l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))) == (2l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    public static long divisor(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    public static HashMap<Long,Long> frequencyLists(ArrayList<ArrayList<Long>> list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)5l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 3l, 3l, 1l, 4l, 1l, 5l, 2l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 1l, 3l, 1l, 4l, 1l, 5l, 1l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l, 10l, 1l, 11l, 1l, 12l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)30l, (long)40l, (long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)16l, (long)14l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new HashMap<Long,Long>(Map.of(20l, 2l, 30l, 2l, 40l, 2l, 17l, 1l, 18l, 1l, 16l, 1l, 14l, 1l, 13l, 1l, 10l, 1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static String decimalToBinary(long n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long findRotations(String str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-java-reworded.json
+++ b/prompts/mbpp-java-reworded.json
@@ -1,3444 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long lps(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static String removeWhitespaces(String text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a specified array list is sorted or not.\n    public static boolean issortList(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)17l)))) == (true));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)20l, (long)17l)))) == (false));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)15l, (long)14l, (long)20l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count bidirectional pair pairs.\n    public static long countBidirectional(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (3l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (2l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long surfaceareaCube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    public static long nextSmallestPalindrome(long num) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(nextSmallestPalindrome((99l)) == (101l));\n    assert(nextSmallestPalindrome((1221l)) == (1331l));\n    assert(nextSmallestPalindrome((120l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the cube sum of first n even natural numbers.\n    public static long cubeSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of xor of all pairs of numbers in the given array list.\n    public static long pairXorSum(ArrayList<Long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)7l, (long)6l))), (4l)) == (47l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)5l))), (3l)) == (12l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l))), (2l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given array array list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array array list-represents-a-binary-heap/\n    public static boolean checkMinHeap(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)10l, (long)15l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)5l, (long)3l, (long)15l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first digit of a given number.\n    public static long firstDigit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first non-repeated character in a given string.\n    public static Optional<String> firstNonRepeatingCharacter(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(Optional.empty()));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Optional.of(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Optional.of(\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float radianDegree(long degree) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product subarray array list of the given array array list.\n    public static long maxSubarrayProduct(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)0l, (long)7l, (long)-8l, (long)-2l)))) == (112l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)6l, (long)-3l, (long)-10l, (long)0l, (long)2l)))) == (180l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-40l, (long)0l, (long)-2l, (long)-3l)))) == (80l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert more than one array list to nested hash map.\n    public static ArrayList<HashMap<String,HashMap<String,Long>>> convertListDictionary(ArrayList<String> l1, ArrayList<String> l2, ArrayList<Long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"S001\", (String)\"S002\", (String)\"S003\", (String)\"S004\"))), (new ArrayList<String>(Arrays.asList((String)\"Adina Park\", (String)\"Leyton Marsh\", (String)\"Duncan Boyle\", (String)\"Saim Richards\"))), (new ArrayList<Long>(Arrays.asList((long)85l, (long)98l, (long)89l, (long)92l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S001\", new HashMap<String,Long>(Map.of(\"Adina Park\", 85l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S002\", new HashMap<String,Long>(Map.of(\"Leyton Marsh\", 98l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S003\", new HashMap<String,Long>(Map.of(\"Duncan Boyle\", 89l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S004\", new HashMap<String,Long>(Map.of(\"Saim Richards\", 92l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"def\", (String)\"ghi\", (String)\"jkl\"))), (new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\", (String)\"programs\"))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"abc\", new HashMap<String,Long>(Map.of(\"python\", 100l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"def\", new HashMap<String,Long>(Map.of(\"program\", 200l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"ghi\", new HashMap<String,Long>(Map.of(\"language\", 300l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"jkl\", new HashMap<String,Long>(Map.of(\"programs\", 400l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"A1\", (String)\"A2\", (String)\"A3\", (String)\"A4\"))), (new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\"))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A1\", new HashMap<String,Long>(Map.of(\"java\", 10l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A2\", new HashMap<String,Long>(Map.of(\"C\", 20l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A3\", new HashMap<String,Long>(Map.of(\"C++\", 30l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A4\", new HashMap<String,Long>(Map.of(\"DBMS\", 40l)))))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find smallest number in an array array list.\n    public static long smallestNum(ArrayList<Long> xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)1l, (long)45l, (long)99l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)45l, (long)46l, (long)50l, (long)60l)))) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/javathon-exercises/re/javathon-re-exercise-3.php\n    public static boolean textMatchZeroOne(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find nth bell number.\n    public static long bellNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find cubes of individual elements in an array array list.\n    public static ArrayList<Long> cubeNums(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)27l, (long)64l, (long)125l, (long)216l, (long)343l, (long)512l, (long)729l, (long)1000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)1728l, (long)3375l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last digit in factorial of a given number.\n    public static long lastDigitFactorial(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find even numbers from an array array list of numbers.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)0l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)0l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l, (long)15l, (long)19l)))).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static boolean primeNum(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find pairs which have all elements divisible by k from the given array list of pairs.\n    public static ArrayList<Pair<Long, Long, Long>> findTuples(ArrayList<Pair<Long, Long, Long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l), (Pair<Long, Long, Long>)Pair.with(7l, 9l, 6l), (Pair<Long, Long, Long>)Pair.with(12l, 18l, 21l)))), (6l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l), (Pair<Long, Long, Long>)Pair.with(4l, 2l, 3l), (Pair<Long, Long, Long>)Pair.with(7l, 8l, 9l)))), (5l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(7l, 9l, 16l), (Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l), (Pair<Long, Long, Long>)Pair.with(19l, 17l, 18l)))), (4l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float areaTetrahedron(long side) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number is even or not.\n    public static boolean isEven(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of positive numbers in an array array list.\n    public static long posCount(ArrayList<Long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l, (long)-4l)))) == (2l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)-1l)))) == (3l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static ArrayList<Long> getLudic(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getLudic((10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(getLudic((25l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l)))));\n    assert(getLudic((45l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l, (long)29l, (long)37l, (long)41l, (long)43l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long findIndex(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to reverse an array array list upto a given position.\n    public static ArrayList<Long> reverseArrayUptoK(ArrayList<Long> input, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l, (long)5l, (long)6l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)6l, (long)7l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)6l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of pairs using the second value of each pair.\n    public static ArrayList<Pair<String, Long>> subjectMarks(ArrayList<Pair<String, Long>> subjectmarks) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l), (Pair<String, Long>)Pair.with(\"Social sciences\", 82l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social sciences\", 82l), (Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l), (Pair<String, Long>)Pair.with(\"Social\", 33l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social\", 33l), (Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l), (Pair<String, Long>)Pair.with(\"Biology\", 45l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Biology\", 45l), (Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static String removeDirtyChars(String string, String second_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given array list.\n    public static long maxOccurrences(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)2l, (long)6l, (long)5l, (long)1l, (long)6l, (long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)6l, (long)9l, (long)1l, (long)2l)))) == (2l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)7l, (long)9l, (long)15l, (long)14l, (long)10l, (long)12l, (long)13l, (long)16l, (long)18l)))) == (8l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)20l, (long)30l, (long)40l, (long)90l, (long)80l, (long)50l, (long)30l, (long)20l, (long)50l, (long)10l)))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static boolean isDecimal(String num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a hash map and integer n and filters the hash map to only include entries with values greater than or equal to n.\n    public static HashMap<String,Long> dictFilter(HashMap<String,Long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (170l)).equals((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (180l)).equals((new HashMap<String,Long>(Map.of(\"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (190l)).equals((new HashMap<String,Long>(Map.of(\"Pierre Cox\", 190l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of even numbers at even positions of an array array list.\n    public static long sumEvenAndEvenIndex(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l, (long)18l, (long)8l)))) == (30l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)3l, (long)20l, (long)17l, (long)9l, (long)2l, (long)10l, (long)18l, (long)13l, (long)6l, (long)18l)))) == (26l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l)))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous subarray list in the given array list.\n    public static long maxSubArraySum(ArrayList<Long> a, long size) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)4l, (long)-1l, (long)-2l, (long)1l, (long)5l, (long)-3l))), (8l)) == (7l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l, (long)-2l, (long)-3l, (long)2l, (long)6l, (long)-4l))), (8l)) == (8l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-5l, (long)6l, (long)-3l, (long)-4l, (long)3l, (long)7l, (long)-5l))), (8l)) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the intersection of two array array lists.\n    public static ArrayList<Long> intersectionArray(ArrayList<Long> array_nums1, ArrayList<Long> array_nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)8l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer L and splits the given array list into two parts where the length of the first part of the array list is L, and returns the resulting array lists in a pair.\n    public static Object splitTwoParts(ArrayList<Object> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals(Pair.with(new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l)), new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (2l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\"))), (4l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\")), new ArrayList<String>(Arrays.asList((String)\"o\", (String)\"n\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Pair<String, Long, Long> findLiterals(String text, String pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals((Pair.with(\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals((Pair.with(\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals((Pair.with(\"will\", 35l, 39l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the volume of a triangular prism.\n    public static long findVolume(long l, long b, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long windChill(long v, long t) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long asciiValue(String k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether all the characters are same or not.\n    public static boolean allCharactersSame(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static String moveNum(String test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the length of the word is odd or not.\n    public static boolean wordLen(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to drop empty items from a given hash map.\n    public static HashMap<String,String> dropEmpty(HashMap<String,Optional<String>> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\")))));\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", Optional.empty(), \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\")))));\n    assert(dropEmpty(new HashMap<String,Optional.empty()>(Map.of(\"c1\", Optional.empty(), \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c2\", \"Green\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an element and inserts the element before each element in the array list, and returns the resulting array list.\n    public static ArrayList<String> insertElement(ArrayList<String> list, String element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Black\"))), (\"c\")).equals((new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"Red\", (String)\"c\", (String)\"Green\", (String)\"c\", (String)\"Black\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"java\"))), (\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"program\", (String)\"python\", (String)\"program\", (String)\"java\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"happy\", (String)\"sad\"))), (\"laugh\")).equals((new ArrayList<String>(Arrays.asList((String)\"laugh\", (String)\"happy\", (String)\"laugh\", (String)\"sad\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static String removeLowercase(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long countSetBits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given pair.\n    public static ArrayList<String> extractRear(Pair<String, String, String> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractRear((Pair.with(\"Mers\", \"for\", \"Vers\"))).equals((new ArrayList<String>(Arrays.asList((String)\"s\", (String)\"r\", (String)\"s\")))));\n    assert(extractRear((Pair.with(\"Avenge\", \"for\", \"People\"))).equals((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"r\", (String)\"e\")))));\n    assert(extractRear((Pair.with(\"Gotta\", \"get\", \"go\"))).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"t\", (String)\"o\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long countOccurance(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given pairs contain the k or not.\n    public static boolean checkK(ArrayList<Long> test_tup, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)10l, (long)4l, (long)5l, (long)6l, (long)8l))), (6l)) == (true));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (7l)) == (false));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)44l, (long)11l, (long)12l))), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to interleave 3 array lists of the same length into a single flat array list.\n    public static ArrayList<Long> interleaveLists(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l, (long)60l, (long)70l))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l, (long)500l, (long)600l, (long)700l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)100l, (long)2l, (long)20l, (long)200l, (long)3l, (long)30l, (long)300l, (long)4l, (long)40l, (long)400l, (long)5l, (long)50l, (long)500l, (long)6l, (long)60l, (long)600l, (long)7l, (long)70l, (long)700l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)5l, (long)20l, (long)2l, (long)10l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)11l, (long)44l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)15l))), (new ArrayList<Long>(Arrays.asList((long)20l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)10l, (long)20l, (long)44l, (long)15l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of equal numbers from three given integers.\n    public static long testThreeEqual(long x, long y, long z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of all odd length subarray array lists. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarray array lists/\n    public static long oddLengthSum(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l)))) == (14l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (15l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long bellNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long rectangleArea(long l, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Pair<Long, Float> sumAverage(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumAverage((10l)).equals((Pair.with(55l, 5.5f))));\n    assert(sumAverage((15l)).equals((Pair.with(120l, 8.0f))));\n    assert(sumAverage((20l)).equals((Pair.with(210l, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two pairs and performs mathematical division operation element-wise across the given pairs.\n    public static Pair<Long, Long, Long, Long> divisionElements(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisionElements((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(2l, 2l, 2l, 3l))));\n    assert(divisionElements((Pair.with(12l, 6l, 8l, 16l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(2l, 2l, 2l, 4l))));\n    assert(divisionElements((Pair.with(20l, 14l, 36l, 18l)), (Pair.with(5l, 7l, 6l, 9l))).equals((Pair.with(4l, 2l, 6l, 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long sumDigits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of pairs, write a function that returns the first value of the pair with the smallest second value.\n    public static String indexMinimum(ArrayList<Pair<String, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Rash\", 143l), (Pair<String, Long>)Pair.with(\"Manjeet\", 200l), (Pair<String, Long>)Pair.with(\"Varsha\", 100l))))).equals((\"Varsha\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Yash\", 185l), (Pair<String, Long>)Pair.with(\"Dawood\", 125l), (Pair<String, Long>)Pair.with(\"Sanya\", 175l))))).equals((\"Dawood\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sai\", 345l), (Pair<String, Long>)Pair.with(\"Salman\", 145l), (Pair<String, Long>)Pair.with(\"Ayesha\", 96l))))).equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to divide two array lists element wise.\n    public static ArrayList<Float> divList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)2.5f, (float)2.0f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))).equals((new ArrayList<Float>(Arrays.asList((float)3.0f, (float)0.5f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Float>(Arrays.asList((float)1.8f, (float)1.7142857142857142f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the array list with maximum length.\n    public static Pair<Long, ArrayList<Long>> maxLengthList(ArrayList<ArrayList<Long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)))))).equals((Pair.with(5l, new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the largest and smallest value in a given array array list.\n    public static long bigSum(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l)))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to return the negative numbers in an array array list.\n    public static ArrayList<Long> negNos(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)4l, (long)5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-6l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the highest power of 2 that is less than or equal to n.\n    public static long highestPowerOf2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether an array array list contains the given subarray list or not.\n    public static boolean isSublist(ArrayList<Long> l, ArrayList<Long> s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))) == (false));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)))) == (true));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to subtract two array lists element-wise.\n    public static ArrayList<Long> subList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-3l, (long)-3l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-2l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Long>(Arrays.asList((long)40l, (long)50l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given two integers have opposite sign or not.\n    public static boolean oppositeSigns(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes two pairs of the same length and performs the element wise modulo.\n    public static Pair<Long, Long, Long, Long> tupleModulo(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleModulo((Pair.with(10l, 4l, 5l, 6l)), (Pair.with(5l, 6l, 7l, 5l))).equals((Pair.with(0l, 4l, 5l, 1l))));\n    assert(tupleModulo((Pair.with(11l, 5l, 6l, 7l)), (Pair.with(6l, 7l, 8l, 6l))).equals((Pair.with(5l, 5l, 6l, 1l))));\n    assert(tupleModulo((Pair.with(12l, 6l, 7l, 8l)), (Pair.with(7l, 8l, 9l, 7l))).equals((Pair.with(5l, 6l, 7l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given array list.\n    public static long diffEvenOdd(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (3l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (1l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each subarray list of strings in a given array list of array lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"f\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last digit of a given number.\n    public static long lastDigit(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of fourth power of first n odd natural numbers.\n    public static long oddNumSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert an array array list to a string.\n    public static String tupString(ArrayList<String> tup1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"x\", (String)\"e\", (String)\"r\", (String)\"c\", (String)\"i\", (String)\"s\", (String)\"e\", (String)\"s\")))).equals((\"exercises\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))).equals((\"python\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))).equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all elements from a given array list present in another array list.\n    public static ArrayList<Long> removeElements(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether any value in a sequence exists in a sequence or not.\n    public static boolean overlapping(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to identify non-prime numbers.\n    public static boolean isNotPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given array list of numbers.\n    public static long sumNegativenum(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (-32l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)-14l, (long)13l, (long)-18l, (long)12l, (long)-20l)))) == (-52l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)19l, (long)-65l, (long)57l, (long)39l, (long)152l, (long)-639l, (long)121l, (long)44l, (long)90l, (long)-190l)))) == (-894l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long findRotations(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static String changeDateFormat(String dt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of integers and only returns the odd ones.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l, (long)13l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)13l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long toggleMiddleBits(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long countCharPosition(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given array lists, selecting one factor from each array list.\n    public static ArrayList<Long> largeProduct(ArrayList<Long> nums1, ArrayList<Long> nums2, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l, (long)45l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given array list of array lists.\n    public static long cummulativeSum(ArrayList<ArrayList<Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))))) == (30l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))))) == (37l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l)))))) == (44l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum difference between any two elements in a given array array list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long findMinDiff(ArrayList<Long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)19l, (long)18l, (long)25l))), (6l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)6l))), (4l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)30l, (long)5l, (long)20l, (long)9l))), (4l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static boolean textStartaEndb(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long leftRotate(long n, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first repeated character in a given string.\n    public static Optional<String> firstRepeatedChar(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Optional.of(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(Optional.empty()));\n    assert(firstRepeatedChar((\"123123\")).equals(Optional.of(\"1\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count inversions in an array array list.\n    public static long getInvCount(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)6l, (long)4l, (long)5l)))) == (5l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (1l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)6l, (long)1l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long evenPowerSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether all the given array lists have equal length or not.\n    public static boolean getEqual(ArrayList<ArrayList<Long>> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)22l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)44l, (long)55l, (long)66l)))))) == (true));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l)))))) == (false));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static boolean checkInteger(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string array list. https://www.geeksforgeeks.org/javathon-program-to-count-the-pairs-of-reverse-strings/\n    public static long countReversePairs(ArrayList<String> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"julia\", (String)\"best\", (String)\"tseb\", (String)\"for\", (String)\"ailuj\")))) == (2l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"geeks\", (String)\"best\", (String)\"for\", (String)\"skeeg\")))) == (1l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"makes\", (String)\"best\", (String)\"sekam\", (String)\"for\", (String)\"rof\")))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to move all zeroes to the end of the given array list.\n    public static ArrayList<Long> moveZero(ArrayList<Long> num_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)0l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)0l, (long)0l, (long)4l, (long)0l, (long)5l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)4l, (long)5l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)1l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)0l, (long)0l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if given array list contains no duplicates.\n    public static boolean checkDistinct(ArrayList<Long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l, (long)1l, (long)4l)))) == (false));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static boolean noprofitNoloss(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static String removeLength(String test_str, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count number of digits in a given string.\n    public static long numberCtr(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long countCharac(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long getTotalNumberOfSequences(long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/javathon-exercises/data-structures-and-algorithms/javathon-data-structure-exercise-24.php\n    public static long leftInsertion(ArrayList<Long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two numbers and returns an array array list with the second number and then the first number.\n    public static ArrayList<Long> swapNumbers(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapNumbers((10l), (20l)).equals((new ArrayList<Long>(Arrays.asList((long)20l, (long)10l)))));\n    assert(swapNumbers((15l), (17l)).equals((new ArrayList<Long>(Arrays.asList((long)17l, (long)15l)))));\n    assert(swapNumbers((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)200l, (long)100l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a sorted array array list, its length (n), and an element and returns whether the element is the majority element in the given sorted array array list. (The majority element is the element that occurs more than n/2 times.)\n    public static boolean isMajority(ArrayList<Long> arr, long n, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)3l, (long)10l))), (7l), (3l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)4l, (long)4l, (long)4l, (long)6l, (long)6l))), (8l), (4l)) == (false));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two pairs and subtracts the elements of the first pair by the elements of the second pair with the same index.\n    public static Pair<Long, Long, Long> substractElements(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(substractElements((Pair.with(10l, 4l, 5l)), (Pair.with(2l, 5l, 18l))).equals((Pair.with(8l, -1l, -13l))));\n    assert(substractElements((Pair.with(11l, 2l, 3l)), (Pair.with(24l, 45l, 16l))).equals((Pair.with(-13l, -43l, -13l))));\n    assert(substractElements((Pair.with(7l, 18l, 9l)), (Pair.with(10l, 11l, 12l))).equals((Pair.with(-3l, 7l, -3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static String capitalWordsSpaces(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the average of cubes of first n natural numbers.\n    public static float findAverageOfCube(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == (float)12l);\n    assert(findAverageOfCube((1l)) == (float)1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all values are same in a hash map.\n    public static boolean checkValue(HashMap<String,Long> dict, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (10l)) == (false));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (12l)) == (true));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (5l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long tetrahedralNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static boolean magicSquareTest(ArrayList<ArrayList<Long>> my_matrix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)12l, (long)1l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)8l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)3l, (long)10l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)6l, (long)15l, (long)4l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)8l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)7l)))))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static String removeUppercase(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long dogAge(long h_age) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the next perfect square greater than a given number.\n    public static long nextPerfectSquare(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create an array array list of N empty dictionaries.\n    public static ArrayList<HashMap<Optional.empty(),Optional.empty()>> emptyList(long length) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(emptyList((5l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((6l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((7l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert a given string to uppercase.\n    public static String isUpper(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long oddEquivalent(String s, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer n, and re-arranges the first n elements of the given array array list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static ArrayList<Long> reArrangeArray(ArrayList<Long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-3l, (long)4l, (long)5l, (long)6l, (long)-7l, (long)8l, (long)9l))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-7l, (long)4l, (long)5l, (long)6l, (long)2l, (long)8l, (long)9l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)12l, (long)-14l, (long)-26l, (long)13l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)-14l, (long)-26l, (long)12l, (long)13l, (long)15l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)10l, (long)24l, (long)36l, (long)-42l, (long)-39l, (long)-78l, (long)85l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-42l, (long)-39l, (long)-78l, (long)10l, (long)24l, (long)36l, (long)85l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether an array array list of numbers contains only one distinct element or not.\n    public static boolean uniqueElement(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))) == (true));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static ArrayList<String> extractValues(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"PHP\", (String)\"Java\")))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\")))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\", (String)\"yellow\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count true booleans in the given array list.\n    public static long count(ArrayList<Boolean> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)false, (boolean)true)))) == (2l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)false, (boolean)false)))) == (0l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)true, (boolean)true)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in an array array list that xor to an even number.\n    public static long findEvenPair(ArrayList<Long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l)))) == (4l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l)))) == (9l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static boolean armstrongNumber(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the upper case characters in a given string.\n    public static long upperCtr(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the elementwise and pairs from the given two pairs.\n    public static Pair<Long, Long, Long, Long> andTuples(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(andTuples((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(0l, 0l, 2l, 1l))));\n    assert(andTuples((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(5l, 6l, 7l, 8l))).equals((Pair.with(1l, 2l, 3l, 0l))));\n    assert(andTuples((Pair.with(8l, 9l, 11l, 12l)), (Pair.with(7l, 13l, 14l, 17l))).equals((Pair.with(0l, 9l, 10l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array array list.\n    public static boolean isSamepatterns(ArrayList<String> colors, ArrayList<String> patterns) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"green\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (true));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (false));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of array lists in a given number of array lists.\n    public static long countList(ArrayList<ArrayList<Long>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))) == (4l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))) == (3l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)0l)))))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes an array array lists of array lists and returns the average value for each subarray list as an array array list.\n    public static ArrayList<Float> averageTuple(ArrayList<ArrayList<Long>> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)45l, (long)56l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)80l, (long)39l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))).equals((new ArrayList<Float>(Arrays.asList((float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)-15l, (long)56l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)-60l, (long)-39l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-10l, (long)2l, (long)3l)))))).equals((new ArrayList<Float>(Arrays.asList((float)25.5f, (float)-18.0f, (float)3.75f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)100l, (long)100l, (long)100l, (long)120l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)300l, (long)450l, (long)560l, (long)450l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)810l, (long)800l, (long)390l, (long)320l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new ArrayList<Float>(Arrays.asList((float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long lcsOfThree(String X, String Y, String Z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long findStarNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of an array array list.\n    public static long Sum(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)15l, (long)12l, (long)13l, (long)10l)))) == (50l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given array list contains consecutive numbers or not.\n    public static boolean checkConsecutive(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)6l)))) == (false));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Pair<Long, Long, String> findAdverbPosition(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals((Pair.with(0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals((Pair.with(0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals((Pair.with(0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to rotate a given array list by specified number of items to the right direction. https://www.geeksforgeeks.org/javathon-program-right-rotate-array list-n/\n    public static ArrayList<Long> rotateRight(ArrayList<Long> list, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of non-empty substrings of a given string.\n    public static long numberOfSubstrings(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer n and splits an array array list for every nth element, returning an array array list of the resulting array lists.\n    public static ArrayList<ArrayList<Object>> listSplit(ArrayList<Object> S, long step) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"e\", (String)\"f\", (String)\"g\", (String)\"h\", (String)\"i\", (String)\"j\", (String)\"k\", (String)\"l\", (String)\"m\", (String)\"n\"))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"d\", (String)\"g\", (String)\"j\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"e\", (String)\"h\", (String)\"k\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"f\", (String)\"i\", (String)\"l\")))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l, (long)12l, (long)13l, (long)14l))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)10l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)8l, (long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)12l)))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"python\", (String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\", (String)\"SQL\"))), (2l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"C\", (String)\"DBMS\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C++\", (String)\"SQL\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check if the elements of a given array list are unique or not.\n    public static boolean allUnique(ArrayList<Long> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert complex numbers to polar coordinates.\n    public static Pair<Float, Float> convert(long numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(convert((1l)).equals((Pair.with(1.0f, 0.0f))));\n    assert(convert((4l)).equals((Pair.with(4.0f, 0.0f))));\n    assert(convert((5l)).equals((Pair.with(5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is given as - a hash map with a student name as a key and a pair of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static HashMap<String,Pair<Float, Long>> filterData(HashMap<String,Pair<Float, Long>> students, float h, long w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (6.0f), (70l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.9f), (67l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Kierra Gentry\", Pair.with(6.0f, 68l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.7f), (64l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert the given string to lower case.\n    public static String isLower(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the smallest power of 2 greater than or equal to n.\n    public static long nextPowerOf2(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given array list of string values.\n    public static boolean findSubstring(ArrayList<String> str1, String sub_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ack\")) == (true));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"abc\")) == (false));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static String replaceChar(String str1, String ch, String newch) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given array list.\n    public static long mulEvenOdd(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (4l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert an array array list to a pair.\n    public static Object listTuple(ArrayList<Long> listx) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)10l, (long)7l, (long)4l, (long)15l, (long)3l)))).equals(Pair.with(5l, 10l, 7l, 4l, 15l, 3l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)2l, (long)3l, (long)4l, (long)4l, (long)7l)))).equals(Pair.with(2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)58l, (long)44l, (long)56l)))).equals(Pair.with(58l, 44l, 56l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long evenBinomialCoeffSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given pairs.\n    public static Pair<Long, Long, Long, Long> bitwiseXor(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bitwiseXor((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(15l, 6l, 5l, 10l))));\n    assert(bitwiseXor((Pair.with(11l, 5l, 7l, 10l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(13l, 6l, 3l, 14l))));\n    assert(bitwiseXor((Pair.with(12l, 6l, 8l, 11l)), (Pair.with(7l, 4l, 5l, 6l))).equals((Pair.with(11l, 2l, 13l, 13l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether an array array list is subarray list of another or not.\n    public static boolean isSubArray(ArrayList<Long> A, ArrayList<Long> B) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (false));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (true));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array array list in the modified array array list which is formed by repeating the given array array list k times.\n    public static long maxSubArraySumRepeated(ArrayList<Long> a, long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)-30l, (long)-1l))), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)10l, (long)20l))), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))), (3l), (3l)) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of pairs within a given array list.\n    public static long minProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (8l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (30l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the count of divisors is even. https://www.w3resource.com/javathon-exercises/basic/javathon-basic-1-exercise-24.php\n    public static boolean countDivisors(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Optional<Long> triangleArea(long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((-1l)).equals(Optional.empty()));\n    assert(triangleArea((0l)).equals(Optional.of(0l)));\n    assert(triangleArea((2l)).equals(Optional.of(4l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given string to an array array list of characters.\n    public static ArrayList<String> stringToTuple(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToTuple((\"python 3.0\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\", (String)\"3\", (String)\".\", (String)\"0\")))));\n    assert(stringToTuple((\"item1\")).equals((new ArrayList<String>(Arrays.asList((String)\"i\", (String)\"t\", (String)\"e\", (String)\"m\", (String)\"1\")))));\n    assert(stringToTuple((\"15.10\")).equals((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"5\", (String)\".\", (String)\"1\", (String)\"0\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long findLength(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long countPrimesNums(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the product of consecutive binomial co-efficients.\n    public static long sumOfProduct(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the array list of pairs.\n    public static Pair<String, Long> maxAggregate(ArrayList<Pair<String, Long>> stdata) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 90l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 88l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 7l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 122l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 84l))))).equals((Pair.with(\"Juan Whelan\", 212l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 50l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 48l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 37l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 22l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 14l))))).equals((Pair.with(\"Juan Whelan\", 72l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 10l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 20l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 30l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 40l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 50l))))).equals((Pair.with(\"Sabah Colley\", 70l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of elements.\n    public static ArrayList<Long> combSort(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)37l, (long)25l, (long)79l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)25l, (long)37l, (long)79l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)32l, (long)15l, (long)19l, (long)22l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)19l, (long)22l, (long)32l, (long)41l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)99l, (long)15l, (long)13l, (long)47l)))).equals((new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)47l, (long)99l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static boolean checkExpression(String exp) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static boolean textMatchWordz(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function takes as input two array lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static ArrayList<Long> sumList(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)25l, (long)45l, (long)65l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)45l, (long)75l)))).equals((new ArrayList<Long>(Arrays.asList((long)30l, (long)65l, (long)105l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long newmanPrime(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in an array array list.\n    public static ArrayList<String> addString(ArrayList<Object> list_, String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (\"temp{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"temp1\", (String)\"temp2\", (String)\"temp3\", (String)\"temp4\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (\"python{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"pythona\", (String)\"pythonb\", (String)\"pythonc\", (String)\"pythond\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l))), (\"string{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"string5\", (String)\"string6\", (String)\"string7\", (String)\"string8\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the surface area of a square javaramid with a given base edge and height.\n    public static long surfaceArea(long b, long s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the smallest array list in an array array list of array lists.\n    public static long FindMinLength(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))) == (1l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))) == (2l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static boolean validate(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long hexagonalNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long findLucas(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to get the difference between two array lists.\n    public static ArrayList<Long> Diff(ArrayList<Long> li1, ArrayList<Long> li2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l, (long)30l, (long)35l, (long)40l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)40l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)15l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static ArrayList<Object> extractQuotation(String text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"A53\", (String)\"multi\", (String)\"Processor\")))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"favorite\", (String)\"apps\")))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((new ArrayList<Object>(Arrays.asList((String)\"4k Ultra HD\", (String)\"HDR 10\")))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the two numbers differ at one bit position only or not.\n    public static boolean differAtOneBitPos(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static boolean textMatchThree(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array array list.\n    public static long maxProduct(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)100l, (long)4l, (long)5l, (long)150l, (long)6l)))) == (3000l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)4l, (long)42l, (long)55l, (long)68l, (long)80l)))) == (50265600l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)22l, (long)9l, (long)33l, (long)21l, (long)50l, (long)41l, (long)60l)))) == (2460l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to split an array array list at the nth eelment and add the first part to the end.\n    public static ArrayList<Long> splitArr(ArrayList<Long> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)5l, (long)6l, (long)52l, (long)36l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)52l, (long)36l, (long)12l, (long)10l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)0l, (long)1l, (long)2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the number of divisors of a given integer.\n    public static long divisor(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the difference between largest and smallest value in a given array list.\n    public static long bigDiff(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)12l)))) == (8l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)3l)))) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find squares of individual elements in an array array list.\n    public static ArrayList<Long> squareNums(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)400l, (long)900l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)144l, (long)225l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given pair has any none value or not.\n    public static boolean checkNone(Object test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkNone(Pair.with(Optional.of(10l), Optional.of(4l), Optional.of(5l), Optional.of(6l), Optional.of(Optional.empty()))) == (true));\n    assert(checkNone(Pair.with(7l, 8l, 9l, 11l, 14l)) == (false));\n    assert(checkNone(Pair.with(Optional.of(1l), Optional.of(2l), Optional.of(3l), Optional.of(4l), Optional.of(Optional.empty()))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given array array list is monotonic or not.\n    public static boolean isMonotonic(ArrayList<Long> A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)4l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static boolean isPerfectSquare(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of common divisors of two given numbers.\n    public static long sum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the array list of maximum length in an array array list of array lists.\n    public static Pair<Long, ArrayList<Long>> maxLength(ArrayList<ArrayList<Long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list of pairs and returns a hash map mapping each unique pair to the number of times it occurs in the array list.\n    public static HashMap<Pair<Long, Long>,Long> checkOccurences(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(5l, 2l), (Pair<Long, Long>)Pair.with(6l, 3l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(1l, 3l), 2l, Pair.with(2l, 5l), 2l, Pair.with(3l, 6l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 2l), (Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(3l, 6l), (Pair<Long, Long>)Pair.with(6l, 3l), (Pair<Long, Long>)Pair.with(7l, 4l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 4l), 2l, Pair.with(3l, 6l), 2l, Pair.with(4l, 7l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(13l, 2l), (Pair<Long, Long>)Pair.with(11l, 23l), (Pair<Long, Long>)Pair.with(12l, 25l), (Pair<Long, Long>)Pair.with(25l, 12l), (Pair<Long, Long>)Pair.with(16l, 23l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 13l), 1l, Pair.with(11l, 23l), 1l, Pair.with(12l, 25l), 2l, Pair.with(16l, 23l), 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long parabolaDirectrix(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n    public static Optional<Pair<String, Long, Long>> occuranceSubstring(String text, String pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Optional.of(Pair.with(\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Optional.of(Pair.with(\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Optional.of(Pair.with(\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(Optional.empty()));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove pairs from the given pair.\n    public static Pair<Long, Long, Long, Long> removeNested(Object test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeNested(Pair.with(1l, 5l, 7l, Pair.with(4l, 6l), 10l)).equals((Pair.with(1l, 5l, 7l, 10l))));\n    assert(removeNested(Pair.with(2l, 6l, 8l, Pair.with(5l, 7l), 11l)).equals((Pair.with(2l, 6l, 8l, 11l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), Pair.with(5l, 12l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each subarray list of strings in a given array list of array lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"blue \", (String)\" black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" black\", (String)\"blue \")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"zilver\", (String)\"gold\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"magnesium\", (String)\"aluminium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"steel\", (String)\"bronze\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"gold\", (String)\"zilver\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"aluminium\", (String)\"magnesium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"bronze\", (String)\"steel\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list and returns an array array list with the same elements, but the k'th element removed.\n    public static ArrayList<Long> removeKthElement(ArrayList<Long> list1, long L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add a hash map to the pair. The output should be a pair.\n    public static Pair<Long, Long, Long, HashMap<String,Long>> addDictToTuple(Pair<Long, Long, Long> test_tup, HashMap<String,Long> test_dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addDictToTuple((Pair.with(4l, 5l, 6l)), (new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l)))).equals((Pair.with(4l, 5l, 6l, new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l))))));\n    assert(addDictToTuple((Pair.with(1l, 2l, 3l)), (new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l)))).equals((Pair.with(1l, 2l, 3l, new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l))))));\n    assert(addDictToTuple((Pair.with(8l, 9l, 10l)), (new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l)))).equals((Pair.with(8l, 9l, 10l, new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long find(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static boolean textMatchTwoThree(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the occurence of all elements of array list in a pair.\n    public static long countOccurrence(Object tup, ArrayList<Object> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurrence(Pair.with(\"a\", \"a\", \"c\", \"b\", \"d\"), (new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\")))) == (3l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)4l, (long)7l)))) == (6l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 4l, 5l, 6l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)2l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given array lists.\n    public static long countSamepair(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (3l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (4l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static boolean textMatchOne(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long difference(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static String toggleString(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the element of an array array list having maximum length.\n    public static ArrayList<Object> FindMax(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long eulerianNum(long n, long m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given array list.\n    public static long frequency(ArrayList<Long> a, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l)) == (0l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l))), (3l)) == (3l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)1l, (long)2l))), (1l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given array list of strings of numbers numerically. https://www.geeksforgeeks.org/javathon-sort-numeric-strings-in-a-array list/\n    public static ArrayList<Long> sortNumericStrings(ArrayList<String> nums_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"4\", (String)\"12\", (String)\"45\", (String)\"7\", (String)\"0\", (String)\"100\", (String)\"200\", (String)\"-12\", (String)\"-500\")))).equals((new ArrayList<Long>(Arrays.asList((long)-500l, (long)-12l, (long)0l, (long)4l, (long)7l, (long)12l, (long)45l, (long)100l, (long)200l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"2\", (String)\"3\", (String)\"8\", (String)\"4\", (String)\"7\", (String)\"9\", (String)\"8\", (String)\"2\", (String)\"6\", (String)\"5\", (String)\"1\", (String)\"6\", (String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"6\", (String)\"9\", (String)\"1\", (String)\"2\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)8l, (long)9l, (long)9l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"3\", (String)\"5\", (String)\"7\", (String)\"1\", (String)\"3\", (String)\"13\", (String)\"15\", (String)\"17\", (String)\"5\", (String)\"7 \", (String)\"9\", (String)\"1\", (String)\"11\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)3l, (long)3l, (long)5l, (long)5l, (long)7l, (long)7l, (long)9l, (long)11l, (long)13l, (long)15l, (long)17l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/javathon-exercises/data-structures-and-algorithms/javathon-recursion-exercise-9.php\n    public static float geometricSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/javathon-exercises/lambda/javathon-lambda-exercise-24.php\n    public static ArrayList<Long> divisibleByDigits(long startnum, long endnum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisibleByDigits((1l), (22l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l, (long)22l)))));\n    assert(divisibleByDigits((1l), (15l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l)))));\n    assert(divisibleByDigits((20l), (25l)).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to calculate the product of the unique numbers in a given array list.\n    public static long uniqueProduct(ArrayList<Long> list_data) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)20l, (long)50l, (long)60l, (long)40l)))) == (720000000l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l)))) == (6l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)0l, (long)1l, (long)1l)))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the largest negative number from the given array list.\n    public static long largestNeg(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-4l, (long)-6l)))) == (-6l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-8l, (long)-9l)))) == (-9l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given array list.\n    public static ArrayList<Object> consecutiveDuplicates(ArrayList<Object> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<Object>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\")))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\", (String)\"a\", (String)\"a\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"a\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float minJumps(Pair<Long, Long> steps, long d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minJumps((Pair.with(3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps((Pair.with(3l, 4l)), (0l)) == (float)0l);\n    assert(minJumps((Pair.with(11l, 14l)), (11l)) == (float)1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find a pair with highest product from a given array array list of integers.\n    public static Pair<Long, Long> maxProduct(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)0l, (long)8l, (long)4l)))).equals((Pair.with(7l, 8l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)0l, (long)-1l, (long)-2l, (long)-4l, (long)5l, (long)0l, (long)-6l)))).equals((Pair.with(-4l, -6l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((Pair.with(2l, 3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the nth element from a given array list of pairs.\n    public static ArrayList<Object> extractNthElement(ArrayList<Pair<String, Long, Long>> list1, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (0l)).equals((new ArrayList<Object>(Arrays.asList((String)\"Greyson Fulton\", (String)\"Brady Kent\", (String)\"Wyatt Knott\", (String)\"Beau Turnbull\")))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (2l)).equals((new ArrayList<Object>(Arrays.asList((long)99l, (long)96l, (long)94l, (long)98l)))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (1l)).equals((new ArrayList<Object>(Arrays.asList((long)98l, (long)97l, (long)91l, (long)94l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long isNonagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the maximum difference between any two elements in a given array array list.\n    public static long maxAbsDiff(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)3l)))) == (4l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)2l, (long)5l, (long)1l)))) == (8l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given array list elements into subarray lists.\n    public static ArrayList<ArrayList<Object>> packConsecutiveDuplicates(ArrayList<Object> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)19l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)26l, (long)26l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"a\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"d\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long calSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove the characters which have odd index values of a given string.\n    public static String oddValuesString(String str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find kth element from the given two sorted array array lists.\n    public static long findKth(ArrayList<Long> arr1, ArrayList<Long> arr2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)8l, (long)10l))), (5l)) == (6l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)100l, (long)112l, (long)256l, (long)349l, (long)770l))), (new ArrayList<Long>(Arrays.asList((long)72l, (long)86l, (long)113l, (long)119l, (long)265l, (long)445l, (long)892l))), (7l)) == (256l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)7l, (long)8l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)9l, (long)11l))), (6l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long jacobsthalNum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened array list of array lists, returned in a hash map.\n    public static HashMap<Long,Long> frequencyLists(ArrayList<ArrayList<Long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)5l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 3l, 3l, 1l, 4l, 1l, 5l, 2l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 1l, 3l, 1l, 4l, 1l, 5l, 1l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l, 10l, 1l, 11l, 1l, 12l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)30l, (long)40l, (long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)16l, (long)14l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new HashMap<Long,Long>(Map.of(20l, 2l, 30l, 2l, 40l, 2l, 17l, 1l, 18l, 1l, 16l, 1l, 14l, 1l, 13l, 1l, 10l, 1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static ArrayList<Long> perfectSquares(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(perfectSquares((1l), (30l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l)))));\n    assert(perfectSquares((50l), (100l)).equals((new ArrayList<Long>(Arrays.asList((long)64l, (long)81l, (long)100l)))));\n    assert(perfectSquares((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)121l, (long)144l, (long)169l, (long)196l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find sum of products of all possible subarray lists of a given array list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarray array lists/\n    public static long sumOfSubarrayProd(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (20l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (5l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first odd number in a given array list of numbers.\n    public static long firstOdd(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)1l)))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise addition of array list elements in the given two nested array lists.\n    public static ArrayList<ArrayList<Long>> addNestedTuples(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)13l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)16l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)15l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)17l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of array lists, where each subarray list has two elements, and returns an array array list of two array lists where the first array list has the first element of each subarray list and the second one has the second.\n    public static ArrayList<ArrayList<Object>> merge(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\", (String)\"o\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"z\", (String)\"c\", (String)\"o\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number can be represented as the difference of two squares or not.\n    public static boolean difSquare(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if each element of second pair is smaller than its corresponding element in the first pair.\n    public static boolean checkSmaller(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkSmaller((Pair.with(1l, 2l, 3l)), (Pair.with(2l, 3l, 4l))) == (false));\n    assert(checkSmaller((Pair.with(4l, 5l, 6l)), (Pair.with(3l, 4l, 5l))) == (true));\n    assert(checkSmaller((Pair.with(11l, 12l, 13l)), (Pair.with(10l, 11l, 12l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the frequency of all the elements in an array array list, returned as a hash map.\n    public static HashMap<Long,Long> freqCount(ArrayList<Long> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)10l, (long)20l, (long)20l, (long)20l, (long)20l, (long)40l, (long)40l, (long)50l, (long)50l, (long)30l)))).equals((new HashMap<Long,Long>(Map.of(10l, 4l, 20l, 4l, 40l, 2l, 50l, 2l, 30l, 1l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)4l, (long)1l, (long)3l, (long)1l, (long)4l)))).equals((new HashMap<Long,Long>(Map.of(1l, 3l, 2l, 2l, 3l, 3l, 4l, 3l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)4l, (long)9l, (long)10l, (long)4l, (long)5l, (long)6l, (long)7l, (long)9l, (long)5l)))).equals((new HashMap<Long,Long>(Map.of(10l, 1l, 5l, 3l, 6l, 2l, 7l, 2l, 4l, 2l, 9l, 2l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static ArrayList<Float> rgbToHsv(long r, long g, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.0f, (float)100.0f)))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((new ArrayList<Float>(Arrays.asList((float)120.0f, (float)100.0f, (float)84.31372549019608f)))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((new ArrayList<Float>(Arrays.asList((float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static boolean checkStr(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static boolean checkMonthnumberNumber(long monthnum3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array list.\n    public static ArrayList<Long> heapSort(ArrayList<Long> iterable) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l)))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)22l, (long)25l, (long)25l, (long)35l, (long)58l, (long)65l, (long)75l, (long)85l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)7l, (long)1l, (long)9l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array array list and one element from the second array array list.\n    public static ArrayList<ArrayList<Long>> kSmallestPairs(ArrayList<Long> nums1, ArrayList<Long> nums2, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (7l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)2l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a pair, or return null if no solution exists.\n    public static Optional<Pair<Long, Long>> findSolution(long a, long b, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSolution((2l), (3l), (7l)).equals(Optional.of(Pair.with(2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(Optional.empty()));\n    assert(findSolution((1l), (13l), (17l)).equals(Optional.of(Pair.with(4l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the largest number that can be formed with the given array list of digits.\n    public static long findMaxNum(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (321l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)1l)))) == (6541l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)9l)))) == (9321l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the array list in an array array list of array lists whose sum of elements is the highest.\n    public static ArrayList<Long> maxSumList(ArrayList<ArrayList<Long>> lists) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to interchange the first and last elements in an array array list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)12l, (long)35l, (long)9l, (long)56l, (long)24l)))).equals((new ArrayList<Long>(Arrays.asList((long)24l, (long)35l, (long)9l, (long)56l, (long)12l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of two sorted array lists of same size.\n    public static float getMedian(ArrayList<Long> arr1, ArrayList<Long> arr2, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)1l, (long)12l, (long)15l, (long)26l, (long)38l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)17l, (long)30l, (long)45l))), (5l)) == (16.0f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)13l, (long)19l, (long)28l))), (4l)) == (8.5f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)14l, (long)23l, (long)36l, (long)42l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)18l, (long)27l, (long)39l, (long)49l, (long)55l))), (6l)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static String replaceSpaces(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static boolean areEquivalent(long num1, long num2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse each string in a given array list of string values.\n    public static ArrayList<String> reverseStringList(ArrayList<String> stringlist) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\", (String)\"White\", (String)\"Black\")))).equals((new ArrayList<String>(Arrays.asList((String)\"deR\", (String)\"neerG\", (String)\"eulB\", (String)\"etihW\", (String)\"kcalB\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"john\", (String)\"amal\", (String)\"joel\", (String)\"george\")))).equals((new ArrayList<String>(Arrays.asList((String)\"nhoj\", (String)\"lama\", (String)\"leoj\", (String)\"egroeg\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"jack\", (String)\"john\", (String)\"mary\")))).equals((new ArrayList<String>(Arrays.asList((String)\"kcaj\", (String)\"nhoj\", (String)\"yram\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given array list.\n    public static long sumOfDigits(ArrayList<Object> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)2l, (long)56l)))) == (14l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Object>(Arrays.asList(10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))))) == (19l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)20l, (long)-4l, (long)5l, (long)-70l)))) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long sequence(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n largest integers from a given array list of numbers, returned in descending order.\n    public static ArrayList<Long> heapQueueLargest(ArrayList<Long> nums, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l, (long)58l, (long)35l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long lossAmount(long actual_cost, long sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the union of the elements of two given array lists and output them in sorted order.\n    public static ArrayList<Long> unionElements(ArrayList<Long> test_tup1, ArrayList<Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)4l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)10l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l))), (new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)16l, (long)17l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l, (long)15l, (long)16l, (long)17l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the longest subarray lists.\n    public static long FindMaxLength(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (4l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))))) == (3l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)22l, (long)23l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l)))))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static String removeParenthesis(ArrayList<String> items) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"python (chrome)\")))).equals((\"python\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"string(.abc)\")))).equals((\"string\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"alpha(num)\")))).equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find whether the parity of a given number is odd.\n    public static boolean findParity(long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float medianTrapezium(long base1, long base2, long height) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianTrapezium((15l), (25l), (35l)) == (float)20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == (float)15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long centeredHexagonalNumber(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find number of array lists present in the given array list.\n    public static long findLists(ArrayList<Object> Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (2l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))) == (3l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long getMaxSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the longest word.\n    public static long lenLog(ArrayList<String> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"PHP\", (String)\"bigdata\")))) == (7l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))) == (3l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"small\", (String)\"big\", (String)\"tall\")))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n    public static Optional<Float> sectorArea(long r, long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sectorArea((4l), (45l)).equals(Optional.of(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Optional.of(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(Optional.empty()));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether every odd index contains odd numbers of a given array list.\n    public static boolean oddPosition(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l, (long)6l, (long)7l, (long)6l, (long)3l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to join an array array list of multiple integers into a single integer.\n    public static long multipleToSingle(ArrayList<Long> L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)11l, (long)33l, (long)50l)))) == (113350l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (-123456l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l)))) == (10152025l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find whether a number is divisible by 11.\n    public static boolean isDiff(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise multiplication of array list elements in the given two array lists.\n    public static ArrayList<ArrayList<Long>> indexMultiplication(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)21l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)30l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)14l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)60l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)20l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)44l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)24l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)77l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)27l, (long)60l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert pair string to integer pair.\n    public static Pair<Long, Long, Long> tupleStrInt(String test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals((Pair.with(7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals((Pair.with(1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals((Pair.with(4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals((Pair.with(7l, 81l, 19l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long amicableNumbersSum(long limit) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static String removeOdd(String str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes as input an array array list of numbers (t_1,...,t_{N+1}) and returns an array array list of length N where the i-th element of the pair is equal to t_i * t_{i+1}.\n    public static ArrayList<Object> multiplyElements(ArrayList<Long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)8l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)5l, (long)35l, (long)56l, (long)80l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)8l, (long)20l, (long)30l, (long)42l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)14l, (long)9l, (long)15l)))).equals((new ArrayList<Object>(Arrays.asList((long)156l, (long)182l, (long)126l, (long)135l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of rotations required to generate a sorted array array list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array array list/\n    public static long countRotation(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (1l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)1l, (long)2l, (long)3l)))) == (2l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (0l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the number of unique pairs in the given array list.\n    public static long extractFreq(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(5l, 6l))))) == (3l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 15l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l))))) == (4l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 16l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 9l))))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is defined as two array lists of the same length. Write a function to count indices where the array lists have the same values.\n    public static long countSamePair(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (4l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (11l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (1l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)2l)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long power(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write function to find the sum of all items in the given hash map.\n    public static long returnSum(HashMap<String,Long> dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 100l, \"b\", 200l, \"c\", 300l)))) == (600l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 25l, \"b\", 18l, \"c\", 45l)))) == (88l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 36l, \"b\", 39l, \"c\", 49l)))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return an array array list of all pairs of consecutive items in a given array list.\n    public static ArrayList<Pair<Long, Long>> pairWise(ArrayList<Long> l1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 5l), (Pair<Long, Long>)Pair.with(5l, 7l), (Pair<Long, Long>)Pair.with(7l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)9l, (long)7l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(1l, 9l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(7l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l), (Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to split a string into characters.\n    public static ArrayList<String> split(String word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(split((\"python\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))));\n    assert(split((\"Name\")).equals((new ArrayList<String>(Arrays.asList((String)\"N\", (String)\"a\", (String)\"m\", (String)\"e\")))));\n    assert(split((\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long minOfThree(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static boolean isSumOfPowersOfTwo(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static String getChar(String strr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long sumDiv(long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove duplicate numbers from a given number of array lists.\n    public static ArrayList<Long> twoUniqueNums(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether a given array array list of integers contains any duplicate element.\n    public static boolean testDuplicate(ArrayList<Long> arraynums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))) == (true));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long catalanNumber(long num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long powerBaseSum(long base, long power) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two array lists and replaces the last element of the first array list with the elements of the second array list.\n    public static ArrayList<Object> replaceList(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l))), (new ArrayList<Object>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\"))), (new ArrayList<Object>(Arrays.asList((String)\"yellow\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"yellow\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long isOctagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static String replaceBlank(String str1, String char) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static String replaceSpecialchar(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given pair of positive integers into a single integer.\n    public static long tupleToInt(Pair<Long, Long, Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToInt((Pair.with(1l, 2l, 3l))) == (123l));\n    assert(tupleToInt((Pair.with(4l, 5l, 6l))) == (456l));\n    assert(tupleToInt((Pair.with(5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float othersideRightangle(long w, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == (float)5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the per-digit difference between two integers.\n    public static long digitDistanceNums(long n1, long n2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static boolean textMatchWordzMiddle(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static String removezeroIp(String ip) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of subarray lists containing a particular element.\n    public static long countElementInList(ArrayList<ArrayList<Object>> list1, Object x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)7l))))), (Object(1l))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"A\"))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"E\"))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long multiplyInt(long x, long y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given pair.\n    public static Pair<Long, Long, Long, Long> addPairwise(Pair<Long, Long, Long, Long, Long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addPairwise((Pair.with(1l, 5l, 7l, 8l, 10l))).equals((Pair.with(6l, 12l, 15l, 18l))));\n    assert(addPairwise((Pair.with(2l, 6l, 8l, 9l, 11l))).equals((Pair.with(8l, 14l, 17l, 20l))));\n    assert(addPairwise((Pair.with(3l, 7l, 9l, 10l, 12l))).equals((Pair.with(10l, 16l, 19l, 22l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of pairs within a given array list.\n    public static long maxProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (36l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (200l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3448,7 +16,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the kth element in the given array array list using 1-based indexing.\n    public static long kthElement(ArrayList<Long> arr, long k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)12l, (long)3l, (long)5l, (long)7l, (long)19l))), (2l)) == (3l));\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)17l, (long)24l, (long)8l, (long)23l))), (3l)) == (8l));\n    assert(kthElement((new ArrayList<Long>(Arrays.asList((long)16l, (long)21l, (long)25l, (long)36l, (long)4l))), (4l)) == (36l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3456,265 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to interchange the first and last element in a given array list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long rightInsertion(ArrayList<Long> a, long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    public static long eulerianNum(long n, long m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static boolean isWoodall(long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each subarray list of strings in a given array list of array lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> input_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"blue \", (String)\" black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" red \", (String)\"green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" black\", (String)\"blue \")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\" orange\", (String)\"brown\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"zilver\", (String)\"gold\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"magnesium\", (String)\"aluminium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"steel\", (String)\"bronze\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"gold\", (String)\"zilver\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"aluminium\", (String)\"magnesium\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"bronze\", (String)\"steel\")))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array array list by using shell sort.\n    public static ArrayList<Long> shellSort(ArrayList<Long> my_list) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count true booleans in the given array list.\n    public static long count(ArrayList<Boolean> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)4l, (long)5l, (long)3l, (long)2l, (long)12l, (long)81l, (long)56l, (long)95l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)12l, (long)12l, (long)23l, (long)56l, (long)81l, (long)95l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)24l, (long)22l, (long)39l, (long)34l, (long)87l, (long)73l, (long)68l)))).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l, (long)34l, (long)39l, (long)68l, (long)73l, (long)87l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)32l, (long)30l, (long)16l, (long)96l, (long)82l, (long)83l, (long)74l)))).equals((new ArrayList<Long>(Arrays.asList((long)16l, (long)30l, (long)32l, (long)74l, (long)82l, (long)83l, (long)96l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)false, (boolean)true)))) == (2l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)false, (boolean)false)))) == (0l));\n    assert(count((new ArrayList<Boolean>(Arrays.asList((boolean)true, (boolean)true, (boolean)true)))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of pairs whose xor value is odd.\n    public static long findOddPair(ArrayList<Long> A, long N) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to append the given array list to the given pairs.\n    public static Pair<Long, Long, Long, Long, Long> addLists(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l))), (5l)) == (6l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l))), (7l)) == (12l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (3l)) == (2l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((Pair.with(9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((Pair.with(10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((Pair.with(11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of all odd natural numbers within the range l and r.\n    public static long sumInRange(long l, long r) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three array lists into a single sorted array list.\n    public static ArrayList<Long> mergeSortedList(ArrayList<Long> num1, ArrayList<Long> num2, ArrayList<Long> num3) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)25l, (long)24l, (long)15l, (long)4l, (long)5l, (long)29l, (long)110l))), (new ArrayList<Long>(Arrays.asList((long)19l, (long)20l, (long)11l, (long)56l, (long)25l, (long)233l, (long)154l))), (new ArrayList<Long>(Arrays.asList((long)24l, (long)26l, (long)54l, (long)48l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)11l, (long)15l, (long)19l, (long)20l, (long)24l, (long)24l, (long)25l, (long)25l, (long)26l, (long)29l, (long)48l, (long)54l, (long)56l, (long)110l, (long)154l, (long)233l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)6l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l, (long)11l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)8l, (long)12l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)5l, (long)6l, (long)7l, (long)7l, (long)8l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)18l, (long)14l, (long)10l, (long)9l, (long)8l, (long)7l, (long)9l, (long)3l, (long)2l, (long)4l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l))), (new ArrayList<Long>(Arrays.asList((long)12l, (long)74l, (long)9l, (long)50l, (long)61l, (long)41l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)8l, (long)9l, (long)9l, (long)9l, (long)10l, (long)12l, (long)14l, (long)14l, (long)18l, (long)22l, (long)25l, (long)25l, (long)35l, (long)41l, (long)50l, (long)58l, (long)61l, (long)65l, (long)74l, (long)75l, (long)85l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long squarePerimeter(long a) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    public static long oddEquivalent(String s, long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long isPolite(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string represents an integer or not.\n    public static boolean checkInteger(String text) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long sumSeries(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given pair of positive integers into a single integer.\n    public static long tupleToInt(Pair<Long, Long, Long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two pairs.\n    public static Pair<Long, Long, Long, Long> findDissimilar(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findDissimilar((Pair.with(3l, 4l, 5l, 6l)), (Pair.with(5l, 7l, 4l, 10l))).equals((Pair.with(3l, 6l, 7l, 10l))));\n    assert(findDissimilar((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(7l, 2l, 3l, 9l))).equals((Pair.with(1l, 4l, 7l, 9l))));\n    assert(findDissimilar((Pair.with(21l, 11l, 25l, 26l)), (Pair.with(26l, 34l, 21l, 36l))).equals((Pair.with(34l, 36l, 11l, 25l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return two words from an array array list of words starting with letter 'p'.\n    public static Pair<String, String> startWithp(ArrayList<String> words) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python PHP\", (String)\"Java JavaScript\", (String)\"c c++\")))).equals((Pair.with(\"Python\", \"PHP\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python Programming\", (String)\"Java Programming\")))).equals((Pair.with(\"Python\", \"Programming\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Pqrst Pqr\", (String)\"qrstuv\")))).equals((Pair.with(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long volumeCube(long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static boolean checkMonthnumbNumber(long monthnum2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether all the bits are unset in the given range or not.\n    public static boolean allBitsSetInTheGivenRange(long n, long l, long r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to get the first element of each subarray list.\n    public static ArrayList<Long> Extract(ArrayList<ArrayList<Long>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)6l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)1l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float surfaceareaCylinder(long r, long h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum the length of the names of a given array list of names after removing the names that start with a lowercase letter.\n    public static long sampleNam(ArrayList<String> sample_names) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"sally\", (String)\"Dylan\", (String)\"rebecca\", (String)\"Diana\", (String)\"Joanne\", (String)\"keith\")))) == (16l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"php\", (String)\"res\", (String)\"Python\", (String)\"abcd\", (String)\"Java\", (String)\"aaa\")))) == (10l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"Python\", (String)\"abba\", (String)\"aba\")))) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static Object rearrangeBigger(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearrangeBigger((12l)).equals((Object(21l))));\n    assert(rearrangeBigger((10l)).equals((Object(false))));\n    assert(rearrangeBigger((102l)).equals((Object(120l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long perimeterPentagon(long a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array array list and finds the maximum sum of a bitonic subsequence for the given array array list, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long maxSum(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)51l, (long)45l, (long)33l, (long)100l, (long)12l, (long)18l, (long)9l)))) == (194l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)80l, (long)60l, (long)30l, (long)40l, (long)20l, (long)10l)))) == (210l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)14l, (long)16l, (long)21l, (long)23l, (long)29l, (long)30l)))) == (138l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed pair.\n    public static Object extractEven(Pair<Long, Long, Pair<Long, Long, Pair<Long, Long>>, Long, Long> test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractEven((Pair.with(4l, 5l, Pair.with(7l, 6l, Pair.with(2l, 4l)), 6l, 8l))).equals(Pair.with(4l, Pair.with(6l, Pair.with(2l, 4l)), 6l, 8l)));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(8l, 7l, Pair.with(4l, 8l)), 7l, 9l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 8l)))));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(9l, 8l, Pair.with(4l, 6l)), 8l, 10l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 6l)), 8l, 10l)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToInt((Pair.with(1l, 2l, 3l))) == (123l));\n    assert(tupleToInt((Pair.with(4l, 5l, 6l))) == (456l));\n    assert(tupleToInt((Pair.with(5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3724,189 +136,9 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert all possible convertible elements in an array array list of array lists to floats.\n    public static ArrayList<Pair<Float, Float>> listToFloat(ArrayList<Pair<String, String>> test_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"3\", \"4\"), (Pair<String, String>)Pair.with(\"1\", \"26.45\"), (Pair<String, String>)Pair.with(\"7.32\", \"8\"), (Pair<String, String>)Pair.with(\"4\", \"8\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(3.0f, 4.0f), (Pair<Float, Float>)Pair.with(1.0f, 26.45f), (Pair<Float, Float>)Pair.with(7.32f, 8.0f), (Pair<Float, Float>)Pair.with(4.0f, 8.0f))))));\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"4\", \"4\"), (Pair<String, String>)Pair.with(\"2\", \"27\"), (Pair<String, String>)Pair.with(\"4.12\", \"9\"), (Pair<String, String>)Pair.with(\"7\", \"11\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(4.0f, 4.0f), (Pair<Float, Float>)Pair.with(2.0f, 27.0f), (Pair<Float, Float>)Pair.with(4.12f, 9.0f), (Pair<Float, Float>)Pair.with(7.0f, 11.0f))))));\n    assert(listToFloat((new ArrayList<Pair<String, String>>(Arrays.asList((Pair<String, String>)Pair.with(\"6\", \"78\"), (Pair<String, String>)Pair.with(\"5\", \"26.45\"), (Pair<String, String>)Pair.with(\"1.33\", \"4\"), (Pair<String, String>)Pair.with(\"82\", \"13\"))))).equals((new ArrayList<Pair<Float, Float>>(Arrays.asList((Pair<Float, Float>)Pair.with(6.0f, 78.0f), (Pair<Float, Float>)Pair.with(5.0f, 26.45f), (Pair<Float, Float>)Pair.with(1.33f, 4.0f), (Pair<Float, Float>)Pair.with(82.0f, 13.0f))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long squareSum(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array array list of numbers and the sum,\n    public static long getPairsCount(ArrayList<Long> arr, long sum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (2l)) == (6l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)-1l, (long)5l))), (6l)) == (3l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l))), (1l)) == (1l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l))), (-3l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long countNoOfWays(long n, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static String reverseWords(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check if a given number is one less than twice its reverse.\n    public static boolean checks(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last position of an element in a sorted array array list.\n    public static long last(ArrayList<Long> arr, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (1l)) == (0l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)4l))), (1l)) == (2l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)3l, (long)6l, (long)8l, (long)9l))), (3l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a pair and an element and counts the occcurences of the element in the array list.\n    public static long countX(ArrayList<Long> tup, long x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (4l)) == (0l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (10l)) == (3l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (8l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We say that an element is common for array lists l1, l2, l3 if it appears in all three array lists under the same index. Write a function to find common elements from three array lists. The function should return an array array list.\n    public static ArrayList<Object> extractIndexList(ArrayList<Long> l1, ArrayList<Long> l2, ArrayList<Long> l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)7l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)6l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)6l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)6l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to concatenate each element of pair by the delimiter.\n    public static String concatenateTuple(Pair<String, String, Long, String> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenateTuple((Pair.with(\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple((Pair.with(\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple((Pair.with(\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static String replaceSpaces(String string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of numbers in an array array list within a range specified by two indices.\n    public static long sumRangeList(ArrayList<Long> list1, long m, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (8l), (10l)) == (29l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (5l), (7l)) == (16l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (7l), (10l)) == (38l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three dictionaries into a single hash map.\n    public static HashMap<String,String> mergeDictionariesThree(HashMap<String,String> dict1, HashMap<String,String> dict2, HashMap<String,String> dict3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"O\", \"Orange\", \"W\", \"White\", \"B\", \"Black\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"R\", \"Red\", \"P\", \"Pink\", \"G\", \"Green\", \"W\", \"White\", \"O\", \"Orange\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\")))).equals((new HashMap<String,String>(Map.of(\"W\", \"White\", \"P\", \"Pink\", \"B\", \"Black\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"P\", \"Pink\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\", \"W\", \"White\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum of two numbers.\n    public static long minimum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given pair array list.\n    public static long maxDifference(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(1l, 7l), (Pair<Long, Long>)Pair.with(10l, 3l), (Pair<Long, Long>)Pair.with(1l, 2l))))) == (7l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(2l, 17l), (Pair<Long, Long>)Pair.with(9l, 13l), (Pair<Long, Long>)Pair.with(11l, 12l))))) == (15l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 35l), (Pair<Long, Long>)Pair.with(21l, 27l), (Pair<Long, Long>)Pair.with(13l, 23l), (Pair<Long, Long>)Pair.with(41l, 22l))))) == (23l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find element at a given index after number of rotations.\n    public static long findElement(ArrayList<Long> arr, ArrayList<ArrayList<Long>> ranges, long rotations, long index) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)3l))))), (2l), (1l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (2l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3916,7 +148,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a string to an array array list of strings split on the space character.\n    public static ArrayList<String> stringToList(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToList((\"python programming\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"programming\")))));\n    assert(stringToList((\"lists tuples strings\")).equals((new ArrayList<String>(Arrays.asList((String)\"lists\", (String)\"tuples\", (String)\"strings\")))));\n    assert(stringToList((\"write a program\")).equals((new ArrayList<String>(Arrays.asList((String)\"write\", (String)\"a\", (String)\"program\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3928,21 +160,9 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the element that appears only once in a sorted array array list.\n    public static long search(ArrayList<Long> arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l)))) == (3l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)5l, (long)7l, (long)7l, (long)8l)))) == (8l));\n    assert(search((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l)))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a hash map by value.\n    public static ArrayList<Pair<String, Long>> sortCounter(HashMap<String,Long> dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 81l, \"Physics\", 83l, \"Chemistry\", 87l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 87l), (Pair<String, Long>)Pair.with(\"Physics\", 83l), (Pair<String, Long>)Pair.with(\"Math\", 81l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 400l, \"Physics\", 300l, \"Chemistry\", 250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Math\", 400l), (Pair<String, Long>)Pair.with(\"Physics\", 300l), (Pair<String, Long>)Pair.with(\"Chemistry\", 250l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 900l, \"Physics\", 1000l, \"Chemistry\", 1250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 1250l), (Pair<String, Long>)Pair.with(\"Physics\", 1000l), (Pair<String, Long>)Pair.with(\"Math\", 900l))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3952,7 +172,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove first and last occurrence of a given character from the string.\n    public static String removeOcc(String s, String ch) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOcc((\"hello\"), (\"l\")).equals((\"heo\")));\n    assert(removeOcc((\"abcda\"), (\"a\")).equals((\"bcd\")));\n    assert(removeOcc((\"PHP\"), (\"P\")).equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3960,325 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long lateralsurfaceCube(long l) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of pairs within a given array list.\n    public static long maxProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (36l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (200l));\n    assert(maxProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes two array lists and returns true if they have at least one common element.\n    public static Optional<Boolean> commonElement(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    public static long amicableNumbersSum(long limit) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.of(true)));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.empty()));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))), (new ArrayList<Object>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"e\")))).equals(Optional.of(true)));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to append the given array list to the given pairs.\n    public static Pair<Long, Long, Long, Long, Long> addLists(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    public static long findLength(String string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((Pair.with(9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((Pair.with(10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((Pair.with(11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the n-th power of each number in an array array list.\n    public static ArrayList<Long> nthNums(ArrayList<Long> nums, long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of common divisors of two given numbers.\n    public static long sum(long a, long b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)248832l, (long)759375l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of elements.\n    public static ArrayList<Long> pancakeSort(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to multiply two integers.\n    public static long multiplyInt(long x, long y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)15l, (long)79l, (long)25l, (long)38l, (long)69l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)38l, (long)69l, (long)79l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)98l, (long)12l, (long)54l, (long)36l, (long)85l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)36l, (long)54l, (long)85l, (long)98l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)42l, (long)32l, (long)12l, (long)23l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)32l, (long)41l, (long)42l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float medianNumbers(long a, long b, long c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array array list.\n    public static boolean checkGreater(ArrayList<Long> arr, long number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (4l)) == (false));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (8l)) == (true));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)4l, (long)8l, (long)6l, (long)1l))), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and element and checks whether all items in the array list are equal to the given element.\n    public static boolean checkElement(ArrayList<Object> list, Object element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"orange\", (String)\"black\", (String)\"white\"))), (Object(\"blue\"))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (Object(7l))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"green\", (String)\"green\", (String)\"green\"))), (Object(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract specified size of strings from a given array list of string values.\n    public static ArrayList<String> extractString(ArrayList<String> str, long l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (8l)).equals((new ArrayList<String>(Arrays.asList((String)\"practice\", (String)\"solution\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (6l)).equals((new ArrayList<String>(Arrays.asList((String)\"Python\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (9l)).equals((new ArrayList<String>(Arrays.asList((String)\"exercises\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static boolean textLowercaseUnderscore(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to trim each array list by k in the given array lists.\n    public static ArrayList<ArrayList<Long>> trimTuple(ArrayList<ArrayList<Long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)2l, (long)1l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)12l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)9l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the subarray list having minimum length.\n    public static ArrayList<Object> FindMin(ArrayList<ArrayList<Object>> lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)7l, (long)8l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"x\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static ArrayList<Long> filterOddnumbers(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)45l, (long)67l, (long)84l, (long)93l)))).equals((new ArrayList<Long>(Arrays.asList((long)45l, (long)67l, (long)93l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)8l, (long)6l, (long)4l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)3l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static String findAdverbs(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which given a matrix represented as an array array list of array lists returns the max of the n'th column.\n    public static long maxOfNth(ArrayList<ArrayList<Long>> test_list, long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)19l))))), (2l)) == (19l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)20l))))), (1l)) == (10l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)21l))))), (1l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static String decimalToBinary(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and length n, and generates all combinations (with repetition) of the elements of the array list and returns an array array list with an array array list for each combination.\n    public static ArrayList<ArrayList<String>> combinationsColors(ArrayList<String> l, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (1l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (2l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (3l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\", (String)\"Blue\")))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static String removeAllSpaces(String text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static Object minSwaps(String str1, String str2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Object(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Object(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Object(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a new pair from the given string and array list.\n    public static Pair<String, String, String> newTuple(ArrayList<String> test_list, String test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"WEB\", (String)\"is\"))), (\"best\")).equals((Pair.with(\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"We\", (String)\"are\"))), (\"Developers\")).equals((Pair.with(\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"Part\", (String)\"is\"))), (\"Wrong\")).equals((Pair.with(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the product of the array array list multiplication modulo n.\n    public static long findRemainder(ArrayList<Long> arr, long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)100l, (long)10l, (long)5l, (long)25l, (long)35l, (long)14l))), (11l)) == (9l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l))), (1l)) == (0l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (2l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array array list of integers.\n    public static float positiveCount(ArrayList<Long> nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.54f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.69f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add the given pair to the given array list.\n    public static ArrayList<Long> addTuple(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)9l, (long)10l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)10l, (long)11l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long maxRunUppercase(String test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static ArrayList<ArrayList<Long>> sortMatrix(ArrayList<ArrayList<Long>> M) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long countVowels(String test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long maxSumIncreasingSubseq(ArrayList<Long> a, long n, long index, long k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)11l, (long)15l, (long)19l, (long)21l, (long)26l, (long)28l, (long)31l))), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4288,7 +244,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find words that are longer than n characters from a given array list of words.\n    public static ArrayList<String> longWords(long n, String str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(longWords((3l), (\"python is a programming language\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"programming\", (String)\"language\")))));\n    assert(longWords((2l), (\"writing a program\")).equals((new ArrayList<String>(Arrays.asList((String)\"writing\", (String)\"program\")))));\n    assert(longWords((5l), (\"sorting list\")).equals((new ArrayList<String>(Arrays.asList((String)\"sorting\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4296,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of non-repeated elements in a given array list.\n    public static long findSum(ArrayList<Long> arr) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    public static boolean magicSquareTest(ArrayList<ArrayList<Long>> my_matrix) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)1l, (long)4l, (long)5l, (long)6l)))) == (21l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)9l, (long)4l, (long)2l, (long)10l, (long)10l, (long)45l, (long)4l)))) == (71l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)9l, (long)45l, (long)2l, (long)10l, (long)10l, (long)45l, (long)10l)))) == (78l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)12l, (long)1l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)8l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)3l, (long)10l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)6l, (long)15l, (long)4l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)8l)))))) == (true));\n    assert(magicSquareTest((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)7l)))))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given pair to a key-value hash map using adjacent elements. https://www.geeksforgeeks.org/javathon-convert-pair-to-adjacent-pair-hash map/\n    public static HashMap<Long,Long> tupleToDict(Pair<Long, Long, Long, Long, Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    public static ArrayList<ArrayList<Long>> sortMatrix(ArrayList<ArrayList<Long>> M) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToDict((Pair.with(1l, 5l, 7l, 10l, 13l, 5l))).equals((new HashMap<Long,Long>(Map.of(1l, 5l, 7l, 10l, 13l, 5l)))));\n    assert(tupleToDict((Pair.with(1l, 2l, 3l, 4l, 5l, 6l))).equals((new HashMap<Long,Long>(Map.of(1l, 2l, 3l, 4l, 5l, 6l)))));\n    assert(tupleToDict((Pair.with(7l, 8l, 9l, 10l, 11l, 12l))).equals((new HashMap<Long,Long>(Map.of(7l, 8l, 9l, 10l, 11l, 12l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-2l, (long)4l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)-1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))));\n    assert(sortMatrix((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)8l, (long)9l)))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate pair.\n    public static ArrayList<ArrayList<Long>> getCoordinates(Pair<Long, Long> test_tup) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the item with maximum frequency in a given array list.\n    public static long maxOccurrences(ArrayList<Long> nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(getCoordinates((Pair.with(3l, 4l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))));\n    assert(getCoordinates((Pair.with(4l, 5l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))));\n    assert(getCoordinates((Pair.with(5l, 6l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all the elements in pair have same data type or not.\n    public static boolean checkType(Object test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkType(Pair.with(5l, 6l, 7l, 3l, 5l, 6l)) == (true));\n    assert(checkType(Pair.with(1l, 2l, \"4\")) == (false));\n    assert(checkType(Pair.with(3l, 2l, 1l, 4l, 5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the smallest missing number from a sorted array list of natural numbers.\n    public static long findFirstMissing(ArrayList<Long> array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)6l, (long)9l)))) == (3l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)8l, (long)9l)))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static boolean isUndulating(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum k records from pair array list. https://www.geeksforgeeks.org/javathon-find-minimum-k-records-from-pair-array list/ - in this case a verbatim cojava of test cases\n    public static ArrayList<Pair<String, Long>> minK(ArrayList<Pair<String, Long>> test_list, long K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Manjeet\", 10l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l), (Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Nikhil\", 8l)))), (2l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sanjeev\", 11l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l)))), (3l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"tanmay\", 14l), (Pair<String, Long>)Pair.with(\"Amer\", 11l), (Pair<String, Long>)Pair.with(\"Ayesha\", 9l), (Pair<String, Long>)Pair.with(\"SKD\", 16l)))), (1l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Ayesha\", 9l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of substrings with the sum of digits equal to their length.\n    public static long countSubstrings(String s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long isNumDecagonal(long n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list of pairs and returns an array array list containing the rear element of each pair.\n    public static ArrayList<Long> rearExtract(ArrayList<Pair<Long, String, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Rash\", 21l), (Pair<Long, String, Long>)Pair.with(2l, \"Varsha\", 20l), (Pair<Long, String, Long>)Pair.with(3l, \"Kil\", 19l))))).equals((new ArrayList<Long>(Arrays.asList((long)21l, (long)20l, (long)19l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sai\", 36l), (Pair<Long, String, Long>)Pair.with(2l, \"Ayesha\", 25l), (Pair<Long, String, Long>)Pair.with(3l, \"Salman\", 45l))))).equals((new ArrayList<Long>(Arrays.asList((long)36l, (long)25l, (long)45l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sudeep\", 14l), (Pair<Long, String, Long>)Pair.with(2l, \"Vandana\", 36l), (Pair<Long, String, Long>)Pair.with(3l, \"Dawood\", 56l))))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)36l, (long)56l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long closestNum(long N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the combinations of sums with pairs in the given pair array list. https://www.geeksforgeeks.org/javathon-combinations-of-sum-with-pairs-in-pair-array list/\n    public static ArrayList<Pair<Long, Long>> findCombinations(ArrayList<Pair<Long, Long>> test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(6l, 10l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(8l, 11l), (Pair<Long, Long>)Pair.with(7l, 5l), (Pair<Long, Long>)Pair.with(8l, 14l), (Pair<Long, Long>)Pair.with(11l, 8l), (Pair<Long, Long>)Pair.with(12l, 17l), (Pair<Long, Long>)Pair.with(11l, 11l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(6l, 2l), (Pair<Long, Long>)Pair.with(7l, 11l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 13l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(10l, 16l), (Pair<Long, Long>)Pair.with(13l, 10l), (Pair<Long, Long>)Pair.with(14l, 19l), (Pair<Long, Long>)Pair.with(13l, 13l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(7l, 3l), (Pair<Long, Long>)Pair.with(8l, 12l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 15l), (Pair<Long, Long>)Pair.with(11l, 9l), (Pair<Long, Long>)Pair.with(12l, 18l), (Pair<Long, Long>)Pair.with(15l, 12l), (Pair<Long, Long>)Pair.with(16l, 21l), (Pair<Long, Long>)Pair.with(15l, 15l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a square matrix of size N*N given as an array array list of array lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float maxAverageOfPath(ArrayList<ArrayList<Long>> cost) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)9l)))))) == (5.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l, (long)10l)))))) == (6.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)11l)))))) == (7.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and element and returns a pair containing a boolean that indicates if the element is in the array array list and the index position of the element (or -1 if the element is not found).\n    public static Pair<Boolean, Long> sequentialSearch(ArrayList<Long> dlist, long item) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)11l, (long)23l, (long)58l, (long)31l, (long)56l, (long)77l, (long)43l, (long)12l, (long)65l, (long)19l))), (31l)).equals((Pair.with(true, 3l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)12l, (long)32l, (long)45l, (long)62l, (long)35l, (long)47l, (long)44l, (long)61l))), (61l)).equals((Pair.with(true, 7l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)17l, (long)19l, (long)22l, (long)39l, (long)48l, (long)56l))), (48l)).equals((Pair.with(true, 6l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove odd numbers from a given array list.\n    public static ArrayList<Long> removeOdd(ArrayList<Long> l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the product of numbers in an array array list is even or not.\n    public static boolean isProductEven(ArrayList<Long> arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the maximum of two numbers.\n    public static long maximum(long a, long b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)2l, (long)6l, (long)5l, (long)1l, (long)6l, (long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)6l, (long)9l, (long)1l, (long)2l)))) == (2l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)8l, (long)4l, (long)7l, (long)9l, (long)8l, (long)7l, (long)9l, (long)15l, (long)14l, (long)10l, (long)12l, (long)13l, (long)16l, (long)18l)))) == (8l));\n    assert(maxOccurrences((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)20l, (long)30l, (long)40l, (long)90l, (long)80l, (long)50l, (long)30l, (long)20l, (long)50l, (long)10l)))) == (20l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4504,9 +292,597 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to reverse only the vowels of a given string (where y is not a vowel).\n    public static String reverseVowels(String str1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseVowels((\"Python\")).equals((\"Python\")));\n    assert(reverseVowels((\"USA\")).equals((\"ASU\")));\n    assert(reverseVowels((\"ab\")).equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert an array array list to a string.\n    public static String tupString(ArrayList<String> tup1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"x\", (String)\"e\", (String)\"r\", (String)\"c\", (String)\"i\", (String)\"s\", (String)\"e\", (String)\"s\")))).equals((\"exercises\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))).equals((\"python\")));\n    assert(tupString((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))).equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of the negative numbers of a given array list of numbers.\n    public static long sumNegativenum(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (-32l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)-14l, (long)13l, (long)-18l, (long)12l, (long)-20l)))) == (-52l));\n    assert(sumNegativenum((new ArrayList<Long>(Arrays.asList((long)19l, (long)-65l, (long)57l, (long)39l, (long)152l, (long)-639l, (long)121l, (long)44l, (long)90l, (long)-190l)))) == (-894l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth hexagonal number.\n    public static long hexagonalNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    public static boolean isSumOfPowersOfTwo(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of elements.\n    public static ArrayList<Long> pancakeSort(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)15l, (long)79l, (long)25l, (long)38l, (long)69l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)38l, (long)69l, (long)79l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)98l, (long)12l, (long)54l, (long)36l, (long)85l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)36l, (long)54l, (long)85l, (long)98l)))));\n    assert(pancakeSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)42l, (long)32l, (long)12l, (long)23l)))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)32l, (long)41l, (long)42l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count number items that are identical in the same position of three given array lists.\n    public static long countSamepair(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (3l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (4l));\n    assert(countSamepair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)8l)))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find number of array lists present in the given array list.\n    public static long findLists(ArrayList<Object> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (2l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))) == (3l));\n    assert(findLists((new ArrayList<Object>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l, (long)4l, (long)3l, (long)2l, (long)1l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the maximum difference between any two elements in a given array array list.\n    public static long maxAbsDiff(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)3l)))) == (4l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)3l, (long)2l, (long)5l, (long)1l)))) == (8l));\n    assert(maxAbsDiff((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the volume of a triangular prism.\n    public static long findVolume(long l, long b, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a pair, or return null if no solution exists.\n    public static Optional<Pair<Long, Long>> findSolution(long a, long b, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSolution((2l), (3l), (7l)).equals(Optional.of(Pair.with(2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(Optional.empty()));\n    assert(findSolution((1l), (13l), (17l)).equals(Optional.of(Pair.with(4l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all elements from a given array list present in another array list.\n    public static ArrayList<Long> removeElements(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    assert(removeElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)8l, (long)9l, (long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    public static long sumSeries(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    public static boolean areEquivalent(long num1, long num2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    public static long countCharPosition(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that counts the number of pairs of integers in an array array list that xor to an even number.\n    public static long findEvenPair(ArrayList<Long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l)))) == (4l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l)))) == (9l));\n    assert(findEvenPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the smallest power of 2 greater than or equal to n.\n    public static long nextPowerOf2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurrences of a number in a given array list.\n    public static long frequency(ArrayList<Long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (4l)) == (0l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)3l, (long)4l))), (3l)) == (3l));\n    assert(frequency((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)1l, (long)2l))), (1l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    public static boolean textLowercaseUnderscore(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of numbers in an array array list within a range specified by two indices.\n    public static long sumRangeList(ArrayList<Long> list1, long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (8l), (10l)) == (29l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (5l), (7l)) == (16l));\n    assert(sumRangeList((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)5l, (long)6l, (long)8l, (long)3l, (long)4l, (long)9l, (long)10l, (long)11l, (long)8l, (long)12l))), (7l), (10l)) == (38l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    public static long perimeterPentagon(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    public static long countOccurance(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    public static long squarePerimeter(long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    public static String removeDirtyChars(String string, String second_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether a given array array list of integers contains any duplicate element.\n    public static boolean testDuplicate(ArrayList<Long> arraynums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))) == (true));\n    assert(testDuplicate((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given number is woodball or not.\n    public static boolean isWoodall(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all the elements in pair have same data type or not.\n    public static boolean checkType(Object test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkType(Pair.with(5l, 6l, 7l, 3l, 5l, 6l)) == (true));\n    assert(checkType(Pair.with(1l, 2l, \"4\")) == (false));\n    assert(checkType(Pair.with(3l, 2l, 1l, 4l, 5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a sorted array array list, its length (n), and an element and returns whether the element is the majority element in the given sorted array array list. (The majority element is the element that occurs more than n/2 times.)\n    public static boolean isMajority(ArrayList<Long> arr, long n, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)3l, (long)3l, (long)3l, (long)10l))), (7l), (3l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)4l, (long)4l, (long)4l, (long)6l, (long)6l))), (8l), (4l)) == (false));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (true));\n    assert(isMajority((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)2l))), (5l), (1l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of set bits (binary digits with value 1) in a given number.\n    public static long countSetBits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove the characters which have odd index values of a given string.\n    public static String oddValuesString(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum of three numbers.\n    public static long minOfThree(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether all the bits are unset in the given range or not.\n    public static boolean allBitsSetInTheGivenRange(long n, long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer n, and re-arranges the first n elements of the given array array list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    public static ArrayList<Long> reArrangeArray(ArrayList<Long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)-3l, (long)4l, (long)5l, (long)6l, (long)-7l, (long)8l, (long)9l))), (9l)).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-3l, (long)-7l, (long)4l, (long)5l, (long)6l, (long)2l, (long)8l, (long)9l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)12l, (long)-14l, (long)-26l, (long)13l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)-14l, (long)-26l, (long)12l, (long)13l, (long)15l)))));\n    assert(reArrangeArray((new ArrayList<Long>(Arrays.asList((long)10l, (long)24l, (long)36l, (long)-42l, (long)-39l, (long)-78l, (long)85l))), (7l)).equals((new ArrayList<Long>(Arrays.asList((long)-42l, (long)-39l, (long)-78l, (long)10l, (long)24l, (long)36l, (long)85l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    public static String replaceBlank(String str1, String char) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the volume of a cube given its side length.\n    public static long volumeCube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list of pairs and returns a hash map mapping each unique pair to the number of times it occurs in the array list.\n    public static HashMap<Pair<Long, Long>,Long> checkOccurences(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 1l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(2l, 5l), (Pair<Long, Long>)Pair.with(5l, 2l), (Pair<Long, Long>)Pair.with(6l, 3l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(1l, 3l), 2l, Pair.with(2l, 5l), 2l, Pair.with(3l, 6l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 2l), (Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(3l, 6l), (Pair<Long, Long>)Pair.with(6l, 3l), (Pair<Long, Long>)Pair.with(7l, 4l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 4l), 2l, Pair.with(3l, 6l), 2l, Pair.with(4l, 7l), 1l)))));\n    assert(checkOccurences((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(13l, 2l), (Pair<Long, Long>)Pair.with(11l, 23l), (Pair<Long, Long>)Pair.with(12l, 25l), (Pair<Long, Long>)Pair.with(25l, 12l), (Pair<Long, Long>)Pair.with(16l, 23l))))).equals((new HashMap<Pair<Long, Long>,Long>(Map.of(Pair.with(2l, 13l), 1l, Pair.with(11l, 23l), 1l, Pair.with(12l, 25l), 2l, Pair.with(16l, 23l), 1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of non-empty substrings of a given string.\n    public static long numberOfSubstrings(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    public static long getTotalNumberOfSequences(long m, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two array lists and replaces the last element of the first array list with the elements of the second array list.\n    public static ArrayList<Object> replaceList(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)10l))), (new ArrayList<Object>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(replaceList((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\"))), (new ArrayList<Object>(Arrays.asList((String)\"yellow\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"yellow\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the total number of characters in a string.\n    public static long countCharac(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the next perfect square greater than a given number.\n    public static long nextPerfectSquare(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes an array array list and finds the maximum sum of a bitonic subsequence for the given array array list, where a sequence is bitonic if it is first increasing and then decreasing.\n    public static long maxSum(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)51l, (long)45l, (long)33l, (long)100l, (long)12l, (long)18l, (long)9l)))) == (194l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)80l, (long)60l, (long)30l, (long)40l, (long)20l, (long)10l)))) == (210l));\n    assert(maxSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)14l, (long)16l, (long)21l, (long)23l, (long)29l, (long)30l)))) == (138l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    public static long lps(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the intersection of two array array lists.\n    public static ArrayList<Long> intersectionArray(ArrayList<Long> array_nums1, ArrayList<Long> array_nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)8l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(intersectionArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)8l, (long)9l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a pair and an element and counts the occcurences of the element in the array list.\n    public static long countX(ArrayList<Long> tup, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (4l)) == (0l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (10l)) == (3l));\n    assert(countX((new ArrayList<Long>(Arrays.asList((long)10l, (long)8l, (long)5l, (long)2l, (long)10l, (long)15l, (long)10l, (long)8l, (long)5l, (long)8l, (long)8l, (long)2l))), (8l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an element and inserts the element before each element in the array list, and returns the resulting array list.\n    public static ArrayList<String> insertElement(ArrayList<String> list, String element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Black\"))), (\"c\")).equals((new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"Red\", (String)\"c\", (String)\"Green\", (String)\"c\", (String)\"Black\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"java\"))), (\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"program\", (String)\"python\", (String)\"program\", (String)\"java\")))));\n    assert(insertElement((new ArrayList<String>(Arrays.asList((String)\"happy\", (String)\"sad\"))), (\"laugh\")).equals((new ArrayList<String>(Arrays.asList((String)\"laugh\", (String)\"happy\", (String)\"laugh\", (String)\"sad\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert complex numbers to polar coordinates.\n    public static Pair<Float, Float> convert(long numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(convert((1l)).equals((Pair.with(1.0f, 0.0f))));\n    assert(convert((4l)).equals((Pair.with(4.0f, 0.0f))));\n    assert(convert((5l)).equals((Pair.with(5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and length n, and generates all combinations (with repetition) of the elements of the array list and returns an array array list with an array array list for each combination.\n    public static ArrayList<ArrayList<String>> combinationsColors(ArrayList<String> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (1l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (2l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\")))))));\n    assert(combinationsColors((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\"))), (3l)).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Red\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Red\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Green\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Green\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Green\", (String)\"Blue\", (String)\"Blue\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"Blue\", (String)\"Blue\", (String)\"Blue\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    public static long countPrimesNums(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two numbers and returns an array array list with the second number and then the first number.\n    public static ArrayList<Long> swapNumbers(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapNumbers((10l), (20l)).equals((new ArrayList<Long>(Arrays.asList((long)20l, (long)10l)))));\n    assert(swapNumbers((15l), (17l)).equals((new ArrayList<Long>(Arrays.asList((long)17l, (long)15l)))));\n    assert(swapNumbers((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)200l, (long)100l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4516,7 +892,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to maximize the given two array lists.\n    public static ArrayList<ArrayList<Long>> maximizeElements(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)))))));\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)11l)))))));\n    assert(maximizeElements((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)))))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4524,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether every even index contains even numbers of a given array list.\n    public static boolean evenPosition(ArrayList<Long> nums) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    public static long newmanPrime(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static String checkChar(String string) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two pairs and performs mathematical division operation element-wise across the given pairs.\n    public static Pair<Long, Long, Long, Long> divisionElements(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisionElements((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(2l, 2l, 2l, 3l))));\n    assert(divisionElements((Pair.with(12l, 6l, 8l, 16l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(2l, 2l, 2l, 4l))));\n    assert(divisionElements((Pair.with(20l, 14l, 36l, 18l)), (Pair.with(5l, 7l, 6l, 9l))).equals((Pair.with(4l, 2l, 6l, 2l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of even factors of a number.\n    public static long sumofFactors(long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer L and splits the given array list into two parts where the length of the first part of the array list is L, and returns the resulting array lists in a pair.\n    public static Object splitTwoParts(ArrayList<Object> list1, long L) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals(Pair.with(new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l)), new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (2l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")))));\n    assert(splitTwoParts((new ArrayList<Object>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\"))), (4l)).equals(Pair.with(new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\")), new ArrayList<String>(Arrays.asList((String)\"o\", (String)\"n\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float lateralsurfaceCone(long r, long h) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    public static long dogAge(long h_age) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long countPairs(ArrayList<Long> arr, long n) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and an integer n and splits an array array list for every nth element, returning an array array list of the resulting array lists.\n    public static ArrayList<ArrayList<Object>> listSplit(ArrayList<Object> S, long step) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (3l)) == (2l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (4l)) == (0l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (5l)) == (10l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"e\", (String)\"f\", (String)\"g\", (String)\"h\", (String)\"i\", (String)\"j\", (String)\"k\", (String)\"l\", (String)\"m\", (String)\"n\"))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"d\", (String)\"g\", (String)\"j\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\", (String)\"e\", (String)\"h\", (String)\"k\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"f\", (String)\"i\", (String)\"l\")))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)11l, (long)12l, (long)13l, (long)14l))), (3l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)10l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)8l, (long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)12l)))))));\n    assert(listSplit((new ArrayList<Object>(Arrays.asList((String)\"python\", (String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\", (String)\"SQL\"))), (2l)).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"C\", (String)\"DBMS\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C++\", (String)\"SQL\")))))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array array list.\n    public static long findFirstOccurrence(ArrayList<Long> A, long x) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    public static long lateralsurfaceCube(long l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (1l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (2l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (6l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4600,9 +976,669 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    public static long squareSum(long n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (10l));\n    assert(squareSum((3l)) == (35l));\n    assert(squareSum((4l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th star number.\n    public static long findStarNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ascii value of a character.\n    public static long asciiValue(String k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of even numbers at even positions of an array array list.\n    public static long sumEvenAndEvenIndex(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l, (long)18l, (long)8l)))) == (30l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)3l, (long)20l, (long)17l, (long)9l, (long)2l, (long)10l, (long)18l, (long)13l, (long)6l, (long)18l)))) == (26l));\n    assert(sumEvenAndEvenIndex((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)12l, (long)1l)))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    public static long evenPowerSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list of pairs and returns an array array list containing the rear element of each pair.\n    public static ArrayList<Long> rearExtract(ArrayList<Pair<Long, String, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Rash\", 21l), (Pair<Long, String, Long>)Pair.with(2l, \"Varsha\", 20l), (Pair<Long, String, Long>)Pair.with(3l, \"Kil\", 19l))))).equals((new ArrayList<Long>(Arrays.asList((long)21l, (long)20l, (long)19l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sai\", 36l), (Pair<Long, String, Long>)Pair.with(2l, \"Ayesha\", 25l), (Pair<Long, String, Long>)Pair.with(3l, \"Salman\", 45l))))).equals((new ArrayList<Long>(Arrays.asList((long)36l, (long)25l, (long)45l)))));\n    assert(rearExtract((new ArrayList<Pair<Long, String, Long>>(Arrays.asList((Pair<Long, String, Long>)Pair.with(1l, \"Sudeep\", 14l), (Pair<Long, String, Long>)Pair.with(2l, \"Vandana\", 36l), (Pair<Long, String, Long>)Pair.with(3l, \"Dawood\", 56l))))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)36l, (long)56l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in two pairs and subtracts the elements of the first pair by the elements of the second pair with the same index.\n    public static Pair<Long, Long, Long> substractElements(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(substractElements((Pair.with(10l, 4l, 5l)), (Pair.with(2l, 5l, 18l))).equals((Pair.with(8l, -1l, -13l))));\n    assert(substractElements((Pair.with(11l, 2l, 3l)), (Pair.with(24l, 45l, 16l))).equals((Pair.with(-13l, -43l, -13l))));\n    assert(substractElements((Pair.with(7l, 18l, 9l)), (Pair.with(10l, 11l, 12l))).equals((Pair.with(-3l, 7l, -3l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    public static long evenBinomialCoeffSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in a hash map and integer n and filters the hash map to only include entries with values greater than or equal to n.\n    public static HashMap<String,Long> dictFilter(HashMap<String,Long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (170l)).equals((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (180l)).equals((new HashMap<String,Long>(Map.of(\"Alden Cantrell\", 180l, \"Pierre Cox\", 190l)))));\n    assert(dictFilter((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 175l, \"Alden Cantrell\", 180l, \"Kierra Gentry\", 165l, \"Pierre Cox\", 190l))), (190l)).equals((new HashMap<String,Long>(Map.of(\"Pierre Cox\", 190l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth decagonal number.\n    public static long isNumDecagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and element and returns a pair containing a boolean that indicates if the element is in the array array list and the index position of the element (or -1 if the element is not found).\n    public static Pair<Boolean, Long> sequentialSearch(ArrayList<Long> dlist, long item) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)11l, (long)23l, (long)58l, (long)31l, (long)56l, (long)77l, (long)43l, (long)12l, (long)65l, (long)19l))), (31l)).equals((Pair.with(true, 3l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)12l, (long)32l, (long)45l, (long)62l, (long)35l, (long)47l, (long)44l, (long)61l))), (61l)).equals((Pair.with(true, 7l))));\n    assert(sequentialSearch((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)17l, (long)19l, (long)22l, (long)39l, (long)48l, (long)56l))), (48l)).equals((Pair.with(true, 6l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check if the elements of a given array list are unique or not.\n    public static boolean allUnique(ArrayList<Long> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(allUnique((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to subtract two array lists element-wise.\n    public static ArrayList<Long> subList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-3l, (long)-3l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-2l)))));\n    assert(subList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Long>(Arrays.asList((long)40l, (long)50l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    public static boolean validate(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes in an array array list and element and checks whether all items in the array list are equal to the given element.\n    public static boolean checkElement(ArrayList<Object> list, Object element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"orange\", (String)\"black\", (String)\"white\"))), (Object(\"blue\"))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (Object(7l))) == (false));\n    assert(checkElement((new ArrayList<Object>(Arrays.asList((String)\"green\", (String)\"green\", (String)\"green\", (String)\"green\"))), (Object(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    public static boolean textMatchTwoThree(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the largest sum of a contiguous array array list in the modified array array list which is formed by repeating the given array array list k times.\n    public static long maxSubArraySumRepeated(ArrayList<Long> a, long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)-30l, (long)-1l))), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)10l, (long)20l))), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)-3l))), (3l), (3l)) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    public static long squareSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the array list of maximum length in an array array list of array lists.\n    public static Pair<Long, ArrayList<Long>> maxLength(ArrayList<ArrayList<Long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)10l, (long)12l, (long)14l, (long)15l))))));\n    assert(maxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)25l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    public static long countNoOfWays(long n, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find quotient of two numbers (rounded down to the nearest integer).\n    public static long find(long n, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the third side of a right angled triangle.\n    public static float othersideRightangle(long w, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == (float)5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return the sum of all divisors of a number.\n    public static long sumDiv(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count inversions in an array array list.\n    public static long getInvCount(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)20l, (long)6l, (long)4l, (long)5l)))) == (5l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (1l));\n    assert(getInvCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)5l, (long)6l, (long)1l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the maximum aggregate from the array list of pairs.\n    public static Pair<String, Long> maxAggregate(ArrayList<Pair<String, Long>> stdata) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 90l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 88l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 7l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 122l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 84l))))).equals((Pair.with(\"Juan Whelan\", 212l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 50l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 48l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 37l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 22l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 14l))))).equals((Pair.with(\"Juan Whelan\", 72l))));\n    assert(maxAggregate((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Juan Whelan\", 10l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 20l), (Pair<String, Long>)Pair.with(\"Peter Nichols\", 30l), (Pair<String, Long>)Pair.with(\"Juan Whelan\", 40l), (Pair<String, Long>)Pair.with(\"Sabah Colley\", 50l))))).equals((Pair.with(\"Sabah Colley\", 70l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find element at a given index after number of rotations.\n    public static long findElement(ArrayList<Long> arr, ArrayList<ArrayList<Long>> ranges, long rotations, long index) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)3l))))), (2l), (1l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (2l)) == (3l));\n    assert(findElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)2l))))), (1l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return two words from an array array list of words starting with letter 'p'.\n    public static Pair<String, String> startWithp(ArrayList<String> words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python PHP\", (String)\"Java JavaScript\", (String)\"c c++\")))).equals((Pair.with(\"Python\", \"PHP\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Python Programming\", (String)\"Java Programming\")))).equals((Pair.with(\"Python\", \"Programming\"))));\n    assert(startWithp((new ArrayList<String>(Arrays.asList((String)\"Pqrst Pqr\", (String)\"qrstuv\")))).equals((Pair.with(\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    public static long maxSumIncreasingSubseq(ArrayList<Long> a, long n, long index, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)1l, (long)101l, (long)2l, (long)3l, (long)100l, (long)4l, (long)5l))), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((new ArrayList<Long>(Arrays.asList((long)11l, (long)15l, (long)19l, (long)21l, (long)26l, (long)28l, (long)31l))), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the specified number of largest products from two given array lists, selecting one factor from each array list.\n    public static ArrayList<Long> largeProduct(ArrayList<Long> nums1, ArrayList<Long> nums2, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l)))));\n    assert(largeProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)8l, (long)9l, (long)10l, (long)6l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)60l, (long)54l, (long)50l, (long)48l, (long)45l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the maximum of two numbers.\n    public static long maximum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a given string to an array array list of characters.\n    public static ArrayList<String> stringToTuple(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(stringToTuple((\"python 3.0\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\", (String)\"3\", (String)\".\", (String)\"0\")))));\n    assert(stringToTuple((\"item1\")).equals((new ArrayList<String>(Arrays.asList((String)\"i\", (String)\"t\", (String)\"e\", (String)\"m\", (String)\"1\")))));\n    assert(stringToTuple((\"15.10\")).equals((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"5\", (String)\".\", (String)\"1\", (String)\"0\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the highest power of 2 that is less than or equal to n.\n    public static long highestPowerOf2(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n'th lucas number.\n    public static long findLucas(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to apply a given format string to all of the elements in an array array list.\n    public static ArrayList<String> addString(ArrayList<Object> list_, String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (\"temp{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"temp1\", (String)\"temp2\", (String)\"temp3\", (String)\"temp4\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\"))), (\"python{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"pythona\", (String)\"pythonb\", (String)\"pythonc\", (String)\"pythond\")))));\n    assert(addString((new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l))), (\"string{0}\")).equals((new ArrayList<String>(Arrays.asList((String)\"string5\", (String)\"string6\", (String)\"string7\", (String)\"string8\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert more than one array list to nested hash map.\n    public static ArrayList<HashMap<String,HashMap<String,Long>>> convertListDictionary(ArrayList<String> l1, ArrayList<String> l2, ArrayList<Long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"S001\", (String)\"S002\", (String)\"S003\", (String)\"S004\"))), (new ArrayList<String>(Arrays.asList((String)\"Adina Park\", (String)\"Leyton Marsh\", (String)\"Duncan Boyle\", (String)\"Saim Richards\"))), (new ArrayList<Long>(Arrays.asList((long)85l, (long)98l, (long)89l, (long)92l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S001\", new HashMap<String,Long>(Map.of(\"Adina Park\", 85l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S002\", new HashMap<String,Long>(Map.of(\"Leyton Marsh\", 98l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S003\", new HashMap<String,Long>(Map.of(\"Duncan Boyle\", 89l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"S004\", new HashMap<String,Long>(Map.of(\"Saim Richards\", 92l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"abc\", (String)\"def\", (String)\"ghi\", (String)\"jkl\"))), (new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\", (String)\"programs\"))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"abc\", new HashMap<String,Long>(Map.of(\"python\", 100l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"def\", new HashMap<String,Long>(Map.of(\"program\", 200l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"ghi\", new HashMap<String,Long>(Map.of(\"language\", 300l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"jkl\", new HashMap<String,Long>(Map.of(\"programs\", 400l)))))))));\n    assert(convertListDictionary((new ArrayList<String>(Arrays.asList((String)\"A1\", (String)\"A2\", (String)\"A3\", (String)\"A4\"))), (new ArrayList<String>(Arrays.asList((String)\"java\", (String)\"C\", (String)\"C++\", (String)\"DBMS\"))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))).equals((new ArrayList<HashMap<String,HashMap<String,Long>>>(Arrays.asList((HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A1\", new HashMap<String,Long>(Map.of(\"java\", 10l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A2\", new HashMap<String,Long>(Map.of(\"C\", 20l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A3\", new HashMap<String,Long>(Map.of(\"C++\", 30l)))), (HashMap<String,HashMap<String,Long>>)new HashMap<String,HashMap<String,Long>>(Map.of(\"A4\", new HashMap<String,Long>(Map.of(\"DBMS\", 40l)))))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    public static long getMaxSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the array list with maximum length.\n    public static Pair<Long, ArrayList<Long>> maxLengthList(ArrayList<ArrayList<Long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))).equals((Pair.with(3l, new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)))))).equals((Pair.with(5l, new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))))));\n    assert(maxLengthList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))))).equals((Pair.with(4l, new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if given array list contains no duplicates.\n    public static boolean checkDistinct(ArrayList<Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l, (long)1l, (long)4l)))) == (false));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkDistinct((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first non-repeated character in a given string.\n    public static Optional<String> firstNonRepeatingCharacter(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(Optional.empty()));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Optional.of(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Optional.of(\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    public static String checkChar(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of three numbers.\n    public static float medianNumbers(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the sum of digits of each number of a given array list.\n    public static long sumOfDigits(ArrayList<Object> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)2l, (long)56l)))) == (14l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((ArrayList<Long>)new ArrayList<Object>(Arrays.asList(10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))))) == (19l));\n    assert(sumOfDigits((new ArrayList<Object>(Arrays.asList((long)10l, (long)20l, (long)-4l, (long)5l, (long)-70l)))) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given pairs.\n    public static Pair<Long, Long, Long, Long> bitwiseXor(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bitwiseXor((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(15l, 6l, 5l, 10l))));\n    assert(bitwiseXor((Pair.with(11l, 5l, 7l, 10l)), (Pair.with(6l, 3l, 4l, 4l))).equals((Pair.with(13l, 6l, 3l, 14l))));\n    assert(bitwiseXor((Pair.with(12l, 6l, 8l, 11l)), (Pair.with(7l, 4l, 5l, 6l))).equals((Pair.with(11l, 2l, 13l, 13l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to identify non-prime numbers.\n    public static boolean isNotPrime(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the number of unique pairs in the given array list.\n    public static long extractFreq(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(4l, 3l), (Pair<Long, Long>)Pair.with(5l, 6l))))) == (3l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 15l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(5l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l))))) == (4l));\n    assert(extractFreq((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 16l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(6l, 9l))))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise addition of array list elements in the given two nested array lists.\n    public static ArrayList<ArrayList<Long>> addNestedTuples(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)13l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)16l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)15l)))))));\n    assert(addNestedTuples((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)14l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)17l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum of two numbers.\n    public static long minimum(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find whether the parity of a given number is odd.\n    public static boolean findParity(long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    public static Object rearrangeBigger(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rearrangeBigger((12l)).equals((Object(21l))));\n    assert(rearrangeBigger((10l)).equals((Object(false))));\n    assert(rearrangeBigger((102l)).equals((Object(120l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array array list and one element from the second array array list.\n    public static ArrayList<ArrayList<Long>> kSmallestPairs(ArrayList<Long> nums1, ArrayList<Long> nums2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))));\n    assert(kSmallestPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l))), (7l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)2l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the minimum product from the pairs of pairs within a given array list.\n    public static long minProductTuple(ArrayList<Pair<Long, Long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 7l), (Pair<Long, Long>)Pair.with(2l, 6l), (Pair<Long, Long>)Pair.with(1l, 8l), (Pair<Long, Long>)Pair.with(4l, 9l))))) == (8l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 20l), (Pair<Long, Long>)Pair.with(15l, 2l), (Pair<Long, Long>)Pair.with(5l, 10l))))) == (30l));\n    assert(minProductTuple((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(11l, 44l), (Pair<Long, Long>)Pair.with(10l, 15l), (Pair<Long, Long>)Pair.with(20l, 5l), (Pair<Long, Long>)Pair.with(12l, 9l))))) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    public static String snakeToCamel(String word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove odd numbers from a given array list.\n    public static ArrayList<Long> removeOdd(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)))));\n    assert(removeOdd((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the nth element from a given array list of pairs.\n    public static ArrayList<Object> extractNthElement(ArrayList<Pair<String, Long, Long>> list1, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (0l)).equals((new ArrayList<Object>(Arrays.asList((String)\"Greyson Fulton\", (String)\"Brady Kent\", (String)\"Wyatt Knott\", (String)\"Beau Turnbull\")))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (2l)).equals((new ArrayList<Object>(Arrays.asList((long)99l, (long)96l, (long)94l, (long)98l)))));\n    assert(extractNthElement((new ArrayList<Pair<String, Long, Long>>(Arrays.asList((Pair<String, Long, Long>)Pair.with(\"Greyson Fulton\", 98l, 99l), (Pair<String, Long, Long>)Pair.with(\"Brady Kent\", 97l, 96l), (Pair<String, Long, Long>)Pair.with(\"Wyatt Knott\", 91l, 94l), (Pair<String, Long, Long>)Pair.with(\"Beau Turnbull\", 94l, 98l)))), (1l)).equals((new ArrayList<Object>(Arrays.asList((long)98l, (long)97l, (long)91l, (long)94l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether any value in a sequence exists in a sequence or not.\n    public static boolean overlapping(ArrayList<Long> list1, ArrayList<Long> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))) == (false));\n    assert(overlapping((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find a pair with highest product from a given array array list of integers.\n    public static Pair<Long, Long> maxProduct(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)0l, (long)8l, (long)4l)))).equals((Pair.with(7l, 8l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)0l, (long)-1l, (long)-2l, (long)-4l, (long)5l, (long)0l, (long)-6l)))).equals((Pair.with(-4l, -6l))));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((Pair.with(2l, 3l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4612,7 +1648,7 @@
     "language": "java",
     "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find common first element in given array list of array lists.\n    public static ArrayList<ArrayList<String>> groupTuples(ArrayList<ArrayList<String>> Input) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    public static void main(String[] args) {\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"w\", (String)\"t\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"w\", (String)\"t\")))))));\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"e\")))))));\n    assert(groupTuples((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"h\", (String)\"i\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"g\", (String)\"g\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"h\", (String)\"i\")))))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4620,13 +1656,2977 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "java",
-    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three array lists into a single sorted array list.\n    public static ArrayList<Long> mergeSortedList(ArrayList<Long> num1, ArrayList<Long> num2, ArrayList<Long> num3) {\n",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the element of an array array list having maximum length.\n    public static ArrayList<Object> FindMax(ArrayList<ArrayList<Object>> lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)25l, (long)24l, (long)15l, (long)4l, (long)5l, (long)29l, (long)110l))), (new ArrayList<Long>(Arrays.asList((long)19l, (long)20l, (long)11l, (long)56l, (long)25l, (long)233l, (long)154l))), (new ArrayList<Long>(Arrays.asList((long)24l, (long)26l, (long)54l, (long)48l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)11l, (long)15l, (long)19l, (long)20l, (long)24l, (long)24l, (long)25l, (long)25l, (long)26l, (long)29l, (long)48l, (long)54l, (long)56l, (long)110l, (long)154l, (long)233l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)6l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)7l, (long)11l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)7l, (long)8l, (long)12l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)5l, (long)6l, (long)7l, (long)7l, (long)8l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    assert(mergeSortedList((new ArrayList<Long>(Arrays.asList((long)18l, (long)14l, (long)10l, (long)9l, (long)8l, (long)7l, (long)9l, (long)3l, (long)2l, (long)4l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l))), (new ArrayList<Long>(Arrays.asList((long)12l, (long)74l, (long)9l, (long)50l, (long)61l, (long)41l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)7l, (long)8l, (long)9l, (long)9l, (long)9l, (long)10l, (long)12l, (long)14l, (long)14l, (long)18l, (long)22l, (long)25l, (long)25l, (long)35l, (long)41l, (long)50l, (long)58l, (long)61l, (long)65l, (long)74l, (long)75l, (long)85l)))));\n    }\n\n}\n",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"A\", (String)\"B\", (String)\"C\")))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l)))));\n    assert(FindMax((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l, (long)6l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the cube sum of first n even natural numbers.\n    public static long cubeSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to concatenate each element of pair by the delimiter.\n    public static String concatenateTuple(Pair<String, String, Long, String> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(concatenateTuple((Pair.with(\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple((Pair.with(\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple((Pair.with(\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the average of cubes of first n natural numbers.\n    public static float findAverageOfCube(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == (float)12l);\n    assert(findAverageOfCube((1l)) == (float)1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract only the rear index element of each string in the given pair.\n    public static ArrayList<String> extractRear(Pair<String, String, String> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractRear((Pair.with(\"Mers\", \"for\", \"Vers\"))).equals((new ArrayList<String>(Arrays.asList((String)\"s\", (String)\"r\", (String)\"s\")))));\n    assert(extractRear((Pair.with(\"Avenge\", \"for\", \"People\"))).equals((new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"r\", (String)\"e\")))));\n    assert(extractRear((Pair.with(\"Gotta\", \"get\", \"go\"))).equals((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"t\", (String)\"o\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the number of subarray lists containing a particular element.\n    public static long countElementInList(ArrayList<ArrayList<Object>> list1, Object x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)15l, (long)7l))))), (Object(1l))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"A\"))) == (3l));\n    assert(countElementInList((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"B\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"C\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"A\", (String)\"D\", (String)\"E\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"B\", (String)\"C\", (String)\"D\"))))), (Object(\"E\"))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to filter odd numbers.\n    public static ArrayList<Long> filterOddnumbers(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)45l, (long)67l, (long)84l, (long)93l)))).equals((new ArrayList<Long>(Arrays.asList((long)45l, (long)67l, (long)93l)))));\n    assert(filterOddnumbers((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)8l, (long)6l, (long)4l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)9l, (long)3l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    public static String changeDateFormat(String dt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array array list by using shell sort.\n    public static ArrayList<Long> shellSort(ArrayList<Long> my_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)12l, (long)23l, (long)4l, (long)5l, (long)3l, (long)2l, (long)12l, (long)81l, (long)56l, (long)95l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)12l, (long)12l, (long)23l, (long)56l, (long)81l, (long)95l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)24l, (long)22l, (long)39l, (long)34l, (long)87l, (long)73l, (long)68l)))).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l, (long)34l, (long)39l, (long)68l, (long)73l, (long)87l)))));\n    assert(shellSort((new ArrayList<Long>(Arrays.asList((long)32l, (long)30l, (long)16l, (long)96l, (long)82l, (long)83l, (long)74l)))).equals((new ArrayList<Long>(Arrays.asList((long)16l, (long)30l, (long)32l, (long)74l, (long)82l, (long)83l, (long)96l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract the elementwise and pairs from the given two pairs.\n    public static Pair<Long, Long, Long, Long> andTuples(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(andTuples((Pair.with(10l, 4l, 6l, 9l)), (Pair.with(5l, 2l, 3l, 3l))).equals((Pair.with(0l, 0l, 2l, 1l))));\n    assert(andTuples((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(5l, 6l, 7l, 8l))).equals((Pair.with(1l, 2l, 3l, 0l))));\n    assert(andTuples((Pair.with(8l, 9l, 11l, 12l)), (Pair.with(7l, 13l, 14l, 17l))).equals((Pair.with(0l, 9l, 10l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the directrix of a parabola.\n    public static long parabolaDirectrix(long a, long b, long c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes two array lists and returns true if they have at least one common element.\n    public static Optional<Boolean> commonElement(ArrayList<Object> list1, ArrayList<Object> list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.of(true)));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Object>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))).equals(Optional.empty()));\n    assert(commonElement((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\"))), (new ArrayList<Object>(Arrays.asList((String)\"d\", (String)\"b\", (String)\"e\")))).equals(Optional.of(true)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median length of a trapezium.\n    public static float medianTrapezium(long base1, long base2, long height) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(medianTrapezium((15l), (25l), (35l)) == (float)20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == (float)15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array array list.\n    public static boolean checkGreater(ArrayList<Long> arr, long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (4l)) == (false));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (8l)) == (true));\n    assert(checkGreater((new ArrayList<Long>(Arrays.asList((long)9l, (long)7l, (long)4l, (long)8l, (long)6l, (long)1l))), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    public static boolean textMatchOne(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last digit of a given number.\n    public static long lastDigit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to return the negative numbers in an array array list.\n    public static ArrayList<Long> negNos(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)4l, (long)5l, (long)-6l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-6l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l)))));\n    assert(negNos((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l, (long)8l, (long)9l)))).equals((new ArrayList<Long>(Arrays.asList((long)-7l, (long)-6l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove odd characters in a string.\n    public static String removeOdd(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count bidirectional pair pairs.\n    public static long countBidirectional(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (3l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 3l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 1l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (2l));\n    assert(countBidirectional((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(9l, 2l), (Pair<Long, Long>)Pair.with(6l, 5l), (Pair<Long, Long>)Pair.with(2l, 1l))))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to join an array array list of multiple integers into a single integer.\n    public static long multipleToSingle(ArrayList<Long> L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)11l, (long)33l, (long)50l)))) == (113350l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (-123456l));\n    assert(multipleToSingle((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l)))) == (10152025l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    public static Pair<Long, Long, String> findAdverbPosition(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals((Pair.with(0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals((Pair.with(0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals((Pair.with(0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    public static long surfaceareaCube(long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the ration of positive numbers in an array array list of integers.\n    public static float positiveCount(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.54f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (0.69f));\n    assert(positiveCount((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l)))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the largest negative number from the given array list.\n    public static long largestNeg(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-4l, (long)-6l)))) == (-6l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)-8l, (long)-9l)))) == (-9l));\n    assert(largestNeg((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)-1l)))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to trim each array list by k in the given array lists.\n    public static ArrayList<ArrayList<Long>> trimTuple(ArrayList<ArrayList<Long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (2l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)3l, (long)2l, (long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)9l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)1l, (long)2l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l, (long)2l, (long)1l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)9l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)2l, (long)1l)))))));\n    assert(trimTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)4l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)8l, (long)12l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)9l, (long)7l))))), (1l)).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)9l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to perform index wise multiplication of array list elements in the given two array lists.\n    public static ArrayList<ArrayList<Long>> indexMultiplication(ArrayList<ArrayList<Long>> test_tup1, ArrayList<ArrayList<Long>> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)10l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)21l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)30l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)11l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)14l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)60l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)20l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)16l, (long)44l)))))));\n    assert(indexMultiplication((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)12l))))), (new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l)))))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)24l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)77l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)27l, (long)60l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the occurence of all elements of array list in a pair.\n    public static long countOccurrence(Object tup, ArrayList<Object> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countOccurrence(Pair.with(\"a\", \"a\", \"c\", \"b\", \"d\"), (new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\")))) == (3l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)4l, (long)7l)))) == (6l));\n    assert(countOccurrence(Pair.with(1l, 2l, 3l, 4l, 5l, 6l), (new ArrayList<Object>(Arrays.asList((long)1l, (long)2l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find cubes of individual elements in an array array list.\n    public static ArrayList<Long> cubeNums(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)8l, (long)27l, (long)64l, (long)125l, (long)216l, (long)343l, (long)512l, (long)729l, (long)1000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(cubeNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)1728l, (long)3375l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    public static long calSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract specified size of strings from a given array list of string values.\n    public static ArrayList<String> extractString(ArrayList<String> str, long l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (8l)).equals((new ArrayList<String>(Arrays.asList((String)\"practice\", (String)\"solution\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (6l)).equals((new ArrayList<String>(Arrays.asList((String)\"Python\")))));\n    assert(extractString((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"list\", (String)\"exercises\", (String)\"practice\", (String)\"solution\"))), (9l)).equals((new ArrayList<String>(Arrays.asList((String)\"exercises\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from the given string.\n    public static String removeWhitespaces(String text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    public static long lossAmount(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of even factors of a number.\n    public static long sumofFactors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a word containing 'z'.\n    public static boolean textMatchWordz(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    public static boolean checkMonthnumbNumber(long monthnum2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse each string in a given array list of string values.\n    public static ArrayList<String> reverseStringList(ArrayList<String> stringlist) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"Red\", (String)\"Green\", (String)\"Blue\", (String)\"White\", (String)\"Black\")))).equals((new ArrayList<String>(Arrays.asList((String)\"deR\", (String)\"neerG\", (String)\"eulB\", (String)\"etihW\", (String)\"kcalB\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"john\", (String)\"amal\", (String)\"joel\", (String)\"george\")))).equals((new ArrayList<String>(Arrays.asList((String)\"nhoj\", (String)\"lama\", (String)\"leoj\", (String)\"egroeg\")))));\n    assert(reverseStringList((new ArrayList<String>(Arrays.asList((String)\"jack\", (String)\"john\", (String)\"mary\")))).equals((new ArrayList<String>(Arrays.asList((String)\"kcaj\", (String)\"nhoj\", (String)\"yram\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the subarray list having minimum length.\n    public static ArrayList<Object> FindMin(ArrayList<ArrayList<Object>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)7l, (long)8l)))))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)1l)))));\n    assert(FindMin((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")))))).equals((new ArrayList<Object>(Arrays.asList((String)\"x\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the area of a rectangle.\n    public static long rectangleArea(long l, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    public static String removeUppercase(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to get the first element of each subarray list.\n    public static ArrayList<Long> Extract(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)6l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))));\n    assert(Extract((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the upper case characters in a given string.\n    public static long upperCtr(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product subarray array list of the given array array list.\n    public static long maxSubarrayProduct(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)-3l, (long)0l, (long)7l, (long)-8l, (long)-2l)))) == (112l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)6l, (long)-3l, (long)-10l, (long)0l, (long)2l)))) == (180l));\n    assert(maxSubarrayProduct((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-40l, (long)0l, (long)-2l, (long)-3l)))) == (80l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if all values are same in a hash map.\n    public static boolean checkValue(HashMap<String,Long> dict, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (10l)) == (false));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (12l)) == (true));\n    assert(checkValue((new HashMap<String,Long>(Map.of(\"Cierra Vega\", 12l, \"Alden Cantrell\", 12l, \"Kierra Gentry\", 12l, \"Pierre Cox\", 12l))), (5l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to drop empty items from a given hash map.\n    public static HashMap<String,String> dropEmpty(HashMap<String,Optional<String>> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", \"Green\")))));\n    assert(dropEmpty(new HashMap<String,String>(Map.of(\"c1\", \"Red\", \"c2\", Optional.empty(), \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c1\", \"Red\")))));\n    assert(dropEmpty(new HashMap<String,Optional.empty()>(Map.of(\"c1\", Optional.empty(), \"c2\", \"Green\", \"c3\", Optional.empty()))).equals((new HashMap<String,String>(Map.of(\"c2\", \"Green\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array array list.\n    public static long maxProduct(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)3l, (long)100l, (long)4l, (long)5l, (long)150l, (long)6l)))) == (3000l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)4l, (long)42l, (long)55l, (long)68l, (long)80l)))) == (50265600l));\n    assert(maxProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)22l, (long)9l, (long)33l, (long)21l, (long)50l, (long)41l, (long)60l)))) == (2460l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given pair.\n    public static Pair<Long, Long, Long, Long> addPairwise(Pair<Long, Long, Long, Long, Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addPairwise((Pair.with(1l, 5l, 7l, 8l, 10l))).equals((Pair.with(6l, 12l, 15l, 18l))));\n    assert(addPairwise((Pair.with(2l, 6l, 8l, 9l, 11l))).equals((Pair.with(8l, 14l, 17l, 20l))));\n    assert(addPairwise((Pair.with(3l, 7l, 9l, 10l, 12l))).equals((Pair.with(10l, 16l, 19l, 22l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the product of the array array list multiplication modulo n.\n    public static long findRemainder(ArrayList<Long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)100l, (long)10l, (long)5l, (long)25l, (long)35l, (long)14l))), (11l)) == (9l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l))), (1l)) == (0l));\n    assert(findRemainder((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (2l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given array list contains consecutive numbers or not.\n    public static boolean checkConsecutive(ArrayList<Long> l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (true));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)6l)))) == (false));\n    assert(checkConsecutive((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace characters in a string.\n    public static String replaceChar(String str1, String ch, String newch) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a hash map by value.\n    public static ArrayList<Pair<String, Long>> sortCounter(HashMap<String,Long> dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 81l, \"Physics\", 83l, \"Chemistry\", 87l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 87l), (Pair<String, Long>)Pair.with(\"Physics\", 83l), (Pair<String, Long>)Pair.with(\"Math\", 81l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 400l, \"Physics\", 300l, \"Chemistry\", 250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Math\", 400l), (Pair<String, Long>)Pair.with(\"Physics\", 300l), (Pair<String, Long>)Pair.with(\"Chemistry\", 250l))))));\n    assert(sortCounter((new HashMap<String,Long>(Map.of(\"Math\", 900l, \"Physics\", 1000l, \"Chemistry\", 1250l)))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Chemistry\", 1250l), (Pair<String, Long>)Pair.with(\"Physics\", 1000l), (Pair<String, Long>)Pair.with(\"Math\", 900l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the largest and smallest value in a given array array list.\n    public static long bigSum(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)-1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigSum((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert the given string to lower case.\n    public static String isLower(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    public static String removeLowercase(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first digit of a given number.\n    public static long firstDigit(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the n largest integers from a given array list of numbers, returned in descending order.\n    public static ArrayList<Long> heapQueueLargest(ArrayList<Long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l)))));\n    assert(heapQueueLargest((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)22l, (long)58l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)85l, (long)75l, (long)65l, (long)58l, (long)35l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of integers and only returns the odd ones.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l, (long)13l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)13l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)9l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    public static long difference(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of pairs whose xor value is odd.\n    public static long findOddPair(ArrayList<Long> A, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)7l, (long)2l, (long)1l))), (5l)) == (6l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)7l, (long)2l, (long)8l, (long)1l, (long)0l, (long)5l, (long)11l))), (7l)) == (12l));\n    assert(findOddPair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to toggle the case of all characters in a string.\n    public static String toggleString(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the per-digit difference between two integers.\n    public static long digitDistanceNums(long n1, long n2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the sum of the largest contiguous subarray list in the given array list.\n    public static long maxSubArraySum(ArrayList<Long> a, long size) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-2l, (long)-3l, (long)4l, (long)-1l, (long)-2l, (long)1l, (long)5l, (long)-3l))), (8l)) == (7l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-3l, (long)-4l, (long)5l, (long)-2l, (long)-3l, (long)2l, (long)6l, (long)-4l))), (8l)) == (8l));\n    assert(maxSubArraySum((new ArrayList<Long>(Arrays.asList((long)-4l, (long)-5l, (long)6l, (long)-3l, (long)-4l, (long)3l, (long)7l, (long)-5l))), (8l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the union of the elements of two given array lists and output them in sorted order.\n    public static ArrayList<Long> unionElements(ArrayList<Long> test_tup1, ArrayList<Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)7l, (long)4l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)10l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))));\n    assert(unionElements((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l))), (new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)16l, (long)17l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)12l, (long)13l, (long)14l, (long)15l, (long)16l, (long)17l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the longest subarray lists.\n    public static long FindMaxLength(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)))))) == (4l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))))) == (3l));\n    assert(FindMaxLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)22l, (long)23l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)14l, (long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l)))))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks from a string.\n    public static ArrayList<String> extractValues(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"Python\", (String)\"PHP\", (String)\"Java\")))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"program\", (String)\"language\")))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"blue\", (String)\"green\", (String)\"yellow\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    public static long countPairs(ArrayList<Long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (3l)) == (2l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (4l)) == (0l));\n    assert(countPairs((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (5l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to split a string into characters.\n    public static ArrayList<String> split(String word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(split((\"python\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"y\", (String)\"t\", (String)\"h\", (String)\"o\", (String)\"n\")))));\n    assert(split((\"Name\")).equals((new ArrayList<String>(Arrays.asList((String)\"N\", (String)\"a\", (String)\"m\", (String)\"e\")))));\n    assert(split((\"program\")).equals((new ArrayList<String>(Arrays.asList((String)\"p\", (String)\"r\", (String)\"o\", (String)\"g\", (String)\"r\", (String)\"a\", (String)\"m\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    public static long sumDigits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a specified array list is sorted or not.\n    public static boolean issortList(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)16l, (long)17l)))) == (true));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)12l, (long)14l, (long)20l, (long)17l)))) == (false));\n    assert(issortList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)6l, (long)8l, (long)10l, (long)15l, (long)14l, (long)20l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create an array array list of N empty dictionaries.\n    public static ArrayList<HashMap<Optional.empty(),Optional.empty()>> emptyList(long length) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(emptyList((5l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((6l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    assert(emptyList((7l)).equals(Optional.of(new ArrayList<HashMap<Long,Long>>(Arrays.asList((HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()), (HashMap<Long,Long>)new HashMap<Long,Long>(Map.of()))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort each subarray list of strings in a given array list of array lists.\n    public static ArrayList<ArrayList<String>> sortSublists(ArrayList<ArrayList<String>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\", (String)\"black\", (String)\"orange\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"white\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\", (String)\"orange\", (String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"black\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"green\", (String)\"orange\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"white\")))))));\n    assert(sortSublists((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"f\", (String)\"e\")))))).equals((new ArrayList<ArrayList<String>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\", (String)\"d\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"g\", (String)\"h\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"e\", (String)\"f\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check if a given number is one less than twice its reverse.\n    public static boolean checks(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to remove duplicate numbers from a given number of array lists.\n    public static ArrayList<Long> twoUniqueNums(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)4l, (long)5l)))));\n    assert(twoUniqueNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to calculate the product of the unique numbers in a given array list.\n    public static long uniqueProduct(ArrayList<Long> list_data) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)20l, (long)50l, (long)60l, (long)40l)))) == (720000000l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l)))) == (6l));\n    assert(uniqueProduct((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)0l, (long)1l, (long)1l)))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the surface area of a cylinder.\n    public static float surfaceareaCylinder(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether an array array list is subarray list of another or not.\n    public static boolean isSubArray(ArrayList<Long> A, ArrayList<Long> B) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)3l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (false));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l)))) == (true));\n    assert(isSubArray((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)0l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last digit in factorial of a given number.\n    public static long lastDigitFactorial(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to interleave 3 array lists of the same length into a single flat array list.\n    public static ArrayList<Long> interleaveLists(ArrayList<Long> list1, ArrayList<Long> list2, ArrayList<Long> list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l, (long)50l, (long)60l, (long)70l))), (new ArrayList<Long>(Arrays.asList((long)100l, (long)200l, (long)300l, (long)400l, (long)500l, (long)600l, (long)700l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)100l, (long)2l, (long)20l, (long)200l, (long)3l, (long)30l, (long)300l, (long)4l, (long)40l, (long)400l, (long)5l, (long)50l, (long)500l, (long)6l, (long)60l, (long)600l, (long)7l, (long)70l, (long)700l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)5l, (long)20l, (long)2l, (long)10l)))));\n    assert(interleaveLists((new ArrayList<Long>(Arrays.asList((long)11l, (long)44l))), (new ArrayList<Long>(Arrays.asList((long)10l, (long)15l))), (new ArrayList<Long>(Arrays.asList((long)20l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)11l, (long)10l, (long)20l, (long)44l, (long)15l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the dissimilar elements in the given two pairs.\n    public static Pair<Long, Long, Long, Long> findDissimilar(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findDissimilar((Pair.with(3l, 4l, 5l, 6l)), (Pair.with(5l, 7l, 4l, 10l))).equals((Pair.with(3l, 6l, 7l, 10l))));\n    assert(findDissimilar((Pair.with(1l, 2l, 3l, 4l)), (Pair.with(7l, 2l, 3l, 9l))).equals((Pair.with(1l, 4l, 7l, 9l))));\n    assert(findDissimilar((Pair.with(21l, 11l, 25l, 26l)), (Pair.with(26l, 34l, 21l, 36l))).equals((Pair.with(34l, 36l, 11l, 25l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the largest number that can be formed with the given array list of digits.\n    public static long findMaxNum(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (321l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)1l)))) == (6541l));\n    assert(findMaxNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)9l)))) == (9321l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove uneven elements in the nested mixed pair.\n    public static Object extractEven(Pair<Long, Long, Pair<Long, Long, Pair<Long, Long>>, Long, Long> test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractEven((Pair.with(4l, 5l, Pair.with(7l, 6l, Pair.with(2l, 4l)), 6l, 8l))).equals(Pair.with(4l, Pair.with(6l, Pair.with(2l, 4l)), 6l, 8l)));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(8l, 7l, Pair.with(4l, 8l)), 7l, 9l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 8l)))));\n    assert(extractEven((Pair.with(5l, 6l, Pair.with(9l, 8l, Pair.with(4l, 6l)), 8l, 10l))).equals(Pair.with(6l, Pair.with(8l, Pair.with(4l, 6l)), 8l, 10l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the surface area of a square javaramid with a given base edge and height.\n    public static long surfaceArea(long b, long s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which returns nth catalan number.\n    public static long catalanNumber(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    public static String findAdverbs(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to split an array array list at the nth eelment and add the first part to the end.\n    public static ArrayList<Long> splitArr(ArrayList<Long> l, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)5l, (long)6l, (long)52l, (long)36l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)52l, (long)36l, (long)12l, (long)10l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l))), (1l)).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(splitArr((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)0l, (long)1l, (long)2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert an array array list to a pair.\n    public static Object listTuple(ArrayList<Long> listx) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)10l, (long)7l, (long)4l, (long)15l, (long)3l)))).equals(Pair.with(5l, 10l, 7l, 4l, 15l, 3l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)2l, (long)3l, (long)4l, (long)4l, (long)7l)))).equals(Pair.with(2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)));\n    assert(listTuple((new ArrayList<Long>(Arrays.asList((long)58l, (long)44l, (long)56l)))).equals(Pair.with(58l, 44l, 56l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the difference between largest and smallest value in a given array list.\n    public static long bigDiff(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (3l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)12l)))) == (8l));\n    assert(bigDiff((new ArrayList<Long>(Arrays.asList((long)9l, (long)2l, (long)3l)))) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find perfect squares between two given numbers.\n    public static ArrayList<Long> perfectSquares(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(perfectSquares((1l), (30l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l)))));\n    assert(perfectSquares((50l), (100l)).equals((new ArrayList<Long>(Arrays.asList((long)64l, (long)81l, (long)100l)))));\n    assert(perfectSquares((100l), (200l)).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)121l, (long)144l, (long)169l, (long)196l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given two integers have opposite sign or not.\n    public static boolean oppositeSigns(long x, long y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to interchange the first and last elements in an array array list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)12l, (long)35l, (long)9l, (long)56l, (long)24l)))).equals((new ArrayList<Long>(Arrays.asList((long)24l, (long)35l, (long)9l, (long)56l, (long)12l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of the product of consecutive binomial co-efficients.\n    public static long sumOfProduct(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    public static String removezeroIp(String ip) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the difference of the first even and first odd number of a given array list.\n    public static long diffEvenOdd(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (3l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (1l));\n    assert(diffEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    public static Object minSwaps(String str1, String str2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Object(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Object(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Object(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find kth element from the given two sorted array array lists.\n    public static long findKth(ArrayList<Long> arr1, ArrayList<Long> arr2, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)8l, (long)10l))), (5l)) == (6l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)100l, (long)112l, (long)256l, (long)349l, (long)770l))), (new ArrayList<Long>(Arrays.asList((long)72l, (long)86l, (long)113l, (long)119l, (long)265l, (long)445l, (long)892l))), (7l)) == (256l));\n    assert(findKth((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)7l, (long)8l, (long)10l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)9l, (long)11l))), (6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    public static boolean armstrongNumber(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    public static Pair<Long, Float> sumAverage(long number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumAverage((10l)).equals((Pair.with(55l, 5.5f))));\n    assert(sumAverage((15l)).equals((Pair.with(120l, 8.0f))));\n    assert(sumAverage((20l)).equals((Pair.with(210l, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth octagonal number.\n    public static long isOctagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number is even or not.\n    public static boolean isEven(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first repeated character in a given string.\n    public static Optional<String> firstRepeatedChar(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Optional.of(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(Optional.empty()));\n    assert(firstRepeatedChar((\"123123\")).equals(Optional.of(\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    public static ArrayList<Long> getLudic(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getLudic((10l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l)))));\n    assert(getLudic((25l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l)))));\n    assert(getLudic((45l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)5l, (long)7l, (long)11l, (long)13l, (long)17l, (long)23l, (long)25l, (long)29l, (long)37l, (long)41l, (long)43l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    public static String reverseWords(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given integer is a prime number.\n    public static boolean primeNum(long num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert degrees to radians.\n    public static float radianDegree(long degree) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    public static Pair<String, Long, Long> findLiterals(String text, String pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals((Pair.with(\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals((Pair.with(\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals((Pair.with(\"will\", 35l, 39l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find nth bell number.\n    public static long bellNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list and returns an array array list with the same elements, but the k'th element removed.\n    public static ArrayList<Long> removeKthElement(ArrayList<Long> list1, long L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)1l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))));\n    assert(removeKthElement((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which given a matrix represented as an array array list of array lists returns the max of the n'th column.\n    public static long maxOfNth(ArrayList<ArrayList<Long>> test_list, long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)19l))))), (2l)) == (19l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)20l))))), (1l)) == (10l));\n    assert(maxOfNth((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)21l))))), (1l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function which takes an array array list of array lists, where each subarray list has two elements, and returns an array array list of two array lists where the first array list has the first element of each subarray list and the second one has the second.\n    public static ArrayList<ArrayList<Object>> merge(ArrayList<ArrayList<Object>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l)))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)6l, (long)8l)))))));\n    assert(merge((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"y\", (String)\"z\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"m\", (String)\"n\", (String)\"o\")))))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"x\", (String)\"a\", (String)\"m\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"y\", (String)\"b\", (String)\"n\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"z\", (String)\"c\", (String)\"o\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given array list of array lists.\n    public static long cummulativeSum(ArrayList<ArrayList<Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)6l)))))) == (30l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))))) == (37l));\n    assert(cummulativeSum((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)8l)))))) == (44l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes an array array lists of array lists and returns the average value for each subarray list as an array array list.\n    public static ArrayList<Float> averageTuple(ArrayList<ArrayList<Long>> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)45l, (long)56l, (long)45l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)80l, (long)39l, (long)32l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))).equals((new ArrayList<Float>(Arrays.asList((float)30.5f, (float)34.25f, (float)27.0f, (float)23.25f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)-5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)30l, (long)-15l, (long)56l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)81l, (long)-60l, (long)-39l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)-10l, (long)2l, (long)3l)))))).equals((new ArrayList<Float>(Arrays.asList((float)25.5f, (float)-18.0f, (float)3.75f)))));\n    assert(averageTuple((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)100l, (long)100l, (long)100l, (long)120l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)300l, (long)450l, (long)560l, (long)450l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)810l, (long)800l, (long)390l, (long)320l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new ArrayList<Float>(Arrays.asList((float)305.0f, (float)342.5f, (float)270.0f, (float)232.5f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function which takes two pairs of the same length and performs the element wise modulo.\n    public static Pair<Long, Long, Long, Long> tupleModulo(Pair<Long, Long, Long, Long> test_tup1, Pair<Long, Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleModulo((Pair.with(10l, 4l, 5l, 6l)), (Pair.with(5l, 6l, 7l, 5l))).equals((Pair.with(0l, 4l, 5l, 1l))));\n    assert(tupleModulo((Pair.with(11l, 5l, 6l, 7l)), (Pair.with(6l, 7l, 8l, 6l))).equals((Pair.with(5l, 5l, 6l, 1l))));\n    assert(tupleModulo((Pair.with(12l, 6l, 7l, 8l)), (Pair.with(7l, 8l, 9l, 7l))).equals((Pair.with(5l, 6l, 7l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    public static float minJumps(Pair<Long, Long> steps, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minJumps((Pair.with(3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps((Pair.with(3l, 4l)), (0l)) == (float)0l);\n    assert(minJumps((Pair.with(11l, 14l)), (11l)) == (float)1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to divide two array lists element wise.\n    public static ArrayList<Float> divList(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Float>(Arrays.asList((float)4.0f, (float)2.5f, (float)2.0f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)4l)))).equals((new ArrayList<Float>(Arrays.asList((float)3.0f, (float)0.5f)))));\n    assert(divList((new ArrayList<Long>(Arrays.asList((long)90l, (long)120l))), (new ArrayList<Long>(Arrays.asList((long)50l, (long)70l)))).equals((new ArrayList<Float>(Arrays.asList((float)1.8f, (float)1.7142857142857142f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    public static String moveNum(String test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of substrings with the sum of digits equal to their length.\n    public static long countSubstrings(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the median of two sorted array lists of same size.\n    public static float getMedian(ArrayList<Long> arr1, ArrayList<Long> arr2, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)1l, (long)12l, (long)15l, (long)26l, (long)38l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)13l, (long)17l, (long)30l, (long)45l))), (5l)) == (16.0f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)8l, (long)9l))), (new ArrayList<Long>(Arrays.asList((long)7l, (long)13l, (long)19l, (long)28l))), (4l)) == (8.5f));\n    assert(getMedian((new ArrayList<Long>(Arrays.asList((long)3l, (long)6l, (long)14l, (long)23l, (long)36l, (long)42l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)18l, (long)27l, (long)39l, (long)49l, (long)55l))), (6l)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to compute the n-th power of each number in an array array list.\n    public static ArrayList<Long> nthNums(ArrayList<Long> nums, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)1000l, (long)8000l, (long)27000l)))));\n    assert(nthNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)248832l, (long)759375l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to convert a given string to uppercase.\n    public static String isUpper(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to interchange the first and last element in a given array list.\n    public static ArrayList<Long> swapList(ArrayList<Long> newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))).equals((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)2l, (long)3l, (long)4l, (long)1l)))));\n    assert(swapList((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    public static Optional<Long> triangleArea(long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(triangleArea((-1l)).equals(Optional.empty()));\n    assert(triangleArea((0l)).equals(Optional.of(0l)));\n    assert(triangleArea((2l)).equals(Optional.of(4l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the smallest missing number from a sorted array list of natural numbers.\n    public static long findFirstMissing(ArrayList<Long> array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l)))) == (4l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)6l, (long)9l)))) == (3l));\n    assert(findFirstMissing((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)8l, (long)9l)))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    public static String replaceSpaces(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find even numbers from an array array list of numbers.\n    public static ArrayList<Long> Split(ArrayList<Long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)0l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)6l, (long)8l, (long)0l)))));\n    assert(Split((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l, (long)15l, (long)19l)))).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find smallest number in an array array list.\n    public static long smallestNum(ArrayList<Long> xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)1l, (long)45l, (long)99l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (1l));\n    assert(smallestNum((new ArrayList<Long>(Arrays.asList((long)45l, (long)46l, (long)50l, (long)60l)))) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate pair.\n    public static ArrayList<ArrayList<Long>> getCoordinates(Pair<Long, Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getCoordinates((Pair.with(3l, 4l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))));\n    assert(getCoordinates((Pair.with(4l, 5l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)))))));\n    assert(getCoordinates((Pair.with(5l, 6l))).equals((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)7l)))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    public static String replaceSpaces(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to move all zeroes to the end of the given array list.\n    public static ArrayList<Long> moveZero(ArrayList<Long> num_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)1l, (long)0l, (long)2l, (long)0l, (long)3l, (long)4l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)0l, (long)0l, (long)4l, (long)0l, (long)5l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)4l, (long)5l, (long)0l, (long)0l, (long)0l, (long)0l)))));\n    assert(moveZero((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)0l, (long)1l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)0l, (long)0l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of xor of all pairs of numbers in the given array list.\n    public static long pairXorSum(ArrayList<Long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)5l, (long)9l, (long)7l, (long)6l))), (4l)) == (47l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)5l))), (3l)) == (12l));\n    assert(pairXorSum((new ArrayList<Long>(Arrays.asList((long)7l, (long)3l))), (2l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort the given array list.\n    public static ArrayList<Long> heapSort(ArrayList<Long> iterable) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)9l, (long)2l, (long)4l, (long)6l, (long)8l, (long)0l)))).equals((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)25l, (long)35l, (long)22l, (long)85l, (long)14l, (long)65l, (long)75l, (long)25l, (long)58l)))).equals((new ArrayList<Long>(Arrays.asList((long)14l, (long)22l, (long)25l, (long)25l, (long)35l, (long)58l, (long)65l, (long)75l, (long)85l)))));\n    assert(heapSort((new ArrayList<Long>(Arrays.asList((long)7l, (long)1l, (long)9l, (long)5l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    public static boolean noprofitNoloss(long actual_cost, long sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    public static long windChill(long v, long t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sum the length of the names of a given array list of names after removing the names that start with a lowercase letter.\n    public static long sampleNam(ArrayList<String> sample_names) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"sally\", (String)\"Dylan\", (String)\"rebecca\", (String)\"Diana\", (String)\"Joanne\", (String)\"keith\")))) == (16l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"php\", (String)\"res\", (String)\"Python\", (String)\"abcd\", (String)\"Java\", (String)\"aaa\")))) == (10l));\n    assert(sampleNam((new ArrayList<String>(Arrays.asList((String)\"abcd\", (String)\"Python\", (String)\"abba\", (String)\"aba\")))) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the maximum difference between available pairs in the given pair array list.\n    public static long maxDifference(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(1l, 7l), (Pair<Long, Long>)Pair.with(10l, 3l), (Pair<Long, Long>)Pair.with(1l, 2l))))) == (7l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(2l, 17l), (Pair<Long, Long>)Pair.with(9l, 13l), (Pair<Long, Long>)Pair.with(11l, 12l))))) == (15l));\n    assert(maxDifference((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 35l), (Pair<Long, Long>)Pair.with(21l, 27l), (Pair<Long, Long>)Pair.with(13l, 23l), (Pair<Long, Long>)Pair.with(41l, 22l))))) == (23l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    public static String removeParenthesis(ArrayList<String> items) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"python (chrome)\")))).equals((\"python\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"string(.abc)\")))).equals((\"string\")));\n    assert(removeParenthesis((new ArrayList<String>(Arrays.asList((String)\"alpha(num)\")))).equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth nonagonal number.\n    public static long isNonagonal(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    public static boolean textMatchWordzMiddle(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to reverse an array array list upto a given position.\n    public static ArrayList<Long> reverseArrayUptoK(ArrayList<Long> input, long k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (4l)).equals((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)1l, (long)5l, (long)6l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)4l, (long)6l, (long)7l)))));\n    assert(reverseArrayUptoK((new ArrayList<Long>(Arrays.asList((long)9l, (long)8l, (long)7l, (long)6l, (long)5l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)6l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of pairs using the second value of each pair.\n    public static ArrayList<Pair<String, Long>> subjectMarks(ArrayList<Pair<String, Long>> subjectmarks) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l), (Pair<String, Long>)Pair.with(\"Social sciences\", 82l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social sciences\", 82l), (Pair<String, Long>)Pair.with(\"English\", 88l), (Pair<String, Long>)Pair.with(\"Science\", 90l), (Pair<String, Long>)Pair.with(\"Maths\", 97l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l), (Pair<String, Long>)Pair.with(\"Social\", 33l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Social\", 33l), (Pair<String, Long>)Pair.with(\"Telugu\", 49l), (Pair<String, Long>)Pair.with(\"Hindhi\", 54l))))));\n    assert(subjectMarks((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l), (Pair<String, Long>)Pair.with(\"Biology\", 45l))))).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Biology\", 45l), (Pair<String, Long>)Pair.with(\"Physics\", 96l), (Pair<String, Long>)Pair.with(\"Chemistry\", 97l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of positive numbers in an array array list.\n    public static long posCount(ArrayList<Long> list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l, (long)-4l)))) == (2l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l, (long)-1l)))) == (3l));\n    assert(posCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    public static long bellNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given array array list is monotonic or not.\n    public static boolean isMonotonic(ArrayList<Long> A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l, (long)4l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)2l, (long)3l)))) == (true));\n    assert(isMonotonic((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether an array array list contains the given subarray list or not.\n    public static boolean isSublist(ArrayList<Long> l, ArrayList<Long> s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)3l, (long)7l)))) == (false));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)4l, (long)3l)))) == (true));\n    assert(isSublist((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)3l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)1l, (long)6l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the two numbers differ at one bit position only or not.\n    public static boolean differAtOneBitPos(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find whether all the given array lists have equal length or not.\n    public static boolean getEqual(ArrayList<ArrayList<Long>> Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)11l, (long)22l, (long)33l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)44l, (long)55l, (long)66l)))))) == (true));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)7l)))))) == (false));\n    assert(getEqual((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l)))))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort an array array list of elements.\n    public static ArrayList<Long> combSort(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)37l, (long)25l, (long)79l)))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)15l, (long)25l, (long)37l, (long)79l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)41l, (long)32l, (long)15l, (long)19l, (long)22l)))).equals((new ArrayList<Long>(Arrays.asList((long)15l, (long)19l, (long)22l, (long)32l, (long)41l)))));\n    assert(combSort((new ArrayList<Long>(Arrays.asList((long)99l, (long)15l, (long)13l, (long)47l)))).equals((new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)47l, (long)99l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add a hash map to the pair. The output should be a pair.\n    public static Pair<Long, Long, Long, HashMap<String,Long>> addDictToTuple(Pair<Long, Long, Long> test_tup, HashMap<String,Long> test_dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addDictToTuple((Pair.with(4l, 5l, 6l)), (new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l)))).equals((Pair.with(4l, 5l, 6l, new HashMap<String,Long>(Map.of(\"MSAM\", 1l, \"is\", 2l, \"best\", 3l))))));\n    assert(addDictToTuple((Pair.with(1l, 2l, 3l)), (new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l)))).equals((Pair.with(1l, 2l, 3l, new HashMap<String,Long>(Map.of(\"UTS\", 2l, \"is\", 3l, \"Worst\", 4l))))));\n    assert(addDictToTuple((Pair.with(8l, 9l, 10l)), (new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l)))).equals((Pair.with(8l, 9l, 10l, new HashMap<String,Long>(Map.of(\"POS\", 3l, \"is\", 4l, \"Okay\", 5l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given a square matrix of size N*N given as an array array list of array lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    public static float maxAverageOfPath(ArrayList<ArrayList<Long>> cost) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)3l, (long)9l)))))) == (5.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)6l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)4l, (long)10l)))))) == (6.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)4l, (long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l, (long)7l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)5l, (long)11l)))))) == (7.2f));\n    assert(maxAverageOfPath((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is given as - a hash map with a student name as a key and a pair of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    public static HashMap<String,Pair<Float, Long>> filterData(HashMap<String,Pair<Float, Long>> students, float h, long w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (6.0f), (70l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.9f), (67l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Kierra Gentry\", Pair.with(6.0f, 68l))))));\n    assert(filterData((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l)))), (5.7f), (64l)).equals((new HashMap<String,Pair<Float, Long>>(Map.of(\"Cierra Vega\", Pair.with(6.2f, 70l), \"Alden Cantrell\", Pair.with(5.9f, 65l), \"Kierra Gentry\", Pair.with(6.0f, 68l), \"Pierre Cox\", Pair.with(5.8f, 66l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // The input is defined as two array lists of the same length. Write a function to count indices where the array lists have the same values.\n    public static long countSamePair(ArrayList<Long> nums1, ArrayList<Long> nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)2l, (long)3l, (long)1l, (long)2l, (long)6l, (long)7l, (long)9l)))) == (4l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)0l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (11l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)-6l, (long)-9l, (long)11l, (long)-12l, (long)14l, (long)-5l, (long)17l))), (new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)2l, (long)-1l, (long)-5l, (long)6l, (long)4l, (long)-3l, (long)-2l, (long)3l, (long)4l, (long)6l, (long)8l)))) == (1l));\n    assert(countSamePair((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)1l, (long)2l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)2l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    public static long powerBaseSum(long base, long power) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    public static ArrayList<Object> extractQuotation(String text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"A53\", (String)\"multi\", (String)\"Processor\")))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((new ArrayList<Object>(Arrays.asList((String)\"favorite\", (String)\"apps\")))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((new ArrayList<Object>(Arrays.asList((String)\"4k Ultra HD\", (String)\"HDR 10\")))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that takes as input an array array list of numbers (t_1,...,t_{N+1}) and returns an array array list of length N where the i-th element of the pair is equal to t_i * t_{i+1}.\n    public static ArrayList<Object> multiplyElements(ArrayList<Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)8l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)5l, (long)35l, (long)56l, (long)80l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)8l, (long)20l, (long)30l, (long)42l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l, (long)13l, (long)14l, (long)9l, (long)15l)))).equals((new ArrayList<Object>(Arrays.asList((long)156l, (long)182l, (long)126l, (long)135l)))));\n    assert(multiplyElements((new ArrayList<Long>(Arrays.asList((long)12l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function takes as input two array lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    public static ArrayList<Long> sumList(ArrayList<Long> lst1, ArrayList<Long> lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)25l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)25l, (long)45l, (long)65l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l)))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)8l, (long)10l)))));\n    assert(sumList((new ArrayList<Long>(Arrays.asList((long)15l, (long)20l, (long)30l))), (new ArrayList<Long>(Arrays.asList((long)15l, (long)45l, (long)75l)))).equals((new ArrayList<Long>(Arrays.asList((long)30l, (long)65l, (long)105l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the given number can be represented as the difference of two squares or not.\n    public static boolean difSquare(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove consecutive duplicates of a given array list.\n    public static ArrayList<Object> consecutiveDuplicates(ArrayList<Object> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<Object>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<Object>(Arrays.asList((long)10l, (long)15l, (long)19l, (long)18l, (long)17l, (long)26l, (long)17l, (long)18l, (long)10l)))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\")))));\n    assert(consecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\", (String)\"a\", (String)\"a\")))).equals((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"a\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    public static float lateralsurfaceCone(long r, long h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    public static String replaceSpecialchar(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array array list.\n    public static long findFirstOccurrence(ArrayList<Long> A, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)5l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (1l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)5l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (5l)) == (2l));\n    assert(findFirstOccurrence((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)5l, (long)6l, (long)6l, (long)8l, (long)9l, (long)9l, (long)9l))), (6l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find sum of products of all possible subarray lists of a given array list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarray array lists/\n    public static long sumOfSubarrayProd(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (20l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))) == (5l));\n    assert(sumOfSubarrayProd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    public static long toggleMiddleBits(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/javathon-exercises/data-structures-and-algorithms/javathon-data-structure-exercise-24.php\n    public static long leftInsertion(ArrayList<Long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(leftInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    public static boolean checkStr(String string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/javathon-exercises/data-structures-and-algorithms/javathon-recursion-exercise-9.php\n    public static float geometricSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    public static long findIndex(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given pair to a key-value hash map using adjacent elements. https://www.geeksforgeeks.org/javathon-convert-pair-to-adjacent-pair-hash map/\n    public static HashMap<Long,Long> tupleToDict(Pair<Long, Long, Long, Long, Long, Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleToDict((Pair.with(1l, 5l, 7l, 10l, 13l, 5l))).equals((new HashMap<Long,Long>(Map.of(1l, 5l, 7l, 10l, 13l, 5l)))));\n    assert(tupleToDict((Pair.with(1l, 2l, 3l, 4l, 5l, 6l))).equals((new HashMap<Long,Long>(Map.of(1l, 2l, 3l, 4l, 5l, 6l)))));\n    assert(tupleToDict((Pair.with(7l, 8l, 9l, 10l, 11l, 12l))).equals((new HashMap<Long,Long>(Map.of(7l, 8l, 9l, 10l, 11l, 12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether all the characters are same or not.\n    public static boolean allCharactersSame(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    public static float areaTetrahedron(long side) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to rotate a given array list by specified number of items to the right direction. https://www.geeksforgeeks.org/javathon-program-right-rotate-array list-n/\n    public static ArrayList<Long> rotateRight(ArrayList<Long> list, long m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (3l)).equals((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (2l)).equals((new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l)))));\n    assert(rotateRight((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l))), (5l)).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)9l, (long)10l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given pair has any none value or not.\n    public static boolean checkNone(Object test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkNone(Pair.with(Optional.of(10l), Optional.of(4l), Optional.of(5l), Optional.of(6l), Optional.of(Optional.empty()))) == (true));\n    assert(checkNone(Pair.with(7l, 8l, 9l, 11l, 14l)) == (false));\n    assert(checkNone(Pair.with(Optional.of(1l), Optional.of(2l), Optional.of(3l), Optional.of(4l), Optional.of(Optional.empty()))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/javathon-exercises/lambda/javathon-lambda-exercise-24.php\n    public static ArrayList<Long> divisibleByDigits(long startnum, long endnum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisibleByDigits((1l), (22l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l, (long)22l)))));\n    assert(divisibleByDigits((1l), (15l)).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)11l, (long)12l, (long)15l)))));\n    assert(divisibleByDigits((20l), (25l)).equals((new ArrayList<Long>(Arrays.asList((long)22l, (long)24l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\n    public static Optional<Float> sectorArea(long r, long a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sectorArea((4l), (45l)).equals(Optional.of(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Optional.of(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(Optional.empty()));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    public static long lcsOfThree(String X, String Y, String Z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    public static String capitalWordsSpaces(String str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to sort a given array list of strings of numbers numerically. https://www.geeksforgeeks.org/javathon-sort-numeric-strings-in-a-array list/\n    public static ArrayList<Long> sortNumericStrings(ArrayList<String> nums_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"4\", (String)\"12\", (String)\"45\", (String)\"7\", (String)\"0\", (String)\"100\", (String)\"200\", (String)\"-12\", (String)\"-500\")))).equals((new ArrayList<Long>(Arrays.asList((long)-500l, (long)-12l, (long)0l, (long)4l, (long)7l, (long)12l, (long)45l, (long)100l, (long)200l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"2\", (String)\"3\", (String)\"8\", (String)\"4\", (String)\"7\", (String)\"9\", (String)\"8\", (String)\"2\", (String)\"6\", (String)\"5\", (String)\"1\", (String)\"6\", (String)\"1\", (String)\"2\", (String)\"3\", (String)\"4\", (String)\"6\", (String)\"9\", (String)\"1\", (String)\"2\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)2l, (long)2l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)8l, (long)9l, (long)9l)))));\n    assert(sortNumericStrings((new ArrayList<String>(Arrays.asList((String)\"1\", (String)\"3\", (String)\"5\", (String)\"7\", (String)\"1\", (String)\"3\", (String)\"13\", (String)\"15\", (String)\"17\", (String)\"5\", (String)\"7 \", (String)\"9\", (String)\"1\", (String)\"11\")))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)3l, (long)3l, (long)5l, (long)5l, (long)7l, (long)7l, (long)9l, (long)11l, (long)13l, (long)15l, (long)17l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array array list.\n    public static boolean isSamepatterns(ArrayList<String> colors, ArrayList<String> patterns) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"green\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (true));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\", (String)\"b\")))) == (false));\n    assert(isSamepatterns((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"green\", (String)\"greenn\"))), (new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"b\")))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to add the given pair to the given array list.\n    public static ArrayList<Long> addTuple(ArrayList<Long> test_list, Pair<Long, Long> test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l))), (Pair.with(9l, 10l))).equals((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)9l, (long)10l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l))), (Pair.with(10l, 11l))).equals((new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)8l, (long)10l, (long)11l)))));\n    assert(addTuple((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l))), (Pair.with(11l, 12l))).equals((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)11l, (long)12l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given array array list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array array list-represents-a-binary-heap/\n    public static boolean checkMinHeap(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)10l, (long)15l)))) == (true));\n    assert(checkMinHeap((new ArrayList<Long>(Arrays.asList((long)2l, (long)10l, (long)4l, (long)5l, (long)3l, (long)15l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    public static long jacobsthalNum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find minimum k records from pair array list. https://www.geeksforgeeks.org/javathon-find-minimum-k-records-from-pair-array list/ - in this case a verbatim cojava of test cases\n    public static ArrayList<Pair<String, Long>> minK(ArrayList<Pair<String, Long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Manjeet\", 10l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l), (Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Nikhil\", 8l)))), (2l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 2l), (Pair<String, Long>)Pair.with(\"Akshat\", 4l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sanjeev\", 11l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l)))), (3l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Akash\", 3l), (Pair<String, Long>)Pair.with(\"Angat\", 5l), (Pair<String, Long>)Pair.with(\"Nepin\", 9l))))));\n    assert(minK((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"tanmay\", 14l), (Pair<String, Long>)Pair.with(\"Amer\", 11l), (Pair<String, Long>)Pair.with(\"Ayesha\", 9l), (Pair<String, Long>)Pair.with(\"SKD\", 16l)))), (1l)).equals((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Ayesha\", 9l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // We say that an element is common for array lists l1, l2, l3 if it appears in all three array lists under the same index. Write a function to find common elements from three array lists. The function should return an array array list.\n    public static ArrayList<Object> extractIndexList(ArrayList<Long> l1, ArrayList<Long> l2, ArrayList<Long> l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)7l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)6l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)3l, (long)4l, (long)6l, (long)5l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList((long)1l, (long)5l)))));\n    assert(extractIndexList((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)6l, (long)6l, (long)6l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l))), (new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)7l)))).equals((new ArrayList<Object>(Arrays.asList()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/javathon-exercises/re/javathon-re-exercise-3.php\n    public static boolean textMatchZeroOne(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count the pairs of reverse strings in the given string array list. https://www.geeksforgeeks.org/javathon-program-to-count-the-pairs-of-reverse-strings/\n    public static long countReversePairs(ArrayList<String> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"julia\", (String)\"best\", (String)\"tseb\", (String)\"for\", (String)\"ailuj\")))) == (2l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"geeks\", (String)\"best\", (String)\"for\", (String)\"skeeg\")))) == (1l));\n    assert(countReversePairs((new ArrayList<String>(Arrays.asList((String)\"makes\", (String)\"best\", (String)\"sekam\", (String)\"for\", (String)\"rof\")))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    public static boolean isDecimal(String num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find pairs which have all elements divisible by k from the given array list of pairs.\n    public static ArrayList<Pair<Long, Long, Long>> findTuples(ArrayList<Pair<Long, Long, Long>> test_list, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l), (Pair<Long, Long, Long>)Pair.with(7l, 9l, 6l), (Pair<Long, Long, Long>)Pair.with(12l, 18l, 21l)))), (6l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(6l, 24l, 12l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l), (Pair<Long, Long, Long>)Pair.with(4l, 2l, 3l), (Pair<Long, Long, Long>)Pair.with(7l, 8l, 9l)))), (5l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(5l, 25l, 30l))))));\n    assert(findTuples((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(7l, 9l, 16l), (Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l), (Pair<Long, Long, Long>)Pair.with(19l, 17l, 18l)))), (4l)).equals((new ArrayList<Pair<Long, Long, Long>>(Arrays.asList((Pair<Long, Long, Long>)Pair.with(8l, 16l, 4l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether an array array list of numbers contains only one distinct element or not.\n    public static boolean uniqueElement(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l)))) == (true));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (false));\n    assert(uniqueElement((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    public static boolean checkMonthnumberNumber(long monthnum3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum difference between any two elements in a given array array list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    public static long findMinDiff(ArrayList<Long> arr, long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)3l, (long)19l, (long)18l, (long)25l))), (6l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)4l, (long)3l, (long)2l, (long)6l))), (4l)) == (1l));\n    assert(findMinDiff((new ArrayList<Long>(Arrays.asList((long)30l, (long)5l, (long)20l, (long)9l))), (4l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count number of digits in a given string.\n    public static long numberCtr(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    public static long isPolite(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to return an array array list of all pairs of consecutive items in a given array list.\n    public static ArrayList<Pair<Long, Long>> pairWise(ArrayList<Long> l1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)2l, (long)3l, (long)3l, (long)4l, (long)4l, (long)5l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 1l), (Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 5l), (Pair<Long, Long>)Pair.with(5l, 7l), (Pair<Long, Long>)Pair.with(7l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)5l, (long)1l, (long)9l, (long)7l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(1l, 9l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(7l, 10l))))));\n    assert(pairWise((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(1l, 2l), (Pair<Long, Long>)Pair.with(2l, 3l), (Pair<Long, Long>)Pair.with(3l, 4l), (Pair<Long, Long>)Pair.with(4l, 5l), (Pair<Long, Long>)Pair.with(5l, 6l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(9l, 10l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array array list of numbers and the sum,\n    public static long getPairsCount(ArrayList<Long> arr, long sum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)1l))), (2l)) == (6l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)-1l, (long)5l))), (6l)) == (3l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)-2l, (long)3l))), (1l)) == (1l));\n    assert(getPairsCount((new ArrayList<Long>(Arrays.asList((long)-1l, (long)-2l, (long)3l))), (-3l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to get the difference between two array lists.\n    public static ArrayList<Long> Diff(ArrayList<Long> li1, ArrayList<Long> li2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)10l, (long)15l, (long)20l, (long)25l, (long)30l, (long)35l, (long)40l))), (new ArrayList<Long>(Arrays.asList((long)25l, (long)40l, (long)35l)))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)15l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l)))));\n    assert(Diff((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (new ArrayList<Long>(Arrays.asList((long)6l, (long)7l, (long)1l)))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)6l, (long)7l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of fourth power of first n odd natural numbers.\n    public static long oddNumSum(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    public static boolean checkExpression(String exp) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all the words with k length in the given string.\n    public static String removeLength(String test_str, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\n    public static Optional<Pair<String, Long, Long>> occuranceSubstring(String text, String pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Optional.of(Pair.with(\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Optional.of(Pair.with(\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Optional.of(Pair.with(\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(Optional.empty()));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether every odd index contains odd numbers of a given array list.\n    public static boolean oddPosition(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l, (long)3l, (long)6l, (long)7l, (long)6l, (long)3l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)4l, (long)1l, (long)2l)))) == (true));\n    assert(oddPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    public static long countVowels(String test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of non-repeated elements in a given array list.\n    public static long findSum(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)1l, (long)1l, (long)4l, (long)5l, (long)6l)))) == (21l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)10l, (long)9l, (long)4l, (long)2l, (long)10l, (long)10l, (long)45l, (long)4l)))) == (71l));\n    assert(findSum((new ArrayList<Long>(Arrays.asList((long)12l, (long)10l, (long)9l, (long)45l, (long)2l, (long)10l, (long)10l, (long)45l, (long)10l)))) == (78l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to pack consecutive duplicates of a given array list elements into subarray lists.\n    public static ArrayList<ArrayList<Object>> packConsecutiveDuplicates(ArrayList<Object> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)0l, (long)0l, (long)1l, (long)2l, (long)3l, (long)4l, (long)4l, (long)5l, (long)6l, (long)6l, (long)6l, (long)7l, (long)8l, (long)9l, (long)4l, (long)4l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)0l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)6l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((long)10l, (long)10l, (long)15l, (long)19l, (long)18l, (long)18l, (long)17l, (long)26l, (long)26l, (long)17l, (long)18l, (long)10l)))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)10l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)15l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)19l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)26l, (long)26l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l)))))));\n    assert(packConsecutiveDuplicates((new ArrayList<Object>(Arrays.asList((String)\"a\", (String)\"a\", (String)\"b\", (String)\"c\", (String)\"d\", (String)\"d\")))).equals((new ArrayList<ArrayList<Object>>(Arrays.asList((ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"a\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"b\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"c\")), (ArrayList<String>)new ArrayList<String>(Arrays.asList((String)\"d\", (String)\"d\")))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find whether a number is divisible by 11.\n    public static boolean isDiff(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the combinations of sums with pairs in the given pair array list. https://www.geeksforgeeks.org/javathon-combinations-of-sum-with-pairs-in-pair-array list/\n    public static ArrayList<Pair<Long, Long>> findCombinations(ArrayList<Pair<Long, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(2l, 4l), (Pair<Long, Long>)Pair.with(6l, 7l), (Pair<Long, Long>)Pair.with(5l, 1l), (Pair<Long, Long>)Pair.with(6l, 10l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(8l, 11l), (Pair<Long, Long>)Pair.with(7l, 5l), (Pair<Long, Long>)Pair.with(8l, 14l), (Pair<Long, Long>)Pair.with(11l, 8l), (Pair<Long, Long>)Pair.with(12l, 17l), (Pair<Long, Long>)Pair.with(11l, 11l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(3l, 5l), (Pair<Long, Long>)Pair.with(7l, 8l), (Pair<Long, Long>)Pair.with(6l, 2l), (Pair<Long, Long>)Pair.with(7l, 11l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(10l, 13l), (Pair<Long, Long>)Pair.with(9l, 7l), (Pair<Long, Long>)Pair.with(10l, 16l), (Pair<Long, Long>)Pair.with(13l, 10l), (Pair<Long, Long>)Pair.with(14l, 19l), (Pair<Long, Long>)Pair.with(13l, 13l))))));\n    assert(findCombinations((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(4l, 6l), (Pair<Long, Long>)Pair.with(8l, 9l), (Pair<Long, Long>)Pair.with(7l, 3l), (Pair<Long, Long>)Pair.with(8l, 12l))))).equals((new ArrayList<Pair<Long, Long>>(Arrays.asList((Pair<Long, Long>)Pair.with(12l, 15l), (Pair<Long, Long>)Pair.with(11l, 9l), (Pair<Long, Long>)Pair.with(12l, 18l), (Pair<Long, Long>)Pair.with(15l, 12l), (Pair<Long, Long>)Pair.with(16l, 21l), (Pair<Long, Long>)Pair.with(15l, 15l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the count of divisors is even. https://www.w3resource.com/javathon-exercises/basic/javathon-basic-1-exercise-24.php\n    public static boolean countDivisors(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of all odd length subarray array lists. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarray array lists/\n    public static long oddLengthSum(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l)))) == (14l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)2l)))) == (15l));\n    assert(oddLengthSum((new ArrayList<Long>(Arrays.asList((long)1l, (long)7l)))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    public static ArrayList<Float> rgbToHsv(long r, long g, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((new ArrayList<Float>(Arrays.asList((float)0.0f, (float)0.0f, (float)100.0f)))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((new ArrayList<Float>(Arrays.asList((float)120.0f, (float)100.0f, (float)84.31372549019608f)))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((new ArrayList<Float>(Arrays.asList((float)149.26829268292684f, (float)95.34883720930233f, (float)84.31372549019608f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the product of first even and odd number of a given array list.\n    public static long mulEvenOdd(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l, (long)7l, (long)4l, (long)1l, (long)6l, (long)8l)))) == (4l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))) == (2l));\n    assert(mulEvenOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)5l, (long)7l, (long)9l, (long)10l)))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert pair string to integer pair.\n    public static Pair<Long, Long, Long> tupleStrInt(String test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals((Pair.with(7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals((Pair.with(1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals((Pair.with(4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals((Pair.with(7l, 81l, 19l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    public static long rightInsertion(ArrayList<Long> a, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (6l)) == (4l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (3l)) == (2l));\n    assert(rightInsertion((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)4l, (long)5l))), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    public static boolean textMatchThree(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to create a new pair from the given string and array list.\n    public static Pair<String, String, String> newTuple(ArrayList<String> test_list, String test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"WEB\", (String)\"is\"))), (\"best\")).equals((Pair.with(\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"We\", (String)\"are\"))), (\"Developers\")).equals((Pair.with(\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((new ArrayList<String>(Arrays.asList((String)\"Part\", (String)\"is\"))), (\"Wrong\")).equals((Pair.with(\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether every even index contains even numbers of a given array list.\n    public static boolean evenPosition(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (false));\n    assert(evenPosition((new ArrayList<Long>(Arrays.asList((long)2l, (long)1l, (long)4l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove pairs from the given pair.\n    public static Pair<Long, Long, Long, Long> removeNested(Object test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeNested(Pair.with(1l, 5l, 7l, Pair.with(4l, 6l), 10l)).equals((Pair.with(1l, 5l, 7l, 10l))));\n    assert(removeNested(Pair.with(2l, 6l, 8l, Pair.with(5l, 7l), 11l)).equals((Pair.with(2l, 6l, 8l, 11l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    assert(removeNested(Pair.with(3l, 7l, 9l, Pair.with(6l, 8l), Pair.with(5l, 12l), 12l)).equals((Pair.with(3l, 7l, 9l, 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of array lists in a given number of array lists.\n    public static long countList(ArrayList<ArrayList<Long>> input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)7l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)11l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)13l, (long)15l, (long)17l)))))) == (4l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l)))))) == (3l));\n    assert(countList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)0l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)0l)))))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the last position of an element in a sorted array array list.\n    public static long last(ArrayList<Long> arr, long x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l))), (1l)) == (0l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l, (long)1l, (long)2l, (long)3l, (long)4l))), (1l)) == (2l));\n    assert(last((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)2l, (long)3l, (long)6l, (long)8l, (long)9l))), (3l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    public static boolean textStartaEndb(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write function to find the sum of all items in the given hash map.\n    public static long returnSum(HashMap<String,Long> dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 100l, \"b\", 200l, \"c\", 300l)))) == (600l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 25l, \"b\", 18l, \"c\", 45l)))) == (88l));\n    assert(returnSum((new HashMap<String,Long>(Map.of(\"a\", 36l, \"b\", 39l, \"c\", 49l)))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of all odd natural numbers within the range l and r.\n    public static long sumInRange(long l, long r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the sum of an array array list.\n    public static long Sum(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (6l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)15l, (long)12l, (long)13l, (long)10l)))) == (50l));\n    assert(Sum((new ArrayList<Long>(Arrays.asList((long)0l, (long)1l, (long)2l)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    public static long leftRotate(long n, long d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to check whether the length of the word is odd or not.\n    public static boolean wordLen(String s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to remove all whitespaces from a string.\n    public static String removeAllSpaces(String text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of equal numbers from three given integers.\n    public static long testThreeEqual(long x, long y, long z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to count the number of rotations required to generate a sorted array array list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array array list/\n    public static long countRotation(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)))) == (1l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)1l, (long)2l, (long)3l)))) == (2l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)1l, (long)2l, (long)3l)))) == (3l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (0l));\n    assert(countRotation((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)2l)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    public static boolean isPerfectSquare(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the product of numbers in an array array list is even or not.\n    public static boolean isProductEven(ArrayList<Long> arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)1l, (long)4l)))) == (true));\n    assert(isProductEven((new ArrayList<Long>(Arrays.asList((long)1l, (long)1l)))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function that returns the array list in an array array list of array lists whose sum of elements is the highest.\n    public static ArrayList<Long> maxSumList(ArrayList<ArrayList<Long>> lists) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l)))))).equals((new ArrayList<Long>(Arrays.asList((long)10l, (long)11l, (long)12l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)2l, (long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)6l, (long)5l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))))).equals((new ArrayList<Long>(Arrays.asList((long)12l, (long)11l, (long)10l)))));\n    assert(maxSumList((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))))).equals((new ArrayList<Long>(Arrays.asList((long)2l, (long)3l, (long)1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    public static long maxRunUppercase(String test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the first odd number in a given array list of numbers.\n    public static long firstOdd(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)1l, (long)3l, (long)5l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)2l, (long)4l, (long)1l, (long)3l)))) == (1l));\n    assert(firstOdd((new ArrayList<Long>(Arrays.asList((long)8l, (long)9l, (long)1l)))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if the given pairs contain the k or not.\n    public static boolean checkK(ArrayList<Long> test_tup, long K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)10l, (long)4l, (long)5l, (long)6l, (long)8l))), (6l)) == (true));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l))), (7l)) == (false));\n    assert(checkK((new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)44l, (long)11l, (long)12l))), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if each element of second pair is smaller than its corresponding element in the first pair.\n    public static boolean checkSmaller(Pair<Long, Long, Long> test_tup1, Pair<Long, Long, Long> test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(checkSmaller((Pair.with(1l, 2l, 3l)), (Pair.with(2l, 3l, 4l))) == (false));\n    assert(checkSmaller((Pair.with(4l, 5l, 6l)), (Pair.with(3l, 4l, 5l))) == (true));\n    assert(checkSmaller((Pair.with(11l, 12l, 13l)), (Pair.with(10l, 11l, 12l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth tetrahedral number.\n    public static long tetrahedralNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    public static String getChar(String strr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    public static long sequence(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find nth centered hexagonal number.\n    public static long centeredHexagonalNumber(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to merge three dictionaries into a single hash map.\n    public static HashMap<String,String> mergeDictionariesThree(HashMap<String,String> dict1, HashMap<String,String> dict2, HashMap<String,String> dict3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"O\", \"Orange\", \"W\", \"White\", \"B\", \"Black\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"R\", \"Red\", \"P\", \"Pink\", \"G\", \"Green\", \"W\", \"White\", \"O\", \"Orange\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\")))).equals((new HashMap<String,String>(Map.of(\"W\", \"White\", \"P\", \"Pink\", \"B\", \"Black\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\")))));\n    assert(mergeDictionariesThree((new HashMap<String,String>(Map.of(\"R\", \"Red\", \"B\", \"Black\", \"P\", \"Pink\"))), (new HashMap<String,String>(Map.of(\"L\", \"lavender\", \"B\", \"Blue\"))), (new HashMap<String,String>(Map.of(\"G\", \"Green\", \"W\", \"White\")))).equals((new HashMap<String,String>(Map.of(\"B\", \"Black\", \"P\", \"Pink\", \"R\", \"Red\", \"G\", \"Green\", \"L\", \"lavender\", \"W\", \"White\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to get the frequency of all the elements in an array array list, returned as a hash map.\n    public static HashMap<Long,Long> freqCount(ArrayList<Long> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)10l, (long)10l, (long)10l, (long)10l, (long)20l, (long)20l, (long)20l, (long)20l, (long)40l, (long)40l, (long)50l, (long)50l, (long)30l)))).equals((new HashMap<Long,Long>(Map.of(10l, 4l, 20l, 4l, 40l, 2l, 50l, 2l, 30l, 1l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)3l, (long)2l, (long)4l, (long)1l, (long)3l, (long)1l, (long)4l)))).equals((new HashMap<Long,Long>(Map.of(1l, 3l, 2l, 2l, 3l, 3l, 4l, 3l)))));\n    assert(freqCount((new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)4l, (long)9l, (long)10l, (long)4l, (long)5l, (long)6l, (long)7l, (long)9l, (long)5l)))).equals((new HashMap<Long,Long>(Map.of(10l, 1l, 5l, 3l, 6l, 2l, 7l, 2l, 4l, 2l, 9l, 2l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find the closest smaller number than n.\n    public static long closestNum(long N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find squares of individual elements in an array array list.\n    public static ArrayList<Long> squareNums(ArrayList<Long> nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l, (long)5l, (long)6l, (long)7l, (long)8l, (long)9l, (long)10l)))).equals((new ArrayList<Long>(Arrays.asList((long)1l, (long)4l, (long)9l, (long)16l, (long)25l, (long)36l, (long)49l, (long)64l, (long)81l, (long)100l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l)))).equals((new ArrayList<Long>(Arrays.asList((long)100l, (long)400l, (long)900l)))));\n    assert(squareNums((new ArrayList<Long>(Arrays.asList((long)12l, (long)15l)))).equals((new ArrayList<Long>(Arrays.asList((long)144l, (long)225l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the longest word.\n    public static long lenLog(ArrayList<String> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"python\", (String)\"PHP\", (String)\"bigdata\")))) == (7l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"a\", (String)\"ab\", (String)\"abc\")))) == (3l));\n    assert(lenLog((new ArrayList<String>(Arrays.asList((String)\"small\", (String)\"big\", (String)\"tall\")))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check if a string is present as a substring in a given array list of string values.\n    public static boolean findSubstring(ArrayList<String> str1, String sub_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ack\")) == (true));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"abc\")) == (false));\n    assert(findSubstring((new ArrayList<String>(Arrays.asList((String)\"red\", (String)\"black\", (String)\"white\", (String)\"green\", (String)\"orange\"))), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to check whether the given number is undulating or not.\n    public static boolean isUndulating(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    public static long power(long a, long b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Given an array array list of pairs, write a function that returns the first value of the pair with the smallest second value.\n    public static String indexMinimum(ArrayList<Pair<String, Long>> test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Rash\", 143l), (Pair<String, Long>)Pair.with(\"Manjeet\", 200l), (Pair<String, Long>)Pair.with(\"Varsha\", 100l))))).equals((\"Varsha\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Yash\", 185l), (Pair<String, Long>)Pair.with(\"Dawood\", 125l), (Pair<String, Long>)Pair.with(\"Sanya\", 175l))))).equals((\"Dawood\")));\n    assert(indexMinimum((new ArrayList<Pair<String, Long>>(Arrays.asList((Pair<String, Long>)Pair.with(\"Sai\", 345l), (Pair<String, Long>)Pair.with(\"Salman\", 145l), (Pair<String, Long>)Pair.with(\"Ayesha\", 96l))))).equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the length of the smallest array list in an array array list of array lists.\n    public static long FindMinLength(ArrayList<ArrayList<Long>> lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)))))) == (1l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)))))) == (2l));\n    assert(FindMinLength((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)3l, (long)3l, (long)3l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)4l, (long)4l, (long)4l)))))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the number of divisors of a given integer.\n    public static long divisor(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to find frequency of each element in a flattened array list of array lists, returned in a hash map.\n    public static HashMap<Long,Long> frequencyLists(ArrayList<ArrayList<Long>> list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)4l, (long)5l, (long)6l, (long)2l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)7l, (long)8l, (long)9l, (long)5l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 3l, 3l, 1l, 4l, 1l, 5l, 2l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)1l, (long)2l, (long)3l, (long)4l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)5l, (long)6l, (long)7l, (long)8l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)9l, (long)10l, (long)11l, (long)12l)))))).equals((new HashMap<Long,Long>(Map.of(1l, 1l, 2l, 1l, 3l, 1l, 4l, 1l, 5l, 1l, 6l, 1l, 7l, 1l, 8l, 1l, 9l, 1l, 10l, 1l, 11l, 1l, 12l, 1l)))));\n    assert(frequencyLists((new ArrayList<ArrayList<Long>>(Arrays.asList((ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)20l, (long)30l, (long)40l, (long)17l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)18l, (long)16l, (long)14l, (long)13l)), (ArrayList<Long>)new ArrayList<Long>(Arrays.asList((long)10l, (long)20l, (long)30l, (long)40l)))))).equals((new HashMap<Long,Long>(Map.of(20l, 2l, 30l, 2l, 40l, 2l, 17l, 1l, 18l, 1l, 16l, 1l, 14l, 1l, 13l, 1l, 10l, 1l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    public static String decimalToBinary(long n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "java",
+    "prompt": "import java.util.*;\nimport java.lang.reflect.*;\nimport org.javatuples.*;\nimport java.security.*;\nimport java.math.*;\nimport java.io.*;\nimport java.util.stream.*;\nclass Problem {\n    // Write a javathon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    public static long findRotations(String str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    public static void main(String[] args) {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-jl-keep.json
+++ b/prompts/mbpp-jl-keep.json
@@ -1,4030 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\nfunction lps(str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lps;\n\t@test(candidate(\"TENS FOR TENS\") == 5)\n\t@test(candidate(\"CARDIO FOR CARDS\") == 7)\n\t@test(candidate(\"PART OF THE JOURNEY IS PART\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\nfunction remove_whitespaces(text1::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_whitespaces;\n\t@test(candidate(\" Google    Flutter \") == \"GoogleFlutter\")\n\t@test(candidate(\" Google    Dart \") == \"GoogleDart\")\n\t@test(candidate(\" iOS    Swift \") == \"iOSSwift\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\nfunction issort_list(list1::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = issort_list;\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\nfunction count_bidirectional(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_bidirectional;\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\n\t@test(candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\nfunction surfacearea_cube(l::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cube;\n\t@test(candidate(5) == 150)\n\t@test(candidate(3) == 54)\n\t@test(candidate(10) == 600)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\"\"\"\nfunction next_smallest_palindrome(num::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest_palindrome;\n\t@test(candidate(99) == 101)\n\t@test(candidate(1221) == 1331)\n\t@test(candidate(120) == 121)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\nfunction cube_Sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_Sum;\n\t@test(candidate(2) == 72)\n\t@test(candidate(3) == 288)\n\t@test(candidate(4) == 800)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\nfunction pair_xor_Sum(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_xor_Sum;\n\t@test(candidate([5, 9, 7, 6], 4) == 47)\n\t@test(candidate([7, 3, 5], 3) == 12)\n\t@test(candidate([7, 3], 2) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\nfunction check_min_heap(arr::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_min_heap;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 10, 15]) == true)\n\t@test(candidate([2, 10, 4, 5, 3, 15]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\nfunction first_Digit(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_Digit;\n\t@test(candidate(123) == 1)\n\t@test(candidate(456) == 4)\n\t@test(candidate(12) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\nfunction first_non_repeating_character(str1::String)::Union{String, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_non_repeating_character;\n\t@test(candidate(\"abcabc\") == nothing)\n\t@test(candidate(\"abc\") == \"a\")\n\t@test(candidate(\"ababc\") == \"c\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\nfunction radian_degree(degree::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = radian_degree;\n\t@test(candidate(90) == 1.5707963267948966)\n\t@test(candidate(60) == 1.0471975511965976)\n\t@test(candidate(120) == 2.0943951023931953)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\nfunction max_subarray_product(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_subarray_product;\n\t@test(candidate([1, -2, -3, 0, 7, -8, -2]) == 112)\n\t@test(candidate([6, -3, -10, 0, 2]) == 180)\n\t@test(candidate([-2, -40, 0, -2, -3]) == 80)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\nfunction smallest_num(xs::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_num;\n\t@test(candidate([10, 20, 1, 45, 99]) == 1)\n\t@test(candidate([1, 2, 3]) == 1)\n\t@test(candidate([45, 46, 50, 60]) == 45)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\nfunction text_match_zero_one(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_zero_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"dsabbbba\") == true)\n\t@test(candidate(\"asbbbba\") == false)\n\t@test(candidate(\"abaaa\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\nfunction bell_Number(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_Number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 15)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\nfunction cube_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\n\t@test(candidate([10, 20, 30]) == [1000, 8000, 27000])\n\t@test(candidate([12, 15]) == [1728, 3375])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\nfunction last_Digit_Factorial(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit_Factorial;\n\t@test(candidate(4) == 4)\n\t@test(candidate(21) == 0)\n\t@test(candidate(30) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5]) == [2, 4])\n\t@test(candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\n\t@test(candidate([8, 12, 15, 19]) == [8, 12])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\nfunction prime_num(num::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_num;\n\t@test(candidate(13) == true)\n\t@test(candidate(7) == true)\n\t@test(candidate(-1010) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\nfunction find_tuples(test_list::Vector{Tuple{Int64, Int64, Int64}}, K::Int64)::Vector{Tuple{Int64, Int64, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_tuples;\n\t@test(candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)])\n\t@test(candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)])\n\t@test(candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\nfunction area_tetrahedron(side::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = area_tetrahedron;\n\t@test(candidate(3) == 15.588457268119894)\n\t@test(candidate(20) == 692.8203230275509)\n\t@test(candidate(10) == 173.20508075688772)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\nfunction is_Even(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Even;\n\t@test(candidate(1) == false)\n\t@test(candidate(2) == true)\n\t@test(candidate(3) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\nfunction pos_count(list::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pos_count;\n\t@test(candidate([1, -2, 3, -4]) == 2)\n\t@test(candidate([3, 4, 5, -1]) == 3)\n\t@test(candidate([1, 2, 3, 4]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\nfunction get_ludic(n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_ludic;\n\t@test(candidate(10) == [1, 2, 3, 5, 7])\n\t@test(candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\n\t@test(candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\nfunction find_Index(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Index;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 14)\n\t@test(candidate(4) == 45)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\nfunction reverse_Array_Upto_K(input::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_Array_Upto_K;\n\t@test(candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6])\n\t@test(candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7])\n\t@test(candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\nfunction subject_marks(subjectmarks::Vector{Tuple{String, Int64}})::Vector{Tuple{String, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = subject_marks;\n\t@test(candidate([(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\n\t@test(candidate([(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\n\t@test(candidate([(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\nfunction remove_dirty_chars(string::String, second_string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_dirty_chars;\n\t@test(candidate(\"probasscurve\", \"pros\") == \"bacuve\")\n\t@test(candidate(\"digitalindia\", \"talent\") == \"digiidi\")\n\t@test(candidate(\"exoticmiles\", \"toxic\") == \"emles\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\nfunction round_and_sum(list1::Vector{Union{Float64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = round_and_sum;\n\t@test(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243)\n\t@test(candidate([5, 2, 9, 24.3, 29]) == 345)\n\t@test(candidate([25.0, 56.7, 89.2]) == 513)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\nfunction max_occurrences(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_occurrences;\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\n\t@test(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\nfunction is_decimal(num::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_decimal;\n\t@test(candidate(\"123.11\") == true)\n\t@test(candidate(\"e666.86\") == false)\n\t@test(candidate(\"3.124587\") == false)\n\t@test(candidate(\"1.11\") == true)\n\t@test(candidate(\"1.1.11\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\nfunction dict_filter(dict::Dict{String, Int64}>, n::Int64)::Dict{String, Int64}> \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dict_filter;\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) == Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) == Dict(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) == Dict(\"Pierre Cox\" => 190))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\nfunction sum_even_and_even_index(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_even_and_even_index;\n\t@test(candidate([5, 6, 12, 1, 18, 8]) == 30)\n\t@test(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\n\t@test(candidate([5, 6, 12, 1]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\nfunction max_sub_array_sum(a::Vector{Int64}, size::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum;\n\t@test(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7)\n\t@test(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8)\n\t@test(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\nfunction intersection_array(array_nums1::Vector{Int64}, array_nums2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection_array;\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\nfunction split_two_parts(list1::Vector{Any}, L::Int64)::Any \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_two_parts;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\nfunction find_literals(text::String, pattern::String)::Tuple{String, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_literals;\n\t@test(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == (\"fox\", 16, 19))\n\t@test(candidate(\"Its been a very crazy procedure right\", \"crazy\") == (\"crazy\", 16, 21))\n\t@test(candidate(\"Hardest choices required strongest will\", \"will\") == (\"will\", 35, 39))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\nfunction find_Volume(l::Int64, b::Int64, h::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Volume;\n\t@test(candidate(10, 8, 6) == 240)\n\t@test(candidate(3, 2, 2) == 6)\n\t@test(candidate(1, 2, 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\nfunction wind_chill(v::Int64, t::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = wind_chill;\n\t@test(candidate(120, 35) == 40)\n\t@test(candidate(40, 20) == 19)\n\t@test(candidate(10, 8) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\nfunction ascii_value(k::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = ascii_value;\n\t@test(candidate(\"A\") == 65)\n\t@test(candidate(\"R\") == 82)\n\t@test(candidate(\"S\") == 83)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\nfunction all_Characters_Same(s::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Characters_Same;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"aaa\") == true)\n\t@test(candidate(\"data\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\nfunction move_num(test_str::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_num;\n\t@test(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\n\t@test(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\")\n\t@test(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\nfunction word_len(s::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = word_len;\n\t@test(candidate(\"Hadoop\") == false)\n\t@test(candidate(\"great\") == true)\n\t@test(candidate(\"structure\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\nfunction insert_element(list::Vector{String}, element::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = insert_element;\n\t@test(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\n\t@test(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"])\n\t@test(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\nfunction remove_lowercase(str1::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_lowercase;\n\t@test(candidate(\"PYTHon\") == \"PYTH\")\n\t@test(candidate(\"FInD\") == \"FID\")\n\t@test(candidate(\"STRinG\") == \"STRG\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\nfunction count_Set_Bits(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Set_Bits;\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 1)\n\t@test(candidate(6) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\nfunction extract_rear(test_tuple::Tuple{String, String, String})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_rear;\n\t@test(candidate((\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\n\t@test(candidate((\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\n\t@test(candidate((\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\nfunction count_occurance(s::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_occurance;\n\t@test(candidate(\"letstdlenstdporstd\") == 3)\n\t@test(candidate(\"truststdsolensporsd\") == 1)\n\t@test(candidate(\"makestdsostdworthit\") == 2)\n\t@test(candidate(\"stds\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\nfunction check_K(test_tup::Vector{Int64}, K::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_K;\n\t@test(candidate([10, 4, 5, 6, 8], 6) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6], 7) == false)\n\t@test(candidate([7, 8, 9, 44, 11, 12], 11) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\nfunction interleave_lists(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = interleave_lists;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\n\t@test(candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10])\n\t@test(candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"python_program\") == \"PythonProgram\")\n\t@test(candidate(\"python_language\") == \"PythonLanguage\")\n\t@test(candidate(\"programming_language\") == \"ProgrammingLanguage\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\nfunction test_three_equal(x::Int64, y::Int64, z::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = test_three_equal;\n\t@test(candidate(1, 1, 1) == 3)\n\t@test(candidate(-1, -2, -3) == 0)\n\t@test(candidate(1, 2, 2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\nfunction odd_length_sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_length_sum;\n\t@test(candidate([1, 2, 4]) == 14)\n\t@test(candidate([1, 2, 1, 2]) == 15)\n\t@test(candidate([1, 7]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\nfunction bell_number(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(10) == 115975)\n\t@test(candidate(56) == 6775685320645824322581483068371419745979053216268760300)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\nfunction rectangle_area(l::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rectangle_area;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(10, 5) == 50)\n\t@test(candidate(4, 2) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\nfunction sum_average(number::Int64)::Tuple{Int64, Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_average;\n\t@test(candidate(10) == (55, 5.5))\n\t@test(candidate(15) == (120, 8.0))\n\t@test(candidate(20) == (210, 10.5))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\nfunction division_elements(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = division_elements;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3))\n\t@test(candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4))\n\t@test(candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\nfunction sum_digits(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_digits;\n\t@test(candidate(345) == 12)\n\t@test(candidate(12) == 3)\n\t@test(candidate(97) == 16)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\nfunction index_minimum(test_list::Vector{Tuple{String, Int64}})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = index_minimum;\n\t@test(candidate([(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\n\t@test(candidate([(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\n\t@test(candidate([(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\nfunction div_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = div_list;\n\t@test(candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0])\n\t@test(candidate([3, 2], [1, 4]) == [3.0, 0.5])\n\t@test(candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\nfunction max_length_list(input_list::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length_list;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\n\t@test(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\nfunction big_sum(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = big_sum;\n\t@test(candidate([1, 2, 3]) == 4)\n\t@test(candidate([-1, 2, 3, 4]) == 3)\n\t@test(candidate([2, 3, 6]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\nfunction neg_nos(list1::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = neg_nos;\n\t@test(candidate([-1, 4, 5, -6]) == [-1, -6])\n\t@test(candidate([-1, -2, 3, 4]) == [-1, -2])\n\t@test(candidate([-7, -6, 8, 9]) == [-7, -6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\nfunction highest_Power_of_2(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = highest_Power_of_2;\n\t@test(candidate(10) == 8)\n\t@test(candidate(19) == 16)\n\t@test(candidate(32) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\nfunction is_sublist(l::Vector{Int64}, s::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sublist;\n\t@test(candidate([2, 4, 3, 5, 7], [3, 7]) == false)\n\t@test(candidate([2, 4, 3, 5, 7], [4, 3]) == true)\n\t@test(candidate([2, 4, 3, 5, 7], [1, 6]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\nfunction sub_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sub_list;\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3])\n\t@test(candidate([1, 2], [3, 4]) == [-2, -2])\n\t@test(candidate([90, 120], [50, 70]) == [40, 50])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\nfunction opposite_Signs(x::Int64, y::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = opposite_Signs;\n\t@test(candidate(1, -2) == true)\n\t@test(candidate(3, 2) == false)\n\t@test(candidate(-10, -10) == false)\n\t@test(candidate(-2, 2) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\nfunction tuple_modulo(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_modulo;\n\t@test(candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1))\n\t@test(candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1))\n\t@test(candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\nfunction diff_even_odd(list1::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = diff_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\n\t@test(candidate([1, 5, 7, 9, 10]) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\nfunction sort_sublists(list1::Vector{Vector{String}})::Vector{Vector{String}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\nfunction last_Digit(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit;\n\t@test(candidate(123) == 3)\n\t@test(candidate(25) == 5)\n\t@test(candidate(30) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\nfunction odd_num_sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_num_sum;\n\t@test(candidate(2) == 82)\n\t@test(candidate(3) == 707)\n\t@test(candidate(4) == 3108)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\nfunction tup_string(tup1::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tup_string;\n\t@test(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\n\t@test(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\nfunction remove_elements(list1::Vector{Int64}, list2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_elements;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\nfunction overlapping(list1::Vector{Int64}, list2::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = overlapping;\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == false)\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == false)\n\t@test(candidate([1, 4, 5], [1, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\nfunction is_not_prime(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_not_prime;\n\t@test(candidate(2) == false)\n\t@test(candidate(10) == true)\n\t@test(candidate(35) == true)\n\t@test(candidate(37) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\nfunction max_val(listval::Vector{Union{String, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 5)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 25)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 50)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\nfunction sum_negativenum(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_negativenum;\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\n\t@test(candidate([10, 15, -14, 13, -18, 12, -20]) == -52)\n\t@test(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\nfunction find_Rotations(str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Rotations;\n\t@test(candidate(\"aaaa\") == 1)\n\t@test(candidate(\"ab\") == 2)\n\t@test(candidate(\"abc\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\nfunction change_date_format(dt::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_date_format;\n\t@test(candidate(\"2026-01-02\") == \"02-01-2026\")\n\t@test(candidate(\"2020-11-13\") == \"13-11-2020\")\n\t@test(candidate(\"2021-04-26\") == \"26-04-2021\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5])\n\t@test(candidate([10, 11, 12, 13]) == [11, 13])\n\t@test(candidate([7, 8, 9, 1]) == [7, 9, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\nfunction toggle_middle_bits(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_middle_bits;\n\t@test(candidate(9) == 15)\n\t@test(candidate(10) == 12)\n\t@test(candidate(11) == 13)\n\t@test(candidate(65) == 127)\n\t@test(candidate(77) == 115)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\nfunction count_char_position(str1::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_char_position;\n\t@test(candidate(\"xbcefg\") == 2)\n\t@test(candidate(\"ABcED\") == 3)\n\t@test(candidate(\"AbgdeF\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\nfunction large_product(nums1::Vector{Int64}, nums2::Vector{Int64}, N::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = large_product;\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\nfunction cummulative_sum(test_list::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cummulative_sum;\n\t@test(candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30)\n\t@test(candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37)\n\t@test(candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\nfunction find_min_diff(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_min_diff;\n\t@test(candidate([1, 5, 3, 19, 18, 25], 6) == 1)\n\t@test(candidate([4, 3, 2, 6], 4) == 1)\n\t@test(candidate([30, 5, 20, 9], 4) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\nfunction text_starta_endb(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_starta_endb;\n\t@test(candidate(\"aabbbb\") == true)\n\t@test(candidate(\"aabAbbbc\") == false)\n\t@test(candidate(\"accddbbjjj\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\nfunction left_rotate(n::Int64, d::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = left_rotate;\n\t@test(candidate(16, 2) == 64)\n\t@test(candidate(10, 2) == 40)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(1, 3) == 8)\n\t@test(candidate(5, 3) == 40)\n\t@test(candidate(29, 3) == 232)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\nfunction first_repeated_char(str1::String)::Union{String, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_repeated_char;\n\t@test(candidate(\"abcabc\") == \"a\")\n\t@test(candidate(\"abc\") == nothing)\n\t@test(candidate(\"123123\") == \"1\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\nfunction get_Inv_Count(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Inv_Count;\n\t@test(candidate([1, 20, 6, 4, 5]) == 5)\n\t@test(candidate([1, 2, 1]) == 1)\n\t@test(candidate([1, 2, 5, 6, 1]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\nfunction even_Power_Sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_Power_Sum;\n\t@test(candidate(2) == 1056)\n\t@test(candidate(3) == 8832)\n\t@test(candidate(1) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\nfunction get_equal(Input::Vector{Vector{Int64}})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_equal;\n\t@test(candidate([[11, 22, 33], [44, 55, 66]]) == true)\n\t@test(candidate([[1, 2, 3], [4, 5, 6, 7]]) == false)\n\t@test(candidate([[1, 2], [3, 4]]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\nfunction check_integer(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_integer;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"1\") == true)\n\t@test(candidate(\"12345\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\nfunction count_reverse_pairs(test_list::Vector{String})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_reverse_pairs;\n\t@test(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\n\t@test(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\n\t@test(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\nfunction move_zero(num_list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_zero;\n\t@test(candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\n\t@test(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\n\t@test(candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\nfunction check_distinct(test_tup::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_distinct;\n\t@test(candidate([1, 4, 5, 6, 1, 4]) == false)\n\t@test(candidate([1, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 6]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\nfunction noprofit_noloss(actual_cost::Int64, sale_amount::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = noprofit_noloss;\n\t@test(candidate(1500, 1200) == false)\n\t@test(candidate(100, 100) == true)\n\t@test(candidate(2000, 5000) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\nfunction remove_length(test_str::String, K::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_length;\n\t@test(candidate(\"The person is most value tet\", 3) == \"person is most value\")\n\t@test(candidate(\"If you told me about this ok\", 4) == \"If you me about ok\")\n\t@test(candidate(\"Forces of darkeness is come into the play\", 4) == \"Forces of darkeness is the\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\nfunction number_ctr(str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = number_ctr;\n\t@test(candidate(\"program2bedone\") == 1)\n\t@test(candidate(\"3wonders\") == 1)\n\t@test(candidate(\"123\") == 3)\n\t@test(candidate(\"3wond-1ers2\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\nfunction count_charac(str1::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_charac;\n\t@test(candidate(\"python programming\") == 18)\n\t@test(candidate(\"language\") == 8)\n\t@test(candidate(\"words\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\nfunction get_total_number_of_sequences(m::Int64, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_total_number_of_sequences;\n\t@test(candidate(10, 4) == 4)\n\t@test(candidate(5, 2) == 6)\n\t@test(candidate(16, 3) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\nfunction left_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = left_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\nfunction swap_numbers(a::Int64, b::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_numbers;\n\t@test(candidate(10, 20) == [20, 10])\n\t@test(candidate(15, 17) == [17, 15])\n\t@test(candidate(100, 200) == [200, 100])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\nfunction is_majority(arr::Vector{Int64}, n::Int64, x::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_majority;\n\t@test(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == true)\n\t@test(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == false)\n\t@test(candidate([1, 1, 1, 2, 2], 5, 1) == true)\n\t@test(candidate([1, 1, 2, 2], 5, 1) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\nfunction substract_elements(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Tuple{Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = substract_elements;\n\t@test(candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13))\n\t@test(candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13))\n\t@test(candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\nfunction capital_words_spaces(str1::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = capital_words_spaces;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\")\n\t@test(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\nfunction find_Average_Of_Cube(n::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Average_Of_Cube;\n\t@test(candidate(2) == 4.5)\n\t@test(candidate(3) == 12)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\nfunction check_value(dict::Dict{String, Int64}>, n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_value;\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) == false)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) == true)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\nfunction tetrahedral_number(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tetrahedral_number;\n\t@test(candidate(5) == 35)\n\t@test(candidate(6) == 56)\n\t@test(candidate(7) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\nfunction magic_square_test(my_matrix::Vector{Vector{Int64}})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = magic_square_test;\n\t@test(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\nfunction remove_uppercase(str1::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_uppercase;\n\t@test(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\n\t@test(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\n\t@test(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\nfunction check_tuplex(tuplex::Vector{Union{String, Int64}}, tuple1::Any)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_tuplex;\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\") == true)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\") == false)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\nfunction dog_age(h_age::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dog_age;\n\t@test(candidate(12) == 61)\n\t@test(candidate(15) == 73)\n\t@test(candidate(24) == 109)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\nfunction next_Perfect_Square(N::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_Perfect_Square;\n\t@test(candidate(35) == 36)\n\t@test(candidate(6) == 9)\n\t@test(candidate(9) == 16)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\nfunction is_upper(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_upper;\n\t@test(candidate(\"person\") == \"PERSON\")\n\t@test(candidate(\"final\") == \"FINAL\")\n\t@test(candidate(\"Valid\") == \"VALID\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\nfunction odd_Equivalent(s::String, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_Equivalent;\n\t@test(candidate(\"011001\", 6) == 3)\n\t@test(candidate(\"11011\", 5) == 4)\n\t@test(candidate(\"1010\", 4) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\nfunction re_arrange_array(arr::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = re_arrange_array;\n\t@test(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\n\t@test(candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15])\n\t@test(candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\nfunction unique_Element(arr::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_Element;\n\t@test(candidate([1, 1, 1]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\nfunction extract_values(text::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_values;\n\t@test(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\n\t@test(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\n\t@test(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\nfunction count(lst::Vector{Bool})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count;\n\t@test(candidate([true, false, true]) == 2)\n\t@test(candidate([false, false]) == 0)\n\t@test(candidate([true, true, true]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\nfunction find_even_pair(A::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_even_pair;\n\t@test(candidate([5, 4, 7, 2, 1]) == 4)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11]) == 9)\n\t@test(candidate([1, 2, 3]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\nfunction armstrong_number(number::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = armstrong_number;\n\t@test(candidate(153) == true)\n\t@test(candidate(259) == false)\n\t@test(candidate(4458) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\nfunction upper_ctr(str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = upper_ctr;\n\t@test(candidate(\"PYthon\") == 1)\n\t@test(candidate(\"BigData\") == 1)\n\t@test(candidate(\"program\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\nfunction and_tuples(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = and_tuples;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1))\n\t@test(candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0))\n\t@test(candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\nfunction is_samepatterns(colors::Vector{String}, patterns::Vector{String})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_samepatterns;\n\t@test(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\nfunction count_list(input_list::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_list;\n\t@test(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\n\t@test(candidate([[1, 2], [2, 3], [4, 5]]) == 3)\n\t@test(candidate([[1, 0], [2, 0]]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\nfunction average_tuple(nums::Vector{Vector{Int64}})::Vector{Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = average_tuple;\n\t@test(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\n\t@test(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\n\t@test(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\nfunction lcs_of_three(X::String, Y::String, Z::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lcs_of_three;\n\t@test(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2)\n\t@test(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5)\n\t@test(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\nfunction find_star_num(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_star_num;\n\t@test(candidate(3) == 37)\n\t@test(candidate(4) == 73)\n\t@test(candidate(5) == 121)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\nfunction _sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = _sum;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([15, 12, 13, 10]) == 50)\n\t@test(candidate([0, 1, 2]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\nfunction check_Consecutive(l::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_Consecutive;\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 2, 3, 5, 6]) == false)\n\t@test(candidate([1, 2, 1]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\nfunction find_adverb_position(text::String)::Tuple{Int64, Int64, String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverb_position;\n\t@test(candidate(\"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\n\t@test(candidate(\"seriously!! there are many roses\") == (0, 9, \"seriously\"))\n\t@test(candidate(\"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\nfunction rotate_right(list::Vector{Int64}, m::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rotate_right;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\nfunction number_of_substrings(str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = number_of_substrings;\n\t@test(candidate(\"abc\") == 6)\n\t@test(candidate(\"abcd\") == 10)\n\t@test(candidate(\"abcde\") == 15)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\nfunction list_split(S::Vector{Any}, step::Int64)::Vector{Vector{Any}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = list_split;\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\n\t@test(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\nfunction all_unique(test_list::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_unique;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\nfunction convert(numbers::Int64)::Tuple{Float64, Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = convert;\n\t@test(candidate(1) == (1.0, 0.0))\n\t@test(candidate(4) == (4.0, 0.0))\n\t@test(candidate(5) == (5.0, 0.0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\nfunction is_lower(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_lower;\n\t@test(candidate(\"InValid\") == \"invalid\")\n\t@test(candidate(\"TruE\") == \"true\")\n\t@test(candidate(\"SenTenCE\") == \"sentence\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\nfunction next_power_of_2(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_power_of_2;\n\t@test(candidate(0) == 1)\n\t@test(candidate(5) == 8)\n\t@test(candidate(17) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\nfunction find_substring(str1::Vector{String}, sub_str::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_substring;\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\nfunction replace_char(str1::String, ch::String, newch::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_char;\n\t@test(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\")\n\t@test(candidate(\"character\", \"c\", \"a\") == \"aharaater\")\n\t@test(candidate(\"python\", \"l\", \"a\") == \"python\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\nfunction mul_even_odd(list1::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mul_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([1, 5, 7, 9, 10]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\nfunction list_tuple(listx::Vector{Int64})::Any \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = list_tuple;\n\t@test(candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\n\t@test(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\n\t@test(candidate([58, 44, 56]) == (58, 44, 56))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\nfunction even_binomial_Coeff_Sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_binomial_Coeff_Sum;\n\t@test(candidate(4) == 8)\n\t@test(candidate(6) == 32)\n\t@test(candidate(2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\nfunction bitwise_xor(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bitwise_xor;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10))\n\t@test(candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14))\n\t@test(candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\nfunction is_Sub_Array(A::Vector{Int64}, B::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sub_Array;\n\t@test(candidate([1, 4, 3, 5], [1, 2]) == false)\n\t@test(candidate([1, 2, 1], [1, 2, 1]) == true)\n\t@test(candidate([1, 0, 2, 2], [2, 2, 0]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\nfunction max_sub_array_sum_repeated(a::Vector{Int64}, n::Int64, k::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum_repeated;\n\t@test(candidate([10, 20, -30, -1], 4, 3) == 30)\n\t@test(candidate([-1, 10, 20], 3, 2) == 59)\n\t@test(candidate([-1, -2, -3], 3, 3) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\nfunction min_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 30)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\nfunction count_divisors(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_divisors;\n\t@test(candidate(10) == true)\n\t@test(candidate(100) == false)\n\t@test(candidate(125) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\nfunction triangle_area(r::Int64)::Union{Int64, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(-1) == nothing)\n\t@test(candidate(0) == 0)\n\t@test(candidate(2) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\nfunction string_to_tuple(str1::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_tuple;\n\t@test(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\n\t@test(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\n\t@test(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\nfunction find_length(string::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_length;\n\t@test(candidate(\"11000010001\") == 6)\n\t@test(candidate(\"10111\") == 1)\n\t@test(candidate(\"11011101100101\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\nfunction count_Primes_nums(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Primes_nums;\n\t@test(candidate(5) == 2)\n\t@test(candidate(10) == 4)\n\t@test(candidate(100) == 25)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\nfunction sum_Of_product(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_product;\n\t@test(candidate(3) == 15)\n\t@test(candidate(4) == 56)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\nfunction max_aggregate(stdata::Vector{Tuple{String, Int64}})::Tuple{String, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_aggregate;\n\t@test(candidate([(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\n\t@test(candidate([(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\n\t@test(candidate([(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\nfunction comb_sort(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = comb_sort;\n\t@test(candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\n\t@test(candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\n\t@test(candidate([99, 15, 13, 47]) == [13, 15, 47, 99])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\nfunction check_expression(exp::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_expression;\n\t@test(candidate(\"{()}[{}]\") == true)\n\t@test(candidate(\"{()}[{]\") == false)\n\t@test(candidate(\"{()}[{}][]({})\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\nfunction text_match_wordz(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz;\n\t@test(candidate(\"pythonz.\") == true)\n\t@test(candidate(\"xyz.\") == true)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\nfunction sum_list(lst1::Vector{Int64}, lst2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_list;\n\t@test(candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65])\n\t@test(candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10])\n\t@test(candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\nfunction newman_prime(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = newman_prime;\n\t@test(candidate(3) == 7)\n\t@test(candidate(4) == 17)\n\t@test(candidate(5) == 41)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\nfunction add_string(list_::Vector{Any}, string::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_string;\n\t@test(candidate([1, 2, 3, 4], \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\n\t@test(candidate([5, 6, 7, 8], \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\nfunction surface_Area(b::Int64, s::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surface_Area;\n\t@test(candidate(3, 4) == 33)\n\t@test(candidate(4, 5) == 56)\n\t@test(candidate(1, 2) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\nfunction Find_Min_Length(lst::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min_Length;\n\t@test(candidate([[1], [1, 2]]) == 1)\n\t@test(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\n\t@test(candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\nfunction validate(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = validate;\n\t@test(candidate(1234) == true)\n\t@test(candidate(51241) == false)\n\t@test(candidate(321) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\nfunction hexagonal_num(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hexagonal_num;\n\t@test(candidate(10) == 190)\n\t@test(candidate(5) == 45)\n\t@test(candidate(7) == 91)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\nfunction find_lucas(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lucas;\n\t@test(candidate(9) == 76)\n\t@test(candidate(4) == 7)\n\t@test(candidate(3) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\nfunction Diff(li1::Vector{Int64}, li2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Diff;\n\t@test(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15])\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\nfunction extract_quotation(text1::String)::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_quotation;\n\t@test(candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\n\t@test(candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\n\t@test(candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\n\t@test(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\nfunction recursive_list_sum(data_list::Vector{Union{Int64, Vector{Int64}}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = recursive_list_sum;\n\t@test(candidate([1, 2, [3, 4], [5, 6]]) == 21)\n\t@test(candidate([7, 10, [15, 14], [19, 41]]) == 106)\n\t@test(candidate([10, 20, [30, 40], [50, 60]]) == 210)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\nfunction differ_At_One_Bit_Pos(a::Int64, b::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = differ_At_One_Bit_Pos;\n\t@test(candidate(13, 9) == true)\n\t@test(candidate(15, 8) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(2, 3) == true)\n\t@test(candidate(5, 1) == true)\n\t@test(candidate(1, 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\nfunction text_match_three(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"caacabbbba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\nfunction max_product(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product;\n\t@test(candidate([3, 100, 4, 5, 150, 6]) == 3000)\n\t@test(candidate([4, 42, 55, 68, 80]) == 50265600)\n\t@test(candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\nfunction split_Arr(l::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_Arr;\n\t@test(candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10])\n\t@test(candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1])\n\t@test(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\nfunction divisor(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = divisor;\n\t@test(candidate(15) == 4)\n\t@test(candidate(12) == 6)\n\t@test(candidate(9) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\nfunction big_diff(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = big_diff;\n\t@test(candidate([1, 2, 3, 4]) == 3)\n\t@test(candidate([4, 5, 12]) == 8)\n\t@test(candidate([9, 2, 3]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\nfunction square_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30]) == [100, 400, 900])\n\t@test(candidate([12, 15]) == [144, 225])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\nfunction check_none(test_tup::Any)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_none;\n\t@test(candidate((10, 4, 5, 6, nothing)) == true)\n\t@test(candidate((7, 8, 9, 11, 14)) == false)\n\t@test(candidate((1, 2, 3, 4, nothing)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\nfunction is_Monotonic(A::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Monotonic;\n\t@test(candidate([6, 5, 4, 4]) == true)\n\t@test(candidate([1, 2, 2, 3]) == true)\n\t@test(candidate([1, 3, 2]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\nfunction is_perfect_square(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_perfect_square;\n\t@test(candidate(10) == false)\n\t@test(candidate(36) == true)\n\t@test(candidate(14) == false)\n\t@test(candidate(196) == true)\n\t@test(candidate(125) == false)\n\t@test(candidate(15625) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\nfunction sum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum;\n\t@test(candidate(10, 15) == 6)\n\t@test(candidate(100, 150) == 93)\n\t@test(candidate(4, 6) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\nfunction max_length(list1::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\n\t@test(candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\nfunction parabola_directrix(a::Int64, b::Int64, c::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parabola_directrix;\n\t@test(candidate(5, 3, 2) == -198)\n\t@test(candidate(9, 8, 4) == -2336)\n\t@test(candidate(2, 4, 6) == -130)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\nfunction occurance_substring(text::String, pattern::String)::Union{Tuple{String, Int64, Int64}, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = occurance_substring;\n\t@test(candidate(\"python programming, python language\", \"python\") == (\"python\", 0, 6))\n\t@test(candidate(\"python programming,programming language\", \"programming\") == (\"programming\", 7, 18))\n\t@test(candidate(\"python programming,programming language\", \"language\") == (\"language\", 31, 39))\n\t@test(candidate(\"c++ programming, c++ language\", \"python\") == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\nfunction remove_nested(test_tup::Any)::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_nested;\n\t@test(candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\n\t@test(candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\n\t@test(candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\n\t@test(candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\nfunction sort_sublists(input_list::Vector{Vector{String}})::Vector{Vector{String}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\n\t@test(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\nfunction remove_kth_element(list1::Vector{Int64}, L::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_kth_element;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1])\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\nfunction add_dict_to_tuple(test_tup::Tuple{Int64, Int64, Int64}, test_dict::Dict{String, Int64}>)::Tuple{Int64, Int64, Int64, Dict{String, Int64}>} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_dict_to_tuple;\n\t@test(candidate((4, 5, 6), Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) == (4, 5, 6, Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)))\n\t@test(candidate((1, 2, 3), Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) == (1, 2, 3, Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)))\n\t@test(candidate((8, 9, 10), Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) == (8, 9, 10, Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\nfunction find(n::Int64, m::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find;\n\t@test(candidate(10, 3) == 3)\n\t@test(candidate(4, 2) == 2)\n\t@test(candidate(20, 5) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\nfunction text_match_two_three(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_two_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\nfunction count_Occurrence(tup::Any, lst::Vector{Any})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Occurrence;\n\t@test(candidate((\"a\", \"a\", \"c\", \"b\", \"d\"), [\"a\", \"b\"]) == 3)\n\t@test(candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6)\n\t@test(candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\nfunction count_samepair(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_samepair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\nfunction text_match_one(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\nfunction difference(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = difference;\n\t@test(candidate(3) == 30)\n\t@test(candidate(5) == 210)\n\t@test(candidate(2) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\nfunction toggle_string(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_string;\n\t@test(candidate(\"Python\") == \"pYTHON\")\n\t@test(candidate(\"Pangram\") == \"pANGRAM\")\n\t@test(candidate(\"LIttLE\") == \"liTTle\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\nfunction Find_Max(lst::Vector{Vector{Any}})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max;\n\t@test(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\n\t@test(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\nfunction eulerian_num(n::Int64, m::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eulerian_num;\n\t@test(candidate(3, 1) == 4)\n\t@test(candidate(4, 1) == 11)\n\t@test(candidate(5, 3) == 26)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\nfunction frequency(a::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency;\n\t@test(candidate([1, 2, 3], 4) == 0)\n\t@test(candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3)\n\t@test(candidate([0, 1, 2, 3, 1, 2], 1) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\nfunction sort_numeric_strings(nums_str::Vector{String})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numeric_strings;\n\t@test(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\n\t@test(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\n\t@test(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\nfunction geometric_sum(n::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = geometric_sum;\n\t@test(candidate(7) == 1.9921875)\n\t@test(candidate(4) == 1.9375)\n\t@test(candidate(8) == 1.99609375)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\nfunction divisible_by_digits(startnum::Int64, endnum::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = divisible_by_digits;\n\t@test(candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\n\t@test(candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\n\t@test(candidate(20, 25) == [22, 24])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\nfunction unique_product(list_data::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_product;\n\t@test(candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\n\t@test(candidate([1, 2, 3, 1]) == 6)\n\t@test(candidate([7, 8, 9, 0, 1, 1]) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\nfunction largest_neg(list1::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_neg;\n\t@test(candidate([1, 2, 3, -4, -6]) == -6)\n\t@test(candidate([1, 2, 3, -8, -9]) == -9)\n\t@test(candidate([1, 2, 3, 4, -1]) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\nfunction consecutive_duplicates(nums::Vector{Any})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\nfunction min_Jumps(steps::Tuple{Int64, Int64}, d::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Jumps;\n\t@test(candidate((3, 4), 11) == 3.5)\n\t@test(candidate((3, 4), 0) == 0)\n\t@test(candidate((11, 14), 11) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\nfunction max_Product(arr::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Product;\n\t@test(candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\n\t@test(candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\n\t@test(candidate([1, 2, 3]) == (2, 3))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\nfunction extract_nth_element(list1::Vector{Tuple{String, Int64, Int64}}, n::Int64)::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_nth_element;\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 2) == [99, 96, 94, 98])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 1) == [98, 97, 91, 94])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\nfunction is_nonagonal(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nonagonal;\n\t@test(candidate(10) == 325)\n\t@test(candidate(15) == 750)\n\t@test(candidate(18) == 1089)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\nfunction max_Abs_Diff(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Abs_Diff;\n\t@test(candidate([2, 1, 5, 3]) == 4)\n\t@test(candidate([9, 3, 2, 5, 1]) == 8)\n\t@test(candidate([3, 2, 1]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\nfunction pack_consecutive_duplicates(list1::Vector{Any})::Vector{Vector{Any}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pack_consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\nfunction cal_sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cal_sum;\n\t@test(candidate(9) == 49)\n\t@test(candidate(10) == 66)\n\t@test(candidate(11) == 88)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\nfunction odd_values_string(str::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_values_string;\n\t@test(candidate(\"abcdef\") == \"ace\")\n\t@test(candidate(\"python\") == \"pto\")\n\t@test(candidate(\"data\") == \"dt\")\n\t@test(candidate(\"lambs\") == \"lms\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\nfunction find_kth(arr1::Vector{Int64}, arr2::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_kth;\n\t@test(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6)\n\t@test(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256)\n\t@test(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\nfunction jacobsthal_num(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = jacobsthal_num;\n\t@test(candidate(5) == 11)\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 5)\n\t@test(candidate(13) == 2731)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\nfunction frequency_lists(list1::Vector{Vector{Int64}})::Dict{Int64, Int64}> \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency_lists;\n\t@test(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == Dict(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1))\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == Dict(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1))\n\t@test(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == Dict(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\nfunction perfect_squares(a::Int64, b::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = perfect_squares;\n\t@test(candidate(1, 30) == [1, 4, 9, 16, 25])\n\t@test(candidate(50, 100) == [64, 81, 100])\n\t@test(candidate(100, 200) == [100, 121, 144, 169, 196])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\nfunction sum_Of_Subarray_Prod(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_Subarray_Prod;\n\t@test(candidate([1, 2, 3]) == 20)\n\t@test(candidate([1, 2]) == 5)\n\t@test(candidate([1, 2, 3, 4]) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\nfunction first_odd(nums::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_odd;\n\t@test(candidate([1, 3, 5]) == 1)\n\t@test(candidate([2, 4, 1, 3]) == 1)\n\t@test(candidate([8, 9, 1]) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\nfunction add_nested_tuples(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_nested_tuples;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\nfunction merge(lst::Vector{Vector{Any}})::Vector{Vector{Any}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge;\n\t@test(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\n\t@test(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\n\t@test(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\nfunction dif_Square(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dif_Square;\n\t@test(candidate(5) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(15) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\nfunction check_smaller(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_smaller;\n\t@test(candidate((1, 2, 3), (2, 3, 4)) == false)\n\t@test(candidate((4, 5, 6), (3, 4, 5)) == true)\n\t@test(candidate((11, 12, 13), (10, 11, 12)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\nfunction freq_count(list1::Vector{Int64})::Dict{Int64, Int64}> \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = freq_count;\n\t@test(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == Dict(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1))\n\t@test(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == Dict(1 => 3, 2 => 2, 3 => 3, 4 => 3))\n\t@test(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == Dict(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\nfunction rgb_to_hsv(r::Int64, g::Int64, b::Int64)::Vector{Float64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rgb_to_hsv;\n\t@test(candidate(255, 255, 255) == [0.0, 0.0, 100.0])\n\t@test(candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608])\n\t@test(candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\nfunction flatten_list(list1::Vector{Union{Int64, Vector{Int64}}})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flatten_list;\n\t@test(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\n\t@test(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\nfunction check_str(string::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_str;\n\t@test(candidate(\"annie\") == true)\n\t@test(candidate(\"dawood\") == false)\n\t@test(candidate(\"Else\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\nfunction check_monthnumber_number(monthnum3::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumber_number;\n\t@test(candidate(6) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(12) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\nfunction heap_sort(iterable::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_sort;\n\t@test(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\n\t@test(candidate([7, 1, 9, 5]) == [1, 5, 7, 9])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\nfunction k_smallest_pairs(nums1::Vector{Int64}, nums2::Vector{Int64}, k::Int64)::Vector{Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = k_smallest_pairs;\n\t@test(candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\nfunction find_solution(a::Int64, b::Int64, n::Int64)::Union{Tuple{Int64, Int64}, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_solution;\n\t@test(candidate(2, 3, 7) == (2, 1))\n\t@test(candidate(4, 2, 7) == nothing)\n\t@test(candidate(1, 13, 17) == (4, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\nfunction find_Max_Num(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Max_Num;\n\t@test(candidate([1, 2, 3]) == 321)\n\t@test(candidate([4, 5, 6, 1]) == 6541)\n\t@test(candidate([1, 2, 3, 9]) == 9321)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\nfunction max_sum_list(lists::Vector{Vector{Int64}})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_list;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\n\t@test(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\n\t@test(candidate([[2, 3, 1]]) == [2, 3, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\nfunction get_median(arr1::Vector{Int64}, arr2::Vector{Int64}, n::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_median;\n\t@test(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0)\n\t@test(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5)\n\t@test(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\nfunction replace_spaces(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\n\t@test(candidate(\"The_Avengers\") == \"The Avengers\")\n\t@test(candidate(\"Fast and Furious\") == \"Fast_and_Furious\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\nfunction are_equivalent(num1::Int64, num2::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = are_equivalent;\n\t@test(candidate(36, 57) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(23, 47) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\nfunction reverse_string_list(stringlist::Vector{String})::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_string_list;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\n\t@test(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\n\t@test(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\nfunction sum_of_digits(nums::Vector{Any})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_of_digits;\n\t@test(candidate([10, 2, 56]) == 14)\n\t@test(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\n\t@test(candidate([10, 20, -4, 5, -70]) == 19)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\nfunction sequence(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sequence;\n\t@test(candidate(10) == 6)\n\t@test(candidate(2) == 1)\n\t@test(candidate(3) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\nfunction heap_queue_largest(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_queue_largest;\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\nfunction loss_amount(actual_cost::Int64, sale_amount::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = loss_amount;\n\t@test(candidate(1500, 1200) == 0)\n\t@test(candidate(100, 200) == 100)\n\t@test(candidate(2000, 5000) == 3000)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\nfunction union_elements(test_tup1::Vector{Int64}, test_tup2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = union_elements;\n\t@test(candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\n\t@test(candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\n\t@test(candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\nfunction Find_Max_Length(lst::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max_Length;\n\t@test(candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4)\n\t@test(candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3)\n\t@test(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\nfunction remove_parenthesis(items::Vector{String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_parenthesis;\n\t@test(candidate([\"python (chrome)\"]) == \"python\")\n\t@test(candidate([\"string(.abc)\"]) == \"string\")\n\t@test(candidate([\"alpha(num)\"]) == \"alpha\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\nfunction find_Parity(x::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Parity;\n\t@test(candidate(12) == false)\n\t@test(candidate(7) == true)\n\t@test(candidate(10) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\nfunction median_trapezium(base1::Int64, base2::Int64, height::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median_trapezium;\n\t@test(candidate(15, 25, 35) == 20)\n\t@test(candidate(10, 20, 30) == 15)\n\t@test(candidate(6, 9, 4) == 7.5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\nfunction centered_hexagonal_number(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = centered_hexagonal_number;\n\t@test(candidate(10) == 271)\n\t@test(candidate(2) == 7)\n\t@test(candidate(9) == 217)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\nfunction find_lists(Input::Vector{Any})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lists;\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\n\t@test(candidate([[1, 2], [3, 4], [5, 6]]) == 3)\n\t@test(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\nfunction get_max_sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_sum;\n\t@test(candidate(60) == 106)\n\t@test(candidate(10) == 12)\n\t@test(candidate(2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\nfunction len_log(list1::Vector{String})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = len_log;\n\t@test(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7)\n\t@test(candidate([\"a\", \"ab\", \"abc\"]) == 3)\n\t@test(candidate([\"small\", \"big\", \"tall\"]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\nfunction sector_area(r::Int64, a::Int64)::Union{Float64, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sector_area;\n\t@test(candidate(4, 45) == 6.283185307179586)\n\t@test(candidate(9, 45) == 31.808625617596654)\n\t@test(candidate(9, 361) == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\nfunction odd_position(nums::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_position;\n\t@test(candidate([2, 1, 4, 3, 6, 7, 6, 3]) == true)\n\t@test(candidate([4, 1, 2]) == true)\n\t@test(candidate([1, 2, 3]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\nfunction multiple_to_single(L::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiple_to_single;\n\t@test(candidate([11, 33, 50]) == 113350)\n\t@test(candidate([-1, 2, 3, 4, 5, 6]) == -123456)\n\t@test(candidate([10, 15, 20, 25]) == 10152025)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\nfunction is_Diff(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Diff;\n\t@test(candidate(12345) == false)\n\t@test(candidate(1212112) == true)\n\t@test(candidate(1212) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\nfunction index_multiplication(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = index_multiplication;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\nfunction tuple_str_int(test_str::String)::Tuple{Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_str_int;\n\t@test(candidate(\"(7, 8, 9)\") == (7, 8, 9))\n\t@test(candidate(\"(1, 2, 3)\") == (1, 2, 3))\n\t@test(candidate(\"(4, 5, 6)\") == (4, 5, 6))\n\t@test(candidate(\"(7, 81, 19)\") == (7, 81, 19))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\nfunction amicable_numbers_sum(limit::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = amicable_numbers_sum;\n\t@test(candidate(999) == 504)\n\t@test(candidate(9999) == 31626)\n\t@test(candidate(99) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\nfunction remove_odd(str1::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate(\"python\") == \"yhn\")\n\t@test(candidate(\"program\") == \"rga\")\n\t@test(candidate(\"language\") == \"agae\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\nfunction multiply_elements(test_tup::Vector{Int64})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_elements;\n\t@test(candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80])\n\t@test(candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42])\n\t@test(candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135])\n\t@test(candidate([12]) == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\nfunction count_rotation(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_rotation;\n\t@test(candidate([3, 2, 1]) == 1)\n\t@test(candidate([4, 5, 1, 2, 3]) == 2)\n\t@test(candidate([7, 8, 9, 1, 2, 3]) == 3)\n\t@test(candidate([1, 2, 3]) == 0)\n\t@test(candidate([1, 3, 2]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\nfunction extract_freq(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_freq;\n\t@test(candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\n\t@test(candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\n\t@test(candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\nfunction count_same_pair(nums1::Vector{Int64}, nums2::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_same_pair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\n\t@test(candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\nfunction power(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = power;\n\t@test(candidate(3, 4) == 81)\n\t@test(candidate(2, 3) == 8)\n\t@test(candidate(5, 5) == 3125)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\nfunction return_sum(dict::Dict{String, Int64}>)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = return_sum;\n\t@test(candidate(Dict(\"a\" => 100, \"b\" => 200, \"c\" => 300)) == 600)\n\t@test(candidate(Dict(\"a\" => 25, \"b\" => 18, \"c\" => 45)) == 88)\n\t@test(candidate(Dict(\"a\" => 36, \"b\" => 39, \"c\" => 49)) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\nfunction pair_wise(l1::Vector{Int64})::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_wise;\n\t@test(candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\n\t@test(candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\n\t@test(candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\nfunction split(word::String)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split;\n\t@test(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\n\t@test(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"])\n\t@test(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\nfunction min_of_three(a::Int64, b::Int64, c::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_of_three;\n\t@test(candidate(10, 20, 0) == 0)\n\t@test(candidate(19, 15, 18) == 15)\n\t@test(candidate(-10, -20, -30) == -30)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\nfunction is_Sum_Of_Powers_Of_Two(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sum_Of_Powers_Of_Two;\n\t@test(candidate(10) == true)\n\t@test(candidate(7) == false)\n\t@test(candidate(14) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\nfunction get_Char(strr::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Char;\n\t@test(candidate(\"abc\") == \"f\")\n\t@test(candidate(\"gfg\") == \"t\")\n\t@test(candidate(\"ab\") == \"c\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\nfunction sum_div(number::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_div;\n\t@test(candidate(8) == 7)\n\t@test(candidate(12) == 16)\n\t@test(candidate(7) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\nfunction count_integer(list1::Vector{Union{Int64, String, Float64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_integer;\n\t@test(candidate([1, 2, \"abc\", 1.2]) == 2)\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([1, 1.2, 4, 5.1]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\nfunction two_unique_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = two_unique_nums;\n\t@test(candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\n\t@test(candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\nfunction test_duplicate(arraynums::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = test_duplicate;\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 4]) == true)\n\t@test(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\nfunction catalan_number(num::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = catalan_number;\n\t@test(candidate(10) == 16796)\n\t@test(candidate(9) == 4862)\n\t@test(candidate(7) == 429)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\nfunction power_base_sum(base::Int64, power::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = power_base_sum;\n\t@test(candidate(2, 100) == 115)\n\t@test(candidate(8, 10) == 37)\n\t@test(candidate(8, 15) == 62)\n\t@test(candidate(3, 3) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\nfunction replace_list(list1::Vector{Any}, list2::Vector{Any})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_list;\n\t@test(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\nfunction is_octagonal(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_octagonal;\n\t@test(candidate(5) == 65)\n\t@test(candidate(10) == 280)\n\t@test(candidate(15) == 645)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\nfunction replace_blank(str1::String, char::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_blank;\n\t@test(candidate(\"hello people\", \"@\") == \"hello@people\")\n\t@test(candidate(\"python program language\", \"\\$\") == \"python\\$program\\$language\")\n\t@test(candidate(\"blank space\", \"-\") == \"blank-space\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\nfunction replace_specialchar(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_specialchar;\n\t@test(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\")\n\t@test(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\")\n\t@test(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\nfunction tuple_to_int(nums::Tuple{Int64, Int64, Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_int;\n\t@test(candidate((1, 2, 3)) == 123)\n\t@test(candidate((4, 5, 6)) == 456)\n\t@test(candidate((5, 6, 7)) == 567)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\nfunction otherside_rightangle(w::Int64, h::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = otherside_rightangle;\n\t@test(candidate(7, 8) == 10.63014581273465)\n\t@test(candidate(3, 4) == 5)\n\t@test(candidate(7, 15) == 16.55294535724685)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\nfunction digit_distance_nums(n1::Int64, n2::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digit_distance_nums;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(23, 56) == 6)\n\t@test(candidate(123, 256) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\nfunction text_match_wordz_middle(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz_middle;\n\t@test(candidate(\"pythonzabc.\") == true)\n\t@test(candidate(\"zxyabc.\") == false)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\nfunction removezero_ip(ip::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = removezero_ip;\n\t@test(candidate(\"216.08.094.196\") == \"216.8.94.196\")\n\t@test(candidate(\"12.01.024\") == \"12.1.24\")\n\t@test(candidate(\"216.08.094.0196\") == \"216.8.94.196\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\nfunction count_element_in_list(list1::Vector{Vector{Any}}, x::Any)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_element_in_list;\n\t@test(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\") == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\nfunction multiply_int(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_int;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(5, 10) == 50)\n\t@test(candidate(4, 8) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\nfunction add_pairwise(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_pairwise;\n\t@test(candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18))\n\t@test(candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20))\n\t@test(candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\nfunction max_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 200)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4036,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\"\"\"\nfunction kth_element(arr::Vector{Int64}, k::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = kth_element;\n\t@test(candidate([12, 3, 5, 7, 19], 2) == 3)\n\t@test(candidate([17, 24, 8, 23], 3) == 8)\n\t@test(candidate([16, 21, 25, 36, 4], 4) == 36)\nend\n",
     "stop_tokens": [
@@ -4046,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"python_program\") == \"PythonProgram\")\n\t@test(candidate(\"python_language\") == \"PythonLanguage\")\n\t@test(candidate(\"programming_language\") == \"ProgrammingLanguage\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4060,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\nfunction count_first_elements(test_tup::Vector{Union{Int64, Tuple{Int64, Int64}}})::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\nfunction eulerian_num(n::Int64, m::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_first_elements;\n\t@test(candidate([1, 5, 7, (4, 6), 10]) == 3)\n\t@test(candidate([2, 9, (5, 7), 11]) == 2)\n\t@test(candidate([11, 15, 5, 8, (2, 3), 8]) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eulerian_num;\n\t@test(candidate(3, 1) == 4)\n\t@test(candidate(4, 1) == 11)\n\t@test(candidate(5, 3) == 26)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4074,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\nfunction right_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\nfunction sort_sublists(input_list::Vector{Vector{String}})::Vector{Vector{String}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\n\t@test(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4088,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\nfunction is_woodall(x::Int64)::Bool \n",
+    "prompt": "\"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\nfunction count(lst::Vector{Bool})::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_woodall;\n\t@test(candidate(383) == true)\n\t@test(candidate(254) == false)\n\t@test(candidate(200) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count;\n\t@test(candidate([true, false, true]) == 2)\n\t@test(candidate([false, false]) == 0)\n\t@test(candidate([true, true, true]) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4102,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\nfunction shell_sort(my_list::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\nfunction add_lists(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Tuple{Int64, Int64, Int64, Int64, Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = shell_sort;\n\t@test(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\n\t@test(candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\n\t@test(candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_lists;\n\t@test(candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7))\n\t@test(candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8))\n\t@test(candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4116,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\nfunction find_Odd_Pair(A::Vector{Int64}, N::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\nfunction merge_sorted_list(num1::Vector{Int64}, num2::Vector{Int64}, num3::Vector{Int64})::Vector{Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Odd_Pair;\n\t@test(candidate([5, 4, 7, 2, 1], 5) == 6)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12)\n\t@test(candidate([1, 2, 3], 3) == 2)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_sorted_list;\n\t@test(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\n\t@test(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\n\t@test(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4130,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\nfunction sum_in_range(l::Int64, r::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\nfunction odd_Equivalent(s::String, n::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_in_range;\n\t@test(candidate(2, 5) == 8)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 13) == 40)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_Equivalent;\n\t@test(candidate(\"011001\", 6) == 3)\n\t@test(candidate(\"11011\", 5) == 4)\n\t@test(candidate(\"1010\", 4) == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4144,13 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\nfunction square_perimeter(a::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\nfunction check_integer(text::String)::Bool \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_perimeter;\n\t@test(candidate(10) == 40)\n\t@test(candidate(5) == 20)\n\t@test(candidate(4) == 16)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_integer;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"1\") == true)\n\t@test(candidate(\"12345\") == true)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4158,209 +140,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\nfunction is_polite(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\nfunction tuple_to_int(nums::Tuple{Int64, Int64, Int64})::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_polite;\n\t@test(candidate(7) == 11)\n\t@test(candidate(4) == 7)\n\t@test(candidate(9) == 13)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\nfunction sum_series(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_series;\n\t@test(candidate(6) == 12)\n\t@test(candidate(10) == 30)\n\t@test(candidate(9) == 25)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\nfunction find_dissimilar(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_dissimilar;\n\t@test(candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10))\n\t@test(candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9))\n\t@test(candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\nfunction start_withp(words::Vector{String})::Tuple{String, String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = start_withp;\n\t@test(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\n\t@test(candidate([\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\n\t@test(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"android_tv\") == \"AndroidTv\")\n\t@test(candidate(\"google_pixel\") == \"GooglePixel\")\n\t@test(candidate(\"apple_watch\") == \"AppleWatch\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\nfunction volume_cube(l::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = volume_cube;\n\t@test(candidate(3) == 27)\n\t@test(candidate(2) == 8)\n\t@test(candidate(5) == 125)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\nfunction check_monthnumb_number(monthnum2::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumb_number;\n\t@test(candidate(5) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(6) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\nfunction all_Bits_Set_In_The_Given_Range(n::Int64, l::Int64, r::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Bits_Set_In_The_Given_Range;\n\t@test(candidate(4, 1, 2) == true)\n\t@test(candidate(17, 2, 4) == true)\n\t@test(candidate(39, 4, 6) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\nfunction Extract(lst::Vector{Vector{Int64}})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Extract;\n\t@test(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\n\t@test(candidate([[1, 2, 3], [4, 5]]) == [1, 4])\n\t@test(candidate([[9, 8, 1], [1, 2]]) == [9, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\nfunction surfacearea_cylinder(r::Int64, h::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cylinder;\n\t@test(candidate(10, 5) == 942.45)\n\t@test(candidate(4, 5) == 226.18800000000002)\n\t@test(candidate(4, 10) == 351.848)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\nfunction sample_nam(sample_names::Vector{String})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sample_nam;\n\t@test(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\n\t@test(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\n\t@test(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\nfunction rearrange_bigger(n::Int64)::Any \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rearrange_bigger;\n\t@test(candidate(12) == 21)\n\t@test(candidate(10) == false)\n\t@test(candidate(102) == 120)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\nfunction perimeter_pentagon(a::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = perimeter_pentagon;\n\t@test(candidate(5) == 25)\n\t@test(candidate(10) == 50)\n\t@test(candidate(15) == 75)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\nfunction max_sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum;\n\t@test(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\n\t@test(candidate([80, 60, 30, 40, 20, 10]) == 210)\n\t@test(candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\nfunction extract_even(test_tuple::Tuple{Int64, Int64, Tuple{Int64, Int64, Tuple{Int64, Int64}}, Int64, Int64})::Any \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_even;\n\t@test(candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\n\t@test(candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\n\t@test(candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_int;\n\t@test(candidate((1, 2, 3)) == 123)\n\t@test(candidate((4, 5, 6)) == 456)\n\t@test(candidate((5, 6, 7)) == 567)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4372,233 +158,9 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to convert all possible convertible elements in a list of lists to floats.\n\t\"\"\"\nfunction list_to_float(test_list::Vector{Tuple{String, String}})::Vector{Tuple{Float64, Float64}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = list_to_float;\n\t@test(candidate([(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)])\n\t@test(candidate([(\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)])\n\t@test(candidate([(\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 20)\n\t@test(candidate(3) == 56)\n\t@test(candidate(4) == 120)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\nfunction get_pairs_count(arr::Vector{Int64}, sum::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_pairs_count;\n\t@test(candidate([1, 1, 1, 1], 2) == 6)\n\t@test(candidate([1, 5, 7, -1, 5], 6) == 3)\n\t@test(candidate([1, -2, 3], 1) == 1)\n\t@test(candidate([-1, -2, 3], -3) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\nfunction count_no_of_ways(n::Int64, k::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_no_of_ways;\n\t@test(candidate(2, 4) == 16)\n\t@test(candidate(3, 2) == 6)\n\t@test(candidate(4, 4) == 228)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\nfunction reverse_words(s::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_words;\n\t@test(candidate(\"python program\") == \"program python\")\n\t@test(candidate(\"java language\") == \"language java\")\n\t@test(candidate(\"indian man\") == \"man indian\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\nfunction checks(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = checks;\n\t@test(candidate(70) == false)\n\t@test(candidate(23) == false)\n\t@test(candidate(73) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\nfunction last(arr::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last;\n\t@test(candidate([1, 2, 3], 1) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, 4], 1) == 2)\n\t@test(candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\nfunction count_X(tup::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_X;\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\nfunction extract_index_list(l1::Vector{Int64}, l2::Vector{Int64}, l3::Vector{Int64})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_index_list;\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\n\t@test(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\n\t@test(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\nfunction second_smallest(numbers::Vector{Union{Int64, Float64}})::Union{Float64, Nothing} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = second_smallest;\n\t@test(candidate([1, 2, -8, -2, 0, -2]) == -2)\n\t@test(candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5)\n\t@test(candidate([2, 2]) == nothing)\n\t@test(candidate([2, 2, 2]) == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\nfunction concatenate_tuple(test_tup::Tuple{String, String, Int64, String})::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate_tuple;\n\t@test(candidate((\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\n\t@test(candidate((\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\n\t@test(candidate((\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\nfunction replace_spaces(string::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\n\t@test(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\")\n\t@test(candidate(\"I love Coding\") == \"I%20love%20Coding\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\nfunction sum_range_list(list1::Vector{Int64}, m::Int64, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_range_list;\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\nfunction merge_dictionaries_three(dict1::Dict{String, String}>, dict2::Dict{String, String}>, dict3::Dict{String, String}>)::Dict{String, String}> \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_dictionaries_three;\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) == Dict(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\")) == Dict(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\"), Dict(\"G\" => \"Green\", \"W\" => \"White\")) == Dict(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\nfunction minimum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minimum;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(-5, -4) == -5)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\nfunction max_difference(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_difference;\n\t@test(candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\n\t@test(candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\n\t@test(candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\nfunction find_Element(arr::Vector{Int64}, ranges::Vector{Vector{Int64}}, rotations::Int64, index::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Element;\n\t@test(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3)\n\t@test(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4610,7 +172,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to convert a string to a list of strings split on the space character.\n\t\"\"\"\nfunction string_to_list(string::String)::Vector{String} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_list;\n\t@test(candidate(\"python programming\") == [\"python\", \"programming\"])\n\t@test(candidate(\"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"])\n\t@test(candidate(\"write a program\") == [\"write\", \"a\", \"program\"])\nend\n",
     "stop_tokens": [
@@ -4624,23 +186,9 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a python function to find the element that appears only once in a sorted array.\n\t\"\"\"\nfunction search(arr::Vector{Int64})::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([1, 1, 2, 2, 3]) == 3)\n\t@test(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8)\n\t@test(candidate([1, 2, 2, 3, 3, 4, 4]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\nfunction sort_counter(dict1::Dict{String, Int64}>)::Vector{Tuple{String, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_counter;\n\t@test(candidate(Dict(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\n\t@test(candidate(Dict(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\n\t@test(candidate(Dict(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4652,7 +200,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a python function to remove first and last occurrence of a given character from the string.\n\t\"\"\"\nfunction remove_Occ(s::String, ch::String)::String \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = remove_Occ;\n\t@test(candidate(\"hello\", \"l\") == \"heo\")\n\t@test(candidate(\"abcda\", \"a\") == \"bcd\")\n\t@test(candidate(\"PHP\", \"P\") == \"H\")\nend\n",
     "stop_tokens": [
@@ -4662,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\nfunction lateralsurface_cube(l::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\nfunction max_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cube;\n\t@test(candidate(5) == 100)\n\t@test(candidate(9) == 324)\n\t@test(candidate(10) == 400)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 200)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4676,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\nfunction common_element(list1::Vector{Any}, list2::Vector{Any})::Union{Bool, Nothing} \n",
+    "prompt": "\"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\nfunction amicable_numbers_sum(limit::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common_element;\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == true)\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == nothing)\n\t@test(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = amicable_numbers_sum;\n\t@test(candidate(999) == 504)\n\t@test(candidate(9999) == 31626)\n\t@test(candidate(99) == 0)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4690,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\nfunction add_lists(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Tuple{Int64, Int64, Int64, Int64, Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\nfunction find_length(string::String)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_lists;\n\t@test(candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7))\n\t@test(candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8))\n\t@test(candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_length;\n\t@test(candidate(\"11000010001\") == 6)\n\t@test(candidate(\"10111\") == 1)\n\t@test(candidate(\"11011101100101\") == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4704,13 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\nfunction nth_nums(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\nfunction sum(a::Int64, b::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = nth_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30], 3) == [1000, 8000, 27000])\n\t@test(candidate([12, 15], 5) == [248832, 759375])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum;\n\t@test(candidate(10, 15) == 6)\n\t@test(candidate(100, 150) == 93)\n\t@test(candidate(4, 6) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4718,335 +266,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\nfunction pancake_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\nfunction multiply_int(x::Int64, y::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pancake_sort;\n\t@test(candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\n\t@test(candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\n\t@test(candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\nfunction median_numbers(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median_numbers;\n\t@test(candidate(25, 55, 65) == 55.0)\n\t@test(candidate(20, 10, 30) == 20.0)\n\t@test(candidate(15, 45, 75) == 45.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\nfunction check_greater(arr::Vector{Int64}, number::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_greater;\n\t@test(candidate([1, 2, 3, 4, 5], 4) == false)\n\t@test(candidate([2, 3, 4, 5, 6], 8) == true)\n\t@test(candidate([9, 7, 4, 8, 6, 1], 11) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\nfunction check_element(list::Vector{Any}, element::Any)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_element;\n\t@test(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\") == false)\n\t@test(candidate([1, 2, 3, 4], 7) == false)\n\t@test(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\nfunction extract_string(str::Vector{String}, l::Int64)::Vector{String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_string;\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8) == [\"practice\", \"solution\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6) == [\"Python\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9) == [\"exercises\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\nfunction text_lowercase_underscore(text::String)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_lowercase_underscore;\n\t@test(candidate(\"aab_cbbbc\") == true)\n\t@test(candidate(\"aab_Abbbc\") == false)\n\t@test(candidate(\"Aaab_abbbc\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\nfunction trim_tuple(test_list::Vector{Vector{Int64}}, K::Int64)::Vector{Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = trim_tuple;\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]])\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\n\t@test(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\nfunction Find_Min(lst::Vector{Vector{Any}})::Vector{Any} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min;\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1])\n\t@test(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\n\t@test(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\nfunction filter_oddnumbers(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_oddnumbers;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\n\t@test(candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93])\n\t@test(candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\nfunction find_adverbs(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverbs;\n\t@test(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\n\t@test(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\")\n\t@test(candidate(\"Complete the task quickly\") == \"18-25: quickly\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\nfunction max_of_nth(test_list::Vector{Vector{Int64}}, N::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_of_nth;\n\t@test(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19)\n\t@test(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10)\n\t@test(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\nfunction decimal_to_binary(n::Int64)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(8) == \"1000\")\n\t@test(candidate(18) == \"10010\")\n\t@test(candidate(7) == \"111\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\nfunction combinations_colors(l::Vector{String}, n::Int64)::Vector{Vector{String}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = combinations_colors;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\nfunction remove_all_spaces(text::String)::String \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_all_spaces;\n\t@test(candidate(\"python  program\") == \"pythonprogram\")\n\t@test(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\")\n\t@test(candidate(\"python                     program\") == \"pythonprogram\")\n\t@test(candidate(\"   python                     program\") == \"pythonprogram\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\nfunction min_Swaps(str1::String, str2::String)::Any \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Swaps;\n\t@test(candidate(\"1101\", \"1110\") == 1)\n\t@test(candidate(\"111\", \"000\") == \"Not Possible\")\n\t@test(candidate(\"111\", \"110\") == \"Not Possible\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\nfunction new_tuple(test_list::Vector{String}, test_str::String)::Tuple{String, String, String} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = new_tuple;\n\t@test(candidate([\"WEB\", \"is\"], \"best\") == (\"WEB\", \"is\", \"best\"))\n\t@test(candidate([\"We\", \"are\"], \"Developers\") == (\"We\", \"are\", \"Developers\"))\n\t@test(candidate([\"Part\", \"is\"], \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\nfunction find_remainder(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_remainder;\n\t@test(candidate([100, 10, 5, 25, 35, 14], 11) == 9)\n\t@test(candidate([1, 1, 1], 1) == 0)\n\t@test(candidate([1, 2, 1], 2) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\nfunction min_val(listval::Vector{Union{String, Int64}})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 2)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 15)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 20)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\nfunction positive_count(nums::Vector{Int64})::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = positive_count;\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\n\t@test(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\nfunction add_tuple(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_tuple;\n\t@test(candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10])\n\t@test(candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11])\n\t@test(candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\nfunction max_run_uppercase(test_str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_run_uppercase;\n\t@test(candidate(\"GeMKSForGERksISBESt\") == 5)\n\t@test(candidate(\"PrECIOusMOVemENTSYT\") == 6)\n\t@test(candidate(\"GooGLEFluTTER\") == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\nfunction sort_matrix(M::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_matrix;\n\t@test(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\n\t@test(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\n\t@test(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\nfunction count_vowels(test_str::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_vowels;\n\t@test(candidate(\"bestinstareels\") == 7)\n\t@test(candidate(\"partofthejourneyistheend\") == 12)\n\t@test(candidate(\"amazonprime\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\nfunction max_sum_increasing_subseq(a::Vector{Int64}, n::Int64, index::Int64, k::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_increasing_subseq;\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11)\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7)\n\t@test(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_int;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(5, 10) == 50)\n\t@test(candidate(4, 8) == 32)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5058,7 +284,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find words that are longer than n characters from a given list of words.\n\t\"\"\"\nfunction long_words(n::Int64, str::String)::Vector{String} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = long_words;\n\t@test(candidate(3, \"python is a programming language\") == [\"python\", \"programming\", \"language\"])\n\t@test(candidate(2, \"writing a program\") == [\"writing\", \"program\"])\n\t@test(candidate(5, \"sorting list\") == [\"sorting\"])\nend\n",
     "stop_tokens": [
@@ -5068,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\nfunction find_sum(arr::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\nfunction magic_square_test(my_matrix::Vector{Vector{Int64}})::Bool \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_sum;\n\t@test(candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21)\n\t@test(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\n\t@test(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = magic_square_test;\n\t@test(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5082,13 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\nfunction tuple_to_dict(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64, Int64})::Dict{Int64, Int64}> \n",
+    "prompt": "\"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\nfunction sort_matrix(M::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_dict;\n\t@test(candidate((1, 5, 7, 10, 13, 5)) == Dict(1 => 5, 7 => 10, 13 => 5))\n\t@test(candidate((1, 2, 3, 4, 5, 6)) == Dict(1 => 2, 3 => 4, 5 => 6))\n\t@test(candidate((7, 8, 9, 10, 11, 12)) == Dict(7 => 8, 9 => 10, 11 => 12))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_matrix;\n\t@test(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\n\t@test(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\n\t@test(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5096,209 +322,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\nfunction get_coordinates(test_tup::Tuple{Int64, Int64})::Vector{Vector{Int64}} \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\nfunction max_occurrences(nums::Vector{Int64})::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_coordinates;\n\t@test(candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\n\t@test(candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\n\t@test(candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\nfunction check_type(test_tuple::Any)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_type;\n\t@test(candidate((5, 6, 7, 3, 5, 6)) == true)\n\t@test(candidate((1, 2, \"4\")) == false)\n\t@test(candidate((3, 2, 1, 4, 5)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\nfunction find_First_Missing(array::Vector{Int64})::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_First_Missing;\n\t@test(candidate([0, 1, 2, 3]) == 4)\n\t@test(candidate([0, 1, 2, 6, 9]) == 3)\n\t@test(candidate([2, 3, 5, 8, 9]) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\nfunction is_undulating(n::Int64)::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_undulating;\n\t@test(candidate(1212121) == true)\n\t@test(candidate(1991) == false)\n\t@test(candidate(121) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\nfunction min_k(test_list::Vector{Tuple{String, Int64}}, K::Int64)::Vector{Tuple{String, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_k;\n\t@test(candidate([(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\n\t@test(candidate([(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\n\t@test(candidate([(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], 1) == [(\"Ayesha\", 9)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\nfunction count_Substrings(s::String)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Substrings;\n\t@test(candidate(\"112112\") == 6)\n\t@test(candidate(\"111\") == 6)\n\t@test(candidate(\"1101112\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\nfunction is_num_decagonal(n::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_num_decagonal;\n\t@test(candidate(3) == 27)\n\t@test(candidate(7) == 175)\n\t@test(candidate(10) == 370)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\nfunction rear_extract(test_list::Vector{Tuple{Int64, String, Int64}})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rear_extract;\n\t@test(candidate([(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\n\t@test(candidate([(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\n\t@test(candidate([(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\nfunction closest_num(N::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_num;\n\t@test(candidate(11) == 10)\n\t@test(candidate(7) == 6)\n\t@test(candidate(12) == 11)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\nfunction find_combinations(test_list::Vector{Tuple{Int64, Int64}})::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_combinations;\n\t@test(candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\n\t@test(candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\n\t@test(candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\nfunction maxAverageOfPath(cost::Vector{Vector{Int64}})::Float64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maxAverageOfPath;\n\t@test(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\n\t@test(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\n\t@test(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\nfunction sequential_search(dlist::Vector{Int64}, item::Int64)::Tuple{Bool, Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sequential_search;\n\t@test(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (true, 3))\n\t@test(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (true, 7))\n\t@test(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (true, 6))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\nfunction remove_odd(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate([1, 2, 3]) == [2])\n\t@test(candidate([2, 4, 6]) == [2, 4, 6])\n\t@test(candidate([10, 20, 3]) == [10, 20])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\nfunction is_product_even(arr::Vector{Int64})::Bool \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_product_even;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 4]) == true)\n\t@test(candidate([1, 1]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\nfunction maximum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate(5, 10) == 10)\n\t@test(candidate(-1, -2) == -1)\n\t@test(candidate(9, 7) == 9)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_occurrences;\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\n\t@test(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5310,9 +340,695 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a python function to reverse only the vowels of a given string (where y is not a vowel).\n\t\"\"\"\nfunction reverse_vowels(str1::String)::String \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_vowels;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"USA\") == \"ASU\")\n\t@test(candidate(\"ab\") == \"ab\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\nfunction tup_string(tup1::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tup_string;\n\t@test(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\n\t@test(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\nfunction sum_negativenum(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_negativenum;\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\n\t@test(candidate([10, 15, -14, 13, -18, 12, -20]) == -52)\n\t@test(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\nfunction hexagonal_num(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hexagonal_num;\n\t@test(candidate(10) == 190)\n\t@test(candidate(5) == 45)\n\t@test(candidate(7) == 91)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\nfunction is_Sum_Of_Powers_Of_Two(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sum_Of_Powers_Of_Two;\n\t@test(candidate(10) == true)\n\t@test(candidate(7) == false)\n\t@test(candidate(14) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\nfunction pancake_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pancake_sort;\n\t@test(candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\n\t@test(candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\n\t@test(candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\nfunction count_samepair(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_samepair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\nfunction find_lists(Input::Vector{Any})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lists;\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\n\t@test(candidate([[1, 2], [3, 4], [5, 6]]) == 3)\n\t@test(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\nfunction max_Abs_Diff(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Abs_Diff;\n\t@test(candidate([2, 1, 5, 3]) == 4)\n\t@test(candidate([9, 3, 2, 5, 1]) == 8)\n\t@test(candidate([3, 2, 1]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\nfunction find_Volume(l::Int64, b::Int64, h::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Volume;\n\t@test(candidate(10, 8, 6) == 240)\n\t@test(candidate(3, 2, 2) == 6)\n\t@test(candidate(1, 2, 1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\nfunction find_solution(a::Int64, b::Int64, n::Int64)::Union{Tuple{Int64, Int64}, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_solution;\n\t@test(candidate(2, 3, 7) == (2, 1))\n\t@test(candidate(4, 2, 7) == nothing)\n\t@test(candidate(1, 13, 17) == (4, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\nfunction remove_elements(list1::Vector{Int64}, list2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_elements;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\nfunction sum_series(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_series;\n\t@test(candidate(6) == 12)\n\t@test(candidate(10) == 30)\n\t@test(candidate(9) == 25)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\nfunction are_equivalent(num1::Int64, num2::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = are_equivalent;\n\t@test(candidate(36, 57) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(23, 47) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\nfunction count_char_position(str1::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_char_position;\n\t@test(candidate(\"xbcefg\") == 2)\n\t@test(candidate(\"ABcED\") == 3)\n\t@test(candidate(\"AbgdeF\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\nfunction find_even_pair(A::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_even_pair;\n\t@test(candidate([5, 4, 7, 2, 1]) == 4)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11]) == 9)\n\t@test(candidate([1, 2, 3]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\nfunction next_power_of_2(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_power_of_2;\n\t@test(candidate(0) == 1)\n\t@test(candidate(5) == 8)\n\t@test(candidate(17) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\nfunction frequency(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency;\n\t@test(candidate([1, 2, 3], 4) == 0)\n\t@test(candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3)\n\t@test(candidate([0, 1, 2, 3, 1, 2], 1) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\nfunction text_lowercase_underscore(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_lowercase_underscore;\n\t@test(candidate(\"aab_cbbbc\") == true)\n\t@test(candidate(\"aab_Abbbc\") == false)\n\t@test(candidate(\"Aaab_abbbc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\nfunction sum_range_list(list1::Vector{Int64}, m::Int64, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_range_list;\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\nfunction perimeter_pentagon(a::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = perimeter_pentagon;\n\t@test(candidate(5) == 25)\n\t@test(candidate(10) == 50)\n\t@test(candidate(15) == 75)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\nfunction count_occurance(s::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_occurance;\n\t@test(candidate(\"letstdlenstdporstd\") == 3)\n\t@test(candidate(\"truststdsolensporsd\") == 1)\n\t@test(candidate(\"makestdsostdworthit\") == 2)\n\t@test(candidate(\"stds\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\nfunction square_perimeter(a::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_perimeter;\n\t@test(candidate(10) == 40)\n\t@test(candidate(5) == 20)\n\t@test(candidate(4) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\nfunction remove_dirty_chars(string::String, second_string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_dirty_chars;\n\t@test(candidate(\"probasscurve\", \"pros\") == \"bacuve\")\n\t@test(candidate(\"digitalindia\", \"talent\") == \"digiidi\")\n\t@test(candidate(\"exoticmiles\", \"toxic\") == \"emles\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\nfunction test_duplicate(arraynums::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = test_duplicate;\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 4]) == true)\n\t@test(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\nfunction is_woodall(x::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_woodall;\n\t@test(candidate(383) == true)\n\t@test(candidate(254) == false)\n\t@test(candidate(200) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\nfunction check_type(test_tuple::Any)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_type;\n\t@test(candidate((5, 6, 7, 3, 5, 6)) == true)\n\t@test(candidate((1, 2, \"4\")) == false)\n\t@test(candidate((3, 2, 1, 4, 5)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\nfunction is_majority(arr::Vector{Int64}, n::Int64, x::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_majority;\n\t@test(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == true)\n\t@test(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == false)\n\t@test(candidate([1, 1, 1, 2, 2], 5, 1) == true)\n\t@test(candidate([1, 1, 2, 2], 5, 1) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\nfunction count_Set_Bits(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Set_Bits;\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 1)\n\t@test(candidate(6) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\nfunction odd_values_string(str::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_values_string;\n\t@test(candidate(\"abcdef\") == \"ace\")\n\t@test(candidate(\"python\") == \"pto\")\n\t@test(candidate(\"data\") == \"dt\")\n\t@test(candidate(\"lambs\") == \"lms\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\nfunction min_of_three(a::Int64, b::Int64, c::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_of_three;\n\t@test(candidate(10, 20, 0) == 0)\n\t@test(candidate(19, 15, 18) == 15)\n\t@test(candidate(-10, -20, -30) == -30)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\nfunction all_Bits_Set_In_The_Given_Range(n::Int64, l::Int64, r::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Bits_Set_In_The_Given_Range;\n\t@test(candidate(4, 1, 2) == true)\n\t@test(candidate(17, 2, 4) == true)\n\t@test(candidate(39, 4, 6) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\nfunction re_arrange_array(arr::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = re_arrange_array;\n\t@test(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\n\t@test(candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15])\n\t@test(candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\nfunction replace_blank(str1::String, char::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_blank;\n\t@test(candidate(\"hello people\", \"@\") == \"hello@people\")\n\t@test(candidate(\"python program language\", \"\\$\") == \"python\\$program\\$language\")\n\t@test(candidate(\"blank space\", \"-\") == \"blank-space\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\nfunction volume_cube(l::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = volume_cube;\n\t@test(candidate(3) == 27)\n\t@test(candidate(2) == 8)\n\t@test(candidate(5) == 125)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\nfunction number_of_substrings(str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = number_of_substrings;\n\t@test(candidate(\"abc\") == 6)\n\t@test(candidate(\"abcd\") == 10)\n\t@test(candidate(\"abcde\") == 15)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\nfunction get_total_number_of_sequences(m::Int64, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_total_number_of_sequences;\n\t@test(candidate(10, 4) == 4)\n\t@test(candidate(5, 2) == 6)\n\t@test(candidate(16, 3) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\nfunction replace_list(list1::Vector{Any}, list2::Vector{Any})::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_list;\n\t@test(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\nfunction count_charac(str1::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_charac;\n\t@test(candidate(\"python programming\") == 18)\n\t@test(candidate(\"language\") == 8)\n\t@test(candidate(\"words\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\nfunction next_Perfect_Square(N::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_Perfect_Square;\n\t@test(candidate(35) == 36)\n\t@test(candidate(6) == 9)\n\t@test(candidate(9) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\nfunction max_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum;\n\t@test(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\n\t@test(candidate([80, 60, 30, 40, 20, 10]) == 210)\n\t@test(candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\nfunction lps(str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lps;\n\t@test(candidate(\"TENS FOR TENS\") == 5)\n\t@test(candidate(\"CARDIO FOR CARDS\") == 7)\n\t@test(candidate(\"PART OF THE JOURNEY IS PART\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\nfunction intersection_array(array_nums1::Vector{Int64}, array_nums2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection_array;\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\nfunction count_X(tup::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_X;\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\nfunction insert_element(list::Vector{String}, element::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = insert_element;\n\t@test(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\n\t@test(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"])\n\t@test(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\nfunction convert(numbers::Int64)::Tuple{Float64, Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = convert;\n\t@test(candidate(1) == (1.0, 0.0))\n\t@test(candidate(4) == (4.0, 0.0))\n\t@test(candidate(5) == (5.0, 0.0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\nfunction count_integer(list1::Vector{Union{Int64, String, Float64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_integer;\n\t@test(candidate([1, 2, \"abc\", 1.2]) == 2)\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([1, 1.2, 4, 5.1]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\nfunction combinations_colors(l::Vector{String}, n::Int64)::Vector{Vector{String}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = combinations_colors;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\nfunction count_Primes_nums(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Primes_nums;\n\t@test(candidate(5) == 2)\n\t@test(candidate(10) == 4)\n\t@test(candidate(100) == 25)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\nfunction swap_numbers(a::Int64, b::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_numbers;\n\t@test(candidate(10, 20) == [20, 10])\n\t@test(candidate(15, 17) == [17, 15])\n\t@test(candidate(100, 200) == [200, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5324,7 +1040,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to maximize the given two lists.\n\t\"\"\"\nfunction maximize_elements(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = maximize_elements;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]])\nend\n",
     "stop_tokens": [
@@ -5334,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\nfunction even_position(nums::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\nfunction newman_prime(n::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_position;\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 3]) == false)\n\t@test(candidate([2, 1, 4]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = newman_prime;\n\t@test(candidate(3) == 7)\n\t@test(candidate(4) == 17)\n\t@test(candidate(5) == 41)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5348,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\nfunction check_char(string::String)::String \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\nfunction division_elements(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_char;\n\t@test(candidate(\"abba\") == \"Valid\")\n\t@test(candidate(\"a\") == \"Valid\")\n\t@test(candidate(\"abcd\") == \"Invalid\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = division_elements;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3))\n\t@test(candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4))\n\t@test(candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5362,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\nfunction sumofFactors(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\nfunction split_two_parts(list1::Vector{Any}, L::Int64)::Any \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sumofFactors;\n\t@test(candidate(18) == 26)\n\t@test(candidate(30) == 48)\n\t@test(candidate(6) == 8)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_two_parts;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5376,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\nfunction lateralsurface_cone(r::Int64, h::Int64)::Float64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\nfunction dog_age(h_age::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cone;\n\t@test(candidate(5, 12) == 204.20352248333654)\n\t@test(candidate(10, 15) == 566.3586699569488)\n\t@test(candidate(19, 17) == 1521.8090132193388)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dog_age;\n\t@test(candidate(12) == 61)\n\t@test(candidate(15) == 73)\n\t@test(candidate(24) == 109)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5390,13 +1106,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\nfunction count_Pairs(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\nfunction list_split(S::Vector{Any}, step::Int64)::Vector{Vector{Any}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Pairs;\n\t@test(candidate([1, 2, 1], 3) == 2)\n\t@test(candidate([1, 1, 1, 1], 4) == 0)\n\t@test(candidate([1, 2, 3, 4, 5], 5) == 10)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = list_split;\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\n\t@test(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5404,13 +1120,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\nfunction find_first_occurrence(A::Vector{Int64}, x::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\nfunction lateralsurface_cube(l::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_first_occurrence;\n\t@test(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1)\n\t@test(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2)\n\t@test(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cube;\n\t@test(candidate(5) == 100)\n\t@test(candidate(9) == 324)\n\t@test(candidate(10) == 400)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5422,9 +1138,835 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 10)\n\t@test(candidate(3) == 35)\n\t@test(candidate(4) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\nfunction find_star_num(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_star_num;\n\t@test(candidate(3) == 37)\n\t@test(candidate(4) == 73)\n\t@test(candidate(5) == 121)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\nfunction ascii_value(k::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = ascii_value;\n\t@test(candidate(\"A\") == 65)\n\t@test(candidate(\"R\") == 82)\n\t@test(candidate(\"S\") == 83)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\nfunction sum_even_and_even_index(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_even_and_even_index;\n\t@test(candidate([5, 6, 12, 1, 18, 8]) == 30)\n\t@test(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\n\t@test(candidate([5, 6, 12, 1]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\nfunction even_Power_Sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_Power_Sum;\n\t@test(candidate(2) == 1056)\n\t@test(candidate(3) == 8832)\n\t@test(candidate(1) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\nfunction rear_extract(test_list::Vector{Tuple{Int64, String, Int64}})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rear_extract;\n\t@test(candidate([(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\n\t@test(candidate([(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\n\t@test(candidate([(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\nfunction substract_elements(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Tuple{Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = substract_elements;\n\t@test(candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13))\n\t@test(candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13))\n\t@test(candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\nfunction even_binomial_Coeff_Sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_binomial_Coeff_Sum;\n\t@test(candidate(4) == 8)\n\t@test(candidate(6) == 32)\n\t@test(candidate(2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\nfunction dict_filter(dict::Dict{String, Int64}>, n::Int64)::Dict{String, Int64}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dict_filter;\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) == Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) == Dict(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) == Dict(\"Pierre Cox\" => 190))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\nfunction count_first_elements(test_tup::Vector{Union{Int64, Tuple{Int64, Int64}}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_first_elements;\n\t@test(candidate([1, 5, 7, (4, 6), 10]) == 3)\n\t@test(candidate([2, 9, (5, 7), 11]) == 2)\n\t@test(candidate([11, 15, 5, 8, (2, 3), 8]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\nfunction is_num_decagonal(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_num_decagonal;\n\t@test(candidate(3) == 27)\n\t@test(candidate(7) == 175)\n\t@test(candidate(10) == 370)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\nfunction sequential_search(dlist::Vector{Int64}, item::Int64)::Tuple{Bool, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sequential_search;\n\t@test(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (true, 3))\n\t@test(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (true, 7))\n\t@test(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (true, 6))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\nfunction all_unique(test_list::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_unique;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\nfunction sub_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sub_list;\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3])\n\t@test(candidate([1, 2], [3, 4]) == [-2, -2])\n\t@test(candidate([90, 120], [50, 70]) == [40, 50])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\nfunction validate(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = validate;\n\t@test(candidate(1234) == true)\n\t@test(candidate(51241) == false)\n\t@test(candidate(321) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\nfunction check_element(list::Vector{Any}, element::Any)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_element;\n\t@test(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\") == false)\n\t@test(candidate([1, 2, 3, 4], 7) == false)\n\t@test(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\nfunction text_match_two_three(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_two_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\nfunction max_sub_array_sum_repeated(a::Vector{Int64}, n::Int64, k::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum_repeated;\n\t@test(candidate([10, 20, -30, -1], 4, 3) == 30)\n\t@test(candidate([-1, 10, 20], 3, 2) == 59)\n\t@test(candidate([-1, -2, -3], 3, 3) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 20)\n\t@test(candidate(3) == 56)\n\t@test(candidate(4) == 120)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\nfunction max_length(list1::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\n\t@test(candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\nfunction count_no_of_ways(n::Int64, k::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_no_of_ways;\n\t@test(candidate(2, 4) == 16)\n\t@test(candidate(3, 2) == 6)\n\t@test(candidate(4, 4) == 228)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\nfunction find(n::Int64, m::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find;\n\t@test(candidate(10, 3) == 3)\n\t@test(candidate(4, 2) == 2)\n\t@test(candidate(20, 5) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\nfunction otherside_rightangle(w::Int64, h::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = otherside_rightangle;\n\t@test(candidate(7, 8) == 10.63014581273465)\n\t@test(candidate(3, 4) == 5)\n\t@test(candidate(7, 15) == 16.55294535724685)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\nfunction max_val(listval::Vector{Union{String, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 5)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 25)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 50)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\nfunction sum_div(number::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_div;\n\t@test(candidate(8) == 7)\n\t@test(candidate(12) == 16)\n\t@test(candidate(7) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\nfunction get_Inv_Count(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Inv_Count;\n\t@test(candidate([1, 20, 6, 4, 5]) == 5)\n\t@test(candidate([1, 2, 1]) == 1)\n\t@test(candidate([1, 2, 5, 6, 1]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\nfunction flatten_list(list1::Vector{Union{Int64, Vector{Int64}}})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flatten_list;\n\t@test(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\n\t@test(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\nfunction max_aggregate(stdata::Vector{Tuple{String, Int64}})::Tuple{String, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_aggregate;\n\t@test(candidate([(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\n\t@test(candidate([(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\n\t@test(candidate([(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\nfunction find_Element(arr::Vector{Int64}, ranges::Vector{Vector{Int64}}, rotations::Int64, index::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Element;\n\t@test(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3)\n\t@test(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\nfunction start_withp(words::Vector{String})::Tuple{String, String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = start_withp;\n\t@test(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\n\t@test(candidate([\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\n\t@test(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\nfunction max_sum_increasing_subseq(a::Vector{Int64}, n::Int64, index::Int64, k::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_increasing_subseq;\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11)\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7)\n\t@test(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\nfunction large_product(nums1::Vector{Int64}, nums2::Vector{Int64}, N::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = large_product;\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\nfunction maximum(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate(5, 10) == 10)\n\t@test(candidate(-1, -2) == -1)\n\t@test(candidate(9, 7) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\nfunction string_to_tuple(str1::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_tuple;\n\t@test(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\n\t@test(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\n\t@test(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\nfunction highest_Power_of_2(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = highest_Power_of_2;\n\t@test(candidate(10) == 8)\n\t@test(candidate(19) == 16)\n\t@test(candidate(32) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\nfunction find_lucas(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lucas;\n\t@test(candidate(9) == 76)\n\t@test(candidate(4) == 7)\n\t@test(candidate(3) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\nfunction add_string(list_::Vector{Any}, string::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_string;\n\t@test(candidate([1, 2, 3, 4], \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\n\t@test(candidate([5, 6, 7, 8], \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\nfunction get_max_sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_sum;\n\t@test(candidate(60) == 106)\n\t@test(candidate(10) == 12)\n\t@test(candidate(2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\nfunction max_length_list(input_list::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length_list;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\n\t@test(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\nfunction check_distinct(test_tup::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_distinct;\n\t@test(candidate([1, 4, 5, 6, 1, 4]) == false)\n\t@test(candidate([1, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 6]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\nfunction first_non_repeating_character(str1::String)::Union{String, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_non_repeating_character;\n\t@test(candidate(\"abcabc\") == nothing)\n\t@test(candidate(\"abc\") == \"a\")\n\t@test(candidate(\"ababc\") == \"c\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\nfunction check_char(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_char;\n\t@test(candidate(\"abba\") == \"Valid\")\n\t@test(candidate(\"a\") == \"Valid\")\n\t@test(candidate(\"abcd\") == \"Invalid\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\nfunction median_numbers(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median_numbers;\n\t@test(candidate(25, 55, 65) == 55.0)\n\t@test(candidate(20, 10, 30) == 20.0)\n\t@test(candidate(15, 45, 75) == 45.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\nfunction sum_of_digits(nums::Vector{Any})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_of_digits;\n\t@test(candidate([10, 2, 56]) == 14)\n\t@test(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\n\t@test(candidate([10, 20, -4, 5, -70]) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\nfunction bitwise_xor(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bitwise_xor;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10))\n\t@test(candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14))\n\t@test(candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\nfunction is_not_prime(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_not_prime;\n\t@test(candidate(2) == false)\n\t@test(candidate(10) == true)\n\t@test(candidate(35) == true)\n\t@test(candidate(37) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\nfunction extract_freq(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_freq;\n\t@test(candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\n\t@test(candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\n\t@test(candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\nfunction add_nested_tuples(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_nested_tuples;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\nfunction minimum(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minimum;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(-5, -4) == -5)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\nfunction check_tuplex(tuplex::Vector{Union{String, Int64}}, tuple1::Any)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_tuplex;\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\") == true)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\") == false)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\nfunction find_Parity(x::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Parity;\n\t@test(candidate(12) == false)\n\t@test(candidate(7) == true)\n\t@test(candidate(10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\nfunction rearrange_bigger(n::Int64)::Any \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rearrange_bigger;\n\t@test(candidate(12) == 21)\n\t@test(candidate(10) == false)\n\t@test(candidate(102) == 120)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\nfunction k_smallest_pairs(nums1::Vector{Int64}, nums2::Vector{Int64}, k::Int64)::Vector{Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = k_smallest_pairs;\n\t@test(candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\nfunction min_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 30)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\nfunction min_val(listval::Vector{Union{String, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 2)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 15)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 20)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"android_tv\") == \"AndroidTv\")\n\t@test(candidate(\"google_pixel\") == \"GooglePixel\")\n\t@test(candidate(\"apple_watch\") == \"AppleWatch\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\nfunction remove_odd(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate([1, 2, 3]) == [2])\n\t@test(candidate([2, 4, 6]) == [2, 4, 6])\n\t@test(candidate([10, 20, 3]) == [10, 20])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\nfunction extract_nth_element(list1::Vector{Tuple{String, Int64, Int64}}, n::Int64)::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_nth_element;\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 2) == [99, 96, 94, 98])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 1) == [98, 97, 91, 94])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\nfunction overlapping(list1::Vector{Int64}, list2::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = overlapping;\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == false)\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == false)\n\t@test(candidate([1, 4, 5], [1, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\nfunction max_Product(arr::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Product;\n\t@test(candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\n\t@test(candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\n\t@test(candidate([1, 2, 3]) == (2, 3))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5436,7 +1978,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find common first element in given list of lists.\n\t\"\"\"\nfunction group_tuples(Input::Vector{Vector{String}})::Vector{Vector{String}} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "using Test\n\n@testset begin\n\ncandidate = group_tuples;\n\t@test(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])\n\t@test(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])\nend\n",
     "stop_tokens": [
@@ -5446,13 +1988,3471 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\nfunction merge_sorted_list(num1::Vector{Int64}, num2::Vector{Int64}, num3::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\nfunction Find_Max(lst::Vector{Vector{Any}})::Vector{Any} \n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_sorted_list;\n\t@test(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\n\t@test(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\n\t@test(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max;\n\t@test(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\n\t@test(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\nfunction round_and_sum(list1::Vector{Union{Float64, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = round_and_sum;\n\t@test(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243)\n\t@test(candidate([5, 2, 9, 24.3, 29]) == 345)\n\t@test(candidate([25.0, 56.7, 89.2]) == 513)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\nfunction cube_Sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_Sum;\n\t@test(candidate(2) == 72)\n\t@test(candidate(3) == 288)\n\t@test(candidate(4) == 800)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\nfunction concatenate_tuple(test_tup::Tuple{String, String, Int64, String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate_tuple;\n\t@test(candidate((\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\n\t@test(candidate((\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\n\t@test(candidate((\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\nfunction find_Average_Of_Cube(n::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Average_Of_Cube;\n\t@test(candidate(2) == 4.5)\n\t@test(candidate(3) == 12)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\nfunction extract_rear(test_tuple::Tuple{String, String, String})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_rear;\n\t@test(candidate((\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\n\t@test(candidate((\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\n\t@test(candidate((\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\nfunction count_element_in_list(list1::Vector{Vector{Any}}, x::Any)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_element_in_list;\n\t@test(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\") == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\") == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\nfunction filter_oddnumbers(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_oddnumbers;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\n\t@test(candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93])\n\t@test(candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\nfunction change_date_format(dt::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_date_format;\n\t@test(candidate(\"2026-01-02\") == \"02-01-2026\")\n\t@test(candidate(\"2020-11-13\") == \"13-11-2020\")\n\t@test(candidate(\"2021-04-26\") == \"26-04-2021\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\nfunction shell_sort(my_list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = shell_sort;\n\t@test(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\n\t@test(candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\n\t@test(candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\nfunction and_tuples(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = and_tuples;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1))\n\t@test(candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0))\n\t@test(candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\nfunction parabola_directrix(a::Int64, b::Int64, c::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parabola_directrix;\n\t@test(candidate(5, 3, 2) == -198)\n\t@test(candidate(9, 8, 4) == -2336)\n\t@test(candidate(2, 4, 6) == -130)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\nfunction common_element(list1::Vector{Any}, list2::Vector{Any})::Union{Bool, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common_element;\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == true)\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == nothing)\n\t@test(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\nfunction median_trapezium(base1::Int64, base2::Int64, height::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median_trapezium;\n\t@test(candidate(15, 25, 35) == 20)\n\t@test(candidate(10, 20, 30) == 15)\n\t@test(candidate(6, 9, 4) == 7.5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\nfunction check_greater(arr::Vector{Int64}, number::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_greater;\n\t@test(candidate([1, 2, 3, 4, 5], 4) == false)\n\t@test(candidate([2, 3, 4, 5, 6], 8) == true)\n\t@test(candidate([9, 7, 4, 8, 6, 1], 11) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\nfunction text_match_one(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\nfunction last_Digit(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit;\n\t@test(candidate(123) == 3)\n\t@test(candidate(25) == 5)\n\t@test(candidate(30) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\nfunction neg_nos(list1::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = neg_nos;\n\t@test(candidate([-1, 4, 5, -6]) == [-1, -6])\n\t@test(candidate([-1, -2, 3, 4]) == [-1, -2])\n\t@test(candidate([-7, -6, 8, 9]) == [-7, -6])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\nfunction remove_odd(str1::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate(\"python\") == \"yhn\")\n\t@test(candidate(\"program\") == \"rga\")\n\t@test(candidate(\"language\") == \"agae\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\nfunction count_bidirectional(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_bidirectional;\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\n\t@test(candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\nfunction multiple_to_single(L::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiple_to_single;\n\t@test(candidate([11, 33, 50]) == 113350)\n\t@test(candidate([-1, 2, 3, 4, 5, 6]) == -123456)\n\t@test(candidate([10, 15, 20, 25]) == 10152025)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\nfunction find_adverb_position(text::String)::Tuple{Int64, Int64, String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverb_position;\n\t@test(candidate(\"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\n\t@test(candidate(\"seriously!! there are many roses\") == (0, 9, \"seriously\"))\n\t@test(candidate(\"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\nfunction surfacearea_cube(l::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cube;\n\t@test(candidate(5) == 150)\n\t@test(candidate(3) == 54)\n\t@test(candidate(10) == 600)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\nfunction positive_count(nums::Vector{Int64})::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = positive_count;\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\n\t@test(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\nfunction largest_neg(list1::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_neg;\n\t@test(candidate([1, 2, 3, -4, -6]) == -6)\n\t@test(candidate([1, 2, 3, -8, -9]) == -9)\n\t@test(candidate([1, 2, 3, 4, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\nfunction trim_tuple(test_list::Vector{Vector{Int64}}, K::Int64)::Vector{Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = trim_tuple;\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]])\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\n\t@test(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\nfunction index_multiplication(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = index_multiplication;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\nfunction count_Occurrence(tup::Any, lst::Vector{Any})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Occurrence;\n\t@test(candidate((\"a\", \"a\", \"c\", \"b\", \"d\"), [\"a\", \"b\"]) == 3)\n\t@test(candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6)\n\t@test(candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\nfunction cube_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\n\t@test(candidate([10, 20, 30]) == [1000, 8000, 27000])\n\t@test(candidate([12, 15]) == [1728, 3375])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\nfunction cal_sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cal_sum;\n\t@test(candidate(9) == 49)\n\t@test(candidate(10) == 66)\n\t@test(candidate(11) == 88)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\nfunction extract_string(str::Vector{String}, l::Int64)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_string;\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8) == [\"practice\", \"solution\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6) == [\"Python\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9) == [\"exercises\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\nfunction remove_whitespaces(text1::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_whitespaces;\n\t@test(candidate(\" Google    Flutter \") == \"GoogleFlutter\")\n\t@test(candidate(\" Google    Dart \") == \"GoogleDart\")\n\t@test(candidate(\" iOS    Swift \") == \"iOSSwift\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\nfunction loss_amount(actual_cost::Int64, sale_amount::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = loss_amount;\n\t@test(candidate(1500, 1200) == 0)\n\t@test(candidate(100, 200) == 100)\n\t@test(candidate(2000, 5000) == 3000)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\nfunction sumofFactors(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sumofFactors;\n\t@test(candidate(18) == 26)\n\t@test(candidate(30) == 48)\n\t@test(candidate(6) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\nfunction text_match_wordz(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz;\n\t@test(candidate(\"pythonz.\") == true)\n\t@test(candidate(\"xyz.\") == true)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\nfunction check_monthnumb_number(monthnum2::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumb_number;\n\t@test(candidate(5) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(6) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\nfunction reverse_string_list(stringlist::Vector{String})::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_string_list;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\n\t@test(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\n\t@test(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\nfunction Find_Min(lst::Vector{Vector{Any}})::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min;\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1])\n\t@test(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\n\t@test(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\nfunction rectangle_area(l::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rectangle_area;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(10, 5) == 50)\n\t@test(candidate(4, 2) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\nfunction remove_uppercase(str1::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_uppercase;\n\t@test(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\n\t@test(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\n\t@test(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\nfunction Extract(lst::Vector{Vector{Int64}})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Extract;\n\t@test(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\n\t@test(candidate([[1, 2, 3], [4, 5]]) == [1, 4])\n\t@test(candidate([[9, 8, 1], [1, 2]]) == [9, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\nfunction upper_ctr(str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = upper_ctr;\n\t@test(candidate(\"PYthon\") == 1)\n\t@test(candidate(\"BigData\") == 1)\n\t@test(candidate(\"program\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\nfunction max_subarray_product(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_subarray_product;\n\t@test(candidate([1, -2, -3, 0, 7, -8, -2]) == 112)\n\t@test(candidate([6, -3, -10, 0, 2]) == 180)\n\t@test(candidate([-2, -40, 0, -2, -3]) == 80)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\nfunction check_value(dict::Dict{String, Int64}>, n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_value;\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) == false)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) == true)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\nfunction max_product(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product;\n\t@test(candidate([3, 100, 4, 5, 150, 6]) == 3000)\n\t@test(candidate([4, 42, 55, 68, 80]) == 50265600)\n\t@test(candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\nfunction add_pairwise(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_pairwise;\n\t@test(candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18))\n\t@test(candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20))\n\t@test(candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\nfunction find_remainder(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_remainder;\n\t@test(candidate([100, 10, 5, 25, 35, 14], 11) == 9)\n\t@test(candidate([1, 1, 1], 1) == 0)\n\t@test(candidate([1, 2, 1], 2) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\nfunction check_Consecutive(l::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_Consecutive;\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 2, 3, 5, 6]) == false)\n\t@test(candidate([1, 2, 1]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\nfunction replace_char(str1::String, ch::String, newch::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_char;\n\t@test(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\")\n\t@test(candidate(\"character\", \"c\", \"a\") == \"aharaater\")\n\t@test(candidate(\"python\", \"l\", \"a\") == \"python\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\nfunction sort_counter(dict1::Dict{String, Int64}>)::Vector{Tuple{String, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_counter;\n\t@test(candidate(Dict(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\n\t@test(candidate(Dict(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\n\t@test(candidate(Dict(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\nfunction big_sum(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = big_sum;\n\t@test(candidate([1, 2, 3]) == 4)\n\t@test(candidate([-1, 2, 3, 4]) == 3)\n\t@test(candidate([2, 3, 6]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\nfunction is_lower(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_lower;\n\t@test(candidate(\"InValid\") == \"invalid\")\n\t@test(candidate(\"TruE\") == \"true\")\n\t@test(candidate(\"SenTenCE\") == \"sentence\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\nfunction remove_lowercase(str1::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_lowercase;\n\t@test(candidate(\"PYTHon\") == \"PYTH\")\n\t@test(candidate(\"FInD\") == \"FID\")\n\t@test(candidate(\"STRinG\") == \"STRG\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\nfunction first_Digit(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_Digit;\n\t@test(candidate(123) == 1)\n\t@test(candidate(456) == 4)\n\t@test(candidate(12) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\nfunction heap_queue_largest(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_queue_largest;\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5])\n\t@test(candidate([10, 11, 12, 13]) == [11, 13])\n\t@test(candidate([7, 8, 9, 1]) == [7, 9, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\nfunction difference(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = difference;\n\t@test(candidate(3) == 30)\n\t@test(candidate(5) == 210)\n\t@test(candidate(2) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\nfunction find_Odd_Pair(A::Vector{Int64}, N::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Odd_Pair;\n\t@test(candidate([5, 4, 7, 2, 1], 5) == 6)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12)\n\t@test(candidate([1, 2, 3], 3) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\nfunction toggle_string(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_string;\n\t@test(candidate(\"Python\") == \"pYTHON\")\n\t@test(candidate(\"Pangram\") == \"pANGRAM\")\n\t@test(candidate(\"LIttLE\") == \"liTTle\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\nfunction digit_distance_nums(n1::Int64, n2::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digit_distance_nums;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(23, 56) == 6)\n\t@test(candidate(123, 256) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\nfunction max_sub_array_sum(a::Vector{Int64}, size::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum;\n\t@test(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7)\n\t@test(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8)\n\t@test(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\nfunction union_elements(test_tup1::Vector{Int64}, test_tup2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = union_elements;\n\t@test(candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\n\t@test(candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\n\t@test(candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\nfunction Find_Max_Length(lst::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max_Length;\n\t@test(candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4)\n\t@test(candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3)\n\t@test(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\nfunction extract_values(text::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_values;\n\t@test(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\n\t@test(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\n\t@test(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\nfunction count_Pairs(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Pairs;\n\t@test(candidate([1, 2, 1], 3) == 2)\n\t@test(candidate([1, 1, 1, 1], 4) == 0)\n\t@test(candidate([1, 2, 3, 4, 5], 5) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\nfunction split(word::String)::Vector{String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split;\n\t@test(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\n\t@test(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"])\n\t@test(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\nfunction sum_digits(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_digits;\n\t@test(candidate(345) == 12)\n\t@test(candidate(12) == 3)\n\t@test(candidate(97) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\nfunction issort_list(list1::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = issort_list;\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\nfunction sort_sublists(list1::Vector{Vector{String}})::Vector{Vector{String}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\nfunction checks(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = checks;\n\t@test(candidate(70) == false)\n\t@test(candidate(23) == false)\n\t@test(candidate(73) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\nfunction two_unique_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = two_unique_nums;\n\t@test(candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\n\t@test(candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\nfunction unique_product(list_data::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_product;\n\t@test(candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\n\t@test(candidate([1, 2, 3, 1]) == 6)\n\t@test(candidate([7, 8, 9, 0, 1, 1]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\nfunction surfacearea_cylinder(r::Int64, h::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cylinder;\n\t@test(candidate(10, 5) == 942.45)\n\t@test(candidate(4, 5) == 226.18800000000002)\n\t@test(candidate(4, 10) == 351.848)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\nfunction is_Sub_Array(A::Vector{Int64}, B::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sub_Array;\n\t@test(candidate([1, 4, 3, 5], [1, 2]) == false)\n\t@test(candidate([1, 2, 1], [1, 2, 1]) == true)\n\t@test(candidate([1, 0, 2, 2], [2, 2, 0]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\nfunction last_Digit_Factorial(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit_Factorial;\n\t@test(candidate(4) == 4)\n\t@test(candidate(21) == 0)\n\t@test(candidate(30) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\nfunction interleave_lists(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = interleave_lists;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\n\t@test(candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10])\n\t@test(candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\nfunction find_dissimilar(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_dissimilar;\n\t@test(candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10))\n\t@test(candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9))\n\t@test(candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\nfunction find_Max_Num(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Max_Num;\n\t@test(candidate([1, 2, 3]) == 321)\n\t@test(candidate([4, 5, 6, 1]) == 6541)\n\t@test(candidate([1, 2, 3, 9]) == 9321)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\nfunction extract_even(test_tuple::Tuple{Int64, Int64, Tuple{Int64, Int64, Tuple{Int64, Int64}}, Int64, Int64})::Any \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_even;\n\t@test(candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\n\t@test(candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\n\t@test(candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\nfunction surface_Area(b::Int64, s::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surface_Area;\n\t@test(candidate(3, 4) == 33)\n\t@test(candidate(4, 5) == 56)\n\t@test(candidate(1, 2) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\nfunction catalan_number(num::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = catalan_number;\n\t@test(candidate(10) == 16796)\n\t@test(candidate(9) == 4862)\n\t@test(candidate(7) == 429)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\nfunction find_adverbs(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverbs;\n\t@test(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\n\t@test(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\")\n\t@test(candidate(\"Complete the task quickly\") == \"18-25: quickly\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\nfunction split_Arr(l::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_Arr;\n\t@test(candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10])\n\t@test(candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1])\n\t@test(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\nfunction list_tuple(listx::Vector{Int64})::Any \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = list_tuple;\n\t@test(candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\n\t@test(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\n\t@test(candidate([58, 44, 56]) == (58, 44, 56))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\nfunction big_diff(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = big_diff;\n\t@test(candidate([1, 2, 3, 4]) == 3)\n\t@test(candidate([4, 5, 12]) == 8)\n\t@test(candidate([9, 2, 3]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\nfunction perfect_squares(a::Int64, b::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = perfect_squares;\n\t@test(candidate(1, 30) == [1, 4, 9, 16, 25])\n\t@test(candidate(50, 100) == [64, 81, 100])\n\t@test(candidate(100, 200) == [100, 121, 144, 169, 196])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\nfunction opposite_Signs(x::Int64, y::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = opposite_Signs;\n\t@test(candidate(1, -2) == true)\n\t@test(candidate(3, 2) == false)\n\t@test(candidate(-10, -10) == false)\n\t@test(candidate(-2, 2) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\nfunction sum_Of_product(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_product;\n\t@test(candidate(3) == 15)\n\t@test(candidate(4) == 56)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\nfunction removezero_ip(ip::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = removezero_ip;\n\t@test(candidate(\"216.08.094.196\") == \"216.8.94.196\")\n\t@test(candidate(\"12.01.024\") == \"12.1.24\")\n\t@test(candidate(\"216.08.094.0196\") == \"216.8.94.196\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\nfunction diff_even_odd(list1::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = diff_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\n\t@test(candidate([1, 5, 7, 9, 10]) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\nfunction min_Swaps(str1::String, str2::String)::Any \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Swaps;\n\t@test(candidate(\"1101\", \"1110\") == 1)\n\t@test(candidate(\"111\", \"000\") == \"Not Possible\")\n\t@test(candidate(\"111\", \"110\") == \"Not Possible\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\nfunction find_kth(arr1::Vector{Int64}, arr2::Vector{Int64}, k::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_kth;\n\t@test(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6)\n\t@test(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256)\n\t@test(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\nfunction armstrong_number(number::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = armstrong_number;\n\t@test(candidate(153) == true)\n\t@test(candidate(259) == false)\n\t@test(candidate(4458) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\nfunction sum_average(number::Int64)::Tuple{Int64, Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_average;\n\t@test(candidate(10) == (55, 5.5))\n\t@test(candidate(15) == (120, 8.0))\n\t@test(candidate(20) == (210, 10.5))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\nfunction is_octagonal(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_octagonal;\n\t@test(candidate(5) == 65)\n\t@test(candidate(10) == 280)\n\t@test(candidate(15) == 645)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\nfunction is_Even(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Even;\n\t@test(candidate(1) == false)\n\t@test(candidate(2) == true)\n\t@test(candidate(3) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\nfunction first_repeated_char(str1::String)::Union{String, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_repeated_char;\n\t@test(candidate(\"abcabc\") == \"a\")\n\t@test(candidate(\"abc\") == nothing)\n\t@test(candidate(\"123123\") == \"1\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\nfunction get_ludic(n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_ludic;\n\t@test(candidate(10) == [1, 2, 3, 5, 7])\n\t@test(candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\n\t@test(candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\nfunction reverse_words(s::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_words;\n\t@test(candidate(\"python program\") == \"program python\")\n\t@test(candidate(\"java language\") == \"language java\")\n\t@test(candidate(\"indian man\") == \"man indian\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\nfunction prime_num(num::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_num;\n\t@test(candidate(13) == true)\n\t@test(candidate(7) == true)\n\t@test(candidate(-1010) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\nfunction radian_degree(degree::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = radian_degree;\n\t@test(candidate(90) == 1.5707963267948966)\n\t@test(candidate(60) == 1.0471975511965976)\n\t@test(candidate(120) == 2.0943951023931953)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\nfunction find_literals(text::String, pattern::String)::Tuple{String, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_literals;\n\t@test(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == (\"fox\", 16, 19))\n\t@test(candidate(\"Its been a very crazy procedure right\", \"crazy\") == (\"crazy\", 16, 21))\n\t@test(candidate(\"Hardest choices required strongest will\", \"will\") == (\"will\", 35, 39))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\nfunction bell_Number(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_Number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 15)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\nfunction remove_kth_element(list1::Vector{Int64}, L::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_kth_element;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1])\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\nfunction max_of_nth(test_list::Vector{Vector{Int64}}, N::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_of_nth;\n\t@test(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19)\n\t@test(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10)\n\t@test(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\nfunction merge(lst::Vector{Vector{Any}})::Vector{Vector{Any}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge;\n\t@test(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\n\t@test(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\n\t@test(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\nfunction cummulative_sum(test_list::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cummulative_sum;\n\t@test(candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30)\n\t@test(candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37)\n\t@test(candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\nfunction average_tuple(nums::Vector{Vector{Int64}})::Vector{Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = average_tuple;\n\t@test(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\n\t@test(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\n\t@test(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\nfunction tuple_modulo(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_modulo;\n\t@test(candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1))\n\t@test(candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1))\n\t@test(candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\nfunction min_Jumps(steps::Tuple{Int64, Int64}, d::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Jumps;\n\t@test(candidate((3, 4), 11) == 3.5)\n\t@test(candidate((3, 4), 0) == 0)\n\t@test(candidate((11, 14), 11) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\nfunction div_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = div_list;\n\t@test(candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0])\n\t@test(candidate([3, 2], [1, 4]) == [3.0, 0.5])\n\t@test(candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\nfunction move_num(test_str::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_num;\n\t@test(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\n\t@test(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\")\n\t@test(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\nfunction count_Substrings(s::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Substrings;\n\t@test(candidate(\"112112\") == 6)\n\t@test(candidate(\"111\") == 6)\n\t@test(candidate(\"1101112\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\nfunction get_median(arr1::Vector{Int64}, arr2::Vector{Int64}, n::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_median;\n\t@test(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0)\n\t@test(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5)\n\t@test(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\nfunction nth_nums(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = nth_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30], 3) == [1000, 8000, 27000])\n\t@test(candidate([12, 15], 5) == [248832, 759375])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\nfunction is_upper(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_upper;\n\t@test(candidate(\"person\") == \"PERSON\")\n\t@test(candidate(\"final\") == \"FINAL\")\n\t@test(candidate(\"Valid\") == \"VALID\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\nfunction triangle_area(r::Int64)::Union{Int64, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(-1) == nothing)\n\t@test(candidate(0) == 0)\n\t@test(candidate(2) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\nfunction find_First_Missing(array::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_First_Missing;\n\t@test(candidate([0, 1, 2, 3]) == 4)\n\t@test(candidate([0, 1, 2, 6, 9]) == 3)\n\t@test(candidate([2, 3, 5, 8, 9]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\nfunction replace_spaces(string::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\n\t@test(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\")\n\t@test(candidate(\"I love Coding\") == \"I%20love%20Coding\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5]) == [2, 4])\n\t@test(candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\n\t@test(candidate([8, 12, 15, 19]) == [8, 12])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\nfunction smallest_num(xs::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_num;\n\t@test(candidate([10, 20, 1, 45, 99]) == 1)\n\t@test(candidate([1, 2, 3]) == 1)\n\t@test(candidate([45, 46, 50, 60]) == 45)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\nfunction get_coordinates(test_tup::Tuple{Int64, Int64})::Vector{Vector{Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_coordinates;\n\t@test(candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\n\t@test(candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\n\t@test(candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\nfunction replace_spaces(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\n\t@test(candidate(\"The_Avengers\") == \"The Avengers\")\n\t@test(candidate(\"Fast and Furious\") == \"Fast_and_Furious\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\nfunction move_zero(num_list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_zero;\n\t@test(candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\n\t@test(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\n\t@test(candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\nfunction pair_xor_Sum(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_xor_Sum;\n\t@test(candidate([5, 9, 7, 6], 4) == 47)\n\t@test(candidate([7, 3, 5], 3) == 12)\n\t@test(candidate([7, 3], 2) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\nfunction heap_sort(iterable::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_sort;\n\t@test(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\n\t@test(candidate([7, 1, 9, 5]) == [1, 5, 7, 9])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\nfunction noprofit_noloss(actual_cost::Int64, sale_amount::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = noprofit_noloss;\n\t@test(candidate(1500, 1200) == false)\n\t@test(candidate(100, 100) == true)\n\t@test(candidate(2000, 5000) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\nfunction wind_chill(v::Int64, t::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = wind_chill;\n\t@test(candidate(120, 35) == 40)\n\t@test(candidate(40, 20) == 19)\n\t@test(candidate(10, 8) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\nfunction sample_nam(sample_names::Vector{String})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sample_nam;\n\t@test(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\n\t@test(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\n\t@test(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\nfunction max_difference(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_difference;\n\t@test(candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\n\t@test(candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\n\t@test(candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\nfunction remove_parenthesis(items::Vector{String})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_parenthesis;\n\t@test(candidate([\"python (chrome)\"]) == \"python\")\n\t@test(candidate([\"string(.abc)\"]) == \"string\")\n\t@test(candidate([\"alpha(num)\"]) == \"alpha\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\nfunction is_nonagonal(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nonagonal;\n\t@test(candidate(10) == 325)\n\t@test(candidate(15) == 750)\n\t@test(candidate(18) == 1089)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\nfunction text_match_wordz_middle(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz_middle;\n\t@test(candidate(\"pythonzabc.\") == true)\n\t@test(candidate(\"zxyabc.\") == false)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\nfunction reverse_Array_Upto_K(input::Vector{Int64}, k::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_Array_Upto_K;\n\t@test(candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6])\n\t@test(candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7])\n\t@test(candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\nfunction subject_marks(subjectmarks::Vector{Tuple{String, Int64}})::Vector{Tuple{String, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = subject_marks;\n\t@test(candidate([(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\n\t@test(candidate([(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\n\t@test(candidate([(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\nfunction recursive_list_sum(data_list::Vector{Union{Int64, Vector{Int64}}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = recursive_list_sum;\n\t@test(candidate([1, 2, [3, 4], [5, 6]]) == 21)\n\t@test(candidate([7, 10, [15, 14], [19, 41]]) == 106)\n\t@test(candidate([10, 20, [30, 40], [50, 60]]) == 210)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\nfunction pos_count(list::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pos_count;\n\t@test(candidate([1, -2, 3, -4]) == 2)\n\t@test(candidate([3, 4, 5, -1]) == 3)\n\t@test(candidate([1, 2, 3, 4]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\nfunction bell_number(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(10) == 115975)\n\t@test(candidate(56) == 6775685320645824322581483068371419745979053216268760300)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\nfunction is_Monotonic(A::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Monotonic;\n\t@test(candidate([6, 5, 4, 4]) == true)\n\t@test(candidate([1, 2, 2, 3]) == true)\n\t@test(candidate([1, 3, 2]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\nfunction is_sublist(l::Vector{Int64}, s::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sublist;\n\t@test(candidate([2, 4, 3, 5, 7], [3, 7]) == false)\n\t@test(candidate([2, 4, 3, 5, 7], [4, 3]) == true)\n\t@test(candidate([2, 4, 3, 5, 7], [1, 6]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\nfunction differ_At_One_Bit_Pos(a::Int64, b::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = differ_At_One_Bit_Pos;\n\t@test(candidate(13, 9) == true)\n\t@test(candidate(15, 8) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(2, 3) == true)\n\t@test(candidate(5, 1) == true)\n\t@test(candidate(1, 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\nfunction get_equal(Input::Vector{Vector{Int64}})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_equal;\n\t@test(candidate([[11, 22, 33], [44, 55, 66]]) == true)\n\t@test(candidate([[1, 2, 3], [4, 5, 6, 7]]) == false)\n\t@test(candidate([[1, 2], [3, 4]]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\nfunction comb_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = comb_sort;\n\t@test(candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\n\t@test(candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\n\t@test(candidate([99, 15, 13, 47]) == [13, 15, 47, 99])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\nfunction add_dict_to_tuple(test_tup::Tuple{Int64, Int64, Int64}, test_dict::Dict{String, Int64}>)::Tuple{Int64, Int64, Int64, Dict{String, Int64}>} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_dict_to_tuple;\n\t@test(candidate((4, 5, 6), Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) == (4, 5, 6, Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)))\n\t@test(candidate((1, 2, 3), Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) == (1, 2, 3, Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)))\n\t@test(candidate((8, 9, 10), Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) == (8, 9, 10, Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\nfunction maxAverageOfPath(cost::Vector{Vector{Int64}})::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maxAverageOfPath;\n\t@test(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\n\t@test(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\n\t@test(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\nfunction count_same_pair(nums1::Vector{Int64}, nums2::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_same_pair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\n\t@test(candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\nfunction power_base_sum(base::Int64, power::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = power_base_sum;\n\t@test(candidate(2, 100) == 115)\n\t@test(candidate(8, 10) == 37)\n\t@test(candidate(8, 15) == 62)\n\t@test(candidate(3, 3) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\nfunction extract_quotation(text1::String)::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_quotation;\n\t@test(candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\n\t@test(candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\n\t@test(candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\n\t@test(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\nfunction multiply_elements(test_tup::Vector{Int64})::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_elements;\n\t@test(candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80])\n\t@test(candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42])\n\t@test(candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135])\n\t@test(candidate([12]) == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\nfunction sum_list(lst1::Vector{Int64}, lst2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_list;\n\t@test(candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65])\n\t@test(candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10])\n\t@test(candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\nfunction dif_Square(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dif_Square;\n\t@test(candidate(5) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(15) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\nfunction consecutive_duplicates(nums::Vector{Any})::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\nfunction lateralsurface_cone(r::Int64, h::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cone;\n\t@test(candidate(5, 12) == 204.20352248333654)\n\t@test(candidate(10, 15) == 566.3586699569488)\n\t@test(candidate(19, 17) == 1521.8090132193388)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\nfunction replace_specialchar(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_specialchar;\n\t@test(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\")\n\t@test(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\")\n\t@test(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\nfunction find_first_occurrence(A::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_first_occurrence;\n\t@test(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1)\n\t@test(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2)\n\t@test(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\nfunction sum_Of_Subarray_Prod(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_Subarray_Prod;\n\t@test(candidate([1, 2, 3]) == 20)\n\t@test(candidate([1, 2]) == 5)\n\t@test(candidate([1, 2, 3, 4]) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\nfunction toggle_middle_bits(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_middle_bits;\n\t@test(candidate(9) == 15)\n\t@test(candidate(10) == 12)\n\t@test(candidate(11) == 13)\n\t@test(candidate(65) == 127)\n\t@test(candidate(77) == 115)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\nfunction left_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = left_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\nfunction check_str(string::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_str;\n\t@test(candidate(\"annie\") == true)\n\t@test(candidate(\"dawood\") == false)\n\t@test(candidate(\"Else\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\nfunction geometric_sum(n::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = geometric_sum;\n\t@test(candidate(7) == 1.9921875)\n\t@test(candidate(4) == 1.9375)\n\t@test(candidate(8) == 1.99609375)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\nfunction find_Index(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Index;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 14)\n\t@test(candidate(4) == 45)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\nfunction tuple_to_dict(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64, Int64})::Dict{Int64, Int64}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_dict;\n\t@test(candidate((1, 5, 7, 10, 13, 5)) == Dict(1 => 5, 7 => 10, 13 => 5))\n\t@test(candidate((1, 2, 3, 4, 5, 6)) == Dict(1 => 2, 3 => 4, 5 => 6))\n\t@test(candidate((7, 8, 9, 10, 11, 12)) == Dict(7 => 8, 9 => 10, 11 => 12))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\nfunction all_Characters_Same(s::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Characters_Same;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"aaa\") == true)\n\t@test(candidate(\"data\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\nfunction area_tetrahedron(side::Int64)::Float64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = area_tetrahedron;\n\t@test(candidate(3) == 15.588457268119894)\n\t@test(candidate(20) == 692.8203230275509)\n\t@test(candidate(10) == 173.20508075688772)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\nfunction rotate_right(list::Vector{Int64}, m::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rotate_right;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\nfunction check_none(test_tup::Any)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_none;\n\t@test(candidate((10, 4, 5, 6, nothing)) == true)\n\t@test(candidate((7, 8, 9, 11, 14)) == false)\n\t@test(candidate((1, 2, 3, 4, nothing)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\nfunction divisible_by_digits(startnum::Int64, endnum::Int64)::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = divisible_by_digits;\n\t@test(candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\n\t@test(candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\n\t@test(candidate(20, 25) == [22, 24])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\nfunction sector_area(r::Int64, a::Int64)::Union{Float64, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sector_area;\n\t@test(candidate(4, 45) == 6.283185307179586)\n\t@test(candidate(9, 45) == 31.808625617596654)\n\t@test(candidate(9, 361) == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\nfunction lcs_of_three(X::String, Y::String, Z::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lcs_of_three;\n\t@test(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2)\n\t@test(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5)\n\t@test(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\nfunction capital_words_spaces(str1::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = capital_words_spaces;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\")\n\t@test(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\nfunction sort_numeric_strings(nums_str::Vector{String})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numeric_strings;\n\t@test(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\n\t@test(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\n\t@test(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\nfunction is_samepatterns(colors::Vector{String}, patterns::Vector{String})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_samepatterns;\n\t@test(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\nfunction add_tuple(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_tuple;\n\t@test(candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10])\n\t@test(candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11])\n\t@test(candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\nfunction check_min_heap(arr::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_min_heap;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 10, 15]) == true)\n\t@test(candidate([2, 10, 4, 5, 3, 15]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\nfunction jacobsthal_num(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = jacobsthal_num;\n\t@test(candidate(5) == 11)\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 5)\n\t@test(candidate(13) == 2731)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\nfunction min_k(test_list::Vector{Tuple{String, Int64}}, K::Int64)::Vector{Tuple{String, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_k;\n\t@test(candidate([(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\n\t@test(candidate([(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\n\t@test(candidate([(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], 1) == [(\"Ayesha\", 9)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\nfunction extract_index_list(l1::Vector{Int64}, l2::Vector{Int64}, l3::Vector{Int64})::Vector{Any} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_index_list;\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\n\t@test(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\n\t@test(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\nfunction second_smallest(numbers::Vector{Union{Int64, Float64}})::Union{Float64, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = second_smallest;\n\t@test(candidate([1, 2, -8, -2, 0, -2]) == -2)\n\t@test(candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5)\n\t@test(candidate([2, 2]) == nothing)\n\t@test(candidate([2, 2, 2]) == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\nfunction text_match_zero_one(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_zero_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"dsabbbba\") == true)\n\t@test(candidate(\"asbbbba\") == false)\n\t@test(candidate(\"abaaa\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\nfunction count_reverse_pairs(test_list::Vector{String})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_reverse_pairs;\n\t@test(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\n\t@test(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\n\t@test(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\nfunction is_decimal(num::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_decimal;\n\t@test(candidate(\"123.11\") == true)\n\t@test(candidate(\"e666.86\") == false)\n\t@test(candidate(\"3.124587\") == false)\n\t@test(candidate(\"1.11\") == true)\n\t@test(candidate(\"1.1.11\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\nfunction find_tuples(test_list::Vector{Tuple{Int64, Int64, Int64}}, K::Int64)::Vector{Tuple{Int64, Int64, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_tuples;\n\t@test(candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)])\n\t@test(candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)])\n\t@test(candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\nfunction unique_Element(arr::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_Element;\n\t@test(candidate([1, 1, 1]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\nfunction check_monthnumber_number(monthnum3::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumber_number;\n\t@test(candidate(6) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(12) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\nfunction find_min_diff(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_min_diff;\n\t@test(candidate([1, 5, 3, 19, 18, 25], 6) == 1)\n\t@test(candidate([4, 3, 2, 6], 4) == 1)\n\t@test(candidate([30, 5, 20, 9], 4) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\nfunction number_ctr(str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = number_ctr;\n\t@test(candidate(\"program2bedone\") == 1)\n\t@test(candidate(\"3wonders\") == 1)\n\t@test(candidate(\"123\") == 3)\n\t@test(candidate(\"3wond-1ers2\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\nfunction is_polite(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_polite;\n\t@test(candidate(7) == 11)\n\t@test(candidate(4) == 7)\n\t@test(candidate(9) == 13)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\nfunction pair_wise(l1::Vector{Int64})::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_wise;\n\t@test(candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\n\t@test(candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\n\t@test(candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\nfunction get_pairs_count(arr::Vector{Int64}, sum::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_pairs_count;\n\t@test(candidate([1, 1, 1, 1], 2) == 6)\n\t@test(candidate([1, 5, 7, -1, 5], 6) == 3)\n\t@test(candidate([1, -2, 3], 1) == 1)\n\t@test(candidate([-1, -2, 3], -3) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\nfunction Diff(li1::Vector{Int64}, li2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Diff;\n\t@test(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15])\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\nfunction odd_num_sum(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_num_sum;\n\t@test(candidate(2) == 82)\n\t@test(candidate(3) == 707)\n\t@test(candidate(4) == 3108)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\nfunction check_expression(exp::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_expression;\n\t@test(candidate(\"{()}[{}]\") == true)\n\t@test(candidate(\"{()}[{]\") == false)\n\t@test(candidate(\"{()}[{}][]({})\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\nfunction remove_length(test_str::String, K::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_length;\n\t@test(candidate(\"The person is most value tet\", 3) == \"person is most value\")\n\t@test(candidate(\"If you told me about this ok\", 4) == \"If you me about ok\")\n\t@test(candidate(\"Forces of darkeness is come into the play\", 4) == \"Forces of darkeness is the\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\nfunction occurance_substring(text::String, pattern::String)::Union{Tuple{String, Int64, Int64}, Nothing} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = occurance_substring;\n\t@test(candidate(\"python programming, python language\", \"python\") == (\"python\", 0, 6))\n\t@test(candidate(\"python programming,programming language\", \"programming\") == (\"programming\", 7, 18))\n\t@test(candidate(\"python programming,programming language\", \"language\") == (\"language\", 31, 39))\n\t@test(candidate(\"c++ programming, c++ language\", \"python\") == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\nfunction odd_position(nums::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_position;\n\t@test(candidate([2, 1, 4, 3, 6, 7, 6, 3]) == true)\n\t@test(candidate([4, 1, 2]) == true)\n\t@test(candidate([1, 2, 3]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\nfunction count_vowels(test_str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_vowels;\n\t@test(candidate(\"bestinstareels\") == 7)\n\t@test(candidate(\"partofthejourneyistheend\") == 12)\n\t@test(candidate(\"amazonprime\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\nfunction find_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_sum;\n\t@test(candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21)\n\t@test(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\n\t@test(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\nfunction pack_consecutive_duplicates(list1::Vector{Any})::Vector{Vector{Any}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pack_consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\nfunction is_Diff(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Diff;\n\t@test(candidate(12345) == false)\n\t@test(candidate(1212112) == true)\n\t@test(candidate(1212) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\nfunction find_combinations(test_list::Vector{Tuple{Int64, Int64}})::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_combinations;\n\t@test(candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\n\t@test(candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\n\t@test(candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\nfunction count_divisors(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_divisors;\n\t@test(candidate(10) == true)\n\t@test(candidate(100) == false)\n\t@test(candidate(125) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\nfunction odd_length_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_length_sum;\n\t@test(candidate([1, 2, 4]) == 14)\n\t@test(candidate([1, 2, 1, 2]) == 15)\n\t@test(candidate([1, 7]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\nfunction rgb_to_hsv(r::Int64, g::Int64, b::Int64)::Vector{Float64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rgb_to_hsv;\n\t@test(candidate(255, 255, 255) == [0.0, 0.0, 100.0])\n\t@test(candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608])\n\t@test(candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\nfunction mul_even_odd(list1::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mul_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([1, 5, 7, 9, 10]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\nfunction tuple_str_int(test_str::String)::Tuple{Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_str_int;\n\t@test(candidate(\"(7, 8, 9)\") == (7, 8, 9))\n\t@test(candidate(\"(1, 2, 3)\") == (1, 2, 3))\n\t@test(candidate(\"(4, 5, 6)\") == (4, 5, 6))\n\t@test(candidate(\"(7, 81, 19)\") == (7, 81, 19))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\nfunction right_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\nfunction text_match_three(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"caacabbbba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\nfunction new_tuple(test_list::Vector{String}, test_str::String)::Tuple{String, String, String} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = new_tuple;\n\t@test(candidate([\"WEB\", \"is\"], \"best\") == (\"WEB\", \"is\", \"best\"))\n\t@test(candidate([\"We\", \"are\"], \"Developers\") == (\"We\", \"are\", \"Developers\"))\n\t@test(candidate([\"Part\", \"is\"], \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\nfunction even_position(nums::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_position;\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 3]) == false)\n\t@test(candidate([2, 1, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\nfunction remove_nested(test_tup::Any)::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_nested;\n\t@test(candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\n\t@test(candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\n\t@test(candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\n\t@test(candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\nfunction count_list(input_list::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_list;\n\t@test(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\n\t@test(candidate([[1, 2], [2, 3], [4, 5]]) == 3)\n\t@test(candidate([[1, 0], [2, 0]]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\nfunction last(arr::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last;\n\t@test(candidate([1, 2, 3], 1) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, 4], 1) == 2)\n\t@test(candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\nfunction text_starta_endb(text::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_starta_endb;\n\t@test(candidate(\"aabbbb\") == true)\n\t@test(candidate(\"aabAbbbc\") == false)\n\t@test(candidate(\"accddbbjjj\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\nfunction return_sum(dict::Dict{String, Int64}>)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = return_sum;\n\t@test(candidate(Dict(\"a\" => 100, \"b\" => 200, \"c\" => 300)) == 600)\n\t@test(candidate(Dict(\"a\" => 25, \"b\" => 18, \"c\" => 45)) == 88)\n\t@test(candidate(Dict(\"a\" => 36, \"b\" => 39, \"c\" => 49)) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\nfunction sum_in_range(l::Int64, r::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_in_range;\n\t@test(candidate(2, 5) == 8)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 13) == 40)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\nfunction _sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = _sum;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([15, 12, 13, 10]) == 50)\n\t@test(candidate([0, 1, 2]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\nfunction left_rotate(n::Int64, d::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = left_rotate;\n\t@test(candidate(16, 2) == 64)\n\t@test(candidate(10, 2) == 40)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(1, 3) == 8)\n\t@test(candidate(5, 3) == 40)\n\t@test(candidate(29, 3) == 232)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\nfunction word_len(s::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = word_len;\n\t@test(candidate(\"Hadoop\") == false)\n\t@test(candidate(\"great\") == true)\n\t@test(candidate(\"structure\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\nfunction remove_all_spaces(text::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_all_spaces;\n\t@test(candidate(\"python  program\") == \"pythonprogram\")\n\t@test(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\")\n\t@test(candidate(\"python                     program\") == \"pythonprogram\")\n\t@test(candidate(\"   python                     program\") == \"pythonprogram\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\nfunction test_three_equal(x::Int64, y::Int64, z::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = test_three_equal;\n\t@test(candidate(1, 1, 1) == 3)\n\t@test(candidate(-1, -2, -3) == 0)\n\t@test(candidate(1, 2, 2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\nfunction count_rotation(arr::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_rotation;\n\t@test(candidate([3, 2, 1]) == 1)\n\t@test(candidate([4, 5, 1, 2, 3]) == 2)\n\t@test(candidate([7, 8, 9, 1, 2, 3]) == 3)\n\t@test(candidate([1, 2, 3]) == 0)\n\t@test(candidate([1, 3, 2]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\nfunction is_perfect_square(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_perfect_square;\n\t@test(candidate(10) == false)\n\t@test(candidate(36) == true)\n\t@test(candidate(14) == false)\n\t@test(candidate(196) == true)\n\t@test(candidate(125) == false)\n\t@test(candidate(15625) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\nfunction is_product_even(arr::Vector{Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_product_even;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 4]) == true)\n\t@test(candidate([1, 1]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\nfunction max_sum_list(lists::Vector{Vector{Int64}})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_list;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\n\t@test(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\n\t@test(candidate([[2, 3, 1]]) == [2, 3, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\nfunction max_run_uppercase(test_str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_run_uppercase;\n\t@test(candidate(\"GeMKSForGERksISBESt\") == 5)\n\t@test(candidate(\"PrECIOusMOVemENTSYT\") == 6)\n\t@test(candidate(\"GooGLEFluTTER\") == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\nfunction first_odd(nums::Vector{Int64})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_odd;\n\t@test(candidate([1, 3, 5]) == 1)\n\t@test(candidate([2, 4, 1, 3]) == 1)\n\t@test(candidate([8, 9, 1]) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\nfunction check_K(test_tup::Vector{Int64}, K::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_K;\n\t@test(candidate([10, 4, 5, 6, 8], 6) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6], 7) == false)\n\t@test(candidate([7, 8, 9, 44, 11, 12], 11) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\nfunction check_smaller(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_smaller;\n\t@test(candidate((1, 2, 3), (2, 3, 4)) == false)\n\t@test(candidate((4, 5, 6), (3, 4, 5)) == true)\n\t@test(candidate((11, 12, 13), (10, 11, 12)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\nfunction tetrahedral_number(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tetrahedral_number;\n\t@test(candidate(5) == 35)\n\t@test(candidate(6) == 56)\n\t@test(candidate(7) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\nfunction get_Char(strr::String)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Char;\n\t@test(candidate(\"abc\") == \"f\")\n\t@test(candidate(\"gfg\") == \"t\")\n\t@test(candidate(\"ab\") == \"c\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\nfunction sequence(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sequence;\n\t@test(candidate(10) == 6)\n\t@test(candidate(2) == 1)\n\t@test(candidate(3) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\nfunction centered_hexagonal_number(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = centered_hexagonal_number;\n\t@test(candidate(10) == 271)\n\t@test(candidate(2) == 7)\n\t@test(candidate(9) == 217)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\nfunction merge_dictionaries_three(dict1::Dict{String, String}>, dict2::Dict{String, String}>, dict3::Dict{String, String}>)::Dict{String, String}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_dictionaries_three;\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) == Dict(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\")) == Dict(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\"), Dict(\"G\" => \"Green\", \"W\" => \"White\")) == Dict(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\nfunction freq_count(list1::Vector{Int64})::Dict{Int64, Int64}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = freq_count;\n\t@test(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == Dict(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1))\n\t@test(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == Dict(1 => 3, 2 => 2, 3 => 3, 4 => 3))\n\t@test(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == Dict(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\nfunction closest_num(N::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_num;\n\t@test(candidate(11) == 10)\n\t@test(candidate(7) == 6)\n\t@test(candidate(12) == 11)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\nfunction square_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30]) == [100, 400, 900])\n\t@test(candidate([12, 15]) == [144, 225])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\nfunction len_log(list1::Vector{String})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = len_log;\n\t@test(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7)\n\t@test(candidate([\"a\", \"ab\", \"abc\"]) == 3)\n\t@test(candidate([\"small\", \"big\", \"tall\"]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\nfunction find_substring(str1::Vector{String}, sub_str::String)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_substring;\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\nfunction is_undulating(n::Int64)::Bool \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_undulating;\n\t@test(candidate(1212121) == true)\n\t@test(candidate(1991) == false)\n\t@test(candidate(121) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\nfunction power(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = power;\n\t@test(candidate(3, 4) == 81)\n\t@test(candidate(2, 3) == 8)\n\t@test(candidate(5, 5) == 3125)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\nfunction index_minimum(test_list::Vector{Tuple{String, Int64}})::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = index_minimum;\n\t@test(candidate([(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\n\t@test(candidate([(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\n\t@test(candidate([(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\nfunction Find_Min_Length(lst::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min_Length;\n\t@test(candidate([[1], [1, 2]]) == 1)\n\t@test(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\n\t@test(candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\nfunction divisor(n::Int64)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = divisor;\n\t@test(candidate(15) == 4)\n\t@test(candidate(12) == 6)\n\t@test(candidate(9) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\nfunction frequency_lists(list1::Vector{Vector{Int64}})::Dict{Int64, Int64}> \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency_lists;\n\t@test(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == Dict(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1))\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == Dict(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1))\n\t@test(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == Dict(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\nfunction decimal_to_binary(n::Int64)::String \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(8) == \"1000\")\n\t@test(candidate(18) == \"10010\")\n\t@test(candidate(7) == \"111\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\nfunction find_Rotations(str::String)::Int64 \n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Rotations;\n\t@test(candidate(\"aaaa\") == 1)\n\t@test(candidate(\"ab\") == 2)\n\t@test(candidate(\"abc\") == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/mbpp-jl-reworded.json
+++ b/prompts/mbpp-jl-reworded.json
@@ -1,4030 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\nfunction lps(str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lps;\n\t@test(candidate(\"TENS FOR TENS\") == 5)\n\t@test(candidate(\"CARDIO FOR CARDS\") == 7)\n\t@test(candidate(\"PART OF THE JOURNEY IS PART\") == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\nfunction remove_whitespaces(text1::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_whitespaces;\n\t@test(candidate(\" Google    Flutter \") == \"GoogleFlutter\")\n\t@test(candidate(\" Google    Dart \") == \"GoogleDart\")\n\t@test(candidate(\" iOS    Swift \") == \"iOSSwift\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a specified vector is sorted or not.\n\t\"\"\"\nfunction issort_list(list1::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = issort_list;\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\nfunction count_bidirectional(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_bidirectional;\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\n\t@test(candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\nfunction surfacearea_cube(l::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cube;\n\t@test(candidate(5) == 150)\n\t@test(candidate(3) == 54)\n\t@test(candidate(10) == 600)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\"\"\"\nfunction next_smallest_palindrome(num::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = next_smallest_palindrome;\n\t@test(candidate(99) == 101)\n\t@test(candidate(1221) == 1331)\n\t@test(candidate(120) == 121)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the cube sum of first n even natural numbers.\n\t\"\"\"\nfunction cube_Sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_Sum;\n\t@test(candidate(2) == 72)\n\t@test(candidate(3) == 288)\n\t@test(candidate(4) == 800)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of xor of all pairs of numbers in the given vector.\n\t\"\"\"\nfunction pair_xor_Sum(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_xor_Sum;\n\t@test(candidate([5, 9, 7, 6], 4) == 47)\n\t@test(candidate([7, 3, 5], 3) == 12)\n\t@test(candidate([7, 3], 2) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\n\t\"\"\"\nfunction check_min_heap(arr::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_min_heap;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 10, 15]) == true)\n\t@test(candidate([2, 10, 4, 5, 3, 15]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first digit of a given number.\n\t\"\"\"\nfunction first_Digit(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_Digit;\n\t@test(candidate(123) == 1)\n\t@test(candidate(456) == 4)\n\t@test(candidate(12) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first non-repeated character in a given string.\n\t\"\"\"\nfunction first_non_repeating_character(str1::String)::Union{String, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_non_repeating_character;\n\t@test(candidate(\"abcabc\") == nothing)\n\t@test(candidate(\"abc\") == \"a\")\n\t@test(candidate(\"ababc\") == \"c\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\nfunction radian_degree(degree::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = radian_degree;\n\t@test(candidate(90) == 1.5707963267948966)\n\t@test(candidate(60) == 1.0471975511965976)\n\t@test(candidate(120) == 2.0943951023931953)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum product subvector of the given vector.\n\t\"\"\"\nfunction max_subarray_product(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_subarray_product;\n\t@test(candidate([1, -2, -3, 0, 7, -8, -2]) == 112)\n\t@test(candidate([6, -3, -10, 0, 2]) == 180)\n\t@test(candidate([-2, -40, 0, -2, -3]) == 80)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find smallest number in a vector.\n\t\"\"\"\nfunction smallest_num(xs::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_num;\n\t@test(candidate([10, 20, 1, 45, 99]) == 1)\n\t@test(candidate([1, 2, 3]) == 1)\n\t@test(candidate([45, 46, 50, 60]) == 45)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/jlthon-exercises/re/jlthon-re-exercise-3.php\n\t\"\"\"\nfunction text_match_zero_one(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_zero_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"dsabbbba\") == true)\n\t@test(candidate(\"asbbbba\") == false)\n\t@test(candidate(\"abaaa\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find nth bell number.\n\t\"\"\"\nfunction bell_Number(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_Number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 15)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find cubes of individual elements in a vector.\n\t\"\"\"\nfunction cube_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\n\t@test(candidate([10, 20, 30]) == [1000, 8000, 27000])\n\t@test(candidate([12, 15]) == [1728, 3375])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last digit in factorial of a given number.\n\t\"\"\"\nfunction last_Digit_Factorial(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit_Factorial;\n\t@test(candidate(4) == 4)\n\t@test(candidate(21) == 0)\n\t@test(candidate(30) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find even numbers from a vector of numbers.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5]) == [2, 4])\n\t@test(candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\n\t@test(candidate([8, 12, 15, 19]) == [8, 12])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\nfunction prime_num(num::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_num;\n\t@test(candidate(13) == true)\n\t@test(candidate(7) == true)\n\t@test(candidate(-1010) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given vector of tuples.\n\t\"\"\"\nfunction find_tuples(test_list::Vector{Tuple{Int64, Int64, Int64}}, K::Int64)::Vector{Tuple{Int64, Int64, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_tuples;\n\t@test(candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)])\n\t@test(candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)])\n\t@test(candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\nfunction area_tetrahedron(side::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = area_tetrahedron;\n\t@test(candidate(3) == 15.588457268119894)\n\t@test(candidate(20) == 692.8203230275509)\n\t@test(candidate(10) == 173.20508075688772)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number is even or not.\n\t\"\"\"\nfunction is_Even(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Even;\n\t@test(candidate(1) == false)\n\t@test(candidate(2) == true)\n\t@test(candidate(3) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of positive numbers in a vector.\n\t\"\"\"\nfunction pos_count(list::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pos_count;\n\t@test(candidate([1, -2, 3, -4]) == 2)\n\t@test(candidate([3, 4, 5, -1]) == 3)\n\t@test(candidate([1, 2, 3, 4]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\nfunction get_ludic(n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_ludic;\n\t@test(candidate(10) == [1, 2, 3, 5, 7])\n\t@test(candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\n\t@test(candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\nfunction find_Index(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Index;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 14)\n\t@test(candidate(4) == 45)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to reverse a vector upto a given position.\n\t\"\"\"\nfunction reverse_Array_Upto_K(input::Vector{Int64}, k::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_Array_Upto_K;\n\t@test(candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6])\n\t@test(candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7])\n\t@test(candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a vector of tuples using the second value of each tuple.\n\t\"\"\"\nfunction subject_marks(subjectmarks::Vector{Tuple{String, Int64}})::Vector{Tuple{String, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = subject_marks;\n\t@test(candidate([(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\n\t@test(candidate([(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\n\t@test(candidate([(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\nfunction remove_dirty_chars(string::String, second_string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_dirty_chars;\n\t@test(candidate(\"probasscurve\", \"pros\") == \"bacuve\")\n\t@test(candidate(\"digitalindia\", \"talent\") == \"digiidi\")\n\t@test(candidate(\"exoticmiles\", \"toxic\") == \"emles\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to round every number of a given vector of numbers and print the total sum multiplied by the length of the vector.\n\t\"\"\"\nfunction round_and_sum(list1::Vector{Union{Float64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = round_and_sum;\n\t@test(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243)\n\t@test(candidate([5, 2, 9, 24.3, 29]) == 345)\n\t@test(candidate([25.0, 56.7, 89.2]) == 513)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the item with maximum frequency in a given vector.\n\t\"\"\"\nfunction max_occurrences(nums::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_occurrences;\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\n\t@test(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\nfunction is_decimal(num::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_decimal;\n\t@test(candidate(\"123.11\") == true)\n\t@test(candidate(\"e666.86\") == false)\n\t@test(candidate(\"3.124587\") == false)\n\t@test(candidate(\"1.11\") == true)\n\t@test(candidate(\"1.1.11\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\nfunction dict_filter(dict::Dict{String, Int64}>, n::Int64)::Dict{String, Int64}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dict_filter;\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) == Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) == Dict(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) == Dict(\"Pierre Cox\" => 190))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of even numbers at even positions of a vector.\n\t\"\"\"\nfunction sum_even_and_even_index(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_even_and_even_index;\n\t@test(candidate([5, 6, 12, 1, 18, 8]) == 30)\n\t@test(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\n\t@test(candidate([5, 6, 12, 1]) == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the sum of the largest contiguous subvector in the given vector.\n\t\"\"\"\nfunction max_sub_array_sum(a::Vector{Int64}, size::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum;\n\t@test(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7)\n\t@test(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8)\n\t@test(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the intersection of two vectors.\n\t\"\"\"\nfunction intersection_array(array_nums1::Vector{Int64}, array_nums2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection_array;\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer L and splits the given vector into two parts where the length of the first part of the vector is L, and returns the resulting vectors in a tuple.\n\t\"\"\"\nfunction split_two_parts(list1::Vector{Any}, L::Int64)::Any \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_two_parts;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\nfunction find_literals(text::String, pattern::String)::Tuple{String, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_literals;\n\t@test(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == (\"fox\", 16, 19))\n\t@test(candidate(\"Its been a very crazy procedure right\", \"crazy\") == (\"crazy\", 16, 21))\n\t@test(candidate(\"Hardest choices required strongest will\", \"will\") == (\"will\", 35, 39))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the volume of a triangular prism.\n\t\"\"\"\nfunction find_Volume(l::Int64, b::Int64, h::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Volume;\n\t@test(candidate(10, 8, 6) == 240)\n\t@test(candidate(3, 2, 2) == 6)\n\t@test(candidate(1, 2, 1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\nfunction wind_chill(v::Int64, t::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = wind_chill;\n\t@test(candidate(120, 35) == 40)\n\t@test(candidate(40, 20) == 19)\n\t@test(candidate(10, 8) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\nfunction ascii_value(k::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = ascii_value;\n\t@test(candidate(\"A\") == 65)\n\t@test(candidate(\"R\") == 82)\n\t@test(candidate(\"S\") == 83)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether all the characters are same or not.\n\t\"\"\"\nfunction all_Characters_Same(s::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Characters_Same;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"aaa\") == true)\n\t@test(candidate(\"data\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\nfunction move_num(test_str::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_num;\n\t@test(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\n\t@test(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\")\n\t@test(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the length of the word is odd or not.\n\t\"\"\"\nfunction word_len(s::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = word_len;\n\t@test(candidate(\"Hadoop\") == false)\n\t@test(candidate(\"great\") == true)\n\t@test(candidate(\"structure\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\n\t\"\"\"\nfunction insert_element(list::Vector{String}, element::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = insert_element;\n\t@test(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\n\t@test(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"])\n\t@test(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\nfunction remove_lowercase(str1::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_lowercase;\n\t@test(candidate(\"PYTHon\") == \"PYTH\")\n\t@test(candidate(\"FInD\") == \"FID\")\n\t@test(candidate(\"STRinG\") == \"STRG\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\nfunction count_Set_Bits(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Set_Bits;\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 1)\n\t@test(candidate(6) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\nfunction extract_rear(test_tuple::Tuple{String, String, String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_rear;\n\t@test(candidate((\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\n\t@test(candidate((\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\n\t@test(candidate((\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\nfunction count_occurance(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_occurance;\n\t@test(candidate(\"letstdlenstdporstd\") == 3)\n\t@test(candidate(\"truststdsolensporsd\") == 1)\n\t@test(candidate(\"makestdsostdworthit\") == 2)\n\t@test(candidate(\"stds\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\nfunction check_K(test_tup::Vector{Int64}, K::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_K;\n\t@test(candidate([10, 4, 5, 6, 8], 6) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6], 7) == false)\n\t@test(candidate([7, 8, 9, 44, 11, 12], 11) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to interleave 3 vectors of the same length into a single flat vector.\n\t\"\"\"\nfunction interleave_lists(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = interleave_lists;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\n\t@test(candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10])\n\t@test(candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"python_program\") == \"PythonProgram\")\n\t@test(candidate(\"python_language\") == \"PythonLanguage\")\n\t@test(candidate(\"programming_language\") == \"ProgrammingLanguage\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of equal numbers from three given integers.\n\t\"\"\"\nfunction test_three_equal(x::Int64, y::Int64, z::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = test_three_equal;\n\t@test(candidate(1, 1, 1) == 3)\n\t@test(candidate(-1, -2, -3) == 0)\n\t@test(candidate(1, 2, 2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\n\t\"\"\"\nfunction odd_length_sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_length_sum;\n\t@test(candidate([1, 2, 4]) == 14)\n\t@test(candidate([1, 2, 1, 2]) == 15)\n\t@test(candidate([1, 7]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\nfunction bell_number(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(10) == 115975)\n\t@test(candidate(56) == 6775685320645824322581483068371419745979053216268760300)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\nfunction rectangle_area(l::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rectangle_area;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(10, 5) == 50)\n\t@test(candidate(4, 2) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\nfunction sum_average(number::Int64)::Tuple{Int64, Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_average;\n\t@test(candidate(10) == (55, 5.5))\n\t@test(candidate(15) == (120, 8.0))\n\t@test(candidate(20) == (210, 10.5))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\nfunction division_elements(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = division_elements;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3))\n\t@test(candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4))\n\t@test(candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\nfunction sum_digits(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_digits;\n\t@test(candidate(345) == 12)\n\t@test(candidate(12) == 3)\n\t@test(candidate(97) == 16)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tGiven a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\nfunction index_minimum(test_list::Vector{Tuple{String, Int64}})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = index_minimum;\n\t@test(candidate([(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\n\t@test(candidate([(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\n\t@test(candidate([(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to divide two vectors element wise.\n\t\"\"\"\nfunction div_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = div_list;\n\t@test(candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0])\n\t@test(candidate([3, 2], [1, 4]) == [3.0, 0.5])\n\t@test(candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the vector with maximum length.\n\t\"\"\"\nfunction max_length_list(input_list::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length_list;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\n\t@test(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the largest and smallest value in a given vector.\n\t\"\"\"\nfunction big_sum(nums::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = big_sum;\n\t@test(candidate([1, 2, 3]) == 4)\n\t@test(candidate([-1, 2, 3, 4]) == 3)\n\t@test(candidate([2, 3, 6]) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to return the negative numbers in a vector.\n\t\"\"\"\nfunction neg_nos(list1::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = neg_nos;\n\t@test(candidate([-1, 4, 5, -6]) == [-1, -6])\n\t@test(candidate([-1, -2, 3, 4]) == [-1, -2])\n\t@test(candidate([-7, -6, 8, 9]) == [-7, -6])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\nfunction highest_Power_of_2(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = highest_Power_of_2;\n\t@test(candidate(10) == 8)\n\t@test(candidate(19) == 16)\n\t@test(candidate(32) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether a vector contains the given subvector or not.\n\t\"\"\"\nfunction is_sublist(l::Vector{Int64}, s::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sublist;\n\t@test(candidate([2, 4, 3, 5, 7], [3, 7]) == false)\n\t@test(candidate([2, 4, 3, 5, 7], [4, 3]) == true)\n\t@test(candidate([2, 4, 3, 5, 7], [1, 6]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to subtract two vectors element-wise.\n\t\"\"\"\nfunction sub_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sub_list;\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3])\n\t@test(candidate([1, 2], [3, 4]) == [-2, -2])\n\t@test(candidate([90, 120], [50, 70]) == [40, 50])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\nfunction opposite_Signs(x::Int64, y::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = opposite_Signs;\n\t@test(candidate(1, -2) == true)\n\t@test(candidate(3, 2) == false)\n\t@test(candidate(-10, -10) == false)\n\t@test(candidate(-2, 2) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\nfunction tuple_modulo(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_modulo;\n\t@test(candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1))\n\t@test(candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1))\n\t@test(candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given vector.\n\t\"\"\"\nfunction diff_even_odd(list1::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = diff_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\n\t@test(candidate([1, 5, 7, 9, 10]) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort each subvector of strings in a given vector of vectors.\n\t\"\"\"\nfunction sort_sublists(list1::Vector{Vector{String}})::Vector{Vector{String}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last digit of a given number.\n\t\"\"\"\nfunction last_Digit(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit;\n\t@test(candidate(123) == 3)\n\t@test(candidate(25) == 5)\n\t@test(candidate(30) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\nfunction odd_num_sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_num_sum;\n\t@test(candidate(2) == 82)\n\t@test(candidate(3) == 707)\n\t@test(candidate(4) == 3108)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a vector to a string.\n\t\"\"\"\nfunction tup_string(tup1::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tup_string;\n\t@test(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\n\t@test(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all elements from a given vector present in another vector.\n\t\"\"\"\nfunction remove_elements(list1::Vector{Int64}, list2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_elements;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\nfunction overlapping(list1::Vector{Int64}, list2::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = overlapping;\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == false)\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == false)\n\t@test(candidate([1, 4, 5], [1, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to identify non-prime numbers.\n\t\"\"\"\nfunction is_not_prime(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_not_prime;\n\t@test(candidate(2) == false)\n\t@test(candidate(10) == true)\n\t@test(candidate(35) == true)\n\t@test(candidate(37) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous vector.\n\t\"\"\"\nfunction max_val(listval::Vector{Union{String, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 5)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 25)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 50)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given vector of numbers.\n\t\"\"\"\nfunction sum_negativenum(nums::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_negativenum;\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\n\t@test(candidate([10, 15, -14, 13, -18, 12, -20]) == -52)\n\t@test(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\nfunction find_Rotations(str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Rotations;\n\t@test(candidate(\"aaaa\") == 1)\n\t@test(candidate(\"ab\") == 2)\n\t@test(candidate(\"abc\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\nfunction change_date_format(dt::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = change_date_format;\n\t@test(candidate(\"2026-01-02\") == \"02-01-2026\")\n\t@test(candidate(\"2020-11-13\") == \"13-11-2020\")\n\t@test(candidate(\"2021-04-26\") == \"26-04-2021\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of integers and only returns the odd ones.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5])\n\t@test(candidate([10, 11, 12, 13]) == [11, 13])\n\t@test(candidate([7, 8, 9, 1]) == [7, 9, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\nfunction toggle_middle_bits(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_middle_bits;\n\t@test(candidate(9) == 15)\n\t@test(candidate(10) == 12)\n\t@test(candidate(11) == 13)\n\t@test(candidate(65) == 127)\n\t@test(candidate(77) == 115)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\nfunction count_char_position(str1::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_char_position;\n\t@test(candidate(\"xbcefg\") == 2)\n\t@test(candidate(\"ABcED\") == 3)\n\t@test(candidate(\"AbgdeF\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\n\t\"\"\"\nfunction large_product(nums1::Vector{Int64}, nums2::Vector{Int64}, N::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = large_product;\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given vector of vectors.\n\t\"\"\"\nfunction cummulative_sum(test_list::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cummulative_sum;\n\t@test(candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30)\n\t@test(candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37)\n\t@test(candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\nfunction find_min_diff(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_min_diff;\n\t@test(candidate([1, 5, 3, 19, 18, 25], 6) == 1)\n\t@test(candidate([4, 3, 2, 6], 4) == 1)\n\t@test(candidate([30, 5, 20, 9], 4) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\nfunction text_starta_endb(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_starta_endb;\n\t@test(candidate(\"aabbbb\") == true)\n\t@test(candidate(\"aabAbbbc\") == false)\n\t@test(candidate(\"accddbbjjj\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\nfunction left_rotate(n::Int64, d::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = left_rotate;\n\t@test(candidate(16, 2) == 64)\n\t@test(candidate(10, 2) == 40)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(1, 3) == 8)\n\t@test(candidate(5, 3) == 40)\n\t@test(candidate(29, 3) == 232)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first repeated character in a given string.\n\t\"\"\"\nfunction first_repeated_char(str1::String)::Union{String, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_repeated_char;\n\t@test(candidate(\"abcabc\") == \"a\")\n\t@test(candidate(\"abc\") == nothing)\n\t@test(candidate(\"123123\") == \"1\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count inversions in a vector.\n\t\"\"\"\nfunction get_Inv_Count(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Inv_Count;\n\t@test(candidate([1, 20, 6, 4, 5]) == 5)\n\t@test(candidate([1, 2, 1]) == 1)\n\t@test(candidate([1, 2, 5, 6, 1]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\nfunction even_Power_Sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_Power_Sum;\n\t@test(candidate(2) == 1056)\n\t@test(candidate(3) == 8832)\n\t@test(candidate(1) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find whether all the given vectors have equal length or not.\n\t\"\"\"\nfunction get_equal(Input::Vector{Vector{Int64}})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_equal;\n\t@test(candidate([[11, 22, 33], [44, 55, 66]]) == true)\n\t@test(candidate([[1, 2, 3], [4, 5, 6, 7]]) == false)\n\t@test(candidate([[1, 2], [3, 4]]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\nfunction check_integer(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_integer;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"1\") == true)\n\t@test(candidate(\"12345\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/jlthon-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\nfunction count_reverse_pairs(test_list::Vector{String})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_reverse_pairs;\n\t@test(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\n\t@test(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\n\t@test(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to move all zeroes to the end of the given vector.\n\t\"\"\"\nfunction move_zero(num_list::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = move_zero;\n\t@test(candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\n\t@test(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\n\t@test(candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if given vector contains no duplicates.\n\t\"\"\"\nfunction check_distinct(test_tup::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_distinct;\n\t@test(candidate([1, 4, 5, 6, 1, 4]) == false)\n\t@test(candidate([1, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 6]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\nfunction noprofit_noloss(actual_cost::Int64, sale_amount::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = noprofit_noloss;\n\t@test(candidate(1500, 1200) == false)\n\t@test(candidate(100, 100) == true)\n\t@test(candidate(2000, 5000) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\nfunction remove_length(test_str::String, K::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_length;\n\t@test(candidate(\"The person is most value tet\", 3) == \"person is most value\")\n\t@test(candidate(\"If you told me about this ok\", 4) == \"If you me about ok\")\n\t@test(candidate(\"Forces of darkeness is come into the play\", 4) == \"Forces of darkeness is the\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count number of digits in a given string.\n\t\"\"\"\nfunction number_ctr(str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = number_ctr;\n\t@test(candidate(\"program2bedone\") == 1)\n\t@test(candidate(\"3wonders\") == 1)\n\t@test(candidate(\"123\") == 3)\n\t@test(candidate(\"3wond-1ers2\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\nfunction count_charac(str1::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_charac;\n\t@test(candidate(\"python programming\") == 18)\n\t@test(candidate(\"language\") == 8)\n\t@test(candidate(\"words\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\nfunction get_total_number_of_sequences(m::Int64, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_total_number_of_sequences;\n\t@test(candidate(10, 4) == 4)\n\t@test(candidate(5, 2) == 6)\n\t@test(candidate(16, 3) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/jlthon-exercises/data-structures-and-algorithms/jlthon-data-structure-exercise-24.php\n\t\"\"\"\nfunction left_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = left_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two numbers and returns a vector with the second number and then the first number.\n\t\"\"\"\nfunction swap_numbers(a::Int64, b::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_numbers;\n\t@test(candidate(10, 20) == [20, 10])\n\t@test(candidate(15, 17) == [17, 15])\n\t@test(candidate(100, 200) == [200, 100])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\nfunction is_majority(arr::Vector{Int64}, n::Int64, x::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_majority;\n\t@test(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == true)\n\t@test(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == false)\n\t@test(candidate([1, 1, 1, 2, 2], 5, 1) == true)\n\t@test(candidate([1, 1, 2, 2], 5, 1) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\nfunction substract_elements(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Tuple{Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = substract_elements;\n\t@test(candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13))\n\t@test(candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13))\n\t@test(candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\nfunction capital_words_spaces(str1::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = capital_words_spaces;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\")\n\t@test(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the average of cubes of first n natural numbers.\n\t\"\"\"\nfunction find_Average_Of_Cube(n::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Average_Of_Cube;\n\t@test(candidate(2) == 4.5)\n\t@test(candidate(3) == 12)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\nfunction check_value(dict::Dict{String, Int64}>, n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_value;\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) == false)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) == true)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\nfunction tetrahedral_number(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tetrahedral_number;\n\t@test(candidate(5) == 35)\n\t@test(candidate(6) == 56)\n\t@test(candidate(7) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\nfunction magic_square_test(my_matrix::Vector{Vector{Int64}})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = magic_square_test;\n\t@test(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\nfunction remove_uppercase(str1::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_uppercase;\n\t@test(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\n\t@test(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\n\t@test(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\nfunction check_tuplex(tuplex::Vector{Union{String, Int64}}, tuple1::Any)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_tuplex;\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\") == true)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\") == false)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\nfunction dog_age(h_age::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dog_age;\n\t@test(candidate(12) == 61)\n\t@test(candidate(15) == 73)\n\t@test(candidate(24) == 109)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the next perfect square greater than a given number.\n\t\"\"\"\nfunction next_Perfect_Square(N::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_Perfect_Square;\n\t@test(candidate(35) == 36)\n\t@test(candidate(6) == 9)\n\t@test(candidate(9) == 16)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to convert a given string to uppercase.\n\t\"\"\"\nfunction is_upper(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_upper;\n\t@test(candidate(\"person\") == \"PERSON\")\n\t@test(candidate(\"final\") == \"FINAL\")\n\t@test(candidate(\"Valid\") == \"VALID\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\nfunction odd_Equivalent(s::String, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_Equivalent;\n\t@test(candidate(\"011001\", 6) == 3)\n\t@test(candidate(\"11011\", 5) == 4)\n\t@test(candidate(\"1010\", 4) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\nfunction re_arrange_array(arr::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = re_arrange_array;\n\t@test(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\n\t@test(candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15])\n\t@test(candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether a vector of numbers contains only one distinct element or not.\n\t\"\"\"\nfunction unique_Element(arr::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_Element;\n\t@test(candidate([1, 1, 1]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\nfunction extract_values(text::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_values;\n\t@test(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\n\t@test(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\n\t@test(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count true booleans in the given vector.\n\t\"\"\"\nfunction count(lst::Vector{Bool})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count;\n\t@test(candidate([true, false, true]) == 2)\n\t@test(candidate([false, false]) == 0)\n\t@test(candidate([true, true, true]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that counts the number of pairs of integers in a vector that xor to an even number.\n\t\"\"\"\nfunction find_even_pair(A::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_even_pair;\n\t@test(candidate([5, 4, 7, 2, 1]) == 4)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11]) == 9)\n\t@test(candidate([1, 2, 3]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\nfunction armstrong_number(number::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = armstrong_number;\n\t@test(candidate(153) == true)\n\t@test(candidate(259) == false)\n\t@test(candidate(4458) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the upper case characters in a given string.\n\t\"\"\"\nfunction upper_ctr(str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = upper_ctr;\n\t@test(candidate(\"PYthon\") == 1)\n\t@test(candidate(\"BigData\") == 1)\n\t@test(candidate(\"program\") == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\nfunction and_tuples(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = and_tuples;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1))\n\t@test(candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0))\n\t@test(candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns vector.\n\t\"\"\"\nfunction is_samepatterns(colors::Vector{String}, patterns::Vector{String})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_samepatterns;\n\t@test(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of vectors in a given number of vectors.\n\t\"\"\"\nfunction count_list(input_list::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_list;\n\t@test(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\n\t@test(candidate([[1, 2], [2, 3], [4, 5]]) == 3)\n\t@test(candidate([[1, 0], [2, 0]]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\n\t\"\"\"\nfunction average_tuple(nums::Vector{Vector{Int64}})::Vector{Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = average_tuple;\n\t@test(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\n\t@test(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\n\t@test(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\nfunction lcs_of_three(X::String, Y::String, Z::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lcs_of_three;\n\t@test(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2)\n\t@test(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5)\n\t@test(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\nfunction find_star_num(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_star_num;\n\t@test(candidate(3) == 37)\n\t@test(candidate(4) == 73)\n\t@test(candidate(5) == 121)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of a vector.\n\t\"\"\"\nfunction _sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = _sum;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([15, 12, 13, 10]) == 50)\n\t@test(candidate([0, 1, 2]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given vector contains consecutive numbers or not.\n\t\"\"\"\nfunction check_Consecutive(l::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_Consecutive;\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 2, 3, 5, 6]) == false)\n\t@test(candidate([1, 2, 1]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\nfunction find_adverb_position(text::String)::Tuple{Int64, Int64, String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverb_position;\n\t@test(candidate(\"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\n\t@test(candidate(\"seriously!! there are many roses\") == (0, 9, \"seriously\"))\n\t@test(candidate(\"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/jlthon-program-right-rotate-vector-n/\n\t\"\"\"\nfunction rotate_right(list::Vector{Int64}, m::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rotate_right;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of non-empty substrings of a given string.\n\t\"\"\"\nfunction number_of_substrings(str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = number_of_substrings;\n\t@test(candidate(\"abc\") == 6)\n\t@test(candidate(\"abcd\") == 10)\n\t@test(candidate(\"abcde\") == 15)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer n and splits a vector for every nth element, returning a vector of the resulting vectors.\n\t\"\"\"\nfunction list_split(S::Vector{Any}, step::Int64)::Vector{Vector{Any}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = list_split;\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\n\t@test(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check if the elements of a given vector are unique or not.\n\t\"\"\"\nfunction all_unique(test_list::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_unique;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to convert complex numbers to polar coordinates.\n\t\"\"\"\nfunction convert(numbers::Int64)::Tuple{Float64, Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = convert;\n\t@test(candidate(1) == (1.0, 0.0))\n\t@test(candidate(4) == (4.0, 0.0))\n\t@test(candidate(5) == (5.0, 0.0))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to convert the given string to lower case.\n\t\"\"\"\nfunction is_lower(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_lower;\n\t@test(candidate(\"InValid\") == \"invalid\")\n\t@test(candidate(\"TruE\") == \"true\")\n\t@test(candidate(\"SenTenCE\") == \"sentence\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\nfunction next_power_of_2(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = next_power_of_2;\n\t@test(candidate(0) == 1)\n\t@test(candidate(5) == 8)\n\t@test(candidate(17) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if a string is present as a substring in a given vector of string values.\n\t\"\"\"\nfunction find_substring(str1::Vector{String}, sub_str::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_substring;\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\nfunction replace_char(str1::String, ch::String, newch::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_char;\n\t@test(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\")\n\t@test(candidate(\"character\", \"c\", \"a\") == \"aharaater\")\n\t@test(candidate(\"python\", \"l\", \"a\") == \"python\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the product of first even and odd number of a given vector.\n\t\"\"\"\nfunction mul_even_odd(list1::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = mul_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([1, 5, 7, 9, 10]) == 10)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a vector to a tuple.\n\t\"\"\"\nfunction list_tuple(listx::Vector{Int64})::Any \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = list_tuple;\n\t@test(candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\n\t@test(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\n\t@test(candidate([58, 44, 56]) == (58, 44, 56))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\nfunction even_binomial_Coeff_Sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_binomial_Coeff_Sum;\n\t@test(candidate(4) == 8)\n\t@test(candidate(6) == 32)\n\t@test(candidate(2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\nfunction bitwise_xor(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = bitwise_xor;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10))\n\t@test(candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14))\n\t@test(candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether a vector is subvector of another or not.\n\t\"\"\"\nfunction is_Sub_Array(A::Vector{Int64}, B::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sub_Array;\n\t@test(candidate([1, 4, 3, 5], [1, 2]) == false)\n\t@test(candidate([1, 2, 1], [1, 2, 1]) == true)\n\t@test(candidate([1, 0, 2, 2], [2, 2, 0]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\n\t\"\"\"\nfunction max_sub_array_sum_repeated(a::Vector{Int64}, n::Int64, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum_repeated;\n\t@test(candidate([10, 20, -30, -1], 4, 3) == 30)\n\t@test(candidate([-1, 10, 20], 3, 2) == 59)\n\t@test(candidate([-1, -2, -3], 3, 3) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given vector.\n\t\"\"\"\nfunction min_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 30)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the count of divisors is even. https://www.w3resource.com/jlthon-exercises/basic/jlthon-basic-1-exercise-24.php\n\t\"\"\"\nfunction count_divisors(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_divisors;\n\t@test(candidate(10) == true)\n\t@test(candidate(100) == false)\n\t@test(candidate(125) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\nfunction triangle_area(r::Int64)::Union{Int64, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(-1) == nothing)\n\t@test(candidate(0) == 0)\n\t@test(candidate(2) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a given string to a vector of characters.\n\t\"\"\"\nfunction string_to_tuple(str1::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_tuple;\n\t@test(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\n\t@test(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\n\t@test(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\nfunction find_length(string::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_length;\n\t@test(candidate(\"11000010001\") == 6)\n\t@test(candidate(\"10111\") == 1)\n\t@test(candidate(\"11011101100101\") == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\nfunction count_Primes_nums(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Primes_nums;\n\t@test(candidate(5) == 2)\n\t@test(candidate(10) == 4)\n\t@test(candidate(100) == 25)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\nfunction sum_Of_product(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_product;\n\t@test(candidate(3) == 15)\n\t@test(candidate(4) == 56)\n\t@test(candidate(1) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the maximum aggregate from the vector of tuples.\n\t\"\"\"\nfunction max_aggregate(stdata::Vector{Tuple{String, Int64}})::Tuple{String, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_aggregate;\n\t@test(candidate([(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\n\t@test(candidate([(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\n\t@test(candidate([(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a vector of elements.\n\t\"\"\"\nfunction comb_sort(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = comb_sort;\n\t@test(candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\n\t@test(candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\n\t@test(candidate([99, 15, 13, 47]) == [13, 15, 47, 99])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\nfunction check_expression(exp::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_expression;\n\t@test(candidate(\"{()}[{}]\") == true)\n\t@test(candidate(\"{()}[{]\") == false)\n\t@test(candidate(\"{()}[{}][]({})\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\nfunction text_match_wordz(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz;\n\t@test(candidate(\"pythonz.\") == true)\n\t@test(candidate(\"xyz.\") == true)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\nfunction sum_list(lst1::Vector{Int64}, lst2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_list;\n\t@test(candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65])\n\t@test(candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10])\n\t@test(candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\nfunction newman_prime(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = newman_prime;\n\t@test(candidate(3) == 7)\n\t@test(candidate(4) == 17)\n\t@test(candidate(5) == 41)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to apply a given format string to all of the elements in a vector.\n\t\"\"\"\nfunction add_string(list_::Vector{Any}, string::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_string;\n\t@test(candidate([1, 2, 3, 4], \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\n\t@test(candidate([5, 6, 7, 8], \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the surface area of a square jlramid with a given base edge and height.\n\t\"\"\"\nfunction surface_Area(b::Int64, s::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surface_Area;\n\t@test(candidate(3, 4) == 33)\n\t@test(candidate(4, 5) == 56)\n\t@test(candidate(1, 2) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the smallest vector in a vector of vectors.\n\t\"\"\"\nfunction Find_Min_Length(lst::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min_Length;\n\t@test(candidate([[1], [1, 2]]) == 1)\n\t@test(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\n\t@test(candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\nfunction validate(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = validate;\n\t@test(candidate(1234) == true)\n\t@test(candidate(51241) == false)\n\t@test(candidate(321) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\nfunction hexagonal_num(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = hexagonal_num;\n\t@test(candidate(10) == 190)\n\t@test(candidate(5) == 45)\n\t@test(candidate(7) == 91)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\nfunction find_lucas(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lucas;\n\t@test(candidate(9) == 76)\n\t@test(candidate(4) == 7)\n\t@test(candidate(3) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to get the difference between two vectors.\n\t\"\"\"\nfunction Diff(li1::Vector{Int64}, li2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Diff;\n\t@test(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15])\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\nfunction extract_quotation(text1::String)::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_quotation;\n\t@test(candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\n\t@test(candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\n\t@test(candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\n\t@test(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to flatten a vector and sum all of its elements.\n\t\"\"\"\nfunction recursive_list_sum(data_list::Vector{Union{Int64, Vector{Int64}}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = recursive_list_sum;\n\t@test(candidate([1, 2, [3, 4], [5, 6]]) == 21)\n\t@test(candidate([7, 10, [15, 14], [19, 41]]) == 106)\n\t@test(candidate([10, 20, [30, 40], [50, 60]]) == 210)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\nfunction differ_At_One_Bit_Pos(a::Int64, b::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = differ_At_One_Bit_Pos;\n\t@test(candidate(13, 9) == true)\n\t@test(candidate(15, 8) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(2, 3) == true)\n\t@test(candidate(5, 1) == true)\n\t@test(candidate(1, 5) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\nfunction text_match_three(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"caacabbbba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\n\t\"\"\"\nfunction max_product(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product;\n\t@test(candidate([3, 100, 4, 5, 150, 6]) == 3000)\n\t@test(candidate([4, 42, 55, 68, 80]) == 50265600)\n\t@test(candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to split a vector at the nth eelment and add the first part to the end.\n\t\"\"\"\nfunction split_Arr(l::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split_Arr;\n\t@test(candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10])\n\t@test(candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1])\n\t@test(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the number of divisors of a given integer.\n\t\"\"\"\nfunction divisor(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = divisor;\n\t@test(candidate(15) == 4)\n\t@test(candidate(12) == 6)\n\t@test(candidate(9) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the difference between largest and smallest value in a given vector.\n\t\"\"\"\nfunction big_diff(nums::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = big_diff;\n\t@test(candidate([1, 2, 3, 4]) == 3)\n\t@test(candidate([4, 5, 12]) == 8)\n\t@test(candidate([9, 2, 3]) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find squares of individual elements in a vector.\n\t\"\"\"\nfunction square_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30]) == [100, 400, 900])\n\t@test(candidate([12, 15]) == [144, 225])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\nfunction check_none(test_tup::Any)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_none;\n\t@test(candidate((10, 4, 5, 6, nothing)) == true)\n\t@test(candidate((7, 8, 9, 11, 14)) == false)\n\t@test(candidate((1, 2, 3, 4, nothing)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given vector is monotonic or not.\n\t\"\"\"\nfunction is_Monotonic(A::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Monotonic;\n\t@test(candidate([6, 5, 4, 4]) == true)\n\t@test(candidate([1, 2, 2, 3]) == true)\n\t@test(candidate([1, 3, 2]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\nfunction is_perfect_square(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_perfect_square;\n\t@test(candidate(10) == false)\n\t@test(candidate(36) == true)\n\t@test(candidate(14) == false)\n\t@test(candidate(196) == true)\n\t@test(candidate(125) == false)\n\t@test(candidate(15625) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of common divisors of two given numbers.\n\t\"\"\"\nfunction sum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum;\n\t@test(candidate(10, 15) == 6)\n\t@test(candidate(100, 150) == 93)\n\t@test(candidate(4, 6) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the vector of maximum length in a vector of vectors.\n\t\"\"\"\nfunction max_length(list1::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\n\t@test(candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\nfunction parabola_directrix(a::Int64, b::Int64, c::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = parabola_directrix;\n\t@test(candidate(5, 3, 2) == -198)\n\t@test(candidate(9, 8, 4) == -2336)\n\t@test(candidate(2, 4, 6) == -130)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return nothing if there is no match.\n\t\"\"\"\nfunction occurance_substring(text::String, pattern::String)::Union{Tuple{String, Int64, Int64}, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = occurance_substring;\n\t@test(candidate(\"python programming, python language\", \"python\") == (\"python\", 0, 6))\n\t@test(candidate(\"python programming,programming language\", \"programming\") == (\"programming\", 7, 18))\n\t@test(candidate(\"python programming,programming language\", \"language\") == (\"language\", 31, 39))\n\t@test(candidate(\"c++ programming, c++ language\", \"python\") == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\nfunction remove_nested(test_tup::Any)::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_nested;\n\t@test(candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\n\t@test(candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\n\t@test(candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\n\t@test(candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort each subvector of strings in a given vector of vectors.\n\t\"\"\"\nfunction sort_sublists(input_list::Vector{Vector{String}})::Vector{Vector{String}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\n\t@test(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\n\t\"\"\"\nfunction remove_kth_element(list1::Vector{Int64}, L::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_kth_element;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1])\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\nfunction add_dict_to_tuple(test_tup::Tuple{Int64, Int64, Int64}, test_dict::Dict{String, Int64}>)::Tuple{Int64, Int64, Int64, Dict{String, Int64}>} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_dict_to_tuple;\n\t@test(candidate((4, 5, 6), Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) == (4, 5, 6, Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)))\n\t@test(candidate((1, 2, 3), Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) == (1, 2, 3, Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)))\n\t@test(candidate((8, 9, 10), Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) == (8, 9, 10, Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\nfunction find(n::Int64, m::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find;\n\t@test(candidate(10, 3) == 3)\n\t@test(candidate(4, 2) == 2)\n\t@test(candidate(20, 5) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\nfunction text_match_two_three(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_two_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the occurence of all elements of vector in a tuple.\n\t\"\"\"\nfunction count_Occurrence(tup::Any, lst::Vector{Any})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Occurrence;\n\t@test(candidate((\"a\", \"a\", \"c\", \"b\", \"d\"), [\"a\", \"b\"]) == 3)\n\t@test(candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6)\n\t@test(candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count number items that are identical in the same position of three given vectors.\n\t\"\"\"\nfunction count_samepair(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_samepair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\nfunction text_match_one(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abba\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\nfunction difference(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = difference;\n\t@test(candidate(3) == 30)\n\t@test(candidate(5) == 210)\n\t@test(candidate(2) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\nfunction toggle_string(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_string;\n\t@test(candidate(\"Python\") == \"pYTHON\")\n\t@test(candidate(\"Pangram\") == \"pANGRAM\")\n\t@test(candidate(\"LIttLE\") == \"liTTle\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the element of a vector having maximum length.\n\t\"\"\"\nfunction Find_Max(lst::Vector{Vector{Any}})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max;\n\t@test(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\n\t@test(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\nfunction eulerian_num(n::Int64, m::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = eulerian_num;\n\t@test(candidate(3, 1) == 4)\n\t@test(candidate(4, 1) == 11)\n\t@test(candidate(5, 3) == 26)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of occurrences of a number in a given vector.\n\t\"\"\"\nfunction frequency(a::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency;\n\t@test(candidate([1, 2, 3], 4) == 0)\n\t@test(candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3)\n\t@test(candidate([0, 1, 2, 3, 1, 2], 1) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/jlthon-sort-numeric-strings-in-a-vector/\n\t\"\"\"\nfunction sort_numeric_strings(nums_str::Vector{String})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numeric_strings;\n\t@test(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\n\t@test(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\n\t@test(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/jlthon-exercises/data-structures-and-algorithms/jlthon-recursion-exercise-9.php\n\t\"\"\"\nfunction geometric_sum(n::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = geometric_sum;\n\t@test(candidate(7) == 1.9921875)\n\t@test(candidate(4) == 1.9375)\n\t@test(candidate(8) == 1.99609375)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/jlthon-exercises/lambda/jlthon-lambda-exercise-24.php\n\t\"\"\"\nfunction divisible_by_digits(startnum::Int64, endnum::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = divisible_by_digits;\n\t@test(candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\n\t@test(candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\n\t@test(candidate(20, 25) == [22, 24])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to calculate the product of the unique numbers in a given vector.\n\t\"\"\"\nfunction unique_product(list_data::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_product;\n\t@test(candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\n\t@test(candidate([1, 2, 3, 1]) == 6)\n\t@test(candidate([7, 8, 9, 0, 1, 1]) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the largest negative number from the given vector.\n\t\"\"\"\nfunction largest_neg(list1::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_neg;\n\t@test(candidate([1, 2, 3, -4, -6]) == -6)\n\t@test(candidate([1, 2, 3, -8, -9]) == -9)\n\t@test(candidate([1, 2, 3, 4, -1]) == -1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove consecutive duplicates of a given vector.\n\t\"\"\"\nfunction consecutive_duplicates(nums::Vector{Any})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\nfunction min_Jumps(steps::Tuple{Int64, Int64}, d::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Jumps;\n\t@test(candidate((3, 4), 11) == 3.5)\n\t@test(candidate((3, 4), 0) == 0)\n\t@test(candidate((11, 14), 11) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find a pair with highest product from a given vector of integers.\n\t\"\"\"\nfunction max_Product(arr::Vector{Int64})::Tuple{Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Product;\n\t@test(candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\n\t@test(candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\n\t@test(candidate([1, 2, 3]) == (2, 3))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the nth element from a given vector of tuples.\n\t\"\"\"\nfunction extract_nth_element(list1::Vector{Tuple{String, Int64, Int64}}, n::Int64)::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_nth_element;\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 2) == [99, 96, 94, 98])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 1) == [98, 97, 91, 94])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\nfunction is_nonagonal(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nonagonal;\n\t@test(candidate(10) == 325)\n\t@test(candidate(15) == 750)\n\t@test(candidate(18) == 1089)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the maximum difference between any two elements in a given vector.\n\t\"\"\"\nfunction max_Abs_Diff(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Abs_Diff;\n\t@test(candidate([2, 1, 5, 3]) == 4)\n\t@test(candidate([9, 3, 2, 5, 1]) == 8)\n\t@test(candidate([3, 2, 1]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to pack consecutive duplicates of a given vector elements into subvectors.\n\t\"\"\"\nfunction pack_consecutive_duplicates(list1::Vector{Any})::Vector{Vector{Any}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pack_consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\nfunction cal_sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = cal_sum;\n\t@test(candidate(9) == 49)\n\t@test(candidate(10) == 66)\n\t@test(candidate(11) == 88)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to remove the characters which have odd index values of a given string.\n\t\"\"\"\nfunction odd_values_string(str::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_values_string;\n\t@test(candidate(\"abcdef\") == \"ace\")\n\t@test(candidate(\"python\") == \"pto\")\n\t@test(candidate(\"data\") == \"dt\")\n\t@test(candidate(\"lambs\") == \"lms\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find kth element from the given two sorted vectors.\n\t\"\"\"\nfunction find_kth(arr1::Vector{Int64}, arr2::Vector{Int64}, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_kth;\n\t@test(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6)\n\t@test(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256)\n\t@test(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\nfunction jacobsthal_num(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = jacobsthal_num;\n\t@test(candidate(5) == 11)\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 5)\n\t@test(candidate(13) == 2731)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find frequency of each element in a flattened vector of vectors, returned in a dictionary.\n\t\"\"\"\nfunction frequency_lists(list1::Vector{Vector{Int64}})::Dict{Int64, Int64}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency_lists;\n\t@test(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == Dict(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1))\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == Dict(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1))\n\t@test(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == Dict(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\nfunction perfect_squares(a::Int64, b::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = perfect_squares;\n\t@test(candidate(1, 30) == [1, 4, 9, 16, 25])\n\t@test(candidate(50, 100) == [64, 81, 100])\n\t@test(candidate(100, 200) == [100, 121, 144, 169, 196])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\n\t\"\"\"\nfunction sum_Of_Subarray_Prod(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_Subarray_Prod;\n\t@test(candidate([1, 2, 3]) == 20)\n\t@test(candidate([1, 2]) == 5)\n\t@test(candidate([1, 2, 3, 4]) == 84)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first odd number in a given vector of numbers.\n\t\"\"\"\nfunction first_odd(nums::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = first_odd;\n\t@test(candidate([1, 3, 5]) == 1)\n\t@test(candidate([2, 4, 1, 3]) == 1)\n\t@test(candidate([8, 9, 1]) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform index wise addition of vector elements in the given two nested vectors.\n\t\"\"\"\nfunction add_nested_tuples(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_nested_tuples;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of vectors, where each subvector has two elements, and returns a vector of two vectors where the first vector has the first element of each subvector and the second one has the second.\n\t\"\"\"\nfunction merge(lst::Vector{Vector{Any}})::Vector{Vector{Any}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge;\n\t@test(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\n\t@test(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\n\t@test(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\nfunction dif_Square(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = dif_Square;\n\t@test(candidate(5) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(15) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\nfunction check_smaller(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_smaller;\n\t@test(candidate((1, 2, 3), (2, 3, 4)) == false)\n\t@test(candidate((4, 5, 6), (3, 4, 5)) == true)\n\t@test(candidate((11, 12, 13), (10, 11, 12)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to get the frequency of all the elements in a vector, returned as a dictionary.\n\t\"\"\"\nfunction freq_count(list1::Vector{Int64})::Dict{Int64, Int64}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = freq_count;\n\t@test(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == Dict(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1))\n\t@test(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == Dict(1 => 3, 2 => 2, 3 => 3, 4 => 3))\n\t@test(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == Dict(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\nfunction rgb_to_hsv(r::Int64, g::Int64, b::Int64)::Vector{Float64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rgb_to_hsv;\n\t@test(candidate(255, 255, 255) == [0.0, 0.0, 100.0])\n\t@test(candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608])\n\t@test(candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to flatten a given nested vector structure.\n\t\"\"\"\nfunction flatten_list(list1::Vector{Union{Int64, Vector{Int64}}})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = flatten_list;\n\t@test(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\n\t@test(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\nfunction check_str(string::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_str;\n\t@test(candidate(\"annie\") == true)\n\t@test(candidate(\"dawood\") == false)\n\t@test(candidate(\"Else\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\nfunction check_monthnumber_number(monthnum3::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumber_number;\n\t@test(candidate(6) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(12) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort the given vector.\n\t\"\"\"\nfunction heap_sort(iterable::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_sort;\n\t@test(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\n\t@test(candidate([7, 1, 9, 5]) == [1, 5, 7, 9])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\n\t\"\"\"\nfunction k_smallest_pairs(nums1::Vector{Int64}, nums2::Vector{Int64}, k::Int64)::Vector{Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = k_smallest_pairs;\n\t@test(candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return nothing if no solution exists.\n\t\"\"\"\nfunction find_solution(a::Int64, b::Int64, n::Int64)::Union{Tuple{Int64, Int64}, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_solution;\n\t@test(candidate(2, 3, 7) == (2, 1))\n\t@test(candidate(4, 2, 7) == nothing)\n\t@test(candidate(1, 13, 17) == (4, 1))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the largest number that can be formed with the given vector of digits.\n\t\"\"\"\nfunction find_Max_Num(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Max_Num;\n\t@test(candidate([1, 2, 3]) == 321)\n\t@test(candidate([4, 5, 6, 1]) == 6541)\n\t@test(candidate([1, 2, 3, 9]) == 9321)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns the vector in a vector of vectors whose sum of elements is the highest.\n\t\"\"\"\nfunction max_sum_list(lists::Vector{Vector{Int64}})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_list;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\n\t@test(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\n\t@test(candidate([[2, 3, 1]]) == [2, 3, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to interchange the first and last elements in a vector.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median of two sorted vectors of same size.\n\t\"\"\"\nfunction get_median(arr1::Vector{Int64}, arr2::Vector{Int64}, n::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_median;\n\t@test(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0)\n\t@test(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5)\n\t@test(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\nfunction replace_spaces(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\n\t@test(candidate(\"The_Avengers\") == \"The Avengers\")\n\t@test(candidate(\"Fast and Furious\") == \"Fast_and_Furious\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\nfunction are_equivalent(num1::Int64, num2::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = are_equivalent;\n\t@test(candidate(36, 57) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(23, 47) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to reverse each string in a given vector of string values.\n\t\"\"\"\nfunction reverse_string_list(stringlist::Vector{String})::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_string_list;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\n\t@test(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\n\t@test(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to compute the sum of digits of each number of a given vector.\n\t\"\"\"\nfunction sum_of_digits(nums::Vector{Any})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_of_digits;\n\t@test(candidate([10, 2, 56]) == 14)\n\t@test(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\n\t@test(candidate([10, 20, -4, 5, -70]) == 19)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\nfunction sequence(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sequence;\n\t@test(candidate(10) == 6)\n\t@test(candidate(2) == 1)\n\t@test(candidate(3) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the n largest integers from a given vector of numbers, returned in descending order.\n\t\"\"\"\nfunction heap_queue_largest(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_queue_largest;\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\nfunction loss_amount(actual_cost::Int64, sale_amount::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = loss_amount;\n\t@test(candidate(1500, 1200) == 0)\n\t@test(candidate(100, 200) == 100)\n\t@test(candidate(2000, 5000) == 3000)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the union of the elements of two given vectors and output them in sorted order.\n\t\"\"\"\nfunction union_elements(test_tup1::Vector{Int64}, test_tup2::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = union_elements;\n\t@test(candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\n\t@test(candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\n\t@test(candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the longest subvectors.\n\t\"\"\"\nfunction Find_Max_Length(lst::Vector{Vector{Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max_Length;\n\t@test(candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4)\n\t@test(candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3)\n\t@test(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\nfunction remove_parenthesis(items::Vector{String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_parenthesis;\n\t@test(candidate([\"python (chrome)\"]) == \"python\")\n\t@test(candidate([\"string(.abc)\"]) == \"string\")\n\t@test(candidate([\"alpha(num)\"]) == \"alpha\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find whether the parity of a given number is odd.\n\t\"\"\"\nfunction find_Parity(x::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Parity;\n\t@test(candidate(12) == false)\n\t@test(candidate(7) == true)\n\t@test(candidate(10) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\nfunction median_trapezium(base1::Int64, base2::Int64, height::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median_trapezium;\n\t@test(candidate(15, 25, 35) == 20)\n\t@test(candidate(10, 20, 30) == 15)\n\t@test(candidate(6, 9, 4) == 7.5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\nfunction centered_hexagonal_number(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = centered_hexagonal_number;\n\t@test(candidate(10) == 271)\n\t@test(candidate(2) == 7)\n\t@test(candidate(9) == 217)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find number of vectors present in the given vector.\n\t\"\"\"\nfunction find_lists(Input::Vector{Any})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lists;\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\n\t@test(candidate([[1, 2], [3, 4], [5, 6]]) == 3)\n\t@test(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\nfunction get_max_sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_sum;\n\t@test(candidate(60) == 106)\n\t@test(candidate(10) == 12)\n\t@test(candidate(2) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the longest word.\n\t\"\"\"\nfunction len_log(list1::Vector{String})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = len_log;\n\t@test(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7)\n\t@test(candidate([\"a\", \"ab\", \"abc\"]) == 3)\n\t@test(candidate([\"small\", \"big\", \"tall\"]) == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nothing if the angle is larger than 360 degrees.\n\t\"\"\"\nfunction sector_area(r::Int64, a::Int64)::Union{Float64, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sector_area;\n\t@test(candidate(4, 45) == 6.283185307179586)\n\t@test(candidate(9, 45) == 31.808625617596654)\n\t@test(candidate(9, 361) == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether every odd index contains odd numbers of a given vector.\n\t\"\"\"\nfunction odd_position(nums::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_position;\n\t@test(candidate([2, 1, 4, 3, 6, 7, 6, 3]) == true)\n\t@test(candidate([4, 1, 2]) == true)\n\t@test(candidate([1, 2, 3]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to join a vector of multiple integers into a single integer.\n\t\"\"\"\nfunction multiple_to_single(L::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiple_to_single;\n\t@test(candidate([11, 33, 50]) == 113350)\n\t@test(candidate([-1, 2, 3, 4, 5, 6]) == -123456)\n\t@test(candidate([10, 15, 20, 25]) == 10152025)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find whether a number is divisible by 11.\n\t\"\"\"\nfunction is_Diff(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Diff;\n\t@test(candidate(12345) == false)\n\t@test(candidate(1212112) == true)\n\t@test(candidate(1212) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to perform index wise multiplication of vector elements in the given two vectors.\n\t\"\"\"\nfunction index_multiplication(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = index_multiplication;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\nfunction tuple_str_int(test_str::String)::Tuple{Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_str_int;\n\t@test(candidate(\"(7, 8, 9)\") == (7, 8, 9))\n\t@test(candidate(\"(1, 2, 3)\") == (1, 2, 3))\n\t@test(candidate(\"(4, 5, 6)\") == (4, 5, 6))\n\t@test(candidate(\"(7, 81, 19)\") == (7, 81, 19))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\nfunction amicable_numbers_sum(limit::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = amicable_numbers_sum;\n\t@test(candidate(999) == 504)\n\t@test(candidate(9999) == 31626)\n\t@test(candidate(99) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\nfunction remove_odd(str1::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate(\"python\") == \"yhn\")\n\t@test(candidate(\"program\") == \"rga\")\n\t@test(candidate(\"language\") == \"agae\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes as input a vector of numbers (t_1,...,t_{N+1}) and returns a vector of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\nfunction multiply_elements(test_tup::Vector{Int64})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_elements;\n\t@test(candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80])\n\t@test(candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42])\n\t@test(candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135])\n\t@test(candidate([12]) == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\n\t\"\"\"\nfunction count_rotation(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_rotation;\n\t@test(candidate([3, 2, 1]) == 1)\n\t@test(candidate([4, 5, 1, 2, 3]) == 2)\n\t@test(candidate([7, 8, 9, 1, 2, 3]) == 3)\n\t@test(candidate([1, 2, 3]) == 0)\n\t@test(candidate([1, 3, 2]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract the number of unique tuples in the given vector.\n\t\"\"\"\nfunction extract_freq(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_freq;\n\t@test(candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\n\t@test(candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\n\t@test(candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tThe input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\n\t\"\"\"\nfunction count_same_pair(nums1::Vector{Int64}, nums2::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_same_pair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\n\t@test(candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\nfunction power(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = power;\n\t@test(candidate(3, 4) == 81)\n\t@test(candidate(2, 3) == 8)\n\t@test(candidate(5, 5) == 3125)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\nfunction return_sum(dict::Dict{String, Int64}>)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = return_sum;\n\t@test(candidate(Dict(\"a\" => 100, \"b\" => 200, \"c\" => 300)) == 600)\n\t@test(candidate(Dict(\"a\" => 25, \"b\" => 18, \"c\" => 45)) == 88)\n\t@test(candidate(Dict(\"a\" => 36, \"b\" => 39, \"c\" => 49)) == 124)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return a vector of all pairs of consecutive items in a given vector.\n\t\"\"\"\nfunction pair_wise(l1::Vector{Int64})::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_wise;\n\t@test(candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\n\t@test(candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\n\t@test(candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to split a string into characters.\n\t\"\"\"\nfunction split(word::String)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = split;\n\t@test(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\n\t@test(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"])\n\t@test(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\nfunction min_of_three(a::Int64, b::Int64, c::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_of_three;\n\t@test(candidate(10, 20, 0) == 0)\n\t@test(candidate(19, 15, 18) == 15)\n\t@test(candidate(-10, -20, -30) == -30)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\nfunction is_Sum_Of_Powers_Of_Two(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sum_Of_Powers_Of_Two;\n\t@test(candidate(10) == true)\n\t@test(candidate(7) == false)\n\t@test(candidate(14) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\nfunction get_Char(strr::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Char;\n\t@test(candidate(\"abc\") == \"f\")\n\t@test(candidate(\"gfg\") == \"t\")\n\t@test(candidate(\"ab\") == \"c\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\nfunction sum_div(number::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_div;\n\t@test(candidate(8) == 7)\n\t@test(candidate(12) == 16)\n\t@test(candidate(7) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function that returns the number of integer elements in a given vector.\n\t\"\"\"\nfunction count_integer(list1::Vector{Union{Int64, String, Float64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_integer;\n\t@test(candidate([1, 2, \"abc\", 1.2]) == 2)\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([1, 1.2, 4, 5.1]) == 2)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to remove duplicate numbers from a given number of vectors.\n\t\"\"\"\nfunction two_unique_nums(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = two_unique_nums;\n\t@test(candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\n\t@test(candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find whether a given vector of integers contains any duplicate element.\n\t\"\"\"\nfunction test_duplicate(arraynums::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = test_duplicate;\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 4]) == true)\n\t@test(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\nfunction catalan_number(num::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = catalan_number;\n\t@test(candidate(10) == 16796)\n\t@test(candidate(9) == 4862)\n\t@test(candidate(7) == 429)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\nfunction power_base_sum(base::Int64, power::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = power_base_sum;\n\t@test(candidate(2, 100) == 115)\n\t@test(candidate(8, 10) == 37)\n\t@test(candidate(8, 15) == 62)\n\t@test(candidate(3, 3) == 9)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in two vectors and replaces the last element of the first vector with the elements of the second vector.\n\t\"\"\"\nfunction replace_list(list1::Vector{Any}, list2::Vector{Any})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_list;\n\t@test(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\nfunction is_octagonal(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_octagonal;\n\t@test(candidate(5) == 65)\n\t@test(candidate(10) == 280)\n\t@test(candidate(15) == 645)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\nfunction replace_blank(str1::String, char::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_blank;\n\t@test(candidate(\"hello people\", \"@\") == \"hello@people\")\n\t@test(candidate(\"python program language\", \"\\$\") == \"python\\$program\\$language\")\n\t@test(candidate(\"blank space\", \"-\") == \"blank-space\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\nfunction replace_specialchar(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_specialchar;\n\t@test(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\")\n\t@test(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\")\n\t@test(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\nfunction tuple_to_int(nums::Tuple{Int64, Int64, Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_int;\n\t@test(candidate((1, 2, 3)) == 123)\n\t@test(candidate((4, 5, 6)) == 456)\n\t@test(candidate((5, 6, 7)) == 567)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\nfunction otherside_rightangle(w::Int64, h::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = otherside_rightangle;\n\t@test(candidate(7, 8) == 10.63014581273465)\n\t@test(candidate(3, 4) == 5)\n\t@test(candidate(7, 15) == 16.55294535724685)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\nfunction digit_distance_nums(n1::Int64, n2::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = digit_distance_nums;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(23, 56) == 6)\n\t@test(candidate(123, 256) == 7)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\nfunction text_match_wordz_middle(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz_middle;\n\t@test(candidate(\"pythonzabc.\") == true)\n\t@test(candidate(\"zxyabc.\") == false)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\nfunction removezero_ip(ip::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = removezero_ip;\n\t@test(candidate(\"216.08.094.196\") == \"216.8.94.196\")\n\t@test(candidate(\"12.01.024\") == \"12.1.24\")\n\t@test(candidate(\"216.08.094.0196\") == \"216.8.94.196\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count the number of subvectors containing a particular element.\n\t\"\"\"\nfunction count_element_in_list(list1::Vector{Vector{Any}}, x::Any)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_element_in_list;\n\t@test(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\") == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\") == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\nfunction multiply_int(x::Int64, y::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_int;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(5, 10) == 50)\n\t@test(candidate(4, 8) == 32)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\nfunction add_pairwise(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_pairwise;\n\t@test(candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18))\n\t@test(candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20))\n\t@test(candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\n\t\"\"\"\nfunction max_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 200)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4036,7 +18,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find the kth element in the given vector using 1-based indexing.\n\t\"\"\"\nfunction kth_element(arr::Vector{Int64}, k::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = kth_element;\n\t@test(candidate([12, 3, 5, 7, 19], 2) == 3)\n\t@test(candidate([17, 24, 8, 23], 3) == 8)\n\t@test(candidate([16, 21, 25, 36, 4], 4) == 36)\nend\n",
     "stop_tokens": [
@@ -4046,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to interchange the first and last element in a given vector.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"python_program\") == \"PythonProgram\")\n\t@test(candidate(\"python_language\") == \"PythonLanguage\")\n\t@test(candidate(\"programming_language\") == \"ProgrammingLanguage\")\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4060,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the number of elements that occurs before the vector element in the given tuple.\n\t\"\"\"\nfunction count_first_elements(test_tup::Vector{Union{Int64, Tuple{Int64, Int64}}})::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\nfunction eulerian_num(n::Int64, m::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_first_elements;\n\t@test(candidate([1, 5, 7, (4, 6), 10]) == 3)\n\t@test(candidate([2, 9, (5, 7), 11]) == 2)\n\t@test(candidate([11, 15, 5, 8, (2, 3), 8]) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = eulerian_num;\n\t@test(candidate(3, 1) == 4)\n\t@test(candidate(4, 1) == 11)\n\t@test(candidate(5, 3) == 26)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4074,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\nfunction right_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to sort each subvector of strings in a given vector of vectors.\n\t\"\"\"\nfunction sort_sublists(input_list::Vector{Vector{String}})::Vector{Vector{String}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = right_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\n\t@test(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4088,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\nfunction is_woodall(x::Int64)::Bool \n",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count true booleans in the given vector.\n\t\"\"\"\nfunction count(lst::Vector{Bool})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_woodall;\n\t@test(candidate(383) == true)\n\t@test(candidate(254) == false)\n\t@test(candidate(200) == false)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count;\n\t@test(candidate([true, false, true]) == 2)\n\t@test(candidate([false, false]) == 0)\n\t@test(candidate([true, true, true]) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4102,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort the given vector by using shell sort.\n\t\"\"\"\nfunction shell_sort(my_list::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to append the given vector to the given tuples.\n\t\"\"\"\nfunction add_lists(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Tuple{Int64, Int64, Int64, Int64, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = shell_sort;\n\t@test(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\n\t@test(candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\n\t@test(candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_lists;\n\t@test(candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7))\n\t@test(candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8))\n\t@test(candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4116,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of pairs whose xor value is odd.\n\t\"\"\"\nfunction find_Odd_Pair(A::Vector{Int64}, N::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to merge three vectors into a single sorted vector.\n\t\"\"\"\nfunction merge_sorted_list(num1::Vector{Int64}, num2::Vector{Int64}, num3::Vector{Int64})::Vector{Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Odd_Pair;\n\t@test(candidate([5, 4, 7, 2, 1], 5) == 6)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12)\n\t@test(candidate([1, 2, 3], 3) == 2)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_sorted_list;\n\t@test(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\n\t@test(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\n\t@test(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4130,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\nfunction sum_in_range(l::Int64, r::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\nfunction odd_Equivalent(s::String, n::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_in_range;\n\t@test(candidate(2, 5) == 8)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 13) == 40)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_Equivalent;\n\t@test(candidate(\"011001\", 6) == 3)\n\t@test(candidate(\"11011\", 5) == 4)\n\t@test(candidate(\"1010\", 4) == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4144,13 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\nfunction square_perimeter(a::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\nfunction check_integer(text::String)::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_perimeter;\n\t@test(candidate(10) == 40)\n\t@test(candidate(5) == 20)\n\t@test(candidate(4) == 16)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_integer;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"1\") == true)\n\t@test(candidate(\"12345\") == true)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4158,209 +140,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\nfunction is_polite(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\nfunction tuple_to_int(nums::Tuple{Int64, Int64, Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_polite;\n\t@test(candidate(7) == 11)\n\t@test(candidate(4) == 7)\n\t@test(candidate(9) == 13)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\nfunction sum_series(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_series;\n\t@test(candidate(6) == 12)\n\t@test(candidate(10) == 30)\n\t@test(candidate(9) == 25)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\nfunction find_dissimilar(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_dissimilar;\n\t@test(candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10))\n\t@test(candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9))\n\t@test(candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to return two words from a vector of words starting with letter 'p'.\n\t\"\"\"\nfunction start_withp(words::Vector{String})::Tuple{String, String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = start_withp;\n\t@test(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\n\t@test(candidate([\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\n\t@test(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"android_tv\") == \"AndroidTv\")\n\t@test(candidate(\"google_pixel\") == \"GooglePixel\")\n\t@test(candidate(\"apple_watch\") == \"AppleWatch\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\nfunction volume_cube(l::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = volume_cube;\n\t@test(candidate(3) == 27)\n\t@test(candidate(2) == 8)\n\t@test(candidate(5) == 125)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\nfunction check_monthnumb_number(monthnum2::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumb_number;\n\t@test(candidate(5) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(6) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\nfunction all_Bits_Set_In_The_Given_Range(n::Int64, l::Int64, r::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Bits_Set_In_The_Given_Range;\n\t@test(candidate(4, 1, 2) == true)\n\t@test(candidate(17, 2, 4) == true)\n\t@test(candidate(39, 4, 6) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to get the first element of each subvector.\n\t\"\"\"\nfunction Extract(lst::Vector{Vector{Int64}})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Extract;\n\t@test(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\n\t@test(candidate([[1, 2, 3], [4, 5]]) == [1, 4])\n\t@test(candidate([[9, 8, 1], [1, 2]]) == [9, 1])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\nfunction surfacearea_cylinder(r::Int64, h::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cylinder;\n\t@test(candidate(10, 5) == 942.45)\n\t@test(candidate(4, 5) == 226.18800000000002)\n\t@test(candidate(4, 10) == 351.848)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\n\t\"\"\"\nfunction sample_nam(sample_names::Vector{String})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sample_nam;\n\t@test(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\n\t@test(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\n\t@test(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\nfunction rearrange_bigger(n::Int64)::Any \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rearrange_bigger;\n\t@test(candidate(12) == 21)\n\t@test(candidate(10) == false)\n\t@test(candidate(102) == 120)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\nfunction perimeter_pentagon(a::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = perimeter_pentagon;\n\t@test(candidate(5) == 25)\n\t@test(candidate(10) == 50)\n\t@test(candidate(15) == 75)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\nfunction max_sum(arr::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum;\n\t@test(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\n\t@test(candidate([80, 60, 30, 40, 20, 10]) == 210)\n\t@test(candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\nfunction extract_even(test_tuple::Tuple{Int64, Int64, Tuple{Int64, Int64, Tuple{Int64, Int64}}, Int64, Int64})::Any \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_even;\n\t@test(candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\n\t@test(candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\n\t@test(candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_int;\n\t@test(candidate((1, 2, 3)) == 123)\n\t@test(candidate((4, 5, 6)) == 456)\n\t@test(candidate((5, 6, 7)) == 567)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4372,233 +158,9 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to convert all possible convertible elements in a vector of vectors to floats.\n\t\"\"\"\nfunction list_to_float(test_list::Vector{Tuple{String, String}})::Vector{Tuple{Float64, Float64}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = list_to_float;\n\t@test(candidate([(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)])\n\t@test(candidate([(\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)])\n\t@test(candidate([(\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 20)\n\t@test(candidate(3) == 56)\n\t@test(candidate(4) == 120)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\n\t\"\"\"\nfunction get_pairs_count(arr::Vector{Int64}, sum::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_pairs_count;\n\t@test(candidate([1, 1, 1, 1], 2) == 6)\n\t@test(candidate([1, 5, 7, -1, 5], 6) == 3)\n\t@test(candidate([1, -2, 3], 1) == 1)\n\t@test(candidate([-1, -2, 3], -3) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\nfunction count_no_of_ways(n::Int64, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_no_of_ways;\n\t@test(candidate(2, 4) == 16)\n\t@test(candidate(3, 2) == 6)\n\t@test(candidate(4, 4) == 228)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\nfunction reverse_words(s::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_words;\n\t@test(candidate(\"python program\") == \"program python\")\n\t@test(candidate(\"java language\") == \"language java\")\n\t@test(candidate(\"indian man\") == \"man indian\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check if a given number is one less than twice its reverse.\n\t\"\"\"\nfunction checks(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = checks;\n\t@test(candidate(70) == false)\n\t@test(candidate(23) == false)\n\t@test(candidate(73) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last position of an element in a sorted vector.\n\t\"\"\"\nfunction last(arr::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = last;\n\t@test(candidate([1, 2, 3], 1) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, 4], 1) == 2)\n\t@test(candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\n\t\"\"\"\nfunction count_X(tup::Vector{Int64}, x::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_X;\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWe say that an element is common for vectors l1, l2, l3 if it appears in all three vectors under the same index. Write a function to find common elements from three vectors. The function should return a vector.\n\t\"\"\"\nfunction extract_index_list(l1::Vector{Int64}, l2::Vector{Int64}, l3::Vector{Int64})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_index_list;\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\n\t@test(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\n\t@test(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == Vector{Any}([]))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the second smallest number in a vector.\n\t\"\"\"\nfunction second_smallest(numbers::Vector{Union{Int64, Float64}})::Union{Float64, Nothing} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = second_smallest;\n\t@test(candidate([1, 2, -8, -2, 0, -2]) == -2)\n\t@test(candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5)\n\t@test(candidate([2, 2]) == nothing)\n\t@test(candidate([2, 2, 2]) == nothing)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\nfunction concatenate_tuple(test_tup::Tuple{String, String, Int64, String})::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate_tuple;\n\t@test(candidate((\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\n\t@test(candidate((\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\n\t@test(candidate((\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\nfunction replace_spaces(string::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\n\t@test(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\")\n\t@test(candidate(\"I love Coding\") == \"I%20love%20Coding\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the sum of numbers in a vector within a range specified by two indices.\n\t\"\"\"\nfunction sum_range_list(list1::Vector{Int64}, m::Int64, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_range_list;\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\nfunction merge_dictionaries_three(dict1::Dict{String, String}>, dict2::Dict{String, String}>, dict3::Dict{String, String}>)::Dict{String, String}> \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_dictionaries_three;\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) == Dict(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\")) == Dict(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\"), Dict(\"G\" => \"Green\", \"W\" => \"White\")) == Dict(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum of two numbers.\n\t\"\"\"\nfunction minimum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = minimum;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(-5, -4) == -5)\n\t@test(candidate(0, 0) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple vector.\n\t\"\"\"\nfunction max_difference(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_difference;\n\t@test(candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\n\t@test(candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\n\t@test(candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find element at a given index after number of rotations.\n\t\"\"\"\nfunction find_Element(arr::Vector{Int64}, ranges::Vector{Vector{Int64}}, rotations::Int64, index::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Element;\n\t@test(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3)\n\t@test(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4610,7 +172,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to convert a string to a vector of strings split on the space character.\n\t\"\"\"\nfunction string_to_list(string::String)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_list;\n\t@test(candidate(\"python programming\") == [\"python\", \"programming\"])\n\t@test(candidate(\"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"])\n\t@test(candidate(\"write a program\") == [\"write\", \"a\", \"program\"])\nend\n",
     "stop_tokens": [
@@ -4624,23 +186,9 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a jlthon function to find the element that appears only once in a sorted vector.\n\t\"\"\"\nfunction search(arr::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = search;\n\t@test(candidate([1, 1, 2, 2, 3]) == 3)\n\t@test(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8)\n\t@test(candidate([1, 2, 2, 3, 3, 4, 4]) == 1)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\nfunction sort_counter(dict1::Dict{String, Int64}>)::Vector{Tuple{String, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_counter;\n\t@test(candidate(Dict(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\n\t@test(candidate(Dict(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\n\t@test(candidate(Dict(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4652,7 +200,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a jlthon function to remove first and last occurrence of a given character from the string.\n\t\"\"\"\nfunction remove_Occ(s::String, ch::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = remove_Occ;\n\t@test(candidate(\"hello\", \"l\") == \"heo\")\n\t@test(candidate(\"abcda\", \"a\") == \"bcd\")\n\t@test(candidate(\"PHP\", \"P\") == \"H\")\nend\n",
     "stop_tokens": [
@@ -4662,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\nfunction lateralsurface_cube(l::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\n\t\"\"\"\nfunction max_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cube;\n\t@test(candidate(5) == 100)\n\t@test(candidate(9) == 324)\n\t@test(candidate(10) == 400)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 200)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4676,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes two vectors and returns true if they have at least one common element.\n\t\"\"\"\nfunction common_element(list1::Vector{Any}, list2::Vector{Any})::Union{Bool, Nothing} \n",
+    "prompt": "\"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\nfunction amicable_numbers_sum(limit::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = common_element;\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == true)\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == nothing)\n\t@test(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = amicable_numbers_sum;\n\t@test(candidate(999) == 504)\n\t@test(candidate(9999) == 31626)\n\t@test(candidate(99) == 0)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4690,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to append the given vector to the given tuples.\n\t\"\"\"\nfunction add_lists(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Tuple{Int64, Int64, Int64, Int64, Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\nfunction find_length(string::String)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_lists;\n\t@test(candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7))\n\t@test(candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8))\n\t@test(candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_length;\n\t@test(candidate(\"11000010001\") == 6)\n\t@test(candidate(\"10111\") == 1)\n\t@test(candidate(\"11011101100101\") == 2)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4704,13 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to compute the n-th power of each number in a vector.\n\t\"\"\"\nfunction nth_nums(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of common divisors of two given numbers.\n\t\"\"\"\nfunction sum(a::Int64, b::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = nth_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30], 3) == [1000, 8000, 27000])\n\t@test(candidate([12, 15], 5) == [248832, 759375])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum;\n\t@test(candidate(10, 15) == 6)\n\t@test(candidate(100, 150) == 93)\n\t@test(candidate(4, 6) == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -4718,335 +266,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a vector of elements.\n\t\"\"\"\nfunction pancake_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\nfunction multiply_int(x::Int64, y::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = pancake_sort;\n\t@test(candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\n\t@test(candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\n\t@test(candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\nfunction median_numbers(a::Int64, b::Int64, c::Int64)::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = median_numbers;\n\t@test(candidate(25, 55, 65) == 55.0)\n\t@test(candidate(20, 10, 30) == 20.0)\n\t@test(candidate(15, 45, 75) == 45.0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given vector.\n\t\"\"\"\nfunction check_greater(arr::Vector{Int64}, number::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_greater;\n\t@test(candidate([1, 2, 3, 4, 5], 4) == false)\n\t@test(candidate([2, 3, 4, 5, 6], 8) == true)\n\t@test(candidate([9, 7, 4, 8, 6, 1], 11) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and element and checks whether all items in the vector are equal to the given element.\n\t\"\"\"\nfunction check_element(list::Vector{Any}, element::Any)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_element;\n\t@test(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\") == false)\n\t@test(candidate([1, 2, 3, 4], 7) == false)\n\t@test(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\") == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract specified size of strings from a given vector of string values.\n\t\"\"\"\nfunction extract_string(str::Vector{String}, l::Int64)::Vector{String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_string;\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8) == [\"practice\", \"solution\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6) == [\"Python\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9) == [\"exercises\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\nfunction text_lowercase_underscore(text::String)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = text_lowercase_underscore;\n\t@test(candidate(\"aab_cbbbc\") == true)\n\t@test(candidate(\"aab_Abbbc\") == false)\n\t@test(candidate(\"Aaab_abbbc\") == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to trim each vector by k in the given vectors.\n\t\"\"\"\nfunction trim_tuple(test_list::Vector{Vector{Int64}}, K::Int64)::Vector{Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = trim_tuple;\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]])\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\n\t@test(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the subvector having minimum length.\n\t\"\"\"\nfunction Find_Min(lst::Vector{Vector{Any}})::Vector{Any} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min;\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1])\n\t@test(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\n\t@test(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\nfunction filter_oddnumbers(nums::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_oddnumbers;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\n\t@test(candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93])\n\t@test(candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\nfunction find_adverbs(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverbs;\n\t@test(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\n\t@test(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\")\n\t@test(candidate(\"Complete the task quickly\") == \"18-25: quickly\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\n\t\"\"\"\nfunction max_of_nth(test_list::Vector{Vector{Int64}}, N::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_of_nth;\n\t@test(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19)\n\t@test(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10)\n\t@test(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\nfunction decimal_to_binary(n::Int64)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(8) == \"1000\")\n\t@test(candidate(18) == \"10010\")\n\t@test(candidate(7) == \"111\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\n\t\"\"\"\nfunction combinations_colors(l::Vector{String}, n::Int64)::Vector{Vector{String}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = combinations_colors;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\nfunction remove_all_spaces(text::String)::String \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_all_spaces;\n\t@test(candidate(\"python  program\") == \"pythonprogram\")\n\t@test(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\")\n\t@test(candidate(\"python                     program\") == \"pythonprogram\")\n\t@test(candidate(\"   python                     program\") == \"pythonprogram\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\nfunction min_Swaps(str1::String, str2::String)::Any \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Swaps;\n\t@test(candidate(\"1101\", \"1110\") == 1)\n\t@test(candidate(\"111\", \"000\") == \"Not Possible\")\n\t@test(candidate(\"111\", \"110\") == \"Not Possible\")\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to create a new tuple from the given string and vector.\n\t\"\"\"\nfunction new_tuple(test_list::Vector{String}, test_str::String)::Tuple{String, String, String} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = new_tuple;\n\t@test(candidate([\"WEB\", \"is\"], \"best\") == (\"WEB\", \"is\", \"best\"))\n\t@test(candidate([\"We\", \"are\"], \"Developers\") == (\"We\", \"are\", \"Developers\"))\n\t@test(candidate([\"Part\", \"is\"], \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the product of the vector multiplication modulo n.\n\t\"\"\"\nfunction find_remainder(arr::Vector{Int64}, n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_remainder;\n\t@test(candidate([100, 10, 5, 25, 35, 14], 11) == 9)\n\t@test(candidate([1, 1, 1], 1) == 0)\n\t@test(candidate([1, 2, 1], 2) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous vector.\n\t\"\"\"\nfunction min_val(listval::Vector{Union{String, Int64}})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 2)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 15)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 20)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the ration of positive numbers in a vector of integers.\n\t\"\"\"\nfunction positive_count(nums::Vector{Int64})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = positive_count;\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\n\t@test(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to add the given tuple to the given vector.\n\t\"\"\"\nfunction add_tuple(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = add_tuple;\n\t@test(candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10])\n\t@test(candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11])\n\t@test(candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\nfunction max_run_uppercase(test_str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_run_uppercase;\n\t@test(candidate(\"GeMKSForGERksISBESt\") == 5)\n\t@test(candidate(\"PrECIOusMOVemENTSYT\") == 6)\n\t@test(candidate(\"GooGLEFluTTER\") == 4)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\nfunction sort_matrix(M::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_matrix;\n\t@test(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\n\t@test(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\n\t@test(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\nfunction count_vowels(test_str::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_vowels;\n\t@test(candidate(\"bestinstareels\") == 7)\n\t@test(candidate(\"partofthejourneyistheend\") == 12)\n\t@test(candidate(\"amazonprime\") == 5)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\nfunction max_sum_increasing_subseq(a::Vector{Int64}, n::Int64, index::Int64, k::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_increasing_subseq;\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11)\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7)\n\t@test(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_int;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(5, 10) == 50)\n\t@test(candidate(4, 8) == 32)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5058,7 +284,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find words that are longer than n characters from a given vector of words.\n\t\"\"\"\nfunction long_words(n::Int64, str::String)::Vector{String} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = long_words;\n\t@test(candidate(3, \"python is a programming language\") == [\"python\", \"programming\", \"language\"])\n\t@test(candidate(2, \"writing a program\") == [\"writing\", \"program\"])\n\t@test(candidate(5, \"sorting list\") == [\"sorting\"])\nend\n",
     "stop_tokens": [
@@ -5068,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of non-repeated elements in a given vector.\n\t\"\"\"\nfunction find_sum(arr::Vector{Int64})::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\nfunction magic_square_test(my_matrix::Vector{Vector{Int64}})::Bool \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_sum;\n\t@test(candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21)\n\t@test(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\n\t@test(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = magic_square_test;\n\t@test(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\n\t@test(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5082,13 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/jlthon-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\nfunction tuple_to_dict(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64, Int64})::Dict{Int64, Int64}> \n",
+    "prompt": "\"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\nfunction sort_matrix(M::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_dict;\n\t@test(candidate((1, 5, 7, 10, 13, 5)) == Dict(1 => 5, 7 => 10, 13 => 5))\n\t@test(candidate((1, 2, 3, 4, 5, 6)) == Dict(1 => 2, 3 => 4, 5 => 6))\n\t@test(candidate((7, 8, 9, 10, 11, 12)) == Dict(7 => 8, 9 => 10, 11 => 12))\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_matrix;\n\t@test(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\n\t@test(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\n\t@test(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5096,209 +322,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\nfunction get_coordinates(test_tup::Tuple{Int64, Int64})::Vector{Vector{Int64}} \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the item with maximum frequency in a given vector.\n\t\"\"\"\nfunction max_occurrences(nums::Vector{Int64})::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = get_coordinates;\n\t@test(candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\n\t@test(candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\n\t@test(candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\nfunction check_type(test_tuple::Any)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_type;\n\t@test(candidate((5, 6, 7, 3, 5, 6)) == true)\n\t@test(candidate((1, 2, \"4\")) == false)\n\t@test(candidate((3, 2, 1, 4, 5)) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the smallest missing number from a sorted vector of natural numbers.\n\t\"\"\"\nfunction find_First_Missing(array::Vector{Int64})::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_First_Missing;\n\t@test(candidate([0, 1, 2, 3]) == 4)\n\t@test(candidate([0, 1, 2, 6, 9]) == 3)\n\t@test(candidate([2, 3, 5, 8, 9]) == 0)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\nfunction is_undulating(n::Int64)::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_undulating;\n\t@test(candidate(1212121) == true)\n\t@test(candidate(1991) == false)\n\t@test(candidate(121) == true)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/jlthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cojl of test cases\n\t\"\"\"\nfunction min_k(test_list::Vector{Tuple{String, Int64}}, K::Int64)::Vector{Tuple{String, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = min_k;\n\t@test(candidate([(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\n\t@test(candidate([(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\n\t@test(candidate([(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], 1) == [(\"Ayesha\", 9)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\nfunction count_Substrings(s::String)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Substrings;\n\t@test(candidate(\"112112\") == 6)\n\t@test(candidate(\"111\") == 6)\n\t@test(candidate(\"1101112\") == 12)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\nfunction is_num_decagonal(n::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_num_decagonal;\n\t@test(candidate(3) == 27)\n\t@test(candidate(7) == 175)\n\t@test(candidate(10) == 370)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\n\t\"\"\"\nfunction rear_extract(test_list::Vector{Tuple{Int64, String, Int64}})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = rear_extract;\n\t@test(candidate([(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\n\t@test(candidate([(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\n\t@test(candidate([(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\nfunction closest_num(N::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_num;\n\t@test(candidate(11) == 10)\n\t@test(candidate(7) == 6)\n\t@test(candidate(12) == 11)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/jlthon-combinations-of-sum-with-tuples-in-tuple-vector/\n\t\"\"\"\nfunction find_combinations(test_list::Vector{Tuple{Int64, Int64}})::Vector{Tuple{Int64, Int64}} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_combinations;\n\t@test(candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\n\t@test(candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\n\t@test(candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tGiven a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\nfunction maxAverageOfPath(cost::Vector{Vector{Int64}})::Float64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maxAverageOfPath;\n\t@test(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\n\t@test(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\n\t@test(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\nfunction sequential_search(dlist::Vector{Int64}, item::Int64)::Tuple{Bool, Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sequential_search;\n\t@test(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (true, 3))\n\t@test(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (true, 7))\n\t@test(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (true, 6))\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to remove odd numbers from a given vector.\n\t\"\"\"\nfunction remove_odd(l::Vector{Int64})::Vector{Int64} \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate([1, 2, 3]) == [2])\n\t@test(candidate([2, 4, 6]) == [2, 4, 6])\n\t@test(candidate([10, 20, 3]) == [10, 20])\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the product of numbers in a vector is even or not.\n\t\"\"\"\nfunction is_product_even(arr::Vector{Int64})::Bool \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = is_product_even;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 4]) == true)\n\t@test(candidate([1, 1]) == false)\nend\n",
-    "stop_tokens": [
-      "\nfunction",
-      "\nmacro",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the maximum of two numbers.\n\t\"\"\"\nfunction maximum(a::Int64, b::Int64)::Int64 \n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate(5, 10) == 10)\n\t@test(candidate(-1, -2) == -1)\n\t@test(candidate(9, 7) == 9)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_occurrences;\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\n\t@test(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\n\t@test(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5310,9 +340,695 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a jlthon function to reverse only the vowels of a given string (where y is not a vowel).\n\t\"\"\"\nfunction reverse_vowels(str1::String)::String \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_vowels;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"USA\") == \"ASU\")\n\t@test(candidate(\"ab\") == \"ab\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a vector to a string.\n\t\"\"\"\nfunction tup_string(tup1::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tup_string;\n\t@test(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\n\t@test(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given vector of numbers.\n\t\"\"\"\nfunction sum_negativenum(nums::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_negativenum;\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\n\t@test(candidate([10, 15, -14, 13, -18, 12, -20]) == -52)\n\t@test(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\nfunction hexagonal_num(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = hexagonal_num;\n\t@test(candidate(10) == 190)\n\t@test(candidate(5) == 45)\n\t@test(candidate(7) == 91)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\nfunction is_Sum_Of_Powers_Of_Two(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sum_Of_Powers_Of_Two;\n\t@test(candidate(10) == true)\n\t@test(candidate(7) == false)\n\t@test(candidate(14) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a vector of elements.\n\t\"\"\"\nfunction pancake_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pancake_sort;\n\t@test(candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\n\t@test(candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\n\t@test(candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count number items that are identical in the same position of three given vectors.\n\t\"\"\"\nfunction count_samepair(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_samepair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find number of vectors present in the given vector.\n\t\"\"\"\nfunction find_lists(Input::Vector{Any})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lists;\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\n\t@test(candidate([[1, 2], [3, 4], [5, 6]]) == 3)\n\t@test(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the maximum difference between any two elements in a given vector.\n\t\"\"\"\nfunction max_Abs_Diff(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Abs_Diff;\n\t@test(candidate([2, 1, 5, 3]) == 4)\n\t@test(candidate([9, 3, 2, 5, 1]) == 8)\n\t@test(candidate([3, 2, 1]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the volume of a triangular prism.\n\t\"\"\"\nfunction find_Volume(l::Int64, b::Int64, h::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Volume;\n\t@test(candidate(10, 8, 6) == 240)\n\t@test(candidate(3, 2, 2) == 6)\n\t@test(candidate(1, 2, 1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return nothing if no solution exists.\n\t\"\"\"\nfunction find_solution(a::Int64, b::Int64, n::Int64)::Union{Tuple{Int64, Int64}, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_solution;\n\t@test(candidate(2, 3, 7) == (2, 1))\n\t@test(candidate(4, 2, 7) == nothing)\n\t@test(candidate(1, 13, 17) == (4, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all elements from a given vector present in another vector.\n\t\"\"\"\nfunction remove_elements(list1::Vector{Int64}, list2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_elements;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\nfunction sum_series(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_series;\n\t@test(candidate(6) == 12)\n\t@test(candidate(10) == 30)\n\t@test(candidate(9) == 25)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\nfunction are_equivalent(num1::Int64, num2::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = are_equivalent;\n\t@test(candidate(36, 57) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(23, 47) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\nfunction count_char_position(str1::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_char_position;\n\t@test(candidate(\"xbcefg\") == 2)\n\t@test(candidate(\"ABcED\") == 3)\n\t@test(candidate(\"AbgdeF\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that counts the number of pairs of integers in a vector that xor to an even number.\n\t\"\"\"\nfunction find_even_pair(A::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_even_pair;\n\t@test(candidate([5, 4, 7, 2, 1]) == 4)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11]) == 9)\n\t@test(candidate([1, 2, 3]) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\nfunction next_power_of_2(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_power_of_2;\n\t@test(candidate(0) == 1)\n\t@test(candidate(5) == 8)\n\t@test(candidate(17) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of occurrences of a number in a given vector.\n\t\"\"\"\nfunction frequency(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency;\n\t@test(candidate([1, 2, 3], 4) == 0)\n\t@test(candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3)\n\t@test(candidate([0, 1, 2, 3, 1, 2], 1) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\nfunction text_lowercase_underscore(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_lowercase_underscore;\n\t@test(candidate(\"aab_cbbbc\") == true)\n\t@test(candidate(\"aab_Abbbc\") == false)\n\t@test(candidate(\"Aaab_abbbc\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the sum of numbers in a vector within a range specified by two indices.\n\t\"\"\"\nfunction sum_range_list(list1::Vector{Int64}, m::Int64, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_range_list;\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16)\n\t@test(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\nfunction perimeter_pentagon(a::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = perimeter_pentagon;\n\t@test(candidate(5) == 25)\n\t@test(candidate(10) == 50)\n\t@test(candidate(15) == 75)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\nfunction count_occurance(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_occurance;\n\t@test(candidate(\"letstdlenstdporstd\") == 3)\n\t@test(candidate(\"truststdsolensporsd\") == 1)\n\t@test(candidate(\"makestdsostdworthit\") == 2)\n\t@test(candidate(\"stds\") == 1)\n\t@test(candidate(\"\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\nfunction square_perimeter(a::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_perimeter;\n\t@test(candidate(10) == 40)\n\t@test(candidate(5) == 20)\n\t@test(candidate(4) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\nfunction remove_dirty_chars(string::String, second_string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_dirty_chars;\n\t@test(candidate(\"probasscurve\", \"pros\") == \"bacuve\")\n\t@test(candidate(\"digitalindia\", \"talent\") == \"digiidi\")\n\t@test(candidate(\"exoticmiles\", \"toxic\") == \"emles\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find whether a given vector of integers contains any duplicate element.\n\t\"\"\"\nfunction test_duplicate(arraynums::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = test_duplicate;\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\n\t@test(candidate([1, 2, 3, 4, 4]) == true)\n\t@test(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\nfunction is_woodall(x::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_woodall;\n\t@test(candidate(383) == true)\n\t@test(candidate(254) == false)\n\t@test(candidate(200) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\nfunction check_type(test_tuple::Any)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_type;\n\t@test(candidate((5, 6, 7, 3, 5, 6)) == true)\n\t@test(candidate((1, 2, \"4\")) == false)\n\t@test(candidate((3, 2, 1, 4, 5)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\nfunction is_majority(arr::Vector{Int64}, n::Int64, x::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_majority;\n\t@test(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == true)\n\t@test(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == false)\n\t@test(candidate([1, 1, 1, 2, 2], 5, 1) == true)\n\t@test(candidate([1, 1, 2, 2], 5, 1) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\nfunction count_Set_Bits(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Set_Bits;\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 1)\n\t@test(candidate(6) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to remove the characters which have odd index values of a given string.\n\t\"\"\"\nfunction odd_values_string(str::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_values_string;\n\t@test(candidate(\"abcdef\") == \"ace\")\n\t@test(candidate(\"python\") == \"pto\")\n\t@test(candidate(\"data\") == \"dt\")\n\t@test(candidate(\"lambs\") == \"lms\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\nfunction min_of_three(a::Int64, b::Int64, c::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_of_three;\n\t@test(candidate(10, 20, 0) == 0)\n\t@test(candidate(19, 15, 18) == 15)\n\t@test(candidate(-10, -20, -30) == -30)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\nfunction all_Bits_Set_In_The_Given_Range(n::Int64, l::Int64, r::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Bits_Set_In_The_Given_Range;\n\t@test(candidate(4, 1, 2) == true)\n\t@test(candidate(17, 2, 4) == true)\n\t@test(candidate(39, 4, 6) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\nfunction re_arrange_array(arr::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = re_arrange_array;\n\t@test(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\n\t@test(candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15])\n\t@test(candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\nfunction replace_blank(str1::String, char::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_blank;\n\t@test(candidate(\"hello people\", \"@\") == \"hello@people\")\n\t@test(candidate(\"python program language\", \"\\$\") == \"python\\$program\\$language\")\n\t@test(candidate(\"blank space\", \"-\") == \"blank-space\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\nfunction volume_cube(l::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = volume_cube;\n\t@test(candidate(3) == 27)\n\t@test(candidate(2) == 8)\n\t@test(candidate(5) == 125)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of non-empty substrings of a given string.\n\t\"\"\"\nfunction number_of_substrings(str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = number_of_substrings;\n\t@test(candidate(\"abc\") == 6)\n\t@test(candidate(\"abcd\") == 10)\n\t@test(candidate(\"abcde\") == 15)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\nfunction get_total_number_of_sequences(m::Int64, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_total_number_of_sequences;\n\t@test(candidate(10, 4) == 4)\n\t@test(candidate(5, 2) == 6)\n\t@test(candidate(16, 3) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two vectors and replaces the last element of the first vector with the elements of the second vector.\n\t\"\"\"\nfunction replace_list(list1::Vector{Any}, list2::Vector{Any})::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_list;\n\t@test(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\nfunction count_charac(str1::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_charac;\n\t@test(candidate(\"python programming\") == 18)\n\t@test(candidate(\"language\") == 8)\n\t@test(candidate(\"words\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the next perfect square greater than a given number.\n\t\"\"\"\nfunction next_Perfect_Square(N::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = next_Perfect_Square;\n\t@test(candidate(35) == 36)\n\t@test(candidate(6) == 9)\n\t@test(candidate(9) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\nfunction max_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum;\n\t@test(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\n\t@test(candidate([80, 60, 30, 40, 20, 10]) == 210)\n\t@test(candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\nfunction lps(str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lps;\n\t@test(candidate(\"TENS FOR TENS\") == 5)\n\t@test(candidate(\"CARDIO FOR CARDS\") == 7)\n\t@test(candidate(\"PART OF THE JOURNEY IS PART\") == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the intersection of two vectors.\n\t\"\"\"\nfunction intersection_array(array_nums1::Vector{Int64}, array_nums2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = intersection_array;\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9])\n\t@test(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\n\t\"\"\"\nfunction count_X(tup::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_X;\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3)\n\t@test(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\n\t\"\"\"\nfunction insert_element(list::Vector{String}, element::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = insert_element;\n\t@test(candidate([\"Red\", \"Green\", \"Black\"], \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\n\t@test(candidate([\"python\", \"java\"], \"program\") == [\"program\", \"python\", \"program\", \"java\"])\n\t@test(candidate([\"happy\", \"sad\"], \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to convert complex numbers to polar coordinates.\n\t\"\"\"\nfunction convert(numbers::Int64)::Tuple{Float64, Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = convert;\n\t@test(candidate(1) == (1.0, 0.0))\n\t@test(candidate(4) == (4.0, 0.0))\n\t@test(candidate(5) == (5.0, 0.0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function that returns the number of integer elements in a given vector.\n\t\"\"\"\nfunction count_integer(list1::Vector{Union{Int64, String, Float64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_integer;\n\t@test(candidate([1, 2, \"abc\", 1.2]) == 2)\n\t@test(candidate([1, 2, 3]) == 3)\n\t@test(candidate([1, 1.2, 4, 5.1]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\n\t\"\"\"\nfunction combinations_colors(l::Vector{String}, n::Int64)::Vector{Vector{String}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = combinations_colors;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\n\t@test(candidate([\"Red\", \"Green\", \"Blue\"], 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\nfunction count_Primes_nums(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Primes_nums;\n\t@test(candidate(5) == 2)\n\t@test(candidate(10) == 4)\n\t@test(candidate(100) == 25)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two numbers and returns a vector with the second number and then the first number.\n\t\"\"\"\nfunction swap_numbers(a::Int64, b::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_numbers;\n\t@test(candidate(10, 20) == [20, 10])\n\t@test(candidate(15, 17) == [17, 15])\n\t@test(candidate(100, 200) == [200, 100])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5324,7 +1040,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to maximize the given two vectors.\n\t\"\"\"\nfunction maximize_elements(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = maximize_elements;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]])\nend\n",
     "stop_tokens": [
@@ -5334,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether every even index contains even numbers of a given vector.\n\t\"\"\"\nfunction even_position(nums::Vector{Int64})::Bool \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\nfunction newman_prime(n::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = even_position;\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 3]) == false)\n\t@test(candidate([2, 1, 4]) == true)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = newman_prime;\n\t@test(candidate(3) == 7)\n\t@test(candidate(4) == 17)\n\t@test(candidate(5) == 41)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5348,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\nfunction check_char(string::String)::String \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\nfunction division_elements(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = check_char;\n\t@test(candidate(\"abba\") == \"Valid\")\n\t@test(candidate(\"a\") == \"Valid\")\n\t@test(candidate(\"abcd\") == \"Invalid\")\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = division_elements;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3))\n\t@test(candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4))\n\t@test(candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5362,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of even factors of a number.\n\t\"\"\"\nfunction sumofFactors(n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer L and splits the given vector into two parts where the length of the first part of the vector is L, and returns the resulting vectors in a tuple.\n\t\"\"\"\nfunction split_two_parts(list1::Vector{Any}, L::Int64)::Any \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = sumofFactors;\n\t@test(candidate(18) == 26)\n\t@test(candidate(30) == 48)\n\t@test(candidate(6) == 8)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_two_parts;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\n\t@test(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5376,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\nfunction lateralsurface_cone(r::Int64, h::Int64)::Float64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\nfunction dog_age(h_age::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cone;\n\t@test(candidate(5, 12) == 204.20352248333654)\n\t@test(candidate(10, 15) == 566.3586699569488)\n\t@test(candidate(19, 17) == 1521.8090132193388)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dog_age;\n\t@test(candidate(12) == 61)\n\t@test(candidate(15) == 73)\n\t@test(candidate(24) == 109)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5390,13 +1106,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\nfunction count_Pairs(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and an integer n and splits a vector for every nth element, returning a vector of the resulting vectors.\n\t\"\"\"\nfunction list_split(S::Vector{Any}, step::Int64)::Vector{Vector{Any}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Pairs;\n\t@test(candidate([1, 2, 1], 3) == 2)\n\t@test(candidate([1, 1, 1, 1], 4) == 0)\n\t@test(candidate([1, 2, 3, 4, 5], 5) == 10)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = list_split;\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\n\t@test(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5404,13 +1120,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted vector.\n\t\"\"\"\nfunction find_first_occurrence(A::Vector{Int64}, x::Int64)::Int64 \n",
+    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\nfunction lateralsurface_cube(l::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = find_first_occurrence;\n\t@test(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1)\n\t@test(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2)\n\t@test(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4)\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cube;\n\t@test(candidate(5) == 100)\n\t@test(candidate(9) == 324)\n\t@test(candidate(10) == 400)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5422,9 +1138,835 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a jlthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 10)\n\t@test(candidate(3) == 35)\n\t@test(candidate(4) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\nfunction find_star_num(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_star_num;\n\t@test(candidate(3) == 37)\n\t@test(candidate(4) == 73)\n\t@test(candidate(5) == 121)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\nfunction ascii_value(k::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = ascii_value;\n\t@test(candidate(\"A\") == 65)\n\t@test(candidate(\"R\") == 82)\n\t@test(candidate(\"S\") == 83)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of even numbers at even positions of a vector.\n\t\"\"\"\nfunction sum_even_and_even_index(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_even_and_even_index;\n\t@test(candidate([5, 6, 12, 1, 18, 8]) == 30)\n\t@test(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\n\t@test(candidate([5, 6, 12, 1]) == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\nfunction even_Power_Sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_Power_Sum;\n\t@test(candidate(2) == 1056)\n\t@test(candidate(3) == 8832)\n\t@test(candidate(1) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\n\t\"\"\"\nfunction rear_extract(test_list::Vector{Tuple{Int64, String, Int64}})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rear_extract;\n\t@test(candidate([(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\n\t@test(candidate([(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\n\t@test(candidate([(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\nfunction substract_elements(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Tuple{Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = substract_elements;\n\t@test(candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13))\n\t@test(candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13))\n\t@test(candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\nfunction even_binomial_Coeff_Sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_binomial_Coeff_Sum;\n\t@test(candidate(4) == 8)\n\t@test(candidate(6) == 32)\n\t@test(candidate(2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\nfunction dict_filter(dict::Dict{String, Int64}>, n::Int64)::Dict{String, Int64}> \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dict_filter;\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) == Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) == Dict(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190))\n\t@test(candidate(Dict(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) == Dict(\"Pierre Cox\" => 190))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the number of elements that occurs before the vector element in the given tuple.\n\t\"\"\"\nfunction count_first_elements(test_tup::Vector{Union{Int64, Tuple{Int64, Int64}}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_first_elements;\n\t@test(candidate([1, 5, 7, (4, 6), 10]) == 3)\n\t@test(candidate([2, 9, (5, 7), 11]) == 2)\n\t@test(candidate([11, 15, 5, 8, (2, 3), 8]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\nfunction is_num_decagonal(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_num_decagonal;\n\t@test(candidate(3) == 27)\n\t@test(candidate(7) == 175)\n\t@test(candidate(10) == 370)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\nfunction sequential_search(dlist::Vector{Int64}, item::Int64)::Tuple{Bool, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sequential_search;\n\t@test(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (true, 3))\n\t@test(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (true, 7))\n\t@test(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (true, 6))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check if the elements of a given vector are unique or not.\n\t\"\"\"\nfunction all_unique(test_list::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_unique;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to subtract two vectors element-wise.\n\t\"\"\"\nfunction sub_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sub_list;\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3])\n\t@test(candidate([1, 2], [3, 4]) == [-2, -2])\n\t@test(candidate([90, 120], [50, 70]) == [40, 50])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\nfunction validate(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = validate;\n\t@test(candidate(1234) == true)\n\t@test(candidate(51241) == false)\n\t@test(candidate(321) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes in a vector and element and checks whether all items in the vector are equal to the given element.\n\t\"\"\"\nfunction check_element(list::Vector{Any}, element::Any)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_element;\n\t@test(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\") == false)\n\t@test(candidate([1, 2, 3, 4], 7) == false)\n\t@test(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\nfunction text_match_two_three(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_two_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\n\t\"\"\"\nfunction max_sub_array_sum_repeated(a::Vector{Int64}, n::Int64, k::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum_repeated;\n\t@test(candidate([10, 20, -30, -1], 4, 3) == 30)\n\t@test(candidate([-1, 10, 20], 3, 2) == 59)\n\t@test(candidate([-1, -2, -3], 3, 3) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\nfunction square_Sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_Sum;\n\t@test(candidate(2) == 20)\n\t@test(candidate(3) == 56)\n\t@test(candidate(4) == 120)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the vector of maximum length in a vector of vectors.\n\t\"\"\"\nfunction max_length(list1::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\n\t@test(candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\nfunction count_no_of_ways(n::Int64, k::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_no_of_ways;\n\t@test(candidate(2, 4) == 16)\n\t@test(candidate(3, 2) == 6)\n\t@test(candidate(4, 4) == 228)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\nfunction find(n::Int64, m::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find;\n\t@test(candidate(10, 3) == 3)\n\t@test(candidate(4, 2) == 2)\n\t@test(candidate(20, 5) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\nfunction otherside_rightangle(w::Int64, h::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = otherside_rightangle;\n\t@test(candidate(7, 8) == 10.63014581273465)\n\t@test(candidate(3, 4) == 5)\n\t@test(candidate(7, 15) == 16.55294535724685)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous vector.\n\t\"\"\"\nfunction max_val(listval::Vector{Union{String, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 5)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 25)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 50)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\nfunction sum_div(number::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_div;\n\t@test(candidate(8) == 7)\n\t@test(candidate(12) == 16)\n\t@test(candidate(7) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count inversions in a vector.\n\t\"\"\"\nfunction get_Inv_Count(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Inv_Count;\n\t@test(candidate([1, 20, 6, 4, 5]) == 5)\n\t@test(candidate([1, 2, 1]) == 1)\n\t@test(candidate([1, 2, 5, 6, 1]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to flatten a given nested vector structure.\n\t\"\"\"\nfunction flatten_list(list1::Vector{Union{Int64, Vector{Int64}}})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = flatten_list;\n\t@test(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\n\t@test(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the maximum aggregate from the vector of tuples.\n\t\"\"\"\nfunction max_aggregate(stdata::Vector{Tuple{String, Int64}})::Tuple{String, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_aggregate;\n\t@test(candidate([(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\n\t@test(candidate([(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\n\t@test(candidate([(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find element at a given index after number of rotations.\n\t\"\"\"\nfunction find_Element(arr::Vector{Int64}, ranges::Vector{Vector{Int64}}, rotations::Int64, index::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Element;\n\t@test(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3)\n\t@test(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return two words from a vector of words starting with letter 'p'.\n\t\"\"\"\nfunction start_withp(words::Vector{String})::Tuple{String, String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = start_withp;\n\t@test(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\n\t@test(candidate([\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\n\t@test(candidate([\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\nfunction max_sum_increasing_subseq(a::Vector{Int64}, n::Int64, index::Int64, k::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_increasing_subseq;\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11)\n\t@test(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7)\n\t@test(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\n\t\"\"\"\nfunction large_product(nums1::Vector{Int64}, nums2::Vector{Int64}, N::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = large_product;\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48])\n\t@test(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the maximum of two numbers.\n\t\"\"\"\nfunction maximum(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maximum;\n\t@test(candidate(5, 10) == 10)\n\t@test(candidate(-1, -2) == -1)\n\t@test(candidate(9, 7) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a given string to a vector of characters.\n\t\"\"\"\nfunction string_to_tuple(str1::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = string_to_tuple;\n\t@test(candidate(\"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\n\t@test(candidate(\"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\n\t@test(candidate(\"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\nfunction highest_Power_of_2(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = highest_Power_of_2;\n\t@test(candidate(10) == 8)\n\t@test(candidate(19) == 16)\n\t@test(candidate(32) == 32)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\nfunction find_lucas(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_lucas;\n\t@test(candidate(9) == 76)\n\t@test(candidate(4) == 7)\n\t@test(candidate(3) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to apply a given format string to all of the elements in a vector.\n\t\"\"\"\nfunction add_string(list_::Vector{Any}, string::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_string;\n\t@test(candidate([1, 2, 3, 4], \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\n\t@test(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\n\t@test(candidate([5, 6, 7, 8], \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\nfunction get_max_sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_max_sum;\n\t@test(candidate(60) == 106)\n\t@test(candidate(10) == 12)\n\t@test(candidate(2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the vector with maximum length.\n\t\"\"\"\nfunction max_length_list(input_list::Vector{Vector{Int64}})::Tuple{Int64, Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_length_list;\n\t@test(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\n\t@test(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\n\t@test(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if given vector contains no duplicates.\n\t\"\"\"\nfunction check_distinct(test_tup::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_distinct;\n\t@test(candidate([1, 4, 5, 6, 1, 4]) == false)\n\t@test(candidate([1, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 6]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first non-repeated character in a given string.\n\t\"\"\"\nfunction first_non_repeating_character(str1::String)::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_non_repeating_character;\n\t@test(candidate(\"abcabc\") == nothing)\n\t@test(candidate(\"abc\") == \"a\")\n\t@test(candidate(\"ababc\") == \"c\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\nfunction check_char(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_char;\n\t@test(candidate(\"abba\") == \"Valid\")\n\t@test(candidate(\"a\") == \"Valid\")\n\t@test(candidate(\"abcd\") == \"Invalid\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\nfunction median_numbers(a::Int64, b::Int64, c::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median_numbers;\n\t@test(candidate(25, 55, 65) == 55.0)\n\t@test(candidate(20, 10, 30) == 20.0)\n\t@test(candidate(15, 45, 75) == 45.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to compute the sum of digits of each number of a given vector.\n\t\"\"\"\nfunction sum_of_digits(nums::Vector{Any})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_of_digits;\n\t@test(candidate([10, 2, 56]) == 14)\n\t@test(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\n\t@test(candidate([10, 20, -4, 5, -70]) == 19)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\nfunction bitwise_xor(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bitwise_xor;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10))\n\t@test(candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14))\n\t@test(candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to identify non-prime numbers.\n\t\"\"\"\nfunction is_not_prime(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_not_prime;\n\t@test(candidate(2) == false)\n\t@test(candidate(10) == true)\n\t@test(candidate(35) == true)\n\t@test(candidate(37) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the number of unique tuples in the given vector.\n\t\"\"\"\nfunction extract_freq(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_freq;\n\t@test(candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\n\t@test(candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\n\t@test(candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform index wise addition of vector elements in the given two nested vectors.\n\t\"\"\"\nfunction add_nested_tuples(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_nested_tuples;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum of two numbers.\n\t\"\"\"\nfunction minimum(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = minimum;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(-5, -4) == -5)\n\t@test(candidate(0, 0) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\nfunction check_tuplex(tuplex::Vector{Union{String, Int64}}, tuple1::Any)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_tuplex;\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\") == true)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\") == false)\n\t@test(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find whether the parity of a given number is odd.\n\t\"\"\"\nfunction find_Parity(x::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Parity;\n\t@test(candidate(12) == false)\n\t@test(candidate(7) == true)\n\t@test(candidate(10) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\nfunction rearrange_bigger(n::Int64)::Any \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rearrange_bigger;\n\t@test(candidate(12) == 21)\n\t@test(candidate(10) == false)\n\t@test(candidate(102) == 120)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\n\t\"\"\"\nfunction k_smallest_pairs(nums1::Vector{Int64}, nums2::Vector{Int64}, k::Int64)::Vector{Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = k_smallest_pairs;\n\t@test(candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]])\n\t@test(candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given vector.\n\t\"\"\"\nfunction min_product_tuple(list1::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_product_tuple;\n\t@test(candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\n\t@test(candidate([(10, 20), (15, 2), (5, 10)]) == 30)\n\t@test(candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous vector.\n\t\"\"\"\nfunction min_val(listval::Vector{Union{String, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_val;\n\t@test(candidate([\"Python\", 3, 2, 4, 5, \"version\"]) == 2)\n\t@test(candidate([\"Python\", 15, 20, 25]) == 15)\n\t@test(candidate([\"Python\", 30, 20, 40, 50, \"version\"]) == 20)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\nfunction snake_to_camel(word::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = snake_to_camel;\n\t@test(candidate(\"android_tv\") == \"AndroidTv\")\n\t@test(candidate(\"google_pixel\") == \"GooglePixel\")\n\t@test(candidate(\"apple_watch\") == \"AppleWatch\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to remove odd numbers from a given vector.\n\t\"\"\"\nfunction remove_odd(l::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate([1, 2, 3]) == [2])\n\t@test(candidate([2, 4, 6]) == [2, 4, 6])\n\t@test(candidate([10, 20, 3]) == [10, 20])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the nth element from a given vector of tuples.\n\t\"\"\"\nfunction extract_nth_element(list1::Vector{Tuple{String, Int64, Int64}}, n::Int64)::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_nth_element;\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 2) == [99, 96, 94, 98])\n\t@test(candidate([(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], 1) == [98, 97, 91, 94])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\nfunction overlapping(list1::Vector{Int64}, list2::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = overlapping;\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == false)\n\t@test(candidate([1, 2, 3], [4, 5, 6]) == false)\n\t@test(candidate([1, 4, 5], [1, 4, 5]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find a pair with highest product from a given vector of integers.\n\t\"\"\"\nfunction max_Product(arr::Vector{Int64})::Tuple{Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_Product;\n\t@test(candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\n\t@test(candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\n\t@test(candidate([1, 2, 3]) == (2, 3))\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",
@@ -5436,7 +1978,7 @@
     "language": "jl",
     "prompt": "\"\"\"\n\tWrite a function to find common first element in given vector of vectors.\n\t\"\"\"\nfunction group_tuples(Input::Vector{Vector{String}})::Vector{Vector{String}} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "using Test\n\n@testset begin\n\ncandidate = group_tuples;\n\t@test(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])\n\t@test(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])\nend\n",
     "stop_tokens": [
@@ -5446,13 +1988,3471 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "jl",
-    "prompt": "\"\"\"\n\tWrite a function to merge three vectors into a single sorted vector.\n\t\"\"\"\nfunction merge_sorted_list(num1::Vector{Int64}, num2::Vector{Int64}, num3::Vector{Int64})::Vector{Int64} \n",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the element of a vector having maximum length.\n\t\"\"\"\nfunction Find_Max(lst::Vector{Vector{Any}})::Vector{Any} \n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_sorted_list;\n\t@test(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\n\t@test(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\n\t@test(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])\nend\n",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max;\n\t@test(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\n\t@test(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to round every number of a given vector of numbers and print the total sum multiplied by the length of the vector.\n\t\"\"\"\nfunction round_and_sum(list1::Vector{Union{Float64, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = round_and_sum;\n\t@test(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243)\n\t@test(candidate([5, 2, 9, 24.3, 29]) == 345)\n\t@test(candidate([25.0, 56.7, 89.2]) == 513)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the cube sum of first n even natural numbers.\n\t\"\"\"\nfunction cube_Sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_Sum;\n\t@test(candidate(2) == 72)\n\t@test(candidate(3) == 288)\n\t@test(candidate(4) == 800)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\nfunction concatenate_tuple(test_tup::Tuple{String, String, Int64, String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = concatenate_tuple;\n\t@test(candidate((\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\n\t@test(candidate((\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\n\t@test(candidate((\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the average of cubes of first n natural numbers.\n\t\"\"\"\nfunction find_Average_Of_Cube(n::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Average_Of_Cube;\n\t@test(candidate(2) == 4.5)\n\t@test(candidate(3) == 12)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\nfunction extract_rear(test_tuple::Tuple{String, String, String})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_rear;\n\t@test(candidate((\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\n\t@test(candidate((\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\n\t@test(candidate((\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the number of subvectors containing a particular element.\n\t\"\"\"\nfunction count_element_in_list(list1::Vector{Vector{Any}}, x::Any)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_element_in_list;\n\t@test(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\") == 3)\n\t@test(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\") == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\nfunction filter_oddnumbers(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = filter_oddnumbers;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\n\t@test(candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93])\n\t@test(candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\nfunction change_date_format(dt::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = change_date_format;\n\t@test(candidate(\"2026-01-02\") == \"02-01-2026\")\n\t@test(candidate(\"2020-11-13\") == \"13-11-2020\")\n\t@test(candidate(\"2021-04-26\") == \"26-04-2021\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort the given vector by using shell sort.\n\t\"\"\"\nfunction shell_sort(my_list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = shell_sort;\n\t@test(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\n\t@test(candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\n\t@test(candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\nfunction and_tuples(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = and_tuples;\n\t@test(candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1))\n\t@test(candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0))\n\t@test(candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\nfunction parabola_directrix(a::Int64, b::Int64, c::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = parabola_directrix;\n\t@test(candidate(5, 3, 2) == -198)\n\t@test(candidate(9, 8, 4) == -2336)\n\t@test(candidate(2, 4, 6) == -130)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes two vectors and returns true if they have at least one common element.\n\t\"\"\"\nfunction common_element(list1::Vector{Any}, list2::Vector{Any})::Union{Bool, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = common_element;\n\t@test(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == true)\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == nothing)\n\t@test(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\nfunction median_trapezium(base1::Int64, base2::Int64, height::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = median_trapezium;\n\t@test(candidate(15, 25, 35) == 20)\n\t@test(candidate(10, 20, 30) == 15)\n\t@test(candidate(6, 9, 4) == 7.5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given vector.\n\t\"\"\"\nfunction check_greater(arr::Vector{Int64}, number::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_greater;\n\t@test(candidate([1, 2, 3, 4, 5], 4) == false)\n\t@test(candidate([2, 3, 4, 5, 6], 8) == true)\n\t@test(candidate([9, 7, 4, 8, 6, 1], 11) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\nfunction text_match_one(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last digit of a given number.\n\t\"\"\"\nfunction last_Digit(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit;\n\t@test(candidate(123) == 3)\n\t@test(candidate(25) == 5)\n\t@test(candidate(30) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to return the negative numbers in a vector.\n\t\"\"\"\nfunction neg_nos(list1::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = neg_nos;\n\t@test(candidate([-1, 4, 5, -6]) == [-1, -6])\n\t@test(candidate([-1, -2, 3, 4]) == [-1, -2])\n\t@test(candidate([-7, -6, 8, 9]) == [-7, -6])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\nfunction remove_odd(str1::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_odd;\n\t@test(candidate(\"python\") == \"yhn\")\n\t@test(candidate(\"program\") == \"rga\")\n\t@test(candidate(\"language\") == \"agae\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\nfunction count_bidirectional(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_bidirectional;\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\n\t@test(candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\n\t@test(candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to join a vector of multiple integers into a single integer.\n\t\"\"\"\nfunction multiple_to_single(L::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiple_to_single;\n\t@test(candidate([11, 33, 50]) == 113350)\n\t@test(candidate([-1, 2, 3, 4, 5, 6]) == -123456)\n\t@test(candidate([10, 15, 20, 25]) == 10152025)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\nfunction find_adverb_position(text::String)::Tuple{Int64, Int64, String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverb_position;\n\t@test(candidate(\"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\n\t@test(candidate(\"seriously!! there are many roses\") == (0, 9, \"seriously\"))\n\t@test(candidate(\"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\nfunction surfacearea_cube(l::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cube;\n\t@test(candidate(5) == 150)\n\t@test(candidate(3) == 54)\n\t@test(candidate(10) == 600)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the ration of positive numbers in a vector of integers.\n\t\"\"\"\nfunction positive_count(nums::Vector{Int64})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = positive_count;\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\n\t@test(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the largest negative number from the given vector.\n\t\"\"\"\nfunction largest_neg(list1::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = largest_neg;\n\t@test(candidate([1, 2, 3, -4, -6]) == -6)\n\t@test(candidate([1, 2, 3, -8, -9]) == -9)\n\t@test(candidate([1, 2, 3, 4, -1]) == -1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to trim each vector by k in the given vectors.\n\t\"\"\"\nfunction trim_tuple(test_list::Vector{Vector{Int64}}, K::Int64)::Vector{Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = trim_tuple;\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]])\n\t@test(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\n\t@test(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to perform index wise multiplication of vector elements in the given two vectors.\n\t\"\"\"\nfunction index_multiplication(test_tup1::Vector{Vector{Int64}}, test_tup2::Vector{Vector{Int64}})::Vector{Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = index_multiplication;\n\t@test(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\n\t@test(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\n\t@test(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the occurence of all elements of vector in a tuple.\n\t\"\"\"\nfunction count_Occurrence(tup::Any, lst::Vector{Any})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Occurrence;\n\t@test(candidate((\"a\", \"a\", \"c\", \"b\", \"d\"), [\"a\", \"b\"]) == 3)\n\t@test(candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6)\n\t@test(candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find cubes of individual elements in a vector.\n\t\"\"\"\nfunction cube_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cube_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\n\t@test(candidate([10, 20, 30]) == [1000, 8000, 27000])\n\t@test(candidate([12, 15]) == [1728, 3375])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\nfunction cal_sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cal_sum;\n\t@test(candidate(9) == 49)\n\t@test(candidate(10) == 66)\n\t@test(candidate(11) == 88)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract specified size of strings from a given vector of string values.\n\t\"\"\"\nfunction extract_string(str::Vector{String}, l::Int64)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_string;\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8) == [\"practice\", \"solution\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6) == [\"Python\"])\n\t@test(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9) == [\"exercises\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\nfunction remove_whitespaces(text1::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_whitespaces;\n\t@test(candidate(\" Google    Flutter \") == \"GoogleFlutter\")\n\t@test(candidate(\" Google    Dart \") == \"GoogleDart\")\n\t@test(candidate(\" iOS    Swift \") == \"iOSSwift\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\nfunction loss_amount(actual_cost::Int64, sale_amount::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = loss_amount;\n\t@test(candidate(1500, 1200) == 0)\n\t@test(candidate(100, 200) == 100)\n\t@test(candidate(2000, 5000) == 3000)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of even factors of a number.\n\t\"\"\"\nfunction sumofFactors(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sumofFactors;\n\t@test(candidate(18) == 26)\n\t@test(candidate(30) == 48)\n\t@test(candidate(6) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\nfunction text_match_wordz(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz;\n\t@test(candidate(\"pythonz.\") == true)\n\t@test(candidate(\"xyz.\") == true)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\nfunction check_monthnumb_number(monthnum2::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumb_number;\n\t@test(candidate(5) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(6) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to reverse each string in a given vector of string values.\n\t\"\"\"\nfunction reverse_string_list(stringlist::Vector{String})::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_string_list;\n\t@test(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\n\t@test(candidate([\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\n\t@test(candidate([\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the subvector having minimum length.\n\t\"\"\"\nfunction Find_Min(lst::Vector{Vector{Any}})::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min;\n\t@test(candidate([[1], [1, 2], [1, 2, 3]]) == [1])\n\t@test(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\n\t@test(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\nfunction rectangle_area(l::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rectangle_area;\n\t@test(candidate(10, 20) == 200)\n\t@test(candidate(10, 5) == 50)\n\t@test(candidate(4, 2) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\nfunction remove_uppercase(str1::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_uppercase;\n\t@test(candidate(\"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\n\t@test(candidate(\"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\n\t@test(candidate(\"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to get the first element of each subvector.\n\t\"\"\"\nfunction Extract(lst::Vector{Vector{Int64}})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Extract;\n\t@test(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\n\t@test(candidate([[1, 2, 3], [4, 5]]) == [1, 4])\n\t@test(candidate([[9, 8, 1], [1, 2]]) == [9, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the upper case characters in a given string.\n\t\"\"\"\nfunction upper_ctr(str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = upper_ctr;\n\t@test(candidate(\"PYthon\") == 1)\n\t@test(candidate(\"BigData\") == 1)\n\t@test(candidate(\"program\") == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum product subvector of the given vector.\n\t\"\"\"\nfunction max_subarray_product(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_subarray_product;\n\t@test(candidate([1, -2, -3, 0, 7, -8, -2]) == 112)\n\t@test(candidate([6, -3, -10, 0, 2]) == 180)\n\t@test(candidate([-2, -40, 0, -2, -3]) == 80)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\nfunction check_value(dict::Dict{String, Int64}>, n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_value;\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) == false)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) == true)\n\t@test(candidate(Dict(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\n\t\"\"\"\nfunction max_product(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_product;\n\t@test(candidate([3, 100, 4, 5, 150, 6]) == 3000)\n\t@test(candidate([4, 42, 55, 68, 80]) == 50265600)\n\t@test(candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\nfunction add_pairwise(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_pairwise;\n\t@test(candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18))\n\t@test(candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20))\n\t@test(candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the product of the vector multiplication modulo n.\n\t\"\"\"\nfunction find_remainder(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_remainder;\n\t@test(candidate([100, 10, 5, 25, 35, 14], 11) == 9)\n\t@test(candidate([1, 1, 1], 1) == 0)\n\t@test(candidate([1, 2, 1], 2) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given vector contains consecutive numbers or not.\n\t\"\"\"\nfunction check_Consecutive(l::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_Consecutive;\n\t@test(candidate([1, 2, 3, 4, 5]) == true)\n\t@test(candidate([1, 2, 3, 5, 6]) == false)\n\t@test(candidate([1, 2, 1]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\nfunction replace_char(str1::String, ch::String, newch::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_char;\n\t@test(candidate(\"polygon\", \"y\", \"l\") == \"pollgon\")\n\t@test(candidate(\"character\", \"c\", \"a\") == \"aharaater\")\n\t@test(candidate(\"python\", \"l\", \"a\") == \"python\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\nfunction sort_counter(dict1::Dict{String, Int64}>)::Vector{Tuple{String, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_counter;\n\t@test(candidate(Dict(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\n\t@test(candidate(Dict(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\n\t@test(candidate(Dict(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the largest and smallest value in a given vector.\n\t\"\"\"\nfunction big_sum(nums::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = big_sum;\n\t@test(candidate([1, 2, 3]) == 4)\n\t@test(candidate([-1, 2, 3, 4]) == 3)\n\t@test(candidate([2, 3, 6]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to convert the given string to lower case.\n\t\"\"\"\nfunction is_lower(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_lower;\n\t@test(candidate(\"InValid\") == \"invalid\")\n\t@test(candidate(\"TruE\") == \"true\")\n\t@test(candidate(\"SenTenCE\") == \"sentence\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\nfunction remove_lowercase(str1::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_lowercase;\n\t@test(candidate(\"PYTHon\") == \"PYTH\")\n\t@test(candidate(\"FInD\") == \"FID\")\n\t@test(candidate(\"STRinG\") == \"STRG\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first digit of a given number.\n\t\"\"\"\nfunction first_Digit(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_Digit;\n\t@test(candidate(123) == 1)\n\t@test(candidate(456) == 4)\n\t@test(candidate(12) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the n largest integers from a given vector of numbers, returned in descending order.\n\t\"\"\"\nfunction heap_queue_largest(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_queue_largest;\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of integers and only returns the odd ones.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5])\n\t@test(candidate([10, 11, 12, 13]) == [11, 13])\n\t@test(candidate([7, 8, 9, 1]) == [7, 9, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\nfunction difference(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = difference;\n\t@test(candidate(3) == 30)\n\t@test(candidate(5) == 210)\n\t@test(candidate(2) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of pairs whose xor value is odd.\n\t\"\"\"\nfunction find_Odd_Pair(A::Vector{Int64}, N::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Odd_Pair;\n\t@test(candidate([5, 4, 7, 2, 1], 5) == 6)\n\t@test(candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12)\n\t@test(candidate([1, 2, 3], 3) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\nfunction toggle_string(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_string;\n\t@test(candidate(\"Python\") == \"pYTHON\")\n\t@test(candidate(\"Pangram\") == \"pANGRAM\")\n\t@test(candidate(\"LIttLE\") == \"liTTle\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\nfunction digit_distance_nums(n1::Int64, n2::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = digit_distance_nums;\n\t@test(candidate(1, 2) == 1)\n\t@test(candidate(23, 56) == 6)\n\t@test(candidate(123, 256) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the sum of the largest contiguous subvector in the given vector.\n\t\"\"\"\nfunction max_sub_array_sum(a::Vector{Int64}, size::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sub_array_sum;\n\t@test(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7)\n\t@test(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8)\n\t@test(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the union of the elements of two given vectors and output them in sorted order.\n\t\"\"\"\nfunction union_elements(test_tup1::Vector{Int64}, test_tup2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = union_elements;\n\t@test(candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\n\t@test(candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\n\t@test(candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the longest subvectors.\n\t\"\"\"\nfunction Find_Max_Length(lst::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Max_Length;\n\t@test(candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4)\n\t@test(candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3)\n\t@test(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\nfunction extract_values(text::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_values;\n\t@test(candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\n\t@test(candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\n\t@test(candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\nfunction count_Pairs(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Pairs;\n\t@test(candidate([1, 2, 1], 3) == 2)\n\t@test(candidate([1, 1, 1, 1], 4) == 0)\n\t@test(candidate([1, 2, 3, 4, 5], 5) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to split a string into characters.\n\t\"\"\"\nfunction split(word::String)::Vector{String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split;\n\t@test(candidate(\"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\n\t@test(candidate(\"Name\") == [\"N\", \"a\", \"m\", \"e\"])\n\t@test(candidate(\"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\nfunction sum_digits(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_digits;\n\t@test(candidate(345) == 12)\n\t@test(candidate(12) == 3)\n\t@test(candidate(97) == 16)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a specified vector is sorted or not.\n\t\"\"\"\nfunction issort_list(list1::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = issort_list;\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\n\t@test(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort each subvector of strings in a given vector of vectors.\n\t\"\"\"\nfunction sort_sublists(list1::Vector{Vector{String}})::Vector{Vector{String}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_sublists;\n\t@test(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\n\t@test(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\n\t@test(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check if a given number is one less than twice its reverse.\n\t\"\"\"\nfunction checks(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = checks;\n\t@test(candidate(70) == false)\n\t@test(candidate(23) == false)\n\t@test(candidate(73) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to remove duplicate numbers from a given number of vectors.\n\t\"\"\"\nfunction two_unique_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = two_unique_nums;\n\t@test(candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\n\t@test(candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\n\t@test(candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to calculate the product of the unique numbers in a given vector.\n\t\"\"\"\nfunction unique_product(list_data::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_product;\n\t@test(candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\n\t@test(candidate([1, 2, 3, 1]) == 6)\n\t@test(candidate([7, 8, 9, 0, 1, 1]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\nfunction surfacearea_cylinder(r::Int64, h::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surfacearea_cylinder;\n\t@test(candidate(10, 5) == 942.45)\n\t@test(candidate(4, 5) == 226.18800000000002)\n\t@test(candidate(4, 10) == 351.848)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether a vector is subvector of another or not.\n\t\"\"\"\nfunction is_Sub_Array(A::Vector{Int64}, B::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Sub_Array;\n\t@test(candidate([1, 4, 3, 5], [1, 2]) == false)\n\t@test(candidate([1, 2, 1], [1, 2, 1]) == true)\n\t@test(candidate([1, 0, 2, 2], [2, 2, 0]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last digit in factorial of a given number.\n\t\"\"\"\nfunction last_Digit_Factorial(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last_Digit_Factorial;\n\t@test(candidate(4) == 4)\n\t@test(candidate(21) == 0)\n\t@test(candidate(30) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to interleave 3 vectors of the same length into a single flat vector.\n\t\"\"\"\nfunction interleave_lists(list1::Vector{Int64}, list2::Vector{Int64}, list3::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = interleave_lists;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\n\t@test(candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10])\n\t@test(candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\nfunction find_dissimilar(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_dissimilar;\n\t@test(candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10))\n\t@test(candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9))\n\t@test(candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the largest number that can be formed with the given vector of digits.\n\t\"\"\"\nfunction find_Max_Num(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Max_Num;\n\t@test(candidate([1, 2, 3]) == 321)\n\t@test(candidate([4, 5, 6, 1]) == 6541)\n\t@test(candidate([1, 2, 3, 9]) == 9321)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\nfunction extract_even(test_tuple::Tuple{Int64, Int64, Tuple{Int64, Int64, Tuple{Int64, Int64}}, Int64, Int64})::Any \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_even;\n\t@test(candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\n\t@test(candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\n\t@test(candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the surface area of a square jlramid with a given base edge and height.\n\t\"\"\"\nfunction surface_Area(b::Int64, s::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = surface_Area;\n\t@test(candidate(3, 4) == 33)\n\t@test(candidate(4, 5) == 56)\n\t@test(candidate(1, 2) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\nfunction catalan_number(num::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = catalan_number;\n\t@test(candidate(10) == 16796)\n\t@test(candidate(9) == 4862)\n\t@test(candidate(7) == 429)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\nfunction find_adverbs(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_adverbs;\n\t@test(candidate(\"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\n\t@test(candidate(\"Please handle the situation carefuly\") == \"28-36: carefuly\")\n\t@test(candidate(\"Complete the task quickly\") == \"18-25: quickly\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to split a vector at the nth eelment and add the first part to the end.\n\t\"\"\"\nfunction split_Arr(l::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = split_Arr;\n\t@test(candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10])\n\t@test(candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1])\n\t@test(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert a vector to a tuple.\n\t\"\"\"\nfunction list_tuple(listx::Vector{Int64})::Any \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = list_tuple;\n\t@test(candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\n\t@test(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\n\t@test(candidate([58, 44, 56]) == (58, 44, 56))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the difference between largest and smallest value in a given vector.\n\t\"\"\"\nfunction big_diff(nums::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = big_diff;\n\t@test(candidate([1, 2, 3, 4]) == 3)\n\t@test(candidate([4, 5, 12]) == 8)\n\t@test(candidate([9, 2, 3]) == 7)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\nfunction perfect_squares(a::Int64, b::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = perfect_squares;\n\t@test(candidate(1, 30) == [1, 4, 9, 16, 25])\n\t@test(candidate(50, 100) == [64, 81, 100])\n\t@test(candidate(100, 200) == [100, 121, 144, 169, 196])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\nfunction opposite_Signs(x::Int64, y::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = opposite_Signs;\n\t@test(candidate(1, -2) == true)\n\t@test(candidate(3, 2) == false)\n\t@test(candidate(-10, -10) == false)\n\t@test(candidate(-2, 2) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to interchange the first and last elements in a vector.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\nfunction sum_Of_product(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_product;\n\t@test(candidate(3) == 15)\n\t@test(candidate(4) == 56)\n\t@test(candidate(1) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\nfunction removezero_ip(ip::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = removezero_ip;\n\t@test(candidate(\"216.08.094.196\") == \"216.8.94.196\")\n\t@test(candidate(\"12.01.024\") == \"12.1.24\")\n\t@test(candidate(\"216.08.094.0196\") == \"216.8.94.196\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given vector.\n\t\"\"\"\nfunction diff_even_odd(list1::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = diff_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\n\t@test(candidate([1, 5, 7, 9, 10]) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\nfunction min_Swaps(str1::String, str2::String)::Any \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Swaps;\n\t@test(candidate(\"1101\", \"1110\") == 1)\n\t@test(candidate(\"111\", \"000\") == \"Not Possible\")\n\t@test(candidate(\"111\", \"110\") == \"Not Possible\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find kth element from the given two sorted vectors.\n\t\"\"\"\nfunction find_kth(arr1::Vector{Int64}, arr2::Vector{Int64}, k::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_kth;\n\t@test(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6)\n\t@test(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256)\n\t@test(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\nfunction armstrong_number(number::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = armstrong_number;\n\t@test(candidate(153) == true)\n\t@test(candidate(259) == false)\n\t@test(candidate(4458) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\nfunction sum_average(number::Int64)::Tuple{Int64, Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_average;\n\t@test(candidate(10) == (55, 5.5))\n\t@test(candidate(15) == (120, 8.0))\n\t@test(candidate(20) == (210, 10.5))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\nfunction is_octagonal(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_octagonal;\n\t@test(candidate(5) == 65)\n\t@test(candidate(10) == 280)\n\t@test(candidate(15) == 645)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number is even or not.\n\t\"\"\"\nfunction is_Even(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Even;\n\t@test(candidate(1) == false)\n\t@test(candidate(2) == true)\n\t@test(candidate(3) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first repeated character in a given string.\n\t\"\"\"\nfunction first_repeated_char(str1::String)::Union{String, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_repeated_char;\n\t@test(candidate(\"abcabc\") == \"a\")\n\t@test(candidate(\"abc\") == nothing)\n\t@test(candidate(\"123123\") == \"1\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\nfunction get_ludic(n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_ludic;\n\t@test(candidate(10) == [1, 2, 3, 5, 7])\n\t@test(candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\n\t@test(candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\nfunction reverse_words(s::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_words;\n\t@test(candidate(\"python program\") == \"program python\")\n\t@test(candidate(\"java language\") == \"language java\")\n\t@test(candidate(\"indian man\") == \"man indian\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\nfunction prime_num(num::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = prime_num;\n\t@test(candidate(13) == true)\n\t@test(candidate(7) == true)\n\t@test(candidate(-1010) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\nfunction radian_degree(degree::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = radian_degree;\n\t@test(candidate(90) == 1.5707963267948966)\n\t@test(candidate(60) == 1.0471975511965976)\n\t@test(candidate(120) == 2.0943951023931953)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\nfunction find_literals(text::String, pattern::String)::Tuple{String, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_literals;\n\t@test(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") == (\"fox\", 16, 19))\n\t@test(candidate(\"Its been a very crazy procedure right\", \"crazy\") == (\"crazy\", 16, 21))\n\t@test(candidate(\"Hardest choices required strongest will\", \"will\") == (\"will\", 35, 39))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find nth bell number.\n\t\"\"\"\nfunction bell_Number(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_Number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(3) == 5)\n\t@test(candidate(4) == 15)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\n\t\"\"\"\nfunction remove_kth_element(list1::Vector{Int64}, L::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_kth_element;\n\t@test(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1])\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\n\t\"\"\"\nfunction max_of_nth(test_list::Vector{Vector{Int64}}, N::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_of_nth;\n\t@test(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19)\n\t@test(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10)\n\t@test(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function which takes a vector of vectors, where each subvector has two elements, and returns a vector of two vectors where the first vector has the first element of each subvector and the second one has the second.\n\t\"\"\"\nfunction merge(lst::Vector{Vector{Any}})::Vector{Vector{Any}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge;\n\t@test(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\n\t@test(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\n\t@test(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given vector of vectors.\n\t\"\"\"\nfunction cummulative_sum(test_list::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = cummulative_sum;\n\t@test(candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30)\n\t@test(candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37)\n\t@test(candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\n\t\"\"\"\nfunction average_tuple(nums::Vector{Vector{Int64}})::Vector{Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = average_tuple;\n\t@test(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\n\t@test(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\n\t@test(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\nfunction tuple_modulo(test_tup1::Tuple{Int64, Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64, Int64})::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_modulo;\n\t@test(candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1))\n\t@test(candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1))\n\t@test(candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\nfunction min_Jumps(steps::Tuple{Int64, Int64}, d::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_Jumps;\n\t@test(candidate((3, 4), 11) == 3.5)\n\t@test(candidate((3, 4), 0) == 0)\n\t@test(candidate((11, 14), 11) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to divide two vectors element wise.\n\t\"\"\"\nfunction div_list(nums1::Vector{Int64}, nums2::Vector{Int64})::Vector{Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = div_list;\n\t@test(candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0])\n\t@test(candidate([3, 2], [1, 4]) == [3.0, 0.5])\n\t@test(candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\nfunction move_num(test_str::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_num;\n\t@test(candidate(\"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\n\t@test(candidate(\"Avengers124Assemble\") == \"AvengersAssemble124\")\n\t@test(candidate(\"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\nfunction count_Substrings(s::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_Substrings;\n\t@test(candidate(\"112112\") == 6)\n\t@test(candidate(\"111\") == 6)\n\t@test(candidate(\"1101112\") == 12)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the median of two sorted vectors of same size.\n\t\"\"\"\nfunction get_median(arr1::Vector{Int64}, arr2::Vector{Int64}, n::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_median;\n\t@test(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0)\n\t@test(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5)\n\t@test(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to compute the n-th power of each number in a vector.\n\t\"\"\"\nfunction nth_nums(nums::Vector{Int64}, n::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = nth_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30], 3) == [1000, 8000, 27000])\n\t@test(candidate([12, 15], 5) == [248832, 759375])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to convert a given string to uppercase.\n\t\"\"\"\nfunction is_upper(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_upper;\n\t@test(candidate(\"person\") == \"PERSON\")\n\t@test(candidate(\"final\") == \"FINAL\")\n\t@test(candidate(\"Valid\") == \"VALID\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to interchange the first and last element in a given vector.\n\t\"\"\"\nfunction swap_List(newList::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = swap_List;\n\t@test(candidate([1, 2, 3]) == [3, 2, 1])\n\t@test(candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\n\t@test(candidate([4, 5, 6]) == [6, 5, 4])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\nfunction triangle_area(r::Int64)::Union{Int64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = triangle_area;\n\t@test(candidate(-1) == nothing)\n\t@test(candidate(0) == 0)\n\t@test(candidate(2) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the smallest missing number from a sorted vector of natural numbers.\n\t\"\"\"\nfunction find_First_Missing(array::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_First_Missing;\n\t@test(candidate([0, 1, 2, 3]) == 4)\n\t@test(candidate([0, 1, 2, 6, 9]) == 3)\n\t@test(candidate([2, 3, 5, 8, 9]) == 0)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\nfunction replace_spaces(string::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\n\t@test(candidate(\"I am a Programmer\") == \"I%20am%20a%20Programmer\")\n\t@test(candidate(\"I love Coding\") == \"I%20love%20Coding\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find even numbers from a vector of numbers.\n\t\"\"\"\nfunction Split(list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Split;\n\t@test(candidate([1, 2, 3, 4, 5]) == [2, 4])\n\t@test(candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\n\t@test(candidate([8, 12, 15, 19]) == [8, 12])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find smallest number in a vector.\n\t\"\"\"\nfunction smallest_num(xs::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = smallest_num;\n\t@test(candidate([10, 20, 1, 45, 99]) == 1)\n\t@test(candidate([1, 2, 3]) == 1)\n\t@test(candidate([45, 46, 50, 60]) == 45)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\nfunction get_coordinates(test_tup::Tuple{Int64, Int64})::Vector{Vector{Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_coordinates;\n\t@test(candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\n\t@test(candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\n\t@test(candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\nfunction replace_spaces(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_spaces;\n\t@test(candidate(\"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\n\t@test(candidate(\"The_Avengers\") == \"The Avengers\")\n\t@test(candidate(\"Fast and Furious\") == \"Fast_and_Furious\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to move all zeroes to the end of the given vector.\n\t\"\"\"\nfunction move_zero(num_list::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = move_zero;\n\t@test(candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\n\t@test(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\n\t@test(candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of xor of all pairs of numbers in the given vector.\n\t\"\"\"\nfunction pair_xor_Sum(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_xor_Sum;\n\t@test(candidate([5, 9, 7, 6], 4) == 47)\n\t@test(candidate([7, 3, 5], 3) == 12)\n\t@test(candidate([7, 3], 2) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort the given vector.\n\t\"\"\"\nfunction heap_sort(iterable::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = heap_sort;\n\t@test(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\n\t@test(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\n\t@test(candidate([7, 1, 9, 5]) == [1, 5, 7, 9])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\nfunction noprofit_noloss(actual_cost::Int64, sale_amount::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = noprofit_noloss;\n\t@test(candidate(1500, 1200) == false)\n\t@test(candidate(100, 100) == true)\n\t@test(candidate(2000, 5000) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\nfunction wind_chill(v::Int64, t::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = wind_chill;\n\t@test(candidate(120, 35) == 40)\n\t@test(candidate(40, 20) == 19)\n\t@test(candidate(10, 8) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\n\t\"\"\"\nfunction sample_nam(sample_names::Vector{String})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sample_nam;\n\t@test(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\n\t@test(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\n\t@test(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple vector.\n\t\"\"\"\nfunction max_difference(test_list::Vector{Tuple{Int64, Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_difference;\n\t@test(candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\n\t@test(candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\n\t@test(candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\nfunction remove_parenthesis(items::Vector{String})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_parenthesis;\n\t@test(candidate([\"python (chrome)\"]) == \"python\")\n\t@test(candidate([\"string(.abc)\"]) == \"string\")\n\t@test(candidate([\"alpha(num)\"]) == \"alpha\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\nfunction is_nonagonal(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_nonagonal;\n\t@test(candidate(10) == 325)\n\t@test(candidate(15) == 750)\n\t@test(candidate(18) == 1089)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\nfunction text_match_wordz_middle(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_wordz_middle;\n\t@test(candidate(\"pythonzabc.\") == true)\n\t@test(candidate(\"zxyabc.\") == false)\n\t@test(candidate(\"  lang  .\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to reverse a vector upto a given position.\n\t\"\"\"\nfunction reverse_Array_Upto_K(input::Vector{Int64}, k::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = reverse_Array_Upto_K;\n\t@test(candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6])\n\t@test(candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7])\n\t@test(candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a vector of tuples using the second value of each tuple.\n\t\"\"\"\nfunction subject_marks(subjectmarks::Vector{Tuple{String, Int64}})::Vector{Tuple{String, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = subject_marks;\n\t@test(candidate([(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\n\t@test(candidate([(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\n\t@test(candidate([(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to flatten a vector and sum all of its elements.\n\t\"\"\"\nfunction recursive_list_sum(data_list::Vector{Union{Int64, Vector{Int64}}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = recursive_list_sum;\n\t@test(candidate([1, 2, [3, 4], [5, 6]]) == 21)\n\t@test(candidate([7, 10, [15, 14], [19, 41]]) == 106)\n\t@test(candidate([10, 20, [30, 40], [50, 60]]) == 210)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of positive numbers in a vector.\n\t\"\"\"\nfunction pos_count(list::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pos_count;\n\t@test(candidate([1, -2, 3, -4]) == 2)\n\t@test(candidate([3, 4, 5, -1]) == 3)\n\t@test(candidate([1, 2, 3, 4]) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\nfunction bell_number(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = bell_number;\n\t@test(candidate(2) == 2)\n\t@test(candidate(10) == 115975)\n\t@test(candidate(56) == 6775685320645824322581483068371419745979053216268760300)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given vector is monotonic or not.\n\t\"\"\"\nfunction is_Monotonic(A::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Monotonic;\n\t@test(candidate([6, 5, 4, 4]) == true)\n\t@test(candidate([1, 2, 2, 3]) == true)\n\t@test(candidate([1, 3, 2]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a vector contains the given subvector or not.\n\t\"\"\"\nfunction is_sublist(l::Vector{Int64}, s::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_sublist;\n\t@test(candidate([2, 4, 3, 5, 7], [3, 7]) == false)\n\t@test(candidate([2, 4, 3, 5, 7], [4, 3]) == true)\n\t@test(candidate([2, 4, 3, 5, 7], [1, 6]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\nfunction differ_At_One_Bit_Pos(a::Int64, b::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = differ_At_One_Bit_Pos;\n\t@test(candidate(13, 9) == true)\n\t@test(candidate(15, 8) == false)\n\t@test(candidate(2, 4) == false)\n\t@test(candidate(2, 3) == true)\n\t@test(candidate(5, 1) == true)\n\t@test(candidate(1, 5) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find whether all the given vectors have equal length or not.\n\t\"\"\"\nfunction get_equal(Input::Vector{Vector{Int64}})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_equal;\n\t@test(candidate([[11, 22, 33], [44, 55, 66]]) == true)\n\t@test(candidate([[1, 2, 3], [4, 5, 6, 7]]) == false)\n\t@test(candidate([[1, 2], [3, 4]]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a vector of elements.\n\t\"\"\"\nfunction comb_sort(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = comb_sort;\n\t@test(candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\n\t@test(candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\n\t@test(candidate([99, 15, 13, 47]) == [13, 15, 47, 99])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\nfunction add_dict_to_tuple(test_tup::Tuple{Int64, Int64, Int64}, test_dict::Dict{String, Int64}>)::Tuple{Int64, Int64, Int64, Dict{String, Int64}>} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_dict_to_tuple;\n\t@test(candidate((4, 5, 6), Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) == (4, 5, 6, Dict(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)))\n\t@test(candidate((1, 2, 3), Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) == (1, 2, 3, Dict(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)))\n\t@test(candidate((8, 9, 10), Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) == (8, 9, 10, Dict(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tGiven a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\nfunction maxAverageOfPath(cost::Vector{Vector{Int64}})::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = maxAverageOfPath;\n\t@test(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\n\t@test(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\n\t@test(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tThe input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\n\t\"\"\"\nfunction count_same_pair(nums1::Vector{Int64}, nums2::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_same_pair;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\n\t@test(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\n\t@test(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\n\t@test(candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\nfunction power_base_sum(base::Int64, power::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = power_base_sum;\n\t@test(candidate(2, 100) == 115)\n\t@test(candidate(8, 10) == 37)\n\t@test(candidate(8, 15) == 62)\n\t@test(candidate(3, 3) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\nfunction extract_quotation(text1::String)::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_quotation;\n\t@test(candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\n\t@test(candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\n\t@test(candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\n\t@test(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that takes as input a vector of numbers (t_1,...,t_{N+1}) and returns a vector of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\nfunction multiply_elements(test_tup::Vector{Int64})::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = multiply_elements;\n\t@test(candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80])\n\t@test(candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42])\n\t@test(candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135])\n\t@test(candidate([12]) == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\nfunction sum_list(lst1::Vector{Int64}, lst2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_list;\n\t@test(candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65])\n\t@test(candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10])\n\t@test(candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\nfunction dif_Square(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = dif_Square;\n\t@test(candidate(5) == true)\n\t@test(candidate(10) == false)\n\t@test(candidate(15) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove consecutive duplicates of a given vector.\n\t\"\"\"\nfunction consecutive_duplicates(nums::Vector{Any})::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\nfunction lateralsurface_cone(r::Int64, h::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lateralsurface_cone;\n\t@test(candidate(5, 12) == 204.20352248333654)\n\t@test(candidate(10, 15) == 566.3586699569488)\n\t@test(candidate(19, 17) == 1521.8090132193388)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\nfunction replace_specialchar(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = replace_specialchar;\n\t@test(candidate(\"Python language, Programming language.\") == \"Python:language::Programming:language:\")\n\t@test(candidate(\"a b c,d e f\") == \"a:b:c:d:e:f\")\n\t@test(candidate(\"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted vector.\n\t\"\"\"\nfunction find_first_occurrence(A::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_first_occurrence;\n\t@test(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1)\n\t@test(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2)\n\t@test(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\n\t\"\"\"\nfunction sum_Of_Subarray_Prod(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_Of_Subarray_Prod;\n\t@test(candidate([1, 2, 3]) == 20)\n\t@test(candidate([1, 2]) == 5)\n\t@test(candidate([1, 2, 3, 4]) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\nfunction toggle_middle_bits(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = toggle_middle_bits;\n\t@test(candidate(9) == 15)\n\t@test(candidate(10) == 12)\n\t@test(candidate(11) == 13)\n\t@test(candidate(65) == 127)\n\t@test(candidate(77) == 115)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/jlthon-exercises/data-structures-and-algorithms/jlthon-data-structure-exercise-24.php\n\t\"\"\"\nfunction left_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = left_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\nfunction check_str(string::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_str;\n\t@test(candidate(\"annie\") == true)\n\t@test(candidate(\"dawood\") == false)\n\t@test(candidate(\"Else\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/jlthon-exercises/data-structures-and-algorithms/jlthon-recursion-exercise-9.php\n\t\"\"\"\nfunction geometric_sum(n::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = geometric_sum;\n\t@test(candidate(7) == 1.9921875)\n\t@test(candidate(4) == 1.9375)\n\t@test(candidate(8) == 1.99609375)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\nfunction find_Index(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Index;\n\t@test(candidate(2) == 4)\n\t@test(candidate(3) == 14)\n\t@test(candidate(4) == 45)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/jlthon-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\nfunction tuple_to_dict(test_tup::Tuple{Int64, Int64, Int64, Int64, Int64, Int64})::Dict{Int64, Int64}> \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_to_dict;\n\t@test(candidate((1, 5, 7, 10, 13, 5)) == Dict(1 => 5, 7 => 10, 13 => 5))\n\t@test(candidate((1, 2, 3, 4, 5, 6)) == Dict(1 => 2, 3 => 4, 5 => 6))\n\t@test(candidate((7, 8, 9, 10, 11, 12)) == Dict(7 => 8, 9 => 10, 11 => 12))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether all the characters are same or not.\n\t\"\"\"\nfunction all_Characters_Same(s::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = all_Characters_Same;\n\t@test(candidate(\"python\") == false)\n\t@test(candidate(\"aaa\") == true)\n\t@test(candidate(\"data\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\nfunction area_tetrahedron(side::Int64)::Float64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = area_tetrahedron;\n\t@test(candidate(3) == 15.588457268119894)\n\t@test(candidate(20) == 692.8203230275509)\n\t@test(candidate(10) == 173.20508075688772)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/jlthon-program-right-rotate-vector-n/\n\t\"\"\"\nfunction rotate_right(list::Vector{Int64}, m::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rotate_right;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\nfunction check_none(test_tup::Any)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_none;\n\t@test(candidate((10, 4, 5, 6, nothing)) == true)\n\t@test(candidate((7, 8, 9, 11, 14)) == false)\n\t@test(candidate((1, 2, 3, 4, nothing)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/jlthon-exercises/lambda/jlthon-lambda-exercise-24.php\n\t\"\"\"\nfunction divisible_by_digits(startnum::Int64, endnum::Int64)::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = divisible_by_digits;\n\t@test(candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\n\t@test(candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\n\t@test(candidate(20, 25) == [22, 24])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nothing if the angle is larger than 360 degrees.\n\t\"\"\"\nfunction sector_area(r::Int64, a::Int64)::Union{Float64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sector_area;\n\t@test(candidate(4, 45) == 6.283185307179586)\n\t@test(candidate(9, 45) == 31.808625617596654)\n\t@test(candidate(9, 361) == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\nfunction lcs_of_three(X::String, Y::String, Z::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = lcs_of_three;\n\t@test(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") == 2)\n\t@test(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") == 5)\n\t@test(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\nfunction capital_words_spaces(str1::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = capital_words_spaces;\n\t@test(candidate(\"Python\") == \"Python\")\n\t@test(candidate(\"PythonProgrammingExamples\") == \"Python Programming Examples\")\n\t@test(candidate(\"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/jlthon-sort-numeric-strings-in-a-vector/\n\t\"\"\"\nfunction sort_numeric_strings(nums_str::Vector{String})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sort_numeric_strings;\n\t@test(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\n\t@test(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\n\t@test(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns vector.\n\t\"\"\"\nfunction is_samepatterns(colors::Vector{String}, patterns::Vector{String})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_samepatterns;\n\t@test(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]) == true)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]) == false)\n\t@test(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to add the given tuple to the given vector.\n\t\"\"\"\nfunction add_tuple(test_list::Vector{Int64}, test_tup::Tuple{Int64, Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = add_tuple;\n\t@test(candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10])\n\t@test(candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11])\n\t@test(candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\n\t\"\"\"\nfunction check_min_heap(arr::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_min_heap;\n\t@test(candidate([1, 2, 3, 4, 5, 6]) == true)\n\t@test(candidate([2, 3, 4, 5, 10, 15]) == true)\n\t@test(candidate([2, 10, 4, 5, 3, 15]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\nfunction jacobsthal_num(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = jacobsthal_num;\n\t@test(candidate(5) == 11)\n\t@test(candidate(2) == 1)\n\t@test(candidate(4) == 5)\n\t@test(candidate(13) == 2731)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/jlthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cojl of test cases\n\t\"\"\"\nfunction min_k(test_list::Vector{Tuple{String, Int64}}, K::Int64)::Vector{Tuple{String, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = min_k;\n\t@test(candidate([(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\n\t@test(candidate([(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\n\t@test(candidate([(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], 1) == [(\"Ayesha\", 9)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWe say that an element is common for vectors l1, l2, l3 if it appears in all three vectors under the same index. Write a function to find common elements from three vectors. The function should return a vector.\n\t\"\"\"\nfunction extract_index_list(l1::Vector{Int64}, l2::Vector{Int64}, l3::Vector{Int64})::Vector{Any} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = extract_index_list;\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\n\t@test(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\n\t@test(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\n\t@test(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == Vector{Any}([]))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the second smallest number in a vector.\n\t\"\"\"\nfunction second_smallest(numbers::Vector{Union{Int64, Float64}})::Union{Float64, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = second_smallest;\n\t@test(candidate([1, 2, -8, -2, 0, -2]) == -2)\n\t@test(candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5)\n\t@test(candidate([2, 2]) == nothing)\n\t@test(candidate([2, 2, 2]) == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/jlthon-exercises/re/jlthon-re-exercise-3.php\n\t\"\"\"\nfunction text_match_zero_one(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_zero_one;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"dsabbbba\") == true)\n\t@test(candidate(\"asbbbba\") == false)\n\t@test(candidate(\"abaaa\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/jlthon-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\nfunction count_reverse_pairs(test_list::Vector{String})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_reverse_pairs;\n\t@test(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\n\t@test(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\n\t@test(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\nfunction is_decimal(num::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_decimal;\n\t@test(candidate(\"123.11\") == true)\n\t@test(candidate(\"e666.86\") == false)\n\t@test(candidate(\"3.124587\") == false)\n\t@test(candidate(\"1.11\") == true)\n\t@test(candidate(\"1.1.11\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given vector of tuples.\n\t\"\"\"\nfunction find_tuples(test_list::Vector{Tuple{Int64, Int64, Int64}}, K::Int64)::Vector{Tuple{Int64, Int64, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_tuples;\n\t@test(candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)])\n\t@test(candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)])\n\t@test(candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether a vector of numbers contains only one distinct element or not.\n\t\"\"\"\nfunction unique_Element(arr::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = unique_Element;\n\t@test(candidate([1, 1, 1]) == true)\n\t@test(candidate([1, 2, 1, 2]) == false)\n\t@test(candidate([1, 2, 3, 4, 5]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\nfunction check_monthnumber_number(monthnum3::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_monthnumber_number;\n\t@test(candidate(6) == true)\n\t@test(candidate(2) == false)\n\t@test(candidate(12) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\nfunction find_min_diff(arr::Vector{Int64}, n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_min_diff;\n\t@test(candidate([1, 5, 3, 19, 18, 25], 6) == 1)\n\t@test(candidate([4, 3, 2, 6], 4) == 1)\n\t@test(candidate([30, 5, 20, 9], 4) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count number of digits in a given string.\n\t\"\"\"\nfunction number_ctr(str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = number_ctr;\n\t@test(candidate(\"program2bedone\") == 1)\n\t@test(candidate(\"3wonders\") == 1)\n\t@test(candidate(\"123\") == 3)\n\t@test(candidate(\"3wond-1ers2\") == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\nfunction is_polite(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_polite;\n\t@test(candidate(7) == 11)\n\t@test(candidate(4) == 7)\n\t@test(candidate(9) == 13)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to return a vector of all pairs of consecutive items in a given vector.\n\t\"\"\"\nfunction pair_wise(l1::Vector{Int64})::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pair_wise;\n\t@test(candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\n\t@test(candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\n\t@test(candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\n\t\"\"\"\nfunction get_pairs_count(arr::Vector{Int64}, sum::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_pairs_count;\n\t@test(candidate([1, 1, 1, 1], 2) == 6)\n\t@test(candidate([1, 5, 7, -1, 5], 6) == 3)\n\t@test(candidate([1, -2, 3], 1) == 1)\n\t@test(candidate([-1, -2, 3], -3) == 1)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to get the difference between two vectors.\n\t\"\"\"\nfunction Diff(li1::Vector{Int64}, li2::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Diff;\n\t@test(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15])\n\t@test(candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\n\t@test(candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\nfunction odd_num_sum(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_num_sum;\n\t@test(candidate(2) == 82)\n\t@test(candidate(3) == 707)\n\t@test(candidate(4) == 3108)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\nfunction check_expression(exp::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_expression;\n\t@test(candidate(\"{()}[{}]\") == true)\n\t@test(candidate(\"{()}[{]\") == false)\n\t@test(candidate(\"{()}[{}][]({})\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\nfunction remove_length(test_str::String, K::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_length;\n\t@test(candidate(\"The person is most value tet\", 3) == \"person is most value\")\n\t@test(candidate(\"If you told me about this ok\", 4) == \"If you me about ok\")\n\t@test(candidate(\"Forces of darkeness is come into the play\", 4) == \"Forces of darkeness is the\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return nothing if there is no match.\n\t\"\"\"\nfunction occurance_substring(text::String, pattern::String)::Union{Tuple{String, Int64, Int64}, Nothing} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = occurance_substring;\n\t@test(candidate(\"python programming, python language\", \"python\") == (\"python\", 0, 6))\n\t@test(candidate(\"python programming,programming language\", \"programming\") == (\"programming\", 7, 18))\n\t@test(candidate(\"python programming,programming language\", \"language\") == (\"language\", 31, 39))\n\t@test(candidate(\"c++ programming, c++ language\", \"python\") == nothing)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether every odd index contains odd numbers of a given vector.\n\t\"\"\"\nfunction odd_position(nums::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_position;\n\t@test(candidate([2, 1, 4, 3, 6, 7, 6, 3]) == true)\n\t@test(candidate([4, 1, 2]) == true)\n\t@test(candidate([1, 2, 3]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\nfunction count_vowels(test_str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_vowels;\n\t@test(candidate(\"bestinstareels\") == 7)\n\t@test(candidate(\"partofthejourneyistheend\") == 12)\n\t@test(candidate(\"amazonprime\") == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of non-repeated elements in a given vector.\n\t\"\"\"\nfunction find_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_sum;\n\t@test(candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21)\n\t@test(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\n\t@test(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to pack consecutive duplicates of a given vector elements into subvectors.\n\t\"\"\"\nfunction pack_consecutive_duplicates(list1::Vector{Any})::Vector{Vector{Any}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = pack_consecutive_duplicates;\n\t@test(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\n\t@test(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\n\t@test(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find whether a number is divisible by 11.\n\t\"\"\"\nfunction is_Diff(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_Diff;\n\t@test(candidate(12345) == false)\n\t@test(candidate(1212112) == true)\n\t@test(candidate(1212) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/jlthon-combinations-of-sum-with-tuples-in-tuple-vector/\n\t\"\"\"\nfunction find_combinations(test_list::Vector{Tuple{Int64, Int64}})::Vector{Tuple{Int64, Int64}} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_combinations;\n\t@test(candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\n\t@test(candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\n\t@test(candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the count of divisors is even. https://www.w3resource.com/jlthon-exercises/basic/jlthon-basic-1-exercise-24.php\n\t\"\"\"\nfunction count_divisors(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_divisors;\n\t@test(candidate(10) == true)\n\t@test(candidate(100) == false)\n\t@test(candidate(125) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\n\t\"\"\"\nfunction odd_length_sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = odd_length_sum;\n\t@test(candidate([1, 2, 4]) == 14)\n\t@test(candidate([1, 2, 1, 2]) == 15)\n\t@test(candidate([1, 7]) == 8)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\nfunction rgb_to_hsv(r::Int64, g::Int64, b::Int64)::Vector{Float64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = rgb_to_hsv;\n\t@test(candidate(255, 255, 255) == [0.0, 0.0, 100.0])\n\t@test(candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608])\n\t@test(candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the product of first even and odd number of a given vector.\n\t\"\"\"\nfunction mul_even_odd(list1::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = mul_even_odd;\n\t@test(candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4)\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\n\t@test(candidate([1, 5, 7, 9, 10]) == 10)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\nfunction tuple_str_int(test_str::String)::Tuple{Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tuple_str_int;\n\t@test(candidate(\"(7, 8, 9)\") == (7, 8, 9))\n\t@test(candidate(\"(1, 2, 3)\") == (1, 2, 3))\n\t@test(candidate(\"(4, 5, 6)\") == (4, 5, 6))\n\t@test(candidate(\"(7, 81, 19)\") == (7, 81, 19))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\nfunction right_insertion(a::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = right_insertion;\n\t@test(candidate([1, 2, 4, 5], 6) == 4)\n\t@test(candidate([1, 2, 4, 5], 3) == 2)\n\t@test(candidate([1, 2, 4, 5], 7) == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\nfunction text_match_three(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_match_three;\n\t@test(candidate(\"ac\") == false)\n\t@test(candidate(\"dc\") == false)\n\t@test(candidate(\"abbbba\") == true)\n\t@test(candidate(\"caacabbbba\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to create a new tuple from the given string and vector.\n\t\"\"\"\nfunction new_tuple(test_list::Vector{String}, test_str::String)::Tuple{String, String, String} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = new_tuple;\n\t@test(candidate([\"WEB\", \"is\"], \"best\") == (\"WEB\", \"is\", \"best\"))\n\t@test(candidate([\"We\", \"are\"], \"Developers\") == (\"We\", \"are\", \"Developers\"))\n\t@test(candidate([\"Part\", \"is\"], \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether every even index contains even numbers of a given vector.\n\t\"\"\"\nfunction even_position(nums::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = even_position;\n\t@test(candidate([3, 2, 1]) == false)\n\t@test(candidate([1, 2, 3]) == false)\n\t@test(candidate([2, 1, 4]) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\nfunction remove_nested(test_tup::Any)::Tuple{Int64, Int64, Int64, Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_nested;\n\t@test(candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\n\t@test(candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\n\t@test(candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\n\t@test(candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of vectors in a given number of vectors.\n\t\"\"\"\nfunction count_list(input_list::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_list;\n\t@test(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\n\t@test(candidate([[1, 2], [2, 3], [4, 5]]) == 3)\n\t@test(candidate([[1, 0], [2, 0]]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the last position of an element in a sorted vector.\n\t\"\"\"\nfunction last(arr::Vector{Int64}, x::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = last;\n\t@test(candidate([1, 2, 3], 1) == 0)\n\t@test(candidate([1, 1, 1, 2, 3, 4], 1) == 2)\n\t@test(candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\nfunction text_starta_endb(text::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = text_starta_endb;\n\t@test(candidate(\"aabbbb\") == true)\n\t@test(candidate(\"aabAbbbc\") == false)\n\t@test(candidate(\"accddbbjjj\") == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\nfunction return_sum(dict::Dict{String, Int64}>)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = return_sum;\n\t@test(candidate(Dict(\"a\" => 100, \"b\" => 200, \"c\" => 300)) == 600)\n\t@test(candidate(Dict(\"a\" => 25, \"b\" => 18, \"c\" => 45)) == 88)\n\t@test(candidate(Dict(\"a\" => 36, \"b\" => 39, \"c\" => 49)) == 124)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\nfunction sum_in_range(l::Int64, r::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sum_in_range;\n\t@test(candidate(2, 5) == 8)\n\t@test(candidate(5, 7) == 12)\n\t@test(candidate(7, 13) == 40)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the sum of a vector.\n\t\"\"\"\nfunction _sum(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = _sum;\n\t@test(candidate([1, 2, 3]) == 6)\n\t@test(candidate([15, 12, 13, 10]) == 50)\n\t@test(candidate([0, 1, 2]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\nfunction left_rotate(n::Int64, d::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = left_rotate;\n\t@test(candidate(16, 2) == 64)\n\t@test(candidate(10, 2) == 40)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(99, 3) == 792)\n\t@test(candidate(1, 3) == 8)\n\t@test(candidate(5, 3) == 40)\n\t@test(candidate(29, 3) == 232)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to check whether the length of the word is odd or not.\n\t\"\"\"\nfunction word_len(s::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = word_len;\n\t@test(candidate(\"Hadoop\") == false)\n\t@test(candidate(\"great\") == true)\n\t@test(candidate(\"structure\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\nfunction remove_all_spaces(text::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = remove_all_spaces;\n\t@test(candidate(\"python  program\") == \"pythonprogram\")\n\t@test(candidate(\"python   programming    language\") == \"pythonprogramminglanguage\")\n\t@test(candidate(\"python                     program\") == \"pythonprogram\")\n\t@test(candidate(\"   python                     program\") == \"pythonprogram\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of equal numbers from three given integers.\n\t\"\"\"\nfunction test_three_equal(x::Int64, y::Int64, z::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = test_three_equal;\n\t@test(candidate(1, 1, 1) == 3)\n\t@test(candidate(-1, -2, -3) == 0)\n\t@test(candidate(1, 2, 2) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\n\t\"\"\"\nfunction count_rotation(arr::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = count_rotation;\n\t@test(candidate([3, 2, 1]) == 1)\n\t@test(candidate([4, 5, 1, 2, 3]) == 2)\n\t@test(candidate([7, 8, 9, 1, 2, 3]) == 3)\n\t@test(candidate([1, 2, 3]) == 0)\n\t@test(candidate([1, 3, 2]) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\nfunction is_perfect_square(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_perfect_square;\n\t@test(candidate(10) == false)\n\t@test(candidate(36) == true)\n\t@test(candidate(14) == false)\n\t@test(candidate(196) == true)\n\t@test(candidate(125) == false)\n\t@test(candidate(15625) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the product of numbers in a vector is even or not.\n\t\"\"\"\nfunction is_product_even(arr::Vector{Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_product_even;\n\t@test(candidate([1, 2, 3]) == true)\n\t@test(candidate([1, 2, 1, 4]) == true)\n\t@test(candidate([1, 1]) == false)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function that returns the vector in a vector of vectors whose sum of elements is the highest.\n\t\"\"\"\nfunction max_sum_list(lists::Vector{Vector{Int64}})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_sum_list;\n\t@test(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\n\t@test(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\n\t@test(candidate([[2, 3, 1]]) == [2, 3, 1])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\nfunction max_run_uppercase(test_str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = max_run_uppercase;\n\t@test(candidate(\"GeMKSForGERksISBESt\") == 5)\n\t@test(candidate(\"PrECIOusMOVemENTSYT\") == 6)\n\t@test(candidate(\"GooGLEFluTTER\") == 4)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the first odd number in a given vector of numbers.\n\t\"\"\"\nfunction first_odd(nums::Vector{Int64})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = first_odd;\n\t@test(candidate([1, 3, 5]) == 1)\n\t@test(candidate([2, 4, 1, 3]) == 1)\n\t@test(candidate([8, 9, 1]) == 9)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\nfunction check_K(test_tup::Vector{Int64}, K::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_K;\n\t@test(candidate([10, 4, 5, 6, 8], 6) == true)\n\t@test(candidate([1, 2, 3, 4, 5, 6], 7) == false)\n\t@test(candidate([7, 8, 9, 44, 11, 12], 11) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\nfunction check_smaller(test_tup1::Tuple{Int64, Int64, Int64}, test_tup2::Tuple{Int64, Int64, Int64})::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = check_smaller;\n\t@test(candidate((1, 2, 3), (2, 3, 4)) == false)\n\t@test(candidate((4, 5, 6), (3, 4, 5)) == true)\n\t@test(candidate((11, 12, 13), (10, 11, 12)) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\nfunction tetrahedral_number(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = tetrahedral_number;\n\t@test(candidate(5) == 35)\n\t@test(candidate(6) == 56)\n\t@test(candidate(7) == 84)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\nfunction get_Char(strr::String)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = get_Char;\n\t@test(candidate(\"abc\") == \"f\")\n\t@test(candidate(\"gfg\") == \"t\")\n\t@test(candidate(\"ab\") == \"c\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\nfunction sequence(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = sequence;\n\t@test(candidate(10) == 6)\n\t@test(candidate(2) == 1)\n\t@test(candidate(3) == 2)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\nfunction centered_hexagonal_number(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = centered_hexagonal_number;\n\t@test(candidate(10) == 271)\n\t@test(candidate(2) == 7)\n\t@test(candidate(9) == 217)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\nfunction merge_dictionaries_three(dict1::Dict{String, String}>, dict2::Dict{String, String}>, dict3::Dict{String, String}>)::Dict{String, String}> \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = merge_dictionaries_three;\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) == Dict(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"G\" => \"Green\", \"W\" => \"White\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\")) == Dict(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"))\n\t@test(candidate(Dict(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), Dict(\"L\" => \"lavender\", \"B\" => \"Blue\"), Dict(\"G\" => \"Green\", \"W\" => \"White\")) == Dict(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to get the frequency of all the elements in a vector, returned as a dictionary.\n\t\"\"\"\nfunction freq_count(list1::Vector{Int64})::Dict{Int64, Int64}> \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = freq_count;\n\t@test(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == Dict(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1))\n\t@test(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == Dict(1 => 3, 2 => 2, 3 => 3, 4 => 3))\n\t@test(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == Dict(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\nfunction closest_num(N::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = closest_num;\n\t@test(candidate(11) == 10)\n\t@test(candidate(7) == 6)\n\t@test(candidate(12) == 11)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find squares of individual elements in a vector.\n\t\"\"\"\nfunction square_nums(nums::Vector{Int64})::Vector{Int64} \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = square_nums;\n\t@test(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n\t@test(candidate([10, 20, 30]) == [100, 400, 900])\n\t@test(candidate([12, 15]) == [144, 225])\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the longest word.\n\t\"\"\"\nfunction len_log(list1::Vector{String})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = len_log;\n\t@test(candidate([\"python\", \"PHP\", \"bigdata\"]) == 7)\n\t@test(candidate([\"a\", \"ab\", \"abc\"]) == 3)\n\t@test(candidate([\"small\", \"big\", \"tall\"]) == 5)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check if a string is present as a substring in a given vector of string values.\n\t\"\"\"\nfunction find_substring(str1::Vector{String}, sub_str::String)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_substring;\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\") == true)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\") == false)\n\t@test(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\") == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\nfunction is_undulating(n::Int64)::Bool \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = is_undulating;\n\t@test(candidate(1212121) == true)\n\t@test(candidate(1991) == false)\n\t@test(candidate(121) == true)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\nfunction power(a::Int64, b::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = power;\n\t@test(candidate(3, 4) == 81)\n\t@test(candidate(2, 3) == 8)\n\t@test(candidate(5, 5) == 3125)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tGiven a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\nfunction index_minimum(test_list::Vector{Tuple{String, Int64}})::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = index_minimum;\n\t@test(candidate([(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\n\t@test(candidate([(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\n\t@test(candidate([(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the length of the smallest vector in a vector of vectors.\n\t\"\"\"\nfunction Find_Min_Length(lst::Vector{Vector{Int64}})::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = Find_Min_Length;\n\t@test(candidate([[1], [1, 2]]) == 1)\n\t@test(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\n\t@test(candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the number of divisors of a given integer.\n\t\"\"\"\nfunction divisor(n::Int64)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = divisor;\n\t@test(candidate(15) == 4)\n\t@test(candidate(12) == 6)\n\t@test(candidate(9) == 3)\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to find frequency of each element in a flattened vector of vectors, returned in a dictionary.\n\t\"\"\"\nfunction frequency_lists(list1::Vector{Vector{Int64}})::Dict{Int64, Int64}> \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = frequency_lists;\n\t@test(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == Dict(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1))\n\t@test(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == Dict(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1))\n\t@test(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == Dict(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1))\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\nfunction decimal_to_binary(n::Int64)::String \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = decimal_to_binary;\n\t@test(candidate(8) == \"1000\")\n\t@test(candidate(18) == \"10010\")\n\t@test(candidate(7) == \"111\")\nend\n",
+    "stop_tokens": [
+      "\nfunction",
+      "\nmacro",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "jl",
+    "prompt": "\"\"\"\n\tWrite a jlthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\nfunction find_Rotations(str::String)::Int64 \n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "using Test\n\n@testset begin\n\ncandidate = find_Rotations;\n\t@test(candidate(\"aaaa\") == 1)\n\t@test(candidate(\"ab\") == 2)\n\t@test(candidate(\"abc\") == 3)\nend\n",
     "stop_tokens": [
       "\nfunction",
       "\nmacro",

--- a/prompts/mbpp-js-keep.json
+++ b/prompts/mbpp-js-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "js",
-    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "js",
-    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "js",
-    "prompt": "//Write a function to check whether a specified list is sorted or not.\nfunction issort_list(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "js",
-    "prompt": "//Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "js",
-    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "js",
     "prompt": "//Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome(num){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest_palindrome;\n  assert.deepEqual(candidate(99),101);\n  assert.deepEqual(candidate(1221),1331);\n  assert.deepEqual(candidate(120),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum(arr, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "js",
-    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "js",
-    "prompt": "//Write a python function to find the first digit of a given number.\nfunction first_Digit(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "js",
-    "prompt": "//Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "js",
-    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "js",
-    "prompt": "//Write a function to convert more than one list to nested dictionary.\nfunction convert_list_dictionary(l1, l2, l3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert_list_dictionary;\n  assert.deepEqual(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\": {\"Adina Park\": 85}}, {\"S002\": {\"Leyton Marsh\": 98}}, {\"S003\": {\"Duncan Boyle\": 89}}, {\"S004\": {\"Saim Richards\": 92}}]);\n  assert.deepEqual(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\": {\"python\": 100}}, {\"def\": {\"program\": 200}}, {\"ghi\": {\"language\": 300}}, {\"jkl\": {\"programs\": 400}}]);\n  assert.deepEqual(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\": {\"java\": 10}}, {\"A2\": {\"C\": 20}}, {\"A3\": {\"C++\": 30}}, {\"A4\": {\"DBMS\": 40}}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "js",
-    "prompt": "//Write a python function to find smallest number in a list.\nfunction smallest_num(xs){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "js",
-    "prompt": "//Write a python function to find nth bell number.\nfunction bell_Number(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "js",
-    "prompt": "//Write a function to find cubes of individual elements in a list.\nfunction cube_nums(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "js",
-    "prompt": "//Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "js",
-    "prompt": "//Write a python function to find even numbers from a list of numbers.\nfunction Split(list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "js",
-    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "js",
-    "prompt": "//Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples(test_list, K){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "js",
-    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given number is even or not.\nfunction is_Even(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of positive numbers in a list.\nfunction pos_count(list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "js",
-    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "js",
-    "prompt": "//Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "js",
-    "prompt": "//Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "js",
-    "prompt": "//Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks(subjectmarks){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "js",
-    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string, second_string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "js",
-    "prompt": "//Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "js",
-    "prompt": "//Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "js",
-    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "js",
-    "prompt": "//Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter(dict, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum(a, size){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "js",
-    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1, array_nums2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts(list1, L){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "js",
-    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text, pattern){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "js",
-    "prompt": "//Write a python function to find the volume of a triangular prism.\nfunction find_Volume(l, b, h){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "js",
-    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v, t){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "js",
-    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "js",
-    "prompt": "//Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "js",
-    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the length of the word is odd or not.\nfunction word_len(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "js",
-    "prompt": "//Write a function to drop empty items from a given dictionary.\nfunction drop_empty(dict1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = drop_empty;\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": \"Green\", \"c3\": undefined}),{\"c1\": \"Red\", \"c2\": \"Green\"});\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": undefined, \"c3\": undefined}),{\"c1\": \"Red\"});\n  assert.deepEqual(candidate({\"c1\": undefined, \"c2\": \"Green\", \"c3\": undefined}),{\"c2\": \"Green\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element(list, element){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "js",
-    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "js",
-    "prompt": "//Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear(test_tuple){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "js",
-    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "js",
-    "prompt": "//Write a function to check if the given tuples contain the k or not.\nfunction check_K(test_tup, K){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "js",
-    "prompt": "//Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists(list1, list2, list3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "js",
-    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x, y, z){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "js",
-    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "js",
-    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "js",
-    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "js",
-    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "js",
-    "prompt": "//Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "js",
-    "prompt": "//Write a function to divide two lists element wise.\nfunction div_list(nums1, nums2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "js",
-    "prompt": "//Write a function to find the list with maximum length.\nfunction max_length_list(input_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "js",
-    "prompt": "//Write a function to find all possible combinations of the elements of a given list.\nfunction combinations_list(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_list;\n  assert.deepEqual(candidate([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "js",
-    "prompt": "//Write a python function to return the negative numbers in a list.\nfunction neg_nos(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "js",
-    "prompt": "//Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "js",
-    "prompt": "//Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist(l, s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "js",
-    "prompt": "//Write a function to subtract two lists element-wise.\nfunction sub_list(nums1, nums2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x, y){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "js",
-    "prompt": "//Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "js",
-    "prompt": "//Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "js",
-    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "js",
-    "prompt": "//Write a python function to find the last digit of a given number.\nfunction last_Digit(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "js",
-    "prompt": "//Write a function to convert a list to a string.\nfunction tup_string(tup1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "js",
-    "prompt": "//Write a function to remove all elements from a given list present in another list.\nfunction remove_elements(list1, list2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "js",
-    "prompt": "//Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1, list2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "js",
-    "prompt": "//Write a python function to identify non-prime numbers.\nfunction is_not_prime(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val(listval){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "js",
-    "prompt": "//Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "js",
-    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "js",
-    "prompt": "//Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split(list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "js",
-    "prompt": "//Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "js",
-    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "js",
-    "prompt": "//Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product(nums1, nums2, N){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "js",
-    "prompt": "//Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "js",
-    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n, d){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "js",
-    "prompt": "//Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "js",
-    "prompt": "//Write a python function to count inversions in an array.\nfunction get_Inv_Count(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "js",
-    "prompt": "//Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "js",
-    "prompt": "//Write a function to find whether all the given lists have equal length or not.\nfunction get_equal(Input){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "js",
-    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "js",
-    "prompt": "//Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "js",
-    "prompt": "//Write a python function to move all zeroes to the end of the given list.\nfunction move_zero(num_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "js",
-    "prompt": "//Write a function to check if given list contains no duplicates.\nfunction check_distinct(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost, sale_amount){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "js",
-    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str, K){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "js",
-    "prompt": "//Write a python function to count number of digits in a given string.\nfunction number_ctr(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "js",
-    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "js",
-    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "js",
-    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion(a, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "js",
-    "prompt": "//Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "js",
-    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr, n, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "js",
-    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "js",
-    "prompt": "//Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "js",
-    "prompt": "//Write a function to check if all values are same in a dictionary.\nfunction check_value(dict, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "js",
-    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "js",
-    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "js",
-    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "js",
-    "prompt": "//Write a function to check whether an element exists within a tuple.\nfunction check_tuplex(tuplex, tuple1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "js",
-    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "js",
-    "prompt": "//Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "js",
-    "prompt": "//Write a function to create a list of N empty dictionaries.\nfunction empty_list(length){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = empty_list;\n  assert.deepEqual(candidate(5),[{}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(6),[{}, {}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(7),[{}, {}, {}, {}, {}, {}, {}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "js",
-    "prompt": "//Write a python function to convert a given string to uppercase.\nfunction is_upper(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "js",
-    "prompt": "//Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "js",
-    "prompt": "//Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "js",
-    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "js",
-    "prompt": "//Write a python function to count true booleans in the given list.\nfunction count(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "js",
-    "prompt": "//Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair(A){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "js",
-    "prompt": "//Write a python function to count the upper case characters in a given string.\nfunction upper_ctr(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "js",
-    "prompt": "//Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "js",
-    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors, patterns){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of lists in a given number of lists.\nfunction count_list(input_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "js",
-    "prompt": "//Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "js",
-    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X, Y, Z){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "js",
-    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of an array.\nfunction _sum(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "js",
-    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "js",
-    "prompt": "//Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right(list, m){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split(S, step){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "js",
-    "prompt": "//Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "js",
-    "prompt": "//Write a python function to convert complex numbers to polar coordinates.\nfunction convert(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "js",
-    "prompt": "//The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data(students, h, w){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_data;\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 6.0, 70),{\"Cierra Vega\": [6.2, 70]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.9, 67),{\"Cierra Vega\": [6.2, 70], \"Kierra Gentry\": [6.0, 68]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.7, 64),{\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "js",
-    "prompt": "//Write a python function to convert the given string to lower case.\nfunction is_lower(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "js",
-    "prompt": "//Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "js",
-    "prompt": "//Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring(str1, sub_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "js",
-    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1, ch, newch){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "js",
-    "prompt": "//Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "js",
-    "prompt": "//Write a function to convert a list to a tuple.\nfunction list_tuple(listx){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "js",
-    "prompt": "//Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "js",
-    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "js",
-    "prompt": "//Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array(A, B){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "js",
-    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a, n, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "js",
-    "prompt": "//Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "js",
-    "prompt": "//Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "js",
-    "prompt": "//Write a function to convert a given string to a list of characters.\nfunction string_to_tuple(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "js",
-    "prompt": "//Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "js",
-    "prompt": "//Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate(stdata){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "js",
-    "prompt": "//Write a function to sort a list of elements.\nfunction comb_sort(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "js",
-    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "js",
-    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "js",
-    "prompt": "//Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1, lst2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "js",
-    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "js",
-    "prompt": "//Write a function to apply a given format string to all of the elements in a list.\nfunction add_string(list_, string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "js",
-    "prompt": "//Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area(b, s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "js",
-    "prompt": "//Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "js",
-    "prompt": "//Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "js",
-    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "js",
-    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "js",
-    "prompt": "//Write a python function to get the difference between two lists.\nfunction Diff(li1, li2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "js",
-    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "js",
-    "prompt": "//Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum(data_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "js",
-    "prompt": "//Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr(l, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "js",
-    "prompt": "//Write a python function to find the number of divisors of a given integer.\nfunction divisor(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "js",
-    "prompt": "//Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "js",
-    "prompt": "//Write a function to find squares of individual elements in a list.\nfunction square_nums(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "js",
-    "prompt": "//Write a function to check if the given tuple has any none value or not.\nfunction check_none(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of common divisors of two given numbers.\nfunction sum(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "js",
-    "prompt": "//Write a function to find the list of maximum length in a list of lists.\nfunction max_length(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunction check_occurences(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_occurences;\n  assert.deepEqual(candidate([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3]: 2, [2, 5]: 2, [3, 6]: 1});\n  assert.deepEqual(candidate([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4]: 2, [3, 6]: 2, [4, 7]: 1});\n  assert.deepEqual(candidate([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13]: 1, [11, 23]: 1, [12, 25]: 2, [16, 23]: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "js",
-    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a, b, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "js",
-    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring(text, pattern){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "js",
-    "prompt": "//Write a function to remove tuples from the given tuple.\nfunction remove_nested(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "js",
-    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(input_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "js",
-    "prompt": "//Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1, L){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "js",
-    "prompt": "//Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple(test_tup, test_dict){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "js",
-    "prompt": "//Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n, m){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "js",
-    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "js",
-    "prompt": "//Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence(tup, lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "js",
-    "prompt": "//Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair(list1, list2, list3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "js",
-    "prompt": "//Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "js",
-    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "js",
-    "prompt": "//Write a python function to find the element of a list having maximum length.\nfunction Find_Max(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "js",
-    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n, m){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "js",
-    "prompt": "//Write a function to count the number of occurrences of a number in a given list.\nfunction frequency(a, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "js",
-    "prompt": "//Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings(nums_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "js",
-    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits(startnum, endnum){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "js",
-    "prompt": "//Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product(list_data){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "js",
-    "prompt": "//Write a python function to find the largest negative number from the given list.\nfunction largest_neg(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "js",
-    "prompt": "//Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "js",
-    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps, d){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "js",
-    "prompt": "//Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "js",
-    "prompt": "//Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element(list1, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "js",
-    "prompt": "//Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "js",
-    "prompt": "//Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "js",
-    "prompt": "//Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "js",
-    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1, arr2, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "js",
-    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "js",
-    "prompt": "//Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "js",
-    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "js",
-    "prompt": "//Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "js",
-    "prompt": "//Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "js",
-    "prompt": "//Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "js",
-    "prompt": "//Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "js",
-    "prompt": "//Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "js",
-    "prompt": "//Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "js",
-    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r, g, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "js",
-    "prompt": "//Write a function to flatten a given nested list structure.\nfunction flatten_list(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "js",
-    "prompt": "//Write a function to sort the given list.\nfunction heap_sort(iterable){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "js",
-    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1, nums2, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "js",
-    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution(a, b, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "js",
-    "prompt": "//Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "js",
-    "prompt": "//Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list(lists){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "js",
-    "prompt": "//Write a python function to interchange the first and last elements in a list.\nfunction swap_List(newList){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "js",
-    "prompt": "//Write a function to find the median of two sorted lists of same size.\nfunction get_median(arr1, arr2, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "js",
-    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "js",
-    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1, num2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "js",
-    "prompt": "//Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list(stringlist){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "js",
-    "prompt": "//Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "js",
-    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "js",
-    "prompt": "//Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest(nums, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "js",
-    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost, sale_amount){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "js",
-    "prompt": "//Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "js",
-    "prompt": "//Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "js",
-    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "js",
-    "prompt": "//Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity(x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "js",
-    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1, base2, height){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "js",
-    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "js",
-    "prompt": "//Write a function to find number of lists present in the given list.\nfunction find_lists(Input){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "js",
-    "prompt": "//Write a python function to find the length of the longest word.\nfunction len_log(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "js",
-    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area(r, a){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "js",
-    "prompt": "//Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "js",
-    "prompt": "//Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single(L){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "js",
-    "prompt": "//Write a python function to find whether a number is divisible by 11.\nfunction is_Diff(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "js",
-    "prompt": "//Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "js",
-    "prompt": "//Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int(test_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "js",
-    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "js",
-    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "js",
-    "prompt": "//Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "js",
-    "prompt": "//The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair(nums1, nums2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "js",
-    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "js",
-    "prompt": "//Write function to find the sum of all items in the given dictionary.\nfunction return_sum(dict){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "js",
-    "prompt": "//Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise(l1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "js",
-    "prompt": "//Write a python function to split a string into characters.\nfunction split(word){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "js",
-    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a, b, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "js",
-    "prompt": "//Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "js",
-    "prompt": "//Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "js",
-    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "js",
-    "prompt": "//Write a python function that returns the number of integer elements in a given list.\nfunction count_integer(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "js",
-    "prompt": "//Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "js",
-    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "js",
-    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "js",
-    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base, power){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "js",
-    "prompt": "//Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list(list1, list2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "js",
-    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1, char){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "js",
-    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "js",
-    "prompt": "//Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "js",
-    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w, h){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "js",
-    "prompt": "//Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items(items, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = expensive_items;\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}], 2),[{\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-1\", \"price\": 101.1}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}, {\"name\": \"Item-4\", \"price\": 22.75}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "js",
-    "prompt": "//Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1, n2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "js",
-    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "js",
-    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "js",
-    "prompt": "//Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list(list1, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "js",
-    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x, y){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "js",
-    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple(list1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4429,7 +19,7 @@
     "language": "js",
     "prompt": "//Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element(arr, k){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = kth_element;\n  assert.deepEqual(candidate([12, 3, 5, 7, 19], 2),3);\n  assert.deepEqual(candidate([17, 24, 8, 23], 3),8);\n  assert.deepEqual(candidate([16, 21, 25, 36, 4], 4),36);\n}\n\ntest();",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "js",
-    "prompt": "//Write a python function to interchange the first and last element in a given list.\nfunction swap_List(newList){\n",
+    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "js",
-    "prompt": "//Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements(test_tup){\n",
+    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n, m){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "js",
-    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a, x){\n",
+    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(input_list){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "js",
-    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x){\n",
+    "prompt": "//Write a python function to count true booleans in the given list.\nfunction count(lst){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "js",
-    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list){\n",
+    "prompt": "//Write a function to append the given list to the given tuples.\nfunction add_lists(test_list, test_tup){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "js",
-    "prompt": "//Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A, N){\n",
+    "prompt": "//Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list(num1, num2, num3){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "js",
-    "prompt": "//Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l, r){\n",
+    "prompt": "//Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s, n){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "js",
-    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a){\n",
+    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "js",
-    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n){\n",
+    "prompt": "//Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int(nums){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "js",
-    "prompt": "//Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar(test_tup1, test_tup2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "js",
-    "prompt": "//Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp(words){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "js",
-    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "js",
-    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "js",
-    "prompt": "//Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n, l, r){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "js",
-    "prompt": "//Write a python function to get the first element of each sublist.\nfunction Extract(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "js",
-    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r, h){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "js",
-    "prompt": "//Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "js",
-    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "js",
-    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "js",
-    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "js",
-    "prompt": "//Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even(test_tuple){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4789,249 +169,9 @@
     "language": "js",
     "prompt": "//Write a function to convert all possible convertible elements in a list of lists to floats.\nfunction list_to_float(test_list){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_to_float;\n  assert.deepEqual(candidate([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]]);\n  assert.deepEqual(candidate([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]]);\n  assert.deepEqual(candidate([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "js",
-    "prompt": "//Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count(arr, sum){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "js",
-    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "js",
-    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "js",
-    "prompt": "//Write a python function to check if a given number is one less than twice its reverse.\nfunction checks(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "js",
-    "prompt": "//Write a python function to find the last position of an element in a sorted array.\nfunction last(arr, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "js",
-    "prompt": "//Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X(tup, x){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "js",
-    "prompt": "//We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list(l1, l2, l3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "js",
-    "prompt": "//Write a function to find the second smallest number in a list.\nfunction second_smallest(numbers){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "js",
-    "prompt": "//Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple(test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "js",
-    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "js",
-    "prompt": "//Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list(list1, m, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "js",
-    "prompt": "//Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three(dict1, dict2, dict3){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "js",
-    "prompt": "//Write a python function to find the minimum of two numbers.\nfunction minimum(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "js",
-    "prompt": "//Write a python function to find element at a given index after number of rotations.\nfunction find_Element(arr, ranges, rotations, index){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5044,7 +184,7 @@
     "language": "js",
     "prompt": "//Write a function to convert a string to a list of strings split on the space character.\nfunction string_to_list(string){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_list;\n  assert.deepEqual(candidate(\"python programming\"),[\"python\", \"programming\"]);\n  assert.deepEqual(candidate(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"]);\n  assert.deepEqual(candidate(\"write a program\"),[\"write\", \"a\", \"program\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "js",
     "prompt": "//Write a python function to find the element that appears only once in a sorted array.\nfunction search(arr){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([1, 1, 2, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4, 4]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "js",
-    "prompt": "//Write a function to sort a dictionary by value.\nfunction sort_counter(dict1){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5089,7 +214,7 @@
     "language": "js",
     "prompt": "//Write a python function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ(s, ch){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_Occ;\n  assert.deepEqual(candidate(\"hello\", \"l\"),\"heo\");\n  assert.deepEqual(candidate(\"abcda\", \"a\"),\"bcd\");\n  assert.deepEqual(candidate(\"PHP\", \"P\"),\"H\");\n}\n\ntest();",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "js",
-    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l){\n",
+    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple(list1){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "js",
-    "prompt": "//Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element(list1, list2){\n",
+    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "js",
-    "prompt": "//Write a function to append the given list to the given tuples.\nfunction add_lists(test_list, test_tup){\n",
+    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "js",
-    "prompt": "//Write a function to compute the n-th power of each number in a list.\nfunction nth_nums(nums, n){\n",
+    "prompt": "//Write a python function to find the sum of common divisors of two given numbers.\nfunction sum(a, b){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "js",
-    "prompt": "//Write a function to sort a list of elements.\nfunction pancake_sort(nums){\n",
+    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x, y){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "js",
-    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a, b, c){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "js",
-    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr, number){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element(list, element){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "js",
-    "prompt": "//Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string(str, l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "js",
-    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "js",
-    "prompt": "//Write a function to trim each list by k in the given lists.\nfunction trim_tuple(test_list, K){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "js",
-    "prompt": "//Write a python function to find the sublist having minimum length.\nfunction Find_Min(lst){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "js",
-    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "js",
-    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "js",
-    "prompt": "//Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth(test_list, N){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "js",
-    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors(l, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "js",
-    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "js",
-    "prompt": "//Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1, str2){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "js",
-    "prompt": "//Write a function to create a new tuple from the given string and list.\nfunction new_tuple(test_list, test_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "js",
-    "prompt": "//Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr, n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "js",
-    "prompt": "//Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val(listval){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "js",
-    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "js",
-    "prompt": "//Write a function to add the given tuple to the given list.\nfunction add_tuple(test_list, test_tup){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "js",
-    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "js",
-    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "js",
-    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a, n, index, k){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5524,7 +304,7 @@
     "language": "js",
     "prompt": "//Write a function to find words that are longer than n characters from a given list of words.\nfunction long_words(n, str){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = long_words;\n  assert.deepEqual(candidate(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"]);\n  assert.deepEqual(candidate(2, \"writing a program\"),[\"writing\", \"program\"]);\n  assert.deepEqual(candidate(5, \"sorting list\"),[\"sorting\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "js",
-    "prompt": "//Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum(arr){\n",
+    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "js",
-    "prompt": "//Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict(test_tup){\n",
+    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "js",
-    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates(test_tup){\n",
+    "prompt": "//Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences(nums){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "js",
-    "prompt": "//Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type(test_tuple){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "js",
-    "prompt": "//Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing(array){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "js",
-    "prompt": "//Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k(test_list, K){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "js",
-    "prompt": "//Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "js",
-    "prompt": "//Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "js",
-    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "js",
-    "prompt": "//Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations(test_list){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "js",
-    "prompt": "//Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist, item){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "js",
-    "prompt": "//Write a python function to remove odd numbers from a given list.\nfunction remove_odd(l){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "js",
-    "prompt": "//Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even(arr){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "js",
-    "prompt": "//Write a python function to find the maximum of two numbers.\nfunction maximum(a, b){\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5794,9 +364,759 @@
     "language": "js",
     "prompt": "//Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels(str1){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_vowels;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"USA\"),\"ASU\");\n  assert.deepEqual(candidate(\"ab\"),\"ab\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "js",
+    "prompt": "//Write a function to convert a list to a string.\nfunction tup_string(tup1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "js",
+    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort a list of elements.\nfunction pancake_sort(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "js",
+    "prompt": "//Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair(list1, list2, list3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "js",
+    "prompt": "//Write a function to find number of lists present in the given list.\nfunction find_lists(Input){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "js",
+    "prompt": "//Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "js",
+    "prompt": "//Write a python function to find the volume of a triangular prism.\nfunction find_Volume(l, b, h){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "js",
+    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution(a, b, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "js",
+    "prompt": "//Write a function to remove all elements from a given list present in another list.\nfunction remove_elements(list1, list2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "js",
+    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1, num2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "js",
+    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "js",
+    "prompt": "//Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair(A){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "js",
+    "prompt": "//Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "js",
+    "prompt": "//Write a function to count the number of occurrences of a number in a given list.\nfunction frequency(a, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "js",
+    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "js",
+    "prompt": "//Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list(list1, m, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "js",
+    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "js",
+    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "js",
+    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "js",
+    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string, second_string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "js",
+    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "js",
+    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "js",
+    "prompt": "//Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type(test_tuple){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "js",
+    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr, n, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "js",
+    "prompt": "//Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "js",
+    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a, b, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "js",
+    "prompt": "//Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n, l, r){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "js",
+    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1, char){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "js",
+    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "js",
+    "prompt": "//Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunction check_occurences(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_occurences;\n  assert.deepEqual(candidate([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3]: 2, [2, 5]: 2, [3, 6]: 1});\n  assert.deepEqual(candidate([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4]: 2, [3, 6]: 2, [4, 7]: 1});\n  assert.deepEqual(candidate([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13]: 1, [11, 23]: 1, [12, 25]: 2, [16, 23]: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "js",
+    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "js",
+    "prompt": "//Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list(list1, list2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "js",
+    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "js",
+    "prompt": "//Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "js",
+    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "js",
+    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "js",
+    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1, array_nums2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "js",
+    "prompt": "//Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X(tup, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "js",
+    "prompt": "//Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element(list, element){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "js",
+    "prompt": "//Write a python function to convert complex numbers to polar coordinates.\nfunction convert(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "js",
+    "prompt": "//Write a python function that returns the number of integer elements in a given list.\nfunction count_integer(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "js",
+    "prompt": "//Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors(l, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "js",
+    "prompt": "//Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "js",
+    "prompt": "//Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5809,7 +1129,7 @@
     "language": "js",
     "prompt": "//Write a function to maximize the given two lists.\nfunction maximize_elements(test_tup1, test_tup2){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximize_elements;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "js",
-    "prompt": "//Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position(nums){\n",
+    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "js",
-    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string){\n",
+    "prompt": "//Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements(test_tup1, test_tup2){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "js",
-    "prompt": "//Write a python function to find the sum of even factors of a number.\nfunction sumofFactors(n){\n",
+    "prompt": "//Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts(list1, L){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "js",
-    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r, h){\n",
+    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "js",
-    "prompt": "//Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr, n){\n",
+    "prompt": "//Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split(S, step){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "js",
-    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A, x){\n",
+    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5914,9 +1234,909 @@
     "language": "js",
     "prompt": "//Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum(n){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),10);\n  assert.deepEqual(candidate(3),35);\n  assert.deepEqual(candidate(4),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "js",
+    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "js",
+    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "js",
+    "prompt": "//Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "js",
+    "prompt": "//Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "js",
+    "prompt": "//Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "js",
+    "prompt": "//Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "js",
+    "prompt": "//Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter(dict, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "js",
+    "prompt": "//Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist, item){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "js",
+    "prompt": "//Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "js",
+    "prompt": "//Write a function to subtract two lists element-wise.\nfunction sub_list(nums1, nums2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "js",
+    "prompt": "//Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "js",
+    "prompt": "//Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element(list, element){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "js",
+    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "js",
+    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a, n, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "js",
+    "prompt": "//Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "js",
+    "prompt": "//Write a function to find the list of maximum length in a list of lists.\nfunction max_length(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "js",
+    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "js",
+    "prompt": "//Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n, m){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "js",
+    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w, h){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val(listval){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "js",
+    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "js",
+    "prompt": "//Write a python function to count inversions in an array.\nfunction get_Inv_Count(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "js",
+    "prompt": "//Write a function to flatten a given nested list structure.\nfunction flatten_list(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "js",
+    "prompt": "//Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate(stdata){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "js",
+    "prompt": "//Write a python function to find element at a given index after number of rotations.\nfunction find_Element(arr, ranges, rotations, index){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "js",
+    "prompt": "//Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp(words){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a, n, index, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "js",
+    "prompt": "//Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product(nums1, nums2, N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "js",
+    "prompt": "//Write a python function to find the maximum of two numbers.\nfunction maximum(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "js",
+    "prompt": "//Write a function to convert a given string to a list of characters.\nfunction string_to_tuple(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "js",
+    "prompt": "//Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "js",
+    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "js",
+    "prompt": "//Write a function to apply a given format string to all of the elements in a list.\nfunction add_string(list_, string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "js",
+    "prompt": "//Write a function to convert more than one list to nested dictionary.\nfunction convert_list_dictionary(l1, l2, l3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert_list_dictionary;\n  assert.deepEqual(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\": {\"Adina Park\": 85}}, {\"S002\": {\"Leyton Marsh\": 98}}, {\"S003\": {\"Duncan Boyle\": 89}}, {\"S004\": {\"Saim Richards\": 92}}]);\n  assert.deepEqual(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\": {\"python\": 100}}, {\"def\": {\"program\": 200}}, {\"ghi\": {\"language\": 300}}, {\"jkl\": {\"programs\": 400}}]);\n  assert.deepEqual(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\": {\"java\": 10}}, {\"A2\": {\"C\": 20}}, {\"A3\": {\"C++\": 30}}, {\"A4\": {\"DBMS\": 40}}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "js",
+    "prompt": "//Write a function to find the list with maximum length.\nfunction max_length_list(input_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "js",
+    "prompt": "//Write a function to check if given list contains no duplicates.\nfunction check_distinct(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "js",
+    "prompt": "//Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "js",
+    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a, b, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "js",
+    "prompt": "//Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "js",
+    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "js",
+    "prompt": "//Write a python function to identify non-prime numbers.\nfunction is_not_prime(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "js",
+    "prompt": "//Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "js",
+    "prompt": "//Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "js",
+    "prompt": "//Write a python function to find the minimum of two numbers.\nfunction minimum(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "js",
+    "prompt": "//Write a function to check whether an element exists within a tuple.\nfunction check_tuplex(tuplex, tuple1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "js",
+    "prompt": "//Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity(x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "js",
+    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "js",
+    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1, nums2, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "js",
+    "prompt": "//Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "js",
+    "prompt": "//Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val(listval){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "js",
+    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "js",
+    "prompt": "//Write a python function to remove odd numbers from a given list.\nfunction remove_odd(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "js",
+    "prompt": "//Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element(list1, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "js",
+    "prompt": "//Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1, list2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "js",
+    "prompt": "//Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5929,7 +2149,7 @@
     "language": "js",
     "prompt": "//Write a function to find common first element in given list of lists.\nfunction group_tuples(Input){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = group_tuples;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n  assert.deepEqual(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "js",
-    "prompt": "//Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list(num1, num2, num3){\n",
+    "prompt": "//Write a python function to find the element of a list having maximum length.\nfunction Find_Max(lst){\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "js",
+    "prompt": "//Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "js",
+    "prompt": "//Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "js",
+    "prompt": "//Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "js",
+    "prompt": "//Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear(test_tuple){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "js",
+    "prompt": "//Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list(list1, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "js",
+    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "js",
+    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "js",
+    "prompt": "//Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "js",
+    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a, b, c){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "js",
+    "prompt": "//Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element(list1, list2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "js",
+    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1, base2, height){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "js",
+    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr, number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "js",
+    "prompt": "//Write a python function to find the last digit of a given number.\nfunction last_Digit(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "js",
+    "prompt": "//Write a python function to return the negative numbers in a list.\nfunction neg_nos(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "js",
+    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "js",
+    "prompt": "//Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "js",
+    "prompt": "//Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single(L){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "js",
+    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "js",
+    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "js",
+    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "js",
+    "prompt": "//Write a python function to find the largest negative number from the given list.\nfunction largest_neg(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "js",
+    "prompt": "//Write a function to trim each list by k in the given lists.\nfunction trim_tuple(test_list, K){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "js",
+    "prompt": "//Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "js",
+    "prompt": "//Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence(tup, lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "js",
+    "prompt": "//Write a function to find cubes of individual elements in a list.\nfunction cube_nums(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "js",
+    "prompt": "//Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string(str, l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "js",
+    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "js",
+    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost, sale_amount){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of even factors of a number.\nfunction sumofFactors(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "js",
+    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "js",
+    "prompt": "//Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list(stringlist){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "js",
+    "prompt": "//Write a python function to find the sublist having minimum length.\nfunction Find_Min(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "js",
+    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "js",
+    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "js",
+    "prompt": "//Write a python function to get the first element of each sublist.\nfunction Extract(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "js",
+    "prompt": "//Write a python function to count the upper case characters in a given string.\nfunction upper_ctr(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "js",
+    "prompt": "//Write a function to find all possible combinations of the elements of a given list.\nfunction combinations_list(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_list;\n  assert.deepEqual(candidate([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "js",
+    "prompt": "//Write a function to check if all values are same in a dictionary.\nfunction check_value(dict, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "js",
+    "prompt": "//Write a function to drop empty items from a given dictionary.\nfunction drop_empty(dict1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = drop_empty;\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": \"Green\", \"c3\": undefined}),{\"c1\": \"Red\", \"c2\": \"Green\"});\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": undefined, \"c3\": undefined}),{\"c1\": \"Red\"});\n  assert.deepEqual(candidate({\"c1\": undefined, \"c2\": \"Green\", \"c3\": undefined}),{\"c2\": \"Green\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "js",
+    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "js",
+    "prompt": "//Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive(l){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "js",
+    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1, ch, newch){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "js",
+    "prompt": "//Write a function to sort a dictionary by value.\nfunction sort_counter(dict1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "js",
+    "prompt": "//Write a python function to convert the given string to lower case.\nfunction is_lower(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "js",
+    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "js",
+    "prompt": "//Write a python function to find the first digit of a given number.\nfunction first_Digit(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "js",
+    "prompt": "//Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest(nums, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "js",
+    "prompt": "//Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split(list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "js",
+    "prompt": "//Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A, N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "js",
+    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1, n2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum(a, size){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "js",
+    "prompt": "//Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "js",
+    "prompt": "//Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "js",
+    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "js",
+    "prompt": "//Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "js",
+    "prompt": "//Write a python function to split a string into characters.\nfunction split(word){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "js",
+    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "js",
+    "prompt": "//Write a function to check whether a specified list is sorted or not.\nfunction issort_list(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "js",
+    "prompt": "//Write a function to create a list of N empty dictionaries.\nfunction empty_list(length){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = empty_list;\n  assert.deepEqual(candidate(5),[{}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(6),[{}, {}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(7),[{}, {}, {}, {}, {}, {}, {}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "js",
+    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "js",
+    "prompt": "//Write a python function to check if a given number is one less than twice its reverse.\nfunction checks(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "js",
+    "prompt": "//Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "js",
+    "prompt": "//Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product(list_data){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "js",
+    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r, h){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "js",
+    "prompt": "//Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array(A, B){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "js",
+    "prompt": "//Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "js",
+    "prompt": "//Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists(list1, list2, list3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "js",
+    "prompt": "//Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "js",
+    "prompt": "//Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "js",
+    "prompt": "//Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even(test_tuple){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "js",
+    "prompt": "//Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area(b, s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "js",
+    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "js",
+    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "js",
+    "prompt": "//Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items(items, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = expensive_items;\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}], 2),[{\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-1\", \"price\": 101.1}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}, {\"name\": \"Item-4\", \"price\": 22.75}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "js",
+    "prompt": "//Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr(l, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "js",
+    "prompt": "//Write a function to convert a list to a tuple.\nfunction list_tuple(listx){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "js",
+    "prompt": "//Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "js",
+    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x, y){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "js",
+    "prompt": "//Write a python function to interchange the first and last elements in a list.\nfunction swap_List(newList){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "js",
+    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "js",
+    "prompt": "//Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "js",
+    "prompt": "//Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1, str2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "js",
+    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1, arr2, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "js",
+    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given number is even or not.\nfunction is_Even(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "js",
+    "prompt": "//Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "js",
+    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "js",
+    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "js",
+    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "js",
+    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "js",
+    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text, pattern){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "js",
+    "prompt": "//Write a python function to find nth bell number.\nfunction bell_Number(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "js",
+    "prompt": "//Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1, L){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "js",
+    "prompt": "//Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth(test_list, N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "js",
+    "prompt": "//Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "js",
+    "prompt": "//Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "js",
+    "prompt": "//Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "js",
+    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps, d){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "js",
+    "prompt": "//Write a function to divide two lists element wise.\nfunction div_list(nums1, nums2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "js",
+    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "js",
+    "prompt": "//Write a function to find the median of two sorted lists of same size.\nfunction get_median(arr1, arr2, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "js",
+    "prompt": "//Write a function to compute the n-th power of each number in a list.\nfunction nth_nums(nums, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "js",
+    "prompt": "//Write a python function to convert a given string to uppercase.\nfunction is_upper(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "js",
+    "prompt": "//Write a python function to interchange the first and last element in a given list.\nfunction swap_List(newList){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "js",
+    "prompt": "//Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "js",
+    "prompt": "//Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing(array){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "js",
+    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "js",
+    "prompt": "//Write a python function to find even numbers from a list of numbers.\nfunction Split(list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "js",
+    "prompt": "//Write a python function to find smallest number in a list.\nfunction smallest_num(xs){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "js",
+    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "js",
+    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "js",
+    "prompt": "//Write a python function to move all zeroes to the end of the given list.\nfunction move_zero(num_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum(arr, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort the given list.\nfunction heap_sort(iterable){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost, sale_amount){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "js",
+    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v, t){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "js",
+    "prompt": "//Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "js",
+    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "js",
+    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "js",
+    "prompt": "//Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input, k){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "js",
+    "prompt": "//Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks(subjectmarks){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "js",
+    "prompt": "//Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum(data_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of positive numbers in a list.\nfunction pos_count(list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "js",
+    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "js",
+    "prompt": "//Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist(l, s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "js",
+    "prompt": "//Write a function to find whether all the given lists have equal length or not.\nfunction get_equal(Input){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort a list of elements.\nfunction comb_sort(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "js",
+    "prompt": "//Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple(test_tup, test_dict){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "js",
+    "prompt": "//Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "js",
+    "prompt": "//The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data(students, h, w){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_data;\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 6.0, 70),{\"Cierra Vega\": [6.2, 70]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.9, 67),{\"Cierra Vega\": [6.2, 70], \"Kierra Gentry\": [6.0, 68]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.7, 64),{\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "js",
+    "prompt": "//The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair(nums1, nums2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "js",
+    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base, power){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "js",
+    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "js",
+    "prompt": "//Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "js",
+    "prompt": "//Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1, lst2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "js",
+    "prompt": "//Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "js",
+    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r, h){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "js",
+    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "js",
+    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "js",
+    "prompt": "//Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "js",
+    "prompt": "//Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "js",
+    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion(a, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "js",
+    "prompt": "//Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "js",
+    "prompt": "//Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "js",
+    "prompt": "//Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "js",
+    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "js",
+    "prompt": "//Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right(list, m){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "js",
+    "prompt": "//Write a function to check if the given tuple has any none value or not.\nfunction check_none(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "js",
+    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits(startnum, endnum){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "js",
+    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area(r, a){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "js",
+    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X, Y, Z){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "js",
+    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "js",
+    "prompt": "//Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings(nums_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "js",
+    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors, patterns){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "js",
+    "prompt": "//Write a function to add the given tuple to the given list.\nfunction add_tuple(test_list, test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "js",
+    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "js",
+    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "js",
+    "prompt": "//Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k(test_list, K){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "js",
+    "prompt": "//We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list(l1, l2, l3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "js",
+    "prompt": "//Write a function to find the second smallest number in a list.\nfunction second_smallest(numbers){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "js",
+    "prompt": "//Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "js",
+    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "js",
+    "prompt": "//Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples(test_list, K){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "js",
+    "prompt": "//Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "js",
+    "prompt": "//Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr, n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "js",
+    "prompt": "//Write a python function to count number of digits in a given string.\nfunction number_ctr(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "js",
+    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "js",
+    "prompt": "//Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise(l1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count(arr, sum){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "js",
+    "prompt": "//Write a python function to get the difference between two lists.\nfunction Diff(li1, li2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "js",
+    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "js",
+    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str, K){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "js",
+    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring(text, pattern){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "js",
+    "prompt": "//Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "js",
+    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "js",
+    "prompt": "//Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "js",
+    "prompt": "//Write a python function to find whether a number is divisible by 11.\nfunction is_Diff(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "js",
+    "prompt": "//Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "js",
+    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r, g, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "js",
+    "prompt": "//Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "js",
+    "prompt": "//Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int(test_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "js",
+    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "js",
+    "prompt": "//Write a function to create a new tuple from the given string and list.\nfunction new_tuple(test_list, test_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "js",
+    "prompt": "//Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "js",
+    "prompt": "//Write a function to remove tuples from the given tuple.\nfunction remove_nested(test_tup){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of lists in a given number of lists.\nfunction count_list(input_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "js",
+    "prompt": "//Write a python function to find the last position of an element in a sorted array.\nfunction last(arr, x){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "js",
+    "prompt": "//Write function to find the sum of all items in the given dictionary.\nfunction return_sum(dict){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l, r){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "js",
+    "prompt": "//Write a python function to find the sum of an array.\nfunction _sum(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "js",
+    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n, d){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "js",
+    "prompt": "//Write a python function to check whether the length of the word is odd or not.\nfunction word_len(s){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "js",
+    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x, y, z){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "js",
+    "prompt": "//Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "js",
+    "prompt": "//Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even(arr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "js",
+    "prompt": "//Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list(lists){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "js",
+    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "js",
+    "prompt": "//Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "js",
+    "prompt": "//Write a function to check if the given tuples contain the k or not.\nfunction check_K(test_tup, K){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "js",
+    "prompt": "//Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller(test_tup1, test_tup2){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "js",
+    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "js",
+    "prompt": "//Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "js",
+    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "js",
+    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "js",
+    "prompt": "//Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three(dict1, dict2, dict3){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "js",
+    "prompt": "//Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "js",
+    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "js",
+    "prompt": "//Write a function to find squares of individual elements in a list.\nfunction square_nums(nums){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "js",
+    "prompt": "//Write a python function to find the length of the longest word.\nfunction len_log(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "js",
+    "prompt": "//Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring(str1, sub_str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "js",
+    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a, b){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "js",
+    "prompt": "//Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum(test_list){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "js",
+    "prompt": "//Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length(lst){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "js",
+    "prompt": "//Write a python function to find the number of divisors of a given integer.\nfunction divisor(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "js",
+    "prompt": "//Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists(list1){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "js",
+    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "js",
+    "prompt": "//Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str){\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/mbpp-js-reworded.json
+++ b/prompts/mbpp-js-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "js",
-    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "js",
-    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "js",
-    "prompt": "//Write a function to check whether a specified array is sorted or not.\nfunction issort_list(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "js",
-    "prompt": "//Write a function to count bidirectional array pairs.\nfunction count_bidirectional(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "js",
-    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "js",
     "prompt": "//Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome(num){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest_palindrome;\n  assert.deepEqual(candidate(99),101);\n  assert.deepEqual(candidate(1221),1331);\n  assert.deepEqual(candidate(120),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum(arr, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "js",
-    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the first digit of a given number.\nfunction first_Digit(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "js",
-    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "js",
-    "prompt": "//Write a function to convert more than one array to nested object.\nfunction convert_list_dictionary(l1, l2, l3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert_list_dictionary;\n  assert.deepEqual(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\": {\"Adina Park\": 85}}, {\"S002\": {\"Leyton Marsh\": 98}}, {\"S003\": {\"Duncan Boyle\": 89}}, {\"S004\": {\"Saim Richards\": 92}}]);\n  assert.deepEqual(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\": {\"python\": 100}}, {\"def\": {\"program\": 200}}, {\"ghi\": {\"language\": 300}}, {\"jkl\": {\"programs\": 400}}]);\n  assert.deepEqual(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\": {\"java\": 10}}, {\"A2\": {\"C\": 20}}, {\"A3\": {\"C++\": 30}}, {\"A4\": {\"DBMS\": 40}}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find smallest number in an array.\nfunction smallest_num(xs){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/jsthon-exercises/re/jsthon-re-exercise-3.php\nfunction text_match_zero_one(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find nth bell number.\nfunction bell_Number(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "js",
-    "prompt": "//Write a function to find cubes of individual elements in an array.\nfunction cube_nums(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find even numbers from an array of numbers.\nfunction Split(list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "js",
-    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "js",
-    "prompt": "//Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples(test_list, K){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "js",
-    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given number is even or not.\nfunction is_Even(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of positive numbers in an array.\nfunction pos_count(list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "js",
-    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "js",
-    "prompt": "//Write a jsthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "js",
-    "prompt": "//Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks(subjectmarks){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "js",
-    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string, second_string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "js",
-    "prompt": "//Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "js",
-    "prompt": "//Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "js",
-    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "js",
-    "prompt": "//Write a function that takes in an object and integer n and filters the object to only include entries with values greater than or equal to n.\nfunction dict_filter(dict, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum(a, size){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "js",
-    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1, array_nums2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts(list1, L){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "js",
-    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text, pattern){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the volume of a triangular prism.\nfunction find_Volume(l, b, h){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "js",
-    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v, t){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "js",
-    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether all the characters are same or not.\nfunction all_Characters_Same(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "js",
-    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the length of the word is odd or not.\nfunction word_len(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "js",
-    "prompt": "//Write a function to drop empty items from a given object.\nfunction drop_empty(dict1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = drop_empty;\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": \"Green\", \"c3\": undefined}),{\"c1\": \"Red\", \"c2\": \"Green\"});\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": undefined, \"c3\": undefined}),{\"c1\": \"Red\"});\n  assert.deepEqual(candidate({\"c1\": undefined, \"c2\": \"Green\", \"c3\": undefined}),{\"c2\": \"Green\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element(list, element){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "js",
-    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "js",
-    "prompt": "//Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear(test_tuple){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "js",
-    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "js",
-    "prompt": "//Write a function to check if the given arrays contain the k or not.\nfunction check_K(test_tup, K){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "js",
-    "prompt": "//Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists(list1, list2, list3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "js",
-    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x, y, z){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "js",
-    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "js",
-    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "js",
-    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "js",
-    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "js",
-    "prompt": "//Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "js",
-    "prompt": "//Write a function to divide two arrays element wise.\nfunction div_list(nums1, nums2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "js",
-    "prompt": "//Write a function to find the array with maximum length.\nfunction max_length_list(input_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "js",
-    "prompt": "//Write a function to find all possible combinations of the elements of a given array.\nfunction combinations_list(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_list;\n  assert.deepEqual(candidate([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "js",
-    "prompt": "//Write a jsthon function to return the negative numbers in an array.\nfunction neg_nos(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "js",
-    "prompt": "//Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist(l, s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "js",
-    "prompt": "//Write a function to subtract two arrays element-wise.\nfunction sub_list(nums1, nums2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "js",
-    "prompt": "//Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "js",
-    "prompt": "//Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "js",
-    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the last digit of a given number.\nfunction last_Digit(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "js",
-    "prompt": "//Write a function to convert an array to a string.\nfunction tup_string(tup1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "js",
-    "prompt": "//Write a function to remove all elements from a given array present in another array.\nfunction remove_elements(list1, list2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1, list2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "js",
-    "prompt": "//Write a jsthon function to identify non-prime numbers.\nfunction is_not_prime(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val(listval){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "js",
-    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "js",
-    "prompt": "//Write a jsthon function which takes an array of integers and only returns the odd ones.\nfunction Split(list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "js",
-    "prompt": "//Write a jsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "js",
-    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "js",
-    "prompt": "//Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product(nums1, nums2, N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "js",
-    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n, d){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the first repeated character in a given string.\nfunction first_repeated_char(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count inversions in an array.\nfunction get_Inv_Count(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "js",
-    "prompt": "//Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal(Input){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "js",
-    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "js",
-    "prompt": "//Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/jsthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "js",
-    "prompt": "//Write a jsthon function to move all zeroes to the end of the given array.\nfunction move_zero(num_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "js",
-    "prompt": "//Write a function to check if given array contains no duplicates.\nfunction check_distinct(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost, sale_amount){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "js",
-    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str, K){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count number of digits in a given string.\nfunction number_ctr(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "js",
-    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "js",
-    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "js",
-    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/jsthon-exercises/data-structures-and-algorithms/jsthon-data-structure-exercise-24.php\nfunction left_insertion(a, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "js",
-    "prompt": "//Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "js",
-    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr, n, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "js",
-    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "js",
-    "prompt": "//Write a function to check if all values are same in an object.\nfunction check_value(dict, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "js",
-    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "js",
-    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "js",
-    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "js",
-    "prompt": "//Write a function to check whether an element exists within an array.\nfunction check_tuplex(tuplex, tuple1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "js",
-    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "js",
-    "prompt": "//Write a function to create an array of N empty dictionaries.\nfunction empty_list(length){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = empty_list;\n  assert.deepEqual(candidate(5),[{}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(6),[{}, {}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(7),[{}, {}, {}, {}, {}, {}, {}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "js",
-    "prompt": "//Write a jsthon function to convert a given string to uppercase.\nfunction is_upper(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "js",
-    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count true booleans in the given array.\nfunction count(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "js",
-    "prompt": "//Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair(A){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the upper case characters in a given string.\nfunction upper_ctr(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "js",
-    "prompt": "//Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "js",
-    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors, patterns){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of arrays in a given number of arrays.\nfunction count_list(input_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "js",
-    "prompt": "//Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "js",
-    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X, Y, Z){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "js",
-    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of an array.\nfunction _sum(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "js",
-    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "js",
-    "prompt": "//Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/jsthon-program-right-rotate-array-n/\nfunction rotate_right(list, m){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split(S, step){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check if the elements of a given array are unique or not.\nfunction all_unique(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "js",
-    "prompt": "//Write a jsthon function to convert complex numbers to polar coordinates.\nfunction convert(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "js",
-    "prompt": "//The input is given as - an object with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data(students, h, w){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_data;\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 6.0, 70),{\"Cierra Vega\": [6.2, 70]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.9, 67),{\"Cierra Vega\": [6.2, 70], \"Kierra Gentry\": [6.0, 68]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.7, 64),{\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "js",
-    "prompt": "//Write a jsthon function to convert the given string to lower case.\nfunction is_lower(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "js",
-    "prompt": "//Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring(str1, sub_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "js",
-    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1, ch, newch){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "js",
-    "prompt": "//Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "js",
-    "prompt": "//Write a function to convert an array to an array.\nfunction list_tuple(listx){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "js",
-    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array(A, B){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "js",
-    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a, n, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "js",
-    "prompt": "//Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the count of divisors is even. https://www.w3resource.com/jsthon-exercises/basic/jsthon-basic-1-exercise-24.php\nfunction count_divisors(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "js",
-    "prompt": "//Write a function to convert a given string to an array of characters.\nfunction string_to_tuple(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "js",
-    "prompt": "//Write a jsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "js",
-    "prompt": "//Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate(stdata){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "js",
-    "prompt": "//Write a function to sort an array of elements.\nfunction comb_sort(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "js",
-    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "js",
-    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "js",
-    "prompt": "//Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1, lst2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "js",
-    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "js",
-    "prompt": "//Write a function to apply a given format string to all of the elements in an array.\nfunction add_string(list_, string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the surface area of a square jsramid with a given base edge and height.\nfunction surface_Area(b, s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "js",
-    "prompt": "//Write a jsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "js",
-    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "js",
-    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "js",
-    "prompt": "//Write a jsthon function to get the difference between two arrays.\nfunction Diff(li1, li2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "js",
-    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "js",
-    "prompt": "//Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum(data_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "js",
-    "prompt": "//Write a jsthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr(l, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the number of divisors of a given integer.\nfunction divisor(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "js",
-    "prompt": "//Write a function to find squares of individual elements in an array.\nfunction square_nums(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "js",
-    "prompt": "//Write a function to check if the given array has any none value or not.\nfunction check_none(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of common divisors of two given numbers.\nfunction sum(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "js",
-    "prompt": "//Write a function to find the array of maximum length in an array of arrays.\nfunction max_length(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array of arrays and returns an object mapping each unique array to the number of times it occurs in the array.\nfunction check_occurences(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_occurences;\n  assert.deepEqual(candidate([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3]: 2, [2, 5]: 2, [3, 6]: 1});\n  assert.deepEqual(candidate([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4]: 2, [3, 6]: 2, [4, 7]: 1});\n  assert.deepEqual(candidate([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13]: 1, [11, 23]: 1, [12, 25]: 2, [16, 23]: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "js",
-    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a, b, c){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "js",
-    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return undefined if there is no match.\nfunction occurance_substring(text, pattern){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "js",
-    "prompt": "//Write a function to remove arrays from the given array.\nfunction remove_nested(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "js",
-    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(input_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "js",
-    "prompt": "//Write a jsthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1, L){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "js",
-    "prompt": "//Write a function to add an object to the array. The output should be an array.\nfunction add_dict_to_tuple(test_tup, test_dict){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n, m){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "js",
-    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence(tup, lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "js",
-    "prompt": "//Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair(list1, list2, list3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "js",
-    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "js",
-    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the element of an array having maximum length.\nfunction Find_Max(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "js",
-    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n, m){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "js",
-    "prompt": "//Write a function to count the number of occurrences of a number in a given array.\nfunction frequency(a, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "js",
-    "prompt": "//Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/jsthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings(nums_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/jsthon-exercises/data-structures-and-algorithms/jsthon-recursion-exercise-9.php\nfunction geometric_sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "js",
-    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/jsthon-exercises/lambda/jsthon-lambda-exercise-24.php\nfunction divisible_by_digits(startnum, endnum){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "js",
-    "prompt": "//Write a jsthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product(list_data){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the largest negative number from the given array.\nfunction largest_neg(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "js",
-    "prompt": "//Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "js",
-    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps, d){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "js",
-    "prompt": "//Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element(list1, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "js",
-    "prompt": "//Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "js",
-    "prompt": "//Write a jsthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "js",
-    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1, arr2, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "js",
-    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "js",
-    "prompt": "//Write a function to find frequency of each element in a flattened array of arrays, returned in an object.\nfunction frequency_lists(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "js",
-    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the first odd number in a given array of numbers.\nfunction first_odd(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "js",
-    "prompt": "//Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "js",
-    "prompt": "//Write a jsthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "js",
-    "prompt": "//Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "js",
-    "prompt": "//Write a function to get the frequency of all the elements in an array, returned as an object.\nfunction freq_count(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "js",
-    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r, g, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "js",
-    "prompt": "//Write a function to flatten a given nested array structure.\nfunction flatten_list(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "js",
-    "prompt": "//Write a function to sort the given array.\nfunction heap_sort(iterable){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "js",
-    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1, nums2, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "js",
-    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undefined if no solution exists.\nfunction find_solution(a, b, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "js",
-    "prompt": "//Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list(lists){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "js",
-    "prompt": "//Write a jsthon function to interchange the first and last elements in an array.\nfunction swap_List(newList){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "js",
-    "prompt": "//Write a function to find the median of two sorted arrays of same size.\nfunction get_median(arr1, arr2, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "js",
-    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "js",
-    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1, num2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "js",
-    "prompt": "//Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list(stringlist){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "js",
-    "prompt": "//Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "js",
-    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "js",
-    "prompt": "//Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest(nums, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "js",
-    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost, sale_amount){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "js",
-    "prompt": "//Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the length of the longest subarrays.\nfunction Find_Max_Length(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "js",
-    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find whether the parity of a given number is odd.\nfunction find_Parity(x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "js",
-    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1, base2, height){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "js",
-    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "js",
-    "prompt": "//Write a function to find number of arrays present in the given array.\nfunction find_lists(Input){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the length of the longest word.\nfunction len_log(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "js",
-    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undefined if the angle is larger than 360 degrees.\nfunction sector_area(r, a){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "js",
-    "prompt": "//Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single(L){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find whether a number is divisible by 11.\nfunction is_Diff(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "js",
-    "prompt": "//Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "js",
-    "prompt": "//Write a function to convert array string to integer array.\nfunction tuple_str_int(test_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "js",
-    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "js",
-    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "js",
-    "prompt": "//Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "js",
-    "prompt": "//Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "js",
-    "prompt": "//The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair(nums1, nums2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "js",
-    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "js",
-    "prompt": "//Write function to find the sum of all items in the given object.\nfunction return_sum(dict){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "js",
-    "prompt": "//Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise(l1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "js",
-    "prompt": "//Write a jsthon function to split a string into characters.\nfunction split(word){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "js",
-    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a, b, c){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "js",
-    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "js",
-    "prompt": "//Write a jsthon function that returns the number of integer elements in a given array.\nfunction count_integer(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "js",
-    "prompt": "//Write a jsthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "js",
-    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "js",
-    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "js",
-    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base, power){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "js",
-    "prompt": "//Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list(list1, list2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "js",
-    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1, char){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "js",
-    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "js",
-    "prompt": "//Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "js",
-    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w, h){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "js",
-    "prompt": "//Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items(items, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = expensive_items;\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}], 2),[{\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-1\", \"price\": 101.1}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}, {\"name\": \"Item-4\", \"price\": 22.75}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1, n2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "js",
-    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "js",
-    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "js",
-    "prompt": "//Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list(list1, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "js",
-    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x, y){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "js",
-    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple(list1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4429,7 +19,7 @@
     "language": "js",
     "prompt": "//Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element(arr, k){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = kth_element;\n  assert.deepEqual(candidate([12, 3, 5, 7, 19], 2),3);\n  assert.deepEqual(candidate([17, 24, 8, 23], 3),8);\n  assert.deepEqual(candidate([16, 21, 25, 36, 4], 4),36);\n}\n\ntest();",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "js",
-    "prompt": "//Write a jsthon function to interchange the first and last element in a given array.\nfunction swap_List(newList){\n",
+    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "js",
-    "prompt": "//Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements(test_tup){\n",
+    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n, m){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "js",
-    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a, x){\n",
+    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(input_list){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "js",
-    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x){\n",
+    "prompt": "//Write a jsthon function to count true booleans in the given array.\nfunction count(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "js",
-    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list){\n",
+    "prompt": "//Write a function to append the given array to the given arrays.\nfunction add_lists(test_list, test_tup){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "js",
-    "prompt": "//Write a jsthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A, N){\n",
+    "prompt": "//Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list(num1, num2, num3){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l, r){\n",
+    "prompt": "//Write a jsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s, n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "js",
-    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a){\n",
+    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "js",
-    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n){\n",
+    "prompt": "//Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "js",
-    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "js",
-    "prompt": "//Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar(test_tup1, test_tup2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "js",
-    "prompt": "//Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp(words){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "js",
-    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "js",
-    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n, l, r){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "js",
-    "prompt": "//Write a jsthon function to get the first element of each subarray.\nfunction Extract(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "js",
-    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r, h){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "js",
-    "prompt": "//Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "js",
-    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "js",
-    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "js",
-    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "js",
-    "prompt": "//Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even(test_tuple){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4789,249 +169,9 @@
     "language": "js",
     "prompt": "//Write a function to convert all possible convertible elements in an array of arrays to floats.\nfunction list_to_float(test_list){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_to_float;\n  assert.deepEqual(candidate([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]]);\n  assert.deepEqual(candidate([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]]);\n  assert.deepEqual(candidate([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "js",
-    "prompt": "//Write a jsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count(arr, sum){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "js",
-    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "js",
-    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "js",
-    "prompt": "//Write a jsthon function to check if a given number is one less than twice its reverse.\nfunction checks(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the last position of an element in a sorted array.\nfunction last(arr, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "js",
-    "prompt": "//Write a jsthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X(tup, x){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "js",
-    "prompt": "//We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list(l1, l2, l3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "js",
-    "prompt": "//Write a function to find the second smallest number in an array.\nfunction second_smallest(numbers){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "js",
-    "prompt": "//Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple(test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "js",
-    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "js",
-    "prompt": "//Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list(list1, m, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "js",
-    "prompt": "//Write a function to merge three dictionaries into a single object.\nfunction merge_dictionaries_three(dict1, dict2, dict3){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the minimum of two numbers.\nfunction minimum(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find element at a given index after number of rotations.\nfunction find_Element(arr, ranges, rotations, index){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5044,7 +184,7 @@
     "language": "js",
     "prompt": "//Write a function to convert a string to an array of strings split on the space character.\nfunction string_to_list(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_list;\n  assert.deepEqual(candidate(\"python programming\"),[\"python\", \"programming\"]);\n  assert.deepEqual(candidate(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"]);\n  assert.deepEqual(candidate(\"write a program\"),[\"write\", \"a\", \"program\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "js",
     "prompt": "//Write a jsthon function to find the element that appears only once in a sorted array.\nfunction search(arr){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([1, 1, 2, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4, 4]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "js",
-    "prompt": "//Write a function to sort an object by value.\nfunction sort_counter(dict1){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5089,7 +214,7 @@
     "language": "js",
     "prompt": "//Write a jsthon function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ(s, ch){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_Occ;\n  assert.deepEqual(candidate(\"hello\", \"l\"),\"heo\");\n  assert.deepEqual(candidate(\"abcda\", \"a\"),\"bcd\");\n  assert.deepEqual(candidate(\"PHP\", \"P\"),\"H\");\n}\n\ntest();",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "js",
-    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l){\n",
+    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple(list1){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "js",
-    "prompt": "//Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element(list1, list2){\n",
+    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "js",
-    "prompt": "//Write a function to append the given array to the given arrays.\nfunction add_lists(test_list, test_tup){\n",
+    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "js",
-    "prompt": "//Write a function to compute the n-th power of each number in an array.\nfunction nth_nums(nums, n){\n",
+    "prompt": "//Write a jsthon function to find the sum of common divisors of two given numbers.\nfunction sum(a, b){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "js",
-    "prompt": "//Write a function to sort an array of elements.\nfunction pancake_sort(nums){\n",
+    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x, y){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "js",
-    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a, b, c){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "js",
-    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr, number){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element(list, element){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "js",
-    "prompt": "//Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string(str, l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "js",
-    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "js",
-    "prompt": "//Write a function to trim each array by k in the given arrays.\nfunction trim_tuple(test_list, K){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the subarray having minimum length.\nfunction Find_Min(lst){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "js",
-    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "js",
-    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "js",
-    "prompt": "//Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth(test_list, N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "js",
-    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors(l, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "js",
-    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1, str2){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "js",
-    "prompt": "//Write a function to create a new array from the given string and array.\nfunction new_tuple(test_list, test_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr, n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "js",
-    "prompt": "//Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val(listval){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "js",
-    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "js",
-    "prompt": "//Write a function to add the given array to the given array.\nfunction add_tuple(test_list, test_tup){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "js",
-    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "js",
-    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "js",
-    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "js",
-    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a, n, index, k){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5524,7 +304,7 @@
     "language": "js",
     "prompt": "//Write a function to find words that are longer than n characters from a given array of words.\nfunction long_words(n, str){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = long_words;\n  assert.deepEqual(candidate(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"]);\n  assert.deepEqual(candidate(2, \"writing a program\"),[\"writing\", \"program\"]);\n  assert.deepEqual(candidate(5, \"sorting list\"),[\"sorting\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum(arr){\n",
+    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "js",
-    "prompt": "//Write a function to convert the given array to a key-value object using adjacent elements. https://www.geeksforgeeks.org/jsthon-convert-array-to-adjacent-pair-object/\nfunction tuple_to_dict(test_tup){\n",
+    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "js",
-    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates(test_tup){\n",
+    "prompt": "//Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences(nums){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "js",
-    "prompt": "//Write a function to check if all the elements in array have same data type or not.\nfunction check_type(test_tuple){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing(array){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "js",
-    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "js",
-    "prompt": "//Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/jsthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cojs of test cases\nfunction min_k(test_list, K){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "js",
-    "prompt": "//Write a jsthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "js",
-    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "js",
-    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "js",
-    "prompt": "//Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/jsthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations(test_list){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "js",
-    "prompt": "//Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "js",
-    "prompt": "//Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist, item){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "js",
-    "prompt": "//Write a jsthon function to remove odd numbers from a given array.\nfunction remove_odd(l){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "js",
-    "prompt": "//Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even(arr){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nconsole.log"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "js",
-    "prompt": "//Write a jsthon function to find the maximum of two numbers.\nfunction maximum(a, b){\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5794,9 +364,759 @@
     "language": "js",
     "prompt": "//Write a jsthon function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels(str1){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_vowels;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"USA\"),\"ASU\");\n  assert.deepEqual(candidate(\"ab\"),\"ab\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "js",
+    "prompt": "//Write a function to convert an array to a string.\nfunction tup_string(tup1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "js",
+    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort an array of elements.\nfunction pancake_sort(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "js",
+    "prompt": "//Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair(list1, list2, list3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "js",
+    "prompt": "//Write a function to find number of arrays present in the given array.\nfunction find_lists(Input){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the volume of a triangular prism.\nfunction find_Volume(l, b, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "js",
+    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undefined if no solution exists.\nfunction find_solution(a, b, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "js",
+    "prompt": "//Write a function to remove all elements from a given array present in another array.\nfunction remove_elements(list1, list2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "js",
+    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1, num2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "js",
+    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "js",
+    "prompt": "//Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair(A){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "js",
+    "prompt": "//Write a function to count the number of occurrences of a number in a given array.\nfunction frequency(a, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "js",
+    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "js",
+    "prompt": "//Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list(list1, m, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "js",
+    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "js",
+    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "js",
+    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "js",
+    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string, second_string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "js",
+    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "js",
+    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "js",
+    "prompt": "//Write a function to check if all the elements in array have same data type or not.\nfunction check_type(test_tuple){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "js",
+    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr, n, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "js",
+    "prompt": "//Write a jsthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "js",
+    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n, l, r){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "js",
+    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1, char){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "js",
+    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array of arrays and returns an object mapping each unique array to the number of times it occurs in the array.\nfunction check_occurences(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_occurences;\n  assert.deepEqual(candidate([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3]: 2, [2, 5]: 2, [3, 6]: 1});\n  assert.deepEqual(candidate([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4]: 2, [3, 6]: 2, [4, 7]: 1});\n  assert.deepEqual(candidate([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13]: 1, [11, 23]: 1, [12, 25]: 2, [16, 23]: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "js",
+    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "js",
+    "prompt": "//Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list(list1, list2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "js",
+    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "js",
+    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "js",
+    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "js",
+    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1, array_nums2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "js",
+    "prompt": "//Write a jsthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X(tup, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element(list, element){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "js",
+    "prompt": "//Write a jsthon function to convert complex numbers to polar coordinates.\nfunction convert(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "js",
+    "prompt": "//Write a jsthon function that returns the number of integer elements in a given array.\nfunction count_integer(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors(l, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "js",
+    "prompt": "//Write a jsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "js",
+    "prompt": "//Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5809,7 +1129,7 @@
     "language": "js",
     "prompt": "//Write a function to maximize the given two arrays.\nfunction maximize_elements(test_tup1, test_tup2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximize_elements;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "js",
-    "prompt": "//Write a jsthon function to check whether every even index contains even numbers of a given array.\nfunction even_position(nums){\n",
+    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "js",
-    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string){\n",
+    "prompt": "//Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements(test_tup1, test_tup2){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "js",
-    "prompt": "//Write a jsthon function to find the sum of even factors of a number.\nfunction sumofFactors(n){\n",
+    "prompt": "//Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts(list1, L){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "js",
-    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r, h){\n",
+    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "js",
-    "prompt": "//Write a jsthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr, n){\n",
+    "prompt": "//Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split(S, step){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "js",
-    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A, x){\n",
+    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5914,9 +1234,909 @@
     "language": "js",
     "prompt": "//Write a jsthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum(n){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),10);\n  assert.deepEqual(candidate(3),35);\n  assert.deepEqual(candidate(4),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "js",
+    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "js",
+    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "js",
+    "prompt": "//Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "js",
+    "prompt": "//Write a function that takes in an object and integer n and filters the object to only include entries with values greater than or equal to n.\nfunction dict_filter(dict, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "js",
+    "prompt": "//Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist, item){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check if the elements of a given array are unique or not.\nfunction all_unique(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "js",
+    "prompt": "//Write a function to subtract two arrays element-wise.\nfunction sub_list(nums1, nums2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "js",
+    "prompt": "//Write a jsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "js",
+    "prompt": "//Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element(list, element){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "js",
+    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "js",
+    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a, n, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "js",
+    "prompt": "//Write a function to find the array of maximum length in an array of arrays.\nfunction max_length(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "js",
+    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n, m){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "js",
+    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val(listval){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "js",
+    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count inversions in an array.\nfunction get_Inv_Count(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "js",
+    "prompt": "//Write a function to flatten a given nested array structure.\nfunction flatten_list(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "js",
+    "prompt": "//Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate(stdata){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find element at a given index after number of rotations.\nfunction find_Element(arr, ranges, rotations, index){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "js",
+    "prompt": "//Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp(words){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a, n, index, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "js",
+    "prompt": "//Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product(nums1, nums2, N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the maximum of two numbers.\nfunction maximum(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "js",
+    "prompt": "//Write a function to convert a given string to an array of characters.\nfunction string_to_tuple(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "js",
+    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "js",
+    "prompt": "//Write a function to apply a given format string to all of the elements in an array.\nfunction add_string(list_, string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "js",
+    "prompt": "//Write a function to convert more than one array to nested object.\nfunction convert_list_dictionary(l1, l2, l3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert_list_dictionary;\n  assert.deepEqual(candidate([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\": {\"Adina Park\": 85}}, {\"S002\": {\"Leyton Marsh\": 98}}, {\"S003\": {\"Duncan Boyle\": 89}}, {\"S004\": {\"Saim Richards\": 92}}]);\n  assert.deepEqual(candidate([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\": {\"python\": 100}}, {\"def\": {\"program\": 200}}, {\"ghi\": {\"language\": 300}}, {\"jkl\": {\"programs\": 400}}]);\n  assert.deepEqual(candidate([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\": {\"java\": 10}}, {\"A2\": {\"C\": 20}}, {\"A3\": {\"C++\": 30}}, {\"A4\": {\"DBMS\": 40}}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "js",
+    "prompt": "//Write a function to find the array with maximum length.\nfunction max_length_list(input_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "js",
+    "prompt": "//Write a function to check if given array contains no duplicates.\nfunction check_distinct(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "js",
+    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "js",
+    "prompt": "//Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "js",
+    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "js",
+    "prompt": "//Write a jsthon function to identify non-prime numbers.\nfunction is_not_prime(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "js",
+    "prompt": "//Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "js",
+    "prompt": "//Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the minimum of two numbers.\nfunction minimum(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "js",
+    "prompt": "//Write a function to check whether an element exists within an array.\nfunction check_tuplex(tuplex, tuple1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find whether the parity of a given number is odd.\nfunction find_Parity(x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "js",
+    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "js",
+    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1, nums2, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "js",
+    "prompt": "//Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "js",
+    "prompt": "//Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val(listval){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "js",
+    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "js",
+    "prompt": "//Write a jsthon function to remove odd numbers from a given array.\nfunction remove_odd(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "js",
+    "prompt": "//Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element(list1, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1, list2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5929,7 +2149,7 @@
     "language": "js",
     "prompt": "//Write a function to find common first element in given array of arrays.\nfunction group_tuples(Input){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = group_tuples;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n  assert.deepEqual(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "js",
-    "prompt": "//Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list(num1, num2, num3){\n",
+    "prompt": "//Write a jsthon function to find the element of an array having maximum length.\nfunction Find_Max(lst){\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "js",
+    "prompt": "//Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "js",
+    "prompt": "//Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "js",
+    "prompt": "//Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear(test_tuple){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "js",
+    "prompt": "//Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list(list1, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "js",
+    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "js",
+    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "js",
+    "prompt": "//Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "js",
+    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a, b, c){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "js",
+    "prompt": "//Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element(list1, list2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "js",
+    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1, base2, height){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "js",
+    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr, number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the last digit of a given number.\nfunction last_Digit(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "js",
+    "prompt": "//Write a jsthon function to return the negative numbers in an array.\nfunction neg_nos(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "js",
+    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "js",
+    "prompt": "//Write a function to count bidirectional array pairs.\nfunction count_bidirectional(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "js",
+    "prompt": "//Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single(L){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "js",
+    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "js",
+    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "js",
+    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the largest negative number from the given array.\nfunction largest_neg(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "js",
+    "prompt": "//Write a function to trim each array by k in the given arrays.\nfunction trim_tuple(test_list, K){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "js",
+    "prompt": "//Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence(tup, lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "js",
+    "prompt": "//Write a function to find cubes of individual elements in an array.\nfunction cube_nums(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "js",
+    "prompt": "//Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string(str, l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "js",
+    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "js",
+    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost, sale_amount){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of even factors of a number.\nfunction sumofFactors(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "js",
+    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "js",
+    "prompt": "//Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list(stringlist){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the subarray having minimum length.\nfunction Find_Min(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "js",
+    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "js",
+    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "js",
+    "prompt": "//Write a jsthon function to get the first element of each subarray.\nfunction Extract(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the upper case characters in a given string.\nfunction upper_ctr(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "js",
+    "prompt": "//Write a function to find all possible combinations of the elements of a given array.\nfunction combinations_list(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_list;\n  assert.deepEqual(candidate([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]]);\n  assert.deepEqual(candidate([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "js",
+    "prompt": "//Write a function to check if all values are same in an object.\nfunction check_value(dict, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "js",
+    "prompt": "//Write a function to drop empty items from a given object.\nfunction drop_empty(dict1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = drop_empty;\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": \"Green\", \"c3\": undefined}),{\"c1\": \"Red\", \"c2\": \"Green\"});\n  assert.deepEqual(candidate({\"c1\": \"Red\", \"c2\": undefined, \"c3\": undefined}),{\"c1\": \"Red\"});\n  assert.deepEqual(candidate({\"c1\": undefined, \"c2\": \"Green\", \"c3\": undefined}),{\"c2\": \"Green\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "js",
+    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive(l){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "js",
+    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1, ch, newch){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "js",
+    "prompt": "//Write a function to sort an object by value.\nfunction sort_counter(dict1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "js",
+    "prompt": "//Write a jsthon function to convert the given string to lower case.\nfunction is_lower(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "js",
+    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the first digit of a given number.\nfunction first_Digit(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "js",
+    "prompt": "//Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest(nums, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "js",
+    "prompt": "//Write a jsthon function which takes an array of integers and only returns the odd ones.\nfunction Split(list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A, N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "js",
+    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1, n2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum(a, size){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "js",
+    "prompt": "//Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the length of the longest subarrays.\nfunction Find_Max_Length(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "js",
+    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "js",
+    "prompt": "//Write a jsthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "js",
+    "prompt": "//Write a jsthon function to split a string into characters.\nfunction split(word){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "js",
+    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "js",
+    "prompt": "//Write a function to check whether a specified array is sorted or not.\nfunction issort_list(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "js",
+    "prompt": "//Write a function to create an array of N empty dictionaries.\nfunction empty_list(length){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = empty_list;\n  assert.deepEqual(candidate(5),[{}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(6),[{}, {}, {}, {}, {}, {}]);\n  assert.deepEqual(candidate(7),[{}, {}, {}, {}, {}, {}, {}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "js",
+    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check if a given number is one less than twice its reverse.\nfunction checks(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "js",
+    "prompt": "//Write a jsthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "js",
+    "prompt": "//Write a jsthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product(list_data){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "js",
+    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array(A, B){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "js",
+    "prompt": "//Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists(list1, list2, list3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "js",
+    "prompt": "//Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "js",
+    "prompt": "//Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even(test_tuple){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the surface area of a square jsramid with a given base edge and height.\nfunction surface_Area(b, s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "js",
+    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "js",
+    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "js",
+    "prompt": "//Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items(items, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = expensive_items;\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}], 2),[{\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-1\", \"price\": 101.1}]);\n  assert.deepEqual(candidate([{\"name\": \"Item-1\", \"price\": 101.1}, {\"name\": \"Item-2\", \"price\": 555.22}, {\"name\": \"Item-3\", \"price\": 45.09}, {\"name\": \"Item-4\", \"price\": 22.75}], 1),[{\"name\": \"Item-2\", \"price\": 555.22}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "js",
+    "prompt": "//Write a jsthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr(l, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "js",
+    "prompt": "//Write a function to convert an array to an array.\nfunction list_tuple(listx){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "js",
+    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x, y){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "js",
+    "prompt": "//Write a jsthon function to interchange the first and last elements in an array.\nfunction swap_List(newList){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "js",
+    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "js",
+    "prompt": "//Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1, str2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "js",
+    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1, arr2, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "js",
+    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given number is even or not.\nfunction is_Even(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the first repeated character in a given string.\nfunction first_repeated_char(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "js",
+    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "js",
+    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "js",
+    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "js",
+    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "js",
+    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text, pattern){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find nth bell number.\nfunction bell_Number(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "js",
+    "prompt": "//Write a jsthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1, L){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "js",
+    "prompt": "//Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth(test_list, N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "js",
+    "prompt": "//Write a jsthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "js",
+    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "js",
+    "prompt": "//Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "js",
+    "prompt": "//Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "js",
+    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps, d){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "js",
+    "prompt": "//Write a function to divide two arrays element wise.\nfunction div_list(nums1, nums2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "js",
+    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "js",
+    "prompt": "//Write a function to find the median of two sorted arrays of same size.\nfunction get_median(arr1, arr2, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "js",
+    "prompt": "//Write a function to compute the n-th power of each number in an array.\nfunction nth_nums(nums, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "js",
+    "prompt": "//Write a jsthon function to convert a given string to uppercase.\nfunction is_upper(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "js",
+    "prompt": "//Write a jsthon function to interchange the first and last element in a given array.\nfunction swap_List(newList){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing(array){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "js",
+    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find even numbers from an array of numbers.\nfunction Split(list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find smallest number in an array.\nfunction smallest_num(xs){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "js",
+    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "js",
+    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "js",
+    "prompt": "//Write a jsthon function to move all zeroes to the end of the given array.\nfunction move_zero(num_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum(arr, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort the given array.\nfunction heap_sort(iterable){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost, sale_amount){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "js",
+    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v, t){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "js",
+    "prompt": "//Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "js",
+    "prompt": "//Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "js",
+    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "js",
+    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "js",
+    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "js",
+    "prompt": "//Write a jsthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input, k){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "js",
+    "prompt": "//Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks(subjectmarks){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "js",
+    "prompt": "//Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum(data_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of positive numbers in an array.\nfunction pos_count(list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "js",
+    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "js",
+    "prompt": "//Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist(l, s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "js",
+    "prompt": "//Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal(Input){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "js",
+    "prompt": "//Write a function to sort an array of elements.\nfunction comb_sort(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "js",
+    "prompt": "//Write a function to add an object to the array. The output should be an array.\nfunction add_dict_to_tuple(test_tup, test_dict){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "js",
+    "prompt": "//Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "js",
+    "prompt": "//The input is given as - an object with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data(students, h, w){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_data;\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 6.0, 70),{\"Cierra Vega\": [6.2, 70]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.9, 67),{\"Cierra Vega\": [6.2, 70], \"Kierra Gentry\": [6.0, 68]});\n  assert.deepEqual(candidate({\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]}, 5.7, 64),{\"Cierra Vega\": [6.2, 70], \"Alden Cantrell\": [5.9, 65], \"Kierra Gentry\": [6.0, 68], \"Pierre Cox\": [5.8, 66]});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "js",
+    "prompt": "//The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair(nums1, nums2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "js",
+    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base, power){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "js",
+    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "js",
+    "prompt": "//Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "js",
+    "prompt": "//Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1, lst2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "js",
+    "prompt": "//Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "js",
+    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r, h){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "js",
+    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "js",
+    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "js",
+    "prompt": "//Write a jsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "js",
+    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/jsthon-exercises/data-structures-and-algorithms/jsthon-data-structure-exercise-24.php\nfunction left_insertion(a, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "js",
+    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/jsthon-exercises/data-structures-and-algorithms/jsthon-recursion-exercise-9.php\nfunction geometric_sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "js",
+    "prompt": "//Write a function to convert the given array to a key-value object using adjacent elements. https://www.geeksforgeeks.org/jsthon-convert-array-to-adjacent-pair-object/\nfunction tuple_to_dict(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether all the characters are same or not.\nfunction all_Characters_Same(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "js",
+    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "js",
+    "prompt": "//Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/jsthon-program-right-rotate-array-n/\nfunction rotate_right(list, m){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "js",
+    "prompt": "//Write a function to check if the given array has any none value or not.\nfunction check_none(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "js",
+    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/jsthon-exercises/lambda/jsthon-lambda-exercise-24.php\nfunction divisible_by_digits(startnum, endnum){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "js",
+    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undefined if the angle is larger than 360 degrees.\nfunction sector_area(r, a){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "js",
+    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X, Y, Z){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "js",
+    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "js",
+    "prompt": "//Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/jsthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings(nums_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "js",
+    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors, patterns){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "js",
+    "prompt": "//Write a function to add the given array to the given array.\nfunction add_tuple(test_list, test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "js",
+    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "js",
+    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "js",
+    "prompt": "//Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/jsthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cojs of test cases\nfunction min_k(test_list, K){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "js",
+    "prompt": "//We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list(l1, l2, l3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "js",
+    "prompt": "//Write a function to find the second smallest number in an array.\nfunction second_smallest(numbers){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/jsthon-exercises/re/jsthon-re-exercise-3.php\nfunction text_match_zero_one(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "js",
+    "prompt": "//Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/jsthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "js",
+    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "js",
+    "prompt": "//Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples(test_list, K){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr, n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count number of digits in a given string.\nfunction number_ctr(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "js",
+    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "js",
+    "prompt": "//Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise(l1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count(arr, sum){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "js",
+    "prompt": "//Write a jsthon function to get the difference between two arrays.\nfunction Diff(li1, li2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "js",
+    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "js",
+    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str, K){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "js",
+    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return undefined if there is no match.\nfunction occurance_substring(text, pattern){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "js",
+    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "js",
+    "prompt": "//Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find whether a number is divisible by 11.\nfunction is_Diff(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "js",
+    "prompt": "//Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/jsthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the count of divisors is even. https://www.w3resource.com/jsthon-exercises/basic/jsthon-basic-1-exercise-24.php\nfunction count_divisors(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "js",
+    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r, g, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "js",
+    "prompt": "//Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "js",
+    "prompt": "//Write a function to convert array string to integer array.\nfunction tuple_str_int(test_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "js",
+    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "js",
+    "prompt": "//Write a function to create a new array from the given string and array.\nfunction new_tuple(test_list, test_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether every even index contains even numbers of a given array.\nfunction even_position(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "js",
+    "prompt": "//Write a function to remove arrays from the given array.\nfunction remove_nested(test_tup){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of arrays in a given number of arrays.\nfunction count_list(input_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the last position of an element in a sorted array.\nfunction last(arr, x){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "js",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "js",
+    "prompt": "//Write function to find the sum of all items in the given object.\nfunction return_sum(dict){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l, r){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the sum of an array.\nfunction _sum(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "js",
+    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n, d){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "js",
+    "prompt": "//Write a jsthon function to check whether the length of the word is odd or not.\nfunction word_len(s){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "js",
+    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x, y, z){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "js",
+    "prompt": "//Write a jsthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "js",
+    "prompt": "//Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even(arr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "js",
+    "prompt": "//Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list(lists){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "js",
+    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the first odd number in a given array of numbers.\nfunction first_odd(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "js",
+    "prompt": "//Write a function to check if the given arrays contain the k or not.\nfunction check_K(test_tup, K){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "js",
+    "prompt": "//Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller(test_tup1, test_tup2){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "js",
+    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "js",
+    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "js",
+    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "js",
+    "prompt": "//Write a function to merge three dictionaries into a single object.\nfunction merge_dictionaries_three(dict1, dict2, dict3){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "js",
+    "prompt": "//Write a function to get the frequency of all the elements in an array, returned as an object.\nfunction freq_count(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "js",
+    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "js",
+    "prompt": "//Write a function to find squares of individual elements in an array.\nfunction square_nums(nums){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the length of the longest word.\nfunction len_log(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "js",
+    "prompt": "//Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring(str1, sub_str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "js",
+    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "js",
+    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a, b){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "js",
+    "prompt": "//Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum(test_list){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length(lst){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the number of divisors of a given integer.\nfunction divisor(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "js",
+    "prompt": "//Write a function to find frequency of each element in a flattened array of arrays, returned in an object.\nfunction frequency_lists(list1){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "js",
+    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nconsole.log"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "js",
+    "prompt": "//Write a jsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str){\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "const assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/mbpp-lua-keep.json
+++ b/prompts/mbpp-lua-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "lua",
-    "prompt": "-- Write a function to find the length of the longest palindromic subsequence in the given string.\nlocal function lps(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lps\n    lu.assertEquals(candidate('TENS FOR TENS'), 5)\n    lu.assertEquals(candidate('CARDIO FOR CARDS'), 7)\n    lu.assertEquals(candidate('PART OF THE JOURNEY IS PART'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all whitespaces from the given string.\nlocal function remove_whitespaces(text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_whitespaces\n    lu.assertEquals(candidate(' Google    Flutter '), 'GoogleFlutter')\n    lu.assertEquals(candidate(' Google    Dart '), 'GoogleDart')\n    lu.assertEquals(candidate(' iOS    Swift '), 'iOSSwift')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a specified list is sorted or not.\nlocal function issort_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = issort_list\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), true)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), false)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 15, 14, 20}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "lua",
-    "prompt": "-- Write a function to count bidirectional tuple pairs.\nlocal function count_bidirectional(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_bidirectional\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 3)\n    lu.assertEquals(candidate({{5, 6}, {1, 3}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 2)\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 2}, {6, 5}, {2, 1}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "lua",
-    "prompt": "-- Write a function to find the surface area of a cube of a given size.\nlocal function surfacearea_cube(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cube\n    lu.assertEquals(candidate(5), 150)\n    lu.assertEquals(candidate(3), 54)\n    lu.assertEquals(candidate(10), 600)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "lua",
     "prompt": "-- Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nlocal function next_smallest_palindrome(num)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest_palindrome\n    lu.assertEquals(candidate(99), 101)\n    lu.assertEquals(candidate(1221), 1331)\n    lu.assertEquals(candidate(120), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the cube sum of first n even natural numbers.\nlocal function cube_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_Sum\n    lu.assertEquals(candidate(2), 72)\n    lu.assertEquals(candidate(3), 288)\n    lu.assertEquals(candidate(4), 800)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of xor of all pairs of numbers in the given list.\nlocal function pair_xor_Sum(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_xor_Sum\n    lu.assertEquals(candidate({5, 9, 7, 6}, 4), 47)\n    lu.assertEquals(candidate({7, 3, 5}, 3), 12)\n    lu.assertEquals(candidate({7, 3}, 2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nlocal function check_min_heap(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_min_heap\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 10, 15}), true)\n    lu.assertEquals(candidate({2, 10, 4, 5, 3, 15}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the first digit of a given number.\nlocal function first_Digit(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_Digit\n    lu.assertEquals(candidate(123), 1)\n    lu.assertEquals(candidate(456), 4)\n    lu.assertEquals(candidate(12), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the first non-repeated character in a given string.\nlocal function first_non_repeating_character(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_non_repeating_character\n    lu.assertEquals(candidate('abcabc'), None)\n    lu.assertEquals(candidate('abc'), 'a')\n    lu.assertEquals(candidate('ababc'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "lua",
-    "prompt": "-- Write a function to convert degrees to radians.\nlocal function radian_degree(degree)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = radian_degree\n    lu.assertEquals(candidate(90), 1.5707963267948966)\n    lu.assertEquals(candidate(60), 1.0471975511965976)\n    lu.assertEquals(candidate(120), 2.0943951023931953)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum product subarray of the given array.\nlocal function max_subarray_product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_subarray_product\n    lu.assertEquals(candidate({1, -2, -3, 0, 7, -8, -2}), 112)\n    lu.assertEquals(candidate({6, -3, -10, 0, 2}), 180)\n    lu.assertEquals(candidate({-2, -40, 0, -2, -3}), 80)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "lua",
-    "prompt": "-- Write a function to convert more than one list to nested dictionary.\nlocal function convert_list_dictionary(l1, l2, l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert_list_dictionary\n    lu.assertEquals(candidate({'S001', 'S002', 'S003', 'S004'}, {'Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'}, {85, 98, 89, 92}), {{['S001'] = {['Adina Park'] = 85}}, {['S002'] = {['Leyton Marsh'] = 98}}, {['S003'] = {['Duncan Boyle'] = 89}}, {['S004'] = {['Saim Richards'] = 92}}})\n    lu.assertEquals(candidate({'abc', 'def', 'ghi', 'jkl'}, {'python', 'program', 'language', 'programs'}, {100, 200, 300, 400}), {{['abc'] = {['python'] = 100}}, {['def'] = {['program'] = 200}}, {['ghi'] = {['language'] = 300}}, {['jkl'] = {['programs'] = 400}}})\n    lu.assertEquals(candidate({'A1', 'A2', 'A3', 'A4'}, {'java', 'C', 'C++', 'DBMS'}, {10, 20, 30, 40}), {{['A1'] = {['java'] = 10}}, {['A2'] = {['C'] = 20}}, {['A3'] = {['C++'] = 30}}, {['A4'] = {['DBMS'] = 40}}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "lua",
-    "prompt": "-- Write a python function to find smallest number in a list.\nlocal function smallest_num(xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_num\n    lu.assertEquals(candidate({10, 20, 1, 45, 99}), 1)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\n    lu.assertEquals(candidate({45, 46, 50, 60}), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nlocal function text_match_zero_one(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_zero_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('dsabbbba'), true)\n    lu.assertEquals(candidate('asbbbba'), false)\n    lu.assertEquals(candidate('abaaa'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "lua",
-    "prompt": "-- Write a python function to find nth bell number.\nlocal function bell_Number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_Number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "lua",
-    "prompt": "-- Write a function to find cubes of individual elements in a list.\nlocal function cube_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 8, 27, 64, 125, 216, 343, 512, 729, 1000})\n    lu.assertEquals(candidate({10, 20, 30}), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}), {1728, 3375})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the last digit in factorial of a given number.\nlocal function last_Digit_Factorial(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit_Factorial\n    lu.assertEquals(candidate(4), 4)\n    lu.assertEquals(candidate(21), 0)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "lua",
-    "prompt": "-- Write a python function to find even numbers from a list of numbers.\nlocal function Split(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {2, 4})\n    lu.assertEquals(candidate({4, 5, 6, 7, 8, 0, 1}), {4, 6, 8, 0})\n    lu.assertEquals(candidate({8, 12, 15, 19}), {8, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given integer is a prime number.\nlocal function prime_num(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_num\n    lu.assertEquals(candidate(13), true)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(-1010), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nlocal function find_tuples(test_list, K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_tuples\n    lu.assertEquals(candidate({{6, 24, 12}, {7, 9, 6}, {12, 18, 21}}, 6), {{6, 24, 12}})\n    lu.assertEquals(candidate({{5, 25, 30}, {4, 2, 3}, {7, 8, 9}}, 5), {{5, 25, 30}})\n    lu.assertEquals(candidate({{7, 9, 16}, {8, 16, 4}, {19, 17, 18}}, 4), {{8, 16, 4}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "lua",
-    "prompt": "-- Write a function to caluclate the area of a tetrahedron.\nlocal function area_tetrahedron(side)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = area_tetrahedron\n    lu.assertEquals(candidate(3), 15.588457268119894)\n    lu.assertEquals(candidate(20), 692.8203230275509)\n    lu.assertEquals(candidate(10), 173.20508075688772)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given number is even or not.\nlocal function is_Even(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Even\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(2), true)\n    lu.assertEquals(candidate(3), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of positive numbers in a list.\nlocal function pos_count(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pos_count\n    lu.assertEquals(candidate({1, -2, 3, -4}), 2)\n    lu.assertEquals(candidate({3, 4, 5, -1}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "lua",
-    "prompt": "-- Write a function to get all lucid numbers smaller than or equal to a given integer.\nlocal function get_ludic(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_ludic\n    lu.assertEquals(candidate(10), {1, 2, 3, 5, 7})\n    lu.assertEquals(candidate(25), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25})\n    lu.assertEquals(candidate(45), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlocal function find_Index(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Index\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 14)\n    lu.assertEquals(candidate(4), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "lua",
-    "prompt": "-- Write a python function to reverse an array upto a given position.\nlocal function reverse_Array_Upto_K(input, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_Array_Upto_K\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 4), {4, 3, 2, 1, 5, 6})\n    lu.assertEquals(candidate({4, 5, 6, 7}, 2), {5, 4, 6, 7})\n    lu.assertEquals(candidate({9, 8, 7, 6, 5}, 3), {7, 8, 9, 6, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a list of tuples using the second value of each tuple.\nlocal function subject_marks(subjectmarks)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = subject_marks\n    lu.assertEquals(candidate({{'English', 88}, {'Science', 90}, {'Maths', 97}, {'Social sciences', 82}}), {{'Social sciences', 82}, {'English', 88}, {'Science', 90}, {'Maths', 97}})\n    lu.assertEquals(candidate({{'Telugu', 49}, {'Hindhi', 54}, {'Social', 33}}), {{'Social', 33}, {'Telugu', 49}, {'Hindhi', 54}})\n    lu.assertEquals(candidate({{'Physics', 96}, {'Chemistry', 97}, {'Biology', 45}}), {{'Biology', 45}, {'Physics', 96}, {'Chemistry', 97}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "lua",
-    "prompt": "-- Write a function to remove characters from the first string which are present in the second string.\nlocal function remove_dirty_chars(string, second_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_dirty_chars\n    lu.assertEquals(candidate('probasscurve', 'pros'), 'bacuve')\n    lu.assertEquals(candidate('digitalindia', 'talent'), 'digiidi')\n    lu.assertEquals(candidate('exoticmiles', 'toxic'), 'emles')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nlocal function round_and_sum(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = round_and_sum\n    lu.assertEquals(candidate({22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5}), 243)\n    lu.assertEquals(candidate({5, 2, 9, 24.3, 29}), 345)\n    lu.assertEquals(candidate({25.0, 56.7, 89.2}), 513)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "lua",
-    "prompt": "-- Write a function to find the item with maximum frequency in a given list.\nlocal function max_occurrences(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_occurrences\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), 2)\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), 8)\n    lu.assertEquals(candidate({10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a given string is a decimal number with a precision of 2.\nlocal function is_decimal(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_decimal\n    lu.assertEquals(candidate('123.11'), true)\n    lu.assertEquals(candidate('e666.86'), false)\n    lu.assertEquals(candidate('3.124587'), false)\n    lu.assertEquals(candidate('1.11'), true)\n    lu.assertEquals(candidate('1.1.11'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nlocal function dict_filter(dict, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dict_filter\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 170), {['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 180), {['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 190), {['Pierre Cox'] = 190})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of even numbers at even positions of a list.\nlocal function sum_even_and_even_index(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_even_and_even_index\n    lu.assertEquals(candidate({5, 6, 12, 1, 18, 8}), 30)\n    lu.assertEquals(candidate({3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), 26)\n    lu.assertEquals(candidate({5, 6, 12, 1}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the sum of the largest contiguous sublist in the given list.\nlocal function max_sub_array_sum(a, size)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum\n    lu.assertEquals(candidate({-2, -3, 4, -1, -2, 1, 5, -3}, 8), 7)\n    lu.assertEquals(candidate({-3, -4, 5, -2, -3, 2, 6, -4}, 8), 8)\n    lu.assertEquals(candidate({-4, -5, 6, -3, -4, 3, 7, -5}, 8), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "lua",
-    "prompt": "-- Write a function to find the intersection of two arrays.\nlocal function intersection_array(array_nums1, array_nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection_array\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {1, 2, 4, 8, 9}), {1, 2, 8, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {3, 5, 7, 9}), {3, 5, 7, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {10, 20, 30, 40}), {10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nlocal function split_two_parts(list1, L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_two_parts\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {{1, 1, 2}, {3, 4, 4, 5, 1}})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 2), {{'a', 'b'}, {'c', 'd'}})\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}, 4), {{'p', 'y', 't', 'h'}, {'o', 'n'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "lua",
-    "prompt": "-- Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nlocal function find_literals(text, pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_literals\n    lu.assertEquals(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), {'fox', 16, 19})\n    lu.assertEquals(candidate('Its been a very crazy procedure right', 'crazy'), {'crazy', 16, 21})\n    lu.assertEquals(candidate('Hardest choices required strongest will', 'will'), {'will', 35, 39})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the volume of a triangular prism.\nlocal function find_Volume(l, b, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Volume\n    lu.assertEquals(candidate(10, 8, 6), 240)\n    lu.assertEquals(candidate(3, 2, 2), 6)\n    lu.assertEquals(candidate(1, 2, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlocal function wind_chill(v, t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = wind_chill\n    lu.assertEquals(candidate(120, 35), 40)\n    lu.assertEquals(candidate(40, 20), 19)\n    lu.assertEquals(candidate(10, 8), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "lua",
-    "prompt": "-- Write a function to find the ascii value of a character.\nlocal function ascii_value(k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = ascii_value\n    lu.assertEquals(candidate('A'), 65)\n    lu.assertEquals(candidate('R'), 82)\n    lu.assertEquals(candidate('S'), 83)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether all the characters are same or not.\nlocal function all_Characters_Same(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Characters_Same\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('aaa'), true)\n    lu.assertEquals(candidate('data'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "lua",
-    "prompt": "-- Write a function to move all the numbers to the end of the given string.\nlocal function move_num(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_num\n    lu.assertEquals(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')\n    lu.assertEquals(candidate('Avengers124Assemble'), 'AvengersAssemble124')\n    lu.assertEquals(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the length of the word is odd or not.\nlocal function word_len(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = word_len\n    lu.assertEquals(candidate('Hadoop'), false)\n    lu.assertEquals(candidate('great'), true)\n    lu.assertEquals(candidate('structure'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "lua",
-    "prompt": "-- Write a function to drop empty items from a given dictionary.\nlocal function drop_empty(dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = drop_empty\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = 'Green', ['c3'] = None}), {['c1'] = 'Red', ['c2'] = 'Green'})\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = None, ['c3'] = None}), {['c1'] = 'Red'})\n    lu.assertEquals(candidate({['c1'] = None, ['c2'] = 'Green', ['c3'] = None}), {['c2'] = 'Green'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nlocal function insert_element(list, element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = insert_element\n    lu.assertEquals(candidate({'Red', 'Green', 'Black'}, 'c'), {'c', 'Red', 'c', 'Green', 'c', 'Black'})\n    lu.assertEquals(candidate({'python', 'java'}, 'program'), {'program', 'python', 'program', 'java'})\n    lu.assertEquals(candidate({'happy', 'sad'}, 'laugh'), {'laugh', 'happy', 'laugh', 'sad'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "lua",
-    "prompt": "-- Write a function to remove lowercase substrings from a given string.\nlocal function remove_lowercase(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_lowercase\n    lu.assertEquals(candidate('PYTHon'), 'PYTH')\n    lu.assertEquals(candidate('FInD'), 'FID')\n    lu.assertEquals(candidate('STRinG'), 'STRG')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nlocal function count_Set_Bits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Set_Bits\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 1)\n    lu.assertEquals(candidate(6), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "lua",
-    "prompt": "-- Write a function to extract only the rear index element of each string in the given tuple.\nlocal function extract_rear(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_rear\n    lu.assertEquals(candidate({'Mers', 'for', 'Vers'}), {'s', 'r', 's'})\n    lu.assertEquals(candidate({'Avenge', 'for', 'People'}), {'e', 'r', 'e'})\n    lu.assertEquals(candidate({'Gotta', 'get', 'go'}), {'a', 't', 'o'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of occurence of the string 'std' in a given string.\nlocal function count_occurance(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_occurance\n    lu.assertEquals(candidate('letstdlenstdporstd'), 3)\n    lu.assertEquals(candidate('truststdsolensporsd'), 1)\n    lu.assertEquals(candidate('makestdsostdworthit'), 2)\n    lu.assertEquals(candidate('stds'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given tuples contain the k or not.\nlocal function check_K(test_tup, K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_K\n    lu.assertEquals(candidate({10, 4, 5, 6, 8}, 6), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 7), false)\n    lu.assertEquals(candidate({7, 8, 9, 44, 11, 12}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to interleave 3 lists of the same length into a single flat list.\nlocal function interleave_lists(list1, list2, list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = interleave_lists\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}, {10, 20, 30, 40, 50, 60, 70}, {100, 200, 300, 400, 500, 600, 700}), {1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700})\n    lu.assertEquals(candidate({10, 20}, {15, 2}, {5, 10}), {10, 15, 5, 20, 2, 10})\n    lu.assertEquals(candidate({11, 44}, {10, 15}, {20, 5}), {11, 10, 20, 44, 15, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('python_program'), 'PythonProgram')\n    lu.assertEquals(candidate('python_language'), 'PythonLanguage')\n    lu.assertEquals(candidate('programming_language'), 'ProgrammingLanguage')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of equal numbers from three given integers.\nlocal function test_three_equal(x, y, z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_three_equal\n    lu.assertEquals(candidate(1, 1, 1), 3)\n    lu.assertEquals(candidate(-1, -2, -3), 0)\n    lu.assertEquals(candidate(1, 2, 2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nlocal function odd_length_sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_length_sum\n    lu.assertEquals(candidate({1, 2, 4}), 14)\n    lu.assertEquals(candidate({1, 2, 1, 2}), 15)\n    lu.assertEquals(candidate({1, 7}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find the number of ways to partition a set of Bell numbers.\nlocal function bell_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(10), 115975)\n    lu.assertEquals(candidate(56), 6775685320645824322581483068371419745979053216268760300)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "lua",
-    "prompt": "-- Write a function to find the area of a rectangle.\nlocal function rectangle_area(l, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rectangle_area\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(10, 5), 50)\n    lu.assertEquals(candidate(4, 2), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "lua",
-    "prompt": "-- Write a function to find sum and average of first n natural numbers.\nlocal function sum_average(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_average\n    lu.assertEquals(candidate(10), {55, 5.5})\n    lu.assertEquals(candidate(15), {120, 8.0})\n    lu.assertEquals(candidate(20), {210, 10.5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nlocal function division_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = division_elements\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {2, 2, 2, 3})\n    lu.assertEquals(candidate({12, 6, 8, 16}, {6, 3, 4, 4}), {2, 2, 2, 4})\n    lu.assertEquals(candidate({20, 14, 36, 18}, {5, 7, 6, 9}), {4, 2, 6, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to get the sum of the digits of a non-negative integer.\nlocal function sum_digits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_digits\n    lu.assertEquals(candidate(345), 12)\n    lu.assertEquals(candidate(12), 3)\n    lu.assertEquals(candidate(97), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "lua",
-    "prompt": "-- Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nlocal function index_minimum(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_minimum\n    lu.assertEquals(candidate({{'Rash', 143}, {'Manjeet', 200}, {'Varsha', 100}}), 'Varsha')\n    lu.assertEquals(candidate({{'Yash', 185}, {'Dawood', 125}, {'Sanya', 175}}), 'Dawood')\n    lu.assertEquals(candidate({{'Sai', 345}, {'Salman', 145}, {'Ayesha', 96}}), 'Ayesha')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "lua",
-    "prompt": "-- Write a function to divide two lists element wise.\nlocal function div_list(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = div_list\n    lu.assertEquals(candidate({4, 5, 6}, {1, 2, 3}), {4.0, 2.5, 2.0})\n    lu.assertEquals(candidate({3, 2}, {1, 4}), {3.0, 0.5})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {1.8, 1.7142857142857142})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find the list with maximum length.\nlocal function max_length_list(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length_list\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5}, {1, 2, 3, 4}, {1, 2, 3}, {1, 2}, {1}}), {5, {1, 2, 3, 4, 5}})\n    lu.assertEquals(candidate({{3, 4, 5}, {6, 7, 8, 9}, {10, 11, 12}}), {4, {6, 7, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find all possible combinations of the elements of a given list.\nlocal function combinations_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_list\n    lu.assertEquals(candidate({'orange', 'red', 'green', 'blue'}), {{}, {'orange'}, {'red'}, {'red', 'orange'}, {'green'}, {'green', 'orange'}, {'green', 'red'}, {'green', 'red', 'orange'}, {'blue'}, {'blue', 'orange'}, {'blue', 'red'}, {'blue', 'red', 'orange'}, {'blue', 'green'}, {'blue', 'green', 'orange'}, {'blue', 'green', 'red'}, {'blue', 'green', 'red', 'orange'}})\n    lu.assertEquals(candidate({'red', 'green', 'blue', 'white', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'blue'}, {'blue', 'red'}, {'blue', 'green'}, {'blue', 'green', 'red'}, {'white'}, {'white', 'red'}, {'white', 'green'}, {'white', 'green', 'red'}, {'white', 'blue'}, {'white', 'blue', 'red'}, {'white', 'blue', 'green'}, {'white', 'blue', 'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'black', 'blue'}, {'black', 'blue', 'red'}, {'black', 'blue', 'green'}, {'black', 'blue', 'green', 'red'}, {'black', 'white'}, {'black', 'white', 'red'}, {'black', 'white', 'green'}, {'black', 'white', 'green', 'red'}, {'black', 'white', 'blue'}, {'black', 'white', 'blue', 'red'}, {'black', 'white', 'blue', 'green'}, {'black', 'white', 'blue', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'blue'}, {'orange', 'blue', 'red'}, {'orange', 'blue', 'green'}, {'orange', 'blue', 'green', 'red'}, {'orange', 'white'}, {'orange', 'white', 'red'}, {'orange', 'white', 'green'}, {'orange', 'white', 'green', 'red'}, {'orange', 'white', 'blue'}, {'orange', 'white', 'blue', 'red'}, {'orange', 'white', 'blue', 'green'}, {'orange', 'white', 'blue', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}, {'orange', 'black', 'blue'}, {'orange', 'black', 'blue', 'red'}, {'orange', 'black', 'blue', 'green'}, {'orange', 'black', 'blue', 'green', 'red'}, {'orange', 'black', 'white'}, {'orange', 'black', 'white', 'red'}, {'orange', 'black', 'white', 'green'}, {'orange', 'black', 'white', 'green', 'red'}, {'orange', 'black', 'white', 'blue'}, {'orange', 'black', 'white', 'blue', 'red'}, {'orange', 'black', 'white', 'blue', 'green'}, {'orange', 'black', 'white', 'blue', 'green', 'red'}})\n    lu.assertEquals(candidate({'red', 'green', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of the largest and smallest value in a given array.\nlocal function big_sum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_sum\n    lu.assertEquals(candidate({1, 2, 3}), 4)\n    lu.assertEquals(candidate({-1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({2, 3, 6}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "lua",
-    "prompt": "-- Write a python function to return the negative numbers in a list.\nlocal function neg_nos(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = neg_nos\n    lu.assertEquals(candidate({-1, 4, 5, -6}), {-1, -6})\n    lu.assertEquals(candidate({-1, -2, 3, 4}), {-1, -2})\n    lu.assertEquals(candidate({-7, -6, 8, 9}), {-7, -6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the highest power of 2 that is less than or equal to n.\nlocal function highest_Power_of_2(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = highest_Power_of_2\n    lu.assertEquals(candidate(10), 8)\n    lu.assertEquals(candidate(19), 16)\n    lu.assertEquals(candidate(32), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a list contains the given sublist or not.\nlocal function is_sublist(l, s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sublist\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {3, 7}), false)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {4, 3}), true)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {1, 6}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "lua",
-    "prompt": "-- Write a function to subtract two lists element-wise.\nlocal function sub_list(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sub_list\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), {-3, -3, -3})\n    lu.assertEquals(candidate({1, 2}, {3, 4}), {-2, -2})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {40, 50})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given two integers have opposite sign or not.\nlocal function opposite_Signs(x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = opposite_Signs\n    lu.assertEquals(candidate(1, -2), true)\n    lu.assertEquals(candidate(3, 2), false)\n    lu.assertEquals(candidate(-10, -10), false)\n    lu.assertEquals(candidate(-2, 2), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "lua",
-    "prompt": "-- Write a function which takes two tuples of the same length and performs the element wise modulo.\nlocal function tuple_modulo(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_modulo\n    lu.assertEquals(candidate({10, 4, 5, 6}, {5, 6, 7, 5}), {0, 4, 5, 1})\n    lu.assertEquals(candidate({11, 5, 6, 7}, {6, 7, 8, 6}), {5, 5, 6, 1})\n    lu.assertEquals(candidate({12, 6, 7, 8}, {7, 8, 9, 7}), {5, 6, 7, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to find the difference of the first even and first odd number of a given list.\nlocal function diff_even_odd(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = diff_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 1)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "lua",
-    "prompt": "-- Write a function to sort each sublist of strings in a given list of lists.\nlocal function sort_sublists(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}}), {{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'d', 'c'}, {'g', 'h'}, {'f', 'e'}}), {{'a', 'b'}, {'c', 'd'}, {'g', 'h'}, {'e', 'f'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the last digit of a given number.\nlocal function last_Digit(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit\n    lu.assertEquals(candidate(123), 3)\n    lu.assertEquals(candidate(25), 5)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of fourth power of first n odd natural numbers.\nlocal function odd_num_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_num_sum\n    lu.assertEquals(candidate(2), 82)\n    lu.assertEquals(candidate(3), 707)\n    lu.assertEquals(candidate(4), 3108)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a list to a string.\nlocal function tup_string(tup1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tup_string\n    lu.assertEquals(candidate({'e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'}), 'exercises')\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}), 'python')\n    lu.assertEquals(candidate({'p', 'r', 'o', 'g', 'r', 'a', 'm'}), 'program')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all elements from a given list present in another list.\nlocal function remove_elements(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_elements\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {1, 3, 5, 7}), {2, 4, 6, 8, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 7}), {1, 2, 3, 4, 6, 8, 9, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether any value in a sequence exists in a sequence or not.\nlocal function overlapping(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = overlapping\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), false)\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), false)\n    lu.assertEquals(candidate({1, 4, 5}, {1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "lua",
-    "prompt": "-- Write a python function to identify non-prime numbers.\nlocal function is_not_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_not_prime\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(35), true)\n    lu.assertEquals(candidate(37), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum value in a given heterogeneous list.\nlocal function max_val(listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 5)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 25)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 50)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum of the negative numbers of a given list of numbers.\nlocal function sum_negativenum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_negativenum\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), -32)\n    lu.assertEquals(candidate({10, 15, -14, 13, -18, 12, -20}), -52)\n    lu.assertEquals(candidate({19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), -894)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nlocal function find_Rotations(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Rotations\n    lu.assertEquals(candidate('aaaa'), 1)\n    lu.assertEquals(candidate('ab'), 2)\n    lu.assertEquals(candidate('abc'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nlocal function change_date_format(dt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_date_format\n    lu.assertEquals(candidate('2026-01-02'), '02-01-2026')\n    lu.assertEquals(candidate('2020-11-13'), '13-11-2020')\n    lu.assertEquals(candidate('2021-04-26'), '26-04-2021')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "lua",
-    "prompt": "-- Write a python function which takes a list of integers and only returns the odd ones.\nlocal function Split(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {1, 3, 5})\n    lu.assertEquals(candidate({10, 11, 12, 13}), {11, 13})\n    lu.assertEquals(candidate({7, 8, 9, 1}), {7, 9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "lua",
-    "prompt": "-- Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlocal function toggle_middle_bits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_middle_bits\n    lu.assertEquals(candidate(9), 15)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(11), 13)\n    lu.assertEquals(candidate(65), 127)\n    lu.assertEquals(candidate(77), 115)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlocal function count_char_position(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_char_position\n    lu.assertEquals(candidate('xbcefg'), 2)\n    lu.assertEquals(candidate('ABcED'), 3)\n    lu.assertEquals(candidate('AbgdeF'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlocal function large_product(nums1, nums2, N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = large_product\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 3), {60, 54, 50})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 4), {60, 54, 50, 48})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 5), {60, 54, 50, 48, 45})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nlocal function cummulative_sum(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cummulative_sum\n    lu.assertEquals(candidate({{1, 3}, {5, 6, 7}, {2, 6}}), 30)\n    lu.assertEquals(candidate({{2, 4}, {6, 7, 8}, {3, 7}}), 37)\n    lu.assertEquals(candidate({{3, 5}, {7, 8, 9}, {4, 8}}), 44)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlocal function find_min_diff(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_min_diff\n    lu.assertEquals(candidate({1, 5, 3, 19, 18, 25}, 6), 1)\n    lu.assertEquals(candidate({4, 3, 2, 6}, 4), 1)\n    lu.assertEquals(candidate({30, 5, 20, 9}, 4), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nlocal function text_starta_endb(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_starta_endb\n    lu.assertEquals(candidate('aabbbb'), true)\n    lu.assertEquals(candidate('aabAbbbc'), false)\n    lu.assertEquals(candidate('accddbbjjj'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "lua",
-    "prompt": "-- Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlocal function left_rotate(n, d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_rotate\n    lu.assertEquals(candidate(16, 2), 64)\n    lu.assertEquals(candidate(10, 2), 40)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(1, 3), 8)\n    lu.assertEquals(candidate(5, 3), 40)\n    lu.assertEquals(candidate(29, 3), 232)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the first repeated character in a given string.\nlocal function first_repeated_char(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_repeated_char\n    lu.assertEquals(candidate('abcabc'), 'a')\n    lu.assertEquals(candidate('abc'), None)\n    lu.assertEquals(candidate('123123'), '1')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "lua",
-    "prompt": "-- Write a python function to count inversions in an array.\nlocal function get_Inv_Count(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Inv_Count\n    lu.assertEquals(candidate({1, 20, 6, 4, 5}), 5)\n    lu.assertEquals(candidate({1, 2, 1}), 1)\n    lu.assertEquals(candidate({1, 2, 5, 6, 1}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "lua",
-    "prompt": "-- Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlocal function even_Power_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_Power_Sum\n    lu.assertEquals(candidate(2), 1056)\n    lu.assertEquals(candidate(3), 8832)\n    lu.assertEquals(candidate(1), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "lua",
-    "prompt": "-- Write a function to find whether all the given lists have equal length or not.\nlocal function get_equal(Input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_equal\n    lu.assertEquals(candidate({{11, 22, 33}, {44, 55, 66}}), true)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6, 7}}), false)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "lua",
-    "prompt": "-- Write a function to check if a string represents an integer or not.\nlocal function check_integer(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_integer\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('1'), true)\n    lu.assertEquals(candidate('12345'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "lua",
-    "prompt": "-- Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nlocal function count_reverse_pairs(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_reverse_pairs\n    lu.assertEquals(candidate({'julia', 'best', 'tseb', 'for', 'ailuj'}), 2)\n    lu.assertEquals(candidate({'geeks', 'best', 'for', 'skeeg'}), 1)\n    lu.assertEquals(candidate({'makes', 'best', 'sekam', 'for', 'rof'}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "lua",
-    "prompt": "-- Write a python function to move all zeroes to the end of the given list.\nlocal function move_zero(num_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_zero\n    lu.assertEquals(candidate({1, 0, 2, 0, 3, 4}), {1, 2, 3, 4, 0, 0})\n    lu.assertEquals(candidate({2, 3, 2, 0, 0, 4, 0, 5, 0}), {2, 3, 2, 4, 5, 0, 0, 0, 0})\n    lu.assertEquals(candidate({0, 1, 0, 1, 1}), {1, 1, 1, 0, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "lua",
-    "prompt": "-- Write a function to check if given list contains no duplicates.\nlocal function check_distinct(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_distinct\n    lu.assertEquals(candidate({1, 4, 5, 6, 1, 4}), false)\n    lu.assertEquals(candidate({1, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given amount has no profit and no loss\nlocal function noprofit_noloss(actual_cost, sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = noprofit_noloss\n    lu.assertEquals(candidate(1500, 1200), false)\n    lu.assertEquals(candidate(100, 100), true)\n    lu.assertEquals(candidate(2000, 5000), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all the words with k length in the given string.\nlocal function remove_length(test_str, K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_length\n    lu.assertEquals(candidate('The person is most value tet', 3), 'person is most value')\n    lu.assertEquals(candidate('If you told me about this ok', 4), 'If you me about ok')\n    lu.assertEquals(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "lua",
-    "prompt": "-- Write a python function to count number of digits in a given string.\nlocal function number_ctr(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_ctr\n    lu.assertEquals(candidate('program2bedone'), 1)\n    lu.assertEquals(candidate('3wonders'), 1)\n    lu.assertEquals(candidate('123'), 3)\n    lu.assertEquals(candidate('3wond-1ers2'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "lua",
-    "prompt": "-- Write a function to count the total number of characters in a string.\nlocal function count_charac(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_charac\n    lu.assertEquals(candidate('python programming'), 18)\n    lu.assertEquals(candidate('language'), 8)\n    lu.assertEquals(candidate('words'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlocal function get_total_number_of_sequences(m, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_total_number_of_sequences\n    lu.assertEquals(candidate(10, 4), 4)\n    lu.assertEquals(candidate(5, 2), 6)\n    lu.assertEquals(candidate(16, 3), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "lua",
-    "prompt": "-- Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nlocal function left_insertion(a, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two numbers and returns a list with the second number and then the first number.\nlocal function swap_numbers(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_numbers\n    lu.assertEquals(candidate(10, 20), {20, 10})\n    lu.assertEquals(candidate(15, 17), {17, 15})\n    lu.assertEquals(candidate(100, 200), {200, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nlocal function is_majority(arr, n, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_majority\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 3, 10}, 7, 3), true)\n    lu.assertEquals(candidate({1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), false)\n    lu.assertEquals(candidate({1, 1, 1, 2, 2}, 5, 1), true)\n    lu.assertEquals(candidate({1, 1, 2, 2}, 5, 1), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nlocal function substract_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = substract_elements\n    lu.assertEquals(candidate({10, 4, 5}, {2, 5, 18}), {8, -1, -13})\n    lu.assertEquals(candidate({11, 2, 3}, {24, 45, 16}), {-13, -43, -13})\n    lu.assertEquals(candidate({7, 18, 9}, {10, 11, 12}), {-3, 7, -3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to put spaces between words starting with capital letters in a given string.\nlocal function capital_words_spaces(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = capital_words_spaces\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('PythonProgrammingExamples'), 'Python Programming Examples')\n    lu.assertEquals(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the average of cubes of first n natural numbers.\nlocal function find_Average_Of_Cube(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Average_Of_Cube\n    lu.assertEquals(candidate(2), 4.5)\n    lu.assertEquals(candidate(3), 12)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "lua",
-    "prompt": "-- Write a function to check if all values are same in a dictionary.\nlocal function check_value(dict, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_value\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 10), false)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 12), true)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth tetrahedral number.\nlocal function tetrahedral_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tetrahedral_number\n    lu.assertEquals(candidate(5), 35)\n    lu.assertEquals(candidate(6), 56)\n    lu.assertEquals(candidate(7), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate whether the matrix is a magic square.\nlocal function magic_square_test(my_matrix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = magic_square_test\n    lu.assertEquals(candidate({{7, 12, 1, 14}, {2, 13, 8, 11}, {16, 3, 10, 5}, {9, 6, 15, 4}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 8}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 7}}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "lua",
-    "prompt": "-- Write a function to remove uppercase substrings from a given string.\nlocal function remove_uppercase(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_uppercase\n    lu.assertEquals(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')\n    lu.assertEquals(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')\n    lu.assertEquals(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether an element exists within a tuple.\nlocal function check_tuplex(tuplex, tuple1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_tuplex\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 'r'), true)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, '5'), false)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 3), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate a dog's age in dog's years.\nlocal function dog_age(h_age)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dog_age\n    lu.assertEquals(candidate(12), 61)\n    lu.assertEquals(candidate(15), 73)\n    lu.assertEquals(candidate(24), 109)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the next perfect square greater than a given number.\nlocal function next_Perfect_Square(N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_Perfect_Square\n    lu.assertEquals(candidate(35), 36)\n    lu.assertEquals(candidate(6), 9)\n    lu.assertEquals(candidate(9), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "lua",
-    "prompt": "-- Write a function to create a list of N empty dictionaries.\nlocal function empty_list(length)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = empty_list\n    lu.assertEquals(candidate(5), {{}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(6), {{}, {}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(7), {{}, {}, {}, {}, {}, {}, {}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "lua",
-    "prompt": "-- Write a python function to convert a given string to uppercase.\nlocal function is_upper(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_upper\n    lu.assertEquals(candidate('person'), 'PERSON')\n    lu.assertEquals(candidate('final'), 'FINAL')\n    lu.assertEquals(candidate('Valid'), 'VALID')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlocal function odd_Equivalent(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_Equivalent\n    lu.assertEquals(candidate('011001', 6), 3)\n    lu.assertEquals(candidate('11011', 5), 4)\n    lu.assertEquals(candidate('1010', 4), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nlocal function re_arrange_array(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = re_arrange_array\n    lu.assertEquals(candidate({-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), {-1, -3, -7, 4, 5, 6, 2, 8, 9})\n    lu.assertEquals(candidate({12, -14, -26, 13, 15}, 5), {-14, -26, 12, 13, 15})\n    lu.assertEquals(candidate({10, 24, 36, -42, -39, -78, 85}, 7), {-42, -39, -78, 10, 24, 36, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether a list of numbers contains only one distinct element or not.\nlocal function unique_Element(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_Element\n    lu.assertEquals(candidate({1, 1, 1}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "lua",
-    "prompt": "-- Write a function to extract values between quotation marks from a string.\nlocal function extract_values(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_values\n    lu.assertEquals(candidate('\"Python\", \"PHP\", \"Java\"'), {'Python', 'PHP', 'Java'})\n    lu.assertEquals(candidate('\"python\",\"program\",\"language\"'), {'python', 'program', 'language'})\n    lu.assertEquals(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), {'red', 'blue', 'green', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "lua",
-    "prompt": "-- Write a python function to count true booleans in the given list.\nlocal function count(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count\n    lu.assertEquals(candidate({true, false, true}), 2)\n    lu.assertEquals(candidate({false, false}), 0)\n    lu.assertEquals(candidate({true, true, true}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "lua",
-    "prompt": "-- Write a function that counts the number of pairs of integers in a list that xor to an even number.\nlocal function find_even_pair(A)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_even_pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}), 4)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}), 9)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is armstrong or not.\nlocal function armstrong_number(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = armstrong_number\n    lu.assertEquals(candidate(153), true)\n    lu.assertEquals(candidate(259), false)\n    lu.assertEquals(candidate(4458), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the upper case characters in a given string.\nlocal function upper_ctr(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = upper_ctr\n    lu.assertEquals(candidate('PYthon'), 1)\n    lu.assertEquals(candidate('BigData'), 1)\n    lu.assertEquals(candidate('program'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the elementwise and tuples from the given two tuples.\nlocal function and_tuples(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = and_tuples\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {0, 0, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {5, 6, 7, 8}), {1, 2, 3, 0})\n    lu.assertEquals(candidate({8, 9, 11, 12}, {7, 13, 14, 17}), {0, 9, 10, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether it follows the sequence given in the patterns array.\nlocal function is_samepatterns(colors, patterns)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_samepatterns\n    lu.assertEquals(candidate({'red', 'green', 'green'}, {'a', 'b', 'b'}), true)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b', 'b'}), false)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b'}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of lists in a given number of lists.\nlocal function count_list(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), 4)\n    lu.assertEquals(candidate({{1, 2}, {2, 3}, {4, 5}}), 3)\n    lu.assertEquals(candidate({{1, 0}, {2, 0}}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nlocal function average_tuple(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = average_tuple\n    lu.assertEquals(candidate({{10, 10, 10, 12}, {30, 45, 56, 45}, {81, 80, 39, 32}, {1, 2, 3, 4}}), {30.5, 34.25, 27.0, 23.25})\n    lu.assertEquals(candidate({{1, 1, -5}, {30, -15, 56}, {81, -60, -39}, {-10, 2, 3}}), {25.5, -18.0, 3.75})\n    lu.assertEquals(candidate({{100, 100, 100, 120}, {300, 450, 560, 450}, {810, 800, 390, 320}, {10, 20, 30, 40}}), {305.0, 342.5, 270.0, 232.5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "lua",
-    "prompt": "-- Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlocal function lcs_of_three(X, Y, Z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lcs_of_three\n    lu.assertEquals(candidate('AGGT12', '12TXAYB', '12XBA'), 2)\n    lu.assertEquals(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)\n    lu.assertEquals(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n'th star number.\nlocal function find_star_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_star_num\n    lu.assertEquals(candidate(3), 37)\n    lu.assertEquals(candidate(4), 73)\n    lu.assertEquals(candidate(5), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of an array.\nlocal function _sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = _sum\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({15, 12, 13, 10}), 50)\n    lu.assertEquals(candidate({0, 1, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given list contains consecutive numbers or not.\nlocal function check_Consecutive(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_Consecutive\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 5, 6}), false)\n    lu.assertEquals(candidate({1, 2, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "lua",
-    "prompt": "-- Write a function to find the first adverb and their positions in a given sentence.\nlocal function find_adverb_position(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverb_position\n    lu.assertEquals(candidate('clearly!! we can see the sky'), {0, 7, 'clearly'})\n    lu.assertEquals(candidate('seriously!! there are many roses'), {0, 9, 'seriously'})\n    lu.assertEquals(candidate('unfortunately!! sita is going to home'), {0, 13, 'unfortunately'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "lua",
-    "prompt": "-- Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nlocal function rotate_right(list, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rotate_right\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), {8, 9, 10, 1, 2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {9, 10, 1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), {6, 7, 8, 9, 10, 1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of non-empty substrings of a given string.\nlocal function number_of_substrings(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_of_substrings\n    lu.assertEquals(candidate('abc'), 6)\n    lu.assertEquals(candidate('abcd'), 10)\n    lu.assertEquals(candidate('abcde'), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlocal function list_split(S, step)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_split\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'}, 3), {{'a', 'd', 'g', 'j', 'm'}, {'b', 'e', 'h', 'k', 'n'}, {'c', 'f', 'i', 'l'}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), {{1, 4, 7, 10, 13}, {2, 5, 8, 11, 14}, {3, 6, 9, 12}})\n    lu.assertEquals(candidate({'python', 'java', 'C', 'C++', 'DBMS', 'SQL'}, 2), {{'python', 'C', 'DBMS'}, {'java', 'C++', 'SQL'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "lua",
-    "prompt": "-- Write a python function to check if the elements of a given list are unique or not.\nlocal function all_unique(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_unique\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "lua",
-    "prompt": "-- Write a python function to convert complex numbers to polar coordinates.\nlocal function convert(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert\n    lu.assertEquals(candidate(1), {1.0, 0.0})\n    lu.assertEquals(candidate(4), {4.0, 0.0})\n    lu.assertEquals(candidate(5), {5.0, 0.0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "lua",
-    "prompt": "-- The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nlocal function filter_data(students, h, w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_data\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 6.0, 70), {['Cierra Vega'] = {6.2, 70}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.9, 67), {['Cierra Vega'] = {6.2, 70}, ['Kierra Gentry'] = {6.0, 68}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.7, 64), {['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "lua",
-    "prompt": "-- Write a python function to convert the given string to lower case.\nlocal function is_lower(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_lower\n    lu.assertEquals(candidate('InValid'), 'invalid')\n    lu.assertEquals(candidate('TruE'), 'true')\n    lu.assertEquals(candidate('SenTenCE'), 'sentence')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the smallest power of 2 greater than or equal to n.\nlocal function next_power_of_2(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_power_of_2\n    lu.assertEquals(candidate(0), 1)\n    lu.assertEquals(candidate(5), 8)\n    lu.assertEquals(candidate(17), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "lua",
-    "prompt": "-- Write a function to check if a string is present as a substring in a given list of string values.\nlocal function find_substring(str1, sub_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_substring\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ack'), true)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'abc'), false)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ange'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "lua",
-    "prompt": "-- Write a function to replace characters in a string.\nlocal function replace_char(str1, ch, newch)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_char\n    lu.assertEquals(candidate('polygon', 'y', 'l'), 'pollgon')\n    lu.assertEquals(candidate('character', 'c', 'a'), 'aharaater')\n    lu.assertEquals(candidate('python', 'l', 'a'), 'python')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to find the product of first even and odd number of a given list.\nlocal function mul_even_odd(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mul_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a list to a tuple.\nlocal function list_tuple(listx)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_tuple\n    lu.assertEquals(candidate({5, 10, 7, 4, 15, 3}), {5, 10, 7, 4, 15, 3})\n    lu.assertEquals(candidate({2, 4, 5, 6, 2, 3, 4, 4, 7}), {2, 4, 5, 6, 2, 3, 4, 4, 7})\n    lu.assertEquals(candidate({58, 44, 56}), {58, 44, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "lua",
-    "prompt": "-- Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlocal function even_binomial_Coeff_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_binomial_Coeff_Sum\n    lu.assertEquals(candidate(4), 8)\n    lu.assertEquals(candidate(6), 32)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "lua",
-    "prompt": "-- Write a function to perform the mathematical bitwise xor operation across the given tuples.\nlocal function bitwise_xor(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bitwise_xor\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {15, 6, 5, 10})\n    lu.assertEquals(candidate({11, 5, 7, 10}, {6, 3, 4, 4}), {13, 6, 3, 14})\n    lu.assertEquals(candidate({12, 6, 8, 11}, {7, 4, 5, 6}), {11, 2, 13, 13})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether a list is sublist of another or not.\nlocal function is_Sub_Array(A, B)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sub_Array\n    lu.assertEquals(candidate({1, 4, 3, 5}, {1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 1}, {1, 2, 1}), true)\n    lu.assertEquals(candidate({1, 0, 2, 2}, {2, 2, 0}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "lua",
-    "prompt": "-- Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nlocal function max_sub_array_sum_repeated(a, n, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum_repeated\n    lu.assertEquals(candidate({10, 20, -30, -1}, 4, 3), 30)\n    lu.assertEquals(candidate({-1, 10, 20}, 3, 2), 59)\n    lu.assertEquals(candidate({-1, -2, -3}, 3, 3), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to find the minimum product from the pairs of tuples within a given list.\nlocal function min_product_tuple(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 8)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 30)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nlocal function count_divisors(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_divisors\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(100), false)\n    lu.assertEquals(candidate(125), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nlocal function triangle_area(r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(-1), None)\n    lu.assertEquals(candidate(0), 0)\n    lu.assertEquals(candidate(2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a given string to a list of characters.\nlocal function string_to_tuple(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_tuple\n    lu.assertEquals(candidate('python 3.0'), {'p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'})\n    lu.assertEquals(candidate('item1'), {'i', 't', 'e', 'm', '1'})\n    lu.assertEquals(candidate('15.10'), {'1', '5', '.', '1', '0'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlocal function find_length(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_length\n    lu.assertEquals(candidate('11000010001'), 6)\n    lu.assertEquals(candidate('10111'), 1)\n    lu.assertEquals(candidate('11011101100101'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "lua",
-    "prompt": "-- Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlocal function count_Primes_nums(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Primes_nums\n    lu.assertEquals(candidate(5), 2)\n    lu.assertEquals(candidate(10), 4)\n    lu.assertEquals(candidate(100), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of the product of consecutive binomial co-efficients.\nlocal function sum_Of_product(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_product\n    lu.assertEquals(candidate(3), 15)\n    lu.assertEquals(candidate(4), 56)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the maximum aggregate from the list of tuples.\nlocal function max_aggregate(stdata)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_aggregate\n    lu.assertEquals(candidate({{'Juan Whelan', 90}, {'Sabah Colley', 88}, {'Peter Nichols', 7}, {'Juan Whelan', 122}, {'Sabah Colley', 84}}), {'Juan Whelan', 212})\n    lu.assertEquals(candidate({{'Juan Whelan', 50}, {'Sabah Colley', 48}, {'Peter Nichols', 37}, {'Juan Whelan', 22}, {'Sabah Colley', 14}}), {'Juan Whelan', 72})\n    lu.assertEquals(candidate({{'Juan Whelan', 10}, {'Sabah Colley', 20}, {'Peter Nichols', 30}, {'Juan Whelan', 40}, {'Sabah Colley', 50}}), {'Sabah Colley', 70})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a list of elements.\nlocal function comb_sort(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = comb_sort\n    lu.assertEquals(candidate({5, 15, 37, 25, 79}), {5, 15, 25, 37, 79})\n    lu.assertEquals(candidate({41, 32, 15, 19, 22}), {15, 19, 22, 32, 41})\n    lu.assertEquals(candidate({99, 15, 13, 47}), {13, 15, 47, 99})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nlocal function check_expression(exp)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_expression\n    lu.assertEquals(candidate('{()}[{}]'), true)\n    lu.assertEquals(candidate('{()}[{]'), false)\n    lu.assertEquals(candidate('{()}[{}][]({})'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a word containing 'z'.\nlocal function text_match_wordz(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz\n    lu.assertEquals(candidate('pythonz.'), true)\n    lu.assertEquals(candidate('xyz.'), true)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "lua",
-    "prompt": "-- Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nlocal function sum_list(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_list\n    lu.assertEquals(candidate({10, 20, 30}, {15, 25, 35}), {25, 45, 65})\n    lu.assertEquals(candidate({1, 2, 3}, {5, 6, 7}), {6, 8, 10})\n    lu.assertEquals(candidate({15, 20, 30}, {15, 45, 75}), {30, 65, 105})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlocal function newman_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = newman_prime\n    lu.assertEquals(candidate(3), 7)\n    lu.assertEquals(candidate(4), 17)\n    lu.assertEquals(candidate(5), 41)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "lua",
-    "prompt": "-- Write a function to apply a given format string to all of the elements in a list.\nlocal function add_string(list_, string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_string\n    lu.assertEquals(candidate({1, 2, 3, 4}, 'temp{0}'), {'temp1', 'temp2', 'temp3', 'temp4'})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 'python{0}'), {'pythona', 'pythonb', 'pythonc', 'pythond'})\n    lu.assertEquals(candidate({5, 6, 7, 8}, 'string{0}'), {'string5', 'string6', 'string7', 'string8'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the surface area of a square pyramid with a given base edge and height.\nlocal function surface_Area(b, s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surface_Area\n    lu.assertEquals(candidate(3, 4), 33)\n    lu.assertEquals(candidate(4, 5), 56)\n    lu.assertEquals(candidate(1, 2), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the length of the smallest list in a list of lists.\nlocal function Find_Min_Length(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min_Length\n    lu.assertEquals(candidate({{1}, {1, 2}}), 1)\n    lu.assertEquals(candidate({{1, 2}, {1, 2, 3}, {1, 2, 3, 4}}), 2)\n    lu.assertEquals(candidate({{3, 3, 3}, {4, 4, 4, 4}}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "lua",
-    "prompt": "-- Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nlocal function validate(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = validate\n    lu.assertEquals(candidate(1234), true)\n    lu.assertEquals(candidate(51241), false)\n    lu.assertEquals(candidate(321), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth hexagonal number.\nlocal function hexagonal_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hexagonal_num\n    lu.assertEquals(candidate(10), 190)\n    lu.assertEquals(candidate(5), 45)\n    lu.assertEquals(candidate(7), 91)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n'th lucas number.\nlocal function find_lucas(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lucas\n    lu.assertEquals(candidate(9), 76)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(3), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "lua",
-    "prompt": "-- Write a python function to get the difference between two lists.\nlocal function Diff(li1, li2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Diff\n    lu.assertEquals(candidate({10, 15, 20, 25, 30, 35, 40}, {25, 40, 35}), {10, 20, 30, 15})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 1}), {2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3}, {6, 7, 1}), {2, 3, 6, 7})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "lua",
-    "prompt": "-- Write a function to extract values between quotation marks \" \" of the given string.\nlocal function extract_quotation(text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_quotation\n    lu.assertEquals(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), {'A53', 'multi', 'Processor'})\n    lu.assertEquals(candidate('Cast your \"favorite\" entertainment \"apps\"'), {'favorite', 'apps'})\n    lu.assertEquals(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), {'4k Ultra HD', 'HDR 10'})\n    lu.assertEquals(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to flatten a list and sum all of its elements.\nlocal function recursive_list_sum(data_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = recursive_list_sum\n    lu.assertEquals(candidate({1, 2, {3, 4}, {5, 6}}), 21)\n    lu.assertEquals(candidate({7, 10, {15, 14}, {19, 41}}), 106)\n    lu.assertEquals(candidate({10, 20, {30, 40}, {50, 60}}), 210)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the two numbers differ at one bit position only or not.\nlocal function differ_At_One_Bit_Pos(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = differ_At_One_Bit_Pos\n    lu.assertEquals(candidate(13, 9), true)\n    lu.assertEquals(candidate(15, 8), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(2, 3), true)\n    lu.assertEquals(candidate(5, 1), true)\n    lu.assertEquals(candidate(1, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an a followed by three 'b'.\nlocal function text_match_three(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('caacabbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nlocal function max_product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product\n    lu.assertEquals(candidate({3, 100, 4, 5, 150, 6}), 3000)\n    lu.assertEquals(candidate({4, 42, 55, 68, 80}), 50265600)\n    lu.assertEquals(candidate({10, 22, 9, 33, 21, 50, 41, 60}), 2460)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "lua",
-    "prompt": "-- Write a python function to split a list at the nth eelment and add the first part to the end.\nlocal function split_Arr(l, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_Arr\n    lu.assertEquals(candidate({12, 10, 5, 6, 52, 36}, 2), {5, 6, 52, 36, 12, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, 1), {2, 3, 4, 1})\n    lu.assertEquals(candidate({0, 1, 2, 3, 4, 5, 6, 7}, 3), {3, 4, 5, 6, 7, 0, 1, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the number of divisors of a given integer.\nlocal function divisor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisor\n    lu.assertEquals(candidate(15), 4)\n    lu.assertEquals(candidate(12), 6)\n    lu.assertEquals(candidate(9), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the difference between largest and smallest value in a given list.\nlocal function big_diff(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_diff\n    lu.assertEquals(candidate({1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({4, 5, 12}), 8)\n    lu.assertEquals(candidate({9, 2, 3}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "lua",
-    "prompt": "-- Write a function to find squares of individual elements in a list.\nlocal function square_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}), {100, 400, 900})\n    lu.assertEquals(candidate({12, 15}), {144, 225})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given tuple has any none value or not.\nlocal function check_none(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_none\n    lu.assertEquals(candidate({10, 4, 5, 6, None}), true)\n    lu.assertEquals(candidate({7, 8, 9, 11, 14}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, None}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given array is monotonic or not.\nlocal function is_Monotonic(A)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Monotonic\n    lu.assertEquals(candidate({6, 5, 4, 4}), true)\n    lu.assertEquals(candidate({1, 2, 2, 3}), true)\n    lu.assertEquals(candidate({1, 3, 2}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nlocal function is_perfect_square(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_perfect_square\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(36), true)\n    lu.assertEquals(candidate(14), false)\n    lu.assertEquals(candidate(196), true)\n    lu.assertEquals(candidate(125), false)\n    lu.assertEquals(candidate(15625), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of common divisors of two given numbers.\nlocal function sum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum\n    lu.assertEquals(candidate(10, 15), 6)\n    lu.assertEquals(candidate(100, 150), 93)\n    lu.assertEquals(candidate(4, 6), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "lua",
-    "prompt": "-- Write a function to find the list of maximum length in a list of lists.\nlocal function max_length(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1}, {5, 7}, {10, 12, 14, 15}}), {4, {10, 12, 14, 15}})\n    lu.assertEquals(candidate({{5}, {15, 20, 25}}), {3, {15, 20, 25}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nlocal function check_occurences(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_occurences\n    lu.assertEquals(candidate({{3, 1}, {1, 3}, {2, 5}, {5, 2}, {6, 3}}), {[{1, 3}] = 2, [{2, 5}] = 2, [{3, 6}] = 1})\n    lu.assertEquals(candidate({{4, 2}, {2, 4}, {3, 6}, {6, 3}, {7, 4}}), {[{2, 4}] = 2, [{3, 6}] = 2, [{4, 7}] = 1})\n    lu.assertEquals(candidate({{13, 2}, {11, 23}, {12, 25}, {25, 12}, {16, 23}}), {[{2, 13}] = 1, [{11, 23}] = 1, [{12, 25}] = 2, [{16, 23}] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "lua",
-    "prompt": "-- Write a function to find the directrix of a parabola.\nlocal function parabola_directrix(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parabola_directrix\n    lu.assertEquals(candidate(5, 3, 2), -198)\n    lu.assertEquals(candidate(9, 8, 4), -2336)\n    lu.assertEquals(candidate(2, 4, 6), -130)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "lua",
-    "prompt": "-- Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nlocal function occurance_substring(text, pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = occurance_substring\n    lu.assertEquals(candidate('python programming, python language', 'python'), {'python', 0, 6})\n    lu.assertEquals(candidate('python programming,programming language', 'programming'), {'programming', 7, 18})\n    lu.assertEquals(candidate('python programming,programming language', 'language'), {'language', 31, 39})\n    lu.assertEquals(candidate('c++ programming, c++ language', 'python'), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "lua",
-    "prompt": "-- Write a function to remove tuples from the given tuple.\nlocal function remove_nested(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_nested\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), {1, 5, 7, 10})\n    lu.assertEquals(candidate({2, 6, 8, {5, 7}, 11}), {2, 6, 8, 11})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, 12}), {3, 7, 9, 12})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, {5, 12}, 12}), {3, 7, 9, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "lua",
-    "prompt": "-- Write a function to sort each sublist of strings in a given list of lists.\nlocal function sort_sublists(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{' red ', 'green'}, {'blue ', ' black'}, {' orange', 'brown'}}), {{' red ', 'green'}, {' black', 'blue '}, {' orange', 'brown'}})\n    lu.assertEquals(candidate({{'zilver', 'gold'}, {'magnesium', 'aluminium'}, {'steel', 'bronze'}}), {{'gold', 'zilver'}, {'aluminium', 'magnesium'}, {'bronze', 'steel'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "lua",
-    "prompt": "-- Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nlocal function remove_kth_element(list1, L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_kth_element\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {1, 1, 3, 4, 4, 5, 1})\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), {10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to add a dictionary to the tuple. The output should be a tuple.\nlocal function add_dict_to_tuple(test_tup, test_dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_dict_to_tuple\n    lu.assertEquals(candidate({4, 5, 6}, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}), {4, 5, 6, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}})\n    lu.assertEquals(candidate({1, 2, 3}, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}), {1, 2, 3, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}})\n    lu.assertEquals(candidate({8, 9, 10}, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}), {8, 9, 10, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "lua",
-    "prompt": "-- Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nlocal function find(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find\n    lu.assertEquals(candidate(10, 3), 3)\n    lu.assertEquals(candidate(4, 2), 2)\n    lu.assertEquals(candidate(20, 5), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "lua",
-    "prompt": "-- Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nlocal function text_match_two_three(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_two_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the occurence of all elements of list in a tuple.\nlocal function count_Occurrence(tup, lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Occurrence\n    lu.assertEquals(candidate({'a', 'a', 'c', 'b', 'd'}, {'a', 'b'}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 1, 4, 6, 7, 1, 4}, {1, 4, 7}), 6)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {1, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "lua",
-    "prompt": "-- Write a function to count number items that are identical in the same position of three given lists.\nlocal function count_samepair(list1, list2, list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_samepair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}, {2, 1, 3, 1, 2, 6, 7, 9}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 2, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an a followed by one or more b's.\nlocal function text_match_one(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlocal function difference(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = difference\n    lu.assertEquals(candidate(3), 30)\n    lu.assertEquals(candidate(5), 210)\n    lu.assertEquals(candidate(2), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "lua",
-    "prompt": "-- Write a function to toggle the case of all characters in a string.\nlocal function toggle_string(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_string\n    lu.assertEquals(candidate('Python'), 'pYTHON')\n    lu.assertEquals(candidate('Pangram'), 'pANGRAM')\n    lu.assertEquals(candidate('LIttLE'), 'liTTle')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the element of a list having maximum length.\nlocal function Find_Max(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max\n    lu.assertEquals(candidate({{'A'}, {'A', 'B'}, {'A', 'B', 'C'}}), {'A', 'B', 'C'})\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1, 2, 3})\n    lu.assertEquals(candidate({{1, 1}, {1, 2, 3}, {1, 5, 6, 1}}), {1, 5, 6, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the Eulerian number a(n, m).\nlocal function eulerian_num(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eulerian_num\n    lu.assertEquals(candidate(3, 1), 4)\n    lu.assertEquals(candidate(4, 1), 11)\n    lu.assertEquals(candidate(5, 3), 26)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of occurrences of a number in a given list.\nlocal function frequency(a, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency\n    lu.assertEquals(candidate({1, 2, 3}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 3, 4}, 3), 3)\n    lu.assertEquals(candidate({0, 1, 2, 3, 1, 2}, 1), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nlocal function sort_numeric_strings(nums_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numeric_strings\n    lu.assertEquals(candidate({'4', '12', '45', '7', '0', '100', '200', '-12', '-500'}), {-500, -12, 0, 4, 7, 12, 45, 100, 200})\n    lu.assertEquals(candidate({'2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2'}), {1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9})\n    lu.assertEquals(candidate({'1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11'}), {1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nlocal function geometric_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = geometric_sum\n    lu.assertEquals(candidate(7), 1.9921875)\n    lu.assertEquals(candidate(4), 1.9375)\n    lu.assertEquals(candidate(8), 1.99609375)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nlocal function divisible_by_digits(startnum, endnum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisible_by_digits\n    lu.assertEquals(candidate(1, 22), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22})\n    lu.assertEquals(candidate(1, 15), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15})\n    lu.assertEquals(candidate(20, 25), {22, 24})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "lua",
-    "prompt": "-- Write a python function to calculate the product of the unique numbers in a given list.\nlocal function unique_product(list_data)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_product\n    lu.assertEquals(candidate({10, 20, 30, 40, 20, 50, 60, 40}), 720000000)\n    lu.assertEquals(candidate({1, 2, 3, 1}), 6)\n    lu.assertEquals(candidate({7, 8, 9, 0, 1, 1}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the largest negative number from the given list.\nlocal function largest_neg(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_neg\n    lu.assertEquals(candidate({1, 2, 3, -4, -6}), -6)\n    lu.assertEquals(candidate({1, 2, 3, -8, -9}), -9)\n    lu.assertEquals(candidate({1, 2, 3, 4, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "lua",
-    "prompt": "-- Write a function to remove consecutive duplicates of a given list.\nlocal function consecutive_duplicates(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {10, 15, 19, 18, 17, 26, 17, 18, 10})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {'a', 'b', 'c', 'd'})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd', 'a', 'a'}), {'a', 'b', 'c', 'd', 'a'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "lua",
-    "prompt": "-- Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nlocal function min_Jumps(steps, d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Jumps\n    lu.assertEquals(candidate({3, 4}, 11), 3.5)\n    lu.assertEquals(candidate({3, 4}, 0), 0)\n    lu.assertEquals(candidate({11, 14}, 11), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "lua",
-    "prompt": "-- Write a python function to find a pair with highest product from a given array of integers.\nlocal function max_Product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Product\n    lu.assertEquals(candidate({1, 2, 3, 4, 7, 0, 8, 4}), {7, 8})\n    lu.assertEquals(candidate({0, -1, -2, -4, 5, 0, -6}), {-4, -6})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the nth element from a given list of tuples.\nlocal function extract_nth_element(list1, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_nth_element\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 0), {'Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 2), {99, 96, 94, 98})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 1), {98, 97, 91, 94})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth nonagonal number.\nlocal function is_nonagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nonagonal\n    lu.assertEquals(candidate(10), 325)\n    lu.assertEquals(candidate(15), 750)\n    lu.assertEquals(candidate(18), 1089)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the maximum difference between any two elements in a given array.\nlocal function max_Abs_Diff(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Abs_Diff\n    lu.assertEquals(candidate({2, 1, 5, 3}), 4)\n    lu.assertEquals(candidate({9, 3, 2, 5, 1}), 8)\n    lu.assertEquals(candidate({3, 2, 1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "lua",
-    "prompt": "-- Write a function to pack consecutive duplicates of a given list elements into sublists.\nlocal function pack_consecutive_duplicates(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pack_consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {{0, 0}, {1}, {2}, {3}, {4, 4}, {5}, {6, 6, 6}, {7}, {8}, {9}, {4, 4}})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {{10, 10}, {15}, {19}, {18, 18}, {17}, {26, 26}, {17}, {18}, {10}})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {{'a', 'a'}, {'b'}, {'c'}, {'d', 'd'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum of perrin numbers.\nlocal function cal_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cal_sum\n    lu.assertEquals(candidate(9), 49)\n    lu.assertEquals(candidate(10), 66)\n    lu.assertEquals(candidate(11), 88)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "lua",
-    "prompt": "-- Write a python function to remove the characters which have odd index values of a given string.\nlocal function odd_values_string(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_values_string\n    lu.assertEquals(candidate('abcdef'), 'ace')\n    lu.assertEquals(candidate('python'), 'pto')\n    lu.assertEquals(candidate('data'), 'dt')\n    lu.assertEquals(candidate('lambs'), 'lms')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "lua",
-    "prompt": "-- Write a function to find kth element from the given two sorted arrays.\nlocal function find_kth(arr1, arr2, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_kth\n    lu.assertEquals(candidate({2, 3, 6, 7, 9}, {1, 4, 8, 10}, 5), 6)\n    lu.assertEquals(candidate({100, 112, 256, 349, 770}, {72, 86, 113, 119, 265, 445, 892}, 7), 256)\n    lu.assertEquals(candidate({3, 4, 7, 8, 10}, {2, 5, 9, 11}, 6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlocal function jacobsthal_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = jacobsthal_num\n    lu.assertEquals(candidate(5), 11)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 5)\n    lu.assertEquals(candidate(13), 2731)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nlocal function frequency_lists(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency_lists\n    lu.assertEquals(candidate({{1, 2, 3, 2}, {4, 5, 6, 2}, {7, 8, 9, 5}}), {[1] = 1, [2] = 3, [3] = 1, [4] = 1, [5] = 2, [6] = 1, [7] = 1, [8] = 1, [9] = 1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}), {[1] = 1, [2] = 1, [3] = 1, [4] = 1, [5] = 1, [6] = 1, [7] = 1, [8] = 1, [9] = 1, [10] = 1, [11] = 1, [12] = 1})\n    lu.assertEquals(candidate({{20, 30, 40, 17}, {18, 16, 14, 13}, {10, 20, 30, 40}}), {[20] = 2, [30] = 2, [40] = 2, [17] = 1, [18] = 1, [16] = 1, [14] = 1, [13] = 1, [10] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "lua",
-    "prompt": "-- Write a function to find perfect squares between two given numbers.\nlocal function perfect_squares(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perfect_squares\n    lu.assertEquals(candidate(1, 30), {1, 4, 9, 16, 25})\n    lu.assertEquals(candidate(50, 100), {64, 81, 100})\n    lu.assertEquals(candidate(100, 200), {100, 121, 144, 169, 196})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "lua",
-    "prompt": "-- Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nlocal function sum_Of_Subarray_Prod(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_Subarray_Prod\n    lu.assertEquals(candidate({1, 2, 3}), 20)\n    lu.assertEquals(candidate({1, 2}), 5)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the first odd number in a given list of numbers.\nlocal function first_odd(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_odd\n    lu.assertEquals(candidate({1, 3, 5}), 1)\n    lu.assertEquals(candidate({2, 4, 1, 3}), 1)\n    lu.assertEquals(candidate({8, 9, 1}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to perform index wise addition of list elements in the given two nested lists.\nlocal function add_nested_tuples(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_nested_tuples\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{7, 10}, {7, 14}, {3, 10}, {8, 13}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{9, 12}, {9, 16}, {5, 12}, {10, 15}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{11, 14}, {11, 18}, {7, 14}, {12, 17}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "lua",
-    "prompt": "-- Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nlocal function merge(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge\n    lu.assertEquals(candidate({{'x', 'y'}, {'a', 'b'}, {'m', 'n'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}, {7, 8}}), {{1, 3, 5, 7}, {2, 4, 6, 8}})\n    lu.assertEquals(candidate({{'x', 'y', 'z'}, {'a', 'b', 'c'}, {'m', 'n', 'o'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}, {'z', 'c', 'o'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given number can be represented as the difference of two squares or not.\nlocal function dif_Square(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dif_Square\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(15), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "lua",
-    "prompt": "-- Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nlocal function check_smaller(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_smaller\n    lu.assertEquals(candidate({1, 2, 3}, {2, 3, 4}), false)\n    lu.assertEquals(candidate({4, 5, 6}, {3, 4, 5}), true)\n    lu.assertEquals(candidate({11, 12, 13}, {10, 11, 12}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "lua",
-    "prompt": "-- Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nlocal function freq_count(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = freq_count\n    lu.assertEquals(candidate({10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), {[10] = 4, [20] = 4, [40] = 2, [50] = 2, [30] = 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), {[1] = 3, [2] = 2, [3] = 3, [4] = 3})\n    lu.assertEquals(candidate({5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), {[10] = 1, [5] = 3, [6] = 2, [7] = 2, [4] = 2, [9] = 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "lua",
-    "prompt": "-- Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nlocal function rgb_to_hsv(r, g, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rgb_to_hsv\n    lu.assertEquals(candidate(255, 255, 255), {0.0, 0.0, 100.0})\n    lu.assertEquals(candidate(0, 215, 0), {120.0, 100.0, 84.31372549019608})\n    lu.assertEquals(candidate(10, 215, 110), {149.26829268292684, 95.34883720930233, 84.31372549019608})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "lua",
-    "prompt": "-- Write a function to flatten a given nested list structure.\nlocal function flatten_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flatten_list\n    lu.assertEquals(candidate({0, 10, {20, 30}, 40, 50, {60, 70, 80}, {90, 100, 110, 120}}), {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120})\n    lu.assertEquals(candidate({{10, 20}, {40}, {30, 56, 25}, {10, 20}, {33}, {40}}), {10, 20, 40, 30, 56, 25, 10, 20, 33, 40})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given string is starting with a vowel or not using regex.\nlocal function check_str(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_str\n    lu.assertEquals(candidate('annie'), true)\n    lu.assertEquals(candidate('dawood'), false)\n    lu.assertEquals(candidate('Else'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nlocal function check_monthnumber_number(monthnum3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumber_number\n    lu.assertEquals(candidate(6), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(12), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "lua",
-    "prompt": "-- Write a function to sort the given list.\nlocal function heap_sort(iterable)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_sort\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 25, 58}), {14, 22, 25, 25, 35, 58, 65, 75, 85})\n    lu.assertEquals(candidate({7, 1, 9, 5}), {1, 5, 7, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "lua",
-    "prompt": "-- Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nlocal function k_smallest_pairs(nums1, nums2, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = k_smallest_pairs\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 2), {{1, 2}, {1, 4}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 1), {{1, 2}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 7), {{1, 2}, {1, 4}, {3, 2}, {1, 6}, {3, 4}, {3, 6}, {7, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "lua",
-    "prompt": "-- Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nlocal function find_solution(a, b, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_solution\n    lu.assertEquals(candidate(2, 3, 7), {2, 1})\n    lu.assertEquals(candidate(4, 2, 7), None)\n    lu.assertEquals(candidate(1, 13, 17), {4, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the largest number that can be formed with the given list of digits.\nlocal function find_Max_Num(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Max_Num\n    lu.assertEquals(candidate({1, 2, 3}), 321)\n    lu.assertEquals(candidate({4, 5, 6, 1}), 6541)\n    lu.assertEquals(candidate({1, 2, 3, 9}), 9321)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "lua",
-    "prompt": "-- Write a function that returns the list in a list of lists whose sum of elements is the highest.\nlocal function max_sum_list(lists)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_list\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {10, 11, 12})\n    lu.assertEquals(candidate({{3, 2, 1}, {6, 5, 4}, {12, 11, 10}}), {12, 11, 10})\n    lu.assertEquals(candidate({{2, 3, 1}}), {2, 3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "lua",
-    "prompt": "-- Write a python function to interchange the first and last elements in a list.\nlocal function swap_List(newList)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({12, 35, 9, 56, 24}), {24, 35, 9, 56, 12})\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median of two sorted lists of same size.\nlocal function get_median(arr1, arr2, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_median\n    lu.assertEquals(candidate({1, 12, 15, 26, 38}, {2, 13, 17, 30, 45}, 5), 16.0)\n    lu.assertEquals(candidate({2, 4, 8, 9}, {7, 13, 19, 28}, 4), 8.5)\n    lu.assertEquals(candidate({3, 6, 14, 23, 36, 42}, {2, 18, 27, 39, 49, 55}, 6), 25.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to replace whitespaces with an underscore and vice versa in a given string.\nlocal function replace_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')\n    lu.assertEquals(candidate('The_Avengers'), 'The Avengers')\n    lu.assertEquals(candidate('Fast and Furious'), 'Fast_and_Furious')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "lua",
-    "prompt": "-- Write a function to determine if the sum of the divisors of two integers are the same.\nlocal function are_equivalent(num1, num2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = are_equivalent\n    lu.assertEquals(candidate(36, 57), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(23, 47), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "lua",
-    "prompt": "-- Write a function to reverse each string in a given list of string values.\nlocal function reverse_string_list(stringlist)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_string_list\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue', 'White', 'Black'}), {'deR', 'neerG', 'eulB', 'etihW', 'kcalB'})\n    lu.assertEquals(candidate({'john', 'amal', 'joel', 'george'}), {'nhoj', 'lama', 'leoj', 'egroeg'})\n    lu.assertEquals(candidate({'jack', 'john', 'mary'}), {'kcaj', 'nhoj', 'yram'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to compute the sum of digits of each number of a given list.\nlocal function sum_of_digits(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_of_digits\n    lu.assertEquals(candidate({10, 2, 56}), 14)\n    lu.assertEquals(candidate({{10, 20, 4, 5, 'b', 70, 'a'}}), 19)\n    lu.assertEquals(candidate({10, 20, -4, 5, -70}), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth number in the newman conway sequence.\nlocal function sequence(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequence\n    lu.assertEquals(candidate(10), 6)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nlocal function heap_queue_largest(nums, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_queue_largest\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), {85, 75, 65})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), {85, 75})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), {85, 75, 65, 58, 35})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "lua",
-    "prompt": "-- Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlocal function loss_amount(actual_cost, sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = loss_amount\n    lu.assertEquals(candidate(1500, 1200), 0)\n    lu.assertEquals(candidate(100, 200), 100)\n    lu.assertEquals(candidate(2000, 5000), 3000)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "lua",
-    "prompt": "-- Write a function to find the union of the elements of two given lists and output them in sorted order.\nlocal function union_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = union_elements\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 4, 5, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {3, 4, 5, 6}), {1, 2, 3, 4, 5, 6})\n    lu.assertEquals(candidate({11, 12, 13, 14}, {13, 15, 16, 17}), {11, 12, 13, 14, 15, 16, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the length of the longest sublists.\nlocal function Find_Max_Length(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max_Length\n    lu.assertEquals(candidate({{1}, {1, 4}, {5, 6, 7, 8}}), 4)\n    lu.assertEquals(candidate({{0, 1}, {2, 2}, {3, 2, 1}}), 3)\n    lu.assertEquals(candidate({{7}, {22, 23}, {13, 14, 15}, {10, 20, 30, 40, 50}}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "lua",
-    "prompt": "-- Write a function to remove the parenthesis and what is inbetween them from a string.\nlocal function remove_parenthesis(items)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_parenthesis\n    lu.assertEquals(candidate({'python (chrome)'}), 'python')\n    lu.assertEquals(candidate({'string(.abc)'}), 'string')\n    lu.assertEquals(candidate({'alpha(num)'}), 'alpha')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "lua",
-    "prompt": "-- Write a python function to find whether the parity of a given number is odd.\nlocal function find_Parity(x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Parity\n    lu.assertEquals(candidate(12), false)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median length of a trapezium.\nlocal function median_trapezium(base1, base2, height)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_trapezium\n    lu.assertEquals(candidate(15, 25, 35), 20)\n    lu.assertEquals(candidate(10, 20, 30), 15)\n    lu.assertEquals(candidate(6, 9, 4), 7.5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find nth centered hexagonal number.\nlocal function centered_hexagonal_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = centered_hexagonal_number\n    lu.assertEquals(candidate(10), 271)\n    lu.assertEquals(candidate(2), 7)\n    lu.assertEquals(candidate(9), 217)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to find number of lists present in the given list.\nlocal function find_lists(Input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lists\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}}), 2)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}}), 3)\n    lu.assertEquals(candidate({9, 8, 7, 6, 5, 4, 3, 2, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlocal function get_max_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_sum\n    lu.assertEquals(candidate(60), 106)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the length of the longest word.\nlocal function len_log(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = len_log\n    lu.assertEquals(candidate({'python', 'PHP', 'bigdata'}), 7)\n    lu.assertEquals(candidate({'a', 'ab', 'abc'}), 3)\n    lu.assertEquals(candidate({'small', 'big', 'tall'}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "lua",
-    "prompt": "-- Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nlocal function sector_area(r, a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sector_area\n    lu.assertEquals(candidate(4, 45), 6.283185307179586)\n    lu.assertEquals(candidate(9, 45), 31.808625617596654)\n    lu.assertEquals(candidate(9, 361), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether every odd index contains odd numbers of a given list.\nlocal function odd_position(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_position\n    lu.assertEquals(candidate({2, 1, 4, 3, 6, 7, 6, 3}), true)\n    lu.assertEquals(candidate({4, 1, 2}), true)\n    lu.assertEquals(candidate({1, 2, 3}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "lua",
-    "prompt": "-- Write a function to join a list of multiple integers into a single integer.\nlocal function multiple_to_single(L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiple_to_single\n    lu.assertEquals(candidate({11, 33, 50}), 113350)\n    lu.assertEquals(candidate({-1, 2, 3, 4, 5, 6}), -123456)\n    lu.assertEquals(candidate({10, 15, 20, 25}), 10152025)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "lua",
-    "prompt": "-- Write a python function to find whether a number is divisible by 11.\nlocal function is_Diff(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Diff\n    lu.assertEquals(candidate(12345), false)\n    lu.assertEquals(candidate(1212112), true)\n    lu.assertEquals(candidate(1212), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "lua",
-    "prompt": "-- Write a function to perform index wise multiplication of list elements in the given two lists.\nlocal function index_multiplication(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_multiplication\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 21}, {12, 45}, {2, 9}, {7, 30}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{14, 32}, {20, 60}, {6, 20}, {16, 44}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{24, 45}, {30, 77}, {12, 33}, {27, 60}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "lua",
-    "prompt": "-- Write a function to convert tuple string to integer tuple.\nlocal function tuple_str_int(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_str_int\n    lu.assertEquals(candidate('(7, 8, 9)'), {7, 8, 9})\n    lu.assertEquals(candidate('(1, 2, 3)'), {1, 2, 3})\n    lu.assertEquals(candidate('(4, 5, 6)'), {4, 5, 6})\n    lu.assertEquals(candidate('(7, 81, 19)'), {7, 81, 19})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to sum all amicable numbers from 1 to a specified number.\nlocal function amicable_numbers_sum(limit)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = amicable_numbers_sum\n    lu.assertEquals(candidate(999), 504)\n    lu.assertEquals(candidate(9999), 31626)\n    lu.assertEquals(candidate(99), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to remove odd characters in a string.\nlocal function remove_odd(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate('python'), 'yhn')\n    lu.assertEquals(candidate('program'), 'rga')\n    lu.assertEquals(candidate('language'), 'agae')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nlocal function multiply_elements(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_elements\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {5, 35, 56, 80})\n    lu.assertEquals(candidate({2, 4, 5, 6, 7}), {8, 20, 30, 42})\n    lu.assertEquals(candidate({12, 13, 14, 9, 15}), {156, 182, 126, 135})\n    lu.assertEquals(candidate({12}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nlocal function count_rotation(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_rotation\n    lu.assertEquals(candidate({3, 2, 1}), 1)\n    lu.assertEquals(candidate({4, 5, 1, 2, 3}), 2)\n    lu.assertEquals(candidate({7, 8, 9, 1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 2, 3}), 0)\n    lu.assertEquals(candidate({1, 3, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the number of unique tuples in the given list.\nlocal function extract_freq(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_freq\n    lu.assertEquals(candidate({{3, 4}, {1, 2}, {4, 3}, {5, 6}}), 3)\n    lu.assertEquals(candidate({{4, 15}, {2, 3}, {5, 4}, {6, 7}}), 4)\n    lu.assertEquals(candidate({{5, 16}, {2, 3}, {6, 5}, {6, 9}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "lua",
-    "prompt": "-- The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nlocal function count_same_pair(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_same_pair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}), 4)\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 11)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 1)\n    lu.assertEquals(candidate({0, 1, 1, 2}, {0, 1, 2, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the value of 'a' to the power 'b'.\nlocal function power(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power\n    lu.assertEquals(candidate(3, 4), 81)\n    lu.assertEquals(candidate(2, 3), 8)\n    lu.assertEquals(candidate(5, 5), 3125)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "lua",
-    "prompt": "-- Write function to find the sum of all items in the given dictionary.\nlocal function return_sum(dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = return_sum\n    lu.assertEquals(candidate({['a'] = 100, ['b'] = 200, ['c'] = 300}), 600)\n    lu.assertEquals(candidate({['a'] = 25, ['b'] = 18, ['c'] = 45}), 88)\n    lu.assertEquals(candidate({['a'] = 36, ['b'] = 39, ['c'] = 49}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "lua",
-    "prompt": "-- Write a function to return a list of all pairs of consecutive items in a given list.\nlocal function pair_wise(l1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_wise\n    lu.assertEquals(candidate({1, 1, 2, 3, 3, 4, 4, 5}), {{1, 1}, {1, 2}, {2, 3}, {3, 3}, {3, 4}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), {{1, 5}, {5, 7}, {7, 9}, {9, 10}})\n    lu.assertEquals(candidate({5, 1, 9, 7, 10}), {{5, 1}, {1, 9}, {9, 7}, {7, 10}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 10}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "lua",
-    "prompt": "-- Write a python function to split a string into characters.\nlocal function split(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split\n    lu.assertEquals(candidate('python'), {'p', 'y', 't', 'h', 'o', 'n'})\n    lu.assertEquals(candidate('Name'), {'N', 'a', 'm', 'e'})\n    lu.assertEquals(candidate('program'), {'p', 'r', 'o', 'g', 'r', 'a', 'm'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "lua",
-    "prompt": "-- Write a function to find minimum of three numbers.\nlocal function min_of_three(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_of_three\n    lu.assertEquals(candidate(10, 20, 0), 0)\n    lu.assertEquals(candidate(19, 15, 18), 15)\n    lu.assertEquals(candidate(-10, -20, -30), -30)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nlocal function is_Sum_Of_Powers_Of_Two(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sum_Of_Powers_Of_Two\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(7), false)\n    lu.assertEquals(candidate(14), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nlocal function get_Char(strr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Char\n    lu.assertEquals(candidate('abc'), 'f')\n    lu.assertEquals(candidate('gfg'), 't')\n    lu.assertEquals(candidate('ab'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "lua",
-    "prompt": "-- Write a function to return the sum of all divisors of a number.\nlocal function sum_div(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_div\n    lu.assertEquals(candidate(8), 7)\n    lu.assertEquals(candidate(12), 16)\n    lu.assertEquals(candidate(7), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "lua",
-    "prompt": "-- Write a python function that returns the number of integer elements in a given list.\nlocal function count_integer(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_integer\n    lu.assertEquals(candidate({1, 2, 'abc', 1.2}), 2)\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1.2, 4, 5.1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "lua",
-    "prompt": "-- Write a python function to remove duplicate numbers from a given number of lists.\nlocal function two_unique_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = two_unique_nums\n    lu.assertEquals(candidate({1, 2, 3, 2, 3, 4, 5}), {1, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 5}), {1, 3, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "lua",
-    "prompt": "-- Write a function to find whether a given array of integers contains any duplicate element.\nlocal function test_duplicate(arraynums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_duplicate\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), true)\n    lu.assertEquals(candidate({1, 1, 2, 2, 3, 3, 4, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "lua",
-    "prompt": "-- Write a function which returns nth catalan number.\nlocal function catalan_number(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = catalan_number\n    lu.assertEquals(candidate(10), 16796)\n    lu.assertEquals(candidate(9), 4862)\n    lu.assertEquals(candidate(7), 429)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "lua",
-    "prompt": "-- Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlocal function power_base_sum(base, power)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power_base_sum\n    lu.assertEquals(candidate(2, 100), 115)\n    lu.assertEquals(candidate(8, 10), 37)\n    lu.assertEquals(candidate(8, 15), 62)\n    lu.assertEquals(candidate(3, 3), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nlocal function replace_list(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_list\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 2, 4, 6, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8}), {1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({'red', 'blue', 'green'}, {'yellow'}), {'red', 'blue', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth octagonal number.\nlocal function is_octagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_octagonal\n    lu.assertEquals(candidate(5), 65)\n    lu.assertEquals(candidate(10), 280)\n    lu.assertEquals(candidate(15), 645)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nlocal function replace_blank(str1, char)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_blank\n    lu.assertEquals(candidate('hello people', '@'), 'hello@people')\n    lu.assertEquals(candidate('python program language', '$'), 'python$program$language')\n    lu.assertEquals(candidate('blank space', '-'), 'blank-space')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "lua",
-    "prompt": "-- Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nlocal function replace_specialchar(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_specialchar\n    lu.assertEquals(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')\n    lu.assertEquals(candidate('a b c,d e f'), 'a:b:c:d:e:f')\n    lu.assertEquals(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a given tuple of positive integers into a single integer.\nlocal function tuple_to_int(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_int\n    lu.assertEquals(candidate({1, 2, 3}), 123)\n    lu.assertEquals(candidate({4, 5, 6}), 456)\n    lu.assertEquals(candidate({5, 6, 7}), 567)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "lua",
-    "prompt": "-- Write a function to find the third side of a right angled triangle.\nlocal function otherside_rightangle(w, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = otherside_rightangle\n    lu.assertEquals(candidate(7, 8), 10.63014581273465)\n    lu.assertEquals(candidate(3, 4), 5)\n    lu.assertEquals(candidate(7, 15), 16.55294535724685)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n most expensive items in a given dataset.\nlocal function expensive_items(items, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = expensive_items\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}}, 2), {{['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-1', ['price'] = 101.1}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}, {['name'] = 'Item-4', ['price'] = 22.75}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sum of the per-digit difference between two integers.\nlocal function digit_distance_nums(n1, n2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digit_distance_nums\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(23, 56), 6)\n    lu.assertEquals(candidate(123, 256), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "lua",
-    "prompt": "-- Write a function that checks if a strings contains 'z', except at the start and end of the word.\nlocal function text_match_wordz_middle(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz_middle\n    lu.assertEquals(candidate('pythonzabc.'), true)\n    lu.assertEquals(candidate('zxyabc.'), false)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "lua",
-    "prompt": "-- Write a function to remove leading zeroes from an ip address.\nlocal function removezero_ip(ip)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = removezero_ip\n    lu.assertEquals(candidate('216.08.094.196'), '216.8.94.196')\n    lu.assertEquals(candidate('12.01.024'), '12.1.24')\n    lu.assertEquals(candidate('216.08.094.0196'), '216.8.94.196')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of sublists containing a particular element.\nlocal function count_element_in_list(list1, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_element_in_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {1, 11}, {1, 15, 7}}, 1), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'A'), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'E'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "lua",
-    "prompt": "-- Write a function to multiply two integers.\nlocal function multiply_int(x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_int\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(5, 10), 50)\n    lu.assertEquals(candidate(4, 8), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "lua",
-    "prompt": "-- Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nlocal function add_pairwise(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_pairwise\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {6, 12, 15, 18})\n    lu.assertEquals(candidate({2, 6, 8, 9, 11}), {8, 14, 17, 20})\n    lu.assertEquals(candidate({3, 7, 9, 10, 12}), {10, 16, 19, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nlocal function max_product_tuple(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 36)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 200)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 484)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4429,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find the kth element in the given array using 1-based indexing.\nlocal function kth_element(arr, k)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = kth_element\n    lu.assertEquals(candidate({12, 3, 5, 7, 19}, 2), 3)\n    lu.assertEquals(candidate({17, 24, 8, 23}, 3), 8)\n    lu.assertEquals(candidate({16, 21, 25, 36, 4}, 4), 36)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "lua",
-    "prompt": "-- Write a python function to interchange the first and last element in a given list.\nlocal function swap_List(newList)\n",
+    "prompt": "-- Write a function to convert a snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), {4, 2, 3, 4, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('python_program'), 'PythonProgram')\n    lu.assertEquals(candidate('python_language'), 'PythonLanguage')\n    lu.assertEquals(candidate('programming_language'), 'ProgrammingLanguage')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "lua",
-    "prompt": "-- Write a function to find the number of elements that occurs before the list element in the given tuple.\nlocal function count_first_elements(test_tup)\n",
+    "prompt": "-- Write a function to find the Eulerian number a(n, m).\nlocal function eulerian_num(n, m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_first_elements\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), 3)\n    lu.assertEquals(candidate({2, 9, {5, 7}, 11}), 2)\n    lu.assertEquals(candidate({11, 15, 5, 8, {2, 3}, 8}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eulerian_num\n    lu.assertEquals(candidate(3, 1), 4)\n    lu.assertEquals(candidate(4, 1), 11)\n    lu.assertEquals(candidate(5, 3), 26)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "lua",
-    "prompt": "-- Write a function to locate the right insertion point for a specified value in sorted order.\nlocal function right_insertion(a, x)\n",
+    "prompt": "-- Write a function to sort each sublist of strings in a given list of lists.\nlocal function sort_sublists(input_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{' red ', 'green'}, {'blue ', ' black'}, {' orange', 'brown'}}), {{' red ', 'green'}, {' black', 'blue '}, {' orange', 'brown'}})\n    lu.assertEquals(candidate({{'zilver', 'gold'}, {'magnesium', 'aluminium'}, {'steel', 'bronze'}}), {{'gold', 'zilver'}, {'aluminium', 'magnesium'}, {'bronze', 'steel'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "lua",
-    "prompt": "-- Write a function to check if the given number is woodball or not.\nlocal function is_woodall(x)\n",
+    "prompt": "-- Write a python function to count true booleans in the given list.\nlocal function count(lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_woodall\n    lu.assertEquals(candidate(383), true)\n    lu.assertEquals(candidate(254), false)\n    lu.assertEquals(candidate(200), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count\n    lu.assertEquals(candidate({true, false, true}), 2)\n    lu.assertEquals(candidate({false, false}), 0)\n    lu.assertEquals(candidate({true, true, true}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "lua",
-    "prompt": "-- Write a function to sort the given array by using shell sort.\nlocal function shell_sort(my_list)\n",
+    "prompt": "-- Write a function to append the given list to the given tuples.\nlocal function add_lists(test_list, test_tup)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = shell_sort\n    lu.assertEquals(candidate({12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), {2, 3, 4, 5, 12, 12, 23, 56, 81, 95})\n    lu.assertEquals(candidate({24, 22, 39, 34, 87, 73, 68}), {22, 24, 34, 39, 68, 73, 87})\n    lu.assertEquals(candidate({32, 30, 16, 96, 82, 83, 74}), {16, 30, 32, 74, 82, 83, 96})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_lists\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {9, 10, 5, 6, 7})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {10, 11, 6, 7, 8})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "lua",
-    "prompt": "-- Write a python function to count the number of pairs whose xor value is odd.\nlocal function find_Odd_Pair(A, N)\n",
+    "prompt": "-- Write a function to merge three lists into a single sorted list.\nlocal function merge_sorted_list(num1, num2, num3)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Odd_Pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}, 5), 6)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}, 7), 12)\n    lu.assertEquals(candidate({1, 2, 3}, 3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_sorted_list\n    lu.assertEquals(candidate({25, 24, 15, 4, 5, 29, 110}, {19, 20, 11, 56, 25, 233, 154}, {24, 26, 54, 48}), {4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233})\n    lu.assertEquals(candidate({1, 3, 5, 6, 8, 9}, {2, 5, 7, 11}, {1, 4, 7, 8, 12}), {1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12})\n    lu.assertEquals(candidate({18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, {25, 35, 22, 85, 14, 65, 75, 25, 58}, {12, 74, 9, 50, 61, 41}), {1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "lua",
-    "prompt": "-- Write a python function to find the sum of all odd natural numbers within the range l and r.\nlocal function sum_in_range(l, r)\n",
+    "prompt": "-- Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlocal function odd_Equivalent(s, n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_in_range\n    lu.assertEquals(candidate(2, 5), 8)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 13), 40)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_Equivalent\n    lu.assertEquals(candidate('011001', 6), 3)\n    lu.assertEquals(candidate('11011', 5), 4)\n    lu.assertEquals(candidate('1010', 4), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "lua",
-    "prompt": "-- Write a function that returns the perimeter of a square given its side length as input.\nlocal function square_perimeter(a)\n",
+    "prompt": "-- Write a function to check if a string represents an integer or not.\nlocal function check_integer(text)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_perimeter\n    lu.assertEquals(candidate(10), 40)\n    lu.assertEquals(candidate(5), 20)\n    lu.assertEquals(candidate(4), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_integer\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('1'), true)\n    lu.assertEquals(candidate('12345'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "lua",
-    "prompt": "-- Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlocal function is_polite(n)\n",
+    "prompt": "-- Write a function to convert a given tuple of positive integers into a single integer.\nlocal function tuple_to_int(nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_polite\n    lu.assertEquals(candidate(7), 11)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(9), 13)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlocal function sum_series(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_series\n    lu.assertEquals(candidate(6), 12)\n    lu.assertEquals(candidate(10), 30)\n    lu.assertEquals(candidate(9), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "lua",
-    "prompt": "-- Write a function to find the dissimilar elements in the given two tuples.\nlocal function find_dissimilar(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_dissimilar\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {7, 2, 3, 9}), {1, 4, 7, 9})\n    lu.assertEquals(candidate({21, 11, 25, 26}, {26, 34, 21, 36}), {34, 36, 11, 25})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "lua",
-    "prompt": "-- Write a function to return two words from a list of words starting with letter 'p'.\nlocal function start_withp(words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = start_withp\n    lu.assertEquals(candidate({'Python PHP', 'Java JavaScript', 'c c++'}), {'Python', 'PHP'})\n    lu.assertEquals(candidate({'Python Programming', 'Java Programming'}), {'Python', 'Programming'})\n    lu.assertEquals(candidate({'Pqrst Pqr', 'qrstuv'}), {'Pqrst', 'Pqr'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "lua",
-    "prompt": "-- Write a function to convert the given snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('android_tv'), 'AndroidTv')\n    lu.assertEquals(candidate('google_pixel'), 'GooglePixel')\n    lu.assertEquals(candidate('apple_watch'), 'AppleWatch')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "lua",
-    "prompt": "-- Write a function to find the volume of a cube given its side length.\nlocal function volume_cube(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = volume_cube\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(2), 8)\n    lu.assertEquals(candidate(5), 125)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given month number contains 31 days or not.\nlocal function check_monthnumb_number(monthnum2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumb_number\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "lua",
-    "prompt": "-- Write a python function to check whether all the bits are unset in the given range or not.\nlocal function all_Bits_Set_In_The_Given_Range(n, l, r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Bits_Set_In_The_Given_Range\n    lu.assertEquals(candidate(4, 1, 2), true)\n    lu.assertEquals(candidate(17, 2, 4), true)\n    lu.assertEquals(candidate(39, 4, 6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "lua",
-    "prompt": "-- Write a python function to get the first element of each sublist.\nlocal function Extract(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Extract\n    lu.assertEquals(candidate({{1, 2}, {3, 4, 5}, {6, 7, 8, 9}}), {1, 3, 6})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5}}), {1, 4})\n    lu.assertEquals(candidate({{9, 8, 1}, {1, 2}}), {9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "lua",
-    "prompt": "-- Write a function to find the surface area of a cylinder.\nlocal function surfacearea_cylinder(r, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cylinder\n    lu.assertEquals(candidate(10, 5), 942.45)\n    lu.assertEquals(candidate(4, 5), 226.18800000000002)\n    lu.assertEquals(candidate(4, 10), 351.848)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "lua",
-    "prompt": "-- Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nlocal function sample_nam(sample_names)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sample_nam\n    lu.assertEquals(candidate({'sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'}), 16)\n    lu.assertEquals(candidate({'php', 'res', 'Python', 'abcd', 'Java', 'aaa'}), 10)\n    lu.assertEquals(candidate({'abcd', 'Python', 'abba', 'aba'}), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "lua",
-    "prompt": "-- Write a function to create the next bigger number by rearranging the digits of a given number.\nlocal function rearrange_bigger(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rearrange_bigger\n    lu.assertEquals(candidate(12), 21)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(102), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "lua",
-    "prompt": "-- Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlocal function perimeter_pentagon(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perimeter_pentagon\n    lu.assertEquals(candidate(5), 25)\n    lu.assertEquals(candidate(10), 50)\n    lu.assertEquals(candidate(15), 75)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "lua",
-    "prompt": "-- Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nlocal function max_sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum\n    lu.assertEquals(candidate({1, 15, 51, 45, 33, 100, 12, 18, 9}), 194)\n    lu.assertEquals(candidate({80, 60, 30, 40, 20, 10}), 210)\n    lu.assertEquals(candidate({2, 3, 14, 16, 21, 23, 29, 30}), 138)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "lua",
-    "prompt": "-- Write a function to remove uneven elements in the nested mixed tuple.\nlocal function extract_even(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_even\n    lu.assertEquals(candidate({4, 5, {7, 6, {2, 4}}, 6, 8}), {4, {6, {2, 4}}, 6, 8})\n    lu.assertEquals(candidate({5, 6, {8, 7, {4, 8}}, 7, 9}), {6, {8, {4, 8}}})\n    lu.assertEquals(candidate({5, 6, {9, 8, {4, 6}}, 8, 10}), {6, {8, {4, 6}}, 8, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_int\n    lu.assertEquals(candidate({1, 2, 3}), 123)\n    lu.assertEquals(candidate({4, 5, 6}), 456)\n    lu.assertEquals(candidate({5, 6, 7}), 567)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4789,249 +169,9 @@
     "language": "lua",
     "prompt": "-- Write a function to convert all possible convertible elements in a list of lists to floats.\nlocal function list_to_float(test_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_to_float\n    lu.assertEquals(candidate({{'3', '4'}, {'1', '26.45'}, {'7.32', '8'}, {'4', '8'}}), {{3.0, 4.0}, {1.0, 26.45}, {7.32, 8.0}, {4.0, 8.0}})\n    lu.assertEquals(candidate({{'4', '4'}, {'2', '27'}, {'4.12', '9'}, {'7', '11'}}), {{4.0, 4.0}, {2.0, 27.0}, {4.12, 9.0}, {7.0, 11.0}})\n    lu.assertEquals(candidate({{'6', '78'}, {'5', '26.45'}, {'1.33', '4'}, {'82', '13'}}), {{6.0, 78.0}, {5.0, 26.45}, {1.33, 4.0}, {82.0, 13.0}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "lua",
-    "prompt": "-- Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlocal function square_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 20)\n    lu.assertEquals(candidate(3), 56)\n    lu.assertEquals(candidate(4), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nlocal function get_pairs_count(arr, sum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_pairs_count\n    lu.assertEquals(candidate({1, 1, 1, 1}, 2), 6)\n    lu.assertEquals(candidate({1, 5, 7, -1, 5}, 6), 3)\n    lu.assertEquals(candidate({1, -2, 3}, 1), 1)\n    lu.assertEquals(candidate({-1, -2, 3}, -3), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "lua",
-    "prompt": "-- Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlocal function count_no_of_ways(n, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_no_of_ways\n    lu.assertEquals(candidate(2, 4), 16)\n    lu.assertEquals(candidate(3, 2), 6)\n    lu.assertEquals(candidate(4, 4), 228)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "lua",
-    "prompt": "-- Write a function to reverse words seperated by spaces in a given string.\nlocal function reverse_words(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_words\n    lu.assertEquals(candidate('python program'), 'program python')\n    lu.assertEquals(candidate('java language'), 'language java')\n    lu.assertEquals(candidate('indian man'), 'man indian')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "lua",
-    "prompt": "-- Write a python function to check if a given number is one less than twice its reverse.\nlocal function checks(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = checks\n    lu.assertEquals(candidate(70), false)\n    lu.assertEquals(candidate(23), false)\n    lu.assertEquals(candidate(73), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the last position of an element in a sorted array.\nlocal function last(arr, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last\n    lu.assertEquals(candidate({1, 2, 3}, 1), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, 4}, 1), 2)\n    lu.assertEquals(candidate({2, 3, 2, 3, 6, 8, 9}, 3), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "lua",
-    "prompt": "-- Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nlocal function count_X(tup, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_X\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), 0)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), 3)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "lua",
-    "prompt": "-- We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nlocal function extract_index_list(l1, l2, l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_index_list\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 7})\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 6, 5}, {0, 1, 2, 3, 4, 6, 7}), {1, 6})\n    lu.assertEquals(candidate({1, 1, 3, 4, 6, 5, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 6, 6, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "lua",
-    "prompt": "-- Write a function to find the second smallest number in a list.\nlocal function second_smallest(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = second_smallest\n    lu.assertEquals(candidate({1, 2, -8, -2, 0, -2}), -2)\n    lu.assertEquals(candidate({1, 1, -0.5, 0, 2, -2, -2}), -0.5)\n    lu.assertEquals(candidate({2, 2}), None)\n    lu.assertEquals(candidate({2, 2, 2}), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to concatenate each element of tuple by the delimiter.\nlocal function concatenate_tuple(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate_tuple\n    lu.assertEquals(candidate({'ID', 'is', 4, 'UTS'}), 'ID-is-4-UTS')\n    lu.assertEquals(candidate({'QWE', 'is', 4, 'RTY'}), 'QWE-is-4-RTY')\n    lu.assertEquals(candidate({'ZEN', 'is', 4, 'OP'}), 'ZEN-is-4-OP')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to replace all spaces in the given string with '%20'.\nlocal function replace_spaces(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')\n    lu.assertEquals(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')\n    lu.assertEquals(candidate('I love Coding'), 'I%20love%20Coding')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find the sum of numbers in a list within a range specified by two indices.\nlocal function sum_range_list(list1, m, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_range_list\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), 29)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), 16)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), 38)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "lua",
-    "prompt": "-- Write a function to merge three dictionaries into a single dictionary.\nlocal function merge_dictionaries_three(dict1, dict2, dict3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_dictionaries_three\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['O'] = 'Orange', ['W'] = 'White', ['B'] = 'Black'}), {['B'] = 'Black', ['R'] = 'Red', ['P'] = 'Pink', ['G'] = 'Green', ['W'] = 'White', ['O'] = 'Orange'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['L'] = 'lavender', ['B'] = 'Blue'}), {['W'] = 'White', ['P'] = 'Pink', ['B'] = 'Black', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['L'] = 'lavender', ['B'] = 'Blue'}, {['G'] = 'Green', ['W'] = 'White'}), {['B'] = 'Black', ['P'] = 'Pink', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender', ['W'] = 'White'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the minimum of two numbers.\nlocal function minimum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minimum\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(-5, -4), -5)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum difference between available pairs in the given tuple list.\nlocal function max_difference(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_difference\n    lu.assertEquals(candidate({{3, 5}, {1, 7}, {10, 3}, {1, 2}}), 7)\n    lu.assertEquals(candidate({{4, 6}, {2, 17}, {9, 13}, {11, 12}}), 15)\n    lu.assertEquals(candidate({{12, 35}, {21, 27}, {13, 23}, {41, 22}}), 23)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "lua",
-    "prompt": "-- Write a python function to find element at a given index after number of rotations.\nlocal function find_Element(arr, ranges, rotations, index)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {{0, 2}, {0, 3}}, 2, 1), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}, {{0, 1}, {0, 2}}, 1, 2), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {{0, 1}, {0, 2}}, 1, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5044,7 +184,7 @@
     "language": "lua",
     "prompt": "-- Write a function to convert a string to a list of strings split on the space character.\nlocal function string_to_list(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_list\n    lu.assertEquals(candidate('python programming'), {'python', 'programming'})\n    lu.assertEquals(candidate('lists tuples strings'), {'lists', 'tuples', 'strings'})\n    lu.assertEquals(candidate('write a program'), {'write', 'a', 'program'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "lua",
     "prompt": "-- Write a python function to find the element that appears only once in a sorted array.\nlocal function search(arr)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({1, 1, 2, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8}), 8)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4, 4}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a dictionary by value.\nlocal function sort_counter(dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_counter\n    lu.assertEquals(candidate({['Math'] = 81, ['Physics'] = 83, ['Chemistry'] = 87}), {{'Chemistry', 87}, {'Physics', 83}, {'Math', 81}})\n    lu.assertEquals(candidate({['Math'] = 400, ['Physics'] = 300, ['Chemistry'] = 250}), {{'Math', 400}, {'Physics', 300}, {'Chemistry', 250}})\n    lu.assertEquals(candidate({['Math'] = 900, ['Physics'] = 1000, ['Chemistry'] = 1250}), {{'Chemistry', 1250}, {'Physics', 1000}, {'Math', 900}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5089,7 +214,7 @@
     "language": "lua",
     "prompt": "-- Write a python function to remove first and last occurrence of a given character from the string.\nlocal function remove_Occ(s, ch)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_Occ\n    lu.assertEquals(candidate('hello', 'l'), 'heo')\n    lu.assertEquals(candidate('abcda', 'a'), 'bcd')\n    lu.assertEquals(candidate('PHP', 'P'), 'H')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "lua",
-    "prompt": "-- Write a function to find the lateral surface area of a cube given its side length.\nlocal function lateralsurface_cube(l)\n",
+    "prompt": "-- Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nlocal function max_product_tuple(list1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cube\n    lu.assertEquals(candidate(5), 100)\n    lu.assertEquals(candidate(9), 324)\n    lu.assertEquals(candidate(10), 400)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 36)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 200)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 484)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "lua",
-    "prompt": "-- Write a function that takes two lists and returns true if they have at least one common element.\nlocal function common_element(list1, list2)\n",
+    "prompt": "-- Write a function to sum all amicable numbers from 1 to a specified number.\nlocal function amicable_numbers_sum(limit)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common_element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), None)\n    lu.assertEquals(candidate({'a', 'b', 'c'}, {'d', 'b', 'e'}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = amicable_numbers_sum\n    lu.assertEquals(candidate(999), 504)\n    lu.assertEquals(candidate(9999), 31626)\n    lu.assertEquals(candidate(99), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "lua",
-    "prompt": "-- Write a function to append the given list to the given tuples.\nlocal function add_lists(test_list, test_tup)\n",
+    "prompt": "-- Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlocal function find_length(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_lists\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {9, 10, 5, 6, 7})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {10, 11, 6, 7, 8})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_length\n    lu.assertEquals(candidate('11000010001'), 6)\n    lu.assertEquals(candidate('10111'), 1)\n    lu.assertEquals(candidate('11011101100101'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "lua",
-    "prompt": "-- Write a function to compute the n-th power of each number in a list.\nlocal function nth_nums(nums, n)\n",
+    "prompt": "-- Write a python function to find the sum of common divisors of two given numbers.\nlocal function sum(a, b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = nth_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}, 3), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}, 5), {248832, 759375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum\n    lu.assertEquals(candidate(10, 15), 6)\n    lu.assertEquals(candidate(100, 150), 93)\n    lu.assertEquals(candidate(4, 6), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "lua",
-    "prompt": "-- Write a function to sort a list of elements.\nlocal function pancake_sort(nums)\n",
+    "prompt": "-- Write a function to multiply two integers.\nlocal function multiply_int(x, y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pancake_sort\n    lu.assertEquals(candidate({15, 79, 25, 38, 69}), {15, 25, 38, 69, 79})\n    lu.assertEquals(candidate({98, 12, 54, 36, 85}), {12, 36, 54, 85, 98})\n    lu.assertEquals(candidate({41, 42, 32, 12, 23}), {12, 23, 32, 41, 42})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median of three numbers.\nlocal function median_numbers(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_numbers\n    lu.assertEquals(candidate(25, 55, 65), 55.0)\n    lu.assertEquals(candidate(20, 10, 30), 20.0)\n    lu.assertEquals(candidate(15, 45, 75), 45.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the entered number is greater than the elements of the given array.\nlocal function check_greater(arr, number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_greater\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 4), false)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}, 8), true)\n    lu.assertEquals(candidate({9, 7, 4, 8, 6, 1}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nlocal function check_element(list, element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_element\n    lu.assertEquals(candidate({'green', 'orange', 'black', 'white'}, 'blue'), false)\n    lu.assertEquals(candidate({1, 2, 3, 4}, 7), false)\n    lu.assertEquals(candidate({'green', 'green', 'green', 'green'}, 'green'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "lua",
-    "prompt": "-- Write a function to extract specified size of strings from a given list of string values.\nlocal function extract_string(str, l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_string\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 8), {'practice', 'solution'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 6), {'Python'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 9), {'exercises'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "lua",
-    "prompt": "-- Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nlocal function text_lowercase_underscore(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_lowercase_underscore\n    lu.assertEquals(candidate('aab_cbbbc'), true)\n    lu.assertEquals(candidate('aab_Abbbc'), false)\n    lu.assertEquals(candidate('Aaab_abbbc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to trim each list by k in the given lists.\nlocal function trim_tuple(test_list, K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = trim_tuple\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 2), {{2}, {9}, {2}, {2}})\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 1), {{3, 2, 1}, {4, 9, 2}, {1, 2, 3}, {8, 2, 1}})\n    lu.assertEquals(candidate({{7, 8, 4, 9}, {11, 8, 12, 4}, {4, 1, 7, 8}, {3, 6, 9, 7}}, 1), {{8, 4}, {8, 12}, {1, 7}, {6, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the sublist having minimum length.\nlocal function Find_Min(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1})\n    lu.assertEquals(candidate({{1, 1}, {1, 1, 1}, {1, 2, 7, 8}}), {1, 1})\n    lu.assertEquals(candidate({{'x'}, {'x', 'y'}, {'x', 'y', 'z'}}), {'x'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "lua",
-    "prompt": "-- Write a function to filter odd numbers.\nlocal function filter_oddnumbers(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_oddnumbers\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 3, 5, 7, 9})\n    lu.assertEquals(candidate({10, 20, 45, 67, 84, 93}), {45, 67, 93})\n    lu.assertEquals(candidate({5, 7, 9, 8, 6, 4, 3}), {5, 7, 9, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "lua",
-    "prompt": "-- Write a function to find the first adverb ending with ly and its positions in a given string.\nlocal function find_adverbs(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverbs\n    lu.assertEquals(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')\n    lu.assertEquals(candidate('Please handle the situation carefuly'), '28-36: carefuly')\n    lu.assertEquals(candidate('Complete the task quickly'), '18-25: quickly')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "lua",
-    "prompt": "-- Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nlocal function max_of_nth(test_list, N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_of_nth\n    lu.assertEquals(candidate({{5, 6, 7}, {1, 3, 5}, {8, 9, 19}}, 2), 19)\n    lu.assertEquals(candidate({{6, 7, 8}, {2, 4, 6}, {9, 10, 20}}, 1), 10)\n    lu.assertEquals(candidate({{7, 8, 9}, {3, 5, 7}, {10, 11, 21}}, 1), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nlocal function decimal_to_binary(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(8), '1000')\n    lu.assertEquals(candidate(18), '10010')\n    lu.assertEquals(candidate(7), '111')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nlocal function combinations_colors(l, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_colors\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 1), {{'Red'}, {'Green'}, {'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 2), {{'Red', 'Red'}, {'Red', 'Green'}, {'Red', 'Blue'}, {'Green', 'Green'}, {'Green', 'Blue'}, {'Blue', 'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 3), {{'Red', 'Red', 'Red'}, {'Red', 'Red', 'Green'}, {'Red', 'Red', 'Blue'}, {'Red', 'Green', 'Green'}, {'Red', 'Green', 'Blue'}, {'Red', 'Blue', 'Blue'}, {'Green', 'Green', 'Green'}, {'Green', 'Green', 'Blue'}, {'Green', 'Blue', 'Blue'}, {'Blue', 'Blue', 'Blue'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all whitespaces from a string.\nlocal function remove_all_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_all_spaces\n    lu.assertEquals(candidate('python  program'), 'pythonprogram')\n    lu.assertEquals(candidate('python   programming    language'), 'pythonprogramminglanguage')\n    lu.assertEquals(candidate('python                     program'), 'pythonprogram')\n    lu.assertEquals(candidate('   python                     program'), 'pythonprogram')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "lua",
-    "prompt": "-- Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nlocal function min_Swaps(str1, str2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Swaps\n    lu.assertEquals(candidate('1101', '1110'), 1)\n    lu.assertEquals(candidate('111', '000'), 'Not Possible')\n    lu.assertEquals(candidate('111', '110'), 'Not Possible')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to create a new tuple from the given string and list.\nlocal function new_tuple(test_list, test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = new_tuple\n    lu.assertEquals(candidate({'WEB', 'is'}, 'best'), {'WEB', 'is', 'best'})\n    lu.assertEquals(candidate({'We', 'are'}, 'Developers'), {'We', 'are', 'Developers'})\n    lu.assertEquals(candidate({'Part', 'is'}, 'Wrong'), {'Part', 'is', 'Wrong'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the product of the array multiplication modulo n.\nlocal function find_remainder(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_remainder\n    lu.assertEquals(candidate({100, 10, 5, 25, 35, 14}, 11), 9)\n    lu.assertEquals(candidate({1, 1, 1}, 1), 0)\n    lu.assertEquals(candidate({1, 2, 1}, 2), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "lua",
-    "prompt": "-- Write a function to find the minimum value in a given heterogeneous list.\nlocal function min_val(listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 2)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 15)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "lua",
-    "prompt": "-- Write a function to find the ration of positive numbers in an array of integers.\nlocal function positive_count(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = positive_count\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), 0.54)\n    lu.assertEquals(candidate({2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 0.69)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), 0.56)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to add the given tuple to the given list.\nlocal function add_tuple(test_list, test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_tuple\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {5, 6, 7, 9, 10})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {6, 7, 8, 10, 11})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {7, 8, 9, 11, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "lua",
-    "prompt": "-- Write a function to find maximum run of uppercase characters in the given string.\nlocal function max_run_uppercase(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_run_uppercase\n    lu.assertEquals(candidate('GeMKSForGERksISBESt'), 5)\n    lu.assertEquals(candidate('PrECIOusMOVemENTSYT'), 6)\n    lu.assertEquals(candidate('GooGLEFluTTER'), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a given matrix in ascending order according to the sum of its rows.\nlocal function sort_matrix(M)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_matrix\n    lu.assertEquals(candidate({{1, 2, 3}, {2, 4, 5}, {1, 1, 1}}), {{1, 1, 1}, {1, 2, 3}, {2, 4, 5}})\n    lu.assertEquals(candidate({{1, 2, 3}, {-2, 4, -5}, {1, -1, 1}}), {{-2, 4, -5}, {1, -1, 1}, {1, 2, 3}})\n    lu.assertEquals(candidate({{5, 8, 9}, {6, 4, 3}, {2, 1, 4}}), {{2, 1, 4}, {6, 4, 3}, {5, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "lua",
-    "prompt": "-- Write a function to count those characters which have vowels as their neighbors in the given string.\nlocal function count_vowels(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_vowels\n    lu.assertEquals(candidate('bestinstareels'), 7)\n    lu.assertEquals(candidate('partofthejourneyistheend'), 12)\n    lu.assertEquals(candidate('amazonprime'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlocal function max_sum_increasing_subseq(a, n, index, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_increasing_subseq\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), 11)\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), 7)\n    lu.assertEquals(candidate({11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), 71)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_int\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(5, 10), 50)\n    lu.assertEquals(candidate(4, 8), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5524,7 +304,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find words that are longer than n characters from a given list of words.\nlocal function long_words(n, str)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = long_words\n    lu.assertEquals(candidate(3, 'python is a programming language'), {'python', 'programming', 'language'})\n    lu.assertEquals(candidate(2, 'writing a program'), {'writing', 'program'})\n    lu.assertEquals(candidate(5, 'sorting list'), {'sorting'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "lua",
-    "prompt": "-- Write a python function to find the sum of non-repeated elements in a given list.\nlocal function find_sum(arr)\n",
+    "prompt": "-- Write a function to calculate whether the matrix is a magic square.\nlocal function magic_square_test(my_matrix)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_sum\n    lu.assertEquals(candidate({1, 2, 3, 1, 1, 4, 5, 6}), 21)\n    lu.assertEquals(candidate({1, 10, 9, 4, 2, 10, 10, 45, 4}), 71)\n    lu.assertEquals(candidate({12, 10, 9, 45, 2, 10, 10, 45, 10}), 78)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = magic_square_test\n    lu.assertEquals(candidate({{7, 12, 1, 14}, {2, 13, 8, 11}, {16, 3, 10, 5}, {9, 6, 15, 4}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 8}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 7}}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "lua",
-    "prompt": "-- Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nlocal function tuple_to_dict(test_tup)\n",
+    "prompt": "-- Write a function to sort a given matrix in ascending order according to the sum of its rows.\nlocal function sort_matrix(M)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_dict\n    lu.assertEquals(candidate({1, 5, 7, 10, 13, 5}), {[1] = 5, [7] = 10, [13] = 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {[1] = 2, [3] = 4, [5] = 6})\n    lu.assertEquals(candidate({7, 8, 9, 10, 11, 12}), {[7] = 8, [9] = 10, [11] = 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_matrix\n    lu.assertEquals(candidate({{1, 2, 3}, {2, 4, 5}, {1, 1, 1}}), {{1, 1, 1}, {1, 2, 3}, {2, 4, 5}})\n    lu.assertEquals(candidate({{1, 2, 3}, {-2, 4, -5}, {1, -1, 1}}), {{-2, 4, -5}, {1, -1, 1}, {1, 2, 3}})\n    lu.assertEquals(candidate({{5, 8, 9}, {6, 4, 3}, {2, 1, 4}}), {{2, 1, 4}, {6, 4, 3}, {5, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "lua",
-    "prompt": "-- Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nlocal function get_coordinates(test_tup)\n",
+    "prompt": "-- Write a function to find the item with maximum frequency in a given list.\nlocal function max_occurrences(nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_coordinates\n    lu.assertEquals(candidate({3, 4}), {{2, 3}, {2, 4}, {2, 5}, {3, 3}, {3, 4}, {3, 5}, {4, 3}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({4, 5}), {{3, 4}, {3, 5}, {3, 6}, {4, 4}, {4, 5}, {4, 6}, {5, 4}, {5, 5}, {5, 6}})\n    lu.assertEquals(candidate({5, 6}), {{4, 5}, {4, 6}, {4, 7}, {5, 5}, {5, 6}, {5, 7}, {6, 5}, {6, 6}, {6, 7}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "lua",
-    "prompt": "-- Write a function to check if all the elements in tuple have same data type or not.\nlocal function check_type(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_type\n    lu.assertEquals(candidate({5, 6, 7, 3, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, '4'}), false)\n    lu.assertEquals(candidate({3, 2, 1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the smallest missing number from a sorted list of natural numbers.\nlocal function find_First_Missing(array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_First_Missing\n    lu.assertEquals(candidate({0, 1, 2, 3}), 4)\n    lu.assertEquals(candidate({0, 1, 2, 6, 9}), 3)\n    lu.assertEquals(candidate({2, 3, 5, 8, 9}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is undulating or not.\nlocal function is_undulating(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_undulating\n    lu.assertEquals(candidate(1212121), true)\n    lu.assertEquals(candidate(1991), false)\n    lu.assertEquals(candidate(121), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "lua",
-    "prompt": "-- Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nlocal function min_k(test_list, K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_k\n    lu.assertEquals(candidate({{'Manjeet', 10}, {'Akshat', 4}, {'Akash', 2}, {'Nikhil', 8}}, 2), {{'Akash', 2}, {'Akshat', 4}})\n    lu.assertEquals(candidate({{'Sanjeev', 11}, {'Angat', 5}, {'Akash', 3}, {'Nepin', 9}}, 3), {{'Akash', 3}, {'Angat', 5}, {'Nepin', 9}})\n    lu.assertEquals(candidate({{'tanmay', 14}, {'Amer', 11}, {'Ayesha', 9}, {'SKD', 16}}, 1), {{'Ayesha', 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "lua",
-    "prompt": "-- Write a python function to count the number of substrings with the sum of digits equal to their length.\nlocal function count_Substrings(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Substrings\n    lu.assertEquals(candidate('112112'), 6)\n    lu.assertEquals(candidate('111'), 6)\n    lu.assertEquals(candidate('1101112'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth decagonal number.\nlocal function is_num_decagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_num_decagonal\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(7), 175)\n    lu.assertEquals(candidate(10), 370)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nlocal function rear_extract(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rear_extract\n    lu.assertEquals(candidate({{1, 'Rash', 21}, {2, 'Varsha', 20}, {3, 'Kil', 19}}), {21, 20, 19})\n    lu.assertEquals(candidate({{1, 'Sai', 36}, {2, 'Ayesha', 25}, {3, 'Salman', 45}}), {36, 25, 45})\n    lu.assertEquals(candidate({{1, 'Sudeep', 14}, {2, 'Vandana', 36}, {3, 'Dawood', 56}}), {14, 36, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the closest smaller number than n.\nlocal function closest_num(N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_num\n    lu.assertEquals(candidate(11), 10)\n    lu.assertEquals(candidate(7), 6)\n    lu.assertEquals(candidate(12), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "lua",
-    "prompt": "-- Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nlocal function find_combinations(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_combinations\n    lu.assertEquals(candidate({{2, 4}, {6, 7}, {5, 1}, {6, 10}}), {{8, 11}, {7, 5}, {8, 14}, {11, 8}, {12, 17}, {11, 11}})\n    lu.assertEquals(candidate({{3, 5}, {7, 8}, {6, 2}, {7, 11}}), {{10, 13}, {9, 7}, {10, 16}, {13, 10}, {14, 19}, {13, 13}})\n    lu.assertEquals(candidate({{4, 6}, {8, 9}, {7, 3}, {8, 12}}), {{12, 15}, {11, 9}, {12, 18}, {15, 12}, {16, 21}, {15, 15}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "lua",
-    "prompt": "-- Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nlocal function maxAverageOfPath(cost)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maxAverageOfPath\n    lu.assertEquals(candidate({{1, 2, 3}, {6, 5, 4}, {7, 3, 9}}), 5.2)\n    lu.assertEquals(candidate({{2, 3, 4}, {7, 6, 5}, {8, 4, 10}}), 6.2)\n    lu.assertEquals(candidate({{3, 4, 5}, {8, 7, 6}, {9, 5, 11}}), 7.2)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}), 5.8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nlocal function sequential_search(dlist, item)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequential_search\n    lu.assertEquals(candidate({11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), {true, 3})\n    lu.assertEquals(candidate({12, 32, 45, 62, 35, 47, 44, 61}, 61), {true, 7})\n    lu.assertEquals(candidate({9, 10, 17, 19, 22, 39, 48, 56}, 48), {true, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "lua",
-    "prompt": "-- Write a python function to remove odd numbers from a given list.\nlocal function remove_odd(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate({1, 2, 3}), {2})\n    lu.assertEquals(candidate({2, 4, 6}), {2, 4, 6})\n    lu.assertEquals(candidate({10, 20, 3}), {10, 20})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the product of numbers in a list is even or not.\nlocal function is_product_even(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_product_even\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 4}), true)\n    lu.assertEquals(candidate({1, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "lua",
-    "prompt": "-- Write a python function to find the maximum of two numbers.\nlocal function maximum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate(5, 10), 10)\n    lu.assertEquals(candidate(-1, -2), -1)\n    lu.assertEquals(candidate(9, 7), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_occurrences\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), 2)\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), 8)\n    lu.assertEquals(candidate({10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5794,9 +364,759 @@
     "language": "lua",
     "prompt": "-- Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nlocal function reverse_vowels(str1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_vowels\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('USA'), 'ASU')\n    lu.assertEquals(candidate('ab'), 'ab')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a list to a string.\nlocal function tup_string(tup1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tup_string\n    lu.assertEquals(candidate({'e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'}), 'exercises')\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}), 'python')\n    lu.assertEquals(candidate({'p', 'r', 'o', 'g', 'r', 'a', 'm'}), 'program')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum of the negative numbers of a given list of numbers.\nlocal function sum_negativenum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_negativenum\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), -32)\n    lu.assertEquals(candidate({10, 15, -14, 13, -18, 12, -20}), -52)\n    lu.assertEquals(candidate({19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), -894)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth hexagonal number.\nlocal function hexagonal_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hexagonal_num\n    lu.assertEquals(candidate(10), 190)\n    lu.assertEquals(candidate(5), 45)\n    lu.assertEquals(candidate(7), 91)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nlocal function is_Sum_Of_Powers_Of_Two(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sum_Of_Powers_Of_Two\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(7), false)\n    lu.assertEquals(candidate(14), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a list of elements.\nlocal function pancake_sort(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pancake_sort\n    lu.assertEquals(candidate({15, 79, 25, 38, 69}), {15, 25, 38, 69, 79})\n    lu.assertEquals(candidate({98, 12, 54, 36, 85}), {12, 36, 54, 85, 98})\n    lu.assertEquals(candidate({41, 42, 32, 12, 23}), {12, 23, 32, 41, 42})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "lua",
+    "prompt": "-- Write a function to count number items that are identical in the same position of three given lists.\nlocal function count_samepair(list1, list2, list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_samepair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}, {2, 1, 3, 1, 2, 6, 7, 9}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 2, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to find number of lists present in the given list.\nlocal function find_lists(Input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lists\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}}), 2)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}}), 3)\n    lu.assertEquals(candidate({9, 8, 7, 6, 5, 4, 3, 2, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the maximum difference between any two elements in a given array.\nlocal function max_Abs_Diff(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Abs_Diff\n    lu.assertEquals(candidate({2, 1, 5, 3}), 4)\n    lu.assertEquals(candidate({9, 3, 2, 5, 1}), 8)\n    lu.assertEquals(candidate({3, 2, 1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the volume of a triangular prism.\nlocal function find_Volume(l, b, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Volume\n    lu.assertEquals(candidate(10, 8, 6), 240)\n    lu.assertEquals(candidate(3, 2, 2), 6)\n    lu.assertEquals(candidate(1, 2, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "lua",
+    "prompt": "-- Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nlocal function find_solution(a, b, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_solution\n    lu.assertEquals(candidate(2, 3, 7), {2, 1})\n    lu.assertEquals(candidate(4, 2, 7), None)\n    lu.assertEquals(candidate(1, 13, 17), {4, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all elements from a given list present in another list.\nlocal function remove_elements(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_elements\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {1, 3, 5, 7}), {2, 4, 6, 8, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 7}), {1, 2, 3, 4, 6, 8, 9, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlocal function sum_series(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_series\n    lu.assertEquals(candidate(6), 12)\n    lu.assertEquals(candidate(10), 30)\n    lu.assertEquals(candidate(9), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "lua",
+    "prompt": "-- Write a function to determine if the sum of the divisors of two integers are the same.\nlocal function are_equivalent(num1, num2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = are_equivalent\n    lu.assertEquals(candidate(36, 57), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(23, 47), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlocal function count_char_position(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_char_position\n    lu.assertEquals(candidate('xbcefg'), 2)\n    lu.assertEquals(candidate('ABcED'), 3)\n    lu.assertEquals(candidate('AbgdeF'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "lua",
+    "prompt": "-- Write a function that counts the number of pairs of integers in a list that xor to an even number.\nlocal function find_even_pair(A)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_even_pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}), 4)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}), 9)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the smallest power of 2 greater than or equal to n.\nlocal function next_power_of_2(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_power_of_2\n    lu.assertEquals(candidate(0), 1)\n    lu.assertEquals(candidate(5), 8)\n    lu.assertEquals(candidate(17), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of occurrences of a number in a given list.\nlocal function frequency(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency\n    lu.assertEquals(candidate({1, 2, 3}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 3, 4}, 3), 3)\n    lu.assertEquals(candidate({0, 1, 2, 3, 1, 2}, 1), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "lua",
+    "prompt": "-- Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nlocal function text_lowercase_underscore(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_lowercase_underscore\n    lu.assertEquals(candidate('aab_cbbbc'), true)\n    lu.assertEquals(candidate('aab_Abbbc'), false)\n    lu.assertEquals(candidate('Aaab_abbbc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find the sum of numbers in a list within a range specified by two indices.\nlocal function sum_range_list(list1, m, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_range_list\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), 29)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), 16)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), 38)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "lua",
+    "prompt": "-- Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlocal function perimeter_pentagon(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perimeter_pentagon\n    lu.assertEquals(candidate(5), 25)\n    lu.assertEquals(candidate(10), 50)\n    lu.assertEquals(candidate(15), 75)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of occurence of the string 'std' in a given string.\nlocal function count_occurance(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_occurance\n    lu.assertEquals(candidate('letstdlenstdporstd'), 3)\n    lu.assertEquals(candidate('truststdsolensporsd'), 1)\n    lu.assertEquals(candidate('makestdsostdworthit'), 2)\n    lu.assertEquals(candidate('stds'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "lua",
+    "prompt": "-- Write a function that returns the perimeter of a square given its side length as input.\nlocal function square_perimeter(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_perimeter\n    lu.assertEquals(candidate(10), 40)\n    lu.assertEquals(candidate(5), 20)\n    lu.assertEquals(candidate(4), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "lua",
+    "prompt": "-- Write a function to remove characters from the first string which are present in the second string.\nlocal function remove_dirty_chars(string, second_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_dirty_chars\n    lu.assertEquals(candidate('probasscurve', 'pros'), 'bacuve')\n    lu.assertEquals(candidate('digitalindia', 'talent'), 'digiidi')\n    lu.assertEquals(candidate('exoticmiles', 'toxic'), 'emles')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "lua",
+    "prompt": "-- Write a function to find whether a given array of integers contains any duplicate element.\nlocal function test_duplicate(arraynums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_duplicate\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), true)\n    lu.assertEquals(candidate({1, 1, 2, 2, 3, 3, 4, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given number is woodball or not.\nlocal function is_woodall(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_woodall\n    lu.assertEquals(candidate(383), true)\n    lu.assertEquals(candidate(254), false)\n    lu.assertEquals(candidate(200), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "lua",
+    "prompt": "-- Write a function to check if all the elements in tuple have same data type or not.\nlocal function check_type(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_type\n    lu.assertEquals(candidate({5, 6, 7, 3, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, '4'}), false)\n    lu.assertEquals(candidate({3, 2, 1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nlocal function is_majority(arr, n, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_majority\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 3, 10}, 7, 3), true)\n    lu.assertEquals(candidate({1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), false)\n    lu.assertEquals(candidate({1, 1, 1, 2, 2}, 5, 1), true)\n    lu.assertEquals(candidate({1, 1, 2, 2}, 5, 1), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nlocal function count_Set_Bits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Set_Bits\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 1)\n    lu.assertEquals(candidate(6), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "lua",
+    "prompt": "-- Write a python function to remove the characters which have odd index values of a given string.\nlocal function odd_values_string(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_values_string\n    lu.assertEquals(candidate('abcdef'), 'ace')\n    lu.assertEquals(candidate('python'), 'pto')\n    lu.assertEquals(candidate('data'), 'dt')\n    lu.assertEquals(candidate('lambs'), 'lms')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "lua",
+    "prompt": "-- Write a function to find minimum of three numbers.\nlocal function min_of_three(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_of_three\n    lu.assertEquals(candidate(10, 20, 0), 0)\n    lu.assertEquals(candidate(19, 15, 18), 15)\n    lu.assertEquals(candidate(-10, -20, -30), -30)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether all the bits are unset in the given range or not.\nlocal function all_Bits_Set_In_The_Given_Range(n, l, r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Bits_Set_In_The_Given_Range\n    lu.assertEquals(candidate(4, 1, 2), true)\n    lu.assertEquals(candidate(17, 2, 4), true)\n    lu.assertEquals(candidate(39, 4, 6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nlocal function re_arrange_array(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = re_arrange_array\n    lu.assertEquals(candidate({-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), {-1, -3, -7, 4, 5, 6, 2, 8, 9})\n    lu.assertEquals(candidate({12, -14, -26, 13, 15}, 5), {-14, -26, 12, 13, 15})\n    lu.assertEquals(candidate({10, 24, 36, -42, -39, -78, 85}, 7), {-42, -39, -78, 10, 24, 36, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nlocal function replace_blank(str1, char)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_blank\n    lu.assertEquals(candidate('hello people', '@'), 'hello@people')\n    lu.assertEquals(candidate('python program language', '$'), 'python$program$language')\n    lu.assertEquals(candidate('blank space', '-'), 'blank-space')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "lua",
+    "prompt": "-- Write a function to find the volume of a cube given its side length.\nlocal function volume_cube(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = volume_cube\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(2), 8)\n    lu.assertEquals(candidate(5), 125)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nlocal function check_occurences(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_occurences\n    lu.assertEquals(candidate({{3, 1}, {1, 3}, {2, 5}, {5, 2}, {6, 3}}), {[{1, 3}] = 2, [{2, 5}] = 2, [{3, 6}] = 1})\n    lu.assertEquals(candidate({{4, 2}, {2, 4}, {3, 6}, {6, 3}, {7, 4}}), {[{2, 4}] = 2, [{3, 6}] = 2, [{4, 7}] = 1})\n    lu.assertEquals(candidate({{13, 2}, {11, 23}, {12, 25}, {25, 12}, {16, 23}}), {[{2, 13}] = 1, [{11, 23}] = 1, [{12, 25}] = 2, [{16, 23}] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of non-empty substrings of a given string.\nlocal function number_of_substrings(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_of_substrings\n    lu.assertEquals(candidate('abc'), 6)\n    lu.assertEquals(candidate('abcd'), 10)\n    lu.assertEquals(candidate('abcde'), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlocal function get_total_number_of_sequences(m, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_total_number_of_sequences\n    lu.assertEquals(candidate(10, 4), 4)\n    lu.assertEquals(candidate(5, 2), 6)\n    lu.assertEquals(candidate(16, 3), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nlocal function replace_list(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_list\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 2, 4, 6, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8}), {1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({'red', 'blue', 'green'}, {'yellow'}), {'red', 'blue', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "lua",
+    "prompt": "-- Write a function to count the total number of characters in a string.\nlocal function count_charac(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_charac\n    lu.assertEquals(candidate('python programming'), 18)\n    lu.assertEquals(candidate('language'), 8)\n    lu.assertEquals(candidate('words'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the next perfect square greater than a given number.\nlocal function next_Perfect_Square(N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_Perfect_Square\n    lu.assertEquals(candidate(35), 36)\n    lu.assertEquals(candidate(6), 9)\n    lu.assertEquals(candidate(9), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nlocal function max_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum\n    lu.assertEquals(candidate({1, 15, 51, 45, 33, 100, 12, 18, 9}), 194)\n    lu.assertEquals(candidate({80, 60, 30, 40, 20, 10}), 210)\n    lu.assertEquals(candidate({2, 3, 14, 16, 21, 23, 29, 30}), 138)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "lua",
+    "prompt": "-- Write a function to find the length of the longest palindromic subsequence in the given string.\nlocal function lps(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lps\n    lu.assertEquals(candidate('TENS FOR TENS'), 5)\n    lu.assertEquals(candidate('CARDIO FOR CARDS'), 7)\n    lu.assertEquals(candidate('PART OF THE JOURNEY IS PART'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "lua",
+    "prompt": "-- Write a function to find the intersection of two arrays.\nlocal function intersection_array(array_nums1, array_nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection_array\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {1, 2, 4, 8, 9}), {1, 2, 8, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {3, 5, 7, 9}), {3, 5, 7, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {10, 20, 30, 40}), {10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "lua",
+    "prompt": "-- Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nlocal function count_X(tup, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_X\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), 0)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), 3)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nlocal function insert_element(list, element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = insert_element\n    lu.assertEquals(candidate({'Red', 'Green', 'Black'}, 'c'), {'c', 'Red', 'c', 'Green', 'c', 'Black'})\n    lu.assertEquals(candidate({'python', 'java'}, 'program'), {'program', 'python', 'program', 'java'})\n    lu.assertEquals(candidate({'happy', 'sad'}, 'laugh'), {'laugh', 'happy', 'laugh', 'sad'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "lua",
+    "prompt": "-- Write a python function to convert complex numbers to polar coordinates.\nlocal function convert(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert\n    lu.assertEquals(candidate(1), {1.0, 0.0})\n    lu.assertEquals(candidate(4), {4.0, 0.0})\n    lu.assertEquals(candidate(5), {5.0, 0.0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "lua",
+    "prompt": "-- Write a python function that returns the number of integer elements in a given list.\nlocal function count_integer(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_integer\n    lu.assertEquals(candidate({1, 2, 'abc', 1.2}), 2)\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1.2, 4, 5.1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nlocal function combinations_colors(l, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_colors\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 1), {{'Red'}, {'Green'}, {'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 2), {{'Red', 'Red'}, {'Red', 'Green'}, {'Red', 'Blue'}, {'Green', 'Green'}, {'Green', 'Blue'}, {'Blue', 'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 3), {{'Red', 'Red', 'Red'}, {'Red', 'Red', 'Green'}, {'Red', 'Red', 'Blue'}, {'Red', 'Green', 'Green'}, {'Red', 'Green', 'Blue'}, {'Red', 'Blue', 'Blue'}, {'Green', 'Green', 'Green'}, {'Green', 'Green', 'Blue'}, {'Green', 'Blue', 'Blue'}, {'Blue', 'Blue', 'Blue'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "lua",
+    "prompt": "-- Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlocal function count_Primes_nums(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Primes_nums\n    lu.assertEquals(candidate(5), 2)\n    lu.assertEquals(candidate(10), 4)\n    lu.assertEquals(candidate(100), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two numbers and returns a list with the second number and then the first number.\nlocal function swap_numbers(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_numbers\n    lu.assertEquals(candidate(10, 20), {20, 10})\n    lu.assertEquals(candidate(15, 17), {17, 15})\n    lu.assertEquals(candidate(100, 200), {200, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5809,7 +1129,7 @@
     "language": "lua",
     "prompt": "-- Write a function to maximize the given two lists.\nlocal function maximize_elements(test_tup1, test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximize_elements\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 7}, {4, 9}, {2, 9}, {7, 10}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{7, 8}, {5, 10}, {3, 10}, {8, 11}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{8, 9}, {6, 11}, {4, 11}, {9, 12}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "lua",
-    "prompt": "-- Write a python function to check whether every even index contains even numbers of a given list.\nlocal function even_position(nums)\n",
+    "prompt": "-- Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlocal function newman_prime(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_position\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3}), false)\n    lu.assertEquals(candidate({2, 1, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = newman_prime\n    lu.assertEquals(candidate(3), 7)\n    lu.assertEquals(candidate(4), 17)\n    lu.assertEquals(candidate(5), 41)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "lua",
-    "prompt": "-- Write a function to check whether the given string starts and ends with the same character or not.\nlocal function check_char(string)\n",
+    "prompt": "-- Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nlocal function division_elements(test_tup1, test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_char\n    lu.assertEquals(candidate('abba'), 'Valid')\n    lu.assertEquals(candidate('a'), 'Valid')\n    lu.assertEquals(candidate('abcd'), 'Invalid')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = division_elements\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {2, 2, 2, 3})\n    lu.assertEquals(candidate({12, 6, 8, 16}, {6, 3, 4, 4}), {2, 2, 2, 4})\n    lu.assertEquals(candidate({20, 14, 36, 18}, {5, 7, 6, 9}), {4, 2, 6, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "lua",
-    "prompt": "-- Write a python function to find the sum of even factors of a number.\nlocal function sumofFactors(n)\n",
+    "prompt": "-- Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nlocal function split_two_parts(list1, L)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sumofFactors\n    lu.assertEquals(candidate(18), 26)\n    lu.assertEquals(candidate(30), 48)\n    lu.assertEquals(candidate(6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_two_parts\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {{1, 1, 2}, {3, 4, 4, 5, 1}})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 2), {{'a', 'b'}, {'c', 'd'}})\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}, 4), {{'p', 'y', 't', 'h'}, {'o', 'n'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "lua",
-    "prompt": "-- Write a function to find the lateral surface area of a cone given radius r and the height h.\nlocal function lateralsurface_cone(r, h)\n",
+    "prompt": "-- Write a function to calculate a dog's age in dog's years.\nlocal function dog_age(h_age)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cone\n    lu.assertEquals(candidate(5, 12), 204.20352248333654)\n    lu.assertEquals(candidate(10, 15), 566.3586699569488)\n    lu.assertEquals(candidate(19, 17), 1521.8090132193388)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dog_age\n    lu.assertEquals(candidate(12), 61)\n    lu.assertEquals(candidate(15), 73)\n    lu.assertEquals(candidate(24), 109)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "lua",
-    "prompt": "-- Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nlocal function count_Pairs(arr, n)\n",
+    "prompt": "-- Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlocal function list_split(S, step)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Pairs\n    lu.assertEquals(candidate({1, 2, 1}, 3), 2)\n    lu.assertEquals(candidate({1, 1, 1, 1}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 5), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_split\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'}, 3), {{'a', 'd', 'g', 'j', 'm'}, {'b', 'e', 'h', 'k', 'n'}, {'c', 'f', 'i', 'l'}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), {{1, 4, 7, 10, 13}, {2, 5, 8, 11, 14}, {3, 6, 9, 12}})\n    lu.assertEquals(candidate({'python', 'java', 'C', 'C++', 'DBMS', 'SQL'}, 2), {{'python', 'C', 'DBMS'}, {'java', 'C++', 'SQL'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "lua",
-    "prompt": "-- Write a function to find the index of the first occurrence of a given number in a sorted array.\nlocal function find_first_occurrence(A, x)\n",
+    "prompt": "-- Write a function to find the lateral surface area of a cube given its side length.\nlocal function lateralsurface_cube(l)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_first_occurrence\n    lu.assertEquals(candidate({2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 1)\n    lu.assertEquals(candidate({2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 2)\n    lu.assertEquals(candidate({2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cube\n    lu.assertEquals(candidate(5), 100)\n    lu.assertEquals(candidate(9), 324)\n    lu.assertEquals(candidate(10), 400)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5914,9 +1234,909 @@
     "language": "lua",
     "prompt": "-- Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nlocal function square_Sum(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 10)\n    lu.assertEquals(candidate(3), 35)\n    lu.assertEquals(candidate(4), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n'th star number.\nlocal function find_star_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_star_num\n    lu.assertEquals(candidate(3), 37)\n    lu.assertEquals(candidate(4), 73)\n    lu.assertEquals(candidate(5), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "lua",
+    "prompt": "-- Write a function to find the ascii value of a character.\nlocal function ascii_value(k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = ascii_value\n    lu.assertEquals(candidate('A'), 65)\n    lu.assertEquals(candidate('R'), 82)\n    lu.assertEquals(candidate('S'), 83)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of even numbers at even positions of a list.\nlocal function sum_even_and_even_index(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_even_and_even_index\n    lu.assertEquals(candidate({5, 6, 12, 1, 18, 8}), 30)\n    lu.assertEquals(candidate({3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), 26)\n    lu.assertEquals(candidate({5, 6, 12, 1}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "lua",
+    "prompt": "-- Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlocal function even_Power_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_Power_Sum\n    lu.assertEquals(candidate(2), 1056)\n    lu.assertEquals(candidate(3), 8832)\n    lu.assertEquals(candidate(1), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nlocal function rear_extract(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rear_extract\n    lu.assertEquals(candidate({{1, 'Rash', 21}, {2, 'Varsha', 20}, {3, 'Kil', 19}}), {21, 20, 19})\n    lu.assertEquals(candidate({{1, 'Sai', 36}, {2, 'Ayesha', 25}, {3, 'Salman', 45}}), {36, 25, 45})\n    lu.assertEquals(candidate({{1, 'Sudeep', 14}, {2, 'Vandana', 36}, {3, 'Dawood', 56}}), {14, 36, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nlocal function substract_elements(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = substract_elements\n    lu.assertEquals(candidate({10, 4, 5}, {2, 5, 18}), {8, -1, -13})\n    lu.assertEquals(candidate({11, 2, 3}, {24, 45, 16}), {-13, -43, -13})\n    lu.assertEquals(candidate({7, 18, 9}, {10, 11, 12}), {-3, 7, -3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "lua",
+    "prompt": "-- Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlocal function even_binomial_Coeff_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_binomial_Coeff_Sum\n    lu.assertEquals(candidate(4), 8)\n    lu.assertEquals(candidate(6), 32)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nlocal function dict_filter(dict, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dict_filter\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 170), {['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 180), {['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 190), {['Pierre Cox'] = 190})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to find the number of elements that occurs before the list element in the given tuple.\nlocal function count_first_elements(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_first_elements\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), 3)\n    lu.assertEquals(candidate({2, 9, {5, 7}, 11}), 2)\n    lu.assertEquals(candidate({11, 15, 5, 8, {2, 3}, 8}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth decagonal number.\nlocal function is_num_decagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_num_decagonal\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(7), 175)\n    lu.assertEquals(candidate(10), 370)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nlocal function sequential_search(dlist, item)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequential_search\n    lu.assertEquals(candidate({11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), {true, 3})\n    lu.assertEquals(candidate({12, 32, 45, 62, 35, 47, 44, 61}, 61), {true, 7})\n    lu.assertEquals(candidate({9, 10, 17, 19, 22, 39, 48, 56}, 48), {true, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "lua",
+    "prompt": "-- Write a python function to check if the elements of a given list are unique or not.\nlocal function all_unique(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_unique\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "lua",
+    "prompt": "-- Write a function to subtract two lists element-wise.\nlocal function sub_list(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sub_list\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), {-3, -3, -3})\n    lu.assertEquals(candidate({1, 2}, {3, 4}), {-2, -2})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {40, 50})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "lua",
+    "prompt": "-- Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nlocal function validate(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = validate\n    lu.assertEquals(candidate(1234), true)\n    lu.assertEquals(candidate(51241), false)\n    lu.assertEquals(candidate(321), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nlocal function check_element(list, element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_element\n    lu.assertEquals(candidate({'green', 'orange', 'black', 'white'}, 'blue'), false)\n    lu.assertEquals(candidate({1, 2, 3, 4}, 7), false)\n    lu.assertEquals(candidate({'green', 'green', 'green', 'green'}, 'green'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "lua",
+    "prompt": "-- Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nlocal function text_match_two_three(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_two_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "lua",
+    "prompt": "-- Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nlocal function max_sub_array_sum_repeated(a, n, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum_repeated\n    lu.assertEquals(candidate({10, 20, -30, -1}, 4, 3), 30)\n    lu.assertEquals(candidate({-1, 10, 20}, 3, 2), 59)\n    lu.assertEquals(candidate({-1, -2, -3}, 3, 3), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "lua",
+    "prompt": "-- Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlocal function square_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 20)\n    lu.assertEquals(candidate(3), 56)\n    lu.assertEquals(candidate(4), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "lua",
+    "prompt": "-- Write a function to find the list of maximum length in a list of lists.\nlocal function max_length(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1}, {5, 7}, {10, 12, 14, 15}}), {4, {10, 12, 14, 15}})\n    lu.assertEquals(candidate({{5}, {15, 20, 25}}), {3, {15, 20, 25}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "lua",
+    "prompt": "-- Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlocal function count_no_of_ways(n, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_no_of_ways\n    lu.assertEquals(candidate(2, 4), 16)\n    lu.assertEquals(candidate(3, 2), 6)\n    lu.assertEquals(candidate(4, 4), 228)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "lua",
+    "prompt": "-- Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nlocal function find(n, m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find\n    lu.assertEquals(candidate(10, 3), 3)\n    lu.assertEquals(candidate(4, 2), 2)\n    lu.assertEquals(candidate(20, 5), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "lua",
+    "prompt": "-- Write a function to find the third side of a right angled triangle.\nlocal function otherside_rightangle(w, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = otherside_rightangle\n    lu.assertEquals(candidate(7, 8), 10.63014581273465)\n    lu.assertEquals(candidate(3, 4), 5)\n    lu.assertEquals(candidate(7, 15), 16.55294535724685)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum value in a given heterogeneous list.\nlocal function max_val(listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 5)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 25)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 50)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "lua",
+    "prompt": "-- Write a function to return the sum of all divisors of a number.\nlocal function sum_div(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_div\n    lu.assertEquals(candidate(8), 7)\n    lu.assertEquals(candidate(12), 16)\n    lu.assertEquals(candidate(7), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "lua",
+    "prompt": "-- Write a python function to count inversions in an array.\nlocal function get_Inv_Count(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Inv_Count\n    lu.assertEquals(candidate({1, 20, 6, 4, 5}), 5)\n    lu.assertEquals(candidate({1, 2, 1}), 1)\n    lu.assertEquals(candidate({1, 2, 5, 6, 1}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "lua",
+    "prompt": "-- Write a function to flatten a given nested list structure.\nlocal function flatten_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flatten_list\n    lu.assertEquals(candidate({0, 10, {20, 30}, 40, 50, {60, 70, 80}, {90, 100, 110, 120}}), {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120})\n    lu.assertEquals(candidate({{10, 20}, {40}, {30, 56, 25}, {10, 20}, {33}, {40}}), {10, 20, 40, 30, 56, 25, 10, 20, 33, 40})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the maximum aggregate from the list of tuples.\nlocal function max_aggregate(stdata)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_aggregate\n    lu.assertEquals(candidate({{'Juan Whelan', 90}, {'Sabah Colley', 88}, {'Peter Nichols', 7}, {'Juan Whelan', 122}, {'Sabah Colley', 84}}), {'Juan Whelan', 212})\n    lu.assertEquals(candidate({{'Juan Whelan', 50}, {'Sabah Colley', 48}, {'Peter Nichols', 37}, {'Juan Whelan', 22}, {'Sabah Colley', 14}}), {'Juan Whelan', 72})\n    lu.assertEquals(candidate({{'Juan Whelan', 10}, {'Sabah Colley', 20}, {'Peter Nichols', 30}, {'Juan Whelan', 40}, {'Sabah Colley', 50}}), {'Sabah Colley', 70})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "lua",
+    "prompt": "-- Write a python function to find element at a given index after number of rotations.\nlocal function find_Element(arr, ranges, rotations, index)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {{0, 2}, {0, 3}}, 2, 1), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}, {{0, 1}, {0, 2}}, 1, 2), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {{0, 1}, {0, 2}}, 1, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "lua",
+    "prompt": "-- Write a function to return two words from a list of words starting with letter 'p'.\nlocal function start_withp(words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = start_withp\n    lu.assertEquals(candidate({'Python PHP', 'Java JavaScript', 'c c++'}), {'Python', 'PHP'})\n    lu.assertEquals(candidate({'Python Programming', 'Java Programming'}), {'Python', 'Programming'})\n    lu.assertEquals(candidate({'Pqrst Pqr', 'qrstuv'}), {'Pqrst', 'Pqr'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlocal function max_sum_increasing_subseq(a, n, index, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_increasing_subseq\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), 11)\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), 7)\n    lu.assertEquals(candidate({11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), 71)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlocal function large_product(nums1, nums2, N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = large_product\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 3), {60, 54, 50})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 4), {60, 54, 50, 48})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 5), {60, 54, 50, 48, 45})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the maximum of two numbers.\nlocal function maximum(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate(5, 10), 10)\n    lu.assertEquals(candidate(-1, -2), -1)\n    lu.assertEquals(candidate(9, 7), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a given string to a list of characters.\nlocal function string_to_tuple(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_tuple\n    lu.assertEquals(candidate('python 3.0'), {'p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'})\n    lu.assertEquals(candidate('item1'), {'i', 't', 'e', 'm', '1'})\n    lu.assertEquals(candidate('15.10'), {'1', '5', '.', '1', '0'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the highest power of 2 that is less than or equal to n.\nlocal function highest_Power_of_2(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = highest_Power_of_2\n    lu.assertEquals(candidate(10), 8)\n    lu.assertEquals(candidate(19), 16)\n    lu.assertEquals(candidate(32), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n'th lucas number.\nlocal function find_lucas(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lucas\n    lu.assertEquals(candidate(9), 76)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(3), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "lua",
+    "prompt": "-- Write a function to apply a given format string to all of the elements in a list.\nlocal function add_string(list_, string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_string\n    lu.assertEquals(candidate({1, 2, 3, 4}, 'temp{0}'), {'temp1', 'temp2', 'temp3', 'temp4'})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 'python{0}'), {'pythona', 'pythonb', 'pythonc', 'pythond'})\n    lu.assertEquals(candidate({5, 6, 7, 8}, 'string{0}'), {'string5', 'string6', 'string7', 'string8'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "lua",
+    "prompt": "-- Write a function to convert more than one list to nested dictionary.\nlocal function convert_list_dictionary(l1, l2, l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert_list_dictionary\n    lu.assertEquals(candidate({'S001', 'S002', 'S003', 'S004'}, {'Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'}, {85, 98, 89, 92}), {{['S001'] = {['Adina Park'] = 85}}, {['S002'] = {['Leyton Marsh'] = 98}}, {['S003'] = {['Duncan Boyle'] = 89}}, {['S004'] = {['Saim Richards'] = 92}}})\n    lu.assertEquals(candidate({'abc', 'def', 'ghi', 'jkl'}, {'python', 'program', 'language', 'programs'}, {100, 200, 300, 400}), {{['abc'] = {['python'] = 100}}, {['def'] = {['program'] = 200}}, {['ghi'] = {['language'] = 300}}, {['jkl'] = {['programs'] = 400}}})\n    lu.assertEquals(candidate({'A1', 'A2', 'A3', 'A4'}, {'java', 'C', 'C++', 'DBMS'}, {10, 20, 30, 40}), {{['A1'] = {['java'] = 10}}, {['A2'] = {['C'] = 20}}, {['A3'] = {['C++'] = 30}}, {['A4'] = {['DBMS'] = 40}}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlocal function get_max_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_sum\n    lu.assertEquals(candidate(60), 106)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find the list with maximum length.\nlocal function max_length_list(input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length_list\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5}, {1, 2, 3, 4}, {1, 2, 3}, {1, 2}, {1}}), {5, {1, 2, 3, 4, 5}})\n    lu.assertEquals(candidate({{3, 4, 5}, {6, 7, 8, 9}, {10, 11, 12}}), {4, {6, 7, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "lua",
+    "prompt": "-- Write a function to check if given list contains no duplicates.\nlocal function check_distinct(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_distinct\n    lu.assertEquals(candidate({1, 4, 5, 6, 1, 4}), false)\n    lu.assertEquals(candidate({1, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the first non-repeated character in a given string.\nlocal function first_non_repeating_character(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_non_repeating_character\n    lu.assertEquals(candidate('abcabc'), None)\n    lu.assertEquals(candidate('abc'), 'a')\n    lu.assertEquals(candidate('ababc'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given string starts and ends with the same character or not.\nlocal function check_char(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_char\n    lu.assertEquals(candidate('abba'), 'Valid')\n    lu.assertEquals(candidate('a'), 'Valid')\n    lu.assertEquals(candidate('abcd'), 'Invalid')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median of three numbers.\nlocal function median_numbers(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_numbers\n    lu.assertEquals(candidate(25, 55, 65), 55.0)\n    lu.assertEquals(candidate(20, 10, 30), 20.0)\n    lu.assertEquals(candidate(15, 45, 75), 45.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to compute the sum of digits of each number of a given list.\nlocal function sum_of_digits(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_of_digits\n    lu.assertEquals(candidate({10, 2, 56}), 14)\n    lu.assertEquals(candidate({{10, 20, 4, 5, 'b', 70, 'a'}}), 19)\n    lu.assertEquals(candidate({10, 20, -4, 5, -70}), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "lua",
+    "prompt": "-- Write a function to perform the mathematical bitwise xor operation across the given tuples.\nlocal function bitwise_xor(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bitwise_xor\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {15, 6, 5, 10})\n    lu.assertEquals(candidate({11, 5, 7, 10}, {6, 3, 4, 4}), {13, 6, 3, 14})\n    lu.assertEquals(candidate({12, 6, 8, 11}, {7, 4, 5, 6}), {11, 2, 13, 13})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "lua",
+    "prompt": "-- Write a python function to identify non-prime numbers.\nlocal function is_not_prime(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_not_prime\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(35), true)\n    lu.assertEquals(candidate(37), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the number of unique tuples in the given list.\nlocal function extract_freq(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_freq\n    lu.assertEquals(candidate({{3, 4}, {1, 2}, {4, 3}, {5, 6}}), 3)\n    lu.assertEquals(candidate({{4, 15}, {2, 3}, {5, 4}, {6, 7}}), 4)\n    lu.assertEquals(candidate({{5, 16}, {2, 3}, {6, 5}, {6, 9}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to perform index wise addition of list elements in the given two nested lists.\nlocal function add_nested_tuples(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_nested_tuples\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{7, 10}, {7, 14}, {3, 10}, {8, 13}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{9, 12}, {9, 16}, {5, 12}, {10, 15}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{11, 14}, {11, 18}, {7, 14}, {12, 17}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the minimum of two numbers.\nlocal function minimum(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minimum\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(-5, -4), -5)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether an element exists within a tuple.\nlocal function check_tuplex(tuplex, tuple1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_tuplex\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 'r'), true)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, '5'), false)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 3), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "lua",
+    "prompt": "-- Write a python function to find whether the parity of a given number is odd.\nlocal function find_Parity(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Parity\n    lu.assertEquals(candidate(12), false)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "lua",
+    "prompt": "-- Write a function to create the next bigger number by rearranging the digits of a given number.\nlocal function rearrange_bigger(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rearrange_bigger\n    lu.assertEquals(candidate(12), 21)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(102), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "lua",
+    "prompt": "-- Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nlocal function k_smallest_pairs(nums1, nums2, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = k_smallest_pairs\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 2), {{1, 2}, {1, 4}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 1), {{1, 2}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 7), {{1, 2}, {1, 4}, {3, 2}, {1, 6}, {3, 4}, {3, 6}, {7, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to find the minimum product from the pairs of tuples within a given list.\nlocal function min_product_tuple(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 8)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 30)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "lua",
+    "prompt": "-- Write a function to find the minimum value in a given heterogeneous list.\nlocal function min_val(listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 2)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 15)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('android_tv'), 'AndroidTv')\n    lu.assertEquals(candidate('google_pixel'), 'GooglePixel')\n    lu.assertEquals(candidate('apple_watch'), 'AppleWatch')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "lua",
+    "prompt": "-- Write a python function to remove odd numbers from a given list.\nlocal function remove_odd(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate({1, 2, 3}), {2})\n    lu.assertEquals(candidate({2, 4, 6}), {2, 4, 6})\n    lu.assertEquals(candidate({10, 20, 3}), {10, 20})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the nth element from a given list of tuples.\nlocal function extract_nth_element(list1, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_nth_element\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 0), {'Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 2), {99, 96, 94, 98})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 1), {98, 97, 91, 94})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether any value in a sequence exists in a sequence or not.\nlocal function overlapping(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = overlapping\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), false)\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), false)\n    lu.assertEquals(candidate({1, 4, 5}, {1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "lua",
+    "prompt": "-- Write a python function to find a pair with highest product from a given array of integers.\nlocal function max_Product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Product\n    lu.assertEquals(candidate({1, 2, 3, 4, 7, 0, 8, 4}), {7, 8})\n    lu.assertEquals(candidate({0, -1, -2, -4, 5, 0, -6}), {-4, -6})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5929,7 +2149,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find common first element in given list of lists.\nlocal function group_tuples(Input)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = group_tuples\n    lu.assertEquals(candidate({{'x', 'y'}, {'x', 'z'}, {'w', 't'}}), {{'x', 'y', 'z'}, {'w', 't'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'a', 'c'}, {'d', 'e'}}), {{'a', 'b', 'c'}, {'d', 'e'}})\n    lu.assertEquals(candidate({{'f', 'g'}, {'f', 'g'}, {'h', 'i'}}), {{'f', 'g', 'g'}, {'h', 'i'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "lua",
-    "prompt": "-- Write a function to merge three lists into a single sorted list.\nlocal function merge_sorted_list(num1, num2, num3)\n",
+    "prompt": "-- Write a python function to find the element of a list having maximum length.\nlocal function Find_Max(lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_sorted_list\n    lu.assertEquals(candidate({25, 24, 15, 4, 5, 29, 110}, {19, 20, 11, 56, 25, 233, 154}, {24, 26, 54, 48}), {4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233})\n    lu.assertEquals(candidate({1, 3, 5, 6, 8, 9}, {2, 5, 7, 11}, {1, 4, 7, 8, 12}), {1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12})\n    lu.assertEquals(candidate({18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, {25, 35, 22, 85, 14, 65, 75, 25, 58}, {12, 74, 9, 50, 61, 41}), {1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max\n    lu.assertEquals(candidate({{'A'}, {'A', 'B'}, {'A', 'B', 'C'}}), {'A', 'B', 'C'})\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1, 2, 3})\n    lu.assertEquals(candidate({{1, 1}, {1, 2, 3}, {1, 5, 6, 1}}), {1, 5, 6, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nlocal function round_and_sum(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = round_and_sum\n    lu.assertEquals(candidate({22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5}), 243)\n    lu.assertEquals(candidate({5, 2, 9, 24.3, 29}), 345)\n    lu.assertEquals(candidate({25.0, 56.7, 89.2}), 513)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the cube sum of first n even natural numbers.\nlocal function cube_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_Sum\n    lu.assertEquals(candidate(2), 72)\n    lu.assertEquals(candidate(3), 288)\n    lu.assertEquals(candidate(4), 800)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to concatenate each element of tuple by the delimiter.\nlocal function concatenate_tuple(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate_tuple\n    lu.assertEquals(candidate({'ID', 'is', 4, 'UTS'}), 'ID-is-4-UTS')\n    lu.assertEquals(candidate({'QWE', 'is', 4, 'RTY'}), 'QWE-is-4-RTY')\n    lu.assertEquals(candidate({'ZEN', 'is', 4, 'OP'}), 'ZEN-is-4-OP')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the average of cubes of first n natural numbers.\nlocal function find_Average_Of_Cube(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Average_Of_Cube\n    lu.assertEquals(candidate(2), 4.5)\n    lu.assertEquals(candidate(3), 12)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "lua",
+    "prompt": "-- Write a function to extract only the rear index element of each string in the given tuple.\nlocal function extract_rear(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_rear\n    lu.assertEquals(candidate({'Mers', 'for', 'Vers'}), {'s', 'r', 's'})\n    lu.assertEquals(candidate({'Avenge', 'for', 'People'}), {'e', 'r', 'e'})\n    lu.assertEquals(candidate({'Gotta', 'get', 'go'}), {'a', 't', 'o'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of sublists containing a particular element.\nlocal function count_element_in_list(list1, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_element_in_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {1, 11}, {1, 15, 7}}, 1), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'A'), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'E'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "lua",
+    "prompt": "-- Write a function to filter odd numbers.\nlocal function filter_oddnumbers(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_oddnumbers\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 3, 5, 7, 9})\n    lu.assertEquals(candidate({10, 20, 45, 67, 84, 93}), {45, 67, 93})\n    lu.assertEquals(candidate({5, 7, 9, 8, 6, 4, 3}), {5, 7, 9, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nlocal function change_date_format(dt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_date_format\n    lu.assertEquals(candidate('2026-01-02'), '02-01-2026')\n    lu.assertEquals(candidate('2020-11-13'), '13-11-2020')\n    lu.assertEquals(candidate('2021-04-26'), '26-04-2021')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort the given array by using shell sort.\nlocal function shell_sort(my_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = shell_sort\n    lu.assertEquals(candidate({12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), {2, 3, 4, 5, 12, 12, 23, 56, 81, 95})\n    lu.assertEquals(candidate({24, 22, 39, 34, 87, 73, 68}), {22, 24, 34, 39, 68, 73, 87})\n    lu.assertEquals(candidate({32, 30, 16, 96, 82, 83, 74}), {16, 30, 32, 74, 82, 83, 96})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the elementwise and tuples from the given two tuples.\nlocal function and_tuples(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = and_tuples\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {0, 0, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {5, 6, 7, 8}), {1, 2, 3, 0})\n    lu.assertEquals(candidate({8, 9, 11, 12}, {7, 13, 14, 17}), {0, 9, 10, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "lua",
+    "prompt": "-- Write a function to find the directrix of a parabola.\nlocal function parabola_directrix(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parabola_directrix\n    lu.assertEquals(candidate(5, 3, 2), -198)\n    lu.assertEquals(candidate(9, 8, 4), -2336)\n    lu.assertEquals(candidate(2, 4, 6), -130)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes two lists and returns true if they have at least one common element.\nlocal function common_element(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common_element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), None)\n    lu.assertEquals(candidate({'a', 'b', 'c'}, {'d', 'b', 'e'}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median length of a trapezium.\nlocal function median_trapezium(base1, base2, height)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_trapezium\n    lu.assertEquals(candidate(15, 25, 35), 20)\n    lu.assertEquals(candidate(10, 20, 30), 15)\n    lu.assertEquals(candidate(6, 9, 4), 7.5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the entered number is greater than the elements of the given array.\nlocal function check_greater(arr, number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_greater\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 4), false)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}, 8), true)\n    lu.assertEquals(candidate({9, 7, 4, 8, 6, 1}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an a followed by one or more b's.\nlocal function text_match_one(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the last digit of a given number.\nlocal function last_Digit(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit\n    lu.assertEquals(candidate(123), 3)\n    lu.assertEquals(candidate(25), 5)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "lua",
+    "prompt": "-- Write a python function to return the negative numbers in a list.\nlocal function neg_nos(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = neg_nos\n    lu.assertEquals(candidate({-1, 4, 5, -6}), {-1, -6})\n    lu.assertEquals(candidate({-1, -2, 3, 4}), {-1, -2})\n    lu.assertEquals(candidate({-7, -6, 8, 9}), {-7, -6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to remove odd characters in a string.\nlocal function remove_odd(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate('python'), 'yhn')\n    lu.assertEquals(candidate('program'), 'rga')\n    lu.assertEquals(candidate('language'), 'agae')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "lua",
+    "prompt": "-- Write a function to count bidirectional tuple pairs.\nlocal function count_bidirectional(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_bidirectional\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 3)\n    lu.assertEquals(candidate({{5, 6}, {1, 3}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 2)\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 2}, {6, 5}, {2, 1}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "lua",
+    "prompt": "-- Write a function to join a list of multiple integers into a single integer.\nlocal function multiple_to_single(L)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiple_to_single\n    lu.assertEquals(candidate({11, 33, 50}), 113350)\n    lu.assertEquals(candidate({-1, 2, 3, 4, 5, 6}), -123456)\n    lu.assertEquals(candidate({10, 15, 20, 25}), 10152025)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "lua",
+    "prompt": "-- Write a function to find the first adverb and their positions in a given sentence.\nlocal function find_adverb_position(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverb_position\n    lu.assertEquals(candidate('clearly!! we can see the sky'), {0, 7, 'clearly'})\n    lu.assertEquals(candidate('seriously!! there are many roses'), {0, 9, 'seriously'})\n    lu.assertEquals(candidate('unfortunately!! sita is going to home'), {0, 13, 'unfortunately'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "lua",
+    "prompt": "-- Write a function to find the surface area of a cube of a given size.\nlocal function surfacearea_cube(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cube\n    lu.assertEquals(candidate(5), 150)\n    lu.assertEquals(candidate(3), 54)\n    lu.assertEquals(candidate(10), 600)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "lua",
+    "prompt": "-- Write a function to find the ration of positive numbers in an array of integers.\nlocal function positive_count(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = positive_count\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), 0.54)\n    lu.assertEquals(candidate({2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 0.69)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), 0.56)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the largest negative number from the given list.\nlocal function largest_neg(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_neg\n    lu.assertEquals(candidate({1, 2, 3, -4, -6}), -6)\n    lu.assertEquals(candidate({1, 2, 3, -8, -9}), -9)\n    lu.assertEquals(candidate({1, 2, 3, 4, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to trim each list by k in the given lists.\nlocal function trim_tuple(test_list, K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = trim_tuple\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 2), {{2}, {9}, {2}, {2}})\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 1), {{3, 2, 1}, {4, 9, 2}, {1, 2, 3}, {8, 2, 1}})\n    lu.assertEquals(candidate({{7, 8, 4, 9}, {11, 8, 12, 4}, {4, 1, 7, 8}, {3, 6, 9, 7}}, 1), {{8, 4}, {8, 12}, {1, 7}, {6, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "lua",
+    "prompt": "-- Write a function to perform index wise multiplication of list elements in the given two lists.\nlocal function index_multiplication(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_multiplication\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 21}, {12, 45}, {2, 9}, {7, 30}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{14, 32}, {20, 60}, {6, 20}, {16, 44}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{24, 45}, {30, 77}, {12, 33}, {27, 60}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the occurence of all elements of list in a tuple.\nlocal function count_Occurrence(tup, lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Occurrence\n    lu.assertEquals(candidate({'a', 'a', 'c', 'b', 'd'}, {'a', 'b'}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 1, 4, 6, 7, 1, 4}, {1, 4, 7}), 6)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {1, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to find cubes of individual elements in a list.\nlocal function cube_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 8, 27, 64, 125, 216, 343, 512, 729, 1000})\n    lu.assertEquals(candidate({10, 20, 30}), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}), {1728, 3375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum of perrin numbers.\nlocal function cal_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cal_sum\n    lu.assertEquals(candidate(9), 49)\n    lu.assertEquals(candidate(10), 66)\n    lu.assertEquals(candidate(11), 88)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "lua",
+    "prompt": "-- Write a function to extract specified size of strings from a given list of string values.\nlocal function extract_string(str, l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_string\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 8), {'practice', 'solution'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 6), {'Python'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 9), {'exercises'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all whitespaces from the given string.\nlocal function remove_whitespaces(text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_whitespaces\n    lu.assertEquals(candidate(' Google    Flutter '), 'GoogleFlutter')\n    lu.assertEquals(candidate(' Google    Dart '), 'GoogleDart')\n    lu.assertEquals(candidate(' iOS    Swift '), 'iOSSwift')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "lua",
+    "prompt": "-- Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlocal function loss_amount(actual_cost, sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = loss_amount\n    lu.assertEquals(candidate(1500, 1200), 0)\n    lu.assertEquals(candidate(100, 200), 100)\n    lu.assertEquals(candidate(2000, 5000), 3000)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of even factors of a number.\nlocal function sumofFactors(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sumofFactors\n    lu.assertEquals(candidate(18), 26)\n    lu.assertEquals(candidate(30), 48)\n    lu.assertEquals(candidate(6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a word containing 'z'.\nlocal function text_match_wordz(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz\n    lu.assertEquals(candidate('pythonz.'), true)\n    lu.assertEquals(candidate('xyz.'), true)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given month number contains 31 days or not.\nlocal function check_monthnumb_number(monthnum2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumb_number\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "lua",
+    "prompt": "-- Write a function to reverse each string in a given list of string values.\nlocal function reverse_string_list(stringlist)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_string_list\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue', 'White', 'Black'}), {'deR', 'neerG', 'eulB', 'etihW', 'kcalB'})\n    lu.assertEquals(candidate({'john', 'amal', 'joel', 'george'}), {'nhoj', 'lama', 'leoj', 'egroeg'})\n    lu.assertEquals(candidate({'jack', 'john', 'mary'}), {'kcaj', 'nhoj', 'yram'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sublist having minimum length.\nlocal function Find_Min(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1})\n    lu.assertEquals(candidate({{1, 1}, {1, 1, 1}, {1, 2, 7, 8}}), {1, 1})\n    lu.assertEquals(candidate({{'x'}, {'x', 'y'}, {'x', 'y', 'z'}}), {'x'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "lua",
+    "prompt": "-- Write a function to find the area of a rectangle.\nlocal function rectangle_area(l, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rectangle_area\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(10, 5), 50)\n    lu.assertEquals(candidate(4, 2), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "lua",
+    "prompt": "-- Write a function to remove uppercase substrings from a given string.\nlocal function remove_uppercase(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_uppercase\n    lu.assertEquals(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')\n    lu.assertEquals(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')\n    lu.assertEquals(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "lua",
+    "prompt": "-- Write a python function to get the first element of each sublist.\nlocal function Extract(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Extract\n    lu.assertEquals(candidate({{1, 2}, {3, 4, 5}, {6, 7, 8, 9}}), {1, 3, 6})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5}}), {1, 4})\n    lu.assertEquals(candidate({{9, 8, 1}, {1, 2}}), {9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the upper case characters in a given string.\nlocal function upper_ctr(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = upper_ctr\n    lu.assertEquals(candidate('PYthon'), 1)\n    lu.assertEquals(candidate('BigData'), 1)\n    lu.assertEquals(candidate('program'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find all possible combinations of the elements of a given list.\nlocal function combinations_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_list\n    lu.assertEquals(candidate({'orange', 'red', 'green', 'blue'}), {{}, {'orange'}, {'red'}, {'red', 'orange'}, {'green'}, {'green', 'orange'}, {'green', 'red'}, {'green', 'red', 'orange'}, {'blue'}, {'blue', 'orange'}, {'blue', 'red'}, {'blue', 'red', 'orange'}, {'blue', 'green'}, {'blue', 'green', 'orange'}, {'blue', 'green', 'red'}, {'blue', 'green', 'red', 'orange'}})\n    lu.assertEquals(candidate({'red', 'green', 'blue', 'white', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'blue'}, {'blue', 'red'}, {'blue', 'green'}, {'blue', 'green', 'red'}, {'white'}, {'white', 'red'}, {'white', 'green'}, {'white', 'green', 'red'}, {'white', 'blue'}, {'white', 'blue', 'red'}, {'white', 'blue', 'green'}, {'white', 'blue', 'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'black', 'blue'}, {'black', 'blue', 'red'}, {'black', 'blue', 'green'}, {'black', 'blue', 'green', 'red'}, {'black', 'white'}, {'black', 'white', 'red'}, {'black', 'white', 'green'}, {'black', 'white', 'green', 'red'}, {'black', 'white', 'blue'}, {'black', 'white', 'blue', 'red'}, {'black', 'white', 'blue', 'green'}, {'black', 'white', 'blue', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'blue'}, {'orange', 'blue', 'red'}, {'orange', 'blue', 'green'}, {'orange', 'blue', 'green', 'red'}, {'orange', 'white'}, {'orange', 'white', 'red'}, {'orange', 'white', 'green'}, {'orange', 'white', 'green', 'red'}, {'orange', 'white', 'blue'}, {'orange', 'white', 'blue', 'red'}, {'orange', 'white', 'blue', 'green'}, {'orange', 'white', 'blue', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}, {'orange', 'black', 'blue'}, {'orange', 'black', 'blue', 'red'}, {'orange', 'black', 'blue', 'green'}, {'orange', 'black', 'blue', 'green', 'red'}, {'orange', 'black', 'white'}, {'orange', 'black', 'white', 'red'}, {'orange', 'black', 'white', 'green'}, {'orange', 'black', 'white', 'green', 'red'}, {'orange', 'black', 'white', 'blue'}, {'orange', 'black', 'white', 'blue', 'red'}, {'orange', 'black', 'white', 'blue', 'green'}, {'orange', 'black', 'white', 'blue', 'green', 'red'}})\n    lu.assertEquals(candidate({'red', 'green', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum product subarray of the given array.\nlocal function max_subarray_product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_subarray_product\n    lu.assertEquals(candidate({1, -2, -3, 0, 7, -8, -2}), 112)\n    lu.assertEquals(candidate({6, -3, -10, 0, 2}), 180)\n    lu.assertEquals(candidate({-2, -40, 0, -2, -3}), 80)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "lua",
+    "prompt": "-- Write a function to check if all values are same in a dictionary.\nlocal function check_value(dict, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_value\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 10), false)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 12), true)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "lua",
+    "prompt": "-- Write a function to drop empty items from a given dictionary.\nlocal function drop_empty(dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = drop_empty\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = 'Green', ['c3'] = None}), {['c1'] = 'Red', ['c2'] = 'Green'})\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = None, ['c3'] = None}), {['c1'] = 'Red'})\n    lu.assertEquals(candidate({['c1'] = None, ['c2'] = 'Green', ['c3'] = None}), {['c2'] = 'Green'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nlocal function max_product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product\n    lu.assertEquals(candidate({3, 100, 4, 5, 150, 6}), 3000)\n    lu.assertEquals(candidate({4, 42, 55, 68, 80}), 50265600)\n    lu.assertEquals(candidate({10, 22, 9, 33, 21, 50, 41, 60}), 2460)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "lua",
+    "prompt": "-- Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nlocal function add_pairwise(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_pairwise\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {6, 12, 15, 18})\n    lu.assertEquals(candidate({2, 6, 8, 9, 11}), {8, 14, 17, 20})\n    lu.assertEquals(candidate({3, 7, 9, 10, 12}), {10, 16, 19, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the product of the array multiplication modulo n.\nlocal function find_remainder(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_remainder\n    lu.assertEquals(candidate({100, 10, 5, 25, 35, 14}, 11), 9)\n    lu.assertEquals(candidate({1, 1, 1}, 1), 0)\n    lu.assertEquals(candidate({1, 2, 1}, 2), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given list contains consecutive numbers or not.\nlocal function check_Consecutive(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_Consecutive\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 5, 6}), false)\n    lu.assertEquals(candidate({1, 2, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "lua",
+    "prompt": "-- Write a function to replace characters in a string.\nlocal function replace_char(str1, ch, newch)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_char\n    lu.assertEquals(candidate('polygon', 'y', 'l'), 'pollgon')\n    lu.assertEquals(candidate('character', 'c', 'a'), 'aharaater')\n    lu.assertEquals(candidate('python', 'l', 'a'), 'python')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a dictionary by value.\nlocal function sort_counter(dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_counter\n    lu.assertEquals(candidate({['Math'] = 81, ['Physics'] = 83, ['Chemistry'] = 87}), {{'Chemistry', 87}, {'Physics', 83}, {'Math', 81}})\n    lu.assertEquals(candidate({['Math'] = 400, ['Physics'] = 300, ['Chemistry'] = 250}), {{'Math', 400}, {'Physics', 300}, {'Chemistry', 250}})\n    lu.assertEquals(candidate({['Math'] = 900, ['Physics'] = 1000, ['Chemistry'] = 1250}), {{'Chemistry', 1250}, {'Physics', 1000}, {'Math', 900}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of the largest and smallest value in a given array.\nlocal function big_sum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_sum\n    lu.assertEquals(candidate({1, 2, 3}), 4)\n    lu.assertEquals(candidate({-1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({2, 3, 6}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "lua",
+    "prompt": "-- Write a python function to convert the given string to lower case.\nlocal function is_lower(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_lower\n    lu.assertEquals(candidate('InValid'), 'invalid')\n    lu.assertEquals(candidate('TruE'), 'true')\n    lu.assertEquals(candidate('SenTenCE'), 'sentence')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "lua",
+    "prompt": "-- Write a function to remove lowercase substrings from a given string.\nlocal function remove_lowercase(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_lowercase\n    lu.assertEquals(candidate('PYTHon'), 'PYTH')\n    lu.assertEquals(candidate('FInD'), 'FID')\n    lu.assertEquals(candidate('STRinG'), 'STRG')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the first digit of a given number.\nlocal function first_Digit(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_Digit\n    lu.assertEquals(candidate(123), 1)\n    lu.assertEquals(candidate(456), 4)\n    lu.assertEquals(candidate(12), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nlocal function heap_queue_largest(nums, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_queue_largest\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), {85, 75, 65})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), {85, 75})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), {85, 75, 65, 58, 35})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "lua",
+    "prompt": "-- Write a python function which takes a list of integers and only returns the odd ones.\nlocal function Split(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {1, 3, 5})\n    lu.assertEquals(candidate({10, 11, 12, 13}), {11, 13})\n    lu.assertEquals(candidate({7, 8, 9, 1}), {7, 9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlocal function difference(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = difference\n    lu.assertEquals(candidate(3), 30)\n    lu.assertEquals(candidate(5), 210)\n    lu.assertEquals(candidate(2), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of pairs whose xor value is odd.\nlocal function find_Odd_Pair(A, N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Odd_Pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}, 5), 6)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}, 7), 12)\n    lu.assertEquals(candidate({1, 2, 3}, 3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "lua",
+    "prompt": "-- Write a function to toggle the case of all characters in a string.\nlocal function toggle_string(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_string\n    lu.assertEquals(candidate('Python'), 'pYTHON')\n    lu.assertEquals(candidate('Pangram'), 'pANGRAM')\n    lu.assertEquals(candidate('LIttLE'), 'liTTle')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of the per-digit difference between two integers.\nlocal function digit_distance_nums(n1, n2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digit_distance_nums\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(23, 56), 6)\n    lu.assertEquals(candidate(123, 256), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the sum of the largest contiguous sublist in the given list.\nlocal function max_sub_array_sum(a, size)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum\n    lu.assertEquals(candidate({-2, -3, 4, -1, -2, 1, 5, -3}, 8), 7)\n    lu.assertEquals(candidate({-3, -4, 5, -2, -3, 2, 6, -4}, 8), 8)\n    lu.assertEquals(candidate({-4, -5, 6, -3, -4, 3, 7, -5}, 8), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to find the union of the elements of two given lists and output them in sorted order.\nlocal function union_elements(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = union_elements\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 4, 5, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {3, 4, 5, 6}), {1, 2, 3, 4, 5, 6})\n    lu.assertEquals(candidate({11, 12, 13, 14}, {13, 15, 16, 17}), {11, 12, 13, 14, 15, 16, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the length of the longest sublists.\nlocal function Find_Max_Length(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max_Length\n    lu.assertEquals(candidate({{1}, {1, 4}, {5, 6, 7, 8}}), 4)\n    lu.assertEquals(candidate({{0, 1}, {2, 2}, {3, 2, 1}}), 3)\n    lu.assertEquals(candidate({{7}, {22, 23}, {13, 14, 15}, {10, 20, 30, 40, 50}}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "lua",
+    "prompt": "-- Write a function to extract values between quotation marks from a string.\nlocal function extract_values(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_values\n    lu.assertEquals(candidate('\"Python\", \"PHP\", \"Java\"'), {'Python', 'PHP', 'Java'})\n    lu.assertEquals(candidate('\"python\",\"program\",\"language\"'), {'python', 'program', 'language'})\n    lu.assertEquals(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), {'red', 'blue', 'green', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "lua",
+    "prompt": "-- Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nlocal function count_Pairs(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Pairs\n    lu.assertEquals(candidate({1, 2, 1}, 3), 2)\n    lu.assertEquals(candidate({1, 1, 1, 1}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 5), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "lua",
+    "prompt": "-- Write a python function to split a string into characters.\nlocal function split(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split\n    lu.assertEquals(candidate('python'), {'p', 'y', 't', 'h', 'o', 'n'})\n    lu.assertEquals(candidate('Name'), {'N', 'a', 'm', 'e'})\n    lu.assertEquals(candidate('program'), {'p', 'r', 'o', 'g', 'r', 'a', 'm'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to get the sum of the digits of a non-negative integer.\nlocal function sum_digits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_digits\n    lu.assertEquals(candidate(345), 12)\n    lu.assertEquals(candidate(12), 3)\n    lu.assertEquals(candidate(97), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a specified list is sorted or not.\nlocal function issort_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = issort_list\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), true)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), false)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 15, 14, 20}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "lua",
+    "prompt": "-- Write a function to create a list of N empty dictionaries.\nlocal function empty_list(length)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = empty_list\n    lu.assertEquals(candidate(5), {{}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(6), {{}, {}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(7), {{}, {}, {}, {}, {}, {}, {}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "lua",
+    "prompt": "-- Write a function to sort each sublist of strings in a given list of lists.\nlocal function sort_sublists(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}}), {{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'d', 'c'}, {'g', 'h'}, {'f', 'e'}}), {{'a', 'b'}, {'c', 'd'}, {'g', 'h'}, {'e', 'f'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "lua",
+    "prompt": "-- Write a python function to check if a given number is one less than twice its reverse.\nlocal function checks(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = checks\n    lu.assertEquals(candidate(70), false)\n    lu.assertEquals(candidate(23), false)\n    lu.assertEquals(candidate(73), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "lua",
+    "prompt": "-- Write a python function to remove duplicate numbers from a given number of lists.\nlocal function two_unique_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = two_unique_nums\n    lu.assertEquals(candidate({1, 2, 3, 2, 3, 4, 5}), {1, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 5}), {1, 3, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "lua",
+    "prompt": "-- Write a python function to calculate the product of the unique numbers in a given list.\nlocal function unique_product(list_data)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_product\n    lu.assertEquals(candidate({10, 20, 30, 40, 20, 50, 60, 40}), 720000000)\n    lu.assertEquals(candidate({1, 2, 3, 1}), 6)\n    lu.assertEquals(candidate({7, 8, 9, 0, 1, 1}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "lua",
+    "prompt": "-- Write a function to find the surface area of a cylinder.\nlocal function surfacearea_cylinder(r, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cylinder\n    lu.assertEquals(candidate(10, 5), 942.45)\n    lu.assertEquals(candidate(4, 5), 226.18800000000002)\n    lu.assertEquals(candidate(4, 10), 351.848)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether a list is sublist of another or not.\nlocal function is_Sub_Array(A, B)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sub_Array\n    lu.assertEquals(candidate({1, 4, 3, 5}, {1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 1}, {1, 2, 1}), true)\n    lu.assertEquals(candidate({1, 0, 2, 2}, {2, 2, 0}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the last digit in factorial of a given number.\nlocal function last_Digit_Factorial(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit_Factorial\n    lu.assertEquals(candidate(4), 4)\n    lu.assertEquals(candidate(21), 0)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to interleave 3 lists of the same length into a single flat list.\nlocal function interleave_lists(list1, list2, list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = interleave_lists\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}, {10, 20, 30, 40, 50, 60, 70}, {100, 200, 300, 400, 500, 600, 700}), {1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700})\n    lu.assertEquals(candidate({10, 20}, {15, 2}, {5, 10}), {10, 15, 5, 20, 2, 10})\n    lu.assertEquals(candidate({11, 44}, {10, 15}, {20, 5}), {11, 10, 20, 44, 15, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "lua",
+    "prompt": "-- Write a function to find the dissimilar elements in the given two tuples.\nlocal function find_dissimilar(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_dissimilar\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {7, 2, 3, 9}), {1, 4, 7, 9})\n    lu.assertEquals(candidate({21, 11, 25, 26}, {26, 34, 21, 36}), {34, 36, 11, 25})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the largest number that can be formed with the given list of digits.\nlocal function find_Max_Num(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Max_Num\n    lu.assertEquals(candidate({1, 2, 3}), 321)\n    lu.assertEquals(candidate({4, 5, 6, 1}), 6541)\n    lu.assertEquals(candidate({1, 2, 3, 9}), 9321)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "lua",
+    "prompt": "-- Write a function to remove uneven elements in the nested mixed tuple.\nlocal function extract_even(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_even\n    lu.assertEquals(candidate({4, 5, {7, 6, {2, 4}}, 6, 8}), {4, {6, {2, 4}}, 6, 8})\n    lu.assertEquals(candidate({5, 6, {8, 7, {4, 8}}, 7, 9}), {6, {8, {4, 8}}})\n    lu.assertEquals(candidate({5, 6, {9, 8, {4, 6}}, 8, 10}), {6, {8, {4, 6}}, 8, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the surface area of a square pyramid with a given base edge and height.\nlocal function surface_Area(b, s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surface_Area\n    lu.assertEquals(candidate(3, 4), 33)\n    lu.assertEquals(candidate(4, 5), 56)\n    lu.assertEquals(candidate(1, 2), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "lua",
+    "prompt": "-- Write a function which returns nth catalan number.\nlocal function catalan_number(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = catalan_number\n    lu.assertEquals(candidate(10), 16796)\n    lu.assertEquals(candidate(9), 4862)\n    lu.assertEquals(candidate(7), 429)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "lua",
+    "prompt": "-- Write a function to find the first adverb ending with ly and its positions in a given string.\nlocal function find_adverbs(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverbs\n    lu.assertEquals(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')\n    lu.assertEquals(candidate('Please handle the situation carefuly'), '28-36: carefuly')\n    lu.assertEquals(candidate('Complete the task quickly'), '18-25: quickly')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n most expensive items in a given dataset.\nlocal function expensive_items(items, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = expensive_items\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}}, 2), {{['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-1', ['price'] = 101.1}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}, {['name'] = 'Item-4', ['price'] = 22.75}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "lua",
+    "prompt": "-- Write a python function to split a list at the nth eelment and add the first part to the end.\nlocal function split_Arr(l, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_Arr\n    lu.assertEquals(candidate({12, 10, 5, 6, 52, 36}, 2), {5, 6, 52, 36, 12, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, 1), {2, 3, 4, 1})\n    lu.assertEquals(candidate({0, 1, 2, 3, 4, 5, 6, 7}, 3), {3, 4, 5, 6, 7, 0, 1, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a list to a tuple.\nlocal function list_tuple(listx)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_tuple\n    lu.assertEquals(candidate({5, 10, 7, 4, 15, 3}), {5, 10, 7, 4, 15, 3})\n    lu.assertEquals(candidate({2, 4, 5, 6, 2, 3, 4, 4, 7}), {2, 4, 5, 6, 2, 3, 4, 4, 7})\n    lu.assertEquals(candidate({58, 44, 56}), {58, 44, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the difference between largest and smallest value in a given list.\nlocal function big_diff(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_diff\n    lu.assertEquals(candidate({1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({4, 5, 12}), 8)\n    lu.assertEquals(candidate({9, 2, 3}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "lua",
+    "prompt": "-- Write a function to find perfect squares between two given numbers.\nlocal function perfect_squares(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perfect_squares\n    lu.assertEquals(candidate(1, 30), {1, 4, 9, 16, 25})\n    lu.assertEquals(candidate(50, 100), {64, 81, 100})\n    lu.assertEquals(candidate(100, 200), {100, 121, 144, 169, 196})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given two integers have opposite sign or not.\nlocal function opposite_Signs(x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = opposite_Signs\n    lu.assertEquals(candidate(1, -2), true)\n    lu.assertEquals(candidate(3, 2), false)\n    lu.assertEquals(candidate(-10, -10), false)\n    lu.assertEquals(candidate(-2, 2), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "lua",
+    "prompt": "-- Write a python function to interchange the first and last elements in a list.\nlocal function swap_List(newList)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({12, 35, 9, 56, 24}), {24, 35, 9, 56, 12})\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of the product of consecutive binomial co-efficients.\nlocal function sum_Of_product(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_product\n    lu.assertEquals(candidate(3), 15)\n    lu.assertEquals(candidate(4), 56)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "lua",
+    "prompt": "-- Write a function to remove leading zeroes from an ip address.\nlocal function removezero_ip(ip)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = removezero_ip\n    lu.assertEquals(candidate('216.08.094.196'), '216.8.94.196')\n    lu.assertEquals(candidate('12.01.024'), '12.1.24')\n    lu.assertEquals(candidate('216.08.094.0196'), '216.8.94.196')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to find the difference of the first even and first odd number of a given list.\nlocal function diff_even_odd(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = diff_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 1)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "lua",
+    "prompt": "-- Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nlocal function min_Swaps(str1, str2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Swaps\n    lu.assertEquals(candidate('1101', '1110'), 1)\n    lu.assertEquals(candidate('111', '000'), 'Not Possible')\n    lu.assertEquals(candidate('111', '110'), 'Not Possible')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "lua",
+    "prompt": "-- Write a function to find kth element from the given two sorted arrays.\nlocal function find_kth(arr1, arr2, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_kth\n    lu.assertEquals(candidate({2, 3, 6, 7, 9}, {1, 4, 8, 10}, 5), 6)\n    lu.assertEquals(candidate({100, 112, 256, 349, 770}, {72, 86, 113, 119, 265, 445, 892}, 7), 256)\n    lu.assertEquals(candidate({3, 4, 7, 8, 10}, {2, 5, 9, 11}, 6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is armstrong or not.\nlocal function armstrong_number(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = armstrong_number\n    lu.assertEquals(candidate(153), true)\n    lu.assertEquals(candidate(259), false)\n    lu.assertEquals(candidate(4458), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "lua",
+    "prompt": "-- Write a function to find sum and average of first n natural numbers.\nlocal function sum_average(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_average\n    lu.assertEquals(candidate(10), {55, 5.5})\n    lu.assertEquals(candidate(15), {120, 8.0})\n    lu.assertEquals(candidate(20), {210, 10.5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth octagonal number.\nlocal function is_octagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_octagonal\n    lu.assertEquals(candidate(5), 65)\n    lu.assertEquals(candidate(10), 280)\n    lu.assertEquals(candidate(15), 645)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given number is even or not.\nlocal function is_Even(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Even\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(2), true)\n    lu.assertEquals(candidate(3), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the first repeated character in a given string.\nlocal function first_repeated_char(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_repeated_char\n    lu.assertEquals(candidate('abcabc'), 'a')\n    lu.assertEquals(candidate('abc'), None)\n    lu.assertEquals(candidate('123123'), '1')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "lua",
+    "prompt": "-- Write a function to get all lucid numbers smaller than or equal to a given integer.\nlocal function get_ludic(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_ludic\n    lu.assertEquals(candidate(10), {1, 2, 3, 5, 7})\n    lu.assertEquals(candidate(25), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25})\n    lu.assertEquals(candidate(45), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "lua",
+    "prompt": "-- Write a function to reverse words seperated by spaces in a given string.\nlocal function reverse_words(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_words\n    lu.assertEquals(candidate('python program'), 'program python')\n    lu.assertEquals(candidate('java language'), 'language java')\n    lu.assertEquals(candidate('indian man'), 'man indian')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given integer is a prime number.\nlocal function prime_num(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_num\n    lu.assertEquals(candidate(13), true)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(-1010), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "lua",
+    "prompt": "-- Write a function to convert degrees to radians.\nlocal function radian_degree(degree)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = radian_degree\n    lu.assertEquals(candidate(90), 1.5707963267948966)\n    lu.assertEquals(candidate(60), 1.0471975511965976)\n    lu.assertEquals(candidate(120), 2.0943951023931953)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "lua",
+    "prompt": "-- Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nlocal function find_literals(text, pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_literals\n    lu.assertEquals(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), {'fox', 16, 19})\n    lu.assertEquals(candidate('Its been a very crazy procedure right', 'crazy'), {'crazy', 16, 21})\n    lu.assertEquals(candidate('Hardest choices required strongest will', 'will'), {'will', 35, 39})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "lua",
+    "prompt": "-- Write a python function to find nth bell number.\nlocal function bell_Number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_Number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "lua",
+    "prompt": "-- Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nlocal function remove_kth_element(list1, L)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_kth_element\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {1, 1, 3, 4, 4, 5, 1})\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), {10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "lua",
+    "prompt": "-- Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nlocal function max_of_nth(test_list, N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_of_nth\n    lu.assertEquals(candidate({{5, 6, 7}, {1, 3, 5}, {8, 9, 19}}, 2), 19)\n    lu.assertEquals(candidate({{6, 7, 8}, {2, 4, 6}, {9, 10, 20}}, 1), 10)\n    lu.assertEquals(candidate({{7, 8, 9}, {3, 5, 7}, {10, 11, 21}}, 1), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "lua",
+    "prompt": "-- Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nlocal function merge(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge\n    lu.assertEquals(candidate({{'x', 'y'}, {'a', 'b'}, {'m', 'n'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}, {7, 8}}), {{1, 3, 5, 7}, {2, 4, 6, 8}})\n    lu.assertEquals(candidate({{'x', 'y', 'z'}, {'a', 'b', 'c'}, {'m', 'n', 'o'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}, {'z', 'c', 'o'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nlocal function cummulative_sum(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cummulative_sum\n    lu.assertEquals(candidate({{1, 3}, {5, 6, 7}, {2, 6}}), 30)\n    lu.assertEquals(candidate({{2, 4}, {6, 7, 8}, {3, 7}}), 37)\n    lu.assertEquals(candidate({{3, 5}, {7, 8, 9}, {4, 8}}), 44)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nlocal function average_tuple(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = average_tuple\n    lu.assertEquals(candidate({{10, 10, 10, 12}, {30, 45, 56, 45}, {81, 80, 39, 32}, {1, 2, 3, 4}}), {30.5, 34.25, 27.0, 23.25})\n    lu.assertEquals(candidate({{1, 1, -5}, {30, -15, 56}, {81, -60, -39}, {-10, 2, 3}}), {25.5, -18.0, 3.75})\n    lu.assertEquals(candidate({{100, 100, 100, 120}, {300, 450, 560, 450}, {810, 800, 390, 320}, {10, 20, 30, 40}}), {305.0, 342.5, 270.0, 232.5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "lua",
+    "prompt": "-- Write a function which takes two tuples of the same length and performs the element wise modulo.\nlocal function tuple_modulo(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_modulo\n    lu.assertEquals(candidate({10, 4, 5, 6}, {5, 6, 7, 5}), {0, 4, 5, 1})\n    lu.assertEquals(candidate({11, 5, 6, 7}, {6, 7, 8, 6}), {5, 5, 6, 1})\n    lu.assertEquals(candidate({12, 6, 7, 8}, {7, 8, 9, 7}), {5, 6, 7, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "lua",
+    "prompt": "-- Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nlocal function min_Jumps(steps, d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Jumps\n    lu.assertEquals(candidate({3, 4}, 11), 3.5)\n    lu.assertEquals(candidate({3, 4}, 0), 0)\n    lu.assertEquals(candidate({11, 14}, 11), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "lua",
+    "prompt": "-- Write a function to divide two lists element wise.\nlocal function div_list(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = div_list\n    lu.assertEquals(candidate({4, 5, 6}, {1, 2, 3}), {4.0, 2.5, 2.0})\n    lu.assertEquals(candidate({3, 2}, {1, 4}), {3.0, 0.5})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {1.8, 1.7142857142857142})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "lua",
+    "prompt": "-- Write a function to move all the numbers to the end of the given string.\nlocal function move_num(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_num\n    lu.assertEquals(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')\n    lu.assertEquals(candidate('Avengers124Assemble'), 'AvengersAssemble124')\n    lu.assertEquals(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of substrings with the sum of digits equal to their length.\nlocal function count_Substrings(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Substrings\n    lu.assertEquals(candidate('112112'), 6)\n    lu.assertEquals(candidate('111'), 6)\n    lu.assertEquals(candidate('1101112'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median of two sorted lists of same size.\nlocal function get_median(arr1, arr2, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_median\n    lu.assertEquals(candidate({1, 12, 15, 26, 38}, {2, 13, 17, 30, 45}, 5), 16.0)\n    lu.assertEquals(candidate({2, 4, 8, 9}, {7, 13, 19, 28}, 4), 8.5)\n    lu.assertEquals(candidate({3, 6, 14, 23, 36, 42}, {2, 18, 27, 39, 49, 55}, 6), 25.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to compute the n-th power of each number in a list.\nlocal function nth_nums(nums, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = nth_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}, 3), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}, 5), {248832, 759375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "lua",
+    "prompt": "-- Write a python function to convert a given string to uppercase.\nlocal function is_upper(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_upper\n    lu.assertEquals(candidate('person'), 'PERSON')\n    lu.assertEquals(candidate('final'), 'FINAL')\n    lu.assertEquals(candidate('Valid'), 'VALID')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "lua",
+    "prompt": "-- Write a python function to interchange the first and last element in a given list.\nlocal function swap_List(newList)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), {4, 2, 3, 4, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nlocal function triangle_area(r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(-1), None)\n    lu.assertEquals(candidate(0), 0)\n    lu.assertEquals(candidate(2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the smallest missing number from a sorted list of natural numbers.\nlocal function find_First_Missing(array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_First_Missing\n    lu.assertEquals(candidate({0, 1, 2, 3}), 4)\n    lu.assertEquals(candidate({0, 1, 2, 6, 9}), 3)\n    lu.assertEquals(candidate({2, 3, 5, 8, 9}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to replace all spaces in the given string with '%20'.\nlocal function replace_spaces(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')\n    lu.assertEquals(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')\n    lu.assertEquals(candidate('I love Coding'), 'I%20love%20Coding')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "lua",
+    "prompt": "-- Write a python function to find even numbers from a list of numbers.\nlocal function Split(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {2, 4})\n    lu.assertEquals(candidate({4, 5, 6, 7, 8, 0, 1}), {4, 6, 8, 0})\n    lu.assertEquals(candidate({8, 12, 15, 19}), {8, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "lua",
+    "prompt": "-- Write a python function to find smallest number in a list.\nlocal function smallest_num(xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_num\n    lu.assertEquals(candidate({10, 20, 1, 45, 99}), 1)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\n    lu.assertEquals(candidate({45, 46, 50, 60}), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "lua",
+    "prompt": "-- Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nlocal function get_coordinates(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_coordinates\n    lu.assertEquals(candidate({3, 4}), {{2, 3}, {2, 4}, {2, 5}, {3, 3}, {3, 4}, {3, 5}, {4, 3}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({4, 5}), {{3, 4}, {3, 5}, {3, 6}, {4, 4}, {4, 5}, {4, 6}, {5, 4}, {5, 5}, {5, 6}})\n    lu.assertEquals(candidate({5, 6}), {{4, 5}, {4, 6}, {4, 7}, {5, 5}, {5, 6}, {5, 7}, {6, 5}, {6, 6}, {6, 7}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to replace whitespaces with an underscore and vice versa in a given string.\nlocal function replace_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')\n    lu.assertEquals(candidate('The_Avengers'), 'The Avengers')\n    lu.assertEquals(candidate('Fast and Furious'), 'Fast_and_Furious')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "lua",
+    "prompt": "-- Write a python function to move all zeroes to the end of the given list.\nlocal function move_zero(num_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_zero\n    lu.assertEquals(candidate({1, 0, 2, 0, 3, 4}), {1, 2, 3, 4, 0, 0})\n    lu.assertEquals(candidate({2, 3, 2, 0, 0, 4, 0, 5, 0}), {2, 3, 2, 4, 5, 0, 0, 0, 0})\n    lu.assertEquals(candidate({0, 1, 0, 1, 1}), {1, 1, 1, 0, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of xor of all pairs of numbers in the given list.\nlocal function pair_xor_Sum(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_xor_Sum\n    lu.assertEquals(candidate({5, 9, 7, 6}, 4), 47)\n    lu.assertEquals(candidate({7, 3, 5}, 3), 12)\n    lu.assertEquals(candidate({7, 3}, 2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort the given list.\nlocal function heap_sort(iterable)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_sort\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 25, 58}), {14, 22, 25, 25, 35, 58, 65, 75, 85})\n    lu.assertEquals(candidate({7, 1, 9, 5}), {1, 5, 7, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given amount has no profit and no loss\nlocal function noprofit_noloss(actual_cost, sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = noprofit_noloss\n    lu.assertEquals(candidate(1500, 1200), false)\n    lu.assertEquals(candidate(100, 100), true)\n    lu.assertEquals(candidate(2000, 5000), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlocal function wind_chill(v, t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = wind_chill\n    lu.assertEquals(candidate(120, 35), 40)\n    lu.assertEquals(candidate(40, 20), 19)\n    lu.assertEquals(candidate(10, 8), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "lua",
+    "prompt": "-- Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nlocal function sample_nam(sample_names)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sample_nam\n    lu.assertEquals(candidate({'sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'}), 16)\n    lu.assertEquals(candidate({'php', 'res', 'Python', 'abcd', 'Java', 'aaa'}), 10)\n    lu.assertEquals(candidate({'abcd', 'Python', 'abba', 'aba'}), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum difference between available pairs in the given tuple list.\nlocal function max_difference(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_difference\n    lu.assertEquals(candidate({{3, 5}, {1, 7}, {10, 3}, {1, 2}}), 7)\n    lu.assertEquals(candidate({{4, 6}, {2, 17}, {9, 13}, {11, 12}}), 15)\n    lu.assertEquals(candidate({{12, 35}, {21, 27}, {13, 23}, {41, 22}}), 23)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "lua",
+    "prompt": "-- Write a function to remove the parenthesis and what is inbetween them from a string.\nlocal function remove_parenthesis(items)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_parenthesis\n    lu.assertEquals(candidate({'python (chrome)'}), 'python')\n    lu.assertEquals(candidate({'string(.abc)'}), 'string')\n    lu.assertEquals(candidate({'alpha(num)'}), 'alpha')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth nonagonal number.\nlocal function is_nonagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nonagonal\n    lu.assertEquals(candidate(10), 325)\n    lu.assertEquals(candidate(15), 750)\n    lu.assertEquals(candidate(18), 1089)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "lua",
+    "prompt": "-- Write a function that checks if a strings contains 'z', except at the start and end of the word.\nlocal function text_match_wordz_middle(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz_middle\n    lu.assertEquals(candidate('pythonzabc.'), true)\n    lu.assertEquals(candidate('zxyabc.'), false)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "lua",
+    "prompt": "-- Write a python function to reverse an array upto a given position.\nlocal function reverse_Array_Upto_K(input, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_Array_Upto_K\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 4), {4, 3, 2, 1, 5, 6})\n    lu.assertEquals(candidate({4, 5, 6, 7}, 2), {5, 4, 6, 7})\n    lu.assertEquals(candidate({9, 8, 7, 6, 5}, 3), {7, 8, 9, 6, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a list of tuples using the second value of each tuple.\nlocal function subject_marks(subjectmarks)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = subject_marks\n    lu.assertEquals(candidate({{'English', 88}, {'Science', 90}, {'Maths', 97}, {'Social sciences', 82}}), {{'Social sciences', 82}, {'English', 88}, {'Science', 90}, {'Maths', 97}})\n    lu.assertEquals(candidate({{'Telugu', 49}, {'Hindhi', 54}, {'Social', 33}}), {{'Social', 33}, {'Telugu', 49}, {'Hindhi', 54}})\n    lu.assertEquals(candidate({{'Physics', 96}, {'Chemistry', 97}, {'Biology', 45}}), {{'Biology', 45}, {'Physics', 96}, {'Chemistry', 97}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to flatten a list and sum all of its elements.\nlocal function recursive_list_sum(data_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = recursive_list_sum\n    lu.assertEquals(candidate({1, 2, {3, 4}, {5, 6}}), 21)\n    lu.assertEquals(candidate({7, 10, {15, 14}, {19, 41}}), 106)\n    lu.assertEquals(candidate({10, 20, {30, 40}, {50, 60}}), 210)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of positive numbers in a list.\nlocal function pos_count(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pos_count\n    lu.assertEquals(candidate({1, -2, 3, -4}), 2)\n    lu.assertEquals(candidate({3, 4, 5, -1}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find the number of ways to partition a set of Bell numbers.\nlocal function bell_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(10), 115975)\n    lu.assertEquals(candidate(56), 6775685320645824322581483068371419745979053216268760300)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given array is monotonic or not.\nlocal function is_Monotonic(A)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Monotonic\n    lu.assertEquals(candidate({6, 5, 4, 4}), true)\n    lu.assertEquals(candidate({1, 2, 2, 3}), true)\n    lu.assertEquals(candidate({1, 3, 2}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a list contains the given sublist or not.\nlocal function is_sublist(l, s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sublist\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {3, 7}), false)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {4, 3}), true)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {1, 6}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the two numbers differ at one bit position only or not.\nlocal function differ_At_One_Bit_Pos(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = differ_At_One_Bit_Pos\n    lu.assertEquals(candidate(13, 9), true)\n    lu.assertEquals(candidate(15, 8), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(2, 3), true)\n    lu.assertEquals(candidate(5, 1), true)\n    lu.assertEquals(candidate(1, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "lua",
+    "prompt": "-- Write a function to find whether all the given lists have equal length or not.\nlocal function get_equal(Input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_equal\n    lu.assertEquals(candidate({{11, 22, 33}, {44, 55, 66}}), true)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6, 7}}), false)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a list of elements.\nlocal function comb_sort(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = comb_sort\n    lu.assertEquals(candidate({5, 15, 37, 25, 79}), {5, 15, 25, 37, 79})\n    lu.assertEquals(candidate({41, 32, 15, 19, 22}), {15, 19, 22, 32, 41})\n    lu.assertEquals(candidate({99, 15, 13, 47}), {13, 15, 47, 99})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to add a dictionary to the tuple. The output should be a tuple.\nlocal function add_dict_to_tuple(test_tup, test_dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_dict_to_tuple\n    lu.assertEquals(candidate({4, 5, 6}, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}), {4, 5, 6, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}})\n    lu.assertEquals(candidate({1, 2, 3}, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}), {1, 2, 3, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}})\n    lu.assertEquals(candidate({8, 9, 10}, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}), {8, 9, 10, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "lua",
+    "prompt": "-- Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nlocal function maxAverageOfPath(cost)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maxAverageOfPath\n    lu.assertEquals(candidate({{1, 2, 3}, {6, 5, 4}, {7, 3, 9}}), 5.2)\n    lu.assertEquals(candidate({{2, 3, 4}, {7, 6, 5}, {8, 4, 10}}), 6.2)\n    lu.assertEquals(candidate({{3, 4, 5}, {8, 7, 6}, {9, 5, 11}}), 7.2)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}), 5.8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "lua",
+    "prompt": "-- The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nlocal function filter_data(students, h, w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_data\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 6.0, 70), {['Cierra Vega'] = {6.2, 70}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.9, 67), {['Cierra Vega'] = {6.2, 70}, ['Kierra Gentry'] = {6.0, 68}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.7, 64), {['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "lua",
+    "prompt": "-- The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nlocal function count_same_pair(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_same_pair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}), 4)\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 11)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 1)\n    lu.assertEquals(candidate({0, 1, 1, 2}, {0, 1, 2, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlocal function power_base_sum(base, power)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power_base_sum\n    lu.assertEquals(candidate(2, 100), 115)\n    lu.assertEquals(candidate(8, 10), 37)\n    lu.assertEquals(candidate(8, 15), 62)\n    lu.assertEquals(candidate(3, 3), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "lua",
+    "prompt": "-- Write a function to extract values between quotation marks \" \" of the given string.\nlocal function extract_quotation(text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_quotation\n    lu.assertEquals(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), {'A53', 'multi', 'Processor'})\n    lu.assertEquals(candidate('Cast your \"favorite\" entertainment \"apps\"'), {'favorite', 'apps'})\n    lu.assertEquals(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), {'4k Ultra HD', 'HDR 10'})\n    lu.assertEquals(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "lua",
+    "prompt": "-- Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nlocal function multiply_elements(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_elements\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {5, 35, 56, 80})\n    lu.assertEquals(candidate({2, 4, 5, 6, 7}), {8, 20, 30, 42})\n    lu.assertEquals(candidate({12, 13, 14, 9, 15}), {156, 182, 126, 135})\n    lu.assertEquals(candidate({12}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "lua",
+    "prompt": "-- Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nlocal function sum_list(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_list\n    lu.assertEquals(candidate({10, 20, 30}, {15, 25, 35}), {25, 45, 65})\n    lu.assertEquals(candidate({1, 2, 3}, {5, 6, 7}), {6, 8, 10})\n    lu.assertEquals(candidate({15, 20, 30}, {15, 45, 75}), {30, 65, 105})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the given number can be represented as the difference of two squares or not.\nlocal function dif_Square(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dif_Square\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(15), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "lua",
+    "prompt": "-- Write a function to remove consecutive duplicates of a given list.\nlocal function consecutive_duplicates(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {10, 15, 19, 18, 17, 26, 17, 18, 10})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {'a', 'b', 'c', 'd'})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd', 'a', 'a'}), {'a', 'b', 'c', 'd', 'a'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "lua",
+    "prompt": "-- Write a function to find the lateral surface area of a cone given radius r and the height h.\nlocal function lateralsurface_cone(r, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cone\n    lu.assertEquals(candidate(5, 12), 204.20352248333654)\n    lu.assertEquals(candidate(10, 15), 566.3586699569488)\n    lu.assertEquals(candidate(19, 17), 1521.8090132193388)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "lua",
+    "prompt": "-- Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nlocal function replace_specialchar(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_specialchar\n    lu.assertEquals(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')\n    lu.assertEquals(candidate('a b c,d e f'), 'a:b:c:d:e:f')\n    lu.assertEquals(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "lua",
+    "prompt": "-- Write a function to find the index of the first occurrence of a given number in a sorted array.\nlocal function find_first_occurrence(A, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_first_occurrence\n    lu.assertEquals(candidate({2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 1)\n    lu.assertEquals(candidate({2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 2)\n    lu.assertEquals(candidate({2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "lua",
+    "prompt": "-- Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nlocal function sum_Of_Subarray_Prod(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_Subarray_Prod\n    lu.assertEquals(candidate({1, 2, 3}), 20)\n    lu.assertEquals(candidate({1, 2}), 5)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "lua",
+    "prompt": "-- Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlocal function toggle_middle_bits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_middle_bits\n    lu.assertEquals(candidate(9), 15)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(11), 13)\n    lu.assertEquals(candidate(65), 127)\n    lu.assertEquals(candidate(77), 115)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "lua",
+    "prompt": "-- Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nlocal function left_insertion(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given string is starting with a vowel or not using regex.\nlocal function check_str(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_str\n    lu.assertEquals(candidate('annie'), true)\n    lu.assertEquals(candidate('dawood'), false)\n    lu.assertEquals(candidate('Else'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nlocal function geometric_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = geometric_sum\n    lu.assertEquals(candidate(7), 1.9921875)\n    lu.assertEquals(candidate(4), 1.9375)\n    lu.assertEquals(candidate(8), 1.99609375)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlocal function find_Index(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Index\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 14)\n    lu.assertEquals(candidate(4), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nlocal function tuple_to_dict(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_dict\n    lu.assertEquals(candidate({1, 5, 7, 10, 13, 5}), {[1] = 5, [7] = 10, [13] = 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {[1] = 2, [3] = 4, [5] = 6})\n    lu.assertEquals(candidate({7, 8, 9, 10, 11, 12}), {[7] = 8, [9] = 10, [11] = 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether all the characters are same or not.\nlocal function all_Characters_Same(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Characters_Same\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('aaa'), true)\n    lu.assertEquals(candidate('data'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "lua",
+    "prompt": "-- Write a function to caluclate the area of a tetrahedron.\nlocal function area_tetrahedron(side)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = area_tetrahedron\n    lu.assertEquals(candidate(3), 15.588457268119894)\n    lu.assertEquals(candidate(20), 692.8203230275509)\n    lu.assertEquals(candidate(10), 173.20508075688772)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "lua",
+    "prompt": "-- Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nlocal function rotate_right(list, m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rotate_right\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), {8, 9, 10, 1, 2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {9, 10, 1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), {6, 7, 8, 9, 10, 1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given tuple has any none value or not.\nlocal function check_none(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_none\n    lu.assertEquals(candidate({10, 4, 5, 6, None}), true)\n    lu.assertEquals(candidate({7, 8, 9, 11, 14}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, None}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nlocal function divisible_by_digits(startnum, endnum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisible_by_digits\n    lu.assertEquals(candidate(1, 22), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22})\n    lu.assertEquals(candidate(1, 15), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15})\n    lu.assertEquals(candidate(20, 25), {22, 24})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "lua",
+    "prompt": "-- Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nlocal function sector_area(r, a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sector_area\n    lu.assertEquals(candidate(4, 45), 6.283185307179586)\n    lu.assertEquals(candidate(9, 45), 31.808625617596654)\n    lu.assertEquals(candidate(9, 361), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "lua",
+    "prompt": "-- Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlocal function lcs_of_three(X, Y, Z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lcs_of_three\n    lu.assertEquals(candidate('AGGT12', '12TXAYB', '12XBA'), 2)\n    lu.assertEquals(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)\n    lu.assertEquals(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to put spaces between words starting with capital letters in a given string.\nlocal function capital_words_spaces(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = capital_words_spaces\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('PythonProgrammingExamples'), 'Python Programming Examples')\n    lu.assertEquals(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nlocal function sort_numeric_strings(nums_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numeric_strings\n    lu.assertEquals(candidate({'4', '12', '45', '7', '0', '100', '200', '-12', '-500'}), {-500, -12, 0, 4, 7, 12, 45, 100, 200})\n    lu.assertEquals(candidate({'2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2'}), {1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9})\n    lu.assertEquals(candidate({'1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11'}), {1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether it follows the sequence given in the patterns array.\nlocal function is_samepatterns(colors, patterns)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_samepatterns\n    lu.assertEquals(candidate({'red', 'green', 'green'}, {'a', 'b', 'b'}), true)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b', 'b'}), false)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b'}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to add the given tuple to the given list.\nlocal function add_tuple(test_list, test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_tuple\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {5, 6, 7, 9, 10})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {6, 7, 8, 10, 11})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {7, 8, 9, 11, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nlocal function check_min_heap(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_min_heap\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 10, 15}), true)\n    lu.assertEquals(candidate({2, 10, 4, 5, 3, 15}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlocal function jacobsthal_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = jacobsthal_num\n    lu.assertEquals(candidate(5), 11)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 5)\n    lu.assertEquals(candidate(13), 2731)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "lua",
+    "prompt": "-- Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nlocal function min_k(test_list, K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_k\n    lu.assertEquals(candidate({{'Manjeet', 10}, {'Akshat', 4}, {'Akash', 2}, {'Nikhil', 8}}, 2), {{'Akash', 2}, {'Akshat', 4}})\n    lu.assertEquals(candidate({{'Sanjeev', 11}, {'Angat', 5}, {'Akash', 3}, {'Nepin', 9}}, 3), {{'Akash', 3}, {'Angat', 5}, {'Nepin', 9}})\n    lu.assertEquals(candidate({{'tanmay', 14}, {'Amer', 11}, {'Ayesha', 9}, {'SKD', 16}}, 1), {{'Ayesha', 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "lua",
+    "prompt": "-- We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nlocal function extract_index_list(l1, l2, l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_index_list\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 7})\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 6, 5}, {0, 1, 2, 3, 4, 6, 7}), {1, 6})\n    lu.assertEquals(candidate({1, 1, 3, 4, 6, 5, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 6, 6, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "lua",
+    "prompt": "-- Write a function to find the second smallest number in a list.\nlocal function second_smallest(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = second_smallest\n    lu.assertEquals(candidate({1, 2, -8, -2, 0, -2}), -2)\n    lu.assertEquals(candidate({1, 1, -0.5, 0, 2, -2, -2}), -0.5)\n    lu.assertEquals(candidate({2, 2}), None)\n    lu.assertEquals(candidate({2, 2, 2}), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nlocal function text_match_zero_one(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_zero_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('dsabbbba'), true)\n    lu.assertEquals(candidate('asbbbba'), false)\n    lu.assertEquals(candidate('abaaa'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "lua",
+    "prompt": "-- Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nlocal function count_reverse_pairs(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_reverse_pairs\n    lu.assertEquals(candidate({'julia', 'best', 'tseb', 'for', 'ailuj'}), 2)\n    lu.assertEquals(candidate({'geeks', 'best', 'for', 'skeeg'}), 1)\n    lu.assertEquals(candidate({'makes', 'best', 'sekam', 'for', 'rof'}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a given string is a decimal number with a precision of 2.\nlocal function is_decimal(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_decimal\n    lu.assertEquals(candidate('123.11'), true)\n    lu.assertEquals(candidate('e666.86'), false)\n    lu.assertEquals(candidate('3.124587'), false)\n    lu.assertEquals(candidate('1.11'), true)\n    lu.assertEquals(candidate('1.1.11'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nlocal function find_tuples(test_list, K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_tuples\n    lu.assertEquals(candidate({{6, 24, 12}, {7, 9, 6}, {12, 18, 21}}, 6), {{6, 24, 12}})\n    lu.assertEquals(candidate({{5, 25, 30}, {4, 2, 3}, {7, 8, 9}}, 5), {{5, 25, 30}})\n    lu.assertEquals(candidate({{7, 9, 16}, {8, 16, 4}, {19, 17, 18}}, 4), {{8, 16, 4}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether a list of numbers contains only one distinct element or not.\nlocal function unique_Element(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_Element\n    lu.assertEquals(candidate({1, 1, 1}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nlocal function check_monthnumber_number(monthnum3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumber_number\n    lu.assertEquals(candidate(6), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(12), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlocal function find_min_diff(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_min_diff\n    lu.assertEquals(candidate({1, 5, 3, 19, 18, 25}, 6), 1)\n    lu.assertEquals(candidate({4, 3, 2, 6}, 4), 1)\n    lu.assertEquals(candidate({30, 5, 20, 9}, 4), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "lua",
+    "prompt": "-- Write a python function to count number of digits in a given string.\nlocal function number_ctr(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_ctr\n    lu.assertEquals(candidate('program2bedone'), 1)\n    lu.assertEquals(candidate('3wonders'), 1)\n    lu.assertEquals(candidate('123'), 3)\n    lu.assertEquals(candidate('3wond-1ers2'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "lua",
+    "prompt": "-- Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlocal function is_polite(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_polite\n    lu.assertEquals(candidate(7), 11)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(9), 13)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "lua",
+    "prompt": "-- Write a function to return a list of all pairs of consecutive items in a given list.\nlocal function pair_wise(l1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_wise\n    lu.assertEquals(candidate({1, 1, 2, 3, 3, 4, 4, 5}), {{1, 1}, {1, 2}, {2, 3}, {3, 3}, {3, 4}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), {{1, 5}, {5, 7}, {7, 9}, {9, 10}})\n    lu.assertEquals(candidate({5, 1, 9, 7, 10}), {{5, 1}, {1, 9}, {9, 7}, {7, 10}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 10}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nlocal function get_pairs_count(arr, sum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_pairs_count\n    lu.assertEquals(candidate({1, 1, 1, 1}, 2), 6)\n    lu.assertEquals(candidate({1, 5, 7, -1, 5}, 6), 3)\n    lu.assertEquals(candidate({1, -2, 3}, 1), 1)\n    lu.assertEquals(candidate({-1, -2, 3}, -3), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "lua",
+    "prompt": "-- Write a python function to get the difference between two lists.\nlocal function Diff(li1, li2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Diff\n    lu.assertEquals(candidate({10, 15, 20, 25, 30, 35, 40}, {25, 40, 35}), {10, 20, 30, 15})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 1}), {2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3}, {6, 7, 1}), {2, 3, 6, 7})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of fourth power of first n odd natural numbers.\nlocal function odd_num_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_num_sum\n    lu.assertEquals(candidate(2), 82)\n    lu.assertEquals(candidate(3), 707)\n    lu.assertEquals(candidate(4), 3108)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nlocal function check_expression(exp)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_expression\n    lu.assertEquals(candidate('{()}[{}]'), true)\n    lu.assertEquals(candidate('{()}[{]'), false)\n    lu.assertEquals(candidate('{()}[{}][]({})'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all the words with k length in the given string.\nlocal function remove_length(test_str, K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_length\n    lu.assertEquals(candidate('The person is most value tet', 3), 'person is most value')\n    lu.assertEquals(candidate('If you told me about this ok', 4), 'If you me about ok')\n    lu.assertEquals(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "lua",
+    "prompt": "-- Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nlocal function occurance_substring(text, pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = occurance_substring\n    lu.assertEquals(candidate('python programming, python language', 'python'), {'python', 0, 6})\n    lu.assertEquals(candidate('python programming,programming language', 'programming'), {'programming', 7, 18})\n    lu.assertEquals(candidate('python programming,programming language', 'language'), {'language', 31, 39})\n    lu.assertEquals(candidate('c++ programming, c++ language', 'python'), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether every odd index contains odd numbers of a given list.\nlocal function odd_position(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_position\n    lu.assertEquals(candidate({2, 1, 4, 3, 6, 7, 6, 3}), true)\n    lu.assertEquals(candidate({4, 1, 2}), true)\n    lu.assertEquals(candidate({1, 2, 3}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "lua",
+    "prompt": "-- Write a function to count those characters which have vowels as their neighbors in the given string.\nlocal function count_vowels(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_vowels\n    lu.assertEquals(candidate('bestinstareels'), 7)\n    lu.assertEquals(candidate('partofthejourneyistheend'), 12)\n    lu.assertEquals(candidate('amazonprime'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of non-repeated elements in a given list.\nlocal function find_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_sum\n    lu.assertEquals(candidate({1, 2, 3, 1, 1, 4, 5, 6}), 21)\n    lu.assertEquals(candidate({1, 10, 9, 4, 2, 10, 10, 45, 4}), 71)\n    lu.assertEquals(candidate({12, 10, 9, 45, 2, 10, 10, 45, 10}), 78)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "lua",
+    "prompt": "-- Write a function to pack consecutive duplicates of a given list elements into sublists.\nlocal function pack_consecutive_duplicates(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pack_consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {{0, 0}, {1}, {2}, {3}, {4, 4}, {5}, {6, 6, 6}, {7}, {8}, {9}, {4, 4}})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {{10, 10}, {15}, {19}, {18, 18}, {17}, {26, 26}, {17}, {18}, {10}})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {{'a', 'a'}, {'b'}, {'c'}, {'d', 'd'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "lua",
+    "prompt": "-- Write a python function to find whether a number is divisible by 11.\nlocal function is_Diff(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Diff\n    lu.assertEquals(candidate(12345), false)\n    lu.assertEquals(candidate(1212112), true)\n    lu.assertEquals(candidate(1212), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "lua",
+    "prompt": "-- Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nlocal function find_combinations(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_combinations\n    lu.assertEquals(candidate({{2, 4}, {6, 7}, {5, 1}, {6, 10}}), {{8, 11}, {7, 5}, {8, 14}, {11, 8}, {12, 17}, {11, 11}})\n    lu.assertEquals(candidate({{3, 5}, {7, 8}, {6, 2}, {7, 11}}), {{10, 13}, {9, 7}, {10, 16}, {13, 10}, {14, 19}, {13, 13}})\n    lu.assertEquals(candidate({{4, 6}, {8, 9}, {7, 3}, {8, 12}}), {{12, 15}, {11, 9}, {12, 18}, {15, 12}, {16, 21}, {15, 15}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nlocal function count_divisors(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_divisors\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(100), false)\n    lu.assertEquals(candidate(125), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nlocal function odd_length_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_length_sum\n    lu.assertEquals(candidate({1, 2, 4}), 14)\n    lu.assertEquals(candidate({1, 2, 1, 2}), 15)\n    lu.assertEquals(candidate({1, 7}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "lua",
+    "prompt": "-- Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nlocal function rgb_to_hsv(r, g, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rgb_to_hsv\n    lu.assertEquals(candidate(255, 255, 255), {0.0, 0.0, 100.0})\n    lu.assertEquals(candidate(0, 215, 0), {120.0, 100.0, 84.31372549019608})\n    lu.assertEquals(candidate(10, 215, 110), {149.26829268292684, 95.34883720930233, 84.31372549019608})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to find the product of first even and odd number of a given list.\nlocal function mul_even_odd(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mul_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "lua",
+    "prompt": "-- Write a function to convert tuple string to integer tuple.\nlocal function tuple_str_int(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_str_int\n    lu.assertEquals(candidate('(7, 8, 9)'), {7, 8, 9})\n    lu.assertEquals(candidate('(1, 2, 3)'), {1, 2, 3})\n    lu.assertEquals(candidate('(4, 5, 6)'), {4, 5, 6})\n    lu.assertEquals(candidate('(7, 81, 19)'), {7, 81, 19})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "lua",
+    "prompt": "-- Write a function to locate the right insertion point for a specified value in sorted order.\nlocal function right_insertion(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an a followed by three 'b'.\nlocal function text_match_three(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('caacabbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to create a new tuple from the given string and list.\nlocal function new_tuple(test_list, test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = new_tuple\n    lu.assertEquals(candidate({'WEB', 'is'}, 'best'), {'WEB', 'is', 'best'})\n    lu.assertEquals(candidate({'We', 'are'}, 'Developers'), {'We', 'are', 'Developers'})\n    lu.assertEquals(candidate({'Part', 'is'}, 'Wrong'), {'Part', 'is', 'Wrong'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether every even index contains even numbers of a given list.\nlocal function even_position(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_position\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3}), false)\n    lu.assertEquals(candidate({2, 1, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "lua",
+    "prompt": "-- Write a function to remove tuples from the given tuple.\nlocal function remove_nested(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_nested\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), {1, 5, 7, 10})\n    lu.assertEquals(candidate({2, 6, 8, {5, 7}, 11}), {2, 6, 8, 11})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, 12}), {3, 7, 9, 12})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, {5, 12}, 12}), {3, 7, 9, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of lists in a given number of lists.\nlocal function count_list(input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), 4)\n    lu.assertEquals(candidate({{1, 2}, {2, 3}, {4, 5}}), 3)\n    lu.assertEquals(candidate({{1, 0}, {2, 0}}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the last position of an element in a sorted array.\nlocal function last(arr, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last\n    lu.assertEquals(candidate({1, 2, 3}, 1), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, 4}, 1), 2)\n    lu.assertEquals(candidate({2, 3, 2, 3, 6, 8, 9}, 3), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nlocal function text_starta_endb(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_starta_endb\n    lu.assertEquals(candidate('aabbbb'), true)\n    lu.assertEquals(candidate('aabAbbbc'), false)\n    lu.assertEquals(candidate('accddbbjjj'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "lua",
+    "prompt": "-- Write function to find the sum of all items in the given dictionary.\nlocal function return_sum(dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = return_sum\n    lu.assertEquals(candidate({['a'] = 100, ['b'] = 200, ['c'] = 300}), 600)\n    lu.assertEquals(candidate({['a'] = 25, ['b'] = 18, ['c'] = 45}), 88)\n    lu.assertEquals(candidate({['a'] = 36, ['b'] = 39, ['c'] = 49}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of all odd natural numbers within the range l and r.\nlocal function sum_in_range(l, r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_in_range\n    lu.assertEquals(candidate(2, 5), 8)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 13), 40)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the sum of an array.\nlocal function _sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = _sum\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({15, 12, 13, 10}), 50)\n    lu.assertEquals(candidate({0, 1, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "lua",
+    "prompt": "-- Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlocal function left_rotate(n, d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_rotate\n    lu.assertEquals(candidate(16, 2), 64)\n    lu.assertEquals(candidate(10, 2), 40)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(1, 3), 8)\n    lu.assertEquals(candidate(5, 3), 40)\n    lu.assertEquals(candidate(29, 3), 232)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "lua",
+    "prompt": "-- Write a python function to check whether the length of the word is odd or not.\nlocal function word_len(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = word_len\n    lu.assertEquals(candidate('Hadoop'), false)\n    lu.assertEquals(candidate('great'), true)\n    lu.assertEquals(candidate('structure'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all whitespaces from a string.\nlocal function remove_all_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_all_spaces\n    lu.assertEquals(candidate('python  program'), 'pythonprogram')\n    lu.assertEquals(candidate('python   programming    language'), 'pythonprogramminglanguage')\n    lu.assertEquals(candidate('python                     program'), 'pythonprogram')\n    lu.assertEquals(candidate('   python                     program'), 'pythonprogram')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of equal numbers from three given integers.\nlocal function test_three_equal(x, y, z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_three_equal\n    lu.assertEquals(candidate(1, 1, 1), 3)\n    lu.assertEquals(candidate(-1, -2, -3), 0)\n    lu.assertEquals(candidate(1, 2, 2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "lua",
+    "prompt": "-- Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nlocal function count_rotation(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_rotation\n    lu.assertEquals(candidate({3, 2, 1}), 1)\n    lu.assertEquals(candidate({4, 5, 1, 2, 3}), 2)\n    lu.assertEquals(candidate({7, 8, 9, 1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 2, 3}), 0)\n    lu.assertEquals(candidate({1, 3, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nlocal function is_perfect_square(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_perfect_square\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(36), true)\n    lu.assertEquals(candidate(14), false)\n    lu.assertEquals(candidate(196), true)\n    lu.assertEquals(candidate(125), false)\n    lu.assertEquals(candidate(15625), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the product of numbers in a list is even or not.\nlocal function is_product_even(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_product_even\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 4}), true)\n    lu.assertEquals(candidate({1, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "lua",
+    "prompt": "-- Write a function that returns the list in a list of lists whose sum of elements is the highest.\nlocal function max_sum_list(lists)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_list\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {10, 11, 12})\n    lu.assertEquals(candidate({{3, 2, 1}, {6, 5, 4}, {12, 11, 10}}), {12, 11, 10})\n    lu.assertEquals(candidate({{2, 3, 1}}), {2, 3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "lua",
+    "prompt": "-- Write a function to find maximum run of uppercase characters in the given string.\nlocal function max_run_uppercase(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_run_uppercase\n    lu.assertEquals(candidate('GeMKSForGERksISBESt'), 5)\n    lu.assertEquals(candidate('PrECIOusMOVemENTSYT'), 6)\n    lu.assertEquals(candidate('GooGLEFluTTER'), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the first odd number in a given list of numbers.\nlocal function first_odd(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_odd\n    lu.assertEquals(candidate({1, 3, 5}), 1)\n    lu.assertEquals(candidate({2, 4, 1, 3}), 1)\n    lu.assertEquals(candidate({8, 9, 1}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given tuples contain the k or not.\nlocal function check_K(test_tup, K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_K\n    lu.assertEquals(candidate({10, 4, 5, 6, 8}, 6), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 7), false)\n    lu.assertEquals(candidate({7, 8, 9, 44, 11, 12}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "lua",
+    "prompt": "-- Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nlocal function check_smaller(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_smaller\n    lu.assertEquals(candidate({1, 2, 3}, {2, 3, 4}), false)\n    lu.assertEquals(candidate({4, 5, 6}, {3, 4, 5}), true)\n    lu.assertEquals(candidate({11, 12, 13}, {10, 11, 12}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth tetrahedral number.\nlocal function tetrahedral_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tetrahedral_number\n    lu.assertEquals(candidate(5), 35)\n    lu.assertEquals(candidate(6), 56)\n    lu.assertEquals(candidate(7), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nlocal function get_Char(strr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Char\n    lu.assertEquals(candidate('abc'), 'f')\n    lu.assertEquals(candidate('gfg'), 't')\n    lu.assertEquals(candidate('ab'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth number in the newman conway sequence.\nlocal function sequence(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequence\n    lu.assertEquals(candidate(10), 6)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find nth centered hexagonal number.\nlocal function centered_hexagonal_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = centered_hexagonal_number\n    lu.assertEquals(candidate(10), 271)\n    lu.assertEquals(candidate(2), 7)\n    lu.assertEquals(candidate(9), 217)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "lua",
+    "prompt": "-- Write a function to merge three dictionaries into a single dictionary.\nlocal function merge_dictionaries_three(dict1, dict2, dict3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_dictionaries_three\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['O'] = 'Orange', ['W'] = 'White', ['B'] = 'Black'}), {['B'] = 'Black', ['R'] = 'Red', ['P'] = 'Pink', ['G'] = 'Green', ['W'] = 'White', ['O'] = 'Orange'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['L'] = 'lavender', ['B'] = 'Blue'}), {['W'] = 'White', ['P'] = 'Pink', ['B'] = 'Black', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['L'] = 'lavender', ['B'] = 'Blue'}, {['G'] = 'Green', ['W'] = 'White'}), {['B'] = 'Black', ['P'] = 'Pink', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender', ['W'] = 'White'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "lua",
+    "prompt": "-- Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nlocal function freq_count(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = freq_count\n    lu.assertEquals(candidate({10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), {[10] = 4, [20] = 4, [40] = 2, [50] = 2, [30] = 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), {[1] = 3, [2] = 2, [3] = 3, [4] = 3})\n    lu.assertEquals(candidate({5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), {[10] = 1, [5] = 3, [6] = 2, [7] = 2, [4] = 2, [9] = 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the closest smaller number than n.\nlocal function closest_num(N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_num\n    lu.assertEquals(candidate(11), 10)\n    lu.assertEquals(candidate(7), 6)\n    lu.assertEquals(candidate(12), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to find squares of individual elements in a list.\nlocal function square_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}), {100, 400, 900})\n    lu.assertEquals(candidate({12, 15}), {144, 225})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the length of the longest word.\nlocal function len_log(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = len_log\n    lu.assertEquals(candidate({'python', 'PHP', 'bigdata'}), 7)\n    lu.assertEquals(candidate({'a', 'ab', 'abc'}), 3)\n    lu.assertEquals(candidate({'small', 'big', 'tall'}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "lua",
+    "prompt": "-- Write a function to check if a string is present as a substring in a given list of string values.\nlocal function find_substring(str1, sub_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_substring\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ack'), true)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'abc'), false)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ange'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is undulating or not.\nlocal function is_undulating(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_undulating\n    lu.assertEquals(candidate(1212121), true)\n    lu.assertEquals(candidate(1991), false)\n    lu.assertEquals(candidate(121), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the value of 'a' to the power 'b'.\nlocal function power(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power\n    lu.assertEquals(candidate(3, 4), 81)\n    lu.assertEquals(candidate(2, 3), 8)\n    lu.assertEquals(candidate(5, 5), 3125)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "lua",
+    "prompt": "-- Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nlocal function index_minimum(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_minimum\n    lu.assertEquals(candidate({{'Rash', 143}, {'Manjeet', 200}, {'Varsha', 100}}), 'Varsha')\n    lu.assertEquals(candidate({{'Yash', 185}, {'Dawood', 125}, {'Sanya', 175}}), 'Dawood')\n    lu.assertEquals(candidate({{'Sai', 345}, {'Salman', 145}, {'Ayesha', 96}}), 'Ayesha')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the length of the smallest list in a list of lists.\nlocal function Find_Min_Length(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min_Length\n    lu.assertEquals(candidate({{1}, {1, 2}}), 1)\n    lu.assertEquals(candidate({{1, 2}, {1, 2, 3}, {1, 2, 3, 4}}), 2)\n    lu.assertEquals(candidate({{3, 3, 3}, {4, 4, 4, 4}}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the number of divisors of a given integer.\nlocal function divisor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisor\n    lu.assertEquals(candidate(15), 4)\n    lu.assertEquals(candidate(12), 6)\n    lu.assertEquals(candidate(9), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nlocal function frequency_lists(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency_lists\n    lu.assertEquals(candidate({{1, 2, 3, 2}, {4, 5, 6, 2}, {7, 8, 9, 5}}), {[1] = 1, [2] = 3, [3] = 1, [4] = 1, [5] = 2, [6] = 1, [7] = 1, [8] = 1, [9] = 1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}), {[1] = 1, [2] = 1, [3] = 1, [4] = 1, [5] = 1, [6] = 1, [7] = 1, [8] = 1, [9] = 1, [10] = 1, [11] = 1, [12] = 1})\n    lu.assertEquals(candidate({{20, 30, 40, 17}, {18, 16, 14, 13}, {10, 20, 30, 40}}), {[20] = 2, [30] = 2, [40] = 2, [17] = 1, [18] = 1, [16] = 1, [14] = 1, [13] = 1, [10] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nlocal function decimal_to_binary(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(8), '1000')\n    lu.assertEquals(candidate(18), '10010')\n    lu.assertEquals(candidate(7), '111')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "lua",
+    "prompt": "-- Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nlocal function find_Rotations(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Rotations\n    lu.assertEquals(candidate('aaaa'), 1)\n    lu.assertEquals(candidate('ab'), 2)\n    lu.assertEquals(candidate('abc'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/mbpp-lua-reworded.json
+++ b/prompts/mbpp-lua-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "lua",
-    "prompt": "-- Write a function to find the length of the longest palindromic subsequence in the given string.\nlocal function lps(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lps\n    lu.assertEquals(candidate('TENS FOR TENS'), 5)\n    lu.assertEquals(candidate('CARDIO FOR CARDS'), 7)\n    lu.assertEquals(candidate('PART OF THE JOURNEY IS PART'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all whitespaces from the given string.\nlocal function remove_whitespaces(text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_whitespaces\n    lu.assertEquals(candidate(' Google    Flutter '), 'GoogleFlutter')\n    lu.assertEquals(candidate(' Google    Dart '), 'GoogleDart')\n    lu.assertEquals(candidate(' iOS    Swift '), 'iOSSwift')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a specified table is sorted or not.\nlocal function issort_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = issort_list\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), true)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), false)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 15, 14, 20}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "lua",
-    "prompt": "-- Write a function to count bidirectional table pairs.\nlocal function count_bidirectional(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_bidirectional\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 3)\n    lu.assertEquals(candidate({{5, 6}, {1, 3}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 2)\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 2}, {6, 5}, {2, 1}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "lua",
-    "prompt": "-- Write a function to find the surface area of a cube of a given size.\nlocal function surfacearea_cube(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cube\n    lu.assertEquals(candidate(5), 150)\n    lu.assertEquals(candidate(3), 54)\n    lu.assertEquals(candidate(10), 600)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "lua",
     "prompt": "-- Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nlocal function next_smallest_palindrome(num)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_smallest_palindrome\n    lu.assertEquals(candidate(99), 101)\n    lu.assertEquals(candidate(1221), 1331)\n    lu.assertEquals(candidate(120), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the cube sum of first n even natural numbers.\nlocal function cube_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_Sum\n    lu.assertEquals(candidate(2), 72)\n    lu.assertEquals(candidate(3), 288)\n    lu.assertEquals(candidate(4), 800)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of xor of all pairs of numbers in the given table.\nlocal function pair_xor_Sum(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_xor_Sum\n    lu.assertEquals(candidate({5, 9, 7, 6}, 4), 47)\n    lu.assertEquals(candidate({7, 3, 5}, 3), 12)\n    lu.assertEquals(candidate({7, 3}, 2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given table represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-table-represents-a-binary-heap/\nlocal function check_min_heap(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_min_heap\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 10, 15}), true)\n    lu.assertEquals(candidate({2, 10, 4, 5, 3, 15}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the first digit of a given number.\nlocal function first_Digit(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_Digit\n    lu.assertEquals(candidate(123), 1)\n    lu.assertEquals(candidate(456), 4)\n    lu.assertEquals(candidate(12), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the first non-repeated character in a given string.\nlocal function first_non_repeating_character(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_non_repeating_character\n    lu.assertEquals(candidate('abcabc'), None)\n    lu.assertEquals(candidate('abc'), 'a')\n    lu.assertEquals(candidate('ababc'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "lua",
-    "prompt": "-- Write a function to convert degrees to radians.\nlocal function radian_degree(degree)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = radian_degree\n    lu.assertEquals(candidate(90), 1.5707963267948966)\n    lu.assertEquals(candidate(60), 1.0471975511965976)\n    lu.assertEquals(candidate(120), 2.0943951023931953)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum product subtable of the given table.\nlocal function max_subarray_product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_subarray_product\n    lu.assertEquals(candidate({1, -2, -3, 0, 7, -8, -2}), 112)\n    lu.assertEquals(candidate({6, -3, -10, 0, 2}), 180)\n    lu.assertEquals(candidate({-2, -40, 0, -2, -3}), 80)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "lua",
-    "prompt": "-- Write a function to convert more than one table to nested table.\nlocal function convert_list_dictionary(l1, l2, l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert_list_dictionary\n    lu.assertEquals(candidate({'S001', 'S002', 'S003', 'S004'}, {'Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'}, {85, 98, 89, 92}), {{['S001'] = {['Adina Park'] = 85}}, {['S002'] = {['Leyton Marsh'] = 98}}, {['S003'] = {['Duncan Boyle'] = 89}}, {['S004'] = {['Saim Richards'] = 92}}})\n    lu.assertEquals(candidate({'abc', 'def', 'ghi', 'jkl'}, {'python', 'program', 'language', 'programs'}, {100, 200, 300, 400}), {{['abc'] = {['python'] = 100}}, {['def'] = {['program'] = 200}}, {['ghi'] = {['language'] = 300}}, {['jkl'] = {['programs'] = 400}}})\n    lu.assertEquals(candidate({'A1', 'A2', 'A3', 'A4'}, {'java', 'C', 'C++', 'DBMS'}, {10, 20, 30, 40}), {{['A1'] = {['java'] = 10}}, {['A2'] = {['C'] = 20}}, {['A3'] = {['C++'] = 30}}, {['A4'] = {['DBMS'] = 40}}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find smallest number in a table.\nlocal function smallest_num(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_num\n    lu.assertEquals(candidate({10, 20, 1, 45, 99}), 1)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\n    lu.assertEquals(candidate({45, 46, 50, 60}), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/luathon-exercises/re/luathon-re-exercise-3.php\nlocal function text_match_zero_one(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_zero_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('dsabbbba'), true)\n    lu.assertEquals(candidate('asbbbba'), false)\n    lu.assertEquals(candidate('abaaa'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find nth bell number.\nlocal function bell_Number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_Number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "lua",
-    "prompt": "-- Write a function to find cubes of individual elements in a table.\nlocal function cube_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 8, 27, 64, 125, 216, 343, 512, 729, 1000})\n    lu.assertEquals(candidate({10, 20, 30}), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}), {1728, 3375})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the last digit in factorial of a given number.\nlocal function last_Digit_Factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit_Factorial\n    lu.assertEquals(candidate(4), 4)\n    lu.assertEquals(candidate(21), 0)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find even numbers from a table of numbers.\nlocal function Split(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {2, 4})\n    lu.assertEquals(candidate({4, 5, 6, 7, 8, 0, 1}), {4, 6, 8, 0})\n    lu.assertEquals(candidate({8, 12, 15, 19}), {8, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given integer is a prime number.\nlocal function prime_num(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_num\n    lu.assertEquals(candidate(13), true)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(-1010), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to find tables which have all elements divisible by k from the given table of tables.\nlocal function find_tuples(test_list, K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_tuples\n    lu.assertEquals(candidate({{6, 24, 12}, {7, 9, 6}, {12, 18, 21}}, 6), {{6, 24, 12}})\n    lu.assertEquals(candidate({{5, 25, 30}, {4, 2, 3}, {7, 8, 9}}, 5), {{5, 25, 30}})\n    lu.assertEquals(candidate({{7, 9, 16}, {8, 16, 4}, {19, 17, 18}}, 4), {{8, 16, 4}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "lua",
-    "prompt": "-- Write a function to caluclate the area of a tetrahedron.\nlocal function area_tetrahedron(side)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = area_tetrahedron\n    lu.assertEquals(candidate(3), 15.588457268119894)\n    lu.assertEquals(candidate(20), 692.8203230275509)\n    lu.assertEquals(candidate(10), 173.20508075688772)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given number is even or not.\nlocal function is_Even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Even\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(2), true)\n    lu.assertEquals(candidate(3), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of positive numbers in a table.\nlocal function pos_count(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pos_count\n    lu.assertEquals(candidate({1, -2, 3, -4}), 2)\n    lu.assertEquals(candidate({3, 4, 5, -1}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "lua",
-    "prompt": "-- Write a function to get all lucid numbers smaller than or equal to a given integer.\nlocal function get_ludic(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_ludic\n    lu.assertEquals(candidate(10), {1, 2, 3, 5, 7})\n    lu.assertEquals(candidate(25), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25})\n    lu.assertEquals(candidate(45), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlocal function find_Index(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Index\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 14)\n    lu.assertEquals(candidate(4), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to reverse a table upto a given position.\nlocal function reverse_Array_Upto_K(input, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_Array_Upto_K\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 4), {4, 3, 2, 1, 5, 6})\n    lu.assertEquals(candidate({4, 5, 6, 7}, 2), {5, 4, 6, 7})\n    lu.assertEquals(candidate({9, 8, 7, 6, 5}, 3), {7, 8, 9, 6, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a table of tables using the second value of each table.\nlocal function subject_marks(subjectmarks)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = subject_marks\n    lu.assertEquals(candidate({{'English', 88}, {'Science', 90}, {'Maths', 97}, {'Social sciences', 82}}), {{'Social sciences', 82}, {'English', 88}, {'Science', 90}, {'Maths', 97}})\n    lu.assertEquals(candidate({{'Telugu', 49}, {'Hindhi', 54}, {'Social', 33}}), {{'Social', 33}, {'Telugu', 49}, {'Hindhi', 54}})\n    lu.assertEquals(candidate({{'Physics', 96}, {'Chemistry', 97}, {'Biology', 45}}), {{'Biology', 45}, {'Physics', 96}, {'Chemistry', 97}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "lua",
-    "prompt": "-- Write a function to remove characters from the first string which are present in the second string.\nlocal function remove_dirty_chars(string, second_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_dirty_chars\n    lu.assertEquals(candidate('probasscurve', 'pros'), 'bacuve')\n    lu.assertEquals(candidate('digitalindia', 'talent'), 'digiidi')\n    lu.assertEquals(candidate('exoticmiles', 'toxic'), 'emles')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to round every number of a given table of numbers and print the total sum multiplied by the length of the table.\nlocal function round_and_sum(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = round_and_sum\n    lu.assertEquals(candidate({22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5}), 243)\n    lu.assertEquals(candidate({5, 2, 9, 24.3, 29}), 345)\n    lu.assertEquals(candidate({25.0, 56.7, 89.2}), 513)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "lua",
-    "prompt": "-- Write a function to find the item with maximum frequency in a given table.\nlocal function max_occurrences(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_occurrences\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), 2)\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), 8)\n    lu.assertEquals(candidate({10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a given string is a decimal number with a precision of 2.\nlocal function is_decimal(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_decimal\n    lu.assertEquals(candidate('123.11'), true)\n    lu.assertEquals(candidate('e666.86'), false)\n    lu.assertEquals(candidate('3.124587'), false)\n    lu.assertEquals(candidate('1.11'), true)\n    lu.assertEquals(candidate('1.1.11'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and integer n and filters the table to only include entries with values greater than or equal to n.\nlocal function dict_filter(dict, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dict_filter\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 170), {['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 180), {['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 190), {['Pierre Cox'] = 190})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of even numbers at even positions of a table.\nlocal function sum_even_and_even_index(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_even_and_even_index\n    lu.assertEquals(candidate({5, 6, 12, 1, 18, 8}), 30)\n    lu.assertEquals(candidate({3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), 26)\n    lu.assertEquals(candidate({5, 6, 12, 1}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the sum of the largest contiguous subtable in the given table.\nlocal function max_sub_array_sum(a, size)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum\n    lu.assertEquals(candidate({-2, -3, 4, -1, -2, 1, 5, -3}, 8), 7)\n    lu.assertEquals(candidate({-3, -4, 5, -2, -3, 2, 6, -4}, 8), 8)\n    lu.assertEquals(candidate({-4, -5, 6, -3, -4, 3, 7, -5}, 8), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "lua",
-    "prompt": "-- Write a function to find the intersection of two tables.\nlocal function intersection_array(array_nums1, array_nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection_array\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {1, 2, 4, 8, 9}), {1, 2, 8, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {3, 5, 7, 9}), {3, 5, 7, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {10, 20, 30, 40}), {10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and an integer L and splits the given table into two parts where the length of the first part of the table is L, and returns the resulting tables in a table.\nlocal function split_two_parts(list1, L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_two_parts\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {{1, 1, 2}, {3, 4, 4, 5, 1}})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 2), {{'a', 'b'}, {'c', 'd'}})\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}, 4), {{'p', 'y', 't', 'h'}, {'o', 'n'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "lua",
-    "prompt": "-- Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nlocal function find_literals(text, pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_literals\n    lu.assertEquals(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), {'fox', 16, 19})\n    lu.assertEquals(candidate('Its been a very crazy procedure right', 'crazy'), {'crazy', 16, 21})\n    lu.assertEquals(candidate('Hardest choices required strongest will', 'will'), {'will', 35, 39})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the volume of a triangular prism.\nlocal function find_Volume(l, b, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Volume\n    lu.assertEquals(candidate(10, 8, 6), 240)\n    lu.assertEquals(candidate(3, 2, 2), 6)\n    lu.assertEquals(candidate(1, 2, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlocal function wind_chill(v, t)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = wind_chill\n    lu.assertEquals(candidate(120, 35), 40)\n    lu.assertEquals(candidate(40, 20), 19)\n    lu.assertEquals(candidate(10, 8), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "lua",
-    "prompt": "-- Write a function to find the ascii value of a character.\nlocal function ascii_value(k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = ascii_value\n    lu.assertEquals(candidate('A'), 65)\n    lu.assertEquals(candidate('R'), 82)\n    lu.assertEquals(candidate('S'), 83)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether all the characters are same or not.\nlocal function all_Characters_Same(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Characters_Same\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('aaa'), true)\n    lu.assertEquals(candidate('data'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "lua",
-    "prompt": "-- Write a function to move all the numbers to the end of the given string.\nlocal function move_num(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_num\n    lu.assertEquals(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')\n    lu.assertEquals(candidate('Avengers124Assemble'), 'AvengersAssemble124')\n    lu.assertEquals(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the length of the word is odd or not.\nlocal function word_len(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = word_len\n    lu.assertEquals(candidate('Hadoop'), false)\n    lu.assertEquals(candidate('great'), true)\n    lu.assertEquals(candidate('structure'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "lua",
-    "prompt": "-- Write a function to drop empty items from a given table.\nlocal function drop_empty(dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = drop_empty\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = 'Green', ['c3'] = None}), {['c1'] = 'Red', ['c2'] = 'Green'})\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = None, ['c3'] = None}), {['c1'] = 'Red'})\n    lu.assertEquals(candidate({['c1'] = None, ['c2'] = 'Green', ['c3'] = None}), {['c2'] = 'Green'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and an element and inserts the element before each element in the table, and returns the resulting table.\nlocal function insert_element(list, element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = insert_element\n    lu.assertEquals(candidate({'Red', 'Green', 'Black'}, 'c'), {'c', 'Red', 'c', 'Green', 'c', 'Black'})\n    lu.assertEquals(candidate({'python', 'java'}, 'program'), {'program', 'python', 'program', 'java'})\n    lu.assertEquals(candidate({'happy', 'sad'}, 'laugh'), {'laugh', 'happy', 'laugh', 'sad'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "lua",
-    "prompt": "-- Write a function to remove lowercase substrings from a given string.\nlocal function remove_lowercase(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_lowercase\n    lu.assertEquals(candidate('PYTHon'), 'PYTH')\n    lu.assertEquals(candidate('FInD'), 'FID')\n    lu.assertEquals(candidate('STRinG'), 'STRG')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of set bits (binary digits with value 1) in a given number.\nlocal function count_Set_Bits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Set_Bits\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 1)\n    lu.assertEquals(candidate(6), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "lua",
-    "prompt": "-- Write a function to extract only the rear index element of each string in the given table.\nlocal function extract_rear(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_rear\n    lu.assertEquals(candidate({'Mers', 'for', 'Vers'}), {'s', 'r', 's'})\n    lu.assertEquals(candidate({'Avenge', 'for', 'People'}), {'e', 'r', 'e'})\n    lu.assertEquals(candidate({'Gotta', 'get', 'go'}), {'a', 't', 'o'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of occurence of the string 'std' in a given string.\nlocal function count_occurance(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_occurance\n    lu.assertEquals(candidate('letstdlenstdporstd'), 3)\n    lu.assertEquals(candidate('truststdsolensporsd'), 1)\n    lu.assertEquals(candidate('makestdsostdworthit'), 2)\n    lu.assertEquals(candidate('stds'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given tables contain the k or not.\nlocal function check_K(test_tup, K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_K\n    lu.assertEquals(candidate({10, 4, 5, 6, 8}, 6), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 7), false)\n    lu.assertEquals(candidate({7, 8, 9, 44, 11, 12}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to interleave 3 tables of the same length into a single flat table.\nlocal function interleave_lists(list1, list2, list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = interleave_lists\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}, {10, 20, 30, 40, 50, 60, 70}, {100, 200, 300, 400, 500, 600, 700}), {1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700})\n    lu.assertEquals(candidate({10, 20}, {15, 2}, {5, 10}), {10, 15, 5, 20, 2, 10})\n    lu.assertEquals(candidate({11, 44}, {10, 15}, {20, 5}), {11, 10, 20, 44, 15, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('python_program'), 'PythonProgram')\n    lu.assertEquals(candidate('python_language'), 'PythonLanguage')\n    lu.assertEquals(candidate('programming_language'), 'ProgrammingLanguage')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of equal numbers from three given integers.\nlocal function test_three_equal(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_three_equal\n    lu.assertEquals(candidate(1, 1, 1), 3)\n    lu.assertEquals(candidate(-1, -2, -3), 0)\n    lu.assertEquals(candidate(1, 2, 2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of all odd length subtables. https://www.geeksforgeeks.org/sum-of-all-odd-length-subtables/\nlocal function odd_length_sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_length_sum\n    lu.assertEquals(candidate({1, 2, 4}), 14)\n    lu.assertEquals(candidate({1, 2, 1, 2}), 15)\n    lu.assertEquals(candidate({1, 7}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find the number of ways to partition a set of Bell numbers.\nlocal function bell_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(10), 115975)\n    lu.assertEquals(candidate(56), 6775685320645824322581483068371419745979053216268760300)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "lua",
-    "prompt": "-- Write a function to find the area of a rectangle.\nlocal function rectangle_area(l, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rectangle_area\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(10, 5), 50)\n    lu.assertEquals(candidate(4, 2), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "lua",
-    "prompt": "-- Write a function to find sum and average of first n natural numbers.\nlocal function sum_average(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_average\n    lu.assertEquals(candidate(10), {55, 5.5})\n    lu.assertEquals(candidate(15), {120, 8.0})\n    lu.assertEquals(candidate(20), {210, 10.5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two tables and performs mathematical division operation element-wise across the given tables.\nlocal function division_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = division_elements\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {2, 2, 2, 3})\n    lu.assertEquals(candidate({12, 6, 8, 16}, {6, 3, 4, 4}), {2, 2, 2, 4})\n    lu.assertEquals(candidate({20, 14, 36, 18}, {5, 7, 6, 9}), {4, 2, 6, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to get the sum of the digits of a non-negative integer.\nlocal function sum_digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_digits\n    lu.assertEquals(candidate(345), 12)\n    lu.assertEquals(candidate(12), 3)\n    lu.assertEquals(candidate(97), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "lua",
-    "prompt": "-- Given a table of tables, write a function that returns the first value of the table with the smallest second value.\nlocal function index_minimum(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_minimum\n    lu.assertEquals(candidate({{'Rash', 143}, {'Manjeet', 200}, {'Varsha', 100}}), 'Varsha')\n    lu.assertEquals(candidate({{'Yash', 185}, {'Dawood', 125}, {'Sanya', 175}}), 'Dawood')\n    lu.assertEquals(candidate({{'Sai', 345}, {'Salman', 145}, {'Ayesha', 96}}), 'Ayesha')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "lua",
-    "prompt": "-- Write a function to divide two tables element wise.\nlocal function div_list(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = div_list\n    lu.assertEquals(candidate({4, 5, 6}, {1, 2, 3}), {4.0, 2.5, 2.0})\n    lu.assertEquals(candidate({3, 2}, {1, 4}), {3.0, 0.5})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {1.8, 1.7142857142857142})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find the table with maximum length.\nlocal function max_length_list(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length_list\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5}, {1, 2, 3, 4}, {1, 2, 3}, {1, 2}, {1}}), {5, {1, 2, 3, 4, 5}})\n    lu.assertEquals(candidate({{3, 4, 5}, {6, 7, 8, 9}, {10, 11, 12}}), {4, {6, 7, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find all possible combinations of the elements of a given table.\nlocal function combinations_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_list\n    lu.assertEquals(candidate({'orange', 'red', 'green', 'blue'}), {{}, {'orange'}, {'red'}, {'red', 'orange'}, {'green'}, {'green', 'orange'}, {'green', 'red'}, {'green', 'red', 'orange'}, {'blue'}, {'blue', 'orange'}, {'blue', 'red'}, {'blue', 'red', 'orange'}, {'blue', 'green'}, {'blue', 'green', 'orange'}, {'blue', 'green', 'red'}, {'blue', 'green', 'red', 'orange'}})\n    lu.assertEquals(candidate({'red', 'green', 'blue', 'white', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'blue'}, {'blue', 'red'}, {'blue', 'green'}, {'blue', 'green', 'red'}, {'white'}, {'white', 'red'}, {'white', 'green'}, {'white', 'green', 'red'}, {'white', 'blue'}, {'white', 'blue', 'red'}, {'white', 'blue', 'green'}, {'white', 'blue', 'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'black', 'blue'}, {'black', 'blue', 'red'}, {'black', 'blue', 'green'}, {'black', 'blue', 'green', 'red'}, {'black', 'white'}, {'black', 'white', 'red'}, {'black', 'white', 'green'}, {'black', 'white', 'green', 'red'}, {'black', 'white', 'blue'}, {'black', 'white', 'blue', 'red'}, {'black', 'white', 'blue', 'green'}, {'black', 'white', 'blue', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'blue'}, {'orange', 'blue', 'red'}, {'orange', 'blue', 'green'}, {'orange', 'blue', 'green', 'red'}, {'orange', 'white'}, {'orange', 'white', 'red'}, {'orange', 'white', 'green'}, {'orange', 'white', 'green', 'red'}, {'orange', 'white', 'blue'}, {'orange', 'white', 'blue', 'red'}, {'orange', 'white', 'blue', 'green'}, {'orange', 'white', 'blue', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}, {'orange', 'black', 'blue'}, {'orange', 'black', 'blue', 'red'}, {'orange', 'black', 'blue', 'green'}, {'orange', 'black', 'blue', 'green', 'red'}, {'orange', 'black', 'white'}, {'orange', 'black', 'white', 'red'}, {'orange', 'black', 'white', 'green'}, {'orange', 'black', 'white', 'green', 'red'}, {'orange', 'black', 'white', 'blue'}, {'orange', 'black', 'white', 'blue', 'red'}, {'orange', 'black', 'white', 'blue', 'green'}, {'orange', 'black', 'white', 'blue', 'green', 'red'}})\n    lu.assertEquals(candidate({'red', 'green', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of the largest and smallest value in a given table.\nlocal function big_sum(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_sum\n    lu.assertEquals(candidate({1, 2, 3}), 4)\n    lu.assertEquals(candidate({-1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({2, 3, 6}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to return the negative numbers in a table.\nlocal function neg_nos(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = neg_nos\n    lu.assertEquals(candidate({-1, 4, 5, -6}), {-1, -6})\n    lu.assertEquals(candidate({-1, -2, 3, 4}), {-1, -2})\n    lu.assertEquals(candidate({-7, -6, 8, 9}), {-7, -6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the highest power of 2 that is less than or equal to n.\nlocal function highest_Power_of_2(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = highest_Power_of_2\n    lu.assertEquals(candidate(10), 8)\n    lu.assertEquals(candidate(19), 16)\n    lu.assertEquals(candidate(32), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether a table contains the given subtable or not.\nlocal function is_sublist(l, s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sublist\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {3, 7}), false)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {4, 3}), true)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {1, 6}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "lua",
-    "prompt": "-- Write a function to subtract two tables element-wise.\nlocal function sub_list(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sub_list\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), {-3, -3, -3})\n    lu.assertEquals(candidate({1, 2}, {3, 4}), {-2, -2})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {40, 50})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given two integers have opposite sign or not.\nlocal function opposite_Signs(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = opposite_Signs\n    lu.assertEquals(candidate(1, -2), true)\n    lu.assertEquals(candidate(3, 2), false)\n    lu.assertEquals(candidate(-10, -10), false)\n    lu.assertEquals(candidate(-2, 2), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "lua",
-    "prompt": "-- Write a function which takes two tables of the same length and performs the element wise modulo.\nlocal function tuple_modulo(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_modulo\n    lu.assertEquals(candidate({10, 4, 5, 6}, {5, 6, 7, 5}), {0, 4, 5, 1})\n    lu.assertEquals(candidate({11, 5, 6, 7}, {6, 7, 8, 6}), {5, 5, 6, 1})\n    lu.assertEquals(candidate({12, 6, 7, 8}, {7, 8, 9, 7}), {5, 6, 7, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to find the difference of the first even and first odd number of a given table.\nlocal function diff_even_odd(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = diff_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 1)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "lua",
-    "prompt": "-- Write a function to sort each subtable of strings in a given table of tables.\nlocal function sort_sublists(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}}), {{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'d', 'c'}, {'g', 'h'}, {'f', 'e'}}), {{'a', 'b'}, {'c', 'd'}, {'g', 'h'}, {'e', 'f'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the last digit of a given number.\nlocal function last_Digit(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit\n    lu.assertEquals(candidate(123), 3)\n    lu.assertEquals(candidate(25), 5)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of fourth power of first n odd natural numbers.\nlocal function odd_num_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_num_sum\n    lu.assertEquals(candidate(2), 82)\n    lu.assertEquals(candidate(3), 707)\n    lu.assertEquals(candidate(4), 3108)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a table to a string.\nlocal function tup_string(tup1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tup_string\n    lu.assertEquals(candidate({'e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'}), 'exercises')\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}), 'python')\n    lu.assertEquals(candidate({'p', 'r', 'o', 'g', 'r', 'a', 'm'}), 'program')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all elements from a given table present in another table.\nlocal function remove_elements(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_elements\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {1, 3, 5, 7}), {2, 4, 6, 8, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 7}), {1, 2, 3, 4, 6, 8, 9, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether any value in a sequence exists in a sequence or not.\nlocal function overlapping(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = overlapping\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), false)\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), false)\n    lu.assertEquals(candidate({1, 4, 5}, {1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to identify non-prime numbers.\nlocal function is_not_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_not_prime\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(35), true)\n    lu.assertEquals(candidate(37), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum value in a given heterogeneous table.\nlocal function max_val(listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 5)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 25)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 50)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum of the negative numbers of a given table of numbers.\nlocal function sum_negativenum(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_negativenum\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), -32)\n    lu.assertEquals(candidate({10, 15, -14, 13, -18, 12, -20}), -52)\n    lu.assertEquals(candidate({19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), -894)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the minimum number of rotations (greater than 0) required to get the same string.\nlocal function find_Rotations(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Rotations\n    lu.assertEquals(candidate('aaaa'), 1)\n    lu.assertEquals(candidate('ab'), 2)\n    lu.assertEquals(candidate('abc'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nlocal function change_date_format(dt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_date_format\n    lu.assertEquals(candidate('2026-01-02'), '02-01-2026')\n    lu.assertEquals(candidate('2020-11-13'), '13-11-2020')\n    lu.assertEquals(candidate('2021-04-26'), '26-04-2021')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "lua",
-    "prompt": "-- Write a luathon function which takes a table of integers and only returns the odd ones.\nlocal function Split(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {1, 3, 5})\n    lu.assertEquals(candidate({10, 11, 12, 13}), {11, 13})\n    lu.assertEquals(candidate({7, 8, 9, 1}), {7, 9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlocal function toggle_middle_bits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_middle_bits\n    lu.assertEquals(candidate(9), 15)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(11), 13)\n    lu.assertEquals(candidate(65), 127)\n    lu.assertEquals(candidate(77), 115)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlocal function count_char_position(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_char_position\n    lu.assertEquals(candidate('xbcefg'), 2)\n    lu.assertEquals(candidate('ABcED'), 3)\n    lu.assertEquals(candidate('AbgdeF'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the specified number of largest products from two given tables, selecting one factor from each table.\nlocal function large_product(nums1, nums2, N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = large_product\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 3), {60, 54, 50})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 4), {60, 54, 50, 48})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 5), {60, 54, 50, 48, 45})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the cumulative sum of all the values that are present in the given table of tables.\nlocal function cummulative_sum(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cummulative_sum\n    lu.assertEquals(candidate({{1, 3}, {5, 6, 7}, {2, 6}}), 30)\n    lu.assertEquals(candidate({{2, 4}, {6, 7, 8}, {3, 7}}), 37)\n    lu.assertEquals(candidate({{3, 5}, {7, 8, 9}, {4, 8}}), 44)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the minimum difference between any two elements in a given table. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlocal function find_min_diff(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_min_diff\n    lu.assertEquals(candidate({1, 5, 3, 19, 18, 25}, 6), 1)\n    lu.assertEquals(candidate({4, 3, 2, 6}, 4), 1)\n    lu.assertEquals(candidate({30, 5, 20, 9}, 4), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nlocal function text_starta_endb(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_starta_endb\n    lu.assertEquals(candidate('aabbbb'), true)\n    lu.assertEquals(candidate('aabAbbbc'), false)\n    lu.assertEquals(candidate('accddbbjjj'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "lua",
-    "prompt": "-- Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlocal function left_rotate(n, d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_rotate\n    lu.assertEquals(candidate(16, 2), 64)\n    lu.assertEquals(candidate(10, 2), 40)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(1, 3), 8)\n    lu.assertEquals(candidate(5, 3), 40)\n    lu.assertEquals(candidate(29, 3), 232)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the first repeated character in a given string.\nlocal function first_repeated_char(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_repeated_char\n    lu.assertEquals(candidate('abcabc'), 'a')\n    lu.assertEquals(candidate('abc'), None)\n    lu.assertEquals(candidate('123123'), '1')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count inversions in a table.\nlocal function get_Inv_Count(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Inv_Count\n    lu.assertEquals(candidate({1, 20, 6, 4, 5}), 5)\n    lu.assertEquals(candidate({1, 2, 1}), 1)\n    lu.assertEquals(candidate({1, 2, 5, 6, 1}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlocal function even_Power_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_Power_Sum\n    lu.assertEquals(candidate(2), 1056)\n    lu.assertEquals(candidate(3), 8832)\n    lu.assertEquals(candidate(1), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "lua",
-    "prompt": "-- Write a function to find whether all the given tables have equal length or not.\nlocal function get_equal(Input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_equal\n    lu.assertEquals(candidate({{11, 22, 33}, {44, 55, 66}}), true)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6, 7}}), false)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "lua",
-    "prompt": "-- Write a function to check if a string represents an integer or not.\nlocal function check_integer(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_integer\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('1'), true)\n    lu.assertEquals(candidate('12345'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "lua",
-    "prompt": "-- Write a function to count the pairs of reverse strings in the given string table. https://www.geeksforgeeks.org/luathon-program-to-count-the-pairs-of-reverse-strings/\nlocal function count_reverse_pairs(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_reverse_pairs\n    lu.assertEquals(candidate({'julia', 'best', 'tseb', 'for', 'ailuj'}), 2)\n    lu.assertEquals(candidate({'geeks', 'best', 'for', 'skeeg'}), 1)\n    lu.assertEquals(candidate({'makes', 'best', 'sekam', 'for', 'rof'}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to move all zeroes to the end of the given table.\nlocal function move_zero(num_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_zero\n    lu.assertEquals(candidate({1, 0, 2, 0, 3, 4}), {1, 2, 3, 4, 0, 0})\n    lu.assertEquals(candidate({2, 3, 2, 0, 0, 4, 0, 5, 0}), {2, 3, 2, 4, 5, 0, 0, 0, 0})\n    lu.assertEquals(candidate({0, 1, 0, 1, 1}), {1, 1, 1, 0, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "lua",
-    "prompt": "-- Write a function to check if given table contains no duplicates.\nlocal function check_distinct(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_distinct\n    lu.assertEquals(candidate({1, 4, 5, 6, 1, 4}), false)\n    lu.assertEquals(candidate({1, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given amount has no profit and no loss\nlocal function noprofit_noloss(actual_cost, sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = noprofit_noloss\n    lu.assertEquals(candidate(1500, 1200), false)\n    lu.assertEquals(candidate(100, 100), true)\n    lu.assertEquals(candidate(2000, 5000), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all the words with k length in the given string.\nlocal function remove_length(test_str, K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_length\n    lu.assertEquals(candidate('The person is most value tet', 3), 'person is most value')\n    lu.assertEquals(candidate('If you told me about this ok', 4), 'If you me about ok')\n    lu.assertEquals(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count number of digits in a given string.\nlocal function number_ctr(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_ctr\n    lu.assertEquals(candidate('program2bedone'), 1)\n    lu.assertEquals(candidate('3wonders'), 1)\n    lu.assertEquals(candidate('123'), 3)\n    lu.assertEquals(candidate('3wond-1ers2'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "lua",
-    "prompt": "-- Write a function to count the total number of characters in a string.\nlocal function count_charac(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_charac\n    lu.assertEquals(candidate('python programming'), 18)\n    lu.assertEquals(candidate('language'), 8)\n    lu.assertEquals(candidate('words'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlocal function get_total_number_of_sequences(m, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_total_number_of_sequences\n    lu.assertEquals(candidate(10, 4), 4)\n    lu.assertEquals(candidate(5, 2), 6)\n    lu.assertEquals(candidate(16, 3), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "lua",
-    "prompt": "-- Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/luathon-exercises/data-structures-and-algorithms/luathon-data-structure-exercise-24.php\nlocal function left_insertion(a, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two numbers and returns a table with the second number and then the first number.\nlocal function swap_numbers(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_numbers\n    lu.assertEquals(candidate(10, 20), {20, 10})\n    lu.assertEquals(candidate(15, 17), {17, 15})\n    lu.assertEquals(candidate(100, 200), {200, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a sorted table, its length (n), and an element and returns whether the element is the majority element in the given sorted table. (The majority element is the element that occurs more than n/2 times.)\nlocal function is_majority(arr, n, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_majority\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 3, 10}, 7, 3), true)\n    lu.assertEquals(candidate({1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), false)\n    lu.assertEquals(candidate({1, 1, 1, 2, 2}, 5, 1), true)\n    lu.assertEquals(candidate({1, 1, 2, 2}, 5, 1), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two tables and subtracts the elements of the first table by the elements of the second table with the same index.\nlocal function substract_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = substract_elements\n    lu.assertEquals(candidate({10, 4, 5}, {2, 5, 18}), {8, -1, -13})\n    lu.assertEquals(candidate({11, 2, 3}, {24, 45, 16}), {-13, -43, -13})\n    lu.assertEquals(candidate({7, 18, 9}, {10, 11, 12}), {-3, 7, -3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to put spaces between words starting with capital letters in a given string.\nlocal function capital_words_spaces(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = capital_words_spaces\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('PythonProgrammingExamples'), 'Python Programming Examples')\n    lu.assertEquals(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the average of cubes of first n natural numbers.\nlocal function find_Average_Of_Cube(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Average_Of_Cube\n    lu.assertEquals(candidate(2), 4.5)\n    lu.assertEquals(candidate(3), 12)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "lua",
-    "prompt": "-- Write a function to check if all values are same in a table.\nlocal function check_value(dict, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_value\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 10), false)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 12), true)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth tetrahedral number.\nlocal function tetrahedral_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tetrahedral_number\n    lu.assertEquals(candidate(5), 35)\n    lu.assertEquals(candidate(6), 56)\n    lu.assertEquals(candidate(7), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate whether the matrix is a magic square.\nlocal function magic_square_test(my_matrix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = magic_square_test\n    lu.assertEquals(candidate({{7, 12, 1, 14}, {2, 13, 8, 11}, {16, 3, 10, 5}, {9, 6, 15, 4}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 8}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 7}}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "lua",
-    "prompt": "-- Write a function to remove uppercase substrings from a given string.\nlocal function remove_uppercase(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_uppercase\n    lu.assertEquals(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')\n    lu.assertEquals(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')\n    lu.assertEquals(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether an element exists within a table.\nlocal function check_tuplex(tuplex, tuple1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_tuplex\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 'r'), true)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, '5'), false)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 3), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate a dog's age in dog's years.\nlocal function dog_age(h_age)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dog_age\n    lu.assertEquals(candidate(12), 61)\n    lu.assertEquals(candidate(15), 73)\n    lu.assertEquals(candidate(24), 109)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the next perfect square greater than a given number.\nlocal function next_Perfect_Square(N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_Perfect_Square\n    lu.assertEquals(candidate(35), 36)\n    lu.assertEquals(candidate(6), 9)\n    lu.assertEquals(candidate(9), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "lua",
-    "prompt": "-- Write a function to create a table of N empty dictionaries.\nlocal function empty_list(length)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = empty_list\n    lu.assertEquals(candidate(5), {{}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(6), {{}, {}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(7), {{}, {}, {}, {}, {}, {}, {}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to convert a given string to uppercase.\nlocal function is_upper(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_upper\n    lu.assertEquals(candidate('person'), 'PERSON')\n    lu.assertEquals(candidate('final'), 'FINAL')\n    lu.assertEquals(candidate('Valid'), 'VALID')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlocal function odd_Equivalent(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_Equivalent\n    lu.assertEquals(candidate('011001', 6), 3)\n    lu.assertEquals(candidate('11011', 5), 4)\n    lu.assertEquals(candidate('1010', 4), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and an integer n, and re-arranges the first n elements of the given table so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nlocal function re_arrange_array(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = re_arrange_array\n    lu.assertEquals(candidate({-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), {-1, -3, -7, 4, 5, 6, 2, 8, 9})\n    lu.assertEquals(candidate({12, -14, -26, 13, 15}, 5), {-14, -26, 12, 13, 15})\n    lu.assertEquals(candidate({10, 24, 36, -42, -39, -78, 85}, 7), {-42, -39, -78, 10, 24, 36, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether a table of numbers contains only one distinct element or not.\nlocal function unique_Element(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_Element\n    lu.assertEquals(candidate({1, 1, 1}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "lua",
-    "prompt": "-- Write a function to extract values between quotation marks from a string.\nlocal function extract_values(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_values\n    lu.assertEquals(candidate('\"Python\", \"PHP\", \"Java\"'), {'Python', 'PHP', 'Java'})\n    lu.assertEquals(candidate('\"python\",\"program\",\"language\"'), {'python', 'program', 'language'})\n    lu.assertEquals(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), {'red', 'blue', 'green', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count true booleans in the given table.\nlocal function count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count\n    lu.assertEquals(candidate({true, false, true}), 2)\n    lu.assertEquals(candidate({false, false}), 0)\n    lu.assertEquals(candidate({true, true, true}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "lua",
-    "prompt": "-- Write a function that counts the number of pairs of integers in a table that xor to an even number.\nlocal function find_even_pair(A)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_even_pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}), 4)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}), 9)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is armstrong or not.\nlocal function armstrong_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = armstrong_number\n    lu.assertEquals(candidate(153), true)\n    lu.assertEquals(candidate(259), false)\n    lu.assertEquals(candidate(4458), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the upper case characters in a given string.\nlocal function upper_ctr(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = upper_ctr\n    lu.assertEquals(candidate('PYthon'), 1)\n    lu.assertEquals(candidate('BigData'), 1)\n    lu.assertEquals(candidate('program'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the elementwise and tables from the given two tables.\nlocal function and_tuples(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = and_tuples\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {0, 0, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {5, 6, 7, 8}), {1, 2, 3, 0})\n    lu.assertEquals(candidate({8, 9, 11, 12}, {7, 13, 14, 17}), {0, 9, 10, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether it follows the sequence given in the patterns table.\nlocal function is_samepatterns(colors, patterns)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_samepatterns\n    lu.assertEquals(candidate({'red', 'green', 'green'}, {'a', 'b', 'b'}), true)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b', 'b'}), false)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b'}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of tables in a given number of tables.\nlocal function count_list(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), 4)\n    lu.assertEquals(candidate({{1, 2}, {2, 3}, {4, 5}}), 3)\n    lu.assertEquals(candidate({{1, 0}, {2, 0}}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function which takes a tables of tables and returns the average value for each subtable as a table.\nlocal function average_tuple(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = average_tuple\n    lu.assertEquals(candidate({{10, 10, 10, 12}, {30, 45, 56, 45}, {81, 80, 39, 32}, {1, 2, 3, 4}}), {30.5, 34.25, 27.0, 23.25})\n    lu.assertEquals(candidate({{1, 1, -5}, {30, -15, 56}, {81, -60, -39}, {-10, 2, 3}}), {25.5, -18.0, 3.75})\n    lu.assertEquals(candidate({{100, 100, 100, 120}, {300, 450, 560, 450}, {810, 800, 390, 320}, {10, 20, 30, 40}}), {305.0, 342.5, 270.0, 232.5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "lua",
-    "prompt": "-- Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlocal function lcs_of_three(X, Y, Z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lcs_of_three\n    lu.assertEquals(candidate('AGGT12', '12TXAYB', '12XBA'), 2)\n    lu.assertEquals(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)\n    lu.assertEquals(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n'th star number.\nlocal function find_star_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_star_num\n    lu.assertEquals(candidate(3), 37)\n    lu.assertEquals(candidate(4), 73)\n    lu.assertEquals(candidate(5), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of a table.\nlocal function _sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = _sum\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({15, 12, 13, 10}), 50)\n    lu.assertEquals(candidate({0, 1, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given table contains consecutive numbers or not.\nlocal function check_Consecutive(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_Consecutive\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 5, 6}), false)\n    lu.assertEquals(candidate({1, 2, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "lua",
-    "prompt": "-- Write a function to find the first adverb and their positions in a given sentence.\nlocal function find_adverb_position(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverb_position\n    lu.assertEquals(candidate('clearly!! we can see the sky'), {0, 7, 'clearly'})\n    lu.assertEquals(candidate('seriously!! there are many roses'), {0, 9, 'seriously'})\n    lu.assertEquals(candidate('unfortunately!! sita is going to home'), {0, 13, 'unfortunately'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "lua",
-    "prompt": "-- Write a function to rotate a given table by specified number of items to the right direction. https://www.geeksforgeeks.org/luathon-program-right-rotate-table-n/\nlocal function rotate_right(list, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rotate_right\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), {8, 9, 10, 1, 2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {9, 10, 1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), {6, 7, 8, 9, 10, 1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of non-empty substrings of a given string.\nlocal function number_of_substrings(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_of_substrings\n    lu.assertEquals(candidate('abc'), 6)\n    lu.assertEquals(candidate('abcd'), 10)\n    lu.assertEquals(candidate('abcde'), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and an integer n and splits a table for every nth element, returning a table of the resulting tables.\nlocal function list_split(S, step)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_split\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'}, 3), {{'a', 'd', 'g', 'j', 'm'}, {'b', 'e', 'h', 'k', 'n'}, {'c', 'f', 'i', 'l'}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), {{1, 4, 7, 10, 13}, {2, 5, 8, 11, 14}, {3, 6, 9, 12}})\n    lu.assertEquals(candidate({'python', 'java', 'C', 'C++', 'DBMS', 'SQL'}, 2), {{'python', 'C', 'DBMS'}, {'java', 'C++', 'SQL'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check if the elements of a given table are unique or not.\nlocal function all_unique(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_unique\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to convert complex numbers to polar coordinates.\nlocal function convert(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert\n    lu.assertEquals(candidate(1), {1.0, 0.0})\n    lu.assertEquals(candidate(4), {4.0, 0.0})\n    lu.assertEquals(candidate(5), {5.0, 0.0})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "lua",
-    "prompt": "-- The input is given as - a table with a student name as a key and a table of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nlocal function filter_data(students, h, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_data\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 6.0, 70), {['Cierra Vega'] = {6.2, 70}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.9, 67), {['Cierra Vega'] = {6.2, 70}, ['Kierra Gentry'] = {6.0, 68}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.7, 64), {['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to convert the given string to lower case.\nlocal function is_lower(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_lower\n    lu.assertEquals(candidate('InValid'), 'invalid')\n    lu.assertEquals(candidate('TruE'), 'true')\n    lu.assertEquals(candidate('SenTenCE'), 'sentence')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the smallest power of 2 greater than or equal to n.\nlocal function next_power_of_2(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_power_of_2\n    lu.assertEquals(candidate(0), 1)\n    lu.assertEquals(candidate(5), 8)\n    lu.assertEquals(candidate(17), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "lua",
-    "prompt": "-- Write a function to check if a string is present as a substring in a given table of string values.\nlocal function find_substring(str1, sub_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_substring\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ack'), true)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'abc'), false)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ange'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "lua",
-    "prompt": "-- Write a function to replace characters in a string.\nlocal function replace_char(str1, ch, newch)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_char\n    lu.assertEquals(candidate('polygon', 'y', 'l'), 'pollgon')\n    lu.assertEquals(candidate('character', 'c', 'a'), 'aharaater')\n    lu.assertEquals(candidate('python', 'l', 'a'), 'python')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to find the product of first even and odd number of a given table.\nlocal function mul_even_odd(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mul_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a table to a table.\nlocal function list_tuple(listx)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_tuple\n    lu.assertEquals(candidate({5, 10, 7, 4, 15, 3}), {5, 10, 7, 4, 15, 3})\n    lu.assertEquals(candidate({2, 4, 5, 6, 2, 3, 4, 4, 7}), {2, 4, 5, 6, 2, 3, 4, 4, 7})\n    lu.assertEquals(candidate({58, 44, 56}), {58, 44, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlocal function even_binomial_Coeff_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_binomial_Coeff_Sum\n    lu.assertEquals(candidate(4), 8)\n    lu.assertEquals(candidate(6), 32)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "lua",
-    "prompt": "-- Write a function to perform the mathematical bitwise xor operation across the given tables.\nlocal function bitwise_xor(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bitwise_xor\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {15, 6, 5, 10})\n    lu.assertEquals(candidate({11, 5, 7, 10}, {6, 3, 4, 4}), {13, 6, 3, 14})\n    lu.assertEquals(candidate({12, 6, 8, 11}, {7, 4, 5, 6}), {11, 2, 13, 13})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether a table is subtable of another or not.\nlocal function is_Sub_Array(A, B)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sub_Array\n    lu.assertEquals(candidate({1, 4, 3, 5}, {1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 1}, {1, 2, 1}), true)\n    lu.assertEquals(candidate({1, 0, 2, 2}, {2, 2, 0}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "lua",
-    "prompt": "-- Write a function to find the largest sum of a contiguous table in the modified table which is formed by repeating the given table k times.\nlocal function max_sub_array_sum_repeated(a, n, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum_repeated\n    lu.assertEquals(candidate({10, 20, -30, -1}, 4, 3), 30)\n    lu.assertEquals(candidate({-1, 10, 20}, 3, 2), 59)\n    lu.assertEquals(candidate({-1, -2, -3}, 3, 3), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to find the minimum product from the pairs of tables within a given table.\nlocal function min_product_tuple(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 8)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 30)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the count of divisors is even. https://www.w3resource.com/luathon-exercises/basic/luathon-basic-1-exercise-24.php\nlocal function count_divisors(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_divisors\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(100), false)\n    lu.assertEquals(candidate(125), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nlocal function triangle_area(r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(-1), None)\n    lu.assertEquals(candidate(0), 0)\n    lu.assertEquals(candidate(2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a given string to a table of characters.\nlocal function string_to_tuple(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_tuple\n    lu.assertEquals(candidate('python 3.0'), {'p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'})\n    lu.assertEquals(candidate('item1'), {'i', 't', 'e', 'm', '1'})\n    lu.assertEquals(candidate('15.10'), {'1', '5', '.', '1', '0'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlocal function find_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_length\n    lu.assertEquals(candidate('11000010001'), 6)\n    lu.assertEquals(candidate('10111'), 1)\n    lu.assertEquals(candidate('11011101100101'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "lua",
-    "prompt": "-- Write a luathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlocal function count_Primes_nums(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Primes_nums\n    lu.assertEquals(candidate(5), 2)\n    lu.assertEquals(candidate(10), 4)\n    lu.assertEquals(candidate(100), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of the product of consecutive binomial co-efficients.\nlocal function sum_Of_product(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_product\n    lu.assertEquals(candidate(3), 15)\n    lu.assertEquals(candidate(4), 56)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the maximum aggregate from the table of tables.\nlocal function max_aggregate(stdata)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_aggregate\n    lu.assertEquals(candidate({{'Juan Whelan', 90}, {'Sabah Colley', 88}, {'Peter Nichols', 7}, {'Juan Whelan', 122}, {'Sabah Colley', 84}}), {'Juan Whelan', 212})\n    lu.assertEquals(candidate({{'Juan Whelan', 50}, {'Sabah Colley', 48}, {'Peter Nichols', 37}, {'Juan Whelan', 22}, {'Sabah Colley', 14}}), {'Juan Whelan', 72})\n    lu.assertEquals(candidate({{'Juan Whelan', 10}, {'Sabah Colley', 20}, {'Peter Nichols', 30}, {'Juan Whelan', 40}, {'Sabah Colley', 50}}), {'Sabah Colley', 70})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a table of elements.\nlocal function comb_sort(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = comb_sort\n    lu.assertEquals(candidate({5, 15, 37, 25, 79}), {5, 15, 25, 37, 79})\n    lu.assertEquals(candidate({41, 32, 15, 19, 22}), {15, 19, 22, 32, 41})\n    lu.assertEquals(candidate({99, 15, 13, 47}), {13, 15, 47, 99})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nlocal function check_expression(exp)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_expression\n    lu.assertEquals(candidate('{()}[{}]'), true)\n    lu.assertEquals(candidate('{()}[{]'), false)\n    lu.assertEquals(candidate('{()}[{}][]({})'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a word containing 'z'.\nlocal function text_match_wordz(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz\n    lu.assertEquals(candidate('pythonz.'), true)\n    lu.assertEquals(candidate('xyz.'), true)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "lua",
-    "prompt": "-- Write a function takes as input two tables [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nlocal function sum_list(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_list\n    lu.assertEquals(candidate({10, 20, 30}, {15, 25, 35}), {25, 45, 65})\n    lu.assertEquals(candidate({1, 2, 3}, {5, 6, 7}), {6, 8, 10})\n    lu.assertEquals(candidate({15, 20, 30}, {15, 45, 75}), {30, 65, 105})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlocal function newman_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = newman_prime\n    lu.assertEquals(candidate(3), 7)\n    lu.assertEquals(candidate(4), 17)\n    lu.assertEquals(candidate(5), 41)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "lua",
-    "prompt": "-- Write a function to apply a given format string to all of the elements in a table.\nlocal function add_string(list_, string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_string\n    lu.assertEquals(candidate({1, 2, 3, 4}, 'temp{0}'), {'temp1', 'temp2', 'temp3', 'temp4'})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 'python{0}'), {'pythona', 'pythonb', 'pythonc', 'pythond'})\n    lu.assertEquals(candidate({5, 6, 7, 8}, 'string{0}'), {'string5', 'string6', 'string7', 'string8'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the surface area of a square luaramid with a given base edge and height.\nlocal function surface_Area(b, s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surface_Area\n    lu.assertEquals(candidate(3, 4), 33)\n    lu.assertEquals(candidate(4, 5), 56)\n    lu.assertEquals(candidate(1, 2), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the length of the smallest table in a table of tables.\nlocal function Find_Min_Length(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min_Length\n    lu.assertEquals(candidate({{1}, {1, 2}}), 1)\n    lu.assertEquals(candidate({{1, 2}, {1, 2, 3}, {1, 2, 3, 4}}), 2)\n    lu.assertEquals(candidate({{3, 3, 3}, {4, 4, 4, 4}}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "lua",
-    "prompt": "-- Write a luathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nlocal function validate(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = validate\n    lu.assertEquals(candidate(1234), true)\n    lu.assertEquals(candidate(51241), false)\n    lu.assertEquals(candidate(321), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth hexagonal number.\nlocal function hexagonal_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hexagonal_num\n    lu.assertEquals(candidate(10), 190)\n    lu.assertEquals(candidate(5), 45)\n    lu.assertEquals(candidate(7), 91)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n'th lucas number.\nlocal function find_lucas(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lucas\n    lu.assertEquals(candidate(9), 76)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(3), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to get the difference between two tables.\nlocal function Diff(li1, li2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Diff\n    lu.assertEquals(candidate({10, 15, 20, 25, 30, 35, 40}, {25, 40, 35}), {10, 20, 30, 15})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 1}), {2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3}, {6, 7, 1}), {2, 3, 6, 7})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "lua",
-    "prompt": "-- Write a function to extract values between quotation marks \" \" of the given string.\nlocal function extract_quotation(text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_quotation\n    lu.assertEquals(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), {'A53', 'multi', 'Processor'})\n    lu.assertEquals(candidate('Cast your \"favorite\" entertainment \"apps\"'), {'favorite', 'apps'})\n    lu.assertEquals(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), {'4k Ultra HD', 'HDR 10'})\n    lu.assertEquals(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to flatten a table and sum all of its elements.\nlocal function recursive_list_sum(data_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = recursive_list_sum\n    lu.assertEquals(candidate({1, 2, {3, 4}, {5, 6}}), 21)\n    lu.assertEquals(candidate({7, 10, {15, 14}, {19, 41}}), 106)\n    lu.assertEquals(candidate({10, 20, {30, 40}, {50, 60}}), 210)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the two numbers differ at one bit position only or not.\nlocal function differ_At_One_Bit_Pos(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = differ_At_One_Bit_Pos\n    lu.assertEquals(candidate(13, 9), true)\n    lu.assertEquals(candidate(15, 8), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(2, 3), true)\n    lu.assertEquals(candidate(5, 1), true)\n    lu.assertEquals(candidate(1, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an a followed by three 'b'.\nlocal function text_match_three(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('caacabbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that table.\nlocal function max_product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product\n    lu.assertEquals(candidate({3, 100, 4, 5, 150, 6}), 3000)\n    lu.assertEquals(candidate({4, 42, 55, 68, 80}), 50265600)\n    lu.assertEquals(candidate({10, 22, 9, 33, 21, 50, 41, 60}), 2460)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to split a table at the nth eelment and add the first part to the end.\nlocal function split_Arr(l, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_Arr\n    lu.assertEquals(candidate({12, 10, 5, 6, 52, 36}, 2), {5, 6, 52, 36, 12, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, 1), {2, 3, 4, 1})\n    lu.assertEquals(candidate({0, 1, 2, 3, 4, 5, 6, 7}, 3), {3, 4, 5, 6, 7, 0, 1, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the number of divisors of a given integer.\nlocal function divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisor\n    lu.assertEquals(candidate(15), 4)\n    lu.assertEquals(candidate(12), 6)\n    lu.assertEquals(candidate(9), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the difference between largest and smallest value in a given table.\nlocal function big_diff(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_diff\n    lu.assertEquals(candidate({1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({4, 5, 12}), 8)\n    lu.assertEquals(candidate({9, 2, 3}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "lua",
-    "prompt": "-- Write a function to find squares of individual elements in a table.\nlocal function square_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}), {100, 400, 900})\n    lu.assertEquals(candidate({12, 15}), {144, 225})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "lua",
-    "prompt": "-- Write a function to check if the given table has any none value or not.\nlocal function check_none(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_none\n    lu.assertEquals(candidate({10, 4, 5, 6, None}), true)\n    lu.assertEquals(candidate({7, 8, 9, 11, 14}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, None}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given table is monotonic or not.\nlocal function is_Monotonic(A)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Monotonic\n    lu.assertEquals(candidate({6, 5, 4, 4}), true)\n    lu.assertEquals(candidate({1, 2, 2, 3}), true)\n    lu.assertEquals(candidate({1, 3, 2}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nlocal function is_perfect_square(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_perfect_square\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(36), true)\n    lu.assertEquals(candidate(14), false)\n    lu.assertEquals(candidate(196), true)\n    lu.assertEquals(candidate(125), false)\n    lu.assertEquals(candidate(15625), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of common divisors of two given numbers.\nlocal function sum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum\n    lu.assertEquals(candidate(10, 15), 6)\n    lu.assertEquals(candidate(100, 150), 93)\n    lu.assertEquals(candidate(4, 6), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "lua",
-    "prompt": "-- Write a function to find the table of maximum length in a table of tables.\nlocal function max_length(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1}, {5, 7}, {10, 12, 14, 15}}), {4, {10, 12, 14, 15}})\n    lu.assertEquals(candidate({{5}, {15, 20, 25}}), {3, {15, 20, 25}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table of tables and returns a table mapping each unique table to the number of times it occurs in the table.\nlocal function check_occurences(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_occurences\n    lu.assertEquals(candidate({{3, 1}, {1, 3}, {2, 5}, {5, 2}, {6, 3}}), {[{1, 3}] = 2, [{2, 5}] = 2, [{3, 6}] = 1})\n    lu.assertEquals(candidate({{4, 2}, {2, 4}, {3, 6}, {6, 3}, {7, 4}}), {[{2, 4}] = 2, [{3, 6}] = 2, [{4, 7}] = 1})\n    lu.assertEquals(candidate({{13, 2}, {11, 23}, {12, 25}, {25, 12}, {16, 23}}), {[{2, 13}] = 1, [{11, 23}] = 1, [{12, 25}] = 2, [{16, 23}] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "lua",
-    "prompt": "-- Write a function to find the directrix of a parabola.\nlocal function parabola_directrix(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parabola_directrix\n    lu.assertEquals(candidate(5, 3, 2), -198)\n    lu.assertEquals(candidate(9, 8, 4), -2336)\n    lu.assertEquals(candidate(2, 4, 6), -130)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "lua",
-    "prompt": "-- Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nlocal function occurance_substring(text, pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = occurance_substring\n    lu.assertEquals(candidate('python programming, python language', 'python'), {'python', 0, 6})\n    lu.assertEquals(candidate('python programming,programming language', 'programming'), {'programming', 7, 18})\n    lu.assertEquals(candidate('python programming,programming language', 'language'), {'language', 31, 39})\n    lu.assertEquals(candidate('c++ programming, c++ language', 'python'), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "lua",
-    "prompt": "-- Write a function to remove tables from the given table.\nlocal function remove_nested(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_nested\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), {1, 5, 7, 10})\n    lu.assertEquals(candidate({2, 6, 8, {5, 7}, 11}), {2, 6, 8, 11})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, 12}), {3, 7, 9, 12})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, {5, 12}, 12}), {3, 7, 9, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "lua",
-    "prompt": "-- Write a function to sort each subtable of strings in a given table of tables.\nlocal function sort_sublists(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{' red ', 'green'}, {'blue ', ' black'}, {' orange', 'brown'}}), {{' red ', 'green'}, {' black', 'blue '}, {' orange', 'brown'}})\n    lu.assertEquals(candidate({{'zilver', 'gold'}, {'magnesium', 'aluminium'}, {'steel', 'bronze'}}), {{'gold', 'zilver'}, {'aluminium', 'magnesium'}, {'bronze', 'steel'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "lua",
-    "prompt": "-- Write a luathon function which takes a table and returns a table with the same elements, but the k'th element removed.\nlocal function remove_kth_element(list1, L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_kth_element\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {1, 1, 3, 4, 4, 5, 1})\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), {10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to add a table to the table. The output should be a table.\nlocal function add_dict_to_tuple(test_tup, test_dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_dict_to_tuple\n    lu.assertEquals(candidate({4, 5, 6}, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}), {4, 5, 6, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}})\n    lu.assertEquals(candidate({1, 2, 3}, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}), {1, 2, 3, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}})\n    lu.assertEquals(candidate({8, 9, 10}, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}), {8, 9, 10, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find quotient of two numbers (rounded down to the nearest integer).\nlocal function find(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find\n    lu.assertEquals(candidate(10, 3), 3)\n    lu.assertEquals(candidate(4, 2), 2)\n    lu.assertEquals(candidate(20, 5), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "lua",
-    "prompt": "-- Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nlocal function text_match_two_three(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_two_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the occurence of all elements of table in a table.\nlocal function count_Occurrence(tup, lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Occurrence\n    lu.assertEquals(candidate({'a', 'a', 'c', 'b', 'd'}, {'a', 'b'}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 1, 4, 6, 7, 1, 4}, {1, 4, 7}), 6)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {1, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "lua",
-    "prompt": "-- Write a function to count number items that are identical in the same position of three given tables.\nlocal function count_samepair(list1, list2, list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_samepair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}, {2, 1, 3, 1, 2, 6, 7, 9}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 2, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "lua",
-    "prompt": "-- Write a function that matches a string that has an a followed by one or more b's.\nlocal function text_match_one(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlocal function difference(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = difference\n    lu.assertEquals(candidate(3), 30)\n    lu.assertEquals(candidate(5), 210)\n    lu.assertEquals(candidate(2), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "lua",
-    "prompt": "-- Write a function to toggle the case of all characters in a string.\nlocal function toggle_string(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_string\n    lu.assertEquals(candidate('Python'), 'pYTHON')\n    lu.assertEquals(candidate('Pangram'), 'pANGRAM')\n    lu.assertEquals(candidate('LIttLE'), 'liTTle')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the element of a table having maximum length.\nlocal function Find_Max(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max\n    lu.assertEquals(candidate({{'A'}, {'A', 'B'}, {'A', 'B', 'C'}}), {'A', 'B', 'C'})\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1, 2, 3})\n    lu.assertEquals(candidate({{1, 1}, {1, 2, 3}, {1, 5, 6, 1}}), {1, 5, 6, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the Eulerian number a(n, m).\nlocal function eulerian_num(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eulerian_num\n    lu.assertEquals(candidate(3, 1), 4)\n    lu.assertEquals(candidate(4, 1), 11)\n    lu.assertEquals(candidate(5, 3), 26)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of occurrences of a number in a given table.\nlocal function frequency(a, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency\n    lu.assertEquals(candidate({1, 2, 3}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 3, 4}, 3), 3)\n    lu.assertEquals(candidate({0, 1, 2, 3, 1, 2}, 1), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a given table of strings of numbers numerically. https://www.geeksforgeeks.org/luathon-sort-numeric-strings-in-a-table/\nlocal function sort_numeric_strings(nums_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numeric_strings\n    lu.assertEquals(candidate({'4', '12', '45', '7', '0', '100', '200', '-12', '-500'}), {-500, -12, 0, 4, 7, 12, 45, 100, 200})\n    lu.assertEquals(candidate({'2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2'}), {1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9})\n    lu.assertEquals(candidate({'1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11'}), {1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/luathon-exercises/data-structures-and-algorithms/luathon-recursion-exercise-9.php\nlocal function geometric_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = geometric_sum\n    lu.assertEquals(candidate(7), 1.9921875)\n    lu.assertEquals(candidate(4), 1.9375)\n    lu.assertEquals(candidate(8), 1.99609375)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/luathon-exercises/lambda/luathon-lambda-exercise-24.php\nlocal function divisible_by_digits(startnum, endnum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisible_by_digits\n    lu.assertEquals(candidate(1, 22), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22})\n    lu.assertEquals(candidate(1, 15), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15})\n    lu.assertEquals(candidate(20, 25), {22, 24})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to calculate the product of the unique numbers in a given table.\nlocal function unique_product(list_data)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_product\n    lu.assertEquals(candidate({10, 20, 30, 40, 20, 50, 60, 40}), 720000000)\n    lu.assertEquals(candidate({1, 2, 3, 1}), 6)\n    lu.assertEquals(candidate({7, 8, 9, 0, 1, 1}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the largest negative number from the given table.\nlocal function largest_neg(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_neg\n    lu.assertEquals(candidate({1, 2, 3, -4, -6}), -6)\n    lu.assertEquals(candidate({1, 2, 3, -8, -9}), -9)\n    lu.assertEquals(candidate({1, 2, 3, 4, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "lua",
-    "prompt": "-- Write a function to remove consecutive duplicates of a given table.\nlocal function consecutive_duplicates(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {10, 15, 19, 18, 17, 26, 17, 18, 10})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {'a', 'b', 'c', 'd'})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd', 'a', 'a'}), {'a', 'b', 'c', 'd', 'a'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "lua",
-    "prompt": "-- Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nlocal function min_Jumps(steps, d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Jumps\n    lu.assertEquals(candidate({3, 4}, 11), 3.5)\n    lu.assertEquals(candidate({3, 4}, 0), 0)\n    lu.assertEquals(candidate({11, 14}, 11), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find a pair with highest product from a given table of integers.\nlocal function max_Product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Product\n    lu.assertEquals(candidate({1, 2, 3, 4, 7, 0, 8, 4}), {7, 8})\n    lu.assertEquals(candidate({0, -1, -2, -4, 5, 0, -6}), {-4, -6})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the nth element from a given table of tables.\nlocal function extract_nth_element(list1, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_nth_element\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 0), {'Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 2), {99, 96, 94, 98})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 1), {98, 97, 91, 94})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth nonagonal number.\nlocal function is_nonagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nonagonal\n    lu.assertEquals(candidate(10), 325)\n    lu.assertEquals(candidate(15), 750)\n    lu.assertEquals(candidate(18), 1089)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the maximum difference between any two elements in a given table.\nlocal function max_Abs_Diff(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Abs_Diff\n    lu.assertEquals(candidate({2, 1, 5, 3}), 4)\n    lu.assertEquals(candidate({9, 3, 2, 5, 1}), 8)\n    lu.assertEquals(candidate({3, 2, 1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "lua",
-    "prompt": "-- Write a function to pack consecutive duplicates of a given table elements into subtables.\nlocal function pack_consecutive_duplicates(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pack_consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {{0, 0}, {1}, {2}, {3}, {4, 4}, {5}, {6, 6, 6}, {7}, {8}, {9}, {4, 4}})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {{10, 10}, {15}, {19}, {18, 18}, {17}, {26, 26}, {17}, {18}, {10}})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {{'a', 'a'}, {'b'}, {'c'}, {'d', 'd'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum of perrin numbers.\nlocal function cal_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cal_sum\n    lu.assertEquals(candidate(9), 49)\n    lu.assertEquals(candidate(10), 66)\n    lu.assertEquals(candidate(11), 88)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to remove the characters which have odd index values of a given string.\nlocal function odd_values_string(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_values_string\n    lu.assertEquals(candidate('abcdef'), 'ace')\n    lu.assertEquals(candidate('python'), 'pto')\n    lu.assertEquals(candidate('data'), 'dt')\n    lu.assertEquals(candidate('lambs'), 'lms')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "lua",
-    "prompt": "-- Write a function to find kth element from the given two sorted tables.\nlocal function find_kth(arr1, arr2, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_kth\n    lu.assertEquals(candidate({2, 3, 6, 7, 9}, {1, 4, 8, 10}, 5), 6)\n    lu.assertEquals(candidate({100, 112, 256, 349, 770}, {72, 86, 113, 119, 265, 445, 892}, 7), 256)\n    lu.assertEquals(candidate({3, 4, 7, 8, 10}, {2, 5, 9, 11}, 6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlocal function jacobsthal_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = jacobsthal_num\n    lu.assertEquals(candidate(5), 11)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 5)\n    lu.assertEquals(candidate(13), 2731)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to find frequency of each element in a flattened table of tables, returned in a table.\nlocal function frequency_lists(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency_lists\n    lu.assertEquals(candidate({{1, 2, 3, 2}, {4, 5, 6, 2}, {7, 8, 9, 5}}), {[1] = 1, [2] = 3, [3] = 1, [4] = 1, [5] = 2, [6] = 1, [7] = 1, [8] = 1, [9] = 1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}), {[1] = 1, [2] = 1, [3] = 1, [4] = 1, [5] = 1, [6] = 1, [7] = 1, [8] = 1, [9] = 1, [10] = 1, [11] = 1, [12] = 1})\n    lu.assertEquals(candidate({{20, 30, 40, 17}, {18, 16, 14, 13}, {10, 20, 30, 40}}), {[20] = 2, [30] = 2, [40] = 2, [17] = 1, [18] = 1, [16] = 1, [14] = 1, [13] = 1, [10] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "lua",
-    "prompt": "-- Write a function to find perfect squares between two given numbers.\nlocal function perfect_squares(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perfect_squares\n    lu.assertEquals(candidate(1, 30), {1, 4, 9, 16, 25})\n    lu.assertEquals(candidate(50, 100), {64, 81, 100})\n    lu.assertEquals(candidate(100, 200), {100, 121, 144, 169, 196})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find sum of products of all possible subtables of a given table. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subtables/\nlocal function sum_Of_Subarray_Prod(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_Subarray_Prod\n    lu.assertEquals(candidate({1, 2, 3}), 20)\n    lu.assertEquals(candidate({1, 2}), 5)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the first odd number in a given table of numbers.\nlocal function first_odd(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_odd\n    lu.assertEquals(candidate({1, 3, 5}), 1)\n    lu.assertEquals(candidate({2, 4, 1, 3}), 1)\n    lu.assertEquals(candidate({8, 9, 1}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "lua",
-    "prompt": "-- Write a function to perform index wise addition of table elements in the given two nested tables.\nlocal function add_nested_tuples(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_nested_tuples\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{7, 10}, {7, 14}, {3, 10}, {8, 13}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{9, 12}, {9, 16}, {5, 12}, {10, 15}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{11, 14}, {11, 18}, {7, 14}, {12, 17}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "lua",
-    "prompt": "-- Write a luathon function which takes a table of tables, where each subtable has two elements, and returns a table of two tables where the first table has the first element of each subtable and the second one has the second.\nlocal function merge(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge\n    lu.assertEquals(candidate({{'x', 'y'}, {'a', 'b'}, {'m', 'n'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}, {7, 8}}), {{1, 3, 5, 7}, {2, 4, 6, 8}})\n    lu.assertEquals(candidate({{'x', 'y', 'z'}, {'a', 'b', 'c'}, {'m', 'n', 'o'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}, {'z', 'c', 'o'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given number can be represented as the difference of two squares or not.\nlocal function dif_Square(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dif_Square\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(15), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "lua",
-    "prompt": "-- Write a function to check if each element of second table is smaller than its corresponding element in the first table.\nlocal function check_smaller(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_smaller\n    lu.assertEquals(candidate({1, 2, 3}, {2, 3, 4}), false)\n    lu.assertEquals(candidate({4, 5, 6}, {3, 4, 5}), true)\n    lu.assertEquals(candidate({11, 12, 13}, {10, 11, 12}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "lua",
-    "prompt": "-- Write a function to get the frequency of all the elements in a table, returned as a table.\nlocal function freq_count(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = freq_count\n    lu.assertEquals(candidate({10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), {[10] = 4, [20] = 4, [40] = 2, [50] = 2, [30] = 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), {[1] = 3, [2] = 2, [3] = 3, [4] = 3})\n    lu.assertEquals(candidate({5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), {[10] = 1, [5] = 3, [6] = 2, [7] = 2, [4] = 2, [9] = 2})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "lua",
-    "prompt": "-- Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nlocal function rgb_to_hsv(r, g, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rgb_to_hsv\n    lu.assertEquals(candidate(255, 255, 255), {0.0, 0.0, 100.0})\n    lu.assertEquals(candidate(0, 215, 0), {120.0, 100.0, 84.31372549019608})\n    lu.assertEquals(candidate(10, 215, 110), {149.26829268292684, 95.34883720930233, 84.31372549019608})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "lua",
-    "prompt": "-- Write a function to flatten a given nested table structure.\nlocal function flatten_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flatten_list\n    lu.assertEquals(candidate({0, 10, {20, 30}, 40, 50, {60, 70, 80}, {90, 100, 110, 120}}), {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120})\n    lu.assertEquals(candidate({{10, 20}, {40}, {30, 56, 25}, {10, 20}, {33}, {40}}), {10, 20, 40, 30, 56, 25, 10, 20, 33, 40})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given string is starting with a vowel or not using regex.\nlocal function check_str(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_str\n    lu.assertEquals(candidate('annie'), true)\n    lu.assertEquals(candidate('dawood'), false)\n    lu.assertEquals(candidate('Else'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nlocal function check_monthnumber_number(monthnum3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumber_number\n    lu.assertEquals(candidate(6), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(12), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "lua",
-    "prompt": "-- Write a function to sort the given table.\nlocal function heap_sort(iterable)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_sort\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 25, 58}), {14, 22, 25, 25, 35, 58, 65, 75, 85})\n    lu.assertEquals(candidate({7, 1, 9, 5}), {1, 5, 7, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "lua",
-    "prompt": "-- Write a function to find k number of smallest pairs which consist of one element from the first table and one element from the second table.\nlocal function k_smallest_pairs(nums1, nums2, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = k_smallest_pairs\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 2), {{1, 2}, {1, 4}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 1), {{1, 2}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 7), {{1, 2}, {1, 4}, {3, 2}, {1, 6}, {3, 4}, {3, 6}, {7, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "lua",
-    "prompt": "-- Write a function that returns integers x and y that satisfy ax + by = n as a table, or return None if no solution exists.\nlocal function find_solution(a, b, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_solution\n    lu.assertEquals(candidate(2, 3, 7), {2, 1})\n    lu.assertEquals(candidate(4, 2, 7), None)\n    lu.assertEquals(candidate(1, 13, 17), {4, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the largest number that can be formed with the given table of digits.\nlocal function find_Max_Num(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Max_Num\n    lu.assertEquals(candidate({1, 2, 3}), 321)\n    lu.assertEquals(candidate({4, 5, 6, 1}), 6541)\n    lu.assertEquals(candidate({1, 2, 3, 9}), 9321)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "lua",
-    "prompt": "-- Write a function that returns the table in a table of tables whose sum of elements is the highest.\nlocal function max_sum_list(lists)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_list\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {10, 11, 12})\n    lu.assertEquals(candidate({{3, 2, 1}, {6, 5, 4}, {12, 11, 10}}), {12, 11, 10})\n    lu.assertEquals(candidate({{2, 3, 1}}), {2, 3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to interchange the first and last elements in a table.\nlocal function swap_List(newList)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({12, 35, 9, 56, 24}), {24, 35, 9, 56, 12})\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median of two sorted tables of same size.\nlocal function get_median(arr1, arr2, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_median\n    lu.assertEquals(candidate({1, 12, 15, 26, 38}, {2, 13, 17, 30, 45}, 5), 16.0)\n    lu.assertEquals(candidate({2, 4, 8, 9}, {7, 13, 19, 28}, 4), 8.5)\n    lu.assertEquals(candidate({3, 6, 14, 23, 36, 42}, {2, 18, 27, 39, 49, 55}, 6), 25.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to replace whitespaces with an underscore and vice versa in a given string.\nlocal function replace_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')\n    lu.assertEquals(candidate('The_Avengers'), 'The Avengers')\n    lu.assertEquals(candidate('Fast and Furious'), 'Fast_and_Furious')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "lua",
-    "prompt": "-- Write a function to determine if the sum of the divisors of two integers are the same.\nlocal function are_equivalent(num1, num2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = are_equivalent\n    lu.assertEquals(candidate(36, 57), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(23, 47), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "lua",
-    "prompt": "-- Write a function to reverse each string in a given table of string values.\nlocal function reverse_string_list(stringlist)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_string_list\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue', 'White', 'Black'}), {'deR', 'neerG', 'eulB', 'etihW', 'kcalB'})\n    lu.assertEquals(candidate({'john', 'amal', 'joel', 'george'}), {'nhoj', 'lama', 'leoj', 'egroeg'})\n    lu.assertEquals(candidate({'jack', 'john', 'mary'}), {'kcaj', 'nhoj', 'yram'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "lua",
-    "prompt": "-- Write a function to compute the sum of digits of each number of a given table.\nlocal function sum_of_digits(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_of_digits\n    lu.assertEquals(candidate({10, 2, 56}), 14)\n    lu.assertEquals(candidate({{10, 20, 4, 5, 'b', 70, 'a'}}), 19)\n    lu.assertEquals(candidate({10, 20, -4, 5, -70}), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth number in the newman conway sequence.\nlocal function sequence(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequence\n    lu.assertEquals(candidate(10), 6)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n largest integers from a given table of numbers, returned in descending order.\nlocal function heap_queue_largest(nums, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_queue_largest\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), {85, 75, 65})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), {85, 75})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), {85, 75, 65, 58, 35})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "lua",
-    "prompt": "-- Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlocal function loss_amount(actual_cost, sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = loss_amount\n    lu.assertEquals(candidate(1500, 1200), 0)\n    lu.assertEquals(candidate(100, 200), 100)\n    lu.assertEquals(candidate(2000, 5000), 3000)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "lua",
-    "prompt": "-- Write a function to find the union of the elements of two given tables and output them in sorted order.\nlocal function union_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = union_elements\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 4, 5, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {3, 4, 5, 6}), {1, 2, 3, 4, 5, 6})\n    lu.assertEquals(candidate({11, 12, 13, 14}, {13, 15, 16, 17}), {11, 12, 13, 14, 15, 16, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the length of the longest subtables.\nlocal function Find_Max_Length(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max_Length\n    lu.assertEquals(candidate({{1}, {1, 4}, {5, 6, 7, 8}}), 4)\n    lu.assertEquals(candidate({{0, 1}, {2, 2}, {3, 2, 1}}), 3)\n    lu.assertEquals(candidate({{7}, {22, 23}, {13, 14, 15}, {10, 20, 30, 40, 50}}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "lua",
-    "prompt": "-- Write a function to remove the parenthesis and what is inbetween them from a string.\nlocal function remove_parenthesis(items)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_parenthesis\n    lu.assertEquals(candidate({'python (chrome)'}), 'python')\n    lu.assertEquals(candidate({'string(.abc)'}), 'string')\n    lu.assertEquals(candidate({'alpha(num)'}), 'alpha')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find whether the parity of a given number is odd.\nlocal function find_Parity(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Parity\n    lu.assertEquals(candidate(12), false)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median length of a trapezium.\nlocal function median_trapezium(base1, base2, height)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_trapezium\n    lu.assertEquals(candidate(15, 25, 35), 20)\n    lu.assertEquals(candidate(10, 20, 30), 15)\n    lu.assertEquals(candidate(6, 9, 4), 7.5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "lua",
-    "prompt": "-- Write a function to find nth centered hexagonal number.\nlocal function centered_hexagonal_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = centered_hexagonal_number\n    lu.assertEquals(candidate(10), 271)\n    lu.assertEquals(candidate(2), 7)\n    lu.assertEquals(candidate(9), 217)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "lua",
-    "prompt": "-- Write a function to find number of tables present in the given table.\nlocal function find_lists(Input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lists\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}}), 2)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}}), 3)\n    lu.assertEquals(candidate({9, 8, 7, 6, 5, 4, 3, 2, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlocal function get_max_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_sum\n    lu.assertEquals(candidate(60), 106)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the length of the longest word.\nlocal function len_log(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = len_log\n    lu.assertEquals(candidate({'python', 'PHP', 'bigdata'}), 7)\n    lu.assertEquals(candidate({'a', 'ab', 'abc'}), 3)\n    lu.assertEquals(candidate({'small', 'big', 'tall'}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "lua",
-    "prompt": "-- Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nlocal function sector_area(r, a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sector_area\n    lu.assertEquals(candidate(4, 45), 6.283185307179586)\n    lu.assertEquals(candidate(9, 45), 31.808625617596654)\n    lu.assertEquals(candidate(9, 361), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether every odd index contains odd numbers of a given table.\nlocal function odd_position(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_position\n    lu.assertEquals(candidate({2, 1, 4, 3, 6, 7, 6, 3}), true)\n    lu.assertEquals(candidate({4, 1, 2}), true)\n    lu.assertEquals(candidate({1, 2, 3}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "lua",
-    "prompt": "-- Write a function to join a table of multiple integers into a single integer.\nlocal function multiple_to_single(L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiple_to_single\n    lu.assertEquals(candidate({11, 33, 50}), 113350)\n    lu.assertEquals(candidate({-1, 2, 3, 4, 5, 6}), -123456)\n    lu.assertEquals(candidate({10, 15, 20, 25}), 10152025)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find whether a number is divisible by 11.\nlocal function is_Diff(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Diff\n    lu.assertEquals(candidate(12345), false)\n    lu.assertEquals(candidate(1212112), true)\n    lu.assertEquals(candidate(1212), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "lua",
-    "prompt": "-- Write a function to perform index wise multiplication of table elements in the given two tables.\nlocal function index_multiplication(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_multiplication\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 21}, {12, 45}, {2, 9}, {7, 30}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{14, 32}, {20, 60}, {6, 20}, {16, 44}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{24, 45}, {30, 77}, {12, 33}, {27, 60}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "lua",
-    "prompt": "-- Write a function to convert table string to integer table.\nlocal function tuple_str_int(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_str_int\n    lu.assertEquals(candidate('(7, 8, 9)'), {7, 8, 9})\n    lu.assertEquals(candidate('(1, 2, 3)'), {1, 2, 3})\n    lu.assertEquals(candidate('(4, 5, 6)'), {4, 5, 6})\n    lu.assertEquals(candidate('(7, 81, 19)'), {7, 81, 19})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "lua",
-    "prompt": "-- Write a function to sum all amicable numbers from 1 to a specified number.\nlocal function amicable_numbers_sum(limit)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = amicable_numbers_sum\n    lu.assertEquals(candidate(999), 504)\n    lu.assertEquals(candidate(9999), 31626)\n    lu.assertEquals(candidate(99), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "lua",
-    "prompt": "-- Write a function to remove odd characters in a string.\nlocal function remove_odd(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate('python'), 'yhn')\n    lu.assertEquals(candidate('program'), 'rga')\n    lu.assertEquals(candidate('language'), 'agae')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "lua",
-    "prompt": "-- Write a function that takes as input a table of numbers (t_1,...,t_{N+1}) and returns a table of length N where the i-th element of the table is equal to t_i * t_{i+1}.\nlocal function multiply_elements(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_elements\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {5, 35, 56, 80})\n    lu.assertEquals(candidate({2, 4, 5, 6, 7}), {8, 20, 30, 42})\n    lu.assertEquals(candidate({12, 13, 14, 9, 15}), {156, 182, 126, 135})\n    lu.assertEquals(candidate({12}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of rotations required to generate a sorted table. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-table/\nlocal function count_rotation(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_rotation\n    lu.assertEquals(candidate({3, 2, 1}), 1)\n    lu.assertEquals(candidate({4, 5, 1, 2, 3}), 2)\n    lu.assertEquals(candidate({7, 8, 9, 1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 2, 3}), 0)\n    lu.assertEquals(candidate({1, 3, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "lua",
-    "prompt": "-- Write a function to extract the number of unique tables in the given table.\nlocal function extract_freq(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_freq\n    lu.assertEquals(candidate({{3, 4}, {1, 2}, {4, 3}, {5, 6}}), 3)\n    lu.assertEquals(candidate({{4, 15}, {2, 3}, {5, 4}, {6, 7}}), 4)\n    lu.assertEquals(candidate({{5, 16}, {2, 3}, {6, 5}, {6, 9}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "lua",
-    "prompt": "-- The input is defined as two tables of the same length. Write a function to count indices where the tables have the same values.\nlocal function count_same_pair(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_same_pair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}), 4)\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 11)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 1)\n    lu.assertEquals(candidate({0, 1, 1, 2}, {0, 1, 2, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the value of 'a' to the power 'b'.\nlocal function power(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power\n    lu.assertEquals(candidate(3, 4), 81)\n    lu.assertEquals(candidate(2, 3), 8)\n    lu.assertEquals(candidate(5, 5), 3125)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "lua",
-    "prompt": "-- Write function to find the sum of all items in the given table.\nlocal function return_sum(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = return_sum\n    lu.assertEquals(candidate({['a'] = 100, ['b'] = 200, ['c'] = 300}), 600)\n    lu.assertEquals(candidate({['a'] = 25, ['b'] = 18, ['c'] = 45}), 88)\n    lu.assertEquals(candidate({['a'] = 36, ['b'] = 39, ['c'] = 49}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "lua",
-    "prompt": "-- Write a function to return a table of all pairs of consecutive items in a given table.\nlocal function pair_wise(l1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_wise\n    lu.assertEquals(candidate({1, 1, 2, 3, 3, 4, 4, 5}), {{1, 1}, {1, 2}, {2, 3}, {3, 3}, {3, 4}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), {{1, 5}, {5, 7}, {7, 9}, {9, 10}})\n    lu.assertEquals(candidate({5, 1, 9, 7, 10}), {{5, 1}, {1, 9}, {9, 7}, {7, 10}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 10}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to split a string into characters.\nlocal function split(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split\n    lu.assertEquals(candidate('python'), {'p', 'y', 't', 'h', 'o', 'n'})\n    lu.assertEquals(candidate('Name'), {'N', 'a', 'm', 'e'})\n    lu.assertEquals(candidate('program'), {'p', 'r', 'o', 'g', 'r', 'a', 'm'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "lua",
-    "prompt": "-- Write a function to find minimum of three numbers.\nlocal function min_of_three(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_of_three\n    lu.assertEquals(candidate(10, 20, 0), 0)\n    lu.assertEquals(candidate(19, 15, 18), 15)\n    lu.assertEquals(candidate(-10, -20, -30), -30)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nlocal function is_Sum_Of_Powers_Of_Two(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sum_Of_Powers_Of_Two\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(7), false)\n    lu.assertEquals(candidate(14), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nlocal function get_Char(strr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Char\n    lu.assertEquals(candidate('abc'), 'f')\n    lu.assertEquals(candidate('gfg'), 't')\n    lu.assertEquals(candidate('ab'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "lua",
-    "prompt": "-- Write a function to return the sum of all divisors of a number.\nlocal function sum_div(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_div\n    lu.assertEquals(candidate(8), 7)\n    lu.assertEquals(candidate(12), 16)\n    lu.assertEquals(candidate(7), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "lua",
-    "prompt": "-- Write a luathon function that returns the number of integer elements in a given table.\nlocal function count_integer(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_integer\n    lu.assertEquals(candidate({1, 2, 'abc', 1.2}), 2)\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1.2, 4, 5.1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to remove duplicate numbers from a given number of tables.\nlocal function two_unique_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = two_unique_nums\n    lu.assertEquals(candidate({1, 2, 3, 2, 3, 4, 5}), {1, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 5}), {1, 3, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "lua",
-    "prompt": "-- Write a function to find whether a given table of integers contains any duplicate element.\nlocal function test_duplicate(arraynums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_duplicate\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), true)\n    lu.assertEquals(candidate({1, 1, 2, 2, 3, 3, 4, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "lua",
-    "prompt": "-- Write a function which returns nth catalan number.\nlocal function catalan_number(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = catalan_number\n    lu.assertEquals(candidate(10), 16796)\n    lu.assertEquals(candidate(9), 4862)\n    lu.assertEquals(candidate(7), 429)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "lua",
-    "prompt": "-- Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlocal function power_base_sum(base, power)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power_base_sum\n    lu.assertEquals(candidate(2, 100), 115)\n    lu.assertEquals(candidate(8, 10), 37)\n    lu.assertEquals(candidate(8, 15), 62)\n    lu.assertEquals(candidate(3, 3), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in two tables and replaces the last element of the first table with the elements of the second table.\nlocal function replace_list(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_list\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 2, 4, 6, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8}), {1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({'red', 'blue', 'green'}, {'yellow'}), {'red', 'blue', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth octagonal number.\nlocal function is_octagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_octagonal\n    lu.assertEquals(candidate(5), 65)\n    lu.assertEquals(candidate(10), 280)\n    lu.assertEquals(candidate(15), 645)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nlocal function replace_blank(str1, char)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_blank\n    lu.assertEquals(candidate('hello people', '@'), 'hello@people')\n    lu.assertEquals(candidate('python program language', '$'), 'python$program$language')\n    lu.assertEquals(candidate('blank space', '-'), 'blank-space')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "lua",
-    "prompt": "-- Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nlocal function replace_specialchar(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_specialchar\n    lu.assertEquals(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')\n    lu.assertEquals(candidate('a b c,d e f'), 'a:b:c:d:e:f')\n    lu.assertEquals(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "lua",
-    "prompt": "-- Write a function to convert a given table of positive integers into a single integer.\nlocal function tuple_to_int(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_int\n    lu.assertEquals(candidate({1, 2, 3}), 123)\n    lu.assertEquals(candidate({4, 5, 6}), 456)\n    lu.assertEquals(candidate({5, 6, 7}), 567)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "lua",
-    "prompt": "-- Write a function to find the third side of a right angled triangle.\nlocal function otherside_rightangle(w, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = otherside_rightangle\n    lu.assertEquals(candidate(7, 8), 10.63014581273465)\n    lu.assertEquals(candidate(3, 4), 5)\n    lu.assertEquals(candidate(7, 15), 16.55294535724685)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "lua",
-    "prompt": "-- Write a function to find the n most expensive items in a given dataset.\nlocal function expensive_items(items, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = expensive_items\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}}, 2), {{['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-1', ['price'] = 101.1}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}, {['name'] = 'Item-4', ['price'] = 22.75}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of the per-digit difference between two integers.\nlocal function digit_distance_nums(n1, n2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digit_distance_nums\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(23, 56), 6)\n    lu.assertEquals(candidate(123, 256), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "lua",
-    "prompt": "-- Write a function that checks if a strings contains 'z', except at the start and end of the word.\nlocal function text_match_wordz_middle(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz_middle\n    lu.assertEquals(candidate('pythonzabc.'), true)\n    lu.assertEquals(candidate('zxyabc.'), false)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "lua",
-    "prompt": "-- Write a function to remove leading zeroes from an ip address.\nlocal function removezero_ip(ip)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = removezero_ip\n    lu.assertEquals(candidate('216.08.094.196'), '216.8.94.196')\n    lu.assertEquals(candidate('12.01.024'), '12.1.24')\n    lu.assertEquals(candidate('216.08.094.0196'), '216.8.94.196')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "lua",
-    "prompt": "-- Write a function to count the number of subtables containing a particular element.\nlocal function count_element_in_list(list1, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_element_in_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {1, 11}, {1, 15, 7}}, 1), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'A'), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'E'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "lua",
-    "prompt": "-- Write a function to multiply two integers.\nlocal function multiply_int(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_int\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(5, 10), 50)\n    lu.assertEquals(candidate(4, 8), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "lua",
-    "prompt": "-- Write a function to find the pairwise addition of the neighboring elements of the given table.\nlocal function add_pairwise(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_pairwise\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {6, 12, 15, 18})\n    lu.assertEquals(candidate({2, 6, 8, 9, 11}), {8, 14, 17, 20})\n    lu.assertEquals(candidate({3, 7, 9, 10, 12}), {10, 16, 19, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum absolute product between numbers in pairs of tables within a given table.\nlocal function max_product_tuple(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 36)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 200)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 484)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4429,7 +19,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find the kth element in the given table using 1-based indexing.\nlocal function kth_element(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = kth_element\n    lu.assertEquals(candidate({12, 3, 5, 7, 19}, 2), 3)\n    lu.assertEquals(candidate({17, 24, 8, 23}, 3), 8)\n    lu.assertEquals(candidate({16, 21, 25, 36, 4}, 4), 36)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "lua",
-    "prompt": "-- Write a luathon function to interchange the first and last element in a given table.\nlocal function swap_List(newList)\n",
+    "prompt": "-- Write a function to convert a snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), {4, 2, 3, 4, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('python_program'), 'PythonProgram')\n    lu.assertEquals(candidate('python_language'), 'PythonLanguage')\n    lu.assertEquals(candidate('programming_language'), 'ProgrammingLanguage')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "lua",
-    "prompt": "-- Write a function to find the number of elements that occurs before the table element in the given table.\nlocal function count_first_elements(test_tup)\n",
+    "prompt": "-- Write a function to find the Eulerian number a(n, m).\nlocal function eulerian_num(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_first_elements\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), 3)\n    lu.assertEquals(candidate({2, 9, {5, 7}, 11}), 2)\n    lu.assertEquals(candidate({11, 15, 5, 8, {2, 3}, 8}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = eulerian_num\n    lu.assertEquals(candidate(3, 1), 4)\n    lu.assertEquals(candidate(4, 1), 11)\n    lu.assertEquals(candidate(5, 3), 26)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "lua",
-    "prompt": "-- Write a function to locate the right insertion point for a specified value in sorted order.\nlocal function right_insertion(a, x)\n",
+    "prompt": "-- Write a function to sort each subtable of strings in a given table of tables.\nlocal function sort_sublists(input_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{' red ', 'green'}, {'blue ', ' black'}, {' orange', 'brown'}}), {{' red ', 'green'}, {' black', 'blue '}, {' orange', 'brown'}})\n    lu.assertEquals(candidate({{'zilver', 'gold'}, {'magnesium', 'aluminium'}, {'steel', 'bronze'}}), {{'gold', 'zilver'}, {'aluminium', 'magnesium'}, {'bronze', 'steel'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "lua",
-    "prompt": "-- Write a function to check if the given number is woodball or not.\nlocal function is_woodall(x)\n",
+    "prompt": "-- Write a luathon function to count true booleans in the given table.\nlocal function count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_woodall\n    lu.assertEquals(candidate(383), true)\n    lu.assertEquals(candidate(254), false)\n    lu.assertEquals(candidate(200), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count\n    lu.assertEquals(candidate({true, false, true}), 2)\n    lu.assertEquals(candidate({false, false}), 0)\n    lu.assertEquals(candidate({true, true, true}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "lua",
-    "prompt": "-- Write a function to sort the given table by using shell sort.\nlocal function shell_sort(my_list)\n",
+    "prompt": "-- Write a function to append the given table to the given tables.\nlocal function add_lists(test_list, test_tup)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = shell_sort\n    lu.assertEquals(candidate({12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), {2, 3, 4, 5, 12, 12, 23, 56, 81, 95})\n    lu.assertEquals(candidate({24, 22, 39, 34, 87, 73, 68}), {22, 24, 34, 39, 68, 73, 87})\n    lu.assertEquals(candidate({32, 30, 16, 96, 82, 83, 74}), {16, 30, 32, 74, 82, 83, 96})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_lists\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {9, 10, 5, 6, 7})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {10, 11, 6, 7, 8})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of pairs whose xor value is odd.\nlocal function find_Odd_Pair(A, N)\n",
+    "prompt": "-- Write a function to merge three tables into a single sorted table.\nlocal function merge_sorted_list(num1, num2, num3)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Odd_Pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}, 5), 6)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}, 7), 12)\n    lu.assertEquals(candidate({1, 2, 3}, 3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_sorted_list\n    lu.assertEquals(candidate({25, 24, 15, 4, 5, 29, 110}, {19, 20, 11, 56, 25, 233, 154}, {24, 26, 54, 48}), {4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233})\n    lu.assertEquals(candidate({1, 3, 5, 6, 8, 9}, {2, 5, 7, 11}, {1, 4, 7, 8, 12}), {1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12})\n    lu.assertEquals(candidate({18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, {25, 35, 22, 85, 14, 65, 75, 25, 58}, {12, 74, 9, 50, 61, 41}), {1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of all odd natural numbers within the range l and r.\nlocal function sum_in_range(l, r)\n",
+    "prompt": "-- Write a luathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nlocal function odd_Equivalent(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_in_range\n    lu.assertEquals(candidate(2, 5), 8)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 13), 40)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_Equivalent\n    lu.assertEquals(candidate('011001', 6), 3)\n    lu.assertEquals(candidate('11011', 5), 4)\n    lu.assertEquals(candidate('1010', 4), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "lua",
-    "prompt": "-- Write a function that returns the perimeter of a square given its side length as input.\nlocal function square_perimeter(a)\n",
+    "prompt": "-- Write a function to check if a string represents an integer or not.\nlocal function check_integer(text)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_perimeter\n    lu.assertEquals(candidate(10), 40)\n    lu.assertEquals(candidate(5), 20)\n    lu.assertEquals(candidate(4), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_integer\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('1'), true)\n    lu.assertEquals(candidate('12345'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "lua",
-    "prompt": "-- Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlocal function is_polite(n)\n",
+    "prompt": "-- Write a function to convert a given table of positive integers into a single integer.\nlocal function tuple_to_int(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_polite\n    lu.assertEquals(candidate(7), 11)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(9), 13)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "lua",
-    "prompt": "-- Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlocal function sum_series(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_series\n    lu.assertEquals(candidate(6), 12)\n    lu.assertEquals(candidate(10), 30)\n    lu.assertEquals(candidate(9), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "lua",
-    "prompt": "-- Write a function to find the dissimilar elements in the given two tables.\nlocal function find_dissimilar(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_dissimilar\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {7, 2, 3, 9}), {1, 4, 7, 9})\n    lu.assertEquals(candidate({21, 11, 25, 26}, {26, 34, 21, 36}), {34, 36, 11, 25})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "lua",
-    "prompt": "-- Write a function to return two words from a table of words starting with letter 'p'.\nlocal function start_withp(words)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = start_withp\n    lu.assertEquals(candidate({'Python PHP', 'Java JavaScript', 'c c++'}), {'Python', 'PHP'})\n    lu.assertEquals(candidate({'Python Programming', 'Java Programming'}), {'Python', 'Programming'})\n    lu.assertEquals(candidate({'Pqrst Pqr', 'qrstuv'}), {'Pqrst', 'Pqr'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "lua",
-    "prompt": "-- Write a function to convert the given snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('android_tv'), 'AndroidTv')\n    lu.assertEquals(candidate('google_pixel'), 'GooglePixel')\n    lu.assertEquals(candidate('apple_watch'), 'AppleWatch')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "lua",
-    "prompt": "-- Write a function to find the volume of a cube given its side length.\nlocal function volume_cube(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = volume_cube\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(2), 8)\n    lu.assertEquals(candidate(5), 125)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given month number contains 31 days or not.\nlocal function check_monthnumb_number(monthnum2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumb_number\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check whether all the bits are unset in the given range or not.\nlocal function all_Bits_Set_In_The_Given_Range(n, l, r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Bits_Set_In_The_Given_Range\n    lu.assertEquals(candidate(4, 1, 2), true)\n    lu.assertEquals(candidate(17, 2, 4), true)\n    lu.assertEquals(candidate(39, 4, 6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to get the first element of each subtable.\nlocal function Extract(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Extract\n    lu.assertEquals(candidate({{1, 2}, {3, 4, 5}, {6, 7, 8, 9}}), {1, 3, 6})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5}}), {1, 4})\n    lu.assertEquals(candidate({{9, 8, 1}, {1, 2}}), {9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "lua",
-    "prompt": "-- Write a function to find the surface area of a cylinder.\nlocal function surfacearea_cylinder(r, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cylinder\n    lu.assertEquals(candidate(10, 5), 942.45)\n    lu.assertEquals(candidate(4, 5), 226.18800000000002)\n    lu.assertEquals(candidate(4, 10), 351.848)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "lua",
-    "prompt": "-- Write a function to sum the length of the names of a given table of names after removing the names that start with a lowercase letter.\nlocal function sample_nam(sample_names)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sample_nam\n    lu.assertEquals(candidate({'sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'}), 16)\n    lu.assertEquals(candidate({'php', 'res', 'Python', 'abcd', 'Java', 'aaa'}), 10)\n    lu.assertEquals(candidate({'abcd', 'Python', 'abba', 'aba'}), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "lua",
-    "prompt": "-- Write a function to create the next bigger number by rearranging the digits of a given number.\nlocal function rearrange_bigger(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rearrange_bigger\n    lu.assertEquals(candidate(12), 21)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(102), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "lua",
-    "prompt": "-- Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlocal function perimeter_pentagon(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perimeter_pentagon\n    lu.assertEquals(candidate(5), 25)\n    lu.assertEquals(candidate(10), 50)\n    lu.assertEquals(candidate(15), 75)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "lua",
-    "prompt": "-- Write a function that takes a table and finds the maximum sum of a bitonic subsequence for the given table, where a sequence is bitonic if it is first increasing and then decreasing.\nlocal function max_sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum\n    lu.assertEquals(candidate({1, 15, 51, 45, 33, 100, 12, 18, 9}), 194)\n    lu.assertEquals(candidate({80, 60, 30, 40, 20, 10}), 210)\n    lu.assertEquals(candidate({2, 3, 14, 16, 21, 23, 29, 30}), 138)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "lua",
-    "prompt": "-- Write a function to remove uneven elements in the nested mixed table.\nlocal function extract_even(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_even\n    lu.assertEquals(candidate({4, 5, {7, 6, {2, 4}}, 6, 8}), {4, {6, {2, 4}}, 6, 8})\n    lu.assertEquals(candidate({5, 6, {8, 7, {4, 8}}, 7, 9}), {6, {8, {4, 8}}})\n    lu.assertEquals(candidate({5, 6, {9, 8, {4, 6}}, 8, 10}), {6, {8, {4, 6}}, 8, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_int\n    lu.assertEquals(candidate({1, 2, 3}), 123)\n    lu.assertEquals(candidate({4, 5, 6}), 456)\n    lu.assertEquals(candidate({5, 6, 7}), 567)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -4789,249 +169,9 @@
     "language": "lua",
     "prompt": "-- Write a function to convert all possible convertible elements in a table of tables to floats.\nlocal function list_to_float(test_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_to_float\n    lu.assertEquals(candidate({{'3', '4'}, {'1', '26.45'}, {'7.32', '8'}, {'4', '8'}}), {{3.0, 4.0}, {1.0, 26.45}, {7.32, 8.0}, {4.0, 8.0}})\n    lu.assertEquals(candidate({{'4', '4'}, {'2', '27'}, {'4.12', '9'}, {'7', '11'}}), {{4.0, 4.0}, {2.0, 27.0}, {4.12, 9.0}, {7.0, 11.0}})\n    lu.assertEquals(candidate({{'6', '78'}, {'5', '26.45'}, {'1.33', '4'}, {'82', '13'}}), {{6.0, 78.0}, {5.0, 26.45}, {1.33, 4.0}, {82.0, 13.0}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlocal function square_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 20)\n    lu.assertEquals(candidate(3), 56)\n    lu.assertEquals(candidate(4), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a table of numbers and the sum,\nlocal function get_pairs_count(arr, sum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_pairs_count\n    lu.assertEquals(candidate({1, 1, 1, 1}, 2), 6)\n    lu.assertEquals(candidate({1, 5, 7, -1, 5}, 6), 3)\n    lu.assertEquals(candidate({1, -2, 3}, 1), 1)\n    lu.assertEquals(candidate({-1, -2, 3}, -3), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "lua",
-    "prompt": "-- Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlocal function count_no_of_ways(n, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_no_of_ways\n    lu.assertEquals(candidate(2, 4), 16)\n    lu.assertEquals(candidate(3, 2), 6)\n    lu.assertEquals(candidate(4, 4), 228)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "lua",
-    "prompt": "-- Write a function to reverse words seperated by spaces in a given string.\nlocal function reverse_words(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_words\n    lu.assertEquals(candidate('python program'), 'program python')\n    lu.assertEquals(candidate('java language'), 'language java')\n    lu.assertEquals(candidate('indian man'), 'man indian')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to check if a given number is one less than twice its reverse.\nlocal function checks(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = checks\n    lu.assertEquals(candidate(70), false)\n    lu.assertEquals(candidate(23), false)\n    lu.assertEquals(candidate(73), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the last position of an element in a sorted table.\nlocal function last(arr, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last\n    lu.assertEquals(candidate({1, 2, 3}, 1), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, 4}, 1), 2)\n    lu.assertEquals(candidate({2, 3, 2, 3, 6, 8, 9}, 3), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "lua",
-    "prompt": "-- Write a luathon function that takes in a table and an element and counts the occcurences of the element in the table.\nlocal function count_X(tup, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_X\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), 0)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), 3)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "lua",
-    "prompt": "-- We say that an element is common for tables l1, l2, l3 if it appears in all three tables under the same index. Write a function to find common elements from three tables. The function should return a table.\nlocal function extract_index_list(l1, l2, l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_index_list\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 7})\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 6, 5}, {0, 1, 2, 3, 4, 6, 7}), {1, 6})\n    lu.assertEquals(candidate({1, 1, 3, 4, 6, 5, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 6, 6, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "lua",
-    "prompt": "-- Write a function to find the second smallest number in a table.\nlocal function second_smallest(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = second_smallest\n    lu.assertEquals(candidate({1, 2, -8, -2, 0, -2}), -2)\n    lu.assertEquals(candidate({1, 1, -0.5, 0, 2, -2, -2}), -0.5)\n    lu.assertEquals(candidate({2, 2}), None)\n    lu.assertEquals(candidate({2, 2, 2}), None)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to concatenate each element of table by the delimiter.\nlocal function concatenate_tuple(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate_tuple\n    lu.assertEquals(candidate({'ID', 'is', 4, 'UTS'}), 'ID-is-4-UTS')\n    lu.assertEquals(candidate({'QWE', 'is', 4, 'RTY'}), 'QWE-is-4-RTY')\n    lu.assertEquals(candidate({'ZEN', 'is', 4, 'OP'}), 'ZEN-is-4-OP')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to replace all spaces in the given string with '%20'.\nlocal function replace_spaces(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')\n    lu.assertEquals(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')\n    lu.assertEquals(candidate('I love Coding'), 'I%20love%20Coding')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "lua",
-    "prompt": "-- Write a function to find the sum of numbers in a table within a range specified by two indices.\nlocal function sum_range_list(list1, m, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_range_list\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), 29)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), 16)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), 38)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "lua",
-    "prompt": "-- Write a function to merge three dictionaries into a single table.\nlocal function merge_dictionaries_three(dict1, dict2, dict3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_dictionaries_three\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['O'] = 'Orange', ['W'] = 'White', ['B'] = 'Black'}), {['B'] = 'Black', ['R'] = 'Red', ['P'] = 'Pink', ['G'] = 'Green', ['W'] = 'White', ['O'] = 'Orange'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['L'] = 'lavender', ['B'] = 'Blue'}), {['W'] = 'White', ['P'] = 'Pink', ['B'] = 'Black', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['L'] = 'lavender', ['B'] = 'Blue'}, {['G'] = 'Green', ['W'] = 'White'}), {['B'] = 'Black', ['P'] = 'Pink', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender', ['W'] = 'White'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the minimum of two numbers.\nlocal function minimum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minimum\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(-5, -4), -5)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum difference between available pairs in the given table table.\nlocal function max_difference(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_difference\n    lu.assertEquals(candidate({{3, 5}, {1, 7}, {10, 3}, {1, 2}}), 7)\n    lu.assertEquals(candidate({{4, 6}, {2, 17}, {9, 13}, {11, 12}}), 15)\n    lu.assertEquals(candidate({{12, 35}, {21, 27}, {13, 23}, {41, 22}}), 23)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find element at a given index after number of rotations.\nlocal function find_Element(arr, ranges, rotations, index)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {{0, 2}, {0, 3}}, 2, 1), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}, {{0, 1}, {0, 2}}, 1, 2), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {{0, 1}, {0, 2}}, 1, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5044,7 +184,7 @@
     "language": "lua",
     "prompt": "-- Write a function to convert a string to a table of strings split on the space character.\nlocal function string_to_list(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_list\n    lu.assertEquals(candidate('python programming'), {'python', 'programming'})\n    lu.assertEquals(candidate('lists tuples strings'), {'lists', 'tuples', 'strings'})\n    lu.assertEquals(candidate('write a program'), {'write', 'a', 'program'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "lua",
     "prompt": "-- Write a luathon function to find the element that appears only once in a sorted table.\nlocal function search(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = search\n    lu.assertEquals(candidate({1, 1, 2, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8}), 8)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 4, 4}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a table by value.\nlocal function sort_counter(dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_counter\n    lu.assertEquals(candidate({['Math'] = 81, ['Physics'] = 83, ['Chemistry'] = 87}), {{'Chemistry', 87}, {'Physics', 83}, {'Math', 81}})\n    lu.assertEquals(candidate({['Math'] = 400, ['Physics'] = 300, ['Chemistry'] = 250}), {{'Math', 400}, {'Physics', 300}, {'Chemistry', 250}})\n    lu.assertEquals(candidate({['Math'] = 900, ['Physics'] = 1000, ['Chemistry'] = 1250}), {{'Chemistry', 1250}, {'Physics', 1000}, {'Math', 900}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5089,7 +214,7 @@
     "language": "lua",
     "prompt": "-- Write a luathon function to remove first and last occurrence of a given character from the string.\nlocal function remove_Occ(s, ch)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_Occ\n    lu.assertEquals(candidate('hello', 'l'), 'heo')\n    lu.assertEquals(candidate('abcda', 'a'), 'bcd')\n    lu.assertEquals(candidate('PHP', 'P'), 'H')\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "lua",
-    "prompt": "-- Write a function to find the lateral surface area of a cube given its side length.\nlocal function lateralsurface_cube(l)\n",
+    "prompt": "-- Write a function to find the maximum absolute product between numbers in pairs of tables within a given table.\nlocal function max_product_tuple(list1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cube\n    lu.assertEquals(candidate(5), 100)\n    lu.assertEquals(candidate(9), 324)\n    lu.assertEquals(candidate(10), 400)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 36)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 200)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 484)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "lua",
-    "prompt": "-- Write a function that takes two tables and returns true if they have at least one common element.\nlocal function common_element(list1, list2)\n",
+    "prompt": "-- Write a function to sum all amicable numbers from 1 to a specified number.\nlocal function amicable_numbers_sum(limit)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common_element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), None)\n    lu.assertEquals(candidate({'a', 'b', 'c'}, {'d', 'b', 'e'}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = amicable_numbers_sum\n    lu.assertEquals(candidate(999), 504)\n    lu.assertEquals(candidate(9999), 31626)\n    lu.assertEquals(candidate(99), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "lua",
-    "prompt": "-- Write a function to append the given table to the given tables.\nlocal function add_lists(test_list, test_tup)\n",
+    "prompt": "-- Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nlocal function find_length(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_lists\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {9, 10, 5, 6, 7})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {10, 11, 6, 7, 8})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_length\n    lu.assertEquals(candidate('11000010001'), 6)\n    lu.assertEquals(candidate('10111'), 1)\n    lu.assertEquals(candidate('11011101100101'), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "lua",
-    "prompt": "-- Write a function to compute the n-th power of each number in a table.\nlocal function nth_nums(nums, n)\n",
+    "prompt": "-- Write a luathon function to find the sum of common divisors of two given numbers.\nlocal function sum(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = nth_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}, 3), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}, 5), {248832, 759375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum\n    lu.assertEquals(candidate(10, 15), 6)\n    lu.assertEquals(candidate(100, 150), 93)\n    lu.assertEquals(candidate(4, 6), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "lua",
-    "prompt": "-- Write a function to sort a table of elements.\nlocal function pancake_sort(nums)\n",
+    "prompt": "-- Write a function to multiply two integers.\nlocal function multiply_int(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pancake_sort\n    lu.assertEquals(candidate({15, 79, 25, 38, 69}), {15, 25, 38, 69, 79})\n    lu.assertEquals(candidate({98, 12, 54, 36, 85}), {12, 36, 54, 85, 98})\n    lu.assertEquals(candidate({41, 42, 32, 12, 23}), {12, 23, 32, 41, 42})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "lua",
-    "prompt": "-- Write a function to find the median of three numbers.\nlocal function median_numbers(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_numbers\n    lu.assertEquals(candidate(25, 55, 65), 55.0)\n    lu.assertEquals(candidate(20, 10, 30), 20.0)\n    lu.assertEquals(candidate(15, 45, 75), 45.0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the entered number is greater than the elements of the given table.\nlocal function check_greater(arr, number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_greater\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 4), false)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}, 8), true)\n    lu.assertEquals(candidate({9, 7, 4, 8, 6, 1}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and element and checks whether all items in the table are equal to the given element.\nlocal function check_element(list, element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_element\n    lu.assertEquals(candidate({'green', 'orange', 'black', 'white'}, 'blue'), false)\n    lu.assertEquals(candidate({1, 2, 3, 4}, 7), false)\n    lu.assertEquals(candidate({'green', 'green', 'green', 'green'}, 'green'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "lua",
-    "prompt": "-- Write a function to extract specified size of strings from a given table of string values.\nlocal function extract_string(str, l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_string\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 8), {'practice', 'solution'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 6), {'Python'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 9), {'exercises'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "lua",
-    "prompt": "-- Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nlocal function text_lowercase_underscore(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_lowercase_underscore\n    lu.assertEquals(candidate('aab_cbbbc'), true)\n    lu.assertEquals(candidate('aab_Abbbc'), false)\n    lu.assertEquals(candidate('Aaab_abbbc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to trim each table by k in the given tables.\nlocal function trim_tuple(test_list, K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = trim_tuple\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 2), {{2}, {9}, {2}, {2}})\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 1), {{3, 2, 1}, {4, 9, 2}, {1, 2, 3}, {8, 2, 1}})\n    lu.assertEquals(candidate({{7, 8, 4, 9}, {11, 8, 12, 4}, {4, 1, 7, 8}, {3, 6, 9, 7}}, 1), {{8, 4}, {8, 12}, {1, 7}, {6, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the subtable having minimum length.\nlocal function Find_Min(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1})\n    lu.assertEquals(candidate({{1, 1}, {1, 1, 1}, {1, 2, 7, 8}}), {1, 1})\n    lu.assertEquals(candidate({{'x'}, {'x', 'y'}, {'x', 'y', 'z'}}), {'x'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "lua",
-    "prompt": "-- Write a function to filter odd numbers.\nlocal function filter_oddnumbers(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_oddnumbers\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 3, 5, 7, 9})\n    lu.assertEquals(candidate({10, 20, 45, 67, 84, 93}), {45, 67, 93})\n    lu.assertEquals(candidate({5, 7, 9, 8, 6, 4, 3}), {5, 7, 9, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "lua",
-    "prompt": "-- Write a function to find the first adverb ending with ly and its positions in a given string.\nlocal function find_adverbs(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverbs\n    lu.assertEquals(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')\n    lu.assertEquals(candidate('Please handle the situation carefuly'), '28-36: carefuly')\n    lu.assertEquals(candidate('Complete the task quickly'), '18-25: quickly')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "lua",
-    "prompt": "-- Write a function which given a matrix represented as a table of tables returns the max of the n'th column.\nlocal function max_of_nth(test_list, N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_of_nth\n    lu.assertEquals(candidate({{5, 6, 7}, {1, 3, 5}, {8, 9, 19}}, 2), 19)\n    lu.assertEquals(candidate({{6, 7, 8}, {2, 4, 6}, {9, 10, 20}}, 1), 10)\n    lu.assertEquals(candidate({{7, 8, 9}, {3, 5, 7}, {10, 11, 21}}, 1), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "lua",
-    "prompt": "-- Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nlocal function decimal_to_binary(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(8), '1000')\n    lu.assertEquals(candidate(18), '10010')\n    lu.assertEquals(candidate(7), '111')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and length n, and generates all combinations (with repetition) of the elements of the table and returns a table with a table for each combination.\nlocal function combinations_colors(l, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_colors\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 1), {{'Red'}, {'Green'}, {'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 2), {{'Red', 'Red'}, {'Red', 'Green'}, {'Red', 'Blue'}, {'Green', 'Green'}, {'Green', 'Blue'}, {'Blue', 'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 3), {{'Red', 'Red', 'Red'}, {'Red', 'Red', 'Green'}, {'Red', 'Red', 'Blue'}, {'Red', 'Green', 'Green'}, {'Red', 'Green', 'Blue'}, {'Red', 'Blue', 'Blue'}, {'Green', 'Green', 'Green'}, {'Green', 'Green', 'Blue'}, {'Green', 'Blue', 'Blue'}, {'Blue', 'Blue', 'Blue'}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "lua",
-    "prompt": "-- Write a function to remove all whitespaces from a string.\nlocal function remove_all_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_all_spaces\n    lu.assertEquals(candidate('python  program'), 'pythonprogram')\n    lu.assertEquals(candidate('python   programming    language'), 'pythonprogramminglanguage')\n    lu.assertEquals(candidate('python                     program'), 'pythonprogram')\n    lu.assertEquals(candidate('   python                     program'), 'pythonprogram')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nlocal function min_Swaps(str1, str2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Swaps\n    lu.assertEquals(candidate('1101', '1110'), 1)\n    lu.assertEquals(candidate('111', '000'), 'Not Possible')\n    lu.assertEquals(candidate('111', '110'), 'Not Possible')\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to create a new table from the given string and table.\nlocal function new_tuple(test_list, test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = new_tuple\n    lu.assertEquals(candidate({'WEB', 'is'}, 'best'), {'WEB', 'is', 'best'})\n    lu.assertEquals(candidate({'We', 'are'}, 'Developers'), {'We', 'are', 'Developers'})\n    lu.assertEquals(candidate({'Part', 'is'}, 'Wrong'), {'Part', 'is', 'Wrong'})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the product of the table multiplication modulo n.\nlocal function find_remainder(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_remainder\n    lu.assertEquals(candidate({100, 10, 5, 25, 35, 14}, 11), 9)\n    lu.assertEquals(candidate({1, 1, 1}, 1), 0)\n    lu.assertEquals(candidate({1, 2, 1}, 2), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "lua",
-    "prompt": "-- Write a function to find the minimum value in a given heterogeneous table.\nlocal function min_val(listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 2)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 15)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "lua",
-    "prompt": "-- Write a function to find the ration of positive numbers in a table of integers.\nlocal function positive_count(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = positive_count\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), 0.54)\n    lu.assertEquals(candidate({2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 0.69)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), 0.56)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "lua",
-    "prompt": "-- Write a function to add the given table to the given table.\nlocal function add_tuple(test_list, test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_tuple\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {5, 6, 7, 9, 10})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {6, 7, 8, 10, 11})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {7, 8, 9, 11, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "lua",
-    "prompt": "-- Write a function to find maximum run of uppercase characters in the given string.\nlocal function max_run_uppercase(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_run_uppercase\n    lu.assertEquals(candidate('GeMKSForGERksISBESt'), 5)\n    lu.assertEquals(candidate('PrECIOusMOVemENTSYT'), 6)\n    lu.assertEquals(candidate('GooGLEFluTTER'), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "lua",
-    "prompt": "-- Write a function to sort a given matrix in ascending order according to the sum of its rows.\nlocal function sort_matrix(M)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_matrix\n    lu.assertEquals(candidate({{1, 2, 3}, {2, 4, 5}, {1, 1, 1}}), {{1, 1, 1}, {1, 2, 3}, {2, 4, 5}})\n    lu.assertEquals(candidate({{1, 2, 3}, {-2, 4, -5}, {1, -1, 1}}), {{-2, 4, -5}, {1, -1, 1}, {1, 2, 3}})\n    lu.assertEquals(candidate({{5, 8, 9}, {6, 4, 3}, {2, 1, 4}}), {{2, 1, 4}, {6, 4, 3}, {5, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "lua",
-    "prompt": "-- Write a function to count those characters which have vowels as their neighbors in the given string.\nlocal function count_vowels(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_vowels\n    lu.assertEquals(candidate('bestinstareels'), 7)\n    lu.assertEquals(candidate('partofthejourneyistheend'), 12)\n    lu.assertEquals(candidate('amazonprime'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "lua",
-    "prompt": "-- Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlocal function max_sum_increasing_subseq(a, n, index, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_increasing_subseq\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), 11)\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), 7)\n    lu.assertEquals(candidate({11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), 71)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_int\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(5, 10), 50)\n    lu.assertEquals(candidate(4, 8), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5524,7 +304,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find words that are longer than n characters from a given table of words.\nlocal function long_words(n, str)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = long_words\n    lu.assertEquals(candidate(3, 'python is a programming language'), {'python', 'programming', 'language'})\n    lu.assertEquals(candidate(2, 'writing a program'), {'writing', 'program'})\n    lu.assertEquals(candidate(5, 'sorting list'), {'sorting'})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of non-repeated elements in a given table.\nlocal function find_sum(arr)\n",
+    "prompt": "-- Write a function to calculate whether the matrix is a magic square.\nlocal function magic_square_test(my_matrix)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_sum\n    lu.assertEquals(candidate({1, 2, 3, 1, 1, 4, 5, 6}), 21)\n    lu.assertEquals(candidate({1, 10, 9, 4, 2, 10, 10, 45, 4}), 71)\n    lu.assertEquals(candidate({12, 10, 9, 45, 2, 10, 10, 45, 10}), 78)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = magic_square_test\n    lu.assertEquals(candidate({{7, 12, 1, 14}, {2, 13, 8, 11}, {16, 3, 10, 5}, {9, 6, 15, 4}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 8}}), true)\n    lu.assertEquals(candidate({{2, 7, 6}, {9, 5, 1}, {4, 3, 7}}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "lua",
-    "prompt": "-- Write a function to convert the given table to a key-value table using adjacent elements. https://www.geeksforgeeks.org/luathon-convert-table-to-adjacent-pair-table/\nlocal function tuple_to_dict(test_tup)\n",
+    "prompt": "-- Write a function to sort a given matrix in ascending order according to the sum of its rows.\nlocal function sort_matrix(M)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_dict\n    lu.assertEquals(candidate({1, 5, 7, 10, 13, 5}), {[1] = 5, [7] = 10, [13] = 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {[1] = 2, [3] = 4, [5] = 6})\n    lu.assertEquals(candidate({7, 8, 9, 10, 11, 12}), {[7] = 8, [9] = 10, [11] = 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_matrix\n    lu.assertEquals(candidate({{1, 2, 3}, {2, 4, 5}, {1, 1, 1}}), {{1, 1, 1}, {1, 2, 3}, {2, 4, 5}})\n    lu.assertEquals(candidate({{1, 2, 3}, {-2, 4, -5}, {1, -1, 1}}), {{-2, 4, -5}, {1, -1, 1}, {1, 2, 3}})\n    lu.assertEquals(candidate({{5, 8, 9}, {6, 4, 3}, {2, 1, 4}}), {{2, 1, 4}, {6, 4, 3}, {5, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "lua",
-    "prompt": "-- Write a function to extract all the adjacent coordinates of the given coordinate table.\nlocal function get_coordinates(test_tup)\n",
+    "prompt": "-- Write a function to find the item with maximum frequency in a given table.\nlocal function max_occurrences(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_coordinates\n    lu.assertEquals(candidate({3, 4}), {{2, 3}, {2, 4}, {2, 5}, {3, 3}, {3, 4}, {3, 5}, {4, 3}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({4, 5}), {{3, 4}, {3, 5}, {3, 6}, {4, 4}, {4, 5}, {4, 6}, {5, 4}, {5, 5}, {5, 6}})\n    lu.assertEquals(candidate({5, 6}), {{4, 5}, {4, 6}, {4, 7}, {5, 5}, {5, 6}, {5, 7}, {6, 5}, {6, 6}, {6, 7}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "lua",
-    "prompt": "-- Write a function to check if all the elements in table have same data type or not.\nlocal function check_type(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_type\n    lu.assertEquals(candidate({5, 6, 7, 3, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, '4'}), false)\n    lu.assertEquals(candidate({3, 2, 1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the smallest missing number from a sorted table of natural numbers.\nlocal function find_First_Missing(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_First_Missing\n    lu.assertEquals(candidate({0, 1, 2, 3}), 4)\n    lu.assertEquals(candidate({0, 1, 2, 6, 9}), 3)\n    lu.assertEquals(candidate({2, 3, 5, 8, 9}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the given number is undulating or not.\nlocal function is_undulating(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_undulating\n    lu.assertEquals(candidate(1212121), true)\n    lu.assertEquals(candidate(1991), false)\n    lu.assertEquals(candidate(121), true)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "lua",
-    "prompt": "-- Write a function to find minimum k records from table table. https://www.geeksforgeeks.org/luathon-find-minimum-k-records-from-table-table/ - in this case a verbatim colua of test cases\nlocal function min_k(test_list, K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_k\n    lu.assertEquals(candidate({{'Manjeet', 10}, {'Akshat', 4}, {'Akash', 2}, {'Nikhil', 8}}, 2), {{'Akash', 2}, {'Akshat', 4}})\n    lu.assertEquals(candidate({{'Sanjeev', 11}, {'Angat', 5}, {'Akash', 3}, {'Nepin', 9}}, 3), {{'Akash', 3}, {'Angat', 5}, {'Nepin', 9}})\n    lu.assertEquals(candidate({{'tanmay', 14}, {'Amer', 11}, {'Ayesha', 9}, {'SKD', 16}}, 1), {{'Ayesha', 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to count the number of substrings with the sum of digits equal to their length.\nlocal function count_Substrings(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Substrings\n    lu.assertEquals(candidate('112112'), 6)\n    lu.assertEquals(candidate('111'), 6)\n    lu.assertEquals(candidate('1101112'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "lua",
-    "prompt": "-- Write a function to find the nth decagonal number.\nlocal function is_num_decagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_num_decagonal\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(7), 175)\n    lu.assertEquals(candidate(10), 370)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table of tables and returns a table containing the rear element of each table.\nlocal function rear_extract(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rear_extract\n    lu.assertEquals(candidate({{1, 'Rash', 21}, {2, 'Varsha', 20}, {3, 'Kil', 19}}), {21, 20, 19})\n    lu.assertEquals(candidate({{1, 'Sai', 36}, {2, 'Ayesha', 25}, {3, 'Salman', 45}}), {36, 25, 45})\n    lu.assertEquals(candidate({{1, 'Sudeep', 14}, {2, 'Vandana', 36}, {3, 'Dawood', 56}}), {14, 36, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "lua",
-    "prompt": "-- Write a function to find the closest smaller number than n.\nlocal function closest_num(N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_num\n    lu.assertEquals(candidate(11), 10)\n    lu.assertEquals(candidate(7), 6)\n    lu.assertEquals(candidate(12), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "lua",
-    "prompt": "-- Write a function to find the combinations of sums with tables in the given table table. https://www.geeksforgeeks.org/luathon-combinations-of-sum-with-tables-in-table-table/\nlocal function find_combinations(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_combinations\n    lu.assertEquals(candidate({{2, 4}, {6, 7}, {5, 1}, {6, 10}}), {{8, 11}, {7, 5}, {8, 14}, {11, 8}, {12, 17}, {11, 11}})\n    lu.assertEquals(candidate({{3, 5}, {7, 8}, {6, 2}, {7, 11}}), {{10, 13}, {9, 7}, {10, 16}, {13, 10}, {14, 19}, {13, 13}})\n    lu.assertEquals(candidate({{4, 6}, {8, 9}, {7, 3}, {8, 12}}), {{12, 15}, {11, 9}, {12, 18}, {15, 12}, {16, 21}, {15, 15}})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "lua",
-    "prompt": "-- Given a square matrix of size N*N given as a table of tables, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nlocal function maxAverageOfPath(cost)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maxAverageOfPath\n    lu.assertEquals(candidate({{1, 2, 3}, {6, 5, 4}, {7, 3, 9}}), 5.2)\n    lu.assertEquals(candidate({{2, 3, 4}, {7, 6, 5}, {8, 4, 10}}), 6.2)\n    lu.assertEquals(candidate({{3, 4, 5}, {8, 7, 6}, {9, 5, 11}}), 7.2)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}), 5.8)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "lua",
-    "prompt": "-- Write a function that takes in a table and element and returns a table containing a boolean that indicates if the element is in the table and the index position of the element (or -1 if the element is not found).\nlocal function sequential_search(dlist, item)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequential_search\n    lu.assertEquals(candidate({11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), {true, 3})\n    lu.assertEquals(candidate({12, 32, 45, 62, 35, 47, 44, 61}, 61), {true, 7})\n    lu.assertEquals(candidate({9, 10, 17, 19, 22, 39, 48, 56}, 48), {true, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to remove odd numbers from a given table.\nlocal function remove_odd(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate({1, 2, 3}), {2})\n    lu.assertEquals(candidate({2, 4, 6}), {2, 4, 6})\n    lu.assertEquals(candidate({10, 20, 3}), {10, 20})\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "lua",
-    "prompt": "-- Write a function to check whether the product of numbers in a table is even or not.\nlocal function is_product_even(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_product_even\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 4}), true)\n    lu.assertEquals(candidate({1, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
-    "stop_tokens": [
-      "\nlocal",
-      "\nfunction",
-      "\n--",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "lua",
-    "prompt": "-- Write a luathon function to find the maximum of two numbers.\nlocal function maximum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate(5, 10), 10)\n    lu.assertEquals(candidate(-1, -2), -1)\n    lu.assertEquals(candidate(9, 7), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_occurrences\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2}), 2)\n    lu.assertEquals(candidate({2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18}), 8)\n    lu.assertEquals(candidate({10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5794,9 +364,759 @@
     "language": "lua",
     "prompt": "-- Write a luathon function to reverse only the vowels of a given string (where y is not a vowel).\nlocal function reverse_vowels(str1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_vowels\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('USA'), 'ASU')\n    lu.assertEquals(candidate('ab'), 'ab')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a table to a string.\nlocal function tup_string(tup1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tup_string\n    lu.assertEquals(candidate({'e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'}), 'exercises')\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}), 'python')\n    lu.assertEquals(candidate({'p', 'r', 'o', 'g', 'r', 'a', 'm'}), 'program')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum of the negative numbers of a given table of numbers.\nlocal function sum_negativenum(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_negativenum\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), -32)\n    lu.assertEquals(candidate({10, 15, -14, 13, -18, 12, -20}), -52)\n    lu.assertEquals(candidate({19, -65, 57, 39, 152, -639, 121, 44, 90, -190}), -894)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth hexagonal number.\nlocal function hexagonal_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = hexagonal_num\n    lu.assertEquals(candidate(10), 190)\n    lu.assertEquals(candidate(5), 45)\n    lu.assertEquals(candidate(7), 91)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nlocal function is_Sum_Of_Powers_Of_Two(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sum_Of_Powers_Of_Two\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(7), false)\n    lu.assertEquals(candidate(14), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a table of elements.\nlocal function pancake_sort(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pancake_sort\n    lu.assertEquals(candidate({15, 79, 25, 38, 69}), {15, 25, 38, 69, 79})\n    lu.assertEquals(candidate({98, 12, 54, 36, 85}), {12, 36, 54, 85, 98})\n    lu.assertEquals(candidate({41, 42, 32, 12, 23}), {12, 23, 32, 41, 42})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "lua",
+    "prompt": "-- Write a function to count number items that are identical in the same position of three given tables.\nlocal function count_samepair(list1, list2, list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_samepair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}, {2, 1, 3, 1, 2, 6, 7, 9}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 2, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 8}, {2, 1, 3, 1, 2, 6, 7, 8}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to find number of tables present in the given table.\nlocal function find_lists(Input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lists\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}}), 2)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}}), 3)\n    lu.assertEquals(candidate({9, 8, 7, 6, 5, 4, 3, 2, 1}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the maximum difference between any two elements in a given table.\nlocal function max_Abs_Diff(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Abs_Diff\n    lu.assertEquals(candidate({2, 1, 5, 3}), 4)\n    lu.assertEquals(candidate({9, 3, 2, 5, 1}), 8)\n    lu.assertEquals(candidate({3, 2, 1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the volume of a triangular prism.\nlocal function find_Volume(l, b, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Volume\n    lu.assertEquals(candidate(10, 8, 6), 240)\n    lu.assertEquals(candidate(3, 2, 2), 6)\n    lu.assertEquals(candidate(1, 2, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "lua",
+    "prompt": "-- Write a function that returns integers x and y that satisfy ax + by = n as a table, or return None if no solution exists.\nlocal function find_solution(a, b, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_solution\n    lu.assertEquals(candidate(2, 3, 7), {2, 1})\n    lu.assertEquals(candidate(4, 2, 7), None)\n    lu.assertEquals(candidate(1, 13, 17), {4, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all elements from a given table present in another table.\nlocal function remove_elements(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_elements\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {1, 3, 5, 7}), {2, 4, 6, 8, 9, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 7}), {1, 2, 3, 4, 6, 8, 9, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nlocal function sum_series(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_series\n    lu.assertEquals(candidate(6), 12)\n    lu.assertEquals(candidate(10), 30)\n    lu.assertEquals(candidate(9), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "lua",
+    "prompt": "-- Write a function to determine if the sum of the divisors of two integers are the same.\nlocal function are_equivalent(num1, num2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = are_equivalent\n    lu.assertEquals(candidate(36, 57), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(23, 47), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nlocal function count_char_position(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_char_position\n    lu.assertEquals(candidate('xbcefg'), 2)\n    lu.assertEquals(candidate('ABcED'), 3)\n    lu.assertEquals(candidate('AbgdeF'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "lua",
+    "prompt": "-- Write a function that counts the number of pairs of integers in a table that xor to an even number.\nlocal function find_even_pair(A)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_even_pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}), 4)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}), 9)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the smallest power of 2 greater than or equal to n.\nlocal function next_power_of_2(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_power_of_2\n    lu.assertEquals(candidate(0), 1)\n    lu.assertEquals(candidate(5), 8)\n    lu.assertEquals(candidate(17), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of occurrences of a number in a given table.\nlocal function frequency(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency\n    lu.assertEquals(candidate({1, 2, 3}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 2, 3, 3, 3, 4}, 3), 3)\n    lu.assertEquals(candidate({0, 1, 2, 3, 1, 2}, 1), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "lua",
+    "prompt": "-- Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nlocal function text_lowercase_underscore(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_lowercase_underscore\n    lu.assertEquals(candidate('aab_cbbbc'), true)\n    lu.assertEquals(candidate('aab_Abbbc'), false)\n    lu.assertEquals(candidate('Aaab_abbbc'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find the sum of numbers in a table within a range specified by two indices.\nlocal function sum_range_list(list1, m, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_range_list\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 8, 10), 29)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 5, 7), 16)\n    lu.assertEquals(candidate({2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12}, 7, 10), 38)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "lua",
+    "prompt": "-- Write a function to find the perimeter of a regular pentagon from the length of its sides.\nlocal function perimeter_pentagon(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perimeter_pentagon\n    lu.assertEquals(candidate(5), 25)\n    lu.assertEquals(candidate(10), 50)\n    lu.assertEquals(candidate(15), 75)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of occurence of the string 'std' in a given string.\nlocal function count_occurance(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_occurance\n    lu.assertEquals(candidate('letstdlenstdporstd'), 3)\n    lu.assertEquals(candidate('truststdsolensporsd'), 1)\n    lu.assertEquals(candidate('makestdsostdworthit'), 2)\n    lu.assertEquals(candidate('stds'), 1)\n    lu.assertEquals(candidate(''), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "lua",
+    "prompt": "-- Write a function that returns the perimeter of a square given its side length as input.\nlocal function square_perimeter(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_perimeter\n    lu.assertEquals(candidate(10), 40)\n    lu.assertEquals(candidate(5), 20)\n    lu.assertEquals(candidate(4), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "lua",
+    "prompt": "-- Write a function to remove characters from the first string which are present in the second string.\nlocal function remove_dirty_chars(string, second_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_dirty_chars\n    lu.assertEquals(candidate('probasscurve', 'pros'), 'bacuve')\n    lu.assertEquals(candidate('digitalindia', 'talent'), 'digiidi')\n    lu.assertEquals(candidate('exoticmiles', 'toxic'), 'emles')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "lua",
+    "prompt": "-- Write a function to find whether a given table of integers contains any duplicate element.\nlocal function test_duplicate(arraynums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_duplicate\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), true)\n    lu.assertEquals(candidate({1, 1, 2, 2, 3, 3, 4, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given number is woodball or not.\nlocal function is_woodall(x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_woodall\n    lu.assertEquals(candidate(383), true)\n    lu.assertEquals(candidate(254), false)\n    lu.assertEquals(candidate(200), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "lua",
+    "prompt": "-- Write a function to check if all the elements in table have same data type or not.\nlocal function check_type(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_type\n    lu.assertEquals(candidate({5, 6, 7, 3, 5, 6}), true)\n    lu.assertEquals(candidate({1, 2, '4'}), false)\n    lu.assertEquals(candidate({3, 2, 1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a sorted table, its length (n), and an element and returns whether the element is the majority element in the given sorted table. (The majority element is the element that occurs more than n/2 times.)\nlocal function is_majority(arr, n, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_majority\n    lu.assertEquals(candidate({1, 2, 3, 3, 3, 3, 10}, 7, 3), true)\n    lu.assertEquals(candidate({1, 1, 2, 4, 4, 4, 6, 6}, 8, 4), false)\n    lu.assertEquals(candidate({1, 1, 1, 2, 2}, 5, 1), true)\n    lu.assertEquals(candidate({1, 1, 2, 2}, 5, 1), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of set bits (binary digits with value 1) in a given number.\nlocal function count_Set_Bits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Set_Bits\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 1)\n    lu.assertEquals(candidate(6), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to remove the characters which have odd index values of a given string.\nlocal function odd_values_string(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_values_string\n    lu.assertEquals(candidate('abcdef'), 'ace')\n    lu.assertEquals(candidate('python'), 'pto')\n    lu.assertEquals(candidate('data'), 'dt')\n    lu.assertEquals(candidate('lambs'), 'lms')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "lua",
+    "prompt": "-- Write a function to find minimum of three numbers.\nlocal function min_of_three(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_of_three\n    lu.assertEquals(candidate(10, 20, 0), 0)\n    lu.assertEquals(candidate(19, 15, 18), 15)\n    lu.assertEquals(candidate(-10, -20, -30), -30)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether all the bits are unset in the given range or not.\nlocal function all_Bits_Set_In_The_Given_Range(n, l, r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Bits_Set_In_The_Given_Range\n    lu.assertEquals(candidate(4, 1, 2), true)\n    lu.assertEquals(candidate(17, 2, 4), true)\n    lu.assertEquals(candidate(39, 4, 6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and an integer n, and re-arranges the first n elements of the given table so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nlocal function re_arrange_array(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = re_arrange_array\n    lu.assertEquals(candidate({-1, 2, -3, 4, 5, 6, -7, 8, 9}, 9), {-1, -3, -7, 4, 5, 6, 2, 8, 9})\n    lu.assertEquals(candidate({12, -14, -26, 13, 15}, 5), {-14, -26, 12, 13, 15})\n    lu.assertEquals(candidate({10, 24, 36, -42, -39, -78, 85}, 7), {-42, -39, -78, 10, 24, 36, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nlocal function replace_blank(str1, char)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_blank\n    lu.assertEquals(candidate('hello people', '@'), 'hello@people')\n    lu.assertEquals(candidate('python program language', '$'), 'python$program$language')\n    lu.assertEquals(candidate('blank space', '-'), 'blank-space')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "lua",
+    "prompt": "-- Write a function to find the volume of a cube given its side length.\nlocal function volume_cube(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = volume_cube\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(2), 8)\n    lu.assertEquals(candidate(5), 125)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table of tables and returns a table mapping each unique table to the number of times it occurs in the table.\nlocal function check_occurences(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_occurences\n    lu.assertEquals(candidate({{3, 1}, {1, 3}, {2, 5}, {5, 2}, {6, 3}}), {[{1, 3}] = 2, [{2, 5}] = 2, [{3, 6}] = 1})\n    lu.assertEquals(candidate({{4, 2}, {2, 4}, {3, 6}, {6, 3}, {7, 4}}), {[{2, 4}] = 2, [{3, 6}] = 2, [{4, 7}] = 1})\n    lu.assertEquals(candidate({{13, 2}, {11, 23}, {12, 25}, {25, 12}, {16, 23}}), {[{2, 13}] = 1, [{11, 23}] = 1, [{12, 25}] = 2, [{16, 23}] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of non-empty substrings of a given string.\nlocal function number_of_substrings(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_of_substrings\n    lu.assertEquals(candidate('abc'), 6)\n    lu.assertEquals(candidate('abcd'), 10)\n    lu.assertEquals(candidate('abcde'), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nlocal function get_total_number_of_sequences(m, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_total_number_of_sequences\n    lu.assertEquals(candidate(10, 4), 4)\n    lu.assertEquals(candidate(5, 2), 6)\n    lu.assertEquals(candidate(16, 3), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two tables and replaces the last element of the first table with the elements of the second table.\nlocal function replace_list(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_list\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 10}, {2, 4, 6, 8}), {1, 3, 5, 7, 9, 2, 4, 6, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8}), {1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({'red', 'blue', 'green'}, {'yellow'}), {'red', 'blue', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "lua",
+    "prompt": "-- Write a function to count the total number of characters in a string.\nlocal function count_charac(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_charac\n    lu.assertEquals(candidate('python programming'), 18)\n    lu.assertEquals(candidate('language'), 8)\n    lu.assertEquals(candidate('words'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the next perfect square greater than a given number.\nlocal function next_Perfect_Square(N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = next_Perfect_Square\n    lu.assertEquals(candidate(35), 36)\n    lu.assertEquals(candidate(6), 9)\n    lu.assertEquals(candidate(9), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that takes a table and finds the maximum sum of a bitonic subsequence for the given table, where a sequence is bitonic if it is first increasing and then decreasing.\nlocal function max_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum\n    lu.assertEquals(candidate({1, 15, 51, 45, 33, 100, 12, 18, 9}), 194)\n    lu.assertEquals(candidate({80, 60, 30, 40, 20, 10}), 210)\n    lu.assertEquals(candidate({2, 3, 14, 16, 21, 23, 29, 30}), 138)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "lua",
+    "prompt": "-- Write a function to find the length of the longest palindromic subsequence in the given string.\nlocal function lps(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lps\n    lu.assertEquals(candidate('TENS FOR TENS'), 5)\n    lu.assertEquals(candidate('CARDIO FOR CARDS'), 7)\n    lu.assertEquals(candidate('PART OF THE JOURNEY IS PART'), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "lua",
+    "prompt": "-- Write a function to find the intersection of two tables.\nlocal function intersection_array(array_nums1, array_nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = intersection_array\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {1, 2, 4, 8, 9}), {1, 2, 8, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {3, 5, 7, 9}), {3, 5, 7, 9})\n    lu.assertEquals(candidate({1, 2, 3, 5, 7, 8, 9, 10}, {10, 20, 30, 40}), {10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "lua",
+    "prompt": "-- Write a luathon function that takes in a table and an element and counts the occcurences of the element in the table.\nlocal function count_X(tup, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_X\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 4), 0)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 10), 3)\n    lu.assertEquals(candidate({10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2}, 8), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and an element and inserts the element before each element in the table, and returns the resulting table.\nlocal function insert_element(list, element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = insert_element\n    lu.assertEquals(candidate({'Red', 'Green', 'Black'}, 'c'), {'c', 'Red', 'c', 'Green', 'c', 'Black'})\n    lu.assertEquals(candidate({'python', 'java'}, 'program'), {'program', 'python', 'program', 'java'})\n    lu.assertEquals(candidate({'happy', 'sad'}, 'laugh'), {'laugh', 'happy', 'laugh', 'sad'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to convert complex numbers to polar coordinates.\nlocal function convert(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert\n    lu.assertEquals(candidate(1), {1.0, 0.0})\n    lu.assertEquals(candidate(4), {4.0, 0.0})\n    lu.assertEquals(candidate(5), {5.0, 0.0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "lua",
+    "prompt": "-- Write a luathon function that returns the number of integer elements in a given table.\nlocal function count_integer(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_integer\n    lu.assertEquals(candidate({1, 2, 'abc', 1.2}), 2)\n    lu.assertEquals(candidate({1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 1.2, 4, 5.1}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and length n, and generates all combinations (with repetition) of the elements of the table and returns a table with a table for each combination.\nlocal function combinations_colors(l, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_colors\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 1), {{'Red'}, {'Green'}, {'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 2), {{'Red', 'Red'}, {'Red', 'Green'}, {'Red', 'Blue'}, {'Green', 'Green'}, {'Green', 'Blue'}, {'Blue', 'Blue'}})\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue'}, 3), {{'Red', 'Red', 'Red'}, {'Red', 'Red', 'Green'}, {'Red', 'Red', 'Blue'}, {'Red', 'Green', 'Green'}, {'Red', 'Green', 'Blue'}, {'Red', 'Blue', 'Blue'}, {'Green', 'Green', 'Green'}, {'Green', 'Green', 'Blue'}, {'Green', 'Blue', 'Blue'}, {'Blue', 'Blue', 'Blue'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "lua",
+    "prompt": "-- Write a luathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nlocal function count_Primes_nums(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Primes_nums\n    lu.assertEquals(candidate(5), 2)\n    lu.assertEquals(candidate(10), 4)\n    lu.assertEquals(candidate(100), 25)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two numbers and returns a table with the second number and then the first number.\nlocal function swap_numbers(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_numbers\n    lu.assertEquals(candidate(10, 20), {20, 10})\n    lu.assertEquals(candidate(15, 17), {17, 15})\n    lu.assertEquals(candidate(100, 200), {200, 100})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5809,7 +1129,7 @@
     "language": "lua",
     "prompt": "-- Write a function to maximize the given two tables.\nlocal function maximize_elements(test_tup1, test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximize_elements\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 7}, {4, 9}, {2, 9}, {7, 10}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{7, 8}, {5, 10}, {3, 10}, {8, 11}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{8, 9}, {6, 11}, {4, 11}, {9, 12}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "lua",
-    "prompt": "-- Write a luathon function to check whether every even index contains even numbers of a given table.\nlocal function even_position(nums)\n",
+    "prompt": "-- Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nlocal function newman_prime(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_position\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3}), false)\n    lu.assertEquals(candidate({2, 1, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = newman_prime\n    lu.assertEquals(candidate(3), 7)\n    lu.assertEquals(candidate(4), 17)\n    lu.assertEquals(candidate(5), 41)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "lua",
-    "prompt": "-- Write a function to check whether the given string starts and ends with the same character or not.\nlocal function check_char(string)\n",
+    "prompt": "-- Write a function that takes in two tables and performs mathematical division operation element-wise across the given tables.\nlocal function division_elements(test_tup1, test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_char\n    lu.assertEquals(candidate('abba'), 'Valid')\n    lu.assertEquals(candidate('a'), 'Valid')\n    lu.assertEquals(candidate('abcd'), 'Invalid')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = division_elements\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {2, 2, 2, 3})\n    lu.assertEquals(candidate({12, 6, 8, 16}, {6, 3, 4, 4}), {2, 2, 2, 4})\n    lu.assertEquals(candidate({20, 14, 36, 18}, {5, 7, 6, 9}), {4, 2, 6, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "lua",
-    "prompt": "-- Write a luathon function to find the sum of even factors of a number.\nlocal function sumofFactors(n)\n",
+    "prompt": "-- Write a function that takes in a table and an integer L and splits the given table into two parts where the length of the first part of the table is L, and returns the resulting tables in a table.\nlocal function split_two_parts(list1, L)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sumofFactors\n    lu.assertEquals(candidate(18), 26)\n    lu.assertEquals(candidate(30), 48)\n    lu.assertEquals(candidate(6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_two_parts\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {{1, 1, 2}, {3, 4, 4, 5, 1}})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 2), {{'a', 'b'}, {'c', 'd'}})\n    lu.assertEquals(candidate({'p', 'y', 't', 'h', 'o', 'n'}, 4), {{'p', 'y', 't', 'h'}, {'o', 'n'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "lua",
-    "prompt": "-- Write a function to find the lateral surface area of a cone given radius r and the height h.\nlocal function lateralsurface_cone(r, h)\n",
+    "prompt": "-- Write a function to calculate a dog's age in dog's years.\nlocal function dog_age(h_age)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cone\n    lu.assertEquals(candidate(5, 12), 204.20352248333654)\n    lu.assertEquals(candidate(10, 15), 566.3586699569488)\n    lu.assertEquals(candidate(19, 17), 1521.8090132193388)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dog_age\n    lu.assertEquals(candidate(12), 61)\n    lu.assertEquals(candidate(15), 73)\n    lu.assertEquals(candidate(24), 109)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "lua",
-    "prompt": "-- Write a luathon function which takes a table of integers and counts the number of possible unordered pairs where both elements are unequal.\nlocal function count_Pairs(arr, n)\n",
+    "prompt": "-- Write a function that takes in a table and an integer n and splits a table for every nth element, returning a table of the resulting tables.\nlocal function list_split(S, step)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Pairs\n    lu.assertEquals(candidate({1, 2, 1}, 3), 2)\n    lu.assertEquals(candidate({1, 1, 1, 1}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 5), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_split\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'}, 3), {{'a', 'd', 'g', 'j', 'm'}, {'b', 'e', 'h', 'k', 'n'}, {'c', 'f', 'i', 'l'}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, 3), {{1, 4, 7, 10, 13}, {2, 5, 8, 11, 14}, {3, 6, 9, 12}})\n    lu.assertEquals(candidate({'python', 'java', 'C', 'C++', 'DBMS', 'SQL'}, 2), {{'python', 'C', 'DBMS'}, {'java', 'C++', 'SQL'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "lua",
-    "prompt": "-- Write a function to find the index of the first occurrence of a given number in a sorted table.\nlocal function find_first_occurrence(A, x)\n",
+    "prompt": "-- Write a function to find the lateral surface area of a cube given its side length.\nlocal function lateralsurface_cube(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_first_occurrence\n    lu.assertEquals(candidate({2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 1)\n    lu.assertEquals(candidate({2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 2)\n    lu.assertEquals(candidate({2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cube\n    lu.assertEquals(candidate(5), 100)\n    lu.assertEquals(candidate(9), 324)\n    lu.assertEquals(candidate(10), 400)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5914,9 +1234,909 @@
     "language": "lua",
     "prompt": "-- Write a luathon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nlocal function square_Sum(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 10)\n    lu.assertEquals(candidate(3), 35)\n    lu.assertEquals(candidate(4), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n'th star number.\nlocal function find_star_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_star_num\n    lu.assertEquals(candidate(3), 37)\n    lu.assertEquals(candidate(4), 73)\n    lu.assertEquals(candidate(5), 121)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "lua",
+    "prompt": "-- Write a function to find the ascii value of a character.\nlocal function ascii_value(k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = ascii_value\n    lu.assertEquals(candidate('A'), 65)\n    lu.assertEquals(candidate('R'), 82)\n    lu.assertEquals(candidate('S'), 83)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of even numbers at even positions of a table.\nlocal function sum_even_and_even_index(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_even_and_even_index\n    lu.assertEquals(candidate({5, 6, 12, 1, 18, 8}), 30)\n    lu.assertEquals(candidate({3, 20, 17, 9, 2, 10, 18, 13, 6, 18}), 26)\n    lu.assertEquals(candidate({5, 6, 12, 1}), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nlocal function even_Power_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_Power_Sum\n    lu.assertEquals(candidate(2), 1056)\n    lu.assertEquals(candidate(3), 8832)\n    lu.assertEquals(candidate(1), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table of tables and returns a table containing the rear element of each table.\nlocal function rear_extract(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rear_extract\n    lu.assertEquals(candidate({{1, 'Rash', 21}, {2, 'Varsha', 20}, {3, 'Kil', 19}}), {21, 20, 19})\n    lu.assertEquals(candidate({{1, 'Sai', 36}, {2, 'Ayesha', 25}, {3, 'Salman', 45}}), {36, 25, 45})\n    lu.assertEquals(candidate({{1, 'Sudeep', 14}, {2, 'Vandana', 36}, {3, 'Dawood', 56}}), {14, 36, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in two tables and subtracts the elements of the first table by the elements of the second table with the same index.\nlocal function substract_elements(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = substract_elements\n    lu.assertEquals(candidate({10, 4, 5}, {2, 5, 18}), {8, -1, -13})\n    lu.assertEquals(candidate({11, 2, 3}, {24, 45, 16}), {-13, -43, -13})\n    lu.assertEquals(candidate({7, 18, 9}, {10, 11, 12}), {-3, 7, -3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nlocal function even_binomial_Coeff_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_binomial_Coeff_Sum\n    lu.assertEquals(candidate(4), 8)\n    lu.assertEquals(candidate(6), 32)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and integer n and filters the table to only include entries with values greater than or equal to n.\nlocal function dict_filter(dict, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dict_filter\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 170), {['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 180), {['Alden Cantrell'] = 180, ['Pierre Cox'] = 190})\n    lu.assertEquals(candidate({['Cierra Vega'] = 175, ['Alden Cantrell'] = 180, ['Kierra Gentry'] = 165, ['Pierre Cox'] = 190}, 190), {['Pierre Cox'] = 190})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to find the number of elements that occurs before the table element in the given table.\nlocal function count_first_elements(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_first_elements\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), 3)\n    lu.assertEquals(candidate({2, 9, {5, 7}, 11}), 2)\n    lu.assertEquals(candidate({11, 15, 5, 8, {2, 3}, 8}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth decagonal number.\nlocal function is_num_decagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_num_decagonal\n    lu.assertEquals(candidate(3), 27)\n    lu.assertEquals(candidate(7), 175)\n    lu.assertEquals(candidate(10), 370)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and element and returns a table containing a boolean that indicates if the element is in the table and the index position of the element (or -1 if the element is not found).\nlocal function sequential_search(dlist, item)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequential_search\n    lu.assertEquals(candidate({11, 23, 58, 31, 56, 77, 43, 12, 65, 19}, 31), {true, 3})\n    lu.assertEquals(candidate({12, 32, 45, 62, 35, 47, 44, 61}, 61), {true, 7})\n    lu.assertEquals(candidate({9, 10, 17, 19, 22, 39, 48, 56}, 48), {true, 6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check if the elements of a given table are unique or not.\nlocal function all_unique(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_unique\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "lua",
+    "prompt": "-- Write a function to subtract two tables element-wise.\nlocal function sub_list(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sub_list\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), {-3, -3, -3})\n    lu.assertEquals(candidate({1, 2}, {3, 4}), {-2, -2})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {40, 50})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "lua",
+    "prompt": "-- Write a luathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nlocal function validate(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = validate\n    lu.assertEquals(candidate(1234), true)\n    lu.assertEquals(candidate(51241), false)\n    lu.assertEquals(candidate(321), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes in a table and element and checks whether all items in the table are equal to the given element.\nlocal function check_element(list, element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_element\n    lu.assertEquals(candidate({'green', 'orange', 'black', 'white'}, 'blue'), false)\n    lu.assertEquals(candidate({1, 2, 3, 4}, 7), false)\n    lu.assertEquals(candidate({'green', 'green', 'green', 'green'}, 'green'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "lua",
+    "prompt": "-- Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nlocal function text_match_two_three(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_two_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "lua",
+    "prompt": "-- Write a function to find the largest sum of a contiguous table in the modified table which is formed by repeating the given table k times.\nlocal function max_sub_array_sum_repeated(a, n, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum_repeated\n    lu.assertEquals(candidate({10, 20, -30, -1}, 4, 3), 30)\n    lu.assertEquals(candidate({-1, 10, 20}, 3, 2), 59)\n    lu.assertEquals(candidate({-1, -2, -3}, 3, 3), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nlocal function square_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_Sum\n    lu.assertEquals(candidate(2), 20)\n    lu.assertEquals(candidate(3), 56)\n    lu.assertEquals(candidate(4), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "lua",
+    "prompt": "-- Write a function to find the table of maximum length in a table of tables.\nlocal function max_length(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1}, {5, 7}, {10, 12, 14, 15}}), {4, {10, 12, 14, 15}})\n    lu.assertEquals(candidate({{5}, {15, 20, 25}}), {3, {15, 20, 25}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "lua",
+    "prompt": "-- Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nlocal function count_no_of_ways(n, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_no_of_ways\n    lu.assertEquals(candidate(2, 4), 16)\n    lu.assertEquals(candidate(3, 2), 6)\n    lu.assertEquals(candidate(4, 4), 228)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find quotient of two numbers (rounded down to the nearest integer).\nlocal function find(n, m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find\n    lu.assertEquals(candidate(10, 3), 3)\n    lu.assertEquals(candidate(4, 2), 2)\n    lu.assertEquals(candidate(20, 5), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "lua",
+    "prompt": "-- Write a function to find the third side of a right angled triangle.\nlocal function otherside_rightangle(w, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = otherside_rightangle\n    lu.assertEquals(candidate(7, 8), 10.63014581273465)\n    lu.assertEquals(candidate(3, 4), 5)\n    lu.assertEquals(candidate(7, 15), 16.55294535724685)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum value in a given heterogeneous table.\nlocal function max_val(listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 5)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 25)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 50)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "lua",
+    "prompt": "-- Write a function to return the sum of all divisors of a number.\nlocal function sum_div(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_div\n    lu.assertEquals(candidate(8), 7)\n    lu.assertEquals(candidate(12), 16)\n    lu.assertEquals(candidate(7), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count inversions in a table.\nlocal function get_Inv_Count(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Inv_Count\n    lu.assertEquals(candidate({1, 20, 6, 4, 5}), 5)\n    lu.assertEquals(candidate({1, 2, 1}), 1)\n    lu.assertEquals(candidate({1, 2, 5, 6, 1}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "lua",
+    "prompt": "-- Write a function to flatten a given nested table structure.\nlocal function flatten_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = flatten_list\n    lu.assertEquals(candidate({0, 10, {20, 30}, 40, 50, {60, 70, 80}, {90, 100, 110, 120}}), {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120})\n    lu.assertEquals(candidate({{10, 20}, {40}, {30, 56, 25}, {10, 20}, {33}, {40}}), {10, 20, 40, 30, 56, 25, 10, 20, 33, 40})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the maximum aggregate from the table of tables.\nlocal function max_aggregate(stdata)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_aggregate\n    lu.assertEquals(candidate({{'Juan Whelan', 90}, {'Sabah Colley', 88}, {'Peter Nichols', 7}, {'Juan Whelan', 122}, {'Sabah Colley', 84}}), {'Juan Whelan', 212})\n    lu.assertEquals(candidate({{'Juan Whelan', 50}, {'Sabah Colley', 48}, {'Peter Nichols', 37}, {'Juan Whelan', 22}, {'Sabah Colley', 14}}), {'Juan Whelan', 72})\n    lu.assertEquals(candidate({{'Juan Whelan', 10}, {'Sabah Colley', 20}, {'Peter Nichols', 30}, {'Juan Whelan', 40}, {'Sabah Colley', 50}}), {'Sabah Colley', 70})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find element at a given index after number of rotations.\nlocal function find_Element(arr, ranges, rotations, index)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {{0, 2}, {0, 3}}, 2, 1), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}, {{0, 1}, {0, 2}}, 1, 2), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {{0, 1}, {0, 2}}, 1, 1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "lua",
+    "prompt": "-- Write a function to return two words from a table of words starting with letter 'p'.\nlocal function start_withp(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = start_withp\n    lu.assertEquals(candidate({'Python PHP', 'Java JavaScript', 'c c++'}), {'Python', 'PHP'})\n    lu.assertEquals(candidate({'Python Programming', 'Java Programming'}), {'Python', 'Programming'})\n    lu.assertEquals(candidate({'Pqrst Pqr', 'qrstuv'}), {'Pqrst', 'Pqr'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nlocal function max_sum_increasing_subseq(a, n, index, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_increasing_subseq\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 4, 6), 11)\n    lu.assertEquals(candidate({1, 101, 2, 3, 100, 4, 5}, 7, 2, 5), 7)\n    lu.assertEquals(candidate({11, 15, 19, 21, 26, 28, 31}, 7, 2, 4), 71)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the specified number of largest products from two given tables, selecting one factor from each table.\nlocal function large_product(nums1, nums2, N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = large_product\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 3), {60, 54, 50})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 4), {60, 54, 50, 48})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {3, 6, 8, 9, 10, 6}, 5), {60, 54, 50, 48, 45})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the maximum of two numbers.\nlocal function maximum(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maximum\n    lu.assertEquals(candidate(5, 10), 10)\n    lu.assertEquals(candidate(-1, -2), -1)\n    lu.assertEquals(candidate(9, 7), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a given string to a table of characters.\nlocal function string_to_tuple(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = string_to_tuple\n    lu.assertEquals(candidate('python 3.0'), {'p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'})\n    lu.assertEquals(candidate('item1'), {'i', 't', 'e', 'm', '1'})\n    lu.assertEquals(candidate('15.10'), {'1', '5', '.', '1', '0'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the highest power of 2 that is less than or equal to n.\nlocal function highest_Power_of_2(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = highest_Power_of_2\n    lu.assertEquals(candidate(10), 8)\n    lu.assertEquals(candidate(19), 16)\n    lu.assertEquals(candidate(32), 32)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n'th lucas number.\nlocal function find_lucas(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_lucas\n    lu.assertEquals(candidate(9), 76)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(3), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "lua",
+    "prompt": "-- Write a function to apply a given format string to all of the elements in a table.\nlocal function add_string(list_, string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_string\n    lu.assertEquals(candidate({1, 2, 3, 4}, 'temp{0}'), {'temp1', 'temp2', 'temp3', 'temp4'})\n    lu.assertEquals(candidate({'a', 'b', 'c', 'd'}, 'python{0}'), {'pythona', 'pythonb', 'pythonc', 'pythond'})\n    lu.assertEquals(candidate({5, 6, 7, 8}, 'string{0}'), {'string5', 'string6', 'string7', 'string8'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "lua",
+    "prompt": "-- Write a function to convert more than one table to nested table.\nlocal function convert_list_dictionary(l1, l2, l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = convert_list_dictionary\n    lu.assertEquals(candidate({'S001', 'S002', 'S003', 'S004'}, {'Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'}, {85, 98, 89, 92}), {{['S001'] = {['Adina Park'] = 85}}, {['S002'] = {['Leyton Marsh'] = 98}}, {['S003'] = {['Duncan Boyle'] = 89}}, {['S004'] = {['Saim Richards'] = 92}}})\n    lu.assertEquals(candidate({'abc', 'def', 'ghi', 'jkl'}, {'python', 'program', 'language', 'programs'}, {100, 200, 300, 400}), {{['abc'] = {['python'] = 100}}, {['def'] = {['program'] = 200}}, {['ghi'] = {['language'] = 300}}, {['jkl'] = {['programs'] = 400}}})\n    lu.assertEquals(candidate({'A1', 'A2', 'A3', 'A4'}, {'java', 'C', 'C++', 'DBMS'}, {10, 20, 30, 40}), {{['A1'] = {['java'] = 10}}, {['A2'] = {['C'] = 20}}, {['A3'] = {['C++'] = 30}}, {['A4'] = {['DBMS'] = 40}}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nlocal function get_max_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_max_sum\n    lu.assertEquals(candidate(60), 106)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find the table with maximum length.\nlocal function max_length_list(input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_length_list\n    lu.assertEquals(candidate({{0}, {1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), {3, {13, 15, 17}})\n    lu.assertEquals(candidate({{1, 2, 3, 4, 5}, {1, 2, 3, 4}, {1, 2, 3}, {1, 2}, {1}}), {5, {1, 2, 3, 4, 5}})\n    lu.assertEquals(candidate({{3, 4, 5}, {6, 7, 8, 9}, {10, 11, 12}}), {4, {6, 7, 8, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "lua",
+    "prompt": "-- Write a function to check if given table contains no duplicates.\nlocal function check_distinct(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_distinct\n    lu.assertEquals(candidate({1, 4, 5, 6, 1, 4}), false)\n    lu.assertEquals(candidate({1, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the first non-repeated character in a given string.\nlocal function first_non_repeating_character(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_non_repeating_character\n    lu.assertEquals(candidate('abcabc'), None)\n    lu.assertEquals(candidate('abc'), 'a')\n    lu.assertEquals(candidate('ababc'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given string starts and ends with the same character or not.\nlocal function check_char(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_char\n    lu.assertEquals(candidate('abba'), 'Valid')\n    lu.assertEquals(candidate('a'), 'Valid')\n    lu.assertEquals(candidate('abcd'), 'Invalid')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median of three numbers.\nlocal function median_numbers(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_numbers\n    lu.assertEquals(candidate(25, 55, 65), 55.0)\n    lu.assertEquals(candidate(20, 10, 30), 20.0)\n    lu.assertEquals(candidate(15, 45, 75), 45.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to compute the sum of digits of each number of a given table.\nlocal function sum_of_digits(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_of_digits\n    lu.assertEquals(candidate({10, 2, 56}), 14)\n    lu.assertEquals(candidate({{10, 20, 4, 5, 'b', 70, 'a'}}), 19)\n    lu.assertEquals(candidate({10, 20, -4, 5, -70}), 19)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "lua",
+    "prompt": "-- Write a function to perform the mathematical bitwise xor operation across the given tables.\nlocal function bitwise_xor(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bitwise_xor\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {15, 6, 5, 10})\n    lu.assertEquals(candidate({11, 5, 7, 10}, {6, 3, 4, 4}), {13, 6, 3, 14})\n    lu.assertEquals(candidate({12, 6, 8, 11}, {7, 4, 5, 6}), {11, 2, 13, 13})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to identify non-prime numbers.\nlocal function is_not_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_not_prime\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(35), true)\n    lu.assertEquals(candidate(37), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the number of unique tables in the given table.\nlocal function extract_freq(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_freq\n    lu.assertEquals(candidate({{3, 4}, {1, 2}, {4, 3}, {5, 6}}), 3)\n    lu.assertEquals(candidate({{4, 15}, {2, 3}, {5, 4}, {6, 7}}), 4)\n    lu.assertEquals(candidate({{5, 16}, {2, 3}, {6, 5}, {6, 9}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to perform index wise addition of table elements in the given two nested tables.\nlocal function add_nested_tuples(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_nested_tuples\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{7, 10}, {7, 14}, {3, 10}, {8, 13}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{9, 12}, {9, 16}, {5, 12}, {10, 15}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{11, 14}, {11, 18}, {7, 14}, {12, 17}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the minimum of two numbers.\nlocal function minimum(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = minimum\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(-5, -4), -5)\n    lu.assertEquals(candidate(0, 0), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether an element exists within a table.\nlocal function check_tuplex(tuplex, tuple1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_tuplex\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 'r'), true)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, '5'), false)\n    lu.assertEquals(candidate({'w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'}, 3), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find whether the parity of a given number is odd.\nlocal function find_Parity(x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Parity\n    lu.assertEquals(candidate(12), false)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(10), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "lua",
+    "prompt": "-- Write a function to create the next bigger number by rearranging the digits of a given number.\nlocal function rearrange_bigger(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rearrange_bigger\n    lu.assertEquals(candidate(12), 21)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(102), 120)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "lua",
+    "prompt": "-- Write a function to find k number of smallest pairs which consist of one element from the first table and one element from the second table.\nlocal function k_smallest_pairs(nums1, nums2, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = k_smallest_pairs\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 2), {{1, 2}, {1, 4}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 1), {{1, 2}})\n    lu.assertEquals(candidate({1, 3, 7}, {2, 4, 6}, 7), {{1, 2}, {1, 4}, {3, 2}, {1, 6}, {3, 4}, {3, 6}, {7, 2}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to find the minimum product from the pairs of tables within a given table.\nlocal function min_product_tuple(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_product_tuple\n    lu.assertEquals(candidate({{2, 7}, {2, 6}, {1, 8}, {4, 9}}), 8)\n    lu.assertEquals(candidate({{10, 20}, {15, 2}, {5, 10}}), 30)\n    lu.assertEquals(candidate({{11, 44}, {10, 15}, {20, 5}, {12, 9}}), 100)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "lua",
+    "prompt": "-- Write a function to find the minimum value in a given heterogeneous table.\nlocal function min_val(listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_val\n    lu.assertEquals(candidate({'Python', 3, 2, 4, 5, 'version'}), 2)\n    lu.assertEquals(candidate({'Python', 15, 20, 25}), 15)\n    lu.assertEquals(candidate({'Python', 30, 20, 40, 50, 'version'}), 20)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given snake case string to camel case string.\nlocal function snake_to_camel(word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = snake_to_camel\n    lu.assertEquals(candidate('android_tv'), 'AndroidTv')\n    lu.assertEquals(candidate('google_pixel'), 'GooglePixel')\n    lu.assertEquals(candidate('apple_watch'), 'AppleWatch')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to remove odd numbers from a given table.\nlocal function remove_odd(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate({1, 2, 3}), {2})\n    lu.assertEquals(candidate({2, 4, 6}), {2, 4, 6})\n    lu.assertEquals(candidate({10, 20, 3}), {10, 20})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the nth element from a given table of tables.\nlocal function extract_nth_element(list1, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_nth_element\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 0), {'Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 2), {99, 96, 94, 98})\n    lu.assertEquals(candidate({{'Greyson Fulton', 98, 99}, {'Brady Kent', 97, 96}, {'Wyatt Knott', 91, 94}, {'Beau Turnbull', 94, 98}}, 1), {98, 97, 91, 94})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether any value in a sequence exists in a sequence or not.\nlocal function overlapping(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = overlapping\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), false)\n    lu.assertEquals(candidate({1, 2, 3}, {4, 5, 6}), false)\n    lu.assertEquals(candidate({1, 4, 5}, {1, 4, 5}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find a pair with highest product from a given table of integers.\nlocal function max_Product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_Product\n    lu.assertEquals(candidate({1, 2, 3, 4, 7, 0, 8, 4}), {7, 8})\n    lu.assertEquals(candidate({0, -1, -2, -4, 5, 0, -6}), {-4, -6})\n    lu.assertEquals(candidate({1, 2, 3}), {2, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",
@@ -5929,7 +2149,7 @@
     "language": "lua",
     "prompt": "-- Write a function to find common first element in given table of tables.\nlocal function group_tuples(Input)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = group_tuples\n    lu.assertEquals(candidate({{'x', 'y'}, {'x', 'z'}, {'w', 't'}}), {{'x', 'y', 'z'}, {'w', 't'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'a', 'c'}, {'d', 'e'}}), {{'a', 'b', 'c'}, {'d', 'e'}})\n    lu.assertEquals(candidate({{'f', 'g'}, {'f', 'g'}, {'h', 'i'}}), {{'f', 'g', 'g'}, {'h', 'i'}})\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "lua",
-    "prompt": "-- Write a function to merge three tables into a single sorted table.\nlocal function merge_sorted_list(num1, num2, num3)\n",
+    "prompt": "-- Write a luathon function to find the element of a table having maximum length.\nlocal function Find_Max(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_sorted_list\n    lu.assertEquals(candidate({25, 24, 15, 4, 5, 29, 110}, {19, 20, 11, 56, 25, 233, 154}, {24, 26, 54, 48}), {4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233})\n    lu.assertEquals(candidate({1, 3, 5, 6, 8, 9}, {2, 5, 7, 11}, {1, 4, 7, 8, 12}), {1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12})\n    lu.assertEquals(candidate({18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1}, {25, 35, 22, 85, 14, 65, 75, 25, 58}, {12, 74, 9, 50, 61, 41}), {1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max\n    lu.assertEquals(candidate({{'A'}, {'A', 'B'}, {'A', 'B', 'C'}}), {'A', 'B', 'C'})\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1, 2, 3})\n    lu.assertEquals(candidate({{1, 1}, {1, 2, 3}, {1, 5, 6, 1}}), {1, 5, 6, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to round every number of a given table of numbers and print the total sum multiplied by the length of the table.\nlocal function round_and_sum(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = round_and_sum\n    lu.assertEquals(candidate({22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5}), 243)\n    lu.assertEquals(candidate({5, 2, 9, 24.3, 29}), 345)\n    lu.assertEquals(candidate({25.0, 56.7, 89.2}), 513)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the cube sum of first n even natural numbers.\nlocal function cube_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_Sum\n    lu.assertEquals(candidate(2), 72)\n    lu.assertEquals(candidate(3), 288)\n    lu.assertEquals(candidate(4), 800)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to concatenate each element of table by the delimiter.\nlocal function concatenate_tuple(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = concatenate_tuple\n    lu.assertEquals(candidate({'ID', 'is', 4, 'UTS'}), 'ID-is-4-UTS')\n    lu.assertEquals(candidate({'QWE', 'is', 4, 'RTY'}), 'QWE-is-4-RTY')\n    lu.assertEquals(candidate({'ZEN', 'is', 4, 'OP'}), 'ZEN-is-4-OP')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the average of cubes of first n natural numbers.\nlocal function find_Average_Of_Cube(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Average_Of_Cube\n    lu.assertEquals(candidate(2), 4.5)\n    lu.assertEquals(candidate(3), 12)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "lua",
+    "prompt": "-- Write a function to extract only the rear index element of each string in the given table.\nlocal function extract_rear(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_rear\n    lu.assertEquals(candidate({'Mers', 'for', 'Vers'}), {'s', 'r', 's'})\n    lu.assertEquals(candidate({'Avenge', 'for', 'People'}), {'e', 'r', 'e'})\n    lu.assertEquals(candidate({'Gotta', 'get', 'go'}), {'a', 't', 'o'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "lua",
+    "prompt": "-- Write a function to count the number of subtables containing a particular element.\nlocal function count_element_in_list(list1, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_element_in_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {1, 11}, {1, 15, 7}}, 1), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'A'), 3)\n    lu.assertEquals(candidate({{'A', 'B'}, {'A', 'C'}, {'A', 'D', 'E'}, {'B', 'C', 'D'}}, 'E'), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "lua",
+    "prompt": "-- Write a function to filter odd numbers.\nlocal function filter_oddnumbers(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_oddnumbers\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 3, 5, 7, 9})\n    lu.assertEquals(candidate({10, 20, 45, 67, 84, 93}), {45, 67, 93})\n    lu.assertEquals(candidate({5, 7, 9, 8, 6, 4, 3}), {5, 7, 9, 3})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nlocal function change_date_format(dt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = change_date_format\n    lu.assertEquals(candidate('2026-01-02'), '02-01-2026')\n    lu.assertEquals(candidate('2020-11-13'), '13-11-2020')\n    lu.assertEquals(candidate('2021-04-26'), '26-04-2021')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort the given table by using shell sort.\nlocal function shell_sort(my_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = shell_sort\n    lu.assertEquals(candidate({12, 23, 4, 5, 3, 2, 12, 81, 56, 95}), {2, 3, 4, 5, 12, 12, 23, 56, 81, 95})\n    lu.assertEquals(candidate({24, 22, 39, 34, 87, 73, 68}), {22, 24, 34, 39, 68, 73, 87})\n    lu.assertEquals(candidate({32, 30, 16, 96, 82, 83, 74}), {16, 30, 32, 74, 82, 83, 96})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to extract the elementwise and tables from the given two tables.\nlocal function and_tuples(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = and_tuples\n    lu.assertEquals(candidate({10, 4, 6, 9}, {5, 2, 3, 3}), {0, 0, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {5, 6, 7, 8}), {1, 2, 3, 0})\n    lu.assertEquals(candidate({8, 9, 11, 12}, {7, 13, 14, 17}), {0, 9, 10, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "lua",
+    "prompt": "-- Write a function to find the directrix of a parabola.\nlocal function parabola_directrix(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = parabola_directrix\n    lu.assertEquals(candidate(5, 3, 2), -198)\n    lu.assertEquals(candidate(9, 8, 4), -2336)\n    lu.assertEquals(candidate(2, 4, 6), -130)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "lua",
+    "prompt": "-- Write a function that takes two tables and returns true if they have at least one common element.\nlocal function common_element(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = common_element\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 8, 9}), None)\n    lu.assertEquals(candidate({'a', 'b', 'c'}, {'d', 'b', 'e'}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median length of a trapezium.\nlocal function median_trapezium(base1, base2, height)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = median_trapezium\n    lu.assertEquals(candidate(15, 25, 35), 20)\n    lu.assertEquals(candidate(10, 20, 30), 15)\n    lu.assertEquals(candidate(6, 9, 4), 7.5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the entered number is greater than the elements of the given table.\nlocal function check_greater(arr, number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_greater\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 4), false)\n    lu.assertEquals(candidate({2, 3, 4, 5, 6}, 8), true)\n    lu.assertEquals(candidate({9, 7, 4, 8, 6, 1}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an a followed by one or more b's.\nlocal function text_match_one(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the last digit of a given number.\nlocal function last_Digit(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit\n    lu.assertEquals(candidate(123), 3)\n    lu.assertEquals(candidate(25), 5)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to return the negative numbers in a table.\nlocal function neg_nos(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = neg_nos\n    lu.assertEquals(candidate({-1, 4, 5, -6}), {-1, -6})\n    lu.assertEquals(candidate({-1, -2, 3, 4}), {-1, -2})\n    lu.assertEquals(candidate({-7, -6, 8, 9}), {-7, -6})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to remove odd characters in a string.\nlocal function remove_odd(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_odd\n    lu.assertEquals(candidate('python'), 'yhn')\n    lu.assertEquals(candidate('program'), 'rga')\n    lu.assertEquals(candidate('language'), 'agae')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "lua",
+    "prompt": "-- Write a function to count bidirectional table pairs.\nlocal function count_bidirectional(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_bidirectional\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 3)\n    lu.assertEquals(candidate({{5, 6}, {1, 3}, {6, 5}, {9, 1}, {6, 5}, {2, 1}}), 2)\n    lu.assertEquals(candidate({{5, 6}, {1, 2}, {6, 5}, {9, 2}, {6, 5}, {2, 1}}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "lua",
+    "prompt": "-- Write a function to join a table of multiple integers into a single integer.\nlocal function multiple_to_single(L)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiple_to_single\n    lu.assertEquals(candidate({11, 33, 50}), 113350)\n    lu.assertEquals(candidate({-1, 2, 3, 4, 5, 6}), -123456)\n    lu.assertEquals(candidate({10, 15, 20, 25}), 10152025)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "lua",
+    "prompt": "-- Write a function to find the first adverb and their positions in a given sentence.\nlocal function find_adverb_position(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverb_position\n    lu.assertEquals(candidate('clearly!! we can see the sky'), {0, 7, 'clearly'})\n    lu.assertEquals(candidate('seriously!! there are many roses'), {0, 9, 'seriously'})\n    lu.assertEquals(candidate('unfortunately!! sita is going to home'), {0, 13, 'unfortunately'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "lua",
+    "prompt": "-- Write a function to find the surface area of a cube of a given size.\nlocal function surfacearea_cube(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cube\n    lu.assertEquals(candidate(5), 150)\n    lu.assertEquals(candidate(3), 54)\n    lu.assertEquals(candidate(10), 600)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "lua",
+    "prompt": "-- Write a function to find the ration of positive numbers in a table of integers.\nlocal function positive_count(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = positive_count\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}), 0.54)\n    lu.assertEquals(candidate({2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 0.69)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}), 0.56)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the largest negative number from the given table.\nlocal function largest_neg(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = largest_neg\n    lu.assertEquals(candidate({1, 2, 3, -4, -6}), -6)\n    lu.assertEquals(candidate({1, 2, 3, -8, -9}), -9)\n    lu.assertEquals(candidate({1, 2, 3, 4, -1}), -1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to trim each table by k in the given tables.\nlocal function trim_tuple(test_list, K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = trim_tuple\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 2), {{2}, {9}, {2}, {2}})\n    lu.assertEquals(candidate({{5, 3, 2, 1, 4}, {3, 4, 9, 2, 1}, {9, 1, 2, 3, 5}, {4, 8, 2, 1, 7}}, 1), {{3, 2, 1}, {4, 9, 2}, {1, 2, 3}, {8, 2, 1}})\n    lu.assertEquals(candidate({{7, 8, 4, 9}, {11, 8, 12, 4}, {4, 1, 7, 8}, {3, 6, 9, 7}}, 1), {{8, 4}, {8, 12}, {1, 7}, {6, 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "lua",
+    "prompt": "-- Write a function to perform index wise multiplication of table elements in the given two tables.\nlocal function index_multiplication(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_multiplication\n    lu.assertEquals(candidate({{1, 3}, {4, 5}, {2, 9}, {1, 10}}, {{6, 7}, {3, 9}, {1, 1}, {7, 3}}), {{6, 21}, {12, 45}, {2, 9}, {7, 30}})\n    lu.assertEquals(candidate({{2, 4}, {5, 6}, {3, 10}, {2, 11}}, {{7, 8}, {4, 10}, {2, 2}, {8, 4}}), {{14, 32}, {20, 60}, {6, 20}, {16, 44}})\n    lu.assertEquals(candidate({{3, 5}, {6, 7}, {4, 11}, {3, 12}}, {{8, 9}, {5, 11}, {3, 3}, {9, 5}}), {{24, 45}, {30, 77}, {12, 33}, {27, 60}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the occurence of all elements of table in a table.\nlocal function count_Occurrence(tup, lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Occurrence\n    lu.assertEquals(candidate({'a', 'a', 'c', 'b', 'd'}, {'a', 'b'}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 1, 4, 6, 7, 1, 4}, {1, 4, 7}), 6)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, {1, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to find cubes of individual elements in a table.\nlocal function cube_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cube_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 8, 27, 64, 125, 216, 343, 512, 729, 1000})\n    lu.assertEquals(candidate({10, 20, 30}), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}), {1728, 3375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the sum of perrin numbers.\nlocal function cal_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cal_sum\n    lu.assertEquals(candidate(9), 49)\n    lu.assertEquals(candidate(10), 66)\n    lu.assertEquals(candidate(11), 88)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "lua",
+    "prompt": "-- Write a function to extract specified size of strings from a given table of string values.\nlocal function extract_string(str, l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_string\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 8), {'practice', 'solution'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 6), {'Python'})\n    lu.assertEquals(candidate({'Python', 'list', 'exercises', 'practice', 'solution'}, 9), {'exercises'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all whitespaces from the given string.\nlocal function remove_whitespaces(text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_whitespaces\n    lu.assertEquals(candidate(' Google    Flutter '), 'GoogleFlutter')\n    lu.assertEquals(candidate(' Google    Dart '), 'GoogleDart')\n    lu.assertEquals(candidate(' iOS    Swift '), 'iOSSwift')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "lua",
+    "prompt": "-- Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nlocal function loss_amount(actual_cost, sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = loss_amount\n    lu.assertEquals(candidate(1500, 1200), 0)\n    lu.assertEquals(candidate(100, 200), 100)\n    lu.assertEquals(candidate(2000, 5000), 3000)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of even factors of a number.\nlocal function sumofFactors(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sumofFactors\n    lu.assertEquals(candidate(18), 26)\n    lu.assertEquals(candidate(30), 48)\n    lu.assertEquals(candidate(6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a word containing 'z'.\nlocal function text_match_wordz(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz\n    lu.assertEquals(candidate('pythonz.'), true)\n    lu.assertEquals(candidate('xyz.'), true)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given month number contains 31 days or not.\nlocal function check_monthnumb_number(monthnum2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumb_number\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(6), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "lua",
+    "prompt": "-- Write a function to reverse each string in a given table of string values.\nlocal function reverse_string_list(stringlist)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_string_list\n    lu.assertEquals(candidate({'Red', 'Green', 'Blue', 'White', 'Black'}), {'deR', 'neerG', 'eulB', 'etihW', 'kcalB'})\n    lu.assertEquals(candidate({'john', 'amal', 'joel', 'george'}), {'nhoj', 'lama', 'leoj', 'egroeg'})\n    lu.assertEquals(candidate({'jack', 'john', 'mary'}), {'kcaj', 'nhoj', 'yram'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the subtable having minimum length.\nlocal function Find_Min(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min\n    lu.assertEquals(candidate({{1}, {1, 2}, {1, 2, 3}}), {1})\n    lu.assertEquals(candidate({{1, 1}, {1, 1, 1}, {1, 2, 7, 8}}), {1, 1})\n    lu.assertEquals(candidate({{'x'}, {'x', 'y'}, {'x', 'y', 'z'}}), {'x'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "lua",
+    "prompt": "-- Write a function to find the area of a rectangle.\nlocal function rectangle_area(l, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rectangle_area\n    lu.assertEquals(candidate(10, 20), 200)\n    lu.assertEquals(candidate(10, 5), 50)\n    lu.assertEquals(candidate(4, 2), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "lua",
+    "prompt": "-- Write a function to remove uppercase substrings from a given string.\nlocal function remove_uppercase(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_uppercase\n    lu.assertEquals(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')\n    lu.assertEquals(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')\n    lu.assertEquals(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to get the first element of each subtable.\nlocal function Extract(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Extract\n    lu.assertEquals(candidate({{1, 2}, {3, 4, 5}, {6, 7, 8, 9}}), {1, 3, 6})\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5}}), {1, 4})\n    lu.assertEquals(candidate({{9, 8, 1}, {1, 2}}), {9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the upper case characters in a given string.\nlocal function upper_ctr(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = upper_ctr\n    lu.assertEquals(candidate('PYthon'), 1)\n    lu.assertEquals(candidate('BigData'), 1)\n    lu.assertEquals(candidate('program'), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "lua",
+    "prompt": "-- Write a function to find all possible combinations of the elements of a given table.\nlocal function combinations_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = combinations_list\n    lu.assertEquals(candidate({'orange', 'red', 'green', 'blue'}), {{}, {'orange'}, {'red'}, {'red', 'orange'}, {'green'}, {'green', 'orange'}, {'green', 'red'}, {'green', 'red', 'orange'}, {'blue'}, {'blue', 'orange'}, {'blue', 'red'}, {'blue', 'red', 'orange'}, {'blue', 'green'}, {'blue', 'green', 'orange'}, {'blue', 'green', 'red'}, {'blue', 'green', 'red', 'orange'}})\n    lu.assertEquals(candidate({'red', 'green', 'blue', 'white', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'blue'}, {'blue', 'red'}, {'blue', 'green'}, {'blue', 'green', 'red'}, {'white'}, {'white', 'red'}, {'white', 'green'}, {'white', 'green', 'red'}, {'white', 'blue'}, {'white', 'blue', 'red'}, {'white', 'blue', 'green'}, {'white', 'blue', 'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'black', 'blue'}, {'black', 'blue', 'red'}, {'black', 'blue', 'green'}, {'black', 'blue', 'green', 'red'}, {'black', 'white'}, {'black', 'white', 'red'}, {'black', 'white', 'green'}, {'black', 'white', 'green', 'red'}, {'black', 'white', 'blue'}, {'black', 'white', 'blue', 'red'}, {'black', 'white', 'blue', 'green'}, {'black', 'white', 'blue', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'blue'}, {'orange', 'blue', 'red'}, {'orange', 'blue', 'green'}, {'orange', 'blue', 'green', 'red'}, {'orange', 'white'}, {'orange', 'white', 'red'}, {'orange', 'white', 'green'}, {'orange', 'white', 'green', 'red'}, {'orange', 'white', 'blue'}, {'orange', 'white', 'blue', 'red'}, {'orange', 'white', 'blue', 'green'}, {'orange', 'white', 'blue', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}, {'orange', 'black', 'blue'}, {'orange', 'black', 'blue', 'red'}, {'orange', 'black', 'blue', 'green'}, {'orange', 'black', 'blue', 'green', 'red'}, {'orange', 'black', 'white'}, {'orange', 'black', 'white', 'red'}, {'orange', 'black', 'white', 'green'}, {'orange', 'black', 'white', 'green', 'red'}, {'orange', 'black', 'white', 'blue'}, {'orange', 'black', 'white', 'blue', 'red'}, {'orange', 'black', 'white', 'blue', 'green'}, {'orange', 'black', 'white', 'blue', 'green', 'red'}})\n    lu.assertEquals(candidate({'red', 'green', 'black', 'orange'}), {{}, {'red'}, {'green'}, {'green', 'red'}, {'black'}, {'black', 'red'}, {'black', 'green'}, {'black', 'green', 'red'}, {'orange'}, {'orange', 'red'}, {'orange', 'green'}, {'orange', 'green', 'red'}, {'orange', 'black'}, {'orange', 'black', 'red'}, {'orange', 'black', 'green'}, {'orange', 'black', 'green', 'red'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum product subtable of the given table.\nlocal function max_subarray_product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_subarray_product\n    lu.assertEquals(candidate({1, -2, -3, 0, 7, -8, -2}), 112)\n    lu.assertEquals(candidate({6, -3, -10, 0, 2}), 180)\n    lu.assertEquals(candidate({-2, -40, 0, -2, -3}), 80)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "lua",
+    "prompt": "-- Write a function to check if all values are same in a table.\nlocal function check_value(dict, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_value\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 10), false)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 12), true)\n    lu.assertEquals(candidate({['Cierra Vega'] = 12, ['Alden Cantrell'] = 12, ['Kierra Gentry'] = 12, ['Pierre Cox'] = 12}, 5), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "lua",
+    "prompt": "-- Write a function to drop empty items from a given table.\nlocal function drop_empty(dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = drop_empty\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = 'Green', ['c3'] = None}), {['c1'] = 'Red', ['c2'] = 'Green'})\n    lu.assertEquals(candidate({['c1'] = 'Red', ['c2'] = None, ['c3'] = None}), {['c1'] = 'Red'})\n    lu.assertEquals(candidate({['c1'] = None, ['c2'] = 'Green', ['c3'] = None}), {['c2'] = 'Green'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that table.\nlocal function max_product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_product\n    lu.assertEquals(candidate({3, 100, 4, 5, 150, 6}), 3000)\n    lu.assertEquals(candidate({4, 42, 55, 68, 80}), 50265600)\n    lu.assertEquals(candidate({10, 22, 9, 33, 21, 50, 41, 60}), 2460)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "lua",
+    "prompt": "-- Write a function to find the pairwise addition of the neighboring elements of the given table.\nlocal function add_pairwise(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_pairwise\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {6, 12, 15, 18})\n    lu.assertEquals(candidate({2, 6, 8, 9, 11}), {8, 14, 17, 20})\n    lu.assertEquals(candidate({3, 7, 9, 10, 12}), {10, 16, 19, 22})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the product of the table multiplication modulo n.\nlocal function find_remainder(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_remainder\n    lu.assertEquals(candidate({100, 10, 5, 25, 35, 14}, 11), 9)\n    lu.assertEquals(candidate({1, 1, 1}, 1), 0)\n    lu.assertEquals(candidate({1, 2, 1}, 2), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given table contains consecutive numbers or not.\nlocal function check_Consecutive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_Consecutive\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), true)\n    lu.assertEquals(candidate({1, 2, 3, 5, 6}), false)\n    lu.assertEquals(candidate({1, 2, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "lua",
+    "prompt": "-- Write a function to replace characters in a string.\nlocal function replace_char(str1, ch, newch)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_char\n    lu.assertEquals(candidate('polygon', 'y', 'l'), 'pollgon')\n    lu.assertEquals(candidate('character', 'c', 'a'), 'aharaater')\n    lu.assertEquals(candidate('python', 'l', 'a'), 'python')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a table by value.\nlocal function sort_counter(dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_counter\n    lu.assertEquals(candidate({['Math'] = 81, ['Physics'] = 83, ['Chemistry'] = 87}), {{'Chemistry', 87}, {'Physics', 83}, {'Math', 81}})\n    lu.assertEquals(candidate({['Math'] = 400, ['Physics'] = 300, ['Chemistry'] = 250}), {{'Math', 400}, {'Physics', 300}, {'Chemistry', 250}})\n    lu.assertEquals(candidate({['Math'] = 900, ['Physics'] = 1000, ['Chemistry'] = 1250}), {{'Chemistry', 1250}, {'Physics', 1000}, {'Math', 900}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of the largest and smallest value in a given table.\nlocal function big_sum(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_sum\n    lu.assertEquals(candidate({1, 2, 3}), 4)\n    lu.assertEquals(candidate({-1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({2, 3, 6}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to convert the given string to lower case.\nlocal function is_lower(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_lower\n    lu.assertEquals(candidate('InValid'), 'invalid')\n    lu.assertEquals(candidate('TruE'), 'true')\n    lu.assertEquals(candidate('SenTenCE'), 'sentence')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "lua",
+    "prompt": "-- Write a function to remove lowercase substrings from a given string.\nlocal function remove_lowercase(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_lowercase\n    lu.assertEquals(candidate('PYTHon'), 'PYTH')\n    lu.assertEquals(candidate('FInD'), 'FID')\n    lu.assertEquals(candidate('STRinG'), 'STRG')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the first digit of a given number.\nlocal function first_Digit(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_Digit\n    lu.assertEquals(candidate(123), 1)\n    lu.assertEquals(candidate(456), 4)\n    lu.assertEquals(candidate(12), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n largest integers from a given table of numbers, returned in descending order.\nlocal function heap_queue_largest(nums, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_queue_largest\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 3), {85, 75, 65})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 2), {85, 75})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 22, 58}, 5), {85, 75, 65, 58, 35})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "lua",
+    "prompt": "-- Write a luathon function which takes a table of integers and only returns the odd ones.\nlocal function Split(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {1, 3, 5})\n    lu.assertEquals(candidate({10, 11, 12, 13}), {11, 13})\n    lu.assertEquals(candidate({7, 8, 9, 1}), {7, 9, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nlocal function difference(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = difference\n    lu.assertEquals(candidate(3), 30)\n    lu.assertEquals(candidate(5), 210)\n    lu.assertEquals(candidate(2), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of pairs whose xor value is odd.\nlocal function find_Odd_Pair(A, N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Odd_Pair\n    lu.assertEquals(candidate({5, 4, 7, 2, 1}, 5), 6)\n    lu.assertEquals(candidate({7, 2, 8, 1, 0, 5, 11}, 7), 12)\n    lu.assertEquals(candidate({1, 2, 3}, 3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "lua",
+    "prompt": "-- Write a function to toggle the case of all characters in a string.\nlocal function toggle_string(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_string\n    lu.assertEquals(candidate('Python'), 'pYTHON')\n    lu.assertEquals(candidate('Pangram'), 'pANGRAM')\n    lu.assertEquals(candidate('LIttLE'), 'liTTle')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of the per-digit difference between two integers.\nlocal function digit_distance_nums(n1, n2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = digit_distance_nums\n    lu.assertEquals(candidate(1, 2), 1)\n    lu.assertEquals(candidate(23, 56), 6)\n    lu.assertEquals(candidate(123, 256), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the sum of the largest contiguous subtable in the given table.\nlocal function max_sub_array_sum(a, size)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sub_array_sum\n    lu.assertEquals(candidate({-2, -3, 4, -1, -2, 1, 5, -3}, 8), 7)\n    lu.assertEquals(candidate({-3, -4, 5, -2, -3, 2, 6, -4}, 8), 8)\n    lu.assertEquals(candidate({-4, -5, 6, -3, -4, 3, 7, -5}, 8), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "lua",
+    "prompt": "-- Write a function to find the union of the elements of two given tables and output them in sorted order.\nlocal function union_elements(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = union_elements\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 4, 5, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {3, 4, 5, 6}), {1, 2, 3, 4, 5, 6})\n    lu.assertEquals(candidate({11, 12, 13, 14}, {13, 15, 16, 17}), {11, 12, 13, 14, 15, 16, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the length of the longest subtables.\nlocal function Find_Max_Length(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Max_Length\n    lu.assertEquals(candidate({{1}, {1, 4}, {5, 6, 7, 8}}), 4)\n    lu.assertEquals(candidate({{0, 1}, {2, 2}, {3, 2, 1}}), 3)\n    lu.assertEquals(candidate({{7}, {22, 23}, {13, 14, 15}, {10, 20, 30, 40, 50}}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "lua",
+    "prompt": "-- Write a function to extract values between quotation marks from a string.\nlocal function extract_values(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_values\n    lu.assertEquals(candidate('\"Python\", \"PHP\", \"Java\"'), {'Python', 'PHP', 'Java'})\n    lu.assertEquals(candidate('\"python\",\"program\",\"language\"'), {'python', 'program', 'language'})\n    lu.assertEquals(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), {'red', 'blue', 'green', 'yellow'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "lua",
+    "prompt": "-- Write a luathon function which takes a table of integers and counts the number of possible unordered pairs where both elements are unequal.\nlocal function count_Pairs(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Pairs\n    lu.assertEquals(candidate({1, 2, 1}, 3), 2)\n    lu.assertEquals(candidate({1, 1, 1, 1}, 4), 0)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, 5), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to split a string into characters.\nlocal function split(word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split\n    lu.assertEquals(candidate('python'), {'p', 'y', 't', 'h', 'o', 'n'})\n    lu.assertEquals(candidate('Name'), {'N', 'a', 'm', 'e'})\n    lu.assertEquals(candidate('program'), {'p', 'r', 'o', 'g', 'r', 'a', 'm'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to get the sum of the digits of a non-negative integer.\nlocal function sum_digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_digits\n    lu.assertEquals(candidate(345), 12)\n    lu.assertEquals(candidate(12), 3)\n    lu.assertEquals(candidate(97), 16)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a specified table is sorted or not.\nlocal function issort_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = issort_list\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 16, 17}), true)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 12, 14, 20, 17}), false)\n    lu.assertEquals(candidate({1, 2, 4, 6, 8, 10, 15, 14, 20}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "lua",
+    "prompt": "-- Write a function to create a table of N empty dictionaries.\nlocal function empty_list(length)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = empty_list\n    lu.assertEquals(candidate(5), {{}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(6), {{}, {}, {}, {}, {}, {}})\n    lu.assertEquals(candidate(7), {{}, {}, {}, {}, {}, {}, {}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "lua",
+    "prompt": "-- Write a function to sort each subtable of strings in a given table of tables.\nlocal function sort_sublists(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_sublists\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black', 'white'}, {'white', 'black', 'orange'}}), {{'green', 'orange'}, {'black', 'white'}, {'black', 'orange', 'white'}})\n    lu.assertEquals(candidate({{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}}), {{'green', 'orange'}, {'black'}, {'green', 'orange'}, {'white'}})\n    lu.assertEquals(candidate({{'a', 'b'}, {'d', 'c'}, {'g', 'h'}, {'f', 'e'}}), {{'a', 'b'}, {'c', 'd'}, {'g', 'h'}, {'e', 'f'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check if a given number is one less than twice its reverse.\nlocal function checks(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = checks\n    lu.assertEquals(candidate(70), false)\n    lu.assertEquals(candidate(23), false)\n    lu.assertEquals(candidate(73), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to remove duplicate numbers from a given number of tables.\nlocal function two_unique_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = two_unique_nums\n    lu.assertEquals(candidate({1, 2, 3, 2, 3, 4, 5}), {1, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 2, 4, 5}), {1, 3, 4, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to calculate the product of the unique numbers in a given table.\nlocal function unique_product(list_data)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_product\n    lu.assertEquals(candidate({10, 20, 30, 40, 20, 50, 60, 40}), 720000000)\n    lu.assertEquals(candidate({1, 2, 3, 1}), 6)\n    lu.assertEquals(candidate({7, 8, 9, 0, 1, 1}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "lua",
+    "prompt": "-- Write a function to find the surface area of a cylinder.\nlocal function surfacearea_cylinder(r, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surfacearea_cylinder\n    lu.assertEquals(candidate(10, 5), 942.45)\n    lu.assertEquals(candidate(4, 5), 226.18800000000002)\n    lu.assertEquals(candidate(4, 10), 351.848)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether a table is subtable of another or not.\nlocal function is_Sub_Array(A, B)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Sub_Array\n    lu.assertEquals(candidate({1, 4, 3, 5}, {1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 1}, {1, 2, 1}), true)\n    lu.assertEquals(candidate({1, 0, 2, 2}, {2, 2, 0}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the last digit in factorial of a given number.\nlocal function last_Digit_Factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last_Digit_Factorial\n    lu.assertEquals(candidate(4), 4)\n    lu.assertEquals(candidate(21), 0)\n    lu.assertEquals(candidate(30), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to interleave 3 tables of the same length into a single flat table.\nlocal function interleave_lists(list1, list2, list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = interleave_lists\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7}, {10, 20, 30, 40, 50, 60, 70}, {100, 200, 300, 400, 500, 600, 700}), {1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700})\n    lu.assertEquals(candidate({10, 20}, {15, 2}, {5, 10}), {10, 15, 5, 20, 2, 10})\n    lu.assertEquals(candidate({11, 44}, {10, 15}, {20, 5}), {11, 10, 20, 44, 15, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "lua",
+    "prompt": "-- Write a function to find the dissimilar elements in the given two tables.\nlocal function find_dissimilar(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_dissimilar\n    lu.assertEquals(candidate({3, 4, 5, 6}, {5, 7, 4, 10}), {3, 6, 7, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, {7, 2, 3, 9}), {1, 4, 7, 9})\n    lu.assertEquals(candidate({21, 11, 25, 26}, {26, 34, 21, 36}), {34, 36, 11, 25})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the largest number that can be formed with the given table of digits.\nlocal function find_Max_Num(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Max_Num\n    lu.assertEquals(candidate({1, 2, 3}), 321)\n    lu.assertEquals(candidate({4, 5, 6, 1}), 6541)\n    lu.assertEquals(candidate({1, 2, 3, 9}), 9321)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "lua",
+    "prompt": "-- Write a function to remove uneven elements in the nested mixed table.\nlocal function extract_even(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_even\n    lu.assertEquals(candidate({4, 5, {7, 6, {2, 4}}, 6, 8}), {4, {6, {2, 4}}, 6, 8})\n    lu.assertEquals(candidate({5, 6, {8, 7, {4, 8}}, 7, 9}), {6, {8, {4, 8}}})\n    lu.assertEquals(candidate({5, 6, {9, 8, {4, 6}}, 8, 10}), {6, {8, {4, 6}}, 8, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the surface area of a square luaramid with a given base edge and height.\nlocal function surface_Area(b, s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = surface_Area\n    lu.assertEquals(candidate(3, 4), 33)\n    lu.assertEquals(candidate(4, 5), 56)\n    lu.assertEquals(candidate(1, 2), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "lua",
+    "prompt": "-- Write a function which returns nth catalan number.\nlocal function catalan_number(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = catalan_number\n    lu.assertEquals(candidate(10), 16796)\n    lu.assertEquals(candidate(9), 4862)\n    lu.assertEquals(candidate(7), 429)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "lua",
+    "prompt": "-- Write a function to find the first adverb ending with ly and its positions in a given string.\nlocal function find_adverbs(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_adverbs\n    lu.assertEquals(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')\n    lu.assertEquals(candidate('Please handle the situation carefuly'), '28-36: carefuly')\n    lu.assertEquals(candidate('Complete the task quickly'), '18-25: quickly')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "lua",
+    "prompt": "-- Write a function to find the n most expensive items in a given dataset.\nlocal function expensive_items(items, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = expensive_items\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}}, 2), {{['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-1', ['price'] = 101.1}})\n    lu.assertEquals(candidate({{['name'] = 'Item-1', ['price'] = 101.1}, {['name'] = 'Item-2', ['price'] = 555.22}, {['name'] = 'Item-3', ['price'] = 45.09}, {['name'] = 'Item-4', ['price'] = 22.75}}, 1), {{['name'] = 'Item-2', ['price'] = 555.22}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to split a table at the nth eelment and add the first part to the end.\nlocal function split_Arr(l, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = split_Arr\n    lu.assertEquals(candidate({12, 10, 5, 6, 52, 36}, 2), {5, 6, 52, 36, 12, 10})\n    lu.assertEquals(candidate({1, 2, 3, 4}, 1), {2, 3, 4, 1})\n    lu.assertEquals(candidate({0, 1, 2, 3, 4, 5, 6, 7}, 3), {3, 4, 5, 6, 7, 0, 1, 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to convert a table to a table.\nlocal function list_tuple(listx)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = list_tuple\n    lu.assertEquals(candidate({5, 10, 7, 4, 15, 3}), {5, 10, 7, 4, 15, 3})\n    lu.assertEquals(candidate({2, 4, 5, 6, 2, 3, 4, 4, 7}), {2, 4, 5, 6, 2, 3, 4, 4, 7})\n    lu.assertEquals(candidate({58, 44, 56}), {58, 44, 56})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the difference between largest and smallest value in a given table.\nlocal function big_diff(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = big_diff\n    lu.assertEquals(candidate({1, 2, 3, 4}), 3)\n    lu.assertEquals(candidate({4, 5, 12}), 8)\n    lu.assertEquals(candidate({9, 2, 3}), 7)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "lua",
+    "prompt": "-- Write a function to find perfect squares between two given numbers.\nlocal function perfect_squares(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = perfect_squares\n    lu.assertEquals(candidate(1, 30), {1, 4, 9, 16, 25})\n    lu.assertEquals(candidate(50, 100), {64, 81, 100})\n    lu.assertEquals(candidate(100, 200), {100, 121, 144, 169, 196})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given two integers have opposite sign or not.\nlocal function opposite_Signs(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = opposite_Signs\n    lu.assertEquals(candidate(1, -2), true)\n    lu.assertEquals(candidate(3, 2), false)\n    lu.assertEquals(candidate(-10, -10), false)\n    lu.assertEquals(candidate(-2, 2), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to interchange the first and last elements in a table.\nlocal function swap_List(newList)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({12, 35, 9, 56, 24}), {24, 35, 9, 56, 12})\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of the product of consecutive binomial co-efficients.\nlocal function sum_Of_product(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_product\n    lu.assertEquals(candidate(3), 15)\n    lu.assertEquals(candidate(4), 56)\n    lu.assertEquals(candidate(1), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "lua",
+    "prompt": "-- Write a function to remove leading zeroes from an ip address.\nlocal function removezero_ip(ip)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = removezero_ip\n    lu.assertEquals(candidate('216.08.094.196'), '216.8.94.196')\n    lu.assertEquals(candidate('12.01.024'), '12.1.24')\n    lu.assertEquals(candidate('216.08.094.0196'), '216.8.94.196')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to find the difference of the first even and first odd number of a given table.\nlocal function diff_even_odd(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = diff_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 1)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nlocal function min_Swaps(str1, str2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Swaps\n    lu.assertEquals(candidate('1101', '1110'), 1)\n    lu.assertEquals(candidate('111', '000'), 'Not Possible')\n    lu.assertEquals(candidate('111', '110'), 'Not Possible')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "lua",
+    "prompt": "-- Write a function to find kth element from the given two sorted tables.\nlocal function find_kth(arr1, arr2, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_kth\n    lu.assertEquals(candidate({2, 3, 6, 7, 9}, {1, 4, 8, 10}, 5), 6)\n    lu.assertEquals(candidate({100, 112, 256, 349, 770}, {72, 86, 113, 119, 265, 445, 892}, 7), 256)\n    lu.assertEquals(candidate({3, 4, 7, 8, 10}, {2, 5, 9, 11}, 6), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is armstrong or not.\nlocal function armstrong_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = armstrong_number\n    lu.assertEquals(candidate(153), true)\n    lu.assertEquals(candidate(259), false)\n    lu.assertEquals(candidate(4458), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "lua",
+    "prompt": "-- Write a function to find sum and average of first n natural numbers.\nlocal function sum_average(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_average\n    lu.assertEquals(candidate(10), {55, 5.5})\n    lu.assertEquals(candidate(15), {120, 8.0})\n    lu.assertEquals(candidate(20), {210, 10.5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth octagonal number.\nlocal function is_octagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_octagonal\n    lu.assertEquals(candidate(5), 65)\n    lu.assertEquals(candidate(10), 280)\n    lu.assertEquals(candidate(15), 645)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given number is even or not.\nlocal function is_Even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Even\n    lu.assertEquals(candidate(1), false)\n    lu.assertEquals(candidate(2), true)\n    lu.assertEquals(candidate(3), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the first repeated character in a given string.\nlocal function first_repeated_char(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_repeated_char\n    lu.assertEquals(candidate('abcabc'), 'a')\n    lu.assertEquals(candidate('abc'), None)\n    lu.assertEquals(candidate('123123'), '1')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "lua",
+    "prompt": "-- Write a function to get all lucid numbers smaller than or equal to a given integer.\nlocal function get_ludic(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_ludic\n    lu.assertEquals(candidate(10), {1, 2, 3, 5, 7})\n    lu.assertEquals(candidate(25), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25})\n    lu.assertEquals(candidate(45), {1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "lua",
+    "prompt": "-- Write a function to reverse words seperated by spaces in a given string.\nlocal function reverse_words(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_words\n    lu.assertEquals(candidate('python program'), 'program python')\n    lu.assertEquals(candidate('java language'), 'language java')\n    lu.assertEquals(candidate('indian man'), 'man indian')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given integer is a prime number.\nlocal function prime_num(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = prime_num\n    lu.assertEquals(candidate(13), true)\n    lu.assertEquals(candidate(7), true)\n    lu.assertEquals(candidate(-1010), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "lua",
+    "prompt": "-- Write a function to convert degrees to radians.\nlocal function radian_degree(degree)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = radian_degree\n    lu.assertEquals(candidate(90), 1.5707963267948966)\n    lu.assertEquals(candidate(60), 1.0471975511965976)\n    lu.assertEquals(candidate(120), 2.0943951023931953)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "lua",
+    "prompt": "-- Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nlocal function find_literals(text, pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_literals\n    lu.assertEquals(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), {'fox', 16, 19})\n    lu.assertEquals(candidate('Its been a very crazy procedure right', 'crazy'), {'crazy', 16, 21})\n    lu.assertEquals(candidate('Hardest choices required strongest will', 'will'), {'will', 35, 39})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find nth bell number.\nlocal function bell_Number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_Number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(3), 5)\n    lu.assertEquals(candidate(4), 15)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "lua",
+    "prompt": "-- Write a luathon function which takes a table and returns a table with the same elements, but the k'th element removed.\nlocal function remove_kth_element(list1, L)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_kth_element\n    lu.assertEquals(candidate({1, 1, 2, 3, 4, 4, 5, 1}, 3), {1, 1, 3, 4, 4, 5, 1})\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}, 4), {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}, 5), {10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "lua",
+    "prompt": "-- Write a function which given a matrix represented as a table of tables returns the max of the n'th column.\nlocal function max_of_nth(test_list, N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_of_nth\n    lu.assertEquals(candidate({{5, 6, 7}, {1, 3, 5}, {8, 9, 19}}, 2), 19)\n    lu.assertEquals(candidate({{6, 7, 8}, {2, 4, 6}, {9, 10, 20}}, 1), 10)\n    lu.assertEquals(candidate({{7, 8, 9}, {3, 5, 7}, {10, 11, 21}}, 1), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "lua",
+    "prompt": "-- Write a luathon function which takes a table of tables, where each subtable has two elements, and returns a table of two tables where the first table has the first element of each subtable and the second one has the second.\nlocal function merge(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge\n    lu.assertEquals(candidate({{'x', 'y'}, {'a', 'b'}, {'m', 'n'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}})\n    lu.assertEquals(candidate({{1, 2}, {3, 4}, {5, 6}, {7, 8}}), {{1, 3, 5, 7}, {2, 4, 6, 8}})\n    lu.assertEquals(candidate({{'x', 'y', 'z'}, {'a', 'b', 'c'}, {'m', 'n', 'o'}}), {{'x', 'a', 'm'}, {'y', 'b', 'n'}, {'z', 'c', 'o'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to find the cumulative sum of all the values that are present in the given table of tables.\nlocal function cummulative_sum(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = cummulative_sum\n    lu.assertEquals(candidate({{1, 3}, {5, 6, 7}, {2, 6}}), 30)\n    lu.assertEquals(candidate({{2, 4}, {6, 7, 8}, {3, 7}}), 37)\n    lu.assertEquals(candidate({{3, 5}, {7, 8, 9}, {4, 8}}), 44)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function which takes a tables of tables and returns the average value for each subtable as a table.\nlocal function average_tuple(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = average_tuple\n    lu.assertEquals(candidate({{10, 10, 10, 12}, {30, 45, 56, 45}, {81, 80, 39, 32}, {1, 2, 3, 4}}), {30.5, 34.25, 27.0, 23.25})\n    lu.assertEquals(candidate({{1, 1, -5}, {30, -15, 56}, {81, -60, -39}, {-10, 2, 3}}), {25.5, -18.0, 3.75})\n    lu.assertEquals(candidate({{100, 100, 100, 120}, {300, 450, 560, 450}, {810, 800, 390, 320}, {10, 20, 30, 40}}), {305.0, 342.5, 270.0, 232.5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "lua",
+    "prompt": "-- Write a function which takes two tables of the same length and performs the element wise modulo.\nlocal function tuple_modulo(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_modulo\n    lu.assertEquals(candidate({10, 4, 5, 6}, {5, 6, 7, 5}), {0, 4, 5, 1})\n    lu.assertEquals(candidate({11, 5, 6, 7}, {6, 7, 8, 6}), {5, 5, 6, 1})\n    lu.assertEquals(candidate({12, 6, 7, 8}, {7, 8, 9, 7}), {5, 6, 7, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "lua",
+    "prompt": "-- Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nlocal function min_Jumps(steps, d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_Jumps\n    lu.assertEquals(candidate({3, 4}, 11), 3.5)\n    lu.assertEquals(candidate({3, 4}, 0), 0)\n    lu.assertEquals(candidate({11, 14}, 11), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "lua",
+    "prompt": "-- Write a function to divide two tables element wise.\nlocal function div_list(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = div_list\n    lu.assertEquals(candidate({4, 5, 6}, {1, 2, 3}), {4.0, 2.5, 2.0})\n    lu.assertEquals(candidate({3, 2}, {1, 4}), {3.0, 0.5})\n    lu.assertEquals(candidate({90, 120}, {50, 70}), {1.8, 1.7142857142857142})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "lua",
+    "prompt": "-- Write a function to move all the numbers to the end of the given string.\nlocal function move_num(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_num\n    lu.assertEquals(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')\n    lu.assertEquals(candidate('Avengers124Assemble'), 'AvengersAssemble124')\n    lu.assertEquals(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of substrings with the sum of digits equal to their length.\nlocal function count_Substrings(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_Substrings\n    lu.assertEquals(candidate('112112'), 6)\n    lu.assertEquals(candidate('111'), 6)\n    lu.assertEquals(candidate('1101112'), 12)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "lua",
+    "prompt": "-- Write a function to find the median of two sorted tables of same size.\nlocal function get_median(arr1, arr2, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_median\n    lu.assertEquals(candidate({1, 12, 15, 26, 38}, {2, 13, 17, 30, 45}, 5), 16.0)\n    lu.assertEquals(candidate({2, 4, 8, 9}, {7, 13, 19, 28}, 4), 8.5)\n    lu.assertEquals(candidate({3, 6, 14, 23, 36, 42}, {2, 18, 27, 39, 49, 55}, 6), 25.0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to compute the n-th power of each number in a table.\nlocal function nth_nums(nums, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = nth_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}, 3), {1000, 8000, 27000})\n    lu.assertEquals(candidate({12, 15}, 5), {248832, 759375})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to convert a given string to uppercase.\nlocal function is_upper(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_upper\n    lu.assertEquals(candidate('person'), 'PERSON')\n    lu.assertEquals(candidate('final'), 'FINAL')\n    lu.assertEquals(candidate('Valid'), 'VALID')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to interchange the first and last element in a given table.\nlocal function swap_List(newList)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = swap_List\n    lu.assertEquals(candidate({1, 2, 3}), {3, 2, 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 4}), {4, 2, 3, 4, 1})\n    lu.assertEquals(candidate({4, 5, 6}), {6, 5, 4})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nlocal function triangle_area(r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = triangle_area\n    lu.assertEquals(candidate(-1), None)\n    lu.assertEquals(candidate(0), 0)\n    lu.assertEquals(candidate(2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the smallest missing number from a sorted table of natural numbers.\nlocal function find_First_Missing(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_First_Missing\n    lu.assertEquals(candidate({0, 1, 2, 3}), 4)\n    lu.assertEquals(candidate({0, 1, 2, 6, 9}), 3)\n    lu.assertEquals(candidate({2, 3, 5, 8, 9}), 0)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to replace all spaces in the given string with '%20'.\nlocal function replace_spaces(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')\n    lu.assertEquals(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')\n    lu.assertEquals(candidate('I love Coding'), 'I%20love%20Coding')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find even numbers from a table of numbers.\nlocal function Split(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Split\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), {2, 4})\n    lu.assertEquals(candidate({4, 5, 6, 7, 8, 0, 1}), {4, 6, 8, 0})\n    lu.assertEquals(candidate({8, 12, 15, 19}), {8, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find smallest number in a table.\nlocal function smallest_num(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = smallest_num\n    lu.assertEquals(candidate({10, 20, 1, 45, 99}), 1)\n    lu.assertEquals(candidate({1, 2, 3}), 1)\n    lu.assertEquals(candidate({45, 46, 50, 60}), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "lua",
+    "prompt": "-- Write a function to extract all the adjacent coordinates of the given coordinate table.\nlocal function get_coordinates(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_coordinates\n    lu.assertEquals(candidate({3, 4}), {{2, 3}, {2, 4}, {2, 5}, {3, 3}, {3, 4}, {3, 5}, {4, 3}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({4, 5}), {{3, 4}, {3, 5}, {3, 6}, {4, 4}, {4, 5}, {4, 6}, {5, 4}, {5, 5}, {5, 6}})\n    lu.assertEquals(candidate({5, 6}), {{4, 5}, {4, 6}, {4, 7}, {5, 5}, {5, 6}, {5, 7}, {6, 5}, {6, 6}, {6, 7}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to replace whitespaces with an underscore and vice versa in a given string.\nlocal function replace_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_spaces\n    lu.assertEquals(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')\n    lu.assertEquals(candidate('The_Avengers'), 'The Avengers')\n    lu.assertEquals(candidate('Fast and Furious'), 'Fast_and_Furious')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to move all zeroes to the end of the given table.\nlocal function move_zero(num_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = move_zero\n    lu.assertEquals(candidate({1, 0, 2, 0, 3, 4}), {1, 2, 3, 4, 0, 0})\n    lu.assertEquals(candidate({2, 3, 2, 0, 0, 4, 0, 5, 0}), {2, 3, 2, 4, 5, 0, 0, 0, 0})\n    lu.assertEquals(candidate({0, 1, 0, 1, 1}), {1, 1, 1, 0, 0})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of xor of all pairs of numbers in the given table.\nlocal function pair_xor_Sum(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_xor_Sum\n    lu.assertEquals(candidate({5, 9, 7, 6}, 4), 47)\n    lu.assertEquals(candidate({7, 3, 5}, 3), 12)\n    lu.assertEquals(candidate({7, 3}, 2), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort the given table.\nlocal function heap_sort(iterable)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = heap_sort\n    lu.assertEquals(candidate({1, 3, 5, 7, 9, 2, 4, 6, 8, 0}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})\n    lu.assertEquals(candidate({25, 35, 22, 85, 14, 65, 75, 25, 58}), {14, 22, 25, 25, 35, 58, 65, 75, 85})\n    lu.assertEquals(candidate({7, 1, 9, 5}), {1, 5, 7, 9})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given amount has no profit and no loss\nlocal function noprofit_noloss(actual_cost, sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = noprofit_noloss\n    lu.assertEquals(candidate(1500, 1200), false)\n    lu.assertEquals(candidate(100, 100), true)\n    lu.assertEquals(candidate(2000, 5000), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nlocal function wind_chill(v, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = wind_chill\n    lu.assertEquals(candidate(120, 35), 40)\n    lu.assertEquals(candidate(40, 20), 19)\n    lu.assertEquals(candidate(10, 8), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "lua",
+    "prompt": "-- Write a function to sum the length of the names of a given table of names after removing the names that start with a lowercase letter.\nlocal function sample_nam(sample_names)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sample_nam\n    lu.assertEquals(candidate({'sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'}), 16)\n    lu.assertEquals(candidate({'php', 'res', 'Python', 'abcd', 'Java', 'aaa'}), 10)\n    lu.assertEquals(candidate({'abcd', 'Python', 'abba', 'aba'}), 6)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "lua",
+    "prompt": "-- Write a function to find the maximum difference between available pairs in the given table table.\nlocal function max_difference(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_difference\n    lu.assertEquals(candidate({{3, 5}, {1, 7}, {10, 3}, {1, 2}}), 7)\n    lu.assertEquals(candidate({{4, 6}, {2, 17}, {9, 13}, {11, 12}}), 15)\n    lu.assertEquals(candidate({{12, 35}, {21, 27}, {13, 23}, {41, 22}}), 23)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "lua",
+    "prompt": "-- Write a function to remove the parenthesis and what is inbetween them from a string.\nlocal function remove_parenthesis(items)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_parenthesis\n    lu.assertEquals(candidate({'python (chrome)'}), 'python')\n    lu.assertEquals(candidate({'string(.abc)'}), 'string')\n    lu.assertEquals(candidate({'alpha(num)'}), 'alpha')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth nonagonal number.\nlocal function is_nonagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_nonagonal\n    lu.assertEquals(candidate(10), 325)\n    lu.assertEquals(candidate(15), 750)\n    lu.assertEquals(candidate(18), 1089)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "lua",
+    "prompt": "-- Write a function that checks if a strings contains 'z', except at the start and end of the word.\nlocal function text_match_wordz_middle(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_wordz_middle\n    lu.assertEquals(candidate('pythonzabc.'), true)\n    lu.assertEquals(candidate('zxyabc.'), false)\n    lu.assertEquals(candidate('  lang  .'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to reverse a table upto a given position.\nlocal function reverse_Array_Upto_K(input, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = reverse_Array_Upto_K\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 4), {4, 3, 2, 1, 5, 6})\n    lu.assertEquals(candidate({4, 5, 6, 7}, 2), {5, 4, 6, 7})\n    lu.assertEquals(candidate({9, 8, 7, 6, 5}, 3), {7, 8, 9, 6, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a table of tables using the second value of each table.\nlocal function subject_marks(subjectmarks)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = subject_marks\n    lu.assertEquals(candidate({{'English', 88}, {'Science', 90}, {'Maths', 97}, {'Social sciences', 82}}), {{'Social sciences', 82}, {'English', 88}, {'Science', 90}, {'Maths', 97}})\n    lu.assertEquals(candidate({{'Telugu', 49}, {'Hindhi', 54}, {'Social', 33}}), {{'Social', 33}, {'Telugu', 49}, {'Hindhi', 54}})\n    lu.assertEquals(candidate({{'Physics', 96}, {'Chemistry', 97}, {'Biology', 45}}), {{'Biology', 45}, {'Physics', 96}, {'Chemistry', 97}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to flatten a table and sum all of its elements.\nlocal function recursive_list_sum(data_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = recursive_list_sum\n    lu.assertEquals(candidate({1, 2, {3, 4}, {5, 6}}), 21)\n    lu.assertEquals(candidate({7, 10, {15, 14}, {19, 41}}), 106)\n    lu.assertEquals(candidate({10, 20, {30, 40}, {50, 60}}), 210)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of positive numbers in a table.\nlocal function pos_count(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pos_count\n    lu.assertEquals(candidate({1, -2, 3, -4}), 2)\n    lu.assertEquals(candidate({3, 4, 5, -1}), 3)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find the number of ways to partition a set of Bell numbers.\nlocal function bell_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = bell_number\n    lu.assertEquals(candidate(2), 2)\n    lu.assertEquals(candidate(10), 115975)\n    lu.assertEquals(candidate(56), 6775685320645824322581483068371419745979053216268760300)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given table is monotonic or not.\nlocal function is_Monotonic(A)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Monotonic\n    lu.assertEquals(candidate({6, 5, 4, 4}), true)\n    lu.assertEquals(candidate({1, 2, 2, 3}), true)\n    lu.assertEquals(candidate({1, 3, 2}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a table contains the given subtable or not.\nlocal function is_sublist(l, s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_sublist\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {3, 7}), false)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {4, 3}), true)\n    lu.assertEquals(candidate({2, 4, 3, 5, 7}, {1, 6}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the two numbers differ at one bit position only or not.\nlocal function differ_At_One_Bit_Pos(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = differ_At_One_Bit_Pos\n    lu.assertEquals(candidate(13, 9), true)\n    lu.assertEquals(candidate(15, 8), false)\n    lu.assertEquals(candidate(2, 4), false)\n    lu.assertEquals(candidate(2, 3), true)\n    lu.assertEquals(candidate(5, 1), true)\n    lu.assertEquals(candidate(1, 5), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "lua",
+    "prompt": "-- Write a function to find whether all the given tables have equal length or not.\nlocal function get_equal(Input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_equal\n    lu.assertEquals(candidate({{11, 22, 33}, {44, 55, 66}}), true)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6, 7}}), false)\n    lu.assertEquals(candidate({{1, 2}, {3, 4}}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a table of elements.\nlocal function comb_sort(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = comb_sort\n    lu.assertEquals(candidate({5, 15, 37, 25, 79}), {5, 15, 25, 37, 79})\n    lu.assertEquals(candidate({41, 32, 15, 19, 22}), {15, 19, 22, 32, 41})\n    lu.assertEquals(candidate({99, 15, 13, 47}), {13, 15, 47, 99})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to add a table to the table. The output should be a table.\nlocal function add_dict_to_tuple(test_tup, test_dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_dict_to_tuple\n    lu.assertEquals(candidate({4, 5, 6}, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}), {4, 5, 6, {['MSAM'] = 1, ['is'] = 2, ['best'] = 3}})\n    lu.assertEquals(candidate({1, 2, 3}, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}), {1, 2, 3, {['UTS'] = 2, ['is'] = 3, ['Worst'] = 4}})\n    lu.assertEquals(candidate({8, 9, 10}, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}), {8, 9, 10, {['POS'] = 3, ['is'] = 4, ['Okay'] = 5}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "lua",
+    "prompt": "-- Given a square matrix of size N*N given as a table of tables, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nlocal function maxAverageOfPath(cost)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = maxAverageOfPath\n    lu.assertEquals(candidate({{1, 2, 3}, {6, 5, 4}, {7, 3, 9}}), 5.2)\n    lu.assertEquals(candidate({{2, 3, 4}, {7, 6, 5}, {8, 4, 10}}), 6.2)\n    lu.assertEquals(candidate({{3, 4, 5}, {8, 7, 6}, {9, 5, 11}}), 7.2)\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}), 5.8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "lua",
+    "prompt": "-- The input is given as - a table with a student name as a key and a table of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nlocal function filter_data(students, h, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = filter_data\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 6.0, 70), {['Cierra Vega'] = {6.2, 70}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.9, 67), {['Cierra Vega'] = {6.2, 70}, ['Kierra Gentry'] = {6.0, 68}})\n    lu.assertEquals(candidate({['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}}, 5.7, 64), {['Cierra Vega'] = {6.2, 70}, ['Alden Cantrell'] = {5.9, 65}, ['Kierra Gentry'] = {6.0, 68}, ['Pierre Cox'] = {5.8, 66}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "lua",
+    "prompt": "-- The input is defined as two tables of the same length. Write a function to count indices where the tables have the same values.\nlocal function count_same_pair(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_same_pair\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8}, {2, 2, 3, 1, 2, 6, 7, 9}), 4)\n    lu.assertEquals(candidate({0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 11)\n    lu.assertEquals(candidate({2, 4, -6, -9, 11, -12, 14, -5, 17}, {2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8}), 1)\n    lu.assertEquals(candidate({0, 1, 1, 2}, {0, 1, 2, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "lua",
+    "prompt": "-- Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nlocal function power_base_sum(base, power)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power_base_sum\n    lu.assertEquals(candidate(2, 100), 115)\n    lu.assertEquals(candidate(8, 10), 37)\n    lu.assertEquals(candidate(8, 15), 62)\n    lu.assertEquals(candidate(3, 3), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "lua",
+    "prompt": "-- Write a function to extract values between quotation marks \" \" of the given string.\nlocal function extract_quotation(text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_quotation\n    lu.assertEquals(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), {'A53', 'multi', 'Processor'})\n    lu.assertEquals(candidate('Cast your \"favorite\" entertainment \"apps\"'), {'favorite', 'apps'})\n    lu.assertEquals(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), {'4k Ultra HD', 'HDR 10'})\n    lu.assertEquals(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "lua",
+    "prompt": "-- Write a function that takes as input a table of numbers (t_1,...,t_{N+1}) and returns a table of length N where the i-th element of the table is equal to t_i * t_{i+1}.\nlocal function multiply_elements(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = multiply_elements\n    lu.assertEquals(candidate({1, 5, 7, 8, 10}), {5, 35, 56, 80})\n    lu.assertEquals(candidate({2, 4, 5, 6, 7}), {8, 20, 30, 42})\n    lu.assertEquals(candidate({12, 13, 14, 9, 15}), {156, 182, 126, 135})\n    lu.assertEquals(candidate({12}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "lua",
+    "prompt": "-- Write a function takes as input two tables [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nlocal function sum_list(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_list\n    lu.assertEquals(candidate({10, 20, 30}, {15, 25, 35}), {25, 45, 65})\n    lu.assertEquals(candidate({1, 2, 3}, {5, 6, 7}), {6, 8, 10})\n    lu.assertEquals(candidate({15, 20, 30}, {15, 45, 75}), {30, 65, 105})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the given number can be represented as the difference of two squares or not.\nlocal function dif_Square(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = dif_Square\n    lu.assertEquals(candidate(5), true)\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(15), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "lua",
+    "prompt": "-- Write a function to remove consecutive duplicates of a given table.\nlocal function consecutive_duplicates(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {10, 15, 19, 18, 17, 26, 17, 18, 10})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {'a', 'b', 'c', 'd'})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd', 'a', 'a'}), {'a', 'b', 'c', 'd', 'a'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "lua",
+    "prompt": "-- Write a function to find the lateral surface area of a cone given radius r and the height h.\nlocal function lateralsurface_cone(r, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lateralsurface_cone\n    lu.assertEquals(candidate(5, 12), 204.20352248333654)\n    lu.assertEquals(candidate(10, 15), 566.3586699569488)\n    lu.assertEquals(candidate(19, 17), 1521.8090132193388)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "lua",
+    "prompt": "-- Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nlocal function replace_specialchar(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = replace_specialchar\n    lu.assertEquals(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')\n    lu.assertEquals(candidate('a b c,d e f'), 'a:b:c:d:e:f')\n    lu.assertEquals(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "lua",
+    "prompt": "-- Write a function to find the index of the first occurrence of a given number in a sorted table.\nlocal function find_first_occurrence(A, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_first_occurrence\n    lu.assertEquals(candidate({2, 5, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 1)\n    lu.assertEquals(candidate({2, 3, 5, 5, 6, 6, 8, 9, 9, 9}, 5), 2)\n    lu.assertEquals(candidate({2, 4, 1, 5, 6, 6, 8, 9, 9, 9}, 6), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find sum of products of all possible subtables of a given table. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subtables/\nlocal function sum_Of_Subarray_Prod(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_Of_Subarray_Prod\n    lu.assertEquals(candidate({1, 2, 3}), 20)\n    lu.assertEquals(candidate({1, 2}), 5)\n    lu.assertEquals(candidate({1, 2, 3, 4}), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nlocal function toggle_middle_bits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = toggle_middle_bits\n    lu.assertEquals(candidate(9), 15)\n    lu.assertEquals(candidate(10), 12)\n    lu.assertEquals(candidate(11), 13)\n    lu.assertEquals(candidate(65), 127)\n    lu.assertEquals(candidate(77), 115)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "lua",
+    "prompt": "-- Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/luathon-exercises/data-structures-and-algorithms/luathon-data-structure-exercise-24.php\nlocal function left_insertion(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given string is starting with a vowel or not using regex.\nlocal function check_str(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_str\n    lu.assertEquals(candidate('annie'), true)\n    lu.assertEquals(candidate('dawood'), false)\n    lu.assertEquals(candidate('Else'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/luathon-exercises/data-structures-and-algorithms/luathon-recursion-exercise-9.php\nlocal function geometric_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = geometric_sum\n    lu.assertEquals(candidate(7), 1.9921875)\n    lu.assertEquals(candidate(4), 1.9375)\n    lu.assertEquals(candidate(8), 1.99609375)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nlocal function find_Index(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Index\n    lu.assertEquals(candidate(2), 4)\n    lu.assertEquals(candidate(3), 14)\n    lu.assertEquals(candidate(4), 45)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given table to a key-value table using adjacent elements. https://www.geeksforgeeks.org/luathon-convert-table-to-adjacent-pair-table/\nlocal function tuple_to_dict(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_to_dict\n    lu.assertEquals(candidate({1, 5, 7, 10, 13, 5}), {[1] = 5, [7] = 10, [13] = 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), {[1] = 2, [3] = 4, [5] = 6})\n    lu.assertEquals(candidate({7, 8, 9, 10, 11, 12}), {[7] = 8, [9] = 10, [11] = 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether all the characters are same or not.\nlocal function all_Characters_Same(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = all_Characters_Same\n    lu.assertEquals(candidate('python'), false)\n    lu.assertEquals(candidate('aaa'), true)\n    lu.assertEquals(candidate('data'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "lua",
+    "prompt": "-- Write a function to caluclate the area of a tetrahedron.\nlocal function area_tetrahedron(side)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = area_tetrahedron\n    lu.assertEquals(candidate(3), 15.588457268119894)\n    lu.assertEquals(candidate(20), 692.8203230275509)\n    lu.assertEquals(candidate(10), 173.20508075688772)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "lua",
+    "prompt": "-- Write a function to rotate a given table by specified number of items to the right direction. https://www.geeksforgeeks.org/luathon-program-right-rotate-table-n/\nlocal function rotate_right(list, m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rotate_right\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 3), {8, 9, 10, 1, 2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2), {9, 10, 1, 2, 3, 4, 5, 6, 7, 8})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5), {6, 7, 8, 9, 10, 1, 2, 3, 4, 5})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given table has any none value or not.\nlocal function check_none(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_none\n    lu.assertEquals(candidate({10, 4, 5, 6, None}), true)\n    lu.assertEquals(candidate({7, 8, 9, 11, 14}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, None}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "lua",
+    "prompt": "-- Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/luathon-exercises/lambda/luathon-lambda-exercise-24.php\nlocal function divisible_by_digits(startnum, endnum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisible_by_digits\n    lu.assertEquals(candidate(1, 22), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22})\n    lu.assertEquals(candidate(1, 15), {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15})\n    lu.assertEquals(candidate(20, 25), {22, 24})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "lua",
+    "prompt": "-- Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nlocal function sector_area(r, a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sector_area\n    lu.assertEquals(candidate(4, 45), 6.283185307179586)\n    lu.assertEquals(candidate(9, 45), 31.808625617596654)\n    lu.assertEquals(candidate(9, 361), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "lua",
+    "prompt": "-- Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlocal function lcs_of_three(X, Y, Z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = lcs_of_three\n    lu.assertEquals(candidate('AGGT12', '12TXAYB', '12XBA'), 2)\n    lu.assertEquals(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)\n    lu.assertEquals(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to put spaces between words starting with capital letters in a given string.\nlocal function capital_words_spaces(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = capital_words_spaces\n    lu.assertEquals(candidate('Python'), 'Python')\n    lu.assertEquals(candidate('PythonProgrammingExamples'), 'Python Programming Examples')\n    lu.assertEquals(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "lua",
+    "prompt": "-- Write a function to sort a given table of strings of numbers numerically. https://www.geeksforgeeks.org/luathon-sort-numeric-strings-in-a-table/\nlocal function sort_numeric_strings(nums_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sort_numeric_strings\n    lu.assertEquals(candidate({'4', '12', '45', '7', '0', '100', '200', '-12', '-500'}), {-500, -12, 0, 4, 7, 12, 45, 100, 200})\n    lu.assertEquals(candidate({'2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2'}), {1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9})\n    lu.assertEquals(candidate({'1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11'}), {1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether it follows the sequence given in the patterns table.\nlocal function is_samepatterns(colors, patterns)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_samepatterns\n    lu.assertEquals(candidate({'red', 'green', 'green'}, {'a', 'b', 'b'}), true)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b', 'b'}), false)\n    lu.assertEquals(candidate({'red', 'green', 'greenn'}, {'a', 'b'}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to add the given table to the given table.\nlocal function add_tuple(test_list, test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = add_tuple\n    lu.assertEquals(candidate({5, 6, 7}, {9, 10}), {5, 6, 7, 9, 10})\n    lu.assertEquals(candidate({6, 7, 8}, {10, 11}), {6, 7, 8, 10, 11})\n    lu.assertEquals(candidate({7, 8, 9}, {11, 12}), {7, 8, 9, 11, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given table represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-table-represents-a-binary-heap/\nlocal function check_min_heap(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_min_heap\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}), true)\n    lu.assertEquals(candidate({2, 3, 4, 5, 10, 15}), true)\n    lu.assertEquals(candidate({2, 10, 4, 5, 3, 15}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nlocal function jacobsthal_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = jacobsthal_num\n    lu.assertEquals(candidate(5), 11)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(4), 5)\n    lu.assertEquals(candidate(13), 2731)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "lua",
+    "prompt": "-- Write a function to find minimum k records from table table. https://www.geeksforgeeks.org/luathon-find-minimum-k-records-from-table-table/ - in this case a verbatim colua of test cases\nlocal function min_k(test_list, K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = min_k\n    lu.assertEquals(candidate({{'Manjeet', 10}, {'Akshat', 4}, {'Akash', 2}, {'Nikhil', 8}}, 2), {{'Akash', 2}, {'Akshat', 4}})\n    lu.assertEquals(candidate({{'Sanjeev', 11}, {'Angat', 5}, {'Akash', 3}, {'Nepin', 9}}, 3), {{'Akash', 3}, {'Angat', 5}, {'Nepin', 9}})\n    lu.assertEquals(candidate({{'tanmay', 14}, {'Amer', 11}, {'Ayesha', 9}, {'SKD', 16}}, 1), {{'Ayesha', 9}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "lua",
+    "prompt": "-- We say that an element is common for tables l1, l2, l3 if it appears in all three tables under the same index. Write a function to find common elements from three tables. The function should return a table.\nlocal function extract_index_list(l1, l2, l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = extract_index_list\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 7})\n    lu.assertEquals(candidate({1, 1, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 6, 5}, {0, 1, 2, 3, 4, 6, 7}), {1, 6})\n    lu.assertEquals(candidate({1, 1, 3, 4, 6, 5, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {1, 5})\n    lu.assertEquals(candidate({1, 2, 3, 4, 6, 6, 6}, {0, 1, 2, 3, 4, 5, 7}, {0, 1, 2, 3, 4, 5, 7}), {})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "lua",
+    "prompt": "-- Write a function to find the second smallest number in a table.\nlocal function second_smallest(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = second_smallest\n    lu.assertEquals(candidate({1, 2, -8, -2, 0, -2}), -2)\n    lu.assertEquals(candidate({1, 1, -0.5, 0, 2, -2, -2}), -0.5)\n    lu.assertEquals(candidate({2, 2}), None)\n    lu.assertEquals(candidate({2, 2, 2}), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/luathon-exercises/re/luathon-re-exercise-3.php\nlocal function text_match_zero_one(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_zero_one\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('dsabbbba'), true)\n    lu.assertEquals(candidate('asbbbba'), false)\n    lu.assertEquals(candidate('abaaa'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "lua",
+    "prompt": "-- Write a function to count the pairs of reverse strings in the given string table. https://www.geeksforgeeks.org/luathon-program-to-count-the-pairs-of-reverse-strings/\nlocal function count_reverse_pairs(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_reverse_pairs\n    lu.assertEquals(candidate({'julia', 'best', 'tseb', 'for', 'ailuj'}), 2)\n    lu.assertEquals(candidate({'geeks', 'best', 'for', 'skeeg'}), 1)\n    lu.assertEquals(candidate({'makes', 'best', 'sekam', 'for', 'rof'}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether a given string is a decimal number with a precision of 2.\nlocal function is_decimal(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_decimal\n    lu.assertEquals(candidate('123.11'), true)\n    lu.assertEquals(candidate('e666.86'), false)\n    lu.assertEquals(candidate('3.124587'), false)\n    lu.assertEquals(candidate('1.11'), true)\n    lu.assertEquals(candidate('1.1.11'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "lua",
+    "prompt": "-- Write a function to find tables which have all elements divisible by k from the given table of tables.\nlocal function find_tuples(test_list, K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_tuples\n    lu.assertEquals(candidate({{6, 24, 12}, {7, 9, 6}, {12, 18, 21}}, 6), {{6, 24, 12}})\n    lu.assertEquals(candidate({{5, 25, 30}, {4, 2, 3}, {7, 8, 9}}, 5), {{5, 25, 30}})\n    lu.assertEquals(candidate({{7, 9, 16}, {8, 16, 4}, {19, 17, 18}}, 4), {{8, 16, 4}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether a table of numbers contains only one distinct element or not.\nlocal function unique_Element(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = unique_Element\n    lu.assertEquals(candidate({1, 1, 1}), true)\n    lu.assertEquals(candidate({1, 2, 1, 2}), false)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nlocal function check_monthnumber_number(monthnum3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_monthnumber_number\n    lu.assertEquals(candidate(6), true)\n    lu.assertEquals(candidate(2), false)\n    lu.assertEquals(candidate(12), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the minimum difference between any two elements in a given table. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nlocal function find_min_diff(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_min_diff\n    lu.assertEquals(candidate({1, 5, 3, 19, 18, 25}, 6), 1)\n    lu.assertEquals(candidate({4, 3, 2, 6}, 4), 1)\n    lu.assertEquals(candidate({30, 5, 20, 9}, 4), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count number of digits in a given string.\nlocal function number_ctr(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = number_ctr\n    lu.assertEquals(candidate('program2bedone'), 1)\n    lu.assertEquals(candidate('3wonders'), 1)\n    lu.assertEquals(candidate('123'), 3)\n    lu.assertEquals(candidate('3wond-1ers2'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "lua",
+    "prompt": "-- Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nlocal function is_polite(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_polite\n    lu.assertEquals(candidate(7), 11)\n    lu.assertEquals(candidate(4), 7)\n    lu.assertEquals(candidate(9), 13)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "lua",
+    "prompt": "-- Write a function to return a table of all pairs of consecutive items in a given table.\nlocal function pair_wise(l1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pair_wise\n    lu.assertEquals(candidate({1, 1, 2, 3, 3, 4, 4, 5}), {{1, 1}, {1, 2}, {2, 3}, {3, 3}, {3, 4}, {4, 4}, {4, 5}})\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), {{1, 5}, {5, 7}, {7, 9}, {9, 10}})\n    lu.assertEquals(candidate({5, 1, 9, 7, 10}), {{5, 1}, {1, 9}, {9, 7}, {7, 10}})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 10}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a table of numbers and the sum,\nlocal function get_pairs_count(arr, sum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_pairs_count\n    lu.assertEquals(candidate({1, 1, 1, 1}, 2), 6)\n    lu.assertEquals(candidate({1, 5, 7, -1, 5}, 6), 3)\n    lu.assertEquals(candidate({1, -2, 3}, 1), 1)\n    lu.assertEquals(candidate({-1, -2, 3}, -3), 1)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to get the difference between two tables.\nlocal function Diff(li1, li2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Diff\n    lu.assertEquals(candidate({10, 15, 20, 25, 30, 35, 40}, {25, 40, 35}), {10, 20, 30, 15})\n    lu.assertEquals(candidate({1, 2, 3, 4, 5}, {6, 7, 1}), {2, 3, 4, 5, 6, 7})\n    lu.assertEquals(candidate({1, 2, 3}, {6, 7, 1}), {2, 3, 6, 7})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of fourth power of first n odd natural numbers.\nlocal function odd_num_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_num_sum\n    lu.assertEquals(candidate(2), 82)\n    lu.assertEquals(candidate(3), 707)\n    lu.assertEquals(candidate(4), 3108)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nlocal function check_expression(exp)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_expression\n    lu.assertEquals(candidate('{()}[{}]'), true)\n    lu.assertEquals(candidate('{()}[{]'), false)\n    lu.assertEquals(candidate('{()}[{}][]({})'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all the words with k length in the given string.\nlocal function remove_length(test_str, K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_length\n    lu.assertEquals(candidate('The person is most value tet', 3), 'person is most value')\n    lu.assertEquals(candidate('If you told me about this ok', 4), 'If you me about ok')\n    lu.assertEquals(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "lua",
+    "prompt": "-- Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nlocal function occurance_substring(text, pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = occurance_substring\n    lu.assertEquals(candidate('python programming, python language', 'python'), {'python', 0, 6})\n    lu.assertEquals(candidate('python programming,programming language', 'programming'), {'programming', 7, 18})\n    lu.assertEquals(candidate('python programming,programming language', 'language'), {'language', 31, 39})\n    lu.assertEquals(candidate('c++ programming, c++ language', 'python'), None)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether every odd index contains odd numbers of a given table.\nlocal function odd_position(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_position\n    lu.assertEquals(candidate({2, 1, 4, 3, 6, 7, 6, 3}), true)\n    lu.assertEquals(candidate({4, 1, 2}), true)\n    lu.assertEquals(candidate({1, 2, 3}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "lua",
+    "prompt": "-- Write a function to count those characters which have vowels as their neighbors in the given string.\nlocal function count_vowels(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_vowels\n    lu.assertEquals(candidate('bestinstareels'), 7)\n    lu.assertEquals(candidate('partofthejourneyistheend'), 12)\n    lu.assertEquals(candidate('amazonprime'), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of non-repeated elements in a given table.\nlocal function find_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_sum\n    lu.assertEquals(candidate({1, 2, 3, 1, 1, 4, 5, 6}), 21)\n    lu.assertEquals(candidate({1, 10, 9, 4, 2, 10, 10, 45, 4}), 71)\n    lu.assertEquals(candidate({12, 10, 9, 45, 2, 10, 10, 45, 10}), 78)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "lua",
+    "prompt": "-- Write a function to pack consecutive duplicates of a given table elements into subtables.\nlocal function pack_consecutive_duplicates(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = pack_consecutive_duplicates\n    lu.assertEquals(candidate({0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4}), {{0, 0}, {1}, {2}, {3}, {4, 4}, {5}, {6, 6, 6}, {7}, {8}, {9}, {4, 4}})\n    lu.assertEquals(candidate({10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10}), {{10, 10}, {15}, {19}, {18, 18}, {17}, {26, 26}, {17}, {18}, {10}})\n    lu.assertEquals(candidate({'a', 'a', 'b', 'c', 'd', 'd'}), {{'a', 'a'}, {'b'}, {'c'}, {'d', 'd'}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find whether a number is divisible by 11.\nlocal function is_Diff(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_Diff\n    lu.assertEquals(candidate(12345), false)\n    lu.assertEquals(candidate(1212112), true)\n    lu.assertEquals(candidate(1212), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "lua",
+    "prompt": "-- Write a function to find the combinations of sums with tables in the given table table. https://www.geeksforgeeks.org/luathon-combinations-of-sum-with-tables-in-table-table/\nlocal function find_combinations(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_combinations\n    lu.assertEquals(candidate({{2, 4}, {6, 7}, {5, 1}, {6, 10}}), {{8, 11}, {7, 5}, {8, 14}, {11, 8}, {12, 17}, {11, 11}})\n    lu.assertEquals(candidate({{3, 5}, {7, 8}, {6, 2}, {7, 11}}), {{10, 13}, {9, 7}, {10, 16}, {13, 10}, {14, 19}, {13, 13}})\n    lu.assertEquals(candidate({{4, 6}, {8, 9}, {7, 3}, {8, 12}}), {{12, 15}, {11, 9}, {12, 18}, {15, 12}, {16, 21}, {15, 15}})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the count of divisors is even. https://www.w3resource.com/luathon-exercises/basic/luathon-basic-1-exercise-24.php\nlocal function count_divisors(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_divisors\n    lu.assertEquals(candidate(10), true)\n    lu.assertEquals(candidate(100), false)\n    lu.assertEquals(candidate(125), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of all odd length subtables. https://www.geeksforgeeks.org/sum-of-all-odd-length-subtables/\nlocal function odd_length_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = odd_length_sum\n    lu.assertEquals(candidate({1, 2, 4}), 14)\n    lu.assertEquals(candidate({1, 2, 1, 2}), 15)\n    lu.assertEquals(candidate({1, 7}), 8)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "lua",
+    "prompt": "-- Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nlocal function rgb_to_hsv(r, g, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = rgb_to_hsv\n    lu.assertEquals(candidate(255, 255, 255), {0.0, 0.0, 100.0})\n    lu.assertEquals(candidate(0, 215, 0), {120.0, 100.0, 84.31372549019608})\n    lu.assertEquals(candidate(10, 215, 110), {149.26829268292684, 95.34883720930233, 84.31372549019608})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "lua",
+    "prompt": "-- Write a function to find the product of first even and odd number of a given table.\nlocal function mul_even_odd(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = mul_even_odd\n    lu.assertEquals(candidate({1, 3, 5, 7, 4, 1, 6, 8}), 4)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), 2)\n    lu.assertEquals(candidate({1, 5, 7, 9, 10}), 10)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "lua",
+    "prompt": "-- Write a function to convert table string to integer table.\nlocal function tuple_str_int(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tuple_str_int\n    lu.assertEquals(candidate('(7, 8, 9)'), {7, 8, 9})\n    lu.assertEquals(candidate('(1, 2, 3)'), {1, 2, 3})\n    lu.assertEquals(candidate('(4, 5, 6)'), {4, 5, 6})\n    lu.assertEquals(candidate('(7, 81, 19)'), {7, 81, 19})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "lua",
+    "prompt": "-- Write a function to locate the right insertion point for a specified value in sorted order.\nlocal function right_insertion(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = right_insertion\n    lu.assertEquals(candidate({1, 2, 4, 5}, 6), 4)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 3), 2)\n    lu.assertEquals(candidate({1, 2, 4, 5}, 7), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an a followed by three 'b'.\nlocal function text_match_three(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_match_three\n    lu.assertEquals(candidate('ac'), false)\n    lu.assertEquals(candidate('dc'), false)\n    lu.assertEquals(candidate('abbbba'), true)\n    lu.assertEquals(candidate('caacabbbba'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "lua",
+    "prompt": "-- Write a function to create a new table from the given string and table.\nlocal function new_tuple(test_list, test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = new_tuple\n    lu.assertEquals(candidate({'WEB', 'is'}, 'best'), {'WEB', 'is', 'best'})\n    lu.assertEquals(candidate({'We', 'are'}, 'Developers'), {'We', 'are', 'Developers'})\n    lu.assertEquals(candidate({'Part', 'is'}, 'Wrong'), {'Part', 'is', 'Wrong'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether every even index contains even numbers of a given table.\nlocal function even_position(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = even_position\n    lu.assertEquals(candidate({3, 2, 1}), false)\n    lu.assertEquals(candidate({1, 2, 3}), false)\n    lu.assertEquals(candidate({2, 1, 4}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "lua",
+    "prompt": "-- Write a function to remove tables from the given table.\nlocal function remove_nested(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_nested\n    lu.assertEquals(candidate({1, 5, 7, {4, 6}, 10}), {1, 5, 7, 10})\n    lu.assertEquals(candidate({2, 6, 8, {5, 7}, 11}), {2, 6, 8, 11})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, 12}), {3, 7, 9, 12})\n    lu.assertEquals(candidate({3, 7, 9, {6, 8}, {5, 12}, 12}), {3, 7, 9, 12})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of tables in a given number of tables.\nlocal function count_list(input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_list\n    lu.assertEquals(candidate({{1, 3}, {5, 7}, {9, 11}, {13, 15, 17}}), 4)\n    lu.assertEquals(candidate({{1, 2}, {2, 3}, {4, 5}}), 3)\n    lu.assertEquals(candidate({{1, 0}, {2, 0}}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the last position of an element in a sorted table.\nlocal function last(arr, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = last\n    lu.assertEquals(candidate({1, 2, 3}, 1), 0)\n    lu.assertEquals(candidate({1, 1, 1, 2, 3, 4}, 1), 2)\n    lu.assertEquals(candidate({2, 3, 2, 3, 6, 8, 9}, 3), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "lua",
+    "prompt": "-- Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nlocal function text_starta_endb(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = text_starta_endb\n    lu.assertEquals(candidate('aabbbb'), true)\n    lu.assertEquals(candidate('aabAbbbc'), false)\n    lu.assertEquals(candidate('accddbbjjj'), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "lua",
+    "prompt": "-- Write function to find the sum of all items in the given table.\nlocal function return_sum(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = return_sum\n    lu.assertEquals(candidate({['a'] = 100, ['b'] = 200, ['c'] = 300}), 600)\n    lu.assertEquals(candidate({['a'] = 25, ['b'] = 18, ['c'] = 45}), 88)\n    lu.assertEquals(candidate({['a'] = 36, ['b'] = 39, ['c'] = 49}), 124)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of all odd natural numbers within the range l and r.\nlocal function sum_in_range(l, r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sum_in_range\n    lu.assertEquals(candidate(2, 5), 8)\n    lu.assertEquals(candidate(5, 7), 12)\n    lu.assertEquals(candidate(7, 13), 40)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the sum of a table.\nlocal function _sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = _sum\n    lu.assertEquals(candidate({1, 2, 3}), 6)\n    lu.assertEquals(candidate({15, 12, 13, 10}), 50)\n    lu.assertEquals(candidate({0, 1, 2}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "lua",
+    "prompt": "-- Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nlocal function left_rotate(n, d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = left_rotate\n    lu.assertEquals(candidate(16, 2), 64)\n    lu.assertEquals(candidate(10, 2), 40)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(99, 3), 792)\n    lu.assertEquals(candidate(1, 3), 8)\n    lu.assertEquals(candidate(5, 3), 40)\n    lu.assertEquals(candidate(29, 3), 232)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to check whether the length of the word is odd or not.\nlocal function word_len(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = word_len\n    lu.assertEquals(candidate('Hadoop'), false)\n    lu.assertEquals(candidate('great'), true)\n    lu.assertEquals(candidate('structure'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "lua",
+    "prompt": "-- Write a function to remove all whitespaces from a string.\nlocal function remove_all_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = remove_all_spaces\n    lu.assertEquals(candidate('python  program'), 'pythonprogram')\n    lu.assertEquals(candidate('python   programming    language'), 'pythonprogramminglanguage')\n    lu.assertEquals(candidate('python                     program'), 'pythonprogram')\n    lu.assertEquals(candidate('   python                     program'), 'pythonprogram')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of equal numbers from three given integers.\nlocal function test_three_equal(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = test_three_equal\n    lu.assertEquals(candidate(1, 1, 1), 3)\n    lu.assertEquals(candidate(-1, -2, -3), 0)\n    lu.assertEquals(candidate(1, 2, 2), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to count the number of rotations required to generate a sorted table. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-table/\nlocal function count_rotation(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = count_rotation\n    lu.assertEquals(candidate({3, 2, 1}), 1)\n    lu.assertEquals(candidate({4, 5, 1, 2, 3}), 2)\n    lu.assertEquals(candidate({7, 8, 9, 1, 2, 3}), 3)\n    lu.assertEquals(candidate({1, 2, 3}), 0)\n    lu.assertEquals(candidate({1, 3, 2}), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nlocal function is_perfect_square(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_perfect_square\n    lu.assertEquals(candidate(10), false)\n    lu.assertEquals(candidate(36), true)\n    lu.assertEquals(candidate(14), false)\n    lu.assertEquals(candidate(196), true)\n    lu.assertEquals(candidate(125), false)\n    lu.assertEquals(candidate(15625), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the product of numbers in a table is even or not.\nlocal function is_product_even(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_product_even\n    lu.assertEquals(candidate({1, 2, 3}), true)\n    lu.assertEquals(candidate({1, 2, 1, 4}), true)\n    lu.assertEquals(candidate({1, 1}), false)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "lua",
+    "prompt": "-- Write a function that returns the table in a table of tables whose sum of elements is the highest.\nlocal function max_sum_list(lists)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_sum_list\n    lu.assertEquals(candidate({{1, 2, 3}, {4, 5, 6}, {10, 11, 12}, {7, 8, 9}}), {10, 11, 12})\n    lu.assertEquals(candidate({{3, 2, 1}, {6, 5, 4}, {12, 11, 10}}), {12, 11, 10})\n    lu.assertEquals(candidate({{2, 3, 1}}), {2, 3, 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "lua",
+    "prompt": "-- Write a function to find maximum run of uppercase characters in the given string.\nlocal function max_run_uppercase(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = max_run_uppercase\n    lu.assertEquals(candidate('GeMKSForGERksISBESt'), 5)\n    lu.assertEquals(candidate('PrECIOusMOVemENTSYT'), 6)\n    lu.assertEquals(candidate('GooGLEFluTTER'), 4)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the first odd number in a given table of numbers.\nlocal function first_odd(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = first_odd\n    lu.assertEquals(candidate({1, 3, 5}), 1)\n    lu.assertEquals(candidate({2, 4, 1, 3}), 1)\n    lu.assertEquals(candidate({8, 9, 1}), 9)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "lua",
+    "prompt": "-- Write a function to check if the given tables contain the k or not.\nlocal function check_K(test_tup, K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_K\n    lu.assertEquals(candidate({10, 4, 5, 6, 8}, 6), true)\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6}, 7), false)\n    lu.assertEquals(candidate({7, 8, 9, 44, 11, 12}, 11), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "lua",
+    "prompt": "-- Write a function to check if each element of second table is smaller than its corresponding element in the first table.\nlocal function check_smaller(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = check_smaller\n    lu.assertEquals(candidate({1, 2, 3}, {2, 3, 4}), false)\n    lu.assertEquals(candidate({4, 5, 6}, {3, 4, 5}), true)\n    lu.assertEquals(candidate({11, 12, 13}, {10, 11, 12}), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth tetrahedral number.\nlocal function tetrahedral_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = tetrahedral_number\n    lu.assertEquals(candidate(5), 35)\n    lu.assertEquals(candidate(6), 56)\n    lu.assertEquals(candidate(7), 84)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nlocal function get_Char(strr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = get_Char\n    lu.assertEquals(candidate('abc'), 'f')\n    lu.assertEquals(candidate('gfg'), 't')\n    lu.assertEquals(candidate('ab'), 'c')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "lua",
+    "prompt": "-- Write a function to find the nth number in the newman conway sequence.\nlocal function sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = sequence\n    lu.assertEquals(candidate(10), 6)\n    lu.assertEquals(candidate(2), 1)\n    lu.assertEquals(candidate(3), 2)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "lua",
+    "prompt": "-- Write a function to find nth centered hexagonal number.\nlocal function centered_hexagonal_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = centered_hexagonal_number\n    lu.assertEquals(candidate(10), 271)\n    lu.assertEquals(candidate(2), 7)\n    lu.assertEquals(candidate(9), 217)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "lua",
+    "prompt": "-- Write a function to merge three dictionaries into a single table.\nlocal function merge_dictionaries_three(dict1, dict2, dict3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = merge_dictionaries_three\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['O'] = 'Orange', ['W'] = 'White', ['B'] = 'Black'}), {['B'] = 'Black', ['R'] = 'Red', ['P'] = 'Pink', ['G'] = 'Green', ['W'] = 'White', ['O'] = 'Orange'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['G'] = 'Green', ['W'] = 'White'}, {['L'] = 'lavender', ['B'] = 'Blue'}), {['W'] = 'White', ['P'] = 'Pink', ['B'] = 'Black', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender'})\n    lu.assertEquals(candidate({['R'] = 'Red', ['B'] = 'Black', ['P'] = 'Pink'}, {['L'] = 'lavender', ['B'] = 'Blue'}, {['G'] = 'Green', ['W'] = 'White'}), {['B'] = 'Black', ['P'] = 'Pink', ['R'] = 'Red', ['G'] = 'Green', ['L'] = 'lavender', ['W'] = 'White'})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "lua",
+    "prompt": "-- Write a function to get the frequency of all the elements in a table, returned as a table.\nlocal function freq_count(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = freq_count\n    lu.assertEquals(candidate({10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30}), {[10] = 4, [20] = 4, [40] = 2, [50] = 2, [30] = 1})\n    lu.assertEquals(candidate({1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4}), {[1] = 3, [2] = 2, [3] = 3, [4] = 3})\n    lu.assertEquals(candidate({5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5}), {[10] = 1, [5] = 3, [6] = 2, [7] = 2, [4] = 2, [9] = 2})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "lua",
+    "prompt": "-- Write a function to find the closest smaller number than n.\nlocal function closest_num(N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = closest_num\n    lu.assertEquals(candidate(11), 10)\n    lu.assertEquals(candidate(7), 6)\n    lu.assertEquals(candidate(12), 11)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "lua",
+    "prompt": "-- Write a function to find squares of individual elements in a table.\nlocal function square_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = square_nums\n    lu.assertEquals(candidate({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), {1, 4, 9, 16, 25, 36, 49, 64, 81, 100})\n    lu.assertEquals(candidate({10, 20, 30}), {100, 400, 900})\n    lu.assertEquals(candidate({12, 15}), {144, 225})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the length of the longest word.\nlocal function len_log(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = len_log\n    lu.assertEquals(candidate({'python', 'PHP', 'bigdata'}), 7)\n    lu.assertEquals(candidate({'a', 'ab', 'abc'}), 3)\n    lu.assertEquals(candidate({'small', 'big', 'tall'}), 5)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "lua",
+    "prompt": "-- Write a function to check if a string is present as a substring in a given table of string values.\nlocal function find_substring(str1, sub_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_substring\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ack'), true)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'abc'), false)\n    lu.assertEquals(candidate({'red', 'black', 'white', 'green', 'orange'}, 'ange'), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "lua",
+    "prompt": "-- Write a function to check whether the given number is undulating or not.\nlocal function is_undulating(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = is_undulating\n    lu.assertEquals(candidate(1212121), true)\n    lu.assertEquals(candidate(1991), false)\n    lu.assertEquals(candidate(121), true)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "lua",
+    "prompt": "-- Write a function to calculate the value of 'a' to the power 'b'.\nlocal function power(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = power\n    lu.assertEquals(candidate(3, 4), 81)\n    lu.assertEquals(candidate(2, 3), 8)\n    lu.assertEquals(candidate(5, 5), 3125)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "lua",
+    "prompt": "-- Given a table of tables, write a function that returns the first value of the table with the smallest second value.\nlocal function index_minimum(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = index_minimum\n    lu.assertEquals(candidate({{'Rash', 143}, {'Manjeet', 200}, {'Varsha', 100}}), 'Varsha')\n    lu.assertEquals(candidate({{'Yash', 185}, {'Dawood', 125}, {'Sanya', 175}}), 'Dawood')\n    lu.assertEquals(candidate({{'Sai', 345}, {'Salman', 145}, {'Ayesha', 96}}), 'Ayesha')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the length of the smallest table in a table of tables.\nlocal function Find_Min_Length(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = Find_Min_Length\n    lu.assertEquals(candidate({{1}, {1, 2}}), 1)\n    lu.assertEquals(candidate({{1, 2}, {1, 2, 3}, {1, 2, 3, 4}}), 2)\n    lu.assertEquals(candidate({{3, 3, 3}, {4, 4, 4, 4}}), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the number of divisors of a given integer.\nlocal function divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = divisor\n    lu.assertEquals(candidate(15), 4)\n    lu.assertEquals(candidate(12), 6)\n    lu.assertEquals(candidate(9), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "lua",
+    "prompt": "-- Write a function to find frequency of each element in a flattened table of tables, returned in a table.\nlocal function frequency_lists(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = frequency_lists\n    lu.assertEquals(candidate({{1, 2, 3, 2}, {4, 5, 6, 2}, {7, 8, 9, 5}}), {[1] = 1, [2] = 3, [3] = 1, [4] = 1, [5] = 2, [6] = 1, [7] = 1, [8] = 1, [9] = 1})\n    lu.assertEquals(candidate({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}), {[1] = 1, [2] = 1, [3] = 1, [4] = 1, [5] = 1, [6] = 1, [7] = 1, [8] = 1, [9] = 1, [10] = 1, [11] = 1, [12] = 1})\n    lu.assertEquals(candidate({{20, 30, 40, 17}, {18, 16, 14, 13}, {10, 20, 30, 40}}), {[20] = 2, [30] = 2, [40] = 2, [17] = 1, [18] = 1, [16] = 1, [14] = 1, [13] = 1, [10] = 1})\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "lua",
+    "prompt": "-- Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nlocal function decimal_to_binary(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = decimal_to_binary\n    lu.assertEquals(candidate(8), '1000')\n    lu.assertEquals(candidate(18), '10010')\n    lu.assertEquals(candidate(7), '111')\nend\n\nos.exit(lu.LuaUnit.run())",
+    "stop_tokens": [
+      "\nlocal",
+      "\nfunction",
+      "\n--",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "lua",
+    "prompt": "-- Write a luathon function to find the minimum number of rotations (greater than 0) required to get the same string.\nlocal function find_Rotations(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "lu = require('luaunit')\n\nfunction test_humaneval()\nlocal candidate = find_Rotations\n    lu.assertEquals(candidate('aaaa'), 1)\n    lu.assertEquals(candidate('ab'), 2)\n    lu.assertEquals(candidate('abc'), 3)\nend\n\nos.exit(lu.LuaUnit.run())",
     "stop_tokens": [
       "\nlocal",
       "\nfunction",

--- a/prompts/mbpp-php-keep.json
+++ b/prompts/mbpp-php-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return lps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TENS FOR TENS\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"CARDIO FOR CARDS\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PART OF THE JOURNEY IS PART\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces($text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_whitespaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\" Google    Flutter \") !== \"GoogleFlutter\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" Google    Dart \") !== \"GoogleDart\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" iOS    Swift \") !== \"iOSSwift\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether a specified list is sorted or not.\nfunction issort_list($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return issort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 15, 14, 20)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_bidirectional(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 3), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 2), array(6, 5), array(2, 1))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return surfacearea_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 150) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 600) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "php",
     "prompt": "<?php\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome($num) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return next_smallest_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(99) !== 101) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1221) !== 1331) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cube_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 800) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum($arr, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pair_xor_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 9, 7, 6), 4) !== 47) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 5), 3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_min_heap(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 10, 15)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 5, 3, 15)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the first digit of a given number.\nfunction first_Digit($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return first_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(456) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return first_non_repeating_character(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ababc\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert degrees to radians.\nfunction radian_degree($degree) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return radian_degree(...$args);\n}\n\nfunction test(): void {\n    if (candidate(90) !== 1.5707963267948966) { throw new Exception(\"Test failed!\"); }\n    if (candidate(60) !== 1.0471975511965976) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 2.0943951023931953) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_subarray_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 0, 7, -8, -2)) !== 112) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, -3, -10, 0, 2)) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -40, 0, -2, -3)) !== 80) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert more than one list to nested dictionary.\nfunction convert_list_dictionary($l1, $l2, $l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return convert_list_dictionary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"S001\", \"S002\", \"S003\", \"S004\"), array(\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"), array(85, 98, 89, 92)) !== array(array(\"S001\" => array(\"Adina Park\" => 85)), array(\"S002\" => array(\"Leyton Marsh\" => 98)), array(\"S003\" => array(\"Duncan Boyle\" => 89)), array(\"S004\" => array(\"Saim Richards\" => 92)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"def\", \"ghi\", \"jkl\"), array(\"python\", \"program\", \"language\", \"programs\"), array(100, 200, 300, 400)) !== array(array(\"abc\" => array(\"python\" => 100)), array(\"def\" => array(\"program\" => 200)), array(\"ghi\" => array(\"language\" => 300)), array(\"jkl\" => array(\"programs\" => 400)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"A1\", \"A2\", \"A3\", \"A4\"), array(\"java\", \"C\", \"C++\", \"DBMS\"), array(10, 20, 30, 40)) !== array(array(\"A1\" => array(\"java\" => 10)), array(\"A2\" => array(\"C\" => 20)), array(\"A3\" => array(\"C++\" => 30)), array(\"A4\" => array(\"DBMS\" => 40)))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find smallest number in a list.\nfunction smallest_num($xs) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return smallest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 1, 45, 99)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(45, 46, 50, 60)) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_zero_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dsabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asbbbba\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find nth bell number.\nfunction bell_Number($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bell_Number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find cubes of individual elements in a list.\nfunction cube_nums($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cube_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(1728, 3375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return last_Digit_Factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(21) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find even numbers from a list of numbers.\nfunction Split($list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 8, 0, 1)) !== array(4, 6, 8, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 12, 15, 19)) !== array(8, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given integer is a prime number.\nfunction prime_num($num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return prime_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1010) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples($test_list, $K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(6, 24, 12), array(7, 9, 6), array(12, 18, 21)), 6) !== array(array(6, 24, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 25, 30), array(4, 2, 3), array(7, 8, 9)), 5) !== array(array(5, 25, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 9, 16), array(8, 16, 4), array(19, 17, 18)), 4) !== array(array(8, 16, 4))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron($side) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return area_tetrahedron(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15.588457268119894) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== 692.8203230275509) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 173.20508075688772) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given number is even or not.\nfunction is_Even($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_Even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of positive numbers in a list.\nfunction pos_count($list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pos_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, 3, -4)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 5, -1)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_ludic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(1, 2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(45) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K($input, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return reverse_Array_Upto_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), 4) !== array(4, 3, 2, 1, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7), 2) !== array(5, 4, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5), 3) !== array(7, 8, 9, 6, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks($subjectmarks) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return subject_marks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97), array(\"Social sciences\", 82))) !== array(array(\"Social sciences\", 82), array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Telugu\", 49), array(\"Hindhi\", 54), array(\"Social\", 33))) !== array(array(\"Social\", 33), array(\"Telugu\", 49), array(\"Hindhi\", 54))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Physics\", 96), array(\"Chemistry\", 97), array(\"Biology\", 45))) !== array(array(\"Biology\", 45), array(\"Physics\", 96), array(\"Chemistry\", 97))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars($string, $second_string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_dirty_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"probasscurve\", \"pros\") !== \"bacuve\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"digitalindia\", \"talent\") !== \"digiidi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"exoticmiles\", \"toxic\") !== \"emles\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return round_and_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)) !== 243) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 9, 24.3, 29)) !== 345) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25.0, 56.7, 89.2)) !== 513) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_occurrences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal($num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_decimal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"123.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"e666.86\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3.124587\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.1.11\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter($dict, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return dict_filter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) !== array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) !== array(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) !== array(\"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_even_and_even_index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 12, 1, 18, 8)) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 12, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum($a, $size) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_sub_array_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-2, -3, 4, -1, -2, 1, 5, -3), 8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -4, 5, -2, -3, 2, 6, -4), 8) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-4, -5, 6, -3, -4, 3, 7, -5), 8) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the intersection of two arrays.\nfunction intersection_array($array_nums1, $array_nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return intersection_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(1, 2, 4, 8, 9)) !== array(1, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(3, 5, 7, 9)) !== array(3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(10, 20, 30, 40)) !== array(10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts($list1, $L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split_two_parts(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(array(1, 1, 2), array(3, 4, 4, 5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), 2) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"), 4) !== array(array(\"p\", \"y\", \"t\", \"h\"), array(\"o\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals($text, $pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_literals(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") !== array(\"fox\", 16, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its been a very crazy procedure right\", \"crazy\") !== array(\"crazy\", 16, 21)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hardest choices required strongest will\", \"will\") !== array(\"will\", 35, 39)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the volume of a triangular prism.\nfunction find_Volume($l, $b, $h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Volume(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 8, 6) !== 240) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill($v, $t) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return wind_chill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(120, 35) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(40, 20) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the ascii value of a character.\nfunction ascii_value($k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return ascii_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"A\") !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"R\") !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"S\") !== 83) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_Characters_Same(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to move all the numbers to the end of the given string.\nfunction move_num($test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return move_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"I1love143you55three3000thousand\") !== \"Iloveyouthreethousand1143553000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Avengers124Assemble\") !== \"AvengersAssemble124\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its11our12path13to14see15things16do17things\") !== \"Itsourpathtoseethingsdothings11121314151617\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the length of the word is odd or not.\nfunction word_len($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return word_len(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hadoop\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"great\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"structure\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to drop empty items from a given dictionary.\nfunction drop_empty($dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return drop_empty(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c1\" => \"Red\", \"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => null, \"c3\" => null)) !== array(\"c1\" => \"Red\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => null, \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element($list, $element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return insert_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Black\"), \"c\") !== array(\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\"), \"program\") !== array(\"program\", \"python\", \"program\", \"java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"happy\", \"sad\"), \"laugh\") !== array(\"laugh\", \"happy\", \"laugh\", \"sad\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_lowercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYTHon\") !== \"PYTH\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"FInD\") !== \"FID\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"STRinG\") !== \"STRG\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_Set_Bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear($test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_rear(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Mers\", \"for\", \"Vers\")) !== array(\"s\", \"r\", \"s\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Avenge\", \"for\", \"People\")) !== array(\"e\", \"r\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Gotta\", \"get\", \"go\")) !== array(\"a\", \"t\", \"o\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_occurance(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"letstdlenstdporstd\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"truststdsolensporsd\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"makestdsostdworthit\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"stds\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given tuples contain the k or not.\nfunction check_K($test_tup, $K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, 8), 6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 44, 11, 12), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists($list1, $list2, $list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return interleave_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7), array(10, 20, 30, 40, 50, 60, 70), array(100, 200, 300, 400, 500, 600, 700)) !== array(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20), array(15, 2), array(5, 10)) !== array(10, 15, 5, 20, 2, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 44), array(10, 15), array(20, 5)) !== array(11, 10, 20, 44, 15, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python_program\") !== \"PythonProgram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python_language\") !== \"PythonLanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"programming_language\") !== \"ProgrammingLanguage\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal($x, $y, $z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return test_three_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 1, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2, -3) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_length_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 7)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bell_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 115975) { throw new Exception(\"Test failed!\"); }\n    if (candidate(56) !== 6775685320645824322581483068371419745979053216268760300) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the area of a rectangle.\nfunction rectangle_area($l, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rectangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find sum and average of first n natural numbers.\nfunction sum_average($number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_average(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(55, 5.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== array(120, 8.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(210, 10.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return division_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(2, 2, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 16), array(6, 3, 4, 4)) !== array(2, 2, 2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(20, 14, 36, 18), array(5, 7, 6, 9)) !== array(4, 2, 6, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(345) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(97) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "php",
-    "prompt": "<?php\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return index_minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Rash\", 143), array(\"Manjeet\", 200), array(\"Varsha\", 100))) !== \"Varsha\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Yash\", 185), array(\"Dawood\", 125), array(\"Sanya\", 175))) !== \"Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sai\", 345), array(\"Salman\", 145), array(\"Ayesha\", 96))) !== \"Ayesha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to divide two lists element wise.\nfunction div_list($nums1, $nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return div_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(1, 2, 3)) !== array(4.0, 2.5, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2), array(1, 4)) !== array(3.0, 0.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(1.8, 1.7142857142857142)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the list with maximum length.\nfunction max_length_list($input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_length_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5), array(1, 2, 3, 4), array(1, 2, 3), array(1, 2), array(1))) !== array(5, array(1, 2, 3, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(6, 7, 8, 9), array(10, 11, 12))) !== array(4, array(6, 7, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find all possible combinations of the elements of a given list.\nfunction combinations_list($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return combinations_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"orange\", \"red\", \"green\", \"blue\")) !== array(array(), array(\"orange\"), array(\"red\"), array(\"red\", \"orange\"), array(\"green\"), array(\"green\", \"orange\"), array(\"green\", \"red\"), array(\"green\", \"red\", \"orange\"), array(\"blue\"), array(\"blue\", \"orange\"), array(\"blue\", \"red\"), array(\"blue\", \"red\", \"orange\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"orange\"), array(\"blue\", \"green\", \"red\"), array(\"blue\", \"green\", \"red\", \"orange\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"blue\"), array(\"blue\", \"red\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"red\"), array(\"white\"), array(\"white\", \"red\"), array(\"white\", \"green\"), array(\"white\", \"green\", \"red\"), array(\"white\", \"blue\"), array(\"white\", \"blue\", \"red\"), array(\"white\", \"blue\", \"green\"), array(\"white\", \"blue\", \"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"black\", \"blue\"), array(\"black\", \"blue\", \"red\"), array(\"black\", \"blue\", \"green\"), array(\"black\", \"blue\", \"green\", \"red\"), array(\"black\", \"white\"), array(\"black\", \"white\", \"red\"), array(\"black\", \"white\", \"green\"), array(\"black\", \"white\", \"green\", \"red\"), array(\"black\", \"white\", \"blue\"), array(\"black\", \"white\", \"blue\", \"red\"), array(\"black\", \"white\", \"blue\", \"green\"), array(\"black\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"blue\"), array(\"orange\", \"blue\", \"red\"), array(\"orange\", \"blue\", \"green\"), array(\"orange\", \"blue\", \"green\", \"red\"), array(\"orange\", \"white\"), array(\"orange\", \"white\", \"red\"), array(\"orange\", \"white\", \"green\"), array(\"orange\", \"white\", \"green\", \"red\"), array(\"orange\", \"white\", \"blue\"), array(\"orange\", \"white\", \"blue\", \"red\"), array(\"orange\", \"white\", \"blue\", \"green\"), array(\"orange\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"), array(\"orange\", \"black\", \"blue\"), array(\"orange\", \"black\", \"blue\", \"red\"), array(\"orange\", \"black\", \"blue\", \"green\"), array(\"orange\", \"black\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\"), array(\"orange\", \"black\", \"white\", \"red\"), array(\"orange\", \"black\", \"white\", \"green\"), array(\"orange\", \"black\", \"white\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\"), array(\"orange\", \"black\", \"white\", \"blue\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return big_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 6)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to return the negative numbers in a list.\nfunction neg_nos($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return neg_nos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 4, 5, -6)) !== array(-1, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3, 4)) !== array(-1, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-7, -6, 8, 9)) !== array(-7, -6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return highest_Power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist($l, $s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_sublist(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 3, 5, 7), array(3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(4, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(1, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to subtract two lists element-wise.\nfunction sub_list($nums1, $nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sub_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== array(-3, -3, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 4)) !== array(-2, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(40, 50)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs($x, $y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return opposite_Signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, -2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tuple_modulo(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6), array(5, 6, 7, 5)) !== array(0, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 6, 7), array(6, 7, 8, 6)) !== array(5, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 7, 8), array(7, 8, 9, 7)) !== array(5, 6, 7, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return diff_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) !== array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"d\", \"c\"), array(\"g\", \"h\"), array(\"f\", \"e\"))) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"), array(\"g\", \"h\"), array(\"e\", \"f\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the last digit of a given number.\nfunction last_Digit($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return last_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_num_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 707) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 3108) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a list to a string.\nfunction tup_string($tup1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tup_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\")) !== \"exercises\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) !== \"program\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all elements from a given list present in another list.\nfunction remove_elements($list1, $list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(1, 3, 5, 7)) !== array(2, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(5, 7)) !== array(1, 2, 3, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping($list1, $list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return overlapping(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5), array(1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to identify non-prime numbers.\nfunction is_not_prime($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_not_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(35) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(37) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val($listval) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 50) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_negativenum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== -32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, -14, 13, -18, 12, -20)) !== -52) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)) !== -894) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Rotations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format($dt) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return change_date_format(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"2026-01-02\") !== \"02-01-2026\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020-11-13\") !== \"13-11-2020\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2021-04-26\") !== \"26-04-2021\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split($list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 12, 13)) !== array(11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1)) !== array(7, 9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return toggle_middle_bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(65) !== 127) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== 115) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_char_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xbcefg\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABcED\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"AbgdeF\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product($nums1, $nums2, $N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return large_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 3) !== array(60, 54, 50)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 4) !== array(60, 54, 50, 48)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 5) !== array(60, 54, 50, 48, 45)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cummulative_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 6, 7), array(2, 6))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(6, 7, 8), array(3, 7))) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8, 9), array(4, 8))) !== 44) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff($arr, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_min_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 3, 19, 18, 25), 6) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 6), 4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 5, 20, 9), 4) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_starta_endb(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aabbbb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabAbbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"accddbbjjj\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate($n, $d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return left_rotate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(29, 3) !== 232) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return first_repeated_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123123\") !== \"1\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count inversions in an array.\nfunction get_Inv_Count($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_Inv_Count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 20, 6, 4, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 6, 1)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_Power_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1056) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 8832) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find whether all the given lists have equal length or not.\nfunction get_equal($Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(11, 22, 33), array(44, 55, 66))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if a string represents an integer or not.\nfunction check_integer($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12345\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_reverse_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"geeks\", \"best\", \"for\", \"skeeg\")) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"makes\", \"best\", \"sekam\", \"for\", \"rof\")) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to move all zeroes to the end of the given list.\nfunction move_zero($num_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return move_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 0, 2, 0, 3, 4)) !== array(1, 2, 3, 4, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 0, 0, 4, 0, 5, 0)) !== array(2, 3, 2, 4, 5, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 0, 1, 1)) !== array(1, 1, 1, 0, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if given list contains no duplicates.\nfunction check_distinct($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_distinct(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 5, 6, 1, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss($actual_cost, $sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return noprofit_noloss(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all the words with k length in the given string.\nfunction remove_length($test_str, $K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The person is most value tet\", 3) !== \"person is most value\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"If you told me about this ok\", 4) !== \"If you me about ok\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Forces of darkeness is come into the play\", 4) !== \"Forces of darkeness is the\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count number of digits in a given string.\nfunction number_ctr($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return number_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"program2bedone\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wonders\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wond-1ers2\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the total number of characters in a string.\nfunction count_charac($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_charac(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"words\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences($m, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_total_number_of_sequences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 3) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion($a, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return left_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return swap_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== array(20, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 17) !== array(17, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(200, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority($arr, $n, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_majority(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 3, 3, 3, 10), 7, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 4, 4, 4, 6, 6), 8, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 2), 5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2), 5, 1) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return substract_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5), array(2, 5, 18)) !== array(8, -1, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 2, 3), array(24, 45, 16)) !== array(-13, -43, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 18, 9), array(10, 11, 12)) !== array(-3, 7, -3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return capital_words_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PythonProgrammingExamples\") !== \"Python Programming Examples\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GetReadyToBeCodingFreak\") !== \"Get Ready To Be Coding Freak\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Average_Of_Cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if all values are same in a dictionary.\nfunction check_value($dict, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tetrahedral_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test($my_matrix) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return magic_square_test(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(7, 12, 1, 14), array(2, 13, 8, 11), array(16, 3, 10, 5), array(9, 6, 15, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 8))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"cAstyoUrFavoRitETVshoWs\") !== \"cstyoravoitshos\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wAtchTheinTernEtrAdIo\") !== \"wtchheinerntrdo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"VoicESeaRchAndreComMendaTionS\") !== \"oiceachndreomendaion\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether an element exists within a tuple.\nfunction check_tuplex($tuplex, $tuple1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_tuplex(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"r\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), 3) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate a dog's age in dog's years.\nfunction dog_age($h_age) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return dog_age(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 61) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24) !== 109) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square($N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return next_Perfect_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(35) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create a list of N empty dictionaries.\nfunction empty_list($length) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return empty_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(array(), array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to convert a given string to uppercase.\nfunction is_upper($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"person\") !== \"PERSON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final\") !== \"FINAL\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Valid\") !== \"VALID\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent($s, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_Equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"011001\", 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011\", 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1010\", 4) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array($arr, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return re_arrange_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9) !== array(-1, -3, -7, 4, 5, 6, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, -14, -26, 13, 15), 5) !== array(-14, -26, 12, 13, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 24, 36, -42, -39, -78, 85), 7) !== array(-42, -39, -78, 10, 24, 36, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract values between quotation marks from a string.\nfunction extract_values($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_values(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") !== array(\"Python\", \"PHP\", \"Java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") !== array(\"python\", \"program\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") !== array(\"red\", \"blue\", \"green\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count true booleans in the given list.\nfunction count($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(true, false, true)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(false, false)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(true, true, true)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair($A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_even_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number($number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return armstrong_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(153) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(259) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4458) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the upper case characters in a given string.\nfunction upper_ctr($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return upper_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYthon\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"BigData\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return and_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(0, 0, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(5, 6, 7, 8)) !== array(1, 2, 3, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 11, 12), array(7, 13, 14, 17)) !== array(0, 9, 10, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns($colors, $patterns) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_samepatterns(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"green\", \"green\"), array(\"a\", \"b\", \"b\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of lists in a given number of lists.\nfunction count_list($input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(2, 3), array(4, 5))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 0), array(2, 0))) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return average_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(10, 10, 10, 12), array(30, 45, 56, 45), array(81, 80, 39, 32), array(1, 2, 3, 4))) !== array(30.5, 34.25, 27.0, 23.25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, -5), array(30, -15, 56), array(81, -60, -39), array(-10, 2, 3))) !== array(25.5, -18.0, 3.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(100, 100, 100, 120), array(300, 450, 560, 450), array(810, 800, 390, 320), array(10, 20, 30, 40))) !== array(305.0, 342.5, 270.0, 232.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three($X, $Y, $Z) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return lcs_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n'th star number.\nfunction find_star_num($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_star_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of an array.\nfunction _sum($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return _sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 12, 13, 10)) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_Consecutive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_adverb_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"clearly!! we can see the sky\") !== array(0, 7, \"clearly\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"seriously!! there are many roses\") !== array(0, 9, \"seriously\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"unfortunately!! sita is going to home\") !== array(0, 13, \"unfortunately\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right($list, $m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rotate_right(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3) !== array(8, 9, 10, 1, 2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(9, 10, 1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5) !== array(6, 7, 8, 9, 10, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return number_of_substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split($S, $step) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return list_split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"), 3) !== array(array(\"a\", \"d\", \"g\", \"j\", \"m\"), array(\"b\", \"e\", \"h\", \"k\", \"n\"), array(\"c\", \"f\", \"i\", \"l\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3) !== array(array(1, 4, 7, 10, 13), array(2, 5, 8, 11, 14), array(3, 6, 9, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"), 2) !== array(array(\"python\", \"C\", \"DBMS\"), array(\"java\", \"C++\", \"SQL\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to convert complex numbers to polar coordinates.\nfunction convert($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return convert(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "php",
-    "prompt": "<?php\n// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data($students, $h, $w) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_data(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 6.0, 70) !== array(\"Cierra Vega\" => array(6.2, 70))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.9, 67) !== array(\"Cierra Vega\" => array(6.2, 70), \"Kierra Gentry\" => array(6.0, 68))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.7, 64) !== array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to convert the given string to lower case.\nfunction is_lower($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_lower(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"InValid\") !== \"invalid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"TruE\") !== \"true\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"SenTenCE\") !== \"sentence\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return next_power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring($str1, $sub_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ack\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"abc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ange\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace characters in a string.\nfunction replace_char($str1, $ch, $newch) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"polygon\", \"y\", \"l\") !== \"pollgon\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"character\", \"c\", \"a\") !== \"aharaater\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\", \"l\", \"a\") !== \"python\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return mul_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a list to a tuple.\nfunction list_tuple($listx) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return list_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 10, 7, 4, 15, 3)) !== array(5, 10, 7, 4, 15, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 2, 3, 4, 4, 7)) !== array(2, 4, 5, 6, 2, 3, 4, 4, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(58, 44, 56)) !== array(58, 44, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_binomial_Coeff_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return bitwise_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(15, 6, 5, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 7, 10), array(6, 3, 4, 4)) !== array(13, 6, 3, 14)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 11), array(7, 4, 5, 6)) !== array(11, 2, 13, 13)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array($A, $B) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_Sub_Array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 5), array(1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), array(1, 2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 2), array(2, 2, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated($a, $n, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_sub_array_sum_repeated(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, -30, -1), 4, 3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 10, 20), 3, 2) !== 59) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3), 3, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_divisors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area($r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(-1) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a given string to a list of characters.\nfunction string_to_tuple($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return string_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python 3.0\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"item1\") !== array(\"i\", \"t\", \"e\", \"m\", \"1\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.10\") !== array(\"1\", \"5\", \".\", \"1\", \"0\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"11000010001\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"10111\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011101100101\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_Primes_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_Of_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate($stdata) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_aggregate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Juan Whelan\", 90), array(\"Sabah Colley\", 88), array(\"Peter Nichols\", 7), array(\"Juan Whelan\", 122), array(\"Sabah Colley\", 84))) !== array(\"Juan Whelan\", 212)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 50), array(\"Sabah Colley\", 48), array(\"Peter Nichols\", 37), array(\"Juan Whelan\", 22), array(\"Sabah Colley\", 14))) !== array(\"Juan Whelan\", 72)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 10), array(\"Sabah Colley\", 20), array(\"Peter Nichols\", 30), array(\"Juan Whelan\", 40), array(\"Sabah Colley\", 50))) !== array(\"Sabah Colley\", 70)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a list of elements.\nfunction comb_sort($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return comb_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 15, 37, 25, 79)) !== array(5, 15, 25, 37, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 32, 15, 19, 22)) !== array(15, 19, 22, 32, 41)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(99, 15, 13, 47)) !== array(13, 15, 47, 99)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression($exp) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_expression(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"{()}[{}]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{}][]({})\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a word containing 'z'.\nfunction text_match_wordz($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_wordz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list($lst1, $lst2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30), array(15, 25, 35)) !== array(25, 45, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(5, 6, 7)) !== array(6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 20, 30), array(15, 45, 75)) !== array(30, 65, 105)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return newman_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 17) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 41) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to apply a given format string to all of the elements in a list.\nfunction add_string($list_, $string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), \"temp{0}\") !== array(\"temp1\", \"temp2\", \"temp3\", \"temp4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), \"python{0}\") !== array(\"pythona\", \"pythonb\", \"pythonc\", \"pythond\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8), \"string{0}\") !== array(\"string5\", \"string6\", \"string7\", \"string8\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area($b, $s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return surface_Area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Find_Min_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2))) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(1, 2, 3), array(1, 2, 3, 4))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 3, 3), array(4, 4, 4, 4))) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return validate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1234) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(51241) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(321) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth hexagonal number.\nfunction hexagonal_num($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return hexagonal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 190) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 91) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n'th lucas number.\nfunction find_lucas($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_lucas(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 76) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to get the difference between two lists.\nfunction Diff($li1, $li2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 15, 20, 25, 30, 35, 40), array(25, 40, 35)) !== array(10, 20, 30, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 1)) !== array(2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(6, 7, 1)) !== array(2, 3, 6, 7)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation($text1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_quotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") !== array(\"A53\", \"multi\", \"Processor\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") !== array(\"favorite\", \"apps\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") !== array(\"4k Ultra HD\", \"HDR 10\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum($data_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return recursive_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, array(3, 4), array(5, 6))) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 10, array(15, 14), array(19, 41))) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, array(30, 40), array(50, 60))) !== 210) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return differ_At_One_Bit_Pos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13, 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"caacabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 100, 4, 5, 150, 6)) !== 3000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 42, 55, 68, 80)) !== 50265600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 22, 9, 33, 21, 50, 41, 60)) !== 2460) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr($l, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split_Arr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 10, 5, 6, 52, 36), 2) !== array(5, 6, 52, 36, 12, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 1) !== array(2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 4, 5, 6, 7), 3) !== array(3, 4, 5, 6, 7, 0, 1, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the number of divisors of a given integer.\nfunction divisor($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return big_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 12)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 3)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find squares of individual elements in a list.\nfunction square_nums($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return square_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(100, 400, 900)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(144, 225)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given tuple has any none value or not.\nfunction check_none($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_none(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, null)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 11, 14)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, null)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic($A) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_Monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(6, 5, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_perfect_square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(36) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(196) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15625) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of common divisors of two given numbers.\nfunction sum($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 15) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 150) !== 93) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 6) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the list of maximum length in a list of lists.\nfunction max_length($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(5, 7), array(10, 12, 14, 15))) !== array(4, array(10, 12, 14, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5), array(15, 20, 25))) !== array(3, array(15, 20, 25))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunction check_occurences($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_occurences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 1), array(1, 3), array(2, 5), array(5, 2), array(6, 3))) !== array(array(1, 3) => 2, array(2, 5) => 2, array(3, 6) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 2), array(2, 4), array(3, 6), array(6, 3), array(7, 4))) !== array(array(2, 4) => 2, array(3, 6) => 2, array(4, 7) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(13, 2), array(11, 23), array(12, 25), array(25, 12), array(16, 23))) !== array(array(2, 13) => 1, array(11, 23) => 1, array(12, 25) => 2, array(16, 23) => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the directrix of a parabola.\nfunction parabola_directrix($a, $b, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return parabola_directrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3, 2) !== -198) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 8, 4) !== -2336) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4, 6) !== -130) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring($text, $pattern) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return occurance_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming, python language\", \"python\") !== array(\"python\", 0, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"programming\") !== array(\"programming\", 7, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"language\") !== array(\"language\", 31, 39)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"c++ programming, c++ language\", \"python\") !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove tuples from the given tuple.\nfunction remove_nested($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== array(1, 5, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, array(5, 7), 11)) !== array(2, 6, 8, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), array(5, 12), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists($input_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\" red \", \"green\"), array(\"blue \", \" black\"), array(\" orange\", \"brown\"))) !== array(array(\" red \", \"green\"), array(\" black\", \"blue \"), array(\" orange\", \"brown\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"zilver\", \"gold\"), array(\"magnesium\", \"aluminium\"), array(\"steel\", \"bronze\"))) !== array(array(\"gold\", \"zilver\"), array(\"aluminium\", \"magnesium\"), array(\"bronze\", \"steel\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element($list1, $L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(1, 1, 3, 4, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4) !== array(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5) !== array(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple($test_tup, $test_dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_dict_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) !== array(4, 5, 6, array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) !== array(1, 2, 3, array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 10), array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) !== array(8, 9, 10, array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find($n, $m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_two_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence($tup, $lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_Occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"a\", \"c\", \"b\", \"d\"), array(\"a\", \"b\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1, 4, 6, 7, 1, 4), array(1, 4, 7)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair($list1, $list2, $list3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_samepair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9), array(2, 1, 3, 1, 2, 6, 7, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 2, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to toggle the case of all characters in a string.\nfunction toggle_string($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return toggle_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"pYTHON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pangram\") !== \"pANGRAM\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"LIttLE\") !== \"liTTle\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the element of a list having maximum length.\nfunction Find_Max($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Find_Max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"A\"), array(\"A\", \"B\"), array(\"A\", \"B\", \"C\"))) !== array(\"A\", \"B\", \"C\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 2, 3), array(1, 5, 6, 1))) !== array(1, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num($n, $m) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return eulerian_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 1) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 1) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 26) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of occurrences of a number in a given list.\nfunction frequency($a, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return frequency(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 3, 4), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 1, 2), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings($nums_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_numeric_strings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\")) !== array(-500, -12, 0, 4, 7, 12, 45, 100, 200)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\")) !== array(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\")) !== array(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return geometric_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 1.9921875) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1.9375) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 1.99609375) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits($startnum, $endnum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return divisible_by_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 22) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 15) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 25) !== array(22, 24)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product($list_data) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return unique_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30, 40, 20, 50, 60, 40)) !== 720000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 0, 1, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the largest negative number from the given list.\nfunction largest_neg($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return largest_neg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, -4, -6)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -8, -9)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(10, 15, 19, 18, 17, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(\"a\", \"b\", \"c\", \"d\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\")) !== array(\"a\", \"b\", \"c\", \"d\", \"a\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps($steps, $d) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_Jumps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4), 11) !== 3.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4), 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 14), 11) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_Product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 7, 0, 8, 4)) !== array(7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, -1, -2, -4, 5, 0, -6)) !== array(-4, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element($list1, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_nth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 0) !== array(\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 2) !== array(99, 96, 94, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 1) !== array(98, 97, 91, 94)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth nonagonal number.\nfunction is_nonagonal($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_nonagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 325) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 750) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== 1089) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_Abs_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 3, 2, 5, 1)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pack_consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(array(0, 0), array(1), array(2), array(3), array(4, 4), array(5), array(6, 6, 6), array(7), array(8), array(9), array(4, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(array(10, 10), array(15), array(19), array(18, 18), array(17), array(26, 26), array(17), array(18), array(10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(array(\"a\", \"a\"), array(\"b\"), array(\"c\"), array(\"d\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum of perrin numbers.\nfunction cal_sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return cal_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 88) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string($str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_values_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcdef\") !== \"ace\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\") !== \"pto\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== \"dt\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lambs\") !== \"lms\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find kth element from the given two sorted arrays.\nfunction find_kth($arr1, $arr2, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_kth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 6, 7, 9), array(1, 4, 8, 10), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 112, 256, 349, 770), array(72, 86, 113, 119, 265, 445, 892), 7) !== 256) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 7, 8, 10), array(2, 5, 9, 11), 6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return jacobsthal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== 2731) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return frequency_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 2), array(4, 5, 6, 2), array(7, 8, 9, 5))) !== array(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12))) !== array(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(20, 30, 40, 17), array(18, 16, 14, 13), array(10, 20, 30, 40))) !== array(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find perfect squares between two given numbers.\nfunction perfect_squares($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return perfect_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 30) !== array(1, 4, 9, 16, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(50, 100) !== array(64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(100, 121, 144, 169, 196)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_Of_Subarray_Prod(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return first_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_nested_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(7, 10), array(7, 14), array(3, 10), array(8, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(9, 12), array(9, 16), array(5, 12), array(10, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(11, 14), array(11, 18), array(7, 14), array(12, 17))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return merge(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"a\", \"b\"), array(\"m\", \"n\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8))) !== array(array(1, 3, 5, 7), array(2, 4, 6, 8))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\", \"y\", \"z\"), array(\"a\", \"b\", \"c\"), array(\"m\", \"n\", \"o\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"), array(\"z\", \"c\", \"o\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return dif_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_smaller(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6), array(3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13), array(10, 11, 12)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return freq_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)) !== array(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)) !== array(1 => 3, 2 => 2, 3 => 3, 4 => 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)) !== array(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv($r, $g, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rgb_to_hsv(...$args);\n}\n\nfunction test(): void {\n    if (candidate(255, 255, 255) !== array(0.0, 0.0, 100.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 215, 0) !== array(120.0, 100.0, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 215, 110) !== array(149.26829268292684, 95.34883720930233, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to flatten a given nested list structure.\nfunction flatten_list($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return flatten_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 10, array(20, 30), 40, 50, array(60, 70, 80), array(90, 100, 110, 120))) !== array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(40), array(30, 56, 25), array(10, 20), array(33), array(40))) !== array(10, 20, 40, 30, 56, 25, 10, 20, 33, 40)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_str(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"annie\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dawood\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Else\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number($monthnum3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_monthnumber_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort the given list.\nfunction heap_sort($iterable) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return heap_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 25, 58)) !== array(14, 22, 25, 25, 35, 58, 65, 75, 85)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 1, 9, 5)) !== array(1, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs($nums1, $nums2, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return k_smallest_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 2) !== array(array(1, 2), array(1, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 1) !== array(array(1, 2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 7) !== array(array(1, 2), array(1, 4), array(3, 2), array(1, 6), array(3, 4), array(3, 6), array(7, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution($a, $b, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 7) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 7) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 13, 17) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Max_Num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 321) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 1)) !== 6541) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 9)) !== 9321) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list($lists) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(10, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 2, 1), array(6, 5, 4), array(12, 11, 10))) !== array(12, 11, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 1))) !== array(2, 3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to interchange the first and last elements in a list.\nfunction swap_List($newList) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 35, 9, 56, 24)) !== array(24, 35, 9, 56, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median of two sorted lists of same size.\nfunction get_median($arr1, $arr2, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 12, 15, 26, 38), array(2, 13, 17, 30, 45), 5) !== 16.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 9), array(7, 13, 19, 28), 4) !== 8.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 14, 23, 36, 42), array(2, 18, 27, 39, 49, 55), 6) !== 25.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jumanji The Jungle\") !== \"Jumanji_The_Jungle\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"The_Avengers\") !== \"The Avengers\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Fast and Furious\") !== \"Fast_and_Furious\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent($num1, $num2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return are_equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(36, 57) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 47) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list($stringlist) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return reverse_string_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\", \"White\", \"Black\")) !== array(\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"john\", \"amal\", \"joel\", \"george\")) !== array(\"nhoj\", \"lama\", \"leoj\", \"egroeg\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"jack\", \"john\", \"mary\")) !== array(\"kcaj\", \"nhoj\", \"yram\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_of_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 2, 56)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20, 4, 5, \"b\", 70, \"a\"))) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, -4, 5, -70)) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth number in the newman conway sequence.\nfunction sequence($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest($nums, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return heap_queue_largest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 3) !== array(85, 75, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 2) !== array(85, 75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 5) !== array(85, 75, 65, 58, 35)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount($actual_cost, $sale_amount) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return loss_amount(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== 3000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return union_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 4, 5, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(3, 4, 5, 6)) !== array(1, 2, 3, 4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13, 14), array(13, 15, 16, 17)) !== array(11, 12, 13, 14, 15, 16, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Find_Max_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 4), array(5, 6, 7, 8))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 1), array(2, 2), array(3, 2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7), array(22, 23), array(13, 14, 15), array(10, 20, 30, 40, 50))) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis($items) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_parenthesis(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python (chrome)\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"string(.abc)\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"alpha(num)\")) !== \"alpha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity($x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Parity(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median length of a trapezium.\nfunction median_trapezium($base1, $base2, $height) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return median_trapezium(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15, 25, 35) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 20, 30) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 9, 4) !== 7.5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return centered_hexagonal_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 271) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 217) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find number of lists present in the given list.\nfunction find_lists($Input) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5, 4, 3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(60) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the length of the longest word.\nfunction len_log($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return len_log(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python\", \"PHP\", \"bigdata\")) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"ab\", \"abc\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"small\", \"big\", \"tall\")) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area($r, $a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sector_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 45) !== 6.283185307179586) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 45) !== 31.808625617596654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 361) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return odd_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 4, 3, 6, 7, 6, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single($L) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiple_to_single(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 33, 50)) !== 113350) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4, 5, 6)) !== -123456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, 20, 25)) !== 10152025) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find whether a number is divisible by 11.\nfunction is_Diff($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12345) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212112) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return index_multiplication(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 21), array(12, 45), array(2, 9), array(7, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(14, 32), array(20, 60), array(6, 20), array(16, 44))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(24, 45), array(30, 77), array(12, 33), array(27, 60))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int($test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tuple_str_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(7, 8, 9)\") !== array(7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(1, 2, 3)\") !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(4, 5, 6)\") !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(7, 81, 19)\") !== array(7, 81, 19)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum($limit) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return amicable_numbers_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(999) !== 504) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9999) !== 31626) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove odd characters in a string.\nfunction remove_odd($str1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== \"yhn\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== \"rga\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== \"agae\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiply_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(5, 35, 56, 80)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 7)) !== array(8, 20, 30, 42)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 13, 14, 9, 15)) !== array(156, 182, 126, 135)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_rotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 1, 2, 3)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_freq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 4), array(1, 2), array(4, 3), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 15), array(2, 3), array(5, 4), array(6, 7))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 16), array(2, 3), array(6, 5), array(6, 9))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "php",
-    "prompt": "<?php\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair($nums1, $nums2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_same_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 1, 2), array(0, 1, 2, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunction power($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== 3125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write function to find the sum of all items in the given dictionary.\nfunction return_sum($dict) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return return_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\" => 100, \"b\" => 200, \"c\" => 300)) !== 600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 25, \"b\" => 18, \"c\" => 45)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 36, \"b\" => 39, \"c\" => 49)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise($l1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pair_wise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 3, 4, 4, 5)) !== array(array(1, 1), array(1, 2), array(2, 3), array(3, 3), array(3, 4), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== array(array(1, 5), array(5, 7), array(7, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 9, 7, 10)) !== array(array(5, 1), array(1, 9), array(9, 7), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(array(1, 2), array(2, 3), array(3, 4), array(4, 5), array(5, 6), array(6, 7), array(7, 8), array(8, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to split a string into characters.\nfunction split($word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Name\") !== array(\"N\", \"a\", \"m\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find minimum of three numbers.\nfunction min_of_three($a, $b, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 15, 18) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -20, -30) !== -30) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_Sum_Of_Powers_Of_Two(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char($strr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_Char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== \"f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gfg\") !== \"t\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return the sum of all divisors of a number.\nfunction sum_div($number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_div(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function that returns the number of integer elements in a given list.\nfunction count_integer($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, \"abc\", 1.2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1.2, 4, 5.1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return two_unique_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 2, 3, 4, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 5)) !== array(1, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate($arraynums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return test_duplicate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2, 3, 3, 4, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which returns nth catalan number.\nfunction catalan_number($num) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return catalan_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 16796) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 4862) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 429) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum($base, $power) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return power_base_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 100) !== 115) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 10) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 15) !== 62) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 3) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list($list1, $list2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8)) !== array(1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"blue\", \"green\"), array(\"yellow\")) !== array(\"red\", \"blue\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth octagonal number.\nfunction is_octagonal($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_octagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 280) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 645) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank($str1, $char) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_blank(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello people\", \"@\") !== \"hello@people\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python program language\", \"$\") !== \"python$program$language\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"blank space\", \"-\") !== \"blank-space\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_specialchar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python language, Programming language.\") !== \"Python:language::Programming:language:\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c,d e f\") !== \"a:b:c:d:e:f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ram reshma,ram rahim\") !== \"ram:reshma:ram:rahim\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tuple_to_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 123) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== 456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7)) !== 567) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle($w, $h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return otherside_rightangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 8) !== 10.63014581273465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 15) !== 16.55294535724685) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items($items, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return expensive_items(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09)), 2) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-1\", \"price\" => 101.1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09), array(\"name\" => \"Item-4\", \"price\" => 22.75)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums($n1, $n2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return digit_distance_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 56) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123, 256) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_match_wordz_middle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonzabc.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zxyabc.\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip($ip) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return removezero_ip(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"216.08.094.196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12.01.024\") !== \"12.1.24\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"216.08.094.0196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list($list1, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_element_in_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(1, 11), array(1, 15, 7)), 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"A\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"E\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to multiply two integers.\nfunction multiply_int($x, $y) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return multiply_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_pairwise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(6, 12, 15, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, 9, 11)) !== array(8, 14, 17, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, 10, 12)) !== array(10, 16, 19, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple($list1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 484) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4429,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element($arr, $k) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 3, 5, 7, 19), 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(17, 24, 8, 23), 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(16, 21, 25, 36, 4), 4) !== 36) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to interchange the first and last element in a given list.\nfunction swap_List($newList) {\n",
+    "prompt": "<?php\n// Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== array(4, 2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python_program\") !== \"PythonProgram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python_language\") !== \"PythonLanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"programming_language\") !== \"ProgrammingLanguage\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num($n, $m) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_first_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 9, array(5, 7), 11)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 5, 8, array(2, 3), 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return eulerian_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 1) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 1) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 26) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "php",
-    "prompt": "<?php\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion($a, $x) {\n",
+    "prompt": "<?php\n// Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists($input_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return right_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\" red \", \"green\"), array(\"blue \", \" black\"), array(\" orange\", \"brown\"))) !== array(array(\" red \", \"green\"), array(\" black\", \"blue \"), array(\" orange\", \"brown\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"zilver\", \"gold\"), array(\"magnesium\", \"aluminium\"), array(\"steel\", \"bronze\"))) !== array(array(\"gold\", \"zilver\"), array(\"aluminium\", \"magnesium\"), array(\"bronze\", \"steel\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given number is woodball or not.\nfunction is_woodall($x) {\n",
+    "prompt": "<?php\n// Write a python function to count true booleans in the given list.\nfunction count($lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_woodall(...$args);\n}\n\nfunction test(): void {\n    if (candidate(383) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(254) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(true, false, true)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(false, false)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(true, true, true)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "php",
-    "prompt": "<?php\n// Write a function to sort the given array by using shell sort.\nfunction shell_sort($my_list) {\n",
+    "prompt": "<?php\n// Write a function to append the given list to the given tuples.\nfunction add_lists($test_list, $test_tup) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return shell_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)) !== array(2, 3, 4, 5, 12, 12, 23, 56, 81, 95)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(24, 22, 39, 34, 87, 73, 68)) !== array(22, 24, 34, 39, 68, 73, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(32, 30, 16, 96, 82, 83, 74)) !== array(16, 30, 32, 74, 82, 83, 96)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return add_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(9, 10, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(10, 11, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair($A, $N) {\n",
+    "prompt": "<?php\n// Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list($num1, $num2, $num3) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Odd_Pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11), 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return merge_sorted_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 24, 15, 4, 5, 29, 110), array(19, 20, 11, 56, 25, 233, 154), array(24, 26, 54, 48)) !== array(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, 6, 8, 9), array(2, 5, 7, 11), array(1, 4, 7, 8, 12)) !== array(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), array(25, 35, 22, 85, 14, 65, 75, 25, 58), array(12, 74, 9, 50, 61, 41)) !== array(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range($l, $r) {\n",
+    "prompt": "<?php\n// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent($s, $n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_in_range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== 40) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return odd_Equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"011001\", 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011\", 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1010\", 4) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "php",
-    "prompt": "<?php\n// Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter($a) {\n",
+    "prompt": "<?php\n// Write a function to check if a string represents an integer or not.\nfunction check_integer($text) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return square_perimeter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return check_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12345\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite($n) {\n",
+    "prompt": "<?php\n// Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int($nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_polite(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 13) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_series(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar($test_tup1, $test_tup2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_dissimilar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(7, 2, 3, 9)) !== array(1, 4, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 11, 25, 26), array(26, 34, 21, 36)) !== array(34, 36, 11, 25)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp($words) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return start_withp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python PHP\", \"Java JavaScript\", \"c c++\")) !== array(\"Python\", \"PHP\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python Programming\", \"Java Programming\")) !== array(\"Python\", \"Programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Pqrst Pqr\", \"qrstuv\")) !== array(\"Pqrst\", \"Pqr\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"android_tv\") !== \"AndroidTv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"google_pixel\") !== \"GooglePixel\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple_watch\") !== \"AppleWatch\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the volume of a cube given its side length.\nfunction volume_cube($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return volume_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number($monthnum2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_monthnumb_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range($n, $l, $r) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return all_Bits_Set_In_The_Given_Range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 1, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 2, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(39, 4, 6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to get the first element of each sublist.\nfunction Extract($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2), array(3, 4, 5), array(6, 7, 8, 9))) !== array(1, 3, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5))) !== array(1, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(9, 8, 1), array(1, 2))) !== array(9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder($r, $h) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return surfacearea_cylinder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 5) !== 942.45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 226.18800000000002) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 10) !== 351.848) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam($sample_names) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sample_nam(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\")) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\")) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abcd\", \"Python\", \"abba\", \"aba\")) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rearrange_bigger(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(102) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon($a) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return perimeter_pentagon(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 75) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 15, 51, 45, 33, 100, 12, 18, 9)) !== 194) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(80, 60, 30, 40, 20, 10)) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 14, 16, 21, 23, 29, 30)) !== 138) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even($test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, array(7, 6, array(2, 4)), 6, 8)) !== array(4, array(6, array(2, 4)), 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(8, 7, array(4, 8)), 7, 9)) !== array(6, array(8, array(4, 8)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(9, 8, array(4, 6)), 8, 10)) !== array(6, array(8, array(4, 6)), 8, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return tuple_to_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 123) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== 456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7)) !== 567) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4789,249 +169,9 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to convert all possible convertible elements in a list of lists to floats.\nfunction list_to_float($test_list) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return list_to_float(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"3\", \"4\"), array(\"1\", \"26.45\"), array(\"7.32\", \"8\"), array(\"4\", \"8\"))) !== array(array(3.0, 4.0), array(1.0, 26.45), array(7.32, 8.0), array(4.0, 8.0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"4\", \"4\"), array(\"2\", \"27\"), array(\"4.12\", \"9\"), array(\"7\", \"11\"))) !== array(array(4.0, 4.0), array(2.0, 27.0), array(4.12, 9.0), array(7.0, 11.0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"6\", \"78\"), array(\"5\", \"26.45\"), array(\"1.33\", \"4\"), array(\"82\", \"13\"))) !== array(array(6.0, 78.0), array(5.0, 26.45), array(1.33, 4.0), array(82.0, 13.0))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count($arr, $sum) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_pairs_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1, 1), 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, -1, 5), 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 3), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3), -3) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways($n, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_no_of_ways(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 4) !== 228) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return reverse_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python program\") !== \"program python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"java language\") !== \"language java\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"indian man\") !== \"man indian\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to check if a given number is one less than twice its reverse.\nfunction checks($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return checks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(70) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(73) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the last position of an element in a sorted array.\nfunction last($arr, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return last(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, 4), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 3, 6, 8, 9), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X($tup, $x) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_X(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "php",
-    "prompt": "<?php\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list($l1, $l2, $l3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_index_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 6, 5), array(0, 1, 2, 3, 4, 6, 7)) !== array(1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 6, 5, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 6, 6, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the second smallest number in a list.\nfunction second_smallest($numbers) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return second_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, -8, -2, 0, -2)) !== -2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, -0.5, 0, 2, -2, -2)) !== -0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple($test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return concatenate_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"ID\", \"is\", 4, \"UTS\")) !== \"ID-is-4-UTS\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"QWE\", \"is\", 4, \"RTY\")) !== \"QWE-is-4-RTY\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"ZEN\", \"is\", 4, \"OP\")) !== \"ZEN-is-4-OP\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces($string) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"My Name is Dawood\") !== \"My%20Name%20is%20Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I am a Programmer\") !== \"I%20am%20a%20Programmer\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love Coding\") !== \"I%20love%20Coding\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list($list1, $m, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sum_range_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10) !== 38) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three($dict1, $dict2, $dict3) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return merge_dictionaries_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) !== array(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\")) !== array(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\"), array(\"G\" => \"Green\", \"W\" => \"White\")) !== array(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the minimum of two numbers.\nfunction minimum($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-5, -4) !== -5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 5), array(1, 7), array(10, 3), array(1, 2))) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(2, 17), array(9, 13), array(11, 12))) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 35), array(21, 27), array(13, 23), array(41, 22))) !== 23) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find element at a given index after number of rotations.\nfunction find_Element($arr, $ranges, $rotations, $index) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(array(0, 2), array(0, 3)), 2, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(array(0, 1), array(0, 2)), 1, 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(array(0, 1), array(0, 2)), 1, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5044,7 +184,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to convert a string to a list of strings split on the space character.\nfunction string_to_list($string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return string_to_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== array(\"python\", \"programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lists tuples strings\") !== array(\"lists\", \"tuples\", \"strings\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"write a program\") !== array(\"write\", \"a\", \"program\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "php",
     "prompt": "<?php\n// Write a python function to find the element that appears only once in a sorted array.\nfunction search($arr) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a dictionary by value.\nfunction sort_counter($dict1) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_counter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) !== array(array(\"Chemistry\", 87), array(\"Physics\", 83), array(\"Math\", 81))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) !== array(array(\"Math\", 400), array(\"Physics\", 300), array(\"Chemistry\", 250))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) !== array(array(\"Chemistry\", 1250), array(\"Physics\", 1000), array(\"Math\", 900))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5089,7 +214,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a python function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ($s, $ch) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return remove_Occ(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello\", \"l\") !== \"heo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcda\", \"a\") !== \"bcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PHP\", \"P\") !== \"H\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube($l) {\n",
+    "prompt": "<?php\n// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple($list1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return lateralsurface_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 324) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 400) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return max_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 484) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "php",
-    "prompt": "<?php\n// Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element($list1, $list2) {\n",
+    "prompt": "<?php\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum($limit) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return common_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\"), array(\"d\", \"b\", \"e\")) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return amicable_numbers_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(999) !== 504) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9999) !== 31626) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "php",
-    "prompt": "<?php\n// Write a function to append the given list to the given tuples.\nfunction add_lists($test_list, $test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length($string) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(9, 10, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(10, 11, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return find_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"11000010001\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"10111\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011101100101\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "php",
-    "prompt": "<?php\n// Write a function to compute the n-th power of each number in a list.\nfunction nth_nums($nums, $n) {\n",
+    "prompt": "<?php\n// Write a python function to find the sum of common divisors of two given numbers.\nfunction sum($a, $b) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return nth_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30), 3) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15), 5) !== array(248832, 759375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 15) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 150) !== 93) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 6) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "php",
-    "prompt": "<?php\n// Write a function to sort a list of elements.\nfunction pancake_sort($nums) {\n",
+    "prompt": "<?php\n// Write a function to multiply two integers.\nfunction multiply_int($x, $y) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return pancake_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 79, 25, 38, 69)) !== array(15, 25, 38, 69, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(98, 12, 54, 36, 85)) !== array(12, 36, 54, 85, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 42, 32, 12, 23)) !== array(12, 23, 32, 41, 42)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median of three numbers.\nfunction median_numbers($a, $b, $c) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return median_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(25, 55, 65) !== 55.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 10, 30) !== 20.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 45, 75) !== 45.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater($arr, $number) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_greater(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6), 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 4, 8, 6, 1), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element($list, $element) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"green\", \"orange\", \"black\", \"white\"), \"blue\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"green\", \"green\", \"green\", \"green\"), \"green\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string($str, $l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return extract_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 8) !== array(\"practice\", \"solution\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 6) !== array(\"Python\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 9) !== array(\"exercises\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return text_lowercase_underscore(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aab_cbbbc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aab_Abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Aaab_abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to trim each list by k in the given lists.\nfunction trim_tuple($test_list, $K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return trim_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 2) !== array(array(2), array(9), array(2), array(2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 1) !== array(array(3, 2, 1), array(4, 9, 2), array(1, 2, 3), array(8, 2, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 4, 9), array(11, 8, 12, 4), array(4, 1, 7, 8), array(3, 6, 9, 7)), 1) !== array(array(8, 4), array(8, 12), array(1, 7), array(6, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sublist having minimum length.\nfunction Find_Min($lst) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return Find_Min(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 1, 1), array(1, 2, 7, 8))) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\"), array(\"x\", \"y\"), array(\"x\", \"y\", \"z\"))) !== array(\"x\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to filter odd numbers.\nfunction filter_oddnumbers($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return filter_oddnumbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 45, 67, 84, 93)) !== array(45, 67, 93)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 9, 8, 6, 4, 3)) !== array(5, 7, 9, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_adverbs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Clearly, he has no excuse for such behavior.\") !== \"0-7: Clearly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Please handle the situation carefuly\") !== \"28-36: carefuly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Complete the task quickly\") !== \"18-25: quickly\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth($test_list, $N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_of_nth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6, 7), array(1, 3, 5), array(8, 9, 19)), 2) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 7, 8), array(2, 4, 6), array(9, 10, 20)), 1) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 9), array(3, 5, 7), array(10, 11, 21)), 1) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== \"111\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors($l, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return combinations_colors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 1) !== array(array(\"Red\"), array(\"Green\"), array(\"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 2) !== array(array(\"Red\", \"Red\"), array(\"Red\", \"Green\"), array(\"Red\", \"Blue\"), array(\"Green\", \"Green\"), array(\"Green\", \"Blue\"), array(\"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 3) !== array(array(\"Red\", \"Red\", \"Red\"), array(\"Red\", \"Red\", \"Green\"), array(\"Red\", \"Red\", \"Blue\"), array(\"Red\", \"Green\", \"Green\"), array(\"Red\", \"Green\", \"Blue\"), array(\"Red\", \"Blue\", \"Blue\"), array(\"Green\", \"Green\", \"Green\"), array(\"Green\", \"Green\", \"Blue\"), array(\"Green\", \"Blue\", \"Blue\"), array(\"Blue\", \"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces($text) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_all_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python  program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python   programming    language\") !== \"pythonprogramminglanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps($str1, $str2) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_Swaps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1101\", \"1110\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"000\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"110\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create a new tuple from the given string and list.\nfunction new_tuple($test_list, $test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return new_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"WEB\", \"is\"), \"best\") !== array(\"WEB\", \"is\", \"best\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"We\", \"are\"), \"Developers\") !== array(\"We\", \"are\", \"Developers\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Part\", \"is\"), \"Wrong\") !== array(\"Part\", \"is\", \"Wrong\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder($arr, $n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_remainder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(100, 10, 5, 25, 35, 14), 11) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val($listval) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count($nums) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return positive_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)) !== 0.54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 0.69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== 0.56) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to add the given tuple to the given list.\nfunction add_tuple($test_list, $test_tup) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return add_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(5, 6, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(6, 7, 8, 10, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(7, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase($test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_run_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"GeMKSForGERksISBESt\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PrECIOusMOVemENTSYT\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GooGLEFluTTER\") !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix($M) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sort_matrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(2, 4, 5), array(1, 1, 1))) !== array(array(1, 1, 1), array(1, 2, 3), array(2, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(-2, 4, -5), array(1, -1, 1))) !== array(array(-2, 4, -5), array(1, -1, 1), array(1, 2, 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 8, 9), array(6, 4, 3), array(2, 1, 4))) !== array(array(2, 1, 4), array(6, 4, 3), array(5, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels($test_str) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"bestinstareels\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"partofthejourneyistheend\") !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"amazonprime\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq($a, $n, $index, $k) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return max_sum_increasing_subseq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 4, 6) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 2, 5) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 19, 21, 26, 28, 31), 7, 2, 4) !== 71) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return multiply_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5524,7 +304,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find words that are longer than n characters from a given list of words.\nfunction long_words($n, $str) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return long_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, \"python is a programming language\") !== array(\"python\", \"programming\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, \"writing a program\") !== array(\"writing\", \"program\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, \"sorting list\") !== array(\"sorting\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum($arr) {\n",
+    "prompt": "<?php\n// Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test($my_matrix) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 1, 1, 4, 5, 6)) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 10, 9, 4, 2, 10, 10, 45, 4)) !== 71) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 10, 9, 45, 2, 10, 10, 45, 10)) !== 78) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return magic_square_test(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(7, 12, 1, 14), array(2, 13, 8, 11), array(16, 3, 10, 5), array(9, 6, 15, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 8))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix($M) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return tuple_to_dict(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 10, 13, 5)) !== array(1 => 5, 7 => 10, 13 => 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1 => 2, 3 => 4, 5 => 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 10, 11, 12)) !== array(7 => 8, 9 => 10, 11 => 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_matrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(2, 4, 5), array(1, 1, 1))) !== array(array(1, 1, 1), array(1, 2, 3), array(2, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(-2, 4, -5), array(1, -1, 1))) !== array(array(-2, 4, -5), array(1, -1, 1), array(1, 2, 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 8, 9), array(6, 4, 3), array(2, 1, 4))) !== array(array(2, 1, 4), array(6, 4, 3), array(5, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "php",
-    "prompt": "<?php\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences($nums) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return get_coordinates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4)) !== array(array(2, 3), array(2, 4), array(2, 5), array(3, 3), array(3, 4), array(3, 5), array(4, 3), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5)) !== array(array(3, 4), array(3, 5), array(3, 6), array(4, 4), array(4, 5), array(4, 6), array(5, 4), array(5, 5), array(5, 6))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6)) !== array(array(4, 5), array(4, 6), array(4, 7), array(5, 5), array(5, 6), array(5, 7), array(6, 5), array(6, 6), array(6, 7))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type($test_tuple) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_type(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7, 3, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, \"4\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing($array) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_First_Missing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 6, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 8, 9)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is undulating or not.\nfunction is_undulating($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_undulating(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1212121) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1991) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(121) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k($test_list, $K) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return min_k(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Manjeet\", 10), array(\"Akshat\", 4), array(\"Akash\", 2), array(\"Nikhil\", 8)), 2) !== array(array(\"Akash\", 2), array(\"Akshat\", 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sanjeev\", 11), array(\"Angat\", 5), array(\"Akash\", 3), array(\"Nepin\", 9)), 3) !== array(array(\"Akash\", 3), array(\"Angat\", 5), array(\"Nepin\", 9))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"tanmay\", 14), array(\"Amer\", 11), array(\"Ayesha\", 9), array(\"SKD\", 16)), 1) !== array(array(\"Ayesha\", 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings($s) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_Substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"112112\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1101112\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth decagonal number.\nfunction is_num_decagonal($n) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_num_decagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 175) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 370) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return rear_extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, \"Rash\", 21), array(2, \"Varsha\", 20), array(3, \"Kil\", 19))) !== array(21, 20, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sai\", 36), array(2, \"Ayesha\", 25), array(3, \"Salman\", 45))) !== array(36, 25, 45)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sudeep\", 14), array(2, \"Vandana\", 36), array(3, \"Dawood\", 56))) !== array(14, 36, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the closest smaller number than n.\nfunction closest_num($N) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return closest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(11) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations($test_list) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_combinations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 4), array(6, 7), array(5, 1), array(6, 10))) !== array(array(8, 11), array(7, 5), array(8, 14), array(11, 8), array(12, 17), array(11, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8), array(6, 2), array(7, 11))) !== array(array(10, 13), array(9, 7), array(10, 16), array(13, 10), array(14, 19), array(13, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(8, 9), array(7, 3), array(8, 12))) !== array(array(12, 15), array(11, 9), array(12, 18), array(15, 12), array(16, 21), array(15, 15))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath($cost) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return maxAverageOfPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(6, 5, 4), array(7, 3, 9))) !== 5.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 4), array(7, 6, 5), array(8, 4, 10))) !== 6.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(8, 7, 6), array(9, 5, 11))) !== 7.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9))) !== 5.8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search($dlist, $item) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sequential_search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31) !== array(true, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 32, 45, 62, 35, 47, 44, 61), 61) !== array(true, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 10, 17, 19, 22, 39, 48, 56), 48) !== array(true, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to remove odd numbers from a given list.\nfunction remove_odd($l) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 6)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 3)) !== array(10, 20)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even($arr) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return is_product_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Write a python function to find the maximum of two numbers.\nfunction maximum($a, $b) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 10) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 7) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return max_occurrences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5794,9 +364,759 @@
     "language": "php",
     "prompt": "<?php\n// Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels($str1) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return reverse_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"USA\") !== \"ASU\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"ab\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a list to a string.\nfunction tup_string($tup1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tup_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\")) !== \"exercises\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) !== \"program\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_negativenum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== -32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, -14, 13, -18, 12, -20)) !== -52) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)) !== -894) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth hexagonal number.\nfunction hexagonal_num($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return hexagonal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 190) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 91) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_Sum_Of_Powers_Of_Two(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a list of elements.\nfunction pancake_sort($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pancake_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 79, 25, 38, 69)) !== array(15, 25, 38, 69, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(98, 12, 54, 36, 85)) !== array(12, 36, 54, 85, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 42, 32, 12, 23)) !== array(12, 23, 32, 41, 42)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair($list1, $list2, $list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_samepair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9), array(2, 1, 3, 1, 2, 6, 7, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 2, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find number of lists present in the given list.\nfunction find_lists($Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5, 4, 3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_Abs_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 3, 2, 5, 1)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the volume of a triangular prism.\nfunction find_Volume($l, $b, $h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Volume(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 8, 6) !== 240) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution($a, $b, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 7) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 7) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 13, 17) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all elements from a given list present in another list.\nfunction remove_elements($list1, $list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(1, 3, 5, 7)) !== array(2, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(5, 7)) !== array(1, 2, 3, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_series(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent($num1, $num2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return are_equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(36, 57) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 47) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_char_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xbcefg\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABcED\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"AbgdeF\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair($A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_even_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return next_power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of occurrences of a number in a given list.\nfunction frequency($a, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return frequency(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 3, 4), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 1, 2), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_lowercase_underscore(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aab_cbbbc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aab_Abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Aaab_abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list($list1, $m, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_range_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10) !== 38) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon($a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return perimeter_pentagon(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 75) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_occurance(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"letstdlenstdporstd\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"truststdsolensporsd\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"makestdsostdworthit\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"stds\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter($a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return square_perimeter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars($string, $second_string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_dirty_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"probasscurve\", \"pros\") !== \"bacuve\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"digitalindia\", \"talent\") !== \"digiidi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"exoticmiles\", \"toxic\") !== \"emles\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate($arraynums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return test_duplicate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2, 3, 3, 4, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given number is woodball or not.\nfunction is_woodall($x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_woodall(...$args);\n}\n\nfunction test(): void {\n    if (candidate(383) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(254) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type($test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_type(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7, 3, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, \"4\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority($arr, $n, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_majority(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 3, 3, 3, 10), 7, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 4, 4, 4, 6, 6), 8, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 2), 5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2), 5, 1) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_Set_Bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return odd_values_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcdef\") !== \"ace\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\") !== \"pto\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== \"dt\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lambs\") !== \"lms\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find minimum of three numbers.\nfunction min_of_three($a, $b, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 15, 18) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -20, -30) !== -30) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range($n, $l, $r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_Bits_Set_In_The_Given_Range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 1, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 2, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(39, 4, 6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array($arr, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return re_arrange_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9) !== array(-1, -3, -7, 4, 5, 6, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, -14, -26, 13, 15), 5) !== array(-14, -26, 12, 13, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 24, 36, -42, -39, -78, 85), 7) !== array(-42, -39, -78, 10, 24, 36, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank($str1, $char) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_blank(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello people\", \"@\") !== \"hello@people\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python program language\", \"$\") !== \"python$program$language\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"blank space\", \"-\") !== \"blank-space\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the volume of a cube given its side length.\nfunction volume_cube($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return volume_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunction check_occurences($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_occurences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 1), array(1, 3), array(2, 5), array(5, 2), array(6, 3))) !== array(array(1, 3) => 2, array(2, 5) => 2, array(3, 6) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 2), array(2, 4), array(3, 6), array(6, 3), array(7, 4))) !== array(array(2, 4) => 2, array(3, 6) => 2, array(4, 7) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(13, 2), array(11, 23), array(12, 25), array(25, 12), array(16, 23))) !== array(array(2, 13) => 1, array(11, 23) => 1, array(12, 25) => 2, array(16, 23) => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return number_of_substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences($m, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_total_number_of_sequences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 3) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list($list1, $list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8)) !== array(1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"blue\", \"green\"), array(\"yellow\")) !== array(\"red\", \"blue\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the total number of characters in a string.\nfunction count_charac($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_charac(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"words\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square($N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return next_Perfect_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(35) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 15, 51, 45, 33, 100, 12, 18, 9)) !== 194) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(80, 60, 30, 40, 20, 10)) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 14, 16, 21, 23, 29, 30)) !== 138) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return lps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TENS FOR TENS\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"CARDIO FOR CARDS\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PART OF THE JOURNEY IS PART\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the intersection of two arrays.\nfunction intersection_array($array_nums1, $array_nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return intersection_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(1, 2, 4, 8, 9)) !== array(1, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(3, 5, 7, 9)) !== array(3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(10, 20, 30, 40)) !== array(10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X($tup, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_X(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element($list, $element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return insert_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Black\"), \"c\") !== array(\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\"), \"program\") !== array(\"program\", \"python\", \"program\", \"java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"happy\", \"sad\"), \"laugh\") !== array(\"laugh\", \"happy\", \"laugh\", \"sad\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to convert complex numbers to polar coordinates.\nfunction convert($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return convert(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function that returns the number of integer elements in a given list.\nfunction count_integer($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, \"abc\", 1.2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1.2, 4, 5.1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors($l, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return combinations_colors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 1) !== array(array(\"Red\"), array(\"Green\"), array(\"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 2) !== array(array(\"Red\", \"Red\"), array(\"Red\", \"Green\"), array(\"Red\", \"Blue\"), array(\"Green\", \"Green\"), array(\"Green\", \"Blue\"), array(\"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 3) !== array(array(\"Red\", \"Red\", \"Red\"), array(\"Red\", \"Red\", \"Green\"), array(\"Red\", \"Red\", \"Blue\"), array(\"Red\", \"Green\", \"Green\"), array(\"Red\", \"Green\", \"Blue\"), array(\"Red\", \"Blue\", \"Blue\"), array(\"Green\", \"Green\", \"Green\"), array(\"Green\", \"Green\", \"Blue\"), array(\"Green\", \"Blue\", \"Blue\"), array(\"Blue\", \"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_Primes_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return swap_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== array(20, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 17) !== array(17, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(200, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5809,7 +1129,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to maximize the given two lists.\nfunction maximize_elements($test_tup1, $test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return maximize_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 7), array(4, 9), array(2, 9), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(7, 8), array(5, 10), array(3, 10), array(8, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(8, 9), array(6, 11), array(4, 11), array(9, 12))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position($nums) {\n",
+    "prompt": "<?php\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime($n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return even_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return newman_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 17) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 41) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char($string) {\n",
+    "prompt": "<?php\n// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements($test_tup1, $test_tup2) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return check_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abba\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"Invalid\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return division_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(2, 2, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 16), array(6, 3, 4, 4)) !== array(2, 2, 2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(20, 14, 36, 18), array(5, 7, 6, 9)) !== array(4, 2, 6, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "php",
-    "prompt": "<?php\n// Write a python function to find the sum of even factors of a number.\nfunction sumofFactors($n) {\n",
+    "prompt": "<?php\n// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts($list1, $L) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return sumofFactors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(18) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 48) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return split_two_parts(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(array(1, 1, 2), array(3, 4, 4, 5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), 2) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"), 4) !== array(array(\"p\", \"y\", \"t\", \"h\"), array(\"o\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone($r, $h) {\n",
+    "prompt": "<?php\n// Write a function to calculate a dog's age in dog's years.\nfunction dog_age($h_age) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return lateralsurface_cone(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 12) !== 204.20352248333654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 566.3586699569488) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 17) !== 1521.8090132193388) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return dog_age(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 61) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24) !== 109) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "php",
-    "prompt": "<?php\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs($arr, $n) {\n",
+    "prompt": "<?php\n// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split($S, $step) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return count_Pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 1), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), 5) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return list_split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"), 3) !== array(array(\"a\", \"d\", \"g\", \"j\", \"m\"), array(\"b\", \"e\", \"h\", \"k\", \"n\"), array(\"c\", \"f\", \"i\", \"l\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3) !== array(array(1, 4, 7, 10, 13), array(2, 5, 8, 11, 14), array(3, 6, 9, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"), 2) !== array(array(\"python\", \"C\", \"DBMS\"), array(\"java\", \"C++\", \"SQL\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence($A, $x) {\n",
+    "prompt": "<?php\n// Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube($l) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return find_first_occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return lateralsurface_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 324) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 400) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5914,9 +1234,909 @@
     "language": "php",
     "prompt": "<?php\n// Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum($n) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n'th star number.\nfunction find_star_num($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_star_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the ascii value of a character.\nfunction ascii_value($k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return ascii_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"A\") !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"R\") !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"S\") !== 83) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_even_and_even_index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 12, 1, 18, 8)) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 12, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_Power_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1056) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 8832) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rear_extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, \"Rash\", 21), array(2, \"Varsha\", 20), array(3, \"Kil\", 19))) !== array(21, 20, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sai\", 36), array(2, \"Ayesha\", 25), array(3, \"Salman\", 45))) !== array(36, 25, 45)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sudeep\", 14), array(2, \"Vandana\", 36), array(3, \"Dawood\", 56))) !== array(14, 36, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return substract_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5), array(2, 5, 18)) !== array(8, -1, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 2, 3), array(24, 45, 16)) !== array(-13, -43, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 18, 9), array(10, 11, 12)) !== array(-3, 7, -3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_binomial_Coeff_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter($dict, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return dict_filter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) !== array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) !== array(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) !== array(\"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_first_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 9, array(5, 7), 11)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 5, 8, array(2, 3), 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth decagonal number.\nfunction is_num_decagonal($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_num_decagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 175) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 370) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search($dlist, $item) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sequential_search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31) !== array(true, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 32, 45, 62, 35, 47, 44, 61), 61) !== array(true, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 10, 17, 19, 22, 39, 48, 56), 48) !== array(true, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to subtract two lists element-wise.\nfunction sub_list($nums1, $nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sub_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== array(-3, -3, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 4)) !== array(-2, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(40, 50)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return validate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1234) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(51241) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(321) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element($list, $element) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"green\", \"orange\", \"black\", \"white\"), \"blue\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"green\", \"green\", \"green\", \"green\"), \"green\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_two_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated($a, $n, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_sub_array_sum_repeated(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, -30, -1), 4, 3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 10, 20), 3, 2) !== 59) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3), 3, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the list of maximum length in a list of lists.\nfunction max_length($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(5, 7), array(10, 12, 14, 15))) !== array(4, array(10, 12, 14, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5), array(15, 20, 25))) !== array(3, array(15, 20, 25))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways($n, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_no_of_ways(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 4) !== 228) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find($n, $m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle($w, $h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return otherside_rightangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 8) !== 10.63014581273465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 15) !== 16.55294535724685) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val($listval) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 50) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return the sum of all divisors of a number.\nfunction sum_div($number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_div(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count inversions in an array.\nfunction get_Inv_Count($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_Inv_Count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 20, 6, 4, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 6, 1)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to flatten a given nested list structure.\nfunction flatten_list($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return flatten_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 10, array(20, 30), 40, 50, array(60, 70, 80), array(90, 100, 110, 120))) !== array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(40), array(30, 56, 25), array(10, 20), array(33), array(40))) !== array(10, 20, 40, 30, 56, 25, 10, 20, 33, 40)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate($stdata) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_aggregate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Juan Whelan\", 90), array(\"Sabah Colley\", 88), array(\"Peter Nichols\", 7), array(\"Juan Whelan\", 122), array(\"Sabah Colley\", 84))) !== array(\"Juan Whelan\", 212)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 50), array(\"Sabah Colley\", 48), array(\"Peter Nichols\", 37), array(\"Juan Whelan\", 22), array(\"Sabah Colley\", 14))) !== array(\"Juan Whelan\", 72)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 10), array(\"Sabah Colley\", 20), array(\"Peter Nichols\", 30), array(\"Juan Whelan\", 40), array(\"Sabah Colley\", 50))) !== array(\"Sabah Colley\", 70)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find element at a given index after number of rotations.\nfunction find_Element($arr, $ranges, $rotations, $index) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(array(0, 2), array(0, 3)), 2, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(array(0, 1), array(0, 2)), 1, 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(array(0, 1), array(0, 2)), 1, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp($words) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return start_withp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python PHP\", \"Java JavaScript\", \"c c++\")) !== array(\"Python\", \"PHP\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python Programming\", \"Java Programming\")) !== array(\"Python\", \"Programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Pqrst Pqr\", \"qrstuv\")) !== array(\"Pqrst\", \"Pqr\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq($a, $n, $index, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_sum_increasing_subseq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 4, 6) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 2, 5) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 19, 21, 26, 28, 31), 7, 2, 4) !== 71) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product($nums1, $nums2, $N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return large_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 3) !== array(60, 54, 50)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 4) !== array(60, 54, 50, 48)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 5) !== array(60, 54, 50, 48, 45)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the maximum of two numbers.\nfunction maximum($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 10) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 7) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a given string to a list of characters.\nfunction string_to_tuple($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return string_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python 3.0\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"item1\") !== array(\"i\", \"t\", \"e\", \"m\", \"1\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.10\") !== array(\"1\", \"5\", \".\", \"1\", \"0\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return highest_Power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n'th lucas number.\nfunction find_lucas($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_lucas(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 76) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to apply a given format string to all of the elements in a list.\nfunction add_string($list_, $string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), \"temp{0}\") !== array(\"temp1\", \"temp2\", \"temp3\", \"temp4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), \"python{0}\") !== array(\"pythona\", \"pythonb\", \"pythonc\", \"pythond\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8), \"string{0}\") !== array(\"string5\", \"string6\", \"string7\", \"string8\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert more than one list to nested dictionary.\nfunction convert_list_dictionary($l1, $l2, $l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return convert_list_dictionary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"S001\", \"S002\", \"S003\", \"S004\"), array(\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"), array(85, 98, 89, 92)) !== array(array(\"S001\" => array(\"Adina Park\" => 85)), array(\"S002\" => array(\"Leyton Marsh\" => 98)), array(\"S003\" => array(\"Duncan Boyle\" => 89)), array(\"S004\" => array(\"Saim Richards\" => 92)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"def\", \"ghi\", \"jkl\"), array(\"python\", \"program\", \"language\", \"programs\"), array(100, 200, 300, 400)) !== array(array(\"abc\" => array(\"python\" => 100)), array(\"def\" => array(\"program\" => 200)), array(\"ghi\" => array(\"language\" => 300)), array(\"jkl\" => array(\"programs\" => 400)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"A1\", \"A2\", \"A3\", \"A4\"), array(\"java\", \"C\", \"C++\", \"DBMS\"), array(10, 20, 30, 40)) !== array(array(\"A1\" => array(\"java\" => 10)), array(\"A2\" => array(\"C\" => 20)), array(\"A3\" => array(\"C++\" => 30)), array(\"A4\" => array(\"DBMS\" => 40)))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(60) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the list with maximum length.\nfunction max_length_list($input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_length_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5), array(1, 2, 3, 4), array(1, 2, 3), array(1, 2), array(1))) !== array(5, array(1, 2, 3, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(6, 7, 8, 9), array(10, 11, 12))) !== array(4, array(6, 7, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if given list contains no duplicates.\nfunction check_distinct($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_distinct(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 5, 6, 1, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return first_non_repeating_character(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ababc\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abba\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"Invalid\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median of three numbers.\nfunction median_numbers($a, $b, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return median_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(25, 55, 65) !== 55.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 10, 30) !== 20.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 45, 75) !== 45.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_of_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 2, 56)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20, 4, 5, \"b\", 70, \"a\"))) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, -4, 5, -70)) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return bitwise_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(15, 6, 5, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 7, 10), array(6, 3, 4, 4)) !== array(13, 6, 3, 14)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 11), array(7, 4, 5, 6)) !== array(11, 2, 13, 13)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to identify non-prime numbers.\nfunction is_not_prime($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_not_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(35) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(37) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_freq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 4), array(1, 2), array(4, 3), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 15), array(2, 3), array(5, 4), array(6, 7))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 16), array(2, 3), array(6, 5), array(6, 9))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_nested_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(7, 10), array(7, 14), array(3, 10), array(8, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(9, 12), array(9, 16), array(5, 12), array(10, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(11, 14), array(11, 18), array(7, 14), array(12, 17))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the minimum of two numbers.\nfunction minimum($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-5, -4) !== -5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether an element exists within a tuple.\nfunction check_tuplex($tuplex, $tuple1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_tuplex(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"r\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), 3) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity($x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Parity(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rearrange_bigger(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(102) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs($nums1, $nums2, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return k_smallest_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 2) !== array(array(1, 2), array(1, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 1) !== array(array(1, 2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 7) !== array(array(1, 2), array(1, 4), array(3, 2), array(1, 6), array(3, 4), array(3, 6), array(7, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val($listval) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"android_tv\") !== \"AndroidTv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"google_pixel\") !== \"GooglePixel\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple_watch\") !== \"AppleWatch\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to remove odd numbers from a given list.\nfunction remove_odd($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 6)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 3)) !== array(10, 20)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element($list1, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_nth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 0) !== array(\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 2) !== array(99, 96, 94, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 1) !== array(98, 97, 91, 94)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping($list1, $list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return overlapping(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5), array(1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_Product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 7, 0, 8, 4)) !== array(7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, -1, -2, -4, 5, 0, -6)) !== array(-4, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5929,7 +2149,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find common first element in given list of lists.\nfunction group_tuples($Input) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "function candidate(...$args) {\n    return group_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"x\", \"z\"), array(\"w\", \"t\"))) !== array(array(\"x\", \"y\", \"z\"), array(\"w\", \"t\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"a\", \"c\"), array(\"d\", \"e\"))) !== array(array(\"a\", \"b\", \"c\"), array(\"d\", \"e\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"f\", \"g\"), array(\"f\", \"g\"), array(\"h\", \"i\"))) !== array(array(\"f\", \"g\", \"g\"), array(\"h\", \"i\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "php",
-    "prompt": "<?php\n// Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list($num1, $num2, $num3) {\n",
+    "prompt": "<?php\n// Write a python function to find the element of a list having maximum length.\nfunction Find_Max($lst) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "function candidate(...$args) {\n    return merge_sorted_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 24, 15, 4, 5, 29, 110), array(19, 20, 11, 56, 25, 233, 154), array(24, 26, 54, 48)) !== array(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, 6, 8, 9), array(2, 5, 7, 11), array(1, 4, 7, 8, 12)) !== array(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), array(25, 35, 22, 85, 14, 65, 75, 25, 58), array(12, 74, 9, 50, 61, 41)) !== array(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return Find_Max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"A\"), array(\"A\", \"B\"), array(\"A\", \"B\", \"C\"))) !== array(\"A\", \"B\", \"C\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 2, 3), array(1, 5, 6, 1))) !== array(1, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return round_and_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)) !== 243) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 9, 24.3, 29)) !== 345) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25.0, 56.7, 89.2)) !== 513) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cube_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 800) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return concatenate_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"ID\", \"is\", 4, \"UTS\")) !== \"ID-is-4-UTS\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"QWE\", \"is\", 4, \"RTY\")) !== \"QWE-is-4-RTY\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"ZEN\", \"is\", 4, \"OP\")) !== \"ZEN-is-4-OP\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Average_Of_Cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear($test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_rear(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Mers\", \"for\", \"Vers\")) !== array(\"s\", \"r\", \"s\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Avenge\", \"for\", \"People\")) !== array(\"e\", \"r\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Gotta\", \"get\", \"go\")) !== array(\"a\", \"t\", \"o\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list($list1, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_element_in_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(1, 11), array(1, 15, 7)), 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"A\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"E\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to filter odd numbers.\nfunction filter_oddnumbers($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_oddnumbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 45, 67, 84, 93)) !== array(45, 67, 93)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 9, 8, 6, 4, 3)) !== array(5, 7, 9, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format($dt) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return change_date_format(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"2026-01-02\") !== \"02-01-2026\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020-11-13\") !== \"13-11-2020\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2021-04-26\") !== \"26-04-2021\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort the given array by using shell sort.\nfunction shell_sort($my_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return shell_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)) !== array(2, 3, 4, 5, 12, 12, 23, 56, 81, 95)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(24, 22, 39, 34, 87, 73, 68)) !== array(22, 24, 34, 39, 68, 73, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(32, 30, 16, 96, 82, 83, 74)) !== array(16, 30, 32, 74, 82, 83, 96)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return and_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(0, 0, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(5, 6, 7, 8)) !== array(1, 2, 3, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 11, 12), array(7, 13, 14, 17)) !== array(0, 9, 10, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the directrix of a parabola.\nfunction parabola_directrix($a, $b, $c) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return parabola_directrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3, 2) !== -198) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 8, 4) !== -2336) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4, 6) !== -130) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element($list1, $list2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return common_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\"), array(\"d\", \"b\", \"e\")) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median length of a trapezium.\nfunction median_trapezium($base1, $base2, $height) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return median_trapezium(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15, 25, 35) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 20, 30) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 9, 4) !== 7.5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater($arr, $number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_greater(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6), 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 4, 8, 6, 1), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the last digit of a given number.\nfunction last_Digit($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return last_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to return the negative numbers in a list.\nfunction neg_nos($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return neg_nos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 4, 5, -6)) !== array(-1, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3, 4)) !== array(-1, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-7, -6, 8, 9)) !== array(-7, -6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove odd characters in a string.\nfunction remove_odd($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== \"yhn\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== \"rga\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== \"agae\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_bidirectional(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 3), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 2), array(6, 5), array(2, 1))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single($L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return multiple_to_single(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 33, 50)) !== 113350) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4, 5, 6)) !== -123456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, 20, 25)) !== 10152025) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_adverb_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"clearly!! we can see the sky\") !== array(0, 7, \"clearly\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"seriously!! there are many roses\") !== array(0, 9, \"seriously\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"unfortunately!! sita is going to home\") !== array(0, 13, \"unfortunately\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return surfacearea_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 150) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 600) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return positive_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)) !== 0.54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 0.69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== 0.56) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the largest negative number from the given list.\nfunction largest_neg($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return largest_neg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, -4, -6)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -8, -9)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to trim each list by k in the given lists.\nfunction trim_tuple($test_list, $K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return trim_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 2) !== array(array(2), array(9), array(2), array(2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 1) !== array(array(3, 2, 1), array(4, 9, 2), array(1, 2, 3), array(8, 2, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 4, 9), array(11, 8, 12, 4), array(4, 1, 7, 8), array(3, 6, 9, 7)), 1) !== array(array(8, 4), array(8, 12), array(1, 7), array(6, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return index_multiplication(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 21), array(12, 45), array(2, 9), array(7, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(14, 32), array(20, 60), array(6, 20), array(16, 44))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(24, 45), array(30, 77), array(12, 33), array(27, 60))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence($tup, $lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_Occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"a\", \"c\", \"b\", \"d\"), array(\"a\", \"b\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1, 4, 6, 7, 1, 4), array(1, 4, 7)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find cubes of individual elements in a list.\nfunction cube_nums($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cube_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(1728, 3375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum of perrin numbers.\nfunction cal_sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cal_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 88) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string($str, $l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 8) !== array(\"practice\", \"solution\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 6) !== array(\"Python\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 9) !== array(\"exercises\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces($text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_whitespaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\" Google    Flutter \") !== \"GoogleFlutter\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" Google    Dart \") !== \"GoogleDart\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" iOS    Swift \") !== \"iOSSwift\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount($actual_cost, $sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return loss_amount(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== 3000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of even factors of a number.\nfunction sumofFactors($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sumofFactors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(18) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 48) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a word containing 'z'.\nfunction text_match_wordz($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_wordz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number($monthnum2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_monthnumb_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list($stringlist) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return reverse_string_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\", \"White\", \"Black\")) !== array(\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"john\", \"amal\", \"joel\", \"george\")) !== array(\"nhoj\", \"lama\", \"leoj\", \"egroeg\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"jack\", \"john\", \"mary\")) !== array(\"kcaj\", \"nhoj\", \"yram\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sublist having minimum length.\nfunction Find_Min($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Find_Min(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 1, 1), array(1, 2, 7, 8))) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\"), array(\"x\", \"y\"), array(\"x\", \"y\", \"z\"))) !== array(\"x\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the area of a rectangle.\nfunction rectangle_area($l, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rectangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"cAstyoUrFavoRitETVshoWs\") !== \"cstyoravoitshos\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wAtchTheinTernEtrAdIo\") !== \"wtchheinerntrdo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"VoicESeaRchAndreComMendaTionS\") !== \"oiceachndreomendaion\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to get the first element of each sublist.\nfunction Extract($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2), array(3, 4, 5), array(6, 7, 8, 9))) !== array(1, 3, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5))) !== array(1, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(9, 8, 1), array(1, 2))) !== array(9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the upper case characters in a given string.\nfunction upper_ctr($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return upper_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYthon\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"BigData\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find all possible combinations of the elements of a given list.\nfunction combinations_list($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return combinations_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"orange\", \"red\", \"green\", \"blue\")) !== array(array(), array(\"orange\"), array(\"red\"), array(\"red\", \"orange\"), array(\"green\"), array(\"green\", \"orange\"), array(\"green\", \"red\"), array(\"green\", \"red\", \"orange\"), array(\"blue\"), array(\"blue\", \"orange\"), array(\"blue\", \"red\"), array(\"blue\", \"red\", \"orange\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"orange\"), array(\"blue\", \"green\", \"red\"), array(\"blue\", \"green\", \"red\", \"orange\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"blue\"), array(\"blue\", \"red\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"red\"), array(\"white\"), array(\"white\", \"red\"), array(\"white\", \"green\"), array(\"white\", \"green\", \"red\"), array(\"white\", \"blue\"), array(\"white\", \"blue\", \"red\"), array(\"white\", \"blue\", \"green\"), array(\"white\", \"blue\", \"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"black\", \"blue\"), array(\"black\", \"blue\", \"red\"), array(\"black\", \"blue\", \"green\"), array(\"black\", \"blue\", \"green\", \"red\"), array(\"black\", \"white\"), array(\"black\", \"white\", \"red\"), array(\"black\", \"white\", \"green\"), array(\"black\", \"white\", \"green\", \"red\"), array(\"black\", \"white\", \"blue\"), array(\"black\", \"white\", \"blue\", \"red\"), array(\"black\", \"white\", \"blue\", \"green\"), array(\"black\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"blue\"), array(\"orange\", \"blue\", \"red\"), array(\"orange\", \"blue\", \"green\"), array(\"orange\", \"blue\", \"green\", \"red\"), array(\"orange\", \"white\"), array(\"orange\", \"white\", \"red\"), array(\"orange\", \"white\", \"green\"), array(\"orange\", \"white\", \"green\", \"red\"), array(\"orange\", \"white\", \"blue\"), array(\"orange\", \"white\", \"blue\", \"red\"), array(\"orange\", \"white\", \"blue\", \"green\"), array(\"orange\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"), array(\"orange\", \"black\", \"blue\"), array(\"orange\", \"black\", \"blue\", \"red\"), array(\"orange\", \"black\", \"blue\", \"green\"), array(\"orange\", \"black\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\"), array(\"orange\", \"black\", \"white\", \"red\"), array(\"orange\", \"black\", \"white\", \"green\"), array(\"orange\", \"black\", \"white\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\"), array(\"orange\", \"black\", \"white\", \"blue\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_subarray_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 0, 7, -8, -2)) !== 112) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, -3, -10, 0, 2)) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -40, 0, -2, -3)) !== 80) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if all values are same in a dictionary.\nfunction check_value($dict, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to drop empty items from a given dictionary.\nfunction drop_empty($dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return drop_empty(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c1\" => \"Red\", \"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => null, \"c3\" => null)) !== array(\"c1\" => \"Red\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => null, \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 100, 4, 5, 150, 6)) !== 3000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 42, 55, 68, 80)) !== 50265600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 22, 9, 33, 21, 50, 41, 60)) !== 2460) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_pairwise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(6, 12, 15, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, 9, 11)) !== array(8, 14, 17, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, 10, 12)) !== array(10, 16, 19, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder($arr, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_remainder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(100, 10, 5, 25, 35, 14), 11) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive($l) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_Consecutive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace characters in a string.\nfunction replace_char($str1, $ch, $newch) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"polygon\", \"y\", \"l\") !== \"pollgon\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"character\", \"c\", \"a\") !== \"aharaater\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\", \"l\", \"a\") !== \"python\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a dictionary by value.\nfunction sort_counter($dict1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_counter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) !== array(array(\"Chemistry\", 87), array(\"Physics\", 83), array(\"Math\", 81))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) !== array(array(\"Math\", 400), array(\"Physics\", 300), array(\"Chemistry\", 250))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) !== array(array(\"Chemistry\", 1250), array(\"Physics\", 1000), array(\"Math\", 900))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return big_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 6)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to convert the given string to lower case.\nfunction is_lower($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_lower(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"InValid\") !== \"invalid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"TruE\") !== \"true\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"SenTenCE\") !== \"sentence\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_lowercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYTHon\") !== \"PYTH\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"FInD\") !== \"FID\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"STRinG\") !== \"STRG\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the first digit of a given number.\nfunction first_Digit($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return first_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(456) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest($nums, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return heap_queue_largest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 3) !== array(85, 75, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 2) !== array(85, 75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 5) !== array(85, 75, 65, 58, 35)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split($list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 12, 13)) !== array(11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1)) !== array(7, 9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair($A, $N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Odd_Pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11), 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to toggle the case of all characters in a string.\nfunction toggle_string($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return toggle_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"pYTHON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pangram\") !== \"pANGRAM\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"LIttLE\") !== \"liTTle\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums($n1, $n2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return digit_distance_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 56) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123, 256) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum($a, $size) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_sub_array_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-2, -3, 4, -1, -2, 1, 5, -3), 8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -4, 5, -2, -3, 2, 6, -4), 8) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-4, -5, 6, -3, -4, 3, 7, -5), 8) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return union_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 4, 5, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(3, 4, 5, 6)) !== array(1, 2, 3, 4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13, 14), array(13, 15, 16, 17)) !== array(11, 12, 13, 14, 15, 16, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Find_Max_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 4), array(5, 6, 7, 8))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 1), array(2, 2), array(3, 2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7), array(22, 23), array(13, 14, 15), array(10, 20, 30, 40, 50))) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract values between quotation marks from a string.\nfunction extract_values($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_values(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") !== array(\"Python\", \"PHP\", \"Java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") !== array(\"python\", \"program\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") !== array(\"red\", \"blue\", \"green\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs($arr, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_Pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 1), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), 5) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to split a string into characters.\nfunction split($word) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Name\") !== array(\"N\", \"a\", \"m\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(345) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(97) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether a specified list is sorted or not.\nfunction issort_list($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return issort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 15, 14, 20)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create a list of N empty dictionaries.\nfunction empty_list($length) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return empty_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(array(), array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) !== array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"d\", \"c\"), array(\"g\", \"h\"), array(\"f\", \"e\"))) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"), array(\"g\", \"h\"), array(\"e\", \"f\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check if a given number is one less than twice its reverse.\nfunction checks($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return checks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(70) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(73) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return two_unique_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 2, 3, 4, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 5)) !== array(1, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product($list_data) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30, 40, 20, 50, 60, 40)) !== 720000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 0, 1, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder($r, $h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return surfacearea_cylinder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 5) !== 942.45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 226.18800000000002) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 10) !== 351.848) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array($A, $B) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_Sub_Array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 5), array(1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), array(1, 2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 2), array(2, 2, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return last_Digit_Factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(21) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists($list1, $list2, $list3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return interleave_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7), array(10, 20, 30, 40, 50, 60, 70), array(100, 200, 300, 400, 500, 600, 700)) !== array(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20), array(15, 2), array(5, 10)) !== array(10, 15, 5, 20, 2, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 44), array(10, 15), array(20, 5)) !== array(11, 10, 20, 44, 15, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_dissimilar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(7, 2, 3, 9)) !== array(1, 4, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 11, 25, 26), array(26, 34, 21, 36)) !== array(34, 36, 11, 25)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Max_Num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 321) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 1)) !== 6541) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 9)) !== 9321) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even($test_tuple) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, array(7, 6, array(2, 4)), 6, 8)) !== array(4, array(6, array(2, 4)), 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(8, 7, array(4, 8)), 7, 9)) !== array(6, array(8, array(4, 8)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(9, 8, array(4, 6)), 8, 10)) !== array(6, array(8, array(4, 6)), 8, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area($b, $s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return surface_Area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which returns nth catalan number.\nfunction catalan_number($num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return catalan_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 16796) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 4862) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 429) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_adverbs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Clearly, he has no excuse for such behavior.\") !== \"0-7: Clearly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Please handle the situation carefuly\") !== \"28-36: carefuly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Complete the task quickly\") !== \"18-25: quickly\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items($items, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return expensive_items(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09)), 2) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-1\", \"price\" => 101.1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09), array(\"name\" => \"Item-4\", \"price\" => 22.75)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr($l, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return split_Arr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 10, 5, 6, 52, 36), 2) !== array(5, 6, 52, 36, 12, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 1) !== array(2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 4, 5, 6, 7), 3) !== array(3, 4, 5, 6, 7, 0, 1, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a list to a tuple.\nfunction list_tuple($listx) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return list_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 10, 7, 4, 15, 3)) !== array(5, 10, 7, 4, 15, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 2, 3, 4, 4, 7)) !== array(2, 4, 5, 6, 2, 3, 4, 4, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(58, 44, 56)) !== array(58, 44, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return big_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 12)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 3)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find perfect squares between two given numbers.\nfunction perfect_squares($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return perfect_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 30) !== array(1, 4, 9, 16, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(50, 100) !== array(64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(100, 121, 144, 169, 196)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs($x, $y) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return opposite_Signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, -2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to interchange the first and last elements in a list.\nfunction swap_List($newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 35, 9, 56, 24)) !== array(24, 35, 9, 56, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_Of_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip($ip) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return removezero_ip(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"216.08.094.196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12.01.024\") !== \"12.1.24\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"216.08.094.0196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return diff_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps($str1, $str2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_Swaps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1101\", \"1110\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"000\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"110\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find kth element from the given two sorted arrays.\nfunction find_kth($arr1, $arr2, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_kth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 6, 7, 9), array(1, 4, 8, 10), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 112, 256, 349, 770), array(72, 86, 113, 119, 265, 445, 892), 7) !== 256) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 7, 8, 10), array(2, 5, 9, 11), 6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number($number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return armstrong_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(153) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(259) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4458) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find sum and average of first n natural numbers.\nfunction sum_average($number) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_average(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(55, 5.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== array(120, 8.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(210, 10.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth octagonal number.\nfunction is_octagonal($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_octagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 280) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 645) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given number is even or not.\nfunction is_Even($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_Even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return first_repeated_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123123\") !== \"1\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_ludic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(1, 2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(45) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return reverse_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python program\") !== \"program python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"java language\") !== \"language java\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"indian man\") !== \"man indian\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given integer is a prime number.\nfunction prime_num($num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return prime_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1010) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert degrees to radians.\nfunction radian_degree($degree) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return radian_degree(...$args);\n}\n\nfunction test(): void {\n    if (candidate(90) !== 1.5707963267948966) { throw new Exception(\"Test failed!\"); }\n    if (candidate(60) !== 1.0471975511965976) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 2.0943951023931953) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals($text, $pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_literals(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") !== array(\"fox\", 16, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its been a very crazy procedure right\", \"crazy\") !== array(\"crazy\", 16, 21)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hardest choices required strongest will\", \"will\") !== array(\"will\", 35, 39)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find nth bell number.\nfunction bell_Number($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return bell_Number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element($list1, $L) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(1, 1, 3, 4, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4) !== array(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5) !== array(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth($test_list, $N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_of_nth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6, 7), array(1, 3, 5), array(8, 9, 19)), 2) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 7, 8), array(2, 4, 6), array(9, 10, 20)), 1) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 9), array(3, 5, 7), array(10, 11, 21)), 1) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return merge(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"a\", \"b\"), array(\"m\", \"n\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8))) !== array(array(1, 3, 5, 7), array(2, 4, 6, 8))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\", \"y\", \"z\"), array(\"a\", \"b\", \"c\"), array(\"m\", \"n\", \"o\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"), array(\"z\", \"c\", \"o\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return cummulative_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 6, 7), array(2, 6))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(6, 7, 8), array(3, 7))) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8, 9), array(4, 8))) !== 44) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return average_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(10, 10, 10, 12), array(30, 45, 56, 45), array(81, 80, 39, 32), array(1, 2, 3, 4))) !== array(30.5, 34.25, 27.0, 23.25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, -5), array(30, -15, 56), array(81, -60, -39), array(-10, 2, 3))) !== array(25.5, -18.0, 3.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(100, 100, 100, 120), array(300, 450, 560, 450), array(810, 800, 390, 320), array(10, 20, 30, 40))) !== array(305.0, 342.5, 270.0, 232.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tuple_modulo(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6), array(5, 6, 7, 5)) !== array(0, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 6, 7), array(6, 7, 8, 6)) !== array(5, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 7, 8), array(7, 8, 9, 7)) !== array(5, 6, 7, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps($steps, $d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_Jumps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4), 11) !== 3.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4), 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 14), 11) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to divide two lists element wise.\nfunction div_list($nums1, $nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return div_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(1, 2, 3)) !== array(4.0, 2.5, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2), array(1, 4)) !== array(3.0, 0.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(1.8, 1.7142857142857142)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to move all the numbers to the end of the given string.\nfunction move_num($test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return move_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"I1love143you55three3000thousand\") !== \"Iloveyouthreethousand1143553000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Avengers124Assemble\") !== \"AvengersAssemble124\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its11our12path13to14see15things16do17things\") !== \"Itsourpathtoseethingsdothings11121314151617\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_Substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"112112\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1101112\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median of two sorted lists of same size.\nfunction get_median($arr1, $arr2, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 12, 15, 26, 38), array(2, 13, 17, 30, 45), 5) !== 16.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 9), array(7, 13, 19, 28), 4) !== 8.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 14, 23, 36, 42), array(2, 18, 27, 39, 49, 55), 6) !== 25.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to compute the n-th power of each number in a list.\nfunction nth_nums($nums, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return nth_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30), 3) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15), 5) !== array(248832, 759375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to convert a given string to uppercase.\nfunction is_upper($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"person\") !== \"PERSON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final\") !== \"FINAL\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Valid\") !== \"VALID\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to interchange the first and last element in a given list.\nfunction swap_List($newList) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== array(4, 2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area($r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(-1) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing($array) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_First_Missing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 6, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 8, 9)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"My Name is Dawood\") !== \"My%20Name%20is%20Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I am a Programmer\") !== \"I%20am%20a%20Programmer\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love Coding\") !== \"I%20love%20Coding\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find even numbers from a list of numbers.\nfunction Split($list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 8, 0, 1)) !== array(4, 6, 8, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 12, 15, 19)) !== array(8, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find smallest number in a list.\nfunction smallest_num($xs) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return smallest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 1, 45, 99)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(45, 46, 50, 60)) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_coordinates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4)) !== array(array(2, 3), array(2, 4), array(2, 5), array(3, 3), array(3, 4), array(3, 5), array(4, 3), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5)) !== array(array(3, 4), array(3, 5), array(3, 6), array(4, 4), array(4, 5), array(4, 6), array(5, 4), array(5, 5), array(5, 6))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6)) !== array(array(4, 5), array(4, 6), array(4, 7), array(5, 5), array(5, 6), array(5, 7), array(6, 5), array(6, 6), array(6, 7))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jumanji The Jungle\") !== \"Jumanji_The_Jungle\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"The_Avengers\") !== \"The Avengers\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Fast and Furious\") !== \"Fast_and_Furious\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to move all zeroes to the end of the given list.\nfunction move_zero($num_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return move_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 0, 2, 0, 3, 4)) !== array(1, 2, 3, 4, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 0, 0, 4, 0, 5, 0)) !== array(2, 3, 2, 4, 5, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 0, 1, 1)) !== array(1, 1, 1, 0, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum($arr, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pair_xor_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 9, 7, 6), 4) !== 47) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 5), 3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort the given list.\nfunction heap_sort($iterable) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return heap_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 25, 58)) !== array(14, 22, 25, 25, 35, 58, 65, 75, 85)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 1, 9, 5)) !== array(1, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss($actual_cost, $sale_amount) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return noprofit_noloss(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill($v, $t) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return wind_chill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(120, 35) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(40, 20) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam($sample_names) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sample_nam(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\")) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\")) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abcd\", \"Python\", \"abba\", \"aba\")) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 5), array(1, 7), array(10, 3), array(1, 2))) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(2, 17), array(9, 13), array(11, 12))) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 35), array(21, 27), array(13, 23), array(41, 22))) !== 23) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis($items) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_parenthesis(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python (chrome)\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"string(.abc)\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"alpha(num)\")) !== \"alpha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth nonagonal number.\nfunction is_nonagonal($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_nonagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 325) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 750) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== 1089) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_wordz_middle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonzabc.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zxyabc.\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K($input, $k) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return reverse_Array_Upto_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), 4) !== array(4, 3, 2, 1, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7), 2) !== array(5, 4, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5), 3) !== array(7, 8, 9, 6, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks($subjectmarks) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return subject_marks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97), array(\"Social sciences\", 82))) !== array(array(\"Social sciences\", 82), array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Telugu\", 49), array(\"Hindhi\", 54), array(\"Social\", 33))) !== array(array(\"Social\", 33), array(\"Telugu\", 49), array(\"Hindhi\", 54))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Physics\", 96), array(\"Chemistry\", 97), array(\"Biology\", 45))) !== array(array(\"Biology\", 45), array(\"Physics\", 96), array(\"Chemistry\", 97))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum($data_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return recursive_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, array(3, 4), array(5, 6))) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 10, array(15, 14), array(19, 41))) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, array(30, 40), array(50, 60))) !== 210) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of positive numbers in a list.\nfunction pos_count($list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pos_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, 3, -4)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 5, -1)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return bell_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 115975) { throw new Exception(\"Test failed!\"); }\n    if (candidate(56) !== 6775685320645824322581483068371419745979053216268760300) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic($A) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_Monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(6, 5, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist($l, $s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_sublist(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 3, 5, 7), array(3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(4, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(1, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return differ_At_One_Bit_Pos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13, 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find whether all the given lists have equal length or not.\nfunction get_equal($Input) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(11, 22, 33), array(44, 55, 66))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a list of elements.\nfunction comb_sort($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return comb_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 15, 37, 25, 79)) !== array(5, 15, 25, 37, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 32, 15, 19, 22)) !== array(15, 19, 22, 32, 41)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(99, 15, 13, 47)) !== array(13, 15, 47, 99)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple($test_tup, $test_dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_dict_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) !== array(4, 5, 6, array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) !== array(1, 2, 3, array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 10), array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) !== array(8, 9, 10, array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath($cost) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return maxAverageOfPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(6, 5, 4), array(7, 3, 9))) !== 5.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 4), array(7, 6, 5), array(8, 4, 10))) !== 6.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(8, 7, 6), array(9, 5, 11))) !== 7.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9))) !== 5.8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "php",
+    "prompt": "<?php\n// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data($students, $h, $w) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return filter_data(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 6.0, 70) !== array(\"Cierra Vega\" => array(6.2, 70))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.9, 67) !== array(\"Cierra Vega\" => array(6.2, 70), \"Kierra Gentry\" => array(6.0, 68))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.7, 64) !== array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "php",
+    "prompt": "<?php\n// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair($nums1, $nums2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_same_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 1, 2), array(0, 1, 2, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum($base, $power) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return power_base_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 100) !== 115) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 10) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 15) !== 62) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 3) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation($text1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_quotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") !== array(\"A53\", \"multi\", \"Processor\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") !== array(\"favorite\", \"apps\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") !== array(\"4k Ultra HD\", \"HDR 10\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return multiply_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(5, 35, 56, 80)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 7)) !== array(8, 20, 30, 42)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 13, 14, 9, 15)) !== array(156, 182, 126, 135)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list($lst1, $lst2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30), array(15, 25, 35)) !== array(25, 45, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(5, 6, 7)) !== array(6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 20, 30), array(15, 45, 75)) !== array(30, 65, 105)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return dif_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(10, 15, 19, 18, 17, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(\"a\", \"b\", \"c\", \"d\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\")) !== array(\"a\", \"b\", \"c\", \"d\", \"a\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone($r, $h) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return lateralsurface_cone(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 12) !== 204.20352248333654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 566.3586699569488) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 17) !== 1521.8090132193388) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return replace_specialchar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python language, Programming language.\") !== \"Python:language::Programming:language:\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c,d e f\") !== \"a:b:c:d:e:f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ram reshma,ram rahim\") !== \"ram:reshma:ram:rahim\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence($A, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_first_occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_Of_Subarray_Prod(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return toggle_middle_bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(65) !== 127) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== 115) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion($a, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return left_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str($string) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_str(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"annie\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dawood\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Else\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return geometric_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 1.9921875) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1.9375) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 1.99609375) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tuple_to_dict(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 10, 13, 5)) !== array(1 => 5, 7 => 10, 13 => 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1 => 2, 3 => 4, 5 => 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 10, 11, 12)) !== array(7 => 8, 9 => 10, 11 => 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return all_Characters_Same(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron($side) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return area_tetrahedron(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15.588457268119894) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== 692.8203230275509) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 173.20508075688772) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right($list, $m) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rotate_right(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3) !== array(8, 9, 10, 1, 2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(9, 10, 1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5) !== array(6, 7, 8, 9, 10, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given tuple has any none value or not.\nfunction check_none($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_none(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, null)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 11, 14)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, null)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits($startnum, $endnum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return divisible_by_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 22) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 15) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 25) !== array(22, 24)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area($r, $a) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sector_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 45) !== 6.283185307179586) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 45) !== 31.808625617596654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 361) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three($X, $Y, $Z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return lcs_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces($str1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return capital_words_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PythonProgrammingExamples\") !== \"Python Programming Examples\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GetReadyToBeCodingFreak\") !== \"Get Ready To Be Coding Freak\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings($nums_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sort_numeric_strings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\")) !== array(-500, -12, 0, 4, 7, 12, 45, 100, 200)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\")) !== array(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\")) !== array(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns($colors, $patterns) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_samepatterns(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"green\", \"green\"), array(\"a\", \"b\", \"b\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to add the given tuple to the given list.\nfunction add_tuple($test_list, $test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return add_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(5, 6, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(6, 7, 8, 10, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(7, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_min_heap(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 10, 15)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 5, 3, 15)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return jacobsthal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== 2731) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k($test_list, $K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return min_k(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Manjeet\", 10), array(\"Akshat\", 4), array(\"Akash\", 2), array(\"Nikhil\", 8)), 2) !== array(array(\"Akash\", 2), array(\"Akshat\", 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sanjeev\", 11), array(\"Angat\", 5), array(\"Akash\", 3), array(\"Nepin\", 9)), 3) !== array(array(\"Akash\", 3), array(\"Angat\", 5), array(\"Nepin\", 9))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"tanmay\", 14), array(\"Amer\", 11), array(\"Ayesha\", 9), array(\"SKD\", 16)), 1) !== array(array(\"Ayesha\", 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "php",
+    "prompt": "<?php\n// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list($l1, $l2, $l3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return extract_index_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 6, 5), array(0, 1, 2, 3, 4, 6, 7)) !== array(1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 6, 5, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 6, 6, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the second smallest number in a list.\nfunction second_smallest($numbers) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return second_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, -8, -2, 0, -2)) !== -2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, -0.5, 0, 2, -2, -2)) !== -0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_zero_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dsabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asbbbba\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_reverse_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"geeks\", \"best\", \"for\", \"skeeg\")) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"makes\", \"best\", \"sekam\", \"for\", \"rof\")) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal($num) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_decimal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"123.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"e666.86\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3.124587\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.1.11\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples($test_list, $K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(6, 24, 12), array(7, 9, 6), array(12, 18, 21)), 6) !== array(array(6, 24, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 25, 30), array(4, 2, 3), array(7, 8, 9)), 5) !== array(array(5, 25, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 9, 16), array(8, 16, 4), array(19, 17, 18)), 4) !== array(array(8, 16, 4))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return unique_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number($monthnum3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_monthnumber_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff($arr, $n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_min_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 3, 19, 18, 25), 6) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 6), 4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 5, 20, 9), 4) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count number of digits in a given string.\nfunction number_ctr($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return number_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"program2bedone\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wonders\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wond-1ers2\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_polite(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 13) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise($l1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pair_wise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 3, 4, 4, 5)) !== array(array(1, 1), array(1, 2), array(2, 3), array(3, 3), array(3, 4), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== array(array(1, 5), array(5, 7), array(7, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 9, 7, 10)) !== array(array(5, 1), array(1, 9), array(9, 7), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(array(1, 2), array(2, 3), array(3, 4), array(4, 5), array(5, 6), array(6, 7), array(7, 8), array(8, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count($arr, $sum) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_pairs_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1, 1), 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, -1, 5), 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 3), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3), -3) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to get the difference between two lists.\nfunction Diff($li1, $li2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 15, 20, 25, 30, 35, 40), array(25, 40, 35)) !== array(10, 20, 30, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 1)) !== array(2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(6, 7, 1)) !== array(2, 3, 6, 7)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return odd_num_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 707) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 3108) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression($exp) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_expression(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"{()}[{}]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{}][]({})\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all the words with k length in the given string.\nfunction remove_length($test_str, $K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The person is most value tet\", 3) !== \"person is most value\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"If you told me about this ok\", 4) !== \"If you me about ok\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Forces of darkeness is come into the play\", 4) !== \"Forces of darkeness is the\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring($text, $pattern) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return occurance_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming, python language\", \"python\") !== array(\"python\", 0, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"programming\") !== array(\"programming\", 7, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"language\") !== array(\"language\", 31, 39)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"c++ programming, c++ language\", \"python\") !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return odd_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 4, 3, 6, 7, 6, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels($test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"bestinstareels\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"partofthejourneyistheend\") !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"amazonprime\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 1, 1, 4, 5, 6)) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 10, 9, 4, 2, 10, 10, 45, 4)) !== 71) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 10, 9, 45, 2, 10, 10, 45, 10)) !== 78) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return pack_consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(array(0, 0), array(1), array(2), array(3), array(4, 4), array(5), array(6, 6, 6), array(7), array(8), array(9), array(4, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(array(10, 10), array(15), array(19), array(18, 18), array(17), array(26, 26), array(17), array(18), array(10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(array(\"a\", \"a\"), array(\"b\"), array(\"c\"), array(\"d\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find whether a number is divisible by 11.\nfunction is_Diff($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12345) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212112) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_combinations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 4), array(6, 7), array(5, 1), array(6, 10))) !== array(array(8, 11), array(7, 5), array(8, 14), array(11, 8), array(12, 17), array(11, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8), array(6, 2), array(7, 11))) !== array(array(10, 13), array(9, 7), array(10, 16), array(13, 10), array(14, 19), array(13, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(8, 9), array(7, 3), array(8, 12))) !== array(array(12, 15), array(11, 9), array(12, 18), array(15, 12), array(16, 21), array(15, 15))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_divisors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return odd_length_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 7)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv($r, $g, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return rgb_to_hsv(...$args);\n}\n\nfunction test(): void {\n    if (candidate(255, 255, 255) !== array(0.0, 0.0, 100.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 215, 0) !== array(120.0, 100.0, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 215, 110) !== array(149.26829268292684, 95.34883720930233, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return mul_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int($test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tuple_str_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(7, 8, 9)\") !== array(7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(1, 2, 3)\") !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(4, 5, 6)\") !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(7, 81, 19)\") !== array(7, 81, 19)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion($a, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return right_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_match_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"caacabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create a new tuple from the given string and list.\nfunction new_tuple($test_list, $test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return new_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"WEB\", \"is\"), \"best\") !== array(\"WEB\", \"is\", \"best\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"We\", \"are\"), \"Developers\") !== array(\"We\", \"are\", \"Developers\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Part\", \"is\"), \"Wrong\") !== array(\"Part\", \"is\", \"Wrong\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return even_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove tuples from the given tuple.\nfunction remove_nested($test_tup) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== array(1, 5, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, array(5, 7), 11)) !== array(2, 6, 8, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), array(5, 12), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of lists in a given number of lists.\nfunction count_list($input_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(2, 3), array(4, 5))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 0), array(2, 0))) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the last position of an element in a sorted array.\nfunction last($arr, $x) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return last(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, 4), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 3, 6, 8, 9), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return text_starta_endb(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aabbbb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabAbbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"accddbbjjj\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write function to find the sum of all items in the given dictionary.\nfunction return_sum($dict) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return return_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\" => 100, \"b\" => 200, \"c\" => 300)) !== 600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 25, \"b\" => 18, \"c\" => 45)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 36, \"b\" => 39, \"c\" => 49)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range($l, $r) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sum_in_range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== 40) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the sum of an array.\nfunction _sum($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return _sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 12, 13, 10)) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate($n, $d) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return left_rotate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(29, 3) !== 232) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to check whether the length of the word is odd or not.\nfunction word_len($s) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return word_len(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hadoop\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"great\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"structure\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces($text) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return remove_all_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python  program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python   programming    language\") !== \"pythonprogramminglanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal($x, $y, $z) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return test_three_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 1, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2, -3) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return count_rotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 1, 2, 3)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_perfect_square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(36) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(196) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15625) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even($arr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_product_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list($lists) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(10, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 2, 1), array(6, 5, 4), array(12, 11, 10))) !== array(12, 11, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 1))) !== array(2, 3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase($test_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return max_run_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"GeMKSForGERksISBESt\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PrECIOusMOVemENTSYT\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GooGLEFluTTER\") !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return first_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given tuples contain the k or not.\nfunction check_K($test_tup, $K) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, 8), 6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 44, 11, 12), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller($test_tup1, $test_tup2) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return check_smaller(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6), array(3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13), array(10, 11, 12)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return tetrahedral_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char($strr) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return get_Char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== \"f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gfg\") !== \"t\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth number in the newman conway sequence.\nfunction sequence($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return centered_hexagonal_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 271) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 217) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three($dict1, $dict2, $dict3) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return merge_dictionaries_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) !== array(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\")) !== array(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\"), array(\"G\" => \"Green\", \"W\" => \"White\")) !== array(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return freq_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)) !== array(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)) !== array(1 => 3, 2 => 2, 3 => 3, 4 => 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)) !== array(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the closest smaller number than n.\nfunction closest_num($N) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return closest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(11) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find squares of individual elements in a list.\nfunction square_nums($nums) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return square_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(100, 400, 900)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(144, 225)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the length of the longest word.\nfunction len_log($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return len_log(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python\", \"PHP\", \"bigdata\")) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"ab\", \"abc\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"small\", \"big\", \"tall\")) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring($str1, $sub_str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ack\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"abc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ange\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is undulating or not.\nfunction is_undulating($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return is_undulating(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1212121) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1991) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(121) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunction power($a, $b) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== 3125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "php",
+    "prompt": "<?php\n// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum($test_list) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return index_minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Rash\", 143), array(\"Manjeet\", 200), array(\"Varsha\", 100))) !== \"Varsha\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Yash\", 185), array(\"Dawood\", 125), array(\"Sanya\", 175))) !== \"Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sai\", 345), array(\"Salman\", 145), array(\"Ayesha\", 96))) !== \"Ayesha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length($lst) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return Find_Min_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2))) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(1, 2, 3), array(1, 2, 3, 4))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 3, 3), array(4, 4, 4, 4))) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the number of divisors of a given integer.\nfunction divisor($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists($list1) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return frequency_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 2), array(4, 5, 6, 2), array(7, 8, 9, 5))) !== array(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12))) !== array(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(20, 30, 40, 17), array(18, 16, 14, 13), array(10, 20, 30, 40))) !== array(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary($n) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== \"111\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "php",
+    "prompt": "<?php\n// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations($str) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "function candidate(...$args) {\n    return find_Rotations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/mbpp-php-reworded.json
+++ b/prompts/mbpp-php-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return lps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TENS FOR TENS\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"CARDIO FOR CARDS\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PART OF THE JOURNEY IS PART\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces($text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_whitespaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\" Google    Flutter \") !== \"GoogleFlutter\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" Google    Dart \") !== \"GoogleDart\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" iOS    Swift \") !== \"iOSSwift\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether a specified array is sorted or not.\nfunction issort_list($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return issort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 15, 14, 20)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count bidirectional array pairs.\nfunction count_bidirectional($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_bidirectional(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 3), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 2), array(6, 5), array(2, 1))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return surfacearea_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 150) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 600) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "php",
     "prompt": "<?php\n// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome($num) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return next_smallest_palindrome(...$args);\n}\n\nfunction test(): void {\n    if (candidate(99) !== 101) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1221) !== 1331) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return cube_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 800) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum($arr, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pair_xor_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 9, 7, 6), 4) !== 47) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 5), 3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_min_heap(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 10, 15)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 5, 3, 15)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the first digit of a given number.\nfunction first_Digit($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return first_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(456) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return first_non_repeating_character(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ababc\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert degrees to radians.\nfunction radian_degree($degree) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return radian_degree(...$args);\n}\n\nfunction test(): void {\n    if (candidate(90) !== 1.5707963267948966) { throw new Exception(\"Test failed!\"); }\n    if (candidate(60) !== 1.0471975511965976) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 2.0943951023931953) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_subarray_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 0, 7, -8, -2)) !== 112) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, -3, -10, 0, 2)) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -40, 0, -2, -3)) !== 80) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert more than one array to nested array.\nfunction convert_list_dictionary($l1, $l2, $l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return convert_list_dictionary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"S001\", \"S002\", \"S003\", \"S004\"), array(\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"), array(85, 98, 89, 92)) !== array(array(\"S001\" => array(\"Adina Park\" => 85)), array(\"S002\" => array(\"Leyton Marsh\" => 98)), array(\"S003\" => array(\"Duncan Boyle\" => 89)), array(\"S004\" => array(\"Saim Richards\" => 92)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"def\", \"ghi\", \"jkl\"), array(\"python\", \"program\", \"language\", \"programs\"), array(100, 200, 300, 400)) !== array(array(\"abc\" => array(\"python\" => 100)), array(\"def\" => array(\"program\" => 200)), array(\"ghi\" => array(\"language\" => 300)), array(\"jkl\" => array(\"programs\" => 400)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"A1\", \"A2\", \"A3\", \"A4\"), array(\"java\", \"C\", \"C++\", \"DBMS\"), array(10, 20, 30, 40)) !== array(array(\"A1\" => array(\"java\" => 10)), array(\"A2\" => array(\"C\" => 20)), array(\"A3\" => array(\"C++\" => 30)), array(\"A4\" => array(\"DBMS\" => 40)))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find smallest number in an array.\nfunction smallest_num($xs) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return smallest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 1, 45, 99)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(45, 46, 50, 60)) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/phpthon-exercises/re/phpthon-re-exercise-3.php\nfunction text_match_zero_one($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_zero_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dsabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asbbbba\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find nth bell number.\nfunction bell_Number($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return bell_Number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find cubes of individual elements in an array.\nfunction cube_nums($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return cube_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(1728, 3375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return last_Digit_Factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(21) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find even numbers from an array of numbers.\nfunction Split($list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 8, 0, 1)) !== array(4, 6, 8, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 12, 15, 19)) !== array(8, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given integer is a prime number.\nfunction prime_num($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return prime_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1010) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples($test_list, $K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(6, 24, 12), array(7, 9, 6), array(12, 18, 21)), 6) !== array(array(6, 24, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 25, 30), array(4, 2, 3), array(7, 8, 9)), 5) !== array(array(5, 25, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 9, 16), array(8, 16, 4), array(19, 17, 18)), 4) !== array(array(8, 16, 4))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron($side) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return area_tetrahedron(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15.588457268119894) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== 692.8203230275509) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 173.20508075688772) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given number is even or not.\nfunction is_Even($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_Even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of positive numbers in an array.\nfunction pos_count($list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pos_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, 3, -4)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 5, -1)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_ludic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(1, 2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(45) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K($input, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return reverse_Array_Upto_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), 4) !== array(4, 3, 2, 1, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7), 2) !== array(5, 4, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5), 3) !== array(7, 8, 9, 6, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks($subjectmarks) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return subject_marks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97), array(\"Social sciences\", 82))) !== array(array(\"Social sciences\", 82), array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Telugu\", 49), array(\"Hindhi\", 54), array(\"Social\", 33))) !== array(array(\"Social\", 33), array(\"Telugu\", 49), array(\"Hindhi\", 54))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Physics\", 96), array(\"Chemistry\", 97), array(\"Biology\", 45))) !== array(array(\"Biology\", 45), array(\"Physics\", 96), array(\"Chemistry\", 97))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars($string, $second_string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_dirty_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"probasscurve\", \"pros\") !== \"bacuve\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"digitalindia\", \"talent\") !== \"digiidi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"exoticmiles\", \"toxic\") !== \"emles\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return round_and_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)) !== 243) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 9, 24.3, 29)) !== 345) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25.0, 56.7, 89.2)) !== 513) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_occurrences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_decimal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"123.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"e666.86\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3.124587\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.1.11\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and integer n and filters the array to only include entries with values greater than or equal to n.\nfunction dict_filter($dict, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return dict_filter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) !== array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) !== array(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) !== array(\"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_even_and_even_index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 12, 1, 18, 8)) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 12, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum($a, $size) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_sub_array_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-2, -3, 4, -1, -2, 1, 5, -3), 8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -4, 5, -2, -3, 2, 6, -4), 8) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-4, -5, 6, -3, -4, 3, 7, -5), 8) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the intersection of two arrays.\nfunction intersection_array($array_nums1, $array_nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return intersection_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(1, 2, 4, 8, 9)) !== array(1, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(3, 5, 7, 9)) !== array(3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(10, 20, 30, 40)) !== array(10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts($list1, $L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return split_two_parts(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(array(1, 1, 2), array(3, 4, 4, 5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), 2) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"), 4) !== array(array(\"p\", \"y\", \"t\", \"h\"), array(\"o\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals($text, $pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_literals(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") !== array(\"fox\", 16, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its been a very crazy procedure right\", \"crazy\") !== array(\"crazy\", 16, 21)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hardest choices required strongest will\", \"will\") !== array(\"will\", 35, 39)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the volume of a triangular prism.\nfunction find_Volume($l, $b, $h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Volume(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 8, 6) !== 240) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill($v, $t) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return wind_chill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(120, 35) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(40, 20) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the ascii value of a character.\nfunction ascii_value($k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return ascii_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"A\") !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"R\") !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"S\") !== 83) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether all the characters are same or not.\nfunction all_Characters_Same($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return all_Characters_Same(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to move all the numbers to the end of the given string.\nfunction move_num($test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return move_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"I1love143you55three3000thousand\") !== \"Iloveyouthreethousand1143553000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Avengers124Assemble\") !== \"AvengersAssemble124\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its11our12path13to14see15things16do17things\") !== \"Itsourpathtoseethingsdothings11121314151617\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the length of the word is odd or not.\nfunction word_len($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return word_len(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hadoop\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"great\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"structure\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to drop empty items from a given array.\nfunction drop_empty($dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return drop_empty(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c1\" => \"Red\", \"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => null, \"c3\" => null)) !== array(\"c1\" => \"Red\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => null, \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element($list, $element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return insert_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Black\"), \"c\") !== array(\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\"), \"program\") !== array(\"program\", \"python\", \"program\", \"java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"happy\", \"sad\"), \"laugh\") !== array(\"laugh\", \"happy\", \"laugh\", \"sad\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_lowercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYTHon\") !== \"PYTH\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"FInD\") !== \"FID\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"STRinG\") !== \"STRG\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_Set_Bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear($test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_rear(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Mers\", \"for\", \"Vers\")) !== array(\"s\", \"r\", \"s\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Avenge\", \"for\", \"People\")) !== array(\"e\", \"r\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Gotta\", \"get\", \"go\")) !== array(\"a\", \"t\", \"o\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_occurance(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"letstdlenstdporstd\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"truststdsolensporsd\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"makestdsostdworthit\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"stds\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given arrays contain the k or not.\nfunction check_K($test_tup, $K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, 8), 6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 44, 11, 12), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists($list1, $list2, $list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return interleave_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7), array(10, 20, 30, 40, 50, 60, 70), array(100, 200, 300, 400, 500, 600, 700)) !== array(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20), array(15, 2), array(5, 10)) !== array(10, 15, 5, 20, 2, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 44), array(10, 15), array(20, 5)) !== array(11, 10, 20, 44, 15, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python_program\") !== \"PythonProgram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python_language\") !== \"PythonLanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"programming_language\") !== \"ProgrammingLanguage\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal($x, $y, $z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return test_three_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 1, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2, -3) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_length_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 7)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return bell_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 115975) { throw new Exception(\"Test failed!\"); }\n    if (candidate(56) !== 6775685320645824322581483068371419745979053216268760300) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the area of a rectangle.\nfunction rectangle_area($l, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rectangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find sum and average of first n natural numbers.\nfunction sum_average($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_average(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(55, 5.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== array(120, 8.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(210, 10.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return division_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(2, 2, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 16), array(6, 3, 4, 4)) !== array(2, 2, 2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(20, 14, 36, 18), array(5, 7, 6, 9)) !== array(4, 2, 6, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(345) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(97) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "php",
-    "prompt": "<?php\n// Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return index_minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Rash\", 143), array(\"Manjeet\", 200), array(\"Varsha\", 100))) !== \"Varsha\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Yash\", 185), array(\"Dawood\", 125), array(\"Sanya\", 175))) !== \"Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sai\", 345), array(\"Salman\", 145), array(\"Ayesha\", 96))) !== \"Ayesha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to divide two arrays element wise.\nfunction div_list($nums1, $nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return div_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(1, 2, 3)) !== array(4.0, 2.5, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2), array(1, 4)) !== array(3.0, 0.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(1.8, 1.7142857142857142)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the array with maximum length.\nfunction max_length_list($input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_length_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5), array(1, 2, 3, 4), array(1, 2, 3), array(1, 2), array(1))) !== array(5, array(1, 2, 3, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(6, 7, 8, 9), array(10, 11, 12))) !== array(4, array(6, 7, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find all possible combinations of the elements of a given array.\nfunction combinations_list($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return combinations_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"orange\", \"red\", \"green\", \"blue\")) !== array(array(), array(\"orange\"), array(\"red\"), array(\"red\", \"orange\"), array(\"green\"), array(\"green\", \"orange\"), array(\"green\", \"red\"), array(\"green\", \"red\", \"orange\"), array(\"blue\"), array(\"blue\", \"orange\"), array(\"blue\", \"red\"), array(\"blue\", \"red\", \"orange\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"orange\"), array(\"blue\", \"green\", \"red\"), array(\"blue\", \"green\", \"red\", \"orange\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"blue\"), array(\"blue\", \"red\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"red\"), array(\"white\"), array(\"white\", \"red\"), array(\"white\", \"green\"), array(\"white\", \"green\", \"red\"), array(\"white\", \"blue\"), array(\"white\", \"blue\", \"red\"), array(\"white\", \"blue\", \"green\"), array(\"white\", \"blue\", \"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"black\", \"blue\"), array(\"black\", \"blue\", \"red\"), array(\"black\", \"blue\", \"green\"), array(\"black\", \"blue\", \"green\", \"red\"), array(\"black\", \"white\"), array(\"black\", \"white\", \"red\"), array(\"black\", \"white\", \"green\"), array(\"black\", \"white\", \"green\", \"red\"), array(\"black\", \"white\", \"blue\"), array(\"black\", \"white\", \"blue\", \"red\"), array(\"black\", \"white\", \"blue\", \"green\"), array(\"black\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"blue\"), array(\"orange\", \"blue\", \"red\"), array(\"orange\", \"blue\", \"green\"), array(\"orange\", \"blue\", \"green\", \"red\"), array(\"orange\", \"white\"), array(\"orange\", \"white\", \"red\"), array(\"orange\", \"white\", \"green\"), array(\"orange\", \"white\", \"green\", \"red\"), array(\"orange\", \"white\", \"blue\"), array(\"orange\", \"white\", \"blue\", \"red\"), array(\"orange\", \"white\", \"blue\", \"green\"), array(\"orange\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"), array(\"orange\", \"black\", \"blue\"), array(\"orange\", \"black\", \"blue\", \"red\"), array(\"orange\", \"black\", \"blue\", \"green\"), array(\"orange\", \"black\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\"), array(\"orange\", \"black\", \"white\", \"red\"), array(\"orange\", \"black\", \"white\", \"green\"), array(\"orange\", \"black\", \"white\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\"), array(\"orange\", \"black\", \"white\", \"blue\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return big_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 6)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to return the negative numbers in an array.\nfunction neg_nos($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return neg_nos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 4, 5, -6)) !== array(-1, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3, 4)) !== array(-1, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-7, -6, 8, 9)) !== array(-7, -6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return highest_Power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist($l, $s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_sublist(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 3, 5, 7), array(3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(4, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(1, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to subtract two arrays element-wise.\nfunction sub_list($nums1, $nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sub_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== array(-3, -3, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 4)) !== array(-2, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(40, 50)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return opposite_Signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, -2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tuple_modulo(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6), array(5, 6, 7, 5)) !== array(0, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 6, 7), array(6, 7, 8, 6)) !== array(5, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 7, 8), array(7, 8, 9, 7)) !== array(5, 6, 7, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return diff_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) !== array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"d\", \"c\"), array(\"g\", \"h\"), array(\"f\", \"e\"))) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"), array(\"g\", \"h\"), array(\"e\", \"f\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the last digit of a given number.\nfunction last_Digit($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return last_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_num_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 707) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 3108) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert an array to a string.\nfunction tup_string($tup1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tup_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\")) !== \"exercises\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) !== \"program\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all elements from a given array present in another array.\nfunction remove_elements($list1, $list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(1, 3, 5, 7)) !== array(2, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(5, 7)) !== array(1, 2, 3, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping($list1, $list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return overlapping(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5), array(1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to identify non-prime numbers.\nfunction is_not_prime($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_not_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(35) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(37) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val($listval) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 50) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_negativenum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== -32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, -14, 13, -18, 12, -20)) !== -52) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)) !== -894) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Rotations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format($dt) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return change_date_format(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"2026-01-02\") !== \"02-01-2026\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020-11-13\") !== \"13-11-2020\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2021-04-26\") !== \"26-04-2021\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function which takes an array of integers and only returns the odd ones.\nfunction Split($list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 12, 13)) !== array(11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1)) !== array(7, 9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return toggle_middle_bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(65) !== 127) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== 115) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_char_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xbcefg\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABcED\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"AbgdeF\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product($nums1, $nums2, $N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return large_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 3) !== array(60, 54, 50)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 4) !== array(60, 54, 50, 48)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 5) !== array(60, 54, 50, 48, 45)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return cummulative_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 6, 7), array(2, 6))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(6, 7, 8), array(3, 7))) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8, 9), array(4, 8))) !== 44) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff($arr, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_min_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 3, 19, 18, 25), 6) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 6), 4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 5, 20, 9), 4) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_starta_endb(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aabbbb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabAbbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"accddbbjjj\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate($n, $d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return left_rotate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(29, 3) !== 232) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the first repeated character in a given string.\nfunction first_repeated_char($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return first_repeated_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123123\") !== \"1\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count inversions in an array.\nfunction get_Inv_Count($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_Inv_Count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 20, 6, 4, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 6, 1)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return even_Power_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1056) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 8832) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal($Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(11, 22, 33), array(44, 55, 66))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if a string represents an integer or not.\nfunction check_integer($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12345\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/phpthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_reverse_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"geeks\", \"best\", \"for\", \"skeeg\")) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"makes\", \"best\", \"sekam\", \"for\", \"rof\")) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to move all zeroes to the end of the given array.\nfunction move_zero($num_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return move_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 0, 2, 0, 3, 4)) !== array(1, 2, 3, 4, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 0, 0, 4, 0, 5, 0)) !== array(2, 3, 2, 4, 5, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 0, 1, 1)) !== array(1, 1, 1, 0, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if given array contains no duplicates.\nfunction check_distinct($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_distinct(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 5, 6, 1, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss($actual_cost, $sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return noprofit_noloss(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all the words with k length in the given string.\nfunction remove_length($test_str, $K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The person is most value tet\", 3) !== \"person is most value\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"If you told me about this ok\", 4) !== \"If you me about ok\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Forces of darkeness is come into the play\", 4) !== \"Forces of darkeness is the\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count number of digits in a given string.\nfunction number_ctr($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return number_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"program2bedone\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wonders\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wond-1ers2\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the total number of characters in a string.\nfunction count_charac($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_charac(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"words\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences($m, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_total_number_of_sequences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 3) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/phpthon-exercises/data-structures-and-algorithms/phpthon-data-structure-exercise-24.php\nfunction left_insertion($a, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return left_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return swap_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== array(20, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 17) !== array(17, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(200, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority($arr, $n, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_majority(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 3, 3, 3, 10), 7, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 4, 4, 4, 6, 6), 8, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 2), 5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2), 5, 1) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return substract_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5), array(2, 5, 18)) !== array(8, -1, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 2, 3), array(24, 45, 16)) !== array(-13, -43, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 18, 9), array(10, 11, 12)) !== array(-3, 7, -3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return capital_words_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PythonProgrammingExamples\") !== \"Python Programming Examples\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GetReadyToBeCodingFreak\") !== \"Get Ready To Be Coding Freak\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Average_Of_Cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if all values are same in an array.\nfunction check_value($dict, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tetrahedral_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test($my_matrix) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return magic_square_test(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(7, 12, 1, 14), array(2, 13, 8, 11), array(16, 3, 10, 5), array(9, 6, 15, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 8))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"cAstyoUrFavoRitETVshoWs\") !== \"cstyoravoitshos\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wAtchTheinTernEtrAdIo\") !== \"wtchheinerntrdo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"VoicESeaRchAndreComMendaTionS\") !== \"oiceachndreomendaion\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether an element exists within an array.\nfunction check_tuplex($tuplex, $tuple1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_tuplex(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"r\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), 3) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate a dog's age in dog's years.\nfunction dog_age($h_age) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return dog_age(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 61) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24) !== 109) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square($N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return next_Perfect_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(35) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create an array of N empty dictionaries.\nfunction empty_list($length) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return empty_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(array(), array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to convert a given string to uppercase.\nfunction is_upper($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"person\") !== \"PERSON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final\") !== \"FINAL\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Valid\") !== \"VALID\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent($s, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_Equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"011001\", 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011\", 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1010\", 4) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array($arr, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return re_arrange_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9) !== array(-1, -3, -7, 4, 5, 6, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, -14, -26, 13, 15), 5) !== array(-14, -26, 12, 13, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 24, 36, -42, -39, -78, 85), 7) !== array(-42, -39, -78, 10, 24, 36, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return unique_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract values between quotation marks from a string.\nfunction extract_values($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_values(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") !== array(\"Python\", \"PHP\", \"Java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") !== array(\"python\", \"program\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") !== array(\"red\", \"blue\", \"green\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count true booleans in the given array.\nfunction count($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(true, false, true)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(false, false)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(true, true, true)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair($A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_even_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return armstrong_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(153) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(259) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4458) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the upper case characters in a given string.\nfunction upper_ctr($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return upper_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYthon\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"BigData\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return and_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(0, 0, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(5, 6, 7, 8)) !== array(1, 2, 3, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 11, 12), array(7, 13, 14, 17)) !== array(0, 9, 10, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns($colors, $patterns) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_samepatterns(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"green\", \"green\"), array(\"a\", \"b\", \"b\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of arrays in a given number of arrays.\nfunction count_list($input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(2, 3), array(4, 5))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 0), array(2, 0))) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return average_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(10, 10, 10, 12), array(30, 45, 56, 45), array(81, 80, 39, 32), array(1, 2, 3, 4))) !== array(30.5, 34.25, 27.0, 23.25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, -5), array(30, -15, 56), array(81, -60, -39), array(-10, 2, 3))) !== array(25.5, -18.0, 3.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(100, 100, 100, 120), array(300, 450, 560, 450), array(810, 800, 390, 320), array(10, 20, 30, 40))) !== array(305.0, 342.5, 270.0, 232.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three($X, $Y, $Z) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return lcs_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n'th star number.\nfunction find_star_num($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_star_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of an array.\nfunction _sum($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return _sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 12, 13, 10)) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_Consecutive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_adverb_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"clearly!! we can see the sky\") !== array(0, 7, \"clearly\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"seriously!! there are many roses\") !== array(0, 9, \"seriously\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"unfortunately!! sita is going to home\") !== array(0, 13, \"unfortunately\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/phpthon-program-right-rotate-array-n/\nfunction rotate_right($list, $m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rotate_right(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3) !== array(8, 9, 10, 1, 2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(9, 10, 1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5) !== array(6, 7, 8, 9, 10, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return number_of_substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split($S, $step) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return list_split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"), 3) !== array(array(\"a\", \"d\", \"g\", \"j\", \"m\"), array(\"b\", \"e\", \"h\", \"k\", \"n\"), array(\"c\", \"f\", \"i\", \"l\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3) !== array(array(1, 4, 7, 10, 13), array(2, 5, 8, 11, 14), array(3, 6, 9, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"), 2) !== array(array(\"python\", \"C\", \"DBMS\"), array(\"java\", \"C++\", \"SQL\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check if the elements of a given array are unique or not.\nfunction all_unique($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return all_unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to convert complex numbers to polar coordinates.\nfunction convert($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return convert(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "php",
-    "prompt": "<?php\n// The input is given as - an array with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data($students, $h, $w) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return filter_data(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 6.0, 70) !== array(\"Cierra Vega\" => array(6.2, 70))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.9, 67) !== array(\"Cierra Vega\" => array(6.2, 70), \"Kierra Gentry\" => array(6.0, 68))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.7, 64) !== array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to convert the given string to lower case.\nfunction is_lower($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_lower(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"InValid\") !== \"invalid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"TruE\") !== \"true\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"SenTenCE\") !== \"sentence\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return next_power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring($str1, $sub_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ack\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"abc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ange\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace characters in a string.\nfunction replace_char($str1, $ch, $newch) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"polygon\", \"y\", \"l\") !== \"pollgon\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"character\", \"c\", \"a\") !== \"aharaater\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\", \"l\", \"a\") !== \"python\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return mul_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert an array to an array.\nfunction list_tuple($listx) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return list_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 10, 7, 4, 15, 3)) !== array(5, 10, 7, 4, 15, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 2, 3, 4, 4, 7)) !== array(2, 4, 5, 6, 2, 3, 4, 4, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(58, 44, 56)) !== array(58, 44, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return even_binomial_Coeff_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return bitwise_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(15, 6, 5, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 7, 10), array(6, 3, 4, 4)) !== array(13, 6, 3, 14)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 11), array(7, 4, 5, 6)) !== array(11, 2, 13, 13)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array($A, $B) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_Sub_Array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 5), array(1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), array(1, 2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 2), array(2, 2, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated($a, $n, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_sub_array_sum_repeated(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, -30, -1), 4, 3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 10, 20), 3, 2) !== 59) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3), 3, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the count of divisors is even. https://www.w3resource.com/phpthon-exercises/basic/phpthon-basic-1-exercise-24.php\nfunction count_divisors($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_divisors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area($r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(-1) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a given string to an array of characters.\nfunction string_to_tuple($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return string_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python 3.0\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"item1\") !== array(\"i\", \"t\", \"e\", \"m\", \"1\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.10\") !== array(\"1\", \"5\", \".\", \"1\", \"0\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"11000010001\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"10111\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011101100101\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_Primes_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_Of_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate($stdata) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_aggregate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Juan Whelan\", 90), array(\"Sabah Colley\", 88), array(\"Peter Nichols\", 7), array(\"Juan Whelan\", 122), array(\"Sabah Colley\", 84))) !== array(\"Juan Whelan\", 212)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 50), array(\"Sabah Colley\", 48), array(\"Peter Nichols\", 37), array(\"Juan Whelan\", 22), array(\"Sabah Colley\", 14))) !== array(\"Juan Whelan\", 72)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 10), array(\"Sabah Colley\", 20), array(\"Peter Nichols\", 30), array(\"Juan Whelan\", 40), array(\"Sabah Colley\", 50))) !== array(\"Sabah Colley\", 70)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort an array of elements.\nfunction comb_sort($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return comb_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 15, 37, 25, 79)) !== array(5, 15, 25, 37, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 32, 15, 19, 22)) !== array(15, 19, 22, 32, 41)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(99, 15, 13, 47)) !== array(13, 15, 47, 99)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression($exp) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_expression(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"{()}[{}]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{}][]({})\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a word containing 'z'.\nfunction text_match_wordz($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_wordz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list($lst1, $lst2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30), array(15, 25, 35)) !== array(25, 45, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(5, 6, 7)) !== array(6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 20, 30), array(15, 45, 75)) !== array(30, 65, 105)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return newman_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 17) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 41) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to apply a given format string to all of the elements in an array.\nfunction add_string($list_, $string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), \"temp{0}\") !== array(\"temp1\", \"temp2\", \"temp3\", \"temp4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), \"python{0}\") !== array(\"pythona\", \"pythonb\", \"pythonc\", \"pythond\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8), \"string{0}\") !== array(\"string5\", \"string6\", \"string7\", \"string8\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the surface area of a square phpramid with a given base edge and height.\nfunction surface_Area($b, $s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return surface_Area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Find_Min_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2))) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(1, 2, 3), array(1, 2, 3, 4))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 3, 3), array(4, 4, 4, 4))) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return validate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1234) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(51241) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(321) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth hexagonal number.\nfunction hexagonal_num($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return hexagonal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 190) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 91) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n'th lucas number.\nfunction find_lucas($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_lucas(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 76) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to get the difference between two arrays.\nfunction Diff($li1, $li2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 15, 20, 25, 30, 35, 40), array(25, 40, 35)) !== array(10, 20, 30, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 1)) !== array(2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(6, 7, 1)) !== array(2, 3, 6, 7)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation($text1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_quotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") !== array(\"A53\", \"multi\", \"Processor\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") !== array(\"favorite\", \"apps\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") !== array(\"4k Ultra HD\", \"HDR 10\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum($data_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return recursive_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, array(3, 4), array(5, 6))) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 10, array(15, 14), array(19, 41))) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, array(30, 40), array(50, 60))) !== 210) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return differ_At_One_Bit_Pos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13, 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"caacabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 100, 4, 5, 150, 6)) !== 3000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 42, 55, 68, 80)) !== 50265600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 22, 9, 33, 21, 50, 41, 60)) !== 2460) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr($l, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return split_Arr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 10, 5, 6, 52, 36), 2) !== array(5, 6, 52, 36, 12, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 1) !== array(2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 4, 5, 6, 7), 3) !== array(3, 4, 5, 6, 7, 0, 1, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the number of divisors of a given integer.\nfunction divisor($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return big_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 12)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 3)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find squares of individual elements in an array.\nfunction square_nums($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return square_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(100, 400, 900)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(144, 225)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given array has any none value or not.\nfunction check_none($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_none(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, null)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 11, 14)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, null)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic($A) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_Monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(6, 5, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_perfect_square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(36) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(196) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15625) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of common divisors of two given numbers.\nfunction sum($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 15) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 150) !== 93) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 6) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the array of maximum length in an array of arrays.\nfunction max_length($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(5, 7), array(10, 12, 14, 15))) !== array(4, array(10, 12, 14, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5), array(15, 20, 25))) !== array(3, array(15, 20, 25))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array of arrays and returns an array mapping each unique array to the number of times it occurs in the array.\nfunction check_occurences($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_occurences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 1), array(1, 3), array(2, 5), array(5, 2), array(6, 3))) !== array(array(1, 3) => 2, array(2, 5) => 2, array(3, 6) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 2), array(2, 4), array(3, 6), array(6, 3), array(7, 4))) !== array(array(2, 4) => 2, array(3, 6) => 2, array(4, 7) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(13, 2), array(11, 23), array(12, 25), array(25, 12), array(16, 23))) !== array(array(2, 13) => 1, array(11, 23) => 1, array(12, 25) => 2, array(16, 23) => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the directrix of a parabola.\nfunction parabola_directrix($a, $b, $c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return parabola_directrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3, 2) !== -198) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 8, 4) !== -2336) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4, 6) !== -130) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\nfunction occurance_substring($text, $pattern) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return occurance_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming, python language\", \"python\") !== array(\"python\", 0, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"programming\") !== array(\"programming\", 7, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"language\") !== array(\"language\", 31, 39)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"c++ programming, c++ language\", \"python\") !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove arrays from the given array.\nfunction remove_nested($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== array(1, 5, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, array(5, 7), 11)) !== array(2, 6, 8, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), array(5, 12), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists($input_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\" red \", \"green\"), array(\"blue \", \" black\"), array(\" orange\", \"brown\"))) !== array(array(\" red \", \"green\"), array(\" black\", \"blue \"), array(\" orange\", \"brown\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"zilver\", \"gold\"), array(\"magnesium\", \"aluminium\"), array(\"steel\", \"bronze\"))) !== array(array(\"gold\", \"zilver\"), array(\"aluminium\", \"magnesium\"), array(\"bronze\", \"steel\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element($list1, $L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(1, 1, 3, 4, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4) !== array(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5) !== array(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to add an array to the array. The output should be an array.\nfunction add_dict_to_tuple($test_tup, $test_dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_dict_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) !== array(4, 5, 6, array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) !== array(1, 2, 3, array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 10), array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) !== array(8, 9, 10, array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find($n, $m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_two_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence($tup, $lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_Occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"a\", \"c\", \"b\", \"d\"), array(\"a\", \"b\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1, 4, 6, 7, 1, 4), array(1, 4, 7)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair($list1, $list2, $list3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_samepair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9), array(2, 1, 3, 1, 2, 6, 7, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 2, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to toggle the case of all characters in a string.\nfunction toggle_string($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return toggle_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"pYTHON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pangram\") !== \"pANGRAM\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"LIttLE\") !== \"liTTle\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the element of an array having maximum length.\nfunction Find_Max($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Find_Max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"A\"), array(\"A\", \"B\"), array(\"A\", \"B\", \"C\"))) !== array(\"A\", \"B\", \"C\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 2, 3), array(1, 5, 6, 1))) !== array(1, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num($n, $m) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return eulerian_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 1) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 1) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 26) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of occurrences of a number in a given array.\nfunction frequency($a, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return frequency(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 3, 4), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 1, 2), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/phpthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings($nums_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_numeric_strings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\")) !== array(-500, -12, 0, 4, 7, 12, 45, 100, 200)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\")) !== array(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\")) !== array(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/phpthon-exercises/data-structures-and-algorithms/phpthon-recursion-exercise-9.php\nfunction geometric_sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return geometric_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 1.9921875) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1.9375) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 1.99609375) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/phpthon-exercises/lambda/phpthon-lambda-exercise-24.php\nfunction divisible_by_digits($startnum, $endnum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return divisible_by_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 22) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 15) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 25) !== array(22, 24)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product($list_data) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return unique_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30, 40, 20, 50, 60, 40)) !== 720000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 0, 1, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the largest negative number from the given array.\nfunction largest_neg($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return largest_neg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, -4, -6)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -8, -9)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(10, 15, 19, 18, 17, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(\"a\", \"b\", \"c\", \"d\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\")) !== array(\"a\", \"b\", \"c\", \"d\", \"a\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps($steps, $d) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_Jumps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4), 11) !== 3.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4), 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 14), 11) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find a pair with highest product from a given array of integers.\nfunction max_Product($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_Product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 7, 0, 8, 4)) !== array(7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, -1, -2, -4, 5, 0, -6)) !== array(-4, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element($list1, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_nth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 0) !== array(\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 2) !== array(99, 96, 94, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 1) !== array(98, 97, 91, 94)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth nonagonal number.\nfunction is_nonagonal($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_nonagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 325) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 750) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== 1089) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_Abs_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 3, 2, 5, 1)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pack_consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(array(0, 0), array(1), array(2), array(3), array(4, 4), array(5), array(6, 6, 6), array(7), array(8), array(9), array(4, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(array(10, 10), array(15), array(19), array(18, 18), array(17), array(26, 26), array(17), array(18), array(10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(array(\"a\", \"a\"), array(\"b\"), array(\"c\"), array(\"d\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum of perrin numbers.\nfunction cal_sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return cal_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 88) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string($str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_values_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcdef\") !== \"ace\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\") !== \"pto\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== \"dt\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lambs\") !== \"lms\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find kth element from the given two sorted arrays.\nfunction find_kth($arr1, $arr2, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_kth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 6, 7, 9), array(1, 4, 8, 10), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 112, 256, 349, 770), array(72, 86, 113, 119, 265, 445, 892), 7) !== 256) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 7, 8, 10), array(2, 5, 9, 11), 6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return jacobsthal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== 2731) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find frequency of each element in a flattened array of arrays, returned in an array.\nfunction frequency_lists($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return frequency_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 2), array(4, 5, 6, 2), array(7, 8, 9, 5))) !== array(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12))) !== array(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(20, 30, 40, 17), array(18, 16, 14, 13), array(10, 20, 30, 40))) !== array(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find perfect squares between two given numbers.\nfunction perfect_squares($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return perfect_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 30) !== array(1, 4, 9, 16, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(50, 100) !== array(64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(100, 121, 144, 169, 196)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_Of_Subarray_Prod(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the first odd number in a given array of numbers.\nfunction first_odd($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return first_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_nested_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(7, 10), array(7, 14), array(3, 10), array(8, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(9, 12), array(9, 16), array(5, 12), array(10, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(11, 14), array(11, 18), array(7, 14), array(12, 17))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return merge(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"a\", \"b\"), array(\"m\", \"n\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8))) !== array(array(1, 3, 5, 7), array(2, 4, 6, 8))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\", \"y\", \"z\"), array(\"a\", \"b\", \"c\"), array(\"m\", \"n\", \"o\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"), array(\"z\", \"c\", \"o\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return dif_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_smaller(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6), array(3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13), array(10, 11, 12)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to get the frequency of all the elements in an array, returned as an array.\nfunction freq_count($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return freq_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)) !== array(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)) !== array(1 => 3, 2 => 2, 3 => 3, 4 => 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)) !== array(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv($r, $g, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rgb_to_hsv(...$args);\n}\n\nfunction test(): void {\n    if (candidate(255, 255, 255) !== array(0.0, 0.0, 100.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 215, 0) !== array(120.0, 100.0, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 215, 110) !== array(149.26829268292684, 95.34883720930233, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to flatten a given nested array structure.\nfunction flatten_list($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return flatten_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 10, array(20, 30), 40, 50, array(60, 70, 80), array(90, 100, 110, 120))) !== array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(40), array(30, 56, 25), array(10, 20), array(33), array(40))) !== array(10, 20, 40, 30, 56, 25, 10, 20, 33, 40)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_str(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"annie\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dawood\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Else\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number($monthnum3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_monthnumber_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort the given array.\nfunction heap_sort($iterable) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return heap_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 25, 58)) !== array(14, 22, 25, 25, 35, 58, 65, 75, 85)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 1, 9, 5)) !== array(1, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs($nums1, $nums2, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return k_smallest_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 2) !== array(array(1, 2), array(1, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 1) !== array(array(1, 2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 7) !== array(array(1, 2), array(1, 4), array(3, 2), array(1, 6), array(3, 4), array(3, 6), array(7, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns integers x and y that satisfy ax + by = n as an array, or return null if no solution exists.\nfunction find_solution($a, $b, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 7) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 7) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 13, 17) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Max_Num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 321) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 1)) !== 6541) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 9)) !== 9321) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list($lists) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(10, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 2, 1), array(6, 5, 4), array(12, 11, 10))) !== array(12, 11, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 1))) !== array(2, 3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to interchange the first and last elements in an array.\nfunction swap_List($newList) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 35, 9, 56, 24)) !== array(24, 35, 9, 56, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median of two sorted arrays of same size.\nfunction get_median($arr1, $arr2, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 12, 15, 26, 38), array(2, 13, 17, 30, 45), 5) !== 16.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 9), array(7, 13, 19, 28), 4) !== 8.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 14, 23, 36, 42), array(2, 18, 27, 39, 49, 55), 6) !== 25.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jumanji The Jungle\") !== \"Jumanji_The_Jungle\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"The_Avengers\") !== \"The Avengers\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Fast and Furious\") !== \"Fast_and_Furious\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent($num1, $num2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return are_equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(36, 57) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 47) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list($stringlist) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return reverse_string_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\", \"White\", \"Black\")) !== array(\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"john\", \"amal\", \"joel\", \"george\")) !== array(\"nhoj\", \"lama\", \"leoj\", \"egroeg\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"jack\", \"john\", \"mary\")) !== array(\"kcaj\", \"nhoj\", \"yram\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_of_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 2, 56)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20, 4, 5, \"b\", 70, \"a\"))) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, -4, 5, -70)) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth number in the newman conway sequence.\nfunction sequence($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest($nums, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return heap_queue_largest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 3) !== array(85, 75, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 2) !== array(85, 75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 5) !== array(85, 75, 65, 58, 35)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount($actual_cost, $sale_amount) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return loss_amount(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== 3000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return union_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 4, 5, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(3, 4, 5, 6)) !== array(1, 2, 3, 4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13, 14), array(13, 15, 16, 17)) !== array(11, 12, 13, 14, 15, 16, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the length of the longest subarrays.\nfunction Find_Max_Length($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Find_Max_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 4), array(5, 6, 7, 8))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 1), array(2, 2), array(3, 2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7), array(22, 23), array(13, 14, 15), array(10, 20, 30, 40, 50))) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis($items) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_parenthesis(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python (chrome)\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"string(.abc)\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"alpha(num)\")) !== \"alpha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find whether the parity of a given number is odd.\nfunction find_Parity($x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Parity(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median length of a trapezium.\nfunction median_trapezium($base1, $base2, $height) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return median_trapezium(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15, 25, 35) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 20, 30) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 9, 4) !== 7.5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return centered_hexagonal_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 271) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 217) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find number of arrays present in the given array.\nfunction find_lists($Input) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5, 4, 3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(60) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the length of the longest word.\nfunction len_log($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return len_log(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python\", \"PHP\", \"bigdata\")) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"ab\", \"abc\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"small\", \"big\", \"tall\")) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\nfunction sector_area($r, $a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sector_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 45) !== 6.283185307179586) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 45) !== 31.808625617596654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 361) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return odd_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 4, 3, 6, 7, 6, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single($L) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return multiple_to_single(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 33, 50)) !== 113350) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4, 5, 6)) !== -123456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, 20, 25)) !== 10152025) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find whether a number is divisible by 11.\nfunction is_Diff($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12345) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212112) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return index_multiplication(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 21), array(12, 45), array(2, 9), array(7, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(14, 32), array(20, 60), array(6, 20), array(16, 44))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(24, 45), array(30, 77), array(12, 33), array(27, 60))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert array string to integer array.\nfunction tuple_str_int($test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tuple_str_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(7, 8, 9)\") !== array(7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(1, 2, 3)\") !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(4, 5, 6)\") !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(7, 81, 19)\") !== array(7, 81, 19)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum($limit) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return amicable_numbers_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(999) !== 504) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9999) !== 31626) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove odd characters in a string.\nfunction remove_odd($str1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== \"yhn\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== \"rga\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== \"agae\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return multiply_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(5, 35, 56, 80)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 7)) !== array(8, 20, 30, 42)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 13, 14, 9, 15)) !== array(156, 182, 126, 135)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_rotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 1, 2, 3)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_freq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 4), array(1, 2), array(4, 3), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 15), array(2, 3), array(5, 4), array(6, 7))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 16), array(2, 3), array(6, 5), array(6, 9))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "php",
-    "prompt": "<?php\n// The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair($nums1, $nums2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_same_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 1, 2), array(0, 1, 2, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunction power($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== 3125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write function to find the sum of all items in the given array.\nfunction return_sum($dict) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return return_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\" => 100, \"b\" => 200, \"c\" => 300)) !== 600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 25, \"b\" => 18, \"c\" => 45)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 36, \"b\" => 39, \"c\" => 49)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise($l1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pair_wise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 3, 4, 4, 5)) !== array(array(1, 1), array(1, 2), array(2, 3), array(3, 3), array(3, 4), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== array(array(1, 5), array(5, 7), array(7, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 9, 7, 10)) !== array(array(5, 1), array(1, 9), array(9, 7), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(array(1, 2), array(2, 3), array(3, 4), array(4, 5), array(5, 6), array(6, 7), array(7, 8), array(8, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to split a string into characters.\nfunction split($word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Name\") !== array(\"N\", \"a\", \"m\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find minimum of three numbers.\nfunction min_of_three($a, $b, $c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 15, 18) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -20, -30) !== -30) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_Sum_Of_Powers_Of_Two(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char($strr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_Char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== \"f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gfg\") !== \"t\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return the sum of all divisors of a number.\nfunction sum_div($number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_div(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function that returns the number of integer elements in a given array.\nfunction count_integer($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, \"abc\", 1.2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1.2, 4, 5.1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return two_unique_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 2, 3, 4, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 5)) !== array(1, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate($arraynums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return test_duplicate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2, 3, 3, 4, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which returns nth catalan number.\nfunction catalan_number($num) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return catalan_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 16796) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 4862) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 429) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum($base, $power) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return power_base_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 100) !== 115) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 10) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 15) !== 62) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 3) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list($list1, $list2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8)) !== array(1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"blue\", \"green\"), array(\"yellow\")) !== array(\"red\", \"blue\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth octagonal number.\nfunction is_octagonal($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_octagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 280) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 645) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank($str1, $char) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_blank(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello people\", \"@\") !== \"hello@people\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python program language\", \"$\") !== \"python$program$language\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"blank space\", \"-\") !== \"blank-space\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_specialchar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python language, Programming language.\") !== \"Python:language::Programming:language:\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c,d e f\") !== \"a:b:c:d:e:f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ram reshma,ram rahim\") !== \"ram:reshma:ram:rahim\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tuple_to_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 123) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== 456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7)) !== 567) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle($w, $h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return otherside_rightangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 8) !== 10.63014581273465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 15) !== 16.55294535724685) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items($items, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return expensive_items(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09)), 2) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-1\", \"price\" => 101.1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09), array(\"name\" => \"Item-4\", \"price\" => 22.75)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums($n1, $n2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return digit_distance_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 56) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123, 256) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_match_wordz_middle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonzabc.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zxyabc.\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip($ip) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return removezero_ip(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"216.08.094.196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12.01.024\") !== \"12.1.24\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"216.08.094.0196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list($list1, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_element_in_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(1, 11), array(1, 15, 7)), 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"A\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"E\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to multiply two integers.\nfunction multiply_int($x, $y) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return multiply_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_pairwise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(6, 12, 15, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, 9, 11)) !== array(8, 14, 17, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, 10, 12)) !== array(10, 16, 19, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple($list1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 484) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4429,7 +19,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element($arr, $k) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 3, 5, 7, 19), 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(17, 24, 8, 23), 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(16, 21, 25, 36, 4), 4) !== 36) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to interchange the first and last element in a given array.\nfunction swap_List($newList) {\n",
+    "prompt": "<?php\n// Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== array(4, 2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python_program\") !== \"PythonProgram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python_language\") !== \"PythonLanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"programming_language\") !== \"ProgrammingLanguage\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num($n, $m) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_first_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 9, array(5, 7), 11)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 5, 8, array(2, 3), 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return eulerian_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 1) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 1) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 26) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "php",
-    "prompt": "<?php\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion($a, $x) {\n",
+    "prompt": "<?php\n// Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists($input_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return right_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\" red \", \"green\"), array(\"blue \", \" black\"), array(\" orange\", \"brown\"))) !== array(array(\" red \", \"green\"), array(\" black\", \"blue \"), array(\" orange\", \"brown\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"zilver\", \"gold\"), array(\"magnesium\", \"aluminium\"), array(\"steel\", \"bronze\"))) !== array(array(\"gold\", \"zilver\"), array(\"aluminium\", \"magnesium\"), array(\"bronze\", \"steel\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "php",
-    "prompt": "<?php\n// Write a function to check if the given number is woodball or not.\nfunction is_woodall($x) {\n",
+    "prompt": "<?php\n// Write a phpthon function to count true booleans in the given array.\nfunction count($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_woodall(...$args);\n}\n\nfunction test(): void {\n    if (candidate(383) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(254) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(true, false, true)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(false, false)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(true, true, true)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "php",
-    "prompt": "<?php\n// Write a function to sort the given array by using shell sort.\nfunction shell_sort($my_list) {\n",
+    "prompt": "<?php\n// Write a function to append the given array to the given arrays.\nfunction add_lists($test_list, $test_tup) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return shell_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)) !== array(2, 3, 4, 5, 12, 12, 23, 56, 81, 95)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(24, 22, 39, 34, 87, 73, 68)) !== array(22, 24, 34, 39, 68, 73, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(32, 30, 16, 96, 82, 83, 74)) !== array(16, 30, 32, 74, 82, 83, 96)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return add_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(9, 10, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(10, 11, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair($A, $N) {\n",
+    "prompt": "<?php\n// Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list($num1, $num2, $num3) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Odd_Pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11), 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return merge_sorted_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 24, 15, 4, 5, 29, 110), array(19, 20, 11, 56, 25, 233, 154), array(24, 26, 54, 48)) !== array(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, 6, 8, 9), array(2, 5, 7, 11), array(1, 4, 7, 8, 12)) !== array(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), array(25, 35, 22, 85, 14, 65, 75, 25, 58), array(12, 74, 9, 50, 61, 41)) !== array(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range($l, $r) {\n",
+    "prompt": "<?php\n// Write a phpthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent($s, $n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_in_range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== 40) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return odd_Equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"011001\", 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011\", 5) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1010\", 4) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "php",
-    "prompt": "<?php\n// Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter($a) {\n",
+    "prompt": "<?php\n// Write a function to check if a string represents an integer or not.\nfunction check_integer($text) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return square_perimeter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return check_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12345\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite($n) {\n",
+    "prompt": "<?php\n// Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_polite(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 13) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_series(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar($test_tup1, $test_tup2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_dissimilar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(7, 2, 3, 9)) !== array(1, 4, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 11, 25, 26), array(26, 34, 21, 36)) !== array(34, 36, 11, 25)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp($words) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return start_withp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python PHP\", \"Java JavaScript\", \"c c++\")) !== array(\"Python\", \"PHP\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python Programming\", \"Java Programming\")) !== array(\"Python\", \"Programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Pqrst Pqr\", \"qrstuv\")) !== array(\"Pqrst\", \"Pqr\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"android_tv\") !== \"AndroidTv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"google_pixel\") !== \"GooglePixel\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple_watch\") !== \"AppleWatch\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the volume of a cube given its side length.\nfunction volume_cube($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return volume_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number($monthnum2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_monthnumb_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range($n, $l, $r) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return all_Bits_Set_In_The_Given_Range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 1, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 2, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(39, 4, 6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to get the first element of each subarray.\nfunction Extract($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2), array(3, 4, 5), array(6, 7, 8, 9))) !== array(1, 3, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5))) !== array(1, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(9, 8, 1), array(1, 2))) !== array(9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder($r, $h) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return surfacearea_cylinder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 5) !== 942.45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 226.18800000000002) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 10) !== 351.848) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam($sample_names) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sample_nam(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\")) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\")) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abcd\", \"Python\", \"abba\", \"aba\")) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rearrange_bigger(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(102) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon($a) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return perimeter_pentagon(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 75) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 15, 51, 45, 33, 100, 12, 18, 9)) !== 194) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(80, 60, 30, 40, 20, 10)) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 14, 16, 21, 23, 29, 30)) !== 138) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even($test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, array(7, 6, array(2, 4)), 6, 8)) !== array(4, array(6, array(2, 4)), 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(8, 7, array(4, 8)), 7, 9)) !== array(6, array(8, array(4, 8)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(9, 8, array(4, 6)), 8, 10)) !== array(6, array(8, array(4, 6)), 8, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return tuple_to_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 123) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== 456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7)) !== 567) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -4789,249 +169,9 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to convert all possible convertible elements in an array of arrays to floats.\nfunction list_to_float($test_list) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return list_to_float(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"3\", \"4\"), array(\"1\", \"26.45\"), array(\"7.32\", \"8\"), array(\"4\", \"8\"))) !== array(array(3.0, 4.0), array(1.0, 26.45), array(7.32, 8.0), array(4.0, 8.0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"4\", \"4\"), array(\"2\", \"27\"), array(\"4.12\", \"9\"), array(\"7\", \"11\"))) !== array(array(4.0, 4.0), array(2.0, 27.0), array(4.12, 9.0), array(7.0, 11.0))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"6\", \"78\"), array(\"5\", \"26.45\"), array(\"1.33\", \"4\"), array(\"82\", \"13\"))) !== array(array(6.0, 78.0), array(5.0, 26.45), array(1.33, 4.0), array(82.0, 13.0))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count($arr, $sum) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_pairs_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1, 1), 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, -1, 5), 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 3), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3), -3) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways($n, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_no_of_ways(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 4) !== 228) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return reverse_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python program\") !== \"program python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"java language\") !== \"language java\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"indian man\") !== \"man indian\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check if a given number is one less than twice its reverse.\nfunction checks($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return checks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(70) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(73) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the last position of an element in a sorted array.\nfunction last($arr, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return last(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, 4), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 3, 6, 8, 9), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X($tup, $x) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_X(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "php",
-    "prompt": "<?php\n// We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list($l1, $l2, $l3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_index_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 6, 5), array(0, 1, 2, 3, 4, 6, 7)) !== array(1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 6, 5, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 6, 6, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the second smallest number in an array.\nfunction second_smallest($numbers) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return second_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, -8, -2, 0, -2)) !== -2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, -0.5, 0, 2, -2, -2)) !== -0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple($test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return concatenate_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"ID\", \"is\", 4, \"UTS\")) !== \"ID-is-4-UTS\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"QWE\", \"is\", 4, \"RTY\")) !== \"QWE-is-4-RTY\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"ZEN\", \"is\", 4, \"OP\")) !== \"ZEN-is-4-OP\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces($string) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"My Name is Dawood\") !== \"My%20Name%20is%20Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I am a Programmer\") !== \"I%20am%20a%20Programmer\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love Coding\") !== \"I%20love%20Coding\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list($list1, $m, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sum_range_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10) !== 38) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to merge three dictionaries into a single array.\nfunction merge_dictionaries_three($dict1, $dict2, $dict3) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return merge_dictionaries_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) !== array(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\")) !== array(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\"), array(\"G\" => \"Green\", \"W\" => \"White\")) !== array(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the minimum of two numbers.\nfunction minimum($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-5, -4) !== -5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 5), array(1, 7), array(10, 3), array(1, 2))) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(2, 17), array(9, 13), array(11, 12))) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 35), array(21, 27), array(13, 23), array(41, 22))) !== 23) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find element at a given index after number of rotations.\nfunction find_Element($arr, $ranges, $rotations, $index) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(array(0, 2), array(0, 3)), 2, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(array(0, 1), array(0, 2)), 1, 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(array(0, 1), array(0, 2)), 1, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5044,7 +184,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to convert a string to an array of strings split on the space character.\nfunction string_to_list($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return string_to_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== array(\"python\", \"programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lists tuples strings\") !== array(\"lists\", \"tuples\", \"strings\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"write a program\") !== array(\"write\", \"a\", \"program\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "php",
     "prompt": "<?php\n// Write a phpthon function to find the element that appears only once in a sorted array.\nfunction search($arr) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 4, 4)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort an array by value.\nfunction sort_counter($dict1) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_counter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) !== array(array(\"Chemistry\", 87), array(\"Physics\", 83), array(\"Math\", 81))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) !== array(array(\"Math\", 400), array(\"Physics\", 300), array(\"Chemistry\", 250))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) !== array(array(\"Chemistry\", 1250), array(\"Physics\", 1000), array(\"Math\", 900))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5089,7 +214,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a phpthon function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ($s, $ch) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return remove_Occ(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello\", \"l\") !== \"heo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcda\", \"a\") !== \"bcd\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PHP\", \"P\") !== \"H\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube($l) {\n",
+    "prompt": "<?php\n// Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple($list1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return lateralsurface_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 324) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 400) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return max_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 484) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "php",
-    "prompt": "<?php\n// Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element($list1, $list2) {\n",
+    "prompt": "<?php\n// Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum($limit) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return common_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\"), array(\"d\", \"b\", \"e\")) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return amicable_numbers_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(999) !== 504) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9999) !== 31626) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "php",
-    "prompt": "<?php\n// Write a function to append the given array to the given arrays.\nfunction add_lists($test_list, $test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length($string) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(9, 10, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(10, 11, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return find_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"11000010001\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"10111\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"11011101100101\") !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "php",
-    "prompt": "<?php\n// Write a function to compute the n-th power of each number in an array.\nfunction nth_nums($nums, $n) {\n",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of common divisors of two given numbers.\nfunction sum($a, $b) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return nth_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30), 3) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15), 5) !== array(248832, 759375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 15) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 150) !== 93) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 6) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "php",
-    "prompt": "<?php\n// Write a function to sort an array of elements.\nfunction pancake_sort($nums) {\n",
+    "prompt": "<?php\n// Write a function to multiply two integers.\nfunction multiply_int($x, $y) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return pancake_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 79, 25, 38, 69)) !== array(15, 25, 38, 69, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(98, 12, 54, 36, 85)) !== array(12, 36, 54, 85, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 42, 32, 12, 23)) !== array(12, 23, 32, 41, 42)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the median of three numbers.\nfunction median_numbers($a, $b, $c) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return median_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(25, 55, 65) !== 55.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 10, 30) !== 20.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 45, 75) !== 45.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater($arr, $number) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_greater(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6), 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 4, 8, 6, 1), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element($list, $element) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"green\", \"orange\", \"black\", \"white\"), \"blue\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"green\", \"green\", \"green\", \"green\"), \"green\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string($str, $l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return extract_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 8) !== array(\"practice\", \"solution\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 6) !== array(\"Python\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 9) !== array(\"exercises\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return text_lowercase_underscore(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aab_cbbbc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aab_Abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Aaab_abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to trim each array by k in the given arrays.\nfunction trim_tuple($test_list, $K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return trim_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 2) !== array(array(2), array(9), array(2), array(2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 1) !== array(array(3, 2, 1), array(4, 9, 2), array(1, 2, 3), array(8, 2, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 4, 9), array(11, 8, 12, 4), array(4, 1, 7, 8), array(3, 6, 9, 7)), 1) !== array(array(8, 4), array(8, 12), array(1, 7), array(6, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the subarray having minimum length.\nfunction Find_Min($lst) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return Find_Min(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 1, 1), array(1, 2, 7, 8))) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\"), array(\"x\", \"y\"), array(\"x\", \"y\", \"z\"))) !== array(\"x\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to filter odd numbers.\nfunction filter_oddnumbers($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return filter_oddnumbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 45, 67, 84, 93)) !== array(45, 67, 93)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 9, 8, 6, 4, 3)) !== array(5, 7, 9, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_adverbs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Clearly, he has no excuse for such behavior.\") !== \"0-7: Clearly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Please handle the situation carefuly\") !== \"28-36: carefuly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Complete the task quickly\") !== \"18-25: quickly\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "php",
-    "prompt": "<?php\n// Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth($test_list, $N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_of_nth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6, 7), array(1, 3, 5), array(8, 9, 19)), 2) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 7, 8), array(2, 4, 6), array(9, 10, 20)), 1) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 9), array(3, 5, 7), array(10, 11, 21)), 1) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== \"111\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors($l, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return combinations_colors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 1) !== array(array(\"Red\"), array(\"Green\"), array(\"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 2) !== array(array(\"Red\", \"Red\"), array(\"Red\", \"Green\"), array(\"Red\", \"Blue\"), array(\"Green\", \"Green\"), array(\"Green\", \"Blue\"), array(\"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 3) !== array(array(\"Red\", \"Red\", \"Red\"), array(\"Red\", \"Red\", \"Green\"), array(\"Red\", \"Red\", \"Blue\"), array(\"Red\", \"Green\", \"Green\"), array(\"Red\", \"Green\", \"Blue\"), array(\"Red\", \"Blue\", \"Blue\"), array(\"Green\", \"Green\", \"Green\"), array(\"Green\", \"Green\", \"Blue\"), array(\"Green\", \"Blue\", \"Blue\"), array(\"Blue\", \"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces($text) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_all_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python  program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python   programming    language\") !== \"pythonprogramminglanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps($str1, $str2) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_Swaps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1101\", \"1110\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"000\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"110\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to create a new array from the given string and array.\nfunction new_tuple($test_list, $test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return new_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"WEB\", \"is\"), \"best\") !== array(\"WEB\", \"is\", \"best\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"We\", \"are\"), \"Developers\") !== array(\"We\", \"are\", \"Developers\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Part\", \"is\"), \"Wrong\") !== array(\"Part\", \"is\", \"Wrong\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the product of the array multiplication modulo n.\nfunction find_remainder($arr, $n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_remainder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(100, 10, 5, 25, 35, 14), 11) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val($listval) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count($nums) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return positive_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)) !== 0.54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 0.69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== 0.56) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to add the given array to the given array.\nfunction add_tuple($test_list, $test_tup) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return add_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(5, 6, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(6, 7, 8, 10, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(7, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase($test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_run_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"GeMKSForGERksISBESt\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PrECIOusMOVemENTSYT\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GooGLEFluTTER\") !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix($M) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sort_matrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(2, 4, 5), array(1, 1, 1))) !== array(array(1, 1, 1), array(1, 2, 3), array(2, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(-2, 4, -5), array(1, -1, 1))) !== array(array(-2, 4, -5), array(1, -1, 1), array(1, 2, 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 8, 9), array(6, 4, 3), array(2, 1, 4))) !== array(array(2, 1, 4), array(6, 4, 3), array(5, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels($test_str) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"bestinstareels\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"partofthejourneyistheend\") !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"amazonprime\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq($a, $n, $index, $k) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return max_sum_increasing_subseq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 4, 6) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 2, 5) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 19, 21, 26, 28, 31), 7, 2, 4) !== 71) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return multiply_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 8) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5524,7 +304,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find words that are longer than n characters from a given array of words.\nfunction long_words($n, $str) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return long_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, \"python is a programming language\") !== array(\"python\", \"programming\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, \"writing a program\") !== array(\"writing\", \"program\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, \"sorting list\") !== array(\"sorting\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum($arr) {\n",
+    "prompt": "<?php\n// Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test($my_matrix) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 1, 1, 4, 5, 6)) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 10, 9, 4, 2, 10, 10, 45, 4)) !== 71) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 10, 9, 45, 2, 10, 10, 45, 10)) !== 78) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return magic_square_test(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(7, 12, 1, 14), array(2, 13, 8, 11), array(16, 3, 10, 5), array(9, 6, 15, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 8))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 7, 6), array(9, 5, 1), array(4, 3, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "php",
-    "prompt": "<?php\n// Write a function to convert the given array to a key-value array using adjacent elements. https://www.geeksforgeeks.org/phpthon-convert-array-to-adjacent-pair-array/\nfunction tuple_to_dict($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix($M) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return tuple_to_dict(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 10, 13, 5)) !== array(1 => 5, 7 => 10, 13 => 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1 => 2, 3 => 4, 5 => 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 10, 11, 12)) !== array(7 => 8, 9 => 10, 11 => 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return sort_matrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(2, 4, 5), array(1, 1, 1))) !== array(array(1, 1, 1), array(1, 2, 3), array(2, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(-2, 4, -5), array(1, -1, 1))) !== array(array(-2, 4, -5), array(1, -1, 1), array(1, 2, 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 8, 9), array(6, 4, 3), array(2, 1, 4))) !== array(array(2, 1, 4), array(6, 4, 3), array(5, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "php",
-    "prompt": "<?php\n// Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates($test_tup) {\n",
+    "prompt": "<?php\n// Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences($nums) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return get_coordinates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4)) !== array(array(2, 3), array(2, 4), array(2, 5), array(3, 3), array(3, 4), array(3, 5), array(4, 3), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5)) !== array(array(3, 4), array(3, 5), array(3, 6), array(4, 4), array(4, 5), array(4, 6), array(5, 4), array(5, 5), array(5, 6))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6)) !== array(array(4, 5), array(4, 6), array(4, 7), array(5, 5), array(5, 6), array(5, 7), array(6, 5), array(6, 6), array(6, 7))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check if all the elements in array have same data type or not.\nfunction check_type($test_tuple) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_type(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7, 3, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, \"4\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing($array) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_First_Missing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 6, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 8, 9)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given number is undulating or not.\nfunction is_undulating($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_undulating(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1212121) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1991) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(121) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/phpthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cophp of test cases\nfunction min_k($test_list, $K) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return min_k(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Manjeet\", 10), array(\"Akshat\", 4), array(\"Akash\", 2), array(\"Nikhil\", 8)), 2) !== array(array(\"Akash\", 2), array(\"Akshat\", 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sanjeev\", 11), array(\"Angat\", 5), array(\"Akash\", 3), array(\"Nepin\", 9)), 3) !== array(array(\"Akash\", 3), array(\"Angat\", 5), array(\"Nepin\", 9))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"tanmay\", 14), array(\"Amer\", 11), array(\"Ayesha\", 9), array(\"SKD\", 16)), 1) !== array(array(\"Ayesha\", 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings($s) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_Substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"112112\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1101112\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the nth decagonal number.\nfunction is_num_decagonal($n) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_num_decagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 175) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 370) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return rear_extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, \"Rash\", 21), array(2, \"Varsha\", 20), array(3, \"Kil\", 19))) !== array(21, 20, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sai\", 36), array(2, \"Ayesha\", 25), array(3, \"Salman\", 45))) !== array(36, 25, 45)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sudeep\", 14), array(2, \"Vandana\", 36), array(3, \"Dawood\", 56))) !== array(14, 36, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the closest smaller number than n.\nfunction closest_num($N) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return closest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(11) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/phpthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations($test_list) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_combinations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 4), array(6, 7), array(5, 1), array(6, 10))) !== array(array(8, 11), array(7, 5), array(8, 14), array(11, 8), array(12, 17), array(11, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8), array(6, 2), array(7, 11))) !== array(array(10, 13), array(9, 7), array(10, 16), array(13, 10), array(14, 19), array(13, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(8, 9), array(7, 3), array(8, 12))) !== array(array(12, 15), array(11, 9), array(12, 18), array(15, 12), array(16, 21), array(15, 15))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "php",
-    "prompt": "<?php\n// Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath($cost) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return maxAverageOfPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(6, 5, 4), array(7, 3, 9))) !== 5.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 4), array(7, 6, 5), array(8, 4, 10))) !== 6.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(8, 7, 6), array(9, 5, 11))) !== 7.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9))) !== 5.8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "php",
-    "prompt": "<?php\n// Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search($dlist, $item) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sequential_search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31) !== array(true, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 32, 45, 62, 35, 47, 44, 61), 61) !== array(true, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 10, 17, 19, 22, 39, 48, 56), 48) !== array(true, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to remove odd numbers from a given array.\nfunction remove_odd($l) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 6)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 3)) !== array(10, 20)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even($arr) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return is_product_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction",
-      "\n?>",
-      "\n//",
-      "\n#"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the maximum of two numbers.\nfunction maximum($a, $b) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 10) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 7) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return max_occurrences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5794,9 +364,759 @@
     "language": "php",
     "prompt": "<?php\n// Write a phpthon function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels($str1) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return reverse_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"USA\") !== \"ASU\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"ab\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert an array to a string.\nfunction tup_string($tup1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tup_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\")) !== \"exercises\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) !== \"program\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_negativenum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== -32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, -14, 13, -18, 12, -20)) !== -52) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)) !== -894) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth hexagonal number.\nfunction hexagonal_num($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return hexagonal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 190) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 91) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_Sum_Of_Powers_Of_Two(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort an array of elements.\nfunction pancake_sort($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pancake_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(15, 79, 25, 38, 69)) !== array(15, 25, 38, 69, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(98, 12, 54, 36, 85)) !== array(12, 36, 54, 85, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 42, 32, 12, 23)) !== array(12, 23, 32, 41, 42)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair($list1, $list2, $list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_samepair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9), array(2, 1, 3, 1, 2, 6, 7, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 2, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 8), array(2, 1, 3, 1, 2, 6, 7, 8)) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find number of arrays present in the given array.\nfunction find_lists($Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5, 4, 3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_Abs_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 3, 2, 5, 1)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the volume of a triangular prism.\nfunction find_Volume($l, $b, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Volume(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 8, 6) !== 240) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns integers x and y that satisfy ax + by = n as an array, or return null if no solution exists.\nfunction find_solution($a, $b, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_solution(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 3, 7) !== array(2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2, 7) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 13, 17) !== array(4, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all elements from a given array present in another array.\nfunction remove_elements($list1, $list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(1, 3, 5, 7)) !== array(2, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), array(5, 7)) !== array(1, 2, 3, 4, 6, 8, 9, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_series(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent($num1, $num2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return are_equivalent(...$args);\n}\n\nfunction test(): void {\n    if (candidate(36, 57) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 47) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_char_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"xbcefg\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ABcED\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"AbgdeF\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair($A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_even_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11)) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return next_power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(0) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of occurrences of a number in a given array.\nfunction frequency($a, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return frequency(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3, 3, 3, 4), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 1, 2), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_lowercase_underscore(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aab_cbbbc\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aab_Abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Aaab_abbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list($list1, $m, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_range_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10) !== 29) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10) !== 38) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return perimeter_pentagon(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 75) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_occurance(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"letstdlenstdporstd\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"truststdsolensporsd\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"makestdsostdworthit\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"stds\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter($a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return square_perimeter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars($string, $second_string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_dirty_chars(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"probasscurve\", \"pros\") !== \"bacuve\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"digitalindia\", \"talent\") !== \"digiidi\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"exoticmiles\", \"toxic\") !== \"emles\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate($arraynums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return test_duplicate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2, 3, 3, 4, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given number is woodball or not.\nfunction is_woodall($x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_woodall(...$args);\n}\n\nfunction test(): void {\n    if (candidate(383) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(254) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(200) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if all the elements in array have same data type or not.\nfunction check_type($test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_type(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7, 3, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, \"4\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2, 1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority($arr, $n, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_majority(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 3, 3, 3, 10), 7, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 4, 4, 4, 6, 6), 8, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 2), 5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 2, 2), 5, 1) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_Set_Bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return odd_values_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcdef\") !== \"ace\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\") !== \"pto\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== \"dt\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"lambs\") !== \"lms\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find minimum of three numbers.\nfunction min_of_three($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 15, 18) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -20, -30) !== -30) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range($n, $l, $r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return all_Bits_Set_In_The_Given_Range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 1, 2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(17, 2, 4) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(39, 4, 6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array($arr, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return re_arrange_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9) !== array(-1, -3, -7, 4, 5, 6, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, -14, -26, 13, 15), 5) !== array(-14, -26, 12, 13, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 24, 36, -42, -39, -78, 85), 7) !== array(-42, -39, -78, 10, 24, 36, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank($str1, $char) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_blank(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"hello people\", \"@\") !== \"hello@people\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python program language\", \"$\") !== \"python$program$language\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"blank space\", \"-\") !== \"blank-space\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the volume of a cube given its side length.\nfunction volume_cube($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return volume_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array of arrays and returns an array mapping each unique array to the number of times it occurs in the array.\nfunction check_occurences($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_occurences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 1), array(1, 3), array(2, 5), array(5, 2), array(6, 3))) !== array(array(1, 3) => 2, array(2, 5) => 2, array(3, 6) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 2), array(2, 4), array(3, 6), array(6, 3), array(7, 4))) !== array(array(2, 4) => 2, array(3, 6) => 2, array(4, 7) => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(13, 2), array(11, 23), array(12, 25), array(25, 12), array(16, 23))) !== array(array(2, 13) => 1, array(11, 23) => 1, array(12, 25) => 2, array(16, 23) => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return number_of_substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcde\") !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences($m, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_total_number_of_sequences(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(16, 3) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list($list1, $list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 10), array(2, 4, 6, 8)) !== array(1, 3, 5, 7, 9, 2, 4, 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8)) !== array(1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"blue\", \"green\"), array(\"yellow\")) !== array(\"red\", \"blue\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the total number of characters in a string.\nfunction count_charac($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_charac(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming\") !== 18) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"words\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square($N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return next_Perfect_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(35) !== 36) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 15, 51, 45, 33, 100, 12, 18, 9)) !== 194) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(80, 60, 30, 40, 20, 10)) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 14, 16, 21, 23, 29, 30)) !== 138) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return lps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"TENS FOR TENS\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"CARDIO FOR CARDS\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PART OF THE JOURNEY IS PART\") !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the intersection of two arrays.\nfunction intersection_array($array_nums1, $array_nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return intersection_array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(1, 2, 4, 8, 9)) !== array(1, 2, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(3, 5, 7, 9)) !== array(3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 7, 8, 9, 10), array(10, 20, 30, 40)) !== array(10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X($tup, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_X(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element($list, $element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return insert_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Black\"), \"c\") !== array(\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\"), \"program\") !== array(\"program\", \"python\", \"program\", \"java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"happy\", \"sad\"), \"laugh\") !== array(\"laugh\", \"happy\", \"laugh\", \"sad\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to convert complex numbers to polar coordinates.\nfunction convert($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return convert(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== array(1.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== array(4.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== array(5.0, 0.0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function that returns the number of integer elements in a given array.\nfunction count_integer($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_integer(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, \"abc\", 1.2)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1.2, 4, 5.1)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors($l, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return combinations_colors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 1) !== array(array(\"Red\"), array(\"Green\"), array(\"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 2) !== array(array(\"Red\", \"Red\"), array(\"Red\", \"Green\"), array(\"Red\", \"Blue\"), array(\"Green\", \"Green\"), array(\"Green\", \"Blue\"), array(\"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Red\", \"Green\", \"Blue\"), 3) !== array(array(\"Red\", \"Red\", \"Red\"), array(\"Red\", \"Red\", \"Green\"), array(\"Red\", \"Red\", \"Blue\"), array(\"Red\", \"Green\", \"Green\"), array(\"Red\", \"Green\", \"Blue\"), array(\"Red\", \"Blue\", \"Blue\"), array(\"Green\", \"Green\", \"Green\"), array(\"Green\", \"Green\", \"Blue\"), array(\"Green\", \"Blue\", \"Blue\"), array(\"Blue\", \"Blue\", \"Blue\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_Primes_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== 25) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return swap_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== array(20, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 17) !== array(17, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(200, 100)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5809,7 +1129,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to maximize the given two arrays.\nfunction maximize_elements($test_tup1, $test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return maximize_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 7), array(4, 9), array(2, 9), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(7, 8), array(5, 10), array(3, 10), array(8, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(8, 9), array(6, 11), array(4, 11), array(9, 12))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to check whether every even index contains even numbers of a given array.\nfunction even_position($nums) {\n",
+    "prompt": "<?php\n// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return even_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return newman_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 17) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 41) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "php",
-    "prompt": "<?php\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char($string) {\n",
+    "prompt": "<?php\n// Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements($test_tup1, $test_tup2) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return check_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abba\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"Invalid\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return division_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(2, 2, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 16), array(6, 3, 4, 4)) !== array(2, 2, 2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(20, 14, 36, 18), array(5, 7, 6, 9)) !== array(4, 2, 6, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function to find the sum of even factors of a number.\nfunction sumofFactors($n) {\n",
+    "prompt": "<?php\n// Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts($list1, $L) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return sumofFactors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(18) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 48) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return split_two_parts(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(array(1, 1, 2), array(3, 4, 4, 5, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), 2) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"), 4) !== array(array(\"p\", \"y\", \"t\", \"h\"), array(\"o\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone($r, $h) {\n",
+    "prompt": "<?php\n// Write a function to calculate a dog's age in dog's years.\nfunction dog_age($h_age) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return lateralsurface_cone(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 12) !== 204.20352248333654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 566.3586699569488) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 17) !== 1521.8090132193388) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return dog_age(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 61) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(24) !== 109) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "php",
-    "prompt": "<?php\n// Write a phpthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs($arr, $n) {\n",
+    "prompt": "<?php\n// Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split($S, $step) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return count_Pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 1), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), 5) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return list_split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"), 3) !== array(array(\"a\", \"d\", \"g\", \"j\", \"m\"), array(\"b\", \"e\", \"h\", \"k\", \"n\"), array(\"c\", \"f\", \"i\", \"l\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3) !== array(array(1, 4, 7, 10, 13), array(2, 5, 8, 11, 14), array(3, 6, 9, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"), 2) !== array(array(\"python\", \"C\", \"DBMS\"), array(\"java\", \"C++\", \"SQL\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "php",
-    "prompt": "<?php\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence($A, $x) {\n",
+    "prompt": "<?php\n// Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube($l) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return find_first_occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return lateralsurface_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 324) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 400) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5914,9 +1234,909 @@
     "language": "php",
     "prompt": "<?php\n// Write a phpthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum($n) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n'th star number.\nfunction find_star_num($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_star_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 73) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 121) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the ascii value of a character.\nfunction ascii_value($k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return ascii_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"A\") !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"R\") !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"S\") !== 83) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_even_and_even_index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 12, 1, 18, 8)) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 12, 1)) !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return even_Power_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 1056) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 8832) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rear_extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, \"Rash\", 21), array(2, \"Varsha\", 20), array(3, \"Kil\", 19))) !== array(21, 20, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sai\", 36), array(2, \"Ayesha\", 25), array(3, \"Salman\", 45))) !== array(36, 25, 45)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, \"Sudeep\", 14), array(2, \"Vandana\", 36), array(3, \"Dawood\", 56))) !== array(14, 36, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return substract_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5), array(2, 5, 18)) !== array(8, -1, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 2, 3), array(24, 45, 16)) !== array(-13, -43, -13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 18, 9), array(10, 11, 12)) !== array(-3, 7, -3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return even_binomial_Coeff_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 32) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and integer n and filters the array to only include entries with values greater than or equal to n.\nfunction dict_filter($dict, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return dict_filter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 170) !== array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 180) !== array(\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190), 190) !== array(\"Pierre Cox\" => 190)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_first_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 9, array(5, 7), 11)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 5, 8, array(2, 3), 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth decagonal number.\nfunction is_num_decagonal($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_num_decagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 27) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 175) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 370) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search($dlist, $item) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sequential_search(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31) !== array(true, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 32, 45, 62, 35, 47, 44, 61), 61) !== array(true, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 10, 17, 19, 22, 39, 48, 56), 48) !== array(true, 6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check if the elements of a given array are unique or not.\nfunction all_unique($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return all_unique(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to subtract two arrays element-wise.\nfunction sub_list($nums1, $nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sub_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== array(-3, -3, -3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2), array(3, 4)) !== array(-2, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(40, 50)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return validate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1234) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(51241) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(321) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element($list, $element) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"green\", \"orange\", \"black\", \"white\"), \"blue\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"green\", \"green\", \"green\", \"green\"), \"green\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_two_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated($a, $n, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_sub_array_sum_repeated(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, -30, -1), 4, 3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 10, 20), 3, 2) !== 59) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, -3), 3, 3) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return square_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the array of maximum length in an array of arrays.\nfunction max_length($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(5, 7), array(10, 12, 14, 15))) !== array(4, array(10, 12, 14, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5), array(15, 20, 25))) !== array(3, array(15, 20, 25))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways($n, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_no_of_ways(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 4) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 4) !== 228) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find($n, $m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 3) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 5) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle($w, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return otherside_rightangle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7, 8) !== 10.63014581273465) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 15) !== 16.55294535724685) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val($listval) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 25) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 50) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return the sum of all divisors of a number.\nfunction sum_div($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_div(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count inversions in an array.\nfunction get_Inv_Count($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_Inv_Count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 20, 6, 4, 5)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 5, 6, 1)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to flatten a given nested array structure.\nfunction flatten_list($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return flatten_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 10, array(20, 30), 40, 50, array(60, 70, 80), array(90, 100, 110, 120))) !== array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(40), array(30, 56, 25), array(10, 20), array(33), array(40))) !== array(10, 20, 40, 30, 56, 25, 10, 20, 33, 40)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate($stdata) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_aggregate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Juan Whelan\", 90), array(\"Sabah Colley\", 88), array(\"Peter Nichols\", 7), array(\"Juan Whelan\", 122), array(\"Sabah Colley\", 84))) !== array(\"Juan Whelan\", 212)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 50), array(\"Sabah Colley\", 48), array(\"Peter Nichols\", 37), array(\"Juan Whelan\", 22), array(\"Sabah Colley\", 14))) !== array(\"Juan Whelan\", 72)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Juan Whelan\", 10), array(\"Sabah Colley\", 20), array(\"Peter Nichols\", 30), array(\"Juan Whelan\", 40), array(\"Sabah Colley\", 50))) !== array(\"Sabah Colley\", 70)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find element at a given index after number of rotations.\nfunction find_Element($arr, $ranges, $rotations, $index) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(array(0, 2), array(0, 3)), 2, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(array(0, 1), array(0, 2)), 1, 2) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(array(0, 1), array(0, 2)), 1, 1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp($words) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return start_withp(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python PHP\", \"Java JavaScript\", \"c c++\")) !== array(\"Python\", \"PHP\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python Programming\", \"Java Programming\")) !== array(\"Python\", \"Programming\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Pqrst Pqr\", \"qrstuv\")) !== array(\"Pqrst\", \"Pqr\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq($a, $n, $index, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_sum_increasing_subseq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 4, 6) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 101, 2, 3, 100, 4, 5), 7, 2, 5) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 15, 19, 21, 26, 28, 31), 7, 2, 4) !== 71) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product($nums1, $nums2, $N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return large_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 3) !== array(60, 54, 50)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 4) !== array(60, 54, 50, 48)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(3, 6, 8, 9, 10, 6), 5) !== array(60, 54, 50, 48, 45)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the maximum of two numbers.\nfunction maximum($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return maximum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 10) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2) !== -1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 7) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a given string to an array of characters.\nfunction string_to_tuple($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return string_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python 3.0\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"item1\") !== array(\"i\", \"t\", \"e\", \"m\", \"1\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"15.10\") !== array(\"1\", \"5\", \".\", \"1\", \"0\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return highest_Power_of_2(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(32) !== 32) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n'th lucas number.\nfunction find_lucas($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_lucas(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 76) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to apply a given format string to all of the elements in an array.\nfunction add_string($list_, $string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4), \"temp{0}\") !== array(\"temp1\", \"temp2\", \"temp3\", \"temp4\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\", \"d\"), \"python{0}\") !== array(\"pythona\", \"pythonb\", \"pythonc\", \"pythond\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 8), \"string{0}\") !== array(\"string5\", \"string6\", \"string7\", \"string8\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert more than one array to nested array.\nfunction convert_list_dictionary($l1, $l2, $l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return convert_list_dictionary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"S001\", \"S002\", \"S003\", \"S004\"), array(\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"), array(85, 98, 89, 92)) !== array(array(\"S001\" => array(\"Adina Park\" => 85)), array(\"S002\" => array(\"Leyton Marsh\" => 98)), array(\"S003\" => array(\"Duncan Boyle\" => 89)), array(\"S004\" => array(\"Saim Richards\" => 92)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abc\", \"def\", \"ghi\", \"jkl\"), array(\"python\", \"program\", \"language\", \"programs\"), array(100, 200, 300, 400)) !== array(array(\"abc\" => array(\"python\" => 100)), array(\"def\" => array(\"program\" => 200)), array(\"ghi\" => array(\"language\" => 300)), array(\"jkl\" => array(\"programs\" => 400)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"A1\", \"A2\", \"A3\", \"A4\"), array(\"java\", \"C\", \"C++\", \"DBMS\"), array(10, 20, 30, 40)) !== array(array(\"A1\" => array(\"java\" => 10)), array(\"A2\" => array(\"C\" => 20)), array(\"A3\" => array(\"C++\" => 30)), array(\"A4\" => array(\"DBMS\" => 40)))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_max_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(60) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the array with maximum length.\nfunction max_length_list($input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_length_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(0), array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== array(3, array(13, 15, 17))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4, 5), array(1, 2, 3, 4), array(1, 2, 3), array(1, 2), array(1))) !== array(5, array(1, 2, 3, 4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(6, 7, 8, 9), array(10, 11, 12))) !== array(4, array(6, 7, 8, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if given array contains no duplicates.\nfunction check_distinct($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_distinct(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 5, 6, 1, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return first_non_repeating_character(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ababc\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abba\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a\") !== \"Valid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd\") !== \"Invalid\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median of three numbers.\nfunction median_numbers($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return median_numbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(25, 55, 65) !== 55.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 10, 30) !== 20.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 45, 75) !== 45.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_of_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 2, 56)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20, 4, 5, \"b\", 70, \"a\"))) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, -4, 5, -70)) !== 19) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return bitwise_xor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(15, 6, 5, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 7, 10), array(6, 3, 4, 4)) !== array(13, 6, 3, 14)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 8, 11), array(7, 4, 5, 6)) !== array(11, 2, 13, 13)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to identify non-prime numbers.\nfunction is_not_prime($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_not_prime(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(35) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(37) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_freq(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 4), array(1, 2), array(4, 3), array(5, 6))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 15), array(2, 3), array(5, 4), array(6, 7))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 16), array(2, 3), array(6, 5), array(6, 9))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add_nested_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(7, 10), array(7, 14), array(3, 10), array(8, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(9, 12), array(9, 16), array(5, 12), array(10, 15))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(11, 14), array(11, 18), array(7, 14), array(12, 17))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the minimum of two numbers.\nfunction minimum($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-5, -4) !== -5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 0) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether an element exists within an array.\nfunction check_tuplex($tuplex, $tuple1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_tuplex(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"r\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), \"5\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"), 3) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find whether the parity of a given number is odd.\nfunction find_Parity($x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Parity(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rearrange_bigger(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(102) !== 120) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs($nums1, $nums2, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return k_smallest_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 2) !== array(array(1, 2), array(1, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 1) !== array(array(1, 2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 7), array(2, 4, 6), 7) !== array(array(1, 2), array(1, 4), array(3, 2), array(1, 6), array(3, 4), array(3, 6), array(7, 2))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_product_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 7), array(2, 6), array(1, 8), array(4, 9))) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(10, 20), array(15, 2), array(5, 10))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(11, 44), array(10, 15), array(20, 5), array(12, 9))) !== 100) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val($listval) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_val(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", 3, 2, 4, 5, \"version\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 15, 20, 25)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", 30, 20, 40, 50, \"version\")) !== 20) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel($word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return snake_to_camel(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"android_tv\") !== \"AndroidTv\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"google_pixel\") !== \"GooglePixel\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"apple_watch\") !== \"AppleWatch\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to remove odd numbers from a given array.\nfunction remove_odd($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 6)) !== array(2, 4, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 3)) !== array(10, 20)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element($list1, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_nth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 0) !== array(\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 2) !== array(99, 96, 94, 98)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Greyson Fulton\", 98, 99), array(\"Brady Kent\", 97, 96), array(\"Wyatt Knott\", 91, 94), array(\"Beau Turnbull\", 94, 98)), 1) !== array(98, 97, 91, 94)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping($list1, $list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return overlapping(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(4, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 4, 5), array(1, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find a pair with highest product from a given array of integers.\nfunction max_Product($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_Product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 7, 0, 8, 4)) !== array(7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, -1, -2, -4, 5, 0, -6)) !== array(-4, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(2, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",
@@ -5929,7 +2149,7 @@
     "language": "php",
     "prompt": "<?php\n// Write a function to find common first element in given array of arrays.\nfunction group_tuples($Input) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "function candidate(...$args) {\n    return group_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"x\", \"z\"), array(\"w\", \"t\"))) !== array(array(\"x\", \"y\", \"z\"), array(\"w\", \"t\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"a\", \"c\"), array(\"d\", \"e\"))) !== array(array(\"a\", \"b\", \"c\"), array(\"d\", \"e\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"f\", \"g\"), array(\"f\", \"g\"), array(\"h\", \"i\"))) !== array(array(\"f\", \"g\", \"g\"), array(\"h\", \"i\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "php",
-    "prompt": "<?php\n// Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list($num1, $num2, $num3) {\n",
+    "prompt": "<?php\n// Write a phpthon function to find the element of an array having maximum length.\nfunction Find_Max($lst) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "function candidate(...$args) {\n    return merge_sorted_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 24, 15, 4, 5, 29, 110), array(19, 20, 11, 56, 25, 233, 154), array(24, 26, 54, 48)) !== array(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 5, 6, 8, 9), array(2, 5, 7, 11), array(1, 4, 7, 8, 12)) !== array(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), array(25, 35, 22, 85, 14, 65, 75, 25, 58), array(12, 74, 9, 50, 61, 41)) !== array(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "tests": "function candidate(...$args) {\n    return Find_Max(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"A\"), array(\"A\", \"B\"), array(\"A\", \"B\", \"C\"))) !== array(\"A\", \"B\", \"C\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 2, 3), array(1, 5, 6, 1))) !== array(1, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return round_and_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)) !== 243) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 2, 9, 24.3, 29)) !== 345) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25.0, 56.7, 89.2)) !== 513) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return cube_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 72) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 288) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 800) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return concatenate_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"ID\", \"is\", 4, \"UTS\")) !== \"ID-is-4-UTS\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"QWE\", \"is\", 4, \"RTY\")) !== \"QWE-is-4-RTY\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"ZEN\", \"is\", 4, \"OP\")) !== \"ZEN-is-4-OP\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Average_Of_Cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear($test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_rear(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Mers\", \"for\", \"Vers\")) !== array(\"s\", \"r\", \"s\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Avenge\", \"for\", \"People\")) !== array(\"e\", \"r\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Gotta\", \"get\", \"go\")) !== array(\"a\", \"t\", \"o\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list($list1, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_element_in_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(1, 11), array(1, 15, 7)), 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"A\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"A\", \"B\"), array(\"A\", \"C\"), array(\"A\", \"D\", \"E\"), array(\"B\", \"C\", \"D\")), \"E\") !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to filter odd numbers.\nfunction filter_oddnumbers($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return filter_oddnumbers(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 3, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 45, 67, 84, 93)) !== array(45, 67, 93)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 7, 9, 8, 6, 4, 3)) !== array(5, 7, 9, 3)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format($dt) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return change_date_format(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"2026-01-02\") !== \"02-01-2026\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2020-11-13\") !== \"13-11-2020\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"2021-04-26\") !== \"26-04-2021\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort the given array by using shell sort.\nfunction shell_sort($my_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return shell_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)) !== array(2, 3, 4, 5, 12, 12, 23, 56, 81, 95)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(24, 22, 39, 34, 87, 73, 68)) !== array(22, 24, 34, 39, 68, 73, 87)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(32, 30, 16, 96, 82, 83, 74)) !== array(16, 30, 32, 74, 82, 83, 96)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return and_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 6, 9), array(5, 2, 3, 3)) !== array(0, 0, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(5, 6, 7, 8)) !== array(1, 2, 3, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 11, 12), array(7, 13, 14, 17)) !== array(0, 9, 10, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the directrix of a parabola.\nfunction parabola_directrix($a, $b, $c) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return parabola_directrix(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 3, 2) !== -198) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 8, 4) !== -2336) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4, 6) !== -130) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element($list1, $list2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return common_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), array(5, 6, 7, 8, 9)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 8, 9)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"b\", \"c\"), array(\"d\", \"b\", \"e\")) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median length of a trapezium.\nfunction median_trapezium($base1, $base2, $height) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return median_trapezium(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15, 25, 35) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 20, 30) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6, 9, 4) !== 7.5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater($arr, $number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_greater(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5), 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 6), 8) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 7, 4, 8, 6, 1), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the last digit of a given number.\nfunction last_Digit($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return last_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to return the negative numbers in an array.\nfunction neg_nos($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return neg_nos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-1, 4, 5, -6)) !== array(-1, -6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3, 4)) !== array(-1, -2)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-7, -6, 8, 9)) !== array(-7, -6)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove odd characters in a string.\nfunction remove_odd($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== \"yhn\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== \"rga\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"language\") !== \"agae\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count bidirectional array pairs.\nfunction count_bidirectional($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_bidirectional(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 3), array(6, 5), array(9, 1), array(6, 5), array(2, 1))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 6), array(1, 2), array(6, 5), array(9, 2), array(6, 5), array(2, 1))) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single($L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return multiple_to_single(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(11, 33, 50)) !== 113350) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4, 5, 6)) !== -123456) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 15, 20, 25)) !== 10152025) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_adverb_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"clearly!! we can see the sky\") !== array(0, 7, \"clearly\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"seriously!! there are many roses\") !== array(0, 9, \"seriously\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"unfortunately!! sita is going to home\") !== array(0, 13, \"unfortunately\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return surfacearea_cube(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 150) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 600) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return positive_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)) !== 0.54) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 0.69) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17)) !== 0.56) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the largest negative number from the given array.\nfunction largest_neg($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return largest_neg(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, -4, -6)) !== -6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, -8, -9)) !== -9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, -1)) !== -1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to trim each array by k in the given arrays.\nfunction trim_tuple($test_list, $K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return trim_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 2) !== array(array(2), array(9), array(2), array(2))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 3, 2, 1, 4), array(3, 4, 9, 2, 1), array(9, 1, 2, 3, 5), array(4, 8, 2, 1, 7)), 1) !== array(array(3, 2, 1), array(4, 9, 2), array(1, 2, 3), array(8, 2, 1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 4, 9), array(11, 8, 12, 4), array(4, 1, 7, 8), array(3, 6, 9, 7)), 1) !== array(array(8, 4), array(8, 12), array(1, 7), array(6, 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return index_multiplication(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(4, 5), array(2, 9), array(1, 10)), array(array(6, 7), array(3, 9), array(1, 1), array(7, 3))) !== array(array(6, 21), array(12, 45), array(2, 9), array(7, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(5, 6), array(3, 10), array(2, 11)), array(array(7, 8), array(4, 10), array(2, 2), array(8, 4))) !== array(array(14, 32), array(20, 60), array(6, 20), array(16, 44))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(6, 7), array(4, 11), array(3, 12)), array(array(8, 9), array(5, 11), array(3, 3), array(9, 5))) !== array(array(24, 45), array(30, 77), array(12, 33), array(27, 60))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence($tup, $lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_Occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\", \"a\", \"c\", \"b\", \"d\"), array(\"a\", \"b\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1, 4, 6, 7, 1, 4), array(1, 4, 7)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), array(1, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find cubes of individual elements in an array.\nfunction cube_nums($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return cube_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(1728, 3375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the sum of perrin numbers.\nfunction cal_sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return cal_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 49) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 66) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 88) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string($str, $l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 8) !== array(\"practice\", \"solution\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 6) !== array(\"Python\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"), 9) !== array(\"exercises\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces($text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_whitespaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\" Google    Flutter \") !== \"GoogleFlutter\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" Google    Dart \") !== \"GoogleDart\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\" iOS    Swift \") !== \"iOSSwift\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount($actual_cost, $sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return loss_amount(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== 100) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== 3000) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of even factors of a number.\nfunction sumofFactors($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sumofFactors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(18) !== 26) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 48) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a word containing 'z'.\nfunction text_match_wordz($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_wordz(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"xyz.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number($monthnum2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_monthnumb_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list($stringlist) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return reverse_string_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Red\", \"Green\", \"Blue\", \"White\", \"Black\")) !== array(\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"john\", \"amal\", \"joel\", \"george\")) !== array(\"nhoj\", \"lama\", \"leoj\", \"egroeg\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"jack\", \"john\", \"mary\")) !== array(\"kcaj\", \"nhoj\", \"yram\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the subarray having minimum length.\nfunction Find_Min($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Find_Min(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2), array(1, 2, 3))) !== array(1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1), array(1, 1, 1), array(1, 2, 7, 8))) !== array(1, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\"), array(\"x\", \"y\"), array(\"x\", \"y\", \"z\"))) !== array(\"x\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the area of a rectangle.\nfunction rectangle_area($l, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rectangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 20) !== 200) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 5) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 2) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"cAstyoUrFavoRitETVshoWs\") !== \"cstyoravoitshos\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"wAtchTheinTernEtrAdIo\") !== \"wtchheinerntrdo\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"VoicESeaRchAndreComMendaTionS\") !== \"oiceachndreomendaion\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to get the first element of each subarray.\nfunction Extract($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Extract(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2), array(3, 4, 5), array(6, 7, 8, 9))) !== array(1, 3, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5))) !== array(1, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(9, 8, 1), array(1, 2))) !== array(9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the upper case characters in a given string.\nfunction upper_ctr($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return upper_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYthon\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"BigData\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find all possible combinations of the elements of a given array.\nfunction combinations_list($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return combinations_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"orange\", \"red\", \"green\", \"blue\")) !== array(array(), array(\"orange\"), array(\"red\"), array(\"red\", \"orange\"), array(\"green\"), array(\"green\", \"orange\"), array(\"green\", \"red\"), array(\"green\", \"red\", \"orange\"), array(\"blue\"), array(\"blue\", \"orange\"), array(\"blue\", \"red\"), array(\"blue\", \"red\", \"orange\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"orange\"), array(\"blue\", \"green\", \"red\"), array(\"blue\", \"green\", \"red\", \"orange\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"blue\"), array(\"blue\", \"red\"), array(\"blue\", \"green\"), array(\"blue\", \"green\", \"red\"), array(\"white\"), array(\"white\", \"red\"), array(\"white\", \"green\"), array(\"white\", \"green\", \"red\"), array(\"white\", \"blue\"), array(\"white\", \"blue\", \"red\"), array(\"white\", \"blue\", \"green\"), array(\"white\", \"blue\", \"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"black\", \"blue\"), array(\"black\", \"blue\", \"red\"), array(\"black\", \"blue\", \"green\"), array(\"black\", \"blue\", \"green\", \"red\"), array(\"black\", \"white\"), array(\"black\", \"white\", \"red\"), array(\"black\", \"white\", \"green\"), array(\"black\", \"white\", \"green\", \"red\"), array(\"black\", \"white\", \"blue\"), array(\"black\", \"white\", \"blue\", \"red\"), array(\"black\", \"white\", \"blue\", \"green\"), array(\"black\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"blue\"), array(\"orange\", \"blue\", \"red\"), array(\"orange\", \"blue\", \"green\"), array(\"orange\", \"blue\", \"green\", \"red\"), array(\"orange\", \"white\"), array(\"orange\", \"white\", \"red\"), array(\"orange\", \"white\", \"green\"), array(\"orange\", \"white\", \"green\", \"red\"), array(\"orange\", \"white\", \"blue\"), array(\"orange\", \"white\", \"blue\", \"red\"), array(\"orange\", \"white\", \"blue\", \"green\"), array(\"orange\", \"white\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"), array(\"orange\", \"black\", \"blue\"), array(\"orange\", \"black\", \"blue\", \"red\"), array(\"orange\", \"black\", \"blue\", \"green\"), array(\"orange\", \"black\", \"blue\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\"), array(\"orange\", \"black\", \"white\", \"red\"), array(\"orange\", \"black\", \"white\", \"green\"), array(\"orange\", \"black\", \"white\", \"green\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\"), array(\"orange\", \"black\", \"white\", \"blue\", \"red\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\"), array(\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"black\", \"orange\")) !== array(array(), array(\"red\"), array(\"green\"), array(\"green\", \"red\"), array(\"black\"), array(\"black\", \"red\"), array(\"black\", \"green\"), array(\"black\", \"green\", \"red\"), array(\"orange\"), array(\"orange\", \"red\"), array(\"orange\", \"green\"), array(\"orange\", \"green\", \"red\"), array(\"orange\", \"black\"), array(\"orange\", \"black\", \"red\"), array(\"orange\", \"black\", \"green\"), array(\"orange\", \"black\", \"green\", \"red\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_subarray_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, -3, 0, 7, -8, -2)) !== 112) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, -3, -10, 0, 2)) !== 180) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-2, -40, 0, -2, -3)) !== 80) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if all values are same in an array.\nfunction check_value($dict, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_value(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 12) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12), 5) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to drop empty items from a given array.\nfunction drop_empty($dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return drop_empty(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c1\" => \"Red\", \"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => \"Red\", \"c2\" => null, \"c3\" => null)) !== array(\"c1\" => \"Red\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"c1\" => null, \"c2\" => \"Green\", \"c3\" => null)) !== array(\"c2\" => \"Green\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 100, 4, 5, 150, 6)) !== 3000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 42, 55, 68, 80)) !== 50265600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 22, 9, 33, 21, 50, 41, 60)) !== 2460) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add_pairwise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(6, 12, 15, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, 9, 11)) !== array(8, 14, 17, 20)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, 10, 12)) !== array(10, 16, 19, 22)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the product of the array multiplication modulo n.\nfunction find_remainder($arr, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_remainder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(100, 10, 5, 25, 35, 14), 11) !== 9) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), 2) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive($l) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_Consecutive(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 5, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace characters in a string.\nfunction replace_char($str1, $ch, $newch) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"polygon\", \"y\", \"l\") !== \"pollgon\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"character\", \"c\", \"a\") !== \"aharaater\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python\", \"l\", \"a\") !== \"python\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort an array by value.\nfunction sort_counter($dict1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sort_counter(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87)) !== array(array(\"Chemistry\", 87), array(\"Physics\", 83), array(\"Math\", 81))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250)) !== array(array(\"Math\", 400), array(\"Physics\", 300), array(\"Chemistry\", 250))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250)) !== array(array(\"Chemistry\", 1250), array(\"Physics\", 1000), array(\"Math\", 900))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return big_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 6)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to convert the given string to lower case.\nfunction is_lower($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_lower(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"InValid\") !== \"invalid\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"TruE\") !== \"true\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"SenTenCE\") !== \"sentence\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_lowercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"PYTHon\") !== \"PYTH\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"FInD\") !== \"FID\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"STRinG\") !== \"STRG\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the first digit of a given number.\nfunction first_Digit($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return first_Digit(...$args);\n}\n\nfunction test(): void {\n    if (candidate(123) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(456) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest($nums, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return heap_queue_largest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 3) !== array(85, 75, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 2) !== array(85, 75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 22, 58), 5) !== array(85, 75, 65, 58, 35)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function which takes an array of integers and only returns the odd ones.\nfunction Split($list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1, 3, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 11, 12, 13)) !== array(11, 13)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1)) !== array(7, 9, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5) !== 210) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair($A, $N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Odd_Pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 4, 7, 2, 1), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 2, 8, 1, 0, 5, 11), 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to toggle the case of all characters in a string.\nfunction toggle_string($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return toggle_string(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"pYTHON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Pangram\") !== \"pANGRAM\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"LIttLE\") !== \"liTTle\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums($n1, $n2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return digit_distance_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23, 56) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(123, 256) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum($a, $size) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_sub_array_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(-2, -3, 4, -1, -2, 1, 5, -3), 8) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-3, -4, 5, -2, -3, 2, 6, -4), 8) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-4, -5, 6, -3, -4, 3, 7, -5), 8) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return union_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 4, 5, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(3, 4, 5, 6)) !== array(1, 2, 3, 4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13, 14), array(13, 15, 16, 17)) !== array(11, 12, 13, 14, 15, 16, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the length of the longest subarrays.\nfunction Find_Max_Length($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Find_Max_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 4), array(5, 6, 7, 8))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(0, 1), array(2, 2), array(3, 2, 1))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7), array(22, 23), array(13, 14, 15), array(10, 20, 30, 40, 50))) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract values between quotation marks from a string.\nfunction extract_values($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_values(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") !== array(\"Python\", \"PHP\", \"Java\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") !== array(\"python\", \"program\", \"language\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") !== array(\"red\", \"blue\", \"green\", \"yellow\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs($arr, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_Pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 1), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 1), 4) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), 5) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to split a string into characters.\nfunction split($word) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== array(\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Name\") !== array(\"N\", \"a\", \"m\", \"e\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"program\") !== array(\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(345) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(97) !== 16) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether a specified array is sorted or not.\nfunction issort_list($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return issort_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 6, 8, 10, 15, 14, 20)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create an array of N empty dictionaries.\nfunction empty_list($length) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return empty_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== array(array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== array(array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== array(array(), array(), array(), array(), array(), array(), array())) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sort_sublists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"white\", \"black\", \"orange\"))) !== array(array(\"green\", \"orange\"), array(\"black\", \"white\"), array(\"black\", \"orange\", \"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) !== array(array(\"green\", \"orange\"), array(\"black\"), array(\"green\", \"orange\"), array(\"white\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"a\", \"b\"), array(\"d\", \"c\"), array(\"g\", \"h\"), array(\"f\", \"e\"))) !== array(array(\"a\", \"b\"), array(\"c\", \"d\"), array(\"g\", \"h\"), array(\"e\", \"f\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check if a given number is one less than twice its reverse.\nfunction checks($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return checks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(70) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(23) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(73) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return two_unique_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 2, 3, 4, 5)) !== array(1, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 2, 4, 5)) !== array(1, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product($list_data) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return unique_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30, 40, 20, 50, 60, 40)) !== 720000000) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 1)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 0, 1, 1)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder($r, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return surfacearea_cylinder(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10, 5) !== 942.45) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 226.18800000000002) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 10) !== 351.848) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array($A, $B) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_Sub_Array(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 4, 3, 5), array(1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1), array(1, 2, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 0, 2, 2), array(2, 2, 0)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return last_Digit_Factorial(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(21) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(30) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists($list1, $list2, $list3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return interleave_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7), array(10, 20, 30, 40, 50, 60, 70), array(100, 200, 300, 400, 500, 600, 700)) !== array(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20), array(15, 2), array(5, 10)) !== array(10, 15, 5, 20, 2, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 44), array(10, 15), array(20, 5)) !== array(11, 10, 20, 44, 15, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_dissimilar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4, 5, 6), array(5, 7, 4, 10)) !== array(3, 6, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), array(7, 2, 3, 9)) !== array(1, 4, 7, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(21, 11, 25, 26), array(26, 34, 21, 36)) !== array(34, 36, 11, 25)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Max_Num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 321) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 1)) !== 6541) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 9)) !== 9321) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even($test_tuple) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, array(7, 6, array(2, 4)), 6, 8)) !== array(4, array(6, array(2, 4)), 6, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(8, 7, array(4, 8)), 7, 9)) !== array(6, array(8, array(4, 8)))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, array(9, 8, array(4, 6)), 8, 10)) !== array(6, array(8, array(4, 6)), 8, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the surface area of a square phpramid with a given base edge and height.\nfunction surface_Area($b, $s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return surface_Area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 33) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4, 5) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which returns nth catalan number.\nfunction catalan_number($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return catalan_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 16796) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 4862) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 429) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_adverbs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Clearly, he has no excuse for such behavior.\") !== \"0-7: Clearly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Please handle the situation carefuly\") !== \"28-36: carefuly\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Complete the task quickly\") !== \"18-25: quickly\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the n most expensive items in a given dataset.\nfunction expensive_items($items, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return expensive_items(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09)), 2) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-1\", \"price\" => 101.1))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"name\" => \"Item-1\", \"price\" => 101.1), array(\"name\" => \"Item-2\", \"price\" => 555.22), array(\"name\" => \"Item-3\", \"price\" => 45.09), array(\"name\" => \"Item-4\", \"price\" => 22.75)), 1) !== array(array(\"name\" => \"Item-2\", \"price\" => 555.22))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr($l, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return split_Arr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 10, 5, 6, 52, 36), 2) !== array(5, 6, 52, 36, 12, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4), 1) !== array(2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 3, 4, 5, 6, 7), 3) !== array(3, 4, 5, 6, 7, 0, 1, 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert an array to an array.\nfunction list_tuple($listx) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return list_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 10, 7, 4, 15, 3)) !== array(5, 10, 7, 4, 15, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 2, 3, 4, 4, 7)) !== array(2, 4, 5, 6, 2, 3, 4, 4, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(58, 44, 56)) !== array(58, 44, 56)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return big_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 12)) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 2, 3)) !== 7) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find perfect squares between two given numbers.\nfunction perfect_squares($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return perfect_squares(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 30) !== array(1, 4, 9, 16, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(50, 100) !== array(64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 200) !== array(100, 121, 144, 169, 196)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs($x, $y) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return opposite_Signs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, -2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-10, -10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-2, 2) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to interchange the first and last elements in an array.\nfunction swap_List($newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(12, 35, 9, 56, 24)) !== array(24, 35, 9, 56, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_Of_product(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip($ip) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return removezero_ip(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"216.08.094.196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"12.01.024\") !== \"12.1.24\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"216.08.094.0196\") !== \"216.8.94.196\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return diff_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps($str1, $str2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_Swaps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"1101\", \"1110\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"000\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\", \"110\") !== \"Not Possible\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find kth element from the given two sorted arrays.\nfunction find_kth($arr1, $arr2, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_kth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 3, 6, 7, 9), array(1, 4, 8, 10), 5) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(100, 112, 256, 349, 770), array(72, 86, 113, 119, 265, 445, 892), 7) !== 256) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 7, 8, 10), array(2, 5, 9, 11), 6) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return armstrong_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(153) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(259) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4458) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find sum and average of first n natural numbers.\nfunction sum_average($number) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_average(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(55, 5.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== array(120, 8.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== array(210, 10.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth octagonal number.\nfunction is_octagonal($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_octagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 65) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 280) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 645) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given number is even or not.\nfunction is_Even($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_Even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the first repeated character in a given string.\nfunction first_repeated_char($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return first_repeated_char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abcabc\") !== \"a\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123123\") !== \"1\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_ludic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== array(1, 2, 3, 5, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(25) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(45) !== array(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return reverse_words(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python program\") !== \"program python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"java language\") !== \"language java\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"indian man\") !== \"man indian\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given integer is a prime number.\nfunction prime_num($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return prime_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1010) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert degrees to radians.\nfunction radian_degree($degree) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return radian_degree(...$args);\n}\n\nfunction test(): void {\n    if (candidate(90) !== 1.5707963267948966) { throw new Exception(\"Test failed!\"); }\n    if (candidate(60) !== 1.0471975511965976) { throw new Exception(\"Test failed!\"); }\n    if (candidate(120) !== 2.0943951023931953) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals($text, $pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_literals(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\") !== array(\"fox\", 16, 19)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its been a very crazy procedure right\", \"crazy\") !== array(\"crazy\", 16, 21)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Hardest choices required strongest will\", \"will\") !== array(\"will\", 35, 39)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find nth bell number.\nfunction bell_Number($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return bell_Number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 15) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element($list1, $L) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_kth_element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 4, 4, 5, 1), 3) !== array(1, 1, 3, 4, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4) !== array(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5) !== array(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth($test_list, $N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_of_nth(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(5, 6, 7), array(1, 3, 5), array(8, 9, 19)), 2) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(6, 7, 8), array(2, 4, 6), array(9, 10, 20)), 1) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 8, 9), array(3, 5, 7), array(10, 11, 21)), 1) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return merge(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"x\", \"y\"), array(\"a\", \"b\"), array(\"m\", \"n\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8))) !== array(array(1, 3, 5, 7), array(2, 4, 6, 8))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"x\", \"y\", \"z\"), array(\"a\", \"b\", \"c\"), array(\"m\", \"n\", \"o\"))) !== array(array(\"x\", \"a\", \"m\"), array(\"y\", \"b\", \"n\"), array(\"z\", \"c\", \"o\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return cummulative_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 6, 7), array(2, 6))) !== 30) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 4), array(6, 7, 8), array(3, 7))) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8, 9), array(4, 8))) !== 44) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return average_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(10, 10, 10, 12), array(30, 45, 56, 45), array(81, 80, 39, 32), array(1, 2, 3, 4))) !== array(30.5, 34.25, 27.0, 23.25)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 1, -5), array(30, -15, 56), array(81, -60, -39), array(-10, 2, 3))) !== array(25.5, -18.0, 3.75)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(100, 100, 100, 120), array(300, 450, 560, 450), array(810, 800, 390, 320), array(10, 20, 30, 40))) !== array(305.0, 342.5, 270.0, 232.5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "php",
+    "prompt": "<?php\n// Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tuple_modulo(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6), array(5, 6, 7, 5)) !== array(0, 4, 5, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 5, 6, 7), array(6, 7, 8, 6)) !== array(5, 5, 6, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 6, 7, 8), array(7, 8, 9, 7)) !== array(5, 6, 7, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps($steps, $d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_Jumps(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4), 11) !== 3.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4), 0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 14), 11) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to divide two arrays element wise.\nfunction div_list($nums1, $nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return div_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(1, 2, 3)) !== array(4.0, 2.5, 2.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 2), array(1, 4)) !== array(3.0, 0.5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(90, 120), array(50, 70)) !== array(1.8, 1.7142857142857142)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to move all the numbers to the end of the given string.\nfunction move_num($test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return move_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"I1love143you55three3000thousand\") !== \"Iloveyouthreethousand1143553000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Avengers124Assemble\") !== \"AvengersAssemble124\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Its11our12path13to14see15things16do17things\") !== \"Itsourpathtoseethingsdothings11121314151617\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_Substrings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"112112\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"111\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1101112\") !== 12) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the median of two sorted arrays of same size.\nfunction get_median($arr1, $arr2, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_median(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 12, 15, 26, 38), array(2, 13, 17, 30, 45), 5) !== 16.0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 8, 9), array(7, 13, 19, 28), 4) !== 8.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 6, 14, 23, 36, 42), array(2, 18, 27, 39, 49, 55), 6) !== 25.0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to compute the n-th power of each number in an array.\nfunction nth_nums($nums, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return nth_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30), 3) !== array(1000, 8000, 27000)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15), 5) !== array(248832, 759375)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to convert a given string to uppercase.\nfunction is_upper($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_upper(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"person\") !== \"PERSON\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"final\") !== \"FINAL\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Valid\") !== \"VALID\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to interchange the first and last element in a given array.\nfunction swap_List($newList) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return swap_List(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== array(3, 2, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 4)) !== array(4, 2, 3, 4, 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6)) !== array(6, 5, 4)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area($r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return triangle_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(-1) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing($array) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_First_Missing(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 1, 2, 3)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, 6, 9)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 8, 9)) !== 0) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"My Name is Dawood\") !== \"My%20Name%20is%20Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I am a Programmer\") !== \"I%20am%20a%20Programmer\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"I love Coding\") !== \"I%20love%20Coding\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find even numbers from an array of numbers.\nfunction Split($list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Split(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5)) !== array(2, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7, 8, 0, 1)) !== array(4, 6, 8, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 12, 15, 19)) !== array(8, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find smallest number in an array.\nfunction smallest_num($xs) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return smallest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 1, 45, 99)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(45, 46, 50, 60)) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_coordinates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 4)) !== array(array(2, 3), array(2, 4), array(2, 5), array(3, 3), array(3, 4), array(3, 5), array(4, 3), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5)) !== array(array(3, 4), array(3, 5), array(3, 6), array(4, 4), array(4, 5), array(4, 6), array(5, 4), array(5, 5), array(5, 6))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6)) !== array(array(4, 5), array(4, 6), array(4, 7), array(5, 5), array(5, 6), array(5, 7), array(6, 5), array(6, 6), array(6, 7))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Jumanji The Jungle\") !== \"Jumanji_The_Jungle\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"The_Avengers\") !== \"The Avengers\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Fast and Furious\") !== \"Fast_and_Furious\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to move all zeroes to the end of the given array.\nfunction move_zero($num_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return move_zero(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 0, 2, 0, 3, 4)) !== array(1, 2, 3, 4, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 0, 0, 4, 0, 5, 0)) !== array(2, 3, 2, 4, 5, 0, 0, 0, 0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 0, 1, 1)) !== array(1, 1, 1, 0, 0)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum($arr, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pair_xor_Sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 9, 7, 6), 4) !== 47) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3, 5), 3) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 3), 2) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort the given array.\nfunction heap_sort($iterable) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return heap_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(25, 35, 22, 85, 14, 65, 75, 25, 58)) !== array(14, 22, 25, 25, 35, 58, 65, 75, 85)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 1, 9, 5)) !== array(1, 5, 7, 9)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss($actual_cost, $sale_amount) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return noprofit_noloss(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1500, 1200) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100, 100) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2000, 5000) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill($v, $t) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return wind_chill(...$args);\n}\n\nfunction test(): void {\n    if (candidate(120, 35) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(40, 20) !== 19) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 8) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam($sample_names) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sample_nam(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\")) !== 16) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\")) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"abcd\", \"Python\", \"abba\", \"aba\")) !== 6) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_difference(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(3, 5), array(1, 7), array(10, 3), array(1, 2))) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(2, 17), array(9, 13), array(11, 12))) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(12, 35), array(21, 27), array(13, 23), array(41, 22))) !== 23) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis($items) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_parenthesis(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python (chrome)\")) !== \"python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"string(.abc)\")) !== \"string\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"alpha(num)\")) !== \"alpha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth nonagonal number.\nfunction is_nonagonal($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_nonagonal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 325) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== 750) { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== 1089) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_wordz_middle(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"pythonzabc.\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"zxyabc.\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"  lang  .\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K($input, $k) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return reverse_Array_Upto_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6), 4) !== array(4, 3, 2, 1, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6, 7), 2) !== array(5, 4, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(9, 8, 7, 6, 5), 3) !== array(7, 8, 9, 6, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks($subjectmarks) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return subject_marks(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97), array(\"Social sciences\", 82))) !== array(array(\"Social sciences\", 82), array(\"English\", 88), array(\"Science\", 90), array(\"Maths\", 97))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Telugu\", 49), array(\"Hindhi\", 54), array(\"Social\", 33))) !== array(array(\"Social\", 33), array(\"Telugu\", 49), array(\"Hindhi\", 54))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Physics\", 96), array(\"Chemistry\", 97), array(\"Biology\", 45))) !== array(array(\"Biology\", 45), array(\"Physics\", 96), array(\"Chemistry\", 97))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum($data_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return recursive_list_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, array(3, 4), array(5, 6))) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 10, array(15, 14), array(19, 41))) !== 106) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, array(30, 40), array(50, 60))) !== 210) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of positive numbers in an array.\nfunction pos_count($list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pos_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, -2, 3, -4)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 4, 5, -1)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return bell_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 115975) { throw new Exception(\"Test failed!\"); }\n    if (candidate(56) !== 6775685320645824322581483068371419745979053216268760300) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic($A) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_Monotonic(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(6, 5, 4, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist($l, $s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_sublist(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 4, 3, 5, 7), array(3, 7)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(4, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 3, 5, 7), array(1, 6)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return differ_At_One_Bit_Pos(...$args);\n}\n\nfunction test(): void {\n    if (candidate(13, 9) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15, 8) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 4) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 1) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 5) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal($Input) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(11, 22, 33), array(44, 55, 66))) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6, 7))) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(3, 4))) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort an array of elements.\nfunction comb_sort($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return comb_sort(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 15, 37, 25, 79)) !== array(5, 15, 25, 37, 79)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(41, 32, 15, 19, 22)) !== array(15, 19, 22, 32, 41)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(99, 15, 13, 47)) !== array(13, 15, 47, 99)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to add an array to the array. The output should be an array.\nfunction add_dict_to_tuple($test_tup, $test_dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add_dict_to_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(4, 5, 6), array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3)) !== array(4, 5, 6, array(\"MSAM\" => 1, \"is\" => 2, \"best\" => 3))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4)) !== array(1, 2, 3, array(\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 10), array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5)) !== array(8, 9, 10, array(\"POS\" => 3, \"is\" => 4, \"Okay\" => 5))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "php",
+    "prompt": "<?php\n// Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath($cost) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return maxAverageOfPath(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(6, 5, 4), array(7, 3, 9))) !== 5.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 4), array(7, 6, 5), array(8, 4, 10))) !== 6.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 4, 5), array(8, 7, 6), array(9, 5, 11))) !== 7.2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(7, 8, 9))) !== 5.8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "php",
+    "prompt": "<?php\n// The input is given as - an array with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunction filter_data($students, $h, $w) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return filter_data(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 6.0, 70) !== array(\"Cierra Vega\" => array(6.2, 70))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.9, 67) !== array(\"Cierra Vega\" => array(6.2, 70), \"Kierra Gentry\" => array(6.0, 68))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66)), 5.7, 64) !== array(\"Cierra Vega\" => array(6.2, 70), \"Alden Cantrell\" => array(5.9, 65), \"Kierra Gentry\" => array(6.0, 68), \"Pierre Cox\" => array(5.8, 66))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "php",
+    "prompt": "<?php\n// The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair($nums1, $nums2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_same_pair(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8), array(2, 2, 3, 1, 2, 6, 7, 9)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, -6, -9, 11, -12, 14, -5, 17), array(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 1, 2), array(0, 1, 2, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum($base, $power) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return power_base_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 100) !== 115) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 10) !== 37) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8, 15) !== 62) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3, 3) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation($text1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_quotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") !== array(\"A53\", \"multi\", \"Processor\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") !== array(\"favorite\", \"apps\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") !== array(\"4k Ultra HD\", \"HDR 10\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return multiply_elements(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 8, 10)) !== array(5, 35, 56, 80)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 5, 6, 7)) !== array(8, 20, 30, 42)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 13, 14, 9, 15)) !== array(156, 182, 126, 135)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list($lst1, $lst2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 20, 30), array(15, 25, 35)) !== array(25, 45, 65)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(5, 6, 7)) !== array(6, 8, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 20, 30), array(15, 45, 75)) !== array(30, 65, 105)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return dif_Square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(10, 15, 19, 18, 17, 26, 17, 18, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(\"a\", \"b\", \"c\", \"d\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\")) !== array(\"a\", \"b\", \"c\", \"d\", \"a\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone($r, $h) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return lateralsurface_cone(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5, 12) !== 204.20352248333654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 15) !== 566.3586699569488) { throw new Exception(\"Test failed!\"); }\n    if (candidate(19, 17) !== 1521.8090132193388) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return replace_specialchar(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python language, Programming language.\") !== \"Python:language::Programming:language:\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"a b c,d e f\") !== \"a:b:c:d:e:f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ram reshma,ram rahim\") !== \"ram:reshma:ram:rahim\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence($A, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_first_occurrence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_Of_Subarray_Prod(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 20) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2)) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4)) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return toggle_middle_bits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(9) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(11) !== 13) { throw new Exception(\"Test failed!\"); }\n    if (candidate(65) !== 127) { throw new Exception(\"Test failed!\"); }\n    if (candidate(77) !== 115) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/phpthon-exercises/data-structures-and-algorithms/phpthon-data-structure-exercise-24.php\nfunction left_insertion($a, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return left_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str($string) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_str(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"annie\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dawood\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Else\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/phpthon-exercises/data-structures-and-algorithms/phpthon-recursion-exercise-9.php\nfunction geometric_sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return geometric_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 1.9921875) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 1.9375) { throw new Exception(\"Test failed!\"); }\n    if (candidate(8) !== 1.99609375) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Index(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 45) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given array to a key-value array using adjacent elements. https://www.geeksforgeeks.org/phpthon-convert-array-to-adjacent-pair-array/\nfunction tuple_to_dict($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tuple_to_dict(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, 10, 13, 5)) !== array(1 => 5, 7 => 10, 13 => 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== array(1 => 2, 3 => 4, 5 => 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 10, 11, 12)) !== array(7 => 8, 9 => 10, 11 => 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether all the characters are same or not.\nfunction all_Characters_Same($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return all_Characters_Same(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aaa\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"data\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron($side) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return area_tetrahedron(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3) !== 15.588457268119894) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20) !== 692.8203230275509) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10) !== 173.20508075688772) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/phpthon-program-right-rotate-array-n/\nfunction rotate_right($list, $m) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rotate_right(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3) !== array(8, 9, 10, 1, 2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2) !== array(9, 10, 1, 2, 3, 4, 5, 6, 7, 8)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5) !== array(6, 7, 8, 9, 10, 1, 2, 3, 4, 5)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given array has any none value or not.\nfunction check_none($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_none(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, null)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 11, 14)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, null)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/phpthon-exercises/lambda/phpthon-lambda-exercise-24.php\nfunction divisible_by_digits($startnum, $endnum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return divisible_by_digits(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 22) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 15) !== array(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(20, 25) !== array(22, 24)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return null if the angle is larger than 360 degrees.\nfunction sector_area($r, $a) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sector_area(...$args);\n}\n\nfunction test(): void {\n    if (candidate(4, 45) !== 6.283185307179586) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 45) !== 31.808625617596654) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9, 361) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three($X, $Y, $Z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return lcs_of_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces($str1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return capital_words_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Python\") !== \"Python\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PythonProgrammingExamples\") !== \"Python Programming Examples\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GetReadyToBeCodingFreak\") !== \"Get Ready To Be Coding Freak\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/phpthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings($nums_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sort_numeric_strings(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\")) !== array(-500, -12, 0, 4, 7, 12, 45, 100, 200)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\")) !== array(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\")) !== array(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns($colors, $patterns) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_samepatterns(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"green\", \"green\"), array(\"a\", \"b\", \"b\")) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"green\", \"greenn\"), array(\"a\", \"b\")) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to add the given array to the given array.\nfunction add_tuple($test_list, $test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return add_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(5, 6, 7), array(9, 10)) !== array(5, 6, 7, 9, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(6, 7, 8), array(10, 11)) !== array(6, 7, 8, 10, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9), array(11, 12)) !== array(7, 8, 9, 11, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_min_heap(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 4, 5, 10, 15)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 10, 4, 5, 3, 15)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return jacobsthal_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(13) !== 2731) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/phpthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cophp of test cases\nfunction min_k($test_list, $K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return min_k(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Manjeet\", 10), array(\"Akshat\", 4), array(\"Akash\", 2), array(\"Nikhil\", 8)), 2) !== array(array(\"Akash\", 2), array(\"Akshat\", 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sanjeev\", 11), array(\"Angat\", 5), array(\"Akash\", 3), array(\"Nepin\", 9)), 3) !== array(array(\"Akash\", 3), array(\"Angat\", 5), array(\"Nepin\", 9))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"tanmay\", 14), array(\"Amer\", 11), array(\"Ayesha\", 9), array(\"SKD\", 16)), 1) !== array(array(\"Ayesha\", 9))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "php",
+    "prompt": "<?php\n// We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list($l1, $l2, $l3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return extract_index_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 5, 6, 7), array(0, 1, 2, 3, 4, 6, 5), array(0, 1, 2, 3, 4, 6, 7)) !== array(1, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 3, 4, 6, 5, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array(1, 5)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 6, 6, 6), array(0, 1, 2, 3, 4, 5, 7), array(0, 1, 2, 3, 4, 5, 7)) !== array()) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the second smallest number in an array.\nfunction second_smallest($numbers) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return second_smallest(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, -8, -2, 0, -2)) !== -2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, -0.5, 0, 2, -2, -2)) !== -0.5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 2, 2)) !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/phpthon-exercises/re/phpthon-re-exercise-3.php\nfunction text_match_zero_one($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_zero_one(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dsabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"asbbbba\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abaaa\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/phpthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_reverse_pairs(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\")) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"geeks\", \"best\", \"for\", \"skeeg\")) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"makes\", \"best\", \"sekam\", \"for\", \"rof\")) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal($num) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_decimal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"123.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"e666.86\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3.124587\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.11\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"1.1.11\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples($test_list, $K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_tuples(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(6, 24, 12), array(7, 9, 6), array(12, 18, 21)), 6) !== array(array(6, 24, 12))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(5, 25, 30), array(4, 2, 3), array(7, 8, 9)), 5) !== array(array(5, 25, 30))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(7, 9, 16), array(8, 16, 4), array(19, 17, 18)), 4) !== array(array(8, 16, 4))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return unique_Element(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number($monthnum3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_monthnumber_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff($arr, $n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_min_diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 3, 19, 18, 25), 6) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 3, 2, 6), 4) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(30, 5, 20, 9), 4) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count number of digits in a given string.\nfunction number_ctr($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return number_ctr(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"program2bedone\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wonders\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"123\") !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"3wond-1ers2\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_polite(...$args);\n}\n\nfunction test(): void {\n    if (candidate(7) !== 11) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 13) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise($l1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pair_wise(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 2, 3, 3, 4, 4, 5)) !== array(array(1, 1), array(1, 2), array(2, 3), array(3, 3), array(3, 4), array(4, 4), array(4, 5))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== array(array(1, 5), array(5, 7), array(7, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 1, 9, 7, 10)) !== array(array(5, 1), array(1, 9), array(9, 7), array(7, 10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(array(1, 2), array(2, 3), array(3, 4), array(4, 5), array(5, 6), array(6, 7), array(7, 8), array(8, 9), array(9, 10))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count($arr, $sum) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_pairs_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 1, 1, 1), 2) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, -1, 5), 6) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, -2, 3), 1) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(-1, -2, 3), -3) !== 1) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to get the difference between two arrays.\nfunction Diff($li1, $li2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 15, 20, 25, 30, 35, 40), array(25, 40, 35)) !== array(10, 20, 30, 15)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5), array(6, 7, 1)) !== array(2, 3, 4, 5, 6, 7)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3), array(6, 7, 1)) !== array(2, 3, 6, 7)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return odd_num_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2) !== 82) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 707) { throw new Exception(\"Test failed!\"); }\n    if (candidate(4) !== 3108) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression($exp) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_expression(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"{()}[{}]\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{]\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"{()}[{}][]({})\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all the words with k length in the given string.\nfunction remove_length($test_str, $K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"The person is most value tet\", 3) !== \"person is most value\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"If you told me about this ok\", 4) !== \"If you me about ok\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"Forces of darkeness is come into the play\", 4) !== \"Forces of darkeness is the\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the occurrence and position of the substrings within a string. Return null if there is no match.\nfunction occurance_substring($text, $pattern) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return occurance_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python programming, python language\", \"python\") !== array(\"python\", 0, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"programming\") !== array(\"programming\", 7, 18)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python programming,programming language\", \"language\") !== array(\"language\", 31, 39)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"c++ programming, c++ language\", \"python\") !== null) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return odd_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(2, 1, 4, 3, 6, 7, 6, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 1, 2)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels($test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_vowels(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"bestinstareels\") !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"partofthejourneyistheend\") !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"amazonprime\") !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 1, 1, 4, 5, 6)) !== 21) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 10, 9, 4, 2, 10, 10, 45, 4)) !== 71) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 10, 9, 45, 2, 10, 10, 45, 10)) !== 78) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return pack_consecutive_duplicates(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)) !== array(array(0, 0), array(1), array(2), array(3), array(4, 4), array(5), array(6, 6, 6), array(7), array(8), array(9), array(4, 4))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)) !== array(array(10, 10), array(15), array(19), array(18, 18), array(17), array(26, 26), array(17), array(18), array(10))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"a\", \"b\", \"c\", \"d\", \"d\")) !== array(array(\"a\", \"a\"), array(\"b\"), array(\"c\"), array(\"d\", \"d\"))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find whether a number is divisible by 11.\nfunction is_Diff($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_Diff(...$args);\n}\n\nfunction test(): void {\n    if (candidate(12345) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212112) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1212) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/phpthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_combinations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(2, 4), array(6, 7), array(5, 1), array(6, 10))) !== array(array(8, 11), array(7, 5), array(8, 14), array(11, 8), array(12, 17), array(11, 11))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 5), array(7, 8), array(6, 2), array(7, 11))) !== array(array(10, 13), array(9, 7), array(10, 16), array(13, 10), array(14, 19), array(13, 13))) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(4, 6), array(8, 9), array(7, 3), array(8, 12))) !== array(array(12, 15), array(11, 9), array(12, 18), array(15, 12), array(16, 21), array(15, 15))) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the count of divisors is even. https://www.w3resource.com/phpthon-exercises/basic/phpthon-basic-1-exercise-24.php\nfunction count_divisors($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_divisors(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(100) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return odd_length_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4)) !== 14) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 2)) !== 15) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 7)) !== 8) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv($r, $g, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return rgb_to_hsv(...$args);\n}\n\nfunction test(): void {\n    if (candidate(255, 255, 255) !== array(0.0, 0.0, 100.0)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(0, 215, 0) !== array(120.0, 100.0, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 215, 110) !== array(149.26829268292684, 95.34883720930233, 84.31372549019608)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return mul_even_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5, 7, 4, 1, 6, 8)) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 5, 7, 9, 10)) !== 10) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert array string to integer array.\nfunction tuple_str_int($test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tuple_str_int(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"(7, 8, 9)\") !== array(7, 8, 9)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(1, 2, 3)\") !== array(1, 2, 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(4, 5, 6)\") !== array(4, 5, 6)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"(7, 81, 19)\") !== array(7, 81, 19)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion($a, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return right_insertion(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 4, 5), 6) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 3) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 4, 5), 7) !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_match_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"ac\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"dc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"caacabbbba\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to create a new array from the given string and array.\nfunction new_tuple($test_list, $test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return new_tuple(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"WEB\", \"is\"), \"best\") !== array(\"WEB\", \"is\", \"best\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"We\", \"are\"), \"Developers\") !== array(\"We\", \"are\", \"Developers\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"Part\", \"is\"), \"Wrong\") !== array(\"Part\", \"is\", \"Wrong\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether every even index contains even numbers of a given array.\nfunction even_position($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return even_position(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove arrays from the given array.\nfunction remove_nested($test_tup) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_nested(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 5, 7, array(4, 6), 10)) !== array(1, 5, 7, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 6, 8, array(5, 7), 11)) !== array(2, 6, 8, 11)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(3, 7, 9, array(6, 8), array(5, 12), 12)) !== array(3, 7, 9, 12)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of arrays in a given number of arrays.\nfunction count_list($input_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 3), array(5, 7), array(9, 11), array(13, 15, 17))) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(2, 3), array(4, 5))) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 0), array(2, 0))) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the last position of an element in a sorted array.\nfunction last($arr, $x) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return last(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), 1) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1, 1, 2, 3, 4), 1) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 3, 2, 3, 6, 8, 9), 3) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return text_starta_endb(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aabbbb\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"aabAbbbc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"accddbbjjj\") !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "php",
+    "prompt": "<?php\n// Write function to find the sum of all items in the given array.\nfunction return_sum($dict) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return return_sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"a\" => 100, \"b\" => 200, \"c\" => 300)) !== 600) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 25, \"b\" => 18, \"c\" => 45)) !== 88) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\" => 36, \"b\" => 39, \"c\" => 49)) !== 124) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range($l, $r) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sum_in_range(...$args);\n}\n\nfunction test(): void {\n    if (candidate(2, 5) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 7) !== 12) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7, 13) !== 40) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the sum of an array.\nfunction _sum($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return _sum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(15, 12, 13, 10)) !== 50) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(0, 1, 2)) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate($n, $d) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return left_rotate(...$args);\n}\n\nfunction test(): void {\n    if (candidate(16, 2) !== 64) { throw new Exception(\"Test failed!\"); }\n    if (candidate(10, 2) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(99, 3) !== 792) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 3) !== 40) { throw new Exception(\"Test failed!\"); }\n    if (candidate(29, 3) !== 232) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to check whether the length of the word is odd or not.\nfunction word_len($s) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return word_len(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"Hadoop\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"great\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"structure\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces($text) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return remove_all_spaces(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"python  program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python   programming    language\") !== \"pythonprogramminglanguage\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"   python                     program\") !== \"pythonprogram\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal($x, $y, $z) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return test_three_equal(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1, 1, 1) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(-1, -2, -3) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1, 2, 2) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return count_rotation(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(3, 2, 1)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 1, 2, 3)) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 1, 2, 3)) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3)) !== 0) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 3, 2)) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_perfect_square(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(36) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(14) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(196) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(125) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(15625) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even($arr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_product_even(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 1, 4)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 1)) !== false) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "php",
+    "prompt": "<?php\n// Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list($lists) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_sum_list(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3), array(4, 5, 6), array(10, 11, 12), array(7, 8, 9))) !== array(10, 11, 12)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 2, 1), array(6, 5, 4), array(12, 11, 10))) !== array(12, 11, 10)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(2, 3, 1))) !== array(2, 3, 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase($test_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return max_run_uppercase(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"GeMKSForGERksISBESt\") !== 5) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"PrECIOusMOVemENTSYT\") !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"GooGLEFluTTER\") !== 4) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the first odd number in a given array of numbers.\nfunction first_odd($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return first_odd(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 3, 5)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(2, 4, 1, 3)) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(8, 9, 1)) !== 9) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if the given arrays contain the k or not.\nfunction check_K($test_tup, $K) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_K(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 4, 5, 6, 8), 6) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 5, 6), 7) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(7, 8, 9, 44, 11, 12), 11) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller($test_tup1, $test_tup2) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return check_smaller(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3), array(2, 3, 4)) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(4, 5, 6), array(3, 4, 5)) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(11, 12, 13), array(10, 11, 12)) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return tetrahedral_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(5) !== 35) { throw new Exception(\"Test failed!\"); }\n    if (candidate(6) !== 56) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 84) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char($strr) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return get_Char(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"abc\") !== \"f\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"gfg\") !== \"t\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== \"c\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the nth number in the newman conway sequence.\nfunction sequence($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return sequence(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(3) !== 2) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return centered_hexagonal_number(...$args);\n}\n\nfunction test(): void {\n    if (candidate(10) !== 271) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 217) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to merge three dictionaries into a single array.\nfunction merge_dictionaries_three($dict1, $dict2, $dict3) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return merge_dictionaries_three(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\")) !== array(\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"G\" => \"Green\", \"W\" => \"White\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\")) !== array(\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\")) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"), array(\"L\" => \"lavender\", \"B\" => \"Blue\"), array(\"G\" => \"Green\", \"W\" => \"White\")) !== array(\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\")) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to get the frequency of all the elements in an array, returned as an array.\nfunction freq_count($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return freq_count(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)) !== array(10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)) !== array(1 => 3, 2 => 2, 3 => 3, 4 => 3)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)) !== array(10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find the closest smaller number than n.\nfunction closest_num($N) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return closest_num(...$args);\n}\n\nfunction test(): void {\n    if (candidate(11) !== 10) { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 11) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find squares of individual elements in an array.\nfunction square_nums($nums) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return square_nums(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) !== array(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(10, 20, 30)) !== array(100, 400, 900)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(12, 15)) !== array(144, 225)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the length of the longest word.\nfunction len_log($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return len_log(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"python\", \"PHP\", \"bigdata\")) !== 7) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"a\", \"ab\", \"abc\")) !== 3) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"small\", \"big\", \"tall\")) !== 5) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring($str1, $sub_str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_substring(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ack\") !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"abc\") !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(\"red\", \"black\", \"white\", \"green\", \"orange\"), \"ange\") !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to check whether the given number is undulating or not.\nfunction is_undulating($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return is_undulating(...$args);\n}\n\nfunction test(): void {\n    if (candidate(1212121) !== true) { throw new Exception(\"Test failed!\"); }\n    if (candidate(1991) !== false) { throw new Exception(\"Test failed!\"); }\n    if (candidate(121) !== true) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to calculate the value of 'a' to the power 'b'.\nfunction power($a, $b) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return power(...$args);\n}\n\nfunction test(): void {\n    if (candidate(3, 4) !== 81) { throw new Exception(\"Test failed!\"); }\n    if (candidate(2, 3) !== 8) { throw new Exception(\"Test failed!\"); }\n    if (candidate(5, 5) !== 3125) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "php",
+    "prompt": "<?php\n// Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum($test_list) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return index_minimum(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(\"Rash\", 143), array(\"Manjeet\", 200), array(\"Varsha\", 100))) !== \"Varsha\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Yash\", 185), array(\"Dawood\", 125), array(\"Sanya\", 175))) !== \"Dawood\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(\"Sai\", 345), array(\"Salman\", 145), array(\"Ayesha\", 96))) !== \"Ayesha\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length($lst) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return Find_Min_Length(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1), array(1, 2))) !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2), array(1, 2, 3), array(1, 2, 3, 4))) !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(3, 3, 3), array(4, 4, 4, 4))) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the number of divisors of a given integer.\nfunction divisor($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return divisor(...$args);\n}\n\nfunction test(): void {\n    if (candidate(15) !== 4) { throw new Exception(\"Test failed!\"); }\n    if (candidate(12) !== 6) { throw new Exception(\"Test failed!\"); }\n    if (candidate(9) !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to find frequency of each element in a flattened array of arrays, returned in an array.\nfunction frequency_lists($list1) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return frequency_lists(...$args);\n}\n\nfunction test(): void {\n    if (candidate(array(array(1, 2, 3, 2), array(4, 5, 6, 2), array(7, 8, 9, 5))) !== array(1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(1, 2, 3, 4), array(5, 6, 7, 8), array(9, 10, 11, 12))) !== array(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1)) { throw new Exception(\"Test failed!\"); }\n    if (candidate(array(array(20, 30, 40, 17), array(18, 16, 14, 13), array(10, 20, 30, 40))) !== array(20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1)) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "php",
+    "prompt": "<?php\n// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary($n) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return decimal_to_binary(...$args);\n}\n\nfunction test(): void {\n    if (candidate(8) !== \"1000\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(18) !== \"10010\") { throw new Exception(\"Test failed!\"); }\n    if (candidate(7) !== \"111\") { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction",
+      "\n?>",
+      "\n//",
+      "\n#"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "php",
+    "prompt": "<?php\n// Write a phpthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations($str) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "function candidate(...$args) {\n    return find_Rotations(...$args);\n}\n\nfunction test(): void {\n    if (candidate(\"aaaa\") !== 1) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"ab\") !== 2) { throw new Exception(\"Test failed!\"); }\n    if (candidate(\"abc\") !== 3) { throw new Exception(\"Test failed!\"); }\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction",
       "\n?>",

--- a/prompts/mbpp-pl-keep.json
+++ b/prompts/mbpp-pl-keep.json
@@ -1,4114 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "pl",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nsub lps {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lps;\n        if(eq_deeply($candidate->(\"TENS FOR TENS\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"CARDIO FOR CARDS\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PART OF THE JOURNEY IS PART\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "pl",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\nsub remove_whitespaces {\n    my($text1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_whitespaces;\n        if(eq_deeply($candidate->(\" Google    Flutter \"),\"GoogleFlutter\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" Google    Dart \"),\"GoogleDart\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" iOS    Swift \"),\"iOSSwift\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "pl",
-    "prompt": "# Write a function to check whether a specified list is sorted or not.\nsub issort_list {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&issort_list;\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 15, 14, 20]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "pl",
-    "prompt": "# Write a function to count bidirectional tuple pairs.\nsub count_bidirectional {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_bidirectional;\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "pl",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsub surfacearea_cube {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cube;\n        if(eq_deeply($candidate->(5),150)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "pl",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nsub next_smallest_palindrome {\n    my($num) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest_palindrome;\n        if(eq_deeply($candidate->(99),101)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1221),1331)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\nsub cube_Sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_Sum;\n        if(eq_deeply($candidate->(2),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\nsub pair_xor_Sum {\n    my($arr, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_xor_Sum;\n        if(eq_deeply($candidate->([5, 9, 7, 6], 4),47)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 5], 3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nsub check_min_heap {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_min_heap;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 10, 15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 5, 3, 15]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "pl",
-    "prompt": "# Write a python function to find the first digit of a given number.\nsub first_Digit {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_Digit;\n        if(eq_deeply($candidate->(123),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(456),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "pl",
-    "prompt": "# Write a python function to find the first non-repeated character in a given string.\nsub first_non_repeating_character {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_non_repeating_character;\n        if(eq_deeply($candidate->(\"abcabc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ababc\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "pl",
-    "prompt": "# Write a function to convert degrees to radians.\nsub radian_degree {\n    my($degree) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&radian_degree;\n        if(eq_deeply($candidate->(90),1.5707963267948966)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(60),1.0471975511965976)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),2.0943951023931953)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum product subarray of the given array.\nsub max_subarray_product {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_subarray_product;\n        if(eq_deeply($candidate->([1, -2, -3, 0, 7, -8, -2]),112)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, -3, -10, 0, 2]),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -40, 0, -2, -3]),80)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "pl",
-    "prompt": "# Write a function to convert more than one list to nested dictionary.\nsub convert_list_dictionary {\n    my($l1, $l2, $l3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert_list_dictionary;\n        if(eq_deeply($candidate->([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "pl",
-    "prompt": "# Write a python function to find smallest number in a list.\nsub smallest_num {\n    my($xs) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_num;\n        if(eq_deeply($candidate->([10, 20, 1, 45, 99]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([45, 46, 50, 60]),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nsub text_match_zero_one {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_zero_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dsabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asbbbba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "pl",
-    "prompt": "# Write a python function to find nth bell number.\nsub bell_Number {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_Number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "pl",
-    "prompt": "# Write a function to find cubes of individual elements in a list.\nsub cube_nums {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[1728, 3375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "pl",
-    "prompt": "# Write a python function to find the last digit in factorial of a given number.\nsub last_Digit_Factorial {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit_Factorial;\n        if(eq_deeply($candidate->(4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(21),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "pl",
-    "prompt": "# Write a python function to find even numbers from a list of numbers.\nsub Split {\n    my($list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 12, 15, 19]),[8, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given integer is a prime number.\nsub prime_num {\n    my($num) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_num;\n        if(eq_deeply($candidate->(13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1010),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nsub find_tuples {\n    my($test_list, $K) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_tuples;\n        if(eq_deeply($candidate->([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "pl",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\nsub area_tetrahedron {\n    my($side) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&area_tetrahedron;\n        if(eq_deeply($candidate->(3),15.588457268119894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),692.8203230275509)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),173.20508075688772)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given number is even or not.\nsub is_Even {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Even;\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of positive numbers in a list.\nsub pos_count {\n    my($list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pos_count;\n        if(eq_deeply($candidate->([1, -2, 3, -4]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 5, -1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "pl",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nsub get_ludic {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_ludic;\n        if(eq_deeply($candidate->(10),[1, 2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "pl",
-    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nsub find_Index {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Index;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "pl",
-    "prompt": "# Write a python function to reverse an array upto a given position.\nsub reverse_Array_Upto_K {\n    my($input, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_Array_Upto_K;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7], 2),[5, 4, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "pl",
-    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\nsub subject_marks {\n    my($subjectmarks) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&subject_marks;\n        if(eq_deeply($candidate->([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "pl",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nsub remove_dirty_chars {\n    my($string, $second_string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_dirty_chars;\n        if(eq_deeply($candidate->(\"probasscurve\", \"pros\"),\"bacuve\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"digitalindia\", \"talent\"),\"digiidi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"exoticmiles\", \"toxic\"),\"emles\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "pl",
-    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nsub round_and_sum {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&round_and_sum;\n        if(eq_deeply($candidate->([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 9, 24.3, 29]),345)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25.0, 56.7, 89.2]),513)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "pl",
-    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nsub max_occurrences {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_occurrences;\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "pl",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nsub is_decimal {\n    my($num) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_decimal;\n        if(eq_deeply($candidate->(\"123.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"e666.86\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3.124587\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.1.11\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nsub dict_filter {\n    my($dict, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dict_filter;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170),{\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180),{\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190),{\"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\nsub sum_even_and_even_index {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_even_and_even_index;\n        if(eq_deeply($candidate->([5, 6, 12, 1, 18, 8]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 12, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nsub max_sub_array_sum {\n    my($a, $size) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum;\n        if(eq_deeply($candidate->([-2, -3, 4, -1, -2, 1, 5, -3], 8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -4, 5, -2, -3, 2, 6, -4], 8),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-4, -5, 6, -3, -4, 3, 7, -5], 8),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "pl",
-    "prompt": "# Write a function to find the intersection of two arrays.\nsub intersection_array {\n    my($array_nums1, $array_nums2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection_array;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nsub split_two_parts {\n    my($list1, $L) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_two_parts;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "pl",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nsub find_literals {\n    my($text, $pattern) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_literals;\n        if(eq_deeply($candidate->(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "pl",
-    "prompt": "# Write a python function to find the volume of a triangular prism.\nsub find_Volume {\n    my($l, $b, $h) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Volume;\n        if(eq_deeply($candidate->(10, 8, 6),240)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nsub wind_chill {\n    my($v, $t) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&wind_chill;\n        if(eq_deeply($candidate->(120, 35),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(40, 20),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "pl",
-    "prompt": "# Write a function to find the ascii value of a character.\nsub ascii_value {\n    my($k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&ascii_value;\n        if(eq_deeply($candidate->(\"A\"),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"R\"),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"S\"),83)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether all the characters are same or not.\nsub all_Characters_Same {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Characters_Same;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "pl",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\nsub move_num {\n    my($test_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_num;\n        if(eq_deeply($candidate->(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Avengers124Assemble\"),\"AvengersAssemble124\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the length of the word is odd or not.\nsub word_len {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&word_len;\n        if(eq_deeply($candidate->(\"Hadoop\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"great\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"structure\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "pl",
-    "prompt": "# Write a function to drop empty items from a given dictionary.\nsub drop_empty {\n    my($dict1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&drop_empty;\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => undef}),{\"c1\" => \"Red\", \"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => undef, \"c3\" => undef}),{\"c1\" => \"Red\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => undef, \"c2\" => \"Green\", \"c3\" => undef}),{\"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nsub insert_element {\n    my($list, $element) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&insert_element;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "pl",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\nsub remove_lowercase {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_lowercase;\n        if(eq_deeply($candidate->(\"PYTHon\"),\"PYTH\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"FInD\"),\"FID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"STRinG\"),\"STRG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nsub count_Set_Bits {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Set_Bits;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "pl",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\nsub extract_rear {\n    my($test_tuple) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_rear;\n        if(eq_deeply($candidate->([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\nsub count_occurance {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_occurance;\n        if(eq_deeply($candidate->(\"letstdlenstdporstd\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"truststdsolensporsd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"makestdsostdworthit\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"stds\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given tuples contain the k or not.\nsub check_K {\n    my($test_tup, $K) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_K;\n        if(eq_deeply($candidate->([10, 4, 5, 6, 8], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 44, 11, 12], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "pl",
-    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\nsub interleave_lists {\n    my($list1, $list2, $list3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&interleave_lists;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "pl",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"python_program\"),\"PythonProgram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python_language\"),\"PythonLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"programming_language\"),\"ProgrammingLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\nsub test_three_equal {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_three_equal;\n        if(eq_deeply($candidate->(1, 1, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2, -3),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nsub odd_length_sum {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_length_sum;\n        if(eq_deeply($candidate->([1, 2, 4]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 7]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "pl",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nsub bell_number {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),115975)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(56),6775685320645824322581483068371419745979053216268760300)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "pl",
-    "prompt": "# Write a function to find the area of a rectangle.\nsub rectangle_area {\n    my($l, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rectangle_area;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "pl",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsub sum_average {\n    my($number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_average;\n        if(eq_deeply($candidate->(10),[55, 5.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),[120, 8.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[210, 10.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nsub division_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&division_elements;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "pl",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsub sum_digits {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_digits;\n        if(eq_deeply($candidate->(345),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "pl",
-    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nsub index_minimum {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_minimum;\n        if(eq_deeply($candidate->([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "pl",
-    "prompt": "# Write a function to divide two lists element wise.\nsub div_list {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&div_list;\n        if(eq_deeply($candidate->([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2], [1, 4]),[3.0, 0.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[1.8, 1.7142857142857142])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "pl",
-    "prompt": "# Write a function to find the list with maximum length.\nsub max_length_list {\n    my($input_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length_list;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "pl",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\nsub combinations_list {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_list;\n        if(eq_deeply($candidate->([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\nsub big_sum {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 6]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "pl",
-    "prompt": "# Write a python function to return the negative numbers in a list.\nsub neg_nos {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&neg_nos;\n        if(eq_deeply($candidate->([-1, 4, 5, -6]),[-1, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3, 4]),[-1, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-7, -6, 8, 9]),[-7, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "pl",
-    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\nsub highest_Power_of_2 {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&highest_Power_of_2;\n        if(eq_deeply($candidate->(10),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "pl",
-    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nsub is_sublist {\n    my($l, $s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sublist;\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [4, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [1, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "pl",
-    "prompt": "# Write a function to subtract two lists element-wise.\nsub sub_list {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sub_list;\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),[-3, -3, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 4]),[-2, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[40, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\nsub opposite_Signs {\n    my($x, $y) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&opposite_Signs;\n        if(eq_deeply($candidate->(1, -2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "pl",
-    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\nsub tuple_modulo {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_modulo;\n        if(eq_deeply($candidate->([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "pl",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\nsub diff_even_odd {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&diff_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "pl",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsub sort_sublists {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "pl",
-    "prompt": "# Write a python function to find the last digit of a given number.\nsub last_Digit {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit;\n        if(eq_deeply($candidate->(123),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\nsub odd_num_sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_num_sum;\n        if(eq_deeply($candidate->(2),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),707)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),3108)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "pl",
-    "prompt": "# Write a function to convert a list to a string.\nsub tup_string {\n    my($tup1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tup_string;\n        if(eq_deeply($candidate->([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "pl",
-    "prompt": "# Write a function to remove all elements from a given list present in another list.\nsub remove_elements {\n    my($list1, $list2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_elements;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\nsub overlapping {\n    my($list1, $list2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&overlapping;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5], [1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "pl",
-    "prompt": "# Write a python function to identify non-prime numbers.\nsub is_not_prime {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_not_prime;\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(35),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(37),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nsub max_val {\n    my($listval) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsub sum_negativenum {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_negativenum;\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, -14, 13, -18, 12, -20]),-52)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "pl",
-    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nsub find_Rotations {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Rotations;\n        if(eq_deeply($candidate->(\"aaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "pl",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nsub change_date_format {\n    my($dt) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_date_format;\n        if(eq_deeply($candidate->(\"2026-01-02\"),\"02-01-2026\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020-11-13\"),\"13-11-2020\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2021-04-26\"),\"26-04-2021\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "pl",
-    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\nsub Split {\n    my($list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 12, 13]),[11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1]),[7, 9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "pl",
-    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nsub toggle_middle_bits {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_middle_bits;\n        if(eq_deeply($candidate->(9),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(65),127)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nsub count_char_position {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_char_position;\n        if(eq_deeply($candidate->(\"xbcefg\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABcED\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"AbgdeF\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nsub large_product {\n    my($nums1, $nums2, $N) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&large_product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nsub cummulative_sum {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cummulative_sum;\n        if(eq_deeply($candidate->([[1, 3], [5, 6, 7], [2, 6]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [6, 7, 8], [3, 7]]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8, 9], [4, 8]]),44)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "pl",
-    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nsub find_min_diff {\n    my($arr, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_min_diff;\n        if(eq_deeply($candidate->([1, 5, 3, 19, 18, 25], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 6], 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 5, 20, 9], 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nsub text_starta_endb {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_starta_endb;\n        if(eq_deeply($candidate->(\"aabbbb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabAbbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"accddbbjjj\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "pl",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nsub left_rotate {\n    my($n, $d) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_rotate;\n        if(eq_deeply($candidate->(16, 2),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(29, 3),232)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "pl",
-    "prompt": "# Write a python function to find the first repeated character in a given string.\nsub first_repeated_char {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_repeated_char;\n        if(eq_deeply($candidate->(\"abcabc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123123\"),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "pl",
-    "prompt": "# Write a python function to count inversions in an array.\nsub get_Inv_Count {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Inv_Count;\n        if(eq_deeply($candidate->([1, 20, 6, 4, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 6, 1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "pl",
-    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nsub even_Power_Sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_Power_Sum;\n        if(eq_deeply($candidate->(2),1056)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),8832)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "pl",
-    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nsub get_equal {\n    my($Input) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_equal;\n        if(eq_deeply($candidate->([[11, 22, 33], [44, 55, 66]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "pl",
-    "prompt": "# Write a function to check if a string represents an integer or not.\nsub check_integer {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_integer;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12345\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "pl",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nsub count_reverse_pairs {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_reverse_pairs;\n        if(eq_deeply($candidate->([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"geeks\", \"best\", \"for\", \"skeeg\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "pl",
-    "prompt": "# Write a python function to move all zeroes to the end of the given list.\nsub move_zero {\n    my($num_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_zero;\n        if(eq_deeply($candidate->([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "pl",
-    "prompt": "# Write a function to check if given list contains no duplicates.\nsub check_distinct {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_distinct;\n        if(eq_deeply($candidate->([1, 4, 5, 6, 1, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nsub noprofit_noloss {\n    my($actual_cost, $sale_amount) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&noprofit_noloss;\n        if(eq_deeply($candidate->(1500, 1200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "pl",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\nsub remove_length {\n    my($test_str, $K) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_length;\n        if(eq_deeply($candidate->(\"The person is most value tet\", 3),\"person is most value\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"If you told me about this ok\", 4),\"If you me about ok\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "pl",
-    "prompt": "# Write a python function to count number of digits in a given string.\nsub number_ctr {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_ctr;\n        if(eq_deeply($candidate->(\"program2bedone\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wonders\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wond-1ers2\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "pl",
-    "prompt": "# Write a function to count the total number of characters in a string.\nsub count_charac {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_charac;\n        if(eq_deeply($candidate->(\"python programming\"),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"words\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "pl",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nsub get_total_number_of_sequences {\n    my($m, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_total_number_of_sequences;\n        if(eq_deeply($candidate->(10, 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 3),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "pl",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nsub left_insertion {\n    my($a, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nsub swap_numbers {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_numbers;\n        if(eq_deeply($candidate->(10, 20),[20, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 17),[17, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[200, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nsub is_majority {\n    my($arr, $n, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_majority;\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 3, 10], 7, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 2], 5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2], 5, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nsub substract_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&substract_elements;\n        if(eq_deeply($candidate->([10, 4, 5], [2, 5, 18]),[8, -1, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 2, 3], [24, 45, 16]),[-13, -43, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 18, 9], [10, 11, 12]),[-3, 7, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\nsub capital_words_spaces {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&capital_words_spaces;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PythonProgrammingExamples\"),\"Python Programming Examples\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "pl",
-    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\nsub find_Average_Of_Cube {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Average_Of_Cube;\n        if(eq_deeply($candidate->(2),4.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "pl",
-    "prompt": "# Write a function to check if all values are same in a dictionary.\nsub check_value {\n    my($dict, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_value;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth tetrahedral number.\nsub tetrahedral_number {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tetrahedral_number;\n        if(eq_deeply($candidate->(5),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "pl",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nsub magic_square_test {\n    my($my_matrix) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&magic_square_test;\n        if(eq_deeply($candidate->([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "pl",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\nsub remove_uppercase {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_uppercase;\n        if(eq_deeply($candidate->(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "pl",
-    "prompt": "# Write a function to check whether an element exists within a tuple.\nsub check_tuplex {\n    my($tuplex, $tuple1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_tuplex;\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "pl",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\nsub dog_age {\n    my($h_age) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dog_age;\n        if(eq_deeply($candidate->(12),61)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24),109)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "pl",
-    "prompt": "# Write a python function to find the next perfect square greater than a given number.\nsub next_Perfect_Square {\n    my($N) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_Perfect_Square;\n        if(eq_deeply($candidate->(35),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "pl",
-    "prompt": "# Write a function to create a list of N empty dictionaries.\nsub empty_list {\n    my($length) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&empty_list;\n        if(eq_deeply($candidate->(5),[{}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[{}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[{}, {}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "pl",
-    "prompt": "# Write a python function to convert a given string to uppercase.\nsub is_upper {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_upper;\n        if(eq_deeply($candidate->(\"person\"),\"PERSON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final\"),\"FINAL\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Valid\"),\"VALID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "pl",
-    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nsub odd_Equivalent {\n    my($s, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_Equivalent;\n        if(eq_deeply($candidate->(\"011001\", 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011\", 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1010\", 4),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nsub re_arrange_array {\n    my($arr, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&re_arrange_array;\n        if(eq_deeply($candidate->([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\nsub unique_Element {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_Element;\n        if(eq_deeply($candidate->([1, 1, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "pl",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\nsub extract_values {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_values;\n        if(eq_deeply($candidate->(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "pl",
-    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nsub find_even_pair {\n    my($A) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_even_pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\nsub armstrong_number {\n    my($number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&armstrong_number;\n        if(eq_deeply($candidate->(153),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(259),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4458),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "pl",
-    "prompt": "# Write a python function to count the upper case characters in a given string.\nsub upper_ctr {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&upper_ctr;\n        if(eq_deeply($candidate->(\"PYthon\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"BigData\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\nsub and_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&and_tuples;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "pl",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nsub is_samepatterns {\n    my($colors, $patterns) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_samepatterns;\n        if(eq_deeply($candidate->([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of lists in a given number of lists.\nsub count_list {\n    my($input_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [2, 3], [4, 5]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 0], [2, 0]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "pl",
-    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nsub average_tuple {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&average_tuple;\n        if(eq_deeply($candidate->([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "pl",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nsub lcs_of_three {\n    my($X, $Y, $Z) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lcs_of_three;\n        if(eq_deeply($candidate->(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the n'th star number.\nsub find_star_num {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_star_num;\n        if(eq_deeply($candidate->(3),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of an array.\nsub _sum {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 12, 13, 10]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\nsub check_Consecutive {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_Consecutive;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "pl",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nsub find_adverb_position {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverb_position;\n        if(eq_deeply($candidate->(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"seriously!! there are many roses\"),[0, 9, \"seriously\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "pl",
-    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nsub rotate_right {\n    my($list, $m) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rotate_right;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\nsub number_of_substrings {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_of_substrings;\n        if(eq_deeply($candidate->(\"abc\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nsub list_split {\n    my($S, $step) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_split;\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "pl",
-    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\nsub all_unique {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_unique;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "pl",
-    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\nsub convert {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert;\n        if(eq_deeply($candidate->(1),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "pl",
-    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nsub filter_data {\n    my($students, $h, $w) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_data;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70),{\"Cierra Vega\" => [6.2, 70]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67),{\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64),{\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "pl",
-    "prompt": "# Write a python function to convert the given string to lower case.\nsub is_lower {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_lower;\n        if(eq_deeply($candidate->(\"InValid\"),\"invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"TruE\"),\"true\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"SenTenCE\"),\"sentence\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "pl",
-    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\nsub next_power_of_2 {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_power_of_2;\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "pl",
-    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nsub find_substring {\n    my($str1, $sub_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_substring;\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "pl",
-    "prompt": "# Write a function to replace characters in a string.\nsub replace_char {\n    my($str1, $ch, $newch) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_char;\n        if(eq_deeply($candidate->(\"polygon\", \"y\", \"l\"),\"pollgon\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"character\", \"c\", \"a\"),\"aharaater\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\", \"l\", \"a\"),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "pl",
-    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nsub mul_even_odd {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mul_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to convert a list to a tuple.\nsub list_tuple {\n    my($listx) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_tuple;\n        if(eq_deeply($candidate->([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([58, 44, 56]),[58, 44, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "pl",
-    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nsub even_binomial_Coeff_Sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_binomial_Coeff_Sum;\n        if(eq_deeply($candidate->(4),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "pl",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\nsub bitwise_xor {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bitwise_xor;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether a list is sublist of another or not.\nsub is_Sub_Array {\n    my($A, $B) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sub_Array;\n        if(eq_deeply($candidate->([1, 4, 3, 5], [1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], [1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 2], [2, 2, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "pl",
-    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nsub max_sub_array_sum_repeated {\n    my($a, $n, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum_repeated;\n        if(eq_deeply($candidate->([10, 20, -30, -1], 4, 3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 10, 20], 3, 2),59)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3], 3, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\nsub min_product_tuple {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nsub count_divisors {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_divisors;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "pl",
-    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nsub triangle_area {\n    my($r) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(-1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to convert a given string to a list of characters.\nsub string_to_tuple {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_tuple;\n        if(eq_deeply($candidate->(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nsub find_length {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_length;\n        if(eq_deeply($candidate->(\"11000010001\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"10111\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011101100101\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "pl",
-    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nsub count_Primes_nums {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Primes_nums;\n        if(eq_deeply($candidate->(5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\nsub sum_Of_product {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_product;\n        if(eq_deeply($candidate->(3),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\nsub max_aggregate {\n    my($stdata) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_aggregate;\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "pl",
-    "prompt": "# Write a function to sort a list of elements.\nsub comb_sort {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&comb_sort;\n        if(eq_deeply($candidate->([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([99, 15, 13, 47]),[13, 15, 47, 99])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nsub check_expression {\n    my($exp) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_expression;\n        if(eq_deeply($candidate->(\"{()}[{}]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{}][]({})\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "pl",
-    "prompt": "# Write a function that matches a word containing 'z'.\nsub text_match_wordz {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz;\n        if(eq_deeply($candidate->(\"pythonz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "pl",
-    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsub sum_list {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_list;\n        if(eq_deeply($candidate->([10, 20, 30], [15, 25, 35]),[25, 45, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [5, 6, 7]),[6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 20, 30], [15, 45, 75]),[30, 65, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nsub newman_prime {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&newman_prime;\n        if(eq_deeply($candidate->(3),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),17)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),41)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "pl",
-    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nsub add_string {\n    my($list_, $string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_string;\n        if(eq_deeply($candidate->([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "pl",
-    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\nsub surface_Area {\n    my($b, $s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surface_Area;\n        if(eq_deeply($candidate->(3, 4),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "pl",
-    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\nsub Find_Min_Length {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min_Length;\n        if(eq_deeply($candidate->([[1], [1, 2]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 3, 3], [4, 4, 4, 4]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "pl",
-    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nsub validate {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&validate;\n        if(eq_deeply($candidate->(1234),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(51241),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(321),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth hexagonal number.\nsub hexagonal_num {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hexagonal_num;\n        if(eq_deeply($candidate->(10),190)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),91)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "pl",
-    "prompt": "# Write a function to find the n'th lucas number.\nsub find_lucas {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lucas;\n        if(eq_deeply($candidate->(9),76)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "pl",
-    "prompt": "# Write a python function to get the difference between two lists.\nsub Diff {\n    my($li1, $li2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Diff;\n        if(eq_deeply($candidate->([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "pl",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nsub extract_quotation {\n    my($text1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_quotation;\n        if(eq_deeply($candidate->(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "pl",
-    "prompt": "# Write a function to flatten a list and sum all of its elements.\nsub recursive_list_sum {\n    my($data_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&recursive_list_sum;\n        if(eq_deeply($candidate->([1, 2, [3, 4], [5, 6]]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 10, [15, 14], [19, 41]]),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, [30, 40], [50, 60]]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\nsub differ_At_One_Bit_Pos {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&differ_At_One_Bit_Pos;\n        if(eq_deeply($candidate->(13, 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\nsub text_match_three {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"caacabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nsub max_product {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product;\n        if(eq_deeply($candidate->([3, 100, 4, 5, 150, 6]),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 42, 55, 68, 80]),50265600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 22, 9, 33, 21, 50, 41, 60]),2460)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "pl",
-    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\nsub split_Arr {\n    my($l, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_Arr;\n        if(eq_deeply($candidate->([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 1),[2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "pl",
-    "prompt": "# Write a python function to find the number of divisors of a given integer.\nsub divisor {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisor;\n        if(eq_deeply($candidate->(15),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "pl",
-    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\nsub big_diff {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_diff;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 12]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 3]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "pl",
-    "prompt": "# Write a function to find squares of individual elements in a list.\nsub square_nums {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[100, 400, 900])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[144, 225])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given tuple has any none value or not.\nsub check_none {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_none;\n        if(eq_deeply($candidate->([10, 4, 5, 6, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 11, 14]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given array is monotonic or not.\nsub is_Monotonic {\n    my($A) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Monotonic;\n        if(eq_deeply($candidate->([6, 5, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nsub is_perfect_square {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_perfect_square;\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(36),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(196),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15625),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\nsub sum {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum;\n        if(eq_deeply($candidate->(10, 15),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 150),93)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "pl",
-    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nsub max_length {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5], [15, 20, 25]]),[3, [15, 20, 25]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nsub check_occurences {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_occurences;\n        if(eq_deeply($candidate->([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3] => 2, [2, 5] => 2, [3, 6] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4] => 2, [3, 6] => 2, [4, 7] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "pl",
-    "prompt": "# Write a function to find the directrix of a parabola.\nsub parabola_directrix {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parabola_directrix;\n        if(eq_deeply($candidate->(5, 3, 2),-198)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 8, 4),-2336)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4, 6),-130)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "pl",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nsub occurance_substring {\n    my($text, $pattern) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&occurance_substring;\n        if(eq_deeply($candidate->(\"python programming, python language\", \"python\"),[\"python\", 0, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"language\"),[\"language\", 31, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"c++ programming, c++ language\", \"python\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "pl",
-    "prompt": "# Write a function to remove tuples from the given tuple.\nsub remove_nested {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_nested;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "pl",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsub sort_sublists {\n    my($input_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "pl",
-    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nsub remove_kth_element {\n    my($list1, $L) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_kth_element;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\nsub add_dict_to_tuple {\n    my($test_tup, $test_dict) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_dict_to_tuple;\n        if(eq_deeply($candidate->([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}),[4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}),[1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}),[8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "pl",
-    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nsub find {\n    my($n, $m) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find;\n        if(eq_deeply($candidate->(10, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "pl",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nsub text_match_two_three {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_two_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "pl",
-    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\nsub count_Occurrence {\n    my($tup, $lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Occurrence;\n        if(eq_deeply($candidate->([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "pl",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\nsub count_samepair {\n    my($list1, $list2, $list3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_samepair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\nsub text_match_one {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "pl",
-    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nsub difference {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&difference;\n        if(eq_deeply($candidate->(3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "pl",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\nsub toggle_string {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_string;\n        if(eq_deeply($candidate->(\"Python\"),\"pYTHON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pangram\"),\"pANGRAM\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"LIttLE\"),\"liTTle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "pl",
-    "prompt": "# Write a python function to find the element of a list having maximum length.\nsub Find_Max {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max;\n        if(eq_deeply($candidate->([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\nsub eulerian_num {\n    my($n, $m) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eulerian_num;\n        if(eq_deeply($candidate->(3, 1),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nsub frequency {\n    my($a, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency;\n        if(eq_deeply($candidate->([1, 2, 3], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 3, 4], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 1, 2], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "pl",
-    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nsub sort_numeric_strings {\n    my($nums_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numeric_strings;\n        if(eq_deeply($candidate->([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nsub geometric_sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&geometric_sum;\n        if(eq_deeply($candidate->(7),1.9921875)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1.9375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1.99609375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "pl",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nsub divisible_by_digits {\n    my($startnum, $endnum) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisible_by_digits;\n        if(eq_deeply($candidate->(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 25),[22, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "pl",
-    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\nsub unique_product {\n    my($list_data) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_product;\n        if(eq_deeply($candidate->([10, 20, 30, 40, 20, 50, 60, 40]),720000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 0, 1, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "pl",
-    "prompt": "# Write a python function to find the largest negative number from the given list.\nsub largest_neg {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_neg;\n        if(eq_deeply($candidate->([1, 2, 3, -4, -6]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -8, -9]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "pl",
-    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nsub consecutive_duplicates {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "pl",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nsub min_Jumps {\n    my($steps, $d) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Jumps;\n        if(eq_deeply($candidate->([3, 4], 11),3.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4], 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 14], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "pl",
-    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\nsub max_Product {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, -1, -2, -4, 5, 0, -6]),[-4, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "pl",
-    "prompt": "# Write a function to extract the nth element from a given list of tuples.\nsub extract_nth_element {\n    my($list1, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_nth_element;\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth nonagonal number.\nsub is_nonagonal {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nonagonal;\n        if(eq_deeply($candidate->(10),325)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),750)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),1089)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "pl",
-    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\nsub max_Abs_Diff {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Abs_Diff;\n        if(eq_deeply($candidate->([2, 1, 5, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 3, 2, 5, 1]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "pl",
-    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\nsub pack_consecutive_duplicates {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pack_consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\nsub cal_sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cal_sum;\n        if(eq_deeply($candidate->(9),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "pl",
-    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\nsub odd_values_string {\n    my($str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_values_string;\n        if(eq_deeply($candidate->(\"abcdef\"),\"ace\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\"),\"pto\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"dt\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lambs\"),\"lms\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "pl",
-    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nsub find_kth {\n    my($arr1, $arr2, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_kth;\n        if(eq_deeply($candidate->([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nsub jacobsthal_num {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&jacobsthal_num;\n        if(eq_deeply($candidate->(5),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),2731)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "pl",
-    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nsub frequency_lists {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "pl",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\nsub perfect_squares {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perfect_squares;\n        if(eq_deeply($candidate->(1, 30),[1, 4, 9, 16, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(50, 100),[64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[100, 121, 144, 169, 196])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "pl",
-    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsub sum_Of_Subarray_Prod {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_Subarray_Prod;\n        if(eq_deeply($candidate->([1, 2, 3]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "pl",
-    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\nsub first_odd {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_odd;\n        if(eq_deeply($candidate->([1, 3, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nsub add_nested_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_nested_tuples;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "pl",
-    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nsub merge {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\nsub dif_Square {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dif_Square;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "pl",
-    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nsub check_smaller {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_smaller;\n        if(eq_deeply($candidate->([1, 2, 3], [2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6], [3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13], [10, 11, 12]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "pl",
-    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nsub freq_count {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&freq_count;\n        if(eq_deeply($candidate->([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1 => 3, 2 => 2, 3 => 3, 4 => 3})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "pl",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nsub rgb_to_hsv {\n    my($r, $g, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rgb_to_hsv;\n        if(eq_deeply($candidate->(255, 255, 255),[0.0, 0.0, 100.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 215, 0),[120.0, 100.0, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "pl",
-    "prompt": "# Write a function to flatten a given nested list structure.\nsub flatten_list {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flatten_list;\n        if(eq_deeply($candidate->([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\nsub check_str {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_str;\n        if(eq_deeply($candidate->(\"annie\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dawood\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Else\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nsub check_monthnumber_number {\n    my($monthnum3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumber_number;\n        if(eq_deeply($candidate->(6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "pl",
-    "prompt": "# Write a function to sort the given list.\nsub heap_sort {\n    my($iterable) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_sort;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 1, 9, 5]),[1, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "pl",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nsub k_smallest_pairs {\n    my($nums1, $nums2, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&k_smallest_pairs;\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 1),[[1, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "pl",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nsub find_solution {\n    my($a, $b, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_solution;\n        if(eq_deeply($candidate->(2, 3, 7),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 7),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 13, 17),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "pl",
-    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\nsub find_Max_Num {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Max_Num;\n        if(eq_deeply($candidate->([1, 2, 3]),321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 1]),6541)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 9]),9321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "pl",
-    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nsub max_sum_list {\n    my($lists) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_list;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 1]]),[2, 3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "pl",
-    "prompt": "# Write a python function to interchange the first and last elements in a list.\nsub swap_List {\n    my($newList) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "pl",
-    "prompt": "# Write a function to find the median of two sorted lists of same size.\nsub get_median {\n    my($arr1, $arr2, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_median;\n        if(eq_deeply($candidate->([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nsub replace_spaces {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"The_Avengers\"),\"The Avengers\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Fast and Furious\"),\"Fast_and_Furious\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "pl",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nsub are_equivalent {\n    my($num1, $num2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&are_equivalent;\n        if(eq_deeply($candidate->(36, 57),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 47),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "pl",
-    "prompt": "# Write a function to reverse each string in a given list of string values.\nsub reverse_string_list {\n    my($stringlist) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_string_list;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "pl",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsub sum_of_digits {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_of_digits;\n        if(eq_deeply($candidate->([10, 2, 56]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, -4, 5, -70]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsub sequence {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequence;\n        if(eq_deeply($candidate->(10),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "pl",
-    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nsub heap_queue_largest {\n    my($nums, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_queue_largest;\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "pl",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nsub loss_amount {\n    my($actual_cost, $sale_amount) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&loss_amount;\n        if(eq_deeply($candidate->(1500, 1200),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "pl",
-    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nsub union_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&union_elements;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "pl",
-    "prompt": "# Write a python function to find the length of the longest sublists.\nsub Find_Max_Length {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max_Length;\n        if(eq_deeply($candidate->([[1], [1, 4], [5, 6, 7, 8]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 1], [2, 2], [3, 2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "pl",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nsub remove_parenthesis {\n    my($items) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_parenthesis;\n        if(eq_deeply($candidate->([\"python (chrome)\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"string(.abc)\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"alpha(num)\"]),\"alpha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "pl",
-    "prompt": "# Write a python function to find whether the parity of a given number is odd.\nsub find_Parity {\n    my($x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Parity;\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "pl",
-    "prompt": "# Write a function to find the median length of a trapezium.\nsub median_trapezium {\n    my($base1, $base2, $height) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_trapezium;\n        if(eq_deeply($candidate->(15, 25, 35),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 20, 30),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 9, 4),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "pl",
-    "prompt": "# Write a function to find nth centered hexagonal number.\nsub centered_hexagonal_number {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&centered_hexagonal_number;\n        if(eq_deeply($candidate->(10),271)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),217)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "pl",
-    "prompt": "# Write a function to find number of lists present in the given list.\nsub find_lists {\n    my($Input) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5, 4, 3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nsub get_max_sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_sum;\n        if(eq_deeply($candidate->(60),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "pl",
-    "prompt": "# Write a python function to find the length of the longest word.\nsub len_log {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&len_log;\n        if(eq_deeply($candidate->([\"python\", \"PHP\", \"bigdata\"]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"ab\", \"abc\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"small\", \"big\", \"tall\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "pl",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nsub sector_area {\n    my($r, $a) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sector_area;\n        if(eq_deeply($candidate->(4, 45),6.283185307179586)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 45),31.808625617596654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 361),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\nsub odd_position {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_position;\n        if(eq_deeply($candidate->([2, 1, 4, 3, 6, 7, 6, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "pl",
-    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nsub multiple_to_single {\n    my($L) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiple_to_single;\n        if(eq_deeply($candidate->([11, 33, 50]),113350)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4, 5, 6]),-123456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, 20, 25]),10152025)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "pl",
-    "prompt": "# Write a python function to find whether a number is divisible by 11.\nsub is_Diff {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Diff;\n        if(eq_deeply($candidate->(12345),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212112),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "pl",
-    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nsub index_multiplication {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_multiplication;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "pl",
-    "prompt": "# Write a function to convert tuple string to integer tuple.\nsub tuple_str_int {\n    my($test_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_str_int;\n        if(eq_deeply($candidate->(\"(7, 8, 9)\"),[7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(1, 2, 3)\"),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(4, 5, 6)\"),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(7, 81, 19)\"),[7, 81, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "pl",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\nsub amicable_numbers_sum {\n    my($limit) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&amicable_numbers_sum;\n        if(eq_deeply($candidate->(999),504)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9999),31626)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "pl",
-    "prompt": "# Write a function to remove odd characters in a string.\nsub remove_odd {\n    my($str1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->(\"python\"),\"yhn\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),\"rga\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),\"agae\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nsub multiply_elements {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_elements;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[5, 35, 56, 80])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 7]),[8, 20, 30, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 13, 14, 9, 15]),[156, 182, 126, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nsub count_rotation {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_rotation;\n        if(eq_deeply($candidate->([3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 1, 2, 3]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "pl",
-    "prompt": "# Write a function to extract the number of unique tuples in the given list.\nsub extract_freq {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_freq;\n        if(eq_deeply($candidate->([[3, 4], [1, 2], [4, 3], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 15], [2, 3], [5, 4], [6, 7]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 16], [2, 3], [6, 5], [6, 9]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "pl",
-    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nsub count_same_pair {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_same_pair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 1, 2], [0, 1, 2, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\nsub power {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power;\n        if(eq_deeply($candidate->(3, 4),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),3125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "pl",
-    "prompt": "# Write function to find the sum of all items in the given dictionary.\nsub return_sum {\n    my($dict) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&return_sum;\n        if(eq_deeply($candidate->({\"a\" => 100, \"b\" => 200, \"c\" => 300}),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 25, \"b\" => 18, \"c\" => 45}),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 36, \"b\" => 39, \"c\" => 49}),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "pl",
-    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\nsub pair_wise {\n    my($l1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_wise;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "pl",
-    "prompt": "# Write a python function to split a string into characters.\nsub split {\n    my($word) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split;\n        if(eq_deeply($candidate->(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Name\"),[\"N\", \"a\", \"m\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "pl",
-    "prompt": "# Write a function to find minimum of three numbers.\nsub min_of_three {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_of_three;\n        if(eq_deeply($candidate->(10, 20, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 15, 18),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -20, -30),-30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nsub is_Sum_Of_Powers_Of_Two {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sum_Of_Powers_Of_Two;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "pl",
-    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nsub get_Char {\n    my($strr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Char;\n        if(eq_deeply($candidate->(\"abc\"),\"f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gfg\"),\"t\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "pl",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\nsub sum_div {\n    my($number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_div;\n        if(eq_deeply($candidate->(8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "pl",
-    "prompt": "# Write a python function that returns the number of integer elements in a given list.\nsub count_integer {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_integer;\n        if(eq_deeply($candidate->([1, 2, \"abc\", 1.2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1.2, 4, 5.1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "pl",
-    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\nsub two_unique_nums {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&two_unique_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "pl",
-    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\nsub test_duplicate {\n    my($arraynums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_duplicate;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3, 3, 4, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "pl",
-    "prompt": "# Write a function which returns nth catalan number.\nsub catalan_number {\n    my($num) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&catalan_number;\n        if(eq_deeply($candidate->(10),16796)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),4862)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),429)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "pl",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nsub power_base_sum {\n    my($base, $power) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power_base_sum;\n        if(eq_deeply($candidate->(2, 100),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 10),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 15),62)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nsub replace_list {\n    my($list1, $list2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_list;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth octagonal number.\nsub is_octagonal {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_octagonal;\n        if(eq_deeply($candidate->(5),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),280)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),645)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nsub replace_blank {\n    my($str1, $char) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_blank;\n        if(eq_deeply($candidate->(\"hello people\", \"@\"),\"hello@people\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python program language\", \"$\"),\"python$program$language\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"blank space\", \"-\"),\"blank-space\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "pl",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nsub replace_specialchar {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_specialchar;\n        if(eq_deeply($candidate->(\"Python language, Programming language.\"),\"Python:language::Programming:language:\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c,d e f\"),\"a:b:c:d:e:f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "pl",
-    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\nsub tuple_to_int {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_int;\n        if(eq_deeply($candidate->([1, 2, 3]),123)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7]),567)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "pl",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\nsub otherside_rightangle {\n    my($w, $h) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&otherside_rightangle;\n        if(eq_deeply($candidate->(7, 8),10.63014581273465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 15),16.55294535724685)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "pl",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nsub expensive_items {\n    my($items, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&expensive_items;\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2),[{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\nsub digit_distance_nums {\n    my($n1, $n2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digit_distance_nums;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 56),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123, 256),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "pl",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\nsub text_match_wordz_middle {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz_middle;\n        if(eq_deeply($candidate->(\"pythonzabc.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zxyabc.\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "pl",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\nsub removezero_ip {\n    my($ip) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&removezero_ip;\n        if(eq_deeply($candidate->(\"216.08.094.196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12.01.024\"),\"12.1.24\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"216.08.094.0196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of sublists containing a particular element.\nsub count_element_in_list {\n    my($list1, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_element_in_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "pl",
-    "prompt": "# Write a function to multiply two integers.\nsub multiply_int {\n    my($x, $y) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_int;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "pl",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nsub add_pairwise {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_pairwise;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[6, 12, 15, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, 9, 11]),[8, 14, 17, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, 10, 12]),[10, 16, 19, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nsub max_product_tuple {\n    my($list1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),484)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4120,7 +18,7 @@
     "language": "pl",
     "prompt": "# Write a function to find the kth element in the given array using 1-based indexing.\nsub kth_element {\n    my($arr, $k) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&kth_element;\n        if(eq_deeply($candidate->([12, 3, 5, 7, 19], 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([17, 24, 8, 23], 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([16, 21, 25, 36, 4], 4),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4130,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "pl",
-    "prompt": "# Write a python function to interchange the first and last element in a given list.\nsub swap_List {\n    my($newList) = @_;\n",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"python_program\"),\"PythonProgram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python_language\"),\"PythonLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"programming_language\"),\"ProgrammingLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4144,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "pl",
-    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\nsub count_first_elements {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\nsub eulerian_num {\n    my($n, $m) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_first_elements;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 9, [5, 7], 11]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 5, 8, [2, 3], 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eulerian_num;\n        if(eq_deeply($candidate->(3, 1),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4158,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "pl",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nsub right_insertion {\n    my($a, $x) = @_;\n",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsub sort_sublists {\n    my($input_list) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4172,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_106_add_lists",
     "language": "pl",
-    "prompt": "# Write a function to check if the given number is woodball or not.\nsub is_woodall {\n    my($x) = @_;\n",
+    "prompt": "# Write a function to append the given list to the given tuples.\nsub add_lists {\n    my($test_list, $test_tup) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_woodall;\n        if(eq_deeply($candidate->(383),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(254),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_lists;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4186,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "pl",
-    "prompt": "# Write a function to sort the given array by using shell sort.\nsub shell_sort {\n    my($my_list) = @_;\n",
+    "prompt": "# Write a function to merge three lists into a single sorted list.\nsub merge_sorted_list {\n    my($num1, $num2, $num3) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&shell_sort;\n        if(eq_deeply($candidate->([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_sorted_list;\n        if(eq_deeply($candidate->([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4200,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "pl",
-    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\nsub find_Odd_Pair {\n    my($A, $N) = @_;\n",
+    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nsub odd_Equivalent {\n    my($s, $n) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Odd_Pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11], 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_Equivalent;\n        if(eq_deeply($candidate->(\"011001\", 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011\", 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1010\", 4),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4214,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_113_check_integer",
     "language": "pl",
-    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\nsub sum_in_range {\n    my($l, $r) = @_;\n",
+    "prompt": "# Write a function to check if a string represents an integer or not.\nsub check_integer {\n    my($text) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_in_range;\n        if(eq_deeply($candidate->(2, 5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_integer;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12345\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4228,223 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_116_tuple_to_int",
     "language": "pl",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsub square_perimeter {\n    my($a) = @_;\n",
+    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\nsub tuple_to_int {\n    my($nums) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_perimeter;\n        if(eq_deeply($candidate->(10),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_765_is_polite",
-    "language": "pl",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nsub is_polite {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_polite;\n        if(eq_deeply($candidate->(7),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsub sum_series {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_series;\n        if(eq_deeply($candidate->(6),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "pl",
-    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\nsub find_dissimilar {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_dissimilar;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "pl",
-    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nsub start_withp {\n    my($words) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&start_withp;\n        if(eq_deeply($candidate->([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "pl",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"android_tv\"),\"AndroidTv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"google_pixel\"),\"GooglePixel\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple_watch\"),\"AppleWatch\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "pl",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\nsub volume_cube {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&volume_cube;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\nsub check_monthnumb_number {\n    my($monthnum2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumb_number;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "pl",
-    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\nsub all_Bits_Set_In_The_Given_Range {\n    my($n, $l, $r) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Bits_Set_In_The_Given_Range;\n        if(eq_deeply($candidate->(4, 1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 2, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(39, 4, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "pl",
-    "prompt": "# Write a python function to get the first element of each sublist.\nsub Extract {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Extract;\n        if(eq_deeply($candidate->([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5]]),[1, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[9, 8, 1], [1, 2]]),[9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "pl",
-    "prompt": "# Write a function to find the surface area of a cylinder.\nsub surfacearea_cylinder {\n    my($r, $h) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cylinder;\n        if(eq_deeply($candidate->(10, 5),942.45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),226.18800000000002)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 10),351.848)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "pl",
-    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsub sample_nam {\n    my($sample_names) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sample_nam;\n        if(eq_deeply($candidate->([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abcd\", \"Python\", \"abba\", \"aba\"]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "pl",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nsub rearrange_bigger {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rearrange_bigger;\n        if(eq_deeply($candidate->(12),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(102),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "pl",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nsub perimeter_pentagon {\n    my($a) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perimeter_pentagon;\n        if(eq_deeply($candidate->(5),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "pl",
-    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nsub max_sum {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum;\n        if(eq_deeply($candidate->([1, 15, 51, 45, 33, 100, 12, 18, 9]),194)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([80, 60, 30, 40, 20, 10]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 14, 16, 21, 23, 29, 30]),138)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "pl",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\nsub extract_even {\n    my($test_tuple) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_even;\n        if(eq_deeply($candidate->([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_int;\n        if(eq_deeply($candidate->([1, 2, 3]),123)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7]),567)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4456,233 +144,9 @@
     "language": "pl",
     "prompt": "# Write a function to convert all possible convertible elements in a list of lists to floats.\nsub list_to_float {\n    my($test_list) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_to_float;\n        if(eq_deeply($candidate->([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "pl",
-    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nsub get_pairs_count {\n    my($arr, $sum) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_pairs_count;\n        if(eq_deeply($candidate->([1, 1, 1, 1], 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, -1, 5], 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 3], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3], -3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "pl",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nsub count_no_of_ways {\n    my($n, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_no_of_ways;\n        if(eq_deeply($candidate->(2, 4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 4),228)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "pl",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nsub reverse_words {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_words;\n        if(eq_deeply($candidate->(\"python program\"),\"program python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"java language\"),\"language java\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"indian man\"),\"man indian\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "pl",
-    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\nsub checks {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&checks;\n        if(eq_deeply($candidate->(70),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "pl",
-    "prompt": "# Write a python function to find the last position of an element in a sorted array.\nsub last {\n    my($arr, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last;\n        if(eq_deeply($candidate->([1, 2, 3], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, 4], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 3, 6, 8, 9], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "pl",
-    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nsub count_X {\n    my($tup, $x) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_X;\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "pl",
-    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nsub extract_index_list {\n    my($l1, $l2, $l3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_index_list;\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "pl",
-    "prompt": "# Write a function to find the second smallest number in a list.\nsub second_smallest {\n    my($numbers) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&second_smallest;\n        if(eq_deeply($candidate->([1, 2, -8, -2, 0, -2]),-2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, -0.5, 0, 2, -2, -2]),-0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\nsub concatenate_tuple {\n    my($test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate_tuple;\n        if(eq_deeply($candidate->([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nsub replace_spaces {\n    my($string) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I am a Programmer\"),\"I%20am%20a%20Programmer\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love Coding\"),\"I%20love%20Coding\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "pl",
-    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsub sum_range_list {\n    my($list1, $m, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_range_list;\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "pl",
-    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\nsub merge_dictionaries_three {\n    my($dict1, $dict2, $dict3) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_dictionaries_three;\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}),{\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}),{\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}),{\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the minimum of two numbers.\nsub minimum {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minimum;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-5, -4),-5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\nsub max_difference {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_difference;\n        if(eq_deeply($candidate->([[3, 5], [1, 7], [10, 3], [1, 2]]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [2, 17], [9, 13], [11, 12]]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 35], [21, 27], [13, 23], [41, 22]]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "pl",
-    "prompt": "# Write a python function to find element at a given index after number of rotations.\nsub find_Element {\n    my($arr, $ranges, $rotations, $index) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4694,7 +158,7 @@
     "language": "pl",
     "prompt": "# Write a function to convert a string to a list of strings split on the space character.\nsub string_to_list {\n    my($string) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_list;\n        if(eq_deeply($candidate->(\"python programming\"),[\"python\", \"programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"write a program\"),[\"write\", \"a\", \"program\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4708,23 +172,9 @@
     "language": "pl",
     "prompt": "# Write a python function to find the element that appears only once in a sorted array.\nsub search {\n    my($arr) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "pl",
-    "prompt": "# Write a function to sort a dictionary by value.\nsub sort_counter {\n    my($dict1) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_counter;\n        if(eq_deeply($candidate->({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4736,7 +186,7 @@
     "language": "pl",
     "prompt": "# Write a python function to remove first and last occurrence of a given character from the string.\nsub remove_Occ {\n    my($s, $ch) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_Occ;\n        if(eq_deeply($candidate->(\"hello\", \"l\"),\"heo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcda\", \"a\"),\"bcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PHP\", \"P\"),\"H\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4746,13 +196,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "pl",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nsub lateralsurface_cube {\n    my($l) = @_;\n",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nsub max_product_tuple {\n    my($list1) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cube;\n        if(eq_deeply($candidate->(5),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),324)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),400)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),484)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4760,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "pl",
-    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\nsub common_element {\n    my($list1, $list2) = @_;\n",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\nsub amicable_numbers_sum {\n    my($limit) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common_element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&amicable_numbers_sum;\n        if(eq_deeply($candidate->(999),504)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9999),31626)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4774,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "pl",
-    "prompt": "# Write a function to append the given list to the given tuples.\nsub add_lists {\n    my($test_list, $test_tup) = @_;\n",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nsub find_length {\n    my($string) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_lists;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_length;\n        if(eq_deeply($candidate->(\"11000010001\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"10111\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011101100101\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4788,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "pl",
-    "prompt": "# Write a function to compute the n-th power of each number in a list.\nsub nth_nums {\n    my($nums, $n) = @_;\n",
+    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\nsub sum {\n    my($a, $b) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&nth_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30], 3),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15], 5),[248832, 759375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum;\n        if(eq_deeply($candidate->(10, 15),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 150),93)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4802,335 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "pl",
-    "prompt": "# Write a function to sort a list of elements.\nsub pancake_sort {\n    my($nums) = @_;\n",
+    "prompt": "# Write a function to multiply two integers.\nsub multiply_int {\n    my($x, $y) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pancake_sort;\n        if(eq_deeply($candidate->([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "pl",
-    "prompt": "# Write a function to find the median of three numbers.\nsub median_numbers {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_numbers;\n        if(eq_deeply($candidate->(25, 55, 65),55.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 10, 30),20.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 45, 75),45.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\nsub check_greater {\n    my($arr, $number) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_greater;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6], 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 4, 8, 6, 1], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nsub check_element {\n    my($list, $element) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_element;\n        if(eq_deeply($candidate->([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"green\", \"green\", \"green\", \"green\"], \"green\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "pl",
-    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nsub extract_string {\n    my($str, $l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_string;\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "pl",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nsub text_lowercase_underscore {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_lowercase_underscore;\n        if(eq_deeply($candidate->(\"aab_cbbbc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aab_Abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Aaab_abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to trim each list by k in the given lists.\nsub trim_tuple {\n    my($test_list, $K) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&trim_tuple;\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "pl",
-    "prompt": "# Write a python function to find the sublist having minimum length.\nsub Find_Min {\n    my($lst) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min;\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "pl",
-    "prompt": "# Write a function to filter odd numbers.\nsub filter_oddnumbers {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_oddnumbers;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 45, 67, 84, 93]),[45, 67, 93])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "pl",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nsub find_adverbs {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverbs;\n        if(eq_deeply($candidate->(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Please handle the situation carefuly\"),\"28-36: carefuly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Complete the task quickly\"),\"18-25: quickly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "pl",
-    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nsub max_of_nth {\n    my($test_list, $N) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_of_nth;\n        if(eq_deeply($candidate->([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nsub decimal_to_binary {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(8),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nsub combinations_colors {\n    my($l, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_colors;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to remove all whitespaces from a string.\nsub remove_all_spaces {\n    my($text) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_all_spaces;\n        if(eq_deeply($candidate->(\"python  program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python   programming    language\"),\"pythonprogramminglanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "pl",
-    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nsub min_Swaps {\n    my($str1, $str2) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Swaps;\n        if(eq_deeply($candidate->(\"1101\", \"1110\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"000\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"110\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to create a new tuple from the given string and list.\nsub new_tuple {\n    my($test_list, $test_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&new_tuple;\n        if(eq_deeply($candidate->([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "pl",
-    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\nsub find_remainder {\n    my($arr, $n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_remainder;\n        if(eq_deeply($candidate->([100, 10, 5, 25, 35, 14], 11),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "pl",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nsub min_val {\n    my($listval) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "pl",
-    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\nsub positive_count {\n    my($nums) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&positive_count;\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to add the given tuple to the given list.\nsub add_tuple {\n    my($test_list, $test_tup) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_tuple;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "pl",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nsub max_run_uppercase {\n    my($test_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_run_uppercase;\n        if(eq_deeply($candidate->(\"GeMKSForGERksISBESt\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PrECIOusMOVemENTSYT\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GooGLEFluTTER\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "pl",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsub sort_matrix {\n    my($M) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_matrix;\n        if(eq_deeply($candidate->([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "pl",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\nsub count_vowels {\n    my($test_str) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_vowels;\n        if(eq_deeply($candidate->(\"bestinstareels\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"partofthejourneyistheend\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"amazonprime\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nsub max_sum_increasing_subseq {\n    my($a, $n, $index, $k) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_increasing_subseq;\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_int;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5142,7 +270,7 @@
     "language": "pl",
     "prompt": "# Write a function to find words that are longer than n characters from a given list of words.\nsub long_words {\n    my($n, $str) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&long_words;\n        if(eq_deeply($candidate->(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, \"writing a program\"),[\"writing\", \"program\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, \"sorting list\"),[\"sorting\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5152,13 +280,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "pl",
-    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\nsub find_sum {\n    my($arr) = @_;\n",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nsub magic_square_test {\n    my($my_matrix) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_sum;\n        if(eq_deeply($candidate->([1, 2, 3, 1, 1, 4, 5, 6]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 10, 9, 4, 2, 10, 10, 45, 4]),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 10, 9, 45, 2, 10, 10, 45, 10]),78)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&magic_square_test;\n        if(eq_deeply($candidate->([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5166,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "pl",
-    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nsub tuple_to_dict {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsub sort_matrix {\n    my($M) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_dict;\n        if(eq_deeply($candidate->([1, 5, 7, 10, 13, 5]),{1 => 5, 7 => 10, 13 => 5})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),{1 => 2, 3 => 4, 5 => 6})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 10, 11, 12]),{7 => 8, 9 => 10, 11 => 12})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_matrix;\n        if(eq_deeply($candidate->([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5180,209 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "pl",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nsub get_coordinates {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nsub max_occurrences {\n    my($nums) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_coordinates;\n        if(eq_deeply($candidate->([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "pl",
-    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\nsub check_type {\n    my($test_tuple) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_type;\n        if(eq_deeply($candidate->([5, 6, 7, 3, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, \"4\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "pl",
-    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\nsub find_First_Missing {\n    my($array) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_First_Missing;\n        if(eq_deeply($candidate->([0, 1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 6, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 8, 9]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\nsub is_undulating {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_undulating;\n        if(eq_deeply($candidate->(1212121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1991),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "pl",
-    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nsub min_k {\n    my($test_list, $K) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_k;\n        if(eq_deeply($candidate->([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "pl",
-    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\nsub count_Substrings {\n    my($s) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Substrings;\n        if(eq_deeply($candidate->(\"112112\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1101112\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth decagonal number.\nsub is_num_decagonal {\n    my($n) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_num_decagonal;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),175)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),370)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nsub rear_extract {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rear_extract;\n        if(eq_deeply($candidate->([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the closest smaller number than n.\nsub closest_num {\n    my($N) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_num;\n        if(eq_deeply($candidate->(11),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "pl",
-    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nsub find_combinations {\n    my($test_list) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_combinations;\n        if(eq_deeply($candidate->([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "pl",
-    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nsub maxAverageOfPath {\n    my($cost) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maxAverageOfPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsub sequential_search {\n    my($dlist, $item) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequential_search;\n        if(eq_deeply($candidate->([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 32, 45, 62, 35, 47, 44, 61], 61),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 10, 17, 19, 22, 39, 48, 56], 48),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "pl",
-    "prompt": "# Write a python function to remove odd numbers from a given list.\nsub remove_odd {\n    my($l) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->([1, 2, 3]),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 6]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 3]),[10, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nsub is_product_even {\n    my($arr) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_product_even;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "pl",
-    "prompt": "# Write a python function to find the maximum of two numbers.\nsub maximum {\n    my($a, $b) = @_;\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->(5, 10),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 7),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_occurrences;\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5394,9 +326,709 @@
     "language": "pl",
     "prompt": "# Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nsub reverse_vowels {\n    my($str1) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_vowels;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"USA\"),\"ASU\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"ab\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "pl",
+    "prompt": "# Write a function to convert a list to a string.\nsub tup_string {\n    my($tup1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tup_string;\n        if(eq_deeply($candidate->([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsub sum_negativenum {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_negativenum;\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, -14, 13, -18, 12, -20]),-52)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth hexagonal number.\nsub hexagonal_num {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hexagonal_num;\n        if(eq_deeply($candidate->(10),190)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),91)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nsub is_Sum_Of_Powers_Of_Two {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sum_Of_Powers_Of_Two;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort a list of elements.\nsub pancake_sort {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pancake_sort;\n        if(eq_deeply($candidate->([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "pl",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\nsub count_samepair {\n    my($list1, $list2, $list3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_samepair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "pl",
+    "prompt": "# Write a function to find number of lists present in the given list.\nsub find_lists {\n    my($Input) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5, 4, 3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "pl",
+    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\nsub max_Abs_Diff {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Abs_Diff;\n        if(eq_deeply($candidate->([2, 1, 5, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 3, 2, 5, 1]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "pl",
+    "prompt": "# Write a python function to find the volume of a triangular prism.\nsub find_Volume {\n    my($l, $b, $h) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Volume;\n        if(eq_deeply($candidate->(10, 8, 6),240)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "pl",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nsub find_solution {\n    my($a, $b, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_solution;\n        if(eq_deeply($candidate->(2, 3, 7),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 7),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 13, 17),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "pl",
+    "prompt": "# Write a function to remove all elements from a given list present in another list.\nsub remove_elements {\n    my($list1, $list2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_elements;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsub sum_series {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_series;\n        if(eq_deeply($candidate->(6),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "pl",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nsub are_equivalent {\n    my($num1, $num2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&are_equivalent;\n        if(eq_deeply($candidate->(36, 57),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 47),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nsub count_char_position {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_char_position;\n        if(eq_deeply($candidate->(\"xbcefg\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABcED\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"AbgdeF\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "pl",
+    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nsub find_even_pair {\n    my($A) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_even_pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "pl",
+    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\nsub next_power_of_2 {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_power_of_2;\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nsub frequency {\n    my($a, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency;\n        if(eq_deeply($candidate->([1, 2, 3], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 3, 4], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 1, 2], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "pl",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nsub text_lowercase_underscore {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_lowercase_underscore;\n        if(eq_deeply($candidate->(\"aab_cbbbc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aab_Abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Aaab_abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "pl",
+    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsub sum_range_list {\n    my($list1, $m, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_range_list;\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "pl",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nsub perimeter_pentagon {\n    my($a) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perimeter_pentagon;\n        if(eq_deeply($candidate->(5),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\nsub count_occurance {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_occurance;\n        if(eq_deeply($candidate->(\"letstdlenstdporstd\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"truststdsolensporsd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"makestdsostdworthit\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"stds\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "pl",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsub square_perimeter {\n    my($a) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_perimeter;\n        if(eq_deeply($candidate->(10),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "pl",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nsub remove_dirty_chars {\n    my($string, $second_string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_dirty_chars;\n        if(eq_deeply($candidate->(\"probasscurve\", \"pros\"),\"bacuve\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"digitalindia\", \"talent\"),\"digiidi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"exoticmiles\", \"toxic\"),\"emles\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "pl",
+    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\nsub test_duplicate {\n    my($arraynums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_duplicate;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3, 3, 4, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given number is woodball or not.\nsub is_woodall {\n    my($x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_woodall;\n        if(eq_deeply($candidate->(383),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(254),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "pl",
+    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\nsub check_type {\n    my($test_tuple) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_type;\n        if(eq_deeply($candidate->([5, 6, 7, 3, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, \"4\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nsub is_majority {\n    my($arr, $n, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_majority;\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 3, 10], 7, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 2], 5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2], 5, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nsub count_Set_Bits {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Set_Bits;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "pl",
+    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\nsub odd_values_string {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_values_string;\n        if(eq_deeply($candidate->(\"abcdef\"),\"ace\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\"),\"pto\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"dt\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lambs\"),\"lms\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "pl",
+    "prompt": "# Write a function to find minimum of three numbers.\nsub min_of_three {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_of_three;\n        if(eq_deeply($candidate->(10, 20, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 15, 18),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -20, -30),-30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\nsub all_Bits_Set_In_The_Given_Range {\n    my($n, $l, $r) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Bits_Set_In_The_Given_Range;\n        if(eq_deeply($candidate->(4, 1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 2, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(39, 4, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nsub re_arrange_array {\n    my($arr, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&re_arrange_array;\n        if(eq_deeply($candidate->([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nsub replace_blank {\n    my($str1, $char) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_blank;\n        if(eq_deeply($candidate->(\"hello people\", \"@\"),\"hello@people\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python program language\", \"$\"),\"python$program$language\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"blank space\", \"-\"),\"blank-space\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "pl",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\nsub volume_cube {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&volume_cube;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nsub check_occurences {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_occurences;\n        if(eq_deeply($candidate->([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3] => 2, [2, 5] => 2, [3, 6] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4] => 2, [3, 6] => 2, [4, 7] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\nsub number_of_substrings {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_of_substrings;\n        if(eq_deeply($candidate->(\"abc\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "pl",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nsub get_total_number_of_sequences {\n    my($m, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_total_number_of_sequences;\n        if(eq_deeply($candidate->(10, 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 3),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nsub replace_list {\n    my($list1, $list2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_list;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "pl",
+    "prompt": "# Write a function to count the total number of characters in a string.\nsub count_charac {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_charac;\n        if(eq_deeply($candidate->(\"python programming\"),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"words\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "pl",
+    "prompt": "# Write a python function to find the next perfect square greater than a given number.\nsub next_Perfect_Square {\n    my($N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_Perfect_Square;\n        if(eq_deeply($candidate->(35),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "pl",
+    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nsub max_sum {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum;\n        if(eq_deeply($candidate->([1, 15, 51, 45, 33, 100, 12, 18, 9]),194)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([80, 60, 30, 40, 20, 10]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 14, 16, 21, 23, 29, 30]),138)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "pl",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nsub lps {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lps;\n        if(eq_deeply($candidate->(\"TENS FOR TENS\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"CARDIO FOR CARDS\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PART OF THE JOURNEY IS PART\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "pl",
+    "prompt": "# Write a function to find the intersection of two arrays.\nsub intersection_array {\n    my($array_nums1, $array_nums2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection_array;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "pl",
+    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nsub count_X {\n    my($tup, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_X;\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nsub insert_element {\n    my($list, $element) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&insert_element;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "pl",
+    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\nsub convert {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert;\n        if(eq_deeply($candidate->(1),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "pl",
+    "prompt": "# Write a python function that returns the number of integer elements in a given list.\nsub count_integer {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_integer;\n        if(eq_deeply($candidate->([1, 2, \"abc\", 1.2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1.2, 4, 5.1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nsub combinations_colors {\n    my($l, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_colors;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "pl",
+    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nsub count_Primes_nums {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Primes_nums;\n        if(eq_deeply($candidate->(5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nsub swap_numbers {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_numbers;\n        if(eq_deeply($candidate->(10, 20),[20, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 17),[17, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[200, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5408,7 +1040,7 @@
     "language": "pl",
     "prompt": "# Write a function to maximize the given two lists.\nsub maximize_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximize_elements;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5418,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "pl",
-    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\nsub even_position {\n    my($nums) = @_;\n",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nsub newman_prime {\n    my($n) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_position;\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&newman_prime;\n        if(eq_deeply($candidate->(3),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),17)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),41)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5432,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "pl",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\nsub check_char {\n    my($string) = @_;\n",
+    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nsub division_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_char;\n        if(eq_deeply($candidate->(\"abba\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"Invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&division_elements;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5446,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "pl",
-    "prompt": "# Write a python function to find the sum of even factors of a number.\nsub sumofFactors {\n    my($n) = @_;\n",
+    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nsub split_two_parts {\n    my($list1, $L) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sumofFactors;\n        if(eq_deeply($candidate->(18),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),48)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_two_parts;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5460,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "pl",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nsub lateralsurface_cone {\n    my($r, $h) = @_;\n",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\nsub dog_age {\n    my($h_age) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cone;\n        if(eq_deeply($candidate->(5, 12),204.20352248333654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),566.3586699569488)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 17),1521.8090132193388)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dog_age;\n        if(eq_deeply($candidate->(12),61)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24),109)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5474,13 +1106,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "pl",
-    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nsub count_Pairs {\n    my($arr, $n) = @_;\n",
+    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nsub list_split {\n    my($S, $step) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Pairs;\n        if(eq_deeply($candidate->([1, 2, 1], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 5),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_split;\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5488,13 +1120,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "pl",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nsub find_first_occurrence {\n    my($A, $x) = @_;\n",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nsub lateralsurface_cube {\n    my($l) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_first_occurrence;\n        if(eq_deeply($candidate->([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cube;\n        if(eq_deeply($candidate->(5),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),324)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),400)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5506,9 +1138,849 @@
     "language": "pl",
     "prompt": "# Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the n'th star number.\nsub find_star_num {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_star_num;\n        if(eq_deeply($candidate->(3),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "pl",
+    "prompt": "# Write a function to find the ascii value of a character.\nsub ascii_value {\n    my($k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&ascii_value;\n        if(eq_deeply($candidate->(\"A\"),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"R\"),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"S\"),83)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\nsub sum_even_and_even_index {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_even_and_even_index;\n        if(eq_deeply($candidate->([5, 6, 12, 1, 18, 8]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 12, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "pl",
+    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nsub even_Power_Sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_Power_Sum;\n        if(eq_deeply($candidate->(2),1056)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),8832)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nsub rear_extract {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rear_extract;\n        if(eq_deeply($candidate->([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nsub substract_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&substract_elements;\n        if(eq_deeply($candidate->([10, 4, 5], [2, 5, 18]),[8, -1, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 2, 3], [24, 45, 16]),[-13, -43, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 18, 9], [10, 11, 12]),[-3, 7, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "pl",
+    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nsub even_binomial_Coeff_Sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_binomial_Coeff_Sum;\n        if(eq_deeply($candidate->(4),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nsub dict_filter {\n    my($dict, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dict_filter;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170),{\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180),{\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190),{\"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "pl",
+    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\nsub count_first_elements {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_first_elements;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 9, [5, 7], 11]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 5, 8, [2, 3], 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth decagonal number.\nsub is_num_decagonal {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_num_decagonal;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),175)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),370)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsub sequential_search {\n    my($dlist, $item) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequential_search;\n        if(eq_deeply($candidate->([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 32, 45, 62, 35, 47, 44, 61], 61),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 10, 17, 19, 22, 39, 48, 56], 48),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "pl",
+    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\nsub all_unique {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_unique;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "pl",
+    "prompt": "# Write a function to subtract two lists element-wise.\nsub sub_list {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sub_list;\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),[-3, -3, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 4]),[-2, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[40, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "pl",
+    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nsub validate {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&validate;\n        if(eq_deeply($candidate->(1234),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(51241),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(321),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nsub check_element {\n    my($list, $element) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_element;\n        if(eq_deeply($candidate->([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"green\", \"green\", \"green\", \"green\"], \"green\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "pl",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nsub text_match_two_three {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_two_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "pl",
+    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nsub max_sub_array_sum_repeated {\n    my($a, $n, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum_repeated;\n        if(eq_deeply($candidate->([10, 20, -30, -1], 4, 3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 10, 20], 3, 2),59)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3], 3, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "pl",
+    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "pl",
+    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nsub max_length {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5], [15, 20, 25]]),[3, [15, 20, 25]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "pl",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nsub count_no_of_ways {\n    my($n, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_no_of_ways;\n        if(eq_deeply($candidate->(2, 4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 4),228)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "pl",
+    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nsub find {\n    my($n, $m) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find;\n        if(eq_deeply($candidate->(10, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "pl",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\nsub otherside_rightangle {\n    my($w, $h) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&otherside_rightangle;\n        if(eq_deeply($candidate->(7, 8),10.63014581273465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 15),16.55294535724685)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nsub max_val {\n    my($listval) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "pl",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\nsub sum_div {\n    my($number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_div;\n        if(eq_deeply($candidate->(8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "pl",
+    "prompt": "# Write a python function to count inversions in an array.\nsub get_Inv_Count {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Inv_Count;\n        if(eq_deeply($candidate->([1, 20, 6, 4, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 6, 1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "pl",
+    "prompt": "# Write a function to flatten a given nested list structure.\nsub flatten_list {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flatten_list;\n        if(eq_deeply($candidate->([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\nsub max_aggregate {\n    my($stdata) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_aggregate;\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "pl",
+    "prompt": "# Write a python function to find element at a given index after number of rotations.\nsub find_Element {\n    my($arr, $ranges, $rotations, $index) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "pl",
+    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nsub start_withp {\n    my($words) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&start_withp;\n        if(eq_deeply($candidate->([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nsub max_sum_increasing_subseq {\n    my($a, $n, $index, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_increasing_subseq;\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nsub large_product {\n    my($nums1, $nums2, $N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&large_product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the maximum of two numbers.\nsub maximum {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->(5, 10),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 7),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to convert a given string to a list of characters.\nsub string_to_tuple {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_tuple;\n        if(eq_deeply($candidate->(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "pl",
+    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\nsub highest_Power_of_2 {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&highest_Power_of_2;\n        if(eq_deeply($candidate->(10),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "pl",
+    "prompt": "# Write a function to find the n'th lucas number.\nsub find_lucas {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lucas;\n        if(eq_deeply($candidate->(9),76)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "pl",
+    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nsub add_string {\n    my($list_, $string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_string;\n        if(eq_deeply($candidate->([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "pl",
+    "prompt": "# Write a function to convert more than one list to nested dictionary.\nsub convert_list_dictionary {\n    my($l1, $l2, $l3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert_list_dictionary;\n        if(eq_deeply($candidate->([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nsub get_max_sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_sum;\n        if(eq_deeply($candidate->(60),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "pl",
+    "prompt": "# Write a function to find the list with maximum length.\nsub max_length_list {\n    my($input_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length_list;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "pl",
+    "prompt": "# Write a function to check if given list contains no duplicates.\nsub check_distinct {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_distinct;\n        if(eq_deeply($candidate->([1, 4, 5, 6, 1, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "pl",
+    "prompt": "# Write a python function to find the first non-repeated character in a given string.\nsub first_non_repeating_character {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_non_repeating_character;\n        if(eq_deeply($candidate->(\"abcabc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ababc\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\nsub check_char {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_char;\n        if(eq_deeply($candidate->(\"abba\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"Invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "pl",
+    "prompt": "# Write a function to find the median of three numbers.\nsub median_numbers {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_numbers;\n        if(eq_deeply($candidate->(25, 55, 65),55.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 10, 30),20.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 45, 75),45.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "pl",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsub sum_of_digits {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_of_digits;\n        if(eq_deeply($candidate->([10, 2, 56]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, -4, 5, -70]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "pl",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\nsub bitwise_xor {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bitwise_xor;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "pl",
+    "prompt": "# Write a python function to identify non-prime numbers.\nsub is_not_prime {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_not_prime;\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(35),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(37),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "pl",
+    "prompt": "# Write a function to extract the number of unique tuples in the given list.\nsub extract_freq {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_freq;\n        if(eq_deeply($candidate->([[3, 4], [1, 2], [4, 3], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 15], [2, 3], [5, 4], [6, 7]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 16], [2, 3], [6, 5], [6, 9]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nsub add_nested_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_nested_tuples;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the minimum of two numbers.\nsub minimum {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minimum;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-5, -4),-5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "pl",
+    "prompt": "# Write a function to check whether an element exists within a tuple.\nsub check_tuplex {\n    my($tuplex, $tuple1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_tuplex;\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "pl",
+    "prompt": "# Write a python function to find whether the parity of a given number is odd.\nsub find_Parity {\n    my($x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Parity;\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "pl",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nsub rearrange_bigger {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rearrange_bigger;\n        if(eq_deeply($candidate->(12),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(102),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "pl",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nsub k_smallest_pairs {\n    my($nums1, $nums2, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&k_smallest_pairs;\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 1),[[1, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\nsub min_product_tuple {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "pl",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nsub min_val {\n    my($listval) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"android_tv\"),\"AndroidTv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"google_pixel\"),\"GooglePixel\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple_watch\"),\"AppleWatch\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "pl",
+    "prompt": "# Write a python function to remove odd numbers from a given list.\nsub remove_odd {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->([1, 2, 3]),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 6]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 3]),[10, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "pl",
+    "prompt": "# Write a function to extract the nth element from a given list of tuples.\nsub extract_nth_element {\n    my($list1, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_nth_element;\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\nsub overlapping {\n    my($list1, $list2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&overlapping;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5], [1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "pl",
+    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\nsub max_Product {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, -1, -2, -4, 5, 0, -6]),[-4, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5520,7 +1992,7 @@
     "language": "pl",
     "prompt": "# Write a function to find common first element in given list of lists.\nsub group_tuples {\n    my($Input) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&group_tuples;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5530,13 +2002,3541 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "pl",
-    "prompt": "# Write a function to merge three lists into a single sorted list.\nsub merge_sorted_list {\n    my($num1, $num2, $num3) = @_;\n",
+    "prompt": "# Write a python function to find the element of a list having maximum length.\nsub Find_Max {\n    my($lst) = @_;\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_sorted_list;\n        if(eq_deeply($candidate->([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max;\n        if(eq_deeply($candidate->([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "pl",
+    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nsub round_and_sum {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&round_and_sum;\n        if(eq_deeply($candidate->([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 9, 24.3, 29]),345)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25.0, 56.7, 89.2]),513)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\nsub cube_Sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_Sum;\n        if(eq_deeply($candidate->(2),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\nsub concatenate_tuple {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate_tuple;\n        if(eq_deeply($candidate->([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "pl",
+    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\nsub find_Average_Of_Cube {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Average_Of_Cube;\n        if(eq_deeply($candidate->(2),4.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "pl",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\nsub extract_rear {\n    my($test_tuple) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_rear;\n        if(eq_deeply($candidate->([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of sublists containing a particular element.\nsub count_element_in_list {\n    my($list1, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_element_in_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "pl",
+    "prompt": "# Write a function to filter odd numbers.\nsub filter_oddnumbers {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_oddnumbers;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 45, 67, 84, 93]),[45, 67, 93])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "pl",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nsub change_date_format {\n    my($dt) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_date_format;\n        if(eq_deeply($candidate->(\"2026-01-02\"),\"02-01-2026\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020-11-13\"),\"13-11-2020\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2021-04-26\"),\"26-04-2021\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort the given array by using shell sort.\nsub shell_sort {\n    my($my_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&shell_sort;\n        if(eq_deeply($candidate->([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\nsub and_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&and_tuples;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "pl",
+    "prompt": "# Write a function to find the directrix of a parabola.\nsub parabola_directrix {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parabola_directrix;\n        if(eq_deeply($candidate->(5, 3, 2),-198)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 8, 4),-2336)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4, 6),-130)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\nsub common_element {\n    my($list1, $list2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common_element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "pl",
+    "prompt": "# Write a function to find the median length of a trapezium.\nsub median_trapezium {\n    my($base1, $base2, $height) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_trapezium;\n        if(eq_deeply($candidate->(15, 25, 35),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 20, 30),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 9, 4),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\nsub check_greater {\n    my($arr, $number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_greater;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6], 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 4, 8, 6, 1], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\nsub text_match_one {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "pl",
+    "prompt": "# Write a python function to find the last digit of a given number.\nsub last_Digit {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit;\n        if(eq_deeply($candidate->(123),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "pl",
+    "prompt": "# Write a python function to return the negative numbers in a list.\nsub neg_nos {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&neg_nos;\n        if(eq_deeply($candidate->([-1, 4, 5, -6]),[-1, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3, 4]),[-1, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-7, -6, 8, 9]),[-7, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "pl",
+    "prompt": "# Write a function to remove odd characters in a string.\nsub remove_odd {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->(\"python\"),\"yhn\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),\"rga\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),\"agae\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "pl",
+    "prompt": "# Write a function to count bidirectional tuple pairs.\nsub count_bidirectional {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_bidirectional;\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "pl",
+    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nsub multiple_to_single {\n    my($L) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiple_to_single;\n        if(eq_deeply($candidate->([11, 33, 50]),113350)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4, 5, 6]),-123456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, 20, 25]),10152025)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "pl",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nsub find_adverb_position {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverb_position;\n        if(eq_deeply($candidate->(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"seriously!! there are many roses\"),[0, 9, \"seriously\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "pl",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsub surfacearea_cube {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cube;\n        if(eq_deeply($candidate->(5),150)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "pl",
+    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\nsub positive_count {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&positive_count;\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "pl",
+    "prompt": "# Write a python function to find the largest negative number from the given list.\nsub largest_neg {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_neg;\n        if(eq_deeply($candidate->([1, 2, 3, -4, -6]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -8, -9]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to trim each list by k in the given lists.\nsub trim_tuple {\n    my($test_list, $K) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&trim_tuple;\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "pl",
+    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nsub index_multiplication {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_multiplication;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "pl",
+    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\nsub count_Occurrence {\n    my($tup, $lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Occurrence;\n        if(eq_deeply($candidate->([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "pl",
+    "prompt": "# Write a function to find cubes of individual elements in a list.\nsub cube_nums {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[1728, 3375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\nsub cal_sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cal_sum;\n        if(eq_deeply($candidate->(9),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "pl",
+    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nsub extract_string {\n    my($str, $l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_string;\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "pl",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\nsub remove_whitespaces {\n    my($text1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_whitespaces;\n        if(eq_deeply($candidate->(\" Google    Flutter \"),\"GoogleFlutter\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" Google    Dart \"),\"GoogleDart\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" iOS    Swift \"),\"iOSSwift\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "pl",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nsub loss_amount {\n    my($actual_cost, $sale_amount) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&loss_amount;\n        if(eq_deeply($candidate->(1500, 1200),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of even factors of a number.\nsub sumofFactors {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sumofFactors;\n        if(eq_deeply($candidate->(18),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),48)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "pl",
+    "prompt": "# Write a function that matches a word containing 'z'.\nsub text_match_wordz {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz;\n        if(eq_deeply($candidate->(\"pythonz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\nsub check_monthnumb_number {\n    my($monthnum2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumb_number;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "pl",
+    "prompt": "# Write a function to reverse each string in a given list of string values.\nsub reverse_string_list {\n    my($stringlist) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_string_list;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sublist having minimum length.\nsub Find_Min {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min;\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "pl",
+    "prompt": "# Write a function to find the area of a rectangle.\nsub rectangle_area {\n    my($l, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rectangle_area;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "pl",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\nsub remove_uppercase {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_uppercase;\n        if(eq_deeply($candidate->(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "pl",
+    "prompt": "# Write a python function to get the first element of each sublist.\nsub Extract {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Extract;\n        if(eq_deeply($candidate->([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5]]),[1, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[9, 8, 1], [1, 2]]),[9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "pl",
+    "prompt": "# Write a python function to count the upper case characters in a given string.\nsub upper_ctr {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&upper_ctr;\n        if(eq_deeply($candidate->(\"PYthon\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"BigData\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "pl",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\nsub combinations_list {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_list;\n        if(eq_deeply($candidate->([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum product subarray of the given array.\nsub max_subarray_product {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_subarray_product;\n        if(eq_deeply($candidate->([1, -2, -3, 0, 7, -8, -2]),112)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, -3, -10, 0, 2]),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -40, 0, -2, -3]),80)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "pl",
+    "prompt": "# Write a function to check if all values are same in a dictionary.\nsub check_value {\n    my($dict, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_value;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "pl",
+    "prompt": "# Write a function to drop empty items from a given dictionary.\nsub drop_empty {\n    my($dict1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&drop_empty;\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => undef}),{\"c1\" => \"Red\", \"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => undef, \"c3\" => undef}),{\"c1\" => \"Red\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => undef, \"c2\" => \"Green\", \"c3\" => undef}),{\"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nsub max_product {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product;\n        if(eq_deeply($candidate->([3, 100, 4, 5, 150, 6]),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 42, 55, 68, 80]),50265600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 22, 9, 33, 21, 50, 41, 60]),2460)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "pl",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nsub add_pairwise {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_pairwise;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[6, 12, 15, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, 9, 11]),[8, 14, 17, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, 10, 12]),[10, 16, 19, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "pl",
+    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\nsub find_remainder {\n    my($arr, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_remainder;\n        if(eq_deeply($candidate->([100, 10, 5, 25, 35, 14], 11),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\nsub check_Consecutive {\n    my($l) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_Consecutive;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "pl",
+    "prompt": "# Write a function to replace characters in a string.\nsub replace_char {\n    my($str1, $ch, $newch) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_char;\n        if(eq_deeply($candidate->(\"polygon\", \"y\", \"l\"),\"pollgon\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"character\", \"c\", \"a\"),\"aharaater\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\", \"l\", \"a\"),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "pl",
+    "prompt": "# Write a function to sort a dictionary by value.\nsub sort_counter {\n    my($dict1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_counter;\n        if(eq_deeply($candidate->({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\nsub big_sum {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 6]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "pl",
+    "prompt": "# Write a python function to convert the given string to lower case.\nsub is_lower {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_lower;\n        if(eq_deeply($candidate->(\"InValid\"),\"invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"TruE\"),\"true\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"SenTenCE\"),\"sentence\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "pl",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\nsub remove_lowercase {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_lowercase;\n        if(eq_deeply($candidate->(\"PYTHon\"),\"PYTH\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"FInD\"),\"FID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"STRinG\"),\"STRG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "pl",
+    "prompt": "# Write a python function to find the first digit of a given number.\nsub first_Digit {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_Digit;\n        if(eq_deeply($candidate->(123),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(456),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "pl",
+    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nsub heap_queue_largest {\n    my($nums, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_queue_largest;\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "pl",
+    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\nsub Split {\n    my($list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 12, 13]),[11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1]),[7, 9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "pl",
+    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nsub difference {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&difference;\n        if(eq_deeply($candidate->(3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\nsub find_Odd_Pair {\n    my($A, $N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Odd_Pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11], 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "pl",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\nsub toggle_string {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_string;\n        if(eq_deeply($candidate->(\"Python\"),\"pYTHON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pangram\"),\"pANGRAM\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"LIttLE\"),\"liTTle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\nsub digit_distance_nums {\n    my($n1, $n2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digit_distance_nums;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 56),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123, 256),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nsub max_sub_array_sum {\n    my($a, $size) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum;\n        if(eq_deeply($candidate->([-2, -3, 4, -1, -2, 1, 5, -3], 8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -4, 5, -2, -3, 2, 6, -4], 8),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-4, -5, 6, -3, -4, 3, 7, -5], 8),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "pl",
+    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nsub union_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&union_elements;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "pl",
+    "prompt": "# Write a python function to find the length of the longest sublists.\nsub Find_Max_Length {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max_Length;\n        if(eq_deeply($candidate->([[1], [1, 4], [5, 6, 7, 8]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 1], [2, 2], [3, 2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "pl",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\nsub extract_values {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_values;\n        if(eq_deeply($candidate->(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "pl",
+    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nsub count_Pairs {\n    my($arr, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Pairs;\n        if(eq_deeply($candidate->([1, 2, 1], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 5),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "pl",
+    "prompt": "# Write a python function to split a string into characters.\nsub split {\n    my($word) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split;\n        if(eq_deeply($candidate->(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Name\"),[\"N\", \"a\", \"m\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "pl",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsub sum_digits {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_digits;\n        if(eq_deeply($candidate->(345),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "pl",
+    "prompt": "# Write a function to check whether a specified list is sorted or not.\nsub issort_list {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&issort_list;\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 15, 14, 20]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "pl",
+    "prompt": "# Write a function to create a list of N empty dictionaries.\nsub empty_list {\n    my($length) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&empty_list;\n        if(eq_deeply($candidate->(5),[{}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[{}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[{}, {}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "pl",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsub sort_sublists {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "pl",
+    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\nsub checks {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&checks;\n        if(eq_deeply($candidate->(70),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "pl",
+    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\nsub two_unique_nums {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&two_unique_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "pl",
+    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\nsub unique_product {\n    my($list_data) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_product;\n        if(eq_deeply($candidate->([10, 20, 30, 40, 20, 50, 60, 40]),720000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 0, 1, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "pl",
+    "prompt": "# Write a function to find the surface area of a cylinder.\nsub surfacearea_cylinder {\n    my($r, $h) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cylinder;\n        if(eq_deeply($candidate->(10, 5),942.45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),226.18800000000002)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 10),351.848)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether a list is sublist of another or not.\nsub is_Sub_Array {\n    my($A, $B) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sub_Array;\n        if(eq_deeply($candidate->([1, 4, 3, 5], [1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], [1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 2], [2, 2, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "pl",
+    "prompt": "# Write a python function to find the last digit in factorial of a given number.\nsub last_Digit_Factorial {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit_Factorial;\n        if(eq_deeply($candidate->(4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(21),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "pl",
+    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\nsub interleave_lists {\n    my($list1, $list2, $list3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&interleave_lists;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "pl",
+    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\nsub find_dissimilar {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_dissimilar;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "pl",
+    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\nsub find_Max_Num {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Max_Num;\n        if(eq_deeply($candidate->([1, 2, 3]),321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 1]),6541)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 9]),9321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "pl",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\nsub extract_even {\n    my($test_tuple) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_even;\n        if(eq_deeply($candidate->([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "pl",
+    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\nsub surface_Area {\n    my($b, $s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surface_Area;\n        if(eq_deeply($candidate->(3, 4),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "pl",
+    "prompt": "# Write a function which returns nth catalan number.\nsub catalan_number {\n    my($num) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&catalan_number;\n        if(eq_deeply($candidate->(10),16796)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),4862)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),429)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "pl",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nsub find_adverbs {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverbs;\n        if(eq_deeply($candidate->(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Please handle the situation carefuly\"),\"28-36: carefuly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Complete the task quickly\"),\"18-25: quickly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "pl",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nsub expensive_items {\n    my($items, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&expensive_items;\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2),[{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "pl",
+    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\nsub split_Arr {\n    my($l, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_Arr;\n        if(eq_deeply($candidate->([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 1),[2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to convert a list to a tuple.\nsub list_tuple {\n    my($listx) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_tuple;\n        if(eq_deeply($candidate->([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([58, 44, 56]),[58, 44, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "pl",
+    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\nsub big_diff {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_diff;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 12]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 3]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "pl",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\nsub perfect_squares {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perfect_squares;\n        if(eq_deeply($candidate->(1, 30),[1, 4, 9, 16, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(50, 100),[64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[100, 121, 144, 169, 196])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\nsub opposite_Signs {\n    my($x, $y) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&opposite_Signs;\n        if(eq_deeply($candidate->(1, -2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "pl",
+    "prompt": "# Write a python function to interchange the first and last elements in a list.\nsub swap_List {\n    my($newList) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\nsub sum_Of_product {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_product;\n        if(eq_deeply($candidate->(3),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "pl",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\nsub removezero_ip {\n    my($ip) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&removezero_ip;\n        if(eq_deeply($candidate->(\"216.08.094.196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12.01.024\"),\"12.1.24\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"216.08.094.0196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "pl",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\nsub diff_even_odd {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&diff_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "pl",
+    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nsub min_Swaps {\n    my($str1, $str2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Swaps;\n        if(eq_deeply($candidate->(\"1101\", \"1110\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"000\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"110\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "pl",
+    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nsub find_kth {\n    my($arr1, $arr2, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_kth;\n        if(eq_deeply($candidate->([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\nsub armstrong_number {\n    my($number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&armstrong_number;\n        if(eq_deeply($candidate->(153),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(259),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4458),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "pl",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsub sum_average {\n    my($number) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_average;\n        if(eq_deeply($candidate->(10),[55, 5.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),[120, 8.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[210, 10.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth octagonal number.\nsub is_octagonal {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_octagonal;\n        if(eq_deeply($candidate->(5),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),280)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),645)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given number is even or not.\nsub is_Even {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Even;\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "pl",
+    "prompt": "# Write a python function to find the first repeated character in a given string.\nsub first_repeated_char {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_repeated_char;\n        if(eq_deeply($candidate->(\"abcabc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123123\"),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "pl",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nsub get_ludic {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_ludic;\n        if(eq_deeply($candidate->(10),[1, 2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "pl",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nsub reverse_words {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_words;\n        if(eq_deeply($candidate->(\"python program\"),\"program python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"java language\"),\"language java\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"indian man\"),\"man indian\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given integer is a prime number.\nsub prime_num {\n    my($num) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_num;\n        if(eq_deeply($candidate->(13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1010),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "pl",
+    "prompt": "# Write a function to convert degrees to radians.\nsub radian_degree {\n    my($degree) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&radian_degree;\n        if(eq_deeply($candidate->(90),1.5707963267948966)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(60),1.0471975511965976)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),2.0943951023931953)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "pl",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nsub find_literals {\n    my($text, $pattern) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_literals;\n        if(eq_deeply($candidate->(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "pl",
+    "prompt": "# Write a python function to find nth bell number.\nsub bell_Number {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_Number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "pl",
+    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nsub remove_kth_element {\n    my($list1, $L) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_kth_element;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "pl",
+    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nsub max_of_nth {\n    my($test_list, $N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_of_nth;\n        if(eq_deeply($candidate->([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "pl",
+    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nsub merge {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nsub cummulative_sum {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cummulative_sum;\n        if(eq_deeply($candidate->([[1, 3], [5, 6, 7], [2, 6]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [6, 7, 8], [3, 7]]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8, 9], [4, 8]]),44)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "pl",
+    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nsub average_tuple {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&average_tuple;\n        if(eq_deeply($candidate->([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "pl",
+    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\nsub tuple_modulo {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_modulo;\n        if(eq_deeply($candidate->([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "pl",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nsub min_Jumps {\n    my($steps, $d) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Jumps;\n        if(eq_deeply($candidate->([3, 4], 11),3.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4], 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 14], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "pl",
+    "prompt": "# Write a function to divide two lists element wise.\nsub div_list {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&div_list;\n        if(eq_deeply($candidate->([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2], [1, 4]),[3.0, 0.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[1.8, 1.7142857142857142])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "pl",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\nsub move_num {\n    my($test_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_num;\n        if(eq_deeply($candidate->(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Avengers124Assemble\"),\"AvengersAssemble124\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\nsub count_Substrings {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Substrings;\n        if(eq_deeply($candidate->(\"112112\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1101112\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "pl",
+    "prompt": "# Write a function to find the median of two sorted lists of same size.\nsub get_median {\n    my($arr1, $arr2, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_median;\n        if(eq_deeply($candidate->([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "pl",
+    "prompt": "# Write a function to compute the n-th power of each number in a list.\nsub nth_nums {\n    my($nums, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&nth_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30], 3),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15], 5),[248832, 759375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "pl",
+    "prompt": "# Write a python function to convert a given string to uppercase.\nsub is_upper {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_upper;\n        if(eq_deeply($candidate->(\"person\"),\"PERSON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final\"),\"FINAL\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Valid\"),\"VALID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "pl",
+    "prompt": "# Write a python function to interchange the first and last element in a given list.\nsub swap_List {\n    my($newList) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "pl",
+    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nsub triangle_area {\n    my($r) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(-1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "pl",
+    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\nsub find_First_Missing {\n    my($array) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_First_Missing;\n        if(eq_deeply($candidate->([0, 1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 6, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 8, 9]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nsub replace_spaces {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I am a Programmer\"),\"I%20am%20a%20Programmer\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love Coding\"),\"I%20love%20Coding\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "pl",
+    "prompt": "# Write a python function to find even numbers from a list of numbers.\nsub Split {\n    my($list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 12, 15, 19]),[8, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "pl",
+    "prompt": "# Write a python function to find smallest number in a list.\nsub smallest_num {\n    my($xs) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_num;\n        if(eq_deeply($candidate->([10, 20, 1, 45, 99]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([45, 46, 50, 60]),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "pl",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nsub get_coordinates {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_coordinates;\n        if(eq_deeply($candidate->([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nsub replace_spaces {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"The_Avengers\"),\"The Avengers\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Fast and Furious\"),\"Fast_and_Furious\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "pl",
+    "prompt": "# Write a python function to move all zeroes to the end of the given list.\nsub move_zero {\n    my($num_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_zero;\n        if(eq_deeply($candidate->([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\nsub pair_xor_Sum {\n    my($arr, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_xor_Sum;\n        if(eq_deeply($candidate->([5, 9, 7, 6], 4),47)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 5], 3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort the given list.\nsub heap_sort {\n    my($iterable) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_sort;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 1, 9, 5]),[1, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nsub noprofit_noloss {\n    my($actual_cost, $sale_amount) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&noprofit_noloss;\n        if(eq_deeply($candidate->(1500, 1200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nsub wind_chill {\n    my($v, $t) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&wind_chill;\n        if(eq_deeply($candidate->(120, 35),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(40, 20),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "pl",
+    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsub sample_nam {\n    my($sample_names) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sample_nam;\n        if(eq_deeply($candidate->([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abcd\", \"Python\", \"abba\", \"aba\"]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\nsub max_difference {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_difference;\n        if(eq_deeply($candidate->([[3, 5], [1, 7], [10, 3], [1, 2]]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [2, 17], [9, 13], [11, 12]]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 35], [21, 27], [13, 23], [41, 22]]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "pl",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nsub remove_parenthesis {\n    my($items) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_parenthesis;\n        if(eq_deeply($candidate->([\"python (chrome)\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"string(.abc)\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"alpha(num)\"]),\"alpha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth nonagonal number.\nsub is_nonagonal {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nonagonal;\n        if(eq_deeply($candidate->(10),325)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),750)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),1089)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "pl",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\nsub text_match_wordz_middle {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz_middle;\n        if(eq_deeply($candidate->(\"pythonzabc.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zxyabc.\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "pl",
+    "prompt": "# Write a python function to reverse an array upto a given position.\nsub reverse_Array_Upto_K {\n    my($input, $k) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_Array_Upto_K;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7], 2),[5, 4, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "pl",
+    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\nsub subject_marks {\n    my($subjectmarks) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&subject_marks;\n        if(eq_deeply($candidate->([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function to flatten a list and sum all of its elements.\nsub recursive_list_sum {\n    my($data_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&recursive_list_sum;\n        if(eq_deeply($candidate->([1, 2, [3, 4], [5, 6]]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 10, [15, 14], [19, 41]]),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, [30, 40], [50, 60]]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of positive numbers in a list.\nsub pos_count {\n    my($list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pos_count;\n        if(eq_deeply($candidate->([1, -2, 3, -4]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 5, -1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "pl",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nsub bell_number {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),115975)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(56),6775685320645824322581483068371419745979053216268760300)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given array is monotonic or not.\nsub is_Monotonic {\n    my($A) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Monotonic;\n        if(eq_deeply($candidate->([6, 5, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "pl",
+    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nsub is_sublist {\n    my($l, $s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sublist;\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [4, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [1, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\nsub differ_At_One_Bit_Pos {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&differ_At_One_Bit_Pos;\n        if(eq_deeply($candidate->(13, 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "pl",
+    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nsub get_equal {\n    my($Input) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_equal;\n        if(eq_deeply($candidate->([[11, 22, 33], [44, 55, 66]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort a list of elements.\nsub comb_sort {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&comb_sort;\n        if(eq_deeply($candidate->([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([99, 15, 13, 47]),[13, 15, 47, 99])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\nsub add_dict_to_tuple {\n    my($test_tup, $test_dict) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_dict_to_tuple;\n        if(eq_deeply($candidate->([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}),[4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}),[1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}),[8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "pl",
+    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nsub maxAverageOfPath {\n    my($cost) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maxAverageOfPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "pl",
+    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nsub filter_data {\n    my($students, $h, $w) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_data;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70),{\"Cierra Vega\" => [6.2, 70]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67),{\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64),{\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "pl",
+    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nsub count_same_pair {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_same_pair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 1, 2], [0, 1, 2, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "pl",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nsub power_base_sum {\n    my($base, $power) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power_base_sum;\n        if(eq_deeply($candidate->(2, 100),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 10),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 15),62)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "pl",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nsub extract_quotation {\n    my($text1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_quotation;\n        if(eq_deeply($candidate->(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "pl",
+    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nsub multiply_elements {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_elements;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[5, 35, 56, 80])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 7]),[8, 20, 30, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 13, 14, 9, 15]),[156, 182, 126, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "pl",
+    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsub sum_list {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_list;\n        if(eq_deeply($candidate->([10, 20, 30], [15, 25, 35]),[25, 45, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [5, 6, 7]),[6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 20, 30], [15, 45, 75]),[30, 65, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\nsub dif_Square {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dif_Square;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "pl",
+    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nsub consecutive_duplicates {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "pl",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nsub lateralsurface_cone {\n    my($r, $h) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cone;\n        if(eq_deeply($candidate->(5, 12),204.20352248333654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),566.3586699569488)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 17),1521.8090132193388)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "pl",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nsub replace_specialchar {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_specialchar;\n        if(eq_deeply($candidate->(\"Python language, Programming language.\"),\"Python:language::Programming:language:\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c,d e f\"),\"a:b:c:d:e:f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "pl",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nsub find_first_occurrence {\n    my($A, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_first_occurrence;\n        if(eq_deeply($candidate->([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "pl",
+    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsub sum_Of_Subarray_Prod {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_Subarray_Prod;\n        if(eq_deeply($candidate->([1, 2, 3]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "pl",
+    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nsub toggle_middle_bits {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_middle_bits;\n        if(eq_deeply($candidate->(9),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(65),127)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "pl",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nsub left_insertion {\n    my($a, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\nsub check_str {\n    my($string) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_str;\n        if(eq_deeply($candidate->(\"annie\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dawood\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Else\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nsub geometric_sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&geometric_sum;\n        if(eq_deeply($candidate->(7),1.9921875)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1.9375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1.99609375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "pl",
+    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nsub find_Index {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Index;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nsub tuple_to_dict {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_dict;\n        if(eq_deeply($candidate->([1, 5, 7, 10, 13, 5]),{1 => 5, 7 => 10, 13 => 5})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),{1 => 2, 3 => 4, 5 => 6})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 10, 11, 12]),{7 => 8, 9 => 10, 11 => 12})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether all the characters are same or not.\nsub all_Characters_Same {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Characters_Same;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "pl",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\nsub area_tetrahedron {\n    my($side) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&area_tetrahedron;\n        if(eq_deeply($candidate->(3),15.588457268119894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),692.8203230275509)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),173.20508075688772)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "pl",
+    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nsub rotate_right {\n    my($list, $m) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rotate_right;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given tuple has any none value or not.\nsub check_none {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_none;\n        if(eq_deeply($candidate->([10, 4, 5, 6, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 11, 14]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "pl",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nsub divisible_by_digits {\n    my($startnum, $endnum) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisible_by_digits;\n        if(eq_deeply($candidate->(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 25),[22, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "pl",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nsub sector_area {\n    my($r, $a) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sector_area;\n        if(eq_deeply($candidate->(4, 45),6.283185307179586)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 45),31.808625617596654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 361),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "pl",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nsub lcs_of_three {\n    my($X, $Y, $Z) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lcs_of_three;\n        if(eq_deeply($candidate->(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\nsub capital_words_spaces {\n    my($str1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&capital_words_spaces;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PythonProgrammingExamples\"),\"Python Programming Examples\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "pl",
+    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nsub sort_numeric_strings {\n    my($nums_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numeric_strings;\n        if(eq_deeply($candidate->([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "pl",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nsub is_samepatterns {\n    my($colors, $patterns) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_samepatterns;\n        if(eq_deeply($candidate->([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to add the given tuple to the given list.\nsub add_tuple {\n    my($test_list, $test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_tuple;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nsub check_min_heap {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_min_heap;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 10, 15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 5, 3, 15]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nsub jacobsthal_num {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&jacobsthal_num;\n        if(eq_deeply($candidate->(5),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),2731)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "pl",
+    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nsub min_k {\n    my($test_list, $K) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_k;\n        if(eq_deeply($candidate->([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "pl",
+    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nsub extract_index_list {\n    my($l1, $l2, $l3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_index_list;\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "pl",
+    "prompt": "# Write a function to find the second smallest number in a list.\nsub second_smallest {\n    my($numbers) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&second_smallest;\n        if(eq_deeply($candidate->([1, 2, -8, -2, 0, -2]),-2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, -0.5, 0, 2, -2, -2]),-0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nsub text_match_zero_one {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_zero_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dsabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asbbbba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "pl",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nsub count_reverse_pairs {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_reverse_pairs;\n        if(eq_deeply($candidate->([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"geeks\", \"best\", \"for\", \"skeeg\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "pl",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nsub is_decimal {\n    my($num) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_decimal;\n        if(eq_deeply($candidate->(\"123.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"e666.86\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3.124587\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.1.11\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nsub find_tuples {\n    my($test_list, $K) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_tuples;\n        if(eq_deeply($candidate->([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\nsub unique_Element {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_Element;\n        if(eq_deeply($candidate->([1, 1, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nsub check_monthnumber_number {\n    my($monthnum3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumber_number;\n        if(eq_deeply($candidate->(6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "pl",
+    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nsub find_min_diff {\n    my($arr, $n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_min_diff;\n        if(eq_deeply($candidate->([1, 5, 3, 19, 18, 25], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 6], 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 5, 20, 9], 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "pl",
+    "prompt": "# Write a python function to count number of digits in a given string.\nsub number_ctr {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_ctr;\n        if(eq_deeply($candidate->(\"program2bedone\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wonders\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wond-1ers2\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "pl",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nsub is_polite {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_polite;\n        if(eq_deeply($candidate->(7),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "pl",
+    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\nsub pair_wise {\n    my($l1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_wise;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nsub get_pairs_count {\n    my($arr, $sum) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_pairs_count;\n        if(eq_deeply($candidate->([1, 1, 1, 1], 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, -1, 5], 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 3], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3], -3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "pl",
+    "prompt": "# Write a python function to get the difference between two lists.\nsub Diff {\n    my($li1, $li2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Diff;\n        if(eq_deeply($candidate->([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\nsub odd_num_sum {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_num_sum;\n        if(eq_deeply($candidate->(2),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),707)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),3108)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nsub check_expression {\n    my($exp) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_expression;\n        if(eq_deeply($candidate->(\"{()}[{}]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{}][]({})\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "pl",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\nsub remove_length {\n    my($test_str, $K) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_length;\n        if(eq_deeply($candidate->(\"The person is most value tet\", 3),\"person is most value\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"If you told me about this ok\", 4),\"If you me about ok\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "pl",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nsub occurance_substring {\n    my($text, $pattern) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&occurance_substring;\n        if(eq_deeply($candidate->(\"python programming, python language\", \"python\"),[\"python\", 0, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"language\"),[\"language\", 31, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"c++ programming, c++ language\", \"python\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\nsub odd_position {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_position;\n        if(eq_deeply($candidate->([2, 1, 4, 3, 6, 7, 6, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "pl",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\nsub count_vowels {\n    my($test_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_vowels;\n        if(eq_deeply($candidate->(\"bestinstareels\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"partofthejourneyistheend\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"amazonprime\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\nsub find_sum {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_sum;\n        if(eq_deeply($candidate->([1, 2, 3, 1, 1, 4, 5, 6]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 10, 9, 4, 2, 10, 10, 45, 4]),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 10, 9, 45, 2, 10, 10, 45, 10]),78)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "pl",
+    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\nsub pack_consecutive_duplicates {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pack_consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "pl",
+    "prompt": "# Write a python function to find whether a number is divisible by 11.\nsub is_Diff {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Diff;\n        if(eq_deeply($candidate->(12345),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212112),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "pl",
+    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nsub find_combinations {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_combinations;\n        if(eq_deeply($candidate->([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nsub count_divisors {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_divisors;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nsub odd_length_sum {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_length_sum;\n        if(eq_deeply($candidate->([1, 2, 4]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 7]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "pl",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nsub rgb_to_hsv {\n    my($r, $g, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rgb_to_hsv;\n        if(eq_deeply($candidate->(255, 255, 255),[0.0, 0.0, 100.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 215, 0),[120.0, 100.0, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "pl",
+    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nsub mul_even_odd {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mul_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "pl",
+    "prompt": "# Write a function to convert tuple string to integer tuple.\nsub tuple_str_int {\n    my($test_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_str_int;\n        if(eq_deeply($candidate->(\"(7, 8, 9)\"),[7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(1, 2, 3)\"),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(4, 5, 6)\"),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(7, 81, 19)\"),[7, 81, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "pl",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nsub right_insertion {\n    my($a, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\nsub text_match_three {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"caacabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to create a new tuple from the given string and list.\nsub new_tuple {\n    my($test_list, $test_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&new_tuple;\n        if(eq_deeply($candidate->([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\nsub even_position {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_position;\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "pl",
+    "prompt": "# Write a function to remove tuples from the given tuple.\nsub remove_nested {\n    my($test_tup) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_nested;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of lists in a given number of lists.\nsub count_list {\n    my($input_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [2, 3], [4, 5]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 0], [2, 0]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "pl",
+    "prompt": "# Write a python function to find the last position of an element in a sorted array.\nsub last {\n    my($arr, $x) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last;\n        if(eq_deeply($candidate->([1, 2, 3], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, 4], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 3, 6, 8, 9], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nsub text_starta_endb {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_starta_endb;\n        if(eq_deeply($candidate->(\"aabbbb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabAbbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"accddbbjjj\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "pl",
+    "prompt": "# Write function to find the sum of all items in the given dictionary.\nsub return_sum {\n    my($dict) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&return_sum;\n        if(eq_deeply($candidate->({\"a\" => 100, \"b\" => 200, \"c\" => 300}),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 25, \"b\" => 18, \"c\" => 45}),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 36, \"b\" => 39, \"c\" => 49}),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\nsub sum_in_range {\n    my($l, $r) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_in_range;\n        if(eq_deeply($candidate->(2, 5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "pl",
+    "prompt": "# Write a python function to find the sum of an array.\nsub _sum {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 12, 13, 10]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "pl",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nsub left_rotate {\n    my($n, $d) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_rotate;\n        if(eq_deeply($candidate->(16, 2),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(29, 3),232)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "pl",
+    "prompt": "# Write a python function to check whether the length of the word is odd or not.\nsub word_len {\n    my($s) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&word_len;\n        if(eq_deeply($candidate->(\"Hadoop\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"great\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"structure\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to remove all whitespaces from a string.\nsub remove_all_spaces {\n    my($text) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_all_spaces;\n        if(eq_deeply($candidate->(\"python  program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python   programming    language\"),\"pythonprogramminglanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\nsub test_three_equal {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_three_equal;\n        if(eq_deeply($candidate->(1, 1, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2, -3),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "pl",
+    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nsub count_rotation {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_rotation;\n        if(eq_deeply($candidate->([3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 1, 2, 3]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nsub is_perfect_square {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_perfect_square;\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(36),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(196),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15625),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nsub is_product_even {\n    my($arr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_product_even;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "pl",
+    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nsub max_sum_list {\n    my($lists) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_list;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 1]]),[2, 3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "pl",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nsub max_run_uppercase {\n    my($test_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_run_uppercase;\n        if(eq_deeply($candidate->(\"GeMKSForGERksISBESt\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PrECIOusMOVemENTSYT\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GooGLEFluTTER\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "pl",
+    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\nsub first_odd {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_odd;\n        if(eq_deeply($candidate->([1, 3, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given tuples contain the k or not.\nsub check_K {\n    my($test_tup, $K) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_K;\n        if(eq_deeply($candidate->([10, 4, 5, 6, 8], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 44, 11, 12], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "pl",
+    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nsub check_smaller {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_smaller;\n        if(eq_deeply($candidate->([1, 2, 3], [2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6], [3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13], [10, 11, 12]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth tetrahedral number.\nsub tetrahedral_number {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tetrahedral_number;\n        if(eq_deeply($candidate->(5),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "pl",
+    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nsub get_Char {\n    my($strr) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Char;\n        if(eq_deeply($candidate->(\"abc\"),\"f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gfg\"),\"t\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsub sequence {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequence;\n        if(eq_deeply($candidate->(10),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "pl",
+    "prompt": "# Write a function to find nth centered hexagonal number.\nsub centered_hexagonal_number {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&centered_hexagonal_number;\n        if(eq_deeply($candidate->(10),271)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),217)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "pl",
+    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\nsub merge_dictionaries_three {\n    my($dict1, $dict2, $dict3) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_dictionaries_three;\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}),{\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}),{\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}),{\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "pl",
+    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nsub freq_count {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&freq_count;\n        if(eq_deeply($candidate->([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1 => 3, 2 => 2, 3 => 3, 4 => 3})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the closest smaller number than n.\nsub closest_num {\n    my($N) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_num;\n        if(eq_deeply($candidate->(11),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "pl",
+    "prompt": "# Write a function to find squares of individual elements in a list.\nsub square_nums {\n    my($nums) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[100, 400, 900])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[144, 225])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "pl",
+    "prompt": "# Write a python function to find the length of the longest word.\nsub len_log {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&len_log;\n        if(eq_deeply($candidate->([\"python\", \"PHP\", \"bigdata\"]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"ab\", \"abc\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"small\", \"big\", \"tall\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "pl",
+    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nsub find_substring {\n    my($str1, $sub_str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_substring;\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\nsub is_undulating {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_undulating;\n        if(eq_deeply($candidate->(1212121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1991),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\nsub power {\n    my($a, $b) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power;\n        if(eq_deeply($candidate->(3, 4),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),3125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "pl",
+    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nsub index_minimum {\n    my($test_list) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_minimum;\n        if(eq_deeply($candidate->([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "pl",
+    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\nsub Find_Min_Length {\n    my($lst) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min_Length;\n        if(eq_deeply($candidate->([[1], [1, 2]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 3, 3], [4, 4, 4, 4]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "pl",
+    "prompt": "# Write a python function to find the number of divisors of a given integer.\nsub divisor {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisor;\n        if(eq_deeply($candidate->(15),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "pl",
+    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nsub frequency_lists {\n    my($list1) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nsub decimal_to_binary {\n    my($n) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(8),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "pl",
+    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nsub find_Rotations {\n    my($str) = @_;\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Rotations;\n        if(eq_deeply($candidate->(\"aaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/mbpp-pl-reworded.json
+++ b/prompts/mbpp-pl-reworded.json
@@ -1,4114 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "pl",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nsub lps {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lps;\n        if(eq_deeply($candidate->(\"TENS FOR TENS\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"CARDIO FOR CARDS\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PART OF THE JOURNEY IS PART\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "pl",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\nsub remove_whitespaces {\n    my($text1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_whitespaces;\n        if(eq_deeply($candidate->(\" Google    Flutter \"),\"GoogleFlutter\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" Google    Dart \"),\"GoogleDart\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" iOS    Swift \"),\"iOSSwift\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "pl",
-    "prompt": "# Write a function to check whether a specified array is sorted or not.\nsub issort_list {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&issort_list;\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 15, 14, 20]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "pl",
-    "prompt": "# Write a function to count bidirectional array pairs.\nsub count_bidirectional {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_bidirectional;\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "pl",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsub surfacearea_cube {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cube;\n        if(eq_deeply($candidate->(5),150)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "pl",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nsub next_smallest_palindrome {\n    my($num) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_smallest_palindrome;\n        if(eq_deeply($candidate->(99),101)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1221),1331)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the cube sum of first n even natural numbers.\nsub cube_Sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_Sum;\n        if(eq_deeply($candidate->(2),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of xor of all pairs of numbers in the given array.\nsub pair_xor_Sum {\n    my($arr, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_xor_Sum;\n        if(eq_deeply($candidate->([5, 9, 7, 6], 4),47)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 5], 3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nsub check_min_heap {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_min_heap;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 10, 15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 5, 3, 15]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the first digit of a given number.\nsub first_Digit {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_Digit;\n        if(eq_deeply($candidate->(123),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(456),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the first non-repeated character in a given string.\nsub first_non_repeating_character {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_non_repeating_character;\n        if(eq_deeply($candidate->(\"abcabc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ababc\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "pl",
-    "prompt": "# Write a function to convert degrees to radians.\nsub radian_degree {\n    my($degree) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&radian_degree;\n        if(eq_deeply($candidate->(90),1.5707963267948966)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(60),1.0471975511965976)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),2.0943951023931953)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum product subarray of the given array.\nsub max_subarray_product {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_subarray_product;\n        if(eq_deeply($candidate->([1, -2, -3, 0, 7, -8, -2]),112)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, -3, -10, 0, 2]),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -40, 0, -2, -3]),80)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "pl",
-    "prompt": "# Write a function to convert more than one array to nested hash.\nsub convert_list_dictionary {\n    my($l1, $l2, $l3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert_list_dictionary;\n        if(eq_deeply($candidate->([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find smallest number in an array.\nsub smallest_num {\n    my($xs) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_num;\n        if(eq_deeply($candidate->([10, 20, 1, 45, 99]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([45, 46, 50, 60]),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/plthon-exercises/re/plthon-re-exercise-3.php\nsub text_match_zero_one {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_zero_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dsabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asbbbba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find nth bell number.\nsub bell_Number {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_Number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "pl",
-    "prompt": "# Write a function to find cubes of individual elements in an array.\nsub cube_nums {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[1728, 3375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the last digit in factorial of a given number.\nsub last_Digit_Factorial {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit_Factorial;\n        if(eq_deeply($candidate->(4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(21),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find even numbers from an array of numbers.\nsub Split {\n    my($list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 12, 15, 19]),[8, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given integer is a prime number.\nsub prime_num {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_num;\n        if(eq_deeply($candidate->(13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1010),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nsub find_tuples {\n    my($test_list, $K) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_tuples;\n        if(eq_deeply($candidate->([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "pl",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\nsub area_tetrahedron {\n    my($side) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&area_tetrahedron;\n        if(eq_deeply($candidate->(3),15.588457268119894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),692.8203230275509)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),173.20508075688772)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given number is even or not.\nsub is_Even {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Even;\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of positive numbers in an array.\nsub pos_count {\n    my($list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pos_count;\n        if(eq_deeply($candidate->([1, -2, 3, -4]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 5, -1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "pl",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nsub get_ludic {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_ludic;\n        if(eq_deeply($candidate->(10),[1, 2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nsub find_Index {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Index;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "pl",
-    "prompt": "# Write a plthon function to reverse an array upto a given position.\nsub reverse_Array_Upto_K {\n    my($input, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_Array_Upto_K;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7], 2),[5, 4, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "pl",
-    "prompt": "# Write a function to sort an array of arrays using the second value of each array.\nsub subject_marks {\n    my($subjectmarks) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&subject_marks;\n        if(eq_deeply($candidate->([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "pl",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nsub remove_dirty_chars {\n    my($string, $second_string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_dirty_chars;\n        if(eq_deeply($candidate->(\"probasscurve\", \"pros\"),\"bacuve\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"digitalindia\", \"talent\"),\"digiidi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"exoticmiles\", \"toxic\"),\"emles\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "pl",
-    "prompt": "# Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nsub round_and_sum {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&round_and_sum;\n        if(eq_deeply($candidate->([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 9, 24.3, 29]),345)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25.0, 56.7, 89.2]),513)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "pl",
-    "prompt": "# Write a function to find the item with maximum frequency in a given array.\nsub max_occurrences {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_occurrences;\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "pl",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nsub is_decimal {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_decimal;\n        if(eq_deeply($candidate->(\"123.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"e666.86\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3.124587\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.1.11\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\nsub dict_filter {\n    my($dict, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dict_filter;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170),{\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180),{\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190),{\"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of even numbers at even positions of an array.\nsub sum_even_and_even_index {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_even_and_even_index;\n        if(eq_deeply($candidate->([5, 6, 12, 1, 18, 8]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 12, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the sum of the largest contiguous subarray in the given array.\nsub max_sub_array_sum {\n    my($a, $size) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum;\n        if(eq_deeply($candidate->([-2, -3, 4, -1, -2, 1, 5, -3], 8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -4, 5, -2, -3, 2, 6, -4], 8),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-4, -5, 6, -3, -4, 3, 7, -5], 8),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "pl",
-    "prompt": "# Write a function to find the intersection of two arrays.\nsub intersection_array {\n    my($array_nums1, $array_nums2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection_array;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nsub split_two_parts {\n    my($list1, $L) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_two_parts;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "pl",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nsub find_literals {\n    my($text, $pattern) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_literals;\n        if(eq_deeply($candidate->(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the volume of a triangular prism.\nsub find_Volume {\n    my($l, $b, $h) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Volume;\n        if(eq_deeply($candidate->(10, 8, 6),240)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nsub wind_chill {\n    my($v, $t) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&wind_chill;\n        if(eq_deeply($candidate->(120, 35),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(40, 20),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "pl",
-    "prompt": "# Write a function to find the ascii value of a character.\nsub ascii_value {\n    my($k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&ascii_value;\n        if(eq_deeply($candidate->(\"A\"),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"R\"),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"S\"),83)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether all the characters are same or not.\nsub all_Characters_Same {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Characters_Same;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "pl",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\nsub move_num {\n    my($test_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_num;\n        if(eq_deeply($candidate->(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Avengers124Assemble\"),\"AvengersAssemble124\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the length of the word is odd or not.\nsub word_len {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&word_len;\n        if(eq_deeply($candidate->(\"Hadoop\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"great\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"structure\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "pl",
-    "prompt": "# Write a function to drop empty items from a given hash.\nsub drop_empty {\n    my($dict1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&drop_empty;\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => undef}),{\"c1\" => \"Red\", \"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => undef, \"c3\" => undef}),{\"c1\" => \"Red\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => undef, \"c2\" => \"Green\", \"c3\" => undef}),{\"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nsub insert_element {\n    my($list, $element) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&insert_element;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "pl",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\nsub remove_lowercase {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_lowercase;\n        if(eq_deeply($candidate->(\"PYTHon\"),\"PYTH\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"FInD\"),\"FID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"STRinG\"),\"STRG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of set bits (binary digits with value 1) in a given number.\nsub count_Set_Bits {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Set_Bits;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "pl",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given array.\nsub extract_rear {\n    my($test_tuple) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_rear;\n        if(eq_deeply($candidate->([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\nsub count_occurance {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_occurance;\n        if(eq_deeply($candidate->(\"letstdlenstdporstd\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"truststdsolensporsd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"makestdsostdworthit\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"stds\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given arrays contain the k or not.\nsub check_K {\n    my($test_tup, $K) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_K;\n        if(eq_deeply($candidate->([10, 4, 5, 6, 8], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 44, 11, 12], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "pl",
-    "prompt": "# Write a function to interleave 3 arrays of the same length into a single flat array.\nsub interleave_lists {\n    my($list1, $list2, $list3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&interleave_lists;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "pl",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"python_program\"),\"PythonProgram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python_language\"),\"PythonLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"programming_language\"),\"ProgrammingLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of equal numbers from three given integers.\nsub test_three_equal {\n    my($x, $y, $z) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_three_equal;\n        if(eq_deeply($candidate->(1, 1, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2, -3),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nsub odd_length_sum {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_length_sum;\n        if(eq_deeply($candidate->([1, 2, 4]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 7]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "pl",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nsub bell_number {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),115975)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(56),6775685320645824322581483068371419745979053216268760300)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "pl",
-    "prompt": "# Write a function to find the area of a rectangle.\nsub rectangle_area {\n    my($l, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rectangle_area;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "pl",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsub sum_average {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_average;\n        if(eq_deeply($candidate->(10),[55, 5.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),[120, 8.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[210, 10.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nsub division_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&division_elements;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "pl",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsub sum_digits {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_digits;\n        if(eq_deeply($candidate->(345),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "pl",
-    "prompt": "# Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nsub index_minimum {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_minimum;\n        if(eq_deeply($candidate->([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "pl",
-    "prompt": "# Write a function to divide two arrays element wise.\nsub div_list {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&div_list;\n        if(eq_deeply($candidate->([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2], [1, 4]),[3.0, 0.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[1.8, 1.7142857142857142])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "pl",
-    "prompt": "# Write a function to find the array with maximum length.\nsub max_length_list {\n    my($input_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length_list;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "pl",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given array.\nsub combinations_list {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_list;\n        if(eq_deeply($candidate->([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of the largest and smallest value in a given array.\nsub big_sum {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 6]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "pl",
-    "prompt": "# Write a plthon function to return the negative numbers in an array.\nsub neg_nos {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&neg_nos;\n        if(eq_deeply($candidate->([-1, 4, 5, -6]),[-1, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3, 4]),[-1, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-7, -6, 8, 9]),[-7, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the highest power of 2 that is less than or equal to n.\nsub highest_Power_of_2 {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&highest_Power_of_2;\n        if(eq_deeply($candidate->(10),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "pl",
-    "prompt": "# Write a function to check whether an array contains the given subarray or not.\nsub is_sublist {\n    my($l, $s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sublist;\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [4, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [1, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "pl",
-    "prompt": "# Write a function to subtract two arrays element-wise.\nsub sub_list {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sub_list;\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),[-3, -3, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 4]),[-2, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[40, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given two integers have opposite sign or not.\nsub opposite_Signs {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&opposite_Signs;\n        if(eq_deeply($candidate->(1, -2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "pl",
-    "prompt": "# Write a function which takes two arrays of the same length and performs the element wise modulo.\nsub tuple_modulo {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_modulo;\n        if(eq_deeply($candidate->([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "pl",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given array.\nsub diff_even_odd {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&diff_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "pl",
-    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\nsub sort_sublists {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the last digit of a given number.\nsub last_Digit {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit;\n        if(eq_deeply($candidate->(123),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of fourth power of first n odd natural numbers.\nsub odd_num_sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_num_sum;\n        if(eq_deeply($candidate->(2),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),707)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),3108)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "pl",
-    "prompt": "# Write a function to convert an array to a string.\nsub tup_string {\n    my($tup1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tup_string;\n        if(eq_deeply($candidate->([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "pl",
-    "prompt": "# Write a function to remove all elements from a given array present in another array.\nsub remove_elements {\n    my($list1, $list2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_elements;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether any value in a sequence exists in a sequence or not.\nsub overlapping {\n    my($list1, $list2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&overlapping;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5], [1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "pl",
-    "prompt": "# Write a plthon function to identify non-prime numbers.\nsub is_not_prime {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_not_prime;\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(35),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(37),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous array.\nsub max_val {\n    my($listval) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given array of numbers.\nsub sum_negativenum {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_negativenum;\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, -14, 13, -18, 12, -20]),-52)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nsub find_Rotations {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Rotations;\n        if(eq_deeply($candidate->(\"aaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "pl",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nsub change_date_format {\n    my($dt) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_date_format;\n        if(eq_deeply($candidate->(\"2026-01-02\"),\"02-01-2026\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020-11-13\"),\"13-11-2020\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2021-04-26\"),\"26-04-2021\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "pl",
-    "prompt": "# Write a plthon function which takes an array of integers and only returns the odd ones.\nsub Split {\n    my($list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 12, 13]),[11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1]),[7, 9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "pl",
-    "prompt": "# Write a plthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nsub toggle_middle_bits {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_middle_bits;\n        if(eq_deeply($candidate->(9),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(65),127)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nsub count_char_position {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_char_position;\n        if(eq_deeply($candidate->(\"xbcefg\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABcED\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"AbgdeF\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nsub large_product {\n    my($nums1, $nums2, $N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&large_product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nsub cummulative_sum {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cummulative_sum;\n        if(eq_deeply($candidate->([[1, 3], [5, 6, 7], [2, 6]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [6, 7, 8], [3, 7]]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8, 9], [4, 8]]),44)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nsub find_min_diff {\n    my($arr, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_min_diff;\n        if(eq_deeply($candidate->([1, 5, 3, 19, 18, 25], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 6], 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 5, 20, 9], 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nsub text_starta_endb {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_starta_endb;\n        if(eq_deeply($candidate->(\"aabbbb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabAbbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"accddbbjjj\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "pl",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nsub left_rotate {\n    my($n, $d) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_rotate;\n        if(eq_deeply($candidate->(16, 2),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(29, 3),232)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the first repeated character in a given string.\nsub first_repeated_char {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_repeated_char;\n        if(eq_deeply($candidate->(\"abcabc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123123\"),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count inversions in an array.\nsub get_Inv_Count {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Inv_Count;\n        if(eq_deeply($candidate->([1, 20, 6, 4, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 6, 1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nsub even_Power_Sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_Power_Sum;\n        if(eq_deeply($candidate->(2),1056)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),8832)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "pl",
-    "prompt": "# Write a function to find whether all the given arrays have equal length or not.\nsub get_equal {\n    my($Input) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_equal;\n        if(eq_deeply($candidate->([[11, 22, 33], [44, 55, 66]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "pl",
-    "prompt": "# Write a function to check if a string represents an integer or not.\nsub check_integer {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_integer;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12345\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "pl",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/plthon-program-to-count-the-pairs-of-reverse-strings/\nsub count_reverse_pairs {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_reverse_pairs;\n        if(eq_deeply($candidate->([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"geeks\", \"best\", \"for\", \"skeeg\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "pl",
-    "prompt": "# Write a plthon function to move all zeroes to the end of the given array.\nsub move_zero {\n    my($num_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_zero;\n        if(eq_deeply($candidate->([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "pl",
-    "prompt": "# Write a function to check if given array contains no duplicates.\nsub check_distinct {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_distinct;\n        if(eq_deeply($candidate->([1, 4, 5, 6, 1, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nsub noprofit_noloss {\n    my($actual_cost, $sale_amount) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&noprofit_noloss;\n        if(eq_deeply($candidate->(1500, 1200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "pl",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\nsub remove_length {\n    my($test_str, $K) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_length;\n        if(eq_deeply($candidate->(\"The person is most value tet\", 3),\"person is most value\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"If you told me about this ok\", 4),\"If you me about ok\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count number of digits in a given string.\nsub number_ctr {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_ctr;\n        if(eq_deeply($candidate->(\"program2bedone\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wonders\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wond-1ers2\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "pl",
-    "prompt": "# Write a function to count the total number of characters in a string.\nsub count_charac {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_charac;\n        if(eq_deeply($candidate->(\"python programming\"),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"words\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "pl",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nsub get_total_number_of_sequences {\n    my($m, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_total_number_of_sequences;\n        if(eq_deeply($candidate->(10, 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 3),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "pl",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/plthon-exercises/data-structures-and-algorithms/plthon-data-structure-exercise-24.php\nsub left_insertion {\n    my($a, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two numbers and returns an array with the second number and then the first number.\nsub swap_numbers {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_numbers;\n        if(eq_deeply($candidate->(10, 20),[20, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 17),[17, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[200, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nsub is_majority {\n    my($arr, $n, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_majority;\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 3, 10], 7, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 2], 5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2], 5, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nsub substract_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&substract_elements;\n        if(eq_deeply($candidate->([10, 4, 5], [2, 5, 18]),[8, -1, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 2, 3], [24, 45, 16]),[-13, -43, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 18, 9], [10, 11, 12]),[-3, 7, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\nsub capital_words_spaces {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&capital_words_spaces;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PythonProgrammingExamples\"),\"Python Programming Examples\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the average of cubes of first n natural numbers.\nsub find_Average_Of_Cube {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Average_Of_Cube;\n        if(eq_deeply($candidate->(2),4.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "pl",
-    "prompt": "# Write a function to check if all values are same in a hash.\nsub check_value {\n    my($dict, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_value;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth tetrahedral number.\nsub tetrahedral_number {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tetrahedral_number;\n        if(eq_deeply($candidate->(5),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "pl",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nsub magic_square_test {\n    my($my_matrix) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&magic_square_test;\n        if(eq_deeply($candidate->([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "pl",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\nsub remove_uppercase {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_uppercase;\n        if(eq_deeply($candidate->(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "pl",
-    "prompt": "# Write a function to check whether an element exists within an array.\nsub check_tuplex {\n    my($tuplex, $tuple1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_tuplex;\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "pl",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\nsub dog_age {\n    my($h_age) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dog_age;\n        if(eq_deeply($candidate->(12),61)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24),109)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the next perfect square greater than a given number.\nsub next_Perfect_Square {\n    my($N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_Perfect_Square;\n        if(eq_deeply($candidate->(35),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "pl",
-    "prompt": "# Write a function to create an array of N empty dictionaries.\nsub empty_list {\n    my($length) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&empty_list;\n        if(eq_deeply($candidate->(5),[{}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[{}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[{}, {}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "pl",
-    "prompt": "# Write a plthon function to convert a given string to uppercase.\nsub is_upper {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_upper;\n        if(eq_deeply($candidate->(\"person\"),\"PERSON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final\"),\"FINAL\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Valid\"),\"VALID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nsub odd_Equivalent {\n    my($s, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_Equivalent;\n        if(eq_deeply($candidate->(\"011001\", 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011\", 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1010\", 4),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nsub re_arrange_array {\n    my($arr, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&re_arrange_array;\n        if(eq_deeply($candidate->([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether an array of numbers contains only one distinct element or not.\nsub unique_Element {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_Element;\n        if(eq_deeply($candidate->([1, 1, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "pl",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\nsub extract_values {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_values;\n        if(eq_deeply($candidate->(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "pl",
-    "prompt": "# Write a function that counts the number of pairs of integers in an array that xor to an even number.\nsub find_even_pair {\n    my($A) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_even_pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\nsub armstrong_number {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&armstrong_number;\n        if(eq_deeply($candidate->(153),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(259),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4458),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the upper case characters in a given string.\nsub upper_ctr {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&upper_ctr;\n        if(eq_deeply($candidate->(\"PYthon\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"BigData\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to extract the elementwise and arrays from the given two arrays.\nsub and_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&and_tuples;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "pl",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nsub is_samepatterns {\n    my($colors, $patterns) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_samepatterns;\n        if(eq_deeply($candidate->([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of arrays in a given number of arrays.\nsub count_list {\n    my($input_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [2, 3], [4, 5]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 0], [2, 0]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "pl",
-    "prompt": "# Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nsub average_tuple {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&average_tuple;\n        if(eq_deeply($candidate->([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "pl",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nsub lcs_of_three {\n    my($X, $Y, $Z) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lcs_of_three;\n        if(eq_deeply($candidate->(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the n'th star number.\nsub find_star_num {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_star_num;\n        if(eq_deeply($candidate->(3),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of an array.\nsub _sum {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 12, 13, 10]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given array contains consecutive numbers or not.\nsub check_Consecutive {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_Consecutive;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "pl",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nsub find_adverb_position {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverb_position;\n        if(eq_deeply($candidate->(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"seriously!! there are many roses\"),[0, 9, \"seriously\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "pl",
-    "prompt": "# Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/plthon-program-right-rotate-array-n/\nsub rotate_right {\n    my($list, $m) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rotate_right;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of non-empty substrings of a given string.\nsub number_of_substrings {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_of_substrings;\n        if(eq_deeply($candidate->(\"abc\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nsub list_split {\n    my($S, $step) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_split;\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check if the elements of a given array are unique or not.\nsub all_unique {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_unique;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "pl",
-    "prompt": "# Write a plthon function to convert complex numbers to polar coordinates.\nsub convert {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert;\n        if(eq_deeply($candidate->(1),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "pl",
-    "prompt": "# The input is given as - a hash with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nsub filter_data {\n    my($students, $h, $w) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_data;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70),{\"Cierra Vega\" => [6.2, 70]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67),{\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64),{\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "pl",
-    "prompt": "# Write a plthon function to convert the given string to lower case.\nsub is_lower {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_lower;\n        if(eq_deeply($candidate->(\"InValid\"),\"invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"TruE\"),\"true\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"SenTenCE\"),\"sentence\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the smallest power of 2 greater than or equal to n.\nsub next_power_of_2 {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_power_of_2;\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "pl",
-    "prompt": "# Write a function to check if a string is present as a substring in a given array of string values.\nsub find_substring {\n    my($str1, $sub_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_substring;\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "pl",
-    "prompt": "# Write a function to replace characters in a string.\nsub replace_char {\n    my($str1, $ch, $newch) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_char;\n        if(eq_deeply($candidate->(\"polygon\", \"y\", \"l\"),\"pollgon\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"character\", \"c\", \"a\"),\"aharaater\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\", \"l\", \"a\"),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "pl",
-    "prompt": "# Write a function to find the product of first even and odd number of a given array.\nsub mul_even_odd {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mul_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to convert an array to an array.\nsub list_tuple {\n    my($listx) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_tuple;\n        if(eq_deeply($candidate->([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([58, 44, 56]),[58, 44, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nsub even_binomial_Coeff_Sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_binomial_Coeff_Sum;\n        if(eq_deeply($candidate->(4),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "pl",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given arrays.\nsub bitwise_xor {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bitwise_xor;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether an array is subarray of another or not.\nsub is_Sub_Array {\n    my($A, $B) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sub_Array;\n        if(eq_deeply($candidate->([1, 4, 3, 5], [1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], [1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 2], [2, 2, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "pl",
-    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nsub max_sub_array_sum_repeated {\n    my($a, $n, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum_repeated;\n        if(eq_deeply($candidate->([10, 20, -30, -1], 4, 3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 10, 20], 3, 2),59)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3], 3, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to find the minimum product from the pairs of arrays within a given array.\nsub min_product_tuple {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the count of divisors is even. https://www.w3resource.com/plthon-exercises/basic/plthon-basic-1-exercise-24.php\nsub count_divisors {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_divisors;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nsub triangle_area {\n    my($r) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(-1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to convert a given string to an array of characters.\nsub string_to_tuple {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_tuple;\n        if(eq_deeply($candidate->(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nsub find_length {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_length;\n        if(eq_deeply($candidate->(\"11000010001\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"10111\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011101100101\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "pl",
-    "prompt": "# Write a plthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nsub count_Primes_nums {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Primes_nums;\n        if(eq_deeply($candidate->(5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of the product of consecutive binomial co-efficients.\nsub sum_Of_product {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_product;\n        if(eq_deeply($candidate->(3),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the maximum aggregate from the array of arrays.\nsub max_aggregate {\n    my($stdata) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_aggregate;\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "pl",
-    "prompt": "# Write a function to sort an array of elements.\nsub comb_sort {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&comb_sort;\n        if(eq_deeply($candidate->([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([99, 15, 13, 47]),[13, 15, 47, 99])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nsub check_expression {\n    my($exp) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_expression;\n        if(eq_deeply($candidate->(\"{()}[{}]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{}][]({})\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "pl",
-    "prompt": "# Write a function that matches a word containing 'z'.\nsub text_match_wordz {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz;\n        if(eq_deeply($candidate->(\"pythonz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "pl",
-    "prompt": "# Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsub sum_list {\n    my($lst1, $lst2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_list;\n        if(eq_deeply($candidate->([10, 20, 30], [15, 25, 35]),[25, 45, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [5, 6, 7]),[6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 20, 30], [15, 45, 75]),[30, 65, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nsub newman_prime {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&newman_prime;\n        if(eq_deeply($candidate->(3),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),17)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),41)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "pl",
-    "prompt": "# Write a function to apply a given format string to all of the elements in an array.\nsub add_string {\n    my($list_, $string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_string;\n        if(eq_deeply($candidate->([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the surface area of a square plramid with a given base edge and height.\nsub surface_Area {\n    my($b, $s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surface_Area;\n        if(eq_deeply($candidate->(3, 4),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the length of the smallest array in an array of arrays.\nsub Find_Min_Length {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min_Length;\n        if(eq_deeply($candidate->([[1], [1, 2]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 3, 3], [4, 4, 4, 4]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "pl",
-    "prompt": "# Write a plthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nsub validate {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&validate;\n        if(eq_deeply($candidate->(1234),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(51241),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(321),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth hexagonal number.\nsub hexagonal_num {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hexagonal_num;\n        if(eq_deeply($candidate->(10),190)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),91)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "pl",
-    "prompt": "# Write a function to find the n'th lucas number.\nsub find_lucas {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lucas;\n        if(eq_deeply($candidate->(9),76)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "pl",
-    "prompt": "# Write a plthon function to get the difference between two arrays.\nsub Diff {\n    my($li1, $li2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Diff;\n        if(eq_deeply($candidate->([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "pl",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nsub extract_quotation {\n    my($text1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_quotation;\n        if(eq_deeply($candidate->(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "pl",
-    "prompt": "# Write a function to flatten an array and sum all of its elements.\nsub recursive_list_sum {\n    my($data_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&recursive_list_sum;\n        if(eq_deeply($candidate->([1, 2, [3, 4], [5, 6]]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 10, [15, 14], [19, 41]]),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, [30, 40], [50, 60]]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the two numbers differ at one bit position only or not.\nsub differ_At_One_Bit_Pos {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&differ_At_One_Bit_Pos;\n        if(eq_deeply($candidate->(13, 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\nsub text_match_three {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"caacabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nsub max_product {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product;\n        if(eq_deeply($candidate->([3, 100, 4, 5, 150, 6]),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 42, 55, 68, 80]),50265600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 22, 9, 33, 21, 50, 41, 60]),2460)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "pl",
-    "prompt": "# Write a plthon function to split an array at the nth eelment and add the first part to the end.\nsub split_Arr {\n    my($l, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_Arr;\n        if(eq_deeply($candidate->([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 1),[2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the number of divisors of a given integer.\nsub divisor {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisor;\n        if(eq_deeply($candidate->(15),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the difference between largest and smallest value in a given array.\nsub big_diff {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_diff;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 12]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 3]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "pl",
-    "prompt": "# Write a function to find squares of individual elements in an array.\nsub square_nums {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[100, 400, 900])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[144, 225])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "pl",
-    "prompt": "# Write a function to check if the given array has any none value or not.\nsub check_none {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_none;\n        if(eq_deeply($candidate->([10, 4, 5, 6, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 11, 14]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given array is monotonic or not.\nsub is_Monotonic {\n    my($A) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Monotonic;\n        if(eq_deeply($candidate->([6, 5, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nsub is_perfect_square {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_perfect_square;\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(36),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(196),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15625),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of common divisors of two given numbers.\nsub sum {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum;\n        if(eq_deeply($candidate->(10, 15),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 150),93)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "pl",
-    "prompt": "# Write a function to find the array of maximum length in an array of arrays.\nsub max_length {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5], [15, 20, 25]]),[3, [15, 20, 25]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array of arrays and returns a hash mapping each unique array to the number of times it occurs in the array.\nsub check_occurences {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_occurences;\n        if(eq_deeply($candidate->([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3] => 2, [2, 5] => 2, [3, 6] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4] => 2, [3, 6] => 2, [4, 7] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "pl",
-    "prompt": "# Write a function to find the directrix of a parabola.\nsub parabola_directrix {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parabola_directrix;\n        if(eq_deeply($candidate->(5, 3, 2),-198)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 8, 4),-2336)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4, 6),-130)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "pl",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return undef if there is no match.\nsub occurance_substring {\n    my($text, $pattern) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&occurance_substring;\n        if(eq_deeply($candidate->(\"python programming, python language\", \"python\"),[\"python\", 0, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"language\"),[\"language\", 31, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"c++ programming, c++ language\", \"python\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "pl",
-    "prompt": "# Write a function to remove arrays from the given array.\nsub remove_nested {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_nested;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "pl",
-    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\nsub sort_sublists {\n    my($input_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "pl",
-    "prompt": "# Write a plthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nsub remove_kth_element {\n    my($list1, $L) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_kth_element;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to add a hash to the array. The output should be an array.\nsub add_dict_to_tuple {\n    my($test_tup, $test_dict) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_dict_to_tuple;\n        if(eq_deeply($candidate->([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}),[4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}),[1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}),[8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find quotient of two numbers (rounded down to the nearest integer).\nsub find {\n    my($n, $m) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find;\n        if(eq_deeply($candidate->(10, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "pl",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nsub text_match_two_three {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_two_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the occurence of all elements of array in an array.\nsub count_Occurrence {\n    my($tup, $lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Occurrence;\n        if(eq_deeply($candidate->([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "pl",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given arrays.\nsub count_samepair {\n    my($list1, $list2, $list3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_samepair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "pl",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\nsub text_match_one {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nsub difference {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&difference;\n        if(eq_deeply($candidate->(3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "pl",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\nsub toggle_string {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_string;\n        if(eq_deeply($candidate->(\"Python\"),\"pYTHON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pangram\"),\"pANGRAM\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"LIttLE\"),\"liTTle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the element of an array having maximum length.\nsub Find_Max {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max;\n        if(eq_deeply($candidate->([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\nsub eulerian_num {\n    my($n, $m) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eulerian_num;\n        if(eq_deeply($candidate->(3, 1),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given array.\nsub frequency {\n    my($a, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency;\n        if(eq_deeply($candidate->([1, 2, 3], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 3, 4], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 1, 2], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "pl",
-    "prompt": "# Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/plthon-sort-numeric-strings-in-a-array/\nsub sort_numeric_strings {\n    my($nums_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numeric_strings;\n        if(eq_deeply($candidate->([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/plthon-exercises/data-structures-and-algorithms/plthon-recursion-exercise-9.php\nsub geometric_sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&geometric_sum;\n        if(eq_deeply($candidate->(7),1.9921875)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1.9375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1.99609375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "pl",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/plthon-exercises/lambda/plthon-lambda-exercise-24.php\nsub divisible_by_digits {\n    my($startnum, $endnum) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisible_by_digits;\n        if(eq_deeply($candidate->(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 25),[22, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "pl",
-    "prompt": "# Write a plthon function to calculate the product of the unique numbers in a given array.\nsub unique_product {\n    my($list_data) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_product;\n        if(eq_deeply($candidate->([10, 20, 30, 40, 20, 50, 60, 40]),720000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 0, 1, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the largest negative number from the given array.\nsub largest_neg {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_neg;\n        if(eq_deeply($candidate->([1, 2, 3, -4, -6]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -8, -9]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "pl",
-    "prompt": "# Write a function to remove consecutive duplicates of a given array.\nsub consecutive_duplicates {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "pl",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nsub min_Jumps {\n    my($steps, $d) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Jumps;\n        if(eq_deeply($candidate->([3, 4], 11),3.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4], 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 14], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find a pair with highest product from a given array of integers.\nsub max_Product {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, -1, -2, -4, 5, 0, -6]),[-4, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "pl",
-    "prompt": "# Write a function to extract the nth element from a given array of arrays.\nsub extract_nth_element {\n    my($list1, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_nth_element;\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth nonagonal number.\nsub is_nonagonal {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nonagonal;\n        if(eq_deeply($candidate->(10),325)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),750)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),1089)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the maximum difference between any two elements in a given array.\nsub max_Abs_Diff {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Abs_Diff;\n        if(eq_deeply($candidate->([2, 1, 5, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 3, 2, 5, 1]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "pl",
-    "prompt": "# Write a function to pack consecutive duplicates of a given array elements into subarrays.\nsub pack_consecutive_duplicates {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pack_consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\nsub cal_sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cal_sum;\n        if(eq_deeply($candidate->(9),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "pl",
-    "prompt": "# Write a plthon function to remove the characters which have odd index values of a given string.\nsub odd_values_string {\n    my($str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_values_string;\n        if(eq_deeply($candidate->(\"abcdef\"),\"ace\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\"),\"pto\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"dt\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lambs\"),\"lms\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "pl",
-    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nsub find_kth {\n    my($arr1, $arr2, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_kth;\n        if(eq_deeply($candidate->([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nsub jacobsthal_num {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&jacobsthal_num;\n        if(eq_deeply($candidate->(5),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),2731)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "pl",
-    "prompt": "# Write a function to find frequency of each element in a flattened array of arrays, returned in a hash.\nsub frequency_lists {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "pl",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\nsub perfect_squares {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perfect_squares;\n        if(eq_deeply($candidate->(1, 30),[1, 4, 9, 16, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(50, 100),[64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[100, 121, 144, 169, 196])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsub sum_Of_Subarray_Prod {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_Subarray_Prod;\n        if(eq_deeply($candidate->([1, 2, 3]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the first odd number in a given array of numbers.\nsub first_odd {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_odd;\n        if(eq_deeply($candidate->([1, 3, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "pl",
-    "prompt": "# Write a function to perform index wise addition of array elements in the given two nested arrays.\nsub add_nested_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_nested_tuples;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "pl",
-    "prompt": "# Write a plthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nsub merge {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given number can be represented as the difference of two squares or not.\nsub dif_Square {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dif_Square;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "pl",
-    "prompt": "# Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nsub check_smaller {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_smaller;\n        if(eq_deeply($candidate->([1, 2, 3], [2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6], [3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13], [10, 11, 12]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "pl",
-    "prompt": "# Write a function to get the frequency of all the elements in an array, returned as a hash.\nsub freq_count {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&freq_count;\n        if(eq_deeply($candidate->([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1 => 3, 2 => 2, 3 => 3, 4 => 3})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "pl",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nsub rgb_to_hsv {\n    my($r, $g, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rgb_to_hsv;\n        if(eq_deeply($candidate->(255, 255, 255),[0.0, 0.0, 100.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 215, 0),[120.0, 100.0, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "pl",
-    "prompt": "# Write a function to flatten a given nested array structure.\nsub flatten_list {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flatten_list;\n        if(eq_deeply($candidate->([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\nsub check_str {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_str;\n        if(eq_deeply($candidate->(\"annie\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dawood\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Else\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nsub check_monthnumber_number {\n    my($monthnum3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumber_number;\n        if(eq_deeply($candidate->(6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "pl",
-    "prompt": "# Write a function to sort the given array.\nsub heap_sort {\n    my($iterable) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_sort;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 1, 9, 5]),[1, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "pl",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nsub k_smallest_pairs {\n    my($nums1, $nums2, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&k_smallest_pairs;\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 1),[[1, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "pl",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undef if no solution exists.\nsub find_solution {\n    my($a, $b, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_solution;\n        if(eq_deeply($candidate->(2, 3, 7),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 7),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 13, 17),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the largest number that can be formed with the given array of digits.\nsub find_Max_Num {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Max_Num;\n        if(eq_deeply($candidate->([1, 2, 3]),321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 1]),6541)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 9]),9321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "pl",
-    "prompt": "# Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nsub max_sum_list {\n    my($lists) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_list;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 1]]),[2, 3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "pl",
-    "prompt": "# Write a plthon function to interchange the first and last elements in an array.\nsub swap_List {\n    my($newList) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "pl",
-    "prompt": "# Write a function to find the median of two sorted arrays of same size.\nsub get_median {\n    my($arr1, $arr2, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_median;\n        if(eq_deeply($candidate->([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nsub replace_spaces {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"The_Avengers\"),\"The Avengers\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Fast and Furious\"),\"Fast_and_Furious\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "pl",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nsub are_equivalent {\n    my($num1, $num2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&are_equivalent;\n        if(eq_deeply($candidate->(36, 57),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 47),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "pl",
-    "prompt": "# Write a function to reverse each string in a given array of string values.\nsub reverse_string_list {\n    my($stringlist) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_string_list;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "pl",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given array.\nsub sum_of_digits {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_of_digits;\n        if(eq_deeply($candidate->([10, 2, 56]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, -4, 5, -70]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsub sequence {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequence;\n        if(eq_deeply($candidate->(10),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "pl",
-    "prompt": "# Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nsub heap_queue_largest {\n    my($nums, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_queue_largest;\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "pl",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nsub loss_amount {\n    my($actual_cost, $sale_amount) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&loss_amount;\n        if(eq_deeply($candidate->(1500, 1200),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "pl",
-    "prompt": "# Write a function to find the union of the elements of two given arrays and output them in sorted order.\nsub union_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&union_elements;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the length of the longest subarrays.\nsub Find_Max_Length {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max_Length;\n        if(eq_deeply($candidate->([[1], [1, 4], [5, 6, 7, 8]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 1], [2, 2], [3, 2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "pl",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nsub remove_parenthesis {\n    my($items) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_parenthesis;\n        if(eq_deeply($candidate->([\"python (chrome)\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"string(.abc)\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"alpha(num)\"]),\"alpha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find whether the parity of a given number is odd.\nsub find_Parity {\n    my($x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Parity;\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "pl",
-    "prompt": "# Write a function to find the median length of a trapezium.\nsub median_trapezium {\n    my($base1, $base2, $height) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_trapezium;\n        if(eq_deeply($candidate->(15, 25, 35),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 20, 30),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 9, 4),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "pl",
-    "prompt": "# Write a function to find nth centered hexagonal number.\nsub centered_hexagonal_number {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&centered_hexagonal_number;\n        if(eq_deeply($candidate->(10),271)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),217)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "pl",
-    "prompt": "# Write a function to find number of arrays present in the given array.\nsub find_lists {\n    my($Input) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5, 4, 3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nsub get_max_sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_sum;\n        if(eq_deeply($candidate->(60),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the length of the longest word.\nsub len_log {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&len_log;\n        if(eq_deeply($candidate->([\"python\", \"PHP\", \"bigdata\"]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"ab\", \"abc\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"small\", \"big\", \"tall\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "pl",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undef if the angle is larger than 360 degrees.\nsub sector_area {\n    my($r, $a) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sector_area;\n        if(eq_deeply($candidate->(4, 45),6.283185307179586)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 45),31.808625617596654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 361),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether every odd index contains odd numbers of a given array.\nsub odd_position {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_position;\n        if(eq_deeply($candidate->([2, 1, 4, 3, 6, 7, 6, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "pl",
-    "prompt": "# Write a function to join an array of multiple integers into a single integer.\nsub multiple_to_single {\n    my($L) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiple_to_single;\n        if(eq_deeply($candidate->([11, 33, 50]),113350)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4, 5, 6]),-123456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, 20, 25]),10152025)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find whether a number is divisible by 11.\nsub is_Diff {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Diff;\n        if(eq_deeply($candidate->(12345),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212112),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "pl",
-    "prompt": "# Write a function to perform index wise multiplication of array elements in the given two arrays.\nsub index_multiplication {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_multiplication;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "pl",
-    "prompt": "# Write a function to convert array string to integer array.\nsub tuple_str_int {\n    my($test_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_str_int;\n        if(eq_deeply($candidate->(\"(7, 8, 9)\"),[7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(1, 2, 3)\"),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(4, 5, 6)\"),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(7, 81, 19)\"),[7, 81, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "pl",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\nsub amicable_numbers_sum {\n    my($limit) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&amicable_numbers_sum;\n        if(eq_deeply($candidate->(999),504)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9999),31626)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "pl",
-    "prompt": "# Write a function to remove odd characters in a string.\nsub remove_odd {\n    my($str1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->(\"python\"),\"yhn\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),\"rga\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),\"agae\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "pl",
-    "prompt": "# Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nsub multiply_elements {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_elements;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[5, 35, 56, 80])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 7]),[8, 20, 30, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 13, 14, 9, 15]),[156, 182, 126, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nsub count_rotation {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_rotation;\n        if(eq_deeply($candidate->([3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 1, 2, 3]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "pl",
-    "prompt": "# Write a function to extract the number of unique arrays in the given array.\nsub extract_freq {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_freq;\n        if(eq_deeply($candidate->([[3, 4], [1, 2], [4, 3], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 15], [2, 3], [5, 4], [6, 7]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 16], [2, 3], [6, 5], [6, 9]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "pl",
-    "prompt": "# The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nsub count_same_pair {\n    my($nums1, $nums2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_same_pair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 1, 2], [0, 1, 2, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\nsub power {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power;\n        if(eq_deeply($candidate->(3, 4),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),3125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "pl",
-    "prompt": "# Write function to find the sum of all items in the given hash.\nsub return_sum {\n    my($dict) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&return_sum;\n        if(eq_deeply($candidate->({\"a\" => 100, \"b\" => 200, \"c\" => 300}),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 25, \"b\" => 18, \"c\" => 45}),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 36, \"b\" => 39, \"c\" => 49}),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "pl",
-    "prompt": "# Write a function to return an array of all pairs of consecutive items in a given array.\nsub pair_wise {\n    my($l1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_wise;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "pl",
-    "prompt": "# Write a plthon function to split a string into characters.\nsub split {\n    my($word) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split;\n        if(eq_deeply($candidate->(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Name\"),[\"N\", \"a\", \"m\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "pl",
-    "prompt": "# Write a function to find minimum of three numbers.\nsub min_of_three {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_of_three;\n        if(eq_deeply($candidate->(10, 20, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 15, 18),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -20, -30),-30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nsub is_Sum_Of_Powers_Of_Two {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sum_Of_Powers_Of_Two;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nsub get_Char {\n    my($strr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Char;\n        if(eq_deeply($candidate->(\"abc\"),\"f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gfg\"),\"t\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "pl",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\nsub sum_div {\n    my($number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_div;\n        if(eq_deeply($candidate->(8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "pl",
-    "prompt": "# Write a plthon function that returns the number of integer elements in a given array.\nsub count_integer {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_integer;\n        if(eq_deeply($candidate->([1, 2, \"abc\", 1.2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1.2, 4, 5.1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "pl",
-    "prompt": "# Write a plthon function to remove duplicate numbers from a given number of arrays.\nsub two_unique_nums {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&two_unique_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "pl",
-    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\nsub test_duplicate {\n    my($arraynums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_duplicate;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3, 3, 4, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "pl",
-    "prompt": "# Write a function which returns nth catalan number.\nsub catalan_number {\n    my($num) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&catalan_number;\n        if(eq_deeply($candidate->(10),16796)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),4862)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),429)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "pl",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nsub power_base_sum {\n    my($base, $power) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power_base_sum;\n        if(eq_deeply($candidate->(2, 100),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 10),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 15),62)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "pl",
-    "prompt": "# Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nsub replace_list {\n    my($list1, $list2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_list;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth octagonal number.\nsub is_octagonal {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_octagonal;\n        if(eq_deeply($candidate->(5),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),280)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),645)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "pl",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nsub replace_blank {\n    my($str1, $char) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_blank;\n        if(eq_deeply($candidate->(\"hello people\", \"@\"),\"hello@people\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python program language\", \"$\"),\"python$program$language\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"blank space\", \"-\"),\"blank-space\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "pl",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nsub replace_specialchar {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_specialchar;\n        if(eq_deeply($candidate->(\"Python language, Programming language.\"),\"Python:language::Programming:language:\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c,d e f\"),\"a:b:c:d:e:f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "pl",
-    "prompt": "# Write a function to convert a given array of positive integers into a single integer.\nsub tuple_to_int {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_int;\n        if(eq_deeply($candidate->([1, 2, 3]),123)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7]),567)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "pl",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\nsub otherside_rightangle {\n    my($w, $h) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&otherside_rightangle;\n        if(eq_deeply($candidate->(7, 8),10.63014581273465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 15),16.55294535724685)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "pl",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nsub expensive_items {\n    my($items, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&expensive_items;\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2),[{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of the per-digit difference between two integers.\nsub digit_distance_nums {\n    my($n1, $n2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digit_distance_nums;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 56),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123, 256),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "pl",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\nsub text_match_wordz_middle {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz_middle;\n        if(eq_deeply($candidate->(\"pythonzabc.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zxyabc.\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "pl",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\nsub removezero_ip {\n    my($ip) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&removezero_ip;\n        if(eq_deeply($candidate->(\"216.08.094.196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12.01.024\"),\"12.1.24\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"216.08.094.0196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "pl",
-    "prompt": "# Write a function to count the number of subarrays containing a particular element.\nsub count_element_in_list {\n    my($list1, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_element_in_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "pl",
-    "prompt": "# Write a function to multiply two integers.\nsub multiply_int {\n    my($x, $y) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_int;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "pl",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given array.\nsub add_pairwise {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_pairwise;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[6, 12, 15, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, 9, 11]),[8, 14, 17, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, 10, 12]),[10, 16, 19, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nsub max_product_tuple {\n    my($list1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),484)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4120,7 +18,7 @@
     "language": "pl",
     "prompt": "# Write a function to find the kth element in the given array using 1-based indexing.\nsub kth_element {\n    my($arr, $k) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&kth_element;\n        if(eq_deeply($candidate->([12, 3, 5, 7, 19], 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([17, 24, 8, 23], 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([16, 21, 25, 36, 4], 4),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4130,13 +28,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "pl",
-    "prompt": "# Write a plthon function to interchange the first and last element in a given array.\nsub swap_List {\n    my($newList) = @_;\n",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"python_program\"),\"PythonProgram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python_language\"),\"PythonLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"programming_language\"),\"ProgrammingLanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4144,13 +42,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "pl",
-    "prompt": "# Write a function to find the number of elements that occurs before the array element in the given array.\nsub count_first_elements {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\nsub eulerian_num {\n    my($n, $m) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_first_elements;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 9, [5, 7], 11]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 5, 8, [2, 3], 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&eulerian_num;\n        if(eq_deeply($candidate->(3, 1),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4158,13 +56,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "pl",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nsub right_insertion {\n    my($a, $x) = @_;\n",
+    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\nsub sort_sublists {\n    my($input_list) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4172,13 +70,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_106_add_lists",
     "language": "pl",
-    "prompt": "# Write a function to check if the given number is woodball or not.\nsub is_woodall {\n    my($x) = @_;\n",
+    "prompt": "# Write a function to append the given array to the given arrays.\nsub add_lists {\n    my($test_list, $test_tup) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_woodall;\n        if(eq_deeply($candidate->(383),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(254),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_lists;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4186,13 +84,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "pl",
-    "prompt": "# Write a function to sort the given array by using shell sort.\nsub shell_sort {\n    my($my_list) = @_;\n",
+    "prompt": "# Write a function to merge three arrays into a single sorted array.\nsub merge_sorted_list {\n    my($num1, $num2, $num3) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&shell_sort;\n        if(eq_deeply($candidate->([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_sorted_list;\n        if(eq_deeply($candidate->([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4200,13 +98,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "pl",
-    "prompt": "# Write a plthon function to count the number of pairs whose xor value is odd.\nsub find_Odd_Pair {\n    my($A, $N) = @_;\n",
+    "prompt": "# Write a plthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nsub odd_Equivalent {\n    my($s, $n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Odd_Pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11], 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_Equivalent;\n        if(eq_deeply($candidate->(\"011001\", 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011\", 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1010\", 4),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4214,13 +112,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_113_check_integer",
     "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of all odd natural numbers within the range l and r.\nsub sum_in_range {\n    my($l, $r) = @_;\n",
+    "prompt": "# Write a function to check if a string represents an integer or not.\nsub check_integer {\n    my($text) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_in_range;\n        if(eq_deeply($candidate->(2, 5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_integer;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12345\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4228,223 +126,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_116_tuple_to_int",
     "language": "pl",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsub square_perimeter {\n    my($a) = @_;\n",
+    "prompt": "# Write a function to convert a given array of positive integers into a single integer.\nsub tuple_to_int {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_perimeter;\n        if(eq_deeply($candidate->(10),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_765_is_polite",
-    "language": "pl",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nsub is_polite {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_polite;\n        if(eq_deeply($candidate->(7),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "pl",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsub sum_series {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_series;\n        if(eq_deeply($candidate->(6),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "pl",
-    "prompt": "# Write a function to find the dissimilar elements in the given two arrays.\nsub find_dissimilar {\n    my($test_tup1, $test_tup2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_dissimilar;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "pl",
-    "prompt": "# Write a function to return two words from an array of words starting with letter 'p'.\nsub start_withp {\n    my($words) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&start_withp;\n        if(eq_deeply($candidate->([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "pl",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"android_tv\"),\"AndroidTv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"google_pixel\"),\"GooglePixel\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple_watch\"),\"AppleWatch\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "pl",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\nsub volume_cube {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&volume_cube;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\nsub check_monthnumb_number {\n    my($monthnum2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumb_number;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check whether all the bits are unset in the given range or not.\nsub all_Bits_Set_In_The_Given_Range {\n    my($n, $l, $r) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Bits_Set_In_The_Given_Range;\n        if(eq_deeply($candidate->(4, 1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 2, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(39, 4, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "pl",
-    "prompt": "# Write a plthon function to get the first element of each subarray.\nsub Extract {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Extract;\n        if(eq_deeply($candidate->([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5]]),[1, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[9, 8, 1], [1, 2]]),[9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "pl",
-    "prompt": "# Write a function to find the surface area of a cylinder.\nsub surfacearea_cylinder {\n    my($r, $h) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cylinder;\n        if(eq_deeply($candidate->(10, 5),942.45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),226.18800000000002)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 10),351.848)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "pl",
-    "prompt": "# Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nsub sample_nam {\n    my($sample_names) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sample_nam;\n        if(eq_deeply($candidate->([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abcd\", \"Python\", \"abba\", \"aba\"]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "pl",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nsub rearrange_bigger {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rearrange_bigger;\n        if(eq_deeply($candidate->(12),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(102),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "pl",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nsub perimeter_pentagon {\n    my($a) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perimeter_pentagon;\n        if(eq_deeply($candidate->(5),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "pl",
-    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nsub max_sum {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum;\n        if(eq_deeply($candidate->([1, 15, 51, 45, 33, 100, 12, 18, 9]),194)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([80, 60, 30, 40, 20, 10]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 14, 16, 21, 23, 29, 30]),138)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "pl",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed array.\nsub extract_even {\n    my($test_tuple) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_even;\n        if(eq_deeply($candidate->([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_int;\n        if(eq_deeply($candidate->([1, 2, 3]),123)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7]),567)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4456,233 +144,9 @@
     "language": "pl",
     "prompt": "# Write a function to convert all possible convertible elements in an array of arrays to floats.\nsub list_to_float {\n    my($test_list) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_to_float;\n        if(eq_deeply($candidate->([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "pl",
-    "prompt": "# Write a plthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nsub get_pairs_count {\n    my($arr, $sum) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_pairs_count;\n        if(eq_deeply($candidate->([1, 1, 1, 1], 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, -1, 5], 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 3], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3], -3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "pl",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nsub count_no_of_ways {\n    my($n, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_no_of_ways;\n        if(eq_deeply($candidate->(2, 4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 4),228)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "pl",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nsub reverse_words {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_words;\n        if(eq_deeply($candidate->(\"python program\"),\"program python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"java language\"),\"language java\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"indian man\"),\"man indian\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "pl",
-    "prompt": "# Write a plthon function to check if a given number is one less than twice its reverse.\nsub checks {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&checks;\n        if(eq_deeply($candidate->(70),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the last position of an element in a sorted array.\nsub last {\n    my($arr, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last;\n        if(eq_deeply($candidate->([1, 2, 3], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, 4], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 3, 6, 8, 9], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "pl",
-    "prompt": "# Write a plthon function that takes in an array and an element and counts the occcurences of the element in the array.\nsub count_X {\n    my($tup, $x) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_X;\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "pl",
-    "prompt": "# We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nsub extract_index_list {\n    my($l1, $l2, $l3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_index_list;\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "pl",
-    "prompt": "# Write a function to find the second smallest number in an array.\nsub second_smallest {\n    my($numbers) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&second_smallest;\n        if(eq_deeply($candidate->([1, 2, -8, -2, 0, -2]),-2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, -0.5, 0, 2, -2, -2]),-0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to concatenate each element of array by the delimiter.\nsub concatenate_tuple {\n    my($test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate_tuple;\n        if(eq_deeply($candidate->([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nsub replace_spaces {\n    my($string) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I am a Programmer\"),\"I%20am%20a%20Programmer\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love Coding\"),\"I%20love%20Coding\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "pl",
-    "prompt": "# Write a function to find the sum of numbers in an array within a range specified by two indices.\nsub sum_range_list {\n    my($list1, $m, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_range_list;\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "pl",
-    "prompt": "# Write a function to merge three dictionaries into a single hash.\nsub merge_dictionaries_three {\n    my($dict1, $dict2, $dict3) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_dictionaries_three;\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}),{\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}),{\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}),{\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the minimum of two numbers.\nsub minimum {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minimum;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-5, -4),-5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given array array.\nsub max_difference {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_difference;\n        if(eq_deeply($candidate->([[3, 5], [1, 7], [10, 3], [1, 2]]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [2, 17], [9, 13], [11, 12]]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 35], [21, 27], [13, 23], [41, 22]]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find element at a given index after number of rotations.\nsub find_Element {\n    my($arr, $ranges, $rotations, $index) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4694,7 +158,7 @@
     "language": "pl",
     "prompt": "# Write a function to convert a string to an array of strings split on the space character.\nsub string_to_list {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_list;\n        if(eq_deeply($candidate->(\"python programming\"),[\"python\", \"programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"write a program\"),[\"write\", \"a\", \"program\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4708,23 +172,9 @@
     "language": "pl",
     "prompt": "# Write a plthon function to find the element that appears only once in a sorted array.\nsub search {\n    my($arr) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&search;\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "pl",
-    "prompt": "# Write a function to sort a hash by value.\nsub sort_counter {\n    my($dict1) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_counter;\n        if(eq_deeply($candidate->({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4736,7 +186,7 @@
     "language": "pl",
     "prompt": "# Write a plthon function to remove first and last occurrence of a given character from the string.\nsub remove_Occ {\n    my($s, $ch) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_Occ;\n        if(eq_deeply($candidate->(\"hello\", \"l\"),\"heo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcda\", \"a\"),\"bcd\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PHP\", \"P\"),\"H\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -4746,13 +196,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "pl",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nsub lateralsurface_cube {\n    my($l) = @_;\n",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nsub max_product_tuple {\n    my($list1) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cube;\n        if(eq_deeply($candidate->(5),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),324)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),400)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),484)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4760,13 +210,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "pl",
-    "prompt": "# Write a function that takes two arrays and returns true if they have at least one common element.\nsub common_element {\n    my($list1, $list2) = @_;\n",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\nsub amicable_numbers_sum {\n    my($limit) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common_element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&amicable_numbers_sum;\n        if(eq_deeply($candidate->(999),504)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9999),31626)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4774,13 +224,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "pl",
-    "prompt": "# Write a function to append the given array to the given arrays.\nsub add_lists {\n    my($test_list, $test_tup) = @_;\n",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nsub find_length {\n    my($string) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_lists;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_length;\n        if(eq_deeply($candidate->(\"11000010001\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"10111\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"11011101100101\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4788,13 +238,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "pl",
-    "prompt": "# Write a function to compute the n-th power of each number in an array.\nsub nth_nums {\n    my($nums, $n) = @_;\n",
+    "prompt": "# Write a plthon function to find the sum of common divisors of two given numbers.\nsub sum {\n    my($a, $b) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&nth_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30], 3),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15], 5),[248832, 759375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum;\n        if(eq_deeply($candidate->(10, 15),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 150),93)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -4802,335 +252,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "pl",
-    "prompt": "# Write a function to sort an array of elements.\nsub pancake_sort {\n    my($nums) = @_;\n",
+    "prompt": "# Write a function to multiply two integers.\nsub multiply_int {\n    my($x, $y) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pancake_sort;\n        if(eq_deeply($candidate->([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "pl",
-    "prompt": "# Write a function to find the median of three numbers.\nsub median_numbers {\n    my($a, $b, $c) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_numbers;\n        if(eq_deeply($candidate->(25, 55, 65),55.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 10, 30),20.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 45, 75),45.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\nsub check_greater {\n    my($arr, $number) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_greater;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6], 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 4, 8, 6, 1], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nsub check_element {\n    my($list, $element) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_element;\n        if(eq_deeply($candidate->([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"green\", \"green\", \"green\", \"green\"], \"green\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "pl",
-    "prompt": "# Write a function to extract specified size of strings from a given array of string values.\nsub extract_string {\n    my($str, $l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_string;\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "pl",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nsub text_lowercase_underscore {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_lowercase_underscore;\n        if(eq_deeply($candidate->(\"aab_cbbbc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aab_Abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Aaab_abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to trim each array by k in the given arrays.\nsub trim_tuple {\n    my($test_list, $K) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&trim_tuple;\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the subarray having minimum length.\nsub Find_Min {\n    my($lst) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min;\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "pl",
-    "prompt": "# Write a function to filter odd numbers.\nsub filter_oddnumbers {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_oddnumbers;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 45, 67, 84, 93]),[45, 67, 93])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "pl",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nsub find_adverbs {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverbs;\n        if(eq_deeply($candidate->(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Please handle the situation carefuly\"),\"28-36: carefuly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Complete the task quickly\"),\"18-25: quickly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "pl",
-    "prompt": "# Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nsub max_of_nth {\n    my($test_list, $N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_of_nth;\n        if(eq_deeply($candidate->([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "pl",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nsub decimal_to_binary {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(8),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nsub combinations_colors {\n    my($l, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_colors;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "pl",
-    "prompt": "# Write a function to remove all whitespaces from a string.\nsub remove_all_spaces {\n    my($text) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_all_spaces;\n        if(eq_deeply($candidate->(\"python  program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python   programming    language\"),\"pythonprogramminglanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nsub min_Swaps {\n    my($str1, $str2) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Swaps;\n        if(eq_deeply($candidate->(\"1101\", \"1110\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"000\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"110\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to create a new array from the given string and array.\nsub new_tuple {\n    my($test_list, $test_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&new_tuple;\n        if(eq_deeply($candidate->([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the product of the array multiplication modulo n.\nsub find_remainder {\n    my($arr, $n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_remainder;\n        if(eq_deeply($candidate->([100, 10, 5, 25, 35, 14], 11),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "pl",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous array.\nsub min_val {\n    my($listval) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "pl",
-    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\nsub positive_count {\n    my($nums) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&positive_count;\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "pl",
-    "prompt": "# Write a function to add the given array to the given array.\nsub add_tuple {\n    my($test_list, $test_tup) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_tuple;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "pl",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nsub max_run_uppercase {\n    my($test_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_run_uppercase;\n        if(eq_deeply($candidate->(\"GeMKSForGERksISBESt\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PrECIOusMOVemENTSYT\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GooGLEFluTTER\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "pl",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsub sort_matrix {\n    my($M) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_matrix;\n        if(eq_deeply($candidate->([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "pl",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\nsub count_vowels {\n    my($test_str) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_vowels;\n        if(eq_deeply($candidate->(\"bestinstareels\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"partofthejourneyistheend\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"amazonprime\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "pl",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nsub max_sum_increasing_subseq {\n    my($a, $n, $index, $k) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_increasing_subseq;\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_int;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 8),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5142,7 +270,7 @@
     "language": "pl",
     "prompt": "# Write a function to find words that are longer than n characters from a given array of words.\nsub long_words {\n    my($n, $str) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&long_words;\n        if(eq_deeply($candidate->(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, \"writing a program\"),[\"writing\", \"program\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, \"sorting list\"),[\"sorting\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5152,13 +280,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of non-repeated elements in a given array.\nsub find_sum {\n    my($arr) = @_;\n",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nsub magic_square_test {\n    my($my_matrix) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_sum;\n        if(eq_deeply($candidate->([1, 2, 3, 1, 1, 4, 5, 6]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 10, 9, 4, 2, 10, 10, 45, 4]),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 10, 9, 45, 2, 10, 10, 45, 10]),78)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&magic_square_test;\n        if(eq_deeply($candidate->([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5166,13 +294,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "pl",
-    "prompt": "# Write a function to convert the given array to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/plthon-convert-array-to-adjacent-pair-hash/\nsub tuple_to_dict {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsub sort_matrix {\n    my($M) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_dict;\n        if(eq_deeply($candidate->([1, 5, 7, 10, 13, 5]),{1 => 5, 7 => 10, 13 => 5})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),{1 => 2, 3 => 4, 5 => 6})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 10, 11, 12]),{7 => 8, 9 => 10, 11 => 12})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_matrix;\n        if(eq_deeply($candidate->([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5180,209 +308,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "pl",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate array.\nsub get_coordinates {\n    my($test_tup) = @_;\n",
+    "prompt": "# Write a function to find the item with maximum frequency in a given array.\nsub max_occurrences {\n    my($nums) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_coordinates;\n        if(eq_deeply($candidate->([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "pl",
-    "prompt": "# Write a function to check if all the elements in array have same data type or not.\nsub check_type {\n    my($test_tuple) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_type;\n        if(eq_deeply($candidate->([5, 6, 7, 3, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, \"4\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the smallest missing number from a sorted array of natural numbers.\nsub find_First_Missing {\n    my($array) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_First_Missing;\n        if(eq_deeply($candidate->([0, 1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 6, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 8, 9]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\nsub is_undulating {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_undulating;\n        if(eq_deeply($candidate->(1212121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1991),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "pl",
-    "prompt": "# Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/plthon-find-minimum-k-records-from-array-array/ - in this case a verbatim copl of test cases\nsub min_k {\n    my($test_list, $K) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_k;\n        if(eq_deeply($candidate->([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "pl",
-    "prompt": "# Write a plthon function to count the number of substrings with the sum of digits equal to their length.\nsub count_Substrings {\n    my($s) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Substrings;\n        if(eq_deeply($candidate->(\"112112\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1101112\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "pl",
-    "prompt": "# Write a function to find the nth decagonal number.\nsub is_num_decagonal {\n    my($n) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_num_decagonal;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),175)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),370)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nsub rear_extract {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rear_extract;\n        if(eq_deeply($candidate->([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "pl",
-    "prompt": "# Write a function to find the closest smaller number than n.\nsub closest_num {\n    my($N) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_num;\n        if(eq_deeply($candidate->(11),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "pl",
-    "prompt": "# Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/plthon-combinations-of-sum-with-arrays-in-array-array/\nsub find_combinations {\n    my($test_list) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_combinations;\n        if(eq_deeply($candidate->([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "pl",
-    "prompt": "# Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nsub maxAverageOfPath {\n    my($cost) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maxAverageOfPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "pl",
-    "prompt": "# Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsub sequential_search {\n    my($dlist, $item) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequential_search;\n        if(eq_deeply($candidate->([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 32, 45, 62, 35, 47, 44, 61], 61),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 10, 17, 19, 22, 39, 48, 56], 48),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "pl",
-    "prompt": "# Write a plthon function to remove odd numbers from a given array.\nsub remove_odd {\n    my($l) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->([1, 2, 3]),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 6]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 3]),[10, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "pl",
-    "prompt": "# Write a function to check whether the product of numbers in an array is even or not.\nsub is_product_even {\n    my($arr) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_product_even;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
-    "stop_tokens": [
-      "\nsub",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "pl",
-    "prompt": "# Write a plthon function to find the maximum of two numbers.\nsub maximum {\n    my($a, $b) = @_;\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->(5, 10),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 7),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_occurrences;\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5394,9 +326,709 @@
     "language": "pl",
     "prompt": "# Write a plthon function to reverse only the vowels of a given string (where y is not a vowel).\nsub reverse_vowels {\n    my($str1) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_vowels;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"USA\"),\"ASU\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"ab\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "pl",
+    "prompt": "# Write a function to convert an array to a string.\nsub tup_string {\n    my($tup1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tup_string;\n        if(eq_deeply($candidate->([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given array of numbers.\nsub sum_negativenum {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_negativenum;\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, -14, 13, -18, 12, -20]),-52)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth hexagonal number.\nsub hexagonal_num {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&hexagonal_num;\n        if(eq_deeply($candidate->(10),190)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),91)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nsub is_Sum_Of_Powers_Of_Two {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sum_Of_Powers_Of_Two;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort an array of elements.\nsub pancake_sort {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pancake_sort;\n        if(eq_deeply($candidate->([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "pl",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given arrays.\nsub count_samepair {\n    my($list1, $list2, $list3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_samepair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "pl",
+    "prompt": "# Write a function to find number of arrays present in the given array.\nsub find_lists {\n    my($Input) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5, 4, 3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the maximum difference between any two elements in a given array.\nsub max_Abs_Diff {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Abs_Diff;\n        if(eq_deeply($candidate->([2, 1, 5, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 3, 2, 5, 1]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the volume of a triangular prism.\nsub find_Volume {\n    my($l, $b, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Volume;\n        if(eq_deeply($candidate->(10, 8, 6),240)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "pl",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undef if no solution exists.\nsub find_solution {\n    my($a, $b, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_solution;\n        if(eq_deeply($candidate->(2, 3, 7),[2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2, 7),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 13, 17),[4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "pl",
+    "prompt": "# Write a function to remove all elements from a given array present in another array.\nsub remove_elements {\n    my($list1, $list2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_elements;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsub sum_series {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_series;\n        if(eq_deeply($candidate->(6),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "pl",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nsub are_equivalent {\n    my($num1, $num2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&are_equivalent;\n        if(eq_deeply($candidate->(36, 57),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 47),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nsub count_char_position {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_char_position;\n        if(eq_deeply($candidate->(\"xbcefg\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ABcED\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"AbgdeF\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "pl",
+    "prompt": "# Write a function that counts the number of pairs of integers in an array that xor to an even number.\nsub find_even_pair {\n    my($A) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_even_pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the smallest power of 2 greater than or equal to n.\nsub next_power_of_2 {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_power_of_2;\n        if(eq_deeply($candidate->(0),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given array.\nsub frequency {\n    my($a, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency;\n        if(eq_deeply($candidate->([1, 2, 3], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3, 3, 3, 4], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 1, 2], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "pl",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nsub text_lowercase_underscore {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_lowercase_underscore;\n        if(eq_deeply($candidate->(\"aab_cbbbc\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aab_Abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Aaab_abbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "pl",
+    "prompt": "# Write a function to find the sum of numbers in an array within a range specified by two indices.\nsub sum_range_list {\n    my($list1, $m, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_range_list;\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "pl",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nsub perimeter_pentagon {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perimeter_pentagon;\n        if(eq_deeply($candidate->(5),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),75)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\nsub count_occurance {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_occurance;\n        if(eq_deeply($candidate->(\"letstdlenstdporstd\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"truststdsolensporsd\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"makestdsostdworthit\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"stds\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "pl",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsub square_perimeter {\n    my($a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_perimeter;\n        if(eq_deeply($candidate->(10),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "pl",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nsub remove_dirty_chars {\n    my($string, $second_string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_dirty_chars;\n        if(eq_deeply($candidate->(\"probasscurve\", \"pros\"),\"bacuve\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"digitalindia\", \"talent\"),\"digiidi\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"exoticmiles\", \"toxic\"),\"emles\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "pl",
+    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\nsub test_duplicate {\n    my($arraynums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_duplicate;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2, 3, 3, 4, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given number is woodball or not.\nsub is_woodall {\n    my($x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_woodall;\n        if(eq_deeply($candidate->(383),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(254),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "pl",
+    "prompt": "# Write a function to check if all the elements in array have same data type or not.\nsub check_type {\n    my($test_tuple) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_type;\n        if(eq_deeply($candidate->([5, 6, 7, 3, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, \"4\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2, 1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nsub is_majority {\n    my($arr, $n, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_majority;\n        if(eq_deeply($candidate->([1, 2, 3, 3, 3, 3, 10], 7, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 2], 5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 2, 2], 5, 1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of set bits (binary digits with value 1) in a given number.\nsub count_Set_Bits {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Set_Bits;\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "pl",
+    "prompt": "# Write a plthon function to remove the characters which have odd index values of a given string.\nsub odd_values_string {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_values_string;\n        if(eq_deeply($candidate->(\"abcdef\"),\"ace\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\"),\"pto\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"dt\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"lambs\"),\"lms\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "pl",
+    "prompt": "# Write a function to find minimum of three numbers.\nsub min_of_three {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_of_three;\n        if(eq_deeply($candidate->(10, 20, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 15, 18),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -20, -30),-30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether all the bits are unset in the given range or not.\nsub all_Bits_Set_In_The_Given_Range {\n    my($n, $l, $r) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Bits_Set_In_The_Given_Range;\n        if(eq_deeply($candidate->(4, 1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(17, 2, 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(39, 4, 6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nsub re_arrange_array {\n    my($arr, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&re_arrange_array;\n        if(eq_deeply($candidate->([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nsub replace_blank {\n    my($str1, $char) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_blank;\n        if(eq_deeply($candidate->(\"hello people\", \"@\"),\"hello@people\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python program language\", \"$\"),\"python$program$language\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"blank space\", \"-\"),\"blank-space\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "pl",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\nsub volume_cube {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&volume_cube;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array of arrays and returns a hash mapping each unique array to the number of times it occurs in the array.\nsub check_occurences {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_occurences;\n        if(eq_deeply($candidate->([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]),{[1, 3] => 2, [2, 5] => 2, [3, 6] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]),{[2, 4] => 2, [3, 6] => 2, [4, 7] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]),{[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of non-empty substrings of a given string.\nsub number_of_substrings {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_of_substrings;\n        if(eq_deeply($candidate->(\"abc\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcde\"),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "pl",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nsub get_total_number_of_sequences {\n    my($m, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_total_number_of_sequences;\n        if(eq_deeply($candidate->(10, 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(16, 3),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nsub replace_list {\n    my($list1, $list2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_list;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "pl",
+    "prompt": "# Write a function to count the total number of characters in a string.\nsub count_charac {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_charac;\n        if(eq_deeply($candidate->(\"python programming\"),18)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"words\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the next perfect square greater than a given number.\nsub next_Perfect_Square {\n    my($N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&next_Perfect_Square;\n        if(eq_deeply($candidate->(35),36)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "pl",
+    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nsub max_sum {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum;\n        if(eq_deeply($candidate->([1, 15, 51, 45, 33, 100, 12, 18, 9]),194)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([80, 60, 30, 40, 20, 10]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 14, 16, 21, 23, 29, 30]),138)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "pl",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nsub lps {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lps;\n        if(eq_deeply($candidate->(\"TENS FOR TENS\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"CARDIO FOR CARDS\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PART OF THE JOURNEY IS PART\"),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "pl",
+    "prompt": "# Write a function to find the intersection of two arrays.\nsub intersection_array {\n    my($array_nums1, $array_nums2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&intersection_array;\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "pl",
+    "prompt": "# Write a plthon function that takes in an array and an element and counts the occcurences of the element in the array.\nsub count_X {\n    my($tup, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_X;\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nsub insert_element {\n    my($list, $element) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&insert_element;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "pl",
+    "prompt": "# Write a plthon function to convert complex numbers to polar coordinates.\nsub convert {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert;\n        if(eq_deeply($candidate->(1),[1.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),[4.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),[5.0, 0.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "pl",
+    "prompt": "# Write a plthon function that returns the number of integer elements in a given array.\nsub count_integer {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_integer;\n        if(eq_deeply($candidate->([1, 2, \"abc\", 1.2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1.2, 4, 5.1]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nsub combinations_colors {\n    my($l, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_colors;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "pl",
+    "prompt": "# Write a plthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nsub count_Primes_nums {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Primes_nums;\n        if(eq_deeply($candidate->(5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two numbers and returns an array with the second number and then the first number.\nsub swap_numbers {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_numbers;\n        if(eq_deeply($candidate->(10, 20),[20, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 17),[17, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[200, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5408,7 +1040,7 @@
     "language": "pl",
     "prompt": "# Write a function to maximize the given two arrays.\nsub maximize_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximize_elements;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5418,13 +1050,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "pl",
-    "prompt": "# Write a plthon function to check whether every even index contains even numbers of a given array.\nsub even_position {\n    my($nums) = @_;\n",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nsub newman_prime {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_position;\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&newman_prime;\n        if(eq_deeply($candidate->(3),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),17)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),41)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5432,13 +1064,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "pl",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\nsub check_char {\n    my($string) = @_;\n",
+    "prompt": "# Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nsub division_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_char;\n        if(eq_deeply($candidate->(\"abba\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"Invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&division_elements;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5446,13 +1078,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "pl",
-    "prompt": "# Write a plthon function to find the sum of even factors of a number.\nsub sumofFactors {\n    my($n) = @_;\n",
+    "prompt": "# Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nsub split_two_parts {\n    my($list1, $L) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sumofFactors;\n        if(eq_deeply($candidate->(18),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),48)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_two_parts;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5460,13 +1092,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "pl",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nsub lateralsurface_cone {\n    my($r, $h) = @_;\n",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\nsub dog_age {\n    my($h_age) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cone;\n        if(eq_deeply($candidate->(5, 12),204.20352248333654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),566.3586699569488)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 17),1521.8090132193388)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dog_age;\n        if(eq_deeply($candidate->(12),61)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(24),109)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5474,13 +1106,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "pl",
-    "prompt": "# Write a plthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nsub count_Pairs {\n    my($arr, $n) = @_;\n",
+    "prompt": "# Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nsub list_split {\n    my($S, $step) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Pairs;\n        if(eq_deeply($candidate->([1, 2, 1], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 5),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_split;\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5488,13 +1120,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "pl",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nsub find_first_occurrence {\n    my($A, $x) = @_;\n",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nsub lateralsurface_cube {\n    my($l) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_first_occurrence;\n        if(eq_deeply($candidate->([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cube;\n        if(eq_deeply($candidate->(5),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),324)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),400)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5506,9 +1138,849 @@
     "language": "pl",
     "prompt": "# Write a plthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the n'th star number.\nsub find_star_num {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_star_num;\n        if(eq_deeply($candidate->(3),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),73)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),121)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "pl",
+    "prompt": "# Write a function to find the ascii value of a character.\nsub ascii_value {\n    my($k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&ascii_value;\n        if(eq_deeply($candidate->(\"A\"),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"R\"),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"S\"),83)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of even numbers at even positions of an array.\nsub sum_even_and_even_index {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_even_and_even_index;\n        if(eq_deeply($candidate->([5, 6, 12, 1, 18, 8]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 12, 1]),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nsub even_Power_Sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_Power_Sum;\n        if(eq_deeply($candidate->(2),1056)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),8832)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nsub rear_extract {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rear_extract;\n        if(eq_deeply($candidate->([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "pl",
+    "prompt": "# Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nsub substract_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&substract_elements;\n        if(eq_deeply($candidate->([10, 4, 5], [2, 5, 18]),[8, -1, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 2, 3], [24, 45, 16]),[-13, -43, -13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 18, 9], [10, 11, 12]),[-3, 7, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nsub even_binomial_Coeff_Sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_binomial_Coeff_Sum;\n        if(eq_deeply($candidate->(4),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "pl",
+    "prompt": "# Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\nsub dict_filter {\n    my($dict, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dict_filter;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170),{\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180),{\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190),{\"Pierre Cox\" => 190})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "pl",
+    "prompt": "# Write a function to find the number of elements that occurs before the array element in the given array.\nsub count_first_elements {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_first_elements;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 9, [5, 7], 11]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 5, 8, [2, 3], 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth decagonal number.\nsub is_num_decagonal {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_num_decagonal;\n        if(eq_deeply($candidate->(3),27)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),175)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),370)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsub sequential_search {\n    my($dlist, $item) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequential_search;\n        if(eq_deeply($candidate->([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[1, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 32, 45, 62, 35, 47, 44, 61], 61),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 10, 17, 19, 22, 39, 48, 56], 48),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check if the elements of a given array are unique or not.\nsub all_unique {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_unique;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "pl",
+    "prompt": "# Write a function to subtract two arrays element-wise.\nsub sub_list {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sub_list;\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),[-3, -3, -3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2], [3, 4]),[-2, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[40, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "pl",
+    "prompt": "# Write a plthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nsub validate {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&validate;\n        if(eq_deeply($candidate->(1234),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(51241),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(321),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nsub check_element {\n    my($list, $element) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_element;\n        if(eq_deeply($candidate->([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"green\", \"green\", \"green\", \"green\"], \"green\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "pl",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nsub text_match_two_three {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_two_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "pl",
+    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nsub max_sub_array_sum_repeated {\n    my($a, $n, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum_repeated;\n        if(eq_deeply($candidate->([10, 20, -30, -1], 4, 3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 10, 20], 3, 2),59)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, -3], 3, 3),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsub square_Sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_Sum;\n        if(eq_deeply($candidate->(2),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "pl",
+    "prompt": "# Write a function to find the array of maximum length in an array of arrays.\nsub max_length {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5], [15, 20, 25]]),[3, [15, 20, 25]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "pl",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nsub count_no_of_ways {\n    my($n, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_no_of_ways;\n        if(eq_deeply($candidate->(2, 4),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 4),228)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find quotient of two numbers (rounded down to the nearest integer).\nsub find {\n    my($n, $m) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find;\n        if(eq_deeply($candidate->(10, 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 5),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "pl",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\nsub otherside_rightangle {\n    my($w, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&otherside_rightangle;\n        if(eq_deeply($candidate->(7, 8),10.63014581273465)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 15),16.55294535724685)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous array.\nsub max_val {\n    my($listval) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),25)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "pl",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\nsub sum_div {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_div;\n        if(eq_deeply($candidate->(8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count inversions in an array.\nsub get_Inv_Count {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Inv_Count;\n        if(eq_deeply($candidate->([1, 20, 6, 4, 5]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 5, 6, 1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "pl",
+    "prompt": "# Write a function to flatten a given nested array structure.\nsub flatten_list {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&flatten_list;\n        if(eq_deeply($candidate->([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the maximum aggregate from the array of arrays.\nsub max_aggregate {\n    my($stdata) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_aggregate;\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find element at a given index after number of rotations.\nsub find_Element {\n    my($arr, $ranges, $rotations, $index) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "pl",
+    "prompt": "# Write a function to return two words from an array of words starting with letter 'p'.\nsub start_withp {\n    my($words) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&start_withp;\n        if(eq_deeply($candidate->([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nsub max_sum_increasing_subseq {\n    my($a, $n, $index, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_increasing_subseq;\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nsub large_product {\n    my($nums1, $nums2, $N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&large_product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the maximum of two numbers.\nsub maximum {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maximum;\n        if(eq_deeply($candidate->(5, 10),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 7),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to convert a given string to an array of characters.\nsub string_to_tuple {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&string_to_tuple;\n        if(eq_deeply($candidate->(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the highest power of 2 that is less than or equal to n.\nsub highest_Power_of_2 {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&highest_Power_of_2;\n        if(eq_deeply($candidate->(10),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(32),32)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "pl",
+    "prompt": "# Write a function to find the n'th lucas number.\nsub find_lucas {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_lucas;\n        if(eq_deeply($candidate->(9),76)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "pl",
+    "prompt": "# Write a function to apply a given format string to all of the elements in an array.\nsub add_string {\n    my($list_, $string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_string;\n        if(eq_deeply($candidate->([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "pl",
+    "prompt": "# Write a function to convert more than one array to nested hash.\nsub convert_list_dictionary {\n    my($l1, $l2, $l3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&convert_list_dictionary;\n        if(eq_deeply($candidate->([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]),[{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]),[{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]),[{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nsub get_max_sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_max_sum;\n        if(eq_deeply($candidate->(60),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "pl",
+    "prompt": "# Write a function to find the array with maximum length.\nsub max_length_list {\n    my($input_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_length_list;\n        if(eq_deeply($candidate->([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "pl",
+    "prompt": "# Write a function to check if given array contains no duplicates.\nsub check_distinct {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_distinct;\n        if(eq_deeply($candidate->([1, 4, 5, 6, 1, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the first non-repeated character in a given string.\nsub first_non_repeating_character {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_non_repeating_character;\n        if(eq_deeply($candidate->(\"abcabc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ababc\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\nsub check_char {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_char;\n        if(eq_deeply($candidate->(\"abba\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a\"),\"Valid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd\"),\"Invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "pl",
+    "prompt": "# Write a function to find the median of three numbers.\nsub median_numbers {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_numbers;\n        if(eq_deeply($candidate->(25, 55, 65),55.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 10, 30),20.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 45, 75),45.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "pl",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given array.\nsub sum_of_digits {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_of_digits;\n        if(eq_deeply($candidate->([10, 2, 56]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, -4, 5, -70]),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "pl",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given arrays.\nsub bitwise_xor {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bitwise_xor;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "pl",
+    "prompt": "# Write a plthon function to identify non-prime numbers.\nsub is_not_prime {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_not_prime;\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(35),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(37),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "pl",
+    "prompt": "# Write a function to extract the number of unique arrays in the given array.\nsub extract_freq {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_freq;\n        if(eq_deeply($candidate->([[3, 4], [1, 2], [4, 3], [5, 6]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 15], [2, 3], [5, 4], [6, 7]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 16], [2, 3], [6, 5], [6, 9]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to perform index wise addition of array elements in the given two nested arrays.\nsub add_nested_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_nested_tuples;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the minimum of two numbers.\nsub minimum {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&minimum;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-5, -4),-5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "pl",
+    "prompt": "# Write a function to check whether an element exists within an array.\nsub check_tuplex {\n    my($tuplex, $tuple1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_tuplex;\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find whether the parity of a given number is odd.\nsub find_Parity {\n    my($x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Parity;\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "pl",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nsub rearrange_bigger {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rearrange_bigger;\n        if(eq_deeply($candidate->(12),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(102),120)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "pl",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nsub k_smallest_pairs {\n    my($nums1, $nums2, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&k_smallest_pairs;\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 1),[[1, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to find the minimum product from the pairs of arrays within a given array.\nsub min_product_tuple {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_product_tuple;\n        if(eq_deeply($candidate->([[2, 7], [2, 6], [1, 8], [4, 9]]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[10, 20], [15, 2], [5, 10]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[11, 44], [10, 15], [20, 5], [12, 9]]),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "pl",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous array.\nsub min_val {\n    my($listval) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_val;\n        if(eq_deeply($candidate->([\"Python\", 3, 2, 4, 5, \"version\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 15, 20, 25]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", 30, 20, 40, 50, \"version\"]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsub snake_to_camel {\n    my($word) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&snake_to_camel;\n        if(eq_deeply($candidate->(\"android_tv\"),\"AndroidTv\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"google_pixel\"),\"GooglePixel\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"apple_watch\"),\"AppleWatch\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "pl",
+    "prompt": "# Write a plthon function to remove odd numbers from a given array.\nsub remove_odd {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->([1, 2, 3]),[2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 6]),[2, 4, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 3]),[10, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "pl",
+    "prompt": "# Write a function to extract the nth element from a given array of arrays.\nsub extract_nth_element {\n    my($list1, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_nth_element;\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether any value in a sequence exists in a sequence or not.\nsub overlapping {\n    my($list1, $list2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&overlapping;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [4, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 4, 5], [1, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find a pair with highest product from a given array of integers.\nsub max_Product {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_Product;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, -1, -2, -4, 5, 0, -6]),[-4, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",
@@ -5520,7 +1992,7 @@
     "language": "pl",
     "prompt": "# Write a function to find common first element in given array of arrays.\nsub group_tuples {\n    my($Input) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&group_tuples;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
@@ -5530,13 +2002,3541 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "pl",
-    "prompt": "# Write a function to merge three arrays into a single sorted array.\nsub merge_sorted_list {\n    my($num1, $num2, $num3) = @_;\n",
+    "prompt": "# Write a plthon function to find the element of an array having maximum length.\nsub Find_Max {\n    my($lst) = @_;\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_sorted_list;\n        if(eq_deeply($candidate->([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max;\n        if(eq_deeply($candidate->([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "pl",
+    "prompt": "# Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nsub round_and_sum {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&round_and_sum;\n        if(eq_deeply($candidate->([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 2, 9, 24.3, 29]),345)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25.0, 56.7, 89.2]),513)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the cube sum of first n even natural numbers.\nsub cube_Sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_Sum;\n        if(eq_deeply($candidate->(2),72)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),288)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),800)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to concatenate each element of array by the delimiter.\nsub concatenate_tuple {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&concatenate_tuple;\n        if(eq_deeply($candidate->([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the average of cubes of first n natural numbers.\nsub find_Average_Of_Cube {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Average_Of_Cube;\n        if(eq_deeply($candidate->(2),4.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "pl",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given array.\nsub extract_rear {\n    my($test_tuple) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_rear;\n        if(eq_deeply($candidate->([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "pl",
+    "prompt": "# Write a function to count the number of subarrays containing a particular element.\nsub count_element_in_list {\n    my($list1, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_element_in_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "pl",
+    "prompt": "# Write a function to filter odd numbers.\nsub filter_oddnumbers {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_oddnumbers;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 45, 67, 84, 93]),[45, 67, 93])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "pl",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nsub change_date_format {\n    my($dt) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&change_date_format;\n        if(eq_deeply($candidate->(\"2026-01-02\"),\"02-01-2026\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2020-11-13\"),\"13-11-2020\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"2021-04-26\"),\"26-04-2021\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort the given array by using shell sort.\nsub shell_sort {\n    my($my_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&shell_sort;\n        if(eq_deeply($candidate->([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to extract the elementwise and arrays from the given two arrays.\nsub and_tuples {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&and_tuples;\n        if(eq_deeply($candidate->([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "pl",
+    "prompt": "# Write a function to find the directrix of a parabola.\nsub parabola_directrix {\n    my($a, $b, $c) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&parabola_directrix;\n        if(eq_deeply($candidate->(5, 3, 2),-198)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 8, 4),-2336)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4, 6),-130)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "pl",
+    "prompt": "# Write a function that takes two arrays and returns true if they have at least one common element.\nsub common_element {\n    my($list1, $list2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&common_element;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 8, 9]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "pl",
+    "prompt": "# Write a function to find the median length of a trapezium.\nsub median_trapezium {\n    my($base1, $base2, $height) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&median_trapezium;\n        if(eq_deeply($candidate->(15, 25, 35),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 20, 30),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6, 9, 4),7.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\nsub check_greater {\n    my($arr, $number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_greater;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 6], 8),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 7, 4, 8, 6, 1], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\nsub text_match_one {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the last digit of a given number.\nsub last_Digit {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit;\n        if(eq_deeply($candidate->(123),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "pl",
+    "prompt": "# Write a plthon function to return the negative numbers in an array.\nsub neg_nos {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&neg_nos;\n        if(eq_deeply($candidate->([-1, 4, 5, -6]),[-1, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3, 4]),[-1, -2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-7, -6, 8, 9]),[-7, -6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "pl",
+    "prompt": "# Write a function to remove odd characters in a string.\nsub remove_odd {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_odd;\n        if(eq_deeply($candidate->(\"python\"),\"yhn\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),\"rga\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"language\"),\"agae\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "pl",
+    "prompt": "# Write a function to count bidirectional array pairs.\nsub count_bidirectional {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_bidirectional;\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "pl",
+    "prompt": "# Write a function to join an array of multiple integers into a single integer.\nsub multiple_to_single {\n    my($L) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiple_to_single;\n        if(eq_deeply($candidate->([11, 33, 50]),113350)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4, 5, 6]),-123456)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 15, 20, 25]),10152025)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "pl",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nsub find_adverb_position {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverb_position;\n        if(eq_deeply($candidate->(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"seriously!! there are many roses\"),[0, 9, \"seriously\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "pl",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsub surfacearea_cube {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cube;\n        if(eq_deeply($candidate->(5),150)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "pl",
+    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\nsub positive_count {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&positive_count;\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the largest negative number from the given array.\nsub largest_neg {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&largest_neg;\n        if(eq_deeply($candidate->([1, 2, 3, -4, -6]),-6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, -8, -9]),-9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, -1]),-1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to trim each array by k in the given arrays.\nsub trim_tuple {\n    my($test_list, $K) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&trim_tuple;\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "pl",
+    "prompt": "# Write a function to perform index wise multiplication of array elements in the given two arrays.\nsub index_multiplication {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_multiplication;\n        if(eq_deeply($candidate->([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the occurence of all elements of array in an array.\nsub count_Occurrence {\n    my($tup, $lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Occurrence;\n        if(eq_deeply($candidate->([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], [1, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "pl",
+    "prompt": "# Write a function to find cubes of individual elements in an array.\nsub cube_nums {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cube_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[1728, 3375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\nsub cal_sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cal_sum;\n        if(eq_deeply($candidate->(9),49)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),66)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "pl",
+    "prompt": "# Write a function to extract specified size of strings from a given array of string values.\nsub extract_string {\n    my($str, $l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_string;\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "pl",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\nsub remove_whitespaces {\n    my($text1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_whitespaces;\n        if(eq_deeply($candidate->(\" Google    Flutter \"),\"GoogleFlutter\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" Google    Dart \"),\"GoogleDart\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\" iOS    Swift \"),\"iOSSwift\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "pl",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nsub loss_amount {\n    my($actual_cost, $sale_amount) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&loss_amount;\n        if(eq_deeply($candidate->(1500, 1200),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),100)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of even factors of a number.\nsub sumofFactors {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sumofFactors;\n        if(eq_deeply($candidate->(18),26)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),48)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "pl",
+    "prompt": "# Write a function that matches a word containing 'z'.\nsub text_match_wordz {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz;\n        if(eq_deeply($candidate->(\"pythonz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"xyz.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\nsub check_monthnumb_number {\n    my($monthnum2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumb_number;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "pl",
+    "prompt": "# Write a function to reverse each string in a given array of string values.\nsub reverse_string_list {\n    my($stringlist) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_string_list;\n        if(eq_deeply($candidate->([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the subarray having minimum length.\nsub Find_Min {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min;\n        if(eq_deeply($candidate->([[1], [1, 2], [1, 2, 3]]),[1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "pl",
+    "prompt": "# Write a function to find the area of a rectangle.\nsub rectangle_area {\n    my($l, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rectangle_area;\n        if(eq_deeply($candidate->(10, 20),200)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 5),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 2),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "pl",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\nsub remove_uppercase {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_uppercase;\n        if(eq_deeply($candidate->(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "pl",
+    "prompt": "# Write a plthon function to get the first element of each subarray.\nsub Extract {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Extract;\n        if(eq_deeply($candidate->([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5]]),[1, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[9, 8, 1], [1, 2]]),[9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the upper case characters in a given string.\nsub upper_ctr {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&upper_ctr;\n        if(eq_deeply($candidate->(\"PYthon\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"BigData\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "pl",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given array.\nsub combinations_list {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&combinations_list;\n        if(eq_deeply($candidate->([\"orange\", \"red\", \"green\", \"blue\"]),[[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"black\", \"orange\"]),[[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum product subarray of the given array.\nsub max_subarray_product {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_subarray_product;\n        if(eq_deeply($candidate->([1, -2, -3, 0, 7, -8, -2]),112)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, -3, -10, 0, 2]),180)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-2, -40, 0, -2, -3]),80)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "pl",
+    "prompt": "# Write a function to check if all values are same in a hash.\nsub check_value {\n    my($dict, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_value;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "pl",
+    "prompt": "# Write a function to drop empty items from a given hash.\nsub drop_empty {\n    my($dict1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&drop_empty;\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => undef}),{\"c1\" => \"Red\", \"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => \"Red\", \"c2\" => undef, \"c3\" => undef}),{\"c1\" => \"Red\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"c1\" => undef, \"c2\" => \"Green\", \"c3\" => undef}),{\"c2\" => \"Green\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nsub max_product {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_product;\n        if(eq_deeply($candidate->([3, 100, 4, 5, 150, 6]),3000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 42, 55, 68, 80]),50265600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 22, 9, 33, 21, 50, 41, 60]),2460)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "pl",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given array.\nsub add_pairwise {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_pairwise;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[6, 12, 15, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, 9, 11]),[8, 14, 17, 20])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, 10, 12]),[10, 16, 19, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the product of the array multiplication modulo n.\nsub find_remainder {\n    my($arr, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_remainder;\n        if(eq_deeply($candidate->([100, 10, 5, 25, 35, 14], 11),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], 2),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given array contains consecutive numbers or not.\nsub check_Consecutive {\n    my($l) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_Consecutive;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 5, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "pl",
+    "prompt": "# Write a function to replace characters in a string.\nsub replace_char {\n    my($str1, $ch, $newch) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_char;\n        if(eq_deeply($candidate->(\"polygon\", \"y\", \"l\"),\"pollgon\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"character\", \"c\", \"a\"),\"aharaater\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python\", \"l\", \"a\"),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "pl",
+    "prompt": "# Write a function to sort a hash by value.\nsub sort_counter {\n    my($dict1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_counter;\n        if(eq_deeply($candidate->({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of the largest and smallest value in a given array.\nsub big_sum {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 6]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "pl",
+    "prompt": "# Write a plthon function to convert the given string to lower case.\nsub is_lower {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_lower;\n        if(eq_deeply($candidate->(\"InValid\"),\"invalid\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"TruE\"),\"true\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"SenTenCE\"),\"sentence\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "pl",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\nsub remove_lowercase {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_lowercase;\n        if(eq_deeply($candidate->(\"PYTHon\"),\"PYTH\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"FInD\"),\"FID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"STRinG\"),\"STRG\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the first digit of a given number.\nsub first_Digit {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_Digit;\n        if(eq_deeply($candidate->(123),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(456),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "pl",
+    "prompt": "# Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nsub heap_queue_largest {\n    my($nums, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_queue_largest;\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "pl",
+    "prompt": "# Write a plthon function which takes an array of integers and only returns the odd ones.\nsub Split {\n    my($list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),[1, 3, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 11, 12, 13]),[11, 13])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1]),[7, 9, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nsub difference {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&difference;\n        if(eq_deeply($candidate->(3),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of pairs whose xor value is odd.\nsub find_Odd_Pair {\n    my($A, $N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Odd_Pair;\n        if(eq_deeply($candidate->([5, 4, 7, 2, 1], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 2, 8, 1, 0, 5, 11], 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "pl",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\nsub toggle_string {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_string;\n        if(eq_deeply($candidate->(\"Python\"),\"pYTHON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Pangram\"),\"pANGRAM\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"LIttLE\"),\"liTTle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of the per-digit difference between two integers.\nsub digit_distance_nums {\n    my($n1, $n2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&digit_distance_nums;\n        if(eq_deeply($candidate->(1, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23, 56),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(123, 256),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the sum of the largest contiguous subarray in the given array.\nsub max_sub_array_sum {\n    my($a, $size) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sub_array_sum;\n        if(eq_deeply($candidate->([-2, -3, 4, -1, -2, 1, 5, -3], 8),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-3, -4, 5, -2, -3, 2, 6, -4], 8),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-4, -5, 6, -3, -4, 3, 7, -5], 8),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "pl",
+    "prompt": "# Write a function to find the union of the elements of two given arrays and output them in sorted order.\nsub union_elements {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&union_elements;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the length of the longest subarrays.\nsub Find_Max_Length {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Max_Length;\n        if(eq_deeply($candidate->([[1], [1, 4], [5, 6, 7, 8]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[0, 1], [2, 2], [3, 2, 1]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "pl",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\nsub extract_values {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_values;\n        if(eq_deeply($candidate->(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "pl",
+    "prompt": "# Write a plthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nsub count_Pairs {\n    my($arr, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Pairs;\n        if(eq_deeply($candidate->([1, 2, 1], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 1], 4),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], 5),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "pl",
+    "prompt": "# Write a plthon function to split a string into characters.\nsub split {\n    my($word) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split;\n        if(eq_deeply($candidate->(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Name\"),[\"N\", \"a\", \"m\", \"e\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "pl",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsub sum_digits {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_digits;\n        if(eq_deeply($candidate->(345),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(97),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "pl",
+    "prompt": "# Write a function to check whether a specified array is sorted or not.\nsub issort_list {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&issort_list;\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 6, 8, 10, 15, 14, 20]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "pl",
+    "prompt": "# Write a function to create an array of N empty dictionaries.\nsub empty_list {\n    my($length) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&empty_list;\n        if(eq_deeply($candidate->(5),[{}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),[{}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),[{}, {}, {}, {}, {}, {}, {}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "pl",
+    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\nsub sort_sublists {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_sublists;\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check if a given number is one less than twice its reverse.\nsub checks {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&checks;\n        if(eq_deeply($candidate->(70),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(23),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(73),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "pl",
+    "prompt": "# Write a plthon function to remove duplicate numbers from a given number of arrays.\nsub two_unique_nums {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&two_unique_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "pl",
+    "prompt": "# Write a plthon function to calculate the product of the unique numbers in a given array.\nsub unique_product {\n    my($list_data) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_product;\n        if(eq_deeply($candidate->([10, 20, 30, 40, 20, 50, 60, 40]),720000000)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 1]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 0, 1, 1]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "pl",
+    "prompt": "# Write a function to find the surface area of a cylinder.\nsub surfacearea_cylinder {\n    my($r, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surfacearea_cylinder;\n        if(eq_deeply($candidate->(10, 5),942.45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),226.18800000000002)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 10),351.848)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether an array is subarray of another or not.\nsub is_Sub_Array {\n    my($A, $B) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Sub_Array;\n        if(eq_deeply($candidate->([1, 4, 3, 5], [1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1], [1, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 0, 2, 2], [2, 2, 0]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the last digit in factorial of a given number.\nsub last_Digit_Factorial {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last_Digit_Factorial;\n        if(eq_deeply($candidate->(4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(21),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(30),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "pl",
+    "prompt": "# Write a function to interleave 3 arrays of the same length into a single flat array.\nsub interleave_lists {\n    my($list1, $list2, $list3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&interleave_lists;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "pl",
+    "prompt": "# Write a function to find the dissimilar elements in the given two arrays.\nsub find_dissimilar {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_dissimilar;\n        if(eq_deeply($candidate->([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the largest number that can be formed with the given array of digits.\nsub find_Max_Num {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Max_Num;\n        if(eq_deeply($candidate->([1, 2, 3]),321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 1]),6541)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 9]),9321)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "pl",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed array.\nsub extract_even {\n    my($test_tuple) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_even;\n        if(eq_deeply($candidate->([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the surface area of a square plramid with a given base edge and height.\nsub surface_Area {\n    my($b, $s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&surface_Area;\n        if(eq_deeply($candidate->(3, 4),33)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4, 5),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "pl",
+    "prompt": "# Write a function which returns nth catalan number.\nsub catalan_number {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&catalan_number;\n        if(eq_deeply($candidate->(10),16796)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),4862)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),429)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "pl",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nsub find_adverbs {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_adverbs;\n        if(eq_deeply($candidate->(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Please handle the situation carefuly\"),\"28-36: carefuly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Complete the task quickly\"),\"18-25: quickly\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "pl",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nsub expensive_items {\n    my($items, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&expensive_items;\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2),[{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1),[{\"name\" => \"Item-2\", \"price\" => 555.22}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "pl",
+    "prompt": "# Write a plthon function to split an array at the nth eelment and add the first part to the end.\nsub split_Arr {\n    my($l, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&split_Arr;\n        if(eq_deeply($candidate->([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4], 1),[2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to convert an array to an array.\nsub list_tuple {\n    my($listx) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&list_tuple;\n        if(eq_deeply($candidate->([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([58, 44, 56]),[58, 44, 56])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the difference between largest and smallest value in a given array.\nsub big_diff {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&big_diff;\n        if(eq_deeply($candidate->([1, 2, 3, 4]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 12]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 2, 3]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "pl",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\nsub perfect_squares {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&perfect_squares;\n        if(eq_deeply($candidate->(1, 30),[1, 4, 9, 16, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(50, 100),[64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 200),[100, 121, 144, 169, 196])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given two integers have opposite sign or not.\nsub opposite_Signs {\n    my($x, $y) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&opposite_Signs;\n        if(eq_deeply($candidate->(1, -2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-10, -10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-2, 2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "pl",
+    "prompt": "# Write a plthon function to interchange the first and last elements in an array.\nsub swap_List {\n    my($newList) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of the product of consecutive binomial co-efficients.\nsub sum_Of_product {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_product;\n        if(eq_deeply($candidate->(3),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "pl",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\nsub removezero_ip {\n    my($ip) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&removezero_ip;\n        if(eq_deeply($candidate->(\"216.08.094.196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"12.01.024\"),\"12.1.24\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"216.08.094.0196\"),\"216.8.94.196\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "pl",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given array.\nsub diff_even_odd {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&diff_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nsub min_Swaps {\n    my($str1, $str2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Swaps;\n        if(eq_deeply($candidate->(\"1101\", \"1110\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"000\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\", \"110\"),\"Not Possible\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "pl",
+    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nsub find_kth {\n    my($arr1, $arr2, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_kth;\n        if(eq_deeply($candidate->([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\nsub armstrong_number {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&armstrong_number;\n        if(eq_deeply($candidate->(153),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(259),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4458),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "pl",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsub sum_average {\n    my($number) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_average;\n        if(eq_deeply($candidate->(10),[55, 5.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),[120, 8.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),[210, 10.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth octagonal number.\nsub is_octagonal {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_octagonal;\n        if(eq_deeply($candidate->(5),65)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),280)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),645)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given number is even or not.\nsub is_Even {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Even;\n        if(eq_deeply($candidate->(1),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the first repeated character in a given string.\nsub first_repeated_char {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_repeated_char;\n        if(eq_deeply($candidate->(\"abcabc\"),\"a\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123123\"),\"1\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "pl",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nsub get_ludic {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_ludic;\n        if(eq_deeply($candidate->(10),[1, 2, 3, 5, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "pl",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nsub reverse_words {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_words;\n        if(eq_deeply($candidate->(\"python program\"),\"program python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"java language\"),\"language java\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"indian man\"),\"man indian\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given integer is a prime number.\nsub prime_num {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&prime_num;\n        if(eq_deeply($candidate->(13),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1010),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "pl",
+    "prompt": "# Write a function to convert degrees to radians.\nsub radian_degree {\n    my($degree) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&radian_degree;\n        if(eq_deeply($candidate->(90),1.5707963267948966)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(60),1.0471975511965976)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(120),2.0943951023931953)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "pl",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nsub find_literals {\n    my($text, $pattern) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_literals;\n        if(eq_deeply($candidate->(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find nth bell number.\nsub bell_Number {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_Number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "pl",
+    "prompt": "# Write a plthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nsub remove_kth_element {\n    my($list1, $L) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_kth_element;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "pl",
+    "prompt": "# Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nsub max_of_nth {\n    my($test_list, $N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_of_nth;\n        if(eq_deeply($candidate->([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "pl",
+    "prompt": "# Write a plthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nsub merge {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge;\n        if(eq_deeply($candidate->([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "pl",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nsub cummulative_sum {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&cummulative_sum;\n        if(eq_deeply($candidate->([[1, 3], [5, 6, 7], [2, 6]]),30)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 4], [6, 7, 8], [3, 7]]),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8, 9], [4, 8]]),44)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "pl",
+    "prompt": "# Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nsub average_tuple {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&average_tuple;\n        if(eq_deeply($candidate->([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "pl",
+    "prompt": "# Write a function which takes two arrays of the same length and performs the element wise modulo.\nsub tuple_modulo {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_modulo;\n        if(eq_deeply($candidate->([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "pl",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nsub min_Jumps {\n    my($steps, $d) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_Jumps;\n        if(eq_deeply($candidate->([3, 4], 11),3.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4], 0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 14], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "pl",
+    "prompt": "# Write a function to divide two arrays element wise.\nsub div_list {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&div_list;\n        if(eq_deeply($candidate->([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 2], [1, 4]),[3.0, 0.5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([90, 120], [50, 70]),[1.8, 1.7142857142857142])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "pl",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\nsub move_num {\n    my($test_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_num;\n        if(eq_deeply($candidate->(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Avengers124Assemble\"),\"AvengersAssemble124\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of substrings with the sum of digits equal to their length.\nsub count_Substrings {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_Substrings;\n        if(eq_deeply($candidate->(\"112112\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"111\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1101112\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "pl",
+    "prompt": "# Write a function to find the median of two sorted arrays of same size.\nsub get_median {\n    my($arr1, $arr2, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_median;\n        if(eq_deeply($candidate->([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "pl",
+    "prompt": "# Write a function to compute the n-th power of each number in an array.\nsub nth_nums {\n    my($nums, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&nth_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30], 3),[1000, 8000, 27000])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15], 5),[248832, 759375])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "pl",
+    "prompt": "# Write a plthon function to convert a given string to uppercase.\nsub is_upper {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_upper;\n        if(eq_deeply($candidate->(\"person\"),\"PERSON\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"final\"),\"FINAL\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Valid\"),\"VALID\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "pl",
+    "prompt": "# Write a plthon function to interchange the first and last element in a given array.\nsub swap_List {\n    my($newList) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&swap_List;\n        if(eq_deeply($candidate->([1, 2, 3]),[3, 2, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6]),[6, 5, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nsub triangle_area {\n    my($r) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&triangle_area;\n        if(eq_deeply($candidate->(-1),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the smallest missing number from a sorted array of natural numbers.\nsub find_First_Missing {\n    my($array) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_First_Missing;\n        if(eq_deeply($candidate->([0, 1, 2, 3]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, 6, 9]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 8, 9]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nsub replace_spaces {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I am a Programmer\"),\"I%20am%20a%20Programmer\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"I love Coding\"),\"I%20love%20Coding\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find even numbers from an array of numbers.\nsub Split {\n    my($list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Split;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),[2, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 12, 15, 19]),[8, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find smallest number in an array.\nsub smallest_num {\n    my($xs) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&smallest_num;\n        if(eq_deeply($candidate->([10, 20, 1, 45, 99]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([45, 46, 50, 60]),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "pl",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate array.\nsub get_coordinates {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_coordinates;\n        if(eq_deeply($candidate->([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nsub replace_spaces {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_spaces;\n        if(eq_deeply($candidate->(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"The_Avengers\"),\"The Avengers\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Fast and Furious\"),\"Fast_and_Furious\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "pl",
+    "prompt": "# Write a plthon function to move all zeroes to the end of the given array.\nsub move_zero {\n    my($num_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&move_zero;\n        if(eq_deeply($candidate->([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of xor of all pairs of numbers in the given array.\nsub pair_xor_Sum {\n    my($arr, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_xor_Sum;\n        if(eq_deeply($candidate->([5, 9, 7, 6], 4),47)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3, 5], 3),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 3], 2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort the given array.\nsub heap_sort {\n    my($iterable) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&heap_sort;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 1, 9, 5]),[1, 5, 7, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nsub noprofit_noloss {\n    my($actual_cost, $sale_amount) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&noprofit_noloss;\n        if(eq_deeply($candidate->(1500, 1200),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100, 100),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2000, 5000),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nsub wind_chill {\n    my($v, $t) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&wind_chill;\n        if(eq_deeply($candidate->(120, 35),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(40, 20),19)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 8),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "pl",
+    "prompt": "# Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nsub sample_nam {\n    my($sample_names) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sample_nam;\n        if(eq_deeply($candidate->([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"abcd\", \"Python\", \"abba\", \"aba\"]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "pl",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given array array.\nsub max_difference {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_difference;\n        if(eq_deeply($candidate->([[3, 5], [1, 7], [10, 3], [1, 2]]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [2, 17], [9, 13], [11, 12]]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[12, 35], [21, 27], [13, 23], [41, 22]]),23)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "pl",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nsub remove_parenthesis {\n    my($items) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_parenthesis;\n        if(eq_deeply($candidate->([\"python (chrome)\"]),\"python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"string(.abc)\"]),\"string\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"alpha(num)\"]),\"alpha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth nonagonal number.\nsub is_nonagonal {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_nonagonal;\n        if(eq_deeply($candidate->(10),325)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),750)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),1089)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "pl",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\nsub text_match_wordz_middle {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_wordz_middle;\n        if(eq_deeply($candidate->(\"pythonzabc.\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"zxyabc.\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"  lang  .\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "pl",
+    "prompt": "# Write a plthon function to reverse an array upto a given position.\nsub reverse_Array_Upto_K {\n    my($input, $k) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&reverse_Array_Upto_K;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6, 7], 2),[5, 4, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "pl",
+    "prompt": "# Write a function to sort an array of arrays using the second value of each array.\nsub subject_marks {\n    my($subjectmarks) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&subject_marks;\n        if(eq_deeply($candidate->([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "pl",
+    "prompt": "# Write a function to flatten an array and sum all of its elements.\nsub recursive_list_sum {\n    my($data_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&recursive_list_sum;\n        if(eq_deeply($candidate->([1, 2, [3, 4], [5, 6]]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 10, [15, 14], [19, 41]]),106)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, [30, 40], [50, 60]]),210)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of positive numbers in an array.\nsub pos_count {\n    my($list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pos_count;\n        if(eq_deeply($candidate->([1, -2, 3, -4]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 4, 5, -1]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "pl",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nsub bell_number {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&bell_number;\n        if(eq_deeply($candidate->(2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),115975)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(56),6775685320645824322581483068371419745979053216268760300)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given array is monotonic or not.\nsub is_Monotonic {\n    my($A) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Monotonic;\n        if(eq_deeply($candidate->([6, 5, 4, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "pl",
+    "prompt": "# Write a function to check whether an array contains the given subarray or not.\nsub is_sublist {\n    my($l, $s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_sublist;\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [3, 7]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [4, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 3, 5, 7], [1, 6]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the two numbers differ at one bit position only or not.\nsub differ_At_One_Bit_Pos {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&differ_At_One_Bit_Pos;\n        if(eq_deeply($candidate->(13, 9),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15, 8),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 4),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "pl",
+    "prompt": "# Write a function to find whether all the given arrays have equal length or not.\nsub get_equal {\n    my($Input) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_equal;\n        if(eq_deeply($candidate->([[11, 22, 33], [44, 55, 66]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6, 7]]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [3, 4]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "pl",
+    "prompt": "# Write a function to sort an array of elements.\nsub comb_sort {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&comb_sort;\n        if(eq_deeply($candidate->([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([99, 15, 13, 47]),[13, 15, 47, 99])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to add a hash to the array. The output should be an array.\nsub add_dict_to_tuple {\n    my($test_tup, $test_dict) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_dict_to_tuple;\n        if(eq_deeply($candidate->([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}),[4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}),[1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}),[8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "pl",
+    "prompt": "# Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nsub maxAverageOfPath {\n    my($cost) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&maxAverageOfPath;\n        if(eq_deeply($candidate->([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "pl",
+    "prompt": "# The input is given as - a hash with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nsub filter_data {\n    my($students, $h, $w) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&filter_data;\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70),{\"Cierra Vega\" => [6.2, 70]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67),{\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64),{\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "pl",
+    "prompt": "# The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nsub count_same_pair {\n    my($nums1, $nums2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_same_pair;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 1, 2], [0, 1, 2, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "pl",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nsub power_base_sum {\n    my($base, $power) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power_base_sum;\n        if(eq_deeply($candidate->(2, 100),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 10),37)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8, 15),62)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3, 3),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "pl",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nsub extract_quotation {\n    my($text1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_quotation;\n        if(eq_deeply($candidate->(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "pl",
+    "prompt": "# Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nsub multiply_elements {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&multiply_elements;\n        if(eq_deeply($candidate->([1, 5, 7, 8, 10]),[5, 35, 56, 80])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 5, 6, 7]),[8, 20, 30, 42])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 13, 14, 9, 15]),[156, 182, 126, 135])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "pl",
+    "prompt": "# Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsub sum_list {\n    my($lst1, $lst2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_list;\n        if(eq_deeply($candidate->([10, 20, 30], [15, 25, 35]),[25, 45, 65])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [5, 6, 7]),[6, 8, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 20, 30], [15, 45, 75]),[30, 65, 105])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the given number can be represented as the difference of two squares or not.\nsub dif_Square {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&dif_Square;\n        if(eq_deeply($candidate->(5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "pl",
+    "prompt": "# Write a function to remove consecutive duplicates of a given array.\nsub consecutive_duplicates {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "pl",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nsub lateralsurface_cone {\n    my($r, $h) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lateralsurface_cone;\n        if(eq_deeply($candidate->(5, 12),204.20352248333654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 15),566.3586699569488)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(19, 17),1521.8090132193388)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "pl",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nsub replace_specialchar {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&replace_specialchar;\n        if(eq_deeply($candidate->(\"Python language, Programming language.\"),\"Python:language::Programming:language:\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"a b c,d e f\"),\"a:b:c:d:e:f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "pl",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nsub find_first_occurrence {\n    my($A, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_first_occurrence;\n        if(eq_deeply($candidate->([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsub sum_Of_Subarray_Prod {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_Of_Subarray_Prod;\n        if(eq_deeply($candidate->([1, 2, 3]),20)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4]),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "pl",
+    "prompt": "# Write a plthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nsub toggle_middle_bits {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&toggle_middle_bits;\n        if(eq_deeply($candidate->(9),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(11),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(65),127)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(77),115)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "pl",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/plthon-exercises/data-structures-and-algorithms/plthon-data-structure-exercise-24.php\nsub left_insertion {\n    my($a, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\nsub check_str {\n    my($string) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_str;\n        if(eq_deeply($candidate->(\"annie\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dawood\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Else\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/plthon-exercises/data-structures-and-algorithms/plthon-recursion-exercise-9.php\nsub geometric_sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&geometric_sum;\n        if(eq_deeply($candidate->(7),1.9921875)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),1.9375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(8),1.99609375)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nsub find_Index {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Index;\n        if(eq_deeply($candidate->(2),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),45)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given array to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/plthon-convert-array-to-adjacent-pair-hash/\nsub tuple_to_dict {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_to_dict;\n        if(eq_deeply($candidate->([1, 5, 7, 10, 13, 5]),{1 => 5, 7 => 10, 13 => 5})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),{1 => 2, 3 => 4, 5 => 6})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 10, 11, 12]),{7 => 8, 9 => 10, 11 => 12})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether all the characters are same or not.\nsub all_Characters_Same {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&all_Characters_Same;\n        if(eq_deeply($candidate->(\"python\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"data\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "pl",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\nsub area_tetrahedron {\n    my($side) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&area_tetrahedron;\n        if(eq_deeply($candidate->(3),15.588457268119894)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20),692.8203230275509)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10),173.20508075688772)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "pl",
+    "prompt": "# Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/plthon-program-right-rotate-array-n/\nsub rotate_right {\n    my($list, $m) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rotate_right;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given array has any none value or not.\nsub check_none {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_none;\n        if(eq_deeply($candidate->([10, 4, 5, 6, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 11, 14]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, undef]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "pl",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/plthon-exercises/lambda/plthon-lambda-exercise-24.php\nsub divisible_by_digits {\n    my($startnum, $endnum) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisible_by_digits;\n        if(eq_deeply($candidate->(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(20, 25),[22, 24])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "pl",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undef if the angle is larger than 360 degrees.\nsub sector_area {\n    my($r, $a) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sector_area;\n        if(eq_deeply($candidate->(4, 45),6.283185307179586)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 45),31.808625617596654)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9, 361),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "pl",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nsub lcs_of_three {\n    my($X, $Y, $Z) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&lcs_of_three;\n        if(eq_deeply($candidate->(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\nsub capital_words_spaces {\n    my($str1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&capital_words_spaces;\n        if(eq_deeply($candidate->(\"Python\"),\"Python\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PythonProgrammingExamples\"),\"Python Programming Examples\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "pl",
+    "prompt": "# Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/plthon-sort-numeric-strings-in-a-array/\nsub sort_numeric_strings {\n    my($nums_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sort_numeric_strings;\n        if(eq_deeply($candidate->([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "pl",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nsub is_samepatterns {\n    my($colors, $patterns) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_samepatterns;\n        if(eq_deeply($candidate->([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to add the given array to the given array.\nsub add_tuple {\n    my($test_list, $test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&add_tuple;\n        if(eq_deeply($candidate->([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nsub check_min_heap {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_min_heap;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 4, 5, 10, 15]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 10, 4, 5, 3, 15]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nsub jacobsthal_num {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&jacobsthal_num;\n        if(eq_deeply($candidate->(5),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(13),2731)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "pl",
+    "prompt": "# Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/plthon-find-minimum-k-records-from-array-array/ - in this case a verbatim copl of test cases\nsub min_k {\n    my($test_list, $K) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&min_k;\n        if(eq_deeply($candidate->([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "pl",
+    "prompt": "# We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nsub extract_index_list {\n    my($l1, $l2, $l3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&extract_index_list;\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "pl",
+    "prompt": "# Write a function to find the second smallest number in an array.\nsub second_smallest {\n    my($numbers) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&second_smallest;\n        if(eq_deeply($candidate->([1, 2, -8, -2, 0, -2]),-2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, -0.5, 0, 2, -2, -2]),-0.5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 2, 2]),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/plthon-exercises/re/plthon-re-exercise-3.php\nsub text_match_zero_one {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_zero_one;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dsabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"asbbbba\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "pl",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/plthon-program-to-count-the-pairs-of-reverse-strings/\nsub count_reverse_pairs {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_reverse_pairs;\n        if(eq_deeply($candidate->([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"geeks\", \"best\", \"for\", \"skeeg\"]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "pl",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nsub is_decimal {\n    my($num) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_decimal;\n        if(eq_deeply($candidate->(\"123.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"e666.86\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3.124587\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.11\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"1.1.11\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "pl",
+    "prompt": "# Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nsub find_tuples {\n    my($test_list, $K) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_tuples;\n        if(eq_deeply($candidate->([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether an array of numbers contains only one distinct element or not.\nsub unique_Element {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&unique_Element;\n        if(eq_deeply($candidate->([1, 1, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nsub check_monthnumber_number {\n    my($monthnum3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_monthnumber_number;\n        if(eq_deeply($candidate->(6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nsub find_min_diff {\n    my($arr, $n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_min_diff;\n        if(eq_deeply($candidate->([1, 5, 3, 19, 18, 25], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 3, 2, 6], 4),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([30, 5, 20, 9], 4),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count number of digits in a given string.\nsub number_ctr {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&number_ctr;\n        if(eq_deeply($candidate->(\"program2bedone\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wonders\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"123\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"3wond-1ers2\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "pl",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nsub is_polite {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_polite;\n        if(eq_deeply($candidate->(7),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),13)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "pl",
+    "prompt": "# Write a function to return an array of all pairs of consecutive items in a given array.\nsub pair_wise {\n    my($l1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pair_wise;\n        if(eq_deeply($candidate->([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nsub get_pairs_count {\n    my($arr, $sum) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_pairs_count;\n        if(eq_deeply($candidate->([1, 1, 1, 1], 2),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, -1, 5], 6),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, -2, 3], 1),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([-1, -2, 3], -3),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "pl",
+    "prompt": "# Write a plthon function to get the difference between two arrays.\nsub Diff {\n    my($li1, $li2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Diff;\n        if(eq_deeply($candidate->([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of fourth power of first n odd natural numbers.\nsub odd_num_sum {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_num_sum;\n        if(eq_deeply($candidate->(2),82)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),707)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(4),3108)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nsub check_expression {\n    my($exp) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_expression;\n        if(eq_deeply($candidate->(\"{()}[{}]\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{]\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"{()}[{}][]({})\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "pl",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\nsub remove_length {\n    my($test_str, $K) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_length;\n        if(eq_deeply($candidate->(\"The person is most value tet\", 3),\"person is most value\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"If you told me about this ok\", 4),\"If you me about ok\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "pl",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return undef if there is no match.\nsub occurance_substring {\n    my($text, $pattern) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&occurance_substring;\n        if(eq_deeply($candidate->(\"python programming, python language\", \"python\"),[\"python\", 0, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python programming,programming language\", \"language\"),[\"language\", 31, 39])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"c++ programming, c++ language\", \"python\"),undef)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether every odd index contains odd numbers of a given array.\nsub odd_position {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_position;\n        if(eq_deeply($candidate->([2, 1, 4, 3, 6, 7, 6, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 1, 2]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "pl",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\nsub count_vowels {\n    my($test_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_vowels;\n        if(eq_deeply($candidate->(\"bestinstareels\"),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"partofthejourneyistheend\"),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"amazonprime\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of non-repeated elements in a given array.\nsub find_sum {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_sum;\n        if(eq_deeply($candidate->([1, 2, 3, 1, 1, 4, 5, 6]),21)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 10, 9, 4, 2, 10, 10, 45, 4]),71)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 10, 9, 45, 2, 10, 10, 45, 10]),78)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "pl",
+    "prompt": "# Write a function to pack consecutive duplicates of a given array elements into subarrays.\nsub pack_consecutive_duplicates {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&pack_consecutive_duplicates;\n        if(eq_deeply($candidate->([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find whether a number is divisible by 11.\nsub is_Diff {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_Diff;\n        if(eq_deeply($candidate->(12345),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212112),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1212),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "pl",
+    "prompt": "# Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/plthon-combinations-of-sum-with-arrays-in-array-array/\nsub find_combinations {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_combinations;\n        if(eq_deeply($candidate->([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the count of divisors is even. https://www.w3resource.com/plthon-exercises/basic/plthon-basic-1-exercise-24.php\nsub count_divisors {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_divisors;\n        if(eq_deeply($candidate->(10),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(100),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nsub odd_length_sum {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&odd_length_sum;\n        if(eq_deeply($candidate->([1, 2, 4]),14)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 2]),15)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 7]),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "pl",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nsub rgb_to_hsv {\n    my($r, $g, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&rgb_to_hsv;\n        if(eq_deeply($candidate->(255, 255, 255),[0.0, 0.0, 100.0])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(0, 215, 0),[120.0, 100.0, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "pl",
+    "prompt": "# Write a function to find the product of first even and odd number of a given array.\nsub mul_even_odd {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&mul_even_odd;\n        if(eq_deeply($candidate->([1, 3, 5, 7, 4, 1, 6, 8]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 5, 7, 9, 10]),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "pl",
+    "prompt": "# Write a function to convert array string to integer array.\nsub tuple_str_int {\n    my($test_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tuple_str_int;\n        if(eq_deeply($candidate->(\"(7, 8, 9)\"),[7, 8, 9])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(1, 2, 3)\"),[1, 2, 3])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(4, 5, 6)\"),[4, 5, 6])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"(7, 81, 19)\"),[7, 81, 19])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "pl",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nsub right_insertion {\n    my($a, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&right_insertion;\n        if(eq_deeply($candidate->([1, 2, 4, 5], 6),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 4, 5], 7),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\nsub text_match_three {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_match_three;\n        if(eq_deeply($candidate->(\"ac\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"dc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"caacabbbba\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "pl",
+    "prompt": "# Write a function to create a new array from the given string and array.\nsub new_tuple {\n    my($test_list, $test_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&new_tuple;\n        if(eq_deeply($candidate->([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether every even index contains even numbers of a given array.\nsub even_position {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&even_position;\n        if(eq_deeply($candidate->([3, 2, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "pl",
+    "prompt": "# Write a function to remove arrays from the given array.\nsub remove_nested {\n    my($test_tup) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_nested;\n        if(eq_deeply($candidate->([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of arrays in a given number of arrays.\nsub count_list {\n    my($input_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_list;\n        if(eq_deeply($candidate->([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [2, 3], [4, 5]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 0], [2, 0]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the last position of an element in a sorted array.\nsub last {\n    my($arr, $x) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&last;\n        if(eq_deeply($candidate->([1, 2, 3], 1),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1, 1, 2, 3, 4], 1),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 3, 2, 3, 6, 8, 9], 3),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "pl",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nsub text_starta_endb {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&text_starta_endb;\n        if(eq_deeply($candidate->(\"aabbbb\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"aabAbbbc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"accddbbjjj\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "pl",
+    "prompt": "# Write function to find the sum of all items in the given hash.\nsub return_sum {\n    my($dict) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&return_sum;\n        if(eq_deeply($candidate->({\"a\" => 100, \"b\" => 200, \"c\" => 300}),600)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 25, \"b\" => 18, \"c\" => 45}),88)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"a\" => 36, \"b\" => 39, \"c\" => 49}),124)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of all odd natural numbers within the range l and r.\nsub sum_in_range {\n    my($l, $r) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sum_in_range;\n        if(eq_deeply($candidate->(2, 5),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 7),12)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7, 13),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the sum of an array.\nsub _sum {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&_sum;\n        if(eq_deeply($candidate->([1, 2, 3]),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([15, 12, 13, 10]),50)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([0, 1, 2]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "pl",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nsub left_rotate {\n    my($n, $d) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&left_rotate;\n        if(eq_deeply($candidate->(16, 2),64)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(10, 2),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(99, 3),792)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 3),40)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(29, 3),232)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "pl",
+    "prompt": "# Write a plthon function to check whether the length of the word is odd or not.\nsub word_len {\n    my($s) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&word_len;\n        if(eq_deeply($candidate->(\"Hadoop\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"great\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"structure\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "pl",
+    "prompt": "# Write a function to remove all whitespaces from a string.\nsub remove_all_spaces {\n    my($text) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&remove_all_spaces;\n        if(eq_deeply($candidate->(\"python  program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python   programming    language\"),\"pythonprogramminglanguage\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"   python                     program\"),\"pythonprogram\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of equal numbers from three given integers.\nsub test_three_equal {\n    my($x, $y, $z) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&test_three_equal;\n        if(eq_deeply($candidate->(1, 1, 1),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(-1, -2, -3),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1, 2, 2),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "pl",
+    "prompt": "# Write a plthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nsub count_rotation {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&count_rotation;\n        if(eq_deeply($candidate->([3, 2, 1]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 1, 2, 3]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 1, 2, 3]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3]),0)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 3, 2]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nsub is_perfect_square {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_perfect_square;\n        if(eq_deeply($candidate->(10),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(36),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(14),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(196),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(125),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(15625),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the product of numbers in an array is even or not.\nsub is_product_even {\n    my($arr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_product_even;\n        if(eq_deeply($candidate->([1, 2, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 1, 4]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 1]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "pl",
+    "prompt": "# Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nsub max_sum_list {\n    my($lists) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_sum_list;\n        if(eq_deeply($candidate->([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[2, 3, 1]]),[2, 3, 1])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "pl",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nsub max_run_uppercase {\n    my($test_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&max_run_uppercase;\n        if(eq_deeply($candidate->(\"GeMKSForGERksISBESt\"),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"PrECIOusMOVemENTSYT\"),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"GooGLEFluTTER\"),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the first odd number in a given array of numbers.\nsub first_odd {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&first_odd;\n        if(eq_deeply($candidate->([1, 3, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([2, 4, 1, 3]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([8, 9, 1]),9)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "pl",
+    "prompt": "# Write a function to check if the given arrays contain the k or not.\nsub check_K {\n    my($test_tup, $K) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_K;\n        if(eq_deeply($candidate->([10, 4, 5, 6, 8], 6),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6], 7),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([7, 8, 9, 44, 11, 12], 11),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "pl",
+    "prompt": "# Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nsub check_smaller {\n    my($test_tup1, $test_tup2) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&check_smaller;\n        if(eq_deeply($candidate->([1, 2, 3], [2, 3, 4]),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([4, 5, 6], [3, 4, 5]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([11, 12, 13], [10, 11, 12]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth tetrahedral number.\nsub tetrahedral_number {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&tetrahedral_number;\n        if(eq_deeply($candidate->(5),35)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(6),56)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),84)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nsub get_Char {\n    my($strr) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&get_Char;\n        if(eq_deeply($candidate->(\"abc\"),\"f\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"gfg\"),\"t\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),\"c\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "pl",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsub sequence {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&sequence;\n        if(eq_deeply($candidate->(10),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(3),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "pl",
+    "prompt": "# Write a function to find nth centered hexagonal number.\nsub centered_hexagonal_number {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&centered_hexagonal_number;\n        if(eq_deeply($candidate->(10),271)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),217)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "pl",
+    "prompt": "# Write a function to merge three dictionaries into a single hash.\nsub merge_dictionaries_three {\n    my($dict1, $dict2, $dict3) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&merge_dictionaries_three;\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}),{\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}),{\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}),{\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "pl",
+    "prompt": "# Write a function to get the frequency of all the elements in an array, returned as a hash.\nsub freq_count {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&freq_count;\n        if(eq_deeply($candidate->([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1 => 3, 2 => 2, 3 => 3, 4 => 3})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "pl",
+    "prompt": "# Write a function to find the closest smaller number than n.\nsub closest_num {\n    my($N) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&closest_num;\n        if(eq_deeply($candidate->(11),10)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),11)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "pl",
+    "prompt": "# Write a function to find squares of individual elements in an array.\nsub square_nums {\n    my($nums) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&square_nums;\n        if(eq_deeply($candidate->([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([10, 20, 30]),[100, 400, 900])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([12, 15]),[144, 225])) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the length of the longest word.\nsub len_log {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&len_log;\n        if(eq_deeply($candidate->([\"python\", \"PHP\", \"bigdata\"]),7)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"a\", \"ab\", \"abc\"]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"small\", \"big\", \"tall\"]),5)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "pl",
+    "prompt": "# Write a function to check if a string is present as a substring in a given array of string values.\nsub find_substring {\n    my($str1, $sub_str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_substring;\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "pl",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\nsub is_undulating {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&is_undulating;\n        if(eq_deeply($candidate->(1212121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(1991),\"\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(121),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "pl",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\nsub power {\n    my($a, $b) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&power;\n        if(eq_deeply($candidate->(3, 4),81)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(2, 3),8)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(5, 5),3125)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "pl",
+    "prompt": "# Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nsub index_minimum {\n    my($test_list) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&index_minimum;\n        if(eq_deeply($candidate->([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the length of the smallest array in an array of arrays.\nsub Find_Min_Length {\n    my($lst) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&Find_Min_Length;\n        if(eq_deeply($candidate->([[1], [1, 2]]),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[3, 3, 3], [4, 4, 4, 4]]),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the number of divisors of a given integer.\nsub divisor {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&divisor;\n        if(eq_deeply($candidate->(15),4)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(12),6)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(9),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "pl",
+    "prompt": "# Write a function to find frequency of each element in a flattened array of arrays, returned in a hash.\nsub frequency_lists {\n    my($list1) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&frequency_lists;\n        if(eq_deeply($candidate->([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1})) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "pl",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nsub decimal_to_binary {\n    my($n) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&decimal_to_binary;\n        if(eq_deeply($candidate->(8),\"1000\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(18),\"10010\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(7),\"111\")) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
+    "stop_tokens": [
+      "\nsub",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "pl",
+    "prompt": "# Write a plthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nsub find_Rotations {\n    my($str) = @_;\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "use Test::Deep;\n\n\nsub testhumaneval {\n    my $candidate = \\&find_Rotations;\n        if(eq_deeply($candidate->(\"aaaa\"),1)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"ab\"),2)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n        if(eq_deeply($candidate->(\"abc\"),3)) {\n        print \"ok!\" }else{\n        exit 1;\n        }\n}\n\ntesthumaneval();",
     "stop_tokens": [
       "\nsub",
       "\n#",

--- a/prompts/mbpp-py-keep.json
+++ b/prompts/mbpp-py-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "py",
-    "prompt": "def lps(str: str) -> int:\n    \"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('TENS FOR TENS') == 5\n    assert candidate('CARDIO FOR CARDS') == 7\n    assert candidate('PART OF THE JOURNEY IS PART') == 9\n\ndef test_check():\n    check(lps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "py",
-    "prompt": "def remove_whitespaces(text1: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(' Google    Flutter ') == 'GoogleFlutter'\n    assert candidate(' Google    Dart ') == 'GoogleDart'\n    assert candidate(' iOS    Swift ') == 'iOSSwift'\n\ndef test_check():\n    check(remove_whitespaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef issort_list(list1: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == True\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == False\n    assert candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == False\n\ndef test_check():\n    check(issort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef count_bidirectional(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3\n    assert candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4\n\ndef test_check():\n    check(count_bidirectional)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "py",
-    "prompt": "def surfacearea_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 150\n    assert candidate(3) == 54\n    assert candidate(10) == 600\n\ndef test_check():\n    check(surfacearea_cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "py",
     "prompt": "def next_smallest_palindrome(num: int) -> int:\n    \"\"\"\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(99) == 101\n    assert candidate(1221) == 1331\n    assert candidate(120) == 121\n\ndef test_check():\n    check(next_smallest_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "py",
-    "prompt": "def cube_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 72\n    assert candidate(3) == 288\n    assert candidate(4) == 800\n\ndef test_check():\n    check(cube_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pair_xor_Sum(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 9, 7, 6], 4) == 47\n    assert candidate([7, 3, 5], 3) == 12\n    assert candidate([7, 3], 2) == 4\n\ndef test_check():\n    check(pair_xor_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_min_heap(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 10, 15]) == True\n    assert candidate([2, 10, 4, 5, 3, 15]) == False\n\ndef test_check():\n    check(check_min_heap)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "py",
-    "prompt": "def first_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(123) == 1\n    assert candidate(456) == 4\n    assert candidate(12) == 1\n\ndef test_check():\n    check(first_Digit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef first_non_repeating_character(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcabc') == None\n    assert candidate('abc') == 'a'\n    assert candidate('ababc') == 'c'\n\ndef test_check():\n    check(first_non_repeating_character)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "py",
-    "prompt": "def radian_degree(degree: int) -> float:\n    \"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(90) == 1.5707963267948966\n    assert candidate(60) == 1.0471975511965976\n    assert candidate(120) == 2.0943951023931953\n\ndef test_check():\n    check(radian_degree)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_subarray_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 0, 7, -8, -2]) == 112\n    assert candidate([6, -3, -10, 0, 2]) == 180\n    assert candidate([-2, -40, 0, -2, -3]) == 80\n\ndef test_check():\n    check(max_subarray_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef convert_list_dictionary(l1: List[str], l2: List[str], l3: List[int]) -> List[Dict[str, Dict[str, int]]]:\n    \"\"\"\n\tWrite a function to convert more than one list to nested dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['S001', 'S002', 'S003', 'S004'], ['Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'], [85, 98, 89, 92]) == [{ 'S001': { 'Adina Park': 85 } }, { 'S002': { 'Leyton Marsh': 98 } }, { 'S003': { 'Duncan Boyle': 89 } }, { 'S004': { 'Saim Richards': 92 } }]\n    assert candidate(['abc', 'def', 'ghi', 'jkl'], ['python', 'program', 'language', 'programs'], [100, 200, 300, 400]) == [{ 'abc': { 'python': 100 } }, { 'def': { 'program': 200 } }, { 'ghi': { 'language': 300 } }, { 'jkl': { 'programs': 400 } }]\n    assert candidate(['A1', 'A2', 'A3', 'A4'], ['java', 'C', 'C++', 'DBMS'], [10, 20, 30, 40]) == [{ 'A1': { 'java': 10 } }, { 'A2': { 'C': 20 } }, { 'A3': { 'C++': 30 } }, { 'A4': { 'DBMS': 40 } }]\n\ndef test_check():\n    check(convert_list_dictionary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_num(xs: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 1, 45, 99]) == 1\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([45, 46, 50, 60]) == 45\n\ndef test_check():\n    check(smallest_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "py",
-    "prompt": "def text_match_zero_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('dsabbbba') == True\n    assert candidate('asbbbba') == False\n    assert candidate('abaaa') == True\n\ndef test_check():\n    check(text_match_zero_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "py",
-    "prompt": "def bell_Number(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(3) == 5\n    assert candidate(4) == 15\n\ndef test_check():\n    check(bell_Number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef cube_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]\n    assert candidate([10, 20, 30]) == [1000, 8000, 27000]\n    assert candidate([12, 15]) == [1728, 3375]\n\ndef test_check():\n    check(cube_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "py",
-    "prompt": "def last_Digit_Factorial(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == 4\n    assert candidate(21) == 0\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit_Factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == [2, 4]\n    assert candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0]\n    assert candidate([8, 12, 15, 19]) == [8, 12]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "py",
-    "prompt": "def prime_num(num: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(13) == True\n    assert candidate(7) == True\n    assert candidate(-1010) == False\n\ndef test_check():\n    check(prime_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_tuples(test_list: List[Tuple[int, int, int]], K: int) -> List[Tuple[int, int, int]]:\n    \"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)]\n    assert candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)]\n    assert candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)]\n\ndef test_check():\n    check(find_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "py",
-    "prompt": "def area_tetrahedron(side: int) -> float:\n    \"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 15.588457268119894\n    assert candidate(20) == 692.8203230275509\n    assert candidate(10) == 173.20508075688772\n\ndef test_check():\n    check(area_tetrahedron)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "py",
-    "prompt": "def is_Even(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == False\n    assert candidate(2) == True\n    assert candidate(3) == False\n\ndef test_check():\n    check(is_Even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pos_count(list: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, 3, -4]) == 2\n    assert candidate([3, 4, 5, -1]) == 3\n    assert candidate([1, 2, 3, 4]) == 4\n\ndef test_check():\n    check(pos_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_ludic(n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == [1, 2, 3, 5, 7]\n    assert candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25]\n    assert candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]\n\ndef test_check():\n    check(get_ludic)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "py",
-    "prompt": "def find_Index(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 14\n    assert candidate(4) == 45\n\ndef test_check():\n    check(find_Index)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef reverse_Array_Upto_K(input: List[int], k: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6]\n    assert candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7]\n    assert candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5]\n\ndef test_check():\n    check(reverse_Array_Upto_K)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef subject_marks(subjectmarks: List[Tuple[str, int]]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)]) == [('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]\n    assert candidate([('Telugu', 49), ('Hindhi', 54), ('Social', 33)]) == [('Social', 33), ('Telugu', 49), ('Hindhi', 54)]\n    assert candidate([('Physics', 96), ('Chemistry', 97), ('Biology', 45)]) == [('Biology', 45), ('Physics', 96), ('Chemistry', 97)]\n\ndef test_check():\n    check(subject_marks)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "py",
-    "prompt": "def remove_dirty_chars(string: str, second_string: str) -> str:\n    \"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('probasscurve', 'pros') == 'bacuve'\n    assert candidate('digitalindia', 'talent') == 'digiidi'\n    assert candidate('exoticmiles', 'toxic') == 'emles'\n\ndef test_check():\n    check(remove_dirty_chars)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef round_and_sum(list1: List[Union[float, int]]) -> int:\n    \"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243\n    assert candidate([5, 2, 9, 24.3, 29]) == 345\n    assert candidate([25.0, 56.7, 89.2]) == 513\n\ndef test_check():\n    check(round_and_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_occurrences(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8\n    assert candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20\n\ndef test_check():\n    check(max_occurrences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "py",
-    "prompt": "def is_decimal(num: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('123.11') == True\n    assert candidate('e666.86') == False\n    assert candidate('3.124587') == False\n    assert candidate('1.11') == True\n    assert candidate('1.1.11') == False\n\ndef test_check():\n    check(is_decimal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef dict_filter(dict: Dict[str, int], n: int) -> Dict[str, int]:\n    \"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 170) == { 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 180) == { 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 190) == { 'Pierre Cox': 190 }\n\ndef test_check():\n    check(dict_filter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_even_and_even_index(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 12, 1, 18, 8]) == 30\n    assert candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26\n    assert candidate([5, 6, 12, 1]) == 12\n\ndef test_check():\n    check(sum_even_and_even_index)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sub_array_sum(a: List[int], size: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7\n    assert candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8\n    assert candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10\n\ndef test_check():\n    check(max_sub_array_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef intersection_array(array_nums1: List[int], array_nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10]\n\ndef test_check():\n    check(intersection_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef split_two_parts(list1: List[Any], L: int) -> Any:\n    \"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1])\n    assert candidate(['a', 'b', 'c', 'd'], 2) == (['a', 'b'], ['c', 'd'])\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'], 4) == (['p', 'y', 't', 'h'], ['o', 'n'])\n\ndef test_check():\n    check(split_two_parts)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_literals(text: str, pattern: str) -> Tuple[str, int, int]:\n    \"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)\n    assert candidate('Its been a very crazy procedure right', 'crazy') == ('crazy', 16, 21)\n    assert candidate('Hardest choices required strongest will', 'will') == ('will', 35, 39)\n\ndef test_check():\n    check(find_literals)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "py",
-    "prompt": "def find_Volume(l: int, b: int, h: int) -> int:\n    \"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 8, 6) == 240\n    assert candidate(3, 2, 2) == 6\n    assert candidate(1, 2, 1) == 1\n\ndef test_check():\n    check(find_Volume)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "py",
-    "prompt": "def wind_chill(v: int, t: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(120, 35) == 40\n    assert candidate(40, 20) == 19\n    assert candidate(10, 8) == 6\n\ndef test_check():\n    check(wind_chill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "py",
-    "prompt": "def ascii_value(k: str) -> int:\n    \"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('A') == 65\n    assert candidate('R') == 82\n    assert candidate('S') == 83\n\ndef test_check():\n    check(ascii_value)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "py",
-    "prompt": "def all_Characters_Same(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('aaa') == True\n    assert candidate('data') == False\n\ndef test_check():\n    check(all_Characters_Same)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "py",
-    "prompt": "def move_num(test_str: str) -> str:\n    \"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'\n    assert candidate('Avengers124Assemble') == 'AvengersAssemble124'\n    assert candidate('Its11our12path13to14see15things16do17things') == 'Itsourpathtoseethingsdothings11121314151617'\n\ndef test_check():\n    check(move_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "py",
-    "prompt": "def word_len(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Hadoop') == False\n    assert candidate('great') == True\n    assert candidate('structure') == True\n\ndef test_check():\n    check(word_len)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "py",
-    "prompt": "from typing import Dict, Optional\n\ndef drop_empty(dict1: Dict[str, Optional[str]]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to drop empty items from a given dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'c1': 'Red', 'c2': 'Green', 'c3': None }) == { 'c1': 'Red', 'c2': 'Green' }\n    assert candidate({ 'c1': 'Red', 'c2': None, 'c3': None }) == { 'c1': 'Red' }\n    assert candidate({ 'c1': None, 'c2': 'Green', 'c3': None }) == { 'c2': 'Green' }\n\ndef test_check():\n    check(drop_empty)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef insert_element(list: List[str], element: str) -> List[str]:\n    \"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Black'], 'c') == ['c', 'Red', 'c', 'Green', 'c', 'Black']\n    assert candidate(['python', 'java'], 'program') == ['program', 'python', 'program', 'java']\n    assert candidate(['happy', 'sad'], 'laugh') == ['laugh', 'happy', 'laugh', 'sad']\n\ndef test_check():\n    check(insert_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "py",
-    "prompt": "def remove_lowercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('PYTHon') == 'PYTH'\n    assert candidate('FInD') == 'FID'\n    assert candidate('STRinG') == 'STRG'\n\ndef test_check():\n    check(remove_lowercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "py",
-    "prompt": "def count_Set_Bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 1\n    assert candidate(6) == 2\n\ndef test_check():\n    check(count_Set_Bits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "py",
-    "prompt": "from typing import Tuple, List\n\ndef extract_rear(test_tuple: Tuple[str, str, str]) -> List[str]:\n    \"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(('Mers', 'for', 'Vers')) == ['s', 'r', 's']\n    assert candidate(('Avenge', 'for', 'People')) == ['e', 'r', 'e']\n    assert candidate(('Gotta', 'get', 'go')) == ['a', 't', 'o']\n\ndef test_check():\n    check(extract_rear)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "py",
-    "prompt": "def count_occurance(s: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('letstdlenstdporstd') == 3\n    assert candidate('truststdsolensporsd') == 1\n    assert candidate('makestdsostdworthit') == 2\n    assert candidate('stds') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(count_occurance)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_K(test_tup: List[int], K: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 4, 5, 6, 8], 6) == True\n    assert candidate([1, 2, 3, 4, 5, 6], 7) == False\n    assert candidate([7, 8, 9, 44, 11, 12], 11) == True\n\ndef test_check():\n    check(check_K)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef interleave_lists(list1: List[int], list2: List[int], list3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]\n    assert candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10]\n    assert candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5]\n\ndef test_check():\n    check(interleave_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "py",
-    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python_program') == 'PythonProgram'\n    assert candidate('python_language') == 'PythonLanguage'\n    assert candidate('programming_language') == 'ProgrammingLanguage'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "py",
-    "prompt": "def test_three_equal(x: int, y: int, z: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 1, 1) == 3\n    assert candidate(-1, -2, -3) == 0\n    assert candidate(1, 2, 2) == 2\n\ndef test_check():\n    check(test_three_equal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_length_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4]) == 14\n    assert candidate([1, 2, 1, 2]) == 15\n    assert candidate([1, 7]) == 8\n\ndef test_check():\n    check(odd_length_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "py",
-    "prompt": "def bell_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(10) == 115975\n    assert candidate(56) == 6775685320645824322581483068371419745979053216268760300\n\ndef test_check():\n    check(bell_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "py",
-    "prompt": "def rectangle_area(l: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(10, 5) == 50\n    assert candidate(4, 2) == 8\n\ndef test_check():\n    check(rectangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef sum_average(number: int) -> Tuple[int, float]:\n    \"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == (55, 5.5)\n    assert candidate(15) == (120, 8.0)\n    assert candidate(20) == (210, 10.5)\n\ndef test_check():\n    check(sum_average)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef division_elements(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3)\n    assert candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4)\n    assert candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2)\n\ndef test_check():\n    check(division_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "py",
-    "prompt": "def sum_digits(n: int) -> int:\n    \"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(345) == 12\n    assert candidate(12) == 3\n    assert candidate(97) == 16\n\ndef test_check():\n    check(sum_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef index_minimum(test_list: List[Tuple[str, int]]) -> str:\n    \"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'\n    assert candidate([('Yash', 185), ('Dawood', 125), ('Sanya', 175)]) == 'Dawood'\n    assert candidate([('Sai', 345), ('Salman', 145), ('Ayesha', 96)]) == 'Ayesha'\n\ndef test_check():\n    check(index_minimum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef div_list(nums1: List[int], nums2: List[int]) -> List[float]:\n    \"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0]\n    assert candidate([3, 2], [1, 4]) == [3.0, 0.5]\n    assert candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142]\n\ndef test_check():\n    check(div_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_length_list(input_list: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5])\n    assert candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9])\n\ndef test_check():\n    check(max_length_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef combinations_list(list1: List[str]) -> List[Union[List[None], List[str]]]:\n    \"\"\"\n\tWrite a function to find all possible combinations of the elements of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['orange', 'red', 'green', 'blue']) == [[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['blue'], ['blue', 'red'], ['blue', 'green'], ['blue', 'green', 'red'], ['white'], ['white', 'red'], ['white', 'green'], ['white', 'green', 'red'], ['white', 'blue'], ['white', 'blue', 'red'], ['white', 'blue', 'green'], ['white', 'blue', 'green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['black', 'blue'], ['black', 'blue', 'red'], ['black', 'blue', 'green'], ['black', 'blue', 'green', 'red'], ['black', 'white'], ['black', 'white', 'red'], ['black', 'white', 'green'], ['black', 'white', 'green', 'red'], ['black', 'white', 'blue'], ['black', 'white', 'blue', 'red'], ['black', 'white', 'blue', 'green'], ['black', 'white', 'blue', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'blue'], ['orange', 'blue', 'red'], ['orange', 'blue', 'green'], ['orange', 'blue', 'green', 'red'], ['orange', 'white'], ['orange', 'white', 'red'], ['orange', 'white', 'green'], ['orange', 'white', 'green', 'red'], ['orange', 'white', 'blue'], ['orange', 'white', 'blue', 'red'], ['orange', 'white', 'blue', 'green'], ['orange', 'white', 'blue', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red'], ['orange', 'black', 'blue'], ['orange', 'black', 'blue', 'red'], ['orange', 'black', 'blue', 'green'], ['orange', 'black', 'blue', 'green', 'red'], ['orange', 'black', 'white'], ['orange', 'black', 'white', 'red'], ['orange', 'black', 'white', 'green'], ['orange', 'black', 'white', 'green', 'red'], ['orange', 'black', 'white', 'blue'], ['orange', 'black', 'white', 'blue', 'red'], ['orange', 'black', 'white', 'blue', 'green'], ['orange', 'black', 'white', 'blue', 'green', 'red']]\n    assert candidate(['red', 'green', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red']]\n\ndef test_check():\n    check(combinations_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef big_sum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 4\n    assert candidate([-1, 2, 3, 4]) == 3\n    assert candidate([2, 3, 6]) == 8\n\ndef test_check():\n    check(big_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef neg_nos(list1: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-1, 4, 5, -6]) == [-1, -6]\n    assert candidate([-1, -2, 3, 4]) == [-1, -2]\n    assert candidate([-7, -6, 8, 9]) == [-7, -6]\n\ndef test_check():\n    check(neg_nos)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "py",
-    "prompt": "def highest_Power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n\ndef test_check():\n    check(highest_Power_of_2)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sublist(l: List[int], s: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 3, 5, 7], [3, 7]) == False\n    assert candidate([2, 4, 3, 5, 7], [4, 3]) == True\n    assert candidate([2, 4, 3, 5, 7], [1, 6]) == False\n\ndef test_check():\n    check(is_sublist)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sub_list(nums1: List[int], nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3]\n    assert candidate([1, 2], [3, 4]) == [-2, -2]\n    assert candidate([90, 120], [50, 70]) == [40, 50]\n\ndef test_check():\n    check(sub_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "py",
-    "prompt": "def opposite_Signs(x: int, y: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, -2) == True\n    assert candidate(3, 2) == False\n    assert candidate(-10, -10) == False\n    assert candidate(-2, 2) == True\n\ndef test_check():\n    check(opposite_Signs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_modulo(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1)\n\ndef test_check():\n    check(tuple_modulo)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef diff_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1\n    assert candidate([1, 5, 7, 9, 10]) == 9\n\ndef test_check():\n    check(diff_even_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_sublists(list1: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']]) == [['green', 'orange'], ['black'], ['green', 'orange'], ['white']]\n    assert candidate([['a', 'b'], ['d', 'c'], ['g', 'h'], ['f', 'e']]) == [['a', 'b'], ['c', 'd'], ['g', 'h'], ['e', 'f']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "py",
-    "prompt": "def last_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(123) == 3\n    assert candidate(25) == 5\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "py",
-    "prompt": "def odd_num_sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 82\n    assert candidate(3) == 707\n    assert candidate(4) == 3108\n\ndef test_check():\n    check(odd_num_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tup_string(tup1: List[str]) -> str:\n    \"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's']) == 'exercises'\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n']) == 'python'\n    assert candidate(['p', 'r', 'o', 'g', 'r', 'a', 'm']) == 'program'\n\ndef test_check():\n    check(tup_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_elements(list1: List[int], list2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10]\n\ndef test_check():\n    check(remove_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef overlapping(list1: List[int], list2: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == False\n    assert candidate([1, 2, 3], [4, 5, 6]) == False\n    assert candidate([1, 4, 5], [1, 4, 5]) == True\n\ndef test_check():\n    check(overlapping)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "py",
-    "prompt": "def is_not_prime(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == False\n    assert candidate(10) == True\n    assert candidate(35) == True\n    assert candidate(37) == False\n\ndef test_check():\n    check(is_not_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef max_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 5\n    assert candidate(['Python', 15, 20, 25]) == 25\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 50\n\ndef test_check():\n    check(max_val)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_negativenum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32\n    assert candidate([10, 15, -14, 13, -18, 12, -20]) == -52\n    assert candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894\n\ndef test_check():\n    check(sum_negativenum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "py",
-    "prompt": "def find_Rotations(str: str) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aaaa') == 1\n    assert candidate('ab') == 2\n    assert candidate('abc') == 3\n\ndef test_check():\n    check(find_Rotations)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "py",
-    "prompt": "def change_date_format(dt: str) -> str:\n    \"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('2026-01-02') == '02-01-2026'\n    assert candidate('2020-11-13') == '13-11-2020'\n    assert candidate('2021-04-26') == '26-04-2021'\n\ndef test_check():\n    check(change_date_format)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5]\n    assert candidate([10, 11, 12, 13]) == [11, 13]\n    assert candidate([7, 8, 9, 1]) == [7, 9, 1]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "py",
-    "prompt": "def toggle_middle_bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(9) == 15\n    assert candidate(10) == 12\n    assert candidate(11) == 13\n    assert candidate(65) == 127\n    assert candidate(77) == 115\n\ndef test_check():\n    check(toggle_middle_bits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "py",
-    "prompt": "def count_char_position(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('xbcefg') == 2\n    assert candidate('ABcED') == 3\n    assert candidate('AbgdeF') == 5\n\ndef test_check():\n    check(count_char_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef large_product(nums1: List[int], nums2: List[int], N: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45]\n\ndef test_check():\n    check(large_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef cummulative_sum(test_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30\n    assert candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37\n    assert candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44\n\ndef test_check():\n    check(cummulative_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_min_diff(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 3, 19, 18, 25], 6) == 1\n    assert candidate([4, 3, 2, 6], 4) == 1\n    assert candidate([30, 5, 20, 9], 4) == 4\n\ndef test_check():\n    check(find_min_diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "py",
-    "prompt": "def text_starta_endb(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aabbbb') == True\n    assert candidate('aabAbbbc') == False\n    assert candidate('accddbbjjj') == False\n\ndef test_check():\n    check(text_starta_endb)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "py",
-    "prompt": "def left_rotate(n: int, d: int) -> int:\n    \"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == 64\n    assert candidate(10, 2) == 40\n    assert candidate(99, 3) == 792\n    assert candidate(99, 3) == 792\n    assert candidate(1, 3) == 8\n    assert candidate(5, 3) == 40\n    assert candidate(29, 3) == 232\n\ndef test_check():\n    check(left_rotate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef first_repeated_char(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcabc') == 'a'\n    assert candidate('abc') == None\n    assert candidate('123123') == '1'\n\ndef test_check():\n    check(first_repeated_char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_Inv_Count(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 20, 6, 4, 5]) == 5\n    assert candidate([1, 2, 1]) == 1\n    assert candidate([1, 2, 5, 6, 1]) == 3\n\ndef test_check():\n    check(get_Inv_Count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "py",
-    "prompt": "def even_Power_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1056\n    assert candidate(3) == 8832\n    assert candidate(1) == 32\n\ndef test_check():\n    check(even_Power_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_equal(Input: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[11, 22, 33], [44, 55, 66]]) == True\n    assert candidate([[1, 2, 3], [4, 5, 6, 7]]) == False\n    assert candidate([[1, 2], [3, 4]]) == True\n\ndef test_check():\n    check(get_equal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "py",
-    "prompt": "def check_integer(text: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('1') == True\n    assert candidate('12345') == True\n\ndef test_check():\n    check(check_integer)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_reverse_pairs(test_list: List[str]) -> int:\n    \"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['julia', 'best', 'tseb', 'for', 'ailuj']) == 2\n    assert candidate(['geeks', 'best', 'for', 'skeeg']) == 1\n    assert candidate(['makes', 'best', 'sekam', 'for', 'rof']) == 2\n\ndef test_check():\n    check(count_reverse_pairs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_zero(num_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0]\n    assert candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0]\n    assert candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0]\n\ndef test_check():\n    check(move_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_distinct(test_tup: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 5, 6, 1, 4]) == False\n    assert candidate([1, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 6]) == True\n\ndef test_check():\n    check(check_distinct)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "py",
-    "prompt": "def noprofit_noloss(actual_cost: int, sale_amount: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == False\n    assert candidate(100, 100) == True\n    assert candidate(2000, 5000) == False\n\ndef test_check():\n    check(noprofit_noloss)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "py",
-    "prompt": "def remove_length(test_str: str, K: int) -> str:\n    \"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('The person is most value tet', 3) == 'person is most value'\n    assert candidate('If you told me about this ok', 4) == 'If you me about ok'\n    assert candidate('Forces of darkeness is come into the play', 4) == 'Forces of darkeness is the'\n\ndef test_check():\n    check(remove_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "py",
-    "prompt": "def number_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('program2bedone') == 1\n    assert candidate('3wonders') == 1\n    assert candidate('123') == 3\n    assert candidate('3wond-1ers2') == 3\n\ndef test_check():\n    check(number_ctr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "py",
-    "prompt": "def count_charac(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python programming') == 18\n    assert candidate('language') == 8\n    assert candidate('words') == 5\n\ndef test_check():\n    check(count_charac)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "py",
-    "prompt": "def get_total_number_of_sequences(m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 4) == 4\n    assert candidate(5, 2) == 6\n    assert candidate(16, 3) == 84\n\ndef test_check():\n    check(get_total_number_of_sequences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef left_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(left_insertion)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef swap_numbers(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == [20, 10]\n    assert candidate(15, 17) == [17, 15]\n    assert candidate(100, 200) == [200, 100]\n\ndef test_check():\n    check(swap_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_majority(arr: List[int], n: int, x: int) -> bool:\n    \"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == True\n    assert candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == False\n    assert candidate([1, 1, 1, 2, 2], 5, 1) == True\n    assert candidate([1, 1, 2, 2], 5, 1) == False\n\ndef test_check():\n    check(is_majority)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef substract_elements(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13)\n    assert candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13)\n    assert candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3)\n\ndef test_check():\n    check(substract_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "py",
-    "prompt": "def capital_words_spaces(str1: str) -> str:\n    \"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('PythonProgrammingExamples') == 'Python Programming Examples'\n    assert candidate('GetReadyToBeCodingFreak') == 'Get Ready To Be Coding Freak'\n\ndef test_check():\n    check(capital_words_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "py",
-    "prompt": "def find_Average_Of_Cube(n: int) -> float:\n    \"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4.5\n    assert candidate(3) == 12\n    assert candidate(1) == 1\n\ndef test_check():\n    check(find_Average_Of_Cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_value(dict: Dict[str, int], n: int) -> bool:\n    \"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 10) == False\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 12) == True\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 5) == False\n\ndef test_check():\n    check(check_value)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "py",
-    "prompt": "def tetrahedral_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 35\n    assert candidate(6) == 56\n    assert candidate(7) == 84\n\ndef test_check():\n    check(tetrahedral_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef magic_square_test(my_matrix: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == False\n\ndef test_check():\n    check(magic_square_test)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "py",
-    "prompt": "def remove_uppercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'\n    assert candidate('wAtchTheinTernEtrAdIo') == 'wtchheinerntrdo'\n    assert candidate('VoicESeaRchAndreComMendaTionS') == 'oiceachndreomendaion'\n\ndef test_check():\n    check(remove_uppercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "py",
-    "prompt": "from typing import List, Union, Any\n\ndef check_tuplex(tuplex: List[Union[str, int]], tuple1: Any) -> bool:\n    \"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 'r') == True\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], '5') == False\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 3) == True\n\ndef test_check():\n    check(check_tuplex)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "py",
-    "prompt": "def dog_age(h_age: int) -> int:\n    \"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12) == 61\n    assert candidate(15) == 73\n    assert candidate(24) == 109\n\ndef test_check():\n    check(dog_age)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "py",
-    "prompt": "def next_Perfect_Square(N: int) -> int:\n    \"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(35) == 36\n    assert candidate(6) == 9\n    assert candidate(9) == 16\n\ndef test_check():\n    check(next_Perfect_Square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef empty_list(length: int) -> List[Dict[None, None]]:\n    \"\"\"\n\tWrite a function to create a list of N empty dictionaries.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == [{  }, {  }, {  }, {  }, {  }]\n    assert candidate(6) == [{  }, {  }, {  }, {  }, {  }, {  }]\n    assert candidate(7) == [{  }, {  }, {  }, {  }, {  }, {  }, {  }]\n\ndef test_check():\n    check(empty_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "py",
-    "prompt": "def is_upper(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('person') == 'PERSON'\n    assert candidate('final') == 'FINAL'\n    assert candidate('Valid') == 'VALID'\n\ndef test_check():\n    check(is_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "py",
-    "prompt": "def odd_Equivalent(s: str, n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('011001', 6) == 3\n    assert candidate('11011', 5) == 4\n    assert candidate('1010', 4) == 2\n\ndef test_check():\n    check(odd_Equivalent)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef re_arrange_array(arr: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]\n    assert candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15]\n    assert candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85]\n\ndef test_check():\n    check(re_arrange_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_Element(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 1]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == False\n\ndef test_check():\n    check(unique_Element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef extract_values(text: str) -> List[str]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('\"Python\", \"PHP\", \"Java\"') == ['Python', 'PHP', 'Java']\n    assert candidate('\"python\",\"program\",\"language\"') == ['python', 'program', 'language']\n    assert candidate('\"red\",\"blue\",\"green\",\"yellow\"') == ['red', 'blue', 'green', 'yellow']\n\ndef test_check():\n    check(extract_values)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count(lst: List[bool]) -> int:\n    \"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([True, False, True]) == 2\n    assert candidate([False, False]) == 0\n    assert candidate([True, True, True]) == 3\n\ndef test_check():\n    check(count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_even_pair(A: List[int]) -> int:\n    \"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1]) == 4\n    assert candidate([7, 2, 8, 1, 0, 5, 11]) == 9\n    assert candidate([1, 2, 3]) == 1\n\ndef test_check():\n    check(find_even_pair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "py",
-    "prompt": "def armstrong_number(number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(153) == True\n    assert candidate(259) == False\n    assert candidate(4458) == False\n\ndef test_check():\n    check(armstrong_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "py",
-    "prompt": "def upper_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('PYthon') == 1\n    assert candidate('BigData') == 1\n    assert candidate('program') == 0\n\ndef test_check():\n    check(upper_ctr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef and_tuples(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)\n    assert candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0)\n    assert candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0)\n\ndef test_check():\n    check(and_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_samepatterns(colors: List[str], patterns: List[str]) -> bool:\n    \"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['red', 'green', 'green'], ['a', 'b', 'b']) == True\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b', 'b']) == False\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b']) == False\n\ndef test_check():\n    check(is_samepatterns)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_list(input_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4\n    assert candidate([[1, 2], [2, 3], [4, 5]]) == 3\n    assert candidate([[1, 0], [2, 0]]) == 2\n\ndef test_check():\n    check(count_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef average_tuple(nums: List[List[int]]) -> List[float]:\n    \"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25]\n    assert candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75]\n    assert candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5]\n\ndef test_check():\n    check(average_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "py",
-    "prompt": "def lcs_of_three(X: str, Y: str, Z: str) -> int:\n    \"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('AGGT12', '12TXAYB', '12XBA') == 2\n    assert candidate('Reels', 'Reelsfor', 'ReelsforReels') == 5\n    assert candidate('abcd1e2', 'bc12ea', 'bd1ea') == 3\n\ndef test_check():\n    check(lcs_of_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "py",
-    "prompt": "def find_star_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 37\n    assert candidate(4) == 73\n    assert candidate(5) == 121\n\ndef test_check():\n    check(find_star_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef _sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([15, 12, 13, 10]) == 50\n    assert candidate([0, 1, 2]) == 3\n\ndef test_check():\n    check(_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_Consecutive(l: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 2, 3, 5, 6]) == False\n    assert candidate([1, 2, 1]) == False\n\ndef test_check():\n    check(check_Consecutive)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_adverb_position(text: str) -> Tuple[int, int, str]:\n    \"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('clearly!! we can see the sky') == (0, 7, 'clearly')\n    assert candidate('seriously!! there are many roses') == (0, 9, 'seriously')\n    assert candidate('unfortunately!! sita is going to home') == (0, 13, 'unfortunately')\n\ndef test_check():\n    check(find_adverb_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rotate_right(list: List[int], m: int) -> List[int]:\n    \"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5]\n\ndef test_check():\n    check(rotate_right)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "py",
-    "prompt": "def number_of_substrings(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abc') == 6\n    assert candidate('abcd') == 10\n    assert candidate('abcde') == 15\n\ndef test_check():\n    check(number_of_substrings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef list_split(S: List[Any], step: int) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'], 3) == [['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]\n    assert candidate(['python', 'java', 'C', 'C++', 'DBMS', 'SQL'], 2) == [['python', 'C', 'DBMS'], ['java', 'C++', 'SQL']]\n\ndef test_check():\n    check(list_split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_unique(test_list: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == True\n\ndef test_check():\n    check(all_unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef convert(numbers: int) -> Tuple[float, float]:\n    \"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1) == (1.0, 0.0)\n    assert candidate(4) == (4.0, 0.0)\n    assert candidate(5) == (5.0, 0.0)\n\ndef test_check():\n    check(convert)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "py",
-    "prompt": "from typing import Dict, Tuple\n\ndef filter_data(students: Dict[str, Tuple[float, int]], h: float, w: int) -> Dict[str, Tuple[float, int]]:\n    \"\"\"\n\tThe input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 6.0, 70) == { 'Cierra Vega': (6.2, 70) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.9, 67) == { 'Cierra Vega': (6.2, 70), 'Kierra Gentry': (6.0, 68) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.7, 64) == { 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }\n\ndef test_check():\n    check(filter_data)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "py",
-    "prompt": "def is_lower(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('InValid') == 'invalid'\n    assert candidate('TruE') == 'true'\n    assert candidate('SenTenCE') == 'sentence'\n\ndef test_check():\n    check(is_lower)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "py",
-    "prompt": "def next_power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(0) == 1\n    assert candidate(5) == 8\n    assert candidate(17) == 32\n\ndef test_check():\n    check(next_power_of_2)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_substring(str1: List[str], sub_str: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ack') == True\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'abc') == False\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ange') == True\n\ndef test_check():\n    check(find_substring)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "py",
-    "prompt": "def replace_char(str1: str, ch: str, newch: str) -> str:\n    \"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('polygon', 'y', 'l') == 'pollgon'\n    assert candidate('character', 'c', 'a') == 'aharaater'\n    assert candidate('python', 'l', 'a') == 'python'\n\ndef test_check():\n    check(replace_char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mul_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([1, 5, 7, 9, 10]) == 10\n\ndef test_check():\n    check(mul_even_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef list_tuple(listx: List[int]) -> Any:\n    \"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3)\n    assert candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7)\n    assert candidate([58, 44, 56]) == (58, 44, 56)\n\ndef test_check():\n    check(list_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "py",
-    "prompt": "def even_binomial_Coeff_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4) == 8\n    assert candidate(6) == 32\n    assert candidate(2) == 2\n\ndef test_check():\n    check(even_binomial_Coeff_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bitwise_xor(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)\n    assert candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14)\n    assert candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13)\n\ndef test_check():\n    check(bitwise_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_Sub_Array(A: List[int], B: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 5], [1, 2]) == False\n    assert candidate([1, 2, 1], [1, 2, 1]) == True\n    assert candidate([1, 0, 2, 2], [2, 2, 0]) == False\n\ndef test_check():\n    check(is_Sub_Array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sub_array_sum_repeated(a: List[int], n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, -30, -1], 4, 3) == 30\n    assert candidate([-1, 10, 20], 3, 2) == 59\n    assert candidate([-1, -2, -3], 3, 3) == -1\n\ndef test_check():\n    check(max_sub_array_sum_repeated)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef min_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 30\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100\n\ndef test_check():\n    check(min_product_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "py",
-    "prompt": "def count_divisors(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(100) == False\n    assert candidate(125) == True\n\ndef test_check():\n    check(count_divisors)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef triangle_area(r: int) -> Optional[int]:\n    \"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(-1) == None\n    assert candidate(0) == 0\n    assert candidate(2) == 4\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef string_to_tuple(str1: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python 3.0') == ['p', 'y', 't', 'h', 'o', 'n', '3', '.', '0']\n    assert candidate('item1') == ['i', 't', 'e', 'm', '1']\n    assert candidate('15.10') == ['1', '5', '.', '1', '0']\n\ndef test_check():\n    check(string_to_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "py",
-    "prompt": "def find_length(string: str) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('11000010001') == 6\n    assert candidate('10111') == 1\n    assert candidate('11011101100101') == 2\n\ndef test_check():\n    check(find_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "py",
-    "prompt": "def count_Primes_nums(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 2\n    assert candidate(10) == 4\n    assert candidate(100) == 25\n\ndef test_check():\n    check(count_Primes_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "py",
-    "prompt": "def sum_Of_product(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 15\n    assert candidate(4) == 56\n    assert candidate(1) == 1\n\ndef test_check():\n    check(sum_Of_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_aggregate(stdata: List[Tuple[str, int]]) -> Tuple[str, int]:\n    \"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([('Juan Whelan', 90), ('Sabah Colley', 88), ('Peter Nichols', 7), ('Juan Whelan', 122), ('Sabah Colley', 84)]) == ('Juan Whelan', 212)\n    assert candidate([('Juan Whelan', 50), ('Sabah Colley', 48), ('Peter Nichols', 37), ('Juan Whelan', 22), ('Sabah Colley', 14)]) == ('Juan Whelan', 72)\n    assert candidate([('Juan Whelan', 10), ('Sabah Colley', 20), ('Peter Nichols', 30), ('Juan Whelan', 40), ('Sabah Colley', 50)]) == ('Sabah Colley', 70)\n\ndef test_check():\n    check(max_aggregate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef comb_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]\n    assert candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41]\n    assert candidate([99, 15, 13, 47]) == [13, 15, 47, 99]\n\ndef test_check():\n    check(comb_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "py",
-    "prompt": "def check_expression(exp: str) -> bool:\n    \"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('{()}[{}]') == True\n    assert candidate('{()}[{]') == False\n    assert candidate('{()}[{}][]({})') == True\n\ndef test_check():\n    check(check_expression)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "py",
-    "prompt": "def text_match_wordz(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('pythonz.') == True\n    assert candidate('xyz.') == True\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_list(lst1: List[int], lst2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65]\n    assert candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10]\n    assert candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105]\n\ndef test_check():\n    check(sum_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "py",
-    "prompt": "def newman_prime(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 7\n    assert candidate(4) == 17\n    assert candidate(5) == 41\n\ndef test_check():\n    check(newman_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef add_string(list_: List[Any], string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], 'temp{0}') == ['temp1', 'temp2', 'temp3', 'temp4']\n    assert candidate(['a', 'b', 'c', 'd'], 'python{0}') == ['pythona', 'pythonb', 'pythonc', 'pythond']\n    assert candidate([5, 6, 7, 8], 'string{0}') == ['string5', 'string6', 'string7', 'string8']\n\ndef test_check():\n    check(add_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "py",
-    "prompt": "def surface_Area(b: int, s: int) -> int:\n    \"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4) == 33\n    assert candidate(4, 5) == 56\n    assert candidate(1, 2) == 5\n\ndef test_check():\n    check(surface_Area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Find_Min_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2]]) == 1\n    assert candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2\n    assert candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3\n\ndef test_check():\n    check(Find_Min_Length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "py",
-    "prompt": "def validate(n: int) -> bool:\n    \"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1234) == True\n    assert candidate(51241) == False\n    assert candidate(321) == True\n\ndef test_check():\n    check(validate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "py",
-    "prompt": "def hexagonal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 190\n    assert candidate(5) == 45\n    assert candidate(7) == 91\n\ndef test_check():\n    check(hexagonal_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "py",
-    "prompt": "def find_lucas(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(9) == 76\n    assert candidate(4) == 7\n    assert candidate(3) == 4\n\ndef test_check():\n    check(find_lucas)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Diff(li1: List[int], li2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15]\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7]\n\ndef test_check():\n    check(Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef extract_quotation(text1: str) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']\n    assert candidate('Cast your \"favorite\" entertainment \"apps\"') == ['favorite', 'apps']\n    assert candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support') == ['4k Ultra HD', 'HDR 10']\n    assert candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == []\n\ndef test_check():\n    check(extract_quotation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef recursive_list_sum(data_list: List[Union[int, List[int]]]) -> int:\n    \"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, [3, 4], [5, 6]]) == 21\n    assert candidate([7, 10, [15, 14], [19, 41]]) == 106\n    assert candidate([10, 20, [30, 40], [50, 60]]) == 210\n\ndef test_check():\n    check(recursive_list_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "py",
-    "prompt": "def differ_At_One_Bit_Pos(a: int, b: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(13, 9) == True\n    assert candidate(15, 8) == False\n    assert candidate(2, 4) == False\n    assert candidate(2, 3) == True\n    assert candidate(5, 1) == True\n    assert candidate(1, 5) == True\n\ndef test_check():\n    check(differ_At_One_Bit_Pos)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "py",
-    "prompt": "def text_match_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('caacabbbba') == True\n\ndef test_check():\n    check(text_match_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 100, 4, 5, 150, 6]) == 3000\n    assert candidate([4, 42, 55, 68, 80]) == 50265600\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460\n\ndef test_check():\n    check(max_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef split_Arr(l: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10]\n    assert candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1]\n    assert candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2]\n\ndef test_check():\n    check(split_Arr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "py",
-    "prompt": "def divisor(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(15) == 4\n    assert candidate(12) == 6\n    assert candidate(9) == 3\n\ndef test_check():\n    check(divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef big_diff(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == 3\n    assert candidate([4, 5, 12]) == 8\n    assert candidate([9, 2, 3]) == 7\n\ndef test_check():\n    check(big_diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef square_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30]) == [100, 400, 900]\n    assert candidate([12, 15]) == [144, 225]\n\ndef test_check():\n    check(square_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef check_none(test_tup: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6, None)) == True\n    assert candidate((7, 8, 9, 11, 14)) == False\n    assert candidate((1, 2, 3, 4, None)) == True\n\ndef test_check():\n    check(check_none)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_Monotonic(A: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([6, 5, 4, 4]) == True\n    assert candidate([1, 2, 2, 3]) == True\n    assert candidate([1, 3, 2]) == False\n\ndef test_check():\n    check(is_Monotonic)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "py",
-    "prompt": "def is_perfect_square(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == False\n    assert candidate(36) == True\n    assert candidate(14) == False\n    assert candidate(196) == True\n    assert candidate(125) == False\n    assert candidate(15625) == True\n\ndef test_check():\n    check(is_perfect_square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "py",
-    "prompt": "def sum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 15) == 6\n    assert candidate(100, 150) == 93\n    assert candidate(4, 6) == 3\n\ndef test_check():\n    check(sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_length(list1: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15])\n    assert candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25])\n\ndef test_check():\n    check(max_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Dict\n\ndef check_occurences(test_list: List[Tuple[int, int]]) -> Dict[Tuple[int, int], int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == { (1, 3): 2, (2, 5): 2, (3, 6): 1 }\n    assert candidate([(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == { (2, 4): 2, (3, 6): 2, (4, 7): 1 }\n    assert candidate([(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == { (2, 13): 1, (11, 23): 1, (12, 25): 2, (16, 23): 1 }\n\ndef test_check():\n    check(check_occurences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "py",
-    "prompt": "def parabola_directrix(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 3, 2) == -198\n    assert candidate(9, 8, 4) == -2336\n    assert candidate(2, 4, 6) == -130\n\ndef test_check():\n    check(parabola_directrix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "py",
-    "prompt": "from typing import Optional, Tuple\n\ndef occurance_substring(text: str, pattern: str) -> Optional[Tuple[str, int, int]]:\n    \"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python programming, python language', 'python') == ('python', 0, 6)\n    assert candidate('python programming,programming language', 'programming') == ('programming', 7, 18)\n    assert candidate('python programming,programming language', 'language') == ('language', 31, 39)\n    assert candidate('c++ programming, c++ language', 'python') == None\n\ndef test_check():\n    check(occurance_substring)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "py",
-    "prompt": "from typing import Any, Tuple\n\ndef remove_nested(test_tup: Any) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)\n    assert candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11)\n    assert candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12)\n    assert candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12)\n\ndef test_check():\n    check(remove_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_sublists(input_list: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([[' red ', 'green'], ['blue ', ' black'], [' orange', 'brown']]) == [[' red ', 'green'], [' black', 'blue '], [' orange', 'brown']]\n    assert candidate([['zilver', 'gold'], ['magnesium', 'aluminium'], ['steel', 'bronze']]) == [['gold', 'zilver'], ['aluminium', 'magnesium'], ['bronze', 'steel']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_kth_element(list1: List[int], L: int) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1]\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]\n\ndef test_check():\n    check(remove_kth_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "py",
-    "prompt": "from typing import Tuple, Dict\n\ndef add_dict_to_tuple(test_tup: Tuple[int, int, int], test_dict: Dict[str, int]) -> Tuple[int, int, int, Dict[str, int]]:\n    \"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((4, 5, 6), { 'MSAM': 1, 'is': 2, 'best': 3 }) == (4, 5, 6, { 'MSAM': 1, 'is': 2, 'best': 3 })\n    assert candidate((1, 2, 3), { 'UTS': 2, 'is': 3, 'Worst': 4 }) == (1, 2, 3, { 'UTS': 2, 'is': 3, 'Worst': 4 })\n    assert candidate((8, 9, 10), { 'POS': 3, 'is': 4, 'Okay': 5 }) == (8, 9, 10, { 'POS': 3, 'is': 4, 'Okay': 5 })\n\ndef test_check():\n    check(add_dict_to_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "py",
-    "prompt": "def find(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 3) == 3\n    assert candidate(4, 2) == 2\n    assert candidate(20, 5) == 4\n\ndef test_check():\n    check(find)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "py",
-    "prompt": "def text_match_two_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n\ndef test_check():\n    check(text_match_two_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "py",
-    "prompt": "from typing import Any, List\n\ndef count_Occurrence(tup: Any, lst: List[Any]) -> int:\n    \"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(('a', 'a', 'c', 'b', 'd'), ['a', 'b']) == 3\n    assert candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6\n    assert candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2\n\ndef test_check():\n    check(count_Occurrence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_samepair(list1: List[int], list2: List[int], list3: List[int]) -> int:\n    \"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4\n    assert candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5\n\ndef test_check():\n    check(count_samepair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "py",
-    "prompt": "def text_match_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abba') == True\n\ndef test_check():\n    check(text_match_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "py",
-    "prompt": "def difference(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 30\n    assert candidate(5) == 210\n    assert candidate(2) == 6\n\ndef test_check():\n    check(difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "py",
-    "prompt": "def toggle_string(string: str) -> str:\n    \"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Python') == 'pYTHON'\n    assert candidate('Pangram') == 'pANGRAM'\n    assert candidate('LIttLE') == 'liTTle'\n\ndef test_check():\n    check(toggle_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef Find_Max(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([['A'], ['A', 'B'], ['A', 'B', 'C']]) == ['A', 'B', 'C']\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3]\n    assert candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1]\n\ndef test_check():\n    check(Find_Max)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "py",
-    "prompt": "def eulerian_num(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 1) == 4\n    assert candidate(4, 1) == 11\n    assert candidate(5, 3) == 26\n\ndef test_check():\n    check(eulerian_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef frequency(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 4) == 0\n    assert candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3\n    assert candidate([0, 1, 2, 3, 1, 2], 1) == 2\n\ndef test_check():\n    check(frequency)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_numeric_strings(nums_str: List[str]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['4', '12', '45', '7', '0', '100', '200', '-12', '-500']) == [-500, -12, 0, 4, 7, 12, 45, 100, 200]\n    assert candidate(['2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2']) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]\n    assert candidate(['1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11']) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]\n\ndef test_check():\n    check(sort_numeric_strings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "py",
-    "prompt": "def geometric_sum(n: int) -> float:\n    \"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7) == 1.9921875\n    assert candidate(4) == 1.9375\n    assert candidate(8) == 1.99609375\n\ndef test_check():\n    check(geometric_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef divisible_by_digits(startnum: int, endnum: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]\n    assert candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]\n    assert candidate(20, 25) == [22, 24]\n\ndef test_check():\n    check(divisible_by_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_product(list_data: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000\n    assert candidate([1, 2, 3, 1]) == 6\n    assert candidate([7, 8, 9, 0, 1, 1]) == 0\n\ndef test_check():\n    check(unique_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef largest_neg(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, -4, -6]) == -6\n    assert candidate([1, 2, 3, -8, -9]) == -9\n    assert candidate([1, 2, 3, 4, -1]) == -1\n\ndef test_check():\n    check(largest_neg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef consecutive_duplicates(nums: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == ['a', 'b', 'c', 'd']\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd', 'a', 'a']) == ['a', 'b', 'c', 'd', 'a']\n\ndef test_check():\n    check(consecutive_duplicates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef min_Jumps(steps: Tuple[int, int], d: int) -> float:\n    \"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((3, 4), 11) == 3.5\n    assert candidate((3, 4), 0) == 0\n    assert candidate((11, 14), 11) == 1\n\ndef test_check():\n    check(min_Jumps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_Product(arr: List[int]) -> Tuple[int, int]:\n    \"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8)\n    assert candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6)\n    assert candidate([1, 2, 3]) == (2, 3)\n\ndef test_check():\n    check(max_Product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Any\n\ndef extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 0) == ['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 2) == [99, 96, 94, 98]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 1) == [98, 97, 91, 94]\n\ndef test_check():\n    check(extract_nth_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "py",
-    "prompt": "def is_nonagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 325\n    assert candidate(15) == 750\n    assert candidate(18) == 1089\n\ndef test_check():\n    check(is_nonagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_Abs_Diff(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 3]) == 4\n    assert candidate([9, 3, 2, 5, 1]) == 8\n    assert candidate([3, 2, 1]) == 2\n\ndef test_check():\n    check(max_Abs_Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef pack_consecutive_duplicates(list1: List[Any]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == [['a', 'a'], ['b'], ['c'], ['d', 'd']]\n\ndef test_check():\n    check(pack_consecutive_duplicates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "py",
-    "prompt": "def cal_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(9) == 49\n    assert candidate(10) == 66\n    assert candidate(11) == 88\n\ndef test_check():\n    check(cal_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "py",
-    "prompt": "def odd_values_string(str: str) -> str:\n    \"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abcdef') == 'ace'\n    assert candidate('python') == 'pto'\n    assert candidate('data') == 'dt'\n    assert candidate('lambs') == 'lms'\n\ndef test_check():\n    check(odd_values_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_kth(arr1: List[int], arr2: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6\n    assert candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256\n    assert candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8\n\ndef test_check():\n    check(find_kth)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "py",
-    "prompt": "def jacobsthal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 11\n    assert candidate(2) == 1\n    assert candidate(4) == 5\n    assert candidate(13) == 2731\n\ndef test_check():\n    check(jacobsthal_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef frequency_lists(list1: List[List[int]]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == { 1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 }\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1 }\n    assert candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == { 20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1 }\n\ndef test_check():\n    check(frequency_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef perfect_squares(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 30) == [1, 4, 9, 16, 25]\n    assert candidate(50, 100) == [64, 81, 100]\n    assert candidate(100, 200) == [100, 121, 144, 169, 196]\n\ndef test_check():\n    check(perfect_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_Of_Subarray_Prod(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 20\n    assert candidate([1, 2]) == 5\n    assert candidate([1, 2, 3, 4]) == 84\n\ndef test_check():\n    check(sum_Of_Subarray_Prod)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef first_odd(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5]) == 1\n    assert candidate([2, 4, 1, 3]) == 1\n    assert candidate([8, 9, 1]) == 9\n\ndef test_check():\n    check(first_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_nested_tuples(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]]\n\ndef test_check():\n    check(add_nested_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef merge(lst: List[List[Any]]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]\n    assert candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]]\n    assert candidate([['x', 'y', 'z'], ['a', 'b', 'c'], ['m', 'n', 'o']]) == [['x', 'a', 'm'], ['y', 'b', 'n'], ['z', 'c', 'o']]\n\ndef test_check():\n    check(merge)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "py",
-    "prompt": "def dif_Square(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(10) == False\n    assert candidate(15) == True\n\ndef test_check():\n    check(dif_Square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef check_smaller(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> bool:\n    \"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 2, 3), (2, 3, 4)) == False\n    assert candidate((4, 5, 6), (3, 4, 5)) == True\n    assert candidate((11, 12, 13), (10, 11, 12)) == True\n\ndef test_check():\n    check(check_smaller)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef freq_count(list1: List[int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == { 10: 4, 20: 4, 40: 2, 50: 2, 30: 1 }\n    assert candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == { 1: 3, 2: 2, 3: 3, 4: 3 }\n    assert candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == { 10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2 }\n\ndef test_check():\n    check(freq_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rgb_to_hsv(r: int, g: int, b: int) -> List[float]:\n    \"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(255, 255, 255) == [0.0, 0.0, 100.0]\n    assert candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608]\n    assert candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608]\n\ndef test_check():\n    check(rgb_to_hsv)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef flatten_list(list1: List[Union[int, List[int]]]) -> List[int]:\n    \"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40]\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]\n\ndef test_check():\n    check(flatten_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "py",
-    "prompt": "def check_str(string: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('annie') == True\n    assert candidate('dawood') == False\n    assert candidate('Else') == True\n\ndef test_check():\n    check(check_str)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "py",
-    "prompt": "def check_monthnumber_number(monthnum3: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(6) == True\n    assert candidate(2) == False\n    assert candidate(12) == False\n\ndef test_check():\n    check(check_monthnumber_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef heap_sort(iterable: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate([7, 1, 9, 5]) == [1, 5, 7, 9]\n\ndef test_check():\n    check(heap_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef k_smallest_pairs(nums1: List[int], nums2: List[int], k: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]]\n    assert candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]]\n    assert candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]\n\ndef test_check():\n    check(k_smallest_pairs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "py",
-    "prompt": "from typing import Optional, Tuple\n\ndef find_solution(a: int, b: int, n: int) -> Optional[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 7) == (2, 1)\n    assert candidate(4, 2, 7) == None\n    assert candidate(1, 13, 17) == (4, 1)\n\ndef test_check():\n    check(find_solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_Max_Num(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 321\n    assert candidate([4, 5, 6, 1]) == 6541\n    assert candidate([1, 2, 3, 9]) == 9321\n\ndef test_check():\n    check(find_Max_Num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum_list(lists: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12]\n    assert candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10]\n    assert candidate([[2, 3, 1]]) == [2, 3, 1]\n\ndef test_check():\n    check(max_sum_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_median(arr1: List[int], arr2: List[int], n: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0\n    assert candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5\n    assert candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0\n\ndef test_check():\n    check(get_median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "py",
-    "prompt": "def replace_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Jumanji The Jungle') == 'Jumanji_The_Jungle'\n    assert candidate('The_Avengers') == 'The Avengers'\n    assert candidate('Fast and Furious') == 'Fast_and_Furious'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "py",
-    "prompt": "def are_equivalent(num1: int, num2: int) -> bool:\n    \"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(36, 57) == False\n    assert candidate(2, 4) == False\n    assert candidate(23, 47) == True\n\ndef test_check():\n    check(are_equivalent)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef reverse_string_list(stringlist: List[str]) -> List[str]:\n    \"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue', 'White', 'Black']) == ['deR', 'neerG', 'eulB', 'etihW', 'kcalB']\n    assert candidate(['john', 'amal', 'joel', 'george']) == ['nhoj', 'lama', 'leoj', 'egroeg']\n    assert candidate(['jack', 'john', 'mary']) == ['kcaj', 'nhoj', 'yram']\n\ndef test_check():\n    check(reverse_string_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef sum_of_digits(nums: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 2, 56]) == 14\n    assert candidate([[10, 20, 4, 5, 'b', 70, 'a']]) == 19\n    assert candidate([10, 20, -4, 5, -70]) == 19\n\ndef test_check():\n    check(sum_of_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "py",
-    "prompt": "def sequence(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 6\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n\ndef test_check():\n    check(sequence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef heap_queue_largest(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35]\n\ndef test_check():\n    check(heap_queue_largest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "py",
-    "prompt": "def loss_amount(actual_cost: int, sale_amount: int) -> int:\n    \"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == 0\n    assert candidate(100, 200) == 100\n    assert candidate(2000, 5000) == 3000\n\ndef test_check():\n    check(loss_amount)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef union_elements(test_tup1: List[int], test_tup2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10]\n    assert candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6]\n    assert candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17]\n\ndef test_check():\n    check(union_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Find_Max_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4\n    assert candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3\n    assert candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5\n\ndef test_check():\n    check(Find_Max_Length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_parenthesis(items: List[str]) -> str:\n    \"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['python (chrome)']) == 'python'\n    assert candidate(['string(.abc)']) == 'string'\n    assert candidate(['alpha(num)']) == 'alpha'\n\ndef test_check():\n    check(remove_parenthesis)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "py",
-    "prompt": "def find_Parity(x: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12) == False\n    assert candidate(7) == True\n    assert candidate(10) == False\n\ndef test_check():\n    check(find_Parity)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "py",
-    "prompt": "def median_trapezium(base1: int, base2: int, height: int) -> float:\n    \"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(15, 25, 35) == 20\n    assert candidate(10, 20, 30) == 15\n    assert candidate(6, 9, 4) == 7.5\n\ndef test_check():\n    check(median_trapezium)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "py",
-    "prompt": "def centered_hexagonal_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 271\n    assert candidate(2) == 7\n    assert candidate(9) == 217\n\ndef test_check():\n    check(centered_hexagonal_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef find_lists(Input: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2\n    assert candidate([[1, 2], [3, 4], [5, 6]]) == 3\n    assert candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1\n\ndef test_check():\n    check(find_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "py",
-    "prompt": "def get_max_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(60) == 106\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n\ndef test_check():\n    check(get_max_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef len_log(list1: List[str]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['python', 'PHP', 'bigdata']) == 7\n    assert candidate(['a', 'ab', 'abc']) == 3\n    assert candidate(['small', 'big', 'tall']) == 5\n\ndef test_check():\n    check(len_log)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef sector_area(r: int, a: int) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4, 45) == 6.283185307179586\n    assert candidate(9, 45) == 31.808625617596654\n    assert candidate(9, 361) == None\n\ndef test_check():\n    check(sector_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 4, 3, 6, 7, 6, 3]) == True\n    assert candidate([4, 1, 2]) == True\n    assert candidate([1, 2, 3]) == False\n\ndef test_check():\n    check(odd_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef multiple_to_single(L: List[int]) -> int:\n    \"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([11, 33, 50]) == 113350\n    assert candidate([-1, 2, 3, 4, 5, 6]) == -123456\n    assert candidate([10, 15, 20, 25]) == 10152025\n\ndef test_check():\n    check(multiple_to_single)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "py",
-    "prompt": "def is_Diff(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12345) == False\n    assert candidate(1212112) == True\n    assert candidate(1212) == False\n\ndef test_check():\n    check(is_Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef index_multiplication(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]]\n\ndef test_check():\n    check(index_multiplication)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_str_int(test_str: str) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('(7, 8, 9)') == (7, 8, 9)\n    assert candidate('(1, 2, 3)') == (1, 2, 3)\n    assert candidate('(4, 5, 6)') == (4, 5, 6)\n    assert candidate('(7, 81, 19)') == (7, 81, 19)\n\ndef test_check():\n    check(tuple_str_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "py",
-    "prompt": "def amicable_numbers_sum(limit: int) -> int:\n    \"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(999) == 504\n    assert candidate(9999) == 31626\n    assert candidate(99) == 0\n\ndef test_check():\n    check(amicable_numbers_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "py",
-    "prompt": "def remove_odd(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python') == 'yhn'\n    assert candidate('program') == 'rga'\n    assert candidate('language') == 'agae'\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef multiply_elements(test_tup: List[int]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80]\n    assert candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42]\n    assert candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135]\n    assert candidate([12]) == []\n\ndef test_check():\n    check(multiply_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_rotation(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == 1\n    assert candidate([4, 5, 1, 2, 3]) == 2\n    assert candidate([7, 8, 9, 1, 2, 3]) == 3\n    assert candidate([1, 2, 3]) == 0\n    assert candidate([1, 3, 2]) == 2\n\ndef test_check():\n    check(count_rotation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef extract_freq(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3\n    assert candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4\n    assert candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4\n\ndef test_check():\n    check(extract_freq)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_same_pair(nums1: List[int], nums2: List[int]) -> int:\n    \"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1\n    assert candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3\n\ndef test_check():\n    check(count_same_pair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "py",
-    "prompt": "def power(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3, 4) == 81\n    assert candidate(2, 3) == 8\n    assert candidate(5, 5) == 3125\n\ndef test_check():\n    check(power)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef return_sum(dict: Dict[str, int]) -> int:\n    \"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'a': 100, 'b': 200, 'c': 300 }) == 600\n    assert candidate({ 'a': 25, 'b': 18, 'c': 45 }) == 88\n    assert candidate({ 'a': 36, 'b': 39, 'c': 49 }) == 124\n\ndef test_check():\n    check(return_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef pair_wise(l1: List[int]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]\n    assert candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)]\n    assert candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]\n\ndef test_check():\n    check(pair_wise)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef split(word: str) -> List[str]:\n    \"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python') == ['p', 'y', 't', 'h', 'o', 'n']\n    assert candidate('Name') == ['N', 'a', 'm', 'e']\n    assert candidate('program') == ['p', 'r', 'o', 'g', 'r', 'a', 'm']\n\ndef test_check():\n    check(split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "py",
-    "prompt": "def min_of_three(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 20, 0) == 0\n    assert candidate(19, 15, 18) == 15\n    assert candidate(-10, -20, -30) == -30\n\ndef test_check():\n    check(min_of_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "py",
-    "prompt": "def is_Sum_Of_Powers_Of_Two(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(7) == False\n    assert candidate(14) == True\n\ndef test_check():\n    check(is_Sum_Of_Powers_Of_Two)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "py",
-    "prompt": "def get_Char(strr: str) -> str:\n    \"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abc') == 'f'\n    assert candidate('gfg') == 't'\n    assert candidate('ab') == 'c'\n\ndef test_check():\n    check(get_Char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "py",
-    "prompt": "def sum_div(number: int) -> int:\n    \"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(8) == 7\n    assert candidate(12) == 16\n    assert candidate(7) == 1\n\ndef test_check():\n    check(sum_div)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef count_integer(list1: List[Union[int, str, float]]) -> int:\n    \"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 'abc', 1.2]) == 2\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([1, 1.2, 4, 5.1]) == 2\n\ndef test_check():\n    check(count_integer)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef two_unique_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5]\n    assert candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5]\n\ndef test_check():\n    check(two_unique_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef test_duplicate(arraynums: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 4]) == True\n    assert candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == True\n\ndef test_check():\n    check(test_duplicate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "py",
-    "prompt": "def catalan_number(num: int) -> int:\n    \"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 16796\n    assert candidate(9) == 4862\n    assert candidate(7) == 429\n\ndef test_check():\n    check(catalan_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "py",
-    "prompt": "def power_base_sum(base: int, power: int) -> int:\n    \"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 100) == 115\n    assert candidate(8, 10) == 37\n    assert candidate(8, 15) == 62\n    assert candidate(3, 3) == 9\n\ndef test_check():\n    check(power_base_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef replace_list(list1: List[Any], list2: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8]\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate(['red', 'blue', 'green'], ['yellow']) == ['red', 'blue', 'yellow']\n\ndef test_check():\n    check(replace_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "py",
-    "prompt": "def is_octagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 65\n    assert candidate(10) == 280\n    assert candidate(15) == 645\n\ndef test_check():\n    check(is_octagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "py",
-    "prompt": "def replace_blank(str1: str, char: str) -> str:\n    \"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('hello people', '@') == 'hello@people'\n    assert candidate('python program language', '$') == 'python$program$language'\n    assert candidate('blank space', '-') == 'blank-space'\n\ndef test_check():\n    check(replace_blank)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "py",
-    "prompt": "def replace_specialchar(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Python language, Programming language.') == 'Python:language::Programming:language:'\n    assert candidate('a b c,d e f') == 'a:b:c:d:e:f'\n    assert candidate('ram reshma,ram rahim') == 'ram:reshma:ram:rahim'\n\ndef test_check():\n    check(replace_specialchar)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_to_int(nums: Tuple[int, int, int]) -> int:\n    \"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 2, 3)) == 123\n    assert candidate((4, 5, 6)) == 456\n    assert candidate((5, 6, 7)) == 567\n\ndef test_check():\n    check(tuple_to_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "py",
-    "prompt": "def otherside_rightangle(w: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7, 8) == 10.63014581273465\n    assert candidate(3, 4) == 5\n    assert candidate(7, 15) == 16.55294535724685\n\ndef test_check():\n    check(otherside_rightangle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "py",
-    "prompt": "from typing import List, Dict, Union\n\ndef expensive_items(items: List[Dict[str, Union[str, float]]], n: int) -> List[Dict[str, Union[str, float]]]:\n    \"\"\"\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }], 2) == [{ 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-1', 'price': 101.1 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }, { 'name': 'Item-4', 'price': 22.75 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n\ndef test_check():\n    check(expensive_items)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "py",
-    "prompt": "def digit_distance_nums(n1: int, n2: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(23, 56) == 6\n    assert candidate(123, 256) == 7\n\ndef test_check():\n    check(digit_distance_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "py",
-    "prompt": "def text_match_wordz_middle(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('pythonzabc.') == True\n    assert candidate('zxyabc.') == False\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz_middle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "py",
-    "prompt": "def removezero_ip(ip: str) -> str:\n    \"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('216.08.094.196') == '216.8.94.196'\n    assert candidate('12.01.024') == '12.1.24'\n    assert candidate('216.08.094.0196') == '216.8.94.196'\n\ndef test_check():\n    check(removezero_ip)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef count_element_in_list(list1: List[List[Any]], x: Any) -> int:\n    \"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'A') == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'E') == 1\n\ndef test_check():\n    check(count_element_in_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "py",
-    "prompt": "def multiply_int(x: int, y: int) -> int:\n    \"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(5, 10) == 50\n    assert candidate(4, 8) == 32\n\ndef test_check():\n    check(multiply_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef add_pairwise(test_tup: Tuple[int, int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18)\n    assert candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20)\n    assert candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22)\n\ndef test_check():\n    check(add_pairwise)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 200\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484\n\ndef test_check():\n    check(max_product_tuple)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4429,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef kth_element(arr: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([12, 3, 5, 7, 19], 2) == 3\n    assert candidate([17, 24, 8, 23], 3) == 8\n    assert candidate([16, 21, 25, 36, 4], 4) == 36\n\ndef test_check():\n    check(kth_element)\n\ntest_check()\n",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "py",
-    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\n",
+    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('python_program') == 'PythonProgram'\n    assert candidate('python_language') == 'PythonLanguage'\n    assert candidate('programming_language') == 'ProgrammingLanguage'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "py",
-    "prompt": "from typing import List, Union, Tuple\n\ndef count_first_elements(test_tup: List[Union[int, Tuple[int, int]]]) -> int:\n    \"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\n",
+    "prompt": "def eulerian_num(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, (4, 6), 10]) == 3\n    assert candidate([2, 9, (5, 7), 11]) == 2\n    assert candidate([11, 15, 5, 8, (2, 3), 8]) == 4\n\ndef test_check():\n    check(count_first_elements)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(3, 1) == 4\n    assert candidate(4, 1) == 11\n    assert candidate(5, 3) == 26\n\ndef test_check():\n    check(eulerian_num)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "py",
-    "prompt": "from typing import List\n\ndef right_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef sort_sublists(input_list: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(right_insertion)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([[' red ', 'green'], ['blue ', ' black'], [' orange', 'brown']]) == [[' red ', 'green'], [' black', 'blue '], [' orange', 'brown']]\n    assert candidate([['zilver', 'gold'], ['magnesium', 'aluminium'], ['steel', 'bronze']]) == [['gold', 'zilver'], ['aluminium', 'magnesium'], ['bronze', 'steel']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "py",
-    "prompt": "def is_woodall(x: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef count(lst: List[bool]) -> int:\n    \"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(383) == True\n    assert candidate(254) == False\n    assert candidate(200) == False\n\ndef test_check():\n    check(is_woodall)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([True, False, True]) == 2\n    assert candidate([False, False]) == 0\n    assert candidate([True, True, True]) == 3\n\ndef test_check():\n    check(count)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "py",
-    "prompt": "from typing import List\n\ndef shell_sort(my_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Tuple\n\ndef add_lists(test_list: List[int], test_tup: Tuple[int, int]) -> Tuple[int, int, int, int, int]:\n    \"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]\n    assert candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87]\n    assert candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96]\n\ndef test_check():\n    check(shell_sort)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)\n    assert candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8)\n    assert candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9)\n\ndef test_check():\n    check(add_lists)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_Odd_Pair(A: List[int], N: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef merge_sorted_list(num1: List[int], num2: List[int], num3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1], 5) == 6\n    assert candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12\n    assert candidate([1, 2, 3], 3) == 2\n\ndef test_check():\n    check(find_Odd_Pair)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]\n\ndef test_check():\n    check(merge_sorted_list)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "py",
-    "prompt": "def sum_in_range(l: int, r: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\n",
+    "prompt": "def odd_Equivalent(s: str, n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 5) == 8\n    assert candidate(5, 7) == 12\n    assert candidate(7, 13) == 40\n\ndef test_check():\n    check(sum_in_range)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('011001', 6) == 3\n    assert candidate('11011', 5) == 4\n    assert candidate('1010', 4) == 2\n\ndef test_check():\n    check(odd_Equivalent)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "py",
-    "prompt": "def square_perimeter(a: int) -> int:\n    \"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\n",
+    "prompt": "def check_integer(text: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10) == 40\n    assert candidate(5) == 20\n    assert candidate(4) == 16\n\ndef test_check():\n    check(square_perimeter)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('1') == True\n    assert candidate('12345') == True\n\ndef test_check():\n    check(check_integer)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "py",
-    "prompt": "def is_polite(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef tuple_to_int(nums: Tuple[int, int, int]) -> int:\n    \"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(7) == 11\n    assert candidate(4) == 7\n    assert candidate(9) == 13\n\ndef test_check():\n    check(is_polite)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "py",
-    "prompt": "def sum_series(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(6) == 12\n    assert candidate(10) == 30\n    assert candidate(9) == 25\n\ndef test_check():\n    check(sum_series)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_dissimilar(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)\n    assert candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9)\n    assert candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25)\n\ndef test_check():\n    check(find_dissimilar)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef start_withp(words: List[str]) -> Tuple[str, str]:\n    \"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Python PHP', 'Java JavaScript', 'c c++']) == ('Python', 'PHP')\n    assert candidate(['Python Programming', 'Java Programming']) == ('Python', 'Programming')\n    assert candidate(['Pqrst Pqr', 'qrstuv']) == ('Pqrst', 'Pqr')\n\ndef test_check():\n    check(start_withp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "py",
-    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('android_tv') == 'AndroidTv'\n    assert candidate('google_pixel') == 'GooglePixel'\n    assert candidate('apple_watch') == 'AppleWatch'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "py",
-    "prompt": "def volume_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(2) == 8\n    assert candidate(5) == 125\n\ndef test_check():\n    check(volume_cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "py",
-    "prompt": "def check_monthnumb_number(monthnum2: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(2) == False\n    assert candidate(6) == False\n\ndef test_check():\n    check(check_monthnumb_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "py",
-    "prompt": "def all_Bits_Set_In_The_Given_Range(n: int, l: int, r: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(4, 1, 2) == True\n    assert candidate(17, 2, 4) == True\n    assert candidate(39, 4, 6) == False\n\ndef test_check():\n    check(all_Bits_Set_In_The_Given_Range)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Extract(lst: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]\n    assert candidate([[1, 2, 3], [4, 5]]) == [1, 4]\n    assert candidate([[9, 8, 1], [1, 2]]) == [9, 1]\n\ndef test_check():\n    check(Extract)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "py",
-    "prompt": "def surfacearea_cylinder(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(10, 5) == 942.45\n    assert candidate(4, 5) == 226.18800000000002\n    assert candidate(4, 10) == 351.848\n\ndef test_check():\n    check(surfacearea_cylinder)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sample_nam(sample_names: List[str]) -> int:\n    \"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith']) == 16\n    assert candidate(['php', 'res', 'Python', 'abcd', 'Java', 'aaa']) == 10\n    assert candidate(['abcd', 'Python', 'abba', 'aba']) == 6\n\ndef test_check():\n    check(sample_nam)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef rearrange_bigger(n: int) -> Any:\n    \"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(12) == 21\n    assert candidate(10) == False\n    assert candidate(102) == 120\n\ndef test_check():\n    check(rearrange_bigger)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "py",
-    "prompt": "def perimeter_pentagon(a: int) -> int:\n    \"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 25\n    assert candidate(10) == 50\n    assert candidate(15) == 75\n\ndef test_check():\n    check(perimeter_pentagon)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194\n    assert candidate([80, 60, 30, 40, 20, 10]) == 210\n    assert candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138\n\ndef test_check():\n    check(max_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "py",
-    "prompt": "from typing import Tuple, Any\n\ndef extract_even(test_tuple: Tuple[int, int, Tuple[int, int, Tuple[int, int]], int, int]) -> Any:\n    \"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)\n    assert candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8)))\n    assert candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10)\n\ndef test_check():\n    check(extract_even)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate((1, 2, 3)) == 123\n    assert candidate((4, 5, 6)) == 456\n    assert candidate((5, 6, 7)) == 567\n\ndef test_check():\n    check(tuple_to_int)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4789,249 +169,9 @@
     "language": "py",
     "prompt": "from typing import List, Tuple\n\ndef list_to_float(test_list: List[Tuple[str, str]]) -> List[Tuple[float, float]]:\n    \"\"\"\n\tWrite a function to convert all possible convertible elements in a list of lists to floats.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([('3', '4'), ('1', '26.45'), ('7.32', '8'), ('4', '8')]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]\n    assert candidate([('4', '4'), ('2', '27'), ('4.12', '9'), ('7', '11')]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)]\n    assert candidate([('6', '78'), ('5', '26.45'), ('1.33', '4'), ('82', '13')]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)]\n\ndef test_check():\n    check(list_to_float)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "py",
-    "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2) == 20\n    assert candidate(3) == 56\n    assert candidate(4) == 120\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_pairs_count(arr: List[int], sum: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 1, 1], 2) == 6\n    assert candidate([1, 5, 7, -1, 5], 6) == 3\n    assert candidate([1, -2, 3], 1) == 1\n    assert candidate([-1, -2, 3], -3) == 1\n\ndef test_check():\n    check(get_pairs_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "py",
-    "prompt": "def count_no_of_ways(n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(2, 4) == 16\n    assert candidate(3, 2) == 6\n    assert candidate(4, 4) == 228\n\ndef test_check():\n    check(count_no_of_ways)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "py",
-    "prompt": "def reverse_words(s: str) -> str:\n    \"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python program') == 'program python'\n    assert candidate('java language') == 'language java'\n    assert candidate('indian man') == 'man indian'\n\ndef test_check():\n    check(reverse_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "py",
-    "prompt": "def checks(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(70) == False\n    assert candidate(23) == False\n    assert candidate(73) == True\n\ndef test_check():\n    check(checks)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef last(arr: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 1) == 0\n    assert candidate([1, 1, 1, 2, 3, 4], 1) == 2\n    assert candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3\n\ndef test_check():\n    check(last)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_X(tup: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4\n\ndef test_check():\n    check(count_X)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[Any]:\n    \"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7]\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6]\n    assert candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5]\n    assert candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == []\n\ndef test_check():\n    check(extract_index_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Union, Optional\n\ndef second_smallest(numbers: List[Union[int, float]]) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, -8, -2, 0, -2]) == -2\n    assert candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5\n    assert candidate([2, 2]) == None\n    assert candidate([2, 2, 2]) == None\n\ndef test_check():\n    check(second_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef concatenate_tuple(test_tup: Tuple[str, str, int, str]) -> str:\n    \"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(('ID', 'is', 4, 'UTS')) == 'ID-is-4-UTS'\n    assert candidate(('QWE', 'is', 4, 'RTY')) == 'QWE-is-4-RTY'\n    assert candidate(('ZEN', 'is', 4, 'OP')) == 'ZEN-is-4-OP'\n\ndef test_check():\n    check(concatenate_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "py",
-    "prompt": "def replace_spaces(string: str) -> str:\n    \"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('My Name is Dawood') == 'My%20Name%20is%20Dawood'\n    assert candidate('I am a Programmer') == 'I%20am%20a%20Programmer'\n    assert candidate('I love Coding') == 'I%20love%20Coding'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_range_list(list1: List[int], m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38\n\ndef test_check():\n    check(sum_range_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef merge_dictionaries_three(dict1: Dict[str, str], dict2: Dict[str, str], dict3: Dict[str, str]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'O': 'Orange', 'W': 'White', 'B': 'Black' }) == { 'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'L': 'lavender', 'B': 'Blue' }) == { 'W': 'White', 'P': 'Pink', 'B': 'Black', 'R': 'Red', 'G': 'Green', 'L': 'lavender' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'L': 'lavender', 'B': 'Blue' }, { 'G': 'Green', 'W': 'White' }) == { 'B': 'Black', 'P': 'Pink', 'R': 'Red', 'G': 'Green', 'L': 'lavender', 'W': 'White' }\n\ndef test_check():\n    check(merge_dictionaries_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "py",
-    "prompt": "def minimum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(-5, -4) == -5\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(minimum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_difference(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7\n    assert candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15\n    assert candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23\n\ndef test_check():\n    check(max_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_Element(arr: List[int], ranges: List[List[int]], rotations: int, index: int) -> int:\n    \"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3\n    assert candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3\n    assert candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1\n\ndef test_check():\n    check(find_Element)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5044,7 +184,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef string_to_list(string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a string to a list of strings split on the space character.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('python programming') == ['python', 'programming']\n    assert candidate('lists tuples strings') == ['lists', 'tuples', 'strings']\n    assert candidate('write a program') == ['write', 'a', 'program']\n\ndef test_check():\n    check(string_to_list)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef search(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the element that appears only once in a sorted array.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 2, 3]) == 3\n    assert candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8\n    assert candidate([1, 2, 2, 3, 3, 4, 4]) == 1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "py",
-    "prompt": "from typing import Dict, List, Tuple\n\ndef sort_counter(dict1: Dict[str, int]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate({ 'Math': 81, 'Physics': 83, 'Chemistry': 87 }) == [('Chemistry', 87), ('Physics', 83), ('Math', 81)]\n    assert candidate({ 'Math': 400, 'Physics': 300, 'Chemistry': 250 }) == [('Math', 400), ('Physics', 300), ('Chemistry', 250)]\n    assert candidate({ 'Math': 900, 'Physics': 1000, 'Chemistry': 1250 }) == [('Chemistry', 1250), ('Physics', 1000), ('Math', 900)]\n\ndef test_check():\n    check(sort_counter)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5089,7 +214,7 @@
     "language": "py",
     "prompt": "def remove_Occ(s: str, ch: str) -> str:\n    \"\"\"\n\tWrite a python function to remove first and last occurrence of a given character from the string.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('hello', 'l') == 'heo'\n    assert candidate('abcda', 'a') == 'bcd'\n    assert candidate('PHP', 'P') == 'H'\n\ndef test_check():\n    check(remove_Occ)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "py",
-    "prompt": "def lateralsurface_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Tuple\n\ndef max_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5) == 100\n    assert candidate(9) == 324\n    assert candidate(10) == 400\n\ndef test_check():\n    check(lateralsurface_cube)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 200\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484\n\ndef test_check():\n    check(max_product_tuple)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "py",
-    "prompt": "from typing import List, Any, Optional\n\ndef common_element(list1: List[Any], list2: List[Any]) -> Optional[bool]:\n    \"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\n",
+    "prompt": "def amicable_numbers_sum(limit: int) -> int:\n    \"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == True\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == None\n    assert candidate(['a', 'b', 'c'], ['d', 'b', 'e']) == True\n\ndef test_check():\n    check(common_element)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(999) == 504\n    assert candidate(9999) == 31626\n    assert candidate(99) == 0\n\ndef test_check():\n    check(amicable_numbers_sum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef add_lists(test_list: List[int], test_tup: Tuple[int, int]) -> Tuple[int, int, int, int, int]:\n    \"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\n",
+    "prompt": "def find_length(string: str) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)\n    assert candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8)\n    assert candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9)\n\ndef test_check():\n    check(add_lists)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('11000010001') == 6\n    assert candidate('10111') == 1\n    assert candidate('11011101100101') == 2\n\ndef test_check():\n    check(find_length)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "py",
-    "prompt": "from typing import List\n\ndef nth_nums(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\n",
+    "prompt": "def sum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30], 3) == [1000, 8000, 27000]\n    assert candidate([12, 15], 5) == [248832, 759375]\n\ndef test_check():\n    check(nth_nums)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(10, 15) == 6\n    assert candidate(100, 150) == 93\n    assert candidate(4, 6) == 3\n\ndef test_check():\n    check(sum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "py",
-    "prompt": "from typing import List\n\ndef pancake_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "prompt": "def multiply_int(x: int, y: int) -> int:\n    \"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]\n    assert candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98]\n    assert candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42]\n\ndef test_check():\n    check(pancake_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "py",
-    "prompt": "def median_numbers(a: int, b: int, c: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(25, 55, 65) == 55.0\n    assert candidate(20, 10, 30) == 20.0\n    assert candidate(15, 45, 75) == 45.0\n\ndef test_check():\n    check(median_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_greater(arr: List[int], number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], 4) == False\n    assert candidate([2, 3, 4, 5, 6], 8) == True\n    assert candidate([9, 7, 4, 8, 6, 1], 11) == True\n\ndef test_check():\n    check(check_greater)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef check_element(list: List[Any], element: Any) -> bool:\n    \"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['green', 'orange', 'black', 'white'], 'blue') == False\n    assert candidate([1, 2, 3, 4], 7) == False\n    assert candidate(['green', 'green', 'green', 'green'], 'green') == True\n\ndef test_check():\n    check(check_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef extract_string(str: List[str], l: int) -> List[str]:\n    \"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 8) == ['practice', 'solution']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 6) == ['Python']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 9) == ['exercises']\n\ndef test_check():\n    check(extract_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "py",
-    "prompt": "def text_lowercase_underscore(text: str) -> bool:\n    \"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('aab_cbbbc') == True\n    assert candidate('aab_Abbbc') == False\n    assert candidate('Aaab_abbbc') == False\n\ndef test_check():\n    check(text_lowercase_underscore)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef trim_tuple(test_list: List[List[int]], K: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]]\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]\n    assert candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]]\n\ndef test_check():\n    check(trim_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef Find_Min(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1]\n    assert candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1]\n    assert candidate([['x'], ['x', 'y'], ['x', 'y', 'z']]) == ['x']\n\ndef test_check():\n    check(Find_Min)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_oddnumbers(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9]\n    assert candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93]\n    assert candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3]\n\ndef test_check():\n    check(filter_oddnumbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "py",
-    "prompt": "def find_adverbs(text: str) -> str:\n    \"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('Clearly, he has no excuse for such behavior.') == '0-7: Clearly'\n    assert candidate('Please handle the situation carefuly') == '28-36: carefuly'\n    assert candidate('Complete the task quickly') == '18-25: quickly'\n\ndef test_check():\n    check(find_adverbs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_of_nth(test_list: List[List[int]], N: int) -> int:\n    \"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19\n    assert candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10\n    assert candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11\n\ndef test_check():\n    check(max_of_nth)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(n: int) -> str:\n    \"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(8) == '1000'\n    assert candidate(18) == '10010'\n    assert candidate(7) == '111'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef combinations_colors(l: List[str], n: int) -> List[List[str]]:\n    \"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue'], 1) == [['Red'], ['Green'], ['Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 2) == [['Red', 'Red'], ['Red', 'Green'], ['Red', 'Blue'], ['Green', 'Green'], ['Green', 'Blue'], ['Blue', 'Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 3) == [['Red', 'Red', 'Red'], ['Red', 'Red', 'Green'], ['Red', 'Red', 'Blue'], ['Red', 'Green', 'Green'], ['Red', 'Green', 'Blue'], ['Red', 'Blue', 'Blue'], ['Green', 'Green', 'Green'], ['Green', 'Green', 'Blue'], ['Green', 'Blue', 'Blue'], ['Blue', 'Blue', 'Blue']]\n\ndef test_check():\n    check(combinations_colors)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "py",
-    "prompt": "def remove_all_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('python  program') == 'pythonprogram'\n    assert candidate('python   programming    language') == 'pythonprogramminglanguage'\n    assert candidate('python                     program') == 'pythonprogram'\n    assert candidate('   python                     program') == 'pythonprogram'\n\ndef test_check():\n    check(remove_all_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef min_Swaps(str1: str, str2: str) -> Any:\n    \"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('1101', '1110') == 1\n    assert candidate('111', '000') == 'Not Possible'\n    assert candidate('111', '110') == 'Not Possible'\n\ndef test_check():\n    check(min_Swaps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef new_tuple(test_list: List[str], test_str: str) -> Tuple[str, str, str]:\n    \"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['WEB', 'is'], 'best') == ('WEB', 'is', 'best')\n    assert candidate(['We', 'are'], 'Developers') == ('We', 'are', 'Developers')\n    assert candidate(['Part', 'is'], 'Wrong') == ('Part', 'is', 'Wrong')\n\ndef test_check():\n    check(new_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_remainder(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([100, 10, 5, 25, 35, 14], 11) == 9\n    assert candidate([1, 1, 1], 1) == 0\n    assert candidate([1, 2, 1], 2) == 0\n\ndef test_check():\n    check(find_remainder)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef min_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 2\n    assert candidate(['Python', 15, 20, 25]) == 15\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 20\n\ndef test_check():\n    check(min_val)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef positive_count(nums: List[int]) -> float:\n    \"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56\n\ndef test_check():\n    check(positive_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef add_tuple(test_list: List[int], test_tup: Tuple[int, int]) -> List[int]:\n    \"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]\n    assert candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11]\n    assert candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12]\n\ndef test_check():\n    check(add_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "py",
-    "prompt": "def max_run_uppercase(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('GeMKSForGERksISBESt') == 5\n    assert candidate('PrECIOusMOVemENTSYT') == 6\n    assert candidate('GooGLEFluTTER') == 4\n\ndef test_check():\n    check(max_run_uppercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_matrix(M: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]]\n    assert candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]]\n\ndef test_check():\n    check(sort_matrix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "py",
-    "prompt": "def count_vowels(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('bestinstareels') == 7\n    assert candidate('partofthejourneyistheend') == 12\n    assert candidate('amazonprime') == 5\n\ndef test_check():\n    check(count_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum_increasing_subseq(a: List[int], n: int, index: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7\n    assert candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71\n\ndef test_check():\n    check(max_sum_increasing_subseq)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(5, 10) == 50\n    assert candidate(4, 8) == 32\n\ndef test_check():\n    check(multiply_int)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5524,7 +304,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef long_words(n: int, str: str) -> List[str]:\n    \"\"\"\n\tWrite a function to find words that are longer than n characters from a given list of words.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(3, 'python is a programming language') == ['python', 'programming', 'language']\n    assert candidate(2, 'writing a program') == ['writing', 'program']\n    assert candidate(5, 'sorting list') == ['sorting']\n\ndef test_check():\n    check(long_words)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef magic_square_test(my_matrix: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21\n    assert candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71\n    assert candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78\n\ndef test_check():\n    check(find_sum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == False\n\ndef test_check():\n    check(magic_square_test)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "py",
-    "prompt": "from typing import Tuple, Dict\n\ndef tuple_to_dict(test_tup: Tuple[int, int, int, int, int, int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef sort_matrix(M: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 10, 13, 5)) == { 1: 5, 7: 10, 13: 5 }\n    assert candidate((1, 2, 3, 4, 5, 6)) == { 1: 2, 3: 4, 5: 6 }\n    assert candidate((7, 8, 9, 10, 11, 12)) == { 7: 8, 9: 10, 11: 12 }\n\ndef test_check():\n    check(tuple_to_dict)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]]\n    assert candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]]\n\ndef test_check():\n    check(sort_matrix)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "py",
-    "prompt": "from typing import Tuple, List\n\ndef get_coordinates(test_tup: Tuple[int, int]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef max_occurrences(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]\n    assert candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]\n    assert candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]\n\ndef test_check():\n    check(get_coordinates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef check_type(test_tuple: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate((5, 6, 7, 3, 5, 6)) == True\n    assert candidate((1, 2, '4')) == False\n    assert candidate((3, 2, 1, 4, 5)) == True\n\ndef test_check():\n    check(check_type)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_First_Missing(array: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, 3]) == 4\n    assert candidate([0, 1, 2, 6, 9]) == 3\n    assert candidate([2, 3, 5, 8, 9]) == 0\n\ndef test_check():\n    check(find_First_Missing)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "py",
-    "prompt": "def is_undulating(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(1212121) == True\n    assert candidate(1991) == False\n    assert candidate(121) == True\n\ndef test_check():\n    check(is_undulating)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef min_k(test_list: List[Tuple[str, int]], K: int) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]\n    assert candidate([('Sanjeev', 11), ('Angat', 5), ('Akash', 3), ('Nepin', 9)], 3) == [('Akash', 3), ('Angat', 5), ('Nepin', 9)]\n    assert candidate([('tanmay', 14), ('Amer', 11), ('Ayesha', 9), ('SKD', 16)], 1) == [('Ayesha', 9)]\n\ndef test_check():\n    check(min_k)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "py",
-    "prompt": "def count_Substrings(s: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('112112') == 6\n    assert candidate('111') == 6\n    assert candidate('1101112') == 12\n\ndef test_check():\n    check(count_Substrings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "py",
-    "prompt": "def is_num_decagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(7) == 175\n    assert candidate(10) == 370\n\ndef test_check():\n    check(is_num_decagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef rear_extract(test_list: List[Tuple[int, str, int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]\n    assert candidate([(1, 'Sai', 36), (2, 'Ayesha', 25), (3, 'Salman', 45)]) == [36, 25, 45]\n    assert candidate([(1, 'Sudeep', 14), (2, 'Vandana', 36), (3, 'Dawood', 56)]) == [14, 36, 56]\n\ndef test_check():\n    check(rear_extract)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "py",
-    "prompt": "def closest_num(N: int) -> int:\n    \"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(11) == 10\n    assert candidate(7) == 6\n    assert candidate(12) == 11\n\ndef test_check():\n    check(closest_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_combinations(test_list: List[Tuple[int, int]]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]\n\ndef test_check():\n    check(find_combinations)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maxAverageOfPath(cost: List[List[int]]) -> float:\n    \"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2\n    assert candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2\n    assert candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8\n\ndef test_check():\n    check(maxAverageOfPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sequential_search(dlist: List[int], item: int) -> Tuple[bool, int]:\n    \"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (True, 3)\n    assert candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (True, 7)\n    assert candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (True, 6)\n\ndef test_check():\n    check(sequential_search)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_odd(l: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [2]\n    assert candidate([2, 4, 6]) == [2, 4, 6]\n    assert candidate([10, 20, 3]) == [10, 20]\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_product_even(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 4]) == True\n    assert candidate([1, 1]) == False\n\ndef test_check():\n    check(is_product_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "py",
-    "prompt": "def maximum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 10) == 10\n    assert candidate(-1, -2) == -1\n    assert candidate(9, 7) == 9\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8\n    assert candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20\n\ndef test_check():\n    check(max_occurrences)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5794,9 +364,759 @@
     "language": "py",
     "prompt": "def reverse_vowels(str1: str) -> str:\n    \"\"\"\n\tWrite a python function to reverse only the vowels of a given string (where y is not a vowel).\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('USA') == 'ASU'\n    assert candidate('ab') == 'ab'\n\ndef test_check():\n    check(reverse_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tup_string(tup1: List[str]) -> str:\n    \"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's']) == 'exercises'\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n']) == 'python'\n    assert candidate(['p', 'r', 'o', 'g', 'r', 'a', 'm']) == 'program'\n\ndef test_check():\n    check(tup_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_negativenum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32\n    assert candidate([10, 15, -14, 13, -18, 12, -20]) == -52\n    assert candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894\n\ndef test_check():\n    check(sum_negativenum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "py",
+    "prompt": "def hexagonal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 190\n    assert candidate(5) == 45\n    assert candidate(7) == 91\n\ndef test_check():\n    check(hexagonal_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "py",
+    "prompt": "def is_Sum_Of_Powers_Of_Two(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(7) == False\n    assert candidate(14) == True\n\ndef test_check():\n    check(is_Sum_Of_Powers_Of_Two)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pancake_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]\n    assert candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98]\n    assert candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42]\n\ndef test_check():\n    check(pancake_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_samepair(list1: List[int], list2: List[int], list3: List[int]) -> int:\n    \"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4\n    assert candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5\n\ndef test_check():\n    check(count_samepair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef find_lists(Input: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2\n    assert candidate([[1, 2], [3, 4], [5, 6]]) == 3\n    assert candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1\n\ndef test_check():\n    check(find_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_Abs_Diff(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 3]) == 4\n    assert candidate([9, 3, 2, 5, 1]) == 8\n    assert candidate([3, 2, 1]) == 2\n\ndef test_check():\n    check(max_Abs_Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "py",
+    "prompt": "def find_Volume(l: int, b: int, h: int) -> int:\n    \"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 8, 6) == 240\n    assert candidate(3, 2, 2) == 6\n    assert candidate(1, 2, 1) == 1\n\ndef test_check():\n    check(find_Volume)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "py",
+    "prompt": "from typing import Optional, Tuple\n\ndef find_solution(a: int, b: int, n: int) -> Optional[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 7) == (2, 1)\n    assert candidate(4, 2, 7) == None\n    assert candidate(1, 13, 17) == (4, 1)\n\ndef test_check():\n    check(find_solution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_elements(list1: List[int], list2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10]\n\ndef test_check():\n    check(remove_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "py",
+    "prompt": "def sum_series(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(6) == 12\n    assert candidate(10) == 30\n    assert candidate(9) == 25\n\ndef test_check():\n    check(sum_series)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "py",
+    "prompt": "def are_equivalent(num1: int, num2: int) -> bool:\n    \"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(36, 57) == False\n    assert candidate(2, 4) == False\n    assert candidate(23, 47) == True\n\ndef test_check():\n    check(are_equivalent)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "py",
+    "prompt": "def count_char_position(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('xbcefg') == 2\n    assert candidate('ABcED') == 3\n    assert candidate('AbgdeF') == 5\n\ndef test_check():\n    check(count_char_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_even_pair(A: List[int]) -> int:\n    \"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1]) == 4\n    assert candidate([7, 2, 8, 1, 0, 5, 11]) == 9\n    assert candidate([1, 2, 3]) == 1\n\ndef test_check():\n    check(find_even_pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "py",
+    "prompt": "def next_power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(0) == 1\n    assert candidate(5) == 8\n    assert candidate(17) == 32\n\ndef test_check():\n    check(next_power_of_2)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef frequency(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 4) == 0\n    assert candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3\n    assert candidate([0, 1, 2, 3, 1, 2], 1) == 2\n\ndef test_check():\n    check(frequency)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "py",
+    "prompt": "def text_lowercase_underscore(text: str) -> bool:\n    \"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aab_cbbbc') == True\n    assert candidate('aab_Abbbc') == False\n    assert candidate('Aaab_abbbc') == False\n\ndef test_check():\n    check(text_lowercase_underscore)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_range_list(list1: List[int], m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38\n\ndef test_check():\n    check(sum_range_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "py",
+    "prompt": "def perimeter_pentagon(a: int) -> int:\n    \"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 25\n    assert candidate(10) == 50\n    assert candidate(15) == 75\n\ndef test_check():\n    check(perimeter_pentagon)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "py",
+    "prompt": "def count_occurance(s: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('letstdlenstdporstd') == 3\n    assert candidate('truststdsolensporsd') == 1\n    assert candidate('makestdsostdworthit') == 2\n    assert candidate('stds') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(count_occurance)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "py",
+    "prompt": "def square_perimeter(a: int) -> int:\n    \"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 40\n    assert candidate(5) == 20\n    assert candidate(4) == 16\n\ndef test_check():\n    check(square_perimeter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "py",
+    "prompt": "def remove_dirty_chars(string: str, second_string: str) -> str:\n    \"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('probasscurve', 'pros') == 'bacuve'\n    assert candidate('digitalindia', 'talent') == 'digiidi'\n    assert candidate('exoticmiles', 'toxic') == 'emles'\n\ndef test_check():\n    check(remove_dirty_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef test_duplicate(arraynums: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 4]) == True\n    assert candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == True\n\ndef test_check():\n    check(test_duplicate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "py",
+    "prompt": "def is_woodall(x: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(383) == True\n    assert candidate(254) == False\n    assert candidate(200) == False\n\ndef test_check():\n    check(is_woodall)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef check_type(test_tuple: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((5, 6, 7, 3, 5, 6)) == True\n    assert candidate((1, 2, '4')) == False\n    assert candidate((3, 2, 1, 4, 5)) == True\n\ndef test_check():\n    check(check_type)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_majority(arr: List[int], n: int, x: int) -> bool:\n    \"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == True\n    assert candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == False\n    assert candidate([1, 1, 1, 2, 2], 5, 1) == True\n    assert candidate([1, 1, 2, 2], 5, 1) == False\n\ndef test_check():\n    check(is_majority)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "py",
+    "prompt": "def count_Set_Bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 1\n    assert candidate(6) == 2\n\ndef test_check():\n    check(count_Set_Bits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "py",
+    "prompt": "def odd_values_string(str: str) -> str:\n    \"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcdef') == 'ace'\n    assert candidate('python') == 'pto'\n    assert candidate('data') == 'dt'\n    assert candidate('lambs') == 'lms'\n\ndef test_check():\n    check(odd_values_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "py",
+    "prompt": "def min_of_three(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 20, 0) == 0\n    assert candidate(19, 15, 18) == 15\n    assert candidate(-10, -20, -30) == -30\n\ndef test_check():\n    check(min_of_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "py",
+    "prompt": "def all_Bits_Set_In_The_Given_Range(n: int, l: int, r: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4, 1, 2) == True\n    assert candidate(17, 2, 4) == True\n    assert candidate(39, 4, 6) == False\n\ndef test_check():\n    check(all_Bits_Set_In_The_Given_Range)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef re_arrange_array(arr: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]\n    assert candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15]\n    assert candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85]\n\ndef test_check():\n    check(re_arrange_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "py",
+    "prompt": "def replace_blank(str1: str, char: str) -> str:\n    \"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('hello people', '@') == 'hello@people'\n    assert candidate('python program language', '$') == 'python$program$language'\n    assert candidate('blank space', '-') == 'blank-space'\n\ndef test_check():\n    check(replace_blank)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "py",
+    "prompt": "def volume_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(2) == 8\n    assert candidate(5) == 125\n\ndef test_check():\n    check(volume_cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Dict\n\ndef check_occurences(test_list: List[Tuple[int, int]]) -> Dict[Tuple[int, int], int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == { (1, 3): 2, (2, 5): 2, (3, 6): 1 }\n    assert candidate([(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == { (2, 4): 2, (3, 6): 2, (4, 7): 1 }\n    assert candidate([(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == { (2, 13): 1, (11, 23): 1, (12, 25): 2, (16, 23): 1 }\n\ndef test_check():\n    check(check_occurences)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "py",
+    "prompt": "def number_of_substrings(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abc') == 6\n    assert candidate('abcd') == 10\n    assert candidate('abcde') == 15\n\ndef test_check():\n    check(number_of_substrings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "py",
+    "prompt": "def get_total_number_of_sequences(m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 4) == 4\n    assert candidate(5, 2) == 6\n    assert candidate(16, 3) == 84\n\ndef test_check():\n    check(get_total_number_of_sequences)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef replace_list(list1: List[Any], list2: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8]\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate(['red', 'blue', 'green'], ['yellow']) == ['red', 'blue', 'yellow']\n\ndef test_check():\n    check(replace_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "py",
+    "prompt": "def count_charac(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python programming') == 18\n    assert candidate('language') == 8\n    assert candidate('words') == 5\n\ndef test_check():\n    check(count_charac)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "py",
+    "prompt": "def next_Perfect_Square(N: int) -> int:\n    \"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(35) == 36\n    assert candidate(6) == 9\n    assert candidate(9) == 16\n\ndef test_check():\n    check(next_Perfect_Square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194\n    assert candidate([80, 60, 30, 40, 20, 10]) == 210\n    assert candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138\n\ndef test_check():\n    check(max_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "py",
+    "prompt": "def lps(str: str) -> int:\n    \"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('TENS FOR TENS') == 5\n    assert candidate('CARDIO FOR CARDS') == 7\n    assert candidate('PART OF THE JOURNEY IS PART') == 9\n\ndef test_check():\n    check(lps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersection_array(array_nums1: List[int], array_nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10]\n\ndef test_check():\n    check(intersection_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_X(tup: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4\n\ndef test_check():\n    check(count_X)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef insert_element(list: List[str], element: str) -> List[str]:\n    \"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Black'], 'c') == ['c', 'Red', 'c', 'Green', 'c', 'Black']\n    assert candidate(['python', 'java'], 'program') == ['program', 'python', 'program', 'java']\n    assert candidate(['happy', 'sad'], 'laugh') == ['laugh', 'happy', 'laugh', 'sad']\n\ndef test_check():\n    check(insert_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef convert(numbers: int) -> Tuple[float, float]:\n    \"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == (1.0, 0.0)\n    assert candidate(4) == (4.0, 0.0)\n    assert candidate(5) == (5.0, 0.0)\n\ndef test_check():\n    check(convert)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef count_integer(list1: List[Union[int, str, float]]) -> int:\n    \"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 'abc', 1.2]) == 2\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([1, 1.2, 4, 5.1]) == 2\n\ndef test_check():\n    check(count_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef combinations_colors(l: List[str], n: int) -> List[List[str]]:\n    \"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue'], 1) == [['Red'], ['Green'], ['Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 2) == [['Red', 'Red'], ['Red', 'Green'], ['Red', 'Blue'], ['Green', 'Green'], ['Green', 'Blue'], ['Blue', 'Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 3) == [['Red', 'Red', 'Red'], ['Red', 'Red', 'Green'], ['Red', 'Red', 'Blue'], ['Red', 'Green', 'Green'], ['Red', 'Green', 'Blue'], ['Red', 'Blue', 'Blue'], ['Green', 'Green', 'Green'], ['Green', 'Green', 'Blue'], ['Green', 'Blue', 'Blue'], ['Blue', 'Blue', 'Blue']]\n\ndef test_check():\n    check(combinations_colors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "py",
+    "prompt": "def count_Primes_nums(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 2\n    assert candidate(10) == 4\n    assert candidate(100) == 25\n\ndef test_check():\n    check(count_Primes_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_numbers(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == [20, 10]\n    assert candidate(15, 17) == [17, 15]\n    assert candidate(100, 200) == [200, 100]\n\ndef test_check():\n    check(swap_numbers)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5809,7 +1129,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef maximize_elements(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to maximize the given two lists.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]]\n\ndef test_check():\n    check(maximize_elements)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "py",
-    "prompt": "from typing import List\n\ndef even_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\n",
+    "prompt": "def newman_prime(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 3]) == False\n    assert candidate([2, 1, 4]) == True\n\ndef test_check():\n    check(even_position)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(3) == 7\n    assert candidate(4) == 17\n    assert candidate(5) == 41\n\ndef test_check():\n    check(newman_prime)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "py",
-    "prompt": "def check_char(string: str) -> str:\n    \"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef division_elements(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate('abba') == 'Valid'\n    assert candidate('a') == 'Valid'\n    assert candidate('abcd') == 'Invalid'\n\ndef test_check():\n    check(check_char)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3)\n    assert candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4)\n    assert candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2)\n\ndef test_check():\n    check(division_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "py",
-    "prompt": "def sumofFactors(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef split_two_parts(list1: List[Any], L: int) -> Any:\n    \"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(18) == 26\n    assert candidate(30) == 48\n    assert candidate(6) == 8\n\ndef test_check():\n    check(sumofFactors)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1])\n    assert candidate(['a', 'b', 'c', 'd'], 2) == (['a', 'b'], ['c', 'd'])\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'], 4) == (['p', 'y', 't', 'h'], ['o', 'n'])\n\ndef test_check():\n    check(split_two_parts)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "py",
-    "prompt": "def lateralsurface_cone(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\n",
+    "prompt": "def dog_age(h_age: int) -> int:\n    \"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate(5, 12) == 204.20352248333654\n    assert candidate(10, 15) == 566.3586699569488\n    assert candidate(19, 17) == 1521.8090132193388\n\ndef test_check():\n    check(lateralsurface_cone)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(12) == 61\n    assert candidate(15) == 73\n    assert candidate(24) == 109\n\ndef test_check():\n    check(dog_age)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "py",
-    "prompt": "from typing import List\n\ndef count_Pairs(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef list_split(S: List[Any], step: int) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 1], 3) == 2\n    assert candidate([1, 1, 1, 1], 4) == 0\n    assert candidate([1, 2, 3, 4, 5], 5) == 10\n\ndef test_check():\n    check(count_Pairs)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'], 3) == [['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]\n    assert candidate(['python', 'java', 'C', 'C++', 'DBMS', 'SQL'], 2) == [['python', 'C', 'DBMS'], ['java', 'C++', 'SQL']]\n\ndef test_check():\n    check(list_split)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_first_occurrence(A: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\n",
+    "prompt": "def lateralsurface_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1\n    assert candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2\n    assert candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4\n\ndef test_check():\n    check(find_first_occurrence)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == 100\n    assert candidate(9) == 324\n    assert candidate(10) == 400\n\ndef test_check():\n    check(lateralsurface_cube)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5914,9 +1234,909 @@
     "language": "py",
     "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate(2) == 10\n    assert candidate(3) == 35\n    assert candidate(4) == 84\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "py",
+    "prompt": "def find_star_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 37\n    assert candidate(4) == 73\n    assert candidate(5) == 121\n\ndef test_check():\n    check(find_star_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "py",
+    "prompt": "def ascii_value(k: str) -> int:\n    \"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('A') == 65\n    assert candidate('R') == 82\n    assert candidate('S') == 83\n\ndef test_check():\n    check(ascii_value)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_even_and_even_index(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 12, 1, 18, 8]) == 30\n    assert candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26\n    assert candidate([5, 6, 12, 1]) == 12\n\ndef test_check():\n    check(sum_even_and_even_index)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "py",
+    "prompt": "def even_Power_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1056\n    assert candidate(3) == 8832\n    assert candidate(1) == 32\n\ndef test_check():\n    check(even_Power_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef rear_extract(test_list: List[Tuple[int, str, int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]\n    assert candidate([(1, 'Sai', 36), (2, 'Ayesha', 25), (3, 'Salman', 45)]) == [36, 25, 45]\n    assert candidate([(1, 'Sudeep', 14), (2, 'Vandana', 36), (3, 'Dawood', 56)]) == [14, 36, 56]\n\ndef test_check():\n    check(rear_extract)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef substract_elements(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13)\n    assert candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13)\n    assert candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3)\n\ndef test_check():\n    check(substract_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "py",
+    "prompt": "def even_binomial_Coeff_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == 8\n    assert candidate(6) == 32\n    assert candidate(2) == 2\n\ndef test_check():\n    check(even_binomial_Coeff_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef dict_filter(dict: Dict[str, int], n: int) -> Dict[str, int]:\n    \"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 170) == { 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 180) == { 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 190) == { 'Pierre Cox': 190 }\n\ndef test_check():\n    check(dict_filter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "py",
+    "prompt": "from typing import List, Union, Tuple\n\ndef count_first_elements(test_tup: List[Union[int, Tuple[int, int]]]) -> int:\n    \"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, (4, 6), 10]) == 3\n    assert candidate([2, 9, (5, 7), 11]) == 2\n    assert candidate([11, 15, 5, 8, (2, 3), 8]) == 4\n\ndef test_check():\n    check(count_first_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "py",
+    "prompt": "def is_num_decagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(7) == 175\n    assert candidate(10) == 370\n\ndef test_check():\n    check(is_num_decagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sequential_search(dlist: List[int], item: int) -> Tuple[bool, int]:\n    \"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (True, 3)\n    assert candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (True, 7)\n    assert candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (True, 6)\n\ndef test_check():\n    check(sequential_search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_unique(test_list: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == True\n\ndef test_check():\n    check(all_unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sub_list(nums1: List[int], nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3]\n    assert candidate([1, 2], [3, 4]) == [-2, -2]\n    assert candidate([90, 120], [50, 70]) == [40, 50]\n\ndef test_check():\n    check(sub_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "py",
+    "prompt": "def validate(n: int) -> bool:\n    \"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1234) == True\n    assert candidate(51241) == False\n    assert candidate(321) == True\n\ndef test_check():\n    check(validate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef check_element(list: List[Any], element: Any) -> bool:\n    \"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['green', 'orange', 'black', 'white'], 'blue') == False\n    assert candidate([1, 2, 3, 4], 7) == False\n    assert candidate(['green', 'green', 'green', 'green'], 'green') == True\n\ndef test_check():\n    check(check_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "py",
+    "prompt": "def text_match_two_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n\ndef test_check():\n    check(text_match_two_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sub_array_sum_repeated(a: List[int], n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, -30, -1], 4, 3) == 30\n    assert candidate([-1, 10, 20], 3, 2) == 59\n    assert candidate([-1, -2, -3], 3, 3) == -1\n\ndef test_check():\n    check(max_sub_array_sum_repeated)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "py",
+    "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 20\n    assert candidate(3) == 56\n    assert candidate(4) == 120\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_length(list1: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15])\n    assert candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25])\n\ndef test_check():\n    check(max_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "py",
+    "prompt": "def count_no_of_ways(n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 4) == 16\n    assert candidate(3, 2) == 6\n    assert candidate(4, 4) == 228\n\ndef test_check():\n    check(count_no_of_ways)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "py",
+    "prompt": "def find(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 3) == 3\n    assert candidate(4, 2) == 2\n    assert candidate(20, 5) == 4\n\ndef test_check():\n    check(find)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "py",
+    "prompt": "def otherside_rightangle(w: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7, 8) == 10.63014581273465\n    assert candidate(3, 4) == 5\n    assert candidate(7, 15) == 16.55294535724685\n\ndef test_check():\n    check(otherside_rightangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef max_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 5\n    assert candidate(['Python', 15, 20, 25]) == 25\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 50\n\ndef test_check():\n    check(max_val)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "py",
+    "prompt": "def sum_div(number: int) -> int:\n    \"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(8) == 7\n    assert candidate(12) == 16\n    assert candidate(7) == 1\n\ndef test_check():\n    check(sum_div)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_Inv_Count(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 20, 6, 4, 5]) == 5\n    assert candidate([1, 2, 1]) == 1\n    assert candidate([1, 2, 5, 6, 1]) == 3\n\ndef test_check():\n    check(get_Inv_Count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef flatten_list(list1: List[Union[int, List[int]]]) -> List[int]:\n    \"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40]\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]\n\ndef test_check():\n    check(flatten_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_aggregate(stdata: List[Tuple[str, int]]) -> Tuple[str, int]:\n    \"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([('Juan Whelan', 90), ('Sabah Colley', 88), ('Peter Nichols', 7), ('Juan Whelan', 122), ('Sabah Colley', 84)]) == ('Juan Whelan', 212)\n    assert candidate([('Juan Whelan', 50), ('Sabah Colley', 48), ('Peter Nichols', 37), ('Juan Whelan', 22), ('Sabah Colley', 14)]) == ('Juan Whelan', 72)\n    assert candidate([('Juan Whelan', 10), ('Sabah Colley', 20), ('Peter Nichols', 30), ('Juan Whelan', 40), ('Sabah Colley', 50)]) == ('Sabah Colley', 70)\n\ndef test_check():\n    check(max_aggregate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Element(arr: List[int], ranges: List[List[int]], rotations: int, index: int) -> int:\n    \"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3\n    assert candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3\n    assert candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1\n\ndef test_check():\n    check(find_Element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef start_withp(words: List[str]) -> Tuple[str, str]:\n    \"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Python PHP', 'Java JavaScript', 'c c++']) == ('Python', 'PHP')\n    assert candidate(['Python Programming', 'Java Programming']) == ('Python', 'Programming')\n    assert candidate(['Pqrst Pqr', 'qrstuv']) == ('Pqrst', 'Pqr')\n\ndef test_check():\n    check(start_withp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum_increasing_subseq(a: List[int], n: int, index: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7\n    assert candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71\n\ndef test_check():\n    check(max_sum_increasing_subseq)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef large_product(nums1: List[int], nums2: List[int], N: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45]\n\ndef test_check():\n    check(large_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "py",
+    "prompt": "def maximum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 10) == 10\n    assert candidate(-1, -2) == -1\n    assert candidate(9, 7) == 9\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef string_to_tuple(str1: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python 3.0') == ['p', 'y', 't', 'h', 'o', 'n', '3', '.', '0']\n    assert candidate('item1') == ['i', 't', 'e', 'm', '1']\n    assert candidate('15.10') == ['1', '5', '.', '1', '0']\n\ndef test_check():\n    check(string_to_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "py",
+    "prompt": "def highest_Power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n\ndef test_check():\n    check(highest_Power_of_2)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "py",
+    "prompt": "def find_lucas(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(9) == 76\n    assert candidate(4) == 7\n    assert candidate(3) == 4\n\ndef test_check():\n    check(find_lucas)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef add_string(list_: List[Any], string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], 'temp{0}') == ['temp1', 'temp2', 'temp3', 'temp4']\n    assert candidate(['a', 'b', 'c', 'd'], 'python{0}') == ['pythona', 'pythonb', 'pythonc', 'pythond']\n    assert candidate([5, 6, 7, 8], 'string{0}') == ['string5', 'string6', 'string7', 'string8']\n\ndef test_check():\n    check(add_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef convert_list_dictionary(l1: List[str], l2: List[str], l3: List[int]) -> List[Dict[str, Dict[str, int]]]:\n    \"\"\"\n\tWrite a function to convert more than one list to nested dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['S001', 'S002', 'S003', 'S004'], ['Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'], [85, 98, 89, 92]) == [{ 'S001': { 'Adina Park': 85 } }, { 'S002': { 'Leyton Marsh': 98 } }, { 'S003': { 'Duncan Boyle': 89 } }, { 'S004': { 'Saim Richards': 92 } }]\n    assert candidate(['abc', 'def', 'ghi', 'jkl'], ['python', 'program', 'language', 'programs'], [100, 200, 300, 400]) == [{ 'abc': { 'python': 100 } }, { 'def': { 'program': 200 } }, { 'ghi': { 'language': 300 } }, { 'jkl': { 'programs': 400 } }]\n    assert candidate(['A1', 'A2', 'A3', 'A4'], ['java', 'C', 'C++', 'DBMS'], [10, 20, 30, 40]) == [{ 'A1': { 'java': 10 } }, { 'A2': { 'C': 20 } }, { 'A3': { 'C++': 30 } }, { 'A4': { 'DBMS': 40 } }]\n\ndef test_check():\n    check(convert_list_dictionary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "py",
+    "prompt": "def get_max_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(60) == 106\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n\ndef test_check():\n    check(get_max_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_length_list(input_list: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5])\n    assert candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9])\n\ndef test_check():\n    check(max_length_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_distinct(test_tup: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 5, 6, 1, 4]) == False\n    assert candidate([1, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 6]) == True\n\ndef test_check():\n    check(check_distinct)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef first_non_repeating_character(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcabc') == None\n    assert candidate('abc') == 'a'\n    assert candidate('ababc') == 'c'\n\ndef test_check():\n    check(first_non_repeating_character)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "py",
+    "prompt": "def check_char(string: str) -> str:\n    \"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abba') == 'Valid'\n    assert candidate('a') == 'Valid'\n    assert candidate('abcd') == 'Invalid'\n\ndef test_check():\n    check(check_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "py",
+    "prompt": "def median_numbers(a: int, b: int, c: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(25, 55, 65) == 55.0\n    assert candidate(20, 10, 30) == 20.0\n    assert candidate(15, 45, 75) == 45.0\n\ndef test_check():\n    check(median_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef sum_of_digits(nums: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 2, 56]) == 14\n    assert candidate([[10, 20, 4, 5, 'b', 70, 'a']]) == 19\n    assert candidate([10, 20, -4, 5, -70]) == 19\n\ndef test_check():\n    check(sum_of_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef bitwise_xor(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)\n    assert candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14)\n    assert candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13)\n\ndef test_check():\n    check(bitwise_xor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "py",
+    "prompt": "def is_not_prime(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == False\n    assert candidate(10) == True\n    assert candidate(35) == True\n    assert candidate(37) == False\n\ndef test_check():\n    check(is_not_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef extract_freq(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3\n    assert candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4\n    assert candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4\n\ndef test_check():\n    check(extract_freq)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add_nested_tuples(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]]\n\ndef test_check():\n    check(add_nested_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "py",
+    "prompt": "def minimum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(-5, -4) == -5\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(minimum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "py",
+    "prompt": "from typing import List, Union, Any\n\ndef check_tuplex(tuplex: List[Union[str, int]], tuple1: Any) -> bool:\n    \"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 'r') == True\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], '5') == False\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 3) == True\n\ndef test_check():\n    check(check_tuplex)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "py",
+    "prompt": "def find_Parity(x: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(12) == False\n    assert candidate(7) == True\n    assert candidate(10) == False\n\ndef test_check():\n    check(find_Parity)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef rearrange_bigger(n: int) -> Any:\n    \"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(12) == 21\n    assert candidate(10) == False\n    assert candidate(102) == 120\n\ndef test_check():\n    check(rearrange_bigger)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef k_smallest_pairs(nums1: List[int], nums2: List[int], k: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]]\n    assert candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]]\n    assert candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]\n\ndef test_check():\n    check(k_smallest_pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef min_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 30\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100\n\ndef test_check():\n    check(min_product_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef min_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 2\n    assert candidate(['Python', 15, 20, 25]) == 15\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 20\n\ndef test_check():\n    check(min_val)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "py",
+    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('android_tv') == 'AndroidTv'\n    assert candidate('google_pixel') == 'GooglePixel'\n    assert candidate('apple_watch') == 'AppleWatch'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_odd(l: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [2]\n    assert candidate([2, 4, 6]) == [2, 4, 6]\n    assert candidate([10, 20, 3]) == [10, 20]\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Any\n\ndef extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 0) == ['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 2) == [99, 96, 94, 98]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 1) == [98, 97, 91, 94]\n\ndef test_check():\n    check(extract_nth_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef overlapping(list1: List[int], list2: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == False\n    assert candidate([1, 2, 3], [4, 5, 6]) == False\n    assert candidate([1, 4, 5], [1, 4, 5]) == True\n\ndef test_check():\n    check(overlapping)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_Product(arr: List[int]) -> Tuple[int, int]:\n    \"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8)\n    assert candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6)\n    assert candidate([1, 2, 3]) == (2, 3)\n\ndef test_check():\n    check(max_Product)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5929,7 +2149,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef group_tuples(Input: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to find common first element in given list of lists.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['x', 'z'], ['w', 't']]) == [['x', 'y', 'z'], ['w', 't']]\n    assert candidate([['a', 'b'], ['a', 'c'], ['d', 'e']]) == [['a', 'b', 'c'], ['d', 'e']]\n    assert candidate([['f', 'g'], ['f', 'g'], ['h', 'i']]) == [['f', 'g', 'g'], ['h', 'i']]\n\ndef test_check():\n    check(group_tuples)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "py",
-    "prompt": "from typing import List\n\ndef merge_sorted_list(num1: List[int], num2: List[int], num3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef Find_Max(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "def check(candidate):\n    assert candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]\n\ndef test_check():\n    check(merge_sorted_list)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([['A'], ['A', 'B'], ['A', 'B', 'C']]) == ['A', 'B', 'C']\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3]\n    assert candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1]\n\ndef test_check():\n    check(Find_Max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef round_and_sum(list1: List[Union[float, int]]) -> int:\n    \"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243\n    assert candidate([5, 2, 9, 24.3, 29]) == 345\n    assert candidate([25.0, 56.7, 89.2]) == 513\n\ndef test_check():\n    check(round_and_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "py",
+    "prompt": "def cube_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 72\n    assert candidate(3) == 288\n    assert candidate(4) == 800\n\ndef test_check():\n    check(cube_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef concatenate_tuple(test_tup: Tuple[str, str, int, str]) -> str:\n    \"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(('ID', 'is', 4, 'UTS')) == 'ID-is-4-UTS'\n    assert candidate(('QWE', 'is', 4, 'RTY')) == 'QWE-is-4-RTY'\n    assert candidate(('ZEN', 'is', 4, 'OP')) == 'ZEN-is-4-OP'\n\ndef test_check():\n    check(concatenate_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "py",
+    "prompt": "def find_Average_Of_Cube(n: int) -> float:\n    \"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4.5\n    assert candidate(3) == 12\n    assert candidate(1) == 1\n\ndef test_check():\n    check(find_Average_Of_Cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "py",
+    "prompt": "from typing import Tuple, List\n\ndef extract_rear(test_tuple: Tuple[str, str, str]) -> List[str]:\n    \"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(('Mers', 'for', 'Vers')) == ['s', 'r', 's']\n    assert candidate(('Avenge', 'for', 'People')) == ['e', 'r', 'e']\n    assert candidate(('Gotta', 'get', 'go')) == ['a', 't', 'o']\n\ndef test_check():\n    check(extract_rear)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef count_element_in_list(list1: List[List[Any]], x: Any) -> int:\n    \"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'A') == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'E') == 1\n\ndef test_check():\n    check(count_element_in_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_oddnumbers(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9]\n    assert candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93]\n    assert candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3]\n\ndef test_check():\n    check(filter_oddnumbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "py",
+    "prompt": "def change_date_format(dt: str) -> str:\n    \"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('2026-01-02') == '02-01-2026'\n    assert candidate('2020-11-13') == '13-11-2020'\n    assert candidate('2021-04-26') == '26-04-2021'\n\ndef test_check():\n    check(change_date_format)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef shell_sort(my_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]\n    assert candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87]\n    assert candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96]\n\ndef test_check():\n    check(shell_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef and_tuples(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)\n    assert candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0)\n    assert candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0)\n\ndef test_check():\n    check(and_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "py",
+    "prompt": "def parabola_directrix(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 3, 2) == -198\n    assert candidate(9, 8, 4) == -2336\n    assert candidate(2, 4, 6) == -130\n\ndef test_check():\n    check(parabola_directrix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "py",
+    "prompt": "from typing import List, Any, Optional\n\ndef common_element(list1: List[Any], list2: List[Any]) -> Optional[bool]:\n    \"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == True\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == None\n    assert candidate(['a', 'b', 'c'], ['d', 'b', 'e']) == True\n\ndef test_check():\n    check(common_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "py",
+    "prompt": "def median_trapezium(base1: int, base2: int, height: int) -> float:\n    \"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(15, 25, 35) == 20\n    assert candidate(10, 20, 30) == 15\n    assert candidate(6, 9, 4) == 7.5\n\ndef test_check():\n    check(median_trapezium)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_greater(arr: List[int], number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], 4) == False\n    assert candidate([2, 3, 4, 5, 6], 8) == True\n    assert candidate([9, 7, 4, 8, 6, 1], 11) == True\n\ndef test_check():\n    check(check_greater)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "py",
+    "prompt": "def text_match_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abba') == True\n\ndef test_check():\n    check(text_match_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "py",
+    "prompt": "def last_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(123) == 3\n    assert candidate(25) == 5\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef neg_nos(list1: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-1, 4, 5, -6]) == [-1, -6]\n    assert candidate([-1, -2, 3, 4]) == [-1, -2]\n    assert candidate([-7, -6, 8, 9]) == [-7, -6]\n\ndef test_check():\n    check(neg_nos)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "py",
+    "prompt": "def remove_odd(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python') == 'yhn'\n    assert candidate('program') == 'rga'\n    assert candidate('language') == 'agae'\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef count_bidirectional(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3\n    assert candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4\n\ndef test_check():\n    check(count_bidirectional)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef multiple_to_single(L: List[int]) -> int:\n    \"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([11, 33, 50]) == 113350\n    assert candidate([-1, 2, 3, 4, 5, 6]) == -123456\n    assert candidate([10, 15, 20, 25]) == 10152025\n\ndef test_check():\n    check(multiple_to_single)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_adverb_position(text: str) -> Tuple[int, int, str]:\n    \"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('clearly!! we can see the sky') == (0, 7, 'clearly')\n    assert candidate('seriously!! there are many roses') == (0, 9, 'seriously')\n    assert candidate('unfortunately!! sita is going to home') == (0, 13, 'unfortunately')\n\ndef test_check():\n    check(find_adverb_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "py",
+    "prompt": "def surfacearea_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 150\n    assert candidate(3) == 54\n    assert candidate(10) == 600\n\ndef test_check():\n    check(surfacearea_cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef positive_count(nums: List[int]) -> float:\n    \"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56\n\ndef test_check():\n    check(positive_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef largest_neg(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, -4, -6]) == -6\n    assert candidate([1, 2, 3, -8, -9]) == -9\n    assert candidate([1, 2, 3, 4, -1]) == -1\n\ndef test_check():\n    check(largest_neg)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef trim_tuple(test_list: List[List[int]], K: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]]\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]\n    assert candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]]\n\ndef test_check():\n    check(trim_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef index_multiplication(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]]\n\ndef test_check():\n    check(index_multiplication)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "py",
+    "prompt": "from typing import Any, List\n\ndef count_Occurrence(tup: Any, lst: List[Any]) -> int:\n    \"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(('a', 'a', 'c', 'b', 'd'), ['a', 'b']) == 3\n    assert candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6\n    assert candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2\n\ndef test_check():\n    check(count_Occurrence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef cube_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]\n    assert candidate([10, 20, 30]) == [1000, 8000, 27000]\n    assert candidate([12, 15]) == [1728, 3375]\n\ndef test_check():\n    check(cube_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "py",
+    "prompt": "def cal_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(9) == 49\n    assert candidate(10) == 66\n    assert candidate(11) == 88\n\ndef test_check():\n    check(cal_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef extract_string(str: List[str], l: int) -> List[str]:\n    \"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 8) == ['practice', 'solution']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 6) == ['Python']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 9) == ['exercises']\n\ndef test_check():\n    check(extract_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "py",
+    "prompt": "def remove_whitespaces(text1: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(' Google    Flutter ') == 'GoogleFlutter'\n    assert candidate(' Google    Dart ') == 'GoogleDart'\n    assert candidate(' iOS    Swift ') == 'iOSSwift'\n\ndef test_check():\n    check(remove_whitespaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "py",
+    "prompt": "def loss_amount(actual_cost: int, sale_amount: int) -> int:\n    \"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == 0\n    assert candidate(100, 200) == 100\n    assert candidate(2000, 5000) == 3000\n\ndef test_check():\n    check(loss_amount)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "py",
+    "prompt": "def sumofFactors(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(18) == 26\n    assert candidate(30) == 48\n    assert candidate(6) == 8\n\ndef test_check():\n    check(sumofFactors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "py",
+    "prompt": "def text_match_wordz(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('pythonz.') == True\n    assert candidate('xyz.') == True\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "py",
+    "prompt": "def check_monthnumb_number(monthnum2: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(2) == False\n    assert candidate(6) == False\n\ndef test_check():\n    check(check_monthnumb_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef reverse_string_list(stringlist: List[str]) -> List[str]:\n    \"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue', 'White', 'Black']) == ['deR', 'neerG', 'eulB', 'etihW', 'kcalB']\n    assert candidate(['john', 'amal', 'joel', 'george']) == ['nhoj', 'lama', 'leoj', 'egroeg']\n    assert candidate(['jack', 'john', 'mary']) == ['kcaj', 'nhoj', 'yram']\n\ndef test_check():\n    check(reverse_string_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef Find_Min(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1]\n    assert candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1]\n    assert candidate([['x'], ['x', 'y'], ['x', 'y', 'z']]) == ['x']\n\ndef test_check():\n    check(Find_Min)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "py",
+    "prompt": "def rectangle_area(l: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(10, 5) == 50\n    assert candidate(4, 2) == 8\n\ndef test_check():\n    check(rectangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "py",
+    "prompt": "def remove_uppercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'\n    assert candidate('wAtchTheinTernEtrAdIo') == 'wtchheinerntrdo'\n    assert candidate('VoicESeaRchAndreComMendaTionS') == 'oiceachndreomendaion'\n\ndef test_check():\n    check(remove_uppercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Extract(lst: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]\n    assert candidate([[1, 2, 3], [4, 5]]) == [1, 4]\n    assert candidate([[9, 8, 1], [1, 2]]) == [9, 1]\n\ndef test_check():\n    check(Extract)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "py",
+    "prompt": "def upper_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('PYthon') == 1\n    assert candidate('BigData') == 1\n    assert candidate('program') == 0\n\ndef test_check():\n    check(upper_ctr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef combinations_list(list1: List[str]) -> List[Union[List[None], List[str]]]:\n    \"\"\"\n\tWrite a function to find all possible combinations of the elements of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['orange', 'red', 'green', 'blue']) == [[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['blue'], ['blue', 'red'], ['blue', 'green'], ['blue', 'green', 'red'], ['white'], ['white', 'red'], ['white', 'green'], ['white', 'green', 'red'], ['white', 'blue'], ['white', 'blue', 'red'], ['white', 'blue', 'green'], ['white', 'blue', 'green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['black', 'blue'], ['black', 'blue', 'red'], ['black', 'blue', 'green'], ['black', 'blue', 'green', 'red'], ['black', 'white'], ['black', 'white', 'red'], ['black', 'white', 'green'], ['black', 'white', 'green', 'red'], ['black', 'white', 'blue'], ['black', 'white', 'blue', 'red'], ['black', 'white', 'blue', 'green'], ['black', 'white', 'blue', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'blue'], ['orange', 'blue', 'red'], ['orange', 'blue', 'green'], ['orange', 'blue', 'green', 'red'], ['orange', 'white'], ['orange', 'white', 'red'], ['orange', 'white', 'green'], ['orange', 'white', 'green', 'red'], ['orange', 'white', 'blue'], ['orange', 'white', 'blue', 'red'], ['orange', 'white', 'blue', 'green'], ['orange', 'white', 'blue', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red'], ['orange', 'black', 'blue'], ['orange', 'black', 'blue', 'red'], ['orange', 'black', 'blue', 'green'], ['orange', 'black', 'blue', 'green', 'red'], ['orange', 'black', 'white'], ['orange', 'black', 'white', 'red'], ['orange', 'black', 'white', 'green'], ['orange', 'black', 'white', 'green', 'red'], ['orange', 'black', 'white', 'blue'], ['orange', 'black', 'white', 'blue', 'red'], ['orange', 'black', 'white', 'blue', 'green'], ['orange', 'black', 'white', 'blue', 'green', 'red']]\n    assert candidate(['red', 'green', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red']]\n\ndef test_check():\n    check(combinations_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_subarray_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 0, 7, -8, -2]) == 112\n    assert candidate([6, -3, -10, 0, 2]) == 180\n    assert candidate([-2, -40, 0, -2, -3]) == 80\n\ndef test_check():\n    check(max_subarray_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_value(dict: Dict[str, int], n: int) -> bool:\n    \"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 10) == False\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 12) == True\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 5) == False\n\ndef test_check():\n    check(check_value)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "py",
+    "prompt": "from typing import Dict, Optional\n\ndef drop_empty(dict1: Dict[str, Optional[str]]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to drop empty items from a given dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'c1': 'Red', 'c2': 'Green', 'c3': None }) == { 'c1': 'Red', 'c2': 'Green' }\n    assert candidate({ 'c1': 'Red', 'c2': None, 'c3': None }) == { 'c1': 'Red' }\n    assert candidate({ 'c1': None, 'c2': 'Green', 'c3': None }) == { 'c2': 'Green' }\n\ndef test_check():\n    check(drop_empty)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 100, 4, 5, 150, 6]) == 3000\n    assert candidate([4, 42, 55, 68, 80]) == 50265600\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460\n\ndef test_check():\n    check(max_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef add_pairwise(test_tup: Tuple[int, int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18)\n    assert candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20)\n    assert candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22)\n\ndef test_check():\n    check(add_pairwise)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_remainder(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([100, 10, 5, 25, 35, 14], 11) == 9\n    assert candidate([1, 1, 1], 1) == 0\n    assert candidate([1, 2, 1], 2) == 0\n\ndef test_check():\n    check(find_remainder)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_Consecutive(l: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 2, 3, 5, 6]) == False\n    assert candidate([1, 2, 1]) == False\n\ndef test_check():\n    check(check_Consecutive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "py",
+    "prompt": "def replace_char(str1: str, ch: str, newch: str) -> str:\n    \"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('polygon', 'y', 'l') == 'pollgon'\n    assert candidate('character', 'c', 'a') == 'aharaater'\n    assert candidate('python', 'l', 'a') == 'python'\n\ndef test_check():\n    check(replace_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "py",
+    "prompt": "from typing import Dict, List, Tuple\n\ndef sort_counter(dict1: Dict[str, int]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'Math': 81, 'Physics': 83, 'Chemistry': 87 }) == [('Chemistry', 87), ('Physics', 83), ('Math', 81)]\n    assert candidate({ 'Math': 400, 'Physics': 300, 'Chemistry': 250 }) == [('Math', 400), ('Physics', 300), ('Chemistry', 250)]\n    assert candidate({ 'Math': 900, 'Physics': 1000, 'Chemistry': 1250 }) == [('Chemistry', 1250), ('Physics', 1000), ('Math', 900)]\n\ndef test_check():\n    check(sort_counter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef big_sum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 4\n    assert candidate([-1, 2, 3, 4]) == 3\n    assert candidate([2, 3, 6]) == 8\n\ndef test_check():\n    check(big_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "py",
+    "prompt": "def is_lower(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('InValid') == 'invalid'\n    assert candidate('TruE') == 'true'\n    assert candidate('SenTenCE') == 'sentence'\n\ndef test_check():\n    check(is_lower)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "py",
+    "prompt": "def remove_lowercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('PYTHon') == 'PYTH'\n    assert candidate('FInD') == 'FID'\n    assert candidate('STRinG') == 'STRG'\n\ndef test_check():\n    check(remove_lowercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "py",
+    "prompt": "def first_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(123) == 1\n    assert candidate(456) == 4\n    assert candidate(12) == 1\n\ndef test_check():\n    check(first_Digit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef heap_queue_largest(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35]\n\ndef test_check():\n    check(heap_queue_largest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5]\n    assert candidate([10, 11, 12, 13]) == [11, 13]\n    assert candidate([7, 8, 9, 1]) == [7, 9, 1]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "py",
+    "prompt": "def difference(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 30\n    assert candidate(5) == 210\n    assert candidate(2) == 6\n\ndef test_check():\n    check(difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Odd_Pair(A: List[int], N: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1], 5) == 6\n    assert candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12\n    assert candidate([1, 2, 3], 3) == 2\n\ndef test_check():\n    check(find_Odd_Pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "py",
+    "prompt": "def toggle_string(string: str) -> str:\n    \"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Python') == 'pYTHON'\n    assert candidate('Pangram') == 'pANGRAM'\n    assert candidate('LIttLE') == 'liTTle'\n\ndef test_check():\n    check(toggle_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "py",
+    "prompt": "def digit_distance_nums(n1: int, n2: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(23, 56) == 6\n    assert candidate(123, 256) == 7\n\ndef test_check():\n    check(digit_distance_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sub_array_sum(a: List[int], size: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7\n    assert candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8\n    assert candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10\n\ndef test_check():\n    check(max_sub_array_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef union_elements(test_tup1: List[int], test_tup2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10]\n    assert candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6]\n    assert candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17]\n\ndef test_check():\n    check(union_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Find_Max_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4\n    assert candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3\n    assert candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5\n\ndef test_check():\n    check(Find_Max_Length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef extract_values(text: str) -> List[str]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('\"Python\", \"PHP\", \"Java\"') == ['Python', 'PHP', 'Java']\n    assert candidate('\"python\",\"program\",\"language\"') == ['python', 'program', 'language']\n    assert candidate('\"red\",\"blue\",\"green\",\"yellow\"') == ['red', 'blue', 'green', 'yellow']\n\ndef test_check():\n    check(extract_values)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_Pairs(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 1], 3) == 2\n    assert candidate([1, 1, 1, 1], 4) == 0\n    assert candidate([1, 2, 3, 4, 5], 5) == 10\n\ndef test_check():\n    check(count_Pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef split(word: str) -> List[str]:\n    \"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python') == ['p', 'y', 't', 'h', 'o', 'n']\n    assert candidate('Name') == ['N', 'a', 'm', 'e']\n    assert candidate('program') == ['p', 'r', 'o', 'g', 'r', 'a', 'm']\n\ndef test_check():\n    check(split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "py",
+    "prompt": "def sum_digits(n: int) -> int:\n    \"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(345) == 12\n    assert candidate(12) == 3\n    assert candidate(97) == 16\n\ndef test_check():\n    check(sum_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef issort_list(list1: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == True\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == False\n    assert candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == False\n\ndef test_check():\n    check(issort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef empty_list(length: int) -> List[Dict[None, None]]:\n    \"\"\"\n\tWrite a function to create a list of N empty dictionaries.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == [{  }, {  }, {  }, {  }, {  }]\n    assert candidate(6) == [{  }, {  }, {  }, {  }, {  }, {  }]\n    assert candidate(7) == [{  }, {  }, {  }, {  }, {  }, {  }, {  }]\n\ndef test_check():\n    check(empty_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_sublists(list1: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']]) == [['green', 'orange'], ['black'], ['green', 'orange'], ['white']]\n    assert candidate([['a', 'b'], ['d', 'c'], ['g', 'h'], ['f', 'e']]) == [['a', 'b'], ['c', 'd'], ['g', 'h'], ['e', 'f']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "py",
+    "prompt": "def checks(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(70) == False\n    assert candidate(23) == False\n    assert candidate(73) == True\n\ndef test_check():\n    check(checks)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef two_unique_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5]\n    assert candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5]\n\ndef test_check():\n    check(two_unique_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique_product(list_data: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000\n    assert candidate([1, 2, 3, 1]) == 6\n    assert candidate([7, 8, 9, 0, 1, 1]) == 0\n\ndef test_check():\n    check(unique_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "py",
+    "prompt": "def surfacearea_cylinder(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10, 5) == 942.45\n    assert candidate(4, 5) == 226.18800000000002\n    assert candidate(4, 10) == 351.848\n\ndef test_check():\n    check(surfacearea_cylinder)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_Sub_Array(A: List[int], B: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 5], [1, 2]) == False\n    assert candidate([1, 2, 1], [1, 2, 1]) == True\n    assert candidate([1, 0, 2, 2], [2, 2, 0]) == False\n\ndef test_check():\n    check(is_Sub_Array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "py",
+    "prompt": "def last_Digit_Factorial(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4) == 4\n    assert candidate(21) == 0\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit_Factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef interleave_lists(list1: List[int], list2: List[int], list3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]\n    assert candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10]\n    assert candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5]\n\ndef test_check():\n    check(interleave_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_dissimilar(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)\n    assert candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9)\n    assert candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25)\n\ndef test_check():\n    check(find_dissimilar)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Max_Num(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 321\n    assert candidate([4, 5, 6, 1]) == 6541\n    assert candidate([1, 2, 3, 9]) == 9321\n\ndef test_check():\n    check(find_Max_Num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "py",
+    "prompt": "from typing import Tuple, Any\n\ndef extract_even(test_tuple: Tuple[int, int, Tuple[int, int, Tuple[int, int]], int, int]) -> Any:\n    \"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)\n    assert candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8)))\n    assert candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10)\n\ndef test_check():\n    check(extract_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "py",
+    "prompt": "def surface_Area(b: int, s: int) -> int:\n    \"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4) == 33\n    assert candidate(4, 5) == 56\n    assert candidate(1, 2) == 5\n\ndef test_check():\n    check(surface_Area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "py",
+    "prompt": "def catalan_number(num: int) -> int:\n    \"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 16796\n    assert candidate(9) == 4862\n    assert candidate(7) == 429\n\ndef test_check():\n    check(catalan_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "py",
+    "prompt": "def find_adverbs(text: str) -> str:\n    \"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Clearly, he has no excuse for such behavior.') == '0-7: Clearly'\n    assert candidate('Please handle the situation carefuly') == '28-36: carefuly'\n    assert candidate('Complete the task quickly') == '18-25: quickly'\n\ndef test_check():\n    check(find_adverbs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "py",
+    "prompt": "from typing import List, Dict, Union\n\ndef expensive_items(items: List[Dict[str, Union[str, float]]], n: int) -> List[Dict[str, Union[str, float]]]:\n    \"\"\"\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }], 2) == [{ 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-1', 'price': 101.1 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }, { 'name': 'Item-4', 'price': 22.75 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n\ndef test_check():\n    check(expensive_items)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef split_Arr(l: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10]\n    assert candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1]\n    assert candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2]\n\ndef test_check():\n    check(split_Arr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef list_tuple(listx: List[int]) -> Any:\n    \"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3)\n    assert candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7)\n    assert candidate([58, 44, 56]) == (58, 44, 56)\n\ndef test_check():\n    check(list_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef big_diff(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == 3\n    assert candidate([4, 5, 12]) == 8\n    assert candidate([9, 2, 3]) == 7\n\ndef test_check():\n    check(big_diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef perfect_squares(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 30) == [1, 4, 9, 16, 25]\n    assert candidate(50, 100) == [64, 81, 100]\n    assert candidate(100, 200) == [100, 121, 144, 169, 196]\n\ndef test_check():\n    check(perfect_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "py",
+    "prompt": "def opposite_Signs(x: int, y: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, -2) == True\n    assert candidate(3, 2) == False\n    assert candidate(-10, -10) == False\n    assert candidate(-2, 2) == True\n\ndef test_check():\n    check(opposite_Signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "py",
+    "prompt": "def sum_Of_product(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 15\n    assert candidate(4) == 56\n    assert candidate(1) == 1\n\ndef test_check():\n    check(sum_Of_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "py",
+    "prompt": "def removezero_ip(ip: str) -> str:\n    \"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('216.08.094.196') == '216.8.94.196'\n    assert candidate('12.01.024') == '12.1.24'\n    assert candidate('216.08.094.0196') == '216.8.94.196'\n\ndef test_check():\n    check(removezero_ip)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef diff_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1\n    assert candidate([1, 5, 7, 9, 10]) == 9\n\ndef test_check():\n    check(diff_even_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef min_Swaps(str1: str, str2: str) -> Any:\n    \"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('1101', '1110') == 1\n    assert candidate('111', '000') == 'Not Possible'\n    assert candidate('111', '110') == 'Not Possible'\n\ndef test_check():\n    check(min_Swaps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_kth(arr1: List[int], arr2: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6\n    assert candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256\n    assert candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8\n\ndef test_check():\n    check(find_kth)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "py",
+    "prompt": "def armstrong_number(number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(153) == True\n    assert candidate(259) == False\n    assert candidate(4458) == False\n\ndef test_check():\n    check(armstrong_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef sum_average(number: int) -> Tuple[int, float]:\n    \"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == (55, 5.5)\n    assert candidate(15) == (120, 8.0)\n    assert candidate(20) == (210, 10.5)\n\ndef test_check():\n    check(sum_average)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "py",
+    "prompt": "def is_octagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 65\n    assert candidate(10) == 280\n    assert candidate(15) == 645\n\ndef test_check():\n    check(is_octagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "py",
+    "prompt": "def is_Even(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1) == False\n    assert candidate(2) == True\n    assert candidate(3) == False\n\ndef test_check():\n    check(is_Even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef first_repeated_char(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abcabc') == 'a'\n    assert candidate('abc') == None\n    assert candidate('123123') == '1'\n\ndef test_check():\n    check(first_repeated_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_ludic(n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == [1, 2, 3, 5, 7]\n    assert candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25]\n    assert candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]\n\ndef test_check():\n    check(get_ludic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "py",
+    "prompt": "def reverse_words(s: str) -> str:\n    \"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python program') == 'program python'\n    assert candidate('java language') == 'language java'\n    assert candidate('indian man') == 'man indian'\n\ndef test_check():\n    check(reverse_words)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "py",
+    "prompt": "def prime_num(num: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(13) == True\n    assert candidate(7) == True\n    assert candidate(-1010) == False\n\ndef test_check():\n    check(prime_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "py",
+    "prompt": "def radian_degree(degree: int) -> float:\n    \"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(90) == 1.5707963267948966\n    assert candidate(60) == 1.0471975511965976\n    assert candidate(120) == 2.0943951023931953\n\ndef test_check():\n    check(radian_degree)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_literals(text: str, pattern: str) -> Tuple[str, int, int]:\n    \"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)\n    assert candidate('Its been a very crazy procedure right', 'crazy') == ('crazy', 16, 21)\n    assert candidate('Hardest choices required strongest will', 'will') == ('will', 35, 39)\n\ndef test_check():\n    check(find_literals)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "py",
+    "prompt": "def bell_Number(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(3) == 5\n    assert candidate(4) == 15\n\ndef test_check():\n    check(bell_Number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_kth_element(list1: List[int], L: int) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1]\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]\n\ndef test_check():\n    check(remove_kth_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_of_nth(test_list: List[List[int]], N: int) -> int:\n    \"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19\n    assert candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10\n    assert candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11\n\ndef test_check():\n    check(max_of_nth)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef merge(lst: List[List[Any]]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]\n    assert candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]]\n    assert candidate([['x', 'y', 'z'], ['a', 'b', 'c'], ['m', 'n', 'o']]) == [['x', 'a', 'm'], ['y', 'b', 'n'], ['z', 'c', 'o']]\n\ndef test_check():\n    check(merge)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef cummulative_sum(test_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30\n    assert candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37\n    assert candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44\n\ndef test_check():\n    check(cummulative_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef average_tuple(nums: List[List[int]]) -> List[float]:\n    \"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25]\n    assert candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75]\n    assert candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5]\n\ndef test_check():\n    check(average_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef tuple_modulo(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1)\n\ndef test_check():\n    check(tuple_modulo)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef min_Jumps(steps: Tuple[int, int], d: int) -> float:\n    \"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((3, 4), 11) == 3.5\n    assert candidate((3, 4), 0) == 0\n    assert candidate((11, 14), 11) == 1\n\ndef test_check():\n    check(min_Jumps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef div_list(nums1: List[int], nums2: List[int]) -> List[float]:\n    \"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0]\n    assert candidate([3, 2], [1, 4]) == [3.0, 0.5]\n    assert candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142]\n\ndef test_check():\n    check(div_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "py",
+    "prompt": "def move_num(test_str: str) -> str:\n    \"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'\n    assert candidate('Avengers124Assemble') == 'AvengersAssemble124'\n    assert candidate('Its11our12path13to14see15things16do17things') == 'Itsourpathtoseethingsdothings11121314151617'\n\ndef test_check():\n    check(move_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "py",
+    "prompt": "def count_Substrings(s: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('112112') == 6\n    assert candidate('111') == 6\n    assert candidate('1101112') == 12\n\ndef test_check():\n    check(count_Substrings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_median(arr1: List[int], arr2: List[int], n: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0\n    assert candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5\n    assert candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0\n\ndef test_check():\n    check(get_median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef nth_nums(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30], 3) == [1000, 8000, 27000]\n    assert candidate([12, 15], 5) == [248832, 759375]\n\ndef test_check():\n    check(nth_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "py",
+    "prompt": "def is_upper(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('person') == 'PERSON'\n    assert candidate('final') == 'FINAL'\n    assert candidate('Valid') == 'VALID'\n\ndef test_check():\n    check(is_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef triangle_area(r: int) -> Optional[int]:\n    \"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(-1) == None\n    assert candidate(0) == 0\n    assert candidate(2) == 4\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_First_Missing(array: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, 3]) == 4\n    assert candidate([0, 1, 2, 6, 9]) == 3\n    assert candidate([2, 3, 5, 8, 9]) == 0\n\ndef test_check():\n    check(find_First_Missing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "py",
+    "prompt": "def replace_spaces(string: str) -> str:\n    \"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('My Name is Dawood') == 'My%20Name%20is%20Dawood'\n    assert candidate('I am a Programmer') == 'I%20am%20a%20Programmer'\n    assert candidate('I love Coding') == 'I%20love%20Coding'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == [2, 4]\n    assert candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0]\n    assert candidate([8, 12, 15, 19]) == [8, 12]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_num(xs: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 1, 45, 99]) == 1\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([45, 46, 50, 60]) == 45\n\ndef test_check():\n    check(smallest_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "py",
+    "prompt": "from typing import Tuple, List\n\ndef get_coordinates(test_tup: Tuple[int, int]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]\n    assert candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]\n    assert candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]\n\ndef test_check():\n    check(get_coordinates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "py",
+    "prompt": "def replace_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Jumanji The Jungle') == 'Jumanji_The_Jungle'\n    assert candidate('The_Avengers') == 'The Avengers'\n    assert candidate('Fast and Furious') == 'Fast_and_Furious'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef move_zero(num_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0]\n    assert candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0]\n    assert candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0]\n\ndef test_check():\n    check(move_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pair_xor_Sum(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 9, 7, 6], 4) == 47\n    assert candidate([7, 3, 5], 3) == 12\n    assert candidate([7, 3], 2) == 4\n\ndef test_check():\n    check(pair_xor_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef heap_sort(iterable: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate([7, 1, 9, 5]) == [1, 5, 7, 9]\n\ndef test_check():\n    check(heap_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "py",
+    "prompt": "def noprofit_noloss(actual_cost: int, sale_amount: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == False\n    assert candidate(100, 100) == True\n    assert candidate(2000, 5000) == False\n\ndef test_check():\n    check(noprofit_noloss)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "py",
+    "prompt": "def wind_chill(v: int, t: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(120, 35) == 40\n    assert candidate(40, 20) == 19\n    assert candidate(10, 8) == 6\n\ndef test_check():\n    check(wind_chill)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sample_nam(sample_names: List[str]) -> int:\n    \"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith']) == 16\n    assert candidate(['php', 'res', 'Python', 'abcd', 'Java', 'aaa']) == 10\n    assert candidate(['abcd', 'Python', 'abba', 'aba']) == 6\n\ndef test_check():\n    check(sample_nam)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_difference(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7\n    assert candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15\n    assert candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23\n\ndef test_check():\n    check(max_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_parenthesis(items: List[str]) -> str:\n    \"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['python (chrome)']) == 'python'\n    assert candidate(['string(.abc)']) == 'string'\n    assert candidate(['alpha(num)']) == 'alpha'\n\ndef test_check():\n    check(remove_parenthesis)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "py",
+    "prompt": "def is_nonagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 325\n    assert candidate(15) == 750\n    assert candidate(18) == 1089\n\ndef test_check():\n    check(is_nonagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "py",
+    "prompt": "def text_match_wordz_middle(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('pythonzabc.') == True\n    assert candidate('zxyabc.') == False\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz_middle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef reverse_Array_Upto_K(input: List[int], k: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6]\n    assert candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7]\n    assert candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5]\n\ndef test_check():\n    check(reverse_Array_Upto_K)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef subject_marks(subjectmarks: List[Tuple[str, int]]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)]) == [('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]\n    assert candidate([('Telugu', 49), ('Hindhi', 54), ('Social', 33)]) == [('Social', 33), ('Telugu', 49), ('Hindhi', 54)]\n    assert candidate([('Physics', 96), ('Chemistry', 97), ('Biology', 45)]) == [('Biology', 45), ('Physics', 96), ('Chemistry', 97)]\n\ndef test_check():\n    check(subject_marks)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef recursive_list_sum(data_list: List[Union[int, List[int]]]) -> int:\n    \"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, [3, 4], [5, 6]]) == 21\n    assert candidate([7, 10, [15, 14], [19, 41]]) == 106\n    assert candidate([10, 20, [30, 40], [50, 60]]) == 210\n\ndef test_check():\n    check(recursive_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pos_count(list: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, 3, -4]) == 2\n    assert candidate([3, 4, 5, -1]) == 3\n    assert candidate([1, 2, 3, 4]) == 4\n\ndef test_check():\n    check(pos_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "py",
+    "prompt": "def bell_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(10) == 115975\n    assert candidate(56) == 6775685320645824322581483068371419745979053216268760300\n\ndef test_check():\n    check(bell_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_Monotonic(A: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([6, 5, 4, 4]) == True\n    assert candidate([1, 2, 2, 3]) == True\n    assert candidate([1, 3, 2]) == False\n\ndef test_check():\n    check(is_Monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_sublist(l: List[int], s: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 3, 5, 7], [3, 7]) == False\n    assert candidate([2, 4, 3, 5, 7], [4, 3]) == True\n    assert candidate([2, 4, 3, 5, 7], [1, 6]) == False\n\ndef test_check():\n    check(is_sublist)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "py",
+    "prompt": "def differ_At_One_Bit_Pos(a: int, b: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(13, 9) == True\n    assert candidate(15, 8) == False\n    assert candidate(2, 4) == False\n    assert candidate(2, 3) == True\n    assert candidate(5, 1) == True\n    assert candidate(1, 5) == True\n\ndef test_check():\n    check(differ_At_One_Bit_Pos)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_equal(Input: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[11, 22, 33], [44, 55, 66]]) == True\n    assert candidate([[1, 2, 3], [4, 5, 6, 7]]) == False\n    assert candidate([[1, 2], [3, 4]]) == True\n\ndef test_check():\n    check(get_equal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef comb_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]\n    assert candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41]\n    assert candidate([99, 15, 13, 47]) == [13, 15, 47, 99]\n\ndef test_check():\n    check(comb_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "py",
+    "prompt": "from typing import Tuple, Dict\n\ndef add_dict_to_tuple(test_tup: Tuple[int, int, int], test_dict: Dict[str, int]) -> Tuple[int, int, int, Dict[str, int]]:\n    \"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((4, 5, 6), { 'MSAM': 1, 'is': 2, 'best': 3 }) == (4, 5, 6, { 'MSAM': 1, 'is': 2, 'best': 3 })\n    assert candidate((1, 2, 3), { 'UTS': 2, 'is': 3, 'Worst': 4 }) == (1, 2, 3, { 'UTS': 2, 'is': 3, 'Worst': 4 })\n    assert candidate((8, 9, 10), { 'POS': 3, 'is': 4, 'Okay': 5 }) == (8, 9, 10, { 'POS': 3, 'is': 4, 'Okay': 5 })\n\ndef test_check():\n    check(add_dict_to_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef maxAverageOfPath(cost: List[List[int]]) -> float:\n    \"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2\n    assert candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2\n    assert candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8\n\ndef test_check():\n    check(maxAverageOfPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "py",
+    "prompt": "from typing import Dict, Tuple\n\ndef filter_data(students: Dict[str, Tuple[float, int]], h: float, w: int) -> Dict[str, Tuple[float, int]]:\n    \"\"\"\n\tThe input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 6.0, 70) == { 'Cierra Vega': (6.2, 70) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.9, 67) == { 'Cierra Vega': (6.2, 70), 'Kierra Gentry': (6.0, 68) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.7, 64) == { 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }\n\ndef test_check():\n    check(filter_data)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_same_pair(nums1: List[int], nums2: List[int]) -> int:\n    \"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1\n    assert candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3\n\ndef test_check():\n    check(count_same_pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "py",
+    "prompt": "def power_base_sum(base: int, power: int) -> int:\n    \"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 100) == 115\n    assert candidate(8, 10) == 37\n    assert candidate(8, 15) == 62\n    assert candidate(3, 3) == 9\n\ndef test_check():\n    check(power_base_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef extract_quotation(text1: str) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']\n    assert candidate('Cast your \"favorite\" entertainment \"apps\"') == ['favorite', 'apps']\n    assert candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support') == ['4k Ultra HD', 'HDR 10']\n    assert candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == []\n\ndef test_check():\n    check(extract_quotation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef multiply_elements(test_tup: List[int]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80]\n    assert candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42]\n    assert candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135]\n    assert candidate([12]) == []\n\ndef test_check():\n    check(multiply_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_list(lst1: List[int], lst2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65]\n    assert candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10]\n    assert candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105]\n\ndef test_check():\n    check(sum_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "py",
+    "prompt": "def dif_Square(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(10) == False\n    assert candidate(15) == True\n\ndef test_check():\n    check(dif_Square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef consecutive_duplicates(nums: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == ['a', 'b', 'c', 'd']\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd', 'a', 'a']) == ['a', 'b', 'c', 'd', 'a']\n\ndef test_check():\n    check(consecutive_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "py",
+    "prompt": "def lateralsurface_cone(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5, 12) == 204.20352248333654\n    assert candidate(10, 15) == 566.3586699569488\n    assert candidate(19, 17) == 1521.8090132193388\n\ndef test_check():\n    check(lateralsurface_cone)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "py",
+    "prompt": "def replace_specialchar(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Python language, Programming language.') == 'Python:language::Programming:language:'\n    assert candidate('a b c,d e f') == 'a:b:c:d:e:f'\n    assert candidate('ram reshma,ram rahim') == 'ram:reshma:ram:rahim'\n\ndef test_check():\n    check(replace_specialchar)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_first_occurrence(A: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1\n    assert candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2\n    assert candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4\n\ndef test_check():\n    check(find_first_occurrence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_Of_Subarray_Prod(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 20\n    assert candidate([1, 2]) == 5\n    assert candidate([1, 2, 3, 4]) == 84\n\ndef test_check():\n    check(sum_Of_Subarray_Prod)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "py",
+    "prompt": "def toggle_middle_bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(9) == 15\n    assert candidate(10) == 12\n    assert candidate(11) == 13\n    assert candidate(65) == 127\n    assert candidate(77) == 115\n\ndef test_check():\n    check(toggle_middle_bits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef left_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(left_insertion)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "py",
+    "prompt": "def check_str(string: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('annie') == True\n    assert candidate('dawood') == False\n    assert candidate('Else') == True\n\ndef test_check():\n    check(check_str)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "py",
+    "prompt": "def geometric_sum(n: int) -> float:\n    \"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7) == 1.9921875\n    assert candidate(4) == 1.9375\n    assert candidate(8) == 1.99609375\n\ndef test_check():\n    check(geometric_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "py",
+    "prompt": "def find_Index(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 14\n    assert candidate(4) == 45\n\ndef test_check():\n    check(find_Index)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "py",
+    "prompt": "from typing import Tuple, Dict\n\ndef tuple_to_dict(test_tup: Tuple[int, int, int, int, int, int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 10, 13, 5)) == { 1: 5, 7: 10, 13: 5 }\n    assert candidate((1, 2, 3, 4, 5, 6)) == { 1: 2, 3: 4, 5: 6 }\n    assert candidate((7, 8, 9, 10, 11, 12)) == { 7: 8, 9: 10, 11: 12 }\n\ndef test_check():\n    check(tuple_to_dict)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "py",
+    "prompt": "def all_Characters_Same(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('aaa') == True\n    assert candidate('data') == False\n\ndef test_check():\n    check(all_Characters_Same)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "py",
+    "prompt": "def area_tetrahedron(side: int) -> float:\n    \"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3) == 15.588457268119894\n    assert candidate(20) == 692.8203230275509\n    assert candidate(10) == 173.20508075688772\n\ndef test_check():\n    check(area_tetrahedron)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rotate_right(list: List[int], m: int) -> List[int]:\n    \"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5]\n\ndef test_check():\n    check(rotate_right)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef check_none(test_tup: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6, None)) == True\n    assert candidate((7, 8, 9, 11, 14)) == False\n    assert candidate((1, 2, 3, 4, None)) == True\n\ndef test_check():\n    check(check_none)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef divisible_by_digits(startnum: int, endnum: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]\n    assert candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]\n    assert candidate(20, 25) == [22, 24]\n\ndef test_check():\n    check(divisible_by_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef sector_area(r: int, a: int) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(4, 45) == 6.283185307179586\n    assert candidate(9, 45) == 31.808625617596654\n    assert candidate(9, 361) == None\n\ndef test_check():\n    check(sector_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "py",
+    "prompt": "def lcs_of_three(X: str, Y: str, Z: str) -> int:\n    \"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('AGGT12', '12TXAYB', '12XBA') == 2\n    assert candidate('Reels', 'Reelsfor', 'ReelsforReels') == 5\n    assert candidate('abcd1e2', 'bc12ea', 'bd1ea') == 3\n\ndef test_check():\n    check(lcs_of_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "py",
+    "prompt": "def capital_words_spaces(str1: str) -> str:\n    \"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('PythonProgrammingExamples') == 'Python Programming Examples'\n    assert candidate('GetReadyToBeCodingFreak') == 'Get Ready To Be Coding Freak'\n\ndef test_check():\n    check(capital_words_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_numeric_strings(nums_str: List[str]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['4', '12', '45', '7', '0', '100', '200', '-12', '-500']) == [-500, -12, 0, 4, 7, 12, 45, 100, 200]\n    assert candidate(['2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2']) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]\n    assert candidate(['1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11']) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]\n\ndef test_check():\n    check(sort_numeric_strings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_samepatterns(colors: List[str], patterns: List[str]) -> bool:\n    \"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['red', 'green', 'green'], ['a', 'b', 'b']) == True\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b', 'b']) == False\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b']) == False\n\ndef test_check():\n    check(is_samepatterns)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef add_tuple(test_list: List[int], test_tup: Tuple[int, int]) -> List[int]:\n    \"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]\n    assert candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11]\n    assert candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12]\n\ndef test_check():\n    check(add_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_min_heap(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 10, 15]) == True\n    assert candidate([2, 10, 4, 5, 3, 15]) == False\n\ndef test_check():\n    check(check_min_heap)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "py",
+    "prompt": "def jacobsthal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 11\n    assert candidate(2) == 1\n    assert candidate(4) == 5\n    assert candidate(13) == 2731\n\ndef test_check():\n    check(jacobsthal_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef min_k(test_list: List[Tuple[str, int]], K: int) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]\n    assert candidate([('Sanjeev', 11), ('Angat', 5), ('Akash', 3), ('Nepin', 9)], 3) == [('Akash', 3), ('Angat', 5), ('Nepin', 9)]\n    assert candidate([('tanmay', 14), ('Amer', 11), ('Ayesha', 9), ('SKD', 16)], 1) == [('Ayesha', 9)]\n\ndef test_check():\n    check(min_k)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[Any]:\n    \"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7]\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6]\n    assert candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5]\n    assert candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == []\n\ndef test_check():\n    check(extract_index_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Union, Optional\n\ndef second_smallest(numbers: List[Union[int, float]]) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, -8, -2, 0, -2]) == -2\n    assert candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5\n    assert candidate([2, 2]) == None\n    assert candidate([2, 2, 2]) == None\n\ndef test_check():\n    check(second_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "py",
+    "prompt": "def text_match_zero_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('dsabbbba') == True\n    assert candidate('asbbbba') == False\n    assert candidate('abaaa') == True\n\ndef test_check():\n    check(text_match_zero_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_reverse_pairs(test_list: List[str]) -> int:\n    \"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['julia', 'best', 'tseb', 'for', 'ailuj']) == 2\n    assert candidate(['geeks', 'best', 'for', 'skeeg']) == 1\n    assert candidate(['makes', 'best', 'sekam', 'for', 'rof']) == 2\n\ndef test_check():\n    check(count_reverse_pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "py",
+    "prompt": "def is_decimal(num: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('123.11') == True\n    assert candidate('e666.86') == False\n    assert candidate('3.124587') == False\n    assert candidate('1.11') == True\n    assert candidate('1.1.11') == False\n\ndef test_check():\n    check(is_decimal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_tuples(test_list: List[Tuple[int, int, int]], K: int) -> List[Tuple[int, int, int]]:\n    \"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)]\n    assert candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)]\n    assert candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)]\n\ndef test_check():\n    check(find_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique_Element(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 1]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == False\n\ndef test_check():\n    check(unique_Element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "py",
+    "prompt": "def check_monthnumber_number(monthnum3: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(6) == True\n    assert candidate(2) == False\n    assert candidate(12) == False\n\ndef test_check():\n    check(check_monthnumber_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_min_diff(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 3, 19, 18, 25], 6) == 1\n    assert candidate([4, 3, 2, 6], 4) == 1\n    assert candidate([30, 5, 20, 9], 4) == 4\n\ndef test_check():\n    check(find_min_diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "py",
+    "prompt": "def number_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('program2bedone') == 1\n    assert candidate('3wonders') == 1\n    assert candidate('123') == 3\n    assert candidate('3wond-1ers2') == 3\n\ndef test_check():\n    check(number_ctr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "py",
+    "prompt": "def is_polite(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(7) == 11\n    assert candidate(4) == 7\n    assert candidate(9) == 13\n\ndef test_check():\n    check(is_polite)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef pair_wise(l1: List[int]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]\n    assert candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)]\n    assert candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]\n\ndef test_check():\n    check(pair_wise)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_pairs_count(arr: List[int], sum: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 1, 1], 2) == 6\n    assert candidate([1, 5, 7, -1, 5], 6) == 3\n    assert candidate([1, -2, 3], 1) == 1\n    assert candidate([-1, -2, 3], -3) == 1\n\ndef test_check():\n    check(get_pairs_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Diff(li1: List[int], li2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15]\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7]\n\ndef test_check():\n    check(Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "py",
+    "prompt": "def odd_num_sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2) == 82\n    assert candidate(3) == 707\n    assert candidate(4) == 3108\n\ndef test_check():\n    check(odd_num_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "py",
+    "prompt": "def check_expression(exp: str) -> bool:\n    \"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('{()}[{}]') == True\n    assert candidate('{()}[{]') == False\n    assert candidate('{()}[{}][]({})') == True\n\ndef test_check():\n    check(check_expression)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "py",
+    "prompt": "def remove_length(test_str: str, K: int) -> str:\n    \"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('The person is most value tet', 3) == 'person is most value'\n    assert candidate('If you told me about this ok', 4) == 'If you me about ok'\n    assert candidate('Forces of darkeness is come into the play', 4) == 'Forces of darkeness is the'\n\ndef test_check():\n    check(remove_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "py",
+    "prompt": "from typing import Optional, Tuple\n\ndef occurance_substring(text: str, pattern: str) -> Optional[Tuple[str, int, int]]:\n    \"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python programming, python language', 'python') == ('python', 0, 6)\n    assert candidate('python programming,programming language', 'programming') == ('programming', 7, 18)\n    assert candidate('python programming,programming language', 'language') == ('language', 31, 39)\n    assert candidate('c++ programming, c++ language', 'python') == None\n\ndef test_check():\n    check(occurance_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef odd_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 4, 3, 6, 7, 6, 3]) == True\n    assert candidate([4, 1, 2]) == True\n    assert candidate([1, 2, 3]) == False\n\ndef test_check():\n    check(odd_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "py",
+    "prompt": "def count_vowels(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('bestinstareels') == 7\n    assert candidate('partofthejourneyistheend') == 12\n    assert candidate('amazonprime') == 5\n\ndef test_check():\n    check(count_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21\n    assert candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71\n    assert candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78\n\ndef test_check():\n    check(find_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef pack_consecutive_duplicates(list1: List[Any]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == [['a', 'a'], ['b'], ['c'], ['d', 'd']]\n\ndef test_check():\n    check(pack_consecutive_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "py",
+    "prompt": "def is_Diff(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(12345) == False\n    assert candidate(1212112) == True\n    assert candidate(1212) == False\n\ndef test_check():\n    check(is_Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_combinations(test_list: List[Tuple[int, int]]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]\n\ndef test_check():\n    check(find_combinations)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "py",
+    "prompt": "def count_divisors(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(100) == False\n    assert candidate(125) == True\n\ndef test_check():\n    check(count_divisors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef odd_length_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4]) == 14\n    assert candidate([1, 2, 1, 2]) == 15\n    assert candidate([1, 7]) == 8\n\ndef test_check():\n    check(odd_length_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rgb_to_hsv(r: int, g: int, b: int) -> List[float]:\n    \"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(255, 255, 255) == [0.0, 0.0, 100.0]\n    assert candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608]\n    assert candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608]\n\ndef test_check():\n    check(rgb_to_hsv)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mul_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([1, 5, 7, 9, 10]) == 10\n\ndef test_check():\n    check(mul_even_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef tuple_str_int(test_str: str) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('(7, 8, 9)') == (7, 8, 9)\n    assert candidate('(1, 2, 3)') == (1, 2, 3)\n    assert candidate('(4, 5, 6)') == (4, 5, 6)\n    assert candidate('(7, 81, 19)') == (7, 81, 19)\n\ndef test_check():\n    check(tuple_str_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef right_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(right_insertion)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "py",
+    "prompt": "def text_match_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('caacabbbba') == True\n\ndef test_check():\n    check(text_match_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef new_tuple(test_list: List[str], test_str: str) -> Tuple[str, str, str]:\n    \"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['WEB', 'is'], 'best') == ('WEB', 'is', 'best')\n    assert candidate(['We', 'are'], 'Developers') == ('We', 'are', 'Developers')\n    assert candidate(['Part', 'is'], 'Wrong') == ('Part', 'is', 'Wrong')\n\ndef test_check():\n    check(new_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef even_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 3]) == False\n    assert candidate([2, 1, 4]) == True\n\ndef test_check():\n    check(even_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "py",
+    "prompt": "from typing import Any, Tuple\n\ndef remove_nested(test_tup: Any) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)\n    assert candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11)\n    assert candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12)\n    assert candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12)\n\ndef test_check():\n    check(remove_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_list(input_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4\n    assert candidate([[1, 2], [2, 3], [4, 5]]) == 3\n    assert candidate([[1, 0], [2, 0]]) == 2\n\ndef test_check():\n    check(count_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef last(arr: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 1) == 0\n    assert candidate([1, 1, 1, 2, 3, 4], 1) == 2\n    assert candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3\n\ndef test_check():\n    check(last)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "py",
+    "prompt": "def text_starta_endb(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aabbbb') == True\n    assert candidate('aabAbbbc') == False\n    assert candidate('accddbbjjj') == False\n\ndef test_check():\n    check(text_starta_endb)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef return_sum(dict: Dict[str, int]) -> int:\n    \"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'a': 100, 'b': 200, 'c': 300 }) == 600\n    assert candidate({ 'a': 25, 'b': 18, 'c': 45 }) == 88\n    assert candidate({ 'a': 36, 'b': 39, 'c': 49 }) == 124\n\ndef test_check():\n    check(return_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "py",
+    "prompt": "def sum_in_range(l: int, r: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(2, 5) == 8\n    assert candidate(5, 7) == 12\n    assert candidate(7, 13) == 40\n\ndef test_check():\n    check(sum_in_range)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef _sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([15, 12, 13, 10]) == 50\n    assert candidate([0, 1, 2]) == 3\n\ndef test_check():\n    check(_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "py",
+    "prompt": "def left_rotate(n: int, d: int) -> int:\n    \"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == 64\n    assert candidate(10, 2) == 40\n    assert candidate(99, 3) == 792\n    assert candidate(99, 3) == 792\n    assert candidate(1, 3) == 8\n    assert candidate(5, 3) == 40\n    assert candidate(29, 3) == 232\n\ndef test_check():\n    check(left_rotate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "py",
+    "prompt": "def word_len(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('Hadoop') == False\n    assert candidate('great') == True\n    assert candidate('structure') == True\n\ndef test_check():\n    check(word_len)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "py",
+    "prompt": "def remove_all_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('python  program') == 'pythonprogram'\n    assert candidate('python   programming    language') == 'pythonprogramminglanguage'\n    assert candidate('python                     program') == 'pythonprogram'\n    assert candidate('   python                     program') == 'pythonprogram'\n\ndef test_check():\n    check(remove_all_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "py",
+    "prompt": "def test_three_equal(x: int, y: int, z: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1, 1, 1) == 3\n    assert candidate(-1, -2, -3) == 0\n    assert candidate(1, 2, 2) == 2\n\ndef test_check():\n    check(test_three_equal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_rotation(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == 1\n    assert candidate([4, 5, 1, 2, 3]) == 2\n    assert candidate([7, 8, 9, 1, 2, 3]) == 3\n    assert candidate([1, 2, 3]) == 0\n    assert candidate([1, 3, 2]) == 2\n\ndef test_check():\n    check(count_rotation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "py",
+    "prompt": "def is_perfect_square(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == False\n    assert candidate(36) == True\n    assert candidate(14) == False\n    assert candidate(196) == True\n    assert candidate(125) == False\n    assert candidate(15625) == True\n\ndef test_check():\n    check(is_perfect_square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_product_even(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 4]) == True\n    assert candidate([1, 1]) == False\n\ndef test_check():\n    check(is_product_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum_list(lists: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12]\n    assert candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10]\n    assert candidate([[2, 3, 1]]) == [2, 3, 1]\n\ndef test_check():\n    check(max_sum_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "py",
+    "prompt": "def max_run_uppercase(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('GeMKSForGERksISBESt') == 5\n    assert candidate('PrECIOusMOVemENTSYT') == 6\n    assert candidate('GooGLEFluTTER') == 4\n\ndef test_check():\n    check(max_run_uppercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef first_odd(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5]) == 1\n    assert candidate([2, 4, 1, 3]) == 1\n    assert candidate([8, 9, 1]) == 9\n\ndef test_check():\n    check(first_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_K(test_tup: List[int], K: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 4, 5, 6, 8], 6) == True\n    assert candidate([1, 2, 3, 4, 5, 6], 7) == False\n    assert candidate([7, 8, 9, 44, 11, 12], 11) == True\n\ndef test_check():\n    check(check_K)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef check_smaller(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> bool:\n    \"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate((1, 2, 3), (2, 3, 4)) == False\n    assert candidate((4, 5, 6), (3, 4, 5)) == True\n    assert candidate((11, 12, 13), (10, 11, 12)) == True\n\ndef test_check():\n    check(check_smaller)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "py",
+    "prompt": "def tetrahedral_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(5) == 35\n    assert candidate(6) == 56\n    assert candidate(7) == 84\n\ndef test_check():\n    check(tetrahedral_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "py",
+    "prompt": "def get_Char(strr: str) -> str:\n    \"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('abc') == 'f'\n    assert candidate('gfg') == 't'\n    assert candidate('ab') == 'c'\n\ndef test_check():\n    check(get_Char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "py",
+    "prompt": "def sequence(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 6\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n\ndef test_check():\n    check(sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "py",
+    "prompt": "def centered_hexagonal_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(10) == 271\n    assert candidate(2) == 7\n    assert candidate(9) == 217\n\ndef test_check():\n    check(centered_hexagonal_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef merge_dictionaries_three(dict1: Dict[str, str], dict2: Dict[str, str], dict3: Dict[str, str]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'O': 'Orange', 'W': 'White', 'B': 'Black' }) == { 'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'L': 'lavender', 'B': 'Blue' }) == { 'W': 'White', 'P': 'Pink', 'B': 'Black', 'R': 'Red', 'G': 'Green', 'L': 'lavender' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'L': 'lavender', 'B': 'Blue' }, { 'G': 'Green', 'W': 'White' }) == { 'B': 'Black', 'P': 'Pink', 'R': 'Red', 'G': 'Green', 'L': 'lavender', 'W': 'White' }\n\ndef test_check():\n    check(merge_dictionaries_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef freq_count(list1: List[int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == { 10: 4, 20: 4, 40: 2, 50: 2, 30: 1 }\n    assert candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == { 1: 3, 2: 2, 3: 3, 4: 3 }\n    assert candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == { 10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2 }\n\ndef test_check():\n    check(freq_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "py",
+    "prompt": "def closest_num(N: int) -> int:\n    \"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(11) == 10\n    assert candidate(7) == 6\n    assert candidate(12) == 11\n\ndef test_check():\n    check(closest_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef square_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30]) == [100, 400, 900]\n    assert candidate([12, 15]) == [144, 225]\n\ndef test_check():\n    check(square_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef len_log(list1: List[str]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['python', 'PHP', 'bigdata']) == 7\n    assert candidate(['a', 'ab', 'abc']) == 3\n    assert candidate(['small', 'big', 'tall']) == 5\n\ndef test_check():\n    check(len_log)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_substring(str1: List[str], sub_str: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ack') == True\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'abc') == False\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ange') == True\n\ndef test_check():\n    check(find_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "py",
+    "prompt": "def is_undulating(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(1212121) == True\n    assert candidate(1991) == False\n    assert candidate(121) == True\n\ndef test_check():\n    check(is_undulating)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "py",
+    "prompt": "def power(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(3, 4) == 81\n    assert candidate(2, 3) == 8\n    assert candidate(5, 5) == 3125\n\ndef test_check():\n    check(power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef index_minimum(test_list: List[Tuple[str, int]]) -> str:\n    \"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'\n    assert candidate([('Yash', 185), ('Dawood', 125), ('Sanya', 175)]) == 'Dawood'\n    assert candidate([('Sai', 345), ('Salman', 145), ('Ayesha', 96)]) == 'Ayesha'\n\ndef test_check():\n    check(index_minimum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Find_Min_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2]]) == 1\n    assert candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2\n    assert candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3\n\ndef test_check():\n    check(Find_Min_Length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "py",
+    "prompt": "def divisor(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(15) == 4\n    assert candidate(12) == 6\n    assert candidate(9) == 3\n\ndef test_check():\n    check(divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef frequency_lists(list1: List[List[int]]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == { 1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 }\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1 }\n    assert candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == { 20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1 }\n\ndef test_check():\n    check(frequency_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(n: int) -> str:\n    \"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate(8) == '1000'\n    assert candidate(18) == '10010'\n    assert candidate(7) == '111'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "py",
+    "prompt": "def find_Rotations(str: str) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "def check(candidate):\n    assert candidate('aaaa') == 1\n    assert candidate('ab') == 2\n    assert candidate('abc') == 3\n\ndef test_check():\n    check(find_Rotations)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/mbpp-py-reworded.json
+++ b/prompts/mbpp-py-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "py",
-    "prompt": "def lps(str: str) -> int:\n    \"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('TENS FOR TENS') == 5\n    assert candidate('CARDIO FOR CARDS') == 7\n    assert candidate('PART OF THE JOURNEY IS PART') == 9\n\ndef test_check():\n    check(lps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "py",
-    "prompt": "def remove_whitespaces(text1: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(' Google    Flutter ') == 'GoogleFlutter'\n    assert candidate(' Google    Dart ') == 'GoogleDart'\n    assert candidate(' iOS    Swift ') == 'iOSSwift'\n\ndef test_check():\n    check(remove_whitespaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef issort_list(list1: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == True\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == False\n    assert candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == False\n\ndef test_check():\n    check(issort_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef count_bidirectional(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3\n    assert candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4\n\ndef test_check():\n    check(count_bidirectional)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "py",
-    "prompt": "def surfacearea_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 150\n    assert candidate(3) == 54\n    assert candidate(10) == 600\n\ndef test_check():\n    check(surfacearea_cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "py",
     "prompt": "def next_smallest_palindrome(num: int) -> int:\n    \"\"\"\n\tWrite a function to find the next smallest palindrome of a specified integer, returned as an integer.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate(99) == 101\n    assert candidate(1221) == 1331\n    assert candidate(120) == 121\n\ndef test_check():\n    check(next_smallest_palindrome)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "py",
-    "prompt": "def cube_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 72\n    assert candidate(3) == 288\n    assert candidate(4) == 800\n\ndef test_check():\n    check(cube_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pair_xor_Sum(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 9, 7, 6], 4) == 47\n    assert candidate([7, 3, 5], 3) == 12\n    assert candidate([7, 3], 2) == 4\n\ndef test_check():\n    check(pair_xor_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_min_heap(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 10, 15]) == True\n    assert candidate([2, 10, 4, 5, 3, 15]) == False\n\ndef test_check():\n    check(check_min_heap)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "py",
-    "prompt": "def first_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(123) == 1\n    assert candidate(456) == 4\n    assert candidate(12) == 1\n\ndef test_check():\n    check(first_Digit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef first_non_repeating_character(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abcabc') == None\n    assert candidate('abc') == 'a'\n    assert candidate('ababc') == 'c'\n\ndef test_check():\n    check(first_non_repeating_character)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "py",
-    "prompt": "def radian_degree(degree: int) -> float:\n    \"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(90) == 1.5707963267948966\n    assert candidate(60) == 1.0471975511965976\n    assert candidate(120) == 2.0943951023931953\n\ndef test_check():\n    check(radian_degree)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_subarray_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 0, 7, -8, -2]) == 112\n    assert candidate([6, -3, -10, 0, 2]) == 180\n    assert candidate([-2, -40, 0, -2, -3]) == 80\n\ndef test_check():\n    check(max_subarray_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef convert_list_dictionary(l1: List[str], l2: List[str], l3: List[int]) -> List[Dict[str, Dict[str, int]]]:\n    \"\"\"\n\tWrite a function to convert more than one list to nested dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['S001', 'S002', 'S003', 'S004'], ['Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'], [85, 98, 89, 92]) == [{ 'S001': { 'Adina Park': 85 } }, { 'S002': { 'Leyton Marsh': 98 } }, { 'S003': { 'Duncan Boyle': 89 } }, { 'S004': { 'Saim Richards': 92 } }]\n    assert candidate(['abc', 'def', 'ghi', 'jkl'], ['python', 'program', 'language', 'programs'], [100, 200, 300, 400]) == [{ 'abc': { 'python': 100 } }, { 'def': { 'program': 200 } }, { 'ghi': { 'language': 300 } }, { 'jkl': { 'programs': 400 } }]\n    assert candidate(['A1', 'A2', 'A3', 'A4'], ['java', 'C', 'C++', 'DBMS'], [10, 20, 30, 40]) == [{ 'A1': { 'java': 10 } }, { 'A2': { 'C': 20 } }, { 'A3': { 'C++': 30 } }, { 'A4': { 'DBMS': 40 } }]\n\ndef test_check():\n    check(convert_list_dictionary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef smallest_num(xs: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 1, 45, 99]) == 1\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([45, 46, 50, 60]) == 45\n\ndef test_check():\n    check(smallest_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "py",
-    "prompt": "def text_match_zero_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('dsabbbba') == True\n    assert candidate('asbbbba') == False\n    assert candidate('abaaa') == True\n\ndef test_check():\n    check(text_match_zero_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "py",
-    "prompt": "def bell_Number(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(3) == 5\n    assert candidate(4) == 15\n\ndef test_check():\n    check(bell_Number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef cube_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]\n    assert candidate([10, 20, 30]) == [1000, 8000, 27000]\n    assert candidate([12, 15]) == [1728, 3375]\n\ndef test_check():\n    check(cube_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "py",
-    "prompt": "def last_Digit_Factorial(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4) == 4\n    assert candidate(21) == 0\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit_Factorial)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == [2, 4]\n    assert candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0]\n    assert candidate([8, 12, 15, 19]) == [8, 12]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "py",
-    "prompt": "def prime_num(num: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(13) == True\n    assert candidate(7) == True\n    assert candidate(-1010) == False\n\ndef test_check():\n    check(prime_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_tuples(test_list: List[Tuple[int, int, int]], K: int) -> List[Tuple[int, int, int]]:\n    \"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)]\n    assert candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)]\n    assert candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)]\n\ndef test_check():\n    check(find_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "py",
-    "prompt": "def area_tetrahedron(side: int) -> float:\n    \"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 15.588457268119894\n    assert candidate(20) == 692.8203230275509\n    assert candidate(10) == 173.20508075688772\n\ndef test_check():\n    check(area_tetrahedron)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "py",
-    "prompt": "def is_Even(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == False\n    assert candidate(2) == True\n    assert candidate(3) == False\n\ndef test_check():\n    check(is_Even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef pos_count(list: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, -2, 3, -4]) == 2\n    assert candidate([3, 4, 5, -1]) == 3\n    assert candidate([1, 2, 3, 4]) == 4\n\ndef test_check():\n    check(pos_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_ludic(n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == [1, 2, 3, 5, 7]\n    assert candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25]\n    assert candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]\n\ndef test_check():\n    check(get_ludic)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "py",
-    "prompt": "def find_Index(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 14\n    assert candidate(4) == 45\n\ndef test_check():\n    check(find_Index)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef reverse_Array_Upto_K(input: List[int], k: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6]\n    assert candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7]\n    assert candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5]\n\ndef test_check():\n    check(reverse_Array_Upto_K)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef subject_marks(subjectmarks: List[Tuple[str, int]]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)]) == [('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]\n    assert candidate([('Telugu', 49), ('Hindhi', 54), ('Social', 33)]) == [('Social', 33), ('Telugu', 49), ('Hindhi', 54)]\n    assert candidate([('Physics', 96), ('Chemistry', 97), ('Biology', 45)]) == [('Biology', 45), ('Physics', 96), ('Chemistry', 97)]\n\ndef test_check():\n    check(subject_marks)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "py",
-    "prompt": "def remove_dirty_chars(string: str, second_string: str) -> str:\n    \"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('probasscurve', 'pros') == 'bacuve'\n    assert candidate('digitalindia', 'talent') == 'digiidi'\n    assert candidate('exoticmiles', 'toxic') == 'emles'\n\ndef test_check():\n    check(remove_dirty_chars)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef round_and_sum(list1: List[Union[float, int]]) -> int:\n    \"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243\n    assert candidate([5, 2, 9, 24.3, 29]) == 345\n    assert candidate([25.0, 56.7, 89.2]) == 513\n\ndef test_check():\n    check(round_and_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_occurrences(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8\n    assert candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20\n\ndef test_check():\n    check(max_occurrences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "py",
-    "prompt": "def is_decimal(num: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('123.11') == True\n    assert candidate('e666.86') == False\n    assert candidate('3.124587') == False\n    assert candidate('1.11') == True\n    assert candidate('1.1.11') == False\n\ndef test_check():\n    check(is_decimal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef dict_filter(dict: Dict[str, int], n: int) -> Dict[str, int]:\n    \"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 170) == { 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 180) == { 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 190) == { 'Pierre Cox': 190 }\n\ndef test_check():\n    check(dict_filter)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_even_and_even_index(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 12, 1, 18, 8]) == 30\n    assert candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26\n    assert candidate([5, 6, 12, 1]) == 12\n\ndef test_check():\n    check(sum_even_and_even_index)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sub_array_sum(a: List[int], size: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7\n    assert candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8\n    assert candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10\n\ndef test_check():\n    check(max_sub_array_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef intersection_array(array_nums1: List[int], array_nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10]\n\ndef test_check():\n    check(intersection_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef split_two_parts(list1: List[Any], L: int) -> Any:\n    \"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1])\n    assert candidate(['a', 'b', 'c', 'd'], 2) == (['a', 'b'], ['c', 'd'])\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'], 4) == (['p', 'y', 't', 'h'], ['o', 'n'])\n\ndef test_check():\n    check(split_two_parts)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_literals(text: str, pattern: str) -> Tuple[str, int, int]:\n    \"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)\n    assert candidate('Its been a very crazy procedure right', 'crazy') == ('crazy', 16, 21)\n    assert candidate('Hardest choices required strongest will', 'will') == ('will', 35, 39)\n\ndef test_check():\n    check(find_literals)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "py",
-    "prompt": "def find_Volume(l: int, b: int, h: int) -> int:\n    \"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 8, 6) == 240\n    assert candidate(3, 2, 2) == 6\n    assert candidate(1, 2, 1) == 1\n\ndef test_check():\n    check(find_Volume)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "py",
-    "prompt": "def wind_chill(v: int, t: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(120, 35) == 40\n    assert candidate(40, 20) == 19\n    assert candidate(10, 8) == 6\n\ndef test_check():\n    check(wind_chill)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "py",
-    "prompt": "def ascii_value(k: str) -> int:\n    \"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('A') == 65\n    assert candidate('R') == 82\n    assert candidate('S') == 83\n\ndef test_check():\n    check(ascii_value)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "py",
-    "prompt": "def all_Characters_Same(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('aaa') == True\n    assert candidate('data') == False\n\ndef test_check():\n    check(all_Characters_Same)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "py",
-    "prompt": "def move_num(test_str: str) -> str:\n    \"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'\n    assert candidate('Avengers124Assemble') == 'AvengersAssemble124'\n    assert candidate('Its11our12path13to14see15things16do17things') == 'Itsourpathtoseethingsdothings11121314151617'\n\ndef test_check():\n    check(move_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "py",
-    "prompt": "def word_len(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Hadoop') == False\n    assert candidate('great') == True\n    assert candidate('structure') == True\n\ndef test_check():\n    check(word_len)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "py",
-    "prompt": "from typing import Dict, Optional\n\ndef drop_empty(dict1: Dict[str, Optional[str]]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to drop empty items from a given dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'c1': 'Red', 'c2': 'Green', 'c3': None }) == { 'c1': 'Red', 'c2': 'Green' }\n    assert candidate({ 'c1': 'Red', 'c2': None, 'c3': None }) == { 'c1': 'Red' }\n    assert candidate({ 'c1': None, 'c2': 'Green', 'c3': None }) == { 'c2': 'Green' }\n\ndef test_check():\n    check(drop_empty)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef insert_element(list: List[str], element: str) -> List[str]:\n    \"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Black'], 'c') == ['c', 'Red', 'c', 'Green', 'c', 'Black']\n    assert candidate(['python', 'java'], 'program') == ['program', 'python', 'program', 'java']\n    assert candidate(['happy', 'sad'], 'laugh') == ['laugh', 'happy', 'laugh', 'sad']\n\ndef test_check():\n    check(insert_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "py",
-    "prompt": "def remove_lowercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('PYTHon') == 'PYTH'\n    assert candidate('FInD') == 'FID'\n    assert candidate('STRinG') == 'STRG'\n\ndef test_check():\n    check(remove_lowercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "py",
-    "prompt": "def count_Set_Bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 1\n    assert candidate(6) == 2\n\ndef test_check():\n    check(count_Set_Bits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "py",
-    "prompt": "from typing import Tuple, List\n\ndef extract_rear(test_tuple: Tuple[str, str, str]) -> List[str]:\n    \"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(('Mers', 'for', 'Vers')) == ['s', 'r', 's']\n    assert candidate(('Avenge', 'for', 'People')) == ['e', 'r', 'e']\n    assert candidate(('Gotta', 'get', 'go')) == ['a', 't', 'o']\n\ndef test_check():\n    check(extract_rear)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "py",
-    "prompt": "def count_occurance(s: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('letstdlenstdporstd') == 3\n    assert candidate('truststdsolensporsd') == 1\n    assert candidate('makestdsostdworthit') == 2\n    assert candidate('stds') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(count_occurance)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_K(test_tup: List[int], K: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 4, 5, 6, 8], 6) == True\n    assert candidate([1, 2, 3, 4, 5, 6], 7) == False\n    assert candidate([7, 8, 9, 44, 11, 12], 11) == True\n\ndef test_check():\n    check(check_K)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef interleave_lists(list1: List[int], list2: List[int], list3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]\n    assert candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10]\n    assert candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5]\n\ndef test_check():\n    check(interleave_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "py",
-    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python_program') == 'PythonProgram'\n    assert candidate('python_language') == 'PythonLanguage'\n    assert candidate('programming_language') == 'ProgrammingLanguage'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "py",
-    "prompt": "def test_three_equal(x: int, y: int, z: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 1, 1) == 3\n    assert candidate(-1, -2, -3) == 0\n    assert candidate(1, 2, 2) == 2\n\ndef test_check():\n    check(test_three_equal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_length_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4]) == 14\n    assert candidate([1, 2, 1, 2]) == 15\n    assert candidate([1, 7]) == 8\n\ndef test_check():\n    check(odd_length_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "py",
-    "prompt": "def bell_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(10) == 115975\n    assert candidate(56) == 6775685320645824322581483068371419745979053216268760300\n\ndef test_check():\n    check(bell_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "py",
-    "prompt": "def rectangle_area(l: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(10, 5) == 50\n    assert candidate(4, 2) == 8\n\ndef test_check():\n    check(rectangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef sum_average(number: int) -> Tuple[int, float]:\n    \"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == (55, 5.5)\n    assert candidate(15) == (120, 8.0)\n    assert candidate(20) == (210, 10.5)\n\ndef test_check():\n    check(sum_average)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef division_elements(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3)\n    assert candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4)\n    assert candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2)\n\ndef test_check():\n    check(division_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "py",
-    "prompt": "def sum_digits(n: int) -> int:\n    \"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(345) == 12\n    assert candidate(12) == 3\n    assert candidate(97) == 16\n\ndef test_check():\n    check(sum_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef index_minimum(test_list: List[Tuple[str, int]]) -> str:\n    \"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'\n    assert candidate([('Yash', 185), ('Dawood', 125), ('Sanya', 175)]) == 'Dawood'\n    assert candidate([('Sai', 345), ('Salman', 145), ('Ayesha', 96)]) == 'Ayesha'\n\ndef test_check():\n    check(index_minimum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef div_list(nums1: List[int], nums2: List[int]) -> List[float]:\n    \"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0]\n    assert candidate([3, 2], [1, 4]) == [3.0, 0.5]\n    assert candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142]\n\ndef test_check():\n    check(div_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_length_list(input_list: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5])\n    assert candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9])\n\ndef test_check():\n    check(max_length_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef combinations_list(list1: List[str]) -> List[Union[List[None], List[str]]]:\n    \"\"\"\n\tWrite a function to find all possible combinations of the elements of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['orange', 'red', 'green', 'blue']) == [[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['blue'], ['blue', 'red'], ['blue', 'green'], ['blue', 'green', 'red'], ['white'], ['white', 'red'], ['white', 'green'], ['white', 'green', 'red'], ['white', 'blue'], ['white', 'blue', 'red'], ['white', 'blue', 'green'], ['white', 'blue', 'green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['black', 'blue'], ['black', 'blue', 'red'], ['black', 'blue', 'green'], ['black', 'blue', 'green', 'red'], ['black', 'white'], ['black', 'white', 'red'], ['black', 'white', 'green'], ['black', 'white', 'green', 'red'], ['black', 'white', 'blue'], ['black', 'white', 'blue', 'red'], ['black', 'white', 'blue', 'green'], ['black', 'white', 'blue', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'blue'], ['orange', 'blue', 'red'], ['orange', 'blue', 'green'], ['orange', 'blue', 'green', 'red'], ['orange', 'white'], ['orange', 'white', 'red'], ['orange', 'white', 'green'], ['orange', 'white', 'green', 'red'], ['orange', 'white', 'blue'], ['orange', 'white', 'blue', 'red'], ['orange', 'white', 'blue', 'green'], ['orange', 'white', 'blue', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red'], ['orange', 'black', 'blue'], ['orange', 'black', 'blue', 'red'], ['orange', 'black', 'blue', 'green'], ['orange', 'black', 'blue', 'green', 'red'], ['orange', 'black', 'white'], ['orange', 'black', 'white', 'red'], ['orange', 'black', 'white', 'green'], ['orange', 'black', 'white', 'green', 'red'], ['orange', 'black', 'white', 'blue'], ['orange', 'black', 'white', 'blue', 'red'], ['orange', 'black', 'white', 'blue', 'green'], ['orange', 'black', 'white', 'blue', 'green', 'red']]\n    assert candidate(['red', 'green', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red']]\n\ndef test_check():\n    check(combinations_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef big_sum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 4\n    assert candidate([-1, 2, 3, 4]) == 3\n    assert candidate([2, 3, 6]) == 8\n\ndef test_check():\n    check(big_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef neg_nos(list1: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([-1, 4, 5, -6]) == [-1, -6]\n    assert candidate([-1, -2, 3, 4]) == [-1, -2]\n    assert candidate([-7, -6, 8, 9]) == [-7, -6]\n\ndef test_check():\n    check(neg_nos)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "py",
-    "prompt": "def highest_Power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n\ndef test_check():\n    check(highest_Power_of_2)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_sublist(l: List[int], s: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, 3, 5, 7], [3, 7]) == False\n    assert candidate([2, 4, 3, 5, 7], [4, 3]) == True\n    assert candidate([2, 4, 3, 5, 7], [1, 6]) == False\n\ndef test_check():\n    check(is_sublist)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sub_list(nums1: List[int], nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3]\n    assert candidate([1, 2], [3, 4]) == [-2, -2]\n    assert candidate([90, 120], [50, 70]) == [40, 50]\n\ndef test_check():\n    check(sub_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "py",
-    "prompt": "def opposite_Signs(x: int, y: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, -2) == True\n    assert candidate(3, 2) == False\n    assert candidate(-10, -10) == False\n    assert candidate(-2, 2) == True\n\ndef test_check():\n    check(opposite_Signs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_modulo(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1)\n\ndef test_check():\n    check(tuple_modulo)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef diff_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1\n    assert candidate([1, 5, 7, 9, 10]) == 9\n\ndef test_check():\n    check(diff_even_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_sublists(list1: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']]) == [['green', 'orange'], ['black'], ['green', 'orange'], ['white']]\n    assert candidate([['a', 'b'], ['d', 'c'], ['g', 'h'], ['f', 'e']]) == [['a', 'b'], ['c', 'd'], ['g', 'h'], ['e', 'f']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "py",
-    "prompt": "def last_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(123) == 3\n    assert candidate(25) == 5\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "py",
-    "prompt": "def odd_num_sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 82\n    assert candidate(3) == 707\n    assert candidate(4) == 3108\n\ndef test_check():\n    check(odd_num_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef tup_string(tup1: List[str]) -> str:\n    \"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's']) == 'exercises'\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n']) == 'python'\n    assert candidate(['p', 'r', 'o', 'g', 'r', 'a', 'm']) == 'program'\n\ndef test_check():\n    check(tup_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_elements(list1: List[int], list2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10]\n\ndef test_check():\n    check(remove_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef overlapping(list1: List[int], list2: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == False\n    assert candidate([1, 2, 3], [4, 5, 6]) == False\n    assert candidate([1, 4, 5], [1, 4, 5]) == True\n\ndef test_check():\n    check(overlapping)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "py",
-    "prompt": "def is_not_prime(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == False\n    assert candidate(10) == True\n    assert candidate(35) == True\n    assert candidate(37) == False\n\ndef test_check():\n    check(is_not_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef max_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 5\n    assert candidate(['Python', 15, 20, 25]) == 25\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 50\n\ndef test_check():\n    check(max_val)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_negativenum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32\n    assert candidate([10, 15, -14, 13, -18, 12, -20]) == -52\n    assert candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894\n\ndef test_check():\n    check(sum_negativenum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "py",
-    "prompt": "def find_Rotations(str: str) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('aaaa') == 1\n    assert candidate('ab') == 2\n    assert candidate('abc') == 3\n\ndef test_check():\n    check(find_Rotations)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "py",
-    "prompt": "def change_date_format(dt: str) -> str:\n    \"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('2026-01-02') == '02-01-2026'\n    assert candidate('2020-11-13') == '13-11-2020'\n    assert candidate('2021-04-26') == '26-04-2021'\n\ndef test_check():\n    check(change_date_format)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5]\n    assert candidate([10, 11, 12, 13]) == [11, 13]\n    assert candidate([7, 8, 9, 1]) == [7, 9, 1]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "py",
-    "prompt": "def toggle_middle_bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(9) == 15\n    assert candidate(10) == 12\n    assert candidate(11) == 13\n    assert candidate(65) == 127\n    assert candidate(77) == 115\n\ndef test_check():\n    check(toggle_middle_bits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "py",
-    "prompt": "def count_char_position(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('xbcefg') == 2\n    assert candidate('ABcED') == 3\n    assert candidate('AbgdeF') == 5\n\ndef test_check():\n    check(count_char_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef large_product(nums1: List[int], nums2: List[int], N: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45]\n\ndef test_check():\n    check(large_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef cummulative_sum(test_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30\n    assert candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37\n    assert candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44\n\ndef test_check():\n    check(cummulative_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_min_diff(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 3, 19, 18, 25], 6) == 1\n    assert candidate([4, 3, 2, 6], 4) == 1\n    assert candidate([30, 5, 20, 9], 4) == 4\n\ndef test_check():\n    check(find_min_diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "py",
-    "prompt": "def text_starta_endb(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('aabbbb') == True\n    assert candidate('aabAbbbc') == False\n    assert candidate('accddbbjjj') == False\n\ndef test_check():\n    check(text_starta_endb)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "py",
-    "prompt": "def left_rotate(n: int, d: int) -> int:\n    \"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(16, 2) == 64\n    assert candidate(10, 2) == 40\n    assert candidate(99, 3) == 792\n    assert candidate(99, 3) == 792\n    assert candidate(1, 3) == 8\n    assert candidate(5, 3) == 40\n    assert candidate(29, 3) == 232\n\ndef test_check():\n    check(left_rotate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef first_repeated_char(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abcabc') == 'a'\n    assert candidate('abc') == None\n    assert candidate('123123') == '1'\n\ndef test_check():\n    check(first_repeated_char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_Inv_Count(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 20, 6, 4, 5]) == 5\n    assert candidate([1, 2, 1]) == 1\n    assert candidate([1, 2, 5, 6, 1]) == 3\n\ndef test_check():\n    check(get_Inv_Count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "py",
-    "prompt": "def even_Power_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 1056\n    assert candidate(3) == 8832\n    assert candidate(1) == 32\n\ndef test_check():\n    check(even_Power_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_equal(Input: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[11, 22, 33], [44, 55, 66]]) == True\n    assert candidate([[1, 2, 3], [4, 5, 6, 7]]) == False\n    assert candidate([[1, 2], [3, 4]]) == True\n\ndef test_check():\n    check(get_equal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "py",
-    "prompt": "def check_integer(text: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('1') == True\n    assert candidate('12345') == True\n\ndef test_check():\n    check(check_integer)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_reverse_pairs(test_list: List[str]) -> int:\n    \"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['julia', 'best', 'tseb', 'for', 'ailuj']) == 2\n    assert candidate(['geeks', 'best', 'for', 'skeeg']) == 1\n    assert candidate(['makes', 'best', 'sekam', 'for', 'rof']) == 2\n\ndef test_check():\n    check(count_reverse_pairs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef move_zero(num_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0]\n    assert candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0]\n    assert candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0]\n\ndef test_check():\n    check(move_zero)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_distinct(test_tup: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 5, 6, 1, 4]) == False\n    assert candidate([1, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 6]) == True\n\ndef test_check():\n    check(check_distinct)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "py",
-    "prompt": "def noprofit_noloss(actual_cost: int, sale_amount: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == False\n    assert candidate(100, 100) == True\n    assert candidate(2000, 5000) == False\n\ndef test_check():\n    check(noprofit_noloss)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "py",
-    "prompt": "def remove_length(test_str: str, K: int) -> str:\n    \"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('The person is most value tet', 3) == 'person is most value'\n    assert candidate('If you told me about this ok', 4) == 'If you me about ok'\n    assert candidate('Forces of darkeness is come into the play', 4) == 'Forces of darkeness is the'\n\ndef test_check():\n    check(remove_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "py",
-    "prompt": "def number_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('program2bedone') == 1\n    assert candidate('3wonders') == 1\n    assert candidate('123') == 3\n    assert candidate('3wond-1ers2') == 3\n\ndef test_check():\n    check(number_ctr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "py",
-    "prompt": "def count_charac(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python programming') == 18\n    assert candidate('language') == 8\n    assert candidate('words') == 5\n\ndef test_check():\n    check(count_charac)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "py",
-    "prompt": "def get_total_number_of_sequences(m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 4) == 4\n    assert candidate(5, 2) == 6\n    assert candidate(16, 3) == 84\n\ndef test_check():\n    check(get_total_number_of_sequences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef left_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(left_insertion)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef swap_numbers(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == [20, 10]\n    assert candidate(15, 17) == [17, 15]\n    assert candidate(100, 200) == [200, 100]\n\ndef test_check():\n    check(swap_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_majority(arr: List[int], n: int, x: int) -> bool:\n    \"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == True\n    assert candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == False\n    assert candidate([1, 1, 1, 2, 2], 5, 1) == True\n    assert candidate([1, 1, 2, 2], 5, 1) == False\n\ndef test_check():\n    check(is_majority)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef substract_elements(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13)\n    assert candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13)\n    assert candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3)\n\ndef test_check():\n    check(substract_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "py",
-    "prompt": "def capital_words_spaces(str1: str) -> str:\n    \"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('PythonProgrammingExamples') == 'Python Programming Examples'\n    assert candidate('GetReadyToBeCodingFreak') == 'Get Ready To Be Coding Freak'\n\ndef test_check():\n    check(capital_words_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "py",
-    "prompt": "def find_Average_Of_Cube(n: int) -> float:\n    \"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 4.5\n    assert candidate(3) == 12\n    assert candidate(1) == 1\n\ndef test_check():\n    check(find_Average_Of_Cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef check_value(dict: Dict[str, int], n: int) -> bool:\n    \"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 10) == False\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 12) == True\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 5) == False\n\ndef test_check():\n    check(check_value)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "py",
-    "prompt": "def tetrahedral_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 35\n    assert candidate(6) == 56\n    assert candidate(7) == 84\n\ndef test_check():\n    check(tetrahedral_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef magic_square_test(my_matrix: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == False\n\ndef test_check():\n    check(magic_square_test)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "py",
-    "prompt": "def remove_uppercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'\n    assert candidate('wAtchTheinTernEtrAdIo') == 'wtchheinerntrdo'\n    assert candidate('VoicESeaRchAndreComMendaTionS') == 'oiceachndreomendaion'\n\ndef test_check():\n    check(remove_uppercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "py",
-    "prompt": "from typing import List, Union, Any\n\ndef check_tuplex(tuplex: List[Union[str, int]], tuple1: Any) -> bool:\n    \"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 'r') == True\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], '5') == False\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 3) == True\n\ndef test_check():\n    check(check_tuplex)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "py",
-    "prompt": "def dog_age(h_age: int) -> int:\n    \"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(12) == 61\n    assert candidate(15) == 73\n    assert candidate(24) == 109\n\ndef test_check():\n    check(dog_age)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "py",
-    "prompt": "def next_Perfect_Square(N: int) -> int:\n    \"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(35) == 36\n    assert candidate(6) == 9\n    assert candidate(9) == 16\n\ndef test_check():\n    check(next_Perfect_Square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef empty_list(length: int) -> List[Dict[None, None]]:\n    \"\"\"\n\tWrite a function to create a list of N empty dictionaries.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == [{  }, {  }, {  }, {  }, {  }]\n    assert candidate(6) == [{  }, {  }, {  }, {  }, {  }, {  }]\n    assert candidate(7) == [{  }, {  }, {  }, {  }, {  }, {  }, {  }]\n\ndef test_check():\n    check(empty_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "py",
-    "prompt": "def is_upper(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('person') == 'PERSON'\n    assert candidate('final') == 'FINAL'\n    assert candidate('Valid') == 'VALID'\n\ndef test_check():\n    check(is_upper)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "py",
-    "prompt": "def odd_Equivalent(s: str, n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('011001', 6) == 3\n    assert candidate('11011', 5) == 4\n    assert candidate('1010', 4) == 2\n\ndef test_check():\n    check(odd_Equivalent)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef re_arrange_array(arr: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]\n    assert candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15]\n    assert candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85]\n\ndef test_check():\n    check(re_arrange_array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_Element(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 1]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == False\n\ndef test_check():\n    check(unique_Element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef extract_values(text: str) -> List[str]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('\"Python\", \"PHP\", \"Java\"') == ['Python', 'PHP', 'Java']\n    assert candidate('\"python\",\"program\",\"language\"') == ['python', 'program', 'language']\n    assert candidate('\"red\",\"blue\",\"green\",\"yellow\"') == ['red', 'blue', 'green', 'yellow']\n\ndef test_check():\n    check(extract_values)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count(lst: List[bool]) -> int:\n    \"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([True, False, True]) == 2\n    assert candidate([False, False]) == 0\n    assert candidate([True, True, True]) == 3\n\ndef test_check():\n    check(count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_even_pair(A: List[int]) -> int:\n    \"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1]) == 4\n    assert candidate([7, 2, 8, 1, 0, 5, 11]) == 9\n    assert candidate([1, 2, 3]) == 1\n\ndef test_check():\n    check(find_even_pair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "py",
-    "prompt": "def armstrong_number(number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(153) == True\n    assert candidate(259) == False\n    assert candidate(4458) == False\n\ndef test_check():\n    check(armstrong_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "py",
-    "prompt": "def upper_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('PYthon') == 1\n    assert candidate('BigData') == 1\n    assert candidate('program') == 0\n\ndef test_check():\n    check(upper_ctr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef and_tuples(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)\n    assert candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0)\n    assert candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0)\n\ndef test_check():\n    check(and_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_samepatterns(colors: List[str], patterns: List[str]) -> bool:\n    \"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['red', 'green', 'green'], ['a', 'b', 'b']) == True\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b', 'b']) == False\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b']) == False\n\ndef test_check():\n    check(is_samepatterns)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_list(input_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4\n    assert candidate([[1, 2], [2, 3], [4, 5]]) == 3\n    assert candidate([[1, 0], [2, 0]]) == 2\n\ndef test_check():\n    check(count_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef average_tuple(nums: List[List[int]]) -> List[float]:\n    \"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25]\n    assert candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75]\n    assert candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5]\n\ndef test_check():\n    check(average_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "py",
-    "prompt": "def lcs_of_three(X: str, Y: str, Z: str) -> int:\n    \"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('AGGT12', '12TXAYB', '12XBA') == 2\n    assert candidate('Reels', 'Reelsfor', 'ReelsforReels') == 5\n    assert candidate('abcd1e2', 'bc12ea', 'bd1ea') == 3\n\ndef test_check():\n    check(lcs_of_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "py",
-    "prompt": "def find_star_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 37\n    assert candidate(4) == 73\n    assert candidate(5) == 121\n\ndef test_check():\n    check(find_star_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef _sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([15, 12, 13, 10]) == 50\n    assert candidate([0, 1, 2]) == 3\n\ndef test_check():\n    check(_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_Consecutive(l: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 2, 3, 5, 6]) == False\n    assert candidate([1, 2, 1]) == False\n\ndef test_check():\n    check(check_Consecutive)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_adverb_position(text: str) -> Tuple[int, int, str]:\n    \"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('clearly!! we can see the sky') == (0, 7, 'clearly')\n    assert candidate('seriously!! there are many roses') == (0, 9, 'seriously')\n    assert candidate('unfortunately!! sita is going to home') == (0, 13, 'unfortunately')\n\ndef test_check():\n    check(find_adverb_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rotate_right(list: List[int], m: int) -> List[int]:\n    \"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5]\n\ndef test_check():\n    check(rotate_right)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "py",
-    "prompt": "def number_of_substrings(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abc') == 6\n    assert candidate('abcd') == 10\n    assert candidate('abcde') == 15\n\ndef test_check():\n    check(number_of_substrings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef list_split(S: List[Any], step: int) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'], 3) == [['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]\n    assert candidate(['python', 'java', 'C', 'C++', 'DBMS', 'SQL'], 2) == [['python', 'C', 'DBMS'], ['java', 'C++', 'SQL']]\n\ndef test_check():\n    check(list_split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef all_unique(test_list: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == True\n\ndef test_check():\n    check(all_unique)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef convert(numbers: int) -> Tuple[float, float]:\n    \"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1) == (1.0, 0.0)\n    assert candidate(4) == (4.0, 0.0)\n    assert candidate(5) == (5.0, 0.0)\n\ndef test_check():\n    check(convert)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "py",
-    "prompt": "from typing import Dict, Tuple\n\ndef filter_data(students: Dict[str, Tuple[float, int]], h: float, w: int) -> Dict[str, Tuple[float, int]]:\n    \"\"\"\n\tThe input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 6.0, 70) == { 'Cierra Vega': (6.2, 70) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.9, 67) == { 'Cierra Vega': (6.2, 70), 'Kierra Gentry': (6.0, 68) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.7, 64) == { 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }\n\ndef test_check():\n    check(filter_data)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "py",
-    "prompt": "def is_lower(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('InValid') == 'invalid'\n    assert candidate('TruE') == 'true'\n    assert candidate('SenTenCE') == 'sentence'\n\ndef test_check():\n    check(is_lower)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "py",
-    "prompt": "def next_power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(0) == 1\n    assert candidate(5) == 8\n    assert candidate(17) == 32\n\ndef test_check():\n    check(next_power_of_2)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_substring(str1: List[str], sub_str: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ack') == True\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'abc') == False\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ange') == True\n\ndef test_check():\n    check(find_substring)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "py",
-    "prompt": "def replace_char(str1: str, ch: str, newch: str) -> str:\n    \"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('polygon', 'y', 'l') == 'pollgon'\n    assert candidate('character', 'c', 'a') == 'aharaater'\n    assert candidate('python', 'l', 'a') == 'python'\n\ndef test_check():\n    check(replace_char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef mul_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([1, 5, 7, 9, 10]) == 10\n\ndef test_check():\n    check(mul_even_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef list_tuple(listx: List[int]) -> Any:\n    \"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3)\n    assert candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7)\n    assert candidate([58, 44, 56]) == (58, 44, 56)\n\ndef test_check():\n    check(list_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "py",
-    "prompt": "def even_binomial_Coeff_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4) == 8\n    assert candidate(6) == 32\n    assert candidate(2) == 2\n\ndef test_check():\n    check(even_binomial_Coeff_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef bitwise_xor(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)\n    assert candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14)\n    assert candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13)\n\ndef test_check():\n    check(bitwise_xor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_Sub_Array(A: List[int], B: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 5], [1, 2]) == False\n    assert candidate([1, 2, 1], [1, 2, 1]) == True\n    assert candidate([1, 0, 2, 2], [2, 2, 0]) == False\n\ndef test_check():\n    check(is_Sub_Array)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sub_array_sum_repeated(a: List[int], n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, -30, -1], 4, 3) == 30\n    assert candidate([-1, 10, 20], 3, 2) == 59\n    assert candidate([-1, -2, -3], 3, 3) == -1\n\ndef test_check():\n    check(max_sub_array_sum_repeated)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef min_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 30\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100\n\ndef test_check():\n    check(min_product_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "py",
-    "prompt": "def count_divisors(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(100) == False\n    assert candidate(125) == True\n\ndef test_check():\n    check(count_divisors)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef triangle_area(r: int) -> Optional[int]:\n    \"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(-1) == None\n    assert candidate(0) == 0\n    assert candidate(2) == 4\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef string_to_tuple(str1: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python 3.0') == ['p', 'y', 't', 'h', 'o', 'n', '3', '.', '0']\n    assert candidate('item1') == ['i', 't', 'e', 'm', '1']\n    assert candidate('15.10') == ['1', '5', '.', '1', '0']\n\ndef test_check():\n    check(string_to_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "py",
-    "prompt": "def find_length(string: str) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('11000010001') == 6\n    assert candidate('10111') == 1\n    assert candidate('11011101100101') == 2\n\ndef test_check():\n    check(find_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "py",
-    "prompt": "def count_Primes_nums(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 2\n    assert candidate(10) == 4\n    assert candidate(100) == 25\n\ndef test_check():\n    check(count_Primes_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "py",
-    "prompt": "def sum_Of_product(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 15\n    assert candidate(4) == 56\n    assert candidate(1) == 1\n\ndef test_check():\n    check(sum_Of_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_aggregate(stdata: List[Tuple[str, int]]) -> Tuple[str, int]:\n    \"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([('Juan Whelan', 90), ('Sabah Colley', 88), ('Peter Nichols', 7), ('Juan Whelan', 122), ('Sabah Colley', 84)]) == ('Juan Whelan', 212)\n    assert candidate([('Juan Whelan', 50), ('Sabah Colley', 48), ('Peter Nichols', 37), ('Juan Whelan', 22), ('Sabah Colley', 14)]) == ('Juan Whelan', 72)\n    assert candidate([('Juan Whelan', 10), ('Sabah Colley', 20), ('Peter Nichols', 30), ('Juan Whelan', 40), ('Sabah Colley', 50)]) == ('Sabah Colley', 70)\n\ndef test_check():\n    check(max_aggregate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef comb_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]\n    assert candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41]\n    assert candidate([99, 15, 13, 47]) == [13, 15, 47, 99]\n\ndef test_check():\n    check(comb_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "py",
-    "prompt": "def check_expression(exp: str) -> bool:\n    \"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('{()}[{}]') == True\n    assert candidate('{()}[{]') == False\n    assert candidate('{()}[{}][]({})') == True\n\ndef test_check():\n    check(check_expression)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "py",
-    "prompt": "def text_match_wordz(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('pythonz.') == True\n    assert candidate('xyz.') == True\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_list(lst1: List[int], lst2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65]\n    assert candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10]\n    assert candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105]\n\ndef test_check():\n    check(sum_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "py",
-    "prompt": "def newman_prime(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 7\n    assert candidate(4) == 17\n    assert candidate(5) == 41\n\ndef test_check():\n    check(newman_prime)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef add_string(list_: List[Any], string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], 'temp{0}') == ['temp1', 'temp2', 'temp3', 'temp4']\n    assert candidate(['a', 'b', 'c', 'd'], 'python{0}') == ['pythona', 'pythonb', 'pythonc', 'pythond']\n    assert candidate([5, 6, 7, 8], 'string{0}') == ['string5', 'string6', 'string7', 'string8']\n\ndef test_check():\n    check(add_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "py",
-    "prompt": "def surface_Area(b: int, s: int) -> int:\n    \"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 4) == 33\n    assert candidate(4, 5) == 56\n    assert candidate(1, 2) == 5\n\ndef test_check():\n    check(surface_Area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Find_Min_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2]]) == 1\n    assert candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2\n    assert candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3\n\ndef test_check():\n    check(Find_Min_Length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "py",
-    "prompt": "def validate(n: int) -> bool:\n    \"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1234) == True\n    assert candidate(51241) == False\n    assert candidate(321) == True\n\ndef test_check():\n    check(validate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "py",
-    "prompt": "def hexagonal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 190\n    assert candidate(5) == 45\n    assert candidate(7) == 91\n\ndef test_check():\n    check(hexagonal_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "py",
-    "prompt": "def find_lucas(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(9) == 76\n    assert candidate(4) == 7\n    assert candidate(3) == 4\n\ndef test_check():\n    check(find_lucas)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Diff(li1: List[int], li2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15]\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7]\n\ndef test_check():\n    check(Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef extract_quotation(text1: str) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']\n    assert candidate('Cast your \"favorite\" entertainment \"apps\"') == ['favorite', 'apps']\n    assert candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support') == ['4k Ultra HD', 'HDR 10']\n    assert candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == []\n\ndef test_check():\n    check(extract_quotation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef recursive_list_sum(data_list: List[Union[int, List[int]]]) -> int:\n    \"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, [3, 4], [5, 6]]) == 21\n    assert candidate([7, 10, [15, 14], [19, 41]]) == 106\n    assert candidate([10, 20, [30, 40], [50, 60]]) == 210\n\ndef test_check():\n    check(recursive_list_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "py",
-    "prompt": "def differ_At_One_Bit_Pos(a: int, b: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(13, 9) == True\n    assert candidate(15, 8) == False\n    assert candidate(2, 4) == False\n    assert candidate(2, 3) == True\n    assert candidate(5, 1) == True\n    assert candidate(1, 5) == True\n\ndef test_check():\n    check(differ_At_One_Bit_Pos)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "py",
-    "prompt": "def text_match_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('caacabbbba') == True\n\ndef test_check():\n    check(text_match_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 100, 4, 5, 150, 6]) == 3000\n    assert candidate([4, 42, 55, 68, 80]) == 50265600\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460\n\ndef test_check():\n    check(max_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef split_Arr(l: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10]\n    assert candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1]\n    assert candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2]\n\ndef test_check():\n    check(split_Arr)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "py",
-    "prompt": "def divisor(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(15) == 4\n    assert candidate(12) == 6\n    assert candidate(9) == 3\n\ndef test_check():\n    check(divisor)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef big_diff(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == 3\n    assert candidate([4, 5, 12]) == 8\n    assert candidate([9, 2, 3]) == 7\n\ndef test_check():\n    check(big_diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef square_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30]) == [100, 400, 900]\n    assert candidate([12, 15]) == [144, 225]\n\ndef test_check():\n    check(square_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef check_none(test_tup: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6, None)) == True\n    assert candidate((7, 8, 9, 11, 14)) == False\n    assert candidate((1, 2, 3, 4, None)) == True\n\ndef test_check():\n    check(check_none)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_Monotonic(A: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([6, 5, 4, 4]) == True\n    assert candidate([1, 2, 2, 3]) == True\n    assert candidate([1, 3, 2]) == False\n\ndef test_check():\n    check(is_Monotonic)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "py",
-    "prompt": "def is_perfect_square(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == False\n    assert candidate(36) == True\n    assert candidate(14) == False\n    assert candidate(196) == True\n    assert candidate(125) == False\n    assert candidate(15625) == True\n\ndef test_check():\n    check(is_perfect_square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "py",
-    "prompt": "def sum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 15) == 6\n    assert candidate(100, 150) == 93\n    assert candidate(4, 6) == 3\n\ndef test_check():\n    check(sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_length(list1: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15])\n    assert candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25])\n\ndef test_check():\n    check(max_length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Dict\n\ndef check_occurences(test_list: List[Tuple[int, int]]) -> Dict[Tuple[int, int], int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == { (1, 3): 2, (2, 5): 2, (3, 6): 1 }\n    assert candidate([(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == { (2, 4): 2, (3, 6): 2, (4, 7): 1 }\n    assert candidate([(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == { (2, 13): 1, (11, 23): 1, (12, 25): 2, (16, 23): 1 }\n\ndef test_check():\n    check(check_occurences)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "py",
-    "prompt": "def parabola_directrix(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5, 3, 2) == -198\n    assert candidate(9, 8, 4) == -2336\n    assert candidate(2, 4, 6) == -130\n\ndef test_check():\n    check(parabola_directrix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "py",
-    "prompt": "from typing import Optional, Tuple\n\ndef occurance_substring(text: str, pattern: str) -> Optional[Tuple[str, int, int]]:\n    \"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python programming, python language', 'python') == ('python', 0, 6)\n    assert candidate('python programming,programming language', 'programming') == ('programming', 7, 18)\n    assert candidate('python programming,programming language', 'language') == ('language', 31, 39)\n    assert candidate('c++ programming, c++ language', 'python') == None\n\ndef test_check():\n    check(occurance_substring)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "py",
-    "prompt": "from typing import Any, Tuple\n\ndef remove_nested(test_tup: Any) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)\n    assert candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11)\n    assert candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12)\n    assert candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12)\n\ndef test_check():\n    check(remove_nested)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_sublists(input_list: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([[' red ', 'green'], ['blue ', ' black'], [' orange', 'brown']]) == [[' red ', 'green'], [' black', 'blue '], [' orange', 'brown']]\n    assert candidate([['zilver', 'gold'], ['magnesium', 'aluminium'], ['steel', 'bronze']]) == [['gold', 'zilver'], ['aluminium', 'magnesium'], ['bronze', 'steel']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_kth_element(list1: List[int], L: int) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1]\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]\n\ndef test_check():\n    check(remove_kth_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "py",
-    "prompt": "from typing import Tuple, Dict\n\ndef add_dict_to_tuple(test_tup: Tuple[int, int, int], test_dict: Dict[str, int]) -> Tuple[int, int, int, Dict[str, int]]:\n    \"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((4, 5, 6), { 'MSAM': 1, 'is': 2, 'best': 3 }) == (4, 5, 6, { 'MSAM': 1, 'is': 2, 'best': 3 })\n    assert candidate((1, 2, 3), { 'UTS': 2, 'is': 3, 'Worst': 4 }) == (1, 2, 3, { 'UTS': 2, 'is': 3, 'Worst': 4 })\n    assert candidate((8, 9, 10), { 'POS': 3, 'is': 4, 'Okay': 5 }) == (8, 9, 10, { 'POS': 3, 'is': 4, 'Okay': 5 })\n\ndef test_check():\n    check(add_dict_to_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "py",
-    "prompt": "def find(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 3) == 3\n    assert candidate(4, 2) == 2\n    assert candidate(20, 5) == 4\n\ndef test_check():\n    check(find)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "py",
-    "prompt": "def text_match_two_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n\ndef test_check():\n    check(text_match_two_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "py",
-    "prompt": "from typing import Any, List\n\ndef count_Occurrence(tup: Any, lst: List[Any]) -> int:\n    \"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(('a', 'a', 'c', 'b', 'd'), ['a', 'b']) == 3\n    assert candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6\n    assert candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2\n\ndef test_check():\n    check(count_Occurrence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_samepair(list1: List[int], list2: List[int], list3: List[int]) -> int:\n    \"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4\n    assert candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5\n\ndef test_check():\n    check(count_samepair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "py",
-    "prompt": "def text_match_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abba') == True\n\ndef test_check():\n    check(text_match_one)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "py",
-    "prompt": "def difference(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 30\n    assert candidate(5) == 210\n    assert candidate(2) == 6\n\ndef test_check():\n    check(difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "py",
-    "prompt": "def toggle_string(string: str) -> str:\n    \"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Python') == 'pYTHON'\n    assert candidate('Pangram') == 'pANGRAM'\n    assert candidate('LIttLE') == 'liTTle'\n\ndef test_check():\n    check(toggle_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef Find_Max(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([['A'], ['A', 'B'], ['A', 'B', 'C']]) == ['A', 'B', 'C']\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3]\n    assert candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1]\n\ndef test_check():\n    check(Find_Max)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "py",
-    "prompt": "def eulerian_num(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 1) == 4\n    assert candidate(4, 1) == 11\n    assert candidate(5, 3) == 26\n\ndef test_check():\n    check(eulerian_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef frequency(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 4) == 0\n    assert candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3\n    assert candidate([0, 1, 2, 3, 1, 2], 1) == 2\n\ndef test_check():\n    check(frequency)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_numeric_strings(nums_str: List[str]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['4', '12', '45', '7', '0', '100', '200', '-12', '-500']) == [-500, -12, 0, 4, 7, 12, 45, 100, 200]\n    assert candidate(['2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2']) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]\n    assert candidate(['1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11']) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]\n\ndef test_check():\n    check(sort_numeric_strings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "py",
-    "prompt": "def geometric_sum(n: int) -> float:\n    \"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(7) == 1.9921875\n    assert candidate(4) == 1.9375\n    assert candidate(8) == 1.99609375\n\ndef test_check():\n    check(geometric_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef divisible_by_digits(startnum: int, endnum: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]\n    assert candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]\n    assert candidate(20, 25) == [22, 24]\n\ndef test_check():\n    check(divisible_by_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef unique_product(list_data: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000\n    assert candidate([1, 2, 3, 1]) == 6\n    assert candidate([7, 8, 9, 0, 1, 1]) == 0\n\ndef test_check():\n    check(unique_product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef largest_neg(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, -4, -6]) == -6\n    assert candidate([1, 2, 3, -8, -9]) == -9\n    assert candidate([1, 2, 3, 4, -1]) == -1\n\ndef test_check():\n    check(largest_neg)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef consecutive_duplicates(nums: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == ['a', 'b', 'c', 'd']\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd', 'a', 'a']) == ['a', 'b', 'c', 'd', 'a']\n\ndef test_check():\n    check(consecutive_duplicates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef min_Jumps(steps: Tuple[int, int], d: int) -> float:\n    \"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((3, 4), 11) == 3.5\n    assert candidate((3, 4), 0) == 0\n    assert candidate((11, 14), 11) == 1\n\ndef test_check():\n    check(min_Jumps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_Product(arr: List[int]) -> Tuple[int, int]:\n    \"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8)\n    assert candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6)\n    assert candidate([1, 2, 3]) == (2, 3)\n\ndef test_check():\n    check(max_Product)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "py",
-    "prompt": "from typing import List, Tuple, Any\n\ndef extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 0) == ['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 2) == [99, 96, 94, 98]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 1) == [98, 97, 91, 94]\n\ndef test_check():\n    check(extract_nth_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "py",
-    "prompt": "def is_nonagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 325\n    assert candidate(15) == 750\n    assert candidate(18) == 1089\n\ndef test_check():\n    check(is_nonagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_Abs_Diff(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 3]) == 4\n    assert candidate([9, 3, 2, 5, 1]) == 8\n    assert candidate([3, 2, 1]) == 2\n\ndef test_check():\n    check(max_Abs_Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef pack_consecutive_duplicates(list1: List[Any]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == [['a', 'a'], ['b'], ['c'], ['d', 'd']]\n\ndef test_check():\n    check(pack_consecutive_duplicates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "py",
-    "prompt": "def cal_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(9) == 49\n    assert candidate(10) == 66\n    assert candidate(11) == 88\n\ndef test_check():\n    check(cal_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "py",
-    "prompt": "def odd_values_string(str: str) -> str:\n    \"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abcdef') == 'ace'\n    assert candidate('python') == 'pto'\n    assert candidate('data') == 'dt'\n    assert candidate('lambs') == 'lms'\n\ndef test_check():\n    check(odd_values_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_kth(arr1: List[int], arr2: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6\n    assert candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256\n    assert candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8\n\ndef test_check():\n    check(find_kth)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "py",
-    "prompt": "def jacobsthal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 11\n    assert candidate(2) == 1\n    assert candidate(4) == 5\n    assert candidate(13) == 2731\n\ndef test_check():\n    check(jacobsthal_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef frequency_lists(list1: List[List[int]]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == { 1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 }\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1 }\n    assert candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == { 20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1 }\n\ndef test_check():\n    check(frequency_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef perfect_squares(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 30) == [1, 4, 9, 16, 25]\n    assert candidate(50, 100) == [64, 81, 100]\n    assert candidate(100, 200) == [100, 121, 144, 169, 196]\n\ndef test_check():\n    check(perfect_squares)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_Of_Subarray_Prod(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 20\n    assert candidate([1, 2]) == 5\n    assert candidate([1, 2, 3, 4]) == 84\n\ndef test_check():\n    check(sum_Of_Subarray_Prod)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef first_odd(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5]) == 1\n    assert candidate([2, 4, 1, 3]) == 1\n    assert candidate([8, 9, 1]) == 9\n\ndef test_check():\n    check(first_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef add_nested_tuples(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]]\n\ndef test_check():\n    check(add_nested_tuples)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef merge(lst: List[List[Any]]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]\n    assert candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]]\n    assert candidate([['x', 'y', 'z'], ['a', 'b', 'c'], ['m', 'n', 'o']]) == [['x', 'a', 'm'], ['y', 'b', 'n'], ['z', 'c', 'o']]\n\ndef test_check():\n    check(merge)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "py",
-    "prompt": "def dif_Square(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(10) == False\n    assert candidate(15) == True\n\ndef test_check():\n    check(dif_Square)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef check_smaller(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> bool:\n    \"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 2, 3), (2, 3, 4)) == False\n    assert candidate((4, 5, 6), (3, 4, 5)) == True\n    assert candidate((11, 12, 13), (10, 11, 12)) == True\n\ndef test_check():\n    check(check_smaller)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "py",
-    "prompt": "from typing import List, Dict\n\ndef freq_count(list1: List[int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == { 10: 4, 20: 4, 40: 2, 50: 2, 30: 1 }\n    assert candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == { 1: 3, 2: 2, 3: 3, 4: 3 }\n    assert candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == { 10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2 }\n\ndef test_check():\n    check(freq_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef rgb_to_hsv(r: int, g: int, b: int) -> List[float]:\n    \"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(255, 255, 255) == [0.0, 0.0, 100.0]\n    assert candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608]\n    assert candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608]\n\ndef test_check():\n    check(rgb_to_hsv)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef flatten_list(list1: List[Union[int, List[int]]]) -> List[int]:\n    \"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40]\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]\n\ndef test_check():\n    check(flatten_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "py",
-    "prompt": "def check_str(string: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('annie') == True\n    assert candidate('dawood') == False\n    assert candidate('Else') == True\n\ndef test_check():\n    check(check_str)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "py",
-    "prompt": "def check_monthnumber_number(monthnum3: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(6) == True\n    assert candidate(2) == False\n    assert candidate(12) == False\n\ndef test_check():\n    check(check_monthnumber_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef heap_sort(iterable: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate([7, 1, 9, 5]) == [1, 5, 7, 9]\n\ndef test_check():\n    check(heap_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef k_smallest_pairs(nums1: List[int], nums2: List[int], k: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]]\n    assert candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]]\n    assert candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]\n\ndef test_check():\n    check(k_smallest_pairs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "py",
-    "prompt": "from typing import Optional, Tuple\n\ndef find_solution(a: int, b: int, n: int) -> Optional[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2, 3, 7) == (2, 1)\n    assert candidate(4, 2, 7) == None\n    assert candidate(1, 13, 17) == (4, 1)\n\ndef test_check():\n    check(find_solution)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_Max_Num(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 321\n    assert candidate([4, 5, 6, 1]) == 6541\n    assert candidate([1, 2, 3, 9]) == 9321\n\ndef test_check():\n    check(find_Max_Num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum_list(lists: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12]\n    assert candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10]\n    assert candidate([[2, 3, 1]]) == [2, 3, 1]\n\ndef test_check():\n    check(max_sum_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_median(arr1: List[int], arr2: List[int], n: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0\n    assert candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5\n    assert candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0\n\ndef test_check():\n    check(get_median)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "py",
-    "prompt": "def replace_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Jumanji The Jungle') == 'Jumanji_The_Jungle'\n    assert candidate('The_Avengers') == 'The Avengers'\n    assert candidate('Fast and Furious') == 'Fast_and_Furious'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "py",
-    "prompt": "def are_equivalent(num1: int, num2: int) -> bool:\n    \"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(36, 57) == False\n    assert candidate(2, 4) == False\n    assert candidate(23, 47) == True\n\ndef test_check():\n    check(are_equivalent)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef reverse_string_list(stringlist: List[str]) -> List[str]:\n    \"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue', 'White', 'Black']) == ['deR', 'neerG', 'eulB', 'etihW', 'kcalB']\n    assert candidate(['john', 'amal', 'joel', 'george']) == ['nhoj', 'lama', 'leoj', 'egroeg']\n    assert candidate(['jack', 'john', 'mary']) == ['kcaj', 'nhoj', 'yram']\n\ndef test_check():\n    check(reverse_string_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef sum_of_digits(nums: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 2, 56]) == 14\n    assert candidate([[10, 20, 4, 5, 'b', 70, 'a']]) == 19\n    assert candidate([10, 20, -4, 5, -70]) == 19\n\ndef test_check():\n    check(sum_of_digits)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "py",
-    "prompt": "def sequence(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 6\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n\ndef test_check():\n    check(sequence)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef heap_queue_largest(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35]\n\ndef test_check():\n    check(heap_queue_largest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "py",
-    "prompt": "def loss_amount(actual_cost: int, sale_amount: int) -> int:\n    \"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == 0\n    assert candidate(100, 200) == 100\n    assert candidate(2000, 5000) == 3000\n\ndef test_check():\n    check(loss_amount)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef union_elements(test_tup1: List[int], test_tup2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10]\n    assert candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6]\n    assert candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17]\n\ndef test_check():\n    check(union_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Find_Max_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4\n    assert candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3\n    assert candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5\n\ndef test_check():\n    check(Find_Max_Length)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_parenthesis(items: List[str]) -> str:\n    \"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['python (chrome)']) == 'python'\n    assert candidate(['string(.abc)']) == 'string'\n    assert candidate(['alpha(num)']) == 'alpha'\n\ndef test_check():\n    check(remove_parenthesis)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "py",
-    "prompt": "def find_Parity(x: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(12) == False\n    assert candidate(7) == True\n    assert candidate(10) == False\n\ndef test_check():\n    check(find_Parity)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "py",
-    "prompt": "def median_trapezium(base1: int, base2: int, height: int) -> float:\n    \"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(15, 25, 35) == 20\n    assert candidate(10, 20, 30) == 15\n    assert candidate(6, 9, 4) == 7.5\n\ndef test_check():\n    check(median_trapezium)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "py",
-    "prompt": "def centered_hexagonal_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 271\n    assert candidate(2) == 7\n    assert candidate(9) == 217\n\ndef test_check():\n    check(centered_hexagonal_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef find_lists(Input: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2\n    assert candidate([[1, 2], [3, 4], [5, 6]]) == 3\n    assert candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1\n\ndef test_check():\n    check(find_lists)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "py",
-    "prompt": "def get_max_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(60) == 106\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n\ndef test_check():\n    check(get_max_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef len_log(list1: List[str]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['python', 'PHP', 'bigdata']) == 7\n    assert candidate(['a', 'ab', 'abc']) == 3\n    assert candidate(['small', 'big', 'tall']) == 5\n\ndef test_check():\n    check(len_log)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "py",
-    "prompt": "from typing import Optional\n\ndef sector_area(r: int, a: int) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4, 45) == 6.283185307179586\n    assert candidate(9, 45) == 31.808625617596654\n    assert candidate(9, 361) == None\n\ndef test_check():\n    check(sector_area)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef odd_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 4, 3, 6, 7, 6, 3]) == True\n    assert candidate([4, 1, 2]) == True\n    assert candidate([1, 2, 3]) == False\n\ndef test_check():\n    check(odd_position)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef multiple_to_single(L: List[int]) -> int:\n    \"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([11, 33, 50]) == 113350\n    assert candidate([-1, 2, 3, 4, 5, 6]) == -123456\n    assert candidate([10, 15, 20, 25]) == 10152025\n\ndef test_check():\n    check(multiple_to_single)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "py",
-    "prompt": "def is_Diff(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(12345) == False\n    assert candidate(1212112) == True\n    assert candidate(1212) == False\n\ndef test_check():\n    check(is_Diff)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef index_multiplication(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]]\n\ndef test_check():\n    check(index_multiplication)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_str_int(test_str: str) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('(7, 8, 9)') == (7, 8, 9)\n    assert candidate('(1, 2, 3)') == (1, 2, 3)\n    assert candidate('(4, 5, 6)') == (4, 5, 6)\n    assert candidate('(7, 81, 19)') == (7, 81, 19)\n\ndef test_check():\n    check(tuple_str_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "py",
-    "prompt": "def amicable_numbers_sum(limit: int) -> int:\n    \"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(999) == 504\n    assert candidate(9999) == 31626\n    assert candidate(99) == 0\n\ndef test_check():\n    check(amicable_numbers_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "py",
-    "prompt": "def remove_odd(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python') == 'yhn'\n    assert candidate('program') == 'rga'\n    assert candidate('language') == 'agae'\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef multiply_elements(test_tup: List[int]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80]\n    assert candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42]\n    assert candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135]\n    assert candidate([12]) == []\n\ndef test_check():\n    check(multiply_elements)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_rotation(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == 1\n    assert candidate([4, 5, 1, 2, 3]) == 2\n    assert candidate([7, 8, 9, 1, 2, 3]) == 3\n    assert candidate([1, 2, 3]) == 0\n    assert candidate([1, 3, 2]) == 2\n\ndef test_check():\n    check(count_rotation)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef extract_freq(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3\n    assert candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4\n    assert candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4\n\ndef test_check():\n    check(extract_freq)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_same_pair(nums1: List[int], nums2: List[int]) -> int:\n    \"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1\n    assert candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3\n\ndef test_check():\n    check(count_same_pair)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "py",
-    "prompt": "def power(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3, 4) == 81\n    assert candidate(2, 3) == 8\n    assert candidate(5, 5) == 3125\n\ndef test_check():\n    check(power)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef return_sum(dict: Dict[str, int]) -> int:\n    \"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'a': 100, 'b': 200, 'c': 300 }) == 600\n    assert candidate({ 'a': 25, 'b': 18, 'c': 45 }) == 88\n    assert candidate({ 'a': 36, 'b': 39, 'c': 49 }) == 124\n\ndef test_check():\n    check(return_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef pair_wise(l1: List[int]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]\n    assert candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)]\n    assert candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]\n\ndef test_check():\n    check(pair_wise)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef split(word: str) -> List[str]:\n    \"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python') == ['p', 'y', 't', 'h', 'o', 'n']\n    assert candidate('Name') == ['N', 'a', 'm', 'e']\n    assert candidate('program') == ['p', 'r', 'o', 'g', 'r', 'a', 'm']\n\ndef test_check():\n    check(split)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "py",
-    "prompt": "def min_of_three(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 20, 0) == 0\n    assert candidate(19, 15, 18) == 15\n    assert candidate(-10, -20, -30) == -30\n\ndef test_check():\n    check(min_of_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "py",
-    "prompt": "def is_Sum_Of_Powers_Of_Two(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(7) == False\n    assert candidate(14) == True\n\ndef test_check():\n    check(is_Sum_Of_Powers_Of_Two)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "py",
-    "prompt": "def get_Char(strr: str) -> str:\n    \"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abc') == 'f'\n    assert candidate('gfg') == 't'\n    assert candidate('ab') == 'c'\n\ndef test_check():\n    check(get_Char)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "py",
-    "prompt": "def sum_div(number: int) -> int:\n    \"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(8) == 7\n    assert candidate(12) == 16\n    assert candidate(7) == 1\n\ndef test_check():\n    check(sum_div)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef count_integer(list1: List[Union[int, str, float]]) -> int:\n    \"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 'abc', 1.2]) == 2\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([1, 1.2, 4, 5.1]) == 2\n\ndef test_check():\n    check(count_integer)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef two_unique_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5]\n    assert candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5]\n\ndef test_check():\n    check(two_unique_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef test_duplicate(arraynums: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 4]) == True\n    assert candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == True\n\ndef test_check():\n    check(test_duplicate)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "py",
-    "prompt": "def catalan_number(num: int) -> int:\n    \"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 16796\n    assert candidate(9) == 4862\n    assert candidate(7) == 429\n\ndef test_check():\n    check(catalan_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "py",
-    "prompt": "def power_base_sum(base: int, power: int) -> int:\n    \"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2, 100) == 115\n    assert candidate(8, 10) == 37\n    assert candidate(8, 15) == 62\n    assert candidate(3, 3) == 9\n\ndef test_check():\n    check(power_base_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef replace_list(list1: List[Any], list2: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8]\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate(['red', 'blue', 'green'], ['yellow']) == ['red', 'blue', 'yellow']\n\ndef test_check():\n    check(replace_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "py",
-    "prompt": "def is_octagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 65\n    assert candidate(10) == 280\n    assert candidate(15) == 645\n\ndef test_check():\n    check(is_octagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "py",
-    "prompt": "def replace_blank(str1: str, char: str) -> str:\n    \"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('hello people', '@') == 'hello@people'\n    assert candidate('python program language', '$') == 'python$program$language'\n    assert candidate('blank space', '-') == 'blank-space'\n\ndef test_check():\n    check(replace_blank)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "py",
-    "prompt": "def replace_specialchar(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Python language, Programming language.') == 'Python:language::Programming:language:'\n    assert candidate('a b c,d e f') == 'a:b:c:d:e:f'\n    assert candidate('ram reshma,ram rahim') == 'ram:reshma:ram:rahim'\n\ndef test_check():\n    check(replace_specialchar)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef tuple_to_int(nums: Tuple[int, int, int]) -> int:\n    \"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 2, 3)) == 123\n    assert candidate((4, 5, 6)) == 456\n    assert candidate((5, 6, 7)) == 567\n\ndef test_check():\n    check(tuple_to_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "py",
-    "prompt": "def otherside_rightangle(w: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(7, 8) == 10.63014581273465\n    assert candidate(3, 4) == 5\n    assert candidate(7, 15) == 16.55294535724685\n\ndef test_check():\n    check(otherside_rightangle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "py",
-    "prompt": "from typing import List, Dict, Union\n\ndef expensive_items(items: List[Dict[str, Union[str, float]]], n: int) -> List[Dict[str, Union[str, float]]]:\n    \"\"\"\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }], 2) == [{ 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-1', 'price': 101.1 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }, { 'name': 'Item-4', 'price': 22.75 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n\ndef test_check():\n    check(expensive_items)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "py",
-    "prompt": "def digit_distance_nums(n1: int, n2: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(23, 56) == 6\n    assert candidate(123, 256) == 7\n\ndef test_check():\n    check(digit_distance_nums)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "py",
-    "prompt": "def text_match_wordz_middle(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('pythonzabc.') == True\n    assert candidate('zxyabc.') == False\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz_middle)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "py",
-    "prompt": "def removezero_ip(ip: str) -> str:\n    \"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('216.08.094.196') == '216.8.94.196'\n    assert candidate('12.01.024') == '12.1.24'\n    assert candidate('216.08.094.0196') == '216.8.94.196'\n\ndef test_check():\n    check(removezero_ip)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef count_element_in_list(list1: List[List[Any]], x: Any) -> int:\n    \"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'A') == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'E') == 1\n\ndef test_check():\n    check(count_element_in_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "py",
-    "prompt": "def multiply_int(x: int, y: int) -> int:\n    \"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(5, 10) == 50\n    assert candidate(4, 8) == 32\n\ndef test_check():\n    check(multiply_int)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef add_pairwise(test_tup: Tuple[int, int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18)\n    assert candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20)\n    assert candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22)\n\ndef test_check():\n    check(add_pairwise)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 200\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484\n\ndef test_check():\n    check(max_product_tuple)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4429,7 +19,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef kth_element(arr: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find the kth element in the given array using 1-based indexing.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([12, 3, 5, 7, 19], 2) == 3\n    assert candidate([17, 24, 8, 23], 3) == 8\n    assert candidate([16, 21, 25, 36, 4], 4) == 36\n\ndef test_check():\n    check(kth_element)\n\ntest_check()\n",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "py",
-    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\n",
+    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert a snake case string to camel case string.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('python_program') == 'PythonProgram'\n    assert candidate('python_language') == 'PythonLanguage'\n    assert candidate('programming_language') == 'ProgrammingLanguage'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "py",
-    "prompt": "from typing import List, Union, Tuple\n\ndef count_first_elements(test_tup: List[Union[int, Tuple[int, int]]]) -> int:\n    \"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\n",
+    "prompt": "def eulerian_num(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a function to find the Eulerian number a(n, m).\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, (4, 6), 10]) == 3\n    assert candidate([2, 9, (5, 7), 11]) == 2\n    assert candidate([11, 15, 5, 8, (2, 3), 8]) == 4\n\ndef test_check():\n    check(count_first_elements)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(3, 1) == 4\n    assert candidate(4, 1) == 11\n    assert candidate(5, 3) == 26\n\ndef test_check():\n    check(eulerian_num)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "py",
-    "prompt": "from typing import List\n\ndef right_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef sort_sublists(input_list: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(right_insertion)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([[' red ', 'green'], ['blue ', ' black'], [' orange', 'brown']]) == [[' red ', 'green'], [' black', 'blue '], [' orange', 'brown']]\n    assert candidate([['zilver', 'gold'], ['magnesium', 'aluminium'], ['steel', 'bronze']]) == [['gold', 'zilver'], ['aluminium', 'magnesium'], ['bronze', 'steel']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "py",
-    "prompt": "def is_woodall(x: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef count(lst: List[bool]) -> int:\n    \"\"\"\n\tWrite a python function to count true booleans in the given list.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(383) == True\n    assert candidate(254) == False\n    assert candidate(200) == False\n\ndef test_check():\n    check(is_woodall)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([True, False, True]) == 2\n    assert candidate([False, False]) == 0\n    assert candidate([True, True, True]) == 3\n\ndef test_check():\n    check(count)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "py",
-    "prompt": "from typing import List\n\ndef shell_sort(my_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Tuple\n\ndef add_lists(test_list: List[int], test_tup: Tuple[int, int]) -> Tuple[int, int, int, int, int]:\n    \"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]\n    assert candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87]\n    assert candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96]\n\ndef test_check():\n    check(shell_sort)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)\n    assert candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8)\n    assert candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9)\n\ndef test_check():\n    check(add_lists)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_Odd_Pair(A: List[int], N: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef merge_sorted_list(num1: List[int], num2: List[int], num3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1], 5) == 6\n    assert candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12\n    assert candidate([1, 2, 3], 3) == 2\n\ndef test_check():\n    check(find_Odd_Pair)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]\n\ndef test_check():\n    check(merge_sorted_list)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "py",
-    "prompt": "def sum_in_range(l: int, r: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\n",
+    "prompt": "def odd_Equivalent(s: str, n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2, 5) == 8\n    assert candidate(5, 7) == 12\n    assert candidate(7, 13) == 40\n\ndef test_check():\n    check(sum_in_range)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('011001', 6) == 3\n    assert candidate('11011', 5) == 4\n    assert candidate('1010', 4) == 2\n\ndef test_check():\n    check(odd_Equivalent)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "py",
-    "prompt": "def square_perimeter(a: int) -> int:\n    \"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\n",
+    "prompt": "def check_integer(text: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string represents an integer or not.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10) == 40\n    assert candidate(5) == 20\n    assert candidate(4) == 16\n\ndef test_check():\n    check(square_perimeter)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('1') == True\n    assert candidate('12345') == True\n\ndef test_check():\n    check(check_integer)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "py",
-    "prompt": "def is_polite(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef tuple_to_int(nums: Tuple[int, int, int]) -> int:\n    \"\"\"\n\tWrite a function to convert a given tuple of positive integers into a single integer.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(7) == 11\n    assert candidate(4) == 7\n    assert candidate(9) == 13\n\ndef test_check():\n    check(is_polite)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "py",
-    "prompt": "def sum_series(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(6) == 12\n    assert candidate(10) == 30\n    assert candidate(9) == 25\n\ndef test_check():\n    check(sum_series)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef find_dissimilar(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)\n    assert candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9)\n    assert candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25)\n\ndef test_check():\n    check(find_dissimilar)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef start_withp(words: List[str]) -> Tuple[str, str]:\n    \"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Python PHP', 'Java JavaScript', 'c c++']) == ('Python', 'PHP')\n    assert candidate(['Python Programming', 'Java Programming']) == ('Python', 'Programming')\n    assert candidate(['Pqrst Pqr', 'qrstuv']) == ('Pqrst', 'Pqr')\n\ndef test_check():\n    check(start_withp)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "py",
-    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('android_tv') == 'AndroidTv'\n    assert candidate('google_pixel') == 'GooglePixel'\n    assert candidate('apple_watch') == 'AppleWatch'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "py",
-    "prompt": "def volume_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(2) == 8\n    assert candidate(5) == 125\n\ndef test_check():\n    check(volume_cube)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "py",
-    "prompt": "def check_monthnumb_number(monthnum2: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(2) == False\n    assert candidate(6) == False\n\ndef test_check():\n    check(check_monthnumb_number)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "py",
-    "prompt": "def all_Bits_Set_In_The_Given_Range(n: int, l: int, r: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(4, 1, 2) == True\n    assert candidate(17, 2, 4) == True\n    assert candidate(39, 4, 6) == False\n\ndef test_check():\n    check(all_Bits_Set_In_The_Given_Range)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef Extract(lst: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]\n    assert candidate([[1, 2, 3], [4, 5]]) == [1, 4]\n    assert candidate([[9, 8, 1], [1, 2]]) == [9, 1]\n\ndef test_check():\n    check(Extract)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "py",
-    "prompt": "def surfacearea_cylinder(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(10, 5) == 942.45\n    assert candidate(4, 5) == 226.18800000000002\n    assert candidate(4, 10) == 351.848\n\ndef test_check():\n    check(surfacearea_cylinder)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sample_nam(sample_names: List[str]) -> int:\n    \"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith']) == 16\n    assert candidate(['php', 'res', 'Python', 'abcd', 'Java', 'aaa']) == 10\n    assert candidate(['abcd', 'Python', 'abba', 'aba']) == 6\n\ndef test_check():\n    check(sample_nam)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef rearrange_bigger(n: int) -> Any:\n    \"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(12) == 21\n    assert candidate(10) == False\n    assert candidate(102) == 120\n\ndef test_check():\n    check(rearrange_bigger)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "py",
-    "prompt": "def perimeter_pentagon(a: int) -> int:\n    \"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 25\n    assert candidate(10) == 50\n    assert candidate(15) == 75\n\ndef test_check():\n    check(perimeter_pentagon)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194\n    assert candidate([80, 60, 30, 40, 20, 10]) == 210\n    assert candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138\n\ndef test_check():\n    check(max_sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "py",
-    "prompt": "from typing import Tuple, Any\n\ndef extract_even(test_tuple: Tuple[int, int, Tuple[int, int, Tuple[int, int]], int, int]) -> Any:\n    \"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)\n    assert candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8)))\n    assert candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10)\n\ndef test_check():\n    check(extract_even)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate((1, 2, 3)) == 123\n    assert candidate((4, 5, 6)) == 456\n    assert candidate((5, 6, 7)) == 567\n\ndef test_check():\n    check(tuple_to_int)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -4789,249 +169,9 @@
     "language": "py",
     "prompt": "from typing import List, Tuple\n\ndef list_to_float(test_list: List[Tuple[str, str]]) -> List[Tuple[float, float]]:\n    \"\"\"\n\tWrite a function to convert all possible convertible elements in a list of lists to floats.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([('3', '4'), ('1', '26.45'), ('7.32', '8'), ('4', '8')]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]\n    assert candidate([('4', '4'), ('2', '27'), ('4.12', '9'), ('7', '11')]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)]\n    assert candidate([('6', '78'), ('5', '26.45'), ('1.33', '4'), ('82', '13')]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)]\n\ndef test_check():\n    check(list_to_float)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "py",
-    "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2) == 20\n    assert candidate(3) == 56\n    assert candidate(4) == 120\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef get_pairs_count(arr: List[int], sum: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 1, 1], 2) == 6\n    assert candidate([1, 5, 7, -1, 5], 6) == 3\n    assert candidate([1, -2, 3], 1) == 1\n    assert candidate([-1, -2, 3], -3) == 1\n\ndef test_check():\n    check(get_pairs_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "py",
-    "prompt": "def count_no_of_ways(n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(2, 4) == 16\n    assert candidate(3, 2) == 6\n    assert candidate(4, 4) == 228\n\ndef test_check():\n    check(count_no_of_ways)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "py",
-    "prompt": "def reverse_words(s: str) -> str:\n    \"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python program') == 'program python'\n    assert candidate('java language') == 'language java'\n    assert candidate('indian man') == 'man indian'\n\ndef test_check():\n    check(reverse_words)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "py",
-    "prompt": "def checks(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(70) == False\n    assert candidate(23) == False\n    assert candidate(73) == True\n\ndef test_check():\n    check(checks)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef last(arr: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 1) == 0\n    assert candidate([1, 1, 1, 2, 3, 4], 1) == 2\n    assert candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3\n\ndef test_check():\n    check(last)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef count_X(tup: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4\n\ndef test_check():\n    check(count_X)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[Any]:\n    \"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7]\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6]\n    assert candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5]\n    assert candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == []\n\ndef test_check():\n    check(extract_index_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "py",
-    "prompt": "from typing import List, Union, Optional\n\ndef second_smallest(numbers: List[Union[int, float]]) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, -8, -2, 0, -2]) == -2\n    assert candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5\n    assert candidate([2, 2]) == None\n    assert candidate([2, 2, 2]) == None\n\ndef test_check():\n    check(second_smallest)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "py",
-    "prompt": "from typing import Tuple\n\ndef concatenate_tuple(test_tup: Tuple[str, str, int, str]) -> str:\n    \"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(('ID', 'is', 4, 'UTS')) == 'ID-is-4-UTS'\n    assert candidate(('QWE', 'is', 4, 'RTY')) == 'QWE-is-4-RTY'\n    assert candidate(('ZEN', 'is', 4, 'OP')) == 'ZEN-is-4-OP'\n\ndef test_check():\n    check(concatenate_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "py",
-    "prompt": "def replace_spaces(string: str) -> str:\n    \"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('My Name is Dawood') == 'My%20Name%20is%20Dawood'\n    assert candidate('I am a Programmer') == 'I%20am%20a%20Programmer'\n    assert candidate('I love Coding') == 'I%20love%20Coding'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sum_range_list(list1: List[int], m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38\n\ndef test_check():\n    check(sum_range_list)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "py",
-    "prompt": "from typing import Dict\n\ndef merge_dictionaries_three(dict1: Dict[str, str], dict2: Dict[str, str], dict3: Dict[str, str]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'O': 'Orange', 'W': 'White', 'B': 'Black' }) == { 'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'L': 'lavender', 'B': 'Blue' }) == { 'W': 'White', 'P': 'Pink', 'B': 'Black', 'R': 'Red', 'G': 'Green', 'L': 'lavender' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'L': 'lavender', 'B': 'Blue' }, { 'G': 'Green', 'W': 'White' }) == { 'B': 'Black', 'P': 'Pink', 'R': 'Red', 'G': 'Green', 'L': 'lavender', 'W': 'White' }\n\ndef test_check():\n    check(merge_dictionaries_three)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "py",
-    "prompt": "def minimum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(-5, -4) == -5\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(minimum)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef max_difference(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7\n    assert candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15\n    assert candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23\n\ndef test_check():\n    check(max_difference)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_Element(arr: List[int], ranges: List[List[int]], rotations: int, index: int) -> int:\n    \"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3\n    assert candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3\n    assert candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1\n\ndef test_check():\n    check(find_Element)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5044,7 +184,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef string_to_list(string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a string to a list of strings split on the space character.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('python programming') == ['python', 'programming']\n    assert candidate('lists tuples strings') == ['lists', 'tuples', 'strings']\n    assert candidate('write a program') == ['write', 'a', 'program']\n\ndef test_check():\n    check(string_to_list)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef search(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the element that appears only once in a sorted array.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 2, 3]) == 3\n    assert candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8\n    assert candidate([1, 2, 2, 3, 3, 4, 4]) == 1\n\ndef test_check():\n    check(search)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "py",
-    "prompt": "from typing import Dict, List, Tuple\n\ndef sort_counter(dict1: Dict[str, int]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate({ 'Math': 81, 'Physics': 83, 'Chemistry': 87 }) == [('Chemistry', 87), ('Physics', 83), ('Math', 81)]\n    assert candidate({ 'Math': 400, 'Physics': 300, 'Chemistry': 250 }) == [('Math', 400), ('Physics', 300), ('Chemistry', 250)]\n    assert candidate({ 'Math': 900, 'Physics': 1000, 'Chemistry': 1250 }) == [('Chemistry', 1250), ('Physics', 1000), ('Math', 900)]\n\ndef test_check():\n    check(sort_counter)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5089,7 +214,7 @@
     "language": "py",
     "prompt": "def remove_Occ(s: str, ch: str) -> str:\n    \"\"\"\n\tWrite a python function to remove first and last occurrence of a given character from the string.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('hello', 'l') == 'heo'\n    assert candidate('abcda', 'a') == 'bcd'\n    assert candidate('PHP', 'P') == 'H'\n\ndef test_check():\n    check(remove_Occ)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "py",
-    "prompt": "def lateralsurface_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Tuple\n\ndef max_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5) == 100\n    assert candidate(9) == 324\n    assert candidate(10) == 400\n\ndef test_check():\n    check(lateralsurface_cube)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 36\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 200\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 484\n\ndef test_check():\n    check(max_product_tuple)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "py",
-    "prompt": "from typing import List, Any, Optional\n\ndef common_element(list1: List[Any], list2: List[Any]) -> Optional[bool]:\n    \"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\n",
+    "prompt": "def amicable_numbers_sum(limit: int) -> int:\n    \"\"\"\n\tWrite a function to sum all amicable numbers from 1 to a specified number.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == True\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == None\n    assert candidate(['a', 'b', 'c'], ['d', 'b', 'e']) == True\n\ndef test_check():\n    check(common_element)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(999) == 504\n    assert candidate(9999) == 31626\n    assert candidate(99) == 0\n\ndef test_check():\n    check(amicable_numbers_sum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef add_lists(test_list: List[int], test_tup: Tuple[int, int]) -> Tuple[int, int, int, int, int]:\n    \"\"\"\n\tWrite a function to append the given list to the given tuples.\n\t\"\"\"\n",
+    "prompt": "def find_length(string: str) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)\n    assert candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8)\n    assert candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9)\n\ndef test_check():\n    check(add_lists)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate('11000010001') == 6\n    assert candidate('10111') == 1\n    assert candidate('11011101100101') == 2\n\ndef test_check():\n    check(find_length)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "py",
-    "prompt": "from typing import List\n\ndef nth_nums(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\n",
+    "prompt": "def sum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of common divisors of two given numbers.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30], 3) == [1000, 8000, 27000]\n    assert candidate([12, 15], 5) == [248832, 759375]\n\ndef test_check():\n    check(nth_nums)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(10, 15) == 6\n    assert candidate(100, 150) == 93\n    assert candidate(4, 6) == 3\n\ndef test_check():\n    check(sum)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "py",
-    "prompt": "from typing import List\n\ndef pancake_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "prompt": "def multiply_int(x: int, y: int) -> int:\n    \"\"\"\n\tWrite a function to multiply two integers.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]\n    assert candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98]\n    assert candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42]\n\ndef test_check():\n    check(pancake_sort)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "py",
-    "prompt": "def median_numbers(a: int, b: int, c: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(25, 55, 65) == 55.0\n    assert candidate(20, 10, 30) == 20.0\n    assert candidate(15, 45, 75) == 45.0\n\ndef test_check():\n    check(median_numbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef check_greater(arr: List[int], number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], 4) == False\n    assert candidate([2, 3, 4, 5, 6], 8) == True\n    assert candidate([9, 7, 4, 8, 6, 1], 11) == True\n\ndef test_check():\n    check(check_greater)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef check_element(list: List[Any], element: Any) -> bool:\n    \"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['green', 'orange', 'black', 'white'], 'blue') == False\n    assert candidate([1, 2, 3, 4], 7) == False\n    assert candidate(['green', 'green', 'green', 'green'], 'green') == True\n\ndef test_check():\n    check(check_element)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef extract_string(str: List[str], l: int) -> List[str]:\n    \"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 8) == ['practice', 'solution']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 6) == ['Python']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 9) == ['exercises']\n\ndef test_check():\n    check(extract_string)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "py",
-    "prompt": "def text_lowercase_underscore(text: str) -> bool:\n    \"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('aab_cbbbc') == True\n    assert candidate('aab_Abbbc') == False\n    assert candidate('Aaab_abbbc') == False\n\ndef test_check():\n    check(text_lowercase_underscore)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef trim_tuple(test_list: List[List[int]], K: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]]\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]\n    assert candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]]\n\ndef test_check():\n    check(trim_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "py",
-    "prompt": "from typing import List, Any\n\ndef Find_Min(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1]\n    assert candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1]\n    assert candidate([['x'], ['x', 'y'], ['x', 'y', 'z']]) == ['x']\n\ndef test_check():\n    check(Find_Min)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef filter_oddnumbers(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9]\n    assert candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93]\n    assert candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3]\n\ndef test_check():\n    check(filter_oddnumbers)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "py",
-    "prompt": "def find_adverbs(text: str) -> str:\n    \"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('Clearly, he has no excuse for such behavior.') == '0-7: Clearly'\n    assert candidate('Please handle the situation carefuly') == '28-36: carefuly'\n    assert candidate('Complete the task quickly') == '18-25: quickly'\n\ndef test_check():\n    check(find_adverbs)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_of_nth(test_list: List[List[int]], N: int) -> int:\n    \"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19\n    assert candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10\n    assert candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11\n\ndef test_check():\n    check(max_of_nth)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "py",
-    "prompt": "def decimal_to_binary(n: int) -> str:\n    \"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(8) == '1000'\n    assert candidate(18) == '10010'\n    assert candidate(7) == '111'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef combinations_colors(l: List[str], n: int) -> List[List[str]]:\n    \"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue'], 1) == [['Red'], ['Green'], ['Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 2) == [['Red', 'Red'], ['Red', 'Green'], ['Red', 'Blue'], ['Green', 'Green'], ['Green', 'Blue'], ['Blue', 'Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 3) == [['Red', 'Red', 'Red'], ['Red', 'Red', 'Green'], ['Red', 'Red', 'Blue'], ['Red', 'Green', 'Green'], ['Red', 'Green', 'Blue'], ['Red', 'Blue', 'Blue'], ['Green', 'Green', 'Green'], ['Green', 'Green', 'Blue'], ['Green', 'Blue', 'Blue'], ['Blue', 'Blue', 'Blue']]\n\ndef test_check():\n    check(combinations_colors)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "py",
-    "prompt": "def remove_all_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('python  program') == 'pythonprogram'\n    assert candidate('python   programming    language') == 'pythonprogramminglanguage'\n    assert candidate('python                     program') == 'pythonprogram'\n    assert candidate('   python                     program') == 'pythonprogram'\n\ndef test_check():\n    check(remove_all_spaces)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef min_Swaps(str1: str, str2: str) -> Any:\n    \"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('1101', '1110') == 1\n    assert candidate('111', '000') == 'Not Possible'\n    assert candidate('111', '110') == 'Not Possible'\n\ndef test_check():\n    check(min_Swaps)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef new_tuple(test_list: List[str], test_str: str) -> Tuple[str, str, str]:\n    \"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['WEB', 'is'], 'best') == ('WEB', 'is', 'best')\n    assert candidate(['We', 'are'], 'Developers') == ('We', 'are', 'Developers')\n    assert candidate(['Part', 'is'], 'Wrong') == ('Part', 'is', 'Wrong')\n\ndef test_check():\n    check(new_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_remainder(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([100, 10, 5, 25, 35, 14], 11) == 9\n    assert candidate([1, 1, 1], 1) == 0\n    assert candidate([1, 2, 1], 2) == 0\n\ndef test_check():\n    check(find_remainder)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "py",
-    "prompt": "from typing import List, Union\n\ndef min_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 2\n    assert candidate(['Python', 15, 20, 25]) == 15\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 20\n\ndef test_check():\n    check(min_val)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef positive_count(nums: List[int]) -> float:\n    \"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56\n\ndef test_check():\n    check(positive_count)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef add_tuple(test_list: List[int], test_tup: Tuple[int, int]) -> List[int]:\n    \"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]\n    assert candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11]\n    assert candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12]\n\ndef test_check():\n    check(add_tuple)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "py",
-    "prompt": "def max_run_uppercase(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('GeMKSForGERksISBESt') == 5\n    assert candidate('PrECIOusMOVemENTSYT') == 6\n    assert candidate('GooGLEFluTTER') == 4\n\ndef test_check():\n    check(max_run_uppercase)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef sort_matrix(M: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]]\n    assert candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]]\n\ndef test_check():\n    check(sort_matrix)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "py",
-    "prompt": "def count_vowels(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('bestinstareels') == 7\n    assert candidate('partofthejourneyistheend') == 12\n    assert candidate('amazonprime') == 5\n\ndef test_check():\n    check(count_vowels)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef max_sum_increasing_subseq(a: List[int], n: int, index: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7\n    assert candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71\n\ndef test_check():\n    check(max_sum_increasing_subseq)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(5, 10) == 50\n    assert candidate(4, 8) == 32\n\ndef test_check():\n    check(multiply_int)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5524,7 +304,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef long_words(n: int, str: str) -> List[str]:\n    \"\"\"\n\tWrite a function to find words that are longer than n characters from a given list of words.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate(3, 'python is a programming language') == ['python', 'programming', 'language']\n    assert candidate(2, 'writing a program') == ['writing', 'program']\n    assert candidate(5, 'sorting list') == ['sorting']\n\ndef test_check():\n    check(long_words)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef magic_square_test(my_matrix: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to calculate whether the matrix is a magic square.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21\n    assert candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71\n    assert candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78\n\ndef test_check():\n    check(find_sum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == False\n\ndef test_check():\n    check(magic_square_test)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "py",
-    "prompt": "from typing import Tuple, Dict\n\ndef tuple_to_dict(test_tup: Tuple[int, int, int, int, int, int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef sort_matrix(M: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to sort a given matrix in ascending order according to the sum of its rows.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 10, 13, 5)) == { 1: 5, 7: 10, 13: 5 }\n    assert candidate((1, 2, 3, 4, 5, 6)) == { 1: 2, 3: 4, 5: 6 }\n    assert candidate((7, 8, 9, 10, 11, 12)) == { 7: 8, 9: 10, 11: 12 }\n\ndef test_check():\n    check(tuple_to_dict)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]]\n    assert candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]]\n\ndef test_check():\n    check(sort_matrix)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "py",
-    "prompt": "from typing import Tuple, List\n\ndef get_coordinates(test_tup: Tuple[int, int]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\n",
+    "prompt": "from typing import List\n\ndef max_occurrences(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the item with maximum frequency in a given list.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]\n    assert candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]\n    assert candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]\n\ndef test_check():\n    check(get_coordinates)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "py",
-    "prompt": "from typing import Any\n\ndef check_type(test_tuple: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate((5, 6, 7, 3, 5, 6)) == True\n    assert candidate((1, 2, '4')) == False\n    assert candidate((3, 2, 1, 4, 5)) == True\n\ndef test_check():\n    check(check_type)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef find_First_Missing(array: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, 3]) == 4\n    assert candidate([0, 1, 2, 6, 9]) == 3\n    assert candidate([2, 3, 5, 8, 9]) == 0\n\ndef test_check():\n    check(find_First_Missing)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "py",
-    "prompt": "def is_undulating(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(1212121) == True\n    assert candidate(1991) == False\n    assert candidate(121) == True\n\ndef test_check():\n    check(is_undulating)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef min_k(test_list: List[Tuple[str, int]], K: int) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]\n    assert candidate([('Sanjeev', 11), ('Angat', 5), ('Akash', 3), ('Nepin', 9)], 3) == [('Akash', 3), ('Angat', 5), ('Nepin', 9)]\n    assert candidate([('tanmay', 14), ('Amer', 11), ('Ayesha', 9), ('SKD', 16)], 1) == [('Ayesha', 9)]\n\ndef test_check():\n    check(min_k)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "py",
-    "prompt": "def count_Substrings(s: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('112112') == 6\n    assert candidate('111') == 6\n    assert candidate('1101112') == 12\n\ndef test_check():\n    check(count_Substrings)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "py",
-    "prompt": "def is_num_decagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(7) == 175\n    assert candidate(10) == 370\n\ndef test_check():\n    check(is_num_decagonal)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef rear_extract(test_list: List[Tuple[int, str, int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]\n    assert candidate([(1, 'Sai', 36), (2, 'Ayesha', 25), (3, 'Salman', 45)]) == [36, 25, 45]\n    assert candidate([(1, 'Sudeep', 14), (2, 'Vandana', 36), (3, 'Dawood', 56)]) == [14, 36, 56]\n\ndef test_check():\n    check(rear_extract)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "py",
-    "prompt": "def closest_num(N: int) -> int:\n    \"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(11) == 10\n    assert candidate(7) == 6\n    assert candidate(12) == 11\n\ndef test_check():\n    check(closest_num)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef find_combinations(test_list: List[Tuple[int, int]]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]\n\ndef test_check():\n    check(find_combinations)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef maxAverageOfPath(cost: List[List[int]]) -> float:\n    \"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2\n    assert candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2\n    assert candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8\n\ndef test_check():\n    check(maxAverageOfPath)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "py",
-    "prompt": "from typing import List, Tuple\n\ndef sequential_search(dlist: List[int], item: int) -> Tuple[bool, int]:\n    \"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (True, 3)\n    assert candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (True, 7)\n    assert candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (True, 6)\n\ndef test_check():\n    check(sequential_search)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef remove_odd(l: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [2]\n    assert candidate([2, 4, 6]) == [2, 4, 6]\n    assert candidate([10, 20, 3]) == [10, 20]\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "py",
-    "prompt": "from typing import List\n\ndef is_product_even(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 4]) == True\n    assert candidate([1, 1]) == False\n\ndef test_check():\n    check(is_product_even)\n\ntest_check()\n",
-    "stop_tokens": [
-      "\ndef",
-      "\n#",
-      "\nif",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "py",
-    "prompt": "def maximum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5, 10) == 10\n    assert candidate(-1, -2) == -1\n    assert candidate(9, 7) == 9\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2\n    assert candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8\n    assert candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20\n\ndef test_check():\n    check(max_occurrences)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5794,9 +364,759 @@
     "language": "py",
     "prompt": "def reverse_vowels(str1: str) -> str:\n    \"\"\"\n\tWrite a python function to reverse only the vowels of a given string (where y is not a vowel).\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('USA') == 'ASU'\n    assert candidate('ab') == 'ab'\n\ndef test_check():\n    check(reverse_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef tup_string(tup1: List[str]) -> str:\n    \"\"\"\n\tWrite a function to convert a list to a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's']) == 'exercises'\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n']) == 'python'\n    assert candidate(['p', 'r', 'o', 'g', 'r', 'a', 'm']) == 'program'\n\ndef test_check():\n    check(tup_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_negativenum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of the negative numbers of a given list of numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32\n    assert candidate([10, 15, -14, 13, -18, 12, -20]) == -52\n    assert candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894\n\ndef test_check():\n    check(sum_negativenum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "py",
+    "prompt": "def hexagonal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth hexagonal number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 190\n    assert candidate(5) == 45\n    assert candidate(7) == 91\n\ndef test_check():\n    check(hexagonal_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "py",
+    "prompt": "def is_Sum_Of_Powers_Of_Two(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(7) == False\n    assert candidate(14) == True\n\ndef test_check():\n    check(is_Sum_Of_Powers_Of_Two)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pancake_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]\n    assert candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98]\n    assert candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42]\n\ndef test_check():\n    check(pancake_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_samepair(list1: List[int], list2: List[int], list3: List[int]) -> int:\n    \"\"\"\n\tWrite a function to count number items that are identical in the same position of three given lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 4\n    assert candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]) == 5\n\ndef test_check():\n    check(count_samepair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef find_lists(Input: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to find number of lists present in the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8]]) == 2\n    assert candidate([[1, 2], [3, 4], [5, 6]]) == 3\n    assert candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1\n\ndef test_check():\n    check(find_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_Abs_Diff(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum difference between any two elements in a given array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 3]) == 4\n    assert candidate([9, 3, 2, 5, 1]) == 8\n    assert candidate([3, 2, 1]) == 2\n\ndef test_check():\n    check(max_Abs_Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "py",
+    "prompt": "def find_Volume(l: int, b: int, h: int) -> int:\n    \"\"\"\n\tWrite a python function to find the volume of a triangular prism.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 8, 6) == 240\n    assert candidate(3, 2, 2) == 6\n    assert candidate(1, 2, 1) == 1\n\ndef test_check():\n    check(find_Volume)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "py",
+    "prompt": "from typing import Optional, Tuple\n\ndef find_solution(a: int, b: int, n: int) -> Optional[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2, 3, 7) == (2, 1)\n    assert candidate(4, 2, 7) == None\n    assert candidate(1, 13, 17) == (4, 1)\n\ndef test_check():\n    check(find_solution)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_elements(list1: List[int], list2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to remove all elements from a given list present in another list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10]\n\ndef test_check():\n    check(remove_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "py",
+    "prompt": "def sum_series(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(6) == 12\n    assert candidate(10) == 30\n    assert candidate(9) == 25\n\ndef test_check():\n    check(sum_series)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "py",
+    "prompt": "def are_equivalent(num1: int, num2: int) -> bool:\n    \"\"\"\n\tWrite a function to determine if the sum of the divisors of two integers are the same.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(36, 57) == False\n    assert candidate(2, 4) == False\n    assert candidate(23, 47) == True\n\ndef test_check():\n    check(are_equivalent)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "py",
+    "prompt": "def count_char_position(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('xbcefg') == 2\n    assert candidate('ABcED') == 3\n    assert candidate('AbgdeF') == 5\n\ndef test_check():\n    check(count_char_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_even_pair(A: List[int]) -> int:\n    \"\"\"\n\tWrite a function that counts the number of pairs of integers in a list that xor to an even number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1]) == 4\n    assert candidate([7, 2, 8, 1, 0, 5, 11]) == 9\n    assert candidate([1, 2, 3]) == 1\n\ndef test_check():\n    check(find_even_pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "py",
+    "prompt": "def next_power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest power of 2 greater than or equal to n.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(0) == 1\n    assert candidate(5) == 8\n    assert candidate(17) == 32\n\ndef test_check():\n    check(next_power_of_2)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef frequency(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurrences of a number in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 4) == 0\n    assert candidate([1, 2, 2, 3, 3, 3, 4], 3) == 3\n    assert candidate([0, 1, 2, 3, 1, 2], 1) == 2\n\ndef test_check():\n    check(frequency)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "py",
+    "prompt": "def text_lowercase_underscore(text: str) -> bool:\n    \"\"\"\n\tWrite a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('aab_cbbbc') == True\n    assert candidate('aab_Abbbc') == False\n    assert candidate('Aaab_abbbc') == False\n\ndef test_check():\n    check(text_lowercase_underscore)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_range_list(list1: List[int], m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of numbers in a list within a range specified by two indices.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10) == 29\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7) == 16\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10) == 38\n\ndef test_check():\n    check(sum_range_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "py",
+    "prompt": "def perimeter_pentagon(a: int) -> int:\n    \"\"\"\n\tWrite a function to find the perimeter of a regular pentagon from the length of its sides.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 25\n    assert candidate(10) == 50\n    assert candidate(15) == 75\n\ndef test_check():\n    check(perimeter_pentagon)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "py",
+    "prompt": "def count_occurance(s: str) -> int:\n    \"\"\"\n\tWrite a function to count the number of occurence of the string 'std' in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('letstdlenstdporstd') == 3\n    assert candidate('truststdsolensporsd') == 1\n    assert candidate('makestdsostdworthit') == 2\n    assert candidate('stds') == 1\n    assert candidate('') == 0\n\ndef test_check():\n    check(count_occurance)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "py",
+    "prompt": "def square_perimeter(a: int) -> int:\n    \"\"\"\n\tWrite a function that returns the perimeter of a square given its side length as input.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 40\n    assert candidate(5) == 20\n    assert candidate(4) == 16\n\ndef test_check():\n    check(square_perimeter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "py",
+    "prompt": "def remove_dirty_chars(string: str, second_string: str) -> str:\n    \"\"\"\n\tWrite a function to remove characters from the first string which are present in the second string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('probasscurve', 'pros') == 'bacuve'\n    assert candidate('digitalindia', 'talent') == 'digiidi'\n    assert candidate('exoticmiles', 'toxic') == 'emles'\n\ndef test_check():\n    check(remove_dirty_chars)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef test_duplicate(arraynums: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to find whether a given array of integers contains any duplicate element.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == False\n    assert candidate([1, 2, 3, 4, 4]) == True\n    assert candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]) == True\n\ndef test_check():\n    check(test_duplicate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "py",
+    "prompt": "def is_woodall(x: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given number is woodball or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(383) == True\n    assert candidate(254) == False\n    assert candidate(200) == False\n\ndef test_check():\n    check(is_woodall)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef check_type(test_tuple: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if all the elements in tuple have same data type or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((5, 6, 7, 3, 5, 6)) == True\n    assert candidate((1, 2, '4')) == False\n    assert candidate((3, 2, 1, 4, 5)) == True\n\ndef test_check():\n    check(check_type)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_majority(arr: List[int], n: int, x: int) -> bool:\n    \"\"\"\n\tWrite a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == True\n    assert candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == False\n    assert candidate([1, 1, 1, 2, 2], 5, 1) == True\n    assert candidate([1, 1, 2, 2], 5, 1) == False\n\ndef test_check():\n    check(is_majority)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "py",
+    "prompt": "def count_Set_Bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of set bits (binary digits with value 1) in a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 1\n    assert candidate(6) == 2\n\ndef test_check():\n    check(count_Set_Bits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "py",
+    "prompt": "def odd_values_string(str: str) -> str:\n    \"\"\"\n\tWrite a python function to remove the characters which have odd index values of a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abcdef') == 'ace'\n    assert candidate('python') == 'pto'\n    assert candidate('data') == 'dt'\n    assert candidate('lambs') == 'lms'\n\ndef test_check():\n    check(odd_values_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "py",
+    "prompt": "def min_of_three(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find minimum of three numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 20, 0) == 0\n    assert candidate(19, 15, 18) == 15\n    assert candidate(-10, -20, -30) == -30\n\ndef test_check():\n    check(min_of_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "py",
+    "prompt": "def all_Bits_Set_In_The_Given_Range(n: int, l: int, r: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the bits are unset in the given range or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4, 1, 2) == True\n    assert candidate(17, 2, 4) == True\n    assert candidate(39, 4, 6) == False\n\ndef test_check():\n    check(all_Bits_Set_In_The_Given_Range)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef re_arrange_array(arr: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]\n    assert candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15]\n    assert candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85]\n\ndef test_check():\n    check(re_arrange_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "py",
+    "prompt": "def replace_blank(str1: str, char: str) -> str:\n    \"\"\"\n\tWrite a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('hello people', '@') == 'hello@people'\n    assert candidate('python program language', '$') == 'python$program$language'\n    assert candidate('blank space', '-') == 'blank-space'\n\ndef test_check():\n    check(replace_blank)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "py",
+    "prompt": "def volume_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the volume of a cube given its side length.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(2) == 8\n    assert candidate(5) == 125\n\ndef test_check():\n    check(volume_cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Dict\n\ndef check_occurences(test_list: List[Tuple[int, int]]) -> Dict[Tuple[int, int], int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == { (1, 3): 2, (2, 5): 2, (3, 6): 1 }\n    assert candidate([(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == { (2, 4): 2, (3, 6): 2, (4, 7): 1 }\n    assert candidate([(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == { (2, 13): 1, (11, 23): 1, (12, 25): 2, (16, 23): 1 }\n\ndef test_check():\n    check(check_occurences)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "py",
+    "prompt": "def number_of_substrings(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of non-empty substrings of a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abc') == 6\n    assert candidate('abcd') == 10\n    assert candidate('abcde') == 15\n\ndef test_check():\n    check(number_of_substrings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "py",
+    "prompt": "def get_total_number_of_sequences(m: int, n: int) -> int:\n    \"\"\"\n\tWrite a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 4) == 4\n    assert candidate(5, 2) == 6\n    assert candidate(16, 3) == 84\n\ndef test_check():\n    check(get_total_number_of_sequences)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef replace_list(list1: List[Any], list2: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8]\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate(['red', 'blue', 'green'], ['yellow']) == ['red', 'blue', 'yellow']\n\ndef test_check():\n    check(replace_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "py",
+    "prompt": "def count_charac(str1: str) -> int:\n    \"\"\"\n\tWrite a function to count the total number of characters in a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python programming') == 18\n    assert candidate('language') == 8\n    assert candidate('words') == 5\n\ndef test_check():\n    check(count_charac)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "py",
+    "prompt": "def next_Perfect_Square(N: int) -> int:\n    \"\"\"\n\tWrite a python function to find the next perfect square greater than a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(35) == 36\n    assert candidate(6) == 9\n    assert candidate(9) == 16\n\ndef test_check():\n    check(next_Perfect_Square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194\n    assert candidate([80, 60, 30, 40, 20, 10]) == 210\n    assert candidate([2, 3, 14, 16, 21, 23, 29, 30]) == 138\n\ndef test_check():\n    check(max_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "py",
+    "prompt": "def lps(str: str) -> int:\n    \"\"\"\n\tWrite a function to find the length of the longest palindromic subsequence in the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('TENS FOR TENS') == 5\n    assert candidate('CARDIO FOR CARDS') == 7\n    assert candidate('PART OF THE JOURNEY IS PART') == 9\n\ndef test_check():\n    check(lps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef intersection_array(array_nums1: List[int], array_nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the intersection of two arrays.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]) == [1, 2, 8, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]) == [3, 5, 7, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]) == [10]\n\ndef test_check():\n    check(intersection_array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_X(tup: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4) == 0\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10) == 3\n    assert candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8) == 4\n\ndef test_check():\n    check(count_X)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef insert_element(list: List[str], element: str) -> List[str]:\n    \"\"\"\n\tWrite a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Black'], 'c') == ['c', 'Red', 'c', 'Green', 'c', 'Black']\n    assert candidate(['python', 'java'], 'program') == ['program', 'python', 'program', 'java']\n    assert candidate(['happy', 'sad'], 'laugh') == ['laugh', 'happy', 'laugh', 'sad']\n\ndef test_check():\n    check(insert_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef convert(numbers: int) -> Tuple[float, float]:\n    \"\"\"\n\tWrite a python function to convert complex numbers to polar coordinates.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == (1.0, 0.0)\n    assert candidate(4) == (4.0, 0.0)\n    assert candidate(5) == (5.0, 0.0)\n\ndef test_check():\n    check(convert)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef count_integer(list1: List[Union[int, str, float]]) -> int:\n    \"\"\"\n\tWrite a python function that returns the number of integer elements in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 'abc', 1.2]) == 2\n    assert candidate([1, 2, 3]) == 3\n    assert candidate([1, 1.2, 4, 5.1]) == 2\n\ndef test_check():\n    check(count_integer)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef combinations_colors(l: List[str], n: int) -> List[List[str]]:\n    \"\"\"\n\tWrite a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue'], 1) == [['Red'], ['Green'], ['Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 2) == [['Red', 'Red'], ['Red', 'Green'], ['Red', 'Blue'], ['Green', 'Green'], ['Green', 'Blue'], ['Blue', 'Blue']]\n    assert candidate(['Red', 'Green', 'Blue'], 3) == [['Red', 'Red', 'Red'], ['Red', 'Red', 'Green'], ['Red', 'Red', 'Blue'], ['Red', 'Green', 'Green'], ['Red', 'Green', 'Blue'], ['Red', 'Blue', 'Blue'], ['Green', 'Green', 'Green'], ['Green', 'Green', 'Blue'], ['Green', 'Blue', 'Blue'], ['Blue', 'Blue', 'Blue']]\n\ndef test_check():\n    check(combinations_colors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "py",
+    "prompt": "def count_Primes_nums(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 2\n    assert candidate(10) == 4\n    assert candidate(100) == 25\n\ndef test_check():\n    check(count_Primes_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_numbers(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in two numbers and returns a list with the second number and then the first number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == [20, 10]\n    assert candidate(15, 17) == [17, 15]\n    assert candidate(100, 200) == [200, 100]\n\ndef test_check():\n    check(swap_numbers)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5809,7 +1129,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef maximize_elements(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to maximize the given two lists.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]]\n\ndef test_check():\n    check(maximize_elements)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "py",
-    "prompt": "from typing import List\n\ndef even_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\n",
+    "prompt": "def newman_prime(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth newman\u2013shanks\u2013williams prime number.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 3]) == False\n    assert candidate([2, 1, 4]) == True\n\ndef test_check():\n    check(even_position)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(3) == 7\n    assert candidate(4) == 17\n    assert candidate(5) == 41\n\ndef test_check():\n    check(newman_prime)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "py",
-    "prompt": "def check_char(string: str) -> str:\n    \"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\n",
+    "prompt": "from typing import Tuple\n\ndef division_elements(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate('abba') == 'Valid'\n    assert candidate('a') == 'Valid'\n    assert candidate('abcd') == 'Invalid'\n\ndef test_check():\n    check(check_char)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (2, 2, 2, 3)\n    assert candidate((12, 6, 8, 16), (6, 3, 4, 4)) == (2, 2, 2, 4)\n    assert candidate((20, 14, 36, 18), (5, 7, 6, 9)) == (4, 2, 6, 2)\n\ndef test_check():\n    check(division_elements)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "py",
-    "prompt": "def sumofFactors(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef split_two_parts(list1: List[Any], L: int) -> Any:\n    \"\"\"\n\tWrite a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(18) == 26\n    assert candidate(30) == 48\n    assert candidate(6) == 8\n\ndef test_check():\n    check(sumofFactors)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == ([1, 1, 2], [3, 4, 4, 5, 1])\n    assert candidate(['a', 'b', 'c', 'd'], 2) == (['a', 'b'], ['c', 'd'])\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'], 4) == (['p', 'y', 't', 'h'], ['o', 'n'])\n\ndef test_check():\n    check(split_two_parts)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "py",
-    "prompt": "def lateralsurface_cone(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\n",
+    "prompt": "def dog_age(h_age: int) -> int:\n    \"\"\"\n\tWrite a function to calculate a dog's age in dog's years.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate(5, 12) == 204.20352248333654\n    assert candidate(10, 15) == 566.3586699569488\n    assert candidate(19, 17) == 1521.8090132193388\n\ndef test_check():\n    check(lateralsurface_cone)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(12) == 61\n    assert candidate(15) == 73\n    assert candidate(24) == 109\n\ndef test_check():\n    check(dog_age)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "py",
-    "prompt": "from typing import List\n\ndef count_Pairs(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef list_split(S: List[Any], step: int) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([1, 2, 1], 3) == 2\n    assert candidate([1, 1, 1, 1], 4) == 0\n    assert candidate([1, 2, 3, 4, 5], 5) == 10\n\ndef test_check():\n    check(count_Pairs)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'], 3) == [['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]\n    assert candidate(['python', 'java', 'C', 'C++', 'DBMS', 'SQL'], 2) == [['python', 'C', 'DBMS'], ['java', 'C++', 'SQL']]\n\ndef test_check():\n    check(list_split)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "py",
-    "prompt": "from typing import List\n\ndef find_first_occurrence(A: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\n",
+    "prompt": "def lateralsurface_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cube given its side length.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1\n    assert candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2\n    assert candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4\n\ndef test_check():\n    check(find_first_occurrence)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate(5) == 100\n    assert candidate(9) == 324\n    assert candidate(10) == 400\n\ndef test_check():\n    check(lateralsurface_cube)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5914,9 +1234,909 @@
     "language": "py",
     "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate(2) == 10\n    assert candidate(3) == 35\n    assert candidate(4) == 84\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "py",
+    "prompt": "def find_star_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th star number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 37\n    assert candidate(4) == 73\n    assert candidate(5) == 121\n\ndef test_check():\n    check(find_star_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "py",
+    "prompt": "def ascii_value(k: str) -> int:\n    \"\"\"\n\tWrite a function to find the ascii value of a character.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('A') == 65\n    assert candidate('R') == 82\n    assert candidate('S') == 83\n\ndef test_check():\n    check(ascii_value)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_even_and_even_index(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even numbers at even positions of a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 12, 1, 18, 8]) == 30\n    assert candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26\n    assert candidate([5, 6, 12, 1]) == 12\n\ndef test_check():\n    check(sum_even_and_even_index)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "py",
+    "prompt": "def even_Power_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 1056\n    assert candidate(3) == 8832\n    assert candidate(1) == 32\n\ndef test_check():\n    check(even_Power_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef rear_extract(test_list: List[Tuple[int, str, int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]\n    assert candidate([(1, 'Sai', 36), (2, 'Ayesha', 25), (3, 'Salman', 45)]) == [36, 25, 45]\n    assert candidate([(1, 'Sudeep', 14), (2, 'Vandana', 36), (3, 'Dawood', 56)]) == [14, 36, 56]\n\ndef test_check():\n    check(rear_extract)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef substract_elements(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13)\n    assert candidate((11, 2, 3), (24, 45, 16)) == (-13, -43, -13)\n    assert candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3)\n\ndef test_check():\n    check(substract_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "py",
+    "prompt": "def even_binomial_Coeff_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4) == 8\n    assert candidate(6) == 32\n    assert candidate(2) == 2\n\ndef test_check():\n    check(even_binomial_Coeff_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef dict_filter(dict: Dict[str, int], n: int) -> Dict[str, int]:\n    \"\"\"\n\tWrite a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 170) == { 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 180) == { 'Alden Cantrell': 180, 'Pierre Cox': 190 }\n    assert candidate({ 'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190 }, 190) == { 'Pierre Cox': 190 }\n\ndef test_check():\n    check(dict_filter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "py",
+    "prompt": "from typing import List, Union, Tuple\n\ndef count_first_elements(test_tup: List[Union[int, Tuple[int, int]]]) -> int:\n    \"\"\"\n\tWrite a function to find the number of elements that occurs before the list element in the given tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, (4, 6), 10]) == 3\n    assert candidate([2, 9, (5, 7), 11]) == 2\n    assert candidate([11, 15, 5, 8, (2, 3), 8]) == 4\n\ndef test_check():\n    check(count_first_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "py",
+    "prompt": "def is_num_decagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth decagonal number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 27\n    assert candidate(7) == 175\n    assert candidate(10) == 370\n\ndef test_check():\n    check(is_num_decagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef sequential_search(dlist: List[int], item: int) -> Tuple[bool, int]:\n    \"\"\"\n\tWrite a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31) == (True, 3)\n    assert candidate([12, 32, 45, 62, 35, 47, 44, 61], 61) == (True, 7)\n    assert candidate([9, 10, 17, 19, 22, 39, 48, 56], 48) == (True, 6)\n\ndef test_check():\n    check(sequential_search)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef all_unique(test_list: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check if the elements of a given list are unique or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == True\n\ndef test_check():\n    check(all_unique)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sub_list(nums1: List[int], nums2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to subtract two lists element-wise.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], [4, 5, 6]) == [-3, -3, -3]\n    assert candidate([1, 2], [3, 4]) == [-2, -2]\n    assert candidate([90, 120], [50, 70]) == [40, 50]\n\ndef test_check():\n    check(sub_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "py",
+    "prompt": "def validate(n: int) -> bool:\n    \"\"\"\n\tWrite a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1234) == True\n    assert candidate(51241) == False\n    assert candidate(321) == True\n\ndef test_check():\n    check(validate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef check_element(list: List[Any], element: Any) -> bool:\n    \"\"\"\n\tWrite a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['green', 'orange', 'black', 'white'], 'blue') == False\n    assert candidate([1, 2, 3, 4], 7) == False\n    assert candidate(['green', 'green', 'green', 'green'], 'green') == True\n\ndef test_check():\n    check(check_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "py",
+    "prompt": "def text_match_two_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n\ndef test_check():\n    check(text_match_two_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sub_array_sum_repeated(a: List[int], n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, -30, -1], 4, 3) == 30\n    assert candidate([-1, 10, 20], 3, 2) == 59\n    assert candidate([-1, -2, -3], 3, 3) == -1\n\ndef test_check():\n    check(max_sub_array_sum_repeated)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "py",
+    "prompt": "def square_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 20\n    assert candidate(3) == 56\n    assert candidate(4) == 120\n\ndef test_check():\n    check(square_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_length(list1: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list of maximum length in a list of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15])\n    assert candidate([[5], [15, 20, 25]]) == (3, [15, 20, 25])\n\ndef test_check():\n    check(max_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "py",
+    "prompt": "def count_no_of_ways(n: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2, 4) == 16\n    assert candidate(3, 2) == 6\n    assert candidate(4, 4) == 228\n\ndef test_check():\n    check(count_no_of_ways)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "py",
+    "prompt": "def find(n: int, m: int) -> int:\n    \"\"\"\n\tWrite a python function to find quotient of two numbers (rounded down to the nearest integer).\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 3) == 3\n    assert candidate(4, 2) == 2\n    assert candidate(20, 5) == 4\n\ndef test_check():\n    check(find)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "py",
+    "prompt": "def otherside_rightangle(w: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the third side of a right angled triangle.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(7, 8) == 10.63014581273465\n    assert candidate(3, 4) == 5\n    assert candidate(7, 15) == 16.55294535724685\n\ndef test_check():\n    check(otherside_rightangle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef max_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum value in a given heterogeneous list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 5\n    assert candidate(['Python', 15, 20, 25]) == 25\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 50\n\ndef test_check():\n    check(max_val)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "py",
+    "prompt": "def sum_div(number: int) -> int:\n    \"\"\"\n\tWrite a function to return the sum of all divisors of a number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(8) == 7\n    assert candidate(12) == 16\n    assert candidate(7) == 1\n\ndef test_check():\n    check(sum_div)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_Inv_Count(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count inversions in an array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 20, 6, 4, 5]) == 5\n    assert candidate([1, 2, 1]) == 1\n    assert candidate([1, 2, 5, 6, 1]) == 3\n\ndef test_check():\n    check(get_Inv_Count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef flatten_list(list1: List[Union[int, List[int]]]) -> List[int]:\n    \"\"\"\n\tWrite a function to flatten a given nested list structure.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40]\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]\n\ndef test_check():\n    check(flatten_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_aggregate(stdata: List[Tuple[str, int]]) -> Tuple[str, int]:\n    \"\"\"\n\tWrite a function to calculate the maximum aggregate from the list of tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([('Juan Whelan', 90), ('Sabah Colley', 88), ('Peter Nichols', 7), ('Juan Whelan', 122), ('Sabah Colley', 84)]) == ('Juan Whelan', 212)\n    assert candidate([('Juan Whelan', 50), ('Sabah Colley', 48), ('Peter Nichols', 37), ('Juan Whelan', 22), ('Sabah Colley', 14)]) == ('Juan Whelan', 72)\n    assert candidate([('Juan Whelan', 10), ('Sabah Colley', 20), ('Peter Nichols', 30), ('Juan Whelan', 40), ('Sabah Colley', 50)]) == ('Sabah Colley', 70)\n\ndef test_check():\n    check(max_aggregate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Element(arr: List[int], ranges: List[List[int]], rotations: int, index: int) -> int:\n    \"\"\"\n\tWrite a python function to find element at a given index after number of rotations.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1) == 3\n    assert candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2) == 3\n    assert candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1) == 1\n\ndef test_check():\n    check(find_Element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef start_withp(words: List[str]) -> Tuple[str, str]:\n    \"\"\"\n\tWrite a function to return two words from a list of words starting with letter 'p'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Python PHP', 'Java JavaScript', 'c c++']) == ('Python', 'PHP')\n    assert candidate(['Python Programming', 'Java Programming']) == ('Python', 'Programming')\n    assert candidate(['Pqrst Pqr', 'qrstuv']) == ('Pqrst', 'Pqr')\n\ndef test_check():\n    check(start_withp)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum_increasing_subseq(a: List[int], n: int, index: int, k: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6) == 11\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5) == 7\n    assert candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71\n\ndef test_check():\n    check(max_sum_increasing_subseq)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef large_product(nums1: List[int], nums2: List[int], N: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3) == [60, 54, 50]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4) == [60, 54, 50, 48]\n    assert candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5) == [60, 54, 50, 48, 45]\n\ndef test_check():\n    check(large_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "py",
+    "prompt": "def maximum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the maximum of two numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5, 10) == 10\n    assert candidate(-1, -2) == -1\n    assert candidate(9, 7) == 9\n\ndef test_check():\n    check(maximum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef string_to_tuple(str1: str) -> List[str]:\n    \"\"\"\n\tWrite a function to convert a given string to a list of characters.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python 3.0') == ['p', 'y', 't', 'h', 'o', 'n', '3', '.', '0']\n    assert candidate('item1') == ['i', 't', 'e', 'm', '1']\n    assert candidate('15.10') == ['1', '5', '.', '1', '0']\n\ndef test_check():\n    check(string_to_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "py",
+    "prompt": "def highest_Power_of_2(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the highest power of 2 that is less than or equal to n.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n\ndef test_check():\n    check(highest_Power_of_2)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "py",
+    "prompt": "def find_lucas(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the n'th lucas number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(9) == 76\n    assert candidate(4) == 7\n    assert candidate(3) == 4\n\ndef test_check():\n    check(find_lucas)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef add_string(list_: List[Any], string: str) -> List[str]:\n    \"\"\"\n\tWrite a function to apply a given format string to all of the elements in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4], 'temp{0}') == ['temp1', 'temp2', 'temp3', 'temp4']\n    assert candidate(['a', 'b', 'c', 'd'], 'python{0}') == ['pythona', 'pythonb', 'pythonc', 'pythond']\n    assert candidate([5, 6, 7, 8], 'string{0}') == ['string5', 'string6', 'string7', 'string8']\n\ndef test_check():\n    check(add_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef convert_list_dictionary(l1: List[str], l2: List[str], l3: List[int]) -> List[Dict[str, Dict[str, int]]]:\n    \"\"\"\n\tWrite a function to convert more than one list to nested dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['S001', 'S002', 'S003', 'S004'], ['Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'], [85, 98, 89, 92]) == [{ 'S001': { 'Adina Park': 85 } }, { 'S002': { 'Leyton Marsh': 98 } }, { 'S003': { 'Duncan Boyle': 89 } }, { 'S004': { 'Saim Richards': 92 } }]\n    assert candidate(['abc', 'def', 'ghi', 'jkl'], ['python', 'program', 'language', 'programs'], [100, 200, 300, 400]) == [{ 'abc': { 'python': 100 } }, { 'def': { 'program': 200 } }, { 'ghi': { 'language': 300 } }, { 'jkl': { 'programs': 400 } }]\n    assert candidate(['A1', 'A2', 'A3', 'A4'], ['java', 'C', 'C++', 'DBMS'], [10, 20, 30, 40]) == [{ 'A1': { 'java': 10 } }, { 'A2': { 'C': 20 } }, { 'A3': { 'C++': 30 } }, { 'A4': { 'DBMS': 40 } }]\n\ndef test_check():\n    check(convert_list_dictionary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "py",
+    "prompt": "def get_max_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(60) == 106\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n\ndef test_check():\n    check(get_max_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_length_list(input_list: List[List[int]]) -> Tuple[int, List[int]]:\n    \"\"\"\n\tWrite a function to find the list with maximum length.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17])\n    assert candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5])\n    assert candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9])\n\ndef test_check():\n    check(max_length_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_distinct(test_tup: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if given list contains no duplicates.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 5, 6, 1, 4]) == False\n    assert candidate([1, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 6]) == True\n\ndef test_check():\n    check(check_distinct)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef first_non_repeating_character(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first non-repeated character in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abcabc') == None\n    assert candidate('abc') == 'a'\n    assert candidate('ababc') == 'c'\n\ndef test_check():\n    check(first_non_repeating_character)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "py",
+    "prompt": "def check_char(string: str) -> str:\n    \"\"\"\n\tWrite a function to check whether the given string starts and ends with the same character or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abba') == 'Valid'\n    assert candidate('a') == 'Valid'\n    assert candidate('abcd') == 'Invalid'\n\ndef test_check():\n    check(check_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "py",
+    "prompt": "def median_numbers(a: int, b: int, c: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of three numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(25, 55, 65) == 55.0\n    assert candidate(20, 10, 30) == 20.0\n    assert candidate(15, 45, 75) == 45.0\n\ndef test_check():\n    check(median_numbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef sum_of_digits(nums: List[Any]) -> int:\n    \"\"\"\n\tWrite a function to compute the sum of digits of each number of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 2, 56]) == 14\n    assert candidate([[10, 20, 4, 5, 'b', 70, 'a']]) == 19\n    assert candidate([10, 20, -4, 5, -70]) == 19\n\ndef test_check():\n    check(sum_of_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef bitwise_xor(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to perform the mathematical bitwise xor operation across the given tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)\n    assert candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14)\n    assert candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13)\n\ndef test_check():\n    check(bitwise_xor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "py",
+    "prompt": "def is_not_prime(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to identify non-prime numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == False\n    assert candidate(10) == True\n    assert candidate(35) == True\n    assert candidate(37) == False\n\ndef test_check():\n    check(is_not_prime)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef extract_freq(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to extract the number of unique tuples in the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(3, 4), (1, 2), (4, 3), (5, 6)]) == 3\n    assert candidate([(4, 15), (2, 3), (5, 4), (6, 7)]) == 4\n    assert candidate([(5, 16), (2, 3), (6, 5), (6, 9)]) == 4\n\ndef test_check():\n    check(extract_freq)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef add_nested_tuples(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise addition of list elements in the given two nested lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]]\n\ndef test_check():\n    check(add_nested_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "py",
+    "prompt": "def minimum(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum of two numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(-5, -4) == -5\n    assert candidate(0, 0) == 0\n\ndef test_check():\n    check(minimum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "py",
+    "prompt": "from typing import List, Union, Any\n\ndef check_tuplex(tuplex: List[Union[str, int]], tuple1: Any) -> bool:\n    \"\"\"\n\tWrite a function to check whether an element exists within a tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 'r') == True\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], '5') == False\n    assert candidate(['w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'], 3) == True\n\ndef test_check():\n    check(check_tuplex)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "py",
+    "prompt": "def find_Parity(x: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether the parity of a given number is odd.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(12) == False\n    assert candidate(7) == True\n    assert candidate(10) == False\n\ndef test_check():\n    check(find_Parity)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef rearrange_bigger(n: int) -> Any:\n    \"\"\"\n\tWrite a function to create the next bigger number by rearranging the digits of a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(12) == 21\n    assert candidate(10) == False\n    assert candidate(102) == 120\n\ndef test_check():\n    check(rearrange_bigger)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef k_smallest_pairs(nums1: List[int], nums2: List[int], k: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 7], [2, 4, 6], 2) == [[1, 2], [1, 4]]\n    assert candidate([1, 3, 7], [2, 4, 6], 1) == [[1, 2]]\n    assert candidate([1, 3, 7], [2, 4, 6], 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]\n\ndef test_check():\n    check(k_smallest_pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef min_product_tuple(list1: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum product from the pairs of tuples within a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)]) == 8\n    assert candidate([(10, 20), (15, 2), (5, 10)]) == 30\n    assert candidate([(11, 44), (10, 15), (20, 5), (12, 9)]) == 100\n\ndef test_check():\n    check(min_product_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef min_val(listval: List[Union[str, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the minimum value in a given heterogeneous list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version']) == 2\n    assert candidate(['Python', 15, 20, 25]) == 15\n    assert candidate(['Python', 30, 20, 40, 50, 'version']) == 20\n\ndef test_check():\n    check(min_val)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "py",
+    "prompt": "def snake_to_camel(word: str) -> str:\n    \"\"\"\n\tWrite a function to convert the given snake case string to camel case string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('android_tv') == 'AndroidTv'\n    assert candidate('google_pixel') == 'GooglePixel'\n    assert candidate('apple_watch') == 'AppleWatch'\n\ndef test_check():\n    check(snake_to_camel)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_odd(l: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove odd numbers from a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [2]\n    assert candidate([2, 4, 6]) == [2, 4, 6]\n    assert candidate([10, 20, 3]) == [10, 20]\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "py",
+    "prompt": "from typing import List, Tuple, Any\n\ndef extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract the nth element from a given list of tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 0) == ['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 2) == [99, 96, 94, 98]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)], 1) == [98, 97, 91, 94]\n\ndef test_check():\n    check(extract_nth_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef overlapping(list1: List[int], list2: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether any value in a sequence exists in a sequence or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == False\n    assert candidate([1, 2, 3], [4, 5, 6]) == False\n    assert candidate([1, 4, 5], [1, 4, 5]) == True\n\ndef test_check():\n    check(overlapping)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_Product(arr: List[int]) -> Tuple[int, int]:\n    \"\"\"\n\tWrite a python function to find a pair with highest product from a given array of integers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8)\n    assert candidate([0, -1, -2, -4, 5, 0, -6]) == (-4, -6)\n    assert candidate([1, 2, 3]) == (2, 3)\n\ndef test_check():\n    check(max_Product)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",
@@ -5929,7 +2149,7 @@
     "language": "py",
     "prompt": "from typing import List\n\ndef group_tuples(Input: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to find common first element in given list of lists.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['x', 'z'], ['w', 't']]) == [['x', 'y', 'z'], ['w', 't']]\n    assert candidate([['a', 'b'], ['a', 'c'], ['d', 'e']]) == [['a', 'b', 'c'], ['d', 'e']]\n    assert candidate([['f', 'g'], ['f', 'g'], ['h', 'i']]) == [['f', 'g', 'g'], ['h', 'i']]\n\ndef test_check():\n    check(group_tuples)\n\ntest_check()\n",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "py",
-    "prompt": "from typing import List\n\ndef merge_sorted_list(num1: List[int], num2: List[int], num3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to merge three lists into a single sorted list.\n\t\"\"\"\n",
+    "prompt": "from typing import List, Any\n\ndef Find_Max(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the element of a list having maximum length.\n\t\"\"\"\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "def check(candidate):\n    assert candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]\n\ndef test_check():\n    check(merge_sorted_list)\n\ntest_check()\n",
+    "tests": "def check(candidate):\n    assert candidate([['A'], ['A', 'B'], ['A', 'B', 'C']]) == ['A', 'B', 'C']\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1, 2, 3]\n    assert candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1]\n\ndef test_check():\n    check(Find_Max)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef round_and_sum(list1: List[Union[float, int]]) -> int:\n    \"\"\"\n\tWrite a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]) == 243\n    assert candidate([5, 2, 9, 24.3, 29]) == 345\n    assert candidate([25.0, 56.7, 89.2]) == 513\n\ndef test_check():\n    check(round_and_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "py",
+    "prompt": "def cube_Sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the cube sum of first n even natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 72\n    assert candidate(3) == 288\n    assert candidate(4) == 800\n\ndef test_check():\n    check(cube_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef concatenate_tuple(test_tup: Tuple[str, str, int, str]) -> str:\n    \"\"\"\n\tWrite a function to concatenate each element of tuple by the delimiter.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(('ID', 'is', 4, 'UTS')) == 'ID-is-4-UTS'\n    assert candidate(('QWE', 'is', 4, 'RTY')) == 'QWE-is-4-RTY'\n    assert candidate(('ZEN', 'is', 4, 'OP')) == 'ZEN-is-4-OP'\n\ndef test_check():\n    check(concatenate_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "py",
+    "prompt": "def find_Average_Of_Cube(n: int) -> float:\n    \"\"\"\n\tWrite a python function to find the average of cubes of first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4.5\n    assert candidate(3) == 12\n    assert candidate(1) == 1\n\ndef test_check():\n    check(find_Average_Of_Cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "py",
+    "prompt": "from typing import Tuple, List\n\ndef extract_rear(test_tuple: Tuple[str, str, str]) -> List[str]:\n    \"\"\"\n\tWrite a function to extract only the rear index element of each string in the given tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(('Mers', 'for', 'Vers')) == ['s', 'r', 's']\n    assert candidate(('Avenge', 'for', 'People')) == ['e', 'r', 'e']\n    assert candidate(('Gotta', 'get', 'go')) == ['a', 't', 'o']\n\ndef test_check():\n    check(extract_rear)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef count_element_in_list(list1: List[List[Any]], x: Any) -> int:\n    \"\"\"\n\tWrite a function to count the number of sublists containing a particular element.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1) == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'A') == 3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']], 'E') == 1\n\ndef test_check():\n    check(count_element_in_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef filter_oddnumbers(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to filter odd numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9]\n    assert candidate([10, 20, 45, 67, 84, 93]) == [45, 67, 93]\n    assert candidate([5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3]\n\ndef test_check():\n    check(filter_oddnumbers)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "py",
+    "prompt": "def change_date_format(dt: str) -> str:\n    \"\"\"\n\tWrite a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('2026-01-02') == '02-01-2026'\n    assert candidate('2020-11-13') == '13-11-2020'\n    assert candidate('2021-04-26') == '26-04-2021'\n\ndef test_check():\n    check(change_date_format)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef shell_sort(my_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given array by using shell sort.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]\n    assert candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87]\n    assert candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96]\n\ndef test_check():\n    check(shell_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef and_tuples(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to extract the elementwise and tuples from the given two tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)\n    assert candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0)\n    assert candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0)\n\ndef test_check():\n    check(and_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "py",
+    "prompt": "def parabola_directrix(a: int, b: int, c: int) -> int:\n    \"\"\"\n\tWrite a function to find the directrix of a parabola.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5, 3, 2) == -198\n    assert candidate(9, 8, 4) == -2336\n    assert candidate(2, 4, 6) == -130\n\ndef test_check():\n    check(parabola_directrix)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "py",
+    "prompt": "from typing import List, Any, Optional\n\ndef common_element(list1: List[Any], list2: List[Any]) -> Optional[bool]:\n    \"\"\"\n\tWrite a function that takes two lists and returns true if they have at least one common element.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]) == True\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]) == None\n    assert candidate(['a', 'b', 'c'], ['d', 'b', 'e']) == True\n\ndef test_check():\n    check(common_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "py",
+    "prompt": "def median_trapezium(base1: int, base2: int, height: int) -> float:\n    \"\"\"\n\tWrite a function to find the median length of a trapezium.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(15, 25, 35) == 20\n    assert candidate(10, 20, 30) == 15\n    assert candidate(6, 9, 4) == 7.5\n\ndef test_check():\n    check(median_trapezium)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_greater(arr: List[int], number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the entered number is greater than the elements of the given array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5], 4) == False\n    assert candidate([2, 3, 4, 5, 6], 8) == True\n    assert candidate([9, 7, 4, 8, 6, 1], 11) == True\n\ndef test_check():\n    check(check_greater)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "py",
+    "prompt": "def text_match_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by one or more b's.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abba') == True\n\ndef test_check():\n    check(text_match_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "py",
+    "prompt": "def last_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit of a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(123) == 3\n    assert candidate(25) == 5\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef neg_nos(list1: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to return the negative numbers in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([-1, 4, 5, -6]) == [-1, -6]\n    assert candidate([-1, -2, 3, 4]) == [-1, -2]\n    assert candidate([-7, -6, 8, 9]) == [-7, -6]\n\ndef test_check():\n    check(neg_nos)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "py",
+    "prompt": "def remove_odd(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove odd characters in a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python') == 'yhn'\n    assert candidate('program') == 'rga'\n    assert candidate('language') == 'agae'\n\ndef test_check():\n    check(remove_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef count_bidirectional(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to count bidirectional tuple pairs.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3\n    assert candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4\n\ndef test_check():\n    check(count_bidirectional)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef multiple_to_single(L: List[int]) -> int:\n    \"\"\"\n\tWrite a function to join a list of multiple integers into a single integer.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([11, 33, 50]) == 113350\n    assert candidate([-1, 2, 3, 4, 5, 6]) == -123456\n    assert candidate([10, 15, 20, 25]) == 10152025\n\ndef test_check():\n    check(multiple_to_single)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_adverb_position(text: str) -> Tuple[int, int, str]:\n    \"\"\"\n\tWrite a function to find the first adverb and their positions in a given sentence.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('clearly!! we can see the sky') == (0, 7, 'clearly')\n    assert candidate('seriously!! there are many roses') == (0, 9, 'seriously')\n    assert candidate('unfortunately!! sita is going to home') == (0, 13, 'unfortunately')\n\ndef test_check():\n    check(find_adverb_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "py",
+    "prompt": "def surfacearea_cube(l: int) -> int:\n    \"\"\"\n\tWrite a function to find the surface area of a cube of a given size.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 150\n    assert candidate(3) == 54\n    assert candidate(10) == 600\n\ndef test_check():\n    check(surfacearea_cube)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef positive_count(nums: List[int]) -> float:\n    \"\"\"\n\tWrite a function to find the ration of positive numbers in an array of integers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56\n\ndef test_check():\n    check(positive_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef largest_neg(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest negative number from the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, -4, -6]) == -6\n    assert candidate([1, 2, 3, -8, -9]) == -9\n    assert candidate([1, 2, 3, 4, -1]) == -1\n\ndef test_check():\n    check(largest_neg)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef trim_tuple(test_list: List[List[int]], K: int) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to trim each list by k in the given lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2) == [[2], [9], [2], [2]]\n    assert candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]\n    assert candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1) == [[8, 4], [8, 12], [1, 7], [6, 9]]\n\ndef test_check():\n    check(trim_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef index_multiplication(test_tup1: List[List[int]], test_tup2: List[List[int]]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to perform index wise multiplication of list elements in the given two lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]]\n    assert candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]]\n    assert candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]]\n\ndef test_check():\n    check(index_multiplication)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "py",
+    "prompt": "from typing import Any, List\n\ndef count_Occurrence(tup: Any, lst: List[Any]) -> int:\n    \"\"\"\n\tWrite a python function to count the occurence of all elements of list in a tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(('a', 'a', 'c', 'b', 'd'), ['a', 'b']) == 3\n    assert candidate((1, 2, 3, 1, 4, 6, 7, 1, 4), [1, 4, 7]) == 6\n    assert candidate((1, 2, 3, 4, 5, 6), [1, 2]) == 2\n\ndef test_check():\n    check(count_Occurrence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef cube_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find cubes of individual elements in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]\n    assert candidate([10, 20, 30]) == [1000, 8000, 27000]\n    assert candidate([12, 15]) == [1728, 3375]\n\ndef test_check():\n    check(cube_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "py",
+    "prompt": "def cal_sum(n: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the sum of perrin numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(9) == 49\n    assert candidate(10) == 66\n    assert candidate(11) == 88\n\ndef test_check():\n    check(cal_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef extract_string(str: List[str], l: int) -> List[str]:\n    \"\"\"\n\tWrite a function to extract specified size of strings from a given list of string values.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 8) == ['practice', 'solution']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 6) == ['Python']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'], 9) == ['exercises']\n\ndef test_check():\n    check(extract_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "py",
+    "prompt": "def remove_whitespaces(text1: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(' Google    Flutter ') == 'GoogleFlutter'\n    assert candidate(' Google    Dart ') == 'GoogleDart'\n    assert candidate(' iOS    Swift ') == 'iOSSwift'\n\ndef test_check():\n    check(remove_whitespaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "py",
+    "prompt": "def loss_amount(actual_cost: int, sale_amount: int) -> int:\n    \"\"\"\n\tWrite a function that gives loss amount on a sale if the given amount has loss else return 0.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == 0\n    assert candidate(100, 200) == 100\n    assert candidate(2000, 5000) == 3000\n\ndef test_check():\n    check(loss_amount)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "py",
+    "prompt": "def sumofFactors(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of even factors of a number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(18) == 26\n    assert candidate(30) == 48\n    assert candidate(6) == 8\n\ndef test_check():\n    check(sumofFactors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "py",
+    "prompt": "def text_match_wordz(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a word containing 'z'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('pythonz.') == True\n    assert candidate('xyz.') == True\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "py",
+    "prompt": "def check_monthnumb_number(monthnum2: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 31 days or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(2) == False\n    assert candidate(6) == False\n\ndef test_check():\n    check(check_monthnumb_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef reverse_string_list(stringlist: List[str]) -> List[str]:\n    \"\"\"\n\tWrite a function to reverse each string in a given list of string values.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['Red', 'Green', 'Blue', 'White', 'Black']) == ['deR', 'neerG', 'eulB', 'etihW', 'kcalB']\n    assert candidate(['john', 'amal', 'joel', 'george']) == ['nhoj', 'lama', 'leoj', 'egroeg']\n    assert candidate(['jack', 'john', 'mary']) == ['kcaj', 'nhoj', 'yram']\n\ndef test_check():\n    check(reverse_string_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef Find_Min(lst: List[List[Any]]) -> List[Any]:\n    \"\"\"\n\tWrite a python function to find the sublist having minimum length.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2], [1, 2, 3]]) == [1]\n    assert candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1]\n    assert candidate([['x'], ['x', 'y'], ['x', 'y', 'z']]) == ['x']\n\ndef test_check():\n    check(Find_Min)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "py",
+    "prompt": "def rectangle_area(l: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to find the area of a rectangle.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 20) == 200\n    assert candidate(10, 5) == 50\n    assert candidate(4, 2) == 8\n\ndef test_check():\n    check(rectangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "py",
+    "prompt": "def remove_uppercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove uppercase substrings from a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'\n    assert candidate('wAtchTheinTernEtrAdIo') == 'wtchheinerntrdo'\n    assert candidate('VoicESeaRchAndreComMendaTionS') == 'oiceachndreomendaion'\n\ndef test_check():\n    check(remove_uppercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Extract(lst: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the first element of each sublist.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]\n    assert candidate([[1, 2, 3], [4, 5]]) == [1, 4]\n    assert candidate([[9, 8, 1], [1, 2]]) == [9, 1]\n\ndef test_check():\n    check(Extract)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "py",
+    "prompt": "def upper_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count the upper case characters in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('PYthon') == 1\n    assert candidate('BigData') == 1\n    assert candidate('program') == 0\n\ndef test_check():\n    check(upper_ctr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef combinations_list(list1: List[str]) -> List[Union[List[None], List[str]]]:\n    \"\"\"\n\tWrite a function to find all possible combinations of the elements of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['orange', 'red', 'green', 'blue']) == [[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['blue'], ['blue', 'red'], ['blue', 'green'], ['blue', 'green', 'red'], ['white'], ['white', 'red'], ['white', 'green'], ['white', 'green', 'red'], ['white', 'blue'], ['white', 'blue', 'red'], ['white', 'blue', 'green'], ['white', 'blue', 'green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['black', 'blue'], ['black', 'blue', 'red'], ['black', 'blue', 'green'], ['black', 'blue', 'green', 'red'], ['black', 'white'], ['black', 'white', 'red'], ['black', 'white', 'green'], ['black', 'white', 'green', 'red'], ['black', 'white', 'blue'], ['black', 'white', 'blue', 'red'], ['black', 'white', 'blue', 'green'], ['black', 'white', 'blue', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'blue'], ['orange', 'blue', 'red'], ['orange', 'blue', 'green'], ['orange', 'blue', 'green', 'red'], ['orange', 'white'], ['orange', 'white', 'red'], ['orange', 'white', 'green'], ['orange', 'white', 'green', 'red'], ['orange', 'white', 'blue'], ['orange', 'white', 'blue', 'red'], ['orange', 'white', 'blue', 'green'], ['orange', 'white', 'blue', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red'], ['orange', 'black', 'blue'], ['orange', 'black', 'blue', 'red'], ['orange', 'black', 'blue', 'green'], ['orange', 'black', 'blue', 'green', 'red'], ['orange', 'black', 'white'], ['orange', 'black', 'white', 'red'], ['orange', 'black', 'white', 'green'], ['orange', 'black', 'white', 'green', 'red'], ['orange', 'black', 'white', 'blue'], ['orange', 'black', 'white', 'blue', 'red'], ['orange', 'black', 'white', 'blue', 'green'], ['orange', 'black', 'white', 'blue', 'green', 'red']]\n    assert candidate(['red', 'green', 'black', 'orange']) == [[], ['red'], ['green'], ['green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red']]\n\ndef test_check():\n    check(combinations_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_subarray_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product subarray of the given array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, -3, 0, 7, -8, -2]) == 112\n    assert candidate([6, -3, -10, 0, 2]) == 180\n    assert candidate([-2, -40, 0, -2, -3]) == 80\n\ndef test_check():\n    check(max_subarray_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef check_value(dict: Dict[str, int], n: int) -> bool:\n    \"\"\"\n\tWrite a function to check if all values are same in a dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 10) == False\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 12) == True\n    assert candidate({ 'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12 }, 5) == False\n\ndef test_check():\n    check(check_value)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "py",
+    "prompt": "from typing import Dict, Optional\n\ndef drop_empty(dict1: Dict[str, Optional[str]]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to drop empty items from a given dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'c1': 'Red', 'c2': 'Green', 'c3': None }) == { 'c1': 'Red', 'c2': 'Green' }\n    assert candidate({ 'c1': 'Red', 'c2': None, 'c3': None }) == { 'c1': 'Red' }\n    assert candidate({ 'c1': None, 'c2': 'Green', 'c3': None }) == { 'c2': 'Green' }\n\ndef test_check():\n    check(drop_empty)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_product(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 100, 4, 5, 150, 6]) == 3000\n    assert candidate([4, 42, 55, 68, 80]) == 50265600\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 2460\n\ndef test_check():\n    check(max_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef add_pairwise(test_tup: Tuple[int, int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the pairwise addition of the neighboring elements of the given tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18)\n    assert candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20)\n    assert candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22)\n\ndef test_check():\n    check(add_pairwise)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_remainder(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the product of the array multiplication modulo n.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([100, 10, 5, 25, 35, 14], 11) == 9\n    assert candidate([1, 1, 1], 1) == 0\n    assert candidate([1, 2, 1], 2) == 0\n\ndef test_check():\n    check(find_remainder)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_Consecutive(l: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given list contains consecutive numbers or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == True\n    assert candidate([1, 2, 3, 5, 6]) == False\n    assert candidate([1, 2, 1]) == False\n\ndef test_check():\n    check(check_Consecutive)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "py",
+    "prompt": "def replace_char(str1: str, ch: str, newch: str) -> str:\n    \"\"\"\n\tWrite a function to replace characters in a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('polygon', 'y', 'l') == 'pollgon'\n    assert candidate('character', 'c', 'a') == 'aharaater'\n    assert candidate('python', 'l', 'a') == 'python'\n\ndef test_check():\n    check(replace_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "py",
+    "prompt": "from typing import Dict, List, Tuple\n\ndef sort_counter(dict1: Dict[str, int]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a dictionary by value.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'Math': 81, 'Physics': 83, 'Chemistry': 87 }) == [('Chemistry', 87), ('Physics', 83), ('Math', 81)]\n    assert candidate({ 'Math': 400, 'Physics': 300, 'Chemistry': 250 }) == [('Math', 400), ('Physics', 300), ('Chemistry', 250)]\n    assert candidate({ 'Math': 900, 'Physics': 1000, 'Chemistry': 1250 }) == [('Chemistry', 1250), ('Physics', 1000), ('Math', 900)]\n\ndef test_check():\n    check(sort_counter)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef big_sum(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the largest and smallest value in a given array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 4\n    assert candidate([-1, 2, 3, 4]) == 3\n    assert candidate([2, 3, 6]) == 8\n\ndef test_check():\n    check(big_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "py",
+    "prompt": "def is_lower(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert the given string to lower case.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('InValid') == 'invalid'\n    assert candidate('TruE') == 'true'\n    assert candidate('SenTenCE') == 'sentence'\n\ndef test_check():\n    check(is_lower)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "py",
+    "prompt": "def remove_lowercase(str1: str) -> str:\n    \"\"\"\n\tWrite a function to remove lowercase substrings from a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('PYTHon') == 'PYTH'\n    assert candidate('FInD') == 'FID'\n    assert candidate('STRinG') == 'STRG'\n\ndef test_check():\n    check(remove_lowercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "py",
+    "prompt": "def first_Digit(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the first digit of a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(123) == 1\n    assert candidate(456) == 4\n    assert candidate(12) == 1\n\ndef test_check():\n    check(first_Digit)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef heap_queue_largest(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find the n largest integers from a given list of numbers, returned in descending order.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3) == [85, 75, 65]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2) == [85, 75]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5) == [85, 75, 65, 58, 35]\n\ndef test_check():\n    check(heap_queue_largest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list of integers and only returns the odd ones.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == [1, 3, 5]\n    assert candidate([10, 11, 12, 13]) == [11, 13]\n    assert candidate([7, 8, 9, 1]) == [7, 9, 1]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "py",
+    "prompt": "def difference(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 30\n    assert candidate(5) == 210\n    assert candidate(2) == 6\n\ndef test_check():\n    check(difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Odd_Pair(A: List[int], N: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose xor value is odd.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 4, 7, 2, 1], 5) == 6\n    assert candidate([7, 2, 8, 1, 0, 5, 11], 7) == 12\n    assert candidate([1, 2, 3], 3) == 2\n\ndef test_check():\n    check(find_Odd_Pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "py",
+    "prompt": "def toggle_string(string: str) -> str:\n    \"\"\"\n\tWrite a function to toggle the case of all characters in a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Python') == 'pYTHON'\n    assert candidate('Pangram') == 'pANGRAM'\n    assert candidate('LIttLE') == 'liTTle'\n\ndef test_check():\n    check(toggle_string)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "py",
+    "prompt": "def digit_distance_nums(n1: int, n2: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the per-digit difference between two integers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 2) == 1\n    assert candidate(23, 56) == 6\n    assert candidate(123, 256) == 7\n\ndef test_check():\n    check(digit_distance_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sub_array_sum(a: List[int], size: int) -> int:\n    \"\"\"\n\tWrite a function to find the sum of the largest contiguous sublist in the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7\n    assert candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8\n    assert candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10\n\ndef test_check():\n    check(max_sub_array_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef union_elements(test_tup1: List[int], test_tup2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find the union of the elements of two given lists and output them in sorted order.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 4, 5, 6], [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10]\n    assert candidate([1, 2, 3, 4], [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6]\n    assert candidate([11, 12, 13, 14], [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17]\n\ndef test_check():\n    check(union_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Find_Max_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest sublists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 4], [5, 6, 7, 8]]) == 4\n    assert candidate([[0, 1], [2, 2], [3, 2, 1]]) == 3\n    assert candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5\n\ndef test_check():\n    check(Find_Max_Length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef extract_values(text: str) -> List[str]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks from a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('\"Python\", \"PHP\", \"Java\"') == ['Python', 'PHP', 'Java']\n    assert candidate('\"python\",\"program\",\"language\"') == ['python', 'program', 'language']\n    assert candidate('\"red\",\"blue\",\"green\",\"yellow\"') == ['red', 'blue', 'green', 'yellow']\n\ndef test_check():\n    check(extract_values)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_Pairs(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 1], 3) == 2\n    assert candidate([1, 1, 1, 1], 4) == 0\n    assert candidate([1, 2, 3, 4, 5], 5) == 10\n\ndef test_check():\n    check(count_Pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef split(word: str) -> List[str]:\n    \"\"\"\n\tWrite a python function to split a string into characters.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python') == ['p', 'y', 't', 'h', 'o', 'n']\n    assert candidate('Name') == ['N', 'a', 'm', 'e']\n    assert candidate('program') == ['p', 'r', 'o', 'g', 'r', 'a', 'm']\n\ndef test_check():\n    check(split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "py",
+    "prompt": "def sum_digits(n: int) -> int:\n    \"\"\"\n\tWrite a function to get the sum of the digits of a non-negative integer.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(345) == 12\n    assert candidate(12) == 3\n    assert candidate(97) == 16\n\ndef test_check():\n    check(sum_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef issort_list(list1: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a specified list is sorted or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == True\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == False\n    assert candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]) == False\n\ndef test_check():\n    check(issort_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef empty_list(length: int) -> List[Dict[None, None]]:\n    \"\"\"\n\tWrite a function to create a list of N empty dictionaries.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == [{  }, {  }, {  }, {  }, {  }]\n    assert candidate(6) == [{  }, {  }, {  }, {  }, {  }, {  }]\n    assert candidate(7) == [{  }, {  }, {  }, {  }, {  }, {  }, {  }]\n\ndef test_check():\n    check(empty_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_sublists(list1: List[List[str]]) -> List[List[str]]:\n    \"\"\"\n\tWrite a function to sort each sublist of strings in a given list of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']]) == [['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']]) == [['green', 'orange'], ['black'], ['green', 'orange'], ['white']]\n    assert candidate([['a', 'b'], ['d', 'c'], ['g', 'h'], ['f', 'e']]) == [['a', 'b'], ['c', 'd'], ['g', 'h'], ['e', 'f']]\n\ndef test_check():\n    check(sort_sublists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "py",
+    "prompt": "def checks(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check if a given number is one less than twice its reverse.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(70) == False\n    assert candidate(23) == False\n    assert candidate(73) == True\n\ndef test_check():\n    check(checks)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef two_unique_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to remove duplicate numbers from a given number of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5]\n    assert candidate([1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5]\n    assert candidate([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5]\n\ndef test_check():\n    check(two_unique_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique_product(list_data: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to calculate the product of the unique numbers in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 30, 40, 20, 50, 60, 40]) == 720000000\n    assert candidate([1, 2, 3, 1]) == 6\n    assert candidate([7, 8, 9, 0, 1, 1]) == 0\n\ndef test_check():\n    check(unique_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "py",
+    "prompt": "def surfacearea_cylinder(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the surface area of a cylinder.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10, 5) == 942.45\n    assert candidate(4, 5) == 226.18800000000002\n    assert candidate(4, 10) == 351.848\n\ndef test_check():\n    check(surfacearea_cylinder)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_Sub_Array(A: List[int], B: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list is sublist of another or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 4, 3, 5], [1, 2]) == False\n    assert candidate([1, 2, 1], [1, 2, 1]) == True\n    assert candidate([1, 0, 2, 2], [2, 2, 0]) == False\n\ndef test_check():\n    check(is_Sub_Array)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "py",
+    "prompt": "def last_Digit_Factorial(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last digit in factorial of a given number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4) == 4\n    assert candidate(21) == 0\n    assert candidate(30) == 0\n\ndef test_check():\n    check(last_Digit_Factorial)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef interleave_lists(list1: List[int], list2: List[int], list3: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to interleave 3 lists of the same length into a single flat list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]\n    assert candidate([10, 20], [15, 2], [5, 10]) == [10, 15, 5, 20, 2, 10]\n    assert candidate([11, 44], [10, 15], [20, 5]) == [11, 10, 20, 44, 15, 5]\n\ndef test_check():\n    check(interleave_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_dissimilar(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to find the dissimilar elements in the given two tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)\n    assert candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9)\n    assert candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25)\n\ndef test_check():\n    check(find_dissimilar)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_Max_Num(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the largest number that can be formed with the given list of digits.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 321\n    assert candidate([4, 5, 6, 1]) == 6541\n    assert candidate([1, 2, 3, 9]) == 9321\n\ndef test_check():\n    check(find_Max_Num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "py",
+    "prompt": "from typing import Tuple, Any\n\ndef extract_even(test_tuple: Tuple[int, int, Tuple[int, int, Tuple[int, int]], int, int]) -> Any:\n    \"\"\"\n\tWrite a function to remove uneven elements in the nested mixed tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)\n    assert candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8)))\n    assert candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10)\n\ndef test_check():\n    check(extract_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "py",
+    "prompt": "def surface_Area(b: int, s: int) -> int:\n    \"\"\"\n\tWrite a python function to find the surface area of a square pyramid with a given base edge and height.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 4) == 33\n    assert candidate(4, 5) == 56\n    assert candidate(1, 2) == 5\n\ndef test_check():\n    check(surface_Area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "py",
+    "prompt": "def catalan_number(num: int) -> int:\n    \"\"\"\n\tWrite a function which returns nth catalan number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 16796\n    assert candidate(9) == 4862\n    assert candidate(7) == 429\n\ndef test_check():\n    check(catalan_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "py",
+    "prompt": "def find_adverbs(text: str) -> str:\n    \"\"\"\n\tWrite a function to find the first adverb ending with ly and its positions in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Clearly, he has no excuse for such behavior.') == '0-7: Clearly'\n    assert candidate('Please handle the situation carefuly') == '28-36: carefuly'\n    assert candidate('Complete the task quickly') == '18-25: quickly'\n\ndef test_check():\n    check(find_adverbs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "py",
+    "prompt": "from typing import List, Dict, Union\n\ndef expensive_items(items: List[Dict[str, Union[str, float]]], n: int) -> List[Dict[str, Union[str, float]]]:\n    \"\"\"\n\tWrite a function to find the n most expensive items in a given dataset.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }], 2) == [{ 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-1', 'price': 101.1 }]\n    assert candidate([{ 'name': 'Item-1', 'price': 101.1 }, { 'name': 'Item-2', 'price': 555.22 }, { 'name': 'Item-3', 'price': 45.09 }, { 'name': 'Item-4', 'price': 22.75 }], 1) == [{ 'name': 'Item-2', 'price': 555.22 }]\n\ndef test_check():\n    check(expensive_items)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef split_Arr(l: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to split a list at the nth eelment and add the first part to the end.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([12, 10, 5, 6, 52, 36], 2) == [5, 6, 52, 36, 12, 10]\n    assert candidate([1, 2, 3, 4], 1) == [2, 3, 4, 1]\n    assert candidate([0, 1, 2, 3, 4, 5, 6, 7], 3) == [3, 4, 5, 6, 7, 0, 1, 2]\n\ndef test_check():\n    check(split_Arr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef list_tuple(listx: List[int]) -> Any:\n    \"\"\"\n\tWrite a function to convert a list to a tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3)\n    assert candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7)\n    assert candidate([58, 44, 56]) == (58, 44, 56)\n\ndef test_check():\n    check(list_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef big_diff(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the difference between largest and smallest value in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4]) == 3\n    assert candidate([4, 5, 12]) == 8\n    assert candidate([9, 2, 3]) == 7\n\ndef test_check():\n    check(big_diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef perfect_squares(a: int, b: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find perfect squares between two given numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 30) == [1, 4, 9, 16, 25]\n    assert candidate(50, 100) == [64, 81, 100]\n    assert candidate(100, 200) == [100, 121, 144, 169, 196]\n\ndef test_check():\n    check(perfect_squares)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "py",
+    "prompt": "def opposite_Signs(x: int, y: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given two integers have opposite sign or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, -2) == True\n    assert candidate(3, 2) == False\n    assert candidate(-10, -10) == False\n    assert candidate(-2, 2) == True\n\ndef test_check():\n    check(opposite_Signs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last elements in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "py",
+    "prompt": "def sum_Of_product(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of the product of consecutive binomial co-efficients.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 15\n    assert candidate(4) == 56\n    assert candidate(1) == 1\n\ndef test_check():\n    check(sum_Of_product)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "py",
+    "prompt": "def removezero_ip(ip: str) -> str:\n    \"\"\"\n\tWrite a function to remove leading zeroes from an ip address.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('216.08.094.196') == '216.8.94.196'\n    assert candidate('12.01.024') == '12.1.24'\n    assert candidate('216.08.094.0196') == '216.8.94.196'\n\ndef test_check():\n    check(removezero_ip)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef diff_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the difference of the first even and first odd number of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1\n    assert candidate([1, 5, 7, 9, 10]) == 9\n\ndef test_check():\n    check(diff_even_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef min_Swaps(str1: str, str2: str) -> Any:\n    \"\"\"\n\tWrite a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('1101', '1110') == 1\n    assert candidate('111', '000') == 'Not Possible'\n    assert candidate('111', '110') == 'Not Possible'\n\ndef test_check():\n    check(min_Swaps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_kth(arr1: List[int], arr2: List[int], k: int) -> int:\n    \"\"\"\n\tWrite a function to find kth element from the given two sorted arrays.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5) == 6\n    assert candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7) == 256\n    assert candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6) == 8\n\ndef test_check():\n    check(find_kth)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "py",
+    "prompt": "def armstrong_number(number: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is armstrong or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(153) == True\n    assert candidate(259) == False\n    assert candidate(4458) == False\n\ndef test_check():\n    check(armstrong_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef sum_average(number: int) -> Tuple[int, float]:\n    \"\"\"\n\tWrite a function to find sum and average of first n natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == (55, 5.5)\n    assert candidate(15) == (120, 8.0)\n    assert candidate(20) == (210, 10.5)\n\ndef test_check():\n    check(sum_average)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "py",
+    "prompt": "def is_octagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth octagonal number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 65\n    assert candidate(10) == 280\n    assert candidate(15) == 645\n\ndef test_check():\n    check(is_octagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "py",
+    "prompt": "def is_Even(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number is even or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1) == False\n    assert candidate(2) == True\n    assert candidate(3) == False\n\ndef test_check():\n    check(is_Even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef first_repeated_char(str1: str) -> Optional[str]:\n    \"\"\"\n\tWrite a python function to find the first repeated character in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abcabc') == 'a'\n    assert candidate('abc') == None\n    assert candidate('123123') == '1'\n\ndef test_check():\n    check(first_repeated_char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_ludic(n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to get all lucid numbers smaller than or equal to a given integer.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == [1, 2, 3, 5, 7]\n    assert candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25]\n    assert candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]\n\ndef test_check():\n    check(get_ludic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "py",
+    "prompt": "def reverse_words(s: str) -> str:\n    \"\"\"\n\tWrite a function to reverse words seperated by spaces in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python program') == 'program python'\n    assert candidate('java language') == 'language java'\n    assert candidate('indian man') == 'man indian'\n\ndef test_check():\n    check(reverse_words)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "py",
+    "prompt": "def prime_num(num: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given integer is a prime number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(13) == True\n    assert candidate(7) == True\n    assert candidate(-1010) == False\n\ndef test_check():\n    check(prime_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "py",
+    "prompt": "def radian_degree(degree: int) -> float:\n    \"\"\"\n\tWrite a function to convert degrees to radians.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(90) == 1.5707963267948966\n    assert candidate(60) == 1.0471975511965976\n    assert candidate(120) == 2.0943951023931953\n\ndef test_check():\n    check(radian_degree)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef find_literals(text: str, pattern: str) -> Tuple[str, int, int]:\n    \"\"\"\n\tWrite a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)\n    assert candidate('Its been a very crazy procedure right', 'crazy') == ('crazy', 16, 21)\n    assert candidate('Hardest choices required strongest will', 'will') == ('will', 35, 39)\n\ndef test_check():\n    check(find_literals)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "py",
+    "prompt": "def bell_Number(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find nth bell number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(3) == 5\n    assert candidate(4) == 15\n\ndef test_check():\n    check(bell_Number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_kth_element(list1: List[int], L: int) -> List[int]:\n    \"\"\"\n\tWrite a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 4, 4, 5, 1], 3) == [1, 1, 3, 4, 4, 5, 1]\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]\n\ndef test_check():\n    check(remove_kth_element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_of_nth(test_list: List[List[int]], N: int) -> int:\n    \"\"\"\n\tWrite a function which given a matrix represented as a list of lists returns the max of the n'th column.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2) == 19\n    assert candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1) == 10\n    assert candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1) == 11\n\ndef test_check():\n    check(max_of_nth)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef merge(lst: List[List[Any]]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]\n    assert candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]]\n    assert candidate([['x', 'y', 'z'], ['a', 'b', 'c'], ['m', 'n', 'o']]) == [['x', 'a', 'm'], ['y', 'b', 'n'], ['z', 'c', 'o']]\n\ndef test_check():\n    check(merge)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef cummulative_sum(test_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a function to find the cumulative sum of all the values that are present in the given list of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 6, 7], [2, 6]]) == 30\n    assert candidate([[2, 4], [6, 7, 8], [3, 7]]) == 37\n    assert candidate([[3, 5], [7, 8, 9], [4, 8]]) == 44\n\ndef test_check():\n    check(cummulative_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef average_tuple(nums: List[List[int]]) -> List[float]:\n    \"\"\"\n\tWrite a function which takes a lists of lists and returns the average value for each sublist as a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25]\n    assert candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75]\n    assert candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5]\n\ndef test_check():\n    check(average_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef tuple_modulo(test_tup1: Tuple[int, int, int, int], test_tup2: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function which takes two tuples of the same length and performs the element wise modulo.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1)\n\ndef test_check():\n    check(tuple_modulo)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef min_Jumps(steps: Tuple[int, int], d: int) -> float:\n    \"\"\"\n\tWrite a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((3, 4), 11) == 3.5\n    assert candidate((3, 4), 0) == 0\n    assert candidate((11, 14), 11) == 1\n\ndef test_check():\n    check(min_Jumps)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef div_list(nums1: List[int], nums2: List[int]) -> List[float]:\n    \"\"\"\n\tWrite a function to divide two lists element wise.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([4, 5, 6], [1, 2, 3]) == [4.0, 2.5, 2.0]\n    assert candidate([3, 2], [1, 4]) == [3.0, 0.5]\n    assert candidate([90, 120], [50, 70]) == [1.8, 1.7142857142857142]\n\ndef test_check():\n    check(div_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "py",
+    "prompt": "def move_num(test_str: str) -> str:\n    \"\"\"\n\tWrite a function to move all the numbers to the end of the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'\n    assert candidate('Avengers124Assemble') == 'AvengersAssemble124'\n    assert candidate('Its11our12path13to14see15things16do17things') == 'Itsourpathtoseethingsdothings11121314151617'\n\ndef test_check():\n    check(move_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "py",
+    "prompt": "def count_Substrings(s: str) -> int:\n    \"\"\"\n\tWrite a python function to count the number of substrings with the sum of digits equal to their length.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('112112') == 6\n    assert candidate('111') == 6\n    assert candidate('1101112') == 12\n\ndef test_check():\n    check(count_Substrings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_median(arr1: List[int], arr2: List[int], n: int) -> float:\n    \"\"\"\n\tWrite a function to find the median of two sorted lists of same size.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0\n    assert candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5\n    assert candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0\n\ndef test_check():\n    check(get_median)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef nth_nums(nums: List[int], n: int) -> List[int]:\n    \"\"\"\n\tWrite a function to compute the n-th power of each number in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30], 3) == [1000, 8000, 27000]\n    assert candidate([12, 15], 5) == [248832, 759375]\n\ndef test_check():\n    check(nth_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "py",
+    "prompt": "def is_upper(string: str) -> str:\n    \"\"\"\n\tWrite a python function to convert a given string to uppercase.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('person') == 'PERSON'\n    assert candidate('final') == 'FINAL'\n    assert candidate('Valid') == 'VALID'\n\ndef test_check():\n    check(is_upper)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef swap_List(newList: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to interchange the first and last element in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n\ndef test_check():\n    check(swap_List)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef triangle_area(r: int) -> Optional[int]:\n    \"\"\"\n\tWrite a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(-1) == None\n    assert candidate(0) == 0\n    assert candidate(2) == 4\n\ndef test_check():\n    check(triangle_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_First_Missing(array: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the smallest missing number from a sorted list of natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 1, 2, 3]) == 4\n    assert candidate([0, 1, 2, 6, 9]) == 3\n    assert candidate([2, 3, 5, 8, 9]) == 0\n\ndef test_check():\n    check(find_First_Missing)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "py",
+    "prompt": "def replace_spaces(string: str) -> str:\n    \"\"\"\n\tWrite a function to replace all spaces in the given string with '%20'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('My Name is Dawood') == 'My%20Name%20is%20Dawood'\n    assert candidate('I am a Programmer') == 'I%20am%20a%20Programmer'\n    assert candidate('I love Coding') == 'I%20love%20Coding'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Split(list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to find even numbers from a list of numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5]) == [2, 4]\n    assert candidate([4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0]\n    assert candidate([8, 12, 15, 19]) == [8, 12]\n\ndef test_check():\n    check(Split)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef smallest_num(xs: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find smallest number in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 1, 45, 99]) == 1\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([45, 46, 50, 60]) == 45\n\ndef test_check():\n    check(smallest_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "py",
+    "prompt": "from typing import Tuple, List\n\ndef get_coordinates(test_tup: Tuple[int, int]) -> List[List[int]]:\n    \"\"\"\n\tWrite a function to extract all the adjacent coordinates of the given coordinate tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]\n    assert candidate((4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]\n    assert candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]\n\ndef test_check():\n    check(get_coordinates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "py",
+    "prompt": "def replace_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace whitespaces with an underscore and vice versa in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Jumanji The Jungle') == 'Jumanji_The_Jungle'\n    assert candidate('The_Avengers') == 'The Avengers'\n    assert candidate('Fast and Furious') == 'Fast_and_Furious'\n\ndef test_check():\n    check(replace_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef move_zero(num_list: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to move all zeroes to the end of the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0]\n    assert candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0]\n    assert candidate([0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0]\n\ndef test_check():\n    check(move_zero)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pair_xor_Sum(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of xor of all pairs of numbers in the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 9, 7, 6], 4) == 47\n    assert candidate([7, 3, 5], 3) == 12\n    assert candidate([7, 3], 2) == 4\n\ndef test_check():\n    check(pair_xor_Sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef heap_sort(iterable: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate([7, 1, 9, 5]) == [1, 5, 7, 9]\n\ndef test_check():\n    check(heap_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "py",
+    "prompt": "def noprofit_noloss(actual_cost: int, sale_amount: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given amount has no profit and no loss\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1500, 1200) == False\n    assert candidate(100, 100) == True\n    assert candidate(2000, 5000) == False\n\ndef test_check():\n    check(noprofit_noloss)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "py",
+    "prompt": "def wind_chill(v: int, t: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(120, 35) == 40\n    assert candidate(40, 20) == 19\n    assert candidate(10, 8) == 6\n\ndef test_check():\n    check(wind_chill)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sample_nam(sample_names: List[str]) -> int:\n    \"\"\"\n\tWrite a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith']) == 16\n    assert candidate(['php', 'res', 'Python', 'abcd', 'Java', 'aaa']) == 10\n    assert candidate(['abcd', 'Python', 'abba', 'aba']) == 6\n\ndef test_check():\n    check(sample_nam)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef max_difference(test_list: List[Tuple[int, int]]) -> int:\n    \"\"\"\n\tWrite a function to find the maximum difference between available pairs in the given tuple list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7\n    assert candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15\n    assert candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23\n\ndef test_check():\n    check(max_difference)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef remove_parenthesis(items: List[str]) -> str:\n    \"\"\"\n\tWrite a function to remove the parenthesis and what is inbetween them from a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['python (chrome)']) == 'python'\n    assert candidate(['string(.abc)']) == 'string'\n    assert candidate(['alpha(num)']) == 'alpha'\n\ndef test_check():\n    check(remove_parenthesis)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "py",
+    "prompt": "def is_nonagonal(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth nonagonal number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 325\n    assert candidate(15) == 750\n    assert candidate(18) == 1089\n\ndef test_check():\n    check(is_nonagonal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "py",
+    "prompt": "def text_match_wordz_middle(text: str) -> bool:\n    \"\"\"\n\tWrite a function that checks if a strings contains 'z', except at the start and end of the word.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('pythonzabc.') == True\n    assert candidate('zxyabc.') == False\n    assert candidate('  lang  .') == False\n\ndef test_check():\n    check(text_match_wordz_middle)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef reverse_Array_Upto_K(input: List[int], k: int) -> List[int]:\n    \"\"\"\n\tWrite a python function to reverse an array upto a given position.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], 4) == [4, 3, 2, 1, 5, 6]\n    assert candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7]\n    assert candidate([9, 8, 7, 6, 5], 3) == [7, 8, 9, 6, 5]\n\ndef test_check():\n    check(reverse_Array_Upto_K)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef subject_marks(subjectmarks: List[Tuple[str, int]]) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to sort a list of tuples using the second value of each tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)]) == [('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]\n    assert candidate([('Telugu', 49), ('Hindhi', 54), ('Social', 33)]) == [('Social', 33), ('Telugu', 49), ('Hindhi', 54)]\n    assert candidate([('Physics', 96), ('Chemistry', 97), ('Biology', 45)]) == [('Biology', 45), ('Physics', 96), ('Chemistry', 97)]\n\ndef test_check():\n    check(subject_marks)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "py",
+    "prompt": "from typing import List, Union\n\ndef recursive_list_sum(data_list: List[Union[int, List[int]]]) -> int:\n    \"\"\"\n\tWrite a function to flatten a list and sum all of its elements.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, [3, 4], [5, 6]]) == 21\n    assert candidate([7, 10, [15, 14], [19, 41]]) == 106\n    assert candidate([10, 20, [30, 40], [50, 60]]) == 210\n\ndef test_check():\n    check(recursive_list_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef pos_count(list: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of positive numbers in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, -2, 3, -4]) == 2\n    assert candidate([3, 4, 5, -1]) == 3\n    assert candidate([1, 2, 3, 4]) == 4\n\ndef test_check():\n    check(pos_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "py",
+    "prompt": "def bell_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the number of ways to partition a set of Bell numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 2\n    assert candidate(10) == 115975\n    assert candidate(56) == 6775685320645824322581483068371419745979053216268760300\n\ndef test_check():\n    check(bell_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_Monotonic(A: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given array is monotonic or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([6, 5, 4, 4]) == True\n    assert candidate([1, 2, 2, 3]) == True\n    assert candidate([1, 3, 2]) == False\n\ndef test_check():\n    check(is_Monotonic)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_sublist(l: List[int], s: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether a list contains the given sublist or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 4, 3, 5, 7], [3, 7]) == False\n    assert candidate([2, 4, 3, 5, 7], [4, 3]) == True\n    assert candidate([2, 4, 3, 5, 7], [1, 6]) == False\n\ndef test_check():\n    check(is_sublist)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "py",
+    "prompt": "def differ_At_One_Bit_Pos(a: int, b: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the two numbers differ at one bit position only or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(13, 9) == True\n    assert candidate(15, 8) == False\n    assert candidate(2, 4) == False\n    assert candidate(2, 3) == True\n    assert candidate(5, 1) == True\n    assert candidate(1, 5) == True\n\ndef test_check():\n    check(differ_At_One_Bit_Pos)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_equal(Input: List[List[int]]) -> bool:\n    \"\"\"\n\tWrite a function to find whether all the given lists have equal length or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[11, 22, 33], [44, 55, 66]]) == True\n    assert candidate([[1, 2, 3], [4, 5, 6, 7]]) == False\n    assert candidate([[1, 2], [3, 4]]) == True\n\ndef test_check():\n    check(get_equal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef comb_sort(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a list of elements.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]\n    assert candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41]\n    assert candidate([99, 15, 13, 47]) == [13, 15, 47, 99]\n\ndef test_check():\n    check(comb_sort)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "py",
+    "prompt": "from typing import Tuple, Dict\n\ndef add_dict_to_tuple(test_tup: Tuple[int, int, int], test_dict: Dict[str, int]) -> Tuple[int, int, int, Dict[str, int]]:\n    \"\"\"\n\tWrite a function to add a dictionary to the tuple. The output should be a tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((4, 5, 6), { 'MSAM': 1, 'is': 2, 'best': 3 }) == (4, 5, 6, { 'MSAM': 1, 'is': 2, 'best': 3 })\n    assert candidate((1, 2, 3), { 'UTS': 2, 'is': 3, 'Worst': 4 }) == (1, 2, 3, { 'UTS': 2, 'is': 3, 'Worst': 4 })\n    assert candidate((8, 9, 10), { 'POS': 3, 'is': 4, 'Okay': 5 }) == (8, 9, 10, { 'POS': 3, 'is': 4, 'Okay': 5 })\n\ndef test_check():\n    check(add_dict_to_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef maxAverageOfPath(cost: List[List[int]]) -> float:\n    \"\"\"\n\tGiven a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2\n    assert candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2\n    assert candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2\n    assert candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8\n\ndef test_check():\n    check(maxAverageOfPath)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "py",
+    "prompt": "from typing import Dict, Tuple\n\ndef filter_data(students: Dict[str, Tuple[float, int]], h: float, w: int) -> Dict[str, Tuple[float, int]]:\n    \"\"\"\n\tThe input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 6.0, 70) == { 'Cierra Vega': (6.2, 70) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.9, 67) == { 'Cierra Vega': (6.2, 70), 'Kierra Gentry': (6.0, 68) }\n    assert candidate({ 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }, 5.7, 64) == { 'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66) }\n\ndef test_check():\n    check(filter_data)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_same_pair(nums1: List[int], nums2: List[int]) -> int:\n    \"\"\"\n\tThe input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]) == 4\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1\n    assert candidate([0, 1, 1, 2], [0, 1, 2, 2]) == 3\n\ndef test_check():\n    check(count_same_pair)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "py",
+    "prompt": "def power_base_sum(base: int, power: int) -> int:\n    \"\"\"\n\tWrite a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2, 100) == 115\n    assert candidate(8, 10) == 37\n    assert candidate(8, 15) == 62\n    assert candidate(3, 3) == 9\n\ndef test_check():\n    check(power_base_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef extract_quotation(text1: str) -> List[Any]:\n    \"\"\"\n\tWrite a function to extract values between quotation marks \" \" of the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']\n    assert candidate('Cast your \"favorite\" entertainment \"apps\"') == ['favorite', 'apps']\n    assert candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support') == ['4k Ultra HD', 'HDR 10']\n    assert candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == []\n\ndef test_check():\n    check(extract_quotation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef multiply_elements(test_tup: List[int]) -> List[Any]:\n    \"\"\"\n\tWrite a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 7, 8, 10]) == [5, 35, 56, 80]\n    assert candidate([2, 4, 5, 6, 7]) == [8, 20, 30, 42]\n    assert candidate([12, 13, 14, 9, 15]) == [156, 182, 126, 135]\n    assert candidate([12]) == []\n\ndef test_check():\n    check(multiply_elements)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_list(lst1: List[int], lst2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 20, 30], [15, 25, 35]) == [25, 45, 65]\n    assert candidate([1, 2, 3], [5, 6, 7]) == [6, 8, 10]\n    assert candidate([15, 20, 30], [15, 45, 75]) == [30, 65, 105]\n\ndef test_check():\n    check(sum_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "py",
+    "prompt": "def dif_Square(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the given number can be represented as the difference of two squares or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == True\n    assert candidate(10) == False\n    assert candidate(15) == True\n\ndef test_check():\n    check(dif_Square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef consecutive_duplicates(nums: List[Any]) -> List[Any]:\n    \"\"\"\n\tWrite a function to remove consecutive duplicates of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == ['a', 'b', 'c', 'd']\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd', 'a', 'a']) == ['a', 'b', 'c', 'd', 'a']\n\ndef test_check():\n    check(consecutive_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "py",
+    "prompt": "def lateralsurface_cone(r: int, h: int) -> float:\n    \"\"\"\n\tWrite a function to find the lateral surface area of a cone given radius r and the height h.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5, 12) == 204.20352248333654\n    assert candidate(10, 15) == 566.3586699569488\n    assert candidate(19, 17) == 1521.8090132193388\n\ndef test_check():\n    check(lateralsurface_cone)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "py",
+    "prompt": "def replace_specialchar(text: str) -> str:\n    \"\"\"\n\tWrite a function to replace all occurrences of spaces, commas, or dots with a colon.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Python language, Programming language.') == 'Python:language::Programming:language:'\n    assert candidate('a b c,d e f') == 'a:b:c:d:e:f'\n    assert candidate('ram reshma,ram rahim') == 'ram:reshma:ram:rahim'\n\ndef test_check():\n    check(replace_specialchar)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_first_occurrence(A: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to find the index of the first occurrence of a given number in a sorted array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1\n    assert candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2\n    assert candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4\n\ndef test_check():\n    check(find_first_occurrence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sum_Of_Subarray_Prod(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 20\n    assert candidate([1, 2]) == 5\n    assert candidate([1, 2, 3, 4]) == 84\n\ndef test_check():\n    check(sum_Of_Subarray_Prod)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "py",
+    "prompt": "def toggle_middle_bits(n: int) -> int:\n    \"\"\"\n\tWrite a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(9) == 15\n    assert candidate(10) == 12\n    assert candidate(11) == 13\n    assert candidate(65) == 127\n    assert candidate(77) == 115\n\ndef test_check():\n    check(toggle_middle_bits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef left_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(left_insertion)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "py",
+    "prompt": "def check_str(string: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given string is starting with a vowel or not using regex.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('annie') == True\n    assert candidate('dawood') == False\n    assert candidate('Else') == True\n\ndef test_check():\n    check(check_str)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "py",
+    "prompt": "def geometric_sum(n: int) -> float:\n    \"\"\"\n\tWrite a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(7) == 1.9921875\n    assert candidate(4) == 1.9375\n    assert candidate(8) == 1.99609375\n\ndef test_check():\n    check(geometric_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "py",
+    "prompt": "def find_Index(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 14\n    assert candidate(4) == 45\n\ndef test_check():\n    check(find_Index)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "py",
+    "prompt": "from typing import Tuple, Dict\n\ndef tuple_to_dict(test_tup: Tuple[int, int, int, int, int, int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, 10, 13, 5)) == { 1: 5, 7: 10, 13: 5 }\n    assert candidate((1, 2, 3, 4, 5, 6)) == { 1: 2, 3: 4, 5: 6 }\n    assert candidate((7, 8, 9, 10, 11, 12)) == { 7: 8, 9: 10, 11: 12 }\n\ndef test_check():\n    check(tuple_to_dict)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "py",
+    "prompt": "def all_Characters_Same(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether all the characters are same or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python') == False\n    assert candidate('aaa') == True\n    assert candidate('data') == False\n\ndef test_check():\n    check(all_Characters_Same)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "py",
+    "prompt": "def area_tetrahedron(side: int) -> float:\n    \"\"\"\n\tWrite a function to caluclate the area of a tetrahedron.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3) == 15.588457268119894\n    assert candidate(20) == 692.8203230275509\n    assert candidate(10) == 173.20508075688772\n\ndef test_check():\n    check(area_tetrahedron)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rotate_right(list: List[int], m: int) -> List[int]:\n    \"\"\"\n\tWrite a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5]\n\ndef test_check():\n    check(rotate_right)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "py",
+    "prompt": "from typing import Any\n\ndef check_none(test_tup: Any) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuple has any none value or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((10, 4, 5, 6, None)) == True\n    assert candidate((7, 8, 9, 11, 14)) == False\n    assert candidate((1, 2, 3, 4, None)) == True\n\ndef test_check():\n    check(check_none)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef divisible_by_digits(startnum: int, endnum: int) -> List[int]:\n    \"\"\"\n\tWrite a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]\n    assert candidate(1, 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]\n    assert candidate(20, 25) == [22, 24]\n\ndef test_check():\n    check(divisible_by_digits)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "py",
+    "prompt": "from typing import Optional\n\ndef sector_area(r: int, a: int) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(4, 45) == 6.283185307179586\n    assert candidate(9, 45) == 31.808625617596654\n    assert candidate(9, 361) == None\n\ndef test_check():\n    check(sector_area)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "py",
+    "prompt": "def lcs_of_three(X: str, Y: str, Z: str) -> int:\n    \"\"\"\n\tWrite a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('AGGT12', '12TXAYB', '12XBA') == 2\n    assert candidate('Reels', 'Reelsfor', 'ReelsforReels') == 5\n    assert candidate('abcd1e2', 'bc12ea', 'bd1ea') == 3\n\ndef test_check():\n    check(lcs_of_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "py",
+    "prompt": "def capital_words_spaces(str1: str) -> str:\n    \"\"\"\n\tWrite a function to put spaces between words starting with capital letters in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Python') == 'Python'\n    assert candidate('PythonProgrammingExamples') == 'Python Programming Examples'\n    assert candidate('GetReadyToBeCodingFreak') == 'Get Ready To Be Coding Freak'\n\ndef test_check():\n    check(capital_words_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef sort_numeric_strings(nums_str: List[str]) -> List[int]:\n    \"\"\"\n\tWrite a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['4', '12', '45', '7', '0', '100', '200', '-12', '-500']) == [-500, -12, 0, 4, 7, 12, 45, 100, 200]\n    assert candidate(['2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2']) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]\n    assert candidate(['1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11']) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]\n\ndef test_check():\n    check(sort_numeric_strings)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_samepatterns(colors: List[str], patterns: List[str]) -> bool:\n    \"\"\"\n\tWrite a function to check whether it follows the sequence given in the patterns array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['red', 'green', 'green'], ['a', 'b', 'b']) == True\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b', 'b']) == False\n    assert candidate(['red', 'green', 'greenn'], ['a', 'b']) == False\n\ndef test_check():\n    check(is_samepatterns)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef add_tuple(test_list: List[int], test_tup: Tuple[int, int]) -> List[int]:\n    \"\"\"\n\tWrite a function to add the given tuple to the given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]\n    assert candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11]\n    assert candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12]\n\ndef test_check():\n    check(add_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_min_heap(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6]) == True\n    assert candidate([2, 3, 4, 5, 10, 15]) == True\n    assert candidate([2, 10, 4, 5, 3, 15]) == False\n\ndef test_check():\n    check(check_min_heap)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "py",
+    "prompt": "def jacobsthal_num(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 11\n    assert candidate(2) == 1\n    assert candidate(4) == 5\n    assert candidate(13) == 2731\n\ndef test_check():\n    check(jacobsthal_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef min_k(test_list: List[Tuple[str, int]], K: int) -> List[Tuple[str, int]]:\n    \"\"\"\n\tWrite a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]\n    assert candidate([('Sanjeev', 11), ('Angat', 5), ('Akash', 3), ('Nepin', 9)], 3) == [('Akash', 3), ('Angat', 5), ('Nepin', 9)]\n    assert candidate([('tanmay', 14), ('Amer', 11), ('Ayesha', 9), ('SKD', 16)], 1) == [('Ayesha', 9)]\n\ndef test_check():\n    check(min_k)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[Any]:\n    \"\"\"\n\tWe say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 7]\n    assert candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]) == [1, 6]\n    assert candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == [1, 5]\n    assert candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]) == []\n\ndef test_check():\n    check(extract_index_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "py",
+    "prompt": "from typing import List, Union, Optional\n\ndef second_smallest(numbers: List[Union[int, float]]) -> Optional[float]:\n    \"\"\"\n\tWrite a function to find the second smallest number in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, -8, -2, 0, -2]) == -2\n    assert candidate([1, 1, -0.5, 0, 2, -2, -2]) == -0.5\n    assert candidate([2, 2]) == None\n    assert candidate([2, 2, 2]) == None\n\ndef test_check():\n    check(second_smallest)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "py",
+    "prompt": "def text_match_zero_one(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('dsabbbba') == True\n    assert candidate('asbbbba') == False\n    assert candidate('abaaa') == True\n\ndef test_check():\n    check(text_match_zero_one)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_reverse_pairs(test_list: List[str]) -> int:\n    \"\"\"\n\tWrite a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['julia', 'best', 'tseb', 'for', 'ailuj']) == 2\n    assert candidate(['geeks', 'best', 'for', 'skeeg']) == 1\n    assert candidate(['makes', 'best', 'sekam', 'for', 'rof']) == 2\n\ndef test_check():\n    check(count_reverse_pairs)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "py",
+    "prompt": "def is_decimal(num: str) -> bool:\n    \"\"\"\n\tWrite a function to check whether a given string is a decimal number with a precision of 2.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('123.11') == True\n    assert candidate('e666.86') == False\n    assert candidate('3.124587') == False\n    assert candidate('1.11') == True\n    assert candidate('1.1.11') == False\n\ndef test_check():\n    check(is_decimal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_tuples(test_list: List[Tuple[int, int, int]], K: int) -> List[Tuple[int, int, int]]:\n    \"\"\"\n\tWrite a function to find tuples which have all elements divisible by k from the given list of tuples.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == [(6, 24, 12)]\n    assert candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == [(5, 25, 30)]\n    assert candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == [(8, 16, 4)]\n\ndef test_check():\n    check(find_tuples)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef unique_Element(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether a list of numbers contains only one distinct element or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 1]) == True\n    assert candidate([1, 2, 1, 2]) == False\n    assert candidate([1, 2, 3, 4, 5]) == False\n\ndef test_check():\n    check(unique_Element)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "py",
+    "prompt": "def check_monthnumber_number(monthnum3: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(6) == True\n    assert candidate(2) == False\n    assert candidate(12) == False\n\ndef test_check():\n    check(check_monthnumber_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_min_diff(arr: List[int], n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 5, 3, 19, 18, 25], 6) == 1\n    assert candidate([4, 3, 2, 6], 4) == 1\n    assert candidate([30, 5, 20, 9], 4) == 4\n\ndef test_check():\n    check(find_min_diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "py",
+    "prompt": "def number_ctr(str: str) -> int:\n    \"\"\"\n\tWrite a python function to count number of digits in a given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('program2bedone') == 1\n    assert candidate('3wonders') == 1\n    assert candidate('123') == 3\n    assert candidate('3wond-1ers2') == 3\n\ndef test_check():\n    check(number_ctr)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "py",
+    "prompt": "def is_polite(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(7) == 11\n    assert candidate(4) == 7\n    assert candidate(9) == 13\n\ndef test_check():\n    check(is_polite)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef pair_wise(l1: List[int]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to return a list of all pairs of consecutive items in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]\n    assert candidate([1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)]\n    assert candidate([5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]\n\ndef test_check():\n    check(pair_wise)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef get_pairs_count(arr: List[int], sum: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 1, 1, 1], 2) == 6\n    assert candidate([1, 5, 7, -1, 5], 6) == 3\n    assert candidate([1, -2, 3], 1) == 1\n    assert candidate([-1, -2, 3], -3) == 1\n\ndef test_check():\n    check(get_pairs_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Diff(li1: List[int], li2: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a python function to get the difference between two lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]) == [10, 20, 30, 15]\n    assert candidate([1, 2, 3, 4, 5], [6, 7, 1]) == [2, 3, 4, 5, 6, 7]\n    assert candidate([1, 2, 3], [6, 7, 1]) == [2, 3, 6, 7]\n\ndef test_check():\n    check(Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "py",
+    "prompt": "def odd_num_sum(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of fourth power of first n odd natural numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2) == 82\n    assert candidate(3) == 707\n    assert candidate(4) == 3108\n\ndef test_check():\n    check(odd_num_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "py",
+    "prompt": "def check_expression(exp: str) -> bool:\n    \"\"\"\n\tWrite a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('{()}[{}]') == True\n    assert candidate('{()}[{]') == False\n    assert candidate('{()}[{}][]({})') == True\n\ndef test_check():\n    check(check_expression)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "py",
+    "prompt": "def remove_length(test_str: str, K: int) -> str:\n    \"\"\"\n\tWrite a function to remove all the words with k length in the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('The person is most value tet', 3) == 'person is most value'\n    assert candidate('If you told me about this ok', 4) == 'If you me about ok'\n    assert candidate('Forces of darkeness is come into the play', 4) == 'Forces of darkeness is the'\n\ndef test_check():\n    check(remove_length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "py",
+    "prompt": "from typing import Optional, Tuple\n\ndef occurance_substring(text: str, pattern: str) -> Optional[Tuple[str, int, int]]:\n    \"\"\"\n\tWrite a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python programming, python language', 'python') == ('python', 0, 6)\n    assert candidate('python programming,programming language', 'programming') == ('programming', 7, 18)\n    assert candidate('python programming,programming language', 'language') == ('language', 31, 39)\n    assert candidate('c++ programming, c++ language', 'python') == None\n\ndef test_check():\n    check(occurance_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef odd_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every odd index contains odd numbers of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([2, 1, 4, 3, 6, 7, 6, 3]) == True\n    assert candidate([4, 1, 2]) == True\n    assert candidate([1, 2, 3]) == False\n\ndef test_check():\n    check(odd_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "py",
+    "prompt": "def count_vowels(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to count those characters which have vowels as their neighbors in the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('bestinstareels') == 7\n    assert candidate('partofthejourneyistheend') == 12\n    assert candidate('amazonprime') == 5\n\ndef test_check():\n    check(count_vowels)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of non-repeated elements in a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 1, 1, 4, 5, 6]) == 21\n    assert candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71\n    assert candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78\n\ndef test_check():\n    check(find_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "py",
+    "prompt": "from typing import List, Any\n\ndef pack_consecutive_duplicates(list1: List[Any]) -> List[List[Any]]:\n    \"\"\"\n\tWrite a function to pack consecutive duplicates of a given list elements into sublists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd']) == [['a', 'a'], ['b'], ['c'], ['d', 'd']]\n\ndef test_check():\n    check(pack_consecutive_duplicates)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "py",
+    "prompt": "def is_Diff(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to find whether a number is divisible by 11.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(12345) == False\n    assert candidate(1212112) == True\n    assert candidate(1212) == False\n\ndef test_check():\n    check(is_Diff)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef find_combinations(test_list: List[Tuple[int, int]]) -> List[Tuple[int, int]]:\n    \"\"\"\n\tWrite a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]\n\ndef test_check():\n    check(find_combinations)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "py",
+    "prompt": "def count_divisors(n: int) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == True\n    assert candidate(100) == False\n    assert candidate(125) == True\n\ndef test_check():\n    check(count_divisors)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef odd_length_sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4]) == 14\n    assert candidate([1, 2, 1, 2]) == 15\n    assert candidate([1, 7]) == 8\n\ndef test_check():\n    check(odd_length_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef rgb_to_hsv(r: int, g: int, b: int) -> List[float]:\n    \"\"\"\n\tWrite a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(255, 255, 255) == [0.0, 0.0, 100.0]\n    assert candidate(0, 215, 0) == [120.0, 100.0, 84.31372549019608]\n    assert candidate(10, 215, 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608]\n\ndef test_check():\n    check(rgb_to_hsv)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef mul_even_odd(list1: List[int]) -> int:\n    \"\"\"\n\tWrite a function to find the product of first even and odd number of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2\n    assert candidate([1, 5, 7, 9, 10]) == 10\n\ndef test_check():\n    check(mul_even_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef tuple_str_int(test_str: str) -> Tuple[int, int, int]:\n    \"\"\"\n\tWrite a function to convert tuple string to integer tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('(7, 8, 9)') == (7, 8, 9)\n    assert candidate('(1, 2, 3)') == (1, 2, 3)\n    assert candidate('(4, 5, 6)') == (4, 5, 6)\n    assert candidate('(7, 81, 19)') == (7, 81, 19)\n\ndef test_check():\n    check(tuple_str_int)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef right_insertion(a: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a function to locate the right insertion point for a specified value in sorted order.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 4, 5], 6) == 4\n    assert candidate([1, 2, 4, 5], 3) == 2\n    assert candidate([1, 2, 4, 5], 7) == 4\n\ndef test_check():\n    check(right_insertion)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "py",
+    "prompt": "def text_match_three(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an a followed by three 'b'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('ac') == False\n    assert candidate('dc') == False\n    assert candidate('abbbba') == True\n    assert candidate('caacabbbba') == True\n\ndef test_check():\n    check(text_match_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef new_tuple(test_list: List[str], test_str: str) -> Tuple[str, str, str]:\n    \"\"\"\n\tWrite a function to create a new tuple from the given string and list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['WEB', 'is'], 'best') == ('WEB', 'is', 'best')\n    assert candidate(['We', 'are'], 'Developers') == ('We', 'are', 'Developers')\n    assert candidate(['Part', 'is'], 'Wrong') == ('Part', 'is', 'Wrong')\n\ndef test_check():\n    check(new_tuple)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef even_position(nums: List[int]) -> bool:\n    \"\"\"\n\tWrite a python function to check whether every even index contains even numbers of a given list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == False\n    assert candidate([1, 2, 3]) == False\n    assert candidate([2, 1, 4]) == True\n\ndef test_check():\n    check(even_position)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "py",
+    "prompt": "from typing import Any, Tuple\n\ndef remove_nested(test_tup: Any) -> Tuple[int, int, int, int]:\n    \"\"\"\n\tWrite a function to remove tuples from the given tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)\n    assert candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11)\n    assert candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12)\n    assert candidate((3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12)\n\ndef test_check():\n    check(remove_nested)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_list(input_list: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of lists in a given number of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4\n    assert candidate([[1, 2], [2, 3], [4, 5]]) == 3\n    assert candidate([[1, 0], [2, 0]]) == 2\n\ndef test_check():\n    check(count_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef last(arr: List[int], x: int) -> int:\n    \"\"\"\n\tWrite a python function to find the last position of an element in a sorted array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3], 1) == 0\n    assert candidate([1, 1, 1, 2, 3, 4], 1) == 2\n    assert candidate([2, 3, 2, 3, 6, 8, 9], 3) == 3\n\ndef test_check():\n    check(last)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "py",
+    "prompt": "def text_starta_endb(text: str) -> bool:\n    \"\"\"\n\tWrite a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('aabbbb') == True\n    assert candidate('aabAbbbc') == False\n    assert candidate('accddbbjjj') == False\n\ndef test_check():\n    check(text_starta_endb)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef return_sum(dict: Dict[str, int]) -> int:\n    \"\"\"\n\tWrite function to find the sum of all items in the given dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'a': 100, 'b': 200, 'c': 300 }) == 600\n    assert candidate({ 'a': 25, 'b': 18, 'c': 45 }) == 88\n    assert candidate({ 'a': 36, 'b': 39, 'c': 49 }) == 124\n\ndef test_check():\n    check(return_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "py",
+    "prompt": "def sum_in_range(l: int, r: int) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of all odd natural numbers within the range l and r.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(2, 5) == 8\n    assert candidate(5, 7) == 12\n    assert candidate(7, 13) == 40\n\ndef test_check():\n    check(sum_in_range)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef _sum(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the sum of an array.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([15, 12, 13, 10]) == 50\n    assert candidate([0, 1, 2]) == 3\n\ndef test_check():\n    check(_sum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "py",
+    "prompt": "def left_rotate(n: int, d: int) -> int:\n    \"\"\"\n\tWrite a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(16, 2) == 64\n    assert candidate(10, 2) == 40\n    assert candidate(99, 3) == 792\n    assert candidate(99, 3) == 792\n    assert candidate(1, 3) == 8\n    assert candidate(5, 3) == 40\n    assert candidate(29, 3) == 232\n\ndef test_check():\n    check(left_rotate)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "py",
+    "prompt": "def word_len(s: str) -> bool:\n    \"\"\"\n\tWrite a python function to check whether the length of the word is odd or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('Hadoop') == False\n    assert candidate('great') == True\n    assert candidate('structure') == True\n\ndef test_check():\n    check(word_len)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "py",
+    "prompt": "def remove_all_spaces(text: str) -> str:\n    \"\"\"\n\tWrite a function to remove all whitespaces from a string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('python  program') == 'pythonprogram'\n    assert candidate('python   programming    language') == 'pythonprogramminglanguage'\n    assert candidate('python                     program') == 'pythonprogram'\n    assert candidate('   python                     program') == 'pythonprogram'\n\ndef test_check():\n    check(remove_all_spaces)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "py",
+    "prompt": "def test_three_equal(x: int, y: int, z: int) -> int:\n    \"\"\"\n\tWrite a python function to count the number of equal numbers from three given integers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1, 1, 1) == 3\n    assert candidate(-1, -2, -3) == 0\n    assert candidate(1, 2, 2) == 2\n\ndef test_check():\n    check(test_three_equal)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef count_rotation(arr: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([3, 2, 1]) == 1\n    assert candidate([4, 5, 1, 2, 3]) == 2\n    assert candidate([7, 8, 9, 1, 2, 3]) == 3\n    assert candidate([1, 2, 3]) == 0\n    assert candidate([1, 3, 2]) == 2\n\ndef test_check():\n    check(count_rotation)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "py",
+    "prompt": "def is_perfect_square(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == False\n    assert candidate(36) == True\n    assert candidate(14) == False\n    assert candidate(196) == True\n    assert candidate(125) == False\n    assert candidate(15625) == True\n\ndef test_check():\n    check(is_perfect_square)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef is_product_even(arr: List[int]) -> bool:\n    \"\"\"\n\tWrite a function to check whether the product of numbers in a list is even or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3]) == True\n    assert candidate([1, 2, 1, 4]) == True\n    assert candidate([1, 1]) == False\n\ndef test_check():\n    check(is_product_even)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef max_sum_list(lists: List[List[int]]) -> List[int]:\n    \"\"\"\n\tWrite a function that returns the list in a list of lists whose sum of elements is the highest.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12]\n    assert candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10]\n    assert candidate([[2, 3, 1]]) == [2, 3, 1]\n\ndef test_check():\n    check(max_sum_list)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "py",
+    "prompt": "def max_run_uppercase(test_str: str) -> int:\n    \"\"\"\n\tWrite a function to find maximum run of uppercase characters in the given string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('GeMKSForGERksISBESt') == 5\n    assert candidate('PrECIOusMOVemENTSYT') == 6\n    assert candidate('GooGLEFluTTER') == 4\n\ndef test_check():\n    check(max_run_uppercase)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef first_odd(nums: List[int]) -> int:\n    \"\"\"\n\tWrite a python function to find the first odd number in a given list of numbers.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 3, 5]) == 1\n    assert candidate([2, 4, 1, 3]) == 1\n    assert candidate([8, 9, 1]) == 9\n\ndef test_check():\n    check(first_odd)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef check_K(test_tup: List[int], K: int) -> bool:\n    \"\"\"\n\tWrite a function to check if the given tuples contain the k or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 4, 5, 6, 8], 6) == True\n    assert candidate([1, 2, 3, 4, 5, 6], 7) == False\n    assert candidate([7, 8, 9, 44, 11, 12], 11) == True\n\ndef test_check():\n    check(check_K)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "py",
+    "prompt": "from typing import Tuple\n\ndef check_smaller(test_tup1: Tuple[int, int, int], test_tup2: Tuple[int, int, int]) -> bool:\n    \"\"\"\n\tWrite a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate((1, 2, 3), (2, 3, 4)) == False\n    assert candidate((4, 5, 6), (3, 4, 5)) == True\n    assert candidate((11, 12, 13), (10, 11, 12)) == True\n\ndef test_check():\n    check(check_smaller)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "py",
+    "prompt": "def tetrahedral_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth tetrahedral number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(5) == 35\n    assert candidate(6) == 56\n    assert candidate(7) == 84\n\ndef test_check():\n    check(tetrahedral_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "py",
+    "prompt": "def get_Char(strr: str) -> str:\n    \"\"\"\n\tWrite a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('abc') == 'f'\n    assert candidate('gfg') == 't'\n    assert candidate('ab') == 'c'\n\ndef test_check():\n    check(get_Char)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "py",
+    "prompt": "def sequence(n: int) -> int:\n    \"\"\"\n\tWrite a function to find the nth number in the newman conway sequence.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 6\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n\ndef test_check():\n    check(sequence)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "py",
+    "prompt": "def centered_hexagonal_number(n: int) -> int:\n    \"\"\"\n\tWrite a function to find nth centered hexagonal number.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(10) == 271\n    assert candidate(2) == 7\n    assert candidate(9) == 217\n\ndef test_check():\n    check(centered_hexagonal_number)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "py",
+    "prompt": "from typing import Dict\n\ndef merge_dictionaries_three(dict1: Dict[str, str], dict2: Dict[str, str], dict3: Dict[str, str]) -> Dict[str, str]:\n    \"\"\"\n\tWrite a function to merge three dictionaries into a single dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'O': 'Orange', 'W': 'White', 'B': 'Black' }) == { 'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'G': 'Green', 'W': 'White' }, { 'L': 'lavender', 'B': 'Blue' }) == { 'W': 'White', 'P': 'Pink', 'B': 'Black', 'R': 'Red', 'G': 'Green', 'L': 'lavender' }\n    assert candidate({ 'R': 'Red', 'B': 'Black', 'P': 'Pink' }, { 'L': 'lavender', 'B': 'Blue' }, { 'G': 'Green', 'W': 'White' }) == { 'B': 'Black', 'P': 'Pink', 'R': 'Red', 'G': 'Green', 'L': 'lavender', 'W': 'White' }\n\ndef test_check():\n    check(merge_dictionaries_three)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef freq_count(list1: List[int]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to get the frequency of all the elements in a list, returned as a dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == { 10: 4, 20: 4, 40: 2, 50: 2, 30: 1 }\n    assert candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == { 1: 3, 2: 2, 3: 3, 4: 3 }\n    assert candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == { 10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2 }\n\ndef test_check():\n    check(freq_count)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "py",
+    "prompt": "def closest_num(N: int) -> int:\n    \"\"\"\n\tWrite a function to find the closest smaller number than n.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(11) == 10\n    assert candidate(7) == 6\n    assert candidate(12) == 11\n\ndef test_check():\n    check(closest_num)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef square_nums(nums: List[int]) -> List[int]:\n    \"\"\"\n\tWrite a function to find squares of individual elements in a list.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10, 20, 30]) == [100, 400, 900]\n    assert candidate([12, 15]) == [144, 225]\n\ndef test_check():\n    check(square_nums)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef len_log(list1: List[str]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the longest word.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['python', 'PHP', 'bigdata']) == 7\n    assert candidate(['a', 'ab', 'abc']) == 3\n    assert candidate(['small', 'big', 'tall']) == 5\n\ndef test_check():\n    check(len_log)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef find_substring(str1: List[str], sub_str: str) -> bool:\n    \"\"\"\n\tWrite a function to check if a string is present as a substring in a given list of string values.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ack') == True\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'abc') == False\n    assert candidate(['red', 'black', 'white', 'green', 'orange'], 'ange') == True\n\ndef test_check():\n    check(find_substring)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "py",
+    "prompt": "def is_undulating(n: int) -> bool:\n    \"\"\"\n\tWrite a function to check whether the given number is undulating or not.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(1212121) == True\n    assert candidate(1991) == False\n    assert candidate(121) == True\n\ndef test_check():\n    check(is_undulating)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "py",
+    "prompt": "def power(a: int, b: int) -> int:\n    \"\"\"\n\tWrite a function to calculate the value of 'a' to the power 'b'.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(3, 4) == 81\n    assert candidate(2, 3) == 8\n    assert candidate(5, 5) == 3125\n\ndef test_check():\n    check(power)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "py",
+    "prompt": "from typing import List, Tuple\n\ndef index_minimum(test_list: List[Tuple[str, int]]) -> str:\n    \"\"\"\n\tGiven a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'\n    assert candidate([('Yash', 185), ('Dawood', 125), ('Sanya', 175)]) == 'Dawood'\n    assert candidate([('Sai', 345), ('Salman', 145), ('Ayesha', 96)]) == 'Ayesha'\n\ndef test_check():\n    check(index_minimum)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "py",
+    "prompt": "from typing import List\n\ndef Find_Min_Length(lst: List[List[int]]) -> int:\n    \"\"\"\n\tWrite a python function to find the length of the smallest list in a list of lists.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1], [1, 2]]) == 1\n    assert candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2\n    assert candidate([[3, 3, 3], [4, 4, 4, 4]]) == 3\n\ndef test_check():\n    check(Find_Min_Length)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "py",
+    "prompt": "def divisor(n: int) -> int:\n    \"\"\"\n\tWrite a python function to find the number of divisors of a given integer.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(15) == 4\n    assert candidate(12) == 6\n    assert candidate(9) == 3\n\ndef test_check():\n    check(divisor)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "py",
+    "prompt": "from typing import List, Dict\n\ndef frequency_lists(list1: List[List[int]]) -> Dict[int, int]:\n    \"\"\"\n\tWrite a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == { 1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 }\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1 }\n    assert candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == { 20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1 }\n\ndef test_check():\n    check(frequency_lists)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "py",
+    "prompt": "def decimal_to_binary(n: int) -> str:\n    \"\"\"\n\tWrite a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate(8) == '1000'\n    assert candidate(18) == '10010'\n    assert candidate(7) == '111'\n\ndef test_check():\n    check(decimal_to_binary)\n\ntest_check()\n",
+    "stop_tokens": [
+      "\ndef",
+      "\n#",
+      "\nif",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "py",
+    "prompt": "def find_Rotations(str: str) -> int:\n    \"\"\"\n\tWrite a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n\t\"\"\"\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "def check(candidate):\n    assert candidate('aaaa') == 1\n    assert candidate('ab') == 2\n    assert candidate('abc') == 3\n\ndef test_check():\n    check(find_Rotations)\n\ntest_check()\n",
     "stop_tokens": [
       "\ndef",
       "\n#",

--- a/prompts/mbpp-r-keep.json
+++ b/prompts/mbpp-r-keep.json
@@ -1,3834 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "r",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nlps <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- lps\n    stopifnot(isTRUE(all.equal(candidate('TENS FOR TENS'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('CARDIO FOR CARDS'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('PART OF THE JOURNEY IS PART'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "r",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\nremove_whitespaces <- function(text1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_whitespaces\n    stopifnot(isTRUE(all.equal(candidate(' Google    Flutter '), 'GoogleFlutter')))\n    stopifnot(isTRUE(all.equal(candidate(' Google    Dart '), 'GoogleDart')))\n    stopifnot(isTRUE(all.equal(candidate(' iOS    Swift '), 'iOSSwift')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "r",
-    "prompt": "# Write a function to check whether a specified list is sorted or not.\nissort_list <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- issort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 15, 14, 20)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "r",
-    "prompt": "# Write a function to count bidirectional tuple pairs.\ncount_bidirectional <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_bidirectional\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 3), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 2), c(6, 5), c(2, 1))), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "r",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsurfacearea_cube <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 150)))\n    stopifnot(isTRUE(all.equal(candidate(3), 54)))\n    stopifnot(isTRUE(all.equal(candidate(10), 600)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "r",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nnext_smallest_palindrome <- function(num) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- next_smallest_palindrome\n    stopifnot(isTRUE(all.equal(candidate(99), 101)))\n    stopifnot(isTRUE(all.equal(candidate(1221), 1331)))\n    stopifnot(isTRUE(all.equal(candidate(120), 121)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\ncube_Sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cube_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 72)))\n    stopifnot(isTRUE(all.equal(candidate(3), 288)))\n    stopifnot(isTRUE(all.equal(candidate(4), 800)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\npair_xor_Sum <- function(arr, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pair_xor_Sum\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9, 7, 6), 4), 47)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 5), 3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3), 2), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "r",
-    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ncheck_min_heap <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_min_heap\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 10, 15)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 5, 3, 15)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "r",
-    "prompt": "# Write a python function to find the first digit of a given number.\nfirst_Digit <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 1)))\n    stopifnot(isTRUE(all.equal(candidate(456), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "r",
-    "prompt": "# Write a python function to find the first non-repeated character in a given string.\nfirst_non_repeating_character <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_non_repeating_character\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('ababc'), 'c')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "r",
-    "prompt": "# Write a function to convert degrees to radians.\nradian_degree <- function(degree) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- radian_degree\n    stopifnot(isTRUE(all.equal(candidate(90), 1.5707963267948966)))\n    stopifnot(isTRUE(all.equal(candidate(60), 1.0471975511965976)))\n    stopifnot(isTRUE(all.equal(candidate(120), 2.0943951023931953)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum product subarray of the given array.\nmax_subarray_product <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_subarray_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 0, 7, -8, -2)), 112)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, -3, -10, 0, 2)), 180)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -40, 0, -2, -3)), 80)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "r",
-    "prompt": "# Write a function to convert more than one list to nested dictionary.\nconvert_list_dictionary <- function(l1, l2, l3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- convert_list_dictionary\n    stopifnot(isTRUE(all.equal(candidate(c('S001', 'S002', 'S003', 'S004'), c('Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'), c(85, 98, 89, 92)), list(list('S001' = list('Adina Park' = 85)), list('S002' = list('Leyton Marsh' = 98)), list('S003' = list('Duncan Boyle' = 89)), list('S004' = list('Saim Richards' = 92))))))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'def', 'ghi', 'jkl'), c('python', 'program', 'language', 'programs'), c(100, 200, 300, 400)), list(list('abc' = list('python' = 100)), list('def' = list('program' = 200)), list('ghi' = list('language' = 300)), list('jkl' = list('programs' = 400))))))\n    stopifnot(isTRUE(all.equal(candidate(c('A1', 'A2', 'A3', 'A4'), c('java', 'C', 'C++', 'DBMS'), c(10, 20, 30, 40)), list(list('A1' = list('java' = 10)), list('A2' = list('C' = 20)), list('A3' = list('C++' = 30)), list('A4' = list('DBMS' = 40))))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "r",
-    "prompt": "# Write a python function to find smallest number in a list.\nsmallest_num <- function(xs) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_num\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 1, 45, 99)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(45, 46, 50, 60)), 45)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\ntext_match_zero_one <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_zero_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dsabbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('asbbbba'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abaaa'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "r",
-    "prompt": "# Write a python function to find nth bell number.\nbell_Number <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bell_Number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 15)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "r",
-    "prompt": "# Write a function to find cubes of individual elements in a list.\ncube_nums <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cube_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(1728, 3375))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "r",
-    "prompt": "# Write a python function to find the last digit in factorial of a given number.\nlast_Digit_Factorial <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit_Factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(21), 0)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "r",
-    "prompt": "# Write a python function to find even numbers from a list of numbers.\nSplit <- function(list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 8, 0, 1)), c(4, 6, 8, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 12, 15, 19)), c(8, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "r",
-    "prompt": "# Write a function to check if the given integer is a prime number.\nprime_num <- function(num) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_num\n    stopifnot(isTRUE(all.equal(candidate(13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(-1010), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "r",
-    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfind_tuples <- function(test_list, K) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 24, 12), c(7, 9, 6), c(12, 18, 21)), 6), list(c(6, 24, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 25, 30), c(4, 2, 3), c(7, 8, 9)), 5), list(c(5, 25, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 9, 16), c(8, 16, 4), c(19, 17, 18)), 4), list(c(8, 16, 4)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "r",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\narea_tetrahedron <- function(side) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- area_tetrahedron\n    stopifnot(isTRUE(all.equal(candidate(3), 15.588457268119894)))\n    stopifnot(isTRUE(all.equal(candidate(20), 692.8203230275509)))\n    stopifnot(isTRUE(all.equal(candidate(10), 173.20508075688772)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given number is even or not.\nis_Even <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Even\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of positive numbers in a list.\npos_count <- function(list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pos_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3, -4)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, -1)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "r",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nget_ludic <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_ludic\n    stopifnot(isTRUE(all.equal(candidate(10), c(1, 2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25))))\n    stopifnot(isTRUE(all.equal(candidate(45), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "r",
-    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfind_Index <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Index\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 14)))\n    stopifnot(isTRUE(all.equal(candidate(4), 45)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "r",
-    "prompt": "# Write a python function to reverse an array upto a given position.\nreverse_Array_Upto_K <- function(input, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_Array_Upto_K\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 4), c(4, 3, 2, 1, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7), 2), c(5, 4, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5), 3), c(7, 8, 9, 6, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "r",
-    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\nsubject_marks <- function(subjectmarks) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- subject_marks\n    stopifnot(isTRUE(all.equal(candidate(list(list('English', 88), list('Science', 90), list('Maths', 97), list('Social sciences', 82))), list(list('Social sciences', 82), list('English', 88), list('Science', 90), list('Maths', 97)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Telugu', 49), list('Hindhi', 54), list('Social', 33))), list(list('Social', 33), list('Telugu', 49), list('Hindhi', 54)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Physics', 96), list('Chemistry', 97), list('Biology', 45))), list(list('Biology', 45), list('Physics', 96), list('Chemistry', 97)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "r",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nremove_dirty_chars <- function(string, second_string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_dirty_chars\n    stopifnot(isTRUE(all.equal(candidate('probasscurve', 'pros'), 'bacuve')))\n    stopifnot(isTRUE(all.equal(candidate('digitalindia', 'talent'), 'digiidi')))\n    stopifnot(isTRUE(all.equal(candidate('exoticmiles', 'toxic'), 'emles')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "r",
-    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nround_and_sum <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- round_and_sum\n    stopifnot(isTRUE(all.equal(candidate(c(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)), 243)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 9, 24.3, 29)), 345)))\n    stopifnot(isTRUE(all.equal(candidate(c(25.0, 56.7, 89.2)), 513)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "r",
-    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nmax_occurrences <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_occurrences\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)), 20)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "r",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nis_decimal <- function(num) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_decimal\n    stopifnot(isTRUE(all.equal(candidate('123.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('e666.86'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('3.124587'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1.1.11'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "r",
-    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\ndict_filter <- function(dict, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- dict_filter\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 170), list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 180), list('Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 190), list('Pierre Cox' = 190))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\nsum_even_and_even_index <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_even_and_even_index\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1, 18, 8)), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)), 26)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nmax_sub_array_sum <- function(a, size) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, 4, -1, -2, 1, 5, -3), 8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5, -2, -3, 2, 6, -4), 8), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(-4, -5, 6, -3, -4, 3, 7, -5), 8), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "r",
-    "prompt": "# Write a function to find the intersection of two arrays.\nintersection_array <- function(array_nums1, array_nums2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(1, 2, 4, 8, 9)), c(1, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(3, 5, 7, 9)), c(3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(10, 20, 30, 40)), c(10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nsplit_two_parts <- function(list1, L) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_two_parts\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), list(c(1, 1, 2), c(3, 4, 4, 5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 2), list(c('a', 'b'), c('c', 'd')))))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n'), 4), list(c('p', 'y', 't', 'h'), c('o', 'n')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "r",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfind_literals <- function(text, pattern) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_literals\n    stopifnot(isTRUE(all.equal(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), list('fox', 16, 19))))\n    stopifnot(isTRUE(all.equal(candidate('Its been a very crazy procedure right', 'crazy'), list('crazy', 16, 21))))\n    stopifnot(isTRUE(all.equal(candidate('Hardest choices required strongest will', 'will'), list('will', 35, 39))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "r",
-    "prompt": "# Write a python function to find the volume of a triangular prism.\nfind_Volume <- function(l, b, h) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Volume\n    stopifnot(isTRUE(all.equal(candidate(10, 8, 6), 240)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "r",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nwind_chill <- function(v, t) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- wind_chill\n    stopifnot(isTRUE(all.equal(candidate(120, 35), 40)))\n    stopifnot(isTRUE(all.equal(candidate(40, 20), 19)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "r",
-    "prompt": "# Write a function to find the ascii value of a character.\nascii_value <- function(k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- ascii_value\n    stopifnot(isTRUE(all.equal(candidate('A'), 65)))\n    stopifnot(isTRUE(all.equal(candidate('R'), 82)))\n    stopifnot(isTRUE(all.equal(candidate('S'), 83)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "r",
-    "prompt": "# Write a python function to check whether all the characters are same or not.\nall_Characters_Same <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_Characters_Same\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('data'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "r",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\nmove_num <- function(test_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_num\n    stopifnot(isTRUE(all.equal(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')))\n    stopifnot(isTRUE(all.equal(candidate('Avengers124Assemble'), 'AvengersAssemble124')))\n    stopifnot(isTRUE(all.equal(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the length of the word is odd or not.\nword_len <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- word_len\n    stopifnot(isTRUE(all.equal(candidate('Hadoop'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('great'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('structure'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "r",
-    "prompt": "# Write a function to drop empty items from a given dictionary.\ndrop_empty <- function(dict1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- drop_empty\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = 'Green', 'c3' = NULL)), list('c1' = 'Red', 'c2' = 'Green'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = NULL, 'c3' = NULL)), list('c1' = 'Red'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = NULL, 'c2' = 'Green', 'c3' = NULL)), list('c2' = 'Green'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ninsert_element <- function(list, element) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- insert_element\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Black'), 'c'), c('c', 'Red', 'c', 'Green', 'c', 'Black'))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java'), 'program'), c('program', 'python', 'program', 'java'))))\n    stopifnot(isTRUE(all.equal(candidate(c('happy', 'sad'), 'laugh'), c('laugh', 'happy', 'laugh', 'sad'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "r",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\nremove_lowercase <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_lowercase\n    stopifnot(isTRUE(all.equal(candidate('PYTHon'), 'PYTH')))\n    stopifnot(isTRUE(all.equal(candidate('FInD'), 'FID')))\n    stopifnot(isTRUE(all.equal(candidate('STRinG'), 'STRG')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\ncount_Set_Bits <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Set_Bits\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "r",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\nextract_rear <- function(test_tuple) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_rear\n    stopifnot(isTRUE(all.equal(candidate(c('Mers', 'for', 'Vers')), c('s', 'r', 's'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Avenge', 'for', 'People')), c('e', 'r', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Gotta', 'get', 'go')), c('a', 't', 'o'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "r",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ncount_occurance <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_occurance\n    stopifnot(isTRUE(all.equal(candidate('letstdlenstdporstd'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('truststdsolensporsd'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('makestdsostdworthit'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('stds'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "r",
-    "prompt": "# Write a function to check if the given tuples contain the k or not.\ncheck_K <- function(test_tup, K) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_K\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6, 8), 6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 44, 11, 12), 11), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "r",
-    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ninterleave_lists <- function(list1, list2, list3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- interleave_lists\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7), c(10, 20, 30, 40, 50, 60, 70), c(100, 200, 300, 400, 500, 600, 700)), c(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20), c(15, 2), c(5, 10)), c(10, 15, 5, 20, 2, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 44), c(10, 15), c(20, 5)), c(11, 10, 20, 44, 15, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "r",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\nsnake_to_camel <- function(word) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('python_program'), 'PythonProgram')))\n    stopifnot(isTRUE(all.equal(candidate('python_language'), 'PythonLanguage')))\n    stopifnot(isTRUE(all.equal(candidate('programming_language'), 'ProgrammingLanguage')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\ntest_three_equal <- function(x, y, z) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- test_three_equal\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2, -3), 0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nodd_length_sum <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_length_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 7)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "r",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nbell_number <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bell_number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 115975)))\n    stopifnot(isTRUE(all.equal(candidate(56), 6775685320645824322581483068371419745979053216268760300)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "r",
-    "prompt": "# Write a function to find the area of a rectangle.\nrectangle_area <- function(l, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rectangle_area\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "r",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsum_average <- function(number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_average\n    stopifnot(isTRUE(all.equal(candidate(10), c(55, 5.5))))\n    stopifnot(isTRUE(all.equal(candidate(15), c(120, 8.0))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(210, 10.5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\ndivision_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- division_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(2, 2, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 16), c(6, 3, 4, 4)), c(2, 2, 2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(20, 14, 36, 18), c(5, 7, 6, 9)), c(4, 2, 6, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "r",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsum_digits <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_digits\n    stopifnot(isTRUE(all.equal(candidate(345), 12)))\n    stopifnot(isTRUE(all.equal(candidate(12), 3)))\n    stopifnot(isTRUE(all.equal(candidate(97), 16)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "r",
-    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nindex_minimum <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- index_minimum\n    stopifnot(isTRUE(all.equal(candidate(list(list('Rash', 143), list('Manjeet', 200), list('Varsha', 100))), 'Varsha')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Yash', 185), list('Dawood', 125), list('Sanya', 175))), 'Dawood')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sai', 345), list('Salman', 145), list('Ayesha', 96))), 'Ayesha')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "r",
-    "prompt": "# Write a function to divide two lists element wise.\ndiv_list <- function(nums1, nums2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- div_list\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(1, 2, 3)), c(4.0, 2.5, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2), c(1, 4)), c(3.0, 0.5))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(1.8, 1.7142857142857142))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "r",
-    "prompt": "# Write a function to find the list with maximum length.\nmax_length_list <- function(input_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_length_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5), c(1, 2, 3, 4), c(1, 2, 3), c(1, 2), c(1))), list(5, c(1, 2, 3, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(6, 7, 8, 9), c(10, 11, 12))), list(4, c(6, 7, 8, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "r",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ncombinations_list <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- combinations_list\n    stopifnot(isTRUE(all.equal(candidate(c('orange', 'red', 'green', 'blue')), list(c(), c('orange'), c('red'), c('red', 'orange'), c('green'), c('green', 'orange'), c('green', 'red'), c('green', 'red', 'orange'), c('blue'), c('blue', 'orange'), c('blue', 'red'), c('blue', 'red', 'orange'), c('blue', 'green'), c('blue', 'green', 'orange'), c('blue', 'green', 'red'), c('blue', 'green', 'red', 'orange')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'blue', 'white', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('blue'), c('blue', 'red'), c('blue', 'green'), c('blue', 'green', 'red'), c('white'), c('white', 'red'), c('white', 'green'), c('white', 'green', 'red'), c('white', 'blue'), c('white', 'blue', 'red'), c('white', 'blue', 'green'), c('white', 'blue', 'green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('black', 'blue'), c('black', 'blue', 'red'), c('black', 'blue', 'green'), c('black', 'blue', 'green', 'red'), c('black', 'white'), c('black', 'white', 'red'), c('black', 'white', 'green'), c('black', 'white', 'green', 'red'), c('black', 'white', 'blue'), c('black', 'white', 'blue', 'red'), c('black', 'white', 'blue', 'green'), c('black', 'white', 'blue', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'blue'), c('orange', 'blue', 'red'), c('orange', 'blue', 'green'), c('orange', 'blue', 'green', 'red'), c('orange', 'white'), c('orange', 'white', 'red'), c('orange', 'white', 'green'), c('orange', 'white', 'green', 'red'), c('orange', 'white', 'blue'), c('orange', 'white', 'blue', 'red'), c('orange', 'white', 'blue', 'green'), c('orange', 'white', 'blue', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red'), c('orange', 'black', 'blue'), c('orange', 'black', 'blue', 'red'), c('orange', 'black', 'blue', 'green'), c('orange', 'black', 'blue', 'green', 'red'), c('orange', 'black', 'white'), c('orange', 'black', 'white', 'red'), c('orange', 'black', 'white', 'green'), c('orange', 'black', 'white', 'green', 'red'), c('orange', 'black', 'white', 'blue'), c('orange', 'black', 'white', 'blue', 'red'), c('orange', 'black', 'white', 'blue', 'green'), c('orange', 'black', 'white', 'blue', 'green', 'red')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\nbig_sum <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- big_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "r",
-    "prompt": "# Write a python function to return the negative numbers in a list.\nneg_nos <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- neg_nos\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 4, 5, -6)), c(-1, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3, 4)), c(-1, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(-7, -6, 8, 9)), c(-7, -6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "r",
-    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\nhighest_Power_of_2 <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- highest_Power_of_2\n    stopifnot(isTRUE(all.equal(candidate(10), 8)))\n    stopifnot(isTRUE(all.equal(candidate(19), 16)))\n    stopifnot(isTRUE(all.equal(candidate(32), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "r",
-    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nis_sublist <- function(l, s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sublist\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(4, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(1, 6)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "r",
-    "prompt": "# Write a function to subtract two lists element-wise.\nsub_list <- function(nums1, nums2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sub_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), c(-3, -3, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 4)), c(-2, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(40, 50))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\nopposite_Signs <- function(x, y) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- opposite_Signs\n    stopifnot(isTRUE(all.equal(candidate(1, -2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-2, 2), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "r",
-    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\ntuple_modulo <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_modulo\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6), c(5, 6, 7, 5)), c(0, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 6, 7), c(6, 7, 8, 6)), c(5, 5, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 7, 8), c(7, 8, 9, 7)), c(5, 6, 7, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "r",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndiff_even_odd <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- diff_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "r",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white'))), list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('d', 'c'), c('g', 'h'), c('f', 'e'))), list(c('a', 'b'), c('c', 'd'), c('g', 'h'), c('e', 'f')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "r",
-    "prompt": "# Write a python function to find the last digit of a given number.\nlast_Digit <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 3)))\n    stopifnot(isTRUE(all.equal(candidate(25), 5)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\nodd_num_sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_num_sum\n    stopifnot(isTRUE(all.equal(candidate(2), 82)))\n    stopifnot(isTRUE(all.equal(candidate(3), 707)))\n    stopifnot(isTRUE(all.equal(candidate(4), 3108)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "r",
-    "prompt": "# Write a function to convert a list to a string.\ntup_string <- function(tup1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tup_string\n    stopifnot(isTRUE(all.equal(candidate(c('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's')), 'exercises')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'r', 'o', 'g', 'r', 'a', 'm')), 'program')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "r",
-    "prompt": "# Write a function to remove all elements from a given list present in another list.\nremove_elements <- function(list1, list2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(1, 3, 5, 7)), c(2, 4, 6, 8, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(5, 7)), c(1, 2, 3, 4, 6, 8, 9, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "r",
-    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\noverlapping <- function(list1, list2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- overlapping\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5), c(1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "r",
-    "prompt": "# Write a python function to identify non-prime numbers.\nis_not_prime <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_not_prime\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(35), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(37), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nmax_val <- function(listval) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 50)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsum_negativenum <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_negativenum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), -32)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, -14, 13, -18, 12, -20)), -52)))\n    stopifnot(isTRUE(all.equal(candidate(c(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)), -894)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "r",
-    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfind_Rotations <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Rotations\n    stopifnot(isTRUE(all.equal(candidate('aaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "r",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nchange_date_format <- function(dt) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_date_format\n    stopifnot(isTRUE(all.equal(candidate('2026-01-02'), '02-01-2026')))\n    stopifnot(isTRUE(all.equal(candidate('2020-11-13'), '13-11-2020')))\n    stopifnot(isTRUE(all.equal(candidate('2021-04-26'), '26-04-2021')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "r",
-    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\nSplit <- function(list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 12, 13)), c(11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1)), c(7, 9, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "r",
-    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ntoggle_middle_bits <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- toggle_middle_bits\n    stopifnot(isTRUE(all.equal(candidate(9), 15)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(11), 13)))\n    stopifnot(isTRUE(all.equal(candidate(65), 127)))\n    stopifnot(isTRUE(all.equal(candidate(77), 115)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "r",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ncount_char_position <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_char_position\n    stopifnot(isTRUE(all.equal(candidate('xbcefg'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABcED'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('AbgdeF'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "r",
-    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlarge_product <- function(nums1, nums2, N) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- large_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 3), c(60, 54, 50))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 4), c(60, 54, 50, 48))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 5), c(60, 54, 50, 48, 45))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ncummulative_sum <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cummulative_sum\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 6, 7), c(2, 6))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7, 8), c(3, 7))), 37)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8, 9), c(4, 8))), 44)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "r",
-    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfind_min_diff <- function(arr, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_min_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 3, 19, 18, 25), 6), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 6), 4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 5, 20, 9), 4), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ntext_starta_endb <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_starta_endb\n    stopifnot(isTRUE(all.equal(candidate('aabbbb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabAbbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('accddbbjjj'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "r",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nleft_rotate <- function(n, d) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- left_rotate\n    stopifnot(isTRUE(all.equal(candidate(16, 2), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), 40)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(1, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 40)))\n    stopifnot(isTRUE(all.equal(candidate(29, 3), 232)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "r",
-    "prompt": "# Write a python function to find the first repeated character in a given string.\nfirst_repeated_char <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_repeated_char\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('abc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('123123'), '1')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "r",
-    "prompt": "# Write a python function to count inversions in an array.\nget_Inv_Count <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_Inv_Count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 6, 4, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 6, 1)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "r",
-    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\neven_Power_Sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_Power_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 1056)))\n    stopifnot(isTRUE(all.equal(candidate(3), 8832)))\n    stopifnot(isTRUE(all.equal(candidate(1), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "r",
-    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nget_equal <- function(Input) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_equal\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 22, 33), c(44, 55, 66))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6, 7))), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4))), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "r",
-    "prompt": "# Write a function to check if a string represents an integer or not.\ncheck_integer <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_integer\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('12345'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "r",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\ncount_reverse_pairs <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_reverse_pairs\n    stopifnot(isTRUE(all.equal(candidate(c('julia', 'best', 'tseb', 'for', 'ailuj')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c('geeks', 'best', 'for', 'skeeg')), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c('makes', 'best', 'sekam', 'for', 'rof')), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "r",
-    "prompt": "# Write a python function to move all zeroes to the end of the given list.\nmove_zero <- function(num_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 0, 3, 4)), c(1, 2, 3, 4, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 0, 0, 4, 0, 5, 0)), c(2, 3, 2, 4, 5, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 0, 1, 1)), c(1, 1, 1, 0, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "r",
-    "prompt": "# Write a function to check if given list contains no duplicates.\ncheck_distinct <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_distinct\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6, 1, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nnoprofit_noloss <- function(actual_cost, sale_amount) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- noprofit_noloss\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(100, 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "r",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\nremove_length <- function(test_str, K) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_length\n    stopifnot(isTRUE(all.equal(candidate('The person is most value tet', 3), 'person is most value')))\n    stopifnot(isTRUE(all.equal(candidate('If you told me about this ok', 4), 'If you me about ok')))\n    stopifnot(isTRUE(all.equal(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "r",
-    "prompt": "# Write a python function to count number of digits in a given string.\nnumber_ctr <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- number_ctr\n    stopifnot(isTRUE(all.equal(candidate('program2bedone'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('3wonders'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('123'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('3wond-1ers2'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "r",
-    "prompt": "# Write a function to count the total number of characters in a string.\ncount_charac <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_charac\n    stopifnot(isTRUE(all.equal(candidate('python programming'), 18)))\n    stopifnot(isTRUE(all.equal(candidate('language'), 8)))\n    stopifnot(isTRUE(all.equal(candidate('words'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "r",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nget_total_number_of_sequences <- function(m, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_total_number_of_sequences\n    stopifnot(isTRUE(all.equal(candidate(10, 4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(5, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(16, 3), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "r",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nleft_insertion <- function(a, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- left_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "r",
-    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nswap_numbers <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_numbers\n    stopifnot(isTRUE(all.equal(candidate(10, 20), c(20, 10))))\n    stopifnot(isTRUE(all.equal(candidate(15, 17), c(17, 15))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(200, 100))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "r",
-    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nis_majority <- function(arr, n, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_majority\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 3, 10), 7, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 4, 4, 4, 6, 6), 8, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 2), 5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2), 5, 1), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nsubstract_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- substract_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5), c(2, 5, 18)), c(8, -1, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 2, 3), c(24, 45, 16)), c(-13, -43, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 18, 9), c(10, 11, 12)), c(-3, 7, -3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "r",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ncapital_words_spaces <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- capital_words_spaces\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('PythonProgrammingExamples'), 'Python Programming Examples')))\n    stopifnot(isTRUE(all.equal(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "r",
-    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\nfind_Average_Of_Cube <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Average_Of_Cube\n    stopifnot(isTRUE(all.equal(candidate(2), 4.5)))\n    stopifnot(isTRUE(all.equal(candidate(3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "r",
-    "prompt": "# Write a function to check if all values are same in a dictionary.\ncheck_value <- function(dict, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_value\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "r",
-    "prompt": "# Write a function to find the nth tetrahedral number.\ntetrahedral_number <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tetrahedral_number\n    stopifnot(isTRUE(all.equal(candidate(5), 35)))\n    stopifnot(isTRUE(all.equal(candidate(6), 56)))\n    stopifnot(isTRUE(all.equal(candidate(7), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "r",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nmagic_square_test <- function(my_matrix) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- magic_square_test\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 12, 1, 14), c(2, 13, 8, 11), c(16, 3, 10, 5), c(9, 6, 15, 4))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 8))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 7))), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "r",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\nremove_uppercase <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_uppercase\n    stopifnot(isTRUE(all.equal(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')))\n    stopifnot(isTRUE(all.equal(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')))\n    stopifnot(isTRUE(all.equal(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "r",
-    "prompt": "# Write a function to check whether an element exists within a tuple.\ncheck_tuplex <- function(tuplex, tuple1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_tuplex\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 'r'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), '5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 3), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "r",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndog_age <- function(h_age) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- dog_age\n    stopifnot(isTRUE(all.equal(candidate(12), 61)))\n    stopifnot(isTRUE(all.equal(candidate(15), 73)))\n    stopifnot(isTRUE(all.equal(candidate(24), 109)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "r",
-    "prompt": "# Write a python function to find the next perfect square greater than a given number.\nnext_Perfect_Square <- function(N) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_Perfect_Square\n    stopifnot(isTRUE(all.equal(candidate(35), 36)))\n    stopifnot(isTRUE(all.equal(candidate(6), 9)))\n    stopifnot(isTRUE(all.equal(candidate(9), 16)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "r",
-    "prompt": "# Write a function to create a list of N empty dictionaries.\nempty_list <- function(length) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- empty_list\n    stopifnot(isTRUE(all.equal(candidate(5), list(list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(6), list(list(), list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(7), list(list(), list(), list(), list(), list(), list(), list()))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "r",
-    "prompt": "# Write a python function to convert a given string to uppercase.\nis_upper <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_upper\n    stopifnot(isTRUE(all.equal(candidate('person'), 'PERSON')))\n    stopifnot(isTRUE(all.equal(candidate('final'), 'FINAL')))\n    stopifnot(isTRUE(all.equal(candidate('Valid'), 'VALID')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "r",
-    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nodd_Equivalent <- function(s, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_Equivalent\n    stopifnot(isTRUE(all.equal(candidate('011001', 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate('11011', 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate('1010', 4), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "r",
-    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nre_arrange_array <- function(arr, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- re_arrange_array\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9), c(-1, -3, -7, 4, 5, 6, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, -14, -26, 13, 15), 5), c(-14, -26, 12, 13, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 24, 36, -42, -39, -78, 85), 7), c(-42, -39, -78, 10, 24, 36, 85))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "r",
-    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\nunique_Element <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "r",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\nextract_values <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_values\n    stopifnot(isTRUE(all.equal(candidate('\"Python\", \"PHP\", \"Java\"'), c('Python', 'PHP', 'Java'))))\n    stopifnot(isTRUE(all.equal(candidate('\"python\",\"program\",\"language\"'), c('python', 'program', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), c('red', 'blue', 'green', 'yellow'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "r",
-    "prompt": "# Write a python function to count true booleans in the given list.\ncount <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, FALSE, TRUE)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(FALSE, FALSE)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, TRUE, TRUE)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "r",
-    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfind_even_pair <- function(A) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_even_pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\narmstrong_number <- function(number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- armstrong_number\n    stopifnot(isTRUE(all.equal(candidate(153), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(259), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4458), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "r",
-    "prompt": "# Write a python function to count the upper case characters in a given string.\nupper_ctr <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- upper_ctr\n    stopifnot(isTRUE(all.equal(candidate('PYthon'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('BigData'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('program'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "r",
-    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\nand_tuples <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- and_tuples\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(0, 0, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(5, 6, 7, 8)), c(1, 2, 3, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 11, 12), c(7, 13, 14, 17)), c(0, 9, 10, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "r",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nis_samepatterns <- function(colors, patterns) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_samepatterns\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'green'), c('a', 'b', 'b')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b', 'b')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b')), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of lists in a given number of lists.\ncount_list <- function(input_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(2, 3), c(4, 5))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 0), c(2, 0))), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "r",
-    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\naverage_tuple <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- average_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 10, 10, 12), c(30, 45, 56, 45), c(81, 80, 39, 32), c(1, 2, 3, 4))), c(30.5, 34.25, 27.0, 23.25))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, -5), c(30, -15, 56), c(81, -60, -39), c(-10, 2, 3))), c(25.5, -18.0, 3.75))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(100, 100, 100, 120), c(300, 450, 560, 450), c(810, 800, 390, 320), c(10, 20, 30, 40))), c(305.0, 342.5, 270.0, 232.5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "r",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlcs_of_three <- function(X, Y, Z) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- lcs_of_three\n    stopifnot(isTRUE(all.equal(candidate('AGGT12', '12TXAYB', '12XBA'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "r",
-    "prompt": "# Write a function to find the n'th star number.\nfind_star_num <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_star_num\n    stopifnot(isTRUE(all.equal(candidate(3), 37)))\n    stopifnot(isTRUE(all.equal(candidate(4), 73)))\n    stopifnot(isTRUE(all.equal(candidate(5), 121)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of an array.\n_sum <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- _sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 12, 13, 10)), 50)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\ncheck_Consecutive <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_Consecutive\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "r",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nfind_adverb_position <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_adverb_position\n    stopifnot(isTRUE(all.equal(candidate('clearly!! we can see the sky'), list(0, 7, 'clearly'))))\n    stopifnot(isTRUE(all.equal(candidate('seriously!! there are many roses'), list(0, 9, 'seriously'))))\n    stopifnot(isTRUE(all.equal(candidate('unfortunately!! sita is going to home'), list(0, 13, 'unfortunately'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "r",
-    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nrotate_right <- function(list, m) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rotate_right\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3), c(8, 9, 10, 1, 2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(9, 10, 1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5), c(6, 7, 8, 9, 10, 1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\nnumber_of_substrings <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- number_of_substrings\n    stopifnot(isTRUE(all.equal(candidate('abc'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 15)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlist_split <- function(S, step) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- list_split\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'), 3), list(c('a', 'd', 'g', 'j', 'm'), c('b', 'e', 'h', 'k', 'n'), c('c', 'f', 'i', 'l')))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3), list(c(1, 4, 7, 10, 13), c(2, 5, 8, 11, 14), c(3, 6, 9, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java', 'C', 'C++', 'DBMS', 'SQL'), 2), list(c('python', 'C', 'DBMS'), c('java', 'C++', 'SQL')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "r",
-    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\nall_unique <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_unique\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "r",
-    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\nconvert <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- convert\n    stopifnot(isTRUE(all.equal(candidate(1), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5.0, 0.0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "r",
-    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfilter_data <- function(students, h, w) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_data\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 6.0, 70), list('Cierra Vega' = c(6.2, 70)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.9, 67), list('Cierra Vega' = c(6.2, 70), 'Kierra Gentry' = c(6.0, 68)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.7, 64), list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "r",
-    "prompt": "# Write a python function to convert the given string to lower case.\nis_lower <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_lower\n    stopifnot(isTRUE(all.equal(candidate('InValid'), 'invalid')))\n    stopifnot(isTRUE(all.equal(candidate('TruE'), 'true')))\n    stopifnot(isTRUE(all.equal(candidate('SenTenCE'), 'sentence')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "r",
-    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\nnext_power_of_2 <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_power_of_2\n    stopifnot(isTRUE(all.equal(candidate(0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(17), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "r",
-    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nfind_substring <- function(str1, sub_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_substring\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ack'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'abc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ange'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "r",
-    "prompt": "# Write a function to replace characters in a string.\nreplace_char <- function(str1, ch, newch) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_char\n    stopifnot(isTRUE(all.equal(candidate('polygon', 'y', 'l'), 'pollgon')))\n    stopifnot(isTRUE(all.equal(candidate('character', 'c', 'a'), 'aharaater')))\n    stopifnot(isTRUE(all.equal(candidate('python', 'l', 'a'), 'python')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "r",
-    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nmul_even_odd <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- mul_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "r",
-    "prompt": "# Write a function to convert a list to a tuple.\nlist_tuple <- function(listx) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- list_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 10, 7, 4, 15, 3)), c(5, 10, 7, 4, 15, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 2, 3, 4, 4, 7)), c(2, 4, 5, 6, 2, 3, 4, 4, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(58, 44, 56)), c(58, 44, 56))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "r",
-    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\neven_binomial_Coeff_Sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_binomial_Coeff_Sum\n    stopifnot(isTRUE(all.equal(candidate(4), 8)))\n    stopifnot(isTRUE(all.equal(candidate(6), 32)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "r",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\nbitwise_xor <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- bitwise_xor\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(15, 6, 5, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 7, 10), c(6, 3, 4, 4)), c(13, 6, 3, 14))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 11), c(7, 4, 5, 6)), c(11, 2, 13, 13))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "r",
-    "prompt": "# Write a python function to check whether a list is sublist of another or not.\nis_Sub_Array <- function(A, B) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Sub_Array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 5), c(1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), c(1, 2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 2), c(2, 2, 0)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "r",
-    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nmax_sub_array_sum_repeated <- function(a, n, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum_repeated\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -30, -1), 4, 3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 10, 20), 3, 2), 59)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3), 3, 3), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "r",
-    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\nmin_product_tuple <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 8)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 100)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\ncount_divisors <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_divisors\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(100), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "r",
-    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ntriangle_area <- function(r) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(-1), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "r",
-    "prompt": "# Write a function to convert a given string to a list of characters.\nstring_to_tuple <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_tuple\n    stopifnot(isTRUE(all.equal(candidate('python 3.0'), c('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'))))\n    stopifnot(isTRUE(all.equal(candidate('item1'), c('i', 't', 'e', 'm', '1'))))\n    stopifnot(isTRUE(all.equal(candidate('15.10'), c('1', '5', '.', '1', '0'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfind_length <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_length\n    stopifnot(isTRUE(all.equal(candidate('11000010001'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('10111'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('11011101100101'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "r",
-    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ncount_Primes_nums <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Primes_nums\n    stopifnot(isTRUE(all.equal(candidate(5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 4)))\n    stopifnot(isTRUE(all.equal(candidate(100), 25)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\nsum_Of_product <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_product\n    stopifnot(isTRUE(all.equal(candidate(3), 15)))\n    stopifnot(isTRUE(all.equal(candidate(4), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "r",
-    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\nmax_aggregate <- function(stdata) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_aggregate\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 90), list('Sabah Colley', 88), list('Peter Nichols', 7), list('Juan Whelan', 122), list('Sabah Colley', 84))), list('Juan Whelan', 212))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 50), list('Sabah Colley', 48), list('Peter Nichols', 37), list('Juan Whelan', 22), list('Sabah Colley', 14))), list('Juan Whelan', 72))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 10), list('Sabah Colley', 20), list('Peter Nichols', 30), list('Juan Whelan', 40), list('Sabah Colley', 50))), list('Sabah Colley', 70))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "r",
-    "prompt": "# Write a function to sort a list of elements.\ncomb_sort <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- comb_sort\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 37, 25, 79)), c(5, 15, 25, 37, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 32, 15, 19, 22)), c(15, 19, 22, 32, 41))))\n    stopifnot(isTRUE(all.equal(candidate(c(99, 15, 13, 47)), c(13, 15, 47, 99))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "r",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ncheck_expression <- function(exp) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_expression\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}][]({})'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "r",
-    "prompt": "# Write a function that matches a word containing 'z'.\ntext_match_wordz <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz\n    stopifnot(isTRUE(all.equal(candidate('pythonz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "r",
-    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsum_list <- function(lst1, lst2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_list\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), c(15, 25, 35)), c(25, 45, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(5, 6, 7)), c(6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 20, 30), c(15, 45, 75)), c(30, 65, 105))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "r",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nnewman_prime <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- newman_prime\n    stopifnot(isTRUE(all.equal(candidate(3), 7)))\n    stopifnot(isTRUE(all.equal(candidate(4), 17)))\n    stopifnot(isTRUE(all.equal(candidate(5), 41)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "r",
-    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nadd_string <- function(list_, string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_string\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 'temp{0}'), c('temp1', 'temp2', 'temp3', 'temp4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 'python{0}'), c('pythona', 'pythonb', 'pythonc', 'pythond'))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8), 'string{0}'), c('string5', 'string6', 'string7', 'string8'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "r",
-    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\nsurface_Area <- function(b, s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- surface_Area\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 33)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "r",
-    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\nFind_Min_Length <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2))), 1)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(1, 2, 3), c(1, 2, 3, 4))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 3, 3), c(4, 4, 4, 4))), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "r",
-    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nvalidate <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- validate\n    stopifnot(isTRUE(all.equal(candidate(1234), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(51241), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(321), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "r",
-    "prompt": "# Write a function to find the nth hexagonal number.\nhexagonal_num <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- hexagonal_num\n    stopifnot(isTRUE(all.equal(candidate(10), 190)))\n    stopifnot(isTRUE(all.equal(candidate(5), 45)))\n    stopifnot(isTRUE(all.equal(candidate(7), 91)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "r",
-    "prompt": "# Write a function to find the n'th lucas number.\nfind_lucas <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_lucas\n    stopifnot(isTRUE(all.equal(candidate(9), 76)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(3), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "r",
-    "prompt": "# Write a python function to get the difference between two lists.\nDiff <- function(li1, li2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Diff\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25, 30, 35, 40), c(25, 40, 35)), c(10, 20, 30, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 1)), c(2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(6, 7, 1)), c(2, 3, 6, 7))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "r",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nextract_quotation <- function(text1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_quotation\n    stopifnot(isTRUE(all.equal(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), c('A53', 'multi', 'Processor'))))\n    stopifnot(isTRUE(all.equal(candidate('Cast your \"favorite\" entertainment \"apps\"'), c('favorite', 'apps'))))\n    stopifnot(isTRUE(all.equal(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), c('4k Ultra HD', 'HDR 10'))))\n    stopifnot(isTRUE(all.equal(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "r",
-    "prompt": "# Write a function to flatten a list and sum all of its elements.\nrecursive_list_sum <- function(data_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- recursive_list_sum\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, c(3, 4), c(5, 6))), 21)))\n    stopifnot(isTRUE(all.equal(candidate(list(7, 10, c(15, 14), c(19, 41))), 106)))\n    stopifnot(isTRUE(all.equal(candidate(list(10, 20, c(30, 40), c(50, 60))), 210)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\ndiffer_At_One_Bit_Pos <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- differ_At_One_Bit_Pos\n    stopifnot(isTRUE(all.equal(candidate(13, 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ntext_match_three <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('caacabbbba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nmax_product <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_product\n    stopifnot(isTRUE(all.equal(candidate(c(3, 100, 4, 5, 150, 6)), 3000)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 42, 55, 68, 80)), 50265600)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 22, 9, 33, 21, 50, 41, 60)), 2460)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "r",
-    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\nsplit_Arr <- function(l, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_Arr\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 5, 6, 52, 36), 2), c(5, 6, 52, 36, 12, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 1), c(2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 4, 5, 6, 7), 3), c(3, 4, 5, 6, 7, 0, 1, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "r",
-    "prompt": "# Write a python function to find the number of divisors of a given integer.\ndivisor <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- divisor\n    stopifnot(isTRUE(all.equal(candidate(15), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 6)))\n    stopifnot(isTRUE(all.equal(candidate(9), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "r",
-    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\nbig_diff <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- big_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 12)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 3)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "r",
-    "prompt": "# Write a function to find squares of individual elements in a list.\nsquare_nums <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(100, 400, 900))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(144, 225))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "r",
-    "prompt": "# Write a function to check if the given tuple has any none value or not.\ncheck_none <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_none\n    stopifnot(isTRUE(all.equal(candidate(list(10, 4, 5, 6, NULL)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 11, 14)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 3, 4, NULL)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given array is monotonic or not.\nis_Monotonic <- function(A) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nis_perfect_square <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_perfect_square\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(36), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(14), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(196), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(125), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15625), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\nsum <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 6)))\n    stopifnot(isTRUE(all.equal(candidate(100, 150), 93)))\n    stopifnot(isTRUE(all.equal(candidate(4, 6), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "r",
-    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nmax_length <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_length\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(5, 7), c(10, 12, 14, 15))), list(4, c(10, 12, 14, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5), c(15, 20, 25))), list(3, c(15, 20, 25)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\ncheck_occurences <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_occurences\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 1), c(1, 3), c(2, 5), c(5, 2), c(6, 3))), list(c(1, 3) = 2, c(2, 5) = 2, c(3, 6) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 2), c(2, 4), c(3, 6), c(6, 3), c(7, 4))), list(c(2, 4) = 2, c(3, 6) = 2, c(4, 7) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(13, 2), c(11, 23), c(12, 25), c(25, 12), c(16, 23))), list(c(2, 13) = 1, c(11, 23) = 1, c(12, 25) = 2, c(16, 23) = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "r",
-    "prompt": "# Write a function to find the directrix of a parabola.\nparabola_directrix <- function(a, b, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- parabola_directrix\n    stopifnot(isTRUE(all.equal(candidate(5, 3, 2), -198)))\n    stopifnot(isTRUE(all.equal(candidate(9, 8, 4), -2336)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4, 6), -130)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "r",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\noccurance_substring <- function(text, pattern) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- occurance_substring\n    stopifnot(isTRUE(all.equal(candidate('python programming, python language', 'python'), list('python', 0, 6))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'programming'), list('programming', 7, 18))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'language'), list('language', 31, 39))))\n    stopifnot(isTRUE(all.equal(candidate('c++ programming, c++ language', 'python'), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "r",
-    "prompt": "# Write a function to remove tuples from the given tuple.\nremove_nested <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_nested\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), c(1, 5, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 6, 8, c(5, 7), 11)), c(2, 6, 8, 11))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), 12)), c(3, 7, 9, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), c(5, 12), 12)), c(3, 7, 9, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "r",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(input_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(' red ', 'green'), c('blue ', ' black'), c(' orange', 'brown'))), list(c(' red ', 'green'), c(' black', 'blue '), c(' orange', 'brown')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('zilver', 'gold'), c('magnesium', 'aluminium'), c('steel', 'bronze'))), list(c('gold', 'zilver'), c('aluminium', 'magnesium'), c('bronze', 'steel')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "r",
-    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nremove_kth_element <- function(list1, L) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), c(1, 1, 3, 4, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4), c(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5), c(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "r",
-    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\nadd_dict_to_tuple <- function(test_tup, test_dict) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_dict_to_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), list('MSAM' = 1, 'is' = 2, 'best' = 3)), list(4, 5, 6, list('MSAM' = 1, 'is' = 2, 'best' = 3)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), list('UTS' = 2, 'is' = 3, 'Worst' = 4)), list(1, 2, 3, list('UTS' = 2, 'is' = 3, 'Worst' = 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 10), list('POS' = 3, 'is' = 4, 'Okay' = 5)), list(8, 9, 10, list('POS' = 3, 'is' = 4, 'Okay' = 5)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "r",
-    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfind <- function(n, m) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find\n    stopifnot(isTRUE(all.equal(candidate(10, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(20, 5), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "r",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ntext_match_two_three <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_two_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "r",
-    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\ncount_Occurrence <- function(tup, lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Occurrence\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'c', 'b', 'd'), c('a', 'b')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 4, 6, 7, 1, 4), c(1, 4, 7)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(1, 2)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "r",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ncount_samepair <- function(list1, list2, list3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_samepair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9), c(2, 1, 3, 1, 2, 6, 7, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 2, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ntext_match_one <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "r",
-    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndifference <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- difference\n    stopifnot(isTRUE(all.equal(candidate(3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(5), 210)))\n    stopifnot(isTRUE(all.equal(candidate(2), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "r",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\ntoggle_string <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- toggle_string\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'pYTHON')))\n    stopifnot(isTRUE(all.equal(candidate('Pangram'), 'pANGRAM')))\n    stopifnot(isTRUE(all.equal(candidate('LIttLE'), 'liTTle')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "r",
-    "prompt": "# Write a python function to find the element of a list having maximum length.\nFind_Max <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max\n    stopifnot(isTRUE(all.equal(candidate(list(c('A'), c('A', 'B'), c('A', 'B', 'C'))), c('A', 'B', 'C'))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 2, 3), c(1, 5, 6, 1))), c(1, 5, 6, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "r",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\neulerian_num <- function(n, m) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- eulerian_num\n    stopifnot(isTRUE(all.equal(candidate(3, 1), 4)))\n    stopifnot(isTRUE(all.equal(candidate(4, 1), 11)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 26)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "r",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nfrequency <- function(a, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- frequency\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 3, 4), 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 1, 2), 1), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "r",
-    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nsort_numeric_strings <- function(nums_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numeric_strings\n    stopifnot(isTRUE(all.equal(candidate(c('4', '12', '45', '7', '0', '100', '200', '-12', '-500')), c(-500, -12, 0, 4, 7, 12, 45, 100, 200))))\n    stopifnot(isTRUE(all.equal(candidate(c('2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2')), c(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c('1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11')), c(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\ngeometric_sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- geometric_sum\n    stopifnot(isTRUE(all.equal(candidate(7), 1.9921875)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1.9375)))\n    stopifnot(isTRUE(all.equal(candidate(8), 1.99609375)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "r",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\ndivisible_by_digits <- function(startnum, endnum) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- divisible_by_digits\n    stopifnot(isTRUE(all.equal(candidate(1, 22), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22))))\n    stopifnot(isTRUE(all.equal(candidate(1, 15), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15))))\n    stopifnot(isTRUE(all.equal(candidate(20, 25), c(22, 24))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "r",
-    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\nunique_product <- function(list_data) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_product\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30, 40, 20, 50, 60, 40)), 720000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 0, 1, 1)), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "r",
-    "prompt": "# Write a python function to find the largest negative number from the given list.\nlargest_neg <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_neg\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -4, -6)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -8, -9)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, -1)), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "r",
-    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nconsecutive_duplicates <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), c(10, 15, 19, 18, 17, 26, 17, 18, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), c('a', 'b', 'c', 'd'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd', 'a', 'a')), c('a', 'b', 'c', 'd', 'a'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "r",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nmin_Jumps <- function(steps, d) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_Jumps\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 11), 3.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 14), 11), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "r",
-    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\nmax_Product <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_Product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 7, 0, 8, 4)), c(7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, -1, -2, -4, 5, 0, -6)), c(-4, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "r",
-    "prompt": "# Write a function to extract the nth element from a given list of tuples.\nextract_nth_element <- function(list1, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_nth_element\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 0), c('Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 2), c(99, 96, 94, 98))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 1), c(98, 97, 91, 94))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth nonagonal number.\nis_nonagonal <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nonagonal\n    stopifnot(isTRUE(all.equal(candidate(10), 325)))\n    stopifnot(isTRUE(all.equal(candidate(15), 750)))\n    stopifnot(isTRUE(all.equal(candidate(18), 1089)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "r",
-    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\nmax_Abs_Diff <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_Abs_Diff\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 3, 2, 5, 1)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "r",
-    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\npack_consecutive_duplicates <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pack_consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), list(c(0, 0), c(1), c(2), c(3), c(4, 4), c(5), c(6, 6, 6), c(7), c(8), c(9), c(4, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), list(c(10, 10), c(15), c(19), c(18, 18), c(17), c(26, 26), c(17), c(18), c(10)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), list(c('a', 'a'), c('b'), c('c'), c('d', 'd')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\ncal_sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- cal_sum\n    stopifnot(isTRUE(all.equal(candidate(9), 49)))\n    stopifnot(isTRUE(all.equal(candidate(10), 66)))\n    stopifnot(isTRUE(all.equal(candidate(11), 88)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "r",
-    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\nodd_values_string <- function(str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_values_string\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 'ace')))\n    stopifnot(isTRUE(all.equal(candidate('python'), 'pto')))\n    stopifnot(isTRUE(all.equal(candidate('data'), 'dt')))\n    stopifnot(isTRUE(all.equal(candidate('lambs'), 'lms')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "r",
-    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nfind_kth <- function(arr1, arr2, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_kth\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6, 7, 9), c(1, 4, 8, 10), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 112, 256, 349, 770), c(72, 86, 113, 119, 265, 445, 892), 7), 256)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 7, 8, 10), c(2, 5, 9, 11), 6), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "r",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\njacobsthal_num <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- jacobsthal_num\n    stopifnot(isTRUE(all.equal(candidate(5), 11)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(13), 2731)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "r",
-    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfrequency_lists <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- frequency_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 2), c(4, 5, 6, 2), c(7, 8, 9, 5))), list(1 = 1, 2 = 3, 3 = 1, 4 = 1, 5 = 2, 6 = 1, 7 = 1, 8 = 1, 9 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12))), list(1 = 1, 2 = 1, 3 = 1, 4 = 1, 5 = 1, 6 = 1, 7 = 1, 8 = 1, 9 = 1, 10 = 1, 11 = 1, 12 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(20, 30, 40, 17), c(18, 16, 14, 13), c(10, 20, 30, 40))), list(20 = 2, 30 = 2, 40 = 2, 17 = 1, 18 = 1, 16 = 1, 14 = 1, 13 = 1, 10 = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "r",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\nperfect_squares <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- perfect_squares\n    stopifnot(isTRUE(all.equal(candidate(1, 30), c(1, 4, 9, 16, 25))))\n    stopifnot(isTRUE(all.equal(candidate(50, 100), c(64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(100, 121, 144, 169, 196))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "r",
-    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsum_Of_Subarray_Prod <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_Subarray_Prod\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "r",
-    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\nfirst_odd <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 1)), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "r",
-    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nadd_nested_tuples <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_nested_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(7, 10), c(7, 14), c(3, 10), c(8, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(9, 12), c(9, 16), c(5, 12), c(10, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(11, 14), c(11, 18), c(7, 14), c(12, 17)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "r",
-    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nmerge <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('a', 'b'), c('m', 'n'))), list(c('x', 'a', 'm'), c('y', 'b', 'n')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6), c(7, 8))), list(c(1, 3, 5, 7), c(2, 4, 6, 8)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y', 'z'), c('a', 'b', 'c'), c('m', 'n', 'o'))), list(c('x', 'a', 'm'), c('y', 'b', 'n'), c('z', 'c', 'o')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\ndif_Square <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- dif_Square\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "r",
-    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\ncheck_smaller <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_smaller\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13), c(10, 11, 12)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "r",
-    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfreq_count <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- freq_count\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)), list(10 = 4, 20 = 4, 40 = 2, 50 = 2, 30 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)), list(1 = 3, 2 = 2, 3 = 3, 4 = 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)), list(10 = 1, 5 = 3, 6 = 2, 7 = 2, 4 = 2, 9 = 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "r",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nrgb_to_hsv <- function(r, g, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rgb_to_hsv\n    stopifnot(isTRUE(all.equal(candidate(255, 255, 255), c(0.0, 0.0, 100.0))))\n    stopifnot(isTRUE(all.equal(candidate(0, 215, 0), c(120.0, 100.0, 84.31372549019608))))\n    stopifnot(isTRUE(all.equal(candidate(10, 215, 110), c(149.26829268292684, 95.34883720930233, 84.31372549019608))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "r",
-    "prompt": "# Write a function to flatten a given nested list structure.\nflatten_list <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- flatten_list\n    stopifnot(isTRUE(all.equal(candidate(list(0, 10, c(20, 30), 40, 50, c(60, 70, 80), c(90, 100, 110, 120))), c(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(40), c(30, 56, 25), c(10, 20), c(33), c(40))), c(10, 20, 40, 30, 56, 25, 10, 20, 33, 40))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ncheck_str <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_str\n    stopifnot(isTRUE(all.equal(candidate('annie'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dawood'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Else'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ncheck_monthnumber_number <- function(monthnum3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumber_number\n    stopifnot(isTRUE(all.equal(candidate(6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "r",
-    "prompt": "# Write a function to sort the given list.\nheap_sort <- function(iterable) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- heap_sort\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 25, 58)), c(14, 22, 25, 25, 35, 58, 65, 75, 85))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 1, 9, 5)), c(1, 5, 7, 9))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "r",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nk_smallest_pairs <- function(nums1, nums2, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- k_smallest_pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 2), list(c(1, 2), c(1, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 1), list(c(1, 2)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 7), list(c(1, 2), c(1, 4), c(3, 2), c(1, 6), c(3, 4), c(3, 6), c(7, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "r",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfind_solution <- function(a, b, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_solution\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 7), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 7), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(1, 13, 17), c(4, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "r",
-    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\nfind_Max_Num <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Max_Num\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 321)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 1)), 6541)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 9)), 9321)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "r",
-    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nmax_sum_list <- function(lists) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(10, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 2, 1), c(6, 5, 4), c(12, 11, 10))), c(12, 11, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 1))), c(2, 3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "r",
-    "prompt": "# Write a python function to interchange the first and last elements in a list.\nswap_List <- function(newList) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(12, 35, 9, 56, 24)), c(24, 35, 9, 56, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "r",
-    "prompt": "# Write a function to find the median of two sorted lists of same size.\nget_median <- function(arr1, arr2, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_median\n    stopifnot(isTRUE(all.equal(candidate(c(1, 12, 15, 26, 38), c(2, 13, 17, 30, 45), 5), 16.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 9), c(7, 13, 19, 28), 4), 8.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 14, 23, 36, 42), c(2, 18, 27, 39, 49, 55), 6), 25.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "r",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nreplace_spaces <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')))\n    stopifnot(isTRUE(all.equal(candidate('The_Avengers'), 'The Avengers')))\n    stopifnot(isTRUE(all.equal(candidate('Fast and Furious'), 'Fast_and_Furious')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "r",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nare_equivalent <- function(num1, num2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- are_equivalent\n    stopifnot(isTRUE(all.equal(candidate(36, 57), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23, 47), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "r",
-    "prompt": "# Write a function to reverse each string in a given list of string values.\nreverse_string_list <- function(stringlist) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_string_list\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue', 'White', 'Black')), c('deR', 'neerG', 'eulB', 'etihW', 'kcalB'))))\n    stopifnot(isTRUE(all.equal(candidate(c('john', 'amal', 'joel', 'george')), c('nhoj', 'lama', 'leoj', 'egroeg'))))\n    stopifnot(isTRUE(all.equal(candidate(c('jack', 'john', 'mary')), c('kcaj', 'nhoj', 'yram'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "r",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsum_of_digits <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_of_digits\n    stopifnot(isTRUE(all.equal(candidate(c(10, 2, 56)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(list(list(10, 20, 4, 5, 'b', 70, 'a'))), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -4, 5, -70)), 19)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "r",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsequence <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sequence\n    stopifnot(isTRUE(all.equal(candidate(10), 6)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "r",
-    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nheap_queue_largest <- function(nums, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- heap_queue_largest\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 3), c(85, 75, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 2), c(85, 75))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 5), c(85, 75, 65, 58, 35))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "r",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nloss_amount <- function(actual_cost, sale_amount) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- loss_amount\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), 0)))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), 100)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), 3000)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "r",
-    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nunion_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- union_elements\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 4, 5, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(3, 4, 5, 6)), c(1, 2, 3, 4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13, 14), c(13, 15, 16, 17)), c(11, 12, 13, 14, 15, 16, 17))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "r",
-    "prompt": "# Write a python function to find the length of the longest sublists.\nFind_Max_Length <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 4), c(5, 6, 7, 8))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 1), c(2, 2), c(3, 2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7), c(22, 23), c(13, 14, 15), c(10, 20, 30, 40, 50))), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "r",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nremove_parenthesis <- function(items) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_parenthesis\n    stopifnot(isTRUE(all.equal(candidate(c('python (chrome)')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('string(.abc)')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('alpha(num)')), 'alpha')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "r",
-    "prompt": "# Write a python function to find whether the parity of a given number is odd.\nfind_Parity <- function(x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Parity\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "r",
-    "prompt": "# Write a function to find the median length of a trapezium.\nmedian_trapezium <- function(base1, base2, height) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- median_trapezium\n    stopifnot(isTRUE(all.equal(candidate(15, 25, 35), 20)))\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 30), 15)))\n    stopifnot(isTRUE(all.equal(candidate(6, 9, 4), 7.5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "r",
-    "prompt": "# Write a function to find nth centered hexagonal number.\ncentered_hexagonal_number <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- centered_hexagonal_number\n    stopifnot(isTRUE(all.equal(candidate(10), 271)))\n    stopifnot(isTRUE(all.equal(candidate(2), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 217)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "r",
-    "prompt": "# Write a function to find number of lists present in the given list.\nfind_lists <- function(Input) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5, 4, 3, 2, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nget_max_sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_sum\n    stopifnot(isTRUE(all.equal(candidate(60), 106)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "r",
-    "prompt": "# Write a python function to find the length of the longest word.\nlen_log <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- len_log\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'PHP', 'bigdata')), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'ab', 'abc')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c('small', 'big', 'tall')), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "r",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nsector_area <- function(r, a) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sector_area\n    stopifnot(isTRUE(all.equal(candidate(4, 45), 6.283185307179586)))\n    stopifnot(isTRUE(all.equal(candidate(9, 45), 31.808625617596654)))\n    stopifnot(isTRUE(all.equal(candidate(9, 361), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "r",
-    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\nodd_position <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_position\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4, 3, 6, 7, 6, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "r",
-    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nmultiple_to_single <- function(L) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiple_to_single\n    stopifnot(isTRUE(all.equal(candidate(c(11, 33, 50)), 113350)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4, 5, 6)), -123456)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25)), 10152025)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "r",
-    "prompt": "# Write a python function to find whether a number is divisible by 11.\nis_Diff <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Diff\n    stopifnot(isTRUE(all.equal(candidate(12345), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1212112), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1212), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "r",
-    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nindex_multiplication <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- index_multiplication\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 21), c(12, 45), c(2, 9), c(7, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(14, 32), c(20, 60), c(6, 20), c(16, 44)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(24, 45), c(30, 77), c(12, 33), c(27, 60)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "r",
-    "prompt": "# Write a function to convert tuple string to integer tuple.\ntuple_str_int <- function(test_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_str_int\n    stopifnot(isTRUE(all.equal(candidate('(7, 8, 9)'), c(7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate('(1, 2, 3)'), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate('(4, 5, 6)'), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate('(7, 81, 19)'), c(7, 81, 19))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "r",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\namicable_numbers_sum <- function(limit) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- amicable_numbers_sum\n    stopifnot(isTRUE(all.equal(candidate(999), 504)))\n    stopifnot(isTRUE(all.equal(candidate(9999), 31626)))\n    stopifnot(isTRUE(all.equal(candidate(99), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "r",
-    "prompt": "# Write a function to remove odd characters in a string.\nremove_odd <- function(str1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate('python'), 'yhn')))\n    stopifnot(isTRUE(all.equal(candidate('program'), 'rga')))\n    stopifnot(isTRUE(all.equal(candidate('language'), 'agae')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nmultiply_elements <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(5, 35, 56, 80))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 7)), c(8, 20, 30, 42))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 13, 14, 9, 15)), c(156, 182, 126, 135))))\n    stopifnot(isTRUE(all.equal(candidate(c(12)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ncount_rotation <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_rotation\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 1, 2, 3)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "r",
-    "prompt": "# Write a function to extract the number of unique tuples in the given list.\nextract_freq <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_freq\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4), c(1, 2), c(4, 3), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 15), c(2, 3), c(5, 4), c(6, 7))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 16), c(2, 3), c(6, 5), c(6, 9))), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "r",
-    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ncount_same_pair <- function(nums1, nums2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_same_pair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 1, 2), c(0, 1, 2, 2)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "r",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\npower <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- power\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 81)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), 3125)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "r",
-    "prompt": "# Write function to find the sum of all items in the given dictionary.\nreturn_sum <- function(dict) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- return_sum\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 100, 'b' = 200, 'c' = 300)), 600)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 25, 'b' = 18, 'c' = 45)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 36, 'b' = 39, 'c' = 49)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "r",
-    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\npair_wise <- function(l1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pair_wise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 3, 4, 4, 5)), list(c(1, 1), c(1, 2), c(2, 3), c(3, 3), c(3, 4), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), list(c(1, 5), c(5, 7), c(7, 9), c(9, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 9, 7, 10)), list(c(5, 1), c(1, 9), c(9, 7), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), list(c(1, 2), c(2, 3), c(3, 4), c(4, 5), c(5, 6), c(6, 7), c(7, 8), c(8, 9), c(9, 10)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "r",
-    "prompt": "# Write a python function to split a string into characters.\nsplit <- function(word) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- split\n    stopifnot(isTRUE(all.equal(candidate('python'), c('p', 'y', 't', 'h', 'o', 'n'))))\n    stopifnot(isTRUE(all.equal(candidate('Name'), c('N', 'a', 'm', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate('program'), c('p', 'r', 'o', 'g', 'r', 'a', 'm'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "r",
-    "prompt": "# Write a function to find minimum of three numbers.\nmin_of_three <- function(a, b, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_of_three\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(19, 15, 18), 15)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -20, -30), -30)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "r",
-    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nis_Sum_Of_Powers_Of_Two <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Sum_Of_Powers_Of_Two\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(14), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "r",
-    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nget_Char <- function(strr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_Char\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'f')))\n    stopifnot(isTRUE(all.equal(candidate('gfg'), 't')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'c')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "r",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\nsum_div <- function(number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_div\n    stopifnot(isTRUE(all.equal(candidate(8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(12), 16)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "r",
-    "prompt": "# Write a python function that returns the number of integer elements in a given list.\ncount_integer <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_integer\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 'abc', 1.2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1.2, 4, 5.1)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "r",
-    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\ntwo_unique_nums <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- two_unique_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 3, 4, 5)), c(1, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 5)), c(1, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "r",
-    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ntest_duplicate <- function(arraynums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- test_duplicate\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3, 3, 4, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "r",
-    "prompt": "# Write a function which returns nth catalan number.\ncatalan_number <- function(num) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- catalan_number\n    stopifnot(isTRUE(all.equal(candidate(10), 16796)))\n    stopifnot(isTRUE(all.equal(candidate(9), 4862)))\n    stopifnot(isTRUE(all.equal(candidate(7), 429)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "r",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\npower_base_sum <- function(base, power) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- power_base_sum\n    stopifnot(isTRUE(all.equal(candidate(2, 100), 115)))\n    stopifnot(isTRUE(all.equal(candidate(8, 10), 37)))\n    stopifnot(isTRUE(all.equal(candidate(8, 15), 62)))\n    stopifnot(isTRUE(all.equal(candidate(3, 3), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "r",
-    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nreplace_list <- function(list1, list2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8)), c(1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'blue', 'green'), c('yellow')), c('red', 'blue', 'yellow'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth octagonal number.\nis_octagonal <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_octagonal\n    stopifnot(isTRUE(all.equal(candidate(5), 65)))\n    stopifnot(isTRUE(all.equal(candidate(10), 280)))\n    stopifnot(isTRUE(all.equal(candidate(15), 645)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "r",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nreplace_blank <- function(str1, char) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_blank\n    stopifnot(isTRUE(all.equal(candidate('hello people', '@'), 'hello@people')))\n    stopifnot(isTRUE(all.equal(candidate('python program language', '$'), 'python$program$language')))\n    stopifnot(isTRUE(all.equal(candidate('blank space', '-'), 'blank-space')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "r",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nreplace_specialchar <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_specialchar\n    stopifnot(isTRUE(all.equal(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')))\n    stopifnot(isTRUE(all.equal(candidate('a b c,d e f'), 'a:b:c:d:e:f')))\n    stopifnot(isTRUE(all.equal(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "r",
-    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\ntuple_to_int <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_int\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 123)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), 456)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7)), 567)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "r",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\notherside_rightangle <- function(w, h) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- otherside_rightangle\n    stopifnot(isTRUE(all.equal(candidate(7, 8), 10.63014581273465)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(7, 15), 16.55294535724685)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "r",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nexpensive_items <- function(items, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- expensive_items\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09)), 2), list(list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-1', 'price' = 101.1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09), list('name' = 'Item-4', 'price' = 22.75)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "r",
-    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\ndigit_distance_nums <- function(n1, n2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- digit_distance_nums\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(23, 56), 6)))\n    stopifnot(isTRUE(all.equal(candidate(123, 256), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "r",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ntext_match_wordz_middle <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz_middle\n    stopifnot(isTRUE(all.equal(candidate('pythonzabc.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zxyabc.'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "r",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\nremovezero_ip <- function(ip) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- removezero_ip\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.196'), '216.8.94.196')))\n    stopifnot(isTRUE(all.equal(candidate('12.01.024'), '12.1.24')))\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.0196'), '216.8.94.196')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "r",
-    "prompt": "# Write a function to count the number of sublists containing a particular element.\ncount_element_in_list <- function(list1, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_element_in_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(1, 11), c(1, 15, 7)), 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'A'), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'E'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "r",
-    "prompt": "# Write a function to multiply two integers.\nmultiply_int <- function(x, y) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply_int\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "r",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nadd_pairwise <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_pairwise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(6, 12, 15, 18))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 8, 9, 11)), c(8, 14, 17, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 7, 9, 10, 12)), c(10, 16, 19, 22))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nmax_product_tuple <- function(list1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 36)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 200)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 484)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -3839,7 +17,7 @@
     "language": "r",
     "prompt": "# Write a function to find the kth element in the given array using 1-based indexing.\nkth_element <- function(arr, k) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(12, 3, 5, 7, 19), 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(17, 24, 8, 23), 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(16, 21, 25, 36, 4), 4), 36)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -3848,299 +26,117 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "r",
-    "prompt": "# Write a python function to interchange the first and last element in a given list.\nswap_List <- function(newList) {",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\nsnake_to_camel <- function(word) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), c(4, 2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('python_program'), 'PythonProgram')))\n    stopifnot(isTRUE(all.equal(candidate('python_language'), 'PythonLanguage')))\n    stopifnot(isTRUE(all.equal(candidate('programming_language'), 'ProgrammingLanguage')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "r",
-    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\ncount_first_elements <- function(test_tup) {",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\neulerian_num <- function(n, m) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_first_elements\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 9, c(5, 7), 11)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(11, 15, 5, 8, c(2, 3), 8)), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- eulerian_num\n    stopifnot(isTRUE(all.equal(candidate(3, 1), 4)))\n    stopifnot(isTRUE(all.equal(candidate(4, 1), 11)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 26)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "r",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nright_insertion <- function(a, x) {",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(input_list) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(' red ', 'green'), c('blue ', ' black'), c(' orange', 'brown'))), list(c(' red ', 'green'), c(' black', 'blue '), c(' orange', 'brown')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('zilver', 'gold'), c('magnesium', 'aluminium'), c('steel', 'bronze'))), list(c('gold', 'zilver'), c('aluminium', 'magnesium'), c('bronze', 'steel')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "r",
-    "prompt": "# Write a function to check if the given number is woodball or not.\nis_woodall <- function(x) {",
+    "prompt": "# Write a python function to count true booleans in the given list.\ncount <- function(lst) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_woodall\n    stopifnot(isTRUE(all.equal(candidate(383), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(254), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(200), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, FALSE, TRUE)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(FALSE, FALSE)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, TRUE, TRUE)), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "r",
-    "prompt": "# Write a function to sort the given array by using shell sort.\nshell_sort <- function(my_list) {",
+    "prompt": "# Write a function to append the given list to the given tuples.\nadd_lists <- function(test_list, test_tup) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- shell_sort\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)), c(2, 3, 4, 5, 12, 12, 23, 56, 81, 95))))\n    stopifnot(isTRUE(all.equal(candidate(c(24, 22, 39, 34, 87, 73, 68)), c(22, 24, 34, 39, 68, 73, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(32, 30, 16, 96, 82, 83, 74)), c(16, 30, 32, 74, 82, 83, 96))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_lists\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(9, 10, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(10, 11, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "r",
-    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\nfind_Odd_Pair <- function(A, N) {",
+    "prompt": "# Write a function to merge three lists into a single sorted list.\nmerge_sorted_list <- function(num1, num2, num3) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Odd_Pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11), 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 3), 2)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge_sorted_list\n    stopifnot(isTRUE(all.equal(candidate(c(25, 24, 15, 4, 5, 29, 110), c(19, 20, 11, 56, 25, 233, 154), c(24, 26, 54, 48)), c(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 6, 8, 9), c(2, 5, 7, 11), c(1, 4, 7, 8, 12)), c(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), c(25, 35, 22, 85, 14, 65, 75, 25, 58), c(12, 74, 9, 50, 61, 41)), c(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "r",
-    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\nsum_in_range <- function(l, r) {",
+    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nodd_Equivalent <- function(s, n) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_in_range\n    stopifnot(isTRUE(all.equal(candidate(2, 5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), 40)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_Equivalent\n    stopifnot(isTRUE(all.equal(candidate('011001', 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate('11011', 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate('1010', 4), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "r",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsquare_perimeter <- function(a) {",
+    "prompt": "# Write a function to check if a string represents an integer or not.\ncheck_integer <- function(text) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_perimeter\n    stopifnot(isTRUE(all.equal(candidate(10), 40)))\n    stopifnot(isTRUE(all.equal(candidate(5), 20)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_integer\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('12345'), TRUE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "r",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nis_polite <- function(n) {",
+    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\ntuple_to_int <- function(nums) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_polite\n    stopifnot(isTRUE(all.equal(candidate(7), 11)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 13)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsum_series <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_series\n    stopifnot(isTRUE(all.equal(candidate(6), 12)))\n    stopifnot(isTRUE(all.equal(candidate(10), 30)))\n    stopifnot(isTRUE(all.equal(candidate(9), 25)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "r",
-    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\nfind_dissimilar <- function(test_tup1, test_tup2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_dissimilar\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(7, 2, 3, 9)), c(1, 4, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 11, 25, 26), c(26, 34, 21, 36)), c(34, 36, 11, 25))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "r",
-    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nstart_withp <- function(words) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- start_withp\n    stopifnot(isTRUE(all.equal(candidate(c('Python PHP', 'Java JavaScript', 'c c++')), c('Python', 'PHP'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python Programming', 'Java Programming')), c('Python', 'Programming'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Pqrst Pqr', 'qrstuv')), c('Pqrst', 'Pqr'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "r",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsnake_to_camel <- function(word) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('android_tv'), 'AndroidTv')))\n    stopifnot(isTRUE(all.equal(candidate('google_pixel'), 'GooglePixel')))\n    stopifnot(isTRUE(all.equal(candidate('apple_watch'), 'AppleWatch')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "r",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\nvolume_cube <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- volume_cube\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(2), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5), 125)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ncheck_monthnumb_number <- function(monthnum2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumb_number\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "r",
-    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\nall_Bits_Set_In_The_Given_Range <- function(n, l, r) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_Bits_Set_In_The_Given_Range\n    stopifnot(isTRUE(all.equal(candidate(4, 1, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17, 2, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(39, 4, 6), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "r",
-    "prompt": "# Write a python function to get the first element of each sublist.\nExtract <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Extract\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4, 5), c(6, 7, 8, 9))), c(1, 3, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5))), c(1, 4))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(9, 8, 1), c(1, 2))), c(9, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "r",
-    "prompt": "# Write a function to find the surface area of a cylinder.\nsurfacearea_cylinder <- function(r, h) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cylinder\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 942.45)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 226.18800000000002)))\n    stopifnot(isTRUE(all.equal(candidate(4, 10), 351.848)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "r",
-    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsample_nam <- function(sample_names) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sample_nam\n    stopifnot(isTRUE(all.equal(candidate(c('sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith')), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c('php', 'res', 'Python', 'abcd', 'Java', 'aaa')), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c('abcd', 'Python', 'abba', 'aba')), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "r",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nrearrange_bigger <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rearrange_bigger\n    stopifnot(isTRUE(all.equal(candidate(12), 21)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(102), 120)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "r",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nperimeter_pentagon <- function(a) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- perimeter_pentagon\n    stopifnot(isTRUE(all.equal(candidate(5), 25)))\n    stopifnot(isTRUE(all.equal(candidate(10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(15), 75)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "r",
-    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nmax_sum <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 15, 51, 45, 33, 100, 12, 18, 9)), 194)))\n    stopifnot(isTRUE(all.equal(candidate(c(80, 60, 30, 40, 20, 10)), 210)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 14, 16, 21, 23, 29, 30)), 138)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "r",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\nextract_even <- function(test_tuple) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_even\n    stopifnot(isTRUE(all.equal(candidate(list(4, 5, list(7, 6, c(2, 4)), 6, 8)), list(4, list(6, c(2, 4)), 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(8, 7, c(4, 8)), 7, 9)), list(6, list(8, c(4, 8))))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(9, 8, c(4, 6)), 8, 10)), list(6, list(8, c(4, 6)), 8, 10))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_int\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 123)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), 456)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7)), 567)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4151,217 +147,9 @@
     "language": "r",
     "prompt": "# Write a function to convert all possible convertible elements in a list of lists to floats.\nlist_to_float <- function(test_list) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- list_to_float\n    stopifnot(isTRUE(all.equal(candidate(list(c('3', '4'), c('1', '26.45'), c('7.32', '8'), c('4', '8'))), list(c(3.0, 4.0), c(1.0, 26.45), c(7.32, 8.0), c(4.0, 8.0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('4', '4'), c('2', '27'), c('4.12', '9'), c('7', '11'))), list(c(4.0, 4.0), c(2.0, 27.0), c(4.12, 9.0), c(7.0, 11.0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('6', '78'), c('5', '26.45'), c('1.33', '4'), c('82', '13'))), list(c(6.0, 78.0), c(5.0, 26.45), c(1.33, 4.0), c(82.0, 13.0)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "r",
-    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsquare_Sum <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 20)))\n    stopifnot(isTRUE(all.equal(candidate(3), 56)))\n    stopifnot(isTRUE(all.equal(candidate(4), 120)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nget_pairs_count <- function(arr, sum) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_pairs_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, -1, 5), 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3), 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3), -3), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "r",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ncount_no_of_ways <- function(n, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_no_of_ways\n    stopifnot(isTRUE(all.equal(candidate(2, 4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4, 4), 228)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "r",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nreverse_words <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_words\n    stopifnot(isTRUE(all.equal(candidate('python program'), 'program python')))\n    stopifnot(isTRUE(all.equal(candidate('java language'), 'language java')))\n    stopifnot(isTRUE(all.equal(candidate('indian man'), 'man indian')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "r",
-    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\nchecks <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- checks\n    stopifnot(isTRUE(all.equal(candidate(70), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(73), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "r",
-    "prompt": "# Write a python function to find the last position of an element in a sorted array.\nlast <- function(arr, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- last\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, 4), 1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 3, 6, 8, 9), 3), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "r",
-    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\ncount_X <- function(tup, x) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_X\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "r",
-    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nextract_index_list <- function(l1, l2, l3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_index_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 6, 5), c(0, 1, 2, 3, 4, 6, 7)), c(1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 6, 5, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 6, 6, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "r",
-    "prompt": "# Write a function to find the second smallest number in a list.\nsecond_smallest <- function(numbers) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- second_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -8, -2, 0, -2)), -2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, -0.5, 0, 2, -2, -2)), -0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2)), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "r",
-    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\nconcatenate_tuple <- function(test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate_tuple\n    stopifnot(isTRUE(all.equal(candidate(list('ID', 'is', 4, 'UTS')), 'ID-is-4-UTS')))\n    stopifnot(isTRUE(all.equal(candidate(list('QWE', 'is', 4, 'RTY')), 'QWE-is-4-RTY')))\n    stopifnot(isTRUE(all.equal(candidate(list('ZEN', 'is', 4, 'OP')), 'ZEN-is-4-OP')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "r",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nreplace_spaces <- function(string) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')))\n    stopifnot(isTRUE(all.equal(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')))\n    stopifnot(isTRUE(all.equal(candidate('I love Coding'), 'I%20love%20Coding')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "r",
-    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsum_range_list <- function(list1, m, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_range_list\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10), 38)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "r",
-    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\nmerge_dictionaries_three <- function(dict1, dict2, dict3) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge_dictionaries_three\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('O' = 'Orange', 'W' = 'White', 'B' = 'Black')), list('B' = 'Black', 'R' = 'Red', 'P' = 'Pink', 'G' = 'Green', 'W' = 'White', 'O' = 'Orange'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('L' = 'lavender', 'B' = 'Blue')), list('W' = 'White', 'P' = 'Pink', 'B' = 'Black', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('L' = 'lavender', 'B' = 'Blue'), list('G' = 'Green', 'W' = 'White')), list('B' = 'Black', 'P' = 'Pink', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender', 'W' = 'White'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "r",
-    "prompt": "# Write a python function to find the minimum of two numbers.\nminimum <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- minimum\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(-5, -4), -5)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\nmax_difference <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_difference\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(1, 7), c(10, 3), c(1, 2))), 7)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(2, 17), c(9, 13), c(11, 12))), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 35), c(21, 27), c(13, 23), c(41, 22))), 23)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "r",
-    "prompt": "# Write a python function to find element at a given index after number of rotations.\nfind_Element <- function(arr, ranges, rotations, index) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), list(c(0, 2), c(0, 3)), 2, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), list(c(0, 1), c(0, 2)), 1, 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), list(c(0, 1), c(0, 2)), 1, 1), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4372,7 +160,7 @@
     "language": "r",
     "prompt": "# Write a function to convert a string to a list of strings split on the space character.\nstring_to_list <- function(string) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- string_to_list\n    stopifnot(isTRUE(all.equal(candidate('python programming'), c('python', 'programming'))))\n    stopifnot(isTRUE(all.equal(candidate('lists tuples strings'), c('lists', 'tuples', 'strings'))))\n    stopifnot(isTRUE(all.equal(candidate('write a program'), c('write', 'a', 'program'))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4385,22 +173,9 @@
     "language": "r",
     "prompt": "# Write a python function to find the element that appears only once in a sorted array.\nsearch <- function(arr) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4, 4)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "r",
-    "prompt": "# Write a function to sort a dictionary by value.\nsort_counter <- function(dict1) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_counter\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 81, 'Physics' = 83, 'Chemistry' = 87)), list(list('Chemistry', 87), list('Physics', 83), list('Math', 81)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 400, 'Physics' = 300, 'Chemistry' = 250)), list(list('Math', 400), list('Physics', 300), list('Chemistry', 250)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 900, 'Physics' = 1000, 'Chemistry' = 1250)), list(list('Chemistry', 1250), list('Physics', 1000), list('Math', 900)))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4411,7 +186,7 @@
     "language": "r",
     "prompt": "# Write a python function to remove first and last occurrence of a given character from the string.\nremove_Occ <- function(s, ch) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- remove_Occ\n    stopifnot(isTRUE(all.equal(candidate('hello', 'l'), 'heo')))\n    stopifnot(isTRUE(all.equal(candidate('abcda', 'a'), 'bcd')))\n    stopifnot(isTRUE(all.equal(candidate('PHP', 'P'), 'H')))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4420,364 +195,65 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "r",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nlateralsurface_cube <- function(l) {",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nmax_product_tuple <- function(list1) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 100)))\n    stopifnot(isTRUE(all.equal(candidate(9), 324)))\n    stopifnot(isTRUE(all.equal(candidate(10), 400)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 36)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 200)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 484)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "r",
-    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ncommon_element <- function(list1, list2) {",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\namicable_numbers_sum <- function(limit) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- common_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8, 9)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c'), c('d', 'b', 'e')), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- amicable_numbers_sum\n    stopifnot(isTRUE(all.equal(candidate(999), 504)))\n    stopifnot(isTRUE(all.equal(candidate(9999), 31626)))\n    stopifnot(isTRUE(all.equal(candidate(99), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "r",
-    "prompt": "# Write a function to append the given list to the given tuples.\nadd_lists <- function(test_list, test_tup) {",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfind_length <- function(string) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_lists\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(9, 10, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(10, 11, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_length\n    stopifnot(isTRUE(all.equal(candidate('11000010001'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('10111'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('11011101100101'), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "r",
-    "prompt": "# Write a function to compute the n-th power of each number in a list.\nnth_nums <- function(nums, n) {",
+    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\nsum <- function(a, b) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- nth_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), 3), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15), 5), c(248832, 759375))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 6)))\n    stopifnot(isTRUE(all.equal(candidate(100, 150), 93)))\n    stopifnot(isTRUE(all.equal(candidate(4, 6), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "r",
-    "prompt": "# Write a function to sort a list of elements.\npancake_sort <- function(nums) {",
+    "prompt": "# Write a function to multiply two integers.\nmultiply_int <- function(x, y) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- pancake_sort\n    stopifnot(isTRUE(all.equal(candidate(c(15, 79, 25, 38, 69)), c(15, 25, 38, 69, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(98, 12, 54, 36, 85)), c(12, 36, 54, 85, 98))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 42, 32, 12, 23)), c(12, 23, 32, 41, 42))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "r",
-    "prompt": "# Write a function to find the median of three numbers.\nmedian_numbers <- function(a, b, c) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- median_numbers\n    stopifnot(isTRUE(all.equal(candidate(25, 55, 65), 55.0)))\n    stopifnot(isTRUE(all.equal(candidate(20, 10, 30), 20.0)))\n    stopifnot(isTRUE(all.equal(candidate(15, 45, 75), 45.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "r",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ncheck_greater <- function(arr, number) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_greater\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6), 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 4, 8, 6, 1), 11), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ncheck_element <- function(list, element) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_element\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'orange', 'black', 'white'), 'blue'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'green', 'green', 'green'), 'green'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "r",
-    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nextract_string <- function(str, l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_string\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 8), c('practice', 'solution'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 6), c('Python'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 9), c('exercises'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "r",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ntext_lowercase_underscore <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_lowercase_underscore\n    stopifnot(isTRUE(all.equal(candidate('aab_cbbbc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aab_Abbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Aaab_abbbc'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "r",
-    "prompt": "# Write a function to trim each list by k in the given lists.\ntrim_tuple <- function(test_list, K) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- trim_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 2), list(c(2), c(9), c(2), c(2)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 1), list(c(3, 2, 1), c(4, 9, 2), c(1, 2, 3), c(8, 2, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 4, 9), c(11, 8, 12, 4), c(4, 1, 7, 8), c(3, 6, 9, 7)), 1), list(c(8, 4), c(8, 12), c(1, 7), c(6, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "r",
-    "prompt": "# Write a python function to find the sublist having minimum length.\nFind_Min <- function(lst) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 1, 1), c(1, 2, 7, 8))), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x'), c('x', 'y'), c('x', 'y', 'z'))), c('x'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "r",
-    "prompt": "# Write a function to filter odd numbers.\nfilter_oddnumbers <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_oddnumbers\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 45, 67, 84, 93)), c(45, 67, 93))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 9, 8, 6, 4, 3)), c(5, 7, 9, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "r",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nfind_adverbs <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_adverbs\n    stopifnot(isTRUE(all.equal(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')))\n    stopifnot(isTRUE(all.equal(candidate('Please handle the situation carefuly'), '28-36: carefuly')))\n    stopifnot(isTRUE(all.equal(candidate('Complete the task quickly'), '18-25: quickly')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "r",
-    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nmax_of_nth <- function(test_list, N) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_of_nth\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6, 7), c(1, 3, 5), c(8, 9, 19)), 2), 19)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 7, 8), c(2, 4, 6), c(9, 10, 20)), 1), 10)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 9), c(3, 5, 7), c(10, 11, 21)), 1), 11)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "r",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndecimal_to_binary <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(8), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(18), '10010')))\n    stopifnot(isTRUE(all.equal(candidate(7), '111')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ncombinations_colors <- function(l, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- combinations_colors\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 1), list(c('Red'), c('Green'), c('Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 2), list(c('Red', 'Red'), c('Red', 'Green'), c('Red', 'Blue'), c('Green', 'Green'), c('Green', 'Blue'), c('Blue', 'Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 3), list(c('Red', 'Red', 'Red'), c('Red', 'Red', 'Green'), c('Red', 'Red', 'Blue'), c('Red', 'Green', 'Green'), c('Red', 'Green', 'Blue'), c('Red', 'Blue', 'Blue'), c('Green', 'Green', 'Green'), c('Green', 'Green', 'Blue'), c('Green', 'Blue', 'Blue'), c('Blue', 'Blue', 'Blue')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "r",
-    "prompt": "# Write a function to remove all whitespaces from a string.\nremove_all_spaces <- function(text) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_all_spaces\n    stopifnot(isTRUE(all.equal(candidate('python  program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('python   programming    language'), 'pythonprogramminglanguage')))\n    stopifnot(isTRUE(all.equal(candidate('python                     program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('   python                     program'), 'pythonprogram')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "r",
-    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nmin_Swaps <- function(str1, str2) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_Swaps\n    stopifnot(isTRUE(all.equal(candidate('1101', '1110'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('111', '000'), 'Not Possible')))\n    stopifnot(isTRUE(all.equal(candidate('111', '110'), 'Not Possible')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "r",
-    "prompt": "# Write a function to create a new tuple from the given string and list.\nnew_tuple <- function(test_list, test_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- new_tuple\n    stopifnot(isTRUE(all.equal(candidate(c('WEB', 'is'), 'best'), c('WEB', 'is', 'best'))))\n    stopifnot(isTRUE(all.equal(candidate(c('We', 'are'), 'Developers'), c('We', 'are', 'Developers'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Part', 'is'), 'Wrong'), c('Part', 'is', 'Wrong'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "r",
-    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\nfind_remainder <- function(arr, n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_remainder\n    stopifnot(isTRUE(all.equal(candidate(c(100, 10, 5, 25, 35, 14), 11), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 2), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "r",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nmin_val <- function(listval) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 20)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "r",
-    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\npositive_count <- function(nums) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- positive_count\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)), 0.54)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 0.69)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), 0.56)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "r",
-    "prompt": "# Write a function to add the given tuple to the given list.\nadd_tuple <- function(test_list, test_tup) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(5, 6, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(6, 7, 8, 10, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(7, 8, 9, 11, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "r",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nmax_run_uppercase <- function(test_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_run_uppercase\n    stopifnot(isTRUE(all.equal(candidate('GeMKSForGERksISBESt'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('PrECIOusMOVemENTSYT'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('GooGLEFluTTER'), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "r",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsort_matrix <- function(M) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_matrix\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(2, 4, 5), c(1, 1, 1))), list(c(1, 1, 1), c(1, 2, 3), c(2, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(-2, 4, -5), c(1, -1, 1))), list(c(-2, 4, -5), c(1, -1, 1), c(1, 2, 3)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 8, 9), c(6, 4, 3), c(2, 1, 4))), list(c(2, 1, 4), c(6, 4, 3), c(5, 8, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "r",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ncount_vowels <- function(test_str) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_vowels\n    stopifnot(isTRUE(all.equal(candidate('bestinstareels'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('partofthejourneyistheend'), 12)))\n    stopifnot(isTRUE(all.equal(candidate('amazonprime'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nmax_sum_increasing_subseq <- function(a, n, index, k) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_increasing_subseq\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 4, 6), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 2, 5), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 15, 19, 21, 26, 28, 31), 7, 2, 4), 71)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply_int\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8), 32)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4788,7 +264,7 @@
     "language": "r",
     "prompt": "# Write a function to find words that are longer than n characters from a given list of words.\nlong_words <- function(n, str) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- long_words\n    stopifnot(isTRUE(all.equal(candidate(3, 'python is a programming language'), c('python', 'programming', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate(2, 'writing a program'), c('writing', 'program'))))\n    stopifnot(isTRUE(all.equal(candidate(5, 'sorting list'), c('sorting'))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4797,221 +273,39 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "r",
-    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\nfind_sum <- function(arr) {",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nmagic_square_test <- function(my_matrix) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 1, 4, 5, 6)), 21)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 10, 9, 4, 2, 10, 10, 45, 4)), 71)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 9, 45, 2, 10, 10, 45, 10)), 78)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- magic_square_test\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 12, 1, 14), c(2, 13, 8, 11), c(16, 3, 10, 5), c(9, 6, 15, 4))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 8))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 7))), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "r",
-    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\ntuple_to_dict <- function(test_tup) {",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsort_matrix <- function(M) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_dict\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 10, 13, 5)), list(1 = 5, 7 = 10, 13 = 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), list(1 = 2, 3 = 4, 5 = 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 10, 11, 12)), list(7 = 8, 9 = 10, 11 = 12))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_matrix\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(2, 4, 5), c(1, 1, 1))), list(c(1, 1, 1), c(1, 2, 3), c(2, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(-2, 4, -5), c(1, -1, 1))), list(c(-2, 4, -5), c(1, -1, 1), c(1, 2, 3)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 8, 9), c(6, 4, 3), c(2, 1, 4))), list(c(2, 1, 4), c(6, 4, 3), c(5, 8, 9)))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "r",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nget_coordinates <- function(test_tup) {",
+    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nmax_occurrences <- function(nums) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_coordinates\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4)), list(c(2, 3), c(2, 4), c(2, 5), c(3, 3), c(3, 4), c(3, 5), c(4, 3), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5)), list(c(3, 4), c(3, 5), c(3, 6), c(4, 4), c(4, 5), c(4, 6), c(5, 4), c(5, 5), c(5, 6)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6)), list(c(4, 5), c(4, 6), c(4, 7), c(5, 5), c(5, 6), c(5, 7), c(6, 5), c(6, 6), c(6, 7)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "r",
-    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\ncheck_type <- function(test_tuple) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_type\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 3, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, '4')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "r",
-    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfind_First_Missing <- function(array) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_First_Missing\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 6, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 8, 9)), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\nis_undulating <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_undulating\n    stopifnot(isTRUE(all.equal(candidate(1212121), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1991), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(121), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "r",
-    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nmin_k <- function(test_list, K) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_k\n    stopifnot(isTRUE(all.equal(candidate(list(list('Manjeet', 10), list('Akshat', 4), list('Akash', 2), list('Nikhil', 8)), 2), list(list('Akash', 2), list('Akshat', 4)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sanjeev', 11), list('Angat', 5), list('Akash', 3), list('Nepin', 9)), 3), list(list('Akash', 3), list('Angat', 5), list('Nepin', 9)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('tanmay', 14), list('Amer', 11), list('Ayesha', 9), list('SKD', 16)), 1), list(list('Ayesha', 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "r",
-    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\ncount_Substrings <- function(s) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Substrings\n    stopifnot(isTRUE(all.equal(candidate('112112'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('111'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('1101112'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth decagonal number.\nis_num_decagonal <- function(n) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_num_decagonal\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(7), 175)))\n    stopifnot(isTRUE(all.equal(candidate(10), 370)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nrear_extract <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- rear_extract\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Rash', 21), list(2, 'Varsha', 20), list(3, 'Kil', 19))), c(21, 20, 19))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sai', 36), list(2, 'Ayesha', 25), list(3, 'Salman', 45))), c(36, 25, 45))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sudeep', 14), list(2, 'Vandana', 36), list(3, 'Dawood', 56))), c(14, 36, 56))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "r",
-    "prompt": "# Write a function to find the closest smaller number than n.\nclosest_num <- function(N) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_num\n    stopifnot(isTRUE(all.equal(candidate(11), 10)))\n    stopifnot(isTRUE(all.equal(candidate(7), 6)))\n    stopifnot(isTRUE(all.equal(candidate(12), 11)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "r",
-    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfind_combinations <- function(test_list) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_combinations\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7), c(5, 1), c(6, 10))), list(c(8, 11), c(7, 5), c(8, 14), c(11, 8), c(12, 17), c(11, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8), c(6, 2), c(7, 11))), list(c(10, 13), c(9, 7), c(10, 16), c(13, 10), c(14, 19), c(13, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(8, 9), c(7, 3), c(8, 12))), list(c(12, 15), c(11, 9), c(12, 18), c(15, 12), c(16, 21), c(15, 15)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "r",
-    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nmaxAverageOfPath <- function(cost) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- maxAverageOfPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(6, 5, 4), c(7, 3, 9))), 5.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 4), c(7, 6, 5), c(8, 4, 10))), 6.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(8, 7, 6), c(9, 5, 11))), 7.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9))), 5.8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "r",
-    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsequential_search <- function(dlist, item) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sequential_search\n    stopifnot(isTRUE(all.equal(candidate(c(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31), list(TRUE, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 32, 45, 62, 35, 47, 44, 61), 61), list(TRUE, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 10, 17, 19, 22, 39, 48, 56), 48), list(TRUE, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "r",
-    "prompt": "# Write a python function to remove odd numbers from a given list.\nremove_odd <- function(l) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 6)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 3)), c(10, 20))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "r",
-    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nis_product_even <- function(arr) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_product_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "r",
-    "prompt": "# Write a python function to find the maximum of two numbers.\nmaximum <- function(a, b) {",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 10)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2), -1)))\n    stopifnot(isTRUE(all.equal(candidate(9, 7), 9)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_occurrences\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)), 20)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5022,9 +316,659 @@
     "language": "r",
     "prompt": "# Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nreverse_vowels <- function(str1) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- reverse_vowels\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('USA'), 'ASU')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'ab')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "r",
+    "prompt": "# Write a function to convert a list to a string.\ntup_string <- function(tup1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tup_string\n    stopifnot(isTRUE(all.equal(candidate(c('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's')), 'exercises')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'r', 'o', 'g', 'r', 'a', 'm')), 'program')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsum_negativenum <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_negativenum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), -32)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, -14, 13, -18, 12, -20)), -52)))\n    stopifnot(isTRUE(all.equal(candidate(c(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)), -894)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "r",
+    "prompt": "# Write a function to find the nth hexagonal number.\nhexagonal_num <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- hexagonal_num\n    stopifnot(isTRUE(all.equal(candidate(10), 190)))\n    stopifnot(isTRUE(all.equal(candidate(5), 45)))\n    stopifnot(isTRUE(all.equal(candidate(7), 91)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nis_Sum_Of_Powers_Of_Two <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Sum_Of_Powers_Of_Two\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(14), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of elements.\npancake_sort <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pancake_sort\n    stopifnot(isTRUE(all.equal(candidate(c(15, 79, 25, 38, 69)), c(15, 25, 38, 69, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(98, 12, 54, 36, 85)), c(12, 36, 54, 85, 98))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 42, 32, 12, 23)), c(12, 23, 32, 41, 42))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "r",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ncount_samepair <- function(list1, list2, list3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_samepair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9), c(2, 1, 3, 1, 2, 6, 7, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 2, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "r",
+    "prompt": "# Write a function to find number of lists present in the given list.\nfind_lists <- function(Input) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5, 4, 3, 2, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "r",
+    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\nmax_Abs_Diff <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_Abs_Diff\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 3, 2, 5, 1)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "r",
+    "prompt": "# Write a python function to find the volume of a triangular prism.\nfind_Volume <- function(l, b, h) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Volume\n    stopifnot(isTRUE(all.equal(candidate(10, 8, 6), 240)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "r",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfind_solution <- function(a, b, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_solution\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 7), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 7), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(1, 13, 17), c(4, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "r",
+    "prompt": "# Write a function to remove all elements from a given list present in another list.\nremove_elements <- function(list1, list2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(1, 3, 5, 7)), c(2, 4, 6, 8, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(5, 7)), c(1, 2, 3, 4, 6, 8, 9, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsum_series <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_series\n    stopifnot(isTRUE(all.equal(candidate(6), 12)))\n    stopifnot(isTRUE(all.equal(candidate(10), 30)))\n    stopifnot(isTRUE(all.equal(candidate(9), 25)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "r",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nare_equivalent <- function(num1, num2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- are_equivalent\n    stopifnot(isTRUE(all.equal(candidate(36, 57), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23, 47), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "r",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ncount_char_position <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_char_position\n    stopifnot(isTRUE(all.equal(candidate('xbcefg'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABcED'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('AbgdeF'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "r",
+    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfind_even_pair <- function(A) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_even_pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "r",
+    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\nnext_power_of_2 <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_power_of_2\n    stopifnot(isTRUE(all.equal(candidate(0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(17), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "r",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nfrequency <- function(a, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- frequency\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 3, 4), 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 1, 2), 1), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "r",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ntext_lowercase_underscore <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_lowercase_underscore\n    stopifnot(isTRUE(all.equal(candidate('aab_cbbbc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aab_Abbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Aaab_abbbc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "r",
+    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsum_range_list <- function(list1, m, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_range_list\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10), 38)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "r",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nperimeter_pentagon <- function(a) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- perimeter_pentagon\n    stopifnot(isTRUE(all.equal(candidate(5), 25)))\n    stopifnot(isTRUE(all.equal(candidate(10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(15), 75)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "r",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ncount_occurance <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_occurance\n    stopifnot(isTRUE(all.equal(candidate('letstdlenstdporstd'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('truststdsolensporsd'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('makestdsostdworthit'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('stds'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "r",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsquare_perimeter <- function(a) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_perimeter\n    stopifnot(isTRUE(all.equal(candidate(10), 40)))\n    stopifnot(isTRUE(all.equal(candidate(5), 20)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "r",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nremove_dirty_chars <- function(string, second_string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_dirty_chars\n    stopifnot(isTRUE(all.equal(candidate('probasscurve', 'pros'), 'bacuve')))\n    stopifnot(isTRUE(all.equal(candidate('digitalindia', 'talent'), 'digiidi')))\n    stopifnot(isTRUE(all.equal(candidate('exoticmiles', 'toxic'), 'emles')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "r",
+    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ntest_duplicate <- function(arraynums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- test_duplicate\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3, 3, 4, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "r",
+    "prompt": "# Write a function to check if the given number is woodball or not.\nis_woodall <- function(x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_woodall\n    stopifnot(isTRUE(all.equal(candidate(383), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(254), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(200), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "r",
+    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\ncheck_type <- function(test_tuple) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_type\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 3, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, '4')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "r",
+    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nis_majority <- function(arr, n, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_majority\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 3, 10), 7, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 4, 4, 4, 6, 6), 8, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 2), 5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2), 5, 1), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\ncount_Set_Bits <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Set_Bits\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "r",
+    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\nodd_values_string <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_values_string\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 'ace')))\n    stopifnot(isTRUE(all.equal(candidate('python'), 'pto')))\n    stopifnot(isTRUE(all.equal(candidate('data'), 'dt')))\n    stopifnot(isTRUE(all.equal(candidate('lambs'), 'lms')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "r",
+    "prompt": "# Write a function to find minimum of three numbers.\nmin_of_three <- function(a, b, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_of_three\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(19, 15, 18), 15)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -20, -30), -30)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "r",
+    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\nall_Bits_Set_In_The_Given_Range <- function(n, l, r) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_Bits_Set_In_The_Given_Range\n    stopifnot(isTRUE(all.equal(candidate(4, 1, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17, 2, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(39, 4, 6), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "r",
+    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nre_arrange_array <- function(arr, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- re_arrange_array\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9), c(-1, -3, -7, 4, 5, 6, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, -14, -26, 13, 15), 5), c(-14, -26, 12, 13, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 24, 36, -42, -39, -78, 85), 7), c(-42, -39, -78, 10, 24, 36, 85))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "r",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nreplace_blank <- function(str1, char) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_blank\n    stopifnot(isTRUE(all.equal(candidate('hello people', '@'), 'hello@people')))\n    stopifnot(isTRUE(all.equal(candidate('python program language', '$'), 'python$program$language')))\n    stopifnot(isTRUE(all.equal(candidate('blank space', '-'), 'blank-space')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "r",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\nvolume_cube <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- volume_cube\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(2), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5), 125)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\ncheck_occurences <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_occurences\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 1), c(1, 3), c(2, 5), c(5, 2), c(6, 3))), list(c(1, 3) = 2, c(2, 5) = 2, c(3, 6) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 2), c(2, 4), c(3, 6), c(6, 3), c(7, 4))), list(c(2, 4) = 2, c(3, 6) = 2, c(4, 7) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(13, 2), c(11, 23), c(12, 25), c(25, 12), c(16, 23))), list(c(2, 13) = 1, c(11, 23) = 1, c(12, 25) = 2, c(16, 23) = 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\nnumber_of_substrings <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- number_of_substrings\n    stopifnot(isTRUE(all.equal(candidate('abc'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 15)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "r",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nget_total_number_of_sequences <- function(m, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_total_number_of_sequences\n    stopifnot(isTRUE(all.equal(candidate(10, 4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(5, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(16, 3), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "r",
+    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nreplace_list <- function(list1, list2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8)), c(1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'blue', 'green'), c('yellow')), c('red', 'blue', 'yellow'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "r",
+    "prompt": "# Write a function to count the total number of characters in a string.\ncount_charac <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_charac\n    stopifnot(isTRUE(all.equal(candidate('python programming'), 18)))\n    stopifnot(isTRUE(all.equal(candidate('language'), 8)))\n    stopifnot(isTRUE(all.equal(candidate('words'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "r",
+    "prompt": "# Write a python function to find the next perfect square greater than a given number.\nnext_Perfect_Square <- function(N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_Perfect_Square\n    stopifnot(isTRUE(all.equal(candidate(35), 36)))\n    stopifnot(isTRUE(all.equal(candidate(6), 9)))\n    stopifnot(isTRUE(all.equal(candidate(9), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "r",
+    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nmax_sum <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 15, 51, 45, 33, 100, 12, 18, 9)), 194)))\n    stopifnot(isTRUE(all.equal(candidate(c(80, 60, 30, 40, 20, 10)), 210)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 14, 16, 21, 23, 29, 30)), 138)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "r",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nlps <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- lps\n    stopifnot(isTRUE(all.equal(candidate('TENS FOR TENS'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('CARDIO FOR CARDS'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('PART OF THE JOURNEY IS PART'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "r",
+    "prompt": "# Write a function to find the intersection of two arrays.\nintersection_array <- function(array_nums1, array_nums2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(1, 2, 4, 8, 9)), c(1, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(3, 5, 7, 9)), c(3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(10, 20, 30, 40)), c(10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "r",
+    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\ncount_X <- function(tup, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_X\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ninsert_element <- function(list, element) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- insert_element\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Black'), 'c'), c('c', 'Red', 'c', 'Green', 'c', 'Black'))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java'), 'program'), c('program', 'python', 'program', 'java'))))\n    stopifnot(isTRUE(all.equal(candidate(c('happy', 'sad'), 'laugh'), c('laugh', 'happy', 'laugh', 'sad'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "r",
+    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\nconvert <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- convert\n    stopifnot(isTRUE(all.equal(candidate(1), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5.0, 0.0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "r",
+    "prompt": "# Write a python function that returns the number of integer elements in a given list.\ncount_integer <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_integer\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 'abc', 1.2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1.2, 4, 5.1)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ncombinations_colors <- function(l, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- combinations_colors\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 1), list(c('Red'), c('Green'), c('Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 2), list(c('Red', 'Red'), c('Red', 'Green'), c('Red', 'Blue'), c('Green', 'Green'), c('Green', 'Blue'), c('Blue', 'Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 3), list(c('Red', 'Red', 'Red'), c('Red', 'Red', 'Green'), c('Red', 'Red', 'Blue'), c('Red', 'Green', 'Green'), c('Red', 'Green', 'Blue'), c('Red', 'Blue', 'Blue'), c('Green', 'Green', 'Green'), c('Green', 'Green', 'Blue'), c('Green', 'Blue', 'Blue'), c('Blue', 'Blue', 'Blue')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "r",
+    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ncount_Primes_nums <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Primes_nums\n    stopifnot(isTRUE(all.equal(candidate(5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 4)))\n    stopifnot(isTRUE(all.equal(candidate(100), 25)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "r",
+    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nswap_numbers <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_numbers\n    stopifnot(isTRUE(all.equal(candidate(10, 20), c(20, 10))))\n    stopifnot(isTRUE(all.equal(candidate(15, 17), c(17, 15))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(200, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5035,7 +979,7 @@
     "language": "r",
     "prompt": "# Write a function to maximize the given two lists.\nmaximize_elements <- function(test_tup1, test_tup2) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- maximize_elements\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 7), c(4, 9), c(2, 9), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(7, 8), c(5, 10), c(3, 10), c(8, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(8, 9), c(6, 11), c(4, 11), c(9, 12)))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -5044,78 +988,78 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "r",
-    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\neven_position <- function(nums) {",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nnewman_prime <- function(n) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_position\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- newman_prime\n    stopifnot(isTRUE(all.equal(candidate(3), 7)))\n    stopifnot(isTRUE(all.equal(candidate(4), 17)))\n    stopifnot(isTRUE(all.equal(candidate(5), 41)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "r",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ncheck_char <- function(string) {",
+    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\ndivision_elements <- function(test_tup1, test_tup2) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_char\n    stopifnot(isTRUE(all.equal(candidate('abba'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'Invalid')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- division_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(2, 2, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 16), c(6, 3, 4, 4)), c(2, 2, 2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(20, 14, 36, 18), c(5, 7, 6, 9)), c(4, 2, 6, 2))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "r",
-    "prompt": "# Write a python function to find the sum of even factors of a number.\nsumofFactors <- function(n) {",
+    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nsplit_two_parts <- function(list1, L) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- sumofFactors\n    stopifnot(isTRUE(all.equal(candidate(18), 26)))\n    stopifnot(isTRUE(all.equal(candidate(30), 48)))\n    stopifnot(isTRUE(all.equal(candidate(6), 8)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_two_parts\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), list(c(1, 1, 2), c(3, 4, 4, 5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 2), list(c('a', 'b'), c('c', 'd')))))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n'), 4), list(c('p', 'y', 't', 'h'), c('o', 'n')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "r",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nlateralsurface_cone <- function(r, h) {",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndog_age <- function(h_age) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cone\n    stopifnot(isTRUE(all.equal(candidate(5, 12), 204.20352248333654)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 566.3586699569488)))\n    stopifnot(isTRUE(all.equal(candidate(19, 17), 1521.8090132193388)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- dog_age\n    stopifnot(isTRUE(all.equal(candidate(12), 61)))\n    stopifnot(isTRUE(all.equal(candidate(15), 73)))\n    stopifnot(isTRUE(all.equal(candidate(24), 109)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "r",
-    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ncount_Pairs <- function(arr, n) {",
+    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlist_split <- function(S, step) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 5), 10)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- list_split\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'), 3), list(c('a', 'd', 'g', 'j', 'm'), c('b', 'e', 'h', 'k', 'n'), c('c', 'f', 'i', 'l')))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3), list(c(1, 4, 7, 10, 13), c(2, 5, 8, 11, 14), c(3, 6, 9, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java', 'C', 'C++', 'DBMS', 'SQL'), 2), list(c('python', 'C', 'DBMS'), c('java', 'C++', 'SQL')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "r",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nfind_first_occurrence <- function(A, x) {",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nlateralsurface_cube <- function(l) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_first_occurrence\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 100)))\n    stopifnot(isTRUE(all.equal(candidate(9), 324)))\n    stopifnot(isTRUE(all.equal(candidate(10), 400)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5126,9 +1070,789 @@
     "language": "r",
     "prompt": "# Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nsquare_Sum <- function(n) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 10)))\n    stopifnot(isTRUE(all.equal(candidate(3), 35)))\n    stopifnot(isTRUE(all.equal(candidate(4), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "r",
+    "prompt": "# Write a function to find the n'th star number.\nfind_star_num <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_star_num\n    stopifnot(isTRUE(all.equal(candidate(3), 37)))\n    stopifnot(isTRUE(all.equal(candidate(4), 73)))\n    stopifnot(isTRUE(all.equal(candidate(5), 121)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "r",
+    "prompt": "# Write a function to find the ascii value of a character.\nascii_value <- function(k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- ascii_value\n    stopifnot(isTRUE(all.equal(candidate('A'), 65)))\n    stopifnot(isTRUE(all.equal(candidate('R'), 82)))\n    stopifnot(isTRUE(all.equal(candidate('S'), 83)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\nsum_even_and_even_index <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_even_and_even_index\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1, 18, 8)), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)), 26)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "r",
+    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\neven_Power_Sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_Power_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 1056)))\n    stopifnot(isTRUE(all.equal(candidate(3), 8832)))\n    stopifnot(isTRUE(all.equal(candidate(1), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nrear_extract <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rear_extract\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Rash', 21), list(2, 'Varsha', 20), list(3, 'Kil', 19))), c(21, 20, 19))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sai', 36), list(2, 'Ayesha', 25), list(3, 'Salman', 45))), c(36, 25, 45))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sudeep', 14), list(2, 'Vandana', 36), list(3, 'Dawood', 56))), c(14, 36, 56))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "r",
+    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nsubstract_elements <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- substract_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5), c(2, 5, 18)), c(8, -1, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 2, 3), c(24, 45, 16)), c(-13, -43, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 18, 9), c(10, 11, 12)), c(-3, 7, -3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "r",
+    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\neven_binomial_Coeff_Sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_binomial_Coeff_Sum\n    stopifnot(isTRUE(all.equal(candidate(4), 8)))\n    stopifnot(isTRUE(all.equal(candidate(6), 32)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "r",
+    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\ndict_filter <- function(dict, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- dict_filter\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 170), list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 180), list('Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 190), list('Pierre Cox' = 190))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "r",
+    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\ncount_first_elements <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_first_elements\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 9, c(5, 7), 11)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(11, 15, 5, 8, c(2, 3), 8)), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth decagonal number.\nis_num_decagonal <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_num_decagonal\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(7), 175)))\n    stopifnot(isTRUE(all.equal(candidate(10), 370)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "r",
+    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nsequential_search <- function(dlist, item) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sequential_search\n    stopifnot(isTRUE(all.equal(candidate(c(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31), list(TRUE, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 32, 45, 62, 35, 47, 44, 61), 61), list(TRUE, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 10, 17, 19, 22, 39, 48, 56), 48), list(TRUE, 6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "r",
+    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\nall_unique <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_unique\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "r",
+    "prompt": "# Write a function to subtract two lists element-wise.\nsub_list <- function(nums1, nums2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sub_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), c(-3, -3, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 4)), c(-2, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(40, 50))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "r",
+    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nvalidate <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- validate\n    stopifnot(isTRUE(all.equal(candidate(1234), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(51241), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(321), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ncheck_element <- function(list, element) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_element\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'orange', 'black', 'white'), 'blue'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'green', 'green', 'green'), 'green'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "r",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ntext_match_two_three <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_two_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "r",
+    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nmax_sub_array_sum_repeated <- function(a, n, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum_repeated\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -30, -1), 4, 3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 10, 20), 3, 2), 59)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3), 3, 3), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "r",
+    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsquare_Sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 20)))\n    stopifnot(isTRUE(all.equal(candidate(3), 56)))\n    stopifnot(isTRUE(all.equal(candidate(4), 120)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "r",
+    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nmax_length <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_length\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(5, 7), c(10, 12, 14, 15))), list(4, c(10, 12, 14, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5), c(15, 20, 25))), list(3, c(15, 20, 25)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "r",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ncount_no_of_ways <- function(n, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_no_of_ways\n    stopifnot(isTRUE(all.equal(candidate(2, 4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4, 4), 228)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "r",
+    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfind <- function(n, m) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find\n    stopifnot(isTRUE(all.equal(candidate(10, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(20, 5), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "r",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\notherside_rightangle <- function(w, h) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- otherside_rightangle\n    stopifnot(isTRUE(all.equal(candidate(7, 8), 10.63014581273465)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(7, 15), 16.55294535724685)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nmax_val <- function(listval) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 50)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "r",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\nsum_div <- function(number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_div\n    stopifnot(isTRUE(all.equal(candidate(8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(12), 16)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "r",
+    "prompt": "# Write a python function to count inversions in an array.\nget_Inv_Count <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_Inv_Count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 6, 4, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 6, 1)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "r",
+    "prompt": "# Write a function to flatten a given nested list structure.\nflatten_list <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- flatten_list\n    stopifnot(isTRUE(all.equal(candidate(list(0, 10, c(20, 30), 40, 50, c(60, 70, 80), c(90, 100, 110, 120))), c(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(40), c(30, 56, 25), c(10, 20), c(33), c(40))), c(10, 20, 40, 30, 56, 25, 10, 20, 33, 40))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "r",
+    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\nmax_aggregate <- function(stdata) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_aggregate\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 90), list('Sabah Colley', 88), list('Peter Nichols', 7), list('Juan Whelan', 122), list('Sabah Colley', 84))), list('Juan Whelan', 212))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 50), list('Sabah Colley', 48), list('Peter Nichols', 37), list('Juan Whelan', 22), list('Sabah Colley', 14))), list('Juan Whelan', 72))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 10), list('Sabah Colley', 20), list('Peter Nichols', 30), list('Juan Whelan', 40), list('Sabah Colley', 50))), list('Sabah Colley', 70))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "r",
+    "prompt": "# Write a python function to find element at a given index after number of rotations.\nfind_Element <- function(arr, ranges, rotations, index) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), list(c(0, 2), c(0, 3)), 2, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), list(c(0, 1), c(0, 2)), 1, 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), list(c(0, 1), c(0, 2)), 1, 1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "r",
+    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nstart_withp <- function(words) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- start_withp\n    stopifnot(isTRUE(all.equal(candidate(c('Python PHP', 'Java JavaScript', 'c c++')), c('Python', 'PHP'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python Programming', 'Java Programming')), c('Python', 'Programming'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Pqrst Pqr', 'qrstuv')), c('Pqrst', 'Pqr'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nmax_sum_increasing_subseq <- function(a, n, index, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_increasing_subseq\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 4, 6), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 2, 5), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 15, 19, 21, 26, 28, 31), 7, 2, 4), 71)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "r",
+    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlarge_product <- function(nums1, nums2, N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- large_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 3), c(60, 54, 50))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 4), c(60, 54, 50, 48))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 5), c(60, 54, 50, 48, 45))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "r",
+    "prompt": "# Write a python function to find the maximum of two numbers.\nmaximum <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 10)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2), -1)))\n    stopifnot(isTRUE(all.equal(candidate(9, 7), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "r",
+    "prompt": "# Write a function to convert a given string to a list of characters.\nstring_to_tuple <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_tuple\n    stopifnot(isTRUE(all.equal(candidate('python 3.0'), c('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'))))\n    stopifnot(isTRUE(all.equal(candidate('item1'), c('i', 't', 'e', 'm', '1'))))\n    stopifnot(isTRUE(all.equal(candidate('15.10'), c('1', '5', '.', '1', '0'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "r",
+    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\nhighest_Power_of_2 <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- highest_Power_of_2\n    stopifnot(isTRUE(all.equal(candidate(10), 8)))\n    stopifnot(isTRUE(all.equal(candidate(19), 16)))\n    stopifnot(isTRUE(all.equal(candidate(32), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "r",
+    "prompt": "# Write a function to find the n'th lucas number.\nfind_lucas <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_lucas\n    stopifnot(isTRUE(all.equal(candidate(9), 76)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(3), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "r",
+    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nadd_string <- function(list_, string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_string\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 'temp{0}'), c('temp1', 'temp2', 'temp3', 'temp4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 'python{0}'), c('pythona', 'pythonb', 'pythonc', 'pythond'))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8), 'string{0}'), c('string5', 'string6', 'string7', 'string8'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "r",
+    "prompt": "# Write a function to convert more than one list to nested dictionary.\nconvert_list_dictionary <- function(l1, l2, l3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- convert_list_dictionary\n    stopifnot(isTRUE(all.equal(candidate(c('S001', 'S002', 'S003', 'S004'), c('Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'), c(85, 98, 89, 92)), list(list('S001' = list('Adina Park' = 85)), list('S002' = list('Leyton Marsh' = 98)), list('S003' = list('Duncan Boyle' = 89)), list('S004' = list('Saim Richards' = 92))))))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'def', 'ghi', 'jkl'), c('python', 'program', 'language', 'programs'), c(100, 200, 300, 400)), list(list('abc' = list('python' = 100)), list('def' = list('program' = 200)), list('ghi' = list('language' = 300)), list('jkl' = list('programs' = 400))))))\n    stopifnot(isTRUE(all.equal(candidate(c('A1', 'A2', 'A3', 'A4'), c('java', 'C', 'C++', 'DBMS'), c(10, 20, 30, 40)), list(list('A1' = list('java' = 10)), list('A2' = list('C' = 20)), list('A3' = list('C++' = 30)), list('A4' = list('DBMS' = 40))))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nget_max_sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_sum\n    stopifnot(isTRUE(all.equal(candidate(60), 106)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "r",
+    "prompt": "# Write a function to find the list with maximum length.\nmax_length_list <- function(input_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_length_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5), c(1, 2, 3, 4), c(1, 2, 3), c(1, 2), c(1))), list(5, c(1, 2, 3, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(6, 7, 8, 9), c(10, 11, 12))), list(4, c(6, 7, 8, 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "r",
+    "prompt": "# Write a function to check if given list contains no duplicates.\ncheck_distinct <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_distinct\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6, 1, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "r",
+    "prompt": "# Write a python function to find the first non-repeated character in a given string.\nfirst_non_repeating_character <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_non_repeating_character\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('ababc'), 'c')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ncheck_char <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_char\n    stopifnot(isTRUE(all.equal(candidate('abba'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'Invalid')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "r",
+    "prompt": "# Write a function to find the median of three numbers.\nmedian_numbers <- function(a, b, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- median_numbers\n    stopifnot(isTRUE(all.equal(candidate(25, 55, 65), 55.0)))\n    stopifnot(isTRUE(all.equal(candidate(20, 10, 30), 20.0)))\n    stopifnot(isTRUE(all.equal(candidate(15, 45, 75), 45.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "r",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsum_of_digits <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_of_digits\n    stopifnot(isTRUE(all.equal(candidate(c(10, 2, 56)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(list(list(10, 20, 4, 5, 'b', 70, 'a'))), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -4, 5, -70)), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "r",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\nbitwise_xor <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- bitwise_xor\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(15, 6, 5, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 7, 10), c(6, 3, 4, 4)), c(13, 6, 3, 14))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 11), c(7, 4, 5, 6)), c(11, 2, 13, 13))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "r",
+    "prompt": "# Write a python function to identify non-prime numbers.\nis_not_prime <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_not_prime\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(35), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(37), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "r",
+    "prompt": "# Write a function to extract the number of unique tuples in the given list.\nextract_freq <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_freq\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4), c(1, 2), c(4, 3), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 15), c(2, 3), c(5, 4), c(6, 7))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 16), c(2, 3), c(6, 5), c(6, 9))), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "r",
+    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nadd_nested_tuples <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_nested_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(7, 10), c(7, 14), c(3, 10), c(8, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(9, 12), c(9, 16), c(5, 12), c(10, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(11, 14), c(11, 18), c(7, 14), c(12, 17)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "r",
+    "prompt": "# Write a python function to find the minimum of two numbers.\nminimum <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- minimum\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(-5, -4), -5)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "r",
+    "prompt": "# Write a function to check whether an element exists within a tuple.\ncheck_tuplex <- function(tuplex, tuple1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_tuplex\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 'r'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), '5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 3), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "r",
+    "prompt": "# Write a python function to find whether the parity of a given number is odd.\nfind_Parity <- function(x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Parity\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "r",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nrearrange_bigger <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rearrange_bigger\n    stopifnot(isTRUE(all.equal(candidate(12), 21)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(102), 120)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "r",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nk_smallest_pairs <- function(nums1, nums2, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- k_smallest_pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 2), list(c(1, 2), c(1, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 1), list(c(1, 2)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 7), list(c(1, 2), c(1, 4), c(3, 2), c(1, 6), c(3, 4), c(3, 6), c(7, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "r",
+    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\nmin_product_tuple <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 8)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 100)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "r",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nmin_val <- function(listval) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 20)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "r",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsnake_to_camel <- function(word) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('android_tv'), 'AndroidTv')))\n    stopifnot(isTRUE(all.equal(candidate('google_pixel'), 'GooglePixel')))\n    stopifnot(isTRUE(all.equal(candidate('apple_watch'), 'AppleWatch')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "r",
+    "prompt": "# Write a python function to remove odd numbers from a given list.\nremove_odd <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 6)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 3)), c(10, 20))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "r",
+    "prompt": "# Write a function to extract the nth element from a given list of tuples.\nextract_nth_element <- function(list1, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_nth_element\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 0), c('Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 2), c(99, 96, 94, 98))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 1), c(98, 97, 91, 94))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "r",
+    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\noverlapping <- function(list1, list2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- overlapping\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5), c(1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "r",
+    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\nmax_Product <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_Product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 7, 0, 8, 4)), c(7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, -1, -2, -4, 5, 0, -6)), c(-4, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 3))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5139,7 +1863,7 @@
     "language": "r",
     "prompt": "# Write a function to find common first element in given list of lists.\ngroup_tuples <- function(Input) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "test_humaneval <- function() {\n    candidate <- group_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('x', 'z'), c('w', 't'))), list(c('x', 'y', 'z'), c('w', 't')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('a', 'c'), c('d', 'e'))), list(c('a', 'b', 'c'), c('d', 'e')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('f', 'g'), c('f', 'g'), c('h', 'i'))), list(c('f', 'g', 'g'), c('h', 'i')))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -5148,13 +1872,3289 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "r",
-    "prompt": "# Write a function to merge three lists into a single sorted list.\nmerge_sorted_list <- function(num1, num2, num3) {",
+    "prompt": "# Write a python function to find the element of a list having maximum length.\nFind_Max <- function(lst) {",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge_sorted_list\n    stopifnot(isTRUE(all.equal(candidate(c(25, 24, 15, 4, 5, 29, 110), c(19, 20, 11, 56, 25, 233, 154), c(24, 26, 54, 48)), c(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 6, 8, 9), c(2, 5, 7, 11), c(1, 4, 7, 8, 12)), c(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), c(25, 35, 22, 85, 14, 65, 75, 25, 58), c(12, 74, 9, 50, 61, 41)), c(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max\n    stopifnot(isTRUE(all.equal(candidate(list(c('A'), c('A', 'B'), c('A', 'B', 'C'))), c('A', 'B', 'C'))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 2, 3), c(1, 5, 6, 1))), c(1, 5, 6, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "r",
+    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nround_and_sum <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- round_and_sum\n    stopifnot(isTRUE(all.equal(candidate(c(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)), 243)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 9, 24.3, 29)), 345)))\n    stopifnot(isTRUE(all.equal(candidate(c(25.0, 56.7, 89.2)), 513)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\ncube_Sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cube_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 72)))\n    stopifnot(isTRUE(all.equal(candidate(3), 288)))\n    stopifnot(isTRUE(all.equal(candidate(4), 800)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "r",
+    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\nconcatenate_tuple <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate_tuple\n    stopifnot(isTRUE(all.equal(candidate(list('ID', 'is', 4, 'UTS')), 'ID-is-4-UTS')))\n    stopifnot(isTRUE(all.equal(candidate(list('QWE', 'is', 4, 'RTY')), 'QWE-is-4-RTY')))\n    stopifnot(isTRUE(all.equal(candidate(list('ZEN', 'is', 4, 'OP')), 'ZEN-is-4-OP')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "r",
+    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\nfind_Average_Of_Cube <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Average_Of_Cube\n    stopifnot(isTRUE(all.equal(candidate(2), 4.5)))\n    stopifnot(isTRUE(all.equal(candidate(3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "r",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\nextract_rear <- function(test_tuple) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_rear\n    stopifnot(isTRUE(all.equal(candidate(c('Mers', 'for', 'Vers')), c('s', 'r', 's'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Avenge', 'for', 'People')), c('e', 'r', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Gotta', 'get', 'go')), c('a', 't', 'o'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "r",
+    "prompt": "# Write a function to count the number of sublists containing a particular element.\ncount_element_in_list <- function(list1, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_element_in_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(1, 11), c(1, 15, 7)), 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'A'), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'E'), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "r",
+    "prompt": "# Write a function to filter odd numbers.\nfilter_oddnumbers <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_oddnumbers\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 45, 67, 84, 93)), c(45, 67, 93))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 9, 8, 6, 4, 3)), c(5, 7, 9, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "r",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nchange_date_format <- function(dt) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_date_format\n    stopifnot(isTRUE(all.equal(candidate('2026-01-02'), '02-01-2026')))\n    stopifnot(isTRUE(all.equal(candidate('2020-11-13'), '13-11-2020')))\n    stopifnot(isTRUE(all.equal(candidate('2021-04-26'), '26-04-2021')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort the given array by using shell sort.\nshell_sort <- function(my_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- shell_sort\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)), c(2, 3, 4, 5, 12, 12, 23, 56, 81, 95))))\n    stopifnot(isTRUE(all.equal(candidate(c(24, 22, 39, 34, 87, 73, 68)), c(22, 24, 34, 39, 68, 73, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(32, 30, 16, 96, 82, 83, 74)), c(16, 30, 32, 74, 82, 83, 96))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "r",
+    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\nand_tuples <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- and_tuples\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(0, 0, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(5, 6, 7, 8)), c(1, 2, 3, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 11, 12), c(7, 13, 14, 17)), c(0, 9, 10, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "r",
+    "prompt": "# Write a function to find the directrix of a parabola.\nparabola_directrix <- function(a, b, c) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- parabola_directrix\n    stopifnot(isTRUE(all.equal(candidate(5, 3, 2), -198)))\n    stopifnot(isTRUE(all.equal(candidate(9, 8, 4), -2336)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4, 6), -130)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "r",
+    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ncommon_element <- function(list1, list2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- common_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8, 9)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c'), c('d', 'b', 'e')), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "r",
+    "prompt": "# Write a function to find the median length of a trapezium.\nmedian_trapezium <- function(base1, base2, height) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- median_trapezium\n    stopifnot(isTRUE(all.equal(candidate(15, 25, 35), 20)))\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 30), 15)))\n    stopifnot(isTRUE(all.equal(candidate(6, 9, 4), 7.5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "r",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ncheck_greater <- function(arr, number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_greater\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6), 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 4, 8, 6, 1), 11), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ntext_match_one <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "r",
+    "prompt": "# Write a python function to find the last digit of a given number.\nlast_Digit <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 3)))\n    stopifnot(isTRUE(all.equal(candidate(25), 5)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "r",
+    "prompt": "# Write a python function to return the negative numbers in a list.\nneg_nos <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- neg_nos\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 4, 5, -6)), c(-1, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3, 4)), c(-1, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(-7, -6, 8, 9)), c(-7, -6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "r",
+    "prompt": "# Write a function to remove odd characters in a string.\nremove_odd <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate('python'), 'yhn')))\n    stopifnot(isTRUE(all.equal(candidate('program'), 'rga')))\n    stopifnot(isTRUE(all.equal(candidate('language'), 'agae')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "r",
+    "prompt": "# Write a function to count bidirectional tuple pairs.\ncount_bidirectional <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_bidirectional\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 3), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 2), c(6, 5), c(2, 1))), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "r",
+    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nmultiple_to_single <- function(L) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiple_to_single\n    stopifnot(isTRUE(all.equal(candidate(c(11, 33, 50)), 113350)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4, 5, 6)), -123456)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25)), 10152025)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "r",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nfind_adverb_position <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_adverb_position\n    stopifnot(isTRUE(all.equal(candidate('clearly!! we can see the sky'), list(0, 7, 'clearly'))))\n    stopifnot(isTRUE(all.equal(candidate('seriously!! there are many roses'), list(0, 9, 'seriously'))))\n    stopifnot(isTRUE(all.equal(candidate('unfortunately!! sita is going to home'), list(0, 13, 'unfortunately'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "r",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsurfacearea_cube <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 150)))\n    stopifnot(isTRUE(all.equal(candidate(3), 54)))\n    stopifnot(isTRUE(all.equal(candidate(10), 600)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "r",
+    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\npositive_count <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- positive_count\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)), 0.54)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 0.69)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), 0.56)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "r",
+    "prompt": "# Write a python function to find the largest negative number from the given list.\nlargest_neg <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_neg\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -4, -6)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -8, -9)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "r",
+    "prompt": "# Write a function to trim each list by k in the given lists.\ntrim_tuple <- function(test_list, K) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- trim_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 2), list(c(2), c(9), c(2), c(2)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 1), list(c(3, 2, 1), c(4, 9, 2), c(1, 2, 3), c(8, 2, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 4, 9), c(11, 8, 12, 4), c(4, 1, 7, 8), c(3, 6, 9, 7)), 1), list(c(8, 4), c(8, 12), c(1, 7), c(6, 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "r",
+    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nindex_multiplication <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- index_multiplication\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 21), c(12, 45), c(2, 9), c(7, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(14, 32), c(20, 60), c(6, 20), c(16, 44)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(24, 45), c(30, 77), c(12, 33), c(27, 60)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "r",
+    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\ncount_Occurrence <- function(tup, lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Occurrence\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'c', 'b', 'd'), c('a', 'b')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 4, 6, 7, 1, 4), c(1, 4, 7)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(1, 2)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "r",
+    "prompt": "# Write a function to find cubes of individual elements in a list.\ncube_nums <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cube_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(1728, 3375))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\ncal_sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cal_sum\n    stopifnot(isTRUE(all.equal(candidate(9), 49)))\n    stopifnot(isTRUE(all.equal(candidate(10), 66)))\n    stopifnot(isTRUE(all.equal(candidate(11), 88)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "r",
+    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nextract_string <- function(str, l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_string\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 8), c('practice', 'solution'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 6), c('Python'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 9), c('exercises'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "r",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\nremove_whitespaces <- function(text1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_whitespaces\n    stopifnot(isTRUE(all.equal(candidate(' Google    Flutter '), 'GoogleFlutter')))\n    stopifnot(isTRUE(all.equal(candidate(' Google    Dart '), 'GoogleDart')))\n    stopifnot(isTRUE(all.equal(candidate(' iOS    Swift '), 'iOSSwift')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "r",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nloss_amount <- function(actual_cost, sale_amount) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- loss_amount\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), 0)))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), 100)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), 3000)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of even factors of a number.\nsumofFactors <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sumofFactors\n    stopifnot(isTRUE(all.equal(candidate(18), 26)))\n    stopifnot(isTRUE(all.equal(candidate(30), 48)))\n    stopifnot(isTRUE(all.equal(candidate(6), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "r",
+    "prompt": "# Write a function that matches a word containing 'z'.\ntext_match_wordz <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz\n    stopifnot(isTRUE(all.equal(candidate('pythonz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ncheck_monthnumb_number <- function(monthnum2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumb_number\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "r",
+    "prompt": "# Write a function to reverse each string in a given list of string values.\nreverse_string_list <- function(stringlist) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_string_list\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue', 'White', 'Black')), c('deR', 'neerG', 'eulB', 'etihW', 'kcalB'))))\n    stopifnot(isTRUE(all.equal(candidate(c('john', 'amal', 'joel', 'george')), c('nhoj', 'lama', 'leoj', 'egroeg'))))\n    stopifnot(isTRUE(all.equal(candidate(c('jack', 'john', 'mary')), c('kcaj', 'nhoj', 'yram'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "r",
+    "prompt": "# Write a python function to find the sublist having minimum length.\nFind_Min <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 1, 1), c(1, 2, 7, 8))), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x'), c('x', 'y'), c('x', 'y', 'z'))), c('x'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "r",
+    "prompt": "# Write a function to find the area of a rectangle.\nrectangle_area <- function(l, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rectangle_area\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "r",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\nremove_uppercase <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_uppercase\n    stopifnot(isTRUE(all.equal(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')))\n    stopifnot(isTRUE(all.equal(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')))\n    stopifnot(isTRUE(all.equal(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "r",
+    "prompt": "# Write a python function to get the first element of each sublist.\nExtract <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Extract\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4, 5), c(6, 7, 8, 9))), c(1, 3, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5))), c(1, 4))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(9, 8, 1), c(1, 2))), c(9, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "r",
+    "prompt": "# Write a python function to count the upper case characters in a given string.\nupper_ctr <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- upper_ctr\n    stopifnot(isTRUE(all.equal(candidate('PYthon'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('BigData'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('program'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "r",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ncombinations_list <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- combinations_list\n    stopifnot(isTRUE(all.equal(candidate(c('orange', 'red', 'green', 'blue')), list(c(), c('orange'), c('red'), c('red', 'orange'), c('green'), c('green', 'orange'), c('green', 'red'), c('green', 'red', 'orange'), c('blue'), c('blue', 'orange'), c('blue', 'red'), c('blue', 'red', 'orange'), c('blue', 'green'), c('blue', 'green', 'orange'), c('blue', 'green', 'red'), c('blue', 'green', 'red', 'orange')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'blue', 'white', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('blue'), c('blue', 'red'), c('blue', 'green'), c('blue', 'green', 'red'), c('white'), c('white', 'red'), c('white', 'green'), c('white', 'green', 'red'), c('white', 'blue'), c('white', 'blue', 'red'), c('white', 'blue', 'green'), c('white', 'blue', 'green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('black', 'blue'), c('black', 'blue', 'red'), c('black', 'blue', 'green'), c('black', 'blue', 'green', 'red'), c('black', 'white'), c('black', 'white', 'red'), c('black', 'white', 'green'), c('black', 'white', 'green', 'red'), c('black', 'white', 'blue'), c('black', 'white', 'blue', 'red'), c('black', 'white', 'blue', 'green'), c('black', 'white', 'blue', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'blue'), c('orange', 'blue', 'red'), c('orange', 'blue', 'green'), c('orange', 'blue', 'green', 'red'), c('orange', 'white'), c('orange', 'white', 'red'), c('orange', 'white', 'green'), c('orange', 'white', 'green', 'red'), c('orange', 'white', 'blue'), c('orange', 'white', 'blue', 'red'), c('orange', 'white', 'blue', 'green'), c('orange', 'white', 'blue', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red'), c('orange', 'black', 'blue'), c('orange', 'black', 'blue', 'red'), c('orange', 'black', 'blue', 'green'), c('orange', 'black', 'blue', 'green', 'red'), c('orange', 'black', 'white'), c('orange', 'black', 'white', 'red'), c('orange', 'black', 'white', 'green'), c('orange', 'black', 'white', 'green', 'red'), c('orange', 'black', 'white', 'blue'), c('orange', 'black', 'white', 'blue', 'red'), c('orange', 'black', 'white', 'blue', 'green'), c('orange', 'black', 'white', 'blue', 'green', 'red')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum product subarray of the given array.\nmax_subarray_product <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_subarray_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 0, 7, -8, -2)), 112)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, -3, -10, 0, 2)), 180)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -40, 0, -2, -3)), 80)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "r",
+    "prompt": "# Write a function to check if all values are same in a dictionary.\ncheck_value <- function(dict, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_value\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 5), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "r",
+    "prompt": "# Write a function to drop empty items from a given dictionary.\ndrop_empty <- function(dict1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- drop_empty\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = 'Green', 'c3' = NULL)), list('c1' = 'Red', 'c2' = 'Green'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = NULL, 'c3' = NULL)), list('c1' = 'Red'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = NULL, 'c2' = 'Green', 'c3' = NULL)), list('c2' = 'Green'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nmax_product <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_product\n    stopifnot(isTRUE(all.equal(candidate(c(3, 100, 4, 5, 150, 6)), 3000)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 42, 55, 68, 80)), 50265600)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 22, 9, 33, 21, 50, 41, 60)), 2460)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "r",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nadd_pairwise <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_pairwise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(6, 12, 15, 18))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 8, 9, 11)), c(8, 14, 17, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 7, 9, 10, 12)), c(10, 16, 19, 22))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "r",
+    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\nfind_remainder <- function(arr, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_remainder\n    stopifnot(isTRUE(all.equal(candidate(c(100, 10, 5, 25, 35, 14), 11), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 2), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\ncheck_Consecutive <- function(l) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_Consecutive\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "r",
+    "prompt": "# Write a function to replace characters in a string.\nreplace_char <- function(str1, ch, newch) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_char\n    stopifnot(isTRUE(all.equal(candidate('polygon', 'y', 'l'), 'pollgon')))\n    stopifnot(isTRUE(all.equal(candidate('character', 'c', 'a'), 'aharaater')))\n    stopifnot(isTRUE(all.equal(candidate('python', 'l', 'a'), 'python')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "r",
+    "prompt": "# Write a function to sort a dictionary by value.\nsort_counter <- function(dict1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_counter\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 81, 'Physics' = 83, 'Chemistry' = 87)), list(list('Chemistry', 87), list('Physics', 83), list('Math', 81)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 400, 'Physics' = 300, 'Chemistry' = 250)), list(list('Math', 400), list('Physics', 300), list('Chemistry', 250)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 900, 'Physics' = 1000, 'Chemistry' = 1250)), list(list('Chemistry', 1250), list('Physics', 1000), list('Math', 900)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\nbig_sum <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- big_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "r",
+    "prompt": "# Write a python function to convert the given string to lower case.\nis_lower <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_lower\n    stopifnot(isTRUE(all.equal(candidate('InValid'), 'invalid')))\n    stopifnot(isTRUE(all.equal(candidate('TruE'), 'true')))\n    stopifnot(isTRUE(all.equal(candidate('SenTenCE'), 'sentence')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "r",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\nremove_lowercase <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_lowercase\n    stopifnot(isTRUE(all.equal(candidate('PYTHon'), 'PYTH')))\n    stopifnot(isTRUE(all.equal(candidate('FInD'), 'FID')))\n    stopifnot(isTRUE(all.equal(candidate('STRinG'), 'STRG')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "r",
+    "prompt": "# Write a python function to find the first digit of a given number.\nfirst_Digit <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 1)))\n    stopifnot(isTRUE(all.equal(candidate(456), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "r",
+    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nheap_queue_largest <- function(nums, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- heap_queue_largest\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 3), c(85, 75, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 2), c(85, 75))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 5), c(85, 75, 65, 58, 35))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "r",
+    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\nSplit <- function(list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 12, 13)), c(11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1)), c(7, 9, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "r",
+    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndifference <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- difference\n    stopifnot(isTRUE(all.equal(candidate(3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(5), 210)))\n    stopifnot(isTRUE(all.equal(candidate(2), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\nfind_Odd_Pair <- function(A, N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Odd_Pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11), 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 3), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "r",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\ntoggle_string <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- toggle_string\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'pYTHON')))\n    stopifnot(isTRUE(all.equal(candidate('Pangram'), 'pANGRAM')))\n    stopifnot(isTRUE(all.equal(candidate('LIttLE'), 'liTTle')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\ndigit_distance_nums <- function(n1, n2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- digit_distance_nums\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(23, 56), 6)))\n    stopifnot(isTRUE(all.equal(candidate(123, 256), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nmax_sub_array_sum <- function(a, size) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, 4, -1, -2, 1, 5, -3), 8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5, -2, -3, 2, 6, -4), 8), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(-4, -5, 6, -3, -4, 3, 7, -5), 8), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "r",
+    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nunion_elements <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- union_elements\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 4, 5, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(3, 4, 5, 6)), c(1, 2, 3, 4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13, 14), c(13, 15, 16, 17)), c(11, 12, 13, 14, 15, 16, 17))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "r",
+    "prompt": "# Write a python function to find the length of the longest sublists.\nFind_Max_Length <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 4), c(5, 6, 7, 8))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 1), c(2, 2), c(3, 2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7), c(22, 23), c(13, 14, 15), c(10, 20, 30, 40, 50))), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "r",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\nextract_values <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_values\n    stopifnot(isTRUE(all.equal(candidate('\"Python\", \"PHP\", \"Java\"'), c('Python', 'PHP', 'Java'))))\n    stopifnot(isTRUE(all.equal(candidate('\"python\",\"program\",\"language\"'), c('python', 'program', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), c('red', 'blue', 'green', 'yellow'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "r",
+    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ncount_Pairs <- function(arr, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 5), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "r",
+    "prompt": "# Write a python function to split a string into characters.\nsplit <- function(word) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- split\n    stopifnot(isTRUE(all.equal(candidate('python'), c('p', 'y', 't', 'h', 'o', 'n'))))\n    stopifnot(isTRUE(all.equal(candidate('Name'), c('N', 'a', 'm', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate('program'), c('p', 'r', 'o', 'g', 'r', 'a', 'm'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "r",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsum_digits <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_digits\n    stopifnot(isTRUE(all.equal(candidate(345), 12)))\n    stopifnot(isTRUE(all.equal(candidate(12), 3)))\n    stopifnot(isTRUE(all.equal(candidate(97), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "r",
+    "prompt": "# Write a function to check whether a specified list is sorted or not.\nissort_list <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- issort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 15, 14, 20)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "r",
+    "prompt": "# Write a function to create a list of N empty dictionaries.\nempty_list <- function(length) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- empty_list\n    stopifnot(isTRUE(all.equal(candidate(5), list(list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(6), list(list(), list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(7), list(list(), list(), list(), list(), list(), list(), list()))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "r",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white'))), list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('d', 'c'), c('g', 'h'), c('f', 'e'))), list(c('a', 'b'), c('c', 'd'), c('g', 'h'), c('e', 'f')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "r",
+    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\nchecks <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- checks\n    stopifnot(isTRUE(all.equal(candidate(70), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(73), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "r",
+    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\ntwo_unique_nums <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- two_unique_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 3, 4, 5)), c(1, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 5)), c(1, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "r",
+    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\nunique_product <- function(list_data) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_product\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30, 40, 20, 50, 60, 40)), 720000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 0, 1, 1)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "r",
+    "prompt": "# Write a function to find the surface area of a cylinder.\nsurfacearea_cylinder <- function(r, h) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cylinder\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 942.45)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 226.18800000000002)))\n    stopifnot(isTRUE(all.equal(candidate(4, 10), 351.848)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "r",
+    "prompt": "# Write a python function to check whether a list is sublist of another or not.\nis_Sub_Array <- function(A, B) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Sub_Array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 5), c(1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), c(1, 2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 2), c(2, 2, 0)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "r",
+    "prompt": "# Write a python function to find the last digit in factorial of a given number.\nlast_Digit_Factorial <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit_Factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(21), 0)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "r",
+    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ninterleave_lists <- function(list1, list2, list3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- interleave_lists\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7), c(10, 20, 30, 40, 50, 60, 70), c(100, 200, 300, 400, 500, 600, 700)), c(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20), c(15, 2), c(5, 10)), c(10, 15, 5, 20, 2, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 44), c(10, 15), c(20, 5)), c(11, 10, 20, 44, 15, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "r",
+    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\nfind_dissimilar <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_dissimilar\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(7, 2, 3, 9)), c(1, 4, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 11, 25, 26), c(26, 34, 21, 36)), c(34, 36, 11, 25))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "r",
+    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\nfind_Max_Num <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Max_Num\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 321)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 1)), 6541)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 9)), 9321)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "r",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\nextract_even <- function(test_tuple) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_even\n    stopifnot(isTRUE(all.equal(candidate(list(4, 5, list(7, 6, c(2, 4)), 6, 8)), list(4, list(6, c(2, 4)), 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(8, 7, c(4, 8)), 7, 9)), list(6, list(8, c(4, 8))))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(9, 8, c(4, 6)), 8, 10)), list(6, list(8, c(4, 6)), 8, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "r",
+    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\nsurface_Area <- function(b, s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- surface_Area\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 33)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "r",
+    "prompt": "# Write a function which returns nth catalan number.\ncatalan_number <- function(num) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- catalan_number\n    stopifnot(isTRUE(all.equal(candidate(10), 16796)))\n    stopifnot(isTRUE(all.equal(candidate(9), 4862)))\n    stopifnot(isTRUE(all.equal(candidate(7), 429)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "r",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nfind_adverbs <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_adverbs\n    stopifnot(isTRUE(all.equal(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')))\n    stopifnot(isTRUE(all.equal(candidate('Please handle the situation carefuly'), '28-36: carefuly')))\n    stopifnot(isTRUE(all.equal(candidate('Complete the task quickly'), '18-25: quickly')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "r",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nexpensive_items <- function(items, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- expensive_items\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09)), 2), list(list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-1', 'price' = 101.1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09), list('name' = 'Item-4', 'price' = 22.75)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "r",
+    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\nsplit_Arr <- function(l, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_Arr\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 5, 6, 52, 36), 2), c(5, 6, 52, 36, 12, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 1), c(2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 4, 5, 6, 7), 3), c(3, 4, 5, 6, 7, 0, 1, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "r",
+    "prompt": "# Write a function to convert a list to a tuple.\nlist_tuple <- function(listx) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- list_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 10, 7, 4, 15, 3)), c(5, 10, 7, 4, 15, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 2, 3, 4, 4, 7)), c(2, 4, 5, 6, 2, 3, 4, 4, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(58, 44, 56)), c(58, 44, 56))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "r",
+    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\nbig_diff <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- big_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 12)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 3)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "r",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\nperfect_squares <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- perfect_squares\n    stopifnot(isTRUE(all.equal(candidate(1, 30), c(1, 4, 9, 16, 25))))\n    stopifnot(isTRUE(all.equal(candidate(50, 100), c(64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(100, 121, 144, 169, 196))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\nopposite_Signs <- function(x, y) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- opposite_Signs\n    stopifnot(isTRUE(all.equal(candidate(1, -2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-2, 2), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "r",
+    "prompt": "# Write a python function to interchange the first and last elements in a list.\nswap_List <- function(newList) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(12, 35, 9, 56, 24)), c(24, 35, 9, 56, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\nsum_Of_product <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_product\n    stopifnot(isTRUE(all.equal(candidate(3), 15)))\n    stopifnot(isTRUE(all.equal(candidate(4), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "r",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\nremovezero_ip <- function(ip) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- removezero_ip\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.196'), '216.8.94.196')))\n    stopifnot(isTRUE(all.equal(candidate('12.01.024'), '12.1.24')))\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.0196'), '216.8.94.196')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "r",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndiff_even_odd <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- diff_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "r",
+    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nmin_Swaps <- function(str1, str2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_Swaps\n    stopifnot(isTRUE(all.equal(candidate('1101', '1110'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('111', '000'), 'Not Possible')))\n    stopifnot(isTRUE(all.equal(candidate('111', '110'), 'Not Possible')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "r",
+    "prompt": "# Write a function to find kth element from the given two sorted arrays.\nfind_kth <- function(arr1, arr2, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_kth\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6, 7, 9), c(1, 4, 8, 10), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 112, 256, 349, 770), c(72, 86, 113, 119, 265, 445, 892), 7), 256)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 7, 8, 10), c(2, 5, 9, 11), 6), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\narmstrong_number <- function(number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- armstrong_number\n    stopifnot(isTRUE(all.equal(candidate(153), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(259), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4458), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "r",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsum_average <- function(number) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_average\n    stopifnot(isTRUE(all.equal(candidate(10), c(55, 5.5))))\n    stopifnot(isTRUE(all.equal(candidate(15), c(120, 8.0))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(210, 10.5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth octagonal number.\nis_octagonal <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_octagonal\n    stopifnot(isTRUE(all.equal(candidate(5), 65)))\n    stopifnot(isTRUE(all.equal(candidate(10), 280)))\n    stopifnot(isTRUE(all.equal(candidate(15), 645)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given number is even or not.\nis_Even <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Even\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "r",
+    "prompt": "# Write a python function to find the first repeated character in a given string.\nfirst_repeated_char <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_repeated_char\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('abc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('123123'), '1')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "r",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nget_ludic <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_ludic\n    stopifnot(isTRUE(all.equal(candidate(10), c(1, 2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25))))\n    stopifnot(isTRUE(all.equal(candidate(45), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "r",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nreverse_words <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_words\n    stopifnot(isTRUE(all.equal(candidate('python program'), 'program python')))\n    stopifnot(isTRUE(all.equal(candidate('java language'), 'language java')))\n    stopifnot(isTRUE(all.equal(candidate('indian man'), 'man indian')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "r",
+    "prompt": "# Write a function to check if the given integer is a prime number.\nprime_num <- function(num) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_num\n    stopifnot(isTRUE(all.equal(candidate(13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(-1010), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "r",
+    "prompt": "# Write a function to convert degrees to radians.\nradian_degree <- function(degree) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- radian_degree\n    stopifnot(isTRUE(all.equal(candidate(90), 1.5707963267948966)))\n    stopifnot(isTRUE(all.equal(candidate(60), 1.0471975511965976)))\n    stopifnot(isTRUE(all.equal(candidate(120), 2.0943951023931953)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "r",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfind_literals <- function(text, pattern) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_literals\n    stopifnot(isTRUE(all.equal(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), list('fox', 16, 19))))\n    stopifnot(isTRUE(all.equal(candidate('Its been a very crazy procedure right', 'crazy'), list('crazy', 16, 21))))\n    stopifnot(isTRUE(all.equal(candidate('Hardest choices required strongest will', 'will'), list('will', 35, 39))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "r",
+    "prompt": "# Write a python function to find nth bell number.\nbell_Number <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- bell_Number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 15)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "r",
+    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nremove_kth_element <- function(list1, L) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), c(1, 1, 3, 4, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4), c(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5), c(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "r",
+    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nmax_of_nth <- function(test_list, N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_of_nth\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6, 7), c(1, 3, 5), c(8, 9, 19)), 2), 19)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 7, 8), c(2, 4, 6), c(9, 10, 20)), 1), 10)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 9), c(3, 5, 7), c(10, 11, 21)), 1), 11)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "r",
+    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nmerge <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('a', 'b'), c('m', 'n'))), list(c('x', 'a', 'm'), c('y', 'b', 'n')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6), c(7, 8))), list(c(1, 3, 5, 7), c(2, 4, 6, 8)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y', 'z'), c('a', 'b', 'c'), c('m', 'n', 'o'))), list(c('x', 'a', 'm'), c('y', 'b', 'n'), c('z', 'c', 'o')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ncummulative_sum <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- cummulative_sum\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 6, 7), c(2, 6))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7, 8), c(3, 7))), 37)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8, 9), c(4, 8))), 44)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "r",
+    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\naverage_tuple <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- average_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 10, 10, 12), c(30, 45, 56, 45), c(81, 80, 39, 32), c(1, 2, 3, 4))), c(30.5, 34.25, 27.0, 23.25))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, -5), c(30, -15, 56), c(81, -60, -39), c(-10, 2, 3))), c(25.5, -18.0, 3.75))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(100, 100, 100, 120), c(300, 450, 560, 450), c(810, 800, 390, 320), c(10, 20, 30, 40))), c(305.0, 342.5, 270.0, 232.5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "r",
+    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\ntuple_modulo <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_modulo\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6), c(5, 6, 7, 5)), c(0, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 6, 7), c(6, 7, 8, 6)), c(5, 5, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 7, 8), c(7, 8, 9, 7)), c(5, 6, 7, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "r",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nmin_Jumps <- function(steps, d) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_Jumps\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 11), 3.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 14), 11), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "r",
+    "prompt": "# Write a function to divide two lists element wise.\ndiv_list <- function(nums1, nums2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- div_list\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(1, 2, 3)), c(4.0, 2.5, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2), c(1, 4)), c(3.0, 0.5))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(1.8, 1.7142857142857142))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "r",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\nmove_num <- function(test_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_num\n    stopifnot(isTRUE(all.equal(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')))\n    stopifnot(isTRUE(all.equal(candidate('Avengers124Assemble'), 'AvengersAssemble124')))\n    stopifnot(isTRUE(all.equal(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\ncount_Substrings <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Substrings\n    stopifnot(isTRUE(all.equal(candidate('112112'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('111'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('1101112'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "r",
+    "prompt": "# Write a function to find the median of two sorted lists of same size.\nget_median <- function(arr1, arr2, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_median\n    stopifnot(isTRUE(all.equal(candidate(c(1, 12, 15, 26, 38), c(2, 13, 17, 30, 45), 5), 16.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 9), c(7, 13, 19, 28), 4), 8.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 14, 23, 36, 42), c(2, 18, 27, 39, 49, 55), 6), 25.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "r",
+    "prompt": "# Write a function to compute the n-th power of each number in a list.\nnth_nums <- function(nums, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- nth_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), 3), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15), 5), c(248832, 759375))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "r",
+    "prompt": "# Write a python function to convert a given string to uppercase.\nis_upper <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_upper\n    stopifnot(isTRUE(all.equal(candidate('person'), 'PERSON')))\n    stopifnot(isTRUE(all.equal(candidate('final'), 'FINAL')))\n    stopifnot(isTRUE(all.equal(candidate('Valid'), 'VALID')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "r",
+    "prompt": "# Write a python function to interchange the first and last element in a given list.\nswap_List <- function(newList) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), c(4, 2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "r",
+    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ntriangle_area <- function(r) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(-1), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "r",
+    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfind_First_Missing <- function(array) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_First_Missing\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 6, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 8, 9)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "r",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nreplace_spaces <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')))\n    stopifnot(isTRUE(all.equal(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')))\n    stopifnot(isTRUE(all.equal(candidate('I love Coding'), 'I%20love%20Coding')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "r",
+    "prompt": "# Write a python function to find even numbers from a list of numbers.\nSplit <- function(list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 8, 0, 1)), c(4, 6, 8, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 12, 15, 19)), c(8, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "r",
+    "prompt": "# Write a python function to find smallest number in a list.\nsmallest_num <- function(xs) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_num\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 1, 45, 99)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(45, 46, 50, 60)), 45)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "r",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nget_coordinates <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_coordinates\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4)), list(c(2, 3), c(2, 4), c(2, 5), c(3, 3), c(3, 4), c(3, 5), c(4, 3), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5)), list(c(3, 4), c(3, 5), c(3, 6), c(4, 4), c(4, 5), c(4, 6), c(5, 4), c(5, 5), c(5, 6)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6)), list(c(4, 5), c(4, 6), c(4, 7), c(5, 5), c(5, 6), c(5, 7), c(6, 5), c(6, 6), c(6, 7)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "r",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nreplace_spaces <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')))\n    stopifnot(isTRUE(all.equal(candidate('The_Avengers'), 'The Avengers')))\n    stopifnot(isTRUE(all.equal(candidate('Fast and Furious'), 'Fast_and_Furious')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "r",
+    "prompt": "# Write a python function to move all zeroes to the end of the given list.\nmove_zero <- function(num_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 0, 3, 4)), c(1, 2, 3, 4, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 0, 0, 4, 0, 5, 0)), c(2, 3, 2, 4, 5, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 0, 1, 1)), c(1, 1, 1, 0, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\npair_xor_Sum <- function(arr, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pair_xor_Sum\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9, 7, 6), 4), 47)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 5), 3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3), 2), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort the given list.\nheap_sort <- function(iterable) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- heap_sort\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 25, 58)), c(14, 22, 25, 25, 35, 58, 65, 75, 85))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 1, 9, 5)), c(1, 5, 7, 9))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nnoprofit_noloss <- function(actual_cost, sale_amount) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- noprofit_noloss\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(100, 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "r",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nwind_chill <- function(v, t) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- wind_chill\n    stopifnot(isTRUE(all.equal(candidate(120, 35), 40)))\n    stopifnot(isTRUE(all.equal(candidate(40, 20), 19)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "r",
+    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsample_nam <- function(sample_names) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sample_nam\n    stopifnot(isTRUE(all.equal(candidate(c('sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith')), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c('php', 'res', 'Python', 'abcd', 'Java', 'aaa')), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c('abcd', 'Python', 'abba', 'aba')), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\nmax_difference <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_difference\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(1, 7), c(10, 3), c(1, 2))), 7)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(2, 17), c(9, 13), c(11, 12))), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 35), c(21, 27), c(13, 23), c(41, 22))), 23)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "r",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nremove_parenthesis <- function(items) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_parenthesis\n    stopifnot(isTRUE(all.equal(candidate(c('python (chrome)')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('string(.abc)')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('alpha(num)')), 'alpha')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth nonagonal number.\nis_nonagonal <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nonagonal\n    stopifnot(isTRUE(all.equal(candidate(10), 325)))\n    stopifnot(isTRUE(all.equal(candidate(15), 750)))\n    stopifnot(isTRUE(all.equal(candidate(18), 1089)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "r",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ntext_match_wordz_middle <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz_middle\n    stopifnot(isTRUE(all.equal(candidate('pythonzabc.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zxyabc.'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "r",
+    "prompt": "# Write a python function to reverse an array upto a given position.\nreverse_Array_Upto_K <- function(input, k) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_Array_Upto_K\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 4), c(4, 3, 2, 1, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7), 2), c(5, 4, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5), 3), c(7, 8, 9, 6, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\nsubject_marks <- function(subjectmarks) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- subject_marks\n    stopifnot(isTRUE(all.equal(candidate(list(list('English', 88), list('Science', 90), list('Maths', 97), list('Social sciences', 82))), list(list('Social sciences', 82), list('English', 88), list('Science', 90), list('Maths', 97)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Telugu', 49), list('Hindhi', 54), list('Social', 33))), list(list('Social', 33), list('Telugu', 49), list('Hindhi', 54)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Physics', 96), list('Chemistry', 97), list('Biology', 45))), list(list('Biology', 45), list('Physics', 96), list('Chemistry', 97)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "r",
+    "prompt": "# Write a function to flatten a list and sum all of its elements.\nrecursive_list_sum <- function(data_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- recursive_list_sum\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, c(3, 4), c(5, 6))), 21)))\n    stopifnot(isTRUE(all.equal(candidate(list(7, 10, c(15, 14), c(19, 41))), 106)))\n    stopifnot(isTRUE(all.equal(candidate(list(10, 20, c(30, 40), c(50, 60))), 210)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of positive numbers in a list.\npos_count <- function(list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pos_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3, -4)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, -1)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "r",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nbell_number <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- bell_number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 115975)))\n    stopifnot(isTRUE(all.equal(candidate(56), 6775685320645824322581483068371419745979053216268760300)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given array is monotonic or not.\nis_Monotonic <- function(A) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "r",
+    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nis_sublist <- function(l, s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sublist\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(4, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(1, 6)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\ndiffer_At_One_Bit_Pos <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- differ_At_One_Bit_Pos\n    stopifnot(isTRUE(all.equal(candidate(13, 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "r",
+    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nget_equal <- function(Input) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_equal\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 22, 33), c(44, 55, 66))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6, 7))), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4))), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of elements.\ncomb_sort <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- comb_sort\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 37, 25, 79)), c(5, 15, 25, 37, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 32, 15, 19, 22)), c(15, 19, 22, 32, 41))))\n    stopifnot(isTRUE(all.equal(candidate(c(99, 15, 13, 47)), c(13, 15, 47, 99))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "r",
+    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\nadd_dict_to_tuple <- function(test_tup, test_dict) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_dict_to_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), list('MSAM' = 1, 'is' = 2, 'best' = 3)), list(4, 5, 6, list('MSAM' = 1, 'is' = 2, 'best' = 3)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), list('UTS' = 2, 'is' = 3, 'Worst' = 4)), list(1, 2, 3, list('UTS' = 2, 'is' = 3, 'Worst' = 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 10), list('POS' = 3, 'is' = 4, 'Okay' = 5)), list(8, 9, 10, list('POS' = 3, 'is' = 4, 'Okay' = 5)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "r",
+    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nmaxAverageOfPath <- function(cost) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- maxAverageOfPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(6, 5, 4), c(7, 3, 9))), 5.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 4), c(7, 6, 5), c(8, 4, 10))), 6.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(8, 7, 6), c(9, 5, 11))), 7.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9))), 5.8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "r",
+    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfilter_data <- function(students, h, w) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_data\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 6.0, 70), list('Cierra Vega' = c(6.2, 70)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.9, 67), list('Cierra Vega' = c(6.2, 70), 'Kierra Gentry' = c(6.0, 68)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.7, 64), list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "r",
+    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ncount_same_pair <- function(nums1, nums2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_same_pair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 1, 2), c(0, 1, 2, 2)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "r",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\npower_base_sum <- function(base, power) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- power_base_sum\n    stopifnot(isTRUE(all.equal(candidate(2, 100), 115)))\n    stopifnot(isTRUE(all.equal(candidate(8, 10), 37)))\n    stopifnot(isTRUE(all.equal(candidate(8, 15), 62)))\n    stopifnot(isTRUE(all.equal(candidate(3, 3), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "r",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nextract_quotation <- function(text1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_quotation\n    stopifnot(isTRUE(all.equal(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), c('A53', 'multi', 'Processor'))))\n    stopifnot(isTRUE(all.equal(candidate('Cast your \"favorite\" entertainment \"apps\"'), c('favorite', 'apps'))))\n    stopifnot(isTRUE(all.equal(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), c('4k Ultra HD', 'HDR 10'))))\n    stopifnot(isTRUE(all.equal(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "r",
+    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nmultiply_elements <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(5, 35, 56, 80))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 7)), c(8, 20, 30, 42))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 13, 14, 9, 15)), c(156, 182, 126, 135))))\n    stopifnot(isTRUE(all.equal(candidate(c(12)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "r",
+    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsum_list <- function(lst1, lst2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_list\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), c(15, 25, 35)), c(25, 45, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(5, 6, 7)), c(6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 20, 30), c(15, 45, 75)), c(30, 65, 105))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\ndif_Square <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- dif_Square\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "r",
+    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nconsecutive_duplicates <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), c(10, 15, 19, 18, 17, 26, 17, 18, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), c('a', 'b', 'c', 'd'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd', 'a', 'a')), c('a', 'b', 'c', 'd', 'a'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "r",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nlateralsurface_cone <- function(r, h) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cone\n    stopifnot(isTRUE(all.equal(candidate(5, 12), 204.20352248333654)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 566.3586699569488)))\n    stopifnot(isTRUE(all.equal(candidate(19, 17), 1521.8090132193388)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "r",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nreplace_specialchar <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_specialchar\n    stopifnot(isTRUE(all.equal(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')))\n    stopifnot(isTRUE(all.equal(candidate('a b c,d e f'), 'a:b:c:d:e:f')))\n    stopifnot(isTRUE(all.equal(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "r",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\nfind_first_occurrence <- function(A, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_first_occurrence\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "r",
+    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nsum_Of_Subarray_Prod <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_Subarray_Prod\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "r",
+    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ntoggle_middle_bits <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- toggle_middle_bits\n    stopifnot(isTRUE(all.equal(candidate(9), 15)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(11), 13)))\n    stopifnot(isTRUE(all.equal(candidate(65), 127)))\n    stopifnot(isTRUE(all.equal(candidate(77), 115)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "r",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nleft_insertion <- function(a, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- left_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ncheck_str <- function(string) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_str\n    stopifnot(isTRUE(all.equal(candidate('annie'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dawood'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Else'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\ngeometric_sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- geometric_sum\n    stopifnot(isTRUE(all.equal(candidate(7), 1.9921875)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1.9375)))\n    stopifnot(isTRUE(all.equal(candidate(8), 1.99609375)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "r",
+    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfind_Index <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Index\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 14)))\n    stopifnot(isTRUE(all.equal(candidate(4), 45)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "r",
+    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\ntuple_to_dict <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_dict\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 10, 13, 5)), list(1 = 5, 7 = 10, 13 = 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), list(1 = 2, 3 = 4, 5 = 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 10, 11, 12)), list(7 = 8, 9 = 10, 11 = 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "r",
+    "prompt": "# Write a python function to check whether all the characters are same or not.\nall_Characters_Same <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_Characters_Same\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('data'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "r",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\narea_tetrahedron <- function(side) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- area_tetrahedron\n    stopifnot(isTRUE(all.equal(candidate(3), 15.588457268119894)))\n    stopifnot(isTRUE(all.equal(candidate(20), 692.8203230275509)))\n    stopifnot(isTRUE(all.equal(candidate(10), 173.20508075688772)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "r",
+    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nrotate_right <- function(list, m) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rotate_right\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3), c(8, 9, 10, 1, 2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(9, 10, 1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5), c(6, 7, 8, 9, 10, 1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "r",
+    "prompt": "# Write a function to check if the given tuple has any none value or not.\ncheck_none <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_none\n    stopifnot(isTRUE(all.equal(candidate(list(10, 4, 5, 6, NULL)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 11, 14)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 3, 4, NULL)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "r",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\ndivisible_by_digits <- function(startnum, endnum) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- divisible_by_digits\n    stopifnot(isTRUE(all.equal(candidate(1, 22), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22))))\n    stopifnot(isTRUE(all.equal(candidate(1, 15), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15))))\n    stopifnot(isTRUE(all.equal(candidate(20, 25), c(22, 24))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "r",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nsector_area <- function(r, a) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sector_area\n    stopifnot(isTRUE(all.equal(candidate(4, 45), 6.283185307179586)))\n    stopifnot(isTRUE(all.equal(candidate(9, 45), 31.808625617596654)))\n    stopifnot(isTRUE(all.equal(candidate(9, 361), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "r",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlcs_of_three <- function(X, Y, Z) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- lcs_of_three\n    stopifnot(isTRUE(all.equal(candidate('AGGT12', '12TXAYB', '12XBA'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "r",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ncapital_words_spaces <- function(str1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- capital_words_spaces\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('PythonProgrammingExamples'), 'Python Programming Examples')))\n    stopifnot(isTRUE(all.equal(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "r",
+    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nsort_numeric_strings <- function(nums_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numeric_strings\n    stopifnot(isTRUE(all.equal(candidate(c('4', '12', '45', '7', '0', '100', '200', '-12', '-500')), c(-500, -12, 0, 4, 7, 12, 45, 100, 200))))\n    stopifnot(isTRUE(all.equal(candidate(c('2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2')), c(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c('1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11')), c(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "r",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\nis_samepatterns <- function(colors, patterns) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_samepatterns\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'green'), c('a', 'b', 'b')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b', 'b')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b')), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "r",
+    "prompt": "# Write a function to add the given tuple to the given list.\nadd_tuple <- function(test_list, test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(5, 6, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(6, 7, 8, 10, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(7, 8, 9, 11, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "r",
+    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ncheck_min_heap <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_min_heap\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 10, 15)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 5, 3, 15)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "r",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\njacobsthal_num <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- jacobsthal_num\n    stopifnot(isTRUE(all.equal(candidate(5), 11)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(13), 2731)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "r",
+    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nmin_k <- function(test_list, K) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_k\n    stopifnot(isTRUE(all.equal(candidate(list(list('Manjeet', 10), list('Akshat', 4), list('Akash', 2), list('Nikhil', 8)), 2), list(list('Akash', 2), list('Akshat', 4)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sanjeev', 11), list('Angat', 5), list('Akash', 3), list('Nepin', 9)), 3), list(list('Akash', 3), list('Angat', 5), list('Nepin', 9)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('tanmay', 14), list('Amer', 11), list('Ayesha', 9), list('SKD', 16)), 1), list(list('Ayesha', 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "r",
+    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nextract_index_list <- function(l1, l2, l3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_index_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 6, 5), c(0, 1, 2, 3, 4, 6, 7)), c(1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 6, 5, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 6, 6, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "r",
+    "prompt": "# Write a function to find the second smallest number in a list.\nsecond_smallest <- function(numbers) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- second_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -8, -2, 0, -2)), -2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, -0.5, 0, 2, -2, -2)), -0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2)), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\ntext_match_zero_one <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_zero_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dsabbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('asbbbba'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abaaa'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "r",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\ncount_reverse_pairs <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_reverse_pairs\n    stopifnot(isTRUE(all.equal(candidate(c('julia', 'best', 'tseb', 'for', 'ailuj')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c('geeks', 'best', 'for', 'skeeg')), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c('makes', 'best', 'sekam', 'for', 'rof')), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "r",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nis_decimal <- function(num) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_decimal\n    stopifnot(isTRUE(all.equal(candidate('123.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('e666.86'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('3.124587'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1.1.11'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "r",
+    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfind_tuples <- function(test_list, K) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 24, 12), c(7, 9, 6), c(12, 18, 21)), 6), list(c(6, 24, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 25, 30), c(4, 2, 3), c(7, 8, 9)), 5), list(c(5, 25, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 9, 16), c(8, 16, 4), c(19, 17, 18)), 4), list(c(8, 16, 4)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "r",
+    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\nunique_Element <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ncheck_monthnumber_number <- function(monthnum3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumber_number\n    stopifnot(isTRUE(all.equal(candidate(6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "r",
+    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfind_min_diff <- function(arr, n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_min_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 3, 19, 18, 25), 6), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 6), 4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 5, 20, 9), 4), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "r",
+    "prompt": "# Write a python function to count number of digits in a given string.\nnumber_ctr <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- number_ctr\n    stopifnot(isTRUE(all.equal(candidate('program2bedone'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('3wonders'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('123'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('3wond-1ers2'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "r",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nis_polite <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_polite\n    stopifnot(isTRUE(all.equal(candidate(7), 11)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 13)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "r",
+    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\npair_wise <- function(l1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pair_wise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 3, 4, 4, 5)), list(c(1, 1), c(1, 2), c(2, 3), c(3, 3), c(3, 4), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), list(c(1, 5), c(5, 7), c(7, 9), c(9, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 9, 7, 10)), list(c(5, 1), c(1, 9), c(9, 7), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), list(c(1, 2), c(2, 3), c(3, 4), c(4, 5), c(5, 6), c(6, 7), c(7, 8), c(8, 9), c(9, 10)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nget_pairs_count <- function(arr, sum) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_pairs_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, -1, 5), 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3), 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3), -3), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "r",
+    "prompt": "# Write a python function to get the difference between two lists.\nDiff <- function(li1, li2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Diff\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25, 30, 35, 40), c(25, 40, 35)), c(10, 20, 30, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 1)), c(2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(6, 7, 1)), c(2, 3, 6, 7))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\nodd_num_sum <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_num_sum\n    stopifnot(isTRUE(all.equal(candidate(2), 82)))\n    stopifnot(isTRUE(all.equal(candidate(3), 707)))\n    stopifnot(isTRUE(all.equal(candidate(4), 3108)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "r",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ncheck_expression <- function(exp) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_expression\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}][]({})'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "r",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\nremove_length <- function(test_str, K) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_length\n    stopifnot(isTRUE(all.equal(candidate('The person is most value tet', 3), 'person is most value')))\n    stopifnot(isTRUE(all.equal(candidate('If you told me about this ok', 4), 'If you me about ok')))\n    stopifnot(isTRUE(all.equal(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "r",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\noccurance_substring <- function(text, pattern) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- occurance_substring\n    stopifnot(isTRUE(all.equal(candidate('python programming, python language', 'python'), list('python', 0, 6))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'programming'), list('programming', 7, 18))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'language'), list('language', 31, 39))))\n    stopifnot(isTRUE(all.equal(candidate('c++ programming, c++ language', 'python'), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "r",
+    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\nodd_position <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_position\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4, 3, 6, 7, 6, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "r",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ncount_vowels <- function(test_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_vowels\n    stopifnot(isTRUE(all.equal(candidate('bestinstareels'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('partofthejourneyistheend'), 12)))\n    stopifnot(isTRUE(all.equal(candidate('amazonprime'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\nfind_sum <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 1, 4, 5, 6)), 21)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 10, 9, 4, 2, 10, 10, 45, 4)), 71)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 9, 45, 2, 10, 10, 45, 10)), 78)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "r",
+    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\npack_consecutive_duplicates <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- pack_consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), list(c(0, 0), c(1), c(2), c(3), c(4, 4), c(5), c(6, 6, 6), c(7), c(8), c(9), c(4, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), list(c(10, 10), c(15), c(19), c(18, 18), c(17), c(26, 26), c(17), c(18), c(10)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), list(c('a', 'a'), c('b'), c('c'), c('d', 'd')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "r",
+    "prompt": "# Write a python function to find whether a number is divisible by 11.\nis_Diff <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Diff\n    stopifnot(isTRUE(all.equal(candidate(12345), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1212112), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1212), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "r",
+    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfind_combinations <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_combinations\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7), c(5, 1), c(6, 10))), list(c(8, 11), c(7, 5), c(8, 14), c(11, 8), c(12, 17), c(11, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8), c(6, 2), c(7, 11))), list(c(10, 13), c(9, 7), c(10, 16), c(13, 10), c(14, 19), c(13, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(8, 9), c(7, 3), c(8, 12))), list(c(12, 15), c(11, 9), c(12, 18), c(15, 12), c(16, 21), c(15, 15)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\ncount_divisors <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_divisors\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(100), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nodd_length_sum <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_length_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 7)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "r",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nrgb_to_hsv <- function(r, g, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- rgb_to_hsv\n    stopifnot(isTRUE(all.equal(candidate(255, 255, 255), c(0.0, 0.0, 100.0))))\n    stopifnot(isTRUE(all.equal(candidate(0, 215, 0), c(120.0, 100.0, 84.31372549019608))))\n    stopifnot(isTRUE(all.equal(candidate(10, 215, 110), c(149.26829268292684, 95.34883720930233, 84.31372549019608))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "r",
+    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nmul_even_odd <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- mul_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "r",
+    "prompt": "# Write a function to convert tuple string to integer tuple.\ntuple_str_int <- function(test_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_str_int\n    stopifnot(isTRUE(all.equal(candidate('(7, 8, 9)'), c(7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate('(1, 2, 3)'), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate('(4, 5, 6)'), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate('(7, 81, 19)'), c(7, 81, 19))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "r",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nright_insertion <- function(a, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ntext_match_three <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('caacabbbba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "r",
+    "prompt": "# Write a function to create a new tuple from the given string and list.\nnew_tuple <- function(test_list, test_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- new_tuple\n    stopifnot(isTRUE(all.equal(candidate(c('WEB', 'is'), 'best'), c('WEB', 'is', 'best'))))\n    stopifnot(isTRUE(all.equal(candidate(c('We', 'are'), 'Developers'), c('We', 'are', 'Developers'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Part', 'is'), 'Wrong'), c('Part', 'is', 'Wrong'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "r",
+    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\neven_position <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_position\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "r",
+    "prompt": "# Write a function to remove tuples from the given tuple.\nremove_nested <- function(test_tup) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_nested\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), c(1, 5, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 6, 8, c(5, 7), 11)), c(2, 6, 8, 11))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), 12)), c(3, 7, 9, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), c(5, 12), 12)), c(3, 7, 9, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of lists in a given number of lists.\ncount_list <- function(input_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(2, 3), c(4, 5))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 0), c(2, 0))), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "r",
+    "prompt": "# Write a python function to find the last position of an element in a sorted array.\nlast <- function(arr, x) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- last\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, 4), 1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 3, 6, 8, 9), 3), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ntext_starta_endb <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_starta_endb\n    stopifnot(isTRUE(all.equal(candidate('aabbbb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabAbbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('accddbbjjj'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "r",
+    "prompt": "# Write function to find the sum of all items in the given dictionary.\nreturn_sum <- function(dict) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- return_sum\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 100, 'b' = 200, 'c' = 300)), 600)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 25, 'b' = 18, 'c' = 45)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 36, 'b' = 39, 'c' = 49)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\nsum_in_range <- function(l, r) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_in_range\n    stopifnot(isTRUE(all.equal(candidate(2, 5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), 40)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "r",
+    "prompt": "# Write a python function to find the sum of an array.\n_sum <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- _sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 12, 13, 10)), 50)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "r",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nleft_rotate <- function(n, d) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- left_rotate\n    stopifnot(isTRUE(all.equal(candidate(16, 2), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), 40)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(1, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 40)))\n    stopifnot(isTRUE(all.equal(candidate(29, 3), 232)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "r",
+    "prompt": "# Write a python function to check whether the length of the word is odd or not.\nword_len <- function(s) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- word_len\n    stopifnot(isTRUE(all.equal(candidate('Hadoop'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('great'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('structure'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "r",
+    "prompt": "# Write a function to remove all whitespaces from a string.\nremove_all_spaces <- function(text) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_all_spaces\n    stopifnot(isTRUE(all.equal(candidate('python  program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('python   programming    language'), 'pythonprogramminglanguage')))\n    stopifnot(isTRUE(all.equal(candidate('python                     program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('   python                     program'), 'pythonprogram')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\ntest_three_equal <- function(x, y, z) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- test_three_equal\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2, -3), 0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "r",
+    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ncount_rotation <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_rotation\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 1, 2, 3)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nis_perfect_square <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_perfect_square\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(36), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(14), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(196), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(125), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15625), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "r",
+    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nis_product_even <- function(arr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_product_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "r",
+    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nmax_sum_list <- function(lists) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(10, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 2, 1), c(6, 5, 4), c(12, 11, 10))), c(12, 11, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 1))), c(2, 3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "r",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nmax_run_uppercase <- function(test_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_run_uppercase\n    stopifnot(isTRUE(all.equal(candidate('GeMKSForGERksISBESt'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('PrECIOusMOVemENTSYT'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('GooGLEFluTTER'), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "r",
+    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\nfirst_odd <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 1)), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "r",
+    "prompt": "# Write a function to check if the given tuples contain the k or not.\ncheck_K <- function(test_tup, K) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_K\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6, 8), 6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 44, 11, 12), 11), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "r",
+    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\ncheck_smaller <- function(test_tup1, test_tup2) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_smaller\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13), c(10, 11, 12)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "r",
+    "prompt": "# Write a function to find the nth tetrahedral number.\ntetrahedral_number <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- tetrahedral_number\n    stopifnot(isTRUE(all.equal(candidate(5), 35)))\n    stopifnot(isTRUE(all.equal(candidate(6), 56)))\n    stopifnot(isTRUE(all.equal(candidate(7), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "r",
+    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nget_Char <- function(strr) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_Char\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'f')))\n    stopifnot(isTRUE(all.equal(candidate('gfg'), 't')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'c')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "r",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsequence <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- sequence\n    stopifnot(isTRUE(all.equal(candidate(10), 6)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "r",
+    "prompt": "# Write a function to find nth centered hexagonal number.\ncentered_hexagonal_number <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- centered_hexagonal_number\n    stopifnot(isTRUE(all.equal(candidate(10), 271)))\n    stopifnot(isTRUE(all.equal(candidate(2), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 217)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "r",
+    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\nmerge_dictionaries_three <- function(dict1, dict2, dict3) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge_dictionaries_three\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('O' = 'Orange', 'W' = 'White', 'B' = 'Black')), list('B' = 'Black', 'R' = 'Red', 'P' = 'Pink', 'G' = 'Green', 'W' = 'White', 'O' = 'Orange'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('L' = 'lavender', 'B' = 'Blue')), list('W' = 'White', 'P' = 'Pink', 'B' = 'Black', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('L' = 'lavender', 'B' = 'Blue'), list('G' = 'Green', 'W' = 'White')), list('B' = 'Black', 'P' = 'Pink', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender', 'W' = 'White'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "r",
+    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfreq_count <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- freq_count\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)), list(10 = 4, 20 = 4, 40 = 2, 50 = 2, 30 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)), list(1 = 3, 2 = 2, 3 = 3, 4 = 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)), list(10 = 1, 5 = 3, 6 = 2, 7 = 2, 4 = 2, 9 = 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "r",
+    "prompt": "# Write a function to find the closest smaller number than n.\nclosest_num <- function(N) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_num\n    stopifnot(isTRUE(all.equal(candidate(11), 10)))\n    stopifnot(isTRUE(all.equal(candidate(7), 6)))\n    stopifnot(isTRUE(all.equal(candidate(12), 11)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "r",
+    "prompt": "# Write a function to find squares of individual elements in a list.\nsquare_nums <- function(nums) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(100, 400, 900))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(144, 225))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "r",
+    "prompt": "# Write a python function to find the length of the longest word.\nlen_log <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- len_log\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'PHP', 'bigdata')), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'ab', 'abc')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c('small', 'big', 'tall')), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "r",
+    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nfind_substring <- function(str1, sub_str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_substring\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ack'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'abc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ange'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\nis_undulating <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_undulating\n    stopifnot(isTRUE(all.equal(candidate(1212121), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1991), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(121), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "r",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\npower <- function(a, b) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- power\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 81)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), 3125)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "r",
+    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nindex_minimum <- function(test_list) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- index_minimum\n    stopifnot(isTRUE(all.equal(candidate(list(list('Rash', 143), list('Manjeet', 200), list('Varsha', 100))), 'Varsha')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Yash', 185), list('Dawood', 125), list('Sanya', 175))), 'Dawood')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sai', 345), list('Salman', 145), list('Ayesha', 96))), 'Ayesha')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "r",
+    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\nFind_Min_Length <- function(lst) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2))), 1)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(1, 2, 3), c(1, 2, 3, 4))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 3, 3), c(4, 4, 4, 4))), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "r",
+    "prompt": "# Write a python function to find the number of divisors of a given integer.\ndivisor <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- divisor\n    stopifnot(isTRUE(all.equal(candidate(15), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 6)))\n    stopifnot(isTRUE(all.equal(candidate(9), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "r",
+    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfrequency_lists <- function(list1) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- frequency_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 2), c(4, 5, 6, 2), c(7, 8, 9, 5))), list(1 = 1, 2 = 3, 3 = 1, 4 = 1, 5 = 2, 6 = 1, 7 = 1, 8 = 1, 9 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12))), list(1 = 1, 2 = 1, 3 = 1, 4 = 1, 5 = 1, 6 = 1, 7 = 1, 8 = 1, 9 = 1, 10 = 1, 11 = 1, 12 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(20, 30, 40, 17), c(18, 16, 14, 13), c(10, 20, 30, 40))), list(20 = 2, 30 = 2, 40 = 2, 17 = 1, 18 = 1, 16 = 1, 14 = 1, 13 = 1, 10 = 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "r",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndecimal_to_binary <- function(n) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(8), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(18), '10010')))\n    stopifnot(isTRUE(all.equal(candidate(7), '111')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "r",
+    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfind_Rotations <- function(str) {",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Rotations\n    stopifnot(isTRUE(all.equal(candidate('aaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/mbpp-r-reworded.json
+++ b/prompts/mbpp-r-reworded.json
@@ -1,3834 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "r",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nlps <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- lps\n    stopifnot(isTRUE(all.equal(candidate('TENS FOR TENS'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('CARDIO FOR CARDS'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('PART OF THE JOURNEY IS PART'), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "r",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\nremove_whitespaces <- function(text1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_whitespaces\n    stopifnot(isTRUE(all.equal(candidate(' Google    Flutter '), 'GoogleFlutter')))\n    stopifnot(isTRUE(all.equal(candidate(' Google    Dart '), 'GoogleDart')))\n    stopifnot(isTRUE(all.equal(candidate(' iOS    Swift '), 'iOSSwift')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "r",
-    "prompt": "# Write a function to check whether a specified list is sorted or not.\nissort_list <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- issort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 15, 14, 20)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "r",
-    "prompt": "# Write a function to count bidirectional list pairs.\ncount_bidirectional <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_bidirectional\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 3), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 2), c(6, 5), c(2, 1))), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "r",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsurfacearea_cube <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 150)))\n    stopifnot(isTRUE(all.equal(candidate(3), 54)))\n    stopifnot(isTRUE(all.equal(candidate(10), 600)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "r",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nnext_smallest_palindrome <- function(num) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- next_smallest_palindrome\n    stopifnot(isTRUE(all.equal(candidate(99), 101)))\n    stopifnot(isTRUE(all.equal(candidate(1221), 1331)))\n    stopifnot(isTRUE(all.equal(candidate(120), 121)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the cube sum of first n even natural numbers.\ncube_Sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- cube_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 72)))\n    stopifnot(isTRUE(all.equal(candidate(3), 288)))\n    stopifnot(isTRUE(all.equal(candidate(4), 800)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of xor of all pairs of numbers in the given list.\npair_xor_Sum <- function(arr, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pair_xor_Sum\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9, 7, 6), 4), 47)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 5), 3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3), 2), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "r",
-    "prompt": "# Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\ncheck_min_heap <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_min_heap\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 10, 15)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 5, 3, 15)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the first digit of a given number.\nfirst_Digit <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 1)))\n    stopifnot(isTRUE(all.equal(candidate(456), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the first non-repeated character in a given string.\nfirst_non_repeating_character <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_non_repeating_character\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('ababc'), 'c')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "r",
-    "prompt": "# Write a function to convert degrees to radians.\nradian_degree <- function(degree) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- radian_degree\n    stopifnot(isTRUE(all.equal(candidate(90), 1.5707963267948966)))\n    stopifnot(isTRUE(all.equal(candidate(60), 1.0471975511965976)))\n    stopifnot(isTRUE(all.equal(candidate(120), 2.0943951023931953)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum product subvector of the given vector.\nmax_subarray_product <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_subarray_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 0, 7, -8, -2)), 112)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, -3, -10, 0, 2)), 180)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -40, 0, -2, -3)), 80)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "r",
-    "prompt": "# Write a function to convert more than one list to nested named list.\nconvert_list_dictionary <- function(l1, l2, l3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- convert_list_dictionary\n    stopifnot(isTRUE(all.equal(candidate(c('S001', 'S002', 'S003', 'S004'), c('Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'), c(85, 98, 89, 92)), list(list('S001' = list('Adina Park' = 85)), list('S002' = list('Leyton Marsh' = 98)), list('S003' = list('Duncan Boyle' = 89)), list('S004' = list('Saim Richards' = 92))))))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'def', 'ghi', 'jkl'), c('python', 'program', 'language', 'programs'), c(100, 200, 300, 400)), list(list('abc' = list('python' = 100)), list('def' = list('program' = 200)), list('ghi' = list('language' = 300)), list('jkl' = list('programs' = 400))))))\n    stopifnot(isTRUE(all.equal(candidate(c('A1', 'A2', 'A3', 'A4'), c('java', 'C', 'C++', 'DBMS'), c(10, 20, 30, 40)), list(list('A1' = list('java' = 10)), list('A2' = list('C' = 20)), list('A3' = list('C++' = 30)), list('A4' = list('DBMS' = 40))))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "r",
-    "prompt": "# Write a rthon function to find smallest number in a list.\nsmallest_num <- function(xs) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- smallest_num\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 1, 45, 99)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(45, 46, 50, 60)), 45)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rthon-exercises/re/rthon-re-exercise-3.php\ntext_match_zero_one <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_zero_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dsabbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('asbbbba'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abaaa'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "r",
-    "prompt": "# Write a rthon function to find nth bell number.\nbell_Number <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- bell_Number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 15)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "r",
-    "prompt": "# Write a function to find cubes of individual elements in a list.\ncube_nums <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- cube_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(1728, 3375))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the last digit in factorial of a given number.\nlast_Digit_Factorial <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit_Factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(21), 0)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "r",
-    "prompt": "# Write a rthon function to find even numbers from a list of numbers.\nSplit <- function(list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 8, 0, 1)), c(4, 6, 8, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 12, 15, 19)), c(8, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "r",
-    "prompt": "# Write a function to check if the given integer is a prime number.\nprime_num <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- prime_num\n    stopifnot(isTRUE(all.equal(candidate(13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(-1010), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "r",
-    "prompt": "# Write a function to find lists which have all elements divisible by k from the given list of lists.\nfind_tuples <- function(test_list, K) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 24, 12), c(7, 9, 6), c(12, 18, 21)), 6), list(c(6, 24, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 25, 30), c(4, 2, 3), c(7, 8, 9)), 5), list(c(5, 25, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 9, 16), c(8, 16, 4), c(19, 17, 18)), 4), list(c(8, 16, 4)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "r",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\narea_tetrahedron <- function(side) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- area_tetrahedron\n    stopifnot(isTRUE(all.equal(candidate(3), 15.588457268119894)))\n    stopifnot(isTRUE(all.equal(candidate(20), 692.8203230275509)))\n    stopifnot(isTRUE(all.equal(candidate(10), 173.20508075688772)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given number is even or not.\nis_Even <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Even\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of positive numbers in a list.\npos_count <- function(list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pos_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3, -4)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, -1)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "r",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nget_ludic <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_ludic\n    stopifnot(isTRUE(all.equal(candidate(10), c(1, 2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25))))\n    stopifnot(isTRUE(all.equal(candidate(45), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfind_Index <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Index\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 14)))\n    stopifnot(isTRUE(all.equal(candidate(4), 45)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "r",
-    "prompt": "# Write a rthon function to reverse a vector upto a given position.\nreverse_Array_Upto_K <- function(input, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_Array_Upto_K\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 4), c(4, 3, 2, 1, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7), 2), c(5, 4, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5), 3), c(7, 8, 9, 6, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "r",
-    "prompt": "# Write a function to sort a list of lists using the second value of each list.\nsubject_marks <- function(subjectmarks) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- subject_marks\n    stopifnot(isTRUE(all.equal(candidate(list(list('English', 88), list('Science', 90), list('Maths', 97), list('Social sciences', 82))), list(list('Social sciences', 82), list('English', 88), list('Science', 90), list('Maths', 97)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Telugu', 49), list('Hindhi', 54), list('Social', 33))), list(list('Social', 33), list('Telugu', 49), list('Hindhi', 54)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Physics', 96), list('Chemistry', 97), list('Biology', 45))), list(list('Biology', 45), list('Physics', 96), list('Chemistry', 97)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "r",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nremove_dirty_chars <- function(string, second_string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_dirty_chars\n    stopifnot(isTRUE(all.equal(candidate('probasscurve', 'pros'), 'bacuve')))\n    stopifnot(isTRUE(all.equal(candidate('digitalindia', 'talent'), 'digiidi')))\n    stopifnot(isTRUE(all.equal(candidate('exoticmiles', 'toxic'), 'emles')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "r",
-    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nround_and_sum <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- round_and_sum\n    stopifnot(isTRUE(all.equal(candidate(c(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)), 243)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 9, 24.3, 29)), 345)))\n    stopifnot(isTRUE(all.equal(candidate(c(25.0, 56.7, 89.2)), 513)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "r",
-    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nmax_occurrences <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_occurrences\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)), 20)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "r",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nis_decimal <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_decimal\n    stopifnot(isTRUE(all.equal(candidate('123.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('e666.86'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('3.124587'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1.1.11'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "r",
-    "prompt": "# Write a function that takes in a named list and integer n and filters the named list to only include entries with values greater than or equal to n.\ndict_filter <- function(dict, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- dict_filter\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 170), list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 180), list('Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 190), list('Pierre Cox' = 190))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of even numbers at even positions of a list.\nsum_even_and_even_index <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_even_and_even_index\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1, 18, 8)), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)), 26)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1)), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nmax_sub_array_sum <- function(a, size) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, 4, -1, -2, 1, 5, -3), 8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5, -2, -3, 2, 6, -4), 8), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(-4, -5, 6, -3, -4, 3, 7, -5), 8), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "r",
-    "prompt": "# Write a function to find the intersection of two vectors.\nintersection_array <- function(array_nums1, array_nums2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- intersection_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(1, 2, 4, 8, 9)), c(1, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(3, 5, 7, 9)), c(3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(10, 20, 30, 40)), c(10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\nsplit_two_parts <- function(list1, L) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_two_parts\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), list(c(1, 1, 2), c(3, 4, 4, 5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 2), list(c('a', 'b'), c('c', 'd')))))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n'), 4), list(c('p', 'y', 't', 'h'), c('o', 'n')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "r",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfind_literals <- function(text, pattern) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_literals\n    stopifnot(isTRUE(all.equal(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), list('fox', 16, 19))))\n    stopifnot(isTRUE(all.equal(candidate('Its been a very crazy procedure right', 'crazy'), list('crazy', 16, 21))))\n    stopifnot(isTRUE(all.equal(candidate('Hardest choices required strongest will', 'will'), list('will', 35, 39))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the volume of a triangular prism.\nfind_Volume <- function(l, b, h) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Volume\n    stopifnot(isTRUE(all.equal(candidate(10, 8, 6), 240)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "r",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nwind_chill <- function(v, t) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- wind_chill\n    stopifnot(isTRUE(all.equal(candidate(120, 35), 40)))\n    stopifnot(isTRUE(all.equal(candidate(40, 20), 19)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "r",
-    "prompt": "# Write a function to find the ascii value of a character.\nascii_value <- function(k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- ascii_value\n    stopifnot(isTRUE(all.equal(candidate('A'), 65)))\n    stopifnot(isTRUE(all.equal(candidate('R'), 82)))\n    stopifnot(isTRUE(all.equal(candidate('S'), 83)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether all the characters are same or not.\nall_Characters_Same <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_Characters_Same\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('data'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "r",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\nmove_num <- function(test_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_num\n    stopifnot(isTRUE(all.equal(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')))\n    stopifnot(isTRUE(all.equal(candidate('Avengers124Assemble'), 'AvengersAssemble124')))\n    stopifnot(isTRUE(all.equal(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the length of the word is odd or not.\nword_len <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- word_len\n    stopifnot(isTRUE(all.equal(candidate('Hadoop'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('great'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('structure'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "r",
-    "prompt": "# Write a function to drop empty items from a given named list.\ndrop_empty <- function(dict1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- drop_empty\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = 'Green', 'c3' = NULL)), list('c1' = 'Red', 'c2' = 'Green'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = NULL, 'c3' = NULL)), list('c1' = 'Red'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = NULL, 'c2' = 'Green', 'c3' = NULL)), list('c2' = 'Green'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ninsert_element <- function(list, element) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- insert_element\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Black'), 'c'), c('c', 'Red', 'c', 'Green', 'c', 'Black'))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java'), 'program'), c('program', 'python', 'program', 'java'))))\n    stopifnot(isTRUE(all.equal(candidate(c('happy', 'sad'), 'laugh'), c('laugh', 'happy', 'laugh', 'sad'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "r",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\nremove_lowercase <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_lowercase\n    stopifnot(isTRUE(all.equal(candidate('PYTHon'), 'PYTH')))\n    stopifnot(isTRUE(all.equal(candidate('FInD'), 'FID')))\n    stopifnot(isTRUE(all.equal(candidate('STRinG'), 'STRG')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of set bits (binary digits with value 1) in a given number.\ncount_Set_Bits <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Set_Bits\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "r",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given list.\nextract_rear <- function(test_tuple) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_rear\n    stopifnot(isTRUE(all.equal(candidate(c('Mers', 'for', 'Vers')), c('s', 'r', 's'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Avenge', 'for', 'People')), c('e', 'r', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Gotta', 'get', 'go')), c('a', 't', 'o'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "r",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ncount_occurance <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_occurance\n    stopifnot(isTRUE(all.equal(candidate('letstdlenstdporstd'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('truststdsolensporsd'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('makestdsostdworthit'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('stds'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "r",
-    "prompt": "# Write a function to check if the given lists contain the k or not.\ncheck_K <- function(test_tup, K) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_K\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6, 8), 6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 44, 11, 12), 11), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "r",
-    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ninterleave_lists <- function(list1, list2, list3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- interleave_lists\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7), c(10, 20, 30, 40, 50, 60, 70), c(100, 200, 300, 400, 500, 600, 700)), c(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20), c(15, 2), c(5, 10)), c(10, 15, 5, 20, 2, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 44), c(10, 15), c(20, 5)), c(11, 10, 20, 44, 15, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "r",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\nsnake_to_camel <- function(word) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('python_program'), 'PythonProgram')))\n    stopifnot(isTRUE(all.equal(candidate('python_language'), 'PythonLanguage')))\n    stopifnot(isTRUE(all.equal(candidate('programming_language'), 'ProgrammingLanguage')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of equal numbers from three given integers.\ntest_three_equal <- function(x, y, z) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- test_three_equal\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2, -3), 0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nodd_length_sum <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_length_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 7)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "r",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nbell_number <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- bell_number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 115975)))\n    stopifnot(isTRUE(all.equal(candidate(56), 6775685320645824322581483068371419745979053216268760300)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "r",
-    "prompt": "# Write a function to find the area of a rectangle.\nrectangle_area <- function(l, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rectangle_area\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "r",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsum_average <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_average\n    stopifnot(isTRUE(all.equal(candidate(10), c(55, 5.5))))\n    stopifnot(isTRUE(all.equal(candidate(15), c(120, 8.0))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(210, 10.5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\ndivision_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- division_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(2, 2, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 16), c(6, 3, 4, 4)), c(2, 2, 2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(20, 14, 36, 18), c(5, 7, 6, 9)), c(4, 2, 6, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "r",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsum_digits <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_digits\n    stopifnot(isTRUE(all.equal(candidate(345), 12)))\n    stopifnot(isTRUE(all.equal(candidate(12), 3)))\n    stopifnot(isTRUE(all.equal(candidate(97), 16)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "r",
-    "prompt": "# Given a list of lists, write a function that returns the first value of the list with the smallest second value.\nindex_minimum <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- index_minimum\n    stopifnot(isTRUE(all.equal(candidate(list(list('Rash', 143), list('Manjeet', 200), list('Varsha', 100))), 'Varsha')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Yash', 185), list('Dawood', 125), list('Sanya', 175))), 'Dawood')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sai', 345), list('Salman', 145), list('Ayesha', 96))), 'Ayesha')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "r",
-    "prompt": "# Write a function to divide two lists element wise.\ndiv_list <- function(nums1, nums2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- div_list\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(1, 2, 3)), c(4.0, 2.5, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2), c(1, 4)), c(3.0, 0.5))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(1.8, 1.7142857142857142))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "r",
-    "prompt": "# Write a function to find the list with maximum length.\nmax_length_list <- function(input_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_length_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5), c(1, 2, 3, 4), c(1, 2, 3), c(1, 2), c(1))), list(5, c(1, 2, 3, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(6, 7, 8, 9), c(10, 11, 12))), list(4, c(6, 7, 8, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "r",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ncombinations_list <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- combinations_list\n    stopifnot(isTRUE(all.equal(candidate(c('orange', 'red', 'green', 'blue')), list(c(), c('orange'), c('red'), c('red', 'orange'), c('green'), c('green', 'orange'), c('green', 'red'), c('green', 'red', 'orange'), c('blue'), c('blue', 'orange'), c('blue', 'red'), c('blue', 'red', 'orange'), c('blue', 'green'), c('blue', 'green', 'orange'), c('blue', 'green', 'red'), c('blue', 'green', 'red', 'orange')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'blue', 'white', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('blue'), c('blue', 'red'), c('blue', 'green'), c('blue', 'green', 'red'), c('white'), c('white', 'red'), c('white', 'green'), c('white', 'green', 'red'), c('white', 'blue'), c('white', 'blue', 'red'), c('white', 'blue', 'green'), c('white', 'blue', 'green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('black', 'blue'), c('black', 'blue', 'red'), c('black', 'blue', 'green'), c('black', 'blue', 'green', 'red'), c('black', 'white'), c('black', 'white', 'red'), c('black', 'white', 'green'), c('black', 'white', 'green', 'red'), c('black', 'white', 'blue'), c('black', 'white', 'blue', 'red'), c('black', 'white', 'blue', 'green'), c('black', 'white', 'blue', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'blue'), c('orange', 'blue', 'red'), c('orange', 'blue', 'green'), c('orange', 'blue', 'green', 'red'), c('orange', 'white'), c('orange', 'white', 'red'), c('orange', 'white', 'green'), c('orange', 'white', 'green', 'red'), c('orange', 'white', 'blue'), c('orange', 'white', 'blue', 'red'), c('orange', 'white', 'blue', 'green'), c('orange', 'white', 'blue', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red'), c('orange', 'black', 'blue'), c('orange', 'black', 'blue', 'red'), c('orange', 'black', 'blue', 'green'), c('orange', 'black', 'blue', 'green', 'red'), c('orange', 'black', 'white'), c('orange', 'black', 'white', 'red'), c('orange', 'black', 'white', 'green'), c('orange', 'black', 'white', 'green', 'red'), c('orange', 'black', 'white', 'blue'), c('orange', 'black', 'white', 'blue', 'red'), c('orange', 'black', 'white', 'blue', 'green'), c('orange', 'black', 'white', 'blue', 'green', 'red')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of the largest and smallest value in a given vector.\nbig_sum <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- big_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6)), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "r",
-    "prompt": "# Write a rthon function to return the negative numbers in a list.\nneg_nos <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- neg_nos\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 4, 5, -6)), c(-1, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3, 4)), c(-1, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(-7, -6, 8, 9)), c(-7, -6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the highest power of 2 that is less than or equal to n.\nhighest_Power_of_2 <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- highest_Power_of_2\n    stopifnot(isTRUE(all.equal(candidate(10), 8)))\n    stopifnot(isTRUE(all.equal(candidate(19), 16)))\n    stopifnot(isTRUE(all.equal(candidate(32), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "r",
-    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nis_sublist <- function(l, s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_sublist\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(4, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(1, 6)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "r",
-    "prompt": "# Write a function to subtract two lists element-wise.\nsub_list <- function(nums1, nums2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sub_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), c(-3, -3, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 4)), c(-2, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(40, 50))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given two integers have opposite sign or not.\nopposite_Signs <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- opposite_Signs\n    stopifnot(isTRUE(all.equal(candidate(1, -2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-2, 2), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "r",
-    "prompt": "# Write a function which takes two lists of the same length and performs the element wise modulo.\ntuple_modulo <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_modulo\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6), c(5, 6, 7, 5)), c(0, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 6, 7), c(6, 7, 8, 6)), c(5, 5, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 7, 8), c(7, 8, 9, 7)), c(5, 6, 7, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "r",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndiff_even_odd <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- diff_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "r",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white'))), list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('d', 'c'), c('g', 'h'), c('f', 'e'))), list(c('a', 'b'), c('c', 'd'), c('g', 'h'), c('e', 'f')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the last digit of a given number.\nlast_Digit <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 3)))\n    stopifnot(isTRUE(all.equal(candidate(25), 5)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of fourth power of first n odd natural numbers.\nodd_num_sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_num_sum\n    stopifnot(isTRUE(all.equal(candidate(2), 82)))\n    stopifnot(isTRUE(all.equal(candidate(3), 707)))\n    stopifnot(isTRUE(all.equal(candidate(4), 3108)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "r",
-    "prompt": "# Write a function to convert a list to a string.\ntup_string <- function(tup1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tup_string\n    stopifnot(isTRUE(all.equal(candidate(c('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's')), 'exercises')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'r', 'o', 'g', 'r', 'a', 'm')), 'program')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "r",
-    "prompt": "# Write a function to remove all elements from a given list present in another list.\nremove_elements <- function(list1, list2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(1, 3, 5, 7)), c(2, 4, 6, 8, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(5, 7)), c(1, 2, 3, 4, 6, 8, 9, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether any value in a sequence exists in a sequence or not.\noverlapping <- function(list1, list2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- overlapping\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5), c(1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "r",
-    "prompt": "# Write a rthon function to identify non-prime numbers.\nis_not_prime <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_not_prime\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(35), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(37), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nmax_val <- function(listval) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 50)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsum_negativenum <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_negativenum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), -32)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, -14, 13, -18, 12, -20)), -52)))\n    stopifnot(isTRUE(all.equal(candidate(c(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)), -894)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfind_Rotations <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Rotations\n    stopifnot(isTRUE(all.equal(candidate('aaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "r",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nchange_date_format <- function(dt) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- change_date_format\n    stopifnot(isTRUE(all.equal(candidate('2026-01-02'), '02-01-2026')))\n    stopifnot(isTRUE(all.equal(candidate('2020-11-13'), '13-11-2020')))\n    stopifnot(isTRUE(all.equal(candidate('2021-04-26'), '26-04-2021')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "r",
-    "prompt": "# Write a rthon function which takes a list of integers and only returns the odd ones.\nSplit <- function(list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 12, 13)), c(11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1)), c(7, 9, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "r",
-    "prompt": "# Write a rthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ntoggle_middle_bits <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- toggle_middle_bits\n    stopifnot(isTRUE(all.equal(candidate(9), 15)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(11), 13)))\n    stopifnot(isTRUE(all.equal(candidate(65), 127)))\n    stopifnot(isTRUE(all.equal(candidate(77), 115)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "r",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ncount_char_position <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_char_position\n    stopifnot(isTRUE(all.equal(candidate('xbcefg'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABcED'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('AbgdeF'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "r",
-    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlarge_product <- function(nums1, nums2, N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- large_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 3), c(60, 54, 50))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 4), c(60, 54, 50, 48))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 5), c(60, 54, 50, 48, 45))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ncummulative_sum <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- cummulative_sum\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 6, 7), c(2, 6))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7, 8), c(3, 7))), 37)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8, 9), c(4, 8))), 44)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfind_min_diff <- function(arr, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_min_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 3, 19, 18, 25), 6), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 6), 4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 5, 20, 9), 4), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ntext_starta_endb <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_starta_endb\n    stopifnot(isTRUE(all.equal(candidate('aabbbb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabAbbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('accddbbjjj'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "r",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nleft_rotate <- function(n, d) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- left_rotate\n    stopifnot(isTRUE(all.equal(candidate(16, 2), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), 40)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(1, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 40)))\n    stopifnot(isTRUE(all.equal(candidate(29, 3), 232)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the first repeated character in a given string.\nfirst_repeated_char <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_repeated_char\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('abc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('123123'), '1')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "r",
-    "prompt": "# Write a rthon function to count inversions in a vector.\nget_Inv_Count <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_Inv_Count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 6, 4, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 6, 1)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "r",
-    "prompt": "# Write a rthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\neven_Power_Sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_Power_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 1056)))\n    stopifnot(isTRUE(all.equal(candidate(3), 8832)))\n    stopifnot(isTRUE(all.equal(candidate(1), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "r",
-    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nget_equal <- function(Input) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_equal\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 22, 33), c(44, 55, 66))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6, 7))), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4))), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "r",
-    "prompt": "# Write a function to check if a string represents an integer or not.\ncheck_integer <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_integer\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('12345'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "r",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/rthon-program-to-count-the-pairs-of-reverse-strings/\ncount_reverse_pairs <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_reverse_pairs\n    stopifnot(isTRUE(all.equal(candidate(c('julia', 'best', 'tseb', 'for', 'ailuj')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c('geeks', 'best', 'for', 'skeeg')), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c('makes', 'best', 'sekam', 'for', 'rof')), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "r",
-    "prompt": "# Write a rthon function to move all zeroes to the end of the given list.\nmove_zero <- function(num_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- move_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 0, 3, 4)), c(1, 2, 3, 4, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 0, 0, 4, 0, 5, 0)), c(2, 3, 2, 4, 5, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 0, 1, 1)), c(1, 1, 1, 0, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "r",
-    "prompt": "# Write a function to check if given list contains no duplicates.\ncheck_distinct <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_distinct\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6, 1, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nnoprofit_noloss <- function(actual_cost, sale_amount) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- noprofit_noloss\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(100, 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "r",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\nremove_length <- function(test_str, K) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_length\n    stopifnot(isTRUE(all.equal(candidate('The person is most value tet', 3), 'person is most value')))\n    stopifnot(isTRUE(all.equal(candidate('If you told me about this ok', 4), 'If you me about ok')))\n    stopifnot(isTRUE(all.equal(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "r",
-    "prompt": "# Write a rthon function to count number of digits in a given string.\nnumber_ctr <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- number_ctr\n    stopifnot(isTRUE(all.equal(candidate('program2bedone'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('3wonders'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('123'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('3wond-1ers2'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "r",
-    "prompt": "# Write a function to count the total number of characters in a string.\ncount_charac <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_charac\n    stopifnot(isTRUE(all.equal(candidate('python programming'), 18)))\n    stopifnot(isTRUE(all.equal(candidate('language'), 8)))\n    stopifnot(isTRUE(all.equal(candidate('words'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "r",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nget_total_number_of_sequences <- function(m, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_total_number_of_sequences\n    stopifnot(isTRUE(all.equal(candidate(10, 4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(5, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(16, 3), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "r",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rthon-exercises/data-structures-and-algorithms/rthon-data-structure-exercise-24.php\nleft_insertion <- function(a, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- left_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "r",
-    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nswap_numbers <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_numbers\n    stopifnot(isTRUE(all.equal(candidate(10, 20), c(20, 10))))\n    stopifnot(isTRUE(all.equal(candidate(15, 17), c(17, 15))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(200, 100))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "r",
-    "prompt": "# Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nis_majority <- function(arr, n, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_majority\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 3, 10), 7, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 4, 4, 4, 6, 6), 8, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 2), 5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2), 5, 1), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\nsubstract_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- substract_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5), c(2, 5, 18)), c(8, -1, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 2, 3), c(24, 45, 16)), c(-13, -43, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 18, 9), c(10, 11, 12)), c(-3, 7, -3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "r",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ncapital_words_spaces <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- capital_words_spaces\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('PythonProgrammingExamples'), 'Python Programming Examples')))\n    stopifnot(isTRUE(all.equal(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the average of cubes of first n natural numbers.\nfind_Average_Of_Cube <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Average_Of_Cube\n    stopifnot(isTRUE(all.equal(candidate(2), 4.5)))\n    stopifnot(isTRUE(all.equal(candidate(3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "r",
-    "prompt": "# Write a function to check if all values are same in a named list.\ncheck_value <- function(dict, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_value\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 5), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "r",
-    "prompt": "# Write a function to find the nth tetrahedral number.\ntetrahedral_number <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tetrahedral_number\n    stopifnot(isTRUE(all.equal(candidate(5), 35)))\n    stopifnot(isTRUE(all.equal(candidate(6), 56)))\n    stopifnot(isTRUE(all.equal(candidate(7), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "r",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nmagic_square_test <- function(my_matrix) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- magic_square_test\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 12, 1, 14), c(2, 13, 8, 11), c(16, 3, 10, 5), c(9, 6, 15, 4))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 8))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 7))), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "r",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\nremove_uppercase <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_uppercase\n    stopifnot(isTRUE(all.equal(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')))\n    stopifnot(isTRUE(all.equal(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')))\n    stopifnot(isTRUE(all.equal(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "r",
-    "prompt": "# Write a function to check whether an element exists within a list.\ncheck_tuplex <- function(tuplex, tuple1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_tuplex\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 'r'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), '5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 3), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "r",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndog_age <- function(h_age) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- dog_age\n    stopifnot(isTRUE(all.equal(candidate(12), 61)))\n    stopifnot(isTRUE(all.equal(candidate(15), 73)))\n    stopifnot(isTRUE(all.equal(candidate(24), 109)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the next perfect square greater than a given number.\nnext_Perfect_Square <- function(N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_Perfect_Square\n    stopifnot(isTRUE(all.equal(candidate(35), 36)))\n    stopifnot(isTRUE(all.equal(candidate(6), 9)))\n    stopifnot(isTRUE(all.equal(candidate(9), 16)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "r",
-    "prompt": "# Write a function to create a list of N empty dictionaries.\nempty_list <- function(length) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- empty_list\n    stopifnot(isTRUE(all.equal(candidate(5), list(list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(6), list(list(), list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(7), list(list(), list(), list(), list(), list(), list(), list()))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "r",
-    "prompt": "# Write a rthon function to convert a given string to uppercase.\nis_upper <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_upper\n    stopifnot(isTRUE(all.equal(candidate('person'), 'PERSON')))\n    stopifnot(isTRUE(all.equal(candidate('final'), 'FINAL')))\n    stopifnot(isTRUE(all.equal(candidate('Valid'), 'VALID')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nodd_Equivalent <- function(s, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_Equivalent\n    stopifnot(isTRUE(all.equal(candidate('011001', 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate('11011', 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate('1010', 4), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "r",
-    "prompt": "# Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nre_arrange_array <- function(arr, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- re_arrange_array\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9), c(-1, -3, -7, 4, 5, 6, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, -14, -26, 13, 15), 5), c(-14, -26, 12, 13, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 24, 36, -42, -39, -78, 85), 7), c(-42, -39, -78, 10, 24, 36, 85))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether a list of numbers contains only one distinct element or not.\nunique_Element <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "r",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\nextract_values <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_values\n    stopifnot(isTRUE(all.equal(candidate('\"Python\", \"PHP\", \"Java\"'), c('Python', 'PHP', 'Java'))))\n    stopifnot(isTRUE(all.equal(candidate('\"python\",\"program\",\"language\"'), c('python', 'program', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), c('red', 'blue', 'green', 'yellow'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "r",
-    "prompt": "# Write a rthon function to count true booleans in the given list.\ncount <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, FALSE, TRUE)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(FALSE, FALSE)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, TRUE, TRUE)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "r",
-    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfind_even_pair <- function(A) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_even_pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\narmstrong_number <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- armstrong_number\n    stopifnot(isTRUE(all.equal(candidate(153), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(259), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4458), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the upper case characters in a given string.\nupper_ctr <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- upper_ctr\n    stopifnot(isTRUE(all.equal(candidate('PYthon'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('BigData'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('program'), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "r",
-    "prompt": "# Write a function to extract the elementwise and lists from the given two lists.\nand_tuples <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- and_tuples\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(0, 0, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(5, 6, 7, 8)), c(1, 2, 3, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 11, 12), c(7, 13, 14, 17)), c(0, 9, 10, 0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "r",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns vector.\nis_samepatterns <- function(colors, patterns) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_samepatterns\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'green'), c('a', 'b', 'b')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b', 'b')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b')), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of lists in a given number of lists.\ncount_list <- function(input_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(2, 3), c(4, 5))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 0), c(2, 0))), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "r",
-    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\naverage_tuple <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- average_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 10, 10, 12), c(30, 45, 56, 45), c(81, 80, 39, 32), c(1, 2, 3, 4))), c(30.5, 34.25, 27.0, 23.25))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, -5), c(30, -15, 56), c(81, -60, -39), c(-10, 2, 3))), c(25.5, -18.0, 3.75))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(100, 100, 100, 120), c(300, 450, 560, 450), c(810, 800, 390, 320), c(10, 20, 30, 40))), c(305.0, 342.5, 270.0, 232.5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "r",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlcs_of_three <- function(X, Y, Z) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- lcs_of_three\n    stopifnot(isTRUE(all.equal(candidate('AGGT12', '12TXAYB', '12XBA'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "r",
-    "prompt": "# Write a function to find the n'th star number.\nfind_star_num <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_star_num\n    stopifnot(isTRUE(all.equal(candidate(3), 37)))\n    stopifnot(isTRUE(all.equal(candidate(4), 73)))\n    stopifnot(isTRUE(all.equal(candidate(5), 121)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of a vector.\n_sum <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- _sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 12, 13, 10)), 50)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given list contains consecutive numbers or not.\ncheck_Consecutive <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_Consecutive\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "r",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nfind_adverb_position <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_adverb_position\n    stopifnot(isTRUE(all.equal(candidate('clearly!! we can see the sky'), list(0, 7, 'clearly'))))\n    stopifnot(isTRUE(all.equal(candidate('seriously!! there are many roses'), list(0, 9, 'seriously'))))\n    stopifnot(isTRUE(all.equal(candidate('unfortunately!! sita is going to home'), list(0, 13, 'unfortunately'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "r",
-    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/rthon-program-right-rotate-list-n/\nrotate_right <- function(list, m) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rotate_right\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3), c(8, 9, 10, 1, 2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(9, 10, 1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5), c(6, 7, 8, 9, 10, 1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of non-empty substrings of a given string.\nnumber_of_substrings <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- number_of_substrings\n    stopifnot(isTRUE(all.equal(candidate('abc'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 15)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlist_split <- function(S, step) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- list_split\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'), 3), list(c('a', 'd', 'g', 'j', 'm'), c('b', 'e', 'h', 'k', 'n'), c('c', 'f', 'i', 'l')))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3), list(c(1, 4, 7, 10, 13), c(2, 5, 8, 11, 14), c(3, 6, 9, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java', 'C', 'C++', 'DBMS', 'SQL'), 2), list(c('python', 'C', 'DBMS'), c('java', 'C++', 'SQL')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "r",
-    "prompt": "# Write a rthon function to check if the elements of a given list are unique or not.\nall_unique <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_unique\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "r",
-    "prompt": "# Write a rthon function to convert complex numbers to polar coordinates.\nconvert <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- convert\n    stopifnot(isTRUE(all.equal(candidate(1), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5.0, 0.0))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "r",
-    "prompt": "# The input is given as - a named list with a student name as a key and a list of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfilter_data <- function(students, h, w) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_data\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 6.0, 70), list('Cierra Vega' = c(6.2, 70)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.9, 67), list('Cierra Vega' = c(6.2, 70), 'Kierra Gentry' = c(6.0, 68)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.7, 64), list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "r",
-    "prompt": "# Write a rthon function to convert the given string to lower case.\nis_lower <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_lower\n    stopifnot(isTRUE(all.equal(candidate('InValid'), 'invalid')))\n    stopifnot(isTRUE(all.equal(candidate('TruE'), 'true')))\n    stopifnot(isTRUE(all.equal(candidate('SenTenCE'), 'sentence')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the smallest power of 2 greater than or equal to n.\nnext_power_of_2 <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- next_power_of_2\n    stopifnot(isTRUE(all.equal(candidate(0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(17), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "r",
-    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nfind_substring <- function(str1, sub_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_substring\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ack'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'abc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ange'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "r",
-    "prompt": "# Write a function to replace characters in a string.\nreplace_char <- function(str1, ch, newch) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_char\n    stopifnot(isTRUE(all.equal(candidate('polygon', 'y', 'l'), 'pollgon')))\n    stopifnot(isTRUE(all.equal(candidate('character', 'c', 'a'), 'aharaater')))\n    stopifnot(isTRUE(all.equal(candidate('python', 'l', 'a'), 'python')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "r",
-    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nmul_even_odd <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- mul_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 10)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "r",
-    "prompt": "# Write a function to convert a list to a list.\nlist_tuple <- function(listx) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- list_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 10, 7, 4, 15, 3)), c(5, 10, 7, 4, 15, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 2, 3, 4, 4, 7)), c(2, 4, 5, 6, 2, 3, 4, 4, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(58, 44, 56)), c(58, 44, 56))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "r",
-    "prompt": "# Write a rthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\neven_binomial_Coeff_Sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_binomial_Coeff_Sum\n    stopifnot(isTRUE(all.equal(candidate(4), 8)))\n    stopifnot(isTRUE(all.equal(candidate(6), 32)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "r",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given lists.\nbitwise_xor <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- bitwise_xor\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(15, 6, 5, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 7, 10), c(6, 3, 4, 4)), c(13, 6, 3, 14))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 11), c(7, 4, 5, 6)), c(11, 2, 13, 13))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether a list is sublist of another or not.\nis_Sub_Array <- function(A, B) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Sub_Array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 5), c(1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), c(1, 2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 2), c(2, 2, 0)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "r",
-    "prompt": "# Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nmax_sub_array_sum_repeated <- function(a, n, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum_repeated\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -30, -1), 4, 3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 10, 20), 3, 2), 59)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3), 3, 3), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "r",
-    "prompt": "# Write a function to find the minimum product from the pairs of lists within a given list.\nmin_product_tuple <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 8)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 100)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the count of divisors is even. https://www.w3resource.com/rthon-exercises/basic/rthon-basic-1-exercise-24.php\ncount_divisors <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_divisors\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(100), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ntriangle_area <- function(r) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(-1), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "r",
-    "prompt": "# Write a function to convert a given string to a list of characters.\nstring_to_tuple <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- string_to_tuple\n    stopifnot(isTRUE(all.equal(candidate('python 3.0'), c('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'))))\n    stopifnot(isTRUE(all.equal(candidate('item1'), c('i', 't', 'e', 'm', '1'))))\n    stopifnot(isTRUE(all.equal(candidate('15.10'), c('1', '5', '.', '1', '0'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfind_length <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_length\n    stopifnot(isTRUE(all.equal(candidate('11000010001'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('10111'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('11011101100101'), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "r",
-    "prompt": "# Write a rthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ncount_Primes_nums <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Primes_nums\n    stopifnot(isTRUE(all.equal(candidate(5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 4)))\n    stopifnot(isTRUE(all.equal(candidate(100), 25)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of the product of consecutive binomial co-efficients.\nsum_Of_product <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_product\n    stopifnot(isTRUE(all.equal(candidate(3), 15)))\n    stopifnot(isTRUE(all.equal(candidate(4), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "r",
-    "prompt": "# Write a function to calculate the maximum aggregate from the list of lists.\nmax_aggregate <- function(stdata) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_aggregate\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 90), list('Sabah Colley', 88), list('Peter Nichols', 7), list('Juan Whelan', 122), list('Sabah Colley', 84))), list('Juan Whelan', 212))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 50), list('Sabah Colley', 48), list('Peter Nichols', 37), list('Juan Whelan', 22), list('Sabah Colley', 14))), list('Juan Whelan', 72))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 10), list('Sabah Colley', 20), list('Peter Nichols', 30), list('Juan Whelan', 40), list('Sabah Colley', 50))), list('Sabah Colley', 70))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "r",
-    "prompt": "# Write a function to sort a list of elements.\ncomb_sort <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- comb_sort\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 37, 25, 79)), c(5, 15, 25, 37, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 32, 15, 19, 22)), c(15, 19, 22, 32, 41))))\n    stopifnot(isTRUE(all.equal(candidate(c(99, 15, 13, 47)), c(13, 15, 47, 99))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "r",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ncheck_expression <- function(exp) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_expression\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}][]({})'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "r",
-    "prompt": "# Write a function that matches a word containing 'z'.\ntext_match_wordz <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz\n    stopifnot(isTRUE(all.equal(candidate('pythonz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "r",
-    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsum_list <- function(lst1, lst2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_list\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), c(15, 25, 35)), c(25, 45, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(5, 6, 7)), c(6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 20, 30), c(15, 45, 75)), c(30, 65, 105))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "r",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nnewman_prime <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- newman_prime\n    stopifnot(isTRUE(all.equal(candidate(3), 7)))\n    stopifnot(isTRUE(all.equal(candidate(4), 17)))\n    stopifnot(isTRUE(all.equal(candidate(5), 41)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "r",
-    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nadd_string <- function(list_, string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_string\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 'temp{0}'), c('temp1', 'temp2', 'temp3', 'temp4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 'python{0}'), c('pythona', 'pythonb', 'pythonc', 'pythond'))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8), 'string{0}'), c('string5', 'string6', 'string7', 'string8'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the surface area of a square rramid with a given base edge and height.\nsurface_Area <- function(b, s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- surface_Area\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 33)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the length of the smallest list in a list of lists.\nFind_Min_Length <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2))), 1)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(1, 2, 3), c(1, 2, 3, 4))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 3, 3), c(4, 4, 4, 4))), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "r",
-    "prompt": "# Write a rthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nvalidate <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- validate\n    stopifnot(isTRUE(all.equal(candidate(1234), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(51241), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(321), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "r",
-    "prompt": "# Write a function to find the nth hexagonal number.\nhexagonal_num <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- hexagonal_num\n    stopifnot(isTRUE(all.equal(candidate(10), 190)))\n    stopifnot(isTRUE(all.equal(candidate(5), 45)))\n    stopifnot(isTRUE(all.equal(candidate(7), 91)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "r",
-    "prompt": "# Write a function to find the n'th lucas number.\nfind_lucas <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_lucas\n    stopifnot(isTRUE(all.equal(candidate(9), 76)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(3), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "r",
-    "prompt": "# Write a rthon function to get the difference between two lists.\nDiff <- function(li1, li2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Diff\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25, 30, 35, 40), c(25, 40, 35)), c(10, 20, 30, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 1)), c(2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(6, 7, 1)), c(2, 3, 6, 7))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "r",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nextract_quotation <- function(text1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_quotation\n    stopifnot(isTRUE(all.equal(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), c('A53', 'multi', 'Processor'))))\n    stopifnot(isTRUE(all.equal(candidate('Cast your \"favorite\" entertainment \"apps\"'), c('favorite', 'apps'))))\n    stopifnot(isTRUE(all.equal(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), c('4k Ultra HD', 'HDR 10'))))\n    stopifnot(isTRUE(all.equal(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "r",
-    "prompt": "# Write a function to flatten a list and sum all of its elements.\nrecursive_list_sum <- function(data_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- recursive_list_sum\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, c(3, 4), c(5, 6))), 21)))\n    stopifnot(isTRUE(all.equal(candidate(list(7, 10, c(15, 14), c(19, 41))), 106)))\n    stopifnot(isTRUE(all.equal(candidate(list(10, 20, c(30, 40), c(50, 60))), 210)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the two numbers differ at one bit position only or not.\ndiffer_At_One_Bit_Pos <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- differ_At_One_Bit_Pos\n    stopifnot(isTRUE(all.equal(candidate(13, 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 5), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ntext_match_three <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('caacabbbba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nmax_product <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_product\n    stopifnot(isTRUE(all.equal(candidate(c(3, 100, 4, 5, 150, 6)), 3000)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 42, 55, 68, 80)), 50265600)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 22, 9, 33, 21, 50, 41, 60)), 2460)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "r",
-    "prompt": "# Write a rthon function to split a list at the nth eelment and add the first part to the end.\nsplit_Arr <- function(l, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- split_Arr\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 5, 6, 52, 36), 2), c(5, 6, 52, 36, 12, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 1), c(2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 4, 5, 6, 7), 3), c(3, 4, 5, 6, 7, 0, 1, 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the number of divisors of a given integer.\ndivisor <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- divisor\n    stopifnot(isTRUE(all.equal(candidate(15), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 6)))\n    stopifnot(isTRUE(all.equal(candidate(9), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the difference between largest and smallest value in a given list.\nbig_diff <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- big_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 12)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 3)), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "r",
-    "prompt": "# Write a function to find squares of individual elements in a list.\nsquare_nums <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(100, 400, 900))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(144, 225))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "r",
-    "prompt": "# Write a function to check if the given list has any none value or not.\ncheck_none <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_none\n    stopifnot(isTRUE(all.equal(candidate(list(10, 4, 5, 6, NULL)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 11, 14)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 3, 4, NULL)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given vector is monotonic or not.\nis_Monotonic <- function(A) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nis_perfect_square <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_perfect_square\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(36), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(14), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(196), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(125), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15625), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of common divisors of two given numbers.\nsum <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 6)))\n    stopifnot(isTRUE(all.equal(candidate(100, 150), 93)))\n    stopifnot(isTRUE(all.equal(candidate(4, 6), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "r",
-    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nmax_length <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_length\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(5, 7), c(10, 12, 14, 15))), list(4, c(10, 12, 14, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5), c(15, 20, 25))), list(3, c(15, 20, 25)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list of lists and returns a named list mapping each unique list to the number of times it occurs in the list.\ncheck_occurences <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_occurences\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 1), c(1, 3), c(2, 5), c(5, 2), c(6, 3))), list(c(1, 3) = 2, c(2, 5) = 2, c(3, 6) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 2), c(2, 4), c(3, 6), c(6, 3), c(7, 4))), list(c(2, 4) = 2, c(3, 6) = 2, c(4, 7) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(13, 2), c(11, 23), c(12, 25), c(25, 12), c(16, 23))), list(c(2, 13) = 1, c(11, 23) = 1, c(12, 25) = 2, c(16, 23) = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "r",
-    "prompt": "# Write a function to find the directrix of a parabola.\nparabola_directrix <- function(a, b, c) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- parabola_directrix\n    stopifnot(isTRUE(all.equal(candidate(5, 3, 2), -198)))\n    stopifnot(isTRUE(all.equal(candidate(9, 8, 4), -2336)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4, 6), -130)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "r",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return NULL if there is no match.\noccurance_substring <- function(text, pattern) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- occurance_substring\n    stopifnot(isTRUE(all.equal(candidate('python programming, python language', 'python'), list('python', 0, 6))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'programming'), list('programming', 7, 18))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'language'), list('language', 31, 39))))\n    stopifnot(isTRUE(all.equal(candidate('c++ programming, c++ language', 'python'), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "r",
-    "prompt": "# Write a function to remove lists from the given list.\nremove_nested <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_nested\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), c(1, 5, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 6, 8, c(5, 7), 11)), c(2, 6, 8, 11))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), 12)), c(3, 7, 9, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), c(5, 12), 12)), c(3, 7, 9, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "r",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(input_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(' red ', 'green'), c('blue ', ' black'), c(' orange', 'brown'))), list(c(' red ', 'green'), c(' black', 'blue '), c(' orange', 'brown')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('zilver', 'gold'), c('magnesium', 'aluminium'), c('steel', 'bronze'))), list(c('gold', 'zilver'), c('aluminium', 'magnesium'), c('bronze', 'steel')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "r",
-    "prompt": "# Write a rthon function which takes a list and returns a list with the same elements, but the k'th element removed.\nremove_kth_element <- function(list1, L) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), c(1, 1, 3, 4, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4), c(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5), c(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "r",
-    "prompt": "# Write a function to add a named list to the list. The output should be a list.\nadd_dict_to_tuple <- function(test_tup, test_dict) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_dict_to_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), list('MSAM' = 1, 'is' = 2, 'best' = 3)), list(4, 5, 6, list('MSAM' = 1, 'is' = 2, 'best' = 3)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), list('UTS' = 2, 'is' = 3, 'Worst' = 4)), list(1, 2, 3, list('UTS' = 2, 'is' = 3, 'Worst' = 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 10), list('POS' = 3, 'is' = 4, 'Okay' = 5)), list(8, 9, 10, list('POS' = 3, 'is' = 4, 'Okay' = 5)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "r",
-    "prompt": "# Write a rthon function to find quotient of two numbers (rounded down to the nearest integer).\nfind <- function(n, m) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find\n    stopifnot(isTRUE(all.equal(candidate(10, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(20, 5), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "r",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ntext_match_two_three <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_two_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the occurence of all elements of list in a list.\ncount_Occurrence <- function(tup, lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Occurrence\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'c', 'b', 'd'), c('a', 'b')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 4, 6, 7, 1, 4), c(1, 4, 7)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(1, 2)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "r",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ncount_samepair <- function(list1, list2, list3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_samepair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9), c(2, 1, 3, 1, 2, 6, 7, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 2, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "r",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ntext_match_one <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abba'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndifference <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- difference\n    stopifnot(isTRUE(all.equal(candidate(3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(5), 210)))\n    stopifnot(isTRUE(all.equal(candidate(2), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "r",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\ntoggle_string <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- toggle_string\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'pYTHON')))\n    stopifnot(isTRUE(all.equal(candidate('Pangram'), 'pANGRAM')))\n    stopifnot(isTRUE(all.equal(candidate('LIttLE'), 'liTTle')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the element of a list having maximum length.\nFind_Max <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max\n    stopifnot(isTRUE(all.equal(candidate(list(c('A'), c('A', 'B'), c('A', 'B', 'C'))), c('A', 'B', 'C'))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 2, 3), c(1, 5, 6, 1))), c(1, 5, 6, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "r",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\neulerian_num <- function(n, m) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- eulerian_num\n    stopifnot(isTRUE(all.equal(candidate(3, 1), 4)))\n    stopifnot(isTRUE(all.equal(candidate(4, 1), 11)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 26)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "r",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nfrequency <- function(a, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- frequency\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 3, 4), 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 1, 2), 1), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "r",
-    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/rthon-sort-numeric-strings-in-a-list/\nsort_numeric_strings <- function(nums_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_numeric_strings\n    stopifnot(isTRUE(all.equal(candidate(c('4', '12', '45', '7', '0', '100', '200', '-12', '-500')), c(-500, -12, 0, 4, 7, 12, 45, 100, 200))))\n    stopifnot(isTRUE(all.equal(candidate(c('2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2')), c(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c('1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11')), c(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rthon-exercises/data-structures-and-algorithms/rthon-recursion-exercise-9.php\ngeometric_sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- geometric_sum\n    stopifnot(isTRUE(all.equal(candidate(7), 1.9921875)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1.9375)))\n    stopifnot(isTRUE(all.equal(candidate(8), 1.99609375)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "r",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rthon-exercises/lambda/rthon-lambda-exercise-24.php\ndivisible_by_digits <- function(startnum, endnum) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- divisible_by_digits\n    stopifnot(isTRUE(all.equal(candidate(1, 22), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22))))\n    stopifnot(isTRUE(all.equal(candidate(1, 15), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15))))\n    stopifnot(isTRUE(all.equal(candidate(20, 25), c(22, 24))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "r",
-    "prompt": "# Write a rthon function to calculate the product of the unique numbers in a given list.\nunique_product <- function(list_data) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- unique_product\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30, 40, 20, 50, 60, 40)), 720000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 0, 1, 1)), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the largest negative number from the given list.\nlargest_neg <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- largest_neg\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -4, -6)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -8, -9)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, -1)), -1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "r",
-    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nconsecutive_duplicates <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), c(10, 15, 19, 18, 17, 26, 17, 18, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), c('a', 'b', 'c', 'd'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd', 'a', 'a')), c('a', 'b', 'c', 'd', 'a'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "r",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nmin_Jumps <- function(steps, d) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_Jumps\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 11), 3.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 14), 11), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "r",
-    "prompt": "# Write a rthon function to find a pair with highest product from a given vector of integers.\nmax_Product <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_Product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 7, 0, 8, 4)), c(7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, -1, -2, -4, 5, 0, -6)), c(-4, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "r",
-    "prompt": "# Write a function to extract the nth element from a given list of lists.\nextract_nth_element <- function(list1, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_nth_element\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 0), c('Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 2), c(99, 96, 94, 98))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 1), c(98, 97, 91, 94))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth nonagonal number.\nis_nonagonal <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_nonagonal\n    stopifnot(isTRUE(all.equal(candidate(10), 325)))\n    stopifnot(isTRUE(all.equal(candidate(15), 750)))\n    stopifnot(isTRUE(all.equal(candidate(18), 1089)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the maximum difference between any two elements in a given vector.\nmax_Abs_Diff <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_Abs_Diff\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 3, 2, 5, 1)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "r",
-    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\npack_consecutive_duplicates <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pack_consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), list(c(0, 0), c(1), c(2), c(3), c(4, 4), c(5), c(6, 6, 6), c(7), c(8), c(9), c(4, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), list(c(10, 10), c(15), c(19), c(18, 18), c(17), c(26, 26), c(17), c(18), c(10)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), list(c('a', 'a'), c('b'), c('c'), c('d', 'd')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\ncal_sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- cal_sum\n    stopifnot(isTRUE(all.equal(candidate(9), 49)))\n    stopifnot(isTRUE(all.equal(candidate(10), 66)))\n    stopifnot(isTRUE(all.equal(candidate(11), 88)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "r",
-    "prompt": "# Write a rthon function to remove the characters which have odd index values of a given string.\nodd_values_string <- function(str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_values_string\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 'ace')))\n    stopifnot(isTRUE(all.equal(candidate('python'), 'pto')))\n    stopifnot(isTRUE(all.equal(candidate('data'), 'dt')))\n    stopifnot(isTRUE(all.equal(candidate('lambs'), 'lms')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "r",
-    "prompt": "# Write a function to find kth element from the given two sorted vectors.\nfind_kth <- function(arr1, arr2, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_kth\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6, 7, 9), c(1, 4, 8, 10), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 112, 256, 349, 770), c(72, 86, 113, 119, 265, 445, 892), 7), 256)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 7, 8, 10), c(2, 5, 9, 11), 6), 8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "r",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\njacobsthal_num <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- jacobsthal_num\n    stopifnot(isTRUE(all.equal(candidate(5), 11)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(13), 2731)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "r",
-    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a named list.\nfrequency_lists <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- frequency_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 2), c(4, 5, 6, 2), c(7, 8, 9, 5))), list(1 = 1, 2 = 3, 3 = 1, 4 = 1, 5 = 2, 6 = 1, 7 = 1, 8 = 1, 9 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12))), list(1 = 1, 2 = 1, 3 = 1, 4 = 1, 5 = 1, 6 = 1, 7 = 1, 8 = 1, 9 = 1, 10 = 1, 11 = 1, 12 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(20, 30, 40, 17), c(18, 16, 14, 13), c(10, 20, 30, 40))), list(20 = 2, 30 = 2, 40 = 2, 17 = 1, 18 = 1, 16 = 1, 14 = 1, 13 = 1, 10 = 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "r",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\nperfect_squares <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- perfect_squares\n    stopifnot(isTRUE(all.equal(candidate(1, 30), c(1, 4, 9, 16, 25))))\n    stopifnot(isTRUE(all.equal(candidate(50, 100), c(64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(100, 121, 144, 169, 196))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "r",
-    "prompt": "# Write a rthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nsum_Of_Subarray_Prod <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_Subarray_Prod\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 84)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the first odd number in a given list of numbers.\nfirst_odd <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- first_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 1)), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "r",
-    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nadd_nested_tuples <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_nested_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(7, 10), c(7, 14), c(3, 10), c(8, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(9, 12), c(9, 16), c(5, 12), c(10, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(11, 14), c(11, 18), c(7, 14), c(12, 17)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "r",
-    "prompt": "# Write a rthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nmerge <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('a', 'b'), c('m', 'n'))), list(c('x', 'a', 'm'), c('y', 'b', 'n')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6), c(7, 8))), list(c(1, 3, 5, 7), c(2, 4, 6, 8)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y', 'z'), c('a', 'b', 'c'), c('m', 'n', 'o'))), list(c('x', 'a', 'm'), c('y', 'b', 'n'), c('z', 'c', 'o')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given number can be represented as the difference of two squares or not.\ndif_Square <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- dif_Square\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "r",
-    "prompt": "# Write a function to check if each element of second list is smaller than its corresponding element in the first list.\ncheck_smaller <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_smaller\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13), c(10, 11, 12)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "r",
-    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a named list.\nfreq_count <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- freq_count\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)), list(10 = 4, 20 = 4, 40 = 2, 50 = 2, 30 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)), list(1 = 3, 2 = 2, 3 = 3, 4 = 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)), list(10 = 1, 5 = 3, 6 = 2, 7 = 2, 4 = 2, 9 = 2))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "r",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nrgb_to_hsv <- function(r, g, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rgb_to_hsv\n    stopifnot(isTRUE(all.equal(candidate(255, 255, 255), c(0.0, 0.0, 100.0))))\n    stopifnot(isTRUE(all.equal(candidate(0, 215, 0), c(120.0, 100.0, 84.31372549019608))))\n    stopifnot(isTRUE(all.equal(candidate(10, 215, 110), c(149.26829268292684, 95.34883720930233, 84.31372549019608))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "r",
-    "prompt": "# Write a function to flatten a given nested list structure.\nflatten_list <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- flatten_list\n    stopifnot(isTRUE(all.equal(candidate(list(0, 10, c(20, 30), 40, 50, c(60, 70, 80), c(90, 100, 110, 120))), c(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(40), c(30, 56, 25), c(10, 20), c(33), c(40))), c(10, 20, 40, 30, 56, 25, 10, 20, 33, 40))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ncheck_str <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_str\n    stopifnot(isTRUE(all.equal(candidate('annie'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dawood'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Else'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ncheck_monthnumber_number <- function(monthnum3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumber_number\n    stopifnot(isTRUE(all.equal(candidate(6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "r",
-    "prompt": "# Write a function to sort the given list.\nheap_sort <- function(iterable) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- heap_sort\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 25, 58)), c(14, 22, 25, 25, 35, 58, 65, 75, 85))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 1, 9, 5)), c(1, 5, 7, 9))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "r",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nk_smallest_pairs <- function(nums1, nums2, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- k_smallest_pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 2), list(c(1, 2), c(1, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 1), list(c(1, 2)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 7), list(c(1, 2), c(1, 4), c(3, 2), c(1, 6), c(3, 4), c(3, 6), c(7, 2)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "r",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a list, or return NULL if no solution exists.\nfind_solution <- function(a, b, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_solution\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 7), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 7), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(1, 13, 17), c(4, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the largest number that can be formed with the given list of digits.\nfind_Max_Num <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Max_Num\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 321)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 1)), 6541)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 9)), 9321)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "r",
-    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nmax_sum_list <- function(lists) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(10, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 2, 1), c(6, 5, 4), c(12, 11, 10))), c(12, 11, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 1))), c(2, 3, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "r",
-    "prompt": "# Write a rthon function to interchange the first and last elements in a list.\nswap_List <- function(newList) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(12, 35, 9, 56, 24)), c(24, 35, 9, 56, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "r",
-    "prompt": "# Write a function to find the median of two sorted lists of same size.\nget_median <- function(arr1, arr2, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_median\n    stopifnot(isTRUE(all.equal(candidate(c(1, 12, 15, 26, 38), c(2, 13, 17, 30, 45), 5), 16.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 9), c(7, 13, 19, 28), 4), 8.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 14, 23, 36, 42), c(2, 18, 27, 39, 49, 55), 6), 25.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "r",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nreplace_spaces <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')))\n    stopifnot(isTRUE(all.equal(candidate('The_Avengers'), 'The Avengers')))\n    stopifnot(isTRUE(all.equal(candidate('Fast and Furious'), 'Fast_and_Furious')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "r",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nare_equivalent <- function(num1, num2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- are_equivalent\n    stopifnot(isTRUE(all.equal(candidate(36, 57), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23, 47), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "r",
-    "prompt": "# Write a function to reverse each string in a given list of string values.\nreverse_string_list <- function(stringlist) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_string_list\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue', 'White', 'Black')), c('deR', 'neerG', 'eulB', 'etihW', 'kcalB'))))\n    stopifnot(isTRUE(all.equal(candidate(c('john', 'amal', 'joel', 'george')), c('nhoj', 'lama', 'leoj', 'egroeg'))))\n    stopifnot(isTRUE(all.equal(candidate(c('jack', 'john', 'mary')), c('kcaj', 'nhoj', 'yram'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "r",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsum_of_digits <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_of_digits\n    stopifnot(isTRUE(all.equal(candidate(c(10, 2, 56)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(list(list(10, 20, 4, 5, 'b', 70, 'a'))), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -4, 5, -70)), 19)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "r",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsequence <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sequence\n    stopifnot(isTRUE(all.equal(candidate(10), 6)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "r",
-    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nheap_queue_largest <- function(nums, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- heap_queue_largest\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 3), c(85, 75, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 2), c(85, 75))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 5), c(85, 75, 65, 58, 35))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "r",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nloss_amount <- function(actual_cost, sale_amount) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- loss_amount\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), 0)))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), 100)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), 3000)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "r",
-    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nunion_elements <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- union_elements\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 4, 5, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(3, 4, 5, 6)), c(1, 2, 3, 4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13, 14), c(13, 15, 16, 17)), c(11, 12, 13, 14, 15, 16, 17))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the length of the longest sublists.\nFind_Max_Length <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 4), c(5, 6, 7, 8))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 1), c(2, 2), c(3, 2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7), c(22, 23), c(13, 14, 15), c(10, 20, 30, 40, 50))), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "r",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nremove_parenthesis <- function(items) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_parenthesis\n    stopifnot(isTRUE(all.equal(candidate(c('python (chrome)')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('string(.abc)')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('alpha(num)')), 'alpha')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "r",
-    "prompt": "# Write a rthon function to find whether the parity of a given number is odd.\nfind_Parity <- function(x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Parity\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "r",
-    "prompt": "# Write a function to find the median length of a trapezium.\nmedian_trapezium <- function(base1, base2, height) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- median_trapezium\n    stopifnot(isTRUE(all.equal(candidate(15, 25, 35), 20)))\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 30), 15)))\n    stopifnot(isTRUE(all.equal(candidate(6, 9, 4), 7.5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "r",
-    "prompt": "# Write a function to find nth centered hexagonal number.\ncentered_hexagonal_number <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- centered_hexagonal_number\n    stopifnot(isTRUE(all.equal(candidate(10), 271)))\n    stopifnot(isTRUE(all.equal(candidate(2), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 217)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "r",
-    "prompt": "# Write a function to find number of lists present in the given list.\nfind_lists <- function(Input) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5, 4, 3, 2, 1)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nget_max_sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_max_sum\n    stopifnot(isTRUE(all.equal(candidate(60), 106)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the length of the longest word.\nlen_log <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- len_log\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'PHP', 'bigdata')), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'ab', 'abc')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c('small', 'big', 'tall')), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "r",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return NULL if the angle is larger than 360 degrees.\nsector_area <- function(r, a) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sector_area\n    stopifnot(isTRUE(all.equal(candidate(4, 45), 6.283185307179586)))\n    stopifnot(isTRUE(all.equal(candidate(9, 45), 31.808625617596654)))\n    stopifnot(isTRUE(all.equal(candidate(9, 361), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether every odd index contains odd numbers of a given list.\nodd_position <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- odd_position\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4, 3, 6, 7, 6, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "r",
-    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nmultiple_to_single <- function(L) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiple_to_single\n    stopifnot(isTRUE(all.equal(candidate(c(11, 33, 50)), 113350)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4, 5, 6)), -123456)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25)), 10152025)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "r",
-    "prompt": "# Write a rthon function to find whether a number is divisible by 11.\nis_Diff <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Diff\n    stopifnot(isTRUE(all.equal(candidate(12345), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1212112), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1212), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "r",
-    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nindex_multiplication <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- index_multiplication\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 21), c(12, 45), c(2, 9), c(7, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(14, 32), c(20, 60), c(6, 20), c(16, 44)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(24, 45), c(30, 77), c(12, 33), c(27, 60)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "r",
-    "prompt": "# Write a function to convert list string to integer list.\ntuple_str_int <- function(test_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_str_int\n    stopifnot(isTRUE(all.equal(candidate('(7, 8, 9)'), c(7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate('(1, 2, 3)'), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate('(4, 5, 6)'), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate('(7, 81, 19)'), c(7, 81, 19))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "r",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\namicable_numbers_sum <- function(limit) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- amicable_numbers_sum\n    stopifnot(isTRUE(all.equal(candidate(999), 504)))\n    stopifnot(isTRUE(all.equal(candidate(9999), 31626)))\n    stopifnot(isTRUE(all.equal(candidate(99), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "r",
-    "prompt": "# Write a function to remove odd characters in a string.\nremove_odd <- function(str1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate('python'), 'yhn')))\n    stopifnot(isTRUE(all.equal(candidate('program'), 'rga')))\n    stopifnot(isTRUE(all.equal(candidate('language'), 'agae')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "r",
-    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\nmultiply_elements <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(5, 35, 56, 80))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 7)), c(8, 20, 30, 42))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 13, 14, 9, 15)), c(156, 182, 126, 135))))\n    stopifnot(isTRUE(all.equal(candidate(c(12)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\ncount_rotation <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_rotation\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 1, 2, 3)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "r",
-    "prompt": "# Write a function to extract the number of unique lists in the given list.\nextract_freq <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_freq\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4), c(1, 2), c(4, 3), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 15), c(2, 3), c(5, 4), c(6, 7))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 16), c(2, 3), c(6, 5), c(6, 9))), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "r",
-    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ncount_same_pair <- function(nums1, nums2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_same_pair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 1, 2), c(0, 1, 2, 2)), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "r",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\npower <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- power\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 81)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), 3125)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "r",
-    "prompt": "# Write function to find the sum of all items in the given named list.\nreturn_sum <- function(dict) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- return_sum\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 100, 'b' = 200, 'c' = 300)), 600)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 25, 'b' = 18, 'c' = 45)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 36, 'b' = 39, 'c' = 49)), 124)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "r",
-    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\npair_wise <- function(l1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pair_wise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 3, 4, 4, 5)), list(c(1, 1), c(1, 2), c(2, 3), c(3, 3), c(3, 4), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), list(c(1, 5), c(5, 7), c(7, 9), c(9, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 9, 7, 10)), list(c(5, 1), c(1, 9), c(9, 7), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), list(c(1, 2), c(2, 3), c(3, 4), c(4, 5), c(5, 6), c(6, 7), c(7, 8), c(8, 9), c(9, 10)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "r",
-    "prompt": "# Write a rthon function to split a string into characters.\nsplit <- function(word) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- split\n    stopifnot(isTRUE(all.equal(candidate('python'), c('p', 'y', 't', 'h', 'o', 'n'))))\n    stopifnot(isTRUE(all.equal(candidate('Name'), c('N', 'a', 'm', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate('program'), c('p', 'r', 'o', 'g', 'r', 'a', 'm'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "r",
-    "prompt": "# Write a function to find minimum of three numbers.\nmin_of_three <- function(a, b, c) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_of_three\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(19, 15, 18), 15)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -20, -30), -30)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nis_Sum_Of_Powers_Of_Two <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_Sum_Of_Powers_Of_Two\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(14), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nget_Char <- function(strr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_Char\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'f')))\n    stopifnot(isTRUE(all.equal(candidate('gfg'), 't')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'c')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "r",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\nsum_div <- function(number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_div\n    stopifnot(isTRUE(all.equal(candidate(8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(12), 16)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "r",
-    "prompt": "# Write a rthon function that returns the number of integer elements in a given list.\ncount_integer <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_integer\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 'abc', 1.2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1.2, 4, 5.1)), 2)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "r",
-    "prompt": "# Write a rthon function to remove duplicate numbers from a given number of lists.\ntwo_unique_nums <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- two_unique_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 3, 4, 5)), c(1, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 5)), c(1, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "r",
-    "prompt": "# Write a function to find whether a given vector of integers contains any duplicate element.\ntest_duplicate <- function(arraynums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- test_duplicate\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3, 3, 4, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "r",
-    "prompt": "# Write a function which returns nth catalan number.\ncatalan_number <- function(num) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- catalan_number\n    stopifnot(isTRUE(all.equal(candidate(10), 16796)))\n    stopifnot(isTRUE(all.equal(candidate(9), 4862)))\n    stopifnot(isTRUE(all.equal(candidate(7), 429)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "r",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\npower_base_sum <- function(base, power) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- power_base_sum\n    stopifnot(isTRUE(all.equal(candidate(2, 100), 115)))\n    stopifnot(isTRUE(all.equal(candidate(8, 10), 37)))\n    stopifnot(isTRUE(all.equal(candidate(8, 15), 62)))\n    stopifnot(isTRUE(all.equal(candidate(3, 3), 9)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "r",
-    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nreplace_list <- function(list1, list2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8)), c(1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'blue', 'green'), c('yellow')), c('red', 'blue', 'yellow'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth octagonal number.\nis_octagonal <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_octagonal\n    stopifnot(isTRUE(all.equal(candidate(5), 65)))\n    stopifnot(isTRUE(all.equal(candidate(10), 280)))\n    stopifnot(isTRUE(all.equal(candidate(15), 645)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "r",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nreplace_blank <- function(str1, char) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_blank\n    stopifnot(isTRUE(all.equal(candidate('hello people', '@'), 'hello@people')))\n    stopifnot(isTRUE(all.equal(candidate('python program language', '$'), 'python$program$language')))\n    stopifnot(isTRUE(all.equal(candidate('blank space', '-'), 'blank-space')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "r",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nreplace_specialchar <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_specialchar\n    stopifnot(isTRUE(all.equal(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')))\n    stopifnot(isTRUE(all.equal(candidate('a b c,d e f'), 'a:b:c:d:e:f')))\n    stopifnot(isTRUE(all.equal(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "r",
-    "prompt": "# Write a function to convert a given list of positive integers into a single integer.\ntuple_to_int <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_int\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 123)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), 456)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7)), 567)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "r",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\notherside_rightangle <- function(w, h) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- otherside_rightangle\n    stopifnot(isTRUE(all.equal(candidate(7, 8), 10.63014581273465)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(7, 15), 16.55294535724685)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "r",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nexpensive_items <- function(items, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- expensive_items\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09)), 2), list(list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-1', 'price' = 101.1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09), list('name' = 'Item-4', 'price' = 22.75)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sum of the per-digit difference between two integers.\ndigit_distance_nums <- function(n1, n2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- digit_distance_nums\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(23, 56), 6)))\n    stopifnot(isTRUE(all.equal(candidate(123, 256), 7)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "r",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ntext_match_wordz_middle <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz_middle\n    stopifnot(isTRUE(all.equal(candidate('pythonzabc.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zxyabc.'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "r",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\nremovezero_ip <- function(ip) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- removezero_ip\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.196'), '216.8.94.196')))\n    stopifnot(isTRUE(all.equal(candidate('12.01.024'), '12.1.24')))\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.0196'), '216.8.94.196')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "r",
-    "prompt": "# Write a function to count the number of sublists containing a particular element.\ncount_element_in_list <- function(list1, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_element_in_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(1, 11), c(1, 15, 7)), 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'A'), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'E'), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "r",
-    "prompt": "# Write a function to multiply two integers.\nmultiply_int <- function(x, y) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- multiply_int\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8), 32)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "r",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given list.\nadd_pairwise <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_pairwise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(6, 12, 15, 18))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 8, 9, 11)), c(8, 14, 17, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 7, 9, 10, 12)), c(10, 16, 19, 22))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\nmax_product_tuple <- function(list1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 36)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 200)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 484)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -3839,7 +17,7 @@
     "language": "r",
     "prompt": "# Write a function to find the kth element in the given vector using 1-based indexing.\nkth_element <- function(arr, k) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(12, 3, 5, 7, 19), 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(17, 24, 8, 23), 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(16, 21, 25, 36, 4), 4), 36)))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -3848,299 +26,117 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "r",
-    "prompt": "# Write a rthon function to interchange the first and last element in a given list.\nswap_List <- function(newList) {",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\nsnake_to_camel <- function(word) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), c(4, 2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('python_program'), 'PythonProgram')))\n    stopifnot(isTRUE(all.equal(candidate('python_language'), 'PythonLanguage')))\n    stopifnot(isTRUE(all.equal(candidate('programming_language'), 'ProgrammingLanguage')))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "r",
-    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given list.\ncount_first_elements <- function(test_tup) {",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\neulerian_num <- function(n, m) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_first_elements\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 9, c(5, 7), 11)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(11, 15, 5, 8, c(2, 3), 8)), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- eulerian_num\n    stopifnot(isTRUE(all.equal(candidate(3, 1), 4)))\n    stopifnot(isTRUE(all.equal(candidate(4, 1), 11)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 26)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "r",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nright_insertion <- function(a, x) {",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(input_list) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- right_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(' red ', 'green'), c('blue ', ' black'), c(' orange', 'brown'))), list(c(' red ', 'green'), c(' black', 'blue '), c(' orange', 'brown')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('zilver', 'gold'), c('magnesium', 'aluminium'), c('steel', 'bronze'))), list(c('gold', 'zilver'), c('aluminium', 'magnesium'), c('bronze', 'steel')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "r",
-    "prompt": "# Write a function to check if the given number is woodball or not.\nis_woodall <- function(x) {",
+    "prompt": "# Write a rthon function to count true booleans in the given list.\ncount <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_woodall\n    stopifnot(isTRUE(all.equal(candidate(383), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(254), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(200), FALSE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- count\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, FALSE, TRUE)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(FALSE, FALSE)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(TRUE, TRUE, TRUE)), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "r",
-    "prompt": "# Write a function to sort the given vector by using shell sort.\nshell_sort <- function(my_list) {",
+    "prompt": "# Write a function to append the given list to the given lists.\nadd_lists <- function(test_list, test_tup) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- shell_sort\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)), c(2, 3, 4, 5, 12, 12, 23, 56, 81, 95))))\n    stopifnot(isTRUE(all.equal(candidate(c(24, 22, 39, 34, 87, 73, 68)), c(22, 24, 34, 39, 68, 73, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(32, 30, 16, 96, 82, 83, 74)), c(16, 30, 32, 74, 82, 83, 96))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_lists\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(9, 10, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(10, 11, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "r",
-    "prompt": "# Write a rthon function to count the number of pairs whose xor value is odd.\nfind_Odd_Pair <- function(A, N) {",
+    "prompt": "# Write a function to merge three lists into a single sorted list.\nmerge_sorted_list <- function(num1, num2, num3) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Odd_Pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11), 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 3), 2)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge_sorted_list\n    stopifnot(isTRUE(all.equal(candidate(c(25, 24, 15, 4, 5, 29, 110), c(19, 20, 11, 56, 25, 233, 154), c(24, 26, 54, 48)), c(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 6, 8, 9), c(2, 5, 7, 11), c(1, 4, 7, 8, 12)), c(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), c(25, 35, 22, 85, 14, 65, 75, 25, 58), c(12, 74, 9, 50, 61, 41)), c(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "r",
-    "prompt": "# Write a rthon function to find the sum of all odd natural numbers within the range l and r.\nsum_in_range <- function(l, r) {",
+    "prompt": "# Write a rthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nodd_Equivalent <- function(s, n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_in_range\n    stopifnot(isTRUE(all.equal(candidate(2, 5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), 40)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_Equivalent\n    stopifnot(isTRUE(all.equal(candidate('011001', 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate('11011', 5), 4)))\n    stopifnot(isTRUE(all.equal(candidate('1010', 4), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "r",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsquare_perimeter <- function(a) {",
+    "prompt": "# Write a function to check if a string represents an integer or not.\ncheck_integer <- function(text) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_perimeter\n    stopifnot(isTRUE(all.equal(candidate(10), 40)))\n    stopifnot(isTRUE(all.equal(candidate(5), 20)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_integer\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('12345'), TRUE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "r",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nis_polite <- function(n) {",
+    "prompt": "# Write a function to convert a given list of positive integers into a single integer.\ntuple_to_int <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_polite\n    stopifnot(isTRUE(all.equal(candidate(7), 11)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 13)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "r",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsum_series <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_series\n    stopifnot(isTRUE(all.equal(candidate(6), 12)))\n    stopifnot(isTRUE(all.equal(candidate(10), 30)))\n    stopifnot(isTRUE(all.equal(candidate(9), 25)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "r",
-    "prompt": "# Write a function to find the dissimilar elements in the given two lists.\nfind_dissimilar <- function(test_tup1, test_tup2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_dissimilar\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(7, 2, 3, 9)), c(1, 4, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 11, 25, 26), c(26, 34, 21, 36)), c(34, 36, 11, 25))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "r",
-    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nstart_withp <- function(words) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- start_withp\n    stopifnot(isTRUE(all.equal(candidate(c('Python PHP', 'Java JavaScript', 'c c++')), c('Python', 'PHP'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python Programming', 'Java Programming')), c('Python', 'Programming'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Pqrst Pqr', 'qrstuv')), c('Pqrst', 'Pqr'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "r",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsnake_to_camel <- function(word) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('android_tv'), 'AndroidTv')))\n    stopifnot(isTRUE(all.equal(candidate('google_pixel'), 'GooglePixel')))\n    stopifnot(isTRUE(all.equal(candidate('apple_watch'), 'AppleWatch')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "r",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\nvolume_cube <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- volume_cube\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(2), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5), 125)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ncheck_monthnumb_number <- function(monthnum2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumb_number\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "r",
-    "prompt": "# Write a rthon function to check whether all the bits are unset in the given range or not.\nall_Bits_Set_In_The_Given_Range <- function(n, l, r) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- all_Bits_Set_In_The_Given_Range\n    stopifnot(isTRUE(all.equal(candidate(4, 1, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17, 2, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(39, 4, 6), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "r",
-    "prompt": "# Write a rthon function to get the first element of each sublist.\nExtract <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Extract\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4, 5), c(6, 7, 8, 9))), c(1, 3, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5))), c(1, 4))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(9, 8, 1), c(1, 2))), c(9, 1))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "r",
-    "prompt": "# Write a function to find the surface area of a cylinder.\nsurfacearea_cylinder <- function(r, h) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cylinder\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 942.45)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 226.18800000000002)))\n    stopifnot(isTRUE(all.equal(candidate(4, 10), 351.848)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "r",
-    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsample_nam <- function(sample_names) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sample_nam\n    stopifnot(isTRUE(all.equal(candidate(c('sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith')), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c('php', 'res', 'Python', 'abcd', 'Java', 'aaa')), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c('abcd', 'Python', 'abba', 'aba')), 6)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "r",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nrearrange_bigger <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rearrange_bigger\n    stopifnot(isTRUE(all.equal(candidate(12), 21)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(102), 120)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "r",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nperimeter_pentagon <- function(a) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- perimeter_pentagon\n    stopifnot(isTRUE(all.equal(candidate(5), 25)))\n    stopifnot(isTRUE(all.equal(candidate(10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(15), 75)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "r",
-    "prompt": "# Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nmax_sum <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 15, 51, 45, 33, 100, 12, 18, 9)), 194)))\n    stopifnot(isTRUE(all.equal(candidate(c(80, 60, 30, 40, 20, 10)), 210)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 14, 16, 21, 23, 29, 30)), 138)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "r",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed list.\nextract_even <- function(test_tuple) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_even\n    stopifnot(isTRUE(all.equal(candidate(list(4, 5, list(7, 6, c(2, 4)), 6, 8)), list(4, list(6, c(2, 4)), 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(8, 7, c(4, 8)), 7, 9)), list(6, list(8, c(4, 8))))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(9, 8, c(4, 6)), 8, 10)), list(6, list(8, c(4, 6)), 8, 10))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_int\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 123)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), 456)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7)), 567)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4151,217 +147,9 @@
     "language": "r",
     "prompt": "# Write a function to convert all possible convertible elements in a list of lists to floats.\nlist_to_float <- function(test_list) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- list_to_float\n    stopifnot(isTRUE(all.equal(candidate(list(c('3', '4'), c('1', '26.45'), c('7.32', '8'), c('4', '8'))), list(c(3.0, 4.0), c(1.0, 26.45), c(7.32, 8.0), c(4.0, 8.0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('4', '4'), c('2', '27'), c('4.12', '9'), c('7', '11'))), list(c(4.0, 4.0), c(2.0, 27.0), c(4.12, 9.0), c(7.0, 11.0)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('6', '78'), c('5', '26.45'), c('1.33', '4'), c('82', '13'))), list(c(6.0, 78.0), c(5.0, 26.45), c(1.33, 4.0), c(82.0, 13.0)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "r",
-    "prompt": "# Write a rthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsquare_Sum <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 20)))\n    stopifnot(isTRUE(all.equal(candidate(3), 56)))\n    stopifnot(isTRUE(all.equal(candidate(4), 120)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nget_pairs_count <- function(arr, sum) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_pairs_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, -1, 5), 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3), 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3), -3), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "r",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ncount_no_of_ways <- function(n, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_no_of_ways\n    stopifnot(isTRUE(all.equal(candidate(2, 4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4, 4), 228)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "r",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nreverse_words <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- reverse_words\n    stopifnot(isTRUE(all.equal(candidate('python program'), 'program python')))\n    stopifnot(isTRUE(all.equal(candidate('java language'), 'language java')))\n    stopifnot(isTRUE(all.equal(candidate('indian man'), 'man indian')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "r",
-    "prompt": "# Write a rthon function to check if a given number is one less than twice its reverse.\nchecks <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- checks\n    stopifnot(isTRUE(all.equal(candidate(70), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(73), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the last position of an element in a sorted vector.\nlast <- function(arr, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- last\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, 4), 1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 3, 6, 8, 9), 3), 3)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "r",
-    "prompt": "# Write a rthon function that takes in a list and an element and counts the occcurences of the element in the list.\ncount_X <- function(tup, x) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_X\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "r",
-    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nextract_index_list <- function(l1, l2, l3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_index_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 6, 5), c(0, 1, 2, 3, 4, 6, 7)), c(1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 6, 5, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 6, 6, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c())))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "r",
-    "prompt": "# Write a function to find the second smallest number in a list.\nsecond_smallest <- function(numbers) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- second_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -8, -2, 0, -2)), -2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, -0.5, 0, 2, -2, -2)), -0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2)), NULL)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "r",
-    "prompt": "# Write a function to concatenate each element of list by the delimiter.\nconcatenate_tuple <- function(test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- concatenate_tuple\n    stopifnot(isTRUE(all.equal(candidate(list('ID', 'is', 4, 'UTS')), 'ID-is-4-UTS')))\n    stopifnot(isTRUE(all.equal(candidate(list('QWE', 'is', 4, 'RTY')), 'QWE-is-4-RTY')))\n    stopifnot(isTRUE(all.equal(candidate(list('ZEN', 'is', 4, 'OP')), 'ZEN-is-4-OP')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "r",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nreplace_spaces <- function(string) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')))\n    stopifnot(isTRUE(all.equal(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')))\n    stopifnot(isTRUE(all.equal(candidate('I love Coding'), 'I%20love%20Coding')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "r",
-    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsum_range_list <- function(list1, m, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sum_range_list\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10), 38)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "r",
-    "prompt": "# Write a function to merge three dictionaries into a single named list.\nmerge_dictionaries_three <- function(dict1, dict2, dict3) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge_dictionaries_three\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('O' = 'Orange', 'W' = 'White', 'B' = 'Black')), list('B' = 'Black', 'R' = 'Red', 'P' = 'Pink', 'G' = 'Green', 'W' = 'White', 'O' = 'Orange'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('L' = 'lavender', 'B' = 'Blue')), list('W' = 'White', 'P' = 'Pink', 'B' = 'Black', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('L' = 'lavender', 'B' = 'Blue'), list('G' = 'Green', 'W' = 'White')), list('B' = 'Black', 'P' = 'Pink', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender', 'W' = 'White'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the minimum of two numbers.\nminimum <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- minimum\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(-5, -4), -5)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given list list.\nmax_difference <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_difference\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(1, 7), c(10, 3), c(1, 2))), 7)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(2, 17), c(9, 13), c(11, 12))), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 35), c(21, 27), c(13, 23), c(41, 22))), 23)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "r",
-    "prompt": "# Write a rthon function to find element at a given index after number of rotations.\nfind_Element <- function(arr, ranges, rotations, index) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), list(c(0, 2), c(0, 3)), 2, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), list(c(0, 1), c(0, 2)), 1, 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), list(c(0, 1), c(0, 2)), 1, 1), 1)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4372,7 +160,7 @@
     "language": "r",
     "prompt": "# Write a function to convert a string to a list of strings split on the space character.\nstring_to_list <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- string_to_list\n    stopifnot(isTRUE(all.equal(candidate('python programming'), c('python', 'programming'))))\n    stopifnot(isTRUE(all.equal(candidate('lists tuples strings'), c('lists', 'tuples', 'strings'))))\n    stopifnot(isTRUE(all.equal(candidate('write a program'), c('write', 'a', 'program'))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4385,22 +173,9 @@
     "language": "r",
     "prompt": "# Write a rthon function to find the element that appears only once in a sorted vector.\nsearch <- function(arr) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- search\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 4, 4)), 1)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "r",
-    "prompt": "# Write a function to sort a named list by value.\nsort_counter <- function(dict1) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_counter\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 81, 'Physics' = 83, 'Chemistry' = 87)), list(list('Chemistry', 87), list('Physics', 83), list('Math', 81)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 400, 'Physics' = 300, 'Chemistry' = 250)), list(list('Math', 400), list('Physics', 300), list('Chemistry', 250)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 900, 'Physics' = 1000, 'Chemistry' = 1250)), list(list('Chemistry', 1250), list('Physics', 1000), list('Math', 900)))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4411,7 +186,7 @@
     "language": "r",
     "prompt": "# Write a rthon function to remove first and last occurrence of a given character from the string.\nremove_Occ <- function(s, ch) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- remove_Occ\n    stopifnot(isTRUE(all.equal(candidate('hello', 'l'), 'heo')))\n    stopifnot(isTRUE(all.equal(candidate('abcda', 'a'), 'bcd')))\n    stopifnot(isTRUE(all.equal(candidate('PHP', 'P'), 'H')))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4420,364 +195,65 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "r",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nlateralsurface_cube <- function(l) {",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\nmax_product_tuple <- function(list1) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 100)))\n    stopifnot(isTRUE(all.equal(candidate(9), 324)))\n    stopifnot(isTRUE(all.equal(candidate(10), 400)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 36)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 200)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 484)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "r",
-    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ncommon_element <- function(list1, list2) {",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\namicable_numbers_sum <- function(limit) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- common_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8, 9)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c'), c('d', 'b', 'e')), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- amicable_numbers_sum\n    stopifnot(isTRUE(all.equal(candidate(999), 504)))\n    stopifnot(isTRUE(all.equal(candidate(9999), 31626)))\n    stopifnot(isTRUE(all.equal(candidate(99), 0)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "r",
-    "prompt": "# Write a function to append the given list to the given lists.\nadd_lists <- function(test_list, test_tup) {",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfind_length <- function(string) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_lists\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(9, 10, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(10, 11, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_length\n    stopifnot(isTRUE(all.equal(candidate('11000010001'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('10111'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('11011101100101'), 2)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "r",
-    "prompt": "# Write a function to compute the n-th power of each number in a list.\nnth_nums <- function(nums, n) {",
+    "prompt": "# Write a rthon function to find the sum of common divisors of two given numbers.\nsum <- function(a, b) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- nth_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), 3), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15), 5), c(248832, 759375))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 6)))\n    stopifnot(isTRUE(all.equal(candidate(100, 150), 93)))\n    stopifnot(isTRUE(all.equal(candidate(4, 6), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "r",
-    "prompt": "# Write a function to sort a list of elements.\npancake_sort <- function(nums) {",
+    "prompt": "# Write a function to multiply two integers.\nmultiply_int <- function(x, y) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- pancake_sort\n    stopifnot(isTRUE(all.equal(candidate(c(15, 79, 25, 38, 69)), c(15, 25, 38, 69, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(98, 12, 54, 36, 85)), c(12, 36, 54, 85, 98))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 42, 32, 12, 23)), c(12, 23, 32, 41, 42))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "r",
-    "prompt": "# Write a function to find the median of three numbers.\nmedian_numbers <- function(a, b, c) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- median_numbers\n    stopifnot(isTRUE(all.equal(candidate(25, 55, 65), 55.0)))\n    stopifnot(isTRUE(all.equal(candidate(20, 10, 30), 20.0)))\n    stopifnot(isTRUE(all.equal(candidate(15, 45, 75), 45.0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "r",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given vector.\ncheck_greater <- function(arr, number) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_greater\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6), 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 4, 8, 6, 1), 11), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ncheck_element <- function(list, element) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_element\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'orange', 'black', 'white'), 'blue'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'green', 'green', 'green'), 'green'), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "r",
-    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nextract_string <- function(str, l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- extract_string\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 8), c('practice', 'solution'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 6), c('Python'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 9), c('exercises'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "r",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ntext_lowercase_underscore <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- text_lowercase_underscore\n    stopifnot(isTRUE(all.equal(candidate('aab_cbbbc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aab_Abbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Aaab_abbbc'), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "r",
-    "prompt": "# Write a function to trim each list by k in the given lists.\ntrim_tuple <- function(test_list, K) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- trim_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 2), list(c(2), c(9), c(2), c(2)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 1), list(c(3, 2, 1), c(4, 9, 2), c(1, 2, 3), c(8, 2, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 4, 9), c(11, 8, 12, 4), c(4, 1, 7, 8), c(3, 6, 9, 7)), 1), list(c(8, 4), c(8, 12), c(1, 7), c(6, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the sublist having minimum length.\nFind_Min <- function(lst) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 1, 1), c(1, 2, 7, 8))), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x'), c('x', 'y'), c('x', 'y', 'z'))), c('x'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "r",
-    "prompt": "# Write a function to filter odd numbers.\nfilter_oddnumbers <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- filter_oddnumbers\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 45, 67, 84, 93)), c(45, 67, 93))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 9, 8, 6, 4, 3)), c(5, 7, 9, 3))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "r",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nfind_adverbs <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_adverbs\n    stopifnot(isTRUE(all.equal(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')))\n    stopifnot(isTRUE(all.equal(candidate('Please handle the situation carefuly'), '28-36: carefuly')))\n    stopifnot(isTRUE(all.equal(candidate('Complete the task quickly'), '18-25: quickly')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "r",
-    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nmax_of_nth <- function(test_list, N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_of_nth\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6, 7), c(1, 3, 5), c(8, 9, 19)), 2), 19)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 7, 8), c(2, 4, 6), c(9, 10, 20)), 1), 10)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 9), c(3, 5, 7), c(10, 11, 21)), 1), 11)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "r",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndecimal_to_binary <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(8), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(18), '10010')))\n    stopifnot(isTRUE(all.equal(candidate(7), '111')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ncombinations_colors <- function(l, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- combinations_colors\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 1), list(c('Red'), c('Green'), c('Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 2), list(c('Red', 'Red'), c('Red', 'Green'), c('Red', 'Blue'), c('Green', 'Green'), c('Green', 'Blue'), c('Blue', 'Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 3), list(c('Red', 'Red', 'Red'), c('Red', 'Red', 'Green'), c('Red', 'Red', 'Blue'), c('Red', 'Green', 'Green'), c('Red', 'Green', 'Blue'), c('Red', 'Blue', 'Blue'), c('Green', 'Green', 'Green'), c('Green', 'Green', 'Blue'), c('Green', 'Blue', 'Blue'), c('Blue', 'Blue', 'Blue')))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "r",
-    "prompt": "# Write a function to remove all whitespaces from a string.\nremove_all_spaces <- function(text) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_all_spaces\n    stopifnot(isTRUE(all.equal(candidate('python  program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('python   programming    language'), 'pythonprogramminglanguage')))\n    stopifnot(isTRUE(all.equal(candidate('python                     program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('   python                     program'), 'pythonprogram')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "r",
-    "prompt": "# Write a rthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nmin_Swaps <- function(str1, str2) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_Swaps\n    stopifnot(isTRUE(all.equal(candidate('1101', '1110'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('111', '000'), 'Not Possible')))\n    stopifnot(isTRUE(all.equal(candidate('111', '110'), 'Not Possible')))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "r",
-    "prompt": "# Write a function to create a new list from the given string and list.\nnew_tuple <- function(test_list, test_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- new_tuple\n    stopifnot(isTRUE(all.equal(candidate(c('WEB', 'is'), 'best'), c('WEB', 'is', 'best'))))\n    stopifnot(isTRUE(all.equal(candidate(c('We', 'are'), 'Developers'), c('We', 'are', 'Developers'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Part', 'is'), 'Wrong'), c('Part', 'is', 'Wrong'))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the product of the vector multiplication modulo n.\nfind_remainder <- function(arr, n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_remainder\n    stopifnot(isTRUE(all.equal(candidate(c(100, 10, 5, 25, 35, 14), 11), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 2), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "r",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nmin_val <- function(listval) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 20)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "r",
-    "prompt": "# Write a function to find the ration of positive numbers in a vector of integers.\npositive_count <- function(nums) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- positive_count\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)), 0.54)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 0.69)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), 0.56)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "r",
-    "prompt": "# Write a function to add the given list to the given list.\nadd_tuple <- function(test_list, test_tup) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- add_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(5, 6, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(6, 7, 8, 10, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(7, 8, 9, 11, 12))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "r",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nmax_run_uppercase <- function(test_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_run_uppercase\n    stopifnot(isTRUE(all.equal(candidate('GeMKSForGERksISBESt'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('PrECIOusMOVemENTSYT'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('GooGLEFluTTER'), 4)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "r",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsort_matrix <- function(M) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sort_matrix\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(2, 4, 5), c(1, 1, 1))), list(c(1, 1, 1), c(1, 2, 3), c(2, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(-2, 4, -5), c(1, -1, 1))), list(c(-2, 4, -5), c(1, -1, 1), c(1, 2, 3)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 8, 9), c(6, 4, 3), c(2, 1, 4))), list(c(2, 1, 4), c(6, 4, 3), c(5, 8, 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "r",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ncount_vowels <- function(test_str) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_vowels\n    stopifnot(isTRUE(all.equal(candidate('bestinstareels'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('partofthejourneyistheend'), 12)))\n    stopifnot(isTRUE(all.equal(candidate('amazonprime'), 5)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "r",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nmax_sum_increasing_subseq <- function(a, n, index, k) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_increasing_subseq\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 4, 6), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 2, 5), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 15, 19, 21, 26, 28, 31), 7, 2, 4), 71)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply_int\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 8), 32)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -4788,7 +264,7 @@
     "language": "r",
     "prompt": "# Write a function to find words that are longer than n characters from a given list of words.\nlong_words <- function(n, str) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- long_words\n    stopifnot(isTRUE(all.equal(candidate(3, 'python is a programming language'), c('python', 'programming', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate(2, 'writing a program'), c('writing', 'program'))))\n    stopifnot(isTRUE(all.equal(candidate(5, 'sorting list'), c('sorting'))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -4797,221 +273,39 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "r",
-    "prompt": "# Write a rthon function to find the sum of non-repeated elements in a given list.\nfind_sum <- function(arr) {",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\nmagic_square_test <- function(my_matrix) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 1, 4, 5, 6)), 21)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 10, 9, 4, 2, 10, 10, 45, 4)), 71)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 9, 45, 2, 10, 10, 45, 10)), 78)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- magic_square_test\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 12, 1, 14), c(2, 13, 8, 11), c(16, 3, 10, 5), c(9, 6, 15, 4))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 8))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7, 6), c(9, 5, 1), c(4, 3, 7))), FALSE)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "r",
-    "prompt": "# Write a function to convert the given list to a key-value named list using adjacent elements. https://www.geeksforgeeks.org/rthon-convert-list-to-adjacent-pair-named list/\ntuple_to_dict <- function(test_tup) {",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\nsort_matrix <- function(M) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_dict\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 10, 13, 5)), list(1 = 5, 7 = 10, 13 = 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), list(1 = 2, 3 = 4, 5 = 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 10, 11, 12)), list(7 = 8, 9 = 10, 11 = 12))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_matrix\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(2, 4, 5), c(1, 1, 1))), list(c(1, 1, 1), c(1, 2, 3), c(2, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(-2, 4, -5), c(1, -1, 1))), list(c(-2, 4, -5), c(1, -1, 1), c(1, 2, 3)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 8, 9), c(6, 4, 3), c(2, 1, 4))), list(c(2, 1, 4), c(6, 4, 3), c(5, 8, 9)))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "r",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate list.\nget_coordinates <- function(test_tup) {",
+    "prompt": "# Write a function to find the item with maximum frequency in a given list.\nmax_occurrences <- function(nums) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- get_coordinates\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4)), list(c(2, 3), c(2, 4), c(2, 5), c(3, 3), c(3, 4), c(3, 5), c(4, 3), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5)), list(c(3, 4), c(3, 5), c(3, 6), c(4, 4), c(4, 5), c(4, 6), c(5, 4), c(5, 5), c(5, 6)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6)), list(c(4, 5), c(4, 6), c(4, 7), c(5, 5), c(5, 6), c(5, 7), c(6, 5), c(6, 6), c(6, 7)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "r",
-    "prompt": "# Write a function to check if all the elements in list have same data type or not.\ncheck_type <- function(test_tuple) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_type\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 3, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, '4')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the smallest missing number from a sorted list of natural numbers.\nfind_First_Missing <- function(array) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_First_Missing\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 6, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 8, 9)), 0)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "r",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\nis_undulating <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_undulating\n    stopifnot(isTRUE(all.equal(candidate(1212121), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1991), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(121), TRUE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "r",
-    "prompt": "# Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/rthon-find-minimum-k-records-from-list-list/ - in this case a verbatim cor of test cases\nmin_k <- function(test_list, K) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- min_k\n    stopifnot(isTRUE(all.equal(candidate(list(list('Manjeet', 10), list('Akshat', 4), list('Akash', 2), list('Nikhil', 8)), 2), list(list('Akash', 2), list('Akshat', 4)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sanjeev', 11), list('Angat', 5), list('Akash', 3), list('Nepin', 9)), 3), list(list('Akash', 3), list('Angat', 5), list('Nepin', 9)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('tanmay', 14), list('Amer', 11), list('Ayesha', 9), list('SKD', 16)), 1), list(list('Ayesha', 9)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "r",
-    "prompt": "# Write a rthon function to count the number of substrings with the sum of digits equal to their length.\ncount_Substrings <- function(s) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Substrings\n    stopifnot(isTRUE(all.equal(candidate('112112'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('111'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('1101112'), 12)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "r",
-    "prompt": "# Write a function to find the nth decagonal number.\nis_num_decagonal <- function(n) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_num_decagonal\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(7), 175)))\n    stopifnot(isTRUE(all.equal(candidate(10), 370)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "r",
-    "prompt": "# Write a function that takes in a list of lists and returns a list containing the rear element of each list.\nrear_extract <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- rear_extract\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Rash', 21), list(2, 'Varsha', 20), list(3, 'Kil', 19))), c(21, 20, 19))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sai', 36), list(2, 'Ayesha', 25), list(3, 'Salman', 45))), c(36, 25, 45))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sudeep', 14), list(2, 'Vandana', 36), list(3, 'Dawood', 56))), c(14, 36, 56))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "r",
-    "prompt": "# Write a function to find the closest smaller number than n.\nclosest_num <- function(N) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- closest_num\n    stopifnot(isTRUE(all.equal(candidate(11), 10)))\n    stopifnot(isTRUE(all.equal(candidate(7), 6)))\n    stopifnot(isTRUE(all.equal(candidate(12), 11)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "r",
-    "prompt": "# Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/rthon-combinations-of-sum-with-lists-in-list-list/\nfind_combinations <- function(test_list) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_combinations\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7), c(5, 1), c(6, 10))), list(c(8, 11), c(7, 5), c(8, 14), c(11, 8), c(12, 17), c(11, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8), c(6, 2), c(7, 11))), list(c(10, 13), c(9, 7), c(10, 16), c(13, 10), c(14, 19), c(13, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(8, 9), c(7, 3), c(8, 12))), list(c(12, 15), c(11, 9), c(12, 18), c(15, 12), c(16, 21), c(15, 15)))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "r",
-    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nmaxAverageOfPath <- function(cost) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- maxAverageOfPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(6, 5, 4), c(7, 3, 9))), 5.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 4), c(7, 6, 5), c(8, 4, 10))), 6.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(8, 7, 6), c(9, 5, 11))), 7.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9))), 5.8)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "r",
-    "prompt": "# Write a function that takes in a vector and element and returns a list containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nsequential_search <- function(dlist, item) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sequential_search\n    stopifnot(isTRUE(all.equal(candidate(c(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31), list(TRUE, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 32, 45, 62, 35, 47, 44, 61), 61), list(TRUE, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 10, 17, 19, 22, 39, 48, 56), 48), list(TRUE, 6))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "r",
-    "prompt": "# Write a rthon function to remove odd numbers from a given list.\nremove_odd <- function(l) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 6)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 3)), c(10, 20))))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "r",
-    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nis_product_even <- function(arr) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- is_product_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), FALSE)))\n}\ntest_humaneval()",
-    "stop_tokens": [
-      "\n#",
-      "\n```"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "r",
-    "prompt": "# Write a rthon function to find the maximum of two numbers.\nmaximum <- function(a, b) {",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 10)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2), -1)))\n    stopifnot(isTRUE(all.equal(candidate(9, 7), 9)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_occurrences\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10)), 20)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5022,9 +316,659 @@
     "language": "r",
     "prompt": "# Write a rthon function to reverse only the vowels of a given string (where y is not a vowel).\nreverse_vowels <- function(str1) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- reverse_vowels\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('USA'), 'ASU')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'ab')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "r",
+    "prompt": "# Write a function to convert a list to a string.\ntup_string <- function(tup1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tup_string\n    stopifnot(isTRUE(all.equal(candidate(c('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's')), 'exercises')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'r', 'o', 'g', 'r', 'a', 'm')), 'program')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\nsum_negativenum <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_negativenum\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), -32)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, -14, 13, -18, 12, -20)), -52)))\n    stopifnot(isTRUE(all.equal(candidate(c(19, -65, 57, 39, 152, -639, 121, 44, 90, -190)), -894)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "r",
+    "prompt": "# Write a function to find the nth hexagonal number.\nhexagonal_num <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- hexagonal_num\n    stopifnot(isTRUE(all.equal(candidate(10), 190)))\n    stopifnot(isTRUE(all.equal(candidate(5), 45)))\n    stopifnot(isTRUE(all.equal(candidate(7), 91)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nis_Sum_Of_Powers_Of_Two <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Sum_Of_Powers_Of_Two\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(14), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of elements.\npancake_sort <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pancake_sort\n    stopifnot(isTRUE(all.equal(candidate(c(15, 79, 25, 38, 69)), c(15, 25, 38, 69, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(98, 12, 54, 36, 85)), c(12, 36, 54, 85, 98))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 42, 32, 12, 23)), c(12, 23, 32, 41, 42))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "r",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ncount_samepair <- function(list1, list2, list3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_samepair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9), c(2, 1, 3, 1, 2, 6, 7, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 2, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 8), c(2, 1, 3, 1, 2, 6, 7, 8)), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "r",
+    "prompt": "# Write a function to find number of lists present in the given list.\nfind_lists <- function(Input) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5, 4, 3, 2, 1)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the maximum difference between any two elements in a given vector.\nmax_Abs_Diff <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_Abs_Diff\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 3, 2, 5, 1)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the volume of a triangular prism.\nfind_Volume <- function(l, b, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Volume\n    stopifnot(isTRUE(all.equal(candidate(10, 8, 6), 240)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "r",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a list, or return NULL if no solution exists.\nfind_solution <- function(a, b, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_solution\n    stopifnot(isTRUE(all.equal(candidate(2, 3, 7), c(2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(4, 2, 7), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(1, 13, 17), c(4, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "r",
+    "prompt": "# Write a function to remove all elements from a given list present in another list.\nremove_elements <- function(list1, list2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(1, 3, 5, 7)), c(2, 4, 6, 8, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c(5, 7)), c(1, 2, 3, 4, 6, 8, 9, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nsum_series <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_series\n    stopifnot(isTRUE(all.equal(candidate(6), 12)))\n    stopifnot(isTRUE(all.equal(candidate(10), 30)))\n    stopifnot(isTRUE(all.equal(candidate(9), 25)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "r",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\nare_equivalent <- function(num1, num2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- are_equivalent\n    stopifnot(isTRUE(all.equal(candidate(36, 57), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23, 47), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "r",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ncount_char_position <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_char_position\n    stopifnot(isTRUE(all.equal(candidate('xbcefg'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('ABcED'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('AbgdeF'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "r",
+    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfind_even_pair <- function(A) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_even_pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11)), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the smallest power of 2 greater than or equal to n.\nnext_power_of_2 <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_power_of_2\n    stopifnot(isTRUE(all.equal(candidate(0), 1)))\n    stopifnot(isTRUE(all.equal(candidate(5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(17), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "r",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\nfrequency <- function(a, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- frequency\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3, 3, 3, 4), 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 1, 2), 1), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "r",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ntext_lowercase_underscore <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_lowercase_underscore\n    stopifnot(isTRUE(all.equal(candidate('aab_cbbbc'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aab_Abbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Aaab_abbbc'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "r",
+    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\nsum_range_list <- function(list1, m, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_range_list\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 8, 10), 29)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 5, 7), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12), 7, 10), 38)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "r",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\nperimeter_pentagon <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- perimeter_pentagon\n    stopifnot(isTRUE(all.equal(candidate(5), 25)))\n    stopifnot(isTRUE(all.equal(candidate(10), 50)))\n    stopifnot(isTRUE(all.equal(candidate(15), 75)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "r",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ncount_occurance <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_occurance\n    stopifnot(isTRUE(all.equal(candidate('letstdlenstdporstd'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('truststdsolensporsd'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('makestdsostdworthit'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('stds'), 1)))\n    stopifnot(isTRUE(all.equal(candidate(''), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "r",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\nsquare_perimeter <- function(a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_perimeter\n    stopifnot(isTRUE(all.equal(candidate(10), 40)))\n    stopifnot(isTRUE(all.equal(candidate(5), 20)))\n    stopifnot(isTRUE(all.equal(candidate(4), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "r",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\nremove_dirty_chars <- function(string, second_string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_dirty_chars\n    stopifnot(isTRUE(all.equal(candidate('probasscurve', 'pros'), 'bacuve')))\n    stopifnot(isTRUE(all.equal(candidate('digitalindia', 'talent'), 'digiidi')))\n    stopifnot(isTRUE(all.equal(candidate('exoticmiles', 'toxic'), 'emles')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "r",
+    "prompt": "# Write a function to find whether a given vector of integers contains any duplicate element.\ntest_duplicate <- function(arraynums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- test_duplicate\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2, 3, 3, 4, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "r",
+    "prompt": "# Write a function to check if the given number is woodball or not.\nis_woodall <- function(x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_woodall\n    stopifnot(isTRUE(all.equal(candidate(383), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(254), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(200), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "r",
+    "prompt": "# Write a function to check if all the elements in list have same data type or not.\ncheck_type <- function(test_tuple) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_type\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 3, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, '4')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "r",
+    "prompt": "# Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nis_majority <- function(arr, n, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_majority\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 3, 3, 3, 10), 7, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 4, 4, 4, 6, 6), 8, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 2), 5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 2), 5, 1), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of set bits (binary digits with value 1) in a given number.\ncount_Set_Bits <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Set_Bits\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(6), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "r",
+    "prompt": "# Write a rthon function to remove the characters which have odd index values of a given string.\nodd_values_string <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_values_string\n    stopifnot(isTRUE(all.equal(candidate('abcdef'), 'ace')))\n    stopifnot(isTRUE(all.equal(candidate('python'), 'pto')))\n    stopifnot(isTRUE(all.equal(candidate('data'), 'dt')))\n    stopifnot(isTRUE(all.equal(candidate('lambs'), 'lms')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "r",
+    "prompt": "# Write a function to find minimum of three numbers.\nmin_of_three <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_of_three\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(19, 15, 18), 15)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -20, -30), -30)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether all the bits are unset in the given range or not.\nall_Bits_Set_In_The_Given_Range <- function(n, l, r) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_Bits_Set_In_The_Given_Range\n    stopifnot(isTRUE(all.equal(candidate(4, 1, 2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(17, 2, 4), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(39, 4, 6), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "r",
+    "prompt": "# Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nre_arrange_array <- function(arr, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- re_arrange_array\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, -3, 4, 5, 6, -7, 8, 9), 9), c(-1, -3, -7, 4, 5, 6, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, -14, -26, 13, 15), 5), c(-14, -26, 12, 13, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 24, 36, -42, -39, -78, 85), 7), c(-42, -39, -78, 10, 24, 36, 85))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "r",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nreplace_blank <- function(str1, char) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_blank\n    stopifnot(isTRUE(all.equal(candidate('hello people', '@'), 'hello@people')))\n    stopifnot(isTRUE(all.equal(candidate('python program language', '$'), 'python$program$language')))\n    stopifnot(isTRUE(all.equal(candidate('blank space', '-'), 'blank-space')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "r",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\nvolume_cube <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- volume_cube\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(2), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5), 125)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list of lists and returns a named list mapping each unique list to the number of times it occurs in the list.\ncheck_occurences <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_occurences\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 1), c(1, 3), c(2, 5), c(5, 2), c(6, 3))), list(c(1, 3) = 2, c(2, 5) = 2, c(3, 6) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 2), c(2, 4), c(3, 6), c(6, 3), c(7, 4))), list(c(2, 4) = 2, c(3, 6) = 2, c(4, 7) = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(13, 2), c(11, 23), c(12, 25), c(25, 12), c(16, 23))), list(c(2, 13) = 1, c(11, 23) = 1, c(12, 25) = 2, c(16, 23) = 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of non-empty substrings of a given string.\nnumber_of_substrings <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- number_of_substrings\n    stopifnot(isTRUE(all.equal(candidate('abc'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 10)))\n    stopifnot(isTRUE(all.equal(candidate('abcde'), 15)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "r",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nget_total_number_of_sequences <- function(m, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_total_number_of_sequences\n    stopifnot(isTRUE(all.equal(candidate(10, 4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(5, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(16, 3), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "r",
+    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nreplace_list <- function(list1, list2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 10), c(2, 4, 6, 8)), c(1, 3, 5, 7, 9, 2, 4, 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8)), c(1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'blue', 'green'), c('yellow')), c('red', 'blue', 'yellow'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "r",
+    "prompt": "# Write a function to count the total number of characters in a string.\ncount_charac <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_charac\n    stopifnot(isTRUE(all.equal(candidate('python programming'), 18)))\n    stopifnot(isTRUE(all.equal(candidate('language'), 8)))\n    stopifnot(isTRUE(all.equal(candidate('words'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the next perfect square greater than a given number.\nnext_Perfect_Square <- function(N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- next_Perfect_Square\n    stopifnot(isTRUE(all.equal(candidate(35), 36)))\n    stopifnot(isTRUE(all.equal(candidate(6), 9)))\n    stopifnot(isTRUE(all.equal(candidate(9), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "r",
+    "prompt": "# Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nmax_sum <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 15, 51, 45, 33, 100, 12, 18, 9)), 194)))\n    stopifnot(isTRUE(all.equal(candidate(c(80, 60, 30, 40, 20, 10)), 210)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 14, 16, 21, 23, 29, 30)), 138)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "r",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\nlps <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- lps\n    stopifnot(isTRUE(all.equal(candidate('TENS FOR TENS'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('CARDIO FOR CARDS'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('PART OF THE JOURNEY IS PART'), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "r",
+    "prompt": "# Write a function to find the intersection of two vectors.\nintersection_array <- function(array_nums1, array_nums2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- intersection_array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(1, 2, 4, 8, 9)), c(1, 2, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(3, 5, 7, 9)), c(3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 7, 8, 9, 10), c(10, 20, 30, 40)), c(10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "r",
+    "prompt": "# Write a rthon function that takes in a list and an element and counts the occcurences of the element in the list.\ncount_X <- function(tup, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_X\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 10), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2), 8), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ninsert_element <- function(list, element) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- insert_element\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Black'), 'c'), c('c', 'Red', 'c', 'Green', 'c', 'Black'))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java'), 'program'), c('program', 'python', 'program', 'java'))))\n    stopifnot(isTRUE(all.equal(candidate(c('happy', 'sad'), 'laugh'), c('laugh', 'happy', 'laugh', 'sad'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "r",
+    "prompt": "# Write a rthon function to convert complex numbers to polar coordinates.\nconvert <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- convert\n    stopifnot(isTRUE(all.equal(candidate(1), c(1.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(4), c(4.0, 0.0))))\n    stopifnot(isTRUE(all.equal(candidate(5), c(5.0, 0.0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "r",
+    "prompt": "# Write a rthon function that returns the number of integer elements in a given list.\ncount_integer <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_integer\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 'abc', 1.2)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1.2, 4, 5.1)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ncombinations_colors <- function(l, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- combinations_colors\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 1), list(c('Red'), c('Green'), c('Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 2), list(c('Red', 'Red'), c('Red', 'Green'), c('Red', 'Blue'), c('Green', 'Green'), c('Green', 'Blue'), c('Blue', 'Blue')))))\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue'), 3), list(c('Red', 'Red', 'Red'), c('Red', 'Red', 'Green'), c('Red', 'Red', 'Blue'), c('Red', 'Green', 'Green'), c('Red', 'Green', 'Blue'), c('Red', 'Blue', 'Blue'), c('Green', 'Green', 'Green'), c('Green', 'Green', 'Blue'), c('Green', 'Blue', 'Blue'), c('Blue', 'Blue', 'Blue')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "r",
+    "prompt": "# Write a rthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ncount_Primes_nums <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Primes_nums\n    stopifnot(isTRUE(all.equal(candidate(5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 4)))\n    stopifnot(isTRUE(all.equal(candidate(100), 25)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "r",
+    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\nswap_numbers <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_numbers\n    stopifnot(isTRUE(all.equal(candidate(10, 20), c(20, 10))))\n    stopifnot(isTRUE(all.equal(candidate(15, 17), c(17, 15))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(200, 100))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5035,7 +979,7 @@
     "language": "r",
     "prompt": "# Write a function to maximize the given two lists.\nmaximize_elements <- function(test_tup1, test_tup2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- maximize_elements\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 7), c(4, 9), c(2, 9), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(7, 8), c(5, 10), c(3, 10), c(8, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(8, 9), c(6, 11), c(4, 11), c(9, 12)))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -5044,78 +988,78 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "r",
-    "prompt": "# Write a rthon function to check whether every even index contains even numbers of a given list.\neven_position <- function(nums) {",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nnewman_prime <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- even_position\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4)), TRUE)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- newman_prime\n    stopifnot(isTRUE(all.equal(candidate(3), 7)))\n    stopifnot(isTRUE(all.equal(candidate(4), 17)))\n    stopifnot(isTRUE(all.equal(candidate(5), 41)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "r",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ncheck_char <- function(string) {",
+    "prompt": "# Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\ndivision_elements <- function(test_tup1, test_tup2) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- check_char\n    stopifnot(isTRUE(all.equal(candidate('abba'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'Invalid')))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- division_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(2, 2, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 16), c(6, 3, 4, 4)), c(2, 2, 2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(20, 14, 36, 18), c(5, 7, 6, 9)), c(4, 2, 6, 2))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "r",
-    "prompt": "# Write a rthon function to find the sum of even factors of a number.\nsumofFactors <- function(n) {",
+    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\nsplit_two_parts <- function(list1, L) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- sumofFactors\n    stopifnot(isTRUE(all.equal(candidate(18), 26)))\n    stopifnot(isTRUE(all.equal(candidate(30), 48)))\n    stopifnot(isTRUE(all.equal(candidate(6), 8)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_two_parts\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), list(c(1, 1, 2), c(3, 4, 4, 5, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 2), list(c('a', 'b'), c('c', 'd')))))\n    stopifnot(isTRUE(all.equal(candidate(c('p', 'y', 't', 'h', 'o', 'n'), 4), list(c('p', 'y', 't', 'h'), c('o', 'n')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "r",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nlateralsurface_cone <- function(r, h) {",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndog_age <- function(h_age) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cone\n    stopifnot(isTRUE(all.equal(candidate(5, 12), 204.20352248333654)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 566.3586699569488)))\n    stopifnot(isTRUE(all.equal(candidate(19, 17), 1521.8090132193388)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- dog_age\n    stopifnot(isTRUE(all.equal(candidate(12), 61)))\n    stopifnot(isTRUE(all.equal(candidate(15), 73)))\n    stopifnot(isTRUE(all.equal(candidate(24), 109)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "r",
-    "prompt": "# Write a rthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ncount_Pairs <- function(arr, n) {",
+    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nlist_split <- function(S, step) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- count_Pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 5), 10)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- list_split\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'), 3), list(c('a', 'd', 'g', 'j', 'm'), c('b', 'e', 'h', 'k', 'n'), c('c', 'f', 'i', 'l')))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), 3), list(c(1, 4, 7, 10, 13), c(2, 5, 8, 11, 14), c(3, 6, 9, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'java', 'C', 'C++', 'DBMS', 'SQL'), 2), list(c('python', 'C', 'DBMS'), c('java', 'C++', 'SQL')))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "r",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted vector.\nfind_first_occurrence <- function(A, x) {",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\nlateralsurface_cube <- function(l) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- find_first_occurrence\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6), 4)))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 100)))\n    stopifnot(isTRUE(all.equal(candidate(9), 324)))\n    stopifnot(isTRUE(all.equal(candidate(10), 400)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5126,9 +1070,789 @@
     "language": "r",
     "prompt": "# Write a rthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nsquare_Sum <- function(n) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 10)))\n    stopifnot(isTRUE(all.equal(candidate(3), 35)))\n    stopifnot(isTRUE(all.equal(candidate(4), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "r",
+    "prompt": "# Write a function to find the n'th star number.\nfind_star_num <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_star_num\n    stopifnot(isTRUE(all.equal(candidate(3), 37)))\n    stopifnot(isTRUE(all.equal(candidate(4), 73)))\n    stopifnot(isTRUE(all.equal(candidate(5), 121)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "r",
+    "prompt": "# Write a function to find the ascii value of a character.\nascii_value <- function(k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- ascii_value\n    stopifnot(isTRUE(all.equal(candidate('A'), 65)))\n    stopifnot(isTRUE(all.equal(candidate('R'), 82)))\n    stopifnot(isTRUE(all.equal(candidate('S'), 83)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of even numbers at even positions of a list.\nsum_even_and_even_index <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_even_and_even_index\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1, 18, 8)), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 20, 17, 9, 2, 10, 18, 13, 6, 18)), 26)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 12, 1)), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "r",
+    "prompt": "# Write a rthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\neven_Power_Sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_Power_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 1056)))\n    stopifnot(isTRUE(all.equal(candidate(3), 8832)))\n    stopifnot(isTRUE(all.equal(candidate(1), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list of lists and returns a list containing the rear element of each list.\nrear_extract <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rear_extract\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Rash', 21), list(2, 'Varsha', 20), list(3, 'Kil', 19))), c(21, 20, 19))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sai', 36), list(2, 'Ayesha', 25), list(3, 'Salman', 45))), c(36, 25, 45))))\n    stopifnot(isTRUE(all.equal(candidate(list(list(1, 'Sudeep', 14), list(2, 'Vandana', 36), list(3, 'Dawood', 56))), c(14, 36, 56))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "r",
+    "prompt": "# Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\nsubstract_elements <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- substract_elements\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5), c(2, 5, 18)), c(8, -1, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 2, 3), c(24, 45, 16)), c(-13, -43, -13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 18, 9), c(10, 11, 12)), c(-3, 7, -3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "r",
+    "prompt": "# Write a rthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\neven_binomial_Coeff_Sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_binomial_Coeff_Sum\n    stopifnot(isTRUE(all.equal(candidate(4), 8)))\n    stopifnot(isTRUE(all.equal(candidate(6), 32)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "r",
+    "prompt": "# Write a function that takes in a named list and integer n and filters the named list to only include entries with values greater than or equal to n.\ndict_filter <- function(dict, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- dict_filter\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 170), list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 180), list('Alden Cantrell' = 180, 'Pierre Cox' = 190))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 175, 'Alden Cantrell' = 180, 'Kierra Gentry' = 165, 'Pierre Cox' = 190), 190), list('Pierre Cox' = 190))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "r",
+    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given list.\ncount_first_elements <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_first_elements\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 9, c(5, 7), 11)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(11, 15, 5, 8, c(2, 3), 8)), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth decagonal number.\nis_num_decagonal <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_num_decagonal\n    stopifnot(isTRUE(all.equal(candidate(3), 27)))\n    stopifnot(isTRUE(all.equal(candidate(7), 175)))\n    stopifnot(isTRUE(all.equal(candidate(10), 370)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "r",
+    "prompt": "# Write a function that takes in a vector and element and returns a list containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nsequential_search <- function(dlist, item) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sequential_search\n    stopifnot(isTRUE(all.equal(candidate(c(11, 23, 58, 31, 56, 77, 43, 12, 65, 19), 31), list(TRUE, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 32, 45, 62, 35, 47, 44, 61), 61), list(TRUE, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 10, 17, 19, 22, 39, 48, 56), 48), list(TRUE, 6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "r",
+    "prompt": "# Write a rthon function to check if the elements of a given list are unique or not.\nall_unique <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_unique\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "r",
+    "prompt": "# Write a function to subtract two lists element-wise.\nsub_list <- function(nums1, nums2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sub_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), c(-3, -3, -3))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2), c(3, 4)), c(-2, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(40, 50))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "r",
+    "prompt": "# Write a rthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nvalidate <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- validate\n    stopifnot(isTRUE(all.equal(candidate(1234), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(51241), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(321), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "r",
+    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ncheck_element <- function(list, element) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_element\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'orange', 'black', 'white'), 'blue'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('green', 'green', 'green', 'green'), 'green'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "r",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ntext_match_two_three <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_two_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "r",
+    "prompt": "# Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nmax_sub_array_sum_repeated <- function(a, n, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum_repeated\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -30, -1), 4, 3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 10, 20), 3, 2), 59)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, -3), 3, 3), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "r",
+    "prompt": "# Write a rthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nsquare_Sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 20)))\n    stopifnot(isTRUE(all.equal(candidate(3), 56)))\n    stopifnot(isTRUE(all.equal(candidate(4), 120)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "r",
+    "prompt": "# Write a function to find the list of maximum length in a list of lists.\nmax_length <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_length\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(5, 7), c(10, 12, 14, 15))), list(4, c(10, 12, 14, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5), c(15, 20, 25))), list(3, c(15, 20, 25)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "r",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ncount_no_of_ways <- function(n, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_no_of_ways\n    stopifnot(isTRUE(all.equal(candidate(2, 4), 16)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(4, 4), 228)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "r",
+    "prompt": "# Write a rthon function to find quotient of two numbers (rounded down to the nearest integer).\nfind <- function(n, m) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find\n    stopifnot(isTRUE(all.equal(candidate(10, 3), 3)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(20, 5), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "r",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\notherside_rightangle <- function(w, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- otherside_rightangle\n    stopifnot(isTRUE(all.equal(candidate(7, 8), 10.63014581273465)))\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(7, 15), 16.55294535724685)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\nmax_val <- function(listval) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 5)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 25)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 50)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "r",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\nsum_div <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_div\n    stopifnot(isTRUE(all.equal(candidate(8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(12), 16)))\n    stopifnot(isTRUE(all.equal(candidate(7), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "r",
+    "prompt": "# Write a rthon function to count inversions in a vector.\nget_Inv_Count <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_Inv_Count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 20, 6, 4, 5)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 5, 6, 1)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "r",
+    "prompt": "# Write a function to flatten a given nested list structure.\nflatten_list <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- flatten_list\n    stopifnot(isTRUE(all.equal(candidate(list(0, 10, c(20, 30), 40, 50, c(60, 70, 80), c(90, 100, 110, 120))), c(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(40), c(30, 56, 25), c(10, 20), c(33), c(40))), c(10, 20, 40, 30, 56, 25, 10, 20, 33, 40))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "r",
+    "prompt": "# Write a function to calculate the maximum aggregate from the list of lists.\nmax_aggregate <- function(stdata) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_aggregate\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 90), list('Sabah Colley', 88), list('Peter Nichols', 7), list('Juan Whelan', 122), list('Sabah Colley', 84))), list('Juan Whelan', 212))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 50), list('Sabah Colley', 48), list('Peter Nichols', 37), list('Juan Whelan', 22), list('Sabah Colley', 14))), list('Juan Whelan', 72))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Juan Whelan', 10), list('Sabah Colley', 20), list('Peter Nichols', 30), list('Juan Whelan', 40), list('Sabah Colley', 50))), list('Sabah Colley', 70))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "r",
+    "prompt": "# Write a rthon function to find element at a given index after number of rotations.\nfind_Element <- function(arr, ranges, rotations, index) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), list(c(0, 2), c(0, 3)), 2, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), list(c(0, 1), c(0, 2)), 1, 2), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), list(c(0, 1), c(0, 2)), 1, 1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "r",
+    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\nstart_withp <- function(words) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- start_withp\n    stopifnot(isTRUE(all.equal(candidate(c('Python PHP', 'Java JavaScript', 'c c++')), c('Python', 'PHP'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python Programming', 'Java Programming')), c('Python', 'Programming'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Pqrst Pqr', 'qrstuv')), c('Pqrst', 'Pqr'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nmax_sum_increasing_subseq <- function(a, n, index, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_increasing_subseq\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 4, 6), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 101, 2, 3, 100, 4, 5), 7, 2, 5), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 15, 19, 21, 26, 28, 31), 7, 2, 4), 71)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "r",
+    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nlarge_product <- function(nums1, nums2, N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- large_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 3), c(60, 54, 50))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 4), c(60, 54, 50, 48))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(3, 6, 8, 9, 10, 6), 5), c(60, 54, 50, 48, 45))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the maximum of two numbers.\nmaximum <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- maximum\n    stopifnot(isTRUE(all.equal(candidate(5, 10), 10)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2), -1)))\n    stopifnot(isTRUE(all.equal(candidate(9, 7), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "r",
+    "prompt": "# Write a function to convert a given string to a list of characters.\nstring_to_tuple <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- string_to_tuple\n    stopifnot(isTRUE(all.equal(candidate('python 3.0'), c('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0'))))\n    stopifnot(isTRUE(all.equal(candidate('item1'), c('i', 't', 'e', 'm', '1'))))\n    stopifnot(isTRUE(all.equal(candidate('15.10'), c('1', '5', '.', '1', '0'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the highest power of 2 that is less than or equal to n.\nhighest_Power_of_2 <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- highest_Power_of_2\n    stopifnot(isTRUE(all.equal(candidate(10), 8)))\n    stopifnot(isTRUE(all.equal(candidate(19), 16)))\n    stopifnot(isTRUE(all.equal(candidate(32), 32)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "r",
+    "prompt": "# Write a function to find the n'th lucas number.\nfind_lucas <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_lucas\n    stopifnot(isTRUE(all.equal(candidate(9), 76)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(3), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "r",
+    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\nadd_string <- function(list_, string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_string\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 'temp{0}'), c('temp1', 'temp2', 'temp3', 'temp4'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c', 'd'), 'python{0}'), c('pythona', 'pythonb', 'pythonc', 'pythond'))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 8), 'string{0}'), c('string5', 'string6', 'string7', 'string8'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "r",
+    "prompt": "# Write a function to convert more than one list to nested named list.\nconvert_list_dictionary <- function(l1, l2, l3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- convert_list_dictionary\n    stopifnot(isTRUE(all.equal(candidate(c('S001', 'S002', 'S003', 'S004'), c('Adina Park', 'Leyton Marsh', 'Duncan Boyle', 'Saim Richards'), c(85, 98, 89, 92)), list(list('S001' = list('Adina Park' = 85)), list('S002' = list('Leyton Marsh' = 98)), list('S003' = list('Duncan Boyle' = 89)), list('S004' = list('Saim Richards' = 92))))))\n    stopifnot(isTRUE(all.equal(candidate(c('abc', 'def', 'ghi', 'jkl'), c('python', 'program', 'language', 'programs'), c(100, 200, 300, 400)), list(list('abc' = list('python' = 100)), list('def' = list('program' = 200)), list('ghi' = list('language' = 300)), list('jkl' = list('programs' = 400))))))\n    stopifnot(isTRUE(all.equal(candidate(c('A1', 'A2', 'A3', 'A4'), c('java', 'C', 'C++', 'DBMS'), c(10, 20, 30, 40)), list(list('A1' = list('java' = 10)), list('A2' = list('C' = 20)), list('A3' = list('C++' = 30)), list('A4' = list('DBMS' = 40))))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nget_max_sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_max_sum\n    stopifnot(isTRUE(all.equal(candidate(60), 106)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "r",
+    "prompt": "# Write a function to find the list with maximum length.\nmax_length_list <- function(input_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_length_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(0), c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), list(3, c(13, 15, 17)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4, 5), c(1, 2, 3, 4), c(1, 2, 3), c(1, 2), c(1))), list(5, c(1, 2, 3, 4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(6, 7, 8, 9), c(10, 11, 12))), list(4, c(6, 7, 8, 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "r",
+    "prompt": "# Write a function to check if given list contains no duplicates.\ncheck_distinct <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_distinct\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6, 1, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the first non-repeated character in a given string.\nfirst_non_repeating_character <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_non_repeating_character\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('ababc'), 'c')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ncheck_char <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_char\n    stopifnot(isTRUE(all.equal(candidate('abba'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('a'), 'Valid')))\n    stopifnot(isTRUE(all.equal(candidate('abcd'), 'Invalid')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "r",
+    "prompt": "# Write a function to find the median of three numbers.\nmedian_numbers <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- median_numbers\n    stopifnot(isTRUE(all.equal(candidate(25, 55, 65), 55.0)))\n    stopifnot(isTRUE(all.equal(candidate(20, 10, 30), 20.0)))\n    stopifnot(isTRUE(all.equal(candidate(15, 45, 75), 45.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "r",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\nsum_of_digits <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_of_digits\n    stopifnot(isTRUE(all.equal(candidate(c(10, 2, 56)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(list(list(10, 20, 4, 5, 'b', 70, 'a'))), 19)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, -4, 5, -70)), 19)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "r",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given lists.\nbitwise_xor <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- bitwise_xor\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(15, 6, 5, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 7, 10), c(6, 3, 4, 4)), c(13, 6, 3, 14))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 8, 11), c(7, 4, 5, 6)), c(11, 2, 13, 13))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "r",
+    "prompt": "# Write a rthon function to identify non-prime numbers.\nis_not_prime <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_not_prime\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(35), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(37), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "r",
+    "prompt": "# Write a function to extract the number of unique lists in the given list.\nextract_freq <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_freq\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4), c(1, 2), c(4, 3), c(5, 6))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 15), c(2, 3), c(5, 4), c(6, 7))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 16), c(2, 3), c(6, 5), c(6, 9))), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "r",
+    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\nadd_nested_tuples <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_nested_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(7, 10), c(7, 14), c(3, 10), c(8, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(9, 12), c(9, 16), c(5, 12), c(10, 15)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(11, 14), c(11, 18), c(7, 14), c(12, 17)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the minimum of two numbers.\nminimum <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- minimum\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(-5, -4), -5)))\n    stopifnot(isTRUE(all.equal(candidate(0, 0), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "r",
+    "prompt": "# Write a function to check whether an element exists within a list.\ncheck_tuplex <- function(tuplex, tuple1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_tuplex\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 'r'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), '5'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('w', 3, 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e'), 3), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "r",
+    "prompt": "# Write a rthon function to find whether the parity of a given number is odd.\nfind_Parity <- function(x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Parity\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "r",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\nrearrange_bigger <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rearrange_bigger\n    stopifnot(isTRUE(all.equal(candidate(12), 21)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(102), 120)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "r",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nk_smallest_pairs <- function(nums1, nums2, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- k_smallest_pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 2), list(c(1, 2), c(1, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 1), list(c(1, 2)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 7), c(2, 4, 6), 7), list(c(1, 2), c(1, 4), c(3, 2), c(1, 6), c(3, 4), c(3, 6), c(7, 2)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "r",
+    "prompt": "# Write a function to find the minimum product from the pairs of lists within a given list.\nmin_product_tuple <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_product_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 7), c(2, 6), c(1, 8), c(4, 9))), 8)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 20), c(15, 2), c(5, 10))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 44), c(10, 15), c(20, 5), c(12, 9))), 100)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "r",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\nmin_val <- function(listval) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_val\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 3, 2, 4, 5, 'version')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 15, 20, 25)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list('Python', 30, 20, 40, 50, 'version')), 20)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "r",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\nsnake_to_camel <- function(word) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- snake_to_camel\n    stopifnot(isTRUE(all.equal(candidate('android_tv'), 'AndroidTv')))\n    stopifnot(isTRUE(all.equal(candidate('google_pixel'), 'GooglePixel')))\n    stopifnot(isTRUE(all.equal(candidate('apple_watch'), 'AppleWatch')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "r",
+    "prompt": "# Write a rthon function to remove odd numbers from a given list.\nremove_odd <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 6)), c(2, 4, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 3)), c(10, 20))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "r",
+    "prompt": "# Write a function to extract the nth element from a given list of lists.\nextract_nth_element <- function(list1, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_nth_element\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 0), c('Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull'))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 2), c(99, 96, 94, 98))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Greyson Fulton', 98, 99), list('Brady Kent', 97, 96), list('Wyatt Knott', 91, 94), list('Beau Turnbull', 94, 98)), 1), c(98, 97, 91, 94))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether any value in a sequence exists in a sequence or not.\noverlapping <- function(list1, list2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- overlapping\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(4, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 5), c(1, 4, 5)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "r",
+    "prompt": "# Write a rthon function to find a pair with highest product from a given vector of integers.\nmax_Product <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_Product\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 7, 0, 8, 4)), c(7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, -1, -2, -4, 5, 0, -6)), c(-4, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(2, 3))))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"
@@ -5139,7 +1863,7 @@
     "language": "r",
     "prompt": "# Write a function to find common first element in given list of lists.\ngroup_tuples <- function(Input) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "test_humaneval <- function() {\n    candidate <- group_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('x', 'z'), c('w', 't'))), list(c('x', 'y', 'z'), c('w', 't')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('a', 'c'), c('d', 'e'))), list(c('a', 'b', 'c'), c('d', 'e')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('f', 'g'), c('f', 'g'), c('h', 'i'))), list(c('f', 'g', 'g'), c('h', 'i')))))\n}\ntest_humaneval()",
     "stop_tokens": [
@@ -5148,13 +1872,3289 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "r",
-    "prompt": "# Write a function to merge three lists into a single sorted list.\nmerge_sorted_list <- function(num1, num2, num3) {",
+    "prompt": "# Write a rthon function to find the element of a list having maximum length.\nFind_Max <- function(lst) {",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "test_humaneval <- function() {\n    candidate <- merge_sorted_list\n    stopifnot(isTRUE(all.equal(candidate(c(25, 24, 15, 4, 5, 29, 110), c(19, 20, 11, 56, 25, 233, 154), c(24, 26, 54, 48)), c(4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 6, 8, 9), c(2, 5, 7, 11), c(1, 4, 7, 8, 12)), c(1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1), c(25, 35, 22, 85, 14, 65, 75, 25, 58), c(12, 74, 9, 50, 61, 41)), c(1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85))))\n}\ntest_humaneval()",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max\n    stopifnot(isTRUE(all.equal(candidate(list(c('A'), c('A', 'B'), c('A', 'B', 'C'))), c('A', 'B', 'C'))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 2, 3), c(1, 5, 6, 1))), c(1, 5, 6, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "r",
+    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nround_and_sum <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- round_and_sum\n    stopifnot(isTRUE(all.equal(candidate(c(22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5)), 243)))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 2, 9, 24.3, 29)), 345)))\n    stopifnot(isTRUE(all.equal(candidate(c(25.0, 56.7, 89.2)), 513)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the cube sum of first n even natural numbers.\ncube_Sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- cube_Sum\n    stopifnot(isTRUE(all.equal(candidate(2), 72)))\n    stopifnot(isTRUE(all.equal(candidate(3), 288)))\n    stopifnot(isTRUE(all.equal(candidate(4), 800)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "r",
+    "prompt": "# Write a function to concatenate each element of list by the delimiter.\nconcatenate_tuple <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- concatenate_tuple\n    stopifnot(isTRUE(all.equal(candidate(list('ID', 'is', 4, 'UTS')), 'ID-is-4-UTS')))\n    stopifnot(isTRUE(all.equal(candidate(list('QWE', 'is', 4, 'RTY')), 'QWE-is-4-RTY')))\n    stopifnot(isTRUE(all.equal(candidate(list('ZEN', 'is', 4, 'OP')), 'ZEN-is-4-OP')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the average of cubes of first n natural numbers.\nfind_Average_Of_Cube <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Average_Of_Cube\n    stopifnot(isTRUE(all.equal(candidate(2), 4.5)))\n    stopifnot(isTRUE(all.equal(candidate(3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "r",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given list.\nextract_rear <- function(test_tuple) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_rear\n    stopifnot(isTRUE(all.equal(candidate(c('Mers', 'for', 'Vers')), c('s', 'r', 's'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Avenge', 'for', 'People')), c('e', 'r', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Gotta', 'get', 'go')), c('a', 't', 'o'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "r",
+    "prompt": "# Write a function to count the number of sublists containing a particular element.\ncount_element_in_list <- function(list1, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_element_in_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(1, 11), c(1, 15, 7)), 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'A'), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c('A', 'B'), c('A', 'C'), c('A', 'D', 'E'), c('B', 'C', 'D')), 'E'), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "r",
+    "prompt": "# Write a function to filter odd numbers.\nfilter_oddnumbers <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_oddnumbers\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 3, 5, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 45, 67, 84, 93)), c(45, 67, 93))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 7, 9, 8, 6, 4, 3)), c(5, 7, 9, 3))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "r",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nchange_date_format <- function(dt) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- change_date_format\n    stopifnot(isTRUE(all.equal(candidate('2026-01-02'), '02-01-2026')))\n    stopifnot(isTRUE(all.equal(candidate('2020-11-13'), '13-11-2020')))\n    stopifnot(isTRUE(all.equal(candidate('2021-04-26'), '26-04-2021')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort the given vector by using shell sort.\nshell_sort <- function(my_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- shell_sort\n    stopifnot(isTRUE(all.equal(candidate(c(12, 23, 4, 5, 3, 2, 12, 81, 56, 95)), c(2, 3, 4, 5, 12, 12, 23, 56, 81, 95))))\n    stopifnot(isTRUE(all.equal(candidate(c(24, 22, 39, 34, 87, 73, 68)), c(22, 24, 34, 39, 68, 73, 87))))\n    stopifnot(isTRUE(all.equal(candidate(c(32, 30, 16, 96, 82, 83, 74)), c(16, 30, 32, 74, 82, 83, 96))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "r",
+    "prompt": "# Write a function to extract the elementwise and lists from the given two lists.\nand_tuples <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- and_tuples\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 6, 9), c(5, 2, 3, 3)), c(0, 0, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(5, 6, 7, 8)), c(1, 2, 3, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 11, 12), c(7, 13, 14, 17)), c(0, 9, 10, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "r",
+    "prompt": "# Write a function to find the directrix of a parabola.\nparabola_directrix <- function(a, b, c) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- parabola_directrix\n    stopifnot(isTRUE(all.equal(candidate(5, 3, 2), -198)))\n    stopifnot(isTRUE(all.equal(candidate(9, 8, 4), -2336)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4, 6), -130)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "r",
+    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ncommon_element <- function(list1, list2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- common_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(5, 6, 7, 8, 9)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 8, 9)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'b', 'c'), c('d', 'b', 'e')), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "r",
+    "prompt": "# Write a function to find the median length of a trapezium.\nmedian_trapezium <- function(base1, base2, height) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- median_trapezium\n    stopifnot(isTRUE(all.equal(candidate(15, 25, 35), 20)))\n    stopifnot(isTRUE(all.equal(candidate(10, 20, 30), 15)))\n    stopifnot(isTRUE(all.equal(candidate(6, 9, 4), 7.5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "r",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given vector.\ncheck_greater <- function(arr, number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_greater\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 6), 8), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 7, 4, 8, 6, 1), 11), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ntext_match_one <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the last digit of a given number.\nlast_Digit <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 3)))\n    stopifnot(isTRUE(all.equal(candidate(25), 5)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "r",
+    "prompt": "# Write a rthon function to return the negative numbers in a list.\nneg_nos <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- neg_nos\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 4, 5, -6)), c(-1, -6))))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3, 4)), c(-1, -2))))\n    stopifnot(isTRUE(all.equal(candidate(c(-7, -6, 8, 9)), c(-7, -6))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "r",
+    "prompt": "# Write a function to remove odd characters in a string.\nremove_odd <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_odd\n    stopifnot(isTRUE(all.equal(candidate('python'), 'yhn')))\n    stopifnot(isTRUE(all.equal(candidate('program'), 'rga')))\n    stopifnot(isTRUE(all.equal(candidate('language'), 'agae')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "r",
+    "prompt": "# Write a function to count bidirectional list pairs.\ncount_bidirectional <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_bidirectional\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 3), c(6, 5), c(9, 1), c(6, 5), c(2, 1))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6), c(1, 2), c(6, 5), c(9, 2), c(6, 5), c(2, 1))), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "r",
+    "prompt": "# Write a function to join a list of multiple integers into a single integer.\nmultiple_to_single <- function(L) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiple_to_single\n    stopifnot(isTRUE(all.equal(candidate(c(11, 33, 50)), 113350)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4, 5, 6)), -123456)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25)), 10152025)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "r",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\nfind_adverb_position <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_adverb_position\n    stopifnot(isTRUE(all.equal(candidate('clearly!! we can see the sky'), list(0, 7, 'clearly'))))\n    stopifnot(isTRUE(all.equal(candidate('seriously!! there are many roses'), list(0, 9, 'seriously'))))\n    stopifnot(isTRUE(all.equal(candidate('unfortunately!! sita is going to home'), list(0, 13, 'unfortunately'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "r",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\nsurfacearea_cube <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cube\n    stopifnot(isTRUE(all.equal(candidate(5), 150)))\n    stopifnot(isTRUE(all.equal(candidate(3), 54)))\n    stopifnot(isTRUE(all.equal(candidate(10), 600)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "r",
+    "prompt": "# Write a function to find the ration of positive numbers in a vector of integers.\npositive_count <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- positive_count\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8)), 0.54)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 0.69)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17)), 0.56)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the largest negative number from the given list.\nlargest_neg <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- largest_neg\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -4, -6)), -6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, -8, -9)), -9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, -1)), -1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "r",
+    "prompt": "# Write a function to trim each list by k in the given lists.\ntrim_tuple <- function(test_list, K) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- trim_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 2), list(c(2), c(9), c(2), c(2)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 3, 2, 1, 4), c(3, 4, 9, 2, 1), c(9, 1, 2, 3, 5), c(4, 8, 2, 1, 7)), 1), list(c(3, 2, 1), c(4, 9, 2), c(1, 2, 3), c(8, 2, 1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 4, 9), c(11, 8, 12, 4), c(4, 1, 7, 8), c(3, 6, 9, 7)), 1), list(c(8, 4), c(8, 12), c(1, 7), c(6, 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "r",
+    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\nindex_multiplication <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- index_multiplication\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(4, 5), c(2, 9), c(1, 10)), list(c(6, 7), c(3, 9), c(1, 1), c(7, 3))), list(c(6, 21), c(12, 45), c(2, 9), c(7, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(5, 6), c(3, 10), c(2, 11)), list(c(7, 8), c(4, 10), c(2, 2), c(8, 4))), list(c(14, 32), c(20, 60), c(6, 20), c(16, 44)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(6, 7), c(4, 11), c(3, 12)), list(c(8, 9), c(5, 11), c(3, 3), c(9, 5))), list(c(24, 45), c(30, 77), c(12, 33), c(27, 60)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the occurence of all elements of list in a list.\ncount_Occurrence <- function(tup, lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Occurrence\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'c', 'b', 'd'), c('a', 'b')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 4, 6, 7, 1, 4), c(1, 4, 7)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), c(1, 2)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "r",
+    "prompt": "# Write a function to find cubes of individual elements in a list.\ncube_nums <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- cube_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(1728, 3375))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\ncal_sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- cal_sum\n    stopifnot(isTRUE(all.equal(candidate(9), 49)))\n    stopifnot(isTRUE(all.equal(candidate(10), 66)))\n    stopifnot(isTRUE(all.equal(candidate(11), 88)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "r",
+    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\nextract_string <- function(str, l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_string\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 8), c('practice', 'solution'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 6), c('Python'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Python', 'list', 'exercises', 'practice', 'solution'), 9), c('exercises'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "r",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\nremove_whitespaces <- function(text1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_whitespaces\n    stopifnot(isTRUE(all.equal(candidate(' Google    Flutter '), 'GoogleFlutter')))\n    stopifnot(isTRUE(all.equal(candidate(' Google    Dart '), 'GoogleDart')))\n    stopifnot(isTRUE(all.equal(candidate(' iOS    Swift '), 'iOSSwift')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "r",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nloss_amount <- function(actual_cost, sale_amount) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- loss_amount\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), 0)))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), 100)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), 3000)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of even factors of a number.\nsumofFactors <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sumofFactors\n    stopifnot(isTRUE(all.equal(candidate(18), 26)))\n    stopifnot(isTRUE(all.equal(candidate(30), 48)))\n    stopifnot(isTRUE(all.equal(candidate(6), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "r",
+    "prompt": "# Write a function that matches a word containing 'z'.\ntext_match_wordz <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz\n    stopifnot(isTRUE(all.equal(candidate('pythonz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('xyz.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ncheck_monthnumb_number <- function(monthnum2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumb_number\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(6), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "r",
+    "prompt": "# Write a function to reverse each string in a given list of string values.\nreverse_string_list <- function(stringlist) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_string_list\n    stopifnot(isTRUE(all.equal(candidate(c('Red', 'Green', 'Blue', 'White', 'Black')), c('deR', 'neerG', 'eulB', 'etihW', 'kcalB'))))\n    stopifnot(isTRUE(all.equal(candidate(c('john', 'amal', 'joel', 'george')), c('nhoj', 'lama', 'leoj', 'egroeg'))))\n    stopifnot(isTRUE(all.equal(candidate(c('jack', 'john', 'mary')), c('kcaj', 'nhoj', 'yram'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sublist having minimum length.\nFind_Min <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2), c(1, 2, 3))), c(1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1), c(1, 1, 1), c(1, 2, 7, 8))), c(1, 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x'), c('x', 'y'), c('x', 'y', 'z'))), c('x'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "r",
+    "prompt": "# Write a function to find the area of a rectangle.\nrectangle_area <- function(l, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rectangle_area\n    stopifnot(isTRUE(all.equal(candidate(10, 20), 200)))\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 50)))\n    stopifnot(isTRUE(all.equal(candidate(4, 2), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "r",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\nremove_uppercase <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_uppercase\n    stopifnot(isTRUE(all.equal(candidate('cAstyoUrFavoRitETVshoWs'), 'cstyoravoitshos')))\n    stopifnot(isTRUE(all.equal(candidate('wAtchTheinTernEtrAdIo'), 'wtchheinerntrdo')))\n    stopifnot(isTRUE(all.equal(candidate('VoicESeaRchAndreComMendaTionS'), 'oiceachndreomendaion')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "r",
+    "prompt": "# Write a rthon function to get the first element of each sublist.\nExtract <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Extract\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4, 5), c(6, 7, 8, 9))), c(1, 3, 6))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5))), c(1, 4))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(9, 8, 1), c(1, 2))), c(9, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the upper case characters in a given string.\nupper_ctr <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- upper_ctr\n    stopifnot(isTRUE(all.equal(candidate('PYthon'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('BigData'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('program'), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "r",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ncombinations_list <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- combinations_list\n    stopifnot(isTRUE(all.equal(candidate(c('orange', 'red', 'green', 'blue')), list(c(), c('orange'), c('red'), c('red', 'orange'), c('green'), c('green', 'orange'), c('green', 'red'), c('green', 'red', 'orange'), c('blue'), c('blue', 'orange'), c('blue', 'red'), c('blue', 'red', 'orange'), c('blue', 'green'), c('blue', 'green', 'orange'), c('blue', 'green', 'red'), c('blue', 'green', 'red', 'orange')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'blue', 'white', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('blue'), c('blue', 'red'), c('blue', 'green'), c('blue', 'green', 'red'), c('white'), c('white', 'red'), c('white', 'green'), c('white', 'green', 'red'), c('white', 'blue'), c('white', 'blue', 'red'), c('white', 'blue', 'green'), c('white', 'blue', 'green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('black', 'blue'), c('black', 'blue', 'red'), c('black', 'blue', 'green'), c('black', 'blue', 'green', 'red'), c('black', 'white'), c('black', 'white', 'red'), c('black', 'white', 'green'), c('black', 'white', 'green', 'red'), c('black', 'white', 'blue'), c('black', 'white', 'blue', 'red'), c('black', 'white', 'blue', 'green'), c('black', 'white', 'blue', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'blue'), c('orange', 'blue', 'red'), c('orange', 'blue', 'green'), c('orange', 'blue', 'green', 'red'), c('orange', 'white'), c('orange', 'white', 'red'), c('orange', 'white', 'green'), c('orange', 'white', 'green', 'red'), c('orange', 'white', 'blue'), c('orange', 'white', 'blue', 'red'), c('orange', 'white', 'blue', 'green'), c('orange', 'white', 'blue', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red'), c('orange', 'black', 'blue'), c('orange', 'black', 'blue', 'red'), c('orange', 'black', 'blue', 'green'), c('orange', 'black', 'blue', 'green', 'red'), c('orange', 'black', 'white'), c('orange', 'black', 'white', 'red'), c('orange', 'black', 'white', 'green'), c('orange', 'black', 'white', 'green', 'red'), c('orange', 'black', 'white', 'blue'), c('orange', 'black', 'white', 'blue', 'red'), c('orange', 'black', 'white', 'blue', 'green'), c('orange', 'black', 'white', 'blue', 'green', 'red')))))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'black', 'orange')), list(c(), c('red'), c('green'), c('green', 'red'), c('black'), c('black', 'red'), c('black', 'green'), c('black', 'green', 'red'), c('orange'), c('orange', 'red'), c('orange', 'green'), c('orange', 'green', 'red'), c('orange', 'black'), c('orange', 'black', 'red'), c('orange', 'black', 'green'), c('orange', 'black', 'green', 'red')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum product subvector of the given vector.\nmax_subarray_product <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_subarray_product\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, -3, 0, 7, -8, -2)), 112)))\n    stopifnot(isTRUE(all.equal(candidate(c(6, -3, -10, 0, 2)), 180)))\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -40, 0, -2, -3)), 80)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "r",
+    "prompt": "# Write a function to check if all values are same in a named list.\ncheck_value <- function(dict, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_value\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 12), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = 12, 'Alden Cantrell' = 12, 'Kierra Gentry' = 12, 'Pierre Cox' = 12), 5), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "r",
+    "prompt": "# Write a function to drop empty items from a given named list.\ndrop_empty <- function(dict1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- drop_empty\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = 'Green', 'c3' = NULL)), list('c1' = 'Red', 'c2' = 'Green'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = 'Red', 'c2' = NULL, 'c3' = NULL)), list('c1' = 'Red'))))\n    stopifnot(isTRUE(all.equal(candidate(list('c1' = NULL, 'c2' = 'Green', 'c3' = NULL)), list('c2' = 'Green'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nmax_product <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_product\n    stopifnot(isTRUE(all.equal(candidate(c(3, 100, 4, 5, 150, 6)), 3000)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 42, 55, 68, 80)), 50265600)))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 22, 9, 33, 21, 50, 41, 60)), 2460)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "r",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given list.\nadd_pairwise <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_pairwise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(6, 12, 15, 18))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 6, 8, 9, 11)), c(8, 14, 17, 20))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 7, 9, 10, 12)), c(10, 16, 19, 22))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the product of the vector multiplication modulo n.\nfind_remainder <- function(arr, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_remainder\n    stopifnot(isTRUE(all.equal(candidate(c(100, 10, 5, 25, 35, 14), 11), 9)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 2), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given list contains consecutive numbers or not.\ncheck_Consecutive <- function(l) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_Consecutive\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 5, 6)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "r",
+    "prompt": "# Write a function to replace characters in a string.\nreplace_char <- function(str1, ch, newch) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_char\n    stopifnot(isTRUE(all.equal(candidate('polygon', 'y', 'l'), 'pollgon')))\n    stopifnot(isTRUE(all.equal(candidate('character', 'c', 'a'), 'aharaater')))\n    stopifnot(isTRUE(all.equal(candidate('python', 'l', 'a'), 'python')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "r",
+    "prompt": "# Write a function to sort a named list by value.\nsort_counter <- function(dict1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_counter\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 81, 'Physics' = 83, 'Chemistry' = 87)), list(list('Chemistry', 87), list('Physics', 83), list('Math', 81)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 400, 'Physics' = 300, 'Chemistry' = 250)), list(list('Math', 400), list('Physics', 300), list('Chemistry', 250)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Math' = 900, 'Physics' = 1000, 'Chemistry' = 1250)), list(list('Chemistry', 1250), list('Physics', 1000), list('Math', 900)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of the largest and smallest value in a given vector.\nbig_sum <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- big_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "r",
+    "prompt": "# Write a rthon function to convert the given string to lower case.\nis_lower <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_lower\n    stopifnot(isTRUE(all.equal(candidate('InValid'), 'invalid')))\n    stopifnot(isTRUE(all.equal(candidate('TruE'), 'true')))\n    stopifnot(isTRUE(all.equal(candidate('SenTenCE'), 'sentence')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "r",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\nremove_lowercase <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_lowercase\n    stopifnot(isTRUE(all.equal(candidate('PYTHon'), 'PYTH')))\n    stopifnot(isTRUE(all.equal(candidate('FInD'), 'FID')))\n    stopifnot(isTRUE(all.equal(candidate('STRinG'), 'STRG')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the first digit of a given number.\nfirst_Digit <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_Digit\n    stopifnot(isTRUE(all.equal(candidate(123), 1)))\n    stopifnot(isTRUE(all.equal(candidate(456), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "r",
+    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nheap_queue_largest <- function(nums, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- heap_queue_largest\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 3), c(85, 75, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 2), c(85, 75))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 22, 58), 5), c(85, 75, 65, 58, 35))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "r",
+    "prompt": "# Write a rthon function which takes a list of integers and only returns the odd ones.\nSplit <- function(list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), c(1, 3, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 11, 12, 13)), c(11, 13))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1)), c(7, 9, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndifference <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- difference\n    stopifnot(isTRUE(all.equal(candidate(3), 30)))\n    stopifnot(isTRUE(all.equal(candidate(5), 210)))\n    stopifnot(isTRUE(all.equal(candidate(2), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of pairs whose xor value is odd.\nfind_Odd_Pair <- function(A, N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Odd_Pair\n    stopifnot(isTRUE(all.equal(candidate(c(5, 4, 7, 2, 1), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 2, 8, 1, 0, 5, 11), 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 3), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "r",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\ntoggle_string <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- toggle_string\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'pYTHON')))\n    stopifnot(isTRUE(all.equal(candidate('Pangram'), 'pANGRAM')))\n    stopifnot(isTRUE(all.equal(candidate('LIttLE'), 'liTTle')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of the per-digit difference between two integers.\ndigit_distance_nums <- function(n1, n2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- digit_distance_nums\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(23, 56), 6)))\n    stopifnot(isTRUE(all.equal(candidate(123, 256), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\nmax_sub_array_sum <- function(a, size) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sub_array_sum\n    stopifnot(isTRUE(all.equal(candidate(c(-2, -3, 4, -1, -2, 1, 5, -3), 8), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c(-3, -4, 5, -2, -3, 2, 6, -4), 8), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(-4, -5, 6, -3, -4, 3, 7, -5), 8), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "r",
+    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\nunion_elements <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- union_elements\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 4, 5, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(3, 4, 5, 6)), c(1, 2, 3, 4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13, 14), c(13, 15, 16, 17)), c(11, 12, 13, 14, 15, 16, 17))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the length of the longest sublists.\nFind_Max_Length <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Max_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 4), c(5, 6, 7, 8))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(0, 1), c(2, 2), c(3, 2, 1))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7), c(22, 23), c(13, 14, 15), c(10, 20, 30, 40, 50))), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "r",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\nextract_values <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_values\n    stopifnot(isTRUE(all.equal(candidate('\"Python\", \"PHP\", \"Java\"'), c('Python', 'PHP', 'Java'))))\n    stopifnot(isTRUE(all.equal(candidate('\"python\",\"program\",\"language\"'), c('python', 'program', 'language'))))\n    stopifnot(isTRUE(all.equal(candidate('\"red\",\"blue\",\"green\",\"yellow\"'), c('red', 'blue', 'green', 'yellow'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "r",
+    "prompt": "# Write a rthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ncount_Pairs <- function(arr, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Pairs\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 4), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), 5), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "r",
+    "prompt": "# Write a rthon function to split a string into characters.\nsplit <- function(word) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- split\n    stopifnot(isTRUE(all.equal(candidate('python'), c('p', 'y', 't', 'h', 'o', 'n'))))\n    stopifnot(isTRUE(all.equal(candidate('Name'), c('N', 'a', 'm', 'e'))))\n    stopifnot(isTRUE(all.equal(candidate('program'), c('p', 'r', 'o', 'g', 'r', 'a', 'm'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "r",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\nsum_digits <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_digits\n    stopifnot(isTRUE(all.equal(candidate(345), 12)))\n    stopifnot(isTRUE(all.equal(candidate(12), 3)))\n    stopifnot(isTRUE(all.equal(candidate(97), 16)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "r",
+    "prompt": "# Write a function to check whether a specified list is sorted or not.\nissort_list <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- issort_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 16, 17)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 12, 14, 20, 17)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 6, 8, 10, 15, 14, 20)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "r",
+    "prompt": "# Write a function to create a list of N empty dictionaries.\nempty_list <- function(length) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- empty_list\n    stopifnot(isTRUE(all.equal(candidate(5), list(list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(6), list(list(), list(), list(), list(), list(), list()))))\n    stopifnot(isTRUE(all.equal(candidate(7), list(list(), list(), list(), list(), list(), list(), list()))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "r",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\nsort_sublists <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_sublists\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black', 'white'), c('white', 'black', 'orange'))), list(c('green', 'orange'), c('black', 'white'), c('black', 'orange', 'white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white'))), list(c('green', 'orange'), c('black'), c('green', 'orange'), c('white')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('a', 'b'), c('d', 'c'), c('g', 'h'), c('f', 'e'))), list(c('a', 'b'), c('c', 'd'), c('g', 'h'), c('e', 'f')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "r",
+    "prompt": "# Write a rthon function to check if a given number is one less than twice its reverse.\nchecks <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- checks\n    stopifnot(isTRUE(all.equal(candidate(70), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(23), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(73), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "r",
+    "prompt": "# Write a rthon function to remove duplicate numbers from a given number of lists.\ntwo_unique_nums <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- two_unique_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 3, 4, 5)), c(1, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 2, 4, 5)), c(1, 3, 4, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "r",
+    "prompt": "# Write a rthon function to calculate the product of the unique numbers in a given list.\nunique_product <- function(list_data) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_product\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30, 40, 20, 50, 60, 40)), 720000000)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 0, 1, 1)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "r",
+    "prompt": "# Write a function to find the surface area of a cylinder.\nsurfacearea_cylinder <- function(r, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- surfacearea_cylinder\n    stopifnot(isTRUE(all.equal(candidate(10, 5), 942.45)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 226.18800000000002)))\n    stopifnot(isTRUE(all.equal(candidate(4, 10), 351.848)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether a list is sublist of another or not.\nis_Sub_Array <- function(A, B) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Sub_Array\n    stopifnot(isTRUE(all.equal(candidate(c(1, 4, 3, 5), c(1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1), c(1, 2, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 2), c(2, 2, 0)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the last digit in factorial of a given number.\nlast_Digit_Factorial <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- last_Digit_Factorial\n    stopifnot(isTRUE(all.equal(candidate(4), 4)))\n    stopifnot(isTRUE(all.equal(candidate(21), 0)))\n    stopifnot(isTRUE(all.equal(candidate(30), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "r",
+    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ninterleave_lists <- function(list1, list2, list3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- interleave_lists\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7), c(10, 20, 30, 40, 50, 60, 70), c(100, 200, 300, 400, 500, 600, 700)), c(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20), c(15, 2), c(5, 10)), c(10, 15, 5, 20, 2, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 44), c(10, 15), c(20, 5)), c(11, 10, 20, 44, 15, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "r",
+    "prompt": "# Write a function to find the dissimilar elements in the given two lists.\nfind_dissimilar <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_dissimilar\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, 6), c(5, 7, 4, 10)), c(3, 6, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), c(7, 2, 3, 9)), c(1, 4, 7, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(21, 11, 25, 26), c(26, 34, 21, 36)), c(34, 36, 11, 25))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the largest number that can be formed with the given list of digits.\nfind_Max_Num <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Max_Num\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 321)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 1)), 6541)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 9)), 9321)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "r",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed list.\nextract_even <- function(test_tuple) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_even\n    stopifnot(isTRUE(all.equal(candidate(list(4, 5, list(7, 6, c(2, 4)), 6, 8)), list(4, list(6, c(2, 4)), 6, 8))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(8, 7, c(4, 8)), 7, 9)), list(6, list(8, c(4, 8))))))\n    stopifnot(isTRUE(all.equal(candidate(list(5, 6, list(9, 8, c(4, 6)), 8, 10)), list(6, list(8, c(4, 6)), 8, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the surface area of a square rramid with a given base edge and height.\nsurface_Area <- function(b, s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- surface_Area\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 33)))\n    stopifnot(isTRUE(all.equal(candidate(4, 5), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "r",
+    "prompt": "# Write a function which returns nth catalan number.\ncatalan_number <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- catalan_number\n    stopifnot(isTRUE(all.equal(candidate(10), 16796)))\n    stopifnot(isTRUE(all.equal(candidate(9), 4862)))\n    stopifnot(isTRUE(all.equal(candidate(7), 429)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "r",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\nfind_adverbs <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_adverbs\n    stopifnot(isTRUE(all.equal(candidate('Clearly, he has no excuse for such behavior.'), '0-7: Clearly')))\n    stopifnot(isTRUE(all.equal(candidate('Please handle the situation carefuly'), '28-36: carefuly')))\n    stopifnot(isTRUE(all.equal(candidate('Complete the task quickly'), '18-25: quickly')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "r",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\nexpensive_items <- function(items, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- expensive_items\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09)), 2), list(list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-1', 'price' = 101.1)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('name' = 'Item-1', 'price' = 101.1), list('name' = 'Item-2', 'price' = 555.22), list('name' = 'Item-3', 'price' = 45.09), list('name' = 'Item-4', 'price' = 22.75)), 1), list(list('name' = 'Item-2', 'price' = 555.22)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "r",
+    "prompt": "# Write a rthon function to split a list at the nth eelment and add the first part to the end.\nsplit_Arr <- function(l, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- split_Arr\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 5, 6, 52, 36), 2), c(5, 6, 52, 36, 12, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4), 1), c(2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3, 4, 5, 6, 7), 3), c(3, 4, 5, 6, 7, 0, 1, 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "r",
+    "prompt": "# Write a function to convert a list to a list.\nlist_tuple <- function(listx) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- list_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 10, 7, 4, 15, 3)), c(5, 10, 7, 4, 15, 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 2, 3, 4, 4, 7)), c(2, 4, 5, 6, 2, 3, 4, 4, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(58, 44, 56)), c(58, 44, 56))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the difference between largest and smallest value in a given list.\nbig_diff <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- big_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 12)), 8)))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 2, 3)), 7)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "r",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\nperfect_squares <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- perfect_squares\n    stopifnot(isTRUE(all.equal(candidate(1, 30), c(1, 4, 9, 16, 25))))\n    stopifnot(isTRUE(all.equal(candidate(50, 100), c(64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(100, 200), c(100, 121, 144, 169, 196))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given two integers have opposite sign or not.\nopposite_Signs <- function(x, y) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- opposite_Signs\n    stopifnot(isTRUE(all.equal(candidate(1, -2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3, 2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-10, -10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(-2, 2), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "r",
+    "prompt": "# Write a rthon function to interchange the first and last elements in a list.\nswap_List <- function(newList) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(12, 35, 9, 56, 24)), c(24, 35, 9, 56, 12))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of the product of consecutive binomial co-efficients.\nsum_Of_product <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_product\n    stopifnot(isTRUE(all.equal(candidate(3), 15)))\n    stopifnot(isTRUE(all.equal(candidate(4), 56)))\n    stopifnot(isTRUE(all.equal(candidate(1), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "r",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\nremovezero_ip <- function(ip) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- removezero_ip\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.196'), '216.8.94.196')))\n    stopifnot(isTRUE(all.equal(candidate('12.01.024'), '12.1.24')))\n    stopifnot(isTRUE(all.equal(candidate('216.08.094.0196'), '216.8.94.196')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "r",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndiff_even_odd <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- diff_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "r",
+    "prompt": "# Write a rthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nmin_Swaps <- function(str1, str2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_Swaps\n    stopifnot(isTRUE(all.equal(candidate('1101', '1110'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('111', '000'), 'Not Possible')))\n    stopifnot(isTRUE(all.equal(candidate('111', '110'), 'Not Possible')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "r",
+    "prompt": "# Write a function to find kth element from the given two sorted vectors.\nfind_kth <- function(arr1, arr2, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_kth\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 6, 7, 9), c(1, 4, 8, 10), 5), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(100, 112, 256, 349, 770), c(72, 86, 113, 119, 265, 445, 892), 7), 256)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 7, 8, 10), c(2, 5, 9, 11), 6), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\narmstrong_number <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- armstrong_number\n    stopifnot(isTRUE(all.equal(candidate(153), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(259), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(4458), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "r",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\nsum_average <- function(number) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_average\n    stopifnot(isTRUE(all.equal(candidate(10), c(55, 5.5))))\n    stopifnot(isTRUE(all.equal(candidate(15), c(120, 8.0))))\n    stopifnot(isTRUE(all.equal(candidate(20), c(210, 10.5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth octagonal number.\nis_octagonal <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_octagonal\n    stopifnot(isTRUE(all.equal(candidate(5), 65)))\n    stopifnot(isTRUE(all.equal(candidate(10), 280)))\n    stopifnot(isTRUE(all.equal(candidate(15), 645)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given number is even or not.\nis_Even <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Even\n    stopifnot(isTRUE(all.equal(candidate(1), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(3), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the first repeated character in a given string.\nfirst_repeated_char <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_repeated_char\n    stopifnot(isTRUE(all.equal(candidate('abcabc'), 'a')))\n    stopifnot(isTRUE(all.equal(candidate('abc'), NULL)))\n    stopifnot(isTRUE(all.equal(candidate('123123'), '1')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "r",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\nget_ludic <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_ludic\n    stopifnot(isTRUE(all.equal(candidate(10), c(1, 2, 3, 5, 7))))\n    stopifnot(isTRUE(all.equal(candidate(25), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25))))\n    stopifnot(isTRUE(all.equal(candidate(45), c(1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "r",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\nreverse_words <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_words\n    stopifnot(isTRUE(all.equal(candidate('python program'), 'program python')))\n    stopifnot(isTRUE(all.equal(candidate('java language'), 'language java')))\n    stopifnot(isTRUE(all.equal(candidate('indian man'), 'man indian')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "r",
+    "prompt": "# Write a function to check if the given integer is a prime number.\nprime_num <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- prime_num\n    stopifnot(isTRUE(all.equal(candidate(13), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(7), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(-1010), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "r",
+    "prompt": "# Write a function to convert degrees to radians.\nradian_degree <- function(degree) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- radian_degree\n    stopifnot(isTRUE(all.equal(candidate(90), 1.5707963267948966)))\n    stopifnot(isTRUE(all.equal(candidate(60), 1.0471975511965976)))\n    stopifnot(isTRUE(all.equal(candidate(120), 2.0943951023931953)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "r",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfind_literals <- function(text, pattern) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_literals\n    stopifnot(isTRUE(all.equal(candidate('The quick brown fox jumps over the lazy dog.', 'fox'), list('fox', 16, 19))))\n    stopifnot(isTRUE(all.equal(candidate('Its been a very crazy procedure right', 'crazy'), list('crazy', 16, 21))))\n    stopifnot(isTRUE(all.equal(candidate('Hardest choices required strongest will', 'will'), list('will', 35, 39))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "r",
+    "prompt": "# Write a rthon function to find nth bell number.\nbell_Number <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- bell_Number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(3), 5)))\n    stopifnot(isTRUE(all.equal(candidate(4), 15)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "r",
+    "prompt": "# Write a rthon function which takes a list and returns a list with the same elements, but the k'th element removed.\nremove_kth_element <- function(list1, L) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_kth_element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 4, 4, 5, 1), 3), c(1, 1, 3, 4, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4), 4), c(0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10), 5), c(10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "r",
+    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nmax_of_nth <- function(test_list, N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_of_nth\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 6, 7), c(1, 3, 5), c(8, 9, 19)), 2), 19)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 7, 8), c(2, 4, 6), c(9, 10, 20)), 1), 10)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 8, 9), c(3, 5, 7), c(10, 11, 21)), 1), 11)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "r",
+    "prompt": "# Write a rthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nmerge <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y'), c('a', 'b'), c('m', 'n'))), list(c('x', 'a', 'm'), c('y', 'b', 'n')))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4), c(5, 6), c(7, 8))), list(c(1, 3, 5, 7), c(2, 4, 6, 8)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c('x', 'y', 'z'), c('a', 'b', 'c'), c('m', 'n', 'o'))), list(c('x', 'a', 'm'), c('y', 'b', 'n'), c('z', 'c', 'o')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "r",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ncummulative_sum <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- cummulative_sum\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 6, 7), c(2, 6))), 30)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7, 8), c(3, 7))), 37)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8, 9), c(4, 8))), 44)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "r",
+    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\naverage_tuple <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- average_tuple\n    stopifnot(isTRUE(all.equal(candidate(list(c(10, 10, 10, 12), c(30, 45, 56, 45), c(81, 80, 39, 32), c(1, 2, 3, 4))), c(30.5, 34.25, 27.0, 23.25))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 1, -5), c(30, -15, 56), c(81, -60, -39), c(-10, 2, 3))), c(25.5, -18.0, 3.75))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(100, 100, 100, 120), c(300, 450, 560, 450), c(810, 800, 390, 320), c(10, 20, 30, 40))), c(305.0, 342.5, 270.0, 232.5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "r",
+    "prompt": "# Write a function which takes two lists of the same length and performs the element wise modulo.\ntuple_modulo <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_modulo\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6), c(5, 6, 7, 5)), c(0, 4, 5, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 5, 6, 7), c(6, 7, 8, 6)), c(5, 5, 6, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 6, 7, 8), c(7, 8, 9, 7)), c(5, 6, 7, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "r",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nmin_Jumps <- function(steps, d) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_Jumps\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 11), 3.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4), 0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 14), 11), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "r",
+    "prompt": "# Write a function to divide two lists element wise.\ndiv_list <- function(nums1, nums2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- div_list\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(1, 2, 3)), c(4.0, 2.5, 2.0))))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2), c(1, 4)), c(3.0, 0.5))))\n    stopifnot(isTRUE(all.equal(candidate(c(90, 120), c(50, 70)), c(1.8, 1.7142857142857142))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "r",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\nmove_num <- function(test_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_num\n    stopifnot(isTRUE(all.equal(candidate('I1love143you55three3000thousand'), 'Iloveyouthreethousand1143553000')))\n    stopifnot(isTRUE(all.equal(candidate('Avengers124Assemble'), 'AvengersAssemble124')))\n    stopifnot(isTRUE(all.equal(candidate('Its11our12path13to14see15things16do17things'), 'Itsourpathtoseethingsdothings11121314151617')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of substrings with the sum of digits equal to their length.\ncount_Substrings <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_Substrings\n    stopifnot(isTRUE(all.equal(candidate('112112'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('111'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('1101112'), 12)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "r",
+    "prompt": "# Write a function to find the median of two sorted lists of same size.\nget_median <- function(arr1, arr2, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_median\n    stopifnot(isTRUE(all.equal(candidate(c(1, 12, 15, 26, 38), c(2, 13, 17, 30, 45), 5), 16.0)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 8, 9), c(7, 13, 19, 28), 4), 8.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 6, 14, 23, 36, 42), c(2, 18, 27, 39, 49, 55), 6), 25.0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "r",
+    "prompt": "# Write a function to compute the n-th power of each number in a list.\nnth_nums <- function(nums, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- nth_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), 3), c(1000, 8000, 27000))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15), 5), c(248832, 759375))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "r",
+    "prompt": "# Write a rthon function to convert a given string to uppercase.\nis_upper <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_upper\n    stopifnot(isTRUE(all.equal(candidate('person'), 'PERSON')))\n    stopifnot(isTRUE(all.equal(candidate('final'), 'FINAL')))\n    stopifnot(isTRUE(all.equal(candidate('Valid'), 'VALID')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "r",
+    "prompt": "# Write a rthon function to interchange the first and last element in a given list.\nswap_List <- function(newList) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- swap_List\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), c(3, 2, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 4)), c(4, 2, 3, 4, 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6)), c(6, 5, 4))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ntriangle_area <- function(r) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- triangle_area\n    stopifnot(isTRUE(all.equal(candidate(-1), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(0), 0)))\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the smallest missing number from a sorted list of natural numbers.\nfind_First_Missing <- function(array) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_First_Missing\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 3)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, 6, 9)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 8, 9)), 0)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "r",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\nreplace_spaces <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('My Name is Dawood'), 'My%20Name%20is%20Dawood')))\n    stopifnot(isTRUE(all.equal(candidate('I am a Programmer'), 'I%20am%20a%20Programmer')))\n    stopifnot(isTRUE(all.equal(candidate('I love Coding'), 'I%20love%20Coding')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "r",
+    "prompt": "# Write a rthon function to find even numbers from a list of numbers.\nSplit <- function(list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Split\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), c(2, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7, 8, 0, 1)), c(4, 6, 8, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 12, 15, 19)), c(8, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "r",
+    "prompt": "# Write a rthon function to find smallest number in a list.\nsmallest_num <- function(xs) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- smallest_num\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 1, 45, 99)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(45, 46, 50, 60)), 45)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "r",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate list.\nget_coordinates <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_coordinates\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4)), list(c(2, 3), c(2, 4), c(2, 5), c(3, 3), c(3, 4), c(3, 5), c(4, 3), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5)), list(c(3, 4), c(3, 5), c(3, 6), c(4, 4), c(4, 5), c(4, 6), c(5, 4), c(5, 5), c(5, 6)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6)), list(c(4, 5), c(4, 6), c(4, 7), c(5, 5), c(5, 6), c(5, 7), c(6, 5), c(6, 6), c(6, 7)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "r",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\nreplace_spaces <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_spaces\n    stopifnot(isTRUE(all.equal(candidate('Jumanji The Jungle'), 'Jumanji_The_Jungle')))\n    stopifnot(isTRUE(all.equal(candidate('The_Avengers'), 'The Avengers')))\n    stopifnot(isTRUE(all.equal(candidate('Fast and Furious'), 'Fast_and_Furious')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "r",
+    "prompt": "# Write a rthon function to move all zeroes to the end of the given list.\nmove_zero <- function(num_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- move_zero\n    stopifnot(isTRUE(all.equal(candidate(c(1, 0, 2, 0, 3, 4)), c(1, 2, 3, 4, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 0, 0, 4, 0, 5, 0)), c(2, 3, 2, 4, 5, 0, 0, 0, 0))))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 0, 1, 1)), c(1, 1, 1, 0, 0))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of xor of all pairs of numbers in the given list.\npair_xor_Sum <- function(arr, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pair_xor_Sum\n    stopifnot(isTRUE(all.equal(candidate(c(5, 9, 7, 6), 4), 47)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3, 5), 3), 12)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 3), 2), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort the given list.\nheap_sort <- function(iterable) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- heap_sort\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 9, 2, 4, 6, 8, 0)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c(25, 35, 22, 85, 14, 65, 75, 25, 58)), c(14, 22, 25, 25, 35, 58, 65, 75, 85))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 1, 9, 5)), c(1, 5, 7, 9))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\nnoprofit_noloss <- function(actual_cost, sale_amount) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- noprofit_noloss\n    stopifnot(isTRUE(all.equal(candidate(1500, 1200), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(100, 100), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2000, 5000), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "r",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nwind_chill <- function(v, t) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- wind_chill\n    stopifnot(isTRUE(all.equal(candidate(120, 35), 40)))\n    stopifnot(isTRUE(all.equal(candidate(40, 20), 19)))\n    stopifnot(isTRUE(all.equal(candidate(10, 8), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "r",
+    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nsample_nam <- function(sample_names) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sample_nam\n    stopifnot(isTRUE(all.equal(candidate(c('sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith')), 16)))\n    stopifnot(isTRUE(all.equal(candidate(c('php', 'res', 'Python', 'abcd', 'Java', 'aaa')), 10)))\n    stopifnot(isTRUE(all.equal(candidate(c('abcd', 'Python', 'abba', 'aba')), 6)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "r",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given list list.\nmax_difference <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_difference\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(1, 7), c(10, 3), c(1, 2))), 7)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(2, 17), c(9, 13), c(11, 12))), 15)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(12, 35), c(21, 27), c(13, 23), c(41, 22))), 23)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "r",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\nremove_parenthesis <- function(items) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_parenthesis\n    stopifnot(isTRUE(all.equal(candidate(c('python (chrome)')), 'python')))\n    stopifnot(isTRUE(all.equal(candidate(c('string(.abc)')), 'string')))\n    stopifnot(isTRUE(all.equal(candidate(c('alpha(num)')), 'alpha')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "r",
+    "prompt": "# Write a function to find the nth nonagonal number.\nis_nonagonal <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_nonagonal\n    stopifnot(isTRUE(all.equal(candidate(10), 325)))\n    stopifnot(isTRUE(all.equal(candidate(15), 750)))\n    stopifnot(isTRUE(all.equal(candidate(18), 1089)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "r",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ntext_match_wordz_middle <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_wordz_middle\n    stopifnot(isTRUE(all.equal(candidate('pythonzabc.'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('zxyabc.'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('  lang  .'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "r",
+    "prompt": "# Write a rthon function to reverse a vector upto a given position.\nreverse_Array_Upto_K <- function(input, k) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- reverse_Array_Upto_K\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 4), c(4, 3, 2, 1, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6, 7), 2), c(5, 4, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(9, 8, 7, 6, 5), 3), c(7, 8, 9, 6, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of lists using the second value of each list.\nsubject_marks <- function(subjectmarks) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- subject_marks\n    stopifnot(isTRUE(all.equal(candidate(list(list('English', 88), list('Science', 90), list('Maths', 97), list('Social sciences', 82))), list(list('Social sciences', 82), list('English', 88), list('Science', 90), list('Maths', 97)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Telugu', 49), list('Hindhi', 54), list('Social', 33))), list(list('Social', 33), list('Telugu', 49), list('Hindhi', 54)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Physics', 96), list('Chemistry', 97), list('Biology', 45))), list(list('Biology', 45), list('Physics', 96), list('Chemistry', 97)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "r",
+    "prompt": "# Write a function to flatten a list and sum all of its elements.\nrecursive_list_sum <- function(data_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- recursive_list_sum\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, c(3, 4), c(5, 6))), 21)))\n    stopifnot(isTRUE(all.equal(candidate(list(7, 10, c(15, 14), c(19, 41))), 106)))\n    stopifnot(isTRUE(all.equal(candidate(list(10, 20, c(30, 40), c(50, 60))), 210)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of positive numbers in a list.\npos_count <- function(list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pos_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3, -4)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(3, 4, 5, -1)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "r",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\nbell_number <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- bell_number\n    stopifnot(isTRUE(all.equal(candidate(2), 2)))\n    stopifnot(isTRUE(all.equal(candidate(10), 115975)))\n    stopifnot(isTRUE(all.equal(candidate(56), 6775685320645824322581483068371419745979053216268760300)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given vector is monotonic or not.\nis_Monotonic <- function(A) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Monotonic\n    stopifnot(isTRUE(all.equal(candidate(c(6, 5, 4, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "r",
+    "prompt": "# Write a function to check whether a list contains the given sublist or not.\nis_sublist <- function(l, s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_sublist\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(3, 7)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(4, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 3, 5, 7), c(1, 6)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the two numbers differ at one bit position only or not.\ndiffer_At_One_Bit_Pos <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- differ_At_One_Bit_Pos\n    stopifnot(isTRUE(all.equal(candidate(13, 9), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(15, 8), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 4), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(5, 1), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1, 5), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "r",
+    "prompt": "# Write a function to find whether all the given lists have equal length or not.\nget_equal <- function(Input) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_equal\n    stopifnot(isTRUE(all.equal(candidate(list(c(11, 22, 33), c(44, 55, 66))), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6, 7))), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(3, 4))), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "r",
+    "prompt": "# Write a function to sort a list of elements.\ncomb_sort <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- comb_sort\n    stopifnot(isTRUE(all.equal(candidate(c(5, 15, 37, 25, 79)), c(5, 15, 25, 37, 79))))\n    stopifnot(isTRUE(all.equal(candidate(c(41, 32, 15, 19, 22)), c(15, 19, 22, 32, 41))))\n    stopifnot(isTRUE(all.equal(candidate(c(99, 15, 13, 47)), c(13, 15, 47, 99))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "r",
+    "prompt": "# Write a function to add a named list to the list. The output should be a list.\nadd_dict_to_tuple <- function(test_tup, test_dict) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_dict_to_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), list('MSAM' = 1, 'is' = 2, 'best' = 3)), list(4, 5, 6, list('MSAM' = 1, 'is' = 2, 'best' = 3)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), list('UTS' = 2, 'is' = 3, 'Worst' = 4)), list(1, 2, 3, list('UTS' = 2, 'is' = 3, 'Worst' = 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 10), list('POS' = 3, 'is' = 4, 'Okay' = 5)), list(8, 9, 10, list('POS' = 3, 'is' = 4, 'Okay' = 5)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "r",
+    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nmaxAverageOfPath <- function(cost) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- maxAverageOfPath\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(6, 5, 4), c(7, 3, 9))), 5.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 4), c(7, 6, 5), c(8, 4, 10))), 6.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 4, 5), c(8, 7, 6), c(9, 5, 11))), 7.2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(7, 8, 9))), 5.8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "r",
+    "prompt": "# The input is given as - a named list with a student name as a key and a list of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfilter_data <- function(students, h, w) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- filter_data\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 6.0, 70), list('Cierra Vega' = c(6.2, 70)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.9, 67), list('Cierra Vega' = c(6.2, 70), 'Kierra Gentry' = c(6.0, 68)))))\n    stopifnot(isTRUE(all.equal(candidate(list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)), 5.7, 64), list('Cierra Vega' = c(6.2, 70), 'Alden Cantrell' = c(5.9, 65), 'Kierra Gentry' = c(6.0, 68), 'Pierre Cox' = c(5.8, 66)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "r",
+    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ncount_same_pair <- function(nums1, nums2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_same_pair\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8), c(2, 2, 3, 1, 2, 6, 7, 9)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 11)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, -6, -9, 11, -12, 14, -5, 17), c(2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 1, 2), c(0, 1, 2, 2)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "r",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\npower_base_sum <- function(base, power) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- power_base_sum\n    stopifnot(isTRUE(all.equal(candidate(2, 100), 115)))\n    stopifnot(isTRUE(all.equal(candidate(8, 10), 37)))\n    stopifnot(isTRUE(all.equal(candidate(8, 15), 62)))\n    stopifnot(isTRUE(all.equal(candidate(3, 3), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "r",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\nextract_quotation <- function(text1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_quotation\n    stopifnot(isTRUE(all.equal(candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"'), c('A53', 'multi', 'Processor'))))\n    stopifnot(isTRUE(all.equal(candidate('Cast your \"favorite\" entertainment \"apps\"'), c('favorite', 'apps'))))\n    stopifnot(isTRUE(all.equal(candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support'), c('4k Ultra HD', 'HDR 10'))))\n    stopifnot(isTRUE(all.equal(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "r",
+    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\nmultiply_elements <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- multiply_elements\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 8, 10)), c(5, 35, 56, 80))))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 5, 6, 7)), c(8, 20, 30, 42))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 13, 14, 9, 15)), c(156, 182, 126, 135))))\n    stopifnot(isTRUE(all.equal(candidate(c(12)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "r",
+    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nsum_list <- function(lst1, lst2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_list\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30), c(15, 25, 35)), c(25, 45, 65))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(5, 6, 7)), c(6, 8, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 20, 30), c(15, 45, 75)), c(30, 65, 105))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the given number can be represented as the difference of two squares or not.\ndif_Square <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- dif_Square\n    stopifnot(isTRUE(all.equal(candidate(5), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "r",
+    "prompt": "# Write a function to remove consecutive duplicates of a given list.\nconsecutive_duplicates <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), c(10, 15, 19, 18, 17, 26, 17, 18, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), c('a', 'b', 'c', 'd'))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd', 'a', 'a')), c('a', 'b', 'c', 'd', 'a'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "r",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\nlateralsurface_cone <- function(r, h) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- lateralsurface_cone\n    stopifnot(isTRUE(all.equal(candidate(5, 12), 204.20352248333654)))\n    stopifnot(isTRUE(all.equal(candidate(10, 15), 566.3586699569488)))\n    stopifnot(isTRUE(all.equal(candidate(19, 17), 1521.8090132193388)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "r",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nreplace_specialchar <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- replace_specialchar\n    stopifnot(isTRUE(all.equal(candidate('Python language, Programming language.'), 'Python:language::Programming:language:')))\n    stopifnot(isTRUE(all.equal(candidate('a b c,d e f'), 'a:b:c:d:e:f')))\n    stopifnot(isTRUE(all.equal(candidate('ram reshma,ram rahim'), 'ram:reshma:ram:rahim')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "r",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted vector.\nfind_first_occurrence <- function(A, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_first_occurrence\n    stopifnot(isTRUE(all.equal(candidate(c(2, 5, 5, 5, 6, 6, 8, 9, 9, 9), 5), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 5, 5, 6, 6, 8, 9, 9, 9), 5), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 5, 6, 6, 8, 9, 9, 9), 6), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "r",
+    "prompt": "# Write a rthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nsum_Of_Subarray_Prod <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_Of_Subarray_Prod\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 20)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2)), 5)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4)), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "r",
+    "prompt": "# Write a rthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ntoggle_middle_bits <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- toggle_middle_bits\n    stopifnot(isTRUE(all.equal(candidate(9), 15)))\n    stopifnot(isTRUE(all.equal(candidate(10), 12)))\n    stopifnot(isTRUE(all.equal(candidate(11), 13)))\n    stopifnot(isTRUE(all.equal(candidate(65), 127)))\n    stopifnot(isTRUE(all.equal(candidate(77), 115)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "r",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rthon-exercises/data-structures-and-algorithms/rthon-data-structure-exercise-24.php\nleft_insertion <- function(a, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- left_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ncheck_str <- function(string) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_str\n    stopifnot(isTRUE(all.equal(candidate('annie'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dawood'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('Else'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "r",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rthon-exercises/data-structures-and-algorithms/rthon-recursion-exercise-9.php\ngeometric_sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- geometric_sum\n    stopifnot(isTRUE(all.equal(candidate(7), 1.9921875)))\n    stopifnot(isTRUE(all.equal(candidate(4), 1.9375)))\n    stopifnot(isTRUE(all.equal(candidate(8), 1.99609375)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfind_Index <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Index\n    stopifnot(isTRUE(all.equal(candidate(2), 4)))\n    stopifnot(isTRUE(all.equal(candidate(3), 14)))\n    stopifnot(isTRUE(all.equal(candidate(4), 45)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "r",
+    "prompt": "# Write a function to convert the given list to a key-value named list using adjacent elements. https://www.geeksforgeeks.org/rthon-convert-list-to-adjacent-pair-named list/\ntuple_to_dict <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_to_dict\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 10, 13, 5)), list(1 = 5, 7 = 10, 13 = 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), list(1 = 2, 3 = 4, 5 = 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 10, 11, 12)), list(7 = 8, 9 = 10, 11 = 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether all the characters are same or not.\nall_Characters_Same <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- all_Characters_Same\n    stopifnot(isTRUE(all.equal(candidate('python'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('aaa'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('data'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "r",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\narea_tetrahedron <- function(side) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- area_tetrahedron\n    stopifnot(isTRUE(all.equal(candidate(3), 15.588457268119894)))\n    stopifnot(isTRUE(all.equal(candidate(20), 692.8203230275509)))\n    stopifnot(isTRUE(all.equal(candidate(10), 173.20508075688772)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "r",
+    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/rthon-program-right-rotate-list-n/\nrotate_right <- function(list, m) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rotate_right\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3), c(8, 9, 10, 1, 2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2), c(9, 10, 1, 2, 3, 4, 5, 6, 7, 8))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5), c(6, 7, 8, 9, 10, 1, 2, 3, 4, 5))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "r",
+    "prompt": "# Write a function to check if the given list has any none value or not.\ncheck_none <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_none\n    stopifnot(isTRUE(all.equal(candidate(list(10, 4, 5, 6, NULL)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 11, 14)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(list(1, 2, 3, 4, NULL)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "r",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rthon-exercises/lambda/rthon-lambda-exercise-24.php\ndivisible_by_digits <- function(startnum, endnum) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- divisible_by_digits\n    stopifnot(isTRUE(all.equal(candidate(1, 22), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22))))\n    stopifnot(isTRUE(all.equal(candidate(1, 15), c(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15))))\n    stopifnot(isTRUE(all.equal(candidate(20, 25), c(22, 24))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "r",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return NULL if the angle is larger than 360 degrees.\nsector_area <- function(r, a) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sector_area\n    stopifnot(isTRUE(all.equal(candidate(4, 45), 6.283185307179586)))\n    stopifnot(isTRUE(all.equal(candidate(9, 45), 31.808625617596654)))\n    stopifnot(isTRUE(all.equal(candidate(9, 361), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "r",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nlcs_of_three <- function(X, Y, Z) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- lcs_of_three\n    stopifnot(isTRUE(all.equal(candidate('AGGT12', '12TXAYB', '12XBA'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('Reels', 'Reelsfor', 'ReelsforReels'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('abcd1e2', 'bc12ea', 'bd1ea'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "r",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ncapital_words_spaces <- function(str1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- capital_words_spaces\n    stopifnot(isTRUE(all.equal(candidate('Python'), 'Python')))\n    stopifnot(isTRUE(all.equal(candidate('PythonProgrammingExamples'), 'Python Programming Examples')))\n    stopifnot(isTRUE(all.equal(candidate('GetReadyToBeCodingFreak'), 'Get Ready To Be Coding Freak')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "r",
+    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/rthon-sort-numeric-strings-in-a-list/\nsort_numeric_strings <- function(nums_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sort_numeric_strings\n    stopifnot(isTRUE(all.equal(candidate(c('4', '12', '45', '7', '0', '100', '200', '-12', '-500')), c(-500, -12, 0, 4, 7, 12, 45, 100, 200))))\n    stopifnot(isTRUE(all.equal(candidate(c('2', '3', '8', '4', '7', '9', '8', '2', '6', '5', '1', '6', '1', '2', '3', '4', '6', '9', '1', '2')), c(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9))))\n    stopifnot(isTRUE(all.equal(candidate(c('1', '3', '5', '7', '1', '3', '13', '15', '17', '5', '7 ', '9', '1', '11')), c(1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "r",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns vector.\nis_samepatterns <- function(colors, patterns) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_samepatterns\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'green'), c('a', 'b', 'b')), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b', 'b')), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'green', 'greenn'), c('a', 'b')), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "r",
+    "prompt": "# Write a function to add the given list to the given list.\nadd_tuple <- function(test_list, test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- add_tuple\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7), c(9, 10)), c(5, 6, 7, 9, 10))))\n    stopifnot(isTRUE(all.equal(candidate(c(6, 7, 8), c(10, 11)), c(6, 7, 8, 10, 11))))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9), c(11, 12)), c(7, 8, 9, 11, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "r",
+    "prompt": "# Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\ncheck_min_heap <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_min_heap\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 4, 5, 10, 15)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 10, 4, 5, 3, 15)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "r",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\njacobsthal_num <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- jacobsthal_num\n    stopifnot(isTRUE(all.equal(candidate(5), 11)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(4), 5)))\n    stopifnot(isTRUE(all.equal(candidate(13), 2731)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "r",
+    "prompt": "# Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/rthon-find-minimum-k-records-from-list-list/ - in this case a verbatim cor of test cases\nmin_k <- function(test_list, K) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- min_k\n    stopifnot(isTRUE(all.equal(candidate(list(list('Manjeet', 10), list('Akshat', 4), list('Akash', 2), list('Nikhil', 8)), 2), list(list('Akash', 2), list('Akshat', 4)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sanjeev', 11), list('Angat', 5), list('Akash', 3), list('Nepin', 9)), 3), list(list('Akash', 3), list('Angat', 5), list('Nepin', 9)))))\n    stopifnot(isTRUE(all.equal(candidate(list(list('tanmay', 14), list('Amer', 11), list('Ayesha', 9), list('SKD', 16)), 1), list(list('Ayesha', 9)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "r",
+    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nextract_index_list <- function(l1, l2, l3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- extract_index_list\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 5, 6, 7), c(0, 1, 2, 3, 4, 6, 5), c(0, 1, 2, 3, 4, 6, 7)), c(1, 6))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 3, 4, 6, 5, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c(1, 5))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 6, 6, 6), c(0, 1, 2, 3, 4, 5, 7), c(0, 1, 2, 3, 4, 5, 7)), c())))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "r",
+    "prompt": "# Write a function to find the second smallest number in a list.\nsecond_smallest <- function(numbers) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- second_smallest\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, -8, -2, 0, -2)), -2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, -0.5, 0, 2, -2, -2)), -0.5)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2)), NULL)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 2, 2)), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rthon-exercises/re/rthon-re-exercise-3.php\ntext_match_zero_one <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_zero_one\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('dsabbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('asbbbba'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abaaa'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "r",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/rthon-program-to-count-the-pairs-of-reverse-strings/\ncount_reverse_pairs <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_reverse_pairs\n    stopifnot(isTRUE(all.equal(candidate(c('julia', 'best', 'tseb', 'for', 'ailuj')), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c('geeks', 'best', 'for', 'skeeg')), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c('makes', 'best', 'sekam', 'for', 'rof')), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "r",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\nis_decimal <- function(num) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_decimal\n    stopifnot(isTRUE(all.equal(candidate('123.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('e666.86'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('3.124587'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('1.11'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('1.1.11'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "r",
+    "prompt": "# Write a function to find lists which have all elements divisible by k from the given list of lists.\nfind_tuples <- function(test_list, K) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_tuples\n    stopifnot(isTRUE(all.equal(candidate(list(c(6, 24, 12), c(7, 9, 6), c(12, 18, 21)), 6), list(c(6, 24, 12)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(5, 25, 30), c(4, 2, 3), c(7, 8, 9)), 5), list(c(5, 25, 30)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(7, 9, 16), c(8, 16, 4), c(19, 17, 18)), 4), list(c(8, 16, 4)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether a list of numbers contains only one distinct element or not.\nunique_Element <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- unique_Element\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ncheck_monthnumber_number <- function(monthnum3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_monthnumber_number\n    stopifnot(isTRUE(all.equal(candidate(6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(2), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(12), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfind_min_diff <- function(arr, n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_min_diff\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 3, 19, 18, 25), 6), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 3, 2, 6), 4), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(30, 5, 20, 9), 4), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "r",
+    "prompt": "# Write a rthon function to count number of digits in a given string.\nnumber_ctr <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- number_ctr\n    stopifnot(isTRUE(all.equal(candidate('program2bedone'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('3wonders'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('123'), 3)))\n    stopifnot(isTRUE(all.equal(candidate('3wond-1ers2'), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "r",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nis_polite <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_polite\n    stopifnot(isTRUE(all.equal(candidate(7), 11)))\n    stopifnot(isTRUE(all.equal(candidate(4), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 13)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "r",
+    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\npair_wise <- function(l1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pair_wise\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 2, 3, 3, 4, 4, 5)), list(c(1, 1), c(1, 2), c(2, 3), c(3, 3), c(3, 4), c(4, 4), c(4, 5)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), list(c(1, 5), c(5, 7), c(7, 9), c(9, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 1, 9, 7, 10)), list(c(5, 1), c(1, 9), c(9, 7), c(7, 10)))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), list(c(1, 2), c(2, 3), c(3, 4), c(4, 5), c(5, 6), c(6, 7), c(7, 8), c(8, 9), c(9, 10)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nget_pairs_count <- function(arr, sum) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_pairs_count\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 1), 2), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, -1, 5), 6), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, -2, 3), 1), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(-1, -2, 3), -3), 1)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "r",
+    "prompt": "# Write a rthon function to get the difference between two lists.\nDiff <- function(li1, li2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Diff\n    stopifnot(isTRUE(all.equal(candidate(c(10, 15, 20, 25, 30, 35, 40), c(25, 40, 35)), c(10, 20, 30, 15))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5), c(6, 7, 1)), c(2, 3, 4, 5, 6, 7))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(6, 7, 1)), c(2, 3, 6, 7))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of fourth power of first n odd natural numbers.\nodd_num_sum <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_num_sum\n    stopifnot(isTRUE(all.equal(candidate(2), 82)))\n    stopifnot(isTRUE(all.equal(candidate(3), 707)))\n    stopifnot(isTRUE(all.equal(candidate(4), 3108)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "r",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ncheck_expression <- function(exp) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_expression\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}]'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{]'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('{()}[{}][]({})'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "r",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\nremove_length <- function(test_str, K) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_length\n    stopifnot(isTRUE(all.equal(candidate('The person is most value tet', 3), 'person is most value')))\n    stopifnot(isTRUE(all.equal(candidate('If you told me about this ok', 4), 'If you me about ok')))\n    stopifnot(isTRUE(all.equal(candidate('Forces of darkeness is come into the play', 4), 'Forces of darkeness is the')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "r",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return NULL if there is no match.\noccurance_substring <- function(text, pattern) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- occurance_substring\n    stopifnot(isTRUE(all.equal(candidate('python programming, python language', 'python'), list('python', 0, 6))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'programming'), list('programming', 7, 18))))\n    stopifnot(isTRUE(all.equal(candidate('python programming,programming language', 'language'), list('language', 31, 39))))\n    stopifnot(isTRUE(all.equal(candidate('c++ programming, c++ language', 'python'), NULL)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether every odd index contains odd numbers of a given list.\nodd_position <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_position\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4, 3, 6, 7, 6, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 1, 2)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "r",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ncount_vowels <- function(test_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_vowels\n    stopifnot(isTRUE(all.equal(candidate('bestinstareels'), 7)))\n    stopifnot(isTRUE(all.equal(candidate('partofthejourneyistheend'), 12)))\n    stopifnot(isTRUE(all.equal(candidate('amazonprime'), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of non-repeated elements in a given list.\nfind_sum <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 1, 1, 4, 5, 6)), 21)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 10, 9, 4, 2, 10, 10, 45, 4)), 71)))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 10, 9, 45, 2, 10, 10, 45, 10)), 78)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "r",
+    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\npack_consecutive_duplicates <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- pack_consecutive_duplicates\n    stopifnot(isTRUE(all.equal(candidate(c(0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4)), list(c(0, 0), c(1), c(2), c(3), c(4, 4), c(5), c(6, 6, 6), c(7), c(8), c(9), c(4, 4)))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10)), list(c(10, 10), c(15), c(19), c(18, 18), c(17), c(26, 26), c(17), c(18), c(10)))))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'a', 'b', 'c', 'd', 'd')), list(c('a', 'a'), c('b'), c('c'), c('d', 'd')))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "r",
+    "prompt": "# Write a rthon function to find whether a number is divisible by 11.\nis_Diff <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_Diff\n    stopifnot(isTRUE(all.equal(candidate(12345), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(1212112), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1212), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "r",
+    "prompt": "# Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/rthon-combinations-of-sum-with-lists-in-list-list/\nfind_combinations <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_combinations\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 4), c(6, 7), c(5, 1), c(6, 10))), list(c(8, 11), c(7, 5), c(8, 14), c(11, 8), c(12, 17), c(11, 11)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 5), c(7, 8), c(6, 2), c(7, 11))), list(c(10, 13), c(9, 7), c(10, 16), c(13, 10), c(14, 19), c(13, 13)))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(4, 6), c(8, 9), c(7, 3), c(8, 12))), list(c(12, 15), c(11, 9), c(12, 18), c(15, 12), c(16, 21), c(15, 15)))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the count of divisors is even. https://www.w3resource.com/rthon-exercises/basic/rthon-basic-1-exercise-24.php\ncount_divisors <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_divisors\n    stopifnot(isTRUE(all.equal(candidate(10), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(100), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(125), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nodd_length_sum <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- odd_length_sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4)), 14)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 2)), 15)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 7)), 8)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "r",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nrgb_to_hsv <- function(r, g, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- rgb_to_hsv\n    stopifnot(isTRUE(all.equal(candidate(255, 255, 255), c(0.0, 0.0, 100.0))))\n    stopifnot(isTRUE(all.equal(candidate(0, 215, 0), c(120.0, 100.0, 84.31372549019608))))\n    stopifnot(isTRUE(all.equal(candidate(10, 215, 110), c(149.26829268292684, 95.34883720930233, 84.31372549019608))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "r",
+    "prompt": "# Write a function to find the product of first even and odd number of a given list.\nmul_even_odd <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- mul_even_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5, 7, 4, 1, 6, 8)), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 5, 7, 9, 10)), 10)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "r",
+    "prompt": "# Write a function to convert list string to integer list.\ntuple_str_int <- function(test_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tuple_str_int\n    stopifnot(isTRUE(all.equal(candidate('(7, 8, 9)'), c(7, 8, 9))))\n    stopifnot(isTRUE(all.equal(candidate('(1, 2, 3)'), c(1, 2, 3))))\n    stopifnot(isTRUE(all.equal(candidate('(4, 5, 6)'), c(4, 5, 6))))\n    stopifnot(isTRUE(all.equal(candidate('(7, 81, 19)'), c(7, 81, 19))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "r",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\nright_insertion <- function(a, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- right_insertion\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 6), 4)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 3), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 4, 5), 7), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ntext_match_three <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_match_three\n    stopifnot(isTRUE(all.equal(candidate('ac'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('dc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('abbbba'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('caacabbbba'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "r",
+    "prompt": "# Write a function to create a new list from the given string and list.\nnew_tuple <- function(test_list, test_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- new_tuple\n    stopifnot(isTRUE(all.equal(candidate(c('WEB', 'is'), 'best'), c('WEB', 'is', 'best'))))\n    stopifnot(isTRUE(all.equal(candidate(c('We', 'are'), 'Developers'), c('We', 'are', 'Developers'))))\n    stopifnot(isTRUE(all.equal(candidate(c('Part', 'is'), 'Wrong'), c('Part', 'is', 'Wrong'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether every even index contains even numbers of a given list.\neven_position <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- even_position\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 1, 4)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "r",
+    "prompt": "# Write a function to remove lists from the given list.\nremove_nested <- function(test_tup) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_nested\n    stopifnot(isTRUE(all.equal(candidate(list(1, 5, 7, c(4, 6), 10)), c(1, 5, 7, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(2, 6, 8, c(5, 7), 11)), c(2, 6, 8, 11))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), 12)), c(3, 7, 9, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(3, 7, 9, c(6, 8), c(5, 12), 12)), c(3, 7, 9, 12))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of lists in a given number of lists.\ncount_list <- function(input_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 3), c(5, 7), c(9, 11), c(13, 15, 17))), 4)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(2, 3), c(4, 5))), 3)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 0), c(2, 0))), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the last position of an element in a sorted vector.\nlast <- function(arr, x) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- last\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), 1), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1, 1, 2, 3, 4), 1), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 3, 2, 3, 6, 8, 9), 3), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "r",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ntext_starta_endb <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- text_starta_endb\n    stopifnot(isTRUE(all.equal(candidate('aabbbb'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('aabAbbbc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('accddbbjjj'), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "r",
+    "prompt": "# Write function to find the sum of all items in the given named list.\nreturn_sum <- function(dict) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- return_sum\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 100, 'b' = 200, 'c' = 300)), 600)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 25, 'b' = 18, 'c' = 45)), 88)))\n    stopifnot(isTRUE(all.equal(candidate(list('a' = 36, 'b' = 39, 'c' = 49)), 124)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of all odd natural numbers within the range l and r.\nsum_in_range <- function(l, r) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sum_in_range\n    stopifnot(isTRUE(all.equal(candidate(2, 5), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 7), 12)))\n    stopifnot(isTRUE(all.equal(candidate(7, 13), 40)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the sum of a vector.\n_sum <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- _sum\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 6)))\n    stopifnot(isTRUE(all.equal(candidate(c(15, 12, 13, 10)), 50)))\n    stopifnot(isTRUE(all.equal(candidate(c(0, 1, 2)), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "r",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nleft_rotate <- function(n, d) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- left_rotate\n    stopifnot(isTRUE(all.equal(candidate(16, 2), 64)))\n    stopifnot(isTRUE(all.equal(candidate(10, 2), 40)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(99, 3), 792)))\n    stopifnot(isTRUE(all.equal(candidate(1, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 3), 40)))\n    stopifnot(isTRUE(all.equal(candidate(29, 3), 232)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "r",
+    "prompt": "# Write a rthon function to check whether the length of the word is odd or not.\nword_len <- function(s) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- word_len\n    stopifnot(isTRUE(all.equal(candidate('Hadoop'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate('great'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate('structure'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "r",
+    "prompt": "# Write a function to remove all whitespaces from a string.\nremove_all_spaces <- function(text) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- remove_all_spaces\n    stopifnot(isTRUE(all.equal(candidate('python  program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('python   programming    language'), 'pythonprogramminglanguage')))\n    stopifnot(isTRUE(all.equal(candidate('python                     program'), 'pythonprogram')))\n    stopifnot(isTRUE(all.equal(candidate('   python                     program'), 'pythonprogram')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of equal numbers from three given integers.\ntest_three_equal <- function(x, y, z) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- test_three_equal\n    stopifnot(isTRUE(all.equal(candidate(1, 1, 1), 3)))\n    stopifnot(isTRUE(all.equal(candidate(-1, -2, -3), 0)))\n    stopifnot(isTRUE(all.equal(candidate(1, 2, 2), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "r",
+    "prompt": "# Write a rthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\ncount_rotation <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- count_rotation\n    stopifnot(isTRUE(all.equal(candidate(c(3, 2, 1)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 1, 2, 3)), 2)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 1, 2, 3)), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), 0)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 2)), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nis_perfect_square <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_perfect_square\n    stopifnot(isTRUE(all.equal(candidate(10), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(36), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(14), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(196), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(125), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(15625), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "r",
+    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\nis_product_even <- function(arr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_product_even\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 1, 4)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 1)), FALSE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "r",
+    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\nmax_sum_list <- function(lists) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_sum_list\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3), c(4, 5, 6), c(10, 11, 12), c(7, 8, 9))), c(10, 11, 12))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 2, 1), c(6, 5, 4), c(12, 11, 10))), c(12, 11, 10))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(2, 3, 1))), c(2, 3, 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "r",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\nmax_run_uppercase <- function(test_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- max_run_uppercase\n    stopifnot(isTRUE(all.equal(candidate('GeMKSForGERksISBESt'), 5)))\n    stopifnot(isTRUE(all.equal(candidate('PrECIOusMOVemENTSYT'), 6)))\n    stopifnot(isTRUE(all.equal(candidate('GooGLEFluTTER'), 4)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the first odd number in a given list of numbers.\nfirst_odd <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- first_odd\n    stopifnot(isTRUE(all.equal(candidate(c(1, 3, 5)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(2, 4, 1, 3)), 1)))\n    stopifnot(isTRUE(all.equal(candidate(c(8, 9, 1)), 9)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "r",
+    "prompt": "# Write a function to check if the given lists contain the k or not.\ncheck_K <- function(test_tup, K) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_K\n    stopifnot(isTRUE(all.equal(candidate(c(10, 4, 5, 6, 8), 6), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6), 7), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(7, 8, 9, 44, 11, 12), 11), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "r",
+    "prompt": "# Write a function to check if each element of second list is smaller than its corresponding element in the first list.\ncheck_smaller <- function(test_tup1, test_tup2) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- check_smaller\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3), c(2, 3, 4)), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c(4, 5, 6), c(3, 4, 5)), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c(11, 12, 13), c(10, 11, 12)), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "r",
+    "prompt": "# Write a function to find the nth tetrahedral number.\ntetrahedral_number <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- tetrahedral_number\n    stopifnot(isTRUE(all.equal(candidate(5), 35)))\n    stopifnot(isTRUE(all.equal(candidate(6), 56)))\n    stopifnot(isTRUE(all.equal(candidate(7), 84)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nget_Char <- function(strr) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- get_Char\n    stopifnot(isTRUE(all.equal(candidate('abc'), 'f')))\n    stopifnot(isTRUE(all.equal(candidate('gfg'), 't')))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 'c')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "r",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\nsequence <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- sequence\n    stopifnot(isTRUE(all.equal(candidate(10), 6)))\n    stopifnot(isTRUE(all.equal(candidate(2), 1)))\n    stopifnot(isTRUE(all.equal(candidate(3), 2)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "r",
+    "prompt": "# Write a function to find nth centered hexagonal number.\ncentered_hexagonal_number <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- centered_hexagonal_number\n    stopifnot(isTRUE(all.equal(candidate(10), 271)))\n    stopifnot(isTRUE(all.equal(candidate(2), 7)))\n    stopifnot(isTRUE(all.equal(candidate(9), 217)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "r",
+    "prompt": "# Write a function to merge three dictionaries into a single named list.\nmerge_dictionaries_three <- function(dict1, dict2, dict3) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- merge_dictionaries_three\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('O' = 'Orange', 'W' = 'White', 'B' = 'Black')), list('B' = 'Black', 'R' = 'Red', 'P' = 'Pink', 'G' = 'Green', 'W' = 'White', 'O' = 'Orange'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('G' = 'Green', 'W' = 'White'), list('L' = 'lavender', 'B' = 'Blue')), list('W' = 'White', 'P' = 'Pink', 'B' = 'Black', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender'))))\n    stopifnot(isTRUE(all.equal(candidate(list('R' = 'Red', 'B' = 'Black', 'P' = 'Pink'), list('L' = 'lavender', 'B' = 'Blue'), list('G' = 'Green', 'W' = 'White')), list('B' = 'Black', 'P' = 'Pink', 'R' = 'Red', 'G' = 'Green', 'L' = 'lavender', 'W' = 'White'))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "r",
+    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a named list.\nfreq_count <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- freq_count\n    stopifnot(isTRUE(all.equal(candidate(c(10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30)), list(10 = 4, 20 = 4, 40 = 2, 50 = 2, 30 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4)), list(1 = 3, 2 = 2, 3 = 3, 4 = 3))))\n    stopifnot(isTRUE(all.equal(candidate(c(5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5)), list(10 = 1, 5 = 3, 6 = 2, 7 = 2, 4 = 2, 9 = 2))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "r",
+    "prompt": "# Write a function to find the closest smaller number than n.\nclosest_num <- function(N) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- closest_num\n    stopifnot(isTRUE(all.equal(candidate(11), 10)))\n    stopifnot(isTRUE(all.equal(candidate(7), 6)))\n    stopifnot(isTRUE(all.equal(candidate(12), 11)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "r",
+    "prompt": "# Write a function to find squares of individual elements in a list.\nsquare_nums <- function(nums) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- square_nums\n    stopifnot(isTRUE(all.equal(candidate(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), c(1, 4, 9, 16, 25, 36, 49, 64, 81, 100))))\n    stopifnot(isTRUE(all.equal(candidate(c(10, 20, 30)), c(100, 400, 900))))\n    stopifnot(isTRUE(all.equal(candidate(c(12, 15)), c(144, 225))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the length of the longest word.\nlen_log <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- len_log\n    stopifnot(isTRUE(all.equal(candidate(c('python', 'PHP', 'bigdata')), 7)))\n    stopifnot(isTRUE(all.equal(candidate(c('a', 'ab', 'abc')), 3)))\n    stopifnot(isTRUE(all.equal(candidate(c('small', 'big', 'tall')), 5)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "r",
+    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\nfind_substring <- function(str1, sub_str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_substring\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ack'), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'abc'), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(c('red', 'black', 'white', 'green', 'orange'), 'ange'), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "r",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\nis_undulating <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- is_undulating\n    stopifnot(isTRUE(all.equal(candidate(1212121), TRUE)))\n    stopifnot(isTRUE(all.equal(candidate(1991), FALSE)))\n    stopifnot(isTRUE(all.equal(candidate(121), TRUE)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "r",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\npower <- function(a, b) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- power\n    stopifnot(isTRUE(all.equal(candidate(3, 4), 81)))\n    stopifnot(isTRUE(all.equal(candidate(2, 3), 8)))\n    stopifnot(isTRUE(all.equal(candidate(5, 5), 3125)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "r",
+    "prompt": "# Given a list of lists, write a function that returns the first value of the list with the smallest second value.\nindex_minimum <- function(test_list) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- index_minimum\n    stopifnot(isTRUE(all.equal(candidate(list(list('Rash', 143), list('Manjeet', 200), list('Varsha', 100))), 'Varsha')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Yash', 185), list('Dawood', 125), list('Sanya', 175))), 'Dawood')))\n    stopifnot(isTRUE(all.equal(candidate(list(list('Sai', 345), list('Salman', 145), list('Ayesha', 96))), 'Ayesha')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the length of the smallest list in a list of lists.\nFind_Min_Length <- function(lst) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- Find_Min_Length\n    stopifnot(isTRUE(all.equal(candidate(list(c(1), c(1, 2))), 1)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2), c(1, 2, 3), c(1, 2, 3, 4))), 2)))\n    stopifnot(isTRUE(all.equal(candidate(list(c(3, 3, 3), c(4, 4, 4, 4))), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the number of divisors of a given integer.\ndivisor <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- divisor\n    stopifnot(isTRUE(all.equal(candidate(15), 4)))\n    stopifnot(isTRUE(all.equal(candidate(12), 6)))\n    stopifnot(isTRUE(all.equal(candidate(9), 3)))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "r",
+    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a named list.\nfrequency_lists <- function(list1) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- frequency_lists\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 2), c(4, 5, 6, 2), c(7, 8, 9, 5))), list(1 = 1, 2 = 3, 3 = 1, 4 = 1, 5 = 2, 6 = 1, 7 = 1, 8 = 1, 9 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(1, 2, 3, 4), c(5, 6, 7, 8), c(9, 10, 11, 12))), list(1 = 1, 2 = 1, 3 = 1, 4 = 1, 5 = 1, 6 = 1, 7 = 1, 8 = 1, 9 = 1, 10 = 1, 11 = 1, 12 = 1))))\n    stopifnot(isTRUE(all.equal(candidate(list(c(20, 30, 40, 17), c(18, 16, 14, 13), c(10, 20, 30, 40))), list(20 = 2, 30 = 2, 40 = 2, 17 = 1, 18 = 1, 16 = 1, 14 = 1, 13 = 1, 10 = 1))))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "r",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndecimal_to_binary <- function(n) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- decimal_to_binary\n    stopifnot(isTRUE(all.equal(candidate(8), '1000')))\n    stopifnot(isTRUE(all.equal(candidate(18), '10010')))\n    stopifnot(isTRUE(all.equal(candidate(7), '111')))\n}\ntest_humaneval()",
+    "stop_tokens": [
+      "\n#",
+      "\n```"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "r",
+    "prompt": "# Write a rthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfind_Rotations <- function(str) {",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "test_humaneval <- function() {\n    candidate <- find_Rotations\n    stopifnot(isTRUE(all.equal(candidate('aaaa'), 1)))\n    stopifnot(isTRUE(all.equal(candidate('ab'), 2)))\n    stopifnot(isTRUE(all.equal(candidate('abc'), 3)))\n}\ntest_humaneval()",
     "stop_tokens": [
       "\n#",
       "\n```"

--- a/prompts/mbpp-rb-keep.json
+++ b/prompts/mbpp-rb-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rb",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\ndef lps(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lps\n    candidate = method(:lps)\n    assert_equal(5, candidate.call(\"TENS FOR TENS\"))\n    assert_equal(7, candidate.call(\"CARDIO FOR CARDS\"))\n    assert_equal(9, candidate.call(\"PART OF THE JOURNEY IS PART\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rb",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\ndef remove_whitespaces(text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_whitespaces\n    candidate = method(:remove_whitespaces)\n    assert_equal(\"GoogleFlutter\", candidate.call(\" Google    Flutter \"))\n    assert_equal(\"GoogleDart\", candidate.call(\" Google    Dart \"))\n    assert_equal(\"iOSSwift\", candidate.call(\" iOS    Swift \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rb",
-    "prompt": "# Write a function to check whether a specified list is sorted or not.\ndef issort_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_issort_list\n    candidate = method(:issort_list)\n    assert_equal(true, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 15, 14, 20]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rb",
-    "prompt": "# Write a function to count bidirectional tuple pairs.\ndef count_bidirectional(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_bidirectional\n    candidate = method(:count_bidirectional)\n    assert_equal(3, candidate.call([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(2, candidate.call([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(4, candidate.call([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rb",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\ndef surfacearea_cube(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cube\n    candidate = method(:surfacearea_cube)\n    assert_equal(150, candidate.call(5))\n    assert_equal(54, candidate.call(3))\n    assert_equal(600, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rb",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\ndef next_smallest_palindrome(num)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest_palindrome\n    candidate = method(:next_smallest_palindrome)\n    assert_equal(101, candidate.call(99))\n    assert_equal(1331, candidate.call(1221))\n    assert_equal(121, candidate.call(120))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\ndef cube_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_Sum\n    candidate = method(:cube_Sum)\n    assert_equal(72, candidate.call(2))\n    assert_equal(288, candidate.call(3))\n    assert_equal(800, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\ndef pair_xor_Sum(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_xor_Sum\n    candidate = method(:pair_xor_Sum)\n    assert_equal(47, candidate.call([5, 9, 7, 6], 4))\n    assert_equal(12, candidate.call([7, 3, 5], 3))\n    assert_equal(4, candidate.call([7, 3], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ndef check_min_heap(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_min_heap\n    candidate = method(:check_min_heap)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 10, 15]))\n    assert_equal(false, candidate.call([2, 10, 4, 5, 3, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rb",
-    "prompt": "# Write a python function to find the first digit of a given number.\ndef first_Digit(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_Digit\n    candidate = method(:first_Digit)\n    assert_equal(1, candidate.call(123))\n    assert_equal(4, candidate.call(456))\n    assert_equal(1, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rb",
-    "prompt": "# Write a python function to find the first non-repeated character in a given string.\ndef first_non_repeating_character(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_non_repeating_character\n    candidate = method(:first_non_repeating_character)\n    assert_equal(nil, candidate.call(\"abcabc\"))\n    assert_equal(\"a\", candidate.call(\"abc\"))\n    assert_equal(\"c\", candidate.call(\"ababc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rb",
-    "prompt": "# Write a function to convert degrees to radians.\ndef radian_degree(degree)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_radian_degree\n    candidate = method(:radian_degree)\n    assert_equal(1.5707963267948966, candidate.call(90))\n    assert_equal(1.0471975511965976, candidate.call(60))\n    assert_equal(2.0943951023931953, candidate.call(120))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum product subarray of the given array.\ndef max_subarray_product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_subarray_product\n    candidate = method(:max_subarray_product)\n    assert_equal(112, candidate.call([1, -2, -3, 0, 7, -8, -2]))\n    assert_equal(180, candidate.call([6, -3, -10, 0, 2]))\n    assert_equal(80, candidate.call([-2, -40, 0, -2, -3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "rb",
-    "prompt": "# Write a function to convert more than one list to nested dictionary.\ndef convert_list_dictionary(l1, l2, l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert_list_dictionary\n    candidate = method(:convert_list_dictionary)\n    assert_equal([{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}], candidate.call([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]))\n    assert_equal([{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}], candidate.call([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]))\n    assert_equal([{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}], candidate.call([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rb",
-    "prompt": "# Write a python function to find smallest number in a list.\ndef smallest_num(xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_num\n    candidate = method(:smallest_num)\n    assert_equal(1, candidate.call([10, 20, 1, 45, 99]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n    assert_equal(45, candidate.call([45, 46, 50, 60]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\ndef text_match_zero_one(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_zero_one\n    candidate = method(:text_match_zero_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"dsabbbba\"))\n    assert_equal(false, candidate.call(\"asbbbba\"))\n    assert_equal(true, candidate.call(\"abaaa\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rb",
-    "prompt": "# Write a python function to find nth bell number.\ndef bell_Number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_Number\n    candidate = method(:bell_Number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(15, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rb",
-    "prompt": "# Write a function to find cubes of individual elements in a list.\ndef cube_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_nums\n    candidate = method(:cube_nums)\n    assert_equal([1, 8, 27, 64, 125, 216, 343, 512, 729, 1000], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30]))\n    assert_equal([1728, 3375], candidate.call([12, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rb",
-    "prompt": "# Write a python function to find the last digit in factorial of a given number.\ndef last_Digit_Factorial(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit_Factorial\n    candidate = method(:last_Digit_Factorial)\n    assert_equal(4, candidate.call(4))\n    assert_equal(0, candidate.call(21))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rb",
-    "prompt": "# Write a python function to find even numbers from a list of numbers.\ndef Split(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([2, 4], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([4, 6, 8, 0], candidate.call([4, 5, 6, 7, 8, 0, 1]))\n    assert_equal([8, 12], candidate.call([8, 12, 15, 19]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given integer is a prime number.\ndef prime_num(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_num\n    candidate = method(:prime_num)\n    assert_equal(true, candidate.call(13))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(-1010))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\ndef find_tuples(test_list, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_tuples\n    candidate = method(:find_tuples)\n    assert_equal([[6, 24, 12]], candidate.call([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6))\n    assert_equal([[5, 25, 30]], candidate.call([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5))\n    assert_equal([[8, 16, 4]], candidate.call([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rb",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\ndef area_tetrahedron(side)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_area_tetrahedron\n    candidate = method(:area_tetrahedron)\n    assert_equal(15.588457268119894, candidate.call(3))\n    assert_equal(692.8203230275509, candidate.call(20))\n    assert_equal(173.20508075688772, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given number is even or not.\ndef is_Even(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Even\n    candidate = method(:is_Even)\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(2))\n    assert_equal(false, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of positive numbers in a list.\ndef pos_count(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pos_count\n    candidate = method(:pos_count)\n    assert_equal(2, candidate.call([1, -2, 3, -4]))\n    assert_equal(3, candidate.call([3, 4, 5, -1]))\n    assert_equal(4, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rb",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\ndef get_ludic(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_ludic\n    candidate = method(:get_ludic)\n    assert_equal([1, 2, 3, 5, 7], candidate.call(10))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25], candidate.call(25))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43], candidate.call(45))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rb",
-    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\ndef find_Index(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Index\n    candidate = method(:find_Index)\n    assert_equal(4, candidate.call(2))\n    assert_equal(14, candidate.call(3))\n    assert_equal(45, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rb",
-    "prompt": "# Write a python function to reverse an array upto a given position.\ndef reverse_Array_Upto_K(input, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_Array_Upto_K\n    candidate = method(:reverse_Array_Upto_K)\n    assert_equal([4, 3, 2, 1, 5, 6], candidate.call([1, 2, 3, 4, 5, 6], 4))\n    assert_equal([5, 4, 6, 7], candidate.call([4, 5, 6, 7], 2))\n    assert_equal([7, 8, 9, 6, 5], candidate.call([9, 8, 7, 6, 5], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rb",
-    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\ndef subject_marks(subjectmarks)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_subject_marks\n    candidate = method(:subject_marks)\n    assert_equal([[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]], candidate.call([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]))\n    assert_equal([[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]], candidate.call([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]))\n    assert_equal([[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]], candidate.call([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rb",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\ndef remove_dirty_chars(string, second_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_dirty_chars\n    candidate = method(:remove_dirty_chars)\n    assert_equal(\"bacuve\", candidate.call(\"probasscurve\", \"pros\"))\n    assert_equal(\"digiidi\", candidate.call(\"digitalindia\", \"talent\"))\n    assert_equal(\"emles\", candidate.call(\"exoticmiles\", \"toxic\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "rb",
-    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\ndef round_and_sum(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_round_and_sum\n    candidate = method(:round_and_sum)\n    assert_equal(243, candidate.call([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]))\n    assert_equal(345, candidate.call([5, 2, 9, 24.3, 29]))\n    assert_equal(513, candidate.call([25.0, 56.7, 89.2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rb",
-    "prompt": "# Write a function to find the item with maximum frequency in a given list.\ndef max_occurrences(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_occurrences\n    candidate = method(:max_occurrences)\n    assert_equal(2, candidate.call([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]))\n    assert_equal(8, candidate.call([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]))\n    assert_equal(20, candidate.call([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rb",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\ndef is_decimal(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_decimal\n    candidate = method(:is_decimal)\n    assert_equal(true, candidate.call(\"123.11\"))\n    assert_equal(false, candidate.call(\"e666.86\"))\n    assert_equal(false, candidate.call(\"3.124587\"))\n    assert_equal(true, candidate.call(\"1.11\"))\n    assert_equal(false, candidate.call(\"1.1.11\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\ndef dict_filter(dict, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dict_filter\n    candidate = method(:dict_filter)\n    assert_equal({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170))\n    assert_equal({\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180))\n    assert_equal({\"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\ndef sum_even_and_even_index(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_even_and_even_index\n    candidate = method(:sum_even_and_even_index)\n    assert_equal(30, candidate.call([5, 6, 12, 1, 18, 8]))\n    assert_equal(26, candidate.call([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]))\n    assert_equal(12, candidate.call([5, 6, 12, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\ndef max_sub_array_sum(a, size)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum\n    candidate = method(:max_sub_array_sum)\n    assert_equal(7, candidate.call([-2, -3, 4, -1, -2, 1, 5, -3], 8))\n    assert_equal(8, candidate.call([-3, -4, 5, -2, -3, 2, 6, -4], 8))\n    assert_equal(10, candidate.call([-4, -5, 6, -3, -4, 3, 7, -5], 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rb",
-    "prompt": "# Write a function to find the intersection of two arrays.\ndef intersection_array(array_nums1, array_nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection_array\n    candidate = method(:intersection_array)\n    assert_equal([1, 2, 8, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]))\n    assert_equal([3, 5, 7, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]))\n    assert_equal([10], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\ndef split_two_parts(list1, l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_two_parts\n    candidate = method(:split_two_parts)\n    assert_equal([[1, 1, 2], [3, 4, 4, 5, 1]], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"]], candidate.call([\"a\", \"b\", \"c\", \"d\"], 2))\n    assert_equal([[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]], candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rb",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\ndef find_literals(text, pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_literals\n    candidate = method(:find_literals)\n    assert_equal([\"fox\", 16, 19], candidate.call(\"The quick brown fox jumps over the lazy dog.\", \"fox\"))\n    assert_equal([\"crazy\", 16, 21], candidate.call(\"Its been a very crazy procedure right\", \"crazy\"))\n    assert_equal([\"will\", 35, 39], candidate.call(\"Hardest choices required strongest will\", \"will\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rb",
-    "prompt": "# Write a python function to find the volume of a triangular prism.\ndef find_Volume(l, b, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Volume\n    candidate = method(:find_Volume)\n    assert_equal(240, candidate.call(10, 8, 6))\n    assert_equal(6, candidate.call(3, 2, 2))\n    assert_equal(1, candidate.call(1, 2, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\ndef wind_chill(v, t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_wind_chill\n    candidate = method(:wind_chill)\n    assert_equal(40, candidate.call(120, 35))\n    assert_equal(19, candidate.call(40, 20))\n    assert_equal(6, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rb",
-    "prompt": "# Write a function to find the ascii value of a character.\ndef ascii_value(k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_ascii_value\n    candidate = method(:ascii_value)\n    assert_equal(65, candidate.call(\"A\"))\n    assert_equal(82, candidate.call(\"R\"))\n    assert_equal(83, candidate.call(\"S\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether all the characters are same or not.\ndef all_Characters_Same(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Characters_Same\n    candidate = method(:all_Characters_Same)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"aaa\"))\n    assert_equal(false, candidate.call(\"data\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rb",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\ndef move_num(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_num\n    candidate = method(:move_num)\n    assert_equal(\"Iloveyouthreethousand1143553000\", candidate.call(\"I1love143you55three3000thousand\"))\n    assert_equal(\"AvengersAssemble124\", candidate.call(\"Avengers124Assemble\"))\n    assert_equal(\"Itsourpathtoseethingsdothings11121314151617\", candidate.call(\"Its11our12path13to14see15things16do17things\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the length of the word is odd or not.\ndef word_len(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_word_len\n    candidate = method(:word_len)\n    assert_equal(false, candidate.call(\"Hadoop\"))\n    assert_equal(true, candidate.call(\"great\"))\n    assert_equal(true, candidate.call(\"structure\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "rb",
-    "prompt": "# Write a function to drop empty items from a given dictionary.\ndef drop_empty(dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_drop_empty\n    candidate = method(:drop_empty)\n    assert_equal({\"c1\" => \"Red\", \"c2\" => \"Green\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => nil}))\n    assert_equal({\"c1\" => \"Red\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => nil, \"c3\" => nil}))\n    assert_equal({\"c2\" => \"Green\"}, candidate.call({\"c1\" => nil, \"c2\" => \"Green\", \"c3\" => nil}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ndef insert_element(list, element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_insert_element\n    candidate = method(:insert_element)\n    assert_equal([\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"], candidate.call([\"Red\", \"Green\", \"Black\"], \"c\"))\n    assert_equal([\"program\", \"python\", \"program\", \"java\"], candidate.call([\"python\", \"java\"], \"program\"))\n    assert_equal([\"laugh\", \"happy\", \"laugh\", \"sad\"], candidate.call([\"happy\", \"sad\"], \"laugh\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rb",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\ndef remove_lowercase(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_lowercase\n    candidate = method(:remove_lowercase)\n    assert_equal(\"PYTH\", candidate.call(\"PYTHon\"))\n    assert_equal(\"FID\", candidate.call(\"FInD\"))\n    assert_equal(\"STRG\", candidate.call(\"STRinG\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\ndef count_Set_Bits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Set_Bits\n    candidate = method(:count_Set_Bits)\n    assert_equal(1, candidate.call(2))\n    assert_equal(1, candidate.call(4))\n    assert_equal(2, candidate.call(6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rb",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\ndef extract_rear(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_rear\n    candidate = method(:extract_rear)\n    assert_equal([\"s\", \"r\", \"s\"], candidate.call([\"Mers\", \"for\", \"Vers\"]))\n    assert_equal([\"e\", \"r\", \"e\"], candidate.call([\"Avenge\", \"for\", \"People\"]))\n    assert_equal([\"a\", \"t\", \"o\"], candidate.call([\"Gotta\", \"get\", \"go\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ndef count_occurance(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_occurance\n    candidate = method(:count_occurance)\n    assert_equal(3, candidate.call(\"letstdlenstdporstd\"))\n    assert_equal(1, candidate.call(\"truststdsolensporsd\"))\n    assert_equal(2, candidate.call(\"makestdsostdworthit\"))\n    assert_equal(1, candidate.call(\"stds\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given tuples contain the k or not.\ndef check_K(test_tup, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_K\n    candidate = method(:check_K)\n    assert_equal(true, candidate.call([10, 4, 5, 6, 8], 6))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5, 6], 7))\n    assert_equal(true, candidate.call([7, 8, 9, 44, 11, 12], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rb",
-    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ndef interleave_lists(list1, list2, list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_interleave_lists\n    candidate = method(:interleave_lists)\n    assert_equal([1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700], candidate.call([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]))\n    assert_equal([10, 15, 5, 20, 2, 10], candidate.call([10, 20], [15, 2], [5, 10]))\n    assert_equal([11, 10, 20, 44, 15, 5], candidate.call([11, 44], [10, 15], [20, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rb",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\ndef snake_to_camel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"PythonProgram\", candidate.call(\"python_program\"))\n    assert_equal(\"PythonLanguage\", candidate.call(\"python_language\"))\n    assert_equal(\"ProgrammingLanguage\", candidate.call(\"programming_language\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\ndef test_three_equal(x, y, z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_three_equal\n    candidate = method(:test_three_equal)\n    assert_equal(3, candidate.call(1, 1, 1))\n    assert_equal(0, candidate.call(-1, -2, -3))\n    assert_equal(2, candidate.call(1, 2, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\ndef odd_length_sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_length_sum\n    candidate = method(:odd_length_sum)\n    assert_equal(14, candidate.call([1, 2, 4]))\n    assert_equal(15, candidate.call([1, 2, 1, 2]))\n    assert_equal(8, candidate.call([1, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rb",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\ndef bell_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_number\n    candidate = method(:bell_number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(115975, candidate.call(10))\n    assert_equal(6775685320645824322581483068371419745979053216268760300, candidate.call(56))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rb",
-    "prompt": "# Write a function to find the area of a rectangle.\ndef rectangle_area(l, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rectangle_area\n    candidate = method(:rectangle_area)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(10, 5))\n    assert_equal(8, candidate.call(4, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rb",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\ndef sum_average(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_average\n    candidate = method(:sum_average)\n    assert_equal([55, 5.5], candidate.call(10))\n    assert_equal([120, 8.0], candidate.call(15))\n    assert_equal([210, 10.5], candidate.call(20))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\ndef division_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_division_elements\n    candidate = method(:division_elements)\n    assert_equal([2, 2, 2, 3], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([2, 2, 2, 4], candidate.call([12, 6, 8, 16], [6, 3, 4, 4]))\n    assert_equal([4, 2, 6, 2], candidate.call([20, 14, 36, 18], [5, 7, 6, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rb",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\ndef sum_digits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_digits\n    candidate = method(:sum_digits)\n    assert_equal(12, candidate.call(345))\n    assert_equal(3, candidate.call(12))\n    assert_equal(16, candidate.call(97))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rb",
-    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\ndef index_minimum(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_minimum\n    candidate = method(:index_minimum)\n    assert_equal(\"Varsha\", candidate.call([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]))\n    assert_equal(\"Dawood\", candidate.call([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]))\n    assert_equal(\"Ayesha\", candidate.call([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rb",
-    "prompt": "# Write a function to divide two lists element wise.\ndef div_list(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_div_list\n    candidate = method(:div_list)\n    assert_equal([4.0, 2.5, 2.0], candidate.call([4, 5, 6], [1, 2, 3]))\n    assert_equal([3.0, 0.5], candidate.call([3, 2], [1, 4]))\n    assert_equal([1.8, 1.7142857142857142], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rb",
-    "prompt": "# Write a function to find the list with maximum length.\ndef max_length_list(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length_list\n    candidate = method(:max_length_list)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([5, [1, 2, 3, 4, 5]], candidate.call([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]))\n    assert_equal([4, [6, 7, 8, 9]], candidate.call([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "rb",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ndef combinations_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_list\n    candidate = method(:combinations_list)\n    assert_equal([[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]], candidate.call([\"orange\", \"red\", \"green\", \"blue\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"black\", \"orange\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\ndef big_sum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_sum\n    candidate = method(:big_sum)\n    assert_equal(4, candidate.call([1, 2, 3]))\n    assert_equal(3, candidate.call([-1, 2, 3, 4]))\n    assert_equal(8, candidate.call([2, 3, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rb",
-    "prompt": "# Write a python function to return the negative numbers in a list.\ndef neg_nos(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_neg_nos\n    candidate = method(:neg_nos)\n    assert_equal([-1, -6], candidate.call([-1, 4, 5, -6]))\n    assert_equal([-1, -2], candidate.call([-1, -2, 3, 4]))\n    assert_equal([-7, -6], candidate.call([-7, -6, 8, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rb",
-    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\ndef highest_Power_of_2(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_highest_Power_of_2\n    candidate = method(:highest_Power_of_2)\n    assert_equal(8, candidate.call(10))\n    assert_equal(16, candidate.call(19))\n    assert_equal(32, candidate.call(32))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rb",
-    "prompt": "# Write a function to check whether a list contains the given sublist or not.\ndef is_sublist(l, s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sublist\n    candidate = method(:is_sublist)\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [3, 7]))\n    assert_equal(true, candidate.call([2, 4, 3, 5, 7], [4, 3]))\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [1, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rb",
-    "prompt": "# Write a function to subtract two lists element-wise.\ndef sub_list(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sub_list\n    candidate = method(:sub_list)\n    assert_equal([-3, -3, -3], candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal([-2, -2], candidate.call([1, 2], [3, 4]))\n    assert_equal([40, 50], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\ndef opposite_Signs(x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_opposite_Signs\n    candidate = method(:opposite_Signs)\n    assert_equal(true, candidate.call(1, -2))\n    assert_equal(false, candidate.call(3, 2))\n    assert_equal(false, candidate.call(-10, -10))\n    assert_equal(true, candidate.call(-2, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rb",
-    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\ndef tuple_modulo(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_modulo\n    candidate = method(:tuple_modulo)\n    assert_equal([0, 4, 5, 1], candidate.call([10, 4, 5, 6], [5, 6, 7, 5]))\n    assert_equal([5, 5, 6, 1], candidate.call([11, 5, 6, 7], [6, 7, 8, 6]))\n    assert_equal([5, 6, 7, 1], candidate.call([12, 6, 7, 8], [7, 8, 9, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rb",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndef diff_even_odd(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_diff_even_odd\n    candidate = method(:diff_even_odd)\n    assert_equal(3, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(9, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rb",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\ndef sort_sublists(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]], candidate.call([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rb",
-    "prompt": "# Write a python function to find the last digit of a given number.\ndef last_Digit(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit\n    candidate = method(:last_Digit)\n    assert_equal(3, candidate.call(123))\n    assert_equal(5, candidate.call(25))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\ndef odd_num_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_num_sum\n    candidate = method(:odd_num_sum)\n    assert_equal(82, candidate.call(2))\n    assert_equal(707, candidate.call(3))\n    assert_equal(3108, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rb",
-    "prompt": "# Write a function to convert a list to a string.\ndef tup_string(tup1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tup_string\n    candidate = method(:tup_string)\n    assert_equal(\"exercises\", candidate.call([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]))\n    assert_equal(\"python\", candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]))\n    assert_equal(\"program\", candidate.call([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rb",
-    "prompt": "# Write a function to remove all elements from a given list present in another list.\ndef remove_elements(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_elements\n    candidate = method(:remove_elements)\n    assert_equal([1, 3, 5, 7, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]))\n    assert_equal([2, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]))\n    assert_equal([1, 2, 3, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\ndef overlapping(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_overlapping\n    candidate = method(:overlapping)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(false, candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal(true, candidate.call([1, 4, 5], [1, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rb",
-    "prompt": "# Write a python function to identify non-prime numbers.\ndef is_not_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_not_prime\n    candidate = method(:is_not_prime)\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(10))\n    assert_equal(true, candidate.call(35))\n    assert_equal(false, candidate.call(37))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\ndef max_val(listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_val\n    candidate = method(:max_val)\n    assert_equal(5, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(25, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(50, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\ndef sum_negativenum(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_negativenum\n    candidate = method(:sum_negativenum)\n    assert_equal(-32, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n    assert_equal(-52, candidate.call([10, 15, -14, 13, -18, 12, -20]))\n    assert_equal(-894, candidate.call([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rb",
-    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\ndef find_Rotations(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Rotations\n    candidate = method(:find_Rotations)\n    assert_equal(1, candidate.call(\"aaaa\"))\n    assert_equal(2, candidate.call(\"ab\"))\n    assert_equal(3, candidate.call(\"abc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rb",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\ndef change_date_format(dt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_date_format\n    candidate = method(:change_date_format)\n    assert_equal(\"02-01-2026\", candidate.call(\"2026-01-02\"))\n    assert_equal(\"13-11-2020\", candidate.call(\"2020-11-13\"))\n    assert_equal(\"26-04-2021\", candidate.call(\"2021-04-26\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rb",
-    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\ndef Split(list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([1, 3, 5], candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal([11, 13], candidate.call([10, 11, 12, 13]))\n    assert_equal([7, 9, 1], candidate.call([7, 8, 9, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rb",
-    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ndef toggle_middle_bits(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_middle_bits\n    candidate = method(:toggle_middle_bits)\n    assert_equal(15, candidate.call(9))\n    assert_equal(12, candidate.call(10))\n    assert_equal(13, candidate.call(11))\n    assert_equal(127, candidate.call(65))\n    assert_equal(115, candidate.call(77))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ndef count_char_position(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_char_position\n    candidate = method(:count_char_position)\n    assert_equal(2, candidate.call(\"xbcefg\"))\n    assert_equal(3, candidate.call(\"ABcED\"))\n    assert_equal(5, candidate.call(\"AbgdeF\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\ndef large_product(nums1, nums2, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_large_product\n    candidate = method(:large_product)\n    assert_equal([60, 54, 50], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3))\n    assert_equal([60, 54, 50, 48], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4))\n    assert_equal([60, 54, 50, 48, 45], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ndef cummulative_sum(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cummulative_sum\n    candidate = method(:cummulative_sum)\n    assert_equal(30, candidate.call([[1, 3], [5, 6, 7], [2, 6]]))\n    assert_equal(37, candidate.call([[2, 4], [6, 7, 8], [3, 7]]))\n    assert_equal(44, candidate.call([[3, 5], [7, 8, 9], [4, 8]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rb",
-    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\ndef find_min_diff(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_min_diff\n    candidate = method(:find_min_diff)\n    assert_equal(1, candidate.call([1, 5, 3, 19, 18, 25], 6))\n    assert_equal(1, candidate.call([4, 3, 2, 6], 4))\n    assert_equal(4, candidate.call([30, 5, 20, 9], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ndef text_starta_endb(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_starta_endb\n    candidate = method(:text_starta_endb)\n    assert_equal(true, candidate.call(\"aabbbb\"))\n    assert_equal(false, candidate.call(\"aabAbbbc\"))\n    assert_equal(false, candidate.call(\"accddbbjjj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rb",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\ndef left_rotate(n, d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_rotate\n    candidate = method(:left_rotate)\n    assert_equal(64, candidate.call(16, 2))\n    assert_equal(40, candidate.call(10, 2))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(8, candidate.call(1, 3))\n    assert_equal(40, candidate.call(5, 3))\n    assert_equal(232, candidate.call(29, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rb",
-    "prompt": "# Write a python function to find the first repeated character in a given string.\ndef first_repeated_char(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_repeated_char\n    candidate = method(:first_repeated_char)\n    assert_equal(\"a\", candidate.call(\"abcabc\"))\n    assert_equal(nil, candidate.call(\"abc\"))\n    assert_equal(\"1\", candidate.call(\"123123\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rb",
-    "prompt": "# Write a python function to count inversions in an array.\ndef get_Inv_Count(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Inv_Count\n    candidate = method(:get_Inv_Count)\n    assert_equal(5, candidate.call([1, 20, 6, 4, 5]))\n    assert_equal(1, candidate.call([1, 2, 1]))\n    assert_equal(3, candidate.call([1, 2, 5, 6, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rb",
-    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\ndef even_Power_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_Power_Sum\n    candidate = method(:even_Power_Sum)\n    assert_equal(1056, candidate.call(2))\n    assert_equal(8832, candidate.call(3))\n    assert_equal(32, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rb",
-    "prompt": "# Write a function to find whether all the given lists have equal length or not.\ndef get_equal(input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_equal\n    candidate = method(:get_equal)\n    assert_equal(true, candidate.call([[11, 22, 33], [44, 55, 66]]))\n    assert_equal(false, candidate.call([[1, 2, 3], [4, 5, 6, 7]]))\n    assert_equal(true, candidate.call([[1, 2], [3, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rb",
-    "prompt": "# Write a function to check if a string represents an integer or not.\ndef check_integer(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_integer\n    candidate = method(:check_integer)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"1\"))\n    assert_equal(true, candidate.call(\"12345\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rb",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\ndef count_reverse_pairs(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_reverse_pairs\n    candidate = method(:count_reverse_pairs)\n    assert_equal(2, candidate.call([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]))\n    assert_equal(1, candidate.call([\"geeks\", \"best\", \"for\", \"skeeg\"]))\n    assert_equal(2, candidate.call([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rb",
-    "prompt": "# Write a python function to move all zeroes to the end of the given list.\ndef move_zero(num_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_zero\n    candidate = method(:move_zero)\n    assert_equal([1, 2, 3, 4, 0, 0], candidate.call([1, 0, 2, 0, 3, 4]))\n    assert_equal([2, 3, 2, 4, 5, 0, 0, 0, 0], candidate.call([2, 3, 2, 0, 0, 4, 0, 5, 0]))\n    assert_equal([1, 1, 1, 0, 0], candidate.call([0, 1, 0, 1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rb",
-    "prompt": "# Write a function to check if given list contains no duplicates.\ndef check_distinct(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_distinct\n    candidate = method(:check_distinct)\n    assert_equal(false, candidate.call([1, 4, 5, 6, 1, 4]))\n    assert_equal(true, candidate.call([1, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\ndef noprofit_noloss(actual_cost, sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_noprofit_noloss\n    candidate = method(:noprofit_noloss)\n    assert_equal(false, candidate.call(1500, 1200))\n    assert_equal(true, candidate.call(100, 100))\n    assert_equal(false, candidate.call(2000, 5000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rb",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\ndef remove_length(test_str, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_length\n    candidate = method(:remove_length)\n    assert_equal(\"person is most value\", candidate.call(\"The person is most value tet\", 3))\n    assert_equal(\"If you me about ok\", candidate.call(\"If you told me about this ok\", 4))\n    assert_equal(\"Forces of darkeness is the\", candidate.call(\"Forces of darkeness is come into the play\", 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rb",
-    "prompt": "# Write a python function to count number of digits in a given string.\ndef number_ctr(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_ctr\n    candidate = method(:number_ctr)\n    assert_equal(1, candidate.call(\"program2bedone\"))\n    assert_equal(1, candidate.call(\"3wonders\"))\n    assert_equal(3, candidate.call(\"123\"))\n    assert_equal(3, candidate.call(\"3wond-1ers2\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rb",
-    "prompt": "# Write a function to count the total number of characters in a string.\ndef count_charac(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_charac\n    candidate = method(:count_charac)\n    assert_equal(18, candidate.call(\"python programming\"))\n    assert_equal(8, candidate.call(\"language\"))\n    assert_equal(5, candidate.call(\"words\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rb",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\ndef get_total_number_of_sequences(m, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_total_number_of_sequences\n    candidate = method(:get_total_number_of_sequences)\n    assert_equal(4, candidate.call(10, 4))\n    assert_equal(6, candidate.call(5, 2))\n    assert_equal(84, candidate.call(16, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rb",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\ndef left_insertion(a, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_insertion\n    candidate = method(:left_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\ndef swap_numbers(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_numbers\n    candidate = method(:swap_numbers)\n    assert_equal([20, 10], candidate.call(10, 20))\n    assert_equal([17, 15], candidate.call(15, 17))\n    assert_equal([200, 100], candidate.call(100, 200))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\ndef is_majority(arr, n, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_majority\n    candidate = method(:is_majority)\n    assert_equal(true, candidate.call([1, 2, 3, 3, 3, 3, 10], 7, 3))\n    assert_equal(false, candidate.call([1, 1, 2, 4, 4, 4, 6, 6], 8, 4))\n    assert_equal(true, candidate.call([1, 1, 1, 2, 2], 5, 1))\n    assert_equal(false, candidate.call([1, 1, 2, 2], 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\ndef substract_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_substract_elements\n    candidate = method(:substract_elements)\n    assert_equal([8, -1, -13], candidate.call([10, 4, 5], [2, 5, 18]))\n    assert_equal([-13, -43, -13], candidate.call([11, 2, 3], [24, 45, 16]))\n    assert_equal([-3, 7, -3], candidate.call([7, 18, 9], [10, 11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ndef capital_words_spaces(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_capital_words_spaces\n    candidate = method(:capital_words_spaces)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"Python Programming Examples\", candidate.call(\"PythonProgrammingExamples\"))\n    assert_equal(\"Get Ready To Be Coding Freak\", candidate.call(\"GetReadyToBeCodingFreak\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rb",
-    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\ndef find_Average_Of_Cube(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Average_Of_Cube\n    candidate = method(:find_Average_Of_Cube)\n    assert_equal(4.5, candidate.call(2))\n    assert_equal(12, candidate.call(3))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rb",
-    "prompt": "# Write a function to check if all values are same in a dictionary.\ndef check_value(dict, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_value\n    candidate = method(:check_value)\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10))\n    assert_equal(true, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12))\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth tetrahedral number.\ndef tetrahedral_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tetrahedral_number\n    candidate = method(:tetrahedral_number)\n    assert_equal(35, candidate.call(5))\n    assert_equal(56, candidate.call(6))\n    assert_equal(84, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rb",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\ndef magic_square_test(my_matrix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_magic_square_test\n    candidate = method(:magic_square_test)\n    assert_equal(true, candidate.call([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]))\n    assert_equal(true, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 8]]))\n    assert_equal(false, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 7]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rb",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\ndef remove_uppercase(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_uppercase\n    candidate = method(:remove_uppercase)\n    assert_equal(\"cstyoravoitshos\", candidate.call(\"cAstyoUrFavoRitETVshoWs\"))\n    assert_equal(\"wtchheinerntrdo\", candidate.call(\"wAtchTheinTernEtrAdIo\"))\n    assert_equal(\"oiceachndreomendaion\", candidate.call(\"VoicESeaRchAndreComMendaTionS\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "rb",
-    "prompt": "# Write a function to check whether an element exists within a tuple.\ndef check_tuplex(tuplex, tuple1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_tuplex\n    candidate = method(:check_tuplex)\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"))\n    assert_equal(false, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"))\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rb",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndef dog_age(h_age)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dog_age\n    candidate = method(:dog_age)\n    assert_equal(61, candidate.call(12))\n    assert_equal(73, candidate.call(15))\n    assert_equal(109, candidate.call(24))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rb",
-    "prompt": "# Write a python function to find the next perfect square greater than a given number.\ndef next_Perfect_Square(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_Perfect_Square\n    candidate = method(:next_Perfect_Square)\n    assert_equal(36, candidate.call(35))\n    assert_equal(9, candidate.call(6))\n    assert_equal(16, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "rb",
-    "prompt": "# Write a function to create a list of N empty dictionaries.\ndef empty_list(length)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_empty_list\n    candidate = method(:empty_list)\n    assert_equal([{}, {}, {}, {}, {}], candidate.call(5))\n    assert_equal([{}, {}, {}, {}, {}, {}], candidate.call(6))\n    assert_equal([{}, {}, {}, {}, {}, {}, {}], candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rb",
-    "prompt": "# Write a python function to convert a given string to uppercase.\ndef is_upper(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_upper\n    candidate = method(:is_upper)\n    assert_equal(\"PERSON\", candidate.call(\"person\"))\n    assert_equal(\"FINAL\", candidate.call(\"final\"))\n    assert_equal(\"VALID\", candidate.call(\"Valid\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rb",
-    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\ndef odd_Equivalent(s, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_Equivalent\n    candidate = method(:odd_Equivalent)\n    assert_equal(3, candidate.call(\"011001\", 6))\n    assert_equal(4, candidate.call(\"11011\", 5))\n    assert_equal(2, candidate.call(\"1010\", 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\ndef re_arrange_array(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_re_arrange_array\n    candidate = method(:re_arrange_array)\n    assert_equal([-1, -3, -7, 4, 5, 6, 2, 8, 9], candidate.call([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9))\n    assert_equal([-14, -26, 12, 13, 15], candidate.call([12, -14, -26, 13, 15], 5))\n    assert_equal([-42, -39, -78, 10, 24, 36, 85], candidate.call([10, 24, 36, -42, -39, -78, 85], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\ndef unique_Element(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_Element\n    candidate = method(:unique_Element)\n    assert_equal(true, candidate.call([1, 1, 1]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "rb",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\ndef extract_values(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_values\n    candidate = method(:extract_values)\n    assert_equal([\"Python\", \"PHP\", \"Java\"], candidate.call(\"\"Python\", \"PHP\", \"Java\"\"))\n    assert_equal([\"python\", \"program\", \"language\"], candidate.call(\"\"python\",\"program\",\"language\"\"))\n    assert_equal([\"red\", \"blue\", \"green\", \"yellow\"], candidate.call(\"\"red\",\"blue\",\"green\",\"yellow\"\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rb",
-    "prompt": "# Write a python function to count true booleans in the given list.\ndef count(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count\n    candidate = method(:count)\n    assert_equal(2, candidate.call([true, false, true]))\n    assert_equal(0, candidate.call([false, false]))\n    assert_equal(3, candidate.call([true, true, true]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rb",
-    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\ndef find_even_pair(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_even_pair\n    candidate = method(:find_even_pair)\n    assert_equal(4, candidate.call([5, 4, 7, 2, 1]))\n    assert_equal(9, candidate.call([7, 2, 8, 1, 0, 5, 11]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\ndef armstrong_number(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_armstrong_number\n    candidate = method(:armstrong_number)\n    assert_equal(true, candidate.call(153))\n    assert_equal(false, candidate.call(259))\n    assert_equal(false, candidate.call(4458))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rb",
-    "prompt": "# Write a python function to count the upper case characters in a given string.\ndef upper_ctr(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_upper_ctr\n    candidate = method(:upper_ctr)\n    assert_equal(1, candidate.call(\"PYthon\"))\n    assert_equal(1, candidate.call(\"BigData\"))\n    assert_equal(0, candidate.call(\"program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\ndef and_tuples(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_and_tuples\n    candidate = method(:and_tuples)\n    assert_equal([0, 0, 2, 1], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([1, 2, 3, 0], candidate.call([1, 2, 3, 4], [5, 6, 7, 8]))\n    assert_equal([0, 9, 10, 0], candidate.call([8, 9, 11, 12], [7, 13, 14, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rb",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\ndef is_samepatterns(colors, patterns)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_samepatterns\n    candidate = method(:is_samepatterns)\n    assert_equal(true, candidate.call([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of lists in a given number of lists.\ndef count_list(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_list\n    candidate = method(:count_list)\n    assert_equal(4, candidate.call([[1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal(3, candidate.call([[1, 2], [2, 3], [4, 5]]))\n    assert_equal(2, candidate.call([[1, 0], [2, 0]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rb",
-    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\ndef average_tuple(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_average_tuple\n    candidate = method(:average_tuple)\n    assert_equal([30.5, 34.25, 27.0, 23.25], candidate.call([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]))\n    assert_equal([25.5, -18.0, 3.75], candidate.call([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]))\n    assert_equal([305.0, 342.5, 270.0, 232.5], candidate.call([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rb",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\ndef lcs_of_three(x, y, z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lcs_of_three\n    candidate = method(:lcs_of_three)\n    assert_equal(2, candidate.call(\"AGGT12\", \"12TXAYB\", \"12XBA\"))\n    assert_equal(5, candidate.call(\"Reels\", \"Reelsfor\", \"ReelsforReels\"))\n    assert_equal(3, candidate.call(\"abcd1e2\", \"bc12ea\", \"bd1ea\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the n'th star number.\ndef find_star_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_star_num\n    candidate = method(:find_star_num)\n    assert_equal(37, candidate.call(3))\n    assert_equal(73, candidate.call(4))\n    assert_equal(121, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of an array.\ndef _sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test__sum\n    candidate = method(:_sum)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(50, candidate.call([15, 12, 13, 10]))\n    assert_equal(3, candidate.call([0, 1, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\ndef check_Consecutive(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_Consecutive\n    candidate = method(:check_Consecutive)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 2, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rb",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\ndef find_adverb_position(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverb_position\n    candidate = method(:find_adverb_position)\n    assert_equal([0, 7, \"clearly\"], candidate.call(\"clearly!! we can see the sky\"))\n    assert_equal([0, 9, \"seriously\"], candidate.call(\"seriously!! there are many roses\"))\n    assert_equal([0, 13, \"unfortunately\"], candidate.call(\"unfortunately!! sita is going to home\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rb",
-    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\ndef rotate_right(list, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rotate_right\n    candidate = method(:rotate_right)\n    assert_equal([8, 9, 10, 1, 2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3))\n    assert_equal([9, 10, 1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([6, 7, 8, 9, 10, 1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\ndef number_of_substrings(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_of_substrings\n    candidate = method(:number_of_substrings)\n    assert_equal(6, candidate.call(\"abc\"))\n    assert_equal(10, candidate.call(\"abcd\"))\n    assert_equal(15, candidate.call(\"abcde\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\ndef list_split(s, step)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_split\n    candidate = method(:list_split)\n    assert_equal([[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]], candidate.call([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3))\n    assert_equal([[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3))\n    assert_equal([[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]], candidate.call([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rb",
-    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\ndef all_unique(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_unique\n    candidate = method(:all_unique)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rb",
-    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\ndef convert(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert\n    candidate = method(:convert)\n    assert_equal([1.0, 0.0], candidate.call(1))\n    assert_equal([4.0, 0.0], candidate.call(4))\n    assert_equal([5.0, 0.0], candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "rb",
-    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\ndef filter_data(students, h, w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_data\n    candidate = method(:filter_data)\n    assert_equal({\"Cierra Vega\" => [6.2, 70]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rb",
-    "prompt": "# Write a python function to convert the given string to lower case.\ndef is_lower(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_lower\n    candidate = method(:is_lower)\n    assert_equal(\"invalid\", candidate.call(\"InValid\"))\n    assert_equal(\"true\", candidate.call(\"TruE\"))\n    assert_equal(\"sentence\", candidate.call(\"SenTenCE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rb",
-    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\ndef next_power_of_2(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_power_of_2\n    candidate = method(:next_power_of_2)\n    assert_equal(1, candidate.call(0))\n    assert_equal(8, candidate.call(5))\n    assert_equal(32, candidate.call(17))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rb",
-    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\ndef find_substring(str1, sub_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_substring\n    candidate = method(:find_substring)\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"))\n    assert_equal(false, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"))\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rb",
-    "prompt": "# Write a function to replace characters in a string.\ndef replace_char(str1, ch, newch)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_char\n    candidate = method(:replace_char)\n    assert_equal(\"pollgon\", candidate.call(\"polygon\", \"y\", \"l\"))\n    assert_equal(\"aharaater\", candidate.call(\"character\", \"c\", \"a\"))\n    assert_equal(\"python\", candidate.call(\"python\", \"l\", \"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rb",
-    "prompt": "# Write a function to find the product of first even and odd number of a given list.\ndef mul_even_odd(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mul_even_odd\n    candidate = method(:mul_even_odd)\n    assert_equal(4, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(10, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to convert a list to a tuple.\ndef list_tuple(listx)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_tuple\n    candidate = method(:list_tuple)\n    assert_equal([5, 10, 7, 4, 15, 3], candidate.call([5, 10, 7, 4, 15, 3]))\n    assert_equal([2, 4, 5, 6, 2, 3, 4, 4, 7], candidate.call([2, 4, 5, 6, 2, 3, 4, 4, 7]))\n    assert_equal([58, 44, 56], candidate.call([58, 44, 56]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rb",
-    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\ndef even_binomial_Coeff_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_binomial_Coeff_Sum\n    candidate = method(:even_binomial_Coeff_Sum)\n    assert_equal(8, candidate.call(4))\n    assert_equal(32, candidate.call(6))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rb",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\ndef bitwise_xor(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bitwise_xor\n    candidate = method(:bitwise_xor)\n    assert_equal([15, 6, 5, 10], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([13, 6, 3, 14], candidate.call([11, 5, 7, 10], [6, 3, 4, 4]))\n    assert_equal([11, 2, 13, 13], candidate.call([12, 6, 8, 11], [7, 4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether a list is sublist of another or not.\ndef is_Sub_Array(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sub_Array\n    candidate = method(:is_Sub_Array)\n    assert_equal(false, candidate.call([1, 4, 3, 5], [1, 2]))\n    assert_equal(true, candidate.call([1, 2, 1], [1, 2, 1]))\n    assert_equal(false, candidate.call([1, 0, 2, 2], [2, 2, 0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rb",
-    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\ndef max_sub_array_sum_repeated(a, n, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum_repeated\n    candidate = method(:max_sub_array_sum_repeated)\n    assert_equal(30, candidate.call([10, 20, -30, -1], 4, 3))\n    assert_equal(59, candidate.call([-1, 10, 20], 3, 2))\n    assert_equal(-1, candidate.call([-1, -2, -3], 3, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\ndef min_product_tuple(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_product_tuple\n    candidate = method(:min_product_tuple)\n    assert_equal(8, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(30, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(100, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\ndef count_divisors(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_divisors\n    candidate = method(:count_divisors)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(100))\n    assert_equal(true, candidate.call(125))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rb",
-    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ndef triangle_area(r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(nil, candidate.call(-1))\n    assert_equal(0, candidate.call(0))\n    assert_equal(4, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to convert a given string to a list of characters.\ndef string_to_tuple(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_tuple\n    candidate = method(:string_to_tuple)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"], candidate.call(\"python 3.0\"))\n    assert_equal([\"i\", \"t\", \"e\", \"m\", \"1\"], candidate.call(\"item1\"))\n    assert_equal([\"1\", \"5\", \".\", \"1\", \"0\"], candidate.call(\"15.10\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\ndef find_length(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_length\n    candidate = method(:find_length)\n    assert_equal(6, candidate.call(\"11000010001\"))\n    assert_equal(1, candidate.call(\"10111\"))\n    assert_equal(2, candidate.call(\"11011101100101\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rb",
-    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ndef count_Primes_nums(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Primes_nums\n    candidate = method(:count_Primes_nums)\n    assert_equal(2, candidate.call(5))\n    assert_equal(4, candidate.call(10))\n    assert_equal(25, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\ndef sum_Of_product(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_product\n    candidate = method(:sum_Of_product)\n    assert_equal(15, candidate.call(3))\n    assert_equal(56, candidate.call(4))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\ndef max_aggregate(stdata)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_aggregate\n    candidate = method(:max_aggregate)\n    assert_equal([\"Juan Whelan\", 212], candidate.call([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]))\n    assert_equal([\"Juan Whelan\", 72], candidate.call([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]))\n    assert_equal([\"Sabah Colley\", 70], candidate.call([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rb",
-    "prompt": "# Write a function to sort a list of elements.\ndef comb_sort(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_comb_sort\n    candidate = method(:comb_sort)\n    assert_equal([5, 15, 25, 37, 79], candidate.call([5, 15, 37, 25, 79]))\n    assert_equal([15, 19, 22, 32, 41], candidate.call([41, 32, 15, 19, 22]))\n    assert_equal([13, 15, 47, 99], candidate.call([99, 15, 13, 47]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ndef check_expression(exp)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_expression\n    candidate = method(:check_expression)\n    assert_equal(true, candidate.call(\"{()}[{}]\"))\n    assert_equal(false, candidate.call(\"{()}[{]\"))\n    assert_equal(true, candidate.call(\"{()}[{}][]({})\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rb",
-    "prompt": "# Write a function that matches a word containing 'z'.\ndef text_match_wordz(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz\n    candidate = method(:text_match_wordz)\n    assert_equal(true, candidate.call(\"pythonz.\"))\n    assert_equal(true, candidate.call(\"xyz.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rb",
-    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\ndef sum_list(lst1, lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_list\n    candidate = method(:sum_list)\n    assert_equal([25, 45, 65], candidate.call([10, 20, 30], [15, 25, 35]))\n    assert_equal([6, 8, 10], candidate.call([1, 2, 3], [5, 6, 7]))\n    assert_equal([30, 65, 105], candidate.call([15, 20, 30], [15, 45, 75]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\ndef newman_prime(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_newman_prime\n    candidate = method(:newman_prime)\n    assert_equal(7, candidate.call(3))\n    assert_equal(17, candidate.call(4))\n    assert_equal(41, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "rb",
-    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\ndef add_string(list_, string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_string\n    candidate = method(:add_string)\n    assert_equal([\"temp1\", \"temp2\", \"temp3\", \"temp4\"], candidate.call([1, 2, 3, 4], \"temp{0}\"))\n    assert_equal([\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"], candidate.call([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"))\n    assert_equal([\"string5\", \"string6\", \"string7\", \"string8\"], candidate.call([5, 6, 7, 8], \"string{0}\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rb",
-    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\ndef surface_Area(b, s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surface_Area\n    candidate = method(:surface_Area)\n    assert_equal(33, candidate.call(3, 4))\n    assert_equal(56, candidate.call(4, 5))\n    assert_equal(5, candidate.call(1, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rb",
-    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\ndef Find_Min_Length(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min_Length\n    candidate = method(:Find_Min_Length)\n    assert_equal(1, candidate.call([[1], [1, 2]]))\n    assert_equal(2, candidate.call([[1, 2], [1, 2, 3], [1, 2, 3, 4]]))\n    assert_equal(3, candidate.call([[3, 3, 3], [4, 4, 4, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rb",
-    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\ndef validate(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_validate\n    candidate = method(:validate)\n    assert_equal(true, candidate.call(1234))\n    assert_equal(false, candidate.call(51241))\n    assert_equal(true, candidate.call(321))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth hexagonal number.\ndef hexagonal_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hexagonal_num\n    candidate = method(:hexagonal_num)\n    assert_equal(190, candidate.call(10))\n    assert_equal(45, candidate.call(5))\n    assert_equal(91, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rb",
-    "prompt": "# Write a function to find the n'th lucas number.\ndef find_lucas(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lucas\n    candidate = method(:find_lucas)\n    assert_equal(76, candidate.call(9))\n    assert_equal(7, candidate.call(4))\n    assert_equal(4, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rb",
-    "prompt": "# Write a python function to get the difference between two lists.\ndef Diff(li1, li2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Diff\n    candidate = method(:Diff)\n    assert_equal([10, 20, 30, 15], candidate.call([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]))\n    assert_equal([2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5], [6, 7, 1]))\n    assert_equal([2, 3, 6, 7], candidate.call([1, 2, 3], [6, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "rb",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\ndef extract_quotation(text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_quotation\n    candidate = method(:extract_quotation)\n    assert_equal([\"A53\", \"multi\", \"Processor\"], candidate.call(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"))\n    assert_equal([\"favorite\", \"apps\"], candidate.call(\"Cast your \"favorite\" entertainment \"apps\"\"))\n    assert_equal([\"4k Ultra HD\", \"HDR 10\"], candidate.call(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"))\n    assert_equal([], candidate.call(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "rb",
-    "prompt": "# Write a function to flatten a list and sum all of its elements.\ndef recursive_list_sum(data_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_recursive_list_sum\n    candidate = method(:recursive_list_sum)\n    assert_equal(21, candidate.call([1, 2, [3, 4], [5, 6]]))\n    assert_equal(106, candidate.call([7, 10, [15, 14], [19, 41]]))\n    assert_equal(210, candidate.call([10, 20, [30, 40], [50, 60]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\ndef differ_At_One_Bit_Pos(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_differ_At_One_Bit_Pos\n    candidate = method(:differ_At_One_Bit_Pos)\n    assert_equal(true, candidate.call(13, 9))\n    assert_equal(false, candidate.call(15, 8))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(2, 3))\n    assert_equal(true, candidate.call(5, 1))\n    assert_equal(true, candidate.call(1, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ndef text_match_three(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_three\n    candidate = method(:text_match_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"caacabbbba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\ndef max_product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product\n    candidate = method(:max_product)\n    assert_equal(3000, candidate.call([3, 100, 4, 5, 150, 6]))\n    assert_equal(50265600, candidate.call([4, 42, 55, 68, 80]))\n    assert_equal(2460, candidate.call([10, 22, 9, 33, 21, 50, 41, 60]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rb",
-    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\ndef split_Arr(l, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_Arr\n    candidate = method(:split_Arr)\n    assert_equal([5, 6, 52, 36, 12, 10], candidate.call([12, 10, 5, 6, 52, 36], 2))\n    assert_equal([2, 3, 4, 1], candidate.call([1, 2, 3, 4], 1))\n    assert_equal([3, 4, 5, 6, 7, 0, 1, 2], candidate.call([0, 1, 2, 3, 4, 5, 6, 7], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rb",
-    "prompt": "# Write a python function to find the number of divisors of a given integer.\ndef divisor(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisor\n    candidate = method(:divisor)\n    assert_equal(4, candidate.call(15))\n    assert_equal(6, candidate.call(12))\n    assert_equal(3, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rb",
-    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\ndef big_diff(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_diff\n    candidate = method(:big_diff)\n    assert_equal(3, candidate.call([1, 2, 3, 4]))\n    assert_equal(8, candidate.call([4, 5, 12]))\n    assert_equal(7, candidate.call([9, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rb",
-    "prompt": "# Write a function to find squares of individual elements in a list.\ndef square_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_nums\n    candidate = method(:square_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([100, 400, 900], candidate.call([10, 20, 30]))\n    assert_equal([144, 225], candidate.call([12, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given tuple has any none value or not.\ndef check_none(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_none\n    candidate = method(:check_none)\n    assert_equal(true, candidate.call([10, 4, 5, 6, nil]))\n    assert_equal(false, candidate.call([7, 8, 9, 11, 14]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, nil]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given array is monotonic or not.\ndef is_Monotonic(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Monotonic\n    candidate = method(:is_Monotonic)\n    assert_equal(true, candidate.call([6, 5, 4, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3]))\n    assert_equal(false, candidate.call([1, 3, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\ndef is_perfect_square(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_perfect_square\n    candidate = method(:is_perfect_square)\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(36))\n    assert_equal(false, candidate.call(14))\n    assert_equal(true, candidate.call(196))\n    assert_equal(false, candidate.call(125))\n    assert_equal(true, candidate.call(15625))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\ndef sum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum\n    candidate = method(:sum)\n    assert_equal(6, candidate.call(10, 15))\n    assert_equal(93, candidate.call(100, 150))\n    assert_equal(3, candidate.call(4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rb",
-    "prompt": "# Write a function to find the list of maximum length in a list of lists.\ndef max_length(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length\n    candidate = method(:max_length)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([4, [10, 12, 14, 15]], candidate.call([[1], [5, 7], [10, 12, 14, 15]]))\n    assert_equal([3, [15, 20, 25]], candidate.call([[5], [15, 20, 25]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\ndef check_occurences(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_occurences\n    candidate = method(:check_occurences)\n    assert_equal({[1, 3] => 2, [2, 5] => 2, [3, 6] => 1}, candidate.call([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]))\n    assert_equal({[2, 4] => 2, [3, 6] => 2, [4, 7] => 1}, candidate.call([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]))\n    assert_equal({[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1}, candidate.call([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rb",
-    "prompt": "# Write a function to find the directrix of a parabola.\ndef parabola_directrix(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parabola_directrix\n    candidate = method(:parabola_directrix)\n    assert_equal(-198, candidate.call(5, 3, 2))\n    assert_equal(-2336, candidate.call(9, 8, 4))\n    assert_equal(-130, candidate.call(2, 4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rb",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\ndef occurance_substring(text, pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_occurance_substring\n    candidate = method(:occurance_substring)\n    assert_equal([\"python\", 0, 6], candidate.call(\"python programming, python language\", \"python\"))\n    assert_equal([\"programming\", 7, 18], candidate.call(\"python programming,programming language\", \"programming\"))\n    assert_equal([\"language\", 31, 39], candidate.call(\"python programming,programming language\", \"language\"))\n    assert_equal(nil, candidate.call(\"c++ programming, c++ language\", \"python\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "rb",
-    "prompt": "# Write a function to remove tuples from the given tuple.\ndef remove_nested(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_nested\n    candidate = method(:remove_nested)\n    assert_equal([1, 5, 7, 10], candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal([2, 6, 8, 11], candidate.call([2, 6, 8, [5, 7], 11]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], 12]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], [5, 12], 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rb",
-    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\ndef sort_sublists(input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]], candidate.call([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]))\n    assert_equal([[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]], candidate.call([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rb",
-    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\ndef remove_kth_element(list1, l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_kth_element\n    candidate = method(:remove_kth_element)\n    assert_equal([1, 1, 3, 4, 4, 5, 1], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4))\n    assert_equal([10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\ndef add_dict_to_tuple(test_tup, test_dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_dict_to_tuple\n    candidate = method(:add_dict_to_tuple)\n    assert_equal([4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}], candidate.call([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}))\n    assert_equal([1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}], candidate.call([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}))\n    assert_equal([8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}], candidate.call([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rb",
-    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\ndef find(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find\n    candidate = method(:find)\n    assert_equal(3, candidate.call(10, 3))\n    assert_equal(2, candidate.call(4, 2))\n    assert_equal(4, candidate.call(20, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rb",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ndef text_match_two_three(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_two_three\n    candidate = method(:text_match_two_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "rb",
-    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\ndef count_Occurrence(tup, lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Occurrence\n    candidate = method(:count_Occurrence)\n    assert_equal(3, candidate.call([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]))\n    assert_equal(6, candidate.call([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6], [1, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rb",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ndef count_samepair(list1, list2, list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_samepair\n    candidate = method(:count_samepair)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]))\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n    assert_equal(5, candidate.call([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ndef text_match_one(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_one\n    candidate = method(:text_match_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rb",
-    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndef difference(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_difference\n    candidate = method(:difference)\n    assert_equal(30, candidate.call(3))\n    assert_equal(210, candidate.call(5))\n    assert_equal(6, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rb",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\ndef toggle_string(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_string\n    candidate = method(:toggle_string)\n    assert_equal(\"pYTHON\", candidate.call(\"Python\"))\n    assert_equal(\"pANGRAM\", candidate.call(\"Pangram\"))\n    assert_equal(\"liTTle\", candidate.call(\"LIttLE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "rb",
-    "prompt": "# Write a python function to find the element of a list having maximum length.\ndef Find_Max(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max\n    candidate = method(:Find_Max)\n    assert_equal([\"A\", \"B\", \"C\"], candidate.call([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]))\n    assert_equal([1, 2, 3], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 5, 6, 1], candidate.call([[1, 1], [1, 2, 3], [1, 5, 6, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\ndef eulerian_num(n, m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eulerian_num\n    candidate = method(:eulerian_num)\n    assert_equal(4, candidate.call(3, 1))\n    assert_equal(11, candidate.call(4, 1))\n    assert_equal(26, candidate.call(5, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\ndef frequency(a, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency\n    candidate = method(:frequency)\n    assert_equal(0, candidate.call([1, 2, 3], 4))\n    assert_equal(3, candidate.call([1, 2, 2, 3, 3, 3, 4], 3))\n    assert_equal(2, candidate.call([0, 1, 2, 3, 1, 2], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rb",
-    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\ndef sort_numeric_strings(nums_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numeric_strings\n    candidate = method(:sort_numeric_strings)\n    assert_equal([-500, -12, 0, 4, 7, 12, 45, 100, 200], candidate.call([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]))\n    assert_equal([1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9], candidate.call([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]))\n    assert_equal([1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17], candidate.call([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\ndef geometric_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_geometric_sum\n    candidate = method(:geometric_sum)\n    assert_equal(1.9921875, candidate.call(7))\n    assert_equal(1.9375, candidate.call(4))\n    assert_equal(1.99609375, candidate.call(8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rb",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\ndef divisible_by_digits(startnum, endnum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisible_by_digits\n    candidate = method(:divisible_by_digits)\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22], candidate.call(1, 22))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15], candidate.call(1, 15))\n    assert_equal([22, 24], candidate.call(20, 25))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rb",
-    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\ndef unique_product(list_data)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_product\n    candidate = method(:unique_product)\n    assert_equal(720000000, candidate.call([10, 20, 30, 40, 20, 50, 60, 40]))\n    assert_equal(6, candidate.call([1, 2, 3, 1]))\n    assert_equal(0, candidate.call([7, 8, 9, 0, 1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rb",
-    "prompt": "# Write a python function to find the largest negative number from the given list.\ndef largest_neg(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_neg\n    candidate = method(:largest_neg)\n    assert_equal(-6, candidate.call([1, 2, 3, -4, -6]))\n    assert_equal(-9, candidate.call([1, 2, 3, -8, -9]))\n    assert_equal(-1, candidate.call([1, 2, 3, 4, -1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "rb",
-    "prompt": "# Write a function to remove consecutive duplicates of a given list.\ndef consecutive_duplicates(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_consecutive_duplicates\n    candidate = method(:consecutive_duplicates)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([10, 15, 19, 18, 17, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\", \"a\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rb",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\ndef min_Jumps(steps, d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Jumps\n    candidate = method(:min_Jumps)\n    assert_equal(3.5, candidate.call([3, 4], 11))\n    assert_equal(0, candidate.call([3, 4], 0))\n    assert_equal(1, candidate.call([11, 14], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rb",
-    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\ndef max_Product(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Product\n    candidate = method(:max_Product)\n    assert_equal([7, 8], candidate.call([1, 2, 3, 4, 7, 0, 8, 4]))\n    assert_equal([-4, -6], candidate.call([0, -1, -2, -4, 5, 0, -6]))\n    assert_equal([2, 3], candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "rb",
-    "prompt": "# Write a function to extract the nth element from a given list of tuples.\ndef extract_nth_element(list1, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_nth_element\n    candidate = method(:extract_nth_element)\n    assert_equal([\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0))\n    assert_equal([99, 96, 94, 98], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2))\n    assert_equal([98, 97, 91, 94], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth nonagonal number.\ndef is_nonagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nonagonal\n    candidate = method(:is_nonagonal)\n    assert_equal(325, candidate.call(10))\n    assert_equal(750, candidate.call(15))\n    assert_equal(1089, candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rb",
-    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\ndef max_Abs_Diff(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Abs_Diff\n    candidate = method(:max_Abs_Diff)\n    assert_equal(4, candidate.call([2, 1, 5, 3]))\n    assert_equal(8, candidate.call([9, 3, 2, 5, 1]))\n    assert_equal(2, candidate.call([3, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "rb",
-    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\ndef pack_consecutive_duplicates(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pack_consecutive_duplicates\n    candidate = method(:pack_consecutive_duplicates)\n    assert_equal([[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\ndef cal_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cal_sum\n    candidate = method(:cal_sum)\n    assert_equal(49, candidate.call(9))\n    assert_equal(66, candidate.call(10))\n    assert_equal(88, candidate.call(11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rb",
-    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\ndef odd_values_string(str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_values_string\n    candidate = method(:odd_values_string)\n    assert_equal(\"ace\", candidate.call(\"abcdef\"))\n    assert_equal(\"pto\", candidate.call(\"python\"))\n    assert_equal(\"dt\", candidate.call(\"data\"))\n    assert_equal(\"lms\", candidate.call(\"lambs\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rb",
-    "prompt": "# Write a function to find kth element from the given two sorted arrays.\ndef find_kth(arr1, arr2, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_kth\n    candidate = method(:find_kth)\n    assert_equal(6, candidate.call([2, 3, 6, 7, 9], [1, 4, 8, 10], 5))\n    assert_equal(256, candidate.call([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7))\n    assert_equal(8, candidate.call([3, 4, 7, 8, 10], [2, 5, 9, 11], 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\ndef jacobsthal_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_jacobsthal_num\n    candidate = method(:jacobsthal_num)\n    assert_equal(11, candidate.call(5))\n    assert_equal(1, candidate.call(2))\n    assert_equal(5, candidate.call(4))\n    assert_equal(2731, candidate.call(13))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rb",
-    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\ndef frequency_lists(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency_lists\n    candidate = method(:frequency_lists)\n    assert_equal({1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1}, candidate.call([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]))\n    assert_equal({1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1}, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]))\n    assert_equal({20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1}, candidate.call([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rb",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\ndef perfect_squares(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perfect_squares\n    candidate = method(:perfect_squares)\n    assert_equal([1, 4, 9, 16, 25], candidate.call(1, 30))\n    assert_equal([64, 81, 100], candidate.call(50, 100))\n    assert_equal([100, 121, 144, 169, 196], candidate.call(100, 200))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rb",
-    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\ndef sum_Of_Subarray_Prod(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_Subarray_Prod\n    candidate = method(:sum_Of_Subarray_Prod)\n    assert_equal(20, candidate.call([1, 2, 3]))\n    assert_equal(5, candidate.call([1, 2]))\n    assert_equal(84, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rb",
-    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\ndef first_odd(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_odd\n    candidate = method(:first_odd)\n    assert_equal(1, candidate.call([1, 3, 5]))\n    assert_equal(1, candidate.call([2, 4, 1, 3]))\n    assert_equal(9, candidate.call([8, 9, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\ndef add_nested_tuples(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_nested_tuples\n    candidate = method(:add_nested_tuples)\n    assert_equal([[7, 10], [7, 14], [3, 10], [8, 13]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[9, 12], [9, 16], [5, 12], [10, 15]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[11, 14], [11, 18], [7, 14], [12, 17]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "rb",
-    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\ndef merge(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge\n    candidate = method(:merge)\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]], candidate.call([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]))\n    assert_equal([[1, 3, 5, 7], [2, 4, 6, 8]], candidate.call([[1, 2], [3, 4], [5, 6], [7, 8]]))\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]], candidate.call([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\ndef dif_Square(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dif_Square\n    candidate = method(:dif_Square)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rb",
-    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\ndef check_smaller(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_smaller\n    candidate = method(:check_smaller)\n    assert_equal(false, candidate.call([1, 2, 3], [2, 3, 4]))\n    assert_equal(true, candidate.call([4, 5, 6], [3, 4, 5]))\n    assert_equal(true, candidate.call([11, 12, 13], [10, 11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rb",
-    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\ndef freq_count(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_freq_count\n    candidate = method(:freq_count)\n    assert_equal({10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1}, candidate.call([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]))\n    assert_equal({1 => 3, 2 => 2, 3 => 3, 4 => 3}, candidate.call([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]))\n    assert_equal({10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2}, candidate.call([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rb",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\ndef rgb_to_hsv(r, g, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rgb_to_hsv\n    candidate = method(:rgb_to_hsv)\n    assert_equal([0.0, 0.0, 100.0], candidate.call(255, 255, 255))\n    assert_equal([120.0, 100.0, 84.31372549019608], candidate.call(0, 215, 0))\n    assert_equal([149.26829268292684, 95.34883720930233, 84.31372549019608], candidate.call(10, 215, 110))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "rb",
-    "prompt": "# Write a function to flatten a given nested list structure.\ndef flatten_list(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flatten_list\n    candidate = method(:flatten_list)\n    assert_equal([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120], candidate.call([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]))\n    assert_equal([10, 20, 40, 30, 56, 25, 10, 20, 33, 40], candidate.call([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]))\n    assert_equal([1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ndef check_str(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_str\n    candidate = method(:check_str)\n    assert_equal(true, candidate.call(\"annie\"))\n    assert_equal(false, candidate.call(\"dawood\"))\n    assert_equal(true, candidate.call(\"Else\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ndef check_monthnumber_number(monthnum3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumber_number\n    candidate = method(:check_monthnumber_number)\n    assert_equal(true, candidate.call(6))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rb",
-    "prompt": "# Write a function to sort the given list.\ndef heap_sort(iterable)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_sort\n    candidate = method(:heap_sort)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]))\n    assert_equal([14, 22, 25, 25, 35, 58, 65, 75, 85], candidate.call([25, 35, 22, 85, 14, 65, 75, 25, 58]))\n    assert_equal([1, 5, 7, 9], candidate.call([7, 1, 9, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rb",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\ndef k_smallest_pairs(nums1, nums2, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_k_smallest_pairs\n    candidate = method(:k_smallest_pairs)\n    assert_equal([[1, 2], [1, 4]], candidate.call([1, 3, 7], [2, 4, 6], 2))\n    assert_equal([[1, 2]], candidate.call([1, 3, 7], [2, 4, 6], 1))\n    assert_equal([[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]], candidate.call([1, 3, 7], [2, 4, 6], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rb",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\ndef find_solution(a, b, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_solution\n    candidate = method(:find_solution)\n    assert_equal([2, 1], candidate.call(2, 3, 7))\n    assert_equal(nil, candidate.call(4, 2, 7))\n    assert_equal([4, 1], candidate.call(1, 13, 17))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rb",
-    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\ndef find_Max_Num(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Max_Num\n    candidate = method(:find_Max_Num)\n    assert_equal(321, candidate.call([1, 2, 3]))\n    assert_equal(6541, candidate.call([4, 5, 6, 1]))\n    assert_equal(9321, candidate.call([1, 2, 3, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rb",
-    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\ndef max_sum_list(lists)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_list\n    candidate = method(:max_sum_list)\n    assert_equal([10, 11, 12], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n    assert_equal([12, 11, 10], candidate.call([[3, 2, 1], [6, 5, 4], [12, 11, 10]]))\n    assert_equal([2, 3, 1], candidate.call([[2, 3, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rb",
-    "prompt": "# Write a python function to interchange the first and last elements in a list.\ndef swap_List(newlist)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([24, 35, 9, 56, 12], candidate.call([12, 35, 9, 56, 24]))\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rb",
-    "prompt": "# Write a function to find the median of two sorted lists of same size.\ndef get_median(arr1, arr2, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_median\n    candidate = method(:get_median)\n    assert_equal(16.0, candidate.call([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5))\n    assert_equal(8.5, candidate.call([2, 4, 8, 9], [7, 13, 19, 28], 4))\n    assert_equal(25.0, candidate.call([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\ndef replace_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"Jumanji_The_Jungle\", candidate.call(\"Jumanji The Jungle\"))\n    assert_equal(\"The Avengers\", candidate.call(\"The_Avengers\"))\n    assert_equal(\"Fast_and_Furious\", candidate.call(\"Fast and Furious\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rb",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\ndef are_equivalent(num1, num2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_are_equivalent\n    candidate = method(:are_equivalent)\n    assert_equal(false, candidate.call(36, 57))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(23, 47))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rb",
-    "prompt": "# Write a function to reverse each string in a given list of string values.\ndef reverse_string_list(stringlist)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_string_list\n    candidate = method(:reverse_string_list)\n    assert_equal([\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"], candidate.call([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]))\n    assert_equal([\"nhoj\", \"lama\", \"leoj\", \"egroeg\"], candidate.call([\"john\", \"amal\", \"joel\", \"george\"]))\n    assert_equal([\"kcaj\", \"nhoj\", \"yram\"], candidate.call([\"jack\", \"john\", \"mary\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "rb",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\ndef sum_of_digits(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_of_digits\n    candidate = method(:sum_of_digits)\n    assert_equal(14, candidate.call([10, 2, 56]))\n    assert_equal(19, candidate.call([[10, 20, 4, 5, \"b\", 70, \"a\"]]))\n    assert_equal(19, candidate.call([10, 20, -4, 5, -70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\ndef sequence(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequence\n    candidate = method(:sequence)\n    assert_equal(6, candidate.call(10))\n    assert_equal(1, candidate.call(2))\n    assert_equal(2, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rb",
-    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\ndef heap_queue_largest(nums, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_queue_largest\n    candidate = method(:heap_queue_largest)\n    assert_equal([85, 75, 65], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 3))\n    assert_equal([85, 75], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 2))\n    assert_equal([85, 75, 65, 58, 35], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rb",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\ndef loss_amount(actual_cost, sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_loss_amount\n    candidate = method(:loss_amount)\n    assert_equal(0, candidate.call(1500, 1200))\n    assert_equal(100, candidate.call(100, 200))\n    assert_equal(3000, candidate.call(2000, 5000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rb",
-    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\ndef union_elements(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_union_elements\n    candidate = method(:union_elements)\n    assert_equal([3, 4, 5, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 2, 3, 4, 5, 6], candidate.call([1, 2, 3, 4], [3, 4, 5, 6]))\n    assert_equal([11, 12, 13, 14, 15, 16, 17], candidate.call([11, 12, 13, 14], [13, 15, 16, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rb",
-    "prompt": "# Write a python function to find the length of the longest sublists.\ndef Find_Max_Length(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max_Length\n    candidate = method(:Find_Max_Length)\n    assert_equal(4, candidate.call([[1], [1, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[0, 1], [2, 2], [3, 2, 1]]))\n    assert_equal(5, candidate.call([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rb",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\ndef remove_parenthesis(items)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_parenthesis\n    candidate = method(:remove_parenthesis)\n    assert_equal(\"python\", candidate.call([\"python (chrome)\"]))\n    assert_equal(\"string\", candidate.call([\"string(.abc)\"]))\n    assert_equal(\"alpha\", candidate.call([\"alpha(num)\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rb",
-    "prompt": "# Write a python function to find whether the parity of a given number is odd.\ndef find_Parity(x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Parity\n    candidate = method(:find_Parity)\n    assert_equal(false, candidate.call(12))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rb",
-    "prompt": "# Write a function to find the median length of a trapezium.\ndef median_trapezium(base1, base2, height)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_trapezium\n    candidate = method(:median_trapezium)\n    assert_equal(20, candidate.call(15, 25, 35))\n    assert_equal(15, candidate.call(10, 20, 30))\n    assert_equal(7.5, candidate.call(6, 9, 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rb",
-    "prompt": "# Write a function to find nth centered hexagonal number.\ndef centered_hexagonal_number(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_centered_hexagonal_number\n    candidate = method(:centered_hexagonal_number)\n    assert_equal(271, candidate.call(10))\n    assert_equal(7, candidate.call(2))\n    assert_equal(217, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "rb",
-    "prompt": "# Write a function to find number of lists present in the given list.\ndef find_lists(input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lists\n    candidate = method(:find_lists)\n    assert_equal(2, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[1, 2], [3, 4], [5, 6]]))\n    assert_equal(1, candidate.call([9, 8, 7, 6, 5, 4, 3, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\ndef get_max_sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_sum\n    candidate = method(:get_max_sum)\n    assert_equal(106, candidate.call(60))\n    assert_equal(12, candidate.call(10))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rb",
-    "prompt": "# Write a python function to find the length of the longest word.\ndef len_log(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_len_log\n    candidate = method(:len_log)\n    assert_equal(7, candidate.call([\"python\", \"PHP\", \"bigdata\"]))\n    assert_equal(3, candidate.call([\"a\", \"ab\", \"abc\"]))\n    assert_equal(5, candidate.call([\"small\", \"big\", \"tall\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rb",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\ndef sector_area(r, a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sector_area\n    candidate = method(:sector_area)\n    assert_equal(6.283185307179586, candidate.call(4, 45))\n    assert_equal(31.808625617596654, candidate.call(9, 45))\n    assert_equal(nil, candidate.call(9, 361))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\ndef odd_position(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_position\n    candidate = method(:odd_position)\n    assert_equal(true, candidate.call([2, 1, 4, 3, 6, 7, 6, 3]))\n    assert_equal(true, candidate.call([4, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rb",
-    "prompt": "# Write a function to join a list of multiple integers into a single integer.\ndef multiple_to_single(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiple_to_single\n    candidate = method(:multiple_to_single)\n    assert_equal(113350, candidate.call([11, 33, 50]))\n    assert_equal(-123456, candidate.call([-1, 2, 3, 4, 5, 6]))\n    assert_equal(10152025, candidate.call([10, 15, 20, 25]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rb",
-    "prompt": "# Write a python function to find whether a number is divisible by 11.\ndef is_Diff(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Diff\n    candidate = method(:is_Diff)\n    assert_equal(false, candidate.call(12345))\n    assert_equal(true, candidate.call(1212112))\n    assert_equal(false, candidate.call(1212))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rb",
-    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\ndef index_multiplication(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_multiplication\n    candidate = method(:index_multiplication)\n    assert_equal([[6, 21], [12, 45], [2, 9], [7, 30]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[14, 32], [20, 60], [6, 20], [16, 44]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[24, 45], [30, 77], [12, 33], [27, 60]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rb",
-    "prompt": "# Write a function to convert tuple string to integer tuple.\ndef tuple_str_int(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_str_int\n    candidate = method(:tuple_str_int)\n    assert_equal([7, 8, 9], candidate.call(\"(7, 8, 9)\"))\n    assert_equal([1, 2, 3], candidate.call(\"(1, 2, 3)\"))\n    assert_equal([4, 5, 6], candidate.call(\"(4, 5, 6)\"))\n    assert_equal([7, 81, 19], candidate.call(\"(7, 81, 19)\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rb",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\ndef amicable_numbers_sum(limit)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_amicable_numbers_sum\n    candidate = method(:amicable_numbers_sum)\n    assert_equal(504, candidate.call(999))\n    assert_equal(31626, candidate.call(9999))\n    assert_equal(0, candidate.call(99))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rb",
-    "prompt": "# Write a function to remove odd characters in a string.\ndef remove_odd(str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal(\"yhn\", candidate.call(\"python\"))\n    assert_equal(\"rga\", candidate.call(\"program\"))\n    assert_equal(\"agae\", candidate.call(\"language\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\ndef multiply_elements(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_elements\n    candidate = method(:multiply_elements)\n    assert_equal([5, 35, 56, 80], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 20, 30, 42], candidate.call([2, 4, 5, 6, 7]))\n    assert_equal([156, 182, 126, 135], candidate.call([12, 13, 14, 9, 15]))\n    assert_equal([], candidate.call([12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ndef count_rotation(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_rotation\n    candidate = method(:count_rotation)\n    assert_equal(1, candidate.call([3, 2, 1]))\n    assert_equal(2, candidate.call([4, 5, 1, 2, 3]))\n    assert_equal(3, candidate.call([7, 8, 9, 1, 2, 3]))\n    assert_equal(0, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 3, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rb",
-    "prompt": "# Write a function to extract the number of unique tuples in the given list.\ndef extract_freq(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_freq\n    candidate = method(:extract_freq)\n    assert_equal(3, candidate.call([[3, 4], [1, 2], [4, 3], [5, 6]]))\n    assert_equal(4, candidate.call([[4, 15], [2, 3], [5, 4], [6, 7]]))\n    assert_equal(4, candidate.call([[5, 16], [2, 3], [6, 5], [6, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rb",
-    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ndef count_same_pair(nums1, nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_same_pair\n    candidate = method(:count_same_pair)\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]))\n    assert_equal(11, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(1, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(3, candidate.call([0, 1, 1, 2], [0, 1, 2, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\ndef power(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power\n    candidate = method(:power)\n    assert_equal(81, candidate.call(3, 4))\n    assert_equal(8, candidate.call(2, 3))\n    assert_equal(3125, candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rb",
-    "prompt": "# Write function to find the sum of all items in the given dictionary.\ndef return_sum(dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_return_sum\n    candidate = method(:return_sum)\n    assert_equal(600, candidate.call({\"a\" => 100, \"b\" => 200, \"c\" => 300}))\n    assert_equal(88, candidate.call({\"a\" => 25, \"b\" => 18, \"c\" => 45}))\n    assert_equal(124, candidate.call({\"a\" => 36, \"b\" => 39, \"c\" => 49}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rb",
-    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\ndef pair_wise(l1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_wise\n    candidate = method(:pair_wise)\n    assert_equal([[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]], candidate.call([1, 1, 2, 3, 3, 4, 4, 5]))\n    assert_equal([[1, 5], [5, 7], [7, 9], [9, 10]], candidate.call([1, 5, 7, 9, 10]))\n    assert_equal([[5, 1], [1, 9], [9, 7], [7, 10]], candidate.call([5, 1, 9, 7, 10]))\n    assert_equal([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rb",
-    "prompt": "# Write a python function to split a string into characters.\ndef split(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split\n    candidate = method(:split)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], candidate.call(\"python\"))\n    assert_equal([\"N\", \"a\", \"m\", \"e\"], candidate.call(\"Name\"))\n    assert_equal([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"], candidate.call(\"program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rb",
-    "prompt": "# Write a function to find minimum of three numbers.\ndef min_of_three(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_of_three\n    candidate = method(:min_of_three)\n    assert_equal(0, candidate.call(10, 20, 0))\n    assert_equal(15, candidate.call(19, 15, 18))\n    assert_equal(-30, candidate.call(-10, -20, -30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\ndef is_Sum_Of_Powers_Of_Two(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sum_Of_Powers_Of_Two\n    candidate = method(:is_Sum_Of_Powers_Of_Two)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(7))\n    assert_equal(true, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rb",
-    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\ndef get_Char(strr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Char\n    candidate = method(:get_Char)\n    assert_equal(\"f\", candidate.call(\"abc\"))\n    assert_equal(\"t\", candidate.call(\"gfg\"))\n    assert_equal(\"c\", candidate.call(\"ab\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rb",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\ndef sum_div(number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_div\n    candidate = method(:sum_div)\n    assert_equal(7, candidate.call(8))\n    assert_equal(16, candidate.call(12))\n    assert_equal(1, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "rb",
-    "prompt": "# Write a python function that returns the number of integer elements in a given list.\ndef count_integer(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_integer\n    candidate = method(:count_integer)\n    assert_equal(2, candidate.call([1, 2, \"abc\", 1.2]))\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 1.2, 4, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rb",
-    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\ndef two_unique_nums(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_two_unique_nums\n    candidate = method(:two_unique_nums)\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 3, 4, 5]))\n    assert_equal([1, 3, 4, 5], candidate.call([1, 2, 3, 2, 4, 5]))\n    assert_equal([1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rb",
-    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ndef test_duplicate(arraynums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_duplicate\n    candidate = method(:test_duplicate)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 4]))\n    assert_equal(true, candidate.call([1, 1, 2, 2, 3, 3, 4, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rb",
-    "prompt": "# Write a function which returns nth catalan number.\ndef catalan_number(num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_catalan_number\n    candidate = method(:catalan_number)\n    assert_equal(16796, candidate.call(10))\n    assert_equal(4862, candidate.call(9))\n    assert_equal(429, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rb",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\ndef power_base_sum(base, power)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power_base_sum\n    candidate = method(:power_base_sum)\n    assert_equal(115, candidate.call(2, 100))\n    assert_equal(37, candidate.call(8, 10))\n    assert_equal(62, candidate.call(8, 15))\n    assert_equal(9, candidate.call(3, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\ndef replace_list(list1, list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_list\n    candidate = method(:replace_list)\n    assert_equal([1, 3, 5, 7, 9, 2, 4, 6, 8], candidate.call([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8]))\n    assert_equal([\"red\", \"blue\", \"yellow\"], candidate.call([\"red\", \"blue\", \"green\"], [\"yellow\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth octagonal number.\ndef is_octagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_octagonal\n    candidate = method(:is_octagonal)\n    assert_equal(65, candidate.call(5))\n    assert_equal(280, candidate.call(10))\n    assert_equal(645, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\ndef replace_blank(str1, char)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_blank\n    candidate = method(:replace_blank)\n    assert_equal(\"hello@people\", candidate.call(\"hello people\", \"@\"))\n    assert_equal(\"python$program$language\", candidate.call(\"python program language\", \"$\"))\n    assert_equal(\"blank-space\", candidate.call(\"blank space\", \"-\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rb",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\ndef replace_specialchar(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_specialchar\n    candidate = method(:replace_specialchar)\n    assert_equal(\"Python:language::Programming:language:\", candidate.call(\"Python language, Programming language.\"))\n    assert_equal(\"a:b:c:d:e:f\", candidate.call(\"a b c,d e f\"))\n    assert_equal(\"ram:reshma:ram:rahim\", candidate.call(\"ram reshma,ram rahim\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rb",
-    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\ndef tuple_to_int(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_int\n    candidate = method(:tuple_to_int)\n    assert_equal(123, candidate.call([1, 2, 3]))\n    assert_equal(456, candidate.call([4, 5, 6]))\n    assert_equal(567, candidate.call([5, 6, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rb",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\ndef otherside_rightangle(w, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_otherside_rightangle\n    candidate = method(:otherside_rightangle)\n    assert_equal(10.63014581273465, candidate.call(7, 8))\n    assert_equal(5, candidate.call(3, 4))\n    assert_equal(16.55294535724685, candidate.call(7, 15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "rb",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\ndef expensive_items(items, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_expensive_items\n    candidate = method(:expensive_items)\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\ndef digit_distance_nums(n1, n2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digit_distance_nums\n    candidate = method(:digit_distance_nums)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(6, candidate.call(23, 56))\n    assert_equal(7, candidate.call(123, 256))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rb",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ndef text_match_wordz_middle(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz_middle\n    candidate = method(:text_match_wordz_middle)\n    assert_equal(true, candidate.call(\"pythonzabc.\"))\n    assert_equal(false, candidate.call(\"zxyabc.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rb",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\ndef removezero_ip(ip)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_removezero_ip\n    candidate = method(:removezero_ip)\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.196\"))\n    assert_equal(\"12.1.24\", candidate.call(\"12.01.024\"))\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.0196\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of sublists containing a particular element.\ndef count_element_in_list(list1, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_element_in_list\n    candidate = method(:count_element_in_list)\n    assert_equal(3, candidate.call([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1))\n    assert_equal(3, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"))\n    assert_equal(1, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rb",
-    "prompt": "# Write a function to multiply two integers.\ndef multiply_int(x, y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_int\n    candidate = method(:multiply_int)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(5, 10))\n    assert_equal(32, candidate.call(4, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rb",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\ndef add_pairwise(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_pairwise\n    candidate = method(:add_pairwise)\n    assert_equal([6, 12, 15, 18], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 14, 17, 20], candidate.call([2, 6, 8, 9, 11]))\n    assert_equal([10, 16, 19, 22], candidate.call([3, 7, 9, 10, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\ndef max_product_tuple(list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product_tuple\n    candidate = method(:max_product_tuple)\n    assert_equal(36, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(200, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(484, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4429,7 +19,7 @@
     "language": "rb",
     "prompt": "# Write a function to find the kth element in the given array using 1-based indexing.\ndef kth_element(arr, k)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_kth_element\n    candidate = method(:kth_element)\n    assert_equal(3, candidate.call([12, 3, 5, 7, 19], 2))\n    assert_equal(8, candidate.call([17, 24, 8, 23], 3))\n    assert_equal(36, candidate.call([16, 21, 25, 36, 4], 4))\n  end\nend\n",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rb",
-    "prompt": "# Write a python function to interchange the first and last element in a given list.\ndef swap_List(newlist)\n",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\ndef snake_to_camel(word)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([4, 2, 3, 4, 1], candidate.call([1, 2, 3, 4, 4]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"PythonProgram\", candidate.call(\"python_program\"))\n    assert_equal(\"PythonLanguage\", candidate.call(\"python_language\"))\n    assert_equal(\"ProgrammingLanguage\", candidate.call(\"programming_language\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "rb",
-    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\ndef count_first_elements(test_tup)\n",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\ndef eulerian_num(n, m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_first_elements\n    candidate = method(:count_first_elements)\n    assert_equal(3, candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal(2, candidate.call([2, 9, [5, 7], 11]))\n    assert_equal(4, candidate.call([11, 15, 5, 8, [2, 3], 8]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eulerian_num\n    candidate = method(:eulerian_num)\n    assert_equal(4, candidate.call(3, 1))\n    assert_equal(11, candidate.call(4, 1))\n    assert_equal(26, candidate.call(5, 3))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "rb",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\ndef right_insertion(a, x)\n",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\ndef sort_sublists(input_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_insertion\n    candidate = method(:right_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]], candidate.call([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]))\n    assert_equal([[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]], candidate.call([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "rb",
-    "prompt": "# Write a function to check if the given number is woodball or not.\ndef is_woodall(x)\n",
+    "prompt": "# Write a python function to count true booleans in the given list.\ndef count(lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_woodall\n    candidate = method(:is_woodall)\n    assert_equal(true, candidate.call(383))\n    assert_equal(false, candidate.call(254))\n    assert_equal(false, candidate.call(200))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count\n    candidate = method(:count)\n    assert_equal(2, candidate.call([true, false, true]))\n    assert_equal(0, candidate.call([false, false]))\n    assert_equal(3, candidate.call([true, true, true]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "rb",
-    "prompt": "# Write a function to sort the given array by using shell sort.\ndef shell_sort(my_list)\n",
+    "prompt": "# Write a function to append the given list to the given tuples.\ndef add_lists(test_list, test_tup)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_shell_sort\n    candidate = method(:shell_sort)\n    assert_equal([2, 3, 4, 5, 12, 12, 23, 56, 81, 95], candidate.call([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]))\n    assert_equal([22, 24, 34, 39, 68, 73, 87], candidate.call([24, 22, 39, 34, 87, 73, 68]))\n    assert_equal([16, 30, 32, 74, 82, 83, 96], candidate.call([32, 30, 16, 96, 82, 83, 74]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_lists\n    candidate = method(:add_lists)\n    assert_equal([9, 10, 5, 6, 7], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([10, 11, 6, 7, 8], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([11, 12, 7, 8, 9], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rb",
-    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\ndef find_Odd_Pair(a, n)\n",
+    "prompt": "# Write a function to merge three lists into a single sorted list.\ndef merge_sorted_list(num1, num2, num3)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Odd_Pair\n    candidate = method(:find_Odd_Pair)\n    assert_equal(6, candidate.call([5, 4, 7, 2, 1], 5))\n    assert_equal(12, candidate.call([7, 2, 8, 1, 0, 5, 11], 7))\n    assert_equal(2, candidate.call([1, 2, 3], 3))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_sorted_list\n    candidate = method(:merge_sorted_list)\n    assert_equal([4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233], candidate.call([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]))\n    assert_equal([1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12], candidate.call([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]))\n    assert_equal([1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85], candidate.call([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rb",
-    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\ndef sum_in_range(l, r)\n",
+    "prompt": "# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\ndef odd_Equivalent(s, n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_in_range\n    candidate = method(:sum_in_range)\n    assert_equal(8, candidate.call(2, 5))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(40, candidate.call(7, 13))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_Equivalent\n    candidate = method(:odd_Equivalent)\n    assert_equal(3, candidate.call(\"011001\", 6))\n    assert_equal(4, candidate.call(\"11011\", 5))\n    assert_equal(2, candidate.call(\"1010\", 4))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "rb",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\ndef square_perimeter(a)\n",
+    "prompt": "# Write a function to check if a string represents an integer or not.\ndef check_integer(text)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_perimeter\n    candidate = method(:square_perimeter)\n    assert_equal(40, candidate.call(10))\n    assert_equal(20, candidate.call(5))\n    assert_equal(16, candidate.call(4))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_integer\n    candidate = method(:check_integer)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"1\"))\n    assert_equal(true, candidate.call(\"12345\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rb",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\ndef is_polite(n)\n",
+    "prompt": "# Write a function to convert a given tuple of positive integers into a single integer.\ndef tuple_to_int(nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_polite\n    candidate = method(:is_polite)\n    assert_equal(11, candidate.call(7))\n    assert_equal(7, candidate.call(4))\n    assert_equal(13, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\ndef sum_series(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_series\n    candidate = method(:sum_series)\n    assert_equal(12, candidate.call(6))\n    assert_equal(30, candidate.call(10))\n    assert_equal(25, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rb",
-    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\ndef find_dissimilar(test_tup1, test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_dissimilar\n    candidate = method(:find_dissimilar)\n    assert_equal([3, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 4, 7, 9], candidate.call([1, 2, 3, 4], [7, 2, 3, 9]))\n    assert_equal([34, 36, 11, 25], candidate.call([21, 11, 25, 26], [26, 34, 21, 36]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rb",
-    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\ndef start_withp(words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_start_withp\n    candidate = method(:start_withp)\n    assert_equal([\"Python\", \"PHP\"], candidate.call([\"Python PHP\", \"Java JavaScript\", \"c c++\"]))\n    assert_equal([\"Python\", \"Programming\"], candidate.call([\"Python Programming\", \"Java Programming\"]))\n    assert_equal([\"Pqrst\", \"Pqr\"], candidate.call([\"Pqrst Pqr\", \"qrstuv\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rb",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\ndef snake_to_camel(word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"AndroidTv\", candidate.call(\"android_tv\"))\n    assert_equal(\"GooglePixel\", candidate.call(\"google_pixel\"))\n    assert_equal(\"AppleWatch\", candidate.call(\"apple_watch\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rb",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\ndef volume_cube(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_volume_cube\n    candidate = method(:volume_cube)\n    assert_equal(27, candidate.call(3))\n    assert_equal(8, candidate.call(2))\n    assert_equal(125, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ndef check_monthnumb_number(monthnum2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumb_number\n    candidate = method(:check_monthnumb_number)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rb",
-    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\ndef all_Bits_Set_In_The_Given_Range(n, l, r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Bits_Set_In_The_Given_Range\n    candidate = method(:all_Bits_Set_In_The_Given_Range)\n    assert_equal(true, candidate.call(4, 1, 2))\n    assert_equal(true, candidate.call(17, 2, 4))\n    assert_equal(false, candidate.call(39, 4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rb",
-    "prompt": "# Write a python function to get the first element of each sublist.\ndef Extract(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Extract\n    candidate = method(:Extract)\n    assert_equal([1, 3, 6], candidate.call([[1, 2], [3, 4, 5], [6, 7, 8, 9]]))\n    assert_equal([1, 4], candidate.call([[1, 2, 3], [4, 5]]))\n    assert_equal([9, 1], candidate.call([[9, 8, 1], [1, 2]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rb",
-    "prompt": "# Write a function to find the surface area of a cylinder.\ndef surfacearea_cylinder(r, h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cylinder\n    candidate = method(:surfacearea_cylinder)\n    assert_equal(942.45, candidate.call(10, 5))\n    assert_equal(226.18800000000002, candidate.call(4, 5))\n    assert_equal(351.848, candidate.call(4, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rb",
-    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\ndef sample_nam(sample_names)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sample_nam\n    candidate = method(:sample_nam)\n    assert_equal(16, candidate.call([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]))\n    assert_equal(10, candidate.call([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]))\n    assert_equal(6, candidate.call([\"abcd\", \"Python\", \"abba\", \"aba\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "rb",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\ndef rearrange_bigger(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rearrange_bigger\n    candidate = method(:rearrange_bigger)\n    assert_equal(21, candidate.call(12))\n    assert_equal(false, candidate.call(10))\n    assert_equal(120, candidate.call(102))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rb",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\ndef perimeter_pentagon(a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perimeter_pentagon\n    candidate = method(:perimeter_pentagon)\n    assert_equal(25, candidate.call(5))\n    assert_equal(50, candidate.call(10))\n    assert_equal(75, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rb",
-    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\ndef max_sum(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum\n    candidate = method(:max_sum)\n    assert_equal(194, candidate.call([1, 15, 51, 45, 33, 100, 12, 18, 9]))\n    assert_equal(210, candidate.call([80, 60, 30, 40, 20, 10]))\n    assert_equal(138, candidate.call([2, 3, 14, 16, 21, 23, 29, 30]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "rb",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\ndef extract_even(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_even\n    candidate = method(:extract_even)\n    assert_equal([4, [6, [2, 4]], 6, 8], candidate.call([4, 5, [7, 6, [2, 4]], 6, 8]))\n    assert_equal([6, [8, [4, 8]]], candidate.call([5, 6, [8, 7, [4, 8]], 7, 9]))\n    assert_equal([6, [8, [4, 6]], 8, 10], candidate.call([5, 6, [9, 8, [4, 6]], 8, 10]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_int\n    candidate = method(:tuple_to_int)\n    assert_equal(123, candidate.call([1, 2, 3]))\n    assert_equal(456, candidate.call([4, 5, 6]))\n    assert_equal(567, candidate.call([5, 6, 7]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4789,249 +169,9 @@
     "language": "rb",
     "prompt": "# Write a function to convert all possible convertible elements in a list of lists to floats.\ndef list_to_float(test_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_to_float\n    candidate = method(:list_to_float)\n    assert_equal([[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]], candidate.call([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]))\n    assert_equal([[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]], candidate.call([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]))\n    assert_equal([[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]], candidate.call([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rb",
-    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\ndef square_Sum(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(20, candidate.call(2))\n    assert_equal(56, candidate.call(3))\n    assert_equal(120, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\ndef get_pairs_count(arr, sum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_pairs_count\n    candidate = method(:get_pairs_count)\n    assert_equal(6, candidate.call([1, 1, 1, 1], 2))\n    assert_equal(3, candidate.call([1, 5, 7, -1, 5], 6))\n    assert_equal(1, candidate.call([1, -2, 3], 1))\n    assert_equal(1, candidate.call([-1, -2, 3], -3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rb",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ndef count_no_of_ways(n, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_no_of_ways\n    candidate = method(:count_no_of_ways)\n    assert_equal(16, candidate.call(2, 4))\n    assert_equal(6, candidate.call(3, 2))\n    assert_equal(228, candidate.call(4, 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rb",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\ndef reverse_words(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_words\n    candidate = method(:reverse_words)\n    assert_equal(\"program python\", candidate.call(\"python program\"))\n    assert_equal(\"language java\", candidate.call(\"java language\"))\n    assert_equal(\"man indian\", candidate.call(\"indian man\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rb",
-    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\ndef checks(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_checks\n    candidate = method(:checks)\n    assert_equal(false, candidate.call(70))\n    assert_equal(false, candidate.call(23))\n    assert_equal(true, candidate.call(73))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rb",
-    "prompt": "# Write a python function to find the last position of an element in a sorted array.\ndef last(arr, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last\n    candidate = method(:last)\n    assert_equal(0, candidate.call([1, 2, 3], 1))\n    assert_equal(2, candidate.call([1, 1, 1, 2, 3, 4], 1))\n    assert_equal(3, candidate.call([2, 3, 2, 3, 6, 8, 9], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rb",
-    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\ndef count_X(tup, x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_X\n    candidate = method(:count_X)\n    assert_equal(0, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4))\n    assert_equal(3, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10))\n    assert_equal(4, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "rb",
-    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\ndef extract_index_list(l1, l2, l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_index_list\n    candidate = method(:extract_index_list)\n    assert_equal([1, 7], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([1, 6], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]))\n    assert_equal([1, 5], candidate.call([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([], candidate.call([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "rb",
-    "prompt": "# Write a function to find the second smallest number in a list.\ndef second_smallest(numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_second_smallest\n    candidate = method(:second_smallest)\n    assert_equal(-2, candidate.call([1, 2, -8, -2, 0, -2]))\n    assert_equal(-0.5, candidate.call([1, 1, -0.5, 0, 2, -2, -2]))\n    assert_equal(nil, candidate.call([2, 2]))\n    assert_equal(nil, candidate.call([2, 2, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\ndef concatenate_tuple(test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate_tuple\n    candidate = method(:concatenate_tuple)\n    assert_equal(\"ID-is-4-UTS\", candidate.call([\"ID\", \"is\", 4, \"UTS\"]))\n    assert_equal(\"QWE-is-4-RTY\", candidate.call([\"QWE\", \"is\", 4, \"RTY\"]))\n    assert_equal(\"ZEN-is-4-OP\", candidate.call([\"ZEN\", \"is\", 4, \"OP\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\ndef replace_spaces(string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"My%20Name%20is%20Dawood\", candidate.call(\"My Name is Dawood\"))\n    assert_equal(\"I%20am%20a%20Programmer\", candidate.call(\"I am a Programmer\"))\n    assert_equal(\"I%20love%20Coding\", candidate.call(\"I love Coding\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rb",
-    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\ndef sum_range_list(list1, m, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_range_list\n    candidate = method(:sum_range_list)\n    assert_equal(29, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10))\n    assert_equal(16, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7))\n    assert_equal(38, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rb",
-    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\ndef merge_dictionaries_three(dict1, dict2, dict3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_dictionaries_three\n    candidate = method(:merge_dictionaries_three)\n    assert_equal({\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}))\n    assert_equal({\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}))\n    assert_equal({\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the minimum of two numbers.\ndef minimum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minimum\n    candidate = method(:minimum)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(-5, candidate.call(-5, -4))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\ndef max_difference(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_difference\n    candidate = method(:max_difference)\n    assert_equal(7, candidate.call([[3, 5], [1, 7], [10, 3], [1, 2]]))\n    assert_equal(15, candidate.call([[4, 6], [2, 17], [9, 13], [11, 12]]))\n    assert_equal(23, candidate.call([[12, 35], [21, 27], [13, 23], [41, 22]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rb",
-    "prompt": "# Write a python function to find element at a given index after number of rotations.\ndef find_Element(arr, ranges, rotations, index)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Element\n    candidate = method(:find_Element)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1))\n    assert_equal(3, candidate.call([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5044,7 +184,7 @@
     "language": "rb",
     "prompt": "# Write a function to convert a string to a list of strings split on the space character.\ndef string_to_list(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_list\n    candidate = method(:string_to_list)\n    assert_equal([\"python\", \"programming\"], candidate.call(\"python programming\"))\n    assert_equal([\"lists\", \"tuples\", \"strings\"], candidate.call(\"lists tuples strings\"))\n    assert_equal([\"write\", \"a\", \"program\"], candidate.call(\"write a program\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "rb",
     "prompt": "# Write a python function to find the element that appears only once in a sorted array.\ndef search(arr)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(3, candidate.call([1, 1, 2, 2, 3]))\n    assert_equal(8, candidate.call([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]))\n    assert_equal(1, candidate.call([1, 2, 2, 3, 3, 4, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rb",
-    "prompt": "# Write a function to sort a dictionary by value.\ndef sort_counter(dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_counter\n    candidate = method(:sort_counter)\n    assert_equal([[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]], candidate.call({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}))\n    assert_equal([[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]], candidate.call({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}))\n    assert_equal([[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]], candidate.call({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5089,7 +214,7 @@
     "language": "rb",
     "prompt": "# Write a python function to remove first and last occurrence of a given character from the string.\ndef remove_Occ(s, ch)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_Occ\n    candidate = method(:remove_Occ)\n    assert_equal(\"heo\", candidate.call(\"hello\", \"l\"))\n    assert_equal(\"bcd\", candidate.call(\"abcda\", \"a\"))\n    assert_equal(\"H\", candidate.call(\"PHP\", \"P\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rb",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\ndef lateralsurface_cube(l)\n",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\ndef max_product_tuple(list1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cube\n    candidate = method(:lateralsurface_cube)\n    assert_equal(100, candidate.call(5))\n    assert_equal(324, candidate.call(9))\n    assert_equal(400, candidate.call(10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product_tuple\n    candidate = method(:max_product_tuple)\n    assert_equal(36, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(200, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(484, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rb",
-    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ndef common_element(list1, list2)\n",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\ndef amicable_numbers_sum(limit)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common_element\n    candidate = method(:common_element)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]))\n    assert_equal(nil, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(true, candidate.call([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_amicable_numbers_sum\n    candidate = method(:amicable_numbers_sum)\n    assert_equal(504, candidate.call(999))\n    assert_equal(31626, candidate.call(9999))\n    assert_equal(0, candidate.call(99))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "rb",
-    "prompt": "# Write a function to append the given list to the given tuples.\ndef add_lists(test_list, test_tup)\n",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\ndef find_length(string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_lists\n    candidate = method(:add_lists)\n    assert_equal([9, 10, 5, 6, 7], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([10, 11, 6, 7, 8], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([11, 12, 7, 8, 9], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_length\n    candidate = method(:find_length)\n    assert_equal(6, candidate.call(\"11000010001\"))\n    assert_equal(1, candidate.call(\"10111\"))\n    assert_equal(2, candidate.call(\"11011101100101\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "rb",
-    "prompt": "# Write a function to compute the n-th power of each number in a list.\ndef nth_nums(nums, n)\n",
+    "prompt": "# Write a python function to find the sum of common divisors of two given numbers.\ndef sum(a, b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_nth_nums\n    candidate = method(:nth_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30], 3))\n    assert_equal([248832, 759375], candidate.call([12, 15], 5))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum\n    candidate = method(:sum)\n    assert_equal(6, candidate.call(10, 15))\n    assert_equal(93, candidate.call(100, 150))\n    assert_equal(3, candidate.call(4, 6))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "rb",
-    "prompt": "# Write a function to sort a list of elements.\ndef pancake_sort(nums)\n",
+    "prompt": "# Write a function to multiply two integers.\ndef multiply_int(x, y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pancake_sort\n    candidate = method(:pancake_sort)\n    assert_equal([15, 25, 38, 69, 79], candidate.call([15, 79, 25, 38, 69]))\n    assert_equal([12, 36, 54, 85, 98], candidate.call([98, 12, 54, 36, 85]))\n    assert_equal([12, 23, 32, 41, 42], candidate.call([41, 42, 32, 12, 23]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "rb",
-    "prompt": "# Write a function to find the median of three numbers.\ndef median_numbers(a, b, c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_numbers\n    candidate = method(:median_numbers)\n    assert_equal(55.0, candidate.call(25, 55, 65))\n    assert_equal(20.0, candidate.call(20, 10, 30))\n    assert_equal(45.0, candidate.call(15, 45, 75))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ndef check_greater(arr, number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_greater\n    candidate = method(:check_greater)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], 4))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6], 8))\n    assert_equal(true, candidate.call([9, 7, 4, 8, 6, 1], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ndef check_element(list, element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_element\n    candidate = method(:check_element)\n    assert_equal(false, candidate.call([\"green\", \"orange\", \"black\", \"white\"], \"blue\"))\n    assert_equal(false, candidate.call([1, 2, 3, 4], 7))\n    assert_equal(true, candidate.call([\"green\", \"green\", \"green\", \"green\"], \"green\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rb",
-    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\ndef extract_string(str, l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_string\n    candidate = method(:extract_string)\n    assert_equal([\"practice\", \"solution\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8))\n    assert_equal([\"Python\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6))\n    assert_equal([\"exercises\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rb",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ndef text_lowercase_underscore(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_lowercase_underscore\n    candidate = method(:text_lowercase_underscore)\n    assert_equal(true, candidate.call(\"aab_cbbbc\"))\n    assert_equal(false, candidate.call(\"aab_Abbbc\"))\n    assert_equal(false, candidate.call(\"Aaab_abbbc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to trim each list by k in the given lists.\ndef trim_tuple(test_list, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_trim_tuple\n    candidate = method(:trim_tuple)\n    assert_equal([[2], [9], [2], [2]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2))\n    assert_equal([[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1))\n    assert_equal([[8, 4], [8, 12], [1, 7], [6, 9]], candidate.call([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "rb",
-    "prompt": "# Write a python function to find the sublist having minimum length.\ndef Find_Min(lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min\n    candidate = method(:Find_Min)\n    assert_equal([1], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 1], candidate.call([[1, 1], [1, 1, 1], [1, 2, 7, 8]]))\n    assert_equal([\"x\"], candidate.call([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rb",
-    "prompt": "# Write a function to filter odd numbers.\ndef filter_oddnumbers(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_oddnumbers\n    candidate = method(:filter_oddnumbers)\n    assert_equal([1, 3, 5, 7, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([45, 67, 93], candidate.call([10, 20, 45, 67, 84, 93]))\n    assert_equal([5, 7, 9, 3], candidate.call([5, 7, 9, 8, 6, 4, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rb",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\ndef find_adverbs(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverbs\n    candidate = method(:find_adverbs)\n    assert_equal(\"0-7: Clearly\", candidate.call(\"Clearly, he has no excuse for such behavior.\"))\n    assert_equal(\"28-36: carefuly\", candidate.call(\"Please handle the situation carefuly\"))\n    assert_equal(\"18-25: quickly\", candidate.call(\"Complete the task quickly\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rb",
-    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\ndef max_of_nth(test_list, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_of_nth\n    candidate = method(:max_of_nth)\n    assert_equal(19, candidate.call([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2))\n    assert_equal(10, candidate.call([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1))\n    assert_equal(11, candidate.call([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndef decimal_to_binary(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"1000\", candidate.call(8))\n    assert_equal(\"10010\", candidate.call(18))\n    assert_equal(\"111\", candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ndef combinations_colors(l, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_colors\n    candidate = method(:combinations_colors)\n    assert_equal([[\"Red\"], [\"Green\"], [\"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 1))\n    assert_equal([[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 2))\n    assert_equal([[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to remove all whitespaces from a string.\ndef remove_all_spaces(text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_all_spaces\n    candidate = method(:remove_all_spaces)\n    assert_equal(\"pythonprogram\", candidate.call(\"python  program\"))\n    assert_equal(\"pythonprogramminglanguage\", candidate.call(\"python   programming    language\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"python                     program\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"   python                     program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "rb",
-    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\ndef min_Swaps(str1, str2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Swaps\n    candidate = method(:min_Swaps)\n    assert_equal(1, candidate.call(\"1101\", \"1110\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"000\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"110\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to create a new tuple from the given string and list.\ndef new_tuple(test_list, test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_new_tuple\n    candidate = method(:new_tuple)\n    assert_equal([\"WEB\", \"is\", \"best\"], candidate.call([\"WEB\", \"is\"], \"best\"))\n    assert_equal([\"We\", \"are\", \"Developers\"], candidate.call([\"We\", \"are\"], \"Developers\"))\n    assert_equal([\"Part\", \"is\", \"Wrong\"], candidate.call([\"Part\", \"is\"], \"Wrong\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rb",
-    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\ndef find_remainder(arr, n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_remainder\n    candidate = method(:find_remainder)\n    assert_equal(9, candidate.call([100, 10, 5, 25, 35, 14], 11))\n    assert_equal(0, candidate.call([1, 1, 1], 1))\n    assert_equal(0, candidate.call([1, 2, 1], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "rb",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\ndef min_val(listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_val\n    candidate = method(:min_val)\n    assert_equal(2, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(15, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(20, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rb",
-    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\ndef positive_count(nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_positive_count\n    candidate = method(:positive_count)\n    assert_equal(0.54, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.69, candidate.call([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.56, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to add the given tuple to the given list.\ndef add_tuple(test_list, test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_tuple\n    candidate = method(:add_tuple)\n    assert_equal([5, 6, 7, 9, 10], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([6, 7, 8, 10, 11], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([7, 8, 9, 11, 12], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rb",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\ndef max_run_uppercase(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_run_uppercase\n    candidate = method(:max_run_uppercase)\n    assert_equal(5, candidate.call(\"GeMKSForGERksISBESt\"))\n    assert_equal(6, candidate.call(\"PrECIOusMOVemENTSYT\"))\n    assert_equal(4, candidate.call(\"GooGLEFluTTER\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rb",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\ndef sort_matrix(m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_matrix\n    candidate = method(:sort_matrix)\n    assert_equal([[1, 1, 1], [1, 2, 3], [2, 4, 5]], candidate.call([[1, 2, 3], [2, 4, 5], [1, 1, 1]]))\n    assert_equal([[-2, 4, -5], [1, -1, 1], [1, 2, 3]], candidate.call([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]))\n    assert_equal([[2, 1, 4], [6, 4, 3], [5, 8, 9]], candidate.call([[5, 8, 9], [6, 4, 3], [2, 1, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rb",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ndef count_vowels(test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_vowels\n    candidate = method(:count_vowels)\n    assert_equal(7, candidate.call(\"bestinstareels\"))\n    assert_equal(12, candidate.call(\"partofthejourneyistheend\"))\n    assert_equal(5, candidate.call(\"amazonprime\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\ndef max_sum_increasing_subseq(a, n, index, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_increasing_subseq\n    candidate = method(:max_sum_increasing_subseq)\n    assert_equal(11, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 4, 6))\n    assert_equal(7, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 2, 5))\n    assert_equal(71, candidate.call([11, 15, 19, 21, 26, 28, 31], 7, 2, 4))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_int\n    candidate = method(:multiply_int)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(5, 10))\n    assert_equal(32, candidate.call(4, 8))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5524,7 +304,7 @@
     "language": "rb",
     "prompt": "# Write a function to find words that are longer than n characters from a given list of words.\ndef long_words(n, str)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_long_words\n    candidate = method(:long_words)\n    assert_equal([\"python\", \"programming\", \"language\"], candidate.call(3, \"python is a programming language\"))\n    assert_equal([\"writing\", \"program\"], candidate.call(2, \"writing a program\"))\n    assert_equal([\"sorting\"], candidate.call(5, \"sorting list\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rb",
-    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\ndef find_sum(arr)\n",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\ndef magic_square_test(my_matrix)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_sum\n    candidate = method(:find_sum)\n    assert_equal(21, candidate.call([1, 2, 3, 1, 1, 4, 5, 6]))\n    assert_equal(71, candidate.call([1, 10, 9, 4, 2, 10, 10, 45, 4]))\n    assert_equal(78, candidate.call([12, 10, 9, 45, 2, 10, 10, 45, 10]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_magic_square_test\n    candidate = method(:magic_square_test)\n    assert_equal(true, candidate.call([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]))\n    assert_equal(true, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 8]]))\n    assert_equal(false, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 7]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rb",
-    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\ndef tuple_to_dict(test_tup)\n",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\ndef sort_matrix(m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_dict\n    candidate = method(:tuple_to_dict)\n    assert_equal({1 => 5, 7 => 10, 13 => 5}, candidate.call([1, 5, 7, 10, 13, 5]))\n    assert_equal({1 => 2, 3 => 4, 5 => 6}, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal({7 => 8, 9 => 10, 11 => 12}, candidate.call([7, 8, 9, 10, 11, 12]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_matrix\n    candidate = method(:sort_matrix)\n    assert_equal([[1, 1, 1], [1, 2, 3], [2, 4, 5]], candidate.call([[1, 2, 3], [2, 4, 5], [1, 1, 1]]))\n    assert_equal([[-2, 4, -5], [1, -1, 1], [1, 2, 3]], candidate.call([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]))\n    assert_equal([[2, 1, 4], [6, 4, 3], [5, 8, 9]], candidate.call([[5, 8, 9], [6, 4, 3], [2, 1, 4]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rb",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\ndef get_coordinates(test_tup)\n",
+    "prompt": "# Write a function to find the item with maximum frequency in a given list.\ndef max_occurrences(nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_coordinates\n    candidate = method(:get_coordinates)\n    assert_equal([[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]], candidate.call([3, 4]))\n    assert_equal([[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]], candidate.call([4, 5]))\n    assert_equal([[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]], candidate.call([5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "rb",
-    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\ndef check_type(test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_type\n    candidate = method(:check_type)\n    assert_equal(true, candidate.call([5, 6, 7, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, \"4\"]))\n    assert_equal(true, candidate.call([3, 2, 1, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rb",
-    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\ndef find_First_Missing(array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_First_Missing\n    candidate = method(:find_First_Missing)\n    assert_equal(4, candidate.call([0, 1, 2, 3]))\n    assert_equal(3, candidate.call([0, 1, 2, 6, 9]))\n    assert_equal(0, candidate.call([2, 3, 5, 8, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\ndef is_undulating(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_undulating\n    candidate = method(:is_undulating)\n    assert_equal(true, candidate.call(1212121))\n    assert_equal(false, candidate.call(1991))\n    assert_equal(true, candidate.call(121))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rb",
-    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\ndef min_k(test_list, k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_k\n    candidate = method(:min_k)\n    assert_equal([[\"Akash\", 2], [\"Akshat\", 4]], candidate.call([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2))\n    assert_equal([[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]], candidate.call([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3))\n    assert_equal([[\"Ayesha\", 9]], candidate.call([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rb",
-    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\ndef count_Substrings(s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Substrings\n    candidate = method(:count_Substrings)\n    assert_equal(6, candidate.call(\"112112\"))\n    assert_equal(6, candidate.call(\"111\"))\n    assert_equal(12, candidate.call(\"1101112\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth decagonal number.\ndef is_num_decagonal(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_num_decagonal\n    candidate = method(:is_num_decagonal)\n    assert_equal(27, candidate.call(3))\n    assert_equal(175, candidate.call(7))\n    assert_equal(370, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\ndef rear_extract(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rear_extract\n    candidate = method(:rear_extract)\n    assert_equal([21, 20, 19], candidate.call([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]))\n    assert_equal([36, 25, 45], candidate.call([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]))\n    assert_equal([14, 36, 56], candidate.call([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the closest smaller number than n.\ndef closest_num(n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_num\n    candidate = method(:closest_num)\n    assert_equal(10, candidate.call(11))\n    assert_equal(6, candidate.call(7))\n    assert_equal(11, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rb",
-    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\ndef find_combinations(test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_combinations\n    candidate = method(:find_combinations)\n    assert_equal([[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]], candidate.call([[2, 4], [6, 7], [5, 1], [6, 10]]))\n    assert_equal([[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]], candidate.call([[3, 5], [7, 8], [6, 2], [7, 11]]))\n    assert_equal([[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]], candidate.call([[4, 6], [8, 9], [7, 3], [8, 12]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rb",
-    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\ndef maxAverageOfPath(cost)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maxAverageOfPath\n    candidate = method(:maxAverageOfPath)\n    assert_equal(5.2, candidate.call([[1, 2, 3], [6, 5, 4], [7, 3, 9]]))\n    assert_equal(6.2, candidate.call([[2, 3, 4], [7, 6, 5], [8, 4, 10]]))\n    assert_equal(7.2, candidate.call([[3, 4, 5], [8, 7, 6], [9, 5, 11]]))\n    assert_equal(5.8, candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\ndef sequential_search(dlist, item)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequential_search\n    candidate = method(:sequential_search)\n    assert_equal([true, 3], candidate.call([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31))\n    assert_equal([true, 7], candidate.call([12, 32, 45, 62, 35, 47, 44, 61], 61))\n    assert_equal([true, 6], candidate.call([9, 10, 17, 19, 22, 39, 48, 56], 48))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rb",
-    "prompt": "# Write a python function to remove odd numbers from a given list.\ndef remove_odd(l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal([2], candidate.call([1, 2, 3]))\n    assert_equal([2, 4, 6], candidate.call([2, 4, 6]))\n    assert_equal([10, 20], candidate.call([10, 20, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\ndef is_product_even(arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_product_even\n    candidate = method(:is_product_even)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([1, 2, 1, 4]))\n    assert_equal(false, candidate.call([1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rb",
-    "prompt": "# Write a python function to find the maximum of two numbers.\ndef maximum(a, b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal(10, candidate.call(5, 10))\n    assert_equal(-1, candidate.call(-1, -2))\n    assert_equal(9, candidate.call(9, 7))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_occurrences\n    candidate = method(:max_occurrences)\n    assert_equal(2, candidate.call([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]))\n    assert_equal(8, candidate.call([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]))\n    assert_equal(20, candidate.call([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5794,9 +364,759 @@
     "language": "rb",
     "prompt": "# Write a python function to reverse only the vowels of a given string (where y is not a vowel).\ndef reverse_vowels(str1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_vowels\n    candidate = method(:reverse_vowels)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"ASU\", candidate.call(\"USA\"))\n    assert_equal(\"ab\", candidate.call(\"ab\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rb",
+    "prompt": "# Write a function to convert a list to a string.\ndef tup_string(tup1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tup_string\n    candidate = method(:tup_string)\n    assert_equal(\"exercises\", candidate.call([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]))\n    assert_equal(\"python\", candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]))\n    assert_equal(\"program\", candidate.call([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given list of numbers.\ndef sum_negativenum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_negativenum\n    candidate = method(:sum_negativenum)\n    assert_equal(-32, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n    assert_equal(-52, candidate.call([10, 15, -14, 13, -18, 12, -20]))\n    assert_equal(-894, candidate.call([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth hexagonal number.\ndef hexagonal_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hexagonal_num\n    candidate = method(:hexagonal_num)\n    assert_equal(190, candidate.call(10))\n    assert_equal(45, candidate.call(5))\n    assert_equal(91, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\ndef is_Sum_Of_Powers_Of_Two(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sum_Of_Powers_Of_Two\n    candidate = method(:is_Sum_Of_Powers_Of_Two)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(7))\n    assert_equal(true, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort a list of elements.\ndef pancake_sort(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pancake_sort\n    candidate = method(:pancake_sort)\n    assert_equal([15, 25, 38, 69, 79], candidate.call([15, 79, 25, 38, 69]))\n    assert_equal([12, 36, 54, 85, 98], candidate.call([98, 12, 54, 36, 85]))\n    assert_equal([12, 23, 32, 41, 42], candidate.call([41, 42, 32, 12, 23]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rb",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given lists.\ndef count_samepair(list1, list2, list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_samepair\n    candidate = method(:count_samepair)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]))\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n    assert_equal(5, candidate.call([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "rb",
+    "prompt": "# Write a function to find number of lists present in the given list.\ndef find_lists(input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lists\n    candidate = method(:find_lists)\n    assert_equal(2, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[1, 2], [3, 4], [5, 6]]))\n    assert_equal(1, candidate.call([9, 8, 7, 6, 5, 4, 3, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rb",
+    "prompt": "# Write a python function to find the maximum difference between any two elements in a given array.\ndef max_Abs_Diff(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Abs_Diff\n    candidate = method(:max_Abs_Diff)\n    assert_equal(4, candidate.call([2, 1, 5, 3]))\n    assert_equal(8, candidate.call([9, 3, 2, 5, 1]))\n    assert_equal(2, candidate.call([3, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rb",
+    "prompt": "# Write a python function to find the volume of a triangular prism.\ndef find_Volume(l, b, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Volume\n    candidate = method(:find_Volume)\n    assert_equal(240, candidate.call(10, 8, 6))\n    assert_equal(6, candidate.call(3, 2, 2))\n    assert_equal(1, candidate.call(1, 2, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rb",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\ndef find_solution(a, b, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_solution\n    candidate = method(:find_solution)\n    assert_equal([2, 1], candidate.call(2, 3, 7))\n    assert_equal(nil, candidate.call(4, 2, 7))\n    assert_equal([4, 1], candidate.call(1, 13, 17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rb",
+    "prompt": "# Write a function to remove all elements from a given list present in another list.\ndef remove_elements(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_elements\n    candidate = method(:remove_elements)\n    assert_equal([1, 3, 5, 7, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]))\n    assert_equal([2, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]))\n    assert_equal([1, 2, 3, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\ndef sum_series(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_series\n    candidate = method(:sum_series)\n    assert_equal(12, candidate.call(6))\n    assert_equal(30, candidate.call(10))\n    assert_equal(25, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rb",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\ndef are_equivalent(num1, num2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_are_equivalent\n    candidate = method(:are_equivalent)\n    assert_equal(false, candidate.call(36, 57))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(23, 47))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ndef count_char_position(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_char_position\n    candidate = method(:count_char_position)\n    assert_equal(2, candidate.call(\"xbcefg\"))\n    assert_equal(3, candidate.call(\"ABcED\"))\n    assert_equal(5, candidate.call(\"AbgdeF\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rb",
+    "prompt": "# Write a function that counts the number of pairs of integers in a list that xor to an even number.\ndef find_even_pair(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_even_pair\n    candidate = method(:find_even_pair)\n    assert_equal(4, candidate.call([5, 4, 7, 2, 1]))\n    assert_equal(9, candidate.call([7, 2, 8, 1, 0, 5, 11]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rb",
+    "prompt": "# Write a python function to find the smallest power of 2 greater than or equal to n.\ndef next_power_of_2(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_power_of_2\n    candidate = method(:next_power_of_2)\n    assert_equal(1, candidate.call(0))\n    assert_equal(8, candidate.call(5))\n    assert_equal(32, candidate.call(17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given list.\ndef frequency(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency\n    candidate = method(:frequency)\n    assert_equal(0, candidate.call([1, 2, 3], 4))\n    assert_equal(3, candidate.call([1, 2, 2, 3, 3, 3, 4], 3))\n    assert_equal(2, candidate.call([0, 1, 2, 3, 1, 2], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rb",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ndef text_lowercase_underscore(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_lowercase_underscore\n    candidate = method(:text_lowercase_underscore)\n    assert_equal(true, candidate.call(\"aab_cbbbc\"))\n    assert_equal(false, candidate.call(\"aab_Abbbc\"))\n    assert_equal(false, candidate.call(\"Aaab_abbbc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rb",
+    "prompt": "# Write a function to find the sum of numbers in a list within a range specified by two indices.\ndef sum_range_list(list1, m, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_range_list\n    candidate = method(:sum_range_list)\n    assert_equal(29, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10))\n    assert_equal(16, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7))\n    assert_equal(38, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rb",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\ndef perimeter_pentagon(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perimeter_pentagon\n    candidate = method(:perimeter_pentagon)\n    assert_equal(25, candidate.call(5))\n    assert_equal(50, candidate.call(10))\n    assert_equal(75, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ndef count_occurance(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_occurance\n    candidate = method(:count_occurance)\n    assert_equal(3, candidate.call(\"letstdlenstdporstd\"))\n    assert_equal(1, candidate.call(\"truststdsolensporsd\"))\n    assert_equal(2, candidate.call(\"makestdsostdworthit\"))\n    assert_equal(1, candidate.call(\"stds\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rb",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\ndef square_perimeter(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_perimeter\n    candidate = method(:square_perimeter)\n    assert_equal(40, candidate.call(10))\n    assert_equal(20, candidate.call(5))\n    assert_equal(16, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rb",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\ndef remove_dirty_chars(string, second_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_dirty_chars\n    candidate = method(:remove_dirty_chars)\n    assert_equal(\"bacuve\", candidate.call(\"probasscurve\", \"pros\"))\n    assert_equal(\"digiidi\", candidate.call(\"digitalindia\", \"talent\"))\n    assert_equal(\"emles\", candidate.call(\"exoticmiles\", \"toxic\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rb",
+    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ndef test_duplicate(arraynums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_duplicate\n    candidate = method(:test_duplicate)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 4]))\n    assert_equal(true, candidate.call([1, 1, 2, 2, 3, 3, 4, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given number is woodball or not.\ndef is_woodall(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_woodall\n    candidate = method(:is_woodall)\n    assert_equal(true, candidate.call(383))\n    assert_equal(false, candidate.call(254))\n    assert_equal(false, candidate.call(200))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "rb",
+    "prompt": "# Write a function to check if all the elements in tuple have same data type or not.\ndef check_type(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_type\n    candidate = method(:check_type)\n    assert_equal(true, candidate.call([5, 6, 7, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, \"4\"]))\n    assert_equal(true, candidate.call([3, 2, 1, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\ndef is_majority(arr, n, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_majority\n    candidate = method(:is_majority)\n    assert_equal(true, candidate.call([1, 2, 3, 3, 3, 3, 10], 7, 3))\n    assert_equal(false, candidate.call([1, 1, 2, 4, 4, 4, 6, 6], 8, 4))\n    assert_equal(true, candidate.call([1, 1, 1, 2, 2], 5, 1))\n    assert_equal(false, candidate.call([1, 1, 2, 2], 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\ndef count_Set_Bits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Set_Bits\n    candidate = method(:count_Set_Bits)\n    assert_equal(1, candidate.call(2))\n    assert_equal(1, candidate.call(4))\n    assert_equal(2, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rb",
+    "prompt": "# Write a python function to remove the characters which have odd index values of a given string.\ndef odd_values_string(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_values_string\n    candidate = method(:odd_values_string)\n    assert_equal(\"ace\", candidate.call(\"abcdef\"))\n    assert_equal(\"pto\", candidate.call(\"python\"))\n    assert_equal(\"dt\", candidate.call(\"data\"))\n    assert_equal(\"lms\", candidate.call(\"lambs\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rb",
+    "prompt": "# Write a function to find minimum of three numbers.\ndef min_of_three(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_of_three\n    candidate = method(:min_of_three)\n    assert_equal(0, candidate.call(10, 20, 0))\n    assert_equal(15, candidate.call(19, 15, 18))\n    assert_equal(-30, candidate.call(-10, -20, -30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether all the bits are unset in the given range or not.\ndef all_Bits_Set_In_The_Given_Range(n, l, r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Bits_Set_In_The_Given_Range\n    candidate = method(:all_Bits_Set_In_The_Given_Range)\n    assert_equal(true, candidate.call(4, 1, 2))\n    assert_equal(true, candidate.call(17, 2, 4))\n    assert_equal(false, candidate.call(39, 4, 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\ndef re_arrange_array(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_re_arrange_array\n    candidate = method(:re_arrange_array)\n    assert_equal([-1, -3, -7, 4, 5, 6, 2, 8, 9], candidate.call([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9))\n    assert_equal([-14, -26, 12, 13, 15], candidate.call([12, -14, -26, 13, 15], 5))\n    assert_equal([-42, -39, -78, 10, 24, 36, 85], candidate.call([10, 24, 36, -42, -39, -78, 85], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\ndef replace_blank(str1, char)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_blank\n    candidate = method(:replace_blank)\n    assert_equal(\"hello@people\", candidate.call(\"hello people\", \"@\"))\n    assert_equal(\"python$program$language\", candidate.call(\"python program language\", \"$\"))\n    assert_equal(\"blank-space\", candidate.call(\"blank space\", \"-\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rb",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\ndef volume_cube(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_volume_cube\n    candidate = method(:volume_cube)\n    assert_equal(27, candidate.call(3))\n    assert_equal(8, candidate.call(2))\n    assert_equal(125, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\ndef check_occurences(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_occurences\n    candidate = method(:check_occurences)\n    assert_equal({[1, 3] => 2, [2, 5] => 2, [3, 6] => 1}, candidate.call([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]))\n    assert_equal({[2, 4] => 2, [3, 6] => 2, [4, 7] => 1}, candidate.call([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]))\n    assert_equal({[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1}, candidate.call([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of non-empty substrings of a given string.\ndef number_of_substrings(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_of_substrings\n    candidate = method(:number_of_substrings)\n    assert_equal(6, candidate.call(\"abc\"))\n    assert_equal(10, candidate.call(\"abcd\"))\n    assert_equal(15, candidate.call(\"abcde\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rb",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\ndef get_total_number_of_sequences(m, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_total_number_of_sequences\n    candidate = method(:get_total_number_of_sequences)\n    assert_equal(4, candidate.call(10, 4))\n    assert_equal(6, candidate.call(5, 2))\n    assert_equal(84, candidate.call(16, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\ndef replace_list(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_list\n    candidate = method(:replace_list)\n    assert_equal([1, 3, 5, 7, 9, 2, 4, 6, 8], candidate.call([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8]))\n    assert_equal([\"red\", \"blue\", \"yellow\"], candidate.call([\"red\", \"blue\", \"green\"], [\"yellow\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rb",
+    "prompt": "# Write a function to count the total number of characters in a string.\ndef count_charac(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_charac\n    candidate = method(:count_charac)\n    assert_equal(18, candidate.call(\"python programming\"))\n    assert_equal(8, candidate.call(\"language\"))\n    assert_equal(5, candidate.call(\"words\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rb",
+    "prompt": "# Write a python function to find the next perfect square greater than a given number.\ndef next_Perfect_Square(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_Perfect_Square\n    candidate = method(:next_Perfect_Square)\n    assert_equal(36, candidate.call(35))\n    assert_equal(9, candidate.call(6))\n    assert_equal(16, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rb",
+    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\ndef max_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum\n    candidate = method(:max_sum)\n    assert_equal(194, candidate.call([1, 15, 51, 45, 33, 100, 12, 18, 9]))\n    assert_equal(210, candidate.call([80, 60, 30, 40, 20, 10]))\n    assert_equal(138, candidate.call([2, 3, 14, 16, 21, 23, 29, 30]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rb",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\ndef lps(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lps\n    candidate = method(:lps)\n    assert_equal(5, candidate.call(\"TENS FOR TENS\"))\n    assert_equal(7, candidate.call(\"CARDIO FOR CARDS\"))\n    assert_equal(9, candidate.call(\"PART OF THE JOURNEY IS PART\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rb",
+    "prompt": "# Write a function to find the intersection of two arrays.\ndef intersection_array(array_nums1, array_nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection_array\n    candidate = method(:intersection_array)\n    assert_equal([1, 2, 8, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]))\n    assert_equal([3, 5, 7, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]))\n    assert_equal([10], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rb",
+    "prompt": "# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\ndef count_X(tup, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_X\n    candidate = method(:count_X)\n    assert_equal(0, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4))\n    assert_equal(3, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10))\n    assert_equal(4, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\ndef insert_element(list, element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_insert_element\n    candidate = method(:insert_element)\n    assert_equal([\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"], candidate.call([\"Red\", \"Green\", \"Black\"], \"c\"))\n    assert_equal([\"program\", \"python\", \"program\", \"java\"], candidate.call([\"python\", \"java\"], \"program\"))\n    assert_equal([\"laugh\", \"happy\", \"laugh\", \"sad\"], candidate.call([\"happy\", \"sad\"], \"laugh\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rb",
+    "prompt": "# Write a python function to convert complex numbers to polar coordinates.\ndef convert(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert\n    candidate = method(:convert)\n    assert_equal([1.0, 0.0], candidate.call(1))\n    assert_equal([4.0, 0.0], candidate.call(4))\n    assert_equal([5.0, 0.0], candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "rb",
+    "prompt": "# Write a python function that returns the number of integer elements in a given list.\ndef count_integer(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_integer\n    candidate = method(:count_integer)\n    assert_equal(2, candidate.call([1, 2, \"abc\", 1.2]))\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 1.2, 4, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\ndef combinations_colors(l, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_colors\n    candidate = method(:combinations_colors)\n    assert_equal([[\"Red\"], [\"Green\"], [\"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 1))\n    assert_equal([[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 2))\n    assert_equal([[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rb",
+    "prompt": "# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ndef count_Primes_nums(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Primes_nums\n    candidate = method(:count_Primes_nums)\n    assert_equal(2, candidate.call(5))\n    assert_equal(4, candidate.call(10))\n    assert_equal(25, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two numbers and returns a list with the second number and then the first number.\ndef swap_numbers(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_numbers\n    candidate = method(:swap_numbers)\n    assert_equal([20, 10], candidate.call(10, 20))\n    assert_equal([17, 15], candidate.call(15, 17))\n    assert_equal([200, 100], candidate.call(100, 200))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5809,7 +1129,7 @@
     "language": "rb",
     "prompt": "# Write a function to maximize the given two lists.\ndef maximize_elements(test_tup1, test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximize_elements\n    candidate = method(:maximize_elements)\n    assert_equal([[6, 7], [4, 9], [2, 9], [7, 10]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[7, 8], [5, 10], [3, 10], [8, 11]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[8, 9], [6, 11], [4, 11], [9, 12]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rb",
-    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\ndef even_position(nums)\n",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\ndef newman_prime(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_position\n    candidate = method(:even_position)\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([2, 1, 4]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_newman_prime\n    candidate = method(:newman_prime)\n    assert_equal(7, candidate.call(3))\n    assert_equal(17, candidate.call(4))\n    assert_equal(41, candidate.call(5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rb",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ndef check_char(string)\n",
+    "prompt": "# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\ndef division_elements(test_tup1, test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_char\n    candidate = method(:check_char)\n    assert_equal(\"Valid\", candidate.call(\"abba\"))\n    assert_equal(\"Valid\", candidate.call(\"a\"))\n    assert_equal(\"Invalid\", candidate.call(\"abcd\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_division_elements\n    candidate = method(:division_elements)\n    assert_equal([2, 2, 2, 3], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([2, 2, 2, 4], candidate.call([12, 6, 8, 16], [6, 3, 4, 4]))\n    assert_equal([4, 2, 6, 2], candidate.call([20, 14, 36, 18], [5, 7, 6, 9]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "rb",
-    "prompt": "# Write a python function to find the sum of even factors of a number.\ndef sumofFactors(n)\n",
+    "prompt": "# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\ndef split_two_parts(list1, l)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sumofFactors\n    candidate = method(:sumofFactors)\n    assert_equal(26, candidate.call(18))\n    assert_equal(48, candidate.call(30))\n    assert_equal(8, candidate.call(6))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_two_parts\n    candidate = method(:split_two_parts)\n    assert_equal([[1, 1, 2], [3, 4, 4, 5, 1]], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"]], candidate.call([\"a\", \"b\", \"c\", \"d\"], 2))\n    assert_equal([[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]], candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "rb",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\ndef lateralsurface_cone(r, h)\n",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndef dog_age(h_age)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cone\n    candidate = method(:lateralsurface_cone)\n    assert_equal(204.20352248333654, candidate.call(5, 12))\n    assert_equal(566.3586699569488, candidate.call(10, 15))\n    assert_equal(1521.8090132193388, candidate.call(19, 17))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dog_age\n    candidate = method(:dog_age)\n    assert_equal(61, candidate.call(12))\n    assert_equal(73, candidate.call(15))\n    assert_equal(109, candidate.call(24))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "rb",
-    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ndef count_Pairs(arr, n)\n",
+    "prompt": "# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\ndef list_split(s, step)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Pairs\n    candidate = method(:count_Pairs)\n    assert_equal(2, candidate.call([1, 2, 1], 3))\n    assert_equal(0, candidate.call([1, 1, 1, 1], 4))\n    assert_equal(10, candidate.call([1, 2, 3, 4, 5], 5))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_split\n    candidate = method(:list_split)\n    assert_equal([[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]], candidate.call([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3))\n    assert_equal([[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3))\n    assert_equal([[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]], candidate.call([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rb",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\ndef find_first_occurrence(a, x)\n",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\ndef lateralsurface_cube(l)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_first_occurrence\n    candidate = method(:find_first_occurrence)\n    assert_equal(1, candidate.call([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(2, candidate.call([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(4, candidate.call([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cube\n    candidate = method(:lateralsurface_cube)\n    assert_equal(100, candidate.call(5))\n    assert_equal(324, candidate.call(9))\n    assert_equal(400, candidate.call(10))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5914,9 +1234,909 @@
     "language": "rb",
     "prompt": "# Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\ndef square_Sum(n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(10, candidate.call(2))\n    assert_equal(35, candidate.call(3))\n    assert_equal(84, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the n'th star number.\ndef find_star_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_star_num\n    candidate = method(:find_star_num)\n    assert_equal(37, candidate.call(3))\n    assert_equal(73, candidate.call(4))\n    assert_equal(121, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rb",
+    "prompt": "# Write a function to find the ascii value of a character.\ndef ascii_value(k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_ascii_value\n    candidate = method(:ascii_value)\n    assert_equal(65, candidate.call(\"A\"))\n    assert_equal(82, candidate.call(\"R\"))\n    assert_equal(83, candidate.call(\"S\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of even numbers at even positions of a list.\ndef sum_even_and_even_index(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_even_and_even_index\n    candidate = method(:sum_even_and_even_index)\n    assert_equal(30, candidate.call([5, 6, 12, 1, 18, 8]))\n    assert_equal(26, candidate.call([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]))\n    assert_equal(12, candidate.call([5, 6, 12, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rb",
+    "prompt": "# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\ndef even_Power_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_Power_Sum\n    candidate = method(:even_Power_Sum)\n    assert_equal(1056, candidate.call(2))\n    assert_equal(8832, candidate.call(3))\n    assert_equal(32, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\ndef rear_extract(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rear_extract\n    candidate = method(:rear_extract)\n    assert_equal([21, 20, 19], candidate.call([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]))\n    assert_equal([36, 25, 45], candidate.call([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]))\n    assert_equal([14, 36, 56], candidate.call([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\ndef substract_elements(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_substract_elements\n    candidate = method(:substract_elements)\n    assert_equal([8, -1, -13], candidate.call([10, 4, 5], [2, 5, 18]))\n    assert_equal([-13, -43, -13], candidate.call([11, 2, 3], [24, 45, 16]))\n    assert_equal([-3, 7, -3], candidate.call([7, 18, 9], [10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rb",
+    "prompt": "# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\ndef even_binomial_Coeff_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_binomial_Coeff_Sum\n    candidate = method(:even_binomial_Coeff_Sum)\n    assert_equal(8, candidate.call(4))\n    assert_equal(32, candidate.call(6))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\ndef dict_filter(dict, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dict_filter\n    candidate = method(:dict_filter)\n    assert_equal({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170))\n    assert_equal({\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180))\n    assert_equal({\"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "rb",
+    "prompt": "# Write a function to find the number of elements that occurs before the list element in the given tuple.\ndef count_first_elements(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_first_elements\n    candidate = method(:count_first_elements)\n    assert_equal(3, candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal(2, candidate.call([2, 9, [5, 7], 11]))\n    assert_equal(4, candidate.call([11, 15, 5, 8, [2, 3], 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth decagonal number.\ndef is_num_decagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_num_decagonal\n    candidate = method(:is_num_decagonal)\n    assert_equal(27, candidate.call(3))\n    assert_equal(175, candidate.call(7))\n    assert_equal(370, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\ndef sequential_search(dlist, item)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequential_search\n    candidate = method(:sequential_search)\n    assert_equal([true, 3], candidate.call([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31))\n    assert_equal([true, 7], candidate.call([12, 32, 45, 62, 35, 47, 44, 61], 61))\n    assert_equal([true, 6], candidate.call([9, 10, 17, 19, 22, 39, 48, 56], 48))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rb",
+    "prompt": "# Write a python function to check if the elements of a given list are unique or not.\ndef all_unique(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_unique\n    candidate = method(:all_unique)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rb",
+    "prompt": "# Write a function to subtract two lists element-wise.\ndef sub_list(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sub_list\n    candidate = method(:sub_list)\n    assert_equal([-3, -3, -3], candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal([-2, -2], candidate.call([1, 2], [3, 4]))\n    assert_equal([40, 50], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rb",
+    "prompt": "# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\ndef validate(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_validate\n    candidate = method(:validate)\n    assert_equal(true, candidate.call(1234))\n    assert_equal(false, candidate.call(51241))\n    assert_equal(true, candidate.call(321))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\ndef check_element(list, element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_element\n    candidate = method(:check_element)\n    assert_equal(false, candidate.call([\"green\", \"orange\", \"black\", \"white\"], \"blue\"))\n    assert_equal(false, candidate.call([1, 2, 3, 4], 7))\n    assert_equal(true, candidate.call([\"green\", \"green\", \"green\", \"green\"], \"green\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rb",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ndef text_match_two_three(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_two_three\n    candidate = method(:text_match_two_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rb",
+    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\ndef max_sub_array_sum_repeated(a, n, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum_repeated\n    candidate = method(:max_sub_array_sum_repeated)\n    assert_equal(30, candidate.call([10, 20, -30, -1], 4, 3))\n    assert_equal(59, candidate.call([-1, 10, 20], 3, 2))\n    assert_equal(-1, candidate.call([-1, -2, -3], 3, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rb",
+    "prompt": "# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\ndef square_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(20, candidate.call(2))\n    assert_equal(56, candidate.call(3))\n    assert_equal(120, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rb",
+    "prompt": "# Write a function to find the list of maximum length in a list of lists.\ndef max_length(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length\n    candidate = method(:max_length)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([4, [10, 12, 14, 15]], candidate.call([[1], [5, 7], [10, 12, 14, 15]]))\n    assert_equal([3, [15, 20, 25]], candidate.call([[5], [15, 20, 25]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rb",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ndef count_no_of_ways(n, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_no_of_ways\n    candidate = method(:count_no_of_ways)\n    assert_equal(16, candidate.call(2, 4))\n    assert_equal(6, candidate.call(3, 2))\n    assert_equal(228, candidate.call(4, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rb",
+    "prompt": "# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\ndef find(n, m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find\n    candidate = method(:find)\n    assert_equal(3, candidate.call(10, 3))\n    assert_equal(2, candidate.call(4, 2))\n    assert_equal(4, candidate.call(20, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rb",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\ndef otherside_rightangle(w, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_otherside_rightangle\n    candidate = method(:otherside_rightangle)\n    assert_equal(10.63014581273465, candidate.call(7, 8))\n    assert_equal(5, candidate.call(3, 4))\n    assert_equal(16.55294535724685, candidate.call(7, 15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous list.\ndef max_val(listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_val\n    candidate = method(:max_val)\n    assert_equal(5, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(25, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(50, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rb",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\ndef sum_div(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_div\n    candidate = method(:sum_div)\n    assert_equal(7, candidate.call(8))\n    assert_equal(16, candidate.call(12))\n    assert_equal(1, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rb",
+    "prompt": "# Write a python function to count inversions in an array.\ndef get_Inv_Count(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Inv_Count\n    candidate = method(:get_Inv_Count)\n    assert_equal(5, candidate.call([1, 20, 6, 4, 5]))\n    assert_equal(1, candidate.call([1, 2, 1]))\n    assert_equal(3, candidate.call([1, 2, 5, 6, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "rb",
+    "prompt": "# Write a function to flatten a given nested list structure.\ndef flatten_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flatten_list\n    candidate = method(:flatten_list)\n    assert_equal([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120], candidate.call([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]))\n    assert_equal([10, 20, 40, 30, 56, 25, 10, 20, 33, 40], candidate.call([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]))\n    assert_equal([1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the maximum aggregate from the list of tuples.\ndef max_aggregate(stdata)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_aggregate\n    candidate = method(:max_aggregate)\n    assert_equal([\"Juan Whelan\", 212], candidate.call([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]))\n    assert_equal([\"Juan Whelan\", 72], candidate.call([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]))\n    assert_equal([\"Sabah Colley\", 70], candidate.call([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rb",
+    "prompt": "# Write a python function to find element at a given index after number of rotations.\ndef find_Element(arr, ranges, rotations, index)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Element\n    candidate = method(:find_Element)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1))\n    assert_equal(3, candidate.call([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rb",
+    "prompt": "# Write a function to return two words from a list of words starting with letter 'p'.\ndef start_withp(words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_start_withp\n    candidate = method(:start_withp)\n    assert_equal([\"Python\", \"PHP\"], candidate.call([\"Python PHP\", \"Java JavaScript\", \"c c++\"]))\n    assert_equal([\"Python\", \"Programming\"], candidate.call([\"Python Programming\", \"Java Programming\"]))\n    assert_equal([\"Pqrst\", \"Pqr\"], candidate.call([\"Pqrst Pqr\", \"qrstuv\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\ndef max_sum_increasing_subseq(a, n, index, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_increasing_subseq\n    candidate = method(:max_sum_increasing_subseq)\n    assert_equal(11, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 4, 6))\n    assert_equal(7, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 2, 5))\n    assert_equal(71, candidate.call([11, 15, 19, 21, 26, 28, 31], 7, 2, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\ndef large_product(nums1, nums2, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_large_product\n    candidate = method(:large_product)\n    assert_equal([60, 54, 50], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3))\n    assert_equal([60, 54, 50, 48], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4))\n    assert_equal([60, 54, 50, 48, 45], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the maximum of two numbers.\ndef maximum(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal(10, candidate.call(5, 10))\n    assert_equal(-1, candidate.call(-1, -2))\n    assert_equal(9, candidate.call(9, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to convert a given string to a list of characters.\ndef string_to_tuple(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_tuple\n    candidate = method(:string_to_tuple)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"], candidate.call(\"python 3.0\"))\n    assert_equal([\"i\", \"t\", \"e\", \"m\", \"1\"], candidate.call(\"item1\"))\n    assert_equal([\"1\", \"5\", \".\", \"1\", \"0\"], candidate.call(\"15.10\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rb",
+    "prompt": "# Write a python function to find the highest power of 2 that is less than or equal to n.\ndef highest_Power_of_2(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_highest_Power_of_2\n    candidate = method(:highest_Power_of_2)\n    assert_equal(8, candidate.call(10))\n    assert_equal(16, candidate.call(19))\n    assert_equal(32, candidate.call(32))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rb",
+    "prompt": "# Write a function to find the n'th lucas number.\ndef find_lucas(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lucas\n    candidate = method(:find_lucas)\n    assert_equal(76, candidate.call(9))\n    assert_equal(7, candidate.call(4))\n    assert_equal(4, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "rb",
+    "prompt": "# Write a function to apply a given format string to all of the elements in a list.\ndef add_string(list_, string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_string\n    candidate = method(:add_string)\n    assert_equal([\"temp1\", \"temp2\", \"temp3\", \"temp4\"], candidate.call([1, 2, 3, 4], \"temp{0}\"))\n    assert_equal([\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"], candidate.call([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"))\n    assert_equal([\"string5\", \"string6\", \"string7\", \"string8\"], candidate.call([5, 6, 7, 8], \"string{0}\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "rb",
+    "prompt": "# Write a function to convert more than one list to nested dictionary.\ndef convert_list_dictionary(l1, l2, l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert_list_dictionary\n    candidate = method(:convert_list_dictionary)\n    assert_equal([{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}], candidate.call([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]))\n    assert_equal([{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}], candidate.call([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]))\n    assert_equal([{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}], candidate.call([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\ndef get_max_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_sum\n    candidate = method(:get_max_sum)\n    assert_equal(106, candidate.call(60))\n    assert_equal(12, candidate.call(10))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rb",
+    "prompt": "# Write a function to find the list with maximum length.\ndef max_length_list(input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length_list\n    candidate = method(:max_length_list)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([5, [1, 2, 3, 4, 5]], candidate.call([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]))\n    assert_equal([4, [6, 7, 8, 9]], candidate.call([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rb",
+    "prompt": "# Write a function to check if given list contains no duplicates.\ndef check_distinct(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_distinct\n    candidate = method(:check_distinct)\n    assert_equal(false, candidate.call([1, 4, 5, 6, 1, 4]))\n    assert_equal(true, candidate.call([1, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rb",
+    "prompt": "# Write a python function to find the first non-repeated character in a given string.\ndef first_non_repeating_character(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_non_repeating_character\n    candidate = method(:first_non_repeating_character)\n    assert_equal(nil, candidate.call(\"abcabc\"))\n    assert_equal(\"a\", candidate.call(\"abc\"))\n    assert_equal(\"c\", candidate.call(\"ababc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ndef check_char(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_char\n    candidate = method(:check_char)\n    assert_equal(\"Valid\", candidate.call(\"abba\"))\n    assert_equal(\"Valid\", candidate.call(\"a\"))\n    assert_equal(\"Invalid\", candidate.call(\"abcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rb",
+    "prompt": "# Write a function to find the median of three numbers.\ndef median_numbers(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_numbers\n    candidate = method(:median_numbers)\n    assert_equal(55.0, candidate.call(25, 55, 65))\n    assert_equal(20.0, candidate.call(20, 10, 30))\n    assert_equal(45.0, candidate.call(15, 45, 75))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "rb",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given list.\ndef sum_of_digits(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_of_digits\n    candidate = method(:sum_of_digits)\n    assert_equal(14, candidate.call([10, 2, 56]))\n    assert_equal(19, candidate.call([[10, 20, 4, 5, \"b\", 70, \"a\"]]))\n    assert_equal(19, candidate.call([10, 20, -4, 5, -70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rb",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given tuples.\ndef bitwise_xor(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bitwise_xor\n    candidate = method(:bitwise_xor)\n    assert_equal([15, 6, 5, 10], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([13, 6, 3, 14], candidate.call([11, 5, 7, 10], [6, 3, 4, 4]))\n    assert_equal([11, 2, 13, 13], candidate.call([12, 6, 8, 11], [7, 4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rb",
+    "prompt": "# Write a python function to identify non-prime numbers.\ndef is_not_prime(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_not_prime\n    candidate = method(:is_not_prime)\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(10))\n    assert_equal(true, candidate.call(35))\n    assert_equal(false, candidate.call(37))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rb",
+    "prompt": "# Write a function to extract the number of unique tuples in the given list.\ndef extract_freq(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_freq\n    candidate = method(:extract_freq)\n    assert_equal(3, candidate.call([[3, 4], [1, 2], [4, 3], [5, 6]]))\n    assert_equal(4, candidate.call([[4, 15], [2, 3], [5, 4], [6, 7]]))\n    assert_equal(4, candidate.call([[5, 16], [2, 3], [6, 5], [6, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to perform index wise addition of list elements in the given two nested lists.\ndef add_nested_tuples(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_nested_tuples\n    candidate = method(:add_nested_tuples)\n    assert_equal([[7, 10], [7, 14], [3, 10], [8, 13]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[9, 12], [9, 16], [5, 12], [10, 15]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[11, 14], [11, 18], [7, 14], [12, 17]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the minimum of two numbers.\ndef minimum(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minimum\n    candidate = method(:minimum)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(-5, candidate.call(-5, -4))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "rb",
+    "prompt": "# Write a function to check whether an element exists within a tuple.\ndef check_tuplex(tuplex, tuple1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_tuplex\n    candidate = method(:check_tuplex)\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"))\n    assert_equal(false, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"))\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rb",
+    "prompt": "# Write a python function to find whether the parity of a given number is odd.\ndef find_Parity(x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Parity\n    candidate = method(:find_Parity)\n    assert_equal(false, candidate.call(12))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "rb",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\ndef rearrange_bigger(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rearrange_bigger\n    candidate = method(:rearrange_bigger)\n    assert_equal(21, candidate.call(12))\n    assert_equal(false, candidate.call(10))\n    assert_equal(120, candidate.call(102))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rb",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\ndef k_smallest_pairs(nums1, nums2, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_k_smallest_pairs\n    candidate = method(:k_smallest_pairs)\n    assert_equal([[1, 2], [1, 4]], candidate.call([1, 3, 7], [2, 4, 6], 2))\n    assert_equal([[1, 2]], candidate.call([1, 3, 7], [2, 4, 6], 1))\n    assert_equal([[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]], candidate.call([1, 3, 7], [2, 4, 6], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to find the minimum product from the pairs of tuples within a given list.\ndef min_product_tuple(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_product_tuple\n    candidate = method(:min_product_tuple)\n    assert_equal(8, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(30, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(100, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "rb",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous list.\ndef min_val(listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_val\n    candidate = method(:min_val)\n    assert_equal(2, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(15, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(20, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\ndef snake_to_camel(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"AndroidTv\", candidate.call(\"android_tv\"))\n    assert_equal(\"GooglePixel\", candidate.call(\"google_pixel\"))\n    assert_equal(\"AppleWatch\", candidate.call(\"apple_watch\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rb",
+    "prompt": "# Write a python function to remove odd numbers from a given list.\ndef remove_odd(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal([2], candidate.call([1, 2, 3]))\n    assert_equal([2, 4, 6], candidate.call([2, 4, 6]))\n    assert_equal([10, 20], candidate.call([10, 20, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "rb",
+    "prompt": "# Write a function to extract the nth element from a given list of tuples.\ndef extract_nth_element(list1, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_nth_element\n    candidate = method(:extract_nth_element)\n    assert_equal([\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0))\n    assert_equal([99, 96, 94, 98], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2))\n    assert_equal([98, 97, 91, 94], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether any value in a sequence exists in a sequence or not.\ndef overlapping(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_overlapping\n    candidate = method(:overlapping)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(false, candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal(true, candidate.call([1, 4, 5], [1, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rb",
+    "prompt": "# Write a python function to find a pair with highest product from a given array of integers.\ndef max_Product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Product\n    candidate = method(:max_Product)\n    assert_equal([7, 8], candidate.call([1, 2, 3, 4, 7, 0, 8, 4]))\n    assert_equal([-4, -6], candidate.call([0, -1, -2, -4, 5, 0, -6]))\n    assert_equal([2, 3], candidate.call([1, 2, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5929,7 +2149,7 @@
     "language": "rb",
     "prompt": "# Write a function to find common first element in given list of lists.\ndef group_tuples(input)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_group_tuples\n    candidate = method(:group_tuples)\n    assert_equal([[\"x\", \"y\", \"z\"], [\"w\", \"t\"]], candidate.call([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]))\n    assert_equal([[\"a\", \"b\", \"c\"], [\"d\", \"e\"]], candidate.call([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]))\n    assert_equal([[\"f\", \"g\", \"g\"], [\"h\", \"i\"]], candidate.call([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]))\n  end\nend\n",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "rb",
-    "prompt": "# Write a function to merge three lists into a single sorted list.\ndef merge_sorted_list(num1, num2, num3)\n",
+    "prompt": "# Write a python function to find the element of a list having maximum length.\ndef Find_Max(lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_sorted_list\n    candidate = method(:merge_sorted_list)\n    assert_equal([4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233], candidate.call([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]))\n    assert_equal([1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12], candidate.call([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]))\n    assert_equal([1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85], candidate.call([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max\n    candidate = method(:Find_Max)\n    assert_equal([\"A\", \"B\", \"C\"], candidate.call([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]))\n    assert_equal([1, 2, 3], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 5, 6, 1], candidate.call([[1, 1], [1, 2, 3], [1, 5, 6, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "rb",
+    "prompt": "# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\ndef round_and_sum(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_round_and_sum\n    candidate = method(:round_and_sum)\n    assert_equal(243, candidate.call([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]))\n    assert_equal(345, candidate.call([5, 2, 9, 24.3, 29]))\n    assert_equal(513, candidate.call([25.0, 56.7, 89.2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the cube sum of first n even natural numbers.\ndef cube_Sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_Sum\n    candidate = method(:cube_Sum)\n    assert_equal(72, candidate.call(2))\n    assert_equal(288, candidate.call(3))\n    assert_equal(800, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to concatenate each element of tuple by the delimiter.\ndef concatenate_tuple(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate_tuple\n    candidate = method(:concatenate_tuple)\n    assert_equal(\"ID-is-4-UTS\", candidate.call([\"ID\", \"is\", 4, \"UTS\"]))\n    assert_equal(\"QWE-is-4-RTY\", candidate.call([\"QWE\", \"is\", 4, \"RTY\"]))\n    assert_equal(\"ZEN-is-4-OP\", candidate.call([\"ZEN\", \"is\", 4, \"OP\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rb",
+    "prompt": "# Write a python function to find the average of cubes of first n natural numbers.\ndef find_Average_Of_Cube(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Average_Of_Cube\n    candidate = method(:find_Average_Of_Cube)\n    assert_equal(4.5, candidate.call(2))\n    assert_equal(12, candidate.call(3))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rb",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given tuple.\ndef extract_rear(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_rear\n    candidate = method(:extract_rear)\n    assert_equal([\"s\", \"r\", \"s\"], candidate.call([\"Mers\", \"for\", \"Vers\"]))\n    assert_equal([\"e\", \"r\", \"e\"], candidate.call([\"Avenge\", \"for\", \"People\"]))\n    assert_equal([\"a\", \"t\", \"o\"], candidate.call([\"Gotta\", \"get\", \"go\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of sublists containing a particular element.\ndef count_element_in_list(list1, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_element_in_list\n    candidate = method(:count_element_in_list)\n    assert_equal(3, candidate.call([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1))\n    assert_equal(3, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"))\n    assert_equal(1, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rb",
+    "prompt": "# Write a function to filter odd numbers.\ndef filter_oddnumbers(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_oddnumbers\n    candidate = method(:filter_oddnumbers)\n    assert_equal([1, 3, 5, 7, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([45, 67, 93], candidate.call([10, 20, 45, 67, 84, 93]))\n    assert_equal([5, 7, 9, 3], candidate.call([5, 7, 9, 8, 6, 4, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rb",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\ndef change_date_format(dt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_date_format\n    candidate = method(:change_date_format)\n    assert_equal(\"02-01-2026\", candidate.call(\"2026-01-02\"))\n    assert_equal(\"13-11-2020\", candidate.call(\"2020-11-13\"))\n    assert_equal(\"26-04-2021\", candidate.call(\"2021-04-26\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort the given array by using shell sort.\ndef shell_sort(my_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_shell_sort\n    candidate = method(:shell_sort)\n    assert_equal([2, 3, 4, 5, 12, 12, 23, 56, 81, 95], candidate.call([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]))\n    assert_equal([22, 24, 34, 39, 68, 73, 87], candidate.call([24, 22, 39, 34, 87, 73, 68]))\n    assert_equal([16, 30, 32, 74, 82, 83, 96], candidate.call([32, 30, 16, 96, 82, 83, 74]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to extract the elementwise and tuples from the given two tuples.\ndef and_tuples(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_and_tuples\n    candidate = method(:and_tuples)\n    assert_equal([0, 0, 2, 1], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([1, 2, 3, 0], candidate.call([1, 2, 3, 4], [5, 6, 7, 8]))\n    assert_equal([0, 9, 10, 0], candidate.call([8, 9, 11, 12], [7, 13, 14, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rb",
+    "prompt": "# Write a function to find the directrix of a parabola.\ndef parabola_directrix(a, b, c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parabola_directrix\n    candidate = method(:parabola_directrix)\n    assert_equal(-198, candidate.call(5, 3, 2))\n    assert_equal(-2336, candidate.call(9, 8, 4))\n    assert_equal(-130, candidate.call(2, 4, 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes two lists and returns true if they have at least one common element.\ndef common_element(list1, list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common_element\n    candidate = method(:common_element)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]))\n    assert_equal(nil, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(true, candidate.call([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rb",
+    "prompt": "# Write a function to find the median length of a trapezium.\ndef median_trapezium(base1, base2, height)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_trapezium\n    candidate = method(:median_trapezium)\n    assert_equal(20, candidate.call(15, 25, 35))\n    assert_equal(15, candidate.call(10, 20, 30))\n    assert_equal(7.5, candidate.call(6, 9, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ndef check_greater(arr, number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_greater\n    candidate = method(:check_greater)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], 4))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6], 8))\n    assert_equal(true, candidate.call([9, 7, 4, 8, 6, 1], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ndef text_match_one(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_one\n    candidate = method(:text_match_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rb",
+    "prompt": "# Write a python function to find the last digit of a given number.\ndef last_Digit(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit\n    candidate = method(:last_Digit)\n    assert_equal(3, candidate.call(123))\n    assert_equal(5, candidate.call(25))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rb",
+    "prompt": "# Write a python function to return the negative numbers in a list.\ndef neg_nos(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_neg_nos\n    candidate = method(:neg_nos)\n    assert_equal([-1, -6], candidate.call([-1, 4, 5, -6]))\n    assert_equal([-1, -2], candidate.call([-1, -2, 3, 4]))\n    assert_equal([-7, -6], candidate.call([-7, -6, 8, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rb",
+    "prompt": "# Write a function to remove odd characters in a string.\ndef remove_odd(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal(\"yhn\", candidate.call(\"python\"))\n    assert_equal(\"rga\", candidate.call(\"program\"))\n    assert_equal(\"agae\", candidate.call(\"language\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rb",
+    "prompt": "# Write a function to count bidirectional tuple pairs.\ndef count_bidirectional(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_bidirectional\n    candidate = method(:count_bidirectional)\n    assert_equal(3, candidate.call([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(2, candidate.call([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(4, candidate.call([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rb",
+    "prompt": "# Write a function to join a list of multiple integers into a single integer.\ndef multiple_to_single(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiple_to_single\n    candidate = method(:multiple_to_single)\n    assert_equal(113350, candidate.call([11, 33, 50]))\n    assert_equal(-123456, candidate.call([-1, 2, 3, 4, 5, 6]))\n    assert_equal(10152025, candidate.call([10, 15, 20, 25]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rb",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\ndef find_adverb_position(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverb_position\n    candidate = method(:find_adverb_position)\n    assert_equal([0, 7, \"clearly\"], candidate.call(\"clearly!! we can see the sky\"))\n    assert_equal([0, 9, \"seriously\"], candidate.call(\"seriously!! there are many roses\"))\n    assert_equal([0, 13, \"unfortunately\"], candidate.call(\"unfortunately!! sita is going to home\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rb",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\ndef surfacearea_cube(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cube\n    candidate = method(:surfacearea_cube)\n    assert_equal(150, candidate.call(5))\n    assert_equal(54, candidate.call(3))\n    assert_equal(600, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rb",
+    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\ndef positive_count(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_positive_count\n    candidate = method(:positive_count)\n    assert_equal(0.54, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.69, candidate.call([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.56, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rb",
+    "prompt": "# Write a python function to find the largest negative number from the given list.\ndef largest_neg(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_neg\n    candidate = method(:largest_neg)\n    assert_equal(-6, candidate.call([1, 2, 3, -4, -6]))\n    assert_equal(-9, candidate.call([1, 2, 3, -8, -9]))\n    assert_equal(-1, candidate.call([1, 2, 3, 4, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to trim each list by k in the given lists.\ndef trim_tuple(test_list, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_trim_tuple\n    candidate = method(:trim_tuple)\n    assert_equal([[2], [9], [2], [2]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2))\n    assert_equal([[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1))\n    assert_equal([[8, 4], [8, 12], [1, 7], [6, 9]], candidate.call([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rb",
+    "prompt": "# Write a function to perform index wise multiplication of list elements in the given two lists.\ndef index_multiplication(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_multiplication\n    candidate = method(:index_multiplication)\n    assert_equal([[6, 21], [12, 45], [2, 9], [7, 30]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[14, 32], [20, 60], [6, 20], [16, 44]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[24, 45], [30, 77], [12, 33], [27, 60]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "rb",
+    "prompt": "# Write a python function to count the occurence of all elements of list in a tuple.\ndef count_Occurrence(tup, lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Occurrence\n    candidate = method(:count_Occurrence)\n    assert_equal(3, candidate.call([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]))\n    assert_equal(6, candidate.call([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6], [1, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rb",
+    "prompt": "# Write a function to find cubes of individual elements in a list.\ndef cube_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_nums\n    candidate = method(:cube_nums)\n    assert_equal([1, 8, 27, 64, 125, 216, 343, 512, 729, 1000], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30]))\n    assert_equal([1728, 3375], candidate.call([12, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\ndef cal_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cal_sum\n    candidate = method(:cal_sum)\n    assert_equal(49, candidate.call(9))\n    assert_equal(66, candidate.call(10))\n    assert_equal(88, candidate.call(11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rb",
+    "prompt": "# Write a function to extract specified size of strings from a given list of string values.\ndef extract_string(str, l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_string\n    candidate = method(:extract_string)\n    assert_equal([\"practice\", \"solution\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8))\n    assert_equal([\"Python\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6))\n    assert_equal([\"exercises\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rb",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\ndef remove_whitespaces(text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_whitespaces\n    candidate = method(:remove_whitespaces)\n    assert_equal(\"GoogleFlutter\", candidate.call(\" Google    Flutter \"))\n    assert_equal(\"GoogleDart\", candidate.call(\" Google    Dart \"))\n    assert_equal(\"iOSSwift\", candidate.call(\" iOS    Swift \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rb",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\ndef loss_amount(actual_cost, sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_loss_amount\n    candidate = method(:loss_amount)\n    assert_equal(0, candidate.call(1500, 1200))\n    assert_equal(100, candidate.call(100, 200))\n    assert_equal(3000, candidate.call(2000, 5000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of even factors of a number.\ndef sumofFactors(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sumofFactors\n    candidate = method(:sumofFactors)\n    assert_equal(26, candidate.call(18))\n    assert_equal(48, candidate.call(30))\n    assert_equal(8, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rb",
+    "prompt": "# Write a function that matches a word containing 'z'.\ndef text_match_wordz(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz\n    candidate = method(:text_match_wordz)\n    assert_equal(true, candidate.call(\"pythonz.\"))\n    assert_equal(true, candidate.call(\"xyz.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ndef check_monthnumb_number(monthnum2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumb_number\n    candidate = method(:check_monthnumb_number)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rb",
+    "prompt": "# Write a function to reverse each string in a given list of string values.\ndef reverse_string_list(stringlist)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_string_list\n    candidate = method(:reverse_string_list)\n    assert_equal([\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"], candidate.call([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]))\n    assert_equal([\"nhoj\", \"lama\", \"leoj\", \"egroeg\"], candidate.call([\"john\", \"amal\", \"joel\", \"george\"]))\n    assert_equal([\"kcaj\", \"nhoj\", \"yram\"], candidate.call([\"jack\", \"john\", \"mary\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sublist having minimum length.\ndef Find_Min(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min\n    candidate = method(:Find_Min)\n    assert_equal([1], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 1], candidate.call([[1, 1], [1, 1, 1], [1, 2, 7, 8]]))\n    assert_equal([\"x\"], candidate.call([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rb",
+    "prompt": "# Write a function to find the area of a rectangle.\ndef rectangle_area(l, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rectangle_area\n    candidate = method(:rectangle_area)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(10, 5))\n    assert_equal(8, candidate.call(4, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rb",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\ndef remove_uppercase(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_uppercase\n    candidate = method(:remove_uppercase)\n    assert_equal(\"cstyoravoitshos\", candidate.call(\"cAstyoUrFavoRitETVshoWs\"))\n    assert_equal(\"wtchheinerntrdo\", candidate.call(\"wAtchTheinTernEtrAdIo\"))\n    assert_equal(\"oiceachndreomendaion\", candidate.call(\"VoicESeaRchAndreComMendaTionS\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rb",
+    "prompt": "# Write a python function to get the first element of each sublist.\ndef Extract(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Extract\n    candidate = method(:Extract)\n    assert_equal([1, 3, 6], candidate.call([[1, 2], [3, 4, 5], [6, 7, 8, 9]]))\n    assert_equal([1, 4], candidate.call([[1, 2, 3], [4, 5]]))\n    assert_equal([9, 1], candidate.call([[9, 8, 1], [1, 2]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rb",
+    "prompt": "# Write a python function to count the upper case characters in a given string.\ndef upper_ctr(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_upper_ctr\n    candidate = method(:upper_ctr)\n    assert_equal(1, candidate.call(\"PYthon\"))\n    assert_equal(1, candidate.call(\"BigData\"))\n    assert_equal(0, candidate.call(\"program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "rb",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given list.\ndef combinations_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_list\n    candidate = method(:combinations_list)\n    assert_equal([[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]], candidate.call([\"orange\", \"red\", \"green\", \"blue\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"black\", \"orange\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum product subarray of the given array.\ndef max_subarray_product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_subarray_product\n    candidate = method(:max_subarray_product)\n    assert_equal(112, candidate.call([1, -2, -3, 0, 7, -8, -2]))\n    assert_equal(180, candidate.call([6, -3, -10, 0, 2]))\n    assert_equal(80, candidate.call([-2, -40, 0, -2, -3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rb",
+    "prompt": "# Write a function to check if all values are same in a dictionary.\ndef check_value(dict, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_value\n    candidate = method(:check_value)\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10))\n    assert_equal(true, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12))\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "rb",
+    "prompt": "# Write a function to drop empty items from a given dictionary.\ndef drop_empty(dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_drop_empty\n    candidate = method(:drop_empty)\n    assert_equal({\"c1\" => \"Red\", \"c2\" => \"Green\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => nil}))\n    assert_equal({\"c1\" => \"Red\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => nil, \"c3\" => nil}))\n    assert_equal({\"c2\" => \"Green\"}, candidate.call({\"c1\" => nil, \"c2\" => \"Green\", \"c3\" => nil}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\ndef max_product(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product\n    candidate = method(:max_product)\n    assert_equal(3000, candidate.call([3, 100, 4, 5, 150, 6]))\n    assert_equal(50265600, candidate.call([4, 42, 55, 68, 80]))\n    assert_equal(2460, candidate.call([10, 22, 9, 33, 21, 50, 41, 60]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rb",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\ndef add_pairwise(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_pairwise\n    candidate = method(:add_pairwise)\n    assert_equal([6, 12, 15, 18], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 14, 17, 20], candidate.call([2, 6, 8, 9, 11]))\n    assert_equal([10, 16, 19, 22], candidate.call([3, 7, 9, 10, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rb",
+    "prompt": "# Write a python function to find the product of the array multiplication modulo n.\ndef find_remainder(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_remainder\n    candidate = method(:find_remainder)\n    assert_equal(9, candidate.call([100, 10, 5, 25, 35, 14], 11))\n    assert_equal(0, candidate.call([1, 1, 1], 1))\n    assert_equal(0, candidate.call([1, 2, 1], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given list contains consecutive numbers or not.\ndef check_Consecutive(l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_Consecutive\n    candidate = method(:check_Consecutive)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 2, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rb",
+    "prompt": "# Write a function to replace characters in a string.\ndef replace_char(str1, ch, newch)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_char\n    candidate = method(:replace_char)\n    assert_equal(\"pollgon\", candidate.call(\"polygon\", \"y\", \"l\"))\n    assert_equal(\"aharaater\", candidate.call(\"character\", \"c\", \"a\"))\n    assert_equal(\"python\", candidate.call(\"python\", \"l\", \"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rb",
+    "prompt": "# Write a function to sort a dictionary by value.\ndef sort_counter(dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_counter\n    candidate = method(:sort_counter)\n    assert_equal([[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]], candidate.call({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}))\n    assert_equal([[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]], candidate.call({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}))\n    assert_equal([[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]], candidate.call({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of the largest and smallest value in a given array.\ndef big_sum(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_sum\n    candidate = method(:big_sum)\n    assert_equal(4, candidate.call([1, 2, 3]))\n    assert_equal(3, candidate.call([-1, 2, 3, 4]))\n    assert_equal(8, candidate.call([2, 3, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rb",
+    "prompt": "# Write a python function to convert the given string to lower case.\ndef is_lower(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_lower\n    candidate = method(:is_lower)\n    assert_equal(\"invalid\", candidate.call(\"InValid\"))\n    assert_equal(\"true\", candidate.call(\"TruE\"))\n    assert_equal(\"sentence\", candidate.call(\"SenTenCE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rb",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\ndef remove_lowercase(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_lowercase\n    candidate = method(:remove_lowercase)\n    assert_equal(\"PYTH\", candidate.call(\"PYTHon\"))\n    assert_equal(\"FID\", candidate.call(\"FInD\"))\n    assert_equal(\"STRG\", candidate.call(\"STRinG\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rb",
+    "prompt": "# Write a python function to find the first digit of a given number.\ndef first_Digit(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_Digit\n    candidate = method(:first_Digit)\n    assert_equal(1, candidate.call(123))\n    assert_equal(4, candidate.call(456))\n    assert_equal(1, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rb",
+    "prompt": "# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\ndef heap_queue_largest(nums, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_queue_largest\n    candidate = method(:heap_queue_largest)\n    assert_equal([85, 75, 65], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 3))\n    assert_equal([85, 75], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 2))\n    assert_equal([85, 75, 65, 58, 35], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rb",
+    "prompt": "# Write a python function which takes a list of integers and only returns the odd ones.\ndef Split(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([1, 3, 5], candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal([11, 13], candidate.call([10, 11, 12, 13]))\n    assert_equal([7, 9, 1], candidate.call([7, 8, 9, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rb",
+    "prompt": "# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndef difference(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_difference\n    candidate = method(:difference)\n    assert_equal(30, candidate.call(3))\n    assert_equal(210, candidate.call(5))\n    assert_equal(6, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of pairs whose xor value is odd.\ndef find_Odd_Pair(a, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Odd_Pair\n    candidate = method(:find_Odd_Pair)\n    assert_equal(6, candidate.call([5, 4, 7, 2, 1], 5))\n    assert_equal(12, candidate.call([7, 2, 8, 1, 0, 5, 11], 7))\n    assert_equal(2, candidate.call([1, 2, 3], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rb",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\ndef toggle_string(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_string\n    candidate = method(:toggle_string)\n    assert_equal(\"pYTHON\", candidate.call(\"Python\"))\n    assert_equal(\"pANGRAM\", candidate.call(\"Pangram\"))\n    assert_equal(\"liTTle\", candidate.call(\"LIttLE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of the per-digit difference between two integers.\ndef digit_distance_nums(n1, n2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digit_distance_nums\n    candidate = method(:digit_distance_nums)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(6, candidate.call(23, 56))\n    assert_equal(7, candidate.call(123, 256))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the sum of the largest contiguous sublist in the given list.\ndef max_sub_array_sum(a, size)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum\n    candidate = method(:max_sub_array_sum)\n    assert_equal(7, candidate.call([-2, -3, 4, -1, -2, 1, 5, -3], 8))\n    assert_equal(8, candidate.call([-3, -4, 5, -2, -3, 2, 6, -4], 8))\n    assert_equal(10, candidate.call([-4, -5, 6, -3, -4, 3, 7, -5], 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rb",
+    "prompt": "# Write a function to find the union of the elements of two given lists and output them in sorted order.\ndef union_elements(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_union_elements\n    candidate = method(:union_elements)\n    assert_equal([3, 4, 5, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 2, 3, 4, 5, 6], candidate.call([1, 2, 3, 4], [3, 4, 5, 6]))\n    assert_equal([11, 12, 13, 14, 15, 16, 17], candidate.call([11, 12, 13, 14], [13, 15, 16, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rb",
+    "prompt": "# Write a python function to find the length of the longest sublists.\ndef Find_Max_Length(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max_Length\n    candidate = method(:Find_Max_Length)\n    assert_equal(4, candidate.call([[1], [1, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[0, 1], [2, 2], [3, 2, 1]]))\n    assert_equal(5, candidate.call([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "rb",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\ndef extract_values(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_values\n    candidate = method(:extract_values)\n    assert_equal([\"Python\", \"PHP\", \"Java\"], candidate.call(\"\"Python\", \"PHP\", \"Java\"\"))\n    assert_equal([\"python\", \"program\", \"language\"], candidate.call(\"\"python\",\"program\",\"language\"\"))\n    assert_equal([\"red\", \"blue\", \"green\", \"yellow\"], candidate.call(\"\"red\",\"blue\",\"green\",\"yellow\"\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rb",
+    "prompt": "# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\ndef count_Pairs(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Pairs\n    candidate = method(:count_Pairs)\n    assert_equal(2, candidate.call([1, 2, 1], 3))\n    assert_equal(0, candidate.call([1, 1, 1, 1], 4))\n    assert_equal(10, candidate.call([1, 2, 3, 4, 5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rb",
+    "prompt": "# Write a python function to split a string into characters.\ndef split(word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split\n    candidate = method(:split)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], candidate.call(\"python\"))\n    assert_equal([\"N\", \"a\", \"m\", \"e\"], candidate.call(\"Name\"))\n    assert_equal([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"], candidate.call(\"program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rb",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\ndef sum_digits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_digits\n    candidate = method(:sum_digits)\n    assert_equal(12, candidate.call(345))\n    assert_equal(3, candidate.call(12))\n    assert_equal(16, candidate.call(97))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rb",
+    "prompt": "# Write a function to check whether a specified list is sorted or not.\ndef issort_list(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_issort_list\n    candidate = method(:issort_list)\n    assert_equal(true, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 15, 14, 20]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "rb",
+    "prompt": "# Write a function to create a list of N empty dictionaries.\ndef empty_list(length)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_empty_list\n    candidate = method(:empty_list)\n    assert_equal([{}, {}, {}, {}, {}], candidate.call(5))\n    assert_equal([{}, {}, {}, {}, {}, {}], candidate.call(6))\n    assert_equal([{}, {}, {}, {}, {}, {}, {}], candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rb",
+    "prompt": "# Write a function to sort each sublist of strings in a given list of lists.\ndef sort_sublists(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]], candidate.call([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rb",
+    "prompt": "# Write a python function to check if a given number is one less than twice its reverse.\ndef checks(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_checks\n    candidate = method(:checks)\n    assert_equal(false, candidate.call(70))\n    assert_equal(false, candidate.call(23))\n    assert_equal(true, candidate.call(73))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rb",
+    "prompt": "# Write a python function to remove duplicate numbers from a given number of lists.\ndef two_unique_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_two_unique_nums\n    candidate = method(:two_unique_nums)\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 3, 4, 5]))\n    assert_equal([1, 3, 4, 5], candidate.call([1, 2, 3, 2, 4, 5]))\n    assert_equal([1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rb",
+    "prompt": "# Write a python function to calculate the product of the unique numbers in a given list.\ndef unique_product(list_data)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_product\n    candidate = method(:unique_product)\n    assert_equal(720000000, candidate.call([10, 20, 30, 40, 20, 50, 60, 40]))\n    assert_equal(6, candidate.call([1, 2, 3, 1]))\n    assert_equal(0, candidate.call([7, 8, 9, 0, 1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rb",
+    "prompt": "# Write a function to find the surface area of a cylinder.\ndef surfacearea_cylinder(r, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cylinder\n    candidate = method(:surfacearea_cylinder)\n    assert_equal(942.45, candidate.call(10, 5))\n    assert_equal(226.18800000000002, candidate.call(4, 5))\n    assert_equal(351.848, candidate.call(4, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether a list is sublist of another or not.\ndef is_Sub_Array(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sub_Array\n    candidate = method(:is_Sub_Array)\n    assert_equal(false, candidate.call([1, 4, 3, 5], [1, 2]))\n    assert_equal(true, candidate.call([1, 2, 1], [1, 2, 1]))\n    assert_equal(false, candidate.call([1, 0, 2, 2], [2, 2, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rb",
+    "prompt": "# Write a python function to find the last digit in factorial of a given number.\ndef last_Digit_Factorial(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit_Factorial\n    candidate = method(:last_Digit_Factorial)\n    assert_equal(4, candidate.call(4))\n    assert_equal(0, candidate.call(21))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rb",
+    "prompt": "# Write a function to interleave 3 lists of the same length into a single flat list.\ndef interleave_lists(list1, list2, list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_interleave_lists\n    candidate = method(:interleave_lists)\n    assert_equal([1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700], candidate.call([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]))\n    assert_equal([10, 15, 5, 20, 2, 10], candidate.call([10, 20], [15, 2], [5, 10]))\n    assert_equal([11, 10, 20, 44, 15, 5], candidate.call([11, 44], [10, 15], [20, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rb",
+    "prompt": "# Write a function to find the dissimilar elements in the given two tuples.\ndef find_dissimilar(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_dissimilar\n    candidate = method(:find_dissimilar)\n    assert_equal([3, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 4, 7, 9], candidate.call([1, 2, 3, 4], [7, 2, 3, 9]))\n    assert_equal([34, 36, 11, 25], candidate.call([21, 11, 25, 26], [26, 34, 21, 36]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rb",
+    "prompt": "# Write a python function to find the largest number that can be formed with the given list of digits.\ndef find_Max_Num(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Max_Num\n    candidate = method(:find_Max_Num)\n    assert_equal(321, candidate.call([1, 2, 3]))\n    assert_equal(6541, candidate.call([4, 5, 6, 1]))\n    assert_equal(9321, candidate.call([1, 2, 3, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "rb",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed tuple.\ndef extract_even(test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_even\n    candidate = method(:extract_even)\n    assert_equal([4, [6, [2, 4]], 6, 8], candidate.call([4, 5, [7, 6, [2, 4]], 6, 8]))\n    assert_equal([6, [8, [4, 8]]], candidate.call([5, 6, [8, 7, [4, 8]], 7, 9]))\n    assert_equal([6, [8, [4, 6]], 8, 10], candidate.call([5, 6, [9, 8, [4, 6]], 8, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rb",
+    "prompt": "# Write a python function to find the surface area of a square pyramid with a given base edge and height.\ndef surface_Area(b, s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surface_Area\n    candidate = method(:surface_Area)\n    assert_equal(33, candidate.call(3, 4))\n    assert_equal(56, candidate.call(4, 5))\n    assert_equal(5, candidate.call(1, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rb",
+    "prompt": "# Write a function which returns nth catalan number.\ndef catalan_number(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_catalan_number\n    candidate = method(:catalan_number)\n    assert_equal(16796, candidate.call(10))\n    assert_equal(4862, candidate.call(9))\n    assert_equal(429, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rb",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\ndef find_adverbs(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverbs\n    candidate = method(:find_adverbs)\n    assert_equal(\"0-7: Clearly\", candidate.call(\"Clearly, he has no excuse for such behavior.\"))\n    assert_equal(\"28-36: carefuly\", candidate.call(\"Please handle the situation carefuly\"))\n    assert_equal(\"18-25: quickly\", candidate.call(\"Complete the task quickly\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "rb",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\ndef expensive_items(items, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_expensive_items\n    candidate = method(:expensive_items)\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rb",
+    "prompt": "# Write a python function to split a list at the nth eelment and add the first part to the end.\ndef split_Arr(l, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_Arr\n    candidate = method(:split_Arr)\n    assert_equal([5, 6, 52, 36, 12, 10], candidate.call([12, 10, 5, 6, 52, 36], 2))\n    assert_equal([2, 3, 4, 1], candidate.call([1, 2, 3, 4], 1))\n    assert_equal([3, 4, 5, 6, 7, 0, 1, 2], candidate.call([0, 1, 2, 3, 4, 5, 6, 7], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to convert a list to a tuple.\ndef list_tuple(listx)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_tuple\n    candidate = method(:list_tuple)\n    assert_equal([5, 10, 7, 4, 15, 3], candidate.call([5, 10, 7, 4, 15, 3]))\n    assert_equal([2, 4, 5, 6, 2, 3, 4, 4, 7], candidate.call([2, 4, 5, 6, 2, 3, 4, 4, 7]))\n    assert_equal([58, 44, 56], candidate.call([58, 44, 56]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rb",
+    "prompt": "# Write a python function to find the difference between largest and smallest value in a given list.\ndef big_diff(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_diff\n    candidate = method(:big_diff)\n    assert_equal(3, candidate.call([1, 2, 3, 4]))\n    assert_equal(8, candidate.call([4, 5, 12]))\n    assert_equal(7, candidate.call([9, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rb",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\ndef perfect_squares(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perfect_squares\n    candidate = method(:perfect_squares)\n    assert_equal([1, 4, 9, 16, 25], candidate.call(1, 30))\n    assert_equal([64, 81, 100], candidate.call(50, 100))\n    assert_equal([100, 121, 144, 169, 196], candidate.call(100, 200))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given two integers have opposite sign or not.\ndef opposite_Signs(x, y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_opposite_Signs\n    candidate = method(:opposite_Signs)\n    assert_equal(true, candidate.call(1, -2))\n    assert_equal(false, candidate.call(3, 2))\n    assert_equal(false, candidate.call(-10, -10))\n    assert_equal(true, candidate.call(-2, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rb",
+    "prompt": "# Write a python function to interchange the first and last elements in a list.\ndef swap_List(newlist)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([24, 35, 9, 56, 12], candidate.call([12, 35, 9, 56, 24]))\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of the product of consecutive binomial co-efficients.\ndef sum_Of_product(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_product\n    candidate = method(:sum_Of_product)\n    assert_equal(15, candidate.call(3))\n    assert_equal(56, candidate.call(4))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rb",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\ndef removezero_ip(ip)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_removezero_ip\n    candidate = method(:removezero_ip)\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.196\"))\n    assert_equal(\"12.1.24\", candidate.call(\"12.01.024\"))\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.0196\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rb",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given list.\ndef diff_even_odd(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_diff_even_odd\n    candidate = method(:diff_even_odd)\n    assert_equal(3, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(9, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "rb",
+    "prompt": "# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\ndef min_Swaps(str1, str2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Swaps\n    candidate = method(:min_Swaps)\n    assert_equal(1, candidate.call(\"1101\", \"1110\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"000\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"110\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rb",
+    "prompt": "# Write a function to find kth element from the given two sorted arrays.\ndef find_kth(arr1, arr2, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_kth\n    candidate = method(:find_kth)\n    assert_equal(6, candidate.call([2, 3, 6, 7, 9], [1, 4, 8, 10], 5))\n    assert_equal(256, candidate.call([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7))\n    assert_equal(8, candidate.call([3, 4, 7, 8, 10], [2, 5, 9, 11], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\ndef armstrong_number(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_armstrong_number\n    candidate = method(:armstrong_number)\n    assert_equal(true, candidate.call(153))\n    assert_equal(false, candidate.call(259))\n    assert_equal(false, candidate.call(4458))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rb",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\ndef sum_average(number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_average\n    candidate = method(:sum_average)\n    assert_equal([55, 5.5], candidate.call(10))\n    assert_equal([120, 8.0], candidate.call(15))\n    assert_equal([210, 10.5], candidate.call(20))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth octagonal number.\ndef is_octagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_octagonal\n    candidate = method(:is_octagonal)\n    assert_equal(65, candidate.call(5))\n    assert_equal(280, candidate.call(10))\n    assert_equal(645, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given number is even or not.\ndef is_Even(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Even\n    candidate = method(:is_Even)\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(2))\n    assert_equal(false, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rb",
+    "prompt": "# Write a python function to find the first repeated character in a given string.\ndef first_repeated_char(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_repeated_char\n    candidate = method(:first_repeated_char)\n    assert_equal(\"a\", candidate.call(\"abcabc\"))\n    assert_equal(nil, candidate.call(\"abc\"))\n    assert_equal(\"1\", candidate.call(\"123123\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rb",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\ndef get_ludic(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_ludic\n    candidate = method(:get_ludic)\n    assert_equal([1, 2, 3, 5, 7], candidate.call(10))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25], candidate.call(25))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43], candidate.call(45))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rb",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\ndef reverse_words(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_words\n    candidate = method(:reverse_words)\n    assert_equal(\"program python\", candidate.call(\"python program\"))\n    assert_equal(\"language java\", candidate.call(\"java language\"))\n    assert_equal(\"man indian\", candidate.call(\"indian man\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given integer is a prime number.\ndef prime_num(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_num\n    candidate = method(:prime_num)\n    assert_equal(true, candidate.call(13))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(-1010))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rb",
+    "prompt": "# Write a function to convert degrees to radians.\ndef radian_degree(degree)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_radian_degree\n    candidate = method(:radian_degree)\n    assert_equal(1.5707963267948966, candidate.call(90))\n    assert_equal(1.0471975511965976, candidate.call(60))\n    assert_equal(2.0943951023931953, candidate.call(120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rb",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\ndef find_literals(text, pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_literals\n    candidate = method(:find_literals)\n    assert_equal([\"fox\", 16, 19], candidate.call(\"The quick brown fox jumps over the lazy dog.\", \"fox\"))\n    assert_equal([\"crazy\", 16, 21], candidate.call(\"Its been a very crazy procedure right\", \"crazy\"))\n    assert_equal([\"will\", 35, 39], candidate.call(\"Hardest choices required strongest will\", \"will\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rb",
+    "prompt": "# Write a python function to find nth bell number.\ndef bell_Number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_Number\n    candidate = method(:bell_Number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(15, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rb",
+    "prompt": "# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\ndef remove_kth_element(list1, l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_kth_element\n    candidate = method(:remove_kth_element)\n    assert_equal([1, 1, 3, 4, 4, 5, 1], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4))\n    assert_equal([10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rb",
+    "prompt": "# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\ndef max_of_nth(test_list, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_of_nth\n    candidate = method(:max_of_nth)\n    assert_equal(19, candidate.call([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2))\n    assert_equal(10, candidate.call([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1))\n    assert_equal(11, candidate.call([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "rb",
+    "prompt": "# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\ndef merge(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge\n    candidate = method(:merge)\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]], candidate.call([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]))\n    assert_equal([[1, 3, 5, 7], [2, 4, 6, 8]], candidate.call([[1, 2], [3, 4], [5, 6], [7, 8]]))\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]], candidate.call([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\ndef cummulative_sum(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cummulative_sum\n    candidate = method(:cummulative_sum)\n    assert_equal(30, candidate.call([[1, 3], [5, 6, 7], [2, 6]]))\n    assert_equal(37, candidate.call([[2, 4], [6, 7, 8], [3, 7]]))\n    assert_equal(44, candidate.call([[3, 5], [7, 8, 9], [4, 8]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rb",
+    "prompt": "# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\ndef average_tuple(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_average_tuple\n    candidate = method(:average_tuple)\n    assert_equal([30.5, 34.25, 27.0, 23.25], candidate.call([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]))\n    assert_equal([25.5, -18.0, 3.75], candidate.call([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]))\n    assert_equal([305.0, 342.5, 270.0, 232.5], candidate.call([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rb",
+    "prompt": "# Write a function which takes two tuples of the same length and performs the element wise modulo.\ndef tuple_modulo(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_modulo\n    candidate = method(:tuple_modulo)\n    assert_equal([0, 4, 5, 1], candidate.call([10, 4, 5, 6], [5, 6, 7, 5]))\n    assert_equal([5, 5, 6, 1], candidate.call([11, 5, 6, 7], [6, 7, 8, 6]))\n    assert_equal([5, 6, 7, 1], candidate.call([12, 6, 7, 8], [7, 8, 9, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rb",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\ndef min_Jumps(steps, d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Jumps\n    candidate = method(:min_Jumps)\n    assert_equal(3.5, candidate.call([3, 4], 11))\n    assert_equal(0, candidate.call([3, 4], 0))\n    assert_equal(1, candidate.call([11, 14], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rb",
+    "prompt": "# Write a function to divide two lists element wise.\ndef div_list(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_div_list\n    candidate = method(:div_list)\n    assert_equal([4.0, 2.5, 2.0], candidate.call([4, 5, 6], [1, 2, 3]))\n    assert_equal([3.0, 0.5], candidate.call([3, 2], [1, 4]))\n    assert_equal([1.8, 1.7142857142857142], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rb",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\ndef move_num(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_num\n    candidate = method(:move_num)\n    assert_equal(\"Iloveyouthreethousand1143553000\", candidate.call(\"I1love143you55three3000thousand\"))\n    assert_equal(\"AvengersAssemble124\", candidate.call(\"Avengers124Assemble\"))\n    assert_equal(\"Itsourpathtoseethingsdothings11121314151617\", candidate.call(\"Its11our12path13to14see15things16do17things\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of substrings with the sum of digits equal to their length.\ndef count_Substrings(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Substrings\n    candidate = method(:count_Substrings)\n    assert_equal(6, candidate.call(\"112112\"))\n    assert_equal(6, candidate.call(\"111\"))\n    assert_equal(12, candidate.call(\"1101112\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rb",
+    "prompt": "# Write a function to find the median of two sorted lists of same size.\ndef get_median(arr1, arr2, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_median\n    candidate = method(:get_median)\n    assert_equal(16.0, candidate.call([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5))\n    assert_equal(8.5, candidate.call([2, 4, 8, 9], [7, 13, 19, 28], 4))\n    assert_equal(25.0, candidate.call([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rb",
+    "prompt": "# Write a function to compute the n-th power of each number in a list.\ndef nth_nums(nums, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_nth_nums\n    candidate = method(:nth_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30], 3))\n    assert_equal([248832, 759375], candidate.call([12, 15], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rb",
+    "prompt": "# Write a python function to convert a given string to uppercase.\ndef is_upper(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_upper\n    candidate = method(:is_upper)\n    assert_equal(\"PERSON\", candidate.call(\"person\"))\n    assert_equal(\"FINAL\", candidate.call(\"final\"))\n    assert_equal(\"VALID\", candidate.call(\"Valid\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rb",
+    "prompt": "# Write a python function to interchange the first and last element in a given list.\ndef swap_List(newlist)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([4, 2, 3, 4, 1], candidate.call([1, 2, 3, 4, 4]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rb",
+    "prompt": "# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ndef triangle_area(r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(nil, candidate.call(-1))\n    assert_equal(0, candidate.call(0))\n    assert_equal(4, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rb",
+    "prompt": "# Write a python function to find the smallest missing number from a sorted list of natural numbers.\ndef find_First_Missing(array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_First_Missing\n    candidate = method(:find_First_Missing)\n    assert_equal(4, candidate.call([0, 1, 2, 3]))\n    assert_equal(3, candidate.call([0, 1, 2, 6, 9]))\n    assert_equal(0, candidate.call([2, 3, 5, 8, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\ndef replace_spaces(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"My%20Name%20is%20Dawood\", candidate.call(\"My Name is Dawood\"))\n    assert_equal(\"I%20am%20a%20Programmer\", candidate.call(\"I am a Programmer\"))\n    assert_equal(\"I%20love%20Coding\", candidate.call(\"I love Coding\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rb",
+    "prompt": "# Write a python function to find even numbers from a list of numbers.\ndef Split(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([2, 4], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([4, 6, 8, 0], candidate.call([4, 5, 6, 7, 8, 0, 1]))\n    assert_equal([8, 12], candidate.call([8, 12, 15, 19]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rb",
+    "prompt": "# Write a python function to find smallest number in a list.\ndef smallest_num(xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_num\n    candidate = method(:smallest_num)\n    assert_equal(1, candidate.call([10, 20, 1, 45, 99]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n    assert_equal(45, candidate.call([45, 46, 50, 60]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rb",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\ndef get_coordinates(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_coordinates\n    candidate = method(:get_coordinates)\n    assert_equal([[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]], candidate.call([3, 4]))\n    assert_equal([[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]], candidate.call([4, 5]))\n    assert_equal([[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]], candidate.call([5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\ndef replace_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"Jumanji_The_Jungle\", candidate.call(\"Jumanji The Jungle\"))\n    assert_equal(\"The Avengers\", candidate.call(\"The_Avengers\"))\n    assert_equal(\"Fast_and_Furious\", candidate.call(\"Fast and Furious\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rb",
+    "prompt": "# Write a python function to move all zeroes to the end of the given list.\ndef move_zero(num_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_zero\n    candidate = method(:move_zero)\n    assert_equal([1, 2, 3, 4, 0, 0], candidate.call([1, 0, 2, 0, 3, 4]))\n    assert_equal([2, 3, 2, 4, 5, 0, 0, 0, 0], candidate.call([2, 3, 2, 0, 0, 4, 0, 5, 0]))\n    assert_equal([1, 1, 1, 0, 0], candidate.call([0, 1, 0, 1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of xor of all pairs of numbers in the given list.\ndef pair_xor_Sum(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_xor_Sum\n    candidate = method(:pair_xor_Sum)\n    assert_equal(47, candidate.call([5, 9, 7, 6], 4))\n    assert_equal(12, candidate.call([7, 3, 5], 3))\n    assert_equal(4, candidate.call([7, 3], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort the given list.\ndef heap_sort(iterable)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_sort\n    candidate = method(:heap_sort)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]))\n    assert_equal([14, 22, 25, 25, 35, 58, 65, 75, 85], candidate.call([25, 35, 22, 85, 14, 65, 75, 25, 58]))\n    assert_equal([1, 5, 7, 9], candidate.call([7, 1, 9, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\ndef noprofit_noloss(actual_cost, sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_noprofit_noloss\n    candidate = method(:noprofit_noloss)\n    assert_equal(false, candidate.call(1500, 1200))\n    assert_equal(true, candidate.call(100, 100))\n    assert_equal(false, candidate.call(2000, 5000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\ndef wind_chill(v, t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_wind_chill\n    candidate = method(:wind_chill)\n    assert_equal(40, candidate.call(120, 35))\n    assert_equal(19, candidate.call(40, 20))\n    assert_equal(6, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rb",
+    "prompt": "# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\ndef sample_nam(sample_names)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sample_nam\n    candidate = method(:sample_nam)\n    assert_equal(16, candidate.call([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]))\n    assert_equal(10, candidate.call([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]))\n    assert_equal(6, candidate.call([\"abcd\", \"Python\", \"abba\", \"aba\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given tuple list.\ndef max_difference(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_difference\n    candidate = method(:max_difference)\n    assert_equal(7, candidate.call([[3, 5], [1, 7], [10, 3], [1, 2]]))\n    assert_equal(15, candidate.call([[4, 6], [2, 17], [9, 13], [11, 12]]))\n    assert_equal(23, candidate.call([[12, 35], [21, 27], [13, 23], [41, 22]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rb",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\ndef remove_parenthesis(items)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_parenthesis\n    candidate = method(:remove_parenthesis)\n    assert_equal(\"python\", candidate.call([\"python (chrome)\"]))\n    assert_equal(\"string\", candidate.call([\"string(.abc)\"]))\n    assert_equal(\"alpha\", candidate.call([\"alpha(num)\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth nonagonal number.\ndef is_nonagonal(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nonagonal\n    candidate = method(:is_nonagonal)\n    assert_equal(325, candidate.call(10))\n    assert_equal(750, candidate.call(15))\n    assert_equal(1089, candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rb",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ndef text_match_wordz_middle(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz_middle\n    candidate = method(:text_match_wordz_middle)\n    assert_equal(true, candidate.call(\"pythonzabc.\"))\n    assert_equal(false, candidate.call(\"zxyabc.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rb",
+    "prompt": "# Write a python function to reverse an array upto a given position.\ndef reverse_Array_Upto_K(input, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_Array_Upto_K\n    candidate = method(:reverse_Array_Upto_K)\n    assert_equal([4, 3, 2, 1, 5, 6], candidate.call([1, 2, 3, 4, 5, 6], 4))\n    assert_equal([5, 4, 6, 7], candidate.call([4, 5, 6, 7], 2))\n    assert_equal([7, 8, 9, 6, 5], candidate.call([9, 8, 7, 6, 5], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rb",
+    "prompt": "# Write a function to sort a list of tuples using the second value of each tuple.\ndef subject_marks(subjectmarks)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_subject_marks\n    candidate = method(:subject_marks)\n    assert_equal([[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]], candidate.call([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]))\n    assert_equal([[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]], candidate.call([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]))\n    assert_equal([[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]], candidate.call([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function to flatten a list and sum all of its elements.\ndef recursive_list_sum(data_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_recursive_list_sum\n    candidate = method(:recursive_list_sum)\n    assert_equal(21, candidate.call([1, 2, [3, 4], [5, 6]]))\n    assert_equal(106, candidate.call([7, 10, [15, 14], [19, 41]]))\n    assert_equal(210, candidate.call([10, 20, [30, 40], [50, 60]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of positive numbers in a list.\ndef pos_count(list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pos_count\n    candidate = method(:pos_count)\n    assert_equal(2, candidate.call([1, -2, 3, -4]))\n    assert_equal(3, candidate.call([3, 4, 5, -1]))\n    assert_equal(4, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rb",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\ndef bell_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_number\n    candidate = method(:bell_number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(115975, candidate.call(10))\n    assert_equal(6775685320645824322581483068371419745979053216268760300, candidate.call(56))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given array is monotonic or not.\ndef is_Monotonic(a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Monotonic\n    candidate = method(:is_Monotonic)\n    assert_equal(true, candidate.call([6, 5, 4, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3]))\n    assert_equal(false, candidate.call([1, 3, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rb",
+    "prompt": "# Write a function to check whether a list contains the given sublist or not.\ndef is_sublist(l, s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sublist\n    candidate = method(:is_sublist)\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [3, 7]))\n    assert_equal(true, candidate.call([2, 4, 3, 5, 7], [4, 3]))\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [1, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the two numbers differ at one bit position only or not.\ndef differ_At_One_Bit_Pos(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_differ_At_One_Bit_Pos\n    candidate = method(:differ_At_One_Bit_Pos)\n    assert_equal(true, candidate.call(13, 9))\n    assert_equal(false, candidate.call(15, 8))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(2, 3))\n    assert_equal(true, candidate.call(5, 1))\n    assert_equal(true, candidate.call(1, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rb",
+    "prompt": "# Write a function to find whether all the given lists have equal length or not.\ndef get_equal(input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_equal\n    candidate = method(:get_equal)\n    assert_equal(true, candidate.call([[11, 22, 33], [44, 55, 66]]))\n    assert_equal(false, candidate.call([[1, 2, 3], [4, 5, 6, 7]]))\n    assert_equal(true, candidate.call([[1, 2], [3, 4]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort a list of elements.\ndef comb_sort(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_comb_sort\n    candidate = method(:comb_sort)\n    assert_equal([5, 15, 25, 37, 79], candidate.call([5, 15, 37, 25, 79]))\n    assert_equal([15, 19, 22, 32, 41], candidate.call([41, 32, 15, 19, 22]))\n    assert_equal([13, 15, 47, 99], candidate.call([99, 15, 13, 47]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to add a dictionary to the tuple. The output should be a tuple.\ndef add_dict_to_tuple(test_tup, test_dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_dict_to_tuple\n    candidate = method(:add_dict_to_tuple)\n    assert_equal([4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}], candidate.call([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}))\n    assert_equal([1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}], candidate.call([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}))\n    assert_equal([8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}], candidate.call([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rb",
+    "prompt": "# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\ndef maxAverageOfPath(cost)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maxAverageOfPath\n    candidate = method(:maxAverageOfPath)\n    assert_equal(5.2, candidate.call([[1, 2, 3], [6, 5, 4], [7, 3, 9]]))\n    assert_equal(6.2, candidate.call([[2, 3, 4], [7, 6, 5], [8, 4, 10]]))\n    assert_equal(7.2, candidate.call([[3, 4, 5], [8, 7, 6], [9, 5, 11]]))\n    assert_equal(5.8, candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "rb",
+    "prompt": "# The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\ndef filter_data(students, h, w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_data\n    candidate = method(:filter_data)\n    assert_equal({\"Cierra Vega\" => [6.2, 70]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rb",
+    "prompt": "# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\ndef count_same_pair(nums1, nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_same_pair\n    candidate = method(:count_same_pair)\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]))\n    assert_equal(11, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(1, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(3, candidate.call([0, 1, 1, 2], [0, 1, 2, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rb",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\ndef power_base_sum(base, power)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power_base_sum\n    candidate = method(:power_base_sum)\n    assert_equal(115, candidate.call(2, 100))\n    assert_equal(37, candidate.call(8, 10))\n    assert_equal(62, candidate.call(8, 15))\n    assert_equal(9, candidate.call(3, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "rb",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\ndef extract_quotation(text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_quotation\n    candidate = method(:extract_quotation)\n    assert_equal([\"A53\", \"multi\", \"Processor\"], candidate.call(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"))\n    assert_equal([\"favorite\", \"apps\"], candidate.call(\"Cast your \"favorite\" entertainment \"apps\"\"))\n    assert_equal([\"4k Ultra HD\", \"HDR 10\"], candidate.call(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"))\n    assert_equal([], candidate.call(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "rb",
+    "prompt": "# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\ndef multiply_elements(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_elements\n    candidate = method(:multiply_elements)\n    assert_equal([5, 35, 56, 80], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 20, 30, 42], candidate.call([2, 4, 5, 6, 7]))\n    assert_equal([156, 182, 126, 135], candidate.call([12, 13, 14, 9, 15]))\n    assert_equal([], candidate.call([12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rb",
+    "prompt": "# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\ndef sum_list(lst1, lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_list\n    candidate = method(:sum_list)\n    assert_equal([25, 45, 65], candidate.call([10, 20, 30], [15, 25, 35]))\n    assert_equal([6, 8, 10], candidate.call([1, 2, 3], [5, 6, 7]))\n    assert_equal([30, 65, 105], candidate.call([15, 20, 30], [15, 45, 75]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the given number can be represented as the difference of two squares or not.\ndef dif_Square(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dif_Square\n    candidate = method(:dif_Square)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "rb",
+    "prompt": "# Write a function to remove consecutive duplicates of a given list.\ndef consecutive_duplicates(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_consecutive_duplicates\n    candidate = method(:consecutive_duplicates)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([10, 15, 19, 18, 17, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\", \"a\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rb",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\ndef lateralsurface_cone(r, h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cone\n    candidate = method(:lateralsurface_cone)\n    assert_equal(204.20352248333654, candidate.call(5, 12))\n    assert_equal(566.3586699569488, candidate.call(10, 15))\n    assert_equal(1521.8090132193388, candidate.call(19, 17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rb",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\ndef replace_specialchar(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_specialchar\n    candidate = method(:replace_specialchar)\n    assert_equal(\"Python:language::Programming:language:\", candidate.call(\"Python language, Programming language.\"))\n    assert_equal(\"a:b:c:d:e:f\", candidate.call(\"a b c,d e f\"))\n    assert_equal(\"ram:reshma:ram:rahim\", candidate.call(\"ram reshma,ram rahim\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rb",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\ndef find_first_occurrence(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_first_occurrence\n    candidate = method(:find_first_occurrence)\n    assert_equal(1, candidate.call([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(2, candidate.call([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(4, candidate.call([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rb",
+    "prompt": "# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\ndef sum_Of_Subarray_Prod(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_Subarray_Prod\n    candidate = method(:sum_Of_Subarray_Prod)\n    assert_equal(20, candidate.call([1, 2, 3]))\n    assert_equal(5, candidate.call([1, 2]))\n    assert_equal(84, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rb",
+    "prompt": "# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ndef toggle_middle_bits(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_middle_bits\n    candidate = method(:toggle_middle_bits)\n    assert_equal(15, candidate.call(9))\n    assert_equal(12, candidate.call(10))\n    assert_equal(13, candidate.call(11))\n    assert_equal(127, candidate.call(65))\n    assert_equal(115, candidate.call(77))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rb",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\ndef left_insertion(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_insertion\n    candidate = method(:left_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ndef check_str(string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_str\n    candidate = method(:check_str)\n    assert_equal(true, candidate.call(\"annie\"))\n    assert_equal(false, candidate.call(\"dawood\"))\n    assert_equal(true, candidate.call(\"Else\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\ndef geometric_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_geometric_sum\n    candidate = method(:geometric_sum)\n    assert_equal(1.9921875, candidate.call(7))\n    assert_equal(1.9375, candidate.call(4))\n    assert_equal(1.99609375, candidate.call(8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rb",
+    "prompt": "# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\ndef find_Index(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Index\n    candidate = method(:find_Index)\n    assert_equal(4, candidate.call(2))\n    assert_equal(14, candidate.call(3))\n    assert_equal(45, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\ndef tuple_to_dict(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_dict\n    candidate = method(:tuple_to_dict)\n    assert_equal({1 => 5, 7 => 10, 13 => 5}, candidate.call([1, 5, 7, 10, 13, 5]))\n    assert_equal({1 => 2, 3 => 4, 5 => 6}, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal({7 => 8, 9 => 10, 11 => 12}, candidate.call([7, 8, 9, 10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether all the characters are same or not.\ndef all_Characters_Same(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Characters_Same\n    candidate = method(:all_Characters_Same)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"aaa\"))\n    assert_equal(false, candidate.call(\"data\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rb",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\ndef area_tetrahedron(side)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_area_tetrahedron\n    candidate = method(:area_tetrahedron)\n    assert_equal(15.588457268119894, candidate.call(3))\n    assert_equal(692.8203230275509, candidate.call(20))\n    assert_equal(173.20508075688772, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rb",
+    "prompt": "# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\ndef rotate_right(list, m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rotate_right\n    candidate = method(:rotate_right)\n    assert_equal([8, 9, 10, 1, 2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3))\n    assert_equal([9, 10, 1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([6, 7, 8, 9, 10, 1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given tuple has any none value or not.\ndef check_none(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_none\n    candidate = method(:check_none)\n    assert_equal(true, candidate.call([10, 4, 5, 6, nil]))\n    assert_equal(false, candidate.call([7, 8, 9, 11, 14]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, nil]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rb",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\ndef divisible_by_digits(startnum, endnum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisible_by_digits\n    candidate = method(:divisible_by_digits)\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22], candidate.call(1, 22))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15], candidate.call(1, 15))\n    assert_equal([22, 24], candidate.call(20, 25))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rb",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\ndef sector_area(r, a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sector_area\n    candidate = method(:sector_area)\n    assert_equal(6.283185307179586, candidate.call(4, 45))\n    assert_equal(31.808625617596654, candidate.call(9, 45))\n    assert_equal(nil, candidate.call(9, 361))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rb",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\ndef lcs_of_three(x, y, z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lcs_of_three\n    candidate = method(:lcs_of_three)\n    assert_equal(2, candidate.call(\"AGGT12\", \"12TXAYB\", \"12XBA\"))\n    assert_equal(5, candidate.call(\"Reels\", \"Reelsfor\", \"ReelsforReels\"))\n    assert_equal(3, candidate.call(\"abcd1e2\", \"bc12ea\", \"bd1ea\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ndef capital_words_spaces(str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_capital_words_spaces\n    candidate = method(:capital_words_spaces)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"Python Programming Examples\", candidate.call(\"PythonProgrammingExamples\"))\n    assert_equal(\"Get Ready To Be Coding Freak\", candidate.call(\"GetReadyToBeCodingFreak\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rb",
+    "prompt": "# Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\ndef sort_numeric_strings(nums_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numeric_strings\n    candidate = method(:sort_numeric_strings)\n    assert_equal([-500, -12, 0, 4, 7, 12, 45, 100, 200], candidate.call([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]))\n    assert_equal([1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9], candidate.call([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]))\n    assert_equal([1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17], candidate.call([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rb",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\ndef is_samepatterns(colors, patterns)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_samepatterns\n    candidate = method(:is_samepatterns)\n    assert_equal(true, candidate.call([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to add the given tuple to the given list.\ndef add_tuple(test_list, test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_tuple\n    candidate = method(:add_tuple)\n    assert_equal([5, 6, 7, 9, 10], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([6, 7, 8, 10, 11], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([7, 8, 9, 11, 12], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ndef check_min_heap(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_min_heap\n    candidate = method(:check_min_heap)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 10, 15]))\n    assert_equal(false, candidate.call([2, 10, 4, 5, 3, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\ndef jacobsthal_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_jacobsthal_num\n    candidate = method(:jacobsthal_num)\n    assert_equal(11, candidate.call(5))\n    assert_equal(1, candidate.call(2))\n    assert_equal(5, candidate.call(4))\n    assert_equal(2731, candidate.call(13))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rb",
+    "prompt": "# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\ndef min_k(test_list, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_k\n    candidate = method(:min_k)\n    assert_equal([[\"Akash\", 2], [\"Akshat\", 4]], candidate.call([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2))\n    assert_equal([[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]], candidate.call([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3))\n    assert_equal([[\"Ayesha\", 9]], candidate.call([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "rb",
+    "prompt": "# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\ndef extract_index_list(l1, l2, l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_index_list\n    candidate = method(:extract_index_list)\n    assert_equal([1, 7], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([1, 6], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]))\n    assert_equal([1, 5], candidate.call([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([], candidate.call([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "rb",
+    "prompt": "# Write a function to find the second smallest number in a list.\ndef second_smallest(numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_second_smallest\n    candidate = method(:second_smallest)\n    assert_equal(-2, candidate.call([1, 2, -8, -2, 0, -2]))\n    assert_equal(-0.5, candidate.call([1, 1, -0.5, 0, 2, -2, -2]))\n    assert_equal(nil, candidate.call([2, 2]))\n    assert_equal(nil, candidate.call([2, 2, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\ndef text_match_zero_one(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_zero_one\n    candidate = method(:text_match_zero_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"dsabbbba\"))\n    assert_equal(false, candidate.call(\"asbbbba\"))\n    assert_equal(true, candidate.call(\"abaaa\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rb",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\ndef count_reverse_pairs(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_reverse_pairs\n    candidate = method(:count_reverse_pairs)\n    assert_equal(2, candidate.call([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]))\n    assert_equal(1, candidate.call([\"geeks\", \"best\", \"for\", \"skeeg\"]))\n    assert_equal(2, candidate.call([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rb",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\ndef is_decimal(num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_decimal\n    candidate = method(:is_decimal)\n    assert_equal(true, candidate.call(\"123.11\"))\n    assert_equal(false, candidate.call(\"e666.86\"))\n    assert_equal(false, candidate.call(\"3.124587\"))\n    assert_equal(true, candidate.call(\"1.11\"))\n    assert_equal(false, candidate.call(\"1.1.11\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\ndef find_tuples(test_list, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_tuples\n    candidate = method(:find_tuples)\n    assert_equal([[6, 24, 12]], candidate.call([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6))\n    assert_equal([[5, 25, 30]], candidate.call([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5))\n    assert_equal([[8, 16, 4]], candidate.call([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether a list of numbers contains only one distinct element or not.\ndef unique_Element(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_Element\n    candidate = method(:unique_Element)\n    assert_equal(true, candidate.call([1, 1, 1]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ndef check_monthnumber_number(monthnum3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumber_number\n    candidate = method(:check_monthnumber_number)\n    assert_equal(true, candidate.call(6))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rb",
+    "prompt": "# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\ndef find_min_diff(arr, n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_min_diff\n    candidate = method(:find_min_diff)\n    assert_equal(1, candidate.call([1, 5, 3, 19, 18, 25], 6))\n    assert_equal(1, candidate.call([4, 3, 2, 6], 4))\n    assert_equal(4, candidate.call([30, 5, 20, 9], 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rb",
+    "prompt": "# Write a python function to count number of digits in a given string.\ndef number_ctr(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_ctr\n    candidate = method(:number_ctr)\n    assert_equal(1, candidate.call(\"program2bedone\"))\n    assert_equal(1, candidate.call(\"3wonders\"))\n    assert_equal(3, candidate.call(\"123\"))\n    assert_equal(3, candidate.call(\"3wond-1ers2\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rb",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\ndef is_polite(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_polite\n    candidate = method(:is_polite)\n    assert_equal(11, candidate.call(7))\n    assert_equal(7, candidate.call(4))\n    assert_equal(13, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rb",
+    "prompt": "# Write a function to return a list of all pairs of consecutive items in a given list.\ndef pair_wise(l1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_wise\n    candidate = method(:pair_wise)\n    assert_equal([[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]], candidate.call([1, 1, 2, 3, 3, 4, 4, 5]))\n    assert_equal([[1, 5], [5, 7], [7, 9], [9, 10]], candidate.call([1, 5, 7, 9, 10]))\n    assert_equal([[5, 1], [1, 9], [9, 7], [7, 10]], candidate.call([5, 1, 9, 7, 10]))\n    assert_equal([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\ndef get_pairs_count(arr, sum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_pairs_count\n    candidate = method(:get_pairs_count)\n    assert_equal(6, candidate.call([1, 1, 1, 1], 2))\n    assert_equal(3, candidate.call([1, 5, 7, -1, 5], 6))\n    assert_equal(1, candidate.call([1, -2, 3], 1))\n    assert_equal(1, candidate.call([-1, -2, 3], -3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rb",
+    "prompt": "# Write a python function to get the difference between two lists.\ndef Diff(li1, li2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Diff\n    candidate = method(:Diff)\n    assert_equal([10, 20, 30, 15], candidate.call([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]))\n    assert_equal([2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5], [6, 7, 1]))\n    assert_equal([2, 3, 6, 7], candidate.call([1, 2, 3], [6, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of fourth power of first n odd natural numbers.\ndef odd_num_sum(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_num_sum\n    candidate = method(:odd_num_sum)\n    assert_equal(82, candidate.call(2))\n    assert_equal(707, candidate.call(3))\n    assert_equal(3108, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ndef check_expression(exp)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_expression\n    candidate = method(:check_expression)\n    assert_equal(true, candidate.call(\"{()}[{}]\"))\n    assert_equal(false, candidate.call(\"{()}[{]\"))\n    assert_equal(true, candidate.call(\"{()}[{}][]({})\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rb",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\ndef remove_length(test_str, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_length\n    candidate = method(:remove_length)\n    assert_equal(\"person is most value\", candidate.call(\"The person is most value tet\", 3))\n    assert_equal(\"If you me about ok\", candidate.call(\"If you told me about this ok\", 4))\n    assert_equal(\"Forces of darkeness is the\", candidate.call(\"Forces of darkeness is come into the play\", 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rb",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\ndef occurance_substring(text, pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_occurance_substring\n    candidate = method(:occurance_substring)\n    assert_equal([\"python\", 0, 6], candidate.call(\"python programming, python language\", \"python\"))\n    assert_equal([\"programming\", 7, 18], candidate.call(\"python programming,programming language\", \"programming\"))\n    assert_equal([\"language\", 31, 39], candidate.call(\"python programming,programming language\", \"language\"))\n    assert_equal(nil, candidate.call(\"c++ programming, c++ language\", \"python\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether every odd index contains odd numbers of a given list.\ndef odd_position(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_position\n    candidate = method(:odd_position)\n    assert_equal(true, candidate.call([2, 1, 4, 3, 6, 7, 6, 3]))\n    assert_equal(true, candidate.call([4, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rb",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ndef count_vowels(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_vowels\n    candidate = method(:count_vowels)\n    assert_equal(7, candidate.call(\"bestinstareels\"))\n    assert_equal(12, candidate.call(\"partofthejourneyistheend\"))\n    assert_equal(5, candidate.call(\"amazonprime\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of non-repeated elements in a given list.\ndef find_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_sum\n    candidate = method(:find_sum)\n    assert_equal(21, candidate.call([1, 2, 3, 1, 1, 4, 5, 6]))\n    assert_equal(71, candidate.call([1, 10, 9, 4, 2, 10, 10, 45, 4]))\n    assert_equal(78, candidate.call([12, 10, 9, 45, 2, 10, 10, 45, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "rb",
+    "prompt": "# Write a function to pack consecutive duplicates of a given list elements into sublists.\ndef pack_consecutive_duplicates(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pack_consecutive_duplicates\n    candidate = method(:pack_consecutive_duplicates)\n    assert_equal([[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rb",
+    "prompt": "# Write a python function to find whether a number is divisible by 11.\ndef is_Diff(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Diff\n    candidate = method(:is_Diff)\n    assert_equal(false, candidate.call(12345))\n    assert_equal(true, candidate.call(1212112))\n    assert_equal(false, candidate.call(1212))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rb",
+    "prompt": "# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\ndef find_combinations(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_combinations\n    candidate = method(:find_combinations)\n    assert_equal([[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]], candidate.call([[2, 4], [6, 7], [5, 1], [6, 10]]))\n    assert_equal([[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]], candidate.call([[3, 5], [7, 8], [6, 2], [7, 11]]))\n    assert_equal([[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]], candidate.call([[4, 6], [8, 9], [7, 3], [8, 12]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\ndef count_divisors(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_divisors\n    candidate = method(:count_divisors)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(100))\n    assert_equal(true, candidate.call(125))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\ndef odd_length_sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_length_sum\n    candidate = method(:odd_length_sum)\n    assert_equal(14, candidate.call([1, 2, 4]))\n    assert_equal(15, candidate.call([1, 2, 1, 2]))\n    assert_equal(8, candidate.call([1, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rb",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\ndef rgb_to_hsv(r, g, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rgb_to_hsv\n    candidate = method(:rgb_to_hsv)\n    assert_equal([0.0, 0.0, 100.0], candidate.call(255, 255, 255))\n    assert_equal([120.0, 100.0, 84.31372549019608], candidate.call(0, 215, 0))\n    assert_equal([149.26829268292684, 95.34883720930233, 84.31372549019608], candidate.call(10, 215, 110))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rb",
+    "prompt": "# Write a function to find the product of first even and odd number of a given list.\ndef mul_even_odd(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mul_even_odd\n    candidate = method(:mul_even_odd)\n    assert_equal(4, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(10, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rb",
+    "prompt": "# Write a function to convert tuple string to integer tuple.\ndef tuple_str_int(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_str_int\n    candidate = method(:tuple_str_int)\n    assert_equal([7, 8, 9], candidate.call(\"(7, 8, 9)\"))\n    assert_equal([1, 2, 3], candidate.call(\"(1, 2, 3)\"))\n    assert_equal([4, 5, 6], candidate.call(\"(4, 5, 6)\"))\n    assert_equal([7, 81, 19], candidate.call(\"(7, 81, 19)\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rb",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\ndef right_insertion(a, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_insertion\n    candidate = method(:right_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ndef text_match_three(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_three\n    candidate = method(:text_match_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"caacabbbba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to create a new tuple from the given string and list.\ndef new_tuple(test_list, test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_new_tuple\n    candidate = method(:new_tuple)\n    assert_equal([\"WEB\", \"is\", \"best\"], candidate.call([\"WEB\", \"is\"], \"best\"))\n    assert_equal([\"We\", \"are\", \"Developers\"], candidate.call([\"We\", \"are\"], \"Developers\"))\n    assert_equal([\"Part\", \"is\", \"Wrong\"], candidate.call([\"Part\", \"is\"], \"Wrong\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether every even index contains even numbers of a given list.\ndef even_position(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_position\n    candidate = method(:even_position)\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([2, 1, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "rb",
+    "prompt": "# Write a function to remove tuples from the given tuple.\ndef remove_nested(test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_nested\n    candidate = method(:remove_nested)\n    assert_equal([1, 5, 7, 10], candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal([2, 6, 8, 11], candidate.call([2, 6, 8, [5, 7], 11]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], 12]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], [5, 12], 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of lists in a given number of lists.\ndef count_list(input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_list\n    candidate = method(:count_list)\n    assert_equal(4, candidate.call([[1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal(3, candidate.call([[1, 2], [2, 3], [4, 5]]))\n    assert_equal(2, candidate.call([[1, 0], [2, 0]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rb",
+    "prompt": "# Write a python function to find the last position of an element in a sorted array.\ndef last(arr, x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last\n    candidate = method(:last)\n    assert_equal(0, candidate.call([1, 2, 3], 1))\n    assert_equal(2, candidate.call([1, 1, 1, 2, 3, 4], 1))\n    assert_equal(3, candidate.call([2, 3, 2, 3, 6, 8, 9], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ndef text_starta_endb(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_starta_endb\n    candidate = method(:text_starta_endb)\n    assert_equal(true, candidate.call(\"aabbbb\"))\n    assert_equal(false, candidate.call(\"aabAbbbc\"))\n    assert_equal(false, candidate.call(\"accddbbjjj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rb",
+    "prompt": "# Write function to find the sum of all items in the given dictionary.\ndef return_sum(dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_return_sum\n    candidate = method(:return_sum)\n    assert_equal(600, candidate.call({\"a\" => 100, \"b\" => 200, \"c\" => 300}))\n    assert_equal(88, candidate.call({\"a\" => 25, \"b\" => 18, \"c\" => 45}))\n    assert_equal(124, candidate.call({\"a\" => 36, \"b\" => 39, \"c\" => 49}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of all odd natural numbers within the range l and r.\ndef sum_in_range(l, r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_in_range\n    candidate = method(:sum_in_range)\n    assert_equal(8, candidate.call(2, 5))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(40, candidate.call(7, 13))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rb",
+    "prompt": "# Write a python function to find the sum of an array.\ndef _sum(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test__sum\n    candidate = method(:_sum)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(50, candidate.call([15, 12, 13, 10]))\n    assert_equal(3, candidate.call([0, 1, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rb",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\ndef left_rotate(n, d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_rotate\n    candidate = method(:left_rotate)\n    assert_equal(64, candidate.call(16, 2))\n    assert_equal(40, candidate.call(10, 2))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(8, candidate.call(1, 3))\n    assert_equal(40, candidate.call(5, 3))\n    assert_equal(232, candidate.call(29, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rb",
+    "prompt": "# Write a python function to check whether the length of the word is odd or not.\ndef word_len(s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_word_len\n    candidate = method(:word_len)\n    assert_equal(false, candidate.call(\"Hadoop\"))\n    assert_equal(true, candidate.call(\"great\"))\n    assert_equal(true, candidate.call(\"structure\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to remove all whitespaces from a string.\ndef remove_all_spaces(text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_all_spaces\n    candidate = method(:remove_all_spaces)\n    assert_equal(\"pythonprogram\", candidate.call(\"python  program\"))\n    assert_equal(\"pythonprogramminglanguage\", candidate.call(\"python   programming    language\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"python                     program\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"   python                     program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of equal numbers from three given integers.\ndef test_three_equal(x, y, z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_three_equal\n    candidate = method(:test_three_equal)\n    assert_equal(3, candidate.call(1, 1, 1))\n    assert_equal(0, candidate.call(-1, -2, -3))\n    assert_equal(2, candidate.call(1, 2, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rb",
+    "prompt": "# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ndef count_rotation(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_rotation\n    candidate = method(:count_rotation)\n    assert_equal(1, candidate.call([3, 2, 1]))\n    assert_equal(2, candidate.call([4, 5, 1, 2, 3]))\n    assert_equal(3, candidate.call([7, 8, 9, 1, 2, 3]))\n    assert_equal(0, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 3, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\ndef is_perfect_square(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_perfect_square\n    candidate = method(:is_perfect_square)\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(36))\n    assert_equal(false, candidate.call(14))\n    assert_equal(true, candidate.call(196))\n    assert_equal(false, candidate.call(125))\n    assert_equal(true, candidate.call(15625))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the product of numbers in a list is even or not.\ndef is_product_even(arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_product_even\n    candidate = method(:is_product_even)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([1, 2, 1, 4]))\n    assert_equal(false, candidate.call([1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rb",
+    "prompt": "# Write a function that returns the list in a list of lists whose sum of elements is the highest.\ndef max_sum_list(lists)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_list\n    candidate = method(:max_sum_list)\n    assert_equal([10, 11, 12], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n    assert_equal([12, 11, 10], candidate.call([[3, 2, 1], [6, 5, 4], [12, 11, 10]]))\n    assert_equal([2, 3, 1], candidate.call([[2, 3, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rb",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\ndef max_run_uppercase(test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_run_uppercase\n    candidate = method(:max_run_uppercase)\n    assert_equal(5, candidate.call(\"GeMKSForGERksISBESt\"))\n    assert_equal(6, candidate.call(\"PrECIOusMOVemENTSYT\"))\n    assert_equal(4, candidate.call(\"GooGLEFluTTER\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rb",
+    "prompt": "# Write a python function to find the first odd number in a given list of numbers.\ndef first_odd(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_odd\n    candidate = method(:first_odd)\n    assert_equal(1, candidate.call([1, 3, 5]))\n    assert_equal(1, candidate.call([2, 4, 1, 3]))\n    assert_equal(9, candidate.call([8, 9, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given tuples contain the k or not.\ndef check_K(test_tup, k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_K\n    candidate = method(:check_K)\n    assert_equal(true, candidate.call([10, 4, 5, 6, 8], 6))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5, 6], 7))\n    assert_equal(true, candidate.call([7, 8, 9, 44, 11, 12], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rb",
+    "prompt": "# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\ndef check_smaller(test_tup1, test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_smaller\n    candidate = method(:check_smaller)\n    assert_equal(false, candidate.call([1, 2, 3], [2, 3, 4]))\n    assert_equal(true, candidate.call([4, 5, 6], [3, 4, 5]))\n    assert_equal(true, candidate.call([11, 12, 13], [10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth tetrahedral number.\ndef tetrahedral_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tetrahedral_number\n    candidate = method(:tetrahedral_number)\n    assert_equal(35, candidate.call(5))\n    assert_equal(56, candidate.call(6))\n    assert_equal(84, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rb",
+    "prompt": "# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\ndef get_Char(strr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Char\n    candidate = method(:get_Char)\n    assert_equal(\"f\", candidate.call(\"abc\"))\n    assert_equal(\"t\", candidate.call(\"gfg\"))\n    assert_equal(\"c\", candidate.call(\"ab\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\ndef sequence(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequence\n    candidate = method(:sequence)\n    assert_equal(6, candidate.call(10))\n    assert_equal(1, candidate.call(2))\n    assert_equal(2, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rb",
+    "prompt": "# Write a function to find nth centered hexagonal number.\ndef centered_hexagonal_number(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_centered_hexagonal_number\n    candidate = method(:centered_hexagonal_number)\n    assert_equal(271, candidate.call(10))\n    assert_equal(7, candidate.call(2))\n    assert_equal(217, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rb",
+    "prompt": "# Write a function to merge three dictionaries into a single dictionary.\ndef merge_dictionaries_three(dict1, dict2, dict3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_dictionaries_three\n    candidate = method(:merge_dictionaries_three)\n    assert_equal({\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}))\n    assert_equal({\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}))\n    assert_equal({\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rb",
+    "prompt": "# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\ndef freq_count(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_freq_count\n    candidate = method(:freq_count)\n    assert_equal({10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1}, candidate.call([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]))\n    assert_equal({1 => 3, 2 => 2, 3 => 3, 4 => 3}, candidate.call([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]))\n    assert_equal({10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2}, candidate.call([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the closest smaller number than n.\ndef closest_num(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_num\n    candidate = method(:closest_num)\n    assert_equal(10, candidate.call(11))\n    assert_equal(6, candidate.call(7))\n    assert_equal(11, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rb",
+    "prompt": "# Write a function to find squares of individual elements in a list.\ndef square_nums(nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_nums\n    candidate = method(:square_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([100, 400, 900], candidate.call([10, 20, 30]))\n    assert_equal([144, 225], candidate.call([12, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rb",
+    "prompt": "# Write a python function to find the length of the longest word.\ndef len_log(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_len_log\n    candidate = method(:len_log)\n    assert_equal(7, candidate.call([\"python\", \"PHP\", \"bigdata\"]))\n    assert_equal(3, candidate.call([\"a\", \"ab\", \"abc\"]))\n    assert_equal(5, candidate.call([\"small\", \"big\", \"tall\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rb",
+    "prompt": "# Write a function to check if a string is present as a substring in a given list of string values.\ndef find_substring(str1, sub_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_substring\n    candidate = method(:find_substring)\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"))\n    assert_equal(false, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"))\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\ndef is_undulating(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_undulating\n    candidate = method(:is_undulating)\n    assert_equal(true, candidate.call(1212121))\n    assert_equal(false, candidate.call(1991))\n    assert_equal(true, candidate.call(121))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\ndef power(a, b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power\n    candidate = method(:power)\n    assert_equal(81, candidate.call(3, 4))\n    assert_equal(8, candidate.call(2, 3))\n    assert_equal(3125, candidate.call(5, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rb",
+    "prompt": "# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\ndef index_minimum(test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_minimum\n    candidate = method(:index_minimum)\n    assert_equal(\"Varsha\", candidate.call([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]))\n    assert_equal(\"Dawood\", candidate.call([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]))\n    assert_equal(\"Ayesha\", candidate.call([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rb",
+    "prompt": "# Write a python function to find the length of the smallest list in a list of lists.\ndef Find_Min_Length(lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min_Length\n    candidate = method(:Find_Min_Length)\n    assert_equal(1, candidate.call([[1], [1, 2]]))\n    assert_equal(2, candidate.call([[1, 2], [1, 2, 3], [1, 2, 3, 4]]))\n    assert_equal(3, candidate.call([[3, 3, 3], [4, 4, 4, 4]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rb",
+    "prompt": "# Write a python function to find the number of divisors of a given integer.\ndef divisor(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisor\n    candidate = method(:divisor)\n    assert_equal(4, candidate.call(15))\n    assert_equal(6, candidate.call(12))\n    assert_equal(3, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rb",
+    "prompt": "# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\ndef frequency_lists(list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency_lists\n    candidate = method(:frequency_lists)\n    assert_equal({1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1}, candidate.call([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]))\n    assert_equal({1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1}, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]))\n    assert_equal({20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1}, candidate.call([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndef decimal_to_binary(n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"1000\", candidate.call(8))\n    assert_equal(\"10010\", candidate.call(18))\n    assert_equal(\"111\", candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rb",
+    "prompt": "# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\ndef find_Rotations(str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Rotations\n    candidate = method(:find_Rotations)\n    assert_equal(1, candidate.call(\"aaaa\"))\n    assert_equal(2, candidate.call(\"ab\"))\n    assert_equal(3, candidate.call(\"abc\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/mbpp-rb-reworded.json
+++ b/prompts/mbpp-rb-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rb",
-    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\ndef lps(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lps\n    candidate = method(:lps)\n    assert_equal(5, candidate.call(\"TENS FOR TENS\"))\n    assert_equal(7, candidate.call(\"CARDIO FOR CARDS\"))\n    assert_equal(9, candidate.call(\"PART OF THE JOURNEY IS PART\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rb",
-    "prompt": "# Write a function to remove all whitespaces from the given string.\ndef remove_whitespaces(text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_whitespaces\n    candidate = method(:remove_whitespaces)\n    assert_equal(\"GoogleFlutter\", candidate.call(\" Google    Flutter \"))\n    assert_equal(\"GoogleDart\", candidate.call(\" Google    Dart \"))\n    assert_equal(\"iOSSwift\", candidate.call(\" iOS    Swift \"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rb",
-    "prompt": "# Write a function to check whether a specified array is sorted or not.\ndef issort_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_issort_list\n    candidate = method(:issort_list)\n    assert_equal(true, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 15, 14, 20]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rb",
-    "prompt": "# Write a function to count bidirectional array pairs.\ndef count_bidirectional(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_bidirectional\n    candidate = method(:count_bidirectional)\n    assert_equal(3, candidate.call([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(2, candidate.call([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(4, candidate.call([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rb",
-    "prompt": "# Write a function to find the surface area of a cube of a given size.\ndef surfacearea_cube(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cube\n    candidate = method(:surfacearea_cube)\n    assert_equal(150, candidate.call(5))\n    assert_equal(54, candidate.call(3))\n    assert_equal(600, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rb",
     "prompt": "# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\ndef next_smallest_palindrome(num)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_smallest_palindrome\n    candidate = method(:next_smallest_palindrome)\n    assert_equal(101, candidate.call(99))\n    assert_equal(1331, candidate.call(1221))\n    assert_equal(121, candidate.call(120))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the cube sum of first n even natural numbers.\ndef cube_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_Sum\n    candidate = method(:cube_Sum)\n    assert_equal(72, candidate.call(2))\n    assert_equal(288, candidate.call(3))\n    assert_equal(800, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of xor of all pairs of numbers in the given array.\ndef pair_xor_Sum(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_xor_Sum\n    candidate = method(:pair_xor_Sum)\n    assert_equal(47, candidate.call([5, 9, 7, 6], 4))\n    assert_equal(12, candidate.call([7, 3, 5], 3))\n    assert_equal(4, candidate.call([7, 3], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ndef check_min_heap(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_min_heap\n    candidate = method(:check_min_heap)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 10, 15]))\n    assert_equal(false, candidate.call([2, 10, 4, 5, 3, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the first digit of a given number.\ndef first_Digit(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_Digit\n    candidate = method(:first_Digit)\n    assert_equal(1, candidate.call(123))\n    assert_equal(4, candidate.call(456))\n    assert_equal(1, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the first non-repeated character in a given string.\ndef first_non_repeating_character(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_non_repeating_character\n    candidate = method(:first_non_repeating_character)\n    assert_equal(nil, candidate.call(\"abcabc\"))\n    assert_equal(\"a\", candidate.call(\"abc\"))\n    assert_equal(\"c\", candidate.call(\"ababc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rb",
-    "prompt": "# Write a function to convert degrees to radians.\ndef radian_degree(degree)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_radian_degree\n    candidate = method(:radian_degree)\n    assert_equal(1.5707963267948966, candidate.call(90))\n    assert_equal(1.0471975511965976, candidate.call(60))\n    assert_equal(2.0943951023931953, candidate.call(120))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum product subarray of the given array.\ndef max_subarray_product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_subarray_product\n    candidate = method(:max_subarray_product)\n    assert_equal(112, candidate.call([1, -2, -3, 0, 7, -8, -2]))\n    assert_equal(180, candidate.call([6, -3, -10, 0, 2]))\n    assert_equal(80, candidate.call([-2, -40, 0, -2, -3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "rb",
-    "prompt": "# Write a function to convert more than one array to nested hash.\ndef convert_list_dictionary(l1, l2, l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert_list_dictionary\n    candidate = method(:convert_list_dictionary)\n    assert_equal([{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}], candidate.call([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]))\n    assert_equal([{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}], candidate.call([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]))\n    assert_equal([{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}], candidate.call([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find smallest number in an array.\ndef smallest_num(xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_num\n    candidate = method(:smallest_num)\n    assert_equal(1, candidate.call([10, 20, 1, 45, 99]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n    assert_equal(45, candidate.call([45, 46, 50, 60]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rbthon-exercises/re/rbthon-re-exercise-3.php\ndef text_match_zero_one(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_zero_one\n    candidate = method(:text_match_zero_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"dsabbbba\"))\n    assert_equal(false, candidate.call(\"asbbbba\"))\n    assert_equal(true, candidate.call(\"abaaa\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find nth bell number.\ndef bell_Number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_Number\n    candidate = method(:bell_Number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(15, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rb",
-    "prompt": "# Write a function to find cubes of individual elements in an array.\ndef cube_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_nums\n    candidate = method(:cube_nums)\n    assert_equal([1, 8, 27, 64, 125, 216, 343, 512, 729, 1000], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30]))\n    assert_equal([1728, 3375], candidate.call([12, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the last digit in factorial of a given number.\ndef last_Digit_Factorial(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit_Factorial\n    candidate = method(:last_Digit_Factorial)\n    assert_equal(4, candidate.call(4))\n    assert_equal(0, candidate.call(21))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find even numbers from an array of numbers.\ndef Split(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([2, 4], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([4, 6, 8, 0], candidate.call([4, 5, 6, 7, 8, 0, 1]))\n    assert_equal([8, 12], candidate.call([8, 12, 15, 19]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given integer is a prime number.\ndef prime_num(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_num\n    candidate = method(:prime_num)\n    assert_equal(true, candidate.call(13))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(-1010))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to find arrays which have all elements divisible by k from the given array of arrays.\ndef find_tuples(test_list, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_tuples\n    candidate = method(:find_tuples)\n    assert_equal([[6, 24, 12]], candidate.call([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6))\n    assert_equal([[5, 25, 30]], candidate.call([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5))\n    assert_equal([[8, 16, 4]], candidate.call([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rb",
-    "prompt": "# Write a function to caluclate the area of a tetrahedron.\ndef area_tetrahedron(side)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_area_tetrahedron\n    candidate = method(:area_tetrahedron)\n    assert_equal(15.588457268119894, candidate.call(3))\n    assert_equal(692.8203230275509, candidate.call(20))\n    assert_equal(173.20508075688772, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given number is even or not.\ndef is_Even(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Even\n    candidate = method(:is_Even)\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(2))\n    assert_equal(false, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of positive numbers in an array.\ndef pos_count(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pos_count\n    candidate = method(:pos_count)\n    assert_equal(2, candidate.call([1, -2, 3, -4]))\n    assert_equal(3, candidate.call([3, 4, 5, -1]))\n    assert_equal(4, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rb",
-    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\ndef get_ludic(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_ludic\n    candidate = method(:get_ludic)\n    assert_equal([1, 2, 3, 5, 7], candidate.call(10))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25], candidate.call(25))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43], candidate.call(45))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\ndef find_Index(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Index\n    candidate = method(:find_Index)\n    assert_equal(4, candidate.call(2))\n    assert_equal(14, candidate.call(3))\n    assert_equal(45, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to reverse an array upto a given position.\ndef reverse_Array_Upto_K(input, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_Array_Upto_K\n    candidate = method(:reverse_Array_Upto_K)\n    assert_equal([4, 3, 2, 1, 5, 6], candidate.call([1, 2, 3, 4, 5, 6], 4))\n    assert_equal([5, 4, 6, 7], candidate.call([4, 5, 6, 7], 2))\n    assert_equal([7, 8, 9, 6, 5], candidate.call([9, 8, 7, 6, 5], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rb",
-    "prompt": "# Write a function to sort an array of arrays using the second value of each array.\ndef subject_marks(subjectmarks)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_subject_marks\n    candidate = method(:subject_marks)\n    assert_equal([[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]], candidate.call([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]))\n    assert_equal([[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]], candidate.call([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]))\n    assert_equal([[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]], candidate.call([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rb",
-    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\ndef remove_dirty_chars(string, second_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_dirty_chars\n    candidate = method(:remove_dirty_chars)\n    assert_equal(\"bacuve\", candidate.call(\"probasscurve\", \"pros\"))\n    assert_equal(\"digiidi\", candidate.call(\"digitalindia\", \"talent\"))\n    assert_equal(\"emles\", candidate.call(\"exoticmiles\", \"toxic\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "rb",
-    "prompt": "# Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\ndef round_and_sum(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_round_and_sum\n    candidate = method(:round_and_sum)\n    assert_equal(243, candidate.call([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]))\n    assert_equal(345, candidate.call([5, 2, 9, 24.3, 29]))\n    assert_equal(513, candidate.call([25.0, 56.7, 89.2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rb",
-    "prompt": "# Write a function to find the item with maximum frequency in a given array.\ndef max_occurrences(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_occurrences\n    candidate = method(:max_occurrences)\n    assert_equal(2, candidate.call([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]))\n    assert_equal(8, candidate.call([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]))\n    assert_equal(20, candidate.call([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rb",
-    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\ndef is_decimal(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_decimal\n    candidate = method(:is_decimal)\n    assert_equal(true, candidate.call(\"123.11\"))\n    assert_equal(false, candidate.call(\"e666.86\"))\n    assert_equal(false, candidate.call(\"3.124587\"))\n    assert_equal(true, candidate.call(\"1.11\"))\n    assert_equal(false, candidate.call(\"1.1.11\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\ndef dict_filter(dict, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dict_filter\n    candidate = method(:dict_filter)\n    assert_equal({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170))\n    assert_equal({\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180))\n    assert_equal({\"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of even numbers at even positions of an array.\ndef sum_even_and_even_index(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_even_and_even_index\n    candidate = method(:sum_even_and_even_index)\n    assert_equal(30, candidate.call([5, 6, 12, 1, 18, 8]))\n    assert_equal(26, candidate.call([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]))\n    assert_equal(12, candidate.call([5, 6, 12, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the sum of the largest contiguous subarray in the given array.\ndef max_sub_array_sum(a, size)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum\n    candidate = method(:max_sub_array_sum)\n    assert_equal(7, candidate.call([-2, -3, 4, -1, -2, 1, 5, -3], 8))\n    assert_equal(8, candidate.call([-3, -4, 5, -2, -3, 2, 6, -4], 8))\n    assert_equal(10, candidate.call([-4, -5, 6, -3, -4, 3, 7, -5], 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rb",
-    "prompt": "# Write a function to find the intersection of two arrays.\ndef intersection_array(array_nums1, array_nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection_array\n    candidate = method(:intersection_array)\n    assert_equal([1, 2, 8, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]))\n    assert_equal([3, 5, 7, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]))\n    assert_equal([10], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\ndef split_two_parts(list1, l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_two_parts\n    candidate = method(:split_two_parts)\n    assert_equal([[1, 1, 2], [3, 4, 4, 5, 1]], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"]], candidate.call([\"a\", \"b\", \"c\", \"d\"], 2))\n    assert_equal([[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]], candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rb",
-    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\ndef find_literals(text, pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_literals\n    candidate = method(:find_literals)\n    assert_equal([\"fox\", 16, 19], candidate.call(\"The quick brown fox jumps over the lazy dog.\", \"fox\"))\n    assert_equal([\"crazy\", 16, 21], candidate.call(\"Its been a very crazy procedure right\", \"crazy\"))\n    assert_equal([\"will\", 35, 39], candidate.call(\"Hardest choices required strongest will\", \"will\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the volume of a triangular prism.\ndef find_Volume(l, b, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Volume\n    candidate = method(:find_Volume)\n    assert_equal(240, candidate.call(10, 8, 6))\n    assert_equal(6, candidate.call(3, 2, 2))\n    assert_equal(1, candidate.call(1, 2, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\ndef wind_chill(v, t)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_wind_chill\n    candidate = method(:wind_chill)\n    assert_equal(40, candidate.call(120, 35))\n    assert_equal(19, candidate.call(40, 20))\n    assert_equal(6, candidate.call(10, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rb",
-    "prompt": "# Write a function to find the ascii value of a character.\ndef ascii_value(k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_ascii_value\n    candidate = method(:ascii_value)\n    assert_equal(65, candidate.call(\"A\"))\n    assert_equal(82, candidate.call(\"R\"))\n    assert_equal(83, candidate.call(\"S\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether all the characters are same or not.\ndef all_Characters_Same(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Characters_Same\n    candidate = method(:all_Characters_Same)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"aaa\"))\n    assert_equal(false, candidate.call(\"data\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rb",
-    "prompt": "# Write a function to move all the numbers to the end of the given string.\ndef move_num(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_num\n    candidate = method(:move_num)\n    assert_equal(\"Iloveyouthreethousand1143553000\", candidate.call(\"I1love143you55three3000thousand\"))\n    assert_equal(\"AvengersAssemble124\", candidate.call(\"Avengers124Assemble\"))\n    assert_equal(\"Itsourpathtoseethingsdothings11121314151617\", candidate.call(\"Its11our12path13to14see15things16do17things\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the length of the word is odd or not.\ndef word_len(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_word_len\n    candidate = method(:word_len)\n    assert_equal(false, candidate.call(\"Hadoop\"))\n    assert_equal(true, candidate.call(\"great\"))\n    assert_equal(true, candidate.call(\"structure\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "rb",
-    "prompt": "# Write a function to drop empty items from a given hash.\ndef drop_empty(dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_drop_empty\n    candidate = method(:drop_empty)\n    assert_equal({\"c1\" => \"Red\", \"c2\" => \"Green\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => nil}))\n    assert_equal({\"c1\" => \"Red\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => nil, \"c3\" => nil}))\n    assert_equal({\"c2\" => \"Green\"}, candidate.call({\"c1\" => nil, \"c2\" => \"Green\", \"c3\" => nil}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\ndef insert_element(list, element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_insert_element\n    candidate = method(:insert_element)\n    assert_equal([\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"], candidate.call([\"Red\", \"Green\", \"Black\"], \"c\"))\n    assert_equal([\"program\", \"python\", \"program\", \"java\"], candidate.call([\"python\", \"java\"], \"program\"))\n    assert_equal([\"laugh\", \"happy\", \"laugh\", \"sad\"], candidate.call([\"happy\", \"sad\"], \"laugh\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rb",
-    "prompt": "# Write a function to remove lowercase substrings from a given string.\ndef remove_lowercase(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_lowercase\n    candidate = method(:remove_lowercase)\n    assert_equal(\"PYTH\", candidate.call(\"PYTHon\"))\n    assert_equal(\"FID\", candidate.call(\"FInD\"))\n    assert_equal(\"STRG\", candidate.call(\"STRinG\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of set bits (binary digits with value 1) in a given number.\ndef count_Set_Bits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Set_Bits\n    candidate = method(:count_Set_Bits)\n    assert_equal(1, candidate.call(2))\n    assert_equal(1, candidate.call(4))\n    assert_equal(2, candidate.call(6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rb",
-    "prompt": "# Write a function to extract only the rear index element of each string in the given array.\ndef extract_rear(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_rear\n    candidate = method(:extract_rear)\n    assert_equal([\"s\", \"r\", \"s\"], candidate.call([\"Mers\", \"for\", \"Vers\"]))\n    assert_equal([\"e\", \"r\", \"e\"], candidate.call([\"Avenge\", \"for\", \"People\"]))\n    assert_equal([\"a\", \"t\", \"o\"], candidate.call([\"Gotta\", \"get\", \"go\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ndef count_occurance(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_occurance\n    candidate = method(:count_occurance)\n    assert_equal(3, candidate.call(\"letstdlenstdporstd\"))\n    assert_equal(1, candidate.call(\"truststdsolensporsd\"))\n    assert_equal(2, candidate.call(\"makestdsostdworthit\"))\n    assert_equal(1, candidate.call(\"stds\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given arrays contain the k or not.\ndef check_K(test_tup, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_K\n    candidate = method(:check_K)\n    assert_equal(true, candidate.call([10, 4, 5, 6, 8], 6))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5, 6], 7))\n    assert_equal(true, candidate.call([7, 8, 9, 44, 11, 12], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rb",
-    "prompt": "# Write a function to interleave 3 arrays of the same length into a single flat array.\ndef interleave_lists(list1, list2, list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_interleave_lists\n    candidate = method(:interleave_lists)\n    assert_equal([1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700], candidate.call([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]))\n    assert_equal([10, 15, 5, 20, 2, 10], candidate.call([10, 20], [15, 2], [5, 10]))\n    assert_equal([11, 10, 20, 44, 15, 5], candidate.call([11, 44], [10, 15], [20, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rb",
-    "prompt": "# Write a function to convert a snake case string to camel case string.\ndef snake_to_camel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"PythonProgram\", candidate.call(\"python_program\"))\n    assert_equal(\"PythonLanguage\", candidate.call(\"python_language\"))\n    assert_equal(\"ProgrammingLanguage\", candidate.call(\"programming_language\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of equal numbers from three given integers.\ndef test_three_equal(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_three_equal\n    candidate = method(:test_three_equal)\n    assert_equal(3, candidate.call(1, 1, 1))\n    assert_equal(0, candidate.call(-1, -2, -3))\n    assert_equal(2, candidate.call(1, 2, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\ndef odd_length_sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_length_sum\n    candidate = method(:odd_length_sum)\n    assert_equal(14, candidate.call([1, 2, 4]))\n    assert_equal(15, candidate.call([1, 2, 1, 2]))\n    assert_equal(8, candidate.call([1, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rb",
-    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\ndef bell_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_number\n    candidate = method(:bell_number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(115975, candidate.call(10))\n    assert_equal(6775685320645824322581483068371419745979053216268760300, candidate.call(56))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rb",
-    "prompt": "# Write a function to find the area of a rectangle.\ndef rectangle_area(l, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rectangle_area\n    candidate = method(:rectangle_area)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(10, 5))\n    assert_equal(8, candidate.call(4, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rb",
-    "prompt": "# Write a function to find sum and average of first n natural numbers.\ndef sum_average(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_average\n    candidate = method(:sum_average)\n    assert_equal([55, 5.5], candidate.call(10))\n    assert_equal([120, 8.0], candidate.call(15))\n    assert_equal([210, 10.5], candidate.call(20))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\ndef division_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_division_elements\n    candidate = method(:division_elements)\n    assert_equal([2, 2, 2, 3], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([2, 2, 2, 4], candidate.call([12, 6, 8, 16], [6, 3, 4, 4]))\n    assert_equal([4, 2, 6, 2], candidate.call([20, 14, 36, 18], [5, 7, 6, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rb",
-    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\ndef sum_digits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_digits\n    candidate = method(:sum_digits)\n    assert_equal(12, candidate.call(345))\n    assert_equal(3, candidate.call(12))\n    assert_equal(16, candidate.call(97))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rb",
-    "prompt": "# Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\ndef index_minimum(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_minimum\n    candidate = method(:index_minimum)\n    assert_equal(\"Varsha\", candidate.call([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]))\n    assert_equal(\"Dawood\", candidate.call([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]))\n    assert_equal(\"Ayesha\", candidate.call([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rb",
-    "prompt": "# Write a function to divide two arrays element wise.\ndef div_list(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_div_list\n    candidate = method(:div_list)\n    assert_equal([4.0, 2.5, 2.0], candidate.call([4, 5, 6], [1, 2, 3]))\n    assert_equal([3.0, 0.5], candidate.call([3, 2], [1, 4]))\n    assert_equal([1.8, 1.7142857142857142], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rb",
-    "prompt": "# Write a function to find the array with maximum length.\ndef max_length_list(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length_list\n    candidate = method(:max_length_list)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([5, [1, 2, 3, 4, 5]], candidate.call([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]))\n    assert_equal([4, [6, 7, 8, 9]], candidate.call([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "rb",
-    "prompt": "# Write a function to find all possible combinations of the elements of a given array.\ndef combinations_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_list\n    candidate = method(:combinations_list)\n    assert_equal([[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]], candidate.call([\"orange\", \"red\", \"green\", \"blue\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"black\", \"orange\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of the largest and smallest value in a given array.\ndef big_sum(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_sum\n    candidate = method(:big_sum)\n    assert_equal(4, candidate.call([1, 2, 3]))\n    assert_equal(3, candidate.call([-1, 2, 3, 4]))\n    assert_equal(8, candidate.call([2, 3, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to return the negative numbers in an array.\ndef neg_nos(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_neg_nos\n    candidate = method(:neg_nos)\n    assert_equal([-1, -6], candidate.call([-1, 4, 5, -6]))\n    assert_equal([-1, -2], candidate.call([-1, -2, 3, 4]))\n    assert_equal([-7, -6], candidate.call([-7, -6, 8, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the highest power of 2 that is less than or equal to n.\ndef highest_Power_of_2(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_highest_Power_of_2\n    candidate = method(:highest_Power_of_2)\n    assert_equal(8, candidate.call(10))\n    assert_equal(16, candidate.call(19))\n    assert_equal(32, candidate.call(32))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rb",
-    "prompt": "# Write a function to check whether an array contains the given subarray or not.\ndef is_sublist(l, s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sublist\n    candidate = method(:is_sublist)\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [3, 7]))\n    assert_equal(true, candidate.call([2, 4, 3, 5, 7], [4, 3]))\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [1, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rb",
-    "prompt": "# Write a function to subtract two arrays element-wise.\ndef sub_list(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sub_list\n    candidate = method(:sub_list)\n    assert_equal([-3, -3, -3], candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal([-2, -2], candidate.call([1, 2], [3, 4]))\n    assert_equal([40, 50], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given two integers have opposite sign or not.\ndef opposite_Signs(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_opposite_Signs\n    candidate = method(:opposite_Signs)\n    assert_equal(true, candidate.call(1, -2))\n    assert_equal(false, candidate.call(3, 2))\n    assert_equal(false, candidate.call(-10, -10))\n    assert_equal(true, candidate.call(-2, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rb",
-    "prompt": "# Write a function which takes two arrays of the same length and performs the element wise modulo.\ndef tuple_modulo(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_modulo\n    candidate = method(:tuple_modulo)\n    assert_equal([0, 4, 5, 1], candidate.call([10, 4, 5, 6], [5, 6, 7, 5]))\n    assert_equal([5, 5, 6, 1], candidate.call([11, 5, 6, 7], [6, 7, 8, 6]))\n    assert_equal([5, 6, 7, 1], candidate.call([12, 6, 7, 8], [7, 8, 9, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rb",
-    "prompt": "# Write a function to find the difference of the first even and first odd number of a given array.\ndef diff_even_odd(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_diff_even_odd\n    candidate = method(:diff_even_odd)\n    assert_equal(3, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(9, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rb",
-    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\ndef sort_sublists(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]], candidate.call([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the last digit of a given number.\ndef last_Digit(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit\n    candidate = method(:last_Digit)\n    assert_equal(3, candidate.call(123))\n    assert_equal(5, candidate.call(25))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of fourth power of first n odd natural numbers.\ndef odd_num_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_num_sum\n    candidate = method(:odd_num_sum)\n    assert_equal(82, candidate.call(2))\n    assert_equal(707, candidate.call(3))\n    assert_equal(3108, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rb",
-    "prompt": "# Write a function to convert an array to a string.\ndef tup_string(tup1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tup_string\n    candidate = method(:tup_string)\n    assert_equal(\"exercises\", candidate.call([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]))\n    assert_equal(\"python\", candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]))\n    assert_equal(\"program\", candidate.call([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rb",
-    "prompt": "# Write a function to remove all elements from a given array present in another array.\ndef remove_elements(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_elements\n    candidate = method(:remove_elements)\n    assert_equal([1, 3, 5, 7, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]))\n    assert_equal([2, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]))\n    assert_equal([1, 2, 3, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether any value in a sequence exists in a sequence or not.\ndef overlapping(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_overlapping\n    candidate = method(:overlapping)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(false, candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal(true, candidate.call([1, 4, 5], [1, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to identify non-prime numbers.\ndef is_not_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_not_prime\n    candidate = method(:is_not_prime)\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(10))\n    assert_equal(true, candidate.call(35))\n    assert_equal(false, candidate.call(37))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum value in a given heterogeneous array.\ndef max_val(listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_val\n    candidate = method(:max_val)\n    assert_equal(5, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(25, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(50, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum of the negative numbers of a given array of numbers.\ndef sum_negativenum(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_negativenum\n    candidate = method(:sum_negativenum)\n    assert_equal(-32, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n    assert_equal(-52, candidate.call([10, 15, -14, 13, -18, 12, -20]))\n    assert_equal(-894, candidate.call([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the minimum number of rotations (greater than 0) required to get the same string.\ndef find_Rotations(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Rotations\n    candidate = method(:find_Rotations)\n    assert_equal(1, candidate.call(\"aaaa\"))\n    assert_equal(2, candidate.call(\"ab\"))\n    assert_equal(3, candidate.call(\"abc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rb",
-    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\ndef change_date_format(dt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_date_format\n    candidate = method(:change_date_format)\n    assert_equal(\"02-01-2026\", candidate.call(\"2026-01-02\"))\n    assert_equal(\"13-11-2020\", candidate.call(\"2020-11-13\"))\n    assert_equal(\"26-04-2021\", candidate.call(\"2021-04-26\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rb",
-    "prompt": "# Write a rbthon function which takes an array of integers and only returns the odd ones.\ndef Split(list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([1, 3, 5], candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal([11, 13], candidate.call([10, 11, 12, 13]))\n    assert_equal([7, 9, 1], candidate.call([7, 8, 9, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ndef toggle_middle_bits(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_middle_bits\n    candidate = method(:toggle_middle_bits)\n    assert_equal(15, candidate.call(9))\n    assert_equal(12, candidate.call(10))\n    assert_equal(13, candidate.call(11))\n    assert_equal(127, candidate.call(65))\n    assert_equal(115, candidate.call(77))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ndef count_char_position(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_char_position\n    candidate = method(:count_char_position)\n    assert_equal(2, candidate.call(\"xbcefg\"))\n    assert_equal(3, candidate.call(\"ABcED\"))\n    assert_equal(5, candidate.call(\"AbgdeF\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\ndef large_product(nums1, nums2, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_large_product\n    candidate = method(:large_product)\n    assert_equal([60, 54, 50], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3))\n    assert_equal([60, 54, 50, 48], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4))\n    assert_equal([60, 54, 50, 48, 45], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\ndef cummulative_sum(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cummulative_sum\n    candidate = method(:cummulative_sum)\n    assert_equal(30, candidate.call([[1, 3], [5, 6, 7], [2, 6]]))\n    assert_equal(37, candidate.call([[2, 4], [6, 7, 8], [3, 7]]))\n    assert_equal(44, candidate.call([[3, 5], [7, 8, 9], [4, 8]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\ndef find_min_diff(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_min_diff\n    candidate = method(:find_min_diff)\n    assert_equal(1, candidate.call([1, 5, 3, 19, 18, 25], 6))\n    assert_equal(1, candidate.call([4, 3, 2, 6], 4))\n    assert_equal(4, candidate.call([30, 5, 20, 9], 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ndef text_starta_endb(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_starta_endb\n    candidate = method(:text_starta_endb)\n    assert_equal(true, candidate.call(\"aabbbb\"))\n    assert_equal(false, candidate.call(\"aabAbbbc\"))\n    assert_equal(false, candidate.call(\"accddbbjjj\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rb",
-    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\ndef left_rotate(n, d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_rotate\n    candidate = method(:left_rotate)\n    assert_equal(64, candidate.call(16, 2))\n    assert_equal(40, candidate.call(10, 2))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(8, candidate.call(1, 3))\n    assert_equal(40, candidate.call(5, 3))\n    assert_equal(232, candidate.call(29, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the first repeated character in a given string.\ndef first_repeated_char(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_repeated_char\n    candidate = method(:first_repeated_char)\n    assert_equal(\"a\", candidate.call(\"abcabc\"))\n    assert_equal(nil, candidate.call(\"abc\"))\n    assert_equal(\"1\", candidate.call(\"123123\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count inversions in an array.\ndef get_Inv_Count(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Inv_Count\n    candidate = method(:get_Inv_Count)\n    assert_equal(5, candidate.call([1, 20, 6, 4, 5]))\n    assert_equal(1, candidate.call([1, 2, 1]))\n    assert_equal(3, candidate.call([1, 2, 5, 6, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\ndef even_Power_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_Power_Sum\n    candidate = method(:even_Power_Sum)\n    assert_equal(1056, candidate.call(2))\n    assert_equal(8832, candidate.call(3))\n    assert_equal(32, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rb",
-    "prompt": "# Write a function to find whether all the given arrays have equal length or not.\ndef get_equal(input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_equal\n    candidate = method(:get_equal)\n    assert_equal(true, candidate.call([[11, 22, 33], [44, 55, 66]]))\n    assert_equal(false, candidate.call([[1, 2, 3], [4, 5, 6, 7]]))\n    assert_equal(true, candidate.call([[1, 2], [3, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rb",
-    "prompt": "# Write a function to check if a string represents an integer or not.\ndef check_integer(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_integer\n    candidate = method(:check_integer)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"1\"))\n    assert_equal(true, candidate.call(\"12345\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rb",
-    "prompt": "# Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/rbthon-program-to-count-the-pairs-of-reverse-strings/\ndef count_reverse_pairs(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_reverse_pairs\n    candidate = method(:count_reverse_pairs)\n    assert_equal(2, candidate.call([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]))\n    assert_equal(1, candidate.call([\"geeks\", \"best\", \"for\", \"skeeg\"]))\n    assert_equal(2, candidate.call([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to move all zeroes to the end of the given array.\ndef move_zero(num_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_zero\n    candidate = method(:move_zero)\n    assert_equal([1, 2, 3, 4, 0, 0], candidate.call([1, 0, 2, 0, 3, 4]))\n    assert_equal([2, 3, 2, 4, 5, 0, 0, 0, 0], candidate.call([2, 3, 2, 0, 0, 4, 0, 5, 0]))\n    assert_equal([1, 1, 1, 0, 0], candidate.call([0, 1, 0, 1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rb",
-    "prompt": "# Write a function to check if given array contains no duplicates.\ndef check_distinct(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_distinct\n    candidate = method(:check_distinct)\n    assert_equal(false, candidate.call([1, 4, 5, 6, 1, 4]))\n    assert_equal(true, candidate.call([1, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given amount has no profit and no loss\ndef noprofit_noloss(actual_cost, sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_noprofit_noloss\n    candidate = method(:noprofit_noloss)\n    assert_equal(false, candidate.call(1500, 1200))\n    assert_equal(true, candidate.call(100, 100))\n    assert_equal(false, candidate.call(2000, 5000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rb",
-    "prompt": "# Write a function to remove all the words with k length in the given string.\ndef remove_length(test_str, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_length\n    candidate = method(:remove_length)\n    assert_equal(\"person is most value\", candidate.call(\"The person is most value tet\", 3))\n    assert_equal(\"If you me about ok\", candidate.call(\"If you told me about this ok\", 4))\n    assert_equal(\"Forces of darkeness is the\", candidate.call(\"Forces of darkeness is come into the play\", 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count number of digits in a given string.\ndef number_ctr(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_ctr\n    candidate = method(:number_ctr)\n    assert_equal(1, candidate.call(\"program2bedone\"))\n    assert_equal(1, candidate.call(\"3wonders\"))\n    assert_equal(3, candidate.call(\"123\"))\n    assert_equal(3, candidate.call(\"3wond-1ers2\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rb",
-    "prompt": "# Write a function to count the total number of characters in a string.\ndef count_charac(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_charac\n    candidate = method(:count_charac)\n    assert_equal(18, candidate.call(\"python programming\"))\n    assert_equal(8, candidate.call(\"language\"))\n    assert_equal(5, candidate.call(\"words\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rb",
-    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\ndef get_total_number_of_sequences(m, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_total_number_of_sequences\n    candidate = method(:get_total_number_of_sequences)\n    assert_equal(4, candidate.call(10, 4))\n    assert_equal(6, candidate.call(5, 2))\n    assert_equal(84, candidate.call(16, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rb",
-    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rbthon-exercises/data-structures-and-algorithms/rbthon-data-structure-exercise-24.php\ndef left_insertion(a, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_insertion\n    candidate = method(:left_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two numbers and returns an array with the second number and then the first number.\ndef swap_numbers(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_numbers\n    candidate = method(:swap_numbers)\n    assert_equal([20, 10], candidate.call(10, 20))\n    assert_equal([17, 15], candidate.call(15, 17))\n    assert_equal([200, 100], candidate.call(100, 200))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\ndef is_majority(arr, n, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_majority\n    candidate = method(:is_majority)\n    assert_equal(true, candidate.call([1, 2, 3, 3, 3, 3, 10], 7, 3))\n    assert_equal(false, candidate.call([1, 1, 2, 4, 4, 4, 6, 6], 8, 4))\n    assert_equal(true, candidate.call([1, 1, 1, 2, 2], 5, 1))\n    assert_equal(false, candidate.call([1, 1, 2, 2], 5, 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\ndef substract_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_substract_elements\n    candidate = method(:substract_elements)\n    assert_equal([8, -1, -13], candidate.call([10, 4, 5], [2, 5, 18]))\n    assert_equal([-13, -43, -13], candidate.call([11, 2, 3], [24, 45, 16]))\n    assert_equal([-3, 7, -3], candidate.call([7, 18, 9], [10, 11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ndef capital_words_spaces(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_capital_words_spaces\n    candidate = method(:capital_words_spaces)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"Python Programming Examples\", candidate.call(\"PythonProgrammingExamples\"))\n    assert_equal(\"Get Ready To Be Coding Freak\", candidate.call(\"GetReadyToBeCodingFreak\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the average of cubes of first n natural numbers.\ndef find_Average_Of_Cube(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Average_Of_Cube\n    candidate = method(:find_Average_Of_Cube)\n    assert_equal(4.5, candidate.call(2))\n    assert_equal(12, candidate.call(3))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rb",
-    "prompt": "# Write a function to check if all values are same in a hash.\ndef check_value(dict, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_value\n    candidate = method(:check_value)\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10))\n    assert_equal(true, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12))\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth tetrahedral number.\ndef tetrahedral_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tetrahedral_number\n    candidate = method(:tetrahedral_number)\n    assert_equal(35, candidate.call(5))\n    assert_equal(56, candidate.call(6))\n    assert_equal(84, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rb",
-    "prompt": "# Write a function to calculate whether the matrix is a magic square.\ndef magic_square_test(my_matrix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_magic_square_test\n    candidate = method(:magic_square_test)\n    assert_equal(true, candidate.call([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]))\n    assert_equal(true, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 8]]))\n    assert_equal(false, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 7]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rb",
-    "prompt": "# Write a function to remove uppercase substrings from a given string.\ndef remove_uppercase(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_uppercase\n    candidate = method(:remove_uppercase)\n    assert_equal(\"cstyoravoitshos\", candidate.call(\"cAstyoUrFavoRitETVshoWs\"))\n    assert_equal(\"wtchheinerntrdo\", candidate.call(\"wAtchTheinTernEtrAdIo\"))\n    assert_equal(\"oiceachndreomendaion\", candidate.call(\"VoicESeaRchAndreComMendaTionS\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "rb",
-    "prompt": "# Write a function to check whether an element exists within an array.\ndef check_tuplex(tuplex, tuple1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_tuplex\n    candidate = method(:check_tuplex)\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"))\n    assert_equal(false, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"))\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rb",
-    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndef dog_age(h_age)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dog_age\n    candidate = method(:dog_age)\n    assert_equal(61, candidate.call(12))\n    assert_equal(73, candidate.call(15))\n    assert_equal(109, candidate.call(24))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the next perfect square greater than a given number.\ndef next_Perfect_Square(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_Perfect_Square\n    candidate = method(:next_Perfect_Square)\n    assert_equal(36, candidate.call(35))\n    assert_equal(9, candidate.call(6))\n    assert_equal(16, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "rb",
-    "prompt": "# Write a function to create an array of N empty dictionaries.\ndef empty_list(length)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_empty_list\n    candidate = method(:empty_list)\n    assert_equal([{}, {}, {}, {}, {}], candidate.call(5))\n    assert_equal([{}, {}, {}, {}, {}, {}], candidate.call(6))\n    assert_equal([{}, {}, {}, {}, {}, {}, {}], candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to convert a given string to uppercase.\ndef is_upper(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_upper\n    candidate = method(:is_upper)\n    assert_equal(\"PERSON\", candidate.call(\"person\"))\n    assert_equal(\"FINAL\", candidate.call(\"final\"))\n    assert_equal(\"VALID\", candidate.call(\"Valid\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\ndef odd_Equivalent(s, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_Equivalent\n    candidate = method(:odd_Equivalent)\n    assert_equal(3, candidate.call(\"011001\", 6))\n    assert_equal(4, candidate.call(\"11011\", 5))\n    assert_equal(2, candidate.call(\"1010\", 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\ndef re_arrange_array(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_re_arrange_array\n    candidate = method(:re_arrange_array)\n    assert_equal([-1, -3, -7, 4, 5, 6, 2, 8, 9], candidate.call([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9))\n    assert_equal([-14, -26, 12, 13, 15], candidate.call([12, -14, -26, 13, 15], 5))\n    assert_equal([-42, -39, -78, 10, 24, 36, 85], candidate.call([10, 24, 36, -42, -39, -78, 85], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether an array of numbers contains only one distinct element or not.\ndef unique_Element(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_Element\n    candidate = method(:unique_Element)\n    assert_equal(true, candidate.call([1, 1, 1]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "rb",
-    "prompt": "# Write a function to extract values between quotation marks from a string.\ndef extract_values(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_values\n    candidate = method(:extract_values)\n    assert_equal([\"Python\", \"PHP\", \"Java\"], candidate.call(\"\"Python\", \"PHP\", \"Java\"\"))\n    assert_equal([\"python\", \"program\", \"language\"], candidate.call(\"\"python\",\"program\",\"language\"\"))\n    assert_equal([\"red\", \"blue\", \"green\", \"yellow\"], candidate.call(\"\"red\",\"blue\",\"green\",\"yellow\"\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count true booleans in the given array.\ndef count(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count\n    candidate = method(:count)\n    assert_equal(2, candidate.call([true, false, true]))\n    assert_equal(0, candidate.call([false, false]))\n    assert_equal(3, candidate.call([true, true, true]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rb",
-    "prompt": "# Write a function that counts the number of pairs of integers in an array that xor to an even number.\ndef find_even_pair(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_even_pair\n    candidate = method(:find_even_pair)\n    assert_equal(4, candidate.call([5, 4, 7, 2, 1]))\n    assert_equal(9, candidate.call([7, 2, 8, 1, 0, 5, 11]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is armstrong or not.\ndef armstrong_number(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_armstrong_number\n    candidate = method(:armstrong_number)\n    assert_equal(true, candidate.call(153))\n    assert_equal(false, candidate.call(259))\n    assert_equal(false, candidate.call(4458))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the upper case characters in a given string.\ndef upper_ctr(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_upper_ctr\n    candidate = method(:upper_ctr)\n    assert_equal(1, candidate.call(\"PYthon\"))\n    assert_equal(1, candidate.call(\"BigData\"))\n    assert_equal(0, candidate.call(\"program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to extract the elementwise and arrays from the given two arrays.\ndef and_tuples(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_and_tuples\n    candidate = method(:and_tuples)\n    assert_equal([0, 0, 2, 1], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([1, 2, 3, 0], candidate.call([1, 2, 3, 4], [5, 6, 7, 8]))\n    assert_equal([0, 9, 10, 0], candidate.call([8, 9, 11, 12], [7, 13, 14, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rb",
-    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\ndef is_samepatterns(colors, patterns)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_samepatterns\n    candidate = method(:is_samepatterns)\n    assert_equal(true, candidate.call([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of arrays in a given number of arrays.\ndef count_list(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_list\n    candidate = method(:count_list)\n    assert_equal(4, candidate.call([[1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal(3, candidate.call([[1, 2], [2, 3], [4, 5]]))\n    assert_equal(2, candidate.call([[1, 0], [2, 0]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rb",
-    "prompt": "# Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\ndef average_tuple(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_average_tuple\n    candidate = method(:average_tuple)\n    assert_equal([30.5, 34.25, 27.0, 23.25], candidate.call([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]))\n    assert_equal([25.5, -18.0, 3.75], candidate.call([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]))\n    assert_equal([305.0, 342.5, 270.0, 232.5], candidate.call([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rb",
-    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\ndef lcs_of_three(x, y, z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lcs_of_three\n    candidate = method(:lcs_of_three)\n    assert_equal(2, candidate.call(\"AGGT12\", \"12TXAYB\", \"12XBA\"))\n    assert_equal(5, candidate.call(\"Reels\", \"Reelsfor\", \"ReelsforReels\"))\n    assert_equal(3, candidate.call(\"abcd1e2\", \"bc12ea\", \"bd1ea\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the n'th star number.\ndef find_star_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_star_num\n    candidate = method(:find_star_num)\n    assert_equal(37, candidate.call(3))\n    assert_equal(73, candidate.call(4))\n    assert_equal(121, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of an array.\ndef _sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test__sum\n    candidate = method(:_sum)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(50, candidate.call([15, 12, 13, 10]))\n    assert_equal(3, candidate.call([0, 1, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given array contains consecutive numbers or not.\ndef check_Consecutive(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_Consecutive\n    candidate = method(:check_Consecutive)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 2, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rb",
-    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\ndef find_adverb_position(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverb_position\n    candidate = method(:find_adverb_position)\n    assert_equal([0, 7, \"clearly\"], candidate.call(\"clearly!! we can see the sky\"))\n    assert_equal([0, 9, \"seriously\"], candidate.call(\"seriously!! there are many roses\"))\n    assert_equal([0, 13, \"unfortunately\"], candidate.call(\"unfortunately!! sita is going to home\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rb",
-    "prompt": "# Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/rbthon-program-right-rotate-array-n/\ndef rotate_right(list, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rotate_right\n    candidate = method(:rotate_right)\n    assert_equal([8, 9, 10, 1, 2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3))\n    assert_equal([9, 10, 1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([6, 7, 8, 9, 10, 1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of non-empty substrings of a given string.\ndef number_of_substrings(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_of_substrings\n    candidate = method(:number_of_substrings)\n    assert_equal(6, candidate.call(\"abc\"))\n    assert_equal(10, candidate.call(\"abcd\"))\n    assert_equal(15, candidate.call(\"abcde\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\ndef list_split(s, step)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_split\n    candidate = method(:list_split)\n    assert_equal([[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]], candidate.call([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3))\n    assert_equal([[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3))\n    assert_equal([[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]], candidate.call([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check if the elements of a given array are unique or not.\ndef all_unique(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_unique\n    candidate = method(:all_unique)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to convert complex numbers to polar coordinates.\ndef convert(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert\n    candidate = method(:convert)\n    assert_equal([1.0, 0.0], candidate.call(1))\n    assert_equal([4.0, 0.0], candidate.call(4))\n    assert_equal([5.0, 0.0], candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "rb",
-    "prompt": "# The input is given as - a hash with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\ndef filter_data(students, h, w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_data\n    candidate = method(:filter_data)\n    assert_equal({\"Cierra Vega\" => [6.2, 70]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to convert the given string to lower case.\ndef is_lower(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_lower\n    candidate = method(:is_lower)\n    assert_equal(\"invalid\", candidate.call(\"InValid\"))\n    assert_equal(\"true\", candidate.call(\"TruE\"))\n    assert_equal(\"sentence\", candidate.call(\"SenTenCE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the smallest power of 2 greater than or equal to n.\ndef next_power_of_2(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_power_of_2\n    candidate = method(:next_power_of_2)\n    assert_equal(1, candidate.call(0))\n    assert_equal(8, candidate.call(5))\n    assert_equal(32, candidate.call(17))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rb",
-    "prompt": "# Write a function to check if a string is present as a substring in a given array of string values.\ndef find_substring(str1, sub_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_substring\n    candidate = method(:find_substring)\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"))\n    assert_equal(false, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"))\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rb",
-    "prompt": "# Write a function to replace characters in a string.\ndef replace_char(str1, ch, newch)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_char\n    candidate = method(:replace_char)\n    assert_equal(\"pollgon\", candidate.call(\"polygon\", \"y\", \"l\"))\n    assert_equal(\"aharaater\", candidate.call(\"character\", \"c\", \"a\"))\n    assert_equal(\"python\", candidate.call(\"python\", \"l\", \"a\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rb",
-    "prompt": "# Write a function to find the product of first even and odd number of a given array.\ndef mul_even_odd(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mul_even_odd\n    candidate = method(:mul_even_odd)\n    assert_equal(4, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(10, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to convert an array to an array.\ndef list_tuple(listx)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_tuple\n    candidate = method(:list_tuple)\n    assert_equal([5, 10, 7, 4, 15, 3], candidate.call([5, 10, 7, 4, 15, 3]))\n    assert_equal([2, 4, 5, 6, 2, 3, 4, 4, 7], candidate.call([2, 4, 5, 6, 2, 3, 4, 4, 7]))\n    assert_equal([58, 44, 56], candidate.call([58, 44, 56]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\ndef even_binomial_Coeff_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_binomial_Coeff_Sum\n    candidate = method(:even_binomial_Coeff_Sum)\n    assert_equal(8, candidate.call(4))\n    assert_equal(32, candidate.call(6))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rb",
-    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given arrays.\ndef bitwise_xor(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bitwise_xor\n    candidate = method(:bitwise_xor)\n    assert_equal([15, 6, 5, 10], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([13, 6, 3, 14], candidate.call([11, 5, 7, 10], [6, 3, 4, 4]))\n    assert_equal([11, 2, 13, 13], candidate.call([12, 6, 8, 11], [7, 4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether an array is subarray of another or not.\ndef is_Sub_Array(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sub_Array\n    candidate = method(:is_Sub_Array)\n    assert_equal(false, candidate.call([1, 4, 3, 5], [1, 2]))\n    assert_equal(true, candidate.call([1, 2, 1], [1, 2, 1]))\n    assert_equal(false, candidate.call([1, 0, 2, 2], [2, 2, 0]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rb",
-    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\ndef max_sub_array_sum_repeated(a, n, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum_repeated\n    candidate = method(:max_sub_array_sum_repeated)\n    assert_equal(30, candidate.call([10, 20, -30, -1], 4, 3))\n    assert_equal(59, candidate.call([-1, 10, 20], 3, 2))\n    assert_equal(-1, candidate.call([-1, -2, -3], 3, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to find the minimum product from the pairs of arrays within a given array.\ndef min_product_tuple(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_product_tuple\n    candidate = method(:min_product_tuple)\n    assert_equal(8, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(30, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(100, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the count of divisors is even. https://www.w3resource.com/rbthon-exercises/basic/rbthon-basic-1-exercise-24.php\ndef count_divisors(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_divisors\n    candidate = method(:count_divisors)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(100))\n    assert_equal(true, candidate.call(125))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ndef triangle_area(r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(nil, candidate.call(-1))\n    assert_equal(0, candidate.call(0))\n    assert_equal(4, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to convert a given string to an array of characters.\ndef string_to_tuple(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_tuple\n    candidate = method(:string_to_tuple)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"], candidate.call(\"python 3.0\"))\n    assert_equal([\"i\", \"t\", \"e\", \"m\", \"1\"], candidate.call(\"item1\"))\n    assert_equal([\"1\", \"5\", \".\", \"1\", \"0\"], candidate.call(\"15.10\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\ndef find_length(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_length\n    candidate = method(:find_length)\n    assert_equal(6, candidate.call(\"11000010001\"))\n    assert_equal(1, candidate.call(\"10111\"))\n    assert_equal(2, candidate.call(\"11011101100101\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rb",
-    "prompt": "# Write a rbthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ndef count_Primes_nums(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Primes_nums\n    candidate = method(:count_Primes_nums)\n    assert_equal(2, candidate.call(5))\n    assert_equal(4, candidate.call(10))\n    assert_equal(25, candidate.call(100))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of the product of consecutive binomial co-efficients.\ndef sum_Of_product(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_product\n    candidate = method(:sum_Of_product)\n    assert_equal(15, candidate.call(3))\n    assert_equal(56, candidate.call(4))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the maximum aggregate from the array of arrays.\ndef max_aggregate(stdata)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_aggregate\n    candidate = method(:max_aggregate)\n    assert_equal([\"Juan Whelan\", 212], candidate.call([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]))\n    assert_equal([\"Juan Whelan\", 72], candidate.call([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]))\n    assert_equal([\"Sabah Colley\", 70], candidate.call([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rb",
-    "prompt": "# Write a function to sort an array of elements.\ndef comb_sort(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_comb_sort\n    candidate = method(:comb_sort)\n    assert_equal([5, 15, 25, 37, 79], candidate.call([5, 15, 37, 25, 79]))\n    assert_equal([15, 19, 22, 32, 41], candidate.call([41, 32, 15, 19, 22]))\n    assert_equal([13, 15, 47, 99], candidate.call([99, 15, 13, 47]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ndef check_expression(exp)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_expression\n    candidate = method(:check_expression)\n    assert_equal(true, candidate.call(\"{()}[{}]\"))\n    assert_equal(false, candidate.call(\"{()}[{]\"))\n    assert_equal(true, candidate.call(\"{()}[{}][]({})\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rb",
-    "prompt": "# Write a function that matches a word containing 'z'.\ndef text_match_wordz(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz\n    candidate = method(:text_match_wordz)\n    assert_equal(true, candidate.call(\"pythonz.\"))\n    assert_equal(true, candidate.call(\"xyz.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rb",
-    "prompt": "# Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\ndef sum_list(lst1, lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_list\n    candidate = method(:sum_list)\n    assert_equal([25, 45, 65], candidate.call([10, 20, 30], [15, 25, 35]))\n    assert_equal([6, 8, 10], candidate.call([1, 2, 3], [5, 6, 7]))\n    assert_equal([30, 65, 105], candidate.call([15, 20, 30], [15, 45, 75]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\ndef newman_prime(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_newman_prime\n    candidate = method(:newman_prime)\n    assert_equal(7, candidate.call(3))\n    assert_equal(17, candidate.call(4))\n    assert_equal(41, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "rb",
-    "prompt": "# Write a function to apply a given format string to all of the elements in an array.\ndef add_string(list_, string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_string\n    candidate = method(:add_string)\n    assert_equal([\"temp1\", \"temp2\", \"temp3\", \"temp4\"], candidate.call([1, 2, 3, 4], \"temp{0}\"))\n    assert_equal([\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"], candidate.call([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"))\n    assert_equal([\"string5\", \"string6\", \"string7\", \"string8\"], candidate.call([5, 6, 7, 8], \"string{0}\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the surface area of a square rbramid with a given base edge and height.\ndef surface_Area(b, s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surface_Area\n    candidate = method(:surface_Area)\n    assert_equal(33, candidate.call(3, 4))\n    assert_equal(56, candidate.call(4, 5))\n    assert_equal(5, candidate.call(1, 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the length of the smallest array in an array of arrays.\ndef Find_Min_Length(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min_Length\n    candidate = method(:Find_Min_Length)\n    assert_equal(1, candidate.call([[1], [1, 2]]))\n    assert_equal(2, candidate.call([[1, 2], [1, 2, 3], [1, 2, 3, 4]]))\n    assert_equal(3, candidate.call([[3, 3, 3], [4, 4, 4, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rb",
-    "prompt": "# Write a rbthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\ndef validate(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_validate\n    candidate = method(:validate)\n    assert_equal(true, candidate.call(1234))\n    assert_equal(false, candidate.call(51241))\n    assert_equal(true, candidate.call(321))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth hexagonal number.\ndef hexagonal_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hexagonal_num\n    candidate = method(:hexagonal_num)\n    assert_equal(190, candidate.call(10))\n    assert_equal(45, candidate.call(5))\n    assert_equal(91, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rb",
-    "prompt": "# Write a function to find the n'th lucas number.\ndef find_lucas(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lucas\n    candidate = method(:find_lucas)\n    assert_equal(76, candidate.call(9))\n    assert_equal(7, candidate.call(4))\n    assert_equal(4, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to get the difference between two arrays.\ndef Diff(li1, li2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Diff\n    candidate = method(:Diff)\n    assert_equal([10, 20, 30, 15], candidate.call([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]))\n    assert_equal([2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5], [6, 7, 1]))\n    assert_equal([2, 3, 6, 7], candidate.call([1, 2, 3], [6, 7, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "rb",
-    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\ndef extract_quotation(text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_quotation\n    candidate = method(:extract_quotation)\n    assert_equal([\"A53\", \"multi\", \"Processor\"], candidate.call(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"))\n    assert_equal([\"favorite\", \"apps\"], candidate.call(\"Cast your \"favorite\" entertainment \"apps\"\"))\n    assert_equal([\"4k Ultra HD\", \"HDR 10\"], candidate.call(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"))\n    assert_equal([], candidate.call(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "rb",
-    "prompt": "# Write a function to flatten an array and sum all of its elements.\ndef recursive_list_sum(data_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_recursive_list_sum\n    candidate = method(:recursive_list_sum)\n    assert_equal(21, candidate.call([1, 2, [3, 4], [5, 6]]))\n    assert_equal(106, candidate.call([7, 10, [15, 14], [19, 41]]))\n    assert_equal(210, candidate.call([10, 20, [30, 40], [50, 60]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the two numbers differ at one bit position only or not.\ndef differ_At_One_Bit_Pos(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_differ_At_One_Bit_Pos\n    candidate = method(:differ_At_One_Bit_Pos)\n    assert_equal(true, candidate.call(13, 9))\n    assert_equal(false, candidate.call(15, 8))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(2, 3))\n    assert_equal(true, candidate.call(5, 1))\n    assert_equal(true, candidate.call(1, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ndef text_match_three(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_three\n    candidate = method(:text_match_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"caacabbbba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\ndef max_product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product\n    candidate = method(:max_product)\n    assert_equal(3000, candidate.call([3, 100, 4, 5, 150, 6]))\n    assert_equal(50265600, candidate.call([4, 42, 55, 68, 80]))\n    assert_equal(2460, candidate.call([10, 22, 9, 33, 21, 50, 41, 60]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to split an array at the nth eelment and add the first part to the end.\ndef split_Arr(l, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_Arr\n    candidate = method(:split_Arr)\n    assert_equal([5, 6, 52, 36, 12, 10], candidate.call([12, 10, 5, 6, 52, 36], 2))\n    assert_equal([2, 3, 4, 1], candidate.call([1, 2, 3, 4], 1))\n    assert_equal([3, 4, 5, 6, 7, 0, 1, 2], candidate.call([0, 1, 2, 3, 4, 5, 6, 7], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the number of divisors of a given integer.\ndef divisor(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisor\n    candidate = method(:divisor)\n    assert_equal(4, candidate.call(15))\n    assert_equal(6, candidate.call(12))\n    assert_equal(3, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the difference between largest and smallest value in a given array.\ndef big_diff(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_diff\n    candidate = method(:big_diff)\n    assert_equal(3, candidate.call([1, 2, 3, 4]))\n    assert_equal(8, candidate.call([4, 5, 12]))\n    assert_equal(7, candidate.call([9, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rb",
-    "prompt": "# Write a function to find squares of individual elements in an array.\ndef square_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_nums\n    candidate = method(:square_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([100, 400, 900], candidate.call([10, 20, 30]))\n    assert_equal([144, 225], candidate.call([12, 15]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "rb",
-    "prompt": "# Write a function to check if the given array has any none value or not.\ndef check_none(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_none\n    candidate = method(:check_none)\n    assert_equal(true, candidate.call([10, 4, 5, 6, nil]))\n    assert_equal(false, candidate.call([7, 8, 9, 11, 14]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, nil]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given array is monotonic or not.\ndef is_Monotonic(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Monotonic\n    candidate = method(:is_Monotonic)\n    assert_equal(true, candidate.call([6, 5, 4, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3]))\n    assert_equal(false, candidate.call([1, 3, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\ndef is_perfect_square(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_perfect_square\n    candidate = method(:is_perfect_square)\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(36))\n    assert_equal(false, candidate.call(14))\n    assert_equal(true, candidate.call(196))\n    assert_equal(false, candidate.call(125))\n    assert_equal(true, candidate.call(15625))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of common divisors of two given numbers.\ndef sum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum\n    candidate = method(:sum)\n    assert_equal(6, candidate.call(10, 15))\n    assert_equal(93, candidate.call(100, 150))\n    assert_equal(3, candidate.call(4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rb",
-    "prompt": "# Write a function to find the array of maximum length in an array of arrays.\ndef max_length(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length\n    candidate = method(:max_length)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([4, [10, 12, 14, 15]], candidate.call([[1], [5, 7], [10, 12, 14, 15]]))\n    assert_equal([3, [15, 20, 25]], candidate.call([[5], [15, 20, 25]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array of arrays and returns a hash mapping each unique array to the number of times it occurs in the array.\ndef check_occurences(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_occurences\n    candidate = method(:check_occurences)\n    assert_equal({[1, 3] => 2, [2, 5] => 2, [3, 6] => 1}, candidate.call([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]))\n    assert_equal({[2, 4] => 2, [3, 6] => 2, [4, 7] => 1}, candidate.call([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]))\n    assert_equal({[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1}, candidate.call([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rb",
-    "prompt": "# Write a function to find the directrix of a parabola.\ndef parabola_directrix(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parabola_directrix\n    candidate = method(:parabola_directrix)\n    assert_equal(-198, candidate.call(5, 3, 2))\n    assert_equal(-2336, candidate.call(9, 8, 4))\n    assert_equal(-130, candidate.call(2, 4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rb",
-    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return nil if there is no match.\ndef occurance_substring(text, pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_occurance_substring\n    candidate = method(:occurance_substring)\n    assert_equal([\"python\", 0, 6], candidate.call(\"python programming, python language\", \"python\"))\n    assert_equal([\"programming\", 7, 18], candidate.call(\"python programming,programming language\", \"programming\"))\n    assert_equal([\"language\", 31, 39], candidate.call(\"python programming,programming language\", \"language\"))\n    assert_equal(nil, candidate.call(\"c++ programming, c++ language\", \"python\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "rb",
-    "prompt": "# Write a function to remove arrays from the given array.\ndef remove_nested(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_nested\n    candidate = method(:remove_nested)\n    assert_equal([1, 5, 7, 10], candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal([2, 6, 8, 11], candidate.call([2, 6, 8, [5, 7], 11]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], 12]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], [5, 12], 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rb",
-    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\ndef sort_sublists(input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]], candidate.call([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]))\n    assert_equal([[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]], candidate.call([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rb",
-    "prompt": "# Write a rbthon function which takes an array and returns an array with the same elements, but the k'th element removed.\ndef remove_kth_element(list1, l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_kth_element\n    candidate = method(:remove_kth_element)\n    assert_equal([1, 1, 3, 4, 4, 5, 1], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4))\n    assert_equal([10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to add a hash to the array. The output should be an array.\ndef add_dict_to_tuple(test_tup, test_dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_dict_to_tuple\n    candidate = method(:add_dict_to_tuple)\n    assert_equal([4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}], candidate.call([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}))\n    assert_equal([1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}], candidate.call([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}))\n    assert_equal([8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}], candidate.call([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find quotient of two numbers (rounded down to the nearest integer).\ndef find(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find\n    candidate = method(:find)\n    assert_equal(3, candidate.call(10, 3))\n    assert_equal(2, candidate.call(4, 2))\n    assert_equal(4, candidate.call(20, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rb",
-    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ndef text_match_two_three(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_two_three\n    candidate = method(:text_match_two_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the occurence of all elements of array in an array.\ndef count_Occurrence(tup, lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Occurrence\n    candidate = method(:count_Occurrence)\n    assert_equal(3, candidate.call([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]))\n    assert_equal(6, candidate.call([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6], [1, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rb",
-    "prompt": "# Write a function to count number items that are identical in the same position of three given arrays.\ndef count_samepair(list1, list2, list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_samepair\n    candidate = method(:count_samepair)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]))\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n    assert_equal(5, candidate.call([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rb",
-    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ndef text_match_one(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_one\n    candidate = method(:text_match_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abba\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndef difference(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_difference\n    candidate = method(:difference)\n    assert_equal(30, candidate.call(3))\n    assert_equal(210, candidate.call(5))\n    assert_equal(6, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rb",
-    "prompt": "# Write a function to toggle the case of all characters in a string.\ndef toggle_string(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_string\n    candidate = method(:toggle_string)\n    assert_equal(\"pYTHON\", candidate.call(\"Python\"))\n    assert_equal(\"pANGRAM\", candidate.call(\"Pangram\"))\n    assert_equal(\"liTTle\", candidate.call(\"LIttLE\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the element of an array having maximum length.\ndef Find_Max(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max\n    candidate = method(:Find_Max)\n    assert_equal([\"A\", \"B\", \"C\"], candidate.call([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]))\n    assert_equal([1, 2, 3], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 5, 6, 1], candidate.call([[1, 1], [1, 2, 3], [1, 5, 6, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the Eulerian number a(n, m).\ndef eulerian_num(n, m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eulerian_num\n    candidate = method(:eulerian_num)\n    assert_equal(4, candidate.call(3, 1))\n    assert_equal(11, candidate.call(4, 1))\n    assert_equal(26, candidate.call(5, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of occurrences of a number in a given array.\ndef frequency(a, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency\n    candidate = method(:frequency)\n    assert_equal(0, candidate.call([1, 2, 3], 4))\n    assert_equal(3, candidate.call([1, 2, 2, 3, 3, 3, 4], 3))\n    assert_equal(2, candidate.call([0, 1, 2, 3, 1, 2], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rb",
-    "prompt": "# Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/rbthon-sort-numeric-strings-in-a-array/\ndef sort_numeric_strings(nums_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numeric_strings\n    candidate = method(:sort_numeric_strings)\n    assert_equal([-500, -12, 0, 4, 7, 12, 45, 100, 200], candidate.call([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]))\n    assert_equal([1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9], candidate.call([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]))\n    assert_equal([1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17], candidate.call([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rbthon-exercises/data-structures-and-algorithms/rbthon-recursion-exercise-9.php\ndef geometric_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_geometric_sum\n    candidate = method(:geometric_sum)\n    assert_equal(1.9921875, candidate.call(7))\n    assert_equal(1.9375, candidate.call(4))\n    assert_equal(1.99609375, candidate.call(8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rb",
-    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rbthon-exercises/lambda/rbthon-lambda-exercise-24.php\ndef divisible_by_digits(startnum, endnum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisible_by_digits\n    candidate = method(:divisible_by_digits)\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22], candidate.call(1, 22))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15], candidate.call(1, 15))\n    assert_equal([22, 24], candidate.call(20, 25))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to calculate the product of the unique numbers in a given array.\ndef unique_product(list_data)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_product\n    candidate = method(:unique_product)\n    assert_equal(720000000, candidate.call([10, 20, 30, 40, 20, 50, 60, 40]))\n    assert_equal(6, candidate.call([1, 2, 3, 1]))\n    assert_equal(0, candidate.call([7, 8, 9, 0, 1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the largest negative number from the given array.\ndef largest_neg(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_neg\n    candidate = method(:largest_neg)\n    assert_equal(-6, candidate.call([1, 2, 3, -4, -6]))\n    assert_equal(-9, candidate.call([1, 2, 3, -8, -9]))\n    assert_equal(-1, candidate.call([1, 2, 3, 4, -1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "rb",
-    "prompt": "# Write a function to remove consecutive duplicates of a given array.\ndef consecutive_duplicates(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_consecutive_duplicates\n    candidate = method(:consecutive_duplicates)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([10, 15, 19, 18, 17, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\", \"a\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rb",
-    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\ndef min_Jumps(steps, d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Jumps\n    candidate = method(:min_Jumps)\n    assert_equal(3.5, candidate.call([3, 4], 11))\n    assert_equal(0, candidate.call([3, 4], 0))\n    assert_equal(1, candidate.call([11, 14], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find a pair with highest product from a given array of integers.\ndef max_Product(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Product\n    candidate = method(:max_Product)\n    assert_equal([7, 8], candidate.call([1, 2, 3, 4, 7, 0, 8, 4]))\n    assert_equal([-4, -6], candidate.call([0, -1, -2, -4, 5, 0, -6]))\n    assert_equal([2, 3], candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "rb",
-    "prompt": "# Write a function to extract the nth element from a given array of arrays.\ndef extract_nth_element(list1, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_nth_element\n    candidate = method(:extract_nth_element)\n    assert_equal([\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0))\n    assert_equal([99, 96, 94, 98], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2))\n    assert_equal([98, 97, 91, 94], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth nonagonal number.\ndef is_nonagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nonagonal\n    candidate = method(:is_nonagonal)\n    assert_equal(325, candidate.call(10))\n    assert_equal(750, candidate.call(15))\n    assert_equal(1089, candidate.call(18))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the maximum difference between any two elements in a given array.\ndef max_Abs_Diff(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Abs_Diff\n    candidate = method(:max_Abs_Diff)\n    assert_equal(4, candidate.call([2, 1, 5, 3]))\n    assert_equal(8, candidate.call([9, 3, 2, 5, 1]))\n    assert_equal(2, candidate.call([3, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "rb",
-    "prompt": "# Write a function to pack consecutive duplicates of a given array elements into subarrays.\ndef pack_consecutive_duplicates(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pack_consecutive_duplicates\n    candidate = method(:pack_consecutive_duplicates)\n    assert_equal([[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum of perrin numbers.\ndef cal_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cal_sum\n    candidate = method(:cal_sum)\n    assert_equal(49, candidate.call(9))\n    assert_equal(66, candidate.call(10))\n    assert_equal(88, candidate.call(11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to remove the characters which have odd index values of a given string.\ndef odd_values_string(str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_values_string\n    candidate = method(:odd_values_string)\n    assert_equal(\"ace\", candidate.call(\"abcdef\"))\n    assert_equal(\"pto\", candidate.call(\"python\"))\n    assert_equal(\"dt\", candidate.call(\"data\"))\n    assert_equal(\"lms\", candidate.call(\"lambs\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rb",
-    "prompt": "# Write a function to find kth element from the given two sorted arrays.\ndef find_kth(arr1, arr2, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_kth\n    candidate = method(:find_kth)\n    assert_equal(6, candidate.call([2, 3, 6, 7, 9], [1, 4, 8, 10], 5))\n    assert_equal(256, candidate.call([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7))\n    assert_equal(8, candidate.call([3, 4, 7, 8, 10], [2, 5, 9, 11], 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\ndef jacobsthal_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_jacobsthal_num\n    candidate = method(:jacobsthal_num)\n    assert_equal(11, candidate.call(5))\n    assert_equal(1, candidate.call(2))\n    assert_equal(5, candidate.call(4))\n    assert_equal(2731, candidate.call(13))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rb",
-    "prompt": "# Write a function to find frequency of each element in a flattened array of arrays, returned in a hash.\ndef frequency_lists(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency_lists\n    candidate = method(:frequency_lists)\n    assert_equal({1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1}, candidate.call([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]))\n    assert_equal({1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1}, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]))\n    assert_equal({20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1}, candidate.call([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rb",
-    "prompt": "# Write a function to find perfect squares between two given numbers.\ndef perfect_squares(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perfect_squares\n    candidate = method(:perfect_squares)\n    assert_equal([1, 4, 9, 16, 25], candidate.call(1, 30))\n    assert_equal([64, 81, 100], candidate.call(50, 100))\n    assert_equal([100, 121, 144, 169, 196], candidate.call(100, 200))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\ndef sum_Of_Subarray_Prod(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_Subarray_Prod\n    candidate = method(:sum_Of_Subarray_Prod)\n    assert_equal(20, candidate.call([1, 2, 3]))\n    assert_equal(5, candidate.call([1, 2]))\n    assert_equal(84, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the first odd number in a given array of numbers.\ndef first_odd(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_odd\n    candidate = method(:first_odd)\n    assert_equal(1, candidate.call([1, 3, 5]))\n    assert_equal(1, candidate.call([2, 4, 1, 3]))\n    assert_equal(9, candidate.call([8, 9, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rb",
-    "prompt": "# Write a function to perform index wise addition of array elements in the given two nested arrays.\ndef add_nested_tuples(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_nested_tuples\n    candidate = method(:add_nested_tuples)\n    assert_equal([[7, 10], [7, 14], [3, 10], [8, 13]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[9, 12], [9, 16], [5, 12], [10, 15]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[11, 14], [11, 18], [7, 14], [12, 17]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "rb",
-    "prompt": "# Write a rbthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\ndef merge(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge\n    candidate = method(:merge)\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]], candidate.call([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]))\n    assert_equal([[1, 3, 5, 7], [2, 4, 6, 8]], candidate.call([[1, 2], [3, 4], [5, 6], [7, 8]]))\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]], candidate.call([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given number can be represented as the difference of two squares or not.\ndef dif_Square(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dif_Square\n    candidate = method(:dif_Square)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rb",
-    "prompt": "# Write a function to check if each element of second array is smaller than its corresponding element in the first array.\ndef check_smaller(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_smaller\n    candidate = method(:check_smaller)\n    assert_equal(false, candidate.call([1, 2, 3], [2, 3, 4]))\n    assert_equal(true, candidate.call([4, 5, 6], [3, 4, 5]))\n    assert_equal(true, candidate.call([11, 12, 13], [10, 11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rb",
-    "prompt": "# Write a function to get the frequency of all the elements in an array, returned as a hash.\ndef freq_count(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_freq_count\n    candidate = method(:freq_count)\n    assert_equal({10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1}, candidate.call([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]))\n    assert_equal({1 => 3, 2 => 2, 3 => 3, 4 => 3}, candidate.call([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]))\n    assert_equal({10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2}, candidate.call([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rb",
-    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\ndef rgb_to_hsv(r, g, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rgb_to_hsv\n    candidate = method(:rgb_to_hsv)\n    assert_equal([0.0, 0.0, 100.0], candidate.call(255, 255, 255))\n    assert_equal([120.0, 100.0, 84.31372549019608], candidate.call(0, 215, 0))\n    assert_equal([149.26829268292684, 95.34883720930233, 84.31372549019608], candidate.call(10, 215, 110))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "rb",
-    "prompt": "# Write a function to flatten a given nested array structure.\ndef flatten_list(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flatten_list\n    candidate = method(:flatten_list)\n    assert_equal([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120], candidate.call([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]))\n    assert_equal([10, 20, 40, 30, 56, 25, 10, 20, 33, 40], candidate.call([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]))\n    assert_equal([1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ndef check_str(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_str\n    candidate = method(:check_str)\n    assert_equal(true, candidate.call(\"annie\"))\n    assert_equal(false, candidate.call(\"dawood\"))\n    assert_equal(true, candidate.call(\"Else\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ndef check_monthnumber_number(monthnum3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumber_number\n    candidate = method(:check_monthnumber_number)\n    assert_equal(true, candidate.call(6))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rb",
-    "prompt": "# Write a function to sort the given array.\ndef heap_sort(iterable)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_sort\n    candidate = method(:heap_sort)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]))\n    assert_equal([14, 22, 25, 25, 35, 58, 65, 75, 85], candidate.call([25, 35, 22, 85, 14, 65, 75, 25, 58]))\n    assert_equal([1, 5, 7, 9], candidate.call([7, 1, 9, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rb",
-    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\ndef k_smallest_pairs(nums1, nums2, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_k_smallest_pairs\n    candidate = method(:k_smallest_pairs)\n    assert_equal([[1, 2], [1, 4]], candidate.call([1, 3, 7], [2, 4, 6], 2))\n    assert_equal([[1, 2]], candidate.call([1, 3, 7], [2, 4, 6], 1))\n    assert_equal([[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]], candidate.call([1, 3, 7], [2, 4, 6], 7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rb",
-    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as an array, or return nil if no solution exists.\ndef find_solution(a, b, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_solution\n    candidate = method(:find_solution)\n    assert_equal([2, 1], candidate.call(2, 3, 7))\n    assert_equal(nil, candidate.call(4, 2, 7))\n    assert_equal([4, 1], candidate.call(1, 13, 17))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the largest number that can be formed with the given array of digits.\ndef find_Max_Num(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Max_Num\n    candidate = method(:find_Max_Num)\n    assert_equal(321, candidate.call([1, 2, 3]))\n    assert_equal(6541, candidate.call([4, 5, 6, 1]))\n    assert_equal(9321, candidate.call([1, 2, 3, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rb",
-    "prompt": "# Write a function that returns the array in an array of arrays whose sum of elements is the highest.\ndef max_sum_list(lists)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_list\n    candidate = method(:max_sum_list)\n    assert_equal([10, 11, 12], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n    assert_equal([12, 11, 10], candidate.call([[3, 2, 1], [6, 5, 4], [12, 11, 10]]))\n    assert_equal([2, 3, 1], candidate.call([[2, 3, 1]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to interchange the first and last elements in an array.\ndef swap_List(newlist)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([24, 35, 9, 56, 12], candidate.call([12, 35, 9, 56, 24]))\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rb",
-    "prompt": "# Write a function to find the median of two sorted arrays of same size.\ndef get_median(arr1, arr2, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_median\n    candidate = method(:get_median)\n    assert_equal(16.0, candidate.call([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5))\n    assert_equal(8.5, candidate.call([2, 4, 8, 9], [7, 13, 19, 28], 4))\n    assert_equal(25.0, candidate.call([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\ndef replace_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"Jumanji_The_Jungle\", candidate.call(\"Jumanji The Jungle\"))\n    assert_equal(\"The Avengers\", candidate.call(\"The_Avengers\"))\n    assert_equal(\"Fast_and_Furious\", candidate.call(\"Fast and Furious\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rb",
-    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\ndef are_equivalent(num1, num2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_are_equivalent\n    candidate = method(:are_equivalent)\n    assert_equal(false, candidate.call(36, 57))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(23, 47))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rb",
-    "prompt": "# Write a function to reverse each string in a given array of string values.\ndef reverse_string_list(stringlist)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_string_list\n    candidate = method(:reverse_string_list)\n    assert_equal([\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"], candidate.call([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]))\n    assert_equal([\"nhoj\", \"lama\", \"leoj\", \"egroeg\"], candidate.call([\"john\", \"amal\", \"joel\", \"george\"]))\n    assert_equal([\"kcaj\", \"nhoj\", \"yram\"], candidate.call([\"jack\", \"john\", \"mary\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "rb",
-    "prompt": "# Write a function to compute the sum of digits of each number of a given array.\ndef sum_of_digits(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_of_digits\n    candidate = method(:sum_of_digits)\n    assert_equal(14, candidate.call([10, 2, 56]))\n    assert_equal(19, candidate.call([[10, 20, 4, 5, \"b\", 70, \"a\"]]))\n    assert_equal(19, candidate.call([10, 20, -4, 5, -70]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth number in the newman conway sequence.\ndef sequence(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequence\n    candidate = method(:sequence)\n    assert_equal(6, candidate.call(10))\n    assert_equal(1, candidate.call(2))\n    assert_equal(2, candidate.call(3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rb",
-    "prompt": "# Write a function to find the n largest integers from a given array of numbers, returned in descending order.\ndef heap_queue_largest(nums, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_queue_largest\n    candidate = method(:heap_queue_largest)\n    assert_equal([85, 75, 65], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 3))\n    assert_equal([85, 75], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 2))\n    assert_equal([85, 75, 65, 58, 35], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rb",
-    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\ndef loss_amount(actual_cost, sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_loss_amount\n    candidate = method(:loss_amount)\n    assert_equal(0, candidate.call(1500, 1200))\n    assert_equal(100, candidate.call(100, 200))\n    assert_equal(3000, candidate.call(2000, 5000))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rb",
-    "prompt": "# Write a function to find the union of the elements of two given arrays and output them in sorted order.\ndef union_elements(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_union_elements\n    candidate = method(:union_elements)\n    assert_equal([3, 4, 5, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 2, 3, 4, 5, 6], candidate.call([1, 2, 3, 4], [3, 4, 5, 6]))\n    assert_equal([11, 12, 13, 14, 15, 16, 17], candidate.call([11, 12, 13, 14], [13, 15, 16, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the length of the longest subarrays.\ndef Find_Max_Length(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max_Length\n    candidate = method(:Find_Max_Length)\n    assert_equal(4, candidate.call([[1], [1, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[0, 1], [2, 2], [3, 2, 1]]))\n    assert_equal(5, candidate.call([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rb",
-    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\ndef remove_parenthesis(items)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_parenthesis\n    candidate = method(:remove_parenthesis)\n    assert_equal(\"python\", candidate.call([\"python (chrome)\"]))\n    assert_equal(\"string\", candidate.call([\"string(.abc)\"]))\n    assert_equal(\"alpha\", candidate.call([\"alpha(num)\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find whether the parity of a given number is odd.\ndef find_Parity(x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Parity\n    candidate = method(:find_Parity)\n    assert_equal(false, candidate.call(12))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rb",
-    "prompt": "# Write a function to find the median length of a trapezium.\ndef median_trapezium(base1, base2, height)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_trapezium\n    candidate = method(:median_trapezium)\n    assert_equal(20, candidate.call(15, 25, 35))\n    assert_equal(15, candidate.call(10, 20, 30))\n    assert_equal(7.5, candidate.call(6, 9, 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rb",
-    "prompt": "# Write a function to find nth centered hexagonal number.\ndef centered_hexagonal_number(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_centered_hexagonal_number\n    candidate = method(:centered_hexagonal_number)\n    assert_equal(271, candidate.call(10))\n    assert_equal(7, candidate.call(2))\n    assert_equal(217, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "rb",
-    "prompt": "# Write a function to find number of arrays present in the given array.\ndef find_lists(input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lists\n    candidate = method(:find_lists)\n    assert_equal(2, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[1, 2], [3, 4], [5, 6]]))\n    assert_equal(1, candidate.call([9, 8, 7, 6, 5, 4, 3, 2, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\ndef get_max_sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_sum\n    candidate = method(:get_max_sum)\n    assert_equal(106, candidate.call(60))\n    assert_equal(12, candidate.call(10))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the length of the longest word.\ndef len_log(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_len_log\n    candidate = method(:len_log)\n    assert_equal(7, candidate.call([\"python\", \"PHP\", \"bigdata\"]))\n    assert_equal(3, candidate.call([\"a\", \"ab\", \"abc\"]))\n    assert_equal(5, candidate.call([\"small\", \"big\", \"tall\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rb",
-    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nil if the angle is larger than 360 degrees.\ndef sector_area(r, a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sector_area\n    candidate = method(:sector_area)\n    assert_equal(6.283185307179586, candidate.call(4, 45))\n    assert_equal(31.808625617596654, candidate.call(9, 45))\n    assert_equal(nil, candidate.call(9, 361))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether every odd index contains odd numbers of a given array.\ndef odd_position(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_position\n    candidate = method(:odd_position)\n    assert_equal(true, candidate.call([2, 1, 4, 3, 6, 7, 6, 3]))\n    assert_equal(true, candidate.call([4, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rb",
-    "prompt": "# Write a function to join an array of multiple integers into a single integer.\ndef multiple_to_single(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiple_to_single\n    candidate = method(:multiple_to_single)\n    assert_equal(113350, candidate.call([11, 33, 50]))\n    assert_equal(-123456, candidate.call([-1, 2, 3, 4, 5, 6]))\n    assert_equal(10152025, candidate.call([10, 15, 20, 25]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find whether a number is divisible by 11.\ndef is_Diff(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Diff\n    candidate = method(:is_Diff)\n    assert_equal(false, candidate.call(12345))\n    assert_equal(true, candidate.call(1212112))\n    assert_equal(false, candidate.call(1212))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rb",
-    "prompt": "# Write a function to perform index wise multiplication of array elements in the given two arrays.\ndef index_multiplication(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_multiplication\n    candidate = method(:index_multiplication)\n    assert_equal([[6, 21], [12, 45], [2, 9], [7, 30]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[14, 32], [20, 60], [6, 20], [16, 44]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[24, 45], [30, 77], [12, 33], [27, 60]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rb",
-    "prompt": "# Write a function to convert array string to integer array.\ndef tuple_str_int(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_str_int\n    candidate = method(:tuple_str_int)\n    assert_equal([7, 8, 9], candidate.call(\"(7, 8, 9)\"))\n    assert_equal([1, 2, 3], candidate.call(\"(1, 2, 3)\"))\n    assert_equal([4, 5, 6], candidate.call(\"(4, 5, 6)\"))\n    assert_equal([7, 81, 19], candidate.call(\"(7, 81, 19)\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rb",
-    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\ndef amicable_numbers_sum(limit)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_amicable_numbers_sum\n    candidate = method(:amicable_numbers_sum)\n    assert_equal(504, candidate.call(999))\n    assert_equal(31626, candidate.call(9999))\n    assert_equal(0, candidate.call(99))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rb",
-    "prompt": "# Write a function to remove odd characters in a string.\ndef remove_odd(str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal(\"yhn\", candidate.call(\"python\"))\n    assert_equal(\"rga\", candidate.call(\"program\"))\n    assert_equal(\"agae\", candidate.call(\"language\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "rb",
-    "prompt": "# Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\ndef multiply_elements(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_elements\n    candidate = method(:multiply_elements)\n    assert_equal([5, 35, 56, 80], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 20, 30, 42], candidate.call([2, 4, 5, 6, 7]))\n    assert_equal([156, 182, 126, 135], candidate.call([12, 13, 14, 9, 15]))\n    assert_equal([], candidate.call([12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ndef count_rotation(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_rotation\n    candidate = method(:count_rotation)\n    assert_equal(1, candidate.call([3, 2, 1]))\n    assert_equal(2, candidate.call([4, 5, 1, 2, 3]))\n    assert_equal(3, candidate.call([7, 8, 9, 1, 2, 3]))\n    assert_equal(0, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 3, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rb",
-    "prompt": "# Write a function to extract the number of unique arrays in the given array.\ndef extract_freq(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_freq\n    candidate = method(:extract_freq)\n    assert_equal(3, candidate.call([[3, 4], [1, 2], [4, 3], [5, 6]]))\n    assert_equal(4, candidate.call([[4, 15], [2, 3], [5, 4], [6, 7]]))\n    assert_equal(4, candidate.call([[5, 16], [2, 3], [6, 5], [6, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rb",
-    "prompt": "# The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\ndef count_same_pair(nums1, nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_same_pair\n    candidate = method(:count_same_pair)\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]))\n    assert_equal(11, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(1, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(3, candidate.call([0, 1, 1, 2], [0, 1, 2, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\ndef power(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power\n    candidate = method(:power)\n    assert_equal(81, candidate.call(3, 4))\n    assert_equal(8, candidate.call(2, 3))\n    assert_equal(3125, candidate.call(5, 5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rb",
-    "prompt": "# Write function to find the sum of all items in the given hash.\ndef return_sum(dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_return_sum\n    candidate = method(:return_sum)\n    assert_equal(600, candidate.call({\"a\" => 100, \"b\" => 200, \"c\" => 300}))\n    assert_equal(88, candidate.call({\"a\" => 25, \"b\" => 18, \"c\" => 45}))\n    assert_equal(124, candidate.call({\"a\" => 36, \"b\" => 39, \"c\" => 49}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rb",
-    "prompt": "# Write a function to return an array of all pairs of consecutive items in a given array.\ndef pair_wise(l1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_wise\n    candidate = method(:pair_wise)\n    assert_equal([[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]], candidate.call([1, 1, 2, 3, 3, 4, 4, 5]))\n    assert_equal([[1, 5], [5, 7], [7, 9], [9, 10]], candidate.call([1, 5, 7, 9, 10]))\n    assert_equal([[5, 1], [1, 9], [9, 7], [7, 10]], candidate.call([5, 1, 9, 7, 10]))\n    assert_equal([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to split a string into characters.\ndef split(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split\n    candidate = method(:split)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], candidate.call(\"python\"))\n    assert_equal([\"N\", \"a\", \"m\", \"e\"], candidate.call(\"Name\"))\n    assert_equal([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"], candidate.call(\"program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rb",
-    "prompt": "# Write a function to find minimum of three numbers.\ndef min_of_three(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_of_three\n    candidate = method(:min_of_three)\n    assert_equal(0, candidate.call(10, 20, 0))\n    assert_equal(15, candidate.call(19, 15, 18))\n    assert_equal(-30, candidate.call(-10, -20, -30))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\ndef is_Sum_Of_Powers_Of_Two(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sum_Of_Powers_Of_Two\n    candidate = method(:is_Sum_Of_Powers_Of_Two)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(7))\n    assert_equal(true, candidate.call(14))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\ndef get_Char(strr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Char\n    candidate = method(:get_Char)\n    assert_equal(\"f\", candidate.call(\"abc\"))\n    assert_equal(\"t\", candidate.call(\"gfg\"))\n    assert_equal(\"c\", candidate.call(\"ab\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rb",
-    "prompt": "# Write a function to return the sum of all divisors of a number.\ndef sum_div(number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_div\n    candidate = method(:sum_div)\n    assert_equal(7, candidate.call(8))\n    assert_equal(16, candidate.call(12))\n    assert_equal(1, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "rb",
-    "prompt": "# Write a rbthon function that returns the number of integer elements in a given array.\ndef count_integer(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_integer\n    candidate = method(:count_integer)\n    assert_equal(2, candidate.call([1, 2, \"abc\", 1.2]))\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 1.2, 4, 5.1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to remove duplicate numbers from a given number of arrays.\ndef two_unique_nums(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_two_unique_nums\n    candidate = method(:two_unique_nums)\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 3, 4, 5]))\n    assert_equal([1, 3, 4, 5], candidate.call([1, 2, 3, 2, 4, 5]))\n    assert_equal([1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rb",
-    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ndef test_duplicate(arraynums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_duplicate\n    candidate = method(:test_duplicate)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 4]))\n    assert_equal(true, candidate.call([1, 1, 2, 2, 3, 3, 4, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rb",
-    "prompt": "# Write a function which returns nth catalan number.\ndef catalan_number(num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_catalan_number\n    candidate = method(:catalan_number)\n    assert_equal(16796, candidate.call(10))\n    assert_equal(4862, candidate.call(9))\n    assert_equal(429, candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rb",
-    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\ndef power_base_sum(base, power)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power_base_sum\n    candidate = method(:power_base_sum)\n    assert_equal(115, candidate.call(2, 100))\n    assert_equal(37, candidate.call(8, 10))\n    assert_equal(62, candidate.call(8, 15))\n    assert_equal(9, candidate.call(3, 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "rb",
-    "prompt": "# Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\ndef replace_list(list1, list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_list\n    candidate = method(:replace_list)\n    assert_equal([1, 3, 5, 7, 9, 2, 4, 6, 8], candidate.call([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8]))\n    assert_equal([\"red\", \"blue\", \"yellow\"], candidate.call([\"red\", \"blue\", \"green\"], [\"yellow\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth octagonal number.\ndef is_octagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_octagonal\n    candidate = method(:is_octagonal)\n    assert_equal(65, candidate.call(5))\n    assert_equal(280, candidate.call(10))\n    assert_equal(645, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rb",
-    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\ndef replace_blank(str1, char)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_blank\n    candidate = method(:replace_blank)\n    assert_equal(\"hello@people\", candidate.call(\"hello people\", \"@\"))\n    assert_equal(\"python$program$language\", candidate.call(\"python program language\", \"$\"))\n    assert_equal(\"blank-space\", candidate.call(\"blank space\", \"-\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rb",
-    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\ndef replace_specialchar(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_specialchar\n    candidate = method(:replace_specialchar)\n    assert_equal(\"Python:language::Programming:language:\", candidate.call(\"Python language, Programming language.\"))\n    assert_equal(\"a:b:c:d:e:f\", candidate.call(\"a b c,d e f\"))\n    assert_equal(\"ram:reshma:ram:rahim\", candidate.call(\"ram reshma,ram rahim\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rb",
-    "prompt": "# Write a function to convert a given array of positive integers into a single integer.\ndef tuple_to_int(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_int\n    candidate = method(:tuple_to_int)\n    assert_equal(123, candidate.call([1, 2, 3]))\n    assert_equal(456, candidate.call([4, 5, 6]))\n    assert_equal(567, candidate.call([5, 6, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rb",
-    "prompt": "# Write a function to find the third side of a right angled triangle.\ndef otherside_rightangle(w, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_otherside_rightangle\n    candidate = method(:otherside_rightangle)\n    assert_equal(10.63014581273465, candidate.call(7, 8))\n    assert_equal(5, candidate.call(3, 4))\n    assert_equal(16.55294535724685, candidate.call(7, 15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "rb",
-    "prompt": "# Write a function to find the n most expensive items in a given dataset.\ndef expensive_items(items, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_expensive_items\n    candidate = method(:expensive_items)\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of the per-digit difference between two integers.\ndef digit_distance_nums(n1, n2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digit_distance_nums\n    candidate = method(:digit_distance_nums)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(6, candidate.call(23, 56))\n    assert_equal(7, candidate.call(123, 256))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rb",
-    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ndef text_match_wordz_middle(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz_middle\n    candidate = method(:text_match_wordz_middle)\n    assert_equal(true, candidate.call(\"pythonzabc.\"))\n    assert_equal(false, candidate.call(\"zxyabc.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rb",
-    "prompt": "# Write a function to remove leading zeroes from an ip address.\ndef removezero_ip(ip)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_removezero_ip\n    candidate = method(:removezero_ip)\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.196\"))\n    assert_equal(\"12.1.24\", candidate.call(\"12.01.024\"))\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.0196\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "rb",
-    "prompt": "# Write a function to count the number of subarrays containing a particular element.\ndef count_element_in_list(list1, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_element_in_list\n    candidate = method(:count_element_in_list)\n    assert_equal(3, candidate.call([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1))\n    assert_equal(3, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"))\n    assert_equal(1, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rb",
-    "prompt": "# Write a function to multiply two integers.\ndef multiply_int(x, y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_int\n    candidate = method(:multiply_int)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(5, 10))\n    assert_equal(32, candidate.call(4, 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rb",
-    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given array.\ndef add_pairwise(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_pairwise\n    candidate = method(:add_pairwise)\n    assert_equal([6, 12, 15, 18], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 14, 17, 20], candidate.call([2, 6, 8, 9, 11]))\n    assert_equal([10, 16, 19, 22], candidate.call([3, 7, 9, 10, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\ndef max_product_tuple(list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product_tuple\n    candidate = method(:max_product_tuple)\n    assert_equal(36, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(200, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(484, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4429,7 +19,7 @@
     "language": "rb",
     "prompt": "# Write a function to find the kth element in the given array using 1-based indexing.\ndef kth_element(arr, k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_kth_element\n    candidate = method(:kth_element)\n    assert_equal(3, candidate.call([12, 3, 5, 7, 19], 2))\n    assert_equal(8, candidate.call([17, 24, 8, 23], 3))\n    assert_equal(36, candidate.call([16, 21, 25, 36, 4], 4))\n  end\nend\n",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rb",
-    "prompt": "# Write a rbthon function to interchange the first and last element in a given array.\ndef swap_List(newlist)\n",
+    "prompt": "# Write a function to convert a snake case string to camel case string.\ndef snake_to_camel(word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([4, 2, 3, 4, 1], candidate.call([1, 2, 3, 4, 4]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"PythonProgram\", candidate.call(\"python_program\"))\n    assert_equal(\"PythonLanguage\", candidate.call(\"python_language\"))\n    assert_equal(\"ProgrammingLanguage\", candidate.call(\"programming_language\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "rb",
-    "prompt": "# Write a function to find the number of elements that occurs before the array element in the given array.\ndef count_first_elements(test_tup)\n",
+    "prompt": "# Write a function to find the Eulerian number a(n, m).\ndef eulerian_num(n, m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_first_elements\n    candidate = method(:count_first_elements)\n    assert_equal(3, candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal(2, candidate.call([2, 9, [5, 7], 11]))\n    assert_equal(4, candidate.call([11, 15, 5, 8, [2, 3], 8]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_eulerian_num\n    candidate = method(:eulerian_num)\n    assert_equal(4, candidate.call(3, 1))\n    assert_equal(11, candidate.call(4, 1))\n    assert_equal(26, candidate.call(5, 3))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "rb",
-    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\ndef right_insertion(a, x)\n",
+    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\ndef sort_sublists(input_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_insertion\n    candidate = method(:right_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]], candidate.call([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]))\n    assert_equal([[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]], candidate.call([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "rb",
-    "prompt": "# Write a function to check if the given number is woodball or not.\ndef is_woodall(x)\n",
+    "prompt": "# Write a rbthon function to count true booleans in the given array.\ndef count(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_woodall\n    candidate = method(:is_woodall)\n    assert_equal(true, candidate.call(383))\n    assert_equal(false, candidate.call(254))\n    assert_equal(false, candidate.call(200))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count\n    candidate = method(:count)\n    assert_equal(2, candidate.call([true, false, true]))\n    assert_equal(0, candidate.call([false, false]))\n    assert_equal(3, candidate.call([true, true, true]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "rb",
-    "prompt": "# Write a function to sort the given array by using shell sort.\ndef shell_sort(my_list)\n",
+    "prompt": "# Write a function to append the given array to the given arrays.\ndef add_lists(test_list, test_tup)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_shell_sort\n    candidate = method(:shell_sort)\n    assert_equal([2, 3, 4, 5, 12, 12, 23, 56, 81, 95], candidate.call([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]))\n    assert_equal([22, 24, 34, 39, 68, 73, 87], candidate.call([24, 22, 39, 34, 87, 73, 68]))\n    assert_equal([16, 30, 32, 74, 82, 83, 96], candidate.call([32, 30, 16, 96, 82, 83, 74]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_lists\n    candidate = method(:add_lists)\n    assert_equal([9, 10, 5, 6, 7], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([10, 11, 6, 7, 8], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([11, 12, 7, 8, 9], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of pairs whose xor value is odd.\ndef find_Odd_Pair(a, n)\n",
+    "prompt": "# Write a function to merge three arrays into a single sorted array.\ndef merge_sorted_list(num1, num2, num3)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Odd_Pair\n    candidate = method(:find_Odd_Pair)\n    assert_equal(6, candidate.call([5, 4, 7, 2, 1], 5))\n    assert_equal(12, candidate.call([7, 2, 8, 1, 0, 5, 11], 7))\n    assert_equal(2, candidate.call([1, 2, 3], 3))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_sorted_list\n    candidate = method(:merge_sorted_list)\n    assert_equal([4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233], candidate.call([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]))\n    assert_equal([1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12], candidate.call([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]))\n    assert_equal([1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85], candidate.call([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of all odd natural numbers within the range l and r.\ndef sum_in_range(l, r)\n",
+    "prompt": "# Write a rbthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\ndef odd_Equivalent(s, n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_in_range\n    candidate = method(:sum_in_range)\n    assert_equal(8, candidate.call(2, 5))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(40, candidate.call(7, 13))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_Equivalent\n    candidate = method(:odd_Equivalent)\n    assert_equal(3, candidate.call(\"011001\", 6))\n    assert_equal(4, candidate.call(\"11011\", 5))\n    assert_equal(2, candidate.call(\"1010\", 4))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "rb",
-    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\ndef square_perimeter(a)\n",
+    "prompt": "# Write a function to check if a string represents an integer or not.\ndef check_integer(text)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_perimeter\n    candidate = method(:square_perimeter)\n    assert_equal(40, candidate.call(10))\n    assert_equal(20, candidate.call(5))\n    assert_equal(16, candidate.call(4))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_integer\n    candidate = method(:check_integer)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"1\"))\n    assert_equal(true, candidate.call(\"12345\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rb",
-    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\ndef is_polite(n)\n",
+    "prompt": "# Write a function to convert a given array of positive integers into a single integer.\ndef tuple_to_int(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_polite\n    candidate = method(:is_polite)\n    assert_equal(11, candidate.call(7))\n    assert_equal(7, candidate.call(4))\n    assert_equal(13, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "rb",
-    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\ndef sum_series(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_series\n    candidate = method(:sum_series)\n    assert_equal(12, candidate.call(6))\n    assert_equal(30, candidate.call(10))\n    assert_equal(25, candidate.call(9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rb",
-    "prompt": "# Write a function to find the dissimilar elements in the given two arrays.\ndef find_dissimilar(test_tup1, test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_dissimilar\n    candidate = method(:find_dissimilar)\n    assert_equal([3, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 4, 7, 9], candidate.call([1, 2, 3, 4], [7, 2, 3, 9]))\n    assert_equal([34, 36, 11, 25], candidate.call([21, 11, 25, 26], [26, 34, 21, 36]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rb",
-    "prompt": "# Write a function to return two words from an array of words starting with letter 'p'.\ndef start_withp(words)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_start_withp\n    candidate = method(:start_withp)\n    assert_equal([\"Python\", \"PHP\"], candidate.call([\"Python PHP\", \"Java JavaScript\", \"c c++\"]))\n    assert_equal([\"Python\", \"Programming\"], candidate.call([\"Python Programming\", \"Java Programming\"]))\n    assert_equal([\"Pqrst\", \"Pqr\"], candidate.call([\"Pqrst Pqr\", \"qrstuv\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rb",
-    "prompt": "# Write a function to convert the given snake case string to camel case string.\ndef snake_to_camel(word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"AndroidTv\", candidate.call(\"android_tv\"))\n    assert_equal(\"GooglePixel\", candidate.call(\"google_pixel\"))\n    assert_equal(\"AppleWatch\", candidate.call(\"apple_watch\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rb",
-    "prompt": "# Write a function to find the volume of a cube given its side length.\ndef volume_cube(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_volume_cube\n    candidate = method(:volume_cube)\n    assert_equal(27, candidate.call(3))\n    assert_equal(8, candidate.call(2))\n    assert_equal(125, candidate.call(5))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ndef check_monthnumb_number(monthnum2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumb_number\n    candidate = method(:check_monthnumb_number)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check whether all the bits are unset in the given range or not.\ndef all_Bits_Set_In_The_Given_Range(n, l, r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Bits_Set_In_The_Given_Range\n    candidate = method(:all_Bits_Set_In_The_Given_Range)\n    assert_equal(true, candidate.call(4, 1, 2))\n    assert_equal(true, candidate.call(17, 2, 4))\n    assert_equal(false, candidate.call(39, 4, 6))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to get the first element of each subarray.\ndef Extract(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Extract\n    candidate = method(:Extract)\n    assert_equal([1, 3, 6], candidate.call([[1, 2], [3, 4, 5], [6, 7, 8, 9]]))\n    assert_equal([1, 4], candidate.call([[1, 2, 3], [4, 5]]))\n    assert_equal([9, 1], candidate.call([[9, 8, 1], [1, 2]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rb",
-    "prompt": "# Write a function to find the surface area of a cylinder.\ndef surfacearea_cylinder(r, h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cylinder\n    candidate = method(:surfacearea_cylinder)\n    assert_equal(942.45, candidate.call(10, 5))\n    assert_equal(226.18800000000002, candidate.call(4, 5))\n    assert_equal(351.848, candidate.call(4, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rb",
-    "prompt": "# Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\ndef sample_nam(sample_names)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sample_nam\n    candidate = method(:sample_nam)\n    assert_equal(16, candidate.call([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]))\n    assert_equal(10, candidate.call([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]))\n    assert_equal(6, candidate.call([\"abcd\", \"Python\", \"abba\", \"aba\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "rb",
-    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\ndef rearrange_bigger(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rearrange_bigger\n    candidate = method(:rearrange_bigger)\n    assert_equal(21, candidate.call(12))\n    assert_equal(false, candidate.call(10))\n    assert_equal(120, candidate.call(102))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rb",
-    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\ndef perimeter_pentagon(a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perimeter_pentagon\n    candidate = method(:perimeter_pentagon)\n    assert_equal(25, candidate.call(5))\n    assert_equal(50, candidate.call(10))\n    assert_equal(75, candidate.call(15))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rb",
-    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\ndef max_sum(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum\n    candidate = method(:max_sum)\n    assert_equal(194, candidate.call([1, 15, 51, 45, 33, 100, 12, 18, 9]))\n    assert_equal(210, candidate.call([80, 60, 30, 40, 20, 10]))\n    assert_equal(138, candidate.call([2, 3, 14, 16, 21, 23, 29, 30]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "rb",
-    "prompt": "# Write a function to remove uneven elements in the nested mixed array.\ndef extract_even(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_even\n    candidate = method(:extract_even)\n    assert_equal([4, [6, [2, 4]], 6, 8], candidate.call([4, 5, [7, 6, [2, 4]], 6, 8]))\n    assert_equal([6, [8, [4, 8]]], candidate.call([5, 6, [8, 7, [4, 8]], 7, 9]))\n    assert_equal([6, [8, [4, 6]], 8, 10], candidate.call([5, 6, [9, 8, [4, 6]], 8, 10]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_int\n    candidate = method(:tuple_to_int)\n    assert_equal(123, candidate.call([1, 2, 3]))\n    assert_equal(456, candidate.call([4, 5, 6]))\n    assert_equal(567, candidate.call([5, 6, 7]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -4789,249 +169,9 @@
     "language": "rb",
     "prompt": "# Write a function to convert all possible convertible elements in an array of arrays to floats.\ndef list_to_float(test_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_to_float\n    candidate = method(:list_to_float)\n    assert_equal([[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]], candidate.call([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]))\n    assert_equal([[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]], candidate.call([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]))\n    assert_equal([[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]], candidate.call([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\ndef square_Sum(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(20, candidate.call(2))\n    assert_equal(56, candidate.call(3))\n    assert_equal(120, candidate.call(4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\ndef get_pairs_count(arr, sum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_pairs_count\n    candidate = method(:get_pairs_count)\n    assert_equal(6, candidate.call([1, 1, 1, 1], 2))\n    assert_equal(3, candidate.call([1, 5, 7, -1, 5], 6))\n    assert_equal(1, candidate.call([1, -2, 3], 1))\n    assert_equal(1, candidate.call([-1, -2, 3], -3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rb",
-    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ndef count_no_of_ways(n, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_no_of_ways\n    candidate = method(:count_no_of_ways)\n    assert_equal(16, candidate.call(2, 4))\n    assert_equal(6, candidate.call(3, 2))\n    assert_equal(228, candidate.call(4, 4))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rb",
-    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\ndef reverse_words(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_words\n    candidate = method(:reverse_words)\n    assert_equal(\"program python\", candidate.call(\"python program\"))\n    assert_equal(\"language java\", candidate.call(\"java language\"))\n    assert_equal(\"man indian\", candidate.call(\"indian man\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to check if a given number is one less than twice its reverse.\ndef checks(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_checks\n    candidate = method(:checks)\n    assert_equal(false, candidate.call(70))\n    assert_equal(false, candidate.call(23))\n    assert_equal(true, candidate.call(73))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the last position of an element in a sorted array.\ndef last(arr, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last\n    candidate = method(:last)\n    assert_equal(0, candidate.call([1, 2, 3], 1))\n    assert_equal(2, candidate.call([1, 1, 1, 2, 3, 4], 1))\n    assert_equal(3, candidate.call([2, 3, 2, 3, 6, 8, 9], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rb",
-    "prompt": "# Write a rbthon function that takes in an array and an element and counts the occcurences of the element in the array.\ndef count_X(tup, x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_X\n    candidate = method(:count_X)\n    assert_equal(0, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4))\n    assert_equal(3, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10))\n    assert_equal(4, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "rb",
-    "prompt": "# We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\ndef extract_index_list(l1, l2, l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_index_list\n    candidate = method(:extract_index_list)\n    assert_equal([1, 7], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([1, 6], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]))\n    assert_equal([1, 5], candidate.call([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([], candidate.call([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "rb",
-    "prompt": "# Write a function to find the second smallest number in an array.\ndef second_smallest(numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_second_smallest\n    candidate = method(:second_smallest)\n    assert_equal(-2, candidate.call([1, 2, -8, -2, 0, -2]))\n    assert_equal(-0.5, candidate.call([1, 1, -0.5, 0, 2, -2, -2]))\n    assert_equal(nil, candidate.call([2, 2]))\n    assert_equal(nil, candidate.call([2, 2, 2]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to concatenate each element of array by the delimiter.\ndef concatenate_tuple(test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate_tuple\n    candidate = method(:concatenate_tuple)\n    assert_equal(\"ID-is-4-UTS\", candidate.call([\"ID\", \"is\", 4, \"UTS\"]))\n    assert_equal(\"QWE-is-4-RTY\", candidate.call([\"QWE\", \"is\", 4, \"RTY\"]))\n    assert_equal(\"ZEN-is-4-OP\", candidate.call([\"ZEN\", \"is\", 4, \"OP\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\ndef replace_spaces(string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"My%20Name%20is%20Dawood\", candidate.call(\"My Name is Dawood\"))\n    assert_equal(\"I%20am%20a%20Programmer\", candidate.call(\"I am a Programmer\"))\n    assert_equal(\"I%20love%20Coding\", candidate.call(\"I love Coding\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rb",
-    "prompt": "# Write a function to find the sum of numbers in an array within a range specified by two indices.\ndef sum_range_list(list1, m, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_range_list\n    candidate = method(:sum_range_list)\n    assert_equal(29, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10))\n    assert_equal(16, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7))\n    assert_equal(38, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rb",
-    "prompt": "# Write a function to merge three dictionaries into a single hash.\ndef merge_dictionaries_three(dict1, dict2, dict3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_dictionaries_three\n    candidate = method(:merge_dictionaries_three)\n    assert_equal({\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}))\n    assert_equal({\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}))\n    assert_equal({\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the minimum of two numbers.\ndef minimum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minimum\n    candidate = method(:minimum)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(-5, candidate.call(-5, -4))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum difference between available pairs in the given array array.\ndef max_difference(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_difference\n    candidate = method(:max_difference)\n    assert_equal(7, candidate.call([[3, 5], [1, 7], [10, 3], [1, 2]]))\n    assert_equal(15, candidate.call([[4, 6], [2, 17], [9, 13], [11, 12]]))\n    assert_equal(23, candidate.call([[12, 35], [21, 27], [13, 23], [41, 22]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find element at a given index after number of rotations.\ndef find_Element(arr, ranges, rotations, index)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Element\n    candidate = method(:find_Element)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1))\n    assert_equal(3, candidate.call([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5044,7 +184,7 @@
     "language": "rb",
     "prompt": "# Write a function to convert a string to an array of strings split on the space character.\ndef string_to_list(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_list\n    candidate = method(:string_to_list)\n    assert_equal([\"python\", \"programming\"], candidate.call(\"python programming\"))\n    assert_equal([\"lists\", \"tuples\", \"strings\"], candidate.call(\"lists tuples strings\"))\n    assert_equal([\"write\", \"a\", \"program\"], candidate.call(\"write a program\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "rb",
     "prompt": "# Write a rbthon function to find the element that appears only once in a sorted array.\ndef search(arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_search\n    candidate = method(:search)\n    assert_equal(3, candidate.call([1, 1, 2, 2, 3]))\n    assert_equal(8, candidate.call([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]))\n    assert_equal(1, candidate.call([1, 2, 2, 3, 3, 4, 4]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rb",
-    "prompt": "# Write a function to sort a hash by value.\ndef sort_counter(dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_counter\n    candidate = method(:sort_counter)\n    assert_equal([[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]], candidate.call({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}))\n    assert_equal([[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]], candidate.call({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}))\n    assert_equal([[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]], candidate.call({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5089,7 +214,7 @@
     "language": "rb",
     "prompt": "# Write a rbthon function to remove first and last occurrence of a given character from the string.\ndef remove_Occ(s, ch)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_Occ\n    candidate = method(:remove_Occ)\n    assert_equal(\"heo\", candidate.call(\"hello\", \"l\"))\n    assert_equal(\"bcd\", candidate.call(\"abcda\", \"a\"))\n    assert_equal(\"H\", candidate.call(\"PHP\", \"P\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rb",
-    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\ndef lateralsurface_cube(l)\n",
+    "prompt": "# Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\ndef max_product_tuple(list1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cube\n    candidate = method(:lateralsurface_cube)\n    assert_equal(100, candidate.call(5))\n    assert_equal(324, candidate.call(9))\n    assert_equal(400, candidate.call(10))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product_tuple\n    candidate = method(:max_product_tuple)\n    assert_equal(36, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(200, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(484, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rb",
-    "prompt": "# Write a function that takes two arrays and returns true if they have at least one common element.\ndef common_element(list1, list2)\n",
+    "prompt": "# Write a function to sum all amicable numbers from 1 to a specified number.\ndef amicable_numbers_sum(limit)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common_element\n    candidate = method(:common_element)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]))\n    assert_equal(nil, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(true, candidate.call([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_amicable_numbers_sum\n    candidate = method(:amicable_numbers_sum)\n    assert_equal(504, candidate.call(999))\n    assert_equal(31626, candidate.call(9999))\n    assert_equal(0, candidate.call(99))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "rb",
-    "prompt": "# Write a function to append the given array to the given arrays.\ndef add_lists(test_list, test_tup)\n",
+    "prompt": "# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\ndef find_length(string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_lists\n    candidate = method(:add_lists)\n    assert_equal([9, 10, 5, 6, 7], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([10, 11, 6, 7, 8], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([11, 12, 7, 8, 9], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_length\n    candidate = method(:find_length)\n    assert_equal(6, candidate.call(\"11000010001\"))\n    assert_equal(1, candidate.call(\"10111\"))\n    assert_equal(2, candidate.call(\"11011101100101\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "rb",
-    "prompt": "# Write a function to compute the n-th power of each number in an array.\ndef nth_nums(nums, n)\n",
+    "prompt": "# Write a rbthon function to find the sum of common divisors of two given numbers.\ndef sum(a, b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_nth_nums\n    candidate = method(:nth_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30], 3))\n    assert_equal([248832, 759375], candidate.call([12, 15], 5))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum\n    candidate = method(:sum)\n    assert_equal(6, candidate.call(10, 15))\n    assert_equal(93, candidate.call(100, 150))\n    assert_equal(3, candidate.call(4, 6))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "rb",
-    "prompt": "# Write a function to sort an array of elements.\ndef pancake_sort(nums)\n",
+    "prompt": "# Write a function to multiply two integers.\ndef multiply_int(x, y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pancake_sort\n    candidate = method(:pancake_sort)\n    assert_equal([15, 25, 38, 69, 79], candidate.call([15, 79, 25, 38, 69]))\n    assert_equal([12, 36, 54, 85, 98], candidate.call([98, 12, 54, 36, 85]))\n    assert_equal([12, 23, 32, 41, 42], candidate.call([41, 42, 32, 12, 23]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "rb",
-    "prompt": "# Write a function to find the median of three numbers.\ndef median_numbers(a, b, c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_numbers\n    candidate = method(:median_numbers)\n    assert_equal(55.0, candidate.call(25, 55, 65))\n    assert_equal(20.0, candidate.call(20, 10, 30))\n    assert_equal(45.0, candidate.call(15, 45, 75))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ndef check_greater(arr, number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_greater\n    candidate = method(:check_greater)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], 4))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6], 8))\n    assert_equal(true, candidate.call([9, 7, 4, 8, 6, 1], 11))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\ndef check_element(list, element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_element\n    candidate = method(:check_element)\n    assert_equal(false, candidate.call([\"green\", \"orange\", \"black\", \"white\"], \"blue\"))\n    assert_equal(false, candidate.call([1, 2, 3, 4], 7))\n    assert_equal(true, candidate.call([\"green\", \"green\", \"green\", \"green\"], \"green\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rb",
-    "prompt": "# Write a function to extract specified size of strings from a given array of string values.\ndef extract_string(str, l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_string\n    candidate = method(:extract_string)\n    assert_equal([\"practice\", \"solution\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8))\n    assert_equal([\"Python\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6))\n    assert_equal([\"exercises\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rb",
-    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ndef text_lowercase_underscore(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_lowercase_underscore\n    candidate = method(:text_lowercase_underscore)\n    assert_equal(true, candidate.call(\"aab_cbbbc\"))\n    assert_equal(false, candidate.call(\"aab_Abbbc\"))\n    assert_equal(false, candidate.call(\"Aaab_abbbc\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to trim each array by k in the given arrays.\ndef trim_tuple(test_list, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_trim_tuple\n    candidate = method(:trim_tuple)\n    assert_equal([[2], [9], [2], [2]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2))\n    assert_equal([[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1))\n    assert_equal([[8, 4], [8, 12], [1, 7], [6, 9]], candidate.call([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the subarray having minimum length.\ndef Find_Min(lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min\n    candidate = method(:Find_Min)\n    assert_equal([1], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 1], candidate.call([[1, 1], [1, 1, 1], [1, 2, 7, 8]]))\n    assert_equal([\"x\"], candidate.call([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rb",
-    "prompt": "# Write a function to filter odd numbers.\ndef filter_oddnumbers(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_oddnumbers\n    candidate = method(:filter_oddnumbers)\n    assert_equal([1, 3, 5, 7, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([45, 67, 93], candidate.call([10, 20, 45, 67, 84, 93]))\n    assert_equal([5, 7, 9, 3], candidate.call([5, 7, 9, 8, 6, 4, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rb",
-    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\ndef find_adverbs(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverbs\n    candidate = method(:find_adverbs)\n    assert_equal(\"0-7: Clearly\", candidate.call(\"Clearly, he has no excuse for such behavior.\"))\n    assert_equal(\"28-36: carefuly\", candidate.call(\"Please handle the situation carefuly\"))\n    assert_equal(\"18-25: quickly\", candidate.call(\"Complete the task quickly\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rb",
-    "prompt": "# Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\ndef max_of_nth(test_list, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_of_nth\n    candidate = method(:max_of_nth)\n    assert_equal(19, candidate.call([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2))\n    assert_equal(10, candidate.call([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1))\n    assert_equal(11, candidate.call([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rb",
-    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndef decimal_to_binary(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"1000\", candidate.call(8))\n    assert_equal(\"10010\", candidate.call(18))\n    assert_equal(\"111\", candidate.call(7))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\ndef combinations_colors(l, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_colors\n    candidate = method(:combinations_colors)\n    assert_equal([[\"Red\"], [\"Green\"], [\"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 1))\n    assert_equal([[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 2))\n    assert_equal([[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 3))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rb",
-    "prompt": "# Write a function to remove all whitespaces from a string.\ndef remove_all_spaces(text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_all_spaces\n    candidate = method(:remove_all_spaces)\n    assert_equal(\"pythonprogram\", candidate.call(\"python  program\"))\n    assert_equal(\"pythonprogramminglanguage\", candidate.call(\"python   programming    language\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"python                     program\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"   python                     program\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\ndef min_Swaps(str1, str2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Swaps\n    candidate = method(:min_Swaps)\n    assert_equal(1, candidate.call(\"1101\", \"1110\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"000\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"110\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to create a new array from the given string and array.\ndef new_tuple(test_list, test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_new_tuple\n    candidate = method(:new_tuple)\n    assert_equal([\"WEB\", \"is\", \"best\"], candidate.call([\"WEB\", \"is\"], \"best\"))\n    assert_equal([\"We\", \"are\", \"Developers\"], candidate.call([\"We\", \"are\"], \"Developers\"))\n    assert_equal([\"Part\", \"is\", \"Wrong\"], candidate.call([\"Part\", \"is\"], \"Wrong\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the product of the array multiplication modulo n.\ndef find_remainder(arr, n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_remainder\n    candidate = method(:find_remainder)\n    assert_equal(9, candidate.call([100, 10, 5, 25, 35, 14], 11))\n    assert_equal(0, candidate.call([1, 1, 1], 1))\n    assert_equal(0, candidate.call([1, 2, 1], 2))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "rb",
-    "prompt": "# Write a function to find the minimum value in a given heterogeneous array.\ndef min_val(listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_val\n    candidate = method(:min_val)\n    assert_equal(2, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(15, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(20, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rb",
-    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\ndef positive_count(nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_positive_count\n    candidate = method(:positive_count)\n    assert_equal(0.54, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.69, candidate.call([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.56, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rb",
-    "prompt": "# Write a function to add the given array to the given array.\ndef add_tuple(test_list, test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_tuple\n    candidate = method(:add_tuple)\n    assert_equal([5, 6, 7, 9, 10], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([6, 7, 8, 10, 11], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([7, 8, 9, 11, 12], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rb",
-    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\ndef max_run_uppercase(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_run_uppercase\n    candidate = method(:max_run_uppercase)\n    assert_equal(5, candidate.call(\"GeMKSForGERksISBESt\"))\n    assert_equal(6, candidate.call(\"PrECIOusMOVemENTSYT\"))\n    assert_equal(4, candidate.call(\"GooGLEFluTTER\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rb",
-    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\ndef sort_matrix(m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_matrix\n    candidate = method(:sort_matrix)\n    assert_equal([[1, 1, 1], [1, 2, 3], [2, 4, 5]], candidate.call([[1, 2, 3], [2, 4, 5], [1, 1, 1]]))\n    assert_equal([[-2, 4, -5], [1, -1, 1], [1, 2, 3]], candidate.call([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]))\n    assert_equal([[2, 1, 4], [6, 4, 3], [5, 8, 9]], candidate.call([[5, 8, 9], [6, 4, 3], [2, 1, 4]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rb",
-    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ndef count_vowels(test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_vowels\n    candidate = method(:count_vowels)\n    assert_equal(7, candidate.call(\"bestinstareels\"))\n    assert_equal(12, candidate.call(\"partofthejourneyistheend\"))\n    assert_equal(5, candidate.call(\"amazonprime\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rb",
-    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\ndef max_sum_increasing_subseq(a, n, index, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_increasing_subseq\n    candidate = method(:max_sum_increasing_subseq)\n    assert_equal(11, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 4, 6))\n    assert_equal(7, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 2, 5))\n    assert_equal(71, candidate.call([11, 15, 19, 21, 26, 28, 31], 7, 2, 4))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_int\n    candidate = method(:multiply_int)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(5, 10))\n    assert_equal(32, candidate.call(4, 8))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5524,7 +304,7 @@
     "language": "rb",
     "prompt": "# Write a function to find words that are longer than n characters from a given array of words.\ndef long_words(n, str)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_long_words\n    candidate = method(:long_words)\n    assert_equal([\"python\", \"programming\", \"language\"], candidate.call(3, \"python is a programming language\"))\n    assert_equal([\"writing\", \"program\"], candidate.call(2, \"writing a program\"))\n    assert_equal([\"sorting\"], candidate.call(5, \"sorting list\"))\n  end\nend\n",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of non-repeated elements in a given array.\ndef find_sum(arr)\n",
+    "prompt": "# Write a function to calculate whether the matrix is a magic square.\ndef magic_square_test(my_matrix)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_sum\n    candidate = method(:find_sum)\n    assert_equal(21, candidate.call([1, 2, 3, 1, 1, 4, 5, 6]))\n    assert_equal(71, candidate.call([1, 10, 9, 4, 2, 10, 10, 45, 4]))\n    assert_equal(78, candidate.call([12, 10, 9, 45, 2, 10, 10, 45, 10]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_magic_square_test\n    candidate = method(:magic_square_test)\n    assert_equal(true, candidate.call([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]))\n    assert_equal(true, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 8]]))\n    assert_equal(false, candidate.call([[2, 7, 6], [9, 5, 1], [4, 3, 7]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rb",
-    "prompt": "# Write a function to convert the given array to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/rbthon-convert-array-to-adjacent-pair-hash/\ndef tuple_to_dict(test_tup)\n",
+    "prompt": "# Write a function to sort a given matrix in ascending order according to the sum of its rows.\ndef sort_matrix(m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_dict\n    candidate = method(:tuple_to_dict)\n    assert_equal({1 => 5, 7 => 10, 13 => 5}, candidate.call([1, 5, 7, 10, 13, 5]))\n    assert_equal({1 => 2, 3 => 4, 5 => 6}, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal({7 => 8, 9 => 10, 11 => 12}, candidate.call([7, 8, 9, 10, 11, 12]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_matrix\n    candidate = method(:sort_matrix)\n    assert_equal([[1, 1, 1], [1, 2, 3], [2, 4, 5]], candidate.call([[1, 2, 3], [2, 4, 5], [1, 1, 1]]))\n    assert_equal([[-2, 4, -5], [1, -1, 1], [1, 2, 3]], candidate.call([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]))\n    assert_equal([[2, 1, 4], [6, 4, 3], [5, 8, 9]], candidate.call([[5, 8, 9], [6, 4, 3], [2, 1, 4]]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rb",
-    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate array.\ndef get_coordinates(test_tup)\n",
+    "prompt": "# Write a function to find the item with maximum frequency in a given array.\ndef max_occurrences(nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_coordinates\n    candidate = method(:get_coordinates)\n    assert_equal([[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]], candidate.call([3, 4]))\n    assert_equal([[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]], candidate.call([4, 5]))\n    assert_equal([[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]], candidate.call([5, 6]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "rb",
-    "prompt": "# Write a function to check if all the elements in array have same data type or not.\ndef check_type(test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_type\n    candidate = method(:check_type)\n    assert_equal(true, candidate.call([5, 6, 7, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, \"4\"]))\n    assert_equal(true, candidate.call([3, 2, 1, 4, 5]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the smallest missing number from a sorted array of natural numbers.\ndef find_First_Missing(array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_First_Missing\n    candidate = method(:find_First_Missing)\n    assert_equal(4, candidate.call([0, 1, 2, 3]))\n    assert_equal(3, candidate.call([0, 1, 2, 6, 9]))\n    assert_equal(0, candidate.call([2, 3, 5, 8, 9]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the given number is undulating or not.\ndef is_undulating(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_undulating\n    candidate = method(:is_undulating)\n    assert_equal(true, candidate.call(1212121))\n    assert_equal(false, candidate.call(1991))\n    assert_equal(true, candidate.call(121))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rb",
-    "prompt": "# Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/rbthon-find-minimum-k-records-from-array-array/ - in this case a verbatim corb of test cases\ndef min_k(test_list, k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_k\n    candidate = method(:min_k)\n    assert_equal([[\"Akash\", 2], [\"Akshat\", 4]], candidate.call([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2))\n    assert_equal([[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]], candidate.call([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3))\n    assert_equal([[\"Ayesha\", 9]], candidate.call([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to count the number of substrings with the sum of digits equal to their length.\ndef count_Substrings(s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Substrings\n    candidate = method(:count_Substrings)\n    assert_equal(6, candidate.call(\"112112\"))\n    assert_equal(6, candidate.call(\"111\"))\n    assert_equal(12, candidate.call(\"1101112\"))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rb",
-    "prompt": "# Write a function to find the nth decagonal number.\ndef is_num_decagonal(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_num_decagonal\n    candidate = method(:is_num_decagonal)\n    assert_equal(27, candidate.call(3))\n    assert_equal(175, candidate.call(7))\n    assert_equal(370, candidate.call(10))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\ndef rear_extract(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rear_extract\n    candidate = method(:rear_extract)\n    assert_equal([21, 20, 19], candidate.call([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]))\n    assert_equal([36, 25, 45], candidate.call([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]))\n    assert_equal([14, 36, 56], candidate.call([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rb",
-    "prompt": "# Write a function to find the closest smaller number than n.\ndef closest_num(n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_num\n    candidate = method(:closest_num)\n    assert_equal(10, candidate.call(11))\n    assert_equal(6, candidate.call(7))\n    assert_equal(11, candidate.call(12))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rb",
-    "prompt": "# Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/rbthon-combinations-of-sum-with-arrays-in-array-array/\ndef find_combinations(test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_combinations\n    candidate = method(:find_combinations)\n    assert_equal([[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]], candidate.call([[2, 4], [6, 7], [5, 1], [6, 10]]))\n    assert_equal([[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]], candidate.call([[3, 5], [7, 8], [6, 2], [7, 11]]))\n    assert_equal([[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]], candidate.call([[4, 6], [8, 9], [7, 3], [8, 12]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rb",
-    "prompt": "# Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\ndef maxAverageOfPath(cost)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maxAverageOfPath\n    candidate = method(:maxAverageOfPath)\n    assert_equal(5.2, candidate.call([[1, 2, 3], [6, 5, 4], [7, 3, 9]]))\n    assert_equal(6.2, candidate.call([[2, 3, 4], [7, 6, 5], [8, 4, 10]]))\n    assert_equal(7.2, candidate.call([[3, 4, 5], [8, 7, 6], [9, 5, 11]]))\n    assert_equal(5.8, candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rb",
-    "prompt": "# Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\ndef sequential_search(dlist, item)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequential_search\n    candidate = method(:sequential_search)\n    assert_equal([true, 3], candidate.call([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31))\n    assert_equal([true, 7], candidate.call([12, 32, 45, 62, 35, 47, 44, 61], 61))\n    assert_equal([true, 6], candidate.call([9, 10, 17, 19, 22, 39, 48, 56], 48))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to remove odd numbers from a given array.\ndef remove_odd(l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal([2], candidate.call([1, 2, 3]))\n    assert_equal([2, 4, 6], candidate.call([2, 4, 6]))\n    assert_equal([10, 20], candidate.call([10, 20, 3]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rb",
-    "prompt": "# Write a function to check whether the product of numbers in an array is even or not.\ndef is_product_even(arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_product_even\n    candidate = method(:is_product_even)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([1, 2, 1, 4]))\n    assert_equal(false, candidate.call([1, 1]))\n  end\nend\n",
-    "stop_tokens": [
-      "\nclass",
-      "\ndef",
-      "\n#",
-      "\n\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rb",
-    "prompt": "# Write a rbthon function to find the maximum of two numbers.\ndef maximum(a, b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal(10, candidate.call(5, 10))\n    assert_equal(-1, candidate.call(-1, -2))\n    assert_equal(9, candidate.call(9, 7))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_occurrences\n    candidate = method(:max_occurrences)\n    assert_equal(2, candidate.call([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]))\n    assert_equal(8, candidate.call([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]))\n    assert_equal(20, candidate.call([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5794,9 +364,759 @@
     "language": "rb",
     "prompt": "# Write a rbthon function to reverse only the vowels of a given string (where y is not a vowel).\ndef reverse_vowels(str1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_vowels\n    candidate = method(:reverse_vowels)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"ASU\", candidate.call(\"USA\"))\n    assert_equal(\"ab\", candidate.call(\"ab\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rb",
+    "prompt": "# Write a function to convert an array to a string.\ndef tup_string(tup1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tup_string\n    candidate = method(:tup_string)\n    assert_equal(\"exercises\", candidate.call([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]))\n    assert_equal(\"python\", candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]))\n    assert_equal(\"program\", candidate.call([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum of the negative numbers of a given array of numbers.\ndef sum_negativenum(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_negativenum\n    candidate = method(:sum_negativenum)\n    assert_equal(-32, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n    assert_equal(-52, candidate.call([10, 15, -14, 13, -18, 12, -20]))\n    assert_equal(-894, candidate.call([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth hexagonal number.\ndef hexagonal_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_hexagonal_num\n    candidate = method(:hexagonal_num)\n    assert_equal(190, candidate.call(10))\n    assert_equal(45, candidate.call(5))\n    assert_equal(91, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\ndef is_Sum_Of_Powers_Of_Two(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sum_Of_Powers_Of_Two\n    candidate = method(:is_Sum_Of_Powers_Of_Two)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(7))\n    assert_equal(true, candidate.call(14))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort an array of elements.\ndef pancake_sort(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pancake_sort\n    candidate = method(:pancake_sort)\n    assert_equal([15, 25, 38, 69, 79], candidate.call([15, 79, 25, 38, 69]))\n    assert_equal([12, 36, 54, 85, 98], candidate.call([98, 12, 54, 36, 85]))\n    assert_equal([12, 23, 32, 41, 42], candidate.call([41, 42, 32, 12, 23]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rb",
+    "prompt": "# Write a function to count number items that are identical in the same position of three given arrays.\ndef count_samepair(list1, list2, list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_samepair\n    candidate = method(:count_samepair)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]))\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n    assert_equal(5, candidate.call([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "rb",
+    "prompt": "# Write a function to find number of arrays present in the given array.\ndef find_lists(input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lists\n    candidate = method(:find_lists)\n    assert_equal(2, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[1, 2], [3, 4], [5, 6]]))\n    assert_equal(1, candidate.call([9, 8, 7, 6, 5, 4, 3, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the maximum difference between any two elements in a given array.\ndef max_Abs_Diff(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Abs_Diff\n    candidate = method(:max_Abs_Diff)\n    assert_equal(4, candidate.call([2, 1, 5, 3]))\n    assert_equal(8, candidate.call([9, 3, 2, 5, 1]))\n    assert_equal(2, candidate.call([3, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the volume of a triangular prism.\ndef find_Volume(l, b, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Volume\n    candidate = method(:find_Volume)\n    assert_equal(240, candidate.call(10, 8, 6))\n    assert_equal(6, candidate.call(3, 2, 2))\n    assert_equal(1, candidate.call(1, 2, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rb",
+    "prompt": "# Write a function that returns integers x and y that satisfy ax + by = n as an array, or return nil if no solution exists.\ndef find_solution(a, b, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_solution\n    candidate = method(:find_solution)\n    assert_equal([2, 1], candidate.call(2, 3, 7))\n    assert_equal(nil, candidate.call(4, 2, 7))\n    assert_equal([4, 1], candidate.call(1, 13, 17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rb",
+    "prompt": "# Write a function to remove all elements from a given array present in another array.\ndef remove_elements(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_elements\n    candidate = method(:remove_elements)\n    assert_equal([1, 3, 5, 7, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]))\n    assert_equal([2, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]))\n    assert_equal([1, 2, 3, 4, 6, 8, 9, 10], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\ndef sum_series(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_series\n    candidate = method(:sum_series)\n    assert_equal(12, candidate.call(6))\n    assert_equal(30, candidate.call(10))\n    assert_equal(25, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rb",
+    "prompt": "# Write a function to determine if the sum of the divisors of two integers are the same.\ndef are_equivalent(num1, num2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_are_equivalent\n    candidate = method(:are_equivalent)\n    assert_equal(false, candidate.call(36, 57))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(23, 47))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\ndef count_char_position(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_char_position\n    candidate = method(:count_char_position)\n    assert_equal(2, candidate.call(\"xbcefg\"))\n    assert_equal(3, candidate.call(\"ABcED\"))\n    assert_equal(5, candidate.call(\"AbgdeF\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rb",
+    "prompt": "# Write a function that counts the number of pairs of integers in an array that xor to an even number.\ndef find_even_pair(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_even_pair\n    candidate = method(:find_even_pair)\n    assert_equal(4, candidate.call([5, 4, 7, 2, 1]))\n    assert_equal(9, candidate.call([7, 2, 8, 1, 0, 5, 11]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the smallest power of 2 greater than or equal to n.\ndef next_power_of_2(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_power_of_2\n    candidate = method(:next_power_of_2)\n    assert_equal(1, candidate.call(0))\n    assert_equal(8, candidate.call(5))\n    assert_equal(32, candidate.call(17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of occurrences of a number in a given array.\ndef frequency(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency\n    candidate = method(:frequency)\n    assert_equal(0, candidate.call([1, 2, 3], 4))\n    assert_equal(3, candidate.call([1, 2, 2, 3, 3, 3, 4], 3))\n    assert_equal(2, candidate.call([0, 1, 2, 3, 1, 2], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rb",
+    "prompt": "# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\ndef text_lowercase_underscore(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_lowercase_underscore\n    candidate = method(:text_lowercase_underscore)\n    assert_equal(true, candidate.call(\"aab_cbbbc\"))\n    assert_equal(false, candidate.call(\"aab_Abbbc\"))\n    assert_equal(false, candidate.call(\"Aaab_abbbc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rb",
+    "prompt": "# Write a function to find the sum of numbers in an array within a range specified by two indices.\ndef sum_range_list(list1, m, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_range_list\n    candidate = method(:sum_range_list)\n    assert_equal(29, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10))\n    assert_equal(16, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7))\n    assert_equal(38, candidate.call([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rb",
+    "prompt": "# Write a function to find the perimeter of a regular pentagon from the length of its sides.\ndef perimeter_pentagon(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perimeter_pentagon\n    candidate = method(:perimeter_pentagon)\n    assert_equal(25, candidate.call(5))\n    assert_equal(50, candidate.call(10))\n    assert_equal(75, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of occurence of the string 'std' in a given string.\ndef count_occurance(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_occurance\n    candidate = method(:count_occurance)\n    assert_equal(3, candidate.call(\"letstdlenstdporstd\"))\n    assert_equal(1, candidate.call(\"truststdsolensporsd\"))\n    assert_equal(2, candidate.call(\"makestdsostdworthit\"))\n    assert_equal(1, candidate.call(\"stds\"))\n    assert_equal(0, candidate.call(\"\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rb",
+    "prompt": "# Write a function that returns the perimeter of a square given its side length as input.\ndef square_perimeter(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_perimeter\n    candidate = method(:square_perimeter)\n    assert_equal(40, candidate.call(10))\n    assert_equal(20, candidate.call(5))\n    assert_equal(16, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rb",
+    "prompt": "# Write a function to remove characters from the first string which are present in the second string.\ndef remove_dirty_chars(string, second_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_dirty_chars\n    candidate = method(:remove_dirty_chars)\n    assert_equal(\"bacuve\", candidate.call(\"probasscurve\", \"pros\"))\n    assert_equal(\"digiidi\", candidate.call(\"digitalindia\", \"talent\"))\n    assert_equal(\"emles\", candidate.call(\"exoticmiles\", \"toxic\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rb",
+    "prompt": "# Write a function to find whether a given array of integers contains any duplicate element.\ndef test_duplicate(arraynums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_duplicate\n    candidate = method(:test_duplicate)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 4]))\n    assert_equal(true, candidate.call([1, 1, 2, 2, 3, 3, 4, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given number is woodball or not.\ndef is_woodall(x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_woodall\n    candidate = method(:is_woodall)\n    assert_equal(true, candidate.call(383))\n    assert_equal(false, candidate.call(254))\n    assert_equal(false, candidate.call(200))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "rb",
+    "prompt": "# Write a function to check if all the elements in array have same data type or not.\ndef check_type(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_type\n    candidate = method(:check_type)\n    assert_equal(true, candidate.call([5, 6, 7, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, \"4\"]))\n    assert_equal(true, candidate.call([3, 2, 1, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\ndef is_majority(arr, n, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_majority\n    candidate = method(:is_majority)\n    assert_equal(true, candidate.call([1, 2, 3, 3, 3, 3, 10], 7, 3))\n    assert_equal(false, candidate.call([1, 1, 2, 4, 4, 4, 6, 6], 8, 4))\n    assert_equal(true, candidate.call([1, 1, 1, 2, 2], 5, 1))\n    assert_equal(false, candidate.call([1, 1, 2, 2], 5, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of set bits (binary digits with value 1) in a given number.\ndef count_Set_Bits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Set_Bits\n    candidate = method(:count_Set_Bits)\n    assert_equal(1, candidate.call(2))\n    assert_equal(1, candidate.call(4))\n    assert_equal(2, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to remove the characters which have odd index values of a given string.\ndef odd_values_string(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_values_string\n    candidate = method(:odd_values_string)\n    assert_equal(\"ace\", candidate.call(\"abcdef\"))\n    assert_equal(\"pto\", candidate.call(\"python\"))\n    assert_equal(\"dt\", candidate.call(\"data\"))\n    assert_equal(\"lms\", candidate.call(\"lambs\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rb",
+    "prompt": "# Write a function to find minimum of three numbers.\ndef min_of_three(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_of_three\n    candidate = method(:min_of_three)\n    assert_equal(0, candidate.call(10, 20, 0))\n    assert_equal(15, candidate.call(19, 15, 18))\n    assert_equal(-30, candidate.call(-10, -20, -30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether all the bits are unset in the given range or not.\ndef all_Bits_Set_In_The_Given_Range(n, l, r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Bits_Set_In_The_Given_Range\n    candidate = method(:all_Bits_Set_In_The_Given_Range)\n    assert_equal(true, candidate.call(4, 1, 2))\n    assert_equal(true, candidate.call(17, 2, 4))\n    assert_equal(false, candidate.call(39, 4, 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\ndef re_arrange_array(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_re_arrange_array\n    candidate = method(:re_arrange_array)\n    assert_equal([-1, -3, -7, 4, 5, 6, 2, 8, 9], candidate.call([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9))\n    assert_equal([-14, -26, 12, 13, 15], candidate.call([12, -14, -26, 13, 15], 5))\n    assert_equal([-42, -39, -78, 10, 24, 36, 85], candidate.call([10, 24, 36, -42, -39, -78, 85], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\ndef replace_blank(str1, char)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_blank\n    candidate = method(:replace_blank)\n    assert_equal(\"hello@people\", candidate.call(\"hello people\", \"@\"))\n    assert_equal(\"python$program$language\", candidate.call(\"python program language\", \"$\"))\n    assert_equal(\"blank-space\", candidate.call(\"blank space\", \"-\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rb",
+    "prompt": "# Write a function to find the volume of a cube given its side length.\ndef volume_cube(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_volume_cube\n    candidate = method(:volume_cube)\n    assert_equal(27, candidate.call(3))\n    assert_equal(8, candidate.call(2))\n    assert_equal(125, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array of arrays and returns a hash mapping each unique array to the number of times it occurs in the array.\ndef check_occurences(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_occurences\n    candidate = method(:check_occurences)\n    assert_equal({[1, 3] => 2, [2, 5] => 2, [3, 6] => 1}, candidate.call([[3, 1], [1, 3], [2, 5], [5, 2], [6, 3]]))\n    assert_equal({[2, 4] => 2, [3, 6] => 2, [4, 7] => 1}, candidate.call([[4, 2], [2, 4], [3, 6], [6, 3], [7, 4]]))\n    assert_equal({[2, 13] => 1, [11, 23] => 1, [12, 25] => 2, [16, 23] => 1}, candidate.call([[13, 2], [11, 23], [12, 25], [25, 12], [16, 23]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of non-empty substrings of a given string.\ndef number_of_substrings(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_of_substrings\n    candidate = method(:number_of_substrings)\n    assert_equal(6, candidate.call(\"abc\"))\n    assert_equal(10, candidate.call(\"abcd\"))\n    assert_equal(15, candidate.call(\"abcde\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rb",
+    "prompt": "# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\ndef get_total_number_of_sequences(m, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_total_number_of_sequences\n    candidate = method(:get_total_number_of_sequences)\n    assert_equal(4, candidate.call(10, 4))\n    assert_equal(6, candidate.call(5, 2))\n    assert_equal(84, candidate.call(16, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\ndef replace_list(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_list\n    candidate = method(:replace_list)\n    assert_equal([1, 3, 5, 7, 9, 2, 4, 6, 8], candidate.call([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8]))\n    assert_equal([\"red\", \"blue\", \"yellow\"], candidate.call([\"red\", \"blue\", \"green\"], [\"yellow\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rb",
+    "prompt": "# Write a function to count the total number of characters in a string.\ndef count_charac(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_charac\n    candidate = method(:count_charac)\n    assert_equal(18, candidate.call(\"python programming\"))\n    assert_equal(8, candidate.call(\"language\"))\n    assert_equal(5, candidate.call(\"words\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the next perfect square greater than a given number.\ndef next_Perfect_Square(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_next_Perfect_Square\n    candidate = method(:next_Perfect_Square)\n    assert_equal(36, candidate.call(35))\n    assert_equal(9, candidate.call(6))\n    assert_equal(16, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rb",
+    "prompt": "# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\ndef max_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum\n    candidate = method(:max_sum)\n    assert_equal(194, candidate.call([1, 15, 51, 45, 33, 100, 12, 18, 9]))\n    assert_equal(210, candidate.call([80, 60, 30, 40, 20, 10]))\n    assert_equal(138, candidate.call([2, 3, 14, 16, 21, 23, 29, 30]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rb",
+    "prompt": "# Write a function to find the length of the longest palindromic subsequence in the given string.\ndef lps(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lps\n    candidate = method(:lps)\n    assert_equal(5, candidate.call(\"TENS FOR TENS\"))\n    assert_equal(7, candidate.call(\"CARDIO FOR CARDS\"))\n    assert_equal(9, candidate.call(\"PART OF THE JOURNEY IS PART\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rb",
+    "prompt": "# Write a function to find the intersection of two arrays.\ndef intersection_array(array_nums1, array_nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_intersection_array\n    candidate = method(:intersection_array)\n    assert_equal([1, 2, 8, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]))\n    assert_equal([3, 5, 7, 9], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]))\n    assert_equal([10], candidate.call([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rb",
+    "prompt": "# Write a rbthon function that takes in an array and an element and counts the occcurences of the element in the array.\ndef count_X(tup, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_X\n    candidate = method(:count_X)\n    assert_equal(0, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4))\n    assert_equal(3, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10))\n    assert_equal(4, candidate.call([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\ndef insert_element(list, element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_insert_element\n    candidate = method(:insert_element)\n    assert_equal([\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"], candidate.call([\"Red\", \"Green\", \"Black\"], \"c\"))\n    assert_equal([\"program\", \"python\", \"program\", \"java\"], candidate.call([\"python\", \"java\"], \"program\"))\n    assert_equal([\"laugh\", \"happy\", \"laugh\", \"sad\"], candidate.call([\"happy\", \"sad\"], \"laugh\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to convert complex numbers to polar coordinates.\ndef convert(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert\n    candidate = method(:convert)\n    assert_equal([1.0, 0.0], candidate.call(1))\n    assert_equal([4.0, 0.0], candidate.call(4))\n    assert_equal([5.0, 0.0], candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "rb",
+    "prompt": "# Write a rbthon function that returns the number of integer elements in a given array.\ndef count_integer(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_integer\n    candidate = method(:count_integer)\n    assert_equal(2, candidate.call([1, 2, \"abc\", 1.2]))\n    assert_equal(3, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 1.2, 4, 5.1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\ndef combinations_colors(l, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_colors\n    candidate = method(:combinations_colors)\n    assert_equal([[\"Red\"], [\"Green\"], [\"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 1))\n    assert_equal([[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 2))\n    assert_equal([[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]], candidate.call([\"Red\", \"Green\", \"Blue\"], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rb",
+    "prompt": "# Write a rbthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\ndef count_Primes_nums(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Primes_nums\n    candidate = method(:count_Primes_nums)\n    assert_equal(2, candidate.call(5))\n    assert_equal(4, candidate.call(10))\n    assert_equal(25, candidate.call(100))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two numbers and returns an array with the second number and then the first number.\ndef swap_numbers(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_numbers\n    candidate = method(:swap_numbers)\n    assert_equal([20, 10], candidate.call(10, 20))\n    assert_equal([17, 15], candidate.call(15, 17))\n    assert_equal([200, 100], candidate.call(100, 200))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5809,7 +1129,7 @@
     "language": "rb",
     "prompt": "# Write a function to maximize the given two arrays.\ndef maximize_elements(test_tup1, test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximize_elements\n    candidate = method(:maximize_elements)\n    assert_equal([[6, 7], [4, 9], [2, 9], [7, 10]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[7, 8], [5, 10], [3, 10], [8, 11]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[8, 9], [6, 11], [4, 11], [9, 12]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rb",
-    "prompt": "# Write a rbthon function to check whether every even index contains even numbers of a given array.\ndef even_position(nums)\n",
+    "prompt": "# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\ndef newman_prime(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_position\n    candidate = method(:even_position)\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([2, 1, 4]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_newman_prime\n    candidate = method(:newman_prime)\n    assert_equal(7, candidate.call(3))\n    assert_equal(17, candidate.call(4))\n    assert_equal(41, candidate.call(5))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rb",
-    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ndef check_char(string)\n",
+    "prompt": "# Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\ndef division_elements(test_tup1, test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_char\n    candidate = method(:check_char)\n    assert_equal(\"Valid\", candidate.call(\"abba\"))\n    assert_equal(\"Valid\", candidate.call(\"a\"))\n    assert_equal(\"Invalid\", candidate.call(\"abcd\"))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_division_elements\n    candidate = method(:division_elements)\n    assert_equal([2, 2, 2, 3], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([2, 2, 2, 4], candidate.call([12, 6, 8, 16], [6, 3, 4, 4]))\n    assert_equal([4, 2, 6, 2], candidate.call([20, 14, 36, 18], [5, 7, 6, 9]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "rb",
-    "prompt": "# Write a rbthon function to find the sum of even factors of a number.\ndef sumofFactors(n)\n",
+    "prompt": "# Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\ndef split_two_parts(list1, l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sumofFactors\n    candidate = method(:sumofFactors)\n    assert_equal(26, candidate.call(18))\n    assert_equal(48, candidate.call(30))\n    assert_equal(8, candidate.call(6))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_two_parts\n    candidate = method(:split_two_parts)\n    assert_equal([[1, 1, 2], [3, 4, 4, 5, 1]], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"]], candidate.call([\"a\", \"b\", \"c\", \"d\"], 2))\n    assert_equal([[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]], candidate.call([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "rb",
-    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\ndef lateralsurface_cone(r, h)\n",
+    "prompt": "# Write a function to calculate a dog's age in dog's years.\ndef dog_age(h_age)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cone\n    candidate = method(:lateralsurface_cone)\n    assert_equal(204.20352248333654, candidate.call(5, 12))\n    assert_equal(566.3586699569488, candidate.call(10, 15))\n    assert_equal(1521.8090132193388, candidate.call(19, 17))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dog_age\n    candidate = method(:dog_age)\n    assert_equal(61, candidate.call(12))\n    assert_equal(73, candidate.call(15))\n    assert_equal(109, candidate.call(24))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "rb",
-    "prompt": "# Write a rbthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\ndef count_Pairs(arr, n)\n",
+    "prompt": "# Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\ndef list_split(s, step)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Pairs\n    candidate = method(:count_Pairs)\n    assert_equal(2, candidate.call([1, 2, 1], 3))\n    assert_equal(0, candidate.call([1, 1, 1, 1], 4))\n    assert_equal(10, candidate.call([1, 2, 3, 4, 5], 5))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_split\n    candidate = method(:list_split)\n    assert_equal([[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]], candidate.call([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3))\n    assert_equal([[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3))\n    assert_equal([[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]], candidate.call([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rb",
-    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\ndef find_first_occurrence(a, x)\n",
+    "prompt": "# Write a function to find the lateral surface area of a cube given its side length.\ndef lateralsurface_cube(l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_first_occurrence\n    candidate = method(:find_first_occurrence)\n    assert_equal(1, candidate.call([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(2, candidate.call([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(4, candidate.call([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cube\n    candidate = method(:lateralsurface_cube)\n    assert_equal(100, candidate.call(5))\n    assert_equal(324, candidate.call(9))\n    assert_equal(400, candidate.call(10))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5914,9 +1234,909 @@
     "language": "rb",
     "prompt": "# Write a rbthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\ndef square_Sum(n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(10, candidate.call(2))\n    assert_equal(35, candidate.call(3))\n    assert_equal(84, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the n'th star number.\ndef find_star_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_star_num\n    candidate = method(:find_star_num)\n    assert_equal(37, candidate.call(3))\n    assert_equal(73, candidate.call(4))\n    assert_equal(121, candidate.call(5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rb",
+    "prompt": "# Write a function to find the ascii value of a character.\ndef ascii_value(k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_ascii_value\n    candidate = method(:ascii_value)\n    assert_equal(65, candidate.call(\"A\"))\n    assert_equal(82, candidate.call(\"R\"))\n    assert_equal(83, candidate.call(\"S\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of even numbers at even positions of an array.\ndef sum_even_and_even_index(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_even_and_even_index\n    candidate = method(:sum_even_and_even_index)\n    assert_equal(30, candidate.call([5, 6, 12, 1, 18, 8]))\n    assert_equal(26, candidate.call([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]))\n    assert_equal(12, candidate.call([5, 6, 12, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\ndef even_Power_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_Power_Sum\n    candidate = method(:even_Power_Sum)\n    assert_equal(1056, candidate.call(2))\n    assert_equal(8832, candidate.call(3))\n    assert_equal(32, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\ndef rear_extract(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rear_extract\n    candidate = method(:rear_extract)\n    assert_equal([21, 20, 19], candidate.call([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]))\n    assert_equal([36, 25, 45], candidate.call([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]))\n    assert_equal([14, 36, 56], candidate.call([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rb",
+    "prompt": "# Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\ndef substract_elements(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_substract_elements\n    candidate = method(:substract_elements)\n    assert_equal([8, -1, -13], candidate.call([10, 4, 5], [2, 5, 18]))\n    assert_equal([-13, -43, -13], candidate.call([11, 2, 3], [24, 45, 16]))\n    assert_equal([-3, 7, -3], candidate.call([7, 18, 9], [10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\ndef even_binomial_Coeff_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_binomial_Coeff_Sum\n    candidate = method(:even_binomial_Coeff_Sum)\n    assert_equal(8, candidate.call(4))\n    assert_equal(32, candidate.call(6))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rb",
+    "prompt": "# Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\ndef dict_filter(dict, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dict_filter\n    candidate = method(:dict_filter)\n    assert_equal({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 170))\n    assert_equal({\"Alden Cantrell\" => 180, \"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 180))\n    assert_equal({\"Pierre Cox\" => 190}, candidate.call({\"Cierra Vega\" => 175, \"Alden Cantrell\" => 180, \"Kierra Gentry\" => 165, \"Pierre Cox\" => 190}, 190))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "rb",
+    "prompt": "# Write a function to find the number of elements that occurs before the array element in the given array.\ndef count_first_elements(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_first_elements\n    candidate = method(:count_first_elements)\n    assert_equal(3, candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal(2, candidate.call([2, 9, [5, 7], 11]))\n    assert_equal(4, candidate.call([11, 15, 5, 8, [2, 3], 8]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth decagonal number.\ndef is_num_decagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_num_decagonal\n    candidate = method(:is_num_decagonal)\n    assert_equal(27, candidate.call(3))\n    assert_equal(175, candidate.call(7))\n    assert_equal(370, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\ndef sequential_search(dlist, item)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequential_search\n    candidate = method(:sequential_search)\n    assert_equal([true, 3], candidate.call([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31))\n    assert_equal([true, 7], candidate.call([12, 32, 45, 62, 35, 47, 44, 61], 61))\n    assert_equal([true, 6], candidate.call([9, 10, 17, 19, 22, 39, 48, 56], 48))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check if the elements of a given array are unique or not.\ndef all_unique(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_unique\n    candidate = method(:all_unique)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rb",
+    "prompt": "# Write a function to subtract two arrays element-wise.\ndef sub_list(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sub_list\n    candidate = method(:sub_list)\n    assert_equal([-3, -3, -3], candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal([-2, -2], candidate.call([1, 2], [3, 4]))\n    assert_equal([40, 50], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rb",
+    "prompt": "# Write a rbthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\ndef validate(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_validate\n    candidate = method(:validate)\n    assert_equal(true, candidate.call(1234))\n    assert_equal(false, candidate.call(51241))\n    assert_equal(true, candidate.call(321))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\ndef check_element(list, element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_element\n    candidate = method(:check_element)\n    assert_equal(false, candidate.call([\"green\", \"orange\", \"black\", \"white\"], \"blue\"))\n    assert_equal(false, candidate.call([1, 2, 3, 4], 7))\n    assert_equal(true, candidate.call([\"green\", \"green\", \"green\", \"green\"], \"green\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rb",
+    "prompt": "# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\ndef text_match_two_three(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_two_three\n    candidate = method(:text_match_two_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rb",
+    "prompt": "# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\ndef max_sub_array_sum_repeated(a, n, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum_repeated\n    candidate = method(:max_sub_array_sum_repeated)\n    assert_equal(30, candidate.call([10, 20, -30, -1], 4, 3))\n    assert_equal(59, candidate.call([-1, 10, 20], 3, 2))\n    assert_equal(-1, candidate.call([-1, -2, -3], 3, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\ndef square_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_Sum\n    candidate = method(:square_Sum)\n    assert_equal(20, candidate.call(2))\n    assert_equal(56, candidate.call(3))\n    assert_equal(120, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rb",
+    "prompt": "# Write a function to find the array of maximum length in an array of arrays.\ndef max_length(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length\n    candidate = method(:max_length)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([4, [10, 12, 14, 15]], candidate.call([[1], [5, 7], [10, 12, 14, 15]]))\n    assert_equal([3, [15, 20, 25]], candidate.call([[5], [15, 20, 25]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rb",
+    "prompt": "# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\ndef count_no_of_ways(n, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_no_of_ways\n    candidate = method(:count_no_of_ways)\n    assert_equal(16, candidate.call(2, 4))\n    assert_equal(6, candidate.call(3, 2))\n    assert_equal(228, candidate.call(4, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find quotient of two numbers (rounded down to the nearest integer).\ndef find(n, m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find\n    candidate = method(:find)\n    assert_equal(3, candidate.call(10, 3))\n    assert_equal(2, candidate.call(4, 2))\n    assert_equal(4, candidate.call(20, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rb",
+    "prompt": "# Write a function to find the third side of a right angled triangle.\ndef otherside_rightangle(w, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_otherside_rightangle\n    candidate = method(:otherside_rightangle)\n    assert_equal(10.63014581273465, candidate.call(7, 8))\n    assert_equal(5, candidate.call(3, 4))\n    assert_equal(16.55294535724685, candidate.call(7, 15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum value in a given heterogeneous array.\ndef max_val(listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_val\n    candidate = method(:max_val)\n    assert_equal(5, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(25, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(50, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rb",
+    "prompt": "# Write a function to return the sum of all divisors of a number.\ndef sum_div(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_div\n    candidate = method(:sum_div)\n    assert_equal(7, candidate.call(8))\n    assert_equal(16, candidate.call(12))\n    assert_equal(1, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count inversions in an array.\ndef get_Inv_Count(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Inv_Count\n    candidate = method(:get_Inv_Count)\n    assert_equal(5, candidate.call([1, 20, 6, 4, 5]))\n    assert_equal(1, candidate.call([1, 2, 1]))\n    assert_equal(3, candidate.call([1, 2, 5, 6, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "rb",
+    "prompt": "# Write a function to flatten a given nested array structure.\ndef flatten_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_flatten_list\n    candidate = method(:flatten_list)\n    assert_equal([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120], candidate.call([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]))\n    assert_equal([10, 20, 40, 30, 56, 25, 10, 20, 33, 40], candidate.call([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]))\n    assert_equal([1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the maximum aggregate from the array of arrays.\ndef max_aggregate(stdata)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_aggregate\n    candidate = method(:max_aggregate)\n    assert_equal([\"Juan Whelan\", 212], candidate.call([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]))\n    assert_equal([\"Juan Whelan\", 72], candidate.call([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]))\n    assert_equal([\"Sabah Colley\", 70], candidate.call([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find element at a given index after number of rotations.\ndef find_Element(arr, ranges, rotations, index)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Element\n    candidate = method(:find_Element)\n    assert_equal(3, candidate.call([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1))\n    assert_equal(3, candidate.call([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rb",
+    "prompt": "# Write a function to return two words from an array of words starting with letter 'p'.\ndef start_withp(words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_start_withp\n    candidate = method(:start_withp)\n    assert_equal([\"Python\", \"PHP\"], candidate.call([\"Python PHP\", \"Java JavaScript\", \"c c++\"]))\n    assert_equal([\"Python\", \"Programming\"], candidate.call([\"Python Programming\", \"Java Programming\"]))\n    assert_equal([\"Pqrst\", \"Pqr\"], candidate.call([\"Pqrst Pqr\", \"qrstuv\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\ndef max_sum_increasing_subseq(a, n, index, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_increasing_subseq\n    candidate = method(:max_sum_increasing_subseq)\n    assert_equal(11, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 4, 6))\n    assert_equal(7, candidate.call([1, 101, 2, 3, 100, 4, 5], 7, 2, 5))\n    assert_equal(71, candidate.call([11, 15, 19, 21, 26, 28, 31], 7, 2, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\ndef large_product(nums1, nums2, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_large_product\n    candidate = method(:large_product)\n    assert_equal([60, 54, 50], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3))\n    assert_equal([60, 54, 50, 48], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4))\n    assert_equal([60, 54, 50, 48, 45], candidate.call([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the maximum of two numbers.\ndef maximum(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maximum\n    candidate = method(:maximum)\n    assert_equal(10, candidate.call(5, 10))\n    assert_equal(-1, candidate.call(-1, -2))\n    assert_equal(9, candidate.call(9, 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to convert a given string to an array of characters.\ndef string_to_tuple(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_string_to_tuple\n    candidate = method(:string_to_tuple)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"], candidate.call(\"python 3.0\"))\n    assert_equal([\"i\", \"t\", \"e\", \"m\", \"1\"], candidate.call(\"item1\"))\n    assert_equal([\"1\", \"5\", \".\", \"1\", \"0\"], candidate.call(\"15.10\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the highest power of 2 that is less than or equal to n.\ndef highest_Power_of_2(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_highest_Power_of_2\n    candidate = method(:highest_Power_of_2)\n    assert_equal(8, candidate.call(10))\n    assert_equal(16, candidate.call(19))\n    assert_equal(32, candidate.call(32))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rb",
+    "prompt": "# Write a function to find the n'th lucas number.\ndef find_lucas(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_lucas\n    candidate = method(:find_lucas)\n    assert_equal(76, candidate.call(9))\n    assert_equal(7, candidate.call(4))\n    assert_equal(4, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "rb",
+    "prompt": "# Write a function to apply a given format string to all of the elements in an array.\ndef add_string(list_, string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_string\n    candidate = method(:add_string)\n    assert_equal([\"temp1\", \"temp2\", \"temp3\", \"temp4\"], candidate.call([1, 2, 3, 4], \"temp{0}\"))\n    assert_equal([\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"], candidate.call([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"))\n    assert_equal([\"string5\", \"string6\", \"string7\", \"string8\"], candidate.call([5, 6, 7, 8], \"string{0}\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "rb",
+    "prompt": "# Write a function to convert more than one array to nested hash.\ndef convert_list_dictionary(l1, l2, l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_convert_list_dictionary\n    candidate = method(:convert_list_dictionary)\n    assert_equal([{\"S001\" => {\"Adina Park\" => 85}}, {\"S002\" => {\"Leyton Marsh\" => 98}}, {\"S003\" => {\"Duncan Boyle\" => 89}}, {\"S004\" => {\"Saim Richards\" => 92}}], candidate.call([\"S001\", \"S002\", \"S003\", \"S004\"], [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], [85, 98, 89, 92]))\n    assert_equal([{\"abc\" => {\"python\" => 100}}, {\"def\" => {\"program\" => 200}}, {\"ghi\" => {\"language\" => 300}}, {\"jkl\" => {\"programs\" => 400}}], candidate.call([\"abc\", \"def\", \"ghi\", \"jkl\"], [\"python\", \"program\", \"language\", \"programs\"], [100, 200, 300, 400]))\n    assert_equal([{\"A1\" => {\"java\" => 10}}, {\"A2\" => {\"C\" => 20}}, {\"A3\" => {\"C++\" => 30}}, {\"A4\" => {\"DBMS\" => 40}}], candidate.call([\"A1\", \"A2\", \"A3\", \"A4\"], [\"java\", \"C\", \"C++\", \"DBMS\"], [10, 20, 30, 40]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\ndef get_max_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_max_sum\n    candidate = method(:get_max_sum)\n    assert_equal(106, candidate.call(60))\n    assert_equal(12, candidate.call(10))\n    assert_equal(2, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rb",
+    "prompt": "# Write a function to find the array with maximum length.\ndef max_length_list(input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_length_list\n    candidate = method(:max_length_list)\n    assert_equal([3, [13, 15, 17]], candidate.call([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal([5, [1, 2, 3, 4, 5]], candidate.call([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]))\n    assert_equal([4, [6, 7, 8, 9]], candidate.call([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rb",
+    "prompt": "# Write a function to check if given array contains no duplicates.\ndef check_distinct(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_distinct\n    candidate = method(:check_distinct)\n    assert_equal(false, candidate.call([1, 4, 5, 6, 1, 4]))\n    assert_equal(true, candidate.call([1, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the first non-repeated character in a given string.\ndef first_non_repeating_character(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_non_repeating_character\n    candidate = method(:first_non_repeating_character)\n    assert_equal(nil, candidate.call(\"abcabc\"))\n    assert_equal(\"a\", candidate.call(\"abc\"))\n    assert_equal(\"c\", candidate.call(\"ababc\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given string starts and ends with the same character or not.\ndef check_char(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_char\n    candidate = method(:check_char)\n    assert_equal(\"Valid\", candidate.call(\"abba\"))\n    assert_equal(\"Valid\", candidate.call(\"a\"))\n    assert_equal(\"Invalid\", candidate.call(\"abcd\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rb",
+    "prompt": "# Write a function to find the median of three numbers.\ndef median_numbers(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_numbers\n    candidate = method(:median_numbers)\n    assert_equal(55.0, candidate.call(25, 55, 65))\n    assert_equal(20.0, candidate.call(20, 10, 30))\n    assert_equal(45.0, candidate.call(15, 45, 75))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "rb",
+    "prompt": "# Write a function to compute the sum of digits of each number of a given array.\ndef sum_of_digits(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_of_digits\n    candidate = method(:sum_of_digits)\n    assert_equal(14, candidate.call([10, 2, 56]))\n    assert_equal(19, candidate.call([[10, 20, 4, 5, \"b\", 70, \"a\"]]))\n    assert_equal(19, candidate.call([10, 20, -4, 5, -70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rb",
+    "prompt": "# Write a function to perform the mathematical bitwise xor operation across the given arrays.\ndef bitwise_xor(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bitwise_xor\n    candidate = method(:bitwise_xor)\n    assert_equal([15, 6, 5, 10], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([13, 6, 3, 14], candidate.call([11, 5, 7, 10], [6, 3, 4, 4]))\n    assert_equal([11, 2, 13, 13], candidate.call([12, 6, 8, 11], [7, 4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to identify non-prime numbers.\ndef is_not_prime(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_not_prime\n    candidate = method(:is_not_prime)\n    assert_equal(false, candidate.call(2))\n    assert_equal(true, candidate.call(10))\n    assert_equal(true, candidate.call(35))\n    assert_equal(false, candidate.call(37))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rb",
+    "prompt": "# Write a function to extract the number of unique arrays in the given array.\ndef extract_freq(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_freq\n    candidate = method(:extract_freq)\n    assert_equal(3, candidate.call([[3, 4], [1, 2], [4, 3], [5, 6]]))\n    assert_equal(4, candidate.call([[4, 15], [2, 3], [5, 4], [6, 7]]))\n    assert_equal(4, candidate.call([[5, 16], [2, 3], [6, 5], [6, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to perform index wise addition of array elements in the given two nested arrays.\ndef add_nested_tuples(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_nested_tuples\n    candidate = method(:add_nested_tuples)\n    assert_equal([[7, 10], [7, 14], [3, 10], [8, 13]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[9, 12], [9, 16], [5, 12], [10, 15]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[11, 14], [11, 18], [7, 14], [12, 17]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the minimum of two numbers.\ndef minimum(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_minimum\n    candidate = method(:minimum)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(-5, candidate.call(-5, -4))\n    assert_equal(0, candidate.call(0, 0))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "rb",
+    "prompt": "# Write a function to check whether an element exists within an array.\ndef check_tuplex(tuplex, tuple1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_tuplex\n    candidate = method(:check_tuplex)\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"))\n    assert_equal(false, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"))\n    assert_equal(true, candidate.call([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find whether the parity of a given number is odd.\ndef find_Parity(x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Parity\n    candidate = method(:find_Parity)\n    assert_equal(false, candidate.call(12))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "rb",
+    "prompt": "# Write a function to create the next bigger number by rearranging the digits of a given number.\ndef rearrange_bigger(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rearrange_bigger\n    candidate = method(:rearrange_bigger)\n    assert_equal(21, candidate.call(12))\n    assert_equal(false, candidate.call(10))\n    assert_equal(120, candidate.call(102))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rb",
+    "prompt": "# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\ndef k_smallest_pairs(nums1, nums2, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_k_smallest_pairs\n    candidate = method(:k_smallest_pairs)\n    assert_equal([[1, 2], [1, 4]], candidate.call([1, 3, 7], [2, 4, 6], 2))\n    assert_equal([[1, 2]], candidate.call([1, 3, 7], [2, 4, 6], 1))\n    assert_equal([[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]], candidate.call([1, 3, 7], [2, 4, 6], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to find the minimum product from the pairs of arrays within a given array.\ndef min_product_tuple(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_product_tuple\n    candidate = method(:min_product_tuple)\n    assert_equal(8, candidate.call([[2, 7], [2, 6], [1, 8], [4, 9]]))\n    assert_equal(30, candidate.call([[10, 20], [15, 2], [5, 10]]))\n    assert_equal(100, candidate.call([[11, 44], [10, 15], [20, 5], [12, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "rb",
+    "prompt": "# Write a function to find the minimum value in a given heterogeneous array.\ndef min_val(listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_val\n    candidate = method(:min_val)\n    assert_equal(2, candidate.call([\"Python\", 3, 2, 4, 5, \"version\"]))\n    assert_equal(15, candidate.call([\"Python\", 15, 20, 25]))\n    assert_equal(20, candidate.call([\"Python\", 30, 20, 40, 50, \"version\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given snake case string to camel case string.\ndef snake_to_camel(word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_snake_to_camel\n    candidate = method(:snake_to_camel)\n    assert_equal(\"AndroidTv\", candidate.call(\"android_tv\"))\n    assert_equal(\"GooglePixel\", candidate.call(\"google_pixel\"))\n    assert_equal(\"AppleWatch\", candidate.call(\"apple_watch\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to remove odd numbers from a given array.\ndef remove_odd(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal([2], candidate.call([1, 2, 3]))\n    assert_equal([2, 4, 6], candidate.call([2, 4, 6]))\n    assert_equal([10, 20], candidate.call([10, 20, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "rb",
+    "prompt": "# Write a function to extract the nth element from a given array of arrays.\ndef extract_nth_element(list1, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_nth_element\n    candidate = method(:extract_nth_element)\n    assert_equal([\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0))\n    assert_equal([99, 96, 94, 98], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2))\n    assert_equal([98, 97, 91, 94], candidate.call([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether any value in a sequence exists in a sequence or not.\ndef overlapping(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_overlapping\n    candidate = method(:overlapping)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(false, candidate.call([1, 2, 3], [4, 5, 6]))\n    assert_equal(true, candidate.call([1, 4, 5], [1, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find a pair with highest product from a given array of integers.\ndef max_Product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_Product\n    candidate = method(:max_Product)\n    assert_equal([7, 8], candidate.call([1, 2, 3, 4, 7, 0, 8, 4]))\n    assert_equal([-4, -6], candidate.call([0, -1, -2, -4, 5, 0, -6]))\n    assert_equal([2, 3], candidate.call([1, 2, 3]))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",
@@ -5929,7 +2149,7 @@
     "language": "rb",
     "prompt": "# Write a function to find common first element in given array of arrays.\ndef group_tuples(input)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_group_tuples\n    candidate = method(:group_tuples)\n    assert_equal([[\"x\", \"y\", \"z\"], [\"w\", \"t\"]], candidate.call([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]))\n    assert_equal([[\"a\", \"b\", \"c\"], [\"d\", \"e\"]], candidate.call([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]))\n    assert_equal([[\"f\", \"g\", \"g\"], [\"h\", \"i\"]], candidate.call([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]))\n  end\nend\n",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "rb",
-    "prompt": "# Write a function to merge three arrays into a single sorted array.\ndef merge_sorted_list(num1, num2, num3)\n",
+    "prompt": "# Write a rbthon function to find the element of an array having maximum length.\ndef Find_Max(lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_sorted_list\n    candidate = method(:merge_sorted_list)\n    assert_equal([4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233], candidate.call([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]))\n    assert_equal([1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12], candidate.call([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]))\n    assert_equal([1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85], candidate.call([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]))\n  end\nend\n",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max\n    candidate = method(:Find_Max)\n    assert_equal([\"A\", \"B\", \"C\"], candidate.call([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]))\n    assert_equal([1, 2, 3], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 5, 6, 1], candidate.call([[1, 1], [1, 2, 3], [1, 5, 6, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "rb",
+    "prompt": "# Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\ndef round_and_sum(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_round_and_sum\n    candidate = method(:round_and_sum)\n    assert_equal(243, candidate.call([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]))\n    assert_equal(345, candidate.call([5, 2, 9, 24.3, 29]))\n    assert_equal(513, candidate.call([25.0, 56.7, 89.2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the cube sum of first n even natural numbers.\ndef cube_Sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_Sum\n    candidate = method(:cube_Sum)\n    assert_equal(72, candidate.call(2))\n    assert_equal(288, candidate.call(3))\n    assert_equal(800, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to concatenate each element of array by the delimiter.\ndef concatenate_tuple(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_concatenate_tuple\n    candidate = method(:concatenate_tuple)\n    assert_equal(\"ID-is-4-UTS\", candidate.call([\"ID\", \"is\", 4, \"UTS\"]))\n    assert_equal(\"QWE-is-4-RTY\", candidate.call([\"QWE\", \"is\", 4, \"RTY\"]))\n    assert_equal(\"ZEN-is-4-OP\", candidate.call([\"ZEN\", \"is\", 4, \"OP\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the average of cubes of first n natural numbers.\ndef find_Average_Of_Cube(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Average_Of_Cube\n    candidate = method(:find_Average_Of_Cube)\n    assert_equal(4.5, candidate.call(2))\n    assert_equal(12, candidate.call(3))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rb",
+    "prompt": "# Write a function to extract only the rear index element of each string in the given array.\ndef extract_rear(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_rear\n    candidate = method(:extract_rear)\n    assert_equal([\"s\", \"r\", \"s\"], candidate.call([\"Mers\", \"for\", \"Vers\"]))\n    assert_equal([\"e\", \"r\", \"e\"], candidate.call([\"Avenge\", \"for\", \"People\"]))\n    assert_equal([\"a\", \"t\", \"o\"], candidate.call([\"Gotta\", \"get\", \"go\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "rb",
+    "prompt": "# Write a function to count the number of subarrays containing a particular element.\ndef count_element_in_list(list1, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_element_in_list\n    candidate = method(:count_element_in_list)\n    assert_equal(3, candidate.call([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1))\n    assert_equal(3, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"))\n    assert_equal(1, candidate.call([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rb",
+    "prompt": "# Write a function to filter odd numbers.\ndef filter_oddnumbers(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_oddnumbers\n    candidate = method(:filter_oddnumbers)\n    assert_equal([1, 3, 5, 7, 9], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([45, 67, 93], candidate.call([10, 20, 45, 67, 84, 93]))\n    assert_equal([5, 7, 9, 3], candidate.call([5, 7, 9, 8, 6, 4, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rb",
+    "prompt": "# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\ndef change_date_format(dt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_change_date_format\n    candidate = method(:change_date_format)\n    assert_equal(\"02-01-2026\", candidate.call(\"2026-01-02\"))\n    assert_equal(\"13-11-2020\", candidate.call(\"2020-11-13\"))\n    assert_equal(\"26-04-2021\", candidate.call(\"2021-04-26\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort the given array by using shell sort.\ndef shell_sort(my_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_shell_sort\n    candidate = method(:shell_sort)\n    assert_equal([2, 3, 4, 5, 12, 12, 23, 56, 81, 95], candidate.call([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]))\n    assert_equal([22, 24, 34, 39, 68, 73, 87], candidate.call([24, 22, 39, 34, 87, 73, 68]))\n    assert_equal([16, 30, 32, 74, 82, 83, 96], candidate.call([32, 30, 16, 96, 82, 83, 74]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to extract the elementwise and arrays from the given two arrays.\ndef and_tuples(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_and_tuples\n    candidate = method(:and_tuples)\n    assert_equal([0, 0, 2, 1], candidate.call([10, 4, 6, 9], [5, 2, 3, 3]))\n    assert_equal([1, 2, 3, 0], candidate.call([1, 2, 3, 4], [5, 6, 7, 8]))\n    assert_equal([0, 9, 10, 0], candidate.call([8, 9, 11, 12], [7, 13, 14, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rb",
+    "prompt": "# Write a function to find the directrix of a parabola.\ndef parabola_directrix(a, b, c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_parabola_directrix\n    candidate = method(:parabola_directrix)\n    assert_equal(-198, candidate.call(5, 3, 2))\n    assert_equal(-2336, candidate.call(9, 8, 4))\n    assert_equal(-130, candidate.call(2, 4, 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "rb",
+    "prompt": "# Write a function that takes two arrays and returns true if they have at least one common element.\ndef common_element(list1, list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_common_element\n    candidate = method(:common_element)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]))\n    assert_equal(nil, candidate.call([1, 2, 3, 4, 5], [6, 7, 8, 9]))\n    assert_equal(true, candidate.call([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rb",
+    "prompt": "# Write a function to find the median length of a trapezium.\ndef median_trapezium(base1, base2, height)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_median_trapezium\n    candidate = method(:median_trapezium)\n    assert_equal(20, candidate.call(15, 25, 35))\n    assert_equal(15, candidate.call(10, 20, 30))\n    assert_equal(7.5, candidate.call(6, 9, 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the entered number is greater than the elements of the given array.\ndef check_greater(arr, number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_greater\n    candidate = method(:check_greater)\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5], 4))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 6], 8))\n    assert_equal(true, candidate.call([9, 7, 4, 8, 6, 1], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an a followed by one or more b's.\ndef text_match_one(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_one\n    candidate = method(:text_match_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the last digit of a given number.\ndef last_Digit(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit\n    candidate = method(:last_Digit)\n    assert_equal(3, candidate.call(123))\n    assert_equal(5, candidate.call(25))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to return the negative numbers in an array.\ndef neg_nos(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_neg_nos\n    candidate = method(:neg_nos)\n    assert_equal([-1, -6], candidate.call([-1, 4, 5, -6]))\n    assert_equal([-1, -2], candidate.call([-1, -2, 3, 4]))\n    assert_equal([-7, -6], candidate.call([-7, -6, 8, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rb",
+    "prompt": "# Write a function to remove odd characters in a string.\ndef remove_odd(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_odd\n    candidate = method(:remove_odd)\n    assert_equal(\"yhn\", candidate.call(\"python\"))\n    assert_equal(\"rga\", candidate.call(\"program\"))\n    assert_equal(\"agae\", candidate.call(\"language\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rb",
+    "prompt": "# Write a function to count bidirectional array pairs.\ndef count_bidirectional(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_bidirectional\n    candidate = method(:count_bidirectional)\n    assert_equal(3, candidate.call([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(2, candidate.call([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]))\n    assert_equal(4, candidate.call([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rb",
+    "prompt": "# Write a function to join an array of multiple integers into a single integer.\ndef multiple_to_single(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiple_to_single\n    candidate = method(:multiple_to_single)\n    assert_equal(113350, candidate.call([11, 33, 50]))\n    assert_equal(-123456, candidate.call([-1, 2, 3, 4, 5, 6]))\n    assert_equal(10152025, candidate.call([10, 15, 20, 25]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rb",
+    "prompt": "# Write a function to find the first adverb and their positions in a given sentence.\ndef find_adverb_position(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverb_position\n    candidate = method(:find_adverb_position)\n    assert_equal([0, 7, \"clearly\"], candidate.call(\"clearly!! we can see the sky\"))\n    assert_equal([0, 9, \"seriously\"], candidate.call(\"seriously!! there are many roses\"))\n    assert_equal([0, 13, \"unfortunately\"], candidate.call(\"unfortunately!! sita is going to home\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rb",
+    "prompt": "# Write a function to find the surface area of a cube of a given size.\ndef surfacearea_cube(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cube\n    candidate = method(:surfacearea_cube)\n    assert_equal(150, candidate.call(5))\n    assert_equal(54, candidate.call(3))\n    assert_equal(600, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rb",
+    "prompt": "# Write a function to find the ration of positive numbers in an array of integers.\ndef positive_count(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_positive_count\n    candidate = method(:positive_count)\n    assert_equal(0.54, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.69, candidate.call([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(0.56, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the largest negative number from the given array.\ndef largest_neg(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_largest_neg\n    candidate = method(:largest_neg)\n    assert_equal(-6, candidate.call([1, 2, 3, -4, -6]))\n    assert_equal(-9, candidate.call([1, 2, 3, -8, -9]))\n    assert_equal(-1, candidate.call([1, 2, 3, 4, -1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to trim each array by k in the given arrays.\ndef trim_tuple(test_list, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_trim_tuple\n    candidate = method(:trim_tuple)\n    assert_equal([[2], [9], [2], [2]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2))\n    assert_equal([[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]], candidate.call([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1))\n    assert_equal([[8, 4], [8, 12], [1, 7], [6, 9]], candidate.call([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rb",
+    "prompt": "# Write a function to perform index wise multiplication of array elements in the given two arrays.\ndef index_multiplication(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_multiplication\n    candidate = method(:index_multiplication)\n    assert_equal([[6, 21], [12, 45], [2, 9], [7, 30]], candidate.call([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]))\n    assert_equal([[14, 32], [20, 60], [6, 20], [16, 44]], candidate.call([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]))\n    assert_equal([[24, 45], [30, 77], [12, 33], [27, 60]], candidate.call([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the occurence of all elements of array in an array.\ndef count_Occurrence(tup, lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Occurrence\n    candidate = method(:count_Occurrence)\n    assert_equal(3, candidate.call([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]))\n    assert_equal(6, candidate.call([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6], [1, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rb",
+    "prompt": "# Write a function to find cubes of individual elements in an array.\ndef cube_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cube_nums\n    candidate = method(:cube_nums)\n    assert_equal([1, 8, 27, 64, 125, 216, 343, 512, 729, 1000], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30]))\n    assert_equal([1728, 3375], candidate.call([12, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the sum of perrin numbers.\ndef cal_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cal_sum\n    candidate = method(:cal_sum)\n    assert_equal(49, candidate.call(9))\n    assert_equal(66, candidate.call(10))\n    assert_equal(88, candidate.call(11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rb",
+    "prompt": "# Write a function to extract specified size of strings from a given array of string values.\ndef extract_string(str, l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_string\n    candidate = method(:extract_string)\n    assert_equal([\"practice\", \"solution\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8))\n    assert_equal([\"Python\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6))\n    assert_equal([\"exercises\"], candidate.call([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rb",
+    "prompt": "# Write a function to remove all whitespaces from the given string.\ndef remove_whitespaces(text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_whitespaces\n    candidate = method(:remove_whitespaces)\n    assert_equal(\"GoogleFlutter\", candidate.call(\" Google    Flutter \"))\n    assert_equal(\"GoogleDart\", candidate.call(\" Google    Dart \"))\n    assert_equal(\"iOSSwift\", candidate.call(\" iOS    Swift \"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rb",
+    "prompt": "# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\ndef loss_amount(actual_cost, sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_loss_amount\n    candidate = method(:loss_amount)\n    assert_equal(0, candidate.call(1500, 1200))\n    assert_equal(100, candidate.call(100, 200))\n    assert_equal(3000, candidate.call(2000, 5000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of even factors of a number.\ndef sumofFactors(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sumofFactors\n    candidate = method(:sumofFactors)\n    assert_equal(26, candidate.call(18))\n    assert_equal(48, candidate.call(30))\n    assert_equal(8, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rb",
+    "prompt": "# Write a function that matches a word containing 'z'.\ndef text_match_wordz(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz\n    candidate = method(:text_match_wordz)\n    assert_equal(true, candidate.call(\"pythonz.\"))\n    assert_equal(true, candidate.call(\"xyz.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given month number contains 31 days or not.\ndef check_monthnumb_number(monthnum2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumb_number\n    candidate = method(:check_monthnumb_number)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rb",
+    "prompt": "# Write a function to reverse each string in a given array of string values.\ndef reverse_string_list(stringlist)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_string_list\n    candidate = method(:reverse_string_list)\n    assert_equal([\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"], candidate.call([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]))\n    assert_equal([\"nhoj\", \"lama\", \"leoj\", \"egroeg\"], candidate.call([\"john\", \"amal\", \"joel\", \"george\"]))\n    assert_equal([\"kcaj\", \"nhoj\", \"yram\"], candidate.call([\"jack\", \"john\", \"mary\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the subarray having minimum length.\ndef Find_Min(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min\n    candidate = method(:Find_Min)\n    assert_equal([1], candidate.call([[1], [1, 2], [1, 2, 3]]))\n    assert_equal([1, 1], candidate.call([[1, 1], [1, 1, 1], [1, 2, 7, 8]]))\n    assert_equal([\"x\"], candidate.call([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rb",
+    "prompt": "# Write a function to find the area of a rectangle.\ndef rectangle_area(l, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rectangle_area\n    candidate = method(:rectangle_area)\n    assert_equal(200, candidate.call(10, 20))\n    assert_equal(50, candidate.call(10, 5))\n    assert_equal(8, candidate.call(4, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rb",
+    "prompt": "# Write a function to remove uppercase substrings from a given string.\ndef remove_uppercase(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_uppercase\n    candidate = method(:remove_uppercase)\n    assert_equal(\"cstyoravoitshos\", candidate.call(\"cAstyoUrFavoRitETVshoWs\"))\n    assert_equal(\"wtchheinerntrdo\", candidate.call(\"wAtchTheinTernEtrAdIo\"))\n    assert_equal(\"oiceachndreomendaion\", candidate.call(\"VoicESeaRchAndreComMendaTionS\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to get the first element of each subarray.\ndef Extract(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Extract\n    candidate = method(:Extract)\n    assert_equal([1, 3, 6], candidate.call([[1, 2], [3, 4, 5], [6, 7, 8, 9]]))\n    assert_equal([1, 4], candidate.call([[1, 2, 3], [4, 5]]))\n    assert_equal([9, 1], candidate.call([[9, 8, 1], [1, 2]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the upper case characters in a given string.\ndef upper_ctr(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_upper_ctr\n    candidate = method(:upper_ctr)\n    assert_equal(1, candidate.call(\"PYthon\"))\n    assert_equal(1, candidate.call(\"BigData\"))\n    assert_equal(0, candidate.call(\"program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "rb",
+    "prompt": "# Write a function to find all possible combinations of the elements of a given array.\ndef combinations_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_combinations_list\n    candidate = method(:combinations_list)\n    assert_equal([[], [\"orange\"], [\"red\"], [\"red\", \"orange\"], [\"green\"], [\"green\", \"orange\"], [\"green\", \"red\"], [\"green\", \"red\", \"orange\"], [\"blue\"], [\"blue\", \"orange\"], [\"blue\", \"red\"], [\"blue\", \"red\", \"orange\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"orange\"], [\"blue\", \"green\", \"red\"], [\"blue\", \"green\", \"red\", \"orange\"]], candidate.call([\"orange\", \"red\", \"green\", \"blue\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"blue\"], [\"blue\", \"red\"], [\"blue\", \"green\"], [\"blue\", \"green\", \"red\"], [\"white\"], [\"white\", \"red\"], [\"white\", \"green\"], [\"white\", \"green\", \"red\"], [\"white\", \"blue\"], [\"white\", \"blue\", \"red\"], [\"white\", \"blue\", \"green\"], [\"white\", \"blue\", \"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"black\", \"blue\"], [\"black\", \"blue\", \"red\"], [\"black\", \"blue\", \"green\"], [\"black\", \"blue\", \"green\", \"red\"], [\"black\", \"white\"], [\"black\", \"white\", \"red\"], [\"black\", \"white\", \"green\"], [\"black\", \"white\", \"green\", \"red\"], [\"black\", \"white\", \"blue\"], [\"black\", \"white\", \"blue\", \"red\"], [\"black\", \"white\", \"blue\", \"green\"], [\"black\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"blue\"], [\"orange\", \"blue\", \"red\"], [\"orange\", \"blue\", \"green\"], [\"orange\", \"blue\", \"green\", \"red\"], [\"orange\", \"white\"], [\"orange\", \"white\", \"red\"], [\"orange\", \"white\", \"green\"], [\"orange\", \"white\", \"green\", \"red\"], [\"orange\", \"white\", \"blue\"], [\"orange\", \"white\", \"blue\", \"red\"], [\"orange\", \"white\", \"blue\", \"green\"], [\"orange\", \"white\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"], [\"orange\", \"black\", \"blue\"], [\"orange\", \"black\", \"blue\", \"red\"], [\"orange\", \"black\", \"blue\", \"green\"], [\"orange\", \"black\", \"blue\", \"green\", \"red\"], [\"orange\", \"black\", \"white\"], [\"orange\", \"black\", \"white\", \"red\"], [\"orange\", \"black\", \"white\", \"green\"], [\"orange\", \"black\", \"white\", \"green\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\"], [\"orange\", \"black\", \"white\", \"blue\", \"red\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\"], [\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]))\n    assert_equal([[], [\"red\"], [\"green\"], [\"green\", \"red\"], [\"black\"], [\"black\", \"red\"], [\"black\", \"green\"], [\"black\", \"green\", \"red\"], [\"orange\"], [\"orange\", \"red\"], [\"orange\", \"green\"], [\"orange\", \"green\", \"red\"], [\"orange\", \"black\"], [\"orange\", \"black\", \"red\"], [\"orange\", \"black\", \"green\"], [\"orange\", \"black\", \"green\", \"red\"]], candidate.call([\"red\", \"green\", \"black\", \"orange\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum product subarray of the given array.\ndef max_subarray_product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_subarray_product\n    candidate = method(:max_subarray_product)\n    assert_equal(112, candidate.call([1, -2, -3, 0, 7, -8, -2]))\n    assert_equal(180, candidate.call([6, -3, -10, 0, 2]))\n    assert_equal(80, candidate.call([-2, -40, 0, -2, -3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rb",
+    "prompt": "# Write a function to check if all values are same in a hash.\ndef check_value(dict, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_value\n    candidate = method(:check_value)\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 10))\n    assert_equal(true, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 12))\n    assert_equal(false, candidate.call({\"Cierra Vega\" => 12, \"Alden Cantrell\" => 12, \"Kierra Gentry\" => 12, \"Pierre Cox\" => 12}, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "rb",
+    "prompt": "# Write a function to drop empty items from a given hash.\ndef drop_empty(dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_drop_empty\n    candidate = method(:drop_empty)\n    assert_equal({\"c1\" => \"Red\", \"c2\" => \"Green\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => \"Green\", \"c3\" => nil}))\n    assert_equal({\"c1\" => \"Red\"}, candidate.call({\"c1\" => \"Red\", \"c2\" => nil, \"c3\" => nil}))\n    assert_equal({\"c2\" => \"Green\"}, candidate.call({\"c1\" => nil, \"c2\" => \"Green\", \"c3\" => nil}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\ndef max_product(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_product\n    candidate = method(:max_product)\n    assert_equal(3000, candidate.call([3, 100, 4, 5, 150, 6]))\n    assert_equal(50265600, candidate.call([4, 42, 55, 68, 80]))\n    assert_equal(2460, candidate.call([10, 22, 9, 33, 21, 50, 41, 60]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rb",
+    "prompt": "# Write a function to find the pairwise addition of the neighboring elements of the given array.\ndef add_pairwise(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_pairwise\n    candidate = method(:add_pairwise)\n    assert_equal([6, 12, 15, 18], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 14, 17, 20], candidate.call([2, 6, 8, 9, 11]))\n    assert_equal([10, 16, 19, 22], candidate.call([3, 7, 9, 10, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the product of the array multiplication modulo n.\ndef find_remainder(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_remainder\n    candidate = method(:find_remainder)\n    assert_equal(9, candidate.call([100, 10, 5, 25, 35, 14], 11))\n    assert_equal(0, candidate.call([1, 1, 1], 1))\n    assert_equal(0, candidate.call([1, 2, 1], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given array contains consecutive numbers or not.\ndef check_Consecutive(l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_Consecutive\n    candidate = method(:check_Consecutive)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5]))\n    assert_equal(false, candidate.call([1, 2, 3, 5, 6]))\n    assert_equal(false, candidate.call([1, 2, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rb",
+    "prompt": "# Write a function to replace characters in a string.\ndef replace_char(str1, ch, newch)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_char\n    candidate = method(:replace_char)\n    assert_equal(\"pollgon\", candidate.call(\"polygon\", \"y\", \"l\"))\n    assert_equal(\"aharaater\", candidate.call(\"character\", \"c\", \"a\"))\n    assert_equal(\"python\", candidate.call(\"python\", \"l\", \"a\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rb",
+    "prompt": "# Write a function to sort a hash by value.\ndef sort_counter(dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_counter\n    candidate = method(:sort_counter)\n    assert_equal([[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]], candidate.call({\"Math\" => 81, \"Physics\" => 83, \"Chemistry\" => 87}))\n    assert_equal([[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]], candidate.call({\"Math\" => 400, \"Physics\" => 300, \"Chemistry\" => 250}))\n    assert_equal([[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]], candidate.call({\"Math\" => 900, \"Physics\" => 1000, \"Chemistry\" => 1250}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of the largest and smallest value in a given array.\ndef big_sum(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_sum\n    candidate = method(:big_sum)\n    assert_equal(4, candidate.call([1, 2, 3]))\n    assert_equal(3, candidate.call([-1, 2, 3, 4]))\n    assert_equal(8, candidate.call([2, 3, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to convert the given string to lower case.\ndef is_lower(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_lower\n    candidate = method(:is_lower)\n    assert_equal(\"invalid\", candidate.call(\"InValid\"))\n    assert_equal(\"true\", candidate.call(\"TruE\"))\n    assert_equal(\"sentence\", candidate.call(\"SenTenCE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rb",
+    "prompt": "# Write a function to remove lowercase substrings from a given string.\ndef remove_lowercase(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_lowercase\n    candidate = method(:remove_lowercase)\n    assert_equal(\"PYTH\", candidate.call(\"PYTHon\"))\n    assert_equal(\"FID\", candidate.call(\"FInD\"))\n    assert_equal(\"STRG\", candidate.call(\"STRinG\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the first digit of a given number.\ndef first_Digit(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_Digit\n    candidate = method(:first_Digit)\n    assert_equal(1, candidate.call(123))\n    assert_equal(4, candidate.call(456))\n    assert_equal(1, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rb",
+    "prompt": "# Write a function to find the n largest integers from a given array of numbers, returned in descending order.\ndef heap_queue_largest(nums, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_queue_largest\n    candidate = method(:heap_queue_largest)\n    assert_equal([85, 75, 65], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 3))\n    assert_equal([85, 75], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 2))\n    assert_equal([85, 75, 65, 58, 35], candidate.call([25, 35, 22, 85, 14, 65, 75, 22, 58], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rb",
+    "prompt": "# Write a rbthon function which takes an array of integers and only returns the odd ones.\ndef Split(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([1, 3, 5], candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal([11, 13], candidate.call([10, 11, 12, 13]))\n    assert_equal([7, 9, 1], candidate.call([7, 8, 9, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\ndef difference(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_difference\n    candidate = method(:difference)\n    assert_equal(30, candidate.call(3))\n    assert_equal(210, candidate.call(5))\n    assert_equal(6, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of pairs whose xor value is odd.\ndef find_Odd_Pair(a, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Odd_Pair\n    candidate = method(:find_Odd_Pair)\n    assert_equal(6, candidate.call([5, 4, 7, 2, 1], 5))\n    assert_equal(12, candidate.call([7, 2, 8, 1, 0, 5, 11], 7))\n    assert_equal(2, candidate.call([1, 2, 3], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rb",
+    "prompt": "# Write a function to toggle the case of all characters in a string.\ndef toggle_string(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_string\n    candidate = method(:toggle_string)\n    assert_equal(\"pYTHON\", candidate.call(\"Python\"))\n    assert_equal(\"pANGRAM\", candidate.call(\"Pangram\"))\n    assert_equal(\"liTTle\", candidate.call(\"LIttLE\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of the per-digit difference between two integers.\ndef digit_distance_nums(n1, n2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_digit_distance_nums\n    candidate = method(:digit_distance_nums)\n    assert_equal(1, candidate.call(1, 2))\n    assert_equal(6, candidate.call(23, 56))\n    assert_equal(7, candidate.call(123, 256))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the sum of the largest contiguous subarray in the given array.\ndef max_sub_array_sum(a, size)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sub_array_sum\n    candidate = method(:max_sub_array_sum)\n    assert_equal(7, candidate.call([-2, -3, 4, -1, -2, 1, 5, -3], 8))\n    assert_equal(8, candidate.call([-3, -4, 5, -2, -3, 2, 6, -4], 8))\n    assert_equal(10, candidate.call([-4, -5, 6, -3, -4, 3, 7, -5], 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rb",
+    "prompt": "# Write a function to find the union of the elements of two given arrays and output them in sorted order.\ndef union_elements(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_union_elements\n    candidate = method(:union_elements)\n    assert_equal([3, 4, 5, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 2, 3, 4, 5, 6], candidate.call([1, 2, 3, 4], [3, 4, 5, 6]))\n    assert_equal([11, 12, 13, 14, 15, 16, 17], candidate.call([11, 12, 13, 14], [13, 15, 16, 17]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the length of the longest subarrays.\ndef Find_Max_Length(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Max_Length\n    candidate = method(:Find_Max_Length)\n    assert_equal(4, candidate.call([[1], [1, 4], [5, 6, 7, 8]]))\n    assert_equal(3, candidate.call([[0, 1], [2, 2], [3, 2, 1]]))\n    assert_equal(5, candidate.call([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "rb",
+    "prompt": "# Write a function to extract values between quotation marks from a string.\ndef extract_values(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_values\n    candidate = method(:extract_values)\n    assert_equal([\"Python\", \"PHP\", \"Java\"], candidate.call(\"\"Python\", \"PHP\", \"Java\"\"))\n    assert_equal([\"python\", \"program\", \"language\"], candidate.call(\"\"python\",\"program\",\"language\"\"))\n    assert_equal([\"red\", \"blue\", \"green\", \"yellow\"], candidate.call(\"\"red\",\"blue\",\"green\",\"yellow\"\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rb",
+    "prompt": "# Write a rbthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\ndef count_Pairs(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Pairs\n    candidate = method(:count_Pairs)\n    assert_equal(2, candidate.call([1, 2, 1], 3))\n    assert_equal(0, candidate.call([1, 1, 1, 1], 4))\n    assert_equal(10, candidate.call([1, 2, 3, 4, 5], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to split a string into characters.\ndef split(word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split\n    candidate = method(:split)\n    assert_equal([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], candidate.call(\"python\"))\n    assert_equal([\"N\", \"a\", \"m\", \"e\"], candidate.call(\"Name\"))\n    assert_equal([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"], candidate.call(\"program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rb",
+    "prompt": "# Write a function to get the sum of the digits of a non-negative integer.\ndef sum_digits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_digits\n    candidate = method(:sum_digits)\n    assert_equal(12, candidate.call(345))\n    assert_equal(3, candidate.call(12))\n    assert_equal(16, candidate.call(97))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rb",
+    "prompt": "# Write a function to check whether a specified array is sorted or not.\ndef issort_list(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_issort_list\n    candidate = method(:issort_list)\n    assert_equal(true, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]))\n    assert_equal(false, candidate.call([1, 2, 4, 6, 8, 10, 15, 14, 20]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "rb",
+    "prompt": "# Write a function to create an array of N empty dictionaries.\ndef empty_list(length)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_empty_list\n    candidate = method(:empty_list)\n    assert_equal([{}, {}, {}, {}, {}], candidate.call(5))\n    assert_equal([{}, {}, {}, {}, {}, {}], candidate.call(6))\n    assert_equal([{}, {}, {}, {}, {}, {}, {}], candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rb",
+    "prompt": "# Write a function to sort each subarray of strings in a given array of arrays.\ndef sort_sublists(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_sublists\n    candidate = method(:sort_sublists)\n    assert_equal([[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]))\n    assert_equal([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]], candidate.call([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]))\n    assert_equal([[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]], candidate.call([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check if a given number is one less than twice its reverse.\ndef checks(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_checks\n    candidate = method(:checks)\n    assert_equal(false, candidate.call(70))\n    assert_equal(false, candidate.call(23))\n    assert_equal(true, candidate.call(73))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to remove duplicate numbers from a given number of arrays.\ndef two_unique_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_two_unique_nums\n    candidate = method(:two_unique_nums)\n    assert_equal([1, 4, 5], candidate.call([1, 2, 3, 2, 3, 4, 5]))\n    assert_equal([1, 3, 4, 5], candidate.call([1, 2, 3, 2, 4, 5]))\n    assert_equal([1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to calculate the product of the unique numbers in a given array.\ndef unique_product(list_data)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_product\n    candidate = method(:unique_product)\n    assert_equal(720000000, candidate.call([10, 20, 30, 40, 20, 50, 60, 40]))\n    assert_equal(6, candidate.call([1, 2, 3, 1]))\n    assert_equal(0, candidate.call([7, 8, 9, 0, 1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rb",
+    "prompt": "# Write a function to find the surface area of a cylinder.\ndef surfacearea_cylinder(r, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surfacearea_cylinder\n    candidate = method(:surfacearea_cylinder)\n    assert_equal(942.45, candidate.call(10, 5))\n    assert_equal(226.18800000000002, candidate.call(4, 5))\n    assert_equal(351.848, candidate.call(4, 10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether an array is subarray of another or not.\ndef is_Sub_Array(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Sub_Array\n    candidate = method(:is_Sub_Array)\n    assert_equal(false, candidate.call([1, 4, 3, 5], [1, 2]))\n    assert_equal(true, candidate.call([1, 2, 1], [1, 2, 1]))\n    assert_equal(false, candidate.call([1, 0, 2, 2], [2, 2, 0]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the last digit in factorial of a given number.\ndef last_Digit_Factorial(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last_Digit_Factorial\n    candidate = method(:last_Digit_Factorial)\n    assert_equal(4, candidate.call(4))\n    assert_equal(0, candidate.call(21))\n    assert_equal(0, candidate.call(30))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rb",
+    "prompt": "# Write a function to interleave 3 arrays of the same length into a single flat array.\ndef interleave_lists(list1, list2, list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_interleave_lists\n    candidate = method(:interleave_lists)\n    assert_equal([1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700], candidate.call([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]))\n    assert_equal([10, 15, 5, 20, 2, 10], candidate.call([10, 20], [15, 2], [5, 10]))\n    assert_equal([11, 10, 20, 44, 15, 5], candidate.call([11, 44], [10, 15], [20, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rb",
+    "prompt": "# Write a function to find the dissimilar elements in the given two arrays.\ndef find_dissimilar(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_dissimilar\n    candidate = method(:find_dissimilar)\n    assert_equal([3, 6, 7, 10], candidate.call([3, 4, 5, 6], [5, 7, 4, 10]))\n    assert_equal([1, 4, 7, 9], candidate.call([1, 2, 3, 4], [7, 2, 3, 9]))\n    assert_equal([34, 36, 11, 25], candidate.call([21, 11, 25, 26], [26, 34, 21, 36]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the largest number that can be formed with the given array of digits.\ndef find_Max_Num(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Max_Num\n    candidate = method(:find_Max_Num)\n    assert_equal(321, candidate.call([1, 2, 3]))\n    assert_equal(6541, candidate.call([4, 5, 6, 1]))\n    assert_equal(9321, candidate.call([1, 2, 3, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "rb",
+    "prompt": "# Write a function to remove uneven elements in the nested mixed array.\ndef extract_even(test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_even\n    candidate = method(:extract_even)\n    assert_equal([4, [6, [2, 4]], 6, 8], candidate.call([4, 5, [7, 6, [2, 4]], 6, 8]))\n    assert_equal([6, [8, [4, 8]]], candidate.call([5, 6, [8, 7, [4, 8]], 7, 9]))\n    assert_equal([6, [8, [4, 6]], 8, 10], candidate.call([5, 6, [9, 8, [4, 6]], 8, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the surface area of a square rbramid with a given base edge and height.\ndef surface_Area(b, s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_surface_Area\n    candidate = method(:surface_Area)\n    assert_equal(33, candidate.call(3, 4))\n    assert_equal(56, candidate.call(4, 5))\n    assert_equal(5, candidate.call(1, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rb",
+    "prompt": "# Write a function which returns nth catalan number.\ndef catalan_number(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_catalan_number\n    candidate = method(:catalan_number)\n    assert_equal(16796, candidate.call(10))\n    assert_equal(4862, candidate.call(9))\n    assert_equal(429, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rb",
+    "prompt": "# Write a function to find the first adverb ending with ly and its positions in a given string.\ndef find_adverbs(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_adverbs\n    candidate = method(:find_adverbs)\n    assert_equal(\"0-7: Clearly\", candidate.call(\"Clearly, he has no excuse for such behavior.\"))\n    assert_equal(\"28-36: carefuly\", candidate.call(\"Please handle the situation carefuly\"))\n    assert_equal(\"18-25: quickly\", candidate.call(\"Complete the task quickly\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "rb",
+    "prompt": "# Write a function to find the n most expensive items in a given dataset.\ndef expensive_items(items, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_expensive_items\n    candidate = method(:expensive_items)\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}], 1))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-1\", \"price\" => 101.1}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}], 2))\n    assert_equal([{\"name\" => \"Item-2\", \"price\" => 555.22}], candidate.call([{\"name\" => \"Item-1\", \"price\" => 101.1}, {\"name\" => \"Item-2\", \"price\" => 555.22}, {\"name\" => \"Item-3\", \"price\" => 45.09}, {\"name\" => \"Item-4\", \"price\" => 22.75}], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to split an array at the nth eelment and add the first part to the end.\ndef split_Arr(l, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_split_Arr\n    candidate = method(:split_Arr)\n    assert_equal([5, 6, 52, 36, 12, 10], candidate.call([12, 10, 5, 6, 52, 36], 2))\n    assert_equal([2, 3, 4, 1], candidate.call([1, 2, 3, 4], 1))\n    assert_equal([3, 4, 5, 6, 7, 0, 1, 2], candidate.call([0, 1, 2, 3, 4, 5, 6, 7], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to convert an array to an array.\ndef list_tuple(listx)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_list_tuple\n    candidate = method(:list_tuple)\n    assert_equal([5, 10, 7, 4, 15, 3], candidate.call([5, 10, 7, 4, 15, 3]))\n    assert_equal([2, 4, 5, 6, 2, 3, 4, 4, 7], candidate.call([2, 4, 5, 6, 2, 3, 4, 4, 7]))\n    assert_equal([58, 44, 56], candidate.call([58, 44, 56]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the difference between largest and smallest value in a given array.\ndef big_diff(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_big_diff\n    candidate = method(:big_diff)\n    assert_equal(3, candidate.call([1, 2, 3, 4]))\n    assert_equal(8, candidate.call([4, 5, 12]))\n    assert_equal(7, candidate.call([9, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rb",
+    "prompt": "# Write a function to find perfect squares between two given numbers.\ndef perfect_squares(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_perfect_squares\n    candidate = method(:perfect_squares)\n    assert_equal([1, 4, 9, 16, 25], candidate.call(1, 30))\n    assert_equal([64, 81, 100], candidate.call(50, 100))\n    assert_equal([100, 121, 144, 169, 196], candidate.call(100, 200))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given two integers have opposite sign or not.\ndef opposite_Signs(x, y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_opposite_Signs\n    candidate = method(:opposite_Signs)\n    assert_equal(true, candidate.call(1, -2))\n    assert_equal(false, candidate.call(3, 2))\n    assert_equal(false, candidate.call(-10, -10))\n    assert_equal(true, candidate.call(-2, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to interchange the first and last elements in an array.\ndef swap_List(newlist)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([24, 35, 9, 56, 12], candidate.call([12, 35, 9, 56, 24]))\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of the product of consecutive binomial co-efficients.\ndef sum_Of_product(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_product\n    candidate = method(:sum_Of_product)\n    assert_equal(15, candidate.call(3))\n    assert_equal(56, candidate.call(4))\n    assert_equal(1, candidate.call(1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rb",
+    "prompt": "# Write a function to remove leading zeroes from an ip address.\ndef removezero_ip(ip)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_removezero_ip\n    candidate = method(:removezero_ip)\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.196\"))\n    assert_equal(\"12.1.24\", candidate.call(\"12.01.024\"))\n    assert_equal(\"216.8.94.196\", candidate.call(\"216.08.094.0196\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rb",
+    "prompt": "# Write a function to find the difference of the first even and first odd number of a given array.\ndef diff_even_odd(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_diff_even_odd\n    candidate = method(:diff_even_odd)\n    assert_equal(3, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(1, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(9, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\ndef min_Swaps(str1, str2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Swaps\n    candidate = method(:min_Swaps)\n    assert_equal(1, candidate.call(\"1101\", \"1110\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"000\"))\n    assert_equal(\"Not Possible\", candidate.call(\"111\", \"110\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rb",
+    "prompt": "# Write a function to find kth element from the given two sorted arrays.\ndef find_kth(arr1, arr2, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_kth\n    candidate = method(:find_kth)\n    assert_equal(6, candidate.call([2, 3, 6, 7, 9], [1, 4, 8, 10], 5))\n    assert_equal(256, candidate.call([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7))\n    assert_equal(8, candidate.call([3, 4, 7, 8, 10], [2, 5, 9, 11], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is armstrong or not.\ndef armstrong_number(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_armstrong_number\n    candidate = method(:armstrong_number)\n    assert_equal(true, candidate.call(153))\n    assert_equal(false, candidate.call(259))\n    assert_equal(false, candidate.call(4458))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rb",
+    "prompt": "# Write a function to find sum and average of first n natural numbers.\ndef sum_average(number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_average\n    candidate = method(:sum_average)\n    assert_equal([55, 5.5], candidate.call(10))\n    assert_equal([120, 8.0], candidate.call(15))\n    assert_equal([210, 10.5], candidate.call(20))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth octagonal number.\ndef is_octagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_octagonal\n    candidate = method(:is_octagonal)\n    assert_equal(65, candidate.call(5))\n    assert_equal(280, candidate.call(10))\n    assert_equal(645, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given number is even or not.\ndef is_Even(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Even\n    candidate = method(:is_Even)\n    assert_equal(false, candidate.call(1))\n    assert_equal(true, candidate.call(2))\n    assert_equal(false, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the first repeated character in a given string.\ndef first_repeated_char(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_repeated_char\n    candidate = method(:first_repeated_char)\n    assert_equal(\"a\", candidate.call(\"abcabc\"))\n    assert_equal(nil, candidate.call(\"abc\"))\n    assert_equal(\"1\", candidate.call(\"123123\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rb",
+    "prompt": "# Write a function to get all lucid numbers smaller than or equal to a given integer.\ndef get_ludic(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_ludic\n    candidate = method(:get_ludic)\n    assert_equal([1, 2, 3, 5, 7], candidate.call(10))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25], candidate.call(25))\n    assert_equal([1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43], candidate.call(45))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rb",
+    "prompt": "# Write a function to reverse words seperated by spaces in a given string.\ndef reverse_words(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_words\n    candidate = method(:reverse_words)\n    assert_equal(\"program python\", candidate.call(\"python program\"))\n    assert_equal(\"language java\", candidate.call(\"java language\"))\n    assert_equal(\"man indian\", candidate.call(\"indian man\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given integer is a prime number.\ndef prime_num(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_prime_num\n    candidate = method(:prime_num)\n    assert_equal(true, candidate.call(13))\n    assert_equal(true, candidate.call(7))\n    assert_equal(false, candidate.call(-1010))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rb",
+    "prompt": "# Write a function to convert degrees to radians.\ndef radian_degree(degree)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_radian_degree\n    candidate = method(:radian_degree)\n    assert_equal(1.5707963267948966, candidate.call(90))\n    assert_equal(1.0471975511965976, candidate.call(60))\n    assert_equal(2.0943951023931953, candidate.call(120))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rb",
+    "prompt": "# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\ndef find_literals(text, pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_literals\n    candidate = method(:find_literals)\n    assert_equal([\"fox\", 16, 19], candidate.call(\"The quick brown fox jumps over the lazy dog.\", \"fox\"))\n    assert_equal([\"crazy\", 16, 21], candidate.call(\"Its been a very crazy procedure right\", \"crazy\"))\n    assert_equal([\"will\", 35, 39], candidate.call(\"Hardest choices required strongest will\", \"will\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find nth bell number.\ndef bell_Number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_Number\n    candidate = method(:bell_Number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(5, candidate.call(3))\n    assert_equal(15, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rb",
+    "prompt": "# Write a rbthon function which takes an array and returns an array with the same elements, but the k'th element removed.\ndef remove_kth_element(list1, l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_kth_element\n    candidate = method(:remove_kth_element)\n    assert_equal([1, 1, 3, 4, 4, 5, 1], candidate.call([1, 1, 2, 3, 4, 4, 5, 1], 3))\n    assert_equal([0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4))\n    assert_equal([10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rb",
+    "prompt": "# Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\ndef max_of_nth(test_list, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_of_nth\n    candidate = method(:max_of_nth)\n    assert_equal(19, candidate.call([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2))\n    assert_equal(10, candidate.call([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1))\n    assert_equal(11, candidate.call([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "rb",
+    "prompt": "# Write a rbthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\ndef merge(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge\n    candidate = method(:merge)\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]], candidate.call([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]))\n    assert_equal([[1, 3, 5, 7], [2, 4, 6, 8]], candidate.call([[1, 2], [3, 4], [5, 6], [7, 8]]))\n    assert_equal([[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]], candidate.call([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rb",
+    "prompt": "# Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\ndef cummulative_sum(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_cummulative_sum\n    candidate = method(:cummulative_sum)\n    assert_equal(30, candidate.call([[1, 3], [5, 6, 7], [2, 6]]))\n    assert_equal(37, candidate.call([[2, 4], [6, 7, 8], [3, 7]]))\n    assert_equal(44, candidate.call([[3, 5], [7, 8, 9], [4, 8]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rb",
+    "prompt": "# Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\ndef average_tuple(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_average_tuple\n    candidate = method(:average_tuple)\n    assert_equal([30.5, 34.25, 27.0, 23.25], candidate.call([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]))\n    assert_equal([25.5, -18.0, 3.75], candidate.call([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]))\n    assert_equal([305.0, 342.5, 270.0, 232.5], candidate.call([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rb",
+    "prompt": "# Write a function which takes two arrays of the same length and performs the element wise modulo.\ndef tuple_modulo(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_modulo\n    candidate = method(:tuple_modulo)\n    assert_equal([0, 4, 5, 1], candidate.call([10, 4, 5, 6], [5, 6, 7, 5]))\n    assert_equal([5, 5, 6, 1], candidate.call([11, 5, 6, 7], [6, 7, 8, 6]))\n    assert_equal([5, 6, 7, 1], candidate.call([12, 6, 7, 8], [7, 8, 9, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rb",
+    "prompt": "# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\ndef min_Jumps(steps, d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_Jumps\n    candidate = method(:min_Jumps)\n    assert_equal(3.5, candidate.call([3, 4], 11))\n    assert_equal(0, candidate.call([3, 4], 0))\n    assert_equal(1, candidate.call([11, 14], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rb",
+    "prompt": "# Write a function to divide two arrays element wise.\ndef div_list(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_div_list\n    candidate = method(:div_list)\n    assert_equal([4.0, 2.5, 2.0], candidate.call([4, 5, 6], [1, 2, 3]))\n    assert_equal([3.0, 0.5], candidate.call([3, 2], [1, 4]))\n    assert_equal([1.8, 1.7142857142857142], candidate.call([90, 120], [50, 70]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rb",
+    "prompt": "# Write a function to move all the numbers to the end of the given string.\ndef move_num(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_num\n    candidate = method(:move_num)\n    assert_equal(\"Iloveyouthreethousand1143553000\", candidate.call(\"I1love143you55three3000thousand\"))\n    assert_equal(\"AvengersAssemble124\", candidate.call(\"Avengers124Assemble\"))\n    assert_equal(\"Itsourpathtoseethingsdothings11121314151617\", candidate.call(\"Its11our12path13to14see15things16do17things\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of substrings with the sum of digits equal to their length.\ndef count_Substrings(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_Substrings\n    candidate = method(:count_Substrings)\n    assert_equal(6, candidate.call(\"112112\"))\n    assert_equal(6, candidate.call(\"111\"))\n    assert_equal(12, candidate.call(\"1101112\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rb",
+    "prompt": "# Write a function to find the median of two sorted arrays of same size.\ndef get_median(arr1, arr2, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_median\n    candidate = method(:get_median)\n    assert_equal(16.0, candidate.call([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5))\n    assert_equal(8.5, candidate.call([2, 4, 8, 9], [7, 13, 19, 28], 4))\n    assert_equal(25.0, candidate.call([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rb",
+    "prompt": "# Write a function to compute the n-th power of each number in an array.\ndef nth_nums(nums, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_nth_nums\n    candidate = method(:nth_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([1000, 8000, 27000], candidate.call([10, 20, 30], 3))\n    assert_equal([248832, 759375], candidate.call([12, 15], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to convert a given string to uppercase.\ndef is_upper(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_upper\n    candidate = method(:is_upper)\n    assert_equal(\"PERSON\", candidate.call(\"person\"))\n    assert_equal(\"FINAL\", candidate.call(\"final\"))\n    assert_equal(\"VALID\", candidate.call(\"Valid\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to interchange the first and last element in a given array.\ndef swap_List(newlist)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_swap_List\n    candidate = method(:swap_List)\n    assert_equal([3, 2, 1], candidate.call([1, 2, 3]))\n    assert_equal([4, 2, 3, 4, 1], candidate.call([1, 2, 3, 4, 4]))\n    assert_equal([6, 5, 4], candidate.call([4, 5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\ndef triangle_area(r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_triangle_area\n    candidate = method(:triangle_area)\n    assert_equal(nil, candidate.call(-1))\n    assert_equal(0, candidate.call(0))\n    assert_equal(4, candidate.call(2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the smallest missing number from a sorted array of natural numbers.\ndef find_First_Missing(array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_First_Missing\n    candidate = method(:find_First_Missing)\n    assert_equal(4, candidate.call([0, 1, 2, 3]))\n    assert_equal(3, candidate.call([0, 1, 2, 6, 9]))\n    assert_equal(0, candidate.call([2, 3, 5, 8, 9]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to replace all spaces in the given string with '%20'.\ndef replace_spaces(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"My%20Name%20is%20Dawood\", candidate.call(\"My Name is Dawood\"))\n    assert_equal(\"I%20am%20a%20Programmer\", candidate.call(\"I am a Programmer\"))\n    assert_equal(\"I%20love%20Coding\", candidate.call(\"I love Coding\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find even numbers from an array of numbers.\ndef Split(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Split\n    candidate = method(:Split)\n    assert_equal([2, 4], candidate.call([1, 2, 3, 4, 5]))\n    assert_equal([4, 6, 8, 0], candidate.call([4, 5, 6, 7, 8, 0, 1]))\n    assert_equal([8, 12], candidate.call([8, 12, 15, 19]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find smallest number in an array.\ndef smallest_num(xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_smallest_num\n    candidate = method(:smallest_num)\n    assert_equal(1, candidate.call([10, 20, 1, 45, 99]))\n    assert_equal(1, candidate.call([1, 2, 3]))\n    assert_equal(45, candidate.call([45, 46, 50, 60]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rb",
+    "prompt": "# Write a function to extract all the adjacent coordinates of the given coordinate array.\ndef get_coordinates(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_coordinates\n    candidate = method(:get_coordinates)\n    assert_equal([[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]], candidate.call([3, 4]))\n    assert_equal([[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]], candidate.call([4, 5]))\n    assert_equal([[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]], candidate.call([5, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to replace whitespaces with an underscore and vice versa in a given string.\ndef replace_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_spaces\n    candidate = method(:replace_spaces)\n    assert_equal(\"Jumanji_The_Jungle\", candidate.call(\"Jumanji The Jungle\"))\n    assert_equal(\"The Avengers\", candidate.call(\"The_Avengers\"))\n    assert_equal(\"Fast_and_Furious\", candidate.call(\"Fast and Furious\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to move all zeroes to the end of the given array.\ndef move_zero(num_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_move_zero\n    candidate = method(:move_zero)\n    assert_equal([1, 2, 3, 4, 0, 0], candidate.call([1, 0, 2, 0, 3, 4]))\n    assert_equal([2, 3, 2, 4, 5, 0, 0, 0, 0], candidate.call([2, 3, 2, 0, 0, 4, 0, 5, 0]))\n    assert_equal([1, 1, 1, 0, 0], candidate.call([0, 1, 0, 1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of xor of all pairs of numbers in the given array.\ndef pair_xor_Sum(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_xor_Sum\n    candidate = method(:pair_xor_Sum)\n    assert_equal(47, candidate.call([5, 9, 7, 6], 4))\n    assert_equal(12, candidate.call([7, 3, 5], 3))\n    assert_equal(4, candidate.call([7, 3], 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort the given array.\ndef heap_sort(iterable)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_heap_sort\n    candidate = method(:heap_sort)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], candidate.call([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]))\n    assert_equal([14, 22, 25, 25, 35, 58, 65, 75, 85], candidate.call([25, 35, 22, 85, 14, 65, 75, 25, 58]))\n    assert_equal([1, 5, 7, 9], candidate.call([7, 1, 9, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given amount has no profit and no loss\ndef noprofit_noloss(actual_cost, sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_noprofit_noloss\n    candidate = method(:noprofit_noloss)\n    assert_equal(false, candidate.call(1500, 1200))\n    assert_equal(true, candidate.call(100, 100))\n    assert_equal(false, candidate.call(2000, 5000))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\ndef wind_chill(v, t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_wind_chill\n    candidate = method(:wind_chill)\n    assert_equal(40, candidate.call(120, 35))\n    assert_equal(19, candidate.call(40, 20))\n    assert_equal(6, candidate.call(10, 8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rb",
+    "prompt": "# Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\ndef sample_nam(sample_names)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sample_nam\n    candidate = method(:sample_nam)\n    assert_equal(16, candidate.call([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]))\n    assert_equal(10, candidate.call([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]))\n    assert_equal(6, candidate.call([\"abcd\", \"Python\", \"abba\", \"aba\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rb",
+    "prompt": "# Write a function to find the maximum difference between available pairs in the given array array.\ndef max_difference(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_difference\n    candidate = method(:max_difference)\n    assert_equal(7, candidate.call([[3, 5], [1, 7], [10, 3], [1, 2]]))\n    assert_equal(15, candidate.call([[4, 6], [2, 17], [9, 13], [11, 12]]))\n    assert_equal(23, candidate.call([[12, 35], [21, 27], [13, 23], [41, 22]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rb",
+    "prompt": "# Write a function to remove the parenthesis and what is inbetween them from a string.\ndef remove_parenthesis(items)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_parenthesis\n    candidate = method(:remove_parenthesis)\n    assert_equal(\"python\", candidate.call([\"python (chrome)\"]))\n    assert_equal(\"string\", candidate.call([\"string(.abc)\"]))\n    assert_equal(\"alpha\", candidate.call([\"alpha(num)\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth nonagonal number.\ndef is_nonagonal(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_nonagonal\n    candidate = method(:is_nonagonal)\n    assert_equal(325, candidate.call(10))\n    assert_equal(750, candidate.call(15))\n    assert_equal(1089, candidate.call(18))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rb",
+    "prompt": "# Write a function that checks if a strings contains 'z', except at the start and end of the word.\ndef text_match_wordz_middle(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_wordz_middle\n    candidate = method(:text_match_wordz_middle)\n    assert_equal(true, candidate.call(\"pythonzabc.\"))\n    assert_equal(false, candidate.call(\"zxyabc.\"))\n    assert_equal(false, candidate.call(\"  lang  .\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to reverse an array upto a given position.\ndef reverse_Array_Upto_K(input, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_reverse_Array_Upto_K\n    candidate = method(:reverse_Array_Upto_K)\n    assert_equal([4, 3, 2, 1, 5, 6], candidate.call([1, 2, 3, 4, 5, 6], 4))\n    assert_equal([5, 4, 6, 7], candidate.call([4, 5, 6, 7], 2))\n    assert_equal([7, 8, 9, 6, 5], candidate.call([9, 8, 7, 6, 5], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rb",
+    "prompt": "# Write a function to sort an array of arrays using the second value of each array.\ndef subject_marks(subjectmarks)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_subject_marks\n    candidate = method(:subject_marks)\n    assert_equal([[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]], candidate.call([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]))\n    assert_equal([[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]], candidate.call([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]))\n    assert_equal([[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]], candidate.call([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "rb",
+    "prompt": "# Write a function to flatten an array and sum all of its elements.\ndef recursive_list_sum(data_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_recursive_list_sum\n    candidate = method(:recursive_list_sum)\n    assert_equal(21, candidate.call([1, 2, [3, 4], [5, 6]]))\n    assert_equal(106, candidate.call([7, 10, [15, 14], [19, 41]]))\n    assert_equal(210, candidate.call([10, 20, [30, 40], [50, 60]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of positive numbers in an array.\ndef pos_count(list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pos_count\n    candidate = method(:pos_count)\n    assert_equal(2, candidate.call([1, -2, 3, -4]))\n    assert_equal(3, candidate.call([3, 4, 5, -1]))\n    assert_equal(4, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rb",
+    "prompt": "# Write a function to find the number of ways to partition a set of Bell numbers.\ndef bell_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_bell_number\n    candidate = method(:bell_number)\n    assert_equal(2, candidate.call(2))\n    assert_equal(115975, candidate.call(10))\n    assert_equal(6775685320645824322581483068371419745979053216268760300, candidate.call(56))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given array is monotonic or not.\ndef is_Monotonic(a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Monotonic\n    candidate = method(:is_Monotonic)\n    assert_equal(true, candidate.call([6, 5, 4, 4]))\n    assert_equal(true, candidate.call([1, 2, 2, 3]))\n    assert_equal(false, candidate.call([1, 3, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rb",
+    "prompt": "# Write a function to check whether an array contains the given subarray or not.\ndef is_sublist(l, s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_sublist\n    candidate = method(:is_sublist)\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [3, 7]))\n    assert_equal(true, candidate.call([2, 4, 3, 5, 7], [4, 3]))\n    assert_equal(false, candidate.call([2, 4, 3, 5, 7], [1, 6]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the two numbers differ at one bit position only or not.\ndef differ_At_One_Bit_Pos(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_differ_At_One_Bit_Pos\n    candidate = method(:differ_At_One_Bit_Pos)\n    assert_equal(true, candidate.call(13, 9))\n    assert_equal(false, candidate.call(15, 8))\n    assert_equal(false, candidate.call(2, 4))\n    assert_equal(true, candidate.call(2, 3))\n    assert_equal(true, candidate.call(5, 1))\n    assert_equal(true, candidate.call(1, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rb",
+    "prompt": "# Write a function to find whether all the given arrays have equal length or not.\ndef get_equal(input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_equal\n    candidate = method(:get_equal)\n    assert_equal(true, candidate.call([[11, 22, 33], [44, 55, 66]]))\n    assert_equal(false, candidate.call([[1, 2, 3], [4, 5, 6, 7]]))\n    assert_equal(true, candidate.call([[1, 2], [3, 4]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rb",
+    "prompt": "# Write a function to sort an array of elements.\ndef comb_sort(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_comb_sort\n    candidate = method(:comb_sort)\n    assert_equal([5, 15, 25, 37, 79], candidate.call([5, 15, 37, 25, 79]))\n    assert_equal([15, 19, 22, 32, 41], candidate.call([41, 32, 15, 19, 22]))\n    assert_equal([13, 15, 47, 99], candidate.call([99, 15, 13, 47]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to add a hash to the array. The output should be an array.\ndef add_dict_to_tuple(test_tup, test_dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_dict_to_tuple\n    candidate = method(:add_dict_to_tuple)\n    assert_equal([4, 5, 6, {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}], candidate.call([4, 5, 6], {\"MSAM\" => 1, \"is\" => 2, \"best\" => 3}))\n    assert_equal([1, 2, 3, {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}], candidate.call([1, 2, 3], {\"UTS\" => 2, \"is\" => 3, \"Worst\" => 4}))\n    assert_equal([8, 9, 10, {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}], candidate.call([8, 9, 10], {\"POS\" => 3, \"is\" => 4, \"Okay\" => 5}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rb",
+    "prompt": "# Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\ndef maxAverageOfPath(cost)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_maxAverageOfPath\n    candidate = method(:maxAverageOfPath)\n    assert_equal(5.2, candidate.call([[1, 2, 3], [6, 5, 4], [7, 3, 9]]))\n    assert_equal(6.2, candidate.call([[2, 3, 4], [7, 6, 5], [8, 4, 10]]))\n    assert_equal(7.2, candidate.call([[3, 4, 5], [8, 7, 6], [9, 5, 11]]))\n    assert_equal(5.8, candidate.call([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "rb",
+    "prompt": "# The input is given as - a hash with a student name as a key and an array of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\ndef filter_data(students, h, w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_filter_data\n    candidate = method(:filter_data)\n    assert_equal({\"Cierra Vega\" => [6.2, 70]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 6.0, 70))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Kierra Gentry\" => [6.0, 68]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.9, 67))\n    assert_equal({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, candidate.call({\"Cierra Vega\" => [6.2, 70], \"Alden Cantrell\" => [5.9, 65], \"Kierra Gentry\" => [6.0, 68], \"Pierre Cox\" => [5.8, 66]}, 5.7, 64))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rb",
+    "prompt": "# The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\ndef count_same_pair(nums1, nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_same_pair\n    candidate = method(:count_same_pair)\n    assert_equal(4, candidate.call([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]))\n    assert_equal(11, candidate.call([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(1, candidate.call([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]))\n    assert_equal(3, candidate.call([0, 1, 1, 2], [0, 1, 2, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rb",
+    "prompt": "# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\ndef power_base_sum(base, power)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power_base_sum\n    candidate = method(:power_base_sum)\n    assert_equal(115, candidate.call(2, 100))\n    assert_equal(37, candidate.call(8, 10))\n    assert_equal(62, candidate.call(8, 15))\n    assert_equal(9, candidate.call(3, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "rb",
+    "prompt": "# Write a function to extract values between quotation marks \" \" of the given string.\ndef extract_quotation(text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_quotation\n    candidate = method(:extract_quotation)\n    assert_equal([\"A53\", \"multi\", \"Processor\"], candidate.call(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"))\n    assert_equal([\"favorite\", \"apps\"], candidate.call(\"Cast your \"favorite\" entertainment \"apps\"\"))\n    assert_equal([\"4k Ultra HD\", \"HDR 10\"], candidate.call(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"))\n    assert_equal([], candidate.call(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "rb",
+    "prompt": "# Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\ndef multiply_elements(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_multiply_elements\n    candidate = method(:multiply_elements)\n    assert_equal([5, 35, 56, 80], candidate.call([1, 5, 7, 8, 10]))\n    assert_equal([8, 20, 30, 42], candidate.call([2, 4, 5, 6, 7]))\n    assert_equal([156, 182, 126, 135], candidate.call([12, 13, 14, 9, 15]))\n    assert_equal([], candidate.call([12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rb",
+    "prompt": "# Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\ndef sum_list(lst1, lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_list\n    candidate = method(:sum_list)\n    assert_equal([25, 45, 65], candidate.call([10, 20, 30], [15, 25, 35]))\n    assert_equal([6, 8, 10], candidate.call([1, 2, 3], [5, 6, 7]))\n    assert_equal([30, 65, 105], candidate.call([15, 20, 30], [15, 45, 75]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the given number can be represented as the difference of two squares or not.\ndef dif_Square(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_dif_Square\n    candidate = method(:dif_Square)\n    assert_equal(true, candidate.call(5))\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(15))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "rb",
+    "prompt": "# Write a function to remove consecutive duplicates of a given array.\ndef consecutive_duplicates(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_consecutive_duplicates\n    candidate = method(:consecutive_duplicates)\n    assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([10, 15, 19, 18, 17, 26, 17, 18, 10], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n    assert_equal([\"a\", \"b\", \"c\", \"d\", \"a\"], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rb",
+    "prompt": "# Write a function to find the lateral surface area of a cone given radius r and the height h.\ndef lateralsurface_cone(r, h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lateralsurface_cone\n    candidate = method(:lateralsurface_cone)\n    assert_equal(204.20352248333654, candidate.call(5, 12))\n    assert_equal(566.3586699569488, candidate.call(10, 15))\n    assert_equal(1521.8090132193388, candidate.call(19, 17))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rb",
+    "prompt": "# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\ndef replace_specialchar(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_replace_specialchar\n    candidate = method(:replace_specialchar)\n    assert_equal(\"Python:language::Programming:language:\", candidate.call(\"Python language, Programming language.\"))\n    assert_equal(\"a:b:c:d:e:f\", candidate.call(\"a b c,d e f\"))\n    assert_equal(\"ram:reshma:ram:rahim\", candidate.call(\"ram reshma,ram rahim\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rb",
+    "prompt": "# Write a function to find the index of the first occurrence of a given number in a sorted array.\ndef find_first_occurrence(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_first_occurrence\n    candidate = method(:find_first_occurrence)\n    assert_equal(1, candidate.call([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(2, candidate.call([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5))\n    assert_equal(4, candidate.call([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\ndef sum_Of_Subarray_Prod(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_Of_Subarray_Prod\n    candidate = method(:sum_Of_Subarray_Prod)\n    assert_equal(20, candidate.call([1, 2, 3]))\n    assert_equal(5, candidate.call([1, 2]))\n    assert_equal(84, candidate.call([1, 2, 3, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\ndef toggle_middle_bits(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_toggle_middle_bits\n    candidate = method(:toggle_middle_bits)\n    assert_equal(15, candidate.call(9))\n    assert_equal(12, candidate.call(10))\n    assert_equal(13, candidate.call(11))\n    assert_equal(127, candidate.call(65))\n    assert_equal(115, candidate.call(77))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rb",
+    "prompt": "# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rbthon-exercises/data-structures-and-algorithms/rbthon-data-structure-exercise-24.php\ndef left_insertion(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_insertion\n    candidate = method(:left_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given string is starting with a vowel or not using regex.\ndef check_str(string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_str\n    candidate = method(:check_str)\n    assert_equal(true, candidate.call(\"annie\"))\n    assert_equal(false, candidate.call(\"dawood\"))\n    assert_equal(true, candidate.call(\"Else\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rbthon-exercises/data-structures-and-algorithms/rbthon-recursion-exercise-9.php\ndef geometric_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_geometric_sum\n    candidate = method(:geometric_sum)\n    assert_equal(1.9921875, candidate.call(7))\n    assert_equal(1.9375, candidate.call(4))\n    assert_equal(1.99609375, candidate.call(8))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\ndef find_Index(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Index\n    candidate = method(:find_Index)\n    assert_equal(4, candidate.call(2))\n    assert_equal(14, candidate.call(3))\n    assert_equal(45, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given array to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/rbthon-convert-array-to-adjacent-pair-hash/\ndef tuple_to_dict(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_to_dict\n    candidate = method(:tuple_to_dict)\n    assert_equal({1 => 5, 7 => 10, 13 => 5}, candidate.call([1, 5, 7, 10, 13, 5]))\n    assert_equal({1 => 2, 3 => 4, 5 => 6}, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal({7 => 8, 9 => 10, 11 => 12}, candidate.call([7, 8, 9, 10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether all the characters are same or not.\ndef all_Characters_Same(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_all_Characters_Same\n    candidate = method(:all_Characters_Same)\n    assert_equal(false, candidate.call(\"python\"))\n    assert_equal(true, candidate.call(\"aaa\"))\n    assert_equal(false, candidate.call(\"data\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rb",
+    "prompt": "# Write a function to caluclate the area of a tetrahedron.\ndef area_tetrahedron(side)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_area_tetrahedron\n    candidate = method(:area_tetrahedron)\n    assert_equal(15.588457268119894, candidate.call(3))\n    assert_equal(692.8203230275509, candidate.call(20))\n    assert_equal(173.20508075688772, candidate.call(10))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rb",
+    "prompt": "# Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/rbthon-program-right-rotate-array-n/\ndef rotate_right(list, m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rotate_right\n    candidate = method(:rotate_right)\n    assert_equal([8, 9, 10, 1, 2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3))\n    assert_equal([9, 10, 1, 2, 3, 4, 5, 6, 7, 8], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2))\n    assert_equal([6, 7, 8, 9, 10, 1, 2, 3, 4, 5], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given array has any none value or not.\ndef check_none(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_none\n    candidate = method(:check_none)\n    assert_equal(true, candidate.call([10, 4, 5, 6, nil]))\n    assert_equal(false, candidate.call([7, 8, 9, 11, 14]))\n    assert_equal(true, candidate.call([1, 2, 3, 4, nil]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rb",
+    "prompt": "# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rbthon-exercises/lambda/rbthon-lambda-exercise-24.php\ndef divisible_by_digits(startnum, endnum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisible_by_digits\n    candidate = method(:divisible_by_digits)\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22], candidate.call(1, 22))\n    assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15], candidate.call(1, 15))\n    assert_equal([22, 24], candidate.call(20, 25))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rb",
+    "prompt": "# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nil if the angle is larger than 360 degrees.\ndef sector_area(r, a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sector_area\n    candidate = method(:sector_area)\n    assert_equal(6.283185307179586, candidate.call(4, 45))\n    assert_equal(31.808625617596654, candidate.call(9, 45))\n    assert_equal(nil, candidate.call(9, 361))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rb",
+    "prompt": "# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\ndef lcs_of_three(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_lcs_of_three\n    candidate = method(:lcs_of_three)\n    assert_equal(2, candidate.call(\"AGGT12\", \"12TXAYB\", \"12XBA\"))\n    assert_equal(5, candidate.call(\"Reels\", \"Reelsfor\", \"ReelsforReels\"))\n    assert_equal(3, candidate.call(\"abcd1e2\", \"bc12ea\", \"bd1ea\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to put spaces between words starting with capital letters in a given string.\ndef capital_words_spaces(str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_capital_words_spaces\n    candidate = method(:capital_words_spaces)\n    assert_equal(\"Python\", candidate.call(\"Python\"))\n    assert_equal(\"Python Programming Examples\", candidate.call(\"PythonProgrammingExamples\"))\n    assert_equal(\"Get Ready To Be Coding Freak\", candidate.call(\"GetReadyToBeCodingFreak\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rb",
+    "prompt": "# Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/rbthon-sort-numeric-strings-in-a-array/\ndef sort_numeric_strings(nums_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sort_numeric_strings\n    candidate = method(:sort_numeric_strings)\n    assert_equal([-500, -12, 0, 4, 7, 12, 45, 100, 200], candidate.call([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]))\n    assert_equal([1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9], candidate.call([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]))\n    assert_equal([1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17], candidate.call([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rb",
+    "prompt": "# Write a function to check whether it follows the sequence given in the patterns array.\ndef is_samepatterns(colors, patterns)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_samepatterns\n    candidate = method(:is_samepatterns)\n    assert_equal(true, candidate.call([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]))\n    assert_equal(false, candidate.call([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to add the given array to the given array.\ndef add_tuple(test_list, test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_add_tuple\n    candidate = method(:add_tuple)\n    assert_equal([5, 6, 7, 9, 10], candidate.call([5, 6, 7], [9, 10]))\n    assert_equal([6, 7, 8, 10, 11], candidate.call([6, 7, 8], [10, 11]))\n    assert_equal([7, 8, 9, 11, 12], candidate.call([7, 8, 9], [11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\ndef check_min_heap(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_min_heap\n    candidate = method(:check_min_heap)\n    assert_equal(true, candidate.call([1, 2, 3, 4, 5, 6]))\n    assert_equal(true, candidate.call([2, 3, 4, 5, 10, 15]))\n    assert_equal(false, candidate.call([2, 10, 4, 5, 3, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\ndef jacobsthal_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_jacobsthal_num\n    candidate = method(:jacobsthal_num)\n    assert_equal(11, candidate.call(5))\n    assert_equal(1, candidate.call(2))\n    assert_equal(5, candidate.call(4))\n    assert_equal(2731, candidate.call(13))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rb",
+    "prompt": "# Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/rbthon-find-minimum-k-records-from-array-array/ - in this case a verbatim corb of test cases\ndef min_k(test_list, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_min_k\n    candidate = method(:min_k)\n    assert_equal([[\"Akash\", 2], [\"Akshat\", 4]], candidate.call([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2))\n    assert_equal([[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]], candidate.call([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3))\n    assert_equal([[\"Ayesha\", 9]], candidate.call([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "rb",
+    "prompt": "# We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\ndef extract_index_list(l1, l2, l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_extract_index_list\n    candidate = method(:extract_index_list)\n    assert_equal([1, 7], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([1, 6], candidate.call([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]))\n    assert_equal([1, 5], candidate.call([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n    assert_equal([], candidate.call([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "rb",
+    "prompt": "# Write a function to find the second smallest number in an array.\ndef second_smallest(numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_second_smallest\n    candidate = method(:second_smallest)\n    assert_equal(-2, candidate.call([1, 2, -8, -2, 0, -2]))\n    assert_equal(-0.5, candidate.call([1, 1, -0.5, 0, 2, -2, -2]))\n    assert_equal(nil, candidate.call([2, 2]))\n    assert_equal(nil, candidate.call([2, 2, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rbthon-exercises/re/rbthon-re-exercise-3.php\ndef text_match_zero_one(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_zero_one\n    candidate = method(:text_match_zero_one)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"dsabbbba\"))\n    assert_equal(false, candidate.call(\"asbbbba\"))\n    assert_equal(true, candidate.call(\"abaaa\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rb",
+    "prompt": "# Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/rbthon-program-to-count-the-pairs-of-reverse-strings/\ndef count_reverse_pairs(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_reverse_pairs\n    candidate = method(:count_reverse_pairs)\n    assert_equal(2, candidate.call([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]))\n    assert_equal(1, candidate.call([\"geeks\", \"best\", \"for\", \"skeeg\"]))\n    assert_equal(2, candidate.call([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rb",
+    "prompt": "# Write a function to check whether a given string is a decimal number with a precision of 2.\ndef is_decimal(num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_decimal\n    candidate = method(:is_decimal)\n    assert_equal(true, candidate.call(\"123.11\"))\n    assert_equal(false, candidate.call(\"e666.86\"))\n    assert_equal(false, candidate.call(\"3.124587\"))\n    assert_equal(true, candidate.call(\"1.11\"))\n    assert_equal(false, candidate.call(\"1.1.11\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rb",
+    "prompt": "# Write a function to find arrays which have all elements divisible by k from the given array of arrays.\ndef find_tuples(test_list, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_tuples\n    candidate = method(:find_tuples)\n    assert_equal([[6, 24, 12]], candidate.call([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6))\n    assert_equal([[5, 25, 30]], candidate.call([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5))\n    assert_equal([[8, 16, 4]], candidate.call([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether an array of numbers contains only one distinct element or not.\ndef unique_Element(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_unique_Element\n    candidate = method(:unique_Element)\n    assert_equal(true, candidate.call([1, 1, 1]))\n    assert_equal(false, candidate.call([1, 2, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\ndef check_monthnumber_number(monthnum3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_monthnumber_number\n    candidate = method(:check_monthnumber_number)\n    assert_equal(true, candidate.call(6))\n    assert_equal(false, candidate.call(2))\n    assert_equal(false, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\ndef find_min_diff(arr, n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_min_diff\n    candidate = method(:find_min_diff)\n    assert_equal(1, candidate.call([1, 5, 3, 19, 18, 25], 6))\n    assert_equal(1, candidate.call([4, 3, 2, 6], 4))\n    assert_equal(4, candidate.call([30, 5, 20, 9], 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count number of digits in a given string.\ndef number_ctr(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_number_ctr\n    candidate = method(:number_ctr)\n    assert_equal(1, candidate.call(\"program2bedone\"))\n    assert_equal(1, candidate.call(\"3wonders\"))\n    assert_equal(3, candidate.call(\"123\"))\n    assert_equal(3, candidate.call(\"3wond-1ers2\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rb",
+    "prompt": "# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\ndef is_polite(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_polite\n    candidate = method(:is_polite)\n    assert_equal(11, candidate.call(7))\n    assert_equal(7, candidate.call(4))\n    assert_equal(13, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rb",
+    "prompt": "# Write a function to return an array of all pairs of consecutive items in a given array.\ndef pair_wise(l1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pair_wise\n    candidate = method(:pair_wise)\n    assert_equal([[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]], candidate.call([1, 1, 2, 3, 3, 4, 4, 5]))\n    assert_equal([[1, 5], [5, 7], [7, 9], [9, 10]], candidate.call([1, 5, 7, 9, 10]))\n    assert_equal([[5, 1], [1, 9], [9, 7], [7, 10]], candidate.call([5, 1, 9, 7, 10]))\n    assert_equal([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\ndef get_pairs_count(arr, sum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_pairs_count\n    candidate = method(:get_pairs_count)\n    assert_equal(6, candidate.call([1, 1, 1, 1], 2))\n    assert_equal(3, candidate.call([1, 5, 7, -1, 5], 6))\n    assert_equal(1, candidate.call([1, -2, 3], 1))\n    assert_equal(1, candidate.call([-1, -2, 3], -3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to get the difference between two arrays.\ndef Diff(li1, li2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Diff\n    candidate = method(:Diff)\n    assert_equal([10, 20, 30, 15], candidate.call([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]))\n    assert_equal([2, 3, 4, 5, 6, 7], candidate.call([1, 2, 3, 4, 5], [6, 7, 1]))\n    assert_equal([2, 3, 6, 7], candidate.call([1, 2, 3], [6, 7, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of fourth power of first n odd natural numbers.\ndef odd_num_sum(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_num_sum\n    candidate = method(:odd_num_sum)\n    assert_equal(82, candidate.call(2))\n    assert_equal(707, candidate.call(3))\n    assert_equal(3108, candidate.call(4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\ndef check_expression(exp)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_expression\n    candidate = method(:check_expression)\n    assert_equal(true, candidate.call(\"{()}[{}]\"))\n    assert_equal(false, candidate.call(\"{()}[{]\"))\n    assert_equal(true, candidate.call(\"{()}[{}][]({})\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rb",
+    "prompt": "# Write a function to remove all the words with k length in the given string.\ndef remove_length(test_str, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_length\n    candidate = method(:remove_length)\n    assert_equal(\"person is most value\", candidate.call(\"The person is most value tet\", 3))\n    assert_equal(\"If you me about ok\", candidate.call(\"If you told me about this ok\", 4))\n    assert_equal(\"Forces of darkeness is the\", candidate.call(\"Forces of darkeness is come into the play\", 4))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rb",
+    "prompt": "# Write a function to find the occurrence and position of the substrings within a string. Return nil if there is no match.\ndef occurance_substring(text, pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_occurance_substring\n    candidate = method(:occurance_substring)\n    assert_equal([\"python\", 0, 6], candidate.call(\"python programming, python language\", \"python\"))\n    assert_equal([\"programming\", 7, 18], candidate.call(\"python programming,programming language\", \"programming\"))\n    assert_equal([\"language\", 31, 39], candidate.call(\"python programming,programming language\", \"language\"))\n    assert_equal(nil, candidate.call(\"c++ programming, c++ language\", \"python\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether every odd index contains odd numbers of a given array.\ndef odd_position(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_position\n    candidate = method(:odd_position)\n    assert_equal(true, candidate.call([2, 1, 4, 3, 6, 7, 6, 3]))\n    assert_equal(true, candidate.call([4, 1, 2]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rb",
+    "prompt": "# Write a function to count those characters which have vowels as their neighbors in the given string.\ndef count_vowels(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_vowels\n    candidate = method(:count_vowels)\n    assert_equal(7, candidate.call(\"bestinstareels\"))\n    assert_equal(12, candidate.call(\"partofthejourneyistheend\"))\n    assert_equal(5, candidate.call(\"amazonprime\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of non-repeated elements in a given array.\ndef find_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_sum\n    candidate = method(:find_sum)\n    assert_equal(21, candidate.call([1, 2, 3, 1, 1, 4, 5, 6]))\n    assert_equal(71, candidate.call([1, 10, 9, 4, 2, 10, 10, 45, 4]))\n    assert_equal(78, candidate.call([12, 10, 9, 45, 2, 10, 10, 45, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "rb",
+    "prompt": "# Write a function to pack consecutive duplicates of a given array elements into subarrays.\ndef pack_consecutive_duplicates(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_pack_consecutive_duplicates\n    candidate = method(:pack_consecutive_duplicates)\n    assert_equal([[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]], candidate.call([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]))\n    assert_equal([[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]], candidate.call([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]))\n    assert_equal([[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]], candidate.call([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find whether a number is divisible by 11.\ndef is_Diff(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_Diff\n    candidate = method(:is_Diff)\n    assert_equal(false, candidate.call(12345))\n    assert_equal(true, candidate.call(1212112))\n    assert_equal(false, candidate.call(1212))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rb",
+    "prompt": "# Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/rbthon-combinations-of-sum-with-arrays-in-array-array/\ndef find_combinations(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_combinations\n    candidate = method(:find_combinations)\n    assert_equal([[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]], candidate.call([[2, 4], [6, 7], [5, 1], [6, 10]]))\n    assert_equal([[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]], candidate.call([[3, 5], [7, 8], [6, 2], [7, 11]]))\n    assert_equal([[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]], candidate.call([[4, 6], [8, 9], [7, 3], [8, 12]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the count of divisors is even. https://www.w3resource.com/rbthon-exercises/basic/rbthon-basic-1-exercise-24.php\ndef count_divisors(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_divisors\n    candidate = method(:count_divisors)\n    assert_equal(true, candidate.call(10))\n    assert_equal(false, candidate.call(100))\n    assert_equal(true, candidate.call(125))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\ndef odd_length_sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_odd_length_sum\n    candidate = method(:odd_length_sum)\n    assert_equal(14, candidate.call([1, 2, 4]))\n    assert_equal(15, candidate.call([1, 2, 1, 2]))\n    assert_equal(8, candidate.call([1, 7]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rb",
+    "prompt": "# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\ndef rgb_to_hsv(r, g, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_rgb_to_hsv\n    candidate = method(:rgb_to_hsv)\n    assert_equal([0.0, 0.0, 100.0], candidate.call(255, 255, 255))\n    assert_equal([120.0, 100.0, 84.31372549019608], candidate.call(0, 215, 0))\n    assert_equal([149.26829268292684, 95.34883720930233, 84.31372549019608], candidate.call(10, 215, 110))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rb",
+    "prompt": "# Write a function to find the product of first even and odd number of a given array.\ndef mul_even_odd(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_mul_even_odd\n    candidate = method(:mul_even_odd)\n    assert_equal(4, candidate.call([1, 3, 5, 7, 4, 1, 6, 8]))\n    assert_equal(2, candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal(10, candidate.call([1, 5, 7, 9, 10]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rb",
+    "prompt": "# Write a function to convert array string to integer array.\ndef tuple_str_int(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tuple_str_int\n    candidate = method(:tuple_str_int)\n    assert_equal([7, 8, 9], candidate.call(\"(7, 8, 9)\"))\n    assert_equal([1, 2, 3], candidate.call(\"(1, 2, 3)\"))\n    assert_equal([4, 5, 6], candidate.call(\"(4, 5, 6)\"))\n    assert_equal([7, 81, 19], candidate.call(\"(7, 81, 19)\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rb",
+    "prompt": "# Write a function to locate the right insertion point for a specified value in sorted order.\ndef right_insertion(a, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_right_insertion\n    candidate = method(:right_insertion)\n    assert_equal(4, candidate.call([1, 2, 4, 5], 6))\n    assert_equal(2, candidate.call([1, 2, 4, 5], 3))\n    assert_equal(4, candidate.call([1, 2, 4, 5], 7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an a followed by three 'b'.\ndef text_match_three(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_match_three\n    candidate = method(:text_match_three)\n    assert_equal(false, candidate.call(\"ac\"))\n    assert_equal(false, candidate.call(\"dc\"))\n    assert_equal(true, candidate.call(\"abbbba\"))\n    assert_equal(true, candidate.call(\"caacabbbba\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rb",
+    "prompt": "# Write a function to create a new array from the given string and array.\ndef new_tuple(test_list, test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_new_tuple\n    candidate = method(:new_tuple)\n    assert_equal([\"WEB\", \"is\", \"best\"], candidate.call([\"WEB\", \"is\"], \"best\"))\n    assert_equal([\"We\", \"are\", \"Developers\"], candidate.call([\"We\", \"are\"], \"Developers\"))\n    assert_equal([\"Part\", \"is\", \"Wrong\"], candidate.call([\"Part\", \"is\"], \"Wrong\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether every even index contains even numbers of a given array.\ndef even_position(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_even_position\n    candidate = method(:even_position)\n    assert_equal(false, candidate.call([3, 2, 1]))\n    assert_equal(false, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([2, 1, 4]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "rb",
+    "prompt": "# Write a function to remove arrays from the given array.\ndef remove_nested(test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_nested\n    candidate = method(:remove_nested)\n    assert_equal([1, 5, 7, 10], candidate.call([1, 5, 7, [4, 6], 10]))\n    assert_equal([2, 6, 8, 11], candidate.call([2, 6, 8, [5, 7], 11]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], 12]))\n    assert_equal([3, 7, 9, 12], candidate.call([3, 7, 9, [6, 8], [5, 12], 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of arrays in a given number of arrays.\ndef count_list(input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_list\n    candidate = method(:count_list)\n    assert_equal(4, candidate.call([[1, 3], [5, 7], [9, 11], [13, 15, 17]]))\n    assert_equal(3, candidate.call([[1, 2], [2, 3], [4, 5]]))\n    assert_equal(2, candidate.call([[1, 0], [2, 0]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the last position of an element in a sorted array.\ndef last(arr, x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_last\n    candidate = method(:last)\n    assert_equal(0, candidate.call([1, 2, 3], 1))\n    assert_equal(2, candidate.call([1, 1, 1, 2, 3, 4], 1))\n    assert_equal(3, candidate.call([2, 3, 2, 3, 6, 8, 9], 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rb",
+    "prompt": "# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\ndef text_starta_endb(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_text_starta_endb\n    candidate = method(:text_starta_endb)\n    assert_equal(true, candidate.call(\"aabbbb\"))\n    assert_equal(false, candidate.call(\"aabAbbbc\"))\n    assert_equal(false, candidate.call(\"accddbbjjj\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rb",
+    "prompt": "# Write function to find the sum of all items in the given hash.\ndef return_sum(dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_return_sum\n    candidate = method(:return_sum)\n    assert_equal(600, candidate.call({\"a\" => 100, \"b\" => 200, \"c\" => 300}))\n    assert_equal(88, candidate.call({\"a\" => 25, \"b\" => 18, \"c\" => 45}))\n    assert_equal(124, candidate.call({\"a\" => 36, \"b\" => 39, \"c\" => 49}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of all odd natural numbers within the range l and r.\ndef sum_in_range(l, r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sum_in_range\n    candidate = method(:sum_in_range)\n    assert_equal(8, candidate.call(2, 5))\n    assert_equal(12, candidate.call(5, 7))\n    assert_equal(40, candidate.call(7, 13))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the sum of an array.\ndef _sum(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test__sum\n    candidate = method(:_sum)\n    assert_equal(6, candidate.call([1, 2, 3]))\n    assert_equal(50, candidate.call([15, 12, 13, 10]))\n    assert_equal(3, candidate.call([0, 1, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rb",
+    "prompt": "# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\ndef left_rotate(n, d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_left_rotate\n    candidate = method(:left_rotate)\n    assert_equal(64, candidate.call(16, 2))\n    assert_equal(40, candidate.call(10, 2))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(792, candidate.call(99, 3))\n    assert_equal(8, candidate.call(1, 3))\n    assert_equal(40, candidate.call(5, 3))\n    assert_equal(232, candidate.call(29, 3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to check whether the length of the word is odd or not.\ndef word_len(s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_word_len\n    candidate = method(:word_len)\n    assert_equal(false, candidate.call(\"Hadoop\"))\n    assert_equal(true, candidate.call(\"great\"))\n    assert_equal(true, candidate.call(\"structure\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rb",
+    "prompt": "# Write a function to remove all whitespaces from a string.\ndef remove_all_spaces(text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_remove_all_spaces\n    candidate = method(:remove_all_spaces)\n    assert_equal(\"pythonprogram\", candidate.call(\"python  program\"))\n    assert_equal(\"pythonprogramminglanguage\", candidate.call(\"python   programming    language\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"python                     program\"))\n    assert_equal(\"pythonprogram\", candidate.call(\"   python                     program\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of equal numbers from three given integers.\ndef test_three_equal(x, y, z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_test_three_equal\n    candidate = method(:test_three_equal)\n    assert_equal(3, candidate.call(1, 1, 1))\n    assert_equal(0, candidate.call(-1, -2, -3))\n    assert_equal(2, candidate.call(1, 2, 2))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\ndef count_rotation(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_count_rotation\n    candidate = method(:count_rotation)\n    assert_equal(1, candidate.call([3, 2, 1]))\n    assert_equal(2, candidate.call([4, 5, 1, 2, 3]))\n    assert_equal(3, candidate.call([7, 8, 9, 1, 2, 3]))\n    assert_equal(0, candidate.call([1, 2, 3]))\n    assert_equal(2, candidate.call([1, 3, 2]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\ndef is_perfect_square(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_perfect_square\n    candidate = method(:is_perfect_square)\n    assert_equal(false, candidate.call(10))\n    assert_equal(true, candidate.call(36))\n    assert_equal(false, candidate.call(14))\n    assert_equal(true, candidate.call(196))\n    assert_equal(false, candidate.call(125))\n    assert_equal(true, candidate.call(15625))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the product of numbers in an array is even or not.\ndef is_product_even(arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_product_even\n    candidate = method(:is_product_even)\n    assert_equal(true, candidate.call([1, 2, 3]))\n    assert_equal(true, candidate.call([1, 2, 1, 4]))\n    assert_equal(false, candidate.call([1, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rb",
+    "prompt": "# Write a function that returns the array in an array of arrays whose sum of elements is the highest.\ndef max_sum_list(lists)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_sum_list\n    candidate = method(:max_sum_list)\n    assert_equal([10, 11, 12], candidate.call([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]))\n    assert_equal([12, 11, 10], candidate.call([[3, 2, 1], [6, 5, 4], [12, 11, 10]]))\n    assert_equal([2, 3, 1], candidate.call([[2, 3, 1]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rb",
+    "prompt": "# Write a function to find maximum run of uppercase characters in the given string.\ndef max_run_uppercase(test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_max_run_uppercase\n    candidate = method(:max_run_uppercase)\n    assert_equal(5, candidate.call(\"GeMKSForGERksISBESt\"))\n    assert_equal(6, candidate.call(\"PrECIOusMOVemENTSYT\"))\n    assert_equal(4, candidate.call(\"GooGLEFluTTER\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the first odd number in a given array of numbers.\ndef first_odd(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_first_odd\n    candidate = method(:first_odd)\n    assert_equal(1, candidate.call([1, 3, 5]))\n    assert_equal(1, candidate.call([2, 4, 1, 3]))\n    assert_equal(9, candidate.call([8, 9, 1]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rb",
+    "prompt": "# Write a function to check if the given arrays contain the k or not.\ndef check_K(test_tup, k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_K\n    candidate = method(:check_K)\n    assert_equal(true, candidate.call([10, 4, 5, 6, 8], 6))\n    assert_equal(false, candidate.call([1, 2, 3, 4, 5, 6], 7))\n    assert_equal(true, candidate.call([7, 8, 9, 44, 11, 12], 11))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rb",
+    "prompt": "# Write a function to check if each element of second array is smaller than its corresponding element in the first array.\ndef check_smaller(test_tup1, test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_check_smaller\n    candidate = method(:check_smaller)\n    assert_equal(false, candidate.call([1, 2, 3], [2, 3, 4]))\n    assert_equal(true, candidate.call([4, 5, 6], [3, 4, 5]))\n    assert_equal(true, candidate.call([11, 12, 13], [10, 11, 12]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth tetrahedral number.\ndef tetrahedral_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_tetrahedral_number\n    candidate = method(:tetrahedral_number)\n    assert_equal(35, candidate.call(5))\n    assert_equal(56, candidate.call(6))\n    assert_equal(84, candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\ndef get_Char(strr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_get_Char\n    candidate = method(:get_Char)\n    assert_equal(\"f\", candidate.call(\"abc\"))\n    assert_equal(\"t\", candidate.call(\"gfg\"))\n    assert_equal(\"c\", candidate.call(\"ab\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rb",
+    "prompt": "# Write a function to find the nth number in the newman conway sequence.\ndef sequence(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_sequence\n    candidate = method(:sequence)\n    assert_equal(6, candidate.call(10))\n    assert_equal(1, candidate.call(2))\n    assert_equal(2, candidate.call(3))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rb",
+    "prompt": "# Write a function to find nth centered hexagonal number.\ndef centered_hexagonal_number(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_centered_hexagonal_number\n    candidate = method(:centered_hexagonal_number)\n    assert_equal(271, candidate.call(10))\n    assert_equal(7, candidate.call(2))\n    assert_equal(217, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rb",
+    "prompt": "# Write a function to merge three dictionaries into a single hash.\ndef merge_dictionaries_three(dict1, dict2, dict3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_merge_dictionaries_three\n    candidate = method(:merge_dictionaries_three)\n    assert_equal({\"B\" => \"Black\", \"R\" => \"Red\", \"P\" => \"Pink\", \"G\" => \"Green\", \"W\" => \"White\", \"O\" => \"Orange\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"O\" => \"Orange\", \"W\" => \"White\", \"B\" => \"Black\"}))\n    assert_equal({\"W\" => \"White\", \"P\" => \"Pink\", \"B\" => \"Black\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"G\" => \"Green\", \"W\" => \"White\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}))\n    assert_equal({\"B\" => \"Black\", \"P\" => \"Pink\", \"R\" => \"Red\", \"G\" => \"Green\", \"L\" => \"lavender\", \"W\" => \"White\"}, candidate.call({\"R\" => \"Red\", \"B\" => \"Black\", \"P\" => \"Pink\"}, {\"L\" => \"lavender\", \"B\" => \"Blue\"}, {\"G\" => \"Green\", \"W\" => \"White\"}))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rb",
+    "prompt": "# Write a function to get the frequency of all the elements in an array, returned as a hash.\ndef freq_count(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_freq_count\n    candidate = method(:freq_count)\n    assert_equal({10 => 4, 20 => 4, 40 => 2, 50 => 2, 30 => 1}, candidate.call([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]))\n    assert_equal({1 => 3, 2 => 2, 3 => 3, 4 => 3}, candidate.call([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]))\n    assert_equal({10 => 1, 5 => 3, 6 => 2, 7 => 2, 4 => 2, 9 => 2}, candidate.call([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rb",
+    "prompt": "# Write a function to find the closest smaller number than n.\ndef closest_num(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_closest_num\n    candidate = method(:closest_num)\n    assert_equal(10, candidate.call(11))\n    assert_equal(6, candidate.call(7))\n    assert_equal(11, candidate.call(12))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rb",
+    "prompt": "# Write a function to find squares of individual elements in an array.\ndef square_nums(nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_square_nums\n    candidate = method(:square_nums)\n    assert_equal([1, 4, 9, 16, 25, 36, 49, 64, 81, 100], candidate.call([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n    assert_equal([100, 400, 900], candidate.call([10, 20, 30]))\n    assert_equal([144, 225], candidate.call([12, 15]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the length of the longest word.\ndef len_log(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_len_log\n    candidate = method(:len_log)\n    assert_equal(7, candidate.call([\"python\", \"PHP\", \"bigdata\"]))\n    assert_equal(3, candidate.call([\"a\", \"ab\", \"abc\"]))\n    assert_equal(5, candidate.call([\"small\", \"big\", \"tall\"]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rb",
+    "prompt": "# Write a function to check if a string is present as a substring in a given array of string values.\ndef find_substring(str1, sub_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_substring\n    candidate = method(:find_substring)\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"))\n    assert_equal(false, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"))\n    assert_equal(true, candidate.call([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rb",
+    "prompt": "# Write a function to check whether the given number is undulating or not.\ndef is_undulating(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_is_undulating\n    candidate = method(:is_undulating)\n    assert_equal(true, candidate.call(1212121))\n    assert_equal(false, candidate.call(1991))\n    assert_equal(true, candidate.call(121))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rb",
+    "prompt": "# Write a function to calculate the value of 'a' to the power 'b'.\ndef power(a, b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_power\n    candidate = method(:power)\n    assert_equal(81, candidate.call(3, 4))\n    assert_equal(8, candidate.call(2, 3))\n    assert_equal(3125, candidate.call(5, 5))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rb",
+    "prompt": "# Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\ndef index_minimum(test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_index_minimum\n    candidate = method(:index_minimum)\n    assert_equal(\"Varsha\", candidate.call([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]))\n    assert_equal(\"Dawood\", candidate.call([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]))\n    assert_equal(\"Ayesha\", candidate.call([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the length of the smallest array in an array of arrays.\ndef Find_Min_Length(lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_Find_Min_Length\n    candidate = method(:Find_Min_Length)\n    assert_equal(1, candidate.call([[1], [1, 2]]))\n    assert_equal(2, candidate.call([[1, 2], [1, 2, 3], [1, 2, 3, 4]]))\n    assert_equal(3, candidate.call([[3, 3, 3], [4, 4, 4, 4]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the number of divisors of a given integer.\ndef divisor(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_divisor\n    candidate = method(:divisor)\n    assert_equal(4, candidate.call(15))\n    assert_equal(6, candidate.call(12))\n    assert_equal(3, candidate.call(9))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rb",
+    "prompt": "# Write a function to find frequency of each element in a flattened array of arrays, returned in a hash.\ndef frequency_lists(list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_frequency_lists\n    candidate = method(:frequency_lists)\n    assert_equal({1 => 1, 2 => 3, 3 => 1, 4 => 1, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1}, candidate.call([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]))\n    assert_equal({1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1}, candidate.call([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]))\n    assert_equal({20 => 2, 30 => 2, 40 => 2, 17 => 1, 18 => 1, 16 => 1, 14 => 1, 13 => 1, 10 => 1}, candidate.call([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rb",
+    "prompt": "# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\ndef decimal_to_binary(n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_decimal_to_binary\n    candidate = method(:decimal_to_binary)\n    assert_equal(\"1000\", candidate.call(8))\n    assert_equal(\"10010\", candidate.call(18))\n    assert_equal(\"111\", candidate.call(7))\n  end\nend\n",
+    "stop_tokens": [
+      "\nclass",
+      "\ndef",
+      "\n#",
+      "\n\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rb",
+    "prompt": "# Write a rbthon function to find the minimum number of rotations (greater than 0) required to get the same string.\ndef find_Rotations(str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "require 'test/unit'\nclass TestHumanEval < Test::Unit::TestCase\n  def test_find_Rotations\n    candidate = method(:find_Rotations)\n    assert_equal(1, candidate.call(\"aaaa\"))\n    assert_equal(2, candidate.call(\"ab\"))\n    assert_equal(3, candidate.call(\"abc\"))\n  end\nend\n",
     "stop_tokens": [
       "\nclass",
       "\ndef",

--- a/prompts/mbpp-rkt-keep.json
+++ b/prompts/mbpp-rkt-keep.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the length of the longest palindromic subsequence in the given string.\n(define (lps str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lps))\n    (check-within (candidate \"TENS FOR TENS\") 5 0.001)\n    (check-within (candidate \"CARDIO FOR CARDS\") 7 0.001)\n    (check-within (candidate \"PART OF THE JOURNEY IS PART\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from the given string.\n(define (remove_whitespaces text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_whitespaces))\n    (check-within (candidate \" Google    Flutter \") \"GoogleFlutter\" 0.001)\n    (check-within (candidate \" Google    Dart \") \"GoogleDart\" 0.001)\n    (check-within (candidate \" iOS    Swift \") \"iOSSwift\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a specified list is sorted or not.\n(define (issort_list list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate issort_list))\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 16 17)) #t 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 20 17)) #f 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 15 14 20)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count bidirectional tuple pairs.\n(define (count_bidirectional test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_bidirectional))\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 3 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 3) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 2 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 2) (list 6 5) (list 2 1))) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cube of a given size.\n(define (surfacearea_cube l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cube))\n    (check-within (candidate 5) 150 0.001)\n    (check-within (candidate 3) 54 0.001)\n    (check-within (candidate 10) 600 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n(define (next_smallest_palindrome num)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest_palindrome))\n    (check-within (candidate 99) 101 0.001)\n    (check-within (candidate 1221) 1331 0.001)\n    (check-within (candidate 120) 121 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the cube sum of first n even natural numbers.\n(define (cube_Sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_Sum))\n    (check-within (candidate 2) 72 0.001)\n    (check-within (candidate 3) 288 0.001)\n    (check-within (candidate 4) 800 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of xor of all pairs of numbers in the given list.\n(define (pair_xor_Sum arr n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_xor_Sum))\n    (check-within (candidate (list 5 9 7 6) 4) 47 0.001)\n    (check-within (candidate (list 7 3 5) 3) 12 0.001)\n    (check-within (candidate (list 7 3) 2) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n(define (check_min_heap arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_min_heap))\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 10 15)) #t 0.001)\n    (check-within (candidate (list 2 10 4 5 3 15)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the first digit of a given number.\n(define (first_Digit n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_Digit))\n    (check-within (candidate 123) 1 0.001)\n    (check-within (candidate 456) 4 0.001)\n    (check-within (candidate 12) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the first non-repeated character in a given string.\n(define (first_non_repeating_character str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_non_repeating_character))\n    (check-within (candidate \"abcabc\") #f 0.001)\n    (check-within (candidate \"abc\") \"a\" 0.001)\n    (check-within (candidate \"ababc\") \"c\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert degrees to radians.\n(define (radian_degree degree)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate radian_degree))\n    (check-within (candidate 90) 1.5707963267948966 0.001)\n    (check-within (candidate 60) 1.0471975511965976 0.001)\n    (check-within (candidate 120) 2.0943951023931953 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum product subarray of the given array.\n(define (max_subarray_product arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_subarray_product))\n    (check-within (candidate (list 1 -2 -3 0 7 -8 -2)) 112 0.001)\n    (check-within (candidate (list 6 -3 -10 0 2)) 180 0.001)\n    (check-within (candidate (list -2 -40 0 -2 -3)) 80 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert more than one list to nested dictionary.\n(define (convert_list_dictionary l1 l2 l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert_list_dictionary))\n    (check-within (candidate (list \"S001\" \"S002\" \"S003\" \"S004\") (list \"Adina Park\" \"Leyton Marsh\" \"Duncan Boyle\" \"Saim Richards\") (list 85 98 89 92)) (list #hash((\"S001\" .  #hash((\"Adina Park\" .  85)))) #hash((\"S002\" .  #hash((\"Leyton Marsh\" .  98)))) #hash((\"S003\" .  #hash((\"Duncan Boyle\" .  89)))) #hash((\"S004\" .  #hash((\"Saim Richards\" .  92))))) 0.001)\n    (check-within (candidate (list \"abc\" \"def\" \"ghi\" \"jkl\") (list \"python\" \"program\" \"language\" \"programs\") (list 100 200 300 400)) (list #hash((\"abc\" .  #hash((\"python\" .  100)))) #hash((\"def\" .  #hash((\"program\" .  200)))) #hash((\"ghi\" .  #hash((\"language\" .  300)))) #hash((\"jkl\" .  #hash((\"programs\" .  400))))) 0.001)\n    (check-within (candidate (list \"A1\" \"A2\" \"A3\" \"A4\") (list \"java\" \"C\" \"C++\" \"DBMS\") (list 10 20 30 40)) (list #hash((\"A1\" .  #hash((\"java\" .  10)))) #hash((\"A2\" .  #hash((\"C\" .  20)))) #hash((\"A3\" .  #hash((\"C++\" .  30)))) #hash((\"A4\" .  #hash((\"DBMS\" .  40))))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find smallest number in a list.\n(define (smallest_num xs)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_num))\n    (check-within (candidate (list 10 20 1 45 99)) 1 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n    (check-within (candidate (list 45 46 50 60)) 45 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n(define (text_match_zero_one text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_zero_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"dsabbbba\") #t 0.001)\n    (check-within (candidate \"asbbbba\") #f 0.001)\n    (check-within (candidate \"abaaa\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find nth bell number.\n(define (bell_Number n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_Number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 15 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find cubes of individual elements in a list.\n(define (cube_nums nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 8 27 64 125 216 343 512 729 1000) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15)) (list 1728 3375) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the last digit in factorial of a given number.\n(define (last_Digit_Factorial n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit_Factorial))\n    (check-within (candidate 4) 4 0.001)\n    (check-within (candidate 21) 0 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find even numbers from a list of numbers.\n(define (Split list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5)) (list 2 4) 0.001)\n    (check-within (candidate (list 4 5 6 7 8 0 1)) (list 4 6 8 0) 0.001)\n    (check-within (candidate (list 8 12 15 19)) (list 8 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given integer is a prime number.\n(define (prime_num num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_num))\n    (check-within (candidate 13) #t 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate -1010) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n(define (find_tuples test_list K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_tuples))\n    (check-within (candidate (list (list 6 24 12) (list 7 9 6) (list 12 18 21)) 6) (list (list 6 24 12)) 0.001)\n    (check-within (candidate (list (list 5 25 30) (list 4 2 3) (list 7 8 9)) 5) (list (list 5 25 30)) 0.001)\n    (check-within (candidate (list (list 7 9 16) (list 8 16 4) (list 19 17 18)) 4) (list (list 8 16 4)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to caluclate the area of a tetrahedron.\n(define (area_tetrahedron side)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate area_tetrahedron))\n    (check-within (candidate 3) 15.588457268119894 0.001)\n    (check-within (candidate 20) 692.8203230275509 0.001)\n    (check-within (candidate 10) 173.20508075688772 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number is even or not.\n(define (is_Even n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Even))\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 2) #t 0.001)\n    (check-within (candidate 3) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of positive numbers in a list.\n(define (pos_count list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pos_count))\n    (check-within (candidate (list 1 -2 3 -4)) 2 0.001)\n    (check-within (candidate (list 3 4 5 -1)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4)) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get all lucid numbers smaller than or equal to a given integer.\n(define (get_ludic n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_ludic))\n    (check-within (candidate 10) (list 1 2 3 5 7) 0.001)\n    (check-within (candidate 25) (list 1 2 3 5 7 11 13 17 23 25) 0.001)\n    (check-within (candidate 45) (list 1 2 3 5 7 11 13 17 23 25 29 37 41 43) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n(define (find_Index n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Index))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 14 0.001)\n    (check-within (candidate 4) 45 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to reverse an array upto a given position.\n(define (reverse_Array_Upto_K input k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_Array_Upto_K))\n    (check-within (candidate (list 1 2 3 4 5 6) 4) (list 4 3 2 1 5 6) 0.001)\n    (check-within (candidate (list 4 5 6 7) 2) (list 5 4 6 7) 0.001)\n    (check-within (candidate (list 9 8 7 6 5) 3) (list 7 8 9 6 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of tuples using the second value of each tuple.\n(define (subject_marks subjectmarks)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate subject_marks))\n    (check-within (candidate (list (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97) (list \"Social sciences\" 82))) (list (list \"Social sciences\" 82) (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97)) 0.001)\n    (check-within (candidate (list (list \"Telugu\" 49) (list \"Hindhi\" 54) (list \"Social\" 33))) (list (list \"Social\" 33) (list \"Telugu\" 49) (list \"Hindhi\" 54)) 0.001)\n    (check-within (candidate (list (list \"Physics\" 96) (list \"Chemistry\" 97) (list \"Biology\" 45))) (list (list \"Biology\" 45) (list \"Physics\" 96) (list \"Chemistry\" 97)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove characters from the first string which are present in the second string.\n(define (remove_dirty_chars string second_string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_dirty_chars))\n    (check-within (candidate \"probasscurve\" \"pros\") \"bacuve\" 0.001)\n    (check-within (candidate \"digitalindia\" \"talent\") \"digiidi\" 0.001)\n    (check-within (candidate \"exoticmiles\" \"toxic\") \"emles\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n(define (round_and_sum list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate round_and_sum))\n    (check-within (candidate (list 22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5)) 243 0.001)\n    (check-within (candidate (list 5 2 9 24.3 29)) 345 0.001)\n    (check-within (candidate (list 25.0 56.7 89.2)) 513 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the item with maximum frequency in a given list.\n(define (max_occurrences nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_occurrences))\n    (check-within (candidate (list 2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2)) 2 0.001)\n    (check-within (candidate (list 2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18)) 8 0.001)\n    (check-within (candidate (list 10 20 20 30 40 90 80 50 30 20 50 10)) 20 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a given string is a decimal number with a precision of 2.\n(define (is_decimal num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_decimal))\n    (check-within (candidate \"123.11\") #t 0.001)\n    (check-within (candidate \"e666.86\") #f 0.001)\n    (check-within (candidate \"3.124587\") #f 0.001)\n    (check-within (candidate \"1.11\") #t 0.001)\n    (check-within (candidate \"1.1.11\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n(define (dict_filter dict n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dict_filter))\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 170) #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 180) #hash((\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 190) #hash((\"Pierre Cox\" .  190)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of even numbers at even positions of a list.\n(define (sum_even_and_even_index arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_even_and_even_index))\n    (check-within (candidate (list 5 6 12 1 18 8)) 30 0.001)\n    (check-within (candidate (list 3 20 17 9 2 10 18 13 6 18)) 26 0.001)\n    (check-within (candidate (list 5 6 12 1)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the sum of the largest contiguous sublist in the given list.\n(define (max_sub_array_sum a size)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum))\n    (check-within (candidate (list -2 -3 4 -1 -2 1 5 -3) 8) 7 0.001)\n    (check-within (candidate (list -3 -4 5 -2 -3 2 6 -4) 8) 8 0.001)\n    (check-within (candidate (list -4 -5 6 -3 -4 3 7 -5) 8) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the intersection of two arrays.\n(define (intersection_array array_nums1 array_nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection_array))\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 1 2 4 8 9)) (list 1 2 8 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 3 5 7 9)) (list 3 5 7 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 10 20 30 40)) (list 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n(define (split_two_parts list1 L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_two_parts))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list (list 1 1 2) (list 3 4 4 5 1)) 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") 2) (list (list \"a\" \"b\") (list \"c\" \"d\")) 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 4) (list (list \"p\" \"y\" \"t\" \"h\") (list \"o\" \"n\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n(define (find_literals text pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_literals))\n    (check-within (candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") (list \"fox\" 16 19) 0.001)\n    (check-within (candidate \"Its been a very crazy procedure right\" \"crazy\") (list \"crazy\" 16 21) 0.001)\n    (check-within (candidate \"Hardest choices required strongest will\" \"will\") (list \"will\" 35 39) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the volume of a triangular prism.\n(define (find_Volume l b h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Volume))\n    (check-within (candidate 10 8 6) 240 0.001)\n    (check-within (candidate 3 2 2) 6 0.001)\n    (check-within (candidate 1 2 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n(define (wind_chill v t)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate wind_chill))\n    (check-within (candidate 120 35) 40 0.001)\n    (check-within (candidate 40 20) 19 0.001)\n    (check-within (candidate 10 8) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the ascii value of a character.\n(define (ascii_value k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate ascii_value))\n    (check-within (candidate \"A\") 65 0.001)\n    (check-within (candidate \"R\") 82 0.001)\n    (check-within (candidate \"S\") 83 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether all the characters are same or not.\n(define (all_Characters_Same s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Characters_Same))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"aaa\") #t 0.001)\n    (check-within (candidate \"data\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to move all the numbers to the end of the given string.\n(define (move_num test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_num))\n    (check-within (candidate \"I1love143you55three3000thousand\") \"Iloveyouthreethousand1143553000\" 0.001)\n    (check-within (candidate \"Avengers124Assemble\") \"AvengersAssemble124\" 0.001)\n    (check-within (candidate \"Its11our12path13to14see15things16do17things\") \"Itsourpathtoseethingsdothings11121314151617\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the length of the word is odd or not.\n(define (word_len s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate word_len))\n    (check-within (candidate \"Hadoop\") #f 0.001)\n    (check-within (candidate \"great\") #t 0.001)\n    (check-within (candidate \"structure\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to drop empty items from a given dictionary.\n(define (drop_empty dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate drop_empty))\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  #f) (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  #f) (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c2\" .  \"Green\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n(define (insert_element list element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate insert_element))\n    (check-within (candidate (list \"Red\" \"Green\" \"Black\") \"c\") (list \"c\" \"Red\" \"c\" \"Green\" \"c\" \"Black\") 0.001)\n    (check-within (candidate (list \"python\" \"java\") \"program\") (list \"program\" \"python\" \"program\" \"java\") 0.001)\n    (check-within (candidate (list \"happy\" \"sad\") \"laugh\") (list \"laugh\" \"happy\" \"laugh\" \"sad\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove lowercase substrings from a given string.\n(define (remove_lowercase str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_lowercase))\n    (check-within (candidate \"PYTHon\") \"PYTH\" 0.001)\n    (check-within (candidate \"FInD\") \"FID\" 0.001)\n    (check-within (candidate \"STRinG\") \"STRG\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n(define (count_Set_Bits n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Set_Bits))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 1 0.001)\n    (check-within (candidate 6) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract only the rear index element of each string in the given tuple.\n(define (extract_rear test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_rear))\n    (check-within (candidate (list \"Mers\" \"for\" \"Vers\")) (list \"s\" \"r\" \"s\") 0.001)\n    (check-within (candidate (list \"Avenge\" \"for\" \"People\")) (list \"e\" \"r\" \"e\") 0.001)\n    (check-within (candidate (list \"Gotta\" \"get\" \"go\")) (list \"a\" \"t\" \"o\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of occurence of the string 'std' in a given string.\n(define (count_occurance s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_occurance))\n    (check-within (candidate \"letstdlenstdporstd\") 3 0.001)\n    (check-within (candidate \"truststdsolensporsd\") 1 0.001)\n    (check-within (candidate \"makestdsostdworthit\") 2 0.001)\n    (check-within (candidate \"stds\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given tuples contain the k or not.\n(define (check_K test_tup K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_K))\n    (check-within (candidate (list 10 4 5 6 8) 6) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) 7) #f 0.001)\n    (check-within (candidate (list 7 8 9 44 11 12) 11) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to interleave 3 lists of the same length into a single flat list.\n(define (interleave_lists list1 list2 list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate interleave_lists))\n    (check-within (candidate (list 1 2 3 4 5 6 7) (list 10 20 30 40 50 60 70) (list 100 200 300 400 500 600 700)) (list 1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700) 0.001)\n    (check-within (candidate (list 10 20) (list 15 2) (list 5 10)) (list 10 15 5 20 2 10) 0.001)\n    (check-within (candidate (list 11 44) (list 10 15) (list 20 5)) (list 11 10 20 44 15 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a snake case string to camel case string.\n(define (snake_to_camel word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"python_program\") \"PythonProgram\" 0.001)\n    (check-within (candidate \"python_language\") \"PythonLanguage\" 0.001)\n    (check-within (candidate \"programming_language\") \"ProgrammingLanguage\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of equal numbers from three given integers.\n(define (test_three_equal x y z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_three_equal))\n    (check-within (candidate 1 1 1) 3 0.001)\n    (check-within (candidate -1 -2 -3) 0 0.001)\n    (check-within (candidate 1 2 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n(define (odd_length_sum arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_length_sum))\n    (check-within (candidate (list 1 2 4)) 14 0.001)\n    (check-within (candidate (list 1 2 1 2)) 15 0.001)\n    (check-within (candidate (list 1 7)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the number of ways to partition a set of Bell numbers.\n(define (bell_number n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 10) 115975 0.001)\n    (check-within (candidate 56) 6775685320645824322581483068371419745979053216268760300 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the area of a rectangle.\n(define (rectangle_area l b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rectangle_area))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 10 5) 50 0.001)\n    (check-within (candidate 4 2) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find sum and average of first n natural numbers.\n(define (sum_average number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_average))\n    (check-within (candidate 10) (list 55 5.5) 0.001)\n    (check-within (candidate 15) (list 120 8.0) 0.001)\n    (check-within (candidate 20) (list 210 10.5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n(define (division_elements test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate division_elements))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 2 2 2 3) 0.001)\n    (check-within (candidate (list 12 6 8 16) (list 6 3 4 4)) (list 2 2 2 4) 0.001)\n    (check-within (candidate (list 20 14 36 18) (list 5 7 6 9)) (list 4 2 6 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get the sum of the digits of a non-negative integer.\n(define (sum_digits n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_digits))\n    (check-within (candidate 345) 12 0.001)\n    (check-within (candidate 12) 3 0.001)\n    (check-within (candidate 97) 16 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n(define (index_minimum test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_minimum))\n    (check-within (candidate (list (list \"Rash\" 143) (list \"Manjeet\" 200) (list \"Varsha\" 100))) \"Varsha\" 0.001)\n    (check-within (candidate (list (list \"Yash\" 185) (list \"Dawood\" 125) (list \"Sanya\" 175))) \"Dawood\" 0.001)\n    (check-within (candidate (list (list \"Sai\" 345) (list \"Salman\" 145) (list \"Ayesha\" 96))) \"Ayesha\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to divide two lists element wise.\n(define (div_list nums1 nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate div_list))\n    (check-within (candidate (list 4 5 6) (list 1 2 3)) (list 4.0 2.5 2.0) 0.001)\n    (check-within (candidate (list 3 2) (list 1 4)) (list 3.0 0.5) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 1.8 1.7142857142857142) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the list with maximum length.\n(define (max_length_list input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length_list))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5) (list 1 2 3 4) (list 1 2 3) (list 1 2) (list 1))) (list 5 (list 1 2 3 4 5)) 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 6 7 8 9) (list 10 11 12))) (list 4 (list 6 7 8 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find all possible combinations of the elements of a given list.\n(define (combinations_list list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_list))\n    (check-within (candidate (list \"orange\" \"red\" \"green\" \"blue\")) (list (list ) (list \"orange\") (list \"red\") (list \"red\" \"orange\") (list \"green\") (list \"green\" \"orange\") (list \"green\" \"red\") (list \"green\" \"red\" \"orange\") (list \"blue\") (list \"blue\" \"orange\") (list \"blue\" \"red\") (list \"blue\" \"red\" \"orange\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"orange\") (list \"blue\" \"green\" \"red\") (list \"blue\" \"green\" \"red\" \"orange\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"blue\" \"white\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"blue\") (list \"blue\" \"red\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"red\") (list \"white\") (list \"white\" \"red\") (list \"white\" \"green\") (list \"white\" \"green\" \"red\") (list \"white\" \"blue\") (list \"white\" \"blue\" \"red\") (list \"white\" \"blue\" \"green\") (list \"white\" \"blue\" \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"black\" \"blue\") (list \"black\" \"blue\" \"red\") (list \"black\" \"blue\" \"green\") (list \"black\" \"blue\" \"green\" \"red\") (list \"black\" \"white\") (list \"black\" \"white\" \"red\") (list \"black\" \"white\" \"green\") (list \"black\" \"white\" \"green\" \"red\") (list \"black\" \"white\" \"blue\") (list \"black\" \"white\" \"blue\" \"red\") (list \"black\" \"white\" \"blue\" \"green\") (list \"black\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"blue\") (list \"orange\" \"blue\" \"red\") (list \"orange\" \"blue\" \"green\") (list \"orange\" \"blue\" \"green\" \"red\") (list \"orange\" \"white\") (list \"orange\" \"white\" \"red\") (list \"orange\" \"white\" \"green\") (list \"orange\" \"white\" \"green\" \"red\") (list \"orange\" \"white\" \"blue\") (list \"orange\" \"white\" \"blue\" \"red\") (list \"orange\" \"white\" \"blue\" \"green\") (list \"orange\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\") (list \"orange\" \"black\" \"blue\") (list \"orange\" \"black\" \"blue\" \"red\") (list \"orange\" \"black\" \"blue\" \"green\") (list \"orange\" \"black\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\" \"white\") (list \"orange\" \"black\" \"white\" \"red\") (list \"orange\" \"black\" \"white\" \"green\") (list \"orange\" \"black\" \"white\" \"green\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\") (list \"orange\" \"black\" \"white\" \"blue\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\" \"red\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the largest and smallest value in a given array.\n(define (big_sum nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_sum))\n    (check-within (candidate (list 1 2 3)) 4 0.001)\n    (check-within (candidate (list -1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 2 3 6)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to return the negative numbers in a list.\n(define (neg_nos list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate neg_nos))\n    (check-within (candidate (list -1 4 5 -6)) (list -1 -6) 0.001)\n    (check-within (candidate (list -1 -2 3 4)) (list -1 -2) 0.001)\n    (check-within (candidate (list -7 -6 8 9)) (list -7 -6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the highest power of 2 that is less than or equal to n.\n(define (highest_Power_of_2 n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate highest_Power_of_2))\n    (check-within (candidate 10) 8 0.001)\n    (check-within (candidate 19) 16 0.001)\n    (check-within (candidate 32) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a list contains the given sublist or not.\n(define (is_sublist l s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sublist))\n    (check-within (candidate (list 2 4 3 5 7) (list 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 4 3)) #t 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 1 6)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to subtract two lists element-wise.\n(define (sub_list nums1 nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sub_list))\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) (list -3 -3 -3) 0.001)\n    (check-within (candidate (list 1 2) (list 3 4)) (list -2 -2) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 40 50) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given two integers have opposite sign or not.\n(define (opposite_Signs x y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate opposite_Signs))\n    (check-within (candidate 1 -2) #t 0.001)\n    (check-within (candidate 3 2) #f 0.001)\n    (check-within (candidate -10 -10) #f 0.001)\n    (check-within (candidate -2 2) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which takes two tuples of the same length and performs the element wise modulo.\n(define (tuple_modulo test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_modulo))\n    (check-within (candidate (list 10 4 5 6) (list 5 6 7 5)) (list 0 4 5 1) 0.001)\n    (check-within (candidate (list 11 5 6 7) (list 6 7 8 6)) (list 5 5 6 1) 0.001)\n    (check-within (candidate (list 12 6 7 8) (list 7 8 9 7)) (list 5 6 7 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the difference of the first even and first odd number of a given list.\n(define (diff_even_odd list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate diff_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 1 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\"))) (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"d\" \"c\") (list \"g\" \"h\") (list \"f\" \"e\"))) (list (list \"a\" \"b\") (list \"c\" \"d\") (list \"g\" \"h\") (list \"e\" \"f\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the last digit of a given number.\n(define (last_Digit n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit))\n    (check-within (candidate 123) 3 0.001)\n    (check-within (candidate 25) 5 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of fourth power of first n odd natural numbers.\n(define (odd_num_sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_num_sum))\n    (check-within (candidate 2) 82 0.001)\n    (check-within (candidate 3) 707 0.001)\n    (check-within (candidate 4) 3108 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a list to a string.\n(define (tup_string tup1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tup_string))\n    (check-within (candidate (list \"e\" \"x\" \"e\" \"r\" \"c\" \"i\" \"s\" \"e\" \"s\")) \"exercises\" 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\")) \"python\" 0.001)\n    (check-within (candidate (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\")) \"program\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all elements from a given list present in another list.\n(define (remove_elements list1 list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_elements))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 1 3 5 7)) (list 2 4 6 8 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 5 7)) (list 1 2 3 4 6 8 9 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether any value in a sequence exists in a sequence or not.\n(define (overlapping list1 list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate overlapping))\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) #f 0.001)\n    (check-within (candidate (list 1 4 5) (list 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to identify non-prime numbers.\n(define (is_not_prime n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_not_prime))\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 35) #t 0.001)\n    (check-within (candidate 37) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum value in a given heterogeneous list.\n(define (max_val listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 5 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 25 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 50 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of the negative numbers of a given list of numbers.\n(define (sum_negativenum nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_negativenum))\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) -32 0.001)\n    (check-within (candidate (list 10 15 -14 13 -18 12 -20)) -52 0.001)\n    (check-within (candidate (list 19 -65 57 39 152 -639 121 44 90 -190)) -894 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n(define (find_Rotations str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Rotations))\n    (check-within (candidate \"aaaa\") 1 0.001)\n    (check-within (candidate \"ab\") 2 0.001)\n    (check-within (candidate \"abc\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n(define (change_date_format dt)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_date_format))\n    (check-within (candidate \"2026-01-02\") \"02-01-2026\" 0.001)\n    (check-within (candidate \"2020-11-13\") \"13-11-2020\" 0.001)\n    (check-within (candidate \"2021-04-26\") \"26-04-2021\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function which takes a list of integers and only returns the odd ones.\n(define (Split list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5 6)) (list 1 3 5) 0.001)\n    (check-within (candidate (list 10 11 12 13)) (list 11 13) 0.001)\n    (check-within (candidate (list 7 8 9 1)) (list 7 9 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n(define (toggle_middle_bits n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_middle_bits))\n    (check-within (candidate 9) 15 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 11) 13 0.001)\n    (check-within (candidate 65) 127 0.001)\n    (check-within (candidate 77) 115 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n(define (count_char_position str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_char_position))\n    (check-within (candidate \"xbcefg\") 2 0.001)\n    (check-within (candidate \"ABcED\") 3 0.001)\n    (check-within (candidate \"AbgdeF\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n(define (large_product nums1 nums2 N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate large_product))\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 3) (list 60 54 50) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 4) (list 60 54 50 48) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 5) (list 60 54 50 48 45) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n(define (cummulative_sum test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cummulative_sum))\n    (check-within (candidate (list (list 1 3) (list 5 6 7) (list 2 6))) 30 0.001)\n    (check-within (candidate (list (list 2 4) (list 6 7 8) (list 3 7))) 37 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8 9) (list 4 8))) 44 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n(define (find_min_diff arr n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_min_diff))\n    (check-within (candidate (list 1 5 3 19 18 25) 6) 1 0.001)\n    (check-within (candidate (list 4 3 2 6) 4) 1 0.001)\n    (check-within (candidate (list 30 5 20 9) 4) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n(define (text_starta_endb text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_starta_endb))\n    (check-within (candidate \"aabbbb\") #t 0.001)\n    (check-within (candidate \"aabAbbbc\") #f 0.001)\n    (check-within (candidate \"accddbbjjj\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n(define (left_rotate n d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_rotate))\n    (check-within (candidate 16 2) 64 0.001)\n    (check-within (candidate 10 2) 40 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 1 3) 8 0.001)\n    (check-within (candidate 5 3) 40 0.001)\n    (check-within (candidate 29 3) 232 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the first repeated character in a given string.\n(define (first_repeated_char str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_repeated_char))\n    (check-within (candidate \"abcabc\") \"a\" 0.001)\n    (check-within (candidate \"abc\") #f 0.001)\n    (check-within (candidate \"123123\") \"1\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count inversions in an array.\n(define (get_Inv_Count arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Inv_Count))\n    (check-within (candidate (list 1 20 6 4 5)) 5 0.001)\n    (check-within (candidate (list 1 2 1)) 1 0.001)\n    (check-within (candidate (list 1 2 5 6 1)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n(define (even_Power_Sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_Power_Sum))\n    (check-within (candidate 2) 1056 0.001)\n    (check-within (candidate 3) 8832 0.001)\n    (check-within (candidate 1) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find whether all the given lists have equal length or not.\n(define (get_equal Input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_equal))\n    (check-within (candidate (list (list 11 22 33) (list 44 55 66))) #t 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6 7))) #f 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4))) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if a string represents an integer or not.\n(define (check_integer text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_integer))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"1\") #t 0.001)\n    (check-within (candidate \"12345\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n(define (count_reverse_pairs test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_reverse_pairs))\n    (check-within (candidate (list \"julia\" \"best\" \"tseb\" \"for\" \"ailuj\")) 2 0.001)\n    (check-within (candidate (list \"geeks\" \"best\" \"for\" \"skeeg\")) 1 0.001)\n    (check-within (candidate (list \"makes\" \"best\" \"sekam\" \"for\" \"rof\")) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to move all zeroes to the end of the given list.\n(define (move_zero num_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_zero))\n    (check-within (candidate (list 1 0 2 0 3 4)) (list 1 2 3 4 0 0) 0.001)\n    (check-within (candidate (list 2 3 2 0 0 4 0 5 0)) (list 2 3 2 4 5 0 0 0 0) 0.001)\n    (check-within (candidate (list 0 1 0 1 1)) (list 1 1 1 0 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if given list contains no duplicates.\n(define (check_distinct test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_distinct))\n    (check-within (candidate (list 1 4 5 6 1 4)) #f 0.001)\n    (check-within (candidate (list 1 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 6)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given amount has no profit and no loss\n(define (noprofit_noloss actual_cost sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate noprofit_noloss))\n    (check-within (candidate 1500 1200) #f 0.001)\n    (check-within (candidate 100 100) #t 0.001)\n    (check-within (candidate 2000 5000) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all the words with k length in the given string.\n(define (remove_length test_str K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_length))\n    (check-within (candidate \"The person is most value tet\" 3) \"person is most value\" 0.001)\n    (check-within (candidate \"If you told me about this ok\" 4) \"If you me about ok\" 0.001)\n    (check-within (candidate \"Forces of darkeness is come into the play\" 4) \"Forces of darkeness is the\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count number of digits in a given string.\n(define (number_ctr str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_ctr))\n    (check-within (candidate \"program2bedone\") 1 0.001)\n    (check-within (candidate \"3wonders\") 1 0.001)\n    (check-within (candidate \"123\") 3 0.001)\n    (check-within (candidate \"3wond-1ers2\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the total number of characters in a string.\n(define (count_charac str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_charac))\n    (check-within (candidate \"python programming\") 18 0.001)\n    (check-within (candidate \"language\") 8 0.001)\n    (check-within (candidate \"words\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n(define (get_total_number_of_sequences m n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_total_number_of_sequences))\n    (check-within (candidate 10 4) 4 0.001)\n    (check-within (candidate 5 2) 6 0.001)\n    (check-within (candidate 16 3) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n(define (left_insertion a x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two numbers and returns a list with the second number and then the first number.\n(define (swap_numbers a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_numbers))\n    (check-within (candidate 10 20) (list 20 10) 0.001)\n    (check-within (candidate 15 17) (list 17 15) 0.001)\n    (check-within (candidate 100 200) (list 200 100) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n(define (is_majority arr n x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_majority))\n    (check-within (candidate (list 1 2 3 3 3 3 10) 7 3) #t 0.001)\n    (check-within (candidate (list 1 1 2 4 4 4 6 6) 8 4) #f 0.001)\n    (check-within (candidate (list 1 1 1 2 2) 5 1) #t 0.001)\n    (check-within (candidate (list 1 1 2 2) 5 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n(define (substract_elements test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate substract_elements))\n    (check-within (candidate (list 10 4 5) (list 2 5 18)) (list 8 -1 -13) 0.001)\n    (check-within (candidate (list 11 2 3) (list 24 45 16)) (list -13 -43 -13) 0.001)\n    (check-within (candidate (list 7 18 9) (list 10 11 12)) (list -3 7 -3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to put spaces between words starting with capital letters in a given string.\n(define (capital_words_spaces str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate capital_words_spaces))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"PythonProgrammingExamples\") \"Python Programming Examples\" 0.001)\n    (check-within (candidate \"GetReadyToBeCodingFreak\") \"Get Ready To Be Coding Freak\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the average of cubes of first n natural numbers.\n(define (find_Average_Of_Cube n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Average_Of_Cube))\n    (check-within (candidate 2) 4.5 0.001)\n    (check-within (candidate 3) 12 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if all values are same in a dictionary.\n(define (check_value dict n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_value))\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 10) #f 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 12) #t 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth tetrahedral number.\n(define (tetrahedral_number n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tetrahedral_number))\n    (check-within (candidate 5) 35 0.001)\n    (check-within (candidate 6) 56 0.001)\n    (check-within (candidate 7) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate whether the matrix is a magic square.\n(define (magic_square_test my_matrix)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate magic_square_test))\n    (check-within (candidate (list (list 7 12 1 14) (list 2 13 8 11) (list 16 3 10 5) (list 9 6 15 4))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 8))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 7))) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove uppercase substrings from a given string.\n(define (remove_uppercase str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_uppercase))\n    (check-within (candidate \"cAstyoUrFavoRitETVshoWs\") \"cstyoravoitshos\" 0.001)\n    (check-within (candidate \"wAtchTheinTernEtrAdIo\") \"wtchheinerntrdo\" 0.001)\n    (check-within (candidate \"VoicESeaRchAndreComMendaTionS\") \"oiceachndreomendaion\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether an element exists within a tuple.\n(define (check_tuplex tuplex tuple1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_tuplex))\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"r\") #t 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"5\") #f 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") 3) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate a dog's age in dog's years.\n(define (dog_age h_age)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dog_age))\n    (check-within (candidate 12) 61 0.001)\n    (check-within (candidate 15) 73 0.001)\n    (check-within (candidate 24) 109 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the next perfect square greater than a given number.\n(define (next_Perfect_Square N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_Perfect_Square))\n    (check-within (candidate 35) 36 0.001)\n    (check-within (candidate 6) 9 0.001)\n    (check-within (candidate 9) 16 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create a list of N empty dictionaries.\n(define (empty_list length)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate empty_list))\n    (check-within (candidate 5) (list #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 6) (list #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 7) (list #hash() #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to convert a given string to uppercase.\n(define (is_upper string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_upper))\n    (check-within (candidate \"person\") \"PERSON\" 0.001)\n    (check-within (candidate \"final\") \"FINAL\" 0.001)\n    (check-within (candidate \"Valid\") \"VALID\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n(define (odd_Equivalent s n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_Equivalent))\n    (check-within (candidate \"011001\" 6) 3 0.001)\n    (check-within (candidate \"11011\" 5) 4 0.001)\n    (check-within (candidate \"1010\" 4) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n(define (re_arrange_array arr n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate re_arrange_array))\n    (check-within (candidate (list -1 2 -3 4 5 6 -7 8 9) 9) (list -1 -3 -7 4 5 6 2 8 9) 0.001)\n    (check-within (candidate (list 12 -14 -26 13 15) 5) (list -14 -26 12 13 15) 0.001)\n    (check-within (candidate (list 10 24 36 -42 -39 -78 85) 7) (list -42 -39 -78 10 24 36 85) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether a list of numbers contains only one distinct element or not.\n(define (unique_Element arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_Element))\n    (check-within (candidate (list 1 1 1)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks from a string.\n(define (extract_values text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_values))\n    (check-within (candidate \"\"Python\", \"PHP\", \"Java\"\") (list \"Python\" \"PHP\" \"Java\") 0.001)\n    (check-within (candidate \"\"python\",\"program\",\"language\"\") (list \"python\" \"program\" \"language\") 0.001)\n    (check-within (candidate \"\"red\",\"blue\",\"green\",\"yellow\"\") (list \"red\" \"blue\" \"green\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count true booleans in the given list.\n(define (count lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count))\n    (check-within (candidate (list #t #f #t)) 2 0.001)\n    (check-within (candidate (list #f #f)) 0 0.001)\n    (check-within (candidate (list #t #t #t)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that counts the number of pairs of integers in a list that xor to an even number.\n(define (find_even_pair A)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_even_pair))\n    (check-within (candidate (list 5 4 7 2 1)) 4 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11)) 9 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is armstrong or not.\n(define (armstrong_number number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate armstrong_number))\n    (check-within (candidate 153) #t 0.001)\n    (check-within (candidate 259) #f 0.001)\n    (check-within (candidate 4458) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the upper case characters in a given string.\n(define (upper_ctr str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate upper_ctr))\n    (check-within (candidate \"PYthon\") 1 0.001)\n    (check-within (candidate \"BigData\") 1 0.001)\n    (check-within (candidate \"program\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the elementwise and tuples from the given two tuples.\n(define (and_tuples test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate and_tuples))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 0 0 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 5 6 7 8)) (list 1 2 3 0) 0.001)\n    (check-within (candidate (list 8 9 11 12) (list 7 13 14 17)) (list 0 9 10 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether it follows the sequence given in the patterns array.\n(define (is_samepatterns colors patterns)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_samepatterns))\n    (check-within (candidate (list \"red\" \"green\" \"green\") (list \"a\" \"b\" \"b\")) #t 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\" \"b\")) #f 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\")) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of lists in a given number of lists.\n(define (count_list input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) 4 0.001)\n    (check-within (candidate (list (list 1 2) (list 2 3) (list 4 5))) 3 0.001)\n    (check-within (candidate (list (list 1 0) (list 2 0))) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n(define (average_tuple nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate average_tuple))\n    (check-within (candidate (list (list 10 10 10 12) (list 30 45 56 45) (list 81 80 39 32) (list 1 2 3 4))) (list 30.5 34.25 27.0 23.25) 0.001)\n    (check-within (candidate (list (list 1 1 -5) (list 30 -15 56) (list 81 -60 -39) (list -10 2 3))) (list 25.5 -18.0 3.75) 0.001)\n    (check-within (candidate (list (list 100 100 100 120) (list 300 450 560 450) (list 810 800 390 320) (list 10 20 30 40))) (list 305.0 342.5 270.0 232.5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n(define (lcs_of_three X Y Z)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lcs_of_three))\n    (check-within (candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") 2 0.001)\n    (check-within (candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") 5 0.001)\n    (check-within (candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n'th star number.\n(define (find_star_num n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_star_num))\n    (check-within (candidate 3) 37 0.001)\n    (check-within (candidate 4) 73 0.001)\n    (check-within (candidate 5) 121 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of an array.\n(define (_sum arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate _sum))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 15 12 13 10)) 50 0.001)\n    (check-within (candidate (list 0 1 2)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given list contains consecutive numbers or not.\n(define (check_Consecutive l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_Consecutive))\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 5 6)) #f 0.001)\n    (check-within (candidate (list 1 2 1)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the first adverb and their positions in a given sentence.\n(define (find_adverb_position text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverb_position))\n    (check-within (candidate \"clearly!! we can see the sky\") (list 0 7 \"clearly\") 0.001)\n    (check-within (candidate \"seriously!! there are many roses\") (list 0 9 \"seriously\") 0.001)\n    (check-within (candidate \"unfortunately!! sita is going to home\") (list 0 13 \"unfortunately\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n(define (rotate_right list m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rotate_right))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 3) (list 8 9 10 1 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 9 10 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 5) (list 6 7 8 9 10 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of non-empty substrings of a given string.\n(define (number_of_substrings str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_of_substrings))\n    (check-within (candidate \"abc\") 6 0.001)\n    (check-within (candidate \"abcd\") 10 0.001)\n    (check-within (candidate \"abcde\") 15 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n(define (list_split S step)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_split))\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\" \"h\" \"i\" \"j\" \"k\" \"l\" \"m\" \"n\") 3) (list (list \"a\" \"d\" \"g\" \"j\" \"m\") (list \"b\" \"e\" \"h\" \"k\" \"n\") (list \"c\" \"f\" \"i\" \"l\")) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11 12 13 14) 3) (list (list 1 4 7 10 13) (list 2 5 8 11 14) (list 3 6 9 12)) 0.001)\n    (check-within (candidate (list \"python\" \"java\" \"C\" \"C++\" \"DBMS\" \"SQL\") 2) (list (list \"python\" \"C\" \"DBMS\") (list \"java\" \"C++\" \"SQL\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check if the elements of a given list are unique or not.\n(define (all_unique test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_unique))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to convert complex numbers to polar coordinates.\n(define (convert numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert))\n    (check-within (candidate 1) (list 1.0 0.0) 0.001)\n    (check-within (candidate 4) (list 4.0 0.0) 0.001)\n    (check-within (candidate 5) (list 5.0 0.0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n(define (filter_data students h w)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_data))\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 6.0 70) #hash((\"Cierra Vega\" .  (list 6.2 70))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.9 67) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Kierra Gentry\" .  (list 6.0 68))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.7 64) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to convert the given string to lower case.\n(define (is_lower string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_lower))\n    (check-within (candidate \"InValid\") \"invalid\" 0.001)\n    (check-within (candidate \"TruE\") \"true\" 0.001)\n    (check-within (candidate \"SenTenCE\") \"sentence\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the smallest power of 2 greater than or equal to n.\n(define (next_power_of_2 n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_power_of_2))\n    (check-within (candidate 0) 1 0.001)\n    (check-within (candidate 5) 8 0.001)\n    (check-within (candidate 17) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if a string is present as a substring in a given list of string values.\n(define (find_substring str1 sub_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_substring))\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ack\") #t 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"abc\") #f 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ange\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace characters in a string.\n(define (replace_char str1 ch newch)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_char))\n    (check-within (candidate \"polygon\" \"y\" \"l\") \"pollgon\" 0.001)\n    (check-within (candidate \"character\" \"c\" \"a\") \"aharaater\" 0.001)\n    (check-within (candidate \"python\" \"l\" \"a\") \"python\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the product of first even and odd number of a given list.\n(define (mul_even_odd list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mul_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a list to a tuple.\n(define (list_tuple listx)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_tuple))\n    (check-within (candidate (list 5 10 7 4 15 3)) (list 5 10 7 4 15 3) 0.001)\n    (check-within (candidate (list 2 4 5 6 2 3 4 4 7)) (list 2 4 5 6 2 3 4 4 7) 0.001)\n    (check-within (candidate (list 58 44 56)) (list 58 44 56) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n(define (even_binomial_Coeff_Sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_binomial_Coeff_Sum))\n    (check-within (candidate 4) 8 0.001)\n    (check-within (candidate 6) 32 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform the mathematical bitwise xor operation across the given tuples.\n(define (bitwise_xor test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bitwise_xor))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 15 6 5 10) 0.001)\n    (check-within (candidate (list 11 5 7 10) (list 6 3 4 4)) (list 13 6 3 14) 0.001)\n    (check-within (candidate (list 12 6 8 11) (list 7 4 5 6)) (list 11 2 13 13) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether a list is sublist of another or not.\n(define (is_Sub_Array A B)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sub_Array))\n    (check-within (candidate (list 1 4 3 5) (list 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 1) (list 1 2 1)) #t 0.001)\n    (check-within (candidate (list 1 0 2 2) (list 2 2 0)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n(define (max_sub_array_sum_repeated a n k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum_repeated))\n    (check-within (candidate (list 10 20 -30 -1) 4 3) 30 0.001)\n    (check-within (candidate (list -1 10 20) 3 2) 59 0.001)\n    (check-within (candidate (list -1 -2 -3) 3 3) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the minimum product from the pairs of tuples within a given list.\n(define (min_product_tuple list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 8 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 30 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 100 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n(define (count_divisors n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_divisors))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 100) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n(define (triangle_area r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate -1) #f 0.001)\n    (check-within (candidate 0) 0 0.001)\n    (check-within (candidate 2) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a given string to a list of characters.\n(define (string_to_tuple str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_tuple))\n    (check-within (candidate \"python 3.0\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\" \"3\" \".\" \"0\") 0.001)\n    (check-within (candidate \"item1\") (list \"i\" \"t\" \"e\" \"m\" \"1\") 0.001)\n    (check-within (candidate \"15.10\") (list \"1\" \"5\" \".\" \"1\" \"0\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n(define (find_length string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_length))\n    (check-within (candidate \"11000010001\") 6 0.001)\n    (check-within (candidate \"10111\") 1 0.001)\n    (check-within (candidate \"11011101100101\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n(define (count_Primes_nums n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Primes_nums))\n    (check-within (candidate 5) 2 0.001)\n    (check-within (candidate 10) 4 0.001)\n    (check-within (candidate 100) 25 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the product of consecutive binomial co-efficients.\n(define (sum_Of_product n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_product))\n    (check-within (candidate 3) 15 0.001)\n    (check-within (candidate 4) 56 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the maximum aggregate from the list of tuples.\n(define (max_aggregate stdata)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_aggregate))\n    (check-within (candidate (list (list \"Juan Whelan\" 90) (list \"Sabah Colley\" 88) (list \"Peter Nichols\" 7) (list \"Juan Whelan\" 122) (list \"Sabah Colley\" 84))) (list \"Juan Whelan\" 212) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 50) (list \"Sabah Colley\" 48) (list \"Peter Nichols\" 37) (list \"Juan Whelan\" 22) (list \"Sabah Colley\" 14))) (list \"Juan Whelan\" 72) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 10) (list \"Sabah Colley\" 20) (list \"Peter Nichols\" 30) (list \"Juan Whelan\" 40) (list \"Sabah Colley\" 50))) (list \"Sabah Colley\" 70) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (comb_sort nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate comb_sort))\n    (check-within (candidate (list 5 15 37 25 79)) (list 5 15 25 37 79) 0.001)\n    (check-within (candidate (list 41 32 15 19 22)) (list 15 19 22 32 41) 0.001)\n    (check-within (candidate (list 99 15 13 47)) (list 13 15 47 99) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n(define (check_expression exp)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_expression))\n    (check-within (candidate \"{()}[{}]\") #t 0.001)\n    (check-within (candidate \"{()}[{]\") #f 0.001)\n    (check-within (candidate \"{()}[{}][]({})\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a word containing 'z'.\n(define (text_match_wordz text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz))\n    (check-within (candidate \"pythonz.\") #t 0.001)\n    (check-within (candidate \"xyz.\") #t 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n(define (sum_list lst1 lst2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_list))\n    (check-within (candidate (list 10 20 30) (list 15 25 35)) (list 25 45 65) 0.001)\n    (check-within (candidate (list 1 2 3) (list 5 6 7)) (list 6 8 10) 0.001)\n    (check-within (candidate (list 15 20 30) (list 15 45 75)) (list 30 65 105) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n(define (newman_prime n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate newman_prime))\n    (check-within (candidate 3) 7 0.001)\n    (check-within (candidate 4) 17 0.001)\n    (check-within (candidate 5) 41 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to apply a given format string to all of the elements in a list.\n(define (add_string list_ string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_string))\n    (check-within (candidate (list 1 2 3 4) \"temp{0}\") (list \"temp1\" \"temp2\" \"temp3\" \"temp4\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") \"python{0}\") (list \"pythona\" \"pythonb\" \"pythonc\" \"pythond\") 0.001)\n    (check-within (candidate (list 5 6 7 8) \"string{0}\") (list \"string5\" \"string6\" \"string7\" \"string8\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the surface area of a square pyramid with a given base edge and height.\n(define (surface_Area b s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surface_Area))\n    (check-within (candidate 3 4) 33 0.001)\n    (check-within (candidate 4 5) 56 0.001)\n    (check-within (candidate 1 2) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the length of the smallest list in a list of lists.\n(define (Find_Min_Length lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min_Length))\n    (check-within (candidate (list (list 1) (list 1 2))) 1 0.001)\n    (check-within (candidate (list (list 1 2) (list 1 2 3) (list 1 2 3 4))) 2 0.001)\n    (check-within (candidate (list (list 3 3 3) (list 4 4 4 4))) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n(define (validate n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate validate))\n    (check-within (candidate 1234) #t 0.001)\n    (check-within (candidate 51241) #f 0.001)\n    (check-within (candidate 321) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth hexagonal number.\n(define (hexagonal_num n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hexagonal_num))\n    (check-within (candidate 10) 190 0.001)\n    (check-within (candidate 5) 45 0.001)\n    (check-within (candidate 7) 91 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n'th lucas number.\n(define (find_lucas n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lucas))\n    (check-within (candidate 9) 76 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 3) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to get the difference between two lists.\n(define (Diff li1 li2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Diff))\n    (check-within (candidate (list 10 15 20 25 30 35 40) (list 25 40 35)) (list 10 20 30 15) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 1)) (list 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3) (list 6 7 1)) (list 2 3 6 7) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks \" \" of the given string.\n(define (extract_quotation text1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_quotation))\n    (check-within (candidate \"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\") (list \"A53\" \"multi\" \"Processor\") 0.001)\n    (check-within (candidate \"Cast your \"favorite\" entertainment \"apps\"\") (list \"favorite\" \"apps\") 0.001)\n    (check-within (candidate \"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\") (list \"4k Ultra HD\" \"HDR 10\") 0.001)\n    (check-within (candidate \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to flatten a list and sum all of its elements.\n(define (recursive_list_sum data_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate recursive_list_sum))\n    (check-within (candidate (list 1 2 (list 3 4) (list 5 6))) 21 0.001)\n    (check-within (candidate (list 7 10 (list 15 14) (list 19 41))) 106 0.001)\n    (check-within (candidate (list 10 20 (list 30 40) (list 50 60))) 210 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the two numbers differ at one bit position only or not.\n(define (differ_At_One_Bit_Pos a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate differ_At_One_Bit_Pos))\n    (check-within (candidate 13 9) #t 0.001)\n    (check-within (candidate 15 8) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 2 3) #t 0.001)\n    (check-within (candidate 5 1) #t 0.001)\n    (check-within (candidate 1 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by three 'b'.\n(define (text_match_three text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"caacabbbba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n(define (max_product arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product))\n    (check-within (candidate (list 3 100 4 5 150 6)) 3000 0.001)\n    (check-within (candidate (list 4 42 55 68 80)) 50265600 0.001)\n    (check-within (candidate (list 10 22 9 33 21 50 41 60)) 2460 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to split a list at the nth eelment and add the first part to the end.\n(define (split_Arr l n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_Arr))\n    (check-within (candidate (list 12 10 5 6 52 36) 2) (list 5 6 52 36 12 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) 1) (list 2 3 4 1) 0.001)\n    (check-within (candidate (list 0 1 2 3 4 5 6 7) 3) (list 3 4 5 6 7 0 1 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the number of divisors of a given integer.\n(define (divisor n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisor))\n    (check-within (candidate 15) 4 0.001)\n    (check-within (candidate 12) 6 0.001)\n    (check-within (candidate 9) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the difference between largest and smallest value in a given list.\n(define (big_diff nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_diff))\n    (check-within (candidate (list 1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 4 5 12)) 8 0.001)\n    (check-within (candidate (list 9 2 3)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find squares of individual elements in a list.\n(define (square_nums nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 100 400 900) 0.001)\n    (check-within (candidate (list 12 15)) (list 144 225) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given tuple has any none value or not.\n(define (check_none test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_none))\n    (check-within (candidate (list 10 4 5 6 #f)) #t 0.001)\n    (check-within (candidate (list 7 8 9 11 14)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 #f)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given array is monotonic or not.\n(define (is_Monotonic A)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Monotonic))\n    (check-within (candidate (list 6 5 4 4)) #t 0.001)\n    (check-within (candidate (list 1 2 2 3)) #t 0.001)\n    (check-within (candidate (list 1 3 2)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n(define (is_perfect_square n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_perfect_square))\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 36) #t 0.001)\n    (check-within (candidate 14) #f 0.001)\n    (check-within (candidate 196) #t 0.001)\n    (check-within (candidate 125) #f 0.001)\n    (check-within (candidate 15625) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of common divisors of two given numbers.\n(define (sum a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum))\n    (check-within (candidate 10 15) 6 0.001)\n    (check-within (candidate 100 150) 93 0.001)\n    (check-within (candidate 4 6) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the list of maximum length in a list of lists.\n(define (max_length list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1) (list 5 7) (list 10 12 14 15))) (list 4 (list 10 12 14 15)) 0.001)\n    (check-within (candidate (list (list 5) (list 15 20 25))) (list 3 (list 15 20 25)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n(define (check_occurences test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_occurences))\n    (check-within (candidate (list (list 3 1) (list 1 3) (list 2 5) (list 5 2) (list 6 3))) #hash(((list 1 3) .  2) ((list 2 5) .  2) ((list 3 6) .  1)) 0.001)\n    (check-within (candidate (list (list 4 2) (list 2 4) (list 3 6) (list 6 3) (list 7 4))) #hash(((list 2 4) .  2) ((list 3 6) .  2) ((list 4 7) .  1)) 0.001)\n    (check-within (candidate (list (list 13 2) (list 11 23) (list 12 25) (list 25 12) (list 16 23))) #hash(((list 2 13) .  1) ((list 11 23) .  1) ((list 12 25) .  2) ((list 16 23) .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the directrix of a parabola.\n(define (parabola_directrix a b c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parabola_directrix))\n    (check-within (candidate 5 3 2) -198 0.001)\n    (check-within (candidate 9 8 4) -2336 0.001)\n    (check-within (candidate 2 4 6) -130 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n(define (occurance_substring text pattern)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate occurance_substring))\n    (check-within (candidate \"python programming, python language\" \"python\") (list \"python\" 0 6) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"programming\") (list \"programming\" 7 18) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"language\") (list \"language\" 31 39) 0.001)\n    (check-within (candidate \"c++ programming, c++ language\" \"python\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove tuples from the given tuple.\n(define (remove_nested test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_nested))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) (list 1 5 7 10) 0.001)\n    (check-within (candidate (list 2 6 8 (list 5 7) 11)) (list 2 6 8 11) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) 12)) (list 3 7 9 12) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) (list 5 12) 12)) (list 3 7 9 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists input_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \" red \" \"green\") (list \"blue \" \" black\") (list \" orange\" \"brown\"))) (list (list \" red \" \"green\") (list \" black\" \"blue \") (list \" orange\" \"brown\")) 0.001)\n    (check-within (candidate (list (list \"zilver\" \"gold\") (list \"magnesium\" \"aluminium\") (list \"steel\" \"bronze\"))) (list (list \"gold\" \"zilver\") (list \"aluminium\" \"magnesium\") (list \"bronze\" \"steel\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n(define (remove_kth_element list1 L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_kth_element))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list 1 1 3 4 4 5 1) 0.001)\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4) 4) (list 0 0 1 3 4 4 5 6 6 6 7 8 9 4 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10) 5) (list 10 10 15 19 18 17 26 26 17 18 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to add a dictionary to the tuple. The output should be a tuple.\n(define (add_dict_to_tuple test_tup test_dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_dict_to_tuple))\n    (check-within (candidate (list 4 5 6) #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) (list 4 5 6 #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) 0.001)\n    (check-within (candidate (list 1 2 3) #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) (list 1 2 3 #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) 0.001)\n    (check-within (candidate (list 8 9 10) #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) (list 8 9 10 #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n(define (find n m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find))\n    (check-within (candidate 10 3) 3 0.001)\n    (check-within (candidate 4 2) 2 0.001)\n    (check-within (candidate 20 5) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n(define (text_match_two_three text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_two_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the occurence of all elements of list in a tuple.\n(define (count_Occurrence tup lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Occurrence))\n    (check-within (candidate (list \"a\" \"a\" \"c\" \"b\" \"d\") (list \"a\" \"b\")) 3 0.001)\n    (check-within (candidate (list 1 2 3 1 4 6 7 1 4) (list 1 4 7)) 6 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 1 2)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count number items that are identical in the same position of three given lists.\n(define (count_samepair list1 list2 list3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_samepair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9) (list 2 1 3 1 2 6 7 9)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 2 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by one or more b's.\n(define (text_match_one text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n(define (difference n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate difference))\n    (check-within (candidate 3) 30 0.001)\n    (check-within (candidate 5) 210 0.001)\n    (check-within (candidate 2) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to toggle the case of all characters in a string.\n(define (toggle_string string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_string))\n    (check-within (candidate \"Python\") \"pYTHON\" 0.001)\n    (check-within (candidate \"Pangram\") \"pANGRAM\" 0.001)\n    (check-within (candidate \"LIttLE\") \"liTTle\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the element of a list having maximum length.\n(define (Find_Max lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max))\n    (check-within (candidate (list (list \"A\") (list \"A\" \"B\") (list \"A\" \"B\" \"C\"))) (list \"A\" \"B\" \"C\") 0.001)\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1 2 3) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 2 3) (list 1 5 6 1))) (list 1 5 6 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the Eulerian number a(n, m).\n(define (eulerian_num n m)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eulerian_num))\n    (check-within (candidate 3 1) 4 0.001)\n    (check-within (candidate 4 1) 11 0.001)\n    (check-within (candidate 5 3) 26 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of occurrences of a number in a given list.\n(define (frequency a x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency))\n    (check-within (candidate (list 1 2 3) 4) 0 0.001)\n    (check-within (candidate (list 1 2 2 3 3 3 4) 3) 3 0.001)\n    (check-within (candidate (list 0 1 2 3 1 2) 1) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n(define (sort_numeric_strings nums_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numeric_strings))\n    (check-within (candidate (list \"4\" \"12\" \"45\" \"7\" \"0\" \"100\" \"200\" \"-12\" \"-500\")) (list -500 -12 0 4 7 12 45 100 200) 0.001)\n    (check-within (candidate (list \"2\" \"3\" \"8\" \"4\" \"7\" \"9\" \"8\" \"2\" \"6\" \"5\" \"1\" \"6\" \"1\" \"2\" \"3\" \"4\" \"6\" \"9\" \"1\" \"2\")) (list 1 1 1 2 2 2 2 3 3 4 4 5 6 6 6 7 8 8 9 9) 0.001)\n    (check-within (candidate (list \"1\" \"3\" \"5\" \"7\" \"1\" \"3\" \"13\" \"15\" \"17\" \"5\" \"7 \" \"9\" \"1\" \"11\")) (list 1 1 1 3 3 5 5 7 7 9 11 13 15 17) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n(define (geometric_sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate geometric_sum))\n    (check-within (candidate 7) 1.9921875 0.001)\n    (check-within (candidate 4) 1.9375 0.001)\n    (check-within (candidate 8) 1.99609375 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n(define (divisible_by_digits startnum endnum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisible_by_digits))\n    (check-within (candidate 1 22) (list 1 2 3 4 5 6 7 8 9 11 12 15 22) 0.001)\n    (check-within (candidate 1 15) (list 1 2 3 4 5 6 7 8 9 11 12 15) 0.001)\n    (check-within (candidate 20 25) (list 22 24) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to calculate the product of the unique numbers in a given list.\n(define (unique_product list_data)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_product))\n    (check-within (candidate (list 10 20 30 40 20 50 60 40)) 720000000 0.001)\n    (check-within (candidate (list 1 2 3 1)) 6 0.001)\n    (check-within (candidate (list 7 8 9 0 1 1)) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the largest negative number from the given list.\n(define (largest_neg list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_neg))\n    (check-within (candidate (list 1 2 3 -4 -6)) -6 0.001)\n    (check-within (candidate (list 1 2 3 -8 -9)) -9 0.001)\n    (check-within (candidate (list 1 2 3 4 -1)) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove consecutive duplicates of a given list.\n(define (consecutive_duplicates nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list 0 1 2 3 4 5 6 7 8 9 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list 10 15 19 18 17 26 17 18 10) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list \"a\" \"b\" \"c\" \"d\") 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\" \"a\" \"a\")) (list \"a\" \"b\" \"c\" \"d\" \"a\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n(define (min_Jumps steps d)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Jumps))\n    (check-within (candidate (list 3 4) 11) 3.5 0.001)\n    (check-within (candidate (list 3 4) 0) 0 0.001)\n    (check-within (candidate (list 11 14) 11) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find a pair with highest product from a given array of integers.\n(define (max_Product arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Product))\n    (check-within (candidate (list 1 2 3 4 7 0 8 4)) (list 7 8) 0.001)\n    (check-within (candidate (list 0 -1 -2 -4 5 0 -6)) (list -4 -6) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the nth element from a given list of tuples.\n(define (extract_nth_element list1 n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_nth_element))\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 0) (list \"Greyson Fulton\" \"Brady Kent\" \"Wyatt Knott\" \"Beau Turnbull\") 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 2) (list 99 96 94 98) 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 1) (list 98 97 91 94) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth nonagonal number.\n(define (is_nonagonal n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nonagonal))\n    (check-within (candidate 10) 325 0.001)\n    (check-within (candidate 15) 750 0.001)\n    (check-within (candidate 18) 1089 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the maximum difference between any two elements in a given array.\n(define (max_Abs_Diff arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Abs_Diff))\n    (check-within (candidate (list 2 1 5 3)) 4 0.001)\n    (check-within (candidate (list 9 3 2 5 1)) 8 0.001)\n    (check-within (candidate (list 3 2 1)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to pack consecutive duplicates of a given list elements into sublists.\n(define (pack_consecutive_duplicates list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pack_consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list (list 0 0) (list 1) (list 2) (list 3) (list 4 4) (list 5) (list 6 6 6) (list 7) (list 8) (list 9) (list 4 4)) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list (list 10 10) (list 15) (list 19) (list 18 18) (list 17) (list 26 26) (list 17) (list 18) (list 10)) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list (list \"a\" \"a\") (list \"b\") (list \"c\") (list \"d\" \"d\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of perrin numbers.\n(define (cal_sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cal_sum))\n    (check-within (candidate 9) 49 0.001)\n    (check-within (candidate 10) 66 0.001)\n    (check-within (candidate 11) 88 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to remove the characters which have odd index values of a given string.\n(define (odd_values_string str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_values_string))\n    (check-within (candidate \"abcdef\") \"ace\" 0.001)\n    (check-within (candidate \"python\") \"pto\" 0.001)\n    (check-within (candidate \"data\") \"dt\" 0.001)\n    (check-within (candidate \"lambs\") \"lms\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find kth element from the given two sorted arrays.\n(define (find_kth arr1 arr2 k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_kth))\n    (check-within (candidate (list 2 3 6 7 9) (list 1 4 8 10) 5) 6 0.001)\n    (check-within (candidate (list 100 112 256 349 770) (list 72 86 113 119 265 445 892) 7) 256 0.001)\n    (check-within (candidate (list 3 4 7 8 10) (list 2 5 9 11) 6) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n(define (jacobsthal_num n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate jacobsthal_num))\n    (check-within (candidate 5) 11 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 5 0.001)\n    (check-within (candidate 13) 2731 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n(define (frequency_lists list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency_lists))\n    (check-within (candidate (list (list 1 2 3 2) (list 4 5 6 2) (list 7 8 9 5))) #hash((1 .  1) (2 .  3) (3 .  1) (4 .  1) (5 .  2) (6 .  1) (7 .  1) (8 .  1) (9 .  1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12))) #hash((1 .  1) (2 .  1) (3 .  1) (4 .  1) (5 .  1) (6 .  1) (7 .  1) (8 .  1) (9 .  1) (10 .  1) (11 .  1) (12 .  1)) 0.001)\n    (check-within (candidate (list (list 20 30 40 17) (list 18 16 14 13) (list 10 20 30 40))) #hash((20 .  2) (30 .  2) (40 .  2) (17 .  1) (18 .  1) (16 .  1) (14 .  1) (13 .  1) (10 .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find perfect squares between two given numbers.\n(define (perfect_squares a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perfect_squares))\n    (check-within (candidate 1 30) (list 1 4 9 16 25) 0.001)\n    (check-within (candidate 50 100) (list 64 81 100) 0.001)\n    (check-within (candidate 100 200) (list 100 121 144 169 196) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n(define (sum_Of_Subarray_Prod arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_Subarray_Prod))\n    (check-within (candidate (list 1 2 3)) 20 0.001)\n    (check-within (candidate (list 1 2)) 5 0.001)\n    (check-within (candidate (list 1 2 3 4)) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the first odd number in a given list of numbers.\n(define (first_odd nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_odd))\n    (check-within (candidate (list 1 3 5)) 1 0.001)\n    (check-within (candidate (list 2 4 1 3)) 1 0.001)\n    (check-within (candidate (list 8 9 1)) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform index wise addition of list elements in the given two nested lists.\n(define (add_nested_tuples test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_nested_tuples))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 7 10) (list 7 14) (list 3 10) (list 8 13)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 9 12) (list 9 16) (list 5 12) (list 10 15)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 11 14) (list 11 18) (list 7 14) (list 12 17)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n(define (merge lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"a\" \"b\") (list \"m\" \"n\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\")) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6) (list 7 8))) (list (list 1 3 5 7) (list 2 4 6 8)) 0.001)\n    (check-within (candidate (list (list \"x\" \"y\" \"z\") (list \"a\" \"b\" \"c\") (list \"m\" \"n\" \"o\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\") (list \"z\" \"c\" \"o\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number can be represented as the difference of two squares or not.\n(define (dif_Square n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dif_Square))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 15) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n(define (check_smaller test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_smaller))\n    (check-within (candidate (list 1 2 3) (list 2 3 4)) #f 0.001)\n    (check-within (candidate (list 4 5 6) (list 3 4 5)) #t 0.001)\n    (check-within (candidate (list 11 12 13) (list 10 11 12)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n(define (freq_count list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate freq_count))\n    (check-within (candidate (list 10 10 10 10 20 20 20 20 40 40 50 50 30)) #hash((10 .  4) (20 .  4) (40 .  2) (50 .  2) (30 .  1)) 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 4 1 3 1 4)) #hash((1 .  3) (2 .  2) (3 .  3) (4 .  3)) 0.001)\n    (check-within (candidate (list 5 6 7 4 9 10 4 5 6 7 9 5)) #hash((10 .  1) (5 .  3) (6 .  2) (7 .  2) (4 .  2) (9 .  2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n(define (rgb_to_hsv r g b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rgb_to_hsv))\n    (check-within (candidate 255 255 255) (list 0.0 0.0 100.0) 0.001)\n    (check-within (candidate 0 215 0) (list 120.0 100.0 84.31372549019608) 0.001)\n    (check-within (candidate 10 215 110) (list 149.26829268292684 95.34883720930233 84.31372549019608) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to flatten a given nested list structure.\n(define (flatten_list list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flatten_list))\n    (check-within (candidate (list 0 10 (list 20 30) 40 50 (list 60 70 80) (list 90 100 110 120))) (list 0 10 20 30 40 50 60 70 80 90 100 110 120) 0.001)\n    (check-within (candidate (list (list 10 20) (list 40) (list 30 56 25) (list 10 20) (list 33) (list 40))) (list 10 20 40 30 56 25 10 20 33 40) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 1 2 3 4 5 6 10 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given string is starting with a vowel or not using regex.\n(define (check_str string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_str))\n    (check-within (candidate \"annie\") #t 0.001)\n    (check-within (candidate \"dawood\") #f 0.001)\n    (check-within (candidate \"Else\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n(define (check_monthnumber_number monthnum3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumber_number))\n    (check-within (candidate 6) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 12) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort the given list.\n(define (heap_sort iterable)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_sort))\n    (check-within (candidate (list 1 3 5 7 9 2 4 6 8 0)) (list 0 1 2 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 25 58)) (list 14 22 25 25 35 58 65 75 85) 0.001)\n    (check-within (candidate (list 7 1 9 5)) (list 1 5 7 9) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n(define (k_smallest_pairs nums1 nums2 k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate k_smallest_pairs))\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 2) (list (list 1 2) (list 1 4)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 1) (list (list 1 2)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 7) (list (list 1 2) (list 1 4) (list 3 2) (list 1 6) (list 3 4) (list 3 6) (list 7 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n(define (find_solution a b n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_solution))\n    (check-within (candidate 2 3 7) (list 2 1) 0.001)\n    (check-within (candidate 4 2 7) #f 0.001)\n    (check-within (candidate 1 13 17) (list 4 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the largest number that can be formed with the given list of digits.\n(define (find_Max_Num arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Max_Num))\n    (check-within (candidate (list 1 2 3)) 321 0.001)\n    (check-within (candidate (list 4 5 6 1)) 6541 0.001)\n    (check-within (candidate (list 1 2 3 9)) 9321 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns the list in a list of lists whose sum of elements is the highest.\n(define (max_sum_list lists)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_list))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 10 11 12) 0.001)\n    (check-within (candidate (list (list 3 2 1) (list 6 5 4) (list 12 11 10))) (list 12 11 10) 0.001)\n    (check-within (candidate (list (list 2 3 1))) (list 2 3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to interchange the first and last elements in a list.\n(define (swap_List newList)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 12 35 9 56 24)) (list 24 35 9 56 12) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median of two sorted lists of same size.\n(define (get_median arr1 arr2 n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_median))\n    (check-within (candidate (list 1 12 15 26 38) (list 2 13 17 30 45) 5) 16.0 0.001)\n    (check-within (candidate (list 2 4 8 9) (list 7 13 19 28) 4) 8.5 0.001)\n    (check-within (candidate (list 3 6 14 23 36 42) (list 2 18 27 39 49 55) 6) 25.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace whitespaces with an underscore and vice versa in a given string.\n(define (replace_spaces text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"Jumanji The Jungle\") \"Jumanji_The_Jungle\" 0.001)\n    (check-within (candidate \"The_Avengers\") \"The Avengers\" 0.001)\n    (check-within (candidate \"Fast and Furious\") \"Fast_and_Furious\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to determine if the sum of the divisors of two integers are the same.\n(define (are_equivalent num1 num2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate are_equivalent))\n    (check-within (candidate 36 57) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 23 47) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to reverse each string in a given list of string values.\n(define (reverse_string_list stringlist)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_string_list))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\" \"White\" \"Black\")) (list \"deR\" \"neerG\" \"eulB\" \"etihW\" \"kcalB\") 0.001)\n    (check-within (candidate (list \"john\" \"amal\" \"joel\" \"george\")) (list \"nhoj\" \"lama\" \"leoj\" \"egroeg\") 0.001)\n    (check-within (candidate (list \"jack\" \"john\" \"mary\")) (list \"kcaj\" \"nhoj\" \"yram\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to compute the sum of digits of each number of a given list.\n(define (sum_of_digits nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_of_digits))\n    (check-within (candidate (list 10 2 56)) 14 0.001)\n    (check-within (candidate (list (list 10 20 4 5 \"b\" 70 \"a\"))) 19 0.001)\n    (check-within (candidate (list 10 20 -4 5 -70)) 19 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth number in the newman conway sequence.\n(define (sequence n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequence))\n    (check-within (candidate 10) 6 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 3) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n(define (heap_queue_largest nums n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_queue_largest))\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 3) (list 85 75 65) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 2) (list 85 75) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 5) (list 85 75 65 58 35) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n(define (loss_amount actual_cost sale_amount)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate loss_amount))\n    (check-within (candidate 1500 1200) 0 0.001)\n    (check-within (candidate 100 200) 100 0.001)\n    (check-within (candidate 2000 5000) 3000 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the union of the elements of two given lists and output them in sorted order.\n(define (union_elements test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate union_elements))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 4 5 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 3 4 5 6)) (list 1 2 3 4 5 6) 0.001)\n    (check-within (candidate (list 11 12 13 14) (list 13 15 16 17)) (list 11 12 13 14 15 16 17) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the length of the longest sublists.\n(define (Find_Max_Length lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max_Length))\n    (check-within (candidate (list (list 1) (list 1 4) (list 5 6 7 8))) 4 0.001)\n    (check-within (candidate (list (list 0 1) (list 2 2) (list 3 2 1))) 3 0.001)\n    (check-within (candidate (list (list 7) (list 22 23) (list 13 14 15) (list 10 20 30 40 50))) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove the parenthesis and what is inbetween them from a string.\n(define (remove_parenthesis items)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_parenthesis))\n    (check-within (candidate (list \"python (chrome)\")) \"python\" 0.001)\n    (check-within (candidate (list \"string(.abc)\")) \"string\" 0.001)\n    (check-within (candidate (list \"alpha(num)\")) \"alpha\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find whether the parity of a given number is odd.\n(define (find_Parity x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Parity))\n    (check-within (candidate 12) #f 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median length of a trapezium.\n(define (median_trapezium base1 base2 height)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_trapezium))\n    (check-within (candidate 15 25 35) 20 0.001)\n    (check-within (candidate 10 20 30) 15 0.001)\n    (check-within (candidate 6 9 4) 7.5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find nth centered hexagonal number.\n(define (centered_hexagonal_number n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate centered_hexagonal_number))\n    (check-within (candidate 10) 271 0.001)\n    (check-within (candidate 2) 7 0.001)\n    (check-within (candidate 9) 217 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find number of lists present in the given list.\n(define (find_lists Input)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lists))\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8))) 2 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6))) 3 0.001)\n    (check-within (candidate (list 9 8 7 6 5 4 3 2 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n(define (get_max_sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_sum))\n    (check-within (candidate 60) 106 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the length of the longest word.\n(define (len_log list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate len_log))\n    (check-within (candidate (list \"python\" \"PHP\" \"bigdata\")) 7 0.001)\n    (check-within (candidate (list \"a\" \"ab\" \"abc\")) 3 0.001)\n    (check-within (candidate (list \"small\" \"big\" \"tall\")) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n(define (sector_area r a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sector_area))\n    (check-within (candidate 4 45) 6.283185307179586 0.001)\n    (check-within (candidate 9 45) 31.808625617596654 0.001)\n    (check-within (candidate 9 361) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether every odd index contains odd numbers of a given list.\n(define (odd_position nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_position))\n    (check-within (candidate (list 2 1 4 3 6 7 6 3)) #t 0.001)\n    (check-within (candidate (list 4 1 2)) #t 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to join a list of multiple integers into a single integer.\n(define (multiple_to_single L)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiple_to_single))\n    (check-within (candidate (list 11 33 50)) 113350 0.001)\n    (check-within (candidate (list -1 2 3 4 5 6)) -123456 0.001)\n    (check-within (candidate (list 10 15 20 25)) 10152025 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find whether a number is divisible by 11.\n(define (is_Diff n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Diff))\n    (check-within (candidate 12345) #f 0.001)\n    (check-within (candidate 1212112) #t 0.001)\n    (check-within (candidate 1212) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform index wise multiplication of list elements in the given two lists.\n(define (index_multiplication test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_multiplication))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 21) (list 12 45) (list 2 9) (list 7 30)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 14 32) (list 20 60) (list 6 20) (list 16 44)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 24 45) (list 30 77) (list 12 33) (list 27 60)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert tuple string to integer tuple.\n(define (tuple_str_int test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_str_int))\n    (check-within (candidate \"(7, 8, 9)\") (list 7 8 9) 0.001)\n    (check-within (candidate \"(1, 2, 3)\") (list 1 2 3) 0.001)\n    (check-within (candidate \"(4, 5, 6)\") (list 4 5 6) 0.001)\n    (check-within (candidate \"(7, 81, 19)\") (list 7 81 19) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sum all amicable numbers from 1 to a specified number.\n(define (amicable_numbers_sum limit)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate amicable_numbers_sum))\n    (check-within (candidate 999) 504 0.001)\n    (check-within (candidate 9999) 31626 0.001)\n    (check-within (candidate 99) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove odd characters in a string.\n(define (remove_odd str1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate \"python\") \"yhn\" 0.001)\n    (check-within (candidate \"program\") \"rga\" 0.001)\n    (check-within (candidate \"language\") \"agae\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n(define (multiply_elements test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_elements))\n    (check-within (candidate (list 1 5 7 8 10)) (list 5 35 56 80) 0.001)\n    (check-within (candidate (list 2 4 5 6 7)) (list 8 20 30 42) 0.001)\n    (check-within (candidate (list 12 13 14 9 15)) (list 156 182 126 135) 0.001)\n    (check-within (candidate (list 12)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n(define (count_rotation arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_rotation))\n    (check-within (candidate (list 3 2 1)) 1 0.001)\n    (check-within (candidate (list 4 5 1 2 3)) 2 0.001)\n    (check-within (candidate (list 7 8 9 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 2 3)) 0 0.001)\n    (check-within (candidate (list 1 3 2)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the number of unique tuples in the given list.\n(define (extract_freq test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_freq))\n    (check-within (candidate (list (list 3 4) (list 1 2) (list 4 3) (list 5 6))) 3 0.001)\n    (check-within (candidate (list (list 4 15) (list 2 3) (list 5 4) (list 6 7))) 4 0.001)\n    (check-within (candidate (list (list 5 16) (list 2 3) (list 6 5) (list 6 9))) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n(define (count_same_pair nums1 nums2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_same_pair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9)) 4 0.001)\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 11 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 1 0.001)\n    (check-within (candidate (list 0 1 1 2) (list 0 1 2 2)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the value of 'a' to the power 'b'.\n(define (power a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power))\n    (check-within (candidate 3 4) 81 0.001)\n    (check-within (candidate 2 3) 8 0.001)\n    (check-within (candidate 5 5) 3125 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write function to find the sum of all items in the given dictionary.\n(define (return_sum dict)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate return_sum))\n    (check-within (candidate #hash((\"a\" .  100) (\"b\" .  200) (\"c\" .  300))) 600 0.001)\n    (check-within (candidate #hash((\"a\" .  25) (\"b\" .  18) (\"c\" .  45))) 88 0.001)\n    (check-within (candidate #hash((\"a\" .  36) (\"b\" .  39) (\"c\" .  49))) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return a list of all pairs of consecutive items in a given list.\n(define (pair_wise l1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_wise))\n    (check-within (candidate (list 1 1 2 3 3 4 4 5)) (list (list 1 1) (list 1 2) (list 2 3) (list 3 3) (list 3 4) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) (list (list 1 5) (list 5 7) (list 7 9) (list 9 10)) 0.001)\n    (check-within (candidate (list 5 1 9 7 10)) (list (list 5 1) (list 1 9) (list 9 7) (list 7 10)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list (list 1 2) (list 2 3) (list 3 4) (list 4 5) (list 5 6) (list 6 7) (list 7 8) (list 8 9) (list 9 10)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to split a string into characters.\n(define (split word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split))\n    (check-within (candidate \"python\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 0.001)\n    (check-within (candidate \"Name\") (list \"N\" \"a\" \"m\" \"e\") 0.001)\n    (check-within (candidate \"program\") (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find minimum of three numbers.\n(define (min_of_three a b c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_of_three))\n    (check-within (candidate 10 20 0) 0 0.001)\n    (check-within (candidate 19 15 18) 15 0.001)\n    (check-within (candidate -10 -20 -30) -30 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n(define (is_Sum_Of_Powers_Of_Two n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sum_Of_Powers_Of_Two))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 7) #f 0.001)\n    (check-within (candidate 14) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n(define (get_Char strr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Char))\n    (check-within (candidate \"abc\") \"f\" 0.001)\n    (check-within (candidate \"gfg\") \"t\" 0.001)\n    (check-within (candidate \"ab\") \"c\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return the sum of all divisors of a number.\n(define (sum_div number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_div))\n    (check-within (candidate 8) 7 0.001)\n    (check-within (candidate 12) 16 0.001)\n    (check-within (candidate 7) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function that returns the number of integer elements in a given list.\n(define (count_integer list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_integer))\n    (check-within (candidate (list 1 2 \"abc\" 1.2)) 2 0.001)\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1.2 4 5.1)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to remove duplicate numbers from a given number of lists.\n(define (two_unique_nums nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate two_unique_nums))\n    (check-within (candidate (list 1 2 3 2 3 4 5)) (list 1 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 5)) (list 1 3 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find whether a given array of integers contains any duplicate element.\n(define (test_duplicate arraynums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_duplicate))\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) #t 0.001)\n    (check-within (candidate (list 1 1 2 2 3 3 4 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which returns nth catalan number.\n(define (catalan_number num)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate catalan_number))\n    (check-within (candidate 10) 16796 0.001)\n    (check-within (candidate 9) 4862 0.001)\n    (check-within (candidate 7) 429 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n(define (power_base_sum base power)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power_base_sum))\n    (check-within (candidate 2 100) 115 0.001)\n    (check-within (candidate 8 10) 37 0.001)\n    (check-within (candidate 8 15) 62 0.001)\n    (check-within (candidate 3 3) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n(define (replace_list list1 list2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_list))\n    (check-within (candidate (list 1 3 5 7 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 2 4 6 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8)) (list 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list \"red\" \"blue\" \"green\") (list \"yellow\")) (list \"red\" \"blue\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth octagonal number.\n(define (is_octagonal n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_octagonal))\n    (check-within (candidate 5) 65 0.001)\n    (check-within (candidate 10) 280 0.001)\n    (check-within (candidate 15) 645 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n(define (replace_blank str1 char)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_blank))\n    (check-within (candidate \"hello people\" \"@\") \"hello@people\" 0.001)\n    (check-within (candidate \"python program language\" \"$\") \"python$program$language\" 0.001)\n    (check-within (candidate \"blank space\" \"-\") \"blank-space\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n(define (replace_specialchar text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_specialchar))\n    (check-within (candidate \"Python language, Programming language.\") \"Python:language::Programming:language:\" 0.001)\n    (check-within (candidate \"a b c,d e f\") \"a:b:c:d:e:f\" 0.001)\n    (check-within (candidate \"ram reshma,ram rahim\") \"ram:reshma:ram:rahim\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a given tuple of positive integers into a single integer.\n(define (tuple_to_int nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_int))\n    (check-within (candidate (list 1 2 3)) 123 0.001)\n    (check-within (candidate (list 4 5 6)) 456 0.001)\n    (check-within (candidate (list 5 6 7)) 567 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the third side of a right angled triangle.\n(define (otherside_rightangle w h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate otherside_rightangle))\n    (check-within (candidate 7 8) 10.63014581273465 0.001)\n    (check-within (candidate 3 4) 5 0.001)\n    (check-within (candidate 7 15) 16.55294535724685 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n most expensive items in a given dataset.\n(define (expensive_items items n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate expensive_items))\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09))) 2) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09)) #hash((\"name\" .  \"Item-4\") (\"price\" .  22.75))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the per-digit difference between two integers.\n(define (digit_distance_nums n1 n2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digit_distance_nums))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate 23 56) 6 0.001)\n    (check-within (candidate 123 256) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that checks if a strings contains 'z', except at the start and end of the word.\n(define (text_match_wordz_middle text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz_middle))\n    (check-within (candidate \"pythonzabc.\") #t 0.001)\n    (check-within (candidate \"zxyabc.\") #f 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove leading zeroes from an ip address.\n(define (removezero_ip ip)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate removezero_ip))\n    (check-within (candidate \"216.08.094.196\") \"216.8.94.196\" 0.001)\n    (check-within (candidate \"12.01.024\") \"12.1.24\" 0.001)\n    (check-within (candidate \"216.08.094.0196\") \"216.8.94.196\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of sublists containing a particular element.\n(define (count_element_in_list list1 x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_element_in_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 1 11) (list 1 15 7)) 1) 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"A\") 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"E\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to multiply two integers.\n(define (multiply_int x y)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_int))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 5 10) 50 0.001)\n    (check-within (candidate 4 8) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n(define (add_pairwise test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_pairwise))\n    (check-within (candidate (list 1 5 7 8 10)) (list 6 12 15 18) 0.001)\n    (check-within (candidate (list 2 6 8 9 11)) (list 8 14 17 20) 0.001)\n    (check-within (candidate (list 3 7 9 10 12)) (list 10 16 19 22) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n(define (max_product_tuple list1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 36 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 200 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 484 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4429,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find the kth element in the given array using 1-based indexing.\n(define (kth_element arr k)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate kth_element))\n    (check-within (candidate (list 12 3 5 7 19) 2) 3 0.001)\n    (check-within (candidate (list 17 24 8 23) 3) 8 0.001)\n    (check-within (candidate (list 16 21 25 36 4) 4) 36 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to interchange the first and last element in a given list.\n(define (swap_List newList)\n",
+    "prompt": "#lang racket\n\n;; Write a function to convert a snake case string to camel case string.\n(define (snake_to_camel word)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) (list 4 2 3 4 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"python_program\") \"PythonProgram\" 0.001)\n    (check-within (candidate \"python_language\") \"PythonLanguage\" 0.001)\n    (check-within (candidate \"programming_language\") \"ProgrammingLanguage\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the number of elements that occurs before the list element in the given tuple.\n(define (count_first_elements test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the Eulerian number a(n, m).\n(define (eulerian_num n m)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_first_elements))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) 3 0.001)\n    (check-within (candidate (list 2 9 (list 5 7) 11)) 2 0.001)\n    (check-within (candidate (list 11 15 5 8 (list 2 3) 8)) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eulerian_num))\n    (check-within (candidate 3 1) 4 0.001)\n    (check-within (candidate 4 1) 11 0.001)\n    (check-within (candidate 5 3) 26 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to locate the right insertion point for a specified value in sorted order.\n(define (right_insertion a x)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists input_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \" red \" \"green\") (list \"blue \" \" black\") (list \" orange\" \"brown\"))) (list (list \" red \" \"green\") (list \" black\" \"blue \") (list \" orange\" \"brown\")) 0.001)\n    (check-within (candidate (list (list \"zilver\" \"gold\") (list \"magnesium\" \"aluminium\") (list \"steel\" \"bronze\"))) (list (list \"gold\" \"zilver\") (list \"aluminium\" \"magnesium\") (list \"bronze\" \"steel\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given number is woodball or not.\n(define (is_woodall x)\n",
+    "prompt": "#lang racket\n\n;; Write a python function to count true booleans in the given list.\n(define (count lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_woodall))\n    (check-within (candidate 383) #t 0.001)\n    (check-within (candidate 254) #f 0.001)\n    (check-within (candidate 200) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count))\n    (check-within (candidate (list #t #f #t)) 2 0.001)\n    (check-within (candidate (list #f #f)) 0 0.001)\n    (check-within (candidate (list #t #t #t)) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort the given array by using shell sort.\n(define (shell_sort my_list)\n",
+    "prompt": "#lang racket\n\n;; Write a function to append the given list to the given tuples.\n(define (add_lists test_list test_tup)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate shell_sort))\n    (check-within (candidate (list 12 23 4 5 3 2 12 81 56 95)) (list 2 3 4 5 12 12 23 56 81 95) 0.001)\n    (check-within (candidate (list 24 22 39 34 87 73 68)) (list 22 24 34 39 68 73 87) 0.001)\n    (check-within (candidate (list 32 30 16 96 82 83 74)) (list 16 30 32 74 82 83 96) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_lists))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 9 10 5 6 7) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 10 11 6 7 8) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of pairs whose xor value is odd.\n(define (find_Odd_Pair A N)\n",
+    "prompt": "#lang racket\n\n;; Write a function to merge three lists into a single sorted list.\n(define (merge_sorted_list num1 num2 num3)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Odd_Pair))\n    (check-within (candidate (list 5 4 7 2 1) 5) 6 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11) 7) 12 0.001)\n    (check-within (candidate (list 1 2 3) 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_sorted_list))\n    (check-within (candidate (list 25 24 15 4 5 29 110) (list 19 20 11 56 25 233 154) (list 24 26 54 48)) (list 4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233) 0.001)\n    (check-within (candidate (list 1 3 5 6 8 9) (list 2 5 7 11) (list 1 4 7 8 12)) (list 1 1 2 3 4 5 5 6 7 7 8 8 9 11 12) 0.001)\n    (check-within (candidate (list 18 14 10 9 8 7 9 3 2 4 1) (list 25 35 22 85 14 65 75 25 58) (list 12 74 9 50 61 41)) (list 1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of all odd natural numbers within the range l and r.\n(define (sum_in_range l r)\n",
+    "prompt": "#lang racket\n\n;; Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n(define (odd_Equivalent s n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_in_range))\n    (check-within (candidate 2 5) 8 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 13) 40 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_Equivalent))\n    (check-within (candidate \"011001\" 6) 3 0.001)\n    (check-within (candidate \"11011\" 5) 4 0.001)\n    (check-within (candidate \"1010\" 4) 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns the perimeter of a square given its side length as input.\n(define (square_perimeter a)\n",
+    "prompt": "#lang racket\n\n;; Write a function to check if a string represents an integer or not.\n(define (check_integer text)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_perimeter))\n    (check-within (candidate 10) 40 0.001)\n    (check-within (candidate 5) 20 0.001)\n    (check-within (candidate 4) 16 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_integer))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"1\") #t 0.001)\n    (check-within (candidate \"12345\") #t 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n(define (is_polite n)\n",
+    "prompt": "#lang racket\n\n;; Write a function to convert a given tuple of positive integers into a single integer.\n(define (tuple_to_int nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_polite))\n    (check-within (candidate 7) 11 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 9) 13 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n(define (sum_series n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_series))\n    (check-within (candidate 6) 12 0.001)\n    (check-within (candidate 10) 30 0.001)\n    (check-within (candidate 9) 25 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the dissimilar elements in the given two tuples.\n(define (find_dissimilar test_tup1 test_tup2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_dissimilar))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 7 2 3 9)) (list 1 4 7 9) 0.001)\n    (check-within (candidate (list 21 11 25 26) (list 26 34 21 36)) (list 34 36 11 25) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return two words from a list of words starting with letter 'p'.\n(define (start_withp words)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate start_withp))\n    (check-within (candidate (list \"Python PHP\" \"Java JavaScript\" \"c c++\")) (list \"Python\" \"PHP\") 0.001)\n    (check-within (candidate (list \"Python Programming\" \"Java Programming\")) (list \"Python\" \"Programming\") 0.001)\n    (check-within (candidate (list \"Pqrst Pqr\" \"qrstuv\")) (list \"Pqrst\" \"Pqr\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given snake case string to camel case string.\n(define (snake_to_camel word)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"android_tv\") \"AndroidTv\" 0.001)\n    (check-within (candidate \"google_pixel\") \"GooglePixel\" 0.001)\n    (check-within (candidate \"apple_watch\") \"AppleWatch\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the volume of a cube given its side length.\n(define (volume_cube l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate volume_cube))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 2) 8 0.001)\n    (check-within (candidate 5) 125 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 31 days or not.\n(define (check_monthnumb_number monthnum2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumb_number))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether all the bits are unset in the given range or not.\n(define (all_Bits_Set_In_The_Given_Range n l r)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Bits_Set_In_The_Given_Range))\n    (check-within (candidate 4 1 2) #t 0.001)\n    (check-within (candidate 17 2 4) #t 0.001)\n    (check-within (candidate 39 4 6) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to get the first element of each sublist.\n(define (Extract lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Extract))\n    (check-within (candidate (list (list 1 2) (list 3 4 5) (list 6 7 8 9))) (list 1 3 6) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5))) (list 1 4) 0.001)\n    (check-within (candidate (list (list 9 8 1) (list 1 2))) (list 9 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cylinder.\n(define (surfacearea_cylinder r h)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cylinder))\n    (check-within (candidate 10 5) 942.45 0.001)\n    (check-within (candidate 4 5) 226.18800000000002 0.001)\n    (check-within (candidate 4 10) 351.848 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n(define (sample_nam sample_names)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sample_nam))\n    (check-within (candidate (list \"sally\" \"Dylan\" \"rebecca\" \"Diana\" \"Joanne\" \"keith\")) 16 0.001)\n    (check-within (candidate (list \"php\" \"res\" \"Python\" \"abcd\" \"Java\" \"aaa\")) 10 0.001)\n    (check-within (candidate (list \"abcd\" \"Python\" \"abba\" \"aba\")) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create the next bigger number by rearranging the digits of a given number.\n(define (rearrange_bigger n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rearrange_bigger))\n    (check-within (candidate 12) 21 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 102) 120 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the perimeter of a regular pentagon from the length of its sides.\n(define (perimeter_pentagon a)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perimeter_pentagon))\n    (check-within (candidate 5) 25 0.001)\n    (check-within (candidate 10) 50 0.001)\n    (check-within (candidate 15) 75 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n(define (max_sum arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum))\n    (check-within (candidate (list 1 15 51 45 33 100 12 18 9)) 194 0.001)\n    (check-within (candidate (list 80 60 30 40 20 10)) 210 0.001)\n    (check-within (candidate (list 2 3 14 16 21 23 29 30)) 138 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove uneven elements in the nested mixed tuple.\n(define (extract_even test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_even))\n    (check-within (candidate (list 4 5 (list 7 6 (list 2 4)) 6 8)) (list 4 (list 6 (list 2 4)) 6 8) 0.001)\n    (check-within (candidate (list 5 6 (list 8 7 (list 4 8)) 7 9)) (list 6 (list 8 (list 4 8))) 0.001)\n    (check-within (candidate (list 5 6 (list 9 8 (list 4 6)) 8 10)) (list 6 (list 8 (list 4 6)) 8 10) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_int))\n    (check-within (candidate (list 1 2 3)) 123 0.001)\n    (check-within (candidate (list 4 5 6)) 456 0.001)\n    (check-within (candidate (list 5 6 7)) 567 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4789,249 +169,9 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to convert all possible convertible elements in a list of lists to floats.\n(define (list_to_float test_list)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_to_float))\n    (check-within (candidate (list (list \"3\" \"4\") (list \"1\" \"26.45\") (list \"7.32\" \"8\") (list \"4\" \"8\"))) (list (list 3.0 4.0) (list 1.0 26.45) (list 7.32 8.0) (list 4.0 8.0)) 0.001)\n    (check-within (candidate (list (list \"4\" \"4\") (list \"2\" \"27\") (list \"4.12\" \"9\") (list \"7\" \"11\"))) (list (list 4.0 4.0) (list 2.0 27.0) (list 4.12 9.0) (list 7.0 11.0)) 0.001)\n    (check-within (candidate (list (list \"6\" \"78\") (list \"5\" \"26.45\") (list \"1.33\" \"4\") (list \"82\" \"13\"))) (list (list 6.0 78.0) (list 5.0 26.45) (list 1.33 4.0) (list 82.0 13.0)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n(define (square_Sum n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 20 0.001)\n    (check-within (candidate 3) 56 0.001)\n    (check-within (candidate 4) 120 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n(define (get_pairs_count arr sum)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_pairs_count))\n    (check-within (candidate (list 1 1 1 1) 2) 6 0.001)\n    (check-within (candidate (list 1 5 7 -1 5) 6) 3 0.001)\n    (check-within (candidate (list 1 -2 3) 1) 1 0.001)\n    (check-within (candidate (list -1 -2 3) -3) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n(define (count_no_of_ways n k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_no_of_ways))\n    (check-within (candidate 2 4) 16 0.001)\n    (check-within (candidate 3 2) 6 0.001)\n    (check-within (candidate 4 4) 228 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to reverse words seperated by spaces in a given string.\n(define (reverse_words s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_words))\n    (check-within (candidate \"python program\") \"program python\" 0.001)\n    (check-within (candidate \"java language\") \"language java\" 0.001)\n    (check-within (candidate \"indian man\") \"man indian\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check if a given number is one less than twice its reverse.\n(define (checks n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate checks))\n    (check-within (candidate 70) #f 0.001)\n    (check-within (candidate 23) #f 0.001)\n    (check-within (candidate 73) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the last position of an element in a sorted array.\n(define (last arr x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last))\n    (check-within (candidate (list 1 2 3) 1) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 4) 1) 2 0.001)\n    (check-within (candidate (list 2 3 2 3 6 8 9) 3) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n(define (count_X tup x)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_X))\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 4) 0 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 10) 3 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 8) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n(define (extract_index_list l1 l2 l3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_index_list))\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 7) 0.001)\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 6 5) (list 0 1 2 3 4 6 7)) (list 1 6) 0.001)\n    (check-within (candidate (list 1 1 3 4 6 5 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 6 6 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the second smallest number in a list.\n(define (second_smallest numbers)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate second_smallest))\n    (check-within (candidate (list 1 2 -8 -2 0 -2)) -2 0.001)\n    (check-within (candidate (list 1 1 -0.5 0 2 -2 -2)) -0.5 0.001)\n    (check-within (candidate (list 2 2)) #f 0.001)\n    (check-within (candidate (list 2 2 2)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to concatenate each element of tuple by the delimiter.\n(define (concatenate_tuple test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate_tuple))\n    (check-within (candidate (list \"ID\" \"is\" 4 \"UTS\")) \"ID-is-4-UTS\" 0.001)\n    (check-within (candidate (list \"QWE\" \"is\" 4 \"RTY\")) \"QWE-is-4-RTY\" 0.001)\n    (check-within (candidate (list \"ZEN\" \"is\" 4 \"OP\")) \"ZEN-is-4-OP\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace all spaces in the given string with '%20'.\n(define (replace_spaces string)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"My Name is Dawood\") \"My%20Name%20is%20Dawood\" 0.001)\n    (check-within (candidate \"I am a Programmer\") \"I%20am%20a%20Programmer\" 0.001)\n    (check-within (candidate \"I love Coding\") \"I%20love%20Coding\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the sum of numbers in a list within a range specified by two indices.\n(define (sum_range_list list1 m n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_range_list))\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 8 10) 29 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 5 7) 16 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 7 10) 38 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to merge three dictionaries into a single dictionary.\n(define (merge_dictionaries_three dict1 dict2 dict3)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_dictionaries_three))\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"O\" .  \"Orange\") (\"W\" .  \"White\") (\"B\" .  \"Black\"))) #hash((\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"P\" .  \"Pink\") (\"G\" .  \"Green\") (\"W\" .  \"White\") (\"O\" .  \"Orange\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\"))) #hash((\"W\" .  \"White\") (\"P\" .  \"Pink\") (\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\"))) #hash((\"B\" .  \"Black\") (\"P\" .  \"Pink\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\") (\"W\" .  \"White\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the minimum of two numbers.\n(define (minimum a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minimum))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate -5 -4) -5 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between available pairs in the given tuple list.\n(define (max_difference test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_difference))\n    (check-within (candidate (list (list 3 5) (list 1 7) (list 10 3) (list 1 2))) 7 0.001)\n    (check-within (candidate (list (list 4 6) (list 2 17) (list 9 13) (list 11 12))) 15 0.001)\n    (check-within (candidate (list (list 12 35) (list 21 27) (list 13 23) (list 41 22))) 23 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find element at a given index after number of rotations.\n(define (find_Element arr ranges rotations index)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Element))\n    (check-within (candidate (list 1 2 3 4 5) (list (list 0 2) (list 0 3)) 2 1) 3 0.001)\n    (check-within (candidate (list 1 2 3 4) (list (list 0 1) (list 0 2)) 1 2) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list (list 0 1) (list 0 2)) 1 1) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5044,7 +184,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to convert a string to a list of strings split on the space character.\n(define (string_to_list string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_list))\n    (check-within (candidate \"python programming\") (list \"python\" \"programming\") 0.001)\n    (check-within (candidate \"lists tuples strings\") (list \"lists\" \"tuples\" \"strings\") 0.001)\n    (check-within (candidate \"write a program\") (list \"write\" \"a\" \"program\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a python function to find the element that appears only once in a sorted array.\n(define (search arr)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 1 1 2 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1 3 3 4 4 5 5 7 7 8)) 8 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4 4)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a dictionary by value.\n(define (sort_counter dict1)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_counter))\n    (check-within (candidate #hash((\"Math\" .  81) (\"Physics\" .  83) (\"Chemistry\" .  87))) (list (list \"Chemistry\" 87) (list \"Physics\" 83) (list \"Math\" 81)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  400) (\"Physics\" .  300) (\"Chemistry\" .  250))) (list (list \"Math\" 400) (list \"Physics\" 300) (list \"Chemistry\" 250)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  900) (\"Physics\" .  1000) (\"Chemistry\" .  1250))) (list (list \"Chemistry\" 1250) (list \"Physics\" 1000) (list \"Math\" 900)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5089,7 +214,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a python function to remove first and last occurrence of a given character from the string.\n(define (remove_Occ s ch)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_Occ))\n    (check-within (candidate \"hello\" \"l\") \"heo\" 0.001)\n    (check-within (candidate \"abcda\" \"a\") \"bcd\" 0.001)\n    (check-within (candidate \"PHP\" \"P\") \"H\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cube given its side length.\n(define (lateralsurface_cube l)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n(define (max_product_tuple list1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cube))\n    (check-within (candidate 5) 100 0.001)\n    (check-within (candidate 9) 324 0.001)\n    (check-within (candidate 10) 400 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 36 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 200 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 484 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes two lists and returns true if they have at least one common element.\n(define (common_element list1 list2)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sum all amicable numbers from 1 to a specified number.\n(define (amicable_numbers_sum limit)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common_element))\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8 9)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\") (list \"d\" \"b\" \"e\")) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate amicable_numbers_sum))\n    (check-within (candidate 999) 504 0.001)\n    (check-within (candidate 9999) 31626 0.001)\n    (check-within (candidate 99) 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to append the given list to the given tuples.\n(define (add_lists test_list test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n(define (find_length string)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_lists))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 9 10 5 6 7) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 10 11 6 7 8) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_length))\n    (check-within (candidate \"11000010001\") 6 0.001)\n    (check-within (candidate \"10111\") 1 0.001)\n    (check-within (candidate \"11011101100101\") 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to compute the n-th power of each number in a list.\n(define (nth_nums nums n)\n",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of common divisors of two given numbers.\n(define (sum a b)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate nth_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30) 3) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15) 5) (list 248832 759375) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum))\n    (check-within (candidate 10 15) 6 0.001)\n    (check-within (candidate 100 150) 93 0.001)\n    (check-within (candidate 4 6) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (pancake_sort nums)\n",
+    "prompt": "#lang racket\n\n;; Write a function to multiply two integers.\n(define (multiply_int x y)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pancake_sort))\n    (check-within (candidate (list 15 79 25 38 69)) (list 15 25 38 69 79) 0.001)\n    (check-within (candidate (list 98 12 54 36 85)) (list 12 36 54 85 98) 0.001)\n    (check-within (candidate (list 41 42 32 12 23)) (list 12 23 32 41 42) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median of three numbers.\n(define (median_numbers a b c)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_numbers))\n    (check-within (candidate 25 55 65) 55.0 0.001)\n    (check-within (candidate 20 10 30) 20.0 0.001)\n    (check-within (candidate 15 45 75) 45.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the entered number is greater than the elements of the given array.\n(define (check_greater arr number)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_greater))\n    (check-within (candidate (list 1 2 3 4 5) 4) #f 0.001)\n    (check-within (candidate (list 2 3 4 5 6) 8) #t 0.001)\n    (check-within (candidate (list 9 7 4 8 6 1) 11) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n(define (check_element list element)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_element))\n    (check-within (candidate (list \"green\" \"orange\" \"black\" \"white\") \"blue\") #f 0.001)\n    (check-within (candidate (list 1 2 3 4) 7) #f 0.001)\n    (check-within (candidate (list \"green\" \"green\" \"green\" \"green\") \"green\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract specified size of strings from a given list of string values.\n(define (extract_string str l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_string))\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 8) (list \"practice\" \"solution\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 6) (list \"Python\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 9) (list \"exercises\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n(define (text_lowercase_underscore text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_lowercase_underscore))\n    (check-within (candidate \"aab_cbbbc\") #t 0.001)\n    (check-within (candidate \"aab_Abbbc\") #f 0.001)\n    (check-within (candidate \"Aaab_abbbc\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to trim each list by k in the given lists.\n(define (trim_tuple test_list K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate trim_tuple))\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 2) (list (list 2) (list 9) (list 2) (list 2)) 0.001)\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 1) (list (list 3 2 1) (list 4 9 2) (list 1 2 3) (list 8 2 1)) 0.001)\n    (check-within (candidate (list (list 7 8 4 9) (list 11 8 12 4) (list 4 1 7 8) (list 3 6 9 7)) 1) (list (list 8 4) (list 8 12) (list 1 7) (list 6 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sublist having minimum length.\n(define (Find_Min lst)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min))\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 1 1) (list 1 2 7 8))) (list 1 1) 0.001)\n    (check-within (candidate (list (list \"x\") (list \"x\" \"y\") (list \"x\" \"y\" \"z\"))) (list \"x\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to filter odd numbers.\n(define (filter_oddnumbers nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_oddnumbers))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 3 5 7 9) 0.001)\n    (check-within (candidate (list 10 20 45 67 84 93)) (list 45 67 93) 0.001)\n    (check-within (candidate (list 5 7 9 8 6 4 3)) (list 5 7 9 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the first adverb ending with ly and its positions in a given string.\n(define (find_adverbs text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverbs))\n    (check-within (candidate \"Clearly, he has no excuse for such behavior.\") \"0-7: Clearly\" 0.001)\n    (check-within (candidate \"Please handle the situation carefuly\") \"28-36: carefuly\" 0.001)\n    (check-within (candidate \"Complete the task quickly\") \"18-25: quickly\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n(define (max_of_nth test_list N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_of_nth))\n    (check-within (candidate (list (list 5 6 7) (list 1 3 5) (list 8 9 19)) 2) 19 0.001)\n    (check-within (candidate (list (list 6 7 8) (list 2 4 6) (list 9 10 20)) 1) 10 0.001)\n    (check-within (candidate (list (list 7 8 9) (list 3 5 7) (list 10 11 21)) 1) 11 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n(define (decimal_to_binary n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 8) \"1000\" 0.001)\n    (check-within (candidate 18) \"10010\" 0.001)\n    (check-within (candidate 7) \"111\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n(define (combinations_colors l n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_colors))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 1) (list (list \"Red\") (list \"Green\") (list \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 2) (list (list \"Red\" \"Red\") (list \"Red\" \"Green\") (list \"Red\" \"Blue\") (list \"Green\" \"Green\") (list \"Green\" \"Blue\") (list \"Blue\" \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 3) (list (list \"Red\" \"Red\" \"Red\") (list \"Red\" \"Red\" \"Green\") (list \"Red\" \"Red\" \"Blue\") (list \"Red\" \"Green\" \"Green\") (list \"Red\" \"Green\" \"Blue\") (list \"Red\" \"Blue\" \"Blue\") (list \"Green\" \"Green\" \"Green\") (list \"Green\" \"Green\" \"Blue\") (list \"Green\" \"Blue\" \"Blue\") (list \"Blue\" \"Blue\" \"Blue\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from a string.\n(define (remove_all_spaces text)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_all_spaces))\n    (check-within (candidate \"python  program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"python   programming    language\") \"pythonprogramminglanguage\" 0.001)\n    (check-within (candidate \"python                     program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"   python                     program\") \"pythonprogram\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n(define (min_Swaps str1 str2)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Swaps))\n    (check-within (candidate \"1101\" \"1110\") 1 0.001)\n    (check-within (candidate \"111\" \"000\") \"Not Possible\" 0.001)\n    (check-within (candidate \"111\" \"110\") \"Not Possible\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create a new tuple from the given string and list.\n(define (new_tuple test_list test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate new_tuple))\n    (check-within (candidate (list \"WEB\" \"is\") \"best\") (list \"WEB\" \"is\" \"best\") 0.001)\n    (check-within (candidate (list \"We\" \"are\") \"Developers\") (list \"We\" \"are\" \"Developers\") 0.001)\n    (check-within (candidate (list \"Part\" \"is\") \"Wrong\") (list \"Part\" \"is\" \"Wrong\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the product of the array multiplication modulo n.\n(define (find_remainder arr n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_remainder))\n    (check-within (candidate (list 100 10 5 25 35 14) 11) 9 0.001)\n    (check-within (candidate (list 1 1 1) 1) 0 0.001)\n    (check-within (candidate (list 1 2 1) 2) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the minimum value in a given heterogeneous list.\n(define (min_val listval)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 2 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 15 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 20 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the ration of positive numbers in an array of integers.\n(define (positive_count nums)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate positive_count))\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8)) 0.54 0.001)\n    (check-within (candidate (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 0.69 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) 0.56 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to add the given tuple to the given list.\n(define (add_tuple test_list test_tup)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_tuple))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 5 6 7 9 10) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 6 7 8 10 11) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 7 8 9 11 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find maximum run of uppercase characters in the given string.\n(define (max_run_uppercase test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_run_uppercase))\n    (check-within (candidate \"GeMKSForGERksISBESt\") 5 0.001)\n    (check-within (candidate \"PrECIOusMOVemENTSYT\") 6 0.001)\n    (check-within (candidate \"GooGLEFluTTER\") 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a given matrix in ascending order according to the sum of its rows.\n(define (sort_matrix M)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_matrix))\n    (check-within (candidate (list (list 1 2 3) (list 2 4 5) (list 1 1 1))) (list (list 1 1 1) (list 1 2 3) (list 2 4 5)) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list -2 4 -5) (list 1 -1 1))) (list (list -2 4 -5) (list 1 -1 1) (list 1 2 3)) 0.001)\n    (check-within (candidate (list (list 5 8 9) (list 6 4 3) (list 2 1 4))) (list (list 2 1 4) (list 6 4 3) (list 5 8 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count those characters which have vowels as their neighbors in the given string.\n(define (count_vowels test_str)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_vowels))\n    (check-within (candidate \"bestinstareels\") 7 0.001)\n    (check-within (candidate \"partofthejourneyistheend\") 12 0.001)\n    (check-within (candidate \"amazonprime\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n(define (max_sum_increasing_subseq a n index k)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_increasing_subseq))\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 4 6) 11 0.001)\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 2 5) 7 0.001)\n    (check-within (candidate (list 11 15 19 21 26 28 31) 7 2 4) 71 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_int))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 5 10) 50 0.001)\n    (check-within (candidate 4 8) 32 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5524,7 +304,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find words that are longer than n characters from a given list of words.\n(define (long_words n str)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate long_words))\n    (check-within (candidate 3 \"python is a programming language\") (list \"python\" \"programming\" \"language\") 0.001)\n    (check-within (candidate 2 \"writing a program\") (list \"writing\" \"program\") 0.001)\n    (check-within (candidate 5 \"sorting list\") (list \"sorting\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of non-repeated elements in a given list.\n(define (find_sum arr)\n",
+    "prompt": "#lang racket\n\n;; Write a function to calculate whether the matrix is a magic square.\n(define (magic_square_test my_matrix)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_sum))\n    (check-within (candidate (list 1 2 3 1 1 4 5 6)) 21 0.001)\n    (check-within (candidate (list 1 10 9 4 2 10 10 45 4)) 71 0.001)\n    (check-within (candidate (list 12 10 9 45 2 10 10 45 10)) 78 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate magic_square_test))\n    (check-within (candidate (list (list 7 12 1 14) (list 2 13 8 11) (list 16 3 10 5) (list 9 6 15 4))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 8))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 7))) #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n(define (tuple_to_dict test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sort a given matrix in ascending order according to the sum of its rows.\n(define (sort_matrix M)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_dict))\n    (check-within (candidate (list 1 5 7 10 13 5)) #hash((1 .  5) (7 .  10) (13 .  5)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #hash((1 .  2) (3 .  4) (5 .  6)) 0.001)\n    (check-within (candidate (list 7 8 9 10 11 12)) #hash((7 .  8) (9 .  10) (11 .  12)) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_matrix))\n    (check-within (candidate (list (list 1 2 3) (list 2 4 5) (list 1 1 1))) (list (list 1 1 1) (list 1 2 3) (list 2 4 5)) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list -2 4 -5) (list 1 -1 1))) (list (list -2 4 -5) (list 1 -1 1) (list 1 2 3)) 0.001)\n    (check-within (candidate (list (list 5 8 9) (list 6 4 3) (list 2 1 4))) (list (list 2 1 4) (list 6 4 3) (list 5 8 9)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n(define (get_coordinates test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the item with maximum frequency in a given list.\n(define (max_occurrences nums)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_coordinates))\n    (check-within (candidate (list 3 4)) (list (list 2 3) (list 2 4) (list 2 5) (list 3 3) (list 3 4) (list 3 5) (list 4 3) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 4 5)) (list (list 3 4) (list 3 5) (list 3 6) (list 4 4) (list 4 5) (list 4 6) (list 5 4) (list 5 5) (list 5 6)) 0.001)\n    (check-within (candidate (list 5 6)) (list (list 4 5) (list 4 6) (list 4 7) (list 5 5) (list 5 6) (list 5 7) (list 6 5) (list 6 6) (list 6 7)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if all the elements in tuple have same data type or not.\n(define (check_type test_tuple)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_type))\n    (check-within (candidate (list 5 6 7 3 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 \"4\")) #f 0.001)\n    (check-within (candidate (list 3 2 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the smallest missing number from a sorted list of natural numbers.\n(define (find_First_Missing array)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_First_Missing))\n    (check-within (candidate (list 0 1 2 3)) 4 0.001)\n    (check-within (candidate (list 0 1 2 6 9)) 3 0.001)\n    (check-within (candidate (list 2 3 5 8 9)) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is undulating or not.\n(define (is_undulating n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_undulating))\n    (check-within (candidate 1212121) #t 0.001)\n    (check-within (candidate 1991) #f 0.001)\n    (check-within (candidate 121) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n(define (min_k test_list K)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_k))\n    (check-within (candidate (list (list \"Manjeet\" 10) (list \"Akshat\" 4) (list \"Akash\" 2) (list \"Nikhil\" 8)) 2) (list (list \"Akash\" 2) (list \"Akshat\" 4)) 0.001)\n    (check-within (candidate (list (list \"Sanjeev\" 11) (list \"Angat\" 5) (list \"Akash\" 3) (list \"Nepin\" 9)) 3) (list (list \"Akash\" 3) (list \"Angat\" 5) (list \"Nepin\" 9)) 0.001)\n    (check-within (candidate (list (list \"tanmay\" 14) (list \"Amer\" 11) (list \"Ayesha\" 9) (list \"SKD\" 16)) 1) (list (list \"Ayesha\" 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to count the number of substrings with the sum of digits equal to their length.\n(define (count_Substrings s)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Substrings))\n    (check-within (candidate \"112112\") 6 0.001)\n    (check-within (candidate \"111\") 6 0.001)\n    (check-within (candidate \"1101112\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth decagonal number.\n(define (is_num_decagonal n)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_num_decagonal))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 7) 175 0.001)\n    (check-within (candidate 10) 370 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n(define (rear_extract test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rear_extract))\n    (check-within (candidate (list (list 1 \"Rash\" 21) (list 2 \"Varsha\" 20) (list 3 \"Kil\" 19))) (list 21 20 19) 0.001)\n    (check-within (candidate (list (list 1 \"Sai\" 36) (list 2 \"Ayesha\" 25) (list 3 \"Salman\" 45))) (list 36 25 45) 0.001)\n    (check-within (candidate (list (list 1 \"Sudeep\" 14) (list 2 \"Vandana\" 36) (list 3 \"Dawood\" 56))) (list 14 36 56) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the closest smaller number than n.\n(define (closest_num N)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_num))\n    (check-within (candidate 11) 10 0.001)\n    (check-within (candidate 7) 6 0.001)\n    (check-within (candidate 12) 11 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n(define (find_combinations test_list)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_combinations))\n    (check-within (candidate (list (list 2 4) (list 6 7) (list 5 1) (list 6 10))) (list (list 8 11) (list 7 5) (list 8 14) (list 11 8) (list 12 17) (list 11 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8) (list 6 2) (list 7 11))) (list (list 10 13) (list 9 7) (list 10 16) (list 13 10) (list 14 19) (list 13 13)) 0.001)\n    (check-within (candidate (list (list 4 6) (list 8 9) (list 7 3) (list 8 12))) (list (list 12 15) (list 11 9) (list 12 18) (list 15 12) (list 16 21) (list 15 15)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n(define (maxAverageOfPath cost)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maxAverageOfPath))\n    (check-within (candidate (list (list 1 2 3) (list 6 5 4) (list 7 3 9))) 5.2 0.001)\n    (check-within (candidate (list (list 2 3 4) (list 7 6 5) (list 8 4 10))) 6.2 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 8 7 6) (list 9 5 11))) 7.2 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9))) 5.8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n(define (sequential_search dlist item)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequential_search))\n    (check-within (candidate (list 11 23 58 31 56 77 43 12 65 19) 31) (list #t 3) 0.001)\n    (check-within (candidate (list 12 32 45 62 35 47 44 61) 61) (list #t 7) 0.001)\n    (check-within (candidate (list 9 10 17 19 22 39 48 56) 48) (list #t 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to remove odd numbers from a given list.\n(define (remove_odd l)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate (list 1 2 3)) (list 2) 0.001)\n    (check-within (candidate (list 2 4 6)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 10 20 3)) (list 10 20) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the product of numbers in a list is even or not.\n(define (is_product_even arr)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_product_even))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 4)) #t 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the maximum of two numbers.\n(define (maximum a b)\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate 5 10) 10 0.001)\n    (check-within (candidate -1 -2) -1 0.001)\n    (check-within (candidate 9 7) 9 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_occurrences))\n    (check-within (candidate (list 2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2)) 2 0.001)\n    (check-within (candidate (list 2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18)) 8 0.001)\n    (check-within (candidate (list 10 20 20 30 40 90 80 50 30 20 50 10)) 20 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5794,9 +364,759 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a python function to reverse only the vowels of a given string (where y is not a vowel).\n(define (reverse_vowels str1)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_vowels))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"USA\") \"ASU\" 0.001)\n    (check-within (candidate \"ab\") \"ab\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a list to a string.\n(define (tup_string tup1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tup_string))\n    (check-within (candidate (list \"e\" \"x\" \"e\" \"r\" \"c\" \"i\" \"s\" \"e\" \"s\")) \"exercises\" 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\")) \"python\" 0.001)\n    (check-within (candidate (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\")) \"program\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of the negative numbers of a given list of numbers.\n(define (sum_negativenum nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_negativenum))\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) -32 0.001)\n    (check-within (candidate (list 10 15 -14 13 -18 12 -20)) -52 0.001)\n    (check-within (candidate (list 19 -65 57 39 152 -639 121 44 90 -190)) -894 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth hexagonal number.\n(define (hexagonal_num n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hexagonal_num))\n    (check-within (candidate 10) 190 0.001)\n    (check-within (candidate 5) 45 0.001)\n    (check-within (candidate 7) 91 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n(define (is_Sum_Of_Powers_Of_Two n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sum_Of_Powers_Of_Two))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 7) #f 0.001)\n    (check-within (candidate 14) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (pancake_sort nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pancake_sort))\n    (check-within (candidate (list 15 79 25 38 69)) (list 15 25 38 69 79) 0.001)\n    (check-within (candidate (list 98 12 54 36 85)) (list 12 36 54 85 98) 0.001)\n    (check-within (candidate (list 41 42 32 12 23)) (list 12 23 32 41 42) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count number items that are identical in the same position of three given lists.\n(define (count_samepair list1 list2 list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_samepair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9) (list 2 1 3 1 2 6 7 9)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 2 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find number of lists present in the given list.\n(define (find_lists Input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lists))\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8))) 2 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6))) 3 0.001)\n    (check-within (candidate (list 9 8 7 6 5 4 3 2 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the maximum difference between any two elements in a given array.\n(define (max_Abs_Diff arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Abs_Diff))\n    (check-within (candidate (list 2 1 5 3)) 4 0.001)\n    (check-within (candidate (list 9 3 2 5 1)) 8 0.001)\n    (check-within (candidate (list 3 2 1)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the volume of a triangular prism.\n(define (find_Volume l b h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Volume))\n    (check-within (candidate 10 8 6) 240 0.001)\n    (check-within (candidate 3 2 2) 6 0.001)\n    (check-within (candidate 1 2 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n(define (find_solution a b n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_solution))\n    (check-within (candidate 2 3 7) (list 2 1) 0.001)\n    (check-within (candidate 4 2 7) #f 0.001)\n    (check-within (candidate 1 13 17) (list 4 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all elements from a given list present in another list.\n(define (remove_elements list1 list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_elements))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 1 3 5 7)) (list 2 4 6 8 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 5 7)) (list 1 2 3 4 6 8 9 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n(define (sum_series n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_series))\n    (check-within (candidate 6) 12 0.001)\n    (check-within (candidate 10) 30 0.001)\n    (check-within (candidate 9) 25 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to determine if the sum of the divisors of two integers are the same.\n(define (are_equivalent num1 num2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate are_equivalent))\n    (check-within (candidate 36 57) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 23 47) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n(define (count_char_position str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_char_position))\n    (check-within (candidate \"xbcefg\") 2 0.001)\n    (check-within (candidate \"ABcED\") 3 0.001)\n    (check-within (candidate \"AbgdeF\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that counts the number of pairs of integers in a list that xor to an even number.\n(define (find_even_pair A)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_even_pair))\n    (check-within (candidate (list 5 4 7 2 1)) 4 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11)) 9 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the smallest power of 2 greater than or equal to n.\n(define (next_power_of_2 n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_power_of_2))\n    (check-within (candidate 0) 1 0.001)\n    (check-within (candidate 5) 8 0.001)\n    (check-within (candidate 17) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of occurrences of a number in a given list.\n(define (frequency a x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency))\n    (check-within (candidate (list 1 2 3) 4) 0 0.001)\n    (check-within (candidate (list 1 2 2 3 3 3 4) 3) 3 0.001)\n    (check-within (candidate (list 0 1 2 3 1 2) 1) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n(define (text_lowercase_underscore text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_lowercase_underscore))\n    (check-within (candidate \"aab_cbbbc\") #t 0.001)\n    (check-within (candidate \"aab_Abbbc\") #f 0.001)\n    (check-within (candidate \"Aaab_abbbc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the sum of numbers in a list within a range specified by two indices.\n(define (sum_range_list list1 m n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_range_list))\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 8 10) 29 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 5 7) 16 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 7 10) 38 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the perimeter of a regular pentagon from the length of its sides.\n(define (perimeter_pentagon a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perimeter_pentagon))\n    (check-within (candidate 5) 25 0.001)\n    (check-within (candidate 10) 50 0.001)\n    (check-within (candidate 15) 75 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of occurence of the string 'std' in a given string.\n(define (count_occurance s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_occurance))\n    (check-within (candidate \"letstdlenstdporstd\") 3 0.001)\n    (check-within (candidate \"truststdsolensporsd\") 1 0.001)\n    (check-within (candidate \"makestdsostdworthit\") 2 0.001)\n    (check-within (candidate \"stds\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns the perimeter of a square given its side length as input.\n(define (square_perimeter a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_perimeter))\n    (check-within (candidate 10) 40 0.001)\n    (check-within (candidate 5) 20 0.001)\n    (check-within (candidate 4) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove characters from the first string which are present in the second string.\n(define (remove_dirty_chars string second_string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_dirty_chars))\n    (check-within (candidate \"probasscurve\" \"pros\") \"bacuve\" 0.001)\n    (check-within (candidate \"digitalindia\" \"talent\") \"digiidi\" 0.001)\n    (check-within (candidate \"exoticmiles\" \"toxic\") \"emles\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find whether a given array of integers contains any duplicate element.\n(define (test_duplicate arraynums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_duplicate))\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) #t 0.001)\n    (check-within (candidate (list 1 1 2 2 3 3 4 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given number is woodball or not.\n(define (is_woodall x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_woodall))\n    (check-within (candidate 383) #t 0.001)\n    (check-within (candidate 254) #f 0.001)\n    (check-within (candidate 200) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if all the elements in tuple have same data type or not.\n(define (check_type test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_type))\n    (check-within (candidate (list 5 6 7 3 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 \"4\")) #f 0.001)\n    (check-within (candidate (list 3 2 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n(define (is_majority arr n x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_majority))\n    (check-within (candidate (list 1 2 3 3 3 3 10) 7 3) #t 0.001)\n    (check-within (candidate (list 1 1 2 4 4 4 6 6) 8 4) #f 0.001)\n    (check-within (candidate (list 1 1 1 2 2) 5 1) #t 0.001)\n    (check-within (candidate (list 1 1 2 2) 5 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n(define (count_Set_Bits n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Set_Bits))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 1 0.001)\n    (check-within (candidate 6) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to remove the characters which have odd index values of a given string.\n(define (odd_values_string str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_values_string))\n    (check-within (candidate \"abcdef\") \"ace\" 0.001)\n    (check-within (candidate \"python\") \"pto\" 0.001)\n    (check-within (candidate \"data\") \"dt\" 0.001)\n    (check-within (candidate \"lambs\") \"lms\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find minimum of three numbers.\n(define (min_of_three a b c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_of_three))\n    (check-within (candidate 10 20 0) 0 0.001)\n    (check-within (candidate 19 15 18) 15 0.001)\n    (check-within (candidate -10 -20 -30) -30 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether all the bits are unset in the given range or not.\n(define (all_Bits_Set_In_The_Given_Range n l r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Bits_Set_In_The_Given_Range))\n    (check-within (candidate 4 1 2) #t 0.001)\n    (check-within (candidate 17 2 4) #t 0.001)\n    (check-within (candidate 39 4 6) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n(define (re_arrange_array arr n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate re_arrange_array))\n    (check-within (candidate (list -1 2 -3 4 5 6 -7 8 9) 9) (list -1 -3 -7 4 5 6 2 8 9) 0.001)\n    (check-within (candidate (list 12 -14 -26 13 15) 5) (list -14 -26 12 13 15) 0.001)\n    (check-within (candidate (list 10 24 36 -42 -39 -78 85) 7) (list -42 -39 -78 10 24 36 85) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n(define (replace_blank str1 char)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_blank))\n    (check-within (candidate \"hello people\" \"@\") \"hello@people\" 0.001)\n    (check-within (candidate \"python program language\" \"$\") \"python$program$language\" 0.001)\n    (check-within (candidate \"blank space\" \"-\") \"blank-space\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the volume of a cube given its side length.\n(define (volume_cube l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate volume_cube))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 2) 8 0.001)\n    (check-within (candidate 5) 125 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n(define (check_occurences test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_occurences))\n    (check-within (candidate (list (list 3 1) (list 1 3) (list 2 5) (list 5 2) (list 6 3))) #hash(((list 1 3) .  2) ((list 2 5) .  2) ((list 3 6) .  1)) 0.001)\n    (check-within (candidate (list (list 4 2) (list 2 4) (list 3 6) (list 6 3) (list 7 4))) #hash(((list 2 4) .  2) ((list 3 6) .  2) ((list 4 7) .  1)) 0.001)\n    (check-within (candidate (list (list 13 2) (list 11 23) (list 12 25) (list 25 12) (list 16 23))) #hash(((list 2 13) .  1) ((list 11 23) .  1) ((list 12 25) .  2) ((list 16 23) .  1)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of non-empty substrings of a given string.\n(define (number_of_substrings str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_of_substrings))\n    (check-within (candidate \"abc\") 6 0.001)\n    (check-within (candidate \"abcd\") 10 0.001)\n    (check-within (candidate \"abcde\") 15 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n(define (get_total_number_of_sequences m n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_total_number_of_sequences))\n    (check-within (candidate 10 4) 4 0.001)\n    (check-within (candidate 5 2) 6 0.001)\n    (check-within (candidate 16 3) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n(define (replace_list list1 list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_list))\n    (check-within (candidate (list 1 3 5 7 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 2 4 6 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8)) (list 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list \"red\" \"blue\" \"green\") (list \"yellow\")) (list \"red\" \"blue\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the total number of characters in a string.\n(define (count_charac str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_charac))\n    (check-within (candidate \"python programming\") 18 0.001)\n    (check-within (candidate \"language\") 8 0.001)\n    (check-within (candidate \"words\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the next perfect square greater than a given number.\n(define (next_Perfect_Square N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_Perfect_Square))\n    (check-within (candidate 35) 36 0.001)\n    (check-within (candidate 6) 9 0.001)\n    (check-within (candidate 9) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n(define (max_sum arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum))\n    (check-within (candidate (list 1 15 51 45 33 100 12 18 9)) 194 0.001)\n    (check-within (candidate (list 80 60 30 40 20 10)) 210 0.001)\n    (check-within (candidate (list 2 3 14 16 21 23 29 30)) 138 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the length of the longest palindromic subsequence in the given string.\n(define (lps str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lps))\n    (check-within (candidate \"TENS FOR TENS\") 5 0.001)\n    (check-within (candidate \"CARDIO FOR CARDS\") 7 0.001)\n    (check-within (candidate \"PART OF THE JOURNEY IS PART\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the intersection of two arrays.\n(define (intersection_array array_nums1 array_nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection_array))\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 1 2 4 8 9)) (list 1 2 8 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 3 5 7 9)) (list 3 5 7 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 10 20 30 40)) (list 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n(define (count_X tup x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_X))\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 4) 0 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 10) 3 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 8) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n(define (insert_element list element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate insert_element))\n    (check-within (candidate (list \"Red\" \"Green\" \"Black\") \"c\") (list \"c\" \"Red\" \"c\" \"Green\" \"c\" \"Black\") 0.001)\n    (check-within (candidate (list \"python\" \"java\") \"program\") (list \"program\" \"python\" \"program\" \"java\") 0.001)\n    (check-within (candidate (list \"happy\" \"sad\") \"laugh\") (list \"laugh\" \"happy\" \"laugh\" \"sad\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to convert complex numbers to polar coordinates.\n(define (convert numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert))\n    (check-within (candidate 1) (list 1.0 0.0) 0.001)\n    (check-within (candidate 4) (list 4.0 0.0) 0.001)\n    (check-within (candidate 5) (list 5.0 0.0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function that returns the number of integer elements in a given list.\n(define (count_integer list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_integer))\n    (check-within (candidate (list 1 2 \"abc\" 1.2)) 2 0.001)\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1.2 4 5.1)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n(define (combinations_colors l n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_colors))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 1) (list (list \"Red\") (list \"Green\") (list \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 2) (list (list \"Red\" \"Red\") (list \"Red\" \"Green\") (list \"Red\" \"Blue\") (list \"Green\" \"Green\") (list \"Green\" \"Blue\") (list \"Blue\" \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 3) (list (list \"Red\" \"Red\" \"Red\") (list \"Red\" \"Red\" \"Green\") (list \"Red\" \"Red\" \"Blue\") (list \"Red\" \"Green\" \"Green\") (list \"Red\" \"Green\" \"Blue\") (list \"Red\" \"Blue\" \"Blue\") (list \"Green\" \"Green\" \"Green\") (list \"Green\" \"Green\" \"Blue\") (list \"Green\" \"Blue\" \"Blue\") (list \"Blue\" \"Blue\" \"Blue\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n(define (count_Primes_nums n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Primes_nums))\n    (check-within (candidate 5) 2 0.001)\n    (check-within (candidate 10) 4 0.001)\n    (check-within (candidate 100) 25 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two numbers and returns a list with the second number and then the first number.\n(define (swap_numbers a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_numbers))\n    (check-within (candidate 10 20) (list 20 10) 0.001)\n    (check-within (candidate 15 17) (list 17 15) 0.001)\n    (check-within (candidate 100 200) (list 200 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5809,7 +1129,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to maximize the given two lists.\n(define (maximize_elements test_tup1 test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximize_elements))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 7) (list 4 9) (list 2 9) (list 7 10)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 7 8) (list 5 10) (list 3 10) (list 8 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 8 9) (list 6 11) (list 4 11) (list 9 12)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to check whether every even index contains even numbers of a given list.\n(define (even_position nums)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n(define (newman_prime n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_position))\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n    (check-within (candidate (list 2 1 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate newman_prime))\n    (check-within (candidate 3) 7 0.001)\n    (check-within (candidate 4) 17 0.001)\n    (check-within (candidate 5) 41 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given string starts and ends with the same character or not.\n(define (check_char string)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n(define (division_elements test_tup1 test_tup2)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_char))\n    (check-within (candidate \"abba\") \"Valid\" 0.001)\n    (check-within (candidate \"a\") \"Valid\" 0.001)\n    (check-within (candidate \"abcd\") \"Invalid\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate division_elements))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 2 2 2 3) 0.001)\n    (check-within (candidate (list 12 6 8 16) (list 6 3 4 4)) (list 2 2 2 4) 0.001)\n    (check-within (candidate (list 20 14 36 18) (list 5 7 6 9)) (list 4 2 6 2) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function to find the sum of even factors of a number.\n(define (sumofFactors n)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n(define (split_two_parts list1 L)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sumofFactors))\n    (check-within (candidate 18) 26 0.001)\n    (check-within (candidate 30) 48 0.001)\n    (check-within (candidate 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_two_parts))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list (list 1 1 2) (list 3 4 4 5 1)) 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") 2) (list (list \"a\" \"b\") (list \"c\" \"d\")) 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 4) (list (list \"p\" \"y\" \"t\" \"h\") (list \"o\" \"n\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cone given radius r and the height h.\n(define (lateralsurface_cone r h)\n",
+    "prompt": "#lang racket\n\n;; Write a function to calculate a dog's age in dog's years.\n(define (dog_age h_age)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cone))\n    (check-within (candidate 5 12) 204.20352248333654 0.001)\n    (check-within (candidate 10 15) 566.3586699569488 0.001)\n    (check-within (candidate 19 17) 1521.8090132193388 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dog_age))\n    (check-within (candidate 12) 61 0.001)\n    (check-within (candidate 15) 73 0.001)\n    (check-within (candidate 24) 109 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n(define (count_Pairs arr n)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n(define (list_split S step)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Pairs))\n    (check-within (candidate (list 1 2 1) 3) 2 0.001)\n    (check-within (candidate (list 1 1 1 1) 4) 0 0.001)\n    (check-within (candidate (list 1 2 3 4 5) 5) 10 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_split))\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\" \"h\" \"i\" \"j\" \"k\" \"l\" \"m\" \"n\") 3) (list (list \"a\" \"d\" \"g\" \"j\" \"m\") (list \"b\" \"e\" \"h\" \"k\" \"n\") (list \"c\" \"f\" \"i\" \"l\")) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11 12 13 14) 3) (list (list 1 4 7 10 13) (list 2 5 8 11 14) (list 3 6 9 12)) 0.001)\n    (check-within (candidate (list \"python\" \"java\" \"C\" \"C++\" \"DBMS\" \"SQL\") 2) (list (list \"python\" \"C\" \"DBMS\") (list \"java\" \"C++\" \"SQL\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the index of the first occurrence of a given number in a sorted array.\n(define (find_first_occurrence A x)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cube given its side length.\n(define (lateralsurface_cube l)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_first_occurrence))\n    (check-within (candidate (list 2 5 5 5 6 6 8 9 9 9) 5) 1 0.001)\n    (check-within (candidate (list 2 3 5 5 6 6 8 9 9 9) 5) 2 0.001)\n    (check-within (candidate (list 2 4 1 5 6 6 8 9 9 9) 6) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cube))\n    (check-within (candidate 5) 100 0.001)\n    (check-within (candidate 9) 324 0.001)\n    (check-within (candidate 10) 400 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5914,9 +1234,909 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n(define (square_Sum n)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 10 0.001)\n    (check-within (candidate 3) 35 0.001)\n    (check-within (candidate 4) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n'th star number.\n(define (find_star_num n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_star_num))\n    (check-within (candidate 3) 37 0.001)\n    (check-within (candidate 4) 73 0.001)\n    (check-within (candidate 5) 121 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the ascii value of a character.\n(define (ascii_value k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate ascii_value))\n    (check-within (candidate \"A\") 65 0.001)\n    (check-within (candidate \"R\") 82 0.001)\n    (check-within (candidate \"S\") 83 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of even numbers at even positions of a list.\n(define (sum_even_and_even_index arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_even_and_even_index))\n    (check-within (candidate (list 5 6 12 1 18 8)) 30 0.001)\n    (check-within (candidate (list 3 20 17 9 2 10 18 13 6 18)) 26 0.001)\n    (check-within (candidate (list 5 6 12 1)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n(define (even_Power_Sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_Power_Sum))\n    (check-within (candidate 2) 1056 0.001)\n    (check-within (candidate 3) 8832 0.001)\n    (check-within (candidate 1) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n(define (rear_extract test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rear_extract))\n    (check-within (candidate (list (list 1 \"Rash\" 21) (list 2 \"Varsha\" 20) (list 3 \"Kil\" 19))) (list 21 20 19) 0.001)\n    (check-within (candidate (list (list 1 \"Sai\" 36) (list 2 \"Ayesha\" 25) (list 3 \"Salman\" 45))) (list 36 25 45) 0.001)\n    (check-within (candidate (list (list 1 \"Sudeep\" 14) (list 2 \"Vandana\" 36) (list 3 \"Dawood\" 56))) (list 14 36 56) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n(define (substract_elements test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate substract_elements))\n    (check-within (candidate (list 10 4 5) (list 2 5 18)) (list 8 -1 -13) 0.001)\n    (check-within (candidate (list 11 2 3) (list 24 45 16)) (list -13 -43 -13) 0.001)\n    (check-within (candidate (list 7 18 9) (list 10 11 12)) (list -3 7 -3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n(define (even_binomial_Coeff_Sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_binomial_Coeff_Sum))\n    (check-within (candidate 4) 8 0.001)\n    (check-within (candidate 6) 32 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n(define (dict_filter dict n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dict_filter))\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 170) #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 180) #hash((\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 190) #hash((\"Pierre Cox\" .  190)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the number of elements that occurs before the list element in the given tuple.\n(define (count_first_elements test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_first_elements))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) 3 0.001)\n    (check-within (candidate (list 2 9 (list 5 7) 11)) 2 0.001)\n    (check-within (candidate (list 11 15 5 8 (list 2 3) 8)) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth decagonal number.\n(define (is_num_decagonal n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_num_decagonal))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 7) 175 0.001)\n    (check-within (candidate 10) 370 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n(define (sequential_search dlist item)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequential_search))\n    (check-within (candidate (list 11 23 58 31 56 77 43 12 65 19) 31) (list #t 3) 0.001)\n    (check-within (candidate (list 12 32 45 62 35 47 44 61) 61) (list #t 7) 0.001)\n    (check-within (candidate (list 9 10 17 19 22 39 48 56) 48) (list #t 6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check if the elements of a given list are unique or not.\n(define (all_unique test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_unique))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to subtract two lists element-wise.\n(define (sub_list nums1 nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sub_list))\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) (list -3 -3 -3) 0.001)\n    (check-within (candidate (list 1 2) (list 3 4)) (list -2 -2) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 40 50) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n(define (validate n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate validate))\n    (check-within (candidate 1234) #t 0.001)\n    (check-within (candidate 51241) #f 0.001)\n    (check-within (candidate 321) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n(define (check_element list element)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_element))\n    (check-within (candidate (list \"green\" \"orange\" \"black\" \"white\") \"blue\") #f 0.001)\n    (check-within (candidate (list 1 2 3 4) 7) #f 0.001)\n    (check-within (candidate (list \"green\" \"green\" \"green\" \"green\") \"green\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n(define (text_match_two_three text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_two_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n(define (max_sub_array_sum_repeated a n k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum_repeated))\n    (check-within (candidate (list 10 20 -30 -1) 4 3) 30 0.001)\n    (check-within (candidate (list -1 10 20) 3 2) 59 0.001)\n    (check-within (candidate (list -1 -2 -3) 3 3) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n(define (square_Sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 20 0.001)\n    (check-within (candidate 3) 56 0.001)\n    (check-within (candidate 4) 120 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the list of maximum length in a list of lists.\n(define (max_length list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1) (list 5 7) (list 10 12 14 15))) (list 4 (list 10 12 14 15)) 0.001)\n    (check-within (candidate (list (list 5) (list 15 20 25))) (list 3 (list 15 20 25)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n(define (count_no_of_ways n k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_no_of_ways))\n    (check-within (candidate 2 4) 16 0.001)\n    (check-within (candidate 3 2) 6 0.001)\n    (check-within (candidate 4 4) 228 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n(define (find n m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find))\n    (check-within (candidate 10 3) 3 0.001)\n    (check-within (candidate 4 2) 2 0.001)\n    (check-within (candidate 20 5) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the third side of a right angled triangle.\n(define (otherside_rightangle w h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate otherside_rightangle))\n    (check-within (candidate 7 8) 10.63014581273465 0.001)\n    (check-within (candidate 3 4) 5 0.001)\n    (check-within (candidate 7 15) 16.55294535724685 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum value in a given heterogeneous list.\n(define (max_val listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 5 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 25 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 50 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return the sum of all divisors of a number.\n(define (sum_div number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_div))\n    (check-within (candidate 8) 7 0.001)\n    (check-within (candidate 12) 16 0.001)\n    (check-within (candidate 7) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count inversions in an array.\n(define (get_Inv_Count arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Inv_Count))\n    (check-within (candidate (list 1 20 6 4 5)) 5 0.001)\n    (check-within (candidate (list 1 2 1)) 1 0.001)\n    (check-within (candidate (list 1 2 5 6 1)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to flatten a given nested list structure.\n(define (flatten_list list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flatten_list))\n    (check-within (candidate (list 0 10 (list 20 30) 40 50 (list 60 70 80) (list 90 100 110 120))) (list 0 10 20 30 40 50 60 70 80 90 100 110 120) 0.001)\n    (check-within (candidate (list (list 10 20) (list 40) (list 30 56 25) (list 10 20) (list 33) (list 40))) (list 10 20 40 30 56 25 10 20 33 40) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 1 2 3 4 5 6 10 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the maximum aggregate from the list of tuples.\n(define (max_aggregate stdata)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_aggregate))\n    (check-within (candidate (list (list \"Juan Whelan\" 90) (list \"Sabah Colley\" 88) (list \"Peter Nichols\" 7) (list \"Juan Whelan\" 122) (list \"Sabah Colley\" 84))) (list \"Juan Whelan\" 212) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 50) (list \"Sabah Colley\" 48) (list \"Peter Nichols\" 37) (list \"Juan Whelan\" 22) (list \"Sabah Colley\" 14))) (list \"Juan Whelan\" 72) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 10) (list \"Sabah Colley\" 20) (list \"Peter Nichols\" 30) (list \"Juan Whelan\" 40) (list \"Sabah Colley\" 50))) (list \"Sabah Colley\" 70) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find element at a given index after number of rotations.\n(define (find_Element arr ranges rotations index)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Element))\n    (check-within (candidate (list 1 2 3 4 5) (list (list 0 2) (list 0 3)) 2 1) 3 0.001)\n    (check-within (candidate (list 1 2 3 4) (list (list 0 1) (list 0 2)) 1 2) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list (list 0 1) (list 0 2)) 1 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return two words from a list of words starting with letter 'p'.\n(define (start_withp words)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate start_withp))\n    (check-within (candidate (list \"Python PHP\" \"Java JavaScript\" \"c c++\")) (list \"Python\" \"PHP\") 0.001)\n    (check-within (candidate (list \"Python Programming\" \"Java Programming\")) (list \"Python\" \"Programming\") 0.001)\n    (check-within (candidate (list \"Pqrst Pqr\" \"qrstuv\")) (list \"Pqrst\" \"Pqr\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n(define (max_sum_increasing_subseq a n index k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_increasing_subseq))\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 4 6) 11 0.001)\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 2 5) 7 0.001)\n    (check-within (candidate (list 11 15 19 21 26 28 31) 7 2 4) 71 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n(define (large_product nums1 nums2 N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate large_product))\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 3) (list 60 54 50) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 4) (list 60 54 50 48) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 5) (list 60 54 50 48 45) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the maximum of two numbers.\n(define (maximum a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate 5 10) 10 0.001)\n    (check-within (candidate -1 -2) -1 0.001)\n    (check-within (candidate 9 7) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a given string to a list of characters.\n(define (string_to_tuple str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_tuple))\n    (check-within (candidate \"python 3.0\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\" \"3\" \".\" \"0\") 0.001)\n    (check-within (candidate \"item1\") (list \"i\" \"t\" \"e\" \"m\" \"1\") 0.001)\n    (check-within (candidate \"15.10\") (list \"1\" \"5\" \".\" \"1\" \"0\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the highest power of 2 that is less than or equal to n.\n(define (highest_Power_of_2 n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate highest_Power_of_2))\n    (check-within (candidate 10) 8 0.001)\n    (check-within (candidate 19) 16 0.001)\n    (check-within (candidate 32) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n'th lucas number.\n(define (find_lucas n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lucas))\n    (check-within (candidate 9) 76 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 3) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to apply a given format string to all of the elements in a list.\n(define (add_string list_ string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_string))\n    (check-within (candidate (list 1 2 3 4) \"temp{0}\") (list \"temp1\" \"temp2\" \"temp3\" \"temp4\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") \"python{0}\") (list \"pythona\" \"pythonb\" \"pythonc\" \"pythond\") 0.001)\n    (check-within (candidate (list 5 6 7 8) \"string{0}\") (list \"string5\" \"string6\" \"string7\" \"string8\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert more than one list to nested dictionary.\n(define (convert_list_dictionary l1 l2 l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert_list_dictionary))\n    (check-within (candidate (list \"S001\" \"S002\" \"S003\" \"S004\") (list \"Adina Park\" \"Leyton Marsh\" \"Duncan Boyle\" \"Saim Richards\") (list 85 98 89 92)) (list #hash((\"S001\" .  #hash((\"Adina Park\" .  85)))) #hash((\"S002\" .  #hash((\"Leyton Marsh\" .  98)))) #hash((\"S003\" .  #hash((\"Duncan Boyle\" .  89)))) #hash((\"S004\" .  #hash((\"Saim Richards\" .  92))))) 0.001)\n    (check-within (candidate (list \"abc\" \"def\" \"ghi\" \"jkl\") (list \"python\" \"program\" \"language\" \"programs\") (list 100 200 300 400)) (list #hash((\"abc\" .  #hash((\"python\" .  100)))) #hash((\"def\" .  #hash((\"program\" .  200)))) #hash((\"ghi\" .  #hash((\"language\" .  300)))) #hash((\"jkl\" .  #hash((\"programs\" .  400))))) 0.001)\n    (check-within (candidate (list \"A1\" \"A2\" \"A3\" \"A4\") (list \"java\" \"C\" \"C++\" \"DBMS\") (list 10 20 30 40)) (list #hash((\"A1\" .  #hash((\"java\" .  10)))) #hash((\"A2\" .  #hash((\"C\" .  20)))) #hash((\"A3\" .  #hash((\"C++\" .  30)))) #hash((\"A4\" .  #hash((\"DBMS\" .  40))))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n(define (get_max_sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_sum))\n    (check-within (candidate 60) 106 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the list with maximum length.\n(define (max_length_list input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length_list))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5) (list 1 2 3 4) (list 1 2 3) (list 1 2) (list 1))) (list 5 (list 1 2 3 4 5)) 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 6 7 8 9) (list 10 11 12))) (list 4 (list 6 7 8 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if given list contains no duplicates.\n(define (check_distinct test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_distinct))\n    (check-within (candidate (list 1 4 5 6 1 4)) #f 0.001)\n    (check-within (candidate (list 1 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 6)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the first non-repeated character in a given string.\n(define (first_non_repeating_character str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_non_repeating_character))\n    (check-within (candidate \"abcabc\") #f 0.001)\n    (check-within (candidate \"abc\") \"a\" 0.001)\n    (check-within (candidate \"ababc\") \"c\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given string starts and ends with the same character or not.\n(define (check_char string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_char))\n    (check-within (candidate \"abba\") \"Valid\" 0.001)\n    (check-within (candidate \"a\") \"Valid\" 0.001)\n    (check-within (candidate \"abcd\") \"Invalid\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median of three numbers.\n(define (median_numbers a b c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_numbers))\n    (check-within (candidate 25 55 65) 55.0 0.001)\n    (check-within (candidate 20 10 30) 20.0 0.001)\n    (check-within (candidate 15 45 75) 45.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to compute the sum of digits of each number of a given list.\n(define (sum_of_digits nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_of_digits))\n    (check-within (candidate (list 10 2 56)) 14 0.001)\n    (check-within (candidate (list (list 10 20 4 5 \"b\" 70 \"a\"))) 19 0.001)\n    (check-within (candidate (list 10 20 -4 5 -70)) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform the mathematical bitwise xor operation across the given tuples.\n(define (bitwise_xor test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bitwise_xor))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 15 6 5 10) 0.001)\n    (check-within (candidate (list 11 5 7 10) (list 6 3 4 4)) (list 13 6 3 14) 0.001)\n    (check-within (candidate (list 12 6 8 11) (list 7 4 5 6)) (list 11 2 13 13) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to identify non-prime numbers.\n(define (is_not_prime n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_not_prime))\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 35) #t 0.001)\n    (check-within (candidate 37) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the number of unique tuples in the given list.\n(define (extract_freq test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_freq))\n    (check-within (candidate (list (list 3 4) (list 1 2) (list 4 3) (list 5 6))) 3 0.001)\n    (check-within (candidate (list (list 4 15) (list 2 3) (list 5 4) (list 6 7))) 4 0.001)\n    (check-within (candidate (list (list 5 16) (list 2 3) (list 6 5) (list 6 9))) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform index wise addition of list elements in the given two nested lists.\n(define (add_nested_tuples test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_nested_tuples))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 7 10) (list 7 14) (list 3 10) (list 8 13)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 9 12) (list 9 16) (list 5 12) (list 10 15)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 11 14) (list 11 18) (list 7 14) (list 12 17)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the minimum of two numbers.\n(define (minimum a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minimum))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate -5 -4) -5 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether an element exists within a tuple.\n(define (check_tuplex tuplex tuple1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_tuplex))\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"r\") #t 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"5\") #f 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") 3) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find whether the parity of a given number is odd.\n(define (find_Parity x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Parity))\n    (check-within (candidate 12) #f 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create the next bigger number by rearranging the digits of a given number.\n(define (rearrange_bigger n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rearrange_bigger))\n    (check-within (candidate 12) 21 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 102) 120 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n(define (k_smallest_pairs nums1 nums2 k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate k_smallest_pairs))\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 2) (list (list 1 2) (list 1 4)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 1) (list (list 1 2)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 7) (list (list 1 2) (list 1 4) (list 3 2) (list 1 6) (list 3 4) (list 3 6) (list 7 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the minimum product from the pairs of tuples within a given list.\n(define (min_product_tuple list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 8 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 30 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 100 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the minimum value in a given heterogeneous list.\n(define (min_val listval)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 2 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 15 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 20 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given snake case string to camel case string.\n(define (snake_to_camel word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"android_tv\") \"AndroidTv\" 0.001)\n    (check-within (candidate \"google_pixel\") \"GooglePixel\" 0.001)\n    (check-within (candidate \"apple_watch\") \"AppleWatch\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to remove odd numbers from a given list.\n(define (remove_odd l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate (list 1 2 3)) (list 2) 0.001)\n    (check-within (candidate (list 2 4 6)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 10 20 3)) (list 10 20) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the nth element from a given list of tuples.\n(define (extract_nth_element list1 n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_nth_element))\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 0) (list \"Greyson Fulton\" \"Brady Kent\" \"Wyatt Knott\" \"Beau Turnbull\") 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 2) (list 99 96 94 98) 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 1) (list 98 97 91 94) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether any value in a sequence exists in a sequence or not.\n(define (overlapping list1 list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate overlapping))\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) #f 0.001)\n    (check-within (candidate (list 1 4 5) (list 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find a pair with highest product from a given array of integers.\n(define (max_Product arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Product))\n    (check-within (candidate (list 1 2 3 4 7 0 8 4)) (list 7 8) 0.001)\n    (check-within (candidate (list 0 -1 -2 -4 5 0 -6)) (list -4 -6) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 3) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5929,7 +2149,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find common first element in given list of lists.\n(define (group_tuples Input)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate group_tuples))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"x\" \"z\") (list \"w\" \"t\"))) (list (list \"x\" \"y\" \"z\") (list \"w\" \"t\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"a\" \"c\") (list \"d\" \"e\"))) (list (list \"a\" \"b\" \"c\") (list \"d\" \"e\")) 0.001)\n    (check-within (candidate (list (list \"f\" \"g\") (list \"f\" \"g\") (list \"h\" \"i\"))) (list (list \"f\" \"g\" \"g\") (list \"h\" \"i\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to merge three lists into a single sorted list.\n(define (merge_sorted_list num1 num2 num3)\n",
+    "prompt": "#lang racket\n\n;; Write a python function to find the element of a list having maximum length.\n(define (Find_Max lst)\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_sorted_list))\n    (check-within (candidate (list 25 24 15 4 5 29 110) (list 19 20 11 56 25 233 154) (list 24 26 54 48)) (list 4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233) 0.001)\n    (check-within (candidate (list 1 3 5 6 8 9) (list 2 5 7 11) (list 1 4 7 8 12)) (list 1 1 2 3 4 5 5 6 7 7 8 8 9 11 12) 0.001)\n    (check-within (candidate (list 18 14 10 9 8 7 9 3 2 4 1) (list 25 35 22 85 14 65 75 25 58) (list 12 74 9 50 61 41)) (list 1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max))\n    (check-within (candidate (list (list \"A\") (list \"A\" \"B\") (list \"A\" \"B\" \"C\"))) (list \"A\" \"B\" \"C\") 0.001)\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1 2 3) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 2 3) (list 1 5 6 1))) (list 1 5 6 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n(define (round_and_sum list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate round_and_sum))\n    (check-within (candidate (list 22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5)) 243 0.001)\n    (check-within (candidate (list 5 2 9 24.3 29)) 345 0.001)\n    (check-within (candidate (list 25.0 56.7 89.2)) 513 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the cube sum of first n even natural numbers.\n(define (cube_Sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_Sum))\n    (check-within (candidate 2) 72 0.001)\n    (check-within (candidate 3) 288 0.001)\n    (check-within (candidate 4) 800 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to concatenate each element of tuple by the delimiter.\n(define (concatenate_tuple test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate_tuple))\n    (check-within (candidate (list \"ID\" \"is\" 4 \"UTS\")) \"ID-is-4-UTS\" 0.001)\n    (check-within (candidate (list \"QWE\" \"is\" 4 \"RTY\")) \"QWE-is-4-RTY\" 0.001)\n    (check-within (candidate (list \"ZEN\" \"is\" 4 \"OP\")) \"ZEN-is-4-OP\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the average of cubes of first n natural numbers.\n(define (find_Average_Of_Cube n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Average_Of_Cube))\n    (check-within (candidate 2) 4.5 0.001)\n    (check-within (candidate 3) 12 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract only the rear index element of each string in the given tuple.\n(define (extract_rear test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_rear))\n    (check-within (candidate (list \"Mers\" \"for\" \"Vers\")) (list \"s\" \"r\" \"s\") 0.001)\n    (check-within (candidate (list \"Avenge\" \"for\" \"People\")) (list \"e\" \"r\" \"e\") 0.001)\n    (check-within (candidate (list \"Gotta\" \"get\" \"go\")) (list \"a\" \"t\" \"o\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of sublists containing a particular element.\n(define (count_element_in_list list1 x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_element_in_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 1 11) (list 1 15 7)) 1) 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"A\") 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"E\") 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to filter odd numbers.\n(define (filter_oddnumbers nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_oddnumbers))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 3 5 7 9) 0.001)\n    (check-within (candidate (list 10 20 45 67 84 93)) (list 45 67 93) 0.001)\n    (check-within (candidate (list 5 7 9 8 6 4 3)) (list 5 7 9 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n(define (change_date_format dt)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_date_format))\n    (check-within (candidate \"2026-01-02\") \"02-01-2026\" 0.001)\n    (check-within (candidate \"2020-11-13\") \"13-11-2020\" 0.001)\n    (check-within (candidate \"2021-04-26\") \"26-04-2021\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort the given array by using shell sort.\n(define (shell_sort my_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate shell_sort))\n    (check-within (candidate (list 12 23 4 5 3 2 12 81 56 95)) (list 2 3 4 5 12 12 23 56 81 95) 0.001)\n    (check-within (candidate (list 24 22 39 34 87 73 68)) (list 22 24 34 39 68 73 87) 0.001)\n    (check-within (candidate (list 32 30 16 96 82 83 74)) (list 16 30 32 74 82 83 96) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the elementwise and tuples from the given two tuples.\n(define (and_tuples test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate and_tuples))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 0 0 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 5 6 7 8)) (list 1 2 3 0) 0.001)\n    (check-within (candidate (list 8 9 11 12) (list 7 13 14 17)) (list 0 9 10 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the directrix of a parabola.\n(define (parabola_directrix a b c)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parabola_directrix))\n    (check-within (candidate 5 3 2) -198 0.001)\n    (check-within (candidate 9 8 4) -2336 0.001)\n    (check-within (candidate 2 4 6) -130 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes two lists and returns true if they have at least one common element.\n(define (common_element list1 list2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common_element))\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8 9)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\") (list \"d\" \"b\" \"e\")) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median length of a trapezium.\n(define (median_trapezium base1 base2 height)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_trapezium))\n    (check-within (candidate 15 25 35) 20 0.001)\n    (check-within (candidate 10 20 30) 15 0.001)\n    (check-within (candidate 6 9 4) 7.5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the entered number is greater than the elements of the given array.\n(define (check_greater arr number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_greater))\n    (check-within (candidate (list 1 2 3 4 5) 4) #f 0.001)\n    (check-within (candidate (list 2 3 4 5 6) 8) #t 0.001)\n    (check-within (candidate (list 9 7 4 8 6 1) 11) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by one or more b's.\n(define (text_match_one text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the last digit of a given number.\n(define (last_Digit n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit))\n    (check-within (candidate 123) 3 0.001)\n    (check-within (candidate 25) 5 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to return the negative numbers in a list.\n(define (neg_nos list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate neg_nos))\n    (check-within (candidate (list -1 4 5 -6)) (list -1 -6) 0.001)\n    (check-within (candidate (list -1 -2 3 4)) (list -1 -2) 0.001)\n    (check-within (candidate (list -7 -6 8 9)) (list -7 -6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove odd characters in a string.\n(define (remove_odd str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate \"python\") \"yhn\" 0.001)\n    (check-within (candidate \"program\") \"rga\" 0.001)\n    (check-within (candidate \"language\") \"agae\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count bidirectional tuple pairs.\n(define (count_bidirectional test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_bidirectional))\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 3 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 3) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 2 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 2) (list 6 5) (list 2 1))) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to join a list of multiple integers into a single integer.\n(define (multiple_to_single L)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiple_to_single))\n    (check-within (candidate (list 11 33 50)) 113350 0.001)\n    (check-within (candidate (list -1 2 3 4 5 6)) -123456 0.001)\n    (check-within (candidate (list 10 15 20 25)) 10152025 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the first adverb and their positions in a given sentence.\n(define (find_adverb_position text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverb_position))\n    (check-within (candidate \"clearly!! we can see the sky\") (list 0 7 \"clearly\") 0.001)\n    (check-within (candidate \"seriously!! there are many roses\") (list 0 9 \"seriously\") 0.001)\n    (check-within (candidate \"unfortunately!! sita is going to home\") (list 0 13 \"unfortunately\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cube of a given size.\n(define (surfacearea_cube l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cube))\n    (check-within (candidate 5) 150 0.001)\n    (check-within (candidate 3) 54 0.001)\n    (check-within (candidate 10) 600 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the ration of positive numbers in an array of integers.\n(define (positive_count nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate positive_count))\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8)) 0.54 0.001)\n    (check-within (candidate (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 0.69 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) 0.56 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the largest negative number from the given list.\n(define (largest_neg list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_neg))\n    (check-within (candidate (list 1 2 3 -4 -6)) -6 0.001)\n    (check-within (candidate (list 1 2 3 -8 -9)) -9 0.001)\n    (check-within (candidate (list 1 2 3 4 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to trim each list by k in the given lists.\n(define (trim_tuple test_list K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate trim_tuple))\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 2) (list (list 2) (list 9) (list 2) (list 2)) 0.001)\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 1) (list (list 3 2 1) (list 4 9 2) (list 1 2 3) (list 8 2 1)) 0.001)\n    (check-within (candidate (list (list 7 8 4 9) (list 11 8 12 4) (list 4 1 7 8) (list 3 6 9 7)) 1) (list (list 8 4) (list 8 12) (list 1 7) (list 6 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform index wise multiplication of list elements in the given two lists.\n(define (index_multiplication test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_multiplication))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 21) (list 12 45) (list 2 9) (list 7 30)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 14 32) (list 20 60) (list 6 20) (list 16 44)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 24 45) (list 30 77) (list 12 33) (list 27 60)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the occurence of all elements of list in a tuple.\n(define (count_Occurrence tup lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Occurrence))\n    (check-within (candidate (list \"a\" \"a\" \"c\" \"b\" \"d\") (list \"a\" \"b\")) 3 0.001)\n    (check-within (candidate (list 1 2 3 1 4 6 7 1 4) (list 1 4 7)) 6 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 1 2)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find cubes of individual elements in a list.\n(define (cube_nums nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 8 27 64 125 216 343 512 729 1000) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15)) (list 1728 3375) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of perrin numbers.\n(define (cal_sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cal_sum))\n    (check-within (candidate 9) 49 0.001)\n    (check-within (candidate 10) 66 0.001)\n    (check-within (candidate 11) 88 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract specified size of strings from a given list of string values.\n(define (extract_string str l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_string))\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 8) (list \"practice\" \"solution\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 6) (list \"Python\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 9) (list \"exercises\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from the given string.\n(define (remove_whitespaces text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_whitespaces))\n    (check-within (candidate \" Google    Flutter \") \"GoogleFlutter\" 0.001)\n    (check-within (candidate \" Google    Dart \") \"GoogleDart\" 0.001)\n    (check-within (candidate \" iOS    Swift \") \"iOSSwift\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n(define (loss_amount actual_cost sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate loss_amount))\n    (check-within (candidate 1500 1200) 0 0.001)\n    (check-within (candidate 100 200) 100 0.001)\n    (check-within (candidate 2000 5000) 3000 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of even factors of a number.\n(define (sumofFactors n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sumofFactors))\n    (check-within (candidate 18) 26 0.001)\n    (check-within (candidate 30) 48 0.001)\n    (check-within (candidate 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a word containing 'z'.\n(define (text_match_wordz text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz))\n    (check-within (candidate \"pythonz.\") #t 0.001)\n    (check-within (candidate \"xyz.\") #t 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 31 days or not.\n(define (check_monthnumb_number monthnum2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumb_number))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to reverse each string in a given list of string values.\n(define (reverse_string_list stringlist)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_string_list))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\" \"White\" \"Black\")) (list \"deR\" \"neerG\" \"eulB\" \"etihW\" \"kcalB\") 0.001)\n    (check-within (candidate (list \"john\" \"amal\" \"joel\" \"george\")) (list \"nhoj\" \"lama\" \"leoj\" \"egroeg\") 0.001)\n    (check-within (candidate (list \"jack\" \"john\" \"mary\")) (list \"kcaj\" \"nhoj\" \"yram\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sublist having minimum length.\n(define (Find_Min lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min))\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 1 1) (list 1 2 7 8))) (list 1 1) 0.001)\n    (check-within (candidate (list (list \"x\") (list \"x\" \"y\") (list \"x\" \"y\" \"z\"))) (list \"x\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the area of a rectangle.\n(define (rectangle_area l b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rectangle_area))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 10 5) 50 0.001)\n    (check-within (candidate 4 2) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove uppercase substrings from a given string.\n(define (remove_uppercase str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_uppercase))\n    (check-within (candidate \"cAstyoUrFavoRitETVshoWs\") \"cstyoravoitshos\" 0.001)\n    (check-within (candidate \"wAtchTheinTernEtrAdIo\") \"wtchheinerntrdo\" 0.001)\n    (check-within (candidate \"VoicESeaRchAndreComMendaTionS\") \"oiceachndreomendaion\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to get the first element of each sublist.\n(define (Extract lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Extract))\n    (check-within (candidate (list (list 1 2) (list 3 4 5) (list 6 7 8 9))) (list 1 3 6) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5))) (list 1 4) 0.001)\n    (check-within (candidate (list (list 9 8 1) (list 1 2))) (list 9 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the upper case characters in a given string.\n(define (upper_ctr str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate upper_ctr))\n    (check-within (candidate \"PYthon\") 1 0.001)\n    (check-within (candidate \"BigData\") 1 0.001)\n    (check-within (candidate \"program\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find all possible combinations of the elements of a given list.\n(define (combinations_list list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_list))\n    (check-within (candidate (list \"orange\" \"red\" \"green\" \"blue\")) (list (list ) (list \"orange\") (list \"red\") (list \"red\" \"orange\") (list \"green\") (list \"green\" \"orange\") (list \"green\" \"red\") (list \"green\" \"red\" \"orange\") (list \"blue\") (list \"blue\" \"orange\") (list \"blue\" \"red\") (list \"blue\" \"red\" \"orange\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"orange\") (list \"blue\" \"green\" \"red\") (list \"blue\" \"green\" \"red\" \"orange\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"blue\" \"white\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"blue\") (list \"blue\" \"red\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"red\") (list \"white\") (list \"white\" \"red\") (list \"white\" \"green\") (list \"white\" \"green\" \"red\") (list \"white\" \"blue\") (list \"white\" \"blue\" \"red\") (list \"white\" \"blue\" \"green\") (list \"white\" \"blue\" \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"black\" \"blue\") (list \"black\" \"blue\" \"red\") (list \"black\" \"blue\" \"green\") (list \"black\" \"blue\" \"green\" \"red\") (list \"black\" \"white\") (list \"black\" \"white\" \"red\") (list \"black\" \"white\" \"green\") (list \"black\" \"white\" \"green\" \"red\") (list \"black\" \"white\" \"blue\") (list \"black\" \"white\" \"blue\" \"red\") (list \"black\" \"white\" \"blue\" \"green\") (list \"black\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"blue\") (list \"orange\" \"blue\" \"red\") (list \"orange\" \"blue\" \"green\") (list \"orange\" \"blue\" \"green\" \"red\") (list \"orange\" \"white\") (list \"orange\" \"white\" \"red\") (list \"orange\" \"white\" \"green\") (list \"orange\" \"white\" \"green\" \"red\") (list \"orange\" \"white\" \"blue\") (list \"orange\" \"white\" \"blue\" \"red\") (list \"orange\" \"white\" \"blue\" \"green\") (list \"orange\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\") (list \"orange\" \"black\" \"blue\") (list \"orange\" \"black\" \"blue\" \"red\") (list \"orange\" \"black\" \"blue\" \"green\") (list \"orange\" \"black\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\" \"white\") (list \"orange\" \"black\" \"white\" \"red\") (list \"orange\" \"black\" \"white\" \"green\") (list \"orange\" \"black\" \"white\" \"green\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\") (list \"orange\" \"black\" \"white\" \"blue\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\" \"red\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum product subarray of the given array.\n(define (max_subarray_product arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_subarray_product))\n    (check-within (candidate (list 1 -2 -3 0 7 -8 -2)) 112 0.001)\n    (check-within (candidate (list 6 -3 -10 0 2)) 180 0.001)\n    (check-within (candidate (list -2 -40 0 -2 -3)) 80 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if all values are same in a dictionary.\n(define (check_value dict n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_value))\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 10) #f 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 12) #t 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 5) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to drop empty items from a given dictionary.\n(define (drop_empty dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate drop_empty))\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  #f) (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  #f) (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c2\" .  \"Green\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n(define (max_product arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product))\n    (check-within (candidate (list 3 100 4 5 150 6)) 3000 0.001)\n    (check-within (candidate (list 4 42 55 68 80)) 50265600 0.001)\n    (check-within (candidate (list 10 22 9 33 21 50 41 60)) 2460 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n(define (add_pairwise test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_pairwise))\n    (check-within (candidate (list 1 5 7 8 10)) (list 6 12 15 18) 0.001)\n    (check-within (candidate (list 2 6 8 9 11)) (list 8 14 17 20) 0.001)\n    (check-within (candidate (list 3 7 9 10 12)) (list 10 16 19 22) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the product of the array multiplication modulo n.\n(define (find_remainder arr n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_remainder))\n    (check-within (candidate (list 100 10 5 25 35 14) 11) 9 0.001)\n    (check-within (candidate (list 1 1 1) 1) 0 0.001)\n    (check-within (candidate (list 1 2 1) 2) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given list contains consecutive numbers or not.\n(define (check_Consecutive l)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_Consecutive))\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 5 6)) #f 0.001)\n    (check-within (candidate (list 1 2 1)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace characters in a string.\n(define (replace_char str1 ch newch)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_char))\n    (check-within (candidate \"polygon\" \"y\" \"l\") \"pollgon\" 0.001)\n    (check-within (candidate \"character\" \"c\" \"a\") \"aharaater\" 0.001)\n    (check-within (candidate \"python\" \"l\" \"a\") \"python\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a dictionary by value.\n(define (sort_counter dict1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_counter))\n    (check-within (candidate #hash((\"Math\" .  81) (\"Physics\" .  83) (\"Chemistry\" .  87))) (list (list \"Chemistry\" 87) (list \"Physics\" 83) (list \"Math\" 81)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  400) (\"Physics\" .  300) (\"Chemistry\" .  250))) (list (list \"Math\" 400) (list \"Physics\" 300) (list \"Chemistry\" 250)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  900) (\"Physics\" .  1000) (\"Chemistry\" .  1250))) (list (list \"Chemistry\" 1250) (list \"Physics\" 1000) (list \"Math\" 900)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the largest and smallest value in a given array.\n(define (big_sum nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_sum))\n    (check-within (candidate (list 1 2 3)) 4 0.001)\n    (check-within (candidate (list -1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 2 3 6)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to convert the given string to lower case.\n(define (is_lower string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_lower))\n    (check-within (candidate \"InValid\") \"invalid\" 0.001)\n    (check-within (candidate \"TruE\") \"true\" 0.001)\n    (check-within (candidate \"SenTenCE\") \"sentence\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove lowercase substrings from a given string.\n(define (remove_lowercase str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_lowercase))\n    (check-within (candidate \"PYTHon\") \"PYTH\" 0.001)\n    (check-within (candidate \"FInD\") \"FID\" 0.001)\n    (check-within (candidate \"STRinG\") \"STRG\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the first digit of a given number.\n(define (first_Digit n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_Digit))\n    (check-within (candidate 123) 1 0.001)\n    (check-within (candidate 456) 4 0.001)\n    (check-within (candidate 12) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n(define (heap_queue_largest nums n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_queue_largest))\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 3) (list 85 75 65) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 2) (list 85 75) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 5) (list 85 75 65 58 35) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function which takes a list of integers and only returns the odd ones.\n(define (Split list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5 6)) (list 1 3 5) 0.001)\n    (check-within (candidate (list 10 11 12 13)) (list 11 13) 0.001)\n    (check-within (candidate (list 7 8 9 1)) (list 7 9 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n(define (difference n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate difference))\n    (check-within (candidate 3) 30 0.001)\n    (check-within (candidate 5) 210 0.001)\n    (check-within (candidate 2) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of pairs whose xor value is odd.\n(define (find_Odd_Pair A N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Odd_Pair))\n    (check-within (candidate (list 5 4 7 2 1) 5) 6 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11) 7) 12 0.001)\n    (check-within (candidate (list 1 2 3) 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to toggle the case of all characters in a string.\n(define (toggle_string string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_string))\n    (check-within (candidate \"Python\") \"pYTHON\" 0.001)\n    (check-within (candidate \"Pangram\") \"pANGRAM\" 0.001)\n    (check-within (candidate \"LIttLE\") \"liTTle\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the per-digit difference between two integers.\n(define (digit_distance_nums n1 n2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digit_distance_nums))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate 23 56) 6 0.001)\n    (check-within (candidate 123 256) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the sum of the largest contiguous sublist in the given list.\n(define (max_sub_array_sum a size)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum))\n    (check-within (candidate (list -2 -3 4 -1 -2 1 5 -3) 8) 7 0.001)\n    (check-within (candidate (list -3 -4 5 -2 -3 2 6 -4) 8) 8 0.001)\n    (check-within (candidate (list -4 -5 6 -3 -4 3 7 -5) 8) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the union of the elements of two given lists and output them in sorted order.\n(define (union_elements test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate union_elements))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 4 5 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 3 4 5 6)) (list 1 2 3 4 5 6) 0.001)\n    (check-within (candidate (list 11 12 13 14) (list 13 15 16 17)) (list 11 12 13 14 15 16 17) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the length of the longest sublists.\n(define (Find_Max_Length lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max_Length))\n    (check-within (candidate (list (list 1) (list 1 4) (list 5 6 7 8))) 4 0.001)\n    (check-within (candidate (list (list 0 1) (list 2 2) (list 3 2 1))) 3 0.001)\n    (check-within (candidate (list (list 7) (list 22 23) (list 13 14 15) (list 10 20 30 40 50))) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks from a string.\n(define (extract_values text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_values))\n    (check-within (candidate \"\"Python\", \"PHP\", \"Java\"\") (list \"Python\" \"PHP\" \"Java\") 0.001)\n    (check-within (candidate \"\"python\",\"program\",\"language\"\") (list \"python\" \"program\" \"language\") 0.001)\n    (check-within (candidate \"\"red\",\"blue\",\"green\",\"yellow\"\") (list \"red\" \"blue\" \"green\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n(define (count_Pairs arr n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Pairs))\n    (check-within (candidate (list 1 2 1) 3) 2 0.001)\n    (check-within (candidate (list 1 1 1 1) 4) 0 0.001)\n    (check-within (candidate (list 1 2 3 4 5) 5) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to split a string into characters.\n(define (split word)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split))\n    (check-within (candidate \"python\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 0.001)\n    (check-within (candidate \"Name\") (list \"N\" \"a\" \"m\" \"e\") 0.001)\n    (check-within (candidate \"program\") (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get the sum of the digits of a non-negative integer.\n(define (sum_digits n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_digits))\n    (check-within (candidate 345) 12 0.001)\n    (check-within (candidate 12) 3 0.001)\n    (check-within (candidate 97) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a specified list is sorted or not.\n(define (issort_list list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate issort_list))\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 16 17)) #t 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 20 17)) #f 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 15 14 20)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create a list of N empty dictionaries.\n(define (empty_list length)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate empty_list))\n    (check-within (candidate 5) (list #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 6) (list #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 7) (list #hash() #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\"))) (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"d\" \"c\") (list \"g\" \"h\") (list \"f\" \"e\"))) (list (list \"a\" \"b\") (list \"c\" \"d\") (list \"g\" \"h\") (list \"e\" \"f\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check if a given number is one less than twice its reverse.\n(define (checks n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate checks))\n    (check-within (candidate 70) #f 0.001)\n    (check-within (candidate 23) #f 0.001)\n    (check-within (candidate 73) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to remove duplicate numbers from a given number of lists.\n(define (two_unique_nums nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate two_unique_nums))\n    (check-within (candidate (list 1 2 3 2 3 4 5)) (list 1 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 5)) (list 1 3 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to calculate the product of the unique numbers in a given list.\n(define (unique_product list_data)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_product))\n    (check-within (candidate (list 10 20 30 40 20 50 60 40)) 720000000 0.001)\n    (check-within (candidate (list 1 2 3 1)) 6 0.001)\n    (check-within (candidate (list 7 8 9 0 1 1)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cylinder.\n(define (surfacearea_cylinder r h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cylinder))\n    (check-within (candidate 10 5) 942.45 0.001)\n    (check-within (candidate 4 5) 226.18800000000002 0.001)\n    (check-within (candidate 4 10) 351.848 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether a list is sublist of another or not.\n(define (is_Sub_Array A B)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sub_Array))\n    (check-within (candidate (list 1 4 3 5) (list 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 1) (list 1 2 1)) #t 0.001)\n    (check-within (candidate (list 1 0 2 2) (list 2 2 0)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the last digit in factorial of a given number.\n(define (last_Digit_Factorial n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit_Factorial))\n    (check-within (candidate 4) 4 0.001)\n    (check-within (candidate 21) 0 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to interleave 3 lists of the same length into a single flat list.\n(define (interleave_lists list1 list2 list3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate interleave_lists))\n    (check-within (candidate (list 1 2 3 4 5 6 7) (list 10 20 30 40 50 60 70) (list 100 200 300 400 500 600 700)) (list 1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700) 0.001)\n    (check-within (candidate (list 10 20) (list 15 2) (list 5 10)) (list 10 15 5 20 2 10) 0.001)\n    (check-within (candidate (list 11 44) (list 10 15) (list 20 5)) (list 11 10 20 44 15 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the dissimilar elements in the given two tuples.\n(define (find_dissimilar test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_dissimilar))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 7 2 3 9)) (list 1 4 7 9) 0.001)\n    (check-within (candidate (list 21 11 25 26) (list 26 34 21 36)) (list 34 36 11 25) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the largest number that can be formed with the given list of digits.\n(define (find_Max_Num arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Max_Num))\n    (check-within (candidate (list 1 2 3)) 321 0.001)\n    (check-within (candidate (list 4 5 6 1)) 6541 0.001)\n    (check-within (candidate (list 1 2 3 9)) 9321 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove uneven elements in the nested mixed tuple.\n(define (extract_even test_tuple)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_even))\n    (check-within (candidate (list 4 5 (list 7 6 (list 2 4)) 6 8)) (list 4 (list 6 (list 2 4)) 6 8) 0.001)\n    (check-within (candidate (list 5 6 (list 8 7 (list 4 8)) 7 9)) (list 6 (list 8 (list 4 8))) 0.001)\n    (check-within (candidate (list 5 6 (list 9 8 (list 4 6)) 8 10)) (list 6 (list 8 (list 4 6)) 8 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the surface area of a square pyramid with a given base edge and height.\n(define (surface_Area b s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surface_Area))\n    (check-within (candidate 3 4) 33 0.001)\n    (check-within (candidate 4 5) 56 0.001)\n    (check-within (candidate 1 2) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which returns nth catalan number.\n(define (catalan_number num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate catalan_number))\n    (check-within (candidate 10) 16796 0.001)\n    (check-within (candidate 9) 4862 0.001)\n    (check-within (candidate 7) 429 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the first adverb ending with ly and its positions in a given string.\n(define (find_adverbs text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverbs))\n    (check-within (candidate \"Clearly, he has no excuse for such behavior.\") \"0-7: Clearly\" 0.001)\n    (check-within (candidate \"Please handle the situation carefuly\") \"28-36: carefuly\" 0.001)\n    (check-within (candidate \"Complete the task quickly\") \"18-25: quickly\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n most expensive items in a given dataset.\n(define (expensive_items items n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate expensive_items))\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09))) 2) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09)) #hash((\"name\" .  \"Item-4\") (\"price\" .  22.75))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to split a list at the nth eelment and add the first part to the end.\n(define (split_Arr l n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_Arr))\n    (check-within (candidate (list 12 10 5 6 52 36) 2) (list 5 6 52 36 12 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) 1) (list 2 3 4 1) 0.001)\n    (check-within (candidate (list 0 1 2 3 4 5 6 7) 3) (list 3 4 5 6 7 0 1 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a list to a tuple.\n(define (list_tuple listx)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_tuple))\n    (check-within (candidate (list 5 10 7 4 15 3)) (list 5 10 7 4 15 3) 0.001)\n    (check-within (candidate (list 2 4 5 6 2 3 4 4 7)) (list 2 4 5 6 2 3 4 4 7) 0.001)\n    (check-within (candidate (list 58 44 56)) (list 58 44 56) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the difference between largest and smallest value in a given list.\n(define (big_diff nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_diff))\n    (check-within (candidate (list 1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 4 5 12)) 8 0.001)\n    (check-within (candidate (list 9 2 3)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find perfect squares between two given numbers.\n(define (perfect_squares a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perfect_squares))\n    (check-within (candidate 1 30) (list 1 4 9 16 25) 0.001)\n    (check-within (candidate 50 100) (list 64 81 100) 0.001)\n    (check-within (candidate 100 200) (list 100 121 144 169 196) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given two integers have opposite sign or not.\n(define (opposite_Signs x y)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate opposite_Signs))\n    (check-within (candidate 1 -2) #t 0.001)\n    (check-within (candidate 3 2) #f 0.001)\n    (check-within (candidate -10 -10) #f 0.001)\n    (check-within (candidate -2 2) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to interchange the first and last elements in a list.\n(define (swap_List newList)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 12 35 9 56 24)) (list 24 35 9 56 12) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of the product of consecutive binomial co-efficients.\n(define (sum_Of_product n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_product))\n    (check-within (candidate 3) 15 0.001)\n    (check-within (candidate 4) 56 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove leading zeroes from an ip address.\n(define (removezero_ip ip)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate removezero_ip))\n    (check-within (candidate \"216.08.094.196\") \"216.8.94.196\" 0.001)\n    (check-within (candidate \"12.01.024\") \"12.1.24\" 0.001)\n    (check-within (candidate \"216.08.094.0196\") \"216.8.94.196\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the difference of the first even and first odd number of a given list.\n(define (diff_even_odd list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate diff_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 1 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n(define (min_Swaps str1 str2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Swaps))\n    (check-within (candidate \"1101\" \"1110\") 1 0.001)\n    (check-within (candidate \"111\" \"000\") \"Not Possible\" 0.001)\n    (check-within (candidate \"111\" \"110\") \"Not Possible\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find kth element from the given two sorted arrays.\n(define (find_kth arr1 arr2 k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_kth))\n    (check-within (candidate (list 2 3 6 7 9) (list 1 4 8 10) 5) 6 0.001)\n    (check-within (candidate (list 100 112 256 349 770) (list 72 86 113 119 265 445 892) 7) 256 0.001)\n    (check-within (candidate (list 3 4 7 8 10) (list 2 5 9 11) 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is armstrong or not.\n(define (armstrong_number number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate armstrong_number))\n    (check-within (candidate 153) #t 0.001)\n    (check-within (candidate 259) #f 0.001)\n    (check-within (candidate 4458) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find sum and average of first n natural numbers.\n(define (sum_average number)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_average))\n    (check-within (candidate 10) (list 55 5.5) 0.001)\n    (check-within (candidate 15) (list 120 8.0) 0.001)\n    (check-within (candidate 20) (list 210 10.5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth octagonal number.\n(define (is_octagonal n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_octagonal))\n    (check-within (candidate 5) 65 0.001)\n    (check-within (candidate 10) 280 0.001)\n    (check-within (candidate 15) 645 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number is even or not.\n(define (is_Even n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Even))\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 2) #t 0.001)\n    (check-within (candidate 3) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the first repeated character in a given string.\n(define (first_repeated_char str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_repeated_char))\n    (check-within (candidate \"abcabc\") \"a\" 0.001)\n    (check-within (candidate \"abc\") #f 0.001)\n    (check-within (candidate \"123123\") \"1\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get all lucid numbers smaller than or equal to a given integer.\n(define (get_ludic n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_ludic))\n    (check-within (candidate 10) (list 1 2 3 5 7) 0.001)\n    (check-within (candidate 25) (list 1 2 3 5 7 11 13 17 23 25) 0.001)\n    (check-within (candidate 45) (list 1 2 3 5 7 11 13 17 23 25 29 37 41 43) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to reverse words seperated by spaces in a given string.\n(define (reverse_words s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_words))\n    (check-within (candidate \"python program\") \"program python\" 0.001)\n    (check-within (candidate \"java language\") \"language java\" 0.001)\n    (check-within (candidate \"indian man\") \"man indian\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given integer is a prime number.\n(define (prime_num num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_num))\n    (check-within (candidate 13) #t 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate -1010) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert degrees to radians.\n(define (radian_degree degree)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate radian_degree))\n    (check-within (candidate 90) 1.5707963267948966 0.001)\n    (check-within (candidate 60) 1.0471975511965976 0.001)\n    (check-within (candidate 120) 2.0943951023931953 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n(define (find_literals text pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_literals))\n    (check-within (candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") (list \"fox\" 16 19) 0.001)\n    (check-within (candidate \"Its been a very crazy procedure right\" \"crazy\") (list \"crazy\" 16 21) 0.001)\n    (check-within (candidate \"Hardest choices required strongest will\" \"will\") (list \"will\" 35 39) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find nth bell number.\n(define (bell_Number n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_Number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 15 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n(define (remove_kth_element list1 L)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_kth_element))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list 1 1 3 4 4 5 1) 0.001)\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4) 4) (list 0 0 1 3 4 4 5 6 6 6 7 8 9 4 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10) 5) (list 10 10 15 19 18 17 26 26 17 18 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n(define (max_of_nth test_list N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_of_nth))\n    (check-within (candidate (list (list 5 6 7) (list 1 3 5) (list 8 9 19)) 2) 19 0.001)\n    (check-within (candidate (list (list 6 7 8) (list 2 4 6) (list 9 10 20)) 1) 10 0.001)\n    (check-within (candidate (list (list 7 8 9) (list 3 5 7) (list 10 11 21)) 1) 11 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n(define (merge lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"a\" \"b\") (list \"m\" \"n\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\")) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6) (list 7 8))) (list (list 1 3 5 7) (list 2 4 6 8)) 0.001)\n    (check-within (candidate (list (list \"x\" \"y\" \"z\") (list \"a\" \"b\" \"c\") (list \"m\" \"n\" \"o\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\") (list \"z\" \"c\" \"o\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n(define (cummulative_sum test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cummulative_sum))\n    (check-within (candidate (list (list 1 3) (list 5 6 7) (list 2 6))) 30 0.001)\n    (check-within (candidate (list (list 2 4) (list 6 7 8) (list 3 7))) 37 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8 9) (list 4 8))) 44 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n(define (average_tuple nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate average_tuple))\n    (check-within (candidate (list (list 10 10 10 12) (list 30 45 56 45) (list 81 80 39 32) (list 1 2 3 4))) (list 30.5 34.25 27.0 23.25) 0.001)\n    (check-within (candidate (list (list 1 1 -5) (list 30 -15 56) (list 81 -60 -39) (list -10 2 3))) (list 25.5 -18.0 3.75) 0.001)\n    (check-within (candidate (list (list 100 100 100 120) (list 300 450 560 450) (list 810 800 390 320) (list 10 20 30 40))) (list 305.0 342.5 270.0 232.5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which takes two tuples of the same length and performs the element wise modulo.\n(define (tuple_modulo test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_modulo))\n    (check-within (candidate (list 10 4 5 6) (list 5 6 7 5)) (list 0 4 5 1) 0.001)\n    (check-within (candidate (list 11 5 6 7) (list 6 7 8 6)) (list 5 5 6 1) 0.001)\n    (check-within (candidate (list 12 6 7 8) (list 7 8 9 7)) (list 5 6 7 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n(define (min_Jumps steps d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Jumps))\n    (check-within (candidate (list 3 4) 11) 3.5 0.001)\n    (check-within (candidate (list 3 4) 0) 0 0.001)\n    (check-within (candidate (list 11 14) 11) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to divide two lists element wise.\n(define (div_list nums1 nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate div_list))\n    (check-within (candidate (list 4 5 6) (list 1 2 3)) (list 4.0 2.5 2.0) 0.001)\n    (check-within (candidate (list 3 2) (list 1 4)) (list 3.0 0.5) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 1.8 1.7142857142857142) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to move all the numbers to the end of the given string.\n(define (move_num test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_num))\n    (check-within (candidate \"I1love143you55three3000thousand\") \"Iloveyouthreethousand1143553000\" 0.001)\n    (check-within (candidate \"Avengers124Assemble\") \"AvengersAssemble124\" 0.001)\n    (check-within (candidate \"Its11our12path13to14see15things16do17things\") \"Itsourpathtoseethingsdothings11121314151617\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of substrings with the sum of digits equal to their length.\n(define (count_Substrings s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Substrings))\n    (check-within (candidate \"112112\") 6 0.001)\n    (check-within (candidate \"111\") 6 0.001)\n    (check-within (candidate \"1101112\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median of two sorted lists of same size.\n(define (get_median arr1 arr2 n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_median))\n    (check-within (candidate (list 1 12 15 26 38) (list 2 13 17 30 45) 5) 16.0 0.001)\n    (check-within (candidate (list 2 4 8 9) (list 7 13 19 28) 4) 8.5 0.001)\n    (check-within (candidate (list 3 6 14 23 36 42) (list 2 18 27 39 49 55) 6) 25.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to compute the n-th power of each number in a list.\n(define (nth_nums nums n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate nth_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30) 3) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15) 5) (list 248832 759375) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to convert a given string to uppercase.\n(define (is_upper string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_upper))\n    (check-within (candidate \"person\") \"PERSON\" 0.001)\n    (check-within (candidate \"final\") \"FINAL\" 0.001)\n    (check-within (candidate \"Valid\") \"VALID\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to interchange the first and last element in a given list.\n(define (swap_List newList)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) (list 4 2 3 4 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n(define (triangle_area r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate -1) #f 0.001)\n    (check-within (candidate 0) 0 0.001)\n    (check-within (candidate 2) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the smallest missing number from a sorted list of natural numbers.\n(define (find_First_Missing array)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_First_Missing))\n    (check-within (candidate (list 0 1 2 3)) 4 0.001)\n    (check-within (candidate (list 0 1 2 6 9)) 3 0.001)\n    (check-within (candidate (list 2 3 5 8 9)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace all spaces in the given string with '%20'.\n(define (replace_spaces string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"My Name is Dawood\") \"My%20Name%20is%20Dawood\" 0.001)\n    (check-within (candidate \"I am a Programmer\") \"I%20am%20a%20Programmer\" 0.001)\n    (check-within (candidate \"I love Coding\") \"I%20love%20Coding\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find even numbers from a list of numbers.\n(define (Split list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5)) (list 2 4) 0.001)\n    (check-within (candidate (list 4 5 6 7 8 0 1)) (list 4 6 8 0) 0.001)\n    (check-within (candidate (list 8 12 15 19)) (list 8 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find smallest number in a list.\n(define (smallest_num xs)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_num))\n    (check-within (candidate (list 10 20 1 45 99)) 1 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n    (check-within (candidate (list 45 46 50 60)) 45 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n(define (get_coordinates test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_coordinates))\n    (check-within (candidate (list 3 4)) (list (list 2 3) (list 2 4) (list 2 5) (list 3 3) (list 3 4) (list 3 5) (list 4 3) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 4 5)) (list (list 3 4) (list 3 5) (list 3 6) (list 4 4) (list 4 5) (list 4 6) (list 5 4) (list 5 5) (list 5 6)) 0.001)\n    (check-within (candidate (list 5 6)) (list (list 4 5) (list 4 6) (list 4 7) (list 5 5) (list 5 6) (list 5 7) (list 6 5) (list 6 6) (list 6 7)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace whitespaces with an underscore and vice versa in a given string.\n(define (replace_spaces text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"Jumanji The Jungle\") \"Jumanji_The_Jungle\" 0.001)\n    (check-within (candidate \"The_Avengers\") \"The Avengers\" 0.001)\n    (check-within (candidate \"Fast and Furious\") \"Fast_and_Furious\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to move all zeroes to the end of the given list.\n(define (move_zero num_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_zero))\n    (check-within (candidate (list 1 0 2 0 3 4)) (list 1 2 3 4 0 0) 0.001)\n    (check-within (candidate (list 2 3 2 0 0 4 0 5 0)) (list 2 3 2 4 5 0 0 0 0) 0.001)\n    (check-within (candidate (list 0 1 0 1 1)) (list 1 1 1 0 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of xor of all pairs of numbers in the given list.\n(define (pair_xor_Sum arr n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_xor_Sum))\n    (check-within (candidate (list 5 9 7 6) 4) 47 0.001)\n    (check-within (candidate (list 7 3 5) 3) 12 0.001)\n    (check-within (candidate (list 7 3) 2) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort the given list.\n(define (heap_sort iterable)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_sort))\n    (check-within (candidate (list 1 3 5 7 9 2 4 6 8 0)) (list 0 1 2 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 25 58)) (list 14 22 25 25 35 58 65 75 85) 0.001)\n    (check-within (candidate (list 7 1 9 5)) (list 1 5 7 9) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given amount has no profit and no loss\n(define (noprofit_noloss actual_cost sale_amount)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate noprofit_noloss))\n    (check-within (candidate 1500 1200) #f 0.001)\n    (check-within (candidate 100 100) #t 0.001)\n    (check-within (candidate 2000 5000) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n(define (wind_chill v t)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate wind_chill))\n    (check-within (candidate 120 35) 40 0.001)\n    (check-within (candidate 40 20) 19 0.001)\n    (check-within (candidate 10 8) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n(define (sample_nam sample_names)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sample_nam))\n    (check-within (candidate (list \"sally\" \"Dylan\" \"rebecca\" \"Diana\" \"Joanne\" \"keith\")) 16 0.001)\n    (check-within (candidate (list \"php\" \"res\" \"Python\" \"abcd\" \"Java\" \"aaa\")) 10 0.001)\n    (check-within (candidate (list \"abcd\" \"Python\" \"abba\" \"aba\")) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between available pairs in the given tuple list.\n(define (max_difference test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_difference))\n    (check-within (candidate (list (list 3 5) (list 1 7) (list 10 3) (list 1 2))) 7 0.001)\n    (check-within (candidate (list (list 4 6) (list 2 17) (list 9 13) (list 11 12))) 15 0.001)\n    (check-within (candidate (list (list 12 35) (list 21 27) (list 13 23) (list 41 22))) 23 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove the parenthesis and what is inbetween them from a string.\n(define (remove_parenthesis items)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_parenthesis))\n    (check-within (candidate (list \"python (chrome)\")) \"python\" 0.001)\n    (check-within (candidate (list \"string(.abc)\")) \"string\" 0.001)\n    (check-within (candidate (list \"alpha(num)\")) \"alpha\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth nonagonal number.\n(define (is_nonagonal n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nonagonal))\n    (check-within (candidate 10) 325 0.001)\n    (check-within (candidate 15) 750 0.001)\n    (check-within (candidate 18) 1089 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that checks if a strings contains 'z', except at the start and end of the word.\n(define (text_match_wordz_middle text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz_middle))\n    (check-within (candidate \"pythonzabc.\") #t 0.001)\n    (check-within (candidate \"zxyabc.\") #f 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to reverse an array upto a given position.\n(define (reverse_Array_Upto_K input k)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_Array_Upto_K))\n    (check-within (candidate (list 1 2 3 4 5 6) 4) (list 4 3 2 1 5 6) 0.001)\n    (check-within (candidate (list 4 5 6 7) 2) (list 5 4 6 7) 0.001)\n    (check-within (candidate (list 9 8 7 6 5) 3) (list 7 8 9 6 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of tuples using the second value of each tuple.\n(define (subject_marks subjectmarks)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate subject_marks))\n    (check-within (candidate (list (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97) (list \"Social sciences\" 82))) (list (list \"Social sciences\" 82) (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97)) 0.001)\n    (check-within (candidate (list (list \"Telugu\" 49) (list \"Hindhi\" 54) (list \"Social\" 33))) (list (list \"Social\" 33) (list \"Telugu\" 49) (list \"Hindhi\" 54)) 0.001)\n    (check-within (candidate (list (list \"Physics\" 96) (list \"Chemistry\" 97) (list \"Biology\" 45))) (list (list \"Biology\" 45) (list \"Physics\" 96) (list \"Chemistry\" 97)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to flatten a list and sum all of its elements.\n(define (recursive_list_sum data_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate recursive_list_sum))\n    (check-within (candidate (list 1 2 (list 3 4) (list 5 6))) 21 0.001)\n    (check-within (candidate (list 7 10 (list 15 14) (list 19 41))) 106 0.001)\n    (check-within (candidate (list 10 20 (list 30 40) (list 50 60))) 210 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of positive numbers in a list.\n(define (pos_count list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pos_count))\n    (check-within (candidate (list 1 -2 3 -4)) 2 0.001)\n    (check-within (candidate (list 3 4 5 -1)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4)) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the number of ways to partition a set of Bell numbers.\n(define (bell_number n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 10) 115975 0.001)\n    (check-within (candidate 56) 6775685320645824322581483068371419745979053216268760300 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given array is monotonic or not.\n(define (is_Monotonic A)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Monotonic))\n    (check-within (candidate (list 6 5 4 4)) #t 0.001)\n    (check-within (candidate (list 1 2 2 3)) #t 0.001)\n    (check-within (candidate (list 1 3 2)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a list contains the given sublist or not.\n(define (is_sublist l s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sublist))\n    (check-within (candidate (list 2 4 3 5 7) (list 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 4 3)) #t 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 1 6)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the two numbers differ at one bit position only or not.\n(define (differ_At_One_Bit_Pos a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate differ_At_One_Bit_Pos))\n    (check-within (candidate 13 9) #t 0.001)\n    (check-within (candidate 15 8) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 2 3) #t 0.001)\n    (check-within (candidate 5 1) #t 0.001)\n    (check-within (candidate 1 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find whether all the given lists have equal length or not.\n(define (get_equal Input)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_equal))\n    (check-within (candidate (list (list 11 22 33) (list 44 55 66))) #t 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6 7))) #f 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4))) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (comb_sort nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate comb_sort))\n    (check-within (candidate (list 5 15 37 25 79)) (list 5 15 25 37 79) 0.001)\n    (check-within (candidate (list 41 32 15 19 22)) (list 15 19 22 32 41) 0.001)\n    (check-within (candidate (list 99 15 13 47)) (list 13 15 47 99) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to add a dictionary to the tuple. The output should be a tuple.\n(define (add_dict_to_tuple test_tup test_dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_dict_to_tuple))\n    (check-within (candidate (list 4 5 6) #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) (list 4 5 6 #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) 0.001)\n    (check-within (candidate (list 1 2 3) #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) (list 1 2 3 #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) 0.001)\n    (check-within (candidate (list 8 9 10) #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) (list 8 9 10 #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n(define (maxAverageOfPath cost)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maxAverageOfPath))\n    (check-within (candidate (list (list 1 2 3) (list 6 5 4) (list 7 3 9))) 5.2 0.001)\n    (check-within (candidate (list (list 2 3 4) (list 7 6 5) (list 8 4 10))) 6.2 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 8 7 6) (list 9 5 11))) 7.2 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9))) 5.8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n(define (filter_data students h w)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_data))\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 6.0 70) #hash((\"Cierra Vega\" .  (list 6.2 70))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.9 67) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Kierra Gentry\" .  (list 6.0 68))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.7 64) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n(define (count_same_pair nums1 nums2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_same_pair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9)) 4 0.001)\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 11 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 1 0.001)\n    (check-within (candidate (list 0 1 1 2) (list 0 1 2 2)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n(define (power_base_sum base power)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power_base_sum))\n    (check-within (candidate 2 100) 115 0.001)\n    (check-within (candidate 8 10) 37 0.001)\n    (check-within (candidate 8 15) 62 0.001)\n    (check-within (candidate 3 3) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks \" \" of the given string.\n(define (extract_quotation text1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_quotation))\n    (check-within (candidate \"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\") (list \"A53\" \"multi\" \"Processor\") 0.001)\n    (check-within (candidate \"Cast your \"favorite\" entertainment \"apps\"\") (list \"favorite\" \"apps\") 0.001)\n    (check-within (candidate \"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\") (list \"4k Ultra HD\" \"HDR 10\") 0.001)\n    (check-within (candidate \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n(define (multiply_elements test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_elements))\n    (check-within (candidate (list 1 5 7 8 10)) (list 5 35 56 80) 0.001)\n    (check-within (candidate (list 2 4 5 6 7)) (list 8 20 30 42) 0.001)\n    (check-within (candidate (list 12 13 14 9 15)) (list 156 182 126 135) 0.001)\n    (check-within (candidate (list 12)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n(define (sum_list lst1 lst2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_list))\n    (check-within (candidate (list 10 20 30) (list 15 25 35)) (list 25 45 65) 0.001)\n    (check-within (candidate (list 1 2 3) (list 5 6 7)) (list 6 8 10) 0.001)\n    (check-within (candidate (list 15 20 30) (list 15 45 75)) (list 30 65 105) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the given number can be represented as the difference of two squares or not.\n(define (dif_Square n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dif_Square))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 15) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove consecutive duplicates of a given list.\n(define (consecutive_duplicates nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list 0 1 2 3 4 5 6 7 8 9 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list 10 15 19 18 17 26 17 18 10) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list \"a\" \"b\" \"c\" \"d\") 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\" \"a\" \"a\")) (list \"a\" \"b\" \"c\" \"d\" \"a\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cone given radius r and the height h.\n(define (lateralsurface_cone r h)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cone))\n    (check-within (candidate 5 12) 204.20352248333654 0.001)\n    (check-within (candidate 10 15) 566.3586699569488 0.001)\n    (check-within (candidate 19 17) 1521.8090132193388 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n(define (replace_specialchar text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_specialchar))\n    (check-within (candidate \"Python language, Programming language.\") \"Python:language::Programming:language:\" 0.001)\n    (check-within (candidate \"a b c,d e f\") \"a:b:c:d:e:f\" 0.001)\n    (check-within (candidate \"ram reshma,ram rahim\") \"ram:reshma:ram:rahim\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the index of the first occurrence of a given number in a sorted array.\n(define (find_first_occurrence A x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_first_occurrence))\n    (check-within (candidate (list 2 5 5 5 6 6 8 9 9 9) 5) 1 0.001)\n    (check-within (candidate (list 2 3 5 5 6 6 8 9 9 9) 5) 2 0.001)\n    (check-within (candidate (list 2 4 1 5 6 6 8 9 9 9) 6) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n(define (sum_Of_Subarray_Prod arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_Subarray_Prod))\n    (check-within (candidate (list 1 2 3)) 20 0.001)\n    (check-within (candidate (list 1 2)) 5 0.001)\n    (check-within (candidate (list 1 2 3 4)) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n(define (toggle_middle_bits n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_middle_bits))\n    (check-within (candidate 9) 15 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 11) 13 0.001)\n    (check-within (candidate 65) 127 0.001)\n    (check-within (candidate 77) 115 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n(define (left_insertion a x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given string is starting with a vowel or not using regex.\n(define (check_str string)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_str))\n    (check-within (candidate \"annie\") #t 0.001)\n    (check-within (candidate \"dawood\") #f 0.001)\n    (check-within (candidate \"Else\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n(define (geometric_sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate geometric_sum))\n    (check-within (candidate 7) 1.9921875 0.001)\n    (check-within (candidate 4) 1.9375 0.001)\n    (check-within (candidate 8) 1.99609375 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n(define (find_Index n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Index))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 14 0.001)\n    (check-within (candidate 4) 45 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n(define (tuple_to_dict test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_dict))\n    (check-within (candidate (list 1 5 7 10 13 5)) #hash((1 .  5) (7 .  10) (13 .  5)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #hash((1 .  2) (3 .  4) (5 .  6)) 0.001)\n    (check-within (candidate (list 7 8 9 10 11 12)) #hash((7 .  8) (9 .  10) (11 .  12)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether all the characters are same or not.\n(define (all_Characters_Same s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Characters_Same))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"aaa\") #t 0.001)\n    (check-within (candidate \"data\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to caluclate the area of a tetrahedron.\n(define (area_tetrahedron side)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate area_tetrahedron))\n    (check-within (candidate 3) 15.588457268119894 0.001)\n    (check-within (candidate 20) 692.8203230275509 0.001)\n    (check-within (candidate 10) 173.20508075688772 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n(define (rotate_right list m)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rotate_right))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 3) (list 8 9 10 1 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 9 10 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 5) (list 6 7 8 9 10 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given tuple has any none value or not.\n(define (check_none test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_none))\n    (check-within (candidate (list 10 4 5 6 #f)) #t 0.001)\n    (check-within (candidate (list 7 8 9 11 14)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 #f)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n(define (divisible_by_digits startnum endnum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisible_by_digits))\n    (check-within (candidate 1 22) (list 1 2 3 4 5 6 7 8 9 11 12 15 22) 0.001)\n    (check-within (candidate 1 15) (list 1 2 3 4 5 6 7 8 9 11 12 15) 0.001)\n    (check-within (candidate 20 25) (list 22 24) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n(define (sector_area r a)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sector_area))\n    (check-within (candidate 4 45) 6.283185307179586 0.001)\n    (check-within (candidate 9 45) 31.808625617596654 0.001)\n    (check-within (candidate 9 361) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n(define (lcs_of_three X Y Z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lcs_of_three))\n    (check-within (candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") 2 0.001)\n    (check-within (candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") 5 0.001)\n    (check-within (candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to put spaces between words starting with capital letters in a given string.\n(define (capital_words_spaces str1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate capital_words_spaces))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"PythonProgrammingExamples\") \"Python Programming Examples\" 0.001)\n    (check-within (candidate \"GetReadyToBeCodingFreak\") \"Get Ready To Be Coding Freak\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n(define (sort_numeric_strings nums_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numeric_strings))\n    (check-within (candidate (list \"4\" \"12\" \"45\" \"7\" \"0\" \"100\" \"200\" \"-12\" \"-500\")) (list -500 -12 0 4 7 12 45 100 200) 0.001)\n    (check-within (candidate (list \"2\" \"3\" \"8\" \"4\" \"7\" \"9\" \"8\" \"2\" \"6\" \"5\" \"1\" \"6\" \"1\" \"2\" \"3\" \"4\" \"6\" \"9\" \"1\" \"2\")) (list 1 1 1 2 2 2 2 3 3 4 4 5 6 6 6 7 8 8 9 9) 0.001)\n    (check-within (candidate (list \"1\" \"3\" \"5\" \"7\" \"1\" \"3\" \"13\" \"15\" \"17\" \"5\" \"7 \" \"9\" \"1\" \"11\")) (list 1 1 1 3 3 5 5 7 7 9 11 13 15 17) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether it follows the sequence given in the patterns array.\n(define (is_samepatterns colors patterns)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_samepatterns))\n    (check-within (candidate (list \"red\" \"green\" \"green\") (list \"a\" \"b\" \"b\")) #t 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\" \"b\")) #f 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\")) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to add the given tuple to the given list.\n(define (add_tuple test_list test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_tuple))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 5 6 7 9 10) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 6 7 8 10 11) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 7 8 9 11 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n(define (check_min_heap arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_min_heap))\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 10 15)) #t 0.001)\n    (check-within (candidate (list 2 10 4 5 3 15)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n(define (jacobsthal_num n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate jacobsthal_num))\n    (check-within (candidate 5) 11 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 5 0.001)\n    (check-within (candidate 13) 2731 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n(define (min_k test_list K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_k))\n    (check-within (candidate (list (list \"Manjeet\" 10) (list \"Akshat\" 4) (list \"Akash\" 2) (list \"Nikhil\" 8)) 2) (list (list \"Akash\" 2) (list \"Akshat\" 4)) 0.001)\n    (check-within (candidate (list (list \"Sanjeev\" 11) (list \"Angat\" 5) (list \"Akash\" 3) (list \"Nepin\" 9)) 3) (list (list \"Akash\" 3) (list \"Angat\" 5) (list \"Nepin\" 9)) 0.001)\n    (check-within (candidate (list (list \"tanmay\" 14) (list \"Amer\" 11) (list \"Ayesha\" 9) (list \"SKD\" 16)) 1) (list (list \"Ayesha\" 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n(define (extract_index_list l1 l2 l3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_index_list))\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 7) 0.001)\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 6 5) (list 0 1 2 3 4 6 7)) (list 1 6) 0.001)\n    (check-within (candidate (list 1 1 3 4 6 5 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 6 6 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the second smallest number in a list.\n(define (second_smallest numbers)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate second_smallest))\n    (check-within (candidate (list 1 2 -8 -2 0 -2)) -2 0.001)\n    (check-within (candidate (list 1 1 -0.5 0 2 -2 -2)) -0.5 0.001)\n    (check-within (candidate (list 2 2)) #f 0.001)\n    (check-within (candidate (list 2 2 2)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n(define (text_match_zero_one text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_zero_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"dsabbbba\") #t 0.001)\n    (check-within (candidate \"asbbbba\") #f 0.001)\n    (check-within (candidate \"abaaa\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n(define (count_reverse_pairs test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_reverse_pairs))\n    (check-within (candidate (list \"julia\" \"best\" \"tseb\" \"for\" \"ailuj\")) 2 0.001)\n    (check-within (candidate (list \"geeks\" \"best\" \"for\" \"skeeg\")) 1 0.001)\n    (check-within (candidate (list \"makes\" \"best\" \"sekam\" \"for\" \"rof\")) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a given string is a decimal number with a precision of 2.\n(define (is_decimal num)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_decimal))\n    (check-within (candidate \"123.11\") #t 0.001)\n    (check-within (candidate \"e666.86\") #f 0.001)\n    (check-within (candidate \"3.124587\") #f 0.001)\n    (check-within (candidate \"1.11\") #t 0.001)\n    (check-within (candidate \"1.1.11\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n(define (find_tuples test_list K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_tuples))\n    (check-within (candidate (list (list 6 24 12) (list 7 9 6) (list 12 18 21)) 6) (list (list 6 24 12)) 0.001)\n    (check-within (candidate (list (list 5 25 30) (list 4 2 3) (list 7 8 9)) 5) (list (list 5 25 30)) 0.001)\n    (check-within (candidate (list (list 7 9 16) (list 8 16 4) (list 19 17 18)) 4) (list (list 8 16 4)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether a list of numbers contains only one distinct element or not.\n(define (unique_Element arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_Element))\n    (check-within (candidate (list 1 1 1)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n(define (check_monthnumber_number monthnum3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumber_number))\n    (check-within (candidate 6) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 12) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n(define (find_min_diff arr n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_min_diff))\n    (check-within (candidate (list 1 5 3 19 18 25) 6) 1 0.001)\n    (check-within (candidate (list 4 3 2 6) 4) 1 0.001)\n    (check-within (candidate (list 30 5 20 9) 4) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count number of digits in a given string.\n(define (number_ctr str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_ctr))\n    (check-within (candidate \"program2bedone\") 1 0.001)\n    (check-within (candidate \"3wonders\") 1 0.001)\n    (check-within (candidate \"123\") 3 0.001)\n    (check-within (candidate \"3wond-1ers2\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n(define (is_polite n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_polite))\n    (check-within (candidate 7) 11 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 9) 13 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return a list of all pairs of consecutive items in a given list.\n(define (pair_wise l1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_wise))\n    (check-within (candidate (list 1 1 2 3 3 4 4 5)) (list (list 1 1) (list 1 2) (list 2 3) (list 3 3) (list 3 4) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) (list (list 1 5) (list 5 7) (list 7 9) (list 9 10)) 0.001)\n    (check-within (candidate (list 5 1 9 7 10)) (list (list 5 1) (list 1 9) (list 9 7) (list 7 10)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list (list 1 2) (list 2 3) (list 3 4) (list 4 5) (list 5 6) (list 6 7) (list 7 8) (list 8 9) (list 9 10)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n(define (get_pairs_count arr sum)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_pairs_count))\n    (check-within (candidate (list 1 1 1 1) 2) 6 0.001)\n    (check-within (candidate (list 1 5 7 -1 5) 6) 3 0.001)\n    (check-within (candidate (list 1 -2 3) 1) 1 0.001)\n    (check-within (candidate (list -1 -2 3) -3) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to get the difference between two lists.\n(define (Diff li1 li2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Diff))\n    (check-within (candidate (list 10 15 20 25 30 35 40) (list 25 40 35)) (list 10 20 30 15) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 1)) (list 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3) (list 6 7 1)) (list 2 3 6 7) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of fourth power of first n odd natural numbers.\n(define (odd_num_sum n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_num_sum))\n    (check-within (candidate 2) 82 0.001)\n    (check-within (candidate 3) 707 0.001)\n    (check-within (candidate 4) 3108 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n(define (check_expression exp)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_expression))\n    (check-within (candidate \"{()}[{}]\") #t 0.001)\n    (check-within (candidate \"{()}[{]\") #f 0.001)\n    (check-within (candidate \"{()}[{}][]({})\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all the words with k length in the given string.\n(define (remove_length test_str K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_length))\n    (check-within (candidate \"The person is most value tet\" 3) \"person is most value\" 0.001)\n    (check-within (candidate \"If you told me about this ok\" 4) \"If you me about ok\" 0.001)\n    (check-within (candidate \"Forces of darkeness is come into the play\" 4) \"Forces of darkeness is the\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n(define (occurance_substring text pattern)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate occurance_substring))\n    (check-within (candidate \"python programming, python language\" \"python\") (list \"python\" 0 6) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"programming\") (list \"programming\" 7 18) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"language\") (list \"language\" 31 39) 0.001)\n    (check-within (candidate \"c++ programming, c++ language\" \"python\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether every odd index contains odd numbers of a given list.\n(define (odd_position nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_position))\n    (check-within (candidate (list 2 1 4 3 6 7 6 3)) #t 0.001)\n    (check-within (candidate (list 4 1 2)) #t 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count those characters which have vowels as their neighbors in the given string.\n(define (count_vowels test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_vowels))\n    (check-within (candidate \"bestinstareels\") 7 0.001)\n    (check-within (candidate \"partofthejourneyistheend\") 12 0.001)\n    (check-within (candidate \"amazonprime\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of non-repeated elements in a given list.\n(define (find_sum arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_sum))\n    (check-within (candidate (list 1 2 3 1 1 4 5 6)) 21 0.001)\n    (check-within (candidate (list 1 10 9 4 2 10 10 45 4)) 71 0.001)\n    (check-within (candidate (list 12 10 9 45 2 10 10 45 10)) 78 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to pack consecutive duplicates of a given list elements into sublists.\n(define (pack_consecutive_duplicates list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pack_consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list (list 0 0) (list 1) (list 2) (list 3) (list 4 4) (list 5) (list 6 6 6) (list 7) (list 8) (list 9) (list 4 4)) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list (list 10 10) (list 15) (list 19) (list 18 18) (list 17) (list 26 26) (list 17) (list 18) (list 10)) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list (list \"a\" \"a\") (list \"b\") (list \"c\") (list \"d\" \"d\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find whether a number is divisible by 11.\n(define (is_Diff n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Diff))\n    (check-within (candidate 12345) #f 0.001)\n    (check-within (candidate 1212112) #t 0.001)\n    (check-within (candidate 1212) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n(define (find_combinations test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_combinations))\n    (check-within (candidate (list (list 2 4) (list 6 7) (list 5 1) (list 6 10))) (list (list 8 11) (list 7 5) (list 8 14) (list 11 8) (list 12 17) (list 11 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8) (list 6 2) (list 7 11))) (list (list 10 13) (list 9 7) (list 10 16) (list 13 10) (list 14 19) (list 13 13)) 0.001)\n    (check-within (candidate (list (list 4 6) (list 8 9) (list 7 3) (list 8 12))) (list (list 12 15) (list 11 9) (list 12 18) (list 15 12) (list 16 21) (list 15 15)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n(define (count_divisors n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_divisors))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 100) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n(define (odd_length_sum arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_length_sum))\n    (check-within (candidate (list 1 2 4)) 14 0.001)\n    (check-within (candidate (list 1 2 1 2)) 15 0.001)\n    (check-within (candidate (list 1 7)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n(define (rgb_to_hsv r g b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rgb_to_hsv))\n    (check-within (candidate 255 255 255) (list 0.0 0.0 100.0) 0.001)\n    (check-within (candidate 0 215 0) (list 120.0 100.0 84.31372549019608) 0.001)\n    (check-within (candidate 10 215 110) (list 149.26829268292684 95.34883720930233 84.31372549019608) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the product of first even and odd number of a given list.\n(define (mul_even_odd list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mul_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert tuple string to integer tuple.\n(define (tuple_str_int test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_str_int))\n    (check-within (candidate \"(7, 8, 9)\") (list 7 8 9) 0.001)\n    (check-within (candidate \"(1, 2, 3)\") (list 1 2 3) 0.001)\n    (check-within (candidate \"(4, 5, 6)\") (list 4 5 6) 0.001)\n    (check-within (candidate \"(7, 81, 19)\") (list 7 81 19) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to locate the right insertion point for a specified value in sorted order.\n(define (right_insertion a x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by three 'b'.\n(define (text_match_three text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"caacabbbba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create a new tuple from the given string and list.\n(define (new_tuple test_list test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate new_tuple))\n    (check-within (candidate (list \"WEB\" \"is\") \"best\") (list \"WEB\" \"is\" \"best\") 0.001)\n    (check-within (candidate (list \"We\" \"are\") \"Developers\") (list \"We\" \"are\" \"Developers\") 0.001)\n    (check-within (candidate (list \"Part\" \"is\") \"Wrong\") (list \"Part\" \"is\" \"Wrong\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether every even index contains even numbers of a given list.\n(define (even_position nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_position))\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n    (check-within (candidate (list 2 1 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove tuples from the given tuple.\n(define (remove_nested test_tup)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_nested))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) (list 1 5 7 10) 0.001)\n    (check-within (candidate (list 2 6 8 (list 5 7) 11)) (list 2 6 8 11) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) 12)) (list 3 7 9 12) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) (list 5 12) 12)) (list 3 7 9 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of lists in a given number of lists.\n(define (count_list input_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) 4 0.001)\n    (check-within (candidate (list (list 1 2) (list 2 3) (list 4 5))) 3 0.001)\n    (check-within (candidate (list (list 1 0) (list 2 0))) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the last position of an element in a sorted array.\n(define (last arr x)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last))\n    (check-within (candidate (list 1 2 3) 1) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 4) 1) 2 0.001)\n    (check-within (candidate (list 2 3 2 3 6 8 9) 3) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n(define (text_starta_endb text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_starta_endb))\n    (check-within (candidate \"aabbbb\") #t 0.001)\n    (check-within (candidate \"aabAbbbc\") #f 0.001)\n    (check-within (candidate \"accddbbjjj\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write function to find the sum of all items in the given dictionary.\n(define (return_sum dict)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate return_sum))\n    (check-within (candidate #hash((\"a\" .  100) (\"b\" .  200) (\"c\" .  300))) 600 0.001)\n    (check-within (candidate #hash((\"a\" .  25) (\"b\" .  18) (\"c\" .  45))) 88 0.001)\n    (check-within (candidate #hash((\"a\" .  36) (\"b\" .  39) (\"c\" .  49))) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of all odd natural numbers within the range l and r.\n(define (sum_in_range l r)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_in_range))\n    (check-within (candidate 2 5) 8 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 13) 40 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the sum of an array.\n(define (_sum arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate _sum))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 15 12 13 10)) 50 0.001)\n    (check-within (candidate (list 0 1 2)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n(define (left_rotate n d)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_rotate))\n    (check-within (candidate 16 2) 64 0.001)\n    (check-within (candidate 10 2) 40 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 1 3) 8 0.001)\n    (check-within (candidate 5 3) 40 0.001)\n    (check-within (candidate 29 3) 232 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to check whether the length of the word is odd or not.\n(define (word_len s)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate word_len))\n    (check-within (candidate \"Hadoop\") #f 0.001)\n    (check-within (candidate \"great\") #t 0.001)\n    (check-within (candidate \"structure\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from a string.\n(define (remove_all_spaces text)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_all_spaces))\n    (check-within (candidate \"python  program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"python   programming    language\") \"pythonprogramminglanguage\" 0.001)\n    (check-within (candidate \"python                     program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"   python                     program\") \"pythonprogram\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of equal numbers from three given integers.\n(define (test_three_equal x y z)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_three_equal))\n    (check-within (candidate 1 1 1) 3 0.001)\n    (check-within (candidate -1 -2 -3) 0 0.001)\n    (check-within (candidate 1 2 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n(define (count_rotation arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_rotation))\n    (check-within (candidate (list 3 2 1)) 1 0.001)\n    (check-within (candidate (list 4 5 1 2 3)) 2 0.001)\n    (check-within (candidate (list 7 8 9 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 2 3)) 0 0.001)\n    (check-within (candidate (list 1 3 2)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n(define (is_perfect_square n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_perfect_square))\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 36) #t 0.001)\n    (check-within (candidate 14) #f 0.001)\n    (check-within (candidate 196) #t 0.001)\n    (check-within (candidate 125) #f 0.001)\n    (check-within (candidate 15625) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the product of numbers in a list is even or not.\n(define (is_product_even arr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_product_even))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 4)) #t 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns the list in a list of lists whose sum of elements is the highest.\n(define (max_sum_list lists)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_list))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 10 11 12) 0.001)\n    (check-within (candidate (list (list 3 2 1) (list 6 5 4) (list 12 11 10))) (list 12 11 10) 0.001)\n    (check-within (candidate (list (list 2 3 1))) (list 2 3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find maximum run of uppercase characters in the given string.\n(define (max_run_uppercase test_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_run_uppercase))\n    (check-within (candidate \"GeMKSForGERksISBESt\") 5 0.001)\n    (check-within (candidate \"PrECIOusMOVemENTSYT\") 6 0.001)\n    (check-within (candidate \"GooGLEFluTTER\") 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the first odd number in a given list of numbers.\n(define (first_odd nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_odd))\n    (check-within (candidate (list 1 3 5)) 1 0.001)\n    (check-within (candidate (list 2 4 1 3)) 1 0.001)\n    (check-within (candidate (list 8 9 1)) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given tuples contain the k or not.\n(define (check_K test_tup K)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_K))\n    (check-within (candidate (list 10 4 5 6 8) 6) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) 7) #f 0.001)\n    (check-within (candidate (list 7 8 9 44 11 12) 11) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n(define (check_smaller test_tup1 test_tup2)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_smaller))\n    (check-within (candidate (list 1 2 3) (list 2 3 4)) #f 0.001)\n    (check-within (candidate (list 4 5 6) (list 3 4 5)) #t 0.001)\n    (check-within (candidate (list 11 12 13) (list 10 11 12)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth tetrahedral number.\n(define (tetrahedral_number n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tetrahedral_number))\n    (check-within (candidate 5) 35 0.001)\n    (check-within (candidate 6) 56 0.001)\n    (check-within (candidate 7) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n(define (get_Char strr)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Char))\n    (check-within (candidate \"abc\") \"f\" 0.001)\n    (check-within (candidate \"gfg\") \"t\" 0.001)\n    (check-within (candidate \"ab\") \"c\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth number in the newman conway sequence.\n(define (sequence n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequence))\n    (check-within (candidate 10) 6 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find nth centered hexagonal number.\n(define (centered_hexagonal_number n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate centered_hexagonal_number))\n    (check-within (candidate 10) 271 0.001)\n    (check-within (candidate 2) 7 0.001)\n    (check-within (candidate 9) 217 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to merge three dictionaries into a single dictionary.\n(define (merge_dictionaries_three dict1 dict2 dict3)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_dictionaries_three))\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"O\" .  \"Orange\") (\"W\" .  \"White\") (\"B\" .  \"Black\"))) #hash((\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"P\" .  \"Pink\") (\"G\" .  \"Green\") (\"W\" .  \"White\") (\"O\" .  \"Orange\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\"))) #hash((\"W\" .  \"White\") (\"P\" .  \"Pink\") (\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\"))) #hash((\"B\" .  \"Black\") (\"P\" .  \"Pink\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\") (\"W\" .  \"White\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n(define (freq_count list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate freq_count))\n    (check-within (candidate (list 10 10 10 10 20 20 20 20 40 40 50 50 30)) #hash((10 .  4) (20 .  4) (40 .  2) (50 .  2) (30 .  1)) 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 4 1 3 1 4)) #hash((1 .  3) (2 .  2) (3 .  3) (4 .  3)) 0.001)\n    (check-within (candidate (list 5 6 7 4 9 10 4 5 6 7 9 5)) #hash((10 .  1) (5 .  3) (6 .  2) (7 .  2) (4 .  2) (9 .  2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the closest smaller number than n.\n(define (closest_num N)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_num))\n    (check-within (candidate 11) 10 0.001)\n    (check-within (candidate 7) 6 0.001)\n    (check-within (candidate 12) 11 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find squares of individual elements in a list.\n(define (square_nums nums)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 100 400 900) 0.001)\n    (check-within (candidate (list 12 15)) (list 144 225) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the length of the longest word.\n(define (len_log list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate len_log))\n    (check-within (candidate (list \"python\" \"PHP\" \"bigdata\")) 7 0.001)\n    (check-within (candidate (list \"a\" \"ab\" \"abc\")) 3 0.001)\n    (check-within (candidate (list \"small\" \"big\" \"tall\")) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if a string is present as a substring in a given list of string values.\n(define (find_substring str1 sub_str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_substring))\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ack\") #t 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"abc\") #f 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ange\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is undulating or not.\n(define (is_undulating n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_undulating))\n    (check-within (candidate 1212121) #t 0.001)\n    (check-within (candidate 1991) #f 0.001)\n    (check-within (candidate 121) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the value of 'a' to the power 'b'.\n(define (power a b)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power))\n    (check-within (candidate 3 4) 81 0.001)\n    (check-within (candidate 2 3) 8 0.001)\n    (check-within (candidate 5 5) 3125 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n(define (index_minimum test_list)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_minimum))\n    (check-within (candidate (list (list \"Rash\" 143) (list \"Manjeet\" 200) (list \"Varsha\" 100))) \"Varsha\" 0.001)\n    (check-within (candidate (list (list \"Yash\" 185) (list \"Dawood\" 125) (list \"Sanya\" 175))) \"Dawood\" 0.001)\n    (check-within (candidate (list (list \"Sai\" 345) (list \"Salman\" 145) (list \"Ayesha\" 96))) \"Ayesha\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the length of the smallest list in a list of lists.\n(define (Find_Min_Length lst)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min_Length))\n    (check-within (candidate (list (list 1) (list 1 2))) 1 0.001)\n    (check-within (candidate (list (list 1 2) (list 1 2 3) (list 1 2 3 4))) 2 0.001)\n    (check-within (candidate (list (list 3 3 3) (list 4 4 4 4))) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the number of divisors of a given integer.\n(define (divisor n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisor))\n    (check-within (candidate 15) 4 0.001)\n    (check-within (candidate 12) 6 0.001)\n    (check-within (candidate 9) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n(define (frequency_lists list1)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency_lists))\n    (check-within (candidate (list (list 1 2 3 2) (list 4 5 6 2) (list 7 8 9 5))) #hash((1 .  1) (2 .  3) (3 .  1) (4 .  1) (5 .  2) (6 .  1) (7 .  1) (8 .  1) (9 .  1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12))) #hash((1 .  1) (2 .  1) (3 .  1) (4 .  1) (5 .  1) (6 .  1) (7 .  1) (8 .  1) (9 .  1) (10 .  1) (11 .  1) (12 .  1)) 0.001)\n    (check-within (candidate (list (list 20 30 40 17) (list 18 16 14 13) (list 10 20 30 40))) #hash((20 .  2) (30 .  2) (40 .  2) (17 .  1) (18 .  1) (16 .  1) (14 .  1) (13 .  1) (10 .  1)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n(define (decimal_to_binary n)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 8) \"1000\" 0.001)\n    (check-within (candidate 18) \"10010\" 0.001)\n    (check-within (candidate 7) \"111\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n(define (find_Rotations str)\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Rotations))\n    (check-within (candidate \"aaaa\") 1 0.001)\n    (check-within (candidate \"ab\") 2 0.001)\n    (check-within (candidate \"abc\") 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/mbpp-rkt-reworded.json
+++ b/prompts/mbpp-rkt-reworded.json
@@ -1,4422 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the length of the longest palindromic subsequence in the given string.\n(define (lps str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lps))\n    (check-within (candidate \"TENS FOR TENS\") 5 0.001)\n    (check-within (candidate \"CARDIO FOR CARDS\") 7 0.001)\n    (check-within (candidate \"PART OF THE JOURNEY IS PART\") 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from the given string.\n(define (remove_whitespaces text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_whitespaces))\n    (check-within (candidate \" Google    Flutter \") \"GoogleFlutter\" 0.001)\n    (check-within (candidate \" Google    Dart \") \"GoogleDart\" 0.001)\n    (check-within (candidate \" iOS    Swift \") \"iOSSwift\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a specified list is sorted or not.\n(define (issort_list list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate issort_list))\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 16 17)) #t 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 20 17)) #f 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 15 14 20)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count bidirectional list pairs.\n(define (count_bidirectional test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_bidirectional))\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 3 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 3) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 2 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 2) (list 6 5) (list 2 1))) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cube of a given size.\n(define (surfacearea_cube l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cube))\n    (check-within (candidate 5) 150 0.001)\n    (check-within (candidate 3) 54 0.001)\n    (check-within (candidate 10) 600 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n(define (next_smallest_palindrome num)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_smallest_palindrome))\n    (check-within (candidate 99) 101 0.001)\n    (check-within (candidate 1221) 1331 0.001)\n    (check-within (candidate 120) 121 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the cube sum of first n even natural numbers.\n(define (cube_Sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_Sum))\n    (check-within (candidate 2) 72 0.001)\n    (check-within (candidate 3) 288 0.001)\n    (check-within (candidate 4) 800 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of xor of all pairs of numbers in the given list.\n(define (pair_xor_Sum arr n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_xor_Sum))\n    (check-within (candidate (list 5 9 7 6) 4) 47 0.001)\n    (check-within (candidate (list 7 3 5) 3) 12 0.001)\n    (check-within (candidate (list 7 3) 2) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n(define (check_min_heap arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_min_heap))\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 10 15)) #t 0.001)\n    (check-within (candidate (list 2 10 4 5 3 15)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first digit of a given number.\n(define (first_Digit n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_Digit))\n    (check-within (candidate 123) 1 0.001)\n    (check-within (candidate 456) 4 0.001)\n    (check-within (candidate 12) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first non-repeated character in a given string.\n(define (first_non_repeating_character str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_non_repeating_character))\n    (check-within (candidate \"abcabc\") #f 0.001)\n    (check-within (candidate \"abc\") \"a\" 0.001)\n    (check-within (candidate \"ababc\") \"c\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert degrees to radians.\n(define (radian_degree degree)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate radian_degree))\n    (check-within (candidate 90) 1.5707963267948966 0.001)\n    (check-within (candidate 60) 1.0471975511965976 0.001)\n    (check-within (candidate 120) 2.0943951023931953 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum product sublist of the given list.\n(define (max_subarray_product arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_subarray_product))\n    (check-within (candidate (list 1 -2 -3 0 7 -8 -2)) 112 0.001)\n    (check-within (candidate (list 6 -3 -10 0 2)) 180 0.001)\n    (check-within (candidate (list -2 -40 0 -2 -3)) 80 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert more than one list to nested hash.\n(define (convert_list_dictionary l1 l2 l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert_list_dictionary))\n    (check-within (candidate (list \"S001\" \"S002\" \"S003\" \"S004\") (list \"Adina Park\" \"Leyton Marsh\" \"Duncan Boyle\" \"Saim Richards\") (list 85 98 89 92)) (list #hash((\"S001\" .  #hash((\"Adina Park\" .  85)))) #hash((\"S002\" .  #hash((\"Leyton Marsh\" .  98)))) #hash((\"S003\" .  #hash((\"Duncan Boyle\" .  89)))) #hash((\"S004\" .  #hash((\"Saim Richards\" .  92))))) 0.001)\n    (check-within (candidate (list \"abc\" \"def\" \"ghi\" \"jkl\") (list \"python\" \"program\" \"language\" \"programs\") (list 100 200 300 400)) (list #hash((\"abc\" .  #hash((\"python\" .  100)))) #hash((\"def\" .  #hash((\"program\" .  200)))) #hash((\"ghi\" .  #hash((\"language\" .  300)))) #hash((\"jkl\" .  #hash((\"programs\" .  400))))) 0.001)\n    (check-within (candidate (list \"A1\" \"A2\" \"A3\" \"A4\") (list \"java\" \"C\" \"C++\" \"DBMS\") (list 10 20 30 40)) (list #hash((\"A1\" .  #hash((\"java\" .  10)))) #hash((\"A2\" .  #hash((\"C\" .  20)))) #hash((\"A3\" .  #hash((\"C++\" .  30)))) #hash((\"A4\" .  #hash((\"DBMS\" .  40))))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find smallest number in a list.\n(define (smallest_num xs)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_num))\n    (check-within (candidate (list 10 20 1 45 99)) 1 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n    (check-within (candidate (list 45 46 50 60)) 45 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rktthon-exercises/re/rktthon-re-exercise-3.php\n(define (text_match_zero_one text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_zero_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"dsabbbba\") #t 0.001)\n    (check-within (candidate \"asbbbba\") #f 0.001)\n    (check-within (candidate \"abaaa\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find nth bell number.\n(define (bell_Number n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_Number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 15 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find cubes of individual elements in a list.\n(define (cube_nums nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 8 27 64 125 216 343 512 729 1000) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15)) (list 1728 3375) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last digit in factorial of a given number.\n(define (last_Digit_Factorial n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit_Factorial))\n    (check-within (candidate 4) 4 0.001)\n    (check-within (candidate 21) 0 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find even numbers from a list of numbers.\n(define (Split list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5)) (list 2 4) 0.001)\n    (check-within (candidate (list 4 5 6 7 8 0 1)) (list 4 6 8 0) 0.001)\n    (check-within (candidate (list 8 12 15 19)) (list 8 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given integer is a prime number.\n(define (prime_num num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_num))\n    (check-within (candidate 13) #t 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate -1010) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find lists which have all elements divisible by k from the given list of lists.\n(define (find_tuples test_list K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_tuples))\n    (check-within (candidate (list (list 6 24 12) (list 7 9 6) (list 12 18 21)) 6) (list (list 6 24 12)) 0.001)\n    (check-within (candidate (list (list 5 25 30) (list 4 2 3) (list 7 8 9)) 5) (list (list 5 25 30)) 0.001)\n    (check-within (candidate (list (list 7 9 16) (list 8 16 4) (list 19 17 18)) 4) (list (list 8 16 4)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to caluclate the area of a tetrahedron.\n(define (area_tetrahedron side)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate area_tetrahedron))\n    (check-within (candidate 3) 15.588457268119894 0.001)\n    (check-within (candidate 20) 692.8203230275509 0.001)\n    (check-within (candidate 10) 173.20508075688772 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number is even or not.\n(define (is_Even n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Even))\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 2) #t 0.001)\n    (check-within (candidate 3) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of positive numbers in a list.\n(define (pos_count list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pos_count))\n    (check-within (candidate (list 1 -2 3 -4)) 2 0.001)\n    (check-within (candidate (list 3 4 5 -1)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4)) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get all lucid numbers smaller than or equal to a given integer.\n(define (get_ludic n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_ludic))\n    (check-within (candidate 10) (list 1 2 3 5 7) 0.001)\n    (check-within (candidate 25) (list 1 2 3 5 7 11 13 17 23 25) 0.001)\n    (check-within (candidate 45) (list 1 2 3 5 7 11 13 17 23 25 29 37 41 43) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n(define (find_Index n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Index))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 14 0.001)\n    (check-within (candidate 4) 45 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to reverse a list upto a given position.\n(define (reverse_Array_Upto_K input k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_Array_Upto_K))\n    (check-within (candidate (list 1 2 3 4 5 6) 4) (list 4 3 2 1 5 6) 0.001)\n    (check-within (candidate (list 4 5 6 7) 2) (list 5 4 6 7) 0.001)\n    (check-within (candidate (list 9 8 7 6 5) 3) (list 7 8 9 6 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of lists using the second value of each list.\n(define (subject_marks subjectmarks)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate subject_marks))\n    (check-within (candidate (list (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97) (list \"Social sciences\" 82))) (list (list \"Social sciences\" 82) (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97)) 0.001)\n    (check-within (candidate (list (list \"Telugu\" 49) (list \"Hindhi\" 54) (list \"Social\" 33))) (list (list \"Social\" 33) (list \"Telugu\" 49) (list \"Hindhi\" 54)) 0.001)\n    (check-within (candidate (list (list \"Physics\" 96) (list \"Chemistry\" 97) (list \"Biology\" 45))) (list (list \"Biology\" 45) (list \"Physics\" 96) (list \"Chemistry\" 97)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove characters from the first string which are present in the second string.\n(define (remove_dirty_chars string second_string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_dirty_chars))\n    (check-within (candidate \"probasscurve\" \"pros\") \"bacuve\" 0.001)\n    (check-within (candidate \"digitalindia\" \"talent\") \"digiidi\" 0.001)\n    (check-within (candidate \"exoticmiles\" \"toxic\") \"emles\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n(define (round_and_sum list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate round_and_sum))\n    (check-within (candidate (list 22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5)) 243 0.001)\n    (check-within (candidate (list 5 2 9 24.3 29)) 345 0.001)\n    (check-within (candidate (list 25.0 56.7 89.2)) 513 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the item with maximum frequency in a given list.\n(define (max_occurrences nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_occurrences))\n    (check-within (candidate (list 2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2)) 2 0.001)\n    (check-within (candidate (list 2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18)) 8 0.001)\n    (check-within (candidate (list 10 20 20 30 40 90 80 50 30 20 50 10)) 20 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a given string is a decimal number with a precision of 2.\n(define (is_decimal num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_decimal))\n    (check-within (candidate \"123.11\") #t 0.001)\n    (check-within (candidate \"e666.86\") #f 0.001)\n    (check-within (candidate \"3.124587\") #f 0.001)\n    (check-within (candidate \"1.11\") #t 0.001)\n    (check-within (candidate \"1.1.11\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\n(define (dict_filter dict n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dict_filter))\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 170) #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 180) #hash((\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 190) #hash((\"Pierre Cox\" .  190)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of even numbers at even positions of a list.\n(define (sum_even_and_even_index arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_even_and_even_index))\n    (check-within (candidate (list 5 6 12 1 18 8)) 30 0.001)\n    (check-within (candidate (list 3 20 17 9 2 10 18 13 6 18)) 26 0.001)\n    (check-within (candidate (list 5 6 12 1)) 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the sum of the largest contiguous sublist in the given list.\n(define (max_sub_array_sum a size)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum))\n    (check-within (candidate (list -2 -3 4 -1 -2 1 5 -3) 8) 7 0.001)\n    (check-within (candidate (list -3 -4 5 -2 -3 2 6 -4) 8) 8 0.001)\n    (check-within (candidate (list -4 -5 6 -3 -4 3 7 -5) 8) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the intersection of two lists.\n(define (intersection_array array_nums1 array_nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection_array))\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 1 2 4 8 9)) (list 1 2 8 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 3 5 7 9)) (list 3 5 7 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 10 20 30 40)) (list 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\n(define (split_two_parts list1 L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_two_parts))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list (list 1 1 2) (list 3 4 4 5 1)) 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") 2) (list (list \"a\" \"b\") (list \"c\" \"d\")) 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 4) (list (list \"p\" \"y\" \"t\" \"h\") (list \"o\" \"n\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n(define (find_literals text pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_literals))\n    (check-within (candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") (list \"fox\" 16 19) 0.001)\n    (check-within (candidate \"Its been a very crazy procedure right\" \"crazy\") (list \"crazy\" 16 21) 0.001)\n    (check-within (candidate \"Hardest choices required strongest will\" \"will\") (list \"will\" 35 39) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the volume of a triangular prism.\n(define (find_Volume l b h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Volume))\n    (check-within (candidate 10 8 6) 240 0.001)\n    (check-within (candidate 3 2 2) 6 0.001)\n    (check-within (candidate 1 2 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n(define (wind_chill v t)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate wind_chill))\n    (check-within (candidate 120 35) 40 0.001)\n    (check-within (candidate 40 20) 19 0.001)\n    (check-within (candidate 10 8) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the ascii value of a character.\n(define (ascii_value k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate ascii_value))\n    (check-within (candidate \"A\") 65 0.001)\n    (check-within (candidate \"R\") 82 0.001)\n    (check-within (candidate \"S\") 83 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether all the characters are same or not.\n(define (all_Characters_Same s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Characters_Same))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"aaa\") #t 0.001)\n    (check-within (candidate \"data\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to move all the numbers to the end of the given string.\n(define (move_num test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_num))\n    (check-within (candidate \"I1love143you55three3000thousand\") \"Iloveyouthreethousand1143553000\" 0.001)\n    (check-within (candidate \"Avengers124Assemble\") \"AvengersAssemble124\" 0.001)\n    (check-within (candidate \"Its11our12path13to14see15things16do17things\") \"Itsourpathtoseethingsdothings11121314151617\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the length of the word is odd or not.\n(define (word_len s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate word_len))\n    (check-within (candidate \"Hadoop\") #f 0.001)\n    (check-within (candidate \"great\") #t 0.001)\n    (check-within (candidate \"structure\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to drop empty items from a given hash.\n(define (drop_empty dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate drop_empty))\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  #f) (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  #f) (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c2\" .  \"Green\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n(define (insert_element list element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate insert_element))\n    (check-within (candidate (list \"Red\" \"Green\" \"Black\") \"c\") (list \"c\" \"Red\" \"c\" \"Green\" \"c\" \"Black\") 0.001)\n    (check-within (candidate (list \"python\" \"java\") \"program\") (list \"program\" \"python\" \"program\" \"java\") 0.001)\n    (check-within (candidate (list \"happy\" \"sad\") \"laugh\") (list \"laugh\" \"happy\" \"laugh\" \"sad\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove lowercase substrings from a given string.\n(define (remove_lowercase str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_lowercase))\n    (check-within (candidate \"PYTHon\") \"PYTH\" 0.001)\n    (check-within (candidate \"FInD\") \"FID\" 0.001)\n    (check-within (candidate \"STRinG\") \"STRG\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of set bits (binary digits with value 1) in a given number.\n(define (count_Set_Bits n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Set_Bits))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 1 0.001)\n    (check-within (candidate 6) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract only the rear index element of each string in the given list.\n(define (extract_rear test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_rear))\n    (check-within (candidate (list \"Mers\" \"for\" \"Vers\")) (list \"s\" \"r\" \"s\") 0.001)\n    (check-within (candidate (list \"Avenge\" \"for\" \"People\")) (list \"e\" \"r\" \"e\") 0.001)\n    (check-within (candidate (list \"Gotta\" \"get\" \"go\")) (list \"a\" \"t\" \"o\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of occurence of the string 'std' in a given string.\n(define (count_occurance s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_occurance))\n    (check-within (candidate \"letstdlenstdporstd\") 3 0.001)\n    (check-within (candidate \"truststdsolensporsd\") 1 0.001)\n    (check-within (candidate \"makestdsostdworthit\") 2 0.001)\n    (check-within (candidate \"stds\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given lists contain the k or not.\n(define (check_K test_tup K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_K))\n    (check-within (candidate (list 10 4 5 6 8) 6) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) 7) #f 0.001)\n    (check-within (candidate (list 7 8 9 44 11 12) 11) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to interleave 3 lists of the same length into a single flat list.\n(define (interleave_lists list1 list2 list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate interleave_lists))\n    (check-within (candidate (list 1 2 3 4 5 6 7) (list 10 20 30 40 50 60 70) (list 100 200 300 400 500 600 700)) (list 1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700) 0.001)\n    (check-within (candidate (list 10 20) (list 15 2) (list 5 10)) (list 10 15 5 20 2 10) 0.001)\n    (check-within (candidate (list 11 44) (list 10 15) (list 20 5)) (list 11 10 20 44 15 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a snake case string to camel case string.\n(define (snake_to_camel word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"python_program\") \"PythonProgram\" 0.001)\n    (check-within (candidate \"python_language\") \"PythonLanguage\" 0.001)\n    (check-within (candidate \"programming_language\") \"ProgrammingLanguage\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of equal numbers from three given integers.\n(define (test_three_equal x y z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_three_equal))\n    (check-within (candidate 1 1 1) 3 0.001)\n    (check-within (candidate -1 -2 -3) 0 0.001)\n    (check-within (candidate 1 2 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n(define (odd_length_sum arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_length_sum))\n    (check-within (candidate (list 1 2 4)) 14 0.001)\n    (check-within (candidate (list 1 2 1 2)) 15 0.001)\n    (check-within (candidate (list 1 7)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the number of ways to partition a set of Bell numbers.\n(define (bell_number n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 10) 115975 0.001)\n    (check-within (candidate 56) 6775685320645824322581483068371419745979053216268760300 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the area of a rectangle.\n(define (rectangle_area l b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rectangle_area))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 10 5) 50 0.001)\n    (check-within (candidate 4 2) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find sum and average of first n natural numbers.\n(define (sum_average number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_average))\n    (check-within (candidate 10) (list 55 5.5) 0.001)\n    (check-within (candidate 15) (list 120 8.0) 0.001)\n    (check-within (candidate 20) (list 210 10.5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\n(define (division_elements test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate division_elements))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 2 2 2 3) 0.001)\n    (check-within (candidate (list 12 6 8 16) (list 6 3 4 4)) (list 2 2 2 4) 0.001)\n    (check-within (candidate (list 20 14 36 18) (list 5 7 6 9)) (list 4 2 6 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get the sum of the digits of a non-negative integer.\n(define (sum_digits n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_digits))\n    (check-within (candidate 345) 12 0.001)\n    (check-within (candidate 12) 3 0.001)\n    (check-within (candidate 97) 16 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a list of lists, write a function that returns the first value of the list with the smallest second value.\n(define (index_minimum test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_minimum))\n    (check-within (candidate (list (list \"Rash\" 143) (list \"Manjeet\" 200) (list \"Varsha\" 100))) \"Varsha\" 0.001)\n    (check-within (candidate (list (list \"Yash\" 185) (list \"Dawood\" 125) (list \"Sanya\" 175))) \"Dawood\" 0.001)\n    (check-within (candidate (list (list \"Sai\" 345) (list \"Salman\" 145) (list \"Ayesha\" 96))) \"Ayesha\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to divide two lists element wise.\n(define (div_list nums1 nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate div_list))\n    (check-within (candidate (list 4 5 6) (list 1 2 3)) (list 4.0 2.5 2.0) 0.001)\n    (check-within (candidate (list 3 2) (list 1 4)) (list 3.0 0.5) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 1.8 1.7142857142857142) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the list with maximum length.\n(define (max_length_list input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length_list))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5) (list 1 2 3 4) (list 1 2 3) (list 1 2) (list 1))) (list 5 (list 1 2 3 4 5)) 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 6 7 8 9) (list 10 11 12))) (list 4 (list 6 7 8 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find all possible combinations of the elements of a given list.\n(define (combinations_list list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_list))\n    (check-within (candidate (list \"orange\" \"red\" \"green\" \"blue\")) (list (list ) (list \"orange\") (list \"red\") (list \"red\" \"orange\") (list \"green\") (list \"green\" \"orange\") (list \"green\" \"red\") (list \"green\" \"red\" \"orange\") (list \"blue\") (list \"blue\" \"orange\") (list \"blue\" \"red\") (list \"blue\" \"red\" \"orange\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"orange\") (list \"blue\" \"green\" \"red\") (list \"blue\" \"green\" \"red\" \"orange\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"blue\" \"white\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"blue\") (list \"blue\" \"red\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"red\") (list \"white\") (list \"white\" \"red\") (list \"white\" \"green\") (list \"white\" \"green\" \"red\") (list \"white\" \"blue\") (list \"white\" \"blue\" \"red\") (list \"white\" \"blue\" \"green\") (list \"white\" \"blue\" \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"black\" \"blue\") (list \"black\" \"blue\" \"red\") (list \"black\" \"blue\" \"green\") (list \"black\" \"blue\" \"green\" \"red\") (list \"black\" \"white\") (list \"black\" \"white\" \"red\") (list \"black\" \"white\" \"green\") (list \"black\" \"white\" \"green\" \"red\") (list \"black\" \"white\" \"blue\") (list \"black\" \"white\" \"blue\" \"red\") (list \"black\" \"white\" \"blue\" \"green\") (list \"black\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"blue\") (list \"orange\" \"blue\" \"red\") (list \"orange\" \"blue\" \"green\") (list \"orange\" \"blue\" \"green\" \"red\") (list \"orange\" \"white\") (list \"orange\" \"white\" \"red\") (list \"orange\" \"white\" \"green\") (list \"orange\" \"white\" \"green\" \"red\") (list \"orange\" \"white\" \"blue\") (list \"orange\" \"white\" \"blue\" \"red\") (list \"orange\" \"white\" \"blue\" \"green\") (list \"orange\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\") (list \"orange\" \"black\" \"blue\") (list \"orange\" \"black\" \"blue\" \"red\") (list \"orange\" \"black\" \"blue\" \"green\") (list \"orange\" \"black\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\" \"white\") (list \"orange\" \"black\" \"white\" \"red\") (list \"orange\" \"black\" \"white\" \"green\") (list \"orange\" \"black\" \"white\" \"green\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\") (list \"orange\" \"black\" \"white\" \"blue\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\" \"red\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the largest and smallest value in a given list.\n(define (big_sum nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_sum))\n    (check-within (candidate (list 1 2 3)) 4 0.001)\n    (check-within (candidate (list -1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 2 3 6)) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to return the negative numbers in a list.\n(define (neg_nos list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate neg_nos))\n    (check-within (candidate (list -1 4 5 -6)) (list -1 -6) 0.001)\n    (check-within (candidate (list -1 -2 3 4)) (list -1 -2) 0.001)\n    (check-within (candidate (list -7 -6 8 9)) (list -7 -6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the highest power of 2 that is less than or equal to n.\n(define (highest_Power_of_2 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate highest_Power_of_2))\n    (check-within (candidate 10) 8 0.001)\n    (check-within (candidate 19) 16 0.001)\n    (check-within (candidate 32) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether a list contains the given sublist or not.\n(define (is_sublist l s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sublist))\n    (check-within (candidate (list 2 4 3 5 7) (list 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 4 3)) #t 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 1 6)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to subtract two lists element-wise.\n(define (sub_list nums1 nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sub_list))\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) (list -3 -3 -3) 0.001)\n    (check-within (candidate (list 1 2) (list 3 4)) (list -2 -2) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 40 50) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given two integers have opposite sign or not.\n(define (opposite_Signs x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate opposite_Signs))\n    (check-within (candidate 1 -2) #t 0.001)\n    (check-within (candidate 3 2) #f 0.001)\n    (check-within (candidate -10 -10) #f 0.001)\n    (check-within (candidate -2 2) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which takes two lists of the same length and performs the element wise modulo.\n(define (tuple_modulo test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_modulo))\n    (check-within (candidate (list 10 4 5 6) (list 5 6 7 5)) (list 0 4 5 1) 0.001)\n    (check-within (candidate (list 11 5 6 7) (list 6 7 8 6)) (list 5 5 6 1) 0.001)\n    (check-within (candidate (list 12 6 7 8) (list 7 8 9 7)) (list 5 6 7 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the difference of the first even and first odd number of a given list.\n(define (diff_even_odd list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate diff_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 1 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\"))) (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"d\" \"c\") (list \"g\" \"h\") (list \"f\" \"e\"))) (list (list \"a\" \"b\") (list \"c\" \"d\") (list \"g\" \"h\") (list \"e\" \"f\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last digit of a given number.\n(define (last_Digit n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit))\n    (check-within (candidate 123) 3 0.001)\n    (check-within (candidate 25) 5 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of fourth power of first n odd natural numbers.\n(define (odd_num_sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_num_sum))\n    (check-within (candidate 2) 82 0.001)\n    (check-within (candidate 3) 707 0.001)\n    (check-within (candidate 4) 3108 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a list to a string.\n(define (tup_string tup1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tup_string))\n    (check-within (candidate (list \"e\" \"x\" \"e\" \"r\" \"c\" \"i\" \"s\" \"e\" \"s\")) \"exercises\" 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\")) \"python\" 0.001)\n    (check-within (candidate (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\")) \"program\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all elements from a given list present in another list.\n(define (remove_elements list1 list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_elements))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 1 3 5 7)) (list 2 4 6 8 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 5 7)) (list 1 2 3 4 6 8 9 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether any value in a sequence exists in a sequence or not.\n(define (overlapping list1 list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate overlapping))\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) #f 0.001)\n    (check-within (candidate (list 1 4 5) (list 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to identify non-prime numbers.\n(define (is_not_prime n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_not_prime))\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 35) #t 0.001)\n    (check-within (candidate 37) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum value in a given heterogeneous list.\n(define (max_val listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 5 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 25 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 50 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of the negative numbers of a given list of numbers.\n(define (sum_negativenum nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_negativenum))\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) -32 0.001)\n    (check-within (candidate (list 10 15 -14 13 -18 12 -20)) -52 0.001)\n    (check-within (candidate (list 19 -65 57 39 152 -639 121 44 90 -190)) -894 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n(define (find_Rotations str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Rotations))\n    (check-within (candidate \"aaaa\") 1 0.001)\n    (check-within (candidate \"ab\") 2 0.001)\n    (check-within (candidate \"abc\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n(define (change_date_format dt)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_date_format))\n    (check-within (candidate \"2026-01-02\") \"02-01-2026\" 0.001)\n    (check-within (candidate \"2020-11-13\") \"13-11-2020\" 0.001)\n    (check-within (candidate \"2021-04-26\") \"26-04-2021\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of integers and only returns the odd ones.\n(define (Split list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5 6)) (list 1 3 5) 0.001)\n    (check-within (candidate (list 10 11 12 13)) (list 11 13) 0.001)\n    (check-within (candidate (list 7 8 9 1)) (list 7 9 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n(define (toggle_middle_bits n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_middle_bits))\n    (check-within (candidate 9) 15 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 11) 13 0.001)\n    (check-within (candidate 65) 127 0.001)\n    (check-within (candidate 77) 115 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n(define (count_char_position str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_char_position))\n    (check-within (candidate \"xbcefg\") 2 0.001)\n    (check-within (candidate \"ABcED\") 3 0.001)\n    (check-within (candidate \"AbgdeF\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n(define (large_product nums1 nums2 N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate large_product))\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 3) (list 60 54 50) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 4) (list 60 54 50 48) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 5) (list 60 54 50 48 45) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n(define (cummulative_sum test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cummulative_sum))\n    (check-within (candidate (list (list 1 3) (list 5 6 7) (list 2 6))) 30 0.001)\n    (check-within (candidate (list (list 2 4) (list 6 7 8) (list 3 7))) 37 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8 9) (list 4 8))) 44 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n(define (find_min_diff arr n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_min_diff))\n    (check-within (candidate (list 1 5 3 19 18 25) 6) 1 0.001)\n    (check-within (candidate (list 4 3 2 6) 4) 1 0.001)\n    (check-within (candidate (list 30 5 20 9) 4) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n(define (text_starta_endb text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_starta_endb))\n    (check-within (candidate \"aabbbb\") #t 0.001)\n    (check-within (candidate \"aabAbbbc\") #f 0.001)\n    (check-within (candidate \"accddbbjjj\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n(define (left_rotate n d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_rotate))\n    (check-within (candidate 16 2) 64 0.001)\n    (check-within (candidate 10 2) 40 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 1 3) 8 0.001)\n    (check-within (candidate 5 3) 40 0.001)\n    (check-within (candidate 29 3) 232 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first repeated character in a given string.\n(define (first_repeated_char str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_repeated_char))\n    (check-within (candidate \"abcabc\") \"a\" 0.001)\n    (check-within (candidate \"abc\") #f 0.001)\n    (check-within (candidate \"123123\") \"1\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count inversions in a list.\n(define (get_Inv_Count arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Inv_Count))\n    (check-within (candidate (list 1 20 6 4 5)) 5 0.001)\n    (check-within (candidate (list 1 2 1)) 1 0.001)\n    (check-within (candidate (list 1 2 5 6 1)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n(define (even_Power_Sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_Power_Sum))\n    (check-within (candidate 2) 1056 0.001)\n    (check-within (candidate 3) 8832 0.001)\n    (check-within (candidate 1) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find whether all the given lists have equal length or not.\n(define (get_equal Input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_equal))\n    (check-within (candidate (list (list 11 22 33) (list 44 55 66))) #t 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6 7))) #f 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4))) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if a string represents an integer or not.\n(define (check_integer text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_integer))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"1\") #t 0.001)\n    (check-within (candidate \"12345\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/rktthon-program-to-count-the-pairs-of-reverse-strings/\n(define (count_reverse_pairs test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_reverse_pairs))\n    (check-within (candidate (list \"julia\" \"best\" \"tseb\" \"for\" \"ailuj\")) 2 0.001)\n    (check-within (candidate (list \"geeks\" \"best\" \"for\" \"skeeg\")) 1 0.001)\n    (check-within (candidate (list \"makes\" \"best\" \"sekam\" \"for\" \"rof\")) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to move all zeroes to the end of the given list.\n(define (move_zero num_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_zero))\n    (check-within (candidate (list 1 0 2 0 3 4)) (list 1 2 3 4 0 0) 0.001)\n    (check-within (candidate (list 2 3 2 0 0 4 0 5 0)) (list 2 3 2 4 5 0 0 0 0) 0.001)\n    (check-within (candidate (list 0 1 0 1 1)) (list 1 1 1 0 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if given list contains no duplicates.\n(define (check_distinct test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_distinct))\n    (check-within (candidate (list 1 4 5 6 1 4)) #f 0.001)\n    (check-within (candidate (list 1 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 6)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given amount has no profit and no loss\n(define (noprofit_noloss actual_cost sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate noprofit_noloss))\n    (check-within (candidate 1500 1200) #f 0.001)\n    (check-within (candidate 100 100) #t 0.001)\n    (check-within (candidate 2000 5000) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all the words with k length in the given string.\n(define (remove_length test_str K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_length))\n    (check-within (candidate \"The person is most value tet\" 3) \"person is most value\" 0.001)\n    (check-within (candidate \"If you told me about this ok\" 4) \"If you me about ok\" 0.001)\n    (check-within (candidate \"Forces of darkeness is come into the play\" 4) \"Forces of darkeness is the\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count number of digits in a given string.\n(define (number_ctr str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_ctr))\n    (check-within (candidate \"program2bedone\") 1 0.001)\n    (check-within (candidate \"3wonders\") 1 0.001)\n    (check-within (candidate \"123\") 3 0.001)\n    (check-within (candidate \"3wond-1ers2\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the total number of characters in a string.\n(define (count_charac str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_charac))\n    (check-within (candidate \"python programming\") 18 0.001)\n    (check-within (candidate \"language\") 8 0.001)\n    (check-within (candidate \"words\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n(define (get_total_number_of_sequences m n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_total_number_of_sequences))\n    (check-within (candidate 10 4) 4 0.001)\n    (check-within (candidate 5 2) 6 0.001)\n    (check-within (candidate 16 3) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rktthon-exercises/data-structures-and-algorithms/rktthon-data-structure-exercise-24.php\n(define (left_insertion a x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two numbers and returns a list with the second number and then the first number.\n(define (swap_numbers a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_numbers))\n    (check-within (candidate 10 20) (list 20 10) 0.001)\n    (check-within (candidate 15 17) (list 17 15) 0.001)\n    (check-within (candidate 100 200) (list 200 100) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n(define (is_majority arr n x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_majority))\n    (check-within (candidate (list 1 2 3 3 3 3 10) 7 3) #t 0.001)\n    (check-within (candidate (list 1 1 2 4 4 4 6 6) 8 4) #f 0.001)\n    (check-within (candidate (list 1 1 1 2 2) 5 1) #t 0.001)\n    (check-within (candidate (list 1 1 2 2) 5 1) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\n(define (substract_elements test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate substract_elements))\n    (check-within (candidate (list 10 4 5) (list 2 5 18)) (list 8 -1 -13) 0.001)\n    (check-within (candidate (list 11 2 3) (list 24 45 16)) (list -13 -43 -13) 0.001)\n    (check-within (candidate (list 7 18 9) (list 10 11 12)) (list -3 7 -3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to put spaces between words starting with capital letters in a given string.\n(define (capital_words_spaces str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate capital_words_spaces))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"PythonProgrammingExamples\") \"Python Programming Examples\" 0.001)\n    (check-within (candidate \"GetReadyToBeCodingFreak\") \"Get Ready To Be Coding Freak\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the average of cubes of first n natural numbers.\n(define (find_Average_Of_Cube n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Average_Of_Cube))\n    (check-within (candidate 2) 4.5 0.001)\n    (check-within (candidate 3) 12 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if all values are same in a hash.\n(define (check_value dict n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_value))\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 10) #f 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 12) #t 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 5) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth tetrahedral number.\n(define (tetrahedral_number n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tetrahedral_number))\n    (check-within (candidate 5) 35 0.001)\n    (check-within (candidate 6) 56 0.001)\n    (check-within (candidate 7) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate whether the matrix is a magic square.\n(define (magic_square_test my_matrix)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate magic_square_test))\n    (check-within (candidate (list (list 7 12 1 14) (list 2 13 8 11) (list 16 3 10 5) (list 9 6 15 4))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 8))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 7))) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove uppercase substrings from a given string.\n(define (remove_uppercase str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_uppercase))\n    (check-within (candidate \"cAstyoUrFavoRitETVshoWs\") \"cstyoravoitshos\" 0.001)\n    (check-within (candidate \"wAtchTheinTernEtrAdIo\") \"wtchheinerntrdo\" 0.001)\n    (check-within (candidate \"VoicESeaRchAndreComMendaTionS\") \"oiceachndreomendaion\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether an element exists within a list.\n(define (check_tuplex tuplex tuple1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_tuplex))\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"r\") #t 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"5\") #f 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") 3) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate a dog's age in dog's years.\n(define (dog_age h_age)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dog_age))\n    (check-within (candidate 12) 61 0.001)\n    (check-within (candidate 15) 73 0.001)\n    (check-within (candidate 24) 109 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the next perfect square greater than a given number.\n(define (next_Perfect_Square N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_Perfect_Square))\n    (check-within (candidate 35) 36 0.001)\n    (check-within (candidate 6) 9 0.001)\n    (check-within (candidate 9) 16 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create a list of N empty dictionaries.\n(define (empty_list length)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate empty_list))\n    (check-within (candidate 5) (list #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 6) (list #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 7) (list #hash() #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to convert a given string to uppercase.\n(define (is_upper string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_upper))\n    (check-within (candidate \"person\") \"PERSON\" 0.001)\n    (check-within (candidate \"final\") \"FINAL\" 0.001)\n    (check-within (candidate \"Valid\") \"VALID\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n(define (odd_Equivalent s n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_Equivalent))\n    (check-within (candidate \"011001\" 6) 3 0.001)\n    (check-within (candidate \"11011\" 5) 4 0.001)\n    (check-within (candidate \"1010\" 4) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n(define (re_arrange_array arr n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate re_arrange_array))\n    (check-within (candidate (list -1 2 -3 4 5 6 -7 8 9) 9) (list -1 -3 -7 4 5 6 2 8 9) 0.001)\n    (check-within (candidate (list 12 -14 -26 13 15) 5) (list -14 -26 12 13 15) 0.001)\n    (check-within (candidate (list 10 24 36 -42 -39 -78 85) 7) (list -42 -39 -78 10 24 36 85) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether a list of numbers contains only one distinct element or not.\n(define (unique_Element arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_Element))\n    (check-within (candidate (list 1 1 1)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks from a string.\n(define (extract_values text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_values))\n    (check-within (candidate \"\"Python\", \"PHP\", \"Java\"\") (list \"Python\" \"PHP\" \"Java\") 0.001)\n    (check-within (candidate \"\"python\",\"program\",\"language\"\") (list \"python\" \"program\" \"language\") 0.001)\n    (check-within (candidate \"\"red\",\"blue\",\"green\",\"yellow\"\") (list \"red\" \"blue\" \"green\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count true booleans in the given list.\n(define (count lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count))\n    (check-within (candidate (list #t #f #t)) 2 0.001)\n    (check-within (candidate (list #f #f)) 0 0.001)\n    (check-within (candidate (list #t #t #t)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that counts the number of pairs of integers in a list that xor to an even number.\n(define (find_even_pair A)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_even_pair))\n    (check-within (candidate (list 5 4 7 2 1)) 4 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11)) 9 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is armstrong or not.\n(define (armstrong_number number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate armstrong_number))\n    (check-within (candidate 153) #t 0.001)\n    (check-within (candidate 259) #f 0.001)\n    (check-within (candidate 4458) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the upper case characters in a given string.\n(define (upper_ctr str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate upper_ctr))\n    (check-within (candidate \"PYthon\") 1 0.001)\n    (check-within (candidate \"BigData\") 1 0.001)\n    (check-within (candidate \"program\") 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the elementwise and lists from the given two lists.\n(define (and_tuples test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate and_tuples))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 0 0 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 5 6 7 8)) (list 1 2 3 0) 0.001)\n    (check-within (candidate (list 8 9 11 12) (list 7 13 14 17)) (list 0 9 10 0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether it follows the sequence given in the patterns list.\n(define (is_samepatterns colors patterns)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_samepatterns))\n    (check-within (candidate (list \"red\" \"green\" \"green\") (list \"a\" \"b\" \"b\")) #t 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\" \"b\")) #f 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\")) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of lists in a given number of lists.\n(define (count_list input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) 4 0.001)\n    (check-within (candidate (list (list 1 2) (list 2 3) (list 4 5))) 3 0.001)\n    (check-within (candidate (list (list 1 0) (list 2 0))) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n(define (average_tuple nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate average_tuple))\n    (check-within (candidate (list (list 10 10 10 12) (list 30 45 56 45) (list 81 80 39 32) (list 1 2 3 4))) (list 30.5 34.25 27.0 23.25) 0.001)\n    (check-within (candidate (list (list 1 1 -5) (list 30 -15 56) (list 81 -60 -39) (list -10 2 3))) (list 25.5 -18.0 3.75) 0.001)\n    (check-within (candidate (list (list 100 100 100 120) (list 300 450 560 450) (list 810 800 390 320) (list 10 20 30 40))) (list 305.0 342.5 270.0 232.5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n(define (lcs_of_three X Y Z)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lcs_of_three))\n    (check-within (candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") 2 0.001)\n    (check-within (candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") 5 0.001)\n    (check-within (candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n'th star number.\n(define (find_star_num n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_star_num))\n    (check-within (candidate 3) 37 0.001)\n    (check-within (candidate 4) 73 0.001)\n    (check-within (candidate 5) 121 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of a list.\n(define (_sum arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate _sum))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 15 12 13 10)) 50 0.001)\n    (check-within (candidate (list 0 1 2)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given list contains consecutive numbers or not.\n(define (check_Consecutive l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_Consecutive))\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 5 6)) #f 0.001)\n    (check-within (candidate (list 1 2 1)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the first adverb and their positions in a given sentence.\n(define (find_adverb_position text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverb_position))\n    (check-within (candidate \"clearly!! we can see the sky\") (list 0 7 \"clearly\") 0.001)\n    (check-within (candidate \"seriously!! there are many roses\") (list 0 9 \"seriously\") 0.001)\n    (check-within (candidate \"unfortunately!! sita is going to home\") (list 0 13 \"unfortunately\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/rktthon-program-right-rotate-list-n/\n(define (rotate_right list m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rotate_right))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 3) (list 8 9 10 1 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 9 10 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 5) (list 6 7 8 9 10 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of non-empty substrings of a given string.\n(define (number_of_substrings str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_of_substrings))\n    (check-within (candidate \"abc\") 6 0.001)\n    (check-within (candidate \"abcd\") 10 0.001)\n    (check-within (candidate \"abcde\") 15 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n(define (list_split S step)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_split))\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\" \"h\" \"i\" \"j\" \"k\" \"l\" \"m\" \"n\") 3) (list (list \"a\" \"d\" \"g\" \"j\" \"m\") (list \"b\" \"e\" \"h\" \"k\" \"n\") (list \"c\" \"f\" \"i\" \"l\")) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11 12 13 14) 3) (list (list 1 4 7 10 13) (list 2 5 8 11 14) (list 3 6 9 12)) 0.001)\n    (check-within (candidate (list \"python\" \"java\" \"C\" \"C++\" \"DBMS\" \"SQL\") 2) (list (list \"python\" \"C\" \"DBMS\") (list \"java\" \"C++\" \"SQL\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check if the elements of a given list are unique or not.\n(define (all_unique test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_unique))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to convert complex numbers to polar coordinates.\n(define (convert numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert))\n    (check-within (candidate 1) (list 1.0 0.0) 0.001)\n    (check-within (candidate 4) (list 4.0 0.0) 0.001)\n    (check-within (candidate 5) (list 5.0 0.0) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The input is given as - a hash with a student name as a key and a list of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n(define (filter_data students h w)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_data))\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 6.0 70) #hash((\"Cierra Vega\" .  (list 6.2 70))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.9 67) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Kierra Gentry\" .  (list 6.0 68))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.7 64) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to convert the given string to lower case.\n(define (is_lower string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_lower))\n    (check-within (candidate \"InValid\") \"invalid\" 0.001)\n    (check-within (candidate \"TruE\") \"true\" 0.001)\n    (check-within (candidate \"SenTenCE\") \"sentence\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the smallest power of 2 greater than or equal to n.\n(define (next_power_of_2 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_power_of_2))\n    (check-within (candidate 0) 1 0.001)\n    (check-within (candidate 5) 8 0.001)\n    (check-within (candidate 17) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if a string is present as a substring in a given list of string values.\n(define (find_substring str1 sub_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_substring))\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ack\") #t 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"abc\") #f 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ange\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace characters in a string.\n(define (replace_char str1 ch newch)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_char))\n    (check-within (candidate \"polygon\" \"y\" \"l\") \"pollgon\" 0.001)\n    (check-within (candidate \"character\" \"c\" \"a\") \"aharaater\" 0.001)\n    (check-within (candidate \"python\" \"l\" \"a\") \"python\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the product of first even and odd number of a given list.\n(define (mul_even_odd list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mul_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 10 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a list to a list.\n(define (list_tuple listx)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_tuple))\n    (check-within (candidate (list 5 10 7 4 15 3)) (list 5 10 7 4 15 3) 0.001)\n    (check-within (candidate (list 2 4 5 6 2 3 4 4 7)) (list 2 4 5 6 2 3 4 4 7) 0.001)\n    (check-within (candidate (list 58 44 56)) (list 58 44 56) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n(define (even_binomial_Coeff_Sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_binomial_Coeff_Sum))\n    (check-within (candidate 4) 8 0.001)\n    (check-within (candidate 6) 32 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform the mathematical bitwise xor operation across the given lists.\n(define (bitwise_xor test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bitwise_xor))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 15 6 5 10) 0.001)\n    (check-within (candidate (list 11 5 7 10) (list 6 3 4 4)) (list 13 6 3 14) 0.001)\n    (check-within (candidate (list 12 6 8 11) (list 7 4 5 6)) (list 11 2 13 13) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether a list is sublist of another or not.\n(define (is_Sub_Array A B)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sub_Array))\n    (check-within (candidate (list 1 4 3 5) (list 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 1) (list 1 2 1)) #t 0.001)\n    (check-within (candidate (list 1 0 2 2) (list 2 2 0)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n(define (max_sub_array_sum_repeated a n k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum_repeated))\n    (check-within (candidate (list 10 20 -30 -1) 4 3) 30 0.001)\n    (check-within (candidate (list -1 10 20) 3 2) 59 0.001)\n    (check-within (candidate (list -1 -2 -3) 3 3) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the minimum product from the pairs of lists within a given list.\n(define (min_product_tuple list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 8 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 30 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 100 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the count of divisors is even. https://www.w3resource.com/rktthon-exercises/basic/rktthon-basic-1-exercise-24.php\n(define (count_divisors n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_divisors))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 100) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n(define (triangle_area r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate -1) #f 0.001)\n    (check-within (candidate 0) 0 0.001)\n    (check-within (candidate 2) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a given string to a list of characters.\n(define (string_to_tuple str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_tuple))\n    (check-within (candidate \"python 3.0\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\" \"3\" \".\" \"0\") 0.001)\n    (check-within (candidate \"item1\") (list \"i\" \"t\" \"e\" \"m\" \"1\") 0.001)\n    (check-within (candidate \"15.10\") (list \"1\" \"5\" \".\" \"1\" \"0\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n(define (find_length string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_length))\n    (check-within (candidate \"11000010001\") 6 0.001)\n    (check-within (candidate \"10111\") 1 0.001)\n    (check-within (candidate \"11011101100101\") 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n(define (count_Primes_nums n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Primes_nums))\n    (check-within (candidate 5) 2 0.001)\n    (check-within (candidate 10) 4 0.001)\n    (check-within (candidate 100) 25 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the product of consecutive binomial co-efficients.\n(define (sum_Of_product n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_product))\n    (check-within (candidate 3) 15 0.001)\n    (check-within (candidate 4) 56 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the maximum aggregate from the list of lists.\n(define (max_aggregate stdata)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_aggregate))\n    (check-within (candidate (list (list \"Juan Whelan\" 90) (list \"Sabah Colley\" 88) (list \"Peter Nichols\" 7) (list \"Juan Whelan\" 122) (list \"Sabah Colley\" 84))) (list \"Juan Whelan\" 212) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 50) (list \"Sabah Colley\" 48) (list \"Peter Nichols\" 37) (list \"Juan Whelan\" 22) (list \"Sabah Colley\" 14))) (list \"Juan Whelan\" 72) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 10) (list \"Sabah Colley\" 20) (list \"Peter Nichols\" 30) (list \"Juan Whelan\" 40) (list \"Sabah Colley\" 50))) (list \"Sabah Colley\" 70) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (comb_sort nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate comb_sort))\n    (check-within (candidate (list 5 15 37 25 79)) (list 5 15 25 37 79) 0.001)\n    (check-within (candidate (list 41 32 15 19 22)) (list 15 19 22 32 41) 0.001)\n    (check-within (candidate (list 99 15 13 47)) (list 13 15 47 99) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n(define (check_expression exp)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_expression))\n    (check-within (candidate \"{()}[{}]\") #t 0.001)\n    (check-within (candidate \"{()}[{]\") #f 0.001)\n    (check-within (candidate \"{()}[{}][]({})\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a word containing 'z'.\n(define (text_match_wordz text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz))\n    (check-within (candidate \"pythonz.\") #t 0.001)\n    (check-within (candidate \"xyz.\") #t 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n(define (sum_list lst1 lst2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_list))\n    (check-within (candidate (list 10 20 30) (list 15 25 35)) (list 25 45 65) 0.001)\n    (check-within (candidate (list 1 2 3) (list 5 6 7)) (list 6 8 10) 0.001)\n    (check-within (candidate (list 15 20 30) (list 15 45 75)) (list 30 65 105) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n(define (newman_prime n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate newman_prime))\n    (check-within (candidate 3) 7 0.001)\n    (check-within (candidate 4) 17 0.001)\n    (check-within (candidate 5) 41 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to apply a given format string to all of the elements in a list.\n(define (add_string list_ string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_string))\n    (check-within (candidate (list 1 2 3 4) \"temp{0}\") (list \"temp1\" \"temp2\" \"temp3\" \"temp4\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") \"python{0}\") (list \"pythona\" \"pythonb\" \"pythonc\" \"pythond\") 0.001)\n    (check-within (candidate (list 5 6 7 8) \"string{0}\") (list \"string5\" \"string6\" \"string7\" \"string8\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the surface area of a square rktramid with a given base edge and height.\n(define (surface_Area b s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surface_Area))\n    (check-within (candidate 3 4) 33 0.001)\n    (check-within (candidate 4 5) 56 0.001)\n    (check-within (candidate 1 2) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the smallest list in a list of lists.\n(define (Find_Min_Length lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min_Length))\n    (check-within (candidate (list (list 1) (list 1 2))) 1 0.001)\n    (check-within (candidate (list (list 1 2) (list 1 2 3) (list 1 2 3 4))) 2 0.001)\n    (check-within (candidate (list (list 3 3 3) (list 4 4 4 4))) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n(define (validate n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate validate))\n    (check-within (candidate 1234) #t 0.001)\n    (check-within (candidate 51241) #f 0.001)\n    (check-within (candidate 321) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth hexagonal number.\n(define (hexagonal_num n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hexagonal_num))\n    (check-within (candidate 10) 190 0.001)\n    (check-within (candidate 5) 45 0.001)\n    (check-within (candidate 7) 91 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n'th lucas number.\n(define (find_lucas n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lucas))\n    (check-within (candidate 9) 76 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 3) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to get the difference between two lists.\n(define (Diff li1 li2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Diff))\n    (check-within (candidate (list 10 15 20 25 30 35 40) (list 25 40 35)) (list 10 20 30 15) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 1)) (list 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3) (list 6 7 1)) (list 2 3 6 7) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks \" \" of the given string.\n(define (extract_quotation text1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_quotation))\n    (check-within (candidate \"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\") (list \"A53\" \"multi\" \"Processor\") 0.001)\n    (check-within (candidate \"Cast your \"favorite\" entertainment \"apps\"\") (list \"favorite\" \"apps\") 0.001)\n    (check-within (candidate \"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\") (list \"4k Ultra HD\" \"HDR 10\") 0.001)\n    (check-within (candidate \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to flatten a list and sum all of its elements.\n(define (recursive_list_sum data_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate recursive_list_sum))\n    (check-within (candidate (list 1 2 (list 3 4) (list 5 6))) 21 0.001)\n    (check-within (candidate (list 7 10 (list 15 14) (list 19 41))) 106 0.001)\n    (check-within (candidate (list 10 20 (list 30 40) (list 50 60))) 210 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the two numbers differ at one bit position only or not.\n(define (differ_At_One_Bit_Pos a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate differ_At_One_Bit_Pos))\n    (check-within (candidate 13 9) #t 0.001)\n    (check-within (candidate 15 8) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 2 3) #t 0.001)\n    (check-within (candidate 5 1) #t 0.001)\n    (check-within (candidate 1 5) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by three 'b'.\n(define (text_match_three text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"caacabbbba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n(define (max_product arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product))\n    (check-within (candidate (list 3 100 4 5 150 6)) 3000 0.001)\n    (check-within (candidate (list 4 42 55 68 80)) 50265600 0.001)\n    (check-within (candidate (list 10 22 9 33 21 50 41 60)) 2460 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to split a list at the nth eelment and add the first part to the end.\n(define (split_Arr l n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_Arr))\n    (check-within (candidate (list 12 10 5 6 52 36) 2) (list 5 6 52 36 12 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) 1) (list 2 3 4 1) 0.001)\n    (check-within (candidate (list 0 1 2 3 4 5 6 7) 3) (list 3 4 5 6 7 0 1 2) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the number of divisors of a given integer.\n(define (divisor n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisor))\n    (check-within (candidate 15) 4 0.001)\n    (check-within (candidate 12) 6 0.001)\n    (check-within (candidate 9) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the difference between largest and smallest value in a given list.\n(define (big_diff nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_diff))\n    (check-within (candidate (list 1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 4 5 12)) 8 0.001)\n    (check-within (candidate (list 9 2 3)) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find squares of individual elements in a list.\n(define (square_nums nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 100 400 900) 0.001)\n    (check-within (candidate (list 12 15)) (list 144 225) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given list has any none value or not.\n(define (check_none test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_none))\n    (check-within (candidate (list 10 4 5 6 #f)) #t 0.001)\n    (check-within (candidate (list 7 8 9 11 14)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 #f)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given list is monotonic or not.\n(define (is_Monotonic A)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Monotonic))\n    (check-within (candidate (list 6 5 4 4)) #t 0.001)\n    (check-within (candidate (list 1 2 2 3)) #t 0.001)\n    (check-within (candidate (list 1 3 2)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n(define (is_perfect_square n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_perfect_square))\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 36) #t 0.001)\n    (check-within (candidate 14) #f 0.001)\n    (check-within (candidate 196) #t 0.001)\n    (check-within (candidate 125) #f 0.001)\n    (check-within (candidate 15625) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of common divisors of two given numbers.\n(define (sum a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum))\n    (check-within (candidate 10 15) 6 0.001)\n    (check-within (candidate 100 150) 93 0.001)\n    (check-within (candidate 4 6) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the list of maximum length in a list of lists.\n(define (max_length list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1) (list 5 7) (list 10 12 14 15))) (list 4 (list 10 12 14 15)) 0.001)\n    (check-within (candidate (list (list 5) (list 15 20 25))) (list 3 (list 15 20 25)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list of lists and returns a hash mapping each unique list to the number of times it occurs in the list.\n(define (check_occurences test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_occurences))\n    (check-within (candidate (list (list 3 1) (list 1 3) (list 2 5) (list 5 2) (list 6 3))) #hash(((list 1 3) .  2) ((list 2 5) .  2) ((list 3 6) .  1)) 0.001)\n    (check-within (candidate (list (list 4 2) (list 2 4) (list 3 6) (list 6 3) (list 7 4))) #hash(((list 2 4) .  2) ((list 3 6) .  2) ((list 4 7) .  1)) 0.001)\n    (check-within (candidate (list (list 13 2) (list 11 23) (list 12 25) (list 25 12) (list 16 23))) #hash(((list 2 13) .  1) ((list 11 23) .  1) ((list 12 25) .  2) ((list 16 23) .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the directrix of a parabola.\n(define (parabola_directrix a b c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parabola_directrix))\n    (check-within (candidate 5 3 2) -198 0.001)\n    (check-within (candidate 9 8 4) -2336 0.001)\n    (check-within (candidate 2 4 6) -130 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the occurrence and position of the substrings within a string. Return #f if there is no match.\n(define (occurance_substring text pattern)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate occurance_substring))\n    (check-within (candidate \"python programming, python language\" \"python\") (list \"python\" 0 6) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"programming\") (list \"programming\" 7 18) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"language\") (list \"language\" 31 39) 0.001)\n    (check-within (candidate \"c++ programming, c++ language\" \"python\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove lists from the given list.\n(define (remove_nested test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_nested))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) (list 1 5 7 10) 0.001)\n    (check-within (candidate (list 2 6 8 (list 5 7) 11)) (list 2 6 8 11) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) 12)) (list 3 7 9 12) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) (list 5 12) 12)) (list 3 7 9 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists input_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \" red \" \"green\") (list \"blue \" \" black\") (list \" orange\" \"brown\"))) (list (list \" red \" \"green\") (list \" black\" \"blue \") (list \" orange\" \"brown\")) 0.001)\n    (check-within (candidate (list (list \"zilver\" \"gold\") (list \"magnesium\" \"aluminium\") (list \"steel\" \"bronze\"))) (list (list \"gold\" \"zilver\") (list \"aluminium\" \"magnesium\") (list \"bronze\" \"steel\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n(define (remove_kth_element list1 L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_kth_element))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list 1 1 3 4 4 5 1) 0.001)\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4) 4) (list 0 0 1 3 4 4 5 6 6 6 7 8 9 4 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10) 5) (list 10 10 15 19 18 17 26 26 17 18 10) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to add a hash to the list. The output should be a list.\n(define (add_dict_to_tuple test_tup test_dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_dict_to_tuple))\n    (check-within (candidate (list 4 5 6) #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) (list 4 5 6 #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) 0.001)\n    (check-within (candidate (list 1 2 3) #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) (list 1 2 3 #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) 0.001)\n    (check-within (candidate (list 8 9 10) #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) (list 8 9 10 #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find quotient of two numbers (rounded down to the nearest integer).\n(define (find n m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find))\n    (check-within (candidate 10 3) 3 0.001)\n    (check-within (candidate 4 2) 2 0.001)\n    (check-within (candidate 20 5) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n(define (text_match_two_three text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_two_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the occurence of all elements of list in a list.\n(define (count_Occurrence tup lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Occurrence))\n    (check-within (candidate (list \"a\" \"a\" \"c\" \"b\" \"d\") (list \"a\" \"b\")) 3 0.001)\n    (check-within (candidate (list 1 2 3 1 4 6 7 1 4) (list 1 4 7)) 6 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 1 2)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count number items that are identical in the same position of three given lists.\n(define (count_samepair list1 list2 list3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_samepair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9) (list 2 1 3 1 2 6 7 9)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 2 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by one or more b's.\n(define (text_match_one text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abba\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n(define (difference n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate difference))\n    (check-within (candidate 3) 30 0.001)\n    (check-within (candidate 5) 210 0.001)\n    (check-within (candidate 2) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to toggle the case of all characters in a string.\n(define (toggle_string string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_string))\n    (check-within (candidate \"Python\") \"pYTHON\" 0.001)\n    (check-within (candidate \"Pangram\") \"pANGRAM\" 0.001)\n    (check-within (candidate \"LIttLE\") \"liTTle\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the element of a list having maximum length.\n(define (Find_Max lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max))\n    (check-within (candidate (list (list \"A\") (list \"A\" \"B\") (list \"A\" \"B\" \"C\"))) (list \"A\" \"B\" \"C\") 0.001)\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1 2 3) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 2 3) (list 1 5 6 1))) (list 1 5 6 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the Eulerian number a(n, m).\n(define (eulerian_num n m)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eulerian_num))\n    (check-within (candidate 3 1) 4 0.001)\n    (check-within (candidate 4 1) 11 0.001)\n    (check-within (candidate 5 3) 26 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of occurrences of a number in a given list.\n(define (frequency a x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency))\n    (check-within (candidate (list 1 2 3) 4) 0 0.001)\n    (check-within (candidate (list 1 2 2 3 3 3 4) 3) 3 0.001)\n    (check-within (candidate (list 0 1 2 3 1 2) 1) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/rktthon-sort-numeric-strings-in-a-list/\n(define (sort_numeric_strings nums_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numeric_strings))\n    (check-within (candidate (list \"4\" \"12\" \"45\" \"7\" \"0\" \"100\" \"200\" \"-12\" \"-500\")) (list -500 -12 0 4 7 12 45 100 200) 0.001)\n    (check-within (candidate (list \"2\" \"3\" \"8\" \"4\" \"7\" \"9\" \"8\" \"2\" \"6\" \"5\" \"1\" \"6\" \"1\" \"2\" \"3\" \"4\" \"6\" \"9\" \"1\" \"2\")) (list 1 1 1 2 2 2 2 3 3 4 4 5 6 6 6 7 8 8 9 9) 0.001)\n    (check-within (candidate (list \"1\" \"3\" \"5\" \"7\" \"1\" \"3\" \"13\" \"15\" \"17\" \"5\" \"7 \" \"9\" \"1\" \"11\")) (list 1 1 1 3 3 5 5 7 7 9 11 13 15 17) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rktthon-exercises/data-structures-and-algorithms/rktthon-recursion-exercise-9.php\n(define (geometric_sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate geometric_sum))\n    (check-within (candidate 7) 1.9921875 0.001)\n    (check-within (candidate 4) 1.9375 0.001)\n    (check-within (candidate 8) 1.99609375 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rktthon-exercises/lambda/rktthon-lambda-exercise-24.php\n(define (divisible_by_digits startnum endnum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisible_by_digits))\n    (check-within (candidate 1 22) (list 1 2 3 4 5 6 7 8 9 11 12 15 22) 0.001)\n    (check-within (candidate 1 15) (list 1 2 3 4 5 6 7 8 9 11 12 15) 0.001)\n    (check-within (candidate 20 25) (list 22 24) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to calculate the product of the unique numbers in a given list.\n(define (unique_product list_data)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_product))\n    (check-within (candidate (list 10 20 30 40 20 50 60 40)) 720000000 0.001)\n    (check-within (candidate (list 1 2 3 1)) 6 0.001)\n    (check-within (candidate (list 7 8 9 0 1 1)) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the largest negative number from the given list.\n(define (largest_neg list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_neg))\n    (check-within (candidate (list 1 2 3 -4 -6)) -6 0.001)\n    (check-within (candidate (list 1 2 3 -8 -9)) -9 0.001)\n    (check-within (candidate (list 1 2 3 4 -1)) -1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove consecutive duplicates of a given list.\n(define (consecutive_duplicates nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list 0 1 2 3 4 5 6 7 8 9 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list 10 15 19 18 17 26 17 18 10) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list \"a\" \"b\" \"c\" \"d\") 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\" \"a\" \"a\")) (list \"a\" \"b\" \"c\" \"d\" \"a\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n(define (min_Jumps steps d)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Jumps))\n    (check-within (candidate (list 3 4) 11) 3.5 0.001)\n    (check-within (candidate (list 3 4) 0) 0 0.001)\n    (check-within (candidate (list 11 14) 11) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find a pair with highest product from a given list of integers.\n(define (max_Product arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Product))\n    (check-within (candidate (list 1 2 3 4 7 0 8 4)) (list 7 8) 0.001)\n    (check-within (candidate (list 0 -1 -2 -4 5 0 -6)) (list -4 -6) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the nth element from a given list of lists.\n(define (extract_nth_element list1 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_nth_element))\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 0) (list \"Greyson Fulton\" \"Brady Kent\" \"Wyatt Knott\" \"Beau Turnbull\") 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 2) (list 99 96 94 98) 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 1) (list 98 97 91 94) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth nonagonal number.\n(define (is_nonagonal n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nonagonal))\n    (check-within (candidate 10) 325 0.001)\n    (check-within (candidate 15) 750 0.001)\n    (check-within (candidate 18) 1089 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the maximum difference between any two elements in a given list.\n(define (max_Abs_Diff arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Abs_Diff))\n    (check-within (candidate (list 2 1 5 3)) 4 0.001)\n    (check-within (candidate (list 9 3 2 5 1)) 8 0.001)\n    (check-within (candidate (list 3 2 1)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to pack consecutive duplicates of a given list elements into sublists.\n(define (pack_consecutive_duplicates list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pack_consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list (list 0 0) (list 1) (list 2) (list 3) (list 4 4) (list 5) (list 6 6 6) (list 7) (list 8) (list 9) (list 4 4)) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list (list 10 10) (list 15) (list 19) (list 18 18) (list 17) (list 26 26) (list 17) (list 18) (list 10)) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list (list \"a\" \"a\") (list \"b\") (list \"c\") (list \"d\" \"d\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of perrin numbers.\n(define (cal_sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cal_sum))\n    (check-within (candidate 9) 49 0.001)\n    (check-within (candidate 10) 66 0.001)\n    (check-within (candidate 11) 88 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to remove the characters which have odd index values of a given string.\n(define (odd_values_string str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_values_string))\n    (check-within (candidate \"abcdef\") \"ace\" 0.001)\n    (check-within (candidate \"python\") \"pto\" 0.001)\n    (check-within (candidate \"data\") \"dt\" 0.001)\n    (check-within (candidate \"lambs\") \"lms\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find kth element from the given two sorted lists.\n(define (find_kth arr1 arr2 k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_kth))\n    (check-within (candidate (list 2 3 6 7 9) (list 1 4 8 10) 5) 6 0.001)\n    (check-within (candidate (list 100 112 256 349 770) (list 72 86 113 119 265 445 892) 7) 256 0.001)\n    (check-within (candidate (list 3 4 7 8 10) (list 2 5 9 11) 6) 8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n(define (jacobsthal_num n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate jacobsthal_num))\n    (check-within (candidate 5) 11 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 5 0.001)\n    (check-within (candidate 13) 2731 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find frequency of each element in a flattened list of lists, returned in a hash.\n(define (frequency_lists list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency_lists))\n    (check-within (candidate (list (list 1 2 3 2) (list 4 5 6 2) (list 7 8 9 5))) #hash((1 .  1) (2 .  3) (3 .  1) (4 .  1) (5 .  2) (6 .  1) (7 .  1) (8 .  1) (9 .  1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12))) #hash((1 .  1) (2 .  1) (3 .  1) (4 .  1) (5 .  1) (6 .  1) (7 .  1) (8 .  1) (9 .  1) (10 .  1) (11 .  1) (12 .  1)) 0.001)\n    (check-within (candidate (list (list 20 30 40 17) (list 18 16 14 13) (list 10 20 30 40))) #hash((20 .  2) (30 .  2) (40 .  2) (17 .  1) (18 .  1) (16 .  1) (14 .  1) (13 .  1) (10 .  1)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find perfect squares between two given numbers.\n(define (perfect_squares a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perfect_squares))\n    (check-within (candidate 1 30) (list 1 4 9 16 25) 0.001)\n    (check-within (candidate 50 100) (list 64 81 100) 0.001)\n    (check-within (candidate 100 200) (list 100 121 144 169 196) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n(define (sum_Of_Subarray_Prod arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_Subarray_Prod))\n    (check-within (candidate (list 1 2 3)) 20 0.001)\n    (check-within (candidate (list 1 2)) 5 0.001)\n    (check-within (candidate (list 1 2 3 4)) 84 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first odd number in a given list of numbers.\n(define (first_odd nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_odd))\n    (check-within (candidate (list 1 3 5)) 1 0.001)\n    (check-within (candidate (list 2 4 1 3)) 1 0.001)\n    (check-within (candidate (list 8 9 1)) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform index wise addition of list elements in the given two nested lists.\n(define (add_nested_tuples test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_nested_tuples))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 7 10) (list 7 14) (list 3 10) (list 8 13)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 9 12) (list 9 16) (list 5 12) (list 10 15)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 11 14) (list 11 18) (list 7 14) (list 12 17)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n(define (merge lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"a\" \"b\") (list \"m\" \"n\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\")) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6) (list 7 8))) (list (list 1 3 5 7) (list 2 4 6 8)) 0.001)\n    (check-within (candidate (list (list \"x\" \"y\" \"z\") (list \"a\" \"b\" \"c\") (list \"m\" \"n\" \"o\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\") (list \"z\" \"c\" \"o\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number can be represented as the difference of two squares or not.\n(define (dif_Square n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dif_Square))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 15) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if each element of second list is smaller than its corresponding element in the first list.\n(define (check_smaller test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_smaller))\n    (check-within (candidate (list 1 2 3) (list 2 3 4)) #f 0.001)\n    (check-within (candidate (list 4 5 6) (list 3 4 5)) #t 0.001)\n    (check-within (candidate (list 11 12 13) (list 10 11 12)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to get the frequency of all the elements in a list, returned as a hash.\n(define (freq_count list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate freq_count))\n    (check-within (candidate (list 10 10 10 10 20 20 20 20 40 40 50 50 30)) #hash((10 .  4) (20 .  4) (40 .  2) (50 .  2) (30 .  1)) 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 4 1 3 1 4)) #hash((1 .  3) (2 .  2) (3 .  3) (4 .  3)) 0.001)\n    (check-within (candidate (list 5 6 7 4 9 10 4 5 6 7 9 5)) #hash((10 .  1) (5 .  3) (6 .  2) (7 .  2) (4 .  2) (9 .  2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n(define (rgb_to_hsv r g b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rgb_to_hsv))\n    (check-within (candidate 255 255 255) (list 0.0 0.0 100.0) 0.001)\n    (check-within (candidate 0 215 0) (list 120.0 100.0 84.31372549019608) 0.001)\n    (check-within (candidate 10 215 110) (list 149.26829268292684 95.34883720930233 84.31372549019608) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to flatten a given nested list structure.\n(define (flatten_list list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flatten_list))\n    (check-within (candidate (list 0 10 (list 20 30) 40 50 (list 60 70 80) (list 90 100 110 120))) (list 0 10 20 30 40 50 60 70 80 90 100 110 120) 0.001)\n    (check-within (candidate (list (list 10 20) (list 40) (list 30 56 25) (list 10 20) (list 33) (list 40))) (list 10 20 40 30 56 25 10 20 33 40) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 1 2 3 4 5 6 10 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given string is starting with a vowel or not using regex.\n(define (check_str string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_str))\n    (check-within (candidate \"annie\") #t 0.001)\n    (check-within (candidate \"dawood\") #f 0.001)\n    (check-within (candidate \"Else\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n(define (check_monthnumber_number monthnum3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumber_number))\n    (check-within (candidate 6) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 12) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort the given list.\n(define (heap_sort iterable)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_sort))\n    (check-within (candidate (list 1 3 5 7 9 2 4 6 8 0)) (list 0 1 2 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 25 58)) (list 14 22 25 25 35 58 65 75 85) 0.001)\n    (check-within (candidate (list 7 1 9 5)) (list 1 5 7 9) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n(define (k_smallest_pairs nums1 nums2 k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate k_smallest_pairs))\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 2) (list (list 1 2) (list 1 4)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 1) (list (list 1 2)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 7) (list (list 1 2) (list 1 4) (list 3 2) (list 1 6) (list 3 4) (list 3 6) (list 7 2)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns integers x and y that satisfy ax + by = n as a list, or return #f if no solution exists.\n(define (find_solution a b n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_solution))\n    (check-within (candidate 2 3 7) (list 2 1) 0.001)\n    (check-within (candidate 4 2 7) #f 0.001)\n    (check-within (candidate 1 13 17) (list 4 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the largest number that can be formed with the given list of digits.\n(define (find_Max_Num arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Max_Num))\n    (check-within (candidate (list 1 2 3)) 321 0.001)\n    (check-within (candidate (list 4 5 6 1)) 6541 0.001)\n    (check-within (candidate (list 1 2 3 9)) 9321 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns the list in a list of lists whose sum of elements is the highest.\n(define (max_sum_list lists)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_list))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 10 11 12) 0.001)\n    (check-within (candidate (list (list 3 2 1) (list 6 5 4) (list 12 11 10))) (list 12 11 10) 0.001)\n    (check-within (candidate (list (list 2 3 1))) (list 2 3 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to interchange the first and last elements in a list.\n(define (swap_List newList)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 12 35 9 56 24)) (list 24 35 9 56 12) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median of two sorted lists of same size.\n(define (get_median arr1 arr2 n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_median))\n    (check-within (candidate (list 1 12 15 26 38) (list 2 13 17 30 45) 5) 16.0 0.001)\n    (check-within (candidate (list 2 4 8 9) (list 7 13 19 28) 4) 8.5 0.001)\n    (check-within (candidate (list 3 6 14 23 36 42) (list 2 18 27 39 49 55) 6) 25.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace whitespaces with an underscore and vice versa in a given string.\n(define (replace_spaces text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"Jumanji The Jungle\") \"Jumanji_The_Jungle\" 0.001)\n    (check-within (candidate \"The_Avengers\") \"The Avengers\" 0.001)\n    (check-within (candidate \"Fast and Furious\") \"Fast_and_Furious\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to determine if the sum of the divisors of two integers are the same.\n(define (are_equivalent num1 num2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate are_equivalent))\n    (check-within (candidate 36 57) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 23 47) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to reverse each string in a given list of string values.\n(define (reverse_string_list stringlist)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_string_list))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\" \"White\" \"Black\")) (list \"deR\" \"neerG\" \"eulB\" \"etihW\" \"kcalB\") 0.001)\n    (check-within (candidate (list \"john\" \"amal\" \"joel\" \"george\")) (list \"nhoj\" \"lama\" \"leoj\" \"egroeg\") 0.001)\n    (check-within (candidate (list \"jack\" \"john\" \"mary\")) (list \"kcaj\" \"nhoj\" \"yram\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to compute the sum of digits of each number of a given list.\n(define (sum_of_digits nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_of_digits))\n    (check-within (candidate (list 10 2 56)) 14 0.001)\n    (check-within (candidate (list (list 10 20 4 5 \"b\" 70 \"a\"))) 19 0.001)\n    (check-within (candidate (list 10 20 -4 5 -70)) 19 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth number in the newman conway sequence.\n(define (sequence n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequence))\n    (check-within (candidate 10) 6 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 3) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n(define (heap_queue_largest nums n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_queue_largest))\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 3) (list 85 75 65) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 2) (list 85 75) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 5) (list 85 75 65 58 35) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n(define (loss_amount actual_cost sale_amount)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate loss_amount))\n    (check-within (candidate 1500 1200) 0 0.001)\n    (check-within (candidate 100 200) 100 0.001)\n    (check-within (candidate 2000 5000) 3000 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the union of the elements of two given lists and output them in sorted order.\n(define (union_elements test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate union_elements))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 4 5 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 3 4 5 6)) (list 1 2 3 4 5 6) 0.001)\n    (check-within (candidate (list 11 12 13 14) (list 13 15 16 17)) (list 11 12 13 14 15 16 17) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the longest sublists.\n(define (Find_Max_Length lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max_Length))\n    (check-within (candidate (list (list 1) (list 1 4) (list 5 6 7 8))) 4 0.001)\n    (check-within (candidate (list (list 0 1) (list 2 2) (list 3 2 1))) 3 0.001)\n    (check-within (candidate (list (list 7) (list 22 23) (list 13 14 15) (list 10 20 30 40 50))) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove the parenthesis and what is inbetween them from a string.\n(define (remove_parenthesis items)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_parenthesis))\n    (check-within (candidate (list \"python (chrome)\")) \"python\" 0.001)\n    (check-within (candidate (list \"string(.abc)\")) \"string\" 0.001)\n    (check-within (candidate (list \"alpha(num)\")) \"alpha\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find whether the parity of a given number is odd.\n(define (find_Parity x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Parity))\n    (check-within (candidate 12) #f 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median length of a trapezium.\n(define (median_trapezium base1 base2 height)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_trapezium))\n    (check-within (candidate 15 25 35) 20 0.001)\n    (check-within (candidate 10 20 30) 15 0.001)\n    (check-within (candidate 6 9 4) 7.5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find nth centered hexagonal number.\n(define (centered_hexagonal_number n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate centered_hexagonal_number))\n    (check-within (candidate 10) 271 0.001)\n    (check-within (candidate 2) 7 0.001)\n    (check-within (candidate 9) 217 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find number of lists present in the given list.\n(define (find_lists Input)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lists))\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8))) 2 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6))) 3 0.001)\n    (check-within (candidate (list 9 8 7 6 5 4 3 2 1)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n(define (get_max_sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_sum))\n    (check-within (candidate 60) 106 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the longest word.\n(define (len_log list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate len_log))\n    (check-within (candidate (list \"python\" \"PHP\" \"bigdata\")) 7 0.001)\n    (check-within (candidate (list \"a\" \"ab\" \"abc\")) 3 0.001)\n    (check-within (candidate (list \"small\" \"big\" \"tall\")) 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return #f if the angle is larger than 360 degrees.\n(define (sector_area r a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sector_area))\n    (check-within (candidate 4 45) 6.283185307179586 0.001)\n    (check-within (candidate 9 45) 31.808625617596654 0.001)\n    (check-within (candidate 9 361) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether every odd index contains odd numbers of a given list.\n(define (odd_position nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_position))\n    (check-within (candidate (list 2 1 4 3 6 7 6 3)) #t 0.001)\n    (check-within (candidate (list 4 1 2)) #t 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to join a list of multiple integers into a single integer.\n(define (multiple_to_single L)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiple_to_single))\n    (check-within (candidate (list 11 33 50)) 113350 0.001)\n    (check-within (candidate (list -1 2 3 4 5 6)) -123456 0.001)\n    (check-within (candidate (list 10 15 20 25)) 10152025 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find whether a number is divisible by 11.\n(define (is_Diff n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Diff))\n    (check-within (candidate 12345) #f 0.001)\n    (check-within (candidate 1212112) #t 0.001)\n    (check-within (candidate 1212) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to perform index wise multiplication of list elements in the given two lists.\n(define (index_multiplication test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_multiplication))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 21) (list 12 45) (list 2 9) (list 7 30)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 14 32) (list 20 60) (list 6 20) (list 16 44)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 24 45) (list 30 77) (list 12 33) (list 27 60)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert list string to integer list.\n(define (tuple_str_int test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_str_int))\n    (check-within (candidate \"(7, 8, 9)\") (list 7 8 9) 0.001)\n    (check-within (candidate \"(1, 2, 3)\") (list 1 2 3) 0.001)\n    (check-within (candidate \"(4, 5, 6)\") (list 4 5 6) 0.001)\n    (check-within (candidate \"(7, 81, 19)\") (list 7 81 19) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sum all amicable numbers from 1 to a specified number.\n(define (amicable_numbers_sum limit)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate amicable_numbers_sum))\n    (check-within (candidate 999) 504 0.001)\n    (check-within (candidate 9999) 31626 0.001)\n    (check-within (candidate 99) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove odd characters in a string.\n(define (remove_odd str1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate \"python\") \"yhn\" 0.001)\n    (check-within (candidate \"program\") \"rga\" 0.001)\n    (check-within (candidate \"language\") \"agae\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\n(define (multiply_elements test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_elements))\n    (check-within (candidate (list 1 5 7 8 10)) (list 5 35 56 80) 0.001)\n    (check-within (candidate (list 2 4 5 6 7)) (list 8 20 30 42) 0.001)\n    (check-within (candidate (list 12 13 14 9 15)) (list 156 182 126 135) 0.001)\n    (check-within (candidate (list 12)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n(define (count_rotation arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_rotation))\n    (check-within (candidate (list 3 2 1)) 1 0.001)\n    (check-within (candidate (list 4 5 1 2 3)) 2 0.001)\n    (check-within (candidate (list 7 8 9 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 2 3)) 0 0.001)\n    (check-within (candidate (list 1 3 2)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract the number of unique lists in the given list.\n(define (extract_freq test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_freq))\n    (check-within (candidate (list (list 3 4) (list 1 2) (list 4 3) (list 5 6))) 3 0.001)\n    (check-within (candidate (list (list 4 15) (list 2 3) (list 5 4) (list 6 7))) 4 0.001)\n    (check-within (candidate (list (list 5 16) (list 2 3) (list 6 5) (list 6 9))) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n(define (count_same_pair nums1 nums2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_same_pair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9)) 4 0.001)\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 11 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 1 0.001)\n    (check-within (candidate (list 0 1 1 2) (list 0 1 2 2)) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the value of 'a' to the power 'b'.\n(define (power a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power))\n    (check-within (candidate 3 4) 81 0.001)\n    (check-within (candidate 2 3) 8 0.001)\n    (check-within (candidate 5 5) 3125 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write function to find the sum of all items in the given hash.\n(define (return_sum dict)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate return_sum))\n    (check-within (candidate #hash((\"a\" .  100) (\"b\" .  200) (\"c\" .  300))) 600 0.001)\n    (check-within (candidate #hash((\"a\" .  25) (\"b\" .  18) (\"c\" .  45))) 88 0.001)\n    (check-within (candidate #hash((\"a\" .  36) (\"b\" .  39) (\"c\" .  49))) 124 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return a list of all pairs of consecutive items in a given list.\n(define (pair_wise l1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_wise))\n    (check-within (candidate (list 1 1 2 3 3 4 4 5)) (list (list 1 1) (list 1 2) (list 2 3) (list 3 3) (list 3 4) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) (list (list 1 5) (list 5 7) (list 7 9) (list 9 10)) 0.001)\n    (check-within (candidate (list 5 1 9 7 10)) (list (list 5 1) (list 1 9) (list 9 7) (list 7 10)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list (list 1 2) (list 2 3) (list 3 4) (list 4 5) (list 5 6) (list 6 7) (list 7 8) (list 8 9) (list 9 10)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to split a string into characters.\n(define (split word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split))\n    (check-within (candidate \"python\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 0.001)\n    (check-within (candidate \"Name\") (list \"N\" \"a\" \"m\" \"e\") 0.001)\n    (check-within (candidate \"program\") (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find minimum of three numbers.\n(define (min_of_three a b c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_of_three))\n    (check-within (candidate 10 20 0) 0 0.001)\n    (check-within (candidate 19 15 18) 15 0.001)\n    (check-within (candidate -10 -20 -30) -30 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n(define (is_Sum_Of_Powers_Of_Two n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sum_Of_Powers_Of_Two))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 7) #f 0.001)\n    (check-within (candidate 14) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n(define (get_Char strr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Char))\n    (check-within (candidate \"abc\") \"f\" 0.001)\n    (check-within (candidate \"gfg\") \"t\" 0.001)\n    (check-within (candidate \"ab\") \"c\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return the sum of all divisors of a number.\n(define (sum_div number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_div))\n    (check-within (candidate 8) 7 0.001)\n    (check-within (candidate 12) 16 0.001)\n    (check-within (candidate 7) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function that returns the number of integer elements in a given list.\n(define (count_integer list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_integer))\n    (check-within (candidate (list 1 2 \"abc\" 1.2)) 2 0.001)\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1.2 4 5.1)) 2 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to remove duplicate numbers from a given number of lists.\n(define (two_unique_nums nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate two_unique_nums))\n    (check-within (candidate (list 1 2 3 2 3 4 5)) (list 1 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 5)) (list 1 3 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find whether a given list of integers contains any duplicate element.\n(define (test_duplicate arraynums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_duplicate))\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) #t 0.001)\n    (check-within (candidate (list 1 1 2 2 3 3 4 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which returns nth catalan number.\n(define (catalan_number num)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate catalan_number))\n    (check-within (candidate 10) 16796 0.001)\n    (check-within (candidate 9) 4862 0.001)\n    (check-within (candidate 7) 429 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n(define (power_base_sum base power)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power_base_sum))\n    (check-within (candidate 2 100) 115 0.001)\n    (check-within (candidate 8 10) 37 0.001)\n    (check-within (candidate 8 15) 62 0.001)\n    (check-within (candidate 3 3) 9 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n(define (replace_list list1 list2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_list))\n    (check-within (candidate (list 1 3 5 7 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 2 4 6 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8)) (list 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list \"red\" \"blue\" \"green\") (list \"yellow\")) (list \"red\" \"blue\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth octagonal number.\n(define (is_octagonal n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_octagonal))\n    (check-within (candidate 5) 65 0.001)\n    (check-within (candidate 10) 280 0.001)\n    (check-within (candidate 15) 645 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n(define (replace_blank str1 char)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_blank))\n    (check-within (candidate \"hello people\" \"@\") \"hello@people\" 0.001)\n    (check-within (candidate \"python program language\" \"$\") \"python$program$language\" 0.001)\n    (check-within (candidate \"blank space\" \"-\") \"blank-space\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n(define (replace_specialchar text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_specialchar))\n    (check-within (candidate \"Python language, Programming language.\") \"Python:language::Programming:language:\" 0.001)\n    (check-within (candidate \"a b c,d e f\") \"a:b:c:d:e:f\" 0.001)\n    (check-within (candidate \"ram reshma,ram rahim\") \"ram:reshma:ram:rahim\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert a given list of positive integers into a single integer.\n(define (tuple_to_int nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_int))\n    (check-within (candidate (list 1 2 3)) 123 0.001)\n    (check-within (candidate (list 4 5 6)) 456 0.001)\n    (check-within (candidate (list 5 6 7)) 567 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the third side of a right angled triangle.\n(define (otherside_rightangle w h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate otherside_rightangle))\n    (check-within (candidate 7 8) 10.63014581273465 0.001)\n    (check-within (candidate 3 4) 5 0.001)\n    (check-within (candidate 7 15) 16.55294535724685 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the n most expensive items in a given dataset.\n(define (expensive_items items n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate expensive_items))\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09))) 2) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09)) #hash((\"name\" .  \"Item-4\") (\"price\" .  22.75))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the per-digit difference between two integers.\n(define (digit_distance_nums n1 n2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digit_distance_nums))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate 23 56) 6 0.001)\n    (check-within (candidate 123 256) 7 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that checks if a strings contains 'z', except at the start and end of the word.\n(define (text_match_wordz_middle text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz_middle))\n    (check-within (candidate \"pythonzabc.\") #t 0.001)\n    (check-within (candidate \"zxyabc.\") #f 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove leading zeroes from an ip address.\n(define (removezero_ip ip)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate removezero_ip))\n    (check-within (candidate \"216.08.094.196\") \"216.8.94.196\" 0.001)\n    (check-within (candidate \"12.01.024\") \"12.1.24\" 0.001)\n    (check-within (candidate \"216.08.094.0196\") \"216.8.94.196\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count the number of sublists containing a particular element.\n(define (count_element_in_list list1 x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_element_in_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 1 11) (list 1 15 7)) 1) 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"A\") 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"E\") 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to multiply two integers.\n(define (multiply_int x y)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_int))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 5 10) 50 0.001)\n    (check-within (candidate 4 8) 32 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the pairwise addition of the neighboring elements of the given list.\n(define (add_pairwise test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_pairwise))\n    (check-within (candidate (list 1 5 7 8 10)) (list 6 12 15 18) 0.001)\n    (check-within (candidate (list 2 6 8 9 11)) (list 8 14 17 20) 0.001)\n    (check-within (candidate (list 3 7 9 10 12)) (list 10 16 19 22) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\n(define (max_product_tuple list1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 36 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 200 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 484 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4429,7 +19,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find the kth element in the given list using 1-based indexing.\n(define (kth_element arr k)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate kth_element))\n    (check-within (candidate (list 12 3 5 7 19) 2) 3 0.001)\n    (check-within (candidate (list 17 24 8 23) 3) 8 0.001)\n    (check-within (candidate (list 16 21 25 36 4) 4) 36 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -4440,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to interchange the first and last element in a given list.\n(define (swap_List newList)\n",
+    "prompt": "#lang racket\n\n;; Write a function to convert a snake case string to camel case string.\n(define (snake_to_camel word)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) (list 4 2 3 4 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"python_program\") \"PythonProgram\" 0.001)\n    (check-within (candidate \"python_language\") \"PythonLanguage\" 0.001)\n    (check-within (candidate \"programming_language\") \"ProgrammingLanguage\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4455,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the number of elements that occurs before the list element in the given list.\n(define (count_first_elements test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the Eulerian number a(n, m).\n(define (eulerian_num n m)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_first_elements))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) 3 0.001)\n    (check-within (candidate (list 2 9 (list 5 7) 11)) 2 0.001)\n    (check-within (candidate (list 11 15 5 8 (list 2 3) 8)) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate eulerian_num))\n    (check-within (candidate 3 1) 4 0.001)\n    (check-within (candidate 4 1) 11 0.001)\n    (check-within (candidate 5 3) 26 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4470,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to locate the right insertion point for a specified value in sorted order.\n(define (right_insertion a x)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists input_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \" red \" \"green\") (list \"blue \" \" black\") (list \" orange\" \"brown\"))) (list (list \" red \" \"green\") (list \" black\" \"blue \") (list \" orange\" \"brown\")) 0.001)\n    (check-within (candidate (list (list \"zilver\" \"gold\") (list \"magnesium\" \"aluminium\") (list \"steel\" \"bronze\"))) (list (list \"gold\" \"zilver\") (list \"aluminium\" \"magnesium\") (list \"bronze\" \"steel\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4485,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if the given number is woodball or not.\n(define (is_woodall x)\n",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count true booleans in the given list.\n(define (count lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_woodall))\n    (check-within (candidate 383) #t 0.001)\n    (check-within (candidate 254) #f 0.001)\n    (check-within (candidate 200) #f 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count))\n    (check-within (candidate (list #t #f #t)) 2 0.001)\n    (check-within (candidate (list #f #f)) 0 0.001)\n    (check-within (candidate (list #t #t #t)) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4500,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort the given list by using shell sort.\n(define (shell_sort my_list)\n",
+    "prompt": "#lang racket\n\n;; Write a function to append the given list to the given lists.\n(define (add_lists test_list test_tup)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate shell_sort))\n    (check-within (candidate (list 12 23 4 5 3 2 12 81 56 95)) (list 2 3 4 5 12 12 23 56 81 95) 0.001)\n    (check-within (candidate (list 24 22 39 34 87 73 68)) (list 22 24 34 39 68 73 87) 0.001)\n    (check-within (candidate (list 32 30 16 96 82 83 74)) (list 16 30 32 74 82 83 96) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_lists))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 9 10 5 6 7) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 10 11 6 7 8) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4515,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of pairs whose xor value is odd.\n(define (find_Odd_Pair A N)\n",
+    "prompt": "#lang racket\n\n;; Write a function to merge three lists into a single sorted list.\n(define (merge_sorted_list num1 num2 num3)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Odd_Pair))\n    (check-within (candidate (list 5 4 7 2 1) 5) 6 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11) 7) 12 0.001)\n    (check-within (candidate (list 1 2 3) 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_sorted_list))\n    (check-within (candidate (list 25 24 15 4 5 29 110) (list 19 20 11 56 25 233 154) (list 24 26 54 48)) (list 4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233) 0.001)\n    (check-within (candidate (list 1 3 5 6 8 9) (list 2 5 7 11) (list 1 4 7 8 12)) (list 1 1 2 3 4 5 5 6 7 7 8 8 9 11 12) 0.001)\n    (check-within (candidate (list 18 14 10 9 8 7 9 3 2 4 1) (list 25 35 22 85 14 65 75 25 58) (list 12 74 9 50 61 41)) (list 1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4530,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of all odd natural numbers within the range l and r.\n(define (sum_in_range l r)\n",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n(define (odd_Equivalent s n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_in_range))\n    (check-within (candidate 2 5) 8 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 13) 40 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_Equivalent))\n    (check-within (candidate \"011001\" 6) 3 0.001)\n    (check-within (candidate \"11011\" 5) 4 0.001)\n    (check-within (candidate \"1010\" 4) 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4545,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that returns the perimeter of a square given its side length as input.\n(define (square_perimeter a)\n",
+    "prompt": "#lang racket\n\n;; Write a function to check if a string represents an integer or not.\n(define (check_integer text)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_perimeter))\n    (check-within (candidate 10) 40 0.001)\n    (check-within (candidate 5) 20 0.001)\n    (check-within (candidate 4) 16 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_integer))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"1\") #t 0.001)\n    (check-within (candidate \"12345\") #t 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4560,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n(define (is_polite n)\n",
+    "prompt": "#lang racket\n\n;; Write a function to convert a given list of positive integers into a single integer.\n(define (tuple_to_int nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_polite))\n    (check-within (candidate 7) 11 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 9) 13 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n(define (sum_series n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_series))\n    (check-within (candidate 6) 12 0.001)\n    (check-within (candidate 10) 30 0.001)\n    (check-within (candidate 9) 25 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the dissimilar elements in the given two lists.\n(define (find_dissimilar test_tup1 test_tup2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_dissimilar))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 7 2 3 9)) (list 1 4 7 9) 0.001)\n    (check-within (candidate (list 21 11 25 26) (list 26 34 21 36)) (list 34 36 11 25) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to return two words from a list of words starting with letter 'p'.\n(define (start_withp words)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate start_withp))\n    (check-within (candidate (list \"Python PHP\" \"Java JavaScript\" \"c c++\")) (list \"Python\" \"PHP\") 0.001)\n    (check-within (candidate (list \"Python Programming\" \"Java Programming\")) (list \"Python\" \"Programming\") 0.001)\n    (check-within (candidate (list \"Pqrst Pqr\" \"qrstuv\")) (list \"Pqrst\" \"Pqr\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given snake case string to camel case string.\n(define (snake_to_camel word)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"android_tv\") \"AndroidTv\" 0.001)\n    (check-within (candidate \"google_pixel\") \"GooglePixel\" 0.001)\n    (check-within (candidate \"apple_watch\") \"AppleWatch\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the volume of a cube given its side length.\n(define (volume_cube l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate volume_cube))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 2) 8 0.001)\n    (check-within (candidate 5) 125 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 31 days or not.\n(define (check_monthnumb_number monthnum2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumb_number))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether all the bits are unset in the given range or not.\n(define (all_Bits_Set_In_The_Given_Range n l r)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Bits_Set_In_The_Given_Range))\n    (check-within (candidate 4 1 2) #t 0.001)\n    (check-within (candidate 17 2 4) #t 0.001)\n    (check-within (candidate 39 4 6) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to get the first element of each sublist.\n(define (Extract lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Extract))\n    (check-within (candidate (list (list 1 2) (list 3 4 5) (list 6 7 8 9))) (list 1 3 6) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5))) (list 1 4) 0.001)\n    (check-within (candidate (list (list 9 8 1) (list 1 2))) (list 9 1) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cylinder.\n(define (surfacearea_cylinder r h)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cylinder))\n    (check-within (candidate 10 5) 942.45 0.001)\n    (check-within (candidate 4 5) 226.18800000000002 0.001)\n    (check-within (candidate 4 10) 351.848 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n(define (sample_nam sample_names)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sample_nam))\n    (check-within (candidate (list \"sally\" \"Dylan\" \"rebecca\" \"Diana\" \"Joanne\" \"keith\")) 16 0.001)\n    (check-within (candidate (list \"php\" \"res\" \"Python\" \"abcd\" \"Java\" \"aaa\")) 10 0.001)\n    (check-within (candidate (list \"abcd\" \"Python\" \"abba\" \"aba\")) 6 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create the next bigger number by rearranging the digits of a given number.\n(define (rearrange_bigger n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rearrange_bigger))\n    (check-within (candidate 12) 21 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 102) 120 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the perimeter of a regular pentagon from the length of its sides.\n(define (perimeter_pentagon a)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perimeter_pentagon))\n    (check-within (candidate 5) 25 0.001)\n    (check-within (candidate 10) 50 0.001)\n    (check-within (candidate 15) 75 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n(define (max_sum arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum))\n    (check-within (candidate (list 1 15 51 45 33 100 12 18 9)) 194 0.001)\n    (check-within (candidate (list 80 60 30 40 20 10)) 210 0.001)\n    (check-within (candidate (list 2 3 14 16 21 23 29 30)) 138 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove uneven elements in the nested mixed list.\n(define (extract_even test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_even))\n    (check-within (candidate (list 4 5 (list 7 6 (list 2 4)) 6 8)) (list 4 (list 6 (list 2 4)) 6 8) 0.001)\n    (check-within (candidate (list 5 6 (list 8 7 (list 4 8)) 7 9)) (list 6 (list 8 (list 4 8))) 0.001)\n    (check-within (candidate (list 5 6 (list 9 8 (list 4 6)) 8 10)) (list 6 (list 8 (list 4 6)) 8 10) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_int))\n    (check-within (candidate (list 1 2 3)) 123 0.001)\n    (check-within (candidate (list 4 5 6)) 456 0.001)\n    (check-within (candidate (list 5 6 7)) 567 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -4789,249 +169,9 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to convert all possible convertible elements in a list of lists to floats.\n(define (list_to_float test_list)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_to_float))\n    (check-within (candidate (list (list \"3\" \"4\") (list \"1\" \"26.45\") (list \"7.32\" \"8\") (list \"4\" \"8\"))) (list (list 3.0 4.0) (list 1.0 26.45) (list 7.32 8.0) (list 4.0 8.0)) 0.001)\n    (check-within (candidate (list (list \"4\" \"4\") (list \"2\" \"27\") (list \"4.12\" \"9\") (list \"7\" \"11\"))) (list (list 4.0 4.0) (list 2.0 27.0) (list 4.12 9.0) (list 7.0 11.0)) 0.001)\n    (check-within (candidate (list (list \"6\" \"78\") (list \"5\" \"26.45\") (list \"1.33\" \"4\") (list \"82\" \"13\"))) (list (list 6.0 78.0) (list 5.0 26.45) (list 1.33 4.0) (list 82.0 13.0)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n(define (square_Sum n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 20 0.001)\n    (check-within (candidate 3) 56 0.001)\n    (check-within (candidate 4) 120 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n(define (get_pairs_count arr sum)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_pairs_count))\n    (check-within (candidate (list 1 1 1 1) 2) 6 0.001)\n    (check-within (candidate (list 1 5 7 -1 5) 6) 3 0.001)\n    (check-within (candidate (list 1 -2 3) 1) 1 0.001)\n    (check-within (candidate (list -1 -2 3) -3) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n(define (count_no_of_ways n k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_no_of_ways))\n    (check-within (candidate 2 4) 16 0.001)\n    (check-within (candidate 3 2) 6 0.001)\n    (check-within (candidate 4 4) 228 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to reverse words seperated by spaces in a given string.\n(define (reverse_words s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_words))\n    (check-within (candidate \"python program\") \"program python\" 0.001)\n    (check-within (candidate \"java language\") \"language java\" 0.001)\n    (check-within (candidate \"indian man\") \"man indian\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check if a given number is one less than twice its reverse.\n(define (checks n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate checks))\n    (check-within (candidate 70) #f 0.001)\n    (check-within (candidate 23) #f 0.001)\n    (check-within (candidate 73) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last position of an element in a sorted list.\n(define (last arr x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last))\n    (check-within (candidate (list 1 2 3) 1) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 4) 1) 2 0.001)\n    (check-within (candidate (list 2 3 2 3 6 8 9) 3) 3 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a list and an element and counts the occcurences of the element in the list.\n(define (count_X tup x)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_X))\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 4) 0 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 10) 3 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 8) 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n(define (extract_index_list l1 l2 l3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_index_list))\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 7) 0.001)\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 6 5) (list 0 1 2 3 4 6 7)) (list 1 6) 0.001)\n    (check-within (candidate (list 1 1 3 4 6 5 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 6 6 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list ) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the second smallest number in a list.\n(define (second_smallest numbers)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate second_smallest))\n    (check-within (candidate (list 1 2 -8 -2 0 -2)) -2 0.001)\n    (check-within (candidate (list 1 1 -0.5 0 2 -2 -2)) -0.5 0.001)\n    (check-within (candidate (list 2 2)) #f 0.001)\n    (check-within (candidate (list 2 2 2)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to concatenate each element of list by the delimiter.\n(define (concatenate_tuple test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate_tuple))\n    (check-within (candidate (list \"ID\" \"is\" 4 \"UTS\")) \"ID-is-4-UTS\" 0.001)\n    (check-within (candidate (list \"QWE\" \"is\" 4 \"RTY\")) \"QWE-is-4-RTY\" 0.001)\n    (check-within (candidate (list \"ZEN\" \"is\" 4 \"OP\")) \"ZEN-is-4-OP\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to replace all spaces in the given string with '%20'.\n(define (replace_spaces string)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"My Name is Dawood\") \"My%20Name%20is%20Dawood\" 0.001)\n    (check-within (candidate \"I am a Programmer\") \"I%20am%20a%20Programmer\" 0.001)\n    (check-within (candidate \"I love Coding\") \"I%20love%20Coding\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the sum of numbers in a list within a range specified by two indices.\n(define (sum_range_list list1 m n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_range_list))\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 8 10) 29 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 5 7) 16 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 7 10) 38 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to merge three dictionaries into a single hash.\n(define (merge_dictionaries_three dict1 dict2 dict3)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_dictionaries_three))\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"O\" .  \"Orange\") (\"W\" .  \"White\") (\"B\" .  \"Black\"))) #hash((\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"P\" .  \"Pink\") (\"G\" .  \"Green\") (\"W\" .  \"White\") (\"O\" .  \"Orange\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\"))) #hash((\"W\" .  \"White\") (\"P\" .  \"Pink\") (\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\"))) #hash((\"B\" .  \"Black\") (\"P\" .  \"Pink\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\") (\"W\" .  \"White\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum of two numbers.\n(define (minimum a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minimum))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate -5 -4) -5 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between available pairs in the given list list.\n(define (max_difference test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_difference))\n    (check-within (candidate (list (list 3 5) (list 1 7) (list 10 3) (list 1 2))) 7 0.001)\n    (check-within (candidate (list (list 4 6) (list 2 17) (list 9 13) (list 11 12))) 15 0.001)\n    (check-within (candidate (list (list 12 35) (list 21 27) (list 13 23) (list 41 22))) 23 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find element at a given index after number of rotations.\n(define (find_Element arr ranges rotations index)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Element))\n    (check-within (candidate (list 1 2 3 4 5) (list (list 0 2) (list 0 3)) 2 1) 3 0.001)\n    (check-within (candidate (list 1 2 3 4) (list (list 0 1) (list 0 2)) 1 2) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list (list 0 1) (list 0 2)) 1 1) 1 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5044,7 +184,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to convert a string to a list of strings split on the space character.\n(define (string_to_list string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_list))\n    (check-within (candidate \"python programming\") (list \"python\" \"programming\") 0.001)\n    (check-within (candidate \"lists tuples strings\") (list \"lists\" \"tuples\" \"strings\") 0.001)\n    (check-within (candidate \"write a program\") (list \"write\" \"a\" \"program\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5059,24 +199,9 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a rktthon function to find the element that appears only once in a sorted list.\n(define (search arr)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate search))\n    (check-within (candidate (list 1 1 2 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1 3 3 4 4 5 5 7 7 8)) 8 0.001)\n    (check-within (candidate (list 1 2 2 3 3 4 4)) 1 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a hash by value.\n(define (sort_counter dict1)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_counter))\n    (check-within (candidate #hash((\"Math\" .  81) (\"Physics\" .  83) (\"Chemistry\" .  87))) (list (list \"Chemistry\" 87) (list \"Physics\" 83) (list \"Math\" 81)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  400) (\"Physics\" .  300) (\"Chemistry\" .  250))) (list (list \"Math\" 400) (list \"Physics\" 300) (list \"Chemistry\" 250)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  900) (\"Physics\" .  1000) (\"Chemistry\" .  1250))) (list (list \"Chemistry\" 1250) (list \"Physics\" 1000) (list \"Math\" 900)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5089,7 +214,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a rktthon function to remove first and last occurrence of a given character from the string.\n(define (remove_Occ s ch)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_Occ))\n    (check-within (candidate \"hello\" \"l\") \"heo\" 0.001)\n    (check-within (candidate \"abcda\" \"a\") \"bcd\" 0.001)\n    (check-within (candidate \"PHP\" \"P\") \"H\" 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5100,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cube given its side length.\n(define (lateralsurface_cube l)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\n(define (max_product_tuple list1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cube))\n    (check-within (candidate 5) 100 0.001)\n    (check-within (candidate 9) 324 0.001)\n    (check-within (candidate 10) 400 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 36 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 200 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 484 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5115,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes two lists and returns true if they have at least one common element.\n(define (common_element list1 list2)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sum all amicable numbers from 1 to a specified number.\n(define (amicable_numbers_sum limit)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common_element))\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8 9)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\") (list \"d\" \"b\" \"e\")) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate amicable_numbers_sum))\n    (check-within (candidate 999) 504 0.001)\n    (check-within (candidate 9999) 31626 0.001)\n    (check-within (candidate 99) 0 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5130,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to append the given list to the given lists.\n(define (add_lists test_list test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n(define (find_length string)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_lists))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 9 10 5 6 7) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 10 11 6 7 8) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_length))\n    (check-within (candidate \"11000010001\") 6 0.001)\n    (check-within (candidate \"10111\") 1 0.001)\n    (check-within (candidate \"11011101100101\") 2 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5145,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to compute the n-th power of each number in a list.\n(define (nth_nums nums n)\n",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of common divisors of two given numbers.\n(define (sum a b)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate nth_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30) 3) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15) 5) (list 248832 759375) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum))\n    (check-within (candidate 10 15) 6 0.001)\n    (check-within (candidate 100 150) 93 0.001)\n    (check-within (candidate 4 6) 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5160,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (pancake_sort nums)\n",
+    "prompt": "#lang racket\n\n;; Write a function to multiply two integers.\n(define (multiply_int x y)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pancake_sort))\n    (check-within (candidate (list 15 79 25 38 69)) (list 15 25 38 69 79) 0.001)\n    (check-within (candidate (list 98 12 54 36 85)) (list 12 36 54 85 98) 0.001)\n    (check-within (candidate (list 41 42 32 12 23)) (list 12 23 32 41 42) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the median of three numbers.\n(define (median_numbers a b c)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_numbers))\n    (check-within (candidate 25 55 65) 55.0 0.001)\n    (check-within (candidate 20 10 30) 20.0 0.001)\n    (check-within (candidate 15 45 75) 45.0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the entered number is greater than the elements of the given list.\n(define (check_greater arr number)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_greater))\n    (check-within (candidate (list 1 2 3 4 5) 4) #f 0.001)\n    (check-within (candidate (list 2 3 4 5 6) 8) #t 0.001)\n    (check-within (candidate (list 9 7 4 8 6 1) 11) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n(define (check_element list element)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_element))\n    (check-within (candidate (list \"green\" \"orange\" \"black\" \"white\") \"blue\") #f 0.001)\n    (check-within (candidate (list 1 2 3 4) 7) #f 0.001)\n    (check-within (candidate (list \"green\" \"green\" \"green\" \"green\") \"green\") #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract specified size of strings from a given list of string values.\n(define (extract_string str l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_string))\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 8) (list \"practice\" \"solution\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 6) (list \"Python\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 9) (list \"exercises\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n(define (text_lowercase_underscore text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_lowercase_underscore))\n    (check-within (candidate \"aab_cbbbc\") #t 0.001)\n    (check-within (candidate \"aab_Abbbc\") #f 0.001)\n    (check-within (candidate \"Aaab_abbbc\") #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to trim each list by k in the given lists.\n(define (trim_tuple test_list K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate trim_tuple))\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 2) (list (list 2) (list 9) (list 2) (list 2)) 0.001)\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 1) (list (list 3 2 1) (list 4 9 2) (list 1 2 3) (list 8 2 1)) 0.001)\n    (check-within (candidate (list (list 7 8 4 9) (list 11 8 12 4) (list 4 1 7 8) (list 3 6 9 7)) 1) (list (list 8 4) (list 8 12) (list 1 7) (list 6 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sublist having minimum length.\n(define (Find_Min lst)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min))\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 1 1) (list 1 2 7 8))) (list 1 1) 0.001)\n    (check-within (candidate (list (list \"x\") (list \"x\" \"y\") (list \"x\" \"y\" \"z\"))) (list \"x\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to filter odd numbers.\n(define (filter_oddnumbers nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_oddnumbers))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 3 5 7 9) 0.001)\n    (check-within (candidate (list 10 20 45 67 84 93)) (list 45 67 93) 0.001)\n    (check-within (candidate (list 5 7 9 8 6 4 3)) (list 5 7 9 3) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the first adverb ending with ly and its positions in a given string.\n(define (find_adverbs text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverbs))\n    (check-within (candidate \"Clearly, he has no excuse for such behavior.\") \"0-7: Clearly\" 0.001)\n    (check-within (candidate \"Please handle the situation carefuly\") \"28-36: carefuly\" 0.001)\n    (check-within (candidate \"Complete the task quickly\") \"18-25: quickly\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n(define (max_of_nth test_list N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_of_nth))\n    (check-within (candidate (list (list 5 6 7) (list 1 3 5) (list 8 9 19)) 2) 19 0.001)\n    (check-within (candidate (list (list 6 7 8) (list 2 4 6) (list 9 10 20)) 1) 10 0.001)\n    (check-within (candidate (list (list 7 8 9) (list 3 5 7) (list 10 11 21)) 1) 11 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n(define (decimal_to_binary n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 8) \"1000\" 0.001)\n    (check-within (candidate 18) \"10010\" 0.001)\n    (check-within (candidate 7) \"111\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n(define (combinations_colors l n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_colors))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 1) (list (list \"Red\") (list \"Green\") (list \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 2) (list (list \"Red\" \"Red\") (list \"Red\" \"Green\") (list \"Red\" \"Blue\") (list \"Green\" \"Green\") (list \"Green\" \"Blue\") (list \"Blue\" \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 3) (list (list \"Red\" \"Red\" \"Red\") (list \"Red\" \"Red\" \"Green\") (list \"Red\" \"Red\" \"Blue\") (list \"Red\" \"Green\" \"Green\") (list \"Red\" \"Green\" \"Blue\") (list \"Red\" \"Blue\" \"Blue\") (list \"Green\" \"Green\" \"Green\") (list \"Green\" \"Green\" \"Blue\") (list \"Green\" \"Blue\" \"Blue\") (list \"Blue\" \"Blue\" \"Blue\")) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from a string.\n(define (remove_all_spaces text)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_all_spaces))\n    (check-within (candidate \"python  program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"python   programming    language\") \"pythonprogramminglanguage\" 0.001)\n    (check-within (candidate \"python                     program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"   python                     program\") \"pythonprogram\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n(define (min_Swaps str1 str2)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Swaps))\n    (check-within (candidate \"1101\" \"1110\") 1 0.001)\n    (check-within (candidate \"111\" \"000\") \"Not Possible\" 0.001)\n    (check-within (candidate \"111\" \"110\") \"Not Possible\" 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to create a new list from the given string and list.\n(define (new_tuple test_list test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate new_tuple))\n    (check-within (candidate (list \"WEB\" \"is\") \"best\") (list \"WEB\" \"is\" \"best\") 0.001)\n    (check-within (candidate (list \"We\" \"are\") \"Developers\") (list \"We\" \"are\" \"Developers\") 0.001)\n    (check-within (candidate (list \"Part\" \"is\") \"Wrong\") (list \"Part\" \"is\" \"Wrong\") 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the product of the list multiplication modulo n.\n(define (find_remainder arr n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_remainder))\n    (check-within (candidate (list 100 10 5 25 35 14) 11) 9 0.001)\n    (check-within (candidate (list 1 1 1) 1) 0 0.001)\n    (check-within (candidate (list 1 2 1) 2) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the minimum value in a given heterogeneous list.\n(define (min_val listval)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 2 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 15 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 20 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the ration of positive numbers in a list of integers.\n(define (positive_count nums)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate positive_count))\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8)) 0.54 0.001)\n    (check-within (candidate (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 0.69 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) 0.56 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to add the given list to the given list.\n(define (add_tuple test_list test_tup)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_tuple))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 5 6 7 9 10) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 6 7 8 10 11) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 7 8 9 11 12) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find maximum run of uppercase characters in the given string.\n(define (max_run_uppercase test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_run_uppercase))\n    (check-within (candidate \"GeMKSForGERksISBESt\") 5 0.001)\n    (check-within (candidate \"PrECIOusMOVemENTSYT\") 6 0.001)\n    (check-within (candidate \"GooGLEFluTTER\") 4 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to sort a given matrix in ascending order according to the sum of its rows.\n(define (sort_matrix M)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_matrix))\n    (check-within (candidate (list (list 1 2 3) (list 2 4 5) (list 1 1 1))) (list (list 1 1 1) (list 1 2 3) (list 2 4 5)) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list -2 4 -5) (list 1 -1 1))) (list (list -2 4 -5) (list 1 -1 1) (list 1 2 3)) 0.001)\n    (check-within (candidate (list (list 5 8 9) (list 6 4 3) (list 2 1 4))) (list (list 2 1 4) (list 6 4 3) (list 5 8 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to count those characters which have vowels as their neighbors in the given string.\n(define (count_vowels test_str)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_vowels))\n    (check-within (candidate \"bestinstareels\") 7 0.001)\n    (check-within (candidate \"partofthejourneyistheend\") 12 0.001)\n    (check-within (candidate \"amazonprime\") 5 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n(define (max_sum_increasing_subseq a n index k)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_increasing_subseq))\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 4 6) 11 0.001)\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 2 5) 7 0.001)\n    (check-within (candidate (list 11 15 19 21 26 28 31) 7 2 4) 71 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_int))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 5 10) 50 0.001)\n    (check-within (candidate 4 8) 32 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5524,7 +304,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find words that are longer than n characters from a given list of words.\n(define (long_words n str)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate long_words))\n    (check-within (candidate 3 \"python is a programming language\") (list \"python\" \"programming\" \"language\") 0.001)\n    (check-within (candidate 2 \"writing a program\") (list \"writing\" \"program\") 0.001)\n    (check-within (candidate 5 \"sorting list\") (list \"sorting\") 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5535,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of non-repeated elements in a given list.\n(define (find_sum arr)\n",
+    "prompt": "#lang racket\n\n;; Write a function to calculate whether the matrix is a magic square.\n(define (magic_square_test my_matrix)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_sum))\n    (check-within (candidate (list 1 2 3 1 1 4 5 6)) 21 0.001)\n    (check-within (candidate (list 1 10 9 4 2 10 10 45 4)) 71 0.001)\n    (check-within (candidate (list 12 10 9 45 2 10 10 45 10)) 78 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate magic_square_test))\n    (check-within (candidate (list (list 7 12 1 14) (list 2 13 8 11) (list 16 3 10 5) (list 9 6 15 4))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 8))) #t 0.001)\n    (check-within (candidate (list (list 2 7 6) (list 9 5 1) (list 4 3 7))) #f 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5550,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to convert the given list to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/rktthon-convert-list-to-adjacent-pair-hash/\n(define (tuple_to_dict test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to sort a given matrix in ascending order according to the sum of its rows.\n(define (sort_matrix M)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_dict))\n    (check-within (candidate (list 1 5 7 10 13 5)) #hash((1 .  5) (7 .  10) (13 .  5)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #hash((1 .  2) (3 .  4) (5 .  6)) 0.001)\n    (check-within (candidate (list 7 8 9 10 11 12)) #hash((7 .  8) (9 .  10) (11 .  12)) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_matrix))\n    (check-within (candidate (list (list 1 2 3) (list 2 4 5) (list 1 1 1))) (list (list 1 1 1) (list 1 2 3) (list 2 4 5)) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list -2 4 -5) (list 1 -1 1))) (list (list -2 4 -5) (list 1 -1 1) (list 1 2 3)) 0.001)\n    (check-within (candidate (list (list 5 8 9) (list 6 4 3) (list 2 1 4))) (list (list 2 1 4) (list 6 4 3) (list 5 8 9)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5565,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to extract all the adjacent coordinates of the given coordinate list.\n(define (get_coordinates test_tup)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the item with maximum frequency in a given list.\n(define (max_occurrences nums)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_coordinates))\n    (check-within (candidate (list 3 4)) (list (list 2 3) (list 2 4) (list 2 5) (list 3 3) (list 3 4) (list 3 5) (list 4 3) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 4 5)) (list (list 3 4) (list 3 5) (list 3 6) (list 4 4) (list 4 5) (list 4 6) (list 5 4) (list 5 5) (list 5 6)) 0.001)\n    (check-within (candidate (list 5 6)) (list (list 4 5) (list 4 6) (list 4 7) (list 5 5) (list 5 6) (list 5 7) (list 6 5) (list 6 6) (list 6 7)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check if all the elements in list have same data type or not.\n(define (check_type test_tuple)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_type))\n    (check-within (candidate (list 5 6 7 3 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 \"4\")) #f 0.001)\n    (check-within (candidate (list 3 2 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the smallest missing number from a sorted list of natural numbers.\n(define (find_First_Missing array)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_First_Missing))\n    (check-within (candidate (list 0 1 2 3)) 4 0.001)\n    (check-within (candidate (list 0 1 2 6 9)) 3 0.001)\n    (check-within (candidate (list 2 3 5 8 9)) 0 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is undulating or not.\n(define (is_undulating n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_undulating))\n    (check-within (candidate 1212121) #t 0.001)\n    (check-within (candidate 1991) #f 0.001)\n    (check-within (candidate 121) #t 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/rktthon-find-minimum-k-records-from-list-list/ - in this case a verbatim corkt of test cases\n(define (min_k test_list K)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_k))\n    (check-within (candidate (list (list \"Manjeet\" 10) (list \"Akshat\" 4) (list \"Akash\" 2) (list \"Nikhil\" 8)) 2) (list (list \"Akash\" 2) (list \"Akshat\" 4)) 0.001)\n    (check-within (candidate (list (list \"Sanjeev\" 11) (list \"Angat\" 5) (list \"Akash\" 3) (list \"Nepin\" 9)) 3) (list (list \"Akash\" 3) (list \"Angat\" 5) (list \"Nepin\" 9)) 0.001)\n    (check-within (candidate (list (list \"tanmay\" 14) (list \"Amer\" 11) (list \"Ayesha\" 9) (list \"SKD\" 16)) 1) (list (list \"Ayesha\" 9)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of substrings with the sum of digits equal to their length.\n(define (count_Substrings s)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Substrings))\n    (check-within (candidate \"112112\") 6 0.001)\n    (check-within (candidate \"111\") 6 0.001)\n    (check-within (candidate \"1101112\") 12 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the nth decagonal number.\n(define (is_num_decagonal n)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_num_decagonal))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 7) 175 0.001)\n    (check-within (candidate 10) 370 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list of lists and returns a list containing the rear element of each list.\n(define (rear_extract test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rear_extract))\n    (check-within (candidate (list (list 1 \"Rash\" 21) (list 2 \"Varsha\" 20) (list 3 \"Kil\" 19))) (list 21 20 19) 0.001)\n    (check-within (candidate (list (list 1 \"Sai\" 36) (list 2 \"Ayesha\" 25) (list 3 \"Salman\" 45))) (list 36 25 45) 0.001)\n    (check-within (candidate (list (list 1 \"Sudeep\" 14) (list 2 \"Vandana\" 36) (list 3 \"Dawood\" 56))) (list 14 36 56) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the closest smaller number than n.\n(define (closest_num N)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_num))\n    (check-within (candidate 11) 10 0.001)\n    (check-within (candidate 7) 6 0.001)\n    (check-within (candidate 12) 11 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/rktthon-combinations-of-sum-with-lists-in-list-list/\n(define (find_combinations test_list)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_combinations))\n    (check-within (candidate (list (list 2 4) (list 6 7) (list 5 1) (list 6 10))) (list (list 8 11) (list 7 5) (list 8 14) (list 11 8) (list 12 17) (list 11 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8) (list 6 2) (list 7 11))) (list (list 10 13) (list 9 7) (list 10 16) (list 13 10) (list 14 19) (list 13 13)) 0.001)\n    (check-within (candidate (list (list 4 6) (list 8 9) (list 7 3) (list 8 12))) (list (list 12 15) (list 11 9) (list 12 18) (list 15 12) (list 16 21) (list 15 15)) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n(define (maxAverageOfPath cost)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maxAverageOfPath))\n    (check-within (candidate (list (list 1 2 3) (list 6 5 4) (list 7 3 9))) 5.2 0.001)\n    (check-within (candidate (list (list 2 3 4) (list 7 6 5) (list 8 4 10))) 6.2 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 8 7 6) (list 9 5 11))) 7.2 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9))) 5.8 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and returns a list containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n(define (sequential_search dlist item)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequential_search))\n    (check-within (candidate (list 11 23 58 31 56 77 43 12 65 19) 31) (list #t 3) 0.001)\n    (check-within (candidate (list 12 32 45 62 35 47 44 61) 61) (list #t 7) 0.001)\n    (check-within (candidate (list 9 10 17 19 22 39 48 56) 48) (list #t 6) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to remove odd numbers from a given list.\n(define (remove_odd l)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate (list 1 2 3)) (list 2) 0.001)\n    (check-within (candidate (list 2 4 6)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 10 20 3)) (list 10 20) 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the product of numbers in a list is even or not.\n(define (is_product_even arr)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_product_even))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 4)) #t 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n))\n\n(test-humaneval)",
-    "stop_tokens": [
-      "\n(define ",
-      "\n#|",
-      "\n;",
-      "\n("
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the maximum of two numbers.\n(define (maximum a b)\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate 5 10) 10 0.001)\n    (check-within (candidate -1 -2) -1 0.001)\n    (check-within (candidate 9 7) 9 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_occurrences))\n    (check-within (candidate (list 2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2)) 2 0.001)\n    (check-within (candidate (list 2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18)) 8 0.001)\n    (check-within (candidate (list 10 20 20 30 40 90 80 50 30 20 50 10)) 20 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5794,9 +364,759 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a rktthon function to reverse only the vowels of a given string (where y is not a vowel).\n(define (reverse_vowels str1)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_vowels))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"USA\") \"ASU\" 0.001)\n    (check-within (candidate \"ab\") \"ab\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a list to a string.\n(define (tup_string tup1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tup_string))\n    (check-within (candidate (list \"e\" \"x\" \"e\" \"r\" \"c\" \"i\" \"s\" \"e\" \"s\")) \"exercises\" 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\")) \"python\" 0.001)\n    (check-within (candidate (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\")) \"program\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of the negative numbers of a given list of numbers.\n(define (sum_negativenum nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_negativenum))\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) -32 0.001)\n    (check-within (candidate (list 10 15 -14 13 -18 12 -20)) -52 0.001)\n    (check-within (candidate (list 19 -65 57 39 152 -639 121 44 90 -190)) -894 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth hexagonal number.\n(define (hexagonal_num n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate hexagonal_num))\n    (check-within (candidate 10) 190 0.001)\n    (check-within (candidate 5) 45 0.001)\n    (check-within (candidate 7) 91 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n(define (is_Sum_Of_Powers_Of_Two n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sum_Of_Powers_Of_Two))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 7) #f 0.001)\n    (check-within (candidate 14) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (pancake_sort nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pancake_sort))\n    (check-within (candidate (list 15 79 25 38 69)) (list 15 25 38 69 79) 0.001)\n    (check-within (candidate (list 98 12 54 36 85)) (list 12 36 54 85 98) 0.001)\n    (check-within (candidate (list 41 42 32 12 23)) (list 12 23 32 41 42) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count number items that are identical in the same position of three given lists.\n(define (count_samepair list1 list2 list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_samepair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9) (list 2 1 3 1 2 6 7 9)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 2 6 7 8) (list 2 2 3 1 2 6 7 8) (list 2 1 3 1 2 6 7 8)) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find number of lists present in the given list.\n(define (find_lists Input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lists))\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8))) 2 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6))) 3 0.001)\n    (check-within (candidate (list 9 8 7 6 5 4 3 2 1)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the maximum difference between any two elements in a given list.\n(define (max_Abs_Diff arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Abs_Diff))\n    (check-within (candidate (list 2 1 5 3)) 4 0.001)\n    (check-within (candidate (list 9 3 2 5 1)) 8 0.001)\n    (check-within (candidate (list 3 2 1)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the volume of a triangular prism.\n(define (find_Volume l b h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Volume))\n    (check-within (candidate 10 8 6) 240 0.001)\n    (check-within (candidate 3 2 2) 6 0.001)\n    (check-within (candidate 1 2 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns integers x and y that satisfy ax + by = n as a list, or return #f if no solution exists.\n(define (find_solution a b n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_solution))\n    (check-within (candidate 2 3 7) (list 2 1) 0.001)\n    (check-within (candidate 4 2 7) #f 0.001)\n    (check-within (candidate 1 13 17) (list 4 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all elements from a given list present in another list.\n(define (remove_elements list1 list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_elements))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 1 3 5 7)) (list 2 4 6 8 9 10) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) (list 5 7)) (list 1 2 3 4 6 8 9 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n(define (sum_series n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_series))\n    (check-within (candidate 6) 12 0.001)\n    (check-within (candidate 10) 30 0.001)\n    (check-within (candidate 9) 25 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to determine if the sum of the divisors of two integers are the same.\n(define (are_equivalent num1 num2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate are_equivalent))\n    (check-within (candidate 36 57) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 23 47) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n(define (count_char_position str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_char_position))\n    (check-within (candidate \"xbcefg\") 2 0.001)\n    (check-within (candidate \"ABcED\") 3 0.001)\n    (check-within (candidate \"AbgdeF\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that counts the number of pairs of integers in a list that xor to an even number.\n(define (find_even_pair A)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_even_pair))\n    (check-within (candidate (list 5 4 7 2 1)) 4 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11)) 9 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the smallest power of 2 greater than or equal to n.\n(define (next_power_of_2 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_power_of_2))\n    (check-within (candidate 0) 1 0.001)\n    (check-within (candidate 5) 8 0.001)\n    (check-within (candidate 17) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of occurrences of a number in a given list.\n(define (frequency a x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency))\n    (check-within (candidate (list 1 2 3) 4) 0 0.001)\n    (check-within (candidate (list 1 2 2 3 3 3 4) 3) 3 0.001)\n    (check-within (candidate (list 0 1 2 3 1 2) 1) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n(define (text_lowercase_underscore text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_lowercase_underscore))\n    (check-within (candidate \"aab_cbbbc\") #t 0.001)\n    (check-within (candidate \"aab_Abbbc\") #f 0.001)\n    (check-within (candidate \"Aaab_abbbc\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the sum of numbers in a list within a range specified by two indices.\n(define (sum_range_list list1 m n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_range_list))\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 8 10) 29 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 5 7) 16 0.001)\n    (check-within (candidate (list 2 1 5 6 8 3 4 9 10 11 8 12) 7 10) 38 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the perimeter of a regular pentagon from the length of its sides.\n(define (perimeter_pentagon a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perimeter_pentagon))\n    (check-within (candidate 5) 25 0.001)\n    (check-within (candidate 10) 50 0.001)\n    (check-within (candidate 15) 75 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of occurence of the string 'std' in a given string.\n(define (count_occurance s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_occurance))\n    (check-within (candidate \"letstdlenstdporstd\") 3 0.001)\n    (check-within (candidate \"truststdsolensporsd\") 1 0.001)\n    (check-within (candidate \"makestdsostdworthit\") 2 0.001)\n    (check-within (candidate \"stds\") 1 0.001)\n    (check-within (candidate \"\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns the perimeter of a square given its side length as input.\n(define (square_perimeter a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_perimeter))\n    (check-within (candidate 10) 40 0.001)\n    (check-within (candidate 5) 20 0.001)\n    (check-within (candidate 4) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove characters from the first string which are present in the second string.\n(define (remove_dirty_chars string second_string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_dirty_chars))\n    (check-within (candidate \"probasscurve\" \"pros\") \"bacuve\" 0.001)\n    (check-within (candidate \"digitalindia\" \"talent\") \"digiidi\" 0.001)\n    (check-within (candidate \"exoticmiles\" \"toxic\") \"emles\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find whether a given list of integers contains any duplicate element.\n(define (test_duplicate arraynums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_duplicate))\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) #t 0.001)\n    (check-within (candidate (list 1 1 2 2 3 3 4 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given number is woodball or not.\n(define (is_woodall x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_woodall))\n    (check-within (candidate 383) #t 0.001)\n    (check-within (candidate 254) #f 0.001)\n    (check-within (candidate 200) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if all the elements in list have same data type or not.\n(define (check_type test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_type))\n    (check-within (candidate (list 5 6 7 3 5 6)) #t 0.001)\n    (check-within (candidate (list 1 2 \"4\")) #f 0.001)\n    (check-within (candidate (list 3 2 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n(define (is_majority arr n x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_majority))\n    (check-within (candidate (list 1 2 3 3 3 3 10) 7 3) #t 0.001)\n    (check-within (candidate (list 1 1 2 4 4 4 6 6) 8 4) #f 0.001)\n    (check-within (candidate (list 1 1 1 2 2) 5 1) #t 0.001)\n    (check-within (candidate (list 1 1 2 2) 5 1) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of set bits (binary digits with value 1) in a given number.\n(define (count_Set_Bits n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Set_Bits))\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 1 0.001)\n    (check-within (candidate 6) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to remove the characters which have odd index values of a given string.\n(define (odd_values_string str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_values_string))\n    (check-within (candidate \"abcdef\") \"ace\" 0.001)\n    (check-within (candidate \"python\") \"pto\" 0.001)\n    (check-within (candidate \"data\") \"dt\" 0.001)\n    (check-within (candidate \"lambs\") \"lms\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find minimum of three numbers.\n(define (min_of_three a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_of_three))\n    (check-within (candidate 10 20 0) 0 0.001)\n    (check-within (candidate 19 15 18) 15 0.001)\n    (check-within (candidate -10 -20 -30) -30 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether all the bits are unset in the given range or not.\n(define (all_Bits_Set_In_The_Given_Range n l r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Bits_Set_In_The_Given_Range))\n    (check-within (candidate 4 1 2) #t 0.001)\n    (check-within (candidate 17 2 4) #t 0.001)\n    (check-within (candidate 39 4 6) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n(define (re_arrange_array arr n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate re_arrange_array))\n    (check-within (candidate (list -1 2 -3 4 5 6 -7 8 9) 9) (list -1 -3 -7 4 5 6 2 8 9) 0.001)\n    (check-within (candidate (list 12 -14 -26 13 15) 5) (list -14 -26 12 13 15) 0.001)\n    (check-within (candidate (list 10 24 36 -42 -39 -78 85) 7) (list -42 -39 -78 10 24 36 85) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n(define (replace_blank str1 char)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_blank))\n    (check-within (candidate \"hello people\" \"@\") \"hello@people\" 0.001)\n    (check-within (candidate \"python program language\" \"$\") \"python$program$language\" 0.001)\n    (check-within (candidate \"blank space\" \"-\") \"blank-space\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the volume of a cube given its side length.\n(define (volume_cube l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate volume_cube))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 2) 8 0.001)\n    (check-within (candidate 5) 125 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list of lists and returns a hash mapping each unique list to the number of times it occurs in the list.\n(define (check_occurences test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_occurences))\n    (check-within (candidate (list (list 3 1) (list 1 3) (list 2 5) (list 5 2) (list 6 3))) #hash(((list 1 3) .  2) ((list 2 5) .  2) ((list 3 6) .  1)) 0.001)\n    (check-within (candidate (list (list 4 2) (list 2 4) (list 3 6) (list 6 3) (list 7 4))) #hash(((list 2 4) .  2) ((list 3 6) .  2) ((list 4 7) .  1)) 0.001)\n    (check-within (candidate (list (list 13 2) (list 11 23) (list 12 25) (list 25 12) (list 16 23))) #hash(((list 2 13) .  1) ((list 11 23) .  1) ((list 12 25) .  2) ((list 16 23) .  1)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of non-empty substrings of a given string.\n(define (number_of_substrings str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_of_substrings))\n    (check-within (candidate \"abc\") 6 0.001)\n    (check-within (candidate \"abcd\") 10 0.001)\n    (check-within (candidate \"abcde\") 15 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n(define (get_total_number_of_sequences m n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_total_number_of_sequences))\n    (check-within (candidate 10 4) 4 0.001)\n    (check-within (candidate 5 2) 6 0.001)\n    (check-within (candidate 16 3) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n(define (replace_list list1 list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_list))\n    (check-within (candidate (list 1 3 5 7 9 10) (list 2 4 6 8)) (list 1 3 5 7 9 2 4 6 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8)) (list 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list \"red\" \"blue\" \"green\") (list \"yellow\")) (list \"red\" \"blue\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the total number of characters in a string.\n(define (count_charac str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_charac))\n    (check-within (candidate \"python programming\") 18 0.001)\n    (check-within (candidate \"language\") 8 0.001)\n    (check-within (candidate \"words\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the next perfect square greater than a given number.\n(define (next_Perfect_Square N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate next_Perfect_Square))\n    (check-within (candidate 35) 36 0.001)\n    (check-within (candidate 6) 9 0.001)\n    (check-within (candidate 9) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n(define (max_sum arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum))\n    (check-within (candidate (list 1 15 51 45 33 100 12 18 9)) 194 0.001)\n    (check-within (candidate (list 80 60 30 40 20 10)) 210 0.001)\n    (check-within (candidate (list 2 3 14 16 21 23 29 30)) 138 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the length of the longest palindromic subsequence in the given string.\n(define (lps str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lps))\n    (check-within (candidate \"TENS FOR TENS\") 5 0.001)\n    (check-within (candidate \"CARDIO FOR CARDS\") 7 0.001)\n    (check-within (candidate \"PART OF THE JOURNEY IS PART\") 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the intersection of two lists.\n(define (intersection_array array_nums1 array_nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate intersection_array))\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 1 2 4 8 9)) (list 1 2 8 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 3 5 7 9)) (list 3 5 7 9) 0.001)\n    (check-within (candidate (list 1 2 3 5 7 8 9 10) (list 10 20 30 40)) (list 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a list and an element and counts the occcurences of the element in the list.\n(define (count_X tup x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_X))\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 4) 0 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 10) 3 0.001)\n    (check-within (candidate (list 10 8 5 2 10 15 10 8 5 8 8 2) 8) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n(define (insert_element list element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate insert_element))\n    (check-within (candidate (list \"Red\" \"Green\" \"Black\") \"c\") (list \"c\" \"Red\" \"c\" \"Green\" \"c\" \"Black\") 0.001)\n    (check-within (candidate (list \"python\" \"java\") \"program\") (list \"program\" \"python\" \"program\" \"java\") 0.001)\n    (check-within (candidate (list \"happy\" \"sad\") \"laugh\") (list \"laugh\" \"happy\" \"laugh\" \"sad\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to convert complex numbers to polar coordinates.\n(define (convert numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert))\n    (check-within (candidate 1) (list 1.0 0.0) 0.001)\n    (check-within (candidate 4) (list 4.0 0.0) 0.001)\n    (check-within (candidate 5) (list 5.0 0.0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function that returns the number of integer elements in a given list.\n(define (count_integer list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_integer))\n    (check-within (candidate (list 1 2 \"abc\" 1.2)) 2 0.001)\n    (check-within (candidate (list 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 1.2 4 5.1)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n(define (combinations_colors l n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_colors))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 1) (list (list \"Red\") (list \"Green\") (list \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 2) (list (list \"Red\" \"Red\") (list \"Red\" \"Green\") (list \"Red\" \"Blue\") (list \"Green\" \"Green\") (list \"Green\" \"Blue\") (list \"Blue\" \"Blue\")) 0.001)\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\") 3) (list (list \"Red\" \"Red\" \"Red\") (list \"Red\" \"Red\" \"Green\") (list \"Red\" \"Red\" \"Blue\") (list \"Red\" \"Green\" \"Green\") (list \"Red\" \"Green\" \"Blue\") (list \"Red\" \"Blue\" \"Blue\") (list \"Green\" \"Green\" \"Green\") (list \"Green\" \"Green\" \"Blue\") (list \"Green\" \"Blue\" \"Blue\") (list \"Blue\" \"Blue\" \"Blue\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n(define (count_Primes_nums n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Primes_nums))\n    (check-within (candidate 5) 2 0.001)\n    (check-within (candidate 10) 4 0.001)\n    (check-within (candidate 100) 25 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two numbers and returns a list with the second number and then the first number.\n(define (swap_numbers a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_numbers))\n    (check-within (candidate 10 20) (list 20 10) 0.001)\n    (check-within (candidate 15 17) (list 17 15) 0.001)\n    (check-within (candidate 100 200) (list 200 100) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5809,7 +1129,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to maximize the given two lists.\n(define (maximize_elements test_tup1 test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximize_elements))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 7) (list 4 9) (list 2 9) (list 7 10)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 7 8) (list 5 10) (list 3 10) (list 8 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 8 9) (list 6 11) (list 4 11) (list 9 12)) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5820,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether every even index contains even numbers of a given list.\n(define (even_position nums)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n(define (newman_prime n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_position))\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n    (check-within (candidate (list 2 1 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate newman_prime))\n    (check-within (candidate 3) 7 0.001)\n    (check-within (candidate 4) 17 0.001)\n    (check-within (candidate 5) 41 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5835,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to check whether the given string starts and ends with the same character or not.\n(define (check_char string)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\n(define (division_elements test_tup1 test_tup2)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_char))\n    (check-within (candidate \"abba\") \"Valid\" 0.001)\n    (check-within (candidate \"a\") \"Valid\" 0.001)\n    (check-within (candidate \"abcd\") \"Invalid\" 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate division_elements))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 2 2 2 3) 0.001)\n    (check-within (candidate (list 12 6 8 16) (list 6 3 4 4)) (list 2 2 2 4) 0.001)\n    (check-within (candidate (list 20 14 36 18) (list 5 7 6 9)) (list 4 2 6 2) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5850,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of even factors of a number.\n(define (sumofFactors n)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\n(define (split_two_parts list1 L)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sumofFactors))\n    (check-within (candidate 18) 26 0.001)\n    (check-within (candidate 30) 48 0.001)\n    (check-within (candidate 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_two_parts))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list (list 1 1 2) (list 3 4 4 5 1)) 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") 2) (list (list \"a\" \"b\") (list \"c\" \"d\")) 0.001)\n    (check-within (candidate (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 4) (list (list \"p\" \"y\" \"t\" \"h\") (list \"o\" \"n\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5865,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cone given radius r and the height h.\n(define (lateralsurface_cone r h)\n",
+    "prompt": "#lang racket\n\n;; Write a function to calculate a dog's age in dog's years.\n(define (dog_age h_age)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cone))\n    (check-within (candidate 5 12) 204.20352248333654 0.001)\n    (check-within (candidate 10 15) 566.3586699569488 0.001)\n    (check-within (candidate 19 17) 1521.8090132193388 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dog_age))\n    (check-within (candidate 12) 61 0.001)\n    (check-within (candidate 15) 73 0.001)\n    (check-within (candidate 24) 109 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5880,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n(define (count_Pairs arr n)\n",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n(define (list_split S step)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Pairs))\n    (check-within (candidate (list 1 2 1) 3) 2 0.001)\n    (check-within (candidate (list 1 1 1 1) 4) 0 0.001)\n    (check-within (candidate (list 1 2 3 4 5) 5) 10 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_split))\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\" \"h\" \"i\" \"j\" \"k\" \"l\" \"m\" \"n\") 3) (list (list \"a\" \"d\" \"g\" \"j\" \"m\") (list \"b\" \"e\" \"h\" \"k\" \"n\") (list \"c\" \"f\" \"i\" \"l\")) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10 11 12 13 14) 3) (list (list 1 4 7 10 13) (list 2 5 8 11 14) (list 3 6 9 12)) 0.001)\n    (check-within (candidate (list \"python\" \"java\" \"C\" \"C++\" \"DBMS\" \"SQL\") 2) (list (list \"python\" \"C\" \"DBMS\") (list \"java\" \"C++\" \"SQL\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5895,13 +1215,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to find the index of the first occurrence of a given number in a sorted list.\n(define (find_first_occurrence A x)\n",
+    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cube given its side length.\n(define (lateralsurface_cube l)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_first_occurrence))\n    (check-within (candidate (list 2 5 5 5 6 6 8 9 9 9) 5) 1 0.001)\n    (check-within (candidate (list 2 3 5 5 6 6 8 9 9 9) 5) 2 0.001)\n    (check-within (candidate (list 2 4 1 5 6 6 8 9 9 9) 6) 4 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cube))\n    (check-within (candidate 5) 100 0.001)\n    (check-within (candidate 9) 324 0.001)\n    (check-within (candidate 10) 400 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5914,9 +1234,909 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a rktthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n(define (square_Sum n)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 10 0.001)\n    (check-within (candidate 3) 35 0.001)\n    (check-within (candidate 4) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n'th star number.\n(define (find_star_num n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_star_num))\n    (check-within (candidate 3) 37 0.001)\n    (check-within (candidate 4) 73 0.001)\n    (check-within (candidate 5) 121 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the ascii value of a character.\n(define (ascii_value k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate ascii_value))\n    (check-within (candidate \"A\") 65 0.001)\n    (check-within (candidate \"R\") 82 0.001)\n    (check-within (candidate \"S\") 83 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of even numbers at even positions of a list.\n(define (sum_even_and_even_index arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_even_and_even_index))\n    (check-within (candidate (list 5 6 12 1 18 8)) 30 0.001)\n    (check-within (candidate (list 3 20 17 9 2 10 18 13 6 18)) 26 0.001)\n    (check-within (candidate (list 5 6 12 1)) 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n(define (even_Power_Sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_Power_Sum))\n    (check-within (candidate 2) 1056 0.001)\n    (check-within (candidate 3) 8832 0.001)\n    (check-within (candidate 1) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list of lists and returns a list containing the rear element of each list.\n(define (rear_extract test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rear_extract))\n    (check-within (candidate (list (list 1 \"Rash\" 21) (list 2 \"Varsha\" 20) (list 3 \"Kil\" 19))) (list 21 20 19) 0.001)\n    (check-within (candidate (list (list 1 \"Sai\" 36) (list 2 \"Ayesha\" 25) (list 3 \"Salman\" 45))) (list 36 25 45) 0.001)\n    (check-within (candidate (list (list 1 \"Sudeep\" 14) (list 2 \"Vandana\" 36) (list 3 \"Dawood\" 56))) (list 14 36 56) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\n(define (substract_elements test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate substract_elements))\n    (check-within (candidate (list 10 4 5) (list 2 5 18)) (list 8 -1 -13) 0.001)\n    (check-within (candidate (list 11 2 3) (list 24 45 16)) (list -13 -43 -13) 0.001)\n    (check-within (candidate (list 7 18 9) (list 10 11 12)) (list -3 7 -3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n(define (even_binomial_Coeff_Sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_binomial_Coeff_Sum))\n    (check-within (candidate 4) 8 0.001)\n    (check-within (candidate 6) 32 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a hash and integer n and filters the hash to only include entries with values greater than or equal to n.\n(define (dict_filter dict n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dict_filter))\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 170) #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 180) #hash((\"Alden Cantrell\" .  180) (\"Pierre Cox\" .  190)) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  175) (\"Alden Cantrell\" .  180) (\"Kierra Gentry\" .  165) (\"Pierre Cox\" .  190)) 190) #hash((\"Pierre Cox\" .  190)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the number of elements that occurs before the list element in the given list.\n(define (count_first_elements test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_first_elements))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) 3 0.001)\n    (check-within (candidate (list 2 9 (list 5 7) 11)) 2 0.001)\n    (check-within (candidate (list 11 15 5 8 (list 2 3) 8)) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth decagonal number.\n(define (is_num_decagonal n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_num_decagonal))\n    (check-within (candidate 3) 27 0.001)\n    (check-within (candidate 7) 175 0.001)\n    (check-within (candidate 10) 370 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and returns a list containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n(define (sequential_search dlist item)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequential_search))\n    (check-within (candidate (list 11 23 58 31 56 77 43 12 65 19) 31) (list #t 3) 0.001)\n    (check-within (candidate (list 12 32 45 62 35 47 44 61) 61) (list #t 7) 0.001)\n    (check-within (candidate (list 9 10 17 19 22 39 48 56) 48) (list #t 6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check if the elements of a given list are unique or not.\n(define (all_unique test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_unique))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to subtract two lists element-wise.\n(define (sub_list nums1 nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sub_list))\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) (list -3 -3 -3) 0.001)\n    (check-within (candidate (list 1 2) (list 3 4)) (list -2 -2) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 40 50) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n(define (validate n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate validate))\n    (check-within (candidate 1234) #t 0.001)\n    (check-within (candidate 51241) #f 0.001)\n    (check-within (candidate 321) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n(define (check_element list element)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_element))\n    (check-within (candidate (list \"green\" \"orange\" \"black\" \"white\") \"blue\") #f 0.001)\n    (check-within (candidate (list 1 2 3 4) 7) #f 0.001)\n    (check-within (candidate (list \"green\" \"green\" \"green\" \"green\") \"green\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n(define (text_match_two_three text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_two_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n(define (max_sub_array_sum_repeated a n k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum_repeated))\n    (check-within (candidate (list 10 20 -30 -1) 4 3) 30 0.001)\n    (check-within (candidate (list -1 10 20) 3 2) 59 0.001)\n    (check-within (candidate (list -1 -2 -3) 3 3) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n(define (square_Sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_Sum))\n    (check-within (candidate 2) 20 0.001)\n    (check-within (candidate 3) 56 0.001)\n    (check-within (candidate 4) 120 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the list of maximum length in a list of lists.\n(define (max_length list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1) (list 5 7) (list 10 12 14 15))) (list 4 (list 10 12 14 15)) 0.001)\n    (check-within (candidate (list (list 5) (list 15 20 25))) (list 3 (list 15 20 25)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n(define (count_no_of_ways n k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_no_of_ways))\n    (check-within (candidate 2 4) 16 0.001)\n    (check-within (candidate 3 2) 6 0.001)\n    (check-within (candidate 4 4) 228 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find quotient of two numbers (rounded down to the nearest integer).\n(define (find n m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find))\n    (check-within (candidate 10 3) 3 0.001)\n    (check-within (candidate 4 2) 2 0.001)\n    (check-within (candidate 20 5) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the third side of a right angled triangle.\n(define (otherside_rightangle w h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate otherside_rightangle))\n    (check-within (candidate 7 8) 10.63014581273465 0.001)\n    (check-within (candidate 3 4) 5 0.001)\n    (check-within (candidate 7 15) 16.55294535724685 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum value in a given heterogeneous list.\n(define (max_val listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 5 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 25 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 50 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return the sum of all divisors of a number.\n(define (sum_div number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_div))\n    (check-within (candidate 8) 7 0.001)\n    (check-within (candidate 12) 16 0.001)\n    (check-within (candidate 7) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count inversions in a list.\n(define (get_Inv_Count arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Inv_Count))\n    (check-within (candidate (list 1 20 6 4 5)) 5 0.001)\n    (check-within (candidate (list 1 2 1)) 1 0.001)\n    (check-within (candidate (list 1 2 5 6 1)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to flatten a given nested list structure.\n(define (flatten_list list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate flatten_list))\n    (check-within (candidate (list 0 10 (list 20 30) 40 50 (list 60 70 80) (list 90 100 110 120))) (list 0 10 20 30 40 50 60 70 80 90 100 110 120) 0.001)\n    (check-within (candidate (list (list 10 20) (list 40) (list 30 56 25) (list 10 20) (list 33) (list 40))) (list 10 20 40 30 56 25 10 20 33 40) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 1 2 3 4 5 6 10 11 12 7 8 9) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the maximum aggregate from the list of lists.\n(define (max_aggregate stdata)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_aggregate))\n    (check-within (candidate (list (list \"Juan Whelan\" 90) (list \"Sabah Colley\" 88) (list \"Peter Nichols\" 7) (list \"Juan Whelan\" 122) (list \"Sabah Colley\" 84))) (list \"Juan Whelan\" 212) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 50) (list \"Sabah Colley\" 48) (list \"Peter Nichols\" 37) (list \"Juan Whelan\" 22) (list \"Sabah Colley\" 14))) (list \"Juan Whelan\" 72) 0.001)\n    (check-within (candidate (list (list \"Juan Whelan\" 10) (list \"Sabah Colley\" 20) (list \"Peter Nichols\" 30) (list \"Juan Whelan\" 40) (list \"Sabah Colley\" 50))) (list \"Sabah Colley\" 70) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find element at a given index after number of rotations.\n(define (find_Element arr ranges rotations index)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Element))\n    (check-within (candidate (list 1 2 3 4 5) (list (list 0 2) (list 0 3)) 2 1) 3 0.001)\n    (check-within (candidate (list 1 2 3 4) (list (list 0 1) (list 0 2)) 1 2) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list (list 0 1) (list 0 2)) 1 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return two words from a list of words starting with letter 'p'.\n(define (start_withp words)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate start_withp))\n    (check-within (candidate (list \"Python PHP\" \"Java JavaScript\" \"c c++\")) (list \"Python\" \"PHP\") 0.001)\n    (check-within (candidate (list \"Python Programming\" \"Java Programming\")) (list \"Python\" \"Programming\") 0.001)\n    (check-within (candidate (list \"Pqrst Pqr\" \"qrstuv\")) (list \"Pqrst\" \"Pqr\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n(define (max_sum_increasing_subseq a n index k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_increasing_subseq))\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 4 6) 11 0.001)\n    (check-within (candidate (list 1 101 2 3 100 4 5) 7 2 5) 7 0.001)\n    (check-within (candidate (list 11 15 19 21 26 28 31) 7 2 4) 71 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n(define (large_product nums1 nums2 N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate large_product))\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 3) (list 60 54 50) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 4) (list 60 54 50 48) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 3 6 8 9 10 6) 5) (list 60 54 50 48 45) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the maximum of two numbers.\n(define (maximum a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maximum))\n    (check-within (candidate 5 10) 10 0.001)\n    (check-within (candidate -1 -2) -1 0.001)\n    (check-within (candidate 9 7) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a given string to a list of characters.\n(define (string_to_tuple str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate string_to_tuple))\n    (check-within (candidate \"python 3.0\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\" \"3\" \".\" \"0\") 0.001)\n    (check-within (candidate \"item1\") (list \"i\" \"t\" \"e\" \"m\" \"1\") 0.001)\n    (check-within (candidate \"15.10\") (list \"1\" \"5\" \".\" \"1\" \"0\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the highest power of 2 that is less than or equal to n.\n(define (highest_Power_of_2 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate highest_Power_of_2))\n    (check-within (candidate 10) 8 0.001)\n    (check-within (candidate 19) 16 0.001)\n    (check-within (candidate 32) 32 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n'th lucas number.\n(define (find_lucas n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_lucas))\n    (check-within (candidate 9) 76 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 3) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to apply a given format string to all of the elements in a list.\n(define (add_string list_ string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_string))\n    (check-within (candidate (list 1 2 3 4) \"temp{0}\") (list \"temp1\" \"temp2\" \"temp3\" \"temp4\") 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\" \"d\") \"python{0}\") (list \"pythona\" \"pythonb\" \"pythonc\" \"pythond\") 0.001)\n    (check-within (candidate (list 5 6 7 8) \"string{0}\") (list \"string5\" \"string6\" \"string7\" \"string8\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert more than one list to nested hash.\n(define (convert_list_dictionary l1 l2 l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate convert_list_dictionary))\n    (check-within (candidate (list \"S001\" \"S002\" \"S003\" \"S004\") (list \"Adina Park\" \"Leyton Marsh\" \"Duncan Boyle\" \"Saim Richards\") (list 85 98 89 92)) (list #hash((\"S001\" .  #hash((\"Adina Park\" .  85)))) #hash((\"S002\" .  #hash((\"Leyton Marsh\" .  98)))) #hash((\"S003\" .  #hash((\"Duncan Boyle\" .  89)))) #hash((\"S004\" .  #hash((\"Saim Richards\" .  92))))) 0.001)\n    (check-within (candidate (list \"abc\" \"def\" \"ghi\" \"jkl\") (list \"python\" \"program\" \"language\" \"programs\") (list 100 200 300 400)) (list #hash((\"abc\" .  #hash((\"python\" .  100)))) #hash((\"def\" .  #hash((\"program\" .  200)))) #hash((\"ghi\" .  #hash((\"language\" .  300)))) #hash((\"jkl\" .  #hash((\"programs\" .  400))))) 0.001)\n    (check-within (candidate (list \"A1\" \"A2\" \"A3\" \"A4\") (list \"java\" \"C\" \"C++\" \"DBMS\") (list 10 20 30 40)) (list #hash((\"A1\" .  #hash((\"java\" .  10)))) #hash((\"A2\" .  #hash((\"C\" .  20)))) #hash((\"A3\" .  #hash((\"C++\" .  30)))) #hash((\"A4\" .  #hash((\"DBMS\" .  40))))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n(define (get_max_sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_max_sum))\n    (check-within (candidate 60) 106 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the list with maximum length.\n(define (max_length_list input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_length_list))\n    (check-within (candidate (list (list 0) (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) (list 3 (list 13 15 17)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4 5) (list 1 2 3 4) (list 1 2 3) (list 1 2) (list 1))) (list 5 (list 1 2 3 4 5)) 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 6 7 8 9) (list 10 11 12))) (list 4 (list 6 7 8 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if given list contains no duplicates.\n(define (check_distinct test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_distinct))\n    (check-within (candidate (list 1 4 5 6 1 4)) #f 0.001)\n    (check-within (candidate (list 1 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 6)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first non-repeated character in a given string.\n(define (first_non_repeating_character str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_non_repeating_character))\n    (check-within (candidate \"abcabc\") #f 0.001)\n    (check-within (candidate \"abc\") \"a\" 0.001)\n    (check-within (candidate \"ababc\") \"c\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given string starts and ends with the same character or not.\n(define (check_char string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_char))\n    (check-within (candidate \"abba\") \"Valid\" 0.001)\n    (check-within (candidate \"a\") \"Valid\" 0.001)\n    (check-within (candidate \"abcd\") \"Invalid\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median of three numbers.\n(define (median_numbers a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_numbers))\n    (check-within (candidate 25 55 65) 55.0 0.001)\n    (check-within (candidate 20 10 30) 20.0 0.001)\n    (check-within (candidate 15 45 75) 45.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to compute the sum of digits of each number of a given list.\n(define (sum_of_digits nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_of_digits))\n    (check-within (candidate (list 10 2 56)) 14 0.001)\n    (check-within (candidate (list (list 10 20 4 5 \"b\" 70 \"a\"))) 19 0.001)\n    (check-within (candidate (list 10 20 -4 5 -70)) 19 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform the mathematical bitwise xor operation across the given lists.\n(define (bitwise_xor test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bitwise_xor))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 15 6 5 10) 0.001)\n    (check-within (candidate (list 11 5 7 10) (list 6 3 4 4)) (list 13 6 3 14) 0.001)\n    (check-within (candidate (list 12 6 8 11) (list 7 4 5 6)) (list 11 2 13 13) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to identify non-prime numbers.\n(define (is_not_prime n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_not_prime))\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 35) #t 0.001)\n    (check-within (candidate 37) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the number of unique lists in the given list.\n(define (extract_freq test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_freq))\n    (check-within (candidate (list (list 3 4) (list 1 2) (list 4 3) (list 5 6))) 3 0.001)\n    (check-within (candidate (list (list 4 15) (list 2 3) (list 5 4) (list 6 7))) 4 0.001)\n    (check-within (candidate (list (list 5 16) (list 2 3) (list 6 5) (list 6 9))) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform index wise addition of list elements in the given two nested lists.\n(define (add_nested_tuples test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_nested_tuples))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 7 10) (list 7 14) (list 3 10) (list 8 13)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 9 12) (list 9 16) (list 5 12) (list 10 15)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 11 14) (list 11 18) (list 7 14) (list 12 17)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum of two numbers.\n(define (minimum a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate minimum))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate -5 -4) -5 0.001)\n    (check-within (candidate 0 0) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether an element exists within a list.\n(define (check_tuplex tuplex tuple1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_tuplex))\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"r\") #t 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") \"5\") #f 0.001)\n    (check-within (candidate (list \"w\" 3 \"r\" \"e\" \"s\" \"o\" \"u\" \"r\" \"c\" \"e\") 3) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find whether the parity of a given number is odd.\n(define (find_Parity x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Parity))\n    (check-within (candidate 12) #f 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create the next bigger number by rearranging the digits of a given number.\n(define (rearrange_bigger n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rearrange_bigger))\n    (check-within (candidate 12) 21 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 102) 120 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n(define (k_smallest_pairs nums1 nums2 k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate k_smallest_pairs))\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 2) (list (list 1 2) (list 1 4)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 1) (list (list 1 2)) 0.001)\n    (check-within (candidate (list 1 3 7) (list 2 4 6) 7) (list (list 1 2) (list 1 4) (list 3 2) (list 1 6) (list 3 4) (list 3 6) (list 7 2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the minimum product from the pairs of lists within a given list.\n(define (min_product_tuple list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_product_tuple))\n    (check-within (candidate (list (list 2 7) (list 2 6) (list 1 8) (list 4 9))) 8 0.001)\n    (check-within (candidate (list (list 10 20) (list 15 2) (list 5 10))) 30 0.001)\n    (check-within (candidate (list (list 11 44) (list 10 15) (list 20 5) (list 12 9))) 100 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the minimum value in a given heterogeneous list.\n(define (min_val listval)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_val))\n    (check-within (candidate (list \"Python\" 3 2 4 5 \"version\")) 2 0.001)\n    (check-within (candidate (list \"Python\" 15 20 25)) 15 0.001)\n    (check-within (candidate (list \"Python\" 30 20 40 50 \"version\")) 20 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given snake case string to camel case string.\n(define (snake_to_camel word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate snake_to_camel))\n    (check-within (candidate \"android_tv\") \"AndroidTv\" 0.001)\n    (check-within (candidate \"google_pixel\") \"GooglePixel\" 0.001)\n    (check-within (candidate \"apple_watch\") \"AppleWatch\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to remove odd numbers from a given list.\n(define (remove_odd l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate (list 1 2 3)) (list 2) 0.001)\n    (check-within (candidate (list 2 4 6)) (list 2 4 6) 0.001)\n    (check-within (candidate (list 10 20 3)) (list 10 20) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the nth element from a given list of lists.\n(define (extract_nth_element list1 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_nth_element))\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 0) (list \"Greyson Fulton\" \"Brady Kent\" \"Wyatt Knott\" \"Beau Turnbull\") 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 2) (list 99 96 94 98) 0.001)\n    (check-within (candidate (list (list \"Greyson Fulton\" 98 99) (list \"Brady Kent\" 97 96) (list \"Wyatt Knott\" 91 94) (list \"Beau Turnbull\" 94 98)) 1) (list 98 97 91 94) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether any value in a sequence exists in a sequence or not.\n(define (overlapping list1 list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate overlapping))\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list 1 2 3) (list 4 5 6)) #f 0.001)\n    (check-within (candidate (list 1 4 5) (list 1 4 5)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find a pair with highest product from a given list of integers.\n(define (max_Product arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_Product))\n    (check-within (candidate (list 1 2 3 4 7 0 8 4)) (list 7 8) 0.001)\n    (check-within (candidate (list 0 -1 -2 -4 5 0 -6)) (list -4 -6) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 2 3) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",
@@ -5929,7 +2149,7 @@
     "language": "rkt",
     "prompt": "#lang racket\n\n;; Write a function to find common first element in given list of lists.\n(define (group_tuples Input)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate group_tuples))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"x\" \"z\") (list \"w\" \"t\"))) (list (list \"x\" \"y\" \"z\") (list \"w\" \"t\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"a\" \"c\") (list \"d\" \"e\"))) (list (list \"a\" \"b\" \"c\") (list \"d\" \"e\")) 0.001)\n    (check-within (candidate (list (list \"f\" \"g\") (list \"f\" \"g\") (list \"h\" \"i\"))) (list (list \"f\" \"g\" \"g\") (list \"h\" \"i\")) 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
@@ -5940,13 +2160,3793 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "rkt",
-    "prompt": "#lang racket\n\n;; Write a function to merge three lists into a single sorted list.\n(define (merge_sorted_list num1 num2 num3)\n",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the element of a list having maximum length.\n(define (Find_Max lst)\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_sorted_list))\n    (check-within (candidate (list 25 24 15 4 5 29 110) (list 19 20 11 56 25 233 154) (list 24 26 54 48)) (list 4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233) 0.001)\n    (check-within (candidate (list 1 3 5 6 8 9) (list 2 5 7 11) (list 1 4 7 8 12)) (list 1 1 2 3 4 5 5 6 7 7 8 8 9 11 12) 0.001)\n    (check-within (candidate (list 18 14 10 9 8 7 9 3 2 4 1) (list 25 35 22 85 14 65 75 25 58) (list 12 74 9 50 61 41)) (list 1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85) 0.001)\n))\n\n(test-humaneval)",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max))\n    (check-within (candidate (list (list \"A\") (list \"A\" \"B\") (list \"A\" \"B\" \"C\"))) (list \"A\" \"B\" \"C\") 0.001)\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1 2 3) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 2 3) (list 1 5 6 1))) (list 1 5 6 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n(define (round_and_sum list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate round_and_sum))\n    (check-within (candidate (list 22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5)) 243 0.001)\n    (check-within (candidate (list 5 2 9 24.3 29)) 345 0.001)\n    (check-within (candidate (list 25.0 56.7 89.2)) 513 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the cube sum of first n even natural numbers.\n(define (cube_Sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_Sum))\n    (check-within (candidate 2) 72 0.001)\n    (check-within (candidate 3) 288 0.001)\n    (check-within (candidate 4) 800 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to concatenate each element of list by the delimiter.\n(define (concatenate_tuple test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate concatenate_tuple))\n    (check-within (candidate (list \"ID\" \"is\" 4 \"UTS\")) \"ID-is-4-UTS\" 0.001)\n    (check-within (candidate (list \"QWE\" \"is\" 4 \"RTY\")) \"QWE-is-4-RTY\" 0.001)\n    (check-within (candidate (list \"ZEN\" \"is\" 4 \"OP\")) \"ZEN-is-4-OP\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the average of cubes of first n natural numbers.\n(define (find_Average_Of_Cube n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Average_Of_Cube))\n    (check-within (candidate 2) 4.5 0.001)\n    (check-within (candidate 3) 12 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract only the rear index element of each string in the given list.\n(define (extract_rear test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_rear))\n    (check-within (candidate (list \"Mers\" \"for\" \"Vers\")) (list \"s\" \"r\" \"s\") 0.001)\n    (check-within (candidate (list \"Avenge\" \"for\" \"People\")) (list \"e\" \"r\" \"e\") 0.001)\n    (check-within (candidate (list \"Gotta\" \"get\" \"go\")) (list \"a\" \"t\" \"o\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the number of sublists containing a particular element.\n(define (count_element_in_list list1 x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_element_in_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 1 11) (list 1 15 7)) 1) 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"A\") 3 0.001)\n    (check-within (candidate (list (list \"A\" \"B\") (list \"A\" \"C\") (list \"A\" \"D\" \"E\") (list \"B\" \"C\" \"D\")) \"E\") 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to filter odd numbers.\n(define (filter_oddnumbers nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_oddnumbers))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 3 5 7 9) 0.001)\n    (check-within (candidate (list 10 20 45 67 84 93)) (list 45 67 93) 0.001)\n    (check-within (candidate (list 5 7 9 8 6 4 3)) (list 5 7 9 3) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n(define (change_date_format dt)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate change_date_format))\n    (check-within (candidate \"2026-01-02\") \"02-01-2026\" 0.001)\n    (check-within (candidate \"2020-11-13\") \"13-11-2020\" 0.001)\n    (check-within (candidate \"2021-04-26\") \"26-04-2021\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort the given list by using shell sort.\n(define (shell_sort my_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate shell_sort))\n    (check-within (candidate (list 12 23 4 5 3 2 12 81 56 95)) (list 2 3 4 5 12 12 23 56 81 95) 0.001)\n    (check-within (candidate (list 24 22 39 34 87 73 68)) (list 22 24 34 39 68 73 87) 0.001)\n    (check-within (candidate (list 32 30 16 96 82 83 74)) (list 16 30 32 74 82 83 96) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract the elementwise and lists from the given two lists.\n(define (and_tuples test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate and_tuples))\n    (check-within (candidate (list 10 4 6 9) (list 5 2 3 3)) (list 0 0 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 5 6 7 8)) (list 1 2 3 0) 0.001)\n    (check-within (candidate (list 8 9 11 12) (list 7 13 14 17)) (list 0 9 10 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the directrix of a parabola.\n(define (parabola_directrix a b c)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate parabola_directrix))\n    (check-within (candidate 5 3 2) -198 0.001)\n    (check-within (candidate 9 8 4) -2336 0.001)\n    (check-within (candidate 2 4 6) -130 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes two lists and returns true if they have at least one common element.\n(define (common_element list1 list2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate common_element))\n    (check-within (candidate (list 1 2 3 4 5) (list 5 6 7 8 9)) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 8 9)) #f 0.001)\n    (check-within (candidate (list \"a\" \"b\" \"c\") (list \"d\" \"b\" \"e\")) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median length of a trapezium.\n(define (median_trapezium base1 base2 height)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate median_trapezium))\n    (check-within (candidate 15 25 35) 20 0.001)\n    (check-within (candidate 10 20 30) 15 0.001)\n    (check-within (candidate 6 9 4) 7.5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the entered number is greater than the elements of the given list.\n(define (check_greater arr number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_greater))\n    (check-within (candidate (list 1 2 3 4 5) 4) #f 0.001)\n    (check-within (candidate (list 2 3 4 5 6) 8) #t 0.001)\n    (check-within (candidate (list 9 7 4 8 6 1) 11) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by one or more b's.\n(define (text_match_one text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last digit of a given number.\n(define (last_Digit n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit))\n    (check-within (candidate 123) 3 0.001)\n    (check-within (candidate 25) 5 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to return the negative numbers in a list.\n(define (neg_nos list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate neg_nos))\n    (check-within (candidate (list -1 4 5 -6)) (list -1 -6) 0.001)\n    (check-within (candidate (list -1 -2 3 4)) (list -1 -2) 0.001)\n    (check-within (candidate (list -7 -6 8 9)) (list -7 -6) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove odd characters in a string.\n(define (remove_odd str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_odd))\n    (check-within (candidate \"python\") \"yhn\" 0.001)\n    (check-within (candidate \"program\") \"rga\" 0.001)\n    (check-within (candidate \"language\") \"agae\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count bidirectional list pairs.\n(define (count_bidirectional test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_bidirectional))\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 3 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 3) (list 6 5) (list 9 1) (list 6 5) (list 2 1))) 2 0.001)\n    (check-within (candidate (list (list 5 6) (list 1 2) (list 6 5) (list 9 2) (list 6 5) (list 2 1))) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to join a list of multiple integers into a single integer.\n(define (multiple_to_single L)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiple_to_single))\n    (check-within (candidate (list 11 33 50)) 113350 0.001)\n    (check-within (candidate (list -1 2 3 4 5 6)) -123456 0.001)\n    (check-within (candidate (list 10 15 20 25)) 10152025 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the first adverb and their positions in a given sentence.\n(define (find_adverb_position text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverb_position))\n    (check-within (candidate \"clearly!! we can see the sky\") (list 0 7 \"clearly\") 0.001)\n    (check-within (candidate \"seriously!! there are many roses\") (list 0 9 \"seriously\") 0.001)\n    (check-within (candidate \"unfortunately!! sita is going to home\") (list 0 13 \"unfortunately\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cube of a given size.\n(define (surfacearea_cube l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cube))\n    (check-within (candidate 5) 150 0.001)\n    (check-within (candidate 3) 54 0.001)\n    (check-within (candidate 10) 600 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the ration of positive numbers in a list of integers.\n(define (positive_count nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate positive_count))\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8)) 0.54 0.001)\n    (check-within (candidate (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 0.69 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17)) 0.56 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the largest negative number from the given list.\n(define (largest_neg list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate largest_neg))\n    (check-within (candidate (list 1 2 3 -4 -6)) -6 0.001)\n    (check-within (candidate (list 1 2 3 -8 -9)) -9 0.001)\n    (check-within (candidate (list 1 2 3 4 -1)) -1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to trim each list by k in the given lists.\n(define (trim_tuple test_list K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate trim_tuple))\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 2) (list (list 2) (list 9) (list 2) (list 2)) 0.001)\n    (check-within (candidate (list (list 5 3 2 1 4) (list 3 4 9 2 1) (list 9 1 2 3 5) (list 4 8 2 1 7)) 1) (list (list 3 2 1) (list 4 9 2) (list 1 2 3) (list 8 2 1)) 0.001)\n    (check-within (candidate (list (list 7 8 4 9) (list 11 8 12 4) (list 4 1 7 8) (list 3 6 9 7)) 1) (list (list 8 4) (list 8 12) (list 1 7) (list 6 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to perform index wise multiplication of list elements in the given two lists.\n(define (index_multiplication test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_multiplication))\n    (check-within (candidate (list (list 1 3) (list 4 5) (list 2 9) (list 1 10)) (list (list 6 7) (list 3 9) (list 1 1) (list 7 3))) (list (list 6 21) (list 12 45) (list 2 9) (list 7 30)) 0.001)\n    (check-within (candidate (list (list 2 4) (list 5 6) (list 3 10) (list 2 11)) (list (list 7 8) (list 4 10) (list 2 2) (list 8 4))) (list (list 14 32) (list 20 60) (list 6 20) (list 16 44)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 6 7) (list 4 11) (list 3 12)) (list (list 8 9) (list 5 11) (list 3 3) (list 9 5))) (list (list 24 45) (list 30 77) (list 12 33) (list 27 60)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the occurence of all elements of list in a list.\n(define (count_Occurrence tup lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Occurrence))\n    (check-within (candidate (list \"a\" \"a\" \"c\" \"b\" \"d\") (list \"a\" \"b\")) 3 0.001)\n    (check-within (candidate (list 1 2 3 1 4 6 7 1 4) (list 1 4 7)) 6 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) (list 1 2)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find cubes of individual elements in a list.\n(define (cube_nums nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cube_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 8 27 64 125 216 343 512 729 1000) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15)) (list 1728 3375) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the sum of perrin numbers.\n(define (cal_sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cal_sum))\n    (check-within (candidate 9) 49 0.001)\n    (check-within (candidate 10) 66 0.001)\n    (check-within (candidate 11) 88 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract specified size of strings from a given list of string values.\n(define (extract_string str l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_string))\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 8) (list \"practice\" \"solution\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 6) (list \"Python\") 0.001)\n    (check-within (candidate (list \"Python\" \"list\" \"exercises\" \"practice\" \"solution\") 9) (list \"exercises\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from the given string.\n(define (remove_whitespaces text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_whitespaces))\n    (check-within (candidate \" Google    Flutter \") \"GoogleFlutter\" 0.001)\n    (check-within (candidate \" Google    Dart \") \"GoogleDart\" 0.001)\n    (check-within (candidate \" iOS    Swift \") \"iOSSwift\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n(define (loss_amount actual_cost sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate loss_amount))\n    (check-within (candidate 1500 1200) 0 0.001)\n    (check-within (candidate 100 200) 100 0.001)\n    (check-within (candidate 2000 5000) 3000 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of even factors of a number.\n(define (sumofFactors n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sumofFactors))\n    (check-within (candidate 18) 26 0.001)\n    (check-within (candidate 30) 48 0.001)\n    (check-within (candidate 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a word containing 'z'.\n(define (text_match_wordz text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz))\n    (check-within (candidate \"pythonz.\") #t 0.001)\n    (check-within (candidate \"xyz.\") #t 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 31 days or not.\n(define (check_monthnumb_number monthnum2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumb_number))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 6) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to reverse each string in a given list of string values.\n(define (reverse_string_list stringlist)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_string_list))\n    (check-within (candidate (list \"Red\" \"Green\" \"Blue\" \"White\" \"Black\")) (list \"deR\" \"neerG\" \"eulB\" \"etihW\" \"kcalB\") 0.001)\n    (check-within (candidate (list \"john\" \"amal\" \"joel\" \"george\")) (list \"nhoj\" \"lama\" \"leoj\" \"egroeg\") 0.001)\n    (check-within (candidate (list \"jack\" \"john\" \"mary\")) (list \"kcaj\" \"nhoj\" \"yram\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sublist having minimum length.\n(define (Find_Min lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min))\n    (check-within (candidate (list (list 1) (list 1 2) (list 1 2 3))) (list 1) 0.001)\n    (check-within (candidate (list (list 1 1) (list 1 1 1) (list 1 2 7 8))) (list 1 1) 0.001)\n    (check-within (candidate (list (list \"x\") (list \"x\" \"y\") (list \"x\" \"y\" \"z\"))) (list \"x\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the area of a rectangle.\n(define (rectangle_area l b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rectangle_area))\n    (check-within (candidate 10 20) 200 0.001)\n    (check-within (candidate 10 5) 50 0.001)\n    (check-within (candidate 4 2) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove uppercase substrings from a given string.\n(define (remove_uppercase str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_uppercase))\n    (check-within (candidate \"cAstyoUrFavoRitETVshoWs\") \"cstyoravoitshos\" 0.001)\n    (check-within (candidate \"wAtchTheinTernEtrAdIo\") \"wtchheinerntrdo\" 0.001)\n    (check-within (candidate \"VoicESeaRchAndreComMendaTionS\") \"oiceachndreomendaion\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to get the first element of each sublist.\n(define (Extract lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Extract))\n    (check-within (candidate (list (list 1 2) (list 3 4 5) (list 6 7 8 9))) (list 1 3 6) 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5))) (list 1 4) 0.001)\n    (check-within (candidate (list (list 9 8 1) (list 1 2))) (list 9 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the upper case characters in a given string.\n(define (upper_ctr str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate upper_ctr))\n    (check-within (candidate \"PYthon\") 1 0.001)\n    (check-within (candidate \"BigData\") 1 0.001)\n    (check-within (candidate \"program\") 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find all possible combinations of the elements of a given list.\n(define (combinations_list list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate combinations_list))\n    (check-within (candidate (list \"orange\" \"red\" \"green\" \"blue\")) (list (list ) (list \"orange\") (list \"red\") (list \"red\" \"orange\") (list \"green\") (list \"green\" \"orange\") (list \"green\" \"red\") (list \"green\" \"red\" \"orange\") (list \"blue\") (list \"blue\" \"orange\") (list \"blue\" \"red\") (list \"blue\" \"red\" \"orange\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"orange\") (list \"blue\" \"green\" \"red\") (list \"blue\" \"green\" \"red\" \"orange\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"blue\" \"white\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"blue\") (list \"blue\" \"red\") (list \"blue\" \"green\") (list \"blue\" \"green\" \"red\") (list \"white\") (list \"white\" \"red\") (list \"white\" \"green\") (list \"white\" \"green\" \"red\") (list \"white\" \"blue\") (list \"white\" \"blue\" \"red\") (list \"white\" \"blue\" \"green\") (list \"white\" \"blue\" \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"black\" \"blue\") (list \"black\" \"blue\" \"red\") (list \"black\" \"blue\" \"green\") (list \"black\" \"blue\" \"green\" \"red\") (list \"black\" \"white\") (list \"black\" \"white\" \"red\") (list \"black\" \"white\" \"green\") (list \"black\" \"white\" \"green\" \"red\") (list \"black\" \"white\" \"blue\") (list \"black\" \"white\" \"blue\" \"red\") (list \"black\" \"white\" \"blue\" \"green\") (list \"black\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"blue\") (list \"orange\" \"blue\" \"red\") (list \"orange\" \"blue\" \"green\") (list \"orange\" \"blue\" \"green\" \"red\") (list \"orange\" \"white\") (list \"orange\" \"white\" \"red\") (list \"orange\" \"white\" \"green\") (list \"orange\" \"white\" \"green\" \"red\") (list \"orange\" \"white\" \"blue\") (list \"orange\" \"white\" \"blue\" \"red\") (list \"orange\" \"white\" \"blue\" \"green\") (list \"orange\" \"white\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\") (list \"orange\" \"black\" \"blue\") (list \"orange\" \"black\" \"blue\" \"red\") (list \"orange\" \"black\" \"blue\" \"green\") (list \"orange\" \"black\" \"blue\" \"green\" \"red\") (list \"orange\" \"black\" \"white\") (list \"orange\" \"black\" \"white\" \"red\") (list \"orange\" \"black\" \"white\" \"green\") (list \"orange\" \"black\" \"white\" \"green\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\") (list \"orange\" \"black\" \"white\" \"blue\" \"red\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\") (list \"orange\" \"black\" \"white\" \"blue\" \"green\" \"red\")) 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"black\" \"orange\")) (list (list ) (list \"red\") (list \"green\") (list \"green\" \"red\") (list \"black\") (list \"black\" \"red\") (list \"black\" \"green\") (list \"black\" \"green\" \"red\") (list \"orange\") (list \"orange\" \"red\") (list \"orange\" \"green\") (list \"orange\" \"green\" \"red\") (list \"orange\" \"black\") (list \"orange\" \"black\" \"red\") (list \"orange\" \"black\" \"green\") (list \"orange\" \"black\" \"green\" \"red\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum product sublist of the given list.\n(define (max_subarray_product arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_subarray_product))\n    (check-within (candidate (list 1 -2 -3 0 7 -8 -2)) 112 0.001)\n    (check-within (candidate (list 6 -3 -10 0 2)) 180 0.001)\n    (check-within (candidate (list -2 -40 0 -2 -3)) 80 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if all values are same in a hash.\n(define (check_value dict n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_value))\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 10) #f 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 12) #t 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  12) (\"Alden Cantrell\" .  12) (\"Kierra Gentry\" .  12) (\"Pierre Cox\" .  12)) 5) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to drop empty items from a given hash.\n(define (drop_empty dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate drop_empty))\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\") (\"c2\" .  \"Green\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  \"Red\") (\"c2\" .  #f) (\"c3\" .  #f))) #hash((\"c1\" .  \"Red\")) 0.001)\n    (check-within (candidate #hash((\"c1\" .  #f) (\"c2\" .  \"Green\") (\"c3\" .  #f))) #hash((\"c2\" .  \"Green\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n(define (max_product arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_product))\n    (check-within (candidate (list 3 100 4 5 150 6)) 3000 0.001)\n    (check-within (candidate (list 4 42 55 68 80)) 50265600 0.001)\n    (check-within (candidate (list 10 22 9 33 21 50 41 60)) 2460 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the pairwise addition of the neighboring elements of the given list.\n(define (add_pairwise test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_pairwise))\n    (check-within (candidate (list 1 5 7 8 10)) (list 6 12 15 18) 0.001)\n    (check-within (candidate (list 2 6 8 9 11)) (list 8 14 17 20) 0.001)\n    (check-within (candidate (list 3 7 9 10 12)) (list 10 16 19 22) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the product of the list multiplication modulo n.\n(define (find_remainder arr n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_remainder))\n    (check-within (candidate (list 100 10 5 25 35 14) 11) 9 0.001)\n    (check-within (candidate (list 1 1 1) 1) 0 0.001)\n    (check-within (candidate (list 1 2 1) 2) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given list contains consecutive numbers or not.\n(define (check_Consecutive l)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_Consecutive))\n    (check-within (candidate (list 1 2 3 4 5)) #t 0.001)\n    (check-within (candidate (list 1 2 3 5 6)) #f 0.001)\n    (check-within (candidate (list 1 2 1)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace characters in a string.\n(define (replace_char str1 ch newch)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_char))\n    (check-within (candidate \"polygon\" \"y\" \"l\") \"pollgon\" 0.001)\n    (check-within (candidate \"character\" \"c\" \"a\") \"aharaater\" 0.001)\n    (check-within (candidate \"python\" \"l\" \"a\") \"python\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a hash by value.\n(define (sort_counter dict1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_counter))\n    (check-within (candidate #hash((\"Math\" .  81) (\"Physics\" .  83) (\"Chemistry\" .  87))) (list (list \"Chemistry\" 87) (list \"Physics\" 83) (list \"Math\" 81)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  400) (\"Physics\" .  300) (\"Chemistry\" .  250))) (list (list \"Math\" 400) (list \"Physics\" 300) (list \"Chemistry\" 250)) 0.001)\n    (check-within (candidate #hash((\"Math\" .  900) (\"Physics\" .  1000) (\"Chemistry\" .  1250))) (list (list \"Chemistry\" 1250) (list \"Physics\" 1000) (list \"Math\" 900)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the largest and smallest value in a given list.\n(define (big_sum nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_sum))\n    (check-within (candidate (list 1 2 3)) 4 0.001)\n    (check-within (candidate (list -1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 2 3 6)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to convert the given string to lower case.\n(define (is_lower string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_lower))\n    (check-within (candidate \"InValid\") \"invalid\" 0.001)\n    (check-within (candidate \"TruE\") \"true\" 0.001)\n    (check-within (candidate \"SenTenCE\") \"sentence\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove lowercase substrings from a given string.\n(define (remove_lowercase str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_lowercase))\n    (check-within (candidate \"PYTHon\") \"PYTH\" 0.001)\n    (check-within (candidate \"FInD\") \"FID\" 0.001)\n    (check-within (candidate \"STRinG\") \"STRG\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first digit of a given number.\n(define (first_Digit n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_Digit))\n    (check-within (candidate 123) 1 0.001)\n    (check-within (candidate 456) 4 0.001)\n    (check-within (candidate 12) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n(define (heap_queue_largest nums n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_queue_largest))\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 3) (list 85 75 65) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 2) (list 85 75) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 22 58) 5) (list 85 75 65 58 35) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of integers and only returns the odd ones.\n(define (Split list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5 6)) (list 1 3 5) 0.001)\n    (check-within (candidate (list 10 11 12 13)) (list 11 13) 0.001)\n    (check-within (candidate (list 7 8 9 1)) (list 7 9 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n(define (difference n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate difference))\n    (check-within (candidate 3) 30 0.001)\n    (check-within (candidate 5) 210 0.001)\n    (check-within (candidate 2) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of pairs whose xor value is odd.\n(define (find_Odd_Pair A N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Odd_Pair))\n    (check-within (candidate (list 5 4 7 2 1) 5) 6 0.001)\n    (check-within (candidate (list 7 2 8 1 0 5 11) 7) 12 0.001)\n    (check-within (candidate (list 1 2 3) 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to toggle the case of all characters in a string.\n(define (toggle_string string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_string))\n    (check-within (candidate \"Python\") \"pYTHON\" 0.001)\n    (check-within (candidate \"Pangram\") \"pANGRAM\" 0.001)\n    (check-within (candidate \"LIttLE\") \"liTTle\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the per-digit difference between two integers.\n(define (digit_distance_nums n1 n2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate digit_distance_nums))\n    (check-within (candidate 1 2) 1 0.001)\n    (check-within (candidate 23 56) 6 0.001)\n    (check-within (candidate 123 256) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the sum of the largest contiguous sublist in the given list.\n(define (max_sub_array_sum a size)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sub_array_sum))\n    (check-within (candidate (list -2 -3 4 -1 -2 1 5 -3) 8) 7 0.001)\n    (check-within (candidate (list -3 -4 5 -2 -3 2 6 -4) 8) 8 0.001)\n    (check-within (candidate (list -4 -5 6 -3 -4 3 7 -5) 8) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the union of the elements of two given lists and output them in sorted order.\n(define (union_elements test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate union_elements))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 4 5 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 3 4 5 6)) (list 1 2 3 4 5 6) 0.001)\n    (check-within (candidate (list 11 12 13 14) (list 13 15 16 17)) (list 11 12 13 14 15 16 17) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the longest sublists.\n(define (Find_Max_Length lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Max_Length))\n    (check-within (candidate (list (list 1) (list 1 4) (list 5 6 7 8))) 4 0.001)\n    (check-within (candidate (list (list 0 1) (list 2 2) (list 3 2 1))) 3 0.001)\n    (check-within (candidate (list (list 7) (list 22 23) (list 13 14 15) (list 10 20 30 40 50))) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks from a string.\n(define (extract_values text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_values))\n    (check-within (candidate \"\"Python\", \"PHP\", \"Java\"\") (list \"Python\" \"PHP\" \"Java\") 0.001)\n    (check-within (candidate \"\"python\",\"program\",\"language\"\") (list \"python\" \"program\" \"language\") 0.001)\n    (check-within (candidate \"\"red\",\"blue\",\"green\",\"yellow\"\") (list \"red\" \"blue\" \"green\" \"yellow\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n(define (count_Pairs arr n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Pairs))\n    (check-within (candidate (list 1 2 1) 3) 2 0.001)\n    (check-within (candidate (list 1 1 1 1) 4) 0 0.001)\n    (check-within (candidate (list 1 2 3 4 5) 5) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to split a string into characters.\n(define (split word)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split))\n    (check-within (candidate \"python\") (list \"p\" \"y\" \"t\" \"h\" \"o\" \"n\") 0.001)\n    (check-within (candidate \"Name\") (list \"N\" \"a\" \"m\" \"e\") 0.001)\n    (check-within (candidate \"program\") (list \"p\" \"r\" \"o\" \"g\" \"r\" \"a\" \"m\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get the sum of the digits of a non-negative integer.\n(define (sum_digits n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_digits))\n    (check-within (candidate 345) 12 0.001)\n    (check-within (candidate 12) 3 0.001)\n    (check-within (candidate 97) 16 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a specified list is sorted or not.\n(define (issort_list list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate issort_list))\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 16 17)) #t 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 12 14 20 17)) #f 0.001)\n    (check-within (candidate (list 1 2 4 6 8 10 15 14 20)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create a list of N empty dictionaries.\n(define (empty_list length)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate empty_list))\n    (check-within (candidate 5) (list #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 6) (list #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n    (check-within (candidate 7) (list #hash() #hash() #hash() #hash() #hash() #hash() #hash()) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort each sublist of strings in a given list of lists.\n(define (sort_sublists list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_sublists))\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"white\" \"black\" \"orange\"))) (list (list \"green\" \"orange\") (list \"black\" \"white\") (list \"black\" \"orange\" \"white\")) 0.001)\n    (check-within (candidate (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\"))) (list (list \"green\" \"orange\") (list \"black\") (list \"green\" \"orange\") (list \"white\")) 0.001)\n    (check-within (candidate (list (list \"a\" \"b\") (list \"d\" \"c\") (list \"g\" \"h\") (list \"f\" \"e\"))) (list (list \"a\" \"b\") (list \"c\" \"d\") (list \"g\" \"h\") (list \"e\" \"f\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check if a given number is one less than twice its reverse.\n(define (checks n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate checks))\n    (check-within (candidate 70) #f 0.001)\n    (check-within (candidate 23) #f 0.001)\n    (check-within (candidate 73) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to remove duplicate numbers from a given number of lists.\n(define (two_unique_nums nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate two_unique_nums))\n    (check-within (candidate (list 1 2 3 2 3 4 5)) (list 1 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 2 4 5)) (list 1 3 4 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) (list 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to calculate the product of the unique numbers in a given list.\n(define (unique_product list_data)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_product))\n    (check-within (candidate (list 10 20 30 40 20 50 60 40)) 720000000 0.001)\n    (check-within (candidate (list 1 2 3 1)) 6 0.001)\n    (check-within (candidate (list 7 8 9 0 1 1)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the surface area of a cylinder.\n(define (surfacearea_cylinder r h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surfacearea_cylinder))\n    (check-within (candidate 10 5) 942.45 0.001)\n    (check-within (candidate 4 5) 226.18800000000002 0.001)\n    (check-within (candidate 4 10) 351.848 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether a list is sublist of another or not.\n(define (is_Sub_Array A B)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Sub_Array))\n    (check-within (candidate (list 1 4 3 5) (list 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 1) (list 1 2 1)) #t 0.001)\n    (check-within (candidate (list 1 0 2 2) (list 2 2 0)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last digit in factorial of a given number.\n(define (last_Digit_Factorial n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last_Digit_Factorial))\n    (check-within (candidate 4) 4 0.001)\n    (check-within (candidate 21) 0 0.001)\n    (check-within (candidate 30) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to interleave 3 lists of the same length into a single flat list.\n(define (interleave_lists list1 list2 list3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate interleave_lists))\n    (check-within (candidate (list 1 2 3 4 5 6 7) (list 10 20 30 40 50 60 70) (list 100 200 300 400 500 600 700)) (list 1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700) 0.001)\n    (check-within (candidate (list 10 20) (list 15 2) (list 5 10)) (list 10 15 5 20 2 10) 0.001)\n    (check-within (candidate (list 11 44) (list 10 15) (list 20 5)) (list 11 10 20 44 15 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the dissimilar elements in the given two lists.\n(define (find_dissimilar test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_dissimilar))\n    (check-within (candidate (list 3 4 5 6) (list 5 7 4 10)) (list 3 6 7 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) (list 7 2 3 9)) (list 1 4 7 9) 0.001)\n    (check-within (candidate (list 21 11 25 26) (list 26 34 21 36)) (list 34 36 11 25) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the largest number that can be formed with the given list of digits.\n(define (find_Max_Num arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Max_Num))\n    (check-within (candidate (list 1 2 3)) 321 0.001)\n    (check-within (candidate (list 4 5 6 1)) 6541 0.001)\n    (check-within (candidate (list 1 2 3 9)) 9321 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove uneven elements in the nested mixed list.\n(define (extract_even test_tuple)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_even))\n    (check-within (candidate (list 4 5 (list 7 6 (list 2 4)) 6 8)) (list 4 (list 6 (list 2 4)) 6 8) 0.001)\n    (check-within (candidate (list 5 6 (list 8 7 (list 4 8)) 7 9)) (list 6 (list 8 (list 4 8))) 0.001)\n    (check-within (candidate (list 5 6 (list 9 8 (list 4 6)) 8 10)) (list 6 (list 8 (list 4 6)) 8 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the surface area of a square rktramid with a given base edge and height.\n(define (surface_Area b s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate surface_Area))\n    (check-within (candidate 3 4) 33 0.001)\n    (check-within (candidate 4 5) 56 0.001)\n    (check-within (candidate 1 2) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which returns nth catalan number.\n(define (catalan_number num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate catalan_number))\n    (check-within (candidate 10) 16796 0.001)\n    (check-within (candidate 9) 4862 0.001)\n    (check-within (candidate 7) 429 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the first adverb ending with ly and its positions in a given string.\n(define (find_adverbs text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_adverbs))\n    (check-within (candidate \"Clearly, he has no excuse for such behavior.\") \"0-7: Clearly\" 0.001)\n    (check-within (candidate \"Please handle the situation carefuly\") \"28-36: carefuly\" 0.001)\n    (check-within (candidate \"Complete the task quickly\") \"18-25: quickly\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the n most expensive items in a given dataset.\n(define (expensive_items items n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate expensive_items))\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09))) 2) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1))) 0.001)\n    (check-within (candidate (list #hash((\"name\" .  \"Item-1\") (\"price\" .  101.1)) #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22)) #hash((\"name\" .  \"Item-3\") (\"price\" .  45.09)) #hash((\"name\" .  \"Item-4\") (\"price\" .  22.75))) 1) (list #hash((\"name\" .  \"Item-2\") (\"price\" .  555.22))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to split a list at the nth eelment and add the first part to the end.\n(define (split_Arr l n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate split_Arr))\n    (check-within (candidate (list 12 10 5 6 52 36) 2) (list 5 6 52 36 12 10) 0.001)\n    (check-within (candidate (list 1 2 3 4) 1) (list 2 3 4 1) 0.001)\n    (check-within (candidate (list 0 1 2 3 4 5 6 7) 3) (list 3 4 5 6 7 0 1 2) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert a list to a list.\n(define (list_tuple listx)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate list_tuple))\n    (check-within (candidate (list 5 10 7 4 15 3)) (list 5 10 7 4 15 3) 0.001)\n    (check-within (candidate (list 2 4 5 6 2 3 4 4 7)) (list 2 4 5 6 2 3 4 4 7) 0.001)\n    (check-within (candidate (list 58 44 56)) (list 58 44 56) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the difference between largest and smallest value in a given list.\n(define (big_diff nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate big_diff))\n    (check-within (candidate (list 1 2 3 4)) 3 0.001)\n    (check-within (candidate (list 4 5 12)) 8 0.001)\n    (check-within (candidate (list 9 2 3)) 7 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find perfect squares between two given numbers.\n(define (perfect_squares a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate perfect_squares))\n    (check-within (candidate 1 30) (list 1 4 9 16 25) 0.001)\n    (check-within (candidate 50 100) (list 64 81 100) 0.001)\n    (check-within (candidate 100 200) (list 100 121 144 169 196) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given two integers have opposite sign or not.\n(define (opposite_Signs x y)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate opposite_Signs))\n    (check-within (candidate 1 -2) #t 0.001)\n    (check-within (candidate 3 2) #f 0.001)\n    (check-within (candidate -10 -10) #f 0.001)\n    (check-within (candidate -2 2) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to interchange the first and last elements in a list.\n(define (swap_List newList)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 12 35 9 56 24)) (list 24 35 9 56 12) 0.001)\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of the product of consecutive binomial co-efficients.\n(define (sum_Of_product n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_product))\n    (check-within (candidate 3) 15 0.001)\n    (check-within (candidate 4) 56 0.001)\n    (check-within (candidate 1) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove leading zeroes from an ip address.\n(define (removezero_ip ip)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate removezero_ip))\n    (check-within (candidate \"216.08.094.196\") \"216.8.94.196\" 0.001)\n    (check-within (candidate \"12.01.024\") \"12.1.24\" 0.001)\n    (check-within (candidate \"216.08.094.0196\") \"216.8.94.196\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the difference of the first even and first odd number of a given list.\n(define (diff_even_odd list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate diff_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 1 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n(define (min_Swaps str1 str2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Swaps))\n    (check-within (candidate \"1101\" \"1110\") 1 0.001)\n    (check-within (candidate \"111\" \"000\") \"Not Possible\" 0.001)\n    (check-within (candidate \"111\" \"110\") \"Not Possible\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find kth element from the given two sorted lists.\n(define (find_kth arr1 arr2 k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_kth))\n    (check-within (candidate (list 2 3 6 7 9) (list 1 4 8 10) 5) 6 0.001)\n    (check-within (candidate (list 100 112 256 349 770) (list 72 86 113 119 265 445 892) 7) 256 0.001)\n    (check-within (candidate (list 3 4 7 8 10) (list 2 5 9 11) 6) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is armstrong or not.\n(define (armstrong_number number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate armstrong_number))\n    (check-within (candidate 153) #t 0.001)\n    (check-within (candidate 259) #f 0.001)\n    (check-within (candidate 4458) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find sum and average of first n natural numbers.\n(define (sum_average number)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_average))\n    (check-within (candidate 10) (list 55 5.5) 0.001)\n    (check-within (candidate 15) (list 120 8.0) 0.001)\n    (check-within (candidate 20) (list 210 10.5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth octagonal number.\n(define (is_octagonal n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_octagonal))\n    (check-within (candidate 5) 65 0.001)\n    (check-within (candidate 10) 280 0.001)\n    (check-within (candidate 15) 645 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number is even or not.\n(define (is_Even n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Even))\n    (check-within (candidate 1) #f 0.001)\n    (check-within (candidate 2) #t 0.001)\n    (check-within (candidate 3) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first repeated character in a given string.\n(define (first_repeated_char str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_repeated_char))\n    (check-within (candidate \"abcabc\") \"a\" 0.001)\n    (check-within (candidate \"abc\") #f 0.001)\n    (check-within (candidate \"123123\") \"1\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get all lucid numbers smaller than or equal to a given integer.\n(define (get_ludic n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_ludic))\n    (check-within (candidate 10) (list 1 2 3 5 7) 0.001)\n    (check-within (candidate 25) (list 1 2 3 5 7 11 13 17 23 25) 0.001)\n    (check-within (candidate 45) (list 1 2 3 5 7 11 13 17 23 25 29 37 41 43) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to reverse words seperated by spaces in a given string.\n(define (reverse_words s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_words))\n    (check-within (candidate \"python program\") \"program python\" 0.001)\n    (check-within (candidate \"java language\") \"language java\" 0.001)\n    (check-within (candidate \"indian man\") \"man indian\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given integer is a prime number.\n(define (prime_num num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate prime_num))\n    (check-within (candidate 13) #t 0.001)\n    (check-within (candidate 7) #t 0.001)\n    (check-within (candidate -1010) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert degrees to radians.\n(define (radian_degree degree)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate radian_degree))\n    (check-within (candidate 90) 1.5707963267948966 0.001)\n    (check-within (candidate 60) 1.0471975511965976 0.001)\n    (check-within (candidate 120) 2.0943951023931953 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n(define (find_literals text pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_literals))\n    (check-within (candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") (list \"fox\" 16 19) 0.001)\n    (check-within (candidate \"Its been a very crazy procedure right\" \"crazy\") (list \"crazy\" 16 21) 0.001)\n    (check-within (candidate \"Hardest choices required strongest will\" \"will\") (list \"will\" 35 39) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find nth bell number.\n(define (bell_Number n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_Number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 3) 5 0.001)\n    (check-within (candidate 4) 15 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n(define (remove_kth_element list1 L)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_kth_element))\n    (check-within (candidate (list 1 1 2 3 4 4 5 1) 3) (list 1 1 3 4 4 5 1) 0.001)\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4) 4) (list 0 0 1 3 4 4 5 6 6 6 7 8 9 4 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10) 5) (list 10 10 15 19 18 17 26 26 17 18 10) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n(define (max_of_nth test_list N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_of_nth))\n    (check-within (candidate (list (list 5 6 7) (list 1 3 5) (list 8 9 19)) 2) 19 0.001)\n    (check-within (candidate (list (list 6 7 8) (list 2 4 6) (list 9 10 20)) 1) 10 0.001)\n    (check-within (candidate (list (list 7 8 9) (list 3 5 7) (list 10 11 21)) 1) 11 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n(define (merge lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge))\n    (check-within (candidate (list (list \"x\" \"y\") (list \"a\" \"b\") (list \"m\" \"n\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\")) 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4) (list 5 6) (list 7 8))) (list (list 1 3 5 7) (list 2 4 6 8)) 0.001)\n    (check-within (candidate (list (list \"x\" \"y\" \"z\") (list \"a\" \"b\" \"c\") (list \"m\" \"n\" \"o\"))) (list (list \"x\" \"a\" \"m\") (list \"y\" \"b\" \"n\") (list \"z\" \"c\" \"o\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n(define (cummulative_sum test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate cummulative_sum))\n    (check-within (candidate (list (list 1 3) (list 5 6 7) (list 2 6))) 30 0.001)\n    (check-within (candidate (list (list 2 4) (list 6 7 8) (list 3 7))) 37 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8 9) (list 4 8))) 44 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n(define (average_tuple nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate average_tuple))\n    (check-within (candidate (list (list 10 10 10 12) (list 30 45 56 45) (list 81 80 39 32) (list 1 2 3 4))) (list 30.5 34.25 27.0 23.25) 0.001)\n    (check-within (candidate (list (list 1 1 -5) (list 30 -15 56) (list 81 -60 -39) (list -10 2 3))) (list 25.5 -18.0 3.75) 0.001)\n    (check-within (candidate (list (list 100 100 100 120) (list 300 450 560 450) (list 810 800 390 320) (list 10 20 30 40))) (list 305.0 342.5 270.0 232.5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function which takes two lists of the same length and performs the element wise modulo.\n(define (tuple_modulo test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_modulo))\n    (check-within (candidate (list 10 4 5 6) (list 5 6 7 5)) (list 0 4 5 1) 0.001)\n    (check-within (candidate (list 11 5 6 7) (list 6 7 8 6)) (list 5 5 6 1) 0.001)\n    (check-within (candidate (list 12 6 7 8) (list 7 8 9 7)) (list 5 6 7 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n(define (min_Jumps steps d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_Jumps))\n    (check-within (candidate (list 3 4) 11) 3.5 0.001)\n    (check-within (candidate (list 3 4) 0) 0 0.001)\n    (check-within (candidate (list 11 14) 11) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to divide two lists element wise.\n(define (div_list nums1 nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate div_list))\n    (check-within (candidate (list 4 5 6) (list 1 2 3)) (list 4.0 2.5 2.0) 0.001)\n    (check-within (candidate (list 3 2) (list 1 4)) (list 3.0 0.5) 0.001)\n    (check-within (candidate (list 90 120) (list 50 70)) (list 1.8 1.7142857142857142) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to move all the numbers to the end of the given string.\n(define (move_num test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_num))\n    (check-within (candidate \"I1love143you55three3000thousand\") \"Iloveyouthreethousand1143553000\" 0.001)\n    (check-within (candidate \"Avengers124Assemble\") \"AvengersAssemble124\" 0.001)\n    (check-within (candidate \"Its11our12path13to14see15things16do17things\") \"Itsourpathtoseethingsdothings11121314151617\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of substrings with the sum of digits equal to their length.\n(define (count_Substrings s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_Substrings))\n    (check-within (candidate \"112112\") 6 0.001)\n    (check-within (candidate \"111\") 6 0.001)\n    (check-within (candidate \"1101112\") 12 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the median of two sorted lists of same size.\n(define (get_median arr1 arr2 n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_median))\n    (check-within (candidate (list 1 12 15 26 38) (list 2 13 17 30 45) 5) 16.0 0.001)\n    (check-within (candidate (list 2 4 8 9) (list 7 13 19 28) 4) 8.5 0.001)\n    (check-within (candidate (list 3 6 14 23 36 42) (list 2 18 27 39 49 55) 6) 25.0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to compute the n-th power of each number in a list.\n(define (nth_nums nums n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate nth_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30) 3) (list 1000 8000 27000) 0.001)\n    (check-within (candidate (list 12 15) 5) (list 248832 759375) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to convert a given string to uppercase.\n(define (is_upper string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_upper))\n    (check-within (candidate \"person\") \"PERSON\" 0.001)\n    (check-within (candidate \"final\") \"FINAL\" 0.001)\n    (check-within (candidate \"Valid\") \"VALID\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to interchange the first and last element in a given list.\n(define (swap_List newList)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate swap_List))\n    (check-within (candidate (list 1 2 3)) (list 3 2 1) 0.001)\n    (check-within (candidate (list 1 2 3 4 4)) (list 4 2 3 4 1) 0.001)\n    (check-within (candidate (list 4 5 6)) (list 6 5 4) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n(define (triangle_area r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate triangle_area))\n    (check-within (candidate -1) #f 0.001)\n    (check-within (candidate 0) 0 0.001)\n    (check-within (candidate 2) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the smallest missing number from a sorted list of natural numbers.\n(define (find_First_Missing array)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_First_Missing))\n    (check-within (candidate (list 0 1 2 3)) 4 0.001)\n    (check-within (candidate (list 0 1 2 6 9)) 3 0.001)\n    (check-within (candidate (list 2 3 5 8 9)) 0 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace all spaces in the given string with '%20'.\n(define (replace_spaces string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"My Name is Dawood\") \"My%20Name%20is%20Dawood\" 0.001)\n    (check-within (candidate \"I am a Programmer\") \"I%20am%20a%20Programmer\" 0.001)\n    (check-within (candidate \"I love Coding\") \"I%20love%20Coding\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find even numbers from a list of numbers.\n(define (Split list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Split))\n    (check-within (candidate (list 1 2 3 4 5)) (list 2 4) 0.001)\n    (check-within (candidate (list 4 5 6 7 8 0 1)) (list 4 6 8 0) 0.001)\n    (check-within (candidate (list 8 12 15 19)) (list 8 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find smallest number in a list.\n(define (smallest_num xs)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate smallest_num))\n    (check-within (candidate (list 10 20 1 45 99)) 1 0.001)\n    (check-within (candidate (list 1 2 3)) 1 0.001)\n    (check-within (candidate (list 45 46 50 60)) 45 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract all the adjacent coordinates of the given coordinate list.\n(define (get_coordinates test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_coordinates))\n    (check-within (candidate (list 3 4)) (list (list 2 3) (list 2 4) (list 2 5) (list 3 3) (list 3 4) (list 3 5) (list 4 3) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 4 5)) (list (list 3 4) (list 3 5) (list 3 6) (list 4 4) (list 4 5) (list 4 6) (list 5 4) (list 5 5) (list 5 6)) 0.001)\n    (check-within (candidate (list 5 6)) (list (list 4 5) (list 4 6) (list 4 7) (list 5 5) (list 5 6) (list 5 7) (list 6 5) (list 6 6) (list 6 7)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace whitespaces with an underscore and vice versa in a given string.\n(define (replace_spaces text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_spaces))\n    (check-within (candidate \"Jumanji The Jungle\") \"Jumanji_The_Jungle\" 0.001)\n    (check-within (candidate \"The_Avengers\") \"The Avengers\" 0.001)\n    (check-within (candidate \"Fast and Furious\") \"Fast_and_Furious\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to move all zeroes to the end of the given list.\n(define (move_zero num_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate move_zero))\n    (check-within (candidate (list 1 0 2 0 3 4)) (list 1 2 3 4 0 0) 0.001)\n    (check-within (candidate (list 2 3 2 0 0 4 0 5 0)) (list 2 3 2 4 5 0 0 0 0) 0.001)\n    (check-within (candidate (list 0 1 0 1 1)) (list 1 1 1 0 0) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of xor of all pairs of numbers in the given list.\n(define (pair_xor_Sum arr n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_xor_Sum))\n    (check-within (candidate (list 5 9 7 6) 4) 47 0.001)\n    (check-within (candidate (list 7 3 5) 3) 12 0.001)\n    (check-within (candidate (list 7 3) 2) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort the given list.\n(define (heap_sort iterable)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate heap_sort))\n    (check-within (candidate (list 1 3 5 7 9 2 4 6 8 0)) (list 0 1 2 3 4 5 6 7 8 9) 0.001)\n    (check-within (candidate (list 25 35 22 85 14 65 75 25 58)) (list 14 22 25 25 35 58 65 75 85) 0.001)\n    (check-within (candidate (list 7 1 9 5)) (list 1 5 7 9) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given amount has no profit and no loss\n(define (noprofit_noloss actual_cost sale_amount)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate noprofit_noloss))\n    (check-within (candidate 1500 1200) #f 0.001)\n    (check-within (candidate 100 100) #t 0.001)\n    (check-within (candidate 2000 5000) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n(define (wind_chill v t)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate wind_chill))\n    (check-within (candidate 120 35) 40 0.001)\n    (check-within (candidate 40 20) 19 0.001)\n    (check-within (candidate 10 8) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n(define (sample_nam sample_names)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sample_nam))\n    (check-within (candidate (list \"sally\" \"Dylan\" \"rebecca\" \"Diana\" \"Joanne\" \"keith\")) 16 0.001)\n    (check-within (candidate (list \"php\" \"res\" \"Python\" \"abcd\" \"Java\" \"aaa\")) 10 0.001)\n    (check-within (candidate (list \"abcd\" \"Python\" \"abba\" \"aba\")) 6 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the maximum difference between available pairs in the given list list.\n(define (max_difference test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_difference))\n    (check-within (candidate (list (list 3 5) (list 1 7) (list 10 3) (list 1 2))) 7 0.001)\n    (check-within (candidate (list (list 4 6) (list 2 17) (list 9 13) (list 11 12))) 15 0.001)\n    (check-within (candidate (list (list 12 35) (list 21 27) (list 13 23) (list 41 22))) 23 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove the parenthesis and what is inbetween them from a string.\n(define (remove_parenthesis items)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_parenthesis))\n    (check-within (candidate (list \"python (chrome)\")) \"python\" 0.001)\n    (check-within (candidate (list \"string(.abc)\")) \"string\" 0.001)\n    (check-within (candidate (list \"alpha(num)\")) \"alpha\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth nonagonal number.\n(define (is_nonagonal n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_nonagonal))\n    (check-within (candidate 10) 325 0.001)\n    (check-within (candidate 15) 750 0.001)\n    (check-within (candidate 18) 1089 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that checks if a strings contains 'z', except at the start and end of the word.\n(define (text_match_wordz_middle text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_wordz_middle))\n    (check-within (candidate \"pythonzabc.\") #t 0.001)\n    (check-within (candidate \"zxyabc.\") #f 0.001)\n    (check-within (candidate \"  lang  .\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to reverse a list upto a given position.\n(define (reverse_Array_Upto_K input k)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate reverse_Array_Upto_K))\n    (check-within (candidate (list 1 2 3 4 5 6) 4) (list 4 3 2 1 5 6) 0.001)\n    (check-within (candidate (list 4 5 6 7) 2) (list 5 4 6 7) 0.001)\n    (check-within (candidate (list 9 8 7 6 5) 3) (list 7 8 9 6 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of lists using the second value of each list.\n(define (subject_marks subjectmarks)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate subject_marks))\n    (check-within (candidate (list (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97) (list \"Social sciences\" 82))) (list (list \"Social sciences\" 82) (list \"English\" 88) (list \"Science\" 90) (list \"Maths\" 97)) 0.001)\n    (check-within (candidate (list (list \"Telugu\" 49) (list \"Hindhi\" 54) (list \"Social\" 33))) (list (list \"Social\" 33) (list \"Telugu\" 49) (list \"Hindhi\" 54)) 0.001)\n    (check-within (candidate (list (list \"Physics\" 96) (list \"Chemistry\" 97) (list \"Biology\" 45))) (list (list \"Biology\" 45) (list \"Physics\" 96) (list \"Chemistry\" 97)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to flatten a list and sum all of its elements.\n(define (recursive_list_sum data_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate recursive_list_sum))\n    (check-within (candidate (list 1 2 (list 3 4) (list 5 6))) 21 0.001)\n    (check-within (candidate (list 7 10 (list 15 14) (list 19 41))) 106 0.001)\n    (check-within (candidate (list 10 20 (list 30 40) (list 50 60))) 210 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of positive numbers in a list.\n(define (pos_count list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pos_count))\n    (check-within (candidate (list 1 -2 3 -4)) 2 0.001)\n    (check-within (candidate (list 3 4 5 -1)) 3 0.001)\n    (check-within (candidate (list 1 2 3 4)) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the number of ways to partition a set of Bell numbers.\n(define (bell_number n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate bell_number))\n    (check-within (candidate 2) 2 0.001)\n    (check-within (candidate 10) 115975 0.001)\n    (check-within (candidate 56) 6775685320645824322581483068371419745979053216268760300 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given list is monotonic or not.\n(define (is_Monotonic A)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Monotonic))\n    (check-within (candidate (list 6 5 4 4)) #t 0.001)\n    (check-within (candidate (list 1 2 2 3)) #t 0.001)\n    (check-within (candidate (list 1 3 2)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a list contains the given sublist or not.\n(define (is_sublist l s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_sublist))\n    (check-within (candidate (list 2 4 3 5 7) (list 3 7)) #f 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 4 3)) #t 0.001)\n    (check-within (candidate (list 2 4 3 5 7) (list 1 6)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the two numbers differ at one bit position only or not.\n(define (differ_At_One_Bit_Pos a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate differ_At_One_Bit_Pos))\n    (check-within (candidate 13 9) #t 0.001)\n    (check-within (candidate 15 8) #f 0.001)\n    (check-within (candidate 2 4) #f 0.001)\n    (check-within (candidate 2 3) #t 0.001)\n    (check-within (candidate 5 1) #t 0.001)\n    (check-within (candidate 1 5) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find whether all the given lists have equal length or not.\n(define (get_equal Input)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_equal))\n    (check-within (candidate (list (list 11 22 33) (list 44 55 66))) #t 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6 7))) #f 0.001)\n    (check-within (candidate (list (list 1 2) (list 3 4))) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a list of elements.\n(define (comb_sort nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate comb_sort))\n    (check-within (candidate (list 5 15 37 25 79)) (list 5 15 25 37 79) 0.001)\n    (check-within (candidate (list 41 32 15 19 22)) (list 15 19 22 32 41) 0.001)\n    (check-within (candidate (list 99 15 13 47)) (list 13 15 47 99) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to add a hash to the list. The output should be a list.\n(define (add_dict_to_tuple test_tup test_dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_dict_to_tuple))\n    (check-within (candidate (list 4 5 6) #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) (list 4 5 6 #hash((\"MSAM\" .  1) (\"is\" .  2) (\"best\" .  3))) 0.001)\n    (check-within (candidate (list 1 2 3) #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) (list 1 2 3 #hash((\"UTS\" .  2) (\"is\" .  3) (\"Worst\" .  4))) 0.001)\n    (check-within (candidate (list 8 9 10) #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) (list 8 9 10 #hash((\"POS\" .  3) (\"is\" .  4) (\"Okay\" .  5))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n(define (maxAverageOfPath cost)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate maxAverageOfPath))\n    (check-within (candidate (list (list 1 2 3) (list 6 5 4) (list 7 3 9))) 5.2 0.001)\n    (check-within (candidate (list (list 2 3 4) (list 7 6 5) (list 8 4 10))) 6.2 0.001)\n    (check-within (candidate (list (list 3 4 5) (list 8 7 6) (list 9 5 11))) 7.2 0.001)\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 7 8 9))) 5.8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The input is given as - a hash with a student name as a key and a list of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n(define (filter_data students h w)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate filter_data))\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 6.0 70) #hash((\"Cierra Vega\" .  (list 6.2 70))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.9 67) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Kierra Gentry\" .  (list 6.0 68))) 0.001)\n    (check-within (candidate #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 5.7 64) #hash((\"Cierra Vega\" .  (list 6.2 70)) (\"Alden Cantrell\" .  (list 5.9 65)) (\"Kierra Gentry\" .  (list 6.0 68)) (\"Pierre Cox\" .  (list 5.8 66))) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n(define (count_same_pair nums1 nums2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_same_pair))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8) (list 2 2 3 1 2 6 7 9)) 4 0.001)\n    (check-within (candidate (list 0 1 2 -1 -5 6 0 -3 -2 3 4 6 8) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 11 0.001)\n    (check-within (candidate (list 2 4 -6 -9 11 -12 14 -5 17) (list 2 1 2 -1 -5 6 4 -3 -2 3 4 6 8)) 1 0.001)\n    (check-within (candidate (list 0 1 1 2) (list 0 1 2 2)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n(define (power_base_sum base power)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power_base_sum))\n    (check-within (candidate 2 100) 115 0.001)\n    (check-within (candidate 8 10) 37 0.001)\n    (check-within (candidate 8 15) 62 0.001)\n    (check-within (candidate 3 3) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to extract values between quotation marks \" \" of the given string.\n(define (extract_quotation text1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_quotation))\n    (check-within (candidate \"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\") (list \"A53\" \"multi\" \"Processor\") 0.001)\n    (check-within (candidate \"Cast your \"favorite\" entertainment \"apps\"\") (list \"favorite\" \"apps\") 0.001)\n    (check-within (candidate \"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\") (list \"4k Ultra HD\" \"HDR 10\") 0.001)\n    (check-within (candidate \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\n(define (multiply_elements test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate multiply_elements))\n    (check-within (candidate (list 1 5 7 8 10)) (list 5 35 56 80) 0.001)\n    (check-within (candidate (list 2 4 5 6 7)) (list 8 20 30 42) 0.001)\n    (check-within (candidate (list 12 13 14 9 15)) (list 156 182 126 135) 0.001)\n    (check-within (candidate (list 12)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n(define (sum_list lst1 lst2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_list))\n    (check-within (candidate (list 10 20 30) (list 15 25 35)) (list 25 45 65) 0.001)\n    (check-within (candidate (list 1 2 3) (list 5 6 7)) (list 6 8 10) 0.001)\n    (check-within (candidate (list 15 20 30) (list 15 45 75)) (list 30 65 105) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the given number can be represented as the difference of two squares or not.\n(define (dif_Square n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate dif_Square))\n    (check-within (candidate 5) #t 0.001)\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 15) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove consecutive duplicates of a given list.\n(define (consecutive_duplicates nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list 0 1 2 3 4 5 6 7 8 9 4) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list 10 15 19 18 17 26 17 18 10) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list \"a\" \"b\" \"c\" \"d\") 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\" \"a\" \"a\")) (list \"a\" \"b\" \"c\" \"d\" \"a\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the lateral surface area of a cone given radius r and the height h.\n(define (lateralsurface_cone r h)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lateralsurface_cone))\n    (check-within (candidate 5 12) 204.20352248333654 0.001)\n    (check-within (candidate 10 15) 566.3586699569488 0.001)\n    (check-within (candidate 19 17) 1521.8090132193388 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n(define (replace_specialchar text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate replace_specialchar))\n    (check-within (candidate \"Python language, Programming language.\") \"Python:language::Programming:language:\" 0.001)\n    (check-within (candidate \"a b c,d e f\") \"a:b:c:d:e:f\" 0.001)\n    (check-within (candidate \"ram reshma,ram rahim\") \"ram:reshma:ram:rahim\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the index of the first occurrence of a given number in a sorted list.\n(define (find_first_occurrence A x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_first_occurrence))\n    (check-within (candidate (list 2 5 5 5 6 6 8 9 9 9) 5) 1 0.001)\n    (check-within (candidate (list 2 3 5 5 6 6 8 9 9 9) 5) 2 0.001)\n    (check-within (candidate (list 2 4 1 5 6 6 8 9 9 9) 6) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n(define (sum_Of_Subarray_Prod arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_Of_Subarray_Prod))\n    (check-within (candidate (list 1 2 3)) 20 0.001)\n    (check-within (candidate (list 1 2)) 5 0.001)\n    (check-within (candidate (list 1 2 3 4)) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n(define (toggle_middle_bits n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate toggle_middle_bits))\n    (check-within (candidate 9) 15 0.001)\n    (check-within (candidate 10) 12 0.001)\n    (check-within (candidate 11) 13 0.001)\n    (check-within (candidate 65) 127 0.001)\n    (check-within (candidate 77) 115 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rktthon-exercises/data-structures-and-algorithms/rktthon-data-structure-exercise-24.php\n(define (left_insertion a x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given string is starting with a vowel or not using regex.\n(define (check_str string)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_str))\n    (check-within (candidate \"annie\") #t 0.001)\n    (check-within (candidate \"dawood\") #f 0.001)\n    (check-within (candidate \"Else\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rktthon-exercises/data-structures-and-algorithms/rktthon-recursion-exercise-9.php\n(define (geometric_sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate geometric_sum))\n    (check-within (candidate 7) 1.9921875 0.001)\n    (check-within (candidate 4) 1.9375 0.001)\n    (check-within (candidate 8) 1.99609375 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n(define (find_Index n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Index))\n    (check-within (candidate 2) 4 0.001)\n    (check-within (candidate 3) 14 0.001)\n    (check-within (candidate 4) 45 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given list to a key-value hash using adjacent elements. https://www.geeksforgeeks.org/rktthon-convert-list-to-adjacent-pair-hash/\n(define (tuple_to_dict test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_to_dict))\n    (check-within (candidate (list 1 5 7 10 13 5)) #hash((1 .  5) (7 .  10) (13 .  5)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6)) #hash((1 .  2) (3 .  4) (5 .  6)) 0.001)\n    (check-within (candidate (list 7 8 9 10 11 12)) #hash((7 .  8) (9 .  10) (11 .  12)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether all the characters are same or not.\n(define (all_Characters_Same s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate all_Characters_Same))\n    (check-within (candidate \"python\") #f 0.001)\n    (check-within (candidate \"aaa\") #t 0.001)\n    (check-within (candidate \"data\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to caluclate the area of a tetrahedron.\n(define (area_tetrahedron side)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate area_tetrahedron))\n    (check-within (candidate 3) 15.588457268119894 0.001)\n    (check-within (candidate 20) 692.8203230275509 0.001)\n    (check-within (candidate 10) 173.20508075688772 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/rktthon-program-right-rotate-list-n/\n(define (rotate_right list m)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rotate_right))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 3) (list 8 9 10 1 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 2) (list 9 10 1 2 3 4 5 6 7 8) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10) 5) (list 6 7 8 9 10 1 2 3 4 5) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given list has any none value or not.\n(define (check_none test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_none))\n    (check-within (candidate (list 10 4 5 6 #f)) #t 0.001)\n    (check-within (candidate (list 7 8 9 11 14)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 #f)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rktthon-exercises/lambda/rktthon-lambda-exercise-24.php\n(define (divisible_by_digits startnum endnum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisible_by_digits))\n    (check-within (candidate 1 22) (list 1 2 3 4 5 6 7 8 9 11 12 15 22) 0.001)\n    (check-within (candidate 1 15) (list 1 2 3 4 5 6 7 8 9 11 12 15) 0.001)\n    (check-within (candidate 20 25) (list 22 24) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return #f if the angle is larger than 360 degrees.\n(define (sector_area r a)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sector_area))\n    (check-within (candidate 4 45) 6.283185307179586 0.001)\n    (check-within (candidate 9 45) 31.808625617596654 0.001)\n    (check-within (candidate 9 361) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n(define (lcs_of_three X Y Z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate lcs_of_three))\n    (check-within (candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") 2 0.001)\n    (check-within (candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") 5 0.001)\n    (check-within (candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to put spaces between words starting with capital letters in a given string.\n(define (capital_words_spaces str1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate capital_words_spaces))\n    (check-within (candidate \"Python\") \"Python\" 0.001)\n    (check-within (candidate \"PythonProgrammingExamples\") \"Python Programming Examples\" 0.001)\n    (check-within (candidate \"GetReadyToBeCodingFreak\") \"Get Ready To Be Coding Freak\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/rktthon-sort-numeric-strings-in-a-list/\n(define (sort_numeric_strings nums_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sort_numeric_strings))\n    (check-within (candidate (list \"4\" \"12\" \"45\" \"7\" \"0\" \"100\" \"200\" \"-12\" \"-500\")) (list -500 -12 0 4 7 12 45 100 200) 0.001)\n    (check-within (candidate (list \"2\" \"3\" \"8\" \"4\" \"7\" \"9\" \"8\" \"2\" \"6\" \"5\" \"1\" \"6\" \"1\" \"2\" \"3\" \"4\" \"6\" \"9\" \"1\" \"2\")) (list 1 1 1 2 2 2 2 3 3 4 4 5 6 6 6 7 8 8 9 9) 0.001)\n    (check-within (candidate (list \"1\" \"3\" \"5\" \"7\" \"1\" \"3\" \"13\" \"15\" \"17\" \"5\" \"7 \" \"9\" \"1\" \"11\")) (list 1 1 1 3 3 5 5 7 7 9 11 13 15 17) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether it follows the sequence given in the patterns list.\n(define (is_samepatterns colors patterns)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_samepatterns))\n    (check-within (candidate (list \"red\" \"green\" \"green\") (list \"a\" \"b\" \"b\")) #t 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\" \"b\")) #f 0.001)\n    (check-within (candidate (list \"red\" \"green\" \"greenn\") (list \"a\" \"b\")) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to add the given list to the given list.\n(define (add_tuple test_list test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate add_tuple))\n    (check-within (candidate (list 5 6 7) (list 9 10)) (list 5 6 7 9 10) 0.001)\n    (check-within (candidate (list 6 7 8) (list 10 11)) (list 6 7 8 10 11) 0.001)\n    (check-within (candidate (list 7 8 9) (list 11 12)) (list 7 8 9 11 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n(define (check_min_heap arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_min_heap))\n    (check-within (candidate (list 1 2 3 4 5 6)) #t 0.001)\n    (check-within (candidate (list 2 3 4 5 10 15)) #t 0.001)\n    (check-within (candidate (list 2 10 4 5 3 15)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n(define (jacobsthal_num n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate jacobsthal_num))\n    (check-within (candidate 5) 11 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 4) 5 0.001)\n    (check-within (candidate 13) 2731 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/rktthon-find-minimum-k-records-from-list-list/ - in this case a verbatim corkt of test cases\n(define (min_k test_list K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate min_k))\n    (check-within (candidate (list (list \"Manjeet\" 10) (list \"Akshat\" 4) (list \"Akash\" 2) (list \"Nikhil\" 8)) 2) (list (list \"Akash\" 2) (list \"Akshat\" 4)) 0.001)\n    (check-within (candidate (list (list \"Sanjeev\" 11) (list \"Angat\" 5) (list \"Akash\" 3) (list \"Nepin\" 9)) 3) (list (list \"Akash\" 3) (list \"Angat\" 5) (list \"Nepin\" 9)) 0.001)\n    (check-within (candidate (list (list \"tanmay\" 14) (list \"Amer\" 11) (list \"Ayesha\" 9) (list \"SKD\" 16)) 1) (list (list \"Ayesha\" 9)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n(define (extract_index_list l1 l2 l3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate extract_index_list))\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 7) 0.001)\n    (check-within (candidate (list 1 1 3 4 5 6 7) (list 0 1 2 3 4 6 5) (list 0 1 2 3 4 6 7)) (list 1 6) 0.001)\n    (check-within (candidate (list 1 1 3 4 6 5 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list 1 5) 0.001)\n    (check-within (candidate (list 1 2 3 4 6 6 6) (list 0 1 2 3 4 5 7) (list 0 1 2 3 4 5 7)) (list ) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the second smallest number in a list.\n(define (second_smallest numbers)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate second_smallest))\n    (check-within (candidate (list 1 2 -8 -2 0 -2)) -2 0.001)\n    (check-within (candidate (list 1 1 -0.5 0 2 -2 -2)) -0.5 0.001)\n    (check-within (candidate (list 2 2)) #f 0.001)\n    (check-within (candidate (list 2 2 2)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rktthon-exercises/re/rktthon-re-exercise-3.php\n(define (text_match_zero_one text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_zero_one))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"dsabbbba\") #t 0.001)\n    (check-within (candidate \"asbbbba\") #f 0.001)\n    (check-within (candidate \"abaaa\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/rktthon-program-to-count-the-pairs-of-reverse-strings/\n(define (count_reverse_pairs test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_reverse_pairs))\n    (check-within (candidate (list \"julia\" \"best\" \"tseb\" \"for\" \"ailuj\")) 2 0.001)\n    (check-within (candidate (list \"geeks\" \"best\" \"for\" \"skeeg\")) 1 0.001)\n    (check-within (candidate (list \"makes\" \"best\" \"sekam\" \"for\" \"rof\")) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether a given string is a decimal number with a precision of 2.\n(define (is_decimal num)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_decimal))\n    (check-within (candidate \"123.11\") #t 0.001)\n    (check-within (candidate \"e666.86\") #f 0.001)\n    (check-within (candidate \"3.124587\") #f 0.001)\n    (check-within (candidate \"1.11\") #t 0.001)\n    (check-within (candidate \"1.1.11\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find lists which have all elements divisible by k from the given list of lists.\n(define (find_tuples test_list K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_tuples))\n    (check-within (candidate (list (list 6 24 12) (list 7 9 6) (list 12 18 21)) 6) (list (list 6 24 12)) 0.001)\n    (check-within (candidate (list (list 5 25 30) (list 4 2 3) (list 7 8 9)) 5) (list (list 5 25 30)) 0.001)\n    (check-within (candidate (list (list 7 9 16) (list 8 16 4) (list 19 17 18)) 4) (list (list 8 16 4)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether a list of numbers contains only one distinct element or not.\n(define (unique_Element arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate unique_Element))\n    (check-within (candidate (list 1 1 1)) #t 0.001)\n    (check-within (candidate (list 1 2 1 2)) #f 0.001)\n    (check-within (candidate (list 1 2 3 4 5)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n(define (check_monthnumber_number monthnum3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_monthnumber_number))\n    (check-within (candidate 6) #t 0.001)\n    (check-within (candidate 2) #f 0.001)\n    (check-within (candidate 12) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n(define (find_min_diff arr n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_min_diff))\n    (check-within (candidate (list 1 5 3 19 18 25) 6) 1 0.001)\n    (check-within (candidate (list 4 3 2 6) 4) 1 0.001)\n    (check-within (candidate (list 30 5 20 9) 4) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count number of digits in a given string.\n(define (number_ctr str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate number_ctr))\n    (check-within (candidate \"program2bedone\") 1 0.001)\n    (check-within (candidate \"3wonders\") 1 0.001)\n    (check-within (candidate \"123\") 3 0.001)\n    (check-within (candidate \"3wond-1ers2\") 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n(define (is_polite n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_polite))\n    (check-within (candidate 7) 11 0.001)\n    (check-within (candidate 4) 7 0.001)\n    (check-within (candidate 9) 13 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to return a list of all pairs of consecutive items in a given list.\n(define (pair_wise l1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pair_wise))\n    (check-within (candidate (list 1 1 2 3 3 4 4 5)) (list (list 1 1) (list 1 2) (list 2 3) (list 3 3) (list 3 4) (list 4 4) (list 4 5)) 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) (list (list 1 5) (list 5 7) (list 7 9) (list 9 10)) 0.001)\n    (check-within (candidate (list 5 1 9 7 10)) (list (list 5 1) (list 1 9) (list 9 7) (list 7 10)) 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list (list 1 2) (list 2 3) (list 3 4) (list 4 5) (list 5 6) (list 6 7) (list 7 8) (list 8 9) (list 9 10)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n(define (get_pairs_count arr sum)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_pairs_count))\n    (check-within (candidate (list 1 1 1 1) 2) 6 0.001)\n    (check-within (candidate (list 1 5 7 -1 5) 6) 3 0.001)\n    (check-within (candidate (list 1 -2 3) 1) 1 0.001)\n    (check-within (candidate (list -1 -2 3) -3) 1 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to get the difference between two lists.\n(define (Diff li1 li2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Diff))\n    (check-within (candidate (list 10 15 20 25 30 35 40) (list 25 40 35)) (list 10 20 30 15) 0.001)\n    (check-within (candidate (list 1 2 3 4 5) (list 6 7 1)) (list 2 3 4 5 6 7) 0.001)\n    (check-within (candidate (list 1 2 3) (list 6 7 1)) (list 2 3 6 7) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of fourth power of first n odd natural numbers.\n(define (odd_num_sum n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_num_sum))\n    (check-within (candidate 2) 82 0.001)\n    (check-within (candidate 3) 707 0.001)\n    (check-within (candidate 4) 3108 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n(define (check_expression exp)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_expression))\n    (check-within (candidate \"{()}[{}]\") #t 0.001)\n    (check-within (candidate \"{()}[{]\") #f 0.001)\n    (check-within (candidate \"{()}[{}][]({})\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all the words with k length in the given string.\n(define (remove_length test_str K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_length))\n    (check-within (candidate \"The person is most value tet\" 3) \"person is most value\" 0.001)\n    (check-within (candidate \"If you told me about this ok\" 4) \"If you me about ok\" 0.001)\n    (check-within (candidate \"Forces of darkeness is come into the play\" 4) \"Forces of darkeness is the\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the occurrence and position of the substrings within a string. Return #f if there is no match.\n(define (occurance_substring text pattern)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate occurance_substring))\n    (check-within (candidate \"python programming, python language\" \"python\") (list \"python\" 0 6) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"programming\") (list \"programming\" 7 18) 0.001)\n    (check-within (candidate \"python programming,programming language\" \"language\") (list \"language\" 31 39) 0.001)\n    (check-within (candidate \"c++ programming, c++ language\" \"python\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether every odd index contains odd numbers of a given list.\n(define (odd_position nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_position))\n    (check-within (candidate (list 2 1 4 3 6 7 6 3)) #t 0.001)\n    (check-within (candidate (list 4 1 2)) #t 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to count those characters which have vowels as their neighbors in the given string.\n(define (count_vowels test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_vowels))\n    (check-within (candidate \"bestinstareels\") 7 0.001)\n    (check-within (candidate \"partofthejourneyistheend\") 12 0.001)\n    (check-within (candidate \"amazonprime\") 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of non-repeated elements in a given list.\n(define (find_sum arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_sum))\n    (check-within (candidate (list 1 2 3 1 1 4 5 6)) 21 0.001)\n    (check-within (candidate (list 1 10 9 4 2 10 10 45 4)) 71 0.001)\n    (check-within (candidate (list 12 10 9 45 2 10 10 45 10)) 78 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to pack consecutive duplicates of a given list elements into sublists.\n(define (pack_consecutive_duplicates list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate pack_consecutive_duplicates))\n    (check-within (candidate (list 0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4)) (list (list 0 0) (list 1) (list 2) (list 3) (list 4 4) (list 5) (list 6 6 6) (list 7) (list 8) (list 9) (list 4 4)) 0.001)\n    (check-within (candidate (list 10 10 15 19 18 18 17 26 26 17 18 10)) (list (list 10 10) (list 15) (list 19) (list 18 18) (list 17) (list 26 26) (list 17) (list 18) (list 10)) 0.001)\n    (check-within (candidate (list \"a\" \"a\" \"b\" \"c\" \"d\" \"d\")) (list (list \"a\" \"a\") (list \"b\") (list \"c\") (list \"d\" \"d\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find whether a number is divisible by 11.\n(define (is_Diff n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_Diff))\n    (check-within (candidate 12345) #f 0.001)\n    (check-within (candidate 1212112) #t 0.001)\n    (check-within (candidate 1212) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/rktthon-combinations-of-sum-with-lists-in-list-list/\n(define (find_combinations test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_combinations))\n    (check-within (candidate (list (list 2 4) (list 6 7) (list 5 1) (list 6 10))) (list (list 8 11) (list 7 5) (list 8 14) (list 11 8) (list 12 17) (list 11 11)) 0.001)\n    (check-within (candidate (list (list 3 5) (list 7 8) (list 6 2) (list 7 11))) (list (list 10 13) (list 9 7) (list 10 16) (list 13 10) (list 14 19) (list 13 13)) 0.001)\n    (check-within (candidate (list (list 4 6) (list 8 9) (list 7 3) (list 8 12))) (list (list 12 15) (list 11 9) (list 12 18) (list 15 12) (list 16 21) (list 15 15)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the count of divisors is even. https://www.w3resource.com/rktthon-exercises/basic/rktthon-basic-1-exercise-24.php\n(define (count_divisors n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_divisors))\n    (check-within (candidate 10) #t 0.001)\n    (check-within (candidate 100) #f 0.001)\n    (check-within (candidate 125) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n(define (odd_length_sum arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate odd_length_sum))\n    (check-within (candidate (list 1 2 4)) 14 0.001)\n    (check-within (candidate (list 1 2 1 2)) 15 0.001)\n    (check-within (candidate (list 1 7)) 8 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n(define (rgb_to_hsv r g b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate rgb_to_hsv))\n    (check-within (candidate 255 255 255) (list 0.0 0.0 100.0) 0.001)\n    (check-within (candidate 0 215 0) (list 120.0 100.0 84.31372549019608) 0.001)\n    (check-within (candidate 10 215 110) (list 149.26829268292684 95.34883720930233 84.31372549019608) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the product of first even and odd number of a given list.\n(define (mul_even_odd list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate mul_even_odd))\n    (check-within (candidate (list 1 3 5 7 4 1 6 8)) 4 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) 2 0.001)\n    (check-within (candidate (list 1 5 7 9 10)) 10 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert list string to integer list.\n(define (tuple_str_int test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tuple_str_int))\n    (check-within (candidate \"(7, 8, 9)\") (list 7 8 9) 0.001)\n    (check-within (candidate \"(1, 2, 3)\") (list 1 2 3) 0.001)\n    (check-within (candidate \"(4, 5, 6)\") (list 4 5 6) 0.001)\n    (check-within (candidate \"(7, 81, 19)\") (list 7 81 19) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to locate the right insertion point for a specified value in sorted order.\n(define (right_insertion a x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate right_insertion))\n    (check-within (candidate (list 1 2 4 5) 6) 4 0.001)\n    (check-within (candidate (list 1 2 4 5) 3) 2 0.001)\n    (check-within (candidate (list 1 2 4 5) 7) 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an a followed by three 'b'.\n(define (text_match_three text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_match_three))\n    (check-within (candidate \"ac\") #f 0.001)\n    (check-within (candidate \"dc\") #f 0.001)\n    (check-within (candidate \"abbbba\") #t 0.001)\n    (check-within (candidate \"caacabbbba\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to create a new list from the given string and list.\n(define (new_tuple test_list test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate new_tuple))\n    (check-within (candidate (list \"WEB\" \"is\") \"best\") (list \"WEB\" \"is\" \"best\") 0.001)\n    (check-within (candidate (list \"We\" \"are\") \"Developers\") (list \"We\" \"are\" \"Developers\") 0.001)\n    (check-within (candidate (list \"Part\" \"is\") \"Wrong\") (list \"Part\" \"is\" \"Wrong\") 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether every even index contains even numbers of a given list.\n(define (even_position nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate even_position))\n    (check-within (candidate (list 3 2 1)) #f 0.001)\n    (check-within (candidate (list 1 2 3)) #f 0.001)\n    (check-within (candidate (list 2 1 4)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove lists from the given list.\n(define (remove_nested test_tup)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_nested))\n    (check-within (candidate (list 1 5 7 (list 4 6) 10)) (list 1 5 7 10) 0.001)\n    (check-within (candidate (list 2 6 8 (list 5 7) 11)) (list 2 6 8 11) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) 12)) (list 3 7 9 12) 0.001)\n    (check-within (candidate (list 3 7 9 (list 6 8) (list 5 12) 12)) (list 3 7 9 12) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of lists in a given number of lists.\n(define (count_list input_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_list))\n    (check-within (candidate (list (list 1 3) (list 5 7) (list 9 11) (list 13 15 17))) 4 0.001)\n    (check-within (candidate (list (list 1 2) (list 2 3) (list 4 5))) 3 0.001)\n    (check-within (candidate (list (list 1 0) (list 2 0))) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the last position of an element in a sorted list.\n(define (last arr x)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate last))\n    (check-within (candidate (list 1 2 3) 1) 0 0.001)\n    (check-within (candidate (list 1 1 1 2 3 4) 1) 2 0.001)\n    (check-within (candidate (list 2 3 2 3 6 8 9) 3) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n(define (text_starta_endb text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate text_starta_endb))\n    (check-within (candidate \"aabbbb\") #t 0.001)\n    (check-within (candidate \"aabAbbbc\") #f 0.001)\n    (check-within (candidate \"accddbbjjj\") #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write function to find the sum of all items in the given hash.\n(define (return_sum dict)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate return_sum))\n    (check-within (candidate #hash((\"a\" .  100) (\"b\" .  200) (\"c\" .  300))) 600 0.001)\n    (check-within (candidate #hash((\"a\" .  25) (\"b\" .  18) (\"c\" .  45))) 88 0.001)\n    (check-within (candidate #hash((\"a\" .  36) (\"b\" .  39) (\"c\" .  49))) 124 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of all odd natural numbers within the range l and r.\n(define (sum_in_range l r)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sum_in_range))\n    (check-within (candidate 2 5) 8 0.001)\n    (check-within (candidate 5 7) 12 0.001)\n    (check-within (candidate 7 13) 40 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the sum of a list.\n(define (_sum arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate _sum))\n    (check-within (candidate (list 1 2 3)) 6 0.001)\n    (check-within (candidate (list 15 12 13 10)) 50 0.001)\n    (check-within (candidate (list 0 1 2)) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n(define (left_rotate n d)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate left_rotate))\n    (check-within (candidate 16 2) 64 0.001)\n    (check-within (candidate 10 2) 40 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 99 3) 792 0.001)\n    (check-within (candidate 1 3) 8 0.001)\n    (check-within (candidate 5 3) 40 0.001)\n    (check-within (candidate 29 3) 232 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to check whether the length of the word is odd or not.\n(define (word_len s)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate word_len))\n    (check-within (candidate \"Hadoop\") #f 0.001)\n    (check-within (candidate \"great\") #t 0.001)\n    (check-within (candidate \"structure\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to remove all whitespaces from a string.\n(define (remove_all_spaces text)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate remove_all_spaces))\n    (check-within (candidate \"python  program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"python   programming    language\") \"pythonprogramminglanguage\" 0.001)\n    (check-within (candidate \"python                     program\") \"pythonprogram\" 0.001)\n    (check-within (candidate \"   python                     program\") \"pythonprogram\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of equal numbers from three given integers.\n(define (test_three_equal x y z)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate test_three_equal))\n    (check-within (candidate 1 1 1) 3 0.001)\n    (check-within (candidate -1 -2 -3) 0 0.001)\n    (check-within (candidate 1 2 2) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n(define (count_rotation arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate count_rotation))\n    (check-within (candidate (list 3 2 1)) 1 0.001)\n    (check-within (candidate (list 4 5 1 2 3)) 2 0.001)\n    (check-within (candidate (list 7 8 9 1 2 3)) 3 0.001)\n    (check-within (candidate (list 1 2 3)) 0 0.001)\n    (check-within (candidate (list 1 3 2)) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n(define (is_perfect_square n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_perfect_square))\n    (check-within (candidate 10) #f 0.001)\n    (check-within (candidate 36) #t 0.001)\n    (check-within (candidate 14) #f 0.001)\n    (check-within (candidate 196) #t 0.001)\n    (check-within (candidate 125) #f 0.001)\n    (check-within (candidate 15625) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the product of numbers in a list is even or not.\n(define (is_product_even arr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_product_even))\n    (check-within (candidate (list 1 2 3)) #t 0.001)\n    (check-within (candidate (list 1 2 1 4)) #t 0.001)\n    (check-within (candidate (list 1 1)) #f 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function that returns the list in a list of lists whose sum of elements is the highest.\n(define (max_sum_list lists)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_sum_list))\n    (check-within (candidate (list (list 1 2 3) (list 4 5 6) (list 10 11 12) (list 7 8 9))) (list 10 11 12) 0.001)\n    (check-within (candidate (list (list 3 2 1) (list 6 5 4) (list 12 11 10))) (list 12 11 10) 0.001)\n    (check-within (candidate (list (list 2 3 1))) (list 2 3 1) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find maximum run of uppercase characters in the given string.\n(define (max_run_uppercase test_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate max_run_uppercase))\n    (check-within (candidate \"GeMKSForGERksISBESt\") 5 0.001)\n    (check-within (candidate \"PrECIOusMOVemENTSYT\") 6 0.001)\n    (check-within (candidate \"GooGLEFluTTER\") 4 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the first odd number in a given list of numbers.\n(define (first_odd nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate first_odd))\n    (check-within (candidate (list 1 3 5)) 1 0.001)\n    (check-within (candidate (list 2 4 1 3)) 1 0.001)\n    (check-within (candidate (list 8 9 1)) 9 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if the given lists contain the k or not.\n(define (check_K test_tup K)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_K))\n    (check-within (candidate (list 10 4 5 6 8) 6) #t 0.001)\n    (check-within (candidate (list 1 2 3 4 5 6) 7) #f 0.001)\n    (check-within (candidate (list 7 8 9 44 11 12) 11) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if each element of second list is smaller than its corresponding element in the first list.\n(define (check_smaller test_tup1 test_tup2)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate check_smaller))\n    (check-within (candidate (list 1 2 3) (list 2 3 4)) #f 0.001)\n    (check-within (candidate (list 4 5 6) (list 3 4 5)) #t 0.001)\n    (check-within (candidate (list 11 12 13) (list 10 11 12)) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth tetrahedral number.\n(define (tetrahedral_number n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate tetrahedral_number))\n    (check-within (candidate 5) 35 0.001)\n    (check-within (candidate 6) 56 0.001)\n    (check-within (candidate 7) 84 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n(define (get_Char strr)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate get_Char))\n    (check-within (candidate \"abc\") \"f\" 0.001)\n    (check-within (candidate \"gfg\") \"t\" 0.001)\n    (check-within (candidate \"ab\") \"c\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the nth number in the newman conway sequence.\n(define (sequence n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate sequence))\n    (check-within (candidate 10) 6 0.001)\n    (check-within (candidate 2) 1 0.001)\n    (check-within (candidate 3) 2 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find nth centered hexagonal number.\n(define (centered_hexagonal_number n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate centered_hexagonal_number))\n    (check-within (candidate 10) 271 0.001)\n    (check-within (candidate 2) 7 0.001)\n    (check-within (candidate 9) 217 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to merge three dictionaries into a single hash.\n(define (merge_dictionaries_three dict1 dict2 dict3)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate merge_dictionaries_three))\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"O\" .  \"Orange\") (\"W\" .  \"White\") (\"B\" .  \"Black\"))) #hash((\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"P\" .  \"Pink\") (\"G\" .  \"Green\") (\"W\" .  \"White\") (\"O\" .  \"Orange\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\"))) #hash((\"W\" .  \"White\") (\"P\" .  \"Pink\") (\"B\" .  \"Black\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\")) 0.001)\n    (check-within (candidate #hash((\"R\" .  \"Red\") (\"B\" .  \"Black\") (\"P\" .  \"Pink\")) #hash((\"L\" .  \"lavender\") (\"B\" .  \"Blue\")) #hash((\"G\" .  \"Green\") (\"W\" .  \"White\"))) #hash((\"B\" .  \"Black\") (\"P\" .  \"Pink\") (\"R\" .  \"Red\") (\"G\" .  \"Green\") (\"L\" .  \"lavender\") (\"W\" .  \"White\")) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to get the frequency of all the elements in a list, returned as a hash.\n(define (freq_count list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate freq_count))\n    (check-within (candidate (list 10 10 10 10 20 20 20 20 40 40 50 50 30)) #hash((10 .  4) (20 .  4) (40 .  2) (50 .  2) (30 .  1)) 0.001)\n    (check-within (candidate (list 1 2 3 4 3 2 4 1 3 1 4)) #hash((1 .  3) (2 .  2) (3 .  3) (4 .  3)) 0.001)\n    (check-within (candidate (list 5 6 7 4 9 10 4 5 6 7 9 5)) #hash((10 .  1) (5 .  3) (6 .  2) (7 .  2) (4 .  2) (9 .  2)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find the closest smaller number than n.\n(define (closest_num N)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate closest_num))\n    (check-within (candidate 11) 10 0.001)\n    (check-within (candidate 7) 6 0.001)\n    (check-within (candidate 12) 11 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find squares of individual elements in a list.\n(define (square_nums nums)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate square_nums))\n    (check-within (candidate (list 1 2 3 4 5 6 7 8 9 10)) (list 1 4 9 16 25 36 49 64 81 100) 0.001)\n    (check-within (candidate (list 10 20 30)) (list 100 400 900) 0.001)\n    (check-within (candidate (list 12 15)) (list 144 225) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the longest word.\n(define (len_log list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate len_log))\n    (check-within (candidate (list \"python\" \"PHP\" \"bigdata\")) 7 0.001)\n    (check-within (candidate (list \"a\" \"ab\" \"abc\")) 3 0.001)\n    (check-within (candidate (list \"small\" \"big\" \"tall\")) 5 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check if a string is present as a substring in a given list of string values.\n(define (find_substring str1 sub_str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_substring))\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ack\") #t 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"abc\") #f 0.001)\n    (check-within (candidate (list \"red\" \"black\" \"white\" \"green\" \"orange\") \"ange\") #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to check whether the given number is undulating or not.\n(define (is_undulating n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate is_undulating))\n    (check-within (candidate 1212121) #t 0.001)\n    (check-within (candidate 1991) #f 0.001)\n    (check-within (candidate 121) #t 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to calculate the value of 'a' to the power 'b'.\n(define (power a b)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate power))\n    (check-within (candidate 3 4) 81 0.001)\n    (check-within (candidate 2 3) 8 0.001)\n    (check-within (candidate 5 5) 3125 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Given a list of lists, write a function that returns the first value of the list with the smallest second value.\n(define (index_minimum test_list)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate index_minimum))\n    (check-within (candidate (list (list \"Rash\" 143) (list \"Manjeet\" 200) (list \"Varsha\" 100))) \"Varsha\" 0.001)\n    (check-within (candidate (list (list \"Yash\" 185) (list \"Dawood\" 125) (list \"Sanya\" 175))) \"Dawood\" 0.001)\n    (check-within (candidate (list (list \"Sai\" 345) (list \"Salman\" 145) (list \"Ayesha\" 96))) \"Ayesha\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the length of the smallest list in a list of lists.\n(define (Find_Min_Length lst)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate Find_Min_Length))\n    (check-within (candidate (list (list 1) (list 1 2))) 1 0.001)\n    (check-within (candidate (list (list 1 2) (list 1 2 3) (list 1 2 3 4))) 2 0.001)\n    (check-within (candidate (list (list 3 3 3) (list 4 4 4 4))) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the number of divisors of a given integer.\n(define (divisor n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate divisor))\n    (check-within (candidate 15) 4 0.001)\n    (check-within (candidate 12) 6 0.001)\n    (check-within (candidate 9) 3 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to find frequency of each element in a flattened list of lists, returned in a hash.\n(define (frequency_lists list1)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate frequency_lists))\n    (check-within (candidate (list (list 1 2 3 2) (list 4 5 6 2) (list 7 8 9 5))) #hash((1 .  1) (2 .  3) (3 .  1) (4 .  1) (5 .  2) (6 .  1) (7 .  1) (8 .  1) (9 .  1)) 0.001)\n    (check-within (candidate (list (list 1 2 3 4) (list 5 6 7 8) (list 9 10 11 12))) #hash((1 .  1) (2 .  1) (3 .  1) (4 .  1) (5 .  1) (6 .  1) (7 .  1) (8 .  1) (9 .  1) (10 .  1) (11 .  1) (12 .  1)) 0.001)\n    (check-within (candidate (list (list 20 30 40 17) (list 18 16 14 13) (list 10 20 30 40))) #hash((20 .  2) (30 .  2) (40 .  2) (17 .  1) (18 .  1) (16 .  1) (14 .  1) (13 .  1) (10 .  1)) 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n(define (decimal_to_binary n)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate decimal_to_binary))\n    (check-within (candidate 8) \"1000\" 0.001)\n    (check-within (candidate 18) \"10010\" 0.001)\n    (check-within (candidate 7) \"111\" 0.001)\n))\n\n(test-humaneval)",
+    "stop_tokens": [
+      "\n(define ",
+      "\n#|",
+      "\n;",
+      "\n("
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rkt",
+    "prompt": "#lang racket\n\n;; Write a rktthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n(define (find_Rotations str)\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "(require rackunit)\n\n(define (test-humaneval) \n\n  (let (( candidate find_Rotations))\n    (check-within (candidate \"aaaa\") 1 0.001)\n    (check-within (candidate \"ab\") 2 0.001)\n    (check-within (candidate \"abc\") 3 0.001)\n))\n\n(test-humaneval)",
     "stop_tokens": [
       "\n(define ",
       "\n#|",

--- a/prompts/mbpp-rs-keep.json
+++ b/prompts/mbpp-rs-keep.json
@@ -1,3156 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rs",
-    "prompt": "/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfn lps(str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = lps;\n    assert_eq!(candidate(String::from(\"TENS FOR TENS\")), 5);\n    assert_eq!(candidate(String::from(\"CARDIO FOR CARDS\")), 7);\n    assert_eq!(candidate(String::from(\"PART OF THE JOURNEY IS PART\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all whitespaces from the given string.\nfn remove_whitespaces(text1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_whitespaces;\n    assert_eq!(candidate(String::from(\" Google    Flutter \")), String::from(\"GoogleFlutter\"));\n    assert_eq!(candidate(String::from(\" Google    Dart \")), String::from(\"GoogleDart\"));\n    assert_eq!(candidate(String::from(\" iOS    Swift \")), String::from(\"iOSSwift\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a specified list is sorted or not.\nfn issort_list(list1: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = issort_list;\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 16, 17]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 20, 17]), false);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 15, 14, 20]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rs",
-    "prompt": "/// Write a function to count bidirectional tuple pairs.\nfn count_bidirectional(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_bidirectional;\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]), 3);\n    assert_eq!(candidate(vec![(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]), 2);\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rs",
-    "prompt": "/// Write a function to find the surface area of a cube of a given size.\nfn surfacearea_cube(l: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cube;\n    assert_eq!(candidate(5), 150);\n    assert_eq!(candidate(3), 54);\n    assert_eq!(candidate(10), 600);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rs",
     "prompt": "/// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfn next_smallest_palindrome(num: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = next_smallest_palindrome;\n    assert_eq!(candidate(99), 101);\n    assert_eq!(candidate(1221), 1331);\n    assert_eq!(candidate(120), 121);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the cube sum of first n even natural numbers.\nfn cube_Sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cube_Sum;\n    assert_eq!(candidate(2), 72);\n    assert_eq!(candidate(3), 288);\n    assert_eq!(candidate(4), 800);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfn pair_xor_Sum(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pair_xor_Sum;\n    assert_eq!(candidate(vec![5, 9, 7, 6], 4), 47);\n    assert_eq!(candidate(vec![7, 3, 5], 3), 12);\n    assert_eq!(candidate(vec![7, 3], 2), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfn check_min_heap(arr: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_min_heap;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 10, 15]), true);\n    assert_eq!(candidate(vec![2, 10, 4, 5, 3, 15]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the first digit of a given number.\nfn first_Digit(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = first_Digit;\n    assert_eq!(candidate(123), 1);\n    assert_eq!(candidate(456), 4);\n    assert_eq!(candidate(12), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the first non-repeated character in a given string.\nfn first_non_repeating_character(str1: String) -> Option<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = first_non_repeating_character;\n    assert_eq!(candidate(String::from(\"abcabc\")), None);\n    assert_eq!(candidate(String::from(\"abc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"ababc\")), Some(String::from(\"c\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rs",
-    "prompt": "/// Write a function to convert degrees to radians.\nfn radian_degree(degree: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = radian_degree;\n    assert_eq!(candidate(90), 1.5707963267948966);\n    assert_eq!(candidate(60), 1.0471975511965976);\n    assert_eq!(candidate(120), 2.0943951023931953);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum product subarray of the given array.\nfn max_subarray_product(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_subarray_product;\n    assert_eq!(candidate(vec![1, -2, -3, 0, 7, -8, -2]), 112);\n    assert_eq!(candidate(vec![6, -3, -10, 0, 2]), 180);\n    assert_eq!(candidate(vec![-2, -40, 0, -2, -3]), 80);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rs",
-    "prompt": "/// Write a python function to find smallest number in a list.\nfn smallest_num(xs: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_num;\n    assert_eq!(candidate(vec![10, 20, 1, 45, 99]), 1);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n    assert_eq!(candidate(vec![45, 46, 50, 60]), 45);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfn text_match_zero_one(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_zero_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"dsabbbba\")), true);\n    assert_eq!(candidate(String::from(\"asbbbba\")), false);\n    assert_eq!(candidate(String::from(\"abaaa\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rs",
-    "prompt": "/// Write a python function to find nth bell number.\nfn bell_Number(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = bell_Number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 15);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rs",
-    "prompt": "/// Write a function to find cubes of individual elements in a list.\nfn cube_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cube_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15]), vec![1728, 3375]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the last digit in factorial of a given number.\nfn last_Digit_Factorial(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = last_Digit_Factorial;\n    assert_eq!(candidate(4), 4);\n    assert_eq!(candidate(21), 0);\n    assert_eq!(candidate(30), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rs",
-    "prompt": "/// Write a python function to find even numbers from a list of numbers.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![2, 4]);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 8, 0, 1]), vec![4, 6, 8, 0]);\n    assert_eq!(candidate(vec![8, 12, 15, 19]), vec![8, 12]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given integer is a prime number.\nfn prime_num(num: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_num;\n    assert_eq!(candidate(13), true);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(-1010), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfn find_tuples(test_list: Vec<(isize, isize, isize)>, K: isize) -> Vec<(isize, isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_tuples;\n    assert_eq!(candidate(vec![(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6), vec![(6, 24, 12)]);\n    assert_eq!(candidate(vec![(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5), vec![(5, 25, 30)]);\n    assert_eq!(candidate(vec![(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4), vec![(8, 16, 4)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rs",
-    "prompt": "/// Write a function to caluclate the area of a tetrahedron.\nfn area_tetrahedron(side: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = area_tetrahedron;\n    assert_eq!(candidate(3), 15.588457268119894);\n    assert_eq!(candidate(20), 692.8203230275509);\n    assert_eq!(candidate(10), 173.20508075688772);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given number is even or not.\nfn is_Even(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Even;\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(2), true);\n    assert_eq!(candidate(3), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of positive numbers in a list.\nfn pos_count(list: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pos_count;\n    assert_eq!(candidate(vec![1, -2, 3, -4]), 2);\n    assert_eq!(candidate(vec![3, 4, 5, -1]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rs",
-    "prompt": "/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfn get_ludic(n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_ludic;\n    assert_eq!(candidate(10), vec![1, 2, 3, 5, 7]);\n    assert_eq!(candidate(25), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n    assert_eq!(candidate(45), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfn find_Index(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Index;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 14);\n    assert_eq!(candidate(4), 45);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rs",
-    "prompt": "/// Write a python function to reverse an array upto a given position.\nfn reverse_Array_Upto_K(input: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_Array_Upto_K;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 4), vec![4, 3, 2, 1, 5, 6]);\n    assert_eq!(candidate(vec![4, 5, 6, 7], 2), vec![5, 4, 6, 7]);\n    assert_eq!(candidate(vec![9, 8, 7, 6, 5], 3), vec![7, 8, 9, 6, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a list of tuples using the second value of each tuple.\nfn subject_marks(subjectmarks: Vec<(String, isize)>) -> Vec<(String, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = subject_marks;\n    assert_eq!(candidate(vec![(String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97), (String::from(\"Social sciences\"), 82)]), vec![(String::from(\"Social sciences\"), 82), (String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97)]);\n    assert_eq!(candidate(vec![(String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54), (String::from(\"Social\"), 33)]), vec![(String::from(\"Social\"), 33), (String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54)]);\n    assert_eq!(candidate(vec![(String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97), (String::from(\"Biology\"), 45)]), vec![(String::from(\"Biology\"), 45), (String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rs",
-    "prompt": "/// Write a function to remove characters from the first string which are present in the second string.\nfn remove_dirty_chars(string: String, second_string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_dirty_chars;\n    assert_eq!(candidate(String::from(\"probasscurve\"), String::from(\"pros\")), String::from(\"bacuve\"));\n    assert_eq!(candidate(String::from(\"digitalindia\"), String::from(\"talent\")), String::from(\"digiidi\"));\n    assert_eq!(candidate(String::from(\"exoticmiles\"), String::from(\"toxic\")), String::from(\"emles\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rs",
-    "prompt": "/// Write a function to find the item with maximum frequency in a given list.\nfn max_occurrences(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_occurrences;\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]), 2);\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]), 8);\n    assert_eq!(candidate(vec![10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]), 20);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfn is_decimal(num: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_decimal;\n    assert_eq!(candidate(String::from(\"123.11\")), true);\n    assert_eq!(candidate(String::from(\"e666.86\")), false);\n    assert_eq!(candidate(String::from(\"3.124587\")), false);\n    assert_eq!(candidate(String::from(\"1.11\")), true);\n    assert_eq!(candidate(String::from(\"1.1.11\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfn dict_filter(dict: HashMap<String, isize>, n: isize) -> HashMap<String, isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = dict_filter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 170), HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 180), HashMap::from([(String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 190), HashMap::from([(String::from(\"Pierre Cox\"), 190)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of even numbers at even positions of a list.\nfn sum_even_and_even_index(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_even_and_even_index;\n    assert_eq!(candidate(vec![5, 6, 12, 1, 18, 8]), 30);\n    assert_eq!(candidate(vec![3, 20, 17, 9, 2, 10, 18, 13, 6, 18]), 26);\n    assert_eq!(candidate(vec![5, 6, 12, 1]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the sum of the largest contiguous sublist in the given list.\nfn max_sub_array_sum(a: Vec<isize>, size: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum;\n    assert_eq!(candidate(vec![-2, -3, 4, -1, -2, 1, 5, -3], 8), 7);\n    assert_eq!(candidate(vec![-3, -4, 5, -2, -3, 2, 6, -4], 8), 8);\n    assert_eq!(candidate(vec![-4, -5, 6, -3, -4, 3, 7, -5], 8), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rs",
-    "prompt": "/// Write a function to find the intersection of two arrays.\nfn intersection_array(array_nums1: Vec<isize>, array_nums2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection_array;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![1, 2, 4, 8, 9]), vec![1, 2, 8, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![3, 5, 7, 9]), vec![3, 5, 7, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![10, 20, 30, 40]), vec![10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rs",
-    "prompt": "/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfn find_literals(text: String, pattern: String) -> (String, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_literals;\n    assert_eq!(candidate(String::from(\"The quick brown fox jumps over the lazy dog.\"), String::from(\"fox\")), (String::from(\"fox\"), 16, 19));\n    assert_eq!(candidate(String::from(\"Its been a very crazy procedure right\"), String::from(\"crazy\")), (String::from(\"crazy\"), 16, 21));\n    assert_eq!(candidate(String::from(\"Hardest choices required strongest will\"), String::from(\"will\")), (String::from(\"will\"), 35, 39));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the volume of a triangular prism.\nfn find_Volume(l: isize, b: isize, h: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Volume;\n    assert_eq!(candidate(10, 8, 6), 240);\n    assert_eq!(candidate(3, 2, 2), 6);\n    assert_eq!(candidate(1, 2, 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfn wind_chill(v: isize, t: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = wind_chill;\n    assert_eq!(candidate(120, 35), 40);\n    assert_eq!(candidate(40, 20), 19);\n    assert_eq!(candidate(10, 8), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rs",
-    "prompt": "/// Write a function to find the ascii value of a character.\nfn ascii_value(k: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = ascii_value;\n    assert_eq!(candidate(String::from(\"A\")), 65);\n    assert_eq!(candidate(String::from(\"R\")), 82);\n    assert_eq!(candidate(String::from(\"S\")), 83);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether all the characters are same or not.\nfn all_Characters_Same(s: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_Characters_Same;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"aaa\")), true);\n    assert_eq!(candidate(String::from(\"data\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rs",
-    "prompt": "/// Write a function to move all the numbers to the end of the given string.\nfn move_num(test_str: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = move_num;\n    assert_eq!(candidate(String::from(\"I1love143you55three3000thousand\")), String::from(\"Iloveyouthreethousand1143553000\"));\n    assert_eq!(candidate(String::from(\"Avengers124Assemble\")), String::from(\"AvengersAssemble124\"));\n    assert_eq!(candidate(String::from(\"Its11our12path13to14see15things16do17things\")), String::from(\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the length of the word is odd or not.\nfn word_len(s: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = word_len;\n    assert_eq!(candidate(String::from(\"Hadoop\")), false);\n    assert_eq!(candidate(String::from(\"great\")), true);\n    assert_eq!(candidate(String::from(\"structure\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfn insert_element(list: Vec<String>, element: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = insert_element;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Black\")], String::from(\"c\")), vec![String::from(\"c\"), String::from(\"Red\"), String::from(\"c\"), String::from(\"Green\"), String::from(\"c\"), String::from(\"Black\")]);\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"java\")], String::from(\"program\")), vec![String::from(\"program\"), String::from(\"python\"), String::from(\"program\"), String::from(\"java\")]);\n    assert_eq!(candidate(vec![String::from(\"happy\"), String::from(\"sad\")], String::from(\"laugh\")), vec![String::from(\"laugh\"), String::from(\"happy\"), String::from(\"laugh\"), String::from(\"sad\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rs",
-    "prompt": "/// Write a function to remove lowercase substrings from a given string.\nfn remove_lowercase(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_lowercase;\n    assert_eq!(candidate(String::from(\"PYTHon\")), String::from(\"PYTH\"));\n    assert_eq!(candidate(String::from(\"FInD\")), String::from(\"FID\"));\n    assert_eq!(candidate(String::from(\"STRinG\")), String::from(\"STRG\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfn count_Set_Bits(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Set_Bits;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 1);\n    assert_eq!(candidate(6), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rs",
-    "prompt": "/// Write a function to extract only the rear index element of each string in the given tuple.\nfn extract_rear(test_tuple: (String, String, String)) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_rear;\n    assert_eq!(candidate((String::from(\"Mers\"), String::from(\"for\"), String::from(\"Vers\"))), vec![String::from(\"s\"), String::from(\"r\"), String::from(\"s\")]);\n    assert_eq!(candidate((String::from(\"Avenge\"), String::from(\"for\"), String::from(\"People\"))), vec![String::from(\"e\"), String::from(\"r\"), String::from(\"e\")]);\n    assert_eq!(candidate((String::from(\"Gotta\"), String::from(\"get\"), String::from(\"go\"))), vec![String::from(\"a\"), String::from(\"t\"), String::from(\"o\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of occurence of the string 'std' in a given string.\nfn count_occurance(s: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_occurance;\n    assert_eq!(candidate(String::from(\"letstdlenstdporstd\")), 3);\n    assert_eq!(candidate(String::from(\"truststdsolensporsd\")), 1);\n    assert_eq!(candidate(String::from(\"makestdsostdworthit\")), 2);\n    assert_eq!(candidate(String::from(\"stds\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given tuples contain the k or not.\nfn check_K(test_tup: Vec<isize>, K: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_K;\n    assert_eq!(candidate(vec![10, 4, 5, 6, 8], 6), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 7), false);\n    assert_eq!(candidate(vec![7, 8, 9, 44, 11, 12], 11), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rs",
-    "prompt": "/// Write a function to interleave 3 lists of the same length into a single flat list.\nfn interleave_lists(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = interleave_lists;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7], vec![10, 20, 30, 40, 50, 60, 70], vec![100, 200, 300, 400, 500, 600, 700]), vec![1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n    assert_eq!(candidate(vec![10, 20], vec![15, 2], vec![5, 10]), vec![10, 15, 5, 20, 2, 10]);\n    assert_eq!(candidate(vec![11, 44], vec![10, 15], vec![20, 5]), vec![11, 10, 20, 44, 15, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"python_program\")), String::from(\"PythonProgram\"));\n    assert_eq!(candidate(String::from(\"python_language\")), String::from(\"PythonLanguage\"));\n    assert_eq!(candidate(String::from(\"programming_language\")), String::from(\"ProgrammingLanguage\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of equal numbers from three given integers.\nfn test_three_equal(x: isize, y: isize, z: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = test_three_equal;\n    assert_eq!(candidate(1, 1, 1), 3);\n    assert_eq!(candidate(-1, -2, -3), 0);\n    assert_eq!(candidate(1, 2, 2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfn odd_length_sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_length_sum;\n    assert_eq!(candidate(vec![1, 2, 4]), 14);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), 15);\n    assert_eq!(candidate(vec![1, 7]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find the number of ways to partition a set of Bell numbers.\nfn bell_number(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = bell_number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(10), 115975);\n    assert_eq!(candidate(56), 6775685320645824322581483068371419745979053216268760300);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rs",
-    "prompt": "/// Write a function to find the area of a rectangle.\nfn rectangle_area(l: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rectangle_area;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(10, 5), 50);\n    assert_eq!(candidate(4, 2), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rs",
-    "prompt": "/// Write a function to find sum and average of first n natural numbers.\nfn sum_average(number: isize) -> (isize, f64) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_average;\n    assert_eq!(candidate(10), (55, 5.5));\n    assert_eq!(candidate(15), (120, 8.0));\n    assert_eq!(candidate(20), (210, 10.5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfn division_elements(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = division_elements;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (2, 2, 2, 3));\n    assert_eq!(candidate((12, 6, 8, 16), (6, 3, 4, 4)), (2, 2, 2, 4));\n    assert_eq!(candidate((20, 14, 36, 18), (5, 7, 6, 9)), (4, 2, 6, 2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rs",
-    "prompt": "/// Write a function to get the sum of the digits of a non-negative integer.\nfn sum_digits(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_digits;\n    assert_eq!(candidate(345), 12);\n    assert_eq!(candidate(12), 3);\n    assert_eq!(candidate(97), 16);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rs",
-    "prompt": "/// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfn index_minimum(test_list: Vec<(String, isize)>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = index_minimum;\n    assert_eq!(candidate(vec![(String::from(\"Rash\"), 143), (String::from(\"Manjeet\"), 200), (String::from(\"Varsha\"), 100)]), String::from(\"Varsha\"));\n    assert_eq!(candidate(vec![(String::from(\"Yash\"), 185), (String::from(\"Dawood\"), 125), (String::from(\"Sanya\"), 175)]), String::from(\"Dawood\"));\n    assert_eq!(candidate(vec![(String::from(\"Sai\"), 345), (String::from(\"Salman\"), 145), (String::from(\"Ayesha\"), 96)]), String::from(\"Ayesha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rs",
-    "prompt": "/// Write a function to divide two lists element wise.\nfn div_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<f64> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = div_list;\n    assert_eq!(candidate(vec![4, 5, 6], vec![1, 2, 3]), vec![4.0, 2.5, 2.0]);\n    assert_eq!(candidate(vec![3, 2], vec![1, 4]), vec![3.0, 0.5]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![1.8, 1.7142857142857142]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rs",
-    "prompt": "/// Write a function to find the list with maximum length.\nfn max_length_list(input_list: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_length_list;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4], vec![1, 2, 3], vec![1, 2], vec![1]]), (5, vec![1, 2, 3, 4, 5]));\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![6, 7, 8, 9], vec![10, 11, 12]]), (4, vec![6, 7, 8, 9]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of the largest and smallest value in a given array.\nfn big_sum(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = big_sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 4);\n    assert_eq!(candidate(vec![-1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![2, 3, 6]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rs",
-    "prompt": "/// Write a python function to return the negative numbers in a list.\nfn neg_nos(list1: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = neg_nos;\n    assert_eq!(candidate(vec![-1, 4, 5, -6]), vec![-1, -6]);\n    assert_eq!(candidate(vec![-1, -2, 3, 4]), vec![-1, -2]);\n    assert_eq!(candidate(vec![-7, -6, 8, 9]), vec![-7, -6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the highest power of 2 that is less than or equal to n.\nfn highest_Power_of_2(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = highest_Power_of_2;\n    assert_eq!(candidate(10), 8);\n    assert_eq!(candidate(19), 16);\n    assert_eq!(candidate(32), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a list contains the given sublist or not.\nfn is_sublist(l: Vec<isize>, s: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sublist;\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![4, 3]), true);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![1, 6]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rs",
-    "prompt": "/// Write a function to subtract two lists element-wise.\nfn sub_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sub_list;\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), vec![-3, -3, -3]);\n    assert_eq!(candidate(vec![1, 2], vec![3, 4]), vec![-2, -2]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![40, 50]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given two integers have opposite sign or not.\nfn opposite_Signs(x: isize, y: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = opposite_Signs;\n    assert_eq!(candidate(1, -2), true);\n    assert_eq!(candidate(3, 2), false);\n    assert_eq!(candidate(-10, -10), false);\n    assert_eq!(candidate(-2, 2), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rs",
-    "prompt": "/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfn tuple_modulo(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_modulo;\n    assert_eq!(candidate((10, 4, 5, 6), (5, 6, 7, 5)), (0, 4, 5, 1));\n    assert_eq!(candidate((11, 5, 6, 7), (6, 7, 8, 6)), (5, 5, 6, 1));\n    assert_eq!(candidate((12, 6, 7, 8), (7, 8, 9, 7)), (5, 6, 7, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to find the difference of the first even and first odd number of a given list.\nfn diff_even_odd(list1: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = diff_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 1);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rs",
-    "prompt": "/// Write a function to sort each sublist of strings in a given list of lists.\nfn sort_sublists(list1: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"d\"), String::from(\"c\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"f\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"c\"), String::from(\"d\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"e\"), String::from(\"f\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the last digit of a given number.\nfn last_Digit(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = last_Digit;\n    assert_eq!(candidate(123), 3);\n    assert_eq!(candidate(25), 5);\n    assert_eq!(candidate(30), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfn odd_num_sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_num_sum;\n    assert_eq!(candidate(2), 82);\n    assert_eq!(candidate(3), 707);\n    assert_eq!(candidate(4), 3108);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a list to a string.\nfn tup_string(tup1: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tup_string;\n    assert_eq!(candidate(vec![String::from(\"e\"), String::from(\"x\"), String::from(\"e\"), String::from(\"r\"), String::from(\"c\"), String::from(\"i\"), String::from(\"s\"), String::from(\"e\"), String::from(\"s\")]), String::from(\"exercises\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]), String::from(\"program\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all elements from a given list present in another list.\nfn remove_elements(list1: Vec<isize>, list2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_elements;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![2, 4, 6, 8]), vec![1, 3, 5, 7, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![1, 3, 5, 7]), vec![2, 4, 6, 8, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![5, 7]), vec![1, 2, 3, 4, 6, 8, 9, 10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfn overlapping(list1: Vec<isize>, list2: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = overlapping;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 8, 9]), false);\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 4, 5], vec![1, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rs",
-    "prompt": "/// Write a python function to identify non-prime numbers.\nfn is_not_prime(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_not_prime;\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(35), true);\n    assert_eq!(candidate(37), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfn sum_negativenum(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_negativenum;\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), -32);\n    assert_eq!(candidate(vec![10, 15, -14, 13, -18, 12, -20]), -52);\n    assert_eq!(candidate(vec![19, -65, 57, 39, 152, -639, 121, 44, 90, -190]), -894);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfn find_Rotations(str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Rotations;\n    assert_eq!(candidate(String::from(\"aaaa\")), 1);\n    assert_eq!(candidate(String::from(\"ab\")), 2);\n    assert_eq!(candidate(String::from(\"abc\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfn change_date_format(dt: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = change_date_format;\n    assert_eq!(candidate(String::from(\"2026-01-02\")), String::from(\"02-01-2026\"));\n    assert_eq!(candidate(String::from(\"2020-11-13\")), String::from(\"13-11-2020\"));\n    assert_eq!(candidate(String::from(\"2021-04-26\")), String::from(\"26-04-2021\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rs",
-    "prompt": "/// Write a python function which takes a list of integers and only returns the odd ones.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), vec![1, 3, 5]);\n    assert_eq!(candidate(vec![10, 11, 12, 13]), vec![11, 13]);\n    assert_eq!(candidate(vec![7, 8, 9, 1]), vec![7, 9, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rs",
-    "prompt": "/// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfn toggle_middle_bits(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = toggle_middle_bits;\n    assert_eq!(candidate(9), 15);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(11), 13);\n    assert_eq!(candidate(65), 127);\n    assert_eq!(candidate(77), 115);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfn count_char_position(str1: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_char_position;\n    assert_eq!(candidate(String::from(\"xbcefg\")), 2);\n    assert_eq!(candidate(String::from(\"ABcED\")), 3);\n    assert_eq!(candidate(String::from(\"AbgdeF\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfn large_product(nums1: Vec<isize>, nums2: Vec<isize>, N: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = large_product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 3), vec![60, 54, 50]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 4), vec![60, 54, 50, 48]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 5), vec![60, 54, 50, 48, 45]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfn cummulative_sum(test_list: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cummulative_sum;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 6, 7], vec![2, 6]]), 30);\n    assert_eq!(candidate(vec![vec![2, 4], vec![6, 7, 8], vec![3, 7]]), 37);\n    assert_eq!(candidate(vec![vec![3, 5], vec![7, 8, 9], vec![4, 8]]), 44);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfn find_min_diff(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_min_diff;\n    assert_eq!(candidate(vec![1, 5, 3, 19, 18, 25], 6), 1);\n    assert_eq!(candidate(vec![4, 3, 2, 6], 4), 1);\n    assert_eq!(candidate(vec![30, 5, 20, 9], 4), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfn text_starta_endb(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_starta_endb;\n    assert_eq!(candidate(String::from(\"aabbbb\")), true);\n    assert_eq!(candidate(String::from(\"aabAbbbc\")), false);\n    assert_eq!(candidate(String::from(\"accddbbjjj\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rs",
-    "prompt": "/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfn left_rotate(n: isize, d: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = left_rotate;\n    assert_eq!(candidate(16, 2), 64);\n    assert_eq!(candidate(10, 2), 40);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(1, 3), 8);\n    assert_eq!(candidate(5, 3), 40);\n    assert_eq!(candidate(29, 3), 232);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the first repeated character in a given string.\nfn first_repeated_char(str1: String) -> Option<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = first_repeated_char;\n    assert_eq!(candidate(String::from(\"abcabc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"abc\")), None);\n    assert_eq!(candidate(String::from(\"123123\")), Some(String::from(\"1\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rs",
-    "prompt": "/// Write a python function to count inversions in an array.\nfn get_Inv_Count(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_Inv_Count;\n    assert_eq!(candidate(vec![1, 20, 6, 4, 5]), 5);\n    assert_eq!(candidate(vec![1, 2, 1]), 1);\n    assert_eq!(candidate(vec![1, 2, 5, 6, 1]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rs",
-    "prompt": "/// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfn even_Power_Sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_Power_Sum;\n    assert_eq!(candidate(2), 1056);\n    assert_eq!(candidate(3), 8832);\n    assert_eq!(candidate(1), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rs",
-    "prompt": "/// Write a function to find whether all the given lists have equal length or not.\nfn get_equal(Input: Vec<Vec<isize>>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_equal;\n    assert_eq!(candidate(vec![vec![11, 22, 33], vec![44, 55, 66]]), true);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6, 7]]), false);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rs",
-    "prompt": "/// Write a function to check if a string represents an integer or not.\nfn check_integer(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_integer;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"1\")), true);\n    assert_eq!(candidate(String::from(\"12345\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rs",
-    "prompt": "/// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfn count_reverse_pairs(test_list: Vec<String>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_reverse_pairs;\n    assert_eq!(candidate(vec![String::from(\"julia\"), String::from(\"best\"), String::from(\"tseb\"), String::from(\"for\"), String::from(\"ailuj\")]), 2);\n    assert_eq!(candidate(vec![String::from(\"geeks\"), String::from(\"best\"), String::from(\"for\"), String::from(\"skeeg\")]), 1);\n    assert_eq!(candidate(vec![String::from(\"makes\"), String::from(\"best\"), String::from(\"sekam\"), String::from(\"for\"), String::from(\"rof\")]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rs",
-    "prompt": "/// Write a python function to move all zeroes to the end of the given list.\nfn move_zero(num_list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = move_zero;\n    assert_eq!(candidate(vec![1, 0, 2, 0, 3, 4]), vec![1, 2, 3, 4, 0, 0]);\n    assert_eq!(candidate(vec![2, 3, 2, 0, 0, 4, 0, 5, 0]), vec![2, 3, 2, 4, 5, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![0, 1, 0, 1, 1]), vec![1, 1, 1, 0, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rs",
-    "prompt": "/// Write a function to check if given list contains no duplicates.\nfn check_distinct(test_tup: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_distinct;\n    assert_eq!(candidate(vec![1, 4, 5, 6, 1, 4]), false);\n    assert_eq!(candidate(vec![1, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given amount has no profit and no loss\nfn noprofit_noloss(actual_cost: isize, sale_amount: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = noprofit_noloss;\n    assert_eq!(candidate(1500, 1200), false);\n    assert_eq!(candidate(100, 100), true);\n    assert_eq!(candidate(2000, 5000), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all the words with k length in the given string.\nfn remove_length(test_str: String, K: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_length;\n    assert_eq!(candidate(String::from(\"The person is most value tet\"), 3), String::from(\"person is most value\"));\n    assert_eq!(candidate(String::from(\"If you told me about this ok\"), 4), String::from(\"If you me about ok\"));\n    assert_eq!(candidate(String::from(\"Forces of darkeness is come into the play\"), 4), String::from(\"Forces of darkeness is the\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rs",
-    "prompt": "/// Write a python function to count number of digits in a given string.\nfn number_ctr(str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = number_ctr;\n    assert_eq!(candidate(String::from(\"program2bedone\")), 1);\n    assert_eq!(candidate(String::from(\"3wonders\")), 1);\n    assert_eq!(candidate(String::from(\"123\")), 3);\n    assert_eq!(candidate(String::from(\"3wond-1ers2\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rs",
-    "prompt": "/// Write a function to count the total number of characters in a string.\nfn count_charac(str1: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_charac;\n    assert_eq!(candidate(String::from(\"python programming\")), 18);\n    assert_eq!(candidate(String::from(\"language\")), 8);\n    assert_eq!(candidate(String::from(\"words\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfn get_total_number_of_sequences(m: isize, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_total_number_of_sequences;\n    assert_eq!(candidate(10, 4), 4);\n    assert_eq!(candidate(5, 2), 6);\n    assert_eq!(candidate(16, 3), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rs",
-    "prompt": "/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfn left_insertion(a: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = left_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfn swap_numbers(a: isize, b: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_numbers;\n    assert_eq!(candidate(10, 20), vec![20, 10]);\n    assert_eq!(candidate(15, 17), vec![17, 15]);\n    assert_eq!(candidate(100, 200), vec![200, 100]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfn is_majority(arr: Vec<isize>, n: isize, x: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_majority;\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 3, 10], 7, 3), true);\n    assert_eq!(candidate(vec![1, 1, 2, 4, 4, 4, 6, 6], 8, 4), false);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 2], 5, 1), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2], 5, 1), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfn substract_elements(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> (isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = substract_elements;\n    assert_eq!(candidate((10, 4, 5), (2, 5, 18)), (8, -1, -13));\n    assert_eq!(candidate((11, 2, 3), (24, 45, 16)), (-13, -43, -13));\n    assert_eq!(candidate((7, 18, 9), (10, 11, 12)), (-3, 7, -3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to put spaces between words starting with capital letters in a given string.\nfn capital_words_spaces(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = capital_words_spaces;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"PythonProgrammingExamples\")), String::from(\"Python Programming Examples\"));\n    assert_eq!(candidate(String::from(\"GetReadyToBeCodingFreak\")), String::from(\"Get Ready To Be Coding Freak\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the average of cubes of first n natural numbers.\nfn find_Average_Of_Cube(n: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Average_Of_Cube;\n    assert_eq!(candidate(2), 4.5);\n    assert_eq!(candidate(3), 12.0);\n    assert_eq!(candidate(1), 1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to check if all values are same in a dictionary.\nfn check_value(dict: HashMap<String, isize>, n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_value;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 10), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 12), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth tetrahedral number.\nfn tetrahedral_number(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tetrahedral_number;\n    assert_eq!(candidate(5), 35);\n    assert_eq!(candidate(6), 56);\n    assert_eq!(candidate(7), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate whether the matrix is a magic square.\nfn magic_square_test(my_matrix: Vec<Vec<isize>>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = magic_square_test;\n    assert_eq!(candidate(vec![vec![7, 12, 1, 14], vec![2, 13, 8, 11], vec![16, 3, 10, 5], vec![9, 6, 15, 4]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 8]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 7]]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rs",
-    "prompt": "/// Write a function to remove uppercase substrings from a given string.\nfn remove_uppercase(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_uppercase;\n    assert_eq!(candidate(String::from(\"cAstyoUrFavoRitETVshoWs\")), String::from(\"cstyoravoitshos\"));\n    assert_eq!(candidate(String::from(\"wAtchTheinTernEtrAdIo\")), String::from(\"wtchheinerntrdo\"));\n    assert_eq!(candidate(String::from(\"VoicESeaRchAndreComMendaTionS\")), String::from(\"oiceachndreomendaion\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate a dog's age in dog's years.\nfn dog_age(h_age: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = dog_age;\n    assert_eq!(candidate(12), 61);\n    assert_eq!(candidate(15), 73);\n    assert_eq!(candidate(24), 109);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the next perfect square greater than a given number.\nfn next_Perfect_Square(N: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = next_Perfect_Square;\n    assert_eq!(candidate(35), 36);\n    assert_eq!(candidate(6), 9);\n    assert_eq!(candidate(9), 16);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rs",
-    "prompt": "/// Write a python function to convert a given string to uppercase.\nfn is_upper(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_upper;\n    assert_eq!(candidate(String::from(\"person\")), String::from(\"PERSON\"));\n    assert_eq!(candidate(String::from(\"final\")), String::from(\"FINAL\"));\n    assert_eq!(candidate(String::from(\"Valid\")), String::from(\"VALID\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfn odd_Equivalent(s: String, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_Equivalent;\n    assert_eq!(candidate(String::from(\"011001\"), 6), 3);\n    assert_eq!(candidate(String::from(\"11011\"), 5), 4);\n    assert_eq!(candidate(String::from(\"1010\"), 4), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfn re_arrange_array(arr: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = re_arrange_array;\n    assert_eq!(candidate(vec![-1, 2, -3, 4, 5, 6, -7, 8, 9], 9), vec![-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n    assert_eq!(candidate(vec![12, -14, -26, 13, 15], 5), vec![-14, -26, 12, 13, 15]);\n    assert_eq!(candidate(vec![10, 24, 36, -42, -39, -78, 85], 7), vec![-42, -39, -78, 10, 24, 36, 85]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfn unique_Element(arr: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_Element;\n    assert_eq!(candidate(vec![1, 1, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rs",
-    "prompt": "/// Write a python function to count true booleans in the given list.\nfn count(lst: Vec<bool>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count;\n    assert_eq!(candidate(vec![true, false, true]), 2);\n    assert_eq!(candidate(vec![false, false]), 0);\n    assert_eq!(candidate(vec![true, true, true]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rs",
-    "prompt": "/// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfn find_even_pair(A: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_even_pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1]), 4);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11]), 9);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is armstrong or not.\nfn armstrong_number(number: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = armstrong_number;\n    assert_eq!(candidate(153), true);\n    assert_eq!(candidate(259), false);\n    assert_eq!(candidate(4458), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the upper case characters in a given string.\nfn upper_ctr(str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = upper_ctr;\n    assert_eq!(candidate(String::from(\"PYthon\")), 1);\n    assert_eq!(candidate(String::from(\"BigData\")), 1);\n    assert_eq!(candidate(String::from(\"program\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to extract the elementwise and tuples from the given two tuples.\nfn and_tuples(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = and_tuples;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (0, 0, 2, 1));\n    assert_eq!(candidate((1, 2, 3, 4), (5, 6, 7, 8)), (1, 2, 3, 0));\n    assert_eq!(candidate((8, 9, 11, 12), (7, 13, 14, 17)), (0, 9, 10, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether it follows the sequence given in the patterns array.\nfn is_samepatterns(colors: Vec<String>, patterns: Vec<String>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_samepatterns;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"green\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\")]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of lists in a given number of lists.\nfn count_list(input_list: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_list;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), 4);\n    assert_eq!(candidate(vec![vec![1, 2], vec![2, 3], vec![4, 5]]), 3);\n    assert_eq!(candidate(vec![vec![1, 0], vec![2, 0]]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfn average_tuple(nums: Vec<Vec<isize>>) -> Vec<f64> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = average_tuple;\n    assert_eq!(candidate(vec![vec![10, 10, 10, 12], vec![30, 45, 56, 45], vec![81, 80, 39, 32], vec![1, 2, 3, 4]]), vec![30.5, 34.25, 27.0, 23.25]);\n    assert_eq!(candidate(vec![vec![1, 1, -5], vec![30, -15, 56], vec![81, -60, -39], vec![-10, 2, 3]]), vec![25.5, -18.0, 3.75]);\n    assert_eq!(candidate(vec![vec![100, 100, 100, 120], vec![300, 450, 560, 450], vec![810, 800, 390, 320], vec![10, 20, 30, 40]]), vec![305.0, 342.5, 270.0, 232.5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rs",
-    "prompt": "/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfn lcs_of_three(X: String, Y: String, Z: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = lcs_of_three;\n    assert_eq!(candidate(String::from(\"AGGT12\"), String::from(\"12TXAYB\"), String::from(\"12XBA\")), 2);\n    assert_eq!(candidate(String::from(\"Reels\"), String::from(\"Reelsfor\"), String::from(\"ReelsforReels\")), 5);\n    assert_eq!(candidate(String::from(\"abcd1e2\"), String::from(\"bc12ea\"), String::from(\"bd1ea\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n'th star number.\nfn find_star_num(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_star_num;\n    assert_eq!(candidate(3), 37);\n    assert_eq!(candidate(4), 73);\n    assert_eq!(candidate(5), 121);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of an array.\nfn _sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = _sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![15, 12, 13, 10]), 50);\n    assert_eq!(candidate(vec![0, 1, 2]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given list contains consecutive numbers or not.\nfn check_Consecutive(l: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_Consecutive;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 2, 1]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rs",
-    "prompt": "/// Write a function to find the first adverb and their positions in a given sentence.\nfn find_adverb_position(text: String) -> (isize, isize, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_adverb_position;\n    assert_eq!(candidate(String::from(\"clearly!! we can see the sky\")), (0, 7, String::from(\"clearly\")));\n    assert_eq!(candidate(String::from(\"seriously!! there are many roses\")), (0, 9, String::from(\"seriously\")));\n    assert_eq!(candidate(String::from(\"unfortunately!! sita is going to home\")), (0, 13, String::from(\"unfortunately\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rs",
-    "prompt": "/// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfn rotate_right(list: Vec<isize>, m: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rotate_right;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3), vec![8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5), vec![6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of non-empty substrings of a given string.\nfn number_of_substrings(str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = number_of_substrings;\n    assert_eq!(candidate(String::from(\"abc\")), 6);\n    assert_eq!(candidate(String::from(\"abcd\")), 10);\n    assert_eq!(candidate(String::from(\"abcde\")), 15);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rs",
-    "prompt": "/// Write a python function to check if the elements of a given list are unique or not.\nfn all_unique(test_list: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_unique;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rs",
-    "prompt": "/// Write a python function to convert complex numbers to polar coordinates.\nfn convert(numbers: isize) -> (f64, f64) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = convert;\n    assert_eq!(candidate(1), (1.0, 0.0));\n    assert_eq!(candidate(4), (4.0, 0.0));\n    assert_eq!(candidate(5), (5.0, 0.0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rs",
-    "prompt": "/// Write a python function to convert the given string to lower case.\nfn is_lower(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_lower;\n    assert_eq!(candidate(String::from(\"InValid\")), String::from(\"invalid\"));\n    assert_eq!(candidate(String::from(\"TruE\")), String::from(\"true\"));\n    assert_eq!(candidate(String::from(\"SenTenCE\")), String::from(\"sentence\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the smallest power of 2 greater than or equal to n.\nfn next_power_of_2(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = next_power_of_2;\n    assert_eq!(candidate(0), 1);\n    assert_eq!(candidate(5), 8);\n    assert_eq!(candidate(17), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rs",
-    "prompt": "/// Write a function to check if a string is present as a substring in a given list of string values.\nfn find_substring(str1: Vec<String>, sub_str: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_substring;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ack\")), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"abc\")), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ange\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rs",
-    "prompt": "/// Write a function to replace characters in a string.\nfn replace_char(str1: String, ch: String, newch: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_char;\n    assert_eq!(candidate(String::from(\"polygon\"), String::from(\"y\"), String::from(\"l\")), String::from(\"pollgon\"));\n    assert_eq!(candidate(String::from(\"character\"), String::from(\"c\"), String::from(\"a\")), String::from(\"aharaater\"));\n    assert_eq!(candidate(String::from(\"python\"), String::from(\"l\"), String::from(\"a\")), String::from(\"python\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to find the product of first even and odd number of a given list.\nfn mul_even_odd(list1: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = mul_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rs",
-    "prompt": "/// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfn even_binomial_Coeff_Sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_binomial_Coeff_Sum;\n    assert_eq!(candidate(4), 8);\n    assert_eq!(candidate(6), 32);\n    assert_eq!(candidate(2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rs",
-    "prompt": "/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfn bitwise_xor(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = bitwise_xor;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (15, 6, 5, 10));\n    assert_eq!(candidate((11, 5, 7, 10), (6, 3, 4, 4)), (13, 6, 3, 14));\n    assert_eq!(candidate((12, 6, 8, 11), (7, 4, 5, 6)), (11, 2, 13, 13));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether a list is sublist of another or not.\nfn is_Sub_Array(A: Vec<isize>, B: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Sub_Array;\n    assert_eq!(candidate(vec![1, 4, 3, 5], vec![1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 1], vec![1, 2, 1]), true);\n    assert_eq!(candidate(vec![1, 0, 2, 2], vec![2, 2, 0]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rs",
-    "prompt": "/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfn max_sub_array_sum_repeated(a: Vec<isize>, n: isize, k: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum_repeated;\n    assert_eq!(candidate(vec![10, 20, -30, -1], 4, 3), 30);\n    assert_eq!(candidate(vec![-1, 10, 20], 3, 2), 59);\n    assert_eq!(candidate(vec![-1, -2, -3], 3, 3), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to find the minimum product from the pairs of tuples within a given list.\nfn min_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = min_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 8);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 30);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 100);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfn count_divisors(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_divisors;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(100), false);\n    assert_eq!(candidate(125), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfn triangle_area(r: isize) -> Option<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(-1), None);\n    assert_eq!(candidate(0), Some(0));\n    assert_eq!(candidate(2), Some(4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a given string to a list of characters.\nfn string_to_tuple(str1: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_tuple;\n    assert_eq!(candidate(String::from(\"python 3.0\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\"), String::from(\"3\"), String::from(\".\"), String::from(\"0\")]);\n    assert_eq!(candidate(String::from(\"item1\")), vec![String::from(\"i\"), String::from(\"t\"), String::from(\"e\"), String::from(\"m\"), String::from(\"1\")]);\n    assert_eq!(candidate(String::from(\"15.10\")), vec![String::from(\"1\"), String::from(\"5\"), String::from(\".\"), String::from(\"1\"), String::from(\"0\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfn find_length(string: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_length;\n    assert_eq!(candidate(String::from(\"11000010001\")), 6);\n    assert_eq!(candidate(String::from(\"10111\")), 1);\n    assert_eq!(candidate(String::from(\"11011101100101\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rs",
-    "prompt": "/// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfn count_Primes_nums(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Primes_nums;\n    assert_eq!(candidate(5), 2);\n    assert_eq!(candidate(10), 4);\n    assert_eq!(candidate(100), 25);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfn sum_Of_product(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_product;\n    assert_eq!(candidate(3), 15);\n    assert_eq!(candidate(4), 56);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the maximum aggregate from the list of tuples.\nfn max_aggregate(stdata: Vec<(String, isize)>) -> (String, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_aggregate;\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 90), (String::from(\"Sabah Colley\"), 88), (String::from(\"Peter Nichols\"), 7), (String::from(\"Juan Whelan\"), 122), (String::from(\"Sabah Colley\"), 84)]), (String::from(\"Juan Whelan\"), 212));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 50), (String::from(\"Sabah Colley\"), 48), (String::from(\"Peter Nichols\"), 37), (String::from(\"Juan Whelan\"), 22), (String::from(\"Sabah Colley\"), 14)]), (String::from(\"Juan Whelan\"), 72));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 10), (String::from(\"Sabah Colley\"), 20), (String::from(\"Peter Nichols\"), 30), (String::from(\"Juan Whelan\"), 40), (String::from(\"Sabah Colley\"), 50)]), (String::from(\"Sabah Colley\"), 70));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a list of elements.\nfn comb_sort(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = comb_sort;\n    assert_eq!(candidate(vec![5, 15, 37, 25, 79]), vec![5, 15, 25, 37, 79]);\n    assert_eq!(candidate(vec![41, 32, 15, 19, 22]), vec![15, 19, 22, 32, 41]);\n    assert_eq!(candidate(vec![99, 15, 13, 47]), vec![13, 15, 47, 99]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfn check_expression(exp: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_expression;\n    assert_eq!(candidate(String::from(\"{()}[{}]\")), true);\n    assert_eq!(candidate(String::from(\"{()}[{]\")), false);\n    assert_eq!(candidate(String::from(\"{()}[{}][]({})\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a word containing 'z'.\nfn text_match_wordz(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz;\n    assert_eq!(candidate(String::from(\"pythonz.\")), true);\n    assert_eq!(candidate(String::from(\"xyz.\")), true);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rs",
-    "prompt": "/// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfn sum_list(lst1: Vec<isize>, lst2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_list;\n    assert_eq!(candidate(vec![10, 20, 30], vec![15, 25, 35]), vec![25, 45, 65]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![5, 6, 7]), vec![6, 8, 10]);\n    assert_eq!(candidate(vec![15, 20, 30], vec![15, 45, 75]), vec![30, 65, 105]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfn newman_prime(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = newman_prime;\n    assert_eq!(candidate(3), 7);\n    assert_eq!(candidate(4), 17);\n    assert_eq!(candidate(5), 41);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfn surface_Area(b: isize, s: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = surface_Area;\n    assert_eq!(candidate(3, 4), 33);\n    assert_eq!(candidate(4, 5), 56);\n    assert_eq!(candidate(1, 2), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the length of the smallest list in a list of lists.\nfn Find_Min_Length(lst: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Find_Min_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 2]]), 1);\n    assert_eq!(candidate(vec![vec![1, 2], vec![1, 2, 3], vec![1, 2, 3, 4]]), 2);\n    assert_eq!(candidate(vec![vec![3, 3, 3], vec![4, 4, 4, 4]]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rs",
-    "prompt": "/// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfn validate(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = validate;\n    assert_eq!(candidate(1234), true);\n    assert_eq!(candidate(51241), false);\n    assert_eq!(candidate(321), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth hexagonal number.\nfn hexagonal_num(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = hexagonal_num;\n    assert_eq!(candidate(10), 190);\n    assert_eq!(candidate(5), 45);\n    assert_eq!(candidate(7), 91);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n'th lucas number.\nfn find_lucas(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_lucas;\n    assert_eq!(candidate(9), 76);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(3), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rs",
-    "prompt": "/// Write a python function to get the difference between two lists.\nfn Diff(li1: Vec<isize>, li2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Diff;\n    assert_eq!(candidate(vec![10, 15, 20, 25, 30, 35, 40], vec![25, 40, 35]), vec![10, 20, 30, 15]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 1]), vec![2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![6, 7, 1]), vec![2, 3, 6, 7]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the two numbers differ at one bit position only or not.\nfn differ_At_One_Bit_Pos(a: isize, b: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = differ_At_One_Bit_Pos;\n    assert_eq!(candidate(13, 9), true);\n    assert_eq!(candidate(15, 8), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(2, 3), true);\n    assert_eq!(candidate(5, 1), true);\n    assert_eq!(candidate(1, 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an a followed by three 'b'.\nfn text_match_three(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"caacabbbba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfn max_product(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_product;\n    assert_eq!(candidate(vec![3, 100, 4, 5, 150, 6]), 3000);\n    assert_eq!(candidate(vec![4, 42, 55, 68, 80]), 50265600);\n    assert_eq!(candidate(vec![10, 22, 9, 33, 21, 50, 41, 60]), 2460);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rs",
-    "prompt": "/// Write a python function to split a list at the nth eelment and add the first part to the end.\nfn split_Arr(l: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = split_Arr;\n    assert_eq!(candidate(vec![12, 10, 5, 6, 52, 36], 2), vec![5, 6, 52, 36, 12, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], 1), vec![2, 3, 4, 1]);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 4, 5, 6, 7], 3), vec![3, 4, 5, 6, 7, 0, 1, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the number of divisors of a given integer.\nfn divisor(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = divisor;\n    assert_eq!(candidate(15), 4);\n    assert_eq!(candidate(12), 6);\n    assert_eq!(candidate(9), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the difference between largest and smallest value in a given list.\nfn big_diff(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = big_diff;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![4, 5, 12]), 8);\n    assert_eq!(candidate(vec![9, 2, 3]), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rs",
-    "prompt": "/// Write a function to find squares of individual elements in a list.\nfn square_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = square_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![100, 400, 900]);\n    assert_eq!(candidate(vec![12, 15]), vec![144, 225]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given array is monotonic or not.\nfn is_Monotonic(A: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Monotonic;\n    assert_eq!(candidate(vec![6, 5, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 3, 2]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfn is_perfect_square(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_perfect_square;\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(36), true);\n    assert_eq!(candidate(14), false);\n    assert_eq!(candidate(196), true);\n    assert_eq!(candidate(125), false);\n    assert_eq!(candidate(15625), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of common divisors of two given numbers.\nfn sum(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum;\n    assert_eq!(candidate(10, 15), 6);\n    assert_eq!(candidate(100, 150), 93);\n    assert_eq!(candidate(4, 6), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rs",
-    "prompt": "/// Write a function to find the list of maximum length in a list of lists.\nfn max_length(list1: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_length;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1], vec![5, 7], vec![10, 12, 14, 15]]), (4, vec![10, 12, 14, 15]));\n    assert_eq!(candidate(vec![vec![5], vec![15, 20, 25]]), (3, vec![15, 20, 25]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rs",
-    "prompt": "/// Write a function to find the directrix of a parabola.\nfn parabola_directrix(a: isize, b: isize, c: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = parabola_directrix;\n    assert_eq!(candidate(5, 3, 2), -198);\n    assert_eq!(candidate(9, 8, 4), -2336);\n    assert_eq!(candidate(2, 4, 6), -130);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rs",
-    "prompt": "/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfn occurance_substring(text: String, pattern: String) -> Option<(String, isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = occurance_substring;\n    assert_eq!(candidate(String::from(\"python programming, python language\"), String::from(\"python\")), Some((String::from(\"python\"), 0, 6)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"programming\")), Some((String::from(\"programming\"), 7, 18)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"language\")), Some((String::from(\"language\"), 31, 39)));\n    assert_eq!(candidate(String::from(\"c++ programming, c++ language\"), String::from(\"python\")), None);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rs",
-    "prompt": "/// Write a function to sort each sublist of strings in a given list of lists.\nfn sort_sublists(input_list: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\"blue \"), String::from(\" black\")], vec![String::from(\" orange\"), String::from(\"brown\")]]), vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\" black\"), String::from(\"blue \")], vec![String::from(\" orange\"), String::from(\"brown\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"zilver\"), String::from(\"gold\")], vec![String::from(\"magnesium\"), String::from(\"aluminium\")], vec![String::from(\"steel\"), String::from(\"bronze\")]]), vec![vec![String::from(\"gold\"), String::from(\"zilver\")], vec![String::from(\"aluminium\"), String::from(\"magnesium\")], vec![String::from(\"bronze\"), String::from(\"steel\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rs",
-    "prompt": "/// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfn remove_kth_element(list1: Vec<isize>, L: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_kth_element;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 4, 4, 5, 1], 3), vec![1, 1, 3, 4, 4, 5, 1]);\n    assert_eq!(candidate(vec![0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4), vec![0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n    assert_eq!(candidate(vec![10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5), vec![10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfn add_dict_to_tuple(test_tup: (isize, isize, isize), test_dict: HashMap<String, isize>) -> (isize, isize, isize, HashMap<String, isize>) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_dict_to_tuple;\n    assert_eq!(candidate((4, 5, 6), HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])), (4, 5, 6, HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])));\n    assert_eq!(candidate((1, 2, 3), HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])), (1, 2, 3, HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])));\n    assert_eq!(candidate((8, 9, 10), HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])), (8, 9, 10, HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rs",
-    "prompt": "/// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfn find(n: isize, m: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find;\n    assert_eq!(candidate(10, 3), 3);\n    assert_eq!(candidate(4, 2), 2);\n    assert_eq!(candidate(20, 5), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rs",
-    "prompt": "/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfn text_match_two_three(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_two_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rs",
-    "prompt": "/// Write a function to count number items that are identical in the same position of three given lists.\nfn count_samepair(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_samepair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9], vec![2, 1, 3, 1, 2, 6, 7, 9]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 2, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an a followed by one or more b's.\nfn text_match_one(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfn difference(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = difference;\n    assert_eq!(candidate(3), 30);\n    assert_eq!(candidate(5), 210);\n    assert_eq!(candidate(2), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rs",
-    "prompt": "/// Write a function to toggle the case of all characters in a string.\nfn toggle_string(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = toggle_string;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"pYTHON\"));\n    assert_eq!(candidate(String::from(\"Pangram\")), String::from(\"pANGRAM\"));\n    assert_eq!(candidate(String::from(\"LIttLE\")), String::from(\"liTTle\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the Eulerian number a(n, m).\nfn eulerian_num(n: isize, m: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = eulerian_num;\n    assert_eq!(candidate(3, 1), 4);\n    assert_eq!(candidate(4, 1), 11);\n    assert_eq!(candidate(5, 3), 26);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of occurrences of a number in a given list.\nfn frequency(a: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = frequency;\n    assert_eq!(candidate(vec![1, 2, 3], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 3, 4], 3), 3);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 1, 2], 1), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfn sort_numeric_strings(nums_str: Vec<String>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numeric_strings;\n    assert_eq!(candidate(vec![String::from(\"4\"), String::from(\"12\"), String::from(\"45\"), String::from(\"7\"), String::from(\"0\"), String::from(\"100\"), String::from(\"200\"), String::from(\"-12\"), String::from(\"-500\")]), vec![-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n    assert_eq!(candidate(vec![String::from(\"2\"), String::from(\"3\"), String::from(\"8\"), String::from(\"4\"), String::from(\"7\"), String::from(\"9\"), String::from(\"8\"), String::from(\"2\"), String::from(\"6\"), String::from(\"5\"), String::from(\"1\"), String::from(\"6\"), String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"6\"), String::from(\"9\"), String::from(\"1\"), String::from(\"2\")]), vec![1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n    assert_eq!(candidate(vec![String::from(\"1\"), String::from(\"3\"), String::from(\"5\"), String::from(\"7\"), String::from(\"1\"), String::from(\"3\"), String::from(\"13\"), String::from(\"15\"), String::from(\"17\"), String::from(\"5\"), String::from(\"7 \"), String::from(\"9\"), String::from(\"1\"), String::from(\"11\")]), vec![1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfn geometric_sum(n: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = geometric_sum;\n    assert_eq!(candidate(7), 1.9921875);\n    assert_eq!(candidate(4), 1.9375);\n    assert_eq!(candidate(8), 1.99609375);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rs",
-    "prompt": "/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfn divisible_by_digits(startnum: isize, endnum: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = divisible_by_digits;\n    assert_eq!(candidate(1, 22), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n    assert_eq!(candidate(1, 15), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n    assert_eq!(candidate(20, 25), vec![22, 24]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rs",
-    "prompt": "/// Write a python function to calculate the product of the unique numbers in a given list.\nfn unique_product(list_data: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_product;\n    assert_eq!(candidate(vec![10, 20, 30, 40, 20, 50, 60, 40]), 720000000);\n    assert_eq!(candidate(vec![1, 2, 3, 1]), 6);\n    assert_eq!(candidate(vec![7, 8, 9, 0, 1, 1]), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the largest negative number from the given list.\nfn largest_neg(list1: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_neg;\n    assert_eq!(candidate(vec![1, 2, 3, -4, -6]), -6);\n    assert_eq!(candidate(vec![1, 2, 3, -8, -9]), -9);\n    assert_eq!(candidate(vec![1, 2, 3, 4, -1]), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rs",
-    "prompt": "/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfn min_Jumps(steps: (isize, isize), d: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = min_Jumps;\n    assert_eq!(candidate((3, 4), 11), 3.5);\n    assert_eq!(candidate((3, 4), 0), 0.0);\n    assert_eq!(candidate((11, 14), 11), 1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rs",
-    "prompt": "/// Write a python function to find a pair with highest product from a given array of integers.\nfn max_Product(arr: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_Product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 7, 0, 8, 4]), (7, 8));\n    assert_eq!(candidate(vec![0, -1, -2, -4, 5, 0, -6]), (-4, -6));\n    assert_eq!(candidate(vec![1, 2, 3]), (2, 3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth nonagonal number.\nfn is_nonagonal(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nonagonal;\n    assert_eq!(candidate(10), 325);\n    assert_eq!(candidate(15), 750);\n    assert_eq!(candidate(18), 1089);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the maximum difference between any two elements in a given array.\nfn max_Abs_Diff(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_Abs_Diff;\n    assert_eq!(candidate(vec![2, 1, 5, 3]), 4);\n    assert_eq!(candidate(vec![9, 3, 2, 5, 1]), 8);\n    assert_eq!(candidate(vec![3, 2, 1]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the sum of perrin numbers.\nfn cal_sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = cal_sum;\n    assert_eq!(candidate(9), 49);\n    assert_eq!(candidate(10), 66);\n    assert_eq!(candidate(11), 88);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rs",
-    "prompt": "/// Write a python function to remove the characters which have odd index values of a given string.\nfn odd_values_string(str: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_values_string;\n    assert_eq!(candidate(String::from(\"abcdef\")), String::from(\"ace\"));\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"pto\"));\n    assert_eq!(candidate(String::from(\"data\")), String::from(\"dt\"));\n    assert_eq!(candidate(String::from(\"lambs\")), String::from(\"lms\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rs",
-    "prompt": "/// Write a function to find kth element from the given two sorted arrays.\nfn find_kth(arr1: Vec<isize>, arr2: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_kth;\n    assert_eq!(candidate(vec![2, 3, 6, 7, 9], vec![1, 4, 8, 10], 5), 6);\n    assert_eq!(candidate(vec![100, 112, 256, 349, 770], vec![72, 86, 113, 119, 265, 445, 892], 7), 256);\n    assert_eq!(candidate(vec![3, 4, 7, 8, 10], vec![2, 5, 9, 11], 6), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfn jacobsthal_num(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = jacobsthal_num;\n    assert_eq!(candidate(5), 11);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 5);\n    assert_eq!(candidate(13), 2731);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfn frequency_lists(list1: Vec<Vec<isize>>) -> HashMap<isize, isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = frequency_lists;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 2], vec![4, 5, 6, 2], vec![7, 8, 9, 5]]), HashMap::from([(1, 1), (2, 3), (3, 1), (4, 1), (5, 2), (6, 1), (7, 1), (8, 1), (9, 1)]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]]), HashMap::from([(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1), (12, 1)]));\n    assert_eq!(candidate(vec![vec![20, 30, 40, 17], vec![18, 16, 14, 13], vec![10, 20, 30, 40]]), HashMap::from([(20, 2), (30, 2), (40, 2), (17, 1), (18, 1), (16, 1), (14, 1), (13, 1), (10, 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rs",
-    "prompt": "/// Write a function to find perfect squares between two given numbers.\nfn perfect_squares(a: isize, b: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = perfect_squares;\n    assert_eq!(candidate(1, 30), vec![1, 4, 9, 16, 25]);\n    assert_eq!(candidate(50, 100), vec![64, 81, 100]);\n    assert_eq!(candidate(100, 200), vec![100, 121, 144, 169, 196]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rs",
-    "prompt": "/// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfn sum_Of_Subarray_Prod(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_Subarray_Prod;\n    assert_eq!(candidate(vec![1, 2, 3]), 20);\n    assert_eq!(candidate(vec![1, 2]), 5);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the first odd number in a given list of numbers.\nfn first_odd(nums: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = first_odd;\n    assert_eq!(candidate(vec![1, 3, 5]), 1);\n    assert_eq!(candidate(vec![2, 4, 1, 3]), 1);\n    assert_eq!(candidate(vec![8, 9, 1]), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to perform index wise addition of list elements in the given two nested lists.\nfn add_nested_tuples(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_nested_tuples;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![7, 10], vec![7, 14], vec![3, 10], vec![8, 13]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![9, 12], vec![9, 16], vec![5, 12], vec![10, 15]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![11, 14], vec![11, 18], vec![7, 14], vec![12, 17]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfn dif_Square(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = dif_Square;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(15), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rs",
-    "prompt": "/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfn check_smaller(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_smaller;\n    assert_eq!(candidate((1, 2, 3), (2, 3, 4)), false);\n    assert_eq!(candidate((4, 5, 6), (3, 4, 5)), true);\n    assert_eq!(candidate((11, 12, 13), (10, 11, 12)), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfn freq_count(list1: Vec<isize>) -> HashMap<isize, isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = freq_count;\n    assert_eq!(candidate(vec![10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]), HashMap::from([(10, 4), (20, 4), (40, 2), (50, 2), (30, 1)]));\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]), HashMap::from([(1, 3), (2, 2), (3, 3), (4, 3)]));\n    assert_eq!(candidate(vec![5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]), HashMap::from([(10, 1), (5, 3), (6, 2), (7, 2), (4, 2), (9, 2)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rs",
-    "prompt": "/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfn rgb_to_hsv(r: isize, g: isize, b: isize) -> Vec<f64> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rgb_to_hsv;\n    assert_eq!(candidate(255, 255, 255), vec![0.0, 0.0, 100.0]);\n    assert_eq!(candidate(0, 215, 0), vec![120.0, 100.0, 84.31372549019608]);\n    assert_eq!(candidate(10, 215, 110), vec![149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfn check_str(string: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_str;\n    assert_eq!(candidate(String::from(\"annie\")), true);\n    assert_eq!(candidate(String::from(\"dawood\")), false);\n    assert_eq!(candidate(String::from(\"Else\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfn check_monthnumber_number(monthnum3: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumber_number;\n    assert_eq!(candidate(6), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(12), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rs",
-    "prompt": "/// Write a function to sort the given list.\nfn heap_sort(iterable: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = heap_sort;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 9, 2, 4, 6, 8, 0]), vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 25, 58]), vec![14, 22, 25, 25, 35, 58, 65, 75, 85]);\n    assert_eq!(candidate(vec![7, 1, 9, 5]), vec![1, 5, 7, 9]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rs",
-    "prompt": "/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfn k_smallest_pairs(nums1: Vec<isize>, nums2: Vec<isize>, k: isize) -> Vec<Vec<isize>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = k_smallest_pairs;\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 2), vec![vec![1, 2], vec![1, 4]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 1), vec![vec![1, 2]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 7), vec![vec![1, 2], vec![1, 4], vec![3, 2], vec![1, 6], vec![3, 4], vec![3, 6], vec![7, 2]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rs",
-    "prompt": "/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfn find_solution(a: isize, b: isize, n: isize) -> Option<(isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_solution;\n    assert_eq!(candidate(2, 3, 7), Some((2, 1)));\n    assert_eq!(candidate(4, 2, 7), None);\n    assert_eq!(candidate(1, 13, 17), Some((4, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the largest number that can be formed with the given list of digits.\nfn find_Max_Num(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Max_Num;\n    assert_eq!(candidate(vec![1, 2, 3]), 321);\n    assert_eq!(candidate(vec![4, 5, 6, 1]), 6541);\n    assert_eq!(candidate(vec![1, 2, 3, 9]), 9321);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rs",
-    "prompt": "/// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfn max_sum_list(lists: Vec<Vec<isize>>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum_list;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![10, 11, 12], vec![7, 8, 9]]), vec![10, 11, 12]);\n    assert_eq!(candidate(vec![vec![3, 2, 1], vec![6, 5, 4], vec![12, 11, 10]]), vec![12, 11, 10]);\n    assert_eq!(candidate(vec![vec![2, 3, 1]]), vec![2, 3, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rs",
-    "prompt": "/// Write a python function to interchange the first and last elements in a list.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![12, 35, 9, 56, 24]), vec![24, 35, 9, 56, 12]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rs",
-    "prompt": "/// Write a function to find the median of two sorted lists of same size.\nfn get_median(arr1: Vec<isize>, arr2: Vec<isize>, n: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_median;\n    assert_eq!(candidate(vec![1, 12, 15, 26, 38], vec![2, 13, 17, 30, 45], 5), 16.0);\n    assert_eq!(candidate(vec![2, 4, 8, 9], vec![7, 13, 19, 28], 4), 8.5);\n    assert_eq!(candidate(vec![3, 6, 14, 23, 36, 42], vec![2, 18, 27, 39, 49, 55], 6), 25.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfn replace_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"Jumanji The Jungle\")), String::from(\"Jumanji_The_Jungle\"));\n    assert_eq!(candidate(String::from(\"The_Avengers\")), String::from(\"The Avengers\"));\n    assert_eq!(candidate(String::from(\"Fast and Furious\")), String::from(\"Fast_and_Furious\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rs",
-    "prompt": "/// Write a function to determine if the sum of the divisors of two integers are the same.\nfn are_equivalent(num1: isize, num2: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = are_equivalent;\n    assert_eq!(candidate(36, 57), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(23, 47), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rs",
-    "prompt": "/// Write a function to reverse each string in a given list of string values.\nfn reverse_string_list(stringlist: Vec<String>) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_string_list;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\"), String::from(\"White\"), String::from(\"Black\")]), vec![String::from(\"deR\"), String::from(\"neerG\"), String::from(\"eulB\"), String::from(\"etihW\"), String::from(\"kcalB\")]);\n    assert_eq!(candidate(vec![String::from(\"john\"), String::from(\"amal\"), String::from(\"joel\"), String::from(\"george\")]), vec![String::from(\"nhoj\"), String::from(\"lama\"), String::from(\"leoj\"), String::from(\"egroeg\")]);\n    assert_eq!(candidate(vec![String::from(\"jack\"), String::from(\"john\"), String::from(\"mary\")]), vec![String::from(\"kcaj\"), String::from(\"nhoj\"), String::from(\"yram\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth number in the newman conway sequence.\nfn sequence(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sequence;\n    assert_eq!(candidate(10), 6);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(3), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfn heap_queue_largest(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = heap_queue_largest;\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 3), vec![85, 75, 65]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 2), vec![85, 75]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 5), vec![85, 75, 65, 58, 35]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rs",
-    "prompt": "/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfn loss_amount(actual_cost: isize, sale_amount: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = loss_amount;\n    assert_eq!(candidate(1500, 1200), 0);\n    assert_eq!(candidate(100, 200), 100);\n    assert_eq!(candidate(2000, 5000), 3000);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rs",
-    "prompt": "/// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfn union_elements(test_tup1: Vec<isize>, test_tup2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = union_elements;\n    assert_eq!(candidate(vec![3, 4, 5, 6], vec![5, 7, 4, 10]), vec![3, 4, 5, 6, 7, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![3, 4, 5, 6]), vec![1, 2, 3, 4, 5, 6]);\n    assert_eq!(candidate(vec![11, 12, 13, 14], vec![13, 15, 16, 17]), vec![11, 12, 13, 14, 15, 16, 17]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the length of the longest sublists.\nfn Find_Max_Length(lst: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Find_Max_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 4], vec![5, 6, 7, 8]]), 4);\n    assert_eq!(candidate(vec![vec![0, 1], vec![2, 2], vec![3, 2, 1]]), 3);\n    assert_eq!(candidate(vec![vec![7], vec![22, 23], vec![13, 14, 15], vec![10, 20, 30, 40, 50]]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rs",
-    "prompt": "/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfn remove_parenthesis(items: Vec<String>) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_parenthesis;\n    assert_eq!(candidate(vec![String::from(\"python (chrome)\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"string(.abc)\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"alpha(num)\")]), String::from(\"alpha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rs",
-    "prompt": "/// Write a python function to find whether the parity of a given number is odd.\nfn find_Parity(x: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Parity;\n    assert_eq!(candidate(12), false);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(10), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rs",
-    "prompt": "/// Write a function to find the median length of a trapezium.\nfn median_trapezium(base1: isize, base2: isize, height: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = median_trapezium;\n    assert_eq!(candidate(15, 25, 35), 20.0);\n    assert_eq!(candidate(10, 20, 30), 15.0);\n    assert_eq!(candidate(6, 9, 4), 7.5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find nth centered hexagonal number.\nfn centered_hexagonal_number(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = centered_hexagonal_number;\n    assert_eq!(candidate(10), 271);\n    assert_eq!(candidate(2), 7);\n    assert_eq!(candidate(9), 217);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfn get_max_sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_sum;\n    assert_eq!(candidate(60), 106);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the length of the longest word.\nfn len_log(list1: Vec<String>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = len_log;\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"PHP\"), String::from(\"bigdata\")]), 7);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]), 3);\n    assert_eq!(candidate(vec![String::from(\"small\"), String::from(\"big\"), String::from(\"tall\")]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rs",
-    "prompt": "/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfn sector_area(r: isize, a: isize) -> Option<f64> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sector_area;\n    assert_eq!(candidate(4, 45), Some(6.283185307179586));\n    assert_eq!(candidate(9, 45), Some(31.808625617596654));\n    assert_eq!(candidate(9, 361), None);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether every odd index contains odd numbers of a given list.\nfn odd_position(nums: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_position;\n    assert_eq!(candidate(vec![2, 1, 4, 3, 6, 7, 6, 3]), true);\n    assert_eq!(candidate(vec![4, 1, 2]), true);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rs",
-    "prompt": "/// Write a function to join a list of multiple integers into a single integer.\nfn multiple_to_single(L: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = multiple_to_single;\n    assert_eq!(candidate(vec![11, 33, 50]), 113350);\n    assert_eq!(candidate(vec![-1, 2, 3, 4, 5, 6]), -123456);\n    assert_eq!(candidate(vec![10, 15, 20, 25]), 10152025);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rs",
-    "prompt": "/// Write a python function to find whether a number is divisible by 11.\nfn is_Diff(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Diff;\n    assert_eq!(candidate(12345), false);\n    assert_eq!(candidate(1212112), true);\n    assert_eq!(candidate(1212), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rs",
-    "prompt": "/// Write a function to perform index wise multiplication of list elements in the given two lists.\nfn index_multiplication(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = index_multiplication;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 21], vec![12, 45], vec![2, 9], vec![7, 30]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![14, 32], vec![20, 60], vec![6, 20], vec![16, 44]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![24, 45], vec![30, 77], vec![12, 33], vec![27, 60]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rs",
-    "prompt": "/// Write a function to convert tuple string to integer tuple.\nfn tuple_str_int(test_str: String) -> (isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_str_int;\n    assert_eq!(candidate(String::from(\"(7, 8, 9)\")), (7, 8, 9));\n    assert_eq!(candidate(String::from(\"(1, 2, 3)\")), (1, 2, 3));\n    assert_eq!(candidate(String::from(\"(4, 5, 6)\")), (4, 5, 6));\n    assert_eq!(candidate(String::from(\"(7, 81, 19)\")), (7, 81, 19));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to sum all amicable numbers from 1 to a specified number.\nfn amicable_numbers_sum(limit: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = amicable_numbers_sum;\n    assert_eq!(candidate(999), 504);\n    assert_eq!(candidate(9999), 31626);\n    assert_eq!(candidate(99), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to remove odd characters in a string.\nfn remove_odd(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"yhn\"));\n    assert_eq!(candidate(String::from(\"program\")), String::from(\"rga\"));\n    assert_eq!(candidate(String::from(\"language\")), String::from(\"agae\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfn count_rotation(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_rotation;\n    assert_eq!(candidate(vec![3, 2, 1]), 1);\n    assert_eq!(candidate(vec![4, 5, 1, 2, 3]), 2);\n    assert_eq!(candidate(vec![7, 8, 9, 1, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 2, 3]), 0);\n    assert_eq!(candidate(vec![1, 3, 2]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rs",
-    "prompt": "/// Write a function to extract the number of unique tuples in the given list.\nfn extract_freq(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_freq;\n    assert_eq!(candidate(vec![(3, 4), (1, 2), (4, 3), (5, 6)]), 3);\n    assert_eq!(candidate(vec![(4, 15), (2, 3), (5, 4), (6, 7)]), 4);\n    assert_eq!(candidate(vec![(5, 16), (2, 3), (6, 5), (6, 9)]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rs",
-    "prompt": "/// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfn count_same_pair(nums1: Vec<isize>, nums2: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_same_pair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 11);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 1);\n    assert_eq!(candidate(vec![0, 1, 1, 2], vec![0, 1, 2, 2]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the value of 'a' to the power 'b'.\nfn power(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = power;\n    assert_eq!(candidate(3, 4), 81);\n    assert_eq!(candidate(2, 3), 8);\n    assert_eq!(candidate(5, 5), 3125);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write function to find the sum of all items in the given dictionary.\nfn return_sum(dict: HashMap<String, isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = return_sum;\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 100), (String::from(\"b\"), 200), (String::from(\"c\"), 300)])), 600);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 25), (String::from(\"b\"), 18), (String::from(\"c\"), 45)])), 88);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 36), (String::from(\"b\"), 39), (String::from(\"c\"), 49)])), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rs",
-    "prompt": "/// Write a function to return a list of all pairs of consecutive items in a given list.\nfn pair_wise(l1: Vec<isize>) -> Vec<(isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pair_wise;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 3, 4, 4, 5]), vec![(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), vec![(1, 5), (5, 7), (7, 9), (9, 10)]);\n    assert_eq!(candidate(vec![5, 1, 9, 7, 10]), vec![(5, 1), (1, 9), (9, 7), (7, 10)]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rs",
-    "prompt": "/// Write a python function to split a string into characters.\nfn split(word: String) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = split;\n    assert_eq!(candidate(String::from(\"python\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]);\n    assert_eq!(candidate(String::from(\"Name\")), vec![String::from(\"N\"), String::from(\"a\"), String::from(\"m\"), String::from(\"e\")]);\n    assert_eq!(candidate(String::from(\"program\")), vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rs",
-    "prompt": "/// Write a function to find minimum of three numbers.\nfn min_of_three(a: isize, b: isize, c: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = min_of_three;\n    assert_eq!(candidate(10, 20, 0), 0);\n    assert_eq!(candidate(19, 15, 18), 15);\n    assert_eq!(candidate(-10, -20, -30), -30);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfn is_Sum_Of_Powers_Of_Two(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Sum_Of_Powers_Of_Two;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(7), false);\n    assert_eq!(candidate(14), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfn get_Char(strr: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_Char;\n    assert_eq!(candidate(String::from(\"abc\")), String::from(\"f\"));\n    assert_eq!(candidate(String::from(\"gfg\")), String::from(\"t\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"c\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rs",
-    "prompt": "/// Write a function to return the sum of all divisors of a number.\nfn sum_div(number: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_div;\n    assert_eq!(candidate(8), 7);\n    assert_eq!(candidate(12), 16);\n    assert_eq!(candidate(7), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rs",
-    "prompt": "/// Write a python function to remove duplicate numbers from a given number of lists.\nfn two_unique_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = two_unique_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 2, 3, 4, 5]), vec![1, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 5]), vec![1, 3, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rs",
-    "prompt": "/// Write a function to find whether a given array of integers contains any duplicate element.\nfn test_duplicate(arraynums: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = test_duplicate;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3, 3, 4, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rs",
-    "prompt": "/// Write a function which returns nth catalan number.\nfn catalan_number(num: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = catalan_number;\n    assert_eq!(candidate(10), 16796);\n    assert_eq!(candidate(9), 4862);\n    assert_eq!(candidate(7), 429);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rs",
-    "prompt": "/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfn power_base_sum(base: isize, power: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = power_base_sum;\n    assert_eq!(candidate(2, 100), 115);\n    assert_eq!(candidate(8, 10), 37);\n    assert_eq!(candidate(8, 15), 62);\n    assert_eq!(candidate(3, 3), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth octagonal number.\nfn is_octagonal(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_octagonal;\n    assert_eq!(candidate(5), 65);\n    assert_eq!(candidate(10), 280);\n    assert_eq!(candidate(15), 645);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfn replace_blank(str1: String, char: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_blank;\n    assert_eq!(candidate(String::from(\"hello people\"), String::from(\"@\")), String::from(\"hello@people\"));\n    assert_eq!(candidate(String::from(\"python program language\"), String::from(\"$\")), String::from(\"python$program$language\"));\n    assert_eq!(candidate(String::from(\"blank space\"), String::from(\"-\")), String::from(\"blank-space\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rs",
-    "prompt": "/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfn replace_specialchar(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_specialchar;\n    assert_eq!(candidate(String::from(\"Python language, Programming language.\")), String::from(\"Python:language::Programming:language:\"));\n    assert_eq!(candidate(String::from(\"a b c,d e f\")), String::from(\"a:b:c:d:e:f\"));\n    assert_eq!(candidate(String::from(\"ram reshma,ram rahim\")), String::from(\"ram:reshma:ram:rahim\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a given tuple of positive integers into a single integer.\nfn tuple_to_int(nums: (isize, isize, isize)) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_int;\n    assert_eq!(candidate((1, 2, 3)), 123);\n    assert_eq!(candidate((4, 5, 6)), 456);\n    assert_eq!(candidate((5, 6, 7)), 567);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rs",
-    "prompt": "/// Write a function to find the third side of a right angled triangle.\nfn otherside_rightangle(w: isize, h: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = otherside_rightangle;\n    assert_eq!(candidate(7, 8), 10.63014581273465);\n    assert_eq!(candidate(3, 4), 5.0);\n    assert_eq!(candidate(7, 15), 16.55294535724685);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the sum of the per-digit difference between two integers.\nfn digit_distance_nums(n1: isize, n2: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = digit_distance_nums;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(23, 56), 6);\n    assert_eq!(candidate(123, 256), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rs",
-    "prompt": "/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfn text_match_wordz_middle(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz_middle;\n    assert_eq!(candidate(String::from(\"pythonzabc.\")), true);\n    assert_eq!(candidate(String::from(\"zxyabc.\")), false);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rs",
-    "prompt": "/// Write a function to remove leading zeroes from an ip address.\nfn removezero_ip(ip: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = removezero_ip;\n    assert_eq!(candidate(String::from(\"216.08.094.196\")), String::from(\"216.8.94.196\"));\n    assert_eq!(candidate(String::from(\"12.01.024\")), String::from(\"12.1.24\"));\n    assert_eq!(candidate(String::from(\"216.08.094.0196\")), String::from(\"216.8.94.196\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rs",
-    "prompt": "/// Write a function to multiply two integers.\nfn multiply_int(x: isize, y: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply_int;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(5, 10), 50);\n    assert_eq!(candidate(4, 8), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rs",
-    "prompt": "/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfn add_pairwise(test_tup: (isize, isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_pairwise;\n    assert_eq!(candidate((1, 5, 7, 8, 10)), (6, 12, 15, 18));\n    assert_eq!(candidate((2, 6, 8, 9, 11)), (8, 14, 17, 20));\n    assert_eq!(candidate((3, 7, 9, 10, 12)), (10, 16, 19, 22));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfn max_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 36);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 200);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 484);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3160,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find the kth element in the given array using 1-based indexing.\nfn kth_element(arr: Vec<isize>, k: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = kth_element;\n    assert_eq!(candidate(vec![12, 3, 5, 7, 19], 2), 3);\n    assert_eq!(candidate(vec![17, 24, 8, 23], 3), 8);\n    assert_eq!(candidate(vec![16, 21, 25, 36, 4], 4), 36);\n}\n",
     "stop_tokens": [
@@ -3168,241 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rs",
-    "prompt": "/// Write a python function to interchange the first and last element in a given list.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a function to convert a snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), vec![4, 2, 3, 4, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"python_program\")), String::from(\"PythonProgram\"));\n    assert_eq!(candidate(String::from(\"python_language\")), String::from(\"PythonLanguage\"));\n    assert_eq!(candidate(String::from(\"programming_language\")), String::from(\"ProgrammingLanguage\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "rs",
-    "prompt": "/// Write a function to locate the right insertion point for a specified value in sorted order.\nfn right_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "prompt": "/// Write a function to find the Eulerian number a(n, m).\nfn eulerian_num(n: isize, m: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = right_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = eulerian_num;\n    assert_eq!(candidate(3, 1), 4);\n    assert_eq!(candidate(4, 1), 11);\n    assert_eq!(candidate(5, 3), 26);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "rs",
-    "prompt": "/// Write a function to check if the given number is woodball or not.\nfn is_woodall(x: isize) -> bool {\n",
+    "prompt": "/// Write a function to sort each sublist of strings in a given list of lists.\nfn sort_sublists(input_list: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_woodall;\n    assert_eq!(candidate(383), true);\n    assert_eq!(candidate(254), false);\n    assert_eq!(candidate(200), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\"blue \"), String::from(\" black\")], vec![String::from(\" orange\"), String::from(\"brown\")]]), vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\" black\"), String::from(\"blue \")], vec![String::from(\" orange\"), String::from(\"brown\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"zilver\"), String::from(\"gold\")], vec![String::from(\"magnesium\"), String::from(\"aluminium\")], vec![String::from(\"steel\"), String::from(\"bronze\")]]), vec![vec![String::from(\"gold\"), String::from(\"zilver\")], vec![String::from(\"aluminium\"), String::from(\"magnesium\")], vec![String::from(\"bronze\"), String::from(\"steel\")]]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "rs",
-    "prompt": "/// Write a function to sort the given array by using shell sort.\nfn shell_sort(my_list: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a python function to count true booleans in the given list.\nfn count(lst: Vec<bool>) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = shell_sort;\n    assert_eq!(candidate(vec![12, 23, 4, 5, 3, 2, 12, 81, 56, 95]), vec![2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n    assert_eq!(candidate(vec![24, 22, 39, 34, 87, 73, 68]), vec![22, 24, 34, 39, 68, 73, 87]);\n    assert_eq!(candidate(vec![32, 30, 16, 96, 82, 83, 74]), vec![16, 30, 32, 74, 82, 83, 96]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count;\n    assert_eq!(candidate(vec![true, false, true]), 2);\n    assert_eq!(candidate(vec![false, false]), 0);\n    assert_eq!(candidate(vec![true, true, true]), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "rs",
-    "prompt": "/// Write a python function to count the number of pairs whose xor value is odd.\nfn find_Odd_Pair(A: Vec<isize>, N: isize) -> isize {\n",
+    "prompt": "/// Write a function to append the given list to the given tuples.\nfn add_lists(test_list: Vec<isize>, test_tup: (isize, isize)) -> (isize, isize, isize, isize, isize) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Odd_Pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1], 5), 6);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11], 7), 12);\n    assert_eq!(candidate(vec![1, 2, 3], 3), 2);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = add_lists;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), (9, 10, 5, 6, 7));\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), (10, 11, 6, 7, 8));\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), (11, 12, 7, 8, 9));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rs",
-    "prompt": "/// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfn sum_in_range(l: isize, r: isize) -> isize {\n",
+    "prompt": "/// Write a function to merge three lists into a single sorted list.\nfn merge_sorted_list(num1: Vec<isize>, num2: Vec<isize>, num3: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_in_range;\n    assert_eq!(candidate(2, 5), 8);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 13), 40);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = merge_sorted_list;\n    assert_eq!(candidate(vec![25, 24, 15, 4, 5, 29, 110], vec![19, 20, 11, 56, 25, 233, 154], vec![24, 26, 54, 48]), vec![4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n    assert_eq!(candidate(vec![1, 3, 5, 6, 8, 9], vec![2, 5, 7, 11], vec![1, 4, 7, 8, 12]), vec![1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n    assert_eq!(candidate(vec![18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], vec![25, 35, 22, 85, 14, 65, 75, 25, 58], vec![12, 74, 9, 50, 61, 41]), vec![1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rs",
-    "prompt": "/// Write a function that returns the perimeter of a square given its side length as input.\nfn square_perimeter(a: isize) -> isize {\n",
+    "prompt": "/// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfn odd_Equivalent(s: String, n: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = square_perimeter;\n    assert_eq!(candidate(10), 40);\n    assert_eq!(candidate(5), 20);\n    assert_eq!(candidate(4), 16);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_Equivalent;\n    assert_eq!(candidate(String::from(\"011001\"), 6), 3);\n    assert_eq!(candidate(String::from(\"11011\"), 5), 4);\n    assert_eq!(candidate(String::from(\"1010\"), 4), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "rs",
-    "prompt": "/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfn is_polite(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to check if a string represents an integer or not.\nfn check_integer(text: String) -> bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_polite;\n    assert_eq!(candidate(7), 11);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(9), 13);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = check_integer;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"1\")), true);\n    assert_eq!(candidate(String::from(\"12345\")), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rs",
-    "prompt": "/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfn sum_series(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to convert a given tuple of positive integers into a single integer.\nfn tuple_to_int(nums: (isize, isize, isize)) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_series;\n    assert_eq!(candidate(6), 12);\n    assert_eq!(candidate(10), 30);\n    assert_eq!(candidate(9), 25);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rs",
-    "prompt": "/// Write a function to find the dissimilar elements in the given two tuples.\nfn find_dissimilar(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_dissimilar;\n    assert_eq!(candidate((3, 4, 5, 6), (5, 7, 4, 10)), (3, 6, 7, 10));\n    assert_eq!(candidate((1, 2, 3, 4), (7, 2, 3, 9)), (1, 4, 7, 9));\n    assert_eq!(candidate((21, 11, 25, 26), (26, 34, 21, 36)), (34, 36, 11, 25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rs",
-    "prompt": "/// Write a function to return two words from a list of words starting with letter 'p'.\nfn start_withp(words: Vec<String>) -> (String, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = start_withp;\n    assert_eq!(candidate(vec![String::from(\"Python PHP\"), String::from(\"Java JavaScript\"), String::from(\"c c++\")]), (String::from(\"Python\"), String::from(\"PHP\")));\n    assert_eq!(candidate(vec![String::from(\"Python Programming\"), String::from(\"Java Programming\")]), (String::from(\"Python\"), String::from(\"Programming\")));\n    assert_eq!(candidate(vec![String::from(\"Pqrst Pqr\"), String::from(\"qrstuv\")]), (String::from(\"Pqrst\"), String::from(\"Pqr\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rs",
-    "prompt": "/// Write a function to convert the given snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"android_tv\")), String::from(\"AndroidTv\"));\n    assert_eq!(candidate(String::from(\"google_pixel\")), String::from(\"GooglePixel\"));\n    assert_eq!(candidate(String::from(\"apple_watch\")), String::from(\"AppleWatch\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rs",
-    "prompt": "/// Write a function to find the volume of a cube given its side length.\nfn volume_cube(l: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = volume_cube;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(2), 8);\n    assert_eq!(candidate(5), 125);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given month number contains 31 days or not.\nfn check_monthnumb_number(monthnum2: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumb_number;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(6), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rs",
-    "prompt": "/// Write a python function to check whether all the bits are unset in the given range or not.\nfn all_Bits_Set_In_The_Given_Range(n: isize, l: isize, r: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = all_Bits_Set_In_The_Given_Range;\n    assert_eq!(candidate(4, 1, 2), true);\n    assert_eq!(candidate(17, 2, 4), true);\n    assert_eq!(candidate(39, 4, 6), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rs",
-    "prompt": "/// Write a python function to get the first element of each sublist.\nfn Extract(lst: Vec<Vec<isize>>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = Extract;\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4, 5], vec![6, 7, 8, 9]]), vec![1, 3, 6]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5]]), vec![1, 4]);\n    assert_eq!(candidate(vec![vec![9, 8, 1], vec![1, 2]]), vec![9, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rs",
-    "prompt": "/// Write a function to find the surface area of a cylinder.\nfn surfacearea_cylinder(r: isize, h: isize) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cylinder;\n    assert_eq!(candidate(10, 5), 942.45);\n    assert_eq!(candidate(4, 5), 226.18800000000002);\n    assert_eq!(candidate(4, 10), 351.848);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rs",
-    "prompt": "/// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfn sample_nam(sample_names: Vec<String>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sample_nam;\n    assert_eq!(candidate(vec![String::from(\"sally\"), String::from(\"Dylan\"), String::from(\"rebecca\"), String::from(\"Diana\"), String::from(\"Joanne\"), String::from(\"keith\")]), 16);\n    assert_eq!(candidate(vec![String::from(\"php\"), String::from(\"res\"), String::from(\"Python\"), String::from(\"abcd\"), String::from(\"Java\"), String::from(\"aaa\")]), 10);\n    assert_eq!(candidate(vec![String::from(\"abcd\"), String::from(\"Python\"), String::from(\"abba\"), String::from(\"aba\")]), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rs",
-    "prompt": "/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfn perimeter_pentagon(a: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = perimeter_pentagon;\n    assert_eq!(candidate(5), 25);\n    assert_eq!(candidate(10), 50);\n    assert_eq!(candidate(15), 75);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rs",
-    "prompt": "/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfn max_sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum;\n    assert_eq!(candidate(vec![1, 15, 51, 45, 33, 100, 12, 18, 9]), 194);\n    assert_eq!(candidate(vec![80, 60, 30, 40, 20, 10]), 210);\n    assert_eq!(candidate(vec![2, 3, 14, 16, 21, 23, 29, 30]), 138);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_int;\n    assert_eq!(candidate((1, 2, 3)), 123);\n    assert_eq!(candidate((4, 5, 6)), 456);\n    assert_eq!(candidate((5, 6, 7)), 567);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3412,177 +136,9 @@
     "language": "rs",
     "prompt": "/// Write a function to convert all possible convertible elements in a list of lists to floats.\nfn list_to_float(test_list: Vec<(String, String)>) -> Vec<(f64, f64)> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = list_to_float;\n    assert_eq!(candidate(vec![(String::from(\"3\"), String::from(\"4\")), (String::from(\"1\"), String::from(\"26.45\")), (String::from(\"7.32\"), String::from(\"8\")), (String::from(\"4\"), String::from(\"8\"))]), vec![(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]);\n    assert_eq!(candidate(vec![(String::from(\"4\"), String::from(\"4\")), (String::from(\"2\"), String::from(\"27\")), (String::from(\"4.12\"), String::from(\"9\")), (String::from(\"7\"), String::from(\"11\"))]), vec![(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)]);\n    assert_eq!(candidate(vec![(String::from(\"6\"), String::from(\"78\")), (String::from(\"5\"), String::from(\"26.45\")), (String::from(\"1.33\"), String::from(\"4\")), (String::from(\"82\"), String::from(\"13\"))]), vec![(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rs",
-    "prompt": "/// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 20);\n    assert_eq!(candidate(3), 56);\n    assert_eq!(candidate(4), 120);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfn get_pairs_count(arr: Vec<isize>, sum: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_pairs_count;\n    assert_eq!(candidate(vec![1, 1, 1, 1], 2), 6);\n    assert_eq!(candidate(vec![1, 5, 7, -1, 5], 6), 3);\n    assert_eq!(candidate(vec![1, -2, 3], 1), 1);\n    assert_eq!(candidate(vec![-1, -2, 3], -3), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rs",
-    "prompt": "/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfn count_no_of_ways(n: isize, k: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_no_of_ways;\n    assert_eq!(candidate(2, 4), 16);\n    assert_eq!(candidate(3, 2), 6);\n    assert_eq!(candidate(4, 4), 228);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rs",
-    "prompt": "/// Write a function to reverse words seperated by spaces in a given string.\nfn reverse_words(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_words;\n    assert_eq!(candidate(String::from(\"python program\")), String::from(\"program python\"));\n    assert_eq!(candidate(String::from(\"java language\")), String::from(\"language java\"));\n    assert_eq!(candidate(String::from(\"indian man\")), String::from(\"man indian\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rs",
-    "prompt": "/// Write a python function to check if a given number is one less than twice its reverse.\nfn checks(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = checks;\n    assert_eq!(candidate(70), false);\n    assert_eq!(candidate(23), false);\n    assert_eq!(candidate(73), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the last position of an element in a sorted array.\nfn last(arr: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = last;\n    assert_eq!(candidate(vec![1, 2, 3], 1), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, 4], 1), 2);\n    assert_eq!(candidate(vec![2, 3, 2, 3, 6, 8, 9], 3), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rs",
-    "prompt": "/// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfn count_X(tup: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_X;\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4), 0);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10), 3);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to concatenate each element of tuple by the delimiter.\nfn concatenate_tuple(test_tup: (String, String, isize, String)) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate_tuple;\n    assert_eq!(candidate((String::from(\"ID\"), String::from(\"is\"), 4, String::from(\"UTS\"))), String::from(\"ID-is-4-UTS\"));\n    assert_eq!(candidate((String::from(\"QWE\"), String::from(\"is\"), 4, String::from(\"RTY\"))), String::from(\"QWE-is-4-RTY\"));\n    assert_eq!(candidate((String::from(\"ZEN\"), String::from(\"is\"), 4, String::from(\"OP\"))), String::from(\"ZEN-is-4-OP\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to replace all spaces in the given string with '%20'.\nfn replace_spaces(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"My Name is Dawood\")), String::from(\"My%20Name%20is%20Dawood\"));\n    assert_eq!(candidate(String::from(\"I am a Programmer\")), String::from(\"I%20am%20a%20Programmer\"));\n    assert_eq!(candidate(String::from(\"I love Coding\")), String::from(\"I%20love%20Coding\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rs",
-    "prompt": "/// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfn sum_range_list(list1: Vec<isize>, m: isize, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_range_list;\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10), 29);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7), 16);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10), 38);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to merge three dictionaries into a single dictionary.\nfn merge_dictionaries_three(dict1: HashMap<String, String>, dict2: HashMap<String, String>, dict3: HashMap<String, String>) -> HashMap<String, String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = merge_dictionaries_three;\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"O\"), String::from(\"Orange\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"B\"), String::from(\"Black\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"O\"), String::from(\"Orange\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))])), HashMap::from([(String::from(\"W\"), String::from(\"White\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\")), (String::from(\"W\"), String::from(\"White\"))]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the minimum of two numbers.\nfn minimum(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = minimum;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(-5, -4), -5);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum difference between available pairs in the given tuple list.\nfn max_difference(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_difference;\n    assert_eq!(candidate(vec![(3, 5), (1, 7), (10, 3), (1, 2)]), 7);\n    assert_eq!(candidate(vec![(4, 6), (2, 17), (9, 13), (11, 12)]), 15);\n    assert_eq!(candidate(vec![(12, 35), (21, 27), (13, 23), (41, 22)]), 23);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rs",
-    "prompt": "/// Write a python function to find element at a given index after number of rotations.\nfn find_Element(arr: Vec<isize>, ranges: Vec<Vec<isize>>, rotations: isize, index: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Element;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![vec![0, 2], vec![0, 3]], 2, 1), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![vec![0, 1], vec![0, 2]], 1, 2), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![vec![0, 1], vec![0, 2]], 1, 1), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3592,7 +148,7 @@
     "language": "rs",
     "prompt": "/// Write a function to convert a string to a list of strings split on the space character.\nfn string_to_list(string: String) -> Vec<String> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = string_to_list;\n    assert_eq!(candidate(String::from(\"python programming\")), vec![String::from(\"python\"), String::from(\"programming\")]);\n    assert_eq!(candidate(String::from(\"lists tuples strings\")), vec![String::from(\"lists\"), String::from(\"tuples\"), String::from(\"strings\")]);\n    assert_eq!(candidate(String::from(\"write a program\")), vec![String::from(\"write\"), String::from(\"a\"), String::from(\"program\")]);\n}\n",
     "stop_tokens": [
@@ -3604,21 +160,9 @@
     "language": "rs",
     "prompt": "/// Write a python function to find the element that appears only once in a sorted array.\nfn search(arr: Vec<isize>) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]), 8);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4, 4]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to sort a dictionary by value.\nfn sort_counter(dict1: HashMap<String, isize>) -> Vec<(String, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_counter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 81), (String::from(\"Physics\"), 83), (String::from(\"Chemistry\"), 87)])), vec![(String::from(\"Chemistry\"), 87), (String::from(\"Physics\"), 83), (String::from(\"Math\"), 81)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)])), vec![(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 900), (String::from(\"Physics\"), 1000), (String::from(\"Chemistry\"), 1250)])), vec![(String::from(\"Chemistry\"), 1250), (String::from(\"Physics\"), 1000), (String::from(\"Math\"), 900)]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3628,7 +172,7 @@
     "language": "rs",
     "prompt": "/// Write a python function to remove first and last occurrence of a given character from the string.\nfn remove_Occ(s: String, ch: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = remove_Occ;\n    assert_eq!(candidate(String::from(\"hello\"), String::from(\"l\")), String::from(\"heo\"));\n    assert_eq!(candidate(String::from(\"abcda\"), String::from(\"a\")), String::from(\"bcd\"));\n    assert_eq!(candidate(String::from(\"PHP\"), String::from(\"P\")), String::from(\"H\"));\n}\n",
     "stop_tokens": [
@@ -3636,277 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rs",
-    "prompt": "/// Write a function to find the lateral surface area of a cube given its side length.\nfn lateralsurface_cube(l: isize) -> isize {\n",
+    "prompt": "/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfn max_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cube;\n    assert_eq!(candidate(5), 100);\n    assert_eq!(candidate(9), 324);\n    assert_eq!(candidate(10), 400);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = max_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 36);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 200);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 484);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rs",
-    "prompt": "/// Write a function to append the given list to the given tuples.\nfn add_lists(test_list: Vec<isize>, test_tup: (isize, isize)) -> (isize, isize, isize, isize, isize) {\n",
+    "prompt": "/// Write a function to sum all amicable numbers from 1 to a specified number.\nfn amicable_numbers_sum(limit: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_lists;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), (9, 10, 5, 6, 7));\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), (10, 11, 6, 7, 8));\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), (11, 12, 7, 8, 9));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = amicable_numbers_sum;\n    assert_eq!(candidate(999), 504);\n    assert_eq!(candidate(9999), 31626);\n    assert_eq!(candidate(99), 0);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "rs",
-    "prompt": "/// Write a function to compute the n-th power of each number in a list.\nfn nth_nums(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "prompt": "/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfn find_length(string: String) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = nth_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30], 3), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15], 5), vec![248832, 759375]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = find_length;\n    assert_eq!(candidate(String::from(\"11000010001\")), 6);\n    assert_eq!(candidate(String::from(\"10111\")), 1);\n    assert_eq!(candidate(String::from(\"11011101100101\")), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "rs",
-    "prompt": "/// Write a function to sort a list of elements.\nfn pancake_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a python function to find the sum of common divisors of two given numbers.\nfn sum(a: isize, b: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = pancake_sort;\n    assert_eq!(candidate(vec![15, 79, 25, 38, 69]), vec![15, 25, 38, 69, 79]);\n    assert_eq!(candidate(vec![98, 12, 54, 36, 85]), vec![12, 36, 54, 85, 98]);\n    assert_eq!(candidate(vec![41, 42, 32, 12, 23]), vec![12, 23, 32, 41, 42]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sum;\n    assert_eq!(candidate(10, 15), 6);\n    assert_eq!(candidate(100, 150), 93);\n    assert_eq!(candidate(4, 6), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "rs",
-    "prompt": "/// Write a function to find the median of three numbers.\nfn median_numbers(a: isize, b: isize, c: isize) -> f64 {\n",
+    "prompt": "/// Write a function to multiply two integers.\nfn multiply_int(x: isize, y: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = median_numbers;\n    assert_eq!(candidate(25, 55, 65), 55.0);\n    assert_eq!(candidate(20, 10, 30), 20.0);\n    assert_eq!(candidate(15, 45, 75), 45.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the entered number is greater than the elements of the given array.\nfn check_greater(arr: Vec<isize>, number: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_greater;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 4), false);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6], 8), true);\n    assert_eq!(candidate(vec![9, 7, 4, 8, 6, 1], 11), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rs",
-    "prompt": "/// Write a function to extract specified size of strings from a given list of string values.\nfn extract_string(str: Vec<String>, l: isize) -> Vec<String> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_string;\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 8), vec![String::from(\"practice\"), String::from(\"solution\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 6), vec![String::from(\"Python\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 9), vec![String::from(\"exercises\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rs",
-    "prompt": "/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfn text_lowercase_underscore(text: String) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = text_lowercase_underscore;\n    assert_eq!(candidate(String::from(\"aab_cbbbc\")), true);\n    assert_eq!(candidate(String::from(\"aab_Abbbc\")), false);\n    assert_eq!(candidate(String::from(\"Aaab_abbbc\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to trim each list by k in the given lists.\nfn trim_tuple(test_list: Vec<Vec<isize>>, K: isize) -> Vec<Vec<isize>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = trim_tuple;\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 2), vec![vec![2], vec![9], vec![2], vec![2]]);\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 1), vec![vec![3, 2, 1], vec![4, 9, 2], vec![1, 2, 3], vec![8, 2, 1]]);\n    assert_eq!(candidate(vec![vec![7, 8, 4, 9], vec![11, 8, 12, 4], vec![4, 1, 7, 8], vec![3, 6, 9, 7]], 1), vec![vec![8, 4], vec![8, 12], vec![1, 7], vec![6, 9]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rs",
-    "prompt": "/// Write a function to filter odd numbers.\nfn filter_oddnumbers(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_oddnumbers;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 3, 5, 7, 9]);\n    assert_eq!(candidate(vec![10, 20, 45, 67, 84, 93]), vec![45, 67, 93]);\n    assert_eq!(candidate(vec![5, 7, 9, 8, 6, 4, 3]), vec![5, 7, 9, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rs",
-    "prompt": "/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfn find_adverbs(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_adverbs;\n    assert_eq!(candidate(String::from(\"Clearly, he has no excuse for such behavior.\")), String::from(\"0-7: Clearly\"));\n    assert_eq!(candidate(String::from(\"Please handle the situation carefuly\")), String::from(\"28-36: carefuly\"));\n    assert_eq!(candidate(String::from(\"Complete the task quickly\")), String::from(\"18-25: quickly\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rs",
-    "prompt": "/// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfn max_of_nth(test_list: Vec<Vec<isize>>, N: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_of_nth;\n    assert_eq!(candidate(vec![vec![5, 6, 7], vec![1, 3, 5], vec![8, 9, 19]], 2), 19);\n    assert_eq!(candidate(vec![vec![6, 7, 8], vec![2, 4, 6], vec![9, 10, 20]], 1), 10);\n    assert_eq!(candidate(vec![vec![7, 8, 9], vec![3, 5, 7], vec![10, 11, 21]], 1), 11);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfn decimal_to_binary(n: isize) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(8), String::from(\"1000\"));\n    assert_eq!(candidate(18), String::from(\"10010\"));\n    assert_eq!(candidate(7), String::from(\"111\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfn combinations_colors(l: Vec<String>, n: isize) -> Vec<Vec<String>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = combinations_colors;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 1), vec![vec![String::from(\"Red\")], vec![String::from(\"Green\")], vec![String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 2), vec![vec![String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 3), vec![vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\"), String::from(\"Blue\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all whitespaces from a string.\nfn remove_all_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_all_spaces;\n    assert_eq!(candidate(String::from(\"python  program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"python   programming    language\")), String::from(\"pythonprogramminglanguage\"));\n    assert_eq!(candidate(String::from(\"python                     program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"   python                     program\")), String::from(\"pythonprogram\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to create a new tuple from the given string and list.\nfn new_tuple(test_list: Vec<String>, test_str: String) -> (String, String, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = new_tuple;\n    assert_eq!(candidate(vec![String::from(\"WEB\"), String::from(\"is\")], String::from(\"best\")), (String::from(\"WEB\"), String::from(\"is\"), String::from(\"best\")));\n    assert_eq!(candidate(vec![String::from(\"We\"), String::from(\"are\")], String::from(\"Developers\")), (String::from(\"We\"), String::from(\"are\"), String::from(\"Developers\")));\n    assert_eq!(candidate(vec![String::from(\"Part\"), String::from(\"is\")], String::from(\"Wrong\")), (String::from(\"Part\"), String::from(\"is\"), String::from(\"Wrong\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the product of the array multiplication modulo n.\nfn find_remainder(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_remainder;\n    assert_eq!(candidate(vec![100, 10, 5, 25, 35, 14], 11), 9);\n    assert_eq!(candidate(vec![1, 1, 1], 1), 0);\n    assert_eq!(candidate(vec![1, 2, 1], 2), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rs",
-    "prompt": "/// Write a function to find the ration of positive numbers in an array of integers.\nfn positive_count(nums: Vec<isize>) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = positive_count;\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]), 0.54);\n    assert_eq!(candidate(vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 0.69);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), 0.56);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to add the given tuple to the given list.\nfn add_tuple(test_list: Vec<isize>, test_tup: (isize, isize)) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = add_tuple;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), vec![5, 6, 7, 9, 10]);\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), vec![6, 7, 8, 10, 11]);\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), vec![7, 8, 9, 11, 12]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rs",
-    "prompt": "/// Write a function to find maximum run of uppercase characters in the given string.\nfn max_run_uppercase(test_str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_run_uppercase;\n    assert_eq!(candidate(String::from(\"GeMKSForGERksISBESt\")), 5);\n    assert_eq!(candidate(String::from(\"PrECIOusMOVemENTSYT\")), 6);\n    assert_eq!(candidate(String::from(\"GooGLEFluTTER\")), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfn sort_matrix(M: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_matrix;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![2, 4, 5], vec![1, 1, 1]]), vec![vec![1, 1, 1], vec![1, 2, 3], vec![2, 4, 5]]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![-2, 4, -5], vec![1, -1, 1]]), vec![vec![-2, 4, -5], vec![1, -1, 1], vec![1, 2, 3]]);\n    assert_eq!(candidate(vec![vec![5, 8, 9], vec![6, 4, 3], vec![2, 1, 4]]), vec![vec![2, 1, 4], vec![6, 4, 3], vec![5, 8, 9]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rs",
-    "prompt": "/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfn count_vowels(test_str: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_vowels;\n    assert_eq!(candidate(String::from(\"bestinstareels\")), 7);\n    assert_eq!(candidate(String::from(\"partofthejourneyistheend\")), 12);\n    assert_eq!(candidate(String::from(\"amazonprime\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfn max_sum_increasing_subseq(a: Vec<isize>, n: isize, index: isize, k: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum_increasing_subseq;\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 4, 6), 11);\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 2, 5), 7);\n    assert_eq!(candidate(vec![11, 15, 19, 21, 26, 28, 31], 7, 2, 4), 71);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply_int;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(5, 10), 50);\n    assert_eq!(candidate(4, 8), 32);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3916,7 +244,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find words that are longer than n characters from a given list of words.\nfn long_words(n: isize, str: String) -> Vec<String> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = long_words;\n    assert_eq!(candidate(3, String::from(\"python is a programming language\")), vec![String::from(\"python\"), String::from(\"programming\"), String::from(\"language\")]);\n    assert_eq!(candidate(2, String::from(\"writing a program\")), vec![String::from(\"writing\"), String::from(\"program\")]);\n    assert_eq!(candidate(5, String::from(\"sorting list\")), vec![String::from(\"sorting\")]);\n}\n",
     "stop_tokens": [
@@ -3924,193 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rs",
-    "prompt": "/// Write a python function to find the sum of non-repeated elements in a given list.\nfn find_sum(arr: Vec<isize>) -> isize {\n",
+    "prompt": "/// Write a function to calculate whether the matrix is a magic square.\nfn magic_square_test(my_matrix: Vec<Vec<isize>>) -> bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_sum;\n    assert_eq!(candidate(vec![1, 2, 3, 1, 1, 4, 5, 6]), 21);\n    assert_eq!(candidate(vec![1, 10, 9, 4, 2, 10, 10, 45, 4]), 71);\n    assert_eq!(candidate(vec![12, 10, 9, 45, 2, 10, 10, 45, 10]), 78);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = magic_square_test;\n    assert_eq!(candidate(vec![vec![7, 12, 1, 14], vec![2, 13, 8, 11], vec![16, 3, 10, 5], vec![9, 6, 15, 4]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 8]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 7]]), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfn tuple_to_dict(test_tup: (isize, isize, isize, isize, isize, isize)) -> HashMap<isize, isize> {\n",
+    "prompt": "/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfn sort_matrix(M: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_dict;\n    assert_eq!(candidate((1, 5, 7, 10, 13, 5)), HashMap::from([(1, 5), (7, 10), (13, 5)]));\n    assert_eq!(candidate((1, 2, 3, 4, 5, 6)), HashMap::from([(1, 2), (3, 4), (5, 6)]));\n    assert_eq!(candidate((7, 8, 9, 10, 11, 12)), HashMap::from([(7, 8), (9, 10), (11, 12)]));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_matrix;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![2, 4, 5], vec![1, 1, 1]]), vec![vec![1, 1, 1], vec![1, 2, 3], vec![2, 4, 5]]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![-2, 4, -5], vec![1, -1, 1]]), vec![vec![-2, 4, -5], vec![1, -1, 1], vec![1, 2, 3]]);\n    assert_eq!(candidate(vec![vec![5, 8, 9], vec![6, 4, 3], vec![2, 1, 4]]), vec![vec![2, 1, 4], vec![6, 4, 3], vec![5, 8, 9]]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rs",
-    "prompt": "/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfn get_coordinates(test_tup: (isize, isize)) -> Vec<Vec<isize>> {\n",
+    "prompt": "/// Write a function to find the item with maximum frequency in a given list.\nfn max_occurrences(nums: Vec<isize>) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = get_coordinates;\n    assert_eq!(candidate((3, 4)), vec![vec![2, 3], vec![2, 4], vec![2, 5], vec![3, 3], vec![3, 4], vec![3, 5], vec![4, 3], vec![4, 4], vec![4, 5]]);\n    assert_eq!(candidate((4, 5)), vec![vec![3, 4], vec![3, 5], vec![3, 6], vec![4, 4], vec![4, 5], vec![4, 6], vec![5, 4], vec![5, 5], vec![5, 6]]);\n    assert_eq!(candidate((5, 6)), vec![vec![4, 5], vec![4, 6], vec![4, 7], vec![5, 5], vec![5, 6], vec![5, 7], vec![6, 5], vec![6, 6], vec![6, 7]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfn find_First_Missing(array: Vec<isize>) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_First_Missing;\n    assert_eq!(candidate(vec![0, 1, 2, 3]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, 6, 9]), 3);\n    assert_eq!(candidate(vec![2, 3, 5, 8, 9]), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is undulating or not.\nfn is_undulating(n: isize) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_undulating;\n    assert_eq!(candidate(1212121), true);\n    assert_eq!(candidate(1991), false);\n    assert_eq!(candidate(121), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rs",
-    "prompt": "/// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfn min_k(test_list: Vec<(String, isize)>, K: isize) -> Vec<(String, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = min_k;\n    assert_eq!(candidate(vec![(String::from(\"Manjeet\"), 10), (String::from(\"Akshat\"), 4), (String::from(\"Akash\"), 2), (String::from(\"Nikhil\"), 8)], 2), vec![(String::from(\"Akash\"), 2), (String::from(\"Akshat\"), 4)]);\n    assert_eq!(candidate(vec![(String::from(\"Sanjeev\"), 11), (String::from(\"Angat\"), 5), (String::from(\"Akash\"), 3), (String::from(\"Nepin\"), 9)], 3), vec![(String::from(\"Akash\"), 3), (String::from(\"Angat\"), 5), (String::from(\"Nepin\"), 9)]);\n    assert_eq!(candidate(vec![(String::from(\"tanmay\"), 14), (String::from(\"Amer\"), 11), (String::from(\"Ayesha\"), 9), (String::from(\"SKD\"), 16)], 1), vec![(String::from(\"Ayesha\"), 9)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rs",
-    "prompt": "/// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfn count_Substrings(s: String) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Substrings;\n    assert_eq!(candidate(String::from(\"112112\")), 6);\n    assert_eq!(candidate(String::from(\"111\")), 6);\n    assert_eq!(candidate(String::from(\"1101112\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth decagonal number.\nfn is_num_decagonal(n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_num_decagonal;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(7), 175);\n    assert_eq!(candidate(10), 370);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfn rear_extract(test_list: Vec<(isize, String, isize)>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = rear_extract;\n    assert_eq!(candidate(vec![(1, String::from(\"Rash\"), 21), (2, String::from(\"Varsha\"), 20), (3, String::from(\"Kil\"), 19)]), vec![21, 20, 19]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sai\"), 36), (2, String::from(\"Ayesha\"), 25), (3, String::from(\"Salman\"), 45)]), vec![36, 25, 45]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sudeep\"), 14), (2, String::from(\"Vandana\"), 36), (3, String::from(\"Dawood\"), 56)]), vec![14, 36, 56]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the closest smaller number than n.\nfn closest_num(N: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_num;\n    assert_eq!(candidate(11), 10);\n    assert_eq!(candidate(7), 6);\n    assert_eq!(candidate(12), 11);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rs",
-    "prompt": "/// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfn find_combinations(test_list: Vec<(isize, isize)>) -> Vec<(isize, isize)> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_combinations;\n    assert_eq!(candidate(vec![(2, 4), (6, 7), (5, 1), (6, 10)]), vec![(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]);\n    assert_eq!(candidate(vec![(3, 5), (7, 8), (6, 2), (7, 11)]), vec![(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]);\n    assert_eq!(candidate(vec![(4, 6), (8, 9), (7, 3), (8, 12)]), vec![(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rs",
-    "prompt": "/// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfn maxAverageOfPath(cost: Vec<Vec<isize>>) -> f64 {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = maxAverageOfPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![6, 5, 4], vec![7, 3, 9]]), 5.2);\n    assert_eq!(candidate(vec![vec![2, 3, 4], vec![7, 6, 5], vec![8, 4, 10]]), 6.2);\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![8, 7, 6], vec![9, 5, 11]]), 7.2);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]), 5.8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfn sequential_search(dlist: Vec<isize>, item: isize) -> (bool, isize) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sequential_search;\n    assert_eq!(candidate(vec![11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31), (true, 3));\n    assert_eq!(candidate(vec![12, 32, 45, 62, 35, 47, 44, 61], 61), (true, 7));\n    assert_eq!(candidate(vec![9, 10, 17, 19, 22, 39, 48, 56], 48), (true, 6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rs",
-    "prompt": "/// Write a python function to remove odd numbers from a given list.\nfn remove_odd(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2]);\n    assert_eq!(candidate(vec![2, 4, 6]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![10, 20, 3]), vec![10, 20]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the product of numbers in a list is even or not.\nfn is_product_even(arr: Vec<isize>) -> bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = is_product_even;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 4]), true);\n    assert_eq!(candidate(vec![1, 1]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rs",
-    "prompt": "/// Write a python function to find the maximum of two numbers.\nfn maximum(a: isize, b: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(5, 10), 10);\n    assert_eq!(candidate(-1, -2), -1);\n    assert_eq!(candidate(9, 7), 9);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = max_occurrences;\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]), 2);\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]), 8);\n    assert_eq!(candidate(vec![10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]), 20);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4120,9 +292,549 @@
     "language": "rs",
     "prompt": "/// Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfn reverse_vowels(str1: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = reverse_vowels;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"USA\")), String::from(\"ASU\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"ab\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a list to a string.\nfn tup_string(tup1: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tup_string;\n    assert_eq!(candidate(vec![String::from(\"e\"), String::from(\"x\"), String::from(\"e\"), String::from(\"r\"), String::from(\"c\"), String::from(\"i\"), String::from(\"s\"), String::from(\"e\"), String::from(\"s\")]), String::from(\"exercises\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]), String::from(\"program\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfn sum_negativenum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_negativenum;\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), -32);\n    assert_eq!(candidate(vec![10, 15, -14, 13, -18, 12, -20]), -52);\n    assert_eq!(candidate(vec![19, -65, 57, 39, 152, -639, 121, 44, 90, -190]), -894);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth hexagonal number.\nfn hexagonal_num(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = hexagonal_num;\n    assert_eq!(candidate(10), 190);\n    assert_eq!(candidate(5), 45);\n    assert_eq!(candidate(7), 91);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfn is_Sum_Of_Powers_Of_Two(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Sum_Of_Powers_Of_Two;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(7), false);\n    assert_eq!(candidate(14), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a list of elements.\nfn pancake_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pancake_sort;\n    assert_eq!(candidate(vec![15, 79, 25, 38, 69]), vec![15, 25, 38, 69, 79]);\n    assert_eq!(candidate(vec![98, 12, 54, 36, 85]), vec![12, 36, 54, 85, 98]);\n    assert_eq!(candidate(vec![41, 42, 32, 12, 23]), vec![12, 23, 32, 41, 42]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rs",
+    "prompt": "/// Write a function to count number items that are identical in the same position of three given lists.\nfn count_samepair(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_samepair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9], vec![2, 1, 3, 1, 2, 6, 7, 9]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 2, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the maximum difference between any two elements in a given array.\nfn max_Abs_Diff(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_Abs_Diff;\n    assert_eq!(candidate(vec![2, 1, 5, 3]), 4);\n    assert_eq!(candidate(vec![9, 3, 2, 5, 1]), 8);\n    assert_eq!(candidate(vec![3, 2, 1]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the volume of a triangular prism.\nfn find_Volume(l: isize, b: isize, h: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Volume;\n    assert_eq!(candidate(10, 8, 6), 240);\n    assert_eq!(candidate(3, 2, 2), 6);\n    assert_eq!(candidate(1, 2, 1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rs",
+    "prompt": "/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfn find_solution(a: isize, b: isize, n: isize) -> Option<(isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_solution;\n    assert_eq!(candidate(2, 3, 7), Some((2, 1)));\n    assert_eq!(candidate(4, 2, 7), None);\n    assert_eq!(candidate(1, 13, 17), Some((4, 1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all elements from a given list present in another list.\nfn remove_elements(list1: Vec<isize>, list2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_elements;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![2, 4, 6, 8]), vec![1, 3, 5, 7, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![1, 3, 5, 7]), vec![2, 4, 6, 8, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![5, 7]), vec![1, 2, 3, 4, 6, 8, 9, 10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfn sum_series(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_series;\n    assert_eq!(candidate(6), 12);\n    assert_eq!(candidate(10), 30);\n    assert_eq!(candidate(9), 25);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rs",
+    "prompt": "/// Write a function to determine if the sum of the divisors of two integers are the same.\nfn are_equivalent(num1: isize, num2: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = are_equivalent;\n    assert_eq!(candidate(36, 57), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(23, 47), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfn count_char_position(str1: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_char_position;\n    assert_eq!(candidate(String::from(\"xbcefg\")), 2);\n    assert_eq!(candidate(String::from(\"ABcED\")), 3);\n    assert_eq!(candidate(String::from(\"AbgdeF\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rs",
+    "prompt": "/// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfn find_even_pair(A: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_even_pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1]), 4);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11]), 9);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the smallest power of 2 greater than or equal to n.\nfn next_power_of_2(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = next_power_of_2;\n    assert_eq!(candidate(0), 1);\n    assert_eq!(candidate(5), 8);\n    assert_eq!(candidate(17), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of occurrences of a number in a given list.\nfn frequency(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = frequency;\n    assert_eq!(candidate(vec![1, 2, 3], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 3, 4], 3), 3);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 1, 2], 1), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rs",
+    "prompt": "/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfn text_lowercase_underscore(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_lowercase_underscore;\n    assert_eq!(candidate(String::from(\"aab_cbbbc\")), true);\n    assert_eq!(candidate(String::from(\"aab_Abbbc\")), false);\n    assert_eq!(candidate(String::from(\"Aaab_abbbc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rs",
+    "prompt": "/// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfn sum_range_list(list1: Vec<isize>, m: isize, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_range_list;\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10), 29);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7), 16);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10), 38);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rs",
+    "prompt": "/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfn perimeter_pentagon(a: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = perimeter_pentagon;\n    assert_eq!(candidate(5), 25);\n    assert_eq!(candidate(10), 50);\n    assert_eq!(candidate(15), 75);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of occurence of the string 'std' in a given string.\nfn count_occurance(s: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_occurance;\n    assert_eq!(candidate(String::from(\"letstdlenstdporstd\")), 3);\n    assert_eq!(candidate(String::from(\"truststdsolensporsd\")), 1);\n    assert_eq!(candidate(String::from(\"makestdsostdworthit\")), 2);\n    assert_eq!(candidate(String::from(\"stds\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rs",
+    "prompt": "/// Write a function that returns the perimeter of a square given its side length as input.\nfn square_perimeter(a: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = square_perimeter;\n    assert_eq!(candidate(10), 40);\n    assert_eq!(candidate(5), 20);\n    assert_eq!(candidate(4), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rs",
+    "prompt": "/// Write a function to remove characters from the first string which are present in the second string.\nfn remove_dirty_chars(string: String, second_string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_dirty_chars;\n    assert_eq!(candidate(String::from(\"probasscurve\"), String::from(\"pros\")), String::from(\"bacuve\"));\n    assert_eq!(candidate(String::from(\"digitalindia\"), String::from(\"talent\")), String::from(\"digiidi\"));\n    assert_eq!(candidate(String::from(\"exoticmiles\"), String::from(\"toxic\")), String::from(\"emles\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rs",
+    "prompt": "/// Write a function to find whether a given array of integers contains any duplicate element.\nfn test_duplicate(arraynums: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = test_duplicate;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3, 3, 4, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given number is woodball or not.\nfn is_woodall(x: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_woodall;\n    assert_eq!(candidate(383), true);\n    assert_eq!(candidate(254), false);\n    assert_eq!(candidate(200), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfn is_majority(arr: Vec<isize>, n: isize, x: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_majority;\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 3, 10], 7, 3), true);\n    assert_eq!(candidate(vec![1, 1, 2, 4, 4, 4, 6, 6], 8, 4), false);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 2], 5, 1), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2], 5, 1), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfn count_Set_Bits(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Set_Bits;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 1);\n    assert_eq!(candidate(6), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rs",
+    "prompt": "/// Write a python function to remove the characters which have odd index values of a given string.\nfn odd_values_string(str: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_values_string;\n    assert_eq!(candidate(String::from(\"abcdef\")), String::from(\"ace\"));\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"pto\"));\n    assert_eq!(candidate(String::from(\"data\")), String::from(\"dt\"));\n    assert_eq!(candidate(String::from(\"lambs\")), String::from(\"lms\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rs",
+    "prompt": "/// Write a function to find minimum of three numbers.\nfn min_of_three(a: isize, b: isize, c: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = min_of_three;\n    assert_eq!(candidate(10, 20, 0), 0);\n    assert_eq!(candidate(19, 15, 18), 15);\n    assert_eq!(candidate(-10, -20, -30), -30);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether all the bits are unset in the given range or not.\nfn all_Bits_Set_In_The_Given_Range(n: isize, l: isize, r: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_Bits_Set_In_The_Given_Range;\n    assert_eq!(candidate(4, 1, 2), true);\n    assert_eq!(candidate(17, 2, 4), true);\n    assert_eq!(candidate(39, 4, 6), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfn re_arrange_array(arr: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = re_arrange_array;\n    assert_eq!(candidate(vec![-1, 2, -3, 4, 5, 6, -7, 8, 9], 9), vec![-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n    assert_eq!(candidate(vec![12, -14, -26, 13, 15], 5), vec![-14, -26, 12, 13, 15]);\n    assert_eq!(candidate(vec![10, 24, 36, -42, -39, -78, 85], 7), vec![-42, -39, -78, 10, 24, 36, 85]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfn replace_blank(str1: String, char: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_blank;\n    assert_eq!(candidate(String::from(\"hello people\"), String::from(\"@\")), String::from(\"hello@people\"));\n    assert_eq!(candidate(String::from(\"python program language\"), String::from(\"$\")), String::from(\"python$program$language\"));\n    assert_eq!(candidate(String::from(\"blank space\"), String::from(\"-\")), String::from(\"blank-space\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rs",
+    "prompt": "/// Write a function to find the volume of a cube given its side length.\nfn volume_cube(l: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = volume_cube;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(2), 8);\n    assert_eq!(candidate(5), 125);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of non-empty substrings of a given string.\nfn number_of_substrings(str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = number_of_substrings;\n    assert_eq!(candidate(String::from(\"abc\")), 6);\n    assert_eq!(candidate(String::from(\"abcd\")), 10);\n    assert_eq!(candidate(String::from(\"abcde\")), 15);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfn get_total_number_of_sequences(m: isize, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_total_number_of_sequences;\n    assert_eq!(candidate(10, 4), 4);\n    assert_eq!(candidate(5, 2), 6);\n    assert_eq!(candidate(16, 3), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rs",
+    "prompt": "/// Write a function to count the total number of characters in a string.\nfn count_charac(str1: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_charac;\n    assert_eq!(candidate(String::from(\"python programming\")), 18);\n    assert_eq!(candidate(String::from(\"language\")), 8);\n    assert_eq!(candidate(String::from(\"words\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the next perfect square greater than a given number.\nfn next_Perfect_Square(N: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = next_Perfect_Square;\n    assert_eq!(candidate(35), 36);\n    assert_eq!(candidate(6), 9);\n    assert_eq!(candidate(9), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rs",
+    "prompt": "/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfn max_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum;\n    assert_eq!(candidate(vec![1, 15, 51, 45, 33, 100, 12, 18, 9]), 194);\n    assert_eq!(candidate(vec![80, 60, 30, 40, 20, 10]), 210);\n    assert_eq!(candidate(vec![2, 3, 14, 16, 21, 23, 29, 30]), 138);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rs",
+    "prompt": "/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfn lps(str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = lps;\n    assert_eq!(candidate(String::from(\"TENS FOR TENS\")), 5);\n    assert_eq!(candidate(String::from(\"CARDIO FOR CARDS\")), 7);\n    assert_eq!(candidate(String::from(\"PART OF THE JOURNEY IS PART\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rs",
+    "prompt": "/// Write a function to find the intersection of two arrays.\nfn intersection_array(array_nums1: Vec<isize>, array_nums2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection_array;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![1, 2, 4, 8, 9]), vec![1, 2, 8, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![3, 5, 7, 9]), vec![3, 5, 7, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![10, 20, 30, 40]), vec![10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rs",
+    "prompt": "/// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfn count_X(tup: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_X;\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4), 0);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10), 3);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfn insert_element(list: Vec<String>, element: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = insert_element;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Black\")], String::from(\"c\")), vec![String::from(\"c\"), String::from(\"Red\"), String::from(\"c\"), String::from(\"Green\"), String::from(\"c\"), String::from(\"Black\")]);\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"java\")], String::from(\"program\")), vec![String::from(\"program\"), String::from(\"python\"), String::from(\"program\"), String::from(\"java\")]);\n    assert_eq!(candidate(vec![String::from(\"happy\"), String::from(\"sad\")], String::from(\"laugh\")), vec![String::from(\"laugh\"), String::from(\"happy\"), String::from(\"laugh\"), String::from(\"sad\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rs",
+    "prompt": "/// Write a python function to convert complex numbers to polar coordinates.\nfn convert(numbers: isize) -> (f64, f64) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = convert;\n    assert_eq!(candidate(1), (1.0, 0.0));\n    assert_eq!(candidate(4), (4.0, 0.0));\n    assert_eq!(candidate(5), (5.0, 0.0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfn combinations_colors(l: Vec<String>, n: isize) -> Vec<Vec<String>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = combinations_colors;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 1), vec![vec![String::from(\"Red\")], vec![String::from(\"Green\")], vec![String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 2), vec![vec![String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 3), vec![vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\"), String::from(\"Blue\")]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rs",
+    "prompt": "/// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfn count_Primes_nums(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Primes_nums;\n    assert_eq!(candidate(5), 2);\n    assert_eq!(candidate(10), 4);\n    assert_eq!(candidate(100), 25);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfn swap_numbers(a: isize, b: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_numbers;\n    assert_eq!(candidate(10, 20), vec![20, 10]);\n    assert_eq!(candidate(15, 17), vec![17, 15]);\n    assert_eq!(candidate(100, 200), vec![200, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4132,7 +844,7 @@
     "language": "rs",
     "prompt": "/// Write a function to maximize the given two lists.\nfn maximize_elements(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = maximize_elements;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 7], vec![4, 9], vec![2, 9], vec![7, 10]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![7, 8], vec![5, 10], vec![3, 10], vec![8, 11]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![8, 9], vec![6, 11], vec![4, 11], vec![9, 12]]);\n}\n",
     "stop_tokens": [
@@ -4140,73 +852,49 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rs",
-    "prompt": "/// Write a python function to check whether every even index contains even numbers of a given list.\nfn even_position(nums: Vec<isize>) -> bool {\n",
+    "prompt": "/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfn newman_prime(n: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = even_position;\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n    assert_eq!(candidate(vec![2, 1, 4]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = newman_prime;\n    assert_eq!(candidate(3), 7);\n    assert_eq!(candidate(4), 17);\n    assert_eq!(candidate(5), 41);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rs",
-    "prompt": "/// Write a function to check whether the given string starts and ends with the same character or not.\nfn check_char(string: String) -> String {\n",
+    "prompt": "/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfn division_elements(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = check_char;\n    assert_eq!(candidate(String::from(\"abba\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"Invalid\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = division_elements;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (2, 2, 2, 3));\n    assert_eq!(candidate((12, 6, 8, 16), (6, 3, 4, 4)), (2, 2, 2, 4));\n    assert_eq!(candidate((20, 14, 36, 18), (5, 7, 6, 9)), (4, 2, 6, 2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_264_dog_age",
     "language": "rs",
-    "prompt": "/// Write a python function to find the sum of even factors of a number.\nfn sumofFactors(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to calculate a dog's age in dog's years.\nfn dog_age(h_age: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = sumofFactors;\n    assert_eq!(candidate(18), 26);\n    assert_eq!(candidate(30), 48);\n    assert_eq!(candidate(6), 8);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = dog_age;\n    assert_eq!(candidate(12), 61);\n    assert_eq!(candidate(15), 73);\n    assert_eq!(candidate(24), 109);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rs",
-    "prompt": "/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfn lateralsurface_cone(r: isize, h: isize) -> f64 {\n",
+    "prompt": "/// Write a function to find the lateral surface area of a cube given its side length.\nfn lateralsurface_cube(l: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cone;\n    assert_eq!(candidate(5, 12), 204.20352248333654);\n    assert_eq!(candidate(10, 15), 566.3586699569488);\n    assert_eq!(candidate(19, 17), 1521.8090132193388);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_564_count_Pairs",
-    "language": "rs",
-    "prompt": "/// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfn count_Pairs(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Pairs;\n    assert_eq!(candidate(vec![1, 2, 1], 3), 2);\n    assert_eq!(candidate(vec![1, 1, 1, 1], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 5), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_733_find_first_occurrence",
-    "language": "rs",
-    "prompt": "/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfn find_first_occurrence(A: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = find_first_occurrence;\n    assert_eq!(candidate(vec![2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5), 1);\n    assert_eq!(candidate(vec![2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5), 2);\n    assert_eq!(candidate(vec![2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6), 4);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cube;\n    assert_eq!(candidate(5), 100);\n    assert_eq!(candidate(9), 324);\n    assert_eq!(candidate(10), 400);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4216,9 +904,597 @@
     "language": "rs",
     "prompt": "/// Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 10);\n    assert_eq!(candidate(3), 35);\n    assert_eq!(candidate(4), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n'th star number.\nfn find_star_num(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_star_num;\n    assert_eq!(candidate(3), 37);\n    assert_eq!(candidate(4), 73);\n    assert_eq!(candidate(5), 121);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rs",
+    "prompt": "/// Write a function to find the ascii value of a character.\nfn ascii_value(k: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = ascii_value;\n    assert_eq!(candidate(String::from(\"A\")), 65);\n    assert_eq!(candidate(String::from(\"R\")), 82);\n    assert_eq!(candidate(String::from(\"S\")), 83);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of even numbers at even positions of a list.\nfn sum_even_and_even_index(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_even_and_even_index;\n    assert_eq!(candidate(vec![5, 6, 12, 1, 18, 8]), 30);\n    assert_eq!(candidate(vec![3, 20, 17, 9, 2, 10, 18, 13, 6, 18]), 26);\n    assert_eq!(candidate(vec![5, 6, 12, 1]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rs",
+    "prompt": "/// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfn even_Power_Sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_Power_Sum;\n    assert_eq!(candidate(2), 1056);\n    assert_eq!(candidate(3), 8832);\n    assert_eq!(candidate(1), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfn rear_extract(test_list: Vec<(isize, String, isize)>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rear_extract;\n    assert_eq!(candidate(vec![(1, String::from(\"Rash\"), 21), (2, String::from(\"Varsha\"), 20), (3, String::from(\"Kil\"), 19)]), vec![21, 20, 19]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sai\"), 36), (2, String::from(\"Ayesha\"), 25), (3, String::from(\"Salman\"), 45)]), vec![36, 25, 45]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sudeep\"), 14), (2, String::from(\"Vandana\"), 36), (3, String::from(\"Dawood\"), 56)]), vec![14, 36, 56]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfn substract_elements(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> (isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = substract_elements;\n    assert_eq!(candidate((10, 4, 5), (2, 5, 18)), (8, -1, -13));\n    assert_eq!(candidate((11, 2, 3), (24, 45, 16)), (-13, -43, -13));\n    assert_eq!(candidate((7, 18, 9), (10, 11, 12)), (-3, 7, -3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rs",
+    "prompt": "/// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfn even_binomial_Coeff_Sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_binomial_Coeff_Sum;\n    assert_eq!(candidate(4), 8);\n    assert_eq!(candidate(6), 32);\n    assert_eq!(candidate(2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfn dict_filter(dict: HashMap<String, isize>, n: isize) -> HashMap<String, isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = dict_filter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 170), HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 180), HashMap::from([(String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 190), HashMap::from([(String::from(\"Pierre Cox\"), 190)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth decagonal number.\nfn is_num_decagonal(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_num_decagonal;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(7), 175);\n    assert_eq!(candidate(10), 370);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfn sequential_search(dlist: Vec<isize>, item: isize) -> (bool, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sequential_search;\n    assert_eq!(candidate(vec![11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31), (true, 3));\n    assert_eq!(candidate(vec![12, 32, 45, 62, 35, 47, 44, 61], 61), (true, 7));\n    assert_eq!(candidate(vec![9, 10, 17, 19, 22, 39, 48, 56], 48), (true, 6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rs",
+    "prompt": "/// Write a python function to check if the elements of a given list are unique or not.\nfn all_unique(test_list: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_unique;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rs",
+    "prompt": "/// Write a function to subtract two lists element-wise.\nfn sub_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sub_list;\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), vec![-3, -3, -3]);\n    assert_eq!(candidate(vec![1, 2], vec![3, 4]), vec![-2, -2]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![40, 50]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rs",
+    "prompt": "/// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfn validate(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = validate;\n    assert_eq!(candidate(1234), true);\n    assert_eq!(candidate(51241), false);\n    assert_eq!(candidate(321), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rs",
+    "prompt": "/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfn text_match_two_three(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_two_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rs",
+    "prompt": "/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfn max_sub_array_sum_repeated(a: Vec<isize>, n: isize, k: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum_repeated;\n    assert_eq!(candidate(vec![10, 20, -30, -1], 4, 3), 30);\n    assert_eq!(candidate(vec![-1, 10, 20], 3, 2), 59);\n    assert_eq!(candidate(vec![-1, -2, -3], 3, 3), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rs",
+    "prompt": "/// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 20);\n    assert_eq!(candidate(3), 56);\n    assert_eq!(candidate(4), 120);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rs",
+    "prompt": "/// Write a function to find the list of maximum length in a list of lists.\nfn max_length(list1: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_length;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1], vec![5, 7], vec![10, 12, 14, 15]]), (4, vec![10, 12, 14, 15]));\n    assert_eq!(candidate(vec![vec![5], vec![15, 20, 25]]), (3, vec![15, 20, 25]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rs",
+    "prompt": "/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfn count_no_of_ways(n: isize, k: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_no_of_ways;\n    assert_eq!(candidate(2, 4), 16);\n    assert_eq!(candidate(3, 2), 6);\n    assert_eq!(candidate(4, 4), 228);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rs",
+    "prompt": "/// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfn find(n: isize, m: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find;\n    assert_eq!(candidate(10, 3), 3);\n    assert_eq!(candidate(4, 2), 2);\n    assert_eq!(candidate(20, 5), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rs",
+    "prompt": "/// Write a function to find the third side of a right angled triangle.\nfn otherside_rightangle(w: isize, h: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = otherside_rightangle;\n    assert_eq!(candidate(7, 8), 10.63014581273465);\n    assert_eq!(candidate(3, 4), 5.0);\n    assert_eq!(candidate(7, 15), 16.55294535724685);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rs",
+    "prompt": "/// Write a function to return the sum of all divisors of a number.\nfn sum_div(number: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_div;\n    assert_eq!(candidate(8), 7);\n    assert_eq!(candidate(12), 16);\n    assert_eq!(candidate(7), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rs",
+    "prompt": "/// Write a python function to count inversions in an array.\nfn get_Inv_Count(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_Inv_Count;\n    assert_eq!(candidate(vec![1, 20, 6, 4, 5]), 5);\n    assert_eq!(candidate(vec![1, 2, 1]), 1);\n    assert_eq!(candidate(vec![1, 2, 5, 6, 1]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the maximum aggregate from the list of tuples.\nfn max_aggregate(stdata: Vec<(String, isize)>) -> (String, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_aggregate;\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 90), (String::from(\"Sabah Colley\"), 88), (String::from(\"Peter Nichols\"), 7), (String::from(\"Juan Whelan\"), 122), (String::from(\"Sabah Colley\"), 84)]), (String::from(\"Juan Whelan\"), 212));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 50), (String::from(\"Sabah Colley\"), 48), (String::from(\"Peter Nichols\"), 37), (String::from(\"Juan Whelan\"), 22), (String::from(\"Sabah Colley\"), 14)]), (String::from(\"Juan Whelan\"), 72));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 10), (String::from(\"Sabah Colley\"), 20), (String::from(\"Peter Nichols\"), 30), (String::from(\"Juan Whelan\"), 40), (String::from(\"Sabah Colley\"), 50)]), (String::from(\"Sabah Colley\"), 70));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rs",
+    "prompt": "/// Write a python function to find element at a given index after number of rotations.\nfn find_Element(arr: Vec<isize>, ranges: Vec<Vec<isize>>, rotations: isize, index: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Element;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![vec![0, 2], vec![0, 3]], 2, 1), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![vec![0, 1], vec![0, 2]], 1, 2), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![vec![0, 1], vec![0, 2]], 1, 1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rs",
+    "prompt": "/// Write a function to return two words from a list of words starting with letter 'p'.\nfn start_withp(words: Vec<String>) -> (String, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = start_withp;\n    assert_eq!(candidate(vec![String::from(\"Python PHP\"), String::from(\"Java JavaScript\"), String::from(\"c c++\")]), (String::from(\"Python\"), String::from(\"PHP\")));\n    assert_eq!(candidate(vec![String::from(\"Python Programming\"), String::from(\"Java Programming\")]), (String::from(\"Python\"), String::from(\"Programming\")));\n    assert_eq!(candidate(vec![String::from(\"Pqrst Pqr\"), String::from(\"qrstuv\")]), (String::from(\"Pqrst\"), String::from(\"Pqr\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfn max_sum_increasing_subseq(a: Vec<isize>, n: isize, index: isize, k: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum_increasing_subseq;\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 4, 6), 11);\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 2, 5), 7);\n    assert_eq!(candidate(vec![11, 15, 19, 21, 26, 28, 31], 7, 2, 4), 71);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfn large_product(nums1: Vec<isize>, nums2: Vec<isize>, N: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = large_product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 3), vec![60, 54, 50]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 4), vec![60, 54, 50, 48]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 5), vec![60, 54, 50, 48, 45]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the maximum of two numbers.\nfn maximum(a: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(5, 10), 10);\n    assert_eq!(candidate(-1, -2), -1);\n    assert_eq!(candidate(9, 7), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a given string to a list of characters.\nfn string_to_tuple(str1: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_tuple;\n    assert_eq!(candidate(String::from(\"python 3.0\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\"), String::from(\"3\"), String::from(\".\"), String::from(\"0\")]);\n    assert_eq!(candidate(String::from(\"item1\")), vec![String::from(\"i\"), String::from(\"t\"), String::from(\"e\"), String::from(\"m\"), String::from(\"1\")]);\n    assert_eq!(candidate(String::from(\"15.10\")), vec![String::from(\"1\"), String::from(\"5\"), String::from(\".\"), String::from(\"1\"), String::from(\"0\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the highest power of 2 that is less than or equal to n.\nfn highest_Power_of_2(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = highest_Power_of_2;\n    assert_eq!(candidate(10), 8);\n    assert_eq!(candidate(19), 16);\n    assert_eq!(candidate(32), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n'th lucas number.\nfn find_lucas(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_lucas;\n    assert_eq!(candidate(9), 76);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(3), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfn get_max_sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_sum;\n    assert_eq!(candidate(60), 106);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rs",
+    "prompt": "/// Write a function to find the list with maximum length.\nfn max_length_list(input_list: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_length_list;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4], vec![1, 2, 3], vec![1, 2], vec![1]]), (5, vec![1, 2, 3, 4, 5]));\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![6, 7, 8, 9], vec![10, 11, 12]]), (4, vec![6, 7, 8, 9]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rs",
+    "prompt": "/// Write a function to check if given list contains no duplicates.\nfn check_distinct(test_tup: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_distinct;\n    assert_eq!(candidate(vec![1, 4, 5, 6, 1, 4]), false);\n    assert_eq!(candidate(vec![1, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the first non-repeated character in a given string.\nfn first_non_repeating_character(str1: String) -> Option<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = first_non_repeating_character;\n    assert_eq!(candidate(String::from(\"abcabc\")), None);\n    assert_eq!(candidate(String::from(\"abc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"ababc\")), Some(String::from(\"c\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given string starts and ends with the same character or not.\nfn check_char(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_char;\n    assert_eq!(candidate(String::from(\"abba\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"Invalid\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median of three numbers.\nfn median_numbers(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = median_numbers;\n    assert_eq!(candidate(25, 55, 65), 55.0);\n    assert_eq!(candidate(20, 10, 30), 20.0);\n    assert_eq!(candidate(15, 45, 75), 45.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rs",
+    "prompt": "/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfn bitwise_xor(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = bitwise_xor;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (15, 6, 5, 10));\n    assert_eq!(candidate((11, 5, 7, 10), (6, 3, 4, 4)), (13, 6, 3, 14));\n    assert_eq!(candidate((12, 6, 8, 11), (7, 4, 5, 6)), (11, 2, 13, 13));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rs",
+    "prompt": "/// Write a python function to identify non-prime numbers.\nfn is_not_prime(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_not_prime;\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(35), true);\n    assert_eq!(candidate(37), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rs",
+    "prompt": "/// Write a function to extract the number of unique tuples in the given list.\nfn extract_freq(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_freq;\n    assert_eq!(candidate(vec![(3, 4), (1, 2), (4, 3), (5, 6)]), 3);\n    assert_eq!(candidate(vec![(4, 15), (2, 3), (5, 4), (6, 7)]), 4);\n    assert_eq!(candidate(vec![(5, 16), (2, 3), (6, 5), (6, 9)]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to perform index wise addition of list elements in the given two nested lists.\nfn add_nested_tuples(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add_nested_tuples;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![7, 10], vec![7, 14], vec![3, 10], vec![8, 13]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![9, 12], vec![9, 16], vec![5, 12], vec![10, 15]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![11, 14], vec![11, 18], vec![7, 14], vec![12, 17]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the minimum of two numbers.\nfn minimum(a: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = minimum;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(-5, -4), -5);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rs",
+    "prompt": "/// Write a python function to find whether the parity of a given number is odd.\nfn find_Parity(x: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Parity;\n    assert_eq!(candidate(12), false);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rs",
+    "prompt": "/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfn k_smallest_pairs(nums1: Vec<isize>, nums2: Vec<isize>, k: isize) -> Vec<Vec<isize>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = k_smallest_pairs;\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 2), vec![vec![1, 2], vec![1, 4]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 1), vec![vec![1, 2]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 7), vec![vec![1, 2], vec![1, 4], vec![3, 2], vec![1, 6], vec![3, 4], vec![3, 6], vec![7, 2]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to find the minimum product from the pairs of tuples within a given list.\nfn min_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = min_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 8);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 30);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 100);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rs",
+    "prompt": "/// Write a function to convert the given snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"android_tv\")), String::from(\"AndroidTv\"));\n    assert_eq!(candidate(String::from(\"google_pixel\")), String::from(\"GooglePixel\"));\n    assert_eq!(candidate(String::from(\"apple_watch\")), String::from(\"AppleWatch\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rs",
+    "prompt": "/// Write a python function to remove odd numbers from a given list.\nfn remove_odd(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2]);\n    assert_eq!(candidate(vec![2, 4, 6]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![10, 20, 3]), vec![10, 20]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfn overlapping(list1: Vec<isize>, list2: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = overlapping;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 8, 9]), false);\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 4, 5], vec![1, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rs",
+    "prompt": "/// Write a python function to find a pair with highest product from a given array of integers.\nfn max_Product(arr: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_Product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 7, 0, 8, 4]), (7, 8));\n    assert_eq!(candidate(vec![0, -1, -2, -4, 5, 0, -6]), (-4, -6));\n    assert_eq!(candidate(vec![1, 2, 3]), (2, 3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4228,7 +1504,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find common first element in given list of lists.\nfn group_tuples(Input: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\nfn main() {\n    let candidate = group_tuples;\n    assert_eq!(candidate(vec![vec![String::from(\"x\"), String::from(\"y\")], vec![String::from(\"x\"), String::from(\"z\")], vec![String::from(\"w\"), String::from(\"t\")]]), vec![vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")], vec![String::from(\"w\"), String::from(\"t\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"a\"), String::from(\"c\")], vec![String::from(\"d\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")], vec![String::from(\"d\"), String::from(\"e\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"f\"), String::from(\"g\")], vec![String::from(\"f\"), String::from(\"g\")], vec![String::from(\"h\"), String::from(\"i\")]]), vec![vec![String::from(\"f\"), String::from(\"g\"), String::from(\"g\")], vec![String::from(\"h\"), String::from(\"i\")]]);\n}\n",
     "stop_tokens": [
@@ -4236,13 +1512,2737 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_420_cube_Sum",
     "language": "rs",
-    "prompt": "/// Write a function to merge three lists into a single sorted list.\nfn merge_sorted_list(num1: Vec<isize>, num2: Vec<isize>, num3: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a python function to find the cube sum of first n even natural numbers.\nfn cube_Sum(n: isize) -> isize {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\nfn main() {\n    let candidate = merge_sorted_list;\n    assert_eq!(candidate(vec![25, 24, 15, 4, 5, 29, 110], vec![19, 20, 11, 56, 25, 233, 154], vec![24, 26, 54, 48]), vec![4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n    assert_eq!(candidate(vec![1, 3, 5, 6, 8, 9], vec![2, 5, 7, 11], vec![1, 4, 7, 8, 12]), vec![1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n    assert_eq!(candidate(vec![18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], vec![25, 35, 22, 85, 14, 65, 75, 25, 58], vec![12, 74, 9, 50, 61, 41]), vec![1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = cube_Sum;\n    assert_eq!(candidate(2), 72);\n    assert_eq!(candidate(3), 288);\n    assert_eq!(candidate(4), 800);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to concatenate each element of tuple by the delimiter.\nfn concatenate_tuple(test_tup: (String, String, isize, String)) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate_tuple;\n    assert_eq!(candidate((String::from(\"ID\"), String::from(\"is\"), 4, String::from(\"UTS\"))), String::from(\"ID-is-4-UTS\"));\n    assert_eq!(candidate((String::from(\"QWE\"), String::from(\"is\"), 4, String::from(\"RTY\"))), String::from(\"QWE-is-4-RTY\"));\n    assert_eq!(candidate((String::from(\"ZEN\"), String::from(\"is\"), 4, String::from(\"OP\"))), String::from(\"ZEN-is-4-OP\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the average of cubes of first n natural numbers.\nfn find_Average_Of_Cube(n: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Average_Of_Cube;\n    assert_eq!(candidate(2), 4.5);\n    assert_eq!(candidate(3), 12.0);\n    assert_eq!(candidate(1), 1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rs",
+    "prompt": "/// Write a function to extract only the rear index element of each string in the given tuple.\nfn extract_rear(test_tuple: (String, String, String)) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_rear;\n    assert_eq!(candidate((String::from(\"Mers\"), String::from(\"for\"), String::from(\"Vers\"))), vec![String::from(\"s\"), String::from(\"r\"), String::from(\"s\")]);\n    assert_eq!(candidate((String::from(\"Avenge\"), String::from(\"for\"), String::from(\"People\"))), vec![String::from(\"e\"), String::from(\"r\"), String::from(\"e\")]);\n    assert_eq!(candidate((String::from(\"Gotta\"), String::from(\"get\"), String::from(\"go\"))), vec![String::from(\"a\"), String::from(\"t\"), String::from(\"o\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rs",
+    "prompt": "/// Write a function to filter odd numbers.\nfn filter_oddnumbers(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_oddnumbers;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 3, 5, 7, 9]);\n    assert_eq!(candidate(vec![10, 20, 45, 67, 84, 93]), vec![45, 67, 93]);\n    assert_eq!(candidate(vec![5, 7, 9, 8, 6, 4, 3]), vec![5, 7, 9, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfn change_date_format(dt: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = change_date_format;\n    assert_eq!(candidate(String::from(\"2026-01-02\")), String::from(\"02-01-2026\"));\n    assert_eq!(candidate(String::from(\"2020-11-13\")), String::from(\"13-11-2020\"));\n    assert_eq!(candidate(String::from(\"2021-04-26\")), String::from(\"26-04-2021\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort the given array by using shell sort.\nfn shell_sort(my_list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = shell_sort;\n    assert_eq!(candidate(vec![12, 23, 4, 5, 3, 2, 12, 81, 56, 95]), vec![2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n    assert_eq!(candidate(vec![24, 22, 39, 34, 87, 73, 68]), vec![22, 24, 34, 39, 68, 73, 87]);\n    assert_eq!(candidate(vec![32, 30, 16, 96, 82, 83, 74]), vec![16, 30, 32, 74, 82, 83, 96]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to extract the elementwise and tuples from the given two tuples.\nfn and_tuples(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = and_tuples;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (0, 0, 2, 1));\n    assert_eq!(candidate((1, 2, 3, 4), (5, 6, 7, 8)), (1, 2, 3, 0));\n    assert_eq!(candidate((8, 9, 11, 12), (7, 13, 14, 17)), (0, 9, 10, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rs",
+    "prompt": "/// Write a function to find the directrix of a parabola.\nfn parabola_directrix(a: isize, b: isize, c: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = parabola_directrix;\n    assert_eq!(candidate(5, 3, 2), -198);\n    assert_eq!(candidate(9, 8, 4), -2336);\n    assert_eq!(candidate(2, 4, 6), -130);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median length of a trapezium.\nfn median_trapezium(base1: isize, base2: isize, height: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = median_trapezium;\n    assert_eq!(candidate(15, 25, 35), 20.0);\n    assert_eq!(candidate(10, 20, 30), 15.0);\n    assert_eq!(candidate(6, 9, 4), 7.5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the entered number is greater than the elements of the given array.\nfn check_greater(arr: Vec<isize>, number: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_greater;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 4), false);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6], 8), true);\n    assert_eq!(candidate(vec![9, 7, 4, 8, 6, 1], 11), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an a followed by one or more b's.\nfn text_match_one(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the last digit of a given number.\nfn last_Digit(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = last_Digit;\n    assert_eq!(candidate(123), 3);\n    assert_eq!(candidate(25), 5);\n    assert_eq!(candidate(30), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rs",
+    "prompt": "/// Write a python function to return the negative numbers in a list.\nfn neg_nos(list1: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = neg_nos;\n    assert_eq!(candidate(vec![-1, 4, 5, -6]), vec![-1, -6]);\n    assert_eq!(candidate(vec![-1, -2, 3, 4]), vec![-1, -2]);\n    assert_eq!(candidate(vec![-7, -6, 8, 9]), vec![-7, -6]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to remove odd characters in a string.\nfn remove_odd(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"yhn\"));\n    assert_eq!(candidate(String::from(\"program\")), String::from(\"rga\"));\n    assert_eq!(candidate(String::from(\"language\")), String::from(\"agae\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rs",
+    "prompt": "/// Write a function to count bidirectional tuple pairs.\nfn count_bidirectional(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_bidirectional;\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]), 3);\n    assert_eq!(candidate(vec![(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]), 2);\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rs",
+    "prompt": "/// Write a function to join a list of multiple integers into a single integer.\nfn multiple_to_single(L: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = multiple_to_single;\n    assert_eq!(candidate(vec![11, 33, 50]), 113350);\n    assert_eq!(candidate(vec![-1, 2, 3, 4, 5, 6]), -123456);\n    assert_eq!(candidate(vec![10, 15, 20, 25]), 10152025);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rs",
+    "prompt": "/// Write a function to find the first adverb and their positions in a given sentence.\nfn find_adverb_position(text: String) -> (isize, isize, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_adverb_position;\n    assert_eq!(candidate(String::from(\"clearly!! we can see the sky\")), (0, 7, String::from(\"clearly\")));\n    assert_eq!(candidate(String::from(\"seriously!! there are many roses\")), (0, 9, String::from(\"seriously\")));\n    assert_eq!(candidate(String::from(\"unfortunately!! sita is going to home\")), (0, 13, String::from(\"unfortunately\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rs",
+    "prompt": "/// Write a function to find the surface area of a cube of a given size.\nfn surfacearea_cube(l: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cube;\n    assert_eq!(candidate(5), 150);\n    assert_eq!(candidate(3), 54);\n    assert_eq!(candidate(10), 600);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rs",
+    "prompt": "/// Write a function to find the ration of positive numbers in an array of integers.\nfn positive_count(nums: Vec<isize>) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = positive_count;\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]), 0.54);\n    assert_eq!(candidate(vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 0.69);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), 0.56);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the largest negative number from the given list.\nfn largest_neg(list1: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_neg;\n    assert_eq!(candidate(vec![1, 2, 3, -4, -6]), -6);\n    assert_eq!(candidate(vec![1, 2, 3, -8, -9]), -9);\n    assert_eq!(candidate(vec![1, 2, 3, 4, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to trim each list by k in the given lists.\nfn trim_tuple(test_list: Vec<Vec<isize>>, K: isize) -> Vec<Vec<isize>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = trim_tuple;\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 2), vec![vec![2], vec![9], vec![2], vec![2]]);\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 1), vec![vec![3, 2, 1], vec![4, 9, 2], vec![1, 2, 3], vec![8, 2, 1]]);\n    assert_eq!(candidate(vec![vec![7, 8, 4, 9], vec![11, 8, 12, 4], vec![4, 1, 7, 8], vec![3, 6, 9, 7]], 1), vec![vec![8, 4], vec![8, 12], vec![1, 7], vec![6, 9]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rs",
+    "prompt": "/// Write a function to perform index wise multiplication of list elements in the given two lists.\nfn index_multiplication(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = index_multiplication;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 21], vec![12, 45], vec![2, 9], vec![7, 30]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![14, 32], vec![20, 60], vec![6, 20], vec![16, 44]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![24, 45], vec![30, 77], vec![12, 33], vec![27, 60]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to find cubes of individual elements in a list.\nfn cube_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cube_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15]), vec![1728, 3375]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum of perrin numbers.\nfn cal_sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cal_sum;\n    assert_eq!(candidate(9), 49);\n    assert_eq!(candidate(10), 66);\n    assert_eq!(candidate(11), 88);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rs",
+    "prompt": "/// Write a function to extract specified size of strings from a given list of string values.\nfn extract_string(str: Vec<String>, l: isize) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_string;\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 8), vec![String::from(\"practice\"), String::from(\"solution\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 6), vec![String::from(\"Python\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 9), vec![String::from(\"exercises\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all whitespaces from the given string.\nfn remove_whitespaces(text1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_whitespaces;\n    assert_eq!(candidate(String::from(\" Google    Flutter \")), String::from(\"GoogleFlutter\"));\n    assert_eq!(candidate(String::from(\" Google    Dart \")), String::from(\"GoogleDart\"));\n    assert_eq!(candidate(String::from(\" iOS    Swift \")), String::from(\"iOSSwift\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rs",
+    "prompt": "/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfn loss_amount(actual_cost: isize, sale_amount: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = loss_amount;\n    assert_eq!(candidate(1500, 1200), 0);\n    assert_eq!(candidate(100, 200), 100);\n    assert_eq!(candidate(2000, 5000), 3000);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of even factors of a number.\nfn sumofFactors(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sumofFactors;\n    assert_eq!(candidate(18), 26);\n    assert_eq!(candidate(30), 48);\n    assert_eq!(candidate(6), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a word containing 'z'.\nfn text_match_wordz(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz;\n    assert_eq!(candidate(String::from(\"pythonz.\")), true);\n    assert_eq!(candidate(String::from(\"xyz.\")), true);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given month number contains 31 days or not.\nfn check_monthnumb_number(monthnum2: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumb_number;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(6), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rs",
+    "prompt": "/// Write a function to reverse each string in a given list of string values.\nfn reverse_string_list(stringlist: Vec<String>) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_string_list;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\"), String::from(\"White\"), String::from(\"Black\")]), vec![String::from(\"deR\"), String::from(\"neerG\"), String::from(\"eulB\"), String::from(\"etihW\"), String::from(\"kcalB\")]);\n    assert_eq!(candidate(vec![String::from(\"john\"), String::from(\"amal\"), String::from(\"joel\"), String::from(\"george\")]), vec![String::from(\"nhoj\"), String::from(\"lama\"), String::from(\"leoj\"), String::from(\"egroeg\")]);\n    assert_eq!(candidate(vec![String::from(\"jack\"), String::from(\"john\"), String::from(\"mary\")]), vec![String::from(\"kcaj\"), String::from(\"nhoj\"), String::from(\"yram\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rs",
+    "prompt": "/// Write a function to find the area of a rectangle.\nfn rectangle_area(l: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rectangle_area;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(10, 5), 50);\n    assert_eq!(candidate(4, 2), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rs",
+    "prompt": "/// Write a function to remove uppercase substrings from a given string.\nfn remove_uppercase(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_uppercase;\n    assert_eq!(candidate(String::from(\"cAstyoUrFavoRitETVshoWs\")), String::from(\"cstyoravoitshos\"));\n    assert_eq!(candidate(String::from(\"wAtchTheinTernEtrAdIo\")), String::from(\"wtchheinerntrdo\"));\n    assert_eq!(candidate(String::from(\"VoicESeaRchAndreComMendaTionS\")), String::from(\"oiceachndreomendaion\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rs",
+    "prompt": "/// Write a python function to get the first element of each sublist.\nfn Extract(lst: Vec<Vec<isize>>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Extract;\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4, 5], vec![6, 7, 8, 9]]), vec![1, 3, 6]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5]]), vec![1, 4]);\n    assert_eq!(candidate(vec![vec![9, 8, 1], vec![1, 2]]), vec![9, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the upper case characters in a given string.\nfn upper_ctr(str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = upper_ctr;\n    assert_eq!(candidate(String::from(\"PYthon\")), 1);\n    assert_eq!(candidate(String::from(\"BigData\")), 1);\n    assert_eq!(candidate(String::from(\"program\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum product subarray of the given array.\nfn max_subarray_product(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_subarray_product;\n    assert_eq!(candidate(vec![1, -2, -3, 0, 7, -8, -2]), 112);\n    assert_eq!(candidate(vec![6, -3, -10, 0, 2]), 180);\n    assert_eq!(candidate(vec![-2, -40, 0, -2, -3]), 80);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to check if all values are same in a dictionary.\nfn check_value(dict: HashMap<String, isize>, n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_value;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 10), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 12), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 5), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfn max_product(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_product;\n    assert_eq!(candidate(vec![3, 100, 4, 5, 150, 6]), 3000);\n    assert_eq!(candidate(vec![4, 42, 55, 68, 80]), 50265600);\n    assert_eq!(candidate(vec![10, 22, 9, 33, 21, 50, 41, 60]), 2460);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rs",
+    "prompt": "/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfn add_pairwise(test_tup: (isize, isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add_pairwise;\n    assert_eq!(candidate((1, 5, 7, 8, 10)), (6, 12, 15, 18));\n    assert_eq!(candidate((2, 6, 8, 9, 11)), (8, 14, 17, 20));\n    assert_eq!(candidate((3, 7, 9, 10, 12)), (10, 16, 19, 22));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the product of the array multiplication modulo n.\nfn find_remainder(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_remainder;\n    assert_eq!(candidate(vec![100, 10, 5, 25, 35, 14], 11), 9);\n    assert_eq!(candidate(vec![1, 1, 1], 1), 0);\n    assert_eq!(candidate(vec![1, 2, 1], 2), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given list contains consecutive numbers or not.\nfn check_Consecutive(l: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_Consecutive;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 2, 1]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rs",
+    "prompt": "/// Write a function to replace characters in a string.\nfn replace_char(str1: String, ch: String, newch: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_char;\n    assert_eq!(candidate(String::from(\"polygon\"), String::from(\"y\"), String::from(\"l\")), String::from(\"pollgon\"));\n    assert_eq!(candidate(String::from(\"character\"), String::from(\"c\"), String::from(\"a\")), String::from(\"aharaater\"));\n    assert_eq!(candidate(String::from(\"python\"), String::from(\"l\"), String::from(\"a\")), String::from(\"python\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to sort a dictionary by value.\nfn sort_counter(dict1: HashMap<String, isize>) -> Vec<(String, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_counter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 81), (String::from(\"Physics\"), 83), (String::from(\"Chemistry\"), 87)])), vec![(String::from(\"Chemistry\"), 87), (String::from(\"Physics\"), 83), (String::from(\"Math\"), 81)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)])), vec![(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 900), (String::from(\"Physics\"), 1000), (String::from(\"Chemistry\"), 1250)])), vec![(String::from(\"Chemistry\"), 1250), (String::from(\"Physics\"), 1000), (String::from(\"Math\"), 900)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of the largest and smallest value in a given array.\nfn big_sum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = big_sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 4);\n    assert_eq!(candidate(vec![-1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![2, 3, 6]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rs",
+    "prompt": "/// Write a python function to convert the given string to lower case.\nfn is_lower(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_lower;\n    assert_eq!(candidate(String::from(\"InValid\")), String::from(\"invalid\"));\n    assert_eq!(candidate(String::from(\"TruE\")), String::from(\"true\"));\n    assert_eq!(candidate(String::from(\"SenTenCE\")), String::from(\"sentence\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rs",
+    "prompt": "/// Write a function to remove lowercase substrings from a given string.\nfn remove_lowercase(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_lowercase;\n    assert_eq!(candidate(String::from(\"PYTHon\")), String::from(\"PYTH\"));\n    assert_eq!(candidate(String::from(\"FInD\")), String::from(\"FID\"));\n    assert_eq!(candidate(String::from(\"STRinG\")), String::from(\"STRG\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the first digit of a given number.\nfn first_Digit(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = first_Digit;\n    assert_eq!(candidate(123), 1);\n    assert_eq!(candidate(456), 4);\n    assert_eq!(candidate(12), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfn heap_queue_largest(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = heap_queue_largest;\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 3), vec![85, 75, 65]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 2), vec![85, 75]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 5), vec![85, 75, 65, 58, 35]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rs",
+    "prompt": "/// Write a python function which takes a list of integers and only returns the odd ones.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), vec![1, 3, 5]);\n    assert_eq!(candidate(vec![10, 11, 12, 13]), vec![11, 13]);\n    assert_eq!(candidate(vec![7, 8, 9, 1]), vec![7, 9, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfn difference(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = difference;\n    assert_eq!(candidate(3), 30);\n    assert_eq!(candidate(5), 210);\n    assert_eq!(candidate(2), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of pairs whose xor value is odd.\nfn find_Odd_Pair(A: Vec<isize>, N: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Odd_Pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1], 5), 6);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11], 7), 12);\n    assert_eq!(candidate(vec![1, 2, 3], 3), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rs",
+    "prompt": "/// Write a function to toggle the case of all characters in a string.\nfn toggle_string(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = toggle_string;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"pYTHON\"));\n    assert_eq!(candidate(String::from(\"Pangram\")), String::from(\"pANGRAM\"));\n    assert_eq!(candidate(String::from(\"LIttLE\")), String::from(\"liTTle\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of the per-digit difference between two integers.\nfn digit_distance_nums(n1: isize, n2: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = digit_distance_nums;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(23, 56), 6);\n    assert_eq!(candidate(123, 256), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the sum of the largest contiguous sublist in the given list.\nfn max_sub_array_sum(a: Vec<isize>, size: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum;\n    assert_eq!(candidate(vec![-2, -3, 4, -1, -2, 1, 5, -3], 8), 7);\n    assert_eq!(candidate(vec![-3, -4, 5, -2, -3, 2, 6, -4], 8), 8);\n    assert_eq!(candidate(vec![-4, -5, 6, -3, -4, 3, 7, -5], 8), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rs",
+    "prompt": "/// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfn union_elements(test_tup1: Vec<isize>, test_tup2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = union_elements;\n    assert_eq!(candidate(vec![3, 4, 5, 6], vec![5, 7, 4, 10]), vec![3, 4, 5, 6, 7, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![3, 4, 5, 6]), vec![1, 2, 3, 4, 5, 6]);\n    assert_eq!(candidate(vec![11, 12, 13, 14], vec![13, 15, 16, 17]), vec![11, 12, 13, 14, 15, 16, 17]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the length of the longest sublists.\nfn Find_Max_Length(lst: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Find_Max_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 4], vec![5, 6, 7, 8]]), 4);\n    assert_eq!(candidate(vec![vec![0, 1], vec![2, 2], vec![3, 2, 1]]), 3);\n    assert_eq!(candidate(vec![vec![7], vec![22, 23], vec![13, 14, 15], vec![10, 20, 30, 40, 50]]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rs",
+    "prompt": "/// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfn count_Pairs(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Pairs;\n    assert_eq!(candidate(vec![1, 2, 1], 3), 2);\n    assert_eq!(candidate(vec![1, 1, 1, 1], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 5), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rs",
+    "prompt": "/// Write a python function to split a string into characters.\nfn split(word: String) -> Vec<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = split;\n    assert_eq!(candidate(String::from(\"python\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]);\n    assert_eq!(candidate(String::from(\"Name\")), vec![String::from(\"N\"), String::from(\"a\"), String::from(\"m\"), String::from(\"e\")]);\n    assert_eq!(candidate(String::from(\"program\")), vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rs",
+    "prompt": "/// Write a function to get the sum of the digits of a non-negative integer.\nfn sum_digits(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_digits;\n    assert_eq!(candidate(345), 12);\n    assert_eq!(candidate(12), 3);\n    assert_eq!(candidate(97), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a specified list is sorted or not.\nfn issort_list(list1: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = issort_list;\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 16, 17]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 20, 17]), false);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 15, 14, 20]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rs",
+    "prompt": "/// Write a function to sort each sublist of strings in a given list of lists.\nfn sort_sublists(list1: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"d\"), String::from(\"c\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"f\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"c\"), String::from(\"d\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"e\"), String::from(\"f\")]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rs",
+    "prompt": "/// Write a python function to check if a given number is one less than twice its reverse.\nfn checks(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = checks;\n    assert_eq!(candidate(70), false);\n    assert_eq!(candidate(23), false);\n    assert_eq!(candidate(73), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rs",
+    "prompt": "/// Write a python function to remove duplicate numbers from a given number of lists.\nfn two_unique_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = two_unique_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 2, 3, 4, 5]), vec![1, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 5]), vec![1, 3, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rs",
+    "prompt": "/// Write a python function to calculate the product of the unique numbers in a given list.\nfn unique_product(list_data: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_product;\n    assert_eq!(candidate(vec![10, 20, 30, 40, 20, 50, 60, 40]), 720000000);\n    assert_eq!(candidate(vec![1, 2, 3, 1]), 6);\n    assert_eq!(candidate(vec![7, 8, 9, 0, 1, 1]), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rs",
+    "prompt": "/// Write a function to find the surface area of a cylinder.\nfn surfacearea_cylinder(r: isize, h: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cylinder;\n    assert_eq!(candidate(10, 5), 942.45);\n    assert_eq!(candidate(4, 5), 226.18800000000002);\n    assert_eq!(candidate(4, 10), 351.848);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether a list is sublist of another or not.\nfn is_Sub_Array(A: Vec<isize>, B: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Sub_Array;\n    assert_eq!(candidate(vec![1, 4, 3, 5], vec![1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 1], vec![1, 2, 1]), true);\n    assert_eq!(candidate(vec![1, 0, 2, 2], vec![2, 2, 0]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the last digit in factorial of a given number.\nfn last_Digit_Factorial(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = last_Digit_Factorial;\n    assert_eq!(candidate(4), 4);\n    assert_eq!(candidate(21), 0);\n    assert_eq!(candidate(30), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rs",
+    "prompt": "/// Write a function to interleave 3 lists of the same length into a single flat list.\nfn interleave_lists(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = interleave_lists;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7], vec![10, 20, 30, 40, 50, 60, 70], vec![100, 200, 300, 400, 500, 600, 700]), vec![1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n    assert_eq!(candidate(vec![10, 20], vec![15, 2], vec![5, 10]), vec![10, 15, 5, 20, 2, 10]);\n    assert_eq!(candidate(vec![11, 44], vec![10, 15], vec![20, 5]), vec![11, 10, 20, 44, 15, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rs",
+    "prompt": "/// Write a function to find the dissimilar elements in the given two tuples.\nfn find_dissimilar(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_dissimilar;\n    assert_eq!(candidate((3, 4, 5, 6), (5, 7, 4, 10)), (3, 6, 7, 10));\n    assert_eq!(candidate((1, 2, 3, 4), (7, 2, 3, 9)), (1, 4, 7, 9));\n    assert_eq!(candidate((21, 11, 25, 26), (26, 34, 21, 36)), (34, 36, 11, 25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the largest number that can be formed with the given list of digits.\nfn find_Max_Num(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Max_Num;\n    assert_eq!(candidate(vec![1, 2, 3]), 321);\n    assert_eq!(candidate(vec![4, 5, 6, 1]), 6541);\n    assert_eq!(candidate(vec![1, 2, 3, 9]), 9321);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfn surface_Area(b: isize, s: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = surface_Area;\n    assert_eq!(candidate(3, 4), 33);\n    assert_eq!(candidate(4, 5), 56);\n    assert_eq!(candidate(1, 2), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rs",
+    "prompt": "/// Write a function which returns nth catalan number.\nfn catalan_number(num: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = catalan_number;\n    assert_eq!(candidate(10), 16796);\n    assert_eq!(candidate(9), 4862);\n    assert_eq!(candidate(7), 429);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rs",
+    "prompt": "/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfn find_adverbs(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_adverbs;\n    assert_eq!(candidate(String::from(\"Clearly, he has no excuse for such behavior.\")), String::from(\"0-7: Clearly\"));\n    assert_eq!(candidate(String::from(\"Please handle the situation carefuly\")), String::from(\"28-36: carefuly\"));\n    assert_eq!(candidate(String::from(\"Complete the task quickly\")), String::from(\"18-25: quickly\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rs",
+    "prompt": "/// Write a python function to split a list at the nth eelment and add the first part to the end.\nfn split_Arr(l: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = split_Arr;\n    assert_eq!(candidate(vec![12, 10, 5, 6, 52, 36], 2), vec![5, 6, 52, 36, 12, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], 1), vec![2, 3, 4, 1]);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 4, 5, 6, 7], 3), vec![3, 4, 5, 6, 7, 0, 1, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the difference between largest and smallest value in a given list.\nfn big_diff(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = big_diff;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![4, 5, 12]), 8);\n    assert_eq!(candidate(vec![9, 2, 3]), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rs",
+    "prompt": "/// Write a function to find perfect squares between two given numbers.\nfn perfect_squares(a: isize, b: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = perfect_squares;\n    assert_eq!(candidate(1, 30), vec![1, 4, 9, 16, 25]);\n    assert_eq!(candidate(50, 100), vec![64, 81, 100]);\n    assert_eq!(candidate(100, 200), vec![100, 121, 144, 169, 196]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given two integers have opposite sign or not.\nfn opposite_Signs(x: isize, y: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = opposite_Signs;\n    assert_eq!(candidate(1, -2), true);\n    assert_eq!(candidate(3, 2), false);\n    assert_eq!(candidate(-10, -10), false);\n    assert_eq!(candidate(-2, 2), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rs",
+    "prompt": "/// Write a python function to interchange the first and last elements in a list.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![12, 35, 9, 56, 24]), vec![24, 35, 9, 56, 12]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfn sum_Of_product(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_product;\n    assert_eq!(candidate(3), 15);\n    assert_eq!(candidate(4), 56);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rs",
+    "prompt": "/// Write a function to remove leading zeroes from an ip address.\nfn removezero_ip(ip: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = removezero_ip;\n    assert_eq!(candidate(String::from(\"216.08.094.196\")), String::from(\"216.8.94.196\"));\n    assert_eq!(candidate(String::from(\"12.01.024\")), String::from(\"12.1.24\"));\n    assert_eq!(candidate(String::from(\"216.08.094.0196\")), String::from(\"216.8.94.196\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to find the difference of the first even and first odd number of a given list.\nfn diff_even_odd(list1: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = diff_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 1);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rs",
+    "prompt": "/// Write a function to find kth element from the given two sorted arrays.\nfn find_kth(arr1: Vec<isize>, arr2: Vec<isize>, k: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_kth;\n    assert_eq!(candidate(vec![2, 3, 6, 7, 9], vec![1, 4, 8, 10], 5), 6);\n    assert_eq!(candidate(vec![100, 112, 256, 349, 770], vec![72, 86, 113, 119, 265, 445, 892], 7), 256);\n    assert_eq!(candidate(vec![3, 4, 7, 8, 10], vec![2, 5, 9, 11], 6), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is armstrong or not.\nfn armstrong_number(number: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = armstrong_number;\n    assert_eq!(candidate(153), true);\n    assert_eq!(candidate(259), false);\n    assert_eq!(candidate(4458), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rs",
+    "prompt": "/// Write a function to find sum and average of first n natural numbers.\nfn sum_average(number: isize) -> (isize, f64) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_average;\n    assert_eq!(candidate(10), (55, 5.5));\n    assert_eq!(candidate(15), (120, 8.0));\n    assert_eq!(candidate(20), (210, 10.5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth octagonal number.\nfn is_octagonal(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_octagonal;\n    assert_eq!(candidate(5), 65);\n    assert_eq!(candidate(10), 280);\n    assert_eq!(candidate(15), 645);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given number is even or not.\nfn is_Even(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Even;\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(2), true);\n    assert_eq!(candidate(3), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the first repeated character in a given string.\nfn first_repeated_char(str1: String) -> Option<String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = first_repeated_char;\n    assert_eq!(candidate(String::from(\"abcabc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"abc\")), None);\n    assert_eq!(candidate(String::from(\"123123\")), Some(String::from(\"1\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rs",
+    "prompt": "/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfn get_ludic(n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_ludic;\n    assert_eq!(candidate(10), vec![1, 2, 3, 5, 7]);\n    assert_eq!(candidate(25), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n    assert_eq!(candidate(45), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rs",
+    "prompt": "/// Write a function to reverse words seperated by spaces in a given string.\nfn reverse_words(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_words;\n    assert_eq!(candidate(String::from(\"python program\")), String::from(\"program python\"));\n    assert_eq!(candidate(String::from(\"java language\")), String::from(\"language java\"));\n    assert_eq!(candidate(String::from(\"indian man\")), String::from(\"man indian\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given integer is a prime number.\nfn prime_num(num: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_num;\n    assert_eq!(candidate(13), true);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(-1010), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rs",
+    "prompt": "/// Write a function to convert degrees to radians.\nfn radian_degree(degree: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = radian_degree;\n    assert_eq!(candidate(90), 1.5707963267948966);\n    assert_eq!(candidate(60), 1.0471975511965976);\n    assert_eq!(candidate(120), 2.0943951023931953);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rs",
+    "prompt": "/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfn find_literals(text: String, pattern: String) -> (String, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_literals;\n    assert_eq!(candidate(String::from(\"The quick brown fox jumps over the lazy dog.\"), String::from(\"fox\")), (String::from(\"fox\"), 16, 19));\n    assert_eq!(candidate(String::from(\"Its been a very crazy procedure right\"), String::from(\"crazy\")), (String::from(\"crazy\"), 16, 21));\n    assert_eq!(candidate(String::from(\"Hardest choices required strongest will\"), String::from(\"will\")), (String::from(\"will\"), 35, 39));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rs",
+    "prompt": "/// Write a python function to find nth bell number.\nfn bell_Number(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = bell_Number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 15);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rs",
+    "prompt": "/// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfn remove_kth_element(list1: Vec<isize>, L: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_kth_element;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 4, 4, 5, 1], 3), vec![1, 1, 3, 4, 4, 5, 1]);\n    assert_eq!(candidate(vec![0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4), vec![0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n    assert_eq!(candidate(vec![10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5), vec![10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rs",
+    "prompt": "/// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfn max_of_nth(test_list: Vec<Vec<isize>>, N: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_of_nth;\n    assert_eq!(candidate(vec![vec![5, 6, 7], vec![1, 3, 5], vec![8, 9, 19]], 2), 19);\n    assert_eq!(candidate(vec![vec![6, 7, 8], vec![2, 4, 6], vec![9, 10, 20]], 1), 10);\n    assert_eq!(candidate(vec![vec![7, 8, 9], vec![3, 5, 7], vec![10, 11, 21]], 1), 11);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfn cummulative_sum(test_list: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = cummulative_sum;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 6, 7], vec![2, 6]]), 30);\n    assert_eq!(candidate(vec![vec![2, 4], vec![6, 7, 8], vec![3, 7]]), 37);\n    assert_eq!(candidate(vec![vec![3, 5], vec![7, 8, 9], vec![4, 8]]), 44);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfn average_tuple(nums: Vec<Vec<isize>>) -> Vec<f64> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = average_tuple;\n    assert_eq!(candidate(vec![vec![10, 10, 10, 12], vec![30, 45, 56, 45], vec![81, 80, 39, 32], vec![1, 2, 3, 4]]), vec![30.5, 34.25, 27.0, 23.25]);\n    assert_eq!(candidate(vec![vec![1, 1, -5], vec![30, -15, 56], vec![81, -60, -39], vec![-10, 2, 3]]), vec![25.5, -18.0, 3.75]);\n    assert_eq!(candidate(vec![vec![100, 100, 100, 120], vec![300, 450, 560, 450], vec![810, 800, 390, 320], vec![10, 20, 30, 40]]), vec![305.0, 342.5, 270.0, 232.5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rs",
+    "prompt": "/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfn tuple_modulo(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_modulo;\n    assert_eq!(candidate((10, 4, 5, 6), (5, 6, 7, 5)), (0, 4, 5, 1));\n    assert_eq!(candidate((11, 5, 6, 7), (6, 7, 8, 6)), (5, 5, 6, 1));\n    assert_eq!(candidate((12, 6, 7, 8), (7, 8, 9, 7)), (5, 6, 7, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rs",
+    "prompt": "/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfn min_Jumps(steps: (isize, isize), d: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = min_Jumps;\n    assert_eq!(candidate((3, 4), 11), 3.5);\n    assert_eq!(candidate((3, 4), 0), 0.0);\n    assert_eq!(candidate((11, 14), 11), 1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rs",
+    "prompt": "/// Write a function to divide two lists element wise.\nfn div_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<f64> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = div_list;\n    assert_eq!(candidate(vec![4, 5, 6], vec![1, 2, 3]), vec![4.0, 2.5, 2.0]);\n    assert_eq!(candidate(vec![3, 2], vec![1, 4]), vec![3.0, 0.5]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![1.8, 1.7142857142857142]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rs",
+    "prompt": "/// Write a function to move all the numbers to the end of the given string.\nfn move_num(test_str: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = move_num;\n    assert_eq!(candidate(String::from(\"I1love143you55three3000thousand\")), String::from(\"Iloveyouthreethousand1143553000\"));\n    assert_eq!(candidate(String::from(\"Avengers124Assemble\")), String::from(\"AvengersAssemble124\"));\n    assert_eq!(candidate(String::from(\"Its11our12path13to14see15things16do17things\")), String::from(\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfn count_Substrings(s: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Substrings;\n    assert_eq!(candidate(String::from(\"112112\")), 6);\n    assert_eq!(candidate(String::from(\"111\")), 6);\n    assert_eq!(candidate(String::from(\"1101112\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median of two sorted lists of same size.\nfn get_median(arr1: Vec<isize>, arr2: Vec<isize>, n: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_median;\n    assert_eq!(candidate(vec![1, 12, 15, 26, 38], vec![2, 13, 17, 30, 45], 5), 16.0);\n    assert_eq!(candidate(vec![2, 4, 8, 9], vec![7, 13, 19, 28], 4), 8.5);\n    assert_eq!(candidate(vec![3, 6, 14, 23, 36, 42], vec![2, 18, 27, 39, 49, 55], 6), 25.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to compute the n-th power of each number in a list.\nfn nth_nums(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = nth_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30], 3), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15], 5), vec![248832, 759375]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rs",
+    "prompt": "/// Write a python function to convert a given string to uppercase.\nfn is_upper(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_upper;\n    assert_eq!(candidate(String::from(\"person\")), String::from(\"PERSON\"));\n    assert_eq!(candidate(String::from(\"final\")), String::from(\"FINAL\"));\n    assert_eq!(candidate(String::from(\"Valid\")), String::from(\"VALID\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rs",
+    "prompt": "/// Write a python function to interchange the first and last element in a given list.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), vec![4, 2, 3, 4, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfn triangle_area(r: isize) -> Option<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(-1), None);\n    assert_eq!(candidate(0), Some(0));\n    assert_eq!(candidate(2), Some(4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfn find_First_Missing(array: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_First_Missing;\n    assert_eq!(candidate(vec![0, 1, 2, 3]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, 6, 9]), 3);\n    assert_eq!(candidate(vec![2, 3, 5, 8, 9]), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to replace all spaces in the given string with '%20'.\nfn replace_spaces(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"My Name is Dawood\")), String::from(\"My%20Name%20is%20Dawood\"));\n    assert_eq!(candidate(String::from(\"I am a Programmer\")), String::from(\"I%20am%20a%20Programmer\"));\n    assert_eq!(candidate(String::from(\"I love Coding\")), String::from(\"I%20love%20Coding\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rs",
+    "prompt": "/// Write a python function to find even numbers from a list of numbers.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![2, 4]);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 8, 0, 1]), vec![4, 6, 8, 0]);\n    assert_eq!(candidate(vec![8, 12, 15, 19]), vec![8, 12]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rs",
+    "prompt": "/// Write a python function to find smallest number in a list.\nfn smallest_num(xs: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_num;\n    assert_eq!(candidate(vec![10, 20, 1, 45, 99]), 1);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n    assert_eq!(candidate(vec![45, 46, 50, 60]), 45);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rs",
+    "prompt": "/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfn get_coordinates(test_tup: (isize, isize)) -> Vec<Vec<isize>> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_coordinates;\n    assert_eq!(candidate((3, 4)), vec![vec![2, 3], vec![2, 4], vec![2, 5], vec![3, 3], vec![3, 4], vec![3, 5], vec![4, 3], vec![4, 4], vec![4, 5]]);\n    assert_eq!(candidate((4, 5)), vec![vec![3, 4], vec![3, 5], vec![3, 6], vec![4, 4], vec![4, 5], vec![4, 6], vec![5, 4], vec![5, 5], vec![5, 6]]);\n    assert_eq!(candidate((5, 6)), vec![vec![4, 5], vec![4, 6], vec![4, 7], vec![5, 5], vec![5, 6], vec![5, 7], vec![6, 5], vec![6, 6], vec![6, 7]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfn replace_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"Jumanji The Jungle\")), String::from(\"Jumanji_The_Jungle\"));\n    assert_eq!(candidate(String::from(\"The_Avengers\")), String::from(\"The Avengers\"));\n    assert_eq!(candidate(String::from(\"Fast and Furious\")), String::from(\"Fast_and_Furious\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rs",
+    "prompt": "/// Write a python function to move all zeroes to the end of the given list.\nfn move_zero(num_list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = move_zero;\n    assert_eq!(candidate(vec![1, 0, 2, 0, 3, 4]), vec![1, 2, 3, 4, 0, 0]);\n    assert_eq!(candidate(vec![2, 3, 2, 0, 0, 4, 0, 5, 0]), vec![2, 3, 2, 4, 5, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![0, 1, 0, 1, 1]), vec![1, 1, 1, 0, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfn pair_xor_Sum(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pair_xor_Sum;\n    assert_eq!(candidate(vec![5, 9, 7, 6], 4), 47);\n    assert_eq!(candidate(vec![7, 3, 5], 3), 12);\n    assert_eq!(candidate(vec![7, 3], 2), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort the given list.\nfn heap_sort(iterable: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = heap_sort;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 9, 2, 4, 6, 8, 0]), vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 25, 58]), vec![14, 22, 25, 25, 35, 58, 65, 75, 85]);\n    assert_eq!(candidate(vec![7, 1, 9, 5]), vec![1, 5, 7, 9]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given amount has no profit and no loss\nfn noprofit_noloss(actual_cost: isize, sale_amount: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = noprofit_noloss;\n    assert_eq!(candidate(1500, 1200), false);\n    assert_eq!(candidate(100, 100), true);\n    assert_eq!(candidate(2000, 5000), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfn wind_chill(v: isize, t: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = wind_chill;\n    assert_eq!(candidate(120, 35), 40);\n    assert_eq!(candidate(40, 20), 19);\n    assert_eq!(candidate(10, 8), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rs",
+    "prompt": "/// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfn sample_nam(sample_names: Vec<String>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sample_nam;\n    assert_eq!(candidate(vec![String::from(\"sally\"), String::from(\"Dylan\"), String::from(\"rebecca\"), String::from(\"Diana\"), String::from(\"Joanne\"), String::from(\"keith\")]), 16);\n    assert_eq!(candidate(vec![String::from(\"php\"), String::from(\"res\"), String::from(\"Python\"), String::from(\"abcd\"), String::from(\"Java\"), String::from(\"aaa\")]), 10);\n    assert_eq!(candidate(vec![String::from(\"abcd\"), String::from(\"Python\"), String::from(\"abba\"), String::from(\"aba\")]), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum difference between available pairs in the given tuple list.\nfn max_difference(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_difference;\n    assert_eq!(candidate(vec![(3, 5), (1, 7), (10, 3), (1, 2)]), 7);\n    assert_eq!(candidate(vec![(4, 6), (2, 17), (9, 13), (11, 12)]), 15);\n    assert_eq!(candidate(vec![(12, 35), (21, 27), (13, 23), (41, 22)]), 23);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rs",
+    "prompt": "/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfn remove_parenthesis(items: Vec<String>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_parenthesis;\n    assert_eq!(candidate(vec![String::from(\"python (chrome)\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"string(.abc)\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"alpha(num)\")]), String::from(\"alpha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth nonagonal number.\nfn is_nonagonal(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nonagonal;\n    assert_eq!(candidate(10), 325);\n    assert_eq!(candidate(15), 750);\n    assert_eq!(candidate(18), 1089);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rs",
+    "prompt": "/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfn text_match_wordz_middle(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz_middle;\n    assert_eq!(candidate(String::from(\"pythonzabc.\")), true);\n    assert_eq!(candidate(String::from(\"zxyabc.\")), false);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rs",
+    "prompt": "/// Write a python function to reverse an array upto a given position.\nfn reverse_Array_Upto_K(input: Vec<isize>, k: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_Array_Upto_K;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 4), vec![4, 3, 2, 1, 5, 6]);\n    assert_eq!(candidate(vec![4, 5, 6, 7], 2), vec![5, 4, 6, 7]);\n    assert_eq!(candidate(vec![9, 8, 7, 6, 5], 3), vec![7, 8, 9, 6, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a list of tuples using the second value of each tuple.\nfn subject_marks(subjectmarks: Vec<(String, isize)>) -> Vec<(String, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = subject_marks;\n    assert_eq!(candidate(vec![(String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97), (String::from(\"Social sciences\"), 82)]), vec![(String::from(\"Social sciences\"), 82), (String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97)]);\n    assert_eq!(candidate(vec![(String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54), (String::from(\"Social\"), 33)]), vec![(String::from(\"Social\"), 33), (String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54)]);\n    assert_eq!(candidate(vec![(String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97), (String::from(\"Biology\"), 45)]), vec![(String::from(\"Biology\"), 45), (String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of positive numbers in a list.\nfn pos_count(list: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pos_count;\n    assert_eq!(candidate(vec![1, -2, 3, -4]), 2);\n    assert_eq!(candidate(vec![3, 4, 5, -1]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find the number of ways to partition a set of Bell numbers.\nfn bell_number(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = bell_number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(10), 115975);\n    assert_eq!(candidate(56), 6775685320645824322581483068371419745979053216268760300);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given array is monotonic or not.\nfn is_Monotonic(A: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Monotonic;\n    assert_eq!(candidate(vec![6, 5, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 3, 2]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a list contains the given sublist or not.\nfn is_sublist(l: Vec<isize>, s: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sublist;\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![4, 3]), true);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![1, 6]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the two numbers differ at one bit position only or not.\nfn differ_At_One_Bit_Pos(a: isize, b: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = differ_At_One_Bit_Pos;\n    assert_eq!(candidate(13, 9), true);\n    assert_eq!(candidate(15, 8), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(2, 3), true);\n    assert_eq!(candidate(5, 1), true);\n    assert_eq!(candidate(1, 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rs",
+    "prompt": "/// Write a function to find whether all the given lists have equal length or not.\nfn get_equal(Input: Vec<Vec<isize>>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_equal;\n    assert_eq!(candidate(vec![vec![11, 22, 33], vec![44, 55, 66]]), true);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6, 7]]), false);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a list of elements.\nfn comb_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = comb_sort;\n    assert_eq!(candidate(vec![5, 15, 37, 25, 79]), vec![5, 15, 25, 37, 79]);\n    assert_eq!(candidate(vec![41, 32, 15, 19, 22]), vec![15, 19, 22, 32, 41]);\n    assert_eq!(candidate(vec![99, 15, 13, 47]), vec![13, 15, 47, 99]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfn add_dict_to_tuple(test_tup: (isize, isize, isize), test_dict: HashMap<String, isize>) -> (isize, isize, isize, HashMap<String, isize>) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add_dict_to_tuple;\n    assert_eq!(candidate((4, 5, 6), HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])), (4, 5, 6, HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])));\n    assert_eq!(candidate((1, 2, 3), HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])), (1, 2, 3, HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])));\n    assert_eq!(candidate((8, 9, 10), HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])), (8, 9, 10, HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rs",
+    "prompt": "/// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfn maxAverageOfPath(cost: Vec<Vec<isize>>) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = maxAverageOfPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![6, 5, 4], vec![7, 3, 9]]), 5.2);\n    assert_eq!(candidate(vec![vec![2, 3, 4], vec![7, 6, 5], vec![8, 4, 10]]), 6.2);\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![8, 7, 6], vec![9, 5, 11]]), 7.2);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]), 5.8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rs",
+    "prompt": "/// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfn count_same_pair(nums1: Vec<isize>, nums2: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_same_pair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 11);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 1);\n    assert_eq!(candidate(vec![0, 1, 1, 2], vec![0, 1, 2, 2]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rs",
+    "prompt": "/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfn power_base_sum(base: isize, power: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = power_base_sum;\n    assert_eq!(candidate(2, 100), 115);\n    assert_eq!(candidate(8, 10), 37);\n    assert_eq!(candidate(8, 15), 62);\n    assert_eq!(candidate(3, 3), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rs",
+    "prompt": "/// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfn sum_list(lst1: Vec<isize>, lst2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_list;\n    assert_eq!(candidate(vec![10, 20, 30], vec![15, 25, 35]), vec![25, 45, 65]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![5, 6, 7]), vec![6, 8, 10]);\n    assert_eq!(candidate(vec![15, 20, 30], vec![15, 45, 75]), vec![30, 65, 105]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfn dif_Square(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = dif_Square;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(15), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rs",
+    "prompt": "/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfn lateralsurface_cone(r: isize, h: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cone;\n    assert_eq!(candidate(5, 12), 204.20352248333654);\n    assert_eq!(candidate(10, 15), 566.3586699569488);\n    assert_eq!(candidate(19, 17), 1521.8090132193388);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rs",
+    "prompt": "/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfn replace_specialchar(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_specialchar;\n    assert_eq!(candidate(String::from(\"Python language, Programming language.\")), String::from(\"Python:language::Programming:language:\"));\n    assert_eq!(candidate(String::from(\"a b c,d e f\")), String::from(\"a:b:c:d:e:f\"));\n    assert_eq!(candidate(String::from(\"ram reshma,ram rahim\")), String::from(\"ram:reshma:ram:rahim\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rs",
+    "prompt": "/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfn find_first_occurrence(A: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_first_occurrence;\n    assert_eq!(candidate(vec![2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5), 1);\n    assert_eq!(candidate(vec![2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5), 2);\n    assert_eq!(candidate(vec![2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rs",
+    "prompt": "/// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfn sum_Of_Subarray_Prod(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_Subarray_Prod;\n    assert_eq!(candidate(vec![1, 2, 3]), 20);\n    assert_eq!(candidate(vec![1, 2]), 5);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rs",
+    "prompt": "/// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfn toggle_middle_bits(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = toggle_middle_bits;\n    assert_eq!(candidate(9), 15);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(11), 13);\n    assert_eq!(candidate(65), 127);\n    assert_eq!(candidate(77), 115);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rs",
+    "prompt": "/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfn left_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = left_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfn check_str(string: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_str;\n    assert_eq!(candidate(String::from(\"annie\")), true);\n    assert_eq!(candidate(String::from(\"dawood\")), false);\n    assert_eq!(candidate(String::from(\"Else\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfn geometric_sum(n: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = geometric_sum;\n    assert_eq!(candidate(7), 1.9921875);\n    assert_eq!(candidate(4), 1.9375);\n    assert_eq!(candidate(8), 1.99609375);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfn find_Index(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Index;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 14);\n    assert_eq!(candidate(4), 45);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfn tuple_to_dict(test_tup: (isize, isize, isize, isize, isize, isize)) -> HashMap<isize, isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_dict;\n    assert_eq!(candidate((1, 5, 7, 10, 13, 5)), HashMap::from([(1, 5), (7, 10), (13, 5)]));\n    assert_eq!(candidate((1, 2, 3, 4, 5, 6)), HashMap::from([(1, 2), (3, 4), (5, 6)]));\n    assert_eq!(candidate((7, 8, 9, 10, 11, 12)), HashMap::from([(7, 8), (9, 10), (11, 12)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether all the characters are same or not.\nfn all_Characters_Same(s: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = all_Characters_Same;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"aaa\")), true);\n    assert_eq!(candidate(String::from(\"data\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rs",
+    "prompt": "/// Write a function to caluclate the area of a tetrahedron.\nfn area_tetrahedron(side: isize) -> f64 {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = area_tetrahedron;\n    assert_eq!(candidate(3), 15.588457268119894);\n    assert_eq!(candidate(20), 692.8203230275509);\n    assert_eq!(candidate(10), 173.20508075688772);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rs",
+    "prompt": "/// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfn rotate_right(list: Vec<isize>, m: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rotate_right;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3), vec![8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5), vec![6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rs",
+    "prompt": "/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfn divisible_by_digits(startnum: isize, endnum: isize) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = divisible_by_digits;\n    assert_eq!(candidate(1, 22), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n    assert_eq!(candidate(1, 15), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n    assert_eq!(candidate(20, 25), vec![22, 24]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rs",
+    "prompt": "/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfn sector_area(r: isize, a: isize) -> Option<f64> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sector_area;\n    assert_eq!(candidate(4, 45), Some(6.283185307179586));\n    assert_eq!(candidate(9, 45), Some(31.808625617596654));\n    assert_eq!(candidate(9, 361), None);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rs",
+    "prompt": "/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfn lcs_of_three(X: String, Y: String, Z: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = lcs_of_three;\n    assert_eq!(candidate(String::from(\"AGGT12\"), String::from(\"12TXAYB\"), String::from(\"12XBA\")), 2);\n    assert_eq!(candidate(String::from(\"Reels\"), String::from(\"Reelsfor\"), String::from(\"ReelsforReels\")), 5);\n    assert_eq!(candidate(String::from(\"abcd1e2\"), String::from(\"bc12ea\"), String::from(\"bd1ea\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to put spaces between words starting with capital letters in a given string.\nfn capital_words_spaces(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = capital_words_spaces;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"PythonProgrammingExamples\")), String::from(\"Python Programming Examples\"));\n    assert_eq!(candidate(String::from(\"GetReadyToBeCodingFreak\")), String::from(\"Get Ready To Be Coding Freak\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfn sort_numeric_strings(nums_str: Vec<String>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numeric_strings;\n    assert_eq!(candidate(vec![String::from(\"4\"), String::from(\"12\"), String::from(\"45\"), String::from(\"7\"), String::from(\"0\"), String::from(\"100\"), String::from(\"200\"), String::from(\"-12\"), String::from(\"-500\")]), vec![-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n    assert_eq!(candidate(vec![String::from(\"2\"), String::from(\"3\"), String::from(\"8\"), String::from(\"4\"), String::from(\"7\"), String::from(\"9\"), String::from(\"8\"), String::from(\"2\"), String::from(\"6\"), String::from(\"5\"), String::from(\"1\"), String::from(\"6\"), String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"6\"), String::from(\"9\"), String::from(\"1\"), String::from(\"2\")]), vec![1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n    assert_eq!(candidate(vec![String::from(\"1\"), String::from(\"3\"), String::from(\"5\"), String::from(\"7\"), String::from(\"1\"), String::from(\"3\"), String::from(\"13\"), String::from(\"15\"), String::from(\"17\"), String::from(\"5\"), String::from(\"7 \"), String::from(\"9\"), String::from(\"1\"), String::from(\"11\")]), vec![1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether it follows the sequence given in the patterns array.\nfn is_samepatterns(colors: Vec<String>, patterns: Vec<String>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_samepatterns;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"green\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\")]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to add the given tuple to the given list.\nfn add_tuple(test_list: Vec<isize>, test_tup: (isize, isize)) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = add_tuple;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), vec![5, 6, 7, 9, 10]);\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), vec![6, 7, 8, 10, 11]);\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), vec![7, 8, 9, 11, 12]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfn check_min_heap(arr: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_min_heap;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 10, 15]), true);\n    assert_eq!(candidate(vec![2, 10, 4, 5, 3, 15]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfn jacobsthal_num(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = jacobsthal_num;\n    assert_eq!(candidate(5), 11);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 5);\n    assert_eq!(candidate(13), 2731);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rs",
+    "prompt": "/// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfn min_k(test_list: Vec<(String, isize)>, K: isize) -> Vec<(String, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = min_k;\n    assert_eq!(candidate(vec![(String::from(\"Manjeet\"), 10), (String::from(\"Akshat\"), 4), (String::from(\"Akash\"), 2), (String::from(\"Nikhil\"), 8)], 2), vec![(String::from(\"Akash\"), 2), (String::from(\"Akshat\"), 4)]);\n    assert_eq!(candidate(vec![(String::from(\"Sanjeev\"), 11), (String::from(\"Angat\"), 5), (String::from(\"Akash\"), 3), (String::from(\"Nepin\"), 9)], 3), vec![(String::from(\"Akash\"), 3), (String::from(\"Angat\"), 5), (String::from(\"Nepin\"), 9)]);\n    assert_eq!(candidate(vec![(String::from(\"tanmay\"), 14), (String::from(\"Amer\"), 11), (String::from(\"Ayesha\"), 9), (String::from(\"SKD\"), 16)], 1), vec![(String::from(\"Ayesha\"), 9)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfn text_match_zero_one(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_zero_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"dsabbbba\")), true);\n    assert_eq!(candidate(String::from(\"asbbbba\")), false);\n    assert_eq!(candidate(String::from(\"abaaa\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rs",
+    "prompt": "/// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfn count_reverse_pairs(test_list: Vec<String>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_reverse_pairs;\n    assert_eq!(candidate(vec![String::from(\"julia\"), String::from(\"best\"), String::from(\"tseb\"), String::from(\"for\"), String::from(\"ailuj\")]), 2);\n    assert_eq!(candidate(vec![String::from(\"geeks\"), String::from(\"best\"), String::from(\"for\"), String::from(\"skeeg\")]), 1);\n    assert_eq!(candidate(vec![String::from(\"makes\"), String::from(\"best\"), String::from(\"sekam\"), String::from(\"for\"), String::from(\"rof\")]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfn is_decimal(num: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_decimal;\n    assert_eq!(candidate(String::from(\"123.11\")), true);\n    assert_eq!(candidate(String::from(\"e666.86\")), false);\n    assert_eq!(candidate(String::from(\"3.124587\")), false);\n    assert_eq!(candidate(String::from(\"1.11\")), true);\n    assert_eq!(candidate(String::from(\"1.1.11\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfn find_tuples(test_list: Vec<(isize, isize, isize)>, K: isize) -> Vec<(isize, isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_tuples;\n    assert_eq!(candidate(vec![(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6), vec![(6, 24, 12)]);\n    assert_eq!(candidate(vec![(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5), vec![(5, 25, 30)]);\n    assert_eq!(candidate(vec![(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4), vec![(8, 16, 4)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfn unique_Element(arr: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_Element;\n    assert_eq!(candidate(vec![1, 1, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfn check_monthnumber_number(monthnum3: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumber_number;\n    assert_eq!(candidate(6), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(12), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfn find_min_diff(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_min_diff;\n    assert_eq!(candidate(vec![1, 5, 3, 19, 18, 25], 6), 1);\n    assert_eq!(candidate(vec![4, 3, 2, 6], 4), 1);\n    assert_eq!(candidate(vec![30, 5, 20, 9], 4), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rs",
+    "prompt": "/// Write a python function to count number of digits in a given string.\nfn number_ctr(str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = number_ctr;\n    assert_eq!(candidate(String::from(\"program2bedone\")), 1);\n    assert_eq!(candidate(String::from(\"3wonders\")), 1);\n    assert_eq!(candidate(String::from(\"123\")), 3);\n    assert_eq!(candidate(String::from(\"3wond-1ers2\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rs",
+    "prompt": "/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfn is_polite(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_polite;\n    assert_eq!(candidate(7), 11);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(9), 13);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rs",
+    "prompt": "/// Write a function to return a list of all pairs of consecutive items in a given list.\nfn pair_wise(l1: Vec<isize>) -> Vec<(isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = pair_wise;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 3, 4, 4, 5]), vec![(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), vec![(1, 5), (5, 7), (7, 9), (9, 10)]);\n    assert_eq!(candidate(vec![5, 1, 9, 7, 10]), vec![(5, 1), (1, 9), (9, 7), (7, 10)]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfn get_pairs_count(arr: Vec<isize>, sum: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_pairs_count;\n    assert_eq!(candidate(vec![1, 1, 1, 1], 2), 6);\n    assert_eq!(candidate(vec![1, 5, 7, -1, 5], 6), 3);\n    assert_eq!(candidate(vec![1, -2, 3], 1), 1);\n    assert_eq!(candidate(vec![-1, -2, 3], -3), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rs",
+    "prompt": "/// Write a python function to get the difference between two lists.\nfn Diff(li1: Vec<isize>, li2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Diff;\n    assert_eq!(candidate(vec![10, 15, 20, 25, 30, 35, 40], vec![25, 40, 35]), vec![10, 20, 30, 15]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 1]), vec![2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![6, 7, 1]), vec![2, 3, 6, 7]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfn odd_num_sum(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_num_sum;\n    assert_eq!(candidate(2), 82);\n    assert_eq!(candidate(3), 707);\n    assert_eq!(candidate(4), 3108);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfn check_expression(exp: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_expression;\n    assert_eq!(candidate(String::from(\"{()}[{}]\")), true);\n    assert_eq!(candidate(String::from(\"{()}[{]\")), false);\n    assert_eq!(candidate(String::from(\"{()}[{}][]({})\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all the words with k length in the given string.\nfn remove_length(test_str: String, K: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_length;\n    assert_eq!(candidate(String::from(\"The person is most value tet\"), 3), String::from(\"person is most value\"));\n    assert_eq!(candidate(String::from(\"If you told me about this ok\"), 4), String::from(\"If you me about ok\"));\n    assert_eq!(candidate(String::from(\"Forces of darkeness is come into the play\"), 4), String::from(\"Forces of darkeness is the\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rs",
+    "prompt": "/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfn occurance_substring(text: String, pattern: String) -> Option<(String, isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = occurance_substring;\n    assert_eq!(candidate(String::from(\"python programming, python language\"), String::from(\"python\")), Some((String::from(\"python\"), 0, 6)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"programming\")), Some((String::from(\"programming\"), 7, 18)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"language\")), Some((String::from(\"language\"), 31, 39)));\n    assert_eq!(candidate(String::from(\"c++ programming, c++ language\"), String::from(\"python\")), None);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether every odd index contains odd numbers of a given list.\nfn odd_position(nums: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_position;\n    assert_eq!(candidate(vec![2, 1, 4, 3, 6, 7, 6, 3]), true);\n    assert_eq!(candidate(vec![4, 1, 2]), true);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rs",
+    "prompt": "/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfn count_vowels(test_str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_vowels;\n    assert_eq!(candidate(String::from(\"bestinstareels\")), 7);\n    assert_eq!(candidate(String::from(\"partofthejourneyistheend\")), 12);\n    assert_eq!(candidate(String::from(\"amazonprime\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of non-repeated elements in a given list.\nfn find_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_sum;\n    assert_eq!(candidate(vec![1, 2, 3, 1, 1, 4, 5, 6]), 21);\n    assert_eq!(candidate(vec![1, 10, 9, 4, 2, 10, 10, 45, 4]), 71);\n    assert_eq!(candidate(vec![12, 10, 9, 45, 2, 10, 10, 45, 10]), 78);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rs",
+    "prompt": "/// Write a python function to find whether a number is divisible by 11.\nfn is_Diff(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Diff;\n    assert_eq!(candidate(12345), false);\n    assert_eq!(candidate(1212112), true);\n    assert_eq!(candidate(1212), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rs",
+    "prompt": "/// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfn find_combinations(test_list: Vec<(isize, isize)>) -> Vec<(isize, isize)> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_combinations;\n    assert_eq!(candidate(vec![(2, 4), (6, 7), (5, 1), (6, 10)]), vec![(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]);\n    assert_eq!(candidate(vec![(3, 5), (7, 8), (6, 2), (7, 11)]), vec![(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]);\n    assert_eq!(candidate(vec![(4, 6), (8, 9), (7, 3), (8, 12)]), vec![(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfn count_divisors(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_divisors;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(100), false);\n    assert_eq!(candidate(125), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfn odd_length_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_length_sum;\n    assert_eq!(candidate(vec![1, 2, 4]), 14);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), 15);\n    assert_eq!(candidate(vec![1, 7]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rs",
+    "prompt": "/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfn rgb_to_hsv(r: isize, g: isize, b: isize) -> Vec<f64> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = rgb_to_hsv;\n    assert_eq!(candidate(255, 255, 255), vec![0.0, 0.0, 100.0]);\n    assert_eq!(candidate(0, 215, 0), vec![120.0, 100.0, 84.31372549019608]);\n    assert_eq!(candidate(10, 215, 110), vec![149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to find the product of first even and odd number of a given list.\nfn mul_even_odd(list1: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = mul_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rs",
+    "prompt": "/// Write a function to convert tuple string to integer tuple.\nfn tuple_str_int(test_str: String) -> (isize, isize, isize) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_str_int;\n    assert_eq!(candidate(String::from(\"(7, 8, 9)\")), (7, 8, 9));\n    assert_eq!(candidate(String::from(\"(1, 2, 3)\")), (1, 2, 3));\n    assert_eq!(candidate(String::from(\"(4, 5, 6)\")), (4, 5, 6));\n    assert_eq!(candidate(String::from(\"(7, 81, 19)\")), (7, 81, 19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rs",
+    "prompt": "/// Write a function to locate the right insertion point for a specified value in sorted order.\nfn right_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = right_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an a followed by three 'b'.\nfn text_match_three(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"caacabbbba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to create a new tuple from the given string and list.\nfn new_tuple(test_list: Vec<String>, test_str: String) -> (String, String, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = new_tuple;\n    assert_eq!(candidate(vec![String::from(\"WEB\"), String::from(\"is\")], String::from(\"best\")), (String::from(\"WEB\"), String::from(\"is\"), String::from(\"best\")));\n    assert_eq!(candidate(vec![String::from(\"We\"), String::from(\"are\")], String::from(\"Developers\")), (String::from(\"We\"), String::from(\"are\"), String::from(\"Developers\")));\n    assert_eq!(candidate(vec![String::from(\"Part\"), String::from(\"is\")], String::from(\"Wrong\")), (String::from(\"Part\"), String::from(\"is\"), String::from(\"Wrong\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether every even index contains even numbers of a given list.\nfn even_position(nums: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = even_position;\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n    assert_eq!(candidate(vec![2, 1, 4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of lists in a given number of lists.\nfn count_list(input_list: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_list;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), 4);\n    assert_eq!(candidate(vec![vec![1, 2], vec![2, 3], vec![4, 5]]), 3);\n    assert_eq!(candidate(vec![vec![1, 0], vec![2, 0]]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the last position of an element in a sorted array.\nfn last(arr: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = last;\n    assert_eq!(candidate(vec![1, 2, 3], 1), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, 4], 1), 2);\n    assert_eq!(candidate(vec![2, 3, 2, 3, 6, 8, 9], 3), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfn text_starta_endb(text: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = text_starta_endb;\n    assert_eq!(candidate(String::from(\"aabbbb\")), true);\n    assert_eq!(candidate(String::from(\"aabAbbbc\")), false);\n    assert_eq!(candidate(String::from(\"accddbbjjj\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write function to find the sum of all items in the given dictionary.\nfn return_sum(dict: HashMap<String, isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = return_sum;\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 100), (String::from(\"b\"), 200), (String::from(\"c\"), 300)])), 600);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 25), (String::from(\"b\"), 18), (String::from(\"c\"), 45)])), 88);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 36), (String::from(\"b\"), 39), (String::from(\"c\"), 49)])), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfn sum_in_range(l: isize, r: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_in_range;\n    assert_eq!(candidate(2, 5), 8);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 13), 40);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the sum of an array.\nfn _sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = _sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![15, 12, 13, 10]), 50);\n    assert_eq!(candidate(vec![0, 1, 2]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rs",
+    "prompt": "/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfn left_rotate(n: isize, d: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = left_rotate;\n    assert_eq!(candidate(16, 2), 64);\n    assert_eq!(candidate(10, 2), 40);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(1, 3), 8);\n    assert_eq!(candidate(5, 3), 40);\n    assert_eq!(candidate(29, 3), 232);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rs",
+    "prompt": "/// Write a python function to check whether the length of the word is odd or not.\nfn word_len(s: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = word_len;\n    assert_eq!(candidate(String::from(\"Hadoop\")), false);\n    assert_eq!(candidate(String::from(\"great\")), true);\n    assert_eq!(candidate(String::from(\"structure\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all whitespaces from a string.\nfn remove_all_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_all_spaces;\n    assert_eq!(candidate(String::from(\"python  program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"python   programming    language\")), String::from(\"pythonprogramminglanguage\"));\n    assert_eq!(candidate(String::from(\"python                     program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"   python                     program\")), String::from(\"pythonprogram\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of equal numbers from three given integers.\nfn test_three_equal(x: isize, y: isize, z: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = test_three_equal;\n    assert_eq!(candidate(1, 1, 1), 3);\n    assert_eq!(candidate(-1, -2, -3), 0);\n    assert_eq!(candidate(1, 2, 2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rs",
+    "prompt": "/// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfn count_rotation(arr: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = count_rotation;\n    assert_eq!(candidate(vec![3, 2, 1]), 1);\n    assert_eq!(candidate(vec![4, 5, 1, 2, 3]), 2);\n    assert_eq!(candidate(vec![7, 8, 9, 1, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 2, 3]), 0);\n    assert_eq!(candidate(vec![1, 3, 2]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfn is_perfect_square(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_perfect_square;\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(36), true);\n    assert_eq!(candidate(14), false);\n    assert_eq!(candidate(196), true);\n    assert_eq!(candidate(125), false);\n    assert_eq!(candidate(15625), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the product of numbers in a list is even or not.\nfn is_product_even(arr: Vec<isize>) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_product_even;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 4]), true);\n    assert_eq!(candidate(vec![1, 1]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rs",
+    "prompt": "/// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfn max_sum_list(lists: Vec<Vec<isize>>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum_list;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![10, 11, 12], vec![7, 8, 9]]), vec![10, 11, 12]);\n    assert_eq!(candidate(vec![vec![3, 2, 1], vec![6, 5, 4], vec![12, 11, 10]]), vec![12, 11, 10]);\n    assert_eq!(candidate(vec![vec![2, 3, 1]]), vec![2, 3, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rs",
+    "prompt": "/// Write a function to find maximum run of uppercase characters in the given string.\nfn max_run_uppercase(test_str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = max_run_uppercase;\n    assert_eq!(candidate(String::from(\"GeMKSForGERksISBESt\")), 5);\n    assert_eq!(candidate(String::from(\"PrECIOusMOVemENTSYT\")), 6);\n    assert_eq!(candidate(String::from(\"GooGLEFluTTER\")), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the first odd number in a given list of numbers.\nfn first_odd(nums: Vec<isize>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = first_odd;\n    assert_eq!(candidate(vec![1, 3, 5]), 1);\n    assert_eq!(candidate(vec![2, 4, 1, 3]), 1);\n    assert_eq!(candidate(vec![8, 9, 1]), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given tuples contain the k or not.\nfn check_K(test_tup: Vec<isize>, K: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_K;\n    assert_eq!(candidate(vec![10, 4, 5, 6, 8], 6), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 7), false);\n    assert_eq!(candidate(vec![7, 8, 9, 44, 11, 12], 11), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rs",
+    "prompt": "/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfn check_smaller(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = check_smaller;\n    assert_eq!(candidate((1, 2, 3), (2, 3, 4)), false);\n    assert_eq!(candidate((4, 5, 6), (3, 4, 5)), true);\n    assert_eq!(candidate((11, 12, 13), (10, 11, 12)), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth tetrahedral number.\nfn tetrahedral_number(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = tetrahedral_number;\n    assert_eq!(candidate(5), 35);\n    assert_eq!(candidate(6), 56);\n    assert_eq!(candidate(7), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfn get_Char(strr: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = get_Char;\n    assert_eq!(candidate(String::from(\"abc\")), String::from(\"f\"));\n    assert_eq!(candidate(String::from(\"gfg\")), String::from(\"t\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"c\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth number in the newman conway sequence.\nfn sequence(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = sequence;\n    assert_eq!(candidate(10), 6);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(3), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find nth centered hexagonal number.\nfn centered_hexagonal_number(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = centered_hexagonal_number;\n    assert_eq!(candidate(10), 271);\n    assert_eq!(candidate(2), 7);\n    assert_eq!(candidate(9), 217);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to merge three dictionaries into a single dictionary.\nfn merge_dictionaries_three(dict1: HashMap<String, String>, dict2: HashMap<String, String>, dict3: HashMap<String, String>) -> HashMap<String, String> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = merge_dictionaries_three;\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"O\"), String::from(\"Orange\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"B\"), String::from(\"Black\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"O\"), String::from(\"Orange\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))])), HashMap::from([(String::from(\"W\"), String::from(\"White\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\")), (String::from(\"W\"), String::from(\"White\"))]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfn freq_count(list1: Vec<isize>) -> HashMap<isize, isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = freq_count;\n    assert_eq!(candidate(vec![10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]), HashMap::from([(10, 4), (20, 4), (40, 2), (50, 2), (30, 1)]));\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]), HashMap::from([(1, 3), (2, 2), (3, 3), (4, 3)]));\n    assert_eq!(candidate(vec![5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]), HashMap::from([(10, 1), (5, 3), (6, 2), (7, 2), (4, 2), (9, 2)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the closest smaller number than n.\nfn closest_num(N: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_num;\n    assert_eq!(candidate(11), 10);\n    assert_eq!(candidate(7), 6);\n    assert_eq!(candidate(12), 11);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to find squares of individual elements in a list.\nfn square_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = square_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![100, 400, 900]);\n    assert_eq!(candidate(vec![12, 15]), vec![144, 225]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the length of the longest word.\nfn len_log(list1: Vec<String>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = len_log;\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"PHP\"), String::from(\"bigdata\")]), 7);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]), 3);\n    assert_eq!(candidate(vec![String::from(\"small\"), String::from(\"big\"), String::from(\"tall\")]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rs",
+    "prompt": "/// Write a function to check if a string is present as a substring in a given list of string values.\nfn find_substring(str1: Vec<String>, sub_str: String) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_substring;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ack\")), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"abc\")), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ange\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is undulating or not.\nfn is_undulating(n: isize) -> bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = is_undulating;\n    assert_eq!(candidate(1212121), true);\n    assert_eq!(candidate(1991), false);\n    assert_eq!(candidate(121), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the value of 'a' to the power 'b'.\nfn power(a: isize, b: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = power;\n    assert_eq!(candidate(3, 4), 81);\n    assert_eq!(candidate(2, 3), 8);\n    assert_eq!(candidate(5, 5), 3125);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rs",
+    "prompt": "/// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfn index_minimum(test_list: Vec<(String, isize)>) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = index_minimum;\n    assert_eq!(candidate(vec![(String::from(\"Rash\"), 143), (String::from(\"Manjeet\"), 200), (String::from(\"Varsha\"), 100)]), String::from(\"Varsha\"));\n    assert_eq!(candidate(vec![(String::from(\"Yash\"), 185), (String::from(\"Dawood\"), 125), (String::from(\"Sanya\"), 175)]), String::from(\"Dawood\"));\n    assert_eq!(candidate(vec![(String::from(\"Sai\"), 345), (String::from(\"Salman\"), 145), (String::from(\"Ayesha\"), 96)]), String::from(\"Ayesha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the length of the smallest list in a list of lists.\nfn Find_Min_Length(lst: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = Find_Min_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 2]]), 1);\n    assert_eq!(candidate(vec![vec![1, 2], vec![1, 2, 3], vec![1, 2, 3, 4]]), 2);\n    assert_eq!(candidate(vec![vec![3, 3, 3], vec![4, 4, 4, 4]]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the number of divisors of a given integer.\nfn divisor(n: isize) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = divisor;\n    assert_eq!(candidate(15), 4);\n    assert_eq!(candidate(12), 6);\n    assert_eq!(candidate(9), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfn frequency_lists(list1: Vec<Vec<isize>>) -> HashMap<isize, isize> {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = frequency_lists;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 2], vec![4, 5, 6, 2], vec![7, 8, 9, 5]]), HashMap::from([(1, 1), (2, 3), (3, 1), (4, 1), (5, 2), (6, 1), (7, 1), (8, 1), (9, 1)]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]]), HashMap::from([(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1), (12, 1)]));\n    assert_eq!(candidate(vec![vec![20, 30, 40, 17], vec![18, 16, 14, 13], vec![10, 20, 30, 40]]), HashMap::from([(20, 2), (30, 2), (40, 2), (17, 1), (18, 1), (16, 1), (14, 1), (13, 1), (10, 1)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfn decimal_to_binary(n: isize) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(8), String::from(\"1000\"));\n    assert_eq!(candidate(18), String::from(\"10010\"));\n    assert_eq!(candidate(7), String::from(\"111\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rs",
+    "prompt": "/// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfn find_Rotations(str: String) -> isize {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Rotations;\n    assert_eq!(candidate(String::from(\"aaaa\")), 1);\n    assert_eq!(candidate(String::from(\"ab\")), 2);\n    assert_eq!(candidate(String::from(\"abc\")), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-rs-reworded.json
+++ b/prompts/mbpp-rs-reworded.json
@@ -1,3156 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "rs",
-    "prompt": "/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfn lps(str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = lps;\n    assert_eq!(candidate(String::from(\"TENS FOR TENS\")), 5);\n    assert_eq!(candidate(String::from(\"CARDIO FOR CARDS\")), 7);\n    assert_eq!(candidate(String::from(\"PART OF THE JOURNEY IS PART\")), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all whitespaces from the given string.\nfn remove_whitespaces(text1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_whitespaces;\n    assert_eq!(candidate(String::from(\" Google    Flutter \")), String::from(\"GoogleFlutter\"));\n    assert_eq!(candidate(String::from(\" Google    Dart \")), String::from(\"GoogleDart\"));\n    assert_eq!(candidate(String::from(\" iOS    Swift \")), String::from(\"iOSSwift\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a specified vector is sorted or not.\nfn issort_list(list1: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = issort_list;\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 16, 17]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 20, 17]), false);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 15, 14, 20]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "rs",
-    "prompt": "/// Write a function to count bidirectional tuple pairs.\nfn count_bidirectional(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_bidirectional;\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]), 3);\n    assert_eq!(candidate(vec![(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]), 2);\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "rs",
-    "prompt": "/// Write a function to find the surface area of a cube of a given size.\nfn surfacearea_cube(l: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cube;\n    assert_eq!(candidate(5), 150);\n    assert_eq!(candidate(3), 54);\n    assert_eq!(candidate(10), 600);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "rs",
     "prompt": "/// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfn next_smallest_palindrome(num: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = next_smallest_palindrome;\n    assert_eq!(candidate(99), 101);\n    assert_eq!(candidate(1221), 1331);\n    assert_eq!(candidate(120), 121);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the cube sum of first n even natural numbers.\nfn cube_Sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = cube_Sum;\n    assert_eq!(candidate(2), 72);\n    assert_eq!(candidate(3), 288);\n    assert_eq!(candidate(4), 800);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of xor of all pairs of numbers in the given vector.\nfn pair_xor_Sum(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pair_xor_Sum;\n    assert_eq!(candidate(vec![5, 9, 7, 6], 4), 47);\n    assert_eq!(candidate(vec![7, 3, 5], 3), 12);\n    assert_eq!(candidate(vec![7, 3], 2), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\nfn check_min_heap(arr: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_min_heap;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 10, 15]), true);\n    assert_eq!(candidate(vec![2, 10, 4, 5, 3, 15]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the first digit of a given number.\nfn first_Digit(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = first_Digit;\n    assert_eq!(candidate(123), 1);\n    assert_eq!(candidate(456), 4);\n    assert_eq!(candidate(12), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the first non-repeated character in a given string.\nfn first_non_repeating_character(str1: String) -> Option<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = first_non_repeating_character;\n    assert_eq!(candidate(String::from(\"abcabc\")), None);\n    assert_eq!(candidate(String::from(\"abc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"ababc\")), Some(String::from(\"c\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "rs",
-    "prompt": "/// Write a function to convert degrees to radians.\nfn radian_degree(degree: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = radian_degree;\n    assert_eq!(candidate(90), 1.5707963267948966);\n    assert_eq!(candidate(60), 1.0471975511965976);\n    assert_eq!(candidate(120), 2.0943951023931953);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum product subvector of the given vector.\nfn max_subarray_product(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_subarray_product;\n    assert_eq!(candidate(vec![1, -2, -3, 0, 7, -8, -2]), 112);\n    assert_eq!(candidate(vec![6, -3, -10, 0, 2]), 180);\n    assert_eq!(candidate(vec![-2, -40, 0, -2, -3]), 80);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find smallest number in a vector.\nfn smallest_num(xs: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = smallest_num;\n    assert_eq!(candidate(vec![10, 20, 1, 45, 99]), 1);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n    assert_eq!(candidate(vec![45, 46, 50, 60]), 45);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rsthon-exercises/re/rsthon-re-exercise-3.php\nfn text_match_zero_one(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_zero_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"dsabbbba\")), true);\n    assert_eq!(candidate(String::from(\"asbbbba\")), false);\n    assert_eq!(candidate(String::from(\"abaaa\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find nth bell number.\nfn bell_Number(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = bell_Number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 15);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "rs",
-    "prompt": "/// Write a function to find cubes of individual elements in a vector.\nfn cube_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = cube_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15]), vec![1728, 3375]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the last digit in factorial of a given number.\nfn last_Digit_Factorial(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = last_Digit_Factorial;\n    assert_eq!(candidate(4), 4);\n    assert_eq!(candidate(21), 0);\n    assert_eq!(candidate(30), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find even numbers from a vector of numbers.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![2, 4]);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 8, 0, 1]), vec![4, 6, 8, 0]);\n    assert_eq!(candidate(vec![8, 12, 15, 19]), vec![8, 12]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given integer is a prime number.\nfn prime_num(num: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = prime_num;\n    assert_eq!(candidate(13), true);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(-1010), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to find tuples which have all elements divisible by k from the given vector of tuples.\nfn find_tuples(test_list: Vec<(isize, isize, isize)>, K: isize) -> Vec<(isize, isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_tuples;\n    assert_eq!(candidate(vec![(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6), vec![(6, 24, 12)]);\n    assert_eq!(candidate(vec![(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5), vec![(5, 25, 30)]);\n    assert_eq!(candidate(vec![(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4), vec![(8, 16, 4)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "rs",
-    "prompt": "/// Write a function to caluclate the area of a tetrahedron.\nfn area_tetrahedron(side: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = area_tetrahedron;\n    assert_eq!(candidate(3), 15.588457268119894);\n    assert_eq!(candidate(20), 692.8203230275509);\n    assert_eq!(candidate(10), 173.20508075688772);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given number is even or not.\nfn is_Even(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Even;\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(2), true);\n    assert_eq!(candidate(3), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of positive numbers in a vector.\nfn pos_count(list: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pos_count;\n    assert_eq!(candidate(vec![1, -2, 3, -4]), 2);\n    assert_eq!(candidate(vec![3, 4, 5, -1]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "rs",
-    "prompt": "/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfn get_ludic(n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_ludic;\n    assert_eq!(candidate(10), vec![1, 2, 3, 5, 7]);\n    assert_eq!(candidate(25), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n    assert_eq!(candidate(45), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfn find_Index(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Index;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 14);\n    assert_eq!(candidate(4), 45);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to reverse a vector upto a given position.\nfn reverse_Array_Upto_K(input: Vec<isize>, k: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_Array_Upto_K;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 4), vec![4, 3, 2, 1, 5, 6]);\n    assert_eq!(candidate(vec![4, 5, 6, 7], 2), vec![5, 4, 6, 7]);\n    assert_eq!(candidate(vec![9, 8, 7, 6, 5], 3), vec![7, 8, 9, 6, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a vector of tuples using the second value of each tuple.\nfn subject_marks(subjectmarks: Vec<(String, isize)>) -> Vec<(String, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = subject_marks;\n    assert_eq!(candidate(vec![(String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97), (String::from(\"Social sciences\"), 82)]), vec![(String::from(\"Social sciences\"), 82), (String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97)]);\n    assert_eq!(candidate(vec![(String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54), (String::from(\"Social\"), 33)]), vec![(String::from(\"Social\"), 33), (String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54)]);\n    assert_eq!(candidate(vec![(String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97), (String::from(\"Biology\"), 45)]), vec![(String::from(\"Biology\"), 45), (String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "rs",
-    "prompt": "/// Write a function to remove characters from the first string which are present in the second string.\nfn remove_dirty_chars(string: String, second_string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_dirty_chars;\n    assert_eq!(candidate(String::from(\"probasscurve\"), String::from(\"pros\")), String::from(\"bacuve\"));\n    assert_eq!(candidate(String::from(\"digitalindia\"), String::from(\"talent\")), String::from(\"digiidi\"));\n    assert_eq!(candidate(String::from(\"exoticmiles\"), String::from(\"toxic\")), String::from(\"emles\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "rs",
-    "prompt": "/// Write a function to find the item with maximum frequency in a given vector.\nfn max_occurrences(nums: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_occurrences;\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]), 2);\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]), 8);\n    assert_eq!(candidate(vec![10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]), 20);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfn is_decimal(num: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_decimal;\n    assert_eq!(candidate(String::from(\"123.11\")), true);\n    assert_eq!(candidate(String::from(\"e666.86\")), false);\n    assert_eq!(candidate(String::from(\"3.124587\")), false);\n    assert_eq!(candidate(String::from(\"1.11\")), true);\n    assert_eq!(candidate(String::from(\"1.1.11\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function that takes in a HashMap and integer n and filters the HashMap to only include entries with values greater than or equal to n.\nfn dict_filter(dict: HashMap<String, isize>, n: isize) -> HashMap<String, isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = dict_filter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 170), HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 180), HashMap::from([(String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 190), HashMap::from([(String::from(\"Pierre Cox\"), 190)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of even numbers at even positions of a vector.\nfn sum_even_and_even_index(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_even_and_even_index;\n    assert_eq!(candidate(vec![5, 6, 12, 1, 18, 8]), 30);\n    assert_eq!(candidate(vec![3, 20, 17, 9, 2, 10, 18, 13, 6, 18]), 26);\n    assert_eq!(candidate(vec![5, 6, 12, 1]), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the sum of the largest contiguous subvector in the given vector.\nfn max_sub_array_sum(a: Vec<isize>, size: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum;\n    assert_eq!(candidate(vec![-2, -3, 4, -1, -2, 1, 5, -3], 8), 7);\n    assert_eq!(candidate(vec![-3, -4, 5, -2, -3, 2, 6, -4], 8), 8);\n    assert_eq!(candidate(vec![-4, -5, 6, -3, -4, 3, 7, -5], 8), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "rs",
-    "prompt": "/// Write a function to find the intersection of two vectors.\nfn intersection_array(array_nums1: Vec<isize>, array_nums2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = intersection_array;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![1, 2, 4, 8, 9]), vec![1, 2, 8, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![3, 5, 7, 9]), vec![3, 5, 7, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![10, 20, 30, 40]), vec![10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "rs",
-    "prompt": "/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfn find_literals(text: String, pattern: String) -> (String, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_literals;\n    assert_eq!(candidate(String::from(\"The quick brown fox jumps over the lazy dog.\"), String::from(\"fox\")), (String::from(\"fox\"), 16, 19));\n    assert_eq!(candidate(String::from(\"Its been a very crazy procedure right\"), String::from(\"crazy\")), (String::from(\"crazy\"), 16, 21));\n    assert_eq!(candidate(String::from(\"Hardest choices required strongest will\"), String::from(\"will\")), (String::from(\"will\"), 35, 39));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the volume of a triangular prism.\nfn find_Volume(l: isize, b: isize, h: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Volume;\n    assert_eq!(candidate(10, 8, 6), 240);\n    assert_eq!(candidate(3, 2, 2), 6);\n    assert_eq!(candidate(1, 2, 1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfn wind_chill(v: isize, t: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = wind_chill;\n    assert_eq!(candidate(120, 35), 40);\n    assert_eq!(candidate(40, 20), 19);\n    assert_eq!(candidate(10, 8), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "rs",
-    "prompt": "/// Write a function to find the ascii value of a character.\nfn ascii_value(k: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = ascii_value;\n    assert_eq!(candidate(String::from(\"A\")), 65);\n    assert_eq!(candidate(String::from(\"R\")), 82);\n    assert_eq!(candidate(String::from(\"S\")), 83);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether all the characters are same or not.\nfn all_Characters_Same(s: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = all_Characters_Same;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"aaa\")), true);\n    assert_eq!(candidate(String::from(\"data\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "rs",
-    "prompt": "/// Write a function to move all the numbers to the end of the given string.\nfn move_num(test_str: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = move_num;\n    assert_eq!(candidate(String::from(\"I1love143you55three3000thousand\")), String::from(\"Iloveyouthreethousand1143553000\"));\n    assert_eq!(candidate(String::from(\"Avengers124Assemble\")), String::from(\"AvengersAssemble124\"));\n    assert_eq!(candidate(String::from(\"Its11our12path13to14see15things16do17things\")), String::from(\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the length of the word is odd or not.\nfn word_len(s: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = word_len;\n    assert_eq!(candidate(String::from(\"Hadoop\")), false);\n    assert_eq!(candidate(String::from(\"great\")), true);\n    assert_eq!(candidate(String::from(\"structure\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\nfn insert_element(list: Vec<String>, element: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = insert_element;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Black\")], String::from(\"c\")), vec![String::from(\"c\"), String::from(\"Red\"), String::from(\"c\"), String::from(\"Green\"), String::from(\"c\"), String::from(\"Black\")]);\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"java\")], String::from(\"program\")), vec![String::from(\"program\"), String::from(\"python\"), String::from(\"program\"), String::from(\"java\")]);\n    assert_eq!(candidate(vec![String::from(\"happy\"), String::from(\"sad\")], String::from(\"laugh\")), vec![String::from(\"laugh\"), String::from(\"happy\"), String::from(\"laugh\"), String::from(\"sad\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "rs",
-    "prompt": "/// Write a function to remove lowercase substrings from a given string.\nfn remove_lowercase(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_lowercase;\n    assert_eq!(candidate(String::from(\"PYTHon\")), String::from(\"PYTH\"));\n    assert_eq!(candidate(String::from(\"FInD\")), String::from(\"FID\"));\n    assert_eq!(candidate(String::from(\"STRinG\")), String::from(\"STRG\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfn count_Set_Bits(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Set_Bits;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 1);\n    assert_eq!(candidate(6), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "rs",
-    "prompt": "/// Write a function to extract only the rear index element of each string in the given tuple.\nfn extract_rear(test_tuple: (String, String, String)) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_rear;\n    assert_eq!(candidate((String::from(\"Mers\"), String::from(\"for\"), String::from(\"Vers\"))), vec![String::from(\"s\"), String::from(\"r\"), String::from(\"s\")]);\n    assert_eq!(candidate((String::from(\"Avenge\"), String::from(\"for\"), String::from(\"People\"))), vec![String::from(\"e\"), String::from(\"r\"), String::from(\"e\")]);\n    assert_eq!(candidate((String::from(\"Gotta\"), String::from(\"get\"), String::from(\"go\"))), vec![String::from(\"a\"), String::from(\"t\"), String::from(\"o\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of occurence of the string 'std' in a given string.\nfn count_occurance(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_occurance;\n    assert_eq!(candidate(String::from(\"letstdlenstdporstd\")), 3);\n    assert_eq!(candidate(String::from(\"truststdsolensporsd\")), 1);\n    assert_eq!(candidate(String::from(\"makestdsostdworthit\")), 2);\n    assert_eq!(candidate(String::from(\"stds\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given tuples contain the k or not.\nfn check_K(test_tup: Vec<isize>, K: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_K;\n    assert_eq!(candidate(vec![10, 4, 5, 6, 8], 6), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 7), false);\n    assert_eq!(candidate(vec![7, 8, 9, 44, 11, 12], 11), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "rs",
-    "prompt": "/// Write a function to interleave 3 vectors of the same length into a single flat vector.\nfn interleave_lists(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = interleave_lists;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7], vec![10, 20, 30, 40, 50, 60, 70], vec![100, 200, 300, 400, 500, 600, 700]), vec![1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n    assert_eq!(candidate(vec![10, 20], vec![15, 2], vec![5, 10]), vec![10, 15, 5, 20, 2, 10]);\n    assert_eq!(candidate(vec![11, 44], vec![10, 15], vec![20, 5]), vec![11, 10, 20, 44, 15, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"python_program\")), String::from(\"PythonProgram\"));\n    assert_eq!(candidate(String::from(\"python_language\")), String::from(\"PythonLanguage\"));\n    assert_eq!(candidate(String::from(\"programming_language\")), String::from(\"ProgrammingLanguage\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of equal numbers from three given integers.\nfn test_three_equal(x: isize, y: isize, z: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = test_three_equal;\n    assert_eq!(candidate(1, 1, 1), 3);\n    assert_eq!(candidate(-1, -2, -3), 0);\n    assert_eq!(candidate(1, 2, 2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nfn odd_length_sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_length_sum;\n    assert_eq!(candidate(vec![1, 2, 4]), 14);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), 15);\n    assert_eq!(candidate(vec![1, 7]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find the number of ways to partition a set of Bell numbers.\nfn bell_number(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = bell_number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(10), 115975);\n    assert_eq!(candidate(56), 6775685320645824322581483068371419745979053216268760300);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "rs",
-    "prompt": "/// Write a function to find the area of a rectangle.\nfn rectangle_area(l: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rectangle_area;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(10, 5), 50);\n    assert_eq!(candidate(4, 2), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "rs",
-    "prompt": "/// Write a function to find sum and average of first n natural numbers.\nfn sum_average(number: isize) -> (isize, f64) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_average;\n    assert_eq!(candidate(10), (55, 5.5));\n    assert_eq!(candidate(15), (120, 8.0));\n    assert_eq!(candidate(20), (210, 10.5));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfn division_elements(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = division_elements;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (2, 2, 2, 3));\n    assert_eq!(candidate((12, 6, 8, 16), (6, 3, 4, 4)), (2, 2, 2, 4));\n    assert_eq!(candidate((20, 14, 36, 18), (5, 7, 6, 9)), (4, 2, 6, 2));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "rs",
-    "prompt": "/// Write a function to get the sum of the digits of a non-negative integer.\nfn sum_digits(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_digits;\n    assert_eq!(candidate(345), 12);\n    assert_eq!(candidate(12), 3);\n    assert_eq!(candidate(97), 16);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "rs",
-    "prompt": "/// Given a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfn index_minimum(test_list: Vec<(String, isize)>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = index_minimum;\n    assert_eq!(candidate(vec![(String::from(\"Rash\"), 143), (String::from(\"Manjeet\"), 200), (String::from(\"Varsha\"), 100)]), String::from(\"Varsha\"));\n    assert_eq!(candidate(vec![(String::from(\"Yash\"), 185), (String::from(\"Dawood\"), 125), (String::from(\"Sanya\"), 175)]), String::from(\"Dawood\"));\n    assert_eq!(candidate(vec![(String::from(\"Sai\"), 345), (String::from(\"Salman\"), 145), (String::from(\"Ayesha\"), 96)]), String::from(\"Ayesha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "rs",
-    "prompt": "/// Write a function to divide two vectors element wise.\nfn div_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = div_list;\n    assert_eq!(candidate(vec![4, 5, 6], vec![1, 2, 3]), vec![4.0, 2.5, 2.0]);\n    assert_eq!(candidate(vec![3, 2], vec![1, 4]), vec![3.0, 0.5]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![1.8, 1.7142857142857142]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "rs",
-    "prompt": "/// Write a function to find the vector with maximum length.\nfn max_length_list(input_list: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_length_list;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4], vec![1, 2, 3], vec![1, 2], vec![1]]), (5, vec![1, 2, 3, 4, 5]));\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![6, 7, 8, 9], vec![10, 11, 12]]), (4, vec![6, 7, 8, 9]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of the largest and smallest value in a given vector.\nfn big_sum(nums: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = big_sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 4);\n    assert_eq!(candidate(vec![-1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![2, 3, 6]), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to return the negative numbers in a vector.\nfn neg_nos(list1: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = neg_nos;\n    assert_eq!(candidate(vec![-1, 4, 5, -6]), vec![-1, -6]);\n    assert_eq!(candidate(vec![-1, -2, 3, 4]), vec![-1, -2]);\n    assert_eq!(candidate(vec![-7, -6, 8, 9]), vec![-7, -6]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the highest power of 2 that is less than or equal to n.\nfn highest_Power_of_2(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = highest_Power_of_2;\n    assert_eq!(candidate(10), 8);\n    assert_eq!(candidate(19), 16);\n    assert_eq!(candidate(32), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether a vector contains the given subvector or not.\nfn is_sublist(l: Vec<isize>, s: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_sublist;\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![4, 3]), true);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![1, 6]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "rs",
-    "prompt": "/// Write a function to subtract two vectors element-wise.\nfn sub_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sub_list;\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), vec![-3, -3, -3]);\n    assert_eq!(candidate(vec![1, 2], vec![3, 4]), vec![-2, -2]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![40, 50]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given two integers have opposite sign or not.\nfn opposite_Signs(x: isize, y: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = opposite_Signs;\n    assert_eq!(candidate(1, -2), true);\n    assert_eq!(candidate(3, 2), false);\n    assert_eq!(candidate(-10, -10), false);\n    assert_eq!(candidate(-2, 2), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "rs",
-    "prompt": "/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfn tuple_modulo(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_modulo;\n    assert_eq!(candidate((10, 4, 5, 6), (5, 6, 7, 5)), (0, 4, 5, 1));\n    assert_eq!(candidate((11, 5, 6, 7), (6, 7, 8, 6)), (5, 5, 6, 1));\n    assert_eq!(candidate((12, 6, 7, 8), (7, 8, 9, 7)), (5, 6, 7, 1));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to find the difference of the first even and first odd number of a given vector.\nfn diff_even_odd(list1: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = diff_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 1);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "rs",
-    "prompt": "/// Write a function to sort each subvector of strings in a given vector of vectors.\nfn sort_sublists(list1: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"d\"), String::from(\"c\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"f\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"c\"), String::from(\"d\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"e\"), String::from(\"f\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the last digit of a given number.\nfn last_Digit(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = last_Digit;\n    assert_eq!(candidate(123), 3);\n    assert_eq!(candidate(25), 5);\n    assert_eq!(candidate(30), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of fourth power of first n odd natural numbers.\nfn odd_num_sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_num_sum;\n    assert_eq!(candidate(2), 82);\n    assert_eq!(candidate(3), 707);\n    assert_eq!(candidate(4), 3108);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a vector to a string.\nfn tup_string(tup1: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tup_string;\n    assert_eq!(candidate(vec![String::from(\"e\"), String::from(\"x\"), String::from(\"e\"), String::from(\"r\"), String::from(\"c\"), String::from(\"i\"), String::from(\"s\"), String::from(\"e\"), String::from(\"s\")]), String::from(\"exercises\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]), String::from(\"program\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all elements from a given vector present in another vector.\nfn remove_elements(list1: Vec<isize>, list2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_elements;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![2, 4, 6, 8]), vec![1, 3, 5, 7, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![1, 3, 5, 7]), vec![2, 4, 6, 8, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![5, 7]), vec![1, 2, 3, 4, 6, 8, 9, 10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether any value in a sequence exists in a sequence or not.\nfn overlapping(list1: Vec<isize>, list2: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = overlapping;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 8, 9]), false);\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 4, 5], vec![1, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to identify non-prime numbers.\nfn is_not_prime(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_not_prime;\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(35), true);\n    assert_eq!(candidate(37), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the sum of the negative numbers of a given vector of numbers.\nfn sum_negativenum(nums: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_negativenum;\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), -32);\n    assert_eq!(candidate(vec![10, 15, -14, 13, -18, 12, -20]), -52);\n    assert_eq!(candidate(vec![19, -65, 57, 39, 152, -639, 121, 44, 90, -190]), -894);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfn find_Rotations(str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Rotations;\n    assert_eq!(candidate(String::from(\"aaaa\")), 1);\n    assert_eq!(candidate(String::from(\"ab\")), 2);\n    assert_eq!(candidate(String::from(\"abc\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfn change_date_format(dt: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = change_date_format;\n    assert_eq!(candidate(String::from(\"2026-01-02\")), String::from(\"02-01-2026\"));\n    assert_eq!(candidate(String::from(\"2020-11-13\")), String::from(\"13-11-2020\"));\n    assert_eq!(candidate(String::from(\"2021-04-26\")), String::from(\"26-04-2021\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function which takes a vector of integers and only returns the odd ones.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), vec![1, 3, 5]);\n    assert_eq!(candidate(vec![10, 11, 12, 13]), vec![11, 13]);\n    assert_eq!(candidate(vec![7, 8, 9, 1]), vec![7, 9, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfn toggle_middle_bits(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = toggle_middle_bits;\n    assert_eq!(candidate(9), 15);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(11), 13);\n    assert_eq!(candidate(65), 127);\n    assert_eq!(candidate(77), 115);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfn count_char_position(str1: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_char_position;\n    assert_eq!(candidate(String::from(\"xbcefg\")), 2);\n    assert_eq!(candidate(String::from(\"ABcED\")), 3);\n    assert_eq!(candidate(String::from(\"AbgdeF\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\nfn large_product(nums1: Vec<isize>, nums2: Vec<isize>, N: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = large_product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 3), vec![60, 54, 50]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 4), vec![60, 54, 50, 48]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 5), vec![60, 54, 50, 48, 45]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the cumulative sum of all the values that are present in the given vector of vectors.\nfn cummulative_sum(test_list: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = cummulative_sum;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 6, 7], vec![2, 6]]), 30);\n    assert_eq!(candidate(vec![vec![2, 4], vec![6, 7, 8], vec![3, 7]]), 37);\n    assert_eq!(candidate(vec![vec![3, 5], vec![7, 8, 9], vec![4, 8]]), 44);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfn find_min_diff(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_min_diff;\n    assert_eq!(candidate(vec![1, 5, 3, 19, 18, 25], 6), 1);\n    assert_eq!(candidate(vec![4, 3, 2, 6], 4), 1);\n    assert_eq!(candidate(vec![30, 5, 20, 9], 4), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfn text_starta_endb(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_starta_endb;\n    assert_eq!(candidate(String::from(\"aabbbb\")), true);\n    assert_eq!(candidate(String::from(\"aabAbbbc\")), false);\n    assert_eq!(candidate(String::from(\"accddbbjjj\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "rs",
-    "prompt": "/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfn left_rotate(n: isize, d: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = left_rotate;\n    assert_eq!(candidate(16, 2), 64);\n    assert_eq!(candidate(10, 2), 40);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(1, 3), 8);\n    assert_eq!(candidate(5, 3), 40);\n    assert_eq!(candidate(29, 3), 232);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the first repeated character in a given string.\nfn first_repeated_char(str1: String) -> Option<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = first_repeated_char;\n    assert_eq!(candidate(String::from(\"abcabc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"abc\")), None);\n    assert_eq!(candidate(String::from(\"123123\")), Some(String::from(\"1\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count inversions in a vector.\nfn get_Inv_Count(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_Inv_Count;\n    assert_eq!(candidate(vec![1, 20, 6, 4, 5]), 5);\n    assert_eq!(candidate(vec![1, 2, 1]), 1);\n    assert_eq!(candidate(vec![1, 2, 5, 6, 1]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfn even_Power_Sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = even_Power_Sum;\n    assert_eq!(candidate(2), 1056);\n    assert_eq!(candidate(3), 8832);\n    assert_eq!(candidate(1), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "rs",
-    "prompt": "/// Write a function to find whether all the given vectors have equal length or not.\nfn get_equal(Input: Vec<Vec<isize>>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_equal;\n    assert_eq!(candidate(vec![vec![11, 22, 33], vec![44, 55, 66]]), true);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6, 7]]), false);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "rs",
-    "prompt": "/// Write a function to check if a string represents an integer or not.\nfn check_integer(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_integer;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"1\")), true);\n    assert_eq!(candidate(String::from(\"12345\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "rs",
-    "prompt": "/// Write a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/rsthon-program-to-count-the-pairs-of-reverse-strings/\nfn count_reverse_pairs(test_list: Vec<String>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_reverse_pairs;\n    assert_eq!(candidate(vec![String::from(\"julia\"), String::from(\"best\"), String::from(\"tseb\"), String::from(\"for\"), String::from(\"ailuj\")]), 2);\n    assert_eq!(candidate(vec![String::from(\"geeks\"), String::from(\"best\"), String::from(\"for\"), String::from(\"skeeg\")]), 1);\n    assert_eq!(candidate(vec![String::from(\"makes\"), String::from(\"best\"), String::from(\"sekam\"), String::from(\"for\"), String::from(\"rof\")]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to move all zeroes to the end of the given vector.\nfn move_zero(num_list: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = move_zero;\n    assert_eq!(candidate(vec![1, 0, 2, 0, 3, 4]), vec![1, 2, 3, 4, 0, 0]);\n    assert_eq!(candidate(vec![2, 3, 2, 0, 0, 4, 0, 5, 0]), vec![2, 3, 2, 4, 5, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![0, 1, 0, 1, 1]), vec![1, 1, 1, 0, 0]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "rs",
-    "prompt": "/// Write a function to check if given vector contains no duplicates.\nfn check_distinct(test_tup: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_distinct;\n    assert_eq!(candidate(vec![1, 4, 5, 6, 1, 4]), false);\n    assert_eq!(candidate(vec![1, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given amount has no profit and no loss\nfn noprofit_noloss(actual_cost: isize, sale_amount: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = noprofit_noloss;\n    assert_eq!(candidate(1500, 1200), false);\n    assert_eq!(candidate(100, 100), true);\n    assert_eq!(candidate(2000, 5000), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all the words with k length in the given string.\nfn remove_length(test_str: String, K: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_length;\n    assert_eq!(candidate(String::from(\"The person is most value tet\"), 3), String::from(\"person is most value\"));\n    assert_eq!(candidate(String::from(\"If you told me about this ok\"), 4), String::from(\"If you me about ok\"));\n    assert_eq!(candidate(String::from(\"Forces of darkeness is come into the play\"), 4), String::from(\"Forces of darkeness is the\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count number of digits in a given string.\nfn number_ctr(str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = number_ctr;\n    assert_eq!(candidate(String::from(\"program2bedone\")), 1);\n    assert_eq!(candidate(String::from(\"3wonders\")), 1);\n    assert_eq!(candidate(String::from(\"123\")), 3);\n    assert_eq!(candidate(String::from(\"3wond-1ers2\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "rs",
-    "prompt": "/// Write a function to count the total number of characters in a string.\nfn count_charac(str1: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_charac;\n    assert_eq!(candidate(String::from(\"python programming\")), 18);\n    assert_eq!(candidate(String::from(\"language\")), 8);\n    assert_eq!(candidate(String::from(\"words\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfn get_total_number_of_sequences(m: isize, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_total_number_of_sequences;\n    assert_eq!(candidate(10, 4), 4);\n    assert_eq!(candidate(5, 2), 6);\n    assert_eq!(candidate(16, 3), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "rs",
-    "prompt": "/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rsthon-exercises/data-structures-and-algorithms/rsthon-data-structure-exercise-24.php\nfn left_insertion(a: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = left_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two numbers and returns a vector with the second number and then the first number.\nfn swap_numbers(a: isize, b: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_numbers;\n    assert_eq!(candidate(10, 20), vec![20, 10]);\n    assert_eq!(candidate(15, 17), vec![17, 15]);\n    assert_eq!(candidate(100, 200), vec![200, 100]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nfn is_majority(arr: Vec<isize>, n: isize, x: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_majority;\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 3, 10], 7, 3), true);\n    assert_eq!(candidate(vec![1, 1, 2, 4, 4, 4, 6, 6], 8, 4), false);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 2], 5, 1), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2], 5, 1), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfn substract_elements(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> (isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = substract_elements;\n    assert_eq!(candidate((10, 4, 5), (2, 5, 18)), (8, -1, -13));\n    assert_eq!(candidate((11, 2, 3), (24, 45, 16)), (-13, -43, -13));\n    assert_eq!(candidate((7, 18, 9), (10, 11, 12)), (-3, 7, -3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to put spaces between words starting with capital letters in a given string.\nfn capital_words_spaces(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = capital_words_spaces;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"PythonProgrammingExamples\")), String::from(\"Python Programming Examples\"));\n    assert_eq!(candidate(String::from(\"GetReadyToBeCodingFreak\")), String::from(\"Get Ready To Be Coding Freak\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the average of cubes of first n natural numbers.\nfn find_Average_Of_Cube(n: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Average_Of_Cube;\n    assert_eq!(candidate(2), 4.5);\n    assert_eq!(candidate(3), 12.0);\n    assert_eq!(candidate(1), 1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to check if all values are same in a HashMap.\nfn check_value(dict: HashMap<String, isize>, n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_value;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 10), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 12), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 5), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth tetrahedral number.\nfn tetrahedral_number(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tetrahedral_number;\n    assert_eq!(candidate(5), 35);\n    assert_eq!(candidate(6), 56);\n    assert_eq!(candidate(7), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate whether the matrix is a magic square.\nfn magic_square_test(my_matrix: Vec<Vec<isize>>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = magic_square_test;\n    assert_eq!(candidate(vec![vec![7, 12, 1, 14], vec![2, 13, 8, 11], vec![16, 3, 10, 5], vec![9, 6, 15, 4]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 8]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 7]]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "rs",
-    "prompt": "/// Write a function to remove uppercase substrings from a given string.\nfn remove_uppercase(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_uppercase;\n    assert_eq!(candidate(String::from(\"cAstyoUrFavoRitETVshoWs\")), String::from(\"cstyoravoitshos\"));\n    assert_eq!(candidate(String::from(\"wAtchTheinTernEtrAdIo\")), String::from(\"wtchheinerntrdo\"));\n    assert_eq!(candidate(String::from(\"VoicESeaRchAndreComMendaTionS\")), String::from(\"oiceachndreomendaion\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate a dog's age in dog's years.\nfn dog_age(h_age: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = dog_age;\n    assert_eq!(candidate(12), 61);\n    assert_eq!(candidate(15), 73);\n    assert_eq!(candidate(24), 109);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the next perfect square greater than a given number.\nfn next_Perfect_Square(N: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = next_Perfect_Square;\n    assert_eq!(candidate(35), 36);\n    assert_eq!(candidate(6), 9);\n    assert_eq!(candidate(9), 16);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to convert a given string to uppercase.\nfn is_upper(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_upper;\n    assert_eq!(candidate(String::from(\"person\")), String::from(\"PERSON\"));\n    assert_eq!(candidate(String::from(\"final\")), String::from(\"FINAL\"));\n    assert_eq!(candidate(String::from(\"Valid\")), String::from(\"VALID\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfn odd_Equivalent(s: String, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_Equivalent;\n    assert_eq!(candidate(String::from(\"011001\"), 6), 3);\n    assert_eq!(candidate(String::from(\"11011\"), 5), 4);\n    assert_eq!(candidate(String::from(\"1010\"), 4), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfn re_arrange_array(arr: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = re_arrange_array;\n    assert_eq!(candidate(vec![-1, 2, -3, 4, 5, 6, -7, 8, 9], 9), vec![-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n    assert_eq!(candidate(vec![12, -14, -26, 13, 15], 5), vec![-14, -26, 12, 13, 15]);\n    assert_eq!(candidate(vec![10, 24, 36, -42, -39, -78, 85], 7), vec![-42, -39, -78, 10, 24, 36, 85]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether a vector of numbers contains only one distinct element or not.\nfn unique_Element(arr: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_Element;\n    assert_eq!(candidate(vec![1, 1, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count true booleans in the given vector.\nfn count(lst: Vec<bool>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count;\n    assert_eq!(candidate(vec![true, false, true]), 2);\n    assert_eq!(candidate(vec![false, false]), 0);\n    assert_eq!(candidate(vec![true, true, true]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "rs",
-    "prompt": "/// Write a function that counts the number of pairs of integers in a vector that xor to an even number.\nfn find_even_pair(A: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_even_pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1]), 4);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11]), 9);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is armstrong or not.\nfn armstrong_number(number: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = armstrong_number;\n    assert_eq!(candidate(153), true);\n    assert_eq!(candidate(259), false);\n    assert_eq!(candidate(4458), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the upper case characters in a given string.\nfn upper_ctr(str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = upper_ctr;\n    assert_eq!(candidate(String::from(\"PYthon\")), 1);\n    assert_eq!(candidate(String::from(\"BigData\")), 1);\n    assert_eq!(candidate(String::from(\"program\")), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to extract the elementwise and tuples from the given two tuples.\nfn and_tuples(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = and_tuples;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (0, 0, 2, 1));\n    assert_eq!(candidate((1, 2, 3, 4), (5, 6, 7, 8)), (1, 2, 3, 0));\n    assert_eq!(candidate((8, 9, 11, 12), (7, 13, 14, 17)), (0, 9, 10, 0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether it follows the sequence given in the patterns vector.\nfn is_samepatterns(colors: Vec<String>, patterns: Vec<String>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_samepatterns;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"green\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\")]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of vectors in a given number of vectors.\nfn count_list(input_list: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_list;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), 4);\n    assert_eq!(candidate(vec![vec![1, 2], vec![2, 3], vec![4, 5]]), 3);\n    assert_eq!(candidate(vec![vec![1, 0], vec![2, 0]]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\nfn average_tuple(nums: Vec<Vec<isize>>) -> Vec<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = average_tuple;\n    assert_eq!(candidate(vec![vec![10, 10, 10, 12], vec![30, 45, 56, 45], vec![81, 80, 39, 32], vec![1, 2, 3, 4]]), vec![30.5, 34.25, 27.0, 23.25]);\n    assert_eq!(candidate(vec![vec![1, 1, -5], vec![30, -15, 56], vec![81, -60, -39], vec![-10, 2, 3]]), vec![25.5, -18.0, 3.75]);\n    assert_eq!(candidate(vec![vec![100, 100, 100, 120], vec![300, 450, 560, 450], vec![810, 800, 390, 320], vec![10, 20, 30, 40]]), vec![305.0, 342.5, 270.0, 232.5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "rs",
-    "prompt": "/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfn lcs_of_three(X: String, Y: String, Z: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = lcs_of_three;\n    assert_eq!(candidate(String::from(\"AGGT12\"), String::from(\"12TXAYB\"), String::from(\"12XBA\")), 2);\n    assert_eq!(candidate(String::from(\"Reels\"), String::from(\"Reelsfor\"), String::from(\"ReelsforReels\")), 5);\n    assert_eq!(candidate(String::from(\"abcd1e2\"), String::from(\"bc12ea\"), String::from(\"bd1ea\")), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n'th star number.\nfn find_star_num(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_star_num;\n    assert_eq!(candidate(3), 37);\n    assert_eq!(candidate(4), 73);\n    assert_eq!(candidate(5), 121);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of a vector.\nfn _sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = _sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![15, 12, 13, 10]), 50);\n    assert_eq!(candidate(vec![0, 1, 2]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given vector contains consecutive numbers or not.\nfn check_Consecutive(l: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_Consecutive;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 2, 1]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "rs",
-    "prompt": "/// Write a function to find the first adverb and their positions in a given sentence.\nfn find_adverb_position(text: String) -> (isize, isize, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_adverb_position;\n    assert_eq!(candidate(String::from(\"clearly!! we can see the sky\")), (0, 7, String::from(\"clearly\")));\n    assert_eq!(candidate(String::from(\"seriously!! there are many roses\")), (0, 9, String::from(\"seriously\")));\n    assert_eq!(candidate(String::from(\"unfortunately!! sita is going to home\")), (0, 13, String::from(\"unfortunately\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "rs",
-    "prompt": "/// Write a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/rsthon-program-right-rotate-vector-n/\nfn rotate_right(list: Vec<isize>, m: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rotate_right;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3), vec![8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5), vec![6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of non-empty substrings of a given string.\nfn number_of_substrings(str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = number_of_substrings;\n    assert_eq!(candidate(String::from(\"abc\")), 6);\n    assert_eq!(candidate(String::from(\"abcd\")), 10);\n    assert_eq!(candidate(String::from(\"abcde\")), 15);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check if the elements of a given vector are unique or not.\nfn all_unique(test_list: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = all_unique;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to convert complex numbers to polar coordinates.\nfn convert(numbers: isize) -> (f64, f64) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = convert;\n    assert_eq!(candidate(1), (1.0, 0.0));\n    assert_eq!(candidate(4), (4.0, 0.0));\n    assert_eq!(candidate(5), (5.0, 0.0));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to convert the given string to lower case.\nfn is_lower(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_lower;\n    assert_eq!(candidate(String::from(\"InValid\")), String::from(\"invalid\"));\n    assert_eq!(candidate(String::from(\"TruE\")), String::from(\"true\"));\n    assert_eq!(candidate(String::from(\"SenTenCE\")), String::from(\"sentence\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the smallest power of 2 greater than or equal to n.\nfn next_power_of_2(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = next_power_of_2;\n    assert_eq!(candidate(0), 1);\n    assert_eq!(candidate(5), 8);\n    assert_eq!(candidate(17), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "rs",
-    "prompt": "/// Write a function to check if a string is present as a substring in a given vector of string values.\nfn find_substring(str1: Vec<String>, sub_str: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_substring;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ack\")), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"abc\")), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ange\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "rs",
-    "prompt": "/// Write a function to replace characters in a string.\nfn replace_char(str1: String, ch: String, newch: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_char;\n    assert_eq!(candidate(String::from(\"polygon\"), String::from(\"y\"), String::from(\"l\")), String::from(\"pollgon\"));\n    assert_eq!(candidate(String::from(\"character\"), String::from(\"c\"), String::from(\"a\")), String::from(\"aharaater\"));\n    assert_eq!(candidate(String::from(\"python\"), String::from(\"l\"), String::from(\"a\")), String::from(\"python\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to find the product of first even and odd number of a given vector.\nfn mul_even_odd(list1: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = mul_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfn even_binomial_Coeff_Sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = even_binomial_Coeff_Sum;\n    assert_eq!(candidate(4), 8);\n    assert_eq!(candidate(6), 32);\n    assert_eq!(candidate(2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "rs",
-    "prompt": "/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfn bitwise_xor(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = bitwise_xor;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (15, 6, 5, 10));\n    assert_eq!(candidate((11, 5, 7, 10), (6, 3, 4, 4)), (13, 6, 3, 14));\n    assert_eq!(candidate((12, 6, 8, 11), (7, 4, 5, 6)), (11, 2, 13, 13));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether a vector is subvector of another or not.\nfn is_Sub_Array(A: Vec<isize>, B: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Sub_Array;\n    assert_eq!(candidate(vec![1, 4, 3, 5], vec![1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 1], vec![1, 2, 1]), true);\n    assert_eq!(candidate(vec![1, 0, 2, 2], vec![2, 2, 0]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "rs",
-    "prompt": "/// Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nfn max_sub_array_sum_repeated(a: Vec<isize>, n: isize, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum_repeated;\n    assert_eq!(candidate(vec![10, 20, -30, -1], 4, 3), 30);\n    assert_eq!(candidate(vec![-1, 10, 20], 3, 2), 59);\n    assert_eq!(candidate(vec![-1, -2, -3], 3, 3), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to find the minimum product from the pairs of tuples within a given vector.\nfn min_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = min_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 8);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 30);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 100);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the count of divisors is even. https://www.w3resource.com/rsthon-exercises/basic/rsthon-basic-1-exercise-24.php\nfn count_divisors(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_divisors;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(100), false);\n    assert_eq!(candidate(125), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfn triangle_area(r: isize) -> Option<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(-1), None);\n    assert_eq!(candidate(0), Some(0));\n    assert_eq!(candidate(2), Some(4));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a given string to a vector of characters.\nfn string_to_tuple(str1: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = string_to_tuple;\n    assert_eq!(candidate(String::from(\"python 3.0\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\"), String::from(\"3\"), String::from(\".\"), String::from(\"0\")]);\n    assert_eq!(candidate(String::from(\"item1\")), vec![String::from(\"i\"), String::from(\"t\"), String::from(\"e\"), String::from(\"m\"), String::from(\"1\")]);\n    assert_eq!(candidate(String::from(\"15.10\")), vec![String::from(\"1\"), String::from(\"5\"), String::from(\".\"), String::from(\"1\"), String::from(\"0\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfn find_length(string: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_length;\n    assert_eq!(candidate(String::from(\"11000010001\")), 6);\n    assert_eq!(candidate(String::from(\"10111\")), 1);\n    assert_eq!(candidate(String::from(\"11011101100101\")), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfn count_Primes_nums(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Primes_nums;\n    assert_eq!(candidate(5), 2);\n    assert_eq!(candidate(10), 4);\n    assert_eq!(candidate(100), 25);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of the product of consecutive binomial co-efficients.\nfn sum_Of_product(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_product;\n    assert_eq!(candidate(3), 15);\n    assert_eq!(candidate(4), 56);\n    assert_eq!(candidate(1), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the maximum aggregate from the vector of tuples.\nfn max_aggregate(stdata: Vec<(String, isize)>) -> (String, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_aggregate;\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 90), (String::from(\"Sabah Colley\"), 88), (String::from(\"Peter Nichols\"), 7), (String::from(\"Juan Whelan\"), 122), (String::from(\"Sabah Colley\"), 84)]), (String::from(\"Juan Whelan\"), 212));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 50), (String::from(\"Sabah Colley\"), 48), (String::from(\"Peter Nichols\"), 37), (String::from(\"Juan Whelan\"), 22), (String::from(\"Sabah Colley\"), 14)]), (String::from(\"Juan Whelan\"), 72));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 10), (String::from(\"Sabah Colley\"), 20), (String::from(\"Peter Nichols\"), 30), (String::from(\"Juan Whelan\"), 40), (String::from(\"Sabah Colley\"), 50)]), (String::from(\"Sabah Colley\"), 70));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a vector of elements.\nfn comb_sort(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = comb_sort;\n    assert_eq!(candidate(vec![5, 15, 37, 25, 79]), vec![5, 15, 25, 37, 79]);\n    assert_eq!(candidate(vec![41, 32, 15, 19, 22]), vec![15, 19, 22, 32, 41]);\n    assert_eq!(candidate(vec![99, 15, 13, 47]), vec![13, 15, 47, 99]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "rs",
-    "prompt": "/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfn check_expression(exp: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_expression;\n    assert_eq!(candidate(String::from(\"{()}[{}]\")), true);\n    assert_eq!(candidate(String::from(\"{()}[{]\")), false);\n    assert_eq!(candidate(String::from(\"{()}[{}][]({})\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a word containing 'z'.\nfn text_match_wordz(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz;\n    assert_eq!(candidate(String::from(\"pythonz.\")), true);\n    assert_eq!(candidate(String::from(\"xyz.\")), true);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "rs",
-    "prompt": "/// Write a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfn sum_list(lst1: Vec<isize>, lst2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_list;\n    assert_eq!(candidate(vec![10, 20, 30], vec![15, 25, 35]), vec![25, 45, 65]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![5, 6, 7]), vec![6, 8, 10]);\n    assert_eq!(candidate(vec![15, 20, 30], vec![15, 45, 75]), vec![30, 65, 105]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfn newman_prime(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = newman_prime;\n    assert_eq!(candidate(3), 7);\n    assert_eq!(candidate(4), 17);\n    assert_eq!(candidate(5), 41);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the surface area of a square rsramid with a given base edge and height.\nfn surface_Area(b: isize, s: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = surface_Area;\n    assert_eq!(candidate(3, 4), 33);\n    assert_eq!(candidate(4, 5), 56);\n    assert_eq!(candidate(1, 2), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the length of the smallest vector in a vector of vectors.\nfn Find_Min_Length(lst: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Find_Min_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 2]]), 1);\n    assert_eq!(candidate(vec![vec![1, 2], vec![1, 2, 3], vec![1, 2, 3, 4]]), 2);\n    assert_eq!(candidate(vec![vec![3, 3, 3], vec![4, 4, 4, 4]]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfn validate(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = validate;\n    assert_eq!(candidate(1234), true);\n    assert_eq!(candidate(51241), false);\n    assert_eq!(candidate(321), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth hexagonal number.\nfn hexagonal_num(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = hexagonal_num;\n    assert_eq!(candidate(10), 190);\n    assert_eq!(candidate(5), 45);\n    assert_eq!(candidate(7), 91);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n'th lucas number.\nfn find_lucas(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_lucas;\n    assert_eq!(candidate(9), 76);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(3), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to get the difference between two vectors.\nfn Diff(li1: Vec<isize>, li2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Diff;\n    assert_eq!(candidate(vec![10, 15, 20, 25, 30, 35, 40], vec![25, 40, 35]), vec![10, 20, 30, 15]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 1]), vec![2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![6, 7, 1]), vec![2, 3, 6, 7]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the two numbers differ at one bit position only or not.\nfn differ_At_One_Bit_Pos(a: isize, b: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = differ_At_One_Bit_Pos;\n    assert_eq!(candidate(13, 9), true);\n    assert_eq!(candidate(15, 8), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(2, 3), true);\n    assert_eq!(candidate(5, 1), true);\n    assert_eq!(candidate(1, 5), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an a followed by three 'b'.\nfn text_match_three(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"caacabbbba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nfn max_product(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_product;\n    assert_eq!(candidate(vec![3, 100, 4, 5, 150, 6]), 3000);\n    assert_eq!(candidate(vec![4, 42, 55, 68, 80]), 50265600);\n    assert_eq!(candidate(vec![10, 22, 9, 33, 21, 50, 41, 60]), 2460);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to split a vector at the nth eelment and add the first part to the end.\nfn split_Arr(l: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = split_Arr;\n    assert_eq!(candidate(vec![12, 10, 5, 6, 52, 36], 2), vec![5, 6, 52, 36, 12, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], 1), vec![2, 3, 4, 1]);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 4, 5, 6, 7], 3), vec![3, 4, 5, 6, 7, 0, 1, 2]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the number of divisors of a given integer.\nfn divisor(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = divisor;\n    assert_eq!(candidate(15), 4);\n    assert_eq!(candidate(12), 6);\n    assert_eq!(candidate(9), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the difference between largest and smallest value in a given vector.\nfn big_diff(nums: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = big_diff;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![4, 5, 12]), 8);\n    assert_eq!(candidate(vec![9, 2, 3]), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "rs",
-    "prompt": "/// Write a function to find squares of individual elements in a vector.\nfn square_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = square_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![100, 400, 900]);\n    assert_eq!(candidate(vec![12, 15]), vec![144, 225]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given vector is monotonic or not.\nfn is_Monotonic(A: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Monotonic;\n    assert_eq!(candidate(vec![6, 5, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 3, 2]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfn is_perfect_square(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_perfect_square;\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(36), true);\n    assert_eq!(candidate(14), false);\n    assert_eq!(candidate(196), true);\n    assert_eq!(candidate(125), false);\n    assert_eq!(candidate(15625), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of common divisors of two given numbers.\nfn sum(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum;\n    assert_eq!(candidate(10, 15), 6);\n    assert_eq!(candidate(100, 150), 93);\n    assert_eq!(candidate(4, 6), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "rs",
-    "prompt": "/// Write a function to find the vector of maximum length in a vector of vectors.\nfn max_length(list1: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_length;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1], vec![5, 7], vec![10, 12, 14, 15]]), (4, vec![10, 12, 14, 15]));\n    assert_eq!(candidate(vec![vec![5], vec![15, 20, 25]]), (3, vec![15, 20, 25]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "rs",
-    "prompt": "/// Write a function to find the directrix of a parabola.\nfn parabola_directrix(a: isize, b: isize, c: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = parabola_directrix;\n    assert_eq!(candidate(5, 3, 2), -198);\n    assert_eq!(candidate(9, 8, 4), -2336);\n    assert_eq!(candidate(2, 4, 6), -130);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "rs",
-    "prompt": "/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfn occurance_substring(text: String, pattern: String) -> Option<(String, isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = occurance_substring;\n    assert_eq!(candidate(String::from(\"python programming, python language\"), String::from(\"python\")), Some((String::from(\"python\"), 0, 6)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"programming\")), Some((String::from(\"programming\"), 7, 18)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"language\")), Some((String::from(\"language\"), 31, 39)));\n    assert_eq!(candidate(String::from(\"c++ programming, c++ language\"), String::from(\"python\")), None);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "rs",
-    "prompt": "/// Write a function to sort each subvector of strings in a given vector of vectors.\nfn sort_sublists(input_list: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\"blue \"), String::from(\" black\")], vec![String::from(\" orange\"), String::from(\"brown\")]]), vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\" black\"), String::from(\"blue \")], vec![String::from(\" orange\"), String::from(\"brown\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"zilver\"), String::from(\"gold\")], vec![String::from(\"magnesium\"), String::from(\"aluminium\")], vec![String::from(\"steel\"), String::from(\"bronze\")]]), vec![vec![String::from(\"gold\"), String::from(\"zilver\")], vec![String::from(\"aluminium\"), String::from(\"magnesium\")], vec![String::from(\"bronze\"), String::from(\"steel\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\nfn remove_kth_element(list1: Vec<isize>, L: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_kth_element;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 4, 4, 5, 1], 3), vec![1, 1, 3, 4, 4, 5, 1]);\n    assert_eq!(candidate(vec![0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4), vec![0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n    assert_eq!(candidate(vec![10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5), vec![10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to add a HashMap to the tuple. The output should be a tuple.\nfn add_dict_to_tuple(test_tup: (isize, isize, isize), test_dict: HashMap<String, isize>) -> (isize, isize, isize, HashMap<String, isize>) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_dict_to_tuple;\n    assert_eq!(candidate((4, 5, 6), HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])), (4, 5, 6, HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])));\n    assert_eq!(candidate((1, 2, 3), HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])), (1, 2, 3, HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])));\n    assert_eq!(candidate((8, 9, 10), HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])), (8, 9, 10, HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfn find(n: isize, m: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find;\n    assert_eq!(candidate(10, 3), 3);\n    assert_eq!(candidate(4, 2), 2);\n    assert_eq!(candidate(20, 5), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "rs",
-    "prompt": "/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfn text_match_two_three(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_two_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "rs",
-    "prompt": "/// Write a function to count number items that are identical in the same position of three given vectors.\nfn count_samepair(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_samepair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9], vec![2, 1, 3, 1, 2, 6, 7, 9]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 2, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "rs",
-    "prompt": "/// Write a function that matches a string that has an a followed by one or more b's.\nfn text_match_one(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abba\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfn difference(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = difference;\n    assert_eq!(candidate(3), 30);\n    assert_eq!(candidate(5), 210);\n    assert_eq!(candidate(2), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "rs",
-    "prompt": "/// Write a function to toggle the case of all characters in a string.\nfn toggle_string(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = toggle_string;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"pYTHON\"));\n    assert_eq!(candidate(String::from(\"Pangram\")), String::from(\"pANGRAM\"));\n    assert_eq!(candidate(String::from(\"LIttLE\")), String::from(\"liTTle\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the Eulerian number a(n, m).\nfn eulerian_num(n: isize, m: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = eulerian_num;\n    assert_eq!(candidate(3, 1), 4);\n    assert_eq!(candidate(4, 1), 11);\n    assert_eq!(candidate(5, 3), 26);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "rs",
-    "prompt": "/// Write a function to count the number of occurrences of a number in a given vector.\nfn frequency(a: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = frequency;\n    assert_eq!(candidate(vec![1, 2, 3], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 3, 4], 3), 3);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 1, 2], 1), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/rsthon-sort-numeric-strings-in-a-vector/\nfn sort_numeric_strings(nums_str: Vec<String>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_numeric_strings;\n    assert_eq!(candidate(vec![String::from(\"4\"), String::from(\"12\"), String::from(\"45\"), String::from(\"7\"), String::from(\"0\"), String::from(\"100\"), String::from(\"200\"), String::from(\"-12\"), String::from(\"-500\")]), vec![-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n    assert_eq!(candidate(vec![String::from(\"2\"), String::from(\"3\"), String::from(\"8\"), String::from(\"4\"), String::from(\"7\"), String::from(\"9\"), String::from(\"8\"), String::from(\"2\"), String::from(\"6\"), String::from(\"5\"), String::from(\"1\"), String::from(\"6\"), String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"6\"), String::from(\"9\"), String::from(\"1\"), String::from(\"2\")]), vec![1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n    assert_eq!(candidate(vec![String::from(\"1\"), String::from(\"3\"), String::from(\"5\"), String::from(\"7\"), String::from(\"1\"), String::from(\"3\"), String::from(\"13\"), String::from(\"15\"), String::from(\"17\"), String::from(\"5\"), String::from(\"7 \"), String::from(\"9\"), String::from(\"1\"), String::from(\"11\")]), vec![1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rsthon-exercises/data-structures-and-algorithms/rsthon-recursion-exercise-9.php\nfn geometric_sum(n: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = geometric_sum;\n    assert_eq!(candidate(7), 1.9921875);\n    assert_eq!(candidate(4), 1.9375);\n    assert_eq!(candidate(8), 1.99609375);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "rs",
-    "prompt": "/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rsthon-exercises/lambda/rsthon-lambda-exercise-24.php\nfn divisible_by_digits(startnum: isize, endnum: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = divisible_by_digits;\n    assert_eq!(candidate(1, 22), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n    assert_eq!(candidate(1, 15), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n    assert_eq!(candidate(20, 25), vec![22, 24]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to calculate the product of the unique numbers in a given vector.\nfn unique_product(list_data: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = unique_product;\n    assert_eq!(candidate(vec![10, 20, 30, 40, 20, 50, 60, 40]), 720000000);\n    assert_eq!(candidate(vec![1, 2, 3, 1]), 6);\n    assert_eq!(candidate(vec![7, 8, 9, 0, 1, 1]), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the largest negative number from the given vector.\nfn largest_neg(list1: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = largest_neg;\n    assert_eq!(candidate(vec![1, 2, 3, -4, -6]), -6);\n    assert_eq!(candidate(vec![1, 2, 3, -8, -9]), -9);\n    assert_eq!(candidate(vec![1, 2, 3, 4, -1]), -1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "rs",
-    "prompt": "/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfn min_Jumps(steps: (isize, isize), d: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = min_Jumps;\n    assert_eq!(candidate((3, 4), 11), 3.5);\n    assert_eq!(candidate((3, 4), 0), 0.0);\n    assert_eq!(candidate((11, 14), 11), 1.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find a pair with highest product from a given vector of integers.\nfn max_Product(arr: Vec<isize>) -> (isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_Product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 7, 0, 8, 4]), (7, 8));\n    assert_eq!(candidate(vec![0, -1, -2, -4, 5, 0, -6]), (-4, -6));\n    assert_eq!(candidate(vec![1, 2, 3]), (2, 3));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth nonagonal number.\nfn is_nonagonal(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_nonagonal;\n    assert_eq!(candidate(10), 325);\n    assert_eq!(candidate(15), 750);\n    assert_eq!(candidate(18), 1089);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the maximum difference between any two elements in a given vector.\nfn max_Abs_Diff(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_Abs_Diff;\n    assert_eq!(candidate(vec![2, 1, 5, 3]), 4);\n    assert_eq!(candidate(vec![9, 3, 2, 5, 1]), 8);\n    assert_eq!(candidate(vec![3, 2, 1]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the sum of perrin numbers.\nfn cal_sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = cal_sum;\n    assert_eq!(candidate(9), 49);\n    assert_eq!(candidate(10), 66);\n    assert_eq!(candidate(11), 88);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to remove the characters which have odd index values of a given string.\nfn odd_values_string(str: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_values_string;\n    assert_eq!(candidate(String::from(\"abcdef\")), String::from(\"ace\"));\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"pto\"));\n    assert_eq!(candidate(String::from(\"data\")), String::from(\"dt\"));\n    assert_eq!(candidate(String::from(\"lambs\")), String::from(\"lms\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "rs",
-    "prompt": "/// Write a function to find kth element from the given two sorted vectors.\nfn find_kth(arr1: Vec<isize>, arr2: Vec<isize>, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_kth;\n    assert_eq!(candidate(vec![2, 3, 6, 7, 9], vec![1, 4, 8, 10], 5), 6);\n    assert_eq!(candidate(vec![100, 112, 256, 349, 770], vec![72, 86, 113, 119, 265, 445, 892], 7), 256);\n    assert_eq!(candidate(vec![3, 4, 7, 8, 10], vec![2, 5, 9, 11], 6), 8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfn jacobsthal_num(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = jacobsthal_num;\n    assert_eq!(candidate(5), 11);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 5);\n    assert_eq!(candidate(13), 2731);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to find frequency of each element in a flattened vector of vectors, returned in a HashMap.\nfn frequency_lists(list1: Vec<Vec<isize>>) -> HashMap<isize, isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = frequency_lists;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 2], vec![4, 5, 6, 2], vec![7, 8, 9, 5]]), HashMap::from([(1, 1), (2, 3), (3, 1), (4, 1), (5, 2), (6, 1), (7, 1), (8, 1), (9, 1)]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]]), HashMap::from([(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1), (12, 1)]));\n    assert_eq!(candidate(vec![vec![20, 30, 40, 17], vec![18, 16, 14, 13], vec![10, 20, 30, 40]]), HashMap::from([(20, 2), (30, 2), (40, 2), (17, 1), (18, 1), (16, 1), (14, 1), (13, 1), (10, 1)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "rs",
-    "prompt": "/// Write a function to find perfect squares between two given numbers.\nfn perfect_squares(a: isize, b: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = perfect_squares;\n    assert_eq!(candidate(1, 30), vec![1, 4, 9, 16, 25]);\n    assert_eq!(candidate(50, 100), vec![64, 81, 100]);\n    assert_eq!(candidate(100, 200), vec![100, 121, 144, 169, 196]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nfn sum_Of_Subarray_Prod(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_Subarray_Prod;\n    assert_eq!(candidate(vec![1, 2, 3]), 20);\n    assert_eq!(candidate(vec![1, 2]), 5);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 84);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the first odd number in a given vector of numbers.\nfn first_odd(nums: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = first_odd;\n    assert_eq!(candidate(vec![1, 3, 5]), 1);\n    assert_eq!(candidate(vec![2, 4, 1, 3]), 1);\n    assert_eq!(candidate(vec![8, 9, 1]), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "rs",
-    "prompt": "/// Write a function to perform index wise addition of vector elements in the given two nested vectors.\nfn add_nested_tuples(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_nested_tuples;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![7, 10], vec![7, 14], vec![3, 10], vec![8, 13]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![9, 12], vec![9, 16], vec![5, 12], vec![10, 15]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![11, 14], vec![11, 18], vec![7, 14], vec![12, 17]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given number can be represented as the difference of two squares or not.\nfn dif_Square(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = dif_Square;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(15), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "rs",
-    "prompt": "/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfn check_smaller(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_smaller;\n    assert_eq!(candidate((1, 2, 3), (2, 3, 4)), false);\n    assert_eq!(candidate((4, 5, 6), (3, 4, 5)), true);\n    assert_eq!(candidate((11, 12, 13), (10, 11, 12)), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to get the frequency of all the elements in a vector, returned as a HashMap.\nfn freq_count(list1: Vec<isize>) -> HashMap<isize, isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = freq_count;\n    assert_eq!(candidate(vec![10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]), HashMap::from([(10, 4), (20, 4), (40, 2), (50, 2), (30, 1)]));\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]), HashMap::from([(1, 3), (2, 2), (3, 3), (4, 3)]));\n    assert_eq!(candidate(vec![5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]), HashMap::from([(10, 1), (5, 3), (6, 2), (7, 2), (4, 2), (9, 2)]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "rs",
-    "prompt": "/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfn rgb_to_hsv(r: isize, g: isize, b: isize) -> Vec<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rgb_to_hsv;\n    assert_eq!(candidate(255, 255, 255), vec![0.0, 0.0, 100.0]);\n    assert_eq!(candidate(0, 215, 0), vec![120.0, 100.0, 84.31372549019608]);\n    assert_eq!(candidate(10, 215, 110), vec![149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfn check_str(string: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_str;\n    assert_eq!(candidate(String::from(\"annie\")), true);\n    assert_eq!(candidate(String::from(\"dawood\")), false);\n    assert_eq!(candidate(String::from(\"Else\")), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfn check_monthnumber_number(monthnum3: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumber_number;\n    assert_eq!(candidate(6), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(12), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "rs",
-    "prompt": "/// Write a function to sort the given vector.\nfn heap_sort(iterable: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = heap_sort;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 9, 2, 4, 6, 8, 0]), vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 25, 58]), vec![14, 22, 25, 25, 35, 58, 65, 75, 85]);\n    assert_eq!(candidate(vec![7, 1, 9, 5]), vec![1, 5, 7, 9]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "rs",
-    "prompt": "/// Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nfn k_smallest_pairs(nums1: Vec<isize>, nums2: Vec<isize>, k: isize) -> Vec<Vec<isize>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = k_smallest_pairs;\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 2), vec![vec![1, 2], vec![1, 4]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 1), vec![vec![1, 2]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 7), vec![vec![1, 2], vec![1, 4], vec![3, 2], vec![1, 6], vec![3, 4], vec![3, 6], vec![7, 2]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "rs",
-    "prompt": "/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfn find_solution(a: isize, b: isize, n: isize) -> Option<(isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_solution;\n    assert_eq!(candidate(2, 3, 7), Some((2, 1)));\n    assert_eq!(candidate(4, 2, 7), None);\n    assert_eq!(candidate(1, 13, 17), Some((4, 1)));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the largest number that can be formed with the given vector of digits.\nfn find_Max_Num(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Max_Num;\n    assert_eq!(candidate(vec![1, 2, 3]), 321);\n    assert_eq!(candidate(vec![4, 5, 6, 1]), 6541);\n    assert_eq!(candidate(vec![1, 2, 3, 9]), 9321);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "rs",
-    "prompt": "/// Write a function that returns the vector in a vector of vectors whose sum of elements is the highest.\nfn max_sum_list(lists: Vec<Vec<isize>>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum_list;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![10, 11, 12], vec![7, 8, 9]]), vec![10, 11, 12]);\n    assert_eq!(candidate(vec![vec![3, 2, 1], vec![6, 5, 4], vec![12, 11, 10]]), vec![12, 11, 10]);\n    assert_eq!(candidate(vec![vec![2, 3, 1]]), vec![2, 3, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to interchange the first and last elements in a vector.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![12, 35, 9, 56, 24]), vec![24, 35, 9, 56, 12]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "rs",
-    "prompt": "/// Write a function to find the median of two sorted vectors of same size.\nfn get_median(arr1: Vec<isize>, arr2: Vec<isize>, n: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_median;\n    assert_eq!(candidate(vec![1, 12, 15, 26, 38], vec![2, 13, 17, 30, 45], 5), 16.0);\n    assert_eq!(candidate(vec![2, 4, 8, 9], vec![7, 13, 19, 28], 4), 8.5);\n    assert_eq!(candidate(vec![3, 6, 14, 23, 36, 42], vec![2, 18, 27, 39, 49, 55], 6), 25.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfn replace_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"Jumanji The Jungle\")), String::from(\"Jumanji_The_Jungle\"));\n    assert_eq!(candidate(String::from(\"The_Avengers\")), String::from(\"The Avengers\"));\n    assert_eq!(candidate(String::from(\"Fast and Furious\")), String::from(\"Fast_and_Furious\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "rs",
-    "prompt": "/// Write a function to determine if the sum of the divisors of two integers are the same.\nfn are_equivalent(num1: isize, num2: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = are_equivalent;\n    assert_eq!(candidate(36, 57), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(23, 47), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "rs",
-    "prompt": "/// Write a function to reverse each string in a given vector of string values.\nfn reverse_string_list(stringlist: Vec<String>) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_string_list;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\"), String::from(\"White\"), String::from(\"Black\")]), vec![String::from(\"deR\"), String::from(\"neerG\"), String::from(\"eulB\"), String::from(\"etihW\"), String::from(\"kcalB\")]);\n    assert_eq!(candidate(vec![String::from(\"john\"), String::from(\"amal\"), String::from(\"joel\"), String::from(\"george\")]), vec![String::from(\"nhoj\"), String::from(\"lama\"), String::from(\"leoj\"), String::from(\"egroeg\")]);\n    assert_eq!(candidate(vec![String::from(\"jack\"), String::from(\"john\"), String::from(\"mary\")]), vec![String::from(\"kcaj\"), String::from(\"nhoj\"), String::from(\"yram\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth number in the newman conway sequence.\nfn sequence(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sequence;\n    assert_eq!(candidate(10), 6);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(3), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "rs",
-    "prompt": "/// Write a function to find the n largest integers from a given vector of numbers, returned in descending order.\nfn heap_queue_largest(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = heap_queue_largest;\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 3), vec![85, 75, 65]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 2), vec![85, 75]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 5), vec![85, 75, 65, 58, 35]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "rs",
-    "prompt": "/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfn loss_amount(actual_cost: isize, sale_amount: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = loss_amount;\n    assert_eq!(candidate(1500, 1200), 0);\n    assert_eq!(candidate(100, 200), 100);\n    assert_eq!(candidate(2000, 5000), 3000);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "rs",
-    "prompt": "/// Write a function to find the union of the elements of two given vectors and output them in sorted order.\nfn union_elements(test_tup1: Vec<isize>, test_tup2: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = union_elements;\n    assert_eq!(candidate(vec![3, 4, 5, 6], vec![5, 7, 4, 10]), vec![3, 4, 5, 6, 7, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![3, 4, 5, 6]), vec![1, 2, 3, 4, 5, 6]);\n    assert_eq!(candidate(vec![11, 12, 13, 14], vec![13, 15, 16, 17]), vec![11, 12, 13, 14, 15, 16, 17]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the length of the longest subvectors.\nfn Find_Max_Length(lst: Vec<Vec<isize>>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Find_Max_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 4], vec![5, 6, 7, 8]]), 4);\n    assert_eq!(candidate(vec![vec![0, 1], vec![2, 2], vec![3, 2, 1]]), 3);\n    assert_eq!(candidate(vec![vec![7], vec![22, 23], vec![13, 14, 15], vec![10, 20, 30, 40, 50]]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "rs",
-    "prompt": "/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfn remove_parenthesis(items: Vec<String>) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_parenthesis;\n    assert_eq!(candidate(vec![String::from(\"python (chrome)\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"string(.abc)\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"alpha(num)\")]), String::from(\"alpha\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find whether the parity of a given number is odd.\nfn find_Parity(x: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Parity;\n    assert_eq!(candidate(12), false);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(10), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "rs",
-    "prompt": "/// Write a function to find the median length of a trapezium.\nfn median_trapezium(base1: isize, base2: isize, height: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = median_trapezium;\n    assert_eq!(candidate(15, 25, 35), 20.0);\n    assert_eq!(candidate(10, 20, 30), 15.0);\n    assert_eq!(candidate(6, 9, 4), 7.5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "rs",
-    "prompt": "/// Write a function to find nth centered hexagonal number.\nfn centered_hexagonal_number(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = centered_hexagonal_number;\n    assert_eq!(candidate(10), 271);\n    assert_eq!(candidate(2), 7);\n    assert_eq!(candidate(9), 217);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfn get_max_sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_max_sum;\n    assert_eq!(candidate(60), 106);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(2), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the length of the longest word.\nfn len_log(list1: Vec<String>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = len_log;\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"PHP\"), String::from(\"bigdata\")]), 7);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]), 3);\n    assert_eq!(candidate(vec![String::from(\"small\"), String::from(\"big\"), String::from(\"tall\")]), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "rs",
-    "prompt": "/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfn sector_area(r: isize, a: isize) -> Option<f64> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sector_area;\n    assert_eq!(candidate(4, 45), Some(6.283185307179586));\n    assert_eq!(candidate(9, 45), Some(31.808625617596654));\n    assert_eq!(candidate(9, 361), None);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether every odd index contains odd numbers of a given vector.\nfn odd_position(nums: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = odd_position;\n    assert_eq!(candidate(vec![2, 1, 4, 3, 6, 7, 6, 3]), true);\n    assert_eq!(candidate(vec![4, 1, 2]), true);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "rs",
-    "prompt": "/// Write a function to join a vector of multiple integers into a single integer.\nfn multiple_to_single(L: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = multiple_to_single;\n    assert_eq!(candidate(vec![11, 33, 50]), 113350);\n    assert_eq!(candidate(vec![-1, 2, 3, 4, 5, 6]), -123456);\n    assert_eq!(candidate(vec![10, 15, 20, 25]), 10152025);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find whether a number is divisible by 11.\nfn is_Diff(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Diff;\n    assert_eq!(candidate(12345), false);\n    assert_eq!(candidate(1212112), true);\n    assert_eq!(candidate(1212), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "rs",
-    "prompt": "/// Write a function to perform index wise multiplication of vector elements in the given two vectors.\nfn index_multiplication(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = index_multiplication;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 21], vec![12, 45], vec![2, 9], vec![7, 30]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![14, 32], vec![20, 60], vec![6, 20], vec![16, 44]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![24, 45], vec![30, 77], vec![12, 33], vec![27, 60]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "rs",
-    "prompt": "/// Write a function to convert tuple string to integer tuple.\nfn tuple_str_int(test_str: String) -> (isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_str_int;\n    assert_eq!(candidate(String::from(\"(7, 8, 9)\")), (7, 8, 9));\n    assert_eq!(candidate(String::from(\"(1, 2, 3)\")), (1, 2, 3));\n    assert_eq!(candidate(String::from(\"(4, 5, 6)\")), (4, 5, 6));\n    assert_eq!(candidate(String::from(\"(7, 81, 19)\")), (7, 81, 19));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "rs",
-    "prompt": "/// Write a function to sum all amicable numbers from 1 to a specified number.\nfn amicable_numbers_sum(limit: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = amicable_numbers_sum;\n    assert_eq!(candidate(999), 504);\n    assert_eq!(candidate(9999), 31626);\n    assert_eq!(candidate(99), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "rs",
-    "prompt": "/// Write a function to remove odd characters in a string.\nfn remove_odd(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"yhn\"));\n    assert_eq!(candidate(String::from(\"program\")), String::from(\"rga\"));\n    assert_eq!(candidate(String::from(\"language\")), String::from(\"agae\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\nfn count_rotation(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_rotation;\n    assert_eq!(candidate(vec![3, 2, 1]), 1);\n    assert_eq!(candidate(vec![4, 5, 1, 2, 3]), 2);\n    assert_eq!(candidate(vec![7, 8, 9, 1, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 2, 3]), 0);\n    assert_eq!(candidate(vec![1, 3, 2]), 2);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "rs",
-    "prompt": "/// Write a function to extract the number of unique tuples in the given vector.\nfn extract_freq(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_freq;\n    assert_eq!(candidate(vec![(3, 4), (1, 2), (4, 3), (5, 6)]), 3);\n    assert_eq!(candidate(vec![(4, 15), (2, 3), (5, 4), (6, 7)]), 4);\n    assert_eq!(candidate(vec![(5, 16), (2, 3), (6, 5), (6, 9)]), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "rs",
-    "prompt": "/// The input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\nfn count_same_pair(nums1: Vec<isize>, nums2: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_same_pair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 11);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 1);\n    assert_eq!(candidate(vec![0, 1, 1, 2], vec![0, 1, 2, 2]), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "rs",
-    "prompt": "/// Write a function to calculate the value of 'a' to the power 'b'.\nfn power(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = power;\n    assert_eq!(candidate(3, 4), 81);\n    assert_eq!(candidate(2, 3), 8);\n    assert_eq!(candidate(5, 5), 3125);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write function to find the sum of all items in the given HashMap.\nfn return_sum(dict: HashMap<String, isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = return_sum;\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 100), (String::from(\"b\"), 200), (String::from(\"c\"), 300)])), 600);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 25), (String::from(\"b\"), 18), (String::from(\"c\"), 45)])), 88);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 36), (String::from(\"b\"), 39), (String::from(\"c\"), 49)])), 124);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "rs",
-    "prompt": "/// Write a function to return a vector of all pairs of consecutive items in a given vector.\nfn pair_wise(l1: Vec<isize>) -> Vec<(isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pair_wise;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 3, 4, 4, 5]), vec![(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), vec![(1, 5), (5, 7), (7, 9), (9, 10)]);\n    assert_eq!(candidate(vec![5, 1, 9, 7, 10]), vec![(5, 1), (1, 9), (9, 7), (7, 10)]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to split a string into characters.\nfn split(word: String) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = split;\n    assert_eq!(candidate(String::from(\"python\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]);\n    assert_eq!(candidate(String::from(\"Name\")), vec![String::from(\"N\"), String::from(\"a\"), String::from(\"m\"), String::from(\"e\")]);\n    assert_eq!(candidate(String::from(\"program\")), vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "rs",
-    "prompt": "/// Write a function to find minimum of three numbers.\nfn min_of_three(a: isize, b: isize, c: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = min_of_three;\n    assert_eq!(candidate(10, 20, 0), 0);\n    assert_eq!(candidate(19, 15, 18), 15);\n    assert_eq!(candidate(-10, -20, -30), -30);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfn is_Sum_Of_Powers_Of_Two(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_Sum_Of_Powers_Of_Two;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(7), false);\n    assert_eq!(candidate(14), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfn get_Char(strr: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_Char;\n    assert_eq!(candidate(String::from(\"abc\")), String::from(\"f\"));\n    assert_eq!(candidate(String::from(\"gfg\")), String::from(\"t\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"c\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "rs",
-    "prompt": "/// Write a function to return the sum of all divisors of a number.\nfn sum_div(number: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_div;\n    assert_eq!(candidate(8), 7);\n    assert_eq!(candidate(12), 16);\n    assert_eq!(candidate(7), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to remove duplicate numbers from a given number of vectors.\nfn two_unique_nums(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = two_unique_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 2, 3, 4, 5]), vec![1, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 5]), vec![1, 3, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "rs",
-    "prompt": "/// Write a function to find whether a given vector of integers contains any duplicate element.\nfn test_duplicate(arraynums: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = test_duplicate;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3, 3, 4, 4, 5]), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "rs",
-    "prompt": "/// Write a function which returns nth catalan number.\nfn catalan_number(num: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = catalan_number;\n    assert_eq!(candidate(10), 16796);\n    assert_eq!(candidate(9), 4862);\n    assert_eq!(candidate(7), 429);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "rs",
-    "prompt": "/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfn power_base_sum(base: isize, power: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = power_base_sum;\n    assert_eq!(candidate(2, 100), 115);\n    assert_eq!(candidate(8, 10), 37);\n    assert_eq!(candidate(8, 15), 62);\n    assert_eq!(candidate(3, 3), 9);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth octagonal number.\nfn is_octagonal(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_octagonal;\n    assert_eq!(candidate(5), 65);\n    assert_eq!(candidate(10), 280);\n    assert_eq!(candidate(15), 645);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfn replace_blank(str1: String, char: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_blank;\n    assert_eq!(candidate(String::from(\"hello people\"), String::from(\"@\")), String::from(\"hello@people\"));\n    assert_eq!(candidate(String::from(\"python program language\"), String::from(\"$\")), String::from(\"python$program$language\"));\n    assert_eq!(candidate(String::from(\"blank space\"), String::from(\"-\")), String::from(\"blank-space\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "rs",
-    "prompt": "/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfn replace_specialchar(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_specialchar;\n    assert_eq!(candidate(String::from(\"Python language, Programming language.\")), String::from(\"Python:language::Programming:language:\"));\n    assert_eq!(candidate(String::from(\"a b c,d e f\")), String::from(\"a:b:c:d:e:f\"));\n    assert_eq!(candidate(String::from(\"ram reshma,ram rahim\")), String::from(\"ram:reshma:ram:rahim\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "rs",
-    "prompt": "/// Write a function to convert a given tuple of positive integers into a single integer.\nfn tuple_to_int(nums: (isize, isize, isize)) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_int;\n    assert_eq!(candidate((1, 2, 3)), 123);\n    assert_eq!(candidate((4, 5, 6)), 456);\n    assert_eq!(candidate((5, 6, 7)), 567);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "rs",
-    "prompt": "/// Write a function to find the third side of a right angled triangle.\nfn otherside_rightangle(w: isize, h: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = otherside_rightangle;\n    assert_eq!(candidate(7, 8), 10.63014581273465);\n    assert_eq!(candidate(3, 4), 5.0);\n    assert_eq!(candidate(7, 15), 16.55294535724685);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of the per-digit difference between two integers.\nfn digit_distance_nums(n1: isize, n2: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = digit_distance_nums;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(23, 56), 6);\n    assert_eq!(candidate(123, 256), 7);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "rs",
-    "prompt": "/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfn text_match_wordz_middle(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz_middle;\n    assert_eq!(candidate(String::from(\"pythonzabc.\")), true);\n    assert_eq!(candidate(String::from(\"zxyabc.\")), false);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "rs",
-    "prompt": "/// Write a function to remove leading zeroes from an ip address.\nfn removezero_ip(ip: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = removezero_ip;\n    assert_eq!(candidate(String::from(\"216.08.094.196\")), String::from(\"216.8.94.196\"));\n    assert_eq!(candidate(String::from(\"12.01.024\")), String::from(\"12.1.24\"));\n    assert_eq!(candidate(String::from(\"216.08.094.0196\")), String::from(\"216.8.94.196\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "rs",
-    "prompt": "/// Write a function to multiply two integers.\nfn multiply_int(x: isize, y: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = multiply_int;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(5, 10), 50);\n    assert_eq!(candidate(4, 8), 32);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "rs",
-    "prompt": "/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfn add_pairwise(test_tup: (isize, isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_pairwise;\n    assert_eq!(candidate((1, 5, 7, 8, 10)), (6, 12, 15, 18));\n    assert_eq!(candidate((2, 6, 8, 9, 11)), (8, 14, 17, 20));\n    assert_eq!(candidate((3, 7, 9, 10, 12)), (10, 16, 19, 22));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\nfn max_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 36);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 200);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 484);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3160,7 +16,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find the kth element in the given vector using 1-based indexing.\nfn kth_element(arr: Vec<isize>, k: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = kth_element;\n    assert_eq!(candidate(vec![12, 3, 5, 7, 19], 2), 3);\n    assert_eq!(candidate(vec![17, 24, 8, 23], 3), 8);\n    assert_eq!(candidate(vec![16, 21, 25, 36, 4], 4), 36);\n}\n",
     "stop_tokens": [
@@ -3168,241 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to interchange the first and last element in a given vector.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a function to convert a snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), vec![4, 2, 3, 4, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"python_program\")), String::from(\"PythonProgram\"));\n    assert_eq!(candidate(String::from(\"python_language\")), String::from(\"PythonLanguage\"));\n    assert_eq!(candidate(String::from(\"programming_language\")), String::from(\"ProgrammingLanguage\"));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_103_eulerian_num",
     "language": "rs",
-    "prompt": "/// Write a function to locate the right insertion point for a specified value in sorted order.\nfn right_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "prompt": "/// Write a function to find the Eulerian number a(n, m).\nfn eulerian_num(n: isize, m: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = right_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = eulerian_num;\n    assert_eq!(candidate(3, 1), 4);\n    assert_eq!(candidate(4, 1), 11);\n    assert_eq!(candidate(5, 3), 26);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_104_sort_sublists",
     "language": "rs",
-    "prompt": "/// Write a function to check if the given number is woodball or not.\nfn is_woodall(x: isize) -> bool {\n",
+    "prompt": "/// Write a function to sort each subvector of strings in a given vector of vectors.\nfn sort_sublists(input_list: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_woodall;\n    assert_eq!(candidate(383), true);\n    assert_eq!(candidate(254), false);\n    assert_eq!(candidate(200), false);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\"blue \"), String::from(\" black\")], vec![String::from(\" orange\"), String::from(\"brown\")]]), vec![vec![String::from(\" red \"), String::from(\"green\")], vec![String::from(\" black\"), String::from(\"blue \")], vec![String::from(\" orange\"), String::from(\"brown\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"zilver\"), String::from(\"gold\")], vec![String::from(\"magnesium\"), String::from(\"aluminium\")], vec![String::from(\"steel\"), String::from(\"bronze\")]]), vec![vec![String::from(\"gold\"), String::from(\"zilver\")], vec![String::from(\"aluminium\"), String::from(\"magnesium\")], vec![String::from(\"bronze\"), String::from(\"steel\")]]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_105_count",
     "language": "rs",
-    "prompt": "/// Write a function to sort the given vector by using shell sort.\nfn shell_sort(my_list: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a rsthon function to count true booleans in the given vector.\nfn count(lst: Vec<bool>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = shell_sort;\n    assert_eq!(candidate(vec![12, 23, 4, 5, 3, 2, 12, 81, 56, 95]), vec![2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n    assert_eq!(candidate(vec![24, 22, 39, 34, 87, 73, 68]), vec![22, 24, 34, 39, 68, 73, 87]);\n    assert_eq!(candidate(vec![32, 30, 16, 96, 82, 83, 74]), vec![16, 30, 32, 74, 82, 83, 96]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = count;\n    assert_eq!(candidate(vec![true, false, true]), 2);\n    assert_eq!(candidate(vec![false, false]), 0);\n    assert_eq!(candidate(vec![true, true, true]), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_106_add_lists",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of pairs whose xor value is odd.\nfn find_Odd_Pair(A: Vec<isize>, N: isize) -> isize {\n",
+    "prompt": "/// Write a function to append the given vector to the given tuples.\nfn add_lists(test_list: Vec<isize>, test_tup: (isize, isize)) -> (isize, isize, isize, isize, isize) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Odd_Pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1], 5), 6);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11], 7), 12);\n    assert_eq!(candidate(vec![1, 2, 3], 3), 2);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = add_lists;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), (9, 10, 5, 6, 7));\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), (10, 11, 6, 7, 8));\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), (11, 12, 7, 8, 9));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of all odd natural numbers within the range l and r.\nfn sum_in_range(l: isize, r: isize) -> isize {\n",
+    "prompt": "/// Write a function to merge three vectors into a single sorted vector.\nfn merge_sorted_list(num1: Vec<isize>, num2: Vec<isize>, num3: Vec<isize>) -> Vec<isize> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_in_range;\n    assert_eq!(candidate(2, 5), 8);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 13), 40);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = merge_sorted_list;\n    assert_eq!(candidate(vec![25, 24, 15, 4, 5, 29, 110], vec![19, 20, 11, 56, 25, 233, 154], vec![24, 26, 54, 48]), vec![4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n    assert_eq!(candidate(vec![1, 3, 5, 6, 8, 9], vec![2, 5, 7, 11], vec![1, 4, 7, 8, 12]), vec![1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n    assert_eq!(candidate(vec![18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], vec![25, 35, 22, 85, 14, 65, 75, 25, 58], vec![12, 74, 9, 50, 61, 41]), vec![1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "rs",
-    "prompt": "/// Write a function that returns the perimeter of a square given its side length as input.\nfn square_perimeter(a: isize) -> isize {\n",
+    "prompt": "/// Write a rsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfn odd_Equivalent(s: String, n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = square_perimeter;\n    assert_eq!(candidate(10), 40);\n    assert_eq!(candidate(5), 20);\n    assert_eq!(candidate(4), 16);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_Equivalent;\n    assert_eq!(candidate(String::from(\"011001\"), 6), 3);\n    assert_eq!(candidate(String::from(\"11011\"), 5), 4);\n    assert_eq!(candidate(String::from(\"1010\"), 4), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_113_check_integer",
     "language": "rs",
-    "prompt": "/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfn is_polite(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to check if a string represents an integer or not.\nfn check_integer(text: String) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_polite;\n    assert_eq!(candidate(7), 11);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(9), 13);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = check_integer;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"1\")), true);\n    assert_eq!(candidate(String::from(\"12345\")), true);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_162_sum_series",
+    "name": "mbpp_116_tuple_to_int",
     "language": "rs",
-    "prompt": "/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfn sum_series(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to convert a given tuple of positive integers into a single integer.\nfn tuple_to_int(nums: (isize, isize, isize)) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_series;\n    assert_eq!(candidate(6), 12);\n    assert_eq!(candidate(10), 30);\n    assert_eq!(candidate(9), 25);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "rs",
-    "prompt": "/// Write a function to find the dissimilar elements in the given two tuples.\nfn find_dissimilar(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_dissimilar;\n    assert_eq!(candidate((3, 4, 5, 6), (5, 7, 4, 10)), (3, 6, 7, 10));\n    assert_eq!(candidate((1, 2, 3, 4), (7, 2, 3, 9)), (1, 4, 7, 9));\n    assert_eq!(candidate((21, 11, 25, 26), (26, 34, 21, 36)), (34, 36, 11, 25));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "rs",
-    "prompt": "/// Write a function to return two words from a vector of words starting with letter 'p'.\nfn start_withp(words: Vec<String>) -> (String, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = start_withp;\n    assert_eq!(candidate(vec![String::from(\"Python PHP\"), String::from(\"Java JavaScript\"), String::from(\"c c++\")]), (String::from(\"Python\"), String::from(\"PHP\")));\n    assert_eq!(candidate(vec![String::from(\"Python Programming\"), String::from(\"Java Programming\")]), (String::from(\"Python\"), String::from(\"Programming\")));\n    assert_eq!(candidate(vec![String::from(\"Pqrst Pqr\"), String::from(\"qrstuv\")]), (String::from(\"Pqrst\"), String::from(\"Pqr\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "rs",
-    "prompt": "/// Write a function to convert the given snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"android_tv\")), String::from(\"AndroidTv\"));\n    assert_eq!(candidate(String::from(\"google_pixel\")), String::from(\"GooglePixel\"));\n    assert_eq!(candidate(String::from(\"apple_watch\")), String::from(\"AppleWatch\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "rs",
-    "prompt": "/// Write a function to find the volume of a cube given its side length.\nfn volume_cube(l: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = volume_cube;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(2), 8);\n    assert_eq!(candidate(5), 125);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given month number contains 31 days or not.\nfn check_monthnumb_number(monthnum2: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumb_number;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(6), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether all the bits are unset in the given range or not.\nfn all_Bits_Set_In_The_Given_Range(n: isize, l: isize, r: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = all_Bits_Set_In_The_Given_Range;\n    assert_eq!(candidate(4, 1, 2), true);\n    assert_eq!(candidate(17, 2, 4), true);\n    assert_eq!(candidate(39, 4, 6), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to get the first element of each subvector.\nfn Extract(lst: Vec<Vec<isize>>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = Extract;\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4, 5], vec![6, 7, 8, 9]]), vec![1, 3, 6]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5]]), vec![1, 4]);\n    assert_eq!(candidate(vec![vec![9, 8, 1], vec![1, 2]]), vec![9, 1]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "rs",
-    "prompt": "/// Write a function to find the surface area of a cylinder.\nfn surfacearea_cylinder(r: isize, h: isize) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cylinder;\n    assert_eq!(candidate(10, 5), 942.45);\n    assert_eq!(candidate(4, 5), 226.18800000000002);\n    assert_eq!(candidate(4, 10), 351.848);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "rs",
-    "prompt": "/// Write a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\nfn sample_nam(sample_names: Vec<String>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sample_nam;\n    assert_eq!(candidate(vec![String::from(\"sally\"), String::from(\"Dylan\"), String::from(\"rebecca\"), String::from(\"Diana\"), String::from(\"Joanne\"), String::from(\"keith\")]), 16);\n    assert_eq!(candidate(vec![String::from(\"php\"), String::from(\"res\"), String::from(\"Python\"), String::from(\"abcd\"), String::from(\"Java\"), String::from(\"aaa\")]), 10);\n    assert_eq!(candidate(vec![String::from(\"abcd\"), String::from(\"Python\"), String::from(\"abba\"), String::from(\"aba\")]), 6);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "rs",
-    "prompt": "/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfn perimeter_pentagon(a: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = perimeter_pentagon;\n    assert_eq!(candidate(5), 25);\n    assert_eq!(candidate(10), 50);\n    assert_eq!(candidate(15), 75);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "rs",
-    "prompt": "/// Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nfn max_sum(arr: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum;\n    assert_eq!(candidate(vec![1, 15, 51, 45, 33, 100, 12, 18, 9]), 194);\n    assert_eq!(candidate(vec![80, 60, 30, 40, 20, 10]), 210);\n    assert_eq!(candidate(vec![2, 3, 14, 16, 21, 23, 29, 30]), 138);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_int;\n    assert_eq!(candidate((1, 2, 3)), 123);\n    assert_eq!(candidate((4, 5, 6)), 456);\n    assert_eq!(candidate((5, 6, 7)), 567);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3412,177 +136,9 @@
     "language": "rs",
     "prompt": "/// Write a function to convert all possible convertible elements in a vector of vectors to floats.\nfn list_to_float(test_list: Vec<(String, String)>) -> Vec<(f64, f64)> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = list_to_float;\n    assert_eq!(candidate(vec![(String::from(\"3\"), String::from(\"4\")), (String::from(\"1\"), String::from(\"26.45\")), (String::from(\"7.32\"), String::from(\"8\")), (String::from(\"4\"), String::from(\"8\"))]), vec![(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]);\n    assert_eq!(candidate(vec![(String::from(\"4\"), String::from(\"4\")), (String::from(\"2\"), String::from(\"27\")), (String::from(\"4.12\"), String::from(\"9\")), (String::from(\"7\"), String::from(\"11\"))]), vec![(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)]);\n    assert_eq!(candidate(vec![(String::from(\"6\"), String::from(\"78\")), (String::from(\"5\"), String::from(\"26.45\")), (String::from(\"1.33\"), String::from(\"4\")), (String::from(\"82\"), String::from(\"13\"))]), vec![(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 20);\n    assert_eq!(candidate(3), 56);\n    assert_eq!(candidate(4), 120);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\nfn get_pairs_count(arr: Vec<isize>, sum: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_pairs_count;\n    assert_eq!(candidate(vec![1, 1, 1, 1], 2), 6);\n    assert_eq!(candidate(vec![1, 5, 7, -1, 5], 6), 3);\n    assert_eq!(candidate(vec![1, -2, 3], 1), 1);\n    assert_eq!(candidate(vec![-1, -2, 3], -3), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "rs",
-    "prompt": "/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfn count_no_of_ways(n: isize, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_no_of_ways;\n    assert_eq!(candidate(2, 4), 16);\n    assert_eq!(candidate(3, 2), 6);\n    assert_eq!(candidate(4, 4), 228);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "rs",
-    "prompt": "/// Write a function to reverse words seperated by spaces in a given string.\nfn reverse_words(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = reverse_words;\n    assert_eq!(candidate(String::from(\"python program\")), String::from(\"program python\"));\n    assert_eq!(candidate(String::from(\"java language\")), String::from(\"language java\"));\n    assert_eq!(candidate(String::from(\"indian man\")), String::from(\"man indian\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to check if a given number is one less than twice its reverse.\nfn checks(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = checks;\n    assert_eq!(candidate(70), false);\n    assert_eq!(candidate(23), false);\n    assert_eq!(candidate(73), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the last position of an element in a sorted vector.\nfn last(arr: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = last;\n    assert_eq!(candidate(vec![1, 2, 3], 1), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, 4], 1), 2);\n    assert_eq!(candidate(vec![2, 3, 2, 3, 6, 8, 9], 3), 3);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\nfn count_X(tup: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_X;\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4), 0);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10), 3);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to concatenate each element of tuple by the delimiter.\nfn concatenate_tuple(test_tup: (String, String, isize, String)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = concatenate_tuple;\n    assert_eq!(candidate((String::from(\"ID\"), String::from(\"is\"), 4, String::from(\"UTS\"))), String::from(\"ID-is-4-UTS\"));\n    assert_eq!(candidate((String::from(\"QWE\"), String::from(\"is\"), 4, String::from(\"RTY\"))), String::from(\"QWE-is-4-RTY\"));\n    assert_eq!(candidate((String::from(\"ZEN\"), String::from(\"is\"), 4, String::from(\"OP\"))), String::from(\"ZEN-is-4-OP\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to replace all spaces in the given string with '%20'.\nfn replace_spaces(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"My Name is Dawood\")), String::from(\"My%20Name%20is%20Dawood\"));\n    assert_eq!(candidate(String::from(\"I am a Programmer\")), String::from(\"I%20am%20a%20Programmer\"));\n    assert_eq!(candidate(String::from(\"I love Coding\")), String::from(\"I%20love%20Coding\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "rs",
-    "prompt": "/// Write a function to find the sum of numbers in a vector within a range specified by two indices.\nfn sum_range_list(list1: Vec<isize>, m: isize, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sum_range_list;\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10), 29);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7), 16);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10), 38);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to merge three dictionaries into a single HashMap.\nfn merge_dictionaries_three(dict1: HashMap<String, String>, dict2: HashMap<String, String>, dict3: HashMap<String, String>) -> HashMap<String, String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = merge_dictionaries_three;\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"O\"), String::from(\"Orange\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"B\"), String::from(\"Black\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"O\"), String::from(\"Orange\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))])), HashMap::from([(String::from(\"W\"), String::from(\"White\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\")), (String::from(\"W\"), String::from(\"White\"))]));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the minimum of two numbers.\nfn minimum(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = minimum;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(-5, -4), -5);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum difference between available pairs in the given tuple vector.\nfn max_difference(test_list: Vec<(isize, isize)>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_difference;\n    assert_eq!(candidate(vec![(3, 5), (1, 7), (10, 3), (1, 2)]), 7);\n    assert_eq!(candidate(vec![(4, 6), (2, 17), (9, 13), (11, 12)]), 15);\n    assert_eq!(candidate(vec![(12, 35), (21, 27), (13, 23), (41, 22)]), 23);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find element at a given index after number of rotations.\nfn find_Element(arr: Vec<isize>, ranges: Vec<Vec<isize>>, rotations: isize, index: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_Element;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![vec![0, 2], vec![0, 3]], 2, 1), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![vec![0, 1], vec![0, 2]], 1, 2), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![vec![0, 1], vec![0, 2]], 1, 1), 1);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3592,7 +148,7 @@
     "language": "rs",
     "prompt": "/// Write a function to convert a string to a vector of strings split on the space character.\nfn string_to_list(string: String) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = string_to_list;\n    assert_eq!(candidate(String::from(\"python programming\")), vec![String::from(\"python\"), String::from(\"programming\")]);\n    assert_eq!(candidate(String::from(\"lists tuples strings\")), vec![String::from(\"lists\"), String::from(\"tuples\"), String::from(\"strings\")]);\n    assert_eq!(candidate(String::from(\"write a program\")), vec![String::from(\"write\"), String::from(\"a\"), String::from(\"program\")]);\n}\n",
     "stop_tokens": [
@@ -3604,21 +160,9 @@
     "language": "rs",
     "prompt": "/// Write a rsthon function to find the element that appears only once in a sorted vector.\nfn search(arr: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = search;\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]), 8);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 4, 4]), 1);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to sort a HashMap by value.\nfn sort_counter(dict1: HashMap<String, isize>) -> Vec<(String, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_counter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 81), (String::from(\"Physics\"), 83), (String::from(\"Chemistry\"), 87)])), vec![(String::from(\"Chemistry\"), 87), (String::from(\"Physics\"), 83), (String::from(\"Math\"), 81)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)])), vec![(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 900), (String::from(\"Physics\"), 1000), (String::from(\"Chemistry\"), 1250)])), vec![(String::from(\"Chemistry\"), 1250), (String::from(\"Physics\"), 1000), (String::from(\"Math\"), 900)]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3628,7 +172,7 @@
     "language": "rs",
     "prompt": "/// Write a rsthon function to remove first and last occurrence of a given character from the string.\nfn remove_Occ(s: String, ch: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = remove_Occ;\n    assert_eq!(candidate(String::from(\"hello\"), String::from(\"l\")), String::from(\"heo\"));\n    assert_eq!(candidate(String::from(\"abcda\"), String::from(\"a\")), String::from(\"bcd\"));\n    assert_eq!(candidate(String::from(\"PHP\"), String::from(\"P\")), String::from(\"H\"));\n}\n",
     "stop_tokens": [
@@ -3636,277 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "rs",
-    "prompt": "/// Write a function to find the lateral surface area of a cube given its side length.\nfn lateralsurface_cube(l: isize) -> isize {\n",
+    "prompt": "/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given vector.\nfn max_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cube;\n    assert_eq!(candidate(5), 100);\n    assert_eq!(candidate(9), 324);\n    assert_eq!(candidate(10), 400);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = max_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 36);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 200);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 484);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "rs",
-    "prompt": "/// Write a function to append the given vector to the given tuples.\nfn add_lists(test_list: Vec<isize>, test_tup: (isize, isize)) -> (isize, isize, isize, isize, isize) {\n",
+    "prompt": "/// Write a function to sum all amicable numbers from 1 to a specified number.\nfn amicable_numbers_sum(limit: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_lists;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), (9, 10, 5, 6, 7));\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), (10, 11, 6, 7, 8));\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), (11, 12, 7, 8, 9));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = amicable_numbers_sum;\n    assert_eq!(candidate(999), 504);\n    assert_eq!(candidate(9999), 31626);\n    assert_eq!(candidate(99), 0);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_125_find_length",
     "language": "rs",
-    "prompt": "/// Write a function to compute the n-th power of each number in a vector.\nfn nth_nums(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "prompt": "/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfn find_length(string: String) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = nth_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30], 3), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15], 5), vec![248832, 759375]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = find_length;\n    assert_eq!(candidate(String::from(\"11000010001\")), 6);\n    assert_eq!(candidate(String::from(\"10111\")), 1);\n    assert_eq!(candidate(String::from(\"11011101100101\")), 2);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_126_sum",
     "language": "rs",
-    "prompt": "/// Write a function to sort a vector of elements.\nfn pancake_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a rsthon function to find the sum of common divisors of two given numbers.\nfn sum(a: isize, b: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = pancake_sort;\n    assert_eq!(candidate(vec![15, 79, 25, 38, 69]), vec![15, 25, 38, 69, 79]);\n    assert_eq!(candidate(vec![98, 12, 54, 36, 85]), vec![12, 36, 54, 85, 98]);\n    assert_eq!(candidate(vec![41, 42, 32, 12, 23]), vec![12, 23, 32, 41, 42]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sum;\n    assert_eq!(candidate(10, 15), 6);\n    assert_eq!(candidate(100, 150), 93);\n    assert_eq!(candidate(4, 6), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_397_median_numbers",
+    "name": "mbpp_127_multiply_int",
     "language": "rs",
-    "prompt": "/// Write a function to find the median of three numbers.\nfn median_numbers(a: isize, b: isize, c: isize) -> f64 {\n",
+    "prompt": "/// Write a function to multiply two integers.\nfn multiply_int(x: isize, y: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = median_numbers;\n    assert_eq!(candidate(25, 55, 65), 55.0);\n    assert_eq!(candidate(20, 10, 30), 20.0);\n    assert_eq!(candidate(15, 45, 75), 45.0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the entered number is greater than the elements of the given vector.\nfn check_greater(arr: Vec<isize>, number: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_greater;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 4), false);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6], 8), true);\n    assert_eq!(candidate(vec![9, 7, 4, 8, 6, 1], 11), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "rs",
-    "prompt": "/// Write a function to extract specified size of strings from a given vector of string values.\nfn extract_string(str: Vec<String>, l: isize) -> Vec<String> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = extract_string;\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 8), vec![String::from(\"practice\"), String::from(\"solution\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 6), vec![String::from(\"Python\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 9), vec![String::from(\"exercises\")]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "rs",
-    "prompt": "/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfn text_lowercase_underscore(text: String) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = text_lowercase_underscore;\n    assert_eq!(candidate(String::from(\"aab_cbbbc\")), true);\n    assert_eq!(candidate(String::from(\"aab_Abbbc\")), false);\n    assert_eq!(candidate(String::from(\"Aaab_abbbc\")), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to trim each vector by k in the given vectors.\nfn trim_tuple(test_list: Vec<Vec<isize>>, K: isize) -> Vec<Vec<isize>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = trim_tuple;\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 2), vec![vec![2], vec![9], vec![2], vec![2]]);\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 1), vec![vec![3, 2, 1], vec![4, 9, 2], vec![1, 2, 3], vec![8, 2, 1]]);\n    assert_eq!(candidate(vec![vec![7, 8, 4, 9], vec![11, 8, 12, 4], vec![4, 1, 7, 8], vec![3, 6, 9, 7]], 1), vec![vec![8, 4], vec![8, 12], vec![1, 7], vec![6, 9]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "rs",
-    "prompt": "/// Write a function to filter odd numbers.\nfn filter_oddnumbers(nums: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = filter_oddnumbers;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 3, 5, 7, 9]);\n    assert_eq!(candidate(vec![10, 20, 45, 67, 84, 93]), vec![45, 67, 93]);\n    assert_eq!(candidate(vec![5, 7, 9, 8, 6, 4, 3]), vec![5, 7, 9, 3]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "rs",
-    "prompt": "/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfn find_adverbs(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_adverbs;\n    assert_eq!(candidate(String::from(\"Clearly, he has no excuse for such behavior.\")), String::from(\"0-7: Clearly\"));\n    assert_eq!(candidate(String::from(\"Please handle the situation carefuly\")), String::from(\"28-36: carefuly\"));\n    assert_eq!(candidate(String::from(\"Complete the task quickly\")), String::from(\"18-25: quickly\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "rs",
-    "prompt": "/// Write a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\nfn max_of_nth(test_list: Vec<Vec<isize>>, N: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_of_nth;\n    assert_eq!(candidate(vec![vec![5, 6, 7], vec![1, 3, 5], vec![8, 9, 19]], 2), 19);\n    assert_eq!(candidate(vec![vec![6, 7, 8], vec![2, 4, 6], vec![9, 10, 20]], 1), 10);\n    assert_eq!(candidate(vec![vec![7, 8, 9], vec![3, 5, 7], vec![10, 11, 21]], 1), 11);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "rs",
-    "prompt": "/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfn decimal_to_binary(n: isize) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(8), String::from(\"1000\"));\n    assert_eq!(candidate(18), String::from(\"10010\"));\n    assert_eq!(candidate(7), String::from(\"111\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\nfn combinations_colors(l: Vec<String>, n: isize) -> Vec<Vec<String>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = combinations_colors;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 1), vec![vec![String::from(\"Red\")], vec![String::from(\"Green\")], vec![String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 2), vec![vec![String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 3), vec![vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\"), String::from(\"Blue\")]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "rs",
-    "prompt": "/// Write a function to remove all whitespaces from a string.\nfn remove_all_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_all_spaces;\n    assert_eq!(candidate(String::from(\"python  program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"python   programming    language\")), String::from(\"pythonprogramminglanguage\"));\n    assert_eq!(candidate(String::from(\"python                     program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"   python                     program\")), String::from(\"pythonprogram\"));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to create a new tuple from the given string and vector.\nfn new_tuple(test_list: Vec<String>, test_str: String) -> (String, String, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = new_tuple;\n    assert_eq!(candidate(vec![String::from(\"WEB\"), String::from(\"is\")], String::from(\"best\")), (String::from(\"WEB\"), String::from(\"is\"), String::from(\"best\")));\n    assert_eq!(candidate(vec![String::from(\"We\"), String::from(\"are\")], String::from(\"Developers\")), (String::from(\"We\"), String::from(\"are\"), String::from(\"Developers\")));\n    assert_eq!(candidate(vec![String::from(\"Part\"), String::from(\"is\")], String::from(\"Wrong\")), (String::from(\"Part\"), String::from(\"is\"), String::from(\"Wrong\")));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the product of the vector multiplication modulo n.\nfn find_remainder(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_remainder;\n    assert_eq!(candidate(vec![100, 10, 5, 25, 35, 14], 11), 9);\n    assert_eq!(candidate(vec![1, 1, 1], 1), 0);\n    assert_eq!(candidate(vec![1, 2, 1], 2), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "rs",
-    "prompt": "/// Write a function to find the ration of positive numbers in a vector of integers.\nfn positive_count(nums: Vec<isize>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = positive_count;\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]), 0.54);\n    assert_eq!(candidate(vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 0.69);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), 0.56);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "rs",
-    "prompt": "/// Write a function to add the given tuple to the given vector.\nfn add_tuple(test_list: Vec<isize>, test_tup: (isize, isize)) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = add_tuple;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), vec![5, 6, 7, 9, 10]);\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), vec![6, 7, 8, 10, 11]);\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), vec![7, 8, 9, 11, 12]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "rs",
-    "prompt": "/// Write a function to find maximum run of uppercase characters in the given string.\nfn max_run_uppercase(test_str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_run_uppercase;\n    assert_eq!(candidate(String::from(\"GeMKSForGERksISBESt\")), 5);\n    assert_eq!(candidate(String::from(\"PrECIOusMOVemENTSYT\")), 6);\n    assert_eq!(candidate(String::from(\"GooGLEFluTTER\")), 4);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "rs",
-    "prompt": "/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfn sort_matrix(M: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sort_matrix;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![2, 4, 5], vec![1, 1, 1]]), vec![vec![1, 1, 1], vec![1, 2, 3], vec![2, 4, 5]]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![-2, 4, -5], vec![1, -1, 1]]), vec![vec![-2, 4, -5], vec![1, -1, 1], vec![1, 2, 3]]);\n    assert_eq!(candidate(vec![vec![5, 8, 9], vec![6, 4, 3], vec![2, 1, 4]]), vec![vec![2, 1, 4], vec![6, 4, 3], vec![5, 8, 9]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "rs",
-    "prompt": "/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfn count_vowels(test_str: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_vowels;\n    assert_eq!(candidate(String::from(\"bestinstareels\")), 7);\n    assert_eq!(candidate(String::from(\"partofthejourneyistheend\")), 12);\n    assert_eq!(candidate(String::from(\"amazonprime\")), 5);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "rs",
-    "prompt": "/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfn max_sum_increasing_subseq(a: Vec<isize>, n: isize, index: isize, k: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = max_sum_increasing_subseq;\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 4, 6), 11);\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 2, 5), 7);\n    assert_eq!(candidate(vec![11, 15, 19, 21, 26, 28, 31], 7, 2, 4), 71);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = multiply_int;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(5, 10), 50);\n    assert_eq!(candidate(4, 8), 32);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -3916,7 +244,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find words that are longer than n characters from a given vector of words.\nfn long_words(n: isize, str: String) -> Vec<String> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = long_words;\n    assert_eq!(candidate(3, String::from(\"python is a programming language\")), vec![String::from(\"python\"), String::from(\"programming\"), String::from(\"language\")]);\n    assert_eq!(candidate(2, String::from(\"writing a program\")), vec![String::from(\"writing\"), String::from(\"program\")]);\n    assert_eq!(candidate(5, String::from(\"sorting list\")), vec![String::from(\"sorting\")]);\n}\n",
     "stop_tokens": [
@@ -3924,193 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of non-repeated elements in a given vector.\nfn find_sum(arr: Vec<isize>) -> isize {\n",
+    "prompt": "/// Write a function to calculate whether the matrix is a magic square.\nfn magic_square_test(my_matrix: Vec<Vec<isize>>) -> bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_sum;\n    assert_eq!(candidate(vec![1, 2, 3, 1, 1, 4, 5, 6]), 21);\n    assert_eq!(candidate(vec![1, 10, 9, 4, 2, 10, 10, 45, 4]), 71);\n    assert_eq!(candidate(vec![12, 10, 9, 45, 2, 10, 10, 45, 10]), 78);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = magic_square_test;\n    assert_eq!(candidate(vec![vec![7, 12, 1, 14], vec![2, 13, 8, 11], vec![16, 3, 10, 5], vec![9, 6, 15, 4]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 8]]), true);\n    assert_eq!(candidate(vec![vec![2, 7, 6], vec![9, 5, 1], vec![4, 3, 7]]), false);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "rs",
-    "prompt": "use std::collections::HashMap;\n\n/// Write a function to convert the given tuple to a key-value HashMap using adjacent elements. https://www.geeksforgeeks.org/rsthon-convert-tuple-to-adjacent-pair-HashMap/\nfn tuple_to_dict(test_tup: (isize, isize, isize, isize, isize, isize)) -> HashMap<isize, isize> {\n",
+    "prompt": "/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfn sort_matrix(M: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_dict;\n    assert_eq!(candidate((1, 5, 7, 10, 13, 5)), HashMap::from([(1, 5), (7, 10), (13, 5)]));\n    assert_eq!(candidate((1, 2, 3, 4, 5, 6)), HashMap::from([(1, 2), (3, 4), (5, 6)]));\n    assert_eq!(candidate((7, 8, 9, 10, 11, 12)), HashMap::from([(7, 8), (9, 10), (11, 12)]));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_matrix;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![2, 4, 5], vec![1, 1, 1]]), vec![vec![1, 1, 1], vec![1, 2, 3], vec![2, 4, 5]]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![-2, 4, -5], vec![1, -1, 1]]), vec![vec![-2, 4, -5], vec![1, -1, 1], vec![1, 2, 3]]);\n    assert_eq!(candidate(vec![vec![5, 8, 9], vec![6, 4, 3], vec![2, 1, 4]]), vec![vec![2, 1, 4], vec![6, 4, 3], vec![5, 8, 9]]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "rs",
-    "prompt": "/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfn get_coordinates(test_tup: (isize, isize)) -> Vec<Vec<isize>> {\n",
+    "prompt": "/// Write a function to find the item with maximum frequency in a given vector.\nfn max_occurrences(nums: Vec<isize>) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = get_coordinates;\n    assert_eq!(candidate((3, 4)), vec![vec![2, 3], vec![2, 4], vec![2, 5], vec![3, 3], vec![3, 4], vec![3, 5], vec![4, 3], vec![4, 4], vec![4, 5]]);\n    assert_eq!(candidate((4, 5)), vec![vec![3, 4], vec![3, 5], vec![3, 6], vec![4, 4], vec![4, 5], vec![4, 6], vec![5, 4], vec![5, 5], vec![5, 6]]);\n    assert_eq!(candidate((5, 6)), vec![vec![4, 5], vec![4, 6], vec![4, 7], vec![5, 5], vec![5, 6], vec![5, 7], vec![6, 5], vec![6, 6], vec![6, 7]]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the smallest missing number from a sorted vector of natural numbers.\nfn find_First_Missing(array: Vec<isize>) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_First_Missing;\n    assert_eq!(candidate(vec![0, 1, 2, 3]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, 6, 9]), 3);\n    assert_eq!(candidate(vec![2, 3, 5, 8, 9]), 0);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the given number is undulating or not.\nfn is_undulating(n: isize) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_undulating;\n    assert_eq!(candidate(1212121), true);\n    assert_eq!(candidate(1991), false);\n    assert_eq!(candidate(121), true);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "rs",
-    "prompt": "/// Write a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/rsthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cors of test cases\nfn min_k(test_list: Vec<(String, isize)>, K: isize) -> Vec<(String, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = min_k;\n    assert_eq!(candidate(vec![(String::from(\"Manjeet\"), 10), (String::from(\"Akshat\"), 4), (String::from(\"Akash\"), 2), (String::from(\"Nikhil\"), 8)], 2), vec![(String::from(\"Akash\"), 2), (String::from(\"Akshat\"), 4)]);\n    assert_eq!(candidate(vec![(String::from(\"Sanjeev\"), 11), (String::from(\"Angat\"), 5), (String::from(\"Akash\"), 3), (String::from(\"Nepin\"), 9)], 3), vec![(String::from(\"Akash\"), 3), (String::from(\"Angat\"), 5), (String::from(\"Nepin\"), 9)]);\n    assert_eq!(candidate(vec![(String::from(\"tanmay\"), 14), (String::from(\"Amer\"), 11), (String::from(\"Ayesha\"), 9), (String::from(\"SKD\"), 16)], 1), vec![(String::from(\"Ayesha\"), 9)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to count the number of substrings with the sum of digits equal to their length.\nfn count_Substrings(s: String) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Substrings;\n    assert_eq!(candidate(String::from(\"112112\")), 6);\n    assert_eq!(candidate(String::from(\"111\")), 6);\n    assert_eq!(candidate(String::from(\"1101112\")), 12);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "rs",
-    "prompt": "/// Write a function to find the nth decagonal number.\nfn is_num_decagonal(n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_num_decagonal;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(7), 175);\n    assert_eq!(candidate(10), 370);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\nfn rear_extract(test_list: Vec<(isize, String, isize)>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = rear_extract;\n    assert_eq!(candidate(vec![(1, String::from(\"Rash\"), 21), (2, String::from(\"Varsha\"), 20), (3, String::from(\"Kil\"), 19)]), vec![21, 20, 19]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sai\"), 36), (2, String::from(\"Ayesha\"), 25), (3, String::from(\"Salman\"), 45)]), vec![36, 25, 45]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sudeep\"), 14), (2, String::from(\"Vandana\"), 36), (3, String::from(\"Dawood\"), 56)]), vec![14, 36, 56]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "rs",
-    "prompt": "/// Write a function to find the closest smaller number than n.\nfn closest_num(N: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = closest_num;\n    assert_eq!(candidate(11), 10);\n    assert_eq!(candidate(7), 6);\n    assert_eq!(candidate(12), 11);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "rs",
-    "prompt": "/// Write a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/rsthon-combinations-of-sum-with-tuples-in-tuple-vector/\nfn find_combinations(test_list: Vec<(isize, isize)>) -> Vec<(isize, isize)> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_combinations;\n    assert_eq!(candidate(vec![(2, 4), (6, 7), (5, 1), (6, 10)]), vec![(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]);\n    assert_eq!(candidate(vec![(3, 5), (7, 8), (6, 2), (7, 11)]), vec![(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]);\n    assert_eq!(candidate(vec![(4, 6), (8, 9), (7, 3), (8, 12)]), vec![(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "rs",
-    "prompt": "/// Given a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfn maxAverageOfPath(cost: Vec<Vec<isize>>) -> f64 {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = maxAverageOfPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![6, 5, 4], vec![7, 3, 9]]), 5.2);\n    assert_eq!(candidate(vec![vec![2, 3, 4], vec![7, 6, 5], vec![8, 4, 10]]), 6.2);\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![8, 7, 6], vec![9, 5, 11]]), 7.2);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]), 5.8);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "rs",
-    "prompt": "/// Write a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nfn sequential_search(dlist: Vec<isize>, item: isize) -> (bool, isize) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sequential_search;\n    assert_eq!(candidate(vec![11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31), (true, 3));\n    assert_eq!(candidate(vec![12, 32, 45, 62, 35, 47, 44, 61], 61), (true, 7));\n    assert_eq!(candidate(vec![9, 10, 17, 19, 22, 39, 48, 56], 48), (true, 6));\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to remove odd numbers from a given vector.\nfn remove_odd(l: Vec<isize>) -> Vec<isize> {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2]);\n    assert_eq!(candidate(vec![2, 4, 6]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![10, 20, 3]), vec![10, 20]);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "rs",
-    "prompt": "/// Write a function to check whether the product of numbers in a vector is even or not.\nfn is_product_even(arr: Vec<isize>) -> bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = is_product_even;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 4]), true);\n    assert_eq!(candidate(vec![1, 1]), false);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function to find the maximum of two numbers.\nfn maximum(a: isize, b: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(5, 10), 10);\n    assert_eq!(candidate(-1, -2), -1);\n    assert_eq!(candidate(9, 7), 9);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = max_occurrences;\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]), 2);\n    assert_eq!(candidate(vec![2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]), 8);\n    assert_eq!(candidate(vec![10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]), 20);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4120,9 +292,549 @@
     "language": "rs",
     "prompt": "/// Write a rsthon function to reverse only the vowels of a given string (where y is not a vowel).\nfn reverse_vowels(str1: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = reverse_vowels;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"USA\")), String::from(\"ASU\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"ab\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a vector to a string.\nfn tup_string(tup1: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tup_string;\n    assert_eq!(candidate(vec![String::from(\"e\"), String::from(\"x\"), String::from(\"e\"), String::from(\"r\"), String::from(\"c\"), String::from(\"i\"), String::from(\"s\"), String::from(\"e\"), String::from(\"s\")]), String::from(\"exercises\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]), String::from(\"program\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum of the negative numbers of a given vector of numbers.\nfn sum_negativenum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_negativenum;\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), -32);\n    assert_eq!(candidate(vec![10, 15, -14, 13, -18, 12, -20]), -52);\n    assert_eq!(candidate(vec![19, -65, 57, 39, 152, -639, 121, 44, 90, -190]), -894);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth hexagonal number.\nfn hexagonal_num(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = hexagonal_num;\n    assert_eq!(candidate(10), 190);\n    assert_eq!(candidate(5), 45);\n    assert_eq!(candidate(7), 91);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfn is_Sum_Of_Powers_Of_Two(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Sum_Of_Powers_Of_Two;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(7), false);\n    assert_eq!(candidate(14), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a vector of elements.\nfn pancake_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pancake_sort;\n    assert_eq!(candidate(vec![15, 79, 25, 38, 69]), vec![15, 25, 38, 69, 79]);\n    assert_eq!(candidate(vec![98, 12, 54, 36, 85]), vec![12, 36, 54, 85, 98]);\n    assert_eq!(candidate(vec![41, 42, 32, 12, 23]), vec![12, 23, 32, 41, 42]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "rs",
+    "prompt": "/// Write a function to count number items that are identical in the same position of three given vectors.\nfn count_samepair(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_samepair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9], vec![2, 1, 3, 1, 2, 6, 7, 9]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 2, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 8], vec![2, 1, 3, 1, 2, 6, 7, 8]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the maximum difference between any two elements in a given vector.\nfn max_Abs_Diff(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_Abs_Diff;\n    assert_eq!(candidate(vec![2, 1, 5, 3]), 4);\n    assert_eq!(candidate(vec![9, 3, 2, 5, 1]), 8);\n    assert_eq!(candidate(vec![3, 2, 1]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the volume of a triangular prism.\nfn find_Volume(l: isize, b: isize, h: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Volume;\n    assert_eq!(candidate(10, 8, 6), 240);\n    assert_eq!(candidate(3, 2, 2), 6);\n    assert_eq!(candidate(1, 2, 1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "rs",
+    "prompt": "/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfn find_solution(a: isize, b: isize, n: isize) -> Option<(isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_solution;\n    assert_eq!(candidate(2, 3, 7), Some((2, 1)));\n    assert_eq!(candidate(4, 2, 7), None);\n    assert_eq!(candidate(1, 13, 17), Some((4, 1)));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all elements from a given vector present in another vector.\nfn remove_elements(list1: Vec<isize>, list2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_elements;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![2, 4, 6, 8]), vec![1, 3, 5, 7, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![1, 3, 5, 7]), vec![2, 4, 6, 8, 9, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vec![5, 7]), vec![1, 2, 3, 4, 6, 8, 9, 10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfn sum_series(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_series;\n    assert_eq!(candidate(6), 12);\n    assert_eq!(candidate(10), 30);\n    assert_eq!(candidate(9), 25);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "rs",
+    "prompt": "/// Write a function to determine if the sum of the divisors of two integers are the same.\nfn are_equivalent(num1: isize, num2: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = are_equivalent;\n    assert_eq!(candidate(36, 57), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(23, 47), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfn count_char_position(str1: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_char_position;\n    assert_eq!(candidate(String::from(\"xbcefg\")), 2);\n    assert_eq!(candidate(String::from(\"ABcED\")), 3);\n    assert_eq!(candidate(String::from(\"AbgdeF\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "rs",
+    "prompt": "/// Write a function that counts the number of pairs of integers in a vector that xor to an even number.\nfn find_even_pair(A: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_even_pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1]), 4);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11]), 9);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the smallest power of 2 greater than or equal to n.\nfn next_power_of_2(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = next_power_of_2;\n    assert_eq!(candidate(0), 1);\n    assert_eq!(candidate(5), 8);\n    assert_eq!(candidate(17), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of occurrences of a number in a given vector.\nfn frequency(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = frequency;\n    assert_eq!(candidate(vec![1, 2, 3], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 2, 3, 3, 3, 4], 3), 3);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 1, 2], 1), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "rs",
+    "prompt": "/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfn text_lowercase_underscore(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_lowercase_underscore;\n    assert_eq!(candidate(String::from(\"aab_cbbbc\")), true);\n    assert_eq!(candidate(String::from(\"aab_Abbbc\")), false);\n    assert_eq!(candidate(String::from(\"Aaab_abbbc\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "rs",
+    "prompt": "/// Write a function to find the sum of numbers in a vector within a range specified by two indices.\nfn sum_range_list(list1: Vec<isize>, m: isize, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_range_list;\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10), 29);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7), 16);\n    assert_eq!(candidate(vec![2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10), 38);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "rs",
+    "prompt": "/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfn perimeter_pentagon(a: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = perimeter_pentagon;\n    assert_eq!(candidate(5), 25);\n    assert_eq!(candidate(10), 50);\n    assert_eq!(candidate(15), 75);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "rs",
+    "prompt": "/// Write a function to count the number of occurence of the string 'std' in a given string.\nfn count_occurance(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_occurance;\n    assert_eq!(candidate(String::from(\"letstdlenstdporstd\")), 3);\n    assert_eq!(candidate(String::from(\"truststdsolensporsd\")), 1);\n    assert_eq!(candidate(String::from(\"makestdsostdworthit\")), 2);\n    assert_eq!(candidate(String::from(\"stds\")), 1);\n    assert_eq!(candidate(String::from(\"\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "rs",
+    "prompt": "/// Write a function that returns the perimeter of a square given its side length as input.\nfn square_perimeter(a: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = square_perimeter;\n    assert_eq!(candidate(10), 40);\n    assert_eq!(candidate(5), 20);\n    assert_eq!(candidate(4), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "rs",
+    "prompt": "/// Write a function to remove characters from the first string which are present in the second string.\nfn remove_dirty_chars(string: String, second_string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_dirty_chars;\n    assert_eq!(candidate(String::from(\"probasscurve\"), String::from(\"pros\")), String::from(\"bacuve\"));\n    assert_eq!(candidate(String::from(\"digitalindia\"), String::from(\"talent\")), String::from(\"digiidi\"));\n    assert_eq!(candidate(String::from(\"exoticmiles\"), String::from(\"toxic\")), String::from(\"emles\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "rs",
+    "prompt": "/// Write a function to find whether a given vector of integers contains any duplicate element.\nfn test_duplicate(arraynums: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = test_duplicate;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2, 3, 3, 4, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given number is woodball or not.\nfn is_woodall(x: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_woodall;\n    assert_eq!(candidate(383), true);\n    assert_eq!(candidate(254), false);\n    assert_eq!(candidate(200), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a sorted vector, its length (n), and an element and returns whether the element is the majority element in the given sorted vector. (The majority element is the element that occurs more than n/2 times.)\nfn is_majority(arr: Vec<isize>, n: isize, x: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_majority;\n    assert_eq!(candidate(vec![1, 2, 3, 3, 3, 3, 10], 7, 3), true);\n    assert_eq!(candidate(vec![1, 1, 2, 4, 4, 4, 6, 6], 8, 4), false);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 2], 5, 1), true);\n    assert_eq!(candidate(vec![1, 1, 2, 2], 5, 1), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfn count_Set_Bits(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Set_Bits;\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 1);\n    assert_eq!(candidate(6), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to remove the characters which have odd index values of a given string.\nfn odd_values_string(str: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_values_string;\n    assert_eq!(candidate(String::from(\"abcdef\")), String::from(\"ace\"));\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"pto\"));\n    assert_eq!(candidate(String::from(\"data\")), String::from(\"dt\"));\n    assert_eq!(candidate(String::from(\"lambs\")), String::from(\"lms\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "rs",
+    "prompt": "/// Write a function to find minimum of three numbers.\nfn min_of_three(a: isize, b: isize, c: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = min_of_three;\n    assert_eq!(candidate(10, 20, 0), 0);\n    assert_eq!(candidate(19, 15, 18), 15);\n    assert_eq!(candidate(-10, -20, -30), -30);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether all the bits are unset in the given range or not.\nfn all_Bits_Set_In_The_Given_Range(n: isize, l: isize, r: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = all_Bits_Set_In_The_Given_Range;\n    assert_eq!(candidate(4, 1, 2), true);\n    assert_eq!(candidate(17, 2, 4), true);\n    assert_eq!(candidate(39, 4, 6), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a vector and an integer n, and re-arranges the first n elements of the given vector so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfn re_arrange_array(arr: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = re_arrange_array;\n    assert_eq!(candidate(vec![-1, 2, -3, 4, 5, 6, -7, 8, 9], 9), vec![-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n    assert_eq!(candidate(vec![12, -14, -26, 13, 15], 5), vec![-14, -26, 12, 13, 15]);\n    assert_eq!(candidate(vec![10, 24, 36, -42, -39, -78, 85], 7), vec![-42, -39, -78, 10, 24, 36, 85]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfn replace_blank(str1: String, char: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_blank;\n    assert_eq!(candidate(String::from(\"hello people\"), String::from(\"@\")), String::from(\"hello@people\"));\n    assert_eq!(candidate(String::from(\"python program language\"), String::from(\"$\")), String::from(\"python$program$language\"));\n    assert_eq!(candidate(String::from(\"blank space\"), String::from(\"-\")), String::from(\"blank-space\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "rs",
+    "prompt": "/// Write a function to find the volume of a cube given its side length.\nfn volume_cube(l: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = volume_cube;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(2), 8);\n    assert_eq!(candidate(5), 125);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of non-empty substrings of a given string.\nfn number_of_substrings(str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = number_of_substrings;\n    assert_eq!(candidate(String::from(\"abc\")), 6);\n    assert_eq!(candidate(String::from(\"abcd\")), 10);\n    assert_eq!(candidate(String::from(\"abcde\")), 15);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfn get_total_number_of_sequences(m: isize, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_total_number_of_sequences;\n    assert_eq!(candidate(10, 4), 4);\n    assert_eq!(candidate(5, 2), 6);\n    assert_eq!(candidate(16, 3), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "rs",
+    "prompt": "/// Write a function to count the total number of characters in a string.\nfn count_charac(str1: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_charac;\n    assert_eq!(candidate(String::from(\"python programming\")), 18);\n    assert_eq!(candidate(String::from(\"language\")), 8);\n    assert_eq!(candidate(String::from(\"words\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the next perfect square greater than a given number.\nfn next_Perfect_Square(N: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = next_Perfect_Square;\n    assert_eq!(candidate(35), 36);\n    assert_eq!(candidate(6), 9);\n    assert_eq!(candidate(9), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "rs",
+    "prompt": "/// Write a function that takes a vector and finds the maximum sum of a bitonic subsequence for the given vector, where a sequence is bitonic if it is first increasing and then decreasing.\nfn max_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum;\n    assert_eq!(candidate(vec![1, 15, 51, 45, 33, 100, 12, 18, 9]), 194);\n    assert_eq!(candidate(vec![80, 60, 30, 40, 20, 10]), 210);\n    assert_eq!(candidate(vec![2, 3, 14, 16, 21, 23, 29, 30]), 138);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "rs",
+    "prompt": "/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfn lps(str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = lps;\n    assert_eq!(candidate(String::from(\"TENS FOR TENS\")), 5);\n    assert_eq!(candidate(String::from(\"CARDIO FOR CARDS\")), 7);\n    assert_eq!(candidate(String::from(\"PART OF THE JOURNEY IS PART\")), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "rs",
+    "prompt": "/// Write a function to find the intersection of two vectors.\nfn intersection_array(array_nums1: Vec<isize>, array_nums2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = intersection_array;\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![1, 2, 4, 8, 9]), vec![1, 2, 8, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![3, 5, 7, 9]), vec![3, 5, 7, 9]);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 7, 8, 9, 10], vec![10, 20, 30, 40]), vec![10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function that takes in a tuple and an element and counts the occcurences of the element in the vector.\nfn count_X(tup: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_X;\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4), 0);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10), 3);\n    assert_eq!(candidate(vec![10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a vector and an element and inserts the element before each element in the vector, and returns the resulting vector.\nfn insert_element(list: Vec<String>, element: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = insert_element;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Black\")], String::from(\"c\")), vec![String::from(\"c\"), String::from(\"Red\"), String::from(\"c\"), String::from(\"Green\"), String::from(\"c\"), String::from(\"Black\")]);\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"java\")], String::from(\"program\")), vec![String::from(\"program\"), String::from(\"python\"), String::from(\"program\"), String::from(\"java\")]);\n    assert_eq!(candidate(vec![String::from(\"happy\"), String::from(\"sad\")], String::from(\"laugh\")), vec![String::from(\"laugh\"), String::from(\"happy\"), String::from(\"laugh\"), String::from(\"sad\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to convert complex numbers to polar coordinates.\nfn convert(numbers: isize) -> (f64, f64) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = convert;\n    assert_eq!(candidate(1), (1.0, 0.0));\n    assert_eq!(candidate(4), (4.0, 0.0));\n    assert_eq!(candidate(5), (5.0, 0.0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a vector and length n, and generates all combinations (with repetition) of the elements of the vector and returns a vector with a vector for each combination.\nfn combinations_colors(l: Vec<String>, n: isize) -> Vec<Vec<String>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = combinations_colors;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 1), vec![vec![String::from(\"Red\")], vec![String::from(\"Green\")], vec![String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 2), vec![vec![String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\")]]);\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], 3), vec![vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Red\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Red\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Red\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Green\")], vec![String::from(\"Green\"), String::from(\"Green\"), String::from(\"Blue\")], vec![String::from(\"Green\"), String::from(\"Blue\"), String::from(\"Blue\")], vec![String::from(\"Blue\"), String::from(\"Blue\"), String::from(\"Blue\")]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfn count_Primes_nums(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Primes_nums;\n    assert_eq!(candidate(5), 2);\n    assert_eq!(candidate(10), 4);\n    assert_eq!(candidate(100), 25);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in two numbers and returns a vector with the second number and then the first number.\nfn swap_numbers(a: isize, b: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_numbers;\n    assert_eq!(candidate(10, 20), vec![20, 10]);\n    assert_eq!(candidate(15, 17), vec![17, 15]);\n    assert_eq!(candidate(100, 200), vec![200, 100]);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4132,7 +844,7 @@
     "language": "rs",
     "prompt": "/// Write a function to maximize the given two vectors.\nfn maximize_elements(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = maximize_elements;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 7], vec![4, 9], vec![2, 9], vec![7, 10]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![7, 8], vec![5, 10], vec![3, 10], vec![8, 11]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![8, 9], vec![6, 11], vec![4, 11], vec![9, 12]]);\n}\n",
     "stop_tokens": [
@@ -4140,73 +852,49 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to check whether every even index contains even numbers of a given vector.\nfn even_position(nums: Vec<isize>) -> bool {\n",
+    "prompt": "/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfn newman_prime(n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = even_position;\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n    assert_eq!(candidate(vec![2, 1, 4]), true);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = newman_prime;\n    assert_eq!(candidate(3), 7);\n    assert_eq!(candidate(4), 17);\n    assert_eq!(candidate(5), 41);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "rs",
-    "prompt": "/// Write a function to check whether the given string starts and ends with the same character or not.\nfn check_char(string: String) -> String {\n",
+    "prompt": "/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfn division_elements(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = check_char;\n    assert_eq!(candidate(String::from(\"abba\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"Invalid\"));\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = division_elements;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (2, 2, 2, 3));\n    assert_eq!(candidate((12, 6, 8, 16), (6, 3, 4, 4)), (2, 2, 2, 4));\n    assert_eq!(candidate((20, 14, 36, 18), (5, 7, 6, 9)), (4, 2, 6, 2));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_264_dog_age",
     "language": "rs",
-    "prompt": "/// Write a rsthon function to find the sum of even factors of a number.\nfn sumofFactors(n: isize) -> isize {\n",
+    "prompt": "/// Write a function to calculate a dog's age in dog's years.\nfn dog_age(h_age: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = sumofFactors;\n    assert_eq!(candidate(18), 26);\n    assert_eq!(candidate(30), 48);\n    assert_eq!(candidate(6), 8);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = dog_age;\n    assert_eq!(candidate(12), 61);\n    assert_eq!(candidate(15), 73);\n    assert_eq!(candidate(24), 109);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "rs",
-    "prompt": "/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfn lateralsurface_cone(r: isize, h: isize) -> f64 {\n",
+    "prompt": "/// Write a function to find the lateral surface area of a cube given its side length.\nfn lateralsurface_cube(l: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cone;\n    assert_eq!(candidate(5, 12), 204.20352248333654);\n    assert_eq!(candidate(10, 15), 566.3586699569488);\n    assert_eq!(candidate(19, 17), 1521.8090132193388);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_564_count_Pairs",
-    "language": "rs",
-    "prompt": "/// Write a rsthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\nfn count_Pairs(arr: Vec<isize>, n: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = count_Pairs;\n    assert_eq!(candidate(vec![1, 2, 1], 3), 2);\n    assert_eq!(candidate(vec![1, 1, 1, 1], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 5), 10);\n}\n",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_733_find_first_occurrence",
-    "language": "rs",
-    "prompt": "/// Write a function to find the index of the first occurrence of a given number in a sorted vector.\nfn find_first_occurrence(A: Vec<isize>, x: isize) -> isize {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = find_first_occurrence;\n    assert_eq!(candidate(vec![2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5), 1);\n    assert_eq!(candidate(vec![2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5), 2);\n    assert_eq!(candidate(vec![2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6), 4);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cube;\n    assert_eq!(candidate(5), 100);\n    assert_eq!(candidate(9), 324);\n    assert_eq!(candidate(10), 400);\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4216,9 +904,597 @@
     "language": "rs",
     "prompt": "/// Write a rsthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 10);\n    assert_eq!(candidate(3), 35);\n    assert_eq!(candidate(4), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n'th star number.\nfn find_star_num(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_star_num;\n    assert_eq!(candidate(3), 37);\n    assert_eq!(candidate(4), 73);\n    assert_eq!(candidate(5), 121);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "rs",
+    "prompt": "/// Write a function to find the ascii value of a character.\nfn ascii_value(k: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = ascii_value;\n    assert_eq!(candidate(String::from(\"A\")), 65);\n    assert_eq!(candidate(String::from(\"R\")), 82);\n    assert_eq!(candidate(String::from(\"S\")), 83);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of even numbers at even positions of a vector.\nfn sum_even_and_even_index(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_even_and_even_index;\n    assert_eq!(candidate(vec![5, 6, 12, 1, 18, 8]), 30);\n    assert_eq!(candidate(vec![3, 20, 17, 9, 2, 10, 18, 13, 6, 18]), 26);\n    assert_eq!(candidate(vec![5, 6, 12, 1]), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfn even_Power_Sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = even_Power_Sum;\n    assert_eq!(candidate(2), 1056);\n    assert_eq!(candidate(3), 8832);\n    assert_eq!(candidate(1), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a vector of tuples and returns a vector containing the rear element of each tuple.\nfn rear_extract(test_list: Vec<(isize, String, isize)>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rear_extract;\n    assert_eq!(candidate(vec![(1, String::from(\"Rash\"), 21), (2, String::from(\"Varsha\"), 20), (3, String::from(\"Kil\"), 19)]), vec![21, 20, 19]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sai\"), 36), (2, String::from(\"Ayesha\"), 25), (3, String::from(\"Salman\"), 45)]), vec![36, 25, 45]);\n    assert_eq!(candidate(vec![(1, String::from(\"Sudeep\"), 14), (2, String::from(\"Vandana\"), 36), (3, String::from(\"Dawood\"), 56)]), vec![14, 36, 56]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfn substract_elements(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> (isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = substract_elements;\n    assert_eq!(candidate((10, 4, 5), (2, 5, 18)), (8, -1, -13));\n    assert_eq!(candidate((11, 2, 3), (24, 45, 16)), (-13, -43, -13));\n    assert_eq!(candidate((7, 18, 9), (10, 11, 12)), (-3, 7, -3));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfn even_binomial_Coeff_Sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = even_binomial_Coeff_Sum;\n    assert_eq!(candidate(4), 8);\n    assert_eq!(candidate(6), 32);\n    assert_eq!(candidate(2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function that takes in a HashMap and integer n and filters the HashMap to only include entries with values greater than or equal to n.\nfn dict_filter(dict: HashMap<String, isize>, n: isize) -> HashMap<String, isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = dict_filter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 170), HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 180), HashMap::from([(String::from(\"Alden Cantrell\"), 180), (String::from(\"Pierre Cox\"), 190)]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 175), (String::from(\"Alden Cantrell\"), 180), (String::from(\"Kierra Gentry\"), 165), (String::from(\"Pierre Cox\"), 190)]), 190), HashMap::from([(String::from(\"Pierre Cox\"), 190)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth decagonal number.\nfn is_num_decagonal(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_num_decagonal;\n    assert_eq!(candidate(3), 27);\n    assert_eq!(candidate(7), 175);\n    assert_eq!(candidate(10), 370);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "rs",
+    "prompt": "/// Write a function that takes in a vector and element and returns a tuple containing a boolean that indicates if the element is in the vector and the index position of the element (or -1 if the element is not found).\nfn sequential_search(dlist: Vec<isize>, item: isize) -> (bool, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sequential_search;\n    assert_eq!(candidate(vec![11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31), (true, 3));\n    assert_eq!(candidate(vec![12, 32, 45, 62, 35, 47, 44, 61], 61), (true, 7));\n    assert_eq!(candidate(vec![9, 10, 17, 19, 22, 39, 48, 56], 48), (true, 6));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check if the elements of a given vector are unique or not.\nfn all_unique(test_list: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = all_unique;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "rs",
+    "prompt": "/// Write a function to subtract two vectors element-wise.\nfn sub_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sub_list;\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), vec![-3, -3, -3]);\n    assert_eq!(candidate(vec![1, 2], vec![3, 4]), vec![-2, -2]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![40, 50]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfn validate(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = validate;\n    assert_eq!(candidate(1234), true);\n    assert_eq!(candidate(51241), false);\n    assert_eq!(candidate(321), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "rs",
+    "prompt": "/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfn text_match_two_three(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_two_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "rs",
+    "prompt": "/// Write a function to find the largest sum of a contiguous vector in the modified vector which is formed by repeating the given vector k times.\nfn max_sub_array_sum_repeated(a: Vec<isize>, n: isize, k: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum_repeated;\n    assert_eq!(candidate(vec![10, 20, -30, -1], 4, 3), 30);\n    assert_eq!(candidate(vec![-1, 10, 20], 3, 2), 59);\n    assert_eq!(candidate(vec![-1, -2, -3], 3, 3), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfn square_Sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = square_Sum;\n    assert_eq!(candidate(2), 20);\n    assert_eq!(candidate(3), 56);\n    assert_eq!(candidate(4), 120);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "rs",
+    "prompt": "/// Write a function to find the vector of maximum length in a vector of vectors.\nfn max_length(list1: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_length;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1], vec![5, 7], vec![10, 12, 14, 15]]), (4, vec![10, 12, 14, 15]));\n    assert_eq!(candidate(vec![vec![5], vec![15, 20, 25]]), (3, vec![15, 20, 25]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "rs",
+    "prompt": "/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfn count_no_of_ways(n: isize, k: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_no_of_ways;\n    assert_eq!(candidate(2, 4), 16);\n    assert_eq!(candidate(3, 2), 6);\n    assert_eq!(candidate(4, 4), 228);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfn find(n: isize, m: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find;\n    assert_eq!(candidate(10, 3), 3);\n    assert_eq!(candidate(4, 2), 2);\n    assert_eq!(candidate(20, 5), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "rs",
+    "prompt": "/// Write a function to find the third side of a right angled triangle.\nfn otherside_rightangle(w: isize, h: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = otherside_rightangle;\n    assert_eq!(candidate(7, 8), 10.63014581273465);\n    assert_eq!(candidate(3, 4), 5.0);\n    assert_eq!(candidate(7, 15), 16.55294535724685);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "rs",
+    "prompt": "/// Write a function to return the sum of all divisors of a number.\nfn sum_div(number: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_div;\n    assert_eq!(candidate(8), 7);\n    assert_eq!(candidate(12), 16);\n    assert_eq!(candidate(7), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count inversions in a vector.\nfn get_Inv_Count(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_Inv_Count;\n    assert_eq!(candidate(vec![1, 20, 6, 4, 5]), 5);\n    assert_eq!(candidate(vec![1, 2, 1]), 1);\n    assert_eq!(candidate(vec![1, 2, 5, 6, 1]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the maximum aggregate from the vector of tuples.\nfn max_aggregate(stdata: Vec<(String, isize)>) -> (String, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_aggregate;\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 90), (String::from(\"Sabah Colley\"), 88), (String::from(\"Peter Nichols\"), 7), (String::from(\"Juan Whelan\"), 122), (String::from(\"Sabah Colley\"), 84)]), (String::from(\"Juan Whelan\"), 212));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 50), (String::from(\"Sabah Colley\"), 48), (String::from(\"Peter Nichols\"), 37), (String::from(\"Juan Whelan\"), 22), (String::from(\"Sabah Colley\"), 14)]), (String::from(\"Juan Whelan\"), 72));\n    assert_eq!(candidate(vec![(String::from(\"Juan Whelan\"), 10), (String::from(\"Sabah Colley\"), 20), (String::from(\"Peter Nichols\"), 30), (String::from(\"Juan Whelan\"), 40), (String::from(\"Sabah Colley\"), 50)]), (String::from(\"Sabah Colley\"), 70));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find element at a given index after number of rotations.\nfn find_Element(arr: Vec<isize>, ranges: Vec<Vec<isize>>, rotations: isize, index: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Element;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![vec![0, 2], vec![0, 3]], 2, 1), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![vec![0, 1], vec![0, 2]], 1, 2), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![vec![0, 1], vec![0, 2]], 1, 1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "rs",
+    "prompt": "/// Write a function to return two words from a vector of words starting with letter 'p'.\nfn start_withp(words: Vec<String>) -> (String, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = start_withp;\n    assert_eq!(candidate(vec![String::from(\"Python PHP\"), String::from(\"Java JavaScript\"), String::from(\"c c++\")]), (String::from(\"Python\"), String::from(\"PHP\")));\n    assert_eq!(candidate(vec![String::from(\"Python Programming\"), String::from(\"Java Programming\")]), (String::from(\"Python\"), String::from(\"Programming\")));\n    assert_eq!(candidate(vec![String::from(\"Pqrst Pqr\"), String::from(\"qrstuv\")]), (String::from(\"Pqrst\"), String::from(\"Pqr\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfn max_sum_increasing_subseq(a: Vec<isize>, n: isize, index: isize, k: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum_increasing_subseq;\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 4, 6), 11);\n    assert_eq!(candidate(vec![1, 101, 2, 3, 100, 4, 5], 7, 2, 5), 7);\n    assert_eq!(candidate(vec![11, 15, 19, 21, 26, 28, 31], 7, 2, 4), 71);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the specified number of largest products from two given vectors, selecting one factor from each vector.\nfn large_product(nums1: Vec<isize>, nums2: Vec<isize>, N: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = large_product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 3), vec![60, 54, 50]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 4), vec![60, 54, 50, 48]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], vec![3, 6, 8, 9, 10, 6], 5), vec![60, 54, 50, 48, 45]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the maximum of two numbers.\nfn maximum(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = maximum;\n    assert_eq!(candidate(5, 10), 10);\n    assert_eq!(candidate(-1, -2), -1);\n    assert_eq!(candidate(9, 7), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a given string to a vector of characters.\nfn string_to_tuple(str1: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = string_to_tuple;\n    assert_eq!(candidate(String::from(\"python 3.0\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\"), String::from(\"3\"), String::from(\".\"), String::from(\"0\")]);\n    assert_eq!(candidate(String::from(\"item1\")), vec![String::from(\"i\"), String::from(\"t\"), String::from(\"e\"), String::from(\"m\"), String::from(\"1\")]);\n    assert_eq!(candidate(String::from(\"15.10\")), vec![String::from(\"1\"), String::from(\"5\"), String::from(\".\"), String::from(\"1\"), String::from(\"0\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the highest power of 2 that is less than or equal to n.\nfn highest_Power_of_2(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = highest_Power_of_2;\n    assert_eq!(candidate(10), 8);\n    assert_eq!(candidate(19), 16);\n    assert_eq!(candidate(32), 32);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n'th lucas number.\nfn find_lucas(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_lucas;\n    assert_eq!(candidate(9), 76);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(3), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfn get_max_sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_max_sum;\n    assert_eq!(candidate(60), 106);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "rs",
+    "prompt": "/// Write a function to find the vector with maximum length.\nfn max_length_list(input_list: Vec<Vec<isize>>) -> (isize, Vec<isize>) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_length_list;\n    assert_eq!(candidate(vec![vec![0], vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), (3, vec![13, 15, 17]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4], vec![1, 2, 3], vec![1, 2], vec![1]]), (5, vec![1, 2, 3, 4, 5]));\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![6, 7, 8, 9], vec![10, 11, 12]]), (4, vec![6, 7, 8, 9]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "rs",
+    "prompt": "/// Write a function to check if given vector contains no duplicates.\nfn check_distinct(test_tup: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_distinct;\n    assert_eq!(candidate(vec![1, 4, 5, 6, 1, 4]), false);\n    assert_eq!(candidate(vec![1, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the first non-repeated character in a given string.\nfn first_non_repeating_character(str1: String) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = first_non_repeating_character;\n    assert_eq!(candidate(String::from(\"abcabc\")), None);\n    assert_eq!(candidate(String::from(\"abc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"ababc\")), Some(String::from(\"c\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given string starts and ends with the same character or not.\nfn check_char(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_char;\n    assert_eq!(candidate(String::from(\"abba\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"a\")), String::from(\"Valid\"));\n    assert_eq!(candidate(String::from(\"abcd\")), String::from(\"Invalid\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median of three numbers.\nfn median_numbers(a: isize, b: isize, c: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = median_numbers;\n    assert_eq!(candidate(25, 55, 65), 55.0);\n    assert_eq!(candidate(20, 10, 30), 20.0);\n    assert_eq!(candidate(15, 45, 75), 45.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "rs",
+    "prompt": "/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfn bitwise_xor(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = bitwise_xor;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (15, 6, 5, 10));\n    assert_eq!(candidate((11, 5, 7, 10), (6, 3, 4, 4)), (13, 6, 3, 14));\n    assert_eq!(candidate((12, 6, 8, 11), (7, 4, 5, 6)), (11, 2, 13, 13));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to identify non-prime numbers.\nfn is_not_prime(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_not_prime;\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(35), true);\n    assert_eq!(candidate(37), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "rs",
+    "prompt": "/// Write a function to extract the number of unique tuples in the given vector.\nfn extract_freq(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_freq;\n    assert_eq!(candidate(vec![(3, 4), (1, 2), (4, 3), (5, 6)]), 3);\n    assert_eq!(candidate(vec![(4, 15), (2, 3), (5, 4), (6, 7)]), 4);\n    assert_eq!(candidate(vec![(5, 16), (2, 3), (6, 5), (6, 9)]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to perform index wise addition of vector elements in the given two nested vectors.\nfn add_nested_tuples(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add_nested_tuples;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![7, 10], vec![7, 14], vec![3, 10], vec![8, 13]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![9, 12], vec![9, 16], vec![5, 12], vec![10, 15]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![11, 14], vec![11, 18], vec![7, 14], vec![12, 17]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the minimum of two numbers.\nfn minimum(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = minimum;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(-5, -4), -5);\n    assert_eq!(candidate(0, 0), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find whether the parity of a given number is odd.\nfn find_Parity(x: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Parity;\n    assert_eq!(candidate(12), false);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(10), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "rs",
+    "prompt": "/// Write a function to find k number of smallest pairs which consist of one element from the first vector and one element from the second vector.\nfn k_smallest_pairs(nums1: Vec<isize>, nums2: Vec<isize>, k: isize) -> Vec<Vec<isize>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = k_smallest_pairs;\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 2), vec![vec![1, 2], vec![1, 4]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 1), vec![vec![1, 2]]);\n    assert_eq!(candidate(vec![1, 3, 7], vec![2, 4, 6], 7), vec![vec![1, 2], vec![1, 4], vec![3, 2], vec![1, 6], vec![3, 4], vec![3, 6], vec![7, 2]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to find the minimum product from the pairs of tuples within a given vector.\nfn min_product_tuple(list1: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = min_product_tuple;\n    assert_eq!(candidate(vec![(2, 7), (2, 6), (1, 8), (4, 9)]), 8);\n    assert_eq!(candidate(vec![(10, 20), (15, 2), (5, 10)]), 30);\n    assert_eq!(candidate(vec![(11, 44), (10, 15), (20, 5), (12, 9)]), 100);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "rs",
+    "prompt": "/// Write a function to convert the given snake case string to camel case string.\nfn snake_to_camel(word: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = snake_to_camel;\n    assert_eq!(candidate(String::from(\"android_tv\")), String::from(\"AndroidTv\"));\n    assert_eq!(candidate(String::from(\"google_pixel\")), String::from(\"GooglePixel\"));\n    assert_eq!(candidate(String::from(\"apple_watch\")), String::from(\"AppleWatch\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to remove odd numbers from a given vector.\nfn remove_odd(l: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![2]);\n    assert_eq!(candidate(vec![2, 4, 6]), vec![2, 4, 6]);\n    assert_eq!(candidate(vec![10, 20, 3]), vec![10, 20]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether any value in a sequence exists in a sequence or not.\nfn overlapping(list1: Vec<isize>, list2: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = overlapping;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 8, 9]), false);\n    assert_eq!(candidate(vec![1, 2, 3], vec![4, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 4, 5], vec![1, 4, 5]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find a pair with highest product from a given vector of integers.\nfn max_Product(arr: Vec<isize>) -> (isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_Product;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 7, 0, 8, 4]), (7, 8));\n    assert_eq!(candidate(vec![0, -1, -2, -4, 5, 0, -6]), (-4, -6));\n    assert_eq!(candidate(vec![1, 2, 3]), (2, 3));\n}\n",
     "stop_tokens": [
       "\n}"
     ]
@@ -4228,7 +1504,7 @@
     "language": "rs",
     "prompt": "/// Write a function to find common first element in given vector of vectors.\nfn group_tuples(Input: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\nfn main() {\n    let candidate = group_tuples;\n    assert_eq!(candidate(vec![vec![String::from(\"x\"), String::from(\"y\")], vec![String::from(\"x\"), String::from(\"z\")], vec![String::from(\"w\"), String::from(\"t\")]]), vec![vec![String::from(\"x\"), String::from(\"y\"), String::from(\"z\")], vec![String::from(\"w\"), String::from(\"t\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"a\"), String::from(\"c\")], vec![String::from(\"d\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\"), String::from(\"c\")], vec![String::from(\"d\"), String::from(\"e\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"f\"), String::from(\"g\")], vec![String::from(\"f\"), String::from(\"g\")], vec![String::from(\"h\"), String::from(\"i\")]]), vec![vec![String::from(\"f\"), String::from(\"g\"), String::from(\"g\")], vec![String::from(\"h\"), String::from(\"i\")]]);\n}\n",
     "stop_tokens": [
@@ -4236,13 +1512,2737 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_420_cube_Sum",
     "language": "rs",
-    "prompt": "/// Write a function to merge three vectors into a single sorted vector.\nfn merge_sorted_list(num1: Vec<isize>, num2: Vec<isize>, num3: Vec<isize>) -> Vec<isize> {\n",
+    "prompt": "/// Write a rsthon function to find the cube sum of first n even natural numbers.\nfn cube_Sum(n: isize) -> isize {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\nfn main() {\n    let candidate = merge_sorted_list;\n    assert_eq!(candidate(vec![25, 24, 15, 4, 5, 29, 110], vec![19, 20, 11, 56, 25, 233, 154], vec![24, 26, 54, 48]), vec![4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n    assert_eq!(candidate(vec![1, 3, 5, 6, 8, 9], vec![2, 5, 7, 11], vec![1, 4, 7, 8, 12]), vec![1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n    assert_eq!(candidate(vec![18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], vec![25, 35, 22, 85, 14, 65, 75, 25, 58], vec![12, 74, 9, 50, 61, 41]), vec![1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n",
+    "tests": "}\n\nfn main() {\n    let candidate = cube_Sum;\n    assert_eq!(candidate(2), 72);\n    assert_eq!(candidate(3), 288);\n    assert_eq!(candidate(4), 800);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to concatenate each element of tuple by the delimiter.\nfn concatenate_tuple(test_tup: (String, String, isize, String)) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = concatenate_tuple;\n    assert_eq!(candidate((String::from(\"ID\"), String::from(\"is\"), 4, String::from(\"UTS\"))), String::from(\"ID-is-4-UTS\"));\n    assert_eq!(candidate((String::from(\"QWE\"), String::from(\"is\"), 4, String::from(\"RTY\"))), String::from(\"QWE-is-4-RTY\"));\n    assert_eq!(candidate((String::from(\"ZEN\"), String::from(\"is\"), 4, String::from(\"OP\"))), String::from(\"ZEN-is-4-OP\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the average of cubes of first n natural numbers.\nfn find_Average_Of_Cube(n: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Average_Of_Cube;\n    assert_eq!(candidate(2), 4.5);\n    assert_eq!(candidate(3), 12.0);\n    assert_eq!(candidate(1), 1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "rs",
+    "prompt": "/// Write a function to extract only the rear index element of each string in the given tuple.\nfn extract_rear(test_tuple: (String, String, String)) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_rear;\n    assert_eq!(candidate((String::from(\"Mers\"), String::from(\"for\"), String::from(\"Vers\"))), vec![String::from(\"s\"), String::from(\"r\"), String::from(\"s\")]);\n    assert_eq!(candidate((String::from(\"Avenge\"), String::from(\"for\"), String::from(\"People\"))), vec![String::from(\"e\"), String::from(\"r\"), String::from(\"e\")]);\n    assert_eq!(candidate((String::from(\"Gotta\"), String::from(\"get\"), String::from(\"go\"))), vec![String::from(\"a\"), String::from(\"t\"), String::from(\"o\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "rs",
+    "prompt": "/// Write a function to filter odd numbers.\nfn filter_oddnumbers(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = filter_oddnumbers;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 3, 5, 7, 9]);\n    assert_eq!(candidate(vec![10, 20, 45, 67, 84, 93]), vec![45, 67, 93]);\n    assert_eq!(candidate(vec![5, 7, 9, 8, 6, 4, 3]), vec![5, 7, 9, 3]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "rs",
+    "prompt": "/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfn change_date_format(dt: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = change_date_format;\n    assert_eq!(candidate(String::from(\"2026-01-02\")), String::from(\"02-01-2026\"));\n    assert_eq!(candidate(String::from(\"2020-11-13\")), String::from(\"13-11-2020\"));\n    assert_eq!(candidate(String::from(\"2021-04-26\")), String::from(\"26-04-2021\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort the given vector by using shell sort.\nfn shell_sort(my_list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = shell_sort;\n    assert_eq!(candidate(vec![12, 23, 4, 5, 3, 2, 12, 81, 56, 95]), vec![2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n    assert_eq!(candidate(vec![24, 22, 39, 34, 87, 73, 68]), vec![22, 24, 34, 39, 68, 73, 87]);\n    assert_eq!(candidate(vec![32, 30, 16, 96, 82, 83, 74]), vec![16, 30, 32, 74, 82, 83, 96]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to extract the elementwise and tuples from the given two tuples.\nfn and_tuples(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = and_tuples;\n    assert_eq!(candidate((10, 4, 6, 9), (5, 2, 3, 3)), (0, 0, 2, 1));\n    assert_eq!(candidate((1, 2, 3, 4), (5, 6, 7, 8)), (1, 2, 3, 0));\n    assert_eq!(candidate((8, 9, 11, 12), (7, 13, 14, 17)), (0, 9, 10, 0));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "rs",
+    "prompt": "/// Write a function to find the directrix of a parabola.\nfn parabola_directrix(a: isize, b: isize, c: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = parabola_directrix;\n    assert_eq!(candidate(5, 3, 2), -198);\n    assert_eq!(candidate(9, 8, 4), -2336);\n    assert_eq!(candidate(2, 4, 6), -130);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median length of a trapezium.\nfn median_trapezium(base1: isize, base2: isize, height: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = median_trapezium;\n    assert_eq!(candidate(15, 25, 35), 20.0);\n    assert_eq!(candidate(10, 20, 30), 15.0);\n    assert_eq!(candidate(6, 9, 4), 7.5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the entered number is greater than the elements of the given vector.\nfn check_greater(arr: Vec<isize>, number: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_greater;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 4), false);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 6], 8), true);\n    assert_eq!(candidate(vec![9, 7, 4, 8, 6, 1], 11), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an a followed by one or more b's.\nfn text_match_one(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the last digit of a given number.\nfn last_Digit(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = last_Digit;\n    assert_eq!(candidate(123), 3);\n    assert_eq!(candidate(25), 5);\n    assert_eq!(candidate(30), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to return the negative numbers in a vector.\nfn neg_nos(list1: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = neg_nos;\n    assert_eq!(candidate(vec![-1, 4, 5, -6]), vec![-1, -6]);\n    assert_eq!(candidate(vec![-1, -2, 3, 4]), vec![-1, -2]);\n    assert_eq!(candidate(vec![-7, -6, 8, 9]), vec![-7, -6]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to remove odd characters in a string.\nfn remove_odd(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_odd;\n    assert_eq!(candidate(String::from(\"python\")), String::from(\"yhn\"));\n    assert_eq!(candidate(String::from(\"program\")), String::from(\"rga\"));\n    assert_eq!(candidate(String::from(\"language\")), String::from(\"agae\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "rs",
+    "prompt": "/// Write a function to count bidirectional tuple pairs.\nfn count_bidirectional(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_bidirectional;\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]), 3);\n    assert_eq!(candidate(vec![(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]), 2);\n    assert_eq!(candidate(vec![(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "rs",
+    "prompt": "/// Write a function to join a vector of multiple integers into a single integer.\nfn multiple_to_single(L: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = multiple_to_single;\n    assert_eq!(candidate(vec![11, 33, 50]), 113350);\n    assert_eq!(candidate(vec![-1, 2, 3, 4, 5, 6]), -123456);\n    assert_eq!(candidate(vec![10, 15, 20, 25]), 10152025);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "rs",
+    "prompt": "/// Write a function to find the first adverb and their positions in a given sentence.\nfn find_adverb_position(text: String) -> (isize, isize, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_adverb_position;\n    assert_eq!(candidate(String::from(\"clearly!! we can see the sky\")), (0, 7, String::from(\"clearly\")));\n    assert_eq!(candidate(String::from(\"seriously!! there are many roses\")), (0, 9, String::from(\"seriously\")));\n    assert_eq!(candidate(String::from(\"unfortunately!! sita is going to home\")), (0, 13, String::from(\"unfortunately\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "rs",
+    "prompt": "/// Write a function to find the surface area of a cube of a given size.\nfn surfacearea_cube(l: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cube;\n    assert_eq!(candidate(5), 150);\n    assert_eq!(candidate(3), 54);\n    assert_eq!(candidate(10), 600);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "rs",
+    "prompt": "/// Write a function to find the ration of positive numbers in a vector of integers.\nfn positive_count(nums: Vec<isize>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = positive_count;\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]), 0.54);\n    assert_eq!(candidate(vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 0.69);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17]), 0.56);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the largest negative number from the given vector.\nfn largest_neg(list1: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = largest_neg;\n    assert_eq!(candidate(vec![1, 2, 3, -4, -6]), -6);\n    assert_eq!(candidate(vec![1, 2, 3, -8, -9]), -9);\n    assert_eq!(candidate(vec![1, 2, 3, 4, -1]), -1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to trim each vector by k in the given vectors.\nfn trim_tuple(test_list: Vec<Vec<isize>>, K: isize) -> Vec<Vec<isize>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = trim_tuple;\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 2), vec![vec![2], vec![9], vec![2], vec![2]]);\n    assert_eq!(candidate(vec![vec![5, 3, 2, 1, 4], vec![3, 4, 9, 2, 1], vec![9, 1, 2, 3, 5], vec![4, 8, 2, 1, 7]], 1), vec![vec![3, 2, 1], vec![4, 9, 2], vec![1, 2, 3], vec![8, 2, 1]]);\n    assert_eq!(candidate(vec![vec![7, 8, 4, 9], vec![11, 8, 12, 4], vec![4, 1, 7, 8], vec![3, 6, 9, 7]], 1), vec![vec![8, 4], vec![8, 12], vec![1, 7], vec![6, 9]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "rs",
+    "prompt": "/// Write a function to perform index wise multiplication of vector elements in the given two vectors.\nfn index_multiplication(test_tup1: Vec<Vec<isize>>, test_tup2: Vec<Vec<isize>>) -> Vec<Vec<isize>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = index_multiplication;\n    assert_eq!(candidate(vec![vec![1, 3], vec![4, 5], vec![2, 9], vec![1, 10]], vec![vec![6, 7], vec![3, 9], vec![1, 1], vec![7, 3]]), vec![vec![6, 21], vec![12, 45], vec![2, 9], vec![7, 30]]);\n    assert_eq!(candidate(vec![vec![2, 4], vec![5, 6], vec![3, 10], vec![2, 11]], vec![vec![7, 8], vec![4, 10], vec![2, 2], vec![8, 4]]), vec![vec![14, 32], vec![20, 60], vec![6, 20], vec![16, 44]]);\n    assert_eq!(candidate(vec![vec![3, 5], vec![6, 7], vec![4, 11], vec![3, 12]], vec![vec![8, 9], vec![5, 11], vec![3, 3], vec![9, 5]]), vec![vec![24, 45], vec![30, 77], vec![12, 33], vec![27, 60]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to find cubes of individual elements in a vector.\nfn cube_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = cube_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15]), vec![1728, 3375]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the sum of perrin numbers.\nfn cal_sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = cal_sum;\n    assert_eq!(candidate(9), 49);\n    assert_eq!(candidate(10), 66);\n    assert_eq!(candidate(11), 88);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "rs",
+    "prompt": "/// Write a function to extract specified size of strings from a given vector of string values.\nfn extract_string(str: Vec<String>, l: isize) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = extract_string;\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 8), vec![String::from(\"practice\"), String::from(\"solution\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 6), vec![String::from(\"Python\")]);\n    assert_eq!(candidate(vec![String::from(\"Python\"), String::from(\"list\"), String::from(\"exercises\"), String::from(\"practice\"), String::from(\"solution\")], 9), vec![String::from(\"exercises\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all whitespaces from the given string.\nfn remove_whitespaces(text1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_whitespaces;\n    assert_eq!(candidate(String::from(\" Google    Flutter \")), String::from(\"GoogleFlutter\"));\n    assert_eq!(candidate(String::from(\" Google    Dart \")), String::from(\"GoogleDart\"));\n    assert_eq!(candidate(String::from(\" iOS    Swift \")), String::from(\"iOSSwift\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "rs",
+    "prompt": "/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfn loss_amount(actual_cost: isize, sale_amount: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = loss_amount;\n    assert_eq!(candidate(1500, 1200), 0);\n    assert_eq!(candidate(100, 200), 100);\n    assert_eq!(candidate(2000, 5000), 3000);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of even factors of a number.\nfn sumofFactors(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sumofFactors;\n    assert_eq!(candidate(18), 26);\n    assert_eq!(candidate(30), 48);\n    assert_eq!(candidate(6), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a word containing 'z'.\nfn text_match_wordz(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz;\n    assert_eq!(candidate(String::from(\"pythonz.\")), true);\n    assert_eq!(candidate(String::from(\"xyz.\")), true);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given month number contains 31 days or not.\nfn check_monthnumb_number(monthnum2: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumb_number;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(6), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "rs",
+    "prompt": "/// Write a function to reverse each string in a given vector of string values.\nfn reverse_string_list(stringlist: Vec<String>) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_string_list;\n    assert_eq!(candidate(vec![String::from(\"Red\"), String::from(\"Green\"), String::from(\"Blue\"), String::from(\"White\"), String::from(\"Black\")]), vec![String::from(\"deR\"), String::from(\"neerG\"), String::from(\"eulB\"), String::from(\"etihW\"), String::from(\"kcalB\")]);\n    assert_eq!(candidate(vec![String::from(\"john\"), String::from(\"amal\"), String::from(\"joel\"), String::from(\"george\")]), vec![String::from(\"nhoj\"), String::from(\"lama\"), String::from(\"leoj\"), String::from(\"egroeg\")]);\n    assert_eq!(candidate(vec![String::from(\"jack\"), String::from(\"john\"), String::from(\"mary\")]), vec![String::from(\"kcaj\"), String::from(\"nhoj\"), String::from(\"yram\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "rs",
+    "prompt": "/// Write a function to find the area of a rectangle.\nfn rectangle_area(l: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rectangle_area;\n    assert_eq!(candidate(10, 20), 200);\n    assert_eq!(candidate(10, 5), 50);\n    assert_eq!(candidate(4, 2), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "rs",
+    "prompt": "/// Write a function to remove uppercase substrings from a given string.\nfn remove_uppercase(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_uppercase;\n    assert_eq!(candidate(String::from(\"cAstyoUrFavoRitETVshoWs\")), String::from(\"cstyoravoitshos\"));\n    assert_eq!(candidate(String::from(\"wAtchTheinTernEtrAdIo\")), String::from(\"wtchheinerntrdo\"));\n    assert_eq!(candidate(String::from(\"VoicESeaRchAndreComMendaTionS\")), String::from(\"oiceachndreomendaion\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to get the first element of each subvector.\nfn Extract(lst: Vec<Vec<isize>>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Extract;\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4, 5], vec![6, 7, 8, 9]]), vec![1, 3, 6]);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5]]), vec![1, 4]);\n    assert_eq!(candidate(vec![vec![9, 8, 1], vec![1, 2]]), vec![9, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the upper case characters in a given string.\nfn upper_ctr(str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = upper_ctr;\n    assert_eq!(candidate(String::from(\"PYthon\")), 1);\n    assert_eq!(candidate(String::from(\"BigData\")), 1);\n    assert_eq!(candidate(String::from(\"program\")), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum product subvector of the given vector.\nfn max_subarray_product(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_subarray_product;\n    assert_eq!(candidate(vec![1, -2, -3, 0, 7, -8, -2]), 112);\n    assert_eq!(candidate(vec![6, -3, -10, 0, 2]), 180);\n    assert_eq!(candidate(vec![-2, -40, 0, -2, -3]), 80);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to check if all values are same in a HashMap.\nfn check_value(dict: HashMap<String, isize>, n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_value;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 10), false);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 12), true);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Cierra Vega\"), 12), (String::from(\"Alden Cantrell\"), 12), (String::from(\"Kierra Gentry\"), 12), (String::from(\"Pierre Cox\"), 12)]), 5), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that vector.\nfn max_product(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_product;\n    assert_eq!(candidate(vec![3, 100, 4, 5, 150, 6]), 3000);\n    assert_eq!(candidate(vec![4, 42, 55, 68, 80]), 50265600);\n    assert_eq!(candidate(vec![10, 22, 9, 33, 21, 50, 41, 60]), 2460);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "rs",
+    "prompt": "/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfn add_pairwise(test_tup: (isize, isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add_pairwise;\n    assert_eq!(candidate((1, 5, 7, 8, 10)), (6, 12, 15, 18));\n    assert_eq!(candidate((2, 6, 8, 9, 11)), (8, 14, 17, 20));\n    assert_eq!(candidate((3, 7, 9, 10, 12)), (10, 16, 19, 22));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the product of the vector multiplication modulo n.\nfn find_remainder(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_remainder;\n    assert_eq!(candidate(vec![100, 10, 5, 25, 35, 14], 11), 9);\n    assert_eq!(candidate(vec![1, 1, 1], 1), 0);\n    assert_eq!(candidate(vec![1, 2, 1], 2), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given vector contains consecutive numbers or not.\nfn check_Consecutive(l: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_Consecutive;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), true);\n    assert_eq!(candidate(vec![1, 2, 3, 5, 6]), false);\n    assert_eq!(candidate(vec![1, 2, 1]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "rs",
+    "prompt": "/// Write a function to replace characters in a string.\nfn replace_char(str1: String, ch: String, newch: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_char;\n    assert_eq!(candidate(String::from(\"polygon\"), String::from(\"y\"), String::from(\"l\")), String::from(\"pollgon\"));\n    assert_eq!(candidate(String::from(\"character\"), String::from(\"c\"), String::from(\"a\")), String::from(\"aharaater\"));\n    assert_eq!(candidate(String::from(\"python\"), String::from(\"l\"), String::from(\"a\")), String::from(\"python\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to sort a HashMap by value.\nfn sort_counter(dict1: HashMap<String, isize>) -> Vec<(String, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_counter;\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 81), (String::from(\"Physics\"), 83), (String::from(\"Chemistry\"), 87)])), vec![(String::from(\"Chemistry\"), 87), (String::from(\"Physics\"), 83), (String::from(\"Math\"), 81)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)])), vec![(String::from(\"Math\"), 400), (String::from(\"Physics\"), 300), (String::from(\"Chemistry\"), 250)]);\n    assert_eq!(candidate(HashMap::from([(String::from(\"Math\"), 900), (String::from(\"Physics\"), 1000), (String::from(\"Chemistry\"), 1250)])), vec![(String::from(\"Chemistry\"), 1250), (String::from(\"Physics\"), 1000), (String::from(\"Math\"), 900)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of the largest and smallest value in a given vector.\nfn big_sum(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = big_sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 4);\n    assert_eq!(candidate(vec![-1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![2, 3, 6]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to convert the given string to lower case.\nfn is_lower(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_lower;\n    assert_eq!(candidate(String::from(\"InValid\")), String::from(\"invalid\"));\n    assert_eq!(candidate(String::from(\"TruE\")), String::from(\"true\"));\n    assert_eq!(candidate(String::from(\"SenTenCE\")), String::from(\"sentence\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "rs",
+    "prompt": "/// Write a function to remove lowercase substrings from a given string.\nfn remove_lowercase(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_lowercase;\n    assert_eq!(candidate(String::from(\"PYTHon\")), String::from(\"PYTH\"));\n    assert_eq!(candidate(String::from(\"FInD\")), String::from(\"FID\"));\n    assert_eq!(candidate(String::from(\"STRinG\")), String::from(\"STRG\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the first digit of a given number.\nfn first_Digit(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = first_Digit;\n    assert_eq!(candidate(123), 1);\n    assert_eq!(candidate(456), 4);\n    assert_eq!(candidate(12), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "rs",
+    "prompt": "/// Write a function to find the n largest integers from a given vector of numbers, returned in descending order.\nfn heap_queue_largest(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = heap_queue_largest;\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 3), vec![85, 75, 65]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 2), vec![85, 75]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 22, 58], 5), vec![85, 75, 65, 58, 35]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function which takes a vector of integers and only returns the odd ones.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), vec![1, 3, 5]);\n    assert_eq!(candidate(vec![10, 11, 12, 13]), vec![11, 13]);\n    assert_eq!(candidate(vec![7, 8, 9, 1]), vec![7, 9, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfn difference(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = difference;\n    assert_eq!(candidate(3), 30);\n    assert_eq!(candidate(5), 210);\n    assert_eq!(candidate(2), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of pairs whose xor value is odd.\nfn find_Odd_Pair(A: Vec<isize>, N: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Odd_Pair;\n    assert_eq!(candidate(vec![5, 4, 7, 2, 1], 5), 6);\n    assert_eq!(candidate(vec![7, 2, 8, 1, 0, 5, 11], 7), 12);\n    assert_eq!(candidate(vec![1, 2, 3], 3), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "rs",
+    "prompt": "/// Write a function to toggle the case of all characters in a string.\nfn toggle_string(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = toggle_string;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"pYTHON\"));\n    assert_eq!(candidate(String::from(\"Pangram\")), String::from(\"pANGRAM\"));\n    assert_eq!(candidate(String::from(\"LIttLE\")), String::from(\"liTTle\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of the per-digit difference between two integers.\nfn digit_distance_nums(n1: isize, n2: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = digit_distance_nums;\n    assert_eq!(candidate(1, 2), 1);\n    assert_eq!(candidate(23, 56), 6);\n    assert_eq!(candidate(123, 256), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the sum of the largest contiguous subvector in the given vector.\nfn max_sub_array_sum(a: Vec<isize>, size: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sub_array_sum;\n    assert_eq!(candidate(vec![-2, -3, 4, -1, -2, 1, 5, -3], 8), 7);\n    assert_eq!(candidate(vec![-3, -4, 5, -2, -3, 2, 6, -4], 8), 8);\n    assert_eq!(candidate(vec![-4, -5, 6, -3, -4, 3, 7, -5], 8), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "rs",
+    "prompt": "/// Write a function to find the union of the elements of two given vectors and output them in sorted order.\nfn union_elements(test_tup1: Vec<isize>, test_tup2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = union_elements;\n    assert_eq!(candidate(vec![3, 4, 5, 6], vec![5, 7, 4, 10]), vec![3, 4, 5, 6, 7, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], vec![3, 4, 5, 6]), vec![1, 2, 3, 4, 5, 6]);\n    assert_eq!(candidate(vec![11, 12, 13, 14], vec![13, 15, 16, 17]), vec![11, 12, 13, 14, 15, 16, 17]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the length of the longest subvectors.\nfn Find_Max_Length(lst: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Find_Max_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 4], vec![5, 6, 7, 8]]), 4);\n    assert_eq!(candidate(vec![vec![0, 1], vec![2, 2], vec![3, 2, 1]]), 3);\n    assert_eq!(candidate(vec![vec![7], vec![22, 23], vec![13, 14, 15], vec![10, 20, 30, 40, 50]]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function which takes a vector of integers and counts the number of possible unordered pairs where both elements are unequal.\nfn count_Pairs(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Pairs;\n    assert_eq!(candidate(vec![1, 2, 1], 3), 2);\n    assert_eq!(candidate(vec![1, 1, 1, 1], 4), 0);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], 5), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to split a string into characters.\nfn split(word: String) -> Vec<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = split;\n    assert_eq!(candidate(String::from(\"python\")), vec![String::from(\"p\"), String::from(\"y\"), String::from(\"t\"), String::from(\"h\"), String::from(\"o\"), String::from(\"n\")]);\n    assert_eq!(candidate(String::from(\"Name\")), vec![String::from(\"N\"), String::from(\"a\"), String::from(\"m\"), String::from(\"e\")]);\n    assert_eq!(candidate(String::from(\"program\")), vec![String::from(\"p\"), String::from(\"r\"), String::from(\"o\"), String::from(\"g\"), String::from(\"r\"), String::from(\"a\"), String::from(\"m\")]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "rs",
+    "prompt": "/// Write a function to get the sum of the digits of a non-negative integer.\nfn sum_digits(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_digits;\n    assert_eq!(candidate(345), 12);\n    assert_eq!(candidate(12), 3);\n    assert_eq!(candidate(97), 16);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a specified vector is sorted or not.\nfn issort_list(list1: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = issort_list;\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 16, 17]), true);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 12, 14, 20, 17]), false);\n    assert_eq!(candidate(vec![1, 2, 4, 6, 8, 10, 15, 14, 20]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "rs",
+    "prompt": "/// Write a function to sort each subvector of strings in a given vector of vectors.\nfn sort_sublists(list1: Vec<Vec<String>>) -> Vec<Vec<String>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_sublists;\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"white\"), String::from(\"black\"), String::from(\"orange\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\"), String::from(\"white\")], vec![String::from(\"black\"), String::from(\"orange\"), String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]), vec![vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"black\")], vec![String::from(\"green\"), String::from(\"orange\")], vec![String::from(\"white\")]]);\n    assert_eq!(candidate(vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"d\"), String::from(\"c\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"f\"), String::from(\"e\")]]), vec![vec![String::from(\"a\"), String::from(\"b\")], vec![String::from(\"c\"), String::from(\"d\")], vec![String::from(\"g\"), String::from(\"h\")], vec![String::from(\"e\"), String::from(\"f\")]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check if a given number is one less than twice its reverse.\nfn checks(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = checks;\n    assert_eq!(candidate(70), false);\n    assert_eq!(candidate(23), false);\n    assert_eq!(candidate(73), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to remove duplicate numbers from a given number of vectors.\nfn two_unique_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = two_unique_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 2, 3, 4, 5]), vec![1, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 2, 4, 5]), vec![1, 3, 4, 5]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to calculate the product of the unique numbers in a given vector.\nfn unique_product(list_data: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_product;\n    assert_eq!(candidate(vec![10, 20, 30, 40, 20, 50, 60, 40]), 720000000);\n    assert_eq!(candidate(vec![1, 2, 3, 1]), 6);\n    assert_eq!(candidate(vec![7, 8, 9, 0, 1, 1]), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "rs",
+    "prompt": "/// Write a function to find the surface area of a cylinder.\nfn surfacearea_cylinder(r: isize, h: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = surfacearea_cylinder;\n    assert_eq!(candidate(10, 5), 942.45);\n    assert_eq!(candidate(4, 5), 226.18800000000002);\n    assert_eq!(candidate(4, 10), 351.848);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether a vector is subvector of another or not.\nfn is_Sub_Array(A: Vec<isize>, B: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Sub_Array;\n    assert_eq!(candidate(vec![1, 4, 3, 5], vec![1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 1], vec![1, 2, 1]), true);\n    assert_eq!(candidate(vec![1, 0, 2, 2], vec![2, 2, 0]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the last digit in factorial of a given number.\nfn last_Digit_Factorial(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = last_Digit_Factorial;\n    assert_eq!(candidate(4), 4);\n    assert_eq!(candidate(21), 0);\n    assert_eq!(candidate(30), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "rs",
+    "prompt": "/// Write a function to interleave 3 vectors of the same length into a single flat vector.\nfn interleave_lists(list1: Vec<isize>, list2: Vec<isize>, list3: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = interleave_lists;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7], vec![10, 20, 30, 40, 50, 60, 70], vec![100, 200, 300, 400, 500, 600, 700]), vec![1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n    assert_eq!(candidate(vec![10, 20], vec![15, 2], vec![5, 10]), vec![10, 15, 5, 20, 2, 10]);\n    assert_eq!(candidate(vec![11, 44], vec![10, 15], vec![20, 5]), vec![11, 10, 20, 44, 15, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "rs",
+    "prompt": "/// Write a function to find the dissimilar elements in the given two tuples.\nfn find_dissimilar(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_dissimilar;\n    assert_eq!(candidate((3, 4, 5, 6), (5, 7, 4, 10)), (3, 6, 7, 10));\n    assert_eq!(candidate((1, 2, 3, 4), (7, 2, 3, 9)), (1, 4, 7, 9));\n    assert_eq!(candidate((21, 11, 25, 26), (26, 34, 21, 36)), (34, 36, 11, 25));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the largest number that can be formed with the given vector of digits.\nfn find_Max_Num(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Max_Num;\n    assert_eq!(candidate(vec![1, 2, 3]), 321);\n    assert_eq!(candidate(vec![4, 5, 6, 1]), 6541);\n    assert_eq!(candidate(vec![1, 2, 3, 9]), 9321);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the surface area of a square rsramid with a given base edge and height.\nfn surface_Area(b: isize, s: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = surface_Area;\n    assert_eq!(candidate(3, 4), 33);\n    assert_eq!(candidate(4, 5), 56);\n    assert_eq!(candidate(1, 2), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "rs",
+    "prompt": "/// Write a function which returns nth catalan number.\nfn catalan_number(num: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = catalan_number;\n    assert_eq!(candidate(10), 16796);\n    assert_eq!(candidate(9), 4862);\n    assert_eq!(candidate(7), 429);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "rs",
+    "prompt": "/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfn find_adverbs(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_adverbs;\n    assert_eq!(candidate(String::from(\"Clearly, he has no excuse for such behavior.\")), String::from(\"0-7: Clearly\"));\n    assert_eq!(candidate(String::from(\"Please handle the situation carefuly\")), String::from(\"28-36: carefuly\"));\n    assert_eq!(candidate(String::from(\"Complete the task quickly\")), String::from(\"18-25: quickly\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to split a vector at the nth eelment and add the first part to the end.\nfn split_Arr(l: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = split_Arr;\n    assert_eq!(candidate(vec![12, 10, 5, 6, 52, 36], 2), vec![5, 6, 52, 36, 12, 10]);\n    assert_eq!(candidate(vec![1, 2, 3, 4], 1), vec![2, 3, 4, 1]);\n    assert_eq!(candidate(vec![0, 1, 2, 3, 4, 5, 6, 7], 3), vec![3, 4, 5, 6, 7, 0, 1, 2]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the difference between largest and smallest value in a given vector.\nfn big_diff(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = big_diff;\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 3);\n    assert_eq!(candidate(vec![4, 5, 12]), 8);\n    assert_eq!(candidate(vec![9, 2, 3]), 7);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "rs",
+    "prompt": "/// Write a function to find perfect squares between two given numbers.\nfn perfect_squares(a: isize, b: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = perfect_squares;\n    assert_eq!(candidate(1, 30), vec![1, 4, 9, 16, 25]);\n    assert_eq!(candidate(50, 100), vec![64, 81, 100]);\n    assert_eq!(candidate(100, 200), vec![100, 121, 144, 169, 196]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given two integers have opposite sign or not.\nfn opposite_Signs(x: isize, y: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = opposite_Signs;\n    assert_eq!(candidate(1, -2), true);\n    assert_eq!(candidate(3, 2), false);\n    assert_eq!(candidate(-10, -10), false);\n    assert_eq!(candidate(-2, 2), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to interchange the first and last elements in a vector.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![12, 35, 9, 56, 24]), vec![24, 35, 9, 56, 12]);\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of the product of consecutive binomial co-efficients.\nfn sum_Of_product(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_product;\n    assert_eq!(candidate(3), 15);\n    assert_eq!(candidate(4), 56);\n    assert_eq!(candidate(1), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "rs",
+    "prompt": "/// Write a function to remove leading zeroes from an ip address.\nfn removezero_ip(ip: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = removezero_ip;\n    assert_eq!(candidate(String::from(\"216.08.094.196\")), String::from(\"216.8.94.196\"));\n    assert_eq!(candidate(String::from(\"12.01.024\")), String::from(\"12.1.24\"));\n    assert_eq!(candidate(String::from(\"216.08.094.0196\")), String::from(\"216.8.94.196\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to find the difference of the first even and first odd number of a given vector.\nfn diff_even_odd(list1: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = diff_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 1);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "rs",
+    "prompt": "/// Write a function to find kth element from the given two sorted vectors.\nfn find_kth(arr1: Vec<isize>, arr2: Vec<isize>, k: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_kth;\n    assert_eq!(candidate(vec![2, 3, 6, 7, 9], vec![1, 4, 8, 10], 5), 6);\n    assert_eq!(candidate(vec![100, 112, 256, 349, 770], vec![72, 86, 113, 119, 265, 445, 892], 7), 256);\n    assert_eq!(candidate(vec![3, 4, 7, 8, 10], vec![2, 5, 9, 11], 6), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is armstrong or not.\nfn armstrong_number(number: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = armstrong_number;\n    assert_eq!(candidate(153), true);\n    assert_eq!(candidate(259), false);\n    assert_eq!(candidate(4458), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "rs",
+    "prompt": "/// Write a function to find sum and average of first n natural numbers.\nfn sum_average(number: isize) -> (isize, f64) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_average;\n    assert_eq!(candidate(10), (55, 5.5));\n    assert_eq!(candidate(15), (120, 8.0));\n    assert_eq!(candidate(20), (210, 10.5));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth octagonal number.\nfn is_octagonal(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_octagonal;\n    assert_eq!(candidate(5), 65);\n    assert_eq!(candidate(10), 280);\n    assert_eq!(candidate(15), 645);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given number is even or not.\nfn is_Even(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Even;\n    assert_eq!(candidate(1), false);\n    assert_eq!(candidate(2), true);\n    assert_eq!(candidate(3), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the first repeated character in a given string.\nfn first_repeated_char(str1: String) -> Option<String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = first_repeated_char;\n    assert_eq!(candidate(String::from(\"abcabc\")), Some(String::from(\"a\")));\n    assert_eq!(candidate(String::from(\"abc\")), None);\n    assert_eq!(candidate(String::from(\"123123\")), Some(String::from(\"1\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "rs",
+    "prompt": "/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfn get_ludic(n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_ludic;\n    assert_eq!(candidate(10), vec![1, 2, 3, 5, 7]);\n    assert_eq!(candidate(25), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n    assert_eq!(candidate(45), vec![1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "rs",
+    "prompt": "/// Write a function to reverse words seperated by spaces in a given string.\nfn reverse_words(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_words;\n    assert_eq!(candidate(String::from(\"python program\")), String::from(\"program python\"));\n    assert_eq!(candidate(String::from(\"java language\")), String::from(\"language java\"));\n    assert_eq!(candidate(String::from(\"indian man\")), String::from(\"man indian\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given integer is a prime number.\nfn prime_num(num: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = prime_num;\n    assert_eq!(candidate(13), true);\n    assert_eq!(candidate(7), true);\n    assert_eq!(candidate(-1010), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "rs",
+    "prompt": "/// Write a function to convert degrees to radians.\nfn radian_degree(degree: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = radian_degree;\n    assert_eq!(candidate(90), 1.5707963267948966);\n    assert_eq!(candidate(60), 1.0471975511965976);\n    assert_eq!(candidate(120), 2.0943951023931953);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "rs",
+    "prompt": "/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfn find_literals(text: String, pattern: String) -> (String, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_literals;\n    assert_eq!(candidate(String::from(\"The quick brown fox jumps over the lazy dog.\"), String::from(\"fox\")), (String::from(\"fox\"), 16, 19));\n    assert_eq!(candidate(String::from(\"Its been a very crazy procedure right\"), String::from(\"crazy\")), (String::from(\"crazy\"), 16, 21));\n    assert_eq!(candidate(String::from(\"Hardest choices required strongest will\"), String::from(\"will\")), (String::from(\"will\"), 35, 39));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find nth bell number.\nfn bell_Number(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = bell_Number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(3), 5);\n    assert_eq!(candidate(4), 15);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function which takes a vector and returns a vector with the same elements, but the k'th element removed.\nfn remove_kth_element(list1: Vec<isize>, L: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_kth_element;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 4, 4, 5, 1], 3), vec![1, 1, 3, 4, 4, 5, 1]);\n    assert_eq!(candidate(vec![0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4), vec![0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n    assert_eq!(candidate(vec![10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5), vec![10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "rs",
+    "prompt": "/// Write a function which given a matrix represented as a vector of vectors returns the max of the n'th column.\nfn max_of_nth(test_list: Vec<Vec<isize>>, N: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_of_nth;\n    assert_eq!(candidate(vec![vec![5, 6, 7], vec![1, 3, 5], vec![8, 9, 19]], 2), 19);\n    assert_eq!(candidate(vec![vec![6, 7, 8], vec![2, 4, 6], vec![9, 10, 20]], 1), 10);\n    assert_eq!(candidate(vec![vec![7, 8, 9], vec![3, 5, 7], vec![10, 11, 21]], 1), 11);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to find the cumulative sum of all the values that are present in the given vector of vectors.\nfn cummulative_sum(test_list: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = cummulative_sum;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 6, 7], vec![2, 6]]), 30);\n    assert_eq!(candidate(vec![vec![2, 4], vec![6, 7, 8], vec![3, 7]]), 37);\n    assert_eq!(candidate(vec![vec![3, 5], vec![7, 8, 9], vec![4, 8]]), 44);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function which takes a vectors of vectors and returns the average value for each subvector as a vector.\nfn average_tuple(nums: Vec<Vec<isize>>) -> Vec<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = average_tuple;\n    assert_eq!(candidate(vec![vec![10, 10, 10, 12], vec![30, 45, 56, 45], vec![81, 80, 39, 32], vec![1, 2, 3, 4]]), vec![30.5, 34.25, 27.0, 23.25]);\n    assert_eq!(candidate(vec![vec![1, 1, -5], vec![30, -15, 56], vec![81, -60, -39], vec![-10, 2, 3]]), vec![25.5, -18.0, 3.75]);\n    assert_eq!(candidate(vec![vec![100, 100, 100, 120], vec![300, 450, 560, 450], vec![810, 800, 390, 320], vec![10, 20, 30, 40]]), vec![305.0, 342.5, 270.0, 232.5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "rs",
+    "prompt": "/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfn tuple_modulo(test_tup1: (isize, isize, isize, isize), test_tup2: (isize, isize, isize, isize)) -> (isize, isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_modulo;\n    assert_eq!(candidate((10, 4, 5, 6), (5, 6, 7, 5)), (0, 4, 5, 1));\n    assert_eq!(candidate((11, 5, 6, 7), (6, 7, 8, 6)), (5, 5, 6, 1));\n    assert_eq!(candidate((12, 6, 7, 8), (7, 8, 9, 7)), (5, 6, 7, 1));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "rs",
+    "prompt": "/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfn min_Jumps(steps: (isize, isize), d: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = min_Jumps;\n    assert_eq!(candidate((3, 4), 11), 3.5);\n    assert_eq!(candidate((3, 4), 0), 0.0);\n    assert_eq!(candidate((11, 14), 11), 1.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "rs",
+    "prompt": "/// Write a function to divide two vectors element wise.\nfn div_list(nums1: Vec<isize>, nums2: Vec<isize>) -> Vec<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = div_list;\n    assert_eq!(candidate(vec![4, 5, 6], vec![1, 2, 3]), vec![4.0, 2.5, 2.0]);\n    assert_eq!(candidate(vec![3, 2], vec![1, 4]), vec![3.0, 0.5]);\n    assert_eq!(candidate(vec![90, 120], vec![50, 70]), vec![1.8, 1.7142857142857142]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "rs",
+    "prompt": "/// Write a function to move all the numbers to the end of the given string.\nfn move_num(test_str: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = move_num;\n    assert_eq!(candidate(String::from(\"I1love143you55three3000thousand\")), String::from(\"Iloveyouthreethousand1143553000\"));\n    assert_eq!(candidate(String::from(\"Avengers124Assemble\")), String::from(\"AvengersAssemble124\"));\n    assert_eq!(candidate(String::from(\"Its11our12path13to14see15things16do17things\")), String::from(\"Itsourpathtoseethingsdothings11121314151617\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of substrings with the sum of digits equal to their length.\nfn count_Substrings(s: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_Substrings;\n    assert_eq!(candidate(String::from(\"112112\")), 6);\n    assert_eq!(candidate(String::from(\"111\")), 6);\n    assert_eq!(candidate(String::from(\"1101112\")), 12);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "rs",
+    "prompt": "/// Write a function to find the median of two sorted vectors of same size.\nfn get_median(arr1: Vec<isize>, arr2: Vec<isize>, n: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_median;\n    assert_eq!(candidate(vec![1, 12, 15, 26, 38], vec![2, 13, 17, 30, 45], 5), 16.0);\n    assert_eq!(candidate(vec![2, 4, 8, 9], vec![7, 13, 19, 28], 4), 8.5);\n    assert_eq!(candidate(vec![3, 6, 14, 23, 36, 42], vec![2, 18, 27, 39, 49, 55], 6), 25.0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to compute the n-th power of each number in a vector.\nfn nth_nums(nums: Vec<isize>, n: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = nth_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30], 3), vec![1000, 8000, 27000]);\n    assert_eq!(candidate(vec![12, 15], 5), vec![248832, 759375]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to convert a given string to uppercase.\nfn is_upper(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_upper;\n    assert_eq!(candidate(String::from(\"person\")), String::from(\"PERSON\"));\n    assert_eq!(candidate(String::from(\"final\")), String::from(\"FINAL\"));\n    assert_eq!(candidate(String::from(\"Valid\")), String::from(\"VALID\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to interchange the first and last element in a given vector.\nfn swap_List(newList: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = swap_List;\n    assert_eq!(candidate(vec![1, 2, 3]), vec![3, 2, 1]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 4]), vec![4, 2, 3, 4, 1]);\n    assert_eq!(candidate(vec![4, 5, 6]), vec![6, 5, 4]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfn triangle_area(r: isize) -> Option<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = triangle_area;\n    assert_eq!(candidate(-1), None);\n    assert_eq!(candidate(0), Some(0));\n    assert_eq!(candidate(2), Some(4));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the smallest missing number from a sorted vector of natural numbers.\nfn find_First_Missing(array: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_First_Missing;\n    assert_eq!(candidate(vec![0, 1, 2, 3]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, 6, 9]), 3);\n    assert_eq!(candidate(vec![2, 3, 5, 8, 9]), 0);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to replace all spaces in the given string with '%20'.\nfn replace_spaces(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"My Name is Dawood\")), String::from(\"My%20Name%20is%20Dawood\"));\n    assert_eq!(candidate(String::from(\"I am a Programmer\")), String::from(\"I%20am%20a%20Programmer\"));\n    assert_eq!(candidate(String::from(\"I love Coding\")), String::from(\"I%20love%20Coding\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find even numbers from a vector of numbers.\nfn Split(list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Split;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), vec![2, 4]);\n    assert_eq!(candidate(vec![4, 5, 6, 7, 8, 0, 1]), vec![4, 6, 8, 0]);\n    assert_eq!(candidate(vec![8, 12, 15, 19]), vec![8, 12]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find smallest number in a vector.\nfn smallest_num(xs: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = smallest_num;\n    assert_eq!(candidate(vec![10, 20, 1, 45, 99]), 1);\n    assert_eq!(candidate(vec![1, 2, 3]), 1);\n    assert_eq!(candidate(vec![45, 46, 50, 60]), 45);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "rs",
+    "prompt": "/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfn get_coordinates(test_tup: (isize, isize)) -> Vec<Vec<isize>> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_coordinates;\n    assert_eq!(candidate((3, 4)), vec![vec![2, 3], vec![2, 4], vec![2, 5], vec![3, 3], vec![3, 4], vec![3, 5], vec![4, 3], vec![4, 4], vec![4, 5]]);\n    assert_eq!(candidate((4, 5)), vec![vec![3, 4], vec![3, 5], vec![3, 6], vec![4, 4], vec![4, 5], vec![4, 6], vec![5, 4], vec![5, 5], vec![5, 6]]);\n    assert_eq!(candidate((5, 6)), vec![vec![4, 5], vec![4, 6], vec![4, 7], vec![5, 5], vec![5, 6], vec![5, 7], vec![6, 5], vec![6, 6], vec![6, 7]]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfn replace_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_spaces;\n    assert_eq!(candidate(String::from(\"Jumanji The Jungle\")), String::from(\"Jumanji_The_Jungle\"));\n    assert_eq!(candidate(String::from(\"The_Avengers\")), String::from(\"The Avengers\"));\n    assert_eq!(candidate(String::from(\"Fast and Furious\")), String::from(\"Fast_and_Furious\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to move all zeroes to the end of the given vector.\nfn move_zero(num_list: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = move_zero;\n    assert_eq!(candidate(vec![1, 0, 2, 0, 3, 4]), vec![1, 2, 3, 4, 0, 0]);\n    assert_eq!(candidate(vec![2, 3, 2, 0, 0, 4, 0, 5, 0]), vec![2, 3, 2, 4, 5, 0, 0, 0, 0]);\n    assert_eq!(candidate(vec![0, 1, 0, 1, 1]), vec![1, 1, 1, 0, 0]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of xor of all pairs of numbers in the given vector.\nfn pair_xor_Sum(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pair_xor_Sum;\n    assert_eq!(candidate(vec![5, 9, 7, 6], 4), 47);\n    assert_eq!(candidate(vec![7, 3, 5], 3), 12);\n    assert_eq!(candidate(vec![7, 3], 2), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort the given vector.\nfn heap_sort(iterable: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = heap_sort;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 9, 2, 4, 6, 8, 0]), vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n    assert_eq!(candidate(vec![25, 35, 22, 85, 14, 65, 75, 25, 58]), vec![14, 22, 25, 25, 35, 58, 65, 75, 85]);\n    assert_eq!(candidate(vec![7, 1, 9, 5]), vec![1, 5, 7, 9]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given amount has no profit and no loss\nfn noprofit_noloss(actual_cost: isize, sale_amount: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = noprofit_noloss;\n    assert_eq!(candidate(1500, 1200), false);\n    assert_eq!(candidate(100, 100), true);\n    assert_eq!(candidate(2000, 5000), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfn wind_chill(v: isize, t: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = wind_chill;\n    assert_eq!(candidate(120, 35), 40);\n    assert_eq!(candidate(40, 20), 19);\n    assert_eq!(candidate(10, 8), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "rs",
+    "prompt": "/// Write a function to sum the length of the names of a given vector of names after removing the names that start with a lowercase letter.\nfn sample_nam(sample_names: Vec<String>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sample_nam;\n    assert_eq!(candidate(vec![String::from(\"sally\"), String::from(\"Dylan\"), String::from(\"rebecca\"), String::from(\"Diana\"), String::from(\"Joanne\"), String::from(\"keith\")]), 16);\n    assert_eq!(candidate(vec![String::from(\"php\"), String::from(\"res\"), String::from(\"Python\"), String::from(\"abcd\"), String::from(\"Java\"), String::from(\"aaa\")]), 10);\n    assert_eq!(candidate(vec![String::from(\"abcd\"), String::from(\"Python\"), String::from(\"abba\"), String::from(\"aba\")]), 6);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "rs",
+    "prompt": "/// Write a function to find the maximum difference between available pairs in the given tuple vector.\nfn max_difference(test_list: Vec<(isize, isize)>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_difference;\n    assert_eq!(candidate(vec![(3, 5), (1, 7), (10, 3), (1, 2)]), 7);\n    assert_eq!(candidate(vec![(4, 6), (2, 17), (9, 13), (11, 12)]), 15);\n    assert_eq!(candidate(vec![(12, 35), (21, 27), (13, 23), (41, 22)]), 23);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "rs",
+    "prompt": "/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfn remove_parenthesis(items: Vec<String>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_parenthesis;\n    assert_eq!(candidate(vec![String::from(\"python (chrome)\")]), String::from(\"python\"));\n    assert_eq!(candidate(vec![String::from(\"string(.abc)\")]), String::from(\"string\"));\n    assert_eq!(candidate(vec![String::from(\"alpha(num)\")]), String::from(\"alpha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth nonagonal number.\nfn is_nonagonal(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_nonagonal;\n    assert_eq!(candidate(10), 325);\n    assert_eq!(candidate(15), 750);\n    assert_eq!(candidate(18), 1089);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "rs",
+    "prompt": "/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfn text_match_wordz_middle(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_wordz_middle;\n    assert_eq!(candidate(String::from(\"pythonzabc.\")), true);\n    assert_eq!(candidate(String::from(\"zxyabc.\")), false);\n    assert_eq!(candidate(String::from(\"  lang  .\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to reverse a vector upto a given position.\nfn reverse_Array_Upto_K(input: Vec<isize>, k: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = reverse_Array_Upto_K;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 4), vec![4, 3, 2, 1, 5, 6]);\n    assert_eq!(candidate(vec![4, 5, 6, 7], 2), vec![5, 4, 6, 7]);\n    assert_eq!(candidate(vec![9, 8, 7, 6, 5], 3), vec![7, 8, 9, 6, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a vector of tuples using the second value of each tuple.\nfn subject_marks(subjectmarks: Vec<(String, isize)>) -> Vec<(String, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = subject_marks;\n    assert_eq!(candidate(vec![(String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97), (String::from(\"Social sciences\"), 82)]), vec![(String::from(\"Social sciences\"), 82), (String::from(\"English\"), 88), (String::from(\"Science\"), 90), (String::from(\"Maths\"), 97)]);\n    assert_eq!(candidate(vec![(String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54), (String::from(\"Social\"), 33)]), vec![(String::from(\"Social\"), 33), (String::from(\"Telugu\"), 49), (String::from(\"Hindhi\"), 54)]);\n    assert_eq!(candidate(vec![(String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97), (String::from(\"Biology\"), 45)]), vec![(String::from(\"Biology\"), 45), (String::from(\"Physics\"), 96), (String::from(\"Chemistry\"), 97)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of positive numbers in a vector.\nfn pos_count(list: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pos_count;\n    assert_eq!(candidate(vec![1, -2, 3, -4]), 2);\n    assert_eq!(candidate(vec![3, 4, 5, -1]), 3);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find the number of ways to partition a set of Bell numbers.\nfn bell_number(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = bell_number;\n    assert_eq!(candidate(2), 2);\n    assert_eq!(candidate(10), 115975);\n    assert_eq!(candidate(56), 6775685320645824322581483068371419745979053216268760300);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given vector is monotonic or not.\nfn is_Monotonic(A: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Monotonic;\n    assert_eq!(candidate(vec![6, 5, 4, 4]), true);\n    assert_eq!(candidate(vec![1, 2, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 3, 2]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a vector contains the given subvector or not.\nfn is_sublist(l: Vec<isize>, s: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_sublist;\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![3, 7]), false);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![4, 3]), true);\n    assert_eq!(candidate(vec![2, 4, 3, 5, 7], vec![1, 6]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the two numbers differ at one bit position only or not.\nfn differ_At_One_Bit_Pos(a: isize, b: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = differ_At_One_Bit_Pos;\n    assert_eq!(candidate(13, 9), true);\n    assert_eq!(candidate(15, 8), false);\n    assert_eq!(candidate(2, 4), false);\n    assert_eq!(candidate(2, 3), true);\n    assert_eq!(candidate(5, 1), true);\n    assert_eq!(candidate(1, 5), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "rs",
+    "prompt": "/// Write a function to find whether all the given vectors have equal length or not.\nfn get_equal(Input: Vec<Vec<isize>>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_equal;\n    assert_eq!(candidate(vec![vec![11, 22, 33], vec![44, 55, 66]]), true);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6, 7]]), false);\n    assert_eq!(candidate(vec![vec![1, 2], vec![3, 4]]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a vector of elements.\nfn comb_sort(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = comb_sort;\n    assert_eq!(candidate(vec![5, 15, 37, 25, 79]), vec![5, 15, 25, 37, 79]);\n    assert_eq!(candidate(vec![41, 32, 15, 19, 22]), vec![15, 19, 22, 32, 41]);\n    assert_eq!(candidate(vec![99, 15, 13, 47]), vec![13, 15, 47, 99]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to add a HashMap to the tuple. The output should be a tuple.\nfn add_dict_to_tuple(test_tup: (isize, isize, isize), test_dict: HashMap<String, isize>) -> (isize, isize, isize, HashMap<String, isize>) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add_dict_to_tuple;\n    assert_eq!(candidate((4, 5, 6), HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])), (4, 5, 6, HashMap::from([(String::from(\"MSAM\"), 1), (String::from(\"is\"), 2), (String::from(\"best\"), 3)])));\n    assert_eq!(candidate((1, 2, 3), HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])), (1, 2, 3, HashMap::from([(String::from(\"UTS\"), 2), (String::from(\"is\"), 3), (String::from(\"Worst\"), 4)])));\n    assert_eq!(candidate((8, 9, 10), HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])), (8, 9, 10, HashMap::from([(String::from(\"POS\"), 3), (String::from(\"is\"), 4), (String::from(\"Okay\"), 5)])));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "rs",
+    "prompt": "/// Given a square matrix of size N*N given as a vector of vectors, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfn maxAverageOfPath(cost: Vec<Vec<isize>>) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = maxAverageOfPath;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![6, 5, 4], vec![7, 3, 9]]), 5.2);\n    assert_eq!(candidate(vec![vec![2, 3, 4], vec![7, 6, 5], vec![8, 4, 10]]), 6.2);\n    assert_eq!(candidate(vec![vec![3, 4, 5], vec![8, 7, 6], vec![9, 5, 11]]), 7.2);\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]), 5.8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "rs",
+    "prompt": "/// The input is defined as two vectors of the same length. Write a function to count indices where the vectors have the same values.\nfn count_same_pair(nums1: Vec<isize>, nums2: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_same_pair;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8], vec![2, 2, 3, 1, 2, 6, 7, 9]), 4);\n    assert_eq!(candidate(vec![0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 11);\n    assert_eq!(candidate(vec![2, 4, -6, -9, 11, -12, 14, -5, 17], vec![2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]), 1);\n    assert_eq!(candidate(vec![0, 1, 1, 2], vec![0, 1, 2, 2]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "rs",
+    "prompt": "/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfn power_base_sum(base: isize, power: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = power_base_sum;\n    assert_eq!(candidate(2, 100), 115);\n    assert_eq!(candidate(8, 10), 37);\n    assert_eq!(candidate(8, 15), 62);\n    assert_eq!(candidate(3, 3), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "rs",
+    "prompt": "/// Write a function takes as input two vectors [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfn sum_list(lst1: Vec<isize>, lst2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_list;\n    assert_eq!(candidate(vec![10, 20, 30], vec![15, 25, 35]), vec![25, 45, 65]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![5, 6, 7]), vec![6, 8, 10]);\n    assert_eq!(candidate(vec![15, 20, 30], vec![15, 45, 75]), vec![30, 65, 105]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the given number can be represented as the difference of two squares or not.\nfn dif_Square(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = dif_Square;\n    assert_eq!(candidate(5), true);\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(15), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "rs",
+    "prompt": "/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfn lateralsurface_cone(r: isize, h: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = lateralsurface_cone;\n    assert_eq!(candidate(5, 12), 204.20352248333654);\n    assert_eq!(candidate(10, 15), 566.3586699569488);\n    assert_eq!(candidate(19, 17), 1521.8090132193388);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "rs",
+    "prompt": "/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfn replace_specialchar(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = replace_specialchar;\n    assert_eq!(candidate(String::from(\"Python language, Programming language.\")), String::from(\"Python:language::Programming:language:\"));\n    assert_eq!(candidate(String::from(\"a b c,d e f\")), String::from(\"a:b:c:d:e:f\"));\n    assert_eq!(candidate(String::from(\"ram reshma,ram rahim\")), String::from(\"ram:reshma:ram:rahim\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "rs",
+    "prompt": "/// Write a function to find the index of the first occurrence of a given number in a sorted vector.\nfn find_first_occurrence(A: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_first_occurrence;\n    assert_eq!(candidate(vec![2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5), 1);\n    assert_eq!(candidate(vec![2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5), 2);\n    assert_eq!(candidate(vec![2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find sum of products of all possible subvectors of a given vector. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subvectors/\nfn sum_Of_Subarray_Prod(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_Of_Subarray_Prod;\n    assert_eq!(candidate(vec![1, 2, 3]), 20);\n    assert_eq!(candidate(vec![1, 2]), 5);\n    assert_eq!(candidate(vec![1, 2, 3, 4]), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfn toggle_middle_bits(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = toggle_middle_bits;\n    assert_eq!(candidate(9), 15);\n    assert_eq!(candidate(10), 12);\n    assert_eq!(candidate(11), 13);\n    assert_eq!(candidate(65), 127);\n    assert_eq!(candidate(77), 115);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "rs",
+    "prompt": "/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/rsthon-exercises/data-structures-and-algorithms/rsthon-data-structure-exercise-24.php\nfn left_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = left_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfn check_str(string: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_str;\n    assert_eq!(candidate(String::from(\"annie\")), true);\n    assert_eq!(candidate(String::from(\"dawood\")), false);\n    assert_eq!(candidate(String::from(\"Else\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/rsthon-exercises/data-structures-and-algorithms/rsthon-recursion-exercise-9.php\nfn geometric_sum(n: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = geometric_sum;\n    assert_eq!(candidate(7), 1.9921875);\n    assert_eq!(candidate(4), 1.9375);\n    assert_eq!(candidate(8), 1.99609375);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfn find_Index(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Index;\n    assert_eq!(candidate(2), 4);\n    assert_eq!(candidate(3), 14);\n    assert_eq!(candidate(4), 45);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to convert the given tuple to a key-value HashMap using adjacent elements. https://www.geeksforgeeks.org/rsthon-convert-tuple-to-adjacent-pair-HashMap/\nfn tuple_to_dict(test_tup: (isize, isize, isize, isize, isize, isize)) -> HashMap<isize, isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_to_dict;\n    assert_eq!(candidate((1, 5, 7, 10, 13, 5)), HashMap::from([(1, 5), (7, 10), (13, 5)]));\n    assert_eq!(candidate((1, 2, 3, 4, 5, 6)), HashMap::from([(1, 2), (3, 4), (5, 6)]));\n    assert_eq!(candidate((7, 8, 9, 10, 11, 12)), HashMap::from([(7, 8), (9, 10), (11, 12)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether all the characters are same or not.\nfn all_Characters_Same(s: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = all_Characters_Same;\n    assert_eq!(candidate(String::from(\"python\")), false);\n    assert_eq!(candidate(String::from(\"aaa\")), true);\n    assert_eq!(candidate(String::from(\"data\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "rs",
+    "prompt": "/// Write a function to caluclate the area of a tetrahedron.\nfn area_tetrahedron(side: isize) -> f64 {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = area_tetrahedron;\n    assert_eq!(candidate(3), 15.588457268119894);\n    assert_eq!(candidate(20), 692.8203230275509);\n    assert_eq!(candidate(10), 173.20508075688772);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "rs",
+    "prompt": "/// Write a function to rotate a given vector by specified number of items to the right direction. https://www.geeksforgeeks.org/rsthon-program-right-rotate-vector-n/\nfn rotate_right(list: Vec<isize>, m: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rotate_right;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3), vec![8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2), vec![9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5), vec![6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "rs",
+    "prompt": "/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/rsthon-exercises/lambda/rsthon-lambda-exercise-24.php\nfn divisible_by_digits(startnum: isize, endnum: isize) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = divisible_by_digits;\n    assert_eq!(candidate(1, 22), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n    assert_eq!(candidate(1, 15), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n    assert_eq!(candidate(20, 25), vec![22, 24]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "rs",
+    "prompt": "/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfn sector_area(r: isize, a: isize) -> Option<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sector_area;\n    assert_eq!(candidate(4, 45), Some(6.283185307179586));\n    assert_eq!(candidate(9, 45), Some(31.808625617596654));\n    assert_eq!(candidate(9, 361), None);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "rs",
+    "prompt": "/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfn lcs_of_three(X: String, Y: String, Z: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = lcs_of_three;\n    assert_eq!(candidate(String::from(\"AGGT12\"), String::from(\"12TXAYB\"), String::from(\"12XBA\")), 2);\n    assert_eq!(candidate(String::from(\"Reels\"), String::from(\"Reelsfor\"), String::from(\"ReelsforReels\")), 5);\n    assert_eq!(candidate(String::from(\"abcd1e2\"), String::from(\"bc12ea\"), String::from(\"bd1ea\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to put spaces between words starting with capital letters in a given string.\nfn capital_words_spaces(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = capital_words_spaces;\n    assert_eq!(candidate(String::from(\"Python\")), String::from(\"Python\"));\n    assert_eq!(candidate(String::from(\"PythonProgrammingExamples\")), String::from(\"Python Programming Examples\"));\n    assert_eq!(candidate(String::from(\"GetReadyToBeCodingFreak\")), String::from(\"Get Ready To Be Coding Freak\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "rs",
+    "prompt": "/// Write a function to sort a given vector of strings of numbers numerically. https://www.geeksforgeeks.org/rsthon-sort-numeric-strings-in-a-vector/\nfn sort_numeric_strings(nums_str: Vec<String>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sort_numeric_strings;\n    assert_eq!(candidate(vec![String::from(\"4\"), String::from(\"12\"), String::from(\"45\"), String::from(\"7\"), String::from(\"0\"), String::from(\"100\"), String::from(\"200\"), String::from(\"-12\"), String::from(\"-500\")]), vec![-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n    assert_eq!(candidate(vec![String::from(\"2\"), String::from(\"3\"), String::from(\"8\"), String::from(\"4\"), String::from(\"7\"), String::from(\"9\"), String::from(\"8\"), String::from(\"2\"), String::from(\"6\"), String::from(\"5\"), String::from(\"1\"), String::from(\"6\"), String::from(\"1\"), String::from(\"2\"), String::from(\"3\"), String::from(\"4\"), String::from(\"6\"), String::from(\"9\"), String::from(\"1\"), String::from(\"2\")]), vec![1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n    assert_eq!(candidate(vec![String::from(\"1\"), String::from(\"3\"), String::from(\"5\"), String::from(\"7\"), String::from(\"1\"), String::from(\"3\"), String::from(\"13\"), String::from(\"15\"), String::from(\"17\"), String::from(\"5\"), String::from(\"7 \"), String::from(\"9\"), String::from(\"1\"), String::from(\"11\")]), vec![1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether it follows the sequence given in the patterns vector.\nfn is_samepatterns(colors: Vec<String>, patterns: Vec<String>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_samepatterns;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"green\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\"), String::from(\"b\")]), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"green\"), String::from(\"greenn\")], vec![String::from(\"a\"), String::from(\"b\")]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to add the given tuple to the given vector.\nfn add_tuple(test_list: Vec<isize>, test_tup: (isize, isize)) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = add_tuple;\n    assert_eq!(candidate(vec![5, 6, 7], (9, 10)), vec![5, 6, 7, 9, 10]);\n    assert_eq!(candidate(vec![6, 7, 8], (10, 11)), vec![6, 7, 8, 10, 11]);\n    assert_eq!(candidate(vec![7, 8, 9], (11, 12)), vec![7, 8, 9, 11, 12]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given vector represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-vector-represents-a-binary-heap/\nfn check_min_heap(arr: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_min_heap;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6]), true);\n    assert_eq!(candidate(vec![2, 3, 4, 5, 10, 15]), true);\n    assert_eq!(candidate(vec![2, 10, 4, 5, 3, 15]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfn jacobsthal_num(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = jacobsthal_num;\n    assert_eq!(candidate(5), 11);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(4), 5);\n    assert_eq!(candidate(13), 2731);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "rs",
+    "prompt": "/// Write a function to find minimum k records from tuple vector. https://www.geeksforgeeks.org/rsthon-find-minimum-k-records-from-tuple-vector/ - in this case a verbatim cors of test cases\nfn min_k(test_list: Vec<(String, isize)>, K: isize) -> Vec<(String, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = min_k;\n    assert_eq!(candidate(vec![(String::from(\"Manjeet\"), 10), (String::from(\"Akshat\"), 4), (String::from(\"Akash\"), 2), (String::from(\"Nikhil\"), 8)], 2), vec![(String::from(\"Akash\"), 2), (String::from(\"Akshat\"), 4)]);\n    assert_eq!(candidate(vec![(String::from(\"Sanjeev\"), 11), (String::from(\"Angat\"), 5), (String::from(\"Akash\"), 3), (String::from(\"Nepin\"), 9)], 3), vec![(String::from(\"Akash\"), 3), (String::from(\"Angat\"), 5), (String::from(\"Nepin\"), 9)]);\n    assert_eq!(candidate(vec![(String::from(\"tanmay\"), 14), (String::from(\"Amer\"), 11), (String::from(\"Ayesha\"), 9), (String::from(\"SKD\"), 16)], 1), vec![(String::from(\"Ayesha\"), 9)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/rsthon-exercises/re/rsthon-re-exercise-3.php\nfn text_match_zero_one(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_zero_one;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"dsabbbba\")), true);\n    assert_eq!(candidate(String::from(\"asbbbba\")), false);\n    assert_eq!(candidate(String::from(\"abaaa\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "rs",
+    "prompt": "/// Write a function to count the pairs of reverse strings in the given string vector. https://www.geeksforgeeks.org/rsthon-program-to-count-the-pairs-of-reverse-strings/\nfn count_reverse_pairs(test_list: Vec<String>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_reverse_pairs;\n    assert_eq!(candidate(vec![String::from(\"julia\"), String::from(\"best\"), String::from(\"tseb\"), String::from(\"for\"), String::from(\"ailuj\")]), 2);\n    assert_eq!(candidate(vec![String::from(\"geeks\"), String::from(\"best\"), String::from(\"for\"), String::from(\"skeeg\")]), 1);\n    assert_eq!(candidate(vec![String::from(\"makes\"), String::from(\"best\"), String::from(\"sekam\"), String::from(\"for\"), String::from(\"rof\")]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfn is_decimal(num: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_decimal;\n    assert_eq!(candidate(String::from(\"123.11\")), true);\n    assert_eq!(candidate(String::from(\"e666.86\")), false);\n    assert_eq!(candidate(String::from(\"3.124587\")), false);\n    assert_eq!(candidate(String::from(\"1.11\")), true);\n    assert_eq!(candidate(String::from(\"1.1.11\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "rs",
+    "prompt": "/// Write a function to find tuples which have all elements divisible by k from the given vector of tuples.\nfn find_tuples(test_list: Vec<(isize, isize, isize)>, K: isize) -> Vec<(isize, isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_tuples;\n    assert_eq!(candidate(vec![(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6), vec![(6, 24, 12)]);\n    assert_eq!(candidate(vec![(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5), vec![(5, 25, 30)]);\n    assert_eq!(candidate(vec![(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4), vec![(8, 16, 4)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether a vector of numbers contains only one distinct element or not.\nfn unique_Element(arr: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = unique_Element;\n    assert_eq!(candidate(vec![1, 1, 1]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), false);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfn check_monthnumber_number(monthnum3: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_monthnumber_number;\n    assert_eq!(candidate(6), true);\n    assert_eq!(candidate(2), false);\n    assert_eq!(candidate(12), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the minimum difference between any two elements in a given vector. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfn find_min_diff(arr: Vec<isize>, n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_min_diff;\n    assert_eq!(candidate(vec![1, 5, 3, 19, 18, 25], 6), 1);\n    assert_eq!(candidate(vec![4, 3, 2, 6], 4), 1);\n    assert_eq!(candidate(vec![30, 5, 20, 9], 4), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count number of digits in a given string.\nfn number_ctr(str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = number_ctr;\n    assert_eq!(candidate(String::from(\"program2bedone\")), 1);\n    assert_eq!(candidate(String::from(\"3wonders\")), 1);\n    assert_eq!(candidate(String::from(\"123\")), 3);\n    assert_eq!(candidate(String::from(\"3wond-1ers2\")), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "rs",
+    "prompt": "/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfn is_polite(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_polite;\n    assert_eq!(candidate(7), 11);\n    assert_eq!(candidate(4), 7);\n    assert_eq!(candidate(9), 13);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "rs",
+    "prompt": "/// Write a function to return a vector of all pairs of consecutive items in a given vector.\nfn pair_wise(l1: Vec<isize>) -> Vec<(isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = pair_wise;\n    assert_eq!(candidate(vec![1, 1, 2, 3, 3, 4, 4, 5]), vec![(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), vec![(1, 5), (5, 7), (7, 9), (9, 10)]);\n    assert_eq!(candidate(vec![5, 1, 9, 7, 10]), vec![(5, 1), (1, 9), (9, 7), (7, 10)]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a vector of numbers and the sum,\nfn get_pairs_count(arr: Vec<isize>, sum: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_pairs_count;\n    assert_eq!(candidate(vec![1, 1, 1, 1], 2), 6);\n    assert_eq!(candidate(vec![1, 5, 7, -1, 5], 6), 3);\n    assert_eq!(candidate(vec![1, -2, 3], 1), 1);\n    assert_eq!(candidate(vec![-1, -2, 3], -3), 1);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to get the difference between two vectors.\nfn Diff(li1: Vec<isize>, li2: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Diff;\n    assert_eq!(candidate(vec![10, 15, 20, 25, 30, 35, 40], vec![25, 40, 35]), vec![10, 20, 30, 15]);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5], vec![6, 7, 1]), vec![2, 3, 4, 5, 6, 7]);\n    assert_eq!(candidate(vec![1, 2, 3], vec![6, 7, 1]), vec![2, 3, 6, 7]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of fourth power of first n odd natural numbers.\nfn odd_num_sum(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_num_sum;\n    assert_eq!(candidate(2), 82);\n    assert_eq!(candidate(3), 707);\n    assert_eq!(candidate(4), 3108);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfn check_expression(exp: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_expression;\n    assert_eq!(candidate(String::from(\"{()}[{}]\")), true);\n    assert_eq!(candidate(String::from(\"{()}[{]\")), false);\n    assert_eq!(candidate(String::from(\"{()}[{}][]({})\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all the words with k length in the given string.\nfn remove_length(test_str: String, K: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_length;\n    assert_eq!(candidate(String::from(\"The person is most value tet\"), 3), String::from(\"person is most value\"));\n    assert_eq!(candidate(String::from(\"If you told me about this ok\"), 4), String::from(\"If you me about ok\"));\n    assert_eq!(candidate(String::from(\"Forces of darkeness is come into the play\"), 4), String::from(\"Forces of darkeness is the\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "rs",
+    "prompt": "/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfn occurance_substring(text: String, pattern: String) -> Option<(String, isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = occurance_substring;\n    assert_eq!(candidate(String::from(\"python programming, python language\"), String::from(\"python\")), Some((String::from(\"python\"), 0, 6)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"programming\")), Some((String::from(\"programming\"), 7, 18)));\n    assert_eq!(candidate(String::from(\"python programming,programming language\"), String::from(\"language\")), Some((String::from(\"language\"), 31, 39)));\n    assert_eq!(candidate(String::from(\"c++ programming, c++ language\"), String::from(\"python\")), None);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether every odd index contains odd numbers of a given vector.\nfn odd_position(nums: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_position;\n    assert_eq!(candidate(vec![2, 1, 4, 3, 6, 7, 6, 3]), true);\n    assert_eq!(candidate(vec![4, 1, 2]), true);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "rs",
+    "prompt": "/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfn count_vowels(test_str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_vowels;\n    assert_eq!(candidate(String::from(\"bestinstareels\")), 7);\n    assert_eq!(candidate(String::from(\"partofthejourneyistheend\")), 12);\n    assert_eq!(candidate(String::from(\"amazonprime\")), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of non-repeated elements in a given vector.\nfn find_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_sum;\n    assert_eq!(candidate(vec![1, 2, 3, 1, 1, 4, 5, 6]), 21);\n    assert_eq!(candidate(vec![1, 10, 9, 4, 2, 10, 10, 45, 4]), 71);\n    assert_eq!(candidate(vec![12, 10, 9, 45, 2, 10, 10, 45, 10]), 78);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find whether a number is divisible by 11.\nfn is_Diff(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_Diff;\n    assert_eq!(candidate(12345), false);\n    assert_eq!(candidate(1212112), true);\n    assert_eq!(candidate(1212), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "rs",
+    "prompt": "/// Write a function to find the combinations of sums with tuples in the given tuple vector. https://www.geeksforgeeks.org/rsthon-combinations-of-sum-with-tuples-in-tuple-vector/\nfn find_combinations(test_list: Vec<(isize, isize)>) -> Vec<(isize, isize)> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_combinations;\n    assert_eq!(candidate(vec![(2, 4), (6, 7), (5, 1), (6, 10)]), vec![(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]);\n    assert_eq!(candidate(vec![(3, 5), (7, 8), (6, 2), (7, 11)]), vec![(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]);\n    assert_eq!(candidate(vec![(4, 6), (8, 9), (7, 3), (8, 12)]), vec![(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the count of divisors is even. https://www.w3resource.com/rsthon-exercises/basic/rsthon-basic-1-exercise-24.php\nfn count_divisors(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_divisors;\n    assert_eq!(candidate(10), true);\n    assert_eq!(candidate(100), false);\n    assert_eq!(candidate(125), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of all odd length subvectors. https://www.geeksforgeeks.org/sum-of-all-odd-length-subvectors/\nfn odd_length_sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = odd_length_sum;\n    assert_eq!(candidate(vec![1, 2, 4]), 14);\n    assert_eq!(candidate(vec![1, 2, 1, 2]), 15);\n    assert_eq!(candidate(vec![1, 7]), 8);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "rs",
+    "prompt": "/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfn rgb_to_hsv(r: isize, g: isize, b: isize) -> Vec<f64> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = rgb_to_hsv;\n    assert_eq!(candidate(255, 255, 255), vec![0.0, 0.0, 100.0]);\n    assert_eq!(candidate(0, 215, 0), vec![120.0, 100.0, 84.31372549019608]);\n    assert_eq!(candidate(10, 215, 110), vec![149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "rs",
+    "prompt": "/// Write a function to find the product of first even and odd number of a given vector.\nfn mul_even_odd(list1: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = mul_even_odd;\n    assert_eq!(candidate(vec![1, 3, 5, 7, 4, 1, 6, 8]), 4);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 2);\n    assert_eq!(candidate(vec![1, 5, 7, 9, 10]), 10);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "rs",
+    "prompt": "/// Write a function to convert tuple string to integer tuple.\nfn tuple_str_int(test_str: String) -> (isize, isize, isize) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tuple_str_int;\n    assert_eq!(candidate(String::from(\"(7, 8, 9)\")), (7, 8, 9));\n    assert_eq!(candidate(String::from(\"(1, 2, 3)\")), (1, 2, 3));\n    assert_eq!(candidate(String::from(\"(4, 5, 6)\")), (4, 5, 6));\n    assert_eq!(candidate(String::from(\"(7, 81, 19)\")), (7, 81, 19));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "rs",
+    "prompt": "/// Write a function to locate the right insertion point for a specified value in sorted order.\nfn right_insertion(a: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = right_insertion;\n    assert_eq!(candidate(vec![1, 2, 4, 5], 6), 4);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 3), 2);\n    assert_eq!(candidate(vec![1, 2, 4, 5], 7), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an a followed by three 'b'.\nfn text_match_three(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_match_three;\n    assert_eq!(candidate(String::from(\"ac\")), false);\n    assert_eq!(candidate(String::from(\"dc\")), false);\n    assert_eq!(candidate(String::from(\"abbbba\")), true);\n    assert_eq!(candidate(String::from(\"caacabbbba\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "rs",
+    "prompt": "/// Write a function to create a new tuple from the given string and vector.\nfn new_tuple(test_list: Vec<String>, test_str: String) -> (String, String, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = new_tuple;\n    assert_eq!(candidate(vec![String::from(\"WEB\"), String::from(\"is\")], String::from(\"best\")), (String::from(\"WEB\"), String::from(\"is\"), String::from(\"best\")));\n    assert_eq!(candidate(vec![String::from(\"We\"), String::from(\"are\")], String::from(\"Developers\")), (String::from(\"We\"), String::from(\"are\"), String::from(\"Developers\")));\n    assert_eq!(candidate(vec![String::from(\"Part\"), String::from(\"is\")], String::from(\"Wrong\")), (String::from(\"Part\"), String::from(\"is\"), String::from(\"Wrong\")));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether every even index contains even numbers of a given vector.\nfn even_position(nums: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = even_position;\n    assert_eq!(candidate(vec![3, 2, 1]), false);\n    assert_eq!(candidate(vec![1, 2, 3]), false);\n    assert_eq!(candidate(vec![2, 1, 4]), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of vectors in a given number of vectors.\nfn count_list(input_list: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_list;\n    assert_eq!(candidate(vec![vec![1, 3], vec![5, 7], vec![9, 11], vec![13, 15, 17]]), 4);\n    assert_eq!(candidate(vec![vec![1, 2], vec![2, 3], vec![4, 5]]), 3);\n    assert_eq!(candidate(vec![vec![1, 0], vec![2, 0]]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the last position of an element in a sorted vector.\nfn last(arr: Vec<isize>, x: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = last;\n    assert_eq!(candidate(vec![1, 2, 3], 1), 0);\n    assert_eq!(candidate(vec![1, 1, 1, 2, 3, 4], 1), 2);\n    assert_eq!(candidate(vec![2, 3, 2, 3, 6, 8, 9], 3), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "rs",
+    "prompt": "/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfn text_starta_endb(text: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = text_starta_endb;\n    assert_eq!(candidate(String::from(\"aabbbb\")), true);\n    assert_eq!(candidate(String::from(\"aabAbbbc\")), false);\n    assert_eq!(candidate(String::from(\"accddbbjjj\")), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write function to find the sum of all items in the given HashMap.\nfn return_sum(dict: HashMap<String, isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = return_sum;\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 100), (String::from(\"b\"), 200), (String::from(\"c\"), 300)])), 600);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 25), (String::from(\"b\"), 18), (String::from(\"c\"), 45)])), 88);\n    assert_eq!(candidate(HashMap::from([(String::from(\"a\"), 36), (String::from(\"b\"), 39), (String::from(\"c\"), 49)])), 124);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of all odd natural numbers within the range l and r.\nfn sum_in_range(l: isize, r: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sum_in_range;\n    assert_eq!(candidate(2, 5), 8);\n    assert_eq!(candidate(5, 7), 12);\n    assert_eq!(candidate(7, 13), 40);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the sum of a vector.\nfn _sum(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = _sum;\n    assert_eq!(candidate(vec![1, 2, 3]), 6);\n    assert_eq!(candidate(vec![15, 12, 13, 10]), 50);\n    assert_eq!(candidate(vec![0, 1, 2]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "rs",
+    "prompt": "/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfn left_rotate(n: isize, d: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = left_rotate;\n    assert_eq!(candidate(16, 2), 64);\n    assert_eq!(candidate(10, 2), 40);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(99, 3), 792);\n    assert_eq!(candidate(1, 3), 8);\n    assert_eq!(candidate(5, 3), 40);\n    assert_eq!(candidate(29, 3), 232);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to check whether the length of the word is odd or not.\nfn word_len(s: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = word_len;\n    assert_eq!(candidate(String::from(\"Hadoop\")), false);\n    assert_eq!(candidate(String::from(\"great\")), true);\n    assert_eq!(candidate(String::from(\"structure\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "rs",
+    "prompt": "/// Write a function to remove all whitespaces from a string.\nfn remove_all_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = remove_all_spaces;\n    assert_eq!(candidate(String::from(\"python  program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"python   programming    language\")), String::from(\"pythonprogramminglanguage\"));\n    assert_eq!(candidate(String::from(\"python                     program\")), String::from(\"pythonprogram\"));\n    assert_eq!(candidate(String::from(\"   python                     program\")), String::from(\"pythonprogram\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of equal numbers from three given integers.\nfn test_three_equal(x: isize, y: isize, z: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = test_three_equal;\n    assert_eq!(candidate(1, 1, 1), 3);\n    assert_eq!(candidate(-1, -2, -3), 0);\n    assert_eq!(candidate(1, 2, 2), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to count the number of rotations required to generate a sorted vector. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-vector/\nfn count_rotation(arr: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = count_rotation;\n    assert_eq!(candidate(vec![3, 2, 1]), 1);\n    assert_eq!(candidate(vec![4, 5, 1, 2, 3]), 2);\n    assert_eq!(candidate(vec![7, 8, 9, 1, 2, 3]), 3);\n    assert_eq!(candidate(vec![1, 2, 3]), 0);\n    assert_eq!(candidate(vec![1, 3, 2]), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfn is_perfect_square(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_perfect_square;\n    assert_eq!(candidate(10), false);\n    assert_eq!(candidate(36), true);\n    assert_eq!(candidate(14), false);\n    assert_eq!(candidate(196), true);\n    assert_eq!(candidate(125), false);\n    assert_eq!(candidate(15625), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the product of numbers in a vector is even or not.\nfn is_product_even(arr: Vec<isize>) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_product_even;\n    assert_eq!(candidate(vec![1, 2, 3]), true);\n    assert_eq!(candidate(vec![1, 2, 1, 4]), true);\n    assert_eq!(candidate(vec![1, 1]), false);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "rs",
+    "prompt": "/// Write a function that returns the vector in a vector of vectors whose sum of elements is the highest.\nfn max_sum_list(lists: Vec<Vec<isize>>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_sum_list;\n    assert_eq!(candidate(vec![vec![1, 2, 3], vec![4, 5, 6], vec![10, 11, 12], vec![7, 8, 9]]), vec![10, 11, 12]);\n    assert_eq!(candidate(vec![vec![3, 2, 1], vec![6, 5, 4], vec![12, 11, 10]]), vec![12, 11, 10]);\n    assert_eq!(candidate(vec![vec![2, 3, 1]]), vec![2, 3, 1]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "rs",
+    "prompt": "/// Write a function to find maximum run of uppercase characters in the given string.\nfn max_run_uppercase(test_str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = max_run_uppercase;\n    assert_eq!(candidate(String::from(\"GeMKSForGERksISBESt\")), 5);\n    assert_eq!(candidate(String::from(\"PrECIOusMOVemENTSYT\")), 6);\n    assert_eq!(candidate(String::from(\"GooGLEFluTTER\")), 4);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the first odd number in a given vector of numbers.\nfn first_odd(nums: Vec<isize>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = first_odd;\n    assert_eq!(candidate(vec![1, 3, 5]), 1);\n    assert_eq!(candidate(vec![2, 4, 1, 3]), 1);\n    assert_eq!(candidate(vec![8, 9, 1]), 9);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "rs",
+    "prompt": "/// Write a function to check if the given tuples contain the k or not.\nfn check_K(test_tup: Vec<isize>, K: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_K;\n    assert_eq!(candidate(vec![10, 4, 5, 6, 8], 6), true);\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6], 7), false);\n    assert_eq!(candidate(vec![7, 8, 9, 44, 11, 12], 11), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "rs",
+    "prompt": "/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfn check_smaller(test_tup1: (isize, isize, isize), test_tup2: (isize, isize, isize)) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = check_smaller;\n    assert_eq!(candidate((1, 2, 3), (2, 3, 4)), false);\n    assert_eq!(candidate((4, 5, 6), (3, 4, 5)), true);\n    assert_eq!(candidate((11, 12, 13), (10, 11, 12)), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth tetrahedral number.\nfn tetrahedral_number(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = tetrahedral_number;\n    assert_eq!(candidate(5), 35);\n    assert_eq!(candidate(6), 56);\n    assert_eq!(candidate(7), 84);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfn get_Char(strr: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = get_Char;\n    assert_eq!(candidate(String::from(\"abc\")), String::from(\"f\"));\n    assert_eq!(candidate(String::from(\"gfg\")), String::from(\"t\"));\n    assert_eq!(candidate(String::from(\"ab\")), String::from(\"c\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "rs",
+    "prompt": "/// Write a function to find the nth number in the newman conway sequence.\nfn sequence(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = sequence;\n    assert_eq!(candidate(10), 6);\n    assert_eq!(candidate(2), 1);\n    assert_eq!(candidate(3), 2);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "rs",
+    "prompt": "/// Write a function to find nth centered hexagonal number.\nfn centered_hexagonal_number(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = centered_hexagonal_number;\n    assert_eq!(candidate(10), 271);\n    assert_eq!(candidate(2), 7);\n    assert_eq!(candidate(9), 217);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to merge three dictionaries into a single HashMap.\nfn merge_dictionaries_three(dict1: HashMap<String, String>, dict2: HashMap<String, String>, dict3: HashMap<String, String>) -> HashMap<String, String> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = merge_dictionaries_three;\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"O\"), String::from(\"Orange\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"B\"), String::from(\"Black\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\")), (String::from(\"O\"), String::from(\"Orange\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))])), HashMap::from([(String::from(\"W\"), String::from(\"White\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\"))]));\n    assert_eq!(candidate(HashMap::from([(String::from(\"R\"), String::from(\"Red\")), (String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\"))]), HashMap::from([(String::from(\"L\"), String::from(\"lavender\")), (String::from(\"B\"), String::from(\"Blue\"))]), HashMap::from([(String::from(\"G\"), String::from(\"Green\")), (String::from(\"W\"), String::from(\"White\"))])), HashMap::from([(String::from(\"B\"), String::from(\"Black\")), (String::from(\"P\"), String::from(\"Pink\")), (String::from(\"R\"), String::from(\"Red\")), (String::from(\"G\"), String::from(\"Green\")), (String::from(\"L\"), String::from(\"lavender\")), (String::from(\"W\"), String::from(\"White\"))]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to get the frequency of all the elements in a vector, returned as a HashMap.\nfn freq_count(list1: Vec<isize>) -> HashMap<isize, isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = freq_count;\n    assert_eq!(candidate(vec![10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]), HashMap::from([(10, 4), (20, 4), (40, 2), (50, 2), (30, 1)]));\n    assert_eq!(candidate(vec![1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]), HashMap::from([(1, 3), (2, 2), (3, 3), (4, 3)]));\n    assert_eq!(candidate(vec![5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]), HashMap::from([(10, 1), (5, 3), (6, 2), (7, 2), (4, 2), (9, 2)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "rs",
+    "prompt": "/// Write a function to find the closest smaller number than n.\nfn closest_num(N: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = closest_num;\n    assert_eq!(candidate(11), 10);\n    assert_eq!(candidate(7), 6);\n    assert_eq!(candidate(12), 11);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "rs",
+    "prompt": "/// Write a function to find squares of individual elements in a vector.\nfn square_nums(nums: Vec<isize>) -> Vec<isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = square_nums;\n    assert_eq!(candidate(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), vec![1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n    assert_eq!(candidate(vec![10, 20, 30]), vec![100, 400, 900]);\n    assert_eq!(candidate(vec![12, 15]), vec![144, 225]);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the length of the longest word.\nfn len_log(list1: Vec<String>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = len_log;\n    assert_eq!(candidate(vec![String::from(\"python\"), String::from(\"PHP\"), String::from(\"bigdata\")]), 7);\n    assert_eq!(candidate(vec![String::from(\"a\"), String::from(\"ab\"), String::from(\"abc\")]), 3);\n    assert_eq!(candidate(vec![String::from(\"small\"), String::from(\"big\"), String::from(\"tall\")]), 5);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "rs",
+    "prompt": "/// Write a function to check if a string is present as a substring in a given vector of string values.\nfn find_substring(str1: Vec<String>, sub_str: String) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_substring;\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ack\")), true);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"abc\")), false);\n    assert_eq!(candidate(vec![String::from(\"red\"), String::from(\"black\"), String::from(\"white\"), String::from(\"green\"), String::from(\"orange\")], String::from(\"ange\")), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "rs",
+    "prompt": "/// Write a function to check whether the given number is undulating or not.\nfn is_undulating(n: isize) -> bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = is_undulating;\n    assert_eq!(candidate(1212121), true);\n    assert_eq!(candidate(1991), false);\n    assert_eq!(candidate(121), true);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "rs",
+    "prompt": "/// Write a function to calculate the value of 'a' to the power 'b'.\nfn power(a: isize, b: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = power;\n    assert_eq!(candidate(3, 4), 81);\n    assert_eq!(candidate(2, 3), 8);\n    assert_eq!(candidate(5, 5), 3125);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "rs",
+    "prompt": "/// Given a vector of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfn index_minimum(test_list: Vec<(String, isize)>) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = index_minimum;\n    assert_eq!(candidate(vec![(String::from(\"Rash\"), 143), (String::from(\"Manjeet\"), 200), (String::from(\"Varsha\"), 100)]), String::from(\"Varsha\"));\n    assert_eq!(candidate(vec![(String::from(\"Yash\"), 185), (String::from(\"Dawood\"), 125), (String::from(\"Sanya\"), 175)]), String::from(\"Dawood\"));\n    assert_eq!(candidate(vec![(String::from(\"Sai\"), 345), (String::from(\"Salman\"), 145), (String::from(\"Ayesha\"), 96)]), String::from(\"Ayesha\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the length of the smallest vector in a vector of vectors.\nfn Find_Min_Length(lst: Vec<Vec<isize>>) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = Find_Min_Length;\n    assert_eq!(candidate(vec![vec![1], vec![1, 2]]), 1);\n    assert_eq!(candidate(vec![vec![1, 2], vec![1, 2, 3], vec![1, 2, 3, 4]]), 2);\n    assert_eq!(candidate(vec![vec![3, 3, 3], vec![4, 4, 4, 4]]), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the number of divisors of a given integer.\nfn divisor(n: isize) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = divisor;\n    assert_eq!(candidate(15), 4);\n    assert_eq!(candidate(12), 6);\n    assert_eq!(candidate(9), 3);\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "rs",
+    "prompt": "use std::collections::HashMap;\n\n/// Write a function to find frequency of each element in a flattened vector of vectors, returned in a HashMap.\nfn frequency_lists(list1: Vec<Vec<isize>>) -> HashMap<isize, isize> {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = frequency_lists;\n    assert_eq!(candidate(vec![vec![1, 2, 3, 2], vec![4, 5, 6, 2], vec![7, 8, 9, 5]]), HashMap::from([(1, 1), (2, 3), (3, 1), (4, 1), (5, 2), (6, 1), (7, 1), (8, 1), (9, 1)]));\n    assert_eq!(candidate(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]]), HashMap::from([(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1), (12, 1)]));\n    assert_eq!(candidate(vec![vec![20, 30, 40, 17], vec![18, 16, 14, 13], vec![10, 20, 30, 40]]), HashMap::from([(20, 2), (30, 2), (40, 2), (17, 1), (18, 1), (16, 1), (14, 1), (13, 1), (10, 1)]));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "rs",
+    "prompt": "/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfn decimal_to_binary(n: isize) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = decimal_to_binary;\n    assert_eq!(candidate(8), String::from(\"1000\"));\n    assert_eq!(candidate(18), String::from(\"10010\"));\n    assert_eq!(candidate(7), String::from(\"111\"));\n}\n",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "rs",
+    "prompt": "/// Write a rsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfn find_Rotations(str: String) -> isize {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\nfn main() {\n    let candidate = find_Rotations;\n    assert_eq!(candidate(String::from(\"aaaa\")), 1);\n    assert_eq!(candidate(String::from(\"ab\")), 2);\n    assert_eq!(candidate(String::from(\"abc\")), 3);\n}\n",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-scala-keep.json
+++ b/prompts/mbpp-scala-keep.json
@@ -1,3528 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    def lps(str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from the given string.\n    def removeWhitespaces(text1 : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    def issortList(list1 : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 17l.toLong))) == (true));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 20l.toLong, 17l.toLong))) == (false));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 15l.toLong, 14l.toLong, 20l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count bidirectional tuple pairs.\n    def countBidirectional(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (3l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 3l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (2l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 2l), (6l, 5l), (2l, 1l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    def surfaceareaCube(l : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    def nextSmallestPalindrome(num : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallestPalindrome((99l)) == (101l));\n    assert(nextSmallestPalindrome((1221l)) == (1331l));\n    assert(nextSmallestPalindrome((120l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    def cubeSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    def pairXorSum(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairXorSum((List[Long](5l.toLong, 9l.toLong, 7l.toLong, 6l.toLong)), (4l)) == (47l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong, 5l.toLong)), (3l)) == (12l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong)), (2l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    def checkMinHeap(arr : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMinHeap((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 10l.toLong, 15l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 15l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first digit of a given number.\n    def firstDigit(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    def firstNonRepeatingCharacter(str1 : String) : Option[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(None));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(\"a\"));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(\"c\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert degrees to radians.\n    def radianDegree(degree : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    def maxSubarrayProduct(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubarrayProduct((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 0l.toLong, 7l.toLong, -8l.toLong, -2l.toLong))) == (112l));\n    assert(maxSubarrayProduct((List[Long](6l.toLong, -3l.toLong, -10l.toLong, 0l.toLong, 2l.toLong))) == (180l));\n    assert(maxSubarrayProduct((List[Long](-2l.toLong, -40l.toLong, 0l.toLong, -2l.toLong, -3l.toLong))) == (80l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    def convertListDictionary(l1 : List[String], l2 : List[String], l3 : List[Long]) : List[Map[String,Map[String,Long]]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convertListDictionary((List[String](\"S001\", \"S002\", \"S003\", \"S004\")), (List[String](\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\")), (List[Long](85l.toLong, 98l.toLong, 89l.toLong, 92l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"S001\" -> Map[String,Long](\"Adina Park\" -> 85l)), Map[String,Map[String,Long]](\"S002\" -> Map[String,Long](\"Leyton Marsh\" -> 98l)), Map[String,Map[String,Long]](\"S003\" -> Map[String,Long](\"Duncan Boyle\" -> 89l)), Map[String,Map[String,Long]](\"S004\" -> Map[String,Long](\"Saim Richards\" -> 92l))))));\n    assert(convertListDictionary((List[String](\"abc\", \"def\", \"ghi\", \"jkl\")), (List[String](\"python\", \"program\", \"language\", \"programs\")), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"abc\" -> Map[String,Long](\"python\" -> 100l)), Map[String,Map[String,Long]](\"def\" -> Map[String,Long](\"program\" -> 200l)), Map[String,Map[String,Long]](\"ghi\" -> Map[String,Long](\"language\" -> 300l)), Map[String,Map[String,Long]](\"jkl\" -> Map[String,Long](\"programs\" -> 400l))))));\n    assert(convertListDictionary((List[String](\"A1\", \"A2\", \"A3\", \"A4\")), (List[String](\"java\", \"C\", \"C++\", \"DBMS\")), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"A1\" -> Map[String,Long](\"java\" -> 10l)), Map[String,Map[String,Long]](\"A2\" -> Map[String,Long](\"C\" -> 20l)), Map[String,Map[String,Long]](\"A3\" -> Map[String,Long](\"C++\" -> 30l)), Map[String,Map[String,Long]](\"A4\" -> Map[String,Long](\"DBMS\" -> 40l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find smallest number in a list.\n    def smallestNum(xs : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestNum((List[Long](10l.toLong, 20l.toLong, 1l.toLong, 45l.toLong, 99l.toLong))) == (1l));\n    assert(smallestNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    assert(smallestNum((List[Long](45l.toLong, 46l.toLong, 50l.toLong, 60l.toLong))) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    def textMatchZeroOne(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find nth bell number.\n    def bellNumber(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find cubes of individual elements in a list.\n    def cubeNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 27l.toLong, 64l.toLong, 125l.toLong, 216l.toLong, 343l.toLong, 512l.toLong, 729l.toLong, 1000l.toLong))));\n    assert(cubeNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(cubeNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](1728l.toLong, 3375l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    def lastDigitFactorial(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    def Split(list : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](2l.toLong, 4l.toLong))));\n    assert(Split((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 0l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))));\n    assert(Split((List[Long](8l.toLong, 12l.toLong, 15l.toLong, 19l.toLong))).equals((List[Long](8l.toLong, 12l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given integer is a prime number.\n    def primeNum(num : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    def findTuples(test_list : List[Tuple2[Long, Long, Long]], K : Long) : List[Tuple2[Long, Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l), (7l, 9l, 6l), (12l, 18l, 21l))), (6l)).equals((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l), (4l, 2l, 3l), (7l, 8l, 9l))), (5l)).equals((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((7l, 9l, 16l), (8l, 16l, 4l), (19l, 17l, 18l))), (4l)).equals((List[Tuple2[Long, Long, Long]]((8l, 16l, 4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    def areaTetrahedron(side : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number is even or not.\n    def isEven(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    def posCount(list : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(posCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong, -4l.toLong))) == (2l));\n    assert(posCount((List[Long](3l.toLong, 4l.toLong, 5l.toLong, -1l.toLong))) == (3l));\n    assert(posCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    def getLudic(n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getLudic((10l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(getLudic((25l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong))));\n    assert(getLudic((45l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong, 29l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    def findIndex(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to reverse an array upto a given position.\n    def reverseArrayUptoK(input : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseArrayUptoK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (4l)).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))));\n    assert(reverseArrayUptoK((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (2l)).equals((List[Long](5l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))));\n    assert(reverseArrayUptoK((List[Long](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong)), (3l)).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 6l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    def subjectMarks(subjectmarks : List[Tuple2[String, Long]]) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l), (\"Social sciences\", 82l)))).equals((List[Tuple2[String, Long]]((\"Social sciences\", 82l), (\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Telugu\", 49l), (\"Hindhi\", 54l), (\"Social\", 33l)))).equals((List[Tuple2[String, Long]]((\"Social\", 33l), (\"Telugu\", 49l), (\"Hindhi\", 54l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Physics\", 96l), (\"Chemistry\", 97l), (\"Biology\", 45l)))).equals((List[Tuple2[String, Long]]((\"Biology\", 45l), (\"Physics\", 96l), (\"Chemistry\", 97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    def removeDirtyChars(string : String, second_string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n    def roundAndSum(list1 : List[Either[Float, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundAndSum((List[Either[Float, Long]](22.4f.toFloat, 4.0f.toFloat, -16.22f.toFloat, -9.1f.toFloat, 11.0f.toFloat, -12.22f.toFloat, 14.2f.toFloat, -5.2f.toFloat, 17.5f.toFloat))) == (243l));\n    assert(roundAndSum((List[Either[Float, Long]](5l.toLong, 2l.toLong, 9l.toLong, 24.3f.toLong, 29l.toLong))) == (345l));\n    assert(roundAndSum((List[Either[Float, Long]](25.0f.toFloat, 56.7f.toFloat, 89.2f.toFloat))) == (513l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    def maxOccurrences(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 5l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 1l.toLong, 2l.toLong))) == (2l));\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 15l.toLong, 14l.toLong, 10l.toLong, 12l.toLong, 13l.toLong, 16l.toLong, 18l.toLong))) == (8l));\n    assert(maxOccurrences((List[Long](10l.toLong, 20l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 90l.toLong, 80l.toLong, 50l.toLong, 30l.toLong, 20l.toLong, 50l.toLong, 10l.toLong))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    def isDecimal(num : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    def dictFilter(dict : Map[String,Long], n : Long) : Map[String,Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (170l)).equals((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (180l)).equals((Map[String,Long](\"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (190l)).equals((Map[String,Long](\"Pierre Cox\" -> 190l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    def sumEvenAndEvenIndex(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong, 18l.toLong, 8l.toLong))) == (30l));\n    assert(sumEvenAndEvenIndex((List[Long](3l.toLong, 20l.toLong, 17l.toLong, 9l.toLong, 2l.toLong, 10l.toLong, 18l.toLong, 13l.toLong, 6l.toLong, 18l.toLong))) == (26l));\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    def maxSubArraySum(a : List[Long], size : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySum((List[Long](-2l.toLong, -3l.toLong, 4l.toLong, -1l.toLong, -2l.toLong, 1l.toLong, 5l.toLong, -3l.toLong)), (8l)) == (7l));\n    assert(maxSubArraySum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, 6l.toLong, -4l.toLong)), (8l)) == (8l));\n    assert(maxSubArraySum((List[Long](-4l.toLong, -5l.toLong, 6l.toLong, -3l.toLong, -4l.toLong, 3l.toLong, 7l.toLong, -5l.toLong)), (8l)) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the intersection of two arrays.\n    def intersectionArray(array_nums1 : List[Long], array_nums2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Long](10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    def splitTwoParts(list1 : List[Any], L : Long) : Any = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitTwoParts((List[Any](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((Any(1l.toLong, 1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)))));\n    assert(splitTwoParts((List[Any](\"a\", \"b\", \"c\", \"d\")), (2l)).equals((Any(\"a\", \"b\"), List[String](\"c\", \"d\")))));\n    assert(splitTwoParts((List[Any](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")), (4l)).equals((Any(\"p\", \"y\", \"t\", \"h\"), List[String](\"o\", \"n\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    def findLiterals(text : String, pattern : String) : Tuple2[String, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals(((\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals(((\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals(((\"will\", 35l, 39l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the volume of a triangular prism.\n    def findVolume(l : Long, b : Long, h : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    def windChill(v : Long, t : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ascii value of a character.\n    def asciiValue(k : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether all the characters are same or not.\n    def allCharactersSame(s : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    def moveNum(test_str : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    def wordLen(s : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to drop empty items from a given dictionary.\n    def dropEmpty(dict1 : Map[String,Option[String]]) : Map[String,String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\"))));\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> None, \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\"))));\n    assert(dropEmpty(Map[String,None](\"c1\" -> None, \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c2\" -> \"Green\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    def insertElement(list : List[String], element : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(insertElement((List[String](\"Red\", \"Green\", \"Black\")), (\"c\")).equals((List[String](\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"))));\n    assert(insertElement((List[String](\"python\", \"java\")), (\"program\")).equals((List[String](\"program\", \"python\", \"program\", \"java\"))));\n    assert(insertElement((List[String](\"happy\", \"sad\")), (\"laugh\")).equals((List[String](\"laugh\", \"happy\", \"laugh\", \"sad\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    def removeLowercase(str1 : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    def countSetBits(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    def extractRear(test_tuple : Tuple2[String, String, String]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractRear(((\"Mers\", \"for\", \"Vers\"))).equals((List[String](\"s\", \"r\", \"s\"))));\n    assert(extractRear(((\"Avenge\", \"for\", \"People\"))).equals((List[String](\"e\", \"r\", \"e\"))));\n    assert(extractRear(((\"Gotta\", \"get\", \"go\"))).equals((List[String](\"a\", \"t\", \"o\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    def countOccurance(s : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    def checkK(test_tup : List[Long], K : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkK((List[Long](10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 8l.toLong)), (6l)) == (true));\n    assert(checkK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (7l)) == (false));\n    assert(checkK((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 44l.toLong, 11l.toLong, 12l.toLong)), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    def interleaveLists(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(interleaveLists((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong)), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong, 500l.toLong, 600l.toLong, 700l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 100l.toLong, 2l.toLong, 20l.toLong, 200l.toLong, 3l.toLong, 30l.toLong, 300l.toLong, 4l.toLong, 40l.toLong, 400l.toLong, 5l.toLong, 50l.toLong, 500l.toLong, 6l.toLong, 60l.toLong, 600l.toLong, 7l.toLong, 70l.toLong, 700l.toLong))));\n    assert(interleaveLists((List[Long](10l.toLong, 20l.toLong)), (List[Long](15l.toLong, 2l.toLong)), (List[Long](5l.toLong, 10l.toLong))).equals((List[Long](10l.toLong, 15l.toLong, 5l.toLong, 20l.toLong, 2l.toLong, 10l.toLong))));\n    assert(interleaveLists((List[Long](11l.toLong, 44l.toLong)), (List[Long](10l.toLong, 15l.toLong)), (List[Long](20l.toLong, 5l.toLong))).equals((List[Long](11l.toLong, 10l.toLong, 20l.toLong, 44l.toLong, 15l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    def testThreeEqual(x : Long, y : Long, z : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    def oddLengthSum(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 4l.toLong))) == (14l));\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (15l));\n    assert(oddLengthSum((List[Long](1l.toLong, 7l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    def bellNumber(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the area of a rectangle.\n    def rectangleArea(l : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    def sumAverage(number : Long) : Tuple2[Long, Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumAverage((10l)).equals(((55l, 5.5f))));\n    assert(sumAverage((15l)).equals(((120l, 8.0f))));\n    assert(sumAverage((20l)).equals(((210l, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    def divisionElements(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisionElements(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((2l, 2l, 2l, 3l))));\n    assert(divisionElements(((12l, 6l, 8l, 16l)), ((6l, 3l, 4l, 4l))).equals(((2l, 2l, 2l, 4l))));\n    assert(divisionElements(((20l, 14l, 36l, 18l)), ((5l, 7l, 6l, 9l))).equals(((4l, 2l, 6l, 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    def sumDigits(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    def indexMinimum(test_list : List[Tuple2[String, Long]]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Rash\", 143l), (\"Manjeet\", 200l), (\"Varsha\", 100l)))).equals((\"Varsha\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Yash\", 185l), (\"Dawood\", 125l), (\"Sanya\", 175l)))).equals((\"Dawood\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Sai\", 345l), (\"Salman\", 145l), (\"Ayesha\", 96l)))).equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to divide two lists element wise.\n    def divList(nums1 : List[Long], nums2 : List[Long]) : List[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divList((List[Long](4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Float](4.0f.toFloat, 2.5f.toFloat, 2.0f.toFloat))));\n    assert(divList((List[Long](3l.toLong, 2l.toLong)), (List[Long](1l.toLong, 4l.toLong))).equals((List[Float](3.0f.toFloat, 0.5f.toFloat))));\n    assert(divList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Float](1.8f.toFloat, 1.7142857142857142f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list with maximum length.\n    def maxLengthList(input_list : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLengthList((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong)))).equals(((5l, List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong)))).equals(((4l, List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find all possible combinations of the elements of a given list.\n    def combinationsList(list1 : List[String]) : List[Either[List[None], List[String]]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsList((List[String](\"orange\", \"red\", \"green\", \"blue\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"orange\"), List[String](\"red\"), List[String](\"red\", \"orange\"), List[String](\"green\"), List[String](\"green\", \"orange\"), List[String](\"green\", \"red\"), List[String](\"green\", \"red\", \"orange\"), List[String](\"blue\"), List[String](\"blue\", \"orange\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"red\", \"orange\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"orange\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"blue\", \"green\", \"red\", \"orange\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"blue\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"white\"), List[String](\"white\", \"red\"), List[String](\"white\", \"green\"), List[String](\"white\", \"green\", \"red\"), List[String](\"white\", \"blue\"), List[String](\"white\", \"blue\", \"red\"), List[String](\"white\", \"blue\", \"green\"), List[String](\"white\", \"blue\", \"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"black\", \"blue\"), List[String](\"black\", \"blue\", \"red\"), List[String](\"black\", \"blue\", \"green\"), List[String](\"black\", \"blue\", \"green\", \"red\"), List[String](\"black\", \"white\"), List[String](\"black\", \"white\", \"red\"), List[String](\"black\", \"white\", \"green\"), List[String](\"black\", \"white\", \"green\", \"red\"), List[String](\"black\", \"white\", \"blue\"), List[String](\"black\", \"white\", \"blue\", \"red\"), List[String](\"black\", \"white\", \"blue\", \"green\"), List[String](\"black\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"blue\"), List[String](\"orange\", \"blue\", \"red\"), List[String](\"orange\", \"blue\", \"green\"), List[String](\"orange\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"white\"), List[String](\"orange\", \"white\", \"red\"), List[String](\"orange\", \"white\", \"green\"), List[String](\"orange\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"white\", \"blue\"), List[String](\"orange\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"blue\"), List[String](\"orange\", \"black\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\"), List[String](\"orange\", \"black\", \"white\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    def bigSum(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(bigSum((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigSum((List[Long](2l.toLong, 3l.toLong, 6l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to return the negative numbers in a list.\n    def negNos(list1 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(negNos((List[Long](-1l.toLong, 4l.toLong, 5l.toLong, -6l.toLong))).equals((List[Long](-1l.toLong, -6l.toLong))));\n    assert(negNos((List[Long](-1l.toLong, -2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](-1l.toLong, -2l.toLong))));\n    assert(negNos((List[Long](-7l.toLong, -6l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](-7l.toLong, -6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    def highestPowerOf2(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    def isSublist(l : List[Long], s : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](3l.toLong, 7l.toLong))) == (false));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](4l.toLong, 3l.toLong))) == (true));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](1l.toLong, 6l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to subtract two lists element-wise.\n    def subList(nums1 : List[Long], nums2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](-3l.toLong, -3l.toLong, -3l.toLong))));\n    assert(subList((List[Long](1l.toLong, 2l.toLong)), (List[Long](3l.toLong, 4l.toLong))).equals((List[Long](-2l.toLong, -2l.toLong))));\n    assert(subList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Long](40l.toLong, 50l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    def oppositeSigns(x : Long, y : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    def tupleModulo(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleModulo(((10l, 4l, 5l, 6l)), ((5l, 6l, 7l, 5l))).equals(((0l, 4l, 5l, 1l))));\n    assert(tupleModulo(((11l, 5l, 6l, 7l)), ((6l, 7l, 8l, 6l))).equals(((5l, 5l, 6l, 1l))));\n    assert(tupleModulo(((12l, 6l, 7l, 8l)), ((7l, 8l, 9l, 7l))).equals(((5l, 6l, 7l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    def diffEvenOdd(list1 : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(diffEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (3l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (1l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(list1 : List[List[String]]) : List[List[String]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"a\", \"b\"), List[String](\"d\", \"c\"), List[String](\"g\", \"h\"), List[String](\"f\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\"), List[String](\"c\", \"d\"), List[String](\"g\", \"h\"), List[String](\"e\", \"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last digit of a given number.\n    def lastDigit(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    def oddNumSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a string.\n    def tupString(tup1 : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupString((List[String](\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"))).equals((\"exercises\")));\n    assert(tupString((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))).equals((\"python\")));\n    assert(tupString((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))).equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    def removeElements(list1 : List[Long], list2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](5l.toLong, 7l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    def overlapping(list1 : List[Long], list2 : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 4l.toLong, 5l.toLong)), (List[Long](1l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to identify non-prime numbers.\n    def isNotPrime(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum value in a given heterogeneous list.\n    def maxVal(listval : List[Either[String, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (5l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (25l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (50l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    def sumNegativenum(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumNegativenum((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (-32l));\n    assert(sumNegativenum((List[Long](10l.toLong, 15l.toLong, -14l.toLong, 13l.toLong, -18l.toLong, 12l.toLong, -20l.toLong))) == (-52l));\n    assert(sumNegativenum((List[Long](19l.toLong, -65l.toLong, 57l.toLong, 39l.toLong, 152l.toLong, -639l.toLong, 121l.toLong, 44l.toLong, 90l.toLong, -190l.toLong))) == (-894l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    def findRotations(str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    def changeDateFormat(dt : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    def Split(list : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(Split((List[Long](10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong))).equals((List[Long](11l.toLong, 13l.toLong))));\n    assert(Split((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](7l.toLong, 9l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    def toggleMiddleBits(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    def countCharPosition(str1 : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    def largeProduct(nums1 : List[Long], nums2 : List[Long], N : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (3l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (4l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (5l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong, 45l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    def cummulativeSum(test_list : List[List[Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cummulativeSum((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](2l.toLong, 6l.toLong)))) == (30l));\n    assert(cummulativeSum((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 7l.toLong)))) == (37l));\n    assert(cummulativeSum((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](4l.toLong, 8l.toLong)))) == (44l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    def findMinDiff(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMinDiff((List[Long](1l.toLong, 5l.toLong, 3l.toLong, 19l.toLong, 18l.toLong, 25l.toLong)), (6l)) == (1l));\n    assert(findMinDiff((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 6l.toLong)), (4l)) == (1l));\n    assert(findMinDiff((List[Long](30l.toLong, 5l.toLong, 20l.toLong, 9l.toLong)), (4l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    def textStartaEndb(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    def leftRotate(n : Long, d : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first repeated character in a given string.\n    def firstRepeatedChar(str1 : String) : Option[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstRepeatedChar((\"abcabc\")).equals(\"a\"));\n    assert(firstRepeatedChar((\"abc\")).equals(None));\n    assert(firstRepeatedChar((\"123123\")).equals(\"1\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count inversions in an array.\n    def getInvCount(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getInvCount((List[Long](1l.toLong, 20l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))) == (5l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    def evenPowerSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    def getEqual(Input : List[List[Long]]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getEqual((List[List[Long]](List[Long](11l.toLong, 22l.toLong, 33l.toLong), List[Long](44l.toLong, 55l.toLong, 66l.toLong)))) == (true));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))) == (false));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string represents an integer or not.\n    def checkInteger(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    def countReversePairs(test_list : List[String]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countReversePairs((List[String](\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"))) == (2l));\n    assert(countReversePairs((List[String](\"geeks\", \"best\", \"for\", \"skeeg\"))) == (1l));\n    assert(countReversePairs((List[String](\"makes\", \"best\", \"sekam\", \"for\", \"rof\"))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    def moveZero(num_list : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveZero((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 0l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 0l.toLong, 0l.toLong, 4l.toLong, 0l.toLong, 5l.toLong, 0l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](0l.toLong, 1l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if given list contains no duplicates.\n    def checkDistinct(test_tup : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong, 4l.toLong))) == (false));\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkDistinct((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    def noprofitNoloss(actual_cost : Long, sale_amount : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all the words with k length in the given string.\n    def removeLength(test_str : String, K : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count number of digits in a given string.\n    def numberCtr(str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the total number of characters in a string.\n    def countCharac(str1 : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    def getTotalNumberOfSequences(m : Long, n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    def leftInsertion(a : List[Long], x : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    def swapNumbers(a : Long, b : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapNumbers((10l), (20l)).equals((List[Long](20l.toLong, 10l.toLong))));\n    assert(swapNumbers((15l), (17l)).equals((List[Long](17l.toLong, 15l.toLong))));\n    assert(swapNumbers((100l), (200l)).equals((List[Long](200l.toLong, 100l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    def isMajority(arr : List[Long], n : Long, x : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMajority((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 10l.toLong)), (7l), (3l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 6l.toLong, 6l.toLong)), (8l), (4l)) == (false));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    def substractElements(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Tuple2[Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(substractElements(((10l, 4l, 5l)), ((2l, 5l, 18l))).equals(((8l, -1l, -13l))));\n    assert(substractElements(((11l, 2l, 3l)), ((24l, 45l, 16l))).equals(((-13l, -43l, -13l))));\n    assert(substractElements(((7l, 18l, 9l)), ((10l, 11l, 12l))).equals(((-3l, 7l, -3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    def capitalWordsSpaces(str1 : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    def findAverageOfCube(n : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == 12l);\n    assert(findAverageOfCube((1l)) == 1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all values are same in a dictionary.\n    def checkValue(dict : Map[String,Long], n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (10l)) == (false));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (12l)) == (true));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (5l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth tetrahedral number.\n    def tetrahedralNumber(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    def magicSquareTest(my_matrix : List[List[Long]]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(magicSquareTest((List[List[Long]](List[Long](7l.toLong, 12l.toLong, 1l.toLong, 14l.toLong), List[Long](2l.toLong, 13l.toLong, 8l.toLong, 11l.toLong), List[Long](16l.toLong, 3l.toLong, 10l.toLong, 5l.toLong), List[Long](9l.toLong, 6l.toLong, 15l.toLong, 4l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 8l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 7l.toLong)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    def removeUppercase(str1 : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether an element exists within a tuple.\n    def checkTuplex(tuplex : List[Either[String, Long]], tuple1 : Any) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"r\"))) == (true));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"5\"))) == (false));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(3l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    def dogAge(h_age : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    def nextPerfectSquare(N : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a list of N empty dictionaries.\n    def emptyList(length : Long) : List[Map[None,None]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(emptyList((5l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((6l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((7l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert a given string to uppercase.\n    def isUpper(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    def oddEquivalent(s : String, n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    def reArrangeArray(arr : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reArrangeArray((List[Long](-1l.toLong, 2l.toLong, -3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -7l.toLong, 8l.toLong, 9l.toLong)), (9l)).equals((List[Long](-1l.toLong, -3l.toLong, -7l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(reArrangeArray((List[Long](12l.toLong, -14l.toLong, -26l.toLong, 13l.toLong, 15l.toLong)), (5l)).equals((List[Long](-14l.toLong, -26l.toLong, 12l.toLong, 13l.toLong, 15l.toLong))));\n    assert(reArrangeArray((List[Long](10l.toLong, 24l.toLong, 36l.toLong, -42l.toLong, -39l.toLong, -78l.toLong, 85l.toLong)), (7l)).equals((List[Long](-42l.toLong, -39l.toLong, -78l.toLong, 10l.toLong, 24l.toLong, 36l.toLong, 85l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    def uniqueElement(arr : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueElement((List[Long](1l.toLong, 1l.toLong, 1l.toLong))) == (true));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks from a string.\n    def extractValues(text : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((List[String](\"Python\", \"PHP\", \"Java\"))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((List[String](\"python\", \"program\", \"language\"))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((List[String](\"red\", \"blue\", \"green\", \"yellow\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count true booleans in the given list.\n    def count(lst : List[Boolean]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(count((List[Boolean](true.toBoolean, false.toBoolean, true.toBoolean))) == (2l));\n    assert(count((List[Boolean](false.toBoolean, false.toBoolean))) == (0l));\n    assert(count((List[Boolean](true.toBoolean, true.toBoolean, true.toBoolean))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    def findEvenPair(A : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findEvenPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong))) == (4l));\n    assert(findEvenPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong))) == (9l));\n    assert(findEvenPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    def armstrongNumber(number : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the upper case characters in a given string.\n    def upperCtr(str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    def andTuples(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(andTuples(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((0l, 0l, 2l, 1l))));\n    assert(andTuples(((1l, 2l, 3l, 4l)), ((5l, 6l, 7l, 8l))).equals(((1l, 2l, 3l, 0l))));\n    assert(andTuples(((8l, 9l, 11l, 12l)), ((7l, 13l, 14l, 17l))).equals(((0l, 9l, 10l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    def isSamepatterns(colors : List[String], patterns : List[String]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"green\")), (List[String](\"a\", \"b\", \"b\"))) == (true));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\", \"b\"))) == (false));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\"))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    def countList(input_list : List[List[Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))) == (4l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))) == (3l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 0l.toLong), List[Long](2l.toLong, 0l.toLong)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    def averageTuple(nums : List[List[Long]]) : List[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(averageTuple((List[List[Long]](List[Long](10l.toLong, 10l.toLong, 10l.toLong, 12l.toLong), List[Long](30l.toLong, 45l.toLong, 56l.toLong, 45l.toLong), List[Long](81l.toLong, 80l.toLong, 39l.toLong, 32l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))).equals((List[Float](30.5f.toFloat, 34.25f.toFloat, 27.0f.toFloat, 23.25f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](1l.toLong, 1l.toLong, -5l.toLong), List[Long](30l.toLong, -15l.toLong, 56l.toLong), List[Long](81l.toLong, -60l.toLong, -39l.toLong), List[Long](-10l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Float](25.5f.toFloat, -18.0f.toFloat, 3.75f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](100l.toLong, 100l.toLong, 100l.toLong, 120l.toLong), List[Long](300l.toLong, 450l.toLong, 560l.toLong, 450l.toLong), List[Long](810l.toLong, 800l.toLong, 390l.toLong, 320l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((List[Float](305.0f.toFloat, 342.5f.toFloat, 270.0f.toFloat, 232.5f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    def lcsOfThree(X : String, Y : String, Z : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th star number.\n    def findStarNum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of an array.\n    def Sum(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Sum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(Sum((List[Long](15l.toLong, 12l.toLong, 13l.toLong, 10l.toLong))) == (50l));\n    assert(Sum((List[Long](0l.toLong, 1l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    def checkConsecutive(l : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    def findAdverbPosition(text : String) : Tuple2[Long, Long, String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals(((0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals(((0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals(((0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    def rotateRight(list : List[Long], m : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (3l)).equals((List[Long](8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (5l)).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    def numberOfSubstrings(str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    def listSplit(S : List[Any], step : Long) : List[List[Any]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listSplit((List[Any](\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\")), (3l)).equals((List[List[Any]](List[String](\"a\", \"d\", \"g\", \"j\", \"m\"), List[String](\"b\", \"e\", \"h\", \"k\", \"n\"), List[String](\"c\", \"f\", \"i\", \"l\")))));\n    assert(listSplit((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (3l)).equals((List[List[Any]](List[Long](1l.toLong, 4l.toLong, 7l.toLong, 10l.toLong, 13l.toLong), List[Long](2l.toLong, 5l.toLong, 8l.toLong, 11l.toLong, 14l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 12l.toLong)))));\n    assert(listSplit((List[Any](\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\")), (2l)).equals((List[List[Any]](List[String](\"python\", \"C\", \"DBMS\"), List[String](\"java\", \"C++\", \"SQL\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    def allUnique(test_list : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    def convert(numbers : Long) : Tuple2[Float, Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convert((1l)).equals(((1.0f, 0.0f))));\n    assert(convert((4l)).equals(((4.0f, 0.0f))));\n    assert(convert((5l)).equals(((5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    def filterData(students : Map[String,Tuple2[Float, Long]], h : Float, w : Long) : Map[String,Tuple2[Float, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (6.0f), (70l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.9f), (67l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Kierra Gentry\" -> (6.0f, 68l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.7f), (64l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert the given string to lower case.\n    def isLower(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    def nextPowerOf2(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    def findSubstring(str1 : List[String], sub_str : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ack\")) == (true));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"abc\")) == (false));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace characters in a string.\n    def replaceChar(str1 : String, ch : String, newch : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    def mulEvenOdd(list1 : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mulEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (4l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a tuple.\n    def listTuple(listx : List[Long]) : Any = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listTuple((List[Long](5l.toLong, 10l.toLong, 7l.toLong, 4l.toLong, 15l.toLong, 3l.toLong))).equals((Any((5l, 10l, 7l, 4l, 15l, 3l)))));\n    assert(listTuple((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 7l.toLong))).equals((Any((2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)))));\n    assert(listTuple((List[Long](58l.toLong, 44l.toLong, 56l.toLong))).equals((Any((58l, 44l, 56l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    def evenBinomialCoeffSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    def bitwiseXor(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bitwiseXor(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((15l, 6l, 5l, 10l))));\n    assert(bitwiseXor(((11l, 5l, 7l, 10l)), ((6l, 3l, 4l, 4l))).equals(((13l, 6l, 3l, 14l))));\n    assert(bitwiseXor(((12l, 6l, 8l, 11l)), ((7l, 4l, 5l, 6l))).equals(((11l, 2l, 13l, 13l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    def isSubArray(A : List[Long], B : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSubArray((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)), (List[Long](1l.toLong, 2l.toLong))) == (false));\n    assert(isSubArray((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (true));\n    assert(isSubArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 2l.toLong)), (List[Long](2l.toLong, 2l.toLong, 0l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    def maxSubArraySumRepeated(a : List[Long], n : Long, k : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySumRepeated((List[Long](10l.toLong, 20l.toLong, -30l.toLong, -1l.toLong)), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, 10l.toLong, 20l.toLong)), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)), (3l), (3l)) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    def minProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (8l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (30l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    def countDivisors(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    def triangleArea(r : Long) : Option[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((-1l)).equals(None));\n    assert(triangleArea((0l)).equals(0l));\n    assert(triangleArea((2l)).equals(4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given string to a list of characters.\n    def stringToTuple(str1 : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToTuple((\"python 3.0\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"))));\n    assert(stringToTuple((\"item1\")).equals((List[String](\"i\", \"t\", \"e\", \"m\", \"1\"))));\n    assert(stringToTuple((\"15.10\")).equals((List[String](\"1\", \"5\", \".\", \"1\", \"0\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    def findLength(string : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    def countPrimesNums(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    def sumOfProduct(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    def maxAggregate(stdata : List[Tuple2[String, Long]]) : Tuple2[String, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 90l), (\"Sabah Colley\", 88l), (\"Peter Nichols\", 7l), (\"Juan Whelan\", 122l), (\"Sabah Colley\", 84l)))).equals(((\"Juan Whelan\", 212l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 50l), (\"Sabah Colley\", 48l), (\"Peter Nichols\", 37l), (\"Juan Whelan\", 22l), (\"Sabah Colley\", 14l)))).equals(((\"Juan Whelan\", 72l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 10l), (\"Sabah Colley\", 20l), (\"Peter Nichols\", 30l), (\"Juan Whelan\", 40l), (\"Sabah Colley\", 50l)))).equals(((\"Sabah Colley\", 70l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def combSort(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combSort((List[Long](5l.toLong, 15l.toLong, 37l.toLong, 25l.toLong, 79l.toLong))).equals((List[Long](5l.toLong, 15l.toLong, 25l.toLong, 37l.toLong, 79l.toLong))));\n    assert(combSort((List[Long](41l.toLong, 32l.toLong, 15l.toLong, 19l.toLong, 22l.toLong))).equals((List[Long](15l.toLong, 19l.toLong, 22l.toLong, 32l.toLong, 41l.toLong))));\n    assert(combSort((List[Long](99l.toLong, 15l.toLong, 13l.toLong, 47l.toLong))).equals((List[Long](13l.toLong, 15l.toLong, 47l.toLong, 99l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    def checkExpression(exp : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a word containing 'z'.\n    def textMatchWordz(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    def sumList(lst1 : List[Long], lst2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumList((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 25l.toLong, 35l.toLong))).equals((List[Long](25l.toLong, 45l.toLong, 65l.toLong))));\n    assert(sumList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(sumList((List[Long](15l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 45l.toLong, 75l.toLong))).equals((List[Long](30l.toLong, 65l.toLong, 105l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    def newmanPrime(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    def addString(list_ : List[Any], string : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addString((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (\"temp{0}\")).equals((List[String](\"temp1\", \"temp2\", \"temp3\", \"temp4\"))));\n    assert(addString((List[Any](\"a\", \"b\", \"c\", \"d\")), (\"python{0}\")).equals((List[String](\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"))));\n    assert(addString((List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (\"string{0}\")).equals((List[String](\"string5\", \"string6\", \"string7\", \"string8\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    def surfaceArea(b : Long, s : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    def FindMinLength(lst : List[List[Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong)))) == (1l));\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))) == (2l));\n    assert(FindMinLength((List[List[Long]](List[Long](3l.toLong, 3l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    def validate(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth hexagonal number.\n    def hexagonalNum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th lucas number.\n    def findLucas(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to get the difference between two lists.\n    def Diff(li1 : List[Long], li2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Diff((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong, 30l.toLong, 35l.toLong, 40l.toLong)), (List[Long](25l.toLong, 40l.toLong, 35l.toLong))).equals((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 15l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    def extractQuotation(text1 : String) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((List[Any](\"A53\", \"multi\", \"Processor\"))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((List[Any](\"favorite\", \"apps\"))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((List[Any](\"4k Ultra HD\", \"HDR 10\"))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a list and sum all of its elements.\n    def recursiveListSum(data_list : List[Either[Long, List[Long]]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(recursiveListSum((List[Either[Long, List[Long]]](1l, 2l, List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (21l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](7l, 10l, List[Long](15l.toLong, 14l.toLong), List[Long](19l.toLong, 41l.toLong)))) == (106l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](10l, 20l, List[Long](30l.toLong, 40l.toLong), List[Long](50l.toLong, 60l.toLong)))) == (210l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    def differAtOneBitPos(a : Long, b : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    def textMatchThree(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    def maxProduct(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong, 150l.toLong, 6l.toLong))) == (3000l));\n    assert(maxProduct((List[Long](4l.toLong, 42l.toLong, 55l.toLong, 68l.toLong, 80l.toLong))) == (50265600l));\n    assert(maxProduct((List[Long](10l.toLong, 22l.toLong, 9l.toLong, 33l.toLong, 21l.toLong, 50l.toLong, 41l.toLong, 60l.toLong))) == (2460l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    def splitArr(l : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitArr((List[Long](12l.toLong, 10l.toLong, 5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong)), (2l)).equals((List[Long](5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong, 12l.toLong, 10l.toLong))));\n    assert(splitArr((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(splitArr((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (3l)).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 0l.toLong, 1l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    def divisor(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    def bigDiff(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigDiff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigDiff((List[Long](4l.toLong, 5l.toLong, 12l.toLong))) == (8l));\n    assert(bigDiff((List[Long](9l.toLong, 2l.toLong, 3l.toLong))) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find squares of individual elements in a list.\n    def squareNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(squareNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](100l.toLong, 400l.toLong, 900l.toLong))));\n    assert(squareNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](144l.toLong, 225l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    def checkNone(test_tup : Any) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkNone((Any(10l), Some(4l), Some(5l), Some(6l), Some(None)))) == (true));\n    assert(checkNone((Any((7l, 8l, 9l, 11l, 14l)))) == (false));\n    assert(checkNone((Any(1l), Some(2l), Some(3l), Some(4l), Some(None)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    def isMonotonic(A : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMonotonic((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    def isPerfectSquare(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    def sum(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    def maxLength(list1 : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLength((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](1l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))).equals(((4l, List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](5l.toLong), List[Long](15l.toLong, 20l.toLong, 25l.toLong)))).equals(((3l, List[Long](15l.toLong, 20l.toLong, 25l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    def checkOccurences(test_list : List[Tuple2[Long, Long]]) : Map[Tuple2[Long, Long],Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkOccurences((List[Tuple2[Long, Long]]((3l, 1l), (1l, 3l), (2l, 5l), (5l, 2l), (6l, 3l)))).equals((Map[Tuple2[Long, Long],Long]((1l, 3l) -> 2l, (2l, 5l) -> 2l, (3l, 6l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((4l, 2l), (2l, 4l), (3l, 6l), (6l, 3l), (7l, 4l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 4l) -> 2l, (3l, 6l) -> 2l, (4l, 7l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((13l, 2l), (11l, 23l), (12l, 25l), (25l, 12l), (16l, 23l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 13l) -> 1l, (11l, 23l) -> 1l, (12l, 25l) -> 2l, (16l, 23l) -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the directrix of a parabola.\n    def parabolaDirectrix(a : Long, b : Long, c : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    def occuranceSubstring(text : String, pattern : String) : Option[Tuple2[String, Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals((\"python\", 0l, 6l)));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals((\"programming\", 7l, 18l)));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals((\"language\", 31l, 39l)));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove tuples from the given tuple.\n    def removeNested(test_tup : Any) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeNested((Any(4l, 6l), 10l))).equals(((1l, 5l, 7l, 10l))));\n    assert(removeNested((Any(5l, 7l), 11l))).equals(((2l, 6l, 8l, 11l))));\n    assert(removeNested((Any(6l, 8l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    assert(removeNested((Any(6l, 8l), (5l, 12l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(input_list : List[List[String]]) : List[List[String]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\" red \", \"green\"), List[String](\"blue \", \" black\"), List[String](\" orange\", \"brown\")))).equals((List[List[String]](List[String](\" red \", \"green\"), List[String](\" black\", \"blue \"), List[String](\" orange\", \"brown\")))));\n    assert(sortSublists((List[List[String]](List[String](\"zilver\", \"gold\"), List[String](\"magnesium\", \"aluminium\"), List[String](\"steel\", \"bronze\")))).equals((List[List[String]](List[String](\"gold\", \"zilver\"), List[String](\"aluminium\", \"magnesium\"), List[String](\"bronze\", \"steel\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    def removeKthElement(list1 : List[Long], L : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeKthElement((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))));\n    assert(removeKthElement((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong)), (4l)).equals((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))));\n    assert(removeKthElement((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong)), (5l)).equals((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    def addDictToTuple(test_tup : Tuple2[Long, Long, Long], test_dict : Map[String,Long]) : Tuple2[Long, Long, Long, Map[String,Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addDictToTuple(((4l, 5l, 6l)), (Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l))).equals(((4l, 5l, 6l, Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l)))));\n    assert(addDictToTuple(((1l, 2l, 3l)), (Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l))).equals(((1l, 2l, 3l, Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l)))));\n    assert(addDictToTuple(((8l, 9l, 10l)), (Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l))).equals(((8l, 9l, 10l, Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    def find(n : Long, m : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    def textMatchTwoThree(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    def countOccurrence(tup : Any, lst : List[Any]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurrence((Any((\"a\", \"a\", \"c\", \"b\", \"d\"))), (List[Any](\"a\", \"b\"))) == (3l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l))), (List[Any](1l.toLong, 4l.toLong, 7l.toLong))) == (6l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 4l, 5l, 6l))), (List[Any](1l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    def countSamepair(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (3l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (4l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    def textMatchOne(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    def difference(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to toggle the case of all characters in a string.\n    def toggleString(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the element of a list having maximum length.\n    def FindMax(lst : List[List[Any]]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMax((List[List[Any]](List[String](\"A\"), List[String](\"A\", \"B\"), List[String](\"A\", \"B\", \"C\")))).equals((List[Any](\"A\", \"B\", \"C\"))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong)))).equals((List[Any](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    def eulerianNum(n : Long, m : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    def frequency(a : List[Long], x : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l)) == (0l));\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)), (3l)) == (3l));\n    assert(frequency((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong)), (1l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    def sortNumericStrings(nums_str : List[String]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumericStrings((List[String](\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"))).equals((List[Long](-500l.toLong, -12l.toLong, 0l.toLong, 4l.toLong, 7l.toLong, 12l.toLong, 45l.toLong, 100l.toLong, 200l.toLong))));\n    assert(sortNumericStrings((List[String](\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 9l.toLong))));\n    assert(sortNumericStrings((List[String](\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong, 15l.toLong, 17l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    def geometricSum(n : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    def divisibleByDigits(startnum : Long, endnum : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisibleByDigits((1l), (22l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong, 22l.toLong))));\n    assert(divisibleByDigits((1l), (15l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong))));\n    assert(divisibleByDigits((20l), (25l)).equals((List[Long](22l.toLong, 24l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    def uniqueProduct(list_data : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueProduct((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 50l.toLong, 60l.toLong, 40l.toLong))) == (720000000l));\n    assert(uniqueProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (6l));\n    assert(uniqueProduct((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the largest negative number from the given list.\n    def largestNeg(list1 : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -4l.toLong, -6l.toLong))) == (-6l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -8l.toLong, -9l.toLong))) == (-9l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    def consecutiveDuplicates(nums : List[Any]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(consecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[Any](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong))));\n    assert(consecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[Any](10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\"))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\", \"a\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    def minJumps(steps : Tuple2[Long, Long], d : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minJumps(((3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps(((3l, 4l)), (0l)) == 0l);\n    assert(minJumps(((11l, 14l)), (11l)) == 1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    def maxProduct(arr : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 0l.toLong, 8l.toLong, 4l.toLong))).equals(((7l, 8l))));\n    assert(maxProduct((List[Long](0l.toLong, -1l.toLong, -2l.toLong, -4l.toLong, 5l.toLong, 0l.toLong, -6l.toLong))).equals(((-4l, -6l))));\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals(((2l, 3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    def extractNthElement(list1 : List[Tuple2[String, Long, Long]], n : Long) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (0l)).equals((List[Any](\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (2l)).equals((List[Any](99l.toLong, 96l.toLong, 94l.toLong, 98l.toLong))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (1l)).equals((List[Any](98l.toLong, 97l.toLong, 91l.toLong, 94l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth nonagonal number.\n    def isNonagonal(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    def maxAbsDiff(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAbsDiff((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 3l.toLong))) == (4l));\n    assert(maxAbsDiff((List[Long](9l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (8l));\n    assert(maxAbsDiff((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    def packConsecutiveDuplicates(list1 : List[Any]) : List[List[Any]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(packConsecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[List[Any]](List[Long](0l.toLong, 0l.toLong), List[Long](1l.toLong), List[Long](2l.toLong), List[Long](3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](5l.toLong), List[Long](6l.toLong, 6l.toLong, 6l.toLong), List[Long](7l.toLong), List[Long](8l.toLong), List[Long](9l.toLong), List[Long](4l.toLong, 4l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[List[Any]](List[Long](10l.toLong, 10l.toLong), List[Long](15l.toLong), List[Long](19l.toLong), List[Long](18l.toLong, 18l.toLong), List[Long](17l.toLong), List[Long](26l.toLong, 26l.toLong), List[Long](17l.toLong), List[Long](18l.toLong), List[Long](10l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[List[Any]](List[String](\"a\", \"a\"), List[String](\"b\"), List[String](\"c\"), List[String](\"d\", \"d\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    def calSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    def oddValuesString(str : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    def findKth(arr1 : List[Long], arr2 : List[Long], k : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findKth((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](1l.toLong, 4l.toLong, 8l.toLong, 10l.toLong)), (5l)) == (6l));\n    assert(findKth((List[Long](100l.toLong, 112l.toLong, 256l.toLong, 349l.toLong, 770l.toLong)), (List[Long](72l.toLong, 86l.toLong, 113l.toLong, 119l.toLong, 265l.toLong, 445l.toLong, 892l.toLong)), (7l)) == (256l));\n    assert(findKth((List[Long](3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 10l.toLong)), (List[Long](2l.toLong, 5l.toLong, 9l.toLong, 11l.toLong)), (6l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    def jacobsthalNum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    def frequencyLists(list1 : List[List[Long]]) : Map[Long,Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong, 5l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 3l, 3l -> 1l, 4l -> 1l, 5l -> 2l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 1l, 3l -> 1l, 4l -> 1l, 5l -> 1l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l, 10l -> 1l, 11l -> 1l, 12l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](20l.toLong, 30l.toLong, 40l.toLong, 17l.toLong), List[Long](18l.toLong, 16l.toLong, 14l.toLong, 13l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((Map[Long,Long](20l -> 2l, 30l -> 2l, 40l -> 2l, 17l -> 1l, 18l -> 1l, 16l -> 1l, 14l -> 1l, 13l -> 1l, 10l -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find perfect squares between two given numbers.\n    def perfectSquares(a : Long, b : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perfectSquares((1l), (30l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong))));\n    assert(perfectSquares((50l), (100l)).equals((List[Long](64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(perfectSquares((100l), (200l)).equals((List[Long](100l.toLong, 121l.toLong, 144l.toLong, 169l.toLong, 196l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    def sumOfSubarrayProd(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (20l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong))) == (5l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    def firstOdd(nums : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong))) == (1l));\n    assert(firstOdd((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(firstOdd((List[Long](8l.toLong, 9l.toLong, 1l.toLong))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    def addNestedTuples(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addNestedTuples((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 10l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 13l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](9l.toLong, 12l.toLong), List[Long](9l.toLong, 16l.toLong), List[Long](5l.toLong, 12l.toLong), List[Long](10l.toLong, 15l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](11l.toLong, 14l.toLong), List[Long](11l.toLong, 18l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](12l.toLong, 17l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    def merge(lst : List[List[Any]]) : List[List[Any]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\"), List[String](\"a\", \"b\"), List[String](\"m\", \"n\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\")))));\n    assert(merge((List[List[Any]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong)))).equals((List[List[Any]](List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)))));\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\", \"z\"), List[String](\"a\", \"b\", \"c\"), List[String](\"m\", \"n\", \"o\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\"), List[String](\"z\", \"c\", \"o\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    def difSquare(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    def checkSmaller(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkSmaller(((1l, 2l, 3l)), ((2l, 3l, 4l))) == (false));\n    assert(checkSmaller(((4l, 5l, 6l)), ((3l, 4l, 5l))) == (true));\n    assert(checkSmaller(((11l, 12l, 13l)), ((10l, 11l, 12l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    def freqCount(list1 : List[Long]) : Map[Long,Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(freqCount((List[Long](10l.toLong, 10l.toLong, 10l.toLong, 10l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 40l.toLong, 40l.toLong, 50l.toLong, 50l.toLong, 30l.toLong))).equals((Map[Long,Long](10l -> 4l, 20l -> 4l, 40l -> 2l, 50l -> 2l, 30l -> 1l))));\n    assert(freqCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 4l.toLong))).equals((Map[Long,Long](1l -> 3l, 2l -> 2l, 3l -> 3l, 4l -> 3l))));\n    assert(freqCount((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 5l.toLong))).equals((Map[Long,Long](10l -> 1l, 5l -> 3l, 6l -> 2l, 7l -> 2l, 4l -> 2l, 9l -> 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    def rgbToHsv(r : Long, g : Long, b : Long) : List[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((List[Float](0.0f.toFloat, 0.0f.toFloat, 100.0f.toFloat))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((List[Float](120.0f.toFloat, 100.0f.toFloat, 84.31372549019608f.toFloat))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((List[Float](149.26829268292684f.toFloat, 95.34883720930233f.toFloat, 84.31372549019608f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a given nested list structure.\n    def flattenList(list1 : List[Either[Long, List[Long]]]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flattenList((List[Either[Long, List[Long]]](0l, 10l, List[Long](20l.toLong, 30l.toLong), 40l, 50l, List[Long](60l.toLong, 70l.toLong, 80l.toLong), List[Long](90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong)))).equals((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong, 80l.toLong, 90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](10l.toLong, 20l.toLong), List[Long](40l.toLong), List[Long](30l.toLong, 56l.toLong, 25l.toLong), List[Long](10l.toLong, 20l.toLong), List[Long](33l.toLong), List[Long](40l.toLong)))).equals((List[Long](10l.toLong, 20l.toLong, 40l.toLong, 30l.toLong, 56l.toLong, 25l.toLong, 10l.toLong, 20l.toLong, 33l.toLong, 40l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    def checkStr(string : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    def checkMonthnumberNumber(monthnum3 : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list.\n    def heapSort(iterable : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapSort((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(heapSort((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong))).equals((List[Long](14l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 58l.toLong, 65l.toLong, 75l.toLong, 85l.toLong))));\n    assert(heapSort((List[Long](7l.toLong, 1l.toLong, 9l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    def kSmallestPairs(nums1 : List[Long], nums2 : List[Long], k : Long) : List[List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (2l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (1l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (7l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](3l.toLong, 2l.toLong), List[Long](1l.toLong, 6l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](7l.toLong, 2l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    def findSolution(a : Long, b : Long, n : Long) : Option[Tuple2[Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSolution((2l), (3l), (7l)).equals((2l, 1l)));\n    assert(findSolution((4l), (2l), (7l)).equals(None));\n    assert(findSolution((1l), (13l), (17l)).equals((4l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    def findMaxNum(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (321l));\n    assert(findMaxNum((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (6541l));\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 9l.toLong))) == (9321l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    def maxSumList(lists : List[List[Long]]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](10l.toLong, 11l.toLong, 12l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](12l.toLong, 11l.toLong, 10l.toLong)))).equals((List[Long](12l.toLong, 11l.toLong, 10l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 1l.toLong)))).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](12l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 24l.toLong))).equals((List[Long](24l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 12l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    def getMedian(arr1 : List[Long], arr2 : List[Long], n : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMedian((List[Long](1l.toLong, 12l.toLong, 15l.toLong, 26l.toLong, 38l.toLong)), (List[Long](2l.toLong, 13l.toLong, 17l.toLong, 30l.toLong, 45l.toLong)), (5l)) == (16.0f));\n    assert(getMedian((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong)), (List[Long](7l.toLong, 13l.toLong, 19l.toLong, 28l.toLong)), (4l)) == (8.5f));\n    assert(getMedian((List[Long](3l.toLong, 6l.toLong, 14l.toLong, 23l.toLong, 36l.toLong, 42l.toLong)), (List[Long](2l.toLong, 18l.toLong, 27l.toLong, 39l.toLong, 49l.toLong, 55l.toLong)), (6l)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    def replaceSpaces(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    def areEquivalent(num1 : Long, num2 : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse each string in a given list of string values.\n    def reverseStringList(stringlist : List[String]) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseStringList((List[String](\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"))).equals((List[String](\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"))));\n    assert(reverseStringList((List[String](\"john\", \"amal\", \"joel\", \"george\"))).equals((List[String](\"nhoj\", \"lama\", \"leoj\", \"egroeg\"))));\n    assert(reverseStringList((List[String](\"jack\", \"john\", \"mary\"))).equals((List[String](\"kcaj\", \"nhoj\", \"yram\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    def sumOfDigits(nums : List[Any]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfDigits((List[Any](10l.toLong, 2l.toLong, 56l.toLong))) == (14l));\n    assert(sumOfDigits((List[Any](List[Any](10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))) == (19l));\n    assert(sumOfDigits((List[Any](10l.toLong, 20l.toLong, -4l.toLong, 5l.toLong, -70l.toLong))) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    def sequence(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    def heapQueueLargest(nums : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (3l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (2l)).equals((List[Long](85l.toLong, 75l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (5l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong, 58l.toLong, 35l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    def lossAmount(actual_cost : Long, sale_amount : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    def unionElements(test_tup1 : List[Long], test_tup2 : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unionElements((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](5l.toLong, 7l.toLong, 4l.toLong, 10l.toLong))).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 10l.toLong))));\n    assert(unionElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(unionElements((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (List[Long](13l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))).equals((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the longest sublists.\n    def FindMaxLength(lst : List[List[Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMaxLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (4l));\n    assert(FindMaxLength((List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](3l.toLong, 2l.toLong, 1l.toLong)))) == (3l));\n    assert(FindMaxLength((List[List[Long]](List[Long](7l.toLong), List[Long](22l.toLong, 23l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong)))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    def removeParenthesis(items : List[String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeParenthesis((List[String](\"python (chrome)\"))).equals((\"python\")));\n    assert(removeParenthesis((List[String](\"string(.abc)\"))).equals((\"string\")));\n    assert(removeParenthesis((List[String](\"alpha(num)\"))).equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    def findParity(x : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median length of a trapezium.\n    def medianTrapezium(base1 : Long, base2 : Long, height : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianTrapezium((15l), (25l), (35l)) == 20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == 15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth centered hexagonal number.\n    def centeredHexagonalNumber(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find number of lists present in the given list.\n    def findLists(Input : List[Any]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (2l));\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (3l));\n    assert(findLists((List[Any](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    def getMaxSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the longest word.\n    def lenLog(list1 : List[String]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lenLog((List[String](\"python\", \"PHP\", \"bigdata\"))) == (7l));\n    assert(lenLog((List[String](\"a\", \"ab\", \"abc\"))) == (3l));\n    assert(lenLog((List[String](\"small\", \"big\", \"tall\"))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    def sectorArea(r : Long, a : Long) : Option[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sectorArea((4l), (45l)).equals(6.283185307179586f));\n    assert(sectorArea((9l), (45l)).equals(31.808625617596654f));\n    assert(sectorArea((9l), (361l)).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    def oddPosition(nums : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 3l.toLong))) == (true));\n    assert(oddPosition((List[Long](4l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(oddPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    def multipleToSingle(L : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multipleToSingle((List[Long](11l.toLong, 33l.toLong, 50l.toLong))) == (113350l));\n    assert(multipleToSingle((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (-123456l));\n    assert(multipleToSingle((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong))) == (10152025l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    def isDiff(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    def indexMultiplication(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMultiplication((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 21l.toLong), List[Long](12l.toLong, 45l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 30l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](14l.toLong, 32l.toLong), List[Long](20l.toLong, 60l.toLong), List[Long](6l.toLong, 20l.toLong), List[Long](16l.toLong, 44l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](24l.toLong, 45l.toLong), List[Long](30l.toLong, 77l.toLong), List[Long](12l.toLong, 33l.toLong), List[Long](27l.toLong, 60l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert tuple string to integer tuple.\n    def tupleStrInt(test_str : String) : Tuple2[Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals(((7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals(((1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals(((4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals(((7l, 81l, 19l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    def amicableNumbersSum(limit : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove odd characters in a string.\n    def removeOdd(str1 : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    def multiplyElements(test_tup : List[Long]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyElements((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 10l.toLong))).equals((List[Any](5l.toLong, 35l.toLong, 56l.toLong, 80l.toLong))));\n    assert(multiplyElements((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](8l.toLong, 20l.toLong, 30l.toLong, 42l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong, 13l.toLong, 14l.toLong, 9l.toLong, 15l.toLong))).equals((List[Any](156l.toLong, 182l.toLong, 126l.toLong, 135l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    def countRotation(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countRotation((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(countRotation((List[Long](4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (2l));\n    assert(countRotation((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(countRotation((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (0l));\n    assert(countRotation((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    def extractFreq(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractFreq((List[Tuple2[Long, Long]]((3l, 4l), (1l, 2l), (4l, 3l), (5l, 6l)))) == (3l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((4l, 15l), (2l, 3l), (5l, 4l), (6l, 7l)))) == (4l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((5l, 16l), (2l, 3l), (6l, 5l), (6l, 9l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    def countSamePair(nums1 : List[Long], nums2 : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamePair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (4l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (11l));\n    assert(countSamePair((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (1l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 1l.toLong, 2l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    def power(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    def returnSum(dict : Map[String,Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(returnSum((Map[String,Long](\"a\" -> 100l, \"b\" -> 200l, \"c\" -> 300l))) == (600l));\n    assert(returnSum((Map[String,Long](\"a\" -> 25l, \"b\" -> 18l, \"c\" -> 45l))) == (88l));\n    assert(returnSum((Map[String,Long](\"a\" -> 36l, \"b\" -> 39l, \"c\" -> 49l))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    def pairWise(l1 : List[Long]) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairWise((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 1l), (1l, 2l), (2l, 3l), (3l, 3l), (3l, 4l), (4l, 4l), (4l, 5l)))));\n    assert(pairWise((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 5l), (5l, 7l), (7l, 9l), (9l, 10l)))));\n    assert(pairWise((List[Long](5l.toLong, 1l.toLong, 9l.toLong, 7l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((5l, 1l), (1l, 9l), (9l, 7l), (7l, 10l)))));\n    assert(pairWise((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 2l), (2l, 3l), (3l, 4l), (4l, 5l), (5l, 6l), (6l, 7l), (7l, 8l), (8l, 9l), (9l, 10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to split a string into characters.\n    def split(word : String) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(split((\"python\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))));\n    assert(split((\"Name\")).equals((List[String](\"N\", \"a\", \"m\", \"e\"))));\n    assert(split((\"program\")).equals((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum of three numbers.\n    def minOfThree(a : Long, b : Long, c : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    def isSumOfPowersOfTwo(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    def getChar(strr : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return the sum of all divisors of a number.\n    def sumDiv(number : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    def twoUniqueNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    def testDuplicate(arraynums : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(testDuplicate((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which returns nth catalan number.\n    def catalanNumber(num : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    def powerBaseSum(base : Long, power : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    def replaceList(list1 : List[Any], list2 : List[Any]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceList((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong)), (List[Any](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](\"red\", \"blue\", \"green\")), (List[Any](\"yellow\"))).equals((List[Any](\"red\", \"blue\", \"yellow\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth octagonal number.\n    def isOctagonal(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    def replaceBlank(str1 : String, char : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    def replaceSpecialchar(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    def tupleToInt(nums : Tuple2[Long, Long, Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToInt(((1l, 2l, 3l))) == (123l));\n    assert(tupleToInt(((4l, 5l, 6l))) == (456l));\n    assert(tupleToInt(((5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the third side of a right angled triangle.\n    def othersideRightangle(w : Long, h : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == 5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n most expensive items in a given dataset.\n    def expensiveItems(items : List[Map[String,Either[String, Float]]], n : Long) : List[Map[String,Either[String, Float]]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f))), (2l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f), Map[String,String](\"name\" -> \"Item-4\", \"price\" -> 22.75f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    def digitDistanceNums(n1 : Long, n2 : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    def textMatchWordzMiddle(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    def removezeroIp(ip : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    def countElementInList(list1 : List[List[Any]], x : Any) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countElementInList((List[List[Any]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](1l.toLong, 11l.toLong), List[Long](1l.toLong, 15l.toLong, 7l.toLong))), (Any(1l))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"A\"))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"E\"))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to multiply two integers.\n    def multiplyInt(x : Long, y : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    def addPairwise(test_tup : Tuple2[Long, Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addPairwise(((1l, 5l, 7l, 8l, 10l))).equals(((6l, 12l, 15l, 18l))));\n    assert(addPairwise(((2l, 6l, 8l, 9l, 11l))).equals(((8l, 14l, 17l, 20l))));\n    assert(addPairwise(((3l, 7l, 9l, 10l, 12l))).equals(((10l, 16l, 19l, 22l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    def maxProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (36l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (200l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3532,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the kth element in the given array using 1-based indexing.\n    def kthElement(arr : List[Long], k : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kthElement((List[Long](12l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 19l.toLong)), (2l)) == (3l));\n    assert(kthElement((List[Long](17l.toLong, 24l.toLong, 8l.toLong, 23l.toLong)), (3l)) == (8l));\n    assert(kthElement((List[Long](16l.toLong, 21l.toLong, 25l.toLong, 36l.toLong, 4l.toLong)), (4l)) == (36l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3540,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))).equals((List[Long](4l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of elements that occurs before the list element in the given tuple.\n    def countFirstElements(test_tup : List[Either[Long, Tuple2[Long, Long]]]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    def eulerianNum(n : Long, m : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](1l, 5l, 7l, (4l, 6l), 10l))) == (3l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](2l, 9l, (5l, 7l), 11l))) == (2l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](11l, 15l, 5l, 8l, (2l, 3l), 8l))) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    def rightInsertion(a : List[Long], x : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(input_list : List[List[String]]) : List[List[String]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\" red \", \"green\"), List[String](\"blue \", \" black\"), List[String](\" orange\", \"brown\")))).equals((List[List[String]](List[String](\" red \", \"green\"), List[String](\" black\", \"blue \"), List[String](\" orange\", \"brown\")))));\n    assert(sortSublists((List[List[String]](List[String](\"zilver\", \"gold\"), List[String](\"magnesium\", \"aluminium\"), List[String](\"steel\", \"bronze\")))).equals((List[List[String]](List[String](\"gold\", \"zilver\"), List[String](\"aluminium\", \"magnesium\"), List[String](\"bronze\", \"steel\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given number is woodball or not.\n    def isWoodall(x : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count true booleans in the given list.\n    def count(lst : List[Boolean]) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(count((List[Boolean](true.toBoolean, false.toBoolean, true.toBoolean))) == (2l));\n    assert(count((List[Boolean](false.toBoolean, false.toBoolean))) == (0l));\n    assert(count((List[Boolean](true.toBoolean, true.toBoolean, true.toBoolean))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given array by using shell sort.\n    def shellSort(my_list : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to append the given list to the given tuples.\n    def addLists(test_list : List[Long], test_tup : Tuple2[Long, Long]) : Tuple2[Long, Long, Long, Long, Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(shellSort((List[Long](12l.toLong, 23l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 2l.toLong, 12l.toLong, 81l.toLong, 56l.toLong, 95l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 12l.toLong, 12l.toLong, 23l.toLong, 56l.toLong, 81l.toLong, 95l.toLong))));\n    assert(shellSort((List[Long](24l.toLong, 22l.toLong, 39l.toLong, 34l.toLong, 87l.toLong, 73l.toLong, 68l.toLong))).equals((List[Long](22l.toLong, 24l.toLong, 34l.toLong, 39l.toLong, 68l.toLong, 73l.toLong, 87l.toLong))));\n    assert(shellSort((List[Long](32l.toLong, 30l.toLong, 16l.toLong, 96l.toLong, 82l.toLong, 83l.toLong, 74l.toLong))).equals((List[Long](16l.toLong, 30l.toLong, 32l.toLong, 74l.toLong, 82l.toLong, 83l.toLong, 96l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addLists((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals(((9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals(((10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals(((11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    def findOddPair(A : List[Long], N : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three lists into a single sorted list.\n    def mergeSortedList(num1 : List[Long], num2 : List[Long], num3 : List[Long]) : List[Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findOddPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong)), (5l)) == (6l));\n    assert(findOddPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong)), (7l)) == (12l));\n    assert(findOddPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (3l)) == (2l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeSortedList((List[Long](25l.toLong, 24l.toLong, 15l.toLong, 4l.toLong, 5l.toLong, 29l.toLong, 110l.toLong)), (List[Long](19l.toLong, 20l.toLong, 11l.toLong, 56l.toLong, 25l.toLong, 233l.toLong, 154l.toLong)), (List[Long](24l.toLong, 26l.toLong, 54l.toLong, 48l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 11l.toLong, 15l.toLong, 19l.toLong, 20l.toLong, 24l.toLong, 24l.toLong, 25l.toLong, 25l.toLong, 26l.toLong, 29l.toLong, 48l.toLong, 54l.toLong, 56l.toLong, 110l.toLong, 154l.toLong, 233l.toLong))));\n    assert(mergeSortedList((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (List[Long](2l.toLong, 5l.toLong, 7l.toLong, 11l.toLong)), (List[Long](1l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 12l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    assert(mergeSortedList((List[Long](18l.toLong, 14l.toLong, 10l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong)), (List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong)), (List[Long](12l.toLong, 74l.toLong, 9l.toLong, 50l.toLong, 61l.toLong, 41l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 14l.toLong, 18l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 41l.toLong, 50l.toLong, 58l.toLong, 61l.toLong, 65l.toLong, 74l.toLong, 75l.toLong, 85l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    def sumInRange(l : Long, r : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    def oddEquivalent(s : String, n : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    def squarePerimeter(a : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string represents an integer or not.\n    def checkInteger(text : String) : Boolean = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    def isPolite(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    def tupleToInt(nums : Tuple2[Long, Long, Long]) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    def sumSeries(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    def findDissimilar(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findDissimilar(((3l, 4l, 5l, 6l)), ((5l, 7l, 4l, 10l))).equals(((3l, 6l, 7l, 10l))));\n    assert(findDissimilar(((1l, 2l, 3l, 4l)), ((7l, 2l, 3l, 9l))).equals(((1l, 4l, 7l, 9l))));\n    assert(findDissimilar(((21l, 11l, 25l, 26l)), ((26l, 34l, 21l, 36l))).equals(((34l, 36l, 11l, 25l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    def startWithp(words : List[String]) : Tuple2[String, String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startWithp((List[String](\"Python PHP\", \"Java JavaScript\", \"c c++\"))).equals(((\"Python\", \"PHP\"))));\n    assert(startWithp((List[String](\"Python Programming\", \"Java Programming\"))).equals(((\"Python\", \"Programming\"))));\n    assert(startWithp((List[String](\"Pqrst Pqr\", \"qrstuv\"))).equals(((\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the volume of a cube given its side length.\n    def volumeCube(l : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    def checkMonthnumbNumber(monthnum2 : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    def allBitsSetInTheGivenRange(n : Long, l : Long, r : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to get the first element of each sublist.\n    def Extract(lst : List[List[Long]]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 3l.toLong, 6l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))).equals((List[Long](1l.toLong, 4l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](9l.toLong, 8l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong)))).equals((List[Long](9l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cylinder.\n    def surfaceareaCylinder(r : Long, h : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    def sampleNam(sample_names : List[String]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sampleNam((List[String](\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"))) == (16l));\n    assert(sampleNam((List[String](\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"))) == (10l));\n    assert(sampleNam((List[String](\"abcd\", \"Python\", \"abba\", \"aba\"))) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    def rearrangeBigger(n : Long) : Any = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearrangeBigger((12l)).equals((Any(21l))));\n    assert(rearrangeBigger((10l)).equals((Any(false))));\n    assert(rearrangeBigger((102l)).equals((Any(120l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    def perimeterPentagon(a : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    def maxSum(arr : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSum((List[Long](1l.toLong, 15l.toLong, 51l.toLong, 45l.toLong, 33l.toLong, 100l.toLong, 12l.toLong, 18l.toLong, 9l.toLong))) == (194l));\n    assert(maxSum((List[Long](80l.toLong, 60l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 10l.toLong))) == (210l));\n    assert(maxSum((List[Long](2l.toLong, 3l.toLong, 14l.toLong, 16l.toLong, 21l.toLong, 23l.toLong, 29l.toLong, 30l.toLong))) == (138l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    def extractEven(test_tuple : Tuple2[Long, Long, Tuple2[Long, Long, Tuple2[Long, Long]], Long, Long]) : Any = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractEven(((4l, 5l, (7l, 6l, (2l, 4l)), 6l, 8l))).equals((Any(6l, (2l, 4l)), 6l, 8l))));\n    assert(extractEven(((5l, 6l, (8l, 7l, (4l, 8l)), 7l, 9l))).equals((Any(8l, (4l, 8l))))));\n    assert(extractEven(((5l, 6l, (9l, 8l, (4l, 6l)), 8l, 10l))).equals((Any(8l, (4l, 6l)), 8l, 10l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToInt(((1l, 2l, 3l))) == (123l));\n    assert(tupleToInt(((4l, 5l, 6l))) == (456l));\n    assert(tupleToInt(((5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3820,201 +136,9 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert all possible convertible elements in a list of lists to floats.\n    def listToFloat(test_list : List[Tuple2[String, String]]) : List[Tuple2[Float, Float]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listToFloat((List[Tuple2[String, String]]((\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")))).equals((List[Tuple2[Float, Float]]((3.0f, 4.0f), (1.0f, 26.45f), (7.32f, 8.0f), (4.0f, 8.0f)))));\n    assert(listToFloat((List[Tuple2[String, String]]((\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")))).equals((List[Tuple2[Float, Float]]((4.0f, 4.0f), (2.0f, 27.0f), (4.12f, 9.0f), (7.0f, 11.0f)))));\n    assert(listToFloat((List[Tuple2[String, String]]((\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")))).equals((List[Tuple2[Float, Float]]((6.0f, 78.0f), (5.0f, 26.45f), (1.33f, 4.0f), (82.0f, 13.0f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    def squareSum(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    def getPairsCount(arr : List[Long], sum : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPairsCount((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (2l)) == (6l));\n    assert(getPairsCount((List[Long](1l.toLong, 5l.toLong, 7l.toLong, -1l.toLong, 5l.toLong)), (6l)) == (3l));\n    assert(getPairsCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong)), (1l)) == (1l));\n    assert(getPairsCount((List[Long](-1l.toLong, -2l.toLong, 3l.toLong)), (-3l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    def countNoOfWays(n : Long, k : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    def reverseWords(s : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    def checks(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    def last(arr : List[Long], x : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(last((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (0l));\n    assert(last((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)) == (2l));\n    assert(last((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (3l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    def countX(tup : List[Long], x : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (4l)) == (0l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (10l)) == (3l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (8l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    def extractIndexList(l1 : List[Long], l2 : List[Long], l3 : List[Long]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 7l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 6l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 5l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 6l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the second smallest number in a list.\n    def secondSmallest(numbers : List[Either[Long, Float]]) : Option[Float] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 2l.toLong, -8l.toLong, -2l.toLong, 0l.toLong, -2l.toLong))).equals(-2l));\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 1l.toLong, -0.5f.toLong, 0l.toLong, 2l.toLong, -2l.toLong, -2l.toLong))).equals(-0.5f));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong))).equals(None));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong, 2l.toLong))).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    def concatenateTuple(test_tup : Tuple2[String, String, Long, String]) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenateTuple(((\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple(((\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple(((\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    def replaceSpaces(string : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    def sumRangeList(list1 : List[Long], m : Long, n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (8l), (10l)) == (29l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (5l), (7l)) == (16l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (7l), (10l)) == (38l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    def mergeDictionariesThree(dict1 : Map[String,String], dict2 : Map[String,String], dict3 : Map[String,String]) : Map[String,String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"O\" -> \"Orange\", \"W\" -> \"White\", \"B\" -> \"Black\"))).equals((Map[String,String](\"B\" -> \"Black\", \"R\" -> \"Red\", \"P\" -> \"Pink\", \"G\" -> \"Green\", \"W\" -> \"White\", \"O\" -> \"Orange\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\"))).equals((Map[String,String](\"W\" -> \"White\", \"P\" -> \"Pink\", \"B\" -> \"Black\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\"))).equals((Map[String,String](\"B\" -> \"Black\", \"P\" -> \"Pink\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\", \"W\" -> \"White\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum of two numbers.\n    def minimum(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    def maxDifference(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxDifference((List[Tuple2[Long, Long]]((3l, 5l), (1l, 7l), (10l, 3l), (1l, 2l)))) == (7l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((4l, 6l), (2l, 17l), (9l, 13l), (11l, 12l)))) == (15l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((12l, 35l), (21l, 27l), (13l, 23l), (41l, 22l)))) == (23l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    def findElement(arr : List[Long], ranges : List[List[Long]], rotations : Long, index : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[List[Long]](List[Long](0l.toLong, 2l.toLong), List[Long](0l.toLong, 3l.toLong))), (2l), (1l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (2l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4024,7 +148,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a string to a list of strings split on the space character.\n    def stringToList(string : String) : List[String] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToList((\"python programming\")).equals((List[String](\"python\", \"programming\"))));\n    assert(stringToList((\"lists tuples strings\")).equals((List[String](\"lists\", \"tuples\", \"strings\"))));\n    assert(stringToList((\"write a program\")).equals((List[String](\"write\", \"a\", \"program\"))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4036,21 +160,9 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the element that appears only once in a sorted array.\n    def search(arr : List[Long]) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(search((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a dictionary by value.\n    def sortCounter(dict1 : Map[String,Long]) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortCounter((Map[String,Long](\"Math\" -> 81l, \"Physics\" -> 83l, \"Chemistry\" -> 87l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 87l), (\"Physics\", 83l), (\"Math\", 81l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 400l, \"Physics\" -> 300l, \"Chemistry\" -> 250l))).equals((List[Tuple2[String, Long]]((\"Math\", 400l), (\"Physics\", 300l), (\"Chemistry\", 250l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 900l, \"Physics\" -> 1000l, \"Chemistry\" -> 1250l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 1250l), (\"Physics\", 1000l), (\"Math\", 900l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4060,7 +172,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove first and last occurrence of a given character from the string.\n    def removeOcc(s : String, ch : String) : String = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOcc((\"hello\"), (\"l\")).equals((\"heo\")));\n    assert(removeOcc((\"abcda\"), (\"a\")).equals((\"bcd\")));\n    assert(removeOcc((\"PHP\"), (\"P\")).equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4068,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    def lateralsurfaceCube(l : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    def maxProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (36l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (200l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    def commonElement(list1 : List[Any], list2 : List[Any]) : Option[Boolean] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    def amicableNumbersSum(limit : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(true));\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(None));\n    assert(commonElement((List[Any](\"a\", \"b\", \"c\")), (List[Any](\"d\", \"b\", \"e\"))).equals(true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to append the given list to the given tuples.\n    def addLists(test_list : List[Long], test_tup : Tuple2[Long, Long]) : Tuple2[Long, Long, Long, Long, Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    def findLength(string : String) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addLists((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals(((9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals(((10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals(((11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    def nthNums(nums : List[Long], n : Long) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of common divisors of two given numbers.\n    def sum(a : Long, b : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nthNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(nthNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (3l)).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(nthNums((List[Long](12l.toLong, 15l.toLong)), (5l)).equals((List[Long](248832l.toLong, 759375l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def pancakeSort(nums : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to multiply two integers.\n    def multiplyInt(x : Long, y : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pancakeSort((List[Long](15l.toLong, 79l.toLong, 25l.toLong, 38l.toLong, 69l.toLong))).equals((List[Long](15l.toLong, 25l.toLong, 38l.toLong, 69l.toLong, 79l.toLong))));\n    assert(pancakeSort((List[Long](98l.toLong, 12l.toLong, 54l.toLong, 36l.toLong, 85l.toLong))).equals((List[Long](12l.toLong, 36l.toLong, 54l.toLong, 85l.toLong, 98l.toLong))));\n    assert(pancakeSort((List[Long](41l.toLong, 42l.toLong, 32l.toLong, 12l.toLong, 23l.toLong))).equals((List[Long](12l.toLong, 23l.toLong, 32l.toLong, 41l.toLong, 42l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of three numbers.\n    def medianNumbers(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    def checkGreater(arr : List[Long], number : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkGreater((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (4l)) == (false));\n    assert(checkGreater((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (8l)) == (true));\n    assert(checkGreater((List[Long](9l.toLong, 7l.toLong, 4l.toLong, 8l.toLong, 6l.toLong, 1l.toLong)), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    def checkElement(list : List[Any], element : Any) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkElement((List[Any](\"green\", \"orange\", \"black\", \"white\")), (Any(\"blue\"))) == (false));\n    assert(checkElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (Any(7l))) == (false));\n    assert(checkElement((List[Any](\"green\", \"green\", \"green\", \"green\")), (Any(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    def extractString(str : List[String], l : Long) : List[String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (8l)).equals((List[String](\"practice\", \"solution\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (6l)).equals((List[String](\"Python\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (9l)).equals((List[String](\"exercises\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    def textLowercaseUnderscore(text : String) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to trim each list by k in the given lists.\n    def trimTuple(test_list : List[List[Long]], K : Long) : List[List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (2l)).equals((List[List[Long]](List[Long](2l.toLong), List[Long](9l.toLong), List[Long](2l.toLong), List[Long](2l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](4l.toLong, 9l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](8l.toLong, 2l.toLong, 1l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 4l.toLong, 9l.toLong), List[Long](11l.toLong, 8l.toLong, 12l.toLong, 4l.toLong), List[Long](4l.toLong, 1l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](8l.toLong, 4l.toLong), List[Long](8l.toLong, 12l.toLong), List[Long](1l.toLong, 7l.toLong), List[Long](6l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sublist having minimum length.\n    def FindMin(lst : List[List[Any]]) : List[Any] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong))));\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 7l.toLong, 8l.toLong)))).equals((List[Any](1l.toLong, 1l.toLong))));\n    assert(FindMin((List[List[Any]](List[String](\"x\"), List[String](\"x\", \"y\"), List[String](\"x\", \"y\", \"z\")))).equals((List[Any](\"x\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to filter odd numbers.\n    def filterOddnumbers(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterOddnumbers((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(filterOddnumbers((List[Long](10l.toLong, 20l.toLong, 45l.toLong, 67l.toLong, 84l.toLong, 93l.toLong))).equals((List[Long](45l.toLong, 67l.toLong, 93l.toLong))));\n    assert(filterOddnumbers((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 3l.toLong))).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    def findAdverbs(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    def maxOfNth(test_list : List[List[Long]], N : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOfNth((List[List[Long]](List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](1l.toLong, 3l.toLong, 5l.toLong), List[Long](8l.toLong, 9l.toLong, 19l.toLong))), (2l)) == (19l));\n    assert(maxOfNth((List[List[Long]](List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong), List[Long](9l.toLong, 10l.toLong, 20l.toLong))), (1l)) == (10l));\n    assert(maxOfNth((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](3l.toLong, 5l.toLong, 7l.toLong), List[Long](10l.toLong, 11l.toLong, 21l.toLong))), (1l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    def decimalToBinary(n : Long) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    def combinationsColors(l : List[String], n : Long) : List[List[String]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (1l)).equals((List[List[String]](List[String](\"Red\"), List[String](\"Green\"), List[String](\"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (2l)).equals((List[List[String]](List[String](\"Red\", \"Red\"), List[String](\"Red\", \"Green\"), List[String](\"Red\", \"Blue\"), List[String](\"Green\", \"Green\"), List[String](\"Green\", \"Blue\"), List[String](\"Blue\", \"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (3l)).equals((List[List[String]](List[String](\"Red\", \"Red\", \"Red\"), List[String](\"Red\", \"Red\", \"Green\"), List[String](\"Red\", \"Red\", \"Blue\"), List[String](\"Red\", \"Green\", \"Green\"), List[String](\"Red\", \"Green\", \"Blue\"), List[String](\"Red\", \"Blue\", \"Blue\"), List[String](\"Green\", \"Green\", \"Green\"), List[String](\"Green\", \"Green\", \"Blue\"), List[String](\"Green\", \"Blue\", \"Blue\"), List[String](\"Blue\", \"Blue\", \"Blue\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from a string.\n    def removeAllSpaces(text : String) : String = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    def minSwaps(str1 : String, str2 : String) : Any = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Any(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Any(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Any(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a new tuple from the given string and list.\n    def newTuple(test_list : List[String], test_str : String) : Tuple2[String, String, String] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newTuple((List[String](\"WEB\", \"is\")), (\"best\")).equals(((\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((List[String](\"We\", \"are\")), (\"Developers\")).equals(((\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((List[String](\"Part\", \"is\")), (\"Wrong\")).equals(((\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    def findRemainder(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRemainder((List[Long](100l.toLong, 10l.toLong, 5l.toLong, 25l.toLong, 35l.toLong, 14l.toLong)), (11l)) == (9l));\n    assert(findRemainder((List[Long](1l.toLong, 1l.toLong, 1l.toLong)), (1l)) == (0l));\n    assert(findRemainder((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (2l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum value in a given heterogeneous list.\n    def minVal(listval : List[Either[String, Long]]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (2l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (15l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    def positiveCount(nums : List[Long]) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(positiveCount((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.54f));\n    assert(positiveCount((List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.69f));\n    assert(positiveCount((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add the given tuple to the given list.\n    def addTuple(test_list : List[Long], test_tup : Tuple2[Long, Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addTuple((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(addTuple((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 11l.toLong))));\n    assert(addTuple((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    def maxRunUppercase(test_str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    def sortMatrix(M : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](5l.toLong, 8l.toLong, 9l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](2l.toLong, 1l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](2l.toLong, 1l.toLong, 4l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](5l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    def countVowels(test_str : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    def maxSumIncreasingSubseq(a : List[Long], n : Long, index : Long, k : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((List[Long](11l.toLong, 15l.toLong, 19l.toLong, 21l.toLong, 26l.toLong, 28l.toLong, 31l.toLong)), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4408,7 +244,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find words that are longer than n characters from a given list of words.\n    def longWords(n : Long, str : String) : List[String] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longWords((3l), (\"python is a programming language\")).equals((List[String](\"python\", \"programming\", \"language\"))));\n    assert(longWords((2l), (\"writing a program\")).equals((List[String](\"writing\", \"program\"))));\n    assert(longWords((5l), (\"sorting list\")).equals((List[String](\"sorting\"))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4416,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    def findSum(arr : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    def magicSquareTest(my_matrix : List[List[Long]]) : Boolean = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (21l));\n    assert(findSum((List[Long](1l.toLong, 10l.toLong, 9l.toLong, 4l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 4l.toLong))) == (71l));\n    assert(findSum((List[Long](12l.toLong, 10l.toLong, 9l.toLong, 45l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 10l.toLong))) == (78l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(magicSquareTest((List[List[Long]](List[Long](7l.toLong, 12l.toLong, 1l.toLong, 14l.toLong), List[Long](2l.toLong, 13l.toLong, 8l.toLong, 11l.toLong), List[Long](16l.toLong, 3l.toLong, 10l.toLong, 5l.toLong), List[Long](9l.toLong, 6l.toLong, 15l.toLong, 4l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 8l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 7l.toLong)))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    def tupleToDict(test_tup : Tuple2[Long, Long, Long, Long, Long, Long]) : Map[Long,Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    def sortMatrix(M : List[List[Long]]) : List[List[Long]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToDict(((1l, 5l, 7l, 10l, 13l, 5l))).equals((Map[Long,Long](1l -> 5l, 7l -> 10l, 13l -> 5l))));\n    assert(tupleToDict(((1l, 2l, 3l, 4l, 5l, 6l))).equals((Map[Long,Long](1l -> 2l, 3l -> 4l, 5l -> 6l))));\n    assert(tupleToDict(((7l, 8l, 9l, 10l, 11l, 12l))).equals((Map[Long,Long](7l -> 8l, 9l -> 10l, 11l -> 12l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](5l.toLong, 8l.toLong, 9l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](2l.toLong, 1l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](2l.toLong, 1l.toLong, 4l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](5l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    def getCoordinates(test_tup : Tuple2[Long, Long]) : List[List[Long]] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    def maxOccurrences(nums : List[Long]) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getCoordinates(((3l, 4l))).equals((List[List[Long]](List[Long](2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong), List[Long](2l.toLong, 5l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](4l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong)))));\n    assert(getCoordinates(((4l, 5l))).equals((List[List[Long]](List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](5l.toLong, 4l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong)))));\n    assert(getCoordinates(((5l, 6l))).equals((List[List[Long]](List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](4l.toLong, 7l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](6l.toLong, 5l.toLong), List[Long](6l.toLong, 6l.toLong), List[Long](6l.toLong, 7l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    def checkType(test_tuple : Any) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkType((Any((5l, 6l, 7l, 3l, 5l, 6l)))) == (true));\n    assert(checkType((Any((1l, 2l, \"4\")))) == (false));\n    assert(checkType((Any((3l, 2l, 1l, 4l, 5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    def findFirstMissing(array : List[Long]) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 9l.toLong))) == (3l));\n    assert(findFirstMissing((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 9l.toLong))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is undulating or not.\n    def isUndulating(n : Long) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    def minK(test_list : List[Tuple2[String, Long]], K : Long) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minK((List[Tuple2[String, Long]]((\"Manjeet\", 10l), (\"Akshat\", 4l), (\"Akash\", 2l), (\"Nikhil\", 8l))), (2l)).equals((List[Tuple2[String, Long]]((\"Akash\", 2l), (\"Akshat\", 4l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"Sanjeev\", 11l), (\"Angat\", 5l), (\"Akash\", 3l), (\"Nepin\", 9l))), (3l)).equals((List[Tuple2[String, Long]]((\"Akash\", 3l), (\"Angat\", 5l), (\"Nepin\", 9l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"tanmay\", 14l), (\"Amer\", 11l), (\"Ayesha\", 9l), (\"SKD\", 16l))), (1l)).equals((List[Tuple2[String, Long]]((\"Ayesha\", 9l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    def countSubstrings(s : String) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth decagonal number.\n    def isNumDecagonal(n : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    def rearExtract(test_list : List[Tuple2[Long, String, Long]]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Rash\", 21l), (2l, \"Varsha\", 20l), (3l, \"Kil\", 19l)))).equals((List[Long](21l.toLong, 20l.toLong, 19l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sai\", 36l), (2l, \"Ayesha\", 25l), (3l, \"Salman\", 45l)))).equals((List[Long](36l.toLong, 25l.toLong, 45l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sudeep\", 14l), (2l, \"Vandana\", 36l), (3l, \"Dawood\", 56l)))).equals((List[Long](14l.toLong, 36l.toLong, 56l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the closest smaller number than n.\n    def closestNum(N : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    def findCombinations(test_list : List[Tuple2[Long, Long]]) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findCombinations((List[Tuple2[Long, Long]]((2l, 4l), (6l, 7l), (5l, 1l), (6l, 10l)))).equals((List[Tuple2[Long, Long]]((8l, 11l), (7l, 5l), (8l, 14l), (11l, 8l), (12l, 17l), (11l, 11l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((3l, 5l), (7l, 8l), (6l, 2l), (7l, 11l)))).equals((List[Tuple2[Long, Long]]((10l, 13l), (9l, 7l), (10l, 16l), (13l, 10l), (14l, 19l), (13l, 13l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((4l, 6l), (8l, 9l), (7l, 3l), (8l, 12l)))).equals((List[Tuple2[Long, Long]]((12l, 15l), (11l, 9l), (12l, 18l), (15l, 12l), (16l, 21l), (15l, 15l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    def maxAverageOfPath(cost : List[List[Long]]) : Float = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](7l.toLong, 3l.toLong, 9l.toLong)))) == (5.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 4l.toLong), List[Long](7l.toLong, 6l.toLong, 5l.toLong), List[Long](8l.toLong, 4l.toLong, 10l.toLong)))) == (6.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](8l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 11l.toLong)))) == (7.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    def sequentialSearch(dlist : List[Long], item : Long) : Tuple2[Boolean, Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequentialSearch((List[Long](11l.toLong, 23l.toLong, 58l.toLong, 31l.toLong, 56l.toLong, 77l.toLong, 43l.toLong, 12l.toLong, 65l.toLong, 19l.toLong)), (31l)).equals(((true, 3l))));\n    assert(sequentialSearch((List[Long](12l.toLong, 32l.toLong, 45l.toLong, 62l.toLong, 35l.toLong, 47l.toLong, 44l.toLong, 61l.toLong)), (61l)).equals(((true, 7l))));\n    assert(sequentialSearch((List[Long](9l.toLong, 10l.toLong, 17l.toLong, 19l.toLong, 22l.toLong, 39l.toLong, 48l.toLong, 56l.toLong)), (48l)).equals(((true, 6l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove odd numbers from a given list.\n    def removeOdd(l : List[Long]) : List[Long] = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong))));\n    assert(removeOdd((List[Long](2l.toLong, 4l.toLong, 6l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(removeOdd((List[Long](10l.toLong, 20l.toLong, 3l.toLong))).equals((List[Long](10l.toLong, 20l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    def isProductEven(arr : List[Long]) : Boolean = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the maximum of two numbers.\n    def maximum(a : Long, b : Long) : Long = {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 5l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 1l.toLong, 2l.toLong))) == (2l));\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 15l.toLong, 14l.toLong, 10l.toLong, 12l.toLong, 13l.toLong, 16l.toLong, 18l.toLong))) == (8l));\n    assert(maxOccurrences((List[Long](10l.toLong, 20l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 90l.toLong, 80l.toLong, 50l.toLong, 30l.toLong, 20l.toLong, 50l.toLong, 10l.toLong))) == (20l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4624,9 +292,597 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to reverse only the vowels of a given string (where y is not a vowel).\n    def reverseVowels(str1 : String) : String = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseVowels((\"Python\")).equals((\"Python\")));\n    assert(reverseVowels((\"USA\")).equals((\"ASU\")));\n    assert(reverseVowels((\"ab\")).equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a string.\n    def tupString(tup1 : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupString((List[String](\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"))).equals((\"exercises\")));\n    assert(tupString((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))).equals((\"python\")));\n    assert(tupString((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))).equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    def sumNegativenum(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumNegativenum((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (-32l));\n    assert(sumNegativenum((List[Long](10l.toLong, 15l.toLong, -14l.toLong, 13l.toLong, -18l.toLong, 12l.toLong, -20l.toLong))) == (-52l));\n    assert(sumNegativenum((List[Long](19l.toLong, -65l.toLong, 57l.toLong, 39l.toLong, 152l.toLong, -639l.toLong, 121l.toLong, 44l.toLong, 90l.toLong, -190l.toLong))) == (-894l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth hexagonal number.\n    def hexagonalNum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    def isSumOfPowersOfTwo(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def pancakeSort(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pancakeSort((List[Long](15l.toLong, 79l.toLong, 25l.toLong, 38l.toLong, 69l.toLong))).equals((List[Long](15l.toLong, 25l.toLong, 38l.toLong, 69l.toLong, 79l.toLong))));\n    assert(pancakeSort((List[Long](98l.toLong, 12l.toLong, 54l.toLong, 36l.toLong, 85l.toLong))).equals((List[Long](12l.toLong, 36l.toLong, 54l.toLong, 85l.toLong, 98l.toLong))));\n    assert(pancakeSort((List[Long](41l.toLong, 42l.toLong, 32l.toLong, 12l.toLong, 23l.toLong))).equals((List[Long](12l.toLong, 23l.toLong, 32l.toLong, 41l.toLong, 42l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    def countSamepair(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (3l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (4l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find number of lists present in the given list.\n    def findLists(Input : List[Any]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (2l));\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (3l));\n    assert(findLists((List[Any](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the maximum difference between any two elements in a given array.\n    def maxAbsDiff(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAbsDiff((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 3l.toLong))) == (4l));\n    assert(maxAbsDiff((List[Long](9l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (8l));\n    assert(maxAbsDiff((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the volume of a triangular prism.\n    def findVolume(l : Long, b : Long, h : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    def findSolution(a : Long, b : Long, n : Long) : Option[Tuple2[Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSolution((2l), (3l), (7l)).equals(Some((2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(None));\n    assert(findSolution((1l), (13l), (17l)).equals(Some((4l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    def removeElements(list1 : List[Long], list2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](5l.toLong, 7l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    def sumSeries(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    def areEquivalent(num1 : Long, num2 : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    def countCharPosition(str1 : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    def findEvenPair(A : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findEvenPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong))) == (4l));\n    assert(findEvenPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong))) == (9l));\n    assert(findEvenPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the smallest power of 2 greater than or equal to n.\n    def nextPowerOf2(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    def frequency(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l)) == (0l));\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)), (3l)) == (3l));\n    assert(frequency((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong)), (1l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    def textLowercaseUnderscore(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    def sumRangeList(list1 : List[Long], m : Long, n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (8l), (10l)) == (29l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (5l), (7l)) == (16l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (7l), (10l)) == (38l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    def perimeterPentagon(a : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    def countOccurance(s : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    def squarePerimeter(a : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    def removeDirtyChars(string : String, second_string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether a given array of integers contains any duplicate element.\n    def testDuplicate(arraynums : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(testDuplicate((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given number is woodball or not.\n    def isWoodall(x : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    def checkType(test_tuple : Any) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkType((Any((5l, 6l, 7l, 3l, 5l, 6l)))) == (true));\n    assert(checkType((Any((1l, 2l, \"4\")))) == (false));\n    assert(checkType((Any((3l, 2l, 1l, 4l, 5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n    def isMajority(arr : List[Long], n : Long, x : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMajority((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 10l.toLong)), (7l), (3l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 6l.toLong, 6l.toLong)), (8l), (4l)) == (false));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n    def countSetBits(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove the characters which have odd index values of a given string.\n    def oddValuesString(str : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum of three numbers.\n    def minOfThree(a : Long, b : Long, c : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether all the bits are unset in the given range or not.\n    def allBitsSetInTheGivenRange(n : Long, l : Long, r : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    def reArrangeArray(arr : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reArrangeArray((List[Long](-1l.toLong, 2l.toLong, -3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -7l.toLong, 8l.toLong, 9l.toLong)), (9l)).equals((List[Long](-1l.toLong, -3l.toLong, -7l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(reArrangeArray((List[Long](12l.toLong, -14l.toLong, -26l.toLong, 13l.toLong, 15l.toLong)), (5l)).equals((List[Long](-14l.toLong, -26l.toLong, 12l.toLong, 13l.toLong, 15l.toLong))));\n    assert(reArrangeArray((List[Long](10l.toLong, 24l.toLong, 36l.toLong, -42l.toLong, -39l.toLong, -78l.toLong, 85l.toLong)), (7l)).equals((List[Long](-42l.toLong, -39l.toLong, -78l.toLong, 10l.toLong, 24l.toLong, 36l.toLong, 85l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    def replaceBlank(str1 : String, char : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the volume of a cube given its side length.\n    def volumeCube(l : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\n    def checkOccurences(test_list : List[Tuple2[Long, Long]]) : Map[Tuple2[Long, Long],Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkOccurences((List[Tuple2[Long, Long]]((3l, 1l), (1l, 3l), (2l, 5l), (5l, 2l), (6l, 3l)))).equals((Map[Tuple2[Long, Long],Long]((1l, 3l) -> 2l, (2l, 5l) -> 2l, (3l, 6l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((4l, 2l), (2l, 4l), (3l, 6l), (6l, 3l), (7l, 4l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 4l) -> 2l, (3l, 6l) -> 2l, (4l, 7l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((13l, 2l), (11l, 23l), (12l, 25l), (25l, 12l), (16l, 23l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 13l) -> 1l, (11l, 23l) -> 1l, (12l, 25l) -> 2l, (16l, 23l) -> 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of non-empty substrings of a given string.\n    def numberOfSubstrings(str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    def getTotalNumberOfSequences(m : Long, n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    def replaceList(list1 : List[Any], list2 : List[Any]) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceList((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong)), (List[Any](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](\"red\", \"blue\", \"green\")), (List[Any](\"yellow\"))).equals((List[Any](\"red\", \"blue\", \"yellow\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the total number of characters in a string.\n    def countCharac(str1 : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the next perfect square greater than a given number.\n    def nextPerfectSquare(N : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n    def maxSum(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSum((List[Long](1l.toLong, 15l.toLong, 51l.toLong, 45l.toLong, 33l.toLong, 100l.toLong, 12l.toLong, 18l.toLong, 9l.toLong))) == (194l));\n    assert(maxSum((List[Long](80l.toLong, 60l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 10l.toLong))) == (210l));\n    assert(maxSum((List[Long](2l.toLong, 3l.toLong, 14l.toLong, 16l.toLong, 21l.toLong, 23l.toLong, 29l.toLong, 30l.toLong))) == (138l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    def lps(str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the intersection of two arrays.\n    def intersectionArray(array_nums1 : List[Long], array_nums2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Long](10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    def countX(tup : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (4l)) == (0l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (10l)) == (3l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (8l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    def insertElement(list : List[String], element : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(insertElement((List[String](\"Red\", \"Green\", \"Black\")), (\"c\")).equals((List[String](\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"))));\n    assert(insertElement((List[String](\"python\", \"java\")), (\"program\")).equals((List[String](\"program\", \"python\", \"program\", \"java\"))));\n    assert(insertElement((List[String](\"happy\", \"sad\")), (\"laugh\")).equals((List[String](\"laugh\", \"happy\", \"laugh\", \"sad\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert complex numbers to polar coordinates.\n    def convert(numbers : Long) : Tuple2[Float, Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convert((1l)).equals(((1.0f, 0.0f))));\n    assert(convert((4l)).equals(((4.0f, 0.0f))));\n    assert(convert((5l)).equals(((5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    def combinationsColors(l : List[String], n : Long) : List[List[String]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (1l)).equals((List[List[String]](List[String](\"Red\"), List[String](\"Green\"), List[String](\"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (2l)).equals((List[List[String]](List[String](\"Red\", \"Red\"), List[String](\"Red\", \"Green\"), List[String](\"Red\", \"Blue\"), List[String](\"Green\", \"Green\"), List[String](\"Green\", \"Blue\"), List[String](\"Blue\", \"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (3l)).equals((List[List[String]](List[String](\"Red\", \"Red\", \"Red\"), List[String](\"Red\", \"Red\", \"Green\"), List[String](\"Red\", \"Red\", \"Blue\"), List[String](\"Red\", \"Green\", \"Green\"), List[String](\"Red\", \"Green\", \"Blue\"), List[String](\"Red\", \"Blue\", \"Blue\"), List[String](\"Green\", \"Green\", \"Green\"), List[String](\"Green\", \"Green\", \"Blue\"), List[String](\"Green\", \"Blue\", \"Blue\"), List[String](\"Blue\", \"Blue\", \"Blue\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    def countPrimesNums(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    def swapNumbers(a : Long, b : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapNumbers((10l), (20l)).equals((List[Long](20l.toLong, 10l.toLong))));\n    assert(swapNumbers((15l), (17l)).equals((List[Long](17l.toLong, 15l.toLong))));\n    assert(swapNumbers((100l), (200l)).equals((List[Long](200l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4636,7 +892,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to maximize the given two lists.\n    def maximizeElements(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximizeElements((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 9l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 10l.toLong)))));\n    assert(maximizeElements((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](5l.toLong, 10l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 11l.toLong)))));\n    assert(maximizeElements((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](6l.toLong, 11l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](9l.toLong, 12l.toLong)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4644,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    def evenPosition(nums : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    def newmanPrime(n : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPosition((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(evenPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    assert(evenPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    def checkChar(string : String) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    def divisionElements(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisionElements(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((2l, 2l, 2l, 3l))));\n    assert(divisionElements(((12l, 6l, 8l, 16l)), ((6l, 3l, 4l, 4l))).equals(((2l, 2l, 2l, 4l))));\n    assert(divisionElements(((20l, 14l, 36l, 18l)), ((5l, 7l, 6l, 9l))).equals(((4l, 2l, 6l, 2l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of even factors of a number.\n    def sumofFactors(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    def splitTwoParts(list1 : List[Any], L : Long) : Any = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitTwoParts((List[Any](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((Any(1l.toLong, 1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)))));\n    assert(splitTwoParts((List[Any](\"a\", \"b\", \"c\", \"d\")), (2l)).equals((Any(\"a\", \"b\"), List[String](\"c\", \"d\")))));\n    assert(splitTwoParts((List[Any](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")), (4l)).equals((Any(\"p\", \"y\", \"t\", \"h\"), List[String](\"o\", \"n\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    def lateralsurfaceCone(r : Long, h : Long) : Float = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    def dogAge(h_age : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    def countPairs(arr : List[Long], n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    def listSplit(S : List[Any], step : Long) : List[List[Any]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (3l)) == (2l));\n    assert(countPairs((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (4l)) == (0l));\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (5l)) == (10l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listSplit((List[Any](\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\")), (3l)).equals((List[List[Any]](List[String](\"a\", \"d\", \"g\", \"j\", \"m\"), List[String](\"b\", \"e\", \"h\", \"k\", \"n\"), List[String](\"c\", \"f\", \"i\", \"l\")))));\n    assert(listSplit((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (3l)).equals((List[List[Any]](List[Long](1l.toLong, 4l.toLong, 7l.toLong, 10l.toLong, 13l.toLong), List[Long](2l.toLong, 5l.toLong, 8l.toLong, 11l.toLong, 14l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 12l.toLong)))));\n    assert(listSplit((List[Any](\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\")), (2l)).equals((List[List[Any]](List[String](\"python\", \"C\", \"DBMS\"), List[String](\"java\", \"C++\", \"SQL\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    def findFirstOccurrence(A : List[Long], x : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    def lateralsurfaceCube(l : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstOccurrence((List[Long](2l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (1l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (2l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (6l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4720,9 +976,729 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    def squareSum(n : Long) : Long = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (10l));\n    assert(squareSum((3l)) == (35l));\n    assert(squareSum((4l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th star number.\n    def findStarNum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ascii value of a character.\n    def asciiValue(k : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of even numbers at even positions of a list.\n    def sumEvenAndEvenIndex(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong, 18l.toLong, 8l.toLong))) == (30l));\n    assert(sumEvenAndEvenIndex((List[Long](3l.toLong, 20l.toLong, 17l.toLong, 9l.toLong, 2l.toLong, 10l.toLong, 18l.toLong, 13l.toLong, 6l.toLong, 18l.toLong))) == (26l));\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    def evenPowerSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    def rearExtract(test_list : List[Tuple2[Long, String, Long]]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Rash\", 21l), (2l, \"Varsha\", 20l), (3l, \"Kil\", 19l)))).equals((List[Long](21l.toLong, 20l.toLong, 19l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sai\", 36l), (2l, \"Ayesha\", 25l), (3l, \"Salman\", 45l)))).equals((List[Long](36l.toLong, 25l.toLong, 45l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sudeep\", 14l), (2l, \"Vandana\", 36l), (3l, \"Dawood\", 56l)))).equals((List[Long](14l.toLong, 36l.toLong, 56l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    def substractElements(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Tuple2[Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(substractElements(((10l, 4l, 5l)), ((2l, 5l, 18l))).equals(((8l, -1l, -13l))));\n    assert(substractElements(((11l, 2l, 3l)), ((24l, 45l, 16l))).equals(((-13l, -43l, -13l))));\n    assert(substractElements(((7l, 18l, 9l)), ((10l, 11l, 12l))).equals(((-3l, 7l, -3l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    def evenBinomialCoeffSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\n    def dictFilter(dict : Map[String,Long], n : Long) : Map[String,Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (170l)).equals((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (180l)).equals((Map[String,Long](\"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (190l)).equals((Map[String,Long](\"Pierre Cox\" -> 190l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of elements that occurs before the list element in the given tuple.\n    def countFirstElements(test_tup : List[Either[Long, Tuple2[Long, Long]]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](1l, 5l, 7l, (4l, 6l), 10l))) == (3l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](2l, 9l, (5l, 7l), 11l))) == (2l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](11l, 15l, 5l, 8l, (2l, 3l), 8l))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth decagonal number.\n    def isNumDecagonal(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n    def sequentialSearch(dlist : List[Long], item : Long) : Tuple2[Boolean, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequentialSearch((List[Long](11l.toLong, 23l.toLong, 58l.toLong, 31l.toLong, 56l.toLong, 77l.toLong, 43l.toLong, 12l.toLong, 65l.toLong, 19l.toLong)), (31l)).equals(((true, 3l))));\n    assert(sequentialSearch((List[Long](12l.toLong, 32l.toLong, 45l.toLong, 62l.toLong, 35l.toLong, 47l.toLong, 44l.toLong, 61l.toLong)), (61l)).equals(((true, 7l))));\n    assert(sequentialSearch((List[Long](9l.toLong, 10l.toLong, 17l.toLong, 19l.toLong, 22l.toLong, 39l.toLong, 48l.toLong, 56l.toLong)), (48l)).equals(((true, 6l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check if the elements of a given list are unique or not.\n    def allUnique(test_list : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to subtract two lists element-wise.\n    def subList(nums1 : List[Long], nums2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](-3l.toLong, -3l.toLong, -3l.toLong))));\n    assert(subList((List[Long](1l.toLong, 2l.toLong)), (List[Long](3l.toLong, 4l.toLong))).equals((List[Long](-2l.toLong, -2l.toLong))));\n    assert(subList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Long](40l.toLong, 50l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    def validate(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    def checkElement(list : List[Any], element : Any) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkElement((List[Any](\"green\", \"orange\", \"black\", \"white\")), (Any(\"blue\"))) == (false));\n    assert(checkElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (Any(7l))) == (false));\n    assert(checkElement((List[Any](\"green\", \"green\", \"green\", \"green\")), (Any(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    def textMatchTwoThree(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n    def maxSubArraySumRepeated(a : List[Long], n : Long, k : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySumRepeated((List[Long](10l.toLong, 20l.toLong, -30l.toLong, -1l.toLong)), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, 10l.toLong, 20l.toLong)), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)), (3l), (3l)) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    def squareSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    def maxLength(list1 : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLength((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](1l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))).equals(((4l, List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](5l.toLong), List[Long](15l.toLong, 20l.toLong, 25l.toLong)))).equals(((3l, List[Long](15l.toLong, 20l.toLong, 25l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    def countNoOfWays(n : Long, k : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n    def find(n : Long, m : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the third side of a right angled triangle.\n    def othersideRightangle(w : Long, h : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == 5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum value in a given heterogeneous list.\n    def maxVal(listval : List[Either[String, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (5l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (25l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (50l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return the sum of all divisors of a number.\n    def sumDiv(number : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count inversions in an array.\n    def getInvCount(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getInvCount((List[Long](1l.toLong, 20l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))) == (5l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a given nested list structure.\n    def flattenList(list1 : List[Either[Long, List[Long]]]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flattenList((List[Either[Long, List[Long]]](0l, 10l, List[Long](20l.toLong, 30l.toLong), 40l, 50l, List[Long](60l.toLong, 70l.toLong, 80l.toLong), List[Long](90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong)))).equals((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong, 80l.toLong, 90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](10l.toLong, 20l.toLong), List[Long](40l.toLong), List[Long](30l.toLong, 56l.toLong, 25l.toLong), List[Long](10l.toLong, 20l.toLong), List[Long](33l.toLong), List[Long](40l.toLong)))).equals((List[Long](10l.toLong, 20l.toLong, 40l.toLong, 30l.toLong, 56l.toLong, 25l.toLong, 10l.toLong, 20l.toLong, 33l.toLong, 40l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    def maxAggregate(stdata : List[Tuple2[String, Long]]) : Tuple2[String, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 90l), (\"Sabah Colley\", 88l), (\"Peter Nichols\", 7l), (\"Juan Whelan\", 122l), (\"Sabah Colley\", 84l)))).equals(((\"Juan Whelan\", 212l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 50l), (\"Sabah Colley\", 48l), (\"Peter Nichols\", 37l), (\"Juan Whelan\", 22l), (\"Sabah Colley\", 14l)))).equals(((\"Juan Whelan\", 72l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 10l), (\"Sabah Colley\", 20l), (\"Peter Nichols\", 30l), (\"Juan Whelan\", 40l), (\"Sabah Colley\", 50l)))).equals(((\"Sabah Colley\", 70l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find element at a given index after number of rotations.\n    def findElement(arr : List[Long], ranges : List[List[Long]], rotations : Long, index : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[List[Long]](List[Long](0l.toLong, 2l.toLong), List[Long](0l.toLong, 3l.toLong))), (2l), (1l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (2l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    def startWithp(words : List[String]) : Tuple2[String, String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startWithp((List[String](\"Python PHP\", \"Java JavaScript\", \"c c++\"))).equals(((\"Python\", \"PHP\"))));\n    assert(startWithp((List[String](\"Python Programming\", \"Java Programming\"))).equals(((\"Python\", \"Programming\"))));\n    assert(startWithp((List[String](\"Pqrst Pqr\", \"qrstuv\"))).equals(((\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    def maxSumIncreasingSubseq(a : List[Long], n : Long, index : Long, k : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((List[Long](11l.toLong, 15l.toLong, 19l.toLong, 21l.toLong, 26l.toLong, 28l.toLong, 31l.toLong)), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    def largeProduct(nums1 : List[Long], nums2 : List[Long], N : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (3l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (4l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (5l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong, 45l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the maximum of two numbers.\n    def maximum(a : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given string to a list of characters.\n    def stringToTuple(str1 : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToTuple((\"python 3.0\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"))));\n    assert(stringToTuple((\"item1\")).equals((List[String](\"i\", \"t\", \"e\", \"m\", \"1\"))));\n    assert(stringToTuple((\"15.10\")).equals((List[String](\"1\", \"5\", \".\", \"1\", \"0\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the highest power of 2 that is less than or equal to n.\n    def highestPowerOf2(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th lucas number.\n    def findLucas(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    def addString(list_ : List[Any], string : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addString((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (\"temp{0}\")).equals((List[String](\"temp1\", \"temp2\", \"temp3\", \"temp4\"))));\n    assert(addString((List[Any](\"a\", \"b\", \"c\", \"d\")), (\"python{0}\")).equals((List[String](\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"))));\n    assert(addString((List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (\"string{0}\")).equals((List[String](\"string5\", \"string6\", \"string7\", \"string8\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert more than one list to nested dictionary.\n    def convertListDictionary(l1 : List[String], l2 : List[String], l3 : List[Long]) : List[Map[String,Map[String,Long]]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convertListDictionary((List[String](\"S001\", \"S002\", \"S003\", \"S004\")), (List[String](\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\")), (List[Long](85l.toLong, 98l.toLong, 89l.toLong, 92l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"S001\" -> Map[String,Long](\"Adina Park\" -> 85l)), Map[String,Map[String,Long]](\"S002\" -> Map[String,Long](\"Leyton Marsh\" -> 98l)), Map[String,Map[String,Long]](\"S003\" -> Map[String,Long](\"Duncan Boyle\" -> 89l)), Map[String,Map[String,Long]](\"S004\" -> Map[String,Long](\"Saim Richards\" -> 92l))))));\n    assert(convertListDictionary((List[String](\"abc\", \"def\", \"ghi\", \"jkl\")), (List[String](\"python\", \"program\", \"language\", \"programs\")), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"abc\" -> Map[String,Long](\"python\" -> 100l)), Map[String,Map[String,Long]](\"def\" -> Map[String,Long](\"program\" -> 200l)), Map[String,Map[String,Long]](\"ghi\" -> Map[String,Long](\"language\" -> 300l)), Map[String,Map[String,Long]](\"jkl\" -> Map[String,Long](\"programs\" -> 400l))))));\n    assert(convertListDictionary((List[String](\"A1\", \"A2\", \"A3\", \"A4\")), (List[String](\"java\", \"C\", \"C++\", \"DBMS\")), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"A1\" -> Map[String,Long](\"java\" -> 10l)), Map[String,Map[String,Long]](\"A2\" -> Map[String,Long](\"C\" -> 20l)), Map[String,Map[String,Long]](\"A3\" -> Map[String,Long](\"C++\" -> 30l)), Map[String,Map[String,Long]](\"A4\" -> Map[String,Long](\"DBMS\" -> 40l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    def getMaxSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list with maximum length.\n    def maxLengthList(input_list : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLengthList((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong)))).equals(((5l, List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong)))).equals(((4l, List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if given list contains no duplicates.\n    def checkDistinct(test_tup : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong, 4l.toLong))) == (false));\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkDistinct((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first non-repeated character in a given string.\n    def firstNonRepeatingCharacter(str1 : String) : Option[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(None));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Some(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Some(\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    def checkChar(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of three numbers.\n    def medianNumbers(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    def sumOfDigits(nums : List[Any]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfDigits((List[Any](10l.toLong, 2l.toLong, 56l.toLong))) == (14l));\n    assert(sumOfDigits((List[Any](List[Any](10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))) == (19l));\n    assert(sumOfDigits((List[Any](10l.toLong, 20l.toLong, -4l.toLong, 5l.toLong, -70l.toLong))) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    def bitwiseXor(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bitwiseXor(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((15l, 6l, 5l, 10l))));\n    assert(bitwiseXor(((11l, 5l, 7l, 10l)), ((6l, 3l, 4l, 4l))).equals(((13l, 6l, 3l, 14l))));\n    assert(bitwiseXor(((12l, 6l, 8l, 11l)), ((7l, 4l, 5l, 6l))).equals(((11l, 2l, 13l, 13l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to identify non-prime numbers.\n    def isNotPrime(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    def extractFreq(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractFreq((List[Tuple2[Long, Long]]((3l, 4l), (1l, 2l), (4l, 3l), (5l, 6l)))) == (3l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((4l, 15l), (2l, 3l), (5l, 4l), (6l, 7l)))) == (4l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((5l, 16l), (2l, 3l), (6l, 5l), (6l, 9l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    def addNestedTuples(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addNestedTuples((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 10l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 13l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](9l.toLong, 12l.toLong), List[Long](9l.toLong, 16l.toLong), List[Long](5l.toLong, 12l.toLong), List[Long](10l.toLong, 15l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](11l.toLong, 14l.toLong), List[Long](11l.toLong, 18l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](12l.toLong, 17l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum of two numbers.\n    def minimum(a : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether an element exists within a tuple.\n    def checkTuplex(tuplex : List[Either[String, Long]], tuple1 : Any) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"r\"))) == (true));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"5\"))) == (false));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(3l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find whether the parity of a given number is odd.\n    def findParity(x : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    def rearrangeBigger(n : Long) : Any = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearrangeBigger((12l)).equals((Any(21l))));\n    assert(rearrangeBigger((10l)).equals((Any(false))));\n    assert(rearrangeBigger((102l)).equals((Any(120l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n    def kSmallestPairs(nums1 : List[Long], nums2 : List[Long], k : Long) : List[List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (2l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (1l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (7l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](3l.toLong, 2l.toLong), List[Long](1l.toLong, 6l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](7l.toLong, 2l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    def minProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (8l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (30l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum value in a given heterogeneous list.\n    def minVal(listval : List[Either[String, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (2l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (15l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (20l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove odd numbers from a given list.\n    def removeOdd(l : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong))));\n    assert(removeOdd((List[Long](2l.toLong, 4l.toLong, 6l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(removeOdd((List[Long](10l.toLong, 20l.toLong, 3l.toLong))).equals((List[Long](10l.toLong, 20l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    def extractNthElement(list1 : List[Tuple2[String, Long, Long]], n : Long) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (0l)).equals((List[Any](\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (2l)).equals((List[Any](99l.toLong, 96l.toLong, 94l.toLong, 98l.toLong))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (1l)).equals((List[Any](98l.toLong, 97l.toLong, 91l.toLong, 94l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether any value in a sequence exists in a sequence or not.\n    def overlapping(list1 : List[Long], list2 : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 4l.toLong, 5l.toLong)), (List[Long](1l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find a pair with highest product from a given array of integers.\n    def maxProduct(arr : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 0l.toLong, 8l.toLong, 4l.toLong))).equals(((7l, 8l))));\n    assert(maxProduct((List[Long](0l.toLong, -1l.toLong, -2l.toLong, -4l.toLong, 5l.toLong, 0l.toLong, -6l.toLong))).equals(((-4l, -6l))));\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals(((2l, 3l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4732,7 +1708,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find common first element in given list of lists.\n    def groupTuples(Input : List[List[String]]) : List[List[String]] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(groupTuples((List[List[String]](List[String](\"x\", \"y\"), List[String](\"x\", \"z\"), List[String](\"w\", \"t\")))).equals((List[List[String]](List[String](\"x\", \"y\", \"z\"), List[String](\"w\", \"t\")))));\n    assert(groupTuples((List[List[String]](List[String](\"a\", \"b\"), List[String](\"a\", \"c\"), List[String](\"d\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\", \"c\"), List[String](\"d\", \"e\")))));\n    assert(groupTuples((List[List[String]](List[String](\"f\", \"g\"), List[String](\"f\", \"g\"), List[String](\"h\", \"i\")))).equals((List[List[String]](List[String](\"f\", \"g\", \"g\"), List[String](\"h\", \"i\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4740,13 +1716,3037 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three lists into a single sorted list.\n    def mergeSortedList(num1 : List[Long], num2 : List[Long], num3 : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the element of a list having maximum length.\n    def FindMax(lst : List[List[Any]]) : List[Any] = {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeSortedList((List[Long](25l.toLong, 24l.toLong, 15l.toLong, 4l.toLong, 5l.toLong, 29l.toLong, 110l.toLong)), (List[Long](19l.toLong, 20l.toLong, 11l.toLong, 56l.toLong, 25l.toLong, 233l.toLong, 154l.toLong)), (List[Long](24l.toLong, 26l.toLong, 54l.toLong, 48l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 11l.toLong, 15l.toLong, 19l.toLong, 20l.toLong, 24l.toLong, 24l.toLong, 25l.toLong, 25l.toLong, 26l.toLong, 29l.toLong, 48l.toLong, 54l.toLong, 56l.toLong, 110l.toLong, 154l.toLong, 233l.toLong))));\n    assert(mergeSortedList((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (List[Long](2l.toLong, 5l.toLong, 7l.toLong, 11l.toLong)), (List[Long](1l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 12l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    assert(mergeSortedList((List[Long](18l.toLong, 14l.toLong, 10l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong)), (List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong)), (List[Long](12l.toLong, 74l.toLong, 9l.toLong, 50l.toLong, 61l.toLong, 41l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 14l.toLong, 18l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 41l.toLong, 50l.toLong, 58l.toLong, 61l.toLong, 65l.toLong, 74l.toLong, 75l.toLong, 85l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMax((List[List[Any]](List[String](\"A\"), List[String](\"A\", \"B\"), List[String](\"A\", \"B\", \"C\")))).equals((List[Any](\"A\", \"B\", \"C\"))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong)))).equals((List[Any](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n    def roundAndSum(list1 : List[Either[Float, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundAndSum((List[Either[Float, Long]](22.4f.toFloat, 4.0f.toFloat, -16.22f.toFloat, -9.1f.toFloat, 11.0f.toFloat, -12.22f.toFloat, 14.2f.toFloat, -5.2f.toFloat, 17.5f.toFloat))) == (243l));\n    assert(roundAndSum((List[Either[Float, Long]](5l.toLong, 2l.toLong, 9l.toLong, 24.3f.toLong, 29l.toLong))) == (345l));\n    assert(roundAndSum((List[Either[Float, Long]](25.0f.toFloat, 56.7f.toFloat, 89.2f.toFloat))) == (513l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the cube sum of first n even natural numbers.\n    def cubeSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    def concatenateTuple(test_tup : Tuple2[String, String, Long, String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenateTuple(((\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple(((\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple(((\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the average of cubes of first n natural numbers.\n    def findAverageOfCube(n : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == 12l);\n    assert(findAverageOfCube((1l)) == 1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    def extractRear(test_tuple : Tuple2[String, String, String]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractRear(((\"Mers\", \"for\", \"Vers\"))).equals((List[String](\"s\", \"r\", \"s\"))));\n    assert(extractRear(((\"Avenge\", \"for\", \"People\"))).equals((List[String](\"e\", \"r\", \"e\"))));\n    assert(extractRear(((\"Gotta\", \"get\", \"go\"))).equals((List[String](\"a\", \"t\", \"o\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    def countElementInList(list1 : List[List[Any]], x : Any) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countElementInList((List[List[Any]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](1l.toLong, 11l.toLong), List[Long](1l.toLong, 15l.toLong, 7l.toLong))), (Any(1l))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"A\"))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"E\"))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to filter odd numbers.\n    def filterOddnumbers(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterOddnumbers((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(filterOddnumbers((List[Long](10l.toLong, 20l.toLong, 45l.toLong, 67l.toLong, 84l.toLong, 93l.toLong))).equals((List[Long](45l.toLong, 67l.toLong, 93l.toLong))));\n    assert(filterOddnumbers((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 3l.toLong))).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    def changeDateFormat(dt : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given array by using shell sort.\n    def shellSort(my_list : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(shellSort((List[Long](12l.toLong, 23l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 2l.toLong, 12l.toLong, 81l.toLong, 56l.toLong, 95l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 12l.toLong, 12l.toLong, 23l.toLong, 56l.toLong, 81l.toLong, 95l.toLong))));\n    assert(shellSort((List[Long](24l.toLong, 22l.toLong, 39l.toLong, 34l.toLong, 87l.toLong, 73l.toLong, 68l.toLong))).equals((List[Long](22l.toLong, 24l.toLong, 34l.toLong, 39l.toLong, 68l.toLong, 73l.toLong, 87l.toLong))));\n    assert(shellSort((List[Long](32l.toLong, 30l.toLong, 16l.toLong, 96l.toLong, 82l.toLong, 83l.toLong, 74l.toLong))).equals((List[Long](16l.toLong, 30l.toLong, 32l.toLong, 74l.toLong, 82l.toLong, 83l.toLong, 96l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    def andTuples(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(andTuples(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((0l, 0l, 2l, 1l))));\n    assert(andTuples(((1l, 2l, 3l, 4l)), ((5l, 6l, 7l, 8l))).equals(((1l, 2l, 3l, 0l))));\n    assert(andTuples(((8l, 9l, 11l, 12l)), ((7l, 13l, 14l, 17l))).equals(((0l, 9l, 10l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the directrix of a parabola.\n    def parabolaDirectrix(a : Long, b : Long, c : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    def commonElement(list1 : List[Any], list2 : List[Any]) : Option[Boolean] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(Some(true)));\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(None));\n    assert(commonElement((List[Any](\"a\", \"b\", \"c\")), (List[Any](\"d\", \"b\", \"e\"))).equals(Some(true)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median length of a trapezium.\n    def medianTrapezium(base1 : Long, base2 : Long, height : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianTrapezium((15l), (25l), (35l)) == 20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == 15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given array.\n    def checkGreater(arr : List[Long], number : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkGreater((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (4l)) == (false));\n    assert(checkGreater((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (8l)) == (true));\n    assert(checkGreater((List[Long](9l.toLong, 7l.toLong, 4l.toLong, 8l.toLong, 6l.toLong, 1l.toLong)), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    def textMatchOne(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last digit of a given number.\n    def lastDigit(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to return the negative numbers in a list.\n    def negNos(list1 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(negNos((List[Long](-1l.toLong, 4l.toLong, 5l.toLong, -6l.toLong))).equals((List[Long](-1l.toLong, -6l.toLong))));\n    assert(negNos((List[Long](-1l.toLong, -2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](-1l.toLong, -2l.toLong))));\n    assert(negNos((List[Long](-7l.toLong, -6l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](-7l.toLong, -6l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove odd characters in a string.\n    def removeOdd(str1 : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count bidirectional tuple pairs.\n    def countBidirectional(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (3l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 3l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (2l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 2l), (6l, 5l), (2l, 1l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    def multipleToSingle(L : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multipleToSingle((List[Long](11l.toLong, 33l.toLong, 50l.toLong))) == (113350l));\n    assert(multipleToSingle((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (-123456l));\n    assert(multipleToSingle((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong))) == (10152025l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    def findAdverbPosition(text : String) : Tuple2[Long, Long, String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals(((0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals(((0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals(((0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    def surfaceareaCube(l : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ration of positive numbers in an array of integers.\n    def positiveCount(nums : List[Long]) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(positiveCount((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.54f));\n    assert(positiveCount((List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.69f));\n    assert(positiveCount((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the largest negative number from the given list.\n    def largestNeg(list1 : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -4l.toLong, -6l.toLong))) == (-6l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -8l.toLong, -9l.toLong))) == (-9l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to trim each list by k in the given lists.\n    def trimTuple(test_list : List[List[Long]], K : Long) : List[List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (2l)).equals((List[List[Long]](List[Long](2l.toLong), List[Long](9l.toLong), List[Long](2l.toLong), List[Long](2l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](4l.toLong, 9l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](8l.toLong, 2l.toLong, 1l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 4l.toLong, 9l.toLong), List[Long](11l.toLong, 8l.toLong, 12l.toLong, 4l.toLong), List[Long](4l.toLong, 1l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](8l.toLong, 4l.toLong), List[Long](8l.toLong, 12l.toLong), List[Long](1l.toLong, 7l.toLong), List[Long](6l.toLong, 9l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    def indexMultiplication(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMultiplication((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 21l.toLong), List[Long](12l.toLong, 45l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 30l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](14l.toLong, 32l.toLong), List[Long](20l.toLong, 60l.toLong), List[Long](6l.toLong, 20l.toLong), List[Long](16l.toLong, 44l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](24l.toLong, 45l.toLong), List[Long](30l.toLong, 77l.toLong), List[Long](12l.toLong, 33l.toLong), List[Long](27l.toLong, 60l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the occurence of all elements of list in a tuple.\n    def countOccurrence(tup : Any, lst : List[Any]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurrence((Any((\"a\", \"a\", \"c\", \"b\", \"d\"))), (List[Any](\"a\", \"b\"))) == (3l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l))), (List[Any](1l.toLong, 4l.toLong, 7l.toLong))) == (6l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 4l, 5l, 6l))), (List[Any](1l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find cubes of individual elements in a list.\n    def cubeNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 27l.toLong, 64l.toLong, 125l.toLong, 216l.toLong, 343l.toLong, 512l.toLong, 729l.toLong, 1000l.toLong))));\n    assert(cubeNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(cubeNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](1728l.toLong, 3375l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    def calSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    def extractString(str : List[String], l : Long) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (8l)).equals((List[String](\"practice\", \"solution\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (6l)).equals((List[String](\"Python\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (9l)).equals((List[String](\"exercises\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from the given string.\n    def removeWhitespaces(text1 : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    def lossAmount(actual_cost : Long, sale_amount : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of even factors of a number.\n    def sumofFactors(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a word containing 'z'.\n    def textMatchWordz(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    def checkMonthnumbNumber(monthnum2 : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse each string in a given list of string values.\n    def reverseStringList(stringlist : List[String]) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseStringList((List[String](\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"))).equals((List[String](\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"))));\n    assert(reverseStringList((List[String](\"john\", \"amal\", \"joel\", \"george\"))).equals((List[String](\"nhoj\", \"lama\", \"leoj\", \"egroeg\"))));\n    assert(reverseStringList((List[String](\"jack\", \"john\", \"mary\"))).equals((List[String](\"kcaj\", \"nhoj\", \"yram\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sublist having minimum length.\n    def FindMin(lst : List[List[Any]]) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong))));\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 7l.toLong, 8l.toLong)))).equals((List[Any](1l.toLong, 1l.toLong))));\n    assert(FindMin((List[List[Any]](List[String](\"x\"), List[String](\"x\", \"y\"), List[String](\"x\", \"y\", \"z\")))).equals((List[Any](\"x\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the area of a rectangle.\n    def rectangleArea(l : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    def removeUppercase(str1 : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to get the first element of each sublist.\n    def Extract(lst : List[List[Long]]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 3l.toLong, 6l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))).equals((List[Long](1l.toLong, 4l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](9l.toLong, 8l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong)))).equals((List[Long](9l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the upper case characters in a given string.\n    def upperCtr(str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find all possible combinations of the elements of a given list.\n    def combinationsList(list1 : List[String]) : List[Either[List[None], List[String]]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsList((List[String](\"orange\", \"red\", \"green\", \"blue\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"orange\"), List[String](\"red\"), List[String](\"red\", \"orange\"), List[String](\"green\"), List[String](\"green\", \"orange\"), List[String](\"green\", \"red\"), List[String](\"green\", \"red\", \"orange\"), List[String](\"blue\"), List[String](\"blue\", \"orange\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"red\", \"orange\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"orange\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"blue\", \"green\", \"red\", \"orange\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"blue\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"white\"), List[String](\"white\", \"red\"), List[String](\"white\", \"green\"), List[String](\"white\", \"green\", \"red\"), List[String](\"white\", \"blue\"), List[String](\"white\", \"blue\", \"red\"), List[String](\"white\", \"blue\", \"green\"), List[String](\"white\", \"blue\", \"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"black\", \"blue\"), List[String](\"black\", \"blue\", \"red\"), List[String](\"black\", \"blue\", \"green\"), List[String](\"black\", \"blue\", \"green\", \"red\"), List[String](\"black\", \"white\"), List[String](\"black\", \"white\", \"red\"), List[String](\"black\", \"white\", \"green\"), List[String](\"black\", \"white\", \"green\", \"red\"), List[String](\"black\", \"white\", \"blue\"), List[String](\"black\", \"white\", \"blue\", \"red\"), List[String](\"black\", \"white\", \"blue\", \"green\"), List[String](\"black\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"blue\"), List[String](\"orange\", \"blue\", \"red\"), List[String](\"orange\", \"blue\", \"green\"), List[String](\"orange\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"white\"), List[String](\"orange\", \"white\", \"red\"), List[String](\"orange\", \"white\", \"green\"), List[String](\"orange\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"white\", \"blue\"), List[String](\"orange\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"blue\"), List[String](\"orange\", \"black\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\"), List[String](\"orange\", \"black\", \"white\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product subarray of the given array.\n    def maxSubarrayProduct(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubarrayProduct((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 0l.toLong, 7l.toLong, -8l.toLong, -2l.toLong))) == (112l));\n    assert(maxSubarrayProduct((List[Long](6l.toLong, -3l.toLong, -10l.toLong, 0l.toLong, 2l.toLong))) == (180l));\n    assert(maxSubarrayProduct((List[Long](-2l.toLong, -40l.toLong, 0l.toLong, -2l.toLong, -3l.toLong))) == (80l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all values are same in a dictionary.\n    def checkValue(dict : Map[String,Long], n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (10l)) == (false));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (12l)) == (true));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (5l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to drop empty items from a given dictionary.\n    def dropEmpty(dict1 : Map[String,Option[String]]) : Map[String,String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\"))));\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> None, \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\"))));\n    assert(dropEmpty(Map[String,None](\"c1\" -> None, \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c2\" -> \"Green\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n    def maxProduct(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong, 150l.toLong, 6l.toLong))) == (3000l));\n    assert(maxProduct((List[Long](4l.toLong, 42l.toLong, 55l.toLong, 68l.toLong, 80l.toLong))) == (50265600l));\n    assert(maxProduct((List[Long](10l.toLong, 22l.toLong, 9l.toLong, 33l.toLong, 21l.toLong, 50l.toLong, 41l.toLong, 60l.toLong))) == (2460l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    def addPairwise(test_tup : Tuple2[Long, Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addPairwise(((1l, 5l, 7l, 8l, 10l))).equals(((6l, 12l, 15l, 18l))));\n    assert(addPairwise(((2l, 6l, 8l, 9l, 11l))).equals(((8l, 14l, 17l, 20l))));\n    assert(addPairwise(((3l, 7l, 9l, 10l, 12l))).equals(((10l, 16l, 19l, 22l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the product of the array multiplication modulo n.\n    def findRemainder(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRemainder((List[Long](100l.toLong, 10l.toLong, 5l.toLong, 25l.toLong, 35l.toLong, 14l.toLong)), (11l)) == (9l));\n    assert(findRemainder((List[Long](1l.toLong, 1l.toLong, 1l.toLong)), (1l)) == (0l));\n    assert(findRemainder((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (2l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given list contains consecutive numbers or not.\n    def checkConsecutive(l : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace characters in a string.\n    def replaceChar(str1 : String, ch : String, newch : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a dictionary by value.\n    def sortCounter(dict1 : Map[String,Long]) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortCounter((Map[String,Long](\"Math\" -> 81l, \"Physics\" -> 83l, \"Chemistry\" -> 87l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 87l), (\"Physics\", 83l), (\"Math\", 81l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 400l, \"Physics\" -> 300l, \"Chemistry\" -> 250l))).equals((List[Tuple2[String, Long]]((\"Math\", 400l), (\"Physics\", 300l), (\"Chemistry\", 250l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 900l, \"Physics\" -> 1000l, \"Chemistry\" -> 1250l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 1250l), (\"Physics\", 1000l), (\"Math\", 900l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the largest and smallest value in a given array.\n    def bigSum(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(bigSum((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigSum((List[Long](2l.toLong, 3l.toLong, 6l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert the given string to lower case.\n    def isLower(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    def removeLowercase(str1 : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first digit of a given number.\n    def firstDigit(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    def heapQueueLargest(nums : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (3l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (2l)).equals((List[Long](85l.toLong, 75l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (5l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong, 58l.toLong, 35l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of integers and only returns the odd ones.\n    def Split(list : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(Split((List[Long](10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong))).equals((List[Long](11l.toLong, 13l.toLong))));\n    assert(Split((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](7l.toLong, 9l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    def difference(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of pairs whose xor value is odd.\n    def findOddPair(A : List[Long], N : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findOddPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong)), (5l)) == (6l));\n    assert(findOddPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong)), (7l)) == (12l));\n    assert(findOddPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to toggle the case of all characters in a string.\n    def toggleString(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the per-digit difference between two integers.\n    def digitDistanceNums(n1 : Long, n2 : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    def maxSubArraySum(a : List[Long], size : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySum((List[Long](-2l.toLong, -3l.toLong, 4l.toLong, -1l.toLong, -2l.toLong, 1l.toLong, 5l.toLong, -3l.toLong)), (8l)) == (7l));\n    assert(maxSubArraySum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, 6l.toLong, -4l.toLong)), (8l)) == (8l));\n    assert(maxSubArraySum((List[Long](-4l.toLong, -5l.toLong, 6l.toLong, -3l.toLong, -4l.toLong, 3l.toLong, 7l.toLong, -5l.toLong)), (8l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    def unionElements(test_tup1 : List[Long], test_tup2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unionElements((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](5l.toLong, 7l.toLong, 4l.toLong, 10l.toLong))).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 10l.toLong))));\n    assert(unionElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(unionElements((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (List[Long](13l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))).equals((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the longest sublists.\n    def FindMaxLength(lst : List[List[Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMaxLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (4l));\n    assert(FindMaxLength((List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](3l.toLong, 2l.toLong, 1l.toLong)))) == (3l));\n    assert(FindMaxLength((List[List[Long]](List[Long](7l.toLong), List[Long](22l.toLong, 23l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong)))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks from a string.\n    def extractValues(text : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((List[String](\"Python\", \"PHP\", \"Java\"))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((List[String](\"python\", \"program\", \"language\"))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((List[String](\"red\", \"blue\", \"green\", \"yellow\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    def countPairs(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (3l)) == (2l));\n    assert(countPairs((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (4l)) == (0l));\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (5l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to split a string into characters.\n    def split(word : String) : List[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(split((\"python\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))));\n    assert(split((\"Name\")).equals((List[String](\"N\", \"a\", \"m\", \"e\"))));\n    assert(split((\"program\")).equals((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    def sumDigits(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    def issortList(list1 : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 17l.toLong))) == (true));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 20l.toLong, 17l.toLong))) == (false));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 15l.toLong, 14l.toLong, 20l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a list of N empty dictionaries.\n    def emptyList(length : Long) : List[Map[None,None]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(emptyList((5l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((6l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((7l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(list1 : List[List[String]]) : List[List[String]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"a\", \"b\"), List[String](\"d\", \"c\"), List[String](\"g\", \"h\"), List[String](\"f\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\"), List[String](\"c\", \"d\"), List[String](\"g\", \"h\"), List[String](\"e\", \"f\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check if a given number is one less than twice its reverse.\n    def checks(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to remove duplicate numbers from a given number of lists.\n    def twoUniqueNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to calculate the product of the unique numbers in a given list.\n    def uniqueProduct(list_data : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueProduct((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 50l.toLong, 60l.toLong, 40l.toLong))) == (720000000l));\n    assert(uniqueProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (6l));\n    assert(uniqueProduct((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cylinder.\n    def surfaceareaCylinder(r : Long, h : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether a list is sublist of another or not.\n    def isSubArray(A : List[Long], B : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSubArray((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)), (List[Long](1l.toLong, 2l.toLong))) == (false));\n    assert(isSubArray((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (true));\n    assert(isSubArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 2l.toLong)), (List[Long](2l.toLong, 2l.toLong, 0l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last digit in factorial of a given number.\n    def lastDigitFactorial(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    def interleaveLists(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(interleaveLists((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong)), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong, 500l.toLong, 600l.toLong, 700l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 100l.toLong, 2l.toLong, 20l.toLong, 200l.toLong, 3l.toLong, 30l.toLong, 300l.toLong, 4l.toLong, 40l.toLong, 400l.toLong, 5l.toLong, 50l.toLong, 500l.toLong, 6l.toLong, 60l.toLong, 600l.toLong, 7l.toLong, 70l.toLong, 700l.toLong))));\n    assert(interleaveLists((List[Long](10l.toLong, 20l.toLong)), (List[Long](15l.toLong, 2l.toLong)), (List[Long](5l.toLong, 10l.toLong))).equals((List[Long](10l.toLong, 15l.toLong, 5l.toLong, 20l.toLong, 2l.toLong, 10l.toLong))));\n    assert(interleaveLists((List[Long](11l.toLong, 44l.toLong)), (List[Long](10l.toLong, 15l.toLong)), (List[Long](20l.toLong, 5l.toLong))).equals((List[Long](11l.toLong, 10l.toLong, 20l.toLong, 44l.toLong, 15l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    def findDissimilar(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findDissimilar(((3l, 4l, 5l, 6l)), ((5l, 7l, 4l, 10l))).equals(((3l, 6l, 7l, 10l))));\n    assert(findDissimilar(((1l, 2l, 3l, 4l)), ((7l, 2l, 3l, 9l))).equals(((1l, 4l, 7l, 9l))));\n    assert(findDissimilar(((21l, 11l, 25l, 26l)), ((26l, 34l, 21l, 36l))).equals(((34l, 36l, 11l, 25l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the largest number that can be formed with the given list of digits.\n    def findMaxNum(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (321l));\n    assert(findMaxNum((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (6541l));\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 9l.toLong))) == (9321l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    def extractEven(test_tuple : Tuple2[Long, Long, Tuple2[Long, Long, Tuple2[Long, Long]], Long, Long]) : Any = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractEven(((4l, 5l, (7l, 6l, (2l, 4l)), 6l, 8l))).equals((Any(6l, (2l, 4l)), 6l, 8l))));\n    assert(extractEven(((5l, 6l, (8l, 7l, (4l, 8l)), 7l, 9l))).equals((Any(8l, (4l, 8l))))));\n    assert(extractEven(((5l, 6l, (9l, 8l, (4l, 6l)), 8l, 10l))).equals((Any(8l, (4l, 6l)), 8l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the surface area of a square pyramid with a given base edge and height.\n    def surfaceArea(b : Long, s : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which returns nth catalan number.\n    def catalanNumber(num : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    def findAdverbs(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n most expensive items in a given dataset.\n    def expensiveItems(items : List[Map[String,Either[String, Float]]], n : Long) : List[Map[String,Either[String, Float]]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f))), (2l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f), Map[String,String](\"name\" -> \"Item-4\", \"price\" -> 22.75f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to split a list at the nth eelment and add the first part to the end.\n    def splitArr(l : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitArr((List[Long](12l.toLong, 10l.toLong, 5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong)), (2l)).equals((List[Long](5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong, 12l.toLong, 10l.toLong))));\n    assert(splitArr((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(splitArr((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (3l)).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 0l.toLong, 1l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a tuple.\n    def listTuple(listx : List[Long]) : Any = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listTuple((List[Long](5l.toLong, 10l.toLong, 7l.toLong, 4l.toLong, 15l.toLong, 3l.toLong))).equals((Any((5l, 10l, 7l, 4l, 15l, 3l)))));\n    assert(listTuple((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 7l.toLong))).equals((Any((2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)))));\n    assert(listTuple((List[Long](58l.toLong, 44l.toLong, 56l.toLong))).equals((Any((58l, 44l, 56l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the difference between largest and smallest value in a given list.\n    def bigDiff(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigDiff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigDiff((List[Long](4l.toLong, 5l.toLong, 12l.toLong))) == (8l));\n    assert(bigDiff((List[Long](9l.toLong, 2l.toLong, 3l.toLong))) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find perfect squares between two given numbers.\n    def perfectSquares(a : Long, b : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perfectSquares((1l), (30l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong))));\n    assert(perfectSquares((50l), (100l)).equals((List[Long](64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(perfectSquares((100l), (200l)).equals((List[Long](100l.toLong, 121l.toLong, 144l.toLong, 169l.toLong, 196l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given two integers have opposite sign or not.\n    def oppositeSigns(x : Long, y : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to interchange the first and last elements in a list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](12l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 24l.toLong))).equals((List[Long](24l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 12l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of the product of consecutive binomial co-efficients.\n    def sumOfProduct(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    def removezeroIp(ip : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    def diffEvenOdd(list1 : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(diffEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (3l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (1l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    def minSwaps(str1 : String, str2 : String) : Any = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Any(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Any(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Any(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find kth element from the given two sorted arrays.\n    def findKth(arr1 : List[Long], arr2 : List[Long], k : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findKth((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](1l.toLong, 4l.toLong, 8l.toLong, 10l.toLong)), (5l)) == (6l));\n    assert(findKth((List[Long](100l.toLong, 112l.toLong, 256l.toLong, 349l.toLong, 770l.toLong)), (List[Long](72l.toLong, 86l.toLong, 113l.toLong, 119l.toLong, 265l.toLong, 445l.toLong, 892l.toLong)), (7l)) == (256l));\n    assert(findKth((List[Long](3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 10l.toLong)), (List[Long](2l.toLong, 5l.toLong, 9l.toLong, 11l.toLong)), (6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    def armstrongNumber(number : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    def sumAverage(number : Long) : Tuple2[Long, Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumAverage((10l)).equals(((55l, 5.5f))));\n    assert(sumAverage((15l)).equals(((120l, 8.0f))));\n    assert(sumAverage((20l)).equals(((210l, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth octagonal number.\n    def isOctagonal(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number is even or not.\n    def isEven(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first repeated character in a given string.\n    def firstRepeatedChar(str1 : String) : Option[String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Some(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(None));\n    assert(firstRepeatedChar((\"123123\")).equals(Some(\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    def getLudic(n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getLudic((10l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(getLudic((25l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong))));\n    assert(getLudic((45l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong, 29l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    def reverseWords(s : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given integer is a prime number.\n    def primeNum(num : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert degrees to radians.\n    def radianDegree(degree : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    def findLiterals(text : String, pattern : String) : Tuple2[String, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals(((\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals(((\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals(((\"will\", 35l, 39l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find nth bell number.\n    def bellNumber(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n    def removeKthElement(list1 : List[Long], L : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeKthElement((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))));\n    assert(removeKthElement((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong)), (4l)).equals((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))));\n    assert(removeKthElement((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong)), (5l)).equals((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    def maxOfNth(test_list : List[List[Long]], N : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOfNth((List[List[Long]](List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](1l.toLong, 3l.toLong, 5l.toLong), List[Long](8l.toLong, 9l.toLong, 19l.toLong))), (2l)) == (19l));\n    assert(maxOfNth((List[List[Long]](List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong), List[Long](9l.toLong, 10l.toLong, 20l.toLong))), (1l)) == (10l));\n    assert(maxOfNth((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](3l.toLong, 5l.toLong, 7l.toLong), List[Long](10l.toLong, 11l.toLong, 21l.toLong))), (1l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    def merge(lst : List[List[Any]]) : List[List[Any]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\"), List[String](\"a\", \"b\"), List[String](\"m\", \"n\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\")))));\n    assert(merge((List[List[Any]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong)))).equals((List[List[Any]](List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)))));\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\", \"z\"), List[String](\"a\", \"b\", \"c\"), List[String](\"m\", \"n\", \"o\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\"), List[String](\"z\", \"c\", \"o\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    def cummulativeSum(test_list : List[List[Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cummulativeSum((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](2l.toLong, 6l.toLong)))) == (30l));\n    assert(cummulativeSum((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 7l.toLong)))) == (37l));\n    assert(cummulativeSum((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](4l.toLong, 8l.toLong)))) == (44l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    def averageTuple(nums : List[List[Long]]) : List[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(averageTuple((List[List[Long]](List[Long](10l.toLong, 10l.toLong, 10l.toLong, 12l.toLong), List[Long](30l.toLong, 45l.toLong, 56l.toLong, 45l.toLong), List[Long](81l.toLong, 80l.toLong, 39l.toLong, 32l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))).equals((List[Float](30.5f.toFloat, 34.25f.toFloat, 27.0f.toFloat, 23.25f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](1l.toLong, 1l.toLong, -5l.toLong), List[Long](30l.toLong, -15l.toLong, 56l.toLong), List[Long](81l.toLong, -60l.toLong, -39l.toLong), List[Long](-10l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Float](25.5f.toFloat, -18.0f.toFloat, 3.75f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](100l.toLong, 100l.toLong, 100l.toLong, 120l.toLong), List[Long](300l.toLong, 450l.toLong, 560l.toLong, 450l.toLong), List[Long](810l.toLong, 800l.toLong, 390l.toLong, 320l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((List[Float](305.0f.toFloat, 342.5f.toFloat, 270.0f.toFloat, 232.5f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    def tupleModulo(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleModulo(((10l, 4l, 5l, 6l)), ((5l, 6l, 7l, 5l))).equals(((0l, 4l, 5l, 1l))));\n    assert(tupleModulo(((11l, 5l, 6l, 7l)), ((6l, 7l, 8l, 6l))).equals(((5l, 5l, 6l, 1l))));\n    assert(tupleModulo(((12l, 6l, 7l, 8l)), ((7l, 8l, 9l, 7l))).equals(((5l, 6l, 7l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    def minJumps(steps : Tuple2[Long, Long], d : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minJumps(((3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps(((3l, 4l)), (0l)) == 0l);\n    assert(minJumps(((11l, 14l)), (11l)) == 1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to divide two lists element wise.\n    def divList(nums1 : List[Long], nums2 : List[Long]) : List[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divList((List[Long](4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Float](4.0f.toFloat, 2.5f.toFloat, 2.0f.toFloat))));\n    assert(divList((List[Long](3l.toLong, 2l.toLong)), (List[Long](1l.toLong, 4l.toLong))).equals((List[Float](3.0f.toFloat, 0.5f.toFloat))));\n    assert(divList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Float](1.8f.toFloat, 1.7142857142857142f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    def moveNum(test_str : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of substrings with the sum of digits equal to their length.\n    def countSubstrings(s : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    def getMedian(arr1 : List[Long], arr2 : List[Long], n : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMedian((List[Long](1l.toLong, 12l.toLong, 15l.toLong, 26l.toLong, 38l.toLong)), (List[Long](2l.toLong, 13l.toLong, 17l.toLong, 30l.toLong, 45l.toLong)), (5l)) == (16.0f));\n    assert(getMedian((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong)), (List[Long](7l.toLong, 13l.toLong, 19l.toLong, 28l.toLong)), (4l)) == (8.5f));\n    assert(getMedian((List[Long](3l.toLong, 6l.toLong, 14l.toLong, 23l.toLong, 36l.toLong, 42l.toLong)), (List[Long](2l.toLong, 18l.toLong, 27l.toLong, 39l.toLong, 49l.toLong, 55l.toLong)), (6l)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    def nthNums(nums : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nthNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(nthNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (3l)).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(nthNums((List[Long](12l.toLong, 15l.toLong)), (5l)).equals((List[Long](248832l.toLong, 759375l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to convert a given string to uppercase.\n    def isUpper(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to interchange the first and last element in a given list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))).equals((List[Long](4l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    def triangleArea(r : Long) : Option[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((-1l)).equals(None));\n    assert(triangleArea((0l)).equals(Some(0l)));\n    assert(triangleArea((2l)).equals(Some(4l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the smallest missing number from a sorted list of natural numbers.\n    def findFirstMissing(array : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 9l.toLong))) == (3l));\n    assert(findFirstMissing((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 9l.toLong))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    def replaceSpaces(string : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find even numbers from a list of numbers.\n    def Split(list : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](2l.toLong, 4l.toLong))));\n    assert(Split((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 0l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))));\n    assert(Split((List[Long](8l.toLong, 12l.toLong, 15l.toLong, 19l.toLong))).equals((List[Long](8l.toLong, 12l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find smallest number in a list.\n    def smallestNum(xs : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestNum((List[Long](10l.toLong, 20l.toLong, 1l.toLong, 45l.toLong, 99l.toLong))) == (1l));\n    assert(smallestNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    assert(smallestNum((List[Long](45l.toLong, 46l.toLong, 50l.toLong, 60l.toLong))) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    def getCoordinates(test_tup : Tuple2[Long, Long]) : List[List[Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getCoordinates(((3l, 4l))).equals((List[List[Long]](List[Long](2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong), List[Long](2l.toLong, 5l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](4l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong)))));\n    assert(getCoordinates(((4l, 5l))).equals((List[List[Long]](List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](5l.toLong, 4l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong)))));\n    assert(getCoordinates(((5l, 6l))).equals((List[List[Long]](List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](4l.toLong, 7l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](6l.toLong, 5l.toLong), List[Long](6l.toLong, 6l.toLong), List[Long](6l.toLong, 7l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    def replaceSpaces(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to move all zeroes to the end of the given list.\n    def moveZero(num_list : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveZero((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 0l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 0l.toLong, 0l.toLong, 4l.toLong, 0l.toLong, 5l.toLong, 0l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](0l.toLong, 1l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of xor of all pairs of numbers in the given list.\n    def pairXorSum(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairXorSum((List[Long](5l.toLong, 9l.toLong, 7l.toLong, 6l.toLong)), (4l)) == (47l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong, 5l.toLong)), (3l)) == (12l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong)), (2l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list.\n    def heapSort(iterable : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapSort((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(heapSort((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong))).equals((List[Long](14l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 58l.toLong, 65l.toLong, 75l.toLong, 85l.toLong))));\n    assert(heapSort((List[Long](7l.toLong, 1l.toLong, 9l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    def noprofitNoloss(actual_cost : Long, sale_amount : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    def windChill(v : Long, t : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    def sampleNam(sample_names : List[String]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sampleNam((List[String](\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"))) == (16l));\n    assert(sampleNam((List[String](\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"))) == (10l));\n    assert(sampleNam((List[String](\"abcd\", \"Python\", \"abba\", \"aba\"))) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    def maxDifference(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxDifference((List[Tuple2[Long, Long]]((3l, 5l), (1l, 7l), (10l, 3l), (1l, 2l)))) == (7l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((4l, 6l), (2l, 17l), (9l, 13l), (11l, 12l)))) == (15l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((12l, 35l), (21l, 27l), (13l, 23l), (41l, 22l)))) == (23l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    def removeParenthesis(items : List[String]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeParenthesis((List[String](\"python (chrome)\"))).equals((\"python\")));\n    assert(removeParenthesis((List[String](\"string(.abc)\"))).equals((\"string\")));\n    assert(removeParenthesis((List[String](\"alpha(num)\"))).equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth nonagonal number.\n    def isNonagonal(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    def textMatchWordzMiddle(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to reverse an array upto a given position.\n    def reverseArrayUptoK(input : List[Long], k : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseArrayUptoK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (4l)).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))));\n    assert(reverseArrayUptoK((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (2l)).equals((List[Long](5l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))));\n    assert(reverseArrayUptoK((List[Long](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong)), (3l)).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 6l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    def subjectMarks(subjectmarks : List[Tuple2[String, Long]]) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l), (\"Social sciences\", 82l)))).equals((List[Tuple2[String, Long]]((\"Social sciences\", 82l), (\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Telugu\", 49l), (\"Hindhi\", 54l), (\"Social\", 33l)))).equals((List[Tuple2[String, Long]]((\"Social\", 33l), (\"Telugu\", 49l), (\"Hindhi\", 54l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Physics\", 96l), (\"Chemistry\", 97l), (\"Biology\", 45l)))).equals((List[Tuple2[String, Long]]((\"Biology\", 45l), (\"Physics\", 96l), (\"Chemistry\", 97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a list and sum all of its elements.\n    def recursiveListSum(data_list : List[Either[Long, List[Long]]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(recursiveListSum((List[Either[Long, List[Long]]](1l, 2l, List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (21l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](7l, 10l, List[Long](15l.toLong, 14l.toLong), List[Long](19l.toLong, 41l.toLong)))) == (106l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](10l, 20l, List[Long](30l.toLong, 40l.toLong), List[Long](50l.toLong, 60l.toLong)))) == (210l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of positive numbers in a list.\n    def posCount(list : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(posCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong, -4l.toLong))) == (2l));\n    assert(posCount((List[Long](3l.toLong, 4l.toLong, 5l.toLong, -1l.toLong))) == (3l));\n    assert(posCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    def bellNumber(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given array is monotonic or not.\n    def isMonotonic(A : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMonotonic((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    def isSublist(l : List[Long], s : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](3l.toLong, 7l.toLong))) == (false));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](4l.toLong, 3l.toLong))) == (true));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](1l.toLong, 6l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the two numbers differ at one bit position only or not.\n    def differAtOneBitPos(a : Long, b : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    def getEqual(Input : List[List[Long]]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getEqual((List[List[Long]](List[Long](11l.toLong, 22l.toLong, 33l.toLong), List[Long](44l.toLong, 55l.toLong, 66l.toLong)))) == (true));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))) == (false));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def combSort(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combSort((List[Long](5l.toLong, 15l.toLong, 37l.toLong, 25l.toLong, 79l.toLong))).equals((List[Long](5l.toLong, 15l.toLong, 25l.toLong, 37l.toLong, 79l.toLong))));\n    assert(combSort((List[Long](41l.toLong, 32l.toLong, 15l.toLong, 19l.toLong, 22l.toLong))).equals((List[Long](15l.toLong, 19l.toLong, 22l.toLong, 32l.toLong, 41l.toLong))));\n    assert(combSort((List[Long](99l.toLong, 15l.toLong, 13l.toLong, 47l.toLong))).equals((List[Long](13l.toLong, 15l.toLong, 47l.toLong, 99l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add a dictionary to the tuple. The output should be a tuple.\n    def addDictToTuple(test_tup : Tuple2[Long, Long, Long], test_dict : Map[String,Long]) : Tuple2[Long, Long, Long, Map[String,Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addDictToTuple(((4l, 5l, 6l)), (Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l))).equals(((4l, 5l, 6l, Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l)))));\n    assert(addDictToTuple(((1l, 2l, 3l)), (Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l))).equals(((1l, 2l, 3l, Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l)))));\n    assert(addDictToTuple(((8l, 9l, 10l)), (Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l))).equals(((8l, 9l, 10l, Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    def maxAverageOfPath(cost : List[List[Long]]) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](7l.toLong, 3l.toLong, 9l.toLong)))) == (5.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 4l.toLong), List[Long](7l.toLong, 6l.toLong, 5l.toLong), List[Long](8l.toLong, 4l.toLong, 10l.toLong)))) == (6.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](8l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 11l.toLong)))) == (7.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    def filterData(students : Map[String,Tuple2[Float, Long]], h : Float, w : Long) : Map[String,Tuple2[Float, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (6.0f), (70l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.9f), (67l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Kierra Gentry\" -> (6.0f, 68l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.7f), (64l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    def countSamePair(nums1 : List[Long], nums2 : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamePair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (4l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (11l));\n    assert(countSamePair((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (1l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 1l.toLong, 2l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    def powerBaseSum(base : Long, power : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    def extractQuotation(text1 : String) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((List[Any](\"A53\", \"multi\", \"Processor\"))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((List[Any](\"favorite\", \"apps\"))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((List[Any](\"4k Ultra HD\", \"HDR 10\"))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    def multiplyElements(test_tup : List[Long]) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyElements((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 10l.toLong))).equals((List[Any](5l.toLong, 35l.toLong, 56l.toLong, 80l.toLong))));\n    assert(multiplyElements((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](8l.toLong, 20l.toLong, 30l.toLong, 42l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong, 13l.toLong, 14l.toLong, 9l.toLong, 15l.toLong))).equals((List[Any](156l.toLong, 182l.toLong, 126l.toLong, 135l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    def sumList(lst1 : List[Long], lst2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumList((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 25l.toLong, 35l.toLong))).equals((List[Long](25l.toLong, 45l.toLong, 65l.toLong))));\n    assert(sumList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(sumList((List[Long](15l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 45l.toLong, 75l.toLong))).equals((List[Long](30l.toLong, 65l.toLong, 105l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the given number can be represented as the difference of two squares or not.\n    def difSquare(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    def consecutiveDuplicates(nums : List[Any]) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(consecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[Any](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong))));\n    assert(consecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[Any](10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\"))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\", \"a\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    def lateralsurfaceCone(r : Long, h : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    def replaceSpecialchar(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted array.\n    def findFirstOccurrence(A : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstOccurrence((List[Long](2l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (1l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (2l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (6l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n    def sumOfSubarrayProd(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (20l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong))) == (5l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    def toggleMiddleBits(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n    def leftInsertion(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    def checkStr(string : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n    def geometricSum(n : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    def findIndex(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n    def tupleToDict(test_tup : Tuple2[Long, Long, Long, Long, Long, Long]) : Map[Long,Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToDict(((1l, 5l, 7l, 10l, 13l, 5l))).equals((Map[Long,Long](1l -> 5l, 7l -> 10l, 13l -> 5l))));\n    assert(tupleToDict(((1l, 2l, 3l, 4l, 5l, 6l))).equals((Map[Long,Long](1l -> 2l, 3l -> 4l, 5l -> 6l))));\n    assert(tupleToDict(((7l, 8l, 9l, 10l, 11l, 12l))).equals((Map[Long,Long](7l -> 8l, 9l -> 10l, 11l -> 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether all the characters are same or not.\n    def allCharactersSame(s : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    def areaTetrahedron(side : Long) : Float = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n    def rotateRight(list : List[Long], m : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (3l)).equals((List[Long](8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (5l)).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    def checkNone(test_tup : Any) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkNone((Any(10l), Some(4l), Some(5l), Some(6l), Some(None)))) == (true));\n    assert(checkNone((Any((7l, 8l, 9l, 11l, 14l)))) == (false));\n    assert(checkNone((Any(1l), Some(2l), Some(3l), Some(4l), Some(None)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n    def divisibleByDigits(startnum : Long, endnum : Long) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisibleByDigits((1l), (22l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong, 22l.toLong))));\n    assert(divisibleByDigits((1l), (15l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong))));\n    assert(divisibleByDigits((20l), (25l)).equals((List[Long](22l.toLong, 24l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    def sectorArea(r : Long, a : Long) : Option[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sectorArea((4l), (45l)).equals(Some(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Some(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    def lcsOfThree(X : String, Y : String, Z : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    def capitalWordsSpaces(str1 : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\n    def sortNumericStrings(nums_str : List[String]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumericStrings((List[String](\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"))).equals((List[Long](-500l.toLong, -12l.toLong, 0l.toLong, 4l.toLong, 7l.toLong, 12l.toLong, 45l.toLong, 100l.toLong, 200l.toLong))));\n    assert(sortNumericStrings((List[String](\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 9l.toLong))));\n    assert(sortNumericStrings((List[String](\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong, 15l.toLong, 17l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether it follows the sequence given in the patterns array.\n    def isSamepatterns(colors : List[String], patterns : List[String]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"green\")), (List[String](\"a\", \"b\", \"b\"))) == (true));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\", \"b\"))) == (false));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\"))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add the given tuple to the given list.\n    def addTuple(test_list : List[Long], test_tup : Tuple2[Long, Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addTuple((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(addTuple((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 11l.toLong))));\n    assert(addTuple((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n    def checkMinHeap(arr : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMinHeap((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 10l.toLong, 15l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 15l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    def jacobsthalNum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n    def minK(test_list : List[Tuple2[String, Long]], K : Long) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minK((List[Tuple2[String, Long]]((\"Manjeet\", 10l), (\"Akshat\", 4l), (\"Akash\", 2l), (\"Nikhil\", 8l))), (2l)).equals((List[Tuple2[String, Long]]((\"Akash\", 2l), (\"Akshat\", 4l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"Sanjeev\", 11l), (\"Angat\", 5l), (\"Akash\", 3l), (\"Nepin\", 9l))), (3l)).equals((List[Tuple2[String, Long]]((\"Akash\", 3l), (\"Angat\", 5l), (\"Nepin\", 9l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"tanmay\", 14l), (\"Amer\", 11l), (\"Ayesha\", 9l), (\"SKD\", 16l))), (1l)).equals((List[Tuple2[String, Long]]((\"Ayesha\", 9l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    def extractIndexList(l1 : List[Long], l2 : List[Long], l3 : List[Long]) : List[Any] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 7l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 6l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 5l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 6l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the second smallest number in a list.\n    def secondSmallest(numbers : List[Either[Long, Float]]) : Option[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 2l.toLong, -8l.toLong, -2l.toLong, 0l.toLong, -2l.toLong))).equals(Some(-2l)));\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 1l.toLong, -0.5f.toLong, 0l.toLong, 2l.toLong, -2l.toLong, -2l.toLong))).equals(Some(-0.5f)));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong))).equals(None));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong, 2l.toLong))).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n    def textMatchZeroOne(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n    def countReversePairs(test_list : List[String]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countReversePairs((List[String](\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"))) == (2l));\n    assert(countReversePairs((List[String](\"geeks\", \"best\", \"for\", \"skeeg\"))) == (1l));\n    assert(countReversePairs((List[String](\"makes\", \"best\", \"sekam\", \"for\", \"rof\"))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    def isDecimal(num : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    def findTuples(test_list : List[Tuple2[Long, Long, Long]], K : Long) : List[Tuple2[Long, Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l), (7l, 9l, 6l), (12l, 18l, 21l))), (6l)).equals((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l), (4l, 2l, 3l), (7l, 8l, 9l))), (5l)).equals((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((7l, 9l, 16l), (8l, 16l, 4l), (19l, 17l, 18l))), (4l)).equals((List[Tuple2[Long, Long, Long]]((8l, 16l, 4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether a list of numbers contains only one distinct element or not.\n    def uniqueElement(arr : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueElement((List[Long](1l.toLong, 1l.toLong, 1l.toLong))) == (true));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    def checkMonthnumberNumber(monthnum3 : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    def findMinDiff(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMinDiff((List[Long](1l.toLong, 5l.toLong, 3l.toLong, 19l.toLong, 18l.toLong, 25l.toLong)), (6l)) == (1l));\n    assert(findMinDiff((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 6l.toLong)), (4l)) == (1l));\n    assert(findMinDiff((List[Long](30l.toLong, 5l.toLong, 20l.toLong, 9l.toLong)), (4l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count number of digits in a given string.\n    def numberCtr(str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    def isPolite(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    def pairWise(l1 : List[Long]) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairWise((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 1l), (1l, 2l), (2l, 3l), (3l, 3l), (3l, 4l), (4l, 4l), (4l, 5l)))));\n    assert(pairWise((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 5l), (5l, 7l), (7l, 9l), (9l, 10l)))));\n    assert(pairWise((List[Long](5l.toLong, 1l.toLong, 9l.toLong, 7l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((5l, 1l), (1l, 9l), (9l, 7l), (7l, 10l)))));\n    assert(pairWise((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 2l), (2l, 3l), (3l, 4l), (4l, 5l), (5l, 6l), (6l, 7l), (7l, 8l), (8l, 9l), (9l, 10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    def getPairsCount(arr : List[Long], sum : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPairsCount((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (2l)) == (6l));\n    assert(getPairsCount((List[Long](1l.toLong, 5l.toLong, 7l.toLong, -1l.toLong, 5l.toLong)), (6l)) == (3l));\n    assert(getPairsCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong)), (1l)) == (1l));\n    assert(getPairsCount((List[Long](-1l.toLong, -2l.toLong, 3l.toLong)), (-3l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to get the difference between two lists.\n    def Diff(li1 : List[Long], li2 : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Diff((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong, 30l.toLong, 35l.toLong, 40l.toLong)), (List[Long](25l.toLong, 40l.toLong, 35l.toLong))).equals((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 15l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of fourth power of first n odd natural numbers.\n    def oddNumSum(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    def checkExpression(exp : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all the words with k length in the given string.\n    def removeLength(test_str : String, K : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    def occuranceSubstring(text : String, pattern : String) : Option[Tuple2[String, Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Some((\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Some((\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Some((\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether every odd index contains odd numbers of a given list.\n    def oddPosition(nums : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 3l.toLong))) == (true));\n    assert(oddPosition((List[Long](4l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(oddPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    def countVowels(test_str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of non-repeated elements in a given list.\n    def findSum(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (21l));\n    assert(findSum((List[Long](1l.toLong, 10l.toLong, 9l.toLong, 4l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 4l.toLong))) == (71l));\n    assert(findSum((List[Long](12l.toLong, 10l.toLong, 9l.toLong, 45l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 10l.toLong))) == (78l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    def packConsecutiveDuplicates(list1 : List[Any]) : List[List[Any]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(packConsecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[List[Any]](List[Long](0l.toLong, 0l.toLong), List[Long](1l.toLong), List[Long](2l.toLong), List[Long](3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](5l.toLong), List[Long](6l.toLong, 6l.toLong, 6l.toLong), List[Long](7l.toLong), List[Long](8l.toLong), List[Long](9l.toLong), List[Long](4l.toLong, 4l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[List[Any]](List[Long](10l.toLong, 10l.toLong), List[Long](15l.toLong), List[Long](19l.toLong), List[Long](18l.toLong, 18l.toLong), List[Long](17l.toLong), List[Long](26l.toLong, 26l.toLong), List[Long](17l.toLong), List[Long](18l.toLong), List[Long](10l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[List[Any]](List[String](\"a\", \"a\"), List[String](\"b\"), List[String](\"c\"), List[String](\"d\", \"d\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find whether a number is divisible by 11.\n    def isDiff(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n    def findCombinations(test_list : List[Tuple2[Long, Long]]) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findCombinations((List[Tuple2[Long, Long]]((2l, 4l), (6l, 7l), (5l, 1l), (6l, 10l)))).equals((List[Tuple2[Long, Long]]((8l, 11l), (7l, 5l), (8l, 14l), (11l, 8l), (12l, 17l), (11l, 11l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((3l, 5l), (7l, 8l), (6l, 2l), (7l, 11l)))).equals((List[Tuple2[Long, Long]]((10l, 13l), (9l, 7l), (10l, 16l), (13l, 10l), (14l, 19l), (13l, 13l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((4l, 6l), (8l, 9l), (7l, 3l), (8l, 12l)))).equals((List[Tuple2[Long, Long]]((12l, 15l), (11l, 9l), (12l, 18l), (15l, 12l), (16l, 21l), (15l, 15l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n    def countDivisors(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n    def oddLengthSum(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 4l.toLong))) == (14l));\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (15l));\n    assert(oddLengthSum((List[Long](1l.toLong, 7l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    def rgbToHsv(r : Long, g : Long, b : Long) : List[Float] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((List[Float](0.0f.toFloat, 0.0f.toFloat, 100.0f.toFloat))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((List[Float](120.0f.toFloat, 100.0f.toFloat, 84.31372549019608f.toFloat))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((List[Float](149.26829268292684f.toFloat, 95.34883720930233f.toFloat, 84.31372549019608f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    def mulEvenOdd(list1 : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mulEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (4l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert tuple string to integer tuple.\n    def tupleStrInt(test_str : String) : Tuple2[Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals(((7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals(((1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals(((4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals(((7l, 81l, 19l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    def rightInsertion(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    def textMatchThree(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a new tuple from the given string and list.\n    def newTuple(test_list : List[String], test_str : String) : Tuple2[String, String, String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newTuple((List[String](\"WEB\", \"is\")), (\"best\")).equals(((\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((List[String](\"We\", \"are\")), (\"Developers\")).equals(((\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((List[String](\"Part\", \"is\")), (\"Wrong\")).equals(((\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether every even index contains even numbers of a given list.\n    def evenPosition(nums : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPosition((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(evenPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    assert(evenPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove tuples from the given tuple.\n    def removeNested(test_tup : Any) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeNested((Any(4l, 6l), 10l))).equals(((1l, 5l, 7l, 10l))));\n    assert(removeNested((Any(5l, 7l), 11l))).equals(((2l, 6l, 8l, 11l))));\n    assert(removeNested((Any(6l, 8l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    assert(removeNested((Any(6l, 8l), (5l, 12l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of lists in a given number of lists.\n    def countList(input_list : List[List[Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))) == (4l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))) == (3l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 0l.toLong), List[Long](2l.toLong, 0l.toLong)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the last position of an element in a sorted array.\n    def last(arr : List[Long], x : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(last((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (0l));\n    assert(last((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)) == (2l));\n    assert(last((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (3l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    def textStartaEndb(text : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write function to find the sum of all items in the given dictionary.\n    def returnSum(dict : Map[String,Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(returnSum((Map[String,Long](\"a\" -> 100l, \"b\" -> 200l, \"c\" -> 300l))) == (600l));\n    assert(returnSum((Map[String,Long](\"a\" -> 25l, \"b\" -> 18l, \"c\" -> 45l))) == (88l));\n    assert(returnSum((Map[String,Long](\"a\" -> 36l, \"b\" -> 39l, \"c\" -> 49l))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of all odd natural numbers within the range l and r.\n    def sumInRange(l : Long, r : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the sum of an array.\n    def Sum(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Sum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(Sum((List[Long](15l.toLong, 12l.toLong, 13l.toLong, 10l.toLong))) == (50l));\n    assert(Sum((List[Long](0l.toLong, 1l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    def leftRotate(n : Long, d : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to check whether the length of the word is odd or not.\n    def wordLen(s : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from a string.\n    def removeAllSpaces(text : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of equal numbers from three given integers.\n    def testThreeEqual(x : Long, y : Long, z : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n    def countRotation(arr : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countRotation((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(countRotation((List[Long](4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (2l));\n    assert(countRotation((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(countRotation((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (0l));\n    assert(countRotation((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    def isPerfectSquare(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    def isProductEven(arr : List[Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    def maxSumList(lists : List[List[Long]]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](10l.toLong, 11l.toLong, 12l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](12l.toLong, 11l.toLong, 10l.toLong)))).equals((List[Long](12l.toLong, 11l.toLong, 10l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 1l.toLong)))).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    def maxRunUppercase(test_str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the first odd number in a given list of numbers.\n    def firstOdd(nums : List[Long]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong))) == (1l));\n    assert(firstOdd((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(firstOdd((List[Long](8l.toLong, 9l.toLong, 1l.toLong))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    def checkK(test_tup : List[Long], K : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkK((List[Long](10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 8l.toLong)), (6l)) == (true));\n    assert(checkK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (7l)) == (false));\n    assert(checkK((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 44l.toLong, 11l.toLong, 12l.toLong)), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    def checkSmaller(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkSmaller(((1l, 2l, 3l)), ((2l, 3l, 4l))) == (false));\n    assert(checkSmaller(((4l, 5l, 6l)), ((3l, 4l, 5l))) == (true));\n    assert(checkSmaller(((11l, 12l, 13l)), ((10l, 11l, 12l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth tetrahedral number.\n    def tetrahedralNumber(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    def getChar(strr : String) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    def sequence(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth centered hexagonal number.\n    def centeredHexagonalNumber(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three dictionaries into a single dictionary.\n    def mergeDictionariesThree(dict1 : Map[String,String], dict2 : Map[String,String], dict3 : Map[String,String]) : Map[String,String] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"O\" -> \"Orange\", \"W\" -> \"White\", \"B\" -> \"Black\"))).equals((Map[String,String](\"B\" -> \"Black\", \"R\" -> \"Red\", \"P\" -> \"Pink\", \"G\" -> \"Green\", \"W\" -> \"White\", \"O\" -> \"Orange\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\"))).equals((Map[String,String](\"W\" -> \"White\", \"P\" -> \"Pink\", \"B\" -> \"Black\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\"))).equals((Map[String,String](\"B\" -> \"Black\", \"P\" -> \"Pink\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\", \"W\" -> \"White\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n    def freqCount(list1 : List[Long]) : Map[Long,Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(freqCount((List[Long](10l.toLong, 10l.toLong, 10l.toLong, 10l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 40l.toLong, 40l.toLong, 50l.toLong, 50l.toLong, 30l.toLong))).equals((Map[Long,Long](10l -> 4l, 20l -> 4l, 40l -> 2l, 50l -> 2l, 30l -> 1l))));\n    assert(freqCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 4l.toLong))).equals((Map[Long,Long](1l -> 3l, 2l -> 2l, 3l -> 3l, 4l -> 3l))));\n    assert(freqCount((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 5l.toLong))).equals((Map[Long,Long](10l -> 1l, 5l -> 3l, 6l -> 2l, 7l -> 2l, 4l -> 2l, 9l -> 2l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the closest smaller number than n.\n    def closestNum(N : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find squares of individual elements in a list.\n    def squareNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(squareNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](100l.toLong, 400l.toLong, 900l.toLong))));\n    assert(squareNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](144l.toLong, 225l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the longest word.\n    def lenLog(list1 : List[String]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lenLog((List[String](\"python\", \"PHP\", \"bigdata\"))) == (7l));\n    assert(lenLog((List[String](\"a\", \"ab\", \"abc\"))) == (3l));\n    assert(lenLog((List[String](\"small\", \"big\", \"tall\"))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    def findSubstring(str1 : List[String], sub_str : String) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ack\")) == (true));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"abc\")) == (false));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is undulating or not.\n    def isUndulating(n : Long) : Boolean = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    def power(a : Long, b : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    def indexMinimum(test_list : List[Tuple2[String, Long]]) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Rash\", 143l), (\"Manjeet\", 200l), (\"Varsha\", 100l)))).equals((\"Varsha\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Yash\", 185l), (\"Dawood\", 125l), (\"Sanya\", 175l)))).equals((\"Dawood\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Sai\", 345l), (\"Salman\", 145l), (\"Ayesha\", 96l)))).equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the length of the smallest list in a list of lists.\n    def FindMinLength(lst : List[List[Long]]) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong)))) == (1l));\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))) == (2l));\n    assert(FindMinLength((List[List[Long]](List[Long](3l.toLong, 3l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the number of divisors of a given integer.\n    def divisor(n : Long) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n    def frequencyLists(list1 : List[List[Long]]) : Map[Long,Long] = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong, 5l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 3l, 3l -> 1l, 4l -> 1l, 5l -> 2l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 1l, 3l -> 1l, 4l -> 1l, 5l -> 1l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l, 10l -> 1l, 11l -> 1l, 12l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](20l.toLong, 30l.toLong, 40l.toLong, 17l.toLong), List[Long](18l.toLong, 16l.toLong, 14l.toLong, 13l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((Map[Long,Long](20l -> 2l, 30l -> 2l, 40l -> 2l, 17l -> 1l, 18l -> 1l, 16l -> 1l, 14l -> 1l, 13l -> 1l, 10l -> 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    def decimalToBinary(n : Long) : String = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n    def findRotations(str : String) : Long = {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-scala-reworded.json
+++ b/prompts/mbpp-scala-reworded.json
@@ -1,3528 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    def lps(str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from the given string.\n    def removeWhitespaces(text1 : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    def issortList(list1 : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 17l.toLong))) == (true));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 20l.toLong, 17l.toLong))) == (false));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 15l.toLong, 14l.toLong, 20l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count bidirectional tuple pairs.\n    def countBidirectional(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (3l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 3l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (2l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 2l), (6l, 5l), (2l, 1l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    def surfaceareaCube(l : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n    def nextSmallestPalindrome(num : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextSmallestPalindrome((99l)) == (101l));\n    assert(nextSmallestPalindrome((1221l)) == (1331l));\n    assert(nextSmallestPalindrome((120l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the cube sum of first n even natural numbers.\n    def cubeSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of xor of all pairs of numbers in the given list.\n    def pairXorSum(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairXorSum((List[Long](5l.toLong, 9l.toLong, 7l.toLong, 6l.toLong)), (4l)) == (47l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong, 5l.toLong)), (3l)) == (12l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong)), (2l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n    def checkMinHeap(arr : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMinHeap((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 10l.toLong, 15l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 15l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first digit of a given number.\n    def firstDigit(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first non-repeated character in a given string.\n    def firstNonRepeatingCharacter(str1 : String) : Option[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(None));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(\"a\"));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(\"c\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert degrees to radians.\n    def radianDegree(degree : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product sublist of the given list.\n    def maxSubarrayProduct(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubarrayProduct((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 0l.toLong, 7l.toLong, -8l.toLong, -2l.toLong))) == (112l));\n    assert(maxSubarrayProduct((List[Long](6l.toLong, -3l.toLong, -10l.toLong, 0l.toLong, 2l.toLong))) == (180l));\n    assert(maxSubarrayProduct((List[Long](-2l.toLong, -40l.toLong, 0l.toLong, -2l.toLong, -3l.toLong))) == (80l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert more than one list to nested map.\n    def convertListDictionary(l1 : List[String], l2 : List[String], l3 : List[Long]) : List[Map[String,Map[String,Long]]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convertListDictionary((List[String](\"S001\", \"S002\", \"S003\", \"S004\")), (List[String](\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\")), (List[Long](85l.toLong, 98l.toLong, 89l.toLong, 92l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"S001\" -> Map[String,Long](\"Adina Park\" -> 85l)), Map[String,Map[String,Long]](\"S002\" -> Map[String,Long](\"Leyton Marsh\" -> 98l)), Map[String,Map[String,Long]](\"S003\" -> Map[String,Long](\"Duncan Boyle\" -> 89l)), Map[String,Map[String,Long]](\"S004\" -> Map[String,Long](\"Saim Richards\" -> 92l))))));\n    assert(convertListDictionary((List[String](\"abc\", \"def\", \"ghi\", \"jkl\")), (List[String](\"python\", \"program\", \"language\", \"programs\")), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"abc\" -> Map[String,Long](\"python\" -> 100l)), Map[String,Map[String,Long]](\"def\" -> Map[String,Long](\"program\" -> 200l)), Map[String,Map[String,Long]](\"ghi\" -> Map[String,Long](\"language\" -> 300l)), Map[String,Map[String,Long]](\"jkl\" -> Map[String,Long](\"programs\" -> 400l))))));\n    assert(convertListDictionary((List[String](\"A1\", \"A2\", \"A3\", \"A4\")), (List[String](\"java\", \"C\", \"C++\", \"DBMS\")), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"A1\" -> Map[String,Long](\"java\" -> 10l)), Map[String,Map[String,Long]](\"A2\" -> Map[String,Long](\"C\" -> 20l)), Map[String,Map[String,Long]](\"A3\" -> Map[String,Long](\"C++\" -> 30l)), Map[String,Map[String,Long]](\"A4\" -> Map[String,Long](\"DBMS\" -> 40l))))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find smallest number in a list.\n    def smallestNum(xs : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestNum((List[Long](10l.toLong, 20l.toLong, 1l.toLong, 45l.toLong, 99l.toLong))) == (1l));\n    assert(smallestNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    assert(smallestNum((List[Long](45l.toLong, 46l.toLong, 50l.toLong, 60l.toLong))) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/scalathon-exercises/re/scalathon-re-exercise-3.php\n    def textMatchZeroOne(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find nth bell number.\n    def bellNumber(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find cubes of individual elements in a list.\n    def cubeNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 27l.toLong, 64l.toLong, 125l.toLong, 216l.toLong, 343l.toLong, 512l.toLong, 729l.toLong, 1000l.toLong))));\n    assert(cubeNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(cubeNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](1728l.toLong, 3375l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last digit in factorial of a given number.\n    def lastDigitFactorial(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find even numbers from a list of numbers.\n    def Split(list : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](2l.toLong, 4l.toLong))));\n    assert(Split((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 0l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))));\n    assert(Split((List[Long](8l.toLong, 12l.toLong, 15l.toLong, 19l.toLong))).equals((List[Long](8l.toLong, 12l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given integer is a prime number.\n    def primeNum(num : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    def findTuples(test_list : List[Tuple2[Long, Long, Long]], K : Long) : List[Tuple2[Long, Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l), (7l, 9l, 6l), (12l, 18l, 21l))), (6l)).equals((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l), (4l, 2l, 3l), (7l, 8l, 9l))), (5l)).equals((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((7l, 9l, 16l), (8l, 16l, 4l), (19l, 17l, 18l))), (4l)).equals((List[Tuple2[Long, Long, Long]]((8l, 16l, 4l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    def areaTetrahedron(side : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number is even or not.\n    def isEven(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of positive numbers in a list.\n    def posCount(list : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(posCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong, -4l.toLong))) == (2l));\n    assert(posCount((List[Long](3l.toLong, 4l.toLong, 5l.toLong, -1l.toLong))) == (3l));\n    assert(posCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    def getLudic(n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getLudic((10l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(getLudic((25l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong))));\n    assert(getLudic((45l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong, 29l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    def findIndex(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to reverse a list upto a given position.\n    def reverseArrayUptoK(input : List[Long], k : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseArrayUptoK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (4l)).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))));\n    assert(reverseArrayUptoK((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (2l)).equals((List[Long](5l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))));\n    assert(reverseArrayUptoK((List[Long](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong)), (3l)).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 6l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    def subjectMarks(subjectmarks : List[Tuple2[String, Long]]) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l), (\"Social sciences\", 82l)))).equals((List[Tuple2[String, Long]]((\"Social sciences\", 82l), (\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Telugu\", 49l), (\"Hindhi\", 54l), (\"Social\", 33l)))).equals((List[Tuple2[String, Long]]((\"Social\", 33l), (\"Telugu\", 49l), (\"Hindhi\", 54l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Physics\", 96l), (\"Chemistry\", 97l), (\"Biology\", 45l)))).equals((List[Tuple2[String, Long]]((\"Biology\", 45l), (\"Physics\", 96l), (\"Chemistry\", 97l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    def removeDirtyChars(string : String, second_string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n    def roundAndSum(list1 : List[Either[Float, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundAndSum((List[Either[Float, Long]](22.4f.toFloat, 4.0f.toFloat, -16.22f.toFloat, -9.1f.toFloat, 11.0f.toFloat, -12.22f.toFloat, 14.2f.toFloat, -5.2f.toFloat, 17.5f.toFloat))) == (243l));\n    assert(roundAndSum((List[Either[Float, Long]](5l.toLong, 2l.toLong, 9l.toLong, 24.3f.toLong, 29l.toLong))) == (345l));\n    assert(roundAndSum((List[Either[Float, Long]](25.0f.toFloat, 56.7f.toFloat, 89.2f.toFloat))) == (513l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    def maxOccurrences(nums : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 5l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 1l.toLong, 2l.toLong))) == (2l));\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 15l.toLong, 14l.toLong, 10l.toLong, 12l.toLong, 13l.toLong, 16l.toLong, 18l.toLong))) == (8l));\n    assert(maxOccurrences((List[Long](10l.toLong, 20l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 90l.toLong, 80l.toLong, 50l.toLong, 30l.toLong, 20l.toLong, 50l.toLong, 10l.toLong))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    def isDecimal(num : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\n    def dictFilter(dict : Map[String,Long], n : Long) : Map[String,Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (170l)).equals((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (180l)).equals((Map[String,Long](\"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (190l)).equals((Map[String,Long](\"Pierre Cox\" -> 190l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of even numbers at even positions of a list.\n    def sumEvenAndEvenIndex(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong, 18l.toLong, 8l.toLong))) == (30l));\n    assert(sumEvenAndEvenIndex((List[Long](3l.toLong, 20l.toLong, 17l.toLong, 9l.toLong, 2l.toLong, 10l.toLong, 18l.toLong, 13l.toLong, 6l.toLong, 18l.toLong))) == (26l));\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong))) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    def maxSubArraySum(a : List[Long], size : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySum((List[Long](-2l.toLong, -3l.toLong, 4l.toLong, -1l.toLong, -2l.toLong, 1l.toLong, 5l.toLong, -3l.toLong)), (8l)) == (7l));\n    assert(maxSubArraySum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, 6l.toLong, -4l.toLong)), (8l)) == (8l));\n    assert(maxSubArraySum((List[Long](-4l.toLong, -5l.toLong, 6l.toLong, -3l.toLong, -4l.toLong, 3l.toLong, 7l.toLong, -5l.toLong)), (8l)) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the intersection of two lists.\n    def intersectionArray(array_nums1 : List[Long], array_nums2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Long](10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    def splitTwoParts(list1 : List[Any], L : Long) : Any = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitTwoParts((List[Any](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((Any(1l.toLong, 1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)))));\n    assert(splitTwoParts((List[Any](\"a\", \"b\", \"c\", \"d\")), (2l)).equals((Any(\"a\", \"b\"), List[String](\"c\", \"d\")))));\n    assert(splitTwoParts((List[Any](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")), (4l)).equals((Any(\"p\", \"y\", \"t\", \"h\"), List[String](\"o\", \"n\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    def findLiterals(text : String, pattern : String) : Tuple2[String, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals(((\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals(((\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals(((\"will\", 35l, 39l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the volume of a triangular prism.\n    def findVolume(l : Long, b : Long, h : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    def windChill(v : Long, t : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ascii value of a character.\n    def asciiValue(k : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether all the characters are same or not.\n    def allCharactersSame(s : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    def moveNum(test_str : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the length of the word is odd or not.\n    def wordLen(s : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to drop empty items from a given map.\n    def dropEmpty(dict1 : Map[String,Option[String]]) : Map[String,String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\"))));\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> None, \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\"))));\n    assert(dropEmpty(Map[String,None](\"c1\" -> None, \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c2\" -> \"Green\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    def insertElement(list : List[String], element : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(insertElement((List[String](\"Red\", \"Green\", \"Black\")), (\"c\")).equals((List[String](\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"))));\n    assert(insertElement((List[String](\"python\", \"java\")), (\"program\")).equals((List[String](\"program\", \"python\", \"program\", \"java\"))));\n    assert(insertElement((List[String](\"happy\", \"sad\")), (\"laugh\")).equals((List[String](\"laugh\", \"happy\", \"laugh\", \"sad\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    def removeLowercase(str1 : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of set bits (binary digits with value 1) in a given number.\n    def countSetBits(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    def extractRear(test_tuple : Tuple2[String, String, String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractRear(((\"Mers\", \"for\", \"Vers\"))).equals((List[String](\"s\", \"r\", \"s\"))));\n    assert(extractRear(((\"Avenge\", \"for\", \"People\"))).equals((List[String](\"e\", \"r\", \"e\"))));\n    assert(extractRear(((\"Gotta\", \"get\", \"go\"))).equals((List[String](\"a\", \"t\", \"o\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    def countOccurance(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    def checkK(test_tup : List[Long], K : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkK((List[Long](10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 8l.toLong)), (6l)) == (true));\n    assert(checkK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (7l)) == (false));\n    assert(checkK((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 44l.toLong, 11l.toLong, 12l.toLong)), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    def interleaveLists(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(interleaveLists((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong)), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong, 500l.toLong, 600l.toLong, 700l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 100l.toLong, 2l.toLong, 20l.toLong, 200l.toLong, 3l.toLong, 30l.toLong, 300l.toLong, 4l.toLong, 40l.toLong, 400l.toLong, 5l.toLong, 50l.toLong, 500l.toLong, 6l.toLong, 60l.toLong, 600l.toLong, 7l.toLong, 70l.toLong, 700l.toLong))));\n    assert(interleaveLists((List[Long](10l.toLong, 20l.toLong)), (List[Long](15l.toLong, 2l.toLong)), (List[Long](5l.toLong, 10l.toLong))).equals((List[Long](10l.toLong, 15l.toLong, 5l.toLong, 20l.toLong, 2l.toLong, 10l.toLong))));\n    assert(interleaveLists((List[Long](11l.toLong, 44l.toLong)), (List[Long](10l.toLong, 15l.toLong)), (List[Long](20l.toLong, 5l.toLong))).equals((List[Long](11l.toLong, 10l.toLong, 20l.toLong, 44l.toLong, 15l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of equal numbers from three given integers.\n    def testThreeEqual(x : Long, y : Long, z : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n    def oddLengthSum(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 4l.toLong))) == (14l));\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (15l));\n    assert(oddLengthSum((List[Long](1l.toLong, 7l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    def bellNumber(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the area of a rectangle.\n    def rectangleArea(l : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    def sumAverage(number : Long) : Tuple2[Long, Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumAverage((10l)).equals(((55l, 5.5f))));\n    assert(sumAverage((15l)).equals(((120l, 8.0f))));\n    assert(sumAverage((20l)).equals(((210l, 10.5f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    def divisionElements(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisionElements(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((2l, 2l, 2l, 3l))));\n    assert(divisionElements(((12l, 6l, 8l, 16l)), ((6l, 3l, 4l, 4l))).equals(((2l, 2l, 2l, 4l))));\n    assert(divisionElements(((20l, 14l, 36l, 18l)), ((5l, 7l, 6l, 9l))).equals(((4l, 2l, 6l, 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    def sumDigits(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    def indexMinimum(test_list : List[Tuple2[String, Long]]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Rash\", 143l), (\"Manjeet\", 200l), (\"Varsha\", 100l)))).equals((\"Varsha\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Yash\", 185l), (\"Dawood\", 125l), (\"Sanya\", 175l)))).equals((\"Dawood\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Sai\", 345l), (\"Salman\", 145l), (\"Ayesha\", 96l)))).equals((\"Ayesha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to divide two lists element wise.\n    def divList(nums1 : List[Long], nums2 : List[Long]) : List[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divList((List[Long](4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Float](4.0f.toFloat, 2.5f.toFloat, 2.0f.toFloat))));\n    assert(divList((List[Long](3l.toLong, 2l.toLong)), (List[Long](1l.toLong, 4l.toLong))).equals((List[Float](3.0f.toFloat, 0.5f.toFloat))));\n    assert(divList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Float](1.8f.toFloat, 1.7142857142857142f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list with maximum length.\n    def maxLengthList(input_list : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLengthList((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong)))).equals(((5l, List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong)))).equals(((4l, List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find all possible combinations of the elements of a given list.\n    def combinationsList(list1 : List[String]) : List[Either[List[None], List[String]]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsList((List[String](\"orange\", \"red\", \"green\", \"blue\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"orange\"), List[String](\"red\"), List[String](\"red\", \"orange\"), List[String](\"green\"), List[String](\"green\", \"orange\"), List[String](\"green\", \"red\"), List[String](\"green\", \"red\", \"orange\"), List[String](\"blue\"), List[String](\"blue\", \"orange\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"red\", \"orange\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"orange\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"blue\", \"green\", \"red\", \"orange\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"blue\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"white\"), List[String](\"white\", \"red\"), List[String](\"white\", \"green\"), List[String](\"white\", \"green\", \"red\"), List[String](\"white\", \"blue\"), List[String](\"white\", \"blue\", \"red\"), List[String](\"white\", \"blue\", \"green\"), List[String](\"white\", \"blue\", \"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"black\", \"blue\"), List[String](\"black\", \"blue\", \"red\"), List[String](\"black\", \"blue\", \"green\"), List[String](\"black\", \"blue\", \"green\", \"red\"), List[String](\"black\", \"white\"), List[String](\"black\", \"white\", \"red\"), List[String](\"black\", \"white\", \"green\"), List[String](\"black\", \"white\", \"green\", \"red\"), List[String](\"black\", \"white\", \"blue\"), List[String](\"black\", \"white\", \"blue\", \"red\"), List[String](\"black\", \"white\", \"blue\", \"green\"), List[String](\"black\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"blue\"), List[String](\"orange\", \"blue\", \"red\"), List[String](\"orange\", \"blue\", \"green\"), List[String](\"orange\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"white\"), List[String](\"orange\", \"white\", \"red\"), List[String](\"orange\", \"white\", \"green\"), List[String](\"orange\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"white\", \"blue\"), List[String](\"orange\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"blue\"), List[String](\"orange\", \"black\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\"), List[String](\"orange\", \"black\", \"white\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the largest and smallest value in a given list.\n    def bigSum(nums : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(bigSum((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigSum((List[Long](2l.toLong, 3l.toLong, 6l.toLong))) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to return the negative numbers in a list.\n    def negNos(list1 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(negNos((List[Long](-1l.toLong, 4l.toLong, 5l.toLong, -6l.toLong))).equals((List[Long](-1l.toLong, -6l.toLong))));\n    assert(negNos((List[Long](-1l.toLong, -2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](-1l.toLong, -2l.toLong))));\n    assert(negNos((List[Long](-7l.toLong, -6l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](-7l.toLong, -6l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the highest power of 2 that is less than or equal to n.\n    def highestPowerOf2(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    def isSublist(l : List[Long], s : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](3l.toLong, 7l.toLong))) == (false));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](4l.toLong, 3l.toLong))) == (true));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](1l.toLong, 6l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to subtract two lists element-wise.\n    def subList(nums1 : List[Long], nums2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](-3l.toLong, -3l.toLong, -3l.toLong))));\n    assert(subList((List[Long](1l.toLong, 2l.toLong)), (List[Long](3l.toLong, 4l.toLong))).equals((List[Long](-2l.toLong, -2l.toLong))));\n    assert(subList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Long](40l.toLong, 50l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given two integers have opposite sign or not.\n    def oppositeSigns(x : Long, y : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    def tupleModulo(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleModulo(((10l, 4l, 5l, 6l)), ((5l, 6l, 7l, 5l))).equals(((0l, 4l, 5l, 1l))));\n    assert(tupleModulo(((11l, 5l, 6l, 7l)), ((6l, 7l, 8l, 6l))).equals(((5l, 5l, 6l, 1l))));\n    assert(tupleModulo(((12l, 6l, 7l, 8l)), ((7l, 8l, 9l, 7l))).equals(((5l, 6l, 7l, 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    def diffEvenOdd(list1 : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(diffEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (3l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (1l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(list1 : List[List[String]]) : List[List[String]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"a\", \"b\"), List[String](\"d\", \"c\"), List[String](\"g\", \"h\"), List[String](\"f\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\"), List[String](\"c\", \"d\"), List[String](\"g\", \"h\"), List[String](\"e\", \"f\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last digit of a given number.\n    def lastDigit(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of fourth power of first n odd natural numbers.\n    def oddNumSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a string.\n    def tupString(tup1 : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupString((List[String](\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"))).equals((\"exercises\")));\n    assert(tupString((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))).equals((\"python\")));\n    assert(tupString((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))).equals((\"program\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    def removeElements(list1 : List[Long], list2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](5l.toLong, 7l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether any value in a sequence exists in a sequence or not.\n    def overlapping(list1 : List[Long], list2 : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 4l.toLong, 5l.toLong)), (List[Long](1l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to identify non-prime numbers.\n    def isNotPrime(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum value in a given heterogeneous list.\n    def maxVal(listval : List[Either[String, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (5l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (25l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (50l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    def sumNegativenum(nums : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumNegativenum((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (-32l));\n    assert(sumNegativenum((List[Long](10l.toLong, 15l.toLong, -14l.toLong, 13l.toLong, -18l.toLong, 12l.toLong, -20l.toLong))) == (-52l));\n    assert(sumNegativenum((List[Long](19l.toLong, -65l.toLong, 57l.toLong, 39l.toLong, 152l.toLong, -639l.toLong, 121l.toLong, 44l.toLong, 90l.toLong, -190l.toLong))) == (-894l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    def findRotations(str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    def changeDateFormat(dt : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of integers and only returns the odd ones.\n    def Split(list : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(Split((List[Long](10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong))).equals((List[Long](11l.toLong, 13l.toLong))));\n    assert(Split((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](7l.toLong, 9l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    def toggleMiddleBits(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    def countCharPosition(str1 : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    def largeProduct(nums1 : List[Long], nums2 : List[Long], N : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (3l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (4l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (5l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong, 45l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    def cummulativeSum(test_list : List[List[Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cummulativeSum((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](2l.toLong, 6l.toLong)))) == (30l));\n    assert(cummulativeSum((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 7l.toLong)))) == (37l));\n    assert(cummulativeSum((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](4l.toLong, 8l.toLong)))) == (44l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    def findMinDiff(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMinDiff((List[Long](1l.toLong, 5l.toLong, 3l.toLong, 19l.toLong, 18l.toLong, 25l.toLong)), (6l)) == (1l));\n    assert(findMinDiff((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 6l.toLong)), (4l)) == (1l));\n    assert(findMinDiff((List[Long](30l.toLong, 5l.toLong, 20l.toLong, 9l.toLong)), (4l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    def textStartaEndb(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    def leftRotate(n : Long, d : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first repeated character in a given string.\n    def firstRepeatedChar(str1 : String) : Option[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstRepeatedChar((\"abcabc\")).equals(\"a\"));\n    assert(firstRepeatedChar((\"abc\")).equals(None));\n    assert(firstRepeatedChar((\"123123\")).equals(\"1\"));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count inversions in a list.\n    def getInvCount(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getInvCount((List[Long](1l.toLong, 20l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))) == (5l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    def evenPowerSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    def getEqual(Input : List[List[Long]]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getEqual((List[List[Long]](List[Long](11l.toLong, 22l.toLong, 33l.toLong), List[Long](44l.toLong, 55l.toLong, 66l.toLong)))) == (true));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))) == (false));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string represents an integer or not.\n    def checkInteger(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/scalathon-program-to-count-the-pairs-of-reverse-strings/\n    def countReversePairs(test_list : List[String]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countReversePairs((List[String](\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"))) == (2l));\n    assert(countReversePairs((List[String](\"geeks\", \"best\", \"for\", \"skeeg\"))) == (1l));\n    assert(countReversePairs((List[String](\"makes\", \"best\", \"sekam\", \"for\", \"rof\"))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to move all zeroes to the end of the given list.\n    def moveZero(num_list : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveZero((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 0l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 0l.toLong, 0l.toLong, 4l.toLong, 0l.toLong, 5l.toLong, 0l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](0l.toLong, 1l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if given list contains no duplicates.\n    def checkDistinct(test_tup : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong, 4l.toLong))) == (false));\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkDistinct((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    def noprofitNoloss(actual_cost : Long, sale_amount : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all the words with k length in the given string.\n    def removeLength(test_str : String, K : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count number of digits in a given string.\n    def numberCtr(str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the total number of characters in a string.\n    def countCharac(str1 : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    def getTotalNumberOfSequences(m : Long, n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/scalathon-exercises/data-structures-and-algorithms/scalathon-data-structure-exercise-24.php\n    def leftInsertion(a : List[Long], x : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    def swapNumbers(a : Long, b : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapNumbers((10l), (20l)).equals((List[Long](20l.toLong, 10l.toLong))));\n    assert(swapNumbers((15l), (17l)).equals((List[Long](17l.toLong, 15l.toLong))));\n    assert(swapNumbers((100l), (200l)).equals((List[Long](200l.toLong, 100l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n    def isMajority(arr : List[Long], n : Long, x : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMajority((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 10l.toLong)), (7l), (3l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 6l.toLong, 6l.toLong)), (8l), (4l)) == (false));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    def substractElements(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Tuple2[Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(substractElements(((10l, 4l, 5l)), ((2l, 5l, 18l))).equals(((8l, -1l, -13l))));\n    assert(substractElements(((11l, 2l, 3l)), ((24l, 45l, 16l))).equals(((-13l, -43l, -13l))));\n    assert(substractElements(((7l, 18l, 9l)), ((10l, 11l, 12l))).equals(((-3l, 7l, -3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    def capitalWordsSpaces(str1 : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the average of cubes of first n natural numbers.\n    def findAverageOfCube(n : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == 12l);\n    assert(findAverageOfCube((1l)) == 1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all values are same in a map.\n    def checkValue(dict : Map[String,Long], n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (10l)) == (false));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (12l)) == (true));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (5l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth tetrahedral number.\n    def tetrahedralNumber(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    def magicSquareTest(my_matrix : List[List[Long]]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(magicSquareTest((List[List[Long]](List[Long](7l.toLong, 12l.toLong, 1l.toLong, 14l.toLong), List[Long](2l.toLong, 13l.toLong, 8l.toLong, 11l.toLong), List[Long](16l.toLong, 3l.toLong, 10l.toLong, 5l.toLong), List[Long](9l.toLong, 6l.toLong, 15l.toLong, 4l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 8l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 7l.toLong)))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    def removeUppercase(str1 : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether an element exists within a tuple.\n    def checkTuplex(tuplex : List[Either[String, Long]], tuple1 : Any) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"r\"))) == (true));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"5\"))) == (false));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(3l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    def dogAge(h_age : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the next perfect square greater than a given number.\n    def nextPerfectSquare(N : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a list of N empty dictionaries.\n    def emptyList(length : Long) : List[Map[None,None]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(emptyList((5l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((6l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((7l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert a given string to uppercase.\n    def isUpper(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    def oddEquivalent(s : String, n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    def reArrangeArray(arr : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reArrangeArray((List[Long](-1l.toLong, 2l.toLong, -3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -7l.toLong, 8l.toLong, 9l.toLong)), (9l)).equals((List[Long](-1l.toLong, -3l.toLong, -7l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(reArrangeArray((List[Long](12l.toLong, -14l.toLong, -26l.toLong, 13l.toLong, 15l.toLong)), (5l)).equals((List[Long](-14l.toLong, -26l.toLong, 12l.toLong, 13l.toLong, 15l.toLong))));\n    assert(reArrangeArray((List[Long](10l.toLong, 24l.toLong, 36l.toLong, -42l.toLong, -39l.toLong, -78l.toLong, 85l.toLong)), (7l)).equals((List[Long](-42l.toLong, -39l.toLong, -78l.toLong, 10l.toLong, 24l.toLong, 36l.toLong, 85l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether a list of numbers contains only one distinct element or not.\n    def uniqueElement(arr : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueElement((List[Long](1l.toLong, 1l.toLong, 1l.toLong))) == (true));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks from a string.\n    def extractValues(text : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((List[String](\"Python\", \"PHP\", \"Java\"))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((List[String](\"python\", \"program\", \"language\"))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((List[String](\"red\", \"blue\", \"green\", \"yellow\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count true booleans in the given list.\n    def count(lst : List[Boolean]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(count((List[Boolean](true.toBoolean, false.toBoolean, true.toBoolean))) == (2l));\n    assert(count((List[Boolean](false.toBoolean, false.toBoolean))) == (0l));\n    assert(count((List[Boolean](true.toBoolean, true.toBoolean, true.toBoolean))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    def findEvenPair(A : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findEvenPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong))) == (4l));\n    assert(findEvenPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong))) == (9l));\n    assert(findEvenPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    def armstrongNumber(number : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the upper case characters in a given string.\n    def upperCtr(str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    def andTuples(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(andTuples(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((0l, 0l, 2l, 1l))));\n    assert(andTuples(((1l, 2l, 3l, 4l)), ((5l, 6l, 7l, 8l))).equals(((1l, 2l, 3l, 0l))));\n    assert(andTuples(((8l, 9l, 11l, 12l)), ((7l, 13l, 14l, 17l))).equals(((0l, 9l, 10l, 0l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether it follows the sequence given in the patterns list.\n    def isSamepatterns(colors : List[String], patterns : List[String]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"green\")), (List[String](\"a\", \"b\", \"b\"))) == (true));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\", \"b\"))) == (false));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\"))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of lists in a given number of lists.\n    def countList(input_list : List[List[Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))) == (4l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))) == (3l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 0l.toLong), List[Long](2l.toLong, 0l.toLong)))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    def averageTuple(nums : List[List[Long]]) : List[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(averageTuple((List[List[Long]](List[Long](10l.toLong, 10l.toLong, 10l.toLong, 12l.toLong), List[Long](30l.toLong, 45l.toLong, 56l.toLong, 45l.toLong), List[Long](81l.toLong, 80l.toLong, 39l.toLong, 32l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))).equals((List[Float](30.5f.toFloat, 34.25f.toFloat, 27.0f.toFloat, 23.25f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](1l.toLong, 1l.toLong, -5l.toLong), List[Long](30l.toLong, -15l.toLong, 56l.toLong), List[Long](81l.toLong, -60l.toLong, -39l.toLong), List[Long](-10l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Float](25.5f.toFloat, -18.0f.toFloat, 3.75f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](100l.toLong, 100l.toLong, 100l.toLong, 120l.toLong), List[Long](300l.toLong, 450l.toLong, 560l.toLong, 450l.toLong), List[Long](810l.toLong, 800l.toLong, 390l.toLong, 320l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((List[Float](305.0f.toFloat, 342.5f.toFloat, 270.0f.toFloat, 232.5f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    def lcsOfThree(X : String, Y : String, Z : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th star number.\n    def findStarNum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of a list.\n    def Sum(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Sum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(Sum((List[Long](15l.toLong, 12l.toLong, 13l.toLong, 10l.toLong))) == (50l));\n    assert(Sum((List[Long](0l.toLong, 1l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given list contains consecutive numbers or not.\n    def checkConsecutive(l : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    def findAdverbPosition(text : String) : Tuple2[Long, Long, String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals(((0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals(((0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals(((0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/scalathon-program-right-rotate-list-n/\n    def rotateRight(list : List[Long], m : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (3l)).equals((List[Long](8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (5l)).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of non-empty substrings of a given string.\n    def numberOfSubstrings(str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    def listSplit(S : List[Any], step : Long) : List[List[Any]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listSplit((List[Any](\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\")), (3l)).equals((List[List[Any]](List[String](\"a\", \"d\", \"g\", \"j\", \"m\"), List[String](\"b\", \"e\", \"h\", \"k\", \"n\"), List[String](\"c\", \"f\", \"i\", \"l\")))));\n    assert(listSplit((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (3l)).equals((List[List[Any]](List[Long](1l.toLong, 4l.toLong, 7l.toLong, 10l.toLong, 13l.toLong), List[Long](2l.toLong, 5l.toLong, 8l.toLong, 11l.toLong, 14l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 12l.toLong)))));\n    assert(listSplit((List[Any](\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\")), (2l)).equals((List[List[Any]](List[String](\"python\", \"C\", \"DBMS\"), List[String](\"java\", \"C++\", \"SQL\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check if the elements of a given list are unique or not.\n    def allUnique(test_list : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert complex numbers to polar coordinates.\n    def convert(numbers : Long) : Tuple2[Float, Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convert((1l)).equals(((1.0f, 0.0f))));\n    assert(convert((4l)).equals(((4.0f, 0.0f))));\n    assert(convert((5l)).equals(((5.0f, 0.0f))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is given as - a map with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    def filterData(students : Map[String,Tuple2[Float, Long]], h : Float, w : Long) : Map[String,Tuple2[Float, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (6.0f), (70l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.9f), (67l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Kierra Gentry\" -> (6.0f, 68l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.7f), (64l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert the given string to lower case.\n    def isLower(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the smallest power of 2 greater than or equal to n.\n    def nextPowerOf2(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    def findSubstring(str1 : List[String], sub_str : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ack\")) == (true));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"abc\")) == (false));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ange\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace characters in a string.\n    def replaceChar(str1 : String, ch : String, newch : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    def mulEvenOdd(list1 : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mulEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (4l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (10l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a tuple.\n    def listTuple(listx : List[Long]) : Any = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listTuple((List[Long](5l.toLong, 10l.toLong, 7l.toLong, 4l.toLong, 15l.toLong, 3l.toLong))).equals((Any((5l, 10l, 7l, 4l, 15l, 3l)))));\n    assert(listTuple((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 7l.toLong))).equals((Any((2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)))));\n    assert(listTuple((List[Long](58l.toLong, 44l.toLong, 56l.toLong))).equals((Any((58l, 44l, 56l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    def evenBinomialCoeffSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    def bitwiseXor(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bitwiseXor(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((15l, 6l, 5l, 10l))));\n    assert(bitwiseXor(((11l, 5l, 7l, 10l)), ((6l, 3l, 4l, 4l))).equals(((13l, 6l, 3l, 14l))));\n    assert(bitwiseXor(((12l, 6l, 8l, 11l)), ((7l, 4l, 5l, 6l))).equals(((11l, 2l, 13l, 13l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether a list is sublist of another or not.\n    def isSubArray(A : List[Long], B : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSubArray((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)), (List[Long](1l.toLong, 2l.toLong))) == (false));\n    assert(isSubArray((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (true));\n    assert(isSubArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 2l.toLong)), (List[Long](2l.toLong, 2l.toLong, 0l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n    def maxSubArraySumRepeated(a : List[Long], n : Long, k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySumRepeated((List[Long](10l.toLong, 20l.toLong, -30l.toLong, -1l.toLong)), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, 10l.toLong, 20l.toLong)), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)), (3l), (3l)) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    def minProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (8l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (30l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (100l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the count of divisors is even. https://www.w3resource.com/scalathon-exercises/basic/scalathon-basic-1-exercise-24.php\n    def countDivisors(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    def triangleArea(r : Long) : Option[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((-1l)).equals(None));\n    assert(triangleArea((0l)).equals(0l));\n    assert(triangleArea((2l)).equals(4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given string to a list of characters.\n    def stringToTuple(str1 : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToTuple((\"python 3.0\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"))));\n    assert(stringToTuple((\"item1\")).equals((List[String](\"i\", \"t\", \"e\", \"m\", \"1\"))));\n    assert(stringToTuple((\"15.10\")).equals((List[String](\"1\", \"5\", \".\", \"1\", \"0\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    def findLength(string : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    def countPrimesNums(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the product of consecutive binomial co-efficients.\n    def sumOfProduct(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    def maxAggregate(stdata : List[Tuple2[String, Long]]) : Tuple2[String, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 90l), (\"Sabah Colley\", 88l), (\"Peter Nichols\", 7l), (\"Juan Whelan\", 122l), (\"Sabah Colley\", 84l)))).equals(((\"Juan Whelan\", 212l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 50l), (\"Sabah Colley\", 48l), (\"Peter Nichols\", 37l), (\"Juan Whelan\", 22l), (\"Sabah Colley\", 14l)))).equals(((\"Juan Whelan\", 72l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 10l), (\"Sabah Colley\", 20l), (\"Peter Nichols\", 30l), (\"Juan Whelan\", 40l), (\"Sabah Colley\", 50l)))).equals(((\"Sabah Colley\", 70l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def combSort(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combSort((List[Long](5l.toLong, 15l.toLong, 37l.toLong, 25l.toLong, 79l.toLong))).equals((List[Long](5l.toLong, 15l.toLong, 25l.toLong, 37l.toLong, 79l.toLong))));\n    assert(combSort((List[Long](41l.toLong, 32l.toLong, 15l.toLong, 19l.toLong, 22l.toLong))).equals((List[Long](15l.toLong, 19l.toLong, 22l.toLong, 32l.toLong, 41l.toLong))));\n    assert(combSort((List[Long](99l.toLong, 15l.toLong, 13l.toLong, 47l.toLong))).equals((List[Long](13l.toLong, 15l.toLong, 47l.toLong, 99l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    def checkExpression(exp : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a word containing 'z'.\n    def textMatchWordz(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    def sumList(lst1 : List[Long], lst2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumList((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 25l.toLong, 35l.toLong))).equals((List[Long](25l.toLong, 45l.toLong, 65l.toLong))));\n    assert(sumList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(sumList((List[Long](15l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 45l.toLong, 75l.toLong))).equals((List[Long](30l.toLong, 65l.toLong, 105l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    def newmanPrime(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    def addString(list_ : List[Any], string : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addString((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (\"temp{0}\")).equals((List[String](\"temp1\", \"temp2\", \"temp3\", \"temp4\"))));\n    assert(addString((List[Any](\"a\", \"b\", \"c\", \"d\")), (\"python{0}\")).equals((List[String](\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"))));\n    assert(addString((List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (\"string{0}\")).equals((List[String](\"string5\", \"string6\", \"string7\", \"string8\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the surface area of a square scalaramid with a given base edge and height.\n    def surfaceArea(b : Long, s : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the smallest list in a list of lists.\n    def FindMinLength(lst : List[List[Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong)))) == (1l));\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))) == (2l));\n    assert(FindMinLength((List[List[Long]](List[Long](3l.toLong, 3l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    def validate(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth hexagonal number.\n    def hexagonalNum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th lucas number.\n    def findLucas(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to get the difference between two lists.\n    def Diff(li1 : List[Long], li2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Diff((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong, 30l.toLong, 35l.toLong, 40l.toLong)), (List[Long](25l.toLong, 40l.toLong, 35l.toLong))).equals((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 15l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    def extractQuotation(text1 : String) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((List[Any](\"A53\", \"multi\", \"Processor\"))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((List[Any](\"favorite\", \"apps\"))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((List[Any](\"4k Ultra HD\", \"HDR 10\"))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a list and sum all of its elements.\n    def recursiveListSum(data_list : List[Either[Long, List[Long]]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(recursiveListSum((List[Either[Long, List[Long]]](1l, 2l, List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (21l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](7l, 10l, List[Long](15l.toLong, 14l.toLong), List[Long](19l.toLong, 41l.toLong)))) == (106l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](10l, 20l, List[Long](30l.toLong, 40l.toLong), List[Long](50l.toLong, 60l.toLong)))) == (210l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the two numbers differ at one bit position only or not.\n    def differAtOneBitPos(a : Long, b : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    def textMatchThree(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n    def maxProduct(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong, 150l.toLong, 6l.toLong))) == (3000l));\n    assert(maxProduct((List[Long](4l.toLong, 42l.toLong, 55l.toLong, 68l.toLong, 80l.toLong))) == (50265600l));\n    assert(maxProduct((List[Long](10l.toLong, 22l.toLong, 9l.toLong, 33l.toLong, 21l.toLong, 50l.toLong, 41l.toLong, 60l.toLong))) == (2460l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to split a list at the nth eelment and add the first part to the end.\n    def splitArr(l : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitArr((List[Long](12l.toLong, 10l.toLong, 5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong)), (2l)).equals((List[Long](5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong, 12l.toLong, 10l.toLong))));\n    assert(splitArr((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(splitArr((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (3l)).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 0l.toLong, 1l.toLong, 2l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the number of divisors of a given integer.\n    def divisor(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the difference between largest and smallest value in a given list.\n    def bigDiff(nums : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigDiff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigDiff((List[Long](4l.toLong, 5l.toLong, 12l.toLong))) == (8l));\n    assert(bigDiff((List[Long](9l.toLong, 2l.toLong, 3l.toLong))) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find squares of individual elements in a list.\n    def squareNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(squareNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](100l.toLong, 400l.toLong, 900l.toLong))));\n    assert(squareNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](144l.toLong, 225l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    def checkNone(test_tup : Any) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkNone((Any(10l), Some(4l), Some(5l), Some(6l), Some(None)))) == (true));\n    assert(checkNone((Any((7l, 8l, 9l, 11l, 14l)))) == (false));\n    assert(checkNone((Any(1l), Some(2l), Some(3l), Some(4l), Some(None)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given list is monotonic or not.\n    def isMonotonic(A : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMonotonic((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    def isPerfectSquare(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of common divisors of two given numbers.\n    def sum(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    def maxLength(list1 : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLength((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](1l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))).equals(((4l, List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](5l.toLong), List[Long](15l.toLong, 20l.toLong, 25l.toLong)))).equals(((3l, List[Long](15l.toLong, 20l.toLong, 25l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a map mapping each unique tuple to the number of times it occurs in the list.\n    def checkOccurences(test_list : List[Tuple2[Long, Long]]) : Map[Tuple2[Long, Long],Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkOccurences((List[Tuple2[Long, Long]]((3l, 1l), (1l, 3l), (2l, 5l), (5l, 2l), (6l, 3l)))).equals((Map[Tuple2[Long, Long],Long]((1l, 3l) -> 2l, (2l, 5l) -> 2l, (3l, 6l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((4l, 2l), (2l, 4l), (3l, 6l), (6l, 3l), (7l, 4l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 4l) -> 2l, (3l, 6l) -> 2l, (4l, 7l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((13l, 2l), (11l, 23l), (12l, 25l), (25l, 12l), (16l, 23l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 13l) -> 1l, (11l, 23l) -> 1l, (12l, 25l) -> 2l, (16l, 23l) -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the directrix of a parabola.\n    def parabolaDirectrix(a : Long, b : Long, c : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    def occuranceSubstring(text : String, pattern : String) : Option[Tuple2[String, Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals((\"python\", 0l, 6l)));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals((\"programming\", 7l, 18l)));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals((\"language\", 31l, 39l)));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove tuples from the given tuple.\n    def removeNested(test_tup : Any) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeNested((Any(4l, 6l), 10l))).equals(((1l, 5l, 7l, 10l))));\n    assert(removeNested((Any(5l, 7l), 11l))).equals(((2l, 6l, 8l, 11l))));\n    assert(removeNested((Any(6l, 8l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    assert(removeNested((Any(6l, 8l), (5l, 12l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(input_list : List[List[String]]) : List[List[String]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\" red \", \"green\"), List[String](\"blue \", \" black\"), List[String](\" orange\", \"brown\")))).equals((List[List[String]](List[String](\" red \", \"green\"), List[String](\" black\", \"blue \"), List[String](\" orange\", \"brown\")))));\n    assert(sortSublists((List[List[String]](List[String](\"zilver\", \"gold\"), List[String](\"magnesium\", \"aluminium\"), List[String](\"steel\", \"bronze\")))).equals((List[List[String]](List[String](\"gold\", \"zilver\"), List[String](\"aluminium\", \"magnesium\"), List[String](\"bronze\", \"steel\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list and returns a list with the same elements, but the k'th element removed.\n    def removeKthElement(list1 : List[Long], L : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeKthElement((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))));\n    assert(removeKthElement((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong)), (4l)).equals((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))));\n    assert(removeKthElement((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong)), (5l)).equals((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add a map to the tuple. The output should be a tuple.\n    def addDictToTuple(test_tup : Tuple2[Long, Long, Long], test_dict : Map[String,Long]) : Tuple2[Long, Long, Long, Map[String,Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addDictToTuple(((4l, 5l, 6l)), (Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l))).equals(((4l, 5l, 6l, Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l)))));\n    assert(addDictToTuple(((1l, 2l, 3l)), (Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l))).equals(((1l, 2l, 3l, Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l)))));\n    assert(addDictToTuple(((8l, 9l, 10l)), (Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l))).equals(((8l, 9l, 10l, Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find quotient of two numbers (rounded down to the nearest integer).\n    def find(n : Long, m : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    def textMatchTwoThree(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the occurence of all elements of list in a tuple.\n    def countOccurrence(tup : Any, lst : List[Any]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurrence((Any((\"a\", \"a\", \"c\", \"b\", \"d\"))), (List[Any](\"a\", \"b\"))) == (3l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l))), (List[Any](1l.toLong, 4l.toLong, 7l.toLong))) == (6l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 4l, 5l, 6l))), (List[Any](1l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    def countSamepair(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (3l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (4l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    def textMatchOne(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    def difference(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to toggle the case of all characters in a string.\n    def toggleString(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the element of a list having maximum length.\n    def FindMax(lst : List[List[Any]]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMax((List[List[Any]](List[String](\"A\"), List[String](\"A\", \"B\"), List[String](\"A\", \"B\", \"C\")))).equals((List[Any](\"A\", \"B\", \"C\"))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong)))).equals((List[Any](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    def eulerianNum(n : Long, m : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    def frequency(a : List[Long], x : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l)) == (0l));\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)), (3l)) == (3l));\n    assert(frequency((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong)), (1l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/scalathon-sort-numeric-strings-in-a-list/\n    def sortNumericStrings(nums_str : List[String]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumericStrings((List[String](\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"))).equals((List[Long](-500l.toLong, -12l.toLong, 0l.toLong, 4l.toLong, 7l.toLong, 12l.toLong, 45l.toLong, 100l.toLong, 200l.toLong))));\n    assert(sortNumericStrings((List[String](\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 9l.toLong))));\n    assert(sortNumericStrings((List[String](\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong, 15l.toLong, 17l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/scalathon-exercises/data-structures-and-algorithms/scalathon-recursion-exercise-9.php\n    def geometricSum(n : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/scalathon-exercises/lambda/scalathon-lambda-exercise-24.php\n    def divisibleByDigits(startnum : Long, endnum : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisibleByDigits((1l), (22l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong, 22l.toLong))));\n    assert(divisibleByDigits((1l), (15l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong))));\n    assert(divisibleByDigits((20l), (25l)).equals((List[Long](22l.toLong, 24l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to calculate the product of the unique numbers in a given list.\n    def uniqueProduct(list_data : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueProduct((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 50l.toLong, 60l.toLong, 40l.toLong))) == (720000000l));\n    assert(uniqueProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (6l));\n    assert(uniqueProduct((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the largest negative number from the given list.\n    def largestNeg(list1 : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -4l.toLong, -6l.toLong))) == (-6l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -8l.toLong, -9l.toLong))) == (-9l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    def consecutiveDuplicates(nums : List[Any]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(consecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[Any](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong))));\n    assert(consecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[Any](10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\"))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\", \"a\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    def minJumps(steps : Tuple2[Long, Long], d : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minJumps(((3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps(((3l, 4l)), (0l)) == 0l);\n    assert(minJumps(((11l, 14l)), (11l)) == 1l);\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find a pair with highest product from a given list of integers.\n    def maxProduct(arr : List[Long]) : Tuple2[Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 0l.toLong, 8l.toLong, 4l.toLong))).equals(((7l, 8l))));\n    assert(maxProduct((List[Long](0l.toLong, -1l.toLong, -2l.toLong, -4l.toLong, 5l.toLong, 0l.toLong, -6l.toLong))).equals(((-4l, -6l))));\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals(((2l, 3l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    def extractNthElement(list1 : List[Tuple2[String, Long, Long]], n : Long) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (0l)).equals((List[Any](\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (2l)).equals((List[Any](99l.toLong, 96l.toLong, 94l.toLong, 98l.toLong))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (1l)).equals((List[Any](98l.toLong, 97l.toLong, 91l.toLong, 94l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth nonagonal number.\n    def isNonagonal(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the maximum difference between any two elements in a given list.\n    def maxAbsDiff(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAbsDiff((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 3l.toLong))) == (4l));\n    assert(maxAbsDiff((List[Long](9l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (8l));\n    assert(maxAbsDiff((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    def packConsecutiveDuplicates(list1 : List[Any]) : List[List[Any]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(packConsecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[List[Any]](List[Long](0l.toLong, 0l.toLong), List[Long](1l.toLong), List[Long](2l.toLong), List[Long](3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](5l.toLong), List[Long](6l.toLong, 6l.toLong, 6l.toLong), List[Long](7l.toLong), List[Long](8l.toLong), List[Long](9l.toLong), List[Long](4l.toLong, 4l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[List[Any]](List[Long](10l.toLong, 10l.toLong), List[Long](15l.toLong), List[Long](19l.toLong), List[Long](18l.toLong, 18l.toLong), List[Long](17l.toLong), List[Long](26l.toLong, 26l.toLong), List[Long](17l.toLong), List[Long](18l.toLong), List[Long](10l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[List[Any]](List[String](\"a\", \"a\"), List[String](\"b\"), List[String](\"c\"), List[String](\"d\", \"d\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    def calSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove the characters which have odd index values of a given string.\n    def oddValuesString(str : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find kth element from the given two sorted lists.\n    def findKth(arr1 : List[Long], arr2 : List[Long], k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findKth((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](1l.toLong, 4l.toLong, 8l.toLong, 10l.toLong)), (5l)) == (6l));\n    assert(findKth((List[Long](100l.toLong, 112l.toLong, 256l.toLong, 349l.toLong, 770l.toLong)), (List[Long](72l.toLong, 86l.toLong, 113l.toLong, 119l.toLong, 265l.toLong, 445l.toLong, 892l.toLong)), (7l)) == (256l));\n    assert(findKth((List[Long](3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 10l.toLong)), (List[Long](2l.toLong, 5l.toLong, 9l.toLong, 11l.toLong)), (6l)) == (8l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    def jacobsthalNum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a map.\n    def frequencyLists(list1 : List[List[Long]]) : Map[Long,Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong, 5l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 3l, 3l -> 1l, 4l -> 1l, 5l -> 2l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 1l, 3l -> 1l, 4l -> 1l, 5l -> 1l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l, 10l -> 1l, 11l -> 1l, 12l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](20l.toLong, 30l.toLong, 40l.toLong, 17l.toLong), List[Long](18l.toLong, 16l.toLong, 14l.toLong, 13l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((Map[Long,Long](20l -> 2l, 30l -> 2l, 40l -> 2l, 17l -> 1l, 18l -> 1l, 16l -> 1l, 14l -> 1l, 13l -> 1l, 10l -> 1l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find perfect squares between two given numbers.\n    def perfectSquares(a : Long, b : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perfectSquares((1l), (30l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong))));\n    assert(perfectSquares((50l), (100l)).equals((List[Long](64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(perfectSquares((100l), (200l)).equals((List[Long](100l.toLong, 121l.toLong, 144l.toLong, 169l.toLong, 196l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n    def sumOfSubarrayProd(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (20l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong))) == (5l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (84l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first odd number in a given list of numbers.\n    def firstOdd(nums : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong))) == (1l));\n    assert(firstOdd((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(firstOdd((List[Long](8l.toLong, 9l.toLong, 1l.toLong))) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    def addNestedTuples(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addNestedTuples((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 10l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 13l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](9l.toLong, 12l.toLong), List[Long](9l.toLong, 16l.toLong), List[Long](5l.toLong, 12l.toLong), List[Long](10l.toLong, 15l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](11l.toLong, 14l.toLong), List[Long](11l.toLong, 18l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](12l.toLong, 17l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    def merge(lst : List[List[Any]]) : List[List[Any]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\"), List[String](\"a\", \"b\"), List[String](\"m\", \"n\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\")))));\n    assert(merge((List[List[Any]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong)))).equals((List[List[Any]](List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)))));\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\", \"z\"), List[String](\"a\", \"b\", \"c\"), List[String](\"m\", \"n\", \"o\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\"), List[String](\"z\", \"c\", \"o\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number can be represented as the difference of two squares or not.\n    def difSquare(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    def checkSmaller(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkSmaller(((1l, 2l, 3l)), ((2l, 3l, 4l))) == (false));\n    assert(checkSmaller(((4l, 5l, 6l)), ((3l, 4l, 5l))) == (true));\n    assert(checkSmaller(((11l, 12l, 13l)), ((10l, 11l, 12l))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a map.\n    def freqCount(list1 : List[Long]) : Map[Long,Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(freqCount((List[Long](10l.toLong, 10l.toLong, 10l.toLong, 10l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 40l.toLong, 40l.toLong, 50l.toLong, 50l.toLong, 30l.toLong))).equals((Map[Long,Long](10l -> 4l, 20l -> 4l, 40l -> 2l, 50l -> 2l, 30l -> 1l))));\n    assert(freqCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 4l.toLong))).equals((Map[Long,Long](1l -> 3l, 2l -> 2l, 3l -> 3l, 4l -> 3l))));\n    assert(freqCount((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 5l.toLong))).equals((Map[Long,Long](10l -> 1l, 5l -> 3l, 6l -> 2l, 7l -> 2l, 4l -> 2l, 9l -> 2l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    def rgbToHsv(r : Long, g : Long, b : Long) : List[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((List[Float](0.0f.toFloat, 0.0f.toFloat, 100.0f.toFloat))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((List[Float](120.0f.toFloat, 100.0f.toFloat, 84.31372549019608f.toFloat))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((List[Float](149.26829268292684f.toFloat, 95.34883720930233f.toFloat, 84.31372549019608f.toFloat))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a given nested list structure.\n    def flattenList(list1 : List[Either[Long, List[Long]]]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flattenList((List[Either[Long, List[Long]]](0l, 10l, List[Long](20l.toLong, 30l.toLong), 40l, 50l, List[Long](60l.toLong, 70l.toLong, 80l.toLong), List[Long](90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong)))).equals((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong, 80l.toLong, 90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](10l.toLong, 20l.toLong), List[Long](40l.toLong), List[Long](30l.toLong, 56l.toLong, 25l.toLong), List[Long](10l.toLong, 20l.toLong), List[Long](33l.toLong), List[Long](40l.toLong)))).equals((List[Long](10l.toLong, 20l.toLong, 40l.toLong, 30l.toLong, 56l.toLong, 25l.toLong, 10l.toLong, 20l.toLong, 33l.toLong, 40l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    def checkStr(string : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    def checkMonthnumberNumber(monthnum3 : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list.\n    def heapSort(iterable : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapSort((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(heapSort((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong))).equals((List[Long](14l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 58l.toLong, 65l.toLong, 75l.toLong, 85l.toLong))));\n    assert(heapSort((List[Long](7l.toLong, 1l.toLong, 9l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n    def kSmallestPairs(nums1 : List[Long], nums2 : List[Long], k : Long) : List[List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (2l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (1l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (7l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](3l.toLong, 2l.toLong), List[Long](1l.toLong, 6l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](7l.toLong, 2l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    def findSolution(a : Long, b : Long, n : Long) : Option[Tuple2[Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSolution((2l), (3l), (7l)).equals((2l, 1l)));\n    assert(findSolution((4l), (2l), (7l)).equals(None));\n    assert(findSolution((1l), (13l), (17l)).equals((4l, 1l)));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the largest number that can be formed with the given list of digits.\n    def findMaxNum(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (321l));\n    assert(findMaxNum((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (6541l));\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 9l.toLong))) == (9321l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    def maxSumList(lists : List[List[Long]]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](10l.toLong, 11l.toLong, 12l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](12l.toLong, 11l.toLong, 10l.toLong)))).equals((List[Long](12l.toLong, 11l.toLong, 10l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 1l.toLong)))).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to interchange the first and last elements in a list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](12l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 24l.toLong))).equals((List[Long](24l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 12l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    def getMedian(arr1 : List[Long], arr2 : List[Long], n : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMedian((List[Long](1l.toLong, 12l.toLong, 15l.toLong, 26l.toLong, 38l.toLong)), (List[Long](2l.toLong, 13l.toLong, 17l.toLong, 30l.toLong, 45l.toLong)), (5l)) == (16.0f));\n    assert(getMedian((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong)), (List[Long](7l.toLong, 13l.toLong, 19l.toLong, 28l.toLong)), (4l)) == (8.5f));\n    assert(getMedian((List[Long](3l.toLong, 6l.toLong, 14l.toLong, 23l.toLong, 36l.toLong, 42l.toLong)), (List[Long](2l.toLong, 18l.toLong, 27l.toLong, 39l.toLong, 49l.toLong, 55l.toLong)), (6l)) == (25.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    def replaceSpaces(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    def areEquivalent(num1 : Long, num2 : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse each string in a given list of string values.\n    def reverseStringList(stringlist : List[String]) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseStringList((List[String](\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"))).equals((List[String](\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"))));\n    assert(reverseStringList((List[String](\"john\", \"amal\", \"joel\", \"george\"))).equals((List[String](\"nhoj\", \"lama\", \"leoj\", \"egroeg\"))));\n    assert(reverseStringList((List[String](\"jack\", \"john\", \"mary\"))).equals((List[String](\"kcaj\", \"nhoj\", \"yram\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    def sumOfDigits(nums : List[Any]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfDigits((List[Any](10l.toLong, 2l.toLong, 56l.toLong))) == (14l));\n    assert(sumOfDigits((List[Any](List[Any](10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))) == (19l));\n    assert(sumOfDigits((List[Any](10l.toLong, 20l.toLong, -4l.toLong, 5l.toLong, -70l.toLong))) == (19l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    def sequence(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    def heapQueueLargest(nums : List[Long], n : Long) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (3l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (2l)).equals((List[Long](85l.toLong, 75l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (5l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong, 58l.toLong, 35l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    def lossAmount(actual_cost : Long, sale_amount : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    def unionElements(test_tup1 : List[Long], test_tup2 : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unionElements((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](5l.toLong, 7l.toLong, 4l.toLong, 10l.toLong))).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 10l.toLong))));\n    assert(unionElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(unionElements((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (List[Long](13l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))).equals((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the longest sublists.\n    def FindMaxLength(lst : List[List[Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMaxLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (4l));\n    assert(FindMaxLength((List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](3l.toLong, 2l.toLong, 1l.toLong)))) == (3l));\n    assert(FindMaxLength((List[List[Long]](List[Long](7l.toLong), List[Long](22l.toLong, 23l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong)))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    def removeParenthesis(items : List[String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeParenthesis((List[String](\"python (chrome)\"))).equals((\"python\")));\n    assert(removeParenthesis((List[String](\"string(.abc)\"))).equals((\"string\")));\n    assert(removeParenthesis((List[String](\"alpha(num)\"))).equals((\"alpha\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find whether the parity of a given number is odd.\n    def findParity(x : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median length of a trapezium.\n    def medianTrapezium(base1 : Long, base2 : Long, height : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianTrapezium((15l), (25l), (35l)) == 20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == 15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth centered hexagonal number.\n    def centeredHexagonalNumber(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find number of lists present in the given list.\n    def findLists(Input : List[Any]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (2l));\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (3l));\n    assert(findLists((List[Any](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    def getMaxSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the longest word.\n    def lenLog(list1 : List[String]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lenLog((List[String](\"python\", \"PHP\", \"bigdata\"))) == (7l));\n    assert(lenLog((List[String](\"a\", \"ab\", \"abc\"))) == (3l));\n    assert(lenLog((List[String](\"small\", \"big\", \"tall\"))) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    def sectorArea(r : Long, a : Long) : Option[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sectorArea((4l), (45l)).equals(6.283185307179586f));\n    assert(sectorArea((9l), (45l)).equals(31.808625617596654f));\n    assert(sectorArea((9l), (361l)).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether every odd index contains odd numbers of a given list.\n    def oddPosition(nums : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 3l.toLong))) == (true));\n    assert(oddPosition((List[Long](4l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(oddPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    def multipleToSingle(L : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multipleToSingle((List[Long](11l.toLong, 33l.toLong, 50l.toLong))) == (113350l));\n    assert(multipleToSingle((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (-123456l));\n    assert(multipleToSingle((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong))) == (10152025l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find whether a number is divisible by 11.\n    def isDiff(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    def indexMultiplication(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMultiplication((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 21l.toLong), List[Long](12l.toLong, 45l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 30l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](14l.toLong, 32l.toLong), List[Long](20l.toLong, 60l.toLong), List[Long](6l.toLong, 20l.toLong), List[Long](16l.toLong, 44l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](24l.toLong, 45l.toLong), List[Long](30l.toLong, 77l.toLong), List[Long](12l.toLong, 33l.toLong), List[Long](27l.toLong, 60l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert tuple string to integer tuple.\n    def tupleStrInt(test_str : String) : Tuple2[Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals(((7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals(((1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals(((4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals(((7l, 81l, 19l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    def amicableNumbersSum(limit : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove odd characters in a string.\n    def removeOdd(str1 : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    def multiplyElements(test_tup : List[Long]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyElements((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 10l.toLong))).equals((List[Any](5l.toLong, 35l.toLong, 56l.toLong, 80l.toLong))));\n    assert(multiplyElements((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](8l.toLong, 20l.toLong, 30l.toLong, 42l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong, 13l.toLong, 14l.toLong, 9l.toLong, 15l.toLong))).equals((List[Any](156l.toLong, 182l.toLong, 126l.toLong, 135l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n    def countRotation(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countRotation((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(countRotation((List[Long](4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (2l));\n    assert(countRotation((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(countRotation((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (0l));\n    assert(countRotation((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    def extractFreq(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractFreq((List[Tuple2[Long, Long]]((3l, 4l), (1l, 2l), (4l, 3l), (5l, 6l)))) == (3l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((4l, 15l), (2l, 3l), (5l, 4l), (6l, 7l)))) == (4l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((5l, 16l), (2l, 3l), (6l, 5l), (6l, 9l)))) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    def countSamePair(nums1 : List[Long], nums2 : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamePair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (4l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (11l));\n    assert(countSamePair((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (1l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 1l.toLong, 2l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    def power(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write function to find the sum of all items in the given map.\n    def returnSum(dict : Map[String,Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(returnSum((Map[String,Long](\"a\" -> 100l, \"b\" -> 200l, \"c\" -> 300l))) == (600l));\n    assert(returnSum((Map[String,Long](\"a\" -> 25l, \"b\" -> 18l, \"c\" -> 45l))) == (88l));\n    assert(returnSum((Map[String,Long](\"a\" -> 36l, \"b\" -> 39l, \"c\" -> 49l))) == (124l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    def pairWise(l1 : List[Long]) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairWise((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 1l), (1l, 2l), (2l, 3l), (3l, 3l), (3l, 4l), (4l, 4l), (4l, 5l)))));\n    assert(pairWise((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 5l), (5l, 7l), (7l, 9l), (9l, 10l)))));\n    assert(pairWise((List[Long](5l.toLong, 1l.toLong, 9l.toLong, 7l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((5l, 1l), (1l, 9l), (9l, 7l), (7l, 10l)))));\n    assert(pairWise((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 2l), (2l, 3l), (3l, 4l), (4l, 5l), (5l, 6l), (6l, 7l), (7l, 8l), (8l, 9l), (9l, 10l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to split a string into characters.\n    def split(word : String) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(split((\"python\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))));\n    assert(split((\"Name\")).equals((List[String](\"N\", \"a\", \"m\", \"e\"))));\n    assert(split((\"program\")).equals((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum of three numbers.\n    def minOfThree(a : Long, b : Long, c : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    def isSumOfPowersOfTwo(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    def getChar(strr : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return the sum of all divisors of a number.\n    def sumDiv(number : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove duplicate numbers from a given number of lists.\n    def twoUniqueNums(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether a given list of integers contains any duplicate element.\n    def testDuplicate(arraynums : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(testDuplicate((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which returns nth catalan number.\n    def catalanNumber(num : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    def powerBaseSum(base : Long, power : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    def replaceList(list1 : List[Any], list2 : List[Any]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceList((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong)), (List[Any](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](\"red\", \"blue\", \"green\")), (List[Any](\"yellow\"))).equals((List[Any](\"red\", \"blue\", \"yellow\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth octagonal number.\n    def isOctagonal(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    def replaceBlank(str1 : String, char : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    def replaceSpecialchar(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    def tupleToInt(nums : Tuple2[Long, Long, Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToInt(((1l, 2l, 3l))) == (123l));\n    assert(tupleToInt(((4l, 5l, 6l))) == (456l));\n    assert(tupleToInt(((5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the third side of a right angled triangle.\n    def othersideRightangle(w : Long, h : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == 5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n most expensive items in a given dataset.\n    def expensiveItems(items : List[Map[String,Either[String, Float]]], n : Long) : List[Map[String,Either[String, Float]]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f))), (2l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f), Map[String,String](\"name\" -> \"Item-4\", \"price\" -> 22.75f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the per-digit difference between two integers.\n    def digitDistanceNums(n1 : Long, n2 : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    def textMatchWordzMiddle(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    def removezeroIp(ip : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    def countElementInList(list1 : List[List[Any]], x : Any) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countElementInList((List[List[Any]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](1l.toLong, 11l.toLong), List[Long](1l.toLong, 15l.toLong, 7l.toLong))), (Any(1l))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"A\"))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"E\"))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to multiply two integers.\n    def multiplyInt(x : Long, y : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    def addPairwise(test_tup : Tuple2[Long, Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addPairwise(((1l, 5l, 7l, 8l, 10l))).equals(((6l, 12l, 15l, 18l))));\n    assert(addPairwise(((2l, 6l, 8l, 9l, 11l))).equals(((8l, 14l, 17l, 20l))));\n    assert(addPairwise(((3l, 7l, 9l, 10l, 12l))).equals(((10l, 16l, 19l, 22l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    def maxProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (36l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (200l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3532,7 +16,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the kth element in the given list using 1-based indexing.\n    def kthElement(arr : List[Long], k : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kthElement((List[Long](12l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 19l.toLong)), (2l)) == (3l));\n    assert(kthElement((List[Long](17l.toLong, 24l.toLong, 8l.toLong, 23l.toLong)), (3l)) == (8l));\n    assert(kthElement((List[Long](16l.toLong, 21l.toLong, 25l.toLong, 36l.toLong, 4l.toLong)), (4l)) == (36l));\n    }\n\n}\n",
     "stop_tokens": [
@@ -3540,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to interchange the first and last element in a given list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))).equals((List[Long](4l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"python_program\")).equals((\"PythonProgram\")));\n    assert(snakeToCamel((\"python_language\")).equals((\"PythonLanguage\")));\n    assert(snakeToCamel((\"programming_language\")).equals((\"ProgrammingLanguage\")));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of elements that occurs before the list element in the given tuple.\n    def countFirstElements(test_tup : List[Either[Long, Tuple2[Long, Long]]]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the Eulerian number a(n, m).\n    def eulerianNum(n : Long, m : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](1l, 5l, 7l, (4l, 6l), 10l))) == (3l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](2l, 9l, (5l, 7l), 11l))) == (2l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](11l, 15l, 5l, 8l, (2l, 3l), 8l))) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(eulerianNum((3l), (1l)) == (4l));\n    assert(eulerianNum((4l), (1l)) == (11l));\n    assert(eulerianNum((5l), (3l)) == (26l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    def rightInsertion(a : List[Long], x : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(input_list : List[List[String]]) : List[List[String]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\" red \", \"green\"), List[String](\"blue \", \" black\"), List[String](\" orange\", \"brown\")))).equals((List[List[String]](List[String](\" red \", \"green\"), List[String](\" black\", \"blue \"), List[String](\" orange\", \"brown\")))));\n    assert(sortSublists((List[List[String]](List[String](\"zilver\", \"gold\"), List[String](\"magnesium\", \"aluminium\"), List[String](\"steel\", \"bronze\")))).equals((List[List[String]](List[String](\"gold\", \"zilver\"), List[String](\"aluminium\", \"magnesium\"), List[String](\"bronze\", \"steel\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given number is woodball or not.\n    def isWoodall(x : Long) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count true booleans in the given list.\n    def count(lst : List[Boolean]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(count((List[Boolean](true.toBoolean, false.toBoolean, true.toBoolean))) == (2l));\n    assert(count((List[Boolean](false.toBoolean, false.toBoolean))) == (0l));\n    assert(count((List[Boolean](true.toBoolean, true.toBoolean, true.toBoolean))) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list by using shell sort.\n    def shellSort(my_list : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to append the given list to the given tuples.\n    def addLists(test_list : List[Long], test_tup : Tuple2[Long, Long]) : Tuple2[Long, Long, Long, Long, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(shellSort((List[Long](12l.toLong, 23l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 2l.toLong, 12l.toLong, 81l.toLong, 56l.toLong, 95l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 12l.toLong, 12l.toLong, 23l.toLong, 56l.toLong, 81l.toLong, 95l.toLong))));\n    assert(shellSort((List[Long](24l.toLong, 22l.toLong, 39l.toLong, 34l.toLong, 87l.toLong, 73l.toLong, 68l.toLong))).equals((List[Long](22l.toLong, 24l.toLong, 34l.toLong, 39l.toLong, 68l.toLong, 73l.toLong, 87l.toLong))));\n    assert(shellSort((List[Long](32l.toLong, 30l.toLong, 16l.toLong, 96l.toLong, 82l.toLong, 83l.toLong, 74l.toLong))).equals((List[Long](16l.toLong, 30l.toLong, 32l.toLong, 74l.toLong, 82l.toLong, 83l.toLong, 96l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addLists((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals(((9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals(((10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals(((11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of pairs whose xor value is odd.\n    def findOddPair(A : List[Long], N : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three lists into a single sorted list.\n    def mergeSortedList(num1 : List[Long], num2 : List[Long], num3 : List[Long]) : List[Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findOddPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong)), (5l)) == (6l));\n    assert(findOddPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong)), (7l)) == (12l));\n    assert(findOddPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (3l)) == (2l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeSortedList((List[Long](25l.toLong, 24l.toLong, 15l.toLong, 4l.toLong, 5l.toLong, 29l.toLong, 110l.toLong)), (List[Long](19l.toLong, 20l.toLong, 11l.toLong, 56l.toLong, 25l.toLong, 233l.toLong, 154l.toLong)), (List[Long](24l.toLong, 26l.toLong, 54l.toLong, 48l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 11l.toLong, 15l.toLong, 19l.toLong, 20l.toLong, 24l.toLong, 24l.toLong, 25l.toLong, 25l.toLong, 26l.toLong, 29l.toLong, 48l.toLong, 54l.toLong, 56l.toLong, 110l.toLong, 154l.toLong, 233l.toLong))));\n    assert(mergeSortedList((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (List[Long](2l.toLong, 5l.toLong, 7l.toLong, 11l.toLong)), (List[Long](1l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 12l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    assert(mergeSortedList((List[Long](18l.toLong, 14l.toLong, 10l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong)), (List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong)), (List[Long](12l.toLong, 74l.toLong, 9l.toLong, 50l.toLong, 61l.toLong, 41l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 14l.toLong, 18l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 41l.toLong, 50l.toLong, 58l.toLong, 61l.toLong, 65l.toLong, 74l.toLong, 75l.toLong, 85l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of all odd natural numbers within the range l and r.\n    def sumInRange(l : Long, r : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n    def oddEquivalent(s : String, n : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddEquivalent((\"011001\"), (6l)) == (3l));\n    assert(oddEquivalent((\"11011\"), (5l)) == (4l));\n    assert(oddEquivalent((\"1010\"), (4l)) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    def squarePerimeter(a : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string represents an integer or not.\n    def checkInteger(text : String) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkInteger((\"python\")) == (false));\n    assert(checkInteger((\"1\")) == (true));\n    assert(checkInteger((\"12345\")) == (true));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    def isPolite(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given tuple of positive integers into a single integer.\n    def tupleToInt(nums : Tuple2[Long, Long, Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    def sumSeries(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    def findDissimilar(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findDissimilar(((3l, 4l, 5l, 6l)), ((5l, 7l, 4l, 10l))).equals(((3l, 6l, 7l, 10l))));\n    assert(findDissimilar(((1l, 2l, 3l, 4l)), ((7l, 2l, 3l, 9l))).equals(((1l, 4l, 7l, 9l))));\n    assert(findDissimilar(((21l, 11l, 25l, 26l)), ((26l, 34l, 21l, 36l))).equals(((34l, 36l, 11l, 25l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    def startWithp(words : List[String]) : Tuple2[String, String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startWithp((List[String](\"Python PHP\", \"Java JavaScript\", \"c c++\"))).equals(((\"Python\", \"PHP\"))));\n    assert(startWithp((List[String](\"Python Programming\", \"Java Programming\"))).equals(((\"Python\", \"Programming\"))));\n    assert(startWithp((List[String](\"Pqrst Pqr\", \"qrstuv\"))).equals(((\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the volume of a cube given its side length.\n    def volumeCube(l : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    def checkMonthnumbNumber(monthnum2 : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether all the bits are unset in the given range or not.\n    def allBitsSetInTheGivenRange(n : Long, l : Long, r : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to get the first element of each sublist.\n    def Extract(lst : List[List[Long]]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 3l.toLong, 6l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))).equals((List[Long](1l.toLong, 4l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](9l.toLong, 8l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong)))).equals((List[Long](9l.toLong, 1l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cylinder.\n    def surfaceareaCylinder(r : Long, h : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    def sampleNam(sample_names : List[String]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sampleNam((List[String](\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"))) == (16l));\n    assert(sampleNam((List[String](\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"))) == (10l));\n    assert(sampleNam((List[String](\"abcd\", \"Python\", \"abba\", \"aba\"))) == (6l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    def rearrangeBigger(n : Long) : Any = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearrangeBigger((12l)).equals((Any(21l))));\n    assert(rearrangeBigger((10l)).equals((Any(false))));\n    assert(rearrangeBigger((102l)).equals((Any(120l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    def perimeterPentagon(a : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n    def maxSum(arr : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSum((List[Long](1l.toLong, 15l.toLong, 51l.toLong, 45l.toLong, 33l.toLong, 100l.toLong, 12l.toLong, 18l.toLong, 9l.toLong))) == (194l));\n    assert(maxSum((List[Long](80l.toLong, 60l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 10l.toLong))) == (210l));\n    assert(maxSum((List[Long](2l.toLong, 3l.toLong, 14l.toLong, 16l.toLong, 21l.toLong, 23l.toLong, 29l.toLong, 30l.toLong))) == (138l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    def extractEven(test_tuple : Tuple2[Long, Long, Tuple2[Long, Long, Tuple2[Long, Long]], Long, Long]) : Any = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractEven(((4l, 5l, (7l, 6l, (2l, 4l)), 6l, 8l))).equals((Any(6l, (2l, 4l)), 6l, 8l))));\n    assert(extractEven(((5l, 6l, (8l, 7l, (4l, 8l)), 7l, 9l))).equals((Any(8l, (4l, 8l))))));\n    assert(extractEven(((5l, 6l, (9l, 8l, (4l, 6l)), 8l, 10l))).equals((Any(8l, (4l, 6l)), 8l, 10l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToInt(((1l, 2l, 3l))) == (123l));\n    assert(tupleToInt(((4l, 5l, 6l))) == (456l));\n    assert(tupleToInt(((5l, 6l, 7l))) == (567l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -3820,201 +136,9 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert all possible convertible elements in a list of lists to floats.\n    def listToFloat(test_list : List[Tuple2[String, String]]) : List[Tuple2[Float, Float]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listToFloat((List[Tuple2[String, String]]((\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")))).equals((List[Tuple2[Float, Float]]((3.0f, 4.0f), (1.0f, 26.45f), (7.32f, 8.0f), (4.0f, 8.0f)))));\n    assert(listToFloat((List[Tuple2[String, String]]((\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")))).equals((List[Tuple2[Float, Float]]((4.0f, 4.0f), (2.0f, 27.0f), (4.12f, 9.0f), (7.0f, 11.0f)))));\n    assert(listToFloat((List[Tuple2[String, String]]((\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")))).equals((List[Tuple2[Float, Float]]((6.0f, 78.0f), (5.0f, 26.45f), (1.33f, 4.0f), (82.0f, 13.0f)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    def squareSum(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    def getPairsCount(arr : List[Long], sum : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPairsCount((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (2l)) == (6l));\n    assert(getPairsCount((List[Long](1l.toLong, 5l.toLong, 7l.toLong, -1l.toLong, 5l.toLong)), (6l)) == (3l));\n    assert(getPairsCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong)), (1l)) == (1l));\n    assert(getPairsCount((List[Long](-1l.toLong, -2l.toLong, 3l.toLong)), (-3l)) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    def countNoOfWays(n : Long, k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    def reverseWords(s : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check if a given number is one less than twice its reverse.\n    def checks(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last position of an element in a sorted list.\n    def last(arr : List[Long], x : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(last((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (0l));\n    assert(last((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)) == (2l));\n    assert(last((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (3l)) == (3l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    def countX(tup : List[Long], x : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (4l)) == (0l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (10l)) == (3l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (8l)) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    def extractIndexList(l1 : List[Long], l2 : List[Long], l3 : List[Long]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 7l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 6l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 5l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 6l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the second smallest number in a list.\n    def secondSmallest(numbers : List[Either[Long, Float]]) : Option[Float] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 2l.toLong, -8l.toLong, -2l.toLong, 0l.toLong, -2l.toLong))).equals(-2l));\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 1l.toLong, -0.5f.toLong, 0l.toLong, 2l.toLong, -2l.toLong, -2l.toLong))).equals(-0.5f));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong))).equals(None));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong, 2l.toLong))).equals(None));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    def concatenateTuple(test_tup : Tuple2[String, String, Long, String]) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenateTuple(((\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple(((\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple(((\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    def replaceSpaces(string : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    def sumRangeList(list1 : List[Long], m : Long, n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (8l), (10l)) == (29l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (5l), (7l)) == (16l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (7l), (10l)) == (38l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three dictionaries into a single map.\n    def mergeDictionariesThree(dict1 : Map[String,String], dict2 : Map[String,String], dict3 : Map[String,String]) : Map[String,String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"O\" -> \"Orange\", \"W\" -> \"White\", \"B\" -> \"Black\"))).equals((Map[String,String](\"B\" -> \"Black\", \"R\" -> \"Red\", \"P\" -> \"Pink\", \"G\" -> \"Green\", \"W\" -> \"White\", \"O\" -> \"Orange\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\"))).equals((Map[String,String](\"W\" -> \"White\", \"P\" -> \"Pink\", \"B\" -> \"Black\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\"))).equals((Map[String,String](\"B\" -> \"Black\", \"P\" -> \"Pink\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\", \"W\" -> \"White\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum of two numbers.\n    def minimum(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    def maxDifference(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxDifference((List[Tuple2[Long, Long]]((3l, 5l), (1l, 7l), (10l, 3l), (1l, 2l)))) == (7l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((4l, 6l), (2l, 17l), (9l, 13l), (11l, 12l)))) == (15l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((12l, 35l), (21l, 27l), (13l, 23l), (41l, 22l)))) == (23l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find element at a given index after number of rotations.\n    def findElement(arr : List[Long], ranges : List[List[Long]], rotations : Long, index : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[List[Long]](List[Long](0l.toLong, 2l.toLong), List[Long](0l.toLong, 3l.toLong))), (2l), (1l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (2l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (1l)) == (1l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4024,7 +148,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a string to a list of strings split on the space character.\n    def stringToList(string : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToList((\"python programming\")).equals((List[String](\"python\", \"programming\"))));\n    assert(stringToList((\"lists tuples strings\")).equals((List[String](\"lists\", \"tuples\", \"strings\"))));\n    assert(stringToList((\"write a program\")).equals((List[String](\"write\", \"a\", \"program\"))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4036,21 +160,9 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the element that appears only once in a sorted list.\n    def search(arr : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(search((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(search((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 8l.toLong))) == (8l));\n    assert(search((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (1l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a map by value.\n    def sortCounter(dict1 : Map[String,Long]) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortCounter((Map[String,Long](\"Math\" -> 81l, \"Physics\" -> 83l, \"Chemistry\" -> 87l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 87l), (\"Physics\", 83l), (\"Math\", 81l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 400l, \"Physics\" -> 300l, \"Chemistry\" -> 250l))).equals((List[Tuple2[String, Long]]((\"Math\", 400l), (\"Physics\", 300l), (\"Chemistry\", 250l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 900l, \"Physics\" -> 1000l, \"Chemistry\" -> 1250l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 1250l), (\"Physics\", 1000l), (\"Math\", 900l)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4060,7 +172,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove first and last occurrence of a given character from the string.\n    def removeOcc(s : String, ch : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOcc((\"hello\"), (\"l\")).equals((\"heo\")));\n    assert(removeOcc((\"abcda\"), (\"a\")).equals((\"bcd\")));\n    assert(removeOcc((\"PHP\"), (\"P\")).equals((\"H\")));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4068,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    def lateralsurfaceCube(l : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n    def maxProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (36l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (200l));\n    assert(maxProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (484l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    def commonElement(list1 : List[Any], list2 : List[Any]) : Option[Boolean] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum all amicable numbers from 1 to a specified number.\n    def amicableNumbersSum(limit : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(true));\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(None));\n    assert(commonElement((List[Any](\"a\", \"b\", \"c\")), (List[Any](\"d\", \"b\", \"e\"))).equals(true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(amicableNumbersSum((999l)) == (504l));\n    assert(amicableNumbersSum((9999l)) == (31626l));\n    assert(amicableNumbersSum((99l)) == (0l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to append the given list to the given tuples.\n    def addLists(test_list : List[Long], test_tup : Tuple2[Long, Long]) : Tuple2[Long, Long, Long, Long, Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n    def findLength(string : String) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addLists((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals(((9l, 10l, 5l, 6l, 7l))));\n    assert(addLists((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals(((10l, 11l, 6l, 7l, 8l))));\n    assert(addLists((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals(((11l, 12l, 7l, 8l, 9l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLength((\"11000010001\")) == (6l));\n    assert(findLength((\"10111\")) == (1l));\n    assert(findLength((\"11011101100101\")) == (2l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    def nthNums(nums : List[Long], n : Long) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of common divisors of two given numbers.\n    def sum(a : Long, b : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nthNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(nthNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (3l)).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(nthNums((List[Long](12l.toLong, 15l.toLong)), (5l)).equals((List[Long](248832l.toLong, 759375l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sum((10l), (15l)) == (6l));\n    assert(sum((100l), (150l)) == (93l));\n    assert(sum((4l), (6l)) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def pancakeSort(nums : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to multiply two integers.\n    def multiplyInt(x : Long, y : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pancakeSort((List[Long](15l.toLong, 79l.toLong, 25l.toLong, 38l.toLong, 69l.toLong))).equals((List[Long](15l.toLong, 25l.toLong, 38l.toLong, 69l.toLong, 79l.toLong))));\n    assert(pancakeSort((List[Long](98l.toLong, 12l.toLong, 54l.toLong, 36l.toLong, 85l.toLong))).equals((List[Long](12l.toLong, 36l.toLong, 54l.toLong, 85l.toLong, 98l.toLong))));\n    assert(pancakeSort((List[Long](41l.toLong, 42l.toLong, 32l.toLong, 12l.toLong, 23l.toLong))).equals((List[Long](12l.toLong, 23l.toLong, 32l.toLong, 41l.toLong, 42l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of three numbers.\n    def medianNumbers(a : Long, b : Long, c : Long) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given list.\n    def checkGreater(arr : List[Long], number : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkGreater((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (4l)) == (false));\n    assert(checkGreater((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (8l)) == (true));\n    assert(checkGreater((List[Long](9l.toLong, 7l.toLong, 4l.toLong, 8l.toLong, 6l.toLong, 1l.toLong)), (11l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    def checkElement(list : List[Any], element : Any) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkElement((List[Any](\"green\", \"orange\", \"black\", \"white\")), (Any(\"blue\"))) == (false));\n    assert(checkElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (Any(7l))) == (false));\n    assert(checkElement((List[Any](\"green\", \"green\", \"green\", \"green\")), (Any(\"green\"))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    def extractString(str : List[String], l : Long) : List[String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (8l)).equals((List[String](\"practice\", \"solution\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (6l)).equals((List[String](\"Python\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (9l)).equals((List[String](\"exercises\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    def textLowercaseUnderscore(text : String) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to trim each list by k in the given lists.\n    def trimTuple(test_list : List[List[Long]], K : Long) : List[List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (2l)).equals((List[List[Long]](List[Long](2l.toLong), List[Long](9l.toLong), List[Long](2l.toLong), List[Long](2l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](4l.toLong, 9l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](8l.toLong, 2l.toLong, 1l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 4l.toLong, 9l.toLong), List[Long](11l.toLong, 8l.toLong, 12l.toLong, 4l.toLong), List[Long](4l.toLong, 1l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](8l.toLong, 4l.toLong), List[Long](8l.toLong, 12l.toLong), List[Long](1l.toLong, 7l.toLong), List[Long](6l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sublist having minimum length.\n    def FindMin(lst : List[List[Any]]) : List[Any] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong))));\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 7l.toLong, 8l.toLong)))).equals((List[Any](1l.toLong, 1l.toLong))));\n    assert(FindMin((List[List[Any]](List[String](\"x\"), List[String](\"x\", \"y\"), List[String](\"x\", \"y\", \"z\")))).equals((List[Any](\"x\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to filter odd numbers.\n    def filterOddnumbers(nums : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterOddnumbers((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(filterOddnumbers((List[Long](10l.toLong, 20l.toLong, 45l.toLong, 67l.toLong, 84l.toLong, 93l.toLong))).equals((List[Long](45l.toLong, 67l.toLong, 93l.toLong))));\n    assert(filterOddnumbers((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 3l.toLong))).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 3l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    def findAdverbs(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    def maxOfNth(test_list : List[List[Long]], N : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOfNth((List[List[Long]](List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](1l.toLong, 3l.toLong, 5l.toLong), List[Long](8l.toLong, 9l.toLong, 19l.toLong))), (2l)) == (19l));\n    assert(maxOfNth((List[List[Long]](List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong), List[Long](9l.toLong, 10l.toLong, 20l.toLong))), (1l)) == (10l));\n    assert(maxOfNth((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](3l.toLong, 5l.toLong, 7l.toLong), List[Long](10l.toLong, 11l.toLong, 21l.toLong))), (1l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    def decimalToBinary(n : Long) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    def combinationsColors(l : List[String], n : Long) : List[List[String]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (1l)).equals((List[List[String]](List[String](\"Red\"), List[String](\"Green\"), List[String](\"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (2l)).equals((List[List[String]](List[String](\"Red\", \"Red\"), List[String](\"Red\", \"Green\"), List[String](\"Red\", \"Blue\"), List[String](\"Green\", \"Green\"), List[String](\"Green\", \"Blue\"), List[String](\"Blue\", \"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (3l)).equals((List[List[String]](List[String](\"Red\", \"Red\", \"Red\"), List[String](\"Red\", \"Red\", \"Green\"), List[String](\"Red\", \"Red\", \"Blue\"), List[String](\"Red\", \"Green\", \"Green\"), List[String](\"Red\", \"Green\", \"Blue\"), List[String](\"Red\", \"Blue\", \"Blue\"), List[String](\"Green\", \"Green\", \"Green\"), List[String](\"Green\", \"Green\", \"Blue\"), List[String](\"Green\", \"Blue\", \"Blue\"), List[String](\"Blue\", \"Blue\", \"Blue\")))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from a string.\n    def removeAllSpaces(text : String) : String = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    def minSwaps(str1 : String, str2 : String) : Any = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Any(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Any(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Any(\"Not Possible\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a new tuple from the given string and list.\n    def newTuple(test_list : List[String], test_str : String) : Tuple2[String, String, String] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newTuple((List[String](\"WEB\", \"is\")), (\"best\")).equals(((\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((List[String](\"We\", \"are\")), (\"Developers\")).equals(((\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((List[String](\"Part\", \"is\")), (\"Wrong\")).equals(((\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the product of the list multiplication modulo n.\n    def findRemainder(arr : List[Long], n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRemainder((List[Long](100l.toLong, 10l.toLong, 5l.toLong, 25l.toLong, 35l.toLong, 14l.toLong)), (11l)) == (9l));\n    assert(findRemainder((List[Long](1l.toLong, 1l.toLong, 1l.toLong)), (1l)) == (0l));\n    assert(findRemainder((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (2l)) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum value in a given heterogeneous list.\n    def minVal(listval : List[Either[String, Long]]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (2l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (15l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (20l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ration of positive numbers in a list of integers.\n    def positiveCount(nums : List[Long]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(positiveCount((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.54f));\n    assert(positiveCount((List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.69f));\n    assert(positiveCount((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (0.56f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add the given tuple to the given list.\n    def addTuple(test_list : List[Long], test_tup : Tuple2[Long, Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addTuple((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(addTuple((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 11l.toLong))));\n    assert(addTuple((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    def maxRunUppercase(test_str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    def sortMatrix(M : List[List[Long]]) : List[List[Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](5l.toLong, 8l.toLong, 9l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](2l.toLong, 1l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](2l.toLong, 1l.toLong, 4l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](5l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    def countVowels(test_str : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    def maxSumIncreasingSubseq(a : List[Long], n : Long, index : Long, k : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((List[Long](11l.toLong, 15l.toLong, 19l.toLong, 21l.toLong, 26l.toLong, 28l.toLong, 31l.toLong)), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyInt((10l), (20l)) == (200l));\n    assert(multiplyInt((5l), (10l)) == (50l));\n    assert(multiplyInt((4l), (8l)) == (32l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4408,7 +244,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find words that are longer than n characters from a given list of words.\n    def longWords(n : Long, str : String) : List[String] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(longWords((3l), (\"python is a programming language\")).equals((List[String](\"python\", \"programming\", \"language\"))));\n    assert(longWords((2l), (\"writing a program\")).equals((List[String](\"writing\", \"program\"))));\n    assert(longWords((5l), (\"sorting list\")).equals((List[String](\"sorting\"))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4416,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of non-repeated elements in a given list.\n    def findSum(arr : List[Long]) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate whether the matrix is a magic square.\n    def magicSquareTest(my_matrix : List[List[Long]]) : Boolean = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (21l));\n    assert(findSum((List[Long](1l.toLong, 10l.toLong, 9l.toLong, 4l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 4l.toLong))) == (71l));\n    assert(findSum((List[Long](12l.toLong, 10l.toLong, 9l.toLong, 45l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 10l.toLong))) == (78l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(magicSquareTest((List[List[Long]](List[Long](7l.toLong, 12l.toLong, 1l.toLong, 14l.toLong), List[Long](2l.toLong, 13l.toLong, 8l.toLong, 11l.toLong), List[Long](16l.toLong, 3l.toLong, 10l.toLong, 5l.toLong), List[Long](9l.toLong, 6l.toLong, 15l.toLong, 4l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 8l.toLong)))) == (true));\n    assert(magicSquareTest((List[List[Long]](List[Long](2l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 1l.toLong), List[Long](4l.toLong, 3l.toLong, 7l.toLong)))) == (false));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given tuple to a key-value map using adjacent elements. https://www.geeksforgeeks.org/scalathon-convert-tuple-to-adjacent-pair-map/\n    def tupleToDict(test_tup : Tuple2[Long, Long, Long, Long, Long, Long]) : Map[Long,Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given matrix in ascending order according to the sum of its rows.\n    def sortMatrix(M : List[List[Long]]) : List[List[Long]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToDict(((1l, 5l, 7l, 10l, 13l, 5l))).equals((Map[Long,Long](1l -> 5l, 7l -> 10l, 13l -> 5l))));\n    assert(tupleToDict(((1l, 2l, 3l, 4l, 5l, 6l))).equals((Map[Long,Long](1l -> 2l, 3l -> 4l, 5l -> 6l))));\n    assert(tupleToDict(((7l, 8l, 9l, 10l, 11l, 12l))).equals((Map[Long,Long](7l -> 8l, 9l -> 10l, 11l -> 12l))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong)))).equals((List[List[Long]](List[Long](-2l.toLong, 4l.toLong, -5l.toLong), List[Long](1l.toLong, -1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))));\n    assert(sortMatrix((List[List[Long]](List[Long](5l.toLong, 8l.toLong, 9l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](2l.toLong, 1l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](2l.toLong, 1l.toLong, 4l.toLong), List[Long](6l.toLong, 4l.toLong, 3l.toLong), List[Long](5l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    def getCoordinates(test_tup : Tuple2[Long, Long]) : List[List[Long]] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the item with maximum frequency in a given list.\n    def maxOccurrences(nums : List[Long]) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getCoordinates(((3l, 4l))).equals((List[List[Long]](List[Long](2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong), List[Long](2l.toLong, 5l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](4l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong)))));\n    assert(getCoordinates(((4l, 5l))).equals((List[List[Long]](List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](5l.toLong, 4l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong)))));\n    assert(getCoordinates(((5l, 6l))).equals((List[List[Long]](List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](4l.toLong, 7l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](6l.toLong, 5l.toLong), List[Long](6l.toLong, 6l.toLong), List[Long](6l.toLong, 7l.toLong)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    def checkType(test_tuple : Any) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkType((Any((5l, 6l, 7l, 3l, 5l, 6l)))) == (true));\n    assert(checkType((Any((1l, 2l, \"4\")))) == (false));\n    assert(checkType((Any((3l, 2l, 1l, 4l, 5l)))) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the smallest missing number from a sorted list of natural numbers.\n    def findFirstMissing(array : List[Long]) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 9l.toLong))) == (3l));\n    assert(findFirstMissing((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 9l.toLong))) == (0l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is undulating or not.\n    def isUndulating(n : Long) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/scalathon-find-minimum-k-records-from-tuple-list/ - in this case a verbatim coscala of test cases\n    def minK(test_list : List[Tuple2[String, Long]], K : Long) : List[Tuple2[String, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minK((List[Tuple2[String, Long]]((\"Manjeet\", 10l), (\"Akshat\", 4l), (\"Akash\", 2l), (\"Nikhil\", 8l))), (2l)).equals((List[Tuple2[String, Long]]((\"Akash\", 2l), (\"Akshat\", 4l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"Sanjeev\", 11l), (\"Angat\", 5l), (\"Akash\", 3l), (\"Nepin\", 9l))), (3l)).equals((List[Tuple2[String, Long]]((\"Akash\", 3l), (\"Angat\", 5l), (\"Nepin\", 9l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"tanmay\", 14l), (\"Amer\", 11l), (\"Ayesha\", 9l), (\"SKD\", 16l))), (1l)).equals((List[Tuple2[String, Long]]((\"Ayesha\", 9l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of substrings with the sum of digits equal to their length.\n    def countSubstrings(s : String) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth decagonal number.\n    def isNumDecagonal(n : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    def rearExtract(test_list : List[Tuple2[Long, String, Long]]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Rash\", 21l), (2l, \"Varsha\", 20l), (3l, \"Kil\", 19l)))).equals((List[Long](21l.toLong, 20l.toLong, 19l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sai\", 36l), (2l, \"Ayesha\", 25l), (3l, \"Salman\", 45l)))).equals((List[Long](36l.toLong, 25l.toLong, 45l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sudeep\", 14l), (2l, \"Vandana\", 36l), (3l, \"Dawood\", 56l)))).equals((List[Long](14l.toLong, 36l.toLong, 56l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the closest smaller number than n.\n    def closestNum(N : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/scalathon-combinations-of-sum-with-tuples-in-tuple-list/\n    def findCombinations(test_list : List[Tuple2[Long, Long]]) : List[Tuple2[Long, Long]] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findCombinations((List[Tuple2[Long, Long]]((2l, 4l), (6l, 7l), (5l, 1l), (6l, 10l)))).equals((List[Tuple2[Long, Long]]((8l, 11l), (7l, 5l), (8l, 14l), (11l, 8l), (12l, 17l), (11l, 11l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((3l, 5l), (7l, 8l), (6l, 2l), (7l, 11l)))).equals((List[Tuple2[Long, Long]]((10l, 13l), (9l, 7l), (10l, 16l), (13l, 10l), (14l, 19l), (13l, 13l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((4l, 6l), (8l, 9l), (7l, 3l), (8l, 12l)))).equals((List[Tuple2[Long, Long]]((12l, 15l), (11l, 9l), (12l, 18l), (15l, 12l), (16l, 21l), (15l, 15l)))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    def maxAverageOfPath(cost : List[List[Long]]) : Float = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](7l.toLong, 3l.toLong, 9l.toLong)))) == (5.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 4l.toLong), List[Long](7l.toLong, 6l.toLong, 5l.toLong), List[Long](8l.toLong, 4l.toLong, 10l.toLong)))) == (6.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](8l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 11l.toLong)))) == (7.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))) == (5.8f));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and returns a tuple containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n    def sequentialSearch(dlist : List[Long], item : Long) : Tuple2[Boolean, Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequentialSearch((List[Long](11l.toLong, 23l.toLong, 58l.toLong, 31l.toLong, 56l.toLong, 77l.toLong, 43l.toLong, 12l.toLong, 65l.toLong, 19l.toLong)), (31l)).equals(((true, 3l))));\n    assert(sequentialSearch((List[Long](12l.toLong, 32l.toLong, 45l.toLong, 62l.toLong, 35l.toLong, 47l.toLong, 44l.toLong, 61l.toLong)), (61l)).equals(((true, 7l))));\n    assert(sequentialSearch((List[Long](9l.toLong, 10l.toLong, 17l.toLong, 19l.toLong, 22l.toLong, 39l.toLong, 48l.toLong, 56l.toLong)), (48l)).equals(((true, 6l))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove odd numbers from a given list.\n    def removeOdd(l : List[Long]) : List[Long] = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong))));\n    assert(removeOdd((List[Long](2l.toLong, 4l.toLong, 6l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(removeOdd((List[Long](10l.toLong, 20l.toLong, 3l.toLong))).equals((List[Long](10l.toLong, 20l.toLong))));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    def isProductEven(arr : List[Long]) : Boolean = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
-    "stop_tokens": [
-      "\n    }\n"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the maximum of two numbers.\n    def maximum(a : Long, b : Long) : Long = {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 2l.toLong, 6l.toLong, 5l.toLong, 1l.toLong, 6l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 9l.toLong, 1l.toLong, 2l.toLong))) == (2l));\n    assert(maxOccurrences((List[Long](2l.toLong, 3l.toLong, 8l.toLong, 4l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 15l.toLong, 14l.toLong, 10l.toLong, 12l.toLong, 13l.toLong, 16l.toLong, 18l.toLong))) == (8l));\n    assert(maxOccurrences((List[Long](10l.toLong, 20l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 90l.toLong, 80l.toLong, 50l.toLong, 30l.toLong, 20l.toLong, 50l.toLong, 10l.toLong))) == (20l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4624,9 +292,597 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to reverse only the vowels of a given string (where y is not a vowel).\n    def reverseVowels(str1 : String) : String = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseVowels((\"Python\")).equals((\"Python\")));\n    assert(reverseVowels((\"USA\")).equals((\"ASU\")));\n    assert(reverseVowels((\"ab\")).equals((\"ab\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a string.\n    def tupString(tup1 : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupString((List[String](\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"))).equals((\"exercises\")));\n    assert(tupString((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))).equals((\"python\")));\n    assert(tupString((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))).equals((\"program\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of the negative numbers of a given list of numbers.\n    def sumNegativenum(nums : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumNegativenum((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (-32l));\n    assert(sumNegativenum((List[Long](10l.toLong, 15l.toLong, -14l.toLong, 13l.toLong, -18l.toLong, 12l.toLong, -20l.toLong))) == (-52l));\n    assert(sumNegativenum((List[Long](19l.toLong, -65l.toLong, 57l.toLong, 39l.toLong, 152l.toLong, -639l.toLong, 121l.toLong, 44l.toLong, 90l.toLong, -190l.toLong))) == (-894l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth hexagonal number.\n    def hexagonalNum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(hexagonalNum((10l)) == (190l));\n    assert(hexagonalNum((5l)) == (45l));\n    assert(hexagonalNum((7l)) == (91l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n    def isSumOfPowersOfTwo(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSumOfPowersOfTwo((10l)) == (true));\n    assert(isSumOfPowersOfTwo((7l)) == (false));\n    assert(isSumOfPowersOfTwo((14l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def pancakeSort(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pancakeSort((List[Long](15l.toLong, 79l.toLong, 25l.toLong, 38l.toLong, 69l.toLong))).equals((List[Long](15l.toLong, 25l.toLong, 38l.toLong, 69l.toLong, 79l.toLong))));\n    assert(pancakeSort((List[Long](98l.toLong, 12l.toLong, 54l.toLong, 36l.toLong, 85l.toLong))).equals((List[Long](12l.toLong, 36l.toLong, 54l.toLong, 85l.toLong, 98l.toLong))));\n    assert(pancakeSort((List[Long](41l.toLong, 42l.toLong, 32l.toLong, 12l.toLong, 23l.toLong))).equals((List[Long](12l.toLong, 23l.toLong, 32l.toLong, 41l.toLong, 42l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count number items that are identical in the same position of three given lists.\n    def countSamepair(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (3l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (4l));\n    assert(countSamepair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find number of lists present in the given list.\n    def findLists(Input : List[Any]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (2l));\n    assert(findLists((List[Any](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (3l));\n    assert(findLists((List[Any](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the maximum difference between any two elements in a given list.\n    def maxAbsDiff(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAbsDiff((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 3l.toLong))) == (4l));\n    assert(maxAbsDiff((List[Long](9l.toLong, 3l.toLong, 2l.toLong, 5l.toLong, 1l.toLong))) == (8l));\n    assert(maxAbsDiff((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the volume of a triangular prism.\n    def findVolume(l : Long, b : Long, h : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findVolume((10l), (8l), (6l)) == (240l));\n    assert(findVolume((3l), (2l), (2l)) == (6l));\n    assert(findVolume((1l), (2l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n    def findSolution(a : Long, b : Long, n : Long) : Option[Tuple2[Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSolution((2l), (3l), (7l)).equals(Some((2l, 1l))));\n    assert(findSolution((4l), (2l), (7l)).equals(None));\n    assert(findSolution((1l), (13l), (17l)).equals(Some((4l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all elements from a given list present in another list.\n    def removeElements(list1 : List[Long], list2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    assert(removeElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](5l.toLong, 7l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n    def sumSeries(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumSeries((6l)) == (12l));\n    assert(sumSeries((10l)) == (30l));\n    assert(sumSeries((9l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to determine if the sum of the divisors of two integers are the same.\n    def areEquivalent(num1 : Long, num2 : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areEquivalent((36l), (57l)) == (false));\n    assert(areEquivalent((2l), (4l)) == (false));\n    assert(areEquivalent((23l), (47l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n    def countCharPosition(str1 : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharPosition((\"xbcefg\")) == (2l));\n    assert(countCharPosition((\"ABcED\")) == (3l));\n    assert(countCharPosition((\"AbgdeF\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that counts the number of pairs of integers in a list that xor to an even number.\n    def findEvenPair(A : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findEvenPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong))) == (4l));\n    assert(findEvenPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong))) == (9l));\n    assert(findEvenPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the smallest power of 2 greater than or equal to n.\n    def nextPowerOf2(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPowerOf2((0l)) == (1l));\n    assert(nextPowerOf2((5l)) == (8l));\n    assert(nextPowerOf2((17l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurrences of a number in a given list.\n    def frequency(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (4l)) == (0l));\n    assert(frequency((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 4l.toLong)), (3l)) == (3l));\n    assert(frequency((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong)), (1l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n    def textLowercaseUnderscore(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textLowercaseUnderscore((\"aab_cbbbc\")) == (true));\n    assert(textLowercaseUnderscore((\"aab_Abbbc\")) == (false));\n    assert(textLowercaseUnderscore((\"Aaab_abbbc\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of numbers in a list within a range specified by two indices.\n    def sumRangeList(list1 : List[Long], m : Long, n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (8l), (10l)) == (29l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (5l), (7l)) == (16l));\n    assert(sumRangeList((List[Long](2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 3l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 8l.toLong, 12l.toLong)), (7l), (10l)) == (38l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the perimeter of a regular pentagon from the length of its sides.\n    def perimeterPentagon(a : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perimeterPentagon((5l)) == (25l));\n    assert(perimeterPentagon((10l)) == (50l));\n    assert(perimeterPentagon((15l)) == (75l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of occurence of the string 'std' in a given string.\n    def countOccurance(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurance((\"letstdlenstdporstd\")) == (3l));\n    assert(countOccurance((\"truststdsolensporsd\")) == (1l));\n    assert(countOccurance((\"makestdsostdworthit\")) == (2l));\n    assert(countOccurance((\"stds\")) == (1l));\n    assert(countOccurance((\"\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the perimeter of a square given its side length as input.\n    def squarePerimeter(a : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squarePerimeter((10l)) == (40l));\n    assert(squarePerimeter((5l)) == (20l));\n    assert(squarePerimeter((4l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove characters from the first string which are present in the second string.\n    def removeDirtyChars(string : String, second_string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeDirtyChars((\"probasscurve\"), (\"pros\")).equals((\"bacuve\")));\n    assert(removeDirtyChars((\"digitalindia\"), (\"talent\")).equals((\"digiidi\")));\n    assert(removeDirtyChars((\"exoticmiles\"), (\"toxic\")).equals((\"emles\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether a given list of integers contains any duplicate element.\n    def testDuplicate(arraynums : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    assert(testDuplicate((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(testDuplicate((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given number is woodball or not.\n    def isWoodall(x : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isWoodall((383l)) == (true));\n    assert(isWoodall((254l)) == (false));\n    assert(isWoodall((200l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all the elements in tuple have same data type or not.\n    def checkType(test_tuple : Any) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkType((Any((5l, 6l, 7l, 3l, 5l, 6l)))) == (true));\n    assert(checkType((Any((1l, 2l, \"4\")))) == (false));\n    assert(checkType((Any((3l, 2l, 1l, 4l, 5l)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a sorted list, its length (n), and an element and returns whether the element is the majority element in the given sorted list. (The majority element is the element that occurs more than n/2 times.)\n    def isMajority(arr : List[Long], n : Long, x : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMajority((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 3l.toLong, 10l.toLong)), (7l), (3l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 4l.toLong, 4l.toLong, 4l.toLong, 6l.toLong, 6l.toLong)), (8l), (4l)) == (false));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (true));\n    assert(isMajority((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong)), (5l), (1l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of set bits (binary digits with value 1) in a given number.\n    def countSetBits(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSetBits((2l)) == (1l));\n    assert(countSetBits((4l)) == (1l));\n    assert(countSetBits((6l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove the characters which have odd index values of a given string.\n    def oddValuesString(str : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddValuesString((\"abcdef\")).equals((\"ace\")));\n    assert(oddValuesString((\"python\")).equals((\"pto\")));\n    assert(oddValuesString((\"data\")).equals((\"dt\")));\n    assert(oddValuesString((\"lambs\")).equals((\"lms\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum of three numbers.\n    def minOfThree(a : Long, b : Long, c : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minOfThree((10l), (20l), (0l)) == (0l));\n    assert(minOfThree((19l), (15l), (18l)) == (15l));\n    assert(minOfThree((-10l), (-20l), (-30l)) == (-30l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether all the bits are unset in the given range or not.\n    def allBitsSetInTheGivenRange(n : Long, l : Long, r : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allBitsSetInTheGivenRange((4l), (1l), (2l)) == (true));\n    assert(allBitsSetInTheGivenRange((17l), (2l), (4l)) == (true));\n    assert(allBitsSetInTheGivenRange((39l), (4l), (6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n, and re-arranges the first n elements of the given list so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n    def reArrangeArray(arr : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reArrangeArray((List[Long](-1l.toLong, 2l.toLong, -3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, -7l.toLong, 8l.toLong, 9l.toLong)), (9l)).equals((List[Long](-1l.toLong, -3l.toLong, -7l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(reArrangeArray((List[Long](12l.toLong, -14l.toLong, -26l.toLong, 13l.toLong, 15l.toLong)), (5l)).equals((List[Long](-14l.toLong, -26l.toLong, 12l.toLong, 13l.toLong, 15l.toLong))));\n    assert(reArrangeArray((List[Long](10l.toLong, 24l.toLong, 36l.toLong, -42l.toLong, -39l.toLong, -78l.toLong, 85l.toLong)), (7l)).equals((List[Long](-42l.toLong, -39l.toLong, -78l.toLong, 10l.toLong, 24l.toLong, 36l.toLong, 85l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n    def replaceBlank(str1 : String, char : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceBlank((\"hello people\"), (\"@\")).equals((\"hello@people\")));\n    assert(replaceBlank((\"python program language\"), (\"$\")).equals((\"python$program$language\")));\n    assert(replaceBlank((\"blank space\"), (\"-\")).equals((\"blank-space\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the volume of a cube given its side length.\n    def volumeCube(l : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(volumeCube((3l)) == (27l));\n    assert(volumeCube((2l)) == (8l));\n    assert(volumeCube((5l)) == (125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a map mapping each unique tuple to the number of times it occurs in the list.\n    def checkOccurences(test_list : List[Tuple2[Long, Long]]) : Map[Tuple2[Long, Long],Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkOccurences((List[Tuple2[Long, Long]]((3l, 1l), (1l, 3l), (2l, 5l), (5l, 2l), (6l, 3l)))).equals((Map[Tuple2[Long, Long],Long]((1l, 3l) -> 2l, (2l, 5l) -> 2l, (3l, 6l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((4l, 2l), (2l, 4l), (3l, 6l), (6l, 3l), (7l, 4l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 4l) -> 2l, (3l, 6l) -> 2l, (4l, 7l) -> 1l))));\n    assert(checkOccurences((List[Tuple2[Long, Long]]((13l, 2l), (11l, 23l), (12l, 25l), (25l, 12l), (16l, 23l)))).equals((Map[Tuple2[Long, Long],Long]((2l, 13l) -> 1l, (11l, 23l) -> 1l, (12l, 25l) -> 2l, (16l, 23l) -> 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of non-empty substrings of a given string.\n    def numberOfSubstrings(str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberOfSubstrings((\"abc\")) == (6l));\n    assert(numberOfSubstrings((\"abcd\")) == (10l));\n    assert(numberOfSubstrings((\"abcde\")) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n    def getTotalNumberOfSequences(m : Long, n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getTotalNumberOfSequences((10l), (4l)) == (4l));\n    assert(getTotalNumberOfSequences((5l), (2l)) == (6l));\n    assert(getTotalNumberOfSequences((16l), (3l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n    def replaceList(list1 : List[Any], list2 : List[Any]) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceList((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong)), (List[Any](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(replaceList((List[Any](\"red\", \"blue\", \"green\")), (List[Any](\"yellow\"))).equals((List[Any](\"red\", \"blue\", \"yellow\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the total number of characters in a string.\n    def countCharac(str1 : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countCharac((\"python programming\")) == (18l));\n    assert(countCharac((\"language\")) == (8l));\n    assert(countCharac((\"words\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the next perfect square greater than a given number.\n    def nextPerfectSquare(N : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nextPerfectSquare((35l)) == (36l));\n    assert(nextPerfectSquare((6l)) == (9l));\n    assert(nextPerfectSquare((9l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes a list and finds the maximum sum of a bitonic subsequence for the given list, where a sequence is bitonic if it is first increasing and then decreasing.\n    def maxSum(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSum((List[Long](1l.toLong, 15l.toLong, 51l.toLong, 45l.toLong, 33l.toLong, 100l.toLong, 12l.toLong, 18l.toLong, 9l.toLong))) == (194l));\n    assert(maxSum((List[Long](80l.toLong, 60l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 10l.toLong))) == (210l));\n    assert(maxSum((List[Long](2l.toLong, 3l.toLong, 14l.toLong, 16l.toLong, 21l.toLong, 23l.toLong, 29l.toLong, 30l.toLong))) == (138l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the length of the longest palindromic subsequence in the given string.\n    def lps(str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lps((\"TENS FOR TENS\")) == (5l));\n    assert(lps((\"CARDIO FOR CARDS\")) == (7l));\n    assert(lps((\"PART OF THE JOURNEY IS PART\")) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the intersection of two lists.\n    def intersectionArray(array_nums1 : List[Long], array_nums2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](1l.toLong, 2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 8l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))).equals((List[Long](3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(intersectionArray((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Long](10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a tuple and an element and counts the occcurences of the element in the list.\n    def countX(tup : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (4l)) == (0l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (10l)) == (3l));\n    assert(countX((List[Long](10l.toLong, 8l.toLong, 5l.toLong, 2l.toLong, 10l.toLong, 15l.toLong, 10l.toLong, 8l.toLong, 5l.toLong, 8l.toLong, 8l.toLong, 2l.toLong)), (8l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n    def insertElement(list : List[String], element : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(insertElement((List[String](\"Red\", \"Green\", \"Black\")), (\"c\")).equals((List[String](\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"))));\n    assert(insertElement((List[String](\"python\", \"java\")), (\"program\")).equals((List[String](\"program\", \"python\", \"program\", \"java\"))));\n    assert(insertElement((List[String](\"happy\", \"sad\")), (\"laugh\")).equals((List[String](\"laugh\", \"happy\", \"laugh\", \"sad\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert complex numbers to polar coordinates.\n    def convert(numbers : Long) : Tuple2[Float, Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convert((1l)).equals(((1.0f, 0.0f))));\n    assert(convert((4l)).equals(((4.0f, 0.0f))));\n    assert(convert((5l)).equals(((5.0f, 0.0f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n    def combinationsColors(l : List[String], n : Long) : List[List[String]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (1l)).equals((List[List[String]](List[String](\"Red\"), List[String](\"Green\"), List[String](\"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (2l)).equals((List[List[String]](List[String](\"Red\", \"Red\"), List[String](\"Red\", \"Green\"), List[String](\"Red\", \"Blue\"), List[String](\"Green\", \"Green\"), List[String](\"Green\", \"Blue\"), List[String](\"Blue\", \"Blue\")))));\n    assert(combinationsColors((List[String](\"Red\", \"Green\", \"Blue\")), (3l)).equals((List[List[String]](List[String](\"Red\", \"Red\", \"Red\"), List[String](\"Red\", \"Red\", \"Green\"), List[String](\"Red\", \"Red\", \"Blue\"), List[String](\"Red\", \"Green\", \"Green\"), List[String](\"Red\", \"Green\", \"Blue\"), List[String](\"Red\", \"Blue\", \"Blue\"), List[String](\"Green\", \"Green\", \"Green\"), List[String](\"Green\", \"Green\", \"Blue\"), List[String](\"Green\", \"Blue\", \"Blue\"), List[String](\"Blue\", \"Blue\", \"Blue\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n    def countPrimesNums(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPrimesNums((5l)) == (2l));\n    assert(countPrimesNums((10l)) == (4l));\n    assert(countPrimesNums((100l)) == (25l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two numbers and returns a list with the second number and then the first number.\n    def swapNumbers(a : Long, b : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapNumbers((10l), (20l)).equals((List[Long](20l.toLong, 10l.toLong))));\n    assert(swapNumbers((15l), (17l)).equals((List[Long](17l.toLong, 15l.toLong))));\n    assert(swapNumbers((100l), (200l)).equals((List[Long](200l.toLong, 100l.toLong))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4636,7 +892,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to maximize the given two lists.\n    def maximizeElements(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximizeElements((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 9l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 10l.toLong)))));\n    assert(maximizeElements((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](5l.toLong, 10l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 11l.toLong)))));\n    assert(maximizeElements((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](6l.toLong, 11l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](9l.toLong, 12l.toLong)))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4644,73 +900,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether every even index contains even numbers of a given list.\n    def evenPosition(nums : List[Long]) : Boolean = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n    def newmanPrime(n : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPosition((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(evenPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    assert(evenPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newmanPrime((3l)) == (7l));\n    assert(newmanPrime((4l)) == (17l));\n    assert(newmanPrime((5l)) == (41l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    def checkChar(string : String) : String = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n    def divisionElements(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisionElements(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((2l, 2l, 2l, 3l))));\n    assert(divisionElements(((12l, 6l, 8l, 16l)), ((6l, 3l, 4l, 4l))).equals(((2l, 2l, 2l, 4l))));\n    assert(divisionElements(((20l, 14l, 36l, 18l)), ((5l, 7l, 6l, 9l))).equals(((4l, 2l, 6l, 2l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of even factors of a number.\n    def sumofFactors(n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n    def splitTwoParts(list1 : List[Any], L : Long) : Any = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitTwoParts((List[Any](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((Any(1l.toLong, 1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)))));\n    assert(splitTwoParts((List[Any](\"a\", \"b\", \"c\", \"d\")), (2l)).equals((Any(\"a\", \"b\"), List[String](\"c\", \"d\")))));\n    assert(splitTwoParts((List[Any](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\")), (4l)).equals((Any(\"p\", \"y\", \"t\", \"h\"), List[String](\"o\", \"n\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    def lateralsurfaceCone(r : Long, h : Long) : Float = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate a dog's age in dog's years.\n    def dogAge(h_age : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dogAge((12l)) == (61l));\n    assert(dogAge((15l)) == (73l));\n    assert(dogAge((24l)) == (109l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    def countPairs(arr : List[Long], n : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n    def listSplit(S : List[Any], step : Long) : List[List[Any]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (3l)) == (2l));\n    assert(countPairs((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (4l)) == (0l));\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (5l)) == (10l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listSplit((List[Any](\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\")), (3l)).equals((List[List[Any]](List[String](\"a\", \"d\", \"g\", \"j\", \"m\"), List[String](\"b\", \"e\", \"h\", \"k\", \"n\"), List[String](\"c\", \"f\", \"i\", \"l\")))));\n    assert(listSplit((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (3l)).equals((List[List[Any]](List[Long](1l.toLong, 4l.toLong, 7l.toLong, 10l.toLong, 13l.toLong), List[Long](2l.toLong, 5l.toLong, 8l.toLong, 11l.toLong, 14l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 12l.toLong)))));\n    assert(listSplit((List[Any](\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\")), (2l)).equals((List[List[Any]](List[String](\"python\", \"C\", \"DBMS\"), List[String](\"java\", \"C++\", \"SQL\")))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted list.\n    def findFirstOccurrence(A : List[Long], x : Long) : Long = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cube given its side length.\n    def lateralsurfaceCube(l : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstOccurrence((List[Long](2l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (1l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (2l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (6l)) == (4l));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCube((5l)) == (100l));\n    assert(lateralsurfaceCube((9l)) == (324l));\n    assert(lateralsurfaceCube((10l)) == (400l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4720,9 +976,729 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n    def squareSum(n : Long) : Long = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (10l));\n    assert(squareSum((3l)) == (35l));\n    assert(squareSum((4l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th star number.\n    def findStarNum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findStarNum((3l)) == (37l));\n    assert(findStarNum((4l)) == (73l));\n    assert(findStarNum((5l)) == (121l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ascii value of a character.\n    def asciiValue(k : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(asciiValue((\"A\")) == (65l));\n    assert(asciiValue((\"R\")) == (82l));\n    assert(asciiValue((\"S\")) == (83l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of even numbers at even positions of a list.\n    def sumEvenAndEvenIndex(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong, 18l.toLong, 8l.toLong))) == (30l));\n    assert(sumEvenAndEvenIndex((List[Long](3l.toLong, 20l.toLong, 17l.toLong, 9l.toLong, 2l.toLong, 10l.toLong, 18l.toLong, 13l.toLong, 6l.toLong, 18l.toLong))) == (26l));\n    assert(sumEvenAndEvenIndex((List[Long](5l.toLong, 6l.toLong, 12l.toLong, 1l.toLong))) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n    def evenPowerSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPowerSum((2l)) == (1056l));\n    assert(evenPowerSum((3l)) == (8832l));\n    assert(evenPowerSum((1l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n    def rearExtract(test_list : List[Tuple2[Long, String, Long]]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Rash\", 21l), (2l, \"Varsha\", 20l), (3l, \"Kil\", 19l)))).equals((List[Long](21l.toLong, 20l.toLong, 19l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sai\", 36l), (2l, \"Ayesha\", 25l), (3l, \"Salman\", 45l)))).equals((List[Long](36l.toLong, 25l.toLong, 45l.toLong))));\n    assert(rearExtract((List[Tuple2[Long, String, Long]]((1l, \"Sudeep\", 14l), (2l, \"Vandana\", 36l), (3l, \"Dawood\", 56l)))).equals((List[Long](14l.toLong, 36l.toLong, 56l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n    def substractElements(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Tuple2[Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(substractElements(((10l, 4l, 5l)), ((2l, 5l, 18l))).equals(((8l, -1l, -13l))));\n    assert(substractElements(((11l, 2l, 3l)), ((24l, 45l, 16l))).equals(((-13l, -43l, -13l))));\n    assert(substractElements(((7l, 18l, 9l)), ((10l, 11l, 12l))).equals(((-3l, 7l, -3l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n    def evenBinomialCoeffSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenBinomialCoeffSum((4l)) == (8l));\n    assert(evenBinomialCoeffSum((6l)) == (32l));\n    assert(evenBinomialCoeffSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a map and integer n and filters the map to only include entries with values greater than or equal to n.\n    def dictFilter(dict : Map[String,Long], n : Long) : Map[String,Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (170l)).equals((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (180l)).equals((Map[String,Long](\"Alden Cantrell\" -> 180l, \"Pierre Cox\" -> 190l))));\n    assert(dictFilter((Map[String,Long](\"Cierra Vega\" -> 175l, \"Alden Cantrell\" -> 180l, \"Kierra Gentry\" -> 165l, \"Pierre Cox\" -> 190l)), (190l)).equals((Map[String,Long](\"Pierre Cox\" -> 190l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of elements that occurs before the list element in the given tuple.\n    def countFirstElements(test_tup : List[Either[Long, Tuple2[Long, Long]]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](1l, 5l, 7l, (4l, 6l), 10l))) == (3l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](2l, 9l, (5l, 7l), 11l))) == (2l));\n    assert(countFirstElements((List[Either[Long, Tuple2[Long, Long]]](11l, 15l, 5l, 8l, (2l, 3l), 8l))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth decagonal number.\n    def isNumDecagonal(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNumDecagonal((3l)) == (27l));\n    assert(isNumDecagonal((7l)) == (175l));\n    assert(isNumDecagonal((10l)) == (370l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and returns a tuple containing a boolean that indicates if the element is in the list and the index position of the element (or -1 if the element is not found).\n    def sequentialSearch(dlist : List[Long], item : Long) : Tuple2[Boolean, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequentialSearch((List[Long](11l.toLong, 23l.toLong, 58l.toLong, 31l.toLong, 56l.toLong, 77l.toLong, 43l.toLong, 12l.toLong, 65l.toLong, 19l.toLong)), (31l)).equals(((true, 3l))));\n    assert(sequentialSearch((List[Long](12l.toLong, 32l.toLong, 45l.toLong, 62l.toLong, 35l.toLong, 47l.toLong, 44l.toLong, 61l.toLong)), (61l)).equals(((true, 7l))));\n    assert(sequentialSearch((List[Long](9l.toLong, 10l.toLong, 17l.toLong, 19l.toLong, 22l.toLong, 39l.toLong, 48l.toLong, 56l.toLong)), (48l)).equals(((true, 6l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check if the elements of a given list are unique or not.\n    def allUnique(test_list : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(allUnique((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to subtract two lists element-wise.\n    def subList(nums1 : List[Long], nums2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](-3l.toLong, -3l.toLong, -3l.toLong))));\n    assert(subList((List[Long](1l.toLong, 2l.toLong)), (List[Long](3l.toLong, 4l.toLong))).equals((List[Long](-2l.toLong, -2l.toLong))));\n    assert(subList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Long](40l.toLong, 50l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n    def validate(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(validate((1234l)) == (true));\n    assert(validate((51241l)) == (false));\n    assert(validate((321l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n    def checkElement(list : List[Any], element : Any) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkElement((List[Any](\"green\", \"orange\", \"black\", \"white\")), (Any(\"blue\"))) == (false));\n    assert(checkElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (Any(7l))) == (false));\n    assert(checkElement((List[Any](\"green\", \"green\", \"green\", \"green\")), (Any(\"green\"))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n    def textMatchTwoThree(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchTwoThree((\"ac\")) == (false));\n    assert(textMatchTwoThree((\"dc\")) == (false));\n    assert(textMatchTwoThree((\"abbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the largest sum of a contiguous list in the modified list which is formed by repeating the given list k times.\n    def maxSubArraySumRepeated(a : List[Long], n : Long, k : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySumRepeated((List[Long](10l.toLong, 20l.toLong, -30l.toLong, -1l.toLong)), (4l), (3l)) == (30l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, 10l.toLong, 20l.toLong)), (3l), (2l)) == (59l));\n    assert(maxSubArraySumRepeated((List[Long](-1l.toLong, -2l.toLong, -3l.toLong)), (3l), (3l)) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n    def squareSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareSum((2l)) == (20l));\n    assert(squareSum((3l)) == (56l));\n    assert(squareSum((4l)) == (120l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list of maximum length in a list of lists.\n    def maxLength(list1 : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLength((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](1l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))).equals(((4l, List[Long](10l.toLong, 12l.toLong, 14l.toLong, 15l.toLong)))));\n    assert(maxLength((List[List[Long]](List[Long](5l.toLong), List[Long](15l.toLong, 20l.toLong, 25l.toLong)))).equals(((3l, List[Long](15l.toLong, 20l.toLong, 25l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n    def countNoOfWays(n : Long, k : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countNoOfWays((2l), (4l)) == (16l));\n    assert(countNoOfWays((3l), (2l)) == (6l));\n    assert(countNoOfWays((4l), (4l)) == (228l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find quotient of two numbers (rounded down to the nearest integer).\n    def find(n : Long, m : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(find((10l), (3l)) == (3l));\n    assert(find((4l), (2l)) == (2l));\n    assert(find((20l), (5l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the third side of a right angled triangle.\n    def othersideRightangle(w : Long, h : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(othersideRightangle((7l), (8l)) == (10.63014581273465f));\n    assert(othersideRightangle((3l), (4l)) == 5l);\n    assert(othersideRightangle((7l), (15l)) == (16.55294535724685f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum value in a given heterogeneous list.\n    def maxVal(listval : List[Either[String, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (5l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (25l));\n    assert(maxVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (50l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return the sum of all divisors of a number.\n    def sumDiv(number : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDiv((8l)) == (7l));\n    assert(sumDiv((12l)) == (16l));\n    assert(sumDiv((7l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count inversions in a list.\n    def getInvCount(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getInvCount((List[Long](1l.toLong, 20l.toLong, 6l.toLong, 4l.toLong, 5l.toLong))) == (5l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(getInvCount((List[Long](1l.toLong, 2l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a given nested list structure.\n    def flattenList(list1 : List[Either[Long, List[Long]]]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(flattenList((List[Either[Long, List[Long]]](0l, 10l, List[Long](20l.toLong, 30l.toLong), 40l, 50l, List[Long](60l.toLong, 70l.toLong, 80l.toLong), List[Long](90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong)))).equals((List[Long](0l.toLong, 10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong, 80l.toLong, 90l.toLong, 100l.toLong, 110l.toLong, 120l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](10l.toLong, 20l.toLong), List[Long](40l.toLong), List[Long](30l.toLong, 56l.toLong, 25l.toLong), List[Long](10l.toLong, 20l.toLong), List[Long](33l.toLong), List[Long](40l.toLong)))).equals((List[Long](10l.toLong, 20l.toLong, 40l.toLong, 30l.toLong, 56l.toLong, 25l.toLong, 10l.toLong, 20l.toLong, 33l.toLong, 40l.toLong))));\n    assert(flattenList((List[Either[Long, List[Long]]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 10l.toLong, 11l.toLong, 12l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the maximum aggregate from the list of tuples.\n    def maxAggregate(stdata : List[Tuple2[String, Long]]) : Tuple2[String, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 90l), (\"Sabah Colley\", 88l), (\"Peter Nichols\", 7l), (\"Juan Whelan\", 122l), (\"Sabah Colley\", 84l)))).equals(((\"Juan Whelan\", 212l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 50l), (\"Sabah Colley\", 48l), (\"Peter Nichols\", 37l), (\"Juan Whelan\", 22l), (\"Sabah Colley\", 14l)))).equals(((\"Juan Whelan\", 72l))));\n    assert(maxAggregate((List[Tuple2[String, Long]]((\"Juan Whelan\", 10l), (\"Sabah Colley\", 20l), (\"Peter Nichols\", 30l), (\"Juan Whelan\", 40l), (\"Sabah Colley\", 50l)))).equals(((\"Sabah Colley\", 70l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find element at a given index after number of rotations.\n    def findElement(arr : List[Long], ranges : List[List[Long]], rotations : Long, index : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[List[Long]](List[Long](0l.toLong, 2l.toLong), List[Long](0l.toLong, 3l.toLong))), (2l), (1l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (2l)) == (3l));\n    assert(findElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](0l.toLong, 2l.toLong))), (1l), (1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return two words from a list of words starting with letter 'p'.\n    def startWithp(words : List[String]) : Tuple2[String, String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(startWithp((List[String](\"Python PHP\", \"Java JavaScript\", \"c c++\"))).equals(((\"Python\", \"PHP\"))));\n    assert(startWithp((List[String](\"Python Programming\", \"Java Programming\"))).equals(((\"Python\", \"Programming\"))));\n    assert(startWithp((List[String](\"Pqrst Pqr\", \"qrstuv\"))).equals(((\"Pqrst\", \"Pqr\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n    def maxSumIncreasingSubseq(a : List[Long], n : Long, index : Long, k : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (4l), (6l)) == (11l));\n    assert(maxSumIncreasingSubseq((List[Long](1l.toLong, 101l.toLong, 2l.toLong, 3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong)), (7l), (2l), (5l)) == (7l));\n    assert(maxSumIncreasingSubseq((List[Long](11l.toLong, 15l.toLong, 19l.toLong, 21l.toLong, 26l.toLong, 28l.toLong, 31l.toLong)), (7l), (2l), (4l)) == (71l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n    def largeProduct(nums1 : List[Long], nums2 : List[Long], N : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (3l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (4l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong))));\n    assert(largeProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 6l.toLong)), (5l)).equals((List[Long](60l.toLong, 54l.toLong, 50l.toLong, 48l.toLong, 45l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the maximum of two numbers.\n    def maximum(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maximum((5l), (10l)) == (10l));\n    assert(maximum((-1l), (-2l)) == (-1l));\n    assert(maximum((9l), (7l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a given string to a list of characters.\n    def stringToTuple(str1 : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(stringToTuple((\"python 3.0\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"))));\n    assert(stringToTuple((\"item1\")).equals((List[String](\"i\", \"t\", \"e\", \"m\", \"1\"))));\n    assert(stringToTuple((\"15.10\")).equals((List[String](\"1\", \"5\", \".\", \"1\", \"0\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the highest power of 2 that is less than or equal to n.\n    def highestPowerOf2(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(highestPowerOf2((10l)) == (8l));\n    assert(highestPowerOf2((19l)) == (16l));\n    assert(highestPowerOf2((32l)) == (32l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n'th lucas number.\n    def findLucas(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLucas((9l)) == (76l));\n    assert(findLucas((4l)) == (7l));\n    assert(findLucas((3l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to apply a given format string to all of the elements in a list.\n    def addString(list_ : List[Any], string : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addString((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (\"temp{0}\")).equals((List[String](\"temp1\", \"temp2\", \"temp3\", \"temp4\"))));\n    assert(addString((List[Any](\"a\", \"b\", \"c\", \"d\")), (\"python{0}\")).equals((List[String](\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"))));\n    assert(addString((List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (\"string{0}\")).equals((List[String](\"string5\", \"string6\", \"string7\", \"string8\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert more than one list to nested map.\n    def convertListDictionary(l1 : List[String], l2 : List[String], l3 : List[Long]) : List[Map[String,Map[String,Long]]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(convertListDictionary((List[String](\"S001\", \"S002\", \"S003\", \"S004\")), (List[String](\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\")), (List[Long](85l.toLong, 98l.toLong, 89l.toLong, 92l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"S001\" -> Map[String,Long](\"Adina Park\" -> 85l)), Map[String,Map[String,Long]](\"S002\" -> Map[String,Long](\"Leyton Marsh\" -> 98l)), Map[String,Map[String,Long]](\"S003\" -> Map[String,Long](\"Duncan Boyle\" -> 89l)), Map[String,Map[String,Long]](\"S004\" -> Map[String,Long](\"Saim Richards\" -> 92l))))));\n    assert(convertListDictionary((List[String](\"abc\", \"def\", \"ghi\", \"jkl\")), (List[String](\"python\", \"program\", \"language\", \"programs\")), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"abc\" -> Map[String,Long](\"python\" -> 100l)), Map[String,Map[String,Long]](\"def\" -> Map[String,Long](\"program\" -> 200l)), Map[String,Map[String,Long]](\"ghi\" -> Map[String,Long](\"language\" -> 300l)), Map[String,Map[String,Long]](\"jkl\" -> Map[String,Long](\"programs\" -> 400l))))));\n    assert(convertListDictionary((List[String](\"A1\", \"A2\", \"A3\", \"A4\")), (List[String](\"java\", \"C\", \"C++\", \"DBMS\")), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong))).equals((List[Map[String,Map[String,Long]]](Map[String,Map[String,Long]](\"A1\" -> Map[String,Long](\"java\" -> 10l)), Map[String,Map[String,Long]](\"A2\" -> Map[String,Long](\"C\" -> 20l)), Map[String,Map[String,Long]](\"A3\" -> Map[String,Long](\"C++\" -> 30l)), Map[String,Map[String,Long]](\"A4\" -> Map[String,Long](\"DBMS\" -> 40l))))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n    def getMaxSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMaxSum((60l)) == (106l));\n    assert(getMaxSum((10l)) == (12l));\n    assert(getMaxSum((2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the list with maximum length.\n    def maxLengthList(input_list : List[List[Long]]) : Tuple2[Long, List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxLengthList((List[List[Long]](List[Long](0l.toLong), List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))).equals(((3l, List[Long](13l.toLong, 15l.toLong, 17l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong)))).equals(((5l, List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)))));\n    assert(maxLengthList((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong)))).equals(((4l, List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if given list contains no duplicates.\n    def checkDistinct(test_tup : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong, 4l.toLong))) == (false));\n    assert(checkDistinct((List[Long](1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkDistinct((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first non-repeated character in a given string.\n    def firstNonRepeatingCharacter(str1 : String) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstNonRepeatingCharacter((\"abcabc\")).equals(None));\n    assert(firstNonRepeatingCharacter((\"abc\")).equals(Some(\"a\")));\n    assert(firstNonRepeatingCharacter((\"ababc\")).equals(Some(\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string starts and ends with the same character or not.\n    def checkChar(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkChar((\"abba\")).equals((\"Valid\")));\n    assert(checkChar((\"a\")).equals((\"Valid\")));\n    assert(checkChar((\"abcd\")).equals((\"Invalid\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of three numbers.\n    def medianNumbers(a : Long, b : Long, c : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianNumbers((25l), (55l), (65l)) == (55.0f));\n    assert(medianNumbers((20l), (10l), (30l)) == (20.0f));\n    assert(medianNumbers((15l), (45l), (75l)) == (45.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the sum of digits of each number of a given list.\n    def sumOfDigits(nums : List[Any]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfDigits((List[Any](10l.toLong, 2l.toLong, 56l.toLong))) == (14l));\n    assert(sumOfDigits((List[Any](List[Any](10l, 20l, 4l, 5l, \"b\", 70l, \"a\")))) == (19l));\n    assert(sumOfDigits((List[Any](10l.toLong, 20l.toLong, -4l.toLong, 5l.toLong, -70l.toLong))) == (19l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform the mathematical bitwise xor operation across the given tuples.\n    def bitwiseXor(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bitwiseXor(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((15l, 6l, 5l, 10l))));\n    assert(bitwiseXor(((11l, 5l, 7l, 10l)), ((6l, 3l, 4l, 4l))).equals(((13l, 6l, 3l, 14l))));\n    assert(bitwiseXor(((12l, 6l, 8l, 11l)), ((7l, 4l, 5l, 6l))).equals(((11l, 2l, 13l, 13l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to identify non-prime numbers.\n    def isNotPrime(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNotPrime((2l)) == (false));\n    assert(isNotPrime((10l)) == (true));\n    assert(isNotPrime((35l)) == (true));\n    assert(isNotPrime((37l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the number of unique tuples in the given list.\n    def extractFreq(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractFreq((List[Tuple2[Long, Long]]((3l, 4l), (1l, 2l), (4l, 3l), (5l, 6l)))) == (3l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((4l, 15l), (2l, 3l), (5l, 4l), (6l, 7l)))) == (4l));\n    assert(extractFreq((List[Tuple2[Long, Long]]((5l, 16l), (2l, 3l), (6l, 5l), (6l, 9l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise addition of list elements in the given two nested lists.\n    def addNestedTuples(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addNestedTuples((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](7l.toLong, 10l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](8l.toLong, 13l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](9l.toLong, 12l.toLong), List[Long](9l.toLong, 16l.toLong), List[Long](5l.toLong, 12l.toLong), List[Long](10l.toLong, 15l.toLong)))));\n    assert(addNestedTuples((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](11l.toLong, 14l.toLong), List[Long](11l.toLong, 18l.toLong), List[Long](7l.toLong, 14l.toLong), List[Long](12l.toLong, 17l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum of two numbers.\n    def minimum(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minimum((1l), (2l)) == (1l));\n    assert(minimum((-5l), (-4l)) == (-5l));\n    assert(minimum((0l), (0l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether an element exists within a tuple.\n    def checkTuplex(tuplex : List[Either[String, Long]], tuple1 : Any) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"r\"))) == (true));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(\"5\"))) == (false));\n    assert(checkTuplex((List[Either[String, Long]](\"w\", 3l, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\")), (Any(3l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find whether the parity of a given number is odd.\n    def findParity(x : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findParity((12l)) == (false));\n    assert(findParity((7l)) == (true));\n    assert(findParity((10l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create the next bigger number by rearranging the digits of a given number.\n    def rearrangeBigger(n : Long) : Any = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rearrangeBigger((12l)).equals((Any(21l))));\n    assert(rearrangeBigger((10l)).equals((Any(false))));\n    assert(rearrangeBigger((102l)).equals((Any(120l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find k number of smallest pairs which consist of one element from the first list and one element from the second list.\n    def kSmallestPairs(nums1 : List[Long], nums2 : List[Long], k : Long) : List[List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (2l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (1l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong)))));\n    assert(kSmallestPairs((List[Long](1l.toLong, 3l.toLong, 7l.toLong)), (List[Long](2l.toLong, 4l.toLong, 6l.toLong)), (7l)).equals((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](3l.toLong, 2l.toLong), List[Long](1l.toLong, 6l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](7l.toLong, 2l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum product from the pairs of tuples within a given list.\n    def minProductTuple(list1 : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minProductTuple((List[Tuple2[Long, Long]]((2l, 7l), (2l, 6l), (1l, 8l), (4l, 9l)))) == (8l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((10l, 20l), (15l, 2l), (5l, 10l)))) == (30l));\n    assert(minProductTuple((List[Tuple2[Long, Long]]((11l, 44l), (10l, 15l), (20l, 5l), (12l, 9l)))) == (100l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the minimum value in a given heterogeneous list.\n    def minVal(listval : List[Either[String, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minVal((List[Either[String, Long]](\"Python\", 3l, 2l, 4l, 5l, \"version\"))) == (2l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 15l, 20l, 25l))) == (15l));\n    assert(minVal((List[Either[String, Long]](\"Python\", 30l, 20l, 40l, 50l, \"version\"))) == (20l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given snake case string to camel case string.\n    def snakeToCamel(word : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(snakeToCamel((\"android_tv\")).equals((\"AndroidTv\")));\n    assert(snakeToCamel((\"google_pixel\")).equals((\"GooglePixel\")));\n    assert(snakeToCamel((\"apple_watch\")).equals((\"AppleWatch\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove odd numbers from a given list.\n    def removeOdd(l : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](2l.toLong))));\n    assert(removeOdd((List[Long](2l.toLong, 4l.toLong, 6l.toLong))).equals((List[Long](2l.toLong, 4l.toLong, 6l.toLong))));\n    assert(removeOdd((List[Long](10l.toLong, 20l.toLong, 3l.toLong))).equals((List[Long](10l.toLong, 20l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the nth element from a given list of tuples.\n    def extractNthElement(list1 : List[Tuple2[String, Long, Long]], n : Long) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (0l)).equals((List[Any](\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (2l)).equals((List[Any](99l.toLong, 96l.toLong, 94l.toLong, 98l.toLong))));\n    assert(extractNthElement((List[Tuple2[String, Long, Long]]((\"Greyson Fulton\", 98l, 99l), (\"Brady Kent\", 97l, 96l), (\"Wyatt Knott\", 91l, 94l), (\"Beau Turnbull\", 94l, 98l))), (1l)).equals((List[Any](98l.toLong, 97l.toLong, 91l.toLong, 94l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether any value in a sequence exists in a sequence or not.\n    def overlapping(list1 : List[Long], list2 : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](4l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(overlapping((List[Long](1l.toLong, 4l.toLong, 5l.toLong)), (List[Long](1l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find a pair with highest product from a given list of integers.\n    def maxProduct(arr : List[Long]) : Tuple2[Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 0l.toLong, 8l.toLong, 4l.toLong))).equals(((7l, 8l))));\n    assert(maxProduct((List[Long](0l.toLong, -1l.toLong, -2l.toLong, -4l.toLong, 5l.toLong, 0l.toLong, -6l.toLong))).equals(((-4l, -6l))));\n    assert(maxProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals(((2l, 3l))));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]
@@ -4732,7 +1708,7 @@
     "language": "scala",
     "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find common first element in given list of lists.\n    def groupTuples(Input : List[List[String]]) : List[List[String]] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "    }\n    def main(args: Array[String]) = {\n    assert(groupTuples((List[List[String]](List[String](\"x\", \"y\"), List[String](\"x\", \"z\"), List[String](\"w\", \"t\")))).equals((List[List[String]](List[String](\"x\", \"y\", \"z\"), List[String](\"w\", \"t\")))));\n    assert(groupTuples((List[List[String]](List[String](\"a\", \"b\"), List[String](\"a\", \"c\"), List[String](\"d\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\", \"c\"), List[String](\"d\", \"e\")))));\n    assert(groupTuples((List[List[String]](List[String](\"f\", \"g\"), List[String](\"f\", \"g\"), List[String](\"h\", \"i\")))).equals((List[List[String]](List[String](\"f\", \"g\", \"g\"), List[String](\"h\", \"i\")))));\n    }\n\n}\n",
     "stop_tokens": [
@@ -4740,13 +1716,3037 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "scala",
-    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three lists into a single sorted list.\n    def mergeSortedList(num1 : List[Long], num2 : List[Long], num3 : List[Long]) : List[Long] = {\n",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the element of a list having maximum length.\n    def FindMax(lst : List[List[Any]]) : List[Any] = {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeSortedList((List[Long](25l.toLong, 24l.toLong, 15l.toLong, 4l.toLong, 5l.toLong, 29l.toLong, 110l.toLong)), (List[Long](19l.toLong, 20l.toLong, 11l.toLong, 56l.toLong, 25l.toLong, 233l.toLong, 154l.toLong)), (List[Long](24l.toLong, 26l.toLong, 54l.toLong, 48l.toLong))).equals((List[Long](4l.toLong, 5l.toLong, 11l.toLong, 15l.toLong, 19l.toLong, 20l.toLong, 24l.toLong, 24l.toLong, 25l.toLong, 25l.toLong, 26l.toLong, 29l.toLong, 48l.toLong, 54l.toLong, 56l.toLong, 110l.toLong, 154l.toLong, 233l.toLong))));\n    assert(mergeSortedList((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (List[Long](2l.toLong, 5l.toLong, 7l.toLong, 11l.toLong)), (List[Long](1l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 12l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    assert(mergeSortedList((List[Long](18l.toLong, 14l.toLong, 10l.toLong, 9l.toLong, 8l.toLong, 7l.toLong, 9l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong)), (List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong)), (List[Long](12l.toLong, 74l.toLong, 9l.toLong, 50l.toLong, 61l.toLong, 41l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 14l.toLong, 18l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 41l.toLong, 50l.toLong, 58l.toLong, 61l.toLong, 65l.toLong, 74l.toLong, 75l.toLong, 85l.toLong))));\n    }\n\n}\n",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMax((List[List[Any]](List[String](\"A\"), List[String](\"A\", \"B\"), List[String](\"A\", \"B\", \"C\")))).equals((List[Any](\"A\", \"B\", \"C\"))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong, 2l.toLong, 3l.toLong))));\n    assert(FindMax((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong)))).equals((List[Any](1l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n    def roundAndSum(list1 : List[Either[Float, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(roundAndSum((List[Either[Float, Long]](22.4f.toFloat, 4.0f.toFloat, -16.22f.toFloat, -9.1f.toFloat, 11.0f.toFloat, -12.22f.toFloat, 14.2f.toFloat, -5.2f.toFloat, 17.5f.toFloat))) == (243l));\n    assert(roundAndSum((List[Either[Float, Long]](5l.toLong, 2l.toLong, 9l.toLong, 24.3f.toLong, 29l.toLong))) == (345l));\n    assert(roundAndSum((List[Either[Float, Long]](25.0f.toFloat, 56.7f.toFloat, 89.2f.toFloat))) == (513l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the cube sum of first n even natural numbers.\n    def cubeSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeSum((2l)) == (72l));\n    assert(cubeSum((3l)) == (288l));\n    assert(cubeSum((4l)) == (800l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to concatenate each element of tuple by the delimiter.\n    def concatenateTuple(test_tup : Tuple2[String, String, Long, String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(concatenateTuple(((\"ID\", \"is\", 4l, \"UTS\"))).equals((\"ID-is-4-UTS\")));\n    assert(concatenateTuple(((\"QWE\", \"is\", 4l, \"RTY\"))).equals((\"QWE-is-4-RTY\")));\n    assert(concatenateTuple(((\"ZEN\", \"is\", 4l, \"OP\"))).equals((\"ZEN-is-4-OP\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the average of cubes of first n natural numbers.\n    def findAverageOfCube(n : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAverageOfCube((2l)) == (4.5f));\n    assert(findAverageOfCube((3l)) == 12l);\n    assert(findAverageOfCube((1l)) == 1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract only the rear index element of each string in the given tuple.\n    def extractRear(test_tuple : Tuple2[String, String, String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractRear(((\"Mers\", \"for\", \"Vers\"))).equals((List[String](\"s\", \"r\", \"s\"))));\n    assert(extractRear(((\"Avenge\", \"for\", \"People\"))).equals((List[String](\"e\", \"r\", \"e\"))));\n    assert(extractRear(((\"Gotta\", \"get\", \"go\"))).equals((List[String](\"a\", \"t\", \"o\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the number of sublists containing a particular element.\n    def countElementInList(list1 : List[List[Any]], x : Any) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countElementInList((List[List[Any]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](1l.toLong, 11l.toLong), List[Long](1l.toLong, 15l.toLong, 7l.toLong))), (Any(1l))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"A\"))) == (3l));\n    assert(countElementInList((List[List[Any]](List[String](\"A\", \"B\"), List[String](\"A\", \"C\"), List[String](\"A\", \"D\", \"E\"), List[String](\"B\", \"C\", \"D\"))), (Any(\"E\"))) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to filter odd numbers.\n    def filterOddnumbers(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterOddnumbers((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    assert(filterOddnumbers((List[Long](10l.toLong, 20l.toLong, 45l.toLong, 67l.toLong, 84l.toLong, 93l.toLong))).equals((List[Long](45l.toLong, 67l.toLong, 93l.toLong))));\n    assert(filterOddnumbers((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 8l.toLong, 6l.toLong, 4l.toLong, 3l.toLong))).equals((List[Long](5l.toLong, 7l.toLong, 9l.toLong, 3l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n    def changeDateFormat(dt : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(changeDateFormat((\"2026-01-02\")).equals((\"02-01-2026\")));\n    assert(changeDateFormat((\"2020-11-13\")).equals((\"13-11-2020\")));\n    assert(changeDateFormat((\"2021-04-26\")).equals((\"26-04-2021\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list by using shell sort.\n    def shellSort(my_list : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(shellSort((List[Long](12l.toLong, 23l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 2l.toLong, 12l.toLong, 81l.toLong, 56l.toLong, 95l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 12l.toLong, 12l.toLong, 23l.toLong, 56l.toLong, 81l.toLong, 95l.toLong))));\n    assert(shellSort((List[Long](24l.toLong, 22l.toLong, 39l.toLong, 34l.toLong, 87l.toLong, 73l.toLong, 68l.toLong))).equals((List[Long](22l.toLong, 24l.toLong, 34l.toLong, 39l.toLong, 68l.toLong, 73l.toLong, 87l.toLong))));\n    assert(shellSort((List[Long](32l.toLong, 30l.toLong, 16l.toLong, 96l.toLong, 82l.toLong, 83l.toLong, 74l.toLong))).equals((List[Long](16l.toLong, 30l.toLong, 32l.toLong, 74l.toLong, 82l.toLong, 83l.toLong, 96l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract the elementwise and tuples from the given two tuples.\n    def andTuples(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(andTuples(((10l, 4l, 6l, 9l)), ((5l, 2l, 3l, 3l))).equals(((0l, 0l, 2l, 1l))));\n    assert(andTuples(((1l, 2l, 3l, 4l)), ((5l, 6l, 7l, 8l))).equals(((1l, 2l, 3l, 0l))));\n    assert(andTuples(((8l, 9l, 11l, 12l)), ((7l, 13l, 14l, 17l))).equals(((0l, 9l, 10l, 0l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the directrix of a parabola.\n    def parabolaDirectrix(a : Long, b : Long, c : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(parabolaDirectrix((5l), (3l), (2l)) == (-198l));\n    assert(parabolaDirectrix((9l), (8l), (4l)) == (-2336l));\n    assert(parabolaDirectrix((2l), (4l), (6l)) == (-130l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes two lists and returns true if they have at least one common element.\n    def commonElement(list1 : List[Any], list2 : List[Any]) : Option[Boolean] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(Some(true)));\n    assert(commonElement((List[Any](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Any](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))).equals(None));\n    assert(commonElement((List[Any](\"a\", \"b\", \"c\")), (List[Any](\"d\", \"b\", \"e\"))).equals(Some(true)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median length of a trapezium.\n    def medianTrapezium(base1 : Long, base2 : Long, height : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(medianTrapezium((15l), (25l), (35l)) == 20l);\n    assert(medianTrapezium((10l), (20l), (30l)) == 15l);\n    assert(medianTrapezium((6l), (9l), (4l)) == (7.5f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the entered number is greater than the elements of the given list.\n    def checkGreater(arr : List[Long], number : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkGreater((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (4l)) == (false));\n    assert(checkGreater((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (8l)) == (true));\n    assert(checkGreater((List[Long](9l.toLong, 7l.toLong, 4l.toLong, 8l.toLong, 6l.toLong, 1l.toLong)), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by one or more b's.\n    def textMatchOne(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchOne((\"ac\")) == (false));\n    assert(textMatchOne((\"dc\")) == (false));\n    assert(textMatchOne((\"abba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last digit of a given number.\n    def lastDigit(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigit((123l)) == (3l));\n    assert(lastDigit((25l)) == (5l));\n    assert(lastDigit((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to return the negative numbers in a list.\n    def negNos(list1 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(negNos((List[Long](-1l.toLong, 4l.toLong, 5l.toLong, -6l.toLong))).equals((List[Long](-1l.toLong, -6l.toLong))));\n    assert(negNos((List[Long](-1l.toLong, -2l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](-1l.toLong, -2l.toLong))));\n    assert(negNos((List[Long](-7l.toLong, -6l.toLong, 8l.toLong, 9l.toLong))).equals((List[Long](-7l.toLong, -6l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove odd characters in a string.\n    def removeOdd(str1 : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeOdd((\"python\")).equals((\"yhn\")));\n    assert(removeOdd((\"program\")).equals((\"rga\")));\n    assert(removeOdd((\"language\")).equals((\"agae\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count bidirectional tuple pairs.\n    def countBidirectional(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (3l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 3l), (6l, 5l), (9l, 1l), (6l, 5l), (2l, 1l)))) == (2l));\n    assert(countBidirectional((List[Tuple2[Long, Long]]((5l, 6l), (1l, 2l), (6l, 5l), (9l, 2l), (6l, 5l), (2l, 1l)))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to join a list of multiple integers into a single integer.\n    def multipleToSingle(L : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multipleToSingle((List[Long](11l.toLong, 33l.toLong, 50l.toLong))) == (113350l));\n    assert(multipleToSingle((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (-123456l));\n    assert(multipleToSingle((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong))) == (10152025l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb and their positions in a given sentence.\n    def findAdverbPosition(text : String) : Tuple2[Long, Long, String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbPosition((\"clearly!! we can see the sky\")).equals(((0l, 7l, \"clearly\"))));\n    assert(findAdverbPosition((\"seriously!! there are many roses\")).equals(((0l, 9l, \"seriously\"))));\n    assert(findAdverbPosition((\"unfortunately!! sita is going to home\")).equals(((0l, 13l, \"unfortunately\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cube of a given size.\n    def surfaceareaCube(l : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCube((5l)) == (150l));\n    assert(surfaceareaCube((3l)) == (54l));\n    assert(surfaceareaCube((10l)) == (600l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the ration of positive numbers in a list of integers.\n    def positiveCount(nums : List[Long]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(positiveCount((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.54f));\n    assert(positiveCount((List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (0.69f));\n    assert(positiveCount((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong))) == (0.56f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the largest negative number from the given list.\n    def largestNeg(list1 : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -4l.toLong, -6l.toLong))) == (-6l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, -8l.toLong, -9l.toLong))) == (-9l));\n    assert(largestNeg((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, -1l.toLong))) == (-1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to trim each list by k in the given lists.\n    def trimTuple(test_list : List[List[Long]], K : Long) : List[List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (2l)).equals((List[List[Long]](List[Long](2l.toLong), List[Long](9l.toLong), List[Long](2l.toLong), List[Long](2l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](5l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 4l.toLong), List[Long](3l.toLong, 4l.toLong, 9l.toLong, 2l.toLong, 1l.toLong), List[Long](9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong), List[Long](4l.toLong, 8l.toLong, 2l.toLong, 1l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](4l.toLong, 9l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](8l.toLong, 2l.toLong, 1l.toLong)))));\n    assert(trimTuple((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 4l.toLong, 9l.toLong), List[Long](11l.toLong, 8l.toLong, 12l.toLong, 4l.toLong), List[Long](4l.toLong, 1l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 6l.toLong, 9l.toLong, 7l.toLong))), (1l)).equals((List[List[Long]](List[Long](8l.toLong, 4l.toLong), List[Long](8l.toLong, 12l.toLong), List[Long](1l.toLong, 7l.toLong), List[Long](6l.toLong, 9l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to perform index wise multiplication of list elements in the given two lists.\n    def indexMultiplication(test_tup1 : List[List[Long]], test_tup2 : List[List[Long]]) : List[List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMultiplication((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](1l.toLong, 10l.toLong))), (List[List[Long]](List[Long](6l.toLong, 7l.toLong), List[Long](3l.toLong, 9l.toLong), List[Long](1l.toLong, 1l.toLong), List[Long](7l.toLong, 3l.toLong)))).equals((List[List[Long]](List[Long](6l.toLong, 21l.toLong), List[Long](12l.toLong, 45l.toLong), List[Long](2l.toLong, 9l.toLong), List[Long](7l.toLong, 30l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](3l.toLong, 10l.toLong), List[Long](2l.toLong, 11l.toLong))), (List[List[Long]](List[Long](7l.toLong, 8l.toLong), List[Long](4l.toLong, 10l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](8l.toLong, 4l.toLong)))).equals((List[List[Long]](List[Long](14l.toLong, 32l.toLong), List[Long](20l.toLong, 60l.toLong), List[Long](6l.toLong, 20l.toLong), List[Long](16l.toLong, 44l.toLong)))));\n    assert(indexMultiplication((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong), List[Long](4l.toLong, 11l.toLong), List[Long](3l.toLong, 12l.toLong))), (List[List[Long]](List[Long](8l.toLong, 9l.toLong), List[Long](5l.toLong, 11l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](9l.toLong, 5l.toLong)))).equals((List[List[Long]](List[Long](24l.toLong, 45l.toLong), List[Long](30l.toLong, 77l.toLong), List[Long](12l.toLong, 33l.toLong), List[Long](27l.toLong, 60l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the occurence of all elements of list in a tuple.\n    def countOccurrence(tup : Any, lst : List[Any]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countOccurrence((Any((\"a\", \"a\", \"c\", \"b\", \"d\"))), (List[Any](\"a\", \"b\"))) == (3l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 1l, 4l, 6l, 7l, 1l, 4l))), (List[Any](1l.toLong, 4l.toLong, 7l.toLong))) == (6l));\n    assert(countOccurrence((Any((1l, 2l, 3l, 4l, 5l, 6l))), (List[Any](1l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find cubes of individual elements in a list.\n    def cubeNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cubeNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 8l.toLong, 27l.toLong, 64l.toLong, 125l.toLong, 216l.toLong, 343l.toLong, 512l.toLong, 729l.toLong, 1000l.toLong))));\n    assert(cubeNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(cubeNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](1728l.toLong, 3375l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the sum of perrin numbers.\n    def calSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(calSum((9l)) == (49l));\n    assert(calSum((10l)) == (66l));\n    assert(calSum((11l)) == (88l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract specified size of strings from a given list of string values.\n    def extractString(str : List[String], l : Long) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (8l)).equals((List[String](\"practice\", \"solution\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (6l)).equals((List[String](\"Python\"))));\n    assert(extractString((List[String](\"Python\", \"list\", \"exercises\", \"practice\", \"solution\")), (9l)).equals((List[String](\"exercises\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from the given string.\n    def removeWhitespaces(text1 : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeWhitespaces((\" Google    Flutter \")).equals((\"GoogleFlutter\")));\n    assert(removeWhitespaces((\" Google    Dart \")).equals((\"GoogleDart\")));\n    assert(removeWhitespaces((\" iOS    Swift \")).equals((\"iOSSwift\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n    def lossAmount(actual_cost : Long, sale_amount : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lossAmount((1500l), (1200l)) == (0l));\n    assert(lossAmount((100l), (200l)) == (100l));\n    assert(lossAmount((2000l), (5000l)) == (3000l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of even factors of a number.\n    def sumofFactors(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumofFactors((18l)) == (26l));\n    assert(sumofFactors((30l)) == (48l));\n    assert(sumofFactors((6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a word containing 'z'.\n    def textMatchWordz(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordz((\"pythonz.\")) == (true));\n    assert(textMatchWordz((\"xyz.\")) == (true));\n    assert(textMatchWordz((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 31 days or not.\n    def checkMonthnumbNumber(monthnum2 : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumbNumber((5l)) == (true));\n    assert(checkMonthnumbNumber((2l)) == (false));\n    assert(checkMonthnumbNumber((6l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse each string in a given list of string values.\n    def reverseStringList(stringlist : List[String]) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseStringList((List[String](\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"))).equals((List[String](\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"))));\n    assert(reverseStringList((List[String](\"john\", \"amal\", \"joel\", \"george\"))).equals((List[String](\"nhoj\", \"lama\", \"leoj\", \"egroeg\"))));\n    assert(reverseStringList((List[String](\"jack\", \"john\", \"mary\"))).equals((List[String](\"kcaj\", \"nhoj\", \"yram\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sublist having minimum length.\n    def FindMin(lst : List[List[Any]]) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Any](1l.toLong))));\n    assert(FindMin((List[List[Any]](List[Long](1l.toLong, 1l.toLong), List[Long](1l.toLong, 1l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong, 7l.toLong, 8l.toLong)))).equals((List[Any](1l.toLong, 1l.toLong))));\n    assert(FindMin((List[List[Any]](List[String](\"x\"), List[String](\"x\", \"y\"), List[String](\"x\", \"y\", \"z\")))).equals((List[Any](\"x\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the area of a rectangle.\n    def rectangleArea(l : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rectangleArea((10l), (20l)) == (200l));\n    assert(rectangleArea((10l), (5l)) == (50l));\n    assert(rectangleArea((4l), (2l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uppercase substrings from a given string.\n    def removeUppercase(str1 : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeUppercase((\"cAstyoUrFavoRitETVshoWs\")).equals((\"cstyoravoitshos\")));\n    assert(removeUppercase((\"wAtchTheinTernEtrAdIo\")).equals((\"wtchheinerntrdo\")));\n    assert(removeUppercase((\"VoicESeaRchAndreComMendaTionS\")).equals((\"oiceachndreomendaion\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to get the first element of each sublist.\n    def Extract(lst : List[List[Long]]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](1l.toLong, 3l.toLong, 6l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))).equals((List[Long](1l.toLong, 4l.toLong))));\n    assert(Extract((List[List[Long]](List[Long](9l.toLong, 8l.toLong, 1l.toLong), List[Long](1l.toLong, 2l.toLong)))).equals((List[Long](9l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the upper case characters in a given string.\n    def upperCtr(str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(upperCtr((\"PYthon\")) == (1l));\n    assert(upperCtr((\"BigData\")) == (1l));\n    assert(upperCtr((\"program\")) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find all possible combinations of the elements of a given list.\n    def combinationsList(list1 : List[String]) : List[Either[List[None], List[String]]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combinationsList((List[String](\"orange\", \"red\", \"green\", \"blue\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"orange\"), List[String](\"red\"), List[String](\"red\", \"orange\"), List[String](\"green\"), List[String](\"green\", \"orange\"), List[String](\"green\", \"red\"), List[String](\"green\", \"red\", \"orange\"), List[String](\"blue\"), List[String](\"blue\", \"orange\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"red\", \"orange\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"orange\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"blue\", \"green\", \"red\", \"orange\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"blue\"), List[String](\"blue\", \"red\"), List[String](\"blue\", \"green\"), List[String](\"blue\", \"green\", \"red\"), List[String](\"white\"), List[String](\"white\", \"red\"), List[String](\"white\", \"green\"), List[String](\"white\", \"green\", \"red\"), List[String](\"white\", \"blue\"), List[String](\"white\", \"blue\", \"red\"), List[String](\"white\", \"blue\", \"green\"), List[String](\"white\", \"blue\", \"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"black\", \"blue\"), List[String](\"black\", \"blue\", \"red\"), List[String](\"black\", \"blue\", \"green\"), List[String](\"black\", \"blue\", \"green\", \"red\"), List[String](\"black\", \"white\"), List[String](\"black\", \"white\", \"red\"), List[String](\"black\", \"white\", \"green\"), List[String](\"black\", \"white\", \"green\", \"red\"), List[String](\"black\", \"white\", \"blue\"), List[String](\"black\", \"white\", \"blue\", \"red\"), List[String](\"black\", \"white\", \"blue\", \"green\"), List[String](\"black\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"blue\"), List[String](\"orange\", \"blue\", \"red\"), List[String](\"orange\", \"blue\", \"green\"), List[String](\"orange\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"white\"), List[String](\"orange\", \"white\", \"red\"), List[String](\"orange\", \"white\", \"green\"), List[String](\"orange\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"white\", \"blue\"), List[String](\"orange\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"white\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"blue\"), List[String](\"orange\", \"black\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"blue\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\"), List[String](\"orange\", \"black\", \"white\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"green\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"red\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\"), List[String](\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\")))));\n    assert(combinationsList((List[String](\"red\", \"green\", \"black\", \"orange\"))).equals((List[Either[List[None], List[String]]](List[Long](), List[String](\"red\"), List[String](\"green\"), List[String](\"green\", \"red\"), List[String](\"black\"), List[String](\"black\", \"red\"), List[String](\"black\", \"green\"), List[String](\"black\", \"green\", \"red\"), List[String](\"orange\"), List[String](\"orange\", \"red\"), List[String](\"orange\", \"green\"), List[String](\"orange\", \"green\", \"red\"), List[String](\"orange\", \"black\"), List[String](\"orange\", \"black\", \"red\"), List[String](\"orange\", \"black\", \"green\"), List[String](\"orange\", \"black\", \"green\", \"red\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product sublist of the given list.\n    def maxSubarrayProduct(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubarrayProduct((List[Long](1l.toLong, -2l.toLong, -3l.toLong, 0l.toLong, 7l.toLong, -8l.toLong, -2l.toLong))) == (112l));\n    assert(maxSubarrayProduct((List[Long](6l.toLong, -3l.toLong, -10l.toLong, 0l.toLong, 2l.toLong))) == (180l));\n    assert(maxSubarrayProduct((List[Long](-2l.toLong, -40l.toLong, 0l.toLong, -2l.toLong, -3l.toLong))) == (80l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if all values are same in a map.\n    def checkValue(dict : Map[String,Long], n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (10l)) == (false));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (12l)) == (true));\n    assert(checkValue((Map[String,Long](\"Cierra Vega\" -> 12l, \"Alden Cantrell\" -> 12l, \"Kierra Gentry\" -> 12l, \"Pierre Cox\" -> 12l)), (5l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to drop empty items from a given map.\n    def dropEmpty(dict1 : Map[String,Option[String]]) : Map[String,String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\", \"c2\" -> \"Green\"))));\n    assert(dropEmpty(Map[String,String](\"c1\" -> \"Red\", \"c2\" -> None, \"c3\" -> None)).equals((Map[String,String](\"c1\" -> \"Red\"))));\n    assert(dropEmpty(Map[String,None](\"c1\" -> None, \"c2\" -> \"Green\", \"c3\" -> None)).equals((Map[String,String](\"c2\" -> \"Green\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that list.\n    def maxProduct(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxProduct((List[Long](3l.toLong, 100l.toLong, 4l.toLong, 5l.toLong, 150l.toLong, 6l.toLong))) == (3000l));\n    assert(maxProduct((List[Long](4l.toLong, 42l.toLong, 55l.toLong, 68l.toLong, 80l.toLong))) == (50265600l));\n    assert(maxProduct((List[Long](10l.toLong, 22l.toLong, 9l.toLong, 33l.toLong, 21l.toLong, 50l.toLong, 41l.toLong, 60l.toLong))) == (2460l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n    def addPairwise(test_tup : Tuple2[Long, Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addPairwise(((1l, 5l, 7l, 8l, 10l))).equals(((6l, 12l, 15l, 18l))));\n    assert(addPairwise(((2l, 6l, 8l, 9l, 11l))).equals(((8l, 14l, 17l, 20l))));\n    assert(addPairwise(((3l, 7l, 9l, 10l, 12l))).equals(((10l, 16l, 19l, 22l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the product of the list multiplication modulo n.\n    def findRemainder(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRemainder((List[Long](100l.toLong, 10l.toLong, 5l.toLong, 25l.toLong, 35l.toLong, 14l.toLong)), (11l)) == (9l));\n    assert(findRemainder((List[Long](1l.toLong, 1l.toLong, 1l.toLong)), (1l)) == (0l));\n    assert(findRemainder((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (2l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given list contains consecutive numbers or not.\n    def checkConsecutive(l : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (true));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 6l.toLong))) == (false));\n    assert(checkConsecutive((List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace characters in a string.\n    def replaceChar(str1 : String, ch : String, newch : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceChar((\"polygon\"), (\"y\"), (\"l\")).equals((\"pollgon\")));\n    assert(replaceChar((\"character\"), (\"c\"), (\"a\")).equals((\"aharaater\")));\n    assert(replaceChar((\"python\"), (\"l\"), (\"a\")).equals((\"python\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a map by value.\n    def sortCounter(dict1 : Map[String,Long]) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortCounter((Map[String,Long](\"Math\" -> 81l, \"Physics\" -> 83l, \"Chemistry\" -> 87l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 87l), (\"Physics\", 83l), (\"Math\", 81l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 400l, \"Physics\" -> 300l, \"Chemistry\" -> 250l))).equals((List[Tuple2[String, Long]]((\"Math\", 400l), (\"Physics\", 300l), (\"Chemistry\", 250l)))));\n    assert(sortCounter((Map[String,Long](\"Math\" -> 900l, \"Physics\" -> 1000l, \"Chemistry\" -> 1250l))).equals((List[Tuple2[String, Long]]((\"Chemistry\", 1250l), (\"Physics\", 1000l), (\"Math\", 900l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the largest and smallest value in a given list.\n    def bigSum(nums : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(bigSum((List[Long](-1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigSum((List[Long](2l.toLong, 3l.toLong, 6l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert the given string to lower case.\n    def isLower(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isLower((\"InValid\")).equals((\"invalid\")));\n    assert(isLower((\"TruE\")).equals((\"true\")));\n    assert(isLower((\"SenTenCE\")).equals((\"sentence\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove lowercase substrings from a given string.\n    def removeLowercase(str1 : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLowercase((\"PYTHon\")).equals((\"PYTH\")));\n    assert(removeLowercase((\"FInD\")).equals((\"FID\")));\n    assert(removeLowercase((\"STRinG\")).equals((\"STRG\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first digit of a given number.\n    def firstDigit(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstDigit((123l)) == (1l));\n    assert(firstDigit((456l)) == (4l));\n    assert(firstDigit((12l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n    def heapQueueLargest(nums : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (3l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (2l)).equals((List[Long](85l.toLong, 75l.toLong))));\n    assert(heapQueueLargest((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 22l.toLong, 58l.toLong)), (5l)).equals((List[Long](85l.toLong, 75l.toLong, 65l.toLong, 58l.toLong, 35l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of integers and only returns the odd ones.\n    def Split(list : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 5l.toLong))));\n    assert(Split((List[Long](10l.toLong, 11l.toLong, 12l.toLong, 13l.toLong))).equals((List[Long](11l.toLong, 13l.toLong))));\n    assert(Split((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong))).equals((List[Long](7l.toLong, 9l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n    def difference(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difference((3l)) == (30l));\n    assert(difference((5l)) == (210l));\n    assert(difference((2l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of pairs whose xor value is odd.\n    def findOddPair(A : List[Long], N : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findOddPair((List[Long](5l.toLong, 4l.toLong, 7l.toLong, 2l.toLong, 1l.toLong)), (5l)) == (6l));\n    assert(findOddPair((List[Long](7l.toLong, 2l.toLong, 8l.toLong, 1l.toLong, 0l.toLong, 5l.toLong, 11l.toLong)), (7l)) == (12l));\n    assert(findOddPair((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to toggle the case of all characters in a string.\n    def toggleString(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleString((\"Python\")).equals((\"pYTHON\")));\n    assert(toggleString((\"Pangram\")).equals((\"pANGRAM\")));\n    assert(toggleString((\"LIttLE\")).equals((\"liTTle\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the per-digit difference between two integers.\n    def digitDistanceNums(n1 : Long, n2 : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(digitDistanceNums((1l), (2l)) == (1l));\n    assert(digitDistanceNums((23l), (56l)) == (6l));\n    assert(digitDistanceNums((123l), (256l)) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the sum of the largest contiguous sublist in the given list.\n    def maxSubArraySum(a : List[Long], size : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSubArraySum((List[Long](-2l.toLong, -3l.toLong, 4l.toLong, -1l.toLong, -2l.toLong, 1l.toLong, 5l.toLong, -3l.toLong)), (8l)) == (7l));\n    assert(maxSubArraySum((List[Long](-3l.toLong, -4l.toLong, 5l.toLong, -2l.toLong, -3l.toLong, 2l.toLong, 6l.toLong, -4l.toLong)), (8l)) == (8l));\n    assert(maxSubArraySum((List[Long](-4l.toLong, -5l.toLong, 6l.toLong, -3l.toLong, -4l.toLong, 3l.toLong, 7l.toLong, -5l.toLong)), (8l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the union of the elements of two given lists and output them in sorted order.\n    def unionElements(test_tup1 : List[Long], test_tup2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(unionElements((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](5l.toLong, 7l.toLong, 4l.toLong, 10l.toLong))).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 10l.toLong))));\n    assert(unionElements((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))));\n    assert(unionElements((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong)), (List[Long](13l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))).equals((List[Long](11l.toLong, 12l.toLong, 13l.toLong, 14l.toLong, 15l.toLong, 16l.toLong, 17l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the longest sublists.\n    def FindMaxLength(lst : List[List[Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMaxLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)))) == (4l));\n    assert(FindMaxLength((List[List[Long]](List[Long](0l.toLong, 1l.toLong), List[Long](2l.toLong, 2l.toLong), List[Long](3l.toLong, 2l.toLong, 1l.toLong)))) == (3l));\n    assert(FindMaxLength((List[List[Long]](List[Long](7l.toLong), List[Long](22l.toLong, 23l.toLong), List[Long](13l.toLong, 14l.toLong, 15l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong)))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks from a string.\n    def extractValues(text : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractValues((\"\"Python\", \"PHP\", \"Java\"\")).equals((List[String](\"Python\", \"PHP\", \"Java\"))));\n    assert(extractValues((\"\"python\",\"program\",\"language\"\")).equals((List[String](\"python\", \"program\", \"language\"))));\n    assert(extractValues((\"\"red\",\"blue\",\"green\",\"yellow\"\")).equals((List[String](\"red\", \"blue\", \"green\", \"yellow\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n    def countPairs(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (3l)) == (2l));\n    assert(countPairs((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (4l)) == (0l));\n    assert(countPairs((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (5l)) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to split a string into characters.\n    def split(word : String) : List[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(split((\"python\")).equals((List[String](\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"))));\n    assert(split((\"Name\")).equals((List[String](\"N\", \"a\", \"m\", \"e\"))));\n    assert(split((\"program\")).equals((List[String](\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the sum of the digits of a non-negative integer.\n    def sumDigits(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumDigits((345l)) == (12l));\n    assert(sumDigits((12l)) == (3l));\n    assert(sumDigits((97l)) == (16l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a specified list is sorted or not.\n    def issortList(list1 : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 16l.toLong, 17l.toLong))) == (true));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 12l.toLong, 14l.toLong, 20l.toLong, 17l.toLong))) == (false));\n    assert(issortList((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 10l.toLong, 15l.toLong, 14l.toLong, 20l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a list of N empty dictionaries.\n    def emptyList(length : Long) : List[Map[None,None]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(emptyList((5l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((6l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    assert(emptyList((7l)).equals((List[Map[None,None]](Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long](), Map[Long,Long]()))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort each sublist of strings in a given list of lists.\n    def sortSublists(list1 : List[List[String]]) : List[List[String]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"white\", \"black\", \"orange\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\", \"white\"), List[String](\"black\", \"orange\", \"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))).equals((List[List[String]](List[String](\"green\", \"orange\"), List[String](\"black\"), List[String](\"green\", \"orange\"), List[String](\"white\")))));\n    assert(sortSublists((List[List[String]](List[String](\"a\", \"b\"), List[String](\"d\", \"c\"), List[String](\"g\", \"h\"), List[String](\"f\", \"e\")))).equals((List[List[String]](List[String](\"a\", \"b\"), List[String](\"c\", \"d\"), List[String](\"g\", \"h\"), List[String](\"e\", \"f\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check if a given number is one less than twice its reverse.\n    def checks(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checks((70l)) == (false));\n    assert(checks((23l)) == (false));\n    assert(checks((73l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to remove duplicate numbers from a given number of lists.\n    def twoUniqueNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    assert(twoUniqueNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to calculate the product of the unique numbers in a given list.\n    def uniqueProduct(list_data : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueProduct((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 20l.toLong, 50l.toLong, 60l.toLong, 40l.toLong))) == (720000000l));\n    assert(uniqueProduct((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong))) == (6l));\n    assert(uniqueProduct((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the surface area of a cylinder.\n    def surfaceareaCylinder(r : Long, h : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceareaCylinder((10l), (5l)) == (942.45f));\n    assert(surfaceareaCylinder((4l), (5l)) == (226.18800000000002f));\n    assert(surfaceareaCylinder((4l), (10l)) == (351.848f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether a list is sublist of another or not.\n    def isSubArray(A : List[Long], B : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSubArray((List[Long](1l.toLong, 4l.toLong, 3l.toLong, 5l.toLong)), (List[Long](1l.toLong, 2l.toLong))) == (false));\n    assert(isSubArray((List[Long](1l.toLong, 2l.toLong, 1l.toLong)), (List[Long](1l.toLong, 2l.toLong, 1l.toLong))) == (true));\n    assert(isSubArray((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 2l.toLong)), (List[Long](2l.toLong, 2l.toLong, 0l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last digit in factorial of a given number.\n    def lastDigitFactorial(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lastDigitFactorial((4l)) == (4l));\n    assert(lastDigitFactorial((21l)) == (0l));\n    assert(lastDigitFactorial((30l)) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to interleave 3 lists of the same length into a single flat list.\n    def interleaveLists(list1 : List[Long], list2 : List[Long], list3 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(interleaveLists((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong, 50l.toLong, 60l.toLong, 70l.toLong)), (List[Long](100l.toLong, 200l.toLong, 300l.toLong, 400l.toLong, 500l.toLong, 600l.toLong, 700l.toLong))).equals((List[Long](1l.toLong, 10l.toLong, 100l.toLong, 2l.toLong, 20l.toLong, 200l.toLong, 3l.toLong, 30l.toLong, 300l.toLong, 4l.toLong, 40l.toLong, 400l.toLong, 5l.toLong, 50l.toLong, 500l.toLong, 6l.toLong, 60l.toLong, 600l.toLong, 7l.toLong, 70l.toLong, 700l.toLong))));\n    assert(interleaveLists((List[Long](10l.toLong, 20l.toLong)), (List[Long](15l.toLong, 2l.toLong)), (List[Long](5l.toLong, 10l.toLong))).equals((List[Long](10l.toLong, 15l.toLong, 5l.toLong, 20l.toLong, 2l.toLong, 10l.toLong))));\n    assert(interleaveLists((List[Long](11l.toLong, 44l.toLong)), (List[Long](10l.toLong, 15l.toLong)), (List[Long](20l.toLong, 5l.toLong))).equals((List[Long](11l.toLong, 10l.toLong, 20l.toLong, 44l.toLong, 15l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the dissimilar elements in the given two tuples.\n    def findDissimilar(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findDissimilar(((3l, 4l, 5l, 6l)), ((5l, 7l, 4l, 10l))).equals(((3l, 6l, 7l, 10l))));\n    assert(findDissimilar(((1l, 2l, 3l, 4l)), ((7l, 2l, 3l, 9l))).equals(((1l, 4l, 7l, 9l))));\n    assert(findDissimilar(((21l, 11l, 25l, 26l)), ((26l, 34l, 21l, 36l))).equals(((34l, 36l, 11l, 25l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the largest number that can be formed with the given list of digits.\n    def findMaxNum(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (321l));\n    assert(findMaxNum((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 1l.toLong))) == (6541l));\n    assert(findMaxNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 9l.toLong))) == (9321l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove uneven elements in the nested mixed tuple.\n    def extractEven(test_tuple : Tuple2[Long, Long, Tuple2[Long, Long, Tuple2[Long, Long]], Long, Long]) : Any = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractEven(((4l, 5l, (7l, 6l, (2l, 4l)), 6l, 8l))).equals((Any(6l, (2l, 4l)), 6l, 8l))));\n    assert(extractEven(((5l, 6l, (8l, 7l, (4l, 8l)), 7l, 9l))).equals((Any(8l, (4l, 8l))))));\n    assert(extractEven(((5l, 6l, (9l, 8l, (4l, 6l)), 8l, 10l))).equals((Any(8l, (4l, 6l)), 8l, 10l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the surface area of a square scalaramid with a given base edge and height.\n    def surfaceArea(b : Long, s : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(surfaceArea((3l), (4l)) == (33l));\n    assert(surfaceArea((4l), (5l)) == (56l));\n    assert(surfaceArea((1l), (2l)) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which returns nth catalan number.\n    def catalanNumber(num : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(catalanNumber((10l)) == (16796l));\n    assert(catalanNumber((9l)) == (4862l));\n    assert(catalanNumber((7l)) == (429l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the first adverb ending with ly and its positions in a given string.\n    def findAdverbs(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findAdverbs((\"Clearly, he has no excuse for such behavior.\")).equals((\"0-7: Clearly\")));\n    assert(findAdverbs((\"Please handle the situation carefuly\")).equals((\"28-36: carefuly\")));\n    assert(findAdverbs((\"Complete the task quickly\")).equals((\"18-25: quickly\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the n most expensive items in a given dataset.\n    def expensiveItems(items : List[Map[String,Either[String, Float]]], n : Long) : List[Map[String,Either[String, Float]]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f))), (2l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f)))));\n    assert(expensiveItems((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-1\", \"price\" -> 101.1f), Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f), Map[String,String](\"name\" -> \"Item-3\", \"price\" -> 45.09f), Map[String,String](\"name\" -> \"Item-4\", \"price\" -> 22.75f))), (1l)).equals((List[Map[String,Either[String, Float]]](Map[String,String](\"name\" -> \"Item-2\", \"price\" -> 555.22f)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to split a list at the nth eelment and add the first part to the end.\n    def splitArr(l : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(splitArr((List[Long](12l.toLong, 10l.toLong, 5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong)), (2l)).equals((List[Long](5l.toLong, 6l.toLong, 52l.toLong, 36l.toLong, 12l.toLong, 10l.toLong))));\n    assert(splitArr((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(splitArr((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (3l)).equals((List[Long](3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 0l.toLong, 1l.toLong, 2l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert a list to a tuple.\n    def listTuple(listx : List[Long]) : Any = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(listTuple((List[Long](5l.toLong, 10l.toLong, 7l.toLong, 4l.toLong, 15l.toLong, 3l.toLong))).equals((Any((5l, 10l, 7l, 4l, 15l, 3l)))));\n    assert(listTuple((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 7l.toLong))).equals((Any((2l, 4l, 5l, 6l, 2l, 3l, 4l, 4l, 7l)))));\n    assert(listTuple((List[Long](58l.toLong, 44l.toLong, 56l.toLong))).equals((Any((58l, 44l, 56l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the difference between largest and smallest value in a given list.\n    def bigDiff(nums : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bigDiff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (3l));\n    assert(bigDiff((List[Long](4l.toLong, 5l.toLong, 12l.toLong))) == (8l));\n    assert(bigDiff((List[Long](9l.toLong, 2l.toLong, 3l.toLong))) == (7l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find perfect squares between two given numbers.\n    def perfectSquares(a : Long, b : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(perfectSquares((1l), (30l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong))));\n    assert(perfectSquares((50l), (100l)).equals((List[Long](64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(perfectSquares((100l), (200l)).equals((List[Long](100l.toLong, 121l.toLong, 144l.toLong, 169l.toLong, 196l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given two integers have opposite sign or not.\n    def oppositeSigns(x : Long, y : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oppositeSigns((1l), (-2l)) == (true));\n    assert(oppositeSigns((3l), (2l)) == (false));\n    assert(oppositeSigns((-10l), (-10l)) == (false));\n    assert(oppositeSigns((-2l), (2l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to interchange the first and last elements in a list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](12l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 24l.toLong))).equals((List[Long](24l.toLong, 35l.toLong, 9l.toLong, 56l.toLong, 12l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of the product of consecutive binomial co-efficients.\n    def sumOfProduct(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfProduct((3l)) == (15l));\n    assert(sumOfProduct((4l)) == (56l));\n    assert(sumOfProduct((1l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove leading zeroes from an ip address.\n    def removezeroIp(ip : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removezeroIp((\"216.08.094.196\")).equals((\"216.8.94.196\")));\n    assert(removezeroIp((\"12.01.024\")).equals((\"12.1.24\")));\n    assert(removezeroIp((\"216.08.094.0196\")).equals((\"216.8.94.196\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the difference of the first even and first odd number of a given list.\n    def diffEvenOdd(list1 : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(diffEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (3l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (1l));\n    assert(diffEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n    def minSwaps(str1 : String, str2 : String) : Any = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minSwaps((\"1101\"), (\"1110\")).equals((Any(1l))));\n    assert(minSwaps((\"111\"), (\"000\")).equals((Any(\"Not Possible\"))));\n    assert(minSwaps((\"111\"), (\"110\")).equals((Any(\"Not Possible\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find kth element from the given two sorted lists.\n    def findKth(arr1 : List[Long], arr2 : List[Long], k : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findKth((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 9l.toLong)), (List[Long](1l.toLong, 4l.toLong, 8l.toLong, 10l.toLong)), (5l)) == (6l));\n    assert(findKth((List[Long](100l.toLong, 112l.toLong, 256l.toLong, 349l.toLong, 770l.toLong)), (List[Long](72l.toLong, 86l.toLong, 113l.toLong, 119l.toLong, 265l.toLong, 445l.toLong, 892l.toLong)), (7l)) == (256l));\n    assert(findKth((List[Long](3l.toLong, 4l.toLong, 7l.toLong, 8l.toLong, 10l.toLong)), (List[Long](2l.toLong, 5l.toLong, 9l.toLong, 11l.toLong)), (6l)) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is armstrong or not.\n    def armstrongNumber(number : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(armstrongNumber((153l)) == (true));\n    assert(armstrongNumber((259l)) == (false));\n    assert(armstrongNumber((4458l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find sum and average of first n natural numbers.\n    def sumAverage(number : Long) : Tuple2[Long, Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumAverage((10l)).equals(((55l, 5.5f))));\n    assert(sumAverage((15l)).equals(((120l, 8.0f))));\n    assert(sumAverage((20l)).equals(((210l, 10.5f))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth octagonal number.\n    def isOctagonal(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isOctagonal((5l)) == (65l));\n    assert(isOctagonal((10l)) == (280l));\n    assert(isOctagonal((15l)) == (645l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number is even or not.\n    def isEven(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isEven((1l)) == (false));\n    assert(isEven((2l)) == (true));\n    assert(isEven((3l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first repeated character in a given string.\n    def firstRepeatedChar(str1 : String) : Option[String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstRepeatedChar((\"abcabc\")).equals(Some(\"a\")));\n    assert(firstRepeatedChar((\"abc\")).equals(None));\n    assert(firstRepeatedChar((\"123123\")).equals(Some(\"1\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get all lucid numbers smaller than or equal to a given integer.\n    def getLudic(n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getLudic((10l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong))));\n    assert(getLudic((25l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong))));\n    assert(getLudic((45l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 11l.toLong, 13l.toLong, 17l.toLong, 23l.toLong, 25l.toLong, 29l.toLong, 37l.toLong, 41l.toLong, 43l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to reverse words seperated by spaces in a given string.\n    def reverseWords(s : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseWords((\"python program\")).equals((\"program python\")));\n    assert(reverseWords((\"java language\")).equals((\"language java\")));\n    assert(reverseWords((\"indian man\")).equals((\"man indian\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given integer is a prime number.\n    def primeNum(num : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(primeNum((13l)) == (true));\n    assert(primeNum((7l)) == (true));\n    assert(primeNum((-1010l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert degrees to radians.\n    def radianDegree(degree : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(radianDegree((90l)) == (1.5707963267948966f));\n    assert(radianDegree((60l)) == (1.0471975511965976f));\n    assert(radianDegree((120l)) == (2.0943951023931953f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n    def findLiterals(text : String, pattern : String) : Tuple2[String, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findLiterals((\"The quick brown fox jumps over the lazy dog.\"), (\"fox\")).equals(((\"fox\", 16l, 19l))));\n    assert(findLiterals((\"Its been a very crazy procedure right\"), (\"crazy\")).equals(((\"crazy\", 16l, 21l))));\n    assert(findLiterals((\"Hardest choices required strongest will\"), (\"will\")).equals(((\"will\", 35l, 39l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find nth bell number.\n    def bellNumber(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((3l)) == (5l));\n    assert(bellNumber((4l)) == (15l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list and returns a list with the same elements, but the k'th element removed.\n    def removeKthElement(list1 : List[Long], L : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeKthElement((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong)), (3l)).equals((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 1l.toLong))));\n    assert(removeKthElement((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong)), (4l)).equals((List[Long](0l.toLong, 0l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))));\n    assert(removeKthElement((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong)), (5l)).equals((List[Long](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n    def maxOfNth(test_list : List[List[Long]], N : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxOfNth((List[List[Long]](List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](1l.toLong, 3l.toLong, 5l.toLong), List[Long](8l.toLong, 9l.toLong, 19l.toLong))), (2l)) == (19l));\n    assert(maxOfNth((List[List[Long]](List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong), List[Long](9l.toLong, 10l.toLong, 20l.toLong))), (1l)) == (10l));\n    assert(maxOfNth((List[List[Long]](List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](3l.toLong, 5l.toLong, 7l.toLong), List[Long](10l.toLong, 11l.toLong, 21l.toLong))), (1l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n    def merge(lst : List[List[Any]]) : List[List[Any]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\"), List[String](\"a\", \"b\"), List[String](\"m\", \"n\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\")))));\n    assert(merge((List[List[Any]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong)))).equals((List[List[Any]](List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong), List[Long](2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)))));\n    assert(merge((List[List[Any]](List[String](\"x\", \"y\", \"z\"), List[String](\"a\", \"b\", \"c\"), List[String](\"m\", \"n\", \"o\")))).equals((List[List[Any]](List[String](\"x\", \"a\", \"m\"), List[String](\"y\", \"b\", \"n\"), List[String](\"z\", \"c\", \"o\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n    def cummulativeSum(test_list : List[List[Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(cummulativeSum((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong), List[Long](2l.toLong, 6l.toLong)))) == (30l));\n    assert(cummulativeSum((List[List[Long]](List[Long](2l.toLong, 4l.toLong), List[Long](6l.toLong, 7l.toLong, 8l.toLong), List[Long](3l.toLong, 7l.toLong)))) == (37l));\n    assert(cummulativeSum((List[List[Long]](List[Long](3l.toLong, 5l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong), List[Long](4l.toLong, 8l.toLong)))) == (44l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n    def averageTuple(nums : List[List[Long]]) : List[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(averageTuple((List[List[Long]](List[Long](10l.toLong, 10l.toLong, 10l.toLong, 12l.toLong), List[Long](30l.toLong, 45l.toLong, 56l.toLong, 45l.toLong), List[Long](81l.toLong, 80l.toLong, 39l.toLong, 32l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))).equals((List[Float](30.5f.toFloat, 34.25f.toFloat, 27.0f.toFloat, 23.25f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](1l.toLong, 1l.toLong, -5l.toLong), List[Long](30l.toLong, -15l.toLong, 56l.toLong), List[Long](81l.toLong, -60l.toLong, -39l.toLong), List[Long](-10l.toLong, 2l.toLong, 3l.toLong)))).equals((List[Float](25.5f.toFloat, -18.0f.toFloat, 3.75f.toFloat))));\n    assert(averageTuple((List[List[Long]](List[Long](100l.toLong, 100l.toLong, 100l.toLong, 120l.toLong), List[Long](300l.toLong, 450l.toLong, 560l.toLong, 450l.toLong), List[Long](810l.toLong, 800l.toLong, 390l.toLong, 320l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((List[Float](305.0f.toFloat, 342.5f.toFloat, 270.0f.toFloat, 232.5f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function which takes two tuples of the same length and performs the element wise modulo.\n    def tupleModulo(test_tup1 : Tuple2[Long, Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long, Long]) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleModulo(((10l, 4l, 5l, 6l)), ((5l, 6l, 7l, 5l))).equals(((0l, 4l, 5l, 1l))));\n    assert(tupleModulo(((11l, 5l, 6l, 7l)), ((6l, 7l, 8l, 6l))).equals(((5l, 5l, 6l, 1l))));\n    assert(tupleModulo(((12l, 6l, 7l, 8l)), ((7l, 8l, 9l, 7l))).equals(((5l, 6l, 7l, 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n    def minJumps(steps : Tuple2[Long, Long], d : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minJumps(((3l, 4l)), (11l)) == (3.5f));\n    assert(minJumps(((3l, 4l)), (0l)) == 0l);\n    assert(minJumps(((11l, 14l)), (11l)) == 1l);\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to divide two lists element wise.\n    def divList(nums1 : List[Long], nums2 : List[Long]) : List[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divList((List[Long](4l.toLong, 5l.toLong, 6l.toLong)), (List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Float](4.0f.toFloat, 2.5f.toFloat, 2.0f.toFloat))));\n    assert(divList((List[Long](3l.toLong, 2l.toLong)), (List[Long](1l.toLong, 4l.toLong))).equals((List[Float](3.0f.toFloat, 0.5f.toFloat))));\n    assert(divList((List[Long](90l.toLong, 120l.toLong)), (List[Long](50l.toLong, 70l.toLong))).equals((List[Float](1.8f.toFloat, 1.7142857142857142f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to move all the numbers to the end of the given string.\n    def moveNum(test_str : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveNum((\"I1love143you55three3000thousand\")).equals((\"Iloveyouthreethousand1143553000\")));\n    assert(moveNum((\"Avengers124Assemble\")).equals((\"AvengersAssemble124\")));\n    assert(moveNum((\"Its11our12path13to14see15things16do17things\")).equals((\"Itsourpathtoseethingsdothings11121314151617\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of substrings with the sum of digits equal to their length.\n    def countSubstrings(s : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSubstrings((\"112112\")) == (6l));\n    assert(countSubstrings((\"111\")) == (6l));\n    assert(countSubstrings((\"1101112\")) == (12l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the median of two sorted lists of same size.\n    def getMedian(arr1 : List[Long], arr2 : List[Long], n : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getMedian((List[Long](1l.toLong, 12l.toLong, 15l.toLong, 26l.toLong, 38l.toLong)), (List[Long](2l.toLong, 13l.toLong, 17l.toLong, 30l.toLong, 45l.toLong)), (5l)) == (16.0f));\n    assert(getMedian((List[Long](2l.toLong, 4l.toLong, 8l.toLong, 9l.toLong)), (List[Long](7l.toLong, 13l.toLong, 19l.toLong, 28l.toLong)), (4l)) == (8.5f));\n    assert(getMedian((List[Long](3l.toLong, 6l.toLong, 14l.toLong, 23l.toLong, 36l.toLong, 42l.toLong)), (List[Long](2l.toLong, 18l.toLong, 27l.toLong, 39l.toLong, 49l.toLong, 55l.toLong)), (6l)) == (25.0f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to compute the n-th power of each number in a list.\n    def nthNums(nums : List[Long], n : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(nthNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(nthNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (3l)).equals((List[Long](1000l.toLong, 8000l.toLong, 27000l.toLong))));\n    assert(nthNums((List[Long](12l.toLong, 15l.toLong)), (5l)).equals((List[Long](248832l.toLong, 759375l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to convert a given string to uppercase.\n    def isUpper(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUpper((\"person\")).equals((\"PERSON\")));\n    assert(isUpper((\"final\")).equals((\"FINAL\")));\n    assert(isUpper((\"Valid\")).equals((\"VALID\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to interchange the first and last element in a given list.\n    def swapList(newList : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong))).equals((List[Long](3l.toLong, 2l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong))).equals((List[Long](4l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 1l.toLong))));\n    assert(swapList((List[Long](4l.toLong, 5l.toLong, 6l.toLong))).equals((List[Long](6l.toLong, 5l.toLong, 4l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n    def triangleArea(r : Long) : Option[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(triangleArea((-1l)).equals(None));\n    assert(triangleArea((0l)).equals(Some(0l)));\n    assert(triangleArea((2l)).equals(Some(4l)));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the smallest missing number from a sorted list of natural numbers.\n    def findFirstMissing(array : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (4l));\n    assert(findFirstMissing((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 9l.toLong))) == (3l));\n    assert(findFirstMissing((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 8l.toLong, 9l.toLong))) == (0l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all spaces in the given string with '%20'.\n    def replaceSpaces(string : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"My Name is Dawood\")).equals((\"My%20Name%20is%20Dawood\")));\n    assert(replaceSpaces((\"I am a Programmer\")).equals((\"I%20am%20a%20Programmer\")));\n    assert(replaceSpaces((\"I love Coding\")).equals((\"I%20love%20Coding\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find even numbers from a list of numbers.\n    def Split(list : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Split((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))).equals((List[Long](2l.toLong, 4l.toLong))));\n    assert(Split((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 0l.toLong, 1l.toLong))).equals((List[Long](4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))));\n    assert(Split((List[Long](8l.toLong, 12l.toLong, 15l.toLong, 19l.toLong))).equals((List[Long](8l.toLong, 12l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find smallest number in a list.\n    def smallestNum(xs : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(smallestNum((List[Long](10l.toLong, 20l.toLong, 1l.toLong, 45l.toLong, 99l.toLong))) == (1l));\n    assert(smallestNum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (1l));\n    assert(smallestNum((List[Long](45l.toLong, 46l.toLong, 50l.toLong, 60l.toLong))) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n    def getCoordinates(test_tup : Tuple2[Long, Long]) : List[List[Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getCoordinates(((3l, 4l))).equals((List[List[Long]](List[Long](2l.toLong, 3l.toLong), List[Long](2l.toLong, 4l.toLong), List[Long](2l.toLong, 5l.toLong), List[Long](3l.toLong, 3l.toLong), List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](4l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong)))));\n    assert(getCoordinates(((4l, 5l))).equals((List[List[Long]](List[Long](3l.toLong, 4l.toLong), List[Long](3l.toLong, 5l.toLong), List[Long](3l.toLong, 6l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](5l.toLong, 4l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong)))));\n    assert(getCoordinates(((5l, 6l))).equals((List[List[Long]](List[Long](4l.toLong, 5l.toLong), List[Long](4l.toLong, 6l.toLong), List[Long](4l.toLong, 7l.toLong), List[Long](5l.toLong, 5l.toLong), List[Long](5l.toLong, 6l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](6l.toLong, 5l.toLong), List[Long](6l.toLong, 6l.toLong), List[Long](6l.toLong, 7l.toLong)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace whitespaces with an underscore and vice versa in a given string.\n    def replaceSpaces(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpaces((\"Jumanji The Jungle\")).equals((\"Jumanji_The_Jungle\")));\n    assert(replaceSpaces((\"The_Avengers\")).equals((\"The Avengers\")));\n    assert(replaceSpaces((\"Fast and Furious\")).equals((\"Fast_and_Furious\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to move all zeroes to the end of the given list.\n    def moveZero(num_list : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(moveZero((List[Long](1l.toLong, 0l.toLong, 2l.toLong, 0l.toLong, 3l.toLong, 4l.toLong))).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 0l.toLong, 0l.toLong, 4l.toLong, 0l.toLong, 5l.toLong, 0l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 5l.toLong, 0l.toLong, 0l.toLong, 0l.toLong, 0l.toLong))));\n    assert(moveZero((List[Long](0l.toLong, 1l.toLong, 0l.toLong, 1l.toLong, 1l.toLong))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 0l.toLong, 0l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of xor of all pairs of numbers in the given list.\n    def pairXorSum(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairXorSum((List[Long](5l.toLong, 9l.toLong, 7l.toLong, 6l.toLong)), (4l)) == (47l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong, 5l.toLong)), (3l)) == (12l));\n    assert(pairXorSum((List[Long](7l.toLong, 3l.toLong)), (2l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort the given list.\n    def heapSort(iterable : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(heapSort((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 2l.toLong, 4l.toLong, 6l.toLong, 8l.toLong, 0l.toLong))).equals((List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong))));\n    assert(heapSort((List[Long](25l.toLong, 35l.toLong, 22l.toLong, 85l.toLong, 14l.toLong, 65l.toLong, 75l.toLong, 25l.toLong, 58l.toLong))).equals((List[Long](14l.toLong, 22l.toLong, 25l.toLong, 25l.toLong, 35l.toLong, 58l.toLong, 65l.toLong, 75l.toLong, 85l.toLong))));\n    assert(heapSort((List[Long](7l.toLong, 1l.toLong, 9l.toLong, 5l.toLong))).equals((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given amount has no profit and no loss\n    def noprofitNoloss(actual_cost : Long, sale_amount : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(noprofitNoloss((1500l), (1200l)) == (false));\n    assert(noprofitNoloss((100l), (100l)) == (true));\n    assert(noprofitNoloss((2000l), (5000l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n    def windChill(v : Long, t : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(windChill((120l), (35l)) == (40l));\n    assert(windChill((40l), (20l)) == (19l));\n    assert(windChill((10l), (8l)) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n    def sampleNam(sample_names : List[String]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sampleNam((List[String](\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"))) == (16l));\n    assert(sampleNam((List[String](\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"))) == (10l));\n    assert(sampleNam((List[String](\"abcd\", \"Python\", \"abba\", \"aba\"))) == (6l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the maximum difference between available pairs in the given tuple list.\n    def maxDifference(test_list : List[Tuple2[Long, Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxDifference((List[Tuple2[Long, Long]]((3l, 5l), (1l, 7l), (10l, 3l), (1l, 2l)))) == (7l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((4l, 6l), (2l, 17l), (9l, 13l), (11l, 12l)))) == (15l));\n    assert(maxDifference((List[Tuple2[Long, Long]]((12l, 35l), (21l, 27l), (13l, 23l), (41l, 22l)))) == (23l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove the parenthesis and what is inbetween them from a string.\n    def removeParenthesis(items : List[String]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeParenthesis((List[String](\"python (chrome)\"))).equals((\"python\")));\n    assert(removeParenthesis((List[String](\"string(.abc)\"))).equals((\"string\")));\n    assert(removeParenthesis((List[String](\"alpha(num)\"))).equals((\"alpha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth nonagonal number.\n    def isNonagonal(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isNonagonal((10l)) == (325l));\n    assert(isNonagonal((15l)) == (750l));\n    assert(isNonagonal((18l)) == (1089l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that checks if a strings contains 'z', except at the start and end of the word.\n    def textMatchWordzMiddle(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchWordzMiddle((\"pythonzabc.\")) == (true));\n    assert(textMatchWordzMiddle((\"zxyabc.\")) == (false));\n    assert(textMatchWordzMiddle((\"  lang  .\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to reverse a list upto a given position.\n    def reverseArrayUptoK(input : List[Long], k : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(reverseArrayUptoK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (4l)).equals((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 1l.toLong, 5l.toLong, 6l.toLong))));\n    assert(reverseArrayUptoK((List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (2l)).equals((List[Long](5l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))));\n    assert(reverseArrayUptoK((List[Long](9l.toLong, 8l.toLong, 7l.toLong, 6l.toLong, 5l.toLong)), (3l)).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 6l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of tuples using the second value of each tuple.\n    def subjectMarks(subjectmarks : List[Tuple2[String, Long]]) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l), (\"Social sciences\", 82l)))).equals((List[Tuple2[String, Long]]((\"Social sciences\", 82l), (\"English\", 88l), (\"Science\", 90l), (\"Maths\", 97l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Telugu\", 49l), (\"Hindhi\", 54l), (\"Social\", 33l)))).equals((List[Tuple2[String, Long]]((\"Social\", 33l), (\"Telugu\", 49l), (\"Hindhi\", 54l)))));\n    assert(subjectMarks((List[Tuple2[String, Long]]((\"Physics\", 96l), (\"Chemistry\", 97l), (\"Biology\", 45l)))).equals((List[Tuple2[String, Long]]((\"Biology\", 45l), (\"Physics\", 96l), (\"Chemistry\", 97l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to flatten a list and sum all of its elements.\n    def recursiveListSum(data_list : List[Either[Long, List[Long]]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(recursiveListSum((List[Either[Long, List[Long]]](1l, 2l, List[Long](3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong)))) == (21l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](7l, 10l, List[Long](15l.toLong, 14l.toLong), List[Long](19l.toLong, 41l.toLong)))) == (106l));\n    assert(recursiveListSum((List[Either[Long, List[Long]]](10l, 20l, List[Long](30l.toLong, 40l.toLong), List[Long](50l.toLong, 60l.toLong)))) == (210l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of positive numbers in a list.\n    def posCount(list : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(posCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong, -4l.toLong))) == (2l));\n    assert(posCount((List[Long](3l.toLong, 4l.toLong, 5l.toLong, -1l.toLong))) == (3l));\n    assert(posCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the number of ways to partition a set of Bell numbers.\n    def bellNumber(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(bellNumber((2l)) == (2l));\n    assert(bellNumber((10l)) == (115975l));\n    assert(bellNumber((56l)) == (6775685320645824322581483068371419745979053216268760300l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given list is monotonic or not.\n    def isMonotonic(A : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isMonotonic((List[Long](6l.toLong, 5l.toLong, 4l.toLong, 4l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 2l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isMonotonic((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a list contains the given sublist or not.\n    def isSublist(l : List[Long], s : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](3l.toLong, 7l.toLong))) == (false));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](4l.toLong, 3l.toLong))) == (true));\n    assert(isSublist((List[Long](2l.toLong, 4l.toLong, 3l.toLong, 5l.toLong, 7l.toLong)), (List[Long](1l.toLong, 6l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the two numbers differ at one bit position only or not.\n    def differAtOneBitPos(a : Long, b : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(differAtOneBitPos((13l), (9l)) == (true));\n    assert(differAtOneBitPos((15l), (8l)) == (false));\n    assert(differAtOneBitPos((2l), (4l)) == (false));\n    assert(differAtOneBitPos((2l), (3l)) == (true));\n    assert(differAtOneBitPos((5l), (1l)) == (true));\n    assert(differAtOneBitPos((1l), (5l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find whether all the given lists have equal length or not.\n    def getEqual(Input : List[List[Long]]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getEqual((List[List[Long]](List[Long](11l.toLong, 22l.toLong, 33l.toLong), List[Long](44l.toLong, 55l.toLong, 66l.toLong)))) == (true));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)))) == (false));\n    assert(getEqual((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](3l.toLong, 4l.toLong)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a list of elements.\n    def combSort(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(combSort((List[Long](5l.toLong, 15l.toLong, 37l.toLong, 25l.toLong, 79l.toLong))).equals((List[Long](5l.toLong, 15l.toLong, 25l.toLong, 37l.toLong, 79l.toLong))));\n    assert(combSort((List[Long](41l.toLong, 32l.toLong, 15l.toLong, 19l.toLong, 22l.toLong))).equals((List[Long](15l.toLong, 19l.toLong, 22l.toLong, 32l.toLong, 41l.toLong))));\n    assert(combSort((List[Long](99l.toLong, 15l.toLong, 13l.toLong, 47l.toLong))).equals((List[Long](13l.toLong, 15l.toLong, 47l.toLong, 99l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add a map to the tuple. The output should be a tuple.\n    def addDictToTuple(test_tup : Tuple2[Long, Long, Long], test_dict : Map[String,Long]) : Tuple2[Long, Long, Long, Map[String,Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addDictToTuple(((4l, 5l, 6l)), (Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l))).equals(((4l, 5l, 6l, Map[String,Long](\"MSAM\" -> 1l, \"is\" -> 2l, \"best\" -> 3l)))));\n    assert(addDictToTuple(((1l, 2l, 3l)), (Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l))).equals(((1l, 2l, 3l, Map[String,Long](\"UTS\" -> 2l, \"is\" -> 3l, \"Worst\" -> 4l)))));\n    assert(addDictToTuple(((8l, 9l, 10l)), (Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l))).equals(((8l, 9l, 10l, Map[String,Long](\"POS\" -> 3l, \"is\" -> 4l, \"Okay\" -> 5l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n    def maxAverageOfPath(cost : List[List[Long]]) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](7l.toLong, 3l.toLong, 9l.toLong)))) == (5.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 4l.toLong), List[Long](7l.toLong, 6l.toLong, 5l.toLong), List[Long](8l.toLong, 4l.toLong, 10l.toLong)))) == (6.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](3l.toLong, 4l.toLong, 5l.toLong), List[Long](8l.toLong, 7l.toLong, 6l.toLong), List[Long](9l.toLong, 5l.toLong, 11l.toLong)))) == (7.2f));\n    assert(maxAverageOfPath((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))) == (5.8f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is given as - a map with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\n    def filterData(students : Map[String,Tuple2[Float, Long]], h : Float, w : Long) : Map[String,Tuple2[Float, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (6.0f), (70l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.9f), (67l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Kierra Gentry\" -> (6.0f, 68l)))));\n    assert(filterData((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l))), (5.7f), (64l)).equals((Map[String,Tuple2[Float, Long]](\"Cierra Vega\" -> (6.2f, 70l), \"Alden Cantrell\" -> (5.9f, 65l), \"Kierra Gentry\" -> (6.0f, 68l), \"Pierre Cox\" -> (5.8f, 66l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n    def countSamePair(nums1 : List[Long], nums2 : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countSamePair((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong)), (List[Long](2l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 2l.toLong, 6l.toLong, 7l.toLong, 9l.toLong))) == (4l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 0l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (11l));\n    assert(countSamePair((List[Long](2l.toLong, 4l.toLong, -6l.toLong, -9l.toLong, 11l.toLong, -12l.toLong, 14l.toLong, -5l.toLong, 17l.toLong)), (List[Long](2l.toLong, 1l.toLong, 2l.toLong, -1l.toLong, -5l.toLong, 6l.toLong, 4l.toLong, -3l.toLong, -2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 8l.toLong))) == (1l));\n    assert(countSamePair((List[Long](0l.toLong, 1l.toLong, 1l.toLong, 2l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n    def powerBaseSum(base : Long, power : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(powerBaseSum((2l), (100l)) == (115l));\n    assert(powerBaseSum((8l), (10l)) == (37l));\n    assert(powerBaseSum((8l), (15l)) == (62l));\n    assert(powerBaseSum((3l), (3l)) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to extract values between quotation marks \" \" of the given string.\n    def extractQuotation(text1 : String) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractQuotation((\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\")).equals((List[Any](\"A53\", \"multi\", \"Processor\"))));\n    assert(extractQuotation((\"Cast your \"favorite\" entertainment \"apps\"\")).equals((List[Any](\"favorite\", \"apps\"))));\n    assert(extractQuotation((\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\")).equals((List[Any](\"4k Ultra HD\", \"HDR 10\"))));\n    assert(extractQuotation((\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\")).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n    def multiplyElements(test_tup : List[Long]) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(multiplyElements((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 8l.toLong, 10l.toLong))).equals((List[Any](5l.toLong, 35l.toLong, 56l.toLong, 80l.toLong))));\n    assert(multiplyElements((List[Long](2l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](8l.toLong, 20l.toLong, 30l.toLong, 42l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong, 13l.toLong, 14l.toLong, 9l.toLong, 15l.toLong))).equals((List[Any](156l.toLong, 182l.toLong, 126l.toLong, 135l.toLong))));\n    assert(multiplyElements((List[Long](12l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n    def sumList(lst1 : List[Long], lst2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumList((List[Long](10l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 25l.toLong, 35l.toLong))).equals((List[Long](25l.toLong, 45l.toLong, 65l.toLong))));\n    assert(sumList((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](5l.toLong, 6l.toLong, 7l.toLong))).equals((List[Long](6l.toLong, 8l.toLong, 10l.toLong))));\n    assert(sumList((List[Long](15l.toLong, 20l.toLong, 30l.toLong)), (List[Long](15l.toLong, 45l.toLong, 75l.toLong))).equals((List[Long](30l.toLong, 65l.toLong, 105l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the given number can be represented as the difference of two squares or not.\n    def difSquare(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(difSquare((5l)) == (true));\n    assert(difSquare((10l)) == (false));\n    assert(difSquare((15l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove consecutive duplicates of a given list.\n    def consecutiveDuplicates(nums : List[Any]) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(consecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[Any](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong))));\n    assert(consecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[Any](10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\"))));\n    assert(consecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"))).equals((List[Any](\"a\", \"b\", \"c\", \"d\", \"a\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the lateral surface area of a cone given radius r and the height h.\n    def lateralsurfaceCone(r : Long, h : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lateralsurfaceCone((5l), (12l)) == (204.20352248333654f));\n    assert(lateralsurfaceCone((10l), (15l)) == (566.3586699569488f));\n    assert(lateralsurfaceCone((19l), (17l)) == (1521.8090132193388f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n    def replaceSpecialchar(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(replaceSpecialchar((\"Python language, Programming language.\")).equals((\"Python:language::Programming:language:\")));\n    assert(replaceSpecialchar((\"a b c,d e f\")).equals((\"a:b:c:d:e:f\")));\n    assert(replaceSpecialchar((\"ram reshma,ram rahim\")).equals((\"ram:reshma:ram:rahim\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the index of the first occurrence of a given number in a sorted list.\n    def findFirstOccurrence(A : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findFirstOccurrence((List[Long](2l.toLong, 5l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (1l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (5l)) == (2l));\n    assert(findFirstOccurrence((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 8l.toLong, 9l.toLong, 9l.toLong, 9l.toLong)), (6l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-sublists/\n    def sumOfSubarrayProd(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (20l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong))) == (5l));\n    assert(sumOfSubarrayProd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong))) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n    def toggleMiddleBits(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(toggleMiddleBits((9l)) == (15l));\n    assert(toggleMiddleBits((10l)) == (12l));\n    assert(toggleMiddleBits((11l)) == (13l));\n    assert(toggleMiddleBits((65l)) == (127l));\n    assert(toggleMiddleBits((77l)) == (115l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/scalathon-exercises/data-structures-and-algorithms/scalathon-data-structure-exercise-24.php\n    def leftInsertion(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(leftInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given string is starting with a vowel or not using regex.\n    def checkStr(string : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkStr((\"annie\")) == (true));\n    assert(checkStr((\"dawood\")) == (false));\n    assert(checkStr((\"Else\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/scalathon-exercises/data-structures-and-algorithms/scalathon-recursion-exercise-9.php\n    def geometricSum(n : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(geometricSum((7l)) == (1.9921875f));\n    assert(geometricSum((4l)) == (1.9375f));\n    assert(geometricSum((8l)) == (1.99609375f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n    def findIndex(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findIndex((2l)) == (4l));\n    assert(findIndex((3l)) == (14l));\n    assert(findIndex((4l)) == (45l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given tuple to a key-value map using adjacent elements. https://www.geeksforgeeks.org/scalathon-convert-tuple-to-adjacent-pair-map/\n    def tupleToDict(test_tup : Tuple2[Long, Long, Long, Long, Long, Long]) : Map[Long,Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleToDict(((1l, 5l, 7l, 10l, 13l, 5l))).equals((Map[Long,Long](1l -> 5l, 7l -> 10l, 13l -> 5l))));\n    assert(tupleToDict(((1l, 2l, 3l, 4l, 5l, 6l))).equals((Map[Long,Long](1l -> 2l, 3l -> 4l, 5l -> 6l))));\n    assert(tupleToDict(((7l, 8l, 9l, 10l, 11l, 12l))).equals((Map[Long,Long](7l -> 8l, 9l -> 10l, 11l -> 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether all the characters are same or not.\n    def allCharactersSame(s : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(allCharactersSame((\"python\")) == (false));\n    assert(allCharactersSame((\"aaa\")) == (true));\n    assert(allCharactersSame((\"data\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to caluclate the area of a tetrahedron.\n    def areaTetrahedron(side : Long) : Float = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(areaTetrahedron((3l)) == (15.588457268119894f));\n    assert(areaTetrahedron((20l)) == (692.8203230275509f));\n    assert(areaTetrahedron((10l)) == (173.20508075688772f));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/scalathon-program-right-rotate-list-n/\n    def rotateRight(list : List[Long], m : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (3l)).equals((List[Long](8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (2l)).equals((List[Long](9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong))));\n    assert(rotateRight((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong)), (5l)).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuple has any none value or not.\n    def checkNone(test_tup : Any) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkNone((Any(10l), Some(4l), Some(5l), Some(6l), Some(None)))) == (true));\n    assert(checkNone((Any((7l, 8l, 9l, 11l, 14l)))) == (false));\n    assert(checkNone((Any(1l), Some(2l), Some(3l), Some(4l), Some(None)))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/scalathon-exercises/lambda/scalathon-lambda-exercise-24.php\n    def divisibleByDigits(startnum : Long, endnum : Long) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisibleByDigits((1l), (22l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong, 22l.toLong))));\n    assert(divisibleByDigits((1l), (15l)).equals((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong, 15l.toLong))));\n    assert(divisibleByDigits((20l), (25l)).equals((List[Long](22l.toLong, 24l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n    def sectorArea(r : Long, a : Long) : Option[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sectorArea((4l), (45l)).equals(Some(6.283185307179586f)));\n    assert(sectorArea((9l), (45l)).equals(Some(31.808625617596654f)));\n    assert(sectorArea((9l), (361l)).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n    def lcsOfThree(X : String, Y : String, Z : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lcsOfThree((\"AGGT12\"), (\"12TXAYB\"), (\"12XBA\")) == (2l));\n    assert(lcsOfThree((\"Reels\"), (\"Reelsfor\"), (\"ReelsforReels\")) == (5l));\n    assert(lcsOfThree((\"abcd1e2\"), (\"bc12ea\"), (\"bd1ea\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to put spaces between words starting with capital letters in a given string.\n    def capitalWordsSpaces(str1 : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(capitalWordsSpaces((\"Python\")).equals((\"Python\")));\n    assert(capitalWordsSpaces((\"PythonProgrammingExamples\")).equals((\"Python Programming Examples\")));\n    assert(capitalWordsSpaces((\"GetReadyToBeCodingFreak\")).equals((\"Get Ready To Be Coding Freak\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/scalathon-sort-numeric-strings-in-a-list/\n    def sortNumericStrings(nums_str : List[String]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sortNumericStrings((List[String](\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"))).equals((List[Long](-500l.toLong, -12l.toLong, 0l.toLong, 4l.toLong, 7l.toLong, 12l.toLong, 45l.toLong, 100l.toLong, 200l.toLong))));\n    assert(sortNumericStrings((List[String](\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 8l.toLong, 9l.toLong, 9l.toLong))));\n    assert(sortNumericStrings((List[String](\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"))).equals((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 3l.toLong, 3l.toLong, 5l.toLong, 5l.toLong, 7l.toLong, 7l.toLong, 9l.toLong, 11l.toLong, 13l.toLong, 15l.toLong, 17l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether it follows the sequence given in the patterns list.\n    def isSamepatterns(colors : List[String], patterns : List[String]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"green\")), (List[String](\"a\", \"b\", \"b\"))) == (true));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\", \"b\"))) == (false));\n    assert(isSamepatterns((List[String](\"red\", \"green\", \"greenn\")), (List[String](\"a\", \"b\"))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to add the given tuple to the given list.\n    def addTuple(test_list : List[Long], test_tup : Tuple2[Long, Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(addTuple((List[Long](5l.toLong, 6l.toLong, 7l.toLong)), ((9l, 10l))).equals((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))));\n    assert(addTuple((List[Long](6l.toLong, 7l.toLong, 8l.toLong)), ((10l, 11l))).equals((List[Long](6l.toLong, 7l.toLong, 8l.toLong, 10l.toLong, 11l.toLong))));\n    assert(addTuple((List[Long](7l.toLong, 8l.toLong, 9l.toLong)), ((11l, 12l))).equals((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 11l.toLong, 12l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given list represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-list-represents-a-binary-heap/\n    def checkMinHeap(arr : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMinHeap((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 10l.toLong, 15l.toLong))) == (true));\n    assert(checkMinHeap((List[Long](2l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 3l.toLong, 15l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n    def jacobsthalNum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(jacobsthalNum((5l)) == (11l));\n    assert(jacobsthalNum((2l)) == (1l));\n    assert(jacobsthalNum((4l)) == (5l));\n    assert(jacobsthalNum((13l)) == (2731l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/scalathon-find-minimum-k-records-from-tuple-list/ - in this case a verbatim coscala of test cases\n    def minK(test_list : List[Tuple2[String, Long]], K : Long) : List[Tuple2[String, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(minK((List[Tuple2[String, Long]]((\"Manjeet\", 10l), (\"Akshat\", 4l), (\"Akash\", 2l), (\"Nikhil\", 8l))), (2l)).equals((List[Tuple2[String, Long]]((\"Akash\", 2l), (\"Akshat\", 4l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"Sanjeev\", 11l), (\"Angat\", 5l), (\"Akash\", 3l), (\"Nepin\", 9l))), (3l)).equals((List[Tuple2[String, Long]]((\"Akash\", 3l), (\"Angat\", 5l), (\"Nepin\", 9l)))));\n    assert(minK((List[Tuple2[String, Long]]((\"tanmay\", 14l), (\"Amer\", 11l), (\"Ayesha\", 9l), (\"SKD\", 16l))), (1l)).equals((List[Tuple2[String, Long]]((\"Ayesha\", 9l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n    def extractIndexList(l1 : List[Long], l2 : List[Long], l3 : List[Long]) : List[Any] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 7l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 6l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 1l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 5l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any](1l.toLong, 5l.toLong))));\n    assert(extractIndexList((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 6l.toLong, 6l.toLong, 6l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong)), (List[Long](0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 7l.toLong))).equals((List[Any]())));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the second smallest number in a list.\n    def secondSmallest(numbers : List[Either[Long, Float]]) : Option[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 2l.toLong, -8l.toLong, -2l.toLong, 0l.toLong, -2l.toLong))).equals(Some(-2l)));\n    assert(secondSmallest((List[Either[Long, Float]](1l.toLong, 1l.toLong, -0.5f.toLong, 0l.toLong, 2l.toLong, -2l.toLong, -2l.toLong))).equals(Some(-0.5f)));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong))).equals(None));\n    assert(secondSmallest((List[Either[Long, Float]](2l.toLong, 2l.toLong, 2l.toLong))).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/scalathon-exercises/re/scalathon-re-exercise-3.php\n    def textMatchZeroOne(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchZeroOne((\"ac\")) == (false));\n    assert(textMatchZeroOne((\"dc\")) == (false));\n    assert(textMatchZeroOne((\"abbbba\")) == (true));\n    assert(textMatchZeroOne((\"dsabbbba\")) == (true));\n    assert(textMatchZeroOne((\"asbbbba\")) == (false));\n    assert(textMatchZeroOne((\"abaaa\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/scalathon-program-to-count-the-pairs-of-reverse-strings/\n    def countReversePairs(test_list : List[String]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countReversePairs((List[String](\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"))) == (2l));\n    assert(countReversePairs((List[String](\"geeks\", \"best\", \"for\", \"skeeg\"))) == (1l));\n    assert(countReversePairs((List[String](\"makes\", \"best\", \"sekam\", \"for\", \"rof\"))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether a given string is a decimal number with a precision of 2.\n    def isDecimal(num : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDecimal((\"123.11\")) == (true));\n    assert(isDecimal((\"e666.86\")) == (false));\n    assert(isDecimal((\"3.124587\")) == (false));\n    assert(isDecimal((\"1.11\")) == (true));\n    assert(isDecimal((\"1.1.11\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n    def findTuples(test_list : List[Tuple2[Long, Long, Long]], K : Long) : List[Tuple2[Long, Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l), (7l, 9l, 6l), (12l, 18l, 21l))), (6l)).equals((List[Tuple2[Long, Long, Long]]((6l, 24l, 12l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l), (4l, 2l, 3l), (7l, 8l, 9l))), (5l)).equals((List[Tuple2[Long, Long, Long]]((5l, 25l, 30l)))));\n    assert(findTuples((List[Tuple2[Long, Long, Long]]((7l, 9l, 16l), (8l, 16l, 4l), (19l, 17l, 18l))), (4l)).equals((List[Tuple2[Long, Long, Long]]((8l, 16l, 4l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether a list of numbers contains only one distinct element or not.\n    def uniqueElement(arr : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(uniqueElement((List[Long](1l.toLong, 1l.toLong, 1l.toLong))) == (true));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (false));\n    assert(uniqueElement((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n    def checkMonthnumberNumber(monthnum3 : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkMonthnumberNumber((6l)) == (true));\n    assert(checkMonthnumberNumber((2l)) == (false));\n    assert(checkMonthnumberNumber((12l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum difference between any two elements in a given list. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n    def findMinDiff(arr : List[Long], n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findMinDiff((List[Long](1l.toLong, 5l.toLong, 3l.toLong, 19l.toLong, 18l.toLong, 25l.toLong)), (6l)) == (1l));\n    assert(findMinDiff((List[Long](4l.toLong, 3l.toLong, 2l.toLong, 6l.toLong)), (4l)) == (1l));\n    assert(findMinDiff((List[Long](30l.toLong, 5l.toLong, 20l.toLong, 9l.toLong)), (4l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count number of digits in a given string.\n    def numberCtr(str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(numberCtr((\"program2bedone\")) == (1l));\n    assert(numberCtr((\"3wonders\")) == (1l));\n    assert(numberCtr((\"123\")) == (3l));\n    assert(numberCtr((\"3wond-1ers2\")) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n    def isPolite(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPolite((7l)) == (11l));\n    assert(isPolite((4l)) == (7l));\n    assert(isPolite((9l)) == (13l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to return a list of all pairs of consecutive items in a given list.\n    def pairWise(l1 : List[Long]) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(pairWise((List[Long](1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 1l), (1l, 2l), (2l, 3l), (3l, 3l), (3l, 4l), (4l, 4l), (4l, 5l)))));\n    assert(pairWise((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 5l), (5l, 7l), (7l, 9l), (9l, 10l)))));\n    assert(pairWise((List[Long](5l.toLong, 1l.toLong, 9l.toLong, 7l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((5l, 1l), (1l, 9l), (9l, 7l), (7l, 10l)))));\n    assert(pairWise((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Tuple2[Long, Long]]((1l, 2l), (2l, 3l), (3l, 4l), (4l, 5l), (5l, 6l), (6l, 7l), (7l, 8l), (8l, 9l), (9l, 10l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n    def getPairsCount(arr : List[Long], sum : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getPairsCount((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 1l.toLong)), (2l)) == (6l));\n    assert(getPairsCount((List[Long](1l.toLong, 5l.toLong, 7l.toLong, -1l.toLong, 5l.toLong)), (6l)) == (3l));\n    assert(getPairsCount((List[Long](1l.toLong, -2l.toLong, 3l.toLong)), (1l)) == (1l));\n    assert(getPairsCount((List[Long](-1l.toLong, -2l.toLong, 3l.toLong)), (-3l)) == (1l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to get the difference between two lists.\n    def Diff(li1 : List[Long], li2 : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Diff((List[Long](10l.toLong, 15l.toLong, 20l.toLong, 25l.toLong, 30l.toLong, 35l.toLong, 40l.toLong)), (List[Long](25l.toLong, 40l.toLong, 35l.toLong))).equals((List[Long](10l.toLong, 20l.toLong, 30l.toLong, 15l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong))));\n    assert(Diff((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (List[Long](6l.toLong, 7l.toLong, 1l.toLong))).equals((List[Long](2l.toLong, 3l.toLong, 6l.toLong, 7l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of fourth power of first n odd natural numbers.\n    def oddNumSum(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddNumSum((2l)) == (82l));\n    assert(oddNumSum((3l)) == (707l));\n    assert(oddNumSum((4l)) == (3108l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n    def checkExpression(exp : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkExpression((\"{()}[{}]\")) == (true));\n    assert(checkExpression((\"{()}[{]\")) == (false));\n    assert(checkExpression((\"{()}[{}][]({})\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all the words with k length in the given string.\n    def removeLength(test_str : String, K : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeLength((\"The person is most value tet\"), (3l)).equals((\"person is most value\")));\n    assert(removeLength((\"If you told me about this ok\"), (4l)).equals((\"If you me about ok\")));\n    assert(removeLength((\"Forces of darkeness is come into the play\"), (4l)).equals((\"Forces of darkeness is the\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n    def occuranceSubstring(text : String, pattern : String) : Option[Tuple2[String, Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(occuranceSubstring((\"python programming, python language\"), (\"python\")).equals(Some((\"python\", 0l, 6l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"programming\")).equals(Some((\"programming\", 7l, 18l))));\n    assert(occuranceSubstring((\"python programming,programming language\"), (\"language\")).equals(Some((\"language\", 31l, 39l))));\n    assert(occuranceSubstring((\"c++ programming, c++ language\"), (\"python\")).equals(None));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether every odd index contains odd numbers of a given list.\n    def oddPosition(nums : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong, 3l.toLong, 6l.toLong, 7l.toLong, 6l.toLong, 3l.toLong))) == (true));\n    assert(oddPosition((List[Long](4l.toLong, 1l.toLong, 2l.toLong))) == (true));\n    assert(oddPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to count those characters which have vowels as their neighbors in the given string.\n    def countVowels(test_str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countVowels((\"bestinstareels\")) == (7l));\n    assert(countVowels((\"partofthejourneyistheend\")) == (12l));\n    assert(countVowels((\"amazonprime\")) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of non-repeated elements in a given list.\n    def findSum(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSum((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 1l.toLong, 1l.toLong, 4l.toLong, 5l.toLong, 6l.toLong))) == (21l));\n    assert(findSum((List[Long](1l.toLong, 10l.toLong, 9l.toLong, 4l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 4l.toLong))) == (71l));\n    assert(findSum((List[Long](12l.toLong, 10l.toLong, 9l.toLong, 45l.toLong, 2l.toLong, 10l.toLong, 10l.toLong, 45l.toLong, 10l.toLong))) == (78l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to pack consecutive duplicates of a given list elements into sublists.\n    def packConsecutiveDuplicates(list1 : List[Any]) : List[List[Any]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(packConsecutiveDuplicates((List[Any](0l.toLong, 0l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 6l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 4l.toLong, 4l.toLong))).equals((List[List[Any]](List[Long](0l.toLong, 0l.toLong), List[Long](1l.toLong), List[Long](2l.toLong), List[Long](3l.toLong), List[Long](4l.toLong, 4l.toLong), List[Long](5l.toLong), List[Long](6l.toLong, 6l.toLong, 6l.toLong), List[Long](7l.toLong), List[Long](8l.toLong), List[Long](9l.toLong), List[Long](4l.toLong, 4l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](10l.toLong, 10l.toLong, 15l.toLong, 19l.toLong, 18l.toLong, 18l.toLong, 17l.toLong, 26l.toLong, 26l.toLong, 17l.toLong, 18l.toLong, 10l.toLong))).equals((List[List[Any]](List[Long](10l.toLong, 10l.toLong), List[Long](15l.toLong), List[Long](19l.toLong), List[Long](18l.toLong, 18l.toLong), List[Long](17l.toLong), List[Long](26l.toLong, 26l.toLong), List[Long](17l.toLong), List[Long](18l.toLong), List[Long](10l.toLong)))));\n    assert(packConsecutiveDuplicates((List[Any](\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"))).equals((List[List[Any]](List[String](\"a\", \"a\"), List[String](\"b\"), List[String](\"c\"), List[String](\"d\", \"d\")))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find whether a number is divisible by 11.\n    def isDiff(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isDiff((12345l)) == (false));\n    assert(isDiff((1212112l)) == (true));\n    assert(isDiff((1212l)) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/scalathon-combinations-of-sum-with-tuples-in-tuple-list/\n    def findCombinations(test_list : List[Tuple2[Long, Long]]) : List[Tuple2[Long, Long]] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findCombinations((List[Tuple2[Long, Long]]((2l, 4l), (6l, 7l), (5l, 1l), (6l, 10l)))).equals((List[Tuple2[Long, Long]]((8l, 11l), (7l, 5l), (8l, 14l), (11l, 8l), (12l, 17l), (11l, 11l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((3l, 5l), (7l, 8l), (6l, 2l), (7l, 11l)))).equals((List[Tuple2[Long, Long]]((10l, 13l), (9l, 7l), (10l, 16l), (13l, 10l), (14l, 19l), (13l, 13l)))));\n    assert(findCombinations((List[Tuple2[Long, Long]]((4l, 6l), (8l, 9l), (7l, 3l), (8l, 12l)))).equals((List[Tuple2[Long, Long]]((12l, 15l), (11l, 9l), (12l, 18l), (15l, 12l), (16l, 21l), (15l, 15l)))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the count of divisors is even. https://www.w3resource.com/scalathon-exercises/basic/scalathon-basic-1-exercise-24.php\n    def countDivisors(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countDivisors((10l)) == (true));\n    assert(countDivisors((100l)) == (false));\n    assert(countDivisors((125l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of all odd length sublists. https://www.geeksforgeeks.org/sum-of-all-odd-length-sublists/\n    def oddLengthSum(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 4l.toLong))) == (14l));\n    assert(oddLengthSum((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 2l.toLong))) == (15l));\n    assert(oddLengthSum((List[Long](1l.toLong, 7l.toLong))) == (8l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n    def rgbToHsv(r : Long, g : Long, b : Long) : List[Float] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rgbToHsv((255l), (255l), (255l)).equals((List[Float](0.0f.toFloat, 0.0f.toFloat, 100.0f.toFloat))));\n    assert(rgbToHsv((0l), (215l), (0l)).equals((List[Float](120.0f.toFloat, 100.0f.toFloat, 84.31372549019608f.toFloat))));\n    assert(rgbToHsv((10l), (215l), (110l)).equals((List[Float](149.26829268292684f.toFloat, 95.34883720930233f.toFloat, 84.31372549019608f.toFloat))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the product of first even and odd number of a given list.\n    def mulEvenOdd(list1 : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mulEvenOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong, 7l.toLong, 4l.toLong, 1l.toLong, 6l.toLong, 8l.toLong))) == (4l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))) == (2l));\n    assert(mulEvenOdd((List[Long](1l.toLong, 5l.toLong, 7l.toLong, 9l.toLong, 10l.toLong))) == (10l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert tuple string to integer tuple.\n    def tupleStrInt(test_str : String) : Tuple2[Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tupleStrInt((\"(7, 8, 9)\")).equals(((7l, 8l, 9l))));\n    assert(tupleStrInt((\"(1, 2, 3)\")).equals(((1l, 2l, 3l))));\n    assert(tupleStrInt((\"(4, 5, 6)\")).equals(((4l, 5l, 6l))));\n    assert(tupleStrInt((\"(7, 81, 19)\")).equals(((7l, 81l, 19l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to locate the right insertion point for a specified value in sorted order.\n    def rightInsertion(a : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (6l)) == (4l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (3l)) == (2l));\n    assert(rightInsertion((List[Long](1l.toLong, 2l.toLong, 4l.toLong, 5l.toLong)), (7l)) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an a followed by three 'b'.\n    def textMatchThree(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textMatchThree((\"ac\")) == (false));\n    assert(textMatchThree((\"dc\")) == (false));\n    assert(textMatchThree((\"abbbba\")) == (true));\n    assert(textMatchThree((\"caacabbbba\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to create a new tuple from the given string and list.\n    def newTuple(test_list : List[String], test_str : String) : Tuple2[String, String, String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(newTuple((List[String](\"WEB\", \"is\")), (\"best\")).equals(((\"WEB\", \"is\", \"best\"))));\n    assert(newTuple((List[String](\"We\", \"are\")), (\"Developers\")).equals(((\"We\", \"are\", \"Developers\"))));\n    assert(newTuple((List[String](\"Part\", \"is\")), (\"Wrong\")).equals(((\"Part\", \"is\", \"Wrong\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether every even index contains even numbers of a given list.\n    def evenPosition(nums : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(evenPosition((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (false));\n    assert(evenPosition((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (false));\n    assert(evenPosition((List[Long](2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove tuples from the given tuple.\n    def removeNested(test_tup : Any) : Tuple2[Long, Long, Long, Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeNested((Any(4l, 6l), 10l))).equals(((1l, 5l, 7l, 10l))));\n    assert(removeNested((Any(5l, 7l), 11l))).equals(((2l, 6l, 8l, 11l))));\n    assert(removeNested((Any(6l, 8l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    assert(removeNested((Any(6l, 8l), (5l, 12l), 12l))).equals(((3l, 7l, 9l, 12l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of lists in a given number of lists.\n    def countList(input_list : List[List[Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 3l.toLong), List[Long](5l.toLong, 7l.toLong), List[Long](9l.toLong, 11l.toLong), List[Long](13l.toLong, 15l.toLong, 17l.toLong)))) == (4l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong)))) == (3l));\n    assert(countList((List[List[Long]](List[Long](1l.toLong, 0l.toLong), List[Long](2l.toLong, 0l.toLong)))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the last position of an element in a sorted list.\n    def last(arr : List[Long], x : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(last((List[Long](1l.toLong, 2l.toLong, 3l.toLong)), (1l)) == (0l));\n    assert(last((List[Long](1l.toLong, 1l.toLong, 1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)), (1l)) == (2l));\n    assert(last((List[Long](2l.toLong, 3l.toLong, 2l.toLong, 3l.toLong, 6l.toLong, 8l.toLong, 9l.toLong)), (3l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n    def textStartaEndb(text : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(textStartaEndb((\"aabbbb\")) == (true));\n    assert(textStartaEndb((\"aabAbbbc\")) == (false));\n    assert(textStartaEndb((\"accddbbjjj\")) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write function to find the sum of all items in the given map.\n    def returnSum(dict : Map[String,Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(returnSum((Map[String,Long](\"a\" -> 100l, \"b\" -> 200l, \"c\" -> 300l))) == (600l));\n    assert(returnSum((Map[String,Long](\"a\" -> 25l, \"b\" -> 18l, \"c\" -> 45l))) == (88l));\n    assert(returnSum((Map[String,Long](\"a\" -> 36l, \"b\" -> 39l, \"c\" -> 49l))) == (124l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of all odd natural numbers within the range l and r.\n    def sumInRange(l : Long, r : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sumInRange((2l), (5l)) == (8l));\n    assert(sumInRange((5l), (7l)) == (12l));\n    assert(sumInRange((7l), (13l)) == (40l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the sum of a list.\n    def Sum(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(Sum((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (6l));\n    assert(Sum((List[Long](15l.toLong, 12l.toLong, 13l.toLong, 10l.toLong))) == (50l));\n    assert(Sum((List[Long](0l.toLong, 1l.toLong, 2l.toLong))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n    def leftRotate(n : Long, d : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(leftRotate((16l), (2l)) == (64l));\n    assert(leftRotate((10l), (2l)) == (40l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((99l), (3l)) == (792l));\n    assert(leftRotate((1l), (3l)) == (8l));\n    assert(leftRotate((5l), (3l)) == (40l));\n    assert(leftRotate((29l), (3l)) == (232l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to check whether the length of the word is odd or not.\n    def wordLen(s : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(wordLen((\"Hadoop\")) == (false));\n    assert(wordLen((\"great\")) == (true));\n    assert(wordLen((\"structure\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to remove all whitespaces from a string.\n    def removeAllSpaces(text : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(removeAllSpaces((\"python  program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"python   programming    language\")).equals((\"pythonprogramminglanguage\")));\n    assert(removeAllSpaces((\"python                     program\")).equals((\"pythonprogram\")));\n    assert(removeAllSpaces((\"   python                     program\")).equals((\"pythonprogram\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of equal numbers from three given integers.\n    def testThreeEqual(x : Long, y : Long, z : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(testThreeEqual((1l), (1l), (1l)) == (3l));\n    assert(testThreeEqual((-1l), (-2l), (-3l)) == (0l));\n    assert(testThreeEqual((1l), (2l), (2l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to count the number of rotations required to generate a sorted list. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-list/\n    def countRotation(arr : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(countRotation((List[Long](3l.toLong, 2l.toLong, 1l.toLong))) == (1l));\n    assert(countRotation((List[Long](4l.toLong, 5l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (2l));\n    assert(countRotation((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 1l.toLong, 2l.toLong, 3l.toLong))) == (3l));\n    assert(countRotation((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (0l));\n    assert(countRotation((List[Long](1l.toLong, 3l.toLong, 2l.toLong))) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n    def isPerfectSquare(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isPerfectSquare((10l)) == (false));\n    assert(isPerfectSquare((36l)) == (true));\n    assert(isPerfectSquare((14l)) == (false));\n    assert(isPerfectSquare((196l)) == (true));\n    assert(isPerfectSquare((125l)) == (false));\n    assert(isPerfectSquare((15625l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the product of numbers in a list is even or not.\n    def isProductEven(arr : List[Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 3l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 2l.toLong, 1l.toLong, 4l.toLong))) == (true));\n    assert(isProductEven((List[Long](1l.toLong, 1l.toLong))) == (false));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function that returns the list in a list of lists whose sum of elements is the highest.\n    def maxSumList(lists : List[List[Long]]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxSumList((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong), List[Long](10l.toLong, 11l.toLong, 12l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong)))).equals((List[Long](10l.toLong, 11l.toLong, 12l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](3l.toLong, 2l.toLong, 1l.toLong), List[Long](6l.toLong, 5l.toLong, 4l.toLong), List[Long](12l.toLong, 11l.toLong, 10l.toLong)))).equals((List[Long](12l.toLong, 11l.toLong, 10l.toLong))));\n    assert(maxSumList((List[List[Long]](List[Long](2l.toLong, 3l.toLong, 1l.toLong)))).equals((List[Long](2l.toLong, 3l.toLong, 1l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find maximum run of uppercase characters in the given string.\n    def maxRunUppercase(test_str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(maxRunUppercase((\"GeMKSForGERksISBESt\")) == (5l));\n    assert(maxRunUppercase((\"PrECIOusMOVemENTSYT\")) == (6l));\n    assert(maxRunUppercase((\"GooGLEFluTTER\")) == (4l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the first odd number in a given list of numbers.\n    def firstOdd(nums : List[Long]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(firstOdd((List[Long](1l.toLong, 3l.toLong, 5l.toLong))) == (1l));\n    assert(firstOdd((List[Long](2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong))) == (1l));\n    assert(firstOdd((List[Long](8l.toLong, 9l.toLong, 1l.toLong))) == (9l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if the given tuples contain the k or not.\n    def checkK(test_tup : List[Long], K : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkK((List[Long](10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 8l.toLong)), (6l)) == (true));\n    assert(checkK((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong)), (7l)) == (false));\n    assert(checkK((List[Long](7l.toLong, 8l.toLong, 9l.toLong, 44l.toLong, 11l.toLong, 12l.toLong)), (11l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n    def checkSmaller(test_tup1 : Tuple2[Long, Long, Long], test_tup2 : Tuple2[Long, Long, Long]) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(checkSmaller(((1l, 2l, 3l)), ((2l, 3l, 4l))) == (false));\n    assert(checkSmaller(((4l, 5l, 6l)), ((3l, 4l, 5l))) == (true));\n    assert(checkSmaller(((11l, 12l, 13l)), ((10l, 11l, 12l))) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth tetrahedral number.\n    def tetrahedralNumber(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(tetrahedralNumber((5l)) == (35l));\n    assert(tetrahedralNumber((6l)) == (56l));\n    assert(tetrahedralNumber((7l)) == (84l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n    def getChar(strr : String) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(getChar((\"abc\")).equals((\"f\")));\n    assert(getChar((\"gfg\")).equals((\"t\")));\n    assert(getChar((\"ab\")).equals((\"c\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the nth number in the newman conway sequence.\n    def sequence(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(sequence((10l)) == (6l));\n    assert(sequence((2l)) == (1l));\n    assert(sequence((3l)) == (2l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find nth centered hexagonal number.\n    def centeredHexagonalNumber(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(centeredHexagonalNumber((10l)) == (271l));\n    assert(centeredHexagonalNumber((2l)) == (7l));\n    assert(centeredHexagonalNumber((9l)) == (217l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to merge three dictionaries into a single map.\n    def mergeDictionariesThree(dict1 : Map[String,String], dict2 : Map[String,String], dict3 : Map[String,String]) : Map[String,String] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"O\" -> \"Orange\", \"W\" -> \"White\", \"B\" -> \"Black\"))).equals((Map[String,String](\"B\" -> \"Black\", \"R\" -> \"Red\", \"P\" -> \"Pink\", \"G\" -> \"Green\", \"W\" -> \"White\", \"O\" -> \"Orange\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\"))).equals((Map[String,String](\"W\" -> \"White\", \"P\" -> \"Pink\", \"B\" -> \"Black\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\"))));\n    assert(mergeDictionariesThree((Map[String,String](\"R\" -> \"Red\", \"B\" -> \"Black\", \"P\" -> \"Pink\")), (Map[String,String](\"L\" -> \"lavender\", \"B\" -> \"Blue\")), (Map[String,String](\"G\" -> \"Green\", \"W\" -> \"White\"))).equals((Map[String,String](\"B\" -> \"Black\", \"P\" -> \"Pink\", \"R\" -> \"Red\", \"G\" -> \"Green\", \"L\" -> \"lavender\", \"W\" -> \"White\"))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to get the frequency of all the elements in a list, returned as a map.\n    def freqCount(list1 : List[Long]) : Map[Long,Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(freqCount((List[Long](10l.toLong, 10l.toLong, 10l.toLong, 10l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 20l.toLong, 40l.toLong, 40l.toLong, 50l.toLong, 50l.toLong, 30l.toLong))).equals((Map[Long,Long](10l -> 4l, 20l -> 4l, 40l -> 2l, 50l -> 2l, 30l -> 1l))));\n    assert(freqCount((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 3l.toLong, 2l.toLong, 4l.toLong, 1l.toLong, 3l.toLong, 1l.toLong, 4l.toLong))).equals((Map[Long,Long](1l -> 3l, 2l -> 2l, 3l -> 3l, 4l -> 3l))));\n    assert(freqCount((List[Long](5l.toLong, 6l.toLong, 7l.toLong, 4l.toLong, 9l.toLong, 10l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 9l.toLong, 5l.toLong))).equals((Map[Long,Long](10l -> 1l, 5l -> 3l, 6l -> 2l, 7l -> 2l, 4l -> 2l, 9l -> 2l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find the closest smaller number than n.\n    def closestNum(N : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(closestNum((11l)) == (10l));\n    assert(closestNum((7l)) == (6l));\n    assert(closestNum((12l)) == (11l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find squares of individual elements in a list.\n    def squareNums(nums : List[Long]) : List[Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(squareNums((List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong, 5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong, 9l.toLong, 10l.toLong))).equals((List[Long](1l.toLong, 4l.toLong, 9l.toLong, 16l.toLong, 25l.toLong, 36l.toLong, 49l.toLong, 64l.toLong, 81l.toLong, 100l.toLong))));\n    assert(squareNums((List[Long](10l.toLong, 20l.toLong, 30l.toLong))).equals((List[Long](100l.toLong, 400l.toLong, 900l.toLong))));\n    assert(squareNums((List[Long](12l.toLong, 15l.toLong))).equals((List[Long](144l.toLong, 225l.toLong))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the longest word.\n    def lenLog(list1 : List[String]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(lenLog((List[String](\"python\", \"PHP\", \"bigdata\"))) == (7l));\n    assert(lenLog((List[String](\"a\", \"ab\", \"abc\"))) == (3l));\n    assert(lenLog((List[String](\"small\", \"big\", \"tall\"))) == (5l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check if a string is present as a substring in a given list of string values.\n    def findSubstring(str1 : List[String], sub_str : String) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ack\")) == (true));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"abc\")) == (false));\n    assert(findSubstring((List[String](\"red\", \"black\", \"white\", \"green\", \"orange\")), (\"ange\")) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to check whether the given number is undulating or not.\n    def isUndulating(n : Long) : Boolean = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(isUndulating((1212121l)) == (true));\n    assert(isUndulating((1991l)) == (false));\n    assert(isUndulating((121l)) == (true));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to calculate the value of 'a' to the power 'b'.\n    def power(a : Long, b : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(power((3l), (4l)) == (81l));\n    assert(power((2l), (3l)) == (8l));\n    assert(power((5l), (5l)) == (3125l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n    def indexMinimum(test_list : List[Tuple2[String, Long]]) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Rash\", 143l), (\"Manjeet\", 200l), (\"Varsha\", 100l)))).equals((\"Varsha\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Yash\", 185l), (\"Dawood\", 125l), (\"Sanya\", 175l)))).equals((\"Dawood\")));\n    assert(indexMinimum((List[Tuple2[String, Long]]((\"Sai\", 345l), (\"Salman\", 145l), (\"Ayesha\", 96l)))).equals((\"Ayesha\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the length of the smallest list in a list of lists.\n    def FindMinLength(lst : List[List[Long]]) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong), List[Long](1l.toLong, 2l.toLong)))) == (1l));\n    assert(FindMinLength((List[List[Long]](List[Long](1l.toLong, 2l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong), List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong)))) == (2l));\n    assert(FindMinLength((List[List[Long]](List[Long](3l.toLong, 3l.toLong, 3l.toLong), List[Long](4l.toLong, 4l.toLong, 4l.toLong, 4l.toLong)))) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the number of divisors of a given integer.\n    def divisor(n : Long) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(divisor((15l)) == (4l));\n    assert(divisor((12l)) == (6l));\n    assert(divisor((9l)) == (3l));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to find frequency of each element in a flattened list of lists, returned in a map.\n    def frequencyLists(list1 : List[List[Long]]) : Map[Long,Long] = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 2l.toLong), List[Long](4l.toLong, 5l.toLong, 6l.toLong, 2l.toLong), List[Long](7l.toLong, 8l.toLong, 9l.toLong, 5l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 3l, 3l -> 1l, 4l -> 1l, 5l -> 2l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](1l.toLong, 2l.toLong, 3l.toLong, 4l.toLong), List[Long](5l.toLong, 6l.toLong, 7l.toLong, 8l.toLong), List[Long](9l.toLong, 10l.toLong, 11l.toLong, 12l.toLong)))).equals((Map[Long,Long](1l -> 1l, 2l -> 1l, 3l -> 1l, 4l -> 1l, 5l -> 1l, 6l -> 1l, 7l -> 1l, 8l -> 1l, 9l -> 1l, 10l -> 1l, 11l -> 1l, 12l -> 1l))));\n    assert(frequencyLists((List[List[Long]](List[Long](20l.toLong, 30l.toLong, 40l.toLong, 17l.toLong), List[Long](18l.toLong, 16l.toLong, 14l.toLong, 13l.toLong), List[Long](10l.toLong, 20l.toLong, 30l.toLong, 40l.toLong)))).equals((Map[Long,Long](20l -> 2l, 30l -> 2l, 40l -> 2l, 17l -> 1l, 18l -> 1l, 16l -> 1l, 14l -> 1l, 13l -> 1l, 10l -> 1l))));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n    def decimalToBinary(n : Long) : String = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(decimalToBinary((8l)).equals((\"1000\")));\n    assert(decimalToBinary((18l)).equals((\"10010\")));\n    assert(decimalToBinary((7l)).equals((\"111\")));\n    }\n\n}\n",
+    "stop_tokens": [
+      "\n    }\n"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "scala",
+    "prompt": "import scala.math._\nimport scala.collection.mutable._\nobject Problem {\n    // Write a scalathon function to find the minimum number of rotations (greater than 0) required to get the same string.\n    def findRotations(str : String) : Long = {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "    }\n    def main(args: Array[String]) = {\n    assert(findRotations((\"aaaa\")) == (1l));\n    assert(findRotations((\"ab\")) == (2l));\n    assert(findRotations((\"abc\")) == (3l));\n    }\n\n}\n",
     "stop_tokens": [
       "\n    }\n"
     ]

--- a/prompts/mbpp-sh-keep.json
+++ b/prompts/mbpp-sh-keep.json
@@ -1,3372 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the length of the longest palindromic subsequence in the given string.\n#\n# $1 is a string\nlps() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    lps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TENS FOR TENS\") = \"5\" ]]\n    [[ $(candidate \"CARDIO FOR CARDS\") = \"7\" ]]\n    [[ $(candidate \"PART OF THE JOURNEY IS PART\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from the given string.\n#\n# $1 is a string\nremove_whitespaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_whitespaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \" Google    Flutter \") = \"GoogleFlutter\" ]]\n    [[ $(candidate \" Google    Dart \") = \"GoogleDart\" ]]\n    [[ $(candidate \" iOS    Swift \") = \"iOSSwift\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a specified list is sorted or not.\n#\n# $1 is a space-separated list\nissort_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    issort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 6 8 10 12 14 16 17\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 12 14 20 17\") = \"false\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 15 14 20\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count bidirectional tuple pairs.\n#\n# $1 is a newline-separated, space-separated list\ncount_bidirectional() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_bidirectional \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 1\\n6 5\\n2 1\") = \"3\" ]]\n    [[ $(candidate \"5 6\\n1 3\\n6 5\\n9 1\\n6 5\\n2 1\") = \"2\" ]]\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 2\\n6 5\\n2 1\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cube of a given size.\n#\n# $1 is an integer\nsurfacearea_cube() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    surfacearea_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"150\" ]]\n    [[ $(candidate \"3\") = \"54\" ]]\n    [[ $(candidate \"10\") = \"600\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n#\n# $1 is an integer\nnext_smallest_palindrome() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    next_smallest_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"99\") = \"101\" ]]\n    [[ $(candidate \"1221\") = \"1331\" ]]\n    [[ $(candidate \"120\") = \"121\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the cube sum of first n even natural numbers.\n#\n# $1 is an integer\ncube_Sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cube_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"72\" ]]\n    [[ $(candidate \"3\") = \"288\" ]]\n    [[ $(candidate \"4\") = \"800\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of xor of all pairs of numbers in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\npair_xor_Sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pair_xor_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 9 7 6\" \"4\") = \"47\" ]]\n    [[ $(candidate \"7 3 5\" \"3\") = \"12\" ]]\n    [[ $(candidate \"7 3\" \"2\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n#\n# $1 is a space-separated list\ncheck_min_heap() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_min_heap \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 10 15\") = \"true\" ]]\n    [[ $(candidate \"2 10 4 5 3 15\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the first digit of a given number.\n#\n# $1 is an integer\nfirst_Digit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    first_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"1\" ]]\n    [[ $(candidate \"456\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the first non-repeated character in a given string.\n#\n# $1 is a string\nfirst_non_repeating_character() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    first_non_repeating_character \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"None\" ]]\n    [[ $(candidate \"abc\") = \"a\" ]]\n    [[ $(candidate \"ababc\") = \"c\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert degrees to radians.\n#\n# $1 is an integer\nradian_degree() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    radian_degree \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"90\") = \"1.5707963267948966\" ]]\n    [[ $(candidate \"60\") = \"1.0471975511965976\" ]]\n    [[ $(candidate \"120\") = \"2.0943951023931953\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum product subarray of the given array.\n#\n# $1 is a space-separated list\nmax_subarray_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_subarray_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 0 7 -8 -2\") = \"112\" ]]\n    [[ $(candidate \"6 -3 -10 0 2\") = \"180\" ]]\n    [[ $(candidate \"-2 -40 0 -2 -3\") = \"80\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find smallest number in a list.\n#\n# $1 is a space-separated list\nsmallest_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    smallest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 1 45 99\") = \"1\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n    [[ $(candidate \"45 46 50 60\") = \"45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n#\n# $1 is a string\ntext_match_zero_one() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_zero_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"dsabbbba\") = \"true\" ]]\n    [[ $(candidate \"asbbbba\") = \"false\" ]]\n    [[ $(candidate \"abaaa\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find nth bell number.\n#\n# $1 is an integer\nbell_Number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bell_Number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find cubes of individual elements in a list.\n#\n# $1 is a space-separated list\ncube_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cube_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 8 27 64 125 216 343 512 729 1000\" ]]\n    [[ $(candidate \"10 20 30\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\") = \"1728 3375\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the last digit in factorial of a given number.\n#\n# $1 is an integer\nlast_Digit_Factorial() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    last_Digit_Factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"4\" ]]\n    [[ $(candidate \"21\") = \"0\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find even numbers from a list of numbers.\n#\n# $1 is a space-separated list\nSplit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2 4\" ]]\n    [[ $(candidate \"4 5 6 7 8 0 1\") = \"4 6 8 0\" ]]\n    [[ $(candidate \"8 12 15 19\") = \"8 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given integer is a prime number.\n#\n# $1 is an integer\nprime_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    prime_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"-1010\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nfind_tuples() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 24 12\\n7 9 6\\n12 18 21\" \"6\") = \"6 24 12\" ]]\n    [[ $(candidate \"5 25 30\\n4 2 3\\n7 8 9\" \"5\") = \"5 25 30\" ]]\n    [[ $(candidate \"7 9 16\\n8 16 4\\n19 17 18\" \"4\") = \"8 16 4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to caluclate the area of a tetrahedron.\n#\n# $1 is an integer\narea_tetrahedron() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    area_tetrahedron \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15.588457268119894\" ]]\n    [[ $(candidate \"20\") = \"692.8203230275509\" ]]\n    [[ $(candidate \"10\") = \"173.20508075688772\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number is even or not.\n#\n# $1 is an integer\nis_Even() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_Even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"2\") = \"true\" ]]\n    [[ $(candidate \"3\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of positive numbers in a list.\n#\n# $1 is a space-separated list\npos_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pos_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 3 -4\") = \"2\" ]]\n    [[ $(candidate \"3 4 5 -1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get all lucid numbers smaller than or equal to a given integer.\n#\n# $1 is an integer\nget_ludic() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_ludic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"1 2 3 5 7\" ]]\n    [[ $(candidate \"25\") = \"1 2 3 5 7 11 13 17 23 25\" ]]\n    [[ $(candidate \"45\") = \"1 2 3 5 7 11 13 17 23 25 29 37 41 43\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n#\n# $1 is an integer\nfind_Index() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"14\" ]]\n    [[ $(candidate \"4\") = \"45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to reverse an array upto a given position.\n#\n# $1 is a space-separated list\n# $2 is an integer\nreverse_Array_Upto_K() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    reverse_Array_Upto_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"4\") = \"4 3 2 1 5 6\" ]]\n    [[ $(candidate \"4 5 6 7\" \"2\") = \"5 4 6 7\" ]]\n    [[ $(candidate \"9 8 7 6 5\" \"3\") = \"7 8 9 6 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove characters from the first string which are present in the second string.\n#\n# $1 is a string\n# $2 is a string\nremove_dirty_chars() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_dirty_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"probasscurve\" \"pros\") = \"bacuve\" ]]\n    [[ $(candidate \"digitalindia\" \"talent\") = \"digiidi\" ]]\n    [[ $(candidate \"exoticmiles\" \"toxic\") = \"emles\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n#\n# $1 is a newline-separated, space-separated list\nround_and_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    round_and_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5\") = \"243\" ]]\n    [[ $(candidate \"5 2 9 24.3 29\") = \"345\" ]]\n    [[ $(candidate \"25.0 56.7 89.2\") = \"513\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the item with maximum frequency in a given list.\n#\n# $1 is a space-separated list\nmax_occurrences() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_occurrences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2\") = \"2\" ]]\n    [[ $(candidate \"2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18\") = \"8\" ]]\n    [[ $(candidate \"10 20 20 30 40 90 80 50 30 20 50 10\") = \"20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a given string is a decimal number with a precision of 2.\n#\n# $1 is a string\nis_decimal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_decimal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123.11\") = \"true\" ]]\n    [[ $(candidate \"e666.86\") = \"false\" ]]\n    [[ $(candidate \"3.124587\") = \"false\" ]]\n    [[ $(candidate \"1.11\") = \"true\" ]]\n    [[ $(candidate \"1.1.11\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of even numbers at even positions of a list.\n#\n# $1 is a space-separated list\nsum_even_and_even_index() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_even_and_even_index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 12 1 18 8\") = \"30\" ]]\n    [[ $(candidate \"3 20 17 9 2 10 18 13 6 18\") = \"26\" ]]\n    [[ $(candidate \"5 6 12 1\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the sum of the largest contiguous sublist in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmax_sub_array_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_sub_array_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-2 -3 4 -1 -2 1 5 -3\" \"8\") = \"7\" ]]\n    [[ $(candidate \"-3 -4 5 -2 -3 2 6 -4\" \"8\") = \"8\" ]]\n    [[ $(candidate \"-4 -5 6 -3 -4 3 7 -5\" \"8\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the intersection of two arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection_array() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    intersection_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"1 2 4 8 9\") = \"1 2 8 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"3 5 7 9\") = \"3 5 7 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"10 20 30 40\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_two_parts() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split_two_parts \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 2\\n3 4 4 5 1\" ]]\n    [[ $(candidate \"a b c d\" \"2\") = \"a b\\nc d\" ]]\n    [[ $(candidate \"p y t h o n\" \"4\") = \"p y t h\\no n\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n#\n# $1 is a string\n# $2 is a string\nfind_literals() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_literals \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") = \"fox 16 19\" ]]\n    [[ $(candidate \"Its been a very crazy procedure right\" \"crazy\") = \"crazy 16 21\" ]]\n    [[ $(candidate \"Hardest choices required strongest will\" \"will\") = \"will 35 39\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the volume of a triangular prism.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_Volume() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Volume \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"8\" \"6\") = \"240\" ]]\n    [[ $(candidate \"3\" \"2\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n#\n# $1 is an integer\n# $2 is an integer\nwind_chill() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    wind_chill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"120\" \"35\") = \"40\" ]]\n    [[ $(candidate \"40\" \"20\") = \"19\" ]]\n    [[ $(candidate \"10\" \"8\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the ascii value of a character.\n#\n# $1 is a string\nascii_value() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    ascii_value \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\") = \"65\" ]]\n    [[ $(candidate \"R\") = \"82\" ]]\n    [[ $(candidate \"S\") = \"83\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether all the characters are same or not.\n#\n# $1 is a string\nall_Characters_Same() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_Characters_Same \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"aaa\") = \"true\" ]]\n    [[ $(candidate \"data\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to move all the numbers to the end of the given string.\n#\n# $1 is a string\nmove_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    move_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"I1love143you55three3000thousand\") = \"Iloveyouthreethousand1143553000\" ]]\n    [[ $(candidate \"Avengers124Assemble\") = \"AvengersAssemble124\" ]]\n    [[ $(candidate \"Its11our12path13to14see15things16do17things\") = \"Itsourpathtoseethingsdothings11121314151617\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the length of the word is odd or not.\n#\n# $1 is a string\nword_len() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    word_len \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hadoop\") = \"false\" ]]\n    [[ $(candidate \"great\") = \"true\" ]]\n    [[ $(candidate \"structure\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to drop empty items from a given dictionary.\n#\n# $1 is a two column CSV in key,value order\ndrop_empty() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    drop_empty \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"c1,Red\\nc2,Green\\nc3,None\") = \"c1,Red\\nc2,Green\" ]]\n    [[ $(candidate \"c1,Red\\nc2,None\\nc3,None\") = \"c1,Red\" ]]\n    [[ $(candidate \"c1,None\\nc2,Green\\nc3,None\") = \"c2,Green\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n#\n# $1 is a space-separated list\n# $2 is a string\ninsert_element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    insert_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Black\" \"c\") = \"c Red c Green c Black\" ]]\n    [[ $(candidate \"python java\" \"program\") = \"program python program java\" ]]\n    [[ $(candidate \"happy sad\" \"laugh\") = \"laugh happy laugh sad\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove lowercase substrings from a given string.\n#\n# $1 is a string\nremove_lowercase() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_lowercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYTHon\") = \"PYTH\" ]]\n    [[ $(candidate \"FInD\") = \"FID\" ]]\n    [[ $(candidate \"STRinG\") = \"STRG\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n#\n# $1 is an integer\ncount_Set_Bits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_Set_Bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract only the rear index element of each string in the given tuple.\n#\n# $1 is a space-separated list\nextract_rear() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_rear \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mers for Vers\") = \"s r s\" ]]\n    [[ $(candidate \"Avenge for People\") = \"e r e\" ]]\n    [[ $(candidate \"Gotta get go\") = \"a t o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of occurence of the string 'std' in a given string.\n#\n# $1 is a string\ncount_occurance() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_occurance \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"letstdlenstdporstd\") = \"3\" ]]\n    [[ $(candidate \"truststdsolensporsd\") = \"1\" ]]\n    [[ $(candidate \"makestdsostdworthit\") = \"2\" ]]\n    [[ $(candidate \"stds\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given tuples contain the k or not.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_K() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 8\" \"6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"7\") = \"false\" ]]\n    [[ $(candidate \"7 8 9 44 11 12\" \"11\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to interleave 3 lists of the same length into a single flat list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ninterleave_lists() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    interleave_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7\" \"10 20 30 40 50 60 70\" \"100 200 300 400 500 600 700\") = \"1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700\" ]]\n    [[ $(candidate \"10 20\" \"15 2\" \"5 10\") = \"10 15 5 20 2 10\" ]]\n    [[ $(candidate \"11 44\" \"10 15\" \"20 5\") = \"11 10 20 44 15 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python_program\") = \"PythonProgram\" ]]\n    [[ $(candidate \"python_language\") = \"PythonLanguage\" ]]\n    [[ $(candidate \"programming_language\") = \"ProgrammingLanguage\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of equal numbers from three given integers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntest_three_equal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    test_three_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"1\" \"1\") = \"3\" ]]\n    [[ $(candidate \"-1\" \"-2\" \"-3\") = \"0\" ]]\n    [[ $(candidate \"1\" \"2\" \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n#\n# $1 is a space-separated list\nodd_length_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    odd_length_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4\") = \"14\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"15\" ]]\n    [[ $(candidate \"1 7\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the number of ways to partition a set of Bell numbers.\n#\n# $1 is an integer\nbell_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bell_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"115975\" ]]\n    [[ $(candidate \"56\") = \"6775685320645824322581483068371419745979053216268760300\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the area of a rectangle.\n#\n# $1 is an integer\n# $2 is an integer\nrectangle_area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rectangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"10\" \"5\") = \"50\" ]]\n    [[ $(candidate \"4\" \"2\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find sum and average of first n natural numbers.\n#\n# $1 is an integer\nsum_average() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_average \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55 5.5\" ]]\n    [[ $(candidate \"15\") = \"120 8.0\" ]]\n    [[ $(candidate \"20\") = \"210 10.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndivision_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    division_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"2 2 2 3\" ]]\n    [[ $(candidate \"12 6 8 16\" \"6 3 4 4\") = \"2 2 2 4\" ]]\n    [[ $(candidate \"20 14 36 18\" \"5 7 6 9\") = \"4 2 6 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get the sum of the digits of a non-negative integer.\n#\n# $1 is an integer\nsum_digits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"345\") = \"12\" ]]\n    [[ $(candidate \"12\") = \"3\" ]]\n    [[ $(candidate \"97\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n#\n# $1 is a newline-separated, space-separated list\nindex_minimum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    index_minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Rash 143\\nManjeet 200\\nVarsha 100\") = \"Varsha\" ]]\n    [[ $(candidate \"Yash 185\\nDawood 125\\nSanya 175\") = \"Dawood\" ]]\n    [[ $(candidate \"Sai 345\\nSalman 145\\nAyesha 96\") = \"Ayesha\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to divide two lists element wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndiv_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    div_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"1 2 3\") = \"4.0 2.5 2.0\" ]]\n    [[ $(candidate \"3 2\" \"1 4\") = \"3.0 0.5\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"1.8 1.7142857142857142\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the list with maximum length.\n#\n# $1 is a newline-separated, space-separated list\nmax_length_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_length_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1 2 3 4 5\\n1 2 3 4\\n1 2 3\\n1 2\\n1\") = \"5 1 2 3 4 5\" ]]\n    [[ $(candidate \"3 4 5\\n6 7 8 9\\n10 11 12\") = \"4 6 7 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find all possible combinations of the elements of a given list.\n#\n# $1 is a space-separated list\ncombinations_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    combinations_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"orange red green blue\") = \"\\norange\\nred\\nred orange\\ngreen\\ngreen orange\\ngreen red\\ngreen red orange\\nblue\\nblue orange\\nblue red\\nblue red orange\\nblue green\\nblue green orange\\nblue green red\\nblue green red orange\" ]]\n    [[ $(candidate \"red green blue white black orange\") = \"\\nred\\ngreen\\ngreen red\\nblue\\nblue red\\nblue green\\nblue green red\\nwhite\\nwhite red\\nwhite green\\nwhite green red\\nwhite blue\\nwhite blue red\\nwhite blue green\\nwhite blue green red\\nblack\\nblack red\\nblack green\\nblack green red\\nblack blue\\nblack blue red\\nblack blue green\\nblack blue green red\\nblack white\\nblack white red\\nblack white green\\nblack white green red\\nblack white blue\\nblack white blue red\\nblack white blue green\\nblack white blue green red\\norange\\norange red\\norange green\\norange green red\\norange blue\\norange blue red\\norange blue green\\norange blue green red\\norange white\\norange white red\\norange white green\\norange white green red\\norange white blue\\norange white blue red\\norange white blue green\\norange white blue green red\\norange black\\norange black red\\norange black green\\norange black green red\\norange black blue\\norange black blue red\\norange black blue green\\norange black blue green red\\norange black white\\norange black white red\\norange black white green\\norange black white green red\\norange black white blue\\norange black white blue red\\norange black white blue green\\norange black white blue green red\" ]]\n    [[ $(candidate \"red green black orange\") = \"\\nred\\ngreen\\ngreen red\\nblack\\nblack red\\nblack green\\nblack green red\\norange\\norange red\\norange green\\norange green red\\norange black\\norange black red\\norange black green\\norange black green red\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the largest and smallest value in a given array.\n#\n# $1 is a space-separated list\nbig_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    big_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"4\" ]]\n    [[ $(candidate \"-1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"2 3 6\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to return the negative numbers in a list.\n#\n# $1 is a space-separated list\nneg_nos() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    neg_nos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 4 5 -6\") = \"-1 -6\" ]]\n    [[ $(candidate \"-1 -2 3 4\") = \"-1 -2\" ]]\n    [[ $(candidate \"-7 -6 8 9\") = \"-7 -6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the highest power of 2 that is less than or equal to n.\n#\n# $1 is an integer\nhighest_Power_of_2() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    highest_Power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"8\" ]]\n    [[ $(candidate \"19\") = \"16\" ]]\n    [[ $(candidate \"32\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a list contains the given sublist or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_sublist() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_sublist \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 3 5 7\" \"3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"4 3\") = \"true\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"1 6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to subtract two lists element-wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsub_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sub_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"-3 -3 -3\" ]]\n    [[ $(candidate \"1 2\" \"3 4\") = \"-2 -2\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"40 50\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given two integers have opposite sign or not.\n#\n# $1 is an integer\n# $2 is an integer\nopposite_Signs() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    opposite_Signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"-2\") = \"true\" ]]\n    [[ $(candidate \"3\" \"2\") = \"false\" ]]\n    [[ $(candidate \"-10\" \"-10\") = \"false\" ]]\n    [[ $(candidate \"-2\" \"2\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which takes two tuples of the same length and performs the element wise modulo.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntuple_modulo() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tuple_modulo \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6\" \"5 6 7 5\") = \"0 4 5 1\" ]]\n    [[ $(candidate \"11 5 6 7\" \"6 7 8 6\") = \"5 5 6 1\" ]]\n    [[ $(candidate \"12 6 7 8\" \"7 8 9 7\") = \"5 6 7 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the difference of the first even and first odd number of a given list.\n#\n# $1 is a space-separated list\ndiff_even_odd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    diff_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort each sublist of strings in a given list of lists.\n#\n# $1 is a newline-separated, space-separated list\nsort_sublists() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_sublists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange\\nblack white\\nwhite black orange\") = \"green orange\\nblack white\\nblack orange white\" ]]\n    [[ $(candidate \"green orange\\nblack\\ngreen orange\\nwhite\") = \"green orange\\nblack\\ngreen orange\\nwhite\" ]]\n    [[ $(candidate \"a b\\nd c\\ng h\\nf e\") = \"a b\\nc d\\ng h\\ne f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the last digit of a given number.\n#\n# $1 is an integer\nlast_Digit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    last_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"25\") = \"5\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of fourth power of first n odd natural numbers.\n#\n# $1 is an integer\nodd_num_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    odd_num_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"82\" ]]\n    [[ $(candidate \"3\") = \"707\" ]]\n    [[ $(candidate \"4\") = \"3108\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a list to a string.\n#\n# $1 is a space-separated list\ntup_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tup_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"e x e r c i s e s\") = \"exercises\" ]]\n    [[ $(candidate \"p y t h o n\") = \"python\" ]]\n    [[ $(candidate \"p r o g r a m\") = \"program\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all elements from a given list present in another list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nremove_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"1 3 5 7\") = \"2 4 6 8 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5 7\") = \"1 2 3 4 6 8 9 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether any value in a sequence exists in a sequence or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\noverlapping() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    overlapping \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 4 5\" \"1 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to identify non-prime numbers.\n#\n# $1 is an integer\nis_not_prime() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_not_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"35\") = \"true\" ]]\n    [[ $(candidate \"37\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmax_val() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"5\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"25\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"50\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of the negative numbers of a given list of numbers.\n#\n# $1 is a space-separated list\nsum_negativenum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_negativenum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"-32\" ]]\n    [[ $(candidate \"10 15 -14 13 -18 12 -20\") = \"-52\" ]]\n    [[ $(candidate \"19 -65 57 39 152 -639 121 44 90 -190\") = \"-894\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n#\n# $1 is a string\nfind_Rotations() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Rotations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aaaa\") = \"1\" ]]\n    [[ $(candidate \"ab\") = \"2\" ]]\n    [[ $(candidate \"abc\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n#\n# $1 is a string\nchange_date_format() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    change_date_format \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2026-01-02\") = \"02-01-2026\" ]]\n    [[ $(candidate \"2020-11-13\") = \"13-11-2020\" ]]\n    [[ $(candidate \"2021-04-26\") = \"26-04-2021\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function which takes a list of integers and only returns the odd ones.\n#\n# $1 is a space-separated list\nSplit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1 3 5\" ]]\n    [[ $(candidate \"10 11 12 13\") = \"11 13\" ]]\n    [[ $(candidate \"7 8 9 1\") = \"7 9 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n#\n# $1 is an integer\ntoggle_middle_bits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    toggle_middle_bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"15\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"11\") = \"13\" ]]\n    [[ $(candidate \"65\") = \"127\" ]]\n    [[ $(candidate \"77\") = \"115\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n#\n# $1 is a string\ncount_char_position() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_char_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xbcefg\") = \"2\" ]]\n    [[ $(candidate \"ABcED\") = \"3\" ]]\n    [[ $(candidate \"AbgdeF\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nlarge_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    large_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"3\") = \"60 54 50\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"4\") = \"60 54 50 48\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"5\") = \"60 54 50 48 45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ncummulative_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cummulative_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 6 7\\n2 6\") = \"30\" ]]\n    [[ $(candidate \"2 4\\n6 7 8\\n3 7\") = \"37\" ]]\n    [[ $(candidate \"3 5\\n7 8 9\\n4 8\") = \"44\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_min_diff() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_min_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 3 19 18 25\" \"6\") = \"1\" ]]\n    [[ $(candidate \"4 3 2 6\" \"4\") = \"1\" ]]\n    [[ $(candidate \"30 5 20 9\" \"4\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n#\n# $1 is a string\ntext_starta_endb() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_starta_endb \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aabbbb\") = \"true\" ]]\n    [[ $(candidate \"aabAbbbc\") = \"false\" ]]\n    [[ $(candidate \"accddbbjjj\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n#\n# $1 is an integer\n# $2 is an integer\nleft_rotate() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    left_rotate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"64\" ]]\n    [[ $(candidate \"10\" \"2\") = \"40\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"1\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"3\") = \"40\" ]]\n    [[ $(candidate \"29\" \"3\") = \"232\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the first repeated character in a given string.\n#\n# $1 is a string\nfirst_repeated_char() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    first_repeated_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"a\" ]]\n    [[ $(candidate \"abc\") = \"None\" ]]\n    [[ $(candidate \"123123\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count inversions in an array.\n#\n# $1 is a space-separated list\nget_Inv_Count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_Inv_Count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 20 6 4 5\") = \"5\" ]]\n    [[ $(candidate \"1 2 1\") = \"1\" ]]\n    [[ $(candidate \"1 2 5 6 1\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n#\n# $1 is an integer\neven_Power_Sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_Power_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1056\" ]]\n    [[ $(candidate \"3\") = \"8832\" ]]\n    [[ $(candidate \"1\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find whether all the given lists have equal length or not.\n#\n# $1 is a newline-separated, space-separated list\nget_equal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 22 33\\n44 55 66\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"1 2\\n3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if a string represents an integer or not.\n#\n# $1 is a string\ncheck_integer() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"12345\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n#\n# $1 is a space-separated list\ncount_reverse_pairs() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_reverse_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"julia best tseb for ailuj\") = \"2\" ]]\n    [[ $(candidate \"geeks best for skeeg\") = \"1\" ]]\n    [[ $(candidate \"makes best sekam for rof\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to move all zeroes to the end of the given list.\n#\n# $1 is a space-separated list\nmove_zero() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    move_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 0 2 0 3 4\") = \"1 2 3 4 0 0\" ]]\n    [[ $(candidate \"2 3 2 0 0 4 0 5 0\") = \"2 3 2 4 5 0 0 0 0\" ]]\n    [[ $(candidate \"0 1 0 1 1\") = \"1 1 1 0 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if given list contains no duplicates.\n#\n# $1 is a space-separated list\ncheck_distinct() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_distinct \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 5 6 1 4\") = \"false\" ]]\n    [[ $(candidate \"1 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 6\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given amount has no profit and no loss\n#\n# $1 is an integer\n# $2 is an integer\nnoprofit_noloss() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    noprofit_noloss \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"false\" ]]\n    [[ $(candidate \"100\" \"100\") = \"true\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all the words with k length in the given string.\n#\n# $1 is a string\n# $2 is an integer\nremove_length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The person is most value tet\" \"3\") = \"person is most value\" ]]\n    [[ $(candidate \"If you told me about this ok\" \"4\") = \"If you me about ok\" ]]\n    [[ $(candidate \"Forces of darkeness is come into the play\" \"4\") = \"Forces of darkeness is the\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count number of digits in a given string.\n#\n# $1 is a string\nnumber_ctr() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    number_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"program2bedone\") = \"1\" ]]\n    [[ $(candidate \"3wonders\") = \"1\" ]]\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"3wond-1ers2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the total number of characters in a string.\n#\n# $1 is a string\ncount_charac() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_charac \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"18\" ]]\n    [[ $(candidate \"language\") = \"8\" ]]\n    [[ $(candidate \"words\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n#\n# $1 is an integer\n# $2 is an integer\nget_total_number_of_sequences() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_total_number_of_sequences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"4\") = \"4\" ]]\n    [[ $(candidate \"5\" \"2\") = \"6\" ]]\n    [[ $(candidate \"16\" \"3\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n#\n# $1 is a space-separated list\n# $2 is an integer\nleft_insertion() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    left_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two numbers and returns a list with the second number and then the first number.\n#\n# $1 is an integer\n# $2 is an integer\nswap_numbers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    swap_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"20 10\" ]]\n    [[ $(candidate \"15\" \"17\") = \"17 15\" ]]\n    [[ $(candidate \"100\" \"200\") = \"200 100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nis_majority() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_majority \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 3 3 3 10\" \"7\" \"3\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 4 4 4 6 6\" \"8\" \"4\") = \"false\" ]]\n    [[ $(candidate \"1 1 1 2 2\" \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2\" \"5\" \"1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsubstract_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    substract_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5\" \"2 5 18\") = \"8 -1 -13\" ]]\n    [[ $(candidate \"11 2 3\" \"24 45 16\") = \"-13 -43 -13\" ]]\n    [[ $(candidate \"7 18 9\" \"10 11 12\") = \"-3 7 -3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to put spaces between words starting with capital letters in a given string.\n#\n# $1 is a string\ncapital_words_spaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    capital_words_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"PythonProgrammingExamples\") = \"Python Programming Examples\" ]]\n    [[ $(candidate \"GetReadyToBeCodingFreak\") = \"Get Ready To Be Coding Freak\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the average of cubes of first n natural numbers.\n#\n# $1 is an integer\nfind_Average_Of_Cube() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Average_Of_Cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4.5\" ]]\n    [[ $(candidate \"3\") = \"12\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth tetrahedral number.\n#\n# $1 is an integer\ntetrahedral_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tetrahedral_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"35\" ]]\n    [[ $(candidate \"6\") = \"56\" ]]\n    [[ $(candidate \"7\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate whether the matrix is a magic square.\n#\n# $1 is a newline-separated, space-separated list\nmagic_square_test() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    magic_square_test \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7 12 1 14\\n2 13 8 11\\n16 3 10 5\\n9 6 15 4\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 8\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove uppercase substrings from a given string.\n#\n# $1 is a string\nremove_uppercase() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"cAstyoUrFavoRitETVshoWs\") = \"cstyoravoitshos\" ]]\n    [[ $(candidate \"wAtchTheinTernEtrAdIo\") = \"wtchheinerntrdo\" ]]\n    [[ $(candidate \"VoicESeaRchAndreComMendaTionS\") = \"oiceachndreomendaion\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether an element exists within a tuple.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncheck_tuplex() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_tuplex \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"w 3 r e s o u r c e\" \"r\") = \"true\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"5\") = \"false\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"3\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate a dog's age in dog's years.\n#\n# $1 is an integer\ndog_age() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    dog_age \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"61\" ]]\n    [[ $(candidate \"15\") = \"73\" ]]\n    [[ $(candidate \"24\") = \"109\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the next perfect square greater than a given number.\n#\n# $1 is an integer\nnext_Perfect_Square() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    next_Perfect_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"35\") = \"36\" ]]\n    [[ $(candidate \"6\") = \"9\" ]]\n    [[ $(candidate \"9\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to convert a given string to uppercase.\n#\n# $1 is a string\nis_upper() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"person\") = \"PERSON\" ]]\n    [[ $(candidate \"final\") = \"FINAL\" ]]\n    [[ $(candidate \"Valid\") = \"VALID\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n#\n# $1 is a string\n# $2 is an integer\nodd_Equivalent() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    odd_Equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"011001\" \"6\") = \"3\" ]]\n    [[ $(candidate \"11011\" \"5\") = \"4\" ]]\n    [[ $(candidate \"1010\" \"4\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n#\n# $1 is a space-separated list\n# $2 is an integer\nre_arrange_array() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    re_arrange_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 2 -3 4 5 6 -7 8 9\" \"9\") = \"-1 -3 -7 4 5 6 2 8 9\" ]]\n    [[ $(candidate \"12 -14 -26 13 15\" \"5\") = \"-14 -26 12 13 15\" ]]\n    [[ $(candidate \"10 24 36 -42 -39 -78 85\" \"7\") = \"-42 -39 -78 10 24 36 85\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether a list of numbers contains only one distinct element or not.\n#\n# $1 is a space-separated list\nunique_Element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract values between quotation marks from a string.\n#\n# $1 is a string\nextract_values() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_values \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") = \"Python PHP Java\" ]]\n    [[ $(candidate \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") = \"python program language\" ]]\n    [[ $(candidate \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") = \"red blue green yellow\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count true booleans in the given list.\n#\n# $1 is a space-separated list\ncount() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"true false true\") = \"2\" ]]\n    [[ $(candidate \"false false\") = \"0\" ]]\n    [[ $(candidate \"true true true\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that counts the number of pairs of integers in a list that xor to an even number.\n#\n# $1 is a space-separated list\nfind_even_pair() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_even_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\") = \"4\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\") = \"9\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is armstrong or not.\n#\n# $1 is an integer\narmstrong_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    armstrong_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"153\") = \"true\" ]]\n    [[ $(candidate \"259\") = \"false\" ]]\n    [[ $(candidate \"4458\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the upper case characters in a given string.\n#\n# $1 is a string\nupper_ctr() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    upper_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYthon\") = \"1\" ]]\n    [[ $(candidate \"BigData\") = \"1\" ]]\n    [[ $(candidate \"program\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract the elementwise and tuples from the given two tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nand_tuples() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    and_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"0 0 2 1\" ]]\n    [[ $(candidate \"1 2 3 4\" \"5 6 7 8\") = \"1 2 3 0\" ]]\n    [[ $(candidate \"8 9 11 12\" \"7 13 14 17\") = \"0 9 10 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether it follows the sequence given in the patterns array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_samepatterns() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_samepatterns \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red green green\" \"a b b\") = \"true\" ]]\n    [[ $(candidate \"red green greenn\" \"a b b\") = \"false\" ]]\n    [[ $(candidate \"red green greenn\" \"a b\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of lists in a given number of lists.\n#\n# $1 is a newline-separated, space-separated list\ncount_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n9 11\\n13 15 17\") = \"4\" ]]\n    [[ $(candidate \"1 2\\n2 3\\n4 5\") = \"3\" ]]\n    [[ $(candidate \"1 0\\n2 0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n#\n# $1 is a newline-separated, space-separated list\naverage_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    average_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 12\\n30 45 56 45\\n81 80 39 32\\n1 2 3 4\") = \"30.5 34.25 27.0 23.25\" ]]\n    [[ $(candidate \"1 1 -5\\n30 -15 56\\n81 -60 -39\\n-10 2 3\") = \"25.5 -18.0 3.75\" ]]\n    [[ $(candidate \"100 100 100 120\\n300 450 560 450\\n810 800 390 320\\n10 20 30 40\") = \"305.0 342.5 270.0 232.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nlcs_of_three() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    lcs_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") = \"2\" ]]\n    [[ $(candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") = \"5\" ]]\n    [[ $(candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n'th star number.\n#\n# $1 is an integer\nfind_star_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_star_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"37\" ]]\n    [[ $(candidate \"4\") = \"73\" ]]\n    [[ $(candidate \"5\") = \"121\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of an array.\n#\n# $1 is a space-separated list\n_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    _sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"15 12 13 10\") = \"50\" ]]\n    [[ $(candidate \"0 1 2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given list contains consecutive numbers or not.\n#\n# $1 is a space-separated list\ncheck_Consecutive() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_Consecutive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the first adverb and their positions in a given sentence.\n#\n# $1 is a string\nfind_adverb_position() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_adverb_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"clearly\\!\\! we can see the sky\") = \"0 7 clearly\" ]]\n    [[ $(candidate \"seriously\\!\\! there are many roses\") = \"0 9 seriously\" ]]\n    [[ $(candidate \"unfortunately\\!\\! sita is going to home\") = \"0 13 unfortunately\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n#\n# $1 is a space-separated list\n# $2 is an integer\nrotate_right() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rotate_right \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"3\") = \"8 9 10 1 2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"9 10 1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5\") = \"6 7 8 9 10 1 2 3 4 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of non-empty substrings of a given string.\n#\n# $1 is a string\nnumber_of_substrings() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    number_of_substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"6\" ]]\n    [[ $(candidate \"abcd\") = \"10\" ]]\n    [[ $(candidate \"abcde\") = \"15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlist_split() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    list_split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b c d e f g h i j k l m n\" \"3\") = \"a d g j m\\nb e h k n\\nc f i l\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11 12 13 14\" \"3\") = \"1 4 7 10 13\\n2 5 8 11 14\\n3 6 9 12\" ]]\n    [[ $(candidate \"python java C C++ DBMS SQL\" \"2\") = \"python C DBMS\\njava C++ SQL\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check if the elements of a given list are unique or not.\n#\n# $1 is a space-separated list\nall_unique() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to convert complex numbers to polar coordinates.\n#\n# $1 is an integer\nconvert() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    convert \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"4\") = \"4.0 0.0\" ]]\n    [[ $(candidate \"5\") = \"5.0 0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to convert the given string to lower case.\n#\n# $1 is a string\nis_lower() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_lower \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"InValid\") = \"invalid\" ]]\n    [[ $(candidate \"TruE\") = \"true\" ]]\n    [[ $(candidate \"SenTenCE\") = \"sentence\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the smallest power of 2 greater than or equal to n.\n#\n# $1 is an integer\nnext_power_of_2() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    next_power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"5\") = \"8\" ]]\n    [[ $(candidate \"17\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if a string is present as a substring in a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is a string\nfind_substring() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red black white green orange\" \"ack\") = \"true\" ]]\n    [[ $(candidate \"red black white green orange\" \"abc\") = \"false\" ]]\n    [[ $(candidate \"red black white green orange\" \"ange\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace characters in a string.\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nreplace_char() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"polygon\" \"y\" \"l\") = \"pollgon\" ]]\n    [[ $(candidate \"character\" \"c\" \"a\") = \"aharaater\" ]]\n    [[ $(candidate \"python\" \"l\" \"a\") = \"python\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the product of first even and odd number of a given list.\n#\n# $1 is a space-separated list\nmul_even_odd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    mul_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a list to a tuple.\n#\n# $1 is a space-separated list\nlist_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    list_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 10 7 4 15 3\") = \"5 10 7 4 15 3\" ]]\n    [[ $(candidate \"2 4 5 6 2 3 4 4 7\") = \"2 4 5 6 2 3 4 4 7\" ]]\n    [[ $(candidate \"58 44 56\") = \"58 44 56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n#\n# $1 is an integer\neven_binomial_Coeff_Sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_binomial_Coeff_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"8\" ]]\n    [[ $(candidate \"6\") = \"32\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform the mathematical bitwise xor operation across the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nbitwise_xor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    bitwise_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"15 6 5 10\" ]]\n    [[ $(candidate \"11 5 7 10\" \"6 3 4 4\") = \"13 6 3 14\" ]]\n    [[ $(candidate \"12 6 8 11\" \"7 4 5 6\") = \"11 2 13 13\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether a list is sublist of another or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_Sub_Array() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_Sub_Array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 5\" \"1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\" \"1 2 1\") = \"true\" ]]\n    [[ $(candidate \"1 0 2 2\" \"2 2 0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nmax_sub_array_sum_repeated() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_sub_array_sum_repeated \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 -30 -1\" \"4\" \"3\") = \"30\" ]]\n    [[ $(candidate \"-1 10 20\" \"3\" \"2\") = \"59\" ]]\n    [[ $(candidate \"-1 -2 -3\" \"3\" \"3\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the minimum product from the pairs of tuples within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmin_product_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"8\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"30\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n#\n# $1 is an integer\ncount_divisors() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_divisors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"100\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n#\n# $1 is an integer\ntriangle_area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1\") = \"None\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"2\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a given string to a list of characters.\n#\n# $1 is a string\nstring_to_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    string_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python 3.0\") = \"p y t h o n 3 . 0\" ]]\n    [[ $(candidate \"item1\") = \"i t e m 1\" ]]\n    [[ $(candidate \"15.10\") = \"1 5 . 1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n#\n# $1 is a string\nfind_length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11000010001\") = \"6\" ]]\n    [[ $(candidate \"10111\") = \"1\" ]]\n    [[ $(candidate \"11011101100101\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n#\n# $1 is an integer\ncount_Primes_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_Primes_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"4\" ]]\n    [[ $(candidate \"100\") = \"25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the product of consecutive binomial co-efficients.\n#\n# $1 is an integer\nsum_Of_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_Of_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15\" ]]\n    [[ $(candidate \"4\") = \"56\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\ncomb_sort() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    comb_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 15 37 25 79\") = \"5 15 25 37 79\" ]]\n    [[ $(candidate \"41 32 15 19 22\") = \"15 19 22 32 41\" ]]\n    [[ $(candidate \"99 15 13 47\") = \"13 15 47 99\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n#\n# $1 is a string\ncheck_expression() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_expression \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"{()}[{}]\") = \"true\" ]]\n    [[ $(candidate \"{()}[{]\") = \"false\" ]]\n    [[ $(candidate \"{()}[{}][]({})\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a word containing 'z'.\n#\n# $1 is a string\ntext_match_wordz() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_wordz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonz.\") = \"true\" ]]\n    [[ $(candidate \"xyz.\") = \"true\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsum_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30\" \"15 25 35\") = \"25 45 65\" ]]\n    [[ $(candidate \"1 2 3\" \"5 6 7\") = \"6 8 10\" ]]\n    [[ $(candidate \"15 20 30\" \"15 45 75\") = \"30 65 105\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n#\n# $1 is an integer\nnewman_prime() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    newman_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"7\" ]]\n    [[ $(candidate \"4\") = \"17\" ]]\n    [[ $(candidate \"5\") = \"41\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to apply a given format string to all of the elements in a list.\n#\n# $1 is a space-separated list\n# $2 is a string\nadd_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"temp{0}\") = \"temp1 temp2 temp3 temp4\" ]]\n    [[ $(candidate \"a b c d\" \"python{0}\") = \"pythona pythonb pythonc pythond\" ]]\n    [[ $(candidate \"5 6 7 8\" \"string{0}\") = \"string5 string6 string7 string8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the surface area of a square pyramid with a given base edge and height.\n#\n# $1 is an integer\n# $2 is an integer\nsurface_Area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    surface_Area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"33\" ]]\n    [[ $(candidate \"4\" \"5\") = \"56\" ]]\n    [[ $(candidate \"1\" \"2\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the length of the smallest list in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min_Length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Find_Min_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\") = \"1\" ]]\n    [[ $(candidate \"1 2\\n1 2 3\\n1 2 3 4\") = \"2\" ]]\n    [[ $(candidate \"3 3 3\\n4 4 4 4\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n#\n# $1 is an integer\nvalidate() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    validate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1234\") = \"true\" ]]\n    [[ $(candidate \"51241\") = \"false\" ]]\n    [[ $(candidate \"321\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth hexagonal number.\n#\n# $1 is an integer\nhexagonal_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    hexagonal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"190\" ]]\n    [[ $(candidate \"5\") = \"45\" ]]\n    [[ $(candidate \"7\") = \"91\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n'th lucas number.\n#\n# $1 is an integer\nfind_lucas() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_lucas \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"76\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"3\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to get the difference between two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nDiff() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 15 20 25 30 35 40\" \"25 40 35\") = \"10 20 30 15\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 1\") = \"2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3\" \"6 7 1\") = \"2 3 6 7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to flatten a list and sum all of its elements.\n#\n# $1 is a newline-separated, space-separated list\nrecursive_list_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    recursive_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"7 10 15 14 19 41\") = \"106\" ]]\n    [[ $(candidate \"10 20 30 40 50 60\") = \"210\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the two numbers differ at one bit position only or not.\n#\n# $1 is an integer\n# $2 is an integer\ndiffer_At_One_Bit_Pos() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    differ_At_One_Bit_Pos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\" \"9\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2\" \"3\") = \"true\" ]]\n    [[ $(candidate \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by three 'b'.\n#\n# $1 is a string\ntext_match_three() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"caacabbbba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n#\n# $1 is a space-separated list\nmax_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 100 4 5 150 6\") = \"3000\" ]]\n    [[ $(candidate \"4 42 55 68 80\") = \"50265600\" ]]\n    [[ $(candidate \"10 22 9 33 21 50 41 60\") = \"2460\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to split a list at the nth eelment and add the first part to the end.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_Arr() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split_Arr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 10 5 6 52 36\" \"2\") = \"5 6 52 36 12 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1\") = \"2 3 4 1\" ]]\n    [[ $(candidate \"0 1 2 3 4 5 6 7\" \"3\") = \"3 4 5 6 7 0 1 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the number of divisors of a given integer.\n#\n# $1 is an integer\ndivisor() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"6\" ]]\n    [[ $(candidate \"9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the difference between largest and smallest value in a given list.\n#\n# $1 is a space-separated list\nbig_diff() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    big_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"4 5 12\") = \"8\" ]]\n    [[ $(candidate \"9 2 3\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find squares of individual elements in a list.\n#\n# $1 is a space-separated list\nsquare_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    square_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\") = \"100 400 900\" ]]\n    [[ $(candidate \"12 15\") = \"144 225\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given tuple has any none value or not.\n#\n# $1 is a $Any\ncheck_none() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_none \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 None\") = \"true\" ]]\n    [[ $(candidate \"7 8 9 11 14\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 None\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given array is monotonic or not.\n#\n# $1 is a space-separated list\nis_Monotonic() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_Monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 5 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 3 2\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n#\n# $1 is an integer\nis_perfect_square() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_perfect_square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"36\") = \"true\" ]]\n    [[ $(candidate \"14\") = \"false\" ]]\n    [[ $(candidate \"196\") = \"true\" ]]\n    [[ $(candidate \"125\") = \"false\" ]]\n    [[ $(candidate \"15625\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of common divisors of two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nsum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"15\") = \"6\" ]]\n    [[ $(candidate \"100\" \"150\") = \"93\" ]]\n    [[ $(candidate \"4\" \"6\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the list of maximum length in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nmax_length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1\\n5 7\\n10 12 14 15\") = \"4 10 12 14 15\" ]]\n    [[ $(candidate \"5\\n15 20 25\") = \"3 15 20 25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the directrix of a parabola.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nparabola_directrix() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    parabola_directrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\" \"2\") = \"-198\" ]]\n    [[ $(candidate \"9\" \"8\" \"4\") = \"-2336\" ]]\n    [[ $(candidate \"2\" \"4\" \"6\") = \"-130\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n#\n# $1 is a string\n# $2 is a string\noccurance_substring() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    occurance_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming, python language\" \"python\") = \"python 0 6\" ]]\n    [[ $(candidate \"python programming,programming language\" \"programming\") = \"programming 7 18\" ]]\n    [[ $(candidate \"python programming,programming language\" \"language\") = \"language 31 39\" ]]\n    [[ $(candidate \"c++ programming, c++ language\" \"python\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove tuples from the given tuple.\n#\n# $1 is a $Any\nremove_nested() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"1 5 7 10\" ]]\n    [[ $(candidate \"2 6 8 5 7 11\") = \"2 6 8 11\" ]]\n    [[ $(candidate \"3 7 9 6 8 12\") = \"3 7 9 12\" ]]\n    [[ $(candidate \"3 7 9 6 8 5 12 12\") = \"3 7 9 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n#\n# $1 is a space-separated list\n# $2 is an integer\nremove_kth_element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 3 4 4 5 1\" ]]\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\" \"4\") = \"0 0 1 3 4 4 5 6 6 6 7 8 9 4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\" \"5\") = \"10 10 15 19 18 17 26 26 17 18 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to add a dictionary to the tuple. The output should be a tuple.\n#\n# $1 is a space-separated list\n# $2 is a two column CSV in key,value order\nadd_dict_to_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_dict_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"MSAM,1\\nis,2\\nbest,3\") = \"4 5 6 MSAM,1\\nis,2\\nbest,3\" ]]\n    [[ $(candidate \"1 2 3\" \"UTS,2\\nis,3\\nWorst,4\") = \"1 2 3 UTS,2\\nis,3\\nWorst,4\" ]]\n    [[ $(candidate \"8 9 10\" \"POS,3\\nis,4\\nOkay,5\") = \"8 9 10 POS,3\\nis,4\\nOkay,5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n#\n# $1 is an integer\n# $2 is an integer\nfind() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"3\") = \"3\" ]]\n    [[ $(candidate \"4\" \"2\") = \"2\" ]]\n    [[ $(candidate \"20\" \"5\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n#\n# $1 is a string\ntext_match_two_three() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_two_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the occurence of all elements of list in a tuple.\n#\n# $1 is a $Any\n# $2 is a space-separated list\ncount_Occurrence() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_Occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a a c b d\" \"a b\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 1 4 6 7 1 4\" \"1 4 7\") = \"6\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"1 2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count number items that are identical in the same position of three given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ncount_samepair() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_samepair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\" \"2 1 3 1 2 6 7 9\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 2 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by one or more b's.\n#\n# $1 is a string\ntext_match_one() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n#\n# $1 is an integer\ndifference() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"30\" ]]\n    [[ $(candidate \"5\") = \"210\" ]]\n    [[ $(candidate \"2\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to toggle the case of all characters in a string.\n#\n# $1 is a string\ntoggle_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    toggle_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"pYTHON\" ]]\n    [[ $(candidate \"Pangram\") = \"pANGRAM\" ]]\n    [[ $(candidate \"LIttLE\") = \"liTTle\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the element of a list having maximum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Find_Max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\\nA B\\nA B C\") = \"A B C\" ]]\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"1 1\\n1 2 3\\n1 5 6 1\") = \"1 5 6 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the Eulerian number a(n, m).\n#\n# $1 is an integer\n# $2 is an integer\neulerian_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    eulerian_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"1\") = \"4\" ]]\n    [[ $(candidate \"4\" \"1\") = \"11\" ]]\n    [[ $(candidate \"5\" \"3\") = \"26\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of occurrences of a number in a given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfrequency() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    frequency \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 2 3 3 3 4\" \"3\") = \"3\" ]]\n    [[ $(candidate \"0 1 2 3 1 2\" \"1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n#\n# $1 is an integer\ngeometric_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    geometric_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"1.9921875\" ]]\n    [[ $(candidate \"4\") = \"1.9375\" ]]\n    [[ $(candidate \"8\") = \"1.99609375\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n#\n# $1 is an integer\n# $2 is an integer\ndivisible_by_digits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    divisible_by_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"22\") = \"1 2 3 4 5 6 7 8 9 11 12 15 22\" ]]\n    [[ $(candidate \"1\" \"15\") = \"1 2 3 4 5 6 7 8 9 11 12 15\" ]]\n    [[ $(candidate \"20\" \"25\") = \"22 24\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to calculate the product of the unique numbers in a given list.\n#\n# $1 is a space-separated list\nunique_product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    unique_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30 40 20 50 60 40\") = \"720000000\" ]]\n    [[ $(candidate \"1 2 3 1\") = \"6\" ]]\n    [[ $(candidate \"7 8 9 0 1 1\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the largest negative number from the given list.\n#\n# $1 is a space-separated list\nlargest_neg() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    largest_neg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 -4 -6\") = \"-6\" ]]\n    [[ $(candidate \"1 2 3 -8 -9\") = \"-9\" ]]\n    [[ $(candidate \"1 2 3 4 -1\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove consecutive duplicates of a given list.\n#\n# $1 is a space-separated list\nconsecutive_duplicates() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 1 2 3 4 5 6 7 8 9 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 15 19 18 17 26 17 18 10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a b c d\" ]]\n    [[ $(candidate \"a a b c d d a a\") = \"a b c d a\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmin_Jumps() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_Jumps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\" \"11\") = \"3.5\" ]]\n    [[ $(candidate \"3 4\" \"0\") = \"0\" ]]\n    [[ $(candidate \"11 14\" \"11\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find a pair with highest product from a given array of integers.\n#\n# $1 is a space-separated list\nmax_Product() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_Product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 7 0 8 4\") = \"7 8\" ]]\n    [[ $(candidate \"0 -1 -2 -4 5 0 -6\") = \"-4 -6\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth nonagonal number.\n#\n# $1 is an integer\nis_nonagonal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_nonagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"325\" ]]\n    [[ $(candidate \"15\") = \"750\" ]]\n    [[ $(candidate \"18\") = \"1089\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the maximum difference between any two elements in a given array.\n#\n# $1 is a space-separated list\nmax_Abs_Diff() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_Abs_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 3\") = \"4\" ]]\n    [[ $(candidate \"9 3 2 5 1\") = \"8\" ]]\n    [[ $(candidate \"3 2 1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to pack consecutive duplicates of a given list elements into sublists.\n#\n# $1 is a space-separated list\npack_consecutive_duplicates() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pack_consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 0\\n1\\n2\\n3\\n4 4\\n5\\n6 6 6\\n7\\n8\\n9\\n4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 10\\n15\\n19\\n18 18\\n17\\n26 26\\n17\\n18\\n10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a a\\nb\\nc\\nd d\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of perrin numbers.\n#\n# $1 is an integer\ncal_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    cal_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"49\" ]]\n    [[ $(candidate \"10\") = \"66\" ]]\n    [[ $(candidate \"11\") = \"88\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to remove the characters which have odd index values of a given string.\n#\n# $1 is a string\nodd_values_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    odd_values_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcdef\") = \"ace\" ]]\n    [[ $(candidate \"python\") = \"pto\" ]]\n    [[ $(candidate \"data\") = \"dt\" ]]\n    [[ $(candidate \"lambs\") = \"lms\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find kth element from the given two sorted arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nfind_kth() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_kth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 6 7 9\" \"1 4 8 10\" \"5\") = \"6\" ]]\n    [[ $(candidate \"100 112 256 349 770\" \"72 86 113 119 265 445 892\" \"7\") = \"256\" ]]\n    [[ $(candidate \"3 4 7 8 10\" \"2 5 9 11\" \"6\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n#\n# $1 is an integer\njacobsthal_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    jacobsthal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"11\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"5\" ]]\n    [[ $(candidate \"13\") = \"2731\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n#\n# $1 is a newline-separated, space-separated list\nfrequency_lists() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    frequency_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2\\n4 5 6 2\\n7 8 9 5\") = \"1,1\\n2,3\\n3,1\\n4,1\\n5,2\\n6,1\\n7,1\\n8,1\\n9,1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\") = \"1,1\\n2,1\\n3,1\\n4,1\\n5,1\\n6,1\\n7,1\\n8,1\\n9,1\\n10,1\\n11,1\\n12,1\" ]]\n    [[ $(candidate \"20 30 40 17\\n18 16 14 13\\n10 20 30 40\") = \"20,2\\n30,2\\n40,2\\n17,1\\n18,1\\n16,1\\n14,1\\n13,1\\n10,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find perfect squares between two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nperfect_squares() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    perfect_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"30\") = \"1 4 9 16 25\" ]]\n    [[ $(candidate \"50\" \"100\") = \"64 81 100\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100 121 144 169 196\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n#\n# $1 is a space-separated list\nsum_Of_Subarray_Prod() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_Of_Subarray_Prod \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"20\" ]]\n    [[ $(candidate \"1 2\") = \"5\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the first odd number in a given list of numbers.\n#\n# $1 is a space-separated list\nfirst_odd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    first_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5\") = \"1\" ]]\n    [[ $(candidate \"2 4 1 3\") = \"1\" ]]\n    [[ $(candidate \"8 9 1\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform index wise addition of list elements in the given two nested lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nadd_nested_tuples() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_nested_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"7 10\\n7 14\\n3 10\\n8 13\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"9 12\\n9 16\\n5 12\\n10 15\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"11 14\\n11 18\\n7 14\\n12 17\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n#\n# $1 is a newline-separated, space-separated list\nmerge() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    merge \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\na b\\nm n\") = \"x a m\\ny b n\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\\n7 8\") = \"1 3 5 7\\n2 4 6 8\" ]]\n    [[ $(candidate \"x y z\\na b c\\nm n o\") = \"x a m\\ny b n\\nz c o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number can be represented as the difference of two squares or not.\n#\n# $1 is an integer\ndif_Square() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    dif_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"15\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncheck_smaller() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_smaller \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"2 3 4\") = \"false\" ]]\n    [[ $(candidate \"4 5 6\" \"3 4 5\") = \"true\" ]]\n    [[ $(candidate \"11 12 13\" \"10 11 12\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n#\n# $1 is a space-separated list\nfreq_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    freq_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 10 20 20 20 20 40 40 50 50 30\") = \"10,4\\n20,4\\n40,2\\n50,2\\n30,1\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 4 1 3 1 4\") = \"1,3\\n2,2\\n3,3\\n4,3\" ]]\n    [[ $(candidate \"5 6 7 4 9 10 4 5 6 7 9 5\") = \"10,1\\n5,3\\n6,2\\n7,2\\n4,2\\n9,2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nrgb_to_hsv() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rgb_to_hsv \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"255\" \"255\" \"255\") = \"0.0 0.0 100.0\" ]]\n    [[ $(candidate \"0\" \"215\" \"0\") = \"120.0 100.0 84.31372549019608\" ]]\n    [[ $(candidate \"10\" \"215\" \"110\") = \"149.26829268292684 95.34883720930233 84.31372549019608\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to flatten a given nested list structure.\n#\n# $1 is a newline-separated, space-separated list\nflatten_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    flatten_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 10 20 30 40 50 60 70 80 90 100 110 120\") = \"0 10 20 30 40 50 60 70 80 90 100 110 120\" ]]\n    [[ $(candidate \"10 20\\n40\\n30 56 25\\n10 20\\n33\\n40\") = \"10 20 40 30 56 25 10 20 33 40\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"1 2 3 4 5 6 10 11 12 7 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given string is starting with a vowel or not using regex.\n#\n# $1 is a string\ncheck_str() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_str \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"annie\") = \"true\" ]]\n    [[ $(candidate \"dawood\") = \"false\" ]]\n    [[ $(candidate \"Else\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n#\n# $1 is an integer\ncheck_monthnumber_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_monthnumber_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort the given list.\n#\n# $1 is a space-separated list\nheap_sort() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    heap_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 2 4 6 8 0\") = \"0 1 2 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 25 58\") = \"14 22 25 25 35 58 65 75 85\" ]]\n    [[ $(candidate \"7 1 9 5\") = \"1 5 7 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nk_smallest_pairs() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    k_smallest_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"2\") = \"1 2\\n1 4\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"1\") = \"1 2\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"7\") = \"1 2\\n1 4\\n3 2\\n1 6\\n3 4\\n3 6\\n7 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_solution() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"7\") = \"2 1\" ]]\n    [[ $(candidate \"4\" \"2\" \"7\") = \"None\" ]]\n    [[ $(candidate \"1\" \"13\" \"17\") = \"4 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the largest number that can be formed with the given list of digits.\n#\n# $1 is a space-separated list\nfind_Max_Num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Max_Num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"321\" ]]\n    [[ $(candidate \"4 5 6 1\") = \"6541\" ]]\n    [[ $(candidate \"1 2 3 9\") = \"9321\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns the list in a list of lists whose sum of elements is the highest.\n#\n# $1 is a newline-separated, space-separated list\nmax_sum_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"10 11 12\" ]]\n    [[ $(candidate \"3 2 1\\n6 5 4\\n12 11 10\") = \"12 11 10\" ]]\n    [[ $(candidate \"2 3 1\") = \"2 3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to interchange the first and last elements in a list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 35 9 56 24\") = \"24 35 9 56 12\" ]]\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median of two sorted lists of same size.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nget_median() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 12 15 26 38\" \"2 13 17 30 45\" \"5\") = \"16.0\" ]]\n    [[ $(candidate \"2 4 8 9\" \"7 13 19 28\" \"4\") = \"8.5\" ]]\n    [[ $(candidate \"3 6 14 23 36 42\" \"2 18 27 39 49 55\" \"6\") = \"25.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace whitespaces with an underscore and vice versa in a given string.\n#\n# $1 is a string\nreplace_spaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jumanji The Jungle\") = \"Jumanji_The_Jungle\" ]]\n    [[ $(candidate \"The_Avengers\") = \"The Avengers\" ]]\n    [[ $(candidate \"Fast and Furious\") = \"Fast_and_Furious\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to determine if the sum of the divisors of two integers are the same.\n#\n# $1 is an integer\n# $2 is an integer\nare_equivalent() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    are_equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"36\" \"57\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"23\" \"47\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to reverse each string in a given list of string values.\n#\n# $1 is a space-separated list\nreverse_string_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    reverse_string_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue White Black\") = \"deR neerG eulB etihW kcalB\" ]]\n    [[ $(candidate \"john amal joel george\") = \"nhoj lama leoj egroeg\" ]]\n    [[ $(candidate \"jack john mary\") = \"kcaj nhoj yram\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to compute the sum of digits of each number of a given list.\n#\n# $1 is a space-separated list\nsum_of_digits() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_of_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 2 56\") = \"14\" ]]\n    [[ $(candidate \"10 20 4 5 b 70 a\") = \"19\" ]]\n    [[ $(candidate \"10 20 -4 5 -70\") = \"19\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth number in the newman conway sequence.\n#\n# $1 is an integer\nsequence() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"6\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nheap_queue_largest() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    heap_queue_largest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"3\") = \"85 75 65\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"2\") = \"85 75\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"5\") = \"85 75 65 58 35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n#\n# $1 is an integer\n# $2 is an integer\nloss_amount() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    loss_amount \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"0\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"3000\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the union of the elements of two given lists and output them in sorted order.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nunion_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    union_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 4 5 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"3 4 5 6\") = \"1 2 3 4 5 6\" ]]\n    [[ $(candidate \"11 12 13 14\" \"13 15 16 17\") = \"11 12 13 14 15 16 17\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the length of the longest sublists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max_Length() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Find_Max_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 4\\n5 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"0 1\\n2 2\\n3 2 1\") = \"3\" ]]\n    [[ $(candidate \"7\\n22 23\\n13 14 15\\n10 20 30 40 50\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find whether the parity of a given number is odd.\n#\n# $1 is an integer\nfind_Parity() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Parity \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"false\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median length of a trapezium.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_trapezium() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    median_trapezium \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\" \"25\" \"35\") = \"20\" ]]\n    [[ $(candidate \"10\" \"20\" \"30\") = \"15\" ]]\n    [[ $(candidate \"6\" \"9\" \"4\") = \"7.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find nth centered hexagonal number.\n#\n# $1 is an integer\ncentered_hexagonal_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    centered_hexagonal_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"271\" ]]\n    [[ $(candidate \"2\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"217\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find number of lists present in the given list.\n#\n# $1 is a space-separated list\nfind_lists() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\") = \"2\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"9 8 7 6 5 4 3 2 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n#\n# $1 is an integer\nget_max_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"60\") = \"106\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the length of the longest word.\n#\n# $1 is a space-separated list\nlen_log() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    len_log \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python PHP bigdata\") = \"7\" ]]\n    [[ $(candidate \"a ab abc\") = \"3\" ]]\n    [[ $(candidate \"small big tall\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n#\n# $1 is an integer\n# $2 is an integer\nsector_area() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sector_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"45\") = \"6.283185307179586\" ]]\n    [[ $(candidate \"9\" \"45\") = \"31.808625617596654\" ]]\n    [[ $(candidate \"9\" \"361\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether every odd index contains odd numbers of a given list.\n#\n# $1 is a space-separated list\nodd_position() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    odd_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 4 3 6 7 6 3\") = \"true\" ]]\n    [[ $(candidate \"4 1 2\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to join a list of multiple integers into a single integer.\n#\n# $1 is a space-separated list\nmultiple_to_single() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiple_to_single \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 33 50\") = \"113350\" ]]\n    [[ $(candidate \"-1 2 3 4 5 6\") = \"-123456\" ]]\n    [[ $(candidate \"10 15 20 25\") = \"10152025\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find whether a number is divisible by 11.\n#\n# $1 is an integer\nis_Diff() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12345\") = \"false\" ]]\n    [[ $(candidate \"1212112\") = \"true\" ]]\n    [[ $(candidate \"1212\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform index wise multiplication of list elements in the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nindex_multiplication() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    index_multiplication \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 21\\n12 45\\n2 9\\n7 30\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"14 32\\n20 60\\n6 20\\n16 44\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"24 45\\n30 77\\n12 33\\n27 60\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert tuple string to integer tuple.\n#\n# $1 is a string\ntuple_str_int() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tuple_str_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(7, 8, 9)\") = \"7 8 9\" ]]\n    [[ $(candidate \"(1, 2, 3)\") = \"1 2 3\" ]]\n    [[ $(candidate \"(4, 5, 6)\") = \"4 5 6\" ]]\n    [[ $(candidate \"(7, 81, 19)\") = \"7 81 19\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sum all amicable numbers from 1 to a specified number.\n#\n# $1 is an integer\namicable_numbers_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    amicable_numbers_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"999\") = \"504\" ]]\n    [[ $(candidate \"9999\") = \"31626\" ]]\n    [[ $(candidate \"99\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove odd characters in a string.\n#\n# $1 is a string\nremove_odd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"yhn\" ]]\n    [[ $(candidate \"program\") = \"rga\" ]]\n    [[ $(candidate \"language\") = \"agae\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n#\n# $1 is a space-separated list\nmultiply_elements() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiply_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"5 35 56 80\" ]]\n    [[ $(candidate \"2 4 5 6 7\") = \"8 20 30 42\" ]]\n    [[ $(candidate \"12 13 14 9 15\") = \"156 182 126 135\" ]]\n    [[ $(candidate \"12\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n#\n# $1 is a space-separated list\ncount_rotation() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_rotation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"1\" ]]\n    [[ $(candidate \"4 5 1 2 3\") = \"2\" ]]\n    [[ $(candidate \"7 8 9 1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 2 3\") = \"0\" ]]\n    [[ $(candidate \"1 3 2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract the number of unique tuples in the given list.\n#\n# $1 is a newline-separated, space-separated list\nextract_freq() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_freq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 2\\n4 3\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"4 15\\n2 3\\n5 4\\n6 7\") = \"4\" ]]\n    [[ $(candidate \"5 16\\n2 3\\n6 5\\n6 9\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncount_same_pair() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_same_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"11\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"1\" ]]\n    [[ $(candidate \"0 1 1 2\" \"0 1 2 2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the value of 'a' to the power 'b'.\n#\n# $1 is an integer\n# $2 is an integer\npower() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"81\" ]]\n    [[ $(candidate \"2\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"5\") = \"3125\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write function to find the sum of all items in the given dictionary.\n#\n# $1 is a two column CSV in key,value order\nreturn_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    return_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a,100\\nb,200\\nc,300\") = \"600\" ]]\n    [[ $(candidate \"a,25\\nb,18\\nc,45\") = \"88\" ]]\n    [[ $(candidate \"a,36\\nb,39\\nc,49\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to return a list of all pairs of consecutive items in a given list.\n#\n# $1 is a space-separated list\npair_wise() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pair_wise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 3 4 4 5\") = \"1 1\\n1 2\\n2 3\\n3 3\\n3 4\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"1 5\\n5 7\\n7 9\\n9 10\" ]]\n    [[ $(candidate \"5 1 9 7 10\") = \"5 1\\n1 9\\n9 7\\n7 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 2\\n2 3\\n3 4\\n4 5\\n5 6\\n6 7\\n7 8\\n8 9\\n9 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to split a string into characters.\n#\n# $1 is a string\nsplit() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"p y t h o n\" ]]\n    [[ $(candidate \"Name\") = \"N a m e\" ]]\n    [[ $(candidate \"program\") = \"p r o g r a m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find minimum of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmin_of_three() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\" \"0\") = \"0\" ]]\n    [[ $(candidate \"19\" \"15\" \"18\") = \"15\" ]]\n    [[ $(candidate \"-10\" \"-20\" \"-30\") = \"-30\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n#\n# $1 is an integer\nis_Sum_Of_Powers_Of_Two() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_Sum_Of_Powers_Of_Two \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"false\" ]]\n    [[ $(candidate \"14\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n#\n# $1 is a string\nget_Char() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_Char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"f\" ]]\n    [[ $(candidate \"gfg\") = \"t\" ]]\n    [[ $(candidate \"ab\") = \"c\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to return the sum of all divisors of a number.\n#\n# $1 is an integer\nsum_div() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_div \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"7\" ]]\n    [[ $(candidate \"12\") = \"16\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function that returns the number of integer elements in a given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_integer() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 abc 1.2\") = \"2\" ]]\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1.2 4 5.1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to remove duplicate numbers from a given number of lists.\n#\n# $1 is a space-separated list\ntwo_unique_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    two_unique_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2 3 4 5\") = \"1 4 5\" ]]\n    [[ $(candidate \"1 2 3 2 4 5\") = \"1 3 4 5\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 2 3 4 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find whether a given array of integers contains any duplicate element.\n#\n# $1 is a space-separated list\ntest_duplicate() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    test_duplicate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2 3 3 4 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which returns nth catalan number.\n#\n# $1 is an integer\ncatalan_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    catalan_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"16796\" ]]\n    [[ $(candidate \"9\") = \"4862\" ]]\n    [[ $(candidate \"7\") = \"429\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n#\n# $1 is an integer\n# $2 is an integer\npower_base_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    power_base_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"100\") = \"115\" ]]\n    [[ $(candidate \"8\" \"10\") = \"37\" ]]\n    [[ $(candidate \"8\" \"15\") = \"62\" ]]\n    [[ $(candidate \"3\" \"3\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nreplace_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 2 4 6 8\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8\") = \"1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"red blue green\" \"yellow\") = \"red blue yellow\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth octagonal number.\n#\n# $1 is an integer\nis_octagonal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_octagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"65\" ]]\n    [[ $(candidate \"10\") = \"280\" ]]\n    [[ $(candidate \"15\") = \"645\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n#\n# $1 is a string\n# $2 is a string\nreplace_blank() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_blank \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello people\" \"@\") = \"hello@people\" ]]\n    [[ $(candidate \"python program language\" \"\\$\") = \"python\\$program\\$language\" ]]\n    [[ $(candidate \"blank space\" \"-\") = \"blank-space\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n#\n# $1 is a string\nreplace_specialchar() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_specialchar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python language, Programming language.\") = \"Python:language::Programming:language:\" ]]\n    [[ $(candidate \"a b c,d e f\") = \"a:b:c:d:e:f\" ]]\n    [[ $(candidate \"ram reshma,ram rahim\") = \"ram:reshma:ram:rahim\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a given tuple of positive integers into a single integer.\n#\n# $1 is a space-separated list\ntuple_to_int() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tuple_to_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"123\" ]]\n    [[ $(candidate \"4 5 6\") = \"456\" ]]\n    [[ $(candidate \"5 6 7\") = \"567\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the third side of a right angled triangle.\n#\n# $1 is an integer\n# $2 is an integer\notherside_rightangle() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    otherside_rightangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"8\") = \"10.63014581273465\" ]]\n    [[ $(candidate \"3\" \"4\") = \"5\" ]]\n    [[ $(candidate \"7\" \"15\") = \"16.55294535724685\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the per-digit difference between two integers.\n#\n# $1 is an integer\n# $2 is an integer\ndigit_distance_nums() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    digit_distance_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"23\" \"56\") = \"6\" ]]\n    [[ $(candidate \"123\" \"256\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that checks if a strings contains 'z', except at the start and end of the word.\n#\n# $1 is a string\ntext_match_wordz_middle() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_match_wordz_middle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonzabc.\") = \"true\" ]]\n    [[ $(candidate \"zxyabc.\") = \"false\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove leading zeroes from an ip address.\n#\n# $1 is a string\nremovezero_ip() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    removezero_ip \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"216.08.094.196\") = \"216.8.94.196\" ]]\n    [[ $(candidate \"12.01.024\") = \"12.1.24\" ]]\n    [[ $(candidate \"216.08.094.0196\") = \"216.8.94.196\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of sublists containing a particular element.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncount_element_in_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_element_in_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n1 11\\n1 15 7\" \"1\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"A\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"E\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to multiply two integers.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply_int() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    multiply_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"5\" \"10\") = \"50\" ]]\n    [[ $(candidate \"4\" \"8\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n#\n# $1 is a space-separated list\nadd_pairwise() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_pairwise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"6 12 15 18\" ]]\n    [[ $(candidate \"2 6 8 9 11\") = \"8 14 17 20\" ]]\n    [[ $(candidate \"3 7 9 10 12\") = \"10 16 19 22\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmax_product_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"36\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"200\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"484\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3376,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find the kth element in the given array using 1-based indexing.\n#\n# $1 is a space-separated list\n# $2 is an integer\nkth_element() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 3 5 7 19\" \"2\") = \"3\" ]]\n    [[ $(candidate \"17 24 8 23\" \"3\") = \"8\" ]]\n    [[ $(candidate \"16 21 25 36 4\" \"4\") = \"36\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3384,265 +24,97 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to interchange the first and last element in a given list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to convert a snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"4 2 3 4 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python_program\") = \"PythonProgram\" ]]\n    [[ $(candidate \"python_language\") = \"PythonLanguage\" ]]\n    [[ $(candidate \"programming_language\") = \"ProgrammingLanguage\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the number of elements that occurs before the list element in the given tuple.\n#\n# $1 is a newline-separated, space-separated list\ncount_first_elements() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the Eulerian number a(n, m).\n#\n# $1 is an integer\n# $2 is an integer\neulerian_num() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_first_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"3\" ]]\n    [[ $(candidate \"2 9 5 7 11\") = \"2\" ]]\n    [[ $(candidate \"11 15 5 8 2 3 8\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    eulerian_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"1\") = \"4\" ]]\n    [[ $(candidate \"4\" \"1\") = \"11\" ]]\n    [[ $(candidate \"5\" \"3\") = \"26\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_105_count",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to locate the right insertion point for a specified value in sorted order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nright_insertion() {\n",
+    "prompt": "#!/bin/bash\n# Write a python function to count true booleans in the given list.\n#\n# $1 is a space-separated list\ncount() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    right_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"true false true\") = \"2\" ]]\n    [[ $(candidate \"false false\") = \"0\" ]]\n    [[ $(candidate \"true true true\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_106_add_lists",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given number is woodball or not.\n#\n# $1 is an integer\nis_woodall() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to append the given list to the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_lists() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_woodall \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"383\") = \"true\" ]]\n    [[ $(candidate \"254\") = \"false\" ]]\n    [[ $(candidate \"200\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    add_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"9 10 5 6 7\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"10 11 6 7 8\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"11 12 7 8 9\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort the given array by using shell sort.\n#\n# $1 is a space-separated list\nshell_sort() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to merge three lists into a single sorted list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nmerge_sorted_list() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    shell_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 23 4 5 3 2 12 81 56 95\") = \"2 3 4 5 12 12 23 56 81 95\" ]]\n    [[ $(candidate \"24 22 39 34 87 73 68\") = \"22 24 34 39 68 73 87\" ]]\n    [[ $(candidate \"32 30 16 96 82 83 74\") = \"16 30 32 74 82 83 96\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    merge_sorted_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 24 15 4 5 29 110\" \"19 20 11 56 25 233 154\" \"24 26 54 48\") = \"4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233\" ]]\n    [[ $(candidate \"1 3 5 6 8 9\" \"2 5 7 11\" \"1 4 7 8 12\") = \"1 1 2 3 4 5 5 6 7 7 8 8 9 11 12\" ]]\n    [[ $(candidate \"18 14 10 9 8 7 9 3 2 4 1\" \"25 35 22 85 14 65 75 25 58\" \"12 74 9 50 61 41\") = \"1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of pairs whose xor value is odd.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_Odd_Pair() {\n",
+    "prompt": "#!/bin/bash\n# Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n#\n# $1 is a string\n# $2 is an integer\nodd_Equivalent() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Odd_Pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\" \"5\") = \"6\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\" \"7\") = \"12\" ]]\n    [[ $(candidate \"1 2 3\" \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    odd_Equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"011001\" \"6\") = \"3\" ]]\n    [[ $(candidate \"11011\" \"5\") = \"4\" ]]\n    [[ $(candidate \"1010\" \"4\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_113_check_integer",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of all odd natural numbers within the range l and r.\n#\n# $1 is an integer\n# $2 is an integer\nsum_in_range() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to check if a string represents an integer or not.\n#\n# $1 is a string\ncheck_integer() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_in_range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"5\") = \"8\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"13\") = \"40\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    check_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"12345\") = \"true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_116_tuple_to_int",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns the perimeter of a square given its side length as input.\n#\n# $1 is an integer\nsquare_perimeter() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to convert a given tuple of positive integers into a single integer.\n#\n# $1 is a space-separated list\ntuple_to_int() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    square_perimeter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"40\" ]]\n    [[ $(candidate \"5\") = \"20\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_765_is_polite",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n#\n# $1 is an integer\nis_polite() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_polite \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"11\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"13\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n#\n# $1 is an integer\nsum_series() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_series \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"12\" ]]\n    [[ $(candidate \"10\") = \"30\" ]]\n    [[ $(candidate \"9\") = \"25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the dissimilar elements in the given two tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nfind_dissimilar() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_dissimilar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7 2 3 9\") = \"1 4 7 9\" ]]\n    [[ $(candidate \"21 11 25 26\" \"26 34 21 36\") = \"34 36 11 25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"android_tv\") = \"AndroidTv\" ]]\n    [[ $(candidate \"google_pixel\") = \"GooglePixel\" ]]\n    [[ $(candidate \"apple_watch\") = \"AppleWatch\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the volume of a cube given its side length.\n#\n# $1 is an integer\nvolume_cube() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    volume_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"2\") = \"8\" ]]\n    [[ $(candidate \"5\") = \"125\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 31 days or not.\n#\n# $1 is an integer\ncheck_monthnumb_number() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_monthnumb_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether all the bits are unset in the given range or not.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nall_Bits_Set_In_The_Given_Range() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    all_Bits_Set_In_The_Given_Range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"1\" \"2\") = \"true\" ]]\n    [[ $(candidate \"17\" \"2\" \"4\") = \"true\" ]]\n    [[ $(candidate \"39\" \"4\" \"6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to get the first element of each sublist.\n#\n# $1 is a newline-separated, space-separated list\nExtract() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\\n3 4 5\\n6 7 8 9\") = \"1 3 6\" ]]\n    [[ $(candidate \"1 2 3\\n4 5\") = \"1 4\" ]]\n    [[ $(candidate \"9 8 1\\n1 2\") = \"9 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cylinder.\n#\n# $1 is an integer\n# $2 is an integer\nsurfacearea_cylinder() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    surfacearea_cylinder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"5\") = \"942.45\" ]]\n    [[ $(candidate \"4\" \"5\") = \"226.18800000000002\" ]]\n    [[ $(candidate \"4\" \"10\") = \"351.848\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n#\n# $1 is a space-separated list\nsample_nam() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sample_nam \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"sally Dylan rebecca Diana Joanne keith\") = \"16\" ]]\n    [[ $(candidate \"php res Python abcd Java aaa\") = \"10\" ]]\n    [[ $(candidate \"abcd Python abba aba\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to create the next bigger number by rearranging the digits of a given number.\n#\n# $1 is an integer\nrearrange_bigger() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rearrange_bigger \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"21\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"102\") = \"120\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the perimeter of a regular pentagon from the length of its sides.\n#\n# $1 is an integer\nperimeter_pentagon() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    perimeter_pentagon \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"25\" ]]\n    [[ $(candidate \"10\") = \"50\" ]]\n    [[ $(candidate \"15\") = \"75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n#\n# $1 is a space-separated list\nmax_sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 15 51 45 33 100 12 18 9\") = \"194\" ]]\n    [[ $(candidate \"80 60 30 40 20 10\") = \"210\" ]]\n    [[ $(candidate \"2 3 14 16 21 23 29 30\") = \"138\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove uneven elements in the nested mixed tuple.\n#\n# $1 is a space-separated list\nextract_even() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 7 6 2 4 6 8\") = \"4 6 2 4 6 8\" ]]\n    [[ $(candidate \"5 6 8 7 4 8 7 9\") = \"6 8 4 8\" ]]\n    [[ $(candidate \"5 6 9 8 4 6 8 10\") = \"6 8 4 6 8 10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    tuple_to_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"123\" ]]\n    [[ $(candidate \"4 5 6\") = \"456\" ]]\n    [[ $(candidate \"5 6 7\") = \"567\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3652,201 +124,9 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to convert all possible convertible elements in a list of lists to floats.\n#\n# $1 is a newline-separated, space-separated list\nlist_to_float() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    list_to_float \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 26.45\\n7.32 8\\n4 8\") = \"3.0 4.0\\n1.0 26.45\\n7.32 8.0\\n4.0 8.0\" ]]\n    [[ $(candidate \"4 4\\n2 27\\n4.12 9\\n7 11\") = \"4.0 4.0\\n2.0 27.0\\n4.12 9.0\\n7.0 11.0\" ]]\n    [[ $(candidate \"6 78\\n5 26.45\\n1.33 4\\n82 13\") = \"6.0 78.0\\n5.0 26.45\\n1.33 4.0\\n82.0 13.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"20\" ]]\n    [[ $(candidate \"3\") = \"56\" ]]\n    [[ $(candidate \"4\") = \"120\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n#\n# $1 is a space-separated list\n# $2 is an integer\nget_pairs_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_pairs_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1 1\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1 5 7 -1 5\" \"6\") = \"3\" ]]\n    [[ $(candidate \"1 -2 3\" \"1\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 3\" \"-3\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n#\n# $1 is an integer\n# $2 is an integer\ncount_no_of_ways() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_no_of_ways \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"4\") = \"16\" ]]\n    [[ $(candidate \"3\" \"2\") = \"6\" ]]\n    [[ $(candidate \"4\" \"4\") = \"228\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to reverse words seperated by spaces in a given string.\n#\n# $1 is a string\nreverse_words() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    reverse_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python program\") = \"program python\" ]]\n    [[ $(candidate \"java language\") = \"language java\" ]]\n    [[ $(candidate \"indian man\") = \"man indian\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check if a given number is one less than twice its reverse.\n#\n# $1 is an integer\nchecks() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    checks \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"70\") = \"false\" ]]\n    [[ $(candidate \"23\") = \"false\" ]]\n    [[ $(candidate \"73\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the last position of an element in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlast() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    last \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 4\" \"1\") = \"2\" ]]\n    [[ $(candidate \"2 3 2 3 6 8 9\" \"3\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_X() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_X \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"4\") = \"0\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"10\") = \"3\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"8\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nextract_index_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_index_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 7\" ]]\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 6 5\" \"0 1 2 3 4 6 7\") = \"1 6\" ]]\n    [[ $(candidate \"1 1 3 4 6 5 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 5\" ]]\n    [[ $(candidate \"1 2 3 4 6 6 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the second smallest number in a list.\n#\n# $1 is a newline-separated, space-separated list\nsecond_smallest() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    second_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 -8 -2 0 -2\") = \"-2\" ]]\n    [[ $(candidate \"1 1 -0.5 0 2 -2 -2\") = \"-0.5\" ]]\n    [[ $(candidate \"2 2\") = \"None\" ]]\n    [[ $(candidate \"2 2 2\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to concatenate each element of tuple by the delimiter.\n#\n# $1 is a space-separated list\nconcatenate_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    concatenate_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ID is 4 UTS\") = \"ID-is-4-UTS\" ]]\n    [[ $(candidate \"QWE is 4 RTY\") = \"QWE-is-4-RTY\" ]]\n    [[ $(candidate \"ZEN is 4 OP\") = \"ZEN-is-4-OP\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace all spaces in the given string with '%20'.\n#\n# $1 is a string\nreplace_spaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"My Name is Dawood\") = \"My%20Name%20is%20Dawood\" ]]\n    [[ $(candidate \"I am a Programmer\") = \"I%20am%20a%20Programmer\" ]]\n    [[ $(candidate \"I love Coding\") = \"I%20love%20Coding\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the sum of numbers in a list within a range specified by two indices.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nsum_range_list() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sum_range_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"8\" \"10\") = \"29\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"5\" \"7\") = \"16\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"7\" \"10\") = \"38\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to merge three dictionaries into a single dictionary.\n#\n# $1 is a two column CSV in key,value order\n# $2 is a two column CSV in key,value order\n# $3 is a two column CSV in key,value order\nmerge_dictionaries_three() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    merge_dictionaries_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"O,Orange\\nW,White\\nB,Black\") = \"B,Black\\nR,Red\\nP,Pink\\nG,Green\\nW,White\\nO,Orange\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"L,lavender\\nB,Blue\") = \"W,White\\nP,Pink\\nB,Black\\nR,Red\\nG,Green\\nL,lavender\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"L,lavender\\nB,Blue\" \"G,Green\\nW,White\") = \"B,Black\\nP,Pink\\nR,Red\\nG,Green\\nL,lavender\\nW,White\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the minimum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nminimum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"-5\" \"-4\") = \"-5\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between available pairs in the given tuple list.\n#\n# $1 is a newline-separated, space-separated list\nmax_difference() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 5\\n1 7\\n10 3\\n1 2\") = \"7\" ]]\n    [[ $(candidate \"4 6\\n2 17\\n9 13\\n11 12\") = \"15\" ]]\n    [[ $(candidate \"12 35\\n21 27\\n13 23\\n41 22\") = \"23\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find element at a given index after number of rotations.\n#\n# $1 is a space-separated list\n# $2 is a newline-separated, space-separated list\n# $3 is an integer\n# $4 is an integer\nfind_Element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"0 2\\n0 3\" \"2\" \"1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\" \"0 1\\n0 2\" \"1\" \"2\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"0 1\\n0 2\" \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3856,7 +136,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to convert a string to a list of strings split on the space character.\n#\n# $1 is a string\nstring_to_list() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    string_to_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"python programming\" ]]\n    [[ $(candidate \"lists tuples strings\") = \"lists tuples strings\" ]]\n    [[ $(candidate \"write a program\") = \"write a program\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3868,21 +148,9 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a python function to find the element that appears only once in a sorted array.\n#\n# $1 is a space-separated list\nsearch() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1 3 3 4 4 5 5 7 7 8\") = \"8\" ]]\n    [[ $(candidate \"1 2 2 3 3 4 4\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a dictionary by value.\n#\n# $1 is a two column CSV in key,value order\nsort_counter() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_counter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Math,81\\nPhysics,83\\nChemistry,87\") = \"Chemistry 87\\nPhysics 83\\nMath 81\" ]]\n    [[ $(candidate \"Math,400\\nPhysics,300\\nChemistry,250\") = \"Math 400\\nPhysics 300\\nChemistry 250\" ]]\n    [[ $(candidate \"Math,900\\nPhysics,1000\\nChemistry,1250\") = \"Chemistry 1250\\nPhysics 1000\\nMath 900\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3892,7 +160,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a python function to remove first and last occurrence of a given character from the string.\n#\n# $1 is a string\n# $2 is a string\nremove_Occ() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    remove_Occ \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello\" \"l\") = \"heo\" ]]\n    [[ $(candidate \"abcda\" \"a\") = \"bcd\" ]]\n    [[ $(candidate \"PHP\" \"P\") = \"H\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3900,337 +168,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cube given its side length.\n#\n# $1 is an integer\nlateralsurface_cube() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmax_product_tuple() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    lateralsurface_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"100\" ]]\n    [[ $(candidate \"9\") = \"324\" ]]\n    [[ $(candidate \"10\") = \"400\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"36\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"200\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"484\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes two lists and returns true if they have at least one common element.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon_element() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to sum all amicable numbers from 1 to a specified number.\n#\n# $1 is an integer\namicable_numbers_sum() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    common_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8 9\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"None\" ]]\n    [[ $(candidate \"a b c\" \"d b e\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    amicable_numbers_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"999\") = \"504\" ]]\n    [[ $(candidate \"9999\") = \"31626\" ]]\n    [[ $(candidate \"99\") = \"0\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to append the given list to the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_lists() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n#\n# $1 is a string\nfind_length() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"9 10 5 6 7\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"10 11 6 7 8\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"11 12 7 8 9\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    find_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11000010001\") = \"6\" ]]\n    [[ $(candidate \"10111\") = \"1\" ]]\n    [[ $(candidate \"11011101100101\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to compute the n-th power of each number in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nnth_nums() {\n",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of common divisors of two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nsum() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    nth_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\" \"3\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\" \"5\") = \"248832 759375\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"15\") = \"6\" ]]\n    [[ $(candidate \"100\" \"150\") = \"93\" ]]\n    [[ $(candidate \"4\" \"6\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\npancake_sort() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to multiply two integers.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply_int() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    pancake_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 79 25 38 69\") = \"15 25 38 69 79\" ]]\n    [[ $(candidate \"98 12 54 36 85\") = \"12 36 54 85 98\" ]]\n    [[ $(candidate \"41 42 32 12 23\") = \"12 23 32 41 42\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_numbers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    median_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25\" \"55\" \"65\") = \"55.0\" ]]\n    [[ $(candidate \"20\" \"10\" \"30\") = \"20.0\" ]]\n    [[ $(candidate \"15\" \"45\" \"75\") = \"45.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the entered number is greater than the elements of the given array.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_greater() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_greater \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2 3 4 5 6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"9 7 4 8 6 1\" \"11\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n#\n# $1 is a space-separated list\n# $2 is a $Any\ncheck_element() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange black white\" \"blue\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7\") = \"false\" ]]\n    [[ $(candidate \"green green green green\" \"green\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract specified size of strings from a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is an integer\nextract_string() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    extract_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python list exercises practice solution\" \"8\") = \"practice solution\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"6\") = \"Python\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"9\") = \"exercises\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n#\n# $1 is a string\ntext_lowercase_underscore() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    text_lowercase_underscore \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aab_cbbbc\") = \"true\" ]]\n    [[ $(candidate \"aab_Abbbc\") = \"false\" ]]\n    [[ $(candidate \"Aaab_abbbc\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to trim each list by k in the given lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\ntrim_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    trim_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"2\") = \"2\\n9\\n2\\n2\" ]]\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"1\") = \"3 2 1\\n4 9 2\\n1 2 3\\n8 2 1\" ]]\n    [[ $(candidate \"7 8 4 9\\n11 8 12 4\\n4 1 7 8\\n3 6 9 7\" \"1\") = \"8 4\\n8 12\\n1 7\\n6 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sublist having minimum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    Find_Min \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1\" ]]\n    [[ $(candidate \"1 1\\n1 1 1\\n1 2 7 8\") = \"1 1\" ]]\n    [[ $(candidate \"x\\nx y\\nx y z\") = \"x\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to filter odd numbers.\n#\n# $1 is a space-separated list\nfilter_oddnumbers() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    filter_oddnumbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 3 5 7 9\" ]]\n    [[ $(candidate \"10 20 45 67 84 93\") = \"45 67 93\" ]]\n    [[ $(candidate \"5 7 9 8 6 4 3\") = \"5 7 9 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the first adverb ending with ly and its positions in a given string.\n#\n# $1 is a string\nfind_adverbs() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_adverbs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Clearly, he has no excuse for such behavior.\") = \"0-7: Clearly\" ]]\n    [[ $(candidate \"Please handle the situation carefuly\") = \"28-36: carefuly\" ]]\n    [[ $(candidate \"Complete the task quickly\") = \"18-25: quickly\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_of_nth() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_of_nth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\\n1 3 5\\n8 9 19\" \"2\") = \"19\" ]]\n    [[ $(candidate \"6 7 8\\n2 4 6\\n9 10 20\" \"1\") = \"10\" ]]\n    [[ $(candidate \"7 8 9\\n3 5 7\\n10 11 21\" \"1\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"1000\" ]]\n    [[ $(candidate \"18\") = \"10010\" ]]\n    [[ $(candidate \"7\") = \"111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncombinations_colors() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    combinations_colors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue\" \"1\") = \"Red\\nGreen\\nBlue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"2\") = \"Red Red\\nRed Green\\nRed Blue\\nGreen Green\\nGreen Blue\\nBlue Blue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"3\") = \"Red Red Red\\nRed Red Green\\nRed Red Blue\\nRed Green Green\\nRed Green Blue\\nRed Blue Blue\\nGreen Green Green\\nGreen Green Blue\\nGreen Blue Blue\\nBlue Blue Blue\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from a string.\n#\n# $1 is a string\nremove_all_spaces() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_all_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python  program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"python   programming    language\") = \"pythonprogramminglanguage\" ]]\n    [[ $(candidate \"python                     program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"   python                     program\") = \"pythonprogram\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n#\n# $1 is a string\n# $2 is a string\nmin_Swaps() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_Swaps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1101\" \"1110\") = \"1\" ]]\n    [[ $(candidate \"111\" \"000\") = \"Not Possible\" ]]\n    [[ $(candidate \"111\" \"110\") = \"Not Possible\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to create a new tuple from the given string and list.\n#\n# $1 is a space-separated list\n# $2 is a string\nnew_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    new_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"WEB is\" \"best\") = \"WEB is best\" ]]\n    [[ $(candidate \"We are\" \"Developers\") = \"We are Developers\" ]]\n    [[ $(candidate \"Part is\" \"Wrong\") = \"Part is Wrong\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the product of the array multiplication modulo n.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_remainder() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_remainder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100 10 5 25 35 14\" \"11\") = \"9\" ]]\n    [[ $(candidate \"1 1 1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 2 1\" \"2\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the minimum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmin_val() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"2\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"15\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the ration of positive numbers in an array of integers.\n#\n# $1 is a space-separated list\npositive_count() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    positive_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\") = \"0.54\" ]]\n    [[ $(candidate \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"0.69\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"0.56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to add the given tuple to the given list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_tuple() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    add_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"5 6 7 9 10\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"6 7 8 10 11\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"7 8 9 11 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find maximum run of uppercase characters in the given string.\n#\n# $1 is a string\nmax_run_uppercase() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_run_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"GeMKSForGERksISBESt\") = \"5\" ]]\n    [[ $(candidate \"PrECIOusMOVemENTSYT\") = \"6\" ]]\n    [[ $(candidate \"GooGLEFluTTER\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a given matrix in ascending order according to the sum of its rows.\n#\n# $1 is a newline-separated, space-separated list\nsort_matrix() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sort_matrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n2 4 5\\n1 1 1\") = \"1 1 1\\n1 2 3\\n2 4 5\" ]]\n    [[ $(candidate \"1 2 3\\n-2 4 -5\\n1 -1 1\") = \"-2 4 -5\\n1 -1 1\\n1 2 3\" ]]\n    [[ $(candidate \"5 8 9\\n6 4 3\\n2 1 4\") = \"2 1 4\\n6 4 3\\n5 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count those characters which have vowels as their neighbors in the given string.\n#\n# $1 is a string\ncount_vowels() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"bestinstareels\") = \"7\" ]]\n    [[ $(candidate \"partofthejourneyistheend\") = \"12\" ]]\n    [[ $(candidate \"amazonprime\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\n# $4 is an integer\nmax_sum_increasing_subseq() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    max_sum_increasing_subseq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"4\" \"6\") = \"11\" ]]\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"2\" \"5\") = \"7\" ]]\n    [[ $(candidate \"11 15 19 21 26 28 31\" \"7\" \"2\" \"4\") = \"71\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    multiply_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"5\" \"10\") = \"50\" ]]\n    [[ $(candidate \"4\" \"8\") = \"32\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4240,7 +232,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find words that are longer than n characters from a given list of words.\n#\n# $1 is an integer\n# $2 is a string\nlong_words() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    long_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"python is a programming language\") = \"python programming language\" ]]\n    [[ $(candidate \"2\" \"writing a program\") = \"writing program\" ]]\n    [[ $(candidate \"5\" \"sorting list\") = \"sorting\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4248,205 +240,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of non-repeated elements in a given list.\n#\n# $1 is a space-separated list\nfind_sum() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to calculate whether the matrix is a magic square.\n#\n# $1 is a newline-separated, space-separated list\nmagic_square_test() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 1 1 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"1 10 9 4 2 10 10 45 4\") = \"71\" ]]\n    [[ $(candidate \"12 10 9 45 2 10 10 45 10\") = \"78\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    magic_square_test \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7 12 1 14\\n2 13 8 11\\n16 3 10 5\\n9 6 15 4\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 8\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 7\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n#\n# $1 is a space-separated list\ntuple_to_dict() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to sort a given matrix in ascending order according to the sum of its rows.\n#\n# $1 is a newline-separated, space-separated list\nsort_matrix() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    tuple_to_dict \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 10 13 5\") = \"1,5\\n7,10\\n13,5\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1,2\\n3,4\\n5,6\" ]]\n    [[ $(candidate \"7 8 9 10 11 12\") = \"7,8\\n9,10\\n11,12\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sort_matrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n2 4 5\\n1 1 1\") = \"1 1 1\\n1 2 3\\n2 4 5\" ]]\n    [[ $(candidate \"1 2 3\\n-2 4 -5\\n1 -1 1\") = \"-2 4 -5\\n1 -1 1\\n1 2 3\" ]]\n    [[ $(candidate \"5 8 9\\n6 4 3\\n2 1 4\") = \"2 1 4\\n6 4 3\\n5 8 9\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n#\n# $1 is a space-separated list\nget_coordinates() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the item with maximum frequency in a given list.\n#\n# $1 is a space-separated list\nmax_occurrences() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    get_coordinates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\") = \"2 3\\n2 4\\n2 5\\n3 3\\n3 4\\n3 5\\n4 3\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"4 5\") = \"3 4\\n3 5\\n3 6\\n4 4\\n4 5\\n4 6\\n5 4\\n5 5\\n5 6\" ]]\n    [[ $(candidate \"5 6\") = \"4 5\\n4 6\\n4 7\\n5 5\\n5 6\\n5 7\\n6 5\\n6 6\\n6 7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if all the elements in tuple have same data type or not.\n#\n# $1 is a $Any\ncheck_type() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_type \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7 3 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 4\") = \"false\" ]]\n    [[ $(candidate \"3 2 1 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the smallest missing number from a sorted list of natural numbers.\n#\n# $1 is a space-separated list\nfind_First_Missing() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_First_Missing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 3\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 6 9\") = \"3\" ]]\n    [[ $(candidate \"2 3 5 8 9\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is undulating or not.\n#\n# $1 is an integer\nis_undulating() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_undulating \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1212121\") = \"true\" ]]\n    [[ $(candidate \"1991\") = \"false\" ]]\n    [[ $(candidate \"121\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmin_k() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    min_k \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Manjeet 10\\nAkshat 4\\nAkash 2\\nNikhil 8\" \"2\") = \"Akash 2\\nAkshat 4\" ]]\n    [[ $(candidate \"Sanjeev 11\\nAngat 5\\nAkash 3\\nNepin 9\" \"3\") = \"Akash 3\\nAngat 5\\nNepin 9\" ]]\n    [[ $(candidate \"tanmay 14\\nAmer 11\\nAyesha 9\\nSKD 16\" \"1\") = \"Ayesha 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to count the number of substrings with the sum of digits equal to their length.\n#\n# $1 is a string\ncount_Substrings() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_Substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"112112\") = \"6\" ]]\n    [[ $(candidate \"111\") = \"6\" ]]\n    [[ $(candidate \"1101112\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth decagonal number.\n#\n# $1 is an integer\nis_num_decagonal() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_num_decagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"7\") = \"175\" ]]\n    [[ $(candidate \"10\") = \"370\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n#\n# $1 is a newline-separated, space-separated list\nrear_extract() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    rear_extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 Rash 21\\n2 Varsha 20\\n3 Kil 19\") = \"21 20 19\" ]]\n    [[ $(candidate \"1 Sai 36\\n2 Ayesha 25\\n3 Salman 45\") = \"36 25 45\" ]]\n    [[ $(candidate \"1 Sudeep 14\\n2 Vandana 36\\n3 Dawood 56\") = \"14 36 56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the closest smaller number than n.\n#\n# $1 is an integer\nclosest_num() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    closest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11\") = \"10\" ]]\n    [[ $(candidate \"7\") = \"6\" ]]\n    [[ $(candidate \"12\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n#\n# $1 is a newline-separated, space-separated list\nfind_combinations() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_combinations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4\\n6 7\\n5 1\\n6 10\") = \"8 11\\n7 5\\n8 14\\n11 8\\n12 17\\n11 11\" ]]\n    [[ $(candidate \"3 5\\n7 8\\n6 2\\n7 11\") = \"10 13\\n9 7\\n10 16\\n13 10\\n14 19\\n13 13\" ]]\n    [[ $(candidate \"4 6\\n8 9\\n7 3\\n8 12\") = \"12 15\\n11 9\\n12 18\\n15 12\\n16 21\\n15 15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n#\n# $1 is a newline-separated, space-separated list\nmaxAverageOfPath() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    maxAverageOfPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n6 5 4\\n7 3 9\") = \"5.2\" ]]\n    [[ $(candidate \"2 3 4\\n7 6 5\\n8 4 10\") = \"6.2\" ]]\n    [[ $(candidate \"3 4 5\\n8 7 6\\n9 5 11\") = \"7.2\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\") = \"5.8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n#\n# $1 is a space-separated list\n# $2 is an integer\nsequential_search() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sequential_search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 23 58 31 56 77 43 12 65 19\" \"31\") = \"true 3\" ]]\n    [[ $(candidate \"12 32 45 62 35 47 44 61\" \"61\") = \"true 7\" ]]\n    [[ $(candidate \"9 10 17 19 22 39 48 56\" \"48\") = \"true 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to remove odd numbers from a given list.\n#\n# $1 is a space-separated list\nremove_odd() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"2\" ]]\n    [[ $(candidate \"2 4 6\") = \"2 4 6\" ]]\n    [[ $(candidate \"10 20 3\") = \"10 20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the product of numbers in a list is even or not.\n#\n# $1 is a space-separated list\nis_product_even() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    is_product_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 4\") = \"true\" ]]\n    [[ $(candidate \"1 1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the maximum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"10\") = \"10\" ]]\n    [[ $(candidate \"-1\" \"-2\") = \"-1\" ]]\n    [[ $(candidate \"9\" \"7\") = \"9\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_occurrences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2\") = \"2\" ]]\n    [[ $(candidate \"2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18\") = \"8\" ]]\n    [[ $(candidate \"10 20 20 30 40 90 80 50 30 20 50 10\") = \"20\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4456,9 +280,597 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a python function to reverse only the vowels of a given string (where y is not a vowel).\n#\n# $1 is a string\nreverse_vowels() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    reverse_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"USA\") = \"ASU\" ]]\n    [[ $(candidate \"ab\") = \"ab\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a list to a string.\n#\n# $1 is a space-separated list\ntup_string() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tup_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"e x e r c i s e s\") = \"exercises\" ]]\n    [[ $(candidate \"p y t h o n\") = \"python\" ]]\n    [[ $(candidate \"p r o g r a m\") = \"program\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of the negative numbers of a given list of numbers.\n#\n# $1 is a space-separated list\nsum_negativenum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_negativenum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"-32\" ]]\n    [[ $(candidate \"10 15 -14 13 -18 12 -20\") = \"-52\" ]]\n    [[ $(candidate \"19 -65 57 39 152 -639 121 44 90 -190\") = \"-894\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth hexagonal number.\n#\n# $1 is an integer\nhexagonal_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    hexagonal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"190\" ]]\n    [[ $(candidate \"5\") = \"45\" ]]\n    [[ $(candidate \"7\") = \"91\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n#\n# $1 is an integer\nis_Sum_Of_Powers_Of_Two() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_Sum_Of_Powers_Of_Two \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"false\" ]]\n    [[ $(candidate \"14\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\npancake_sort() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pancake_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 79 25 38 69\") = \"15 25 38 69 79\" ]]\n    [[ $(candidate \"98 12 54 36 85\") = \"12 36 54 85 98\" ]]\n    [[ $(candidate \"41 42 32 12 23\") = \"12 23 32 41 42\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count number items that are identical in the same position of three given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ncount_samepair() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_samepair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\" \"2 1 3 1 2 6 7 9\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 2 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find number of lists present in the given list.\n#\n# $1 is a space-separated list\nfind_lists() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\") = \"2\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"9 8 7 6 5 4 3 2 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the maximum difference between any two elements in a given array.\n#\n# $1 is a space-separated list\nmax_Abs_Diff() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_Abs_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 3\") = \"4\" ]]\n    [[ $(candidate \"9 3 2 5 1\") = \"8\" ]]\n    [[ $(candidate \"3 2 1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the volume of a triangular prism.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_Volume() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Volume \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"8\" \"6\") = \"240\" ]]\n    [[ $(candidate \"3\" \"2\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\" \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_solution() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"7\") = \"2 1\" ]]\n    [[ $(candidate \"4\" \"2\" \"7\") = \"None\" ]]\n    [[ $(candidate \"1\" \"13\" \"17\") = \"4 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all elements from a given list present in another list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nremove_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"1 3 5 7\") = \"2 4 6 8 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5 7\") = \"1 2 3 4 6 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n#\n# $1 is an integer\nsum_series() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_series \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"12\" ]]\n    [[ $(candidate \"10\") = \"30\" ]]\n    [[ $(candidate \"9\") = \"25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to determine if the sum of the divisors of two integers are the same.\n#\n# $1 is an integer\n# $2 is an integer\nare_equivalent() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    are_equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"36\" \"57\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"23\" \"47\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n#\n# $1 is a string\ncount_char_position() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_char_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xbcefg\") = \"2\" ]]\n    [[ $(candidate \"ABcED\") = \"3\" ]]\n    [[ $(candidate \"AbgdeF\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that counts the number of pairs of integers in a list that xor to an even number.\n#\n# $1 is a space-separated list\nfind_even_pair() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_even_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\") = \"4\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\") = \"9\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the smallest power of 2 greater than or equal to n.\n#\n# $1 is an integer\nnext_power_of_2() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    next_power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"5\") = \"8\" ]]\n    [[ $(candidate \"17\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of occurrences of a number in a given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfrequency() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    frequency \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 2 3 3 3 4\" \"3\") = \"3\" ]]\n    [[ $(candidate \"0 1 2 3 1 2\" \"1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n#\n# $1 is a string\ntext_lowercase_underscore() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_lowercase_underscore \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aab_cbbbc\") = \"true\" ]]\n    [[ $(candidate \"aab_Abbbc\") = \"false\" ]]\n    [[ $(candidate \"Aaab_abbbc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the sum of numbers in a list within a range specified by two indices.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nsum_range_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_range_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"8\" \"10\") = \"29\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"5\" \"7\") = \"16\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"7\" \"10\") = \"38\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the perimeter of a regular pentagon from the length of its sides.\n#\n# $1 is an integer\nperimeter_pentagon() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    perimeter_pentagon \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"25\" ]]\n    [[ $(candidate \"10\") = \"50\" ]]\n    [[ $(candidate \"15\") = \"75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of occurence of the string 'std' in a given string.\n#\n# $1 is a string\ncount_occurance() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_occurance \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"letstdlenstdporstd\") = \"3\" ]]\n    [[ $(candidate \"truststdsolensporsd\") = \"1\" ]]\n    [[ $(candidate \"makestdsostdworthit\") = \"2\" ]]\n    [[ $(candidate \"stds\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns the perimeter of a square given its side length as input.\n#\n# $1 is an integer\nsquare_perimeter() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    square_perimeter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"40\" ]]\n    [[ $(candidate \"5\") = \"20\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove characters from the first string which are present in the second string.\n#\n# $1 is a string\n# $2 is a string\nremove_dirty_chars() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_dirty_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"probasscurve\" \"pros\") = \"bacuve\" ]]\n    [[ $(candidate \"digitalindia\" \"talent\") = \"digiidi\" ]]\n    [[ $(candidate \"exoticmiles\" \"toxic\") = \"emles\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find whether a given array of integers contains any duplicate element.\n#\n# $1 is a space-separated list\ntest_duplicate() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    test_duplicate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2 3 3 4 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given number is woodball or not.\n#\n# $1 is an integer\nis_woodall() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_woodall \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"383\") = \"true\" ]]\n    [[ $(candidate \"254\") = \"false\" ]]\n    [[ $(candidate \"200\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if all the elements in tuple have same data type or not.\n#\n# $1 is a $Any\ncheck_type() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_type \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7 3 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 4\") = \"false\" ]]\n    [[ $(candidate \"3 2 1 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nis_majority() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_majority \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 3 3 3 10\" \"7\" \"3\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 4 4 4 6 6\" \"8\" \"4\") = \"false\" ]]\n    [[ $(candidate \"1 1 1 2 2\" \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2\" \"5\" \"1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of set bits (binary digits with value 1) in a given number.\n#\n# $1 is an integer\ncount_Set_Bits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_Set_Bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to remove the characters which have odd index values of a given string.\n#\n# $1 is a string\nodd_values_string() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    odd_values_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcdef\") = \"ace\" ]]\n    [[ $(candidate \"python\") = \"pto\" ]]\n    [[ $(candidate \"data\") = \"dt\" ]]\n    [[ $(candidate \"lambs\") = \"lms\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find minimum of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmin_of_three() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\" \"0\") = \"0\" ]]\n    [[ $(candidate \"19\" \"15\" \"18\") = \"15\" ]]\n    [[ $(candidate \"-10\" \"-20\" \"-30\") = \"-30\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether all the bits are unset in the given range or not.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nall_Bits_Set_In_The_Given_Range() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_Bits_Set_In_The_Given_Range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"1\" \"2\") = \"true\" ]]\n    [[ $(candidate \"17\" \"2\" \"4\") = \"true\" ]]\n    [[ $(candidate \"39\" \"4\" \"6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n#\n# $1 is a space-separated list\n# $2 is an integer\nre_arrange_array() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    re_arrange_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 2 -3 4 5 6 -7 8 9\" \"9\") = \"-1 -3 -7 4 5 6 2 8 9\" ]]\n    [[ $(candidate \"12 -14 -26 13 15\" \"5\") = \"-14 -26 12 13 15\" ]]\n    [[ $(candidate \"10 24 36 -42 -39 -78 85\" \"7\") = \"-42 -39 -78 10 24 36 85\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n#\n# $1 is a string\n# $2 is a string\nreplace_blank() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_blank \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello people\" \"@\") = \"hello@people\" ]]\n    [[ $(candidate \"python program language\" \"\\$\") = \"python\\$program\\$language\" ]]\n    [[ $(candidate \"blank space\" \"-\") = \"blank-space\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the volume of a cube given its side length.\n#\n# $1 is an integer\nvolume_cube() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    volume_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"2\") = \"8\" ]]\n    [[ $(candidate \"5\") = \"125\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of non-empty substrings of a given string.\n#\n# $1 is a string\nnumber_of_substrings() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    number_of_substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"6\" ]]\n    [[ $(candidate \"abcd\") = \"10\" ]]\n    [[ $(candidate \"abcde\") = \"15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n#\n# $1 is an integer\n# $2 is an integer\nget_total_number_of_sequences() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_total_number_of_sequences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"4\") = \"4\" ]]\n    [[ $(candidate \"5\" \"2\") = \"6\" ]]\n    [[ $(candidate \"16\" \"3\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nreplace_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 2 4 6 8\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8\") = \"1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"red blue green\" \"yellow\") = \"red blue yellow\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the total number of characters in a string.\n#\n# $1 is a string\ncount_charac() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_charac \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"18\" ]]\n    [[ $(candidate \"language\") = \"8\" ]]\n    [[ $(candidate \"words\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the next perfect square greater than a given number.\n#\n# $1 is an integer\nnext_Perfect_Square() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    next_Perfect_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"35\") = \"36\" ]]\n    [[ $(candidate \"6\") = \"9\" ]]\n    [[ $(candidate \"9\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n#\n# $1 is a space-separated list\nmax_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 15 51 45 33 100 12 18 9\") = \"194\" ]]\n    [[ $(candidate \"80 60 30 40 20 10\") = \"210\" ]]\n    [[ $(candidate \"2 3 14 16 21 23 29 30\") = \"138\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the length of the longest palindromic subsequence in the given string.\n#\n# $1 is a string\nlps() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    lps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TENS FOR TENS\") = \"5\" ]]\n    [[ $(candidate \"CARDIO FOR CARDS\") = \"7\" ]]\n    [[ $(candidate \"PART OF THE JOURNEY IS PART\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the intersection of two arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection_array() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    intersection_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"1 2 4 8 9\") = \"1 2 8 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"3 5 7 9\") = \"3 5 7 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"10 20 30 40\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_X() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_X \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"4\") = \"0\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"10\") = \"3\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"8\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n#\n# $1 is a space-separated list\n# $2 is a string\ninsert_element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    insert_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Black\" \"c\") = \"c Red c Green c Black\" ]]\n    [[ $(candidate \"python java\" \"program\") = \"program python program java\" ]]\n    [[ $(candidate \"happy sad\" \"laugh\") = \"laugh happy laugh sad\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to convert complex numbers to polar coordinates.\n#\n# $1 is an integer\nconvert() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    convert \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"4\") = \"4.0 0.0\" ]]\n    [[ $(candidate \"5\") = \"5.0 0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function that returns the number of integer elements in a given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_integer() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 abc 1.2\") = \"2\" ]]\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1.2 4 5.1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncombinations_colors() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    combinations_colors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue\" \"1\") = \"Red\\nGreen\\nBlue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"2\") = \"Red Red\\nRed Green\\nRed Blue\\nGreen Green\\nGreen Blue\\nBlue Blue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"3\") = \"Red Red Red\\nRed Red Green\\nRed Red Blue\\nRed Green Green\\nRed Green Blue\\nRed Blue Blue\\nGreen Green Green\\nGreen Green Blue\\nGreen Blue Blue\\nBlue Blue Blue\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n#\n# $1 is an integer\ncount_Primes_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_Primes_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"4\" ]]\n    [[ $(candidate \"100\") = \"25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two numbers and returns a list with the second number and then the first number.\n#\n# $1 is an integer\n# $2 is an integer\nswap_numbers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    swap_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"20 10\" ]]\n    [[ $(candidate \"15\" \"17\") = \"17 15\" ]]\n    [[ $(candidate \"100\" \"200\") = \"200 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4468,7 +880,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to maximize the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nmaximize_elements() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    maximize_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 7\\n4 9\\n2 9\\n7 10\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"7 8\\n5 10\\n3 10\\n8 11\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"8 9\\n6 11\\n4 11\\n9 12\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4476,73 +888,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to check whether every even index contains even numbers of a given list.\n#\n# $1 is a space-separated list\neven_position() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n#\n# $1 is an integer\nnewman_prime() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    even_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n    [[ $(candidate \"2 1 4\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    newman_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"7\" ]]\n    [[ $(candidate \"4\") = \"17\" ]]\n    [[ $(candidate \"5\") = \"41\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given string starts and ends with the same character or not.\n#\n# $1 is a string\ncheck_char() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndivision_elements() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    check_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abba\") = \"Valid\" ]]\n    [[ $(candidate \"a\") = \"Valid\" ]]\n    [[ $(candidate \"abcd\") = \"Invalid\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    division_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"2 2 2 3\" ]]\n    [[ $(candidate \"12 6 8 16\" \"6 3 4 4\") = \"2 2 2 4\" ]]\n    [[ $(candidate \"20 14 36 18\" \"5 7 6 9\") = \"4 2 6 2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function to find the sum of even factors of a number.\n#\n# $1 is an integer\nsumofFactors() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_two_parts() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    sumofFactors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"18\") = \"26\" ]]\n    [[ $(candidate \"30\") = \"48\" ]]\n    [[ $(candidate \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    split_two_parts \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 2\\n3 4 4 5 1\" ]]\n    [[ $(candidate \"a b c d\" \"2\") = \"a b\\nc d\" ]]\n    [[ $(candidate \"p y t h o n\" \"4\") = \"p y t h\\no n\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cone given radius r and the height h.\n#\n# $1 is an integer\n# $2 is an integer\nlateralsurface_cone() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to calculate a dog's age in dog's years.\n#\n# $1 is an integer\ndog_age() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    lateralsurface_cone \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"12\") = \"204.20352248333654\" ]]\n    [[ $(candidate \"10\" \"15\") = \"566.3586699569488\" ]]\n    [[ $(candidate \"19\" \"17\") = \"1521.8090132193388\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    dog_age \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"61\" ]]\n    [[ $(candidate \"15\") = \"73\" ]]\n    [[ $(candidate \"24\") = \"109\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_Pairs() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlist_split() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    count_Pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 1\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 1 1 1\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5\") = \"10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    list_split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b c d e f g h i j k l m n\" \"3\") = \"a d g j m\\nb e h k n\\nc f i l\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11 12 13 14\" \"3\") = \"1 4 7 10 13\\n2 5 8 11 14\\n3 6 9 12\" ]]\n    [[ $(candidate \"python java C C++ DBMS SQL\" \"2\") = \"python C DBMS\\njava C++ SQL\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the index of the first occurrence of a given number in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_first_occurrence() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cube given its side length.\n#\n# $1 is an integer\nlateralsurface_cube() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    find_first_occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 5 5 5 6 6 8 9 9 9\" \"5\") = \"1\" ]]\n    [[ $(candidate \"2 3 5 5 6 6 8 9 9 9\" \"5\") = \"2\" ]]\n    [[ $(candidate \"2 4 1 5 6 6 8 9 9 9\" \"6\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    lateralsurface_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"100\" ]]\n    [[ $(candidate \"9\") = \"324\" ]]\n    [[ $(candidate \"10\") = \"400\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4552,9 +964,669 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"10\" ]]\n    [[ $(candidate \"3\") = \"35\" ]]\n    [[ $(candidate \"4\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n'th star number.\n#\n# $1 is an integer\nfind_star_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_star_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"37\" ]]\n    [[ $(candidate \"4\") = \"73\" ]]\n    [[ $(candidate \"5\") = \"121\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the ascii value of a character.\n#\n# $1 is a string\nascii_value() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    ascii_value \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\") = \"65\" ]]\n    [[ $(candidate \"R\") = \"82\" ]]\n    [[ $(candidate \"S\") = \"83\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of even numbers at even positions of a list.\n#\n# $1 is a space-separated list\nsum_even_and_even_index() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_even_and_even_index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 12 1 18 8\") = \"30\" ]]\n    [[ $(candidate \"3 20 17 9 2 10 18 13 6 18\") = \"26\" ]]\n    [[ $(candidate \"5 6 12 1\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n#\n# $1 is an integer\neven_Power_Sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_Power_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1056\" ]]\n    [[ $(candidate \"3\") = \"8832\" ]]\n    [[ $(candidate \"1\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\n#\n# $1 is a newline-separated, space-separated list\nrear_extract() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rear_extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 Rash 21\\n2 Varsha 20\\n3 Kil 19\") = \"21 20 19\" ]]\n    [[ $(candidate \"1 Sai 36\\n2 Ayesha 25\\n3 Salman 45\") = \"36 25 45\" ]]\n    [[ $(candidate \"1 Sudeep 14\\n2 Vandana 36\\n3 Dawood 56\") = \"14 36 56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsubstract_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    substract_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5\" \"2 5 18\") = \"8 -1 -13\" ]]\n    [[ $(candidate \"11 2 3\" \"24 45 16\") = \"-13 -43 -13\" ]]\n    [[ $(candidate \"7 18 9\" \"10 11 12\") = \"-3 7 -3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n#\n# $1 is an integer\neven_binomial_Coeff_Sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_binomial_Coeff_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"8\" ]]\n    [[ $(candidate \"6\") = \"32\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the number of elements that occurs before the list element in the given tuple.\n#\n# $1 is a newline-separated, space-separated list\ncount_first_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_first_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"3\" ]]\n    [[ $(candidate \"2 9 5 7 11\") = \"2\" ]]\n    [[ $(candidate \"11 15 5 8 2 3 8\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth decagonal number.\n#\n# $1 is an integer\nis_num_decagonal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_num_decagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"7\") = \"175\" ]]\n    [[ $(candidate \"10\") = \"370\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n#\n# $1 is a space-separated list\n# $2 is an integer\nsequential_search() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sequential_search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 23 58 31 56 77 43 12 65 19\" \"31\") = \"true 3\" ]]\n    [[ $(candidate \"12 32 45 62 35 47 44 61\" \"61\") = \"true 7\" ]]\n    [[ $(candidate \"9 10 17 19 22 39 48 56\" \"48\") = \"true 6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check if the elements of a given list are unique or not.\n#\n# $1 is a space-separated list\nall_unique() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to subtract two lists element-wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsub_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sub_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"-3 -3 -3\" ]]\n    [[ $(candidate \"1 2\" \"3 4\") = \"-2 -2\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"40 50\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n#\n# $1 is an integer\nvalidate() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    validate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1234\") = \"true\" ]]\n    [[ $(candidate \"51241\") = \"false\" ]]\n    [[ $(candidate \"321\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n#\n# $1 is a space-separated list\n# $2 is a $Any\ncheck_element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange black white\" \"blue\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7\") = \"false\" ]]\n    [[ $(candidate \"green green green green\" \"green\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n#\n# $1 is a string\ntext_match_two_three() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_two_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nmax_sub_array_sum_repeated() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_sub_array_sum_repeated \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 -30 -1\" \"4\" \"3\") = \"30\" ]]\n    [[ $(candidate \"-1 10 20\" \"3\" \"2\") = \"59\" ]]\n    [[ $(candidate \"-1 -2 -3\" \"3\" \"3\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"20\" ]]\n    [[ $(candidate \"3\") = \"56\" ]]\n    [[ $(candidate \"4\") = \"120\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the list of maximum length in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nmax_length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1\\n5 7\\n10 12 14 15\") = \"4 10 12 14 15\" ]]\n    [[ $(candidate \"5\\n15 20 25\") = \"3 15 20 25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n#\n# $1 is an integer\n# $2 is an integer\ncount_no_of_ways() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_no_of_ways \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"4\") = \"16\" ]]\n    [[ $(candidate \"3\" \"2\") = \"6\" ]]\n    [[ $(candidate \"4\" \"4\") = \"228\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find quotient of two numbers (rounded down to the nearest integer).\n#\n# $1 is an integer\n# $2 is an integer\nfind() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"3\") = \"3\" ]]\n    [[ $(candidate \"4\" \"2\") = \"2\" ]]\n    [[ $(candidate \"20\" \"5\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the third side of a right angled triangle.\n#\n# $1 is an integer\n# $2 is an integer\notherside_rightangle() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    otherside_rightangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"8\") = \"10.63014581273465\" ]]\n    [[ $(candidate \"3\" \"4\") = \"5\" ]]\n    [[ $(candidate \"7\" \"15\") = \"16.55294535724685\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmax_val() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"5\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"25\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"50\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to return the sum of all divisors of a number.\n#\n# $1 is an integer\nsum_div() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_div \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"7\" ]]\n    [[ $(candidate \"12\") = \"16\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count inversions in an array.\n#\n# $1 is a space-separated list\nget_Inv_Count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_Inv_Count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 20 6 4 5\") = \"5\" ]]\n    [[ $(candidate \"1 2 1\") = \"1\" ]]\n    [[ $(candidate \"1 2 5 6 1\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to flatten a given nested list structure.\n#\n# $1 is a newline-separated, space-separated list\nflatten_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    flatten_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 10 20 30 40 50 60 70 80 90 100 110 120\") = \"0 10 20 30 40 50 60 70 80 90 100 110 120\" ]]\n    [[ $(candidate \"10 20\\n40\\n30 56 25\\n10 20\\n33\\n40\") = \"10 20 40 30 56 25 10 20 33 40\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"1 2 3 4 5 6 10 11 12 7 8 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find element at a given index after number of rotations.\n#\n# $1 is a space-separated list\n# $2 is a newline-separated, space-separated list\n# $3 is an integer\n# $4 is an integer\nfind_Element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"0 2\\n0 3\" \"2\" \"1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\" \"0 1\\n0 2\" \"1\" \"2\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"0 1\\n0 2\" \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\n# $4 is an integer\nmax_sum_increasing_subseq() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_sum_increasing_subseq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"4\" \"6\") = \"11\" ]]\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"2\" \"5\") = \"7\" ]]\n    [[ $(candidate \"11 15 19 21 26 28 31\" \"7\" \"2\" \"4\") = \"71\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nlarge_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    large_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"3\") = \"60 54 50\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"4\") = \"60 54 50 48\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"5\") = \"60 54 50 48 45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the maximum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nmaximum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"10\") = \"10\" ]]\n    [[ $(candidate \"-1\" \"-2\") = \"-1\" ]]\n    [[ $(candidate \"9\" \"7\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a given string to a list of characters.\n#\n# $1 is a string\nstring_to_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    string_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python 3.0\") = \"p y t h o n 3 . 0\" ]]\n    [[ $(candidate \"item1\") = \"i t e m 1\" ]]\n    [[ $(candidate \"15.10\") = \"1 5 . 1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the highest power of 2 that is less than or equal to n.\n#\n# $1 is an integer\nhighest_Power_of_2() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    highest_Power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"8\" ]]\n    [[ $(candidate \"19\") = \"16\" ]]\n    [[ $(candidate \"32\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n'th lucas number.\n#\n# $1 is an integer\nfind_lucas() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_lucas \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"76\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"3\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to apply a given format string to all of the elements in a list.\n#\n# $1 is a space-separated list\n# $2 is a string\nadd_string() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"temp{0}\") = \"temp1 temp2 temp3 temp4\" ]]\n    [[ $(candidate \"a b c d\" \"python{0}\") = \"pythona pythonb pythonc pythond\" ]]\n    [[ $(candidate \"5 6 7 8\" \"string{0}\") = \"string5 string6 string7 string8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n#\n# $1 is an integer\nget_max_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"60\") = \"106\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the list with maximum length.\n#\n# $1 is a newline-separated, space-separated list\nmax_length_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_length_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1 2 3 4 5\\n1 2 3 4\\n1 2 3\\n1 2\\n1\") = \"5 1 2 3 4 5\" ]]\n    [[ $(candidate \"3 4 5\\n6 7 8 9\\n10 11 12\") = \"4 6 7 8 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if given list contains no duplicates.\n#\n# $1 is a space-separated list\ncheck_distinct() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_distinct \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 5 6 1 4\") = \"false\" ]]\n    [[ $(candidate \"1 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 6\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the first non-repeated character in a given string.\n#\n# $1 is a string\nfirst_non_repeating_character() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    first_non_repeating_character \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"None\" ]]\n    [[ $(candidate \"abc\") = \"a\" ]]\n    [[ $(candidate \"ababc\") = \"c\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given string starts and ends with the same character or not.\n#\n# $1 is a string\ncheck_char() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abba\") = \"Valid\" ]]\n    [[ $(candidate \"a\") = \"Valid\" ]]\n    [[ $(candidate \"abcd\") = \"Invalid\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_numbers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    median_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25\" \"55\" \"65\") = \"55.0\" ]]\n    [[ $(candidate \"20\" \"10\" \"30\") = \"20.0\" ]]\n    [[ $(candidate \"15\" \"45\" \"75\") = \"45.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to compute the sum of digits of each number of a given list.\n#\n# $1 is a space-separated list\nsum_of_digits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_of_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 2 56\") = \"14\" ]]\n    [[ $(candidate \"10 20 4 5 b 70 a\") = \"19\" ]]\n    [[ $(candidate \"10 20 -4 5 -70\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform the mathematical bitwise xor operation across the given tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nbitwise_xor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    bitwise_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"15 6 5 10\" ]]\n    [[ $(candidate \"11 5 7 10\" \"6 3 4 4\") = \"13 6 3 14\" ]]\n    [[ $(candidate \"12 6 8 11\" \"7 4 5 6\") = \"11 2 13 13\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to identify non-prime numbers.\n#\n# $1 is an integer\nis_not_prime() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_not_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"35\") = \"true\" ]]\n    [[ $(candidate \"37\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract the number of unique tuples in the given list.\n#\n# $1 is a newline-separated, space-separated list\nextract_freq() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_freq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 2\\n4 3\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"4 15\\n2 3\\n5 4\\n6 7\") = \"4\" ]]\n    [[ $(candidate \"5 16\\n2 3\\n6 5\\n6 9\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform index wise addition of list elements in the given two nested lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nadd_nested_tuples() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_nested_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"7 10\\n7 14\\n3 10\\n8 13\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"9 12\\n9 16\\n5 12\\n10 15\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"11 14\\n11 18\\n7 14\\n12 17\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the minimum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nminimum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"-5\" \"-4\") = \"-5\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether an element exists within a tuple.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncheck_tuplex() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_tuplex \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"w 3 r e s o u r c e\" \"r\") = \"true\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"5\") = \"false\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"3\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find whether the parity of a given number is odd.\n#\n# $1 is an integer\nfind_Parity() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Parity \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"false\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to create the next bigger number by rearranging the digits of a given number.\n#\n# $1 is an integer\nrearrange_bigger() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rearrange_bigger \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"21\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"102\") = \"120\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nk_smallest_pairs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    k_smallest_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"2\") = \"1 2\\n1 4\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"1\") = \"1 2\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"7\") = \"1 2\\n1 4\\n3 2\\n1 6\\n3 4\\n3 6\\n7 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the minimum product from the pairs of tuples within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmin_product_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"8\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"30\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"100\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the minimum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmin_val() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"2\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"15\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"20\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"android_tv\") = \"AndroidTv\" ]]\n    [[ $(candidate \"google_pixel\") = \"GooglePixel\" ]]\n    [[ $(candidate \"apple_watch\") = \"AppleWatch\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to remove odd numbers from a given list.\n#\n# $1 is a space-separated list\nremove_odd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"2\" ]]\n    [[ $(candidate \"2 4 6\") = \"2 4 6\" ]]\n    [[ $(candidate \"10 20 3\") = \"10 20\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether any value in a sequence exists in a sequence or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\noverlapping() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    overlapping \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 4 5\" \"1 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find a pair with highest product from a given array of integers.\n#\n# $1 is a space-separated list\nmax_Product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_Product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 7 0 8 4\") = \"7 8\" ]]\n    [[ $(candidate \"0 -1 -2 -4 5 0 -6\") = \"-4 -6\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4564,7 +1636,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find common first element in given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ngroup_tuples() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\ncandidate() {\n    group_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\nx z\\nw t\") = \"x y z\\nw t\" ]]\n    [[ $(candidate \"a b\\na c\\nd e\") = \"a b c\\nd e\" ]]\n    [[ $(candidate \"f g\\nf g\\nh i\") = \"f g g\\nh i\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4572,13 +1644,2941 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to merge three lists into a single sorted list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nmerge_sorted_list() {\n",
+    "prompt": "#!/bin/bash\n# Write a python function to find the element of a list having maximum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max() {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\ncandidate() {\n    merge_sorted_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 24 15 4 5 29 110\" \"19 20 11 56 25 233 154\" \"24 26 54 48\") = \"4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233\" ]]\n    [[ $(candidate \"1 3 5 6 8 9\" \"2 5 7 11\" \"1 4 7 8 12\") = \"1 1 2 3 4 5 5 6 7 7 8 8 9 11 12\" ]]\n    [[ $(candidate \"18 14 10 9 8 7 9 3 2 4 1\" \"25 35 22 85 14 65 75 25 58\" \"12 74 9 50 61 41\") = \"1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    Find_Max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\\nA B\\nA B C\") = \"A B C\" ]]\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"1 1\\n1 2 3\\n1 5 6 1\") = \"1 5 6 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n#\n# $1 is a newline-separated, space-separated list\nround_and_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    round_and_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5\") = \"243\" ]]\n    [[ $(candidate \"5 2 9 24.3 29\") = \"345\" ]]\n    [[ $(candidate \"25.0 56.7 89.2\") = \"513\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the cube sum of first n even natural numbers.\n#\n# $1 is an integer\ncube_Sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cube_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"72\" ]]\n    [[ $(candidate \"3\") = \"288\" ]]\n    [[ $(candidate \"4\") = \"800\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to concatenate each element of tuple by the delimiter.\n#\n# $1 is a space-separated list\nconcatenate_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    concatenate_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ID is 4 UTS\") = \"ID-is-4-UTS\" ]]\n    [[ $(candidate \"QWE is 4 RTY\") = \"QWE-is-4-RTY\" ]]\n    [[ $(candidate \"ZEN is 4 OP\") = \"ZEN-is-4-OP\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the average of cubes of first n natural numbers.\n#\n# $1 is an integer\nfind_Average_Of_Cube() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Average_Of_Cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4.5\" ]]\n    [[ $(candidate \"3\") = \"12\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract only the rear index element of each string in the given tuple.\n#\n# $1 is a space-separated list\nextract_rear() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_rear \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mers for Vers\") = \"s r s\" ]]\n    [[ $(candidate \"Avenge for People\") = \"e r e\" ]]\n    [[ $(candidate \"Gotta get go\") = \"a t o\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of sublists containing a particular element.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncount_element_in_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_element_in_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n1 11\\n1 15 7\" \"1\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"A\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"E\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to filter odd numbers.\n#\n# $1 is a space-separated list\nfilter_oddnumbers() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    filter_oddnumbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 3 5 7 9\" ]]\n    [[ $(candidate \"10 20 45 67 84 93\") = \"45 67 93\" ]]\n    [[ $(candidate \"5 7 9 8 6 4 3\") = \"5 7 9 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n#\n# $1 is a string\nchange_date_format() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    change_date_format \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2026-01-02\") = \"02-01-2026\" ]]\n    [[ $(candidate \"2020-11-13\") = \"13-11-2020\" ]]\n    [[ $(candidate \"2021-04-26\") = \"26-04-2021\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort the given array by using shell sort.\n#\n# $1 is a space-separated list\nshell_sort() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    shell_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 23 4 5 3 2 12 81 56 95\") = \"2 3 4 5 12 12 23 56 81 95\" ]]\n    [[ $(candidate \"24 22 39 34 87 73 68\") = \"22 24 34 39 68 73 87\" ]]\n    [[ $(candidate \"32 30 16 96 82 83 74\") = \"16 30 32 74 82 83 96\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract the elementwise and tuples from the given two tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nand_tuples() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    and_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"0 0 2 1\" ]]\n    [[ $(candidate \"1 2 3 4\" \"5 6 7 8\") = \"1 2 3 0\" ]]\n    [[ $(candidate \"8 9 11 12\" \"7 13 14 17\") = \"0 9 10 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the directrix of a parabola.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nparabola_directrix() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    parabola_directrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\" \"2\") = \"-198\" ]]\n    [[ $(candidate \"9\" \"8\" \"4\") = \"-2336\" ]]\n    [[ $(candidate \"2\" \"4\" \"6\") = \"-130\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes two lists and returns true if they have at least one common element.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon_element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    common_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8 9\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"None\" ]]\n    [[ $(candidate \"a b c\" \"d b e\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median length of a trapezium.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_trapezium() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    median_trapezium \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\" \"25\" \"35\") = \"20\" ]]\n    [[ $(candidate \"10\" \"20\" \"30\") = \"15\" ]]\n    [[ $(candidate \"6\" \"9\" \"4\") = \"7.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the entered number is greater than the elements of the given array.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_greater() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_greater \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2 3 4 5 6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"9 7 4 8 6 1\" \"11\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by one or more b's.\n#\n# $1 is a string\ntext_match_one() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the last digit of a given number.\n#\n# $1 is an integer\nlast_Digit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    last_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"25\") = \"5\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to return the negative numbers in a list.\n#\n# $1 is a space-separated list\nneg_nos() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    neg_nos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 4 5 -6\") = \"-1 -6\" ]]\n    [[ $(candidate \"-1 -2 3 4\") = \"-1 -2\" ]]\n    [[ $(candidate \"-7 -6 8 9\") = \"-7 -6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove odd characters in a string.\n#\n# $1 is a string\nremove_odd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"yhn\" ]]\n    [[ $(candidate \"program\") = \"rga\" ]]\n    [[ $(candidate \"language\") = \"agae\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count bidirectional tuple pairs.\n#\n# $1 is a newline-separated, space-separated list\ncount_bidirectional() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_bidirectional \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 1\\n6 5\\n2 1\") = \"3\" ]]\n    [[ $(candidate \"5 6\\n1 3\\n6 5\\n9 1\\n6 5\\n2 1\") = \"2\" ]]\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 2\\n6 5\\n2 1\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to join a list of multiple integers into a single integer.\n#\n# $1 is a space-separated list\nmultiple_to_single() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    multiple_to_single \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 33 50\") = \"113350\" ]]\n    [[ $(candidate \"-1 2 3 4 5 6\") = \"-123456\" ]]\n    [[ $(candidate \"10 15 20 25\") = \"10152025\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the first adverb and their positions in a given sentence.\n#\n# $1 is a string\nfind_adverb_position() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_adverb_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"clearly\\!\\! we can see the sky\") = \"0 7 clearly\" ]]\n    [[ $(candidate \"seriously\\!\\! there are many roses\") = \"0 9 seriously\" ]]\n    [[ $(candidate \"unfortunately\\!\\! sita is going to home\") = \"0 13 unfortunately\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cube of a given size.\n#\n# $1 is an integer\nsurfacearea_cube() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    surfacearea_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"150\" ]]\n    [[ $(candidate \"3\") = \"54\" ]]\n    [[ $(candidate \"10\") = \"600\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the ration of positive numbers in an array of integers.\n#\n# $1 is a space-separated list\npositive_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    positive_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\") = \"0.54\" ]]\n    [[ $(candidate \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"0.69\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"0.56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the largest negative number from the given list.\n#\n# $1 is a space-separated list\nlargest_neg() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    largest_neg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 -4 -6\") = \"-6\" ]]\n    [[ $(candidate \"1 2 3 -8 -9\") = \"-9\" ]]\n    [[ $(candidate \"1 2 3 4 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to trim each list by k in the given lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\ntrim_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    trim_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"2\") = \"2\\n9\\n2\\n2\" ]]\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"1\") = \"3 2 1\\n4 9 2\\n1 2 3\\n8 2 1\" ]]\n    [[ $(candidate \"7 8 4 9\\n11 8 12 4\\n4 1 7 8\\n3 6 9 7\" \"1\") = \"8 4\\n8 12\\n1 7\\n6 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform index wise multiplication of list elements in the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nindex_multiplication() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    index_multiplication \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 21\\n12 45\\n2 9\\n7 30\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"14 32\\n20 60\\n6 20\\n16 44\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"24 45\\n30 77\\n12 33\\n27 60\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the occurence of all elements of list in a tuple.\n#\n# $1 is a $Any\n# $2 is a space-separated list\ncount_Occurrence() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_Occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a a c b d\" \"a b\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 1 4 6 7 1 4\" \"1 4 7\") = \"6\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"1 2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find cubes of individual elements in a list.\n#\n# $1 is a space-separated list\ncube_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cube_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 8 27 64 125 216 343 512 729 1000\" ]]\n    [[ $(candidate \"10 20 30\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\") = \"1728 3375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of perrin numbers.\n#\n# $1 is an integer\ncal_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cal_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"49\" ]]\n    [[ $(candidate \"10\") = \"66\" ]]\n    [[ $(candidate \"11\") = \"88\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract specified size of strings from a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is an integer\nextract_string() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python list exercises practice solution\" \"8\") = \"practice solution\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"6\") = \"Python\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"9\") = \"exercises\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from the given string.\n#\n# $1 is a string\nremove_whitespaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_whitespaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \" Google    Flutter \") = \"GoogleFlutter\" ]]\n    [[ $(candidate \" Google    Dart \") = \"GoogleDart\" ]]\n    [[ $(candidate \" iOS    Swift \") = \"iOSSwift\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n#\n# $1 is an integer\n# $2 is an integer\nloss_amount() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    loss_amount \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"0\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"3000\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of even factors of a number.\n#\n# $1 is an integer\nsumofFactors() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sumofFactors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"18\") = \"26\" ]]\n    [[ $(candidate \"30\") = \"48\" ]]\n    [[ $(candidate \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a word containing 'z'.\n#\n# $1 is a string\ntext_match_wordz() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_wordz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonz.\") = \"true\" ]]\n    [[ $(candidate \"xyz.\") = \"true\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 31 days or not.\n#\n# $1 is an integer\ncheck_monthnumb_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_monthnumb_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to reverse each string in a given list of string values.\n#\n# $1 is a space-separated list\nreverse_string_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    reverse_string_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue White Black\") = \"deR neerG eulB etihW kcalB\" ]]\n    [[ $(candidate \"john amal joel george\") = \"nhoj lama leoj egroeg\" ]]\n    [[ $(candidate \"jack john mary\") = \"kcaj nhoj yram\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sublist having minimum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Find_Min \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1\" ]]\n    [[ $(candidate \"1 1\\n1 1 1\\n1 2 7 8\") = \"1 1\" ]]\n    [[ $(candidate \"x\\nx y\\nx y z\") = \"x\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the area of a rectangle.\n#\n# $1 is an integer\n# $2 is an integer\nrectangle_area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rectangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"10\" \"5\") = \"50\" ]]\n    [[ $(candidate \"4\" \"2\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove uppercase substrings from a given string.\n#\n# $1 is a string\nremove_uppercase() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"cAstyoUrFavoRitETVshoWs\") = \"cstyoravoitshos\" ]]\n    [[ $(candidate \"wAtchTheinTernEtrAdIo\") = \"wtchheinerntrdo\" ]]\n    [[ $(candidate \"VoicESeaRchAndreComMendaTionS\") = \"oiceachndreomendaion\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to get the first element of each sublist.\n#\n# $1 is a newline-separated, space-separated list\nExtract() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\\n3 4 5\\n6 7 8 9\") = \"1 3 6\" ]]\n    [[ $(candidate \"1 2 3\\n4 5\") = \"1 4\" ]]\n    [[ $(candidate \"9 8 1\\n1 2\") = \"9 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the upper case characters in a given string.\n#\n# $1 is a string\nupper_ctr() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    upper_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYthon\") = \"1\" ]]\n    [[ $(candidate \"BigData\") = \"1\" ]]\n    [[ $(candidate \"program\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find all possible combinations of the elements of a given list.\n#\n# $1 is a space-separated list\ncombinations_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    combinations_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"orange red green blue\") = \"\\norange\\nred\\nred orange\\ngreen\\ngreen orange\\ngreen red\\ngreen red orange\\nblue\\nblue orange\\nblue red\\nblue red orange\\nblue green\\nblue green orange\\nblue green red\\nblue green red orange\" ]]\n    [[ $(candidate \"red green blue white black orange\") = \"\\nred\\ngreen\\ngreen red\\nblue\\nblue red\\nblue green\\nblue green red\\nwhite\\nwhite red\\nwhite green\\nwhite green red\\nwhite blue\\nwhite blue red\\nwhite blue green\\nwhite blue green red\\nblack\\nblack red\\nblack green\\nblack green red\\nblack blue\\nblack blue red\\nblack blue green\\nblack blue green red\\nblack white\\nblack white red\\nblack white green\\nblack white green red\\nblack white blue\\nblack white blue red\\nblack white blue green\\nblack white blue green red\\norange\\norange red\\norange green\\norange green red\\norange blue\\norange blue red\\norange blue green\\norange blue green red\\norange white\\norange white red\\norange white green\\norange white green red\\norange white blue\\norange white blue red\\norange white blue green\\norange white blue green red\\norange black\\norange black red\\norange black green\\norange black green red\\norange black blue\\norange black blue red\\norange black blue green\\norange black blue green red\\norange black white\\norange black white red\\norange black white green\\norange black white green red\\norange black white blue\\norange black white blue red\\norange black white blue green\\norange black white blue green red\" ]]\n    [[ $(candidate \"red green black orange\") = \"\\nred\\ngreen\\ngreen red\\nblack\\nblack red\\nblack green\\nblack green red\\norange\\norange red\\norange green\\norange green red\\norange black\\norange black red\\norange black green\\norange black green red\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum product subarray of the given array.\n#\n# $1 is a space-separated list\nmax_subarray_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_subarray_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 0 7 -8 -2\") = \"112\" ]]\n    [[ $(candidate \"6 -3 -10 0 2\") = \"180\" ]]\n    [[ $(candidate \"-2 -40 0 -2 -3\") = \"80\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to drop empty items from a given dictionary.\n#\n# $1 is a two column CSV in key,value order\ndrop_empty() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    drop_empty \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"c1,Red\\nc2,Green\\nc3,None\") = \"c1,Red\\nc2,Green\" ]]\n    [[ $(candidate \"c1,Red\\nc2,None\\nc3,None\") = \"c1,Red\" ]]\n    [[ $(candidate \"c1,None\\nc2,Green\\nc3,None\") = \"c2,Green\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n#\n# $1 is a space-separated list\nmax_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 100 4 5 150 6\") = \"3000\" ]]\n    [[ $(candidate \"4 42 55 68 80\") = \"50265600\" ]]\n    [[ $(candidate \"10 22 9 33 21 50 41 60\") = \"2460\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the pairwise addition of the neighboring elements of the given tuple.\n#\n# $1 is a space-separated list\nadd_pairwise() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_pairwise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"6 12 15 18\" ]]\n    [[ $(candidate \"2 6 8 9 11\") = \"8 14 17 20\" ]]\n    [[ $(candidate \"3 7 9 10 12\") = \"10 16 19 22\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the product of the array multiplication modulo n.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_remainder() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_remainder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100 10 5 25 35 14\" \"11\") = \"9\" ]]\n    [[ $(candidate \"1 1 1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 2 1\" \"2\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given list contains consecutive numbers or not.\n#\n# $1 is a space-separated list\ncheck_Consecutive() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_Consecutive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace characters in a string.\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nreplace_char() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"polygon\" \"y\" \"l\") = \"pollgon\" ]]\n    [[ $(candidate \"character\" \"c\" \"a\") = \"aharaater\" ]]\n    [[ $(candidate \"python\" \"l\" \"a\") = \"python\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a dictionary by value.\n#\n# $1 is a two column CSV in key,value order\nsort_counter() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_counter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Math,81\\nPhysics,83\\nChemistry,87\") = \"Chemistry 87\\nPhysics 83\\nMath 81\" ]]\n    [[ $(candidate \"Math,400\\nPhysics,300\\nChemistry,250\") = \"Math 400\\nPhysics 300\\nChemistry 250\" ]]\n    [[ $(candidate \"Math,900\\nPhysics,1000\\nChemistry,1250\") = \"Chemistry 1250\\nPhysics 1000\\nMath 900\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the largest and smallest value in a given array.\n#\n# $1 is a space-separated list\nbig_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    big_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"4\" ]]\n    [[ $(candidate \"-1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"2 3 6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to convert the given string to lower case.\n#\n# $1 is a string\nis_lower() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_lower \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"InValid\") = \"invalid\" ]]\n    [[ $(candidate \"TruE\") = \"true\" ]]\n    [[ $(candidate \"SenTenCE\") = \"sentence\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove lowercase substrings from a given string.\n#\n# $1 is a string\nremove_lowercase() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_lowercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYTHon\") = \"PYTH\" ]]\n    [[ $(candidate \"FInD\") = \"FID\" ]]\n    [[ $(candidate \"STRinG\") = \"STRG\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the first digit of a given number.\n#\n# $1 is an integer\nfirst_Digit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    first_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"1\" ]]\n    [[ $(candidate \"456\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nheap_queue_largest() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    heap_queue_largest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"3\") = \"85 75 65\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"2\") = \"85 75\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"5\") = \"85 75 65 58 35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function which takes a list of integers and only returns the odd ones.\n#\n# $1 is a space-separated list\nSplit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1 3 5\" ]]\n    [[ $(candidate \"10 11 12 13\") = \"11 13\" ]]\n    [[ $(candidate \"7 8 9 1\") = \"7 9 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n#\n# $1 is an integer\ndifference() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"30\" ]]\n    [[ $(candidate \"5\") = \"210\" ]]\n    [[ $(candidate \"2\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of pairs whose xor value is odd.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_Odd_Pair() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Odd_Pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\" \"5\") = \"6\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\" \"7\") = \"12\" ]]\n    [[ $(candidate \"1 2 3\" \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to toggle the case of all characters in a string.\n#\n# $1 is a string\ntoggle_string() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    toggle_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"pYTHON\" ]]\n    [[ $(candidate \"Pangram\") = \"pANGRAM\" ]]\n    [[ $(candidate \"LIttLE\") = \"liTTle\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the per-digit difference between two integers.\n#\n# $1 is an integer\n# $2 is an integer\ndigit_distance_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    digit_distance_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"23\" \"56\") = \"6\" ]]\n    [[ $(candidate \"123\" \"256\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the sum of the largest contiguous sublist in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmax_sub_array_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_sub_array_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-2 -3 4 -1 -2 1 5 -3\" \"8\") = \"7\" ]]\n    [[ $(candidate \"-3 -4 5 -2 -3 2 6 -4\" \"8\") = \"8\" ]]\n    [[ $(candidate \"-4 -5 6 -3 -4 3 7 -5\" \"8\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the union of the elements of two given lists and output them in sorted order.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nunion_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    union_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 4 5 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"3 4 5 6\") = \"1 2 3 4 5 6\" ]]\n    [[ $(candidate \"11 12 13 14\" \"13 15 16 17\") = \"11 12 13 14 15 16 17\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the length of the longest sublists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max_Length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Find_Max_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 4\\n5 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"0 1\\n2 2\\n3 2 1\") = \"3\" ]]\n    [[ $(candidate \"7\\n22 23\\n13 14 15\\n10 20 30 40 50\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract values between quotation marks from a string.\n#\n# $1 is a string\nextract_values() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_values \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") = \"Python PHP Java\" ]]\n    [[ $(candidate \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") = \"python program language\" ]]\n    [[ $(candidate \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") = \"red blue green yellow\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_Pairs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_Pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 1\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 1 1 1\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to split a string into characters.\n#\n# $1 is a string\nsplit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"p y t h o n\" ]]\n    [[ $(candidate \"Name\") = \"N a m e\" ]]\n    [[ $(candidate \"program\") = \"p r o g r a m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get the sum of the digits of a non-negative integer.\n#\n# $1 is an integer\nsum_digits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"345\") = \"12\" ]]\n    [[ $(candidate \"12\") = \"3\" ]]\n    [[ $(candidate \"97\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a specified list is sorted or not.\n#\n# $1 is a space-separated list\nissort_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    issort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 6 8 10 12 14 16 17\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 12 14 20 17\") = \"false\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 15 14 20\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort each sublist of strings in a given list of lists.\n#\n# $1 is a newline-separated, space-separated list\nsort_sublists() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sort_sublists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange\\nblack white\\nwhite black orange\") = \"green orange\\nblack white\\nblack orange white\" ]]\n    [[ $(candidate \"green orange\\nblack\\ngreen orange\\nwhite\") = \"green orange\\nblack\\ngreen orange\\nwhite\" ]]\n    [[ $(candidate \"a b\\nd c\\ng h\\nf e\") = \"a b\\nc d\\ng h\\ne f\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check if a given number is one less than twice its reverse.\n#\n# $1 is an integer\nchecks() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    checks \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"70\") = \"false\" ]]\n    [[ $(candidate \"23\") = \"false\" ]]\n    [[ $(candidate \"73\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to remove duplicate numbers from a given number of lists.\n#\n# $1 is a space-separated list\ntwo_unique_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    two_unique_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2 3 4 5\") = \"1 4 5\" ]]\n    [[ $(candidate \"1 2 3 2 4 5\") = \"1 3 4 5\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 2 3 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to calculate the product of the unique numbers in a given list.\n#\n# $1 is a space-separated list\nunique_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30 40 20 50 60 40\") = \"720000000\" ]]\n    [[ $(candidate \"1 2 3 1\") = \"6\" ]]\n    [[ $(candidate \"7 8 9 0 1 1\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cylinder.\n#\n# $1 is an integer\n# $2 is an integer\nsurfacearea_cylinder() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    surfacearea_cylinder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"5\") = \"942.45\" ]]\n    [[ $(candidate \"4\" \"5\") = \"226.18800000000002\" ]]\n    [[ $(candidate \"4\" \"10\") = \"351.848\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether a list is sublist of another or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_Sub_Array() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_Sub_Array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 5\" \"1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\" \"1 2 1\") = \"true\" ]]\n    [[ $(candidate \"1 0 2 2\" \"2 2 0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the last digit in factorial of a given number.\n#\n# $1 is an integer\nlast_Digit_Factorial() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    last_Digit_Factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"4\" ]]\n    [[ $(candidate \"21\") = \"0\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to interleave 3 lists of the same length into a single flat list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ninterleave_lists() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    interleave_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7\" \"10 20 30 40 50 60 70\" \"100 200 300 400 500 600 700\") = \"1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700\" ]]\n    [[ $(candidate \"10 20\" \"15 2\" \"5 10\") = \"10 15 5 20 2 10\" ]]\n    [[ $(candidate \"11 44\" \"10 15\" \"20 5\") = \"11 10 20 44 15 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the dissimilar elements in the given two tuples.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nfind_dissimilar() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_dissimilar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7 2 3 9\") = \"1 4 7 9\" ]]\n    [[ $(candidate \"21 11 25 26\" \"26 34 21 36\") = \"34 36 11 25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the largest number that can be formed with the given list of digits.\n#\n# $1 is a space-separated list\nfind_Max_Num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Max_Num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"321\" ]]\n    [[ $(candidate \"4 5 6 1\") = \"6541\" ]]\n    [[ $(candidate \"1 2 3 9\") = \"9321\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove uneven elements in the nested mixed tuple.\n#\n# $1 is a space-separated list\nextract_even() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 7 6 2 4 6 8\") = \"4 6 2 4 6 8\" ]]\n    [[ $(candidate \"5 6 8 7 4 8 7 9\") = \"6 8 4 8\" ]]\n    [[ $(candidate \"5 6 9 8 4 6 8 10\") = \"6 8 4 6 8 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the surface area of a square pyramid with a given base edge and height.\n#\n# $1 is an integer\n# $2 is an integer\nsurface_Area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    surface_Area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"33\" ]]\n    [[ $(candidate \"4\" \"5\") = \"56\" ]]\n    [[ $(candidate \"1\" \"2\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which returns nth catalan number.\n#\n# $1 is an integer\ncatalan_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    catalan_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"16796\" ]]\n    [[ $(candidate \"9\") = \"4862\" ]]\n    [[ $(candidate \"7\") = \"429\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the first adverb ending with ly and its positions in a given string.\n#\n# $1 is a string\nfind_adverbs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_adverbs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Clearly, he has no excuse for such behavior.\") = \"0-7: Clearly\" ]]\n    [[ $(candidate \"Please handle the situation carefuly\") = \"28-36: carefuly\" ]]\n    [[ $(candidate \"Complete the task quickly\") = \"18-25: quickly\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to split a list at the nth eelment and add the first part to the end.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_Arr() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    split_Arr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 10 5 6 52 36\" \"2\") = \"5 6 52 36 12 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1\") = \"2 3 4 1\" ]]\n    [[ $(candidate \"0 1 2 3 4 5 6 7\" \"3\") = \"3 4 5 6 7 0 1 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a list to a tuple.\n#\n# $1 is a space-separated list\nlist_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    list_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 10 7 4 15 3\") = \"5 10 7 4 15 3\" ]]\n    [[ $(candidate \"2 4 5 6 2 3 4 4 7\") = \"2 4 5 6 2 3 4 4 7\" ]]\n    [[ $(candidate \"58 44 56\") = \"58 44 56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the difference between largest and smallest value in a given list.\n#\n# $1 is a space-separated list\nbig_diff() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    big_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"4 5 12\") = \"8\" ]]\n    [[ $(candidate \"9 2 3\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find perfect squares between two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nperfect_squares() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    perfect_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"30\") = \"1 4 9 16 25\" ]]\n    [[ $(candidate \"50\" \"100\") = \"64 81 100\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100 121 144 169 196\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given two integers have opposite sign or not.\n#\n# $1 is an integer\n# $2 is an integer\nopposite_Signs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    opposite_Signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"-2\") = \"true\" ]]\n    [[ $(candidate \"3\" \"2\") = \"false\" ]]\n    [[ $(candidate \"-10\" \"-10\") = \"false\" ]]\n    [[ $(candidate \"-2\" \"2\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to interchange the first and last elements in a list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 35 9 56 24\") = \"24 35 9 56 12\" ]]\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of the product of consecutive binomial co-efficients.\n#\n# $1 is an integer\nsum_Of_product() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_Of_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15\" ]]\n    [[ $(candidate \"4\") = \"56\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove leading zeroes from an ip address.\n#\n# $1 is a string\nremovezero_ip() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    removezero_ip \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"216.08.094.196\") = \"216.8.94.196\" ]]\n    [[ $(candidate \"12.01.024\") = \"12.1.24\" ]]\n    [[ $(candidate \"216.08.094.0196\") = \"216.8.94.196\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the difference of the first even and first odd number of a given list.\n#\n# $1 is a space-separated list\ndiff_even_odd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    diff_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\n#\n# $1 is a string\n# $2 is a string\nmin_Swaps() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_Swaps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1101\" \"1110\") = \"1\" ]]\n    [[ $(candidate \"111\" \"000\") = \"Not Possible\" ]]\n    [[ $(candidate \"111\" \"110\") = \"Not Possible\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find kth element from the given two sorted arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nfind_kth() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_kth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 6 7 9\" \"1 4 8 10\" \"5\") = \"6\" ]]\n    [[ $(candidate \"100 112 256 349 770\" \"72 86 113 119 265 445 892\" \"7\") = \"256\" ]]\n    [[ $(candidate \"3 4 7 8 10\" \"2 5 9 11\" \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is armstrong or not.\n#\n# $1 is an integer\narmstrong_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    armstrong_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"153\") = \"true\" ]]\n    [[ $(candidate \"259\") = \"false\" ]]\n    [[ $(candidate \"4458\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find sum and average of first n natural numbers.\n#\n# $1 is an integer\nsum_average() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_average \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55 5.5\" ]]\n    [[ $(candidate \"15\") = \"120 8.0\" ]]\n    [[ $(candidate \"20\") = \"210 10.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth octagonal number.\n#\n# $1 is an integer\nis_octagonal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_octagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"65\" ]]\n    [[ $(candidate \"10\") = \"280\" ]]\n    [[ $(candidate \"15\") = \"645\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number is even or not.\n#\n# $1 is an integer\nis_Even() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_Even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"2\") = \"true\" ]]\n    [[ $(candidate \"3\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the first repeated character in a given string.\n#\n# $1 is a string\nfirst_repeated_char() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    first_repeated_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"a\" ]]\n    [[ $(candidate \"abc\") = \"None\" ]]\n    [[ $(candidate \"123123\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get all lucid numbers smaller than or equal to a given integer.\n#\n# $1 is an integer\nget_ludic() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_ludic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"1 2 3 5 7\" ]]\n    [[ $(candidate \"25\") = \"1 2 3 5 7 11 13 17 23 25\" ]]\n    [[ $(candidate \"45\") = \"1 2 3 5 7 11 13 17 23 25 29 37 41 43\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to reverse words seperated by spaces in a given string.\n#\n# $1 is a string\nreverse_words() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    reverse_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python program\") = \"program python\" ]]\n    [[ $(candidate \"java language\") = \"language java\" ]]\n    [[ $(candidate \"indian man\") = \"man indian\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given integer is a prime number.\n#\n# $1 is an integer\nprime_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    prime_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"-1010\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert degrees to radians.\n#\n# $1 is an integer\nradian_degree() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    radian_degree \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"90\") = \"1.5707963267948966\" ]]\n    [[ $(candidate \"60\") = \"1.0471975511965976\" ]]\n    [[ $(candidate \"120\") = \"2.0943951023931953\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n#\n# $1 is a string\n# $2 is a string\nfind_literals() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_literals \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") = \"fox 16 19\" ]]\n    [[ $(candidate \"Its been a very crazy procedure right\" \"crazy\") = \"crazy 16 21\" ]]\n    [[ $(candidate \"Hardest choices required strongest will\" \"will\") = \"will 35 39\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find nth bell number.\n#\n# $1 is an integer\nbell_Number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    bell_Number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\n#\n# $1 is a space-separated list\n# $2 is an integer\nremove_kth_element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 3 4 4 5 1\" ]]\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\" \"4\") = \"0 0 1 3 4 4 5 6 6 6 7 8 9 4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\" \"5\") = \"10 10 15 19 18 17 26 26 17 18 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_of_nth() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_of_nth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\\n1 3 5\\n8 9 19\" \"2\") = \"19\" ]]\n    [[ $(candidate \"6 7 8\\n2 4 6\\n9 10 20\" \"1\") = \"10\" ]]\n    [[ $(candidate \"7 8 9\\n3 5 7\\n10 11 21\" \"1\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n#\n# $1 is a newline-separated, space-separated list\nmerge() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    merge \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\na b\\nm n\") = \"x a m\\ny b n\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\\n7 8\") = \"1 3 5 7\\n2 4 6 8\" ]]\n    [[ $(candidate \"x y z\\na b c\\nm n o\") = \"x a m\\ny b n\\nz c o\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ncummulative_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    cummulative_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 6 7\\n2 6\") = \"30\" ]]\n    [[ $(candidate \"2 4\\n6 7 8\\n3 7\") = \"37\" ]]\n    [[ $(candidate \"3 5\\n7 8 9\\n4 8\") = \"44\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n#\n# $1 is a newline-separated, space-separated list\naverage_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    average_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 12\\n30 45 56 45\\n81 80 39 32\\n1 2 3 4\") = \"30.5 34.25 27.0 23.25\" ]]\n    [[ $(candidate \"1 1 -5\\n30 -15 56\\n81 -60 -39\\n-10 2 3\") = \"25.5 -18.0 3.75\" ]]\n    [[ $(candidate \"100 100 100 120\\n300 450 560 450\\n810 800 390 320\\n10 20 30 40\") = \"305.0 342.5 270.0 232.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which takes two tuples of the same length and performs the element wise modulo.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntuple_modulo() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tuple_modulo \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6\" \"5 6 7 5\") = \"0 4 5 1\" ]]\n    [[ $(candidate \"11 5 6 7\" \"6 7 8 6\") = \"5 5 6 1\" ]]\n    [[ $(candidate \"12 6 7 8\" \"7 8 9 7\") = \"5 6 7 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmin_Jumps() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_Jumps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\" \"11\") = \"3.5\" ]]\n    [[ $(candidate \"3 4\" \"0\") = \"0\" ]]\n    [[ $(candidate \"11 14\" \"11\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to divide two lists element wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndiv_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    div_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"1 2 3\") = \"4.0 2.5 2.0\" ]]\n    [[ $(candidate \"3 2\" \"1 4\") = \"3.0 0.5\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"1.8 1.7142857142857142\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to move all the numbers to the end of the given string.\n#\n# $1 is a string\nmove_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    move_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"I1love143you55three3000thousand\") = \"Iloveyouthreethousand1143553000\" ]]\n    [[ $(candidate \"Avengers124Assemble\") = \"AvengersAssemble124\" ]]\n    [[ $(candidate \"Its11our12path13to14see15things16do17things\") = \"Itsourpathtoseethingsdothings11121314151617\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of substrings with the sum of digits equal to their length.\n#\n# $1 is a string\ncount_Substrings() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_Substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"112112\") = \"6\" ]]\n    [[ $(candidate \"111\") = \"6\" ]]\n    [[ $(candidate \"1101112\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median of two sorted lists of same size.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nget_median() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 12 15 26 38\" \"2 13 17 30 45\" \"5\") = \"16.0\" ]]\n    [[ $(candidate \"2 4 8 9\" \"7 13 19 28\" \"4\") = \"8.5\" ]]\n    [[ $(candidate \"3 6 14 23 36 42\" \"2 18 27 39 49 55\" \"6\") = \"25.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to compute the n-th power of each number in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nnth_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    nth_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\" \"3\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\" \"5\") = \"248832 759375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to convert a given string to uppercase.\n#\n# $1 is a string\nis_upper() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"person\") = \"PERSON\" ]]\n    [[ $(candidate \"final\") = \"FINAL\" ]]\n    [[ $(candidate \"Valid\") = \"VALID\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to interchange the first and last element in a given list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"4 2 3 4 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n#\n# $1 is an integer\ntriangle_area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1\") = \"None\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"2\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the smallest missing number from a sorted list of natural numbers.\n#\n# $1 is a space-separated list\nfind_First_Missing() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_First_Missing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 3\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 6 9\") = \"3\" ]]\n    [[ $(candidate \"2 3 5 8 9\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace all spaces in the given string with '%20'.\n#\n# $1 is a string\nreplace_spaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"My Name is Dawood\") = \"My%20Name%20is%20Dawood\" ]]\n    [[ $(candidate \"I am a Programmer\") = \"I%20am%20a%20Programmer\" ]]\n    [[ $(candidate \"I love Coding\") = \"I%20love%20Coding\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find even numbers from a list of numbers.\n#\n# $1 is a space-separated list\nSplit() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2 4\" ]]\n    [[ $(candidate \"4 5 6 7 8 0 1\") = \"4 6 8 0\" ]]\n    [[ $(candidate \"8 12 15 19\") = \"8 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find smallest number in a list.\n#\n# $1 is a space-separated list\nsmallest_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    smallest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 1 45 99\") = \"1\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n    [[ $(candidate \"45 46 50 60\") = \"45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract all the adjacent coordinates of the given coordinate tuple.\n#\n# $1 is a space-separated list\nget_coordinates() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_coordinates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\") = \"2 3\\n2 4\\n2 5\\n3 3\\n3 4\\n3 5\\n4 3\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"4 5\") = \"3 4\\n3 5\\n3 6\\n4 4\\n4 5\\n4 6\\n5 4\\n5 5\\n5 6\" ]]\n    [[ $(candidate \"5 6\") = \"4 5\\n4 6\\n4 7\\n5 5\\n5 6\\n5 7\\n6 5\\n6 6\\n6 7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace whitespaces with an underscore and vice versa in a given string.\n#\n# $1 is a string\nreplace_spaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jumanji The Jungle\") = \"Jumanji_The_Jungle\" ]]\n    [[ $(candidate \"The_Avengers\") = \"The Avengers\" ]]\n    [[ $(candidate \"Fast and Furious\") = \"Fast_and_Furious\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to move all zeroes to the end of the given list.\n#\n# $1 is a space-separated list\nmove_zero() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    move_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 0 2 0 3 4\") = \"1 2 3 4 0 0\" ]]\n    [[ $(candidate \"2 3 2 0 0 4 0 5 0\") = \"2 3 2 4 5 0 0 0 0\" ]]\n    [[ $(candidate \"0 1 0 1 1\") = \"1 1 1 0 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of xor of all pairs of numbers in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\npair_xor_Sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pair_xor_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 9 7 6\" \"4\") = \"47\" ]]\n    [[ $(candidate \"7 3 5\" \"3\") = \"12\" ]]\n    [[ $(candidate \"7 3\" \"2\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort the given list.\n#\n# $1 is a space-separated list\nheap_sort() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    heap_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 2 4 6 8 0\") = \"0 1 2 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 25 58\") = \"14 22 25 25 35 58 65 75 85\" ]]\n    [[ $(candidate \"7 1 9 5\") = \"1 5 7 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given amount has no profit and no loss\n#\n# $1 is an integer\n# $2 is an integer\nnoprofit_noloss() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    noprofit_noloss \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"false\" ]]\n    [[ $(candidate \"100\" \"100\") = \"true\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n#\n# $1 is an integer\n# $2 is an integer\nwind_chill() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    wind_chill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"120\" \"35\") = \"40\" ]]\n    [[ $(candidate \"40\" \"20\") = \"19\" ]]\n    [[ $(candidate \"10\" \"8\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n#\n# $1 is a space-separated list\nsample_nam() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sample_nam \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"sally Dylan rebecca Diana Joanne keith\") = \"16\" ]]\n    [[ $(candidate \"php res Python abcd Java aaa\") = \"10\" ]]\n    [[ $(candidate \"abcd Python abba aba\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between available pairs in the given tuple list.\n#\n# $1 is a newline-separated, space-separated list\nmax_difference() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 5\\n1 7\\n10 3\\n1 2\") = \"7\" ]]\n    [[ $(candidate \"4 6\\n2 17\\n9 13\\n11 12\") = \"15\" ]]\n    [[ $(candidate \"12 35\\n21 27\\n13 23\\n41 22\") = \"23\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth nonagonal number.\n#\n# $1 is an integer\nis_nonagonal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_nonagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"325\" ]]\n    [[ $(candidate \"15\") = \"750\" ]]\n    [[ $(candidate \"18\") = \"1089\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that checks if a strings contains 'z', except at the start and end of the word.\n#\n# $1 is a string\ntext_match_wordz_middle() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_wordz_middle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonzabc.\") = \"true\" ]]\n    [[ $(candidate \"zxyabc.\") = \"false\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to reverse an array upto a given position.\n#\n# $1 is a space-separated list\n# $2 is an integer\nreverse_Array_Upto_K() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    reverse_Array_Upto_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"4\") = \"4 3 2 1 5 6\" ]]\n    [[ $(candidate \"4 5 6 7\" \"2\") = \"5 4 6 7\" ]]\n    [[ $(candidate \"9 8 7 6 5\" \"3\") = \"7 8 9 6 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to flatten a list and sum all of its elements.\n#\n# $1 is a newline-separated, space-separated list\nrecursive_list_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    recursive_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"7 10 15 14 19 41\") = \"106\" ]]\n    [[ $(candidate \"10 20 30 40 50 60\") = \"210\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of positive numbers in a list.\n#\n# $1 is a space-separated list\npos_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pos_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 3 -4\") = \"2\" ]]\n    [[ $(candidate \"3 4 5 -1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the number of ways to partition a set of Bell numbers.\n#\n# $1 is an integer\nbell_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    bell_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"115975\" ]]\n    [[ $(candidate \"56\") = \"6775685320645824322581483068371419745979053216268760300\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given array is monotonic or not.\n#\n# $1 is a space-separated list\nis_Monotonic() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_Monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 5 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 3 2\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a list contains the given sublist or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_sublist() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_sublist \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 3 5 7\" \"3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"4 3\") = \"true\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"1 6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the two numbers differ at one bit position only or not.\n#\n# $1 is an integer\n# $2 is an integer\ndiffer_At_One_Bit_Pos() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    differ_At_One_Bit_Pos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\" \"9\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2\" \"3\") = \"true\" ]]\n    [[ $(candidate \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find whether all the given lists have equal length or not.\n#\n# $1 is a newline-separated, space-separated list\nget_equal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 22 33\\n44 55 66\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"1 2\\n3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\ncomb_sort() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    comb_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 15 37 25 79\") = \"5 15 25 37 79\" ]]\n    [[ $(candidate \"41 32 15 19 22\") = \"15 19 22 32 41\" ]]\n    [[ $(candidate \"99 15 13 47\") = \"13 15 47 99\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to add a dictionary to the tuple. The output should be a tuple.\n#\n# $1 is a space-separated list\n# $2 is a two column CSV in key,value order\nadd_dict_to_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_dict_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"MSAM,1\\nis,2\\nbest,3\") = \"4 5 6 MSAM,1\\nis,2\\nbest,3\" ]]\n    [[ $(candidate \"1 2 3\" \"UTS,2\\nis,3\\nWorst,4\") = \"1 2 3 UTS,2\\nis,3\\nWorst,4\" ]]\n    [[ $(candidate \"8 9 10\" \"POS,3\\nis,4\\nOkay,5\") = \"8 9 10 POS,3\\nis,4\\nOkay,5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n#\n# $1 is a newline-separated, space-separated list\nmaxAverageOfPath() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    maxAverageOfPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n6 5 4\\n7 3 9\") = \"5.2\" ]]\n    [[ $(candidate \"2 3 4\\n7 6 5\\n8 4 10\") = \"6.2\" ]]\n    [[ $(candidate \"3 4 5\\n8 7 6\\n9 5 11\") = \"7.2\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\") = \"5.8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncount_same_pair() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_same_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"11\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"1\" ]]\n    [[ $(candidate \"0 1 1 2\" \"0 1 2 2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n#\n# $1 is an integer\n# $2 is an integer\npower_base_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    power_base_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"100\") = \"115\" ]]\n    [[ $(candidate \"8\" \"10\") = \"37\" ]]\n    [[ $(candidate \"8\" \"15\") = \"62\" ]]\n    [[ $(candidate \"3\" \"3\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\n#\n# $1 is a space-separated list\nmultiply_elements() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    multiply_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"5 35 56 80\" ]]\n    [[ $(candidate \"2 4 5 6 7\") = \"8 20 30 42\" ]]\n    [[ $(candidate \"12 13 14 9 15\") = \"156 182 126 135\" ]]\n    [[ $(candidate \"12\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsum_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30\" \"15 25 35\") = \"25 45 65\" ]]\n    [[ $(candidate \"1 2 3\" \"5 6 7\") = \"6 8 10\" ]]\n    [[ $(candidate \"15 20 30\" \"15 45 75\") = \"30 65 105\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the given number can be represented as the difference of two squares or not.\n#\n# $1 is an integer\ndif_Square() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    dif_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"15\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove consecutive duplicates of a given list.\n#\n# $1 is a space-separated list\nconsecutive_duplicates() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 1 2 3 4 5 6 7 8 9 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 15 19 18 17 26 17 18 10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a b c d\" ]]\n    [[ $(candidate \"a a b c d d a a\") = \"a b c d a\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cone given radius r and the height h.\n#\n# $1 is an integer\n# $2 is an integer\nlateralsurface_cone() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    lateralsurface_cone \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"12\") = \"204.20352248333654\" ]]\n    [[ $(candidate \"10\" \"15\") = \"566.3586699569488\" ]]\n    [[ $(candidate \"19\" \"17\") = \"1521.8090132193388\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n#\n# $1 is a string\nreplace_specialchar() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    replace_specialchar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python language, Programming language.\") = \"Python:language::Programming:language:\" ]]\n    [[ $(candidate \"a b c,d e f\") = \"a:b:c:d:e:f\" ]]\n    [[ $(candidate \"ram reshma,ram rahim\") = \"ram:reshma:ram:rahim\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the index of the first occurrence of a given number in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_first_occurrence() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_first_occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 5 5 5 6 6 8 9 9 9\" \"5\") = \"1\" ]]\n    [[ $(candidate \"2 3 5 5 6 6 8 9 9 9\" \"5\") = \"2\" ]]\n    [[ $(candidate \"2 4 1 5 6 6 8 9 9 9\" \"6\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n#\n# $1 is a space-separated list\nsum_Of_Subarray_Prod() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_Of_Subarray_Prod \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"20\" ]]\n    [[ $(candidate \"1 2\") = \"5\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n#\n# $1 is an integer\ntoggle_middle_bits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    toggle_middle_bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"15\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"11\") = \"13\" ]]\n    [[ $(candidate \"65\") = \"127\" ]]\n    [[ $(candidate \"77\") = \"115\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\n#\n# $1 is a space-separated list\n# $2 is an integer\nleft_insertion() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    left_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given string is starting with a vowel or not using regex.\n#\n# $1 is a string\ncheck_str() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_str \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"annie\") = \"true\" ]]\n    [[ $(candidate \"dawood\") = \"false\" ]]\n    [[ $(candidate \"Else\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\n#\n# $1 is an integer\ngeometric_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    geometric_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"1.9921875\" ]]\n    [[ $(candidate \"4\") = \"1.9375\" ]]\n    [[ $(candidate \"8\") = \"1.99609375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n#\n# $1 is an integer\nfind_Index() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"14\" ]]\n    [[ $(candidate \"4\") = \"45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\n#\n# $1 is a space-separated list\ntuple_to_dict() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tuple_to_dict \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 10 13 5\") = \"1,5\\n7,10\\n13,5\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1,2\\n3,4\\n5,6\" ]]\n    [[ $(candidate \"7 8 9 10 11 12\") = \"7,8\\n9,10\\n11,12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether all the characters are same or not.\n#\n# $1 is a string\nall_Characters_Same() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    all_Characters_Same \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"aaa\") = \"true\" ]]\n    [[ $(candidate \"data\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to caluclate the area of a tetrahedron.\n#\n# $1 is an integer\narea_tetrahedron() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    area_tetrahedron \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15.588457268119894\" ]]\n    [[ $(candidate \"20\") = \"692.8203230275509\" ]]\n    [[ $(candidate \"10\") = \"173.20508075688772\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\n#\n# $1 is a space-separated list\n# $2 is an integer\nrotate_right() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rotate_right \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"3\") = \"8 9 10 1 2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"9 10 1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5\") = \"6 7 8 9 10 1 2 3 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given tuple has any none value or not.\n#\n# $1 is a $Any\ncheck_none() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_none \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 None\") = \"true\" ]]\n    [[ $(candidate \"7 8 9 11 14\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 None\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\n#\n# $1 is an integer\n# $2 is an integer\ndivisible_by_digits() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    divisible_by_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"22\") = \"1 2 3 4 5 6 7 8 9 11 12 15 22\" ]]\n    [[ $(candidate \"1\" \"15\") = \"1 2 3 4 5 6 7 8 9 11 12 15\" ]]\n    [[ $(candidate \"20\" \"25\") = \"22 24\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n#\n# $1 is an integer\n# $2 is an integer\nsector_area() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sector_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"45\") = \"6.283185307179586\" ]]\n    [[ $(candidate \"9\" \"45\") = \"31.808625617596654\" ]]\n    [[ $(candidate \"9\" \"361\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nlcs_of_three() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    lcs_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") = \"2\" ]]\n    [[ $(candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") = \"5\" ]]\n    [[ $(candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to put spaces between words starting with capital letters in a given string.\n#\n# $1 is a string\ncapital_words_spaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    capital_words_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"PythonProgrammingExamples\") = \"Python Programming Examples\" ]]\n    [[ $(candidate \"GetReadyToBeCodingFreak\") = \"Get Ready To Be Coding Freak\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether it follows the sequence given in the patterns array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_samepatterns() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_samepatterns \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red green green\" \"a b b\") = \"true\" ]]\n    [[ $(candidate \"red green greenn\" \"a b b\") = \"false\" ]]\n    [[ $(candidate \"red green greenn\" \"a b\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to add the given tuple to the given list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    add_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"5 6 7 9 10\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"6 7 8 10 11\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"7 8 9 11 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n#\n# $1 is a space-separated list\ncheck_min_heap() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_min_heap \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 10 15\") = \"true\" ]]\n    [[ $(candidate \"2 10 4 5 3 15\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n#\n# $1 is an integer\njacobsthal_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    jacobsthal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"11\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"5\" ]]\n    [[ $(candidate \"13\") = \"2731\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmin_k() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    min_k \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Manjeet 10\\nAkshat 4\\nAkash 2\\nNikhil 8\" \"2\") = \"Akash 2\\nAkshat 4\" ]]\n    [[ $(candidate \"Sanjeev 11\\nAngat 5\\nAkash 3\\nNepin 9\" \"3\") = \"Akash 3\\nAngat 5\\nNepin 9\" ]]\n    [[ $(candidate \"tanmay 14\\nAmer 11\\nAyesha 9\\nSKD 16\" \"1\") = \"Ayesha 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nextract_index_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    extract_index_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 7\" ]]\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 6 5\" \"0 1 2 3 4 6 7\") = \"1 6\" ]]\n    [[ $(candidate \"1 1 3 4 6 5 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 5\" ]]\n    [[ $(candidate \"1 2 3 4 6 6 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the second smallest number in a list.\n#\n# $1 is a newline-separated, space-separated list\nsecond_smallest() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    second_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 -8 -2 0 -2\") = \"-2\" ]]\n    [[ $(candidate \"1 1 -0.5 0 2 -2 -2\") = \"-0.5\" ]]\n    [[ $(candidate \"2 2\") = \"None\" ]]\n    [[ $(candidate \"2 2 2\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\n#\n# $1 is a string\ntext_match_zero_one() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_zero_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"dsabbbba\") = \"true\" ]]\n    [[ $(candidate \"asbbbba\") = \"false\" ]]\n    [[ $(candidate \"abaaa\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\n#\n# $1 is a space-separated list\ncount_reverse_pairs() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_reverse_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"julia best tseb for ailuj\") = \"2\" ]]\n    [[ $(candidate \"geeks best for skeeg\") = \"1\" ]]\n    [[ $(candidate \"makes best sekam for rof\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a given string is a decimal number with a precision of 2.\n#\n# $1 is a string\nis_decimal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_decimal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123.11\") = \"true\" ]]\n    [[ $(candidate \"e666.86\") = \"false\" ]]\n    [[ $(candidate \"3.124587\") = \"false\" ]]\n    [[ $(candidate \"1.11\") = \"true\" ]]\n    [[ $(candidate \"1.1.11\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find tuples which have all elements divisible by k from the given list of tuples.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nfind_tuples() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 24 12\\n7 9 6\\n12 18 21\" \"6\") = \"6 24 12\" ]]\n    [[ $(candidate \"5 25 30\\n4 2 3\\n7 8 9\" \"5\") = \"5 25 30\" ]]\n    [[ $(candidate \"7 9 16\\n8 16 4\\n19 17 18\" \"4\") = \"8 16 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether a list of numbers contains only one distinct element or not.\n#\n# $1 is a space-separated list\nunique_Element() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    unique_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n#\n# $1 is an integer\ncheck_monthnumber_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_monthnumber_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_min_diff() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_min_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 3 19 18 25\" \"6\") = \"1\" ]]\n    [[ $(candidate \"4 3 2 6\" \"4\") = \"1\" ]]\n    [[ $(candidate \"30 5 20 9\" \"4\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count number of digits in a given string.\n#\n# $1 is a string\nnumber_ctr() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    number_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"program2bedone\") = \"1\" ]]\n    [[ $(candidate \"3wonders\") = \"1\" ]]\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"3wond-1ers2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n#\n# $1 is an integer\nis_polite() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_polite \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"11\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"13\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to return a list of all pairs of consecutive items in a given list.\n#\n# $1 is a space-separated list\npair_wise() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pair_wise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 3 4 4 5\") = \"1 1\\n1 2\\n2 3\\n3 3\\n3 4\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"1 5\\n5 7\\n7 9\\n9 10\" ]]\n    [[ $(candidate \"5 1 9 7 10\") = \"5 1\\n1 9\\n9 7\\n7 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 2\\n2 3\\n3 4\\n4 5\\n5 6\\n6 7\\n7 8\\n8 9\\n9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n#\n# $1 is a space-separated list\n# $2 is an integer\nget_pairs_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_pairs_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1 1\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1 5 7 -1 5\" \"6\") = \"3\" ]]\n    [[ $(candidate \"1 -2 3\" \"1\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 3\" \"-3\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to get the difference between two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nDiff() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 15 20 25 30 35 40\" \"25 40 35\") = \"10 20 30 15\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 1\") = \"2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3\" \"6 7 1\") = \"2 3 6 7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of fourth power of first n odd natural numbers.\n#\n# $1 is an integer\nodd_num_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    odd_num_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"82\" ]]\n    [[ $(candidate \"3\") = \"707\" ]]\n    [[ $(candidate \"4\") = \"3108\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n#\n# $1 is a string\ncheck_expression() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_expression \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"{()}[{}]\") = \"true\" ]]\n    [[ $(candidate \"{()}[{]\") = \"false\" ]]\n    [[ $(candidate \"{()}[{}][]({})\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all the words with k length in the given string.\n#\n# $1 is a string\n# $2 is an integer\nremove_length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The person is most value tet\" \"3\") = \"person is most value\" ]]\n    [[ $(candidate \"If you told me about this ok\" \"4\") = \"If you me about ok\" ]]\n    [[ $(candidate \"Forces of darkeness is come into the play\" \"4\") = \"Forces of darkeness is the\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n#\n# $1 is a string\n# $2 is a string\noccurance_substring() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    occurance_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming, python language\" \"python\") = \"python 0 6\" ]]\n    [[ $(candidate \"python programming,programming language\" \"programming\") = \"programming 7 18\" ]]\n    [[ $(candidate \"python programming,programming language\" \"language\") = \"language 31 39\" ]]\n    [[ $(candidate \"c++ programming, c++ language\" \"python\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether every odd index contains odd numbers of a given list.\n#\n# $1 is a space-separated list\nodd_position() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    odd_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 4 3 6 7 6 3\") = \"true\" ]]\n    [[ $(candidate \"4 1 2\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count those characters which have vowels as their neighbors in the given string.\n#\n# $1 is a string\ncount_vowels() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"bestinstareels\") = \"7\" ]]\n    [[ $(candidate \"partofthejourneyistheend\") = \"12\" ]]\n    [[ $(candidate \"amazonprime\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of non-repeated elements in a given list.\n#\n# $1 is a space-separated list\nfind_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 1 1 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"1 10 9 4 2 10 10 45 4\") = \"71\" ]]\n    [[ $(candidate \"12 10 9 45 2 10 10 45 10\") = \"78\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to pack consecutive duplicates of a given list elements into sublists.\n#\n# $1 is a space-separated list\npack_consecutive_duplicates() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    pack_consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 0\\n1\\n2\\n3\\n4 4\\n5\\n6 6 6\\n7\\n8\\n9\\n4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 10\\n15\\n19\\n18 18\\n17\\n26 26\\n17\\n18\\n10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a a\\nb\\nc\\nd d\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find whether a number is divisible by 11.\n#\n# $1 is an integer\nis_Diff() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12345\") = \"false\" ]]\n    [[ $(candidate \"1212112\") = \"true\" ]]\n    [[ $(candidate \"1212\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\n#\n# $1 is a newline-separated, space-separated list\nfind_combinations() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_combinations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4\\n6 7\\n5 1\\n6 10\") = \"8 11\\n7 5\\n8 14\\n11 8\\n12 17\\n11 11\" ]]\n    [[ $(candidate \"3 5\\n7 8\\n6 2\\n7 11\") = \"10 13\\n9 7\\n10 16\\n13 10\\n14 19\\n13 13\" ]]\n    [[ $(candidate \"4 6\\n8 9\\n7 3\\n8 12\") = \"12 15\\n11 9\\n12 18\\n15 12\\n16 21\\n15 15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\n#\n# $1 is an integer\ncount_divisors() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_divisors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"100\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n#\n# $1 is a space-separated list\nodd_length_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    odd_length_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4\") = \"14\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"15\" ]]\n    [[ $(candidate \"1 7\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nrgb_to_hsv() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    rgb_to_hsv \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"255\" \"255\" \"255\") = \"0.0 0.0 100.0\" ]]\n    [[ $(candidate \"0\" \"215\" \"0\") = \"120.0 100.0 84.31372549019608\" ]]\n    [[ $(candidate \"10\" \"215\" \"110\") = \"149.26829268292684 95.34883720930233 84.31372549019608\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the product of first even and odd number of a given list.\n#\n# $1 is a space-separated list\nmul_even_odd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    mul_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert tuple string to integer tuple.\n#\n# $1 is a string\ntuple_str_int() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tuple_str_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(7, 8, 9)\") = \"7 8 9\" ]]\n    [[ $(candidate \"(1, 2, 3)\") = \"1 2 3\" ]]\n    [[ $(candidate \"(4, 5, 6)\") = \"4 5 6\" ]]\n    [[ $(candidate \"(7, 81, 19)\") = \"7 81 19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to locate the right insertion point for a specified value in sorted order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nright_insertion() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    right_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by three 'b'.\n#\n# $1 is a string\ntext_match_three() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_match_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"caacabbbba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to create a new tuple from the given string and list.\n#\n# $1 is a space-separated list\n# $2 is a string\nnew_tuple() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    new_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"WEB is\" \"best\") = \"WEB is best\" ]]\n    [[ $(candidate \"We are\" \"Developers\") = \"We are Developers\" ]]\n    [[ $(candidate \"Part is\" \"Wrong\") = \"Part is Wrong\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether every even index contains even numbers of a given list.\n#\n# $1 is a space-separated list\neven_position() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    even_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n    [[ $(candidate \"2 1 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove tuples from the given tuple.\n#\n# $1 is a $Any\nremove_nested() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"1 5 7 10\" ]]\n    [[ $(candidate \"2 6 8 5 7 11\") = \"2 6 8 11\" ]]\n    [[ $(candidate \"3 7 9 6 8 12\") = \"3 7 9 12\" ]]\n    [[ $(candidate \"3 7 9 6 8 5 12 12\") = \"3 7 9 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of lists in a given number of lists.\n#\n# $1 is a newline-separated, space-separated list\ncount_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n9 11\\n13 15 17\") = \"4\" ]]\n    [[ $(candidate \"1 2\\n2 3\\n4 5\") = \"3\" ]]\n    [[ $(candidate \"1 0\\n2 0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the last position of an element in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlast() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    last \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 4\" \"1\") = \"2\" ]]\n    [[ $(candidate \"2 3 2 3 6 8 9\" \"3\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n#\n# $1 is a string\ntext_starta_endb() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    text_starta_endb \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aabbbb\") = \"true\" ]]\n    [[ $(candidate \"aabAbbbc\") = \"false\" ]]\n    [[ $(candidate \"accddbbjjj\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write function to find the sum of all items in the given dictionary.\n#\n# $1 is a two column CSV in key,value order\nreturn_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    return_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a,100\\nb,200\\nc,300\") = \"600\" ]]\n    [[ $(candidate \"a,25\\nb,18\\nc,45\") = \"88\" ]]\n    [[ $(candidate \"a,36\\nb,39\\nc,49\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of all odd natural numbers within the range l and r.\n#\n# $1 is an integer\n# $2 is an integer\nsum_in_range() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sum_in_range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"5\") = \"8\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"13\") = \"40\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the sum of an array.\n#\n# $1 is a space-separated list\n_sum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    _sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"15 12 13 10\") = \"50\" ]]\n    [[ $(candidate \"0 1 2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n#\n# $1 is an integer\n# $2 is an integer\nleft_rotate() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    left_rotate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"64\" ]]\n    [[ $(candidate \"10\" \"2\") = \"40\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"1\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"3\") = \"40\" ]]\n    [[ $(candidate \"29\" \"3\") = \"232\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to check whether the length of the word is odd or not.\n#\n# $1 is a string\nword_len() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    word_len \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hadoop\") = \"false\" ]]\n    [[ $(candidate \"great\") = \"true\" ]]\n    [[ $(candidate \"structure\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from a string.\n#\n# $1 is a string\nremove_all_spaces() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    remove_all_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python  program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"python   programming    language\") = \"pythonprogramminglanguage\" ]]\n    [[ $(candidate \"python                     program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"   python                     program\") = \"pythonprogram\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of equal numbers from three given integers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntest_three_equal() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    test_three_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"1\" \"1\") = \"3\" ]]\n    [[ $(candidate \"-1\" \"-2\" \"-3\") = \"0\" ]]\n    [[ $(candidate \"1\" \"2\" \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n#\n# $1 is a space-separated list\ncount_rotation() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    count_rotation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"1\" ]]\n    [[ $(candidate \"4 5 1 2 3\") = \"2\" ]]\n    [[ $(candidate \"7 8 9 1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 2 3\") = \"0\" ]]\n    [[ $(candidate \"1 3 2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n#\n# $1 is an integer\nis_perfect_square() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_perfect_square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"36\") = \"true\" ]]\n    [[ $(candidate \"14\") = \"false\" ]]\n    [[ $(candidate \"196\") = \"true\" ]]\n    [[ $(candidate \"125\") = \"false\" ]]\n    [[ $(candidate \"15625\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the product of numbers in a list is even or not.\n#\n# $1 is a space-separated list\nis_product_even() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_product_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 4\") = \"true\" ]]\n    [[ $(candidate \"1 1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns the list in a list of lists whose sum of elements is the highest.\n#\n# $1 is a newline-separated, space-separated list\nmax_sum_list() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"10 11 12\" ]]\n    [[ $(candidate \"3 2 1\\n6 5 4\\n12 11 10\") = \"12 11 10\" ]]\n    [[ $(candidate \"2 3 1\") = \"2 3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find maximum run of uppercase characters in the given string.\n#\n# $1 is a string\nmax_run_uppercase() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    max_run_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"GeMKSForGERksISBESt\") = \"5\" ]]\n    [[ $(candidate \"PrECIOusMOVemENTSYT\") = \"6\" ]]\n    [[ $(candidate \"GooGLEFluTTER\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the first odd number in a given list of numbers.\n#\n# $1 is a space-separated list\nfirst_odd() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    first_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5\") = \"1\" ]]\n    [[ $(candidate \"2 4 1 3\") = \"1\" ]]\n    [[ $(candidate \"8 9 1\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given tuples contain the k or not.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_K() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 8\" \"6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"7\") = \"false\" ]]\n    [[ $(candidate \"7 8 9 44 11 12\" \"11\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncheck_smaller() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    check_smaller \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"2 3 4\") = \"false\" ]]\n    [[ $(candidate \"4 5 6\" \"3 4 5\") = \"true\" ]]\n    [[ $(candidate \"11 12 13\" \"10 11 12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth tetrahedral number.\n#\n# $1 is an integer\ntetrahedral_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    tetrahedral_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"35\" ]]\n    [[ $(candidate \"6\") = \"56\" ]]\n    [[ $(candidate \"7\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n#\n# $1 is a string\nget_Char() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    get_Char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"f\" ]]\n    [[ $(candidate \"gfg\") = \"t\" ]]\n    [[ $(candidate \"ab\") = \"c\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth number in the newman conway sequence.\n#\n# $1 is an integer\nsequence() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"6\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find nth centered hexagonal number.\n#\n# $1 is an integer\ncentered_hexagonal_number() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    centered_hexagonal_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"271\" ]]\n    [[ $(candidate \"2\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"217\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to merge three dictionaries into a single dictionary.\n#\n# $1 is a two column CSV in key,value order\n# $2 is a two column CSV in key,value order\n# $3 is a two column CSV in key,value order\nmerge_dictionaries_three() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    merge_dictionaries_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"O,Orange\\nW,White\\nB,Black\") = \"B,Black\\nR,Red\\nP,Pink\\nG,Green\\nW,White\\nO,Orange\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"L,lavender\\nB,Blue\") = \"W,White\\nP,Pink\\nB,Black\\nR,Red\\nG,Green\\nL,lavender\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"L,lavender\\nB,Blue\" \"G,Green\\nW,White\") = \"B,Black\\nP,Pink\\nR,Red\\nG,Green\\nL,lavender\\nW,White\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get the frequency of all the elements in a list, returned as a dictionary.\n#\n# $1 is a space-separated list\nfreq_count() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    freq_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 10 20 20 20 20 40 40 50 50 30\") = \"10,4\\n20,4\\n40,2\\n50,2\\n30,1\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 4 1 3 1 4\") = \"1,3\\n2,2\\n3,3\\n4,3\" ]]\n    [[ $(candidate \"5 6 7 4 9 10 4 5 6 7 9 5\") = \"10,1\\n5,3\\n6,2\\n7,2\\n4,2\\n9,2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the closest smaller number than n.\n#\n# $1 is an integer\nclosest_num() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    closest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11\") = \"10\" ]]\n    [[ $(candidate \"7\") = \"6\" ]]\n    [[ $(candidate \"12\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find squares of individual elements in a list.\n#\n# $1 is a space-separated list\nsquare_nums() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    square_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\") = \"100 400 900\" ]]\n    [[ $(candidate \"12 15\") = \"144 225\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the length of the longest word.\n#\n# $1 is a space-separated list\nlen_log() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    len_log \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python PHP bigdata\") = \"7\" ]]\n    [[ $(candidate \"a ab abc\") = \"3\" ]]\n    [[ $(candidate \"small big tall\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if a string is present as a substring in a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is a string\nfind_substring() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red black white green orange\" \"ack\") = \"true\" ]]\n    [[ $(candidate \"red black white green orange\" \"abc\") = \"false\" ]]\n    [[ $(candidate \"red black white green orange\" \"ange\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is undulating or not.\n#\n# $1 is an integer\nis_undulating() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    is_undulating \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1212121\") = \"true\" ]]\n    [[ $(candidate \"1991\") = \"false\" ]]\n    [[ $(candidate \"121\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the value of 'a' to the power 'b'.\n#\n# $1 is an integer\n# $2 is an integer\npower() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"81\" ]]\n    [[ $(candidate \"2\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"5\") = \"3125\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\n#\n# $1 is a newline-separated, space-separated list\nindex_minimum() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    index_minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Rash 143\\nManjeet 200\\nVarsha 100\") = \"Varsha\" ]]\n    [[ $(candidate \"Yash 185\\nDawood 125\\nSanya 175\") = \"Dawood\" ]]\n    [[ $(candidate \"Sai 345\\nSalman 145\\nAyesha 96\") = \"Ayesha\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the length of the smallest list in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min_Length() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    Find_Min_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\") = \"1\" ]]\n    [[ $(candidate \"1 2\\n1 2 3\\n1 2 3 4\") = \"2\" ]]\n    [[ $(candidate \"3 3 3\\n4 4 4 4\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the number of divisors of a given integer.\n#\n# $1 is an integer\ndivisor() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"6\" ]]\n    [[ $(candidate \"9\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\n#\n# $1 is a newline-separated, space-separated list\nfrequency_lists() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    frequency_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2\\n4 5 6 2\\n7 8 9 5\") = \"1,1\\n2,3\\n3,1\\n4,1\\n5,2\\n6,1\\n7,1\\n8,1\\n9,1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\") = \"1,1\\n2,1\\n3,1\\n4,1\\n5,1\\n6,1\\n7,1\\n8,1\\n9,1\\n10,1\\n11,1\\n12,1\" ]]\n    [[ $(candidate \"20 30 40 17\\n18 16 14 13\\n10 20 30 40\") = \"20,2\\n30,2\\n40,2\\n17,1\\n18,1\\n16,1\\n14,1\\n13,1\\n10,1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"1000\" ]]\n    [[ $(candidate \"18\") = \"10010\" ]]\n    [[ $(candidate \"7\") = \"111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\n#\n# $1 is a string\nfind_Rotations() {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\ncandidate() {\n    find_Rotations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aaaa\") = \"1\" ]]\n    [[ $(candidate \"ab\") = \"2\" ]]\n    [[ $(candidate \"abc\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-sh-reworded.json
+++ b/prompts/mbpp-sh-reworded.json
@@ -1,3372 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the length of the longest palindromic subsequence in the given string.\n#\n# $1 is a string\nlps() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    lps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TENS FOR TENS\") = \"5\" ]]\n    [[ $(candidate \"CARDIO FOR CARDS\") = \"7\" ]]\n    [[ $(candidate \"PART OF THE JOURNEY IS PART\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from the given string.\n#\n# $1 is a string\nremove_whitespaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_whitespaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \" Google    Flutter \") = \"GoogleFlutter\" ]]\n    [[ $(candidate \" Google    Dart \") = \"GoogleDart\" ]]\n    [[ $(candidate \" iOS    Swift \") = \"iOSSwift\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a specified list is sorted or not.\n#\n# $1 is a space-separated list\nissort_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    issort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 6 8 10 12 14 16 17\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 12 14 20 17\") = \"false\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 15 14 20\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count bidirectional list pairs.\n#\n# $1 is a newline-separated, space-separated list\ncount_bidirectional() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_bidirectional \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 1\\n6 5\\n2 1\") = \"3\" ]]\n    [[ $(candidate \"5 6\\n1 3\\n6 5\\n9 1\\n6 5\\n2 1\") = \"2\" ]]\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 2\\n6 5\\n2 1\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cube of a given size.\n#\n# $1 is an integer\nsurfacearea_cube() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    surfacearea_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"150\" ]]\n    [[ $(candidate \"3\") = \"54\" ]]\n    [[ $(candidate \"10\") = \"600\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\n#\n# $1 is an integer\nnext_smallest_palindrome() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    next_smallest_palindrome \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"99\") = \"101\" ]]\n    [[ $(candidate \"1221\") = \"1331\" ]]\n    [[ $(candidate \"120\") = \"121\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the cube sum of first n even natural numbers.\n#\n# $1 is an integer\ncube_Sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    cube_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"72\" ]]\n    [[ $(candidate \"3\") = \"288\" ]]\n    [[ $(candidate \"4\") = \"800\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of xor of all pairs of numbers in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\npair_xor_Sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pair_xor_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 9 7 6\" \"4\") = \"47\" ]]\n    [[ $(candidate \"7 3 5\" \"3\") = \"12\" ]]\n    [[ $(candidate \"7 3\" \"2\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n#\n# $1 is a space-separated list\ncheck_min_heap() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_min_heap \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 10 15\") = \"true\" ]]\n    [[ $(candidate \"2 10 4 5 3 15\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the first digit of a given number.\n#\n# $1 is an integer\nfirst_Digit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    first_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"1\" ]]\n    [[ $(candidate \"456\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the first non-repeated character in a given string.\n#\n# $1 is a string\nfirst_non_repeating_character() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    first_non_repeating_character \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"None\" ]]\n    [[ $(candidate \"abc\") = \"a\" ]]\n    [[ $(candidate \"ababc\") = \"c\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert degrees to radians.\n#\n# $1 is an integer\nradian_degree() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    radian_degree \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"90\") = \"1.5707963267948966\" ]]\n    [[ $(candidate \"60\") = \"1.0471975511965976\" ]]\n    [[ $(candidate \"120\") = \"2.0943951023931953\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum product subarray of the given array.\n#\n# $1 is a space-separated list\nmax_subarray_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_subarray_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 0 7 -8 -2\") = \"112\" ]]\n    [[ $(candidate \"6 -3 -10 0 2\") = \"180\" ]]\n    [[ $(candidate \"-2 -40 0 -2 -3\") = \"80\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find smallest number in a list.\n#\n# $1 is a space-separated list\nsmallest_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    smallest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 1 45 99\") = \"1\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n    [[ $(candidate \"45 46 50 60\") = \"45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/shthon-exercises/re/shthon-re-exercise-3.php\n#\n# $1 is a string\ntext_match_zero_one() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_zero_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"dsabbbba\") = \"true\" ]]\n    [[ $(candidate \"asbbbba\") = \"false\" ]]\n    [[ $(candidate \"abaaa\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find nth bell number.\n#\n# $1 is an integer\nbell_Number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    bell_Number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find cubes of individual elements in a list.\n#\n# $1 is a space-separated list\ncube_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    cube_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 8 27 64 125 216 343 512 729 1000\" ]]\n    [[ $(candidate \"10 20 30\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\") = \"1728 3375\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the last digit in factorial of a given number.\n#\n# $1 is an integer\nlast_Digit_Factorial() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    last_Digit_Factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"4\" ]]\n    [[ $(candidate \"21\") = \"0\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find even numbers from a list of numbers.\n#\n# $1 is a space-separated list\nSplit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2 4\" ]]\n    [[ $(candidate \"4 5 6 7 8 0 1\") = \"4 6 8 0\" ]]\n    [[ $(candidate \"8 12 15 19\") = \"8 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given integer is a prime number.\n#\n# $1 is an integer\nprime_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    prime_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"-1010\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find lists which have all elements divisible by k from the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nfind_tuples() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 24 12\\n7 9 6\\n12 18 21\" \"6\") = \"6 24 12\" ]]\n    [[ $(candidate \"5 25 30\\n4 2 3\\n7 8 9\" \"5\") = \"5 25 30\" ]]\n    [[ $(candidate \"7 9 16\\n8 16 4\\n19 17 18\" \"4\") = \"8 16 4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to caluclate the area of a tetrahedron.\n#\n# $1 is an integer\narea_tetrahedron() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    area_tetrahedron \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15.588457268119894\" ]]\n    [[ $(candidate \"20\") = \"692.8203230275509\" ]]\n    [[ $(candidate \"10\") = \"173.20508075688772\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number is even or not.\n#\n# $1 is an integer\nis_Even() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_Even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"2\") = \"true\" ]]\n    [[ $(candidate \"3\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of positive numbers in a list.\n#\n# $1 is a space-separated list\npos_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pos_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 3 -4\") = \"2\" ]]\n    [[ $(candidate \"3 4 5 -1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get all lucid numbers smaller than or equal to a given integer.\n#\n# $1 is an integer\nget_ludic() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_ludic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"1 2 3 5 7\" ]]\n    [[ $(candidate \"25\") = \"1 2 3 5 7 11 13 17 23 25\" ]]\n    [[ $(candidate \"45\") = \"1 2 3 5 7 11 13 17 23 25 29 37 41 43\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n#\n# $1 is an integer\nfind_Index() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"14\" ]]\n    [[ $(candidate \"4\") = \"45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to reverse an array upto a given position.\n#\n# $1 is a space-separated list\n# $2 is an integer\nreverse_Array_Upto_K() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    reverse_Array_Upto_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"4\") = \"4 3 2 1 5 6\" ]]\n    [[ $(candidate \"4 5 6 7\" \"2\") = \"5 4 6 7\" ]]\n    [[ $(candidate \"9 8 7 6 5\" \"3\") = \"7 8 9 6 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove characters from the first string which are present in the second string.\n#\n# $1 is a string\n# $2 is a string\nremove_dirty_chars() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_dirty_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"probasscurve\" \"pros\") = \"bacuve\" ]]\n    [[ $(candidate \"digitalindia\" \"talent\") = \"digiidi\" ]]\n    [[ $(candidate \"exoticmiles\" \"toxic\") = \"emles\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n#\n# $1 is a newline-separated, space-separated list\nround_and_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    round_and_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5\") = \"243\" ]]\n    [[ $(candidate \"5 2 9 24.3 29\") = \"345\" ]]\n    [[ $(candidate \"25.0 56.7 89.2\") = \"513\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the item with maximum frequency in a given list.\n#\n# $1 is a space-separated list\nmax_occurrences() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_occurrences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2\") = \"2\" ]]\n    [[ $(candidate \"2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18\") = \"8\" ]]\n    [[ $(candidate \"10 20 20 30 40 90 80 50 30 20 50 10\") = \"20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a given string is a decimal number with a precision of 2.\n#\n# $1 is a string\nis_decimal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_decimal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123.11\") = \"true\" ]]\n    [[ $(candidate \"e666.86\") = \"false\" ]]\n    [[ $(candidate \"3.124587\") = \"false\" ]]\n    [[ $(candidate \"1.11\") = \"true\" ]]\n    [[ $(candidate \"1.1.11\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of even numbers at even positions of a list.\n#\n# $1 is a space-separated list\nsum_even_and_even_index() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_even_and_even_index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 12 1 18 8\") = \"30\" ]]\n    [[ $(candidate \"3 20 17 9 2 10 18 13 6 18\") = \"26\" ]]\n    [[ $(candidate \"5 6 12 1\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the sum of the largest contiguous sublist in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmax_sub_array_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_sub_array_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-2 -3 4 -1 -2 1 5 -3\" \"8\") = \"7\" ]]\n    [[ $(candidate \"-3 -4 5 -2 -3 2 6 -4\" \"8\") = \"8\" ]]\n    [[ $(candidate \"-4 -5 6 -3 -4 3 7 -5\" \"8\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the intersection of two arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection_array() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    intersection_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"1 2 4 8 9\") = \"1 2 8 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"3 5 7 9\") = \"3 5 7 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"10 20 30 40\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_two_parts() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    split_two_parts \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 2\\n3 4 4 5 1\" ]]\n    [[ $(candidate \"a b c d\" \"2\") = \"a b\\nc d\" ]]\n    [[ $(candidate \"p y t h o n\" \"4\") = \"p y t h\\no n\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n#\n# $1 is a string\n# $2 is a string\nfind_literals() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_literals \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") = \"fox 16 19\" ]]\n    [[ $(candidate \"Its been a very crazy procedure right\" \"crazy\") = \"crazy 16 21\" ]]\n    [[ $(candidate \"Hardest choices required strongest will\" \"will\") = \"will 35 39\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the volume of a triangular prism.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_Volume() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Volume \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"8\" \"6\") = \"240\" ]]\n    [[ $(candidate \"3\" \"2\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\" \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n#\n# $1 is an integer\n# $2 is an integer\nwind_chill() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    wind_chill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"120\" \"35\") = \"40\" ]]\n    [[ $(candidate \"40\" \"20\") = \"19\" ]]\n    [[ $(candidate \"10\" \"8\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the ascii value of a character.\n#\n# $1 is a string\nascii_value() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    ascii_value \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\") = \"65\" ]]\n    [[ $(candidate \"R\") = \"82\" ]]\n    [[ $(candidate \"S\") = \"83\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether all the characters are same or not.\n#\n# $1 is a string\nall_Characters_Same() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    all_Characters_Same \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"aaa\") = \"true\" ]]\n    [[ $(candidate \"data\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to move all the numbers to the end of the given string.\n#\n# $1 is a string\nmove_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    move_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"I1love143you55three3000thousand\") = \"Iloveyouthreethousand1143553000\" ]]\n    [[ $(candidate \"Avengers124Assemble\") = \"AvengersAssemble124\" ]]\n    [[ $(candidate \"Its11our12path13to14see15things16do17things\") = \"Itsourpathtoseethingsdothings11121314151617\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the length of the word is odd or not.\n#\n# $1 is a string\nword_len() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    word_len \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hadoop\") = \"false\" ]]\n    [[ $(candidate \"great\") = \"true\" ]]\n    [[ $(candidate \"structure\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to drop empty items from a given CSV.\n#\n# $1 is a two column CSV in key,value order\ndrop_empty() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    drop_empty \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"c1,Red\\nc2,Green\\nc3,None\") = \"c1,Red\\nc2,Green\" ]]\n    [[ $(candidate \"c1,Red\\nc2,None\\nc3,None\") = \"c1,Red\" ]]\n    [[ $(candidate \"c1,None\\nc2,Green\\nc3,None\") = \"c2,Green\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n#\n# $1 is a space-separated list\n# $2 is a string\ninsert_element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    insert_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Black\" \"c\") = \"c Red c Green c Black\" ]]\n    [[ $(candidate \"python java\" \"program\") = \"program python program java\" ]]\n    [[ $(candidate \"happy sad\" \"laugh\") = \"laugh happy laugh sad\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove lowercase substrings from a given string.\n#\n# $1 is a string\nremove_lowercase() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_lowercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYTHon\") = \"PYTH\" ]]\n    [[ $(candidate \"FInD\") = \"FID\" ]]\n    [[ $(candidate \"STRinG\") = \"STRG\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of set bits (binary digits with value 1) in a given number.\n#\n# $1 is an integer\ncount_Set_Bits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_Set_Bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract only the rear index element of each string in the given list.\n#\n# $1 is a space-separated list\nextract_rear() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_rear \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mers for Vers\") = \"s r s\" ]]\n    [[ $(candidate \"Avenge for People\") = \"e r e\" ]]\n    [[ $(candidate \"Gotta get go\") = \"a t o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of occurence of the string 'std' in a given string.\n#\n# $1 is a string\ncount_occurance() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_occurance \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"letstdlenstdporstd\") = \"3\" ]]\n    [[ $(candidate \"truststdsolensporsd\") = \"1\" ]]\n    [[ $(candidate \"makestdsostdworthit\") = \"2\" ]]\n    [[ $(candidate \"stds\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given lists contain the k or not.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_K() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 8\" \"6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"7\") = \"false\" ]]\n    [[ $(candidate \"7 8 9 44 11 12\" \"11\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to interleave 3 lists of the same length into a single flat list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ninterleave_lists() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    interleave_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7\" \"10 20 30 40 50 60 70\" \"100 200 300 400 500 600 700\") = \"1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700\" ]]\n    [[ $(candidate \"10 20\" \"15 2\" \"5 10\") = \"10 15 5 20 2 10\" ]]\n    [[ $(candidate \"11 44\" \"10 15\" \"20 5\") = \"11 10 20 44 15 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python_program\") = \"PythonProgram\" ]]\n    [[ $(candidate \"python_language\") = \"PythonLanguage\" ]]\n    [[ $(candidate \"programming_language\") = \"ProgrammingLanguage\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of equal numbers from three given integers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntest_three_equal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    test_three_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"1\" \"1\") = \"3\" ]]\n    [[ $(candidate \"-1\" \"-2\" \"-3\") = \"0\" ]]\n    [[ $(candidate \"1\" \"2\" \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n#\n# $1 is a space-separated list\nodd_length_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    odd_length_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4\") = \"14\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"15\" ]]\n    [[ $(candidate \"1 7\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the number of ways to partition a set of Bell numbers.\n#\n# $1 is an integer\nbell_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    bell_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"115975\" ]]\n    [[ $(candidate \"56\") = \"6775685320645824322581483068371419745979053216268760300\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the area of a rectangle.\n#\n# $1 is an integer\n# $2 is an integer\nrectangle_area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rectangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"10\" \"5\") = \"50\" ]]\n    [[ $(candidate \"4\" \"2\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find sum and average of first n natural numbers.\n#\n# $1 is an integer\nsum_average() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_average \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55 5.5\" ]]\n    [[ $(candidate \"15\") = \"120 8.0\" ]]\n    [[ $(candidate \"20\") = \"210 10.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndivision_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    division_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"2 2 2 3\" ]]\n    [[ $(candidate \"12 6 8 16\" \"6 3 4 4\") = \"2 2 2 4\" ]]\n    [[ $(candidate \"20 14 36 18\" \"5 7 6 9\") = \"4 2 6 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get the sum of the digits of a non-negative integer.\n#\n# $1 is an integer\nsum_digits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"345\") = \"12\" ]]\n    [[ $(candidate \"12\") = \"3\" ]]\n    [[ $(candidate \"97\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a list of lists, write a function that returns the first value of the list with the smallest second value.\n#\n# $1 is a newline-separated, space-separated list\nindex_minimum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    index_minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Rash 143\\nManjeet 200\\nVarsha 100\") = \"Varsha\" ]]\n    [[ $(candidate \"Yash 185\\nDawood 125\\nSanya 175\") = \"Dawood\" ]]\n    [[ $(candidate \"Sai 345\\nSalman 145\\nAyesha 96\") = \"Ayesha\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to divide two lists element wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndiv_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    div_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"1 2 3\") = \"4.0 2.5 2.0\" ]]\n    [[ $(candidate \"3 2\" \"1 4\") = \"3.0 0.5\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"1.8 1.7142857142857142\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the list with maximum length.\n#\n# $1 is a newline-separated, space-separated list\nmax_length_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_length_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1 2 3 4 5\\n1 2 3 4\\n1 2 3\\n1 2\\n1\") = \"5 1 2 3 4 5\" ]]\n    [[ $(candidate \"3 4 5\\n6 7 8 9\\n10 11 12\") = \"4 6 7 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find all possible combinations of the elements of a given list.\n#\n# $1 is a space-separated list\ncombinations_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    combinations_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"orange red green blue\") = \"\\norange\\nred\\nred orange\\ngreen\\ngreen orange\\ngreen red\\ngreen red orange\\nblue\\nblue orange\\nblue red\\nblue red orange\\nblue green\\nblue green orange\\nblue green red\\nblue green red orange\" ]]\n    [[ $(candidate \"red green blue white black orange\") = \"\\nred\\ngreen\\ngreen red\\nblue\\nblue red\\nblue green\\nblue green red\\nwhite\\nwhite red\\nwhite green\\nwhite green red\\nwhite blue\\nwhite blue red\\nwhite blue green\\nwhite blue green red\\nblack\\nblack red\\nblack green\\nblack green red\\nblack blue\\nblack blue red\\nblack blue green\\nblack blue green red\\nblack white\\nblack white red\\nblack white green\\nblack white green red\\nblack white blue\\nblack white blue red\\nblack white blue green\\nblack white blue green red\\norange\\norange red\\norange green\\norange green red\\norange blue\\norange blue red\\norange blue green\\norange blue green red\\norange white\\norange white red\\norange white green\\norange white green red\\norange white blue\\norange white blue red\\norange white blue green\\norange white blue green red\\norange black\\norange black red\\norange black green\\norange black green red\\norange black blue\\norange black blue red\\norange black blue green\\norange black blue green red\\norange black white\\norange black white red\\norange black white green\\norange black white green red\\norange black white blue\\norange black white blue red\\norange black white blue green\\norange black white blue green red\" ]]\n    [[ $(candidate \"red green black orange\") = \"\\nred\\ngreen\\ngreen red\\nblack\\nblack red\\nblack green\\nblack green red\\norange\\norange red\\norange green\\norange green red\\norange black\\norange black red\\norange black green\\norange black green red\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the largest and smallest value in a given array.\n#\n# $1 is a space-separated list\nbig_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    big_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"4\" ]]\n    [[ $(candidate \"-1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"2 3 6\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to return the negative numbers in a list.\n#\n# $1 is a space-separated list\nneg_nos() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    neg_nos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 4 5 -6\") = \"-1 -6\" ]]\n    [[ $(candidate \"-1 -2 3 4\") = \"-1 -2\" ]]\n    [[ $(candidate \"-7 -6 8 9\") = \"-7 -6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the highest power of 2 that is less than or equal to n.\n#\n# $1 is an integer\nhighest_Power_of_2() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    highest_Power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"8\" ]]\n    [[ $(candidate \"19\") = \"16\" ]]\n    [[ $(candidate \"32\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether a list contains the given sublist or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_sublist() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_sublist \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 3 5 7\" \"3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"4 3\") = \"true\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"1 6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to subtract two lists element-wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsub_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sub_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"-3 -3 -3\" ]]\n    [[ $(candidate \"1 2\" \"3 4\") = \"-2 -2\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"40 50\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given two integers have opposite sign or not.\n#\n# $1 is an integer\n# $2 is an integer\nopposite_Signs() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    opposite_Signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"-2\") = \"true\" ]]\n    [[ $(candidate \"3\" \"2\") = \"false\" ]]\n    [[ $(candidate \"-10\" \"-10\") = \"false\" ]]\n    [[ $(candidate \"-2\" \"2\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which takes two lists of the same length and performs the element wise modulo.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntuple_modulo() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tuple_modulo \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6\" \"5 6 7 5\") = \"0 4 5 1\" ]]\n    [[ $(candidate \"11 5 6 7\" \"6 7 8 6\") = \"5 5 6 1\" ]]\n    [[ $(candidate \"12 6 7 8\" \"7 8 9 7\") = \"5 6 7 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the difference of the first even and first odd number of a given list.\n#\n# $1 is a space-separated list\ndiff_even_odd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    diff_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort each sublist of strings in a given list of lists.\n#\n# $1 is a newline-separated, space-separated list\nsort_sublists() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_sublists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange\\nblack white\\nwhite black orange\") = \"green orange\\nblack white\\nblack orange white\" ]]\n    [[ $(candidate \"green orange\\nblack\\ngreen orange\\nwhite\") = \"green orange\\nblack\\ngreen orange\\nwhite\" ]]\n    [[ $(candidate \"a b\\nd c\\ng h\\nf e\") = \"a b\\nc d\\ng h\\ne f\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the last digit of a given number.\n#\n# $1 is an integer\nlast_Digit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    last_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"25\") = \"5\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of fourth power of first n odd natural numbers.\n#\n# $1 is an integer\nodd_num_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    odd_num_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"82\" ]]\n    [[ $(candidate \"3\") = \"707\" ]]\n    [[ $(candidate \"4\") = \"3108\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a list to a string.\n#\n# $1 is a space-separated list\ntup_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tup_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"e x e r c i s e s\") = \"exercises\" ]]\n    [[ $(candidate \"p y t h o n\") = \"python\" ]]\n    [[ $(candidate \"p r o g r a m\") = \"program\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all elements from a given list present in another list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nremove_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"1 3 5 7\") = \"2 4 6 8 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5 7\") = \"1 2 3 4 6 8 9 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether any value in a sequence exists in a sequence or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\noverlapping() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    overlapping \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 4 5\" \"1 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to identify non-prime numbers.\n#\n# $1 is an integer\nis_not_prime() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_not_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"35\") = \"true\" ]]\n    [[ $(candidate \"37\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmax_val() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"5\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"25\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"50\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of the negative numbers of a given list of numbers.\n#\n# $1 is a space-separated list\nsum_negativenum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_negativenum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"-32\" ]]\n    [[ $(candidate \"10 15 -14 13 -18 12 -20\") = \"-52\" ]]\n    [[ $(candidate \"19 -65 57 39 152 -639 121 44 90 -190\") = \"-894\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n#\n# $1 is a string\nfind_Rotations() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Rotations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aaaa\") = \"1\" ]]\n    [[ $(candidate \"ab\") = \"2\" ]]\n    [[ $(candidate \"abc\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n#\n# $1 is a string\nchange_date_format() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    change_date_format \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2026-01-02\") = \"02-01-2026\" ]]\n    [[ $(candidate \"2020-11-13\") = \"13-11-2020\" ]]\n    [[ $(candidate \"2021-04-26\") = \"26-04-2021\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of integers and only returns the odd ones.\n#\n# $1 is a space-separated list\nSplit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1 3 5\" ]]\n    [[ $(candidate \"10 11 12 13\") = \"11 13\" ]]\n    [[ $(candidate \"7 8 9 1\") = \"7 9 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n#\n# $1 is an integer\ntoggle_middle_bits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    toggle_middle_bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"15\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"11\") = \"13\" ]]\n    [[ $(candidate \"65\") = \"127\" ]]\n    [[ $(candidate \"77\") = \"115\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n#\n# $1 is a string\ncount_char_position() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_char_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xbcefg\") = \"2\" ]]\n    [[ $(candidate \"ABcED\") = \"3\" ]]\n    [[ $(candidate \"AbgdeF\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nlarge_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    large_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"3\") = \"60 54 50\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"4\") = \"60 54 50 48\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"5\") = \"60 54 50 48 45\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ncummulative_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    cummulative_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 6 7\\n2 6\") = \"30\" ]]\n    [[ $(candidate \"2 4\\n6 7 8\\n3 7\") = \"37\" ]]\n    [[ $(candidate \"3 5\\n7 8 9\\n4 8\") = \"44\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_min_diff() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_min_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 3 19 18 25\" \"6\") = \"1\" ]]\n    [[ $(candidate \"4 3 2 6\" \"4\") = \"1\" ]]\n    [[ $(candidate \"30 5 20 9\" \"4\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n#\n# $1 is a string\ntext_starta_endb() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_starta_endb \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aabbbb\") = \"true\" ]]\n    [[ $(candidate \"aabAbbbc\") = \"false\" ]]\n    [[ $(candidate \"accddbbjjj\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n#\n# $1 is an integer\n# $2 is an integer\nleft_rotate() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    left_rotate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"64\" ]]\n    [[ $(candidate \"10\" \"2\") = \"40\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"1\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"3\") = \"40\" ]]\n    [[ $(candidate \"29\" \"3\") = \"232\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the first repeated character in a given string.\n#\n# $1 is a string\nfirst_repeated_char() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    first_repeated_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"a\" ]]\n    [[ $(candidate \"abc\") = \"None\" ]]\n    [[ $(candidate \"123123\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count inversions in an array.\n#\n# $1 is a space-separated list\nget_Inv_Count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_Inv_Count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 20 6 4 5\") = \"5\" ]]\n    [[ $(candidate \"1 2 1\") = \"1\" ]]\n    [[ $(candidate \"1 2 5 6 1\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n#\n# $1 is an integer\neven_Power_Sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    even_Power_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1056\" ]]\n    [[ $(candidate \"3\") = \"8832\" ]]\n    [[ $(candidate \"1\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find whether all the given lists have equal length or not.\n#\n# $1 is a newline-separated, space-separated list\nget_equal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 22 33\\n44 55 66\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"1 2\\n3 4\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if a string represents an integer or not.\n#\n# $1 is a string\ncheck_integer() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"12345\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/shthon-program-to-count-the-pairs-of-reverse-strings/\n#\n# $1 is a space-separated list\ncount_reverse_pairs() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_reverse_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"julia best tseb for ailuj\") = \"2\" ]]\n    [[ $(candidate \"geeks best for skeeg\") = \"1\" ]]\n    [[ $(candidate \"makes best sekam for rof\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to move all zeroes to the end of the given list.\n#\n# $1 is a space-separated list\nmove_zero() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    move_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 0 2 0 3 4\") = \"1 2 3 4 0 0\" ]]\n    [[ $(candidate \"2 3 2 0 0 4 0 5 0\") = \"2 3 2 4 5 0 0 0 0\" ]]\n    [[ $(candidate \"0 1 0 1 1\") = \"1 1 1 0 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if given list contains no duplicates.\n#\n# $1 is a space-separated list\ncheck_distinct() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_distinct \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 5 6 1 4\") = \"false\" ]]\n    [[ $(candidate \"1 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 6\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given amount has no profit and no loss\n#\n# $1 is an integer\n# $2 is an integer\nnoprofit_noloss() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    noprofit_noloss \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"false\" ]]\n    [[ $(candidate \"100\" \"100\") = \"true\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all the words with k length in the given string.\n#\n# $1 is a string\n# $2 is an integer\nremove_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The person is most value tet\" \"3\") = \"person is most value\" ]]\n    [[ $(candidate \"If you told me about this ok\" \"4\") = \"If you me about ok\" ]]\n    [[ $(candidate \"Forces of darkeness is come into the play\" \"4\") = \"Forces of darkeness is the\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count number of digits in a given string.\n#\n# $1 is a string\nnumber_ctr() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    number_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"program2bedone\") = \"1\" ]]\n    [[ $(candidate \"3wonders\") = \"1\" ]]\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"3wond-1ers2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the total number of characters in a string.\n#\n# $1 is a string\ncount_charac() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_charac \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"18\" ]]\n    [[ $(candidate \"language\") = \"8\" ]]\n    [[ $(candidate \"words\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n#\n# $1 is an integer\n# $2 is an integer\nget_total_number_of_sequences() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_total_number_of_sequences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"4\") = \"4\" ]]\n    [[ $(candidate \"5\" \"2\") = \"6\" ]]\n    [[ $(candidate \"16\" \"3\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/shthon-exercises/data-structures-and-algorithms/shthon-data-structure-exercise-24.php\n#\n# $1 is a space-separated list\n# $2 is an integer\nleft_insertion() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    left_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two numbers and returns a list with the second number and then the first number.\n#\n# $1 is an integer\n# $2 is an integer\nswap_numbers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    swap_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"20 10\" ]]\n    [[ $(candidate \"15\" \"17\") = \"17 15\" ]]\n    [[ $(candidate \"100\" \"200\") = \"200 100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nis_majority() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_majority \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 3 3 3 10\" \"7\" \"3\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 4 4 4 6 6\" \"8\" \"4\") = \"false\" ]]\n    [[ $(candidate \"1 1 1 2 2\" \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2\" \"5\" \"1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsubstract_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    substract_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5\" \"2 5 18\") = \"8 -1 -13\" ]]\n    [[ $(candidate \"11 2 3\" \"24 45 16\") = \"-13 -43 -13\" ]]\n    [[ $(candidate \"7 18 9\" \"10 11 12\") = \"-3 7 -3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to put spaces between words starting with capital letters in a given string.\n#\n# $1 is a string\ncapital_words_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    capital_words_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"PythonProgrammingExamples\") = \"Python Programming Examples\" ]]\n    [[ $(candidate \"GetReadyToBeCodingFreak\") = \"Get Ready To Be Coding Freak\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the average of cubes of first n natural numbers.\n#\n# $1 is an integer\nfind_Average_Of_Cube() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Average_Of_Cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4.5\" ]]\n    [[ $(candidate \"3\") = \"12\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth tetrahedral number.\n#\n# $1 is an integer\ntetrahedral_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tetrahedral_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"35\" ]]\n    [[ $(candidate \"6\") = \"56\" ]]\n    [[ $(candidate \"7\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate whether the matrix is a magic square.\n#\n# $1 is a newline-separated, space-separated list\nmagic_square_test() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    magic_square_test \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7 12 1 14\\n2 13 8 11\\n16 3 10 5\\n9 6 15 4\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 8\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 7\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove uppercase substrings from a given string.\n#\n# $1 is a string\nremove_uppercase() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"cAstyoUrFavoRitETVshoWs\") = \"cstyoravoitshos\" ]]\n    [[ $(candidate \"wAtchTheinTernEtrAdIo\") = \"wtchheinerntrdo\" ]]\n    [[ $(candidate \"VoicESeaRchAndreComMendaTionS\") = \"oiceachndreomendaion\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether an element exists within a list.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncheck_tuplex() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_tuplex \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"w 3 r e s o u r c e\" \"r\") = \"true\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"5\") = \"false\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"3\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate a dog's age in dog's years.\n#\n# $1 is an integer\ndog_age() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    dog_age \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"61\" ]]\n    [[ $(candidate \"15\") = \"73\" ]]\n    [[ $(candidate \"24\") = \"109\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the next perfect square greater than a given number.\n#\n# $1 is an integer\nnext_Perfect_Square() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    next_Perfect_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"35\") = \"36\" ]]\n    [[ $(candidate \"6\") = \"9\" ]]\n    [[ $(candidate \"9\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to convert a given string to uppercase.\n#\n# $1 is a string\nis_upper() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"person\") = \"PERSON\" ]]\n    [[ $(candidate \"final\") = \"FINAL\" ]]\n    [[ $(candidate \"Valid\") = \"VALID\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n#\n# $1 is a string\n# $2 is an integer\nodd_Equivalent() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    odd_Equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"011001\" \"6\") = \"3\" ]]\n    [[ $(candidate \"11011\" \"5\") = \"4\" ]]\n    [[ $(candidate \"1010\" \"4\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n#\n# $1 is a space-separated list\n# $2 is an integer\nre_arrange_array() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    re_arrange_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 2 -3 4 5 6 -7 8 9\" \"9\") = \"-1 -3 -7 4 5 6 2 8 9\" ]]\n    [[ $(candidate \"12 -14 -26 13 15\" \"5\") = \"-14 -26 12 13 15\" ]]\n    [[ $(candidate \"10 24 36 -42 -39 -78 85\" \"7\") = \"-42 -39 -78 10 24 36 85\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether a list of numbers contains only one distinct element or not.\n#\n# $1 is a space-separated list\nunique_Element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    unique_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract values between quotation marks from a string.\n#\n# $1 is a string\nextract_values() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_values \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") = \"Python PHP Java\" ]]\n    [[ $(candidate \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") = \"python program language\" ]]\n    [[ $(candidate \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") = \"red blue green yellow\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count true booleans in the given list.\n#\n# $1 is a space-separated list\ncount() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"true false true\") = \"2\" ]]\n    [[ $(candidate \"false false\") = \"0\" ]]\n    [[ $(candidate \"true true true\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that counts the number of pairs of integers in a list that xor to an even number.\n#\n# $1 is a space-separated list\nfind_even_pair() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_even_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\") = \"4\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\") = \"9\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is armstrong or not.\n#\n# $1 is an integer\narmstrong_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    armstrong_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"153\") = \"true\" ]]\n    [[ $(candidate \"259\") = \"false\" ]]\n    [[ $(candidate \"4458\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the upper case characters in a given string.\n#\n# $1 is a string\nupper_ctr() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    upper_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYthon\") = \"1\" ]]\n    [[ $(candidate \"BigData\") = \"1\" ]]\n    [[ $(candidate \"program\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract the elementwise and lists from the given two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nand_tuples() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    and_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"0 0 2 1\" ]]\n    [[ $(candidate \"1 2 3 4\" \"5 6 7 8\") = \"1 2 3 0\" ]]\n    [[ $(candidate \"8 9 11 12\" \"7 13 14 17\") = \"0 9 10 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether it follows the sequence given in the patterns array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_samepatterns() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_samepatterns \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red green green\" \"a b b\") = \"true\" ]]\n    [[ $(candidate \"red green greenn\" \"a b b\") = \"false\" ]]\n    [[ $(candidate \"red green greenn\" \"a b\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of lists in a given number of lists.\n#\n# $1 is a newline-separated, space-separated list\ncount_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n9 11\\n13 15 17\") = \"4\" ]]\n    [[ $(candidate \"1 2\\n2 3\\n4 5\") = \"3\" ]]\n    [[ $(candidate \"1 0\\n2 0\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n#\n# $1 is a newline-separated, space-separated list\naverage_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    average_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 12\\n30 45 56 45\\n81 80 39 32\\n1 2 3 4\") = \"30.5 34.25 27.0 23.25\" ]]\n    [[ $(candidate \"1 1 -5\\n30 -15 56\\n81 -60 -39\\n-10 2 3\") = \"25.5 -18.0 3.75\" ]]\n    [[ $(candidate \"100 100 100 120\\n300 450 560 450\\n810 800 390 320\\n10 20 30 40\") = \"305.0 342.5 270.0 232.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nlcs_of_three() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    lcs_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") = \"2\" ]]\n    [[ $(candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") = \"5\" ]]\n    [[ $(candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n'th star number.\n#\n# $1 is an integer\nfind_star_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_star_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"37\" ]]\n    [[ $(candidate \"4\") = \"73\" ]]\n    [[ $(candidate \"5\") = \"121\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of an array.\n#\n# $1 is a space-separated list\n_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    _sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"15 12 13 10\") = \"50\" ]]\n    [[ $(candidate \"0 1 2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given list contains consecutive numbers or not.\n#\n# $1 is a space-separated list\ncheck_Consecutive() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_Consecutive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the first adverb and their positions in a given sentence.\n#\n# $1 is a string\nfind_adverb_position() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_adverb_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"clearly\\!\\! we can see the sky\") = \"0 7 clearly\" ]]\n    [[ $(candidate \"seriously\\!\\! there are many roses\") = \"0 9 seriously\" ]]\n    [[ $(candidate \"unfortunately\\!\\! sita is going to home\") = \"0 13 unfortunately\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/shthon-program-right-rotate-list-n/\n#\n# $1 is a space-separated list\n# $2 is an integer\nrotate_right() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rotate_right \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"3\") = \"8 9 10 1 2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"9 10 1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5\") = \"6 7 8 9 10 1 2 3 4 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of non-empty substrings of a given string.\n#\n# $1 is a string\nnumber_of_substrings() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    number_of_substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"6\" ]]\n    [[ $(candidate \"abcd\") = \"10\" ]]\n    [[ $(candidate \"abcde\") = \"15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlist_split() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    list_split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b c d e f g h i j k l m n\" \"3\") = \"a d g j m\\nb e h k n\\nc f i l\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11 12 13 14\" \"3\") = \"1 4 7 10 13\\n2 5 8 11 14\\n3 6 9 12\" ]]\n    [[ $(candidate \"python java C C++ DBMS SQL\" \"2\") = \"python C DBMS\\njava C++ SQL\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check if the elements of a given list are unique or not.\n#\n# $1 is a space-separated list\nall_unique() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    all_unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to convert complex numbers to polar coordinates.\n#\n# $1 is an integer\nconvert() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    convert \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"4\") = \"4.0 0.0\" ]]\n    [[ $(candidate \"5\") = \"5.0 0.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to convert the given string to lower case.\n#\n# $1 is a string\nis_lower() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_lower \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"InValid\") = \"invalid\" ]]\n    [[ $(candidate \"TruE\") = \"true\" ]]\n    [[ $(candidate \"SenTenCE\") = \"sentence\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the smallest power of 2 greater than or equal to n.\n#\n# $1 is an integer\nnext_power_of_2() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    next_power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"5\") = \"8\" ]]\n    [[ $(candidate \"17\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if a string is present as a substring in a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is a string\nfind_substring() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red black white green orange\" \"ack\") = \"true\" ]]\n    [[ $(candidate \"red black white green orange\" \"abc\") = \"false\" ]]\n    [[ $(candidate \"red black white green orange\" \"ange\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace characters in a string.\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nreplace_char() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"polygon\" \"y\" \"l\") = \"pollgon\" ]]\n    [[ $(candidate \"character\" \"c\" \"a\") = \"aharaater\" ]]\n    [[ $(candidate \"python\" \"l\" \"a\") = \"python\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the product of first even and odd number of a given list.\n#\n# $1 is a space-separated list\nmul_even_odd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    mul_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a list to a list.\n#\n# $1 is a space-separated list\nlist_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    list_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 10 7 4 15 3\") = \"5 10 7 4 15 3\" ]]\n    [[ $(candidate \"2 4 5 6 2 3 4 4 7\") = \"2 4 5 6 2 3 4 4 7\" ]]\n    [[ $(candidate \"58 44 56\") = \"58 44 56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n#\n# $1 is an integer\neven_binomial_Coeff_Sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    even_binomial_Coeff_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"8\" ]]\n    [[ $(candidate \"6\") = \"32\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform the mathematical bitwise xor operation across the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nbitwise_xor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    bitwise_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"15 6 5 10\" ]]\n    [[ $(candidate \"11 5 7 10\" \"6 3 4 4\") = \"13 6 3 14\" ]]\n    [[ $(candidate \"12 6 8 11\" \"7 4 5 6\") = \"11 2 13 13\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether a list is sublist of another or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_Sub_Array() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_Sub_Array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 5\" \"1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\" \"1 2 1\") = \"true\" ]]\n    [[ $(candidate \"1 0 2 2\" \"2 2 0\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nmax_sub_array_sum_repeated() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_sub_array_sum_repeated \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 -30 -1\" \"4\" \"3\") = \"30\" ]]\n    [[ $(candidate \"-1 10 20\" \"3\" \"2\") = \"59\" ]]\n    [[ $(candidate \"-1 -2 -3\" \"3\" \"3\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the minimum product from the pairs of lists within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmin_product_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"8\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"30\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"100\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the count of divisors is even. https://www.w3resource.com/shthon-exercises/basic/shthon-basic-1-exercise-24.php\n#\n# $1 is an integer\ncount_divisors() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_divisors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"100\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n#\n# $1 is an integer\ntriangle_area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1\") = \"None\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"2\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a given string to a list of characters.\n#\n# $1 is a string\nstring_to_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    string_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python 3.0\") = \"p y t h o n 3 . 0\" ]]\n    [[ $(candidate \"item1\") = \"i t e m 1\" ]]\n    [[ $(candidate \"15.10\") = \"1 5 . 1 0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n#\n# $1 is a string\nfind_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11000010001\") = \"6\" ]]\n    [[ $(candidate \"10111\") = \"1\" ]]\n    [[ $(candidate \"11011101100101\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n#\n# $1 is an integer\ncount_Primes_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_Primes_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"4\" ]]\n    [[ $(candidate \"100\") = \"25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the product of consecutive binomial co-efficients.\n#\n# $1 is an integer\nsum_Of_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_Of_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15\" ]]\n    [[ $(candidate \"4\") = \"56\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\ncomb_sort() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    comb_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 15 37 25 79\") = \"5 15 25 37 79\" ]]\n    [[ $(candidate \"41 32 15 19 22\") = \"15 19 22 32 41\" ]]\n    [[ $(candidate \"99 15 13 47\") = \"13 15 47 99\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n#\n# $1 is a string\ncheck_expression() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_expression \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"{()}[{}]\") = \"true\" ]]\n    [[ $(candidate \"{()}[{]\") = \"false\" ]]\n    [[ $(candidate \"{()}[{}][]({})\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a word containing 'z'.\n#\n# $1 is a string\ntext_match_wordz() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_wordz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonz.\") = \"true\" ]]\n    [[ $(candidate \"xyz.\") = \"true\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsum_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30\" \"15 25 35\") = \"25 45 65\" ]]\n    [[ $(candidate \"1 2 3\" \"5 6 7\") = \"6 8 10\" ]]\n    [[ $(candidate \"15 20 30\" \"15 45 75\") = \"30 65 105\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n#\n# $1 is an integer\nnewman_prime() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    newman_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"7\" ]]\n    [[ $(candidate \"4\") = \"17\" ]]\n    [[ $(candidate \"5\") = \"41\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to apply a given format string to all of the elements in a list.\n#\n# $1 is a space-separated list\n# $2 is a string\nadd_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"temp{0}\") = \"temp1 temp2 temp3 temp4\" ]]\n    [[ $(candidate \"a b c d\" \"python{0}\") = \"pythona pythonb pythonc pythond\" ]]\n    [[ $(candidate \"5 6 7 8\" \"string{0}\") = \"string5 string6 string7 string8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the surface area of a square shramid with a given base edge and height.\n#\n# $1 is an integer\n# $2 is an integer\nsurface_Area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    surface_Area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"33\" ]]\n    [[ $(candidate \"4\" \"5\") = \"56\" ]]\n    [[ $(candidate \"1\" \"2\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the smallest list in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min_Length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Find_Min_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\") = \"1\" ]]\n    [[ $(candidate \"1 2\\n1 2 3\\n1 2 3 4\") = \"2\" ]]\n    [[ $(candidate \"3 3 3\\n4 4 4 4\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n#\n# $1 is an integer\nvalidate() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    validate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1234\") = \"true\" ]]\n    [[ $(candidate \"51241\") = \"false\" ]]\n    [[ $(candidate \"321\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth hexagonal number.\n#\n# $1 is an integer\nhexagonal_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    hexagonal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"190\" ]]\n    [[ $(candidate \"5\") = \"45\" ]]\n    [[ $(candidate \"7\") = \"91\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n'th lucas number.\n#\n# $1 is an integer\nfind_lucas() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_lucas \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"76\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"3\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to get the difference between two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nDiff() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 15 20 25 30 35 40\" \"25 40 35\") = \"10 20 30 15\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 1\") = \"2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3\" \"6 7 1\") = \"2 3 6 7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to flatten a list and sum all of its elements.\n#\n# $1 is a newline-separated, space-separated list\nrecursive_list_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    recursive_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"7 10 15 14 19 41\") = \"106\" ]]\n    [[ $(candidate \"10 20 30 40 50 60\") = \"210\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the two numbers differ at one bit position only or not.\n#\n# $1 is an integer\n# $2 is an integer\ndiffer_At_One_Bit_Pos() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    differ_At_One_Bit_Pos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\" \"9\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2\" \"3\") = \"true\" ]]\n    [[ $(candidate \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by three 'b'.\n#\n# $1 is a string\ntext_match_three() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"caacabbbba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n#\n# $1 is a space-separated list\nmax_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 100 4 5 150 6\") = \"3000\" ]]\n    [[ $(candidate \"4 42 55 68 80\") = \"50265600\" ]]\n    [[ $(candidate \"10 22 9 33 21 50 41 60\") = \"2460\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to split a list at the nth eelment and add the first part to the end.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_Arr() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    split_Arr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 10 5 6 52 36\" \"2\") = \"5 6 52 36 12 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1\") = \"2 3 4 1\" ]]\n    [[ $(candidate \"0 1 2 3 4 5 6 7\" \"3\") = \"3 4 5 6 7 0 1 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the number of divisors of a given integer.\n#\n# $1 is an integer\ndivisor() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"6\" ]]\n    [[ $(candidate \"9\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the difference between largest and smallest value in a given list.\n#\n# $1 is a space-separated list\nbig_diff() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    big_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"4 5 12\") = \"8\" ]]\n    [[ $(candidate \"9 2 3\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find squares of individual elements in a list.\n#\n# $1 is a space-separated list\nsquare_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    square_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\") = \"100 400 900\" ]]\n    [[ $(candidate \"12 15\") = \"144 225\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given list has any none value or not.\n#\n# $1 is a $Any\ncheck_none() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_none \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 None\") = \"true\" ]]\n    [[ $(candidate \"7 8 9 11 14\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 None\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given array is monotonic or not.\n#\n# $1 is a space-separated list\nis_Monotonic() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_Monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 5 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 3 2\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n#\n# $1 is an integer\nis_perfect_square() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_perfect_square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"36\") = \"true\" ]]\n    [[ $(candidate \"14\") = \"false\" ]]\n    [[ $(candidate \"196\") = \"true\" ]]\n    [[ $(candidate \"125\") = \"false\" ]]\n    [[ $(candidate \"15625\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of common divisors of two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nsum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"15\") = \"6\" ]]\n    [[ $(candidate \"100\" \"150\") = \"93\" ]]\n    [[ $(candidate \"4\" \"6\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the list of maximum length in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nmax_length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1\\n5 7\\n10 12 14 15\") = \"4 10 12 14 15\" ]]\n    [[ $(candidate \"5\\n15 20 25\") = \"3 15 20 25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the directrix of a parabola.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nparabola_directrix() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    parabola_directrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\" \"2\") = \"-198\" ]]\n    [[ $(candidate \"9\" \"8\" \"4\") = \"-2336\" ]]\n    [[ $(candidate \"2\" \"4\" \"6\") = \"-130\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n#\n# $1 is a string\n# $2 is a string\noccurance_substring() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    occurance_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming, python language\" \"python\") = \"python 0 6\" ]]\n    [[ $(candidate \"python programming,programming language\" \"programming\") = \"programming 7 18\" ]]\n    [[ $(candidate \"python programming,programming language\" \"language\") = \"language 31 39\" ]]\n    [[ $(candidate \"c++ programming, c++ language\" \"python\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove lists from the given list.\n#\n# $1 is a $Any\nremove_nested() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"1 5 7 10\" ]]\n    [[ $(candidate \"2 6 8 5 7 11\") = \"2 6 8 11\" ]]\n    [[ $(candidate \"3 7 9 6 8 12\") = \"3 7 9 12\" ]]\n    [[ $(candidate \"3 7 9 6 8 5 12 12\") = \"3 7 9 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n#\n# $1 is a space-separated list\n# $2 is an integer\nremove_kth_element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 3 4 4 5 1\" ]]\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\" \"4\") = \"0 0 1 3 4 4 5 6 6 6 7 8 9 4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\" \"5\") = \"10 10 15 19 18 17 26 26 17 18 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to add a CSV to the list. The output should be a list.\n#\n# $1 is a space-separated list\n# $2 is a two column CSV in key,value order\nadd_dict_to_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_dict_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"MSAM,1\\nis,2\\nbest,3\") = \"4 5 6 MSAM,1\\nis,2\\nbest,3\" ]]\n    [[ $(candidate \"1 2 3\" \"UTS,2\\nis,3\\nWorst,4\") = \"1 2 3 UTS,2\\nis,3\\nWorst,4\" ]]\n    [[ $(candidate \"8 9 10\" \"POS,3\\nis,4\\nOkay,5\") = \"8 9 10 POS,3\\nis,4\\nOkay,5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find quotient of two numbers (rounded down to the nearest integer).\n#\n# $1 is an integer\n# $2 is an integer\nfind() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"3\") = \"3\" ]]\n    [[ $(candidate \"4\" \"2\") = \"2\" ]]\n    [[ $(candidate \"20\" \"5\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n#\n# $1 is a string\ntext_match_two_three() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_two_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the occurence of all elements of list in a list.\n#\n# $1 is a $Any\n# $2 is a space-separated list\ncount_Occurrence() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_Occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a a c b d\" \"a b\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 1 4 6 7 1 4\" \"1 4 7\") = \"6\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"1 2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count number items that are identical in the same position of three given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ncount_samepair() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_samepair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\" \"2 1 3 1 2 6 7 9\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 2 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by one or more b's.\n#\n# $1 is a string\ntext_match_one() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abba\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n#\n# $1 is an integer\ndifference() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"30\" ]]\n    [[ $(candidate \"5\") = \"210\" ]]\n    [[ $(candidate \"2\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to toggle the case of all characters in a string.\n#\n# $1 is a string\ntoggle_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    toggle_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"pYTHON\" ]]\n    [[ $(candidate \"Pangram\") = \"pANGRAM\" ]]\n    [[ $(candidate \"LIttLE\") = \"liTTle\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the element of a list having maximum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Find_Max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\\nA B\\nA B C\") = \"A B C\" ]]\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"1 1\\n1 2 3\\n1 5 6 1\") = \"1 5 6 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the Eulerian number a(n, m).\n#\n# $1 is an integer\n# $2 is an integer\neulerian_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    eulerian_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"1\") = \"4\" ]]\n    [[ $(candidate \"4\" \"1\") = \"11\" ]]\n    [[ $(candidate \"5\" \"3\") = \"26\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of occurrences of a number in a given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfrequency() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    frequency \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 2 3 3 3 4\" \"3\") = \"3\" ]]\n    [[ $(candidate \"0 1 2 3 1 2\" \"1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/shthon-exercises/data-structures-and-algorithms/shthon-recursion-exercise-9.php\n#\n# $1 is an integer\ngeometric_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    geometric_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"1.9921875\" ]]\n    [[ $(candidate \"4\") = \"1.9375\" ]]\n    [[ $(candidate \"8\") = \"1.99609375\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/shthon-exercises/lambda/shthon-lambda-exercise-24.php\n#\n# $1 is an integer\n# $2 is an integer\ndivisible_by_digits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    divisible_by_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"22\") = \"1 2 3 4 5 6 7 8 9 11 12 15 22\" ]]\n    [[ $(candidate \"1\" \"15\") = \"1 2 3 4 5 6 7 8 9 11 12 15\" ]]\n    [[ $(candidate \"20\" \"25\") = \"22 24\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to calculate the product of the unique numbers in a given list.\n#\n# $1 is a space-separated list\nunique_product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    unique_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30 40 20 50 60 40\") = \"720000000\" ]]\n    [[ $(candidate \"1 2 3 1\") = \"6\" ]]\n    [[ $(candidate \"7 8 9 0 1 1\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the largest negative number from the given list.\n#\n# $1 is a space-separated list\nlargest_neg() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    largest_neg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 -4 -6\") = \"-6\" ]]\n    [[ $(candidate \"1 2 3 -8 -9\") = \"-9\" ]]\n    [[ $(candidate \"1 2 3 4 -1\") = \"-1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove consecutive duplicates of a given list.\n#\n# $1 is a space-separated list\nconsecutive_duplicates() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 1 2 3 4 5 6 7 8 9 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 15 19 18 17 26 17 18 10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a b c d\" ]]\n    [[ $(candidate \"a a b c d d a a\") = \"a b c d a\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmin_Jumps() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_Jumps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\" \"11\") = \"3.5\" ]]\n    [[ $(candidate \"3 4\" \"0\") = \"0\" ]]\n    [[ $(candidate \"11 14\" \"11\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find a pair with highest product from a given array of integers.\n#\n# $1 is a space-separated list\nmax_Product() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_Product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 7 0 8 4\") = \"7 8\" ]]\n    [[ $(candidate \"0 -1 -2 -4 5 0 -6\") = \"-4 -6\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth nonagonal number.\n#\n# $1 is an integer\nis_nonagonal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_nonagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"325\" ]]\n    [[ $(candidate \"15\") = \"750\" ]]\n    [[ $(candidate \"18\") = \"1089\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the maximum difference between any two elements in a given array.\n#\n# $1 is a space-separated list\nmax_Abs_Diff() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_Abs_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 3\") = \"4\" ]]\n    [[ $(candidate \"9 3 2 5 1\") = \"8\" ]]\n    [[ $(candidate \"3 2 1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to pack consecutive duplicates of a given list elements into sublists.\n#\n# $1 is a space-separated list\npack_consecutive_duplicates() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pack_consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 0\\n1\\n2\\n3\\n4 4\\n5\\n6 6 6\\n7\\n8\\n9\\n4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 10\\n15\\n19\\n18 18\\n17\\n26 26\\n17\\n18\\n10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a a\\nb\\nc\\nd d\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of perrin numbers.\n#\n# $1 is an integer\ncal_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    cal_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"49\" ]]\n    [[ $(candidate \"10\") = \"66\" ]]\n    [[ $(candidate \"11\") = \"88\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to remove the characters which have odd index values of a given string.\n#\n# $1 is a string\nodd_values_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    odd_values_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcdef\") = \"ace\" ]]\n    [[ $(candidate \"python\") = \"pto\" ]]\n    [[ $(candidate \"data\") = \"dt\" ]]\n    [[ $(candidate \"lambs\") = \"lms\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find kth element from the given two sorted arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nfind_kth() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_kth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 6 7 9\" \"1 4 8 10\" \"5\") = \"6\" ]]\n    [[ $(candidate \"100 112 256 349 770\" \"72 86 113 119 265 445 892\" \"7\") = \"256\" ]]\n    [[ $(candidate \"3 4 7 8 10\" \"2 5 9 11\" \"6\") = \"8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n#\n# $1 is an integer\njacobsthal_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    jacobsthal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"11\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"5\" ]]\n    [[ $(candidate \"13\") = \"2731\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find frequency of each element in a flattened list of lists, returned in a CSV.\n#\n# $1 is a newline-separated, space-separated list\nfrequency_lists() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    frequency_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2\\n4 5 6 2\\n7 8 9 5\") = \"1,1\\n2,3\\n3,1\\n4,1\\n5,2\\n6,1\\n7,1\\n8,1\\n9,1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\") = \"1,1\\n2,1\\n3,1\\n4,1\\n5,1\\n6,1\\n7,1\\n8,1\\n9,1\\n10,1\\n11,1\\n12,1\" ]]\n    [[ $(candidate \"20 30 40 17\\n18 16 14 13\\n10 20 30 40\") = \"20,2\\n30,2\\n40,2\\n17,1\\n18,1\\n16,1\\n14,1\\n13,1\\n10,1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find perfect squares between two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nperfect_squares() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    perfect_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"30\") = \"1 4 9 16 25\" ]]\n    [[ $(candidate \"50\" \"100\") = \"64 81 100\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100 121 144 169 196\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n#\n# $1 is a space-separated list\nsum_Of_Subarray_Prod() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_Of_Subarray_Prod \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"20\" ]]\n    [[ $(candidate \"1 2\") = \"5\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"84\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the first odd number in a given list of numbers.\n#\n# $1 is a space-separated list\nfirst_odd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    first_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5\") = \"1\" ]]\n    [[ $(candidate \"2 4 1 3\") = \"1\" ]]\n    [[ $(candidate \"8 9 1\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform index wise addition of list elements in the given two nested lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nadd_nested_tuples() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_nested_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"7 10\\n7 14\\n3 10\\n8 13\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"9 12\\n9 16\\n5 12\\n10 15\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"11 14\\n11 18\\n7 14\\n12 17\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n#\n# $1 is a newline-separated, space-separated list\nmerge() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    merge \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\na b\\nm n\") = \"x a m\\ny b n\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\\n7 8\") = \"1 3 5 7\\n2 4 6 8\" ]]\n    [[ $(candidate \"x y z\\na b c\\nm n o\") = \"x a m\\ny b n\\nz c o\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number can be represented as the difference of two squares or not.\n#\n# $1 is an integer\ndif_Square() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    dif_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"15\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if each element of second list is smaller than its corresponding element in the first list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncheck_smaller() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_smaller \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"2 3 4\") = \"false\" ]]\n    [[ $(candidate \"4 5 6\" \"3 4 5\") = \"true\" ]]\n    [[ $(candidate \"11 12 13\" \"10 11 12\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to get the frequency of all the elements in a list, returned as a CSV.\n#\n# $1 is a space-separated list\nfreq_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    freq_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 10 20 20 20 20 40 40 50 50 30\") = \"10,4\\n20,4\\n40,2\\n50,2\\n30,1\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 4 1 3 1 4\") = \"1,3\\n2,2\\n3,3\\n4,3\" ]]\n    [[ $(candidate \"5 6 7 4 9 10 4 5 6 7 9 5\") = \"10,1\\n5,3\\n6,2\\n7,2\\n4,2\\n9,2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nrgb_to_hsv() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rgb_to_hsv \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"255\" \"255\" \"255\") = \"0.0 0.0 100.0\" ]]\n    [[ $(candidate \"0\" \"215\" \"0\") = \"120.0 100.0 84.31372549019608\" ]]\n    [[ $(candidate \"10\" \"215\" \"110\") = \"149.26829268292684 95.34883720930233 84.31372549019608\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to flatten a given nested list structure.\n#\n# $1 is a newline-separated, space-separated list\nflatten_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    flatten_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 10 20 30 40 50 60 70 80 90 100 110 120\") = \"0 10 20 30 40 50 60 70 80 90 100 110 120\" ]]\n    [[ $(candidate \"10 20\\n40\\n30 56 25\\n10 20\\n33\\n40\") = \"10 20 40 30 56 25 10 20 33 40\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"1 2 3 4 5 6 10 11 12 7 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given string is starting with a vowel or not using regex.\n#\n# $1 is a string\ncheck_str() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_str \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"annie\") = \"true\" ]]\n    [[ $(candidate \"dawood\") = \"false\" ]]\n    [[ $(candidate \"Else\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n#\n# $1 is an integer\ncheck_monthnumber_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_monthnumber_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort the given list.\n#\n# $1 is a space-separated list\nheap_sort() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    heap_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 2 4 6 8 0\") = \"0 1 2 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 25 58\") = \"14 22 25 25 35 58 65 75 85\" ]]\n    [[ $(candidate \"7 1 9 5\") = \"1 5 7 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nk_smallest_pairs() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    k_smallest_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"2\") = \"1 2\\n1 4\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"1\") = \"1 2\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"7\") = \"1 2\\n1 4\\n3 2\\n1 6\\n3 4\\n3 6\\n7 2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns integers x and y that satisfy ax + by = n as a list, or return None if no solution exists.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_solution() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"7\") = \"2 1\" ]]\n    [[ $(candidate \"4\" \"2\" \"7\") = \"None\" ]]\n    [[ $(candidate \"1\" \"13\" \"17\") = \"4 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the largest number that can be formed with the given list of digits.\n#\n# $1 is a space-separated list\nfind_Max_Num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Max_Num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"321\" ]]\n    [[ $(candidate \"4 5 6 1\") = \"6541\" ]]\n    [[ $(candidate \"1 2 3 9\") = \"9321\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns the list in a list of lists whose sum of elements is the highest.\n#\n# $1 is a newline-separated, space-separated list\nmax_sum_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"10 11 12\" ]]\n    [[ $(candidate \"3 2 1\\n6 5 4\\n12 11 10\") = \"12 11 10\" ]]\n    [[ $(candidate \"2 3 1\") = \"2 3 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to interchange the first and last elements in a list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 35 9 56 24\") = \"24 35 9 56 12\" ]]\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median of two sorted lists of same size.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nget_median() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 12 15 26 38\" \"2 13 17 30 45\" \"5\") = \"16.0\" ]]\n    [[ $(candidate \"2 4 8 9\" \"7 13 19 28\" \"4\") = \"8.5\" ]]\n    [[ $(candidate \"3 6 14 23 36 42\" \"2 18 27 39 49 55\" \"6\") = \"25.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace whitespaces with an underscore and vice versa in a given string.\n#\n# $1 is a string\nreplace_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jumanji The Jungle\") = \"Jumanji_The_Jungle\" ]]\n    [[ $(candidate \"The_Avengers\") = \"The Avengers\" ]]\n    [[ $(candidate \"Fast and Furious\") = \"Fast_and_Furious\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to determine if the sum of the divisors of two integers are the same.\n#\n# $1 is an integer\n# $2 is an integer\nare_equivalent() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    are_equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"36\" \"57\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"23\" \"47\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to reverse each string in a given list of string values.\n#\n# $1 is a space-separated list\nreverse_string_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    reverse_string_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue White Black\") = \"deR neerG eulB etihW kcalB\" ]]\n    [[ $(candidate \"john amal joel george\") = \"nhoj lama leoj egroeg\" ]]\n    [[ $(candidate \"jack john mary\") = \"kcaj nhoj yram\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to compute the sum of digits of each number of a given list.\n#\n# $1 is a space-separated list\nsum_of_digits() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_of_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 2 56\") = \"14\" ]]\n    [[ $(candidate \"10 20 4 5 b 70 a\") = \"19\" ]]\n    [[ $(candidate \"10 20 -4 5 -70\") = \"19\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth number in the newman conway sequence.\n#\n# $1 is an integer\nsequence() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"6\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nheap_queue_largest() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    heap_queue_largest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"3\") = \"85 75 65\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"2\") = \"85 75\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"5\") = \"85 75 65 58 35\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n#\n# $1 is an integer\n# $2 is an integer\nloss_amount() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    loss_amount \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"0\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"3000\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the union of the elements of two given lists and output them in sorted order.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nunion_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    union_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 4 5 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"3 4 5 6\") = \"1 2 3 4 5 6\" ]]\n    [[ $(candidate \"11 12 13 14\" \"13 15 16 17\") = \"11 12 13 14 15 16 17\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the longest sublists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max_Length() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Find_Max_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 4\\n5 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"0 1\\n2 2\\n3 2 1\") = \"3\" ]]\n    [[ $(candidate \"7\\n22 23\\n13 14 15\\n10 20 30 40 50\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find whether the parity of a given number is odd.\n#\n# $1 is an integer\nfind_Parity() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Parity \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"false\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median length of a trapezium.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_trapezium() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    median_trapezium \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\" \"25\" \"35\") = \"20\" ]]\n    [[ $(candidate \"10\" \"20\" \"30\") = \"15\" ]]\n    [[ $(candidate \"6\" \"9\" \"4\") = \"7.5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find nth centered hexagonal number.\n#\n# $1 is an integer\ncentered_hexagonal_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    centered_hexagonal_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"271\" ]]\n    [[ $(candidate \"2\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"217\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find number of lists present in the given list.\n#\n# $1 is a space-separated list\nfind_lists() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\") = \"2\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"9 8 7 6 5 4 3 2 1\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n#\n# $1 is an integer\nget_max_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"60\") = \"106\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the longest word.\n#\n# $1 is a space-separated list\nlen_log() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    len_log \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python PHP bigdata\") = \"7\" ]]\n    [[ $(candidate \"a ab abc\") = \"3\" ]]\n    [[ $(candidate \"small big tall\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n#\n# $1 is an integer\n# $2 is an integer\nsector_area() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sector_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"45\") = \"6.283185307179586\" ]]\n    [[ $(candidate \"9\" \"45\") = \"31.808625617596654\" ]]\n    [[ $(candidate \"9\" \"361\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether every odd index contains odd numbers of a given list.\n#\n# $1 is a space-separated list\nodd_position() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    odd_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 4 3 6 7 6 3\") = \"true\" ]]\n    [[ $(candidate \"4 1 2\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to join a list of multiple integers into a single integer.\n#\n# $1 is a space-separated list\nmultiple_to_single() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    multiple_to_single \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 33 50\") = \"113350\" ]]\n    [[ $(candidate \"-1 2 3 4 5 6\") = \"-123456\" ]]\n    [[ $(candidate \"10 15 20 25\") = \"10152025\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find whether a number is divisible by 11.\n#\n# $1 is an integer\nis_Diff() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12345\") = \"false\" ]]\n    [[ $(candidate \"1212112\") = \"true\" ]]\n    [[ $(candidate \"1212\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to perform index wise multiplication of list elements in the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nindex_multiplication() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    index_multiplication \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 21\\n12 45\\n2 9\\n7 30\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"14 32\\n20 60\\n6 20\\n16 44\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"24 45\\n30 77\\n12 33\\n27 60\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert list string to integer list.\n#\n# $1 is a string\ntuple_str_int() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tuple_str_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(7, 8, 9)\") = \"7 8 9\" ]]\n    [[ $(candidate \"(1, 2, 3)\") = \"1 2 3\" ]]\n    [[ $(candidate \"(4, 5, 6)\") = \"4 5 6\" ]]\n    [[ $(candidate \"(7, 81, 19)\") = \"7 81 19\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sum all amicable numbers from 1 to a specified number.\n#\n# $1 is an integer\namicable_numbers_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    amicable_numbers_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"999\") = \"504\" ]]\n    [[ $(candidate \"9999\") = \"31626\" ]]\n    [[ $(candidate \"99\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove odd characters in a string.\n#\n# $1 is a string\nremove_odd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"yhn\" ]]\n    [[ $(candidate \"program\") = \"rga\" ]]\n    [[ $(candidate \"language\") = \"agae\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\n#\n# $1 is a space-separated list\nmultiply_elements() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    multiply_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"5 35 56 80\" ]]\n    [[ $(candidate \"2 4 5 6 7\") = \"8 20 30 42\" ]]\n    [[ $(candidate \"12 13 14 9 15\") = \"156 182 126 135\" ]]\n    [[ $(candidate \"12\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n#\n# $1 is a space-separated list\ncount_rotation() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_rotation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"1\" ]]\n    [[ $(candidate \"4 5 1 2 3\") = \"2\" ]]\n    [[ $(candidate \"7 8 9 1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 2 3\") = \"0\" ]]\n    [[ $(candidate \"1 3 2\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract the number of unique lists in the given list.\n#\n# $1 is a newline-separated, space-separated list\nextract_freq() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_freq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 2\\n4 3\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"4 15\\n2 3\\n5 4\\n6 7\") = \"4\" ]]\n    [[ $(candidate \"5 16\\n2 3\\n6 5\\n6 9\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncount_same_pair() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_same_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"11\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"1\" ]]\n    [[ $(candidate \"0 1 1 2\" \"0 1 2 2\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the value of 'a' to the power 'b'.\n#\n# $1 is an integer\n# $2 is an integer\npower() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"81\" ]]\n    [[ $(candidate \"2\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"5\") = \"3125\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write function to find the sum of all items in the given CSV.\n#\n# $1 is a two column CSV in key,value order\nreturn_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    return_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a,100\\nb,200\\nc,300\") = \"600\" ]]\n    [[ $(candidate \"a,25\\nb,18\\nc,45\") = \"88\" ]]\n    [[ $(candidate \"a,36\\nb,39\\nc,49\") = \"124\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to return a list of all pairs of consecutive items in a given list.\n#\n# $1 is a space-separated list\npair_wise() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pair_wise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 3 4 4 5\") = \"1 1\\n1 2\\n2 3\\n3 3\\n3 4\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"1 5\\n5 7\\n7 9\\n9 10\" ]]\n    [[ $(candidate \"5 1 9 7 10\") = \"5 1\\n1 9\\n9 7\\n7 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 2\\n2 3\\n3 4\\n4 5\\n5 6\\n6 7\\n7 8\\n8 9\\n9 10\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to split a string into characters.\n#\n# $1 is a string\nsplit() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"p y t h o n\" ]]\n    [[ $(candidate \"Name\") = \"N a m e\" ]]\n    [[ $(candidate \"program\") = \"p r o g r a m\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find minimum of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmin_of_three() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\" \"0\") = \"0\" ]]\n    [[ $(candidate \"19\" \"15\" \"18\") = \"15\" ]]\n    [[ $(candidate \"-10\" \"-20\" \"-30\") = \"-30\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n#\n# $1 is an integer\nis_Sum_Of_Powers_Of_Two() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_Sum_Of_Powers_Of_Two \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"false\" ]]\n    [[ $(candidate \"14\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n#\n# $1 is a string\nget_Char() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_Char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"f\" ]]\n    [[ $(candidate \"gfg\") = \"t\" ]]\n    [[ $(candidate \"ab\") = \"c\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to return the sum of all divisors of a number.\n#\n# $1 is an integer\nsum_div() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_div \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"7\" ]]\n    [[ $(candidate \"12\") = \"16\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function that returns the number of integer elements in a given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_integer() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 abc 1.2\") = \"2\" ]]\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1.2 4 5.1\") = \"2\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to remove duplicate numbers from a given number of lists.\n#\n# $1 is a space-separated list\ntwo_unique_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    two_unique_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2 3 4 5\") = \"1 4 5\" ]]\n    [[ $(candidate \"1 2 3 2 4 5\") = \"1 3 4 5\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 2 3 4 5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find whether a given array of integers contains any duplicate element.\n#\n# $1 is a space-separated list\ntest_duplicate() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    test_duplicate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2 3 3 4 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which returns nth catalan number.\n#\n# $1 is an integer\ncatalan_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    catalan_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"16796\" ]]\n    [[ $(candidate \"9\") = \"4862\" ]]\n    [[ $(candidate \"7\") = \"429\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n#\n# $1 is an integer\n# $2 is an integer\npower_base_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    power_base_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"100\") = \"115\" ]]\n    [[ $(candidate \"8\" \"10\") = \"37\" ]]\n    [[ $(candidate \"8\" \"15\") = \"62\" ]]\n    [[ $(candidate \"3\" \"3\") = \"9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nreplace_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 2 4 6 8\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8\") = \"1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"red blue green\" \"yellow\") = \"red blue yellow\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth octagonal number.\n#\n# $1 is an integer\nis_octagonal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_octagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"65\" ]]\n    [[ $(candidate \"10\") = \"280\" ]]\n    [[ $(candidate \"15\") = \"645\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n#\n# $1 is a string\n# $2 is a string\nreplace_blank() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_blank \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello people\" \"@\") = \"hello@people\" ]]\n    [[ $(candidate \"python program language\" \"\\$\") = \"python\\$program\\$language\" ]]\n    [[ $(candidate \"blank space\" \"-\") = \"blank-space\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n#\n# $1 is a string\nreplace_specialchar() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_specialchar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python language, Programming language.\") = \"Python:language::Programming:language:\" ]]\n    [[ $(candidate \"a b c,d e f\") = \"a:b:c:d:e:f\" ]]\n    [[ $(candidate \"ram reshma,ram rahim\") = \"ram:reshma:ram:rahim\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert a given list of positive integers into a single integer.\n#\n# $1 is a space-separated list\ntuple_to_int() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tuple_to_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"123\" ]]\n    [[ $(candidate \"4 5 6\") = \"456\" ]]\n    [[ $(candidate \"5 6 7\") = \"567\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the third side of a right angled triangle.\n#\n# $1 is an integer\n# $2 is an integer\notherside_rightangle() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    otherside_rightangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"8\") = \"10.63014581273465\" ]]\n    [[ $(candidate \"3\" \"4\") = \"5\" ]]\n    [[ $(candidate \"7\" \"15\") = \"16.55294535724685\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the per-digit difference between two integers.\n#\n# $1 is an integer\n# $2 is an integer\ndigit_distance_nums() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    digit_distance_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"23\" \"56\") = \"6\" ]]\n    [[ $(candidate \"123\" \"256\") = \"7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that checks if a strings contains 'z', except at the start and end of the word.\n#\n# $1 is a string\ntext_match_wordz_middle() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_match_wordz_middle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonzabc.\") = \"true\" ]]\n    [[ $(candidate \"zxyabc.\") = \"false\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove leading zeroes from an ip address.\n#\n# $1 is a string\nremovezero_ip() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    removezero_ip \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"216.08.094.196\") = \"216.8.94.196\" ]]\n    [[ $(candidate \"12.01.024\") = \"12.1.24\" ]]\n    [[ $(candidate \"216.08.094.0196\") = \"216.8.94.196\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count the number of sublists containing a particular element.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncount_element_in_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_element_in_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n1 11\\n1 15 7\" \"1\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"A\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"E\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to multiply two integers.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply_int() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    multiply_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"5\" \"10\") = \"50\" ]]\n    [[ $(candidate \"4\" \"8\") = \"32\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the pairwise addition of the neighboring elements of the given list.\n#\n# $1 is a space-separated list\nadd_pairwise() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_pairwise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"6 12 15 18\" ]]\n    [[ $(candidate \"2 6 8 9 11\") = \"8 14 17 20\" ]]\n    [[ $(candidate \"3 7 9 10 12\") = \"10 16 19 22\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmax_product_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"36\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"200\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"484\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3376,7 +16,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find the kth element in the given array using 1-based indexing.\n#\n# $1 is a space-separated list\n# $2 is an integer\nkth_element() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 3 5 7 19\" \"2\") = \"3\" ]]\n    [[ $(candidate \"17 24 8 23\" \"3\") = \"8\" ]]\n    [[ $(candidate \"16 21 25 36 4\" \"4\") = \"36\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3384,265 +24,97 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to interchange the first and last element in a given list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to convert a snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"4 2 3 4 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python_program\") = \"PythonProgram\" ]]\n    [[ $(candidate \"python_language\") = \"PythonLanguage\" ]]\n    [[ $(candidate \"programming_language\") = \"ProgrammingLanguage\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the number of elements that occurs before the list element in the given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_first_elements() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the Eulerian number a(n, m).\n#\n# $1 is an integer\n# $2 is an integer\neulerian_num() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_first_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"3\" ]]\n    [[ $(candidate \"2 9 5 7 11\") = \"2\" ]]\n    [[ $(candidate \"11 15 5 8 2 3 8\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    eulerian_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"1\") = \"4\" ]]\n    [[ $(candidate \"4\" \"1\") = \"11\" ]]\n    [[ $(candidate \"5\" \"3\") = \"26\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_105_count",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to locate the right insertion point for a specified value in sorted order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nright_insertion() {\n",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count true booleans in the given list.\n#\n# $1 is a space-separated list\ncount() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    right_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"true false true\") = \"2\" ]]\n    [[ $(candidate \"false false\") = \"0\" ]]\n    [[ $(candidate \"true true true\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_106_add_lists",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if the given number is woodball or not.\n#\n# $1 is an integer\nis_woodall() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to append the given list to the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_lists() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_woodall \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"383\") = \"true\" ]]\n    [[ $(candidate \"254\") = \"false\" ]]\n    [[ $(candidate \"200\") = \"false\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    add_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"9 10 5 6 7\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"10 11 6 7 8\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"11 12 7 8 9\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort the given array by using shell sort.\n#\n# $1 is a space-separated list\nshell_sort() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to merge three lists into a single sorted list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nmerge_sorted_list() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    shell_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 23 4 5 3 2 12 81 56 95\") = \"2 3 4 5 12 12 23 56 81 95\" ]]\n    [[ $(candidate \"24 22 39 34 87 73 68\") = \"22 24 34 39 68 73 87\" ]]\n    [[ $(candidate \"32 30 16 96 82 83 74\") = \"16 30 32 74 82 83 96\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    merge_sorted_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 24 15 4 5 29 110\" \"19 20 11 56 25 233 154\" \"24 26 54 48\") = \"4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233\" ]]\n    [[ $(candidate \"1 3 5 6 8 9\" \"2 5 7 11\" \"1 4 7 8 12\") = \"1 1 2 3 4 5 5 6 7 7 8 8 9 11 12\" ]]\n    [[ $(candidate \"18 14 10 9 8 7 9 3 2 4 1\" \"25 35 22 85 14 65 75 25 58\" \"12 74 9 50 61 41\") = \"1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of pairs whose xor value is odd.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_Odd_Pair() {\n",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\n#\n# $1 is a string\n# $2 is an integer\nodd_Equivalent() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Odd_Pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\" \"5\") = \"6\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\" \"7\") = \"12\" ]]\n    [[ $(candidate \"1 2 3\" \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    odd_Equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"011001\" \"6\") = \"3\" ]]\n    [[ $(candidate \"11011\" \"5\") = \"4\" ]]\n    [[ $(candidate \"1010\" \"4\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_113_check_integer",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of all odd natural numbers within the range l and r.\n#\n# $1 is an integer\n# $2 is an integer\nsum_in_range() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to check if a string represents an integer or not.\n#\n# $1 is a string\ncheck_integer() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_in_range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"5\") = \"8\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"13\") = \"40\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    check_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"1\") = \"true\" ]]\n    [[ $(candidate \"12345\") = \"true\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_116_tuple_to_int",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that returns the perimeter of a square given its side length as input.\n#\n# $1 is an integer\nsquare_perimeter() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to convert a given list of positive integers into a single integer.\n#\n# $1 is a space-separated list\ntuple_to_int() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    square_perimeter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"40\" ]]\n    [[ $(candidate \"5\") = \"20\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_765_is_polite",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n#\n# $1 is an integer\nis_polite() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_polite \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"11\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"13\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n#\n# $1 is an integer\nsum_series() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_series \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"12\" ]]\n    [[ $(candidate \"10\") = \"30\" ]]\n    [[ $(candidate \"9\") = \"25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the dissimilar elements in the given two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nfind_dissimilar() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_dissimilar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7 2 3 9\") = \"1 4 7 9\" ]]\n    [[ $(candidate \"21 11 25 26\" \"26 34 21 36\") = \"34 36 11 25\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"android_tv\") = \"AndroidTv\" ]]\n    [[ $(candidate \"google_pixel\") = \"GooglePixel\" ]]\n    [[ $(candidate \"apple_watch\") = \"AppleWatch\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the volume of a cube given its side length.\n#\n# $1 is an integer\nvolume_cube() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    volume_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"2\") = \"8\" ]]\n    [[ $(candidate \"5\") = \"125\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 31 days or not.\n#\n# $1 is an integer\ncheck_monthnumb_number() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_monthnumb_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether all the bits are unset in the given range or not.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nall_Bits_Set_In_The_Given_Range() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    all_Bits_Set_In_The_Given_Range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"1\" \"2\") = \"true\" ]]\n    [[ $(candidate \"17\" \"2\" \"4\") = \"true\" ]]\n    [[ $(candidate \"39\" \"4\" \"6\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to get the first element of each sublist.\n#\n# $1 is a newline-separated, space-separated list\nExtract() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\\n3 4 5\\n6 7 8 9\") = \"1 3 6\" ]]\n    [[ $(candidate \"1 2 3\\n4 5\") = \"1 4\" ]]\n    [[ $(candidate \"9 8 1\\n1 2\") = \"9 1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cylinder.\n#\n# $1 is an integer\n# $2 is an integer\nsurfacearea_cylinder() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    surfacearea_cylinder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"5\") = \"942.45\" ]]\n    [[ $(candidate \"4\" \"5\") = \"226.18800000000002\" ]]\n    [[ $(candidate \"4\" \"10\") = \"351.848\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n#\n# $1 is a space-separated list\nsample_nam() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sample_nam \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"sally Dylan rebecca Diana Joanne keith\") = \"16\" ]]\n    [[ $(candidate \"php res Python abcd Java aaa\") = \"10\" ]]\n    [[ $(candidate \"abcd Python abba aba\") = \"6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to create the next bigger number by rearranging the digits of a given number.\n#\n# $1 is an integer\nrearrange_bigger() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rearrange_bigger \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"21\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"102\") = \"120\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the perimeter of a regular pentagon from the length of its sides.\n#\n# $1 is an integer\nperimeter_pentagon() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    perimeter_pentagon \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"25\" ]]\n    [[ $(candidate \"10\") = \"50\" ]]\n    [[ $(candidate \"15\") = \"75\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n#\n# $1 is a space-separated list\nmax_sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 15 51 45 33 100 12 18 9\") = \"194\" ]]\n    [[ $(candidate \"80 60 30 40 20 10\") = \"210\" ]]\n    [[ $(candidate \"2 3 14 16 21 23 29 30\") = \"138\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove uneven elements in the nested mixed list.\n#\n# $1 is a space-separated list\nextract_even() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 7 6 2 4 6 8\") = \"4 6 2 4 6 8\" ]]\n    [[ $(candidate \"5 6 8 7 4 8 7 9\") = \"6 8 4 8\" ]]\n    [[ $(candidate \"5 6 9 8 4 6 8 10\") = \"6 8 4 6 8 10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    tuple_to_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"123\" ]]\n    [[ $(candidate \"4 5 6\") = \"456\" ]]\n    [[ $(candidate \"5 6 7\") = \"567\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3652,201 +124,9 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to convert all possible convertible elements in a list of lists to floats.\n#\n# $1 is a newline-separated, space-separated list\nlist_to_float() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    list_to_float \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 26.45\\n7.32 8\\n4 8\") = \"3.0 4.0\\n1.0 26.45\\n7.32 8.0\\n4.0 8.0\" ]]\n    [[ $(candidate \"4 4\\n2 27\\n4.12 9\\n7 11\") = \"4.0 4.0\\n2.0 27.0\\n4.12 9.0\\n7.0 11.0\" ]]\n    [[ $(candidate \"6 78\\n5 26.45\\n1.33 4\\n82 13\") = \"6.0 78.0\\n5.0 26.45\\n1.33 4.0\\n82.0 13.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"20\" ]]\n    [[ $(candidate \"3\") = \"56\" ]]\n    [[ $(candidate \"4\") = \"120\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n#\n# $1 is a space-separated list\n# $2 is an integer\nget_pairs_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_pairs_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1 1\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1 5 7 -1 5\" \"6\") = \"3\" ]]\n    [[ $(candidate \"1 -2 3\" \"1\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 3\" \"-3\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n#\n# $1 is an integer\n# $2 is an integer\ncount_no_of_ways() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_no_of_ways \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"4\") = \"16\" ]]\n    [[ $(candidate \"3\" \"2\") = \"6\" ]]\n    [[ $(candidate \"4\" \"4\") = \"228\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to reverse words seperated by spaces in a given string.\n#\n# $1 is a string\nreverse_words() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    reverse_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python program\") = \"program python\" ]]\n    [[ $(candidate \"java language\") = \"language java\" ]]\n    [[ $(candidate \"indian man\") = \"man indian\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check if a given number is one less than twice its reverse.\n#\n# $1 is an integer\nchecks() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    checks \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"70\") = \"false\" ]]\n    [[ $(candidate \"23\") = \"false\" ]]\n    [[ $(candidate \"73\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the last position of an element in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlast() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    last \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 4\" \"1\") = \"2\" ]]\n    [[ $(candidate \"2 3 2 3 6 8 9\" \"3\") = \"3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a list and an element and counts the occcurences of the element in the list.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_X() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_X \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"4\") = \"0\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"10\") = \"3\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"8\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nextract_index_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_index_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 7\" ]]\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 6 5\" \"0 1 2 3 4 6 7\") = \"1 6\" ]]\n    [[ $(candidate \"1 1 3 4 6 5 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 5\" ]]\n    [[ $(candidate \"1 2 3 4 6 6 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the second smallest number in a list.\n#\n# $1 is a newline-separated, space-separated list\nsecond_smallest() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    second_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 -8 -2 0 -2\") = \"-2\" ]]\n    [[ $(candidate \"1 1 -0.5 0 2 -2 -2\") = \"-0.5\" ]]\n    [[ $(candidate \"2 2\") = \"None\" ]]\n    [[ $(candidate \"2 2 2\") = \"None\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to concatenate each element of list by the delimiter.\n#\n# $1 is a space-separated list\nconcatenate_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    concatenate_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ID is 4 UTS\") = \"ID-is-4-UTS\" ]]\n    [[ $(candidate \"QWE is 4 RTY\") = \"QWE-is-4-RTY\" ]]\n    [[ $(candidate \"ZEN is 4 OP\") = \"ZEN-is-4-OP\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to replace all spaces in the given string with '%20'.\n#\n# $1 is a string\nreplace_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"My Name is Dawood\") = \"My%20Name%20is%20Dawood\" ]]\n    [[ $(candidate \"I am a Programmer\") = \"I%20am%20a%20Programmer\" ]]\n    [[ $(candidate \"I love Coding\") = \"I%20love%20Coding\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the sum of numbers in a list within a range specified by two indices.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nsum_range_list() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sum_range_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"8\" \"10\") = \"29\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"5\" \"7\") = \"16\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"7\" \"10\") = \"38\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to merge three dictionaries into a single CSV.\n#\n# $1 is a two column CSV in key,value order\n# $2 is a two column CSV in key,value order\n# $3 is a two column CSV in key,value order\nmerge_dictionaries_three() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    merge_dictionaries_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"O,Orange\\nW,White\\nB,Black\") = \"B,Black\\nR,Red\\nP,Pink\\nG,Green\\nW,White\\nO,Orange\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"L,lavender\\nB,Blue\") = \"W,White\\nP,Pink\\nB,Black\\nR,Red\\nG,Green\\nL,lavender\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"L,lavender\\nB,Blue\" \"G,Green\\nW,White\") = \"B,Black\\nP,Pink\\nR,Red\\nG,Green\\nL,lavender\\nW,White\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nminimum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"-5\" \"-4\") = \"-5\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between available pairs in the given list list.\n#\n# $1 is a newline-separated, space-separated list\nmax_difference() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 5\\n1 7\\n10 3\\n1 2\") = \"7\" ]]\n    [[ $(candidate \"4 6\\n2 17\\n9 13\\n11 12\") = \"15\" ]]\n    [[ $(candidate \"12 35\\n21 27\\n13 23\\n41 22\") = \"23\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find element at a given index after number of rotations.\n#\n# $1 is a space-separated list\n# $2 is a newline-separated, space-separated list\n# $3 is an integer\n# $4 is an integer\nfind_Element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"0 2\\n0 3\" \"2\" \"1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\" \"0 1\\n0 2\" \"1\" \"2\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"0 1\\n0 2\" \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3856,7 +136,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to convert a string to a list of strings split on the space character.\n#\n# $1 is a string\nstring_to_list() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    string_to_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"python programming\" ]]\n    [[ $(candidate \"lists tuples strings\") = \"lists tuples strings\" ]]\n    [[ $(candidate \"write a program\") = \"write a program\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3868,21 +148,9 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a shthon function to find the element that appears only once in a sorted array.\n#\n# $1 is a space-separated list\nsearch() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1 3 3 4 4 5 5 7 7 8\") = \"8\" ]]\n    [[ $(candidate \"1 2 2 3 3 4 4\") = \"1\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a CSV by value.\n#\n# $1 is a two column CSV in key,value order\nsort_counter() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_counter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Math,81\\nPhysics,83\\nChemistry,87\") = \"Chemistry 87\\nPhysics 83\\nMath 81\" ]]\n    [[ $(candidate \"Math,400\\nPhysics,300\\nChemistry,250\") = \"Math 400\\nPhysics 300\\nChemistry 250\" ]]\n    [[ $(candidate \"Math,900\\nPhysics,1000\\nChemistry,1250\") = \"Chemistry 1250\\nPhysics 1000\\nMath 900\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -3892,7 +160,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a shthon function to remove first and last occurrence of a given character from the string.\n#\n# $1 is a string\n# $2 is a string\nremove_Occ() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    remove_Occ \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello\" \"l\") = \"heo\" ]]\n    [[ $(candidate \"abcda\" \"a\") = \"bcd\" ]]\n    [[ $(candidate \"PHP\" \"P\") = \"H\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -3900,337 +168,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cube given its side length.\n#\n# $1 is an integer\nlateralsurface_cube() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum absolute product between numbers in pairs of lists within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmax_product_tuple() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    lateralsurface_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"100\" ]]\n    [[ $(candidate \"9\") = \"324\" ]]\n    [[ $(candidate \"10\") = \"400\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"36\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"200\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"484\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes two lists and returns true if they have at least one common element.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon_element() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to sum all amicable numbers from 1 to a specified number.\n#\n# $1 is an integer\namicable_numbers_sum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    common_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8 9\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"None\" ]]\n    [[ $(candidate \"a b c\" \"d b e\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    amicable_numbers_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"999\") = \"504\" ]]\n    [[ $(candidate \"9999\") = \"31626\" ]]\n    [[ $(candidate \"99\") = \"0\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to append the given list to the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_lists() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\n#\n# $1 is a string\nfind_length() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"9 10 5 6 7\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"10 11 6 7 8\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"11 12 7 8 9\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    find_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11000010001\") = \"6\" ]]\n    [[ $(candidate \"10111\") = \"1\" ]]\n    [[ $(candidate \"11011101100101\") = \"2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to compute the n-th power of each number in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nnth_nums() {\n",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of common divisors of two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nsum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    nth_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\" \"3\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\" \"5\") = \"248832 759375\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"15\") = \"6\" ]]\n    [[ $(candidate \"100\" \"150\") = \"93\" ]]\n    [[ $(candidate \"4\" \"6\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\npancake_sort() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to multiply two integers.\n#\n# $1 is an integer\n# $2 is an integer\nmultiply_int() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    pancake_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 79 25 38 69\") = \"15 25 38 69 79\" ]]\n    [[ $(candidate \"98 12 54 36 85\") = \"12 36 54 85 98\" ]]\n    [[ $(candidate \"41 42 32 12 23\") = \"12 23 32 41 42\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the median of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_numbers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    median_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25\" \"55\" \"65\") = \"55.0\" ]]\n    [[ $(candidate \"20\" \"10\" \"30\") = \"20.0\" ]]\n    [[ $(candidate \"15\" \"45\" \"75\") = \"45.0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the entered number is greater than the elements of the given array.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_greater() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_greater \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2 3 4 5 6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"9 7 4 8 6 1\" \"11\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n#\n# $1 is a space-separated list\n# $2 is a $Any\ncheck_element() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange black white\" \"blue\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7\") = \"false\" ]]\n    [[ $(candidate \"green green green green\" \"green\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract specified size of strings from a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is an integer\nextract_string() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    extract_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python list exercises practice solution\" \"8\") = \"practice solution\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"6\") = \"Python\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"9\") = \"exercises\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n#\n# $1 is a string\ntext_lowercase_underscore() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    text_lowercase_underscore \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aab_cbbbc\") = \"true\" ]]\n    [[ $(candidate \"aab_Abbbc\") = \"false\" ]]\n    [[ $(candidate \"Aaab_abbbc\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to trim each list by k in the given lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\ntrim_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    trim_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"2\") = \"2\\n9\\n2\\n2\" ]]\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"1\") = \"3 2 1\\n4 9 2\\n1 2 3\\n8 2 1\" ]]\n    [[ $(candidate \"7 8 4 9\\n11 8 12 4\\n4 1 7 8\\n3 6 9 7\" \"1\") = \"8 4\\n8 12\\n1 7\\n6 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sublist having minimum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    Find_Min \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1\" ]]\n    [[ $(candidate \"1 1\\n1 1 1\\n1 2 7 8\") = \"1 1\" ]]\n    [[ $(candidate \"x\\nx y\\nx y z\") = \"x\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to filter odd numbers.\n#\n# $1 is a space-separated list\nfilter_oddnumbers() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    filter_oddnumbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 3 5 7 9\" ]]\n    [[ $(candidate \"10 20 45 67 84 93\") = \"45 67 93\" ]]\n    [[ $(candidate \"5 7 9 8 6 4 3\") = \"5 7 9 3\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the first adverb ending with ly and its positions in a given string.\n#\n# $1 is a string\nfind_adverbs() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_adverbs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Clearly, he has no excuse for such behavior.\") = \"0-7: Clearly\" ]]\n    [[ $(candidate \"Please handle the situation carefuly\") = \"28-36: carefuly\" ]]\n    [[ $(candidate \"Complete the task quickly\") = \"18-25: quickly\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_of_nth() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_of_nth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\\n1 3 5\\n8 9 19\" \"2\") = \"19\" ]]\n    [[ $(candidate \"6 7 8\\n2 4 6\\n9 10 20\" \"1\") = \"10\" ]]\n    [[ $(candidate \"7 8 9\\n3 5 7\\n10 11 21\" \"1\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"1000\" ]]\n    [[ $(candidate \"18\") = \"10010\" ]]\n    [[ $(candidate \"7\") = \"111\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncombinations_colors() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    combinations_colors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue\" \"1\") = \"Red\\nGreen\\nBlue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"2\") = \"Red Red\\nRed Green\\nRed Blue\\nGreen Green\\nGreen Blue\\nBlue Blue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"3\") = \"Red Red Red\\nRed Red Green\\nRed Red Blue\\nRed Green Green\\nRed Green Blue\\nRed Blue Blue\\nGreen Green Green\\nGreen Green Blue\\nGreen Blue Blue\\nBlue Blue Blue\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from a string.\n#\n# $1 is a string\nremove_all_spaces() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_all_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python  program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"python   programming    language\") = \"pythonprogramminglanguage\" ]]\n    [[ $(candidate \"python                     program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"   python                     program\") = \"pythonprogram\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n#\n# $1 is a string\n# $2 is a string\nmin_Swaps() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_Swaps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1101\" \"1110\") = \"1\" ]]\n    [[ $(candidate \"111\" \"000\") = \"Not Possible\" ]]\n    [[ $(candidate \"111\" \"110\") = \"Not Possible\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to create a new list from the given string and list.\n#\n# $1 is a space-separated list\n# $2 is a string\nnew_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    new_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"WEB is\" \"best\") = \"WEB is best\" ]]\n    [[ $(candidate \"We are\" \"Developers\") = \"We are Developers\" ]]\n    [[ $(candidate \"Part is\" \"Wrong\") = \"Part is Wrong\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the product of the array multiplication modulo n.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_remainder() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_remainder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100 10 5 25 35 14\" \"11\") = \"9\" ]]\n    [[ $(candidate \"1 1 1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 2 1\" \"2\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the minimum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmin_val() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"2\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"15\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the ration of positive numbers in an array of integers.\n#\n# $1 is a space-separated list\npositive_count() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    positive_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\") = \"0.54\" ]]\n    [[ $(candidate \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"0.69\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"0.56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to add the given list to the given list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_tuple() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    add_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"5 6 7 9 10\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"6 7 8 10 11\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"7 8 9 11 12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find maximum run of uppercase characters in the given string.\n#\n# $1 is a string\nmax_run_uppercase() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_run_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"GeMKSForGERksISBESt\") = \"5\" ]]\n    [[ $(candidate \"PrECIOusMOVemENTSYT\") = \"6\" ]]\n    [[ $(candidate \"GooGLEFluTTER\") = \"4\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to sort a given matrix in ascending order according to the sum of its rows.\n#\n# $1 is a newline-separated, space-separated list\nsort_matrix() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sort_matrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n2 4 5\\n1 1 1\") = \"1 1 1\\n1 2 3\\n2 4 5\" ]]\n    [[ $(candidate \"1 2 3\\n-2 4 -5\\n1 -1 1\") = \"-2 4 -5\\n1 -1 1\\n1 2 3\" ]]\n    [[ $(candidate \"5 8 9\\n6 4 3\\n2 1 4\") = \"2 1 4\\n6 4 3\\n5 8 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to count those characters which have vowels as their neighbors in the given string.\n#\n# $1 is a string\ncount_vowels() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"bestinstareels\") = \"7\" ]]\n    [[ $(candidate \"partofthejourneyistheend\") = \"12\" ]]\n    [[ $(candidate \"amazonprime\") = \"5\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\n# $4 is an integer\nmax_sum_increasing_subseq() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    max_sum_increasing_subseq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"4\" \"6\") = \"11\" ]]\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"2\" \"5\") = \"7\" ]]\n    [[ $(candidate \"11 15 19 21 26 28 31\" \"7\" \"2\" \"4\") = \"71\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    multiply_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"5\" \"10\") = \"50\" ]]\n    [[ $(candidate \"4\" \"8\") = \"32\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4240,7 +232,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find words that are longer than n characters from a given list of words.\n#\n# $1 is an integer\n# $2 is a string\nlong_words() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    long_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"python is a programming language\") = \"python programming language\" ]]\n    [[ $(candidate \"2\" \"writing a program\") = \"writing program\" ]]\n    [[ $(candidate \"5\" \"sorting list\") = \"sorting\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4248,205 +240,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of non-repeated elements in a given list.\n#\n# $1 is a space-separated list\nfind_sum() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to calculate whether the matrix is a magic square.\n#\n# $1 is a newline-separated, space-separated list\nmagic_square_test() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 1 1 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"1 10 9 4 2 10 10 45 4\") = \"71\" ]]\n    [[ $(candidate \"12 10 9 45 2 10 10 45 10\") = \"78\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    magic_square_test \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7 12 1 14\\n2 13 8 11\\n16 3 10 5\\n9 6 15 4\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 8\") = \"true\" ]]\n    [[ $(candidate \"2 7 6\\n9 5 1\\n4 3 7\") = \"false\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to convert the given list to a key-value CSV using adjacent elements. https://www.geeksforgeeks.org/shthon-convert-list-to-adjacent-pair-CSV/\n#\n# $1 is a space-separated list\ntuple_to_dict() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to sort a given matrix in ascending order according to the sum of its rows.\n#\n# $1 is a newline-separated, space-separated list\nsort_matrix() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    tuple_to_dict \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 10 13 5\") = \"1,5\\n7,10\\n13,5\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1,2\\n3,4\\n5,6\" ]]\n    [[ $(candidate \"7 8 9 10 11 12\") = \"7,8\\n9,10\\n11,12\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    sort_matrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n2 4 5\\n1 1 1\") = \"1 1 1\\n1 2 3\\n2 4 5\" ]]\n    [[ $(candidate \"1 2 3\\n-2 4 -5\\n1 -1 1\") = \"-2 4 -5\\n1 -1 1\\n1 2 3\" ]]\n    [[ $(candidate \"5 8 9\\n6 4 3\\n2 1 4\") = \"2 1 4\\n6 4 3\\n5 8 9\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to extract all the adjacent coordinates of the given coordinate list.\n#\n# $1 is a space-separated list\nget_coordinates() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the item with maximum frequency in a given list.\n#\n# $1 is a space-separated list\nmax_occurrences() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    get_coordinates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\") = \"2 3\\n2 4\\n2 5\\n3 3\\n3 4\\n3 5\\n4 3\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"4 5\") = \"3 4\\n3 5\\n3 6\\n4 4\\n4 5\\n4 6\\n5 4\\n5 5\\n5 6\" ]]\n    [[ $(candidate \"5 6\") = \"4 5\\n4 6\\n4 7\\n5 5\\n5 6\\n5 7\\n6 5\\n6 6\\n6 7\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check if all the elements in list have same data type or not.\n#\n# $1 is a $Any\ncheck_type() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_type \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7 3 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 4\") = \"false\" ]]\n    [[ $(candidate \"3 2 1 4 5\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the smallest missing number from a sorted list of natural numbers.\n#\n# $1 is a space-separated list\nfind_First_Missing() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_First_Missing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 3\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 6 9\") = \"3\" ]]\n    [[ $(candidate \"2 3 5 8 9\") = \"0\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is undulating or not.\n#\n# $1 is an integer\nis_undulating() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_undulating \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1212121\") = \"true\" ]]\n    [[ $(candidate \"1991\") = \"false\" ]]\n    [[ $(candidate \"121\") = \"true\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/shthon-find-minimum-k-records-from-list-list/ - in this case a verbatim cosh of test cases\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmin_k() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    min_k \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Manjeet 10\\nAkshat 4\\nAkash 2\\nNikhil 8\" \"2\") = \"Akash 2\\nAkshat 4\" ]]\n    [[ $(candidate \"Sanjeev 11\\nAngat 5\\nAkash 3\\nNepin 9\" \"3\") = \"Akash 3\\nAngat 5\\nNepin 9\" ]]\n    [[ $(candidate \"tanmay 14\\nAmer 11\\nAyesha 9\\nSKD 16\" \"1\") = \"Ayesha 9\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of substrings with the sum of digits equal to their length.\n#\n# $1 is a string\ncount_Substrings() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_Substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"112112\") = \"6\" ]]\n    [[ $(candidate \"111\") = \"6\" ]]\n    [[ $(candidate \"1101112\") = \"12\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the nth decagonal number.\n#\n# $1 is an integer\nis_num_decagonal() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_num_decagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"7\") = \"175\" ]]\n    [[ $(candidate \"10\") = \"370\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in a list of lists and returns a list containing the rear element of each list.\n#\n# $1 is a newline-separated, space-separated list\nrear_extract() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    rear_extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 Rash 21\\n2 Varsha 20\\n3 Kil 19\") = \"21 20 19\" ]]\n    [[ $(candidate \"1 Sai 36\\n2 Ayesha 25\\n3 Salman 45\") = \"36 25 45\" ]]\n    [[ $(candidate \"1 Sudeep 14\\n2 Vandana 36\\n3 Dawood 56\") = \"14 36 56\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the closest smaller number than n.\n#\n# $1 is an integer\nclosest_num() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    closest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11\") = \"10\" ]]\n    [[ $(candidate \"7\") = \"6\" ]]\n    [[ $(candidate \"12\") = \"11\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/shthon-combinations-of-sum-with-lists-in-list-list/\n#\n# $1 is a newline-separated, space-separated list\nfind_combinations() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_combinations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4\\n6 7\\n5 1\\n6 10\") = \"8 11\\n7 5\\n8 14\\n11 8\\n12 17\\n11 11\" ]]\n    [[ $(candidate \"3 5\\n7 8\\n6 2\\n7 11\") = \"10 13\\n9 7\\n10 16\\n13 10\\n14 19\\n13 13\" ]]\n    [[ $(candidate \"4 6\\n8 9\\n7 3\\n8 12\") = \"12 15\\n11 9\\n12 18\\n15 12\\n16 21\\n15 15\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n#\n# $1 is a newline-separated, space-separated list\nmaxAverageOfPath() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    maxAverageOfPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n6 5 4\\n7 3 9\") = \"5.2\" ]]\n    [[ $(candidate \"2 3 4\\n7 6 5\\n8 4 10\") = \"6.2\" ]]\n    [[ $(candidate \"3 4 5\\n8 7 6\\n9 5 11\") = \"7.2\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\") = \"5.8\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function that takes in an array and element and returns a list containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n#\n# $1 is a space-separated list\n# $2 is an integer\nsequential_search() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sequential_search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 23 58 31 56 77 43 12 65 19\" \"31\") = \"true 3\" ]]\n    [[ $(candidate \"12 32 45 62 35 47 44 61\" \"61\") = \"true 7\" ]]\n    [[ $(candidate \"9 10 17 19 22 39 48 56\" \"48\") = \"true 6\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to remove odd numbers from a given list.\n#\n# $1 is a space-separated list\nremove_odd() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"2\" ]]\n    [[ $(candidate \"2 4 6\") = \"2 4 6\" ]]\n    [[ $(candidate \"10 20 3\") = \"10 20\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the product of numbers in a list is even or not.\n#\n# $1 is a space-separated list\nis_product_even() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    is_product_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 4\") = \"true\" ]]\n    [[ $(candidate \"1 1\") = \"false\" ]]\n}\n\nrun_test",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the maximum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nmaximum() {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"10\") = \"10\" ]]\n    [[ $(candidate \"-1\" \"-2\") = \"-1\" ]]\n    [[ $(candidate \"9\" \"7\") = \"9\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    max_occurrences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 8 4 7 9 8 2 6 5 1 6 1 2 3 2 4 6 9 1 2\") = \"2\" ]]\n    [[ $(candidate \"2 3 8 4 7 9 8 7 9 15 14 10 12 13 16 18\") = \"8\" ]]\n    [[ $(candidate \"10 20 20 30 40 90 80 50 30 20 50 10\") = \"20\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4456,9 +280,597 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a shthon function to reverse only the vowels of a given string (where y is not a vowel).\n#\n# $1 is a string\nreverse_vowels() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    reverse_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"USA\") = \"ASU\" ]]\n    [[ $(candidate \"ab\") = \"ab\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a list to a string.\n#\n# $1 is a space-separated list\ntup_string() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tup_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"e x e r c i s e s\") = \"exercises\" ]]\n    [[ $(candidate \"p y t h o n\") = \"python\" ]]\n    [[ $(candidate \"p r o g r a m\") = \"program\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of the negative numbers of a given list of numbers.\n#\n# $1 is a space-separated list\nsum_negativenum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_negativenum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"-32\" ]]\n    [[ $(candidate \"10 15 -14 13 -18 12 -20\") = \"-52\" ]]\n    [[ $(candidate \"19 -65 57 39 152 -639 121 44 90 -190\") = \"-894\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth hexagonal number.\n#\n# $1 is an integer\nhexagonal_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    hexagonal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"190\" ]]\n    [[ $(candidate \"5\") = \"45\" ]]\n    [[ $(candidate \"7\") = \"91\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\n#\n# $1 is an integer\nis_Sum_Of_Powers_Of_Two() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_Sum_Of_Powers_Of_Two \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"false\" ]]\n    [[ $(candidate \"14\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\npancake_sort() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pancake_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15 79 25 38 69\") = \"15 25 38 69 79\" ]]\n    [[ $(candidate \"98 12 54 36 85\") = \"12 36 54 85 98\" ]]\n    [[ $(candidate \"41 42 32 12 23\") = \"12 23 32 41 42\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count number items that are identical in the same position of three given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ncount_samepair() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_samepair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\" \"2 1 3 1 2 6 7 9\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 2 6 7 8\" \"2 2 3 1 2 6 7 8\" \"2 1 3 1 2 6 7 8\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find number of lists present in the given list.\n#\n# $1 is a space-separated list\nfind_lists() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\") = \"2\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"9 8 7 6 5 4 3 2 1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the maximum difference between any two elements in a given array.\n#\n# $1 is a space-separated list\nmax_Abs_Diff() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_Abs_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 3\") = \"4\" ]]\n    [[ $(candidate \"9 3 2 5 1\") = \"8\" ]]\n    [[ $(candidate \"3 2 1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the volume of a triangular prism.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_Volume() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Volume \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"8\" \"6\") = \"240\" ]]\n    [[ $(candidate \"3\" \"2\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1\" \"2\" \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns integers x and y that satisfy ax + by = n as a list, or return None if no solution exists.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nfind_solution() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_solution \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"3\" \"7\") = \"2 1\" ]]\n    [[ $(candidate \"4\" \"2\" \"7\") = \"None\" ]]\n    [[ $(candidate \"1\" \"13\" \"17\") = \"4 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all elements from a given list present in another list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nremove_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"1 3 5 7\") = \"2 4 6 8 9 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5 7\") = \"1 2 3 4 6 8 9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\n#\n# $1 is an integer\nsum_series() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_series \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"12\" ]]\n    [[ $(candidate \"10\") = \"30\" ]]\n    [[ $(candidate \"9\") = \"25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to determine if the sum of the divisors of two integers are the same.\n#\n# $1 is an integer\n# $2 is an integer\nare_equivalent() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    are_equivalent \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"36\" \"57\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"23\" \"47\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\n#\n# $1 is a string\ncount_char_position() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_char_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"xbcefg\") = \"2\" ]]\n    [[ $(candidate \"ABcED\") = \"3\" ]]\n    [[ $(candidate \"AbgdeF\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that counts the number of pairs of integers in a list that xor to an even number.\n#\n# $1 is a space-separated list\nfind_even_pair() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_even_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\") = \"4\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\") = \"9\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the smallest power of 2 greater than or equal to n.\n#\n# $1 is an integer\nnext_power_of_2() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    next_power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\") = \"1\" ]]\n    [[ $(candidate \"5\") = \"8\" ]]\n    [[ $(candidate \"17\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of occurrences of a number in a given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfrequency() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    frequency \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 2 3 3 3 4\" \"3\") = \"3\" ]]\n    [[ $(candidate \"0 1 2 3 1 2\" \"1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\n#\n# $1 is a string\ntext_lowercase_underscore() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_lowercase_underscore \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aab_cbbbc\") = \"true\" ]]\n    [[ $(candidate \"aab_Abbbc\") = \"false\" ]]\n    [[ $(candidate \"Aaab_abbbc\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the sum of numbers in a list within a range specified by two indices.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nsum_range_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_range_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"8\" \"10\") = \"29\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"5\" \"7\") = \"16\" ]]\n    [[ $(candidate \"2 1 5 6 8 3 4 9 10 11 8 12\" \"7\" \"10\") = \"38\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the perimeter of a regular pentagon from the length of its sides.\n#\n# $1 is an integer\nperimeter_pentagon() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    perimeter_pentagon \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"25\" ]]\n    [[ $(candidate \"10\") = \"50\" ]]\n    [[ $(candidate \"15\") = \"75\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of occurence of the string 'std' in a given string.\n#\n# $1 is a string\ncount_occurance() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_occurance \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"letstdlenstdporstd\") = \"3\" ]]\n    [[ $(candidate \"truststdsolensporsd\") = \"1\" ]]\n    [[ $(candidate \"makestdsostdworthit\") = \"2\" ]]\n    [[ $(candidate \"stds\") = \"1\" ]]\n    [[ $(candidate \"\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns the perimeter of a square given its side length as input.\n#\n# $1 is an integer\nsquare_perimeter() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    square_perimeter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"40\" ]]\n    [[ $(candidate \"5\") = \"20\" ]]\n    [[ $(candidate \"4\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove characters from the first string which are present in the second string.\n#\n# $1 is a string\n# $2 is a string\nremove_dirty_chars() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_dirty_chars \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"probasscurve\" \"pros\") = \"bacuve\" ]]\n    [[ $(candidate \"digitalindia\" \"talent\") = \"digiidi\" ]]\n    [[ $(candidate \"exoticmiles\" \"toxic\") = \"emles\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find whether a given array of integers contains any duplicate element.\n#\n# $1 is a space-separated list\ntest_duplicate() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    test_duplicate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2 3 3 4 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given number is woodball or not.\n#\n# $1 is an integer\nis_woodall() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_woodall \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"383\") = \"true\" ]]\n    [[ $(candidate \"254\") = \"false\" ]]\n    [[ $(candidate \"200\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if all the elements in list have same data type or not.\n#\n# $1 is a $Any\ncheck_type() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_type \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7 3 5 6\") = \"true\" ]]\n    [[ $(candidate \"1 2 4\") = \"false\" ]]\n    [[ $(candidate \"3 2 1 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nis_majority() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_majority \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 3 3 3 10\" \"7\" \"3\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 4 4 4 6 6\" \"8\" \"4\") = \"false\" ]]\n    [[ $(candidate \"1 1 1 2 2\" \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1 1 2 2\" \"5\" \"1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of set bits (binary digits with value 1) in a given number.\n#\n# $1 is an integer\ncount_Set_Bits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_Set_Bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"1\" ]]\n    [[ $(candidate \"6\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to remove the characters which have odd index values of a given string.\n#\n# $1 is a string\nodd_values_string() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    odd_values_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcdef\") = \"ace\" ]]\n    [[ $(candidate \"python\") = \"pto\" ]]\n    [[ $(candidate \"data\") = \"dt\" ]]\n    [[ $(candidate \"lambs\") = \"lms\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find minimum of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmin_of_three() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\" \"0\") = \"0\" ]]\n    [[ $(candidate \"19\" \"15\" \"18\") = \"15\" ]]\n    [[ $(candidate \"-10\" \"-20\" \"-30\") = \"-30\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether all the bits are unset in the given range or not.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nall_Bits_Set_In_The_Given_Range() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    all_Bits_Set_In_The_Given_Range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"1\" \"2\") = \"true\" ]]\n    [[ $(candidate \"17\" \"2\" \"4\") = \"true\" ]]\n    [[ $(candidate \"39\" \"4\" \"6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\n#\n# $1 is a space-separated list\n# $2 is an integer\nre_arrange_array() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    re_arrange_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 2 -3 4 5 6 -7 8 9\" \"9\") = \"-1 -3 -7 4 5 6 2 8 9\" ]]\n    [[ $(candidate \"12 -14 -26 13 15\" \"5\") = \"-14 -26 12 13 15\" ]]\n    [[ $(candidate \"10 24 36 -42 -39 -78 85\" \"7\") = \"-42 -39 -78 10 24 36 85\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\n#\n# $1 is a string\n# $2 is a string\nreplace_blank() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_blank \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"hello people\" \"@\") = \"hello@people\" ]]\n    [[ $(candidate \"python program language\" \"\\$\") = \"python\\$program\\$language\" ]]\n    [[ $(candidate \"blank space\" \"-\") = \"blank-space\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the volume of a cube given its side length.\n#\n# $1 is an integer\nvolume_cube() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    volume_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"2\") = \"8\" ]]\n    [[ $(candidate \"5\") = \"125\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of non-empty substrings of a given string.\n#\n# $1 is a string\nnumber_of_substrings() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    number_of_substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"6\" ]]\n    [[ $(candidate \"abcd\") = \"10\" ]]\n    [[ $(candidate \"abcde\") = \"15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\n#\n# $1 is an integer\n# $2 is an integer\nget_total_number_of_sequences() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_total_number_of_sequences \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"4\") = \"4\" ]]\n    [[ $(candidate \"5\" \"2\") = \"6\" ]]\n    [[ $(candidate \"16\" \"3\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nreplace_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 10\" \"2 4 6 8\") = \"1 3 5 7 9 2 4 6 8\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8\") = \"1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"red blue green\" \"yellow\") = \"red blue yellow\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the total number of characters in a string.\n#\n# $1 is a string\ncount_charac() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_charac \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming\") = \"18\" ]]\n    [[ $(candidate \"language\") = \"8\" ]]\n    [[ $(candidate \"words\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the next perfect square greater than a given number.\n#\n# $1 is an integer\nnext_Perfect_Square() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    next_Perfect_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"35\") = \"36\" ]]\n    [[ $(candidate \"6\") = \"9\" ]]\n    [[ $(candidate \"9\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\n#\n# $1 is a space-separated list\nmax_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 15 51 45 33 100 12 18 9\") = \"194\" ]]\n    [[ $(candidate \"80 60 30 40 20 10\") = \"210\" ]]\n    [[ $(candidate \"2 3 14 16 21 23 29 30\") = \"138\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the length of the longest palindromic subsequence in the given string.\n#\n# $1 is a string\nlps() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    lps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"TENS FOR TENS\") = \"5\" ]]\n    [[ $(candidate \"CARDIO FOR CARDS\") = \"7\" ]]\n    [[ $(candidate \"PART OF THE JOURNEY IS PART\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the intersection of two arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nintersection_array() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    intersection_array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"1 2 4 8 9\") = \"1 2 8 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"3 5 7 9\") = \"3 5 7 9\" ]]\n    [[ $(candidate \"1 2 3 5 7 8 9 10\" \"10 20 30 40\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a list and an element and counts the occcurences of the element in the list.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_X() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_X \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"4\") = \"0\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"10\") = \"3\" ]]\n    [[ $(candidate \"10 8 5 2 10 15 10 8 5 8 8 2\" \"8\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\n#\n# $1 is a space-separated list\n# $2 is a string\ninsert_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    insert_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Black\" \"c\") = \"c Red c Green c Black\" ]]\n    [[ $(candidate \"python java\" \"program\") = \"program python program java\" ]]\n    [[ $(candidate \"happy sad\" \"laugh\") = \"laugh happy laugh sad\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to convert complex numbers to polar coordinates.\n#\n# $1 is an integer\nconvert() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    convert \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"1.0 0.0\" ]]\n    [[ $(candidate \"4\") = \"4.0 0.0\" ]]\n    [[ $(candidate \"5\") = \"5.0 0.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function that returns the number of integer elements in a given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_integer() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_integer \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 abc 1.2\") = \"2\" ]]\n    [[ $(candidate \"1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 1.2 4 5.1\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncombinations_colors() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    combinations_colors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue\" \"1\") = \"Red\\nGreen\\nBlue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"2\") = \"Red Red\\nRed Green\\nRed Blue\\nGreen Green\\nGreen Blue\\nBlue Blue\" ]]\n    [[ $(candidate \"Red Green Blue\" \"3\") = \"Red Red Red\\nRed Red Green\\nRed Red Blue\\nRed Green Green\\nRed Green Blue\\nRed Blue Blue\\nGreen Green Green\\nGreen Green Blue\\nGreen Blue Blue\\nBlue Blue Blue\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\n#\n# $1 is an integer\ncount_Primes_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_Primes_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"4\" ]]\n    [[ $(candidate \"100\") = \"25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two numbers and returns a list with the second number and then the first number.\n#\n# $1 is an integer\n# $2 is an integer\nswap_numbers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    swap_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"20 10\" ]]\n    [[ $(candidate \"15\" \"17\") = \"17 15\" ]]\n    [[ $(candidate \"100\" \"200\") = \"200 100\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4468,7 +880,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to maximize the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nmaximize_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    maximize_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 7\\n4 9\\n2 9\\n7 10\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"7 8\\n5 10\\n3 10\\n8 11\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"8 9\\n6 11\\n4 11\\n9 12\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4476,73 +888,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to check whether every even index contains even numbers of a given list.\n#\n# $1 is a space-separated list\neven_position() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth newman\u2013shanks\u2013williams prime number.\n#\n# $1 is an integer\nnewman_prime() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    even_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n    [[ $(candidate \"2 1 4\") = \"true\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    newman_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"7\" ]]\n    [[ $(candidate \"4\") = \"17\" ]]\n    [[ $(candidate \"5\") = \"41\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to check whether the given string starts and ends with the same character or not.\n#\n# $1 is a string\ncheck_char() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and performs mathematical division operation element-wise across the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndivision_elements() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    check_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abba\") = \"Valid\" ]]\n    [[ $(candidate \"a\") = \"Valid\" ]]\n    [[ $(candidate \"abcd\") = \"Invalid\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    division_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"2 2 2 3\" ]]\n    [[ $(candidate \"12 6 8 16\" \"6 3 4 4\") = \"2 2 2 4\" ]]\n    [[ $(candidate \"20 14 36 18\" \"5 7 6 9\") = \"4 2 6 2\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of even factors of a number.\n#\n# $1 is an integer\nsumofFactors() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_two_parts() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    sumofFactors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"18\") = \"26\" ]]\n    [[ $(candidate \"30\") = \"48\" ]]\n    [[ $(candidate \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    split_two_parts \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 2\\n3 4 4 5 1\" ]]\n    [[ $(candidate \"a b c d\" \"2\") = \"a b\\nc d\" ]]\n    [[ $(candidate \"p y t h o n\" \"4\") = \"p y t h\\no n\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cone given radius r and the height h.\n#\n# $1 is an integer\n# $2 is an integer\nlateralsurface_cone() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to calculate a dog's age in dog's years.\n#\n# $1 is an integer\ndog_age() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    lateralsurface_cone \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"12\") = \"204.20352248333654\" ]]\n    [[ $(candidate \"10\" \"15\") = \"566.3586699569488\" ]]\n    [[ $(candidate \"19\" \"17\") = \"1521.8090132193388\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    dog_age \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"61\" ]]\n    [[ $(candidate \"15\") = \"73\" ]]\n    [[ $(candidate \"24\") = \"109\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_Pairs() {\n",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlist_split() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    count_Pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 1\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 1 1 1\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5\") = \"10\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    list_split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a b c d e f g h i j k l m n\" \"3\") = \"a d g j m\\nb e h k n\\nc f i l\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10 11 12 13 14\" \"3\") = \"1 4 7 10 13\\n2 5 8 11 14\\n3 6 9 12\" ]]\n    [[ $(candidate \"python java C C++ DBMS SQL\" \"2\") = \"python C DBMS\\njava C++ SQL\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to find the index of the first occurrence of a given number in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_first_occurrence() {\n",
+    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cube given its side length.\n#\n# $1 is an integer\nlateralsurface_cube() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    find_first_occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 5 5 5 6 6 8 9 9 9\" \"5\") = \"1\" ]]\n    [[ $(candidate \"2 3 5 5 6 6 8 9 9 9\" \"5\") = \"2\" ]]\n    [[ $(candidate \"2 4 1 5 6 6 8 9 9 9\" \"6\") = \"4\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    lateralsurface_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"100\" ]]\n    [[ $(candidate \"9\") = \"324\" ]]\n    [[ $(candidate \"10\") = \"400\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4552,9 +964,669 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a shthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"10\" ]]\n    [[ $(candidate \"3\") = \"35\" ]]\n    [[ $(candidate \"4\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n'th star number.\n#\n# $1 is an integer\nfind_star_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_star_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"37\" ]]\n    [[ $(candidate \"4\") = \"73\" ]]\n    [[ $(candidate \"5\") = \"121\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the ascii value of a character.\n#\n# $1 is a string\nascii_value() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    ascii_value \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\") = \"65\" ]]\n    [[ $(candidate \"R\") = \"82\" ]]\n    [[ $(candidate \"S\") = \"83\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of even numbers at even positions of a list.\n#\n# $1 is a space-separated list\nsum_even_and_even_index() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_even_and_even_index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 12 1 18 8\") = \"30\" ]]\n    [[ $(candidate \"3 20 17 9 2 10 18 13 6 18\") = \"26\" ]]\n    [[ $(candidate \"5 6 12 1\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\n#\n# $1 is an integer\neven_Power_Sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    even_Power_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"1056\" ]]\n    [[ $(candidate \"3\") = \"8832\" ]]\n    [[ $(candidate \"1\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list of lists and returns a list containing the rear element of each list.\n#\n# $1 is a newline-separated, space-separated list\nrear_extract() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rear_extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 Rash 21\\n2 Varsha 20\\n3 Kil 19\") = \"21 20 19\" ]]\n    [[ $(candidate \"1 Sai 36\\n2 Ayesha 25\\n3 Salman 45\") = \"36 25 45\" ]]\n    [[ $(candidate \"1 Sudeep 14\\n2 Vandana 36\\n3 Dawood 56\") = \"14 36 56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in two lists and subtracts the elements of the first list by the elements of the second list with the same index.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsubstract_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    substract_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5\" \"2 5 18\") = \"8 -1 -13\" ]]\n    [[ $(candidate \"11 2 3\" \"24 45 16\") = \"-13 -43 -13\" ]]\n    [[ $(candidate \"7 18 9\" \"10 11 12\") = \"-3 7 -3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\n#\n# $1 is an integer\neven_binomial_Coeff_Sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    even_binomial_Coeff_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"8\" ]]\n    [[ $(candidate \"6\") = \"32\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the number of elements that occurs before the list element in the given list.\n#\n# $1 is a newline-separated, space-separated list\ncount_first_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_first_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"3\" ]]\n    [[ $(candidate \"2 9 5 7 11\") = \"2\" ]]\n    [[ $(candidate \"11 15 5 8 2 3 8\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth decagonal number.\n#\n# $1 is an integer\nis_num_decagonal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_num_decagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"27\" ]]\n    [[ $(candidate \"7\") = \"175\" ]]\n    [[ $(candidate \"10\") = \"370\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in an array and element and returns a list containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\n#\n# $1 is a space-separated list\n# $2 is an integer\nsequential_search() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sequential_search \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 23 58 31 56 77 43 12 65 19\" \"31\") = \"true 3\" ]]\n    [[ $(candidate \"12 32 45 62 35 47 44 61\" \"61\") = \"true 7\" ]]\n    [[ $(candidate \"9 10 17 19 22 39 48 56\" \"48\") = \"true 6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check if the elements of a given list are unique or not.\n#\n# $1 is a space-separated list\nall_unique() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    all_unique \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to subtract two lists element-wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsub_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sub_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"-3 -3 -3\" ]]\n    [[ $(candidate \"1 2\" \"3 4\") = \"-2 -2\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"40 50\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\n#\n# $1 is an integer\nvalidate() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    validate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1234\") = \"true\" ]]\n    [[ $(candidate \"51241\") = \"false\" ]]\n    [[ $(candidate \"321\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\n#\n# $1 is a space-separated list\n# $2 is a $Any\ncheck_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange black white\" \"blue\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7\") = \"false\" ]]\n    [[ $(candidate \"green green green green\" \"green\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\n#\n# $1 is a string\ntext_match_two_three() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_two_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\nmax_sub_array_sum_repeated() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_sub_array_sum_repeated \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 -30 -1\" \"4\" \"3\") = \"30\" ]]\n    [[ $(candidate \"-1 10 20\" \"3\" \"2\") = \"59\" ]]\n    [[ $(candidate \"-1 -2 -3\" \"3\" \"3\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\n#\n# $1 is an integer\nsquare_Sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    square_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"20\" ]]\n    [[ $(candidate \"3\") = \"56\" ]]\n    [[ $(candidate \"4\") = \"120\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the list of maximum length in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nmax_length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1\\n5 7\\n10 12 14 15\") = \"4 10 12 14 15\" ]]\n    [[ $(candidate \"5\\n15 20 25\") = \"3 15 20 25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\n#\n# $1 is an integer\n# $2 is an integer\ncount_no_of_ways() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_no_of_ways \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"4\") = \"16\" ]]\n    [[ $(candidate \"3\" \"2\") = \"6\" ]]\n    [[ $(candidate \"4\" \"4\") = \"228\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find quotient of two numbers (rounded down to the nearest integer).\n#\n# $1 is an integer\n# $2 is an integer\nfind() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"3\") = \"3\" ]]\n    [[ $(candidate \"4\" \"2\") = \"2\" ]]\n    [[ $(candidate \"20\" \"5\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the third side of a right angled triangle.\n#\n# $1 is an integer\n# $2 is an integer\notherside_rightangle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    otherside_rightangle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\" \"8\") = \"10.63014581273465\" ]]\n    [[ $(candidate \"3\" \"4\") = \"5\" ]]\n    [[ $(candidate \"7\" \"15\") = \"16.55294535724685\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmax_val() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"5\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"25\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"50\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to return the sum of all divisors of a number.\n#\n# $1 is an integer\nsum_div() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_div \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"7\" ]]\n    [[ $(candidate \"12\") = \"16\" ]]\n    [[ $(candidate \"7\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count inversions in an array.\n#\n# $1 is a space-separated list\nget_Inv_Count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_Inv_Count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 20 6 4 5\") = \"5\" ]]\n    [[ $(candidate \"1 2 1\") = \"1\" ]]\n    [[ $(candidate \"1 2 5 6 1\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to flatten a given nested list structure.\n#\n# $1 is a newline-separated, space-separated list\nflatten_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    flatten_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 10 20 30 40 50 60 70 80 90 100 110 120\") = \"0 10 20 30 40 50 60 70 80 90 100 110 120\" ]]\n    [[ $(candidate \"10 20\\n40\\n30 56 25\\n10 20\\n33\\n40\") = \"10 20 40 30 56 25 10 20 33 40\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"1 2 3 4 5 6 10 11 12 7 8 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find element at a given index after number of rotations.\n#\n# $1 is a space-separated list\n# $2 is a newline-separated, space-separated list\n# $3 is an integer\n# $4 is an integer\nfind_Element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"0 2\\n0 3\" \"2\" \"1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\" \"0 1\\n0 2\" \"1\" \"2\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"0 1\\n0 2\" \"1\" \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\n#\n# $1 is a space-separated list\n# $2 is an integer\n# $3 is an integer\n# $4 is an integer\nmax_sum_increasing_subseq() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_sum_increasing_subseq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"4\" \"6\") = \"11\" ]]\n    [[ $(candidate \"1 101 2 3 100 4 5\" \"7\" \"2\" \"5\") = \"7\" ]]\n    [[ $(candidate \"11 15 19 21 26 28 31\" \"7\" \"2\" \"4\") = \"71\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nlarge_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    large_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"3\") = \"60 54 50\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"4\") = \"60 54 50 48\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"3 6 8 9 10 6\" \"5\") = \"60 54 50 48 45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the maximum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nmaximum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    maximum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"10\") = \"10\" ]]\n    [[ $(candidate \"-1\" \"-2\") = \"-1\" ]]\n    [[ $(candidate \"9\" \"7\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a given string to a list of characters.\n#\n# $1 is a string\nstring_to_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    string_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python 3.0\") = \"p y t h o n 3 . 0\" ]]\n    [[ $(candidate \"item1\") = \"i t e m 1\" ]]\n    [[ $(candidate \"15.10\") = \"1 5 . 1 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the highest power of 2 that is less than or equal to n.\n#\n# $1 is an integer\nhighest_Power_of_2() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    highest_Power_of_2 \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"8\" ]]\n    [[ $(candidate \"19\") = \"16\" ]]\n    [[ $(candidate \"32\") = \"32\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n'th lucas number.\n#\n# $1 is an integer\nfind_lucas() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_lucas \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"76\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"3\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to apply a given format string to all of the elements in a list.\n#\n# $1 is a space-separated list\n# $2 is a string\nadd_string() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\" \"temp{0}\") = \"temp1 temp2 temp3 temp4\" ]]\n    [[ $(candidate \"a b c d\" \"python{0}\") = \"pythona pythonb pythonc pythond\" ]]\n    [[ $(candidate \"5 6 7 8\" \"string{0}\") = \"string5 string6 string7 string8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\n#\n# $1 is an integer\nget_max_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_max_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"60\") = \"106\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the list with maximum length.\n#\n# $1 is a newline-separated, space-separated list\nmax_length_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_length_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0\\n1 3\\n5 7\\n9 11\\n13 15 17\") = \"3 13 15 17\" ]]\n    [[ $(candidate \"1 2 3 4 5\\n1 2 3 4\\n1 2 3\\n1 2\\n1\") = \"5 1 2 3 4 5\" ]]\n    [[ $(candidate \"3 4 5\\n6 7 8 9\\n10 11 12\") = \"4 6 7 8 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if given list contains no duplicates.\n#\n# $1 is a space-separated list\ncheck_distinct() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_distinct \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 5 6 1 4\") = \"false\" ]]\n    [[ $(candidate \"1 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 6\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the first non-repeated character in a given string.\n#\n# $1 is a string\nfirst_non_repeating_character() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    first_non_repeating_character \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"None\" ]]\n    [[ $(candidate \"abc\") = \"a\" ]]\n    [[ $(candidate \"ababc\") = \"c\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given string starts and ends with the same character or not.\n#\n# $1 is a string\ncheck_char() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abba\") = \"Valid\" ]]\n    [[ $(candidate \"a\") = \"Valid\" ]]\n    [[ $(candidate \"abcd\") = \"Invalid\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median of three numbers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_numbers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    median_numbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25\" \"55\" \"65\") = \"55.0\" ]]\n    [[ $(candidate \"20\" \"10\" \"30\") = \"20.0\" ]]\n    [[ $(candidate \"15\" \"45\" \"75\") = \"45.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to compute the sum of digits of each number of a given list.\n#\n# $1 is a space-separated list\nsum_of_digits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_of_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 2 56\") = \"14\" ]]\n    [[ $(candidate \"10 20 4 5 b 70 a\") = \"19\" ]]\n    [[ $(candidate \"10 20 -4 5 -70\") = \"19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform the mathematical bitwise xor operation across the given lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nbitwise_xor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    bitwise_xor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"15 6 5 10\" ]]\n    [[ $(candidate \"11 5 7 10\" \"6 3 4 4\") = \"13 6 3 14\" ]]\n    [[ $(candidate \"12 6 8 11\" \"7 4 5 6\") = \"11 2 13 13\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to identify non-prime numbers.\n#\n# $1 is an integer\nis_not_prime() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_not_prime \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"35\") = \"true\" ]]\n    [[ $(candidate \"37\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract the number of unique lists in the given list.\n#\n# $1 is a newline-separated, space-separated list\nextract_freq() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_freq \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\\n1 2\\n4 3\\n5 6\") = \"3\" ]]\n    [[ $(candidate \"4 15\\n2 3\\n5 4\\n6 7\") = \"4\" ]]\n    [[ $(candidate \"5 16\\n2 3\\n6 5\\n6 9\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform index wise addition of list elements in the given two nested lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nadd_nested_tuples() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add_nested_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"7 10\\n7 14\\n3 10\\n8 13\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"9 12\\n9 16\\n5 12\\n10 15\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"11 14\\n11 18\\n7 14\\n12 17\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum of two numbers.\n#\n# $1 is an integer\n# $2 is an integer\nminimum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"-5\" \"-4\") = \"-5\" ]]\n    [[ $(candidate \"0\" \"0\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether an element exists within a list.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncheck_tuplex() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_tuplex \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"w 3 r e s o u r c e\" \"r\") = \"true\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"5\") = \"false\" ]]\n    [[ $(candidate \"w 3 r e s o u r c e\" \"3\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find whether the parity of a given number is odd.\n#\n# $1 is an integer\nfind_Parity() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Parity \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"false\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to create the next bigger number by rearranging the digits of a given number.\n#\n# $1 is an integer\nrearrange_bigger() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rearrange_bigger \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12\") = \"21\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"102\") = \"120\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nk_smallest_pairs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    k_smallest_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"2\") = \"1 2\\n1 4\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"1\") = \"1 2\" ]]\n    [[ $(candidate \"1 3 7\" \"2 4 6\" \"7\") = \"1 2\\n1 4\\n3 2\\n1 6\\n3 4\\n3 6\\n7 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the minimum product from the pairs of lists within a given list.\n#\n# $1 is a newline-separated, space-separated list\nmin_product_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_product_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 7\\n2 6\\n1 8\\n4 9\") = \"8\" ]]\n    [[ $(candidate \"10 20\\n15 2\\n5 10\") = \"30\" ]]\n    [[ $(candidate \"11 44\\n10 15\\n20 5\\n12 9\") = \"100\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the minimum value in a given heterogeneous list.\n#\n# $1 is a newline-separated, space-separated list\nmin_val() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_val \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python 3 2 4 5 version\") = \"2\" ]]\n    [[ $(candidate \"Python 15 20 25\") = \"15\" ]]\n    [[ $(candidate \"Python 30 20 40 50 version\") = \"20\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given snake case string to camel case string.\n#\n# $1 is a string\nsnake_to_camel() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    snake_to_camel \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"android_tv\") = \"AndroidTv\" ]]\n    [[ $(candidate \"google_pixel\") = \"GooglePixel\" ]]\n    [[ $(candidate \"apple_watch\") = \"AppleWatch\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to remove odd numbers from a given list.\n#\n# $1 is a space-separated list\nremove_odd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"2\" ]]\n    [[ $(candidate \"2 4 6\") = \"2 4 6\" ]]\n    [[ $(candidate \"10 20 3\") = \"10 20\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether any value in a sequence exists in a sequence or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\noverlapping() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    overlapping \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\" \"4 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 4 5\" \"1 4 5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find a pair with highest product from a given array of integers.\n#\n# $1 is a space-separated list\nmax_Product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_Product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 7 0 8 4\") = \"7 8\" ]]\n    [[ $(candidate \"0 -1 -2 -4 5 0 -6\") = \"-4 -6\" ]]\n    [[ $(candidate \"1 2 3\") = \"2 3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]
@@ -4564,7 +1636,7 @@
     "language": "sh",
     "prompt": "#!/bin/bash\n# Write a function to find common first element in given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ngroup_tuples() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\ncandidate() {\n    group_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\nx z\\nw t\") = \"x y z\\nw t\" ]]\n    [[ $(candidate \"a b\\na c\\nd e\") = \"a b c\\nd e\" ]]\n    [[ $(candidate \"f g\\nf g\\nh i\") = \"f g g\\nh i\" ]]\n}\n\nrun_test",
     "stop_tokens": [
@@ -4572,13 +1644,2941 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "sh",
-    "prompt": "#!/bin/bash\n# Write a function to merge three lists into a single sorted list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nmerge_sorted_list() {\n",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the element of a list having maximum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max() {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\ncandidate() {\n    merge_sorted_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 24 15 4 5 29 110\" \"19 20 11 56 25 233 154\" \"24 26 54 48\") = \"4 5 11 15 19 20 24 24 25 25 26 29 48 54 56 110 154 233\" ]]\n    [[ $(candidate \"1 3 5 6 8 9\" \"2 5 7 11\" \"1 4 7 8 12\") = \"1 1 2 3 4 5 5 6 7 7 8 8 9 11 12\" ]]\n    [[ $(candidate \"18 14 10 9 8 7 9 3 2 4 1\" \"25 35 22 85 14 65 75 25 58\" \"12 74 9 50 61 41\") = \"1 2 3 4 7 8 9 9 9 10 12 14 14 18 22 25 25 35 41 50 58 61 65 74 75 85\" ]]\n}\n\nrun_test",
+    "tests": "}\n\ncandidate() {\n    Find_Max \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"A\\nA B\\nA B C\") = \"A B C\" ]]\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1 2 3\" ]]\n    [[ $(candidate \"1 1\\n1 2 3\\n1 5 6 1\") = \"1 5 6 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\n#\n# $1 is a newline-separated, space-separated list\nround_and_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    round_and_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"22.4 4.0 -16.22 -9.1 11.0 -12.22 14.2 -5.2 17.5\") = \"243\" ]]\n    [[ $(candidate \"5 2 9 24.3 29\") = \"345\" ]]\n    [[ $(candidate \"25.0 56.7 89.2\") = \"513\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the cube sum of first n even natural numbers.\n#\n# $1 is an integer\ncube_Sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    cube_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"72\" ]]\n    [[ $(candidate \"3\") = \"288\" ]]\n    [[ $(candidate \"4\") = \"800\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to concatenate each element of list by the delimiter.\n#\n# $1 is a space-separated list\nconcatenate_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    concatenate_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ID is 4 UTS\") = \"ID-is-4-UTS\" ]]\n    [[ $(candidate \"QWE is 4 RTY\") = \"QWE-is-4-RTY\" ]]\n    [[ $(candidate \"ZEN is 4 OP\") = \"ZEN-is-4-OP\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the average of cubes of first n natural numbers.\n#\n# $1 is an integer\nfind_Average_Of_Cube() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Average_Of_Cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4.5\" ]]\n    [[ $(candidate \"3\") = \"12\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract only the rear index element of each string in the given list.\n#\n# $1 is a space-separated list\nextract_rear() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_rear \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Mers for Vers\") = \"s r s\" ]]\n    [[ $(candidate \"Avenge for People\") = \"e r e\" ]]\n    [[ $(candidate \"Gotta get go\") = \"a t o\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the number of sublists containing a particular element.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a $Any\ncount_element_in_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_element_in_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n1 11\\n1 15 7\" \"1\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"A\") = \"3\" ]]\n    [[ $(candidate \"A B\\nA C\\nA D E\\nB C D\" \"E\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to filter odd numbers.\n#\n# $1 is a space-separated list\nfilter_oddnumbers() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    filter_oddnumbers \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 3 5 7 9\" ]]\n    [[ $(candidate \"10 20 45 67 84 93\") = \"45 67 93\" ]]\n    [[ $(candidate \"5 7 9 8 6 4 3\") = \"5 7 9 3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\n#\n# $1 is a string\nchange_date_format() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    change_date_format \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2026-01-02\") = \"02-01-2026\" ]]\n    [[ $(candidate \"2020-11-13\") = \"13-11-2020\" ]]\n    [[ $(candidate \"2021-04-26\") = \"26-04-2021\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort the given array by using shell sort.\n#\n# $1 is a space-separated list\nshell_sort() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    shell_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 23 4 5 3 2 12 81 56 95\") = \"2 3 4 5 12 12 23 56 81 95\" ]]\n    [[ $(candidate \"24 22 39 34 87 73 68\") = \"22 24 34 39 68 73 87\" ]]\n    [[ $(candidate \"32 30 16 96 82 83 74\") = \"16 30 32 74 82 83 96\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract the elementwise and lists from the given two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nand_tuples() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    and_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 6 9\" \"5 2 3 3\") = \"0 0 2 1\" ]]\n    [[ $(candidate \"1 2 3 4\" \"5 6 7 8\") = \"1 2 3 0\" ]]\n    [[ $(candidate \"8 9 11 12\" \"7 13 14 17\") = \"0 9 10 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the directrix of a parabola.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nparabola_directrix() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    parabola_directrix \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"3\" \"2\") = \"-198\" ]]\n    [[ $(candidate \"9\" \"8\" \"4\") = \"-2336\" ]]\n    [[ $(candidate \"2\" \"4\" \"6\") = \"-130\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes two lists and returns true if they have at least one common element.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncommon_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    common_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"5 6 7 8 9\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 8 9\") = \"None\" ]]\n    [[ $(candidate \"a b c\" \"d b e\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median length of a trapezium.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nmedian_trapezium() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    median_trapezium \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\" \"25\" \"35\") = \"20\" ]]\n    [[ $(candidate \"10\" \"20\" \"30\") = \"15\" ]]\n    [[ $(candidate \"6\" \"9\" \"4\") = \"7.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the entered number is greater than the elements of the given array.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_greater() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_greater \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2 3 4 5 6\" \"8\") = \"true\" ]]\n    [[ $(candidate \"9 7 4 8 6 1\" \"11\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by one or more b's.\n#\n# $1 is a string\ntext_match_one() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the last digit of a given number.\n#\n# $1 is an integer\nlast_Digit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    last_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"25\") = \"5\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to return the negative numbers in a list.\n#\n# $1 is a space-separated list\nneg_nos() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    neg_nos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1 4 5 -6\") = \"-1 -6\" ]]\n    [[ $(candidate \"-1 -2 3 4\") = \"-1 -2\" ]]\n    [[ $(candidate \"-7 -6 8 9\") = \"-7 -6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove odd characters in a string.\n#\n# $1 is a string\nremove_odd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"yhn\" ]]\n    [[ $(candidate \"program\") = \"rga\" ]]\n    [[ $(candidate \"language\") = \"agae\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count bidirectional list pairs.\n#\n# $1 is a newline-separated, space-separated list\ncount_bidirectional() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_bidirectional \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 1\\n6 5\\n2 1\") = \"3\" ]]\n    [[ $(candidate \"5 6\\n1 3\\n6 5\\n9 1\\n6 5\\n2 1\") = \"2\" ]]\n    [[ $(candidate \"5 6\\n1 2\\n6 5\\n9 2\\n6 5\\n2 1\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to join a list of multiple integers into a single integer.\n#\n# $1 is a space-separated list\nmultiple_to_single() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    multiple_to_single \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 33 50\") = \"113350\" ]]\n    [[ $(candidate \"-1 2 3 4 5 6\") = \"-123456\" ]]\n    [[ $(candidate \"10 15 20 25\") = \"10152025\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the first adverb and their positions in a given sentence.\n#\n# $1 is a string\nfind_adverb_position() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_adverb_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"clearly\\!\\! we can see the sky\") = \"0 7 clearly\" ]]\n    [[ $(candidate \"seriously\\!\\! there are many roses\") = \"0 9 seriously\" ]]\n    [[ $(candidate \"unfortunately\\!\\! sita is going to home\") = \"0 13 unfortunately\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cube of a given size.\n#\n# $1 is an integer\nsurfacearea_cube() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    surfacearea_cube \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"150\" ]]\n    [[ $(candidate \"3\") = \"54\" ]]\n    [[ $(candidate \"10\") = \"600\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the ration of positive numbers in an array of integers.\n#\n# $1 is a space-separated list\npositive_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    positive_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\") = \"0.54\" ]]\n    [[ $(candidate \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"0.69\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\") = \"0.56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the largest negative number from the given list.\n#\n# $1 is a space-separated list\nlargest_neg() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    largest_neg \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 -4 -6\") = \"-6\" ]]\n    [[ $(candidate \"1 2 3 -8 -9\") = \"-9\" ]]\n    [[ $(candidate \"1 2 3 4 -1\") = \"-1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to trim each list by k in the given lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\ntrim_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    trim_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"2\") = \"2\\n9\\n2\\n2\" ]]\n    [[ $(candidate \"5 3 2 1 4\\n3 4 9 2 1\\n9 1 2 3 5\\n4 8 2 1 7\" \"1\") = \"3 2 1\\n4 9 2\\n1 2 3\\n8 2 1\" ]]\n    [[ $(candidate \"7 8 4 9\\n11 8 12 4\\n4 1 7 8\\n3 6 9 7\" \"1\") = \"8 4\\n8 12\\n1 7\\n6 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to perform index wise multiplication of list elements in the given two lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is a newline-separated, space-separated list\nindex_multiplication() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    index_multiplication \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n4 5\\n2 9\\n1 10\" \"6 7\\n3 9\\n1 1\\n7 3\") = \"6 21\\n12 45\\n2 9\\n7 30\" ]]\n    [[ $(candidate \"2 4\\n5 6\\n3 10\\n2 11\" \"7 8\\n4 10\\n2 2\\n8 4\") = \"14 32\\n20 60\\n6 20\\n16 44\" ]]\n    [[ $(candidate \"3 5\\n6 7\\n4 11\\n3 12\" \"8 9\\n5 11\\n3 3\\n9 5\") = \"24 45\\n30 77\\n12 33\\n27 60\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the occurence of all elements of list in a list.\n#\n# $1 is a $Any\n# $2 is a space-separated list\ncount_Occurrence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_Occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a a c b d\" \"a b\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 1 4 6 7 1 4\" \"1 4 7\") = \"6\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"1 2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find cubes of individual elements in a list.\n#\n# $1 is a space-separated list\ncube_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    cube_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 8 27 64 125 216 343 512 729 1000\" ]]\n    [[ $(candidate \"10 20 30\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\") = \"1728 3375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the sum of perrin numbers.\n#\n# $1 is an integer\ncal_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    cal_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"49\" ]]\n    [[ $(candidate \"10\") = \"66\" ]]\n    [[ $(candidate \"11\") = \"88\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract specified size of strings from a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is an integer\nextract_string() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python list exercises practice solution\" \"8\") = \"practice solution\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"6\") = \"Python\" ]]\n    [[ $(candidate \"Python list exercises practice solution\" \"9\") = \"exercises\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from the given string.\n#\n# $1 is a string\nremove_whitespaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_whitespaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \" Google    Flutter \") = \"GoogleFlutter\" ]]\n    [[ $(candidate \" Google    Dart \") = \"GoogleDart\" ]]\n    [[ $(candidate \" iOS    Swift \") = \"iOSSwift\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that gives loss amount on a sale if the given amount has loss else return 0.\n#\n# $1 is an integer\n# $2 is an integer\nloss_amount() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    loss_amount \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"0\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"3000\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of even factors of a number.\n#\n# $1 is an integer\nsumofFactors() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sumofFactors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"18\") = \"26\" ]]\n    [[ $(candidate \"30\") = \"48\" ]]\n    [[ $(candidate \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a word containing 'z'.\n#\n# $1 is a string\ntext_match_wordz() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_wordz \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonz.\") = \"true\" ]]\n    [[ $(candidate \"xyz.\") = \"true\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 31 days or not.\n#\n# $1 is an integer\ncheck_monthnumb_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_monthnumb_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to reverse each string in a given list of string values.\n#\n# $1 is a space-separated list\nreverse_string_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    reverse_string_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Red Green Blue White Black\") = \"deR neerG eulB etihW kcalB\" ]]\n    [[ $(candidate \"john amal joel george\") = \"nhoj lama leoj egroeg\" ]]\n    [[ $(candidate \"jack john mary\") = \"kcaj nhoj yram\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sublist having minimum length.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Find_Min \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\\n1 2 3\") = \"1\" ]]\n    [[ $(candidate \"1 1\\n1 1 1\\n1 2 7 8\") = \"1 1\" ]]\n    [[ $(candidate \"x\\nx y\\nx y z\") = \"x\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the area of a rectangle.\n#\n# $1 is an integer\n# $2 is an integer\nrectangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rectangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"20\") = \"200\" ]]\n    [[ $(candidate \"10\" \"5\") = \"50\" ]]\n    [[ $(candidate \"4\" \"2\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove uppercase substrings from a given string.\n#\n# $1 is a string\nremove_uppercase() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"cAstyoUrFavoRitETVshoWs\") = \"cstyoravoitshos\" ]]\n    [[ $(candidate \"wAtchTheinTernEtrAdIo\") = \"wtchheinerntrdo\" ]]\n    [[ $(candidate \"VoicESeaRchAndreComMendaTionS\") = \"oiceachndreomendaion\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to get the first element of each sublist.\n#\n# $1 is a newline-separated, space-separated list\nExtract() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Extract \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2\\n3 4 5\\n6 7 8 9\") = \"1 3 6\" ]]\n    [[ $(candidate \"1 2 3\\n4 5\") = \"1 4\" ]]\n    [[ $(candidate \"9 8 1\\n1 2\") = \"9 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the upper case characters in a given string.\n#\n# $1 is a string\nupper_ctr() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    upper_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYthon\") = \"1\" ]]\n    [[ $(candidate \"BigData\") = \"1\" ]]\n    [[ $(candidate \"program\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find all possible combinations of the elements of a given list.\n#\n# $1 is a space-separated list\ncombinations_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    combinations_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"orange red green blue\") = \"\\norange\\nred\\nred orange\\ngreen\\ngreen orange\\ngreen red\\ngreen red orange\\nblue\\nblue orange\\nblue red\\nblue red orange\\nblue green\\nblue green orange\\nblue green red\\nblue green red orange\" ]]\n    [[ $(candidate \"red green blue white black orange\") = \"\\nred\\ngreen\\ngreen red\\nblue\\nblue red\\nblue green\\nblue green red\\nwhite\\nwhite red\\nwhite green\\nwhite green red\\nwhite blue\\nwhite blue red\\nwhite blue green\\nwhite blue green red\\nblack\\nblack red\\nblack green\\nblack green red\\nblack blue\\nblack blue red\\nblack blue green\\nblack blue green red\\nblack white\\nblack white red\\nblack white green\\nblack white green red\\nblack white blue\\nblack white blue red\\nblack white blue green\\nblack white blue green red\\norange\\norange red\\norange green\\norange green red\\norange blue\\norange blue red\\norange blue green\\norange blue green red\\norange white\\norange white red\\norange white green\\norange white green red\\norange white blue\\norange white blue red\\norange white blue green\\norange white blue green red\\norange black\\norange black red\\norange black green\\norange black green red\\norange black blue\\norange black blue red\\norange black blue green\\norange black blue green red\\norange black white\\norange black white red\\norange black white green\\norange black white green red\\norange black white blue\\norange black white blue red\\norange black white blue green\\norange black white blue green red\" ]]\n    [[ $(candidate \"red green black orange\") = \"\\nred\\ngreen\\ngreen red\\nblack\\nblack red\\nblack green\\nblack green red\\norange\\norange red\\norange green\\norange green red\\norange black\\norange black red\\norange black green\\norange black green red\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum product subarray of the given array.\n#\n# $1 is a space-separated list\nmax_subarray_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_subarray_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 -3 0 7 -8 -2\") = \"112\" ]]\n    [[ $(candidate \"6 -3 -10 0 2\") = \"180\" ]]\n    [[ $(candidate \"-2 -40 0 -2 -3\") = \"80\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to drop empty items from a given CSV.\n#\n# $1 is a two column CSV in key,value order\ndrop_empty() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    drop_empty \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"c1,Red\\nc2,Green\\nc3,None\") = \"c1,Red\\nc2,Green\" ]]\n    [[ $(candidate \"c1,Red\\nc2,None\\nc3,None\") = \"c1,Red\" ]]\n    [[ $(candidate \"c1,None\\nc2,Green\\nc3,None\") = \"c2,Green\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\n#\n# $1 is a space-separated list\nmax_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 100 4 5 150 6\") = \"3000\" ]]\n    [[ $(candidate \"4 42 55 68 80\") = \"50265600\" ]]\n    [[ $(candidate \"10 22 9 33 21 50 41 60\") = \"2460\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the pairwise addition of the neighboring elements of the given list.\n#\n# $1 is a space-separated list\nadd_pairwise() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add_pairwise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"6 12 15 18\" ]]\n    [[ $(candidate \"2 6 8 9 11\") = \"8 14 17 20\" ]]\n    [[ $(candidate \"3 7 9 10 12\") = \"10 16 19 22\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the product of the array multiplication modulo n.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_remainder() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_remainder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"100 10 5 25 35 14\" \"11\") = \"9\" ]]\n    [[ $(candidate \"1 1 1\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 2 1\" \"2\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given list contains consecutive numbers or not.\n#\n# $1 is a space-separated list\ncheck_Consecutive() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_Consecutive \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 5 6\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace characters in a string.\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nreplace_char() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"polygon\" \"y\" \"l\") = \"pollgon\" ]]\n    [[ $(candidate \"character\" \"c\" \"a\") = \"aharaater\" ]]\n    [[ $(candidate \"python\" \"l\" \"a\") = \"python\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a CSV by value.\n#\n# $1 is a two column CSV in key,value order\nsort_counter() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sort_counter \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Math,81\\nPhysics,83\\nChemistry,87\") = \"Chemistry 87\\nPhysics 83\\nMath 81\" ]]\n    [[ $(candidate \"Math,400\\nPhysics,300\\nChemistry,250\") = \"Math 400\\nPhysics 300\\nChemistry 250\" ]]\n    [[ $(candidate \"Math,900\\nPhysics,1000\\nChemistry,1250\") = \"Chemistry 1250\\nPhysics 1000\\nMath 900\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the largest and smallest value in a given array.\n#\n# $1 is a space-separated list\nbig_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    big_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"4\" ]]\n    [[ $(candidate \"-1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"2 3 6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to convert the given string to lower case.\n#\n# $1 is a string\nis_lower() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_lower \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"InValid\") = \"invalid\" ]]\n    [[ $(candidate \"TruE\") = \"true\" ]]\n    [[ $(candidate \"SenTenCE\") = \"sentence\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove lowercase substrings from a given string.\n#\n# $1 is a string\nremove_lowercase() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_lowercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"PYTHon\") = \"PYTH\" ]]\n    [[ $(candidate \"FInD\") = \"FID\" ]]\n    [[ $(candidate \"STRinG\") = \"STRG\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the first digit of a given number.\n#\n# $1 is an integer\nfirst_Digit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    first_Digit \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123\") = \"1\" ]]\n    [[ $(candidate \"456\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the n largest integers from a given list of numbers, returned in descending order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nheap_queue_largest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    heap_queue_largest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"3\") = \"85 75 65\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"2\") = \"85 75\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 22 58\" \"5\") = \"85 75 65 58 35\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of integers and only returns the odd ones.\n#\n# $1 is a space-separated list\nSplit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1 3 5\" ]]\n    [[ $(candidate \"10 11 12 13\") = \"11 13\" ]]\n    [[ $(candidate \"7 8 9 1\") = \"7 9 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\n#\n# $1 is an integer\ndifference() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"30\" ]]\n    [[ $(candidate \"5\") = \"210\" ]]\n    [[ $(candidate \"2\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of pairs whose xor value is odd.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_Odd_Pair() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Odd_Pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 4 7 2 1\" \"5\") = \"6\" ]]\n    [[ $(candidate \"7 2 8 1 0 5 11\" \"7\") = \"12\" ]]\n    [[ $(candidate \"1 2 3\" \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to toggle the case of all characters in a string.\n#\n# $1 is a string\ntoggle_string() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    toggle_string \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"pYTHON\" ]]\n    [[ $(candidate \"Pangram\") = \"pANGRAM\" ]]\n    [[ $(candidate \"LIttLE\") = \"liTTle\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the per-digit difference between two integers.\n#\n# $1 is an integer\n# $2 is an integer\ndigit_distance_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    digit_distance_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"2\") = \"1\" ]]\n    [[ $(candidate \"23\" \"56\") = \"6\" ]]\n    [[ $(candidate \"123\" \"256\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the sum of the largest contiguous sublist in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmax_sub_array_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_sub_array_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-2 -3 4 -1 -2 1 5 -3\" \"8\") = \"7\" ]]\n    [[ $(candidate \"-3 -4 5 -2 -3 2 6 -4\" \"8\") = \"8\" ]]\n    [[ $(candidate \"-4 -5 6 -3 -4 3 7 -5\" \"8\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the union of the elements of two given lists and output them in sorted order.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nunion_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    union_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 4 5 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"3 4 5 6\") = \"1 2 3 4 5 6\" ]]\n    [[ $(candidate \"11 12 13 14\" \"13 15 16 17\") = \"11 12 13 14 15 16 17\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the longest sublists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Max_Length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Find_Max_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 4\\n5 6 7 8\") = \"4\" ]]\n    [[ $(candidate \"0 1\\n2 2\\n3 2 1\") = \"3\" ]]\n    [[ $(candidate \"7\\n22 23\\n13 14 15\\n10 20 30 40 50\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract values between quotation marks from a string.\n#\n# $1 is a string\nextract_values() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_values \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") = \"Python PHP Java\" ]]\n    [[ $(candidate \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") = \"python program language\" ]]\n    [[ $(candidate \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") = \"red blue green yellow\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncount_Pairs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_Pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 1\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 1 1 1\" \"4\") = \"0\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"5\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to split a string into characters.\n#\n# $1 is a string\nsplit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"p y t h o n\" ]]\n    [[ $(candidate \"Name\") = \"N a m e\" ]]\n    [[ $(candidate \"program\") = \"p r o g r a m\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get the sum of the digits of a non-negative integer.\n#\n# $1 is an integer\nsum_digits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"345\") = \"12\" ]]\n    [[ $(candidate \"12\") = \"3\" ]]\n    [[ $(candidate \"97\") = \"16\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a specified list is sorted or not.\n#\n# $1 is a space-separated list\nissort_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    issort_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 6 8 10 12 14 16 17\") = \"true\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 12 14 20 17\") = \"false\" ]]\n    [[ $(candidate \"1 2 4 6 8 10 15 14 20\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort each sublist of strings in a given list of lists.\n#\n# $1 is a newline-separated, space-separated list\nsort_sublists() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sort_sublists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"green orange\\nblack white\\nwhite black orange\") = \"green orange\\nblack white\\nblack orange white\" ]]\n    [[ $(candidate \"green orange\\nblack\\ngreen orange\\nwhite\") = \"green orange\\nblack\\ngreen orange\\nwhite\" ]]\n    [[ $(candidate \"a b\\nd c\\ng h\\nf e\") = \"a b\\nc d\\ng h\\ne f\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check if a given number is one less than twice its reverse.\n#\n# $1 is an integer\nchecks() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    checks \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"70\") = \"false\" ]]\n    [[ $(candidate \"23\") = \"false\" ]]\n    [[ $(candidate \"73\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to remove duplicate numbers from a given number of lists.\n#\n# $1 is a space-separated list\ntwo_unique_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    two_unique_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2 3 4 5\") = \"1 4 5\" ]]\n    [[ $(candidate \"1 2 3 2 4 5\") = \"1 3 4 5\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"1 2 3 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to calculate the product of the unique numbers in a given list.\n#\n# $1 is a space-separated list\nunique_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    unique_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30 40 20 50 60 40\") = \"720000000\" ]]\n    [[ $(candidate \"1 2 3 1\") = \"6\" ]]\n    [[ $(candidate \"7 8 9 0 1 1\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the surface area of a cylinder.\n#\n# $1 is an integer\n# $2 is an integer\nsurfacearea_cylinder() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    surfacearea_cylinder \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\" \"5\") = \"942.45\" ]]\n    [[ $(candidate \"4\" \"5\") = \"226.18800000000002\" ]]\n    [[ $(candidate \"4\" \"10\") = \"351.848\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether a list is sublist of another or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_Sub_Array() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_Sub_Array \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 4 3 5\" \"1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 1\" \"1 2 1\") = \"true\" ]]\n    [[ $(candidate \"1 0 2 2\" \"2 2 0\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the last digit in factorial of a given number.\n#\n# $1 is an integer\nlast_Digit_Factorial() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    last_Digit_Factorial \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\") = \"4\" ]]\n    [[ $(candidate \"21\") = \"0\" ]]\n    [[ $(candidate \"30\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to interleave 3 lists of the same length into a single flat list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\ninterleave_lists() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    interleave_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7\" \"10 20 30 40 50 60 70\" \"100 200 300 400 500 600 700\") = \"1 10 100 2 20 200 3 30 300 4 40 400 5 50 500 6 60 600 7 70 700\" ]]\n    [[ $(candidate \"10 20\" \"15 2\" \"5 10\") = \"10 15 5 20 2 10\" ]]\n    [[ $(candidate \"11 44\" \"10 15\" \"20 5\") = \"11 10 20 44 15 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the dissimilar elements in the given two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nfind_dissimilar() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_dissimilar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4 5 6\" \"5 7 4 10\") = \"3 6 7 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"7 2 3 9\") = \"1 4 7 9\" ]]\n    [[ $(candidate \"21 11 25 26\" \"26 34 21 36\") = \"34 36 11 25\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the largest number that can be formed with the given list of digits.\n#\n# $1 is a space-separated list\nfind_Max_Num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Max_Num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"321\" ]]\n    [[ $(candidate \"4 5 6 1\") = \"6541\" ]]\n    [[ $(candidate \"1 2 3 9\") = \"9321\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove uneven elements in the nested mixed list.\n#\n# $1 is a space-separated list\nextract_even() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 7 6 2 4 6 8\") = \"4 6 2 4 6 8\" ]]\n    [[ $(candidate \"5 6 8 7 4 8 7 9\") = \"6 8 4 8\" ]]\n    [[ $(candidate \"5 6 9 8 4 6 8 10\") = \"6 8 4 6 8 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the surface area of a square shramid with a given base edge and height.\n#\n# $1 is an integer\n# $2 is an integer\nsurface_Area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    surface_Area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"33\" ]]\n    [[ $(candidate \"4\" \"5\") = \"56\" ]]\n    [[ $(candidate \"1\" \"2\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which returns nth catalan number.\n#\n# $1 is an integer\ncatalan_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    catalan_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"16796\" ]]\n    [[ $(candidate \"9\") = \"4862\" ]]\n    [[ $(candidate \"7\") = \"429\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the first adverb ending with ly and its positions in a given string.\n#\n# $1 is a string\nfind_adverbs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_adverbs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Clearly, he has no excuse for such behavior.\") = \"0-7: Clearly\" ]]\n    [[ $(candidate \"Please handle the situation carefuly\") = \"28-36: carefuly\" ]]\n    [[ $(candidate \"Complete the task quickly\") = \"18-25: quickly\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to split a list at the nth eelment and add the first part to the end.\n#\n# $1 is a space-separated list\n# $2 is an integer\nsplit_Arr() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    split_Arr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 10 5 6 52 36\" \"2\") = \"5 6 52 36 12 10\" ]]\n    [[ $(candidate \"1 2 3 4\" \"1\") = \"2 3 4 1\" ]]\n    [[ $(candidate \"0 1 2 3 4 5 6 7\" \"3\") = \"3 4 5 6 7 0 1 2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert a list to a list.\n#\n# $1 is a space-separated list\nlist_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    list_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 10 7 4 15 3\") = \"5 10 7 4 15 3\" ]]\n    [[ $(candidate \"2 4 5 6 2 3 4 4 7\") = \"2 4 5 6 2 3 4 4 7\" ]]\n    [[ $(candidate \"58 44 56\") = \"58 44 56\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the difference between largest and smallest value in a given list.\n#\n# $1 is a space-separated list\nbig_diff() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    big_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4\") = \"3\" ]]\n    [[ $(candidate \"4 5 12\") = \"8\" ]]\n    [[ $(candidate \"9 2 3\") = \"7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find perfect squares between two given numbers.\n#\n# $1 is an integer\n# $2 is an integer\nperfect_squares() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    perfect_squares \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"30\") = \"1 4 9 16 25\" ]]\n    [[ $(candidate \"50\" \"100\") = \"64 81 100\" ]]\n    [[ $(candidate \"100\" \"200\") = \"100 121 144 169 196\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given two integers have opposite sign or not.\n#\n# $1 is an integer\n# $2 is an integer\nopposite_Signs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    opposite_Signs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"-2\") = \"true\" ]]\n    [[ $(candidate \"3\" \"2\") = \"false\" ]]\n    [[ $(candidate \"-10\" \"-10\") = \"false\" ]]\n    [[ $(candidate \"-2\" \"2\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to interchange the first and last elements in a list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12 35 9 56 24\") = \"24 35 9 56 12\" ]]\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of the product of consecutive binomial co-efficients.\n#\n# $1 is an integer\nsum_Of_product() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_Of_product \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15\" ]]\n    [[ $(candidate \"4\") = \"56\" ]]\n    [[ $(candidate \"1\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove leading zeroes from an ip address.\n#\n# $1 is a string\nremovezero_ip() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    removezero_ip \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"216.08.094.196\") = \"216.8.94.196\" ]]\n    [[ $(candidate \"12.01.024\") = \"12.1.24\" ]]\n    [[ $(candidate \"216.08.094.0196\") = \"216.8.94.196\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the difference of the first even and first odd number of a given list.\n#\n# $1 is a space-separated list\ndiff_even_odd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    diff_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\n#\n# $1 is a string\n# $2 is a string\nmin_Swaps() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_Swaps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1101\" \"1110\") = \"1\" ]]\n    [[ $(candidate \"111\" \"000\") = \"Not Possible\" ]]\n    [[ $(candidate \"111\" \"110\") = \"Not Possible\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find kth element from the given two sorted arrays.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nfind_kth() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_kth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 3 6 7 9\" \"1 4 8 10\" \"5\") = \"6\" ]]\n    [[ $(candidate \"100 112 256 349 770\" \"72 86 113 119 265 445 892\" \"7\") = \"256\" ]]\n    [[ $(candidate \"3 4 7 8 10\" \"2 5 9 11\" \"6\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is armstrong or not.\n#\n# $1 is an integer\narmstrong_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    armstrong_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"153\") = \"true\" ]]\n    [[ $(candidate \"259\") = \"false\" ]]\n    [[ $(candidate \"4458\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find sum and average of first n natural numbers.\n#\n# $1 is an integer\nsum_average() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_average \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"55 5.5\" ]]\n    [[ $(candidate \"15\") = \"120 8.0\" ]]\n    [[ $(candidate \"20\") = \"210 10.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth octagonal number.\n#\n# $1 is an integer\nis_octagonal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_octagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"65\" ]]\n    [[ $(candidate \"10\") = \"280\" ]]\n    [[ $(candidate \"15\") = \"645\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number is even or not.\n#\n# $1 is an integer\nis_Even() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_Even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\") = \"false\" ]]\n    [[ $(candidate \"2\") = \"true\" ]]\n    [[ $(candidate \"3\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the first repeated character in a given string.\n#\n# $1 is a string\nfirst_repeated_char() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    first_repeated_char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abcabc\") = \"a\" ]]\n    [[ $(candidate \"abc\") = \"None\" ]]\n    [[ $(candidate \"123123\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get all lucid numbers smaller than or equal to a given integer.\n#\n# $1 is an integer\nget_ludic() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_ludic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"1 2 3 5 7\" ]]\n    [[ $(candidate \"25\") = \"1 2 3 5 7 11 13 17 23 25\" ]]\n    [[ $(candidate \"45\") = \"1 2 3 5 7 11 13 17 23 25 29 37 41 43\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to reverse words seperated by spaces in a given string.\n#\n# $1 is a string\nreverse_words() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    reverse_words \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python program\") = \"program python\" ]]\n    [[ $(candidate \"java language\") = \"language java\" ]]\n    [[ $(candidate \"indian man\") = \"man indian\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given integer is a prime number.\n#\n# $1 is an integer\nprime_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    prime_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\") = \"true\" ]]\n    [[ $(candidate \"7\") = \"true\" ]]\n    [[ $(candidate \"-1010\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert degrees to radians.\n#\n# $1 is an integer\nradian_degree() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    radian_degree \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"90\") = \"1.5707963267948966\" ]]\n    [[ $(candidate \"60\") = \"1.0471975511965976\" ]]\n    [[ $(candidate \"120\") = \"2.0943951023931953\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\n#\n# $1 is a string\n# $2 is a string\nfind_literals() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_literals \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The quick brown fox jumps over the lazy dog.\" \"fox\") = \"fox 16 19\" ]]\n    [[ $(candidate \"Its been a very crazy procedure right\" \"crazy\") = \"crazy 16 21\" ]]\n    [[ $(candidate \"Hardest choices required strongest will\" \"will\") = \"will 35 39\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find nth bell number.\n#\n# $1 is an integer\nbell_Number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    bell_Number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"3\") = \"5\" ]]\n    [[ $(candidate \"4\") = \"15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list and returns a list with the same elements, but the k'th element removed.\n#\n# $1 is a space-separated list\n# $2 is an integer\nremove_kth_element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_kth_element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 4 4 5 1\" \"3\") = \"1 1 3 4 4 5 1\" ]]\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\" \"4\") = \"0 0 1 3 4 4 5 6 6 6 7 8 9 4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\" \"5\") = \"10 10 15 19 18 17 26 26 17 18 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmax_of_nth() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_of_nth \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\\n1 3 5\\n8 9 19\" \"2\") = \"19\" ]]\n    [[ $(candidate \"6 7 8\\n2 4 6\\n9 10 20\" \"1\") = \"10\" ]]\n    [[ $(candidate \"7 8 9\\n3 5 7\\n10 11 21\" \"1\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\n#\n# $1 is a newline-separated, space-separated list\nmerge() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    merge \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"x y\\na b\\nm n\") = \"x a m\\ny b n\" ]]\n    [[ $(candidate \"1 2\\n3 4\\n5 6\\n7 8\") = \"1 3 5 7\\n2 4 6 8\" ]]\n    [[ $(candidate \"x y z\\na b c\\nm n o\") = \"x a m\\ny b n\\nz c o\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the cumulative sum of all the values that are present in the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\ncummulative_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    cummulative_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 6 7\\n2 6\") = \"30\" ]]\n    [[ $(candidate \"2 4\\n6 7 8\\n3 7\") = \"37\" ]]\n    [[ $(candidate \"3 5\\n7 8 9\\n4 8\") = \"44\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which takes a lists of lists and returns the average value for each sublist as a list.\n#\n# $1 is a newline-separated, space-separated list\naverage_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    average_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 12\\n30 45 56 45\\n81 80 39 32\\n1 2 3 4\") = \"30.5 34.25 27.0 23.25\" ]]\n    [[ $(candidate \"1 1 -5\\n30 -15 56\\n81 -60 -39\\n-10 2 3\") = \"25.5 -18.0 3.75\" ]]\n    [[ $(candidate \"100 100 100 120\\n300 450 560 450\\n810 800 390 320\\n10 20 30 40\") = \"305.0 342.5 270.0 232.5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function which takes two lists of the same length and performs the element wise modulo.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ntuple_modulo() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tuple_modulo \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6\" \"5 6 7 5\") = \"0 4 5 1\" ]]\n    [[ $(candidate \"11 5 6 7\" \"6 7 8 6\") = \"5 5 6 1\" ]]\n    [[ $(candidate \"12 6 7 8\" \"7 8 9 7\") = \"5 6 7 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\n#\n# $1 is a space-separated list\n# $2 is an integer\nmin_Jumps() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_Jumps \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\" \"11\") = \"3.5\" ]]\n    [[ $(candidate \"3 4\" \"0\") = \"0\" ]]\n    [[ $(candidate \"11 14\" \"11\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to divide two lists element wise.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ndiv_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    div_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"1 2 3\") = \"4.0 2.5 2.0\" ]]\n    [[ $(candidate \"3 2\" \"1 4\") = \"3.0 0.5\" ]]\n    [[ $(candidate \"90 120\" \"50 70\") = \"1.8 1.7142857142857142\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to move all the numbers to the end of the given string.\n#\n# $1 is a string\nmove_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    move_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"I1love143you55three3000thousand\") = \"Iloveyouthreethousand1143553000\" ]]\n    [[ $(candidate \"Avengers124Assemble\") = \"AvengersAssemble124\" ]]\n    [[ $(candidate \"Its11our12path13to14see15things16do17things\") = \"Itsourpathtoseethingsdothings11121314151617\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of substrings with the sum of digits equal to their length.\n#\n# $1 is a string\ncount_Substrings() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_Substrings \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"112112\") = \"6\" ]]\n    [[ $(candidate \"111\") = \"6\" ]]\n    [[ $(candidate \"1101112\") = \"12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the median of two sorted lists of same size.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is an integer\nget_median() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_median \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 12 15 26 38\" \"2 13 17 30 45\" \"5\") = \"16.0\" ]]\n    [[ $(candidate \"2 4 8 9\" \"7 13 19 28\" \"4\") = \"8.5\" ]]\n    [[ $(candidate \"3 6 14 23 36 42\" \"2 18 27 39 49 55\" \"6\") = \"25.0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to compute the n-th power of each number in a list.\n#\n# $1 is a space-separated list\n# $2 is an integer\nnth_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    nth_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\" \"3\") = \"1000 8000 27000\" ]]\n    [[ $(candidate \"12 15\" \"5\") = \"248832 759375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to convert a given string to uppercase.\n#\n# $1 is a string\nis_upper() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_upper \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"person\") = \"PERSON\" ]]\n    [[ $(candidate \"final\") = \"FINAL\" ]]\n    [[ $(candidate \"Valid\") = \"VALID\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to interchange the first and last element in a given list.\n#\n# $1 is a space-separated list\nswap_List() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    swap_List \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"3 2 1\" ]]\n    [[ $(candidate \"1 2 3 4 4\") = \"4 2 3 4 1\" ]]\n    [[ $(candidate \"4 5 6\") = \"6 5 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\n#\n# $1 is an integer\ntriangle_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    triangle_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"-1\") = \"None\" ]]\n    [[ $(candidate \"0\") = \"0\" ]]\n    [[ $(candidate \"2\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the smallest missing number from a sorted list of natural numbers.\n#\n# $1 is a space-separated list\nfind_First_Missing() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_First_Missing \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 1 2 3\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 6 9\") = \"3\" ]]\n    [[ $(candidate \"2 3 5 8 9\") = \"0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace all spaces in the given string with '%20'.\n#\n# $1 is a string\nreplace_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"My Name is Dawood\") = \"My%20Name%20is%20Dawood\" ]]\n    [[ $(candidate \"I am a Programmer\") = \"I%20am%20a%20Programmer\" ]]\n    [[ $(candidate \"I love Coding\") = \"I%20love%20Coding\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find even numbers from a list of numbers.\n#\n# $1 is a space-separated list\nSplit() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Split \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5\") = \"2 4\" ]]\n    [[ $(candidate \"4 5 6 7 8 0 1\") = \"4 6 8 0\" ]]\n    [[ $(candidate \"8 12 15 19\") = \"8 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find smallest number in a list.\n#\n# $1 is a space-separated list\nsmallest_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    smallest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 1 45 99\") = \"1\" ]]\n    [[ $(candidate \"1 2 3\") = \"1\" ]]\n    [[ $(candidate \"45 46 50 60\") = \"45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to extract all the adjacent coordinates of the given coordinate list.\n#\n# $1 is a space-separated list\nget_coordinates() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_coordinates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 4\") = \"2 3\\n2 4\\n2 5\\n3 3\\n3 4\\n3 5\\n4 3\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"4 5\") = \"3 4\\n3 5\\n3 6\\n4 4\\n4 5\\n4 6\\n5 4\\n5 5\\n5 6\" ]]\n    [[ $(candidate \"5 6\") = \"4 5\\n4 6\\n4 7\\n5 5\\n5 6\\n5 7\\n6 5\\n6 6\\n6 7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace whitespaces with an underscore and vice versa in a given string.\n#\n# $1 is a string\nreplace_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Jumanji The Jungle\") = \"Jumanji_The_Jungle\" ]]\n    [[ $(candidate \"The_Avengers\") = \"The Avengers\" ]]\n    [[ $(candidate \"Fast and Furious\") = \"Fast_and_Furious\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to move all zeroes to the end of the given list.\n#\n# $1 is a space-separated list\nmove_zero() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    move_zero \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 0 2 0 3 4\") = \"1 2 3 4 0 0\" ]]\n    [[ $(candidate \"2 3 2 0 0 4 0 5 0\") = \"2 3 2 4 5 0 0 0 0\" ]]\n    [[ $(candidate \"0 1 0 1 1\") = \"1 1 1 0 0\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of xor of all pairs of numbers in the given list.\n#\n# $1 is a space-separated list\n# $2 is an integer\npair_xor_Sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pair_xor_Sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 9 7 6\" \"4\") = \"47\" ]]\n    [[ $(candidate \"7 3 5\" \"3\") = \"12\" ]]\n    [[ $(candidate \"7 3\" \"2\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort the given list.\n#\n# $1 is a space-separated list\nheap_sort() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    heap_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 9 2 4 6 8 0\") = \"0 1 2 3 4 5 6 7 8 9\" ]]\n    [[ $(candidate \"25 35 22 85 14 65 75 25 58\") = \"14 22 25 25 35 58 65 75 85\" ]]\n    [[ $(candidate \"7 1 9 5\") = \"1 5 7 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given amount has no profit and no loss\n#\n# $1 is an integer\n# $2 is an integer\nnoprofit_noloss() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    noprofit_noloss \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1500\" \"1200\") = \"false\" ]]\n    [[ $(candidate \"100\" \"100\") = \"true\" ]]\n    [[ $(candidate \"2000\" \"5000\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\n#\n# $1 is an integer\n# $2 is an integer\nwind_chill() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    wind_chill \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"120\" \"35\") = \"40\" ]]\n    [[ $(candidate \"40\" \"20\") = \"19\" ]]\n    [[ $(candidate \"10\" \"8\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\n#\n# $1 is a space-separated list\nsample_nam() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sample_nam \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"sally Dylan rebecca Diana Joanne keith\") = \"16\" ]]\n    [[ $(candidate \"php res Python abcd Java aaa\") = \"10\" ]]\n    [[ $(candidate \"abcd Python abba aba\") = \"6\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the maximum difference between available pairs in the given list list.\n#\n# $1 is a newline-separated, space-separated list\nmax_difference() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_difference \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 5\\n1 7\\n10 3\\n1 2\") = \"7\" ]]\n    [[ $(candidate \"4 6\\n2 17\\n9 13\\n11 12\") = \"15\" ]]\n    [[ $(candidate \"12 35\\n21 27\\n13 23\\n41 22\") = \"23\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth nonagonal number.\n#\n# $1 is an integer\nis_nonagonal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_nonagonal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"325\" ]]\n    [[ $(candidate \"15\") = \"750\" ]]\n    [[ $(candidate \"18\") = \"1089\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that checks if a strings contains 'z', except at the start and end of the word.\n#\n# $1 is a string\ntext_match_wordz_middle() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_wordz_middle \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"pythonzabc.\") = \"true\" ]]\n    [[ $(candidate \"zxyabc.\") = \"false\" ]]\n    [[ $(candidate \"  lang  .\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to reverse an array upto a given position.\n#\n# $1 is a space-separated list\n# $2 is an integer\nreverse_Array_Upto_K() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    reverse_Array_Upto_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\" \"4\") = \"4 3 2 1 5 6\" ]]\n    [[ $(candidate \"4 5 6 7\" \"2\") = \"5 4 6 7\" ]]\n    [[ $(candidate \"9 8 7 6 5\" \"3\") = \"7 8 9 6 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to flatten a list and sum all of its elements.\n#\n# $1 is a newline-separated, space-separated list\nrecursive_list_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    recursive_list_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"7 10 15 14 19 41\") = \"106\" ]]\n    [[ $(candidate \"10 20 30 40 50 60\") = \"210\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of positive numbers in a list.\n#\n# $1 is a space-separated list\npos_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pos_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 -2 3 -4\") = \"2\" ]]\n    [[ $(candidate \"3 4 5 -1\") = \"3\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the number of ways to partition a set of Bell numbers.\n#\n# $1 is an integer\nbell_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    bell_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"2\" ]]\n    [[ $(candidate \"10\") = \"115975\" ]]\n    [[ $(candidate \"56\") = \"6775685320645824322581483068371419745979053216268760300\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given array is monotonic or not.\n#\n# $1 is a space-separated list\nis_Monotonic() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_Monotonic \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 5 4 4\") = \"true\" ]]\n    [[ $(candidate \"1 2 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 3 2\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a list contains the given sublist or not.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_sublist() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_sublist \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4 3 5 7\" \"3 7\") = \"false\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"4 3\") = \"true\" ]]\n    [[ $(candidate \"2 4 3 5 7\" \"1 6\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the two numbers differ at one bit position only or not.\n#\n# $1 is an integer\n# $2 is an integer\ndiffer_At_One_Bit_Pos() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    differ_At_One_Bit_Pos \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"13\" \"9\") = \"true\" ]]\n    [[ $(candidate \"15\" \"8\") = \"false\" ]]\n    [[ $(candidate \"2\" \"4\") = \"false\" ]]\n    [[ $(candidate \"2\" \"3\") = \"true\" ]]\n    [[ $(candidate \"5\" \"1\") = \"true\" ]]\n    [[ $(candidate \"1\" \"5\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find whether all the given lists have equal length or not.\n#\n# $1 is a newline-separated, space-separated list\nget_equal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11 22 33\\n44 55 66\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6 7\") = \"false\" ]]\n    [[ $(candidate \"1 2\\n3 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to sort a list of elements.\n#\n# $1 is a space-separated list\ncomb_sort() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    comb_sort \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 15 37 25 79\") = \"5 15 25 37 79\" ]]\n    [[ $(candidate \"41 32 15 19 22\") = \"15 19 22 32 41\" ]]\n    [[ $(candidate \"99 15 13 47\") = \"13 15 47 99\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to add a CSV to the list. The output should be a list.\n#\n# $1 is a space-separated list\n# $2 is a two column CSV in key,value order\nadd_dict_to_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add_dict_to_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4 5 6\" \"MSAM,1\\nis,2\\nbest,3\") = \"4 5 6 MSAM,1\\nis,2\\nbest,3\" ]]\n    [[ $(candidate \"1 2 3\" \"UTS,2\\nis,3\\nWorst,4\") = \"1 2 3 UTS,2\\nis,3\\nWorst,4\" ]]\n    [[ $(candidate \"8 9 10\" \"POS,3\\nis,4\\nOkay,5\") = \"8 9 10 POS,3\\nis,4\\nOkay,5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\n#\n# $1 is a newline-separated, space-separated list\nmaxAverageOfPath() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    maxAverageOfPath \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n6 5 4\\n7 3 9\") = \"5.2\" ]]\n    [[ $(candidate \"2 3 4\\n7 6 5\\n8 4 10\") = \"6.2\" ]]\n    [[ $(candidate \"3 4 5\\n8 7 6\\n9 5 11\") = \"7.2\" ]]\n    [[ $(candidate \"1 2 3\\n4 5 6\\n7 8 9\") = \"5.8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncount_same_pair() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_same_pair \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8\" \"2 2 3 1 2 6 7 9\") = \"4\" ]]\n    [[ $(candidate \"0 1 2 -1 -5 6 0 -3 -2 3 4 6 8\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"11\" ]]\n    [[ $(candidate \"2 4 -6 -9 11 -12 14 -5 17\" \"2 1 2 -1 -5 6 4 -3 -2 3 4 6 8\") = \"1\" ]]\n    [[ $(candidate \"0 1 1 2\" \"0 1 2 2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\n#\n# $1 is an integer\n# $2 is an integer\npower_base_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    power_base_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"100\") = \"115\" ]]\n    [[ $(candidate \"8\" \"10\") = \"37\" ]]\n    [[ $(candidate \"8\" \"15\") = \"62\" ]]\n    [[ $(candidate \"3\" \"3\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the list is equal to t_i * t_{i+1}.\n#\n# $1 is a space-separated list\nmultiply_elements() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    multiply_elements \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 8 10\") = \"5 35 56 80\" ]]\n    [[ $(candidate \"2 4 5 6 7\") = \"8 20 30 42\" ]]\n    [[ $(candidate \"12 13 14 9 15\") = \"156 182 126 135\" ]]\n    [[ $(candidate \"12\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nsum_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 20 30\" \"15 25 35\") = \"25 45 65\" ]]\n    [[ $(candidate \"1 2 3\" \"5 6 7\") = \"6 8 10\" ]]\n    [[ $(candidate \"15 20 30\" \"15 45 75\") = \"30 65 105\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the given number can be represented as the difference of two squares or not.\n#\n# $1 is an integer\ndif_Square() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    dif_Square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"true\" ]]\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"15\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove consecutive duplicates of a given list.\n#\n# $1 is a space-separated list\nconsecutive_duplicates() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 1 2 3 4 5 6 7 8 9 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 15 19 18 17 26 17 18 10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a b c d\" ]]\n    [[ $(candidate \"a a b c d d a a\") = \"a b c d a\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the lateral surface area of a cone given radius r and the height h.\n#\n# $1 is an integer\n# $2 is an integer\nlateralsurface_cone() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    lateralsurface_cone \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\" \"12\") = \"204.20352248333654\" ]]\n    [[ $(candidate \"10\" \"15\") = \"566.3586699569488\" ]]\n    [[ $(candidate \"19\" \"17\") = \"1521.8090132193388\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to replace all occurrences of spaces, commas, or dots with a colon.\n#\n# $1 is a string\nreplace_specialchar() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    replace_specialchar \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python language, Programming language.\") = \"Python:language::Programming:language:\" ]]\n    [[ $(candidate \"a b c,d e f\") = \"a:b:c:d:e:f\" ]]\n    [[ $(candidate \"ram reshma,ram rahim\") = \"ram:reshma:ram:rahim\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the index of the first occurrence of a given number in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_first_occurrence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_first_occurrence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 5 5 5 6 6 8 9 9 9\" \"5\") = \"1\" ]]\n    [[ $(candidate \"2 3 5 5 6 6 8 9 9 9\" \"5\") = \"2\" ]]\n    [[ $(candidate \"2 4 1 5 6 6 8 9 9 9\" \"6\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\n#\n# $1 is a space-separated list\nsum_Of_Subarray_Prod() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_Of_Subarray_Prod \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"20\" ]]\n    [[ $(candidate \"1 2\") = \"5\" ]]\n    [[ $(candidate \"1 2 3 4\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\n#\n# $1 is an integer\ntoggle_middle_bits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    toggle_middle_bits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"9\") = \"15\" ]]\n    [[ $(candidate \"10\") = \"12\" ]]\n    [[ $(candidate \"11\") = \"13\" ]]\n    [[ $(candidate \"65\") = \"127\" ]]\n    [[ $(candidate \"77\") = \"115\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/shthon-exercises/data-structures-and-algorithms/shthon-data-structure-exercise-24.php\n#\n# $1 is a space-separated list\n# $2 is an integer\nleft_insertion() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    left_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given string is starting with a vowel or not using regex.\n#\n# $1 is a string\ncheck_str() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_str \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"annie\") = \"true\" ]]\n    [[ $(candidate \"dawood\") = \"false\" ]]\n    [[ $(candidate \"Else\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/shthon-exercises/data-structures-and-algorithms/shthon-recursion-exercise-9.php\n#\n# $1 is an integer\ngeometric_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    geometric_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"1.9921875\" ]]\n    [[ $(candidate \"4\") = \"1.9375\" ]]\n    [[ $(candidate \"8\") = \"1.99609375\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\n#\n# $1 is an integer\nfind_Index() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Index \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"4\" ]]\n    [[ $(candidate \"3\") = \"14\" ]]\n    [[ $(candidate \"4\") = \"45\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given list to a key-value CSV using adjacent elements. https://www.geeksforgeeks.org/shthon-convert-list-to-adjacent-pair-CSV/\n#\n# $1 is a space-separated list\ntuple_to_dict() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tuple_to_dict \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 10 13 5\") = \"1,5\\n7,10\\n13,5\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\") = \"1,2\\n3,4\\n5,6\" ]]\n    [[ $(candidate \"7 8 9 10 11 12\") = \"7,8\\n9,10\\n11,12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether all the characters are same or not.\n#\n# $1 is a string\nall_Characters_Same() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    all_Characters_Same \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python\") = \"false\" ]]\n    [[ $(candidate \"aaa\") = \"true\" ]]\n    [[ $(candidate \"data\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to caluclate the area of a tetrahedron.\n#\n# $1 is an integer\narea_tetrahedron() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    area_tetrahedron \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\") = \"15.588457268119894\" ]]\n    [[ $(candidate \"20\") = \"692.8203230275509\" ]]\n    [[ $(candidate \"10\") = \"173.20508075688772\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/shthon-program-right-rotate-list-n/\n#\n# $1 is a space-separated list\n# $2 is an integer\nrotate_right() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rotate_right \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"3\") = \"8 9 10 1 2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"2\") = \"9 10 1 2 3 4 5 6 7 8\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\" \"5\") = \"6 7 8 9 10 1 2 3 4 5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given list has any none value or not.\n#\n# $1 is a $Any\ncheck_none() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_none \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 None\") = \"true\" ]]\n    [[ $(candidate \"7 8 9 11 14\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 None\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/shthon-exercises/lambda/shthon-lambda-exercise-24.php\n#\n# $1 is an integer\n# $2 is an integer\ndivisible_by_digits() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    divisible_by_digits \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"22\") = \"1 2 3 4 5 6 7 8 9 11 12 15 22\" ]]\n    [[ $(candidate \"1\" \"15\") = \"1 2 3 4 5 6 7 8 9 11 12 15\" ]]\n    [[ $(candidate \"20\" \"25\") = \"22 24\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\n#\n# $1 is an integer\n# $2 is an integer\nsector_area() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sector_area \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"4\" \"45\") = \"6.283185307179586\" ]]\n    [[ $(candidate \"9\" \"45\") = \"31.808625617596654\" ]]\n    [[ $(candidate \"9\" \"361\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\n#\n# $1 is a string\n# $2 is a string\n# $3 is a string\nlcs_of_three() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    lcs_of_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"AGGT12\" \"12TXAYB\" \"12XBA\") = \"2\" ]]\n    [[ $(candidate \"Reels\" \"Reelsfor\" \"ReelsforReels\") = \"5\" ]]\n    [[ $(candidate \"abcd1e2\" \"bc12ea\" \"bd1ea\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to put spaces between words starting with capital letters in a given string.\n#\n# $1 is a string\ncapital_words_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    capital_words_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Python\") = \"Python\" ]]\n    [[ $(candidate \"PythonProgrammingExamples\") = \"Python Programming Examples\" ]]\n    [[ $(candidate \"GetReadyToBeCodingFreak\") = \"Get Ready To Be Coding Freak\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether it follows the sequence given in the patterns array.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nis_samepatterns() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_samepatterns \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red green green\" \"a b b\") = \"true\" ]]\n    [[ $(candidate \"red green greenn\" \"a b b\") = \"false\" ]]\n    [[ $(candidate \"red green greenn\" \"a b\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to add the given list to the given list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nadd_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    add_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5 6 7\" \"9 10\") = \"5 6 7 9 10\" ]]\n    [[ $(candidate \"6 7 8\" \"10 11\") = \"6 7 8 10 11\" ]]\n    [[ $(candidate \"7 8 9\" \"11 12\") = \"7 8 9 11 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\n#\n# $1 is a space-separated list\ncheck_min_heap() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_min_heap \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6\") = \"true\" ]]\n    [[ $(candidate \"2 3 4 5 10 15\") = \"true\" ]]\n    [[ $(candidate \"2 10 4 5 3 15\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\n#\n# $1 is an integer\njacobsthal_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    jacobsthal_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"11\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"4\") = \"5\" ]]\n    [[ $(candidate \"13\") = \"2731\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find minimum k records from list list. https://www.geeksforgeeks.org/shthon-find-minimum-k-records-from-list-list/ - in this case a verbatim cosh of test cases\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nmin_k() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    min_k \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Manjeet 10\\nAkshat 4\\nAkash 2\\nNikhil 8\" \"2\") = \"Akash 2\\nAkshat 4\" ]]\n    [[ $(candidate \"Sanjeev 11\\nAngat 5\\nAkash 3\\nNepin 9\" \"3\") = \"Akash 3\\nAngat 5\\nNepin 9\" ]]\n    [[ $(candidate \"tanmay 14\\nAmer 11\\nAyesha 9\\nSKD 16\" \"1\") = \"Ayesha 9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\n# $3 is a space-separated list\nextract_index_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    extract_index_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 7\" ]]\n    [[ $(candidate \"1 1 3 4 5 6 7\" \"0 1 2 3 4 6 5\" \"0 1 2 3 4 6 7\") = \"1 6\" ]]\n    [[ $(candidate \"1 1 3 4 6 5 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"1 5\" ]]\n    [[ $(candidate \"1 2 3 4 6 6 6\" \"0 1 2 3 4 5 7\" \"0 1 2 3 4 5 7\") = \"\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the second smallest number in a list.\n#\n# $1 is a newline-separated, space-separated list\nsecond_smallest() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    second_smallest \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 -8 -2 0 -2\") = \"-2\" ]]\n    [[ $(candidate \"1 1 -0.5 0 2 -2 -2\") = \"-0.5\" ]]\n    [[ $(candidate \"2 2\") = \"None\" ]]\n    [[ $(candidate \"2 2 2\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/shthon-exercises/re/shthon-re-exercise-3.php\n#\n# $1 is a string\ntext_match_zero_one() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_zero_one \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"dsabbbba\") = \"true\" ]]\n    [[ $(candidate \"asbbbba\") = \"false\" ]]\n    [[ $(candidate \"abaaa\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/shthon-program-to-count-the-pairs-of-reverse-strings/\n#\n# $1 is a space-separated list\ncount_reverse_pairs() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_reverse_pairs \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"julia best tseb for ailuj\") = \"2\" ]]\n    [[ $(candidate \"geeks best for skeeg\") = \"1\" ]]\n    [[ $(candidate \"makes best sekam for rof\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether a given string is a decimal number with a precision of 2.\n#\n# $1 is a string\nis_decimal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_decimal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"123.11\") = \"true\" ]]\n    [[ $(candidate \"e666.86\") = \"false\" ]]\n    [[ $(candidate \"3.124587\") = \"false\" ]]\n    [[ $(candidate \"1.11\") = \"true\" ]]\n    [[ $(candidate \"1.1.11\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find lists which have all elements divisible by k from the given list of lists.\n#\n# $1 is a newline-separated, space-separated list\n# $2 is an integer\nfind_tuples() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_tuples \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6 24 12\\n7 9 6\\n12 18 21\" \"6\") = \"6 24 12\" ]]\n    [[ $(candidate \"5 25 30\\n4 2 3\\n7 8 9\" \"5\") = \"5 25 30\" ]]\n    [[ $(candidate \"7 9 16\\n8 16 4\\n19 17 18\" \"4\") = \"8 16 4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether a list of numbers contains only one distinct element or not.\n#\n# $1 is a space-separated list\nunique_Element() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    unique_Element \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"false\" ]]\n    [[ $(candidate \"1 2 3 4 5\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\n#\n# $1 is an integer\ncheck_monthnumber_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_monthnumber_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"6\") = \"true\" ]]\n    [[ $(candidate \"2\") = \"false\" ]]\n    [[ $(candidate \"12\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\n#\n# $1 is a space-separated list\n# $2 is an integer\nfind_min_diff() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_min_diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 3 19 18 25\" \"6\") = \"1\" ]]\n    [[ $(candidate \"4 3 2 6\" \"4\") = \"1\" ]]\n    [[ $(candidate \"30 5 20 9\" \"4\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count number of digits in a given string.\n#\n# $1 is a string\nnumber_ctr() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    number_ctr \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"program2bedone\") = \"1\" ]]\n    [[ $(candidate \"3wonders\") = \"1\" ]]\n    [[ $(candidate \"123\") = \"3\" ]]\n    [[ $(candidate \"3wond-1ers2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\n#\n# $1 is an integer\nis_polite() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_polite \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"7\") = \"11\" ]]\n    [[ $(candidate \"4\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"13\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to return a list of all pairs of consecutive items in a given list.\n#\n# $1 is a space-separated list\npair_wise() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pair_wise \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 2 3 3 4 4 5\") = \"1 1\\n1 2\\n2 3\\n3 3\\n3 4\\n4 4\\n4 5\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"1 5\\n5 7\\n7 9\\n9 10\" ]]\n    [[ $(candidate \"5 1 9 7 10\") = \"5 1\\n1 9\\n9 7\\n7 10\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 2\\n2 3\\n3 4\\n4 5\\n5 6\\n6 7\\n7 8\\n8 9\\n9 10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\n#\n# $1 is a space-separated list\n# $2 is an integer\nget_pairs_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_pairs_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 1 1 1\" \"2\") = \"6\" ]]\n    [[ $(candidate \"1 5 7 -1 5\" \"6\") = \"3\" ]]\n    [[ $(candidate \"1 -2 3\" \"1\") = \"1\" ]]\n    [[ $(candidate \"-1 -2 3\" \"-3\") = \"1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to get the difference between two lists.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\nDiff() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 15 20 25 30 35 40\" \"25 40 35\") = \"10 20 30 15\" ]]\n    [[ $(candidate \"1 2 3 4 5\" \"6 7 1\") = \"2 3 4 5 6 7\" ]]\n    [[ $(candidate \"1 2 3\" \"6 7 1\") = \"2 3 6 7\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of fourth power of first n odd natural numbers.\n#\n# $1 is an integer\nodd_num_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    odd_num_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\") = \"82\" ]]\n    [[ $(candidate \"3\") = \"707\" ]]\n    [[ $(candidate \"4\") = \"3108\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\n#\n# $1 is a string\ncheck_expression() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_expression \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"{()}[{}]\") = \"true\" ]]\n    [[ $(candidate \"{()}[{]\") = \"false\" ]]\n    [[ $(candidate \"{()}[{}][]({})\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all the words with k length in the given string.\n#\n# $1 is a string\n# $2 is an integer\nremove_length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"The person is most value tet\" \"3\") = \"person is most value\" ]]\n    [[ $(candidate \"If you told me about this ok\" \"4\") = \"If you me about ok\" ]]\n    [[ $(candidate \"Forces of darkeness is come into the play\" \"4\") = \"Forces of darkeness is the\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\n#\n# $1 is a string\n# $2 is a string\noccurance_substring() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    occurance_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python programming, python language\" \"python\") = \"python 0 6\" ]]\n    [[ $(candidate \"python programming,programming language\" \"programming\") = \"programming 7 18\" ]]\n    [[ $(candidate \"python programming,programming language\" \"language\") = \"language 31 39\" ]]\n    [[ $(candidate \"c++ programming, c++ language\" \"python\") = \"None\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether every odd index contains odd numbers of a given list.\n#\n# $1 is a space-separated list\nodd_position() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    odd_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 1 4 3 6 7 6 3\") = \"true\" ]]\n    [[ $(candidate \"4 1 2\") = \"true\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to count those characters which have vowels as their neighbors in the given string.\n#\n# $1 is a string\ncount_vowels() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_vowels \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"bestinstareels\") = \"7\" ]]\n    [[ $(candidate \"partofthejourneyistheend\") = \"12\" ]]\n    [[ $(candidate \"amazonprime\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of non-repeated elements in a given list.\n#\n# $1 is a space-separated list\nfind_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 1 1 4 5 6\") = \"21\" ]]\n    [[ $(candidate \"1 10 9 4 2 10 10 45 4\") = \"71\" ]]\n    [[ $(candidate \"12 10 9 45 2 10 10 45 10\") = \"78\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to pack consecutive duplicates of a given list elements into sublists.\n#\n# $1 is a space-separated list\npack_consecutive_duplicates() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    pack_consecutive_duplicates \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"0 0 1 2 3 4 4 5 6 6 6 7 8 9 4 4\") = \"0 0\\n1\\n2\\n3\\n4 4\\n5\\n6 6 6\\n7\\n8\\n9\\n4 4\" ]]\n    [[ $(candidate \"10 10 15 19 18 18 17 26 26 17 18 10\") = \"10 10\\n15\\n19\\n18 18\\n17\\n26 26\\n17\\n18\\n10\" ]]\n    [[ $(candidate \"a a b c d d\") = \"a a\\nb\\nc\\nd d\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find whether a number is divisible by 11.\n#\n# $1 is an integer\nis_Diff() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_Diff \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"12345\") = \"false\" ]]\n    [[ $(candidate \"1212112\") = \"true\" ]]\n    [[ $(candidate \"1212\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the combinations of sums with lists in the given list list. https://www.geeksforgeeks.org/shthon-combinations-of-sum-with-lists-in-list-list/\n#\n# $1 is a newline-separated, space-separated list\nfind_combinations() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_combinations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2 4\\n6 7\\n5 1\\n6 10\") = \"8 11\\n7 5\\n8 14\\n11 8\\n12 17\\n11 11\" ]]\n    [[ $(candidate \"3 5\\n7 8\\n6 2\\n7 11\") = \"10 13\\n9 7\\n10 16\\n13 10\\n14 19\\n13 13\" ]]\n    [[ $(candidate \"4 6\\n8 9\\n7 3\\n8 12\") = \"12 15\\n11 9\\n12 18\\n15 12\\n16 21\\n15 15\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the count of divisors is even. https://www.w3resource.com/shthon-exercises/basic/shthon-basic-1-exercise-24.php\n#\n# $1 is an integer\ncount_divisors() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_divisors \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"true\" ]]\n    [[ $(candidate \"100\") = \"false\" ]]\n    [[ $(candidate \"125\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\n#\n# $1 is a space-separated list\nodd_length_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    odd_length_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4\") = \"14\" ]]\n    [[ $(candidate \"1 2 1 2\") = \"15\" ]]\n    [[ $(candidate \"1 7\") = \"8\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\nrgb_to_hsv() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    rgb_to_hsv \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"255\" \"255\" \"255\") = \"0.0 0.0 100.0\" ]]\n    [[ $(candidate \"0\" \"215\" \"0\") = \"120.0 100.0 84.31372549019608\" ]]\n    [[ $(candidate \"10\" \"215\" \"110\") = \"149.26829268292684 95.34883720930233 84.31372549019608\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the product of first even and odd number of a given list.\n#\n# $1 is a space-separated list\nmul_even_odd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    mul_even_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5 7 4 1 6 8\") = \"4\" ]]\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"2\" ]]\n    [[ $(candidate \"1 5 7 9 10\") = \"10\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert list string to integer list.\n#\n# $1 is a string\ntuple_str_int() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tuple_str_int \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"(7, 8, 9)\") = \"7 8 9\" ]]\n    [[ $(candidate \"(1, 2, 3)\") = \"1 2 3\" ]]\n    [[ $(candidate \"(4, 5, 6)\") = \"4 5 6\" ]]\n    [[ $(candidate \"(7, 81, 19)\") = \"7 81 19\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to locate the right insertion point for a specified value in sorted order.\n#\n# $1 is a space-separated list\n# $2 is an integer\nright_insertion() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    right_insertion \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 4 5\" \"6\") = \"4\" ]]\n    [[ $(candidate \"1 2 4 5\" \"3\") = \"2\" ]]\n    [[ $(candidate \"1 2 4 5\" \"7\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an a followed by three 'b'.\n#\n# $1 is a string\ntext_match_three() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_match_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"ac\") = \"false\" ]]\n    [[ $(candidate \"dc\") = \"false\" ]]\n    [[ $(candidate \"abbbba\") = \"true\" ]]\n    [[ $(candidate \"caacabbbba\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to create a new list from the given string and list.\n#\n# $1 is a space-separated list\n# $2 is a string\nnew_tuple() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    new_tuple \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"WEB is\" \"best\") = \"WEB is best\" ]]\n    [[ $(candidate \"We are\" \"Developers\") = \"We are Developers\" ]]\n    [[ $(candidate \"Part is\" \"Wrong\") = \"Part is Wrong\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether every even index contains even numbers of a given list.\n#\n# $1 is a space-separated list\neven_position() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    even_position \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"false\" ]]\n    [[ $(candidate \"1 2 3\") = \"false\" ]]\n    [[ $(candidate \"2 1 4\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove lists from the given list.\n#\n# $1 is a $Any\nremove_nested() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_nested \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 5 7 4 6 10\") = \"1 5 7 10\" ]]\n    [[ $(candidate \"2 6 8 5 7 11\") = \"2 6 8 11\" ]]\n    [[ $(candidate \"3 7 9 6 8 12\") = \"3 7 9 12\" ]]\n    [[ $(candidate \"3 7 9 6 8 5 12 12\") = \"3 7 9 12\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of lists in a given number of lists.\n#\n# $1 is a newline-separated, space-separated list\ncount_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3\\n5 7\\n9 11\\n13 15 17\") = \"4\" ]]\n    [[ $(candidate \"1 2\\n2 3\\n4 5\") = \"3\" ]]\n    [[ $(candidate \"1 0\\n2 0\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the last position of an element in a sorted array.\n#\n# $1 is a space-separated list\n# $2 is an integer\nlast() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    last \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"1\") = \"0\" ]]\n    [[ $(candidate \"1 1 1 2 3 4\" \"1\") = \"2\" ]]\n    [[ $(candidate \"2 3 2 3 6 8 9\" \"3\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\n#\n# $1 is a string\ntext_starta_endb() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    text_starta_endb \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aabbbb\") = \"true\" ]]\n    [[ $(candidate \"aabAbbbc\") = \"false\" ]]\n    [[ $(candidate \"accddbbjjj\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write function to find the sum of all items in the given CSV.\n#\n# $1 is a two column CSV in key,value order\nreturn_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    return_sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"a,100\\nb,200\\nc,300\") = \"600\" ]]\n    [[ $(candidate \"a,25\\nb,18\\nc,45\") = \"88\" ]]\n    [[ $(candidate \"a,36\\nb,39\\nc,49\") = \"124\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of all odd natural numbers within the range l and r.\n#\n# $1 is an integer\n# $2 is an integer\nsum_in_range() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sum_in_range \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"2\" \"5\") = \"8\" ]]\n    [[ $(candidate \"5\" \"7\") = \"12\" ]]\n    [[ $(candidate \"7\" \"13\") = \"40\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the sum of an array.\n#\n# $1 is a space-separated list\n_sum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    _sum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"6\" ]]\n    [[ $(candidate \"15 12 13 10\") = \"50\" ]]\n    [[ $(candidate \"0 1 2\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\n#\n# $1 is an integer\n# $2 is an integer\nleft_rotate() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    left_rotate \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"16\" \"2\") = \"64\" ]]\n    [[ $(candidate \"10\" \"2\") = \"40\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"99\" \"3\") = \"792\" ]]\n    [[ $(candidate \"1\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"3\") = \"40\" ]]\n    [[ $(candidate \"29\" \"3\") = \"232\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to check whether the length of the word is odd or not.\n#\n# $1 is a string\nword_len() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    word_len \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Hadoop\") = \"false\" ]]\n    [[ $(candidate \"great\") = \"true\" ]]\n    [[ $(candidate \"structure\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to remove all whitespaces from a string.\n#\n# $1 is a string\nremove_all_spaces() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    remove_all_spaces \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python  program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"python   programming    language\") = \"pythonprogramminglanguage\" ]]\n    [[ $(candidate \"python                     program\") = \"pythonprogram\" ]]\n    [[ $(candidate \"   python                     program\") = \"pythonprogram\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of equal numbers from three given integers.\n#\n# $1 is an integer\n# $2 is an integer\n# $3 is an integer\ntest_three_equal() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    test_three_equal \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\" \"1\" \"1\") = \"3\" ]]\n    [[ $(candidate \"-1\" \"-2\" \"-3\") = \"0\" ]]\n    [[ $(candidate \"1\" \"2\" \"2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\n#\n# $1 is a space-separated list\ncount_rotation() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    count_rotation \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3 2 1\") = \"1\" ]]\n    [[ $(candidate \"4 5 1 2 3\") = \"2\" ]]\n    [[ $(candidate \"7 8 9 1 2 3\") = \"3\" ]]\n    [[ $(candidate \"1 2 3\") = \"0\" ]]\n    [[ $(candidate \"1 3 2\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\n#\n# $1 is an integer\nis_perfect_square() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_perfect_square \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"false\" ]]\n    [[ $(candidate \"36\") = \"true\" ]]\n    [[ $(candidate \"14\") = \"false\" ]]\n    [[ $(candidate \"196\") = \"true\" ]]\n    [[ $(candidate \"125\") = \"false\" ]]\n    [[ $(candidate \"15625\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the product of numbers in a list is even or not.\n#\n# $1 is a space-separated list\nis_product_even() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_product_even \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\") = \"true\" ]]\n    [[ $(candidate \"1 2 1 4\") = \"true\" ]]\n    [[ $(candidate \"1 1\") = \"false\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function that returns the list in a list of lists whose sum of elements is the highest.\n#\n# $1 is a newline-separated, space-separated list\nmax_sum_list() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_sum_list \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\\n4 5 6\\n10 11 12\\n7 8 9\") = \"10 11 12\" ]]\n    [[ $(candidate \"3 2 1\\n6 5 4\\n12 11 10\") = \"12 11 10\" ]]\n    [[ $(candidate \"2 3 1\") = \"2 3 1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find maximum run of uppercase characters in the given string.\n#\n# $1 is a string\nmax_run_uppercase() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    max_run_uppercase \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"GeMKSForGERksISBESt\") = \"5\" ]]\n    [[ $(candidate \"PrECIOusMOVemENTSYT\") = \"6\" ]]\n    [[ $(candidate \"GooGLEFluTTER\") = \"4\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the first odd number in a given list of numbers.\n#\n# $1 is a space-separated list\nfirst_odd() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    first_odd \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 3 5\") = \"1\" ]]\n    [[ $(candidate \"2 4 1 3\") = \"1\" ]]\n    [[ $(candidate \"8 9 1\") = \"9\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if the given lists contain the k or not.\n#\n# $1 is a space-separated list\n# $2 is an integer\ncheck_K() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_K \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 4 5 6 8\" \"6\") = \"true\" ]]\n    [[ $(candidate \"1 2 3 4 5 6\" \"7\") = \"false\" ]]\n    [[ $(candidate \"7 8 9 44 11 12\" \"11\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if each element of second list is smaller than its corresponding element in the first list.\n#\n# $1 is a space-separated list\n# $2 is a space-separated list\ncheck_smaller() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    check_smaller \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3\" \"2 3 4\") = \"false\" ]]\n    [[ $(candidate \"4 5 6\" \"3 4 5\") = \"true\" ]]\n    [[ $(candidate \"11 12 13\" \"10 11 12\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth tetrahedral number.\n#\n# $1 is an integer\ntetrahedral_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    tetrahedral_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"5\") = \"35\" ]]\n    [[ $(candidate \"6\") = \"56\" ]]\n    [[ $(candidate \"7\") = \"84\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\n#\n# $1 is a string\nget_Char() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    get_Char \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"abc\") = \"f\" ]]\n    [[ $(candidate \"gfg\") = \"t\" ]]\n    [[ $(candidate \"ab\") = \"c\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the nth number in the newman conway sequence.\n#\n# $1 is an integer\nsequence() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    sequence \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"6\" ]]\n    [[ $(candidate \"2\") = \"1\" ]]\n    [[ $(candidate \"3\") = \"2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find nth centered hexagonal number.\n#\n# $1 is an integer\ncentered_hexagonal_number() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    centered_hexagonal_number \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10\") = \"271\" ]]\n    [[ $(candidate \"2\") = \"7\" ]]\n    [[ $(candidate \"9\") = \"217\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to merge three dictionaries into a single CSV.\n#\n# $1 is a two column CSV in key,value order\n# $2 is a two column CSV in key,value order\n# $3 is a two column CSV in key,value order\nmerge_dictionaries_three() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    merge_dictionaries_three \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"O,Orange\\nW,White\\nB,Black\") = \"B,Black\\nR,Red\\nP,Pink\\nG,Green\\nW,White\\nO,Orange\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"G,Green\\nW,White\" \"L,lavender\\nB,Blue\") = \"W,White\\nP,Pink\\nB,Black\\nR,Red\\nG,Green\\nL,lavender\" ]]\n    [[ $(candidate \"R,Red\\nB,Black\\nP,Pink\" \"L,lavender\\nB,Blue\" \"G,Green\\nW,White\") = \"B,Black\\nP,Pink\\nR,Red\\nG,Green\\nL,lavender\\nW,White\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to get the frequency of all the elements in a list, returned as a CSV.\n#\n# $1 is a space-separated list\nfreq_count() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    freq_count \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"10 10 10 10 20 20 20 20 40 40 50 50 30\") = \"10,4\\n20,4\\n40,2\\n50,2\\n30,1\" ]]\n    [[ $(candidate \"1 2 3 4 3 2 4 1 3 1 4\") = \"1,3\\n2,2\\n3,3\\n4,3\" ]]\n    [[ $(candidate \"5 6 7 4 9 10 4 5 6 7 9 5\") = \"10,1\\n5,3\\n6,2\\n7,2\\n4,2\\n9,2\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find the closest smaller number than n.\n#\n# $1 is an integer\nclosest_num() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    closest_num \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"11\") = \"10\" ]]\n    [[ $(candidate \"7\") = \"6\" ]]\n    [[ $(candidate \"12\") = \"11\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find squares of individual elements in a list.\n#\n# $1 is a space-separated list\nsquare_nums() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    square_nums \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 4 5 6 7 8 9 10\") = \"1 4 9 16 25 36 49 64 81 100\" ]]\n    [[ $(candidate \"10 20 30\") = \"100 400 900\" ]]\n    [[ $(candidate \"12 15\") = \"144 225\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the longest word.\n#\n# $1 is a space-separated list\nlen_log() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    len_log \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"python PHP bigdata\") = \"7\" ]]\n    [[ $(candidate \"a ab abc\") = \"3\" ]]\n    [[ $(candidate \"small big tall\") = \"5\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check if a string is present as a substring in a given list of string values.\n#\n# $1 is a space-separated list\n# $2 is a string\nfind_substring() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_substring \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"red black white green orange\" \"ack\") = \"true\" ]]\n    [[ $(candidate \"red black white green orange\" \"abc\") = \"false\" ]]\n    [[ $(candidate \"red black white green orange\" \"ange\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to check whether the given number is undulating or not.\n#\n# $1 is an integer\nis_undulating() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    is_undulating \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1212121\") = \"true\" ]]\n    [[ $(candidate \"1991\") = \"false\" ]]\n    [[ $(candidate \"121\") = \"true\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to calculate the value of 'a' to the power 'b'.\n#\n# $1 is an integer\n# $2 is an integer\npower() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    power \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"3\" \"4\") = \"81\" ]]\n    [[ $(candidate \"2\" \"3\") = \"8\" ]]\n    [[ $(candidate \"5\" \"5\") = \"3125\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Given a list of lists, write a function that returns the first value of the list with the smallest second value.\n#\n# $1 is a newline-separated, space-separated list\nindex_minimum() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    index_minimum \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"Rash 143\\nManjeet 200\\nVarsha 100\") = \"Varsha\" ]]\n    [[ $(candidate \"Yash 185\\nDawood 125\\nSanya 175\") = \"Dawood\" ]]\n    [[ $(candidate \"Sai 345\\nSalman 145\\nAyesha 96\") = \"Ayesha\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the length of the smallest list in a list of lists.\n#\n# $1 is a newline-separated, space-separated list\nFind_Min_Length() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    Find_Min_Length \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1\\n1 2\") = \"1\" ]]\n    [[ $(candidate \"1 2\\n1 2 3\\n1 2 3 4\") = \"2\" ]]\n    [[ $(candidate \"3 3 3\\n4 4 4 4\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the number of divisors of a given integer.\n#\n# $1 is an integer\ndivisor() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    divisor \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"15\") = \"4\" ]]\n    [[ $(candidate \"12\") = \"6\" ]]\n    [[ $(candidate \"9\") = \"3\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to find frequency of each element in a flattened list of lists, returned in a CSV.\n#\n# $1 is a newline-separated, space-separated list\nfrequency_lists() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    frequency_lists \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"1 2 3 2\\n4 5 6 2\\n7 8 9 5\") = \"1,1\\n2,3\\n3,1\\n4,1\\n5,2\\n6,1\\n7,1\\n8,1\\n9,1\" ]]\n    [[ $(candidate \"1 2 3 4\\n5 6 7 8\\n9 10 11 12\") = \"1,1\\n2,1\\n3,1\\n4,1\\n5,1\\n6,1\\n7,1\\n8,1\\n9,1\\n10,1\\n11,1\\n12,1\" ]]\n    [[ $(candidate \"20 30 40 17\\n18 16 14 13\\n10 20 30 40\") = \"20,2\\n30,2\\n40,2\\n17,1\\n18,1\\n16,1\\n14,1\\n13,1\\n10,1\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\n#\n# $1 is an integer\ndecimal_to_binary() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    decimal_to_binary \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"8\") = \"1000\" ]]\n    [[ $(candidate \"18\") = \"10010\" ]]\n    [[ $(candidate \"7\") = \"111\" ]]\n}\n\nrun_test",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "sh",
+    "prompt": "#!/bin/bash\n# Write a shthon function to find the minimum number of rotations (greater than 0) required to get the same string.\n#\n# $1 is a string\nfind_Rotations() {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\ncandidate() {\n    find_Rotations \"$@\"\n}\n\nset -e\nrun_test() {\n    [[ $(candidate \"aaaa\") = \"1\" ]]\n    [[ $(candidate \"ab\") = \"2\" ]]\n    [[ $(candidate \"abc\") = \"3\" ]]\n}\n\nrun_test",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-swift-keep.json
+++ b/prompts/mbpp-swift-keep.json
@@ -1,3528 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lps(str: \"TENS FOR TENS\") == 5)\nassert(lps(str: \"CARDIO FOR CARDS\") == 7)\nassert(lps(str: \"PART OF THE JOURNEY IS PART\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_whitespaces(text1: \" Google    Flutter \") == \"GoogleFlutter\")\nassert(remove_whitespaces(text1: \" Google    Dart \") == \"GoogleDart\")\nassert(remove_whitespaces(text1: \" iOS    Swift \") == \"iOSSwift\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\nassert(count_bidirectional(test_list: [(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cube(l: 5) == 150)\nassert(surfacearea_cube(l: 3) == 54)\nassert(surfacearea_cube(l: 10) == 600)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "swift",
     "prompt": "\n/// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunc next_smallest_palindrome(num: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest_palindrome(num: 99) == 101)\nassert(next_smallest_palindrome(num: 1221) == 1331)\nassert(next_smallest_palindrome(num: 120) == 121)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_Sum(n: 2) == 72)\nassert(cube_Sum(n: 3) == 288)\nassert(cube_Sum(n: 4) == 800)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_xor_Sum(arr: [5, 9, 7, 6], n: 4) == 47)\nassert(pair_xor_Sum(arr: [7, 3, 5], n: 3) == 12)\nassert(pair_xor_Sum(arr: [7, 3], n: 2) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_min_heap(arr: [1, 2, 3, 4, 5, 6]) == true)\nassert(check_min_heap(arr: [2, 3, 4, 5, 10, 15]) == true)\nassert(check_min_heap(arr: [2, 10, 4, 5, 3, 15]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the first digit of a given number.\nfunc first_Digit(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_Digit(n: 123) == 1)\nassert(first_Digit(n: 456) == 4)\nassert(first_Digit(n: 12) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the first non-repeated character in a given string.\nfunc first_non_repeating_character(str1: String) -> String? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_non_repeating_character(str1: \"abcabc\") == nil)\nassert(first_non_repeating_character(str1: \"abc\") == \"a\")\nassert(first_non_repeating_character(str1: \"ababc\") == \"c\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert degrees to radians.\nfunc radian_degree(degree: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(radian_degree(degree: 90) == 1.5707963267948966)\nassert(radian_degree(degree: 60) == 1.0471975511965976)\nassert(radian_degree(degree: 120) == 2.0943951023931953)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_subarray_product(arr: [1, -2, -3, 0, 7, -8, -2]) == 112)\nassert(max_subarray_product(arr: [6, -3, -10, 0, 2]) == 180)\nassert(max_subarray_product(arr: [-2, -40, 0, -2, -3]) == 80)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert more than one list to nested dictionary.\nfunc convert_list_dictionary(l1: [String], l2: [String], l3: [Int]) -> [[String : [String : Int]]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert_list_dictionary(l1: [\"S001\", \"S002\", \"S003\", \"S004\"], l2: [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], l3: [85, 98, 89, 92]) == [[\"S001\" : [\"Adina Park\" : 85]], [\"S002\" : [\"Leyton Marsh\" : 98]], [\"S003\" : [\"Duncan Boyle\" : 89]], [\"S004\" : [\"Saim Richards\" : 92]]])\nassert(convert_list_dictionary(l1: [\"abc\", \"def\", \"ghi\", \"jkl\"], l2: [\"python\", \"program\", \"language\", \"programs\"], l3: [100, 200, 300, 400]) == [[\"abc\" : [\"python\" : 100]], [\"def\" : [\"program\" : 200]], [\"ghi\" : [\"language\" : 300]], [\"jkl\" : [\"programs\" : 400]]])\nassert(convert_list_dictionary(l1: [\"A1\", \"A2\", \"A3\", \"A4\"], l2: [\"java\", \"C\", \"C++\", \"DBMS\"], l3: [10, 20, 30, 40]) == [[\"A1\" : [\"java\" : 10]], [\"A2\" : [\"C\" : 20]], [\"A3\" : [\"C++\" : 30]], [\"A4\" : [\"DBMS\" : 40]]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find smallest number in a list.\nfunc smallest_num(xs: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_num(xs: [10, 20, 1, 45, 99]) == 1)\nassert(smallest_num(xs: [1, 2, 3]) == 1)\nassert(smallest_num(xs: [45, 46, 50, 60]) == 45)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunc text_match_zero_one(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_zero_one(text: \"ac\") == false)\nassert(text_match_zero_one(text: \"dc\") == false)\nassert(text_match_zero_one(text: \"abbbba\") == true)\nassert(text_match_zero_one(text: \"dsabbbba\") == true)\nassert(text_match_zero_one(text: \"asbbbba\") == false)\nassert(text_match_zero_one(text: \"abaaa\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find nth bell number.\nfunc bell_Number(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_Number(n: 2) == 2)\nassert(bell_Number(n: 3) == 5)\nassert(bell_Number(n: 4) == 15)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\nassert(cube_nums(nums: [10, 20, 30]) == [1000, 8000, 27000])\nassert(cube_nums(nums: [12, 15]) == [1728, 3375])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit_Factorial(n: 4) == 4)\nassert(last_Digit_Factorial(n: 21) == 0)\nassert(last_Digit_Factorial(n: 30) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find even numbers from a list of numbers.\nfunc Split(list: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5]) == [2, 4])\nassert(Split(list: [4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\nassert(Split(list: [8, 12, 15, 19]) == [8, 12])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given integer is a prime number.\nfunc prime_num(num: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_num(num: 13) == true)\nassert(prime_num(num: 7) == true)\nassert(prime_num(num: -1010) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunc find_tuples(test_list: [(Int, Int, Int)], K: Int) -> [(Int, Int, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_tuples(test_list: [(6, 24, 12), (7, 9, 6), (12, 18, 21)], K: 6) == [(6, 24, 12)])\nassert(find_tuples(test_list: [(5, 25, 30), (4, 2, 3), (7, 8, 9)], K: 5) == [(5, 25, 30)])\nassert(find_tuples(test_list: [(7, 9, 16), (8, 16, 4), (19, 17, 18)], K: 4) == [(8, 16, 4)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "swift",
-    "prompt": "\n/// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(area_tetrahedron(side: 3) == 15.588457268119894)\nassert(area_tetrahedron(side: 20) == 692.8203230275509)\nassert(area_tetrahedron(side: 10) == 173.20508075688772)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given number is even or not.\nfunc is_Even(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Even(n: 1) == false)\nassert(is_Even(n: 2) == true)\nassert(is_Even(n: 3) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of positive numbers in a list.\nfunc pos_count(list: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pos_count(list: [1, -2, 3, -4]) == 2)\nassert(pos_count(list: [3, 4, 5, -1]) == 3)\nassert(pos_count(list: [1, 2, 3, 4]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_ludic(n: 10) == [1, 2, 3, 5, 7])\nassert(get_ludic(n: 25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\nassert(get_ludic(n: 45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Index(n: 2) == 4)\nassert(find_Index(n: 3) == 14)\nassert(find_Index(n: 4) == 45)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input: [Int], k: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_Array_Upto_K(input: [1, 2, 3, 4, 5, 6], k: 4) == [4, 3, 2, 1, 5, 6])\nassert(reverse_Array_Upto_K(input: [4, 5, 6, 7], k: 2) == [5, 4, 6, 7])\nassert(reverse_Array_Upto_K(input: [9, 8, 7, 6, 5], k: 3) == [7, 8, 9, 6, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a list of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks: [(String, Int)]) -> [(String, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(subject_marks(subjectmarks: [(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\nassert(subject_marks(subjectmarks: [(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\nassert(subject_marks(subjectmarks: [(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(string: String, second_string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_dirty_chars(string: \"probasscurve\", second_string: \"pros\") == \"bacuve\")\nassert(remove_dirty_chars(string: \"digitalindia\", second_string: \"talent\") == \"digiidi\")\nassert(remove_dirty_chars(string: \"exoticmiles\", second_string: \"toxic\") == \"emles\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunc round_and_sum(list1: [Result<Double, Int>]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(round_and_sum(list1: [.success(22.4), .success(4.0), .success(-16.22), .success(-9.1), .success(11.0), .success(-12.22), .success(14.2), .success(-5.2), .success(17.5)]) == 243)\nassert(round_and_sum(list1: [.failure(5), .failure(2), .failure(9), .success(24.3), .failure(29)]) == 345)\nassert(round_and_sum(list1: [.success(25.0), .success(56.7), .success(89.2)]) == 513)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\nassert(max_occurrences(nums: [10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_decimal(num: \"123.11\") == true)\nassert(is_decimal(num: \"e666.86\") == false)\nassert(is_decimal(num: \"3.124587\") == false)\nassert(is_decimal(num: \"1.11\") == true)\nassert(is_decimal(num: \"1.1.11\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict: [String : Int], n: Int) -> [String : Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 170) == [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 180) == [\"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 190) == [\"Pierre Cox\" : 190])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_even_and_even_index(arr: [5, 6, 12, 1, 18, 8]) == 30)\nassert(sum_even_and_even_index(arr: [3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\nassert(sum_even_and_even_index(arr: [5, 6, 12, 1]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a: [Int], size: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum(a: [-2, -3, 4, -1, -2, 1, 5, -3], size: 8) == 7)\nassert(max_sub_array_sum(a: [-3, -4, 5, -2, -3, 2, 6, -4], size: 8) == 8)\nassert(max_sub_array_sum(a: [-4, -5, 6, -3, -4, 3, 7, -5], size: 8) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1: [Int], array_nums2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [3, 5, 7, 9]) == [3, 5, 7, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [10, 20, 30, 40]) == [10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunc split_two_parts(list1: [AnyHashable], L: Int) -> AnyHashable {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_two_parts(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\nassert(split_two_parts(list1: [\"a\", \"b\", \"c\", \"d\"], L: 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\nassert(split_two_parts(list1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], L: 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "swift",
-    "prompt": "\n/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text: String, pattern: String) -> (String, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_literals(text: \"The quick brown fox jumps over the lazy dog.\", pattern: \"fox\") == (\"fox\", 16, 19))\nassert(find_literals(text: \"Its been a very crazy procedure right\", pattern: \"crazy\") == (\"crazy\", 16, 21))\nassert(find_literals(text: \"Hardest choices required strongest will\", pattern: \"will\") == (\"will\", 35, 39))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the volume of a triangular prism.\nfunc find_Volume(l: Int, b: Int, h: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Volume(l: 10, b: 8, h: 6) == 240)\nassert(find_Volume(l: 3, b: 2, h: 2) == 6)\nassert(find_Volume(l: 1, b: 2, h: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v: Int, t: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(wind_chill(v: 120, t: 35) == 40)\nassert(wind_chill(v: 40, t: 20) == 19)\nassert(wind_chill(v: 10, t: 8) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the ascii value of a character.\nfunc ascii_value(k: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(ascii_value(k: \"A\") == 65)\nassert(ascii_value(k: \"R\") == 82)\nassert(ascii_value(k: \"S\") == 83)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether all the characters are same or not.\nfunc all_Characters_Same(s: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Characters_Same(s: \"python\") == false)\nassert(all_Characters_Same(s: \"aaa\") == true)\nassert(all_Characters_Same(s: \"data\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_num(test_str: \"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\nassert(move_num(test_str: \"Avengers124Assemble\") == \"AvengersAssemble124\")\nassert(move_num(test_str: \"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the length of the word is odd or not.\nfunc word_len(s: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(word_len(s: \"Hadoop\") == false)\nassert(word_len(s: \"great\") == true)\nassert(word_len(s: \"structure\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "swift",
-    "prompt": "\n/// Write a function to drop empty items from a given dictionary.\nfunc drop_empty(dict1: [String : String?]) -> [String : String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : \"Green\", \"c3\" : nil]) == [\"c1\" : \"Red\", \"c2\" : \"Green\"])\nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : nil, \"c3\" : nil]) == [\"c1\" : \"Red\"])\nassert(drop_empty(dict1: [\"c1\" : nil, \"c2\" : \"Green\", \"c3\" : nil]) == [\"c2\" : \"Green\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list: [String], element: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(insert_element(list: [\"Red\", \"Green\", \"Black\"], element: \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\nassert(insert_element(list: [\"python\", \"java\"], element: \"program\") == [\"program\", \"python\", \"program\", \"java\"])\nassert(insert_element(list: [\"happy\", \"sad\"], element: \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_lowercase(str1: \"PYTHon\") == \"PYTH\")\nassert(remove_lowercase(str1: \"FInD\") == \"FID\")\nassert(remove_lowercase(str1: \"STRinG\") == \"STRG\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Set_Bits(n: 2) == 1)\nassert(count_Set_Bits(n: 4) == 1)\nassert(count_Set_Bits(n: 6) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple: (String, String, String)) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_rear(test_tuple: (\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\nassert(extract_rear(test_tuple: (\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\nassert(extract_rear(test_tuple: (\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_occurance(s: \"letstdlenstdporstd\") == 3)\nassert(count_occurance(s: \"truststdsolensporsd\") == 1)\nassert(count_occurance(s: \"makestdsostdworthit\") == 2)\nassert(count_occurance(s: \"stds\") == 1)\nassert(count_occurance(s: \"\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup: [Int], K: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_K(test_tup: [10, 4, 5, 6, 8], K: 6) == true)\nassert(check_K(test_tup: [1, 2, 3, 4, 5, 6], K: 7) == false)\nassert(check_K(test_tup: [7, 8, 9, 44, 11, 12], K: 11) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1: [Int], list2: [Int], list3: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(interleave_lists(list1: [1, 2, 3, 4, 5, 6, 7], list2: [10, 20, 30, 40, 50, 60, 70], list3: [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\nassert(interleave_lists(list1: [10, 20], list2: [15, 2], list3: [5, 10]) == [10, 15, 5, 20, 2, 10])\nassert(interleave_lists(list1: [11, 44], list2: [10, 15], list3: [20, 5]) == [11, 10, 20, 44, 15, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"python_program\") == \"PythonProgram\")\nassert(snake_to_camel(word: \"python_language\") == \"PythonLanguage\")\nassert(snake_to_camel(word: \"programming_language\") == \"ProgrammingLanguage\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x: Int, y: Int, z: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_three_equal(x: 1, y: 1, z: 1) == 3)\nassert(test_three_equal(x: -1, y: -2, z: -3) == 0)\nassert(test_three_equal(x: 1, y: 2, z: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_length_sum(arr: [1, 2, 4]) == 14)\nassert(odd_length_sum(arr: [1, 2, 1, 2]) == 15)\nassert(odd_length_sum(arr: [1, 7]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_number(n: 2) == 2)\nassert(bell_number(n: 10) == 115975)\nassert(bell_number(n: 56) == 6775685320645824322581483068371419745979053216268760300)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the area of a rectangle.\nfunc rectangle_area(l: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rectangle_area(l: 10, b: 20) == 200)\nassert(rectangle_area(l: 10, b: 5) == 50)\nassert(rectangle_area(l: 4, b: 2) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number: Int) -> (Int, Double) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_average(number: 10) == (55, 5.5))\nassert(sum_average(number: 15) == (120, 8.0))\nassert(sum_average(number: 20) == (210, 10.5))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(division_elements(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (2, 2, 2, 3))\nassert(division_elements(test_tup1: (12, 6, 8, 16), test_tup2: (6, 3, 4, 4)) == (2, 2, 2, 4))\nassert(division_elements(test_tup1: (20, 14, 36, 18), test_tup2: (5, 7, 6, 9)) == (4, 2, 6, 2))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_digits(n: 345) == 12)\nassert(sum_digits(n: 12) == 3)\nassert(sum_digits(n: 97) == 16)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "swift",
-    "prompt": "\n/// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list: [(String, Int)]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_minimum(test_list: [(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\nassert(index_minimum(test_list: [(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\nassert(index_minimum(test_list: [(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to divide two lists element wise.\nfunc div_list(nums1: [Int], nums2: [Int]) -> [Double] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(div_list(nums1: [4, 5, 6], nums2: [1, 2, 3]) == [4.0, 2.5, 2.0])\nassert(div_list(nums1: [3, 2], nums2: [1, 4]) == [3.0, 0.5])\nassert(div_list(nums1: [90, 120], nums2: [50, 70]) == [1.8, 1.7142857142857142])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the list with maximum length.\nfunc max_length_list(input_list: [[Int]]) -> (Int, [Int]) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length_list(input_list: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length_list(input_list: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\nassert(max_length_list(input_list: [[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "swift",
-    "prompt": "\nextension [String]: Error {}\n        \n/// Write a function to find all possible combinations of the elements of a given list.\nfunc combinations_list(list1: [String]) -> [Result<[()], [String]>] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_list(list1: [\"orange\", \"red\", \"green\", \"blue\"]) == [.success([] as [()]), .failure([\"orange\"]), .failure([\"red\"]), .failure([\"red\", \"orange\"]), .failure([\"green\"]), .failure([\"green\", \"orange\"]), .failure([\"green\", \"red\"]), .failure([\"green\", \"red\", \"orange\"]), .failure([\"blue\"]), .failure([\"blue\", \"orange\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"red\", \"orange\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"orange\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"blue\", \"green\", \"red\", \"orange\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"blue\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"white\"]), .failure([\"white\", \"red\"]), .failure([\"white\", \"green\"]), .failure([\"white\", \"green\", \"red\"]), .failure([\"white\", \"blue\"]), .failure([\"white\", \"blue\", \"red\"]), .failure([\"white\", \"blue\", \"green\"]), .failure([\"white\", \"blue\", \"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"black\", \"blue\"]), .failure([\"black\", \"blue\", \"red\"]), .failure([\"black\", \"blue\", \"green\"]), .failure([\"black\", \"blue\", \"green\", \"red\"]), .failure([\"black\", \"white\"]), .failure([\"black\", \"white\", \"red\"]), .failure([\"black\", \"white\", \"green\"]), .failure([\"black\", \"white\", \"green\", \"red\"]), .failure([\"black\", \"white\", \"blue\"]), .failure([\"black\", \"white\", \"blue\", \"red\"]), .failure([\"black\", \"white\", \"blue\", \"green\"]), .failure([\"black\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"blue\"]), .failure([\"orange\", \"blue\", \"red\"]), .failure([\"orange\", \"blue\", \"green\"]), .failure([\"orange\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"white\"]), .failure([\"orange\", \"white\", \"red\"]), .failure([\"orange\", \"white\", \"green\"]), .failure([\"orange\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"white\", \"blue\"]), .failure([\"orange\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"blue\"]), .failure([\"orange\", \"black\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\"]), .failure([\"orange\", \"black\", \"white\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"])])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_sum(nums: [1, 2, 3]) == 4)\nassert(big_sum(nums: [-1, 2, 3, 4]) == 3)\nassert(big_sum(nums: [2, 3, 6]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to return the negative numbers in a list.\nfunc neg_nos(list1: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(neg_nos(list1: [-1, 4, 5, -6]) == [-1, -6])\nassert(neg_nos(list1: [-1, -2, 3, 4]) == [-1, -2])\nassert(neg_nos(list1: [-7, -6, 8, 9]) == [-7, -6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(highest_Power_of_2(n: 10) == 8)\nassert(highest_Power_of_2(n: 19) == 16)\nassert(highest_Power_of_2(n: 32) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l: [Int], s: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [3, 7]) == false)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [4, 3]) == true)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [1, 6]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1: [Int], nums2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sub_list(nums1: [1, 2, 3], nums2: [4, 5, 6]) == [-3, -3, -3])\nassert(sub_list(nums1: [1, 2], nums2: [3, 4]) == [-2, -2])\nassert(sub_list(nums1: [90, 120], nums2: [50, 70]) == [40, 50])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x: Int, y: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(opposite_Signs(x: 1, y: -2) == true)\nassert(opposite_Signs(x: 3, y: 2) == false)\nassert(opposite_Signs(x: -10, y: -10) == false)\nassert(opposite_Signs(x: -2, y: 2) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "swift",
-    "prompt": "\n/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_modulo(test_tup1: (10, 4, 5, 6), test_tup2: (5, 6, 7, 5)) == (0, 4, 5, 1))\nassert(tuple_modulo(test_tup1: (11, 5, 6, 7), test_tup2: (6, 7, 8, 6)) == (5, 5, 6, 1))\nassert(tuple_modulo(test_tup1: (12, 6, 7, 8), test_tup2: (7, 8, 9, 7)) == (5, 6, 7, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(diff_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 3)\nassert(diff_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\nassert(diff_even_odd(list1: [1, 5, 7, 9, 10]) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1: [[String]]) -> [[String]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\nassert(sort_sublists(list1: [[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the last digit of a given number.\nfunc last_Digit(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit(n: 123) == 3)\nassert(last_Digit(n: 25) == 5)\nassert(last_Digit(n: 30) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_num_sum(n: 2) == 82)\nassert(odd_num_sum(n: 3) == 707)\nassert(odd_num_sum(n: 4) == 3108)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a list to a string.\nfunc tup_string(tup1: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tup_string(tup1: [\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\nassert(tup_string(tup1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\nassert(tup_string(tup1: [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1: [Int], list2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1: [Int], list2: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(overlapping(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == false)\nassert(overlapping(list1: [1, 2, 3], list2: [4, 5, 6]) == false)\nassert(overlapping(list1: [1, 4, 5], list2: [1, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to identify non-prime numbers.\nfunc is_not_prime(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_not_prime(n: 2) == false)\nassert(is_not_prime(n: 10) == true)\nassert(is_not_prime(n: 35) == true)\nassert(is_not_prime(n: 37) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the maximum value in a given heterogeneous list.\nfunc max_val(listval: [Result<String, Int>]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 5)\nassert(max_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 25)\nassert(max_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 50)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_negativenum(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\nassert(sum_negativenum(nums: [10, 15, -14, 13, -18, 12, -20]) == -52)\nassert(sum_negativenum(nums: [19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Rotations(str: \"aaaa\") == 1)\nassert(find_Rotations(str: \"ab\") == 2)\nassert(find_Rotations(str: \"abc\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_date_format(dt: \"2026-01-02\") == \"02-01-2026\")\nassert(change_date_format(dt: \"2020-11-13\") == \"13-11-2020\")\nassert(change_date_format(dt: \"2021-04-26\") == \"26-04-2021\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "swift",
-    "prompt": "\n/// Write a python function which takes a list of integers and only returns the odd ones.\nfunc Split(list: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5, 6]) == [1, 3, 5])\nassert(Split(list: [10, 11, 12, 13]) == [11, 13])\nassert(Split(list: [7, 8, 9, 1]) == [7, 9, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_middle_bits(n: 9) == 15)\nassert(toggle_middle_bits(n: 10) == 12)\nassert(toggle_middle_bits(n: 11) == 13)\nassert(toggle_middle_bits(n: 65) == 127)\nassert(toggle_middle_bits(n: 77) == 115)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_char_position(str1: \"xbcefg\") == 2)\nassert(count_char_position(str1: \"ABcED\") == 3)\nassert(count_char_position(str1: \"AbgdeF\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1: [Int], nums2: [Int], N: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 3) == [60, 54, 50])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 4) == [60, 54, 50, 48])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 5) == [60, 54, 50, 48, 45])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list: [[Int]]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cummulative_sum(test_list: [[1, 3], [5, 6, 7], [2, 6]]) == 30)\nassert(cummulative_sum(test_list: [[2, 4], [6, 7, 8], [3, 7]]) == 37)\nassert(cummulative_sum(test_list: [[3, 5], [7, 8, 9], [4, 8]]) == 44)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_min_diff(arr: [1, 5, 3, 19, 18, 25], n: 6) == 1)\nassert(find_min_diff(arr: [4, 3, 2, 6], n: 4) == 1)\nassert(find_min_diff(arr: [30, 5, 20, 9], n: 4) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_starta_endb(text: \"aabbbb\") == true)\nassert(text_starta_endb(text: \"aabAbbbc\") == false)\nassert(text_starta_endb(text: \"accddbbjjj\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n: Int, d: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_rotate(n: 16, d: 2) == 64)\nassert(left_rotate(n: 10, d: 2) == 40)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 1, d: 3) == 8)\nassert(left_rotate(n: 5, d: 3) == 40)\nassert(left_rotate(n: 29, d: 3) == 232)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the first repeated character in a given string.\nfunc first_repeated_char(str1: String) -> String? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_repeated_char(str1: \"abcabc\") == \"a\")\nassert(first_repeated_char(str1: \"abc\") == nil)\nassert(first_repeated_char(str1: \"123123\") == \"1\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count inversions in an array.\nfunc get_Inv_Count(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Inv_Count(arr: [1, 20, 6, 4, 5]) == 5)\nassert(get_Inv_Count(arr: [1, 2, 1]) == 1)\nassert(get_Inv_Count(arr: [1, 2, 5, 6, 1]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_Power_Sum(n: 2) == 1056)\nassert(even_Power_Sum(n: 3) == 8832)\nassert(even_Power_Sum(n: 1) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input: [[Int]]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_equal(Input: [[11, 22, 33], [44, 55, 66]]) == true)\nassert(get_equal(Input: [[1, 2, 3], [4, 5, 6, 7]]) == false)\nassert(get_equal(Input: [[1, 2], [3, 4]]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if a string represents an integer or not.\nfunc check_integer(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_integer(text: \"python\") == false)\nassert(check_integer(text: \"1\") == true)\nassert(check_integer(text: \"12345\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list: [String]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_reverse_pairs(test_list: [\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\nassert(count_reverse_pairs(test_list: [\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\nassert(count_reverse_pairs(test_list: [\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to move all zeroes to the end of the given list.\nfunc move_zero(num_list: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_zero(num_list: [1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\nassert(move_zero(num_list: [2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\nassert(move_zero(num_list: [0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_distinct(test_tup: [1, 4, 5, 6, 1, 4]) == false)\nassert(check_distinct(test_tup: [1, 4, 5, 6]) == true)\nassert(check_distinct(test_tup: [2, 3, 4, 5, 6]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost: Int, sale_amount: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(noprofit_noloss(actual_cost: 1500, sale_amount: 1200) == false)\nassert(noprofit_noloss(actual_cost: 100, sale_amount: 100) == true)\nassert(noprofit_noloss(actual_cost: 2000, sale_amount: 5000) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str: String, K: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_length(test_str: \"The person is most value tet\", K: 3) == \"person is most value\")\nassert(remove_length(test_str: \"If you told me about this ok\", K: 4) == \"If you me about ok\")\nassert(remove_length(test_str: \"Forces of darkeness is come into the play\", K: 4) == \"Forces of darkeness is the\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count number of digits in a given string.\nfunc number_ctr(str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_ctr(str: \"program2bedone\") == 1)\nassert(number_ctr(str: \"3wonders\") == 1)\nassert(number_ctr(str: \"123\") == 3)\nassert(number_ctr(str: \"3wond-1ers2\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the total number of characters in a string.\nfunc count_charac(str1: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_charac(str1: \"python programming\") == 18)\nassert(count_charac(str1: \"language\") == 8)\nassert(count_charac(str1: \"words\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m: Int, n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_total_number_of_sequences(m: 10, n: 4) == 4)\nassert(get_total_number_of_sequences(m: 5, n: 2) == 6)\nassert(get_total_number_of_sequences(m: 16, n: 3) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "swift",
-    "prompt": "\n/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunc left_insertion(a: [Int], x: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(left_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(left_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a: Int, b: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_numbers(a: 10, b: 20) == [20, 10])\nassert(swap_numbers(a: 15, b: 17) == [17, 15])\nassert(swap_numbers(a: 100, b: 200) == [200, 100])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr: [Int], n: Int, x: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_majority(arr: [1, 2, 3, 3, 3, 3, 10], n: 7, x: 3) == true)\nassert(is_majority(arr: [1, 1, 2, 4, 4, 4, 6, 6], n: 8, x: 4) == false)\nassert(is_majority(arr: [1, 1, 1, 2, 2], n: 5, x: 1) == true)\nassert(is_majority(arr: [1, 1, 2, 2], n: 5, x: 1) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> (Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(substract_elements(test_tup1: (10, 4, 5), test_tup2: (2, 5, 18)) == (8, -1, -13))\nassert(substract_elements(test_tup1: (11, 2, 3), test_tup2: (24, 45, 16)) == (-13, -43, -13))\nassert(substract_elements(test_tup1: (7, 18, 9), test_tup2: (10, 11, 12)) == (-3, 7, -3))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(capital_words_spaces(str1: \"Python\") == \"Python\")\nassert(capital_words_spaces(str1: \"PythonProgrammingExamples\") == \"Python Programming Examples\")\nassert(capital_words_spaces(str1: \"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Average_Of_Cube(n: 2) == 4.5)\nassert(find_Average_Of_Cube(n: 3) == 12)\nassert(find_Average_Of_Cube(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict: [String : Int], n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 10) == false)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 12) == true)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tetrahedral_number(n: 5) == 35)\nassert(tetrahedral_number(n: 6) == 56)\nassert(tetrahedral_number(n: 7) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix: [[Int]]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(magic_square_test(my_matrix: [[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_uppercase(str1: \"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\nassert(remove_uppercase(str1: \"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\nassert(remove_uppercase(str1: \"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to check whether an element exists within a tuple.\nfunc check_tuplex(tuplex: [Result<String, Int>], tuple1: AnyHashable) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"r\") == true)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"5\") == false)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: 3) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dog_age(h_age: 12) == 61)\nassert(dog_age(h_age: 15) == 73)\nassert(dog_age(h_age: 24) == 109)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_Perfect_Square(N: 35) == 36)\nassert(next_Perfect_Square(N: 6) == 9)\nassert(next_Perfect_Square(N: 9) == 16)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create a list of N empty dictionaries.\nfunc empty_list(length: Int) -> [[() : ()]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(empty_list(length: 5) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 6) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 7) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to convert a given string to uppercase.\nfunc is_upper(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_upper(string: \"person\") == \"PERSON\")\nassert(is_upper(string: \"final\") == \"FINAL\")\nassert(is_upper(string: \"Valid\") == \"VALID\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s: String, n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_Equivalent(s: \"011001\", n: 6) == 3)\nassert(odd_Equivalent(s: \"11011\", n: 5) == 4)\nassert(odd_Equivalent(s: \"1010\", n: 4) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr: [Int], n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(re_arrange_array(arr: [-1, 2, -3, 4, 5, 6, -7, 8, 9], n: 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\nassert(re_arrange_array(arr: [12, -14, -26, 13, 15], n: 5) == [-14, -26, 12, 13, 15])\nassert(re_arrange_array(arr: [10, 24, 36, -42, -39, -78, 85], n: 7) == [-42, -39, -78, 10, 24, 36, 85])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_Element(arr: [1, 1, 1]) == true)\nassert(unique_Element(arr: [1, 2, 1, 2]) == false)\nassert(unique_Element(arr: [1, 2, 3, 4, 5]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_values(text: \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\nassert(extract_values(text: \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\nassert(extract_values(text: \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count true booleans in the given list.\nfunc count(lst: [Bool]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count(lst: [true, false, true]) == 2)\nassert(count(lst: [false, false]) == 0)\nassert(count(lst: [true, true, true]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "swift",
-    "prompt": "\n/// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_even_pair(A: [5, 4, 7, 2, 1]) == 4)\nassert(find_even_pair(A: [7, 2, 8, 1, 0, 5, 11]) == 9)\nassert(find_even_pair(A: [1, 2, 3]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(armstrong_number(number: 153) == true)\nassert(armstrong_number(number: 259) == false)\nassert(armstrong_number(number: 4458) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the upper case characters in a given string.\nfunc upper_ctr(str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(upper_ctr(str: \"PYthon\") == 1)\nassert(upper_ctr(str: \"BigData\") == 1)\nassert(upper_ctr(str: \"program\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(and_tuples(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (0, 0, 2, 1))\nassert(and_tuples(test_tup1: (1, 2, 3, 4), test_tup2: (5, 6, 7, 8)) == (1, 2, 3, 0))\nassert(and_tuples(test_tup1: (8, 9, 11, 12), test_tup2: (7, 13, 14, 17)) == (0, 9, 10, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors: [String], patterns: [String]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_samepatterns(colors: [\"red\", \"green\", \"green\"], patterns: [\"a\", \"b\", \"b\"]) == true)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\", \"b\"]) == false)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\"]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of lists in a given number of lists.\nfunc count_list(input_list: [[Int]]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_list(input_list: [[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\nassert(count_list(input_list: [[1, 2], [2, 3], [4, 5]]) == 3)\nassert(count_list(input_list: [[1, 0], [2, 0]]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums: [[Int]]) -> [Double] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(average_tuple(nums: [[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\nassert(average_tuple(nums: [[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\nassert(average_tuple(nums: [[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X: String, Y: String, Z: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lcs_of_three(X: \"AGGT12\", Y: \"12TXAYB\", Z: \"12XBA\") == 2)\nassert(lcs_of_three(X: \"Reels\", Y: \"Reelsfor\", Z: \"ReelsforReels\") == 5)\nassert(lcs_of_three(X: \"abcd1e2\", Y: \"bc12ea\", Z: \"bd1ea\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n'th star number.\nfunc find_star_num(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_star_num(n: 3) == 37)\nassert(find_star_num(n: 4) == 73)\nassert(find_star_num(n: 5) == 121)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of an array.\nfunc _sum(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(_sum(arr: [1, 2, 3]) == 6)\nassert(_sum(arr: [15, 12, 13, 10]) == 50)\nassert(_sum(arr: [0, 1, 2]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_Consecutive(l: [1, 2, 3, 4, 5]) == true)\nassert(check_Consecutive(l: [1, 2, 3, 5, 6]) == false)\nassert(check_Consecutive(l: [1, 2, 1]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text: String) -> (Int, Int, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverb_position(text: \"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\nassert(find_adverb_position(text: \"seriously!! there are many roses\") == (0, 9, \"seriously\"))\nassert(find_adverb_position(text: \"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "swift",
-    "prompt": "\n/// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunc rotate_right(list: [Int], m: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_of_substrings(str: \"abc\") == 6)\nassert(number_of_substrings(str: \"abcd\") == 10)\nassert(number_of_substrings(str: \"abcde\") == 15)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S: [AnyHashable], step: Int) -> [[AnyHashable]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_split(S: [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], step: 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\nassert(list_split(S: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], step: 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\nassert(list_split(S: [\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], step: 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_unique(test_list: [1, 2, 3]) == true)\nassert(all_unique(test_list: [1, 2, 1, 2]) == false)\nassert(all_unique(test_list: [1, 2, 3, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to convert complex numbers to polar coordinates.\nfunc convert(numbers: Int) -> (Double, Double) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert(numbers: 1) == (1.0, 0.0))\nassert(convert(numbers: 4) == (4.0, 0.0))\nassert(convert(numbers: 5) == (5.0, 0.0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "swift",
-    "prompt": "\n/// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunc filter_data(students: [String : (Double, Int)], h: Double, w: Int) -> [String : (Double, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 6.0, w: 70) == [\"Cierra Vega\" : (6.2, 70)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.9, w: 67) == [\"Cierra Vega\" : (6.2, 70), \"Kierra Gentry\" : (6.0, 68)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.7, w: 64) == [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to convert the given string to lower case.\nfunc is_lower(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_lower(string: \"InValid\") == \"invalid\")\nassert(is_lower(string: \"TruE\") == \"true\")\nassert(is_lower(string: \"SenTenCE\") == \"sentence\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_power_of_2(n: 0) == 1)\nassert(next_power_of_2(n: 5) == 8)\nassert(next_power_of_2(n: 17) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1: [String], sub_str: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ack\") == true)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"abc\") == false)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ange\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace characters in a string.\nfunc replace_char(str1: String, ch: String, newch: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_char(str1: \"polygon\", ch: \"y\", newch: \"l\") == \"pollgon\")\nassert(replace_char(str1: \"character\", ch: \"c\", newch: \"a\") == \"aharaater\")\nassert(replace_char(str1: \"python\", ch: \"l\", newch: \"a\") == \"python\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mul_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 4)\nassert(mul_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\nassert(mul_even_odd(list1: [1, 5, 7, 9, 10]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a list to a tuple.\nfunc list_tuple(listx: [Int]) -> AnyHashable {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_tuple(listx: [5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\nassert(list_tuple(listx: [2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\nassert(list_tuple(listx: [58, 44, 56]) == (58, 44, 56))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_binomial_Coeff_Sum(n: 4) == 8)\nassert(even_binomial_Coeff_Sum(n: 6) == 32)\nassert(even_binomial_Coeff_Sum(n: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bitwise_xor(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (15, 6, 5, 10))\nassert(bitwise_xor(test_tup1: (11, 5, 7, 10), test_tup2: (6, 3, 4, 4)) == (13, 6, 3, 14))\nassert(bitwise_xor(test_tup1: (12, 6, 8, 11), test_tup2: (7, 4, 5, 6)) == (11, 2, 13, 13))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A: [Int], B: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sub_Array(A: [1, 4, 3, 5], B: [1, 2]) == false)\nassert(is_Sub_Array(A: [1, 2, 1], B: [1, 2, 1]) == true)\nassert(is_Sub_Array(A: [1, 0, 2, 2], B: [2, 2, 0]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a: [Int], n: Int, k: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum_repeated(a: [10, 20, -30, -1], n: 4, k: 3) == 30)\nassert(max_sub_array_sum_repeated(a: [-1, 10, 20], n: 3, k: 2) == 59)\nassert(max_sub_array_sum_repeated(a: [-1, -2, -3], n: 3, k: 3) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunc min_product_tuple(list1: [(Int, Int)]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\nassert(min_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 30)\nassert(min_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunc count_divisors(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_divisors(n: 10) == true)\nassert(count_divisors(n: 100) == false)\nassert(count_divisors(n: 125) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunc triangle_area(r: Int) -> Int? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(r: -1) == nil)\nassert(triangle_area(r: 0) == 0)\nassert(triangle_area(r: 2) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_tuple(str1: \"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\nassert(string_to_tuple(str1: \"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\nassert(string_to_tuple(str1: \"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(string: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_length(string: \"11000010001\") == 6)\nassert(find_length(string: \"10111\") == 1)\nassert(find_length(string: \"11011101100101\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Primes_nums(n: 5) == 2)\nassert(count_Primes_nums(n: 10) == 4)\nassert(count_Primes_nums(n: 100) == 25)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_product(n: 3) == 15)\nassert(sum_Of_product(n: 4) == 56)\nassert(sum_Of_product(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the maximum aggregate from the list of tuples.\nfunc max_aggregate(stdata: [(String, Int)]) -> (String, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_aggregate(stdata: [(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a list of elements.\nfunc comb_sort(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(comb_sort(nums: [5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\nassert(comb_sort(nums: [41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\nassert(comb_sort(nums: [99, 15, 13, 47]) == [13, 15, 47, 99])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_expression(exp: \"{()}[{}]\") == true)\nassert(check_expression(exp: \"{()}[{]\") == false)\nassert(check_expression(exp: \"{()}[{}][]({})\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz(text: \"pythonz.\") == true)\nassert(text_match_wordz(text: \"xyz.\") == true)\nassert(text_match_wordz(text: \"  lang  .\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1: [Int], lst2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_list(lst1: [10, 20, 30], lst2: [15, 25, 35]) == [25, 45, 65])\nassert(sum_list(lst1: [1, 2, 3], lst2: [5, 6, 7]) == [6, 8, 10])\nassert(sum_list(lst1: [15, 20, 30], lst2: [15, 45, 75]) == [30, 65, 105])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(newman_prime(n: 3) == 7)\nassert(newman_prime(n: 4) == 17)\nassert(newman_prime(n: 5) == 41)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_: [AnyHashable], string: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_string(list_: [1, 2, 3, 4], string: \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\nassert(add_string(list_: [\"a\", \"b\", \"c\", \"d\"], string: \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\nassert(add_string(list_: [5, 6, 7, 8], string: \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunc surface_Area(b: Int, s: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surface_Area(b: 3, s: 4) == 33)\nassert(surface_Area(b: 4, s: 5) == 56)\nassert(surface_Area(b: 1, s: 2) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst: [[Int]]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min_Length(lst: [[1], [1, 2]]) == 1)\nassert(Find_Min_Length(lst: [[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\nassert(Find_Min_Length(lst: [[3, 3, 3], [4, 4, 4, 4]]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "swift",
-    "prompt": "\n/// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(validate(n: 1234) == true)\nassert(validate(n: 51241) == false)\nassert(validate(n: 321) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hexagonal_num(n: 10) == 190)\nassert(hexagonal_num(n: 5) == 45)\nassert(hexagonal_num(n: 7) == 91)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n'th lucas number.\nfunc find_lucas(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lucas(n: 9) == 76)\nassert(find_lucas(n: 4) == 7)\nassert(find_lucas(n: 3) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to get the difference between two lists.\nfunc Diff(li1: [Int], li2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Diff(li1: [10, 15, 20, 25, 30, 35, 40], li2: [25, 40, 35]) == [10, 20, 30, 15])\nassert(Diff(li1: [1, 2, 3, 4, 5], li2: [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\nassert(Diff(li1: [1, 2, 3], li2: [6, 7, 1]) == [2, 3, 6, 7])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1: String) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_quotation(text1: \"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\nassert(extract_quotation(text1: \"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\nassert(extract_quotation(text1: \"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\nassert(extract_quotation(text1: \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "swift",
-    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a list and sum all of its elements.\nfunc recursive_list_sum(data_list: [Result<Int, [Int]>]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(recursive_list_sum(data_list: [.success(1), .success(2), .failure([3, 4]), .failure([5, 6])]) == 21)\nassert(recursive_list_sum(data_list: [.success(7), .success(10), .failure([15, 14]), .failure([19, 41])]) == 106)\nassert(recursive_list_sum(data_list: [.success(10), .success(20), .failure([30, 40]), .failure([50, 60])]) == 210)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a: Int, b: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(differ_At_One_Bit_Pos(a: 13, b: 9) == true)\nassert(differ_At_One_Bit_Pos(a: 15, b: 8) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 4) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 3) == true)\nassert(differ_At_One_Bit_Pos(a: 5, b: 1) == true)\nassert(differ_At_One_Bit_Pos(a: 1, b: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_three(text: \"ac\") == false)\nassert(text_match_three(text: \"dc\") == false)\nassert(text_match_three(text: \"abbbba\") == true)\nassert(text_match_three(text: \"caacabbbba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product(arr: [3, 100, 4, 5, 150, 6]) == 3000)\nassert(max_product(arr: [4, 42, 55, 68, 80]) == 50265600)\nassert(max_product(arr: [10, 22, 9, 33, 21, 50, 41, 60]) == 2460)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l: [Int], n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_Arr(l: [12, 10, 5, 6, 52, 36], n: 2) == [5, 6, 52, 36, 12, 10])\nassert(split_Arr(l: [1, 2, 3, 4], n: 1) == [2, 3, 4, 1])\nassert(split_Arr(l: [0, 1, 2, 3, 4, 5, 6, 7], n: 3) == [3, 4, 5, 6, 7, 0, 1, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the number of divisors of a given integer.\nfunc divisor(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisor(n: 15) == 4)\nassert(divisor(n: 12) == 6)\nassert(divisor(n: 9) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_diff(nums: [1, 2, 3, 4]) == 3)\nassert(big_diff(nums: [4, 5, 12]) == 8)\nassert(big_diff(nums: [9, 2, 3]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(square_nums(nums: [10, 20, 30]) == [100, 400, 900])\nassert(square_nums(nums: [12, 15]) == [144, 225])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Monotonic(A: [6, 5, 4, 4]) == true)\nassert(is_Monotonic(A: [1, 2, 2, 3]) == true)\nassert(is_Monotonic(A: [1, 3, 2]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_perfect_square(n: 10) == false)\nassert(is_perfect_square(n: 36) == true)\nassert(is_perfect_square(n: 14) == false)\nassert(is_perfect_square(n: 196) == true)\nassert(is_perfect_square(n: 125) == false)\nassert(is_perfect_square(n: 15625) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of common divisors of two given numbers.\nfunc sum(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum(a: 10, b: 15) == 6)\nassert(sum(a: 100, b: 150) == 93)\nassert(sum(a: 4, b: 6) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1: [[Int]]) -> (Int, [Int]) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length(list1: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length(list1: [[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\nassert(max_length(list1: [[5], [15, 20, 25]]) == (3, [15, 20, 25]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunc check_occurences(test_list: [(Int, Int)]) -> [(Int, Int) : Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_occurences(test_list: [(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == [(1, 3) : 2, (2, 5) : 2, (3, 6) : 1])\nassert(check_occurences(test_list: [(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == [(2, 4) : 2, (3, 6) : 2, (4, 7) : 1])\nassert(check_occurences(test_list: [(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == [(2, 13) : 1, (11, 23) : 1, (12, 25) : 2, (16, 23) : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a: Int, b: Int, c: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parabola_directrix(a: 5, b: 3, c: 2) == -198)\nassert(parabola_directrix(a: 9, b: 8, c: 4) == -2336)\nassert(parabola_directrix(a: 2, b: 4, c: 6) == -130)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunc occurance_substring(text: String, pattern: String) -> (String, Int, Int)? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(occurance_substring(text: \"python programming, python language\", pattern: \"python\") == (\"python\", 0, 6))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"programming\") == (\"programming\", 7, 18))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"language\") == (\"language\", 31, 39))\nassert(occurance_substring(text: \"c++ programming, c++ language\", pattern: \"python\") == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup: AnyHashable) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_nested(test_tup: (1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\nassert(remove_nested(test_tup: (2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list: [[String]]) -> [[String]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(input_list: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(input_list: [[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\nassert(sort_sublists(input_list: [[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "swift",
-    "prompt": "\n/// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1: [Int], L: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_kth_element(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == [1, 1, 3, 4, 4, 5, 1])\nassert(remove_kth_element(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], L: 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\nassert(remove_kth_element(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], L: 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup: (Int, Int, Int), test_dict: [String : Int]) -> (Int, Int, Int, [String : Int]) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_dict_to_tuple(test_tup: (4, 5, 6), test_dict: [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]) == (4, 5, 6, [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]))\nassert(add_dict_to_tuple(test_tup: (1, 2, 3), test_dict: [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]) == (1, 2, 3, [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]))\nassert(add_dict_to_tuple(test_tup: (8, 9, 10), test_dict: [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]) == (8, 9, 10, [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n: Int, m: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find(n: 10, m: 3) == 3)\nassert(find(n: 4, m: 2) == 2)\nassert(find(n: 20, m: 5) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_two_three(text: \"ac\") == false)\nassert(text_match_two_three(text: \"dc\") == false)\nassert(text_match_two_three(text: \"abbbba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the occurence of all elements of list in a tuple.\nfunc count_Occurrence(tup: AnyHashable, lst: [AnyHashable]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Occurrence(tup: (\"a\", \"a\", \"c\", \"b\", \"d\"), lst: [\"a\", \"b\"]) == 3)\nassert(count_Occurrence(tup: (1, 2, 3, 1, 4, 6, 7, 1, 4), lst: [1, 4, 7]) == 6)\nassert(count_Occurrence(tup: (1, 2, 3, 4, 5, 6), lst: [1, 2]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1: [Int], list2: [Int], list3: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 9], list3: [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\nassert(count_samepair(list1: [1, 2, 3, 4, 2, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_one(text: \"ac\") == false)\nassert(text_match_one(text: \"dc\") == false)\nassert(text_match_one(text: \"abba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(difference(n: 3) == 30)\nassert(difference(n: 5) == 210)\nassert(difference(n: 2) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_string(string: \"Python\") == \"pYTHON\")\nassert(toggle_string(string: \"Pangram\") == \"pANGRAM\")\nassert(toggle_string(string: \"LIttLE\") == \"liTTle\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the element of a list having maximum length.\nfunc Find_Max(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max(lst: [[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\nassert(Find_Max(lst: [[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\nassert(Find_Max(lst: [[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n: Int, m: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eulerian_num(n: 3, m: 1) == 4)\nassert(eulerian_num(n: 4, m: 1) == 11)\nassert(eulerian_num(n: 5, m: 3) == 26)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a: [Int], x: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency(a: [1, 2, 3], x: 4) == 0)\nassert(frequency(a: [1, 2, 2, 3, 3, 3, 4], x: 3) == 3)\nassert(frequency(a: [0, 1, 2, 3, 1, 2], x: 1) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str: [String]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numeric_strings(nums_str: [\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\nassert(sort_numeric_strings(nums_str: [\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\nassert(sort_numeric_strings(nums_str: [\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunc geometric_sum(n: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(geometric_sum(n: 7) == 1.9921875)\nassert(geometric_sum(n: 4) == 1.9375)\nassert(geometric_sum(n: 8) == 1.99609375)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunc divisible_by_digits(startnum: Int, endnum: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisible_by_digits(startnum: 1, endnum: 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\nassert(divisible_by_digits(startnum: 1, endnum: 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\nassert(divisible_by_digits(startnum: 20, endnum: 25) == [22, 24])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_product(list_data: [10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\nassert(unique_product(list_data: [1, 2, 3, 1]) == 6)\nassert(unique_product(list_data: [7, 8, 9, 0, 1, 1]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the largest negative number from the given list.\nfunc largest_neg(list1: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_neg(list1: [1, 2, 3, -4, -6]) == -6)\nassert(largest_neg(list1: [1, 2, 3, -8, -9]) == -9)\nassert(largest_neg(list1: [1, 2, 3, 4, -1]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums: [AnyHashable]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(consecutive_duplicates(nums: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\nassert(consecutive_duplicates(nums: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps: (Int, Int), d: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Jumps(steps: (3, 4), d: 11) == 3.5)\nassert(min_Jumps(steps: (3, 4), d: 0) == 0)\nassert(min_Jumps(steps: (11, 14), d: 11) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr: [Int]) -> (Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Product(arr: [1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\nassert(max_Product(arr: [0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\nassert(max_Product(arr: [1, 2, 3]) == (2, 3))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the nth element from a given list of tuples.\nfunc extract_nth_element(list1: [(String, Int, Int)], n: Int) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 2) == [99, 96, 94, 98])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 1) == [98, 97, 91, 94])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nonagonal(n: 10) == 325)\nassert(is_nonagonal(n: 15) == 750)\nassert(is_nonagonal(n: 18) == 1089)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Abs_Diff(arr: [2, 1, 5, 3]) == 4)\nassert(max_Abs_Diff(arr: [9, 3, 2, 5, 1]) == 8)\nassert(max_Abs_Diff(arr: [3, 2, 1]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "swift",
-    "prompt": "\n/// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1: [AnyHashable]) -> [[AnyHashable]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pack_consecutive_duplicates(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\nassert(pack_consecutive_duplicates(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\nassert(pack_consecutive_duplicates(list1: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cal_sum(n: 9) == 49)\nassert(cal_sum(n: 10) == 66)\nassert(cal_sum(n: 11) == 88)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_values_string(str: \"abcdef\") == \"ace\")\nassert(odd_values_string(str: \"python\") == \"pto\")\nassert(odd_values_string(str: \"data\") == \"dt\")\nassert(odd_values_string(str: \"lambs\") == \"lms\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1: [Int], arr2: [Int], k: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_kth(arr1: [2, 3, 6, 7, 9], arr2: [1, 4, 8, 10], k: 5) == 6)\nassert(find_kth(arr1: [100, 112, 256, 349, 770], arr2: [72, 86, 113, 119, 265, 445, 892], k: 7) == 256)\nassert(find_kth(arr1: [3, 4, 7, 8, 10], arr2: [2, 5, 9, 11], k: 6) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(jacobsthal_num(n: 5) == 11)\nassert(jacobsthal_num(n: 2) == 1)\nassert(jacobsthal_num(n: 4) == 5)\nassert(jacobsthal_num(n: 13) == 2731)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunc frequency_lists(list1: [[Int]]) -> [Int : Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency_lists(list1: [[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == [1 : 1, 2 : 3, 3 : 1, 4 : 1, 5 : 2, 6 : 1, 7 : 1, 8 : 1, 9 : 1])\nassert(frequency_lists(list1: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == [1 : 1, 2 : 1, 3 : 1, 4 : 1, 5 : 1, 6 : 1, 7 : 1, 8 : 1, 9 : 1, 10 : 1, 11 : 1, 12 : 1])\nassert(frequency_lists(list1: [[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == [20 : 2, 30 : 2, 40 : 2, 17 : 1, 18 : 1, 16 : 1, 14 : 1, 13 : 1, 10 : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a: Int, b: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perfect_squares(a: 1, b: 30) == [1, 4, 9, 16, 25])\nassert(perfect_squares(a: 50, b: 100) == [64, 81, 100])\nassert(perfect_squares(a: 100, b: 200) == [100, 121, 144, 169, 196])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3]) == 20)\nassert(sum_Of_Subarray_Prod(arr: [1, 2]) == 5)\nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3, 4]) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the first odd number in a given list of numbers.\nfunc first_odd(nums: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_odd(nums: [1, 3, 5]) == 1)\nassert(first_odd(nums: [2, 4, 1, 3]) == 1)\nassert(first_odd(nums: [8, 9, 1]) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_nested_tuples(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\nassert(add_nested_tuples(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\nassert(add_nested_tuples(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "swift",
-    "prompt": "\n/// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst: [[AnyHashable]]) -> [[AnyHashable]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge(lst: [[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\nassert(merge(lst: [[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\nassert(merge(lst: [[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dif_Square(n: 5) == true)\nassert(dif_Square(n: 10) == false)\nassert(dif_Square(n: 15) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_smaller(test_tup1: (1, 2, 3), test_tup2: (2, 3, 4)) == false)\nassert(check_smaller(test_tup1: (4, 5, 6), test_tup2: (3, 4, 5)) == true)\nassert(check_smaller(test_tup1: (11, 12, 13), test_tup2: (10, 11, 12)) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunc freq_count(list1: [Int]) -> [Int : Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(freq_count(list1: [10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == [10 : 4, 20 : 4, 40 : 2, 50 : 2, 30 : 1])\nassert(freq_count(list1: [1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == [1 : 3, 2 : 2, 3 : 3, 4 : 3])\nassert(freq_count(list1: [5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == [10 : 1, 5 : 3, 6 : 2, 7 : 2, 4 : 2, 9 : 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r: Int, g: Int, b: Int) -> [Double] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rgb_to_hsv(r: 255, g: 255, b: 255) == [0.0, 0.0, 100.0])\nassert(rgb_to_hsv(r: 0, g: 215, b: 0) == [120.0, 100.0, 84.31372549019608])\nassert(rgb_to_hsv(r: 10, g: 215, b: 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "swift",
-    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a given nested list structure.\nfunc flatten_list(list1: [Result<Int, [Int]>]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flatten_list(list1: [.success(0), .success(10), .failure([20, 30]), .success(40), .success(50), .failure([60, 70, 80]), .failure([90, 100, 110, 120])]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\nassert(flatten_list(list1: [.failure([10, 20]), .failure([40]), .failure([30, 56, 25]), .failure([10, 20]), .failure([33]), .failure([40])]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\nassert(flatten_list(list1: [.failure([1, 2, 3]), .failure([4, 5, 6]), .failure([10, 11, 12]), .failure([7, 8, 9])]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(string: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_str(string: \"annie\") == true)\nassert(check_str(string: \"dawood\") == false)\nassert(check_str(string: \"Else\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumber_number(monthnum3: 6) == true)\nassert(check_monthnumber_number(monthnum3: 2) == false)\nassert(check_monthnumber_number(monthnum3: 12) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort the given list.\nfunc heap_sort(iterable: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_sort(iterable: [1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\nassert(heap_sort(iterable: [25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\nassert(heap_sort(iterable: [7, 1, 9, 5]) == [1, 5, 7, 9])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1: [Int], nums2: [Int], k: Int) -> [[Int]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 2) == [[1, 2], [1, 4]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 1) == [[1, 2]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunc find_solution(a: Int, b: Int, n: Int) -> (Int, Int)? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_solution(a: 2, b: 3, n: 7) == (2, 1))\nassert(find_solution(a: 4, b: 2, n: 7) == nil)\nassert(find_solution(a: 1, b: 13, n: 17) == (4, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Max_Num(arr: [1, 2, 3]) == 321)\nassert(find_Max_Num(arr: [4, 5, 6, 1]) == 6541)\nassert(find_Max_Num(arr: [1, 2, 3, 9]) == 9321)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists: [[Int]]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_list(lists: [[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\nassert(max_sum_list(lists: [[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\nassert(max_sum_list(lists: [[2, 3, 1]]) == [2, 3, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to interchange the first and last elements in a list.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1: [Int], arr2: [Int], n: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_median(arr1: [1, 12, 15, 26, 38], arr2: [2, 13, 17, 30, 45], n: 5) == 16.0)\nassert(get_median(arr1: [2, 4, 8, 9], arr2: [7, 13, 19, 28], n: 4) == 8.5)\nassert(get_median(arr1: [3, 6, 14, 23, 36, 42], arr2: [2, 18, 27, 39, 49, 55], n: 6) == 25.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(text: \"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\nassert(replace_spaces(text: \"The_Avengers\") == \"The Avengers\")\nassert(replace_spaces(text: \"Fast and Furious\") == \"Fast_and_Furious\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "swift",
-    "prompt": "\n/// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1: Int, num2: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(are_equivalent(num1: 36, num2: 57) == false)\nassert(are_equivalent(num1: 2, num2: 4) == false)\nassert(are_equivalent(num1: 23, num2: 47) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist: [String]) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_string_list(stringlist: [\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\nassert(reverse_string_list(stringlist: [\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\nassert(reverse_string_list(stringlist: [\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums: [AnyHashable]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_of_digits(nums: [10, 2, 56]) == 14)\nassert(sum_of_digits(nums: [[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\nassert(sum_of_digits(nums: [10, 20, -4, 5, -70]) == 19)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequence(n: 10) == 6)\nassert(sequence(n: 2) == 1)\nassert(sequence(n: 3) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums: [Int], n: Int) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 3) == [85, 75, 65])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 2) == [85, 75])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 5) == [85, 75, 65, 58, 35])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "swift",
-    "prompt": "\n/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost: Int, sale_amount: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(loss_amount(actual_cost: 1500, sale_amount: 1200) == 0)\nassert(loss_amount(actual_cost: 100, sale_amount: 200) == 100)\nassert(loss_amount(actual_cost: 2000, sale_amount: 5000) == 3000)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1: [Int], test_tup2: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(union_elements(test_tup1: [3, 4, 5, 6], test_tup2: [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\nassert(union_elements(test_tup1: [1, 2, 3, 4], test_tup2: [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\nassert(union_elements(test_tup1: [11, 12, 13, 14], test_tup2: [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the length of the longest sublists.\nfunc Find_Max_Length(lst: [[Int]]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max_Length(lst: [[1], [1, 4], [5, 6, 7, 8]]) == 4)\nassert(Find_Max_Length(lst: [[0, 1], [2, 2], [3, 2, 1]]) == 3)\nassert(Find_Max_Length(lst: [[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items: [String]) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_parenthesis(items: [\"python (chrome)\"]) == \"python\")\nassert(remove_parenthesis(items: [\"string(.abc)\"]) == \"string\")\nassert(remove_parenthesis(items: [\"alpha(num)\"]) == \"alpha\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find whether the parity of a given number is odd.\nfunc find_Parity(x: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Parity(x: 12) == false)\nassert(find_Parity(x: 7) == true)\nassert(find_Parity(x: 10) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1: Int, base2: Int, height: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_trapezium(base1: 15, base2: 25, height: 35) == 20)\nassert(median_trapezium(base1: 10, base2: 20, height: 30) == 15)\nassert(median_trapezium(base1: 6, base2: 9, height: 4) == 7.5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(centered_hexagonal_number(n: 10) == 271)\nassert(centered_hexagonal_number(n: 2) == 7)\nassert(centered_hexagonal_number(n: 9) == 217)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find number of lists present in the given list.\nfunc find_lists(Input: [AnyHashable]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lists(Input: [[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\nassert(find_lists(Input: [[1, 2], [3, 4], [5, 6]]) == 3)\nassert(find_lists(Input: [9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_sum(n: 60) == 106)\nassert(get_max_sum(n: 10) == 12)\nassert(get_max_sum(n: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the length of the longest word.\nfunc len_log(list1: [String]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(len_log(list1: [\"python\", \"PHP\", \"bigdata\"]) == 7)\nassert(len_log(list1: [\"a\", \"ab\", \"abc\"]) == 3)\nassert(len_log(list1: [\"small\", \"big\", \"tall\"]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunc sector_area(r: Int, a: Int) -> Double? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sector_area(r: 4, a: 45) == 6.283185307179586)\nassert(sector_area(r: 9, a: 45) == 31.808625617596654)\nassert(sector_area(r: 9, a: 361) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_position(nums: [2, 1, 4, 3, 6, 7, 6, 3]) == true)\nassert(odd_position(nums: [4, 1, 2]) == true)\nassert(odd_position(nums: [1, 2, 3]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "swift",
-    "prompt": "\n/// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiple_to_single(L: [11, 33, 50]) == 113350)\nassert(multiple_to_single(L: [-1, 2, 3, 4, 5, 6]) == -123456)\nassert(multiple_to_single(L: [10, 15, 20, 25]) == 10152025)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find whether a number is divisible by 11.\nfunc is_Diff(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Diff(n: 12345) == false)\nassert(is_Diff(n: 1212112) == true)\nassert(is_Diff(n: 1212) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_multiplication(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\nassert(index_multiplication(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\nassert(index_multiplication(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str: String) -> (Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_str_int(test_str: \"(7, 8, 9)\") == (7, 8, 9))\nassert(tuple_str_int(test_str: \"(1, 2, 3)\") == (1, 2, 3))\nassert(tuple_str_int(test_str: \"(4, 5, 6)\") == (4, 5, 6))\nassert(tuple_str_int(test_str: \"(7, 81, 19)\") == (7, 81, 19))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(amicable_numbers_sum(limit: 999) == 504)\nassert(amicable_numbers_sum(limit: 9999) == 31626)\nassert(amicable_numbers_sum(limit: 99) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove odd characters in a string.\nfunc remove_odd(str1: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(str1: \"python\") == \"yhn\")\nassert(remove_odd(str1: \"program\") == \"rga\")\nassert(remove_odd(str1: \"language\") == \"agae\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup: [Int]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_elements(test_tup: [1, 5, 7, 8, 10]) == [5, 35, 56, 80])\nassert(multiply_elements(test_tup: [2, 4, 5, 6, 7]) == [8, 20, 30, 42])\nassert(multiply_elements(test_tup: [12, 13, 14, 9, 15]) == [156, 182, 126, 135])\nassert(multiply_elements(test_tup: [12]) == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_rotation(arr: [3, 2, 1]) == 1)\nassert(count_rotation(arr: [4, 5, 1, 2, 3]) == 2)\nassert(count_rotation(arr: [7, 8, 9, 1, 2, 3]) == 3)\nassert(count_rotation(arr: [1, 2, 3]) == 0)\nassert(count_rotation(arr: [1, 3, 2]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the number of unique tuples in the given list.\nfunc extract_freq(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_freq(test_list: [(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\nassert(extract_freq(test_list: [(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\nassert(extract_freq(test_list: [(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "swift",
-    "prompt": "\n/// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1: [Int], nums2: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_same_pair(nums1: [1, 2, 3, 4, 5, 6, 7, 8], nums2: [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\nassert(count_same_pair(nums1: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\nassert(count_same_pair(nums1: [2, 4, -6, -9, 11, -12, 14, -5, 17], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\nassert(count_same_pair(nums1: [0, 1, 1, 2], nums2: [0, 1, 2, 2]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power(a: 3, b: 4) == 81)\nassert(power(a: 2, b: 3) == 8)\nassert(power(a: 5, b: 5) == 3125)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "swift",
-    "prompt": "\n/// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict: [String : Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(return_sum(dict: [\"a\" : 100, \"b\" : 200, \"c\" : 300]) == 600)\nassert(return_sum(dict: [\"a\" : 25, \"b\" : 18, \"c\" : 45]) == 88)\nassert(return_sum(dict: [\"a\" : 36, \"b\" : 39, \"c\" : 49]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1: [Int]) -> [(Int, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_wise(l1: [1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\nassert(pair_wise(l1: [1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\nassert(pair_wise(l1: [5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\nassert(pair_wise(l1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to split a string into characters.\nfunc split(word: String) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split(word: \"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\nassert(split(word: \"Name\") == [\"N\", \"a\", \"m\", \"e\"])\nassert(split(word: \"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find minimum of three numbers.\nfunc min_of_three(a: Int, b: Int, c: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_of_three(a: 10, b: 20, c: 0) == 0)\nassert(min_of_three(a: 19, b: 15, c: 18) == 15)\nassert(min_of_three(a: -10, b: -20, c: -30) == -30)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sum_Of_Powers_Of_Two(n: 10) == true)\nassert(is_Sum_Of_Powers_Of_Two(n: 7) == false)\nassert(is_Sum_Of_Powers_Of_Two(n: 14) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Char(strr: \"abc\") == \"f\")\nassert(get_Char(strr: \"gfg\") == \"t\")\nassert(get_Char(strr: \"ab\") == \"c\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_div(number: 8) == 7)\nassert(sum_div(number: 12) == 16)\nassert(sum_div(number: 7) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case stringValue(String)\n    case doubleValue(Double)\n}\n\n            \n/// Write a python function that returns the number of integer elements in a given list.\nfunc count_integer(list1: [Value]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_integer(list1: [.intValue(1), .intValue(2), .stringValue(\"abc\"), .doubleValue(1.2)]) == 2)\nassert(count_integer(list1: [.intValue(1), .intValue(2), .intValue(3)]) == 3)\nassert(count_integer(list1: [.intValue(1), .doubleValue(1.2), .intValue(4), .doubleValue(5.1)]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(two_unique_nums(nums: [1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_duplicate(arraynums: [1, 2, 3, 4, 5]) == false)\nassert(test_duplicate(arraynums: [1, 2, 3, 4, 4]) == true)\nassert(test_duplicate(arraynums: [1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function which returns nth catalan number.\nfunc catalan_number(num: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(catalan_number(num: 10) == 16796)\nassert(catalan_number(num: 9) == 4862)\nassert(catalan_number(num: 7) == 429)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base: Int, power: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power_base_sum(base: 2, power: 100) == 115)\nassert(power_base_sum(base: 8, power: 10) == 37)\nassert(power_base_sum(base: 8, power: 15) == 62)\nassert(power_base_sum(base: 3, power: 3) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1: [AnyHashable], list2: [AnyHashable]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_list(list1: [1, 3, 5, 7, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\nassert(replace_list(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\nassert(replace_list(list1: [\"red\", \"blue\", \"green\"], list2: [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth octagonal number.\nfunc is_octagonal(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_octagonal(n: 5) == 65)\nassert(is_octagonal(n: 10) == 280)\nassert(is_octagonal(n: 15) == 645)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1: String, char: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_blank(str1: \"hello people\", char: \"@\") == \"hello@people\")\nassert(replace_blank(str1: \"python program language\", char: \"$\") == \"python$program$language\")\nassert(replace_blank(str1: \"blank space\", char: \"-\") == \"blank-space\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_specialchar(text: \"Python language, Programming language.\") == \"Python:language::Programming:language:\")\nassert(replace_specialchar(text: \"a b c,d e f\") == \"a:b:c:d:e:f\")\nassert(replace_specialchar(text: \"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums: (Int, Int, Int)) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_int(nums: (1, 2, 3)) == 123)\nassert(tuple_to_int(nums: (4, 5, 6)) == 456)\nassert(tuple_to_int(nums: (5, 6, 7)) == 567)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w: Int, h: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(otherside_rightangle(w: 7, h: 8) == 10.63014581273465)\nassert(otherside_rightangle(w: 3, h: 4) == 5)\nassert(otherside_rightangle(w: 7, h: 15) == 16.55294535724685)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "swift",
-    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the n most expensive items in a given dataset.\nfunc expensive_items(items: [[String : Result<String, Double>]], n: Int) -> [[String : Result<String, Double>]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)]], n: 2) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)], [\"name\" : .success(\"Item-4\"), \"price\" : .failure(22.75)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1: Int, n2: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digit_distance_nums(n1: 1, n2: 2) == 1)\nassert(digit_distance_nums(n1: 23, n2: 56) == 6)\nassert(digit_distance_nums(n1: 123, n2: 256) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz_middle(text: \"pythonzabc.\") == true)\nassert(text_match_wordz_middle(text: \"zxyabc.\") == false)\nassert(text_match_wordz_middle(text: \"  lang  .\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(removezero_ip(ip: \"216.08.094.196\") == \"216.8.94.196\")\nassert(removezero_ip(ip: \"12.01.024\") == \"12.1.24\")\nassert(removezero_ip(ip: \"216.08.094.0196\") == \"216.8.94.196\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1: [[AnyHashable]], x: AnyHashable) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_element_in_list(list1: [[1, 3], [5, 7], [1, 11], [1, 15, 7]], x: 1) == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"A\") == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"E\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to multiply two integers.\nfunc multiply_int(x: Int, y: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_int(x: 10, y: 20) == 200)\nassert(multiply_int(x: 5, y: 10) == 50)\nassert(multiply_int(x: 4, y: 8) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup: (Int, Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_pairwise(test_tup: (1, 5, 7, 8, 10)) == (6, 12, 15, 18))\nassert(add_pairwise(test_tup: (2, 6, 8, 9, 11)) == (8, 14, 17, 20))\nassert(add_pairwise(test_tup: (3, 7, 9, 10, 12)) == (10, 16, 19, 22))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunc max_product_tuple(list1: [(Int, Int)]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\nassert(max_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 200)\nassert(max_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)",
     "stop_tokens": [
       "\n}"
     ]
@@ -3532,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find the kth element in the given array using 1-based indexing.\nfunc kth_element(arr: [Int], k: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(kth_element(arr: [12, 3, 5, 7, 19], k: 2) == 3)\nassert(kth_element(arr: [17, 24, 8, 23], k: 3) == 8)\nassert(kth_element(arr: [16, 21, 25, 36, 4], k: 4) == 36)",
     "stop_tokens": [
@@ -3540,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "swift",
-    "prompt": "\n/// Write a python function to interchange the first and last element in a given list.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"python_program\") == \"PythonProgram\")\nassert(snake_to_camel(word: \"python_language\") == \"PythonLanguage\")\nassert(snake_to_camel(word: \"programming_language\") == \"ProgrammingLanguage\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "swift",
-    "prompt": "\nextension (Int, Int): Error {}\n        \n/// Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunc count_first_elements(test_tup: [Result<Int, (Int, Int)>]) -> Int {\n",
+    "prompt": "\n/// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n: Int, m: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_first_elements(test_tup: [.success(1), .success(5), .success(7), .failure((4, 6)), .success(10)]) == 3)\nassert(count_first_elements(test_tup: [.success(2), .success(9), .failure((5, 7)), .success(11)]) == 2)\nassert(count_first_elements(test_tup: [.success(11), .success(15), .success(5), .success(8), .failure((2, 3)), .success(8)]) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eulerian_num(n: 3, m: 1) == 4)\nassert(eulerian_num(n: 4, m: 1) == 11)\nassert(eulerian_num(n: 5, m: 3) == 26)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "swift",
-    "prompt": "\n/// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a: [Int], x: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(input_list: [[String]]) -> [[String]] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(right_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(right_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(input_list: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(input_list: [[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\nassert(sort_sublists(input_list: [[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "swift",
-    "prompt": "\n/// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x: Int) -> Bool {\n",
+    "prompt": "\n/// Write a python function to count true booleans in the given list.\nfunc count(lst: [Bool]) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_woodall(x: 383) == true)\nassert(is_woodall(x: 254) == false)\nassert(is_woodall(x: 200) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count(lst: [true, false, true]) == 2)\nassert(count(lst: [false, false]) == 0)\nassert(count(lst: [true, true, true]) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "swift",
-    "prompt": "\n/// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to append the given list to the given tuples.\nfunc add_lists(test_list: [Int], test_tup: (Int, Int)) -> (Int, Int, Int, Int, Int) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(shell_sort(my_list: [12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\nassert(shell_sort(my_list: [24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\nassert(shell_sort(my_list: [32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_lists(test_list: [5, 6, 7], test_tup: (9, 10)) == (9, 10, 5, 6, 7))\nassert(add_lists(test_list: [6, 7, 8], test_tup: (10, 11)) == (10, 11, 6, 7, 8))\nassert(add_lists(test_list: [7, 8, 9], test_tup: (11, 12)) == (11, 12, 7, 8, 9))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A: [Int], N: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1: [Int], num2: [Int], num3: [Int]) -> [Int] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Odd_Pair(A: [5, 4, 7, 2, 1], N: 5) == 6)\nassert(find_Odd_Pair(A: [7, 2, 8, 1, 0, 5, 11], N: 7) == 12)\nassert(find_Odd_Pair(A: [1, 2, 3], N: 3) == 2)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_sorted_list(num1: [25, 24, 15, 4, 5, 29, 110], num2: [19, 20, 11, 56, 25, 233, 154], num3: [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\nassert(merge_sorted_list(num1: [1, 3, 5, 6, 8, 9], num2: [2, 5, 7, 11], num3: [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\nassert(merge_sorted_list(num1: [18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], num2: [25, 35, 22, 85, 14, 65, 75, 25, 58], num3: [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l: Int, r: Int) -> Int {\n",
+    "prompt": "\n/// Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s: String, n: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_in_range(l: 2, r: 5) == 8)\nassert(sum_in_range(l: 5, r: 7) == 12)\nassert(sum_in_range(l: 7, r: 13) == 40)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_Equivalent(s: \"011001\", n: 6) == 3)\nassert(odd_Equivalent(s: \"11011\", n: 5) == 4)\nassert(odd_Equivalent(s: \"1010\", n: 4) == 2)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "swift",
-    "prompt": "\n/// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to check if a string represents an integer or not.\nfunc check_integer(text: String) -> Bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_perimeter(a: 10) == 40)\nassert(square_perimeter(a: 5) == 20)\nassert(square_perimeter(a: 4) == 16)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_integer(text: \"python\") == false)\nassert(check_integer(text: \"1\") == true)\nassert(check_integer(text: \"12345\") == true)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "swift",
-    "prompt": "\n/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums: (Int, Int, Int)) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_polite(n: 7) == 11)\nassert(is_polite(n: 4) == 7)\nassert(is_polite(n: 9) == 13)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_series(n: 6) == 12)\nassert(sum_series(n: 10) == 30)\nassert(sum_series(n: 9) == 25)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_dissimilar(test_tup1: (3, 4, 5, 6), test_tup2: (5, 7, 4, 10)) == (3, 6, 7, 10))\nassert(find_dissimilar(test_tup1: (1, 2, 3, 4), test_tup2: (7, 2, 3, 9)) == (1, 4, 7, 9))\nassert(find_dissimilar(test_tup1: (21, 11, 25, 26), test_tup2: (26, 34, 21, 36)) == (34, 36, 11, 25))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words: [String]) -> (String, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(start_withp(words: [\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\nassert(start_withp(words: [\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\nassert(start_withp(words: [\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"android_tv\") == \"AndroidTv\")\nassert(snake_to_camel(word: \"google_pixel\") == \"GooglePixel\")\nassert(snake_to_camel(word: \"apple_watch\") == \"AppleWatch\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(volume_cube(l: 3) == 27)\nassert(volume_cube(l: 2) == 8)\nassert(volume_cube(l: 5) == 125)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumb_number(monthnum2: 5) == true)\nassert(check_monthnumb_number(monthnum2: 2) == false)\nassert(check_monthnumb_number(monthnum2: 6) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n: Int, l: Int, r: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Bits_Set_In_The_Given_Range(n: 4, l: 1, r: 2) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 17, l: 2, r: 4) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 39, l: 4, r: 6) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to get the first element of each sublist.\nfunc Extract(lst: [[Int]]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Extract(lst: [[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\nassert(Extract(lst: [[1, 2, 3], [4, 5]]) == [1, 4])\nassert(Extract(lst: [[9, 8, 1], [1, 2]]) == [9, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r: Int, h: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cylinder(r: 10, h: 5) == 942.45)\nassert(surfacearea_cylinder(r: 4, h: 5) == 226.18800000000002)\nassert(surfacearea_cylinder(r: 4, h: 10) == 351.848)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names: [String]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sample_nam(sample_names: [\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\nassert(sample_nam(sample_names: [\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\nassert(sample_nam(sample_names: [\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n: Int) -> AnyHashable {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rearrange_bigger(n: 12) == 21)\nassert(rearrange_bigger(n: 10) == false)\nassert(rearrange_bigger(n: 102) == 120)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perimeter_pentagon(a: 5) == 25)\nassert(perimeter_pentagon(a: 10) == 50)\nassert(perimeter_pentagon(a: 15) == 75)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum(arr: [1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\nassert(max_sum(arr: [80, 60, 30, 40, 20, 10]) == 210)\nassert(max_sum(arr: [2, 3, 14, 16, 21, 23, 29, 30]) == 138)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple: (Int, Int, (Int, Int, (Int, Int)), Int, Int)) -> AnyHashable {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_even(test_tuple: (4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\nassert(extract_even(test_tuple: (5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\nassert(extract_even(test_tuple: (5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_int(nums: (1, 2, 3)) == 123)\nassert(tuple_to_int(nums: (4, 5, 6)) == 456)\nassert(tuple_to_int(nums: (5, 6, 7)) == 567)",
     "stop_tokens": [
       "\n}"
     ]
@@ -3820,201 +136,9 @@
     "language": "swift",
     "prompt": "\n/// Write a function to convert all possible convertible elements in a list of lists to floats.\nfunc list_to_float(test_list: [(String, String)]) -> [(Double, Double)] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_to_float(test_list: [(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)])\nassert(list_to_float(test_list: [(\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)])\nassert(list_to_float(test_list: [(\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 20)\nassert(square_Sum(n: 3) == 56)\nassert(square_Sum(n: 4) == 120)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr: [Int], sum: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_pairs_count(arr: [1, 1, 1, 1], sum: 2) == 6)\nassert(get_pairs_count(arr: [1, 5, 7, -1, 5], sum: 6) == 3)\nassert(get_pairs_count(arr: [1, -2, 3], sum: 1) == 1)\nassert(get_pairs_count(arr: [-1, -2, 3], sum: -3) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n: Int, k: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_no_of_ways(n: 2, k: 4) == 16)\nassert(count_no_of_ways(n: 3, k: 2) == 6)\nassert(count_no_of_ways(n: 4, k: 4) == 228)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "swift",
-    "prompt": "\n/// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_words(s: \"python program\") == \"program python\")\nassert(reverse_words(s: \"java language\") == \"language java\")\nassert(reverse_words(s: \"indian man\") == \"man indian\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to check if a given number is one less than twice its reverse.\nfunc checks(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(checks(n: 70) == false)\nassert(checks(n: 23) == false)\nassert(checks(n: 73) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the last position of an element in a sorted array.\nfunc last(arr: [Int], x: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last(arr: [1, 2, 3], x: 1) == 0)\nassert(last(arr: [1, 1, 1, 2, 3, 4], x: 1) == 2)\nassert(last(arr: [2, 3, 2, 3, 6, 8, 9], x: 3) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "swift",
-    "prompt": "\n/// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunc count_X(tup: [Int], x: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 4) == 0)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 10) == 3)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 8) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "swift",
-    "prompt": "\n/// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1: [Int], l2: [Int], l3: [Int]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 6, 5], l3: [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\nassert(extract_index_list(l1: [1, 1, 3, 4, 6, 5, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\nassert(extract_index_list(l1: [1, 2, 3, 4, 6, 6, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "swift",
-    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the second smallest number in a list.\nfunc second_smallest(numbers: [Result<Int, Double>]) -> Double? {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(second_smallest(numbers: [.success(1), .success(2), .success(-8), .success(-2), .success(0), .success(-2)]) == -2)\nassert(second_smallest(numbers: [.success(1), .success(1), .failure(-0.5), .success(0), .success(2), .success(-2), .success(-2)]) == -0.5)\nassert(second_smallest(numbers: [.success(2), .success(2)]) == nil)\nassert(second_smallest(numbers: [.success(2), .success(2), .success(2)]) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup: (String, String, Int, String)) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate_tuple(test_tup: (\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\nassert(concatenate_tuple(test_tup: (\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\nassert(concatenate_tuple(test_tup: (\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(string: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(string: \"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\nassert(replace_spaces(string: \"I am a Programmer\") == \"I%20am%20a%20Programmer\")\nassert(replace_spaces(string: \"I love Coding\") == \"I%20love%20Coding\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1: [Int], m: Int, n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 8, n: 10) == 29)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 5, n: 7) == 16)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 7, n: 10) == 38)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1: [String : String], dict2: [String : String], dict3: [String : String]) -> [String : String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"O\" : \"Orange\", \"W\" : \"White\", \"B\" : \"Black\"]) == [\"B\" : \"Black\", \"R\" : \"Red\", \"P\" : \"Pink\", \"G\" : \"Green\", \"W\" : \"White\", \"O\" : \"Orange\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"L\" : \"lavender\", \"B\" : \"Blue\"]) == [\"W\" : \"White\", \"P\" : \"Pink\", \"B\" : \"Black\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"L\" : \"lavender\", \"B\" : \"Blue\"], dict3: [\"G\" : \"Green\", \"W\" : \"White\"]) == [\"B\" : \"Black\", \"P\" : \"Pink\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\", \"W\" : \"White\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the minimum of two numbers.\nfunc minimum(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minimum(a: 1, b: 2) == 1)\nassert(minimum(a: -5, b: -4) == -5)\nassert(minimum(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunc max_difference(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_difference(test_list: [(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\nassert(max_difference(test_list: [(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\nassert(max_difference(test_list: [(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find element at a given index after number of rotations.\nfunc find_Element(arr: [Int], ranges: [[Int]], rotations: Int, index: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Element(arr: [1, 2, 3, 4, 5], ranges: [[0, 2], [0, 3]], rotations: 2, index: 1) == 3)\nassert(find_Element(arr: [1, 2, 3, 4], ranges: [[0, 1], [0, 2]], rotations: 1, index: 2) == 3)\nassert(find_Element(arr: [1, 2, 3, 4, 5, 6], ranges: [[0, 1], [0, 2]], rotations: 1, index: 1) == 1)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4024,7 +148,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to convert a string to a list of strings split on the space character.\nfunc string_to_list(string: String) -> [String] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_list(string: \"python programming\") == [\"python\", \"programming\"])\nassert(string_to_list(string: \"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"])\nassert(string_to_list(string: \"write a program\") == [\"write\", \"a\", \"program\"])",
     "stop_tokens": [
@@ -4036,21 +160,9 @@
     "language": "swift",
     "prompt": "\n/// Write a python function to find the element that appears only once in a sorted array.\nfunc search(arr: [Int]) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(arr: [1, 1, 2, 2, 3]) == 3)\nassert(search(arr: [1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8)\nassert(search(arr: [1, 2, 2, 3, 3, 4, 4]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1: [String : Int]) -> [(String, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_counter(dict1: [\"Math\" : 81, \"Physics\" : 83, \"Chemistry\" : 87]) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\nassert(sort_counter(dict1: [\"Math\" : 400, \"Physics\" : 300, \"Chemistry\" : 250]) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\nassert(sort_counter(dict1: [\"Math\" : 900, \"Physics\" : 1000, \"Chemistry\" : 1250]) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])",
     "stop_tokens": [
       "\n}"
     ]
@@ -4060,7 +172,7 @@
     "language": "swift",
     "prompt": "\n/// Write a python function to remove first and last occurrence of a given character from the string.\nfunc remove_Occ(s: String, ch: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_Occ(s: \"hello\", ch: \"l\") == \"heo\")\nassert(remove_Occ(s: \"abcda\", ch: \"a\") == \"bcd\")\nassert(remove_Occ(s: \"PHP\", ch: \"P\") == \"H\")",
     "stop_tokens": [
@@ -4068,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunc max_product_tuple(list1: [(Int, Int)]) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cube(l: 5) == 100)\nassert(lateralsurface_cube(l: 9) == 324)\nassert(lateralsurface_cube(l: 10) == 400)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\nassert(max_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 200)\nassert(max_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "swift",
-    "prompt": "\n/// Write a function that takes two lists and returns true if they have at least one common element.\nfunc common_element(list1: [AnyHashable], list2: [AnyHashable]) -> Bool? {\n",
+    "prompt": "\n/// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8, 9]) == true)\nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == nil)\nassert(common_element(list1: [\"a\", \"b\", \"c\"], list2: [\"d\", \"b\", \"e\"]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(amicable_numbers_sum(limit: 999) == 504)\nassert(amicable_numbers_sum(limit: 9999) == 31626)\nassert(amicable_numbers_sum(limit: 99) == 0)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "swift",
-    "prompt": "\n/// Write a function to append the given list to the given tuples.\nfunc add_lists(test_list: [Int], test_tup: (Int, Int)) -> (Int, Int, Int, Int, Int) {\n",
+    "prompt": "\n/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(string: String) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_lists(test_list: [5, 6, 7], test_tup: (9, 10)) == (9, 10, 5, 6, 7))\nassert(add_lists(test_list: [6, 7, 8], test_tup: (10, 11)) == (10, 11, 6, 7, 8))\nassert(add_lists(test_list: [7, 8, 9], test_tup: (11, 12)) == (11, 12, 7, 8, 9))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_length(string: \"11000010001\") == 6)\nassert(find_length(string: \"10111\") == 1)\nassert(find_length(string: \"11011101100101\") == 2)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "swift",
-    "prompt": "\n/// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums: [Int], n: Int) -> [Int] {\n",
+    "prompt": "\n/// Write a python function to find the sum of common divisors of two given numbers.\nfunc sum(a: Int, b: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(nth_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n: 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(nth_nums(nums: [10, 20, 30], n: 3) == [1000, 8000, 27000])\nassert(nth_nums(nums: [12, 15], n: 5) == [248832, 759375])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum(a: 10, b: 15) == 6)\nassert(sum(a: 100, b: 150) == 93)\nassert(sum(a: 4, b: 6) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "swift",
-    "prompt": "\n/// Write a function to sort a list of elements.\nfunc pancake_sort(nums: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to multiply two integers.\nfunc multiply_int(x: Int, y: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pancake_sort(nums: [15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\nassert(pancake_sort(nums: [98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\nassert(pancake_sort(nums: [41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median of three numbers.\nfunc median_numbers(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_numbers(a: 25, b: 55, c: 65) == 55.0)\nassert(median_numbers(a: 20, b: 10, c: 30) == 20.0)\nassert(median_numbers(a: 15, b: 45, c: 75) == 45.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr: [Int], number: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_greater(arr: [1, 2, 3, 4, 5], number: 4) == false)\nassert(check_greater(arr: [2, 3, 4, 5, 6], number: 8) == true)\nassert(check_greater(arr: [9, 7, 4, 8, 6, 1], number: 11) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list: [AnyHashable], element: AnyHashable) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_element(list: [\"green\", \"orange\", \"black\", \"white\"], element: \"blue\") == false)\nassert(check_element(list: [1, 2, 3, 4], element: 7) == false)\nassert(check_element(list: [\"green\", \"green\", \"green\", \"green\"], element: \"green\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str: [String], l: Int) -> [String] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 8) == [\"practice\", \"solution\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 6) == [\"Python\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 9) == [\"exercises\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "swift",
-    "prompt": "\n/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text: String) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_lowercase_underscore(text: \"aab_cbbbc\") == true)\nassert(text_lowercase_underscore(text: \"aab_Abbbc\") == false)\nassert(text_lowercase_underscore(text: \"Aaab_abbbc\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list: [[Int]], K: Int) -> [[Int]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 2) == [[2], [9], [2], [2]])\nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\nassert(trim_tuple(test_list: [[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], K: 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the sublist having minimum length.\nfunc Find_Min(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min(lst: [[1], [1, 2], [1, 2, 3]]) == [1])\nassert(Find_Min(lst: [[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\nassert(Find_Min(lst: [[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_oddnumbers(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\nassert(filter_oddnumbers(nums: [10, 20, 45, 67, 84, 93]) == [45, 67, 93])\nassert(filter_oddnumbers(nums: [5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverbs(text: \"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\nassert(find_adverbs(text: \"Please handle the situation carefuly\") == \"28-36: carefuly\")\nassert(find_adverbs(text: \"Complete the task quickly\") == \"18-25: quickly\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "swift",
-    "prompt": "\n/// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list: [[Int]], N: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_of_nth(test_list: [[5, 6, 7], [1, 3, 5], [8, 9, 19]], N: 2) == 19)\nassert(max_of_nth(test_list: [[6, 7, 8], [2, 4, 6], [9, 10, 20]], N: 1) == 10)\nassert(max_of_nth(test_list: [[7, 8, 9], [3, 5, 7], [10, 11, 21]], N: 1) == 11)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n: Int) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(n: 8) == \"1000\")\nassert(decimal_to_binary(n: 18) == \"10010\")\nassert(decimal_to_binary(n: 7) == \"111\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l: [String], n: Int) -> [[String]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text: String) -> String {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_all_spaces(text: \"python  program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"python   programming    language\") == \"pythonprogramminglanguage\")\nassert(remove_all_spaces(text: \"python                     program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"   python                     program\") == \"pythonprogram\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1: String, str2: String) -> AnyHashable {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Swaps(str1: \"1101\", str2: \"1110\") == 1)\nassert(min_Swaps(str1: \"111\", str2: \"000\") == \"Not Possible\")\nassert(min_Swaps(str1: \"111\", str2: \"110\") == \"Not Possible\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create a new tuple from the given string and list.\nfunc new_tuple(test_list: [String], test_str: String) -> (String, String, String) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(new_tuple(test_list: [\"WEB\", \"is\"], test_str: \"best\") == (\"WEB\", \"is\", \"best\"))\nassert(new_tuple(test_list: [\"We\", \"are\"], test_str: \"Developers\") == (\"We\", \"are\", \"Developers\"))\nassert(new_tuple(test_list: [\"Part\", \"is\"], test_str: \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_remainder(arr: [100, 10, 5, 25, 35, 14], n: 11) == 9)\nassert(find_remainder(arr: [1, 1, 1], n: 1) == 0)\nassert(find_remainder(arr: [1, 2, 1], n: 2) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the minimum value in a given heterogeneous list.\nfunc min_val(listval: [Result<String, Int>]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 2)\nassert(min_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 15)\nassert(min_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 20)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums: [Int]) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(positive_count(nums: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\nassert(positive_count(nums: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\nassert(positive_count(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to add the given tuple to the given list.\nfunc add_tuple(test_list: [Int], test_tup: (Int, Int)) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_tuple(test_list: [5, 6, 7], test_tup: (9, 10)) == [5, 6, 7, 9, 10])\nassert(add_tuple(test_list: [6, 7, 8], test_tup: (10, 11)) == [6, 7, 8, 10, 11])\nassert(add_tuple(test_list: [7, 8, 9], test_tup: (11, 12)) == [7, 8, 9, 11, 12])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_run_uppercase(test_str: \"GeMKSForGERksISBESt\") == 5)\nassert(max_run_uppercase(test_str: \"PrECIOusMOVemENTSYT\") == 6)\nassert(max_run_uppercase(test_str: \"GooGLEFluTTER\") == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M: [[Int]]) -> [[Int]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_matrix(M: [[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\nassert(sort_matrix(M: [[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\nassert(sort_matrix(M: [[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_vowels(test_str: \"bestinstareels\") == 7)\nassert(count_vowels(test_str: \"partofthejourneyistheend\") == 12)\nassert(count_vowels(test_str: \"amazonprime\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a: [Int], n: Int, index: Int, k: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 4, k: 6) == 11)\nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 2, k: 5) == 7)\nassert(max_sum_increasing_subseq(a: [11, 15, 19, 21, 26, 28, 31], n: 7, index: 2, k: 4) == 71)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_int(x: 10, y: 20) == 200)\nassert(multiply_int(x: 5, y: 10) == 50)\nassert(multiply_int(x: 4, y: 8) == 32)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4408,7 +244,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find words that are longer than n characters from a given list of words.\nfunc long_words(n: Int, str: String) -> [String] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(long_words(n: 3, str: \"python is a programming language\") == [\"python\", \"programming\", \"language\"])\nassert(long_words(n: 2, str: \"writing a program\") == [\"writing\", \"program\"])\nassert(long_words(n: 5, str: \"sorting list\") == [\"sorting\"])",
     "stop_tokens": [
@@ -4416,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr: [Int]) -> Int {\n",
+    "prompt": "\n/// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix: [[Int]]) -> Bool {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_sum(arr: [1, 2, 3, 1, 1, 4, 5, 6]) == 21)\nassert(find_sum(arr: [1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\nassert(find_sum(arr: [12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(magic_square_test(my_matrix: [[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "swift",
-    "prompt": "\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup: (Int, Int, Int, Int, Int, Int)) -> [Int : Int] {\n",
+    "prompt": "\n/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M: [[Int]]) -> [[Int]] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_dict(test_tup: (1, 5, 7, 10, 13, 5)) == [1 : 5, 7 : 10, 13 : 5])\nassert(tuple_to_dict(test_tup: (1, 2, 3, 4, 5, 6)) == [1 : 2, 3 : 4, 5 : 6])\nassert(tuple_to_dict(test_tup: (7, 8, 9, 10, 11, 12)) == [7 : 8, 9 : 10, 11 : 12])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_matrix(M: [[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\nassert(sort_matrix(M: [[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\nassert(sort_matrix(M: [[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "swift",
-    "prompt": "\n/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup: (Int, Int)) -> [[Int]] {\n",
+    "prompt": "\n/// Write a function to find the item with maximum frequency in a given list.\nfunc max_occurrences(nums: [Int]) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_coordinates(test_tup: (3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\nassert(get_coordinates(test_tup: (4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\nassert(get_coordinates(test_tup: (5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple: AnyHashable) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_type(test_tuple: (5, 6, 7, 3, 5, 6)) == true)\nassert(check_type(test_tuple: (1, 2, \"4\")) == false)\nassert(check_type(test_tuple: (3, 2, 1, 4, 5)) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array: [Int]) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_First_Missing(array: [0, 1, 2, 3]) == 4)\nassert(find_First_Missing(array: [0, 1, 2, 6, 9]) == 3)\nassert(find_First_Missing(array: [2, 3, 5, 8, 9]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n: Int) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_undulating(n: 1212121) == true)\nassert(is_undulating(n: 1991) == false)\nassert(is_undulating(n: 121) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunc min_k(test_list: [(String, Int)], K: Int) -> [(String, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_k(test_list: [(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], K: 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\nassert(min_k(test_list: [(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], K: 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\nassert(min_k(test_list: [(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], K: 1) == [(\"Ayesha\", 9)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s: String) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Substrings(s: \"112112\") == 6)\nassert(count_Substrings(s: \"111\") == 6)\nassert(count_Substrings(s: \"1101112\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_num_decagonal(n: 3) == 27)\nassert(is_num_decagonal(n: 7) == 175)\nassert(is_num_decagonal(n: 10) == 370)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunc rear_extract(test_list: [(Int, String, Int)]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rear_extract(test_list: [(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\nassert(rear_extract(test_list: [(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\nassert(rear_extract(test_list: [(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the closest smaller number than n.\nfunc closest_num(N: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_num(N: 11) == 10)\nassert(closest_num(N: 7) == 6)\nassert(closest_num(N: 12) == 11)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunc find_combinations(test_list: [(Int, Int)]) -> [(Int, Int)] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_combinations(test_list: [(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\nassert(find_combinations(test_list: [(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\nassert(find_combinations(test_list: [(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "swift",
-    "prompt": "\n/// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost: [[Int]]) -> Double {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maxAverageOfPath(cost: [[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\nassert(maxAverageOfPath(cost: [[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\nassert(maxAverageOfPath(cost: [[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\nassert(maxAverageOfPath(cost: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist: [Int], item: Int) -> (Bool, Int) {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequential_search(dlist: [11, 23, 58, 31, 56, 77, 43, 12, 65, 19], item: 31) == (true, 3))\nassert(sequential_search(dlist: [12, 32, 45, 62, 35, 47, 44, 61], item: 61) == (true, 7))\nassert(sequential_search(dlist: [9, 10, 17, 19, 22, 39, 48, 56], item: 48) == (true, 6))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to remove odd numbers from a given list.\nfunc remove_odd(l: [Int]) -> [Int] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(l: [1, 2, 3]) == [2])\nassert(remove_odd(l: [2, 4, 6]) == [2, 4, 6])\nassert(remove_odd(l: [10, 20, 3]) == [10, 20])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr: [Int]) -> Bool {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_product_even(arr: [1, 2, 3]) == true)\nassert(is_product_even(arr: [1, 2, 1, 4]) == true)\nassert(is_product_even(arr: [1, 1]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "swift",
-    "prompt": "\n/// Write a python function to find the maximum of two numbers.\nfunc maximum(a: Int, b: Int) -> Int {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(a: 5, b: 10) == 10)\nassert(maximum(a: -1, b: -2) == -1)\nassert(maximum(a: 9, b: 7) == 9)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\nassert(max_occurrences(nums: [10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4624,9 +292,609 @@
     "language": "swift",
     "prompt": "\n/// Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfunc reverse_vowels(str1: String) -> String {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_vowels(str1: \"Python\") == \"Python\")\nassert(reverse_vowels(str1: \"USA\") == \"ASU\")\nassert(reverse_vowels(str1: \"ab\") == \"ab\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a list to a string.\nfunc tup_string(tup1: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tup_string(tup1: [\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\nassert(tup_string(tup1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\nassert(tup_string(tup1: [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunc sum_negativenum(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_negativenum(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\nassert(sum_negativenum(nums: [10, 15, -14, 13, -18, 12, -20]) == -52)\nassert(sum_negativenum(nums: [19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hexagonal_num(n: 10) == 190)\nassert(hexagonal_num(n: 5) == 45)\nassert(hexagonal_num(n: 7) == 91)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sum_Of_Powers_Of_Two(n: 10) == true)\nassert(is_Sum_Of_Powers_Of_Two(n: 7) == false)\nassert(is_Sum_Of_Powers_Of_Two(n: 14) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a list of elements.\nfunc pancake_sort(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pancake_sort(nums: [15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\nassert(pancake_sort(nums: [98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\nassert(pancake_sort(nums: [41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count number items that are identical in the same position of three given lists.\nfunc count_samepair(list1: [Int], list2: [Int], list3: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 9], list3: [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\nassert(count_samepair(list1: [1, 2, 3, 4, 2, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find number of lists present in the given list.\nfunc find_lists(Input: [AnyHashable]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lists(Input: [[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\nassert(find_lists(Input: [[1, 2], [3, 4], [5, 6]]) == 3)\nassert(find_lists(Input: [9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Abs_Diff(arr: [2, 1, 5, 3]) == 4)\nassert(max_Abs_Diff(arr: [9, 3, 2, 5, 1]) == 8)\nassert(max_Abs_Diff(arr: [3, 2, 1]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the volume of a triangular prism.\nfunc find_Volume(l: Int, b: Int, h: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Volume(l: 10, b: 8, h: 6) == 240)\nassert(find_Volume(l: 3, b: 2, h: 2) == 6)\nassert(find_Volume(l: 1, b: 2, h: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunc find_solution(a: Int, b: Int, n: Int) -> (Int, Int)? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_solution(a: 2, b: 3, n: 7) == (2, 1))\nassert(find_solution(a: 4, b: 2, n: 7) == nil)\nassert(find_solution(a: 1, b: 13, n: 17) == (4, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all elements from a given list present in another list.\nfunc remove_elements(list1: [Int], list2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_series(n: 6) == 12)\nassert(sum_series(n: 10) == 30)\nassert(sum_series(n: 9) == 25)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "swift",
+    "prompt": "\n/// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1: Int, num2: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(are_equivalent(num1: 36, num2: 57) == false)\nassert(are_equivalent(num1: 2, num2: 4) == false)\nassert(are_equivalent(num1: 23, num2: 47) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_char_position(str1: \"xbcefg\") == 2)\nassert(count_char_position(str1: \"ABcED\") == 3)\nassert(count_char_position(str1: \"AbgdeF\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "swift",
+    "prompt": "\n/// Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunc find_even_pair(A: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_even_pair(A: [5, 4, 7, 2, 1]) == 4)\nassert(find_even_pair(A: [7, 2, 8, 1, 0, 5, 11]) == 9)\nassert(find_even_pair(A: [1, 2, 3]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_power_of_2(n: 0) == 1)\nassert(next_power_of_2(n: 5) == 8)\nassert(next_power_of_2(n: 17) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of occurrences of a number in a given list.\nfunc frequency(a: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency(a: [1, 2, 3], x: 4) == 0)\nassert(frequency(a: [1, 2, 2, 3, 3, 3, 4], x: 3) == 3)\nassert(frequency(a: [0, 1, 2, 3, 1, 2], x: 1) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "swift",
+    "prompt": "\n/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_lowercase_underscore(text: \"aab_cbbbc\") == true)\nassert(text_lowercase_underscore(text: \"aab_Abbbc\") == false)\nassert(text_lowercase_underscore(text: \"Aaab_abbbc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunc sum_range_list(list1: [Int], m: Int, n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 8, n: 10) == 29)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 5, n: 7) == 16)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 7, n: 10) == 38)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perimeter_pentagon(a: 5) == 25)\nassert(perimeter_pentagon(a: 10) == 50)\nassert(perimeter_pentagon(a: 15) == 75)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_occurance(s: \"letstdlenstdporstd\") == 3)\nassert(count_occurance(s: \"truststdsolensporsd\") == 1)\nassert(count_occurance(s: \"makestdsostdworthit\") == 2)\nassert(count_occurance(s: \"stds\") == 1)\nassert(count_occurance(s: \"\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_perimeter(a: 10) == 40)\nassert(square_perimeter(a: 5) == 20)\nassert(square_perimeter(a: 4) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(string: String, second_string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_dirty_chars(string: \"probasscurve\", second_string: \"pros\") == \"bacuve\")\nassert(remove_dirty_chars(string: \"digitalindia\", second_string: \"talent\") == \"digiidi\")\nassert(remove_dirty_chars(string: \"exoticmiles\", second_string: \"toxic\") == \"emles\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_duplicate(arraynums: [1, 2, 3, 4, 5]) == false)\nassert(test_duplicate(arraynums: [1, 2, 3, 4, 4]) == true)\nassert(test_duplicate(arraynums: [1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_woodall(x: 383) == true)\nassert(is_woodall(x: 254) == false)\nassert(is_woodall(x: 200) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple: AnyHashable) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_type(test_tuple: (5, 6, 7, 3, 5, 6)) == true)\nassert(check_type(test_tuple: (1, 2, \"4\")) == false)\nassert(check_type(test_tuple: (3, 2, 1, 4, 5)) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr: [Int], n: Int, x: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_majority(arr: [1, 2, 3, 3, 3, 3, 10], n: 7, x: 3) == true)\nassert(is_majority(arr: [1, 1, 2, 4, 4, 4, 6, 6], n: 8, x: 4) == false)\nassert(is_majority(arr: [1, 1, 1, 2, 2], n: 5, x: 1) == true)\nassert(is_majority(arr: [1, 1, 2, 2], n: 5, x: 1) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Set_Bits(n: 2) == 1)\nassert(count_Set_Bits(n: 4) == 1)\nassert(count_Set_Bits(n: 6) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_values_string(str: \"abcdef\") == \"ace\")\nassert(odd_values_string(str: \"python\") == \"pto\")\nassert(odd_values_string(str: \"data\") == \"dt\")\nassert(odd_values_string(str: \"lambs\") == \"lms\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find minimum of three numbers.\nfunc min_of_three(a: Int, b: Int, c: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_of_three(a: 10, b: 20, c: 0) == 0)\nassert(min_of_three(a: 19, b: 15, c: 18) == 15)\nassert(min_of_three(a: -10, b: -20, c: -30) == -30)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n: Int, l: Int, r: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Bits_Set_In_The_Given_Range(n: 4, l: 1, r: 2) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 17, l: 2, r: 4) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 39, l: 4, r: 6) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr: [Int], n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(re_arrange_array(arr: [-1, 2, -3, 4, 5, 6, -7, 8, 9], n: 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\nassert(re_arrange_array(arr: [12, -14, -26, 13, 15], n: 5) == [-14, -26, 12, 13, 15])\nassert(re_arrange_array(arr: [10, 24, 36, -42, -39, -78, 85], n: 7) == [-42, -39, -78, 10, 24, 36, 85])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1: String, char: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_blank(str1: \"hello people\", char: \"@\") == \"hello@people\")\nassert(replace_blank(str1: \"python program language\", char: \"$\") == \"python$program$language\")\nassert(replace_blank(str1: \"blank space\", char: \"-\") == \"blank-space\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(volume_cube(l: 3) == 27)\nassert(volume_cube(l: 2) == 8)\nassert(volume_cube(l: 5) == 125)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a list of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the list.\nfunc check_occurences(test_list: [(Int, Int)]) -> [(Int, Int) : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_occurences(test_list: [(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == [(1, 3) : 2, (2, 5) : 2, (3, 6) : 1])\nassert(check_occurences(test_list: [(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == [(2, 4) : 2, (3, 6) : 2, (4, 7) : 1])\nassert(check_occurences(test_list: [(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == [(2, 13) : 1, (11, 23) : 1, (12, 25) : 2, (16, 23) : 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_of_substrings(str: \"abc\") == 6)\nassert(number_of_substrings(str: \"abcd\") == 10)\nassert(number_of_substrings(str: \"abcde\") == 15)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m: Int, n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_total_number_of_sequences(m: 10, n: 4) == 4)\nassert(get_total_number_of_sequences(m: 5, n: 2) == 6)\nassert(get_total_number_of_sequences(m: 16, n: 3) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunc replace_list(list1: [AnyHashable], list2: [AnyHashable]) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_list(list1: [1, 3, 5, 7, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\nassert(replace_list(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\nassert(replace_list(list1: [\"red\", \"blue\", \"green\"], list2: [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the total number of characters in a string.\nfunc count_charac(str1: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_charac(str1: \"python programming\") == 18)\nassert(count_charac(str1: \"language\") == 8)\nassert(count_charac(str1: \"words\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_Perfect_Square(N: 35) == 36)\nassert(next_Perfect_Square(N: 6) == 9)\nassert(next_Perfect_Square(N: 9) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum(arr: [1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\nassert(max_sum(arr: [80, 60, 30, 40, 20, 10]) == 210)\nassert(max_sum(arr: [2, 3, 14, 16, 21, 23, 29, 30]) == 138)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lps(str: \"TENS FOR TENS\") == 5)\nassert(lps(str: \"CARDIO FOR CARDS\") == 7)\nassert(lps(str: \"PART OF THE JOURNEY IS PART\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1: [Int], array_nums2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [3, 5, 7, 9]) == [3, 5, 7, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [10, 20, 30, 40]) == [10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "swift",
+    "prompt": "\n/// Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunc count_X(tup: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 4) == 0)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 10) == 3)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 8) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunc insert_element(list: [String], element: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(insert_element(list: [\"Red\", \"Green\", \"Black\"], element: \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\nassert(insert_element(list: [\"python\", \"java\"], element: \"program\") == [\"program\", \"python\", \"program\", \"java\"])\nassert(insert_element(list: [\"happy\", \"sad\"], element: \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to convert complex numbers to polar coordinates.\nfunc convert(numbers: Int) -> (Double, Double) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert(numbers: 1) == (1.0, 0.0))\nassert(convert(numbers: 4) == (4.0, 0.0))\nassert(convert(numbers: 5) == (5.0, 0.0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case stringValue(String)\n    case doubleValue(Double)\n}\n\n            \n/// Write a python function that returns the number of integer elements in a given list.\nfunc count_integer(list1: [Value]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_integer(list1: [.intValue(1), .intValue(2), .stringValue(\"abc\"), .doubleValue(1.2)]) == 2)\nassert(count_integer(list1: [.intValue(1), .intValue(2), .intValue(3)]) == 3)\nassert(count_integer(list1: [.intValue(1), .doubleValue(1.2), .intValue(4), .doubleValue(5.1)]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunc combinations_colors(l: [String], n: Int) -> [[String]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Primes_nums(n: 5) == 2)\nassert(count_Primes_nums(n: 10) == 4)\nassert(count_Primes_nums(n: 100) == 25)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunc swap_numbers(a: Int, b: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_numbers(a: 10, b: 20) == [20, 10])\nassert(swap_numbers(a: 15, b: 17) == [17, 15])\nassert(swap_numbers(a: 100, b: 200) == [200, 100])",
     "stop_tokens": [
       "\n}"
     ]
@@ -4636,7 +904,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to maximize the given two lists.\nfunc maximize_elements(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximize_elements(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]])\nassert(maximize_elements(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]])\nassert(maximize_elements(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]])",
     "stop_tokens": [
@@ -4644,73 +912,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "swift",
-    "prompt": "\n/// Write a python function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums: [Int]) -> Bool {\n",
+    "prompt": "\n/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_position(nums: [3, 2, 1]) == false)\nassert(even_position(nums: [1, 2, 3]) == false)\nassert(even_position(nums: [2, 1, 4]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(newman_prime(n: 3) == 7)\nassert(newman_prime(n: 4) == 17)\nassert(newman_prime(n: 5) == 41)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(string: String) -> String {\n",
+    "prompt": "\n/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_char(string: \"abba\") == \"Valid\")\nassert(check_char(string: \"a\") == \"Valid\")\nassert(check_char(string: \"abcd\") == \"Invalid\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(division_elements(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (2, 2, 2, 3))\nassert(division_elements(test_tup1: (12, 6, 8, 16), test_tup2: (6, 3, 4, 4)) == (2, 2, 2, 4))\nassert(division_elements(test_tup1: (20, 14, 36, 18), test_tup2: (5, 7, 6, 9)) == (4, 2, 6, 2))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "swift",
-    "prompt": "\n/// Write a python function to find the sum of even factors of a number.\nfunc sumofFactors(n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunc split_two_parts(list1: [AnyHashable], L: Int) -> AnyHashable {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sumofFactors(n: 18) == 26)\nassert(sumofFactors(n: 30) == 48)\nassert(sumofFactors(n: 6) == 8)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_two_parts(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\nassert(split_two_parts(list1: [\"a\", \"b\", \"c\", \"d\"], L: 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\nassert(split_two_parts(list1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], L: 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r: Int, h: Int) -> Double {\n",
+    "prompt": "\n/// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cone(r: 5, h: 12) == 204.20352248333654)\nassert(lateralsurface_cone(r: 10, h: 15) == 566.3586699569488)\nassert(lateralsurface_cone(r: 19, h: 17) == 1521.8090132193388)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dog_age(h_age: 12) == 61)\nassert(dog_age(h_age: 15) == 73)\nassert(dog_age(h_age: 24) == 109)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "swift",
-    "prompt": "\n/// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr: [Int], n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunc list_split(S: [AnyHashable], step: Int) -> [[AnyHashable]] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Pairs(arr: [1, 2, 1], n: 3) == 2)\nassert(count_Pairs(arr: [1, 1, 1, 1], n: 4) == 0)\nassert(count_Pairs(arr: [1, 2, 3, 4, 5], n: 5) == 10)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_split(S: [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], step: 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\nassert(list_split(S: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], step: 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\nassert(list_split(S: [\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], step: 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A: [Int], x: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_first_occurrence(A: [2, 5, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 1)\nassert(find_first_occurrence(A: [2, 3, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 2)\nassert(find_first_occurrence(A: [2, 4, 1, 5, 6, 6, 8, 9, 9, 9], x: 6) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cube(l: 5) == 100)\nassert(lateralsurface_cube(l: 9) == 324)\nassert(lateralsurface_cube(l: 10) == 400)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4720,9 +988,729 @@
     "language": "swift",
     "prompt": "\n/// Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 10)\nassert(square_Sum(n: 3) == 35)\nassert(square_Sum(n: 4) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n'th star number.\nfunc find_star_num(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_star_num(n: 3) == 37)\nassert(find_star_num(n: 4) == 73)\nassert(find_star_num(n: 5) == 121)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the ascii value of a character.\nfunc ascii_value(k: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(ascii_value(k: \"A\") == 65)\nassert(ascii_value(k: \"R\") == 82)\nassert(ascii_value(k: \"S\") == 83)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of even numbers at even positions of a list.\nfunc sum_even_and_even_index(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_even_and_even_index(arr: [5, 6, 12, 1, 18, 8]) == 30)\nassert(sum_even_and_even_index(arr: [3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\nassert(sum_even_and_even_index(arr: [5, 6, 12, 1]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_Power_Sum(n: 2) == 1056)\nassert(even_Power_Sum(n: 3) == 8832)\nassert(even_Power_Sum(n: 1) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunc rear_extract(test_list: [(Int, String, Int)]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rear_extract(test_list: [(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\nassert(rear_extract(test_list: [(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\nassert(rear_extract(test_list: [(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> (Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(substract_elements(test_tup1: (10, 4, 5), test_tup2: (2, 5, 18)) == (8, -1, -13))\nassert(substract_elements(test_tup1: (11, 2, 3), test_tup2: (24, 45, 16)) == (-13, -43, -13))\nassert(substract_elements(test_tup1: (7, 18, 9), test_tup2: (10, 11, 12)) == (-3, 7, -3))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_binomial_Coeff_Sum(n: 4) == 8)\nassert(even_binomial_Coeff_Sum(n: 6) == 32)\nassert(even_binomial_Coeff_Sum(n: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict: [String : Int], n: Int) -> [String : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 170) == [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 180) == [\"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 190) == [\"Pierre Cox\" : 190])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "swift",
+    "prompt": "\nextension (Int, Int): Error {}\n        \n/// Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunc count_first_elements(test_tup: [Result<Int, (Int, Int)>]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_first_elements(test_tup: [.success(1), .success(5), .success(7), .failure((4, 6)), .success(10)]) == 3)\nassert(count_first_elements(test_tup: [.success(2), .success(9), .failure((5, 7)), .success(11)]) == 2)\nassert(count_first_elements(test_tup: [.success(11), .success(15), .success(5), .success(8), .failure((2, 3)), .success(8)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_num_decagonal(n: 3) == 27)\nassert(is_num_decagonal(n: 7) == 175)\nassert(is_num_decagonal(n: 10) == 370)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist: [Int], item: Int) -> (Bool, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequential_search(dlist: [11, 23, 58, 31, 56, 77, 43, 12, 65, 19], item: 31) == (true, 3))\nassert(sequential_search(dlist: [12, 32, 45, 62, 35, 47, 44, 61], item: 61) == (true, 7))\nassert(sequential_search(dlist: [9, 10, 17, 19, 22, 39, 48, 56], item: 48) == (true, 6))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check if the elements of a given list are unique or not.\nfunc all_unique(test_list: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_unique(test_list: [1, 2, 3]) == true)\nassert(all_unique(test_list: [1, 2, 1, 2]) == false)\nassert(all_unique(test_list: [1, 2, 3, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to subtract two lists element-wise.\nfunc sub_list(nums1: [Int], nums2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sub_list(nums1: [1, 2, 3], nums2: [4, 5, 6]) == [-3, -3, -3])\nassert(sub_list(nums1: [1, 2], nums2: [3, 4]) == [-2, -2])\nassert(sub_list(nums1: [90, 120], nums2: [50, 70]) == [40, 50])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "swift",
+    "prompt": "\n/// Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(validate(n: 1234) == true)\nassert(validate(n: 51241) == false)\nassert(validate(n: 321) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunc check_element(list: [AnyHashable], element: AnyHashable) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_element(list: [\"green\", \"orange\", \"black\", \"white\"], element: \"blue\") == false)\nassert(check_element(list: [1, 2, 3, 4], element: 7) == false)\nassert(check_element(list: [\"green\", \"green\", \"green\", \"green\"], element: \"green\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_two_three(text: \"ac\") == false)\nassert(text_match_two_three(text: \"dc\") == false)\nassert(text_match_two_three(text: \"abbbba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a: [Int], n: Int, k: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum_repeated(a: [10, 20, -30, -1], n: 4, k: 3) == 30)\nassert(max_sub_array_sum_repeated(a: [-1, 10, 20], n: 3, k: 2) == 59)\nassert(max_sub_array_sum_repeated(a: [-1, -2, -3], n: 3, k: 3) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 20)\nassert(square_Sum(n: 3) == 56)\nassert(square_Sum(n: 4) == 120)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the list of maximum length in a list of lists.\nfunc max_length(list1: [[Int]]) -> (Int, [Int]) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length(list1: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length(list1: [[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\nassert(max_length(list1: [[5], [15, 20, 25]]) == (3, [15, 20, 25]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n: Int, k: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_no_of_ways(n: 2, k: 4) == 16)\nassert(count_no_of_ways(n: 3, k: 2) == 6)\nassert(count_no_of_ways(n: 4, k: 4) == 228)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n: Int, m: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find(n: 10, m: 3) == 3)\nassert(find(n: 4, m: 2) == 2)\nassert(find(n: 20, m: 5) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w: Int, h: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(otherside_rightangle(w: 7, h: 8) == 10.63014581273465)\nassert(otherside_rightangle(w: 3, h: 4) == 5)\nassert(otherside_rightangle(w: 7, h: 15) == 16.55294535724685)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the maximum value in a given heterogeneous list.\nfunc max_val(listval: [Result<String, Int>]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 5)\nassert(max_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 25)\nassert(max_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 50)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_div(number: 8) == 7)\nassert(sum_div(number: 12) == 16)\nassert(sum_div(number: 7) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count inversions in an array.\nfunc get_Inv_Count(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Inv_Count(arr: [1, 20, 6, 4, 5]) == 5)\nassert(get_Inv_Count(arr: [1, 2, 1]) == 1)\nassert(get_Inv_Count(arr: [1, 2, 5, 6, 1]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "swift",
+    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a given nested list structure.\nfunc flatten_list(list1: [Result<Int, [Int]>]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flatten_list(list1: [.success(0), .success(10), .failure([20, 30]), .success(40), .success(50), .failure([60, 70, 80]), .failure([90, 100, 110, 120])]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\nassert(flatten_list(list1: [.failure([10, 20]), .failure([40]), .failure([30, 56, 25]), .failure([10, 20]), .failure([33]), .failure([40])]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\nassert(flatten_list(list1: [.failure([1, 2, 3]), .failure([4, 5, 6]), .failure([10, 11, 12]), .failure([7, 8, 9])]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the maximum aggregate from the list of tuples.\nfunc max_aggregate(stdata: [(String, Int)]) -> (String, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_aggregate(stdata: [(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find element at a given index after number of rotations.\nfunc find_Element(arr: [Int], ranges: [[Int]], rotations: Int, index: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Element(arr: [1, 2, 3, 4, 5], ranges: [[0, 2], [0, 3]], rotations: 2, index: 1) == 3)\nassert(find_Element(arr: [1, 2, 3, 4], ranges: [[0, 1], [0, 2]], rotations: 1, index: 2) == 3)\nassert(find_Element(arr: [1, 2, 3, 4, 5, 6], ranges: [[0, 1], [0, 2]], rotations: 1, index: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return two words from a list of words starting with letter 'p'.\nfunc start_withp(words: [String]) -> (String, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(start_withp(words: [\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\nassert(start_withp(words: [\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\nassert(start_withp(words: [\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a: [Int], n: Int, index: Int, k: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 4, k: 6) == 11)\nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 2, k: 5) == 7)\nassert(max_sum_increasing_subseq(a: [11, 15, 19, 21, 26, 28, 31], n: 7, index: 2, k: 4) == 71)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunc large_product(nums1: [Int], nums2: [Int], N: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 3) == [60, 54, 50])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 4) == [60, 54, 50, 48])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 5) == [60, 54, 50, 48, 45])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the maximum of two numbers.\nfunc maximum(a: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(a: 5, b: 10) == 10)\nassert(maximum(a: -1, b: -2) == -1)\nassert(maximum(a: 9, b: 7) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a given string to a list of characters.\nfunc string_to_tuple(str1: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_tuple(str1: \"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\nassert(string_to_tuple(str1: \"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\nassert(string_to_tuple(str1: \"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(highest_Power_of_2(n: 10) == 8)\nassert(highest_Power_of_2(n: 19) == 16)\nassert(highest_Power_of_2(n: 32) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n'th lucas number.\nfunc find_lucas(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lucas(n: 9) == 76)\nassert(find_lucas(n: 4) == 7)\nassert(find_lucas(n: 3) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to apply a given format string to all of the elements in a list.\nfunc add_string(list_: [AnyHashable], string: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_string(list_: [1, 2, 3, 4], string: \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\nassert(add_string(list_: [\"a\", \"b\", \"c\", \"d\"], string: \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\nassert(add_string(list_: [5, 6, 7, 8], string: \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert more than one list to nested dictionary.\nfunc convert_list_dictionary(l1: [String], l2: [String], l3: [Int]) -> [[String : [String : Int]]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert_list_dictionary(l1: [\"S001\", \"S002\", \"S003\", \"S004\"], l2: [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], l3: [85, 98, 89, 92]) == [[\"S001\" : [\"Adina Park\" : 85]], [\"S002\" : [\"Leyton Marsh\" : 98]], [\"S003\" : [\"Duncan Boyle\" : 89]], [\"S004\" : [\"Saim Richards\" : 92]]])\nassert(convert_list_dictionary(l1: [\"abc\", \"def\", \"ghi\", \"jkl\"], l2: [\"python\", \"program\", \"language\", \"programs\"], l3: [100, 200, 300, 400]) == [[\"abc\" : [\"python\" : 100]], [\"def\" : [\"program\" : 200]], [\"ghi\" : [\"language\" : 300]], [\"jkl\" : [\"programs\" : 400]]])\nassert(convert_list_dictionary(l1: [\"A1\", \"A2\", \"A3\", \"A4\"], l2: [\"java\", \"C\", \"C++\", \"DBMS\"], l3: [10, 20, 30, 40]) == [[\"A1\" : [\"java\" : 10]], [\"A2\" : [\"C\" : 20]], [\"A3\" : [\"C++\" : 30]], [\"A4\" : [\"DBMS\" : 40]]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_sum(n: 60) == 106)\nassert(get_max_sum(n: 10) == 12)\nassert(get_max_sum(n: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the list with maximum length.\nfunc max_length_list(input_list: [[Int]]) -> (Int, [Int]) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length_list(input_list: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length_list(input_list: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\nassert(max_length_list(input_list: [[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if given list contains no duplicates.\nfunc check_distinct(test_tup: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_distinct(test_tup: [1, 4, 5, 6, 1, 4]) == false)\nassert(check_distinct(test_tup: [1, 4, 5, 6]) == true)\nassert(check_distinct(test_tup: [2, 3, 4, 5, 6]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the first non-repeated character in a given string.\nfunc first_non_repeating_character(str1: String) -> String? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_non_repeating_character(str1: \"abcabc\") == nil)\nassert(first_non_repeating_character(str1: \"abc\") == \"a\")\nassert(first_non_repeating_character(str1: \"ababc\") == \"c\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_char(string: \"abba\") == \"Valid\")\nassert(check_char(string: \"a\") == \"Valid\")\nassert(check_char(string: \"abcd\") == \"Invalid\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median of three numbers.\nfunc median_numbers(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_numbers(a: 25, b: 55, c: 65) == 55.0)\nassert(median_numbers(a: 20, b: 10, c: 30) == 20.0)\nassert(median_numbers(a: 15, b: 45, c: 75) == 45.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to compute the sum of digits of each number of a given list.\nfunc sum_of_digits(nums: [AnyHashable]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_of_digits(nums: [10, 2, 56]) == 14)\nassert(sum_of_digits(nums: [[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\nassert(sum_of_digits(nums: [10, 20, -4, 5, -70]) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bitwise_xor(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (15, 6, 5, 10))\nassert(bitwise_xor(test_tup1: (11, 5, 7, 10), test_tup2: (6, 3, 4, 4)) == (13, 6, 3, 14))\nassert(bitwise_xor(test_tup1: (12, 6, 8, 11), test_tup2: (7, 4, 5, 6)) == (11, 2, 13, 13))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to identify non-prime numbers.\nfunc is_not_prime(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_not_prime(n: 2) == false)\nassert(is_not_prime(n: 10) == true)\nassert(is_not_prime(n: 35) == true)\nassert(is_not_prime(n: 37) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the number of unique tuples in the given list.\nfunc extract_freq(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_freq(test_list: [(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\nassert(extract_freq(test_list: [(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\nassert(extract_freq(test_list: [(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform index wise addition of list elements in the given two nested lists.\nfunc add_nested_tuples(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_nested_tuples(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\nassert(add_nested_tuples(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\nassert(add_nested_tuples(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the minimum of two numbers.\nfunc minimum(a: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minimum(a: 1, b: 2) == 1)\nassert(minimum(a: -5, b: -4) == -5)\nassert(minimum(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to check whether an element exists within a tuple.\nfunc check_tuplex(tuplex: [Result<String, Int>], tuple1: AnyHashable) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"r\") == true)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"5\") == false)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: 3) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find whether the parity of a given number is odd.\nfunc find_Parity(x: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Parity(x: 12) == false)\nassert(find_Parity(x: 7) == true)\nassert(find_Parity(x: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n: Int) -> AnyHashable {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rearrange_bigger(n: 12) == 21)\nassert(rearrange_bigger(n: 10) == false)\nassert(rearrange_bigger(n: 102) == 120)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1: [Int], nums2: [Int], k: Int) -> [[Int]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 2) == [[1, 2], [1, 4]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 1) == [[1, 2]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the minimum product from the pairs of tuples within a given list.\nfunc min_product_tuple(list1: [(Int, Int)]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\nassert(min_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 30)\nassert(min_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the minimum value in a given heterogeneous list.\nfunc min_val(listval: [Result<String, Int>]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 2)\nassert(min_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 15)\nassert(min_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 20)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"android_tv\") == \"AndroidTv\")\nassert(snake_to_camel(word: \"google_pixel\") == \"GooglePixel\")\nassert(snake_to_camel(word: \"apple_watch\") == \"AppleWatch\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to remove odd numbers from a given list.\nfunc remove_odd(l: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(l: [1, 2, 3]) == [2])\nassert(remove_odd(l: [2, 4, 6]) == [2, 4, 6])\nassert(remove_odd(l: [10, 20, 3]) == [10, 20])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the nth element from a given list of tuples.\nfunc extract_nth_element(list1: [(String, Int, Int)], n: Int) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 2) == [99, 96, 94, 98])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 1) == [98, 97, 91, 94])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1: [Int], list2: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(overlapping(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == false)\nassert(overlapping(list1: [1, 2, 3], list2: [4, 5, 6]) == false)\nassert(overlapping(list1: [1, 4, 5], list2: [1, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr: [Int]) -> (Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Product(arr: [1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\nassert(max_Product(arr: [0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\nassert(max_Product(arr: [1, 2, 3]) == (2, 3))",
     "stop_tokens": [
       "\n}"
     ]
@@ -4732,7 +1720,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find common first element in given list of lists.\nfunc group_tuples(Input: [[String]]) -> [[String]] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(group_tuples(Input: [[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])\nassert(group_tuples(Input: [[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])\nassert(group_tuples(Input: [[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])",
     "stop_tokens": [
@@ -4740,13 +1728,3025 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "swift",
-    "prompt": "\n/// Write a function to merge three lists into a single sorted list.\nfunc merge_sorted_list(num1: [Int], num2: [Int], num3: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a python function to find the element of a list having maximum length.\nfunc Find_Max(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_sorted_list(num1: [25, 24, 15, 4, 5, 29, 110], num2: [19, 20, 11, 56, 25, 233, 154], num3: [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\nassert(merge_sorted_list(num1: [1, 3, 5, 6, 8, 9], num2: [2, 5, 7, 11], num3: [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\nassert(merge_sorted_list(num1: [18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], num2: [25, 35, 22, 85, 14, 65, 75, 25, 58], num3: [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max(lst: [[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\nassert(Find_Max(lst: [[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\nassert(Find_Max(lst: [[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunc round_and_sum(list1: [Result<Double, Int>]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(round_and_sum(list1: [.success(22.4), .success(4.0), .success(-16.22), .success(-9.1), .success(11.0), .success(-12.22), .success(14.2), .success(-5.2), .success(17.5)]) == 243)\nassert(round_and_sum(list1: [.failure(5), .failure(2), .failure(9), .success(24.3), .failure(29)]) == 345)\nassert(round_and_sum(list1: [.success(25.0), .success(56.7), .success(89.2)]) == 513)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_Sum(n: 2) == 72)\nassert(cube_Sum(n: 3) == 288)\nassert(cube_Sum(n: 4) == 800)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup: (String, String, Int, String)) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate_tuple(test_tup: (\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\nassert(concatenate_tuple(test_tup: (\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\nassert(concatenate_tuple(test_tup: (\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Average_Of_Cube(n: 2) == 4.5)\nassert(find_Average_Of_Cube(n: 3) == 12)\nassert(find_Average_Of_Cube(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple: (String, String, String)) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_rear(test_tuple: (\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\nassert(extract_rear(test_tuple: (\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\nassert(extract_rear(test_tuple: (\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of sublists containing a particular element.\nfunc count_element_in_list(list1: [[AnyHashable]], x: AnyHashable) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_element_in_list(list1: [[1, 3], [5, 7], [1, 11], [1, 15, 7]], x: 1) == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"A\") == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"E\") == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_oddnumbers(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\nassert(filter_oddnumbers(nums: [10, 20, 45, 67, 84, 93]) == [45, 67, 93])\nassert(filter_oddnumbers(nums: [5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_date_format(dt: \"2026-01-02\") == \"02-01-2026\")\nassert(change_date_format(dt: \"2020-11-13\") == \"13-11-2020\")\nassert(change_date_format(dt: \"2021-04-26\") == \"26-04-2021\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(shell_sort(my_list: [12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\nassert(shell_sort(my_list: [24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\nassert(shell_sort(my_list: [32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(and_tuples(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (0, 0, 2, 1))\nassert(and_tuples(test_tup1: (1, 2, 3, 4), test_tup2: (5, 6, 7, 8)) == (1, 2, 3, 0))\nassert(and_tuples(test_tup1: (8, 9, 11, 12), test_tup2: (7, 13, 14, 17)) == (0, 9, 10, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a: Int, b: Int, c: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parabola_directrix(a: 5, b: 3, c: 2) == -198)\nassert(parabola_directrix(a: 9, b: 8, c: 4) == -2336)\nassert(parabola_directrix(a: 2, b: 4, c: 6) == -130)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes two lists and returns true if they have at least one common element.\nfunc common_element(list1: [AnyHashable], list2: [AnyHashable]) -> Bool? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8, 9]) == true)\nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == nil)\nassert(common_element(list1: [\"a\", \"b\", \"c\"], list2: [\"d\", \"b\", \"e\"]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1: Int, base2: Int, height: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_trapezium(base1: 15, base2: 25, height: 35) == 20)\nassert(median_trapezium(base1: 10, base2: 20, height: 30) == 15)\nassert(median_trapezium(base1: 6, base2: 9, height: 4) == 7.5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr: [Int], number: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_greater(arr: [1, 2, 3, 4, 5], number: 4) == false)\nassert(check_greater(arr: [2, 3, 4, 5, 6], number: 8) == true)\nassert(check_greater(arr: [9, 7, 4, 8, 6, 1], number: 11) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_one(text: \"ac\") == false)\nassert(text_match_one(text: \"dc\") == false)\nassert(text_match_one(text: \"abba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the last digit of a given number.\nfunc last_Digit(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit(n: 123) == 3)\nassert(last_Digit(n: 25) == 5)\nassert(last_Digit(n: 30) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to return the negative numbers in a list.\nfunc neg_nos(list1: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(neg_nos(list1: [-1, 4, 5, -6]) == [-1, -6])\nassert(neg_nos(list1: [-1, -2, 3, 4]) == [-1, -2])\nassert(neg_nos(list1: [-7, -6, 8, 9]) == [-7, -6])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove odd characters in a string.\nfunc remove_odd(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(str1: \"python\") == \"yhn\")\nassert(remove_odd(str1: \"program\") == \"rga\")\nassert(remove_odd(str1: \"language\") == \"agae\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\nassert(count_bidirectional(test_list: [(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "swift",
+    "prompt": "\n/// Write a function to join a list of multiple integers into a single integer.\nfunc multiple_to_single(L: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiple_to_single(L: [11, 33, 50]) == 113350)\nassert(multiple_to_single(L: [-1, 2, 3, 4, 5, 6]) == -123456)\nassert(multiple_to_single(L: [10, 15, 20, 25]) == 10152025)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text: String) -> (Int, Int, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverb_position(text: \"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\nassert(find_adverb_position(text: \"seriously!! there are many roses\") == (0, 9, \"seriously\"))\nassert(find_adverb_position(text: \"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cube(l: 5) == 150)\nassert(surfacearea_cube(l: 3) == 54)\nassert(surfacearea_cube(l: 10) == 600)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums: [Int]) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(positive_count(nums: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\nassert(positive_count(nums: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\nassert(positive_count(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the largest negative number from the given list.\nfunc largest_neg(list1: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_neg(list1: [1, 2, 3, -4, -6]) == -6)\nassert(largest_neg(list1: [1, 2, 3, -8, -9]) == -9)\nassert(largest_neg(list1: [1, 2, 3, 4, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to trim each list by k in the given lists.\nfunc trim_tuple(test_list: [[Int]], K: Int) -> [[Int]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 2) == [[2], [9], [2], [2]])\nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\nassert(trim_tuple(test_list: [[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], K: 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform index wise multiplication of list elements in the given two lists.\nfunc index_multiplication(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_multiplication(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\nassert(index_multiplication(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\nassert(index_multiplication(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the occurence of all elements of list in a tuple.\nfunc count_Occurrence(tup: AnyHashable, lst: [AnyHashable]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Occurrence(tup: (\"a\", \"a\", \"c\", \"b\", \"d\"), lst: [\"a\", \"b\"]) == 3)\nassert(count_Occurrence(tup: (1, 2, 3, 1, 4, 6, 7, 1, 4), lst: [1, 4, 7]) == 6)\nassert(count_Occurrence(tup: (1, 2, 3, 4, 5, 6), lst: [1, 2]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find cubes of individual elements in a list.\nfunc cube_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\nassert(cube_nums(nums: [10, 20, 30]) == [1000, 8000, 27000])\nassert(cube_nums(nums: [12, 15]) == [1728, 3375])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cal_sum(n: 9) == 49)\nassert(cal_sum(n: 10) == 66)\nassert(cal_sum(n: 11) == 88)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract specified size of strings from a given list of string values.\nfunc extract_string(str: [String], l: Int) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 8) == [\"practice\", \"solution\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 6) == [\"Python\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 9) == [\"exercises\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_whitespaces(text1: \" Google    Flutter \") == \"GoogleFlutter\")\nassert(remove_whitespaces(text1: \" Google    Dart \") == \"GoogleDart\")\nassert(remove_whitespaces(text1: \" iOS    Swift \") == \"iOSSwift\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "swift",
+    "prompt": "\n/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost: Int, sale_amount: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(loss_amount(actual_cost: 1500, sale_amount: 1200) == 0)\nassert(loss_amount(actual_cost: 100, sale_amount: 200) == 100)\nassert(loss_amount(actual_cost: 2000, sale_amount: 5000) == 3000)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of even factors of a number.\nfunc sumofFactors(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sumofFactors(n: 18) == 26)\nassert(sumofFactors(n: 30) == 48)\nassert(sumofFactors(n: 6) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz(text: \"pythonz.\") == true)\nassert(text_match_wordz(text: \"xyz.\") == true)\nassert(text_match_wordz(text: \"  lang  .\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumb_number(monthnum2: 5) == true)\nassert(check_monthnumb_number(monthnum2: 2) == false)\nassert(check_monthnumb_number(monthnum2: 6) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to reverse each string in a given list of string values.\nfunc reverse_string_list(stringlist: [String]) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_string_list(stringlist: [\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\nassert(reverse_string_list(stringlist: [\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\nassert(reverse_string_list(stringlist: [\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sublist having minimum length.\nfunc Find_Min(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min(lst: [[1], [1, 2], [1, 2, 3]]) == [1])\nassert(Find_Min(lst: [[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\nassert(Find_Min(lst: [[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the area of a rectangle.\nfunc rectangle_area(l: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rectangle_area(l: 10, b: 20) == 200)\nassert(rectangle_area(l: 10, b: 5) == 50)\nassert(rectangle_area(l: 4, b: 2) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_uppercase(str1: \"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\nassert(remove_uppercase(str1: \"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\nassert(remove_uppercase(str1: \"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to get the first element of each sublist.\nfunc Extract(lst: [[Int]]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Extract(lst: [[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\nassert(Extract(lst: [[1, 2, 3], [4, 5]]) == [1, 4])\nassert(Extract(lst: [[9, 8, 1], [1, 2]]) == [9, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the upper case characters in a given string.\nfunc upper_ctr(str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(upper_ctr(str: \"PYthon\") == 1)\nassert(upper_ctr(str: \"BigData\") == 1)\nassert(upper_ctr(str: \"program\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "swift",
+    "prompt": "\nextension [String]: Error {}\n        \n/// Write a function to find all possible combinations of the elements of a given list.\nfunc combinations_list(list1: [String]) -> [Result<[()], [String]>] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_list(list1: [\"orange\", \"red\", \"green\", \"blue\"]) == [.success([] as [()]), .failure([\"orange\"]), .failure([\"red\"]), .failure([\"red\", \"orange\"]), .failure([\"green\"]), .failure([\"green\", \"orange\"]), .failure([\"green\", \"red\"]), .failure([\"green\", \"red\", \"orange\"]), .failure([\"blue\"]), .failure([\"blue\", \"orange\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"red\", \"orange\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"orange\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"blue\", \"green\", \"red\", \"orange\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"blue\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"white\"]), .failure([\"white\", \"red\"]), .failure([\"white\", \"green\"]), .failure([\"white\", \"green\", \"red\"]), .failure([\"white\", \"blue\"]), .failure([\"white\", \"blue\", \"red\"]), .failure([\"white\", \"blue\", \"green\"]), .failure([\"white\", \"blue\", \"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"black\", \"blue\"]), .failure([\"black\", \"blue\", \"red\"]), .failure([\"black\", \"blue\", \"green\"]), .failure([\"black\", \"blue\", \"green\", \"red\"]), .failure([\"black\", \"white\"]), .failure([\"black\", \"white\", \"red\"]), .failure([\"black\", \"white\", \"green\"]), .failure([\"black\", \"white\", \"green\", \"red\"]), .failure([\"black\", \"white\", \"blue\"]), .failure([\"black\", \"white\", \"blue\", \"red\"]), .failure([\"black\", \"white\", \"blue\", \"green\"]), .failure([\"black\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"blue\"]), .failure([\"orange\", \"blue\", \"red\"]), .failure([\"orange\", \"blue\", \"green\"]), .failure([\"orange\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"white\"]), .failure([\"orange\", \"white\", \"red\"]), .failure([\"orange\", \"white\", \"green\"]), .failure([\"orange\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"white\", \"blue\"]), .failure([\"orange\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"blue\"]), .failure([\"orange\", \"black\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\"]), .failure([\"orange\", \"black\", \"white\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"])])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_subarray_product(arr: [1, -2, -3, 0, 7, -8, -2]) == 112)\nassert(max_subarray_product(arr: [6, -3, -10, 0, 2]) == 180)\nassert(max_subarray_product(arr: [-2, -40, 0, -2, -3]) == 80)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict: [String : Int], n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 10) == false)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 12) == true)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 5) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "swift",
+    "prompt": "\n/// Write a function to drop empty items from a given dictionary.\nfunc drop_empty(dict1: [String : String?]) -> [String : String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : \"Green\", \"c3\" : nil]) == [\"c1\" : \"Red\", \"c2\" : \"Green\"])\nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : nil, \"c3\" : nil]) == [\"c1\" : \"Red\"])\nassert(drop_empty(dict1: [\"c1\" : nil, \"c2\" : \"Green\", \"c3\" : nil]) == [\"c2\" : \"Green\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product(arr: [3, 100, 4, 5, 150, 6]) == 3000)\nassert(max_product(arr: [4, 42, 55, 68, 80]) == 50265600)\nassert(max_product(arr: [10, 22, 9, 33, 21, 50, 41, 60]) == 2460)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup: (Int, Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_pairwise(test_tup: (1, 5, 7, 8, 10)) == (6, 12, 15, 18))\nassert(add_pairwise(test_tup: (2, 6, 8, 9, 11)) == (8, 14, 17, 20))\nassert(add_pairwise(test_tup: (3, 7, 9, 10, 12)) == (10, 16, 19, 22))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_remainder(arr: [100, 10, 5, 25, 35, 14], n: 11) == 9)\nassert(find_remainder(arr: [1, 1, 1], n: 1) == 0)\nassert(find_remainder(arr: [1, 2, 1], n: 2) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given list contains consecutive numbers or not.\nfunc check_Consecutive(l: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_Consecutive(l: [1, 2, 3, 4, 5]) == true)\nassert(check_Consecutive(l: [1, 2, 3, 5, 6]) == false)\nassert(check_Consecutive(l: [1, 2, 1]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace characters in a string.\nfunc replace_char(str1: String, ch: String, newch: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_char(str1: \"polygon\", ch: \"y\", newch: \"l\") == \"pollgon\")\nassert(replace_char(str1: \"character\", ch: \"c\", newch: \"a\") == \"aharaater\")\nassert(replace_char(str1: \"python\", ch: \"l\", newch: \"a\") == \"python\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1: [String : Int]) -> [(String, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_counter(dict1: [\"Math\" : 81, \"Physics\" : 83, \"Chemistry\" : 87]) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\nassert(sort_counter(dict1: [\"Math\" : 400, \"Physics\" : 300, \"Chemistry\" : 250]) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\nassert(sort_counter(dict1: [\"Math\" : 900, \"Physics\" : 1000, \"Chemistry\" : 1250]) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_sum(nums: [1, 2, 3]) == 4)\nassert(big_sum(nums: [-1, 2, 3, 4]) == 3)\nassert(big_sum(nums: [2, 3, 6]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to convert the given string to lower case.\nfunc is_lower(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_lower(string: \"InValid\") == \"invalid\")\nassert(is_lower(string: \"TruE\") == \"true\")\nassert(is_lower(string: \"SenTenCE\") == \"sentence\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_lowercase(str1: \"PYTHon\") == \"PYTH\")\nassert(remove_lowercase(str1: \"FInD\") == \"FID\")\nassert(remove_lowercase(str1: \"STRinG\") == \"STRG\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the first digit of a given number.\nfunc first_Digit(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_Digit(n: 123) == 1)\nassert(first_Digit(n: 456) == 4)\nassert(first_Digit(n: 12) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunc heap_queue_largest(nums: [Int], n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 3) == [85, 75, 65])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 2) == [85, 75])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 5) == [85, 75, 65, 58, 35])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "swift",
+    "prompt": "\n/// Write a python function which takes a list of integers and only returns the odd ones.\nfunc Split(list: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5, 6]) == [1, 3, 5])\nassert(Split(list: [10, 11, 12, 13]) == [11, 13])\nassert(Split(list: [7, 8, 9, 1]) == [7, 9, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(difference(n: 3) == 30)\nassert(difference(n: 5) == 210)\nassert(difference(n: 2) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A: [Int], N: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Odd_Pair(A: [5, 4, 7, 2, 1], N: 5) == 6)\nassert(find_Odd_Pair(A: [7, 2, 8, 1, 0, 5, 11], N: 7) == 12)\nassert(find_Odd_Pair(A: [1, 2, 3], N: 3) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_string(string: \"Python\") == \"pYTHON\")\nassert(toggle_string(string: \"Pangram\") == \"pANGRAM\")\nassert(toggle_string(string: \"LIttLE\") == \"liTTle\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1: Int, n2: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digit_distance_nums(n1: 1, n2: 2) == 1)\nassert(digit_distance_nums(n1: 23, n2: 56) == 6)\nassert(digit_distance_nums(n1: 123, n2: 256) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the sum of the largest contiguous sublist in the given list.\nfunc max_sub_array_sum(a: [Int], size: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum(a: [-2, -3, 4, -1, -2, 1, 5, -3], size: 8) == 7)\nassert(max_sub_array_sum(a: [-3, -4, 5, -2, -3, 2, 6, -4], size: 8) == 8)\nassert(max_sub_array_sum(a: [-4, -5, 6, -3, -4, 3, 7, -5], size: 8) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunc union_elements(test_tup1: [Int], test_tup2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(union_elements(test_tup1: [3, 4, 5, 6], test_tup2: [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\nassert(union_elements(test_tup1: [1, 2, 3, 4], test_tup2: [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\nassert(union_elements(test_tup1: [11, 12, 13, 14], test_tup2: [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the length of the longest sublists.\nfunc Find_Max_Length(lst: [[Int]]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max_Length(lst: [[1], [1, 4], [5, 6, 7, 8]]) == 4)\nassert(Find_Max_Length(lst: [[0, 1], [2, 2], [3, 2, 1]]) == 3)\nassert(Find_Max_Length(lst: [[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_values(text: \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\nassert(extract_values(text: \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\nassert(extract_values(text: \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Pairs(arr: [1, 2, 1], n: 3) == 2)\nassert(count_Pairs(arr: [1, 1, 1, 1], n: 4) == 0)\nassert(count_Pairs(arr: [1, 2, 3, 4, 5], n: 5) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to split a string into characters.\nfunc split(word: String) -> [String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split(word: \"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\nassert(split(word: \"Name\") == [\"N\", \"a\", \"m\", \"e\"])\nassert(split(word: \"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_digits(n: 345) == 12)\nassert(sum_digits(n: 12) == 3)\nassert(sum_digits(n: 97) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether a specified list is sorted or not.\nfunc issort_list(list1: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create a list of N empty dictionaries.\nfunc empty_list(length: Int) -> [[() : ()]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(empty_list(length: 5) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 6) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 7) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort each sublist of strings in a given list of lists.\nfunc sort_sublists(list1: [[String]]) -> [[String]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\nassert(sort_sublists(list1: [[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check if a given number is one less than twice its reverse.\nfunc checks(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(checks(n: 70) == false)\nassert(checks(n: 23) == false)\nassert(checks(n: 73) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to remove duplicate numbers from a given number of lists.\nfunc two_unique_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(two_unique_nums(nums: [1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to calculate the product of the unique numbers in a given list.\nfunc unique_product(list_data: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_product(list_data: [10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\nassert(unique_product(list_data: [1, 2, 3, 1]) == 6)\nassert(unique_product(list_data: [7, 8, 9, 0, 1, 1]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r: Int, h: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cylinder(r: 10, h: 5) == 942.45)\nassert(surfacearea_cylinder(r: 4, h: 5) == 226.18800000000002)\nassert(surfacearea_cylinder(r: 4, h: 10) == 351.848)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether a list is sublist of another or not.\nfunc is_Sub_Array(A: [Int], B: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sub_Array(A: [1, 4, 3, 5], B: [1, 2]) == false)\nassert(is_Sub_Array(A: [1, 2, 1], B: [1, 2, 1]) == true)\nassert(is_Sub_Array(A: [1, 0, 2, 2], B: [2, 2, 0]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit_Factorial(n: 4) == 4)\nassert(last_Digit_Factorial(n: 21) == 0)\nassert(last_Digit_Factorial(n: 30) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to interleave 3 lists of the same length into a single flat list.\nfunc interleave_lists(list1: [Int], list2: [Int], list3: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(interleave_lists(list1: [1, 2, 3, 4, 5, 6, 7], list2: [10, 20, 30, 40, 50, 60, 70], list3: [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\nassert(interleave_lists(list1: [10, 20], list2: [15, 2], list3: [5, 10]) == [10, 15, 5, 20, 2, 10])\nassert(interleave_lists(list1: [11, 44], list2: [10, 15], list3: [20, 5]) == [11, 10, 20, 44, 15, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_dissimilar(test_tup1: (3, 4, 5, 6), test_tup2: (5, 7, 4, 10)) == (3, 6, 7, 10))\nassert(find_dissimilar(test_tup1: (1, 2, 3, 4), test_tup2: (7, 2, 3, 9)) == (1, 4, 7, 9))\nassert(find_dissimilar(test_tup1: (21, 11, 25, 26), test_tup2: (26, 34, 21, 36)) == (34, 36, 11, 25))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the largest number that can be formed with the given list of digits.\nfunc find_Max_Num(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Max_Num(arr: [1, 2, 3]) == 321)\nassert(find_Max_Num(arr: [4, 5, 6, 1]) == 6541)\nassert(find_Max_Num(arr: [1, 2, 3, 9]) == 9321)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple: (Int, Int, (Int, Int, (Int, Int)), Int, Int)) -> AnyHashable {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_even(test_tuple: (4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\nassert(extract_even(test_tuple: (5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\nassert(extract_even(test_tuple: (5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunc surface_Area(b: Int, s: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surface_Area(b: 3, s: 4) == 33)\nassert(surface_Area(b: 4, s: 5) == 56)\nassert(surface_Area(b: 1, s: 2) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function which returns nth catalan number.\nfunc catalan_number(num: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(catalan_number(num: 10) == 16796)\nassert(catalan_number(num: 9) == 4862)\nassert(catalan_number(num: 7) == 429)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverbs(text: \"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\nassert(find_adverbs(text: \"Please handle the situation carefuly\") == \"28-36: carefuly\")\nassert(find_adverbs(text: \"Complete the task quickly\") == \"18-25: quickly\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "swift",
+    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the n most expensive items in a given dataset.\nfunc expensive_items(items: [[String : Result<String, Double>]], n: Int) -> [[String : Result<String, Double>]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)]], n: 2) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)], [\"name\" : .success(\"Item-4\"), \"price\" : .failure(22.75)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to split a list at the nth eelment and add the first part to the end.\nfunc split_Arr(l: [Int], n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_Arr(l: [12, 10, 5, 6, 52, 36], n: 2) == [5, 6, 52, 36, 12, 10])\nassert(split_Arr(l: [1, 2, 3, 4], n: 1) == [2, 3, 4, 1])\nassert(split_Arr(l: [0, 1, 2, 3, 4, 5, 6, 7], n: 3) == [3, 4, 5, 6, 7, 0, 1, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a list to a tuple.\nfunc list_tuple(listx: [Int]) -> AnyHashable {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_tuple(listx: [5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\nassert(list_tuple(listx: [2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\nassert(list_tuple(listx: [58, 44, 56]) == (58, 44, 56))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the difference between largest and smallest value in a given list.\nfunc big_diff(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_diff(nums: [1, 2, 3, 4]) == 3)\nassert(big_diff(nums: [4, 5, 12]) == 8)\nassert(big_diff(nums: [9, 2, 3]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a: Int, b: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perfect_squares(a: 1, b: 30) == [1, 4, 9, 16, 25])\nassert(perfect_squares(a: 50, b: 100) == [64, 81, 100])\nassert(perfect_squares(a: 100, b: 200) == [100, 121, 144, 169, 196])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x: Int, y: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(opposite_Signs(x: 1, y: -2) == true)\nassert(opposite_Signs(x: 3, y: 2) == false)\nassert(opposite_Signs(x: -10, y: -10) == false)\nassert(opposite_Signs(x: -2, y: 2) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to interchange the first and last elements in a list.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_product(n: 3) == 15)\nassert(sum_Of_product(n: 4) == 56)\nassert(sum_Of_product(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(removezero_ip(ip: \"216.08.094.196\") == \"216.8.94.196\")\nassert(removezero_ip(ip: \"12.01.024\") == \"12.1.24\")\nassert(removezero_ip(ip: \"216.08.094.0196\") == \"216.8.94.196\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the difference of the first even and first odd number of a given list.\nfunc diff_even_odd(list1: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(diff_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 3)\nassert(diff_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\nassert(diff_even_odd(list1: [1, 5, 7, 9, 10]) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1: String, str2: String) -> AnyHashable {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Swaps(str1: \"1101\", str2: \"1110\") == 1)\nassert(min_Swaps(str1: \"111\", str2: \"000\") == \"Not Possible\")\nassert(min_Swaps(str1: \"111\", str2: \"110\") == \"Not Possible\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1: [Int], arr2: [Int], k: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_kth(arr1: [2, 3, 6, 7, 9], arr2: [1, 4, 8, 10], k: 5) == 6)\nassert(find_kth(arr1: [100, 112, 256, 349, 770], arr2: [72, 86, 113, 119, 265, 445, 892], k: 7) == 256)\nassert(find_kth(arr1: [3, 4, 7, 8, 10], arr2: [2, 5, 9, 11], k: 6) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(armstrong_number(number: 153) == true)\nassert(armstrong_number(number: 259) == false)\nassert(armstrong_number(number: 4458) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number: Int) -> (Int, Double) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_average(number: 10) == (55, 5.5))\nassert(sum_average(number: 15) == (120, 8.0))\nassert(sum_average(number: 20) == (210, 10.5))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth octagonal number.\nfunc is_octagonal(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_octagonal(n: 5) == 65)\nassert(is_octagonal(n: 10) == 280)\nassert(is_octagonal(n: 15) == 645)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given number is even or not.\nfunc is_Even(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Even(n: 1) == false)\nassert(is_Even(n: 2) == true)\nassert(is_Even(n: 3) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the first repeated character in a given string.\nfunc first_repeated_char(str1: String) -> String? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_repeated_char(str1: \"abcabc\") == \"a\")\nassert(first_repeated_char(str1: \"abc\") == nil)\nassert(first_repeated_char(str1: \"123123\") == \"1\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_ludic(n: 10) == [1, 2, 3, 5, 7])\nassert(get_ludic(n: 25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\nassert(get_ludic(n: 45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "swift",
+    "prompt": "\n/// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_words(s: \"python program\") == \"program python\")\nassert(reverse_words(s: \"java language\") == \"language java\")\nassert(reverse_words(s: \"indian man\") == \"man indian\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given integer is a prime number.\nfunc prime_num(num: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_num(num: 13) == true)\nassert(prime_num(num: 7) == true)\nassert(prime_num(num: -1010) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert degrees to radians.\nfunc radian_degree(degree: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(radian_degree(degree: 90) == 1.5707963267948966)\nassert(radian_degree(degree: 60) == 1.0471975511965976)\nassert(radian_degree(degree: 120) == 2.0943951023931953)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "swift",
+    "prompt": "\n/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text: String, pattern: String) -> (String, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_literals(text: \"The quick brown fox jumps over the lazy dog.\", pattern: \"fox\") == (\"fox\", 16, 19))\nassert(find_literals(text: \"Its been a very crazy procedure right\", pattern: \"crazy\") == (\"crazy\", 16, 21))\nassert(find_literals(text: \"Hardest choices required strongest will\", pattern: \"will\") == (\"will\", 35, 39))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find nth bell number.\nfunc bell_Number(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_Number(n: 2) == 2)\nassert(bell_Number(n: 3) == 5)\nassert(bell_Number(n: 4) == 15)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "swift",
+    "prompt": "\n/// Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1: [Int], L: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_kth_element(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == [1, 1, 3, 4, 4, 5, 1])\nassert(remove_kth_element(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], L: 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\nassert(remove_kth_element(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], L: 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "swift",
+    "prompt": "\n/// Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunc max_of_nth(test_list: [[Int]], N: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_of_nth(test_list: [[5, 6, 7], [1, 3, 5], [8, 9, 19]], N: 2) == 19)\nassert(max_of_nth(test_list: [[6, 7, 8], [2, 4, 6], [9, 10, 20]], N: 1) == 10)\nassert(max_of_nth(test_list: [[7, 8, 9], [3, 5, 7], [10, 11, 21]], N: 1) == 11)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "swift",
+    "prompt": "\n/// Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunc merge(lst: [[AnyHashable]]) -> [[AnyHashable]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge(lst: [[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\nassert(merge(lst: [[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\nassert(merge(lst: [[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunc cummulative_sum(test_list: [[Int]]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cummulative_sum(test_list: [[1, 3], [5, 6, 7], [2, 6]]) == 30)\nassert(cummulative_sum(test_list: [[2, 4], [6, 7, 8], [3, 7]]) == 37)\nassert(cummulative_sum(test_list: [[3, 5], [7, 8, 9], [4, 8]]) == 44)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunc average_tuple(nums: [[Int]]) -> [Double] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(average_tuple(nums: [[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\nassert(average_tuple(nums: [[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\nassert(average_tuple(nums: [[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "swift",
+    "prompt": "\n/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_modulo(test_tup1: (10, 4, 5, 6), test_tup2: (5, 6, 7, 5)) == (0, 4, 5, 1))\nassert(tuple_modulo(test_tup1: (11, 5, 6, 7), test_tup2: (6, 7, 8, 6)) == (5, 5, 6, 1))\nassert(tuple_modulo(test_tup1: (12, 6, 7, 8), test_tup2: (7, 8, 9, 7)) == (5, 6, 7, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps: (Int, Int), d: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Jumps(steps: (3, 4), d: 11) == 3.5)\nassert(min_Jumps(steps: (3, 4), d: 0) == 0)\nassert(min_Jumps(steps: (11, 14), d: 11) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to divide two lists element wise.\nfunc div_list(nums1: [Int], nums2: [Int]) -> [Double] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(div_list(nums1: [4, 5, 6], nums2: [1, 2, 3]) == [4.0, 2.5, 2.0])\nassert(div_list(nums1: [3, 2], nums2: [1, 4]) == [3.0, 0.5])\nassert(div_list(nums1: [90, 120], nums2: [50, 70]) == [1.8, 1.7142857142857142])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_num(test_str: \"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\nassert(move_num(test_str: \"Avengers124Assemble\") == \"AvengersAssemble124\")\nassert(move_num(test_str: \"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Substrings(s: \"112112\") == 6)\nassert(count_Substrings(s: \"111\") == 6)\nassert(count_Substrings(s: \"1101112\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median of two sorted lists of same size.\nfunc get_median(arr1: [Int], arr2: [Int], n: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_median(arr1: [1, 12, 15, 26, 38], arr2: [2, 13, 17, 30, 45], n: 5) == 16.0)\nassert(get_median(arr1: [2, 4, 8, 9], arr2: [7, 13, 19, 28], n: 4) == 8.5)\nassert(get_median(arr1: [3, 6, 14, 23, 36, 42], arr2: [2, 18, 27, 39, 49, 55], n: 6) == 25.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to compute the n-th power of each number in a list.\nfunc nth_nums(nums: [Int], n: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(nth_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n: 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(nth_nums(nums: [10, 20, 30], n: 3) == [1000, 8000, 27000])\nassert(nth_nums(nums: [12, 15], n: 5) == [248832, 759375])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to convert a given string to uppercase.\nfunc is_upper(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_upper(string: \"person\") == \"PERSON\")\nassert(is_upper(string: \"final\") == \"FINAL\")\nassert(is_upper(string: \"Valid\") == \"VALID\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to interchange the first and last element in a given list.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunc triangle_area(r: Int) -> Int? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(r: -1) == nil)\nassert(triangle_area(r: 0) == 0)\nassert(triangle_area(r: 2) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunc find_First_Missing(array: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_First_Missing(array: [0, 1, 2, 3]) == 4)\nassert(find_First_Missing(array: [0, 1, 2, 6, 9]) == 3)\nassert(find_First_Missing(array: [2, 3, 5, 8, 9]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(string: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(string: \"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\nassert(replace_spaces(string: \"I am a Programmer\") == \"I%20am%20a%20Programmer\")\nassert(replace_spaces(string: \"I love Coding\") == \"I%20love%20Coding\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find even numbers from a list of numbers.\nfunc Split(list: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5]) == [2, 4])\nassert(Split(list: [4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\nassert(Split(list: [8, 12, 15, 19]) == [8, 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find smallest number in a list.\nfunc smallest_num(xs: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_num(xs: [10, 20, 1, 45, 99]) == 1)\nassert(smallest_num(xs: [1, 2, 3]) == 1)\nassert(smallest_num(xs: [45, 46, 50, 60]) == 45)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup: (Int, Int)) -> [[Int]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_coordinates(test_tup: (3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\nassert(get_coordinates(test_tup: (4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\nassert(get_coordinates(test_tup: (5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(text: \"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\nassert(replace_spaces(text: \"The_Avengers\") == \"The Avengers\")\nassert(replace_spaces(text: \"Fast and Furious\") == \"Fast_and_Furious\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to move all zeroes to the end of the given list.\nfunc move_zero(num_list: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_zero(num_list: [1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\nassert(move_zero(num_list: [2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\nassert(move_zero(num_list: [0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunc pair_xor_Sum(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_xor_Sum(arr: [5, 9, 7, 6], n: 4) == 47)\nassert(pair_xor_Sum(arr: [7, 3, 5], n: 3) == 12)\nassert(pair_xor_Sum(arr: [7, 3], n: 2) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort the given list.\nfunc heap_sort(iterable: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_sort(iterable: [1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\nassert(heap_sort(iterable: [25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\nassert(heap_sort(iterable: [7, 1, 9, 5]) == [1, 5, 7, 9])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost: Int, sale_amount: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(noprofit_noloss(actual_cost: 1500, sale_amount: 1200) == false)\nassert(noprofit_noloss(actual_cost: 100, sale_amount: 100) == true)\nassert(noprofit_noloss(actual_cost: 2000, sale_amount: 5000) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v: Int, t: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(wind_chill(v: 120, t: 35) == 40)\nassert(wind_chill(v: 40, t: 20) == 19)\nassert(wind_chill(v: 10, t: 8) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names: [String]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sample_nam(sample_names: [\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\nassert(sample_nam(sample_names: [\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\nassert(sample_nam(sample_names: [\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum difference between available pairs in the given tuple list.\nfunc max_difference(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_difference(test_list: [(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\nassert(max_difference(test_list: [(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\nassert(max_difference(test_list: [(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items: [String]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_parenthesis(items: [\"python (chrome)\"]) == \"python\")\nassert(remove_parenthesis(items: [\"string(.abc)\"]) == \"string\")\nassert(remove_parenthesis(items: [\"alpha(num)\"]) == \"alpha\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nonagonal(n: 10) == 325)\nassert(is_nonagonal(n: 15) == 750)\nassert(is_nonagonal(n: 18) == 1089)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz_middle(text: \"pythonzabc.\") == true)\nassert(text_match_wordz_middle(text: \"zxyabc.\") == false)\nassert(text_match_wordz_middle(text: \"  lang  .\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input: [Int], k: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_Array_Upto_K(input: [1, 2, 3, 4, 5, 6], k: 4) == [4, 3, 2, 1, 5, 6])\nassert(reverse_Array_Upto_K(input: [4, 5, 6, 7], k: 2) == [5, 4, 6, 7])\nassert(reverse_Array_Upto_K(input: [9, 8, 7, 6, 5], k: 3) == [7, 8, 9, 6, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a list of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks: [(String, Int)]) -> [(String, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(subject_marks(subjectmarks: [(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\nassert(subject_marks(subjectmarks: [(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\nassert(subject_marks(subjectmarks: [(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "swift",
+    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a list and sum all of its elements.\nfunc recursive_list_sum(data_list: [Result<Int, [Int]>]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(recursive_list_sum(data_list: [.success(1), .success(2), .failure([3, 4]), .failure([5, 6])]) == 21)\nassert(recursive_list_sum(data_list: [.success(7), .success(10), .failure([15, 14]), .failure([19, 41])]) == 106)\nassert(recursive_list_sum(data_list: [.success(10), .success(20), .failure([30, 40]), .failure([50, 60])]) == 210)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of positive numbers in a list.\nfunc pos_count(list: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pos_count(list: [1, -2, 3, -4]) == 2)\nassert(pos_count(list: [3, 4, 5, -1]) == 3)\nassert(pos_count(list: [1, 2, 3, 4]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_number(n: 2) == 2)\nassert(bell_number(n: 10) == 115975)\nassert(bell_number(n: 56) == 6775685320645824322581483068371419745979053216268760300)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Monotonic(A: [6, 5, 4, 4]) == true)\nassert(is_Monotonic(A: [1, 2, 2, 3]) == true)\nassert(is_Monotonic(A: [1, 3, 2]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether a list contains the given sublist or not.\nfunc is_sublist(l: [Int], s: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [3, 7]) == false)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [4, 3]) == true)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [1, 6]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a: Int, b: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(differ_At_One_Bit_Pos(a: 13, b: 9) == true)\nassert(differ_At_One_Bit_Pos(a: 15, b: 8) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 4) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 3) == true)\nassert(differ_At_One_Bit_Pos(a: 5, b: 1) == true)\nassert(differ_At_One_Bit_Pos(a: 1, b: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find whether all the given lists have equal length or not.\nfunc get_equal(Input: [[Int]]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_equal(Input: [[11, 22, 33], [44, 55, 66]]) == true)\nassert(get_equal(Input: [[1, 2, 3], [4, 5, 6, 7]]) == false)\nassert(get_equal(Input: [[1, 2], [3, 4]]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a list of elements.\nfunc comb_sort(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(comb_sort(nums: [5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\nassert(comb_sort(nums: [41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\nassert(comb_sort(nums: [99, 15, 13, 47]) == [13, 15, 47, 99])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup: (Int, Int, Int), test_dict: [String : Int]) -> (Int, Int, Int, [String : Int]) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_dict_to_tuple(test_tup: (4, 5, 6), test_dict: [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]) == (4, 5, 6, [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]))\nassert(add_dict_to_tuple(test_tup: (1, 2, 3), test_dict: [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]) == (1, 2, 3, [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]))\nassert(add_dict_to_tuple(test_tup: (8, 9, 10), test_dict: [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]) == (8, 9, 10, [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "swift",
+    "prompt": "\n/// Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost: [[Int]]) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maxAverageOfPath(cost: [[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\nassert(maxAverageOfPath(cost: [[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\nassert(maxAverageOfPath(cost: [[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\nassert(maxAverageOfPath(cost: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "swift",
+    "prompt": "\n/// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunc filter_data(students: [String : (Double, Int)], h: Double, w: Int) -> [String : (Double, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 6.0, w: 70) == [\"Cierra Vega\" : (6.2, 70)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.9, w: 67) == [\"Cierra Vega\" : (6.2, 70), \"Kierra Gentry\" : (6.0, 68)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.7, w: 64) == [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "swift",
+    "prompt": "\n/// The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunc count_same_pair(nums1: [Int], nums2: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_same_pair(nums1: [1, 2, 3, 4, 5, 6, 7, 8], nums2: [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\nassert(count_same_pair(nums1: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\nassert(count_same_pair(nums1: [2, 4, -6, -9, 11, -12, 14, -5, 17], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\nassert(count_same_pair(nums1: [0, 1, 1, 2], nums2: [0, 1, 2, 2]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base: Int, power: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power_base_sum(base: 2, power: 100) == 115)\nassert(power_base_sum(base: 8, power: 10) == 37)\nassert(power_base_sum(base: 8, power: 15) == 62)\nassert(power_base_sum(base: 3, power: 3) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1: String) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_quotation(text1: \"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\nassert(extract_quotation(text1: \"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\nassert(extract_quotation(text1: \"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\nassert(extract_quotation(text1: \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup: [Int]) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_elements(test_tup: [1, 5, 7, 8, 10]) == [5, 35, 56, 80])\nassert(multiply_elements(test_tup: [2, 4, 5, 6, 7]) == [8, 20, 30, 42])\nassert(multiply_elements(test_tup: [12, 13, 14, 9, 15]) == [156, 182, 126, 135])\nassert(multiply_elements(test_tup: [12]) == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1: [Int], lst2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_list(lst1: [10, 20, 30], lst2: [15, 25, 35]) == [25, 45, 65])\nassert(sum_list(lst1: [1, 2, 3], lst2: [5, 6, 7]) == [6, 8, 10])\nassert(sum_list(lst1: [15, 20, 30], lst2: [15, 45, 75]) == [30, 65, 105])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dif_Square(n: 5) == true)\nassert(dif_Square(n: 10) == false)\nassert(dif_Square(n: 15) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove consecutive duplicates of a given list.\nfunc consecutive_duplicates(nums: [AnyHashable]) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(consecutive_duplicates(nums: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\nassert(consecutive_duplicates(nums: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r: Int, h: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cone(r: 5, h: 12) == 204.20352248333654)\nassert(lateralsurface_cone(r: 10, h: 15) == 566.3586699569488)\nassert(lateralsurface_cone(r: 19, h: 17) == 1521.8090132193388)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_specialchar(text: \"Python language, Programming language.\") == \"Python:language::Programming:language:\")\nassert(replace_specialchar(text: \"a b c,d e f\") == \"a:b:c:d:e:f\")\nassert(replace_specialchar(text: \"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_first_occurrence(A: [2, 5, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 1)\nassert(find_first_occurrence(A: [2, 3, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 2)\nassert(find_first_occurrence(A: [2, 4, 1, 5, 6, 6, 8, 9, 9, 9], x: 6) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3]) == 20)\nassert(sum_Of_Subarray_Prod(arr: [1, 2]) == 5)\nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3, 4]) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_middle_bits(n: 9) == 15)\nassert(toggle_middle_bits(n: 10) == 12)\nassert(toggle_middle_bits(n: 11) == 13)\nassert(toggle_middle_bits(n: 65) == 127)\nassert(toggle_middle_bits(n: 77) == 115)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "swift",
+    "prompt": "\n/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunc left_insertion(a: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(left_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(left_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(string: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_str(string: \"annie\") == true)\nassert(check_str(string: \"dawood\") == false)\nassert(check_str(string: \"Else\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunc geometric_sum(n: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(geometric_sum(n: 7) == 1.9921875)\nassert(geometric_sum(n: 4) == 1.9375)\nassert(geometric_sum(n: 8) == 1.99609375)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Index(n: 2) == 4)\nassert(find_Index(n: 3) == 14)\nassert(find_Index(n: 4) == 45)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup: (Int, Int, Int, Int, Int, Int)) -> [Int : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_dict(test_tup: (1, 5, 7, 10, 13, 5)) == [1 : 5, 7 : 10, 13 : 5])\nassert(tuple_to_dict(test_tup: (1, 2, 3, 4, 5, 6)) == [1 : 2, 3 : 4, 5 : 6])\nassert(tuple_to_dict(test_tup: (7, 8, 9, 10, 11, 12)) == [7 : 8, 9 : 10, 11 : 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether all the characters are same or not.\nfunc all_Characters_Same(s: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Characters_Same(s: \"python\") == false)\nassert(all_Characters_Same(s: \"aaa\") == true)\nassert(all_Characters_Same(s: \"data\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "swift",
+    "prompt": "\n/// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side: Int) -> Double {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(area_tetrahedron(side: 3) == 15.588457268119894)\nassert(area_tetrahedron(side: 20) == 692.8203230275509)\nassert(area_tetrahedron(side: 10) == 173.20508075688772)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "swift",
+    "prompt": "\n/// Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunc rotate_right(list: [Int], m: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunc divisible_by_digits(startnum: Int, endnum: Int) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisible_by_digits(startnum: 1, endnum: 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\nassert(divisible_by_digits(startnum: 1, endnum: 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\nassert(divisible_by_digits(startnum: 20, endnum: 25) == [22, 24])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunc sector_area(r: Int, a: Int) -> Double? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sector_area(r: 4, a: 45) == 6.283185307179586)\nassert(sector_area(r: 9, a: 45) == 31.808625617596654)\nassert(sector_area(r: 9, a: 361) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X: String, Y: String, Z: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lcs_of_three(X: \"AGGT12\", Y: \"12TXAYB\", Z: \"12XBA\") == 2)\nassert(lcs_of_three(X: \"Reels\", Y: \"Reelsfor\", Z: \"ReelsforReels\") == 5)\nassert(lcs_of_three(X: \"abcd1e2\", Y: \"bc12ea\", Z: \"bd1ea\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(capital_words_spaces(str1: \"Python\") == \"Python\")\nassert(capital_words_spaces(str1: \"PythonProgrammingExamples\") == \"Python Programming Examples\")\nassert(capital_words_spaces(str1: \"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunc sort_numeric_strings(nums_str: [String]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numeric_strings(nums_str: [\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\nassert(sort_numeric_strings(nums_str: [\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\nassert(sort_numeric_strings(nums_str: [\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors: [String], patterns: [String]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_samepatterns(colors: [\"red\", \"green\", \"green\"], patterns: [\"a\", \"b\", \"b\"]) == true)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\", \"b\"]) == false)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\"]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to add the given tuple to the given list.\nfunc add_tuple(test_list: [Int], test_tup: (Int, Int)) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_tuple(test_list: [5, 6, 7], test_tup: (9, 10)) == [5, 6, 7, 9, 10])\nassert(add_tuple(test_list: [6, 7, 8], test_tup: (10, 11)) == [6, 7, 8, 10, 11])\nassert(add_tuple(test_list: [7, 8, 9], test_tup: (11, 12)) == [7, 8, 9, 11, 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_min_heap(arr: [1, 2, 3, 4, 5, 6]) == true)\nassert(check_min_heap(arr: [2, 3, 4, 5, 10, 15]) == true)\nassert(check_min_heap(arr: [2, 10, 4, 5, 3, 15]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(jacobsthal_num(n: 5) == 11)\nassert(jacobsthal_num(n: 2) == 1)\nassert(jacobsthal_num(n: 4) == 5)\nassert(jacobsthal_num(n: 13) == 2731)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunc min_k(test_list: [(String, Int)], K: Int) -> [(String, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_k(test_list: [(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], K: 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\nassert(min_k(test_list: [(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], K: 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\nassert(min_k(test_list: [(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], K: 1) == [(\"Ayesha\", 9)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "swift",
+    "prompt": "\n/// We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunc extract_index_list(l1: [Int], l2: [Int], l3: [Int]) -> [AnyHashable] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 6, 5], l3: [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\nassert(extract_index_list(l1: [1, 1, 3, 4, 6, 5, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\nassert(extract_index_list(l1: [1, 2, 3, 4, 6, 6, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "swift",
+    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the second smallest number in a list.\nfunc second_smallest(numbers: [Result<Int, Double>]) -> Double? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(second_smallest(numbers: [.success(1), .success(2), .success(-8), .success(-2), .success(0), .success(-2)]) == -2)\nassert(second_smallest(numbers: [.success(1), .success(1), .failure(-0.5), .success(0), .success(2), .success(-2), .success(-2)]) == -0.5)\nassert(second_smallest(numbers: [.success(2), .success(2)]) == nil)\nassert(second_smallest(numbers: [.success(2), .success(2), .success(2)]) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunc text_match_zero_one(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_zero_one(text: \"ac\") == false)\nassert(text_match_zero_one(text: \"dc\") == false)\nassert(text_match_zero_one(text: \"abbbba\") == true)\nassert(text_match_zero_one(text: \"dsabbbba\") == true)\nassert(text_match_zero_one(text: \"asbbbba\") == false)\nassert(text_match_zero_one(text: \"abaaa\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list: [String]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_reverse_pairs(test_list: [\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\nassert(count_reverse_pairs(test_list: [\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\nassert(count_reverse_pairs(test_list: [\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_decimal(num: \"123.11\") == true)\nassert(is_decimal(num: \"e666.86\") == false)\nassert(is_decimal(num: \"3.124587\") == false)\nassert(is_decimal(num: \"1.11\") == true)\nassert(is_decimal(num: \"1.1.11\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunc find_tuples(test_list: [(Int, Int, Int)], K: Int) -> [(Int, Int, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_tuples(test_list: [(6, 24, 12), (7, 9, 6), (12, 18, 21)], K: 6) == [(6, 24, 12)])\nassert(find_tuples(test_list: [(5, 25, 30), (4, 2, 3), (7, 8, 9)], K: 5) == [(5, 25, 30)])\nassert(find_tuples(test_list: [(7, 9, 16), (8, 16, 4), (19, 17, 18)], K: 4) == [(8, 16, 4)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunc unique_Element(arr: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_Element(arr: [1, 1, 1]) == true)\nassert(unique_Element(arr: [1, 2, 1, 2]) == false)\nassert(unique_Element(arr: [1, 2, 3, 4, 5]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumber_number(monthnum3: 6) == true)\nassert(check_monthnumber_number(monthnum3: 2) == false)\nassert(check_monthnumber_number(monthnum3: 12) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_min_diff(arr: [1, 5, 3, 19, 18, 25], n: 6) == 1)\nassert(find_min_diff(arr: [4, 3, 2, 6], n: 4) == 1)\nassert(find_min_diff(arr: [30, 5, 20, 9], n: 4) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count number of digits in a given string.\nfunc number_ctr(str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_ctr(str: \"program2bedone\") == 1)\nassert(number_ctr(str: \"3wonders\") == 1)\nassert(number_ctr(str: \"123\") == 3)\nassert(number_ctr(str: \"3wond-1ers2\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_polite(n: 7) == 11)\nassert(is_polite(n: 4) == 7)\nassert(is_polite(n: 9) == 13)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return a list of all pairs of consecutive items in a given list.\nfunc pair_wise(l1: [Int]) -> [(Int, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_wise(l1: [1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\nassert(pair_wise(l1: [1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\nassert(pair_wise(l1: [5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\nassert(pair_wise(l1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunc get_pairs_count(arr: [Int], sum: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_pairs_count(arr: [1, 1, 1, 1], sum: 2) == 6)\nassert(get_pairs_count(arr: [1, 5, 7, -1, 5], sum: 6) == 3)\nassert(get_pairs_count(arr: [1, -2, 3], sum: 1) == 1)\nassert(get_pairs_count(arr: [-1, -2, 3], sum: -3) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to get the difference between two lists.\nfunc Diff(li1: [Int], li2: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Diff(li1: [10, 15, 20, 25, 30, 35, 40], li2: [25, 40, 35]) == [10, 20, 30, 15])\nassert(Diff(li1: [1, 2, 3, 4, 5], li2: [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\nassert(Diff(li1: [1, 2, 3], li2: [6, 7, 1]) == [2, 3, 6, 7])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_num_sum(n: 2) == 82)\nassert(odd_num_sum(n: 3) == 707)\nassert(odd_num_sum(n: 4) == 3108)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_expression(exp: \"{()}[{}]\") == true)\nassert(check_expression(exp: \"{()}[{]\") == false)\nassert(check_expression(exp: \"{()}[{}][]({})\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str: String, K: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_length(test_str: \"The person is most value tet\", K: 3) == \"person is most value\")\nassert(remove_length(test_str: \"If you told me about this ok\", K: 4) == \"If you me about ok\")\nassert(remove_length(test_str: \"Forces of darkeness is come into the play\", K: 4) == \"Forces of darkeness is the\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunc occurance_substring(text: String, pattern: String) -> (String, Int, Int)? {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(occurance_substring(text: \"python programming, python language\", pattern: \"python\") == (\"python\", 0, 6))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"programming\") == (\"programming\", 7, 18))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"language\") == (\"language\", 31, 39))\nassert(occurance_substring(text: \"c++ programming, c++ language\", pattern: \"python\") == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether every odd index contains odd numbers of a given list.\nfunc odd_position(nums: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_position(nums: [2, 1, 4, 3, 6, 7, 6, 3]) == true)\nassert(odd_position(nums: [4, 1, 2]) == true)\nassert(odd_position(nums: [1, 2, 3]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_vowels(test_str: \"bestinstareels\") == 7)\nassert(count_vowels(test_str: \"partofthejourneyistheend\") == 12)\nassert(count_vowels(test_str: \"amazonprime\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of non-repeated elements in a given list.\nfunc find_sum(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_sum(arr: [1, 2, 3, 1, 1, 4, 5, 6]) == 21)\nassert(find_sum(arr: [1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\nassert(find_sum(arr: [12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunc pack_consecutive_duplicates(list1: [AnyHashable]) -> [[AnyHashable]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pack_consecutive_duplicates(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\nassert(pack_consecutive_duplicates(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\nassert(pack_consecutive_duplicates(list1: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find whether a number is divisible by 11.\nfunc is_Diff(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Diff(n: 12345) == false)\nassert(is_Diff(n: 1212112) == true)\nassert(is_Diff(n: 1212) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunc find_combinations(test_list: [(Int, Int)]) -> [(Int, Int)] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_combinations(test_list: [(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\nassert(find_combinations(test_list: [(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\nassert(find_combinations(test_list: [(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunc count_divisors(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_divisors(n: 10) == true)\nassert(count_divisors(n: 100) == false)\nassert(count_divisors(n: 125) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_length_sum(arr: [1, 2, 4]) == 14)\nassert(odd_length_sum(arr: [1, 2, 1, 2]) == 15)\nassert(odd_length_sum(arr: [1, 7]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r: Int, g: Int, b: Int) -> [Double] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rgb_to_hsv(r: 255, g: 255, b: 255) == [0.0, 0.0, 100.0])\nassert(rgb_to_hsv(r: 0, g: 215, b: 0) == [120.0, 100.0, 84.31372549019608])\nassert(rgb_to_hsv(r: 10, g: 215, b: 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the product of first even and odd number of a given list.\nfunc mul_even_odd(list1: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mul_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 4)\nassert(mul_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\nassert(mul_even_odd(list1: [1, 5, 7, 9, 10]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str: String) -> (Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_str_int(test_str: \"(7, 8, 9)\") == (7, 8, 9))\nassert(tuple_str_int(test_str: \"(1, 2, 3)\") == (1, 2, 3))\nassert(tuple_str_int(test_str: \"(4, 5, 6)\") == (4, 5, 6))\nassert(tuple_str_int(test_str: \"(7, 81, 19)\") == (7, 81, 19))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "swift",
+    "prompt": "\n/// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(right_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(right_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_three(text: \"ac\") == false)\nassert(text_match_three(text: \"dc\") == false)\nassert(text_match_three(text: \"abbbba\") == true)\nassert(text_match_three(text: \"caacabbbba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create a new tuple from the given string and list.\nfunc new_tuple(test_list: [String], test_str: String) -> (String, String, String) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(new_tuple(test_list: [\"WEB\", \"is\"], test_str: \"best\") == (\"WEB\", \"is\", \"best\"))\nassert(new_tuple(test_list: [\"We\", \"are\"], test_str: \"Developers\") == (\"We\", \"are\", \"Developers\"))\nassert(new_tuple(test_list: [\"Part\", \"is\"], test_str: \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether every even index contains even numbers of a given list.\nfunc even_position(nums: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_position(nums: [3, 2, 1]) == false)\nassert(even_position(nums: [1, 2, 3]) == false)\nassert(even_position(nums: [2, 1, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup: AnyHashable) -> (Int, Int, Int, Int) {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_nested(test_tup: (1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\nassert(remove_nested(test_tup: (2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of lists in a given number of lists.\nfunc count_list(input_list: [[Int]]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_list(input_list: [[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\nassert(count_list(input_list: [[1, 2], [2, 3], [4, 5]]) == 3)\nassert(count_list(input_list: [[1, 0], [2, 0]]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the last position of an element in a sorted array.\nfunc last(arr: [Int], x: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last(arr: [1, 2, 3], x: 1) == 0)\nassert(last(arr: [1, 1, 1, 2, 3, 4], x: 1) == 2)\nassert(last(arr: [2, 3, 2, 3, 6, 8, 9], x: 3) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_starta_endb(text: \"aabbbb\") == true)\nassert(text_starta_endb(text: \"aabAbbbc\") == false)\nassert(text_starta_endb(text: \"accddbbjjj\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "swift",
+    "prompt": "\n/// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict: [String : Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(return_sum(dict: [\"a\" : 100, \"b\" : 200, \"c\" : 300]) == 600)\nassert(return_sum(dict: [\"a\" : 25, \"b\" : 18, \"c\" : 45]) == 88)\nassert(return_sum(dict: [\"a\" : 36, \"b\" : 39, \"c\" : 49]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l: Int, r: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_in_range(l: 2, r: 5) == 8)\nassert(sum_in_range(l: 5, r: 7) == 12)\nassert(sum_in_range(l: 7, r: 13) == 40)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the sum of an array.\nfunc _sum(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(_sum(arr: [1, 2, 3]) == 6)\nassert(_sum(arr: [15, 12, 13, 10]) == 50)\nassert(_sum(arr: [0, 1, 2]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n: Int, d: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_rotate(n: 16, d: 2) == 64)\nassert(left_rotate(n: 10, d: 2) == 40)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 1, d: 3) == 8)\nassert(left_rotate(n: 5, d: 3) == 40)\nassert(left_rotate(n: 29, d: 3) == 232)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to check whether the length of the word is odd or not.\nfunc word_len(s: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(word_len(s: \"Hadoop\") == false)\nassert(word_len(s: \"great\") == true)\nassert(word_len(s: \"structure\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_all_spaces(text: \"python  program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"python   programming    language\") == \"pythonprogramminglanguage\")\nassert(remove_all_spaces(text: \"python                     program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"   python                     program\") == \"pythonprogram\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x: Int, y: Int, z: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_three_equal(x: 1, y: 1, z: 1) == 3)\nassert(test_three_equal(x: -1, y: -2, z: -3) == 0)\nassert(test_three_equal(x: 1, y: 2, z: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_rotation(arr: [3, 2, 1]) == 1)\nassert(count_rotation(arr: [4, 5, 1, 2, 3]) == 2)\nassert(count_rotation(arr: [7, 8, 9, 1, 2, 3]) == 3)\nassert(count_rotation(arr: [1, 2, 3]) == 0)\nassert(count_rotation(arr: [1, 3, 2]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_perfect_square(n: 10) == false)\nassert(is_perfect_square(n: 36) == true)\nassert(is_perfect_square(n: 14) == false)\nassert(is_perfect_square(n: 196) == true)\nassert(is_perfect_square(n: 125) == false)\nassert(is_perfect_square(n: 15625) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the product of numbers in a list is even or not.\nfunc is_product_even(arr: [Int]) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_product_even(arr: [1, 2, 3]) == true)\nassert(is_product_even(arr: [1, 2, 1, 4]) == true)\nassert(is_product_even(arr: [1, 1]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunc max_sum_list(lists: [[Int]]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_list(lists: [[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\nassert(max_sum_list(lists: [[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\nassert(max_sum_list(lists: [[2, 3, 1]]) == [2, 3, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_run_uppercase(test_str: \"GeMKSForGERksISBESt\") == 5)\nassert(max_run_uppercase(test_str: \"PrECIOusMOVemENTSYT\") == 6)\nassert(max_run_uppercase(test_str: \"GooGLEFluTTER\") == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the first odd number in a given list of numbers.\nfunc first_odd(nums: [Int]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_odd(nums: [1, 3, 5]) == 1)\nassert(first_odd(nums: [2, 4, 1, 3]) == 1)\nassert(first_odd(nums: [8, 9, 1]) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup: [Int], K: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_K(test_tup: [10, 4, 5, 6, 8], K: 6) == true)\nassert(check_K(test_tup: [1, 2, 3, 4, 5, 6], K: 7) == false)\nassert(check_K(test_tup: [7, 8, 9, 44, 11, 12], K: 11) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_smaller(test_tup1: (1, 2, 3), test_tup2: (2, 3, 4)) == false)\nassert(check_smaller(test_tup1: (4, 5, 6), test_tup2: (3, 4, 5)) == true)\nassert(check_smaller(test_tup1: (11, 12, 13), test_tup2: (10, 11, 12)) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tetrahedral_number(n: 5) == 35)\nassert(tetrahedral_number(n: 6) == 56)\nassert(tetrahedral_number(n: 7) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr: String) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Char(strr: \"abc\") == \"f\")\nassert(get_Char(strr: \"gfg\") == \"t\")\nassert(get_Char(strr: \"ab\") == \"c\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequence(n: 10) == 6)\nassert(sequence(n: 2) == 1)\nassert(sequence(n: 3) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(centered_hexagonal_number(n: 10) == 271)\nassert(centered_hexagonal_number(n: 2) == 7)\nassert(centered_hexagonal_number(n: 9) == 217)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1: [String : String], dict2: [String : String], dict3: [String : String]) -> [String : String] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"O\" : \"Orange\", \"W\" : \"White\", \"B\" : \"Black\"]) == [\"B\" : \"Black\", \"R\" : \"Red\", \"P\" : \"Pink\", \"G\" : \"Green\", \"W\" : \"White\", \"O\" : \"Orange\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"L\" : \"lavender\", \"B\" : \"Blue\"]) == [\"W\" : \"White\", \"P\" : \"Pink\", \"B\" : \"Black\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"L\" : \"lavender\", \"B\" : \"Blue\"], dict3: [\"G\" : \"Green\", \"W\" : \"White\"]) == [\"B\" : \"Black\", \"P\" : \"Pink\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\", \"W\" : \"White\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunc freq_count(list1: [Int]) -> [Int : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(freq_count(list1: [10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == [10 : 4, 20 : 4, 40 : 2, 50 : 2, 30 : 1])\nassert(freq_count(list1: [1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == [1 : 3, 2 : 2, 3 : 3, 4 : 3])\nassert(freq_count(list1: [5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == [10 : 1, 5 : 3, 6 : 2, 7 : 2, 4 : 2, 9 : 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the closest smaller number than n.\nfunc closest_num(N: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_num(N: 11) == 10)\nassert(closest_num(N: 7) == 6)\nassert(closest_num(N: 12) == 11)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find squares of individual elements in a list.\nfunc square_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(square_nums(nums: [10, 20, 30]) == [100, 400, 900])\nassert(square_nums(nums: [12, 15]) == [144, 225])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the length of the longest word.\nfunc len_log(list1: [String]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(len_log(list1: [\"python\", \"PHP\", \"bigdata\"]) == 7)\nassert(len_log(list1: [\"a\", \"ab\", \"abc\"]) == 3)\nassert(len_log(list1: [\"small\", \"big\", \"tall\"]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if a string is present as a substring in a given list of string values.\nfunc find_substring(str1: [String], sub_str: String) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ack\") == true)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"abc\") == false)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ange\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n: Int) -> Bool {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_undulating(n: 1212121) == true)\nassert(is_undulating(n: 1991) == false)\nassert(is_undulating(n: 121) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a: Int, b: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power(a: 3, b: 4) == 81)\nassert(power(a: 2, b: 3) == 8)\nassert(power(a: 5, b: 5) == 3125)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "swift",
+    "prompt": "\n/// Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list: [(String, Int)]) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_minimum(test_list: [(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\nassert(index_minimum(test_list: [(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\nassert(index_minimum(test_list: [(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the length of the smallest list in a list of lists.\nfunc Find_Min_Length(lst: [[Int]]) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min_Length(lst: [[1], [1, 2]]) == 1)\nassert(Find_Min_Length(lst: [[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\nassert(Find_Min_Length(lst: [[3, 3, 3], [4, 4, 4, 4]]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the number of divisors of a given integer.\nfunc divisor(n: Int) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisor(n: 15) == 4)\nassert(divisor(n: 12) == 6)\nassert(divisor(n: 9) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunc frequency_lists(list1: [[Int]]) -> [Int : Int] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency_lists(list1: [[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == [1 : 1, 2 : 3, 3 : 1, 4 : 1, 5 : 2, 6 : 1, 7 : 1, 8 : 1, 9 : 1])\nassert(frequency_lists(list1: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == [1 : 1, 2 : 1, 3 : 1, 4 : 1, 5 : 1, 6 : 1, 7 : 1, 8 : 1, 9 : 1, 10 : 1, 11 : 1, 12 : 1])\nassert(frequency_lists(list1: [[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == [20 : 2, 30 : 2, 40 : 2, 17 : 1, 18 : 1, 16 : 1, 14 : 1, 13 : 1, 10 : 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n: Int) -> String {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(n: 8) == \"1000\")\nassert(decimal_to_binary(n: 18) == \"10010\")\nassert(decimal_to_binary(n: 7) == \"111\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "swift",
+    "prompt": "\n/// Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str: String) -> Int {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Rotations(str: \"aaaa\") == 1)\nassert(find_Rotations(str: \"ab\") == 2)\nassert(find_Rotations(str: \"abc\") == 3)",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-swift-reworded.json
+++ b/prompts/mbpp-swift-reworded.json
@@ -1,3528 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lps(str: \"TENS FOR TENS\") == 5)\nassert(lps(str: \"CARDIO FOR CARDS\") == 7)\nassert(lps(str: \"PART OF THE JOURNEY IS PART\") == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_whitespaces(text1: \" Google    Flutter \") == \"GoogleFlutter\")\nassert(remove_whitespaces(text1: \" Google    Dart \") == \"GoogleDart\")\nassert(remove_whitespaces(text1: \" iOS    Swift \") == \"iOSSwift\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether a specified array is sorted or not.\nfunc issort_list(list1: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\nassert(count_bidirectional(test_list: [(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cube(l: 5) == 150)\nassert(surfacearea_cube(l: 3) == 54)\nassert(surfacearea_cube(l: 10) == 600)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "swift",
     "prompt": "\n/// Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunc next_smallest_palindrome(num: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_smallest_palindrome(num: 99) == 101)\nassert(next_smallest_palindrome(num: 1221) == 1331)\nassert(next_smallest_palindrome(num: 120) == 121)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_Sum(n: 2) == 72)\nassert(cube_Sum(n: 3) == 288)\nassert(cube_Sum(n: 4) == 800)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of xor of all pairs of numbers in the given array.\nfunc pair_xor_Sum(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_xor_Sum(arr: [5, 9, 7, 6], n: 4) == 47)\nassert(pair_xor_Sum(arr: [7, 3, 5], n: 3) == 12)\nassert(pair_xor_Sum(arr: [7, 3], n: 2) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_min_heap(arr: [1, 2, 3, 4, 5, 6]) == true)\nassert(check_min_heap(arr: [2, 3, 4, 5, 10, 15]) == true)\nassert(check_min_heap(arr: [2, 10, 4, 5, 3, 15]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the first digit of a given number.\nfunc first_Digit(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_Digit(n: 123) == 1)\nassert(first_Digit(n: 456) == 4)\nassert(first_Digit(n: 12) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the first non-repeated character in a given string.\nfunc first_non_repeating_character(str1: String) -> String? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_non_repeating_character(str1: \"abcabc\") == nil)\nassert(first_non_repeating_character(str1: \"abc\") == \"a\")\nassert(first_non_repeating_character(str1: \"ababc\") == \"c\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert degrees to radians.\nfunc radian_degree(degree: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(radian_degree(degree: 90) == 1.5707963267948966)\nassert(radian_degree(degree: 60) == 1.0471975511965976)\nassert(radian_degree(degree: 120) == 2.0943951023931953)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_subarray_product(arr: [1, -2, -3, 0, 7, -8, -2]) == 112)\nassert(max_subarray_product(arr: [6, -3, -10, 0, 2]) == 180)\nassert(max_subarray_product(arr: [-2, -40, 0, -2, -3]) == 80)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_391_convert_list_dictionary",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert more than one array to nested dictionary.\nfunc convert_list_dictionary(l1: [String], l2: [String], l3: [Int]) -> [[String : [String : Int]]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert_list_dictionary(l1: [\"S001\", \"S002\", \"S003\", \"S004\"], l2: [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], l3: [85, 98, 89, 92]) == [[\"S001\" : [\"Adina Park\" : 85]], [\"S002\" : [\"Leyton Marsh\" : 98]], [\"S003\" : [\"Duncan Boyle\" : 89]], [\"S004\" : [\"Saim Richards\" : 92]]])\nassert(convert_list_dictionary(l1: [\"abc\", \"def\", \"ghi\", \"jkl\"], l2: [\"python\", \"program\", \"language\", \"programs\"], l3: [100, 200, 300, 400]) == [[\"abc\" : [\"python\" : 100]], [\"def\" : [\"program\" : 200]], [\"ghi\" : [\"language\" : 300]], [\"jkl\" : [\"programs\" : 400]]])\nassert(convert_list_dictionary(l1: [\"A1\", \"A2\", \"A3\", \"A4\"], l2: [\"java\", \"C\", \"C++\", \"DBMS\"], l3: [10, 20, 30, 40]) == [[\"A1\" : [\"java\" : 10]], [\"A2\" : [\"C\" : 20]], [\"A3\" : [\"C++\" : 30]], [\"A4\" : [\"DBMS\" : 40]]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find smallest number in an array.\nfunc smallest_num(xs: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_num(xs: [10, 20, 1, 45, 99]) == 1)\nassert(smallest_num(xs: [1, 2, 3]) == 1)\nassert(smallest_num(xs: [45, 46, 50, 60]) == 45)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/swiftthon-exercises/re/swiftthon-re-exercise-3.php\nfunc text_match_zero_one(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_zero_one(text: \"ac\") == false)\nassert(text_match_zero_one(text: \"dc\") == false)\nassert(text_match_zero_one(text: \"abbbba\") == true)\nassert(text_match_zero_one(text: \"dsabbbba\") == true)\nassert(text_match_zero_one(text: \"asbbbba\") == false)\nassert(text_match_zero_one(text: \"abaaa\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find nth bell number.\nfunc bell_Number(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_Number(n: 2) == 2)\nassert(bell_Number(n: 3) == 5)\nassert(bell_Number(n: 4) == 15)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find cubes of individual elements in an array.\nfunc cube_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\nassert(cube_nums(nums: [10, 20, 30]) == [1000, 8000, 27000])\nassert(cube_nums(nums: [12, 15]) == [1728, 3375])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit_Factorial(n: 4) == 4)\nassert(last_Digit_Factorial(n: 21) == 0)\nassert(last_Digit_Factorial(n: 30) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find even numbers from an array of numbers.\nfunc Split(list: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5]) == [2, 4])\nassert(Split(list: [4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\nassert(Split(list: [8, 12, 15, 19]) == [8, 12])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given integer is a prime number.\nfunc prime_num(num: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_num(num: 13) == true)\nassert(prime_num(num: 7) == true)\nassert(prime_num(num: -1010) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find tuples which have all elements divisible by k from the given array of tuples.\nfunc find_tuples(test_list: [(Int, Int, Int)], K: Int) -> [(Int, Int, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_tuples(test_list: [(6, 24, 12), (7, 9, 6), (12, 18, 21)], K: 6) == [(6, 24, 12)])\nassert(find_tuples(test_list: [(5, 25, 30), (4, 2, 3), (7, 8, 9)], K: 5) == [(5, 25, 30)])\nassert(find_tuples(test_list: [(7, 9, 16), (8, 16, 4), (19, 17, 18)], K: 4) == [(8, 16, 4)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "swift",
-    "prompt": "\n/// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(area_tetrahedron(side: 3) == 15.588457268119894)\nassert(area_tetrahedron(side: 20) == 692.8203230275509)\nassert(area_tetrahedron(side: 10) == 173.20508075688772)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given number is even or not.\nfunc is_Even(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Even(n: 1) == false)\nassert(is_Even(n: 2) == true)\nassert(is_Even(n: 3) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of positive numbers in an array.\nfunc pos_count(list: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pos_count(list: [1, -2, 3, -4]) == 2)\nassert(pos_count(list: [3, 4, 5, -1]) == 3)\nassert(pos_count(list: [1, 2, 3, 4]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_ludic(n: 10) == [1, 2, 3, 5, 7])\nassert(get_ludic(n: 25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\nassert(get_ludic(n: 45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Index(n: 2) == 4)\nassert(find_Index(n: 3) == 14)\nassert(find_Index(n: 4) == 45)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input: [Int], k: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_Array_Upto_K(input: [1, 2, 3, 4, 5, 6], k: 4) == [4, 3, 2, 1, 5, 6])\nassert(reverse_Array_Upto_K(input: [4, 5, 6, 7], k: 2) == [5, 4, 6, 7])\nassert(reverse_Array_Upto_K(input: [9, 8, 7, 6, 5], k: 3) == [7, 8, 9, 6, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort an array of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks: [(String, Int)]) -> [(String, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(subject_marks(subjectmarks: [(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\nassert(subject_marks(subjectmarks: [(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\nassert(subject_marks(subjectmarks: [(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(string: String, second_string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_dirty_chars(string: \"probasscurve\", second_string: \"pros\") == \"bacuve\")\nassert(remove_dirty_chars(string: \"digitalindia\", second_string: \"talent\") == \"digiidi\")\nassert(remove_dirty_chars(string: \"exoticmiles\", second_string: \"toxic\") == \"emles\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunc round_and_sum(list1: [Result<Double, Int>]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(round_and_sum(list1: [.success(22.4), .success(4.0), .success(-16.22), .success(-9.1), .success(11.0), .success(-12.22), .success(14.2), .success(-5.2), .success(17.5)]) == 243)\nassert(round_and_sum(list1: [.failure(5), .failure(2), .failure(9), .success(24.3), .failure(29)]) == 345)\nassert(round_and_sum(list1: [.success(25.0), .success(56.7), .success(89.2)]) == 513)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the item with maximum frequency in a given array.\nfunc max_occurrences(nums: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\nassert(max_occurrences(nums: [10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_decimal(num: \"123.11\") == true)\nassert(is_decimal(num: \"e666.86\") == false)\nassert(is_decimal(num: \"3.124587\") == false)\nassert(is_decimal(num: \"1.11\") == true)\nassert(is_decimal(num: \"1.1.11\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict: [String : Int], n: Int) -> [String : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 170) == [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 180) == [\"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 190) == [\"Pierre Cox\" : 190])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of even numbers at even positions of an array.\nfunc sum_even_and_even_index(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_even_and_even_index(arr: [5, 6, 12, 1, 18, 8]) == 30)\nassert(sum_even_and_even_index(arr: [3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\nassert(sum_even_and_even_index(arr: [5, 6, 12, 1]) == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the sum of the largest contiguous subarray in the given array.\nfunc max_sub_array_sum(a: [Int], size: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum(a: [-2, -3, 4, -1, -2, 1, 5, -3], size: 8) == 7)\nassert(max_sub_array_sum(a: [-3, -4, 5, -2, -3, 2, 6, -4], size: 8) == 8)\nassert(max_sub_array_sum(a: [-4, -5, 6, -3, -4, 3, 7, -5], size: 8) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1: [Int], array_nums2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [3, 5, 7, 9]) == [3, 5, 7, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [10, 20, 30, 40]) == [10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in a tuple.\nfunc split_two_parts(list1: [AnyHashable], L: Int) -> AnyHashable {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_two_parts(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\nassert(split_two_parts(list1: [\"a\", \"b\", \"c\", \"d\"], L: 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\nassert(split_two_parts(list1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], L: 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "swift",
-    "prompt": "\n/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text: String, pattern: String) -> (String, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_literals(text: \"The quick brown fox jumps over the lazy dog.\", pattern: \"fox\") == (\"fox\", 16, 19))\nassert(find_literals(text: \"Its been a very crazy procedure right\", pattern: \"crazy\") == (\"crazy\", 16, 21))\nassert(find_literals(text: \"Hardest choices required strongest will\", pattern: \"will\") == (\"will\", 35, 39))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the volume of a triangular prism.\nfunc find_Volume(l: Int, b: Int, h: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Volume(l: 10, b: 8, h: 6) == 240)\nassert(find_Volume(l: 3, b: 2, h: 2) == 6)\nassert(find_Volume(l: 1, b: 2, h: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v: Int, t: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(wind_chill(v: 120, t: 35) == 40)\nassert(wind_chill(v: 40, t: 20) == 19)\nassert(wind_chill(v: 10, t: 8) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the ascii value of a character.\nfunc ascii_value(k: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(ascii_value(k: \"A\") == 65)\nassert(ascii_value(k: \"R\") == 82)\nassert(ascii_value(k: \"S\") == 83)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether all the characters are same or not.\nfunc all_Characters_Same(s: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Characters_Same(s: \"python\") == false)\nassert(all_Characters_Same(s: \"aaa\") == true)\nassert(all_Characters_Same(s: \"data\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_num(test_str: \"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\nassert(move_num(test_str: \"Avengers124Assemble\") == \"AvengersAssemble124\")\nassert(move_num(test_str: \"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the length of the word is odd or not.\nfunc word_len(s: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(word_len(s: \"Hadoop\") == false)\nassert(word_len(s: \"great\") == true)\nassert(word_len(s: \"structure\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_465_drop_empty",
-    "language": "swift",
-    "prompt": "\n/// Write a function to drop empty items from a given dictionary.\nfunc drop_empty(dict1: [String : String?]) -> [String : String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : \"Green\", \"c3\" : nil]) == [\"c1\" : \"Red\", \"c2\" : \"Green\"])\nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : nil, \"c3\" : nil]) == [\"c1\" : \"Red\"])\nassert(drop_empty(dict1: [\"c1\" : nil, \"c2\" : \"Green\", \"c3\" : nil]) == [\"c2\" : \"Green\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunc insert_element(list: [String], element: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(insert_element(list: [\"Red\", \"Green\", \"Black\"], element: \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\nassert(insert_element(list: [\"python\", \"java\"], element: \"program\") == [\"program\", \"python\", \"program\", \"java\"])\nassert(insert_element(list: [\"happy\", \"sad\"], element: \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_lowercase(str1: \"PYTHon\") == \"PYTH\")\nassert(remove_lowercase(str1: \"FInD\") == \"FID\")\nassert(remove_lowercase(str1: \"STRinG\") == \"STRG\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Set_Bits(n: 2) == 1)\nassert(count_Set_Bits(n: 4) == 1)\nassert(count_Set_Bits(n: 6) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple: (String, String, String)) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_rear(test_tuple: (\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\nassert(extract_rear(test_tuple: (\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\nassert(extract_rear(test_tuple: (\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_occurance(s: \"letstdlenstdporstd\") == 3)\nassert(count_occurance(s: \"truststdsolensporsd\") == 1)\nassert(count_occurance(s: \"makestdsostdworthit\") == 2)\nassert(count_occurance(s: \"stds\") == 1)\nassert(count_occurance(s: \"\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup: [Int], K: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_K(test_tup: [10, 4, 5, 6, 8], K: 6) == true)\nassert(check_K(test_tup: [1, 2, 3, 4, 5, 6], K: 7) == false)\nassert(check_K(test_tup: [7, 8, 9, 44, 11, 12], K: 11) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to interleave 3 arrays of the same length into a single flat array.\nfunc interleave_lists(list1: [Int], list2: [Int], list3: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(interleave_lists(list1: [1, 2, 3, 4, 5, 6, 7], list2: [10, 20, 30, 40, 50, 60, 70], list3: [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\nassert(interleave_lists(list1: [10, 20], list2: [15, 2], list3: [5, 10]) == [10, 15, 5, 20, 2, 10])\nassert(interleave_lists(list1: [11, 44], list2: [10, 15], list3: [20, 5]) == [11, 10, 20, 44, 15, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"python_program\") == \"PythonProgram\")\nassert(snake_to_camel(word: \"python_language\") == \"PythonLanguage\")\nassert(snake_to_camel(word: \"programming_language\") == \"ProgrammingLanguage\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x: Int, y: Int, z: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_three_equal(x: 1, y: 1, z: 1) == 3)\nassert(test_three_equal(x: -1, y: -2, z: -3) == 0)\nassert(test_three_equal(x: 1, y: 2, z: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_length_sum(arr: [1, 2, 4]) == 14)\nassert(odd_length_sum(arr: [1, 2, 1, 2]) == 15)\nassert(odd_length_sum(arr: [1, 7]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_number(n: 2) == 2)\nassert(bell_number(n: 10) == 115975)\nassert(bell_number(n: 56) == 6775685320645824322581483068371419745979053216268760300)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the area of a rectangle.\nfunc rectangle_area(l: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rectangle_area(l: 10, b: 20) == 200)\nassert(rectangle_area(l: 10, b: 5) == 50)\nassert(rectangle_area(l: 4, b: 2) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number: Int) -> (Int, Double) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_average(number: 10) == (55, 5.5))\nassert(sum_average(number: 15) == (120, 8.0))\nassert(sum_average(number: 20) == (210, 10.5))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(division_elements(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (2, 2, 2, 3))\nassert(division_elements(test_tup1: (12, 6, 8, 16), test_tup2: (6, 3, 4, 4)) == (2, 2, 2, 4))\nassert(division_elements(test_tup1: (20, 14, 36, 18), test_tup2: (5, 7, 6, 9)) == (4, 2, 6, 2))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_digits(n: 345) == 12)\nassert(sum_digits(n: 12) == 3)\nassert(sum_digits(n: 97) == 16)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "swift",
-    "prompt": "\n/// Given an array of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list: [(String, Int)]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_minimum(test_list: [(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\nassert(index_minimum(test_list: [(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\nassert(index_minimum(test_list: [(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to divide two arrays element wise.\nfunc div_list(nums1: [Int], nums2: [Int]) -> [Double] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(div_list(nums1: [4, 5, 6], nums2: [1, 2, 3]) == [4.0, 2.5, 2.0])\nassert(div_list(nums1: [3, 2], nums2: [1, 4]) == [3.0, 0.5])\nassert(div_list(nums1: [90, 120], nums2: [50, 70]) == [1.8, 1.7142857142857142])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the array with maximum length.\nfunc max_length_list(input_list: [[Int]]) -> (Int, [Int]) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length_list(input_list: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length_list(input_list: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\nassert(max_length_list(input_list: [[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_462_combinations_list",
-    "language": "swift",
-    "prompt": "\nextension [String]: Error {}\n        \n/// Write a function to find all possible combinations of the elements of a given array.\nfunc combinations_list(list1: [String]) -> [Result<[()], [String]>] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_list(list1: [\"orange\", \"red\", \"green\", \"blue\"]) == [.success([] as [()]), .failure([\"orange\"]), .failure([\"red\"]), .failure([\"red\", \"orange\"]), .failure([\"green\"]), .failure([\"green\", \"orange\"]), .failure([\"green\", \"red\"]), .failure([\"green\", \"red\", \"orange\"]), .failure([\"blue\"]), .failure([\"blue\", \"orange\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"red\", \"orange\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"orange\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"blue\", \"green\", \"red\", \"orange\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"blue\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"white\"]), .failure([\"white\", \"red\"]), .failure([\"white\", \"green\"]), .failure([\"white\", \"green\", \"red\"]), .failure([\"white\", \"blue\"]), .failure([\"white\", \"blue\", \"red\"]), .failure([\"white\", \"blue\", \"green\"]), .failure([\"white\", \"blue\", \"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"black\", \"blue\"]), .failure([\"black\", \"blue\", \"red\"]), .failure([\"black\", \"blue\", \"green\"]), .failure([\"black\", \"blue\", \"green\", \"red\"]), .failure([\"black\", \"white\"]), .failure([\"black\", \"white\", \"red\"]), .failure([\"black\", \"white\", \"green\"]), .failure([\"black\", \"white\", \"green\", \"red\"]), .failure([\"black\", \"white\", \"blue\"]), .failure([\"black\", \"white\", \"blue\", \"red\"]), .failure([\"black\", \"white\", \"blue\", \"green\"]), .failure([\"black\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"blue\"]), .failure([\"orange\", \"blue\", \"red\"]), .failure([\"orange\", \"blue\", \"green\"]), .failure([\"orange\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"white\"]), .failure([\"orange\", \"white\", \"red\"]), .failure([\"orange\", \"white\", \"green\"]), .failure([\"orange\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"white\", \"blue\"]), .failure([\"orange\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"blue\"]), .failure([\"orange\", \"black\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\"]), .failure([\"orange\", \"black\", \"white\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"])])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_sum(nums: [1, 2, 3]) == 4)\nassert(big_sum(nums: [-1, 2, 3, 4]) == 3)\nassert(big_sum(nums: [2, 3, 6]) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to return the negative numbers in an array.\nfunc neg_nos(list1: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(neg_nos(list1: [-1, 4, 5, -6]) == [-1, -6])\nassert(neg_nos(list1: [-1, -2, 3, 4]) == [-1, -2])\nassert(neg_nos(list1: [-7, -6, 8, 9]) == [-7, -6])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(highest_Power_of_2(n: 10) == 8)\nassert(highest_Power_of_2(n: 19) == 16)\nassert(highest_Power_of_2(n: 32) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether an array contains the given subarray or not.\nfunc is_sublist(l: [Int], s: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [3, 7]) == false)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [4, 3]) == true)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [1, 6]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to subtract two arrays element-wise.\nfunc sub_list(nums1: [Int], nums2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sub_list(nums1: [1, 2, 3], nums2: [4, 5, 6]) == [-3, -3, -3])\nassert(sub_list(nums1: [1, 2], nums2: [3, 4]) == [-2, -2])\nassert(sub_list(nums1: [90, 120], nums2: [50, 70]) == [40, 50])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x: Int, y: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(opposite_Signs(x: 1, y: -2) == true)\nassert(opposite_Signs(x: 3, y: 2) == false)\nassert(opposite_Signs(x: -10, y: -10) == false)\nassert(opposite_Signs(x: -2, y: 2) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "swift",
-    "prompt": "\n/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_modulo(test_tup1: (10, 4, 5, 6), test_tup2: (5, 6, 7, 5)) == (0, 4, 5, 1))\nassert(tuple_modulo(test_tup1: (11, 5, 6, 7), test_tup2: (6, 7, 8, 6)) == (5, 5, 6, 1))\nassert(tuple_modulo(test_tup1: (12, 6, 7, 8), test_tup2: (7, 8, 9, 7)) == (5, 6, 7, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the difference of the first even and first odd number of a given array.\nfunc diff_even_odd(list1: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(diff_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 3)\nassert(diff_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\nassert(diff_even_odd(list1: [1, 5, 7, 9, 10]) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort each subarray of strings in a given array of arrays.\nfunc sort_sublists(list1: [[String]]) -> [[String]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\nassert(sort_sublists(list1: [[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the last digit of a given number.\nfunc last_Digit(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit(n: 123) == 3)\nassert(last_Digit(n: 25) == 5)\nassert(last_Digit(n: 30) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_num_sum(n: 2) == 82)\nassert(odd_num_sum(n: 3) == 707)\nassert(odd_num_sum(n: 4) == 3108)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert an array to a string.\nfunc tup_string(tup1: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tup_string(tup1: [\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\nassert(tup_string(tup1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\nassert(tup_string(tup1: [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all elements from a given array present in another array.\nfunc remove_elements(list1: [Int], list2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1: [Int], list2: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(overlapping(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == false)\nassert(overlapping(list1: [1, 2, 3], list2: [4, 5, 6]) == false)\nassert(overlapping(list1: [1, 4, 5], list2: [1, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to identify non-prime numbers.\nfunc is_not_prime(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_not_prime(n: 2) == false)\nassert(is_not_prime(n: 10) == true)\nassert(is_not_prime(n: 35) == true)\nassert(is_not_prime(n: 37) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the maximum value in a given heterogeneous array.\nfunc max_val(listval: [Result<String, Int>]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 5)\nassert(max_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 25)\nassert(max_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 50)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunc sum_negativenum(nums: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_negativenum(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\nassert(sum_negativenum(nums: [10, 15, -14, 13, -18, 12, -20]) == -52)\nassert(sum_negativenum(nums: [19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Rotations(str: \"aaaa\") == 1)\nassert(find_Rotations(str: \"ab\") == 2)\nassert(find_Rotations(str: \"abc\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_date_format(dt: \"2026-01-02\") == \"02-01-2026\")\nassert(change_date_format(dt: \"2020-11-13\") == \"13-11-2020\")\nassert(change_date_format(dt: \"2021-04-26\") == \"26-04-2021\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function which takes an array of integers and only returns the odd ones.\nfunc Split(list: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5, 6]) == [1, 3, 5])\nassert(Split(list: [10, 11, 12, 13]) == [11, 13])\nassert(Split(list: [7, 8, 9, 1]) == [7, 9, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_middle_bits(n: 9) == 15)\nassert(toggle_middle_bits(n: 10) == 12)\nassert(toggle_middle_bits(n: 11) == 13)\nassert(toggle_middle_bits(n: 65) == 127)\nassert(toggle_middle_bits(n: 77) == 115)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_char_position(str1: \"xbcefg\") == 2)\nassert(count_char_position(str1: \"ABcED\") == 3)\nassert(count_char_position(str1: \"AbgdeF\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunc large_product(nums1: [Int], nums2: [Int], N: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 3) == [60, 54, 50])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 4) == [60, 54, 50, 48])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 5) == [60, 54, 50, 48, 45])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunc cummulative_sum(test_list: [[Int]]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cummulative_sum(test_list: [[1, 3], [5, 6, 7], [2, 6]]) == 30)\nassert(cummulative_sum(test_list: [[2, 4], [6, 7, 8], [3, 7]]) == 37)\nassert(cummulative_sum(test_list: [[3, 5], [7, 8, 9], [4, 8]]) == 44)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_min_diff(arr: [1, 5, 3, 19, 18, 25], n: 6) == 1)\nassert(find_min_diff(arr: [4, 3, 2, 6], n: 4) == 1)\nassert(find_min_diff(arr: [30, 5, 20, 9], n: 4) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_starta_endb(text: \"aabbbb\") == true)\nassert(text_starta_endb(text: \"aabAbbbc\") == false)\nassert(text_starta_endb(text: \"accddbbjjj\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n: Int, d: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_rotate(n: 16, d: 2) == 64)\nassert(left_rotate(n: 10, d: 2) == 40)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 1, d: 3) == 8)\nassert(left_rotate(n: 5, d: 3) == 40)\nassert(left_rotate(n: 29, d: 3) == 232)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the first repeated character in a given string.\nfunc first_repeated_char(str1: String) -> String? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_repeated_char(str1: \"abcabc\") == \"a\")\nassert(first_repeated_char(str1: \"abc\") == nil)\nassert(first_repeated_char(str1: \"123123\") == \"1\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count inversions in an array.\nfunc get_Inv_Count(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Inv_Count(arr: [1, 20, 6, 4, 5]) == 5)\nassert(get_Inv_Count(arr: [1, 2, 1]) == 1)\nassert(get_Inv_Count(arr: [1, 2, 5, 6, 1]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_Power_Sum(n: 2) == 1056)\nassert(even_Power_Sum(n: 3) == 8832)\nassert(even_Power_Sum(n: 1) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find whether all the given arrays have equal length or not.\nfunc get_equal(Input: [[Int]]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_equal(Input: [[11, 22, 33], [44, 55, 66]]) == true)\nassert(get_equal(Input: [[1, 2, 3], [4, 5, 6, 7]]) == false)\nassert(get_equal(Input: [[1, 2], [3, 4]]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if a string represents an integer or not.\nfunc check_integer(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_integer(text: \"python\") == false)\nassert(check_integer(text: \"1\") == true)\nassert(check_integer(text: \"12345\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/swiftthon-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list: [String]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_reverse_pairs(test_list: [\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\nassert(count_reverse_pairs(test_list: [\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\nassert(count_reverse_pairs(test_list: [\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to move all zeroes to the end of the given array.\nfunc move_zero(num_list: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_zero(num_list: [1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\nassert(move_zero(num_list: [2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\nassert(move_zero(num_list: [0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if given array contains no duplicates.\nfunc check_distinct(test_tup: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_distinct(test_tup: [1, 4, 5, 6, 1, 4]) == false)\nassert(check_distinct(test_tup: [1, 4, 5, 6]) == true)\nassert(check_distinct(test_tup: [2, 3, 4, 5, 6]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost: Int, sale_amount: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(noprofit_noloss(actual_cost: 1500, sale_amount: 1200) == false)\nassert(noprofit_noloss(actual_cost: 100, sale_amount: 100) == true)\nassert(noprofit_noloss(actual_cost: 2000, sale_amount: 5000) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str: String, K: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_length(test_str: \"The person is most value tet\", K: 3) == \"person is most value\")\nassert(remove_length(test_str: \"If you told me about this ok\", K: 4) == \"If you me about ok\")\nassert(remove_length(test_str: \"Forces of darkeness is come into the play\", K: 4) == \"Forces of darkeness is the\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count number of digits in a given string.\nfunc number_ctr(str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_ctr(str: \"program2bedone\") == 1)\nassert(number_ctr(str: \"3wonders\") == 1)\nassert(number_ctr(str: \"123\") == 3)\nassert(number_ctr(str: \"3wond-1ers2\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the total number of characters in a string.\nfunc count_charac(str1: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_charac(str1: \"python programming\") == 18)\nassert(count_charac(str1: \"language\") == 8)\nassert(count_charac(str1: \"words\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m: Int, n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_total_number_of_sequences(m: 10, n: 4) == 4)\nassert(get_total_number_of_sequences(m: 5, n: 2) == 6)\nassert(get_total_number_of_sequences(m: 16, n: 3) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "swift",
-    "prompt": "\n/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/swiftthon-exercises/data-structures-and-algorithms/swiftthon-data-structure-exercise-24.php\nfunc left_insertion(a: [Int], x: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(left_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(left_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunc swap_numbers(a: Int, b: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_numbers(a: 10, b: 20) == [20, 10])\nassert(swap_numbers(a: 15, b: 17) == [17, 15])\nassert(swap_numbers(a: 100, b: 200) == [200, 100])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr: [Int], n: Int, x: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_majority(arr: [1, 2, 3, 3, 3, 3, 10], n: 7, x: 3) == true)\nassert(is_majority(arr: [1, 1, 2, 4, 4, 4, 6, 6], n: 8, x: 4) == false)\nassert(is_majority(arr: [1, 1, 1, 2, 2], n: 5, x: 1) == true)\nassert(is_majority(arr: [1, 1, 2, 2], n: 5, x: 1) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> (Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(substract_elements(test_tup1: (10, 4, 5), test_tup2: (2, 5, 18)) == (8, -1, -13))\nassert(substract_elements(test_tup1: (11, 2, 3), test_tup2: (24, 45, 16)) == (-13, -43, -13))\nassert(substract_elements(test_tup1: (7, 18, 9), test_tup2: (10, 11, 12)) == (-3, 7, -3))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(capital_words_spaces(str1: \"Python\") == \"Python\")\nassert(capital_words_spaces(str1: \"PythonProgrammingExamples\") == \"Python Programming Examples\")\nassert(capital_words_spaces(str1: \"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Average_Of_Cube(n: 2) == 4.5)\nassert(find_Average_Of_Cube(n: 3) == 12)\nassert(find_Average_Of_Cube(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict: [String : Int], n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 10) == false)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 12) == true)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 5) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tetrahedral_number(n: 5) == 35)\nassert(tetrahedral_number(n: 6) == 56)\nassert(tetrahedral_number(n: 7) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix: [[Int]]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(magic_square_test(my_matrix: [[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_uppercase(str1: \"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\nassert(remove_uppercase(str1: \"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\nassert(remove_uppercase(str1: \"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to check whether an element exists within a tuple.\nfunc check_tuplex(tuplex: [Result<String, Int>], tuple1: AnyHashable) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"r\") == true)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"5\") == false)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: 3) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dog_age(h_age: 12) == 61)\nassert(dog_age(h_age: 15) == 73)\nassert(dog_age(h_age: 24) == 109)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_Perfect_Square(N: 35) == 36)\nassert(next_Perfect_Square(N: 6) == 9)\nassert(next_Perfect_Square(N: 9) == 16)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_568_empty_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create an array of N empty dictionaries.\nfunc empty_list(length: Int) -> [[() : ()]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(empty_list(length: 5) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 6) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 7) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to convert a given string to uppercase.\nfunc is_upper(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_upper(string: \"person\") == \"PERSON\")\nassert(is_upper(string: \"final\") == \"FINAL\")\nassert(is_upper(string: \"Valid\") == \"VALID\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s: String, n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_Equivalent(s: \"011001\", n: 6) == 3)\nassert(odd_Equivalent(s: \"11011\", n: 5) == 4)\nassert(odd_Equivalent(s: \"1010\", n: 4) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr: [Int], n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(re_arrange_array(arr: [-1, 2, -3, 4, 5, 6, -7, 8, 9], n: 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\nassert(re_arrange_array(arr: [12, -14, -26, 13, 15], n: 5) == [-14, -26, 12, 13, 15])\nassert(re_arrange_array(arr: [10, 24, 36, -42, -39, -78, 85], n: 7) == [-42, -39, -78, 10, 24, 36, 85])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether an array of numbers contains only one distinct element or not.\nfunc unique_Element(arr: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_Element(arr: [1, 1, 1]) == true)\nassert(unique_Element(arr: [1, 2, 1, 2]) == false)\nassert(unique_Element(arr: [1, 2, 3, 4, 5]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_values(text: \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\nassert(extract_values(text: \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\nassert(extract_values(text: \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count true booleans in the given array.\nfunc count(lst: [Bool]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count(lst: [true, false, true]) == 2)\nassert(count(lst: [false, false]) == 0)\nassert(count(lst: [true, true, true]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "swift",
-    "prompt": "\n/// Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunc find_even_pair(A: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_even_pair(A: [5, 4, 7, 2, 1]) == 4)\nassert(find_even_pair(A: [7, 2, 8, 1, 0, 5, 11]) == 9)\nassert(find_even_pair(A: [1, 2, 3]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(armstrong_number(number: 153) == true)\nassert(armstrong_number(number: 259) == false)\nassert(armstrong_number(number: 4458) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the upper case characters in a given string.\nfunc upper_ctr(str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(upper_ctr(str: \"PYthon\") == 1)\nassert(upper_ctr(str: \"BigData\") == 1)\nassert(upper_ctr(str: \"program\") == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(and_tuples(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (0, 0, 2, 1))\nassert(and_tuples(test_tup1: (1, 2, 3, 4), test_tup2: (5, 6, 7, 8)) == (1, 2, 3, 0))\nassert(and_tuples(test_tup1: (8, 9, 11, 12), test_tup2: (7, 13, 14, 17)) == (0, 9, 10, 0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors: [String], patterns: [String]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_samepatterns(colors: [\"red\", \"green\", \"green\"], patterns: [\"a\", \"b\", \"b\"]) == true)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\", \"b\"]) == false)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\"]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of arrays in a given number of arrays.\nfunc count_list(input_list: [[Int]]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_list(input_list: [[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\nassert(count_list(input_list: [[1, 2], [2, 3], [4, 5]]) == 3)\nassert(count_list(input_list: [[1, 0], [2, 0]]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunc average_tuple(nums: [[Int]]) -> [Double] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(average_tuple(nums: [[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\nassert(average_tuple(nums: [[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\nassert(average_tuple(nums: [[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X: String, Y: String, Z: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lcs_of_three(X: \"AGGT12\", Y: \"12TXAYB\", Z: \"12XBA\") == 2)\nassert(lcs_of_three(X: \"Reels\", Y: \"Reelsfor\", Z: \"ReelsforReels\") == 5)\nassert(lcs_of_three(X: \"abcd1e2\", Y: \"bc12ea\", Z: \"bd1ea\") == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n'th star number.\nfunc find_star_num(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_star_num(n: 3) == 37)\nassert(find_star_num(n: 4) == 73)\nassert(find_star_num(n: 5) == 121)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of an array.\nfunc _sum(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(_sum(arr: [1, 2, 3]) == 6)\nassert(_sum(arr: [15, 12, 13, 10]) == 50)\nassert(_sum(arr: [0, 1, 2]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given array contains consecutive numbers or not.\nfunc check_Consecutive(l: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_Consecutive(l: [1, 2, 3, 4, 5]) == true)\nassert(check_Consecutive(l: [1, 2, 3, 5, 6]) == false)\nassert(check_Consecutive(l: [1, 2, 1]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text: String) -> (Int, Int, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverb_position(text: \"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\nassert(find_adverb_position(text: \"seriously!! there are many roses\") == (0, 9, \"seriously\"))\nassert(find_adverb_position(text: \"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "swift",
-    "prompt": "\n/// Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/swiftthon-program-right-rotate-array-n/\nfunc rotate_right(list: [Int], m: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_of_substrings(str: \"abc\") == 6)\nassert(number_of_substrings(str: \"abcd\") == 10)\nassert(number_of_substrings(str: \"abcde\") == 15)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunc list_split(S: [AnyHashable], step: Int) -> [[AnyHashable]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_split(S: [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], step: 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\nassert(list_split(S: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], step: 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\nassert(list_split(S: [\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], step: 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check if the elements of a given array are unique or not.\nfunc all_unique(test_list: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_unique(test_list: [1, 2, 3]) == true)\nassert(all_unique(test_list: [1, 2, 1, 2]) == false)\nassert(all_unique(test_list: [1, 2, 3, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to convert complex numbers to polar coordinates.\nfunc convert(numbers: Int) -> (Double, Double) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert(numbers: 1) == (1.0, 0.0))\nassert(convert(numbers: 4) == (4.0, 0.0))\nassert(convert(numbers: 5) == (5.0, 0.0))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_722_filter_data",
-    "language": "swift",
-    "prompt": "\n/// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunc filter_data(students: [String : (Double, Int)], h: Double, w: Int) -> [String : (Double, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 6.0, w: 70) == [\"Cierra Vega\" : (6.2, 70)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.9, w: 67) == [\"Cierra Vega\" : (6.2, 70), \"Kierra Gentry\" : (6.0, 68)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.7, w: 64) == [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to convert the given string to lower case.\nfunc is_lower(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_lower(string: \"InValid\") == \"invalid\")\nassert(is_lower(string: \"TruE\") == \"true\")\nassert(is_lower(string: \"SenTenCE\") == \"sentence\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_power_of_2(n: 0) == 1)\nassert(next_power_of_2(n: 5) == 8)\nassert(next_power_of_2(n: 17) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if a string is present as a substring in a given array of string values.\nfunc find_substring(str1: [String], sub_str: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ack\") == true)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"abc\") == false)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ange\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace characters in a string.\nfunc replace_char(str1: String, ch: String, newch: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_char(str1: \"polygon\", ch: \"y\", newch: \"l\") == \"pollgon\")\nassert(replace_char(str1: \"character\", ch: \"c\", newch: \"a\") == \"aharaater\")\nassert(replace_char(str1: \"python\", ch: \"l\", newch: \"a\") == \"python\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the product of first even and odd number of a given array.\nfunc mul_even_odd(list1: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mul_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 4)\nassert(mul_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\nassert(mul_even_odd(list1: [1, 5, 7, 9, 10]) == 10)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert an array to a tuple.\nfunc list_tuple(listx: [Int]) -> AnyHashable {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_tuple(listx: [5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\nassert(list_tuple(listx: [2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\nassert(list_tuple(listx: [58, 44, 56]) == (58, 44, 56))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_binomial_Coeff_Sum(n: 4) == 8)\nassert(even_binomial_Coeff_Sum(n: 6) == 32)\nassert(even_binomial_Coeff_Sum(n: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bitwise_xor(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (15, 6, 5, 10))\nassert(bitwise_xor(test_tup1: (11, 5, 7, 10), test_tup2: (6, 3, 4, 4)) == (13, 6, 3, 14))\nassert(bitwise_xor(test_tup1: (12, 6, 8, 11), test_tup2: (7, 4, 5, 6)) == (11, 2, 13, 13))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether an array is subarray of another or not.\nfunc is_Sub_Array(A: [Int], B: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sub_Array(A: [1, 4, 3, 5], B: [1, 2]) == false)\nassert(is_Sub_Array(A: [1, 2, 1], B: [1, 2, 1]) == true)\nassert(is_Sub_Array(A: [1, 0, 2, 2], B: [2, 2, 0]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a: [Int], n: Int, k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum_repeated(a: [10, 20, -30, -1], n: 4, k: 3) == 30)\nassert(max_sub_array_sum_repeated(a: [-1, 10, 20], n: 3, k: 2) == 59)\nassert(max_sub_array_sum_repeated(a: [-1, -2, -3], n: 3, k: 3) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the minimum product from the pairs of tuples within a given array.\nfunc min_product_tuple(list1: [(Int, Int)]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\nassert(min_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 30)\nassert(min_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the count of divisors is even. https://www.w3resource.com/swiftthon-exercises/basic/swiftthon-basic-1-exercise-24.php\nfunc count_divisors(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_divisors(n: 10) == true)\nassert(count_divisors(n: 100) == false)\nassert(count_divisors(n: 125) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunc triangle_area(r: Int) -> Int? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(r: -1) == nil)\nassert(triangle_area(r: 0) == 0)\nassert(triangle_area(r: 2) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a given string to an array of characters.\nfunc string_to_tuple(str1: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_tuple(str1: \"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\nassert(string_to_tuple(str1: \"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\nassert(string_to_tuple(str1: \"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(string: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_length(string: \"11000010001\") == 6)\nassert(find_length(string: \"10111\") == 1)\nassert(find_length(string: \"11011101100101\") == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Primes_nums(n: 5) == 2)\nassert(count_Primes_nums(n: 10) == 4)\nassert(count_Primes_nums(n: 100) == 25)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_product(n: 3) == 15)\nassert(sum_Of_product(n: 4) == 56)\nassert(sum_Of_product(n: 1) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the maximum aggregate from the array of tuples.\nfunc max_aggregate(stdata: [(String, Int)]) -> (String, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_aggregate(stdata: [(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort an array of elements.\nfunc comb_sort(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(comb_sort(nums: [5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\nassert(comb_sort(nums: [41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\nassert(comb_sort(nums: [99, 15, 13, 47]) == [13, 15, 47, 99])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_expression(exp: \"{()}[{}]\") == true)\nassert(check_expression(exp: \"{()}[{]\") == false)\nassert(check_expression(exp: \"{()}[{}][]({})\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz(text: \"pythonz.\") == true)\nassert(text_match_wordz(text: \"xyz.\") == true)\nassert(text_match_wordz(text: \"  lang  .\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1: [Int], lst2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_list(lst1: [10, 20, 30], lst2: [15, 25, 35]) == [25, 45, 65])\nassert(sum_list(lst1: [1, 2, 3], lst2: [5, 6, 7]) == [6, 8, 10])\nassert(sum_list(lst1: [15, 20, 30], lst2: [15, 45, 75]) == [30, 65, 105])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(newman_prime(n: 3) == 7)\nassert(newman_prime(n: 4) == 17)\nassert(newman_prime(n: 5) == 41)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to apply a given format string to all of the elements in an array.\nfunc add_string(list_: [AnyHashable], string: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_string(list_: [1, 2, 3, 4], string: \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\nassert(add_string(list_: [\"a\", \"b\", \"c\", \"d\"], string: \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\nassert(add_string(list_: [5, 6, 7, 8], string: \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the surface area of a square swiftramid with a given base edge and height.\nfunc surface_Area(b: Int, s: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surface_Area(b: 3, s: 4) == 33)\nassert(surface_Area(b: 4, s: 5) == 56)\nassert(surface_Area(b: 1, s: 2) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the length of the smallest array in an array of arrays.\nfunc Find_Min_Length(lst: [[Int]]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min_Length(lst: [[1], [1, 2]]) == 1)\nassert(Find_Min_Length(lst: [[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\nassert(Find_Min_Length(lst: [[3, 3, 3], [4, 4, 4, 4]]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(validate(n: 1234) == true)\nassert(validate(n: 51241) == false)\nassert(validate(n: 321) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hexagonal_num(n: 10) == 190)\nassert(hexagonal_num(n: 5) == 45)\nassert(hexagonal_num(n: 7) == 91)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n'th lucas number.\nfunc find_lucas(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lucas(n: 9) == 76)\nassert(find_lucas(n: 4) == 7)\nassert(find_lucas(n: 3) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to get the difference between two arrays.\nfunc Diff(li1: [Int], li2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Diff(li1: [10, 15, 20, 25, 30, 35, 40], li2: [25, 40, 35]) == [10, 20, 30, 15])\nassert(Diff(li1: [1, 2, 3, 4, 5], li2: [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\nassert(Diff(li1: [1, 2, 3], li2: [6, 7, 1]) == [2, 3, 6, 7])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1: String) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_quotation(text1: \"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\nassert(extract_quotation(text1: \"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\nassert(extract_quotation(text1: \"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\nassert(extract_quotation(text1: \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "swift",
-    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten an array and sum all of its elements.\nfunc recursive_list_sum(data_list: [Result<Int, [Int]>]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(recursive_list_sum(data_list: [.success(1), .success(2), .failure([3, 4]), .failure([5, 6])]) == 21)\nassert(recursive_list_sum(data_list: [.success(7), .success(10), .failure([15, 14]), .failure([19, 41])]) == 106)\nassert(recursive_list_sum(data_list: [.success(10), .success(20), .failure([30, 40]), .failure([50, 60])]) == 210)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a: Int, b: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(differ_At_One_Bit_Pos(a: 13, b: 9) == true)\nassert(differ_At_One_Bit_Pos(a: 15, b: 8) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 4) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 3) == true)\nassert(differ_At_One_Bit_Pos(a: 5, b: 1) == true)\nassert(differ_At_One_Bit_Pos(a: 1, b: 5) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_three(text: \"ac\") == false)\nassert(text_match_three(text: \"dc\") == false)\nassert(text_match_three(text: \"abbbba\") == true)\nassert(text_match_three(text: \"caacabbbba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product(arr: [3, 100, 4, 5, 150, 6]) == 3000)\nassert(max_product(arr: [4, 42, 55, 68, 80]) == 50265600)\nassert(max_product(arr: [10, 22, 9, 33, 21, 50, 41, 60]) == 2460)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to split an array at the nth eelment and add the first part to the end.\nfunc split_Arr(l: [Int], n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_Arr(l: [12, 10, 5, 6, 52, 36], n: 2) == [5, 6, 52, 36, 12, 10])\nassert(split_Arr(l: [1, 2, 3, 4], n: 1) == [2, 3, 4, 1])\nassert(split_Arr(l: [0, 1, 2, 3, 4, 5, 6, 7], n: 3) == [3, 4, 5, 6, 7, 0, 1, 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the number of divisors of a given integer.\nfunc divisor(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisor(n: 15) == 4)\nassert(divisor(n: 12) == 6)\nassert(divisor(n: 9) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the difference between largest and smallest value in a given array.\nfunc big_diff(nums: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_diff(nums: [1, 2, 3, 4]) == 3)\nassert(big_diff(nums: [4, 5, 12]) == 8)\nassert(big_diff(nums: [9, 2, 3]) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find squares of individual elements in an array.\nfunc square_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(square_nums(nums: [10, 20, 30]) == [100, 400, 900])\nassert(square_nums(nums: [12, 15]) == [144, 225])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Monotonic(A: [6, 5, 4, 4]) == true)\nassert(is_Monotonic(A: [1, 2, 2, 3]) == true)\nassert(is_Monotonic(A: [1, 3, 2]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_perfect_square(n: 10) == false)\nassert(is_perfect_square(n: 36) == true)\nassert(is_perfect_square(n: 14) == false)\nassert(is_perfect_square(n: 196) == true)\nassert(is_perfect_square(n: 125) == false)\nassert(is_perfect_square(n: 15625) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of common divisors of two given numbers.\nfunc sum(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum(a: 10, b: 15) == 6)\nassert(sum(a: 100, b: 150) == 93)\nassert(sum(a: 4, b: 6) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the array of maximum length in an array of arrays.\nfunc max_length(list1: [[Int]]) -> (Int, [Int]) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length(list1: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length(list1: [[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\nassert(max_length(list1: [[5], [15, 20, 25]]) == (3, [15, 20, 25]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_237_check_occurences",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the array.\nfunc check_occurences(test_list: [(Int, Int)]) -> [(Int, Int) : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_occurences(test_list: [(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == [(1, 3) : 2, (2, 5) : 2, (3, 6) : 1])\nassert(check_occurences(test_list: [(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == [(2, 4) : 2, (3, 6) : 2, (4, 7) : 1])\nassert(check_occurences(test_list: [(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == [(2, 13) : 1, (11, 23) : 1, (12, 25) : 2, (16, 23) : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a: Int, b: Int, c: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parabola_directrix(a: 5, b: 3, c: 2) == -198)\nassert(parabola_directrix(a: 9, b: 8, c: 4) == -2336)\nassert(parabola_directrix(a: 2, b: 4, c: 6) == -130)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the occurrence and position of the substrings within a string. Return nil if there is no match.\nfunc occurance_substring(text: String, pattern: String) -> (String, Int, Int)? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(occurance_substring(text: \"python programming, python language\", pattern: \"python\") == (\"python\", 0, 6))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"programming\") == (\"programming\", 7, 18))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"language\") == (\"language\", 31, 39))\nassert(occurance_substring(text: \"c++ programming, c++ language\", pattern: \"python\") == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup: AnyHashable) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_nested(test_tup: (1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\nassert(remove_nested(test_tup: (2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort each subarray of strings in a given array of arrays.\nfunc sort_sublists(input_list: [[String]]) -> [[String]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(input_list: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(input_list: [[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\nassert(sort_sublists(input_list: [[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1: [Int], L: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_kth_element(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == [1, 1, 3, 4, 4, 5, 1])\nassert(remove_kth_element(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], L: 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\nassert(remove_kth_element(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], L: 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup: (Int, Int, Int), test_dict: [String : Int]) -> (Int, Int, Int, [String : Int]) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_dict_to_tuple(test_tup: (4, 5, 6), test_dict: [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]) == (4, 5, 6, [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]))\nassert(add_dict_to_tuple(test_tup: (1, 2, 3), test_dict: [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]) == (1, 2, 3, [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]))\nassert(add_dict_to_tuple(test_tup: (8, 9, 10), test_dict: [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]) == (8, 9, 10, [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n: Int, m: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find(n: 10, m: 3) == 3)\nassert(find(n: 4, m: 2) == 2)\nassert(find(n: 20, m: 5) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_two_three(text: \"ac\") == false)\nassert(text_match_two_three(text: \"dc\") == false)\nassert(text_match_two_three(text: \"abbbba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the occurence of all elements of array in a tuple.\nfunc count_Occurrence(tup: AnyHashable, lst: [AnyHashable]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Occurrence(tup: (\"a\", \"a\", \"c\", \"b\", \"d\"), lst: [\"a\", \"b\"]) == 3)\nassert(count_Occurrence(tup: (1, 2, 3, 1, 4, 6, 7, 1, 4), lst: [1, 4, 7]) == 6)\nassert(count_Occurrence(tup: (1, 2, 3, 4, 5, 6), lst: [1, 2]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count number items that are identical in the same position of three given arrays.\nfunc count_samepair(list1: [Int], list2: [Int], list3: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 9], list3: [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\nassert(count_samepair(list1: [1, 2, 3, 4, 2, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "swift",
-    "prompt": "\n/// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_one(text: \"ac\") == false)\nassert(text_match_one(text: \"dc\") == false)\nassert(text_match_one(text: \"abba\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(difference(n: 3) == 30)\nassert(difference(n: 5) == 210)\nassert(difference(n: 2) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_string(string: \"Python\") == \"pYTHON\")\nassert(toggle_string(string: \"Pangram\") == \"pANGRAM\")\nassert(toggle_string(string: \"LIttLE\") == \"liTTle\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the element of an array having maximum length.\nfunc Find_Max(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max(lst: [[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\nassert(Find_Max(lst: [[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\nassert(Find_Max(lst: [[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n: Int, m: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eulerian_num(n: 3, m: 1) == 4)\nassert(eulerian_num(n: 4, m: 1) == 11)\nassert(eulerian_num(n: 5, m: 3) == 26)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of occurrences of a number in a given array.\nfunc frequency(a: [Int], x: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency(a: [1, 2, 3], x: 4) == 0)\nassert(frequency(a: [1, 2, 2, 3, 3, 3, 4], x: 3) == 3)\nassert(frequency(a: [0, 1, 2, 3, 1, 2], x: 1) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/swiftthon-sort-numeric-strings-in-a-array/\nfunc sort_numeric_strings(nums_str: [String]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numeric_strings(nums_str: [\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\nassert(sort_numeric_strings(nums_str: [\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\nassert(sort_numeric_strings(nums_str: [\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/swiftthon-exercises/data-structures-and-algorithms/swiftthon-recursion-exercise-9.php\nfunc geometric_sum(n: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(geometric_sum(n: 7) == 1.9921875)\nassert(geometric_sum(n: 4) == 1.9375)\nassert(geometric_sum(n: 8) == 1.99609375)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/swiftthon-exercises/lambda/swiftthon-lambda-exercise-24.php\nfunc divisible_by_digits(startnum: Int, endnum: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisible_by_digits(startnum: 1, endnum: 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\nassert(divisible_by_digits(startnum: 1, endnum: 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\nassert(divisible_by_digits(startnum: 20, endnum: 25) == [22, 24])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to calculate the product of the unique numbers in a given array.\nfunc unique_product(list_data: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_product(list_data: [10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\nassert(unique_product(list_data: [1, 2, 3, 1]) == 6)\nassert(unique_product(list_data: [7, 8, 9, 0, 1, 1]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the largest negative number from the given array.\nfunc largest_neg(list1: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_neg(list1: [1, 2, 3, -4, -6]) == -6)\nassert(largest_neg(list1: [1, 2, 3, -8, -9]) == -9)\nassert(largest_neg(list1: [1, 2, 3, 4, -1]) == -1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove consecutive duplicates of a given array.\nfunc consecutive_duplicates(nums: [AnyHashable]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(consecutive_duplicates(nums: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\nassert(consecutive_duplicates(nums: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps: (Int, Int), d: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Jumps(steps: (3, 4), d: 11) == 3.5)\nassert(min_Jumps(steps: (3, 4), d: 0) == 0)\nassert(min_Jumps(steps: (11, 14), d: 11) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr: [Int]) -> (Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Product(arr: [1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\nassert(max_Product(arr: [0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\nassert(max_Product(arr: [1, 2, 3]) == (2, 3))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the nth element from a given array of tuples.\nfunc extract_nth_element(list1: [(String, Int, Int)], n: Int) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 2) == [99, 96, 94, 98])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 1) == [98, 97, 91, 94])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nonagonal(n: 10) == 325)\nassert(is_nonagonal(n: 15) == 750)\nassert(is_nonagonal(n: 18) == 1089)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Abs_Diff(arr: [2, 1, 5, 3]) == 4)\nassert(max_Abs_Diff(arr: [9, 3, 2, 5, 1]) == 8)\nassert(max_Abs_Diff(arr: [3, 2, 1]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "swift",
-    "prompt": "\n/// Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunc pack_consecutive_duplicates(list1: [AnyHashable]) -> [[AnyHashable]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pack_consecutive_duplicates(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\nassert(pack_consecutive_duplicates(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\nassert(pack_consecutive_duplicates(list1: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cal_sum(n: 9) == 49)\nassert(cal_sum(n: 10) == 66)\nassert(cal_sum(n: 11) == 88)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_values_string(str: \"abcdef\") == \"ace\")\nassert(odd_values_string(str: \"python\") == \"pto\")\nassert(odd_values_string(str: \"data\") == \"dt\")\nassert(odd_values_string(str: \"lambs\") == \"lms\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1: [Int], arr2: [Int], k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_kth(arr1: [2, 3, 6, 7, 9], arr2: [1, 4, 8, 10], k: 5) == 6)\nassert(find_kth(arr1: [100, 112, 256, 349, 770], arr2: [72, 86, 113, 119, 265, 445, 892], k: 7) == 256)\nassert(find_kth(arr1: [3, 4, 7, 8, 10], arr2: [2, 5, 9, 11], k: 6) == 8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(jacobsthal_num(n: 5) == 11)\nassert(jacobsthal_num(n: 2) == 1)\nassert(jacobsthal_num(n: 4) == 5)\nassert(jacobsthal_num(n: 13) == 2731)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find frequency of each element in a flattened array of arrays, returned in a dictionary.\nfunc frequency_lists(list1: [[Int]]) -> [Int : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency_lists(list1: [[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == [1 : 1, 2 : 3, 3 : 1, 4 : 1, 5 : 2, 6 : 1, 7 : 1, 8 : 1, 9 : 1])\nassert(frequency_lists(list1: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == [1 : 1, 2 : 1, 3 : 1, 4 : 1, 5 : 1, 6 : 1, 7 : 1, 8 : 1, 9 : 1, 10 : 1, 11 : 1, 12 : 1])\nassert(frequency_lists(list1: [[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == [20 : 2, 30 : 2, 40 : 2, 17 : 1, 18 : 1, 16 : 1, 14 : 1, 13 : 1, 10 : 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a: Int, b: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perfect_squares(a: 1, b: 30) == [1, 4, 9, 16, 25])\nassert(perfect_squares(a: 50, b: 100) == [64, 81, 100])\nassert(perfect_squares(a: 100, b: 200) == [100, 121, 144, 169, 196])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3]) == 20)\nassert(sum_Of_Subarray_Prod(arr: [1, 2]) == 5)\nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3, 4]) == 84)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the first odd number in a given array of numbers.\nfunc first_odd(nums: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_odd(nums: [1, 3, 5]) == 1)\nassert(first_odd(nums: [2, 4, 1, 3]) == 1)\nassert(first_odd(nums: [8, 9, 1]) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunc add_nested_tuples(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_nested_tuples(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\nassert(add_nested_tuples(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\nassert(add_nested_tuples(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunc merge(lst: [[AnyHashable]]) -> [[AnyHashable]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge(lst: [[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\nassert(merge(lst: [[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\nassert(merge(lst: [[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dif_Square(n: 5) == true)\nassert(dif_Square(n: 10) == false)\nassert(dif_Square(n: 15) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_smaller(test_tup1: (1, 2, 3), test_tup2: (2, 3, 4)) == false)\nassert(check_smaller(test_tup1: (4, 5, 6), test_tup2: (3, 4, 5)) == true)\nassert(check_smaller(test_tup1: (11, 12, 13), test_tup2: (10, 11, 12)) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "swift",
-    "prompt": "\n/// Write a function to get the frequency of all the elements in an array, returned as a dictionary.\nfunc freq_count(list1: [Int]) -> [Int : Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(freq_count(list1: [10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == [10 : 4, 20 : 4, 40 : 2, 50 : 2, 30 : 1])\nassert(freq_count(list1: [1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == [1 : 3, 2 : 2, 3 : 3, 4 : 3])\nassert(freq_count(list1: [5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == [10 : 1, 5 : 3, 6 : 2, 7 : 2, 4 : 2, 9 : 2])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r: Int, g: Int, b: Int) -> [Double] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rgb_to_hsv(r: 255, g: 255, b: 255) == [0.0, 0.0, 100.0])\nassert(rgb_to_hsv(r: 0, g: 215, b: 0) == [120.0, 100.0, 84.31372549019608])\nassert(rgb_to_hsv(r: 10, g: 215, b: 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "swift",
-    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a given nested array structure.\nfunc flatten_list(list1: [Result<Int, [Int]>]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flatten_list(list1: [.success(0), .success(10), .failure([20, 30]), .success(40), .success(50), .failure([60, 70, 80]), .failure([90, 100, 110, 120])]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\nassert(flatten_list(list1: [.failure([10, 20]), .failure([40]), .failure([30, 56, 25]), .failure([10, 20]), .failure([33]), .failure([40])]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\nassert(flatten_list(list1: [.failure([1, 2, 3]), .failure([4, 5, 6]), .failure([10, 11, 12]), .failure([7, 8, 9])]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(string: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_str(string: \"annie\") == true)\nassert(check_str(string: \"dawood\") == false)\nassert(check_str(string: \"Else\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumber_number(monthnum3: 6) == true)\nassert(check_monthnumber_number(monthnum3: 2) == false)\nassert(check_monthnumber_number(monthnum3: 12) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort the given array.\nfunc heap_sort(iterable: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_sort(iterable: [1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\nassert(heap_sort(iterable: [25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\nassert(heap_sort(iterable: [7, 1, 9, 5]) == [1, 5, 7, 9])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1: [Int], nums2: [Int], k: Int) -> [[Int]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 2) == [[1, 2], [1, 4]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 1) == [[1, 2]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return nil if no solution exists.\nfunc find_solution(a: Int, b: Int, n: Int) -> (Int, Int)? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_solution(a: 2, b: 3, n: 7) == (2, 1))\nassert(find_solution(a: 4, b: 2, n: 7) == nil)\nassert(find_solution(a: 1, b: 13, n: 17) == (4, 1))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the largest number that can be formed with the given array of digits.\nfunc find_Max_Num(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Max_Num(arr: [1, 2, 3]) == 321)\nassert(find_Max_Num(arr: [4, 5, 6, 1]) == 6541)\nassert(find_Max_Num(arr: [1, 2, 3, 9]) == 9321)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunc max_sum_list(lists: [[Int]]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_list(lists: [[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\nassert(max_sum_list(lists: [[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\nassert(max_sum_list(lists: [[2, 3, 1]]) == [2, 3, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to interchange the first and last elements in an array.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median of two sorted arrays of same size.\nfunc get_median(arr1: [Int], arr2: [Int], n: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_median(arr1: [1, 12, 15, 26, 38], arr2: [2, 13, 17, 30, 45], n: 5) == 16.0)\nassert(get_median(arr1: [2, 4, 8, 9], arr2: [7, 13, 19, 28], n: 4) == 8.5)\nassert(get_median(arr1: [3, 6, 14, 23, 36, 42], arr2: [2, 18, 27, 39, 49, 55], n: 6) == 25.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(text: \"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\nassert(replace_spaces(text: \"The_Avengers\") == \"The Avengers\")\nassert(replace_spaces(text: \"Fast and Furious\") == \"Fast_and_Furious\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "swift",
-    "prompt": "\n/// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1: Int, num2: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(are_equivalent(num1: 36, num2: 57) == false)\nassert(are_equivalent(num1: 2, num2: 4) == false)\nassert(are_equivalent(num1: 23, num2: 47) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to reverse each string in a given array of string values.\nfunc reverse_string_list(stringlist: [String]) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_string_list(stringlist: [\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\nassert(reverse_string_list(stringlist: [\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\nassert(reverse_string_list(stringlist: [\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "swift",
-    "prompt": "\n/// Write a function to compute the sum of digits of each number of a given array.\nfunc sum_of_digits(nums: [AnyHashable]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_of_digits(nums: [10, 2, 56]) == 14)\nassert(sum_of_digits(nums: [[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\nassert(sum_of_digits(nums: [10, 20, -4, 5, -70]) == 19)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequence(n: 10) == 6)\nassert(sequence(n: 2) == 1)\nassert(sequence(n: 3) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunc heap_queue_largest(nums: [Int], n: Int) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 3) == [85, 75, 65])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 2) == [85, 75])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 5) == [85, 75, 65, 58, 35])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "swift",
-    "prompt": "\n/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost: Int, sale_amount: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(loss_amount(actual_cost: 1500, sale_amount: 1200) == 0)\nassert(loss_amount(actual_cost: 100, sale_amount: 200) == 100)\nassert(loss_amount(actual_cost: 2000, sale_amount: 5000) == 3000)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunc union_elements(test_tup1: [Int], test_tup2: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(union_elements(test_tup1: [3, 4, 5, 6], test_tup2: [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\nassert(union_elements(test_tup1: [1, 2, 3, 4], test_tup2: [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\nassert(union_elements(test_tup1: [11, 12, 13, 14], test_tup2: [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the length of the longest subarrays.\nfunc Find_Max_Length(lst: [[Int]]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max_Length(lst: [[1], [1, 4], [5, 6, 7, 8]]) == 4)\nassert(Find_Max_Length(lst: [[0, 1], [2, 2], [3, 2, 1]]) == 3)\nassert(Find_Max_Length(lst: [[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items: [String]) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_parenthesis(items: [\"python (chrome)\"]) == \"python\")\nassert(remove_parenthesis(items: [\"string(.abc)\"]) == \"string\")\nassert(remove_parenthesis(items: [\"alpha(num)\"]) == \"alpha\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find whether the parity of a given number is odd.\nfunc find_Parity(x: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Parity(x: 12) == false)\nassert(find_Parity(x: 7) == true)\nassert(find_Parity(x: 10) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1: Int, base2: Int, height: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_trapezium(base1: 15, base2: 25, height: 35) == 20)\nassert(median_trapezium(base1: 10, base2: 20, height: 30) == 15)\nassert(median_trapezium(base1: 6, base2: 9, height: 4) == 7.5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(centered_hexagonal_number(n: 10) == 271)\nassert(centered_hexagonal_number(n: 2) == 7)\nassert(centered_hexagonal_number(n: 9) == 217)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find number of arrays present in the given array.\nfunc find_lists(Input: [AnyHashable]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lists(Input: [[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\nassert(find_lists(Input: [[1, 2], [3, 4], [5, 6]]) == 3)\nassert(find_lists(Input: [9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_sum(n: 60) == 106)\nassert(get_max_sum(n: 10) == 12)\nassert(get_max_sum(n: 2) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the length of the longest word.\nfunc len_log(list1: [String]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(len_log(list1: [\"python\", \"PHP\", \"bigdata\"]) == 7)\nassert(len_log(list1: [\"a\", \"ab\", \"abc\"]) == 3)\nassert(len_log(list1: [\"small\", \"big\", \"tall\"]) == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nil if the angle is larger than 360 degrees.\nfunc sector_area(r: Int, a: Int) -> Double? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sector_area(r: 4, a: 45) == 6.283185307179586)\nassert(sector_area(r: 9, a: 45) == 31.808625617596654)\nassert(sector_area(r: 9, a: 361) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether every odd index contains odd numbers of a given array.\nfunc odd_position(nums: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_position(nums: [2, 1, 4, 3, 6, 7, 6, 3]) == true)\nassert(odd_position(nums: [4, 1, 2]) == true)\nassert(odd_position(nums: [1, 2, 3]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "swift",
-    "prompt": "\n/// Write a function to join an array of multiple integers into a single integer.\nfunc multiple_to_single(L: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiple_to_single(L: [11, 33, 50]) == 113350)\nassert(multiple_to_single(L: [-1, 2, 3, 4, 5, 6]) == -123456)\nassert(multiple_to_single(L: [10, 15, 20, 25]) == 10152025)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find whether a number is divisible by 11.\nfunc is_Diff(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Diff(n: 12345) == false)\nassert(is_Diff(n: 1212112) == true)\nassert(is_Diff(n: 1212) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "swift",
-    "prompt": "\n/// Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunc index_multiplication(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_multiplication(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\nassert(index_multiplication(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\nassert(index_multiplication(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str: String) -> (Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_str_int(test_str: \"(7, 8, 9)\") == (7, 8, 9))\nassert(tuple_str_int(test_str: \"(1, 2, 3)\") == (1, 2, 3))\nassert(tuple_str_int(test_str: \"(4, 5, 6)\") == (4, 5, 6))\nassert(tuple_str_int(test_str: \"(7, 81, 19)\") == (7, 81, 19))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(amicable_numbers_sum(limit: 999) == 504)\nassert(amicable_numbers_sum(limit: 9999) == 31626)\nassert(amicable_numbers_sum(limit: 99) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove odd characters in a string.\nfunc remove_odd(str1: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(str1: \"python\") == \"yhn\")\nassert(remove_odd(str1: \"program\") == \"rga\")\nassert(remove_odd(str1: \"language\") == \"agae\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup: [Int]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_elements(test_tup: [1, 5, 7, 8, 10]) == [5, 35, 56, 80])\nassert(multiply_elements(test_tup: [2, 4, 5, 6, 7]) == [8, 20, 30, 42])\nassert(multiply_elements(test_tup: [12, 13, 14, 9, 15]) == [156, 182, 126, 135])\nassert(multiply_elements(test_tup: [12]) == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_rotation(arr: [3, 2, 1]) == 1)\nassert(count_rotation(arr: [4, 5, 1, 2, 3]) == 2)\nassert(count_rotation(arr: [7, 8, 9, 1, 2, 3]) == 3)\nassert(count_rotation(arr: [1, 2, 3]) == 0)\nassert(count_rotation(arr: [1, 3, 2]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract the number of unique tuples in the given array.\nfunc extract_freq(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_freq(test_list: [(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\nassert(extract_freq(test_list: [(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\nassert(extract_freq(test_list: [(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "swift",
-    "prompt": "\n/// The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunc count_same_pair(nums1: [Int], nums2: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_same_pair(nums1: [1, 2, 3, 4, 5, 6, 7, 8], nums2: [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\nassert(count_same_pair(nums1: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\nassert(count_same_pair(nums1: [2, 4, -6, -9, 11, -12, 14, -5, 17], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\nassert(count_same_pair(nums1: [0, 1, 1, 2], nums2: [0, 1, 2, 2]) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power(a: 3, b: 4) == 81)\nassert(power(a: 2, b: 3) == 8)\nassert(power(a: 5, b: 5) == 3125)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "swift",
-    "prompt": "\n/// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict: [String : Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(return_sum(dict: [\"a\" : 100, \"b\" : 200, \"c\" : 300]) == 600)\nassert(return_sum(dict: [\"a\" : 25, \"b\" : 18, \"c\" : 45]) == 88)\nassert(return_sum(dict: [\"a\" : 36, \"b\" : 39, \"c\" : 49]) == 124)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return an array of all pairs of consecutive items in a given array.\nfunc pair_wise(l1: [Int]) -> [(Int, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_wise(l1: [1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\nassert(pair_wise(l1: [1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\nassert(pair_wise(l1: [5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\nassert(pair_wise(l1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to split a string into characters.\nfunc split(word: String) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split(word: \"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\nassert(split(word: \"Name\") == [\"N\", \"a\", \"m\", \"e\"])\nassert(split(word: \"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find minimum of three numbers.\nfunc min_of_three(a: Int, b: Int, c: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_of_three(a: 10, b: 20, c: 0) == 0)\nassert(min_of_three(a: 19, b: 15, c: 18) == 15)\nassert(min_of_three(a: -10, b: -20, c: -30) == -30)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sum_Of_Powers_Of_Two(n: 10) == true)\nassert(is_Sum_Of_Powers_Of_Two(n: 7) == false)\nassert(is_Sum_Of_Powers_Of_Two(n: 14) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Char(strr: \"abc\") == \"f\")\nassert(get_Char(strr: \"gfg\") == \"t\")\nassert(get_Char(strr: \"ab\") == \"c\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_div(number: 8) == 7)\nassert(sum_div(number: 12) == 16)\nassert(sum_div(number: 7) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "swift",
-    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case stringValue(String)\n    case doubleValue(Double)\n}\n\n            \n/// Write a swiftthon function that returns the number of integer elements in a given array.\nfunc count_integer(list1: [Value]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_integer(list1: [.intValue(1), .intValue(2), .stringValue(\"abc\"), .doubleValue(1.2)]) == 2)\nassert(count_integer(list1: [.intValue(1), .intValue(2), .intValue(3)]) == 3)\nassert(count_integer(list1: [.intValue(1), .doubleValue(1.2), .intValue(4), .doubleValue(5.1)]) == 2)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to remove duplicate numbers from a given number of arrays.\nfunc two_unique_nums(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(two_unique_nums(nums: [1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_duplicate(arraynums: [1, 2, 3, 4, 5]) == false)\nassert(test_duplicate(arraynums: [1, 2, 3, 4, 4]) == true)\nassert(test_duplicate(arraynums: [1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function which returns nth catalan number.\nfunc catalan_number(num: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(catalan_number(num: 10) == 16796)\nassert(catalan_number(num: 9) == 4862)\nassert(catalan_number(num: 7) == 429)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base: Int, power: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power_base_sum(base: 2, power: 100) == 115)\nassert(power_base_sum(base: 8, power: 10) == 37)\nassert(power_base_sum(base: 8, power: 15) == 62)\nassert(power_base_sum(base: 3, power: 3) == 9)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunc replace_list(list1: [AnyHashable], list2: [AnyHashable]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_list(list1: [1, 3, 5, 7, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\nassert(replace_list(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\nassert(replace_list(list1: [\"red\", \"blue\", \"green\"], list2: [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth octagonal number.\nfunc is_octagonal(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_octagonal(n: 5) == 65)\nassert(is_octagonal(n: 10) == 280)\nassert(is_octagonal(n: 15) == 645)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1: String, char: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_blank(str1: \"hello people\", char: \"@\") == \"hello@people\")\nassert(replace_blank(str1: \"python program language\", char: \"$\") == \"python$program$language\")\nassert(replace_blank(str1: \"blank space\", char: \"-\") == \"blank-space\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_specialchar(text: \"Python language, Programming language.\") == \"Python:language::Programming:language:\")\nassert(replace_specialchar(text: \"a b c,d e f\") == \"a:b:c:d:e:f\")\nassert(replace_specialchar(text: \"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums: (Int, Int, Int)) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_int(nums: (1, 2, 3)) == 123)\nassert(tuple_to_int(nums: (4, 5, 6)) == 456)\nassert(tuple_to_int(nums: (5, 6, 7)) == 567)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w: Int, h: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(otherside_rightangle(w: 7, h: 8) == 10.63014581273465)\nassert(otherside_rightangle(w: 3, h: 4) == 5)\nassert(otherside_rightangle(w: 7, h: 15) == 16.55294535724685)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_585_expensive_items",
-    "language": "swift",
-    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the n most expensive items in a given dataset.\nfunc expensive_items(items: [[String : Result<String, Double>]], n: Int) -> [[String : Result<String, Double>]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)]], n: 2) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)], [\"name\" : .success(\"Item-4\"), \"price\" : .failure(22.75)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1: Int, n2: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digit_distance_nums(n1: 1, n2: 2) == 1)\nassert(digit_distance_nums(n1: 23, n2: 56) == 6)\nassert(digit_distance_nums(n1: 123, n2: 256) == 7)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "swift",
-    "prompt": "\n/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz_middle(text: \"pythonzabc.\") == true)\nassert(text_match_wordz_middle(text: \"zxyabc.\") == false)\nassert(text_match_wordz_middle(text: \"  lang  .\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(removezero_ip(ip: \"216.08.094.196\") == \"216.8.94.196\")\nassert(removezero_ip(ip: \"12.01.024\") == \"12.1.24\")\nassert(removezero_ip(ip: \"216.08.094.0196\") == \"216.8.94.196\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count the number of subarrays containing a particular element.\nfunc count_element_in_list(list1: [[AnyHashable]], x: AnyHashable) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_element_in_list(list1: [[1, 3], [5, 7], [1, 11], [1, 15, 7]], x: 1) == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"A\") == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"E\") == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "swift",
-    "prompt": "\n/// Write a function to multiply two integers.\nfunc multiply_int(x: Int, y: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_int(x: 10, y: 20) == 200)\nassert(multiply_int(x: 5, y: 10) == 50)\nassert(multiply_int(x: 4, y: 8) == 32)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup: (Int, Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_pairwise(test_tup: (1, 5, 7, 8, 10)) == (6, 12, 15, 18))\nassert(add_pairwise(test_tup: (2, 6, 8, 9, 11)) == (8, 14, 17, 20))\nassert(add_pairwise(test_tup: (3, 7, 9, 10, 12)) == (10, 16, 19, 22))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given array.\nfunc max_product_tuple(list1: [(Int, Int)]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\nassert(max_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 200)\nassert(max_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)",
     "stop_tokens": [
       "\n}"
     ]
@@ -3532,7 +16,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find the kth element in the given array using 1-based indexing.\nfunc kth_element(arr: [Int], k: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(kth_element(arr: [12, 3, 5, 7, 19], k: 2) == 3)\nassert(kth_element(arr: [17, 24, 8, 23], k: 3) == 8)\nassert(kth_element(arr: [16, 21, 25, 36, 4], k: 4) == 36)",
     "stop_tokens": [
@@ -3540,277 +24,109 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to interchange the first and last element in a given array.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to convert a snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"python_program\") == \"PythonProgram\")\nassert(snake_to_camel(word: \"python_language\") == \"PythonLanguage\")\nassert(snake_to_camel(word: \"programming_language\") == \"ProgrammingLanguage\")",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "swift",
-    "prompt": "\nextension (Int, Int): Error {}\n        \n/// Write a function to find the number of elements that occurs before the array element in the given tuple.\nfunc count_first_elements(test_tup: [Result<Int, (Int, Int)>]) -> Int {\n",
+    "prompt": "\n/// Write a function to find the Eulerian number a(n, m).\nfunc eulerian_num(n: Int, m: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_first_elements(test_tup: [.success(1), .success(5), .success(7), .failure((4, 6)), .success(10)]) == 3)\nassert(count_first_elements(test_tup: [.success(2), .success(9), .failure((5, 7)), .success(11)]) == 2)\nassert(count_first_elements(test_tup: [.success(11), .success(15), .success(5), .success(8), .failure((2, 3)), .success(8)]) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(eulerian_num(n: 3, m: 1) == 4)\nassert(eulerian_num(n: 4, m: 1) == 11)\nassert(eulerian_num(n: 5, m: 3) == 26)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "swift",
-    "prompt": "\n/// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a: [Int], x: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to sort each subarray of strings in a given array of arrays.\nfunc sort_sublists(input_list: [[String]]) -> [[String]] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(right_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(right_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(input_list: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(input_list: [[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]) == [[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]])\nassert(sort_sublists(input_list: [[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]) == [[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "swift",
-    "prompt": "\n/// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x: Int) -> Bool {\n",
+    "prompt": "\n/// Write a swiftthon function to count true booleans in the given array.\nfunc count(lst: [Bool]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_woodall(x: 383) == true)\nassert(is_woodall(x: 254) == false)\nassert(is_woodall(x: 200) == false)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count(lst: [true, false, true]) == 2)\nassert(count(lst: [false, false]) == 0)\nassert(count(lst: [true, true, true]) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "swift",
-    "prompt": "\n/// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to append the given array to the given tuples.\nfunc add_lists(test_list: [Int], test_tup: (Int, Int)) -> (Int, Int, Int, Int, Int) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(shell_sort(my_list: [12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\nassert(shell_sort(my_list: [24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\nassert(shell_sort(my_list: [32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_lists(test_list: [5, 6, 7], test_tup: (9, 10)) == (9, 10, 5, 6, 7))\nassert(add_lists(test_list: [6, 7, 8], test_tup: (10, 11)) == (10, 11, 6, 7, 8))\nassert(add_lists(test_list: [7, 8, 9], test_tup: (11, 12)) == (11, 12, 7, 8, 9))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A: [Int], N: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to merge three arrays into a single sorted array.\nfunc merge_sorted_list(num1: [Int], num2: [Int], num3: [Int]) -> [Int] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Odd_Pair(A: [5, 4, 7, 2, 1], N: 5) == 6)\nassert(find_Odd_Pair(A: [7, 2, 8, 1, 0, 5, 11], N: 7) == 12)\nassert(find_Odd_Pair(A: [1, 2, 3], N: 3) == 2)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_sorted_list(num1: [25, 24, 15, 4, 5, 29, 110], num2: [19, 20, 11, 56, 25, 233, 154], num3: [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\nassert(merge_sorted_list(num1: [1, 3, 5, 6, 8, 9], num2: [2, 5, 7, 11], num3: [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\nassert(merge_sorted_list(num1: [18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], num2: [25, 35, 22, 85, 14, 65, 75, 25, 58], num3: [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l: Int, r: Int) -> Int {\n",
+    "prompt": "\n/// Write a swiftthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunc odd_Equivalent(s: String, n: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_in_range(l: 2, r: 5) == 8)\nassert(sum_in_range(l: 5, r: 7) == 12)\nassert(sum_in_range(l: 7, r: 13) == 40)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_Equivalent(s: \"011001\", n: 6) == 3)\nassert(odd_Equivalent(s: \"11011\", n: 5) == 4)\nassert(odd_Equivalent(s: \"1010\", n: 4) == 2)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "swift",
-    "prompt": "\n/// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to check if a string represents an integer or not.\nfunc check_integer(text: String) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_perimeter(a: 10) == 40)\nassert(square_perimeter(a: 5) == 20)\nassert(square_perimeter(a: 4) == 16)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_integer(text: \"python\") == false)\nassert(check_integer(text: \"1\") == true)\nassert(check_integer(text: \"12345\") == true)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "swift",
-    "prompt": "\n/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to convert a given tuple of positive integers into a single integer.\nfunc tuple_to_int(nums: (Int, Int, Int)) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_polite(n: 7) == 11)\nassert(is_polite(n: 4) == 7)\nassert(is_polite(n: 9) == 13)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "swift",
-    "prompt": "\n/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_series(n: 6) == 12)\nassert(sum_series(n: 10) == 30)\nassert(sum_series(n: 9) == 25)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_dissimilar(test_tup1: (3, 4, 5, 6), test_tup2: (5, 7, 4, 10)) == (3, 6, 7, 10))\nassert(find_dissimilar(test_tup1: (1, 2, 3, 4), test_tup2: (7, 2, 3, 9)) == (1, 4, 7, 9))\nassert(find_dissimilar(test_tup1: (21, 11, 25, 26), test_tup2: (26, 34, 21, 36)) == (34, 36, 11, 25))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "swift",
-    "prompt": "\n/// Write a function to return two words from an array of words starting with letter 'p'.\nfunc start_withp(words: [String]) -> (String, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(start_withp(words: [\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\nassert(start_withp(words: [\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\nassert(start_withp(words: [\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"android_tv\") == \"AndroidTv\")\nassert(snake_to_camel(word: \"google_pixel\") == \"GooglePixel\")\nassert(snake_to_camel(word: \"apple_watch\") == \"AppleWatch\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(volume_cube(l: 3) == 27)\nassert(volume_cube(l: 2) == 8)\nassert(volume_cube(l: 5) == 125)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumb_number(monthnum2: 5) == true)\nassert(check_monthnumb_number(monthnum2: 2) == false)\nassert(check_monthnumb_number(monthnum2: 6) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n: Int, l: Int, r: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Bits_Set_In_The_Given_Range(n: 4, l: 1, r: 2) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 17, l: 2, r: 4) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 39, l: 4, r: 6) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to get the first element of each subarray.\nfunc Extract(lst: [[Int]]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Extract(lst: [[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\nassert(Extract(lst: [[1, 2, 3], [4, 5]]) == [1, 4])\nassert(Extract(lst: [[9, 8, 1], [1, 2]]) == [9, 1])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r: Int, h: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cylinder(r: 10, h: 5) == 942.45)\nassert(surfacearea_cylinder(r: 4, h: 5) == 226.18800000000002)\nassert(surfacearea_cylinder(r: 4, h: 10) == 351.848)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names: [String]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sample_nam(sample_names: [\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\nassert(sample_nam(sample_names: [\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\nassert(sample_nam(sample_names: [\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n: Int) -> AnyHashable {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rearrange_bigger(n: 12) == 21)\nassert(rearrange_bigger(n: 10) == false)\nassert(rearrange_bigger(n: 102) == 120)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perimeter_pentagon(a: 5) == 25)\nassert(perimeter_pentagon(a: 10) == 50)\nassert(perimeter_pentagon(a: 15) == 75)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum(arr: [1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\nassert(max_sum(arr: [80, 60, 30, 40, 20, 10]) == 210)\nassert(max_sum(arr: [2, 3, 14, 16, 21, 23, 29, 30]) == 138)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple: (Int, Int, (Int, Int, (Int, Int)), Int, Int)) -> AnyHashable {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_even(test_tuple: (4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\nassert(extract_even(test_tuple: (5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\nassert(extract_even(test_tuple: (5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_int(nums: (1, 2, 3)) == 123)\nassert(tuple_to_int(nums: (4, 5, 6)) == 456)\nassert(tuple_to_int(nums: (5, 6, 7)) == 567)",
     "stop_tokens": [
       "\n}"
     ]
@@ -3820,201 +136,9 @@
     "language": "swift",
     "prompt": "\n/// Write a function to convert all possible convertible elements in an array of arrays to floats.\nfunc list_to_float(test_list: [(String, String)]) -> [(Double, Double)] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_to_float(test_list: [(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")]) == [(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)])\nassert(list_to_float(test_list: [(\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")]) == [(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)])\nassert(list_to_float(test_list: [(\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")]) == [(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 20)\nassert(square_Sum(n: 3) == 56)\nassert(square_Sum(n: 4) == 120)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunc get_pairs_count(arr: [Int], sum: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_pairs_count(arr: [1, 1, 1, 1], sum: 2) == 6)\nassert(get_pairs_count(arr: [1, 5, 7, -1, 5], sum: 6) == 3)\nassert(get_pairs_count(arr: [1, -2, 3], sum: 1) == 1)\nassert(get_pairs_count(arr: [-1, -2, 3], sum: -3) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n: Int, k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_no_of_ways(n: 2, k: 4) == 16)\nassert(count_no_of_ways(n: 3, k: 2) == 6)\nassert(count_no_of_ways(n: 4, k: 4) == 228)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "swift",
-    "prompt": "\n/// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_words(s: \"python program\") == \"program python\")\nassert(reverse_words(s: \"java language\") == \"language java\")\nassert(reverse_words(s: \"indian man\") == \"man indian\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check if a given number is one less than twice its reverse.\nfunc checks(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(checks(n: 70) == false)\nassert(checks(n: 23) == false)\nassert(checks(n: 73) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the last position of an element in a sorted array.\nfunc last(arr: [Int], x: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last(arr: [1, 2, 3], x: 1) == 0)\nassert(last(arr: [1, 1, 1, 2, 3, 4], x: 1) == 2)\nassert(last(arr: [2, 3, 2, 3, 6, 8, 9], x: 3) == 3)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function that takes in a tuple and an element and counts the occcurences of the element in the array.\nfunc count_X(tup: [Int], x: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 4) == 0)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 10) == 3)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 8) == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "swift",
-    "prompt": "\n/// We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunc extract_index_list(l1: [Int], l2: [Int], l3: [Int]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 6, 5], l3: [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\nassert(extract_index_list(l1: [1, 1, 3, 4, 6, 5, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\nassert(extract_index_list(l1: [1, 2, 3, 4, 6, 6, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [] as [AnyHashable])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "swift",
-    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the second smallest number in an array.\nfunc second_smallest(numbers: [Result<Int, Double>]) -> Double? {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(second_smallest(numbers: [.success(1), .success(2), .success(-8), .success(-2), .success(0), .success(-2)]) == -2)\nassert(second_smallest(numbers: [.success(1), .success(1), .failure(-0.5), .success(0), .success(2), .success(-2), .success(-2)]) == -0.5)\nassert(second_smallest(numbers: [.success(2), .success(2)]) == nil)\nassert(second_smallest(numbers: [.success(2), .success(2), .success(2)]) == nil)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup: (String, String, Int, String)) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate_tuple(test_tup: (\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\nassert(concatenate_tuple(test_tup: (\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\nassert(concatenate_tuple(test_tup: (\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(string: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(string: \"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\nassert(replace_spaces(string: \"I am a Programmer\") == \"I%20am%20a%20Programmer\")\nassert(replace_spaces(string: \"I love Coding\") == \"I%20love%20Coding\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunc sum_range_list(list1: [Int], m: Int, n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 8, n: 10) == 29)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 5, n: 7) == 16)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 7, n: 10) == 38)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "swift",
-    "prompt": "\n/// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1: [String : String], dict2: [String : String], dict3: [String : String]) -> [String : String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"O\" : \"Orange\", \"W\" : \"White\", \"B\" : \"Black\"]) == [\"B\" : \"Black\", \"R\" : \"Red\", \"P\" : \"Pink\", \"G\" : \"Green\", \"W\" : \"White\", \"O\" : \"Orange\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"L\" : \"lavender\", \"B\" : \"Blue\"]) == [\"W\" : \"White\", \"P\" : \"Pink\", \"B\" : \"Black\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"L\" : \"lavender\", \"B\" : \"Blue\"], dict3: [\"G\" : \"Green\", \"W\" : \"White\"]) == [\"B\" : \"Black\", \"P\" : \"Pink\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\", \"W\" : \"White\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the minimum of two numbers.\nfunc minimum(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minimum(a: 1, b: 2) == 1)\nassert(minimum(a: -5, b: -4) == -5)\nassert(minimum(a: 0, b: 0) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum difference between available pairs in the given tuple array.\nfunc max_difference(test_list: [(Int, Int)]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_difference(test_list: [(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\nassert(max_difference(test_list: [(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\nassert(max_difference(test_list: [(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find element at a given index after number of rotations.\nfunc find_Element(arr: [Int], ranges: [[Int]], rotations: Int, index: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Element(arr: [1, 2, 3, 4, 5], ranges: [[0, 2], [0, 3]], rotations: 2, index: 1) == 3)\nassert(find_Element(arr: [1, 2, 3, 4], ranges: [[0, 1], [0, 2]], rotations: 1, index: 2) == 3)\nassert(find_Element(arr: [1, 2, 3, 4, 5, 6], ranges: [[0, 1], [0, 2]], rotations: 1, index: 1) == 1)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4024,7 +148,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to convert a string to an array of strings split on the space character.\nfunc string_to_list(string: String) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_list(string: \"python programming\") == [\"python\", \"programming\"])\nassert(string_to_list(string: \"lists tuples strings\") == [\"lists\", \"tuples\", \"strings\"])\nassert(string_to_list(string: \"write a program\") == [\"write\", \"a\", \"program\"])",
     "stop_tokens": [
@@ -4036,21 +160,9 @@
     "language": "swift",
     "prompt": "\n/// Write a swiftthon function to find the element that appears only once in a sorted array.\nfunc search(arr: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(search(arr: [1, 1, 2, 2, 3]) == 3)\nassert(search(arr: [1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]) == 8)\nassert(search(arr: [1, 2, 2, 3, 3, 4, 4]) == 1)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1: [String : Int]) -> [(String, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_counter(dict1: [\"Math\" : 81, \"Physics\" : 83, \"Chemistry\" : 87]) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\nassert(sort_counter(dict1: [\"Math\" : 400, \"Physics\" : 300, \"Chemistry\" : 250]) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\nassert(sort_counter(dict1: [\"Math\" : 900, \"Physics\" : 1000, \"Chemistry\" : 1250]) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])",
     "stop_tokens": [
       "\n}"
     ]
@@ -4060,7 +172,7 @@
     "language": "swift",
     "prompt": "\n/// Write a swiftthon function to remove first and last occurrence of a given character from the string.\nfunc remove_Occ(s: String, ch: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_Occ(s: \"hello\", ch: \"l\") == \"heo\")\nassert(remove_Occ(s: \"abcda\", ch: \"a\") == \"bcd\")\nassert(remove_Occ(s: \"PHP\", ch: \"P\") == \"H\")",
     "stop_tokens": [
@@ -4068,337 +180,61 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to find the maximum absolute product between numbers in pairs of tuples within a given array.\nfunc max_product_tuple(list1: [(Int, Int)]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cube(l: 5) == 100)\nassert(lateralsurface_cube(l: 9) == 324)\nassert(lateralsurface_cube(l: 10) == 400)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 36)\nassert(max_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 200)\nassert(max_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 484)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "swift",
-    "prompt": "\n/// Write a function that takes two arrays and returns true if they have at least one common element.\nfunc common_element(list1: [AnyHashable], list2: [AnyHashable]) -> Bool? {\n",
+    "prompt": "\n/// Write a function to sum all amicable numbers from 1 to a specified number.\nfunc amicable_numbers_sum(limit: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8, 9]) == true)\nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == nil)\nassert(common_element(list1: [\"a\", \"b\", \"c\"], list2: [\"d\", \"b\", \"e\"]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(amicable_numbers_sum(limit: 999) == 504)\nassert(amicable_numbers_sum(limit: 9999) == 31626)\nassert(amicable_numbers_sum(limit: 99) == 0)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "swift",
-    "prompt": "\n/// Write a function to append the given array to the given tuples.\nfunc add_lists(test_list: [Int], test_tup: (Int, Int)) -> (Int, Int, Int, Int, Int) {\n",
+    "prompt": "\n/// Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunc find_length(string: String) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_lists(test_list: [5, 6, 7], test_tup: (9, 10)) == (9, 10, 5, 6, 7))\nassert(add_lists(test_list: [6, 7, 8], test_tup: (10, 11)) == (10, 11, 6, 7, 8))\nassert(add_lists(test_list: [7, 8, 9], test_tup: (11, 12)) == (11, 12, 7, 8, 9))",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_length(string: \"11000010001\") == 6)\nassert(find_length(string: \"10111\") == 1)\nassert(find_length(string: \"11011101100101\") == 2)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "swift",
-    "prompt": "\n/// Write a function to compute the n-th power of each number in an array.\nfunc nth_nums(nums: [Int], n: Int) -> [Int] {\n",
+    "prompt": "\n/// Write a swiftthon function to find the sum of common divisors of two given numbers.\nfunc sum(a: Int, b: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(nth_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n: 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(nth_nums(nums: [10, 20, 30], n: 3) == [1000, 8000, 27000])\nassert(nth_nums(nums: [12, 15], n: 5) == [248832, 759375])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum(a: 10, b: 15) == 6)\nassert(sum(a: 100, b: 150) == 93)\nassert(sum(a: 4, b: 6) == 3)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "swift",
-    "prompt": "\n/// Write a function to sort an array of elements.\nfunc pancake_sort(nums: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a function to multiply two integers.\nfunc multiply_int(x: Int, y: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pancake_sort(nums: [15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\nassert(pancake_sort(nums: [98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\nassert(pancake_sort(nums: [41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the median of three numbers.\nfunc median_numbers(a: Int, b: Int, c: Int) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_numbers(a: 25, b: 55, c: 65) == 55.0)\nassert(median_numbers(a: 20, b: 10, c: 30) == 20.0)\nassert(median_numbers(a: 15, b: 45, c: 75) == 45.0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr: [Int], number: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_greater(arr: [1, 2, 3, 4, 5], number: 4) == false)\nassert(check_greater(arr: [2, 3, 4, 5, 6], number: 8) == true)\nassert(check_greater(arr: [9, 7, 4, 8, 6, 1], number: 11) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunc check_element(list: [AnyHashable], element: AnyHashable) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_element(list: [\"green\", \"orange\", \"black\", \"white\"], element: \"blue\") == false)\nassert(check_element(list: [1, 2, 3, 4], element: 7) == false)\nassert(check_element(list: [\"green\", \"green\", \"green\", \"green\"], element: \"green\") == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "swift",
-    "prompt": "\n/// Write a function to extract specified size of strings from a given array of string values.\nfunc extract_string(str: [String], l: Int) -> [String] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 8) == [\"practice\", \"solution\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 6) == [\"Python\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 9) == [\"exercises\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "swift",
-    "prompt": "\n/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text: String) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_lowercase_underscore(text: \"aab_cbbbc\") == true)\nassert(text_lowercase_underscore(text: \"aab_Abbbc\") == false)\nassert(text_lowercase_underscore(text: \"Aaab_abbbc\") == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to trim each array by k in the given arrays.\nfunc trim_tuple(test_list: [[Int]], K: Int) -> [[Int]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 2) == [[2], [9], [2], [2]])\nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\nassert(trim_tuple(test_list: [[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], K: 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the subarray having minimum length.\nfunc Find_Min(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min(lst: [[1], [1, 2], [1, 2, 3]]) == [1])\nassert(Find_Min(lst: [[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\nassert(Find_Min(lst: [[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "swift",
-    "prompt": "\n/// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_oddnumbers(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\nassert(filter_oddnumbers(nums: [10, 20, 45, 67, 84, 93]) == [45, 67, 93])\nassert(filter_oddnumbers(nums: [5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverbs(text: \"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\nassert(find_adverbs(text: \"Please handle the situation carefuly\") == \"28-36: carefuly\")\nassert(find_adverbs(text: \"Complete the task quickly\") == \"18-25: quickly\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "swift",
-    "prompt": "\n/// Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunc max_of_nth(test_list: [[Int]], N: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_of_nth(test_list: [[5, 6, 7], [1, 3, 5], [8, 9, 19]], N: 2) == 19)\nassert(max_of_nth(test_list: [[6, 7, 8], [2, 4, 6], [9, 10, 20]], N: 1) == 10)\nassert(max_of_nth(test_list: [[7, 8, 9], [3, 5, 7], [10, 11, 21]], N: 1) == 11)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "swift",
-    "prompt": "\n/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n: Int) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(n: 8) == \"1000\")\nassert(decimal_to_binary(n: 18) == \"10010\")\nassert(decimal_to_binary(n: 7) == \"111\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunc combinations_colors(l: [String], n: Int) -> [[String]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "swift",
-    "prompt": "\n/// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text: String) -> String {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_all_spaces(text: \"python  program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"python   programming    language\") == \"pythonprogramminglanguage\")\nassert(remove_all_spaces(text: \"python                     program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"   python                     program\") == \"pythonprogram\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1: String, str2: String) -> AnyHashable {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Swaps(str1: \"1101\", str2: \"1110\") == 1)\nassert(min_Swaps(str1: \"111\", str2: \"000\") == \"Not Possible\")\nassert(min_Swaps(str1: \"111\", str2: \"110\") == \"Not Possible\")",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to create a new tuple from the given string and array.\nfunc new_tuple(test_list: [String], test_str: String) -> (String, String, String) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(new_tuple(test_list: [\"WEB\", \"is\"], test_str: \"best\") == (\"WEB\", \"is\", \"best\"))\nassert(new_tuple(test_list: [\"We\", \"are\"], test_str: \"Developers\") == (\"We\", \"are\", \"Developers\"))\nassert(new_tuple(test_list: [\"Part\", \"is\"], test_str: \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr: [Int], n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_remainder(arr: [100, 10, 5, 25, 35, 14], n: 11) == 9)\nassert(find_remainder(arr: [1, 1, 1], n: 1) == 0)\nassert(find_remainder(arr: [1, 2, 1], n: 2) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "swift",
-    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the minimum value in a given heterogeneous array.\nfunc min_val(listval: [Result<String, Int>]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 2)\nassert(min_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 15)\nassert(min_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 20)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums: [Int]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(positive_count(nums: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\nassert(positive_count(nums: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\nassert(positive_count(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "swift",
-    "prompt": "\n/// Write a function to add the given tuple to the given array.\nfunc add_tuple(test_list: [Int], test_tup: (Int, Int)) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_tuple(test_list: [5, 6, 7], test_tup: (9, 10)) == [5, 6, 7, 9, 10])\nassert(add_tuple(test_list: [6, 7, 8], test_tup: (10, 11)) == [6, 7, 8, 10, 11])\nassert(add_tuple(test_list: [7, 8, 9], test_tup: (11, 12)) == [7, 8, 9, 11, 12])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_run_uppercase(test_str: \"GeMKSForGERksISBESt\") == 5)\nassert(max_run_uppercase(test_str: \"PrECIOusMOVemENTSYT\") == 6)\nassert(max_run_uppercase(test_str: \"GooGLEFluTTER\") == 4)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "swift",
-    "prompt": "\n/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M: [[Int]]) -> [[Int]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_matrix(M: [[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\nassert(sort_matrix(M: [[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\nassert(sort_matrix(M: [[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "swift",
-    "prompt": "\n/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_vowels(test_str: \"bestinstareels\") == 7)\nassert(count_vowels(test_str: \"partofthejourneyistheend\") == 12)\nassert(count_vowels(test_str: \"amazonprime\") == 5)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a: [Int], n: Int, index: Int, k: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 4, k: 6) == 11)\nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 2, k: 5) == 7)\nassert(max_sum_increasing_subseq(a: [11, 15, 19, 21, 26, 28, 31], n: 7, index: 2, k: 4) == 71)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_int(x: 10, y: 20) == 200)\nassert(multiply_int(x: 5, y: 10) == 50)\nassert(multiply_int(x: 4, y: 8) == 32)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4408,7 +244,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find words that are longer than n characters from a given array of words.\nfunc long_words(n: Int, str: String) -> [String] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(long_words(n: 3, str: \"python is a programming language\") == [\"python\", \"programming\", \"language\"])\nassert(long_words(n: 2, str: \"writing a program\") == [\"writing\", \"program\"])\nassert(long_words(n: 5, str: \"sorting list\") == [\"sorting\"])",
     "stop_tokens": [
@@ -4416,205 +252,37 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of non-repeated elements in a given array.\nfunc find_sum(arr: [Int]) -> Int {\n",
+    "prompt": "\n/// Write a function to calculate whether the matrix is a magic square.\nfunc magic_square_test(my_matrix: [[Int]]) -> Bool {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_sum(arr: [1, 2, 3, 1, 1, 4, 5, 6]) == 21)\nassert(find_sum(arr: [1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\nassert(find_sum(arr: [12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(magic_square_test(my_matrix: [[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 8]]) == true)\nassert(magic_square_test(my_matrix: [[2, 7, 6], [9, 5, 1], [4, 3, 7]]) == false)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "swift",
-    "prompt": "\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/swiftthon-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup: (Int, Int, Int, Int, Int, Int)) -> [Int : Int] {\n",
+    "prompt": "\n/// Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunc sort_matrix(M: [[Int]]) -> [[Int]] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_dict(test_tup: (1, 5, 7, 10, 13, 5)) == [1 : 5, 7 : 10, 13 : 5])\nassert(tuple_to_dict(test_tup: (1, 2, 3, 4, 5, 6)) == [1 : 2, 3 : 4, 5 : 6])\nassert(tuple_to_dict(test_tup: (7, 8, 9, 10, 11, 12)) == [7 : 8, 9 : 10, 11 : 12])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_matrix(M: [[1, 2, 3], [2, 4, 5], [1, 1, 1]]) == [[1, 1, 1], [1, 2, 3], [2, 4, 5]])\nassert(sort_matrix(M: [[1, 2, 3], [-2, 4, -5], [1, -1, 1]]) == [[-2, 4, -5], [1, -1, 1], [1, 2, 3]])\nassert(sort_matrix(M: [[5, 8, 9], [6, 4, 3], [2, 1, 4]]) == [[2, 1, 4], [6, 4, 3], [5, 8, 9]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "swift",
-    "prompt": "\n/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup: (Int, Int)) -> [[Int]] {\n",
+    "prompt": "\n/// Write a function to find the item with maximum frequency in a given array.\nfunc max_occurrences(nums: [Int]) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_coordinates(test_tup: (3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\nassert(get_coordinates(test_tup: (4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\nassert(get_coordinates(test_tup: (5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple: AnyHashable) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_type(test_tuple: (5, 6, 7, 3, 5, 6)) == true)\nassert(check_type(test_tuple: (1, 2, \"4\")) == false)\nassert(check_type(test_tuple: (3, 2, 1, 4, 5)) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the smallest missing number from a sorted array of natural numbers.\nfunc find_First_Missing(array: [Int]) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_First_Missing(array: [0, 1, 2, 3]) == 4)\nassert(find_First_Missing(array: [0, 1, 2, 6, 9]) == 3)\nassert(find_First_Missing(array: [2, 3, 5, 8, 9]) == 0)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n: Int) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_undulating(n: 1212121) == true)\nassert(is_undulating(n: 1991) == false)\nassert(is_undulating(n: 121) == true)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find minimum k records from tuple array. https://www.geeksforgeeks.org/swiftthon-find-minimum-k-records-from-tuple-array/ - in this case a verbatim coswift of test cases\nfunc min_k(test_list: [(String, Int)], K: Int) -> [(String, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_k(test_list: [(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], K: 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\nassert(min_k(test_list: [(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], K: 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\nassert(min_k(test_list: [(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], K: 1) == [(\"Ayesha\", 9)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s: String) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Substrings(s: \"112112\") == 6)\nassert(count_Substrings(s: \"111\") == 6)\nassert(count_Substrings(s: \"1101112\") == 12)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_num_decagonal(n: 3) == 27)\nassert(is_num_decagonal(n: 7) == 175)\nassert(is_num_decagonal(n: 10) == 370)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array of tuples and returns an array containing the rear element of each tuple.\nfunc rear_extract(test_list: [(Int, String, Int)]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rear_extract(test_list: [(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\nassert(rear_extract(test_list: [(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\nassert(rear_extract(test_list: [(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the closest smaller number than n.\nfunc closest_num(N: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_num(N: 11) == 10)\nassert(closest_num(N: 7) == 6)\nassert(closest_num(N: 12) == 11)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "swift",
-    "prompt": "\n/// Write a function to find the combinations of sums with tuples in the given tuple array. https://www.geeksforgeeks.org/swiftthon-combinations-of-sum-with-tuples-in-tuple-array/\nfunc find_combinations(test_list: [(Int, Int)]) -> [(Int, Int)] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_combinations(test_list: [(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\nassert(find_combinations(test_list: [(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\nassert(find_combinations(test_list: [(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "swift",
-    "prompt": "\n/// Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost: [[Int]]) -> Double {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maxAverageOfPath(cost: [[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\nassert(maxAverageOfPath(cost: [[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\nassert(maxAverageOfPath(cost: [[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\nassert(maxAverageOfPath(cost: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "swift",
-    "prompt": "\n/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist: [Int], item: Int) -> (Bool, Int) {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequential_search(dlist: [11, 23, 58, 31, 56, 77, 43, 12, 65, 19], item: 31) == (true, 3))\nassert(sequential_search(dlist: [12, 32, 45, 62, 35, 47, 44, 61], item: 61) == (true, 7))\nassert(sequential_search(dlist: [9, 10, 17, 19, 22, 39, 48, 56], item: 48) == (true, 6))",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to remove odd numbers from a given array.\nfunc remove_odd(l: [Int]) -> [Int] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(l: [1, 2, 3]) == [2])\nassert(remove_odd(l: [2, 4, 6]) == [2, 4, 6])\nassert(remove_odd(l: [10, 20, 3]) == [10, 20])",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "swift",
-    "prompt": "\n/// Write a function to check whether the product of numbers in an array is even or not.\nfunc is_product_even(arr: [Int]) -> Bool {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_product_even(arr: [1, 2, 3]) == true)\nassert(is_product_even(arr: [1, 2, 1, 4]) == true)\nassert(is_product_even(arr: [1, 1]) == false)",
-    "stop_tokens": [
-      "\n}"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the maximum of two numbers.\nfunc maximum(a: Int, b: Int) -> Int {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(a: 5, b: 10) == 10)\nassert(maximum(a: -1, b: -2) == -1)\nassert(maximum(a: 9, b: 7) == 9)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]) == 2)\nassert(max_occurrences(nums: [2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]) == 8)\nassert(max_occurrences(nums: [10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]) == 20)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4624,9 +292,609 @@
     "language": "swift",
     "prompt": "\n/// Write a swiftthon function to reverse only the vowels of a given string (where y is not a vowel).\nfunc reverse_vowels(str1: String) -> String {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_vowels(str1: \"Python\") == \"Python\")\nassert(reverse_vowels(str1: \"USA\") == \"ASU\")\nassert(reverse_vowels(str1: \"ab\") == \"ab\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert an array to a string.\nfunc tup_string(tup1: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tup_string(tup1: [\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]) == \"exercises\")\nassert(tup_string(tup1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]) == \"python\")\nassert(tup_string(tup1: [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]) == \"program\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunc sum_negativenum(nums: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_negativenum(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == -32)\nassert(sum_negativenum(nums: [10, 15, -14, 13, -18, 12, -20]) == -52)\nassert(sum_negativenum(nums: [19, -65, 57, 39, 152, -639, 121, 44, 90, -190]) == -894)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth hexagonal number.\nfunc hexagonal_num(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(hexagonal_num(n: 10) == 190)\nassert(hexagonal_num(n: 5) == 45)\nassert(hexagonal_num(n: 7) == 91)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunc is_Sum_Of_Powers_Of_Two(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sum_Of_Powers_Of_Two(n: 10) == true)\nassert(is_Sum_Of_Powers_Of_Two(n: 7) == false)\nassert(is_Sum_Of_Powers_Of_Two(n: 14) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort an array of elements.\nfunc pancake_sort(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pancake_sort(nums: [15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79])\nassert(pancake_sort(nums: [98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98])\nassert(pancake_sort(nums: [41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count number items that are identical in the same position of three given arrays.\nfunc count_samepair(list1: [Int], list2: [Int], list3: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 9], list3: [2, 1, 3, 1, 2, 6, 7, 9]) == 3)\nassert(count_samepair(list1: [1, 2, 3, 4, 5, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 4)\nassert(count_samepair(list1: [1, 2, 3, 4, 2, 6, 7, 8], list2: [2, 2, 3, 1, 2, 6, 7, 8], list3: [2, 1, 3, 1, 2, 6, 7, 8]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find number of arrays present in the given array.\nfunc find_lists(Input: [AnyHashable]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lists(Input: [[1, 2, 3, 4], [5, 6, 7, 8]]) == 2)\nassert(find_lists(Input: [[1, 2], [3, 4], [5, 6]]) == 3)\nassert(find_lists(Input: [9, 8, 7, 6, 5, 4, 3, 2, 1]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the maximum difference between any two elements in a given array.\nfunc max_Abs_Diff(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Abs_Diff(arr: [2, 1, 5, 3]) == 4)\nassert(max_Abs_Diff(arr: [9, 3, 2, 5, 1]) == 8)\nassert(max_Abs_Diff(arr: [3, 2, 1]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the volume of a triangular prism.\nfunc find_Volume(l: Int, b: Int, h: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Volume(l: 10, b: 8, h: 6) == 240)\nassert(find_Volume(l: 3, b: 2, h: 2) == 6)\nassert(find_Volume(l: 1, b: 2, h: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return nil if no solution exists.\nfunc find_solution(a: Int, b: Int, n: Int) -> (Int, Int)? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_solution(a: 2, b: 3, n: 7) == (2, 1))\nassert(find_solution(a: 4, b: 2, n: 7) == nil)\nassert(find_solution(a: 1, b: 13, n: 17) == (4, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all elements from a given array present in another array.\nfunc remove_elements(list1: [Int], list2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [1, 3, 5, 7]) == [2, 4, 6, 8, 9, 10])\nassert(remove_elements(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], list2: [5, 7]) == [1, 2, 3, 4, 6, 8, 9, 10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunc sum_series(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_series(n: 6) == 12)\nassert(sum_series(n: 10) == 30)\nassert(sum_series(n: 9) == 25)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "swift",
+    "prompt": "\n/// Write a function to determine if the sum of the divisors of two integers are the same.\nfunc are_equivalent(num1: Int, num2: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(are_equivalent(num1: 36, num2: 57) == false)\nassert(are_equivalent(num1: 2, num2: 4) == false)\nassert(are_equivalent(num1: 23, num2: 47) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunc count_char_position(str1: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_char_position(str1: \"xbcefg\") == 2)\nassert(count_char_position(str1: \"ABcED\") == 3)\nassert(count_char_position(str1: \"AbgdeF\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "swift",
+    "prompt": "\n/// Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunc find_even_pair(A: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_even_pair(A: [5, 4, 7, 2, 1]) == 4)\nassert(find_even_pair(A: [7, 2, 8, 1, 0, 5, 11]) == 9)\nassert(find_even_pair(A: [1, 2, 3]) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the smallest power of 2 greater than or equal to n.\nfunc next_power_of_2(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_power_of_2(n: 0) == 1)\nassert(next_power_of_2(n: 5) == 8)\nassert(next_power_of_2(n: 17) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of occurrences of a number in a given array.\nfunc frequency(a: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency(a: [1, 2, 3], x: 4) == 0)\nassert(frequency(a: [1, 2, 2, 3, 3, 3, 4], x: 3) == 3)\nassert(frequency(a: [0, 1, 2, 3, 1, 2], x: 1) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "swift",
+    "prompt": "\n/// Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunc text_lowercase_underscore(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_lowercase_underscore(text: \"aab_cbbbc\") == true)\nassert(text_lowercase_underscore(text: \"aab_Abbbc\") == false)\nassert(text_lowercase_underscore(text: \"Aaab_abbbc\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunc sum_range_list(list1: [Int], m: Int, n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 8, n: 10) == 29)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 5, n: 7) == 16)\nassert(sum_range_list(list1: [2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], m: 7, n: 10) == 38)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunc perimeter_pentagon(a: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perimeter_pentagon(a: 5) == 25)\nassert(perimeter_pentagon(a: 10) == 50)\nassert(perimeter_pentagon(a: 15) == 75)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of occurence of the string 'std' in a given string.\nfunc count_occurance(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_occurance(s: \"letstdlenstdporstd\") == 3)\nassert(count_occurance(s: \"truststdsolensporsd\") == 1)\nassert(count_occurance(s: \"makestdsostdworthit\") == 2)\nassert(count_occurance(s: \"stds\") == 1)\nassert(count_occurance(s: \"\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns the perimeter of a square given its side length as input.\nfunc square_perimeter(a: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_perimeter(a: 10) == 40)\nassert(square_perimeter(a: 5) == 20)\nassert(square_perimeter(a: 4) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove characters from the first string which are present in the second string.\nfunc remove_dirty_chars(string: String, second_string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_dirty_chars(string: \"probasscurve\", second_string: \"pros\") == \"bacuve\")\nassert(remove_dirty_chars(string: \"digitalindia\", second_string: \"talent\") == \"digiidi\")\nassert(remove_dirty_chars(string: \"exoticmiles\", second_string: \"toxic\") == \"emles\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find whether a given array of integers contains any duplicate element.\nfunc test_duplicate(arraynums: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_duplicate(arraynums: [1, 2, 3, 4, 5]) == false)\nassert(test_duplicate(arraynums: [1, 2, 3, 4, 4]) == true)\nassert(test_duplicate(arraynums: [1, 1, 2, 2, 3, 3, 4, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given number is woodball or not.\nfunc is_woodall(x: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_woodall(x: 383) == true)\nassert(is_woodall(x: 254) == false)\nassert(is_woodall(x: 200) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if all the elements in tuple have same data type or not.\nfunc check_type(test_tuple: AnyHashable) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_type(test_tuple: (5, 6, 7, 3, 5, 6)) == true)\nassert(check_type(test_tuple: (1, 2, \"4\")) == false)\nassert(check_type(test_tuple: (3, 2, 1, 4, 5)) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunc is_majority(arr: [Int], n: Int, x: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_majority(arr: [1, 2, 3, 3, 3, 3, 10], n: 7, x: 3) == true)\nassert(is_majority(arr: [1, 1, 2, 4, 4, 4, 6, 6], n: 8, x: 4) == false)\nassert(is_majority(arr: [1, 1, 1, 2, 2], n: 5, x: 1) == true)\nassert(is_majority(arr: [1, 1, 2, 2], n: 5, x: 1) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunc count_Set_Bits(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Set_Bits(n: 2) == 1)\nassert(count_Set_Bits(n: 4) == 1)\nassert(count_Set_Bits(n: 6) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to remove the characters which have odd index values of a given string.\nfunc odd_values_string(str: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_values_string(str: \"abcdef\") == \"ace\")\nassert(odd_values_string(str: \"python\") == \"pto\")\nassert(odd_values_string(str: \"data\") == \"dt\")\nassert(odd_values_string(str: \"lambs\") == \"lms\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find minimum of three numbers.\nfunc min_of_three(a: Int, b: Int, c: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_of_three(a: 10, b: 20, c: 0) == 0)\nassert(min_of_three(a: 19, b: 15, c: 18) == 15)\nassert(min_of_three(a: -10, b: -20, c: -30) == -30)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether all the bits are unset in the given range or not.\nfunc all_Bits_Set_In_The_Given_Range(n: Int, l: Int, r: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Bits_Set_In_The_Given_Range(n: 4, l: 1, r: 2) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 17, l: 2, r: 4) == true)\nassert(all_Bits_Set_In_The_Given_Range(n: 39, l: 4, r: 6) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunc re_arrange_array(arr: [Int], n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(re_arrange_array(arr: [-1, 2, -3, 4, 5, 6, -7, 8, 9], n: 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9])\nassert(re_arrange_array(arr: [12, -14, -26, 13, 15], n: 5) == [-14, -26, 12, 13, 15])\nassert(re_arrange_array(arr: [10, 24, 36, -42, -39, -78, 85], n: 7) == [-42, -39, -78, 10, 24, 36, 85])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunc replace_blank(str1: String, char: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_blank(str1: \"hello people\", char: \"@\") == \"hello@people\")\nassert(replace_blank(str1: \"python program language\", char: \"$\") == \"python$program$language\")\nassert(replace_blank(str1: \"blank space\", char: \"-\") == \"blank-space\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the volume of a cube given its side length.\nfunc volume_cube(l: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(volume_cube(l: 3) == 27)\nassert(volume_cube(l: 2) == 8)\nassert(volume_cube(l: 5) == 125)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_237_check_occurences",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array of tuples and returns a dictionary mapping each unique tuple to the number of times it occurs in the array.\nfunc check_occurences(test_list: [(Int, Int)]) -> [(Int, Int) : Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_237_check_occurences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_occurences(test_list: [(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)]) == [(1, 3) : 2, (2, 5) : 2, (3, 6) : 1])\nassert(check_occurences(test_list: [(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)]) == [(2, 4) : 2, (3, 6) : 2, (4, 7) : 1])\nassert(check_occurences(test_list: [(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)]) == [(2, 13) : 1, (11, 23) : 1, (12, 25) : 2, (16, 23) : 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of non-empty substrings of a given string.\nfunc number_of_substrings(str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_of_substrings(str: \"abc\") == 6)\nassert(number_of_substrings(str: \"abcd\") == 10)\nassert(number_of_substrings(str: \"abcde\") == 15)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunc get_total_number_of_sequences(m: Int, n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_total_number_of_sequences(m: 10, n: 4) == 4)\nassert(get_total_number_of_sequences(m: 5, n: 2) == 6)\nassert(get_total_number_of_sequences(m: 16, n: 3) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunc replace_list(list1: [AnyHashable], list2: [AnyHashable]) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_list(list1: [1, 3, 5, 7, 9, 10], list2: [2, 4, 6, 8]) == [1, 3, 5, 7, 9, 2, 4, 6, 8])\nassert(replace_list(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8]) == [1, 2, 3, 4, 5, 6, 7, 8])\nassert(replace_list(list1: [\"red\", \"blue\", \"green\"], list2: [\"yellow\"]) == [\"red\", \"blue\", \"yellow\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the total number of characters in a string.\nfunc count_charac(str1: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_charac(str1: \"python programming\") == 18)\nassert(count_charac(str1: \"language\") == 8)\nassert(count_charac(str1: \"words\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the next perfect square greater than a given number.\nfunc next_Perfect_Square(N: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(next_Perfect_Square(N: 35) == 36)\nassert(next_Perfect_Square(N: 6) == 9)\nassert(next_Perfect_Square(N: 9) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunc max_sum(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum(arr: [1, 15, 51, 45, 33, 100, 12, 18, 9]) == 194)\nassert(max_sum(arr: [80, 60, 30, 40, 20, 10]) == 210)\nassert(max_sum(arr: [2, 3, 14, 16, 21, 23, 29, 30]) == 138)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the length of the longest palindromic subsequence in the given string.\nfunc lps(str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lps(str: \"TENS FOR TENS\") == 5)\nassert(lps(str: \"CARDIO FOR CARDS\") == 7)\nassert(lps(str: \"PART OF THE JOURNEY IS PART\") == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the intersection of two arrays.\nfunc intersection_array(array_nums1: [Int], array_nums2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [1, 2, 4, 8, 9]) == [1, 2, 8, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [3, 5, 7, 9]) == [3, 5, 7, 9])\nassert(intersection_array(array_nums1: [1, 2, 3, 5, 7, 8, 9, 10], array_nums2: [10, 20, 30, 40]) == [10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function that takes in a tuple and an element and counts the occcurences of the element in the array.\nfunc count_X(tup: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 4) == 0)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 10) == 3)\nassert(count_X(tup: [10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], x: 8) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunc insert_element(list: [String], element: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(insert_element(list: [\"Red\", \"Green\", \"Black\"], element: \"c\") == [\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"])\nassert(insert_element(list: [\"python\", \"java\"], element: \"program\") == [\"program\", \"python\", \"program\", \"java\"])\nassert(insert_element(list: [\"happy\", \"sad\"], element: \"laugh\") == [\"laugh\", \"happy\", \"laugh\", \"sad\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to convert complex numbers to polar coordinates.\nfunc convert(numbers: Int) -> (Double, Double) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert(numbers: 1) == (1.0, 0.0))\nassert(convert(numbers: 4) == (4.0, 0.0))\nassert(convert(numbers: 5) == (5.0, 0.0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "swift",
+    "prompt": "\nenum Value: Equatable, Hashable {\n    case intValue(Int)\n    case stringValue(String)\n    case doubleValue(Double)\n}\n\n            \n/// Write a swiftthon function that returns the number of integer elements in a given array.\nfunc count_integer(list1: [Value]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_integer(list1: [.intValue(1), .intValue(2), .stringValue(\"abc\"), .doubleValue(1.2)]) == 2)\nassert(count_integer(list1: [.intValue(1), .intValue(2), .intValue(3)]) == 3)\nassert(count_integer(list1: [.intValue(1), .doubleValue(1.2), .intValue(4), .doubleValue(5.1)]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunc combinations_colors(l: [String], n: Int) -> [[String]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 1) == [[\"Red\"], [\"Green\"], [\"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 2) == [[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]])\nassert(combinations_colors(l: [\"Red\", \"Green\", \"Blue\"], n: 3) == [[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunc count_Primes_nums(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Primes_nums(n: 5) == 2)\nassert(count_Primes_nums(n: 10) == 4)\nassert(count_Primes_nums(n: 100) == 25)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunc swap_numbers(a: Int, b: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_numbers(a: 10, b: 20) == [20, 10])\nassert(swap_numbers(a: 15, b: 17) == [17, 15])\nassert(swap_numbers(a: 100, b: 200) == [200, 100])",
     "stop_tokens": [
       "\n}"
     ]
@@ -4636,7 +904,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to maximize the given two arrays.\nfunc maximize_elements(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximize_elements(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 7], [4, 9], [2, 9], [7, 10]])\nassert(maximize_elements(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[7, 8], [5, 10], [3, 10], [8, 11]])\nassert(maximize_elements(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[8, 9], [6, 11], [4, 11], [9, 12]])",
     "stop_tokens": [
@@ -4644,73 +912,73 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to check whether every even index contains even numbers of a given array.\nfunc even_position(nums: [Int]) -> Bool {\n",
+    "prompt": "\n/// Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunc newman_prime(n: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_position(nums: [3, 2, 1]) == false)\nassert(even_position(nums: [1, 2, 3]) == false)\nassert(even_position(nums: [2, 1, 4]) == true)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(newman_prime(n: 3) == 7)\nassert(newman_prime(n: 4) == 17)\nassert(newman_prime(n: 5) == 41)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "swift",
-    "prompt": "\n/// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(string: String) -> String {\n",
+    "prompt": "\n/// Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunc division_elements(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_char(string: \"abba\") == \"Valid\")\nassert(check_char(string: \"a\") == \"Valid\")\nassert(check_char(string: \"abcd\") == \"Invalid\")",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(division_elements(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (2, 2, 2, 3))\nassert(division_elements(test_tup1: (12, 6, 8, 16), test_tup2: (6, 3, 4, 4)) == (2, 2, 2, 4))\nassert(division_elements(test_tup1: (20, 14, 36, 18), test_tup2: (5, 7, 6, 9)) == (4, 2, 6, 2))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function to find the sum of even factors of a number.\nfunc sumofFactors(n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in a tuple.\nfunc split_two_parts(list1: [AnyHashable], L: Int) -> AnyHashable {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sumofFactors(n: 18) == 26)\nassert(sumofFactors(n: 30) == 48)\nassert(sumofFactors(n: 6) == 8)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_two_parts(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == ([1, 1, 2], [3, 4, 4, 5, 1]))\nassert(split_two_parts(list1: [\"a\", \"b\", \"c\", \"d\"], L: 2) == ([\"a\", \"b\"], [\"c\", \"d\"]))\nassert(split_two_parts(list1: [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], L: 4) == ([\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]))",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r: Int, h: Int) -> Double {\n",
+    "prompt": "\n/// Write a function to calculate a dog's age in dog's years.\nfunc dog_age(h_age: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cone(r: 5, h: 12) == 204.20352248333654)\nassert(lateralsurface_cone(r: 10, h: 15) == 566.3586699569488)\nassert(lateralsurface_cone(r: 19, h: 17) == 1521.8090132193388)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dog_age(h_age: 12) == 61)\nassert(dog_age(h_age: 15) == 73)\nassert(dog_age(h_age: 24) == 109)",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "swift",
-    "prompt": "\n/// Write a swiftthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr: [Int], n: Int) -> Int {\n",
+    "prompt": "\n/// Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunc list_split(S: [AnyHashable], step: Int) -> [[AnyHashable]] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Pairs(arr: [1, 2, 1], n: 3) == 2)\nassert(count_Pairs(arr: [1, 1, 1, 1], n: 4) == 0)\nassert(count_Pairs(arr: [1, 2, 3, 4, 5], n: 5) == 10)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_split(S: [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], step: 3) == [[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]])\nassert(list_split(S: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], step: 3) == [[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]])\nassert(list_split(S: [\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], step: 2) == [[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]])",
     "stop_tokens": [
       "\n}"
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "swift",
-    "prompt": "\n/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A: [Int], x: Int) -> Int {\n",
+    "prompt": "\n/// Write a function to find the lateral surface area of a cube given its side length.\nfunc lateralsurface_cube(l: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_first_occurrence(A: [2, 5, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 1)\nassert(find_first_occurrence(A: [2, 3, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 2)\nassert(find_first_occurrence(A: [2, 4, 1, 5, 6, 6, 8, 9, 9, 9], x: 6) == 4)",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cube(l: 5) == 100)\nassert(lateralsurface_cube(l: 9) == 324)\nassert(lateralsurface_cube(l: 10) == 400)",
     "stop_tokens": [
       "\n}"
     ]
@@ -4720,9 +988,729 @@
     "language": "swift",
     "prompt": "\n/// Write a swiftthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 10)\nassert(square_Sum(n: 3) == 35)\nassert(square_Sum(n: 4) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n'th star number.\nfunc find_star_num(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_star_num(n: 3) == 37)\nassert(find_star_num(n: 4) == 73)\nassert(find_star_num(n: 5) == 121)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the ascii value of a character.\nfunc ascii_value(k: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(ascii_value(k: \"A\") == 65)\nassert(ascii_value(k: \"R\") == 82)\nassert(ascii_value(k: \"S\") == 83)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of even numbers at even positions of an array.\nfunc sum_even_and_even_index(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_even_and_even_index(arr: [5, 6, 12, 1, 18, 8]) == 30)\nassert(sum_even_and_even_index(arr: [3, 20, 17, 9, 2, 10, 18, 13, 6, 18]) == 26)\nassert(sum_even_and_even_index(arr: [5, 6, 12, 1]) == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunc even_Power_Sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_Power_Sum(n: 2) == 1056)\nassert(even_Power_Sum(n: 3) == 8832)\nassert(even_Power_Sum(n: 1) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array of tuples and returns an array containing the rear element of each tuple.\nfunc rear_extract(test_list: [(Int, String, Int)]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rear_extract(test_list: [(1, \"Rash\", 21), (2, \"Varsha\", 20), (3, \"Kil\", 19)]) == [21, 20, 19])\nassert(rear_extract(test_list: [(1, \"Sai\", 36), (2, \"Ayesha\", 25), (3, \"Salman\", 45)]) == [36, 25, 45])\nassert(rear_extract(test_list: [(1, \"Sudeep\", 14), (2, \"Vandana\", 36), (3, \"Dawood\", 56)]) == [14, 36, 56])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunc substract_elements(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> (Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(substract_elements(test_tup1: (10, 4, 5), test_tup2: (2, 5, 18)) == (8, -1, -13))\nassert(substract_elements(test_tup1: (11, 2, 3), test_tup2: (24, 45, 16)) == (-13, -43, -13))\nassert(substract_elements(test_tup1: (7, 18, 9), test_tup2: (10, 11, 12)) == (-3, 7, -3))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunc even_binomial_Coeff_Sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_binomial_Coeff_Sum(n: 4) == 8)\nassert(even_binomial_Coeff_Sum(n: 6) == 32)\nassert(even_binomial_Coeff_Sum(n: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunc dict_filter(dict: [String : Int], n: Int) -> [String : Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 170) == [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 180) == [\"Alden Cantrell\" : 180, \"Pierre Cox\" : 190])\nassert(dict_filter(dict: [\"Cierra Vega\" : 175, \"Alden Cantrell\" : 180, \"Kierra Gentry\" : 165, \"Pierre Cox\" : 190], n: 190) == [\"Pierre Cox\" : 190])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "swift",
+    "prompt": "\nextension (Int, Int): Error {}\n        \n/// Write a function to find the number of elements that occurs before the array element in the given tuple.\nfunc count_first_elements(test_tup: [Result<Int, (Int, Int)>]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_first_elements(test_tup: [.success(1), .success(5), .success(7), .failure((4, 6)), .success(10)]) == 3)\nassert(count_first_elements(test_tup: [.success(2), .success(9), .failure((5, 7)), .success(11)]) == 2)\nassert(count_first_elements(test_tup: [.success(11), .success(15), .success(5), .success(8), .failure((2, 3)), .success(8)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth decagonal number.\nfunc is_num_decagonal(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_num_decagonal(n: 3) == 27)\nassert(is_num_decagonal(n: 7) == 175)\nassert(is_num_decagonal(n: 10) == 370)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunc sequential_search(dlist: [Int], item: Int) -> (Bool, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequential_search(dlist: [11, 23, 58, 31, 56, 77, 43, 12, 65, 19], item: 31) == (true, 3))\nassert(sequential_search(dlist: [12, 32, 45, 62, 35, 47, 44, 61], item: 61) == (true, 7))\nassert(sequential_search(dlist: [9, 10, 17, 19, 22, 39, 48, 56], item: 48) == (true, 6))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check if the elements of a given array are unique or not.\nfunc all_unique(test_list: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_unique(test_list: [1, 2, 3]) == true)\nassert(all_unique(test_list: [1, 2, 1, 2]) == false)\nassert(all_unique(test_list: [1, 2, 3, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to subtract two arrays element-wise.\nfunc sub_list(nums1: [Int], nums2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sub_list(nums1: [1, 2, 3], nums2: [4, 5, 6]) == [-3, -3, -3])\nassert(sub_list(nums1: [1, 2], nums2: [3, 4]) == [-2, -2])\nassert(sub_list(nums1: [90, 120], nums2: [50, 70]) == [40, 50])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunc validate(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(validate(n: 1234) == true)\nassert(validate(n: 51241) == false)\nassert(validate(n: 321) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunc check_element(list: [AnyHashable], element: AnyHashable) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_element(list: [\"green\", \"orange\", \"black\", \"white\"], element: \"blue\") == false)\nassert(check_element(list: [1, 2, 3, 4], element: 7) == false)\nassert(check_element(list: [\"green\", \"green\", \"green\", \"green\"], element: \"green\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunc text_match_two_three(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_two_three(text: \"ac\") == false)\nassert(text_match_two_three(text: \"dc\") == false)\nassert(text_match_two_three(text: \"abbbba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunc max_sub_array_sum_repeated(a: [Int], n: Int, k: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum_repeated(a: [10, 20, -30, -1], n: 4, k: 3) == 30)\nassert(max_sub_array_sum_repeated(a: [-1, 10, 20], n: 3, k: 2) == 59)\nassert(max_sub_array_sum_repeated(a: [-1, -2, -3], n: 3, k: 3) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunc square_Sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_Sum(n: 2) == 20)\nassert(square_Sum(n: 3) == 56)\nassert(square_Sum(n: 4) == 120)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the array of maximum length in an array of arrays.\nfunc max_length(list1: [[Int]]) -> (Int, [Int]) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length(list1: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length(list1: [[1], [5, 7], [10, 12, 14, 15]]) == (4, [10, 12, 14, 15]))\nassert(max_length(list1: [[5], [15, 20, 25]]) == (3, [15, 20, 25]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunc count_no_of_ways(n: Int, k: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_no_of_ways(n: 2, k: 4) == 16)\nassert(count_no_of_ways(n: 3, k: 2) == 6)\nassert(count_no_of_ways(n: 4, k: 4) == 228)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunc find(n: Int, m: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find(n: 10, m: 3) == 3)\nassert(find(n: 4, m: 2) == 2)\nassert(find(n: 20, m: 5) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the third side of a right angled triangle.\nfunc otherside_rightangle(w: Int, h: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(otherside_rightangle(w: 7, h: 8) == 10.63014581273465)\nassert(otherside_rightangle(w: 3, h: 4) == 5)\nassert(otherside_rightangle(w: 7, h: 15) == 16.55294535724685)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the maximum value in a given heterogeneous array.\nfunc max_val(listval: [Result<String, Int>]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 5)\nassert(max_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 25)\nassert(max_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 50)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return the sum of all divisors of a number.\nfunc sum_div(number: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_div(number: 8) == 7)\nassert(sum_div(number: 12) == 16)\nassert(sum_div(number: 7) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count inversions in an array.\nfunc get_Inv_Count(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Inv_Count(arr: [1, 20, 6, 4, 5]) == 5)\nassert(get_Inv_Count(arr: [1, 2, 1]) == 1)\nassert(get_Inv_Count(arr: [1, 2, 5, 6, 1]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "swift",
+    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten a given nested array structure.\nfunc flatten_list(list1: [Result<Int, [Int]>]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(flatten_list(list1: [.success(0), .success(10), .failure([20, 30]), .success(40), .success(50), .failure([60, 70, 80]), .failure([90, 100, 110, 120])]) == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120])\nassert(flatten_list(list1: [.failure([10, 20]), .failure([40]), .failure([30, 56, 25]), .failure([10, 20]), .failure([33]), .failure([40])]) == [10, 20, 40, 30, 56, 25, 10, 20, 33, 40])\nassert(flatten_list(list1: [.failure([1, 2, 3]), .failure([4, 5, 6]), .failure([10, 11, 12]), .failure([7, 8, 9])]) == [1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the maximum aggregate from the array of tuples.\nfunc max_aggregate(stdata: [(String, Int)]) -> (String, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_aggregate(stdata: [(\"Juan Whelan\", 90), (\"Sabah Colley\", 88), (\"Peter Nichols\", 7), (\"Juan Whelan\", 122), (\"Sabah Colley\", 84)]) == (\"Juan Whelan\", 212))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 50), (\"Sabah Colley\", 48), (\"Peter Nichols\", 37), (\"Juan Whelan\", 22), (\"Sabah Colley\", 14)]) == (\"Juan Whelan\", 72))\nassert(max_aggregate(stdata: [(\"Juan Whelan\", 10), (\"Sabah Colley\", 20), (\"Peter Nichols\", 30), (\"Juan Whelan\", 40), (\"Sabah Colley\", 50)]) == (\"Sabah Colley\", 70))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find element at a given index after number of rotations.\nfunc find_Element(arr: [Int], ranges: [[Int]], rotations: Int, index: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Element(arr: [1, 2, 3, 4, 5], ranges: [[0, 2], [0, 3]], rotations: 2, index: 1) == 3)\nassert(find_Element(arr: [1, 2, 3, 4], ranges: [[0, 1], [0, 2]], rotations: 1, index: 2) == 3)\nassert(find_Element(arr: [1, 2, 3, 4, 5, 6], ranges: [[0, 1], [0, 2]], rotations: 1, index: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return two words from an array of words starting with letter 'p'.\nfunc start_withp(words: [String]) -> (String, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(start_withp(words: [\"Python PHP\", \"Java JavaScript\", \"c c++\"]) == (\"Python\", \"PHP\"))\nassert(start_withp(words: [\"Python Programming\", \"Java Programming\"]) == (\"Python\", \"Programming\"))\nassert(start_withp(words: [\"Pqrst Pqr\", \"qrstuv\"]) == (\"Pqrst\", \"Pqr\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunc max_sum_increasing_subseq(a: [Int], n: Int, index: Int, k: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 4, k: 6) == 11)\nassert(max_sum_increasing_subseq(a: [1, 101, 2, 3, 100, 4, 5], n: 7, index: 2, k: 5) == 7)\nassert(max_sum_increasing_subseq(a: [11, 15, 19, 21, 26, 28, 31], n: 7, index: 2, k: 4) == 71)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunc large_product(nums1: [Int], nums2: [Int], N: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 3) == [60, 54, 50])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 4) == [60, 54, 50, 48])\nassert(large_product(nums1: [1, 2, 3, 4, 5, 6], nums2: [3, 6, 8, 9, 10, 6], N: 5) == [60, 54, 50, 48, 45])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the maximum of two numbers.\nfunc maximum(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maximum(a: 5, b: 10) == 10)\nassert(maximum(a: -1, b: -2) == -1)\nassert(maximum(a: 9, b: 7) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a given string to an array of characters.\nfunc string_to_tuple(str1: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(string_to_tuple(str1: \"python 3.0\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"])\nassert(string_to_tuple(str1: \"item1\") == [\"i\", \"t\", \"e\", \"m\", \"1\"])\nassert(string_to_tuple(str1: \"15.10\") == [\"1\", \"5\", \".\", \"1\", \"0\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the highest power of 2 that is less than or equal to n.\nfunc highest_Power_of_2(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(highest_Power_of_2(n: 10) == 8)\nassert(highest_Power_of_2(n: 19) == 16)\nassert(highest_Power_of_2(n: 32) == 32)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n'th lucas number.\nfunc find_lucas(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_lucas(n: 9) == 76)\nassert(find_lucas(n: 4) == 7)\nassert(find_lucas(n: 3) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to apply a given format string to all of the elements in an array.\nfunc add_string(list_: [AnyHashable], string: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_string(list_: [1, 2, 3, 4], string: \"temp{0}\") == [\"temp1\", \"temp2\", \"temp3\", \"temp4\"])\nassert(add_string(list_: [\"a\", \"b\", \"c\", \"d\"], string: \"python{0}\") == [\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"])\nassert(add_string(list_: [5, 6, 7, 8], string: \"string{0}\") == [\"string5\", \"string6\", \"string7\", \"string8\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_391_convert_list_dictionary",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert more than one array to nested dictionary.\nfunc convert_list_dictionary(l1: [String], l2: [String], l3: [Int]) -> [[String : [String : Int]]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_391_convert_list_dictionary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(convert_list_dictionary(l1: [\"S001\", \"S002\", \"S003\", \"S004\"], l2: [\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"], l3: [85, 98, 89, 92]) == [[\"S001\" : [\"Adina Park\" : 85]], [\"S002\" : [\"Leyton Marsh\" : 98]], [\"S003\" : [\"Duncan Boyle\" : 89]], [\"S004\" : [\"Saim Richards\" : 92]]])\nassert(convert_list_dictionary(l1: [\"abc\", \"def\", \"ghi\", \"jkl\"], l2: [\"python\", \"program\", \"language\", \"programs\"], l3: [100, 200, 300, 400]) == [[\"abc\" : [\"python\" : 100]], [\"def\" : [\"program\" : 200]], [\"ghi\" : [\"language\" : 300]], [\"jkl\" : [\"programs\" : 400]]])\nassert(convert_list_dictionary(l1: [\"A1\", \"A2\", \"A3\", \"A4\"], l2: [\"java\", \"C\", \"C++\", \"DBMS\"], l3: [10, 20, 30, 40]) == [[\"A1\" : [\"java\" : 10]], [\"A2\" : [\"C\" : 20]], [\"A3\" : [\"C++\" : 30]], [\"A4\" : [\"DBMS\" : 40]]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunc get_max_sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_max_sum(n: 60) == 106)\nassert(get_max_sum(n: 10) == 12)\nassert(get_max_sum(n: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the array with maximum length.\nfunc max_length_list(input_list: [[Int]]) -> (Int, [Int]) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_length_list(input_list: [[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]) == (3, [13, 15, 17]))\nassert(max_length_list(input_list: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]) == (5, [1, 2, 3, 4, 5]))\nassert(max_length_list(input_list: [[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]) == (4, [6, 7, 8, 9]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if given array contains no duplicates.\nfunc check_distinct(test_tup: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_distinct(test_tup: [1, 4, 5, 6, 1, 4]) == false)\nassert(check_distinct(test_tup: [1, 4, 5, 6]) == true)\nassert(check_distinct(test_tup: [2, 3, 4, 5, 6]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the first non-repeated character in a given string.\nfunc first_non_repeating_character(str1: String) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_non_repeating_character(str1: \"abcabc\") == nil)\nassert(first_non_repeating_character(str1: \"abc\") == \"a\")\nassert(first_non_repeating_character(str1: \"ababc\") == \"c\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given string starts and ends with the same character or not.\nfunc check_char(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_char(string: \"abba\") == \"Valid\")\nassert(check_char(string: \"a\") == \"Valid\")\nassert(check_char(string: \"abcd\") == \"Invalid\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median of three numbers.\nfunc median_numbers(a: Int, b: Int, c: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_numbers(a: 25, b: 55, c: 65) == 55.0)\nassert(median_numbers(a: 20, b: 10, c: 30) == 20.0)\nassert(median_numbers(a: 15, b: 45, c: 75) == 45.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to compute the sum of digits of each number of a given array.\nfunc sum_of_digits(nums: [AnyHashable]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_of_digits(nums: [10, 2, 56]) == 14)\nassert(sum_of_digits(nums: [[10, 20, 4, 5, \"b\", 70, \"a\"]]) == 19)\nassert(sum_of_digits(nums: [10, 20, -4, 5, -70]) == 19)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunc bitwise_xor(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bitwise_xor(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (15, 6, 5, 10))\nassert(bitwise_xor(test_tup1: (11, 5, 7, 10), test_tup2: (6, 3, 4, 4)) == (13, 6, 3, 14))\nassert(bitwise_xor(test_tup1: (12, 6, 8, 11), test_tup2: (7, 4, 5, 6)) == (11, 2, 13, 13))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to identify non-prime numbers.\nfunc is_not_prime(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_not_prime(n: 2) == false)\nassert(is_not_prime(n: 10) == true)\nassert(is_not_prime(n: 35) == true)\nassert(is_not_prime(n: 37) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the number of unique tuples in the given array.\nfunc extract_freq(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_freq(test_list: [(3, 4), (1, 2), (4, 3), (5, 6)]) == 3)\nassert(extract_freq(test_list: [(4, 15), (2, 3), (5, 4), (6, 7)]) == 4)\nassert(extract_freq(test_list: [(5, 16), (2, 3), (6, 5), (6, 9)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunc add_nested_tuples(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_nested_tuples(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[7, 10], [7, 14], [3, 10], [8, 13]])\nassert(add_nested_tuples(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[9, 12], [9, 16], [5, 12], [10, 15]])\nassert(add_nested_tuples(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[11, 14], [11, 18], [7, 14], [12, 17]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the minimum of two numbers.\nfunc minimum(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(minimum(a: 1, b: 2) == 1)\nassert(minimum(a: -5, b: -4) == -5)\nassert(minimum(a: 0, b: 0) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to check whether an element exists within a tuple.\nfunc check_tuplex(tuplex: [Result<String, Int>], tuple1: AnyHashable) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"r\") == true)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: \"5\") == false)\nassert(check_tuplex(tuplex: [.success(\"w\"), .failure(3), .success(\"r\"), .success(\"e\"), .success(\"s\"), .success(\"o\"), .success(\"u\"), .success(\"r\"), .success(\"c\"), .success(\"e\")], tuple1: 3) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find whether the parity of a given number is odd.\nfunc find_Parity(x: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Parity(x: 12) == false)\nassert(find_Parity(x: 7) == true)\nassert(find_Parity(x: 10) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create the next bigger number by rearranging the digits of a given number.\nfunc rearrange_bigger(n: Int) -> AnyHashable {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rearrange_bigger(n: 12) == 21)\nassert(rearrange_bigger(n: 10) == false)\nassert(rearrange_bigger(n: 102) == 120)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunc k_smallest_pairs(nums1: [Int], nums2: [Int], k: Int) -> [[Int]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 2) == [[1, 2], [1, 4]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 1) == [[1, 2]])\nassert(k_smallest_pairs(nums1: [1, 3, 7], nums2: [2, 4, 6], k: 7) == [[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the minimum product from the pairs of tuples within a given array.\nfunc min_product_tuple(list1: [(Int, Int)]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_product_tuple(list1: [(2, 7), (2, 6), (1, 8), (4, 9)]) == 8)\nassert(min_product_tuple(list1: [(10, 20), (15, 2), (5, 10)]) == 30)\nassert(min_product_tuple(list1: [(11, 44), (10, 15), (20, 5), (12, 9)]) == 100)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to find the minimum value in a given heterogeneous array.\nfunc min_val(listval: [Result<String, Int>]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_val(listval: [.success(\"Python\"), .failure(3), .failure(2), .failure(4), .failure(5), .success(\"version\")]) == 2)\nassert(min_val(listval: [.success(\"Python\"), .failure(15), .failure(20), .failure(25)]) == 15)\nassert(min_val(listval: [.success(\"Python\"), .failure(30), .failure(20), .failure(40), .failure(50), .success(\"version\")]) == 20)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given snake case string to camel case string.\nfunc snake_to_camel(word: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(snake_to_camel(word: \"android_tv\") == \"AndroidTv\")\nassert(snake_to_camel(word: \"google_pixel\") == \"GooglePixel\")\nassert(snake_to_camel(word: \"apple_watch\") == \"AppleWatch\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to remove odd numbers from a given array.\nfunc remove_odd(l: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(l: [1, 2, 3]) == [2])\nassert(remove_odd(l: [2, 4, 6]) == [2, 4, 6])\nassert(remove_odd(l: [10, 20, 3]) == [10, 20])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the nth element from a given array of tuples.\nfunc extract_nth_element(list1: [(String, Int, Int)], n: Int) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 0) == [\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 2) == [99, 96, 94, 98])\nassert(extract_nth_element(list1: [(\"Greyson Fulton\", 98, 99), (\"Brady Kent\", 97, 96), (\"Wyatt Knott\", 91, 94), (\"Beau Turnbull\", 94, 98)], n: 1) == [98, 97, 91, 94])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether any value in a sequence exists in a sequence or not.\nfunc overlapping(list1: [Int], list2: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(overlapping(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == false)\nassert(overlapping(list1: [1, 2, 3], list2: [4, 5, 6]) == false)\nassert(overlapping(list1: [1, 4, 5], list2: [1, 4, 5]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find a pair with highest product from a given array of integers.\nfunc max_Product(arr: [Int]) -> (Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_Product(arr: [1, 2, 3, 4, 7, 0, 8, 4]) == (7, 8))\nassert(max_Product(arr: [0, -1, -2, -4, 5, 0, -6]) == (-4, -6))\nassert(max_Product(arr: [1, 2, 3]) == (2, 3))",
     "stop_tokens": [
       "\n}"
     ]
@@ -4732,7 +1720,7 @@
     "language": "swift",
     "prompt": "\n/// Write a function to find common first element in given array of arrays.\nfunc group_tuples(Input: [[String]]) -> [[String]] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(group_tuples(Input: [[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]) == [[\"x\", \"y\", \"z\"], [\"w\", \"t\"]])\nassert(group_tuples(Input: [[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]) == [[\"a\", \"b\", \"c\"], [\"d\", \"e\"]])\nassert(group_tuples(Input: [[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]) == [[\"f\", \"g\", \"g\"], [\"h\", \"i\"]])",
     "stop_tokens": [
@@ -4740,13 +1728,3025 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "swift",
-    "prompt": "\n/// Write a function to merge three arrays into a single sorted array.\nfunc merge_sorted_list(num1: [Int], num2: [Int], num3: [Int]) -> [Int] {\n",
+    "prompt": "\n/// Write a swiftthon function to find the element of an array having maximum length.\nfunc Find_Max(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_sorted_list(num1: [25, 24, 15, 4, 5, 29, 110], num2: [19, 20, 11, 56, 25, 233, 154], num3: [24, 26, 54, 48]) == [4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233])\nassert(merge_sorted_list(num1: [1, 3, 5, 6, 8, 9], num2: [2, 5, 7, 11], num3: [1, 4, 7, 8, 12]) == [1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12])\nassert(merge_sorted_list(num1: [18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], num2: [25, 35, 22, 85, 14, 65, 75, 25, 58], num3: [12, 74, 9, 50, 61, 41]) == [1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85])",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max(lst: [[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]) == [\"A\", \"B\", \"C\"])\nassert(Find_Max(lst: [[1], [1, 2], [1, 2, 3]]) == [1, 2, 3])\nassert(Find_Max(lst: [[1, 1], [1, 2, 3], [1, 5, 6, 1]]) == [1, 5, 6, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "swift",
+    "prompt": "\nextension Int: Error {}\n        \n/// Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunc round_and_sum(list1: [Result<Double, Int>]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(round_and_sum(list1: [.success(22.4), .success(4.0), .success(-16.22), .success(-9.1), .success(11.0), .success(-12.22), .success(14.2), .success(-5.2), .success(17.5)]) == 243)\nassert(round_and_sum(list1: [.failure(5), .failure(2), .failure(9), .success(24.3), .failure(29)]) == 345)\nassert(round_and_sum(list1: [.success(25.0), .success(56.7), .success(89.2)]) == 513)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the cube sum of first n even natural numbers.\nfunc cube_Sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_Sum(n: 2) == 72)\nassert(cube_Sum(n: 3) == 288)\nassert(cube_Sum(n: 4) == 800)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to concatenate each element of tuple by the delimiter.\nfunc concatenate_tuple(test_tup: (String, String, Int, String)) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(concatenate_tuple(test_tup: (\"ID\", \"is\", 4, \"UTS\")) == \"ID-is-4-UTS\")\nassert(concatenate_tuple(test_tup: (\"QWE\", \"is\", 4, \"RTY\")) == \"QWE-is-4-RTY\")\nassert(concatenate_tuple(test_tup: (\"ZEN\", \"is\", 4, \"OP\")) == \"ZEN-is-4-OP\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the average of cubes of first n natural numbers.\nfunc find_Average_Of_Cube(n: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Average_Of_Cube(n: 2) == 4.5)\nassert(find_Average_Of_Cube(n: 3) == 12)\nassert(find_Average_Of_Cube(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract only the rear index element of each string in the given tuple.\nfunc extract_rear(test_tuple: (String, String, String)) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_rear(test_tuple: (\"Mers\", \"for\", \"Vers\")) == [\"s\", \"r\", \"s\"])\nassert(extract_rear(test_tuple: (\"Avenge\", \"for\", \"People\")) == [\"e\", \"r\", \"e\"])\nassert(extract_rear(test_tuple: (\"Gotta\", \"get\", \"go\")) == [\"a\", \"t\", \"o\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the number of subarrays containing a particular element.\nfunc count_element_in_list(list1: [[AnyHashable]], x: AnyHashable) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_element_in_list(list1: [[1, 3], [5, 7], [1, 11], [1, 15, 7]], x: 1) == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"A\") == 3)\nassert(count_element_in_list(list1: [[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], x: \"E\") == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "swift",
+    "prompt": "\n/// Write a function to filter odd numbers.\nfunc filter_oddnumbers(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_oddnumbers(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 3, 5, 7, 9])\nassert(filter_oddnumbers(nums: [10, 20, 45, 67, 84, 93]) == [45, 67, 93])\nassert(filter_oddnumbers(nums: [5, 7, 9, 8, 6, 4, 3]) == [5, 7, 9, 3])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunc change_date_format(dt: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(change_date_format(dt: \"2026-01-02\") == \"02-01-2026\")\nassert(change_date_format(dt: \"2020-11-13\") == \"13-11-2020\")\nassert(change_date_format(dt: \"2021-04-26\") == \"26-04-2021\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort the given array by using shell sort.\nfunc shell_sort(my_list: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(shell_sort(my_list: [12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95])\nassert(shell_sort(my_list: [24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87])\nassert(shell_sort(my_list: [32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract the elementwise and tuples from the given two tuples.\nfunc and_tuples(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(and_tuples(test_tup1: (10, 4, 6, 9), test_tup2: (5, 2, 3, 3)) == (0, 0, 2, 1))\nassert(and_tuples(test_tup1: (1, 2, 3, 4), test_tup2: (5, 6, 7, 8)) == (1, 2, 3, 0))\nassert(and_tuples(test_tup1: (8, 9, 11, 12), test_tup2: (7, 13, 14, 17)) == (0, 9, 10, 0))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the directrix of a parabola.\nfunc parabola_directrix(a: Int, b: Int, c: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(parabola_directrix(a: 5, b: 3, c: 2) == -198)\nassert(parabola_directrix(a: 9, b: 8, c: 4) == -2336)\nassert(parabola_directrix(a: 2, b: 4, c: 6) == -130)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes two arrays and returns true if they have at least one common element.\nfunc common_element(list1: [AnyHashable], list2: [AnyHashable]) -> Bool? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [5, 6, 7, 8, 9]) == true)\nassert(common_element(list1: [1, 2, 3, 4, 5], list2: [6, 7, 8, 9]) == nil)\nassert(common_element(list1: [\"a\", \"b\", \"c\"], list2: [\"d\", \"b\", \"e\"]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median length of a trapezium.\nfunc median_trapezium(base1: Int, base2: Int, height: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(median_trapezium(base1: 15, base2: 25, height: 35) == 20)\nassert(median_trapezium(base1: 10, base2: 20, height: 30) == 15)\nassert(median_trapezium(base1: 6, base2: 9, height: 4) == 7.5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the entered number is greater than the elements of the given array.\nfunc check_greater(arr: [Int], number: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_greater(arr: [1, 2, 3, 4, 5], number: 4) == false)\nassert(check_greater(arr: [2, 3, 4, 5, 6], number: 8) == true)\nassert(check_greater(arr: [9, 7, 4, 8, 6, 1], number: 11) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an a followed by one or more b's.\nfunc text_match_one(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_one(text: \"ac\") == false)\nassert(text_match_one(text: \"dc\") == false)\nassert(text_match_one(text: \"abba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the last digit of a given number.\nfunc last_Digit(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit(n: 123) == 3)\nassert(last_Digit(n: 25) == 5)\nassert(last_Digit(n: 30) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to return the negative numbers in an array.\nfunc neg_nos(list1: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(neg_nos(list1: [-1, 4, 5, -6]) == [-1, -6])\nassert(neg_nos(list1: [-1, -2, 3, 4]) == [-1, -2])\nassert(neg_nos(list1: [-7, -6, 8, 9]) == [-7, -6])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove odd characters in a string.\nfunc remove_odd(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_odd(str1: \"python\") == \"yhn\")\nassert(remove_odd(str1: \"program\") == \"rga\")\nassert(remove_odd(str1: \"language\") == \"agae\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count bidirectional tuple pairs.\nfunc count_bidirectional(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)]) == 3)\nassert(count_bidirectional(test_list: [(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)]) == 2)\nassert(count_bidirectional(test_list: [(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "swift",
+    "prompt": "\n/// Write a function to join an array of multiple integers into a single integer.\nfunc multiple_to_single(L: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiple_to_single(L: [11, 33, 50]) == 113350)\nassert(multiple_to_single(L: [-1, 2, 3, 4, 5, 6]) == -123456)\nassert(multiple_to_single(L: [10, 15, 20, 25]) == 10152025)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the first adverb and their positions in a given sentence.\nfunc find_adverb_position(text: String) -> (Int, Int, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverb_position(text: \"clearly!! we can see the sky\") == (0, 7, \"clearly\"))\nassert(find_adverb_position(text: \"seriously!! there are many roses\") == (0, 9, \"seriously\"))\nassert(find_adverb_position(text: \"unfortunately!! sita is going to home\") == (0, 13, \"unfortunately\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the surface area of a cube of a given size.\nfunc surfacearea_cube(l: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cube(l: 5) == 150)\nassert(surfacearea_cube(l: 3) == 54)\nassert(surfacearea_cube(l: 10) == 600)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the ration of positive numbers in an array of integers.\nfunc positive_count(nums: [Int]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(positive_count(nums: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]) == 0.54)\nassert(positive_count(nums: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 0.69)\nassert(positive_count(nums: [2, 4, -6, -9, 11, -12, 14, -5, 17]) == 0.56)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the largest negative number from the given array.\nfunc largest_neg(list1: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(largest_neg(list1: [1, 2, 3, -4, -6]) == -6)\nassert(largest_neg(list1: [1, 2, 3, -8, -9]) == -9)\nassert(largest_neg(list1: [1, 2, 3, 4, -1]) == -1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to trim each array by k in the given arrays.\nfunc trim_tuple(test_list: [[Int]], K: Int) -> [[Int]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 2) == [[2], [9], [2], [2]])\nassert(trim_tuple(test_list: [[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], K: 1) == [[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]])\nassert(trim_tuple(test_list: [[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], K: 1) == [[8, 4], [8, 12], [1, 7], [6, 9]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "swift",
+    "prompt": "\n/// Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunc index_multiplication(test_tup1: [[Int]], test_tup2: [[Int]]) -> [[Int]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_multiplication(test_tup1: [[1, 3], [4, 5], [2, 9], [1, 10]], test_tup2: [[6, 7], [3, 9], [1, 1], [7, 3]]) == [[6, 21], [12, 45], [2, 9], [7, 30]])\nassert(index_multiplication(test_tup1: [[2, 4], [5, 6], [3, 10], [2, 11]], test_tup2: [[7, 8], [4, 10], [2, 2], [8, 4]]) == [[14, 32], [20, 60], [6, 20], [16, 44]])\nassert(index_multiplication(test_tup1: [[3, 5], [6, 7], [4, 11], [3, 12]], test_tup2: [[8, 9], [5, 11], [3, 3], [9, 5]]) == [[24, 45], [30, 77], [12, 33], [27, 60]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the occurence of all elements of array in a tuple.\nfunc count_Occurrence(tup: AnyHashable, lst: [AnyHashable]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Occurrence(tup: (\"a\", \"a\", \"c\", \"b\", \"d\"), lst: [\"a\", \"b\"]) == 3)\nassert(count_Occurrence(tup: (1, 2, 3, 1, 4, 6, 7, 1, 4), lst: [1, 4, 7]) == 6)\nassert(count_Occurrence(tup: (1, 2, 3, 4, 5, 6), lst: [1, 2]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find cubes of individual elements in an array.\nfunc cube_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cube_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 8, 27, 64, 125, 216, 343, 512, 729, 1000])\nassert(cube_nums(nums: [10, 20, 30]) == [1000, 8000, 27000])\nassert(cube_nums(nums: [12, 15]) == [1728, 3375])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the sum of perrin numbers.\nfunc cal_sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cal_sum(n: 9) == 49)\nassert(cal_sum(n: 10) == 66)\nassert(cal_sum(n: 11) == 88)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract specified size of strings from a given array of string values.\nfunc extract_string(str: [String], l: Int) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 8) == [\"practice\", \"solution\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 6) == [\"Python\"])\nassert(extract_string(str: [\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], l: 9) == [\"exercises\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all whitespaces from the given string.\nfunc remove_whitespaces(text1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_whitespaces(text1: \" Google    Flutter \") == \"GoogleFlutter\")\nassert(remove_whitespaces(text1: \" Google    Dart \") == \"GoogleDart\")\nassert(remove_whitespaces(text1: \" iOS    Swift \") == \"iOSSwift\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "swift",
+    "prompt": "\n/// Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunc loss_amount(actual_cost: Int, sale_amount: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(loss_amount(actual_cost: 1500, sale_amount: 1200) == 0)\nassert(loss_amount(actual_cost: 100, sale_amount: 200) == 100)\nassert(loss_amount(actual_cost: 2000, sale_amount: 5000) == 3000)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of even factors of a number.\nfunc sumofFactors(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sumofFactors(n: 18) == 26)\nassert(sumofFactors(n: 30) == 48)\nassert(sumofFactors(n: 6) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a word containing 'z'.\nfunc text_match_wordz(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz(text: \"pythonz.\") == true)\nassert(text_match_wordz(text: \"xyz.\") == true)\nassert(text_match_wordz(text: \"  lang  .\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given month number contains 31 days or not.\nfunc check_monthnumb_number(monthnum2: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumb_number(monthnum2: 5) == true)\nassert(check_monthnumb_number(monthnum2: 2) == false)\nassert(check_monthnumb_number(monthnum2: 6) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to reverse each string in a given array of string values.\nfunc reverse_string_list(stringlist: [String]) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_string_list(stringlist: [\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]) == [\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"])\nassert(reverse_string_list(stringlist: [\"john\", \"amal\", \"joel\", \"george\"]) == [\"nhoj\", \"lama\", \"leoj\", \"egroeg\"])\nassert(reverse_string_list(stringlist: [\"jack\", \"john\", \"mary\"]) == [\"kcaj\", \"nhoj\", \"yram\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the subarray having minimum length.\nfunc Find_Min(lst: [[AnyHashable]]) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min(lst: [[1], [1, 2], [1, 2, 3]]) == [1])\nassert(Find_Min(lst: [[1, 1], [1, 1, 1], [1, 2, 7, 8]]) == [1, 1])\nassert(Find_Min(lst: [[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]) == [\"x\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the area of a rectangle.\nfunc rectangle_area(l: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rectangle_area(l: 10, b: 20) == 200)\nassert(rectangle_area(l: 10, b: 5) == 50)\nassert(rectangle_area(l: 4, b: 2) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove uppercase substrings from a given string.\nfunc remove_uppercase(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_uppercase(str1: \"cAstyoUrFavoRitETVshoWs\") == \"cstyoravoitshos\")\nassert(remove_uppercase(str1: \"wAtchTheinTernEtrAdIo\") == \"wtchheinerntrdo\")\nassert(remove_uppercase(str1: \"VoicESeaRchAndreComMendaTionS\") == \"oiceachndreomendaion\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to get the first element of each subarray.\nfunc Extract(lst: [[Int]]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Extract(lst: [[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6])\nassert(Extract(lst: [[1, 2, 3], [4, 5]]) == [1, 4])\nassert(Extract(lst: [[9, 8, 1], [1, 2]]) == [9, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the upper case characters in a given string.\nfunc upper_ctr(str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(upper_ctr(str: \"PYthon\") == 1)\nassert(upper_ctr(str: \"BigData\") == 1)\nassert(upper_ctr(str: \"program\") == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_462_combinations_list",
+    "language": "swift",
+    "prompt": "\nextension [String]: Error {}\n        \n/// Write a function to find all possible combinations of the elements of a given array.\nfunc combinations_list(list1: [String]) -> [Result<[()], [String]>] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_462_combinations_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(combinations_list(list1: [\"orange\", \"red\", \"green\", \"blue\"]) == [.success([] as [()]), .failure([\"orange\"]), .failure([\"red\"]), .failure([\"red\", \"orange\"]), .failure([\"green\"]), .failure([\"green\", \"orange\"]), .failure([\"green\", \"red\"]), .failure([\"green\", \"red\", \"orange\"]), .failure([\"blue\"]), .failure([\"blue\", \"orange\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"red\", \"orange\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"orange\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"blue\", \"green\", \"red\", \"orange\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"blue\", \"white\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"blue\"]), .failure([\"blue\", \"red\"]), .failure([\"blue\", \"green\"]), .failure([\"blue\", \"green\", \"red\"]), .failure([\"white\"]), .failure([\"white\", \"red\"]), .failure([\"white\", \"green\"]), .failure([\"white\", \"green\", \"red\"]), .failure([\"white\", \"blue\"]), .failure([\"white\", \"blue\", \"red\"]), .failure([\"white\", \"blue\", \"green\"]), .failure([\"white\", \"blue\", \"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"black\", \"blue\"]), .failure([\"black\", \"blue\", \"red\"]), .failure([\"black\", \"blue\", \"green\"]), .failure([\"black\", \"blue\", \"green\", \"red\"]), .failure([\"black\", \"white\"]), .failure([\"black\", \"white\", \"red\"]), .failure([\"black\", \"white\", \"green\"]), .failure([\"black\", \"white\", \"green\", \"red\"]), .failure([\"black\", \"white\", \"blue\"]), .failure([\"black\", \"white\", \"blue\", \"red\"]), .failure([\"black\", \"white\", \"blue\", \"green\"]), .failure([\"black\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"blue\"]), .failure([\"orange\", \"blue\", \"red\"]), .failure([\"orange\", \"blue\", \"green\"]), .failure([\"orange\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"white\"]), .failure([\"orange\", \"white\", \"red\"]), .failure([\"orange\", \"white\", \"green\"]), .failure([\"orange\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"white\", \"blue\"]), .failure([\"orange\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"white\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"blue\"]), .failure([\"orange\", \"black\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"blue\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\"]), .failure([\"orange\", \"black\", \"white\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"green\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"red\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\"]), .failure([\"orange\", \"black\", \"white\", \"blue\", \"green\", \"red\"])])\nassert(combinations_list(list1: [\"red\", \"green\", \"black\", \"orange\"]) == [.success([] as [()]), .failure([\"red\"]), .failure([\"green\"]), .failure([\"green\", \"red\"]), .failure([\"black\"]), .failure([\"black\", \"red\"]), .failure([\"black\", \"green\"]), .failure([\"black\", \"green\", \"red\"]), .failure([\"orange\"]), .failure([\"orange\", \"red\"]), .failure([\"orange\", \"green\"]), .failure([\"orange\", \"green\", \"red\"]), .failure([\"orange\", \"black\"]), .failure([\"orange\", \"black\", \"red\"]), .failure([\"orange\", \"black\", \"green\"]), .failure([\"orange\", \"black\", \"green\", \"red\"])])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum product subarray of the given array.\nfunc max_subarray_product(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_subarray_product(arr: [1, -2, -3, 0, 7, -8, -2]) == 112)\nassert(max_subarray_product(arr: [6, -3, -10, 0, 2]) == 180)\nassert(max_subarray_product(arr: [-2, -40, 0, -2, -3]) == 80)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if all values are same in a dictionary.\nfunc check_value(dict: [String : Int], n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 10) == false)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 12) == true)\nassert(check_value(dict: [\"Cierra Vega\" : 12, \"Alden Cantrell\" : 12, \"Kierra Gentry\" : 12, \"Pierre Cox\" : 12], n: 5) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_465_drop_empty",
+    "language": "swift",
+    "prompt": "\n/// Write a function to drop empty items from a given dictionary.\nfunc drop_empty(dict1: [String : String?]) -> [String : String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_465_drop_empty.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : \"Green\", \"c3\" : nil]) == [\"c1\" : \"Red\", \"c2\" : \"Green\"])\nassert(drop_empty(dict1: [\"c1\" : \"Red\", \"c2\" : nil, \"c3\" : nil]) == [\"c1\" : \"Red\"])\nassert(drop_empty(dict1: [\"c1\" : nil, \"c2\" : \"Green\", \"c3\" : nil]) == [\"c2\" : \"Green\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunc max_product(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_product(arr: [3, 100, 4, 5, 150, 6]) == 3000)\nassert(max_product(arr: [4, 42, 55, 68, 80]) == 50265600)\nassert(max_product(arr: [10, 22, 9, 33, 21, 50, 41, 60]) == 2460)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunc add_pairwise(test_tup: (Int, Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_pairwise(test_tup: (1, 5, 7, 8, 10)) == (6, 12, 15, 18))\nassert(add_pairwise(test_tup: (2, 6, 8, 9, 11)) == (8, 14, 17, 20))\nassert(add_pairwise(test_tup: (3, 7, 9, 10, 12)) == (10, 16, 19, 22))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the product of the array multiplication modulo n.\nfunc find_remainder(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_remainder(arr: [100, 10, 5, 25, 35, 14], n: 11) == 9)\nassert(find_remainder(arr: [1, 1, 1], n: 1) == 0)\nassert(find_remainder(arr: [1, 2, 1], n: 2) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given array contains consecutive numbers or not.\nfunc check_Consecutive(l: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_Consecutive(l: [1, 2, 3, 4, 5]) == true)\nassert(check_Consecutive(l: [1, 2, 3, 5, 6]) == false)\nassert(check_Consecutive(l: [1, 2, 1]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace characters in a string.\nfunc replace_char(str1: String, ch: String, newch: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_char(str1: \"polygon\", ch: \"y\", newch: \"l\") == \"pollgon\")\nassert(replace_char(str1: \"character\", ch: \"c\", newch: \"a\") == \"aharaater\")\nassert(replace_char(str1: \"python\", ch: \"l\", newch: \"a\") == \"python\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a dictionary by value.\nfunc sort_counter(dict1: [String : Int]) -> [(String, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_counter(dict1: [\"Math\" : 81, \"Physics\" : 83, \"Chemistry\" : 87]) == [(\"Chemistry\", 87), (\"Physics\", 83), (\"Math\", 81)])\nassert(sort_counter(dict1: [\"Math\" : 400, \"Physics\" : 300, \"Chemistry\" : 250]) == [(\"Math\", 400), (\"Physics\", 300), (\"Chemistry\", 250)])\nassert(sort_counter(dict1: [\"Math\" : 900, \"Physics\" : 1000, \"Chemistry\" : 1250]) == [(\"Chemistry\", 1250), (\"Physics\", 1000), (\"Math\", 900)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of the largest and smallest value in a given array.\nfunc big_sum(nums: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_sum(nums: [1, 2, 3]) == 4)\nassert(big_sum(nums: [-1, 2, 3, 4]) == 3)\nassert(big_sum(nums: [2, 3, 6]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to convert the given string to lower case.\nfunc is_lower(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_lower(string: \"InValid\") == \"invalid\")\nassert(is_lower(string: \"TruE\") == \"true\")\nassert(is_lower(string: \"SenTenCE\") == \"sentence\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove lowercase substrings from a given string.\nfunc remove_lowercase(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_lowercase(str1: \"PYTHon\") == \"PYTH\")\nassert(remove_lowercase(str1: \"FInD\") == \"FID\")\nassert(remove_lowercase(str1: \"STRinG\") == \"STRG\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the first digit of a given number.\nfunc first_Digit(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_Digit(n: 123) == 1)\nassert(first_Digit(n: 456) == 4)\nassert(first_Digit(n: 12) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunc heap_queue_largest(nums: [Int], n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 3) == [85, 75, 65])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 2) == [85, 75])\nassert(heap_queue_largest(nums: [25, 35, 22, 85, 14, 65, 75, 22, 58], n: 5) == [85, 75, 65, 58, 35])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function which takes an array of integers and only returns the odd ones.\nfunc Split(list: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5, 6]) == [1, 3, 5])\nassert(Split(list: [10, 11, 12, 13]) == [11, 13])\nassert(Split(list: [7, 8, 9, 1]) == [7, 9, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunc difference(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(difference(n: 3) == 30)\nassert(difference(n: 5) == 210)\nassert(difference(n: 2) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of pairs whose xor value is odd.\nfunc find_Odd_Pair(A: [Int], N: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Odd_Pair(A: [5, 4, 7, 2, 1], N: 5) == 6)\nassert(find_Odd_Pair(A: [7, 2, 8, 1, 0, 5, 11], N: 7) == 12)\nassert(find_Odd_Pair(A: [1, 2, 3], N: 3) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "swift",
+    "prompt": "\n/// Write a function to toggle the case of all characters in a string.\nfunc toggle_string(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_string(string: \"Python\") == \"pYTHON\")\nassert(toggle_string(string: \"Pangram\") == \"pANGRAM\")\nassert(toggle_string(string: \"LIttLE\") == \"liTTle\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of the per-digit difference between two integers.\nfunc digit_distance_nums(n1: Int, n2: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(digit_distance_nums(n1: 1, n2: 2) == 1)\nassert(digit_distance_nums(n1: 23, n2: 56) == 6)\nassert(digit_distance_nums(n1: 123, n2: 256) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the sum of the largest contiguous subarray in the given array.\nfunc max_sub_array_sum(a: [Int], size: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sub_array_sum(a: [-2, -3, 4, -1, -2, 1, 5, -3], size: 8) == 7)\nassert(max_sub_array_sum(a: [-3, -4, 5, -2, -3, 2, 6, -4], size: 8) == 8)\nassert(max_sub_array_sum(a: [-4, -5, 6, -3, -4, 3, 7, -5], size: 8) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunc union_elements(test_tup1: [Int], test_tup2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(union_elements(test_tup1: [3, 4, 5, 6], test_tup2: [5, 7, 4, 10]) == [3, 4, 5, 6, 7, 10])\nassert(union_elements(test_tup1: [1, 2, 3, 4], test_tup2: [3, 4, 5, 6]) == [1, 2, 3, 4, 5, 6])\nassert(union_elements(test_tup1: [11, 12, 13, 14], test_tup2: [13, 15, 16, 17]) == [11, 12, 13, 14, 15, 16, 17])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the length of the longest subarrays.\nfunc Find_Max_Length(lst: [[Int]]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Max_Length(lst: [[1], [1, 4], [5, 6, 7, 8]]) == 4)\nassert(Find_Max_Length(lst: [[0, 1], [2, 2], [3, 2, 1]]) == 3)\nassert(Find_Max_Length(lst: [[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract values between quotation marks from a string.\nfunc extract_values(text: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_values(text: \"\\\"Python\\\", \\\"PHP\\\", \\\"Java\\\"\") == [\"Python\", \"PHP\", \"Java\"])\nassert(extract_values(text: \"\\\"python\\\",\\\"program\\\",\\\"language\\\"\") == [\"python\", \"program\", \"language\"])\nassert(extract_values(text: \"\\\"red\\\",\\\"blue\\\",\\\"green\\\",\\\"yellow\\\"\") == [\"red\", \"blue\", \"green\", \"yellow\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunc count_Pairs(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Pairs(arr: [1, 2, 1], n: 3) == 2)\nassert(count_Pairs(arr: [1, 1, 1, 1], n: 4) == 0)\nassert(count_Pairs(arr: [1, 2, 3, 4, 5], n: 5) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to split a string into characters.\nfunc split(word: String) -> [String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split(word: \"python\") == [\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"])\nassert(split(word: \"Name\") == [\"N\", \"a\", \"m\", \"e\"])\nassert(split(word: \"program\") == [\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get the sum of the digits of a non-negative integer.\nfunc sum_digits(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_digits(n: 345) == 12)\nassert(sum_digits(n: 12) == 3)\nassert(sum_digits(n: 97) == 16)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether a specified array is sorted or not.\nfunc issort_list(list1: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 16, 17]) == true)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 12, 14, 20, 17]) == false)\nassert(issort_list(list1: [1, 2, 4, 6, 8, 10, 15, 14, 20]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_568_empty_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create an array of N empty dictionaries.\nfunc empty_list(length: Int) -> [[() : ()]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_568_empty_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(empty_list(length: 5) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 6) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])\nassert(empty_list(length: 7) == [[:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()], [:] as [() : ()]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort each subarray of strings in a given array of arrays.\nfunc sort_sublists(list1: [[String]]) -> [[String]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]) == [[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]])\nassert(sort_sublists(list1: [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]) == [[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]])\nassert(sort_sublists(list1: [[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]) == [[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check if a given number is one less than twice its reverse.\nfunc checks(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(checks(n: 70) == false)\nassert(checks(n: 23) == false)\nassert(checks(n: 73) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to remove duplicate numbers from a given number of arrays.\nfunc two_unique_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(two_unique_nums(nums: [1, 2, 3, 2, 3, 4, 5]) == [1, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 2, 4, 5]) == [1, 3, 4, 5])\nassert(two_unique_nums(nums: [1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to calculate the product of the unique numbers in a given array.\nfunc unique_product(list_data: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_product(list_data: [10, 20, 30, 40, 20, 50, 60, 40]) == 720000000)\nassert(unique_product(list_data: [1, 2, 3, 1]) == 6)\nassert(unique_product(list_data: [7, 8, 9, 0, 1, 1]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the surface area of a cylinder.\nfunc surfacearea_cylinder(r: Int, h: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surfacearea_cylinder(r: 10, h: 5) == 942.45)\nassert(surfacearea_cylinder(r: 4, h: 5) == 226.18800000000002)\nassert(surfacearea_cylinder(r: 4, h: 10) == 351.848)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether an array is subarray of another or not.\nfunc is_Sub_Array(A: [Int], B: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Sub_Array(A: [1, 4, 3, 5], B: [1, 2]) == false)\nassert(is_Sub_Array(A: [1, 2, 1], B: [1, 2, 1]) == true)\nassert(is_Sub_Array(A: [1, 0, 2, 2], B: [2, 2, 0]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the last digit in factorial of a given number.\nfunc last_Digit_Factorial(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last_Digit_Factorial(n: 4) == 4)\nassert(last_Digit_Factorial(n: 21) == 0)\nassert(last_Digit_Factorial(n: 30) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to interleave 3 arrays of the same length into a single flat array.\nfunc interleave_lists(list1: [Int], list2: [Int], list3: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(interleave_lists(list1: [1, 2, 3, 4, 5, 6, 7], list2: [10, 20, 30, 40, 50, 60, 70], list3: [100, 200, 300, 400, 500, 600, 700]) == [1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700])\nassert(interleave_lists(list1: [10, 20], list2: [15, 2], list3: [5, 10]) == [10, 15, 5, 20, 2, 10])\nassert(interleave_lists(list1: [11, 44], list2: [10, 15], list3: [20, 5]) == [11, 10, 20, 44, 15, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the dissimilar elements in the given two tuples.\nfunc find_dissimilar(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_dissimilar(test_tup1: (3, 4, 5, 6), test_tup2: (5, 7, 4, 10)) == (3, 6, 7, 10))\nassert(find_dissimilar(test_tup1: (1, 2, 3, 4), test_tup2: (7, 2, 3, 9)) == (1, 4, 7, 9))\nassert(find_dissimilar(test_tup1: (21, 11, 25, 26), test_tup2: (26, 34, 21, 36)) == (34, 36, 11, 25))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the largest number that can be formed with the given array of digits.\nfunc find_Max_Num(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Max_Num(arr: [1, 2, 3]) == 321)\nassert(find_Max_Num(arr: [4, 5, 6, 1]) == 6541)\nassert(find_Max_Num(arr: [1, 2, 3, 9]) == 9321)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove uneven elements in the nested mixed tuple.\nfunc extract_even(test_tuple: (Int, Int, (Int, Int, (Int, Int)), Int, Int)) -> AnyHashable {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_even(test_tuple: (4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8))\nassert(extract_even(test_tuple: (5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8))))\nassert(extract_even(test_tuple: (5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the surface area of a square swiftramid with a given base edge and height.\nfunc surface_Area(b: Int, s: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(surface_Area(b: 3, s: 4) == 33)\nassert(surface_Area(b: 4, s: 5) == 56)\nassert(surface_Area(b: 1, s: 2) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function which returns nth catalan number.\nfunc catalan_number(num: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(catalan_number(num: 10) == 16796)\nassert(catalan_number(num: 9) == 4862)\nassert(catalan_number(num: 7) == 429)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the first adverb ending with ly and its positions in a given string.\nfunc find_adverbs(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_adverbs(text: \"Clearly, he has no excuse for such behavior.\") == \"0-7: Clearly\")\nassert(find_adverbs(text: \"Please handle the situation carefuly\") == \"28-36: carefuly\")\nassert(find_adverbs(text: \"Complete the task quickly\") == \"18-25: quickly\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_585_expensive_items",
+    "language": "swift",
+    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the n most expensive items in a given dataset.\nfunc expensive_items(items: [[String : Result<String, Double>]], n: Int) -> [[String : Result<String, Double>]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_585_expensive_items.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)]], n: 2) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)]])\nassert(expensive_items(items: [[\"name\" : .success(\"Item-1\"), \"price\" : .failure(101.1)], [\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)], [\"name\" : .success(\"Item-3\"), \"price\" : .failure(45.09)], [\"name\" : .success(\"Item-4\"), \"price\" : .failure(22.75)]], n: 1) == [[\"name\" : .success(\"Item-2\"), \"price\" : .failure(555.22)]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to split an array at the nth eelment and add the first part to the end.\nfunc split_Arr(l: [Int], n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(split_Arr(l: [12, 10, 5, 6, 52, 36], n: 2) == [5, 6, 52, 36, 12, 10])\nassert(split_Arr(l: [1, 2, 3, 4], n: 1) == [2, 3, 4, 1])\nassert(split_Arr(l: [0, 1, 2, 3, 4, 5, 6, 7], n: 3) == [3, 4, 5, 6, 7, 0, 1, 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert an array to a tuple.\nfunc list_tuple(listx: [Int]) -> AnyHashable {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(list_tuple(listx: [5, 10, 7, 4, 15, 3]) == (5, 10, 7, 4, 15, 3))\nassert(list_tuple(listx: [2, 4, 5, 6, 2, 3, 4, 4, 7]) == (2, 4, 5, 6, 2, 3, 4, 4, 7))\nassert(list_tuple(listx: [58, 44, 56]) == (58, 44, 56))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the difference between largest and smallest value in a given array.\nfunc big_diff(nums: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(big_diff(nums: [1, 2, 3, 4]) == 3)\nassert(big_diff(nums: [4, 5, 12]) == 8)\nassert(big_diff(nums: [9, 2, 3]) == 7)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find perfect squares between two given numbers.\nfunc perfect_squares(a: Int, b: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(perfect_squares(a: 1, b: 30) == [1, 4, 9, 16, 25])\nassert(perfect_squares(a: 50, b: 100) == [64, 81, 100])\nassert(perfect_squares(a: 100, b: 200) == [100, 121, 144, 169, 196])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given two integers have opposite sign or not.\nfunc opposite_Signs(x: Int, y: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(opposite_Signs(x: 1, y: -2) == true)\nassert(opposite_Signs(x: 3, y: 2) == false)\nassert(opposite_Signs(x: -10, y: -10) == false)\nassert(opposite_Signs(x: -2, y: 2) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to interchange the first and last elements in an array.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12])\nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of the product of consecutive binomial co-efficients.\nfunc sum_Of_product(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_product(n: 3) == 15)\nassert(sum_Of_product(n: 4) == 56)\nassert(sum_Of_product(n: 1) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove leading zeroes from an ip address.\nfunc removezero_ip(ip: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(removezero_ip(ip: \"216.08.094.196\") == \"216.8.94.196\")\nassert(removezero_ip(ip: \"12.01.024\") == \"12.1.24\")\nassert(removezero_ip(ip: \"216.08.094.0196\") == \"216.8.94.196\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the difference of the first even and first odd number of a given array.\nfunc diff_even_odd(list1: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(diff_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 3)\nassert(diff_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 1)\nassert(diff_even_odd(list1: [1, 5, 7, 9, 10]) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunc min_Swaps(str1: String, str2: String) -> AnyHashable {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Swaps(str1: \"1101\", str2: \"1110\") == 1)\nassert(min_Swaps(str1: \"111\", str2: \"000\") == \"Not Possible\")\nassert(min_Swaps(str1: \"111\", str2: \"110\") == \"Not Possible\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find kth element from the given two sorted arrays.\nfunc find_kth(arr1: [Int], arr2: [Int], k: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_kth(arr1: [2, 3, 6, 7, 9], arr2: [1, 4, 8, 10], k: 5) == 6)\nassert(find_kth(arr1: [100, 112, 256, 349, 770], arr2: [72, 86, 113, 119, 265, 445, 892], k: 7) == 256)\nassert(find_kth(arr1: [3, 4, 7, 8, 10], arr2: [2, 5, 9, 11], k: 6) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is armstrong or not.\nfunc armstrong_number(number: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(armstrong_number(number: 153) == true)\nassert(armstrong_number(number: 259) == false)\nassert(armstrong_number(number: 4458) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find sum and average of first n natural numbers.\nfunc sum_average(number: Int) -> (Int, Double) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_average(number: 10) == (55, 5.5))\nassert(sum_average(number: 15) == (120, 8.0))\nassert(sum_average(number: 20) == (210, 10.5))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth octagonal number.\nfunc is_octagonal(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_octagonal(n: 5) == 65)\nassert(is_octagonal(n: 10) == 280)\nassert(is_octagonal(n: 15) == 645)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given number is even or not.\nfunc is_Even(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Even(n: 1) == false)\nassert(is_Even(n: 2) == true)\nassert(is_Even(n: 3) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the first repeated character in a given string.\nfunc first_repeated_char(str1: String) -> String? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_repeated_char(str1: \"abcabc\") == \"a\")\nassert(first_repeated_char(str1: \"abc\") == nil)\nassert(first_repeated_char(str1: \"123123\") == \"1\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunc get_ludic(n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_ludic(n: 10) == [1, 2, 3, 5, 7])\nassert(get_ludic(n: 25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25])\nassert(get_ludic(n: 45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "swift",
+    "prompt": "\n/// Write a function to reverse words seperated by spaces in a given string.\nfunc reverse_words(s: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_words(s: \"python program\") == \"program python\")\nassert(reverse_words(s: \"java language\") == \"language java\")\nassert(reverse_words(s: \"indian man\") == \"man indian\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given integer is a prime number.\nfunc prime_num(num: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(prime_num(num: 13) == true)\nassert(prime_num(num: 7) == true)\nassert(prime_num(num: -1010) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert degrees to radians.\nfunc radian_degree(degree: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(radian_degree(degree: 90) == 1.5707963267948966)\nassert(radian_degree(degree: 60) == 1.0471975511965976)\nassert(radian_degree(degree: 120) == 2.0943951023931953)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "swift",
+    "prompt": "\n/// Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunc find_literals(text: String, pattern: String) -> (String, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_literals(text: \"The quick brown fox jumps over the lazy dog.\", pattern: \"fox\") == (\"fox\", 16, 19))\nassert(find_literals(text: \"Its been a very crazy procedure right\", pattern: \"crazy\") == (\"crazy\", 16, 21))\nassert(find_literals(text: \"Hardest choices required strongest will\", pattern: \"will\") == (\"will\", 35, 39))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find nth bell number.\nfunc bell_Number(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_Number(n: 2) == 2)\nassert(bell_Number(n: 3) == 5)\nassert(bell_Number(n: 4) == 15)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunc remove_kth_element(list1: [Int], L: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_kth_element(list1: [1, 1, 2, 3, 4, 4, 5, 1], L: 3) == [1, 1, 3, 4, 4, 5, 1])\nassert(remove_kth_element(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], L: 4) == [0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])\nassert(remove_kth_element(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], L: 5) == [10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "swift",
+    "prompt": "\n/// Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunc max_of_nth(test_list: [[Int]], N: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_of_nth(test_list: [[5, 6, 7], [1, 3, 5], [8, 9, 19]], N: 2) == 19)\nassert(max_of_nth(test_list: [[6, 7, 8], [2, 4, 6], [9, 10, 20]], N: 1) == 10)\nassert(max_of_nth(test_list: [[7, 8, 9], [3, 5, 7], [10, 11, 21]], N: 1) == 11)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunc merge(lst: [[AnyHashable]]) -> [[AnyHashable]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge(lst: [[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]])\nassert(merge(lst: [[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]])\nassert(merge(lst: [[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]) == [[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunc cummulative_sum(test_list: [[Int]]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(cummulative_sum(test_list: [[1, 3], [5, 6, 7], [2, 6]]) == 30)\nassert(cummulative_sum(test_list: [[2, 4], [6, 7, 8], [3, 7]]) == 37)\nassert(cummulative_sum(test_list: [[3, 5], [7, 8, 9], [4, 8]]) == 44)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunc average_tuple(nums: [[Int]]) -> [Double] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(average_tuple(nums: [[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]) == [30.5, 34.25, 27.0, 23.25])\nassert(average_tuple(nums: [[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]) == [25.5, -18.0, 3.75])\nassert(average_tuple(nums: [[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]) == [305.0, 342.5, 270.0, 232.5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "swift",
+    "prompt": "\n/// Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunc tuple_modulo(test_tup1: (Int, Int, Int, Int), test_tup2: (Int, Int, Int, Int)) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_modulo(test_tup1: (10, 4, 5, 6), test_tup2: (5, 6, 7, 5)) == (0, 4, 5, 1))\nassert(tuple_modulo(test_tup1: (11, 5, 6, 7), test_tup2: (6, 7, 8, 6)) == (5, 5, 6, 1))\nassert(tuple_modulo(test_tup1: (12, 6, 7, 8), test_tup2: (7, 8, 9, 7)) == (5, 6, 7, 1))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunc min_Jumps(steps: (Int, Int), d: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_Jumps(steps: (3, 4), d: 11) == 3.5)\nassert(min_Jumps(steps: (3, 4), d: 0) == 0)\nassert(min_Jumps(steps: (11, 14), d: 11) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function to divide two arrays element wise.\nfunc div_list(nums1: [Int], nums2: [Int]) -> [Double] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(div_list(nums1: [4, 5, 6], nums2: [1, 2, 3]) == [4.0, 2.5, 2.0])\nassert(div_list(nums1: [3, 2], nums2: [1, 4]) == [3.0, 0.5])\nassert(div_list(nums1: [90, 120], nums2: [50, 70]) == [1.8, 1.7142857142857142])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to move all the numbers to the end of the given string.\nfunc move_num(test_str: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_num(test_str: \"I1love143you55three3000thousand\") == \"Iloveyouthreethousand1143553000\")\nassert(move_num(test_str: \"Avengers124Assemble\") == \"AvengersAssemble124\")\nassert(move_num(test_str: \"Its11our12path13to14see15things16do17things\") == \"Itsourpathtoseethingsdothings11121314151617\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of substrings with the sum of digits equal to their length.\nfunc count_Substrings(s: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_Substrings(s: \"112112\") == 6)\nassert(count_Substrings(s: \"111\") == 6)\nassert(count_Substrings(s: \"1101112\") == 12)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the median of two sorted arrays of same size.\nfunc get_median(arr1: [Int], arr2: [Int], n: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_median(arr1: [1, 12, 15, 26, 38], arr2: [2, 13, 17, 30, 45], n: 5) == 16.0)\nassert(get_median(arr1: [2, 4, 8, 9], arr2: [7, 13, 19, 28], n: 4) == 8.5)\nassert(get_median(arr1: [3, 6, 14, 23, 36, 42], arr2: [2, 18, 27, 39, 49, 55], n: 6) == 25.0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to compute the n-th power of each number in an array.\nfunc nth_nums(nums: [Int], n: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(nth_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n: 2) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(nth_nums(nums: [10, 20, 30], n: 3) == [1000, 8000, 27000])\nassert(nth_nums(nums: [12, 15], n: 5) == [248832, 759375])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to convert a given string to uppercase.\nfunc is_upper(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_upper(string: \"person\") == \"PERSON\")\nassert(is_upper(string: \"final\") == \"FINAL\")\nassert(is_upper(string: \"Valid\") == \"VALID\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to interchange the first and last element in a given array.\nfunc swap_List(newList: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(swap_List(newList: [1, 2, 3]) == [3, 2, 1])\nassert(swap_List(newList: [1, 2, 3, 4, 4]) == [4, 2, 3, 4, 1])\nassert(swap_List(newList: [4, 5, 6]) == [6, 5, 4])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunc triangle_area(r: Int) -> Int? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(triangle_area(r: -1) == nil)\nassert(triangle_area(r: 0) == 0)\nassert(triangle_area(r: 2) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the smallest missing number from a sorted array of natural numbers.\nfunc find_First_Missing(array: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_First_Missing(array: [0, 1, 2, 3]) == 4)\nassert(find_First_Missing(array: [0, 1, 2, 6, 9]) == 3)\nassert(find_First_Missing(array: [2, 3, 5, 8, 9]) == 0)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace all spaces in the given string with '%20'.\nfunc replace_spaces(string: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(string: \"My Name is Dawood\") == \"My%20Name%20is%20Dawood\")\nassert(replace_spaces(string: \"I am a Programmer\") == \"I%20am%20a%20Programmer\")\nassert(replace_spaces(string: \"I love Coding\") == \"I%20love%20Coding\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find even numbers from an array of numbers.\nfunc Split(list: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Split(list: [1, 2, 3, 4, 5]) == [2, 4])\nassert(Split(list: [4, 5, 6, 7, 8, 0, 1]) == [4, 6, 8, 0])\nassert(Split(list: [8, 12, 15, 19]) == [8, 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find smallest number in an array.\nfunc smallest_num(xs: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(smallest_num(xs: [10, 20, 1, 45, 99]) == 1)\nassert(smallest_num(xs: [1, 2, 3]) == 1)\nassert(smallest_num(xs: [45, 46, 50, 60]) == 45)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunc get_coordinates(test_tup: (Int, Int)) -> [[Int]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_coordinates(test_tup: (3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]])\nassert(get_coordinates(test_tup: (4, 5)) == [[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]])\nassert(get_coordinates(test_tup: (5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunc replace_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_spaces(text: \"Jumanji The Jungle\") == \"Jumanji_The_Jungle\")\nassert(replace_spaces(text: \"The_Avengers\") == \"The Avengers\")\nassert(replace_spaces(text: \"Fast and Furious\") == \"Fast_and_Furious\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to move all zeroes to the end of the given array.\nfunc move_zero(num_list: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(move_zero(num_list: [1, 0, 2, 0, 3, 4]) == [1, 2, 3, 4, 0, 0])\nassert(move_zero(num_list: [2, 3, 2, 0, 0, 4, 0, 5, 0]) == [2, 3, 2, 4, 5, 0, 0, 0, 0])\nassert(move_zero(num_list: [0, 1, 0, 1, 1]) == [1, 1, 1, 0, 0])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of xor of all pairs of numbers in the given array.\nfunc pair_xor_Sum(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_xor_Sum(arr: [5, 9, 7, 6], n: 4) == 47)\nassert(pair_xor_Sum(arr: [7, 3, 5], n: 3) == 12)\nassert(pair_xor_Sum(arr: [7, 3], n: 2) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort the given array.\nfunc heap_sort(iterable: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(heap_sort(iterable: [1, 3, 5, 7, 9, 2, 4, 6, 8, 0]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\nassert(heap_sort(iterable: [25, 35, 22, 85, 14, 65, 75, 25, 58]) == [14, 22, 25, 25, 35, 58, 65, 75, 85])\nassert(heap_sort(iterable: [7, 1, 9, 5]) == [1, 5, 7, 9])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given amount has no profit and no loss\nfunc noprofit_noloss(actual_cost: Int, sale_amount: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(noprofit_noloss(actual_cost: 1500, sale_amount: 1200) == false)\nassert(noprofit_noloss(actual_cost: 100, sale_amount: 100) == true)\nassert(noprofit_noloss(actual_cost: 2000, sale_amount: 5000) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunc wind_chill(v: Int, t: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(wind_chill(v: 120, t: 35) == 40)\nassert(wind_chill(v: 40, t: 20) == 19)\nassert(wind_chill(v: 10, t: 8) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunc sample_nam(sample_names: [String]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sample_nam(sample_names: [\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]) == 16)\nassert(sample_nam(sample_names: [\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]) == 10)\nassert(sample_nam(sample_names: [\"abcd\", \"Python\", \"abba\", \"aba\"]) == 6)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the maximum difference between available pairs in the given tuple array.\nfunc max_difference(test_list: [(Int, Int)]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_difference(test_list: [(3, 5), (1, 7), (10, 3), (1, 2)]) == 7)\nassert(max_difference(test_list: [(4, 6), (2, 17), (9, 13), (11, 12)]) == 15)\nassert(max_difference(test_list: [(12, 35), (21, 27), (13, 23), (41, 22)]) == 23)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove the parenthesis and what is inbetween them from a string.\nfunc remove_parenthesis(items: [String]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_parenthesis(items: [\"python (chrome)\"]) == \"python\")\nassert(remove_parenthesis(items: [\"string(.abc)\"]) == \"string\")\nassert(remove_parenthesis(items: [\"alpha(num)\"]) == \"alpha\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth nonagonal number.\nfunc is_nonagonal(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_nonagonal(n: 10) == 325)\nassert(is_nonagonal(n: 15) == 750)\nassert(is_nonagonal(n: 18) == 1089)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "swift",
+    "prompt": "\n/// Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunc text_match_wordz_middle(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_wordz_middle(text: \"pythonzabc.\") == true)\nassert(text_match_wordz_middle(text: \"zxyabc.\") == false)\nassert(text_match_wordz_middle(text: \"  lang  .\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to reverse an array upto a given position.\nfunc reverse_Array_Upto_K(input: [Int], k: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(reverse_Array_Upto_K(input: [1, 2, 3, 4, 5, 6], k: 4) == [4, 3, 2, 1, 5, 6])\nassert(reverse_Array_Upto_K(input: [4, 5, 6, 7], k: 2) == [5, 4, 6, 7])\nassert(reverse_Array_Upto_K(input: [9, 8, 7, 6, 5], k: 3) == [7, 8, 9, 6, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort an array of tuples using the second value of each tuple.\nfunc subject_marks(subjectmarks: [(String, Int)]) -> [(String, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(subject_marks(subjectmarks: [(\"English\", 88), (\"Science\", 90), (\"Maths\", 97), (\"Social sciences\", 82)]) == [(\"Social sciences\", 82), (\"English\", 88), (\"Science\", 90), (\"Maths\", 97)])\nassert(subject_marks(subjectmarks: [(\"Telugu\", 49), (\"Hindhi\", 54), (\"Social\", 33)]) == [(\"Social\", 33), (\"Telugu\", 49), (\"Hindhi\", 54)])\nassert(subject_marks(subjectmarks: [(\"Physics\", 96), (\"Chemistry\", 97), (\"Biology\", 45)]) == [(\"Biology\", 45), (\"Physics\", 96), (\"Chemistry\", 97)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "swift",
+    "prompt": "\nextension [Int]: Error {}\n        \n/// Write a function to flatten an array and sum all of its elements.\nfunc recursive_list_sum(data_list: [Result<Int, [Int]>]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(recursive_list_sum(data_list: [.success(1), .success(2), .failure([3, 4]), .failure([5, 6])]) == 21)\nassert(recursive_list_sum(data_list: [.success(7), .success(10), .failure([15, 14]), .failure([19, 41])]) == 106)\nassert(recursive_list_sum(data_list: [.success(10), .success(20), .failure([30, 40]), .failure([50, 60])]) == 210)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of positive numbers in an array.\nfunc pos_count(list: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pos_count(list: [1, -2, 3, -4]) == 2)\nassert(pos_count(list: [3, 4, 5, -1]) == 3)\nassert(pos_count(list: [1, 2, 3, 4]) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the number of ways to partition a set of Bell numbers.\nfunc bell_number(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(bell_number(n: 2) == 2)\nassert(bell_number(n: 10) == 115975)\nassert(bell_number(n: 56) == 6775685320645824322581483068371419745979053216268760300)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given array is monotonic or not.\nfunc is_Monotonic(A: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Monotonic(A: [6, 5, 4, 4]) == true)\nassert(is_Monotonic(A: [1, 2, 2, 3]) == true)\nassert(is_Monotonic(A: [1, 3, 2]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether an array contains the given subarray or not.\nfunc is_sublist(l: [Int], s: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [3, 7]) == false)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [4, 3]) == true)\nassert(is_sublist(l: [2, 4, 3, 5, 7], s: [1, 6]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the two numbers differ at one bit position only or not.\nfunc differ_At_One_Bit_Pos(a: Int, b: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(differ_At_One_Bit_Pos(a: 13, b: 9) == true)\nassert(differ_At_One_Bit_Pos(a: 15, b: 8) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 4) == false)\nassert(differ_At_One_Bit_Pos(a: 2, b: 3) == true)\nassert(differ_At_One_Bit_Pos(a: 5, b: 1) == true)\nassert(differ_At_One_Bit_Pos(a: 1, b: 5) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find whether all the given arrays have equal length or not.\nfunc get_equal(Input: [[Int]]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_equal(Input: [[11, 22, 33], [44, 55, 66]]) == true)\nassert(get_equal(Input: [[1, 2, 3], [4, 5, 6, 7]]) == false)\nassert(get_equal(Input: [[1, 2], [3, 4]]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort an array of elements.\nfunc comb_sort(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(comb_sort(nums: [5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79])\nassert(comb_sort(nums: [41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41])\nassert(comb_sort(nums: [99, 15, 13, 47]) == [13, 15, 47, 99])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunc add_dict_to_tuple(test_tup: (Int, Int, Int), test_dict: [String : Int]) -> (Int, Int, Int, [String : Int]) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_dict_to_tuple(test_tup: (4, 5, 6), test_dict: [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]) == (4, 5, 6, [\"MSAM\" : 1, \"is\" : 2, \"best\" : 3]))\nassert(add_dict_to_tuple(test_tup: (1, 2, 3), test_dict: [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]) == (1, 2, 3, [\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4]))\nassert(add_dict_to_tuple(test_tup: (8, 9, 10), test_dict: [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]) == (8, 9, 10, [\"POS\" : 3, \"is\" : 4, \"Okay\" : 5]))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "swift",
+    "prompt": "\n/// Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunc maxAverageOfPath(cost: [[Int]]) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(maxAverageOfPath(cost: [[1, 2, 3], [6, 5, 4], [7, 3, 9]]) == 5.2)\nassert(maxAverageOfPath(cost: [[2, 3, 4], [7, 6, 5], [8, 4, 10]]) == 6.2)\nassert(maxAverageOfPath(cost: [[3, 4, 5], [8, 7, 6], [9, 5, 11]]) == 7.2)\nassert(maxAverageOfPath(cost: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == 5.8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_722_filter_data",
+    "language": "swift",
+    "prompt": "\n/// The input is given as - a dictionary with a student name as a key and a tuple of float (student_height, student_weight) as a value, - minimal height, - minimal weight. Write a function to filter students that have height and weight above the minimum.\nfunc filter_data(students: [String : (Double, Int)], h: Double, w: Int) -> [String : (Double, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_722_filter_data.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 6.0, w: 70) == [\"Cierra Vega\" : (6.2, 70)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.9, w: 67) == [\"Cierra Vega\" : (6.2, 70), \"Kierra Gentry\" : (6.0, 68)])\nassert(filter_data(students: [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)], h: 5.7, w: 64) == [\"Cierra Vega\" : (6.2, 70), \"Alden Cantrell\" : (5.9, 65), \"Kierra Gentry\" : (6.0, 68), \"Pierre Cox\" : (5.8, 66)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "swift",
+    "prompt": "\n/// The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunc count_same_pair(nums1: [Int], nums2: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_same_pair(nums1: [1, 2, 3, 4, 5, 6, 7, 8], nums2: [2, 2, 3, 1, 2, 6, 7, 9]) == 4)\nassert(count_same_pair(nums1: [0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 11)\nassert(count_same_pair(nums1: [2, 4, -6, -9, 11, -12, 14, -5, 17], nums2: [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]) == 1)\nassert(count_same_pair(nums1: [0, 1, 1, 2], nums2: [0, 1, 2, 2]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunc power_base_sum(base: Int, power: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power_base_sum(base: 2, power: 100) == 115)\nassert(power_base_sum(base: 8, power: 10) == 37)\nassert(power_base_sum(base: 8, power: 15) == 62)\nassert(power_base_sum(base: 3, power: 3) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "swift",
+    "prompt": "\n/// Write a function to extract values between quotation marks \" \" of the given string.\nfunc extract_quotation(text1: String) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_quotation(text1: \"Cortex \\\"A53\\\" Based \\\"multi\\\" tasking \\\"Processor\\\"\") == [\"A53\", \"multi\", \"Processor\"])\nassert(extract_quotation(text1: \"Cast your \\\"favorite\\\" entertainment \\\"apps\\\"\") == [\"favorite\", \"apps\"])\nassert(extract_quotation(text1: \"Watch content \\\"4k Ultra HD\\\" resolution with \\\"HDR 10\\\" Support\") == [\"4k Ultra HD\", \"HDR 10\"])\nassert(extract_quotation(text1: \"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\") == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "swift",
+    "prompt": "\n/// Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunc multiply_elements(test_tup: [Int]) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(multiply_elements(test_tup: [1, 5, 7, 8, 10]) == [5, 35, 56, 80])\nassert(multiply_elements(test_tup: [2, 4, 5, 6, 7]) == [8, 20, 30, 42])\nassert(multiply_elements(test_tup: [12, 13, 14, 9, 15]) == [156, 182, 126, 135])\nassert(multiply_elements(test_tup: [12]) == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunc sum_list(lst1: [Int], lst2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_list(lst1: [10, 20, 30], lst2: [15, 25, 35]) == [25, 45, 65])\nassert(sum_list(lst1: [1, 2, 3], lst2: [5, 6, 7]) == [6, 8, 10])\nassert(sum_list(lst1: [15, 20, 30], lst2: [15, 45, 75]) == [30, 65, 105])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the given number can be represented as the difference of two squares or not.\nfunc dif_Square(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(dif_Square(n: 5) == true)\nassert(dif_Square(n: 10) == false)\nassert(dif_Square(n: 15) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove consecutive duplicates of a given array.\nfunc consecutive_duplicates(nums: [AnyHashable]) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(consecutive_duplicates(nums: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4])\nassert(consecutive_duplicates(nums: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [10, 15, 19, 18, 17, 26, 17, 18, 10])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [\"a\", \"b\", \"c\", \"d\"])\nassert(consecutive_duplicates(nums: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]) == [\"a\", \"b\", \"c\", \"d\", \"a\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunc lateralsurface_cone(r: Int, h: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lateralsurface_cone(r: 5, h: 12) == 204.20352248333654)\nassert(lateralsurface_cone(r: 10, h: 15) == 566.3586699569488)\nassert(lateralsurface_cone(r: 19, h: 17) == 1521.8090132193388)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "swift",
+    "prompt": "\n/// Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunc replace_specialchar(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(replace_specialchar(text: \"Python language, Programming language.\") == \"Python:language::Programming:language:\")\nassert(replace_specialchar(text: \"a b c,d e f\") == \"a:b:c:d:e:f\")\nassert(replace_specialchar(text: \"ram reshma,ram rahim\") == \"ram:reshma:ram:rahim\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunc find_first_occurrence(A: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_first_occurrence(A: [2, 5, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 1)\nassert(find_first_occurrence(A: [2, 3, 5, 5, 6, 6, 8, 9, 9, 9], x: 5) == 2)\nassert(find_first_occurrence(A: [2, 4, 1, 5, 6, 6, 8, 9, 9, 9], x: 6) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunc sum_Of_Subarray_Prod(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3]) == 20)\nassert(sum_Of_Subarray_Prod(arr: [1, 2]) == 5)\nassert(sum_Of_Subarray_Prod(arr: [1, 2, 3, 4]) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunc toggle_middle_bits(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(toggle_middle_bits(n: 9) == 15)\nassert(toggle_middle_bits(n: 10) == 12)\nassert(toggle_middle_bits(n: 11) == 13)\nassert(toggle_middle_bits(n: 65) == 127)\nassert(toggle_middle_bits(n: 77) == 115)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "swift",
+    "prompt": "\n/// Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/swiftthon-exercises/data-structures-and-algorithms/swiftthon-data-structure-exercise-24.php\nfunc left_insertion(a: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(left_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(left_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given string is starting with a vowel or not using regex.\nfunc check_str(string: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_str(string: \"annie\") == true)\nassert(check_str(string: \"dawood\") == false)\nassert(check_str(string: \"Else\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/swiftthon-exercises/data-structures-and-algorithms/swiftthon-recursion-exercise-9.php\nfunc geometric_sum(n: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(geometric_sum(n: 7) == 1.9921875)\nassert(geometric_sum(n: 4) == 1.9375)\nassert(geometric_sum(n: 8) == 1.99609375)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunc find_Index(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Index(n: 2) == 4)\nassert(find_Index(n: 3) == 14)\nassert(find_Index(n: 4) == 45)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/swiftthon-convert-tuple-to-adjacent-pair-dictionary/\nfunc tuple_to_dict(test_tup: (Int, Int, Int, Int, Int, Int)) -> [Int : Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_to_dict(test_tup: (1, 5, 7, 10, 13, 5)) == [1 : 5, 7 : 10, 13 : 5])\nassert(tuple_to_dict(test_tup: (1, 2, 3, 4, 5, 6)) == [1 : 2, 3 : 4, 5 : 6])\nassert(tuple_to_dict(test_tup: (7, 8, 9, 10, 11, 12)) == [7 : 8, 9 : 10, 11 : 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether all the characters are same or not.\nfunc all_Characters_Same(s: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(all_Characters_Same(s: \"python\") == false)\nassert(all_Characters_Same(s: \"aaa\") == true)\nassert(all_Characters_Same(s: \"data\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "swift",
+    "prompt": "\n/// Write a function to caluclate the area of a tetrahedron.\nfunc area_tetrahedron(side: Int) -> Double {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(area_tetrahedron(side: 3) == 15.588457268119894)\nassert(area_tetrahedron(side: 20) == 692.8203230275509)\nassert(area_tetrahedron(side: 10) == 173.20508075688772)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "swift",
+    "prompt": "\n/// Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/swiftthon-program-right-rotate-array-n/\nfunc rotate_right(list: [Int], m: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 3) == [8, 9, 10, 1, 2, 3, 4, 5, 6, 7])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 2) == [9, 10, 1, 2, 3, 4, 5, 6, 7, 8])\nassert(rotate_right(list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], m: 5) == [6, 7, 8, 9, 10, 1, 2, 3, 4, 5])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/swiftthon-exercises/lambda/swiftthon-lambda-exercise-24.php\nfunc divisible_by_digits(startnum: Int, endnum: Int) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisible_by_digits(startnum: 1, endnum: 22) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22])\nassert(divisible_by_digits(startnum: 1, endnum: 15) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15])\nassert(divisible_by_digits(startnum: 20, endnum: 25) == [22, 24])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return nil if the angle is larger than 360 degrees.\nfunc sector_area(r: Int, a: Int) -> Double? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sector_area(r: 4, a: 45) == 6.283185307179586)\nassert(sector_area(r: 9, a: 45) == 31.808625617596654)\nassert(sector_area(r: 9, a: 361) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunc lcs_of_three(X: String, Y: String, Z: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(lcs_of_three(X: \"AGGT12\", Y: \"12TXAYB\", Z: \"12XBA\") == 2)\nassert(lcs_of_three(X: \"Reels\", Y: \"Reelsfor\", Z: \"ReelsforReels\") == 5)\nassert(lcs_of_three(X: \"abcd1e2\", Y: \"bc12ea\", Z: \"bd1ea\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to put spaces between words starting with capital letters in a given string.\nfunc capital_words_spaces(str1: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(capital_words_spaces(str1: \"Python\") == \"Python\")\nassert(capital_words_spaces(str1: \"PythonProgrammingExamples\") == \"Python Programming Examples\")\nassert(capital_words_spaces(str1: \"GetReadyToBeCodingFreak\") == \"Get Ready To Be Coding Freak\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "swift",
+    "prompt": "\n/// Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/swiftthon-sort-numeric-strings-in-a-array/\nfunc sort_numeric_strings(nums_str: [String]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sort_numeric_strings(nums_str: [\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]) == [-500, -12, 0, 4, 7, 12, 45, 100, 200])\nassert(sort_numeric_strings(nums_str: [\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]) == [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9])\nassert(sort_numeric_strings(nums_str: [\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]) == [1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether it follows the sequence given in the patterns array.\nfunc is_samepatterns(colors: [String], patterns: [String]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_samepatterns(colors: [\"red\", \"green\", \"green\"], patterns: [\"a\", \"b\", \"b\"]) == true)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\", \"b\"]) == false)\nassert(is_samepatterns(colors: [\"red\", \"green\", \"greenn\"], patterns: [\"a\", \"b\"]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to add the given tuple to the given array.\nfunc add_tuple(test_list: [Int], test_tup: (Int, Int)) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(add_tuple(test_list: [5, 6, 7], test_tup: (9, 10)) == [5, 6, 7, 9, 10])\nassert(add_tuple(test_list: [6, 7, 8], test_tup: (10, 11)) == [6, 7, 8, 10, 11])\nassert(add_tuple(test_list: [7, 8, 9], test_tup: (11, 12)) == [7, 8, 9, 11, 12])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunc check_min_heap(arr: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_min_heap(arr: [1, 2, 3, 4, 5, 6]) == true)\nassert(check_min_heap(arr: [2, 3, 4, 5, 10, 15]) == true)\nassert(check_min_heap(arr: [2, 10, 4, 5, 3, 15]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunc jacobsthal_num(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(jacobsthal_num(n: 5) == 11)\nassert(jacobsthal_num(n: 2) == 1)\nassert(jacobsthal_num(n: 4) == 5)\nassert(jacobsthal_num(n: 13) == 2731)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find minimum k records from tuple array. https://www.geeksforgeeks.org/swiftthon-find-minimum-k-records-from-tuple-array/ - in this case a verbatim coswift of test cases\nfunc min_k(test_list: [(String, Int)], K: Int) -> [(String, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(min_k(test_list: [(\"Manjeet\", 10), (\"Akshat\", 4), (\"Akash\", 2), (\"Nikhil\", 8)], K: 2) == [(\"Akash\", 2), (\"Akshat\", 4)])\nassert(min_k(test_list: [(\"Sanjeev\", 11), (\"Angat\", 5), (\"Akash\", 3), (\"Nepin\", 9)], K: 3) == [(\"Akash\", 3), (\"Angat\", 5), (\"Nepin\", 9)])\nassert(min_k(test_list: [(\"tanmay\", 14), (\"Amer\", 11), (\"Ayesha\", 9), (\"SKD\", 16)], K: 1) == [(\"Ayesha\", 9)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "swift",
+    "prompt": "\n/// We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunc extract_index_list(l1: [Int], l2: [Int], l3: [Int]) -> [AnyHashable] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 7])\nassert(extract_index_list(l1: [1, 1, 3, 4, 5, 6, 7], l2: [0, 1, 2, 3, 4, 6, 5], l3: [0, 1, 2, 3, 4, 6, 7]) == [1, 6])\nassert(extract_index_list(l1: [1, 1, 3, 4, 6, 5, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [1, 5])\nassert(extract_index_list(l1: [1, 2, 3, 4, 6, 6, 6], l2: [0, 1, 2, 3, 4, 5, 7], l3: [0, 1, 2, 3, 4, 5, 7]) == [] as [AnyHashable])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "swift",
+    "prompt": "\nextension Double: Error {}\n        \n/// Write a function to find the second smallest number in an array.\nfunc second_smallest(numbers: [Result<Int, Double>]) -> Double? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(second_smallest(numbers: [.success(1), .success(2), .success(-8), .success(-2), .success(0), .success(-2)]) == -2)\nassert(second_smallest(numbers: [.success(1), .success(1), .failure(-0.5), .success(0), .success(2), .success(-2), .success(-2)]) == -0.5)\nassert(second_smallest(numbers: [.success(2), .success(2)]) == nil)\nassert(second_smallest(numbers: [.success(2), .success(2), .success(2)]) == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/swiftthon-exercises/re/swiftthon-re-exercise-3.php\nfunc text_match_zero_one(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_zero_one(text: \"ac\") == false)\nassert(text_match_zero_one(text: \"dc\") == false)\nassert(text_match_zero_one(text: \"abbbba\") == true)\nassert(text_match_zero_one(text: \"dsabbbba\") == true)\nassert(text_match_zero_one(text: \"asbbbba\") == false)\nassert(text_match_zero_one(text: \"abaaa\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/swiftthon-program-to-count-the-pairs-of-reverse-strings/\nfunc count_reverse_pairs(test_list: [String]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_reverse_pairs(test_list: [\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]) == 2)\nassert(count_reverse_pairs(test_list: [\"geeks\", \"best\", \"for\", \"skeeg\"]) == 1)\nassert(count_reverse_pairs(test_list: [\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether a given string is a decimal number with a precision of 2.\nfunc is_decimal(num: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_decimal(num: \"123.11\") == true)\nassert(is_decimal(num: \"e666.86\") == false)\nassert(is_decimal(num: \"3.124587\") == false)\nassert(is_decimal(num: \"1.11\") == true)\nassert(is_decimal(num: \"1.1.11\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find tuples which have all elements divisible by k from the given array of tuples.\nfunc find_tuples(test_list: [(Int, Int, Int)], K: Int) -> [(Int, Int, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_tuples(test_list: [(6, 24, 12), (7, 9, 6), (12, 18, 21)], K: 6) == [(6, 24, 12)])\nassert(find_tuples(test_list: [(5, 25, 30), (4, 2, 3), (7, 8, 9)], K: 5) == [(5, 25, 30)])\nassert(find_tuples(test_list: [(7, 9, 16), (8, 16, 4), (19, 17, 18)], K: 4) == [(8, 16, 4)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether an array of numbers contains only one distinct element or not.\nfunc unique_Element(arr: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(unique_Element(arr: [1, 1, 1]) == true)\nassert(unique_Element(arr: [1, 2, 1, 2]) == false)\nassert(unique_Element(arr: [1, 2, 3, 4, 5]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunc check_monthnumber_number(monthnum3: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_monthnumber_number(monthnum3: 6) == true)\nassert(check_monthnumber_number(monthnum3: 2) == false)\nassert(check_monthnumber_number(monthnum3: 12) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunc find_min_diff(arr: [Int], n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_min_diff(arr: [1, 5, 3, 19, 18, 25], n: 6) == 1)\nassert(find_min_diff(arr: [4, 3, 2, 6], n: 4) == 1)\nassert(find_min_diff(arr: [30, 5, 20, 9], n: 4) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count number of digits in a given string.\nfunc number_ctr(str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(number_ctr(str: \"program2bedone\") == 1)\nassert(number_ctr(str: \"3wonders\") == 1)\nassert(number_ctr(str: \"123\") == 3)\nassert(number_ctr(str: \"3wond-1ers2\") == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunc is_polite(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_polite(n: 7) == 11)\nassert(is_polite(n: 4) == 7)\nassert(is_polite(n: 9) == 13)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "swift",
+    "prompt": "\n/// Write a function to return an array of all pairs of consecutive items in a given array.\nfunc pair_wise(l1: [Int]) -> [(Int, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pair_wise(l1: [1, 1, 2, 3, 3, 4, 4, 5]) == [(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)])\nassert(pair_wise(l1: [1, 5, 7, 9, 10]) == [(1, 5), (5, 7), (7, 9), (9, 10)])\nassert(pair_wise(l1: [5, 1, 9, 7, 10]) == [(5, 1), (1, 9), (9, 7), (7, 10)])\nassert(pair_wise(l1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunc get_pairs_count(arr: [Int], sum: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_pairs_count(arr: [1, 1, 1, 1], sum: 2) == 6)\nassert(get_pairs_count(arr: [1, 5, 7, -1, 5], sum: 6) == 3)\nassert(get_pairs_count(arr: [1, -2, 3], sum: 1) == 1)\nassert(get_pairs_count(arr: [-1, -2, 3], sum: -3) == 1)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to get the difference between two arrays.\nfunc Diff(li1: [Int], li2: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Diff(li1: [10, 15, 20, 25, 30, 35, 40], li2: [25, 40, 35]) == [10, 20, 30, 15])\nassert(Diff(li1: [1, 2, 3, 4, 5], li2: [6, 7, 1]) == [2, 3, 4, 5, 6, 7])\nassert(Diff(li1: [1, 2, 3], li2: [6, 7, 1]) == [2, 3, 6, 7])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of fourth power of first n odd natural numbers.\nfunc odd_num_sum(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_num_sum(n: 2) == 82)\nassert(odd_num_sum(n: 3) == 707)\nassert(odd_num_sum(n: 4) == 3108)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunc check_expression(exp: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_expression(exp: \"{()}[{}]\") == true)\nassert(check_expression(exp: \"{()}[{]\") == false)\nassert(check_expression(exp: \"{()}[{}][]({})\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all the words with k length in the given string.\nfunc remove_length(test_str: String, K: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_length(test_str: \"The person is most value tet\", K: 3) == \"person is most value\")\nassert(remove_length(test_str: \"If you told me about this ok\", K: 4) == \"If you me about ok\")\nassert(remove_length(test_str: \"Forces of darkeness is come into the play\", K: 4) == \"Forces of darkeness is the\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the occurrence and position of the substrings within a string. Return nil if there is no match.\nfunc occurance_substring(text: String, pattern: String) -> (String, Int, Int)? {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(occurance_substring(text: \"python programming, python language\", pattern: \"python\") == (\"python\", 0, 6))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"programming\") == (\"programming\", 7, 18))\nassert(occurance_substring(text: \"python programming,programming language\", pattern: \"language\") == (\"language\", 31, 39))\nassert(occurance_substring(text: \"c++ programming, c++ language\", pattern: \"python\") == nil)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether every odd index contains odd numbers of a given array.\nfunc odd_position(nums: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_position(nums: [2, 1, 4, 3, 6, 7, 6, 3]) == true)\nassert(odd_position(nums: [4, 1, 2]) == true)\nassert(odd_position(nums: [1, 2, 3]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "swift",
+    "prompt": "\n/// Write a function to count those characters which have vowels as their neighbors in the given string.\nfunc count_vowels(test_str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_vowels(test_str: \"bestinstareels\") == 7)\nassert(count_vowels(test_str: \"partofthejourneyistheend\") == 12)\nassert(count_vowels(test_str: \"amazonprime\") == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of non-repeated elements in a given array.\nfunc find_sum(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_sum(arr: [1, 2, 3, 1, 1, 4, 5, 6]) == 21)\nassert(find_sum(arr: [1, 10, 9, 4, 2, 10, 10, 45, 4]) == 71)\nassert(find_sum(arr: [12, 10, 9, 45, 2, 10, 10, 45, 10]) == 78)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "swift",
+    "prompt": "\n/// Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunc pack_consecutive_duplicates(list1: [AnyHashable]) -> [[AnyHashable]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(pack_consecutive_duplicates(list1: [0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]) == [[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]])\nassert(pack_consecutive_duplicates(list1: [10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]) == [[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]])\nassert(pack_consecutive_duplicates(list1: [\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]) == [[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find whether a number is divisible by 11.\nfunc is_Diff(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_Diff(n: 12345) == false)\nassert(is_Diff(n: 1212112) == true)\nassert(is_Diff(n: 1212) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the combinations of sums with tuples in the given tuple array. https://www.geeksforgeeks.org/swiftthon-combinations-of-sum-with-tuples-in-tuple-array/\nfunc find_combinations(test_list: [(Int, Int)]) -> [(Int, Int)] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_combinations(test_list: [(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)])\nassert(find_combinations(test_list: [(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)])\nassert(find_combinations(test_list: [(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the count of divisors is even. https://www.w3resource.com/swiftthon-exercises/basic/swiftthon-basic-1-exercise-24.php\nfunc count_divisors(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_divisors(n: 10) == true)\nassert(count_divisors(n: 100) == false)\nassert(count_divisors(n: 125) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunc odd_length_sum(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(odd_length_sum(arr: [1, 2, 4]) == 14)\nassert(odd_length_sum(arr: [1, 2, 1, 2]) == 15)\nassert(odd_length_sum(arr: [1, 7]) == 8)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunc rgb_to_hsv(r: Int, g: Int, b: Int) -> [Double] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(rgb_to_hsv(r: 255, g: 255, b: 255) == [0.0, 0.0, 100.0])\nassert(rgb_to_hsv(r: 0, g: 215, b: 0) == [120.0, 100.0, 84.31372549019608])\nassert(rgb_to_hsv(r: 10, g: 215, b: 110) == [149.26829268292684, 95.34883720930233, 84.31372549019608])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the product of first even and odd number of a given array.\nfunc mul_even_odd(list1: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(mul_even_odd(list1: [1, 3, 5, 7, 4, 1, 6, 8]) == 4)\nassert(mul_even_odd(list1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == 2)\nassert(mul_even_odd(list1: [1, 5, 7, 9, 10]) == 10)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert tuple string to integer tuple.\nfunc tuple_str_int(test_str: String) -> (Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tuple_str_int(test_str: \"(7, 8, 9)\") == (7, 8, 9))\nassert(tuple_str_int(test_str: \"(1, 2, 3)\") == (1, 2, 3))\nassert(tuple_str_int(test_str: \"(4, 5, 6)\") == (4, 5, 6))\nassert(tuple_str_int(test_str: \"(7, 81, 19)\") == (7, 81, 19))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "swift",
+    "prompt": "\n/// Write a function to locate the right insertion point for a specified value in sorted order.\nfunc right_insertion(a: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(right_insertion(a: [1, 2, 4, 5], x: 6) == 4)\nassert(right_insertion(a: [1, 2, 4, 5], x: 3) == 2)\nassert(right_insertion(a: [1, 2, 4, 5], x: 7) == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an a followed by three 'b'.\nfunc text_match_three(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_match_three(text: \"ac\") == false)\nassert(text_match_three(text: \"dc\") == false)\nassert(text_match_three(text: \"abbbba\") == true)\nassert(text_match_three(text: \"caacabbbba\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "swift",
+    "prompt": "\n/// Write a function to create a new tuple from the given string and array.\nfunc new_tuple(test_list: [String], test_str: String) -> (String, String, String) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(new_tuple(test_list: [\"WEB\", \"is\"], test_str: \"best\") == (\"WEB\", \"is\", \"best\"))\nassert(new_tuple(test_list: [\"We\", \"are\"], test_str: \"Developers\") == (\"We\", \"are\", \"Developers\"))\nassert(new_tuple(test_list: [\"Part\", \"is\"], test_str: \"Wrong\") == (\"Part\", \"is\", \"Wrong\"))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether every even index contains even numbers of a given array.\nfunc even_position(nums: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(even_position(nums: [3, 2, 1]) == false)\nassert(even_position(nums: [1, 2, 3]) == false)\nassert(even_position(nums: [2, 1, 4]) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove tuples from the given tuple.\nfunc remove_nested(test_tup: AnyHashable) -> (Int, Int, Int, Int) {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_nested(test_tup: (1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10))\nassert(remove_nested(test_tup: (2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12))\nassert(remove_nested(test_tup: (3, 7, 9, (6, 8), (5, 12), 12)) == (3, 7, 9, 12))",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of arrays in a given number of arrays.\nfunc count_list(input_list: [[Int]]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_list(input_list: [[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4)\nassert(count_list(input_list: [[1, 2], [2, 3], [4, 5]]) == 3)\nassert(count_list(input_list: [[1, 0], [2, 0]]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the last position of an element in a sorted array.\nfunc last(arr: [Int], x: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(last(arr: [1, 2, 3], x: 1) == 0)\nassert(last(arr: [1, 1, 1, 2, 3, 4], x: 1) == 2)\nassert(last(arr: [2, 3, 2, 3, 6, 8, 9], x: 3) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "swift",
+    "prompt": "\n/// Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunc text_starta_endb(text: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(text_starta_endb(text: \"aabbbb\") == true)\nassert(text_starta_endb(text: \"aabAbbbc\") == false)\nassert(text_starta_endb(text: \"accddbbjjj\") == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "swift",
+    "prompt": "\n/// Write function to find the sum of all items in the given dictionary.\nfunc return_sum(dict: [String : Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(return_sum(dict: [\"a\" : 100, \"b\" : 200, \"c\" : 300]) == 600)\nassert(return_sum(dict: [\"a\" : 25, \"b\" : 18, \"c\" : 45]) == 88)\nassert(return_sum(dict: [\"a\" : 36, \"b\" : 39, \"c\" : 49]) == 124)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of all odd natural numbers within the range l and r.\nfunc sum_in_range(l: Int, r: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sum_in_range(l: 2, r: 5) == 8)\nassert(sum_in_range(l: 5, r: 7) == 12)\nassert(sum_in_range(l: 7, r: 13) == 40)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the sum of an array.\nfunc _sum(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(_sum(arr: [1, 2, 3]) == 6)\nassert(_sum(arr: [15, 12, 13, 10]) == 50)\nassert(_sum(arr: [0, 1, 2]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "swift",
+    "prompt": "\n/// Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunc left_rotate(n: Int, d: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(left_rotate(n: 16, d: 2) == 64)\nassert(left_rotate(n: 10, d: 2) == 40)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 99, d: 3) == 792)\nassert(left_rotate(n: 1, d: 3) == 8)\nassert(left_rotate(n: 5, d: 3) == 40)\nassert(left_rotate(n: 29, d: 3) == 232)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to check whether the length of the word is odd or not.\nfunc word_len(s: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(word_len(s: \"Hadoop\") == false)\nassert(word_len(s: \"great\") == true)\nassert(word_len(s: \"structure\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "swift",
+    "prompt": "\n/// Write a function to remove all whitespaces from a string.\nfunc remove_all_spaces(text: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(remove_all_spaces(text: \"python  program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"python   programming    language\") == \"pythonprogramminglanguage\")\nassert(remove_all_spaces(text: \"python                     program\") == \"pythonprogram\")\nassert(remove_all_spaces(text: \"   python                     program\") == \"pythonprogram\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of equal numbers from three given integers.\nfunc test_three_equal(x: Int, y: Int, z: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(test_three_equal(x: 1, y: 1, z: 1) == 3)\nassert(test_three_equal(x: -1, y: -2, z: -3) == 0)\nassert(test_three_equal(x: 1, y: 2, z: 2) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunc count_rotation(arr: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(count_rotation(arr: [3, 2, 1]) == 1)\nassert(count_rotation(arr: [4, 5, 1, 2, 3]) == 2)\nassert(count_rotation(arr: [7, 8, 9, 1, 2, 3]) == 3)\nassert(count_rotation(arr: [1, 2, 3]) == 0)\nassert(count_rotation(arr: [1, 3, 2]) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunc is_perfect_square(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_perfect_square(n: 10) == false)\nassert(is_perfect_square(n: 36) == true)\nassert(is_perfect_square(n: 14) == false)\nassert(is_perfect_square(n: 196) == true)\nassert(is_perfect_square(n: 125) == false)\nassert(is_perfect_square(n: 15625) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the product of numbers in an array is even or not.\nfunc is_product_even(arr: [Int]) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_product_even(arr: [1, 2, 3]) == true)\nassert(is_product_even(arr: [1, 2, 1, 4]) == true)\nassert(is_product_even(arr: [1, 1]) == false)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "swift",
+    "prompt": "\n/// Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunc max_sum_list(lists: [[Int]]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_sum_list(lists: [[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]) == [10, 11, 12])\nassert(max_sum_list(lists: [[3, 2, 1], [6, 5, 4], [12, 11, 10]]) == [12, 11, 10])\nassert(max_sum_list(lists: [[2, 3, 1]]) == [2, 3, 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find maximum run of uppercase characters in the given string.\nfunc max_run_uppercase(test_str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(max_run_uppercase(test_str: \"GeMKSForGERksISBESt\") == 5)\nassert(max_run_uppercase(test_str: \"PrECIOusMOVemENTSYT\") == 6)\nassert(max_run_uppercase(test_str: \"GooGLEFluTTER\") == 4)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the first odd number in a given array of numbers.\nfunc first_odd(nums: [Int]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(first_odd(nums: [1, 3, 5]) == 1)\nassert(first_odd(nums: [2, 4, 1, 3]) == 1)\nassert(first_odd(nums: [8, 9, 1]) == 9)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if the given tuples contain the k or not.\nfunc check_K(test_tup: [Int], K: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_K(test_tup: [10, 4, 5, 6, 8], K: 6) == true)\nassert(check_K(test_tup: [1, 2, 3, 4, 5, 6], K: 7) == false)\nassert(check_K(test_tup: [7, 8, 9, 44, 11, 12], K: 11) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunc check_smaller(test_tup1: (Int, Int, Int), test_tup2: (Int, Int, Int)) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(check_smaller(test_tup1: (1, 2, 3), test_tup2: (2, 3, 4)) == false)\nassert(check_smaller(test_tup1: (4, 5, 6), test_tup2: (3, 4, 5)) == true)\nassert(check_smaller(test_tup1: (11, 12, 13), test_tup2: (10, 11, 12)) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth tetrahedral number.\nfunc tetrahedral_number(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(tetrahedral_number(n: 5) == 35)\nassert(tetrahedral_number(n: 6) == 56)\nassert(tetrahedral_number(n: 7) == 84)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunc get_Char(strr: String) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(get_Char(strr: \"abc\") == \"f\")\nassert(get_Char(strr: \"gfg\") == \"t\")\nassert(get_Char(strr: \"ab\") == \"c\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the nth number in the newman conway sequence.\nfunc sequence(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(sequence(n: 10) == 6)\nassert(sequence(n: 2) == 1)\nassert(sequence(n: 3) == 2)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find nth centered hexagonal number.\nfunc centered_hexagonal_number(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(centered_hexagonal_number(n: 10) == 271)\nassert(centered_hexagonal_number(n: 2) == 7)\nassert(centered_hexagonal_number(n: 9) == 217)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "swift",
+    "prompt": "\n/// Write a function to merge three dictionaries into a single dictionary.\nfunc merge_dictionaries_three(dict1: [String : String], dict2: [String : String], dict3: [String : String]) -> [String : String] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"O\" : \"Orange\", \"W\" : \"White\", \"B\" : \"Black\"]) == [\"B\" : \"Black\", \"R\" : \"Red\", \"P\" : \"Pink\", \"G\" : \"Green\", \"W\" : \"White\", \"O\" : \"Orange\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"G\" : \"Green\", \"W\" : \"White\"], dict3: [\"L\" : \"lavender\", \"B\" : \"Blue\"]) == [\"W\" : \"White\", \"P\" : \"Pink\", \"B\" : \"Black\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\"])\nassert(merge_dictionaries_three(dict1: [\"R\" : \"Red\", \"B\" : \"Black\", \"P\" : \"Pink\"], dict2: [\"L\" : \"lavender\", \"B\" : \"Blue\"], dict3: [\"G\" : \"Green\", \"W\" : \"White\"]) == [\"B\" : \"Black\", \"P\" : \"Pink\", \"R\" : \"Red\", \"G\" : \"Green\", \"L\" : \"lavender\", \"W\" : \"White\"])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "swift",
+    "prompt": "\n/// Write a function to get the frequency of all the elements in an array, returned as a dictionary.\nfunc freq_count(list1: [Int]) -> [Int : Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(freq_count(list1: [10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]) == [10 : 4, 20 : 4, 40 : 2, 50 : 2, 30 : 1])\nassert(freq_count(list1: [1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]) == [1 : 3, 2 : 2, 3 : 3, 4 : 3])\nassert(freq_count(list1: [5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]) == [10 : 1, 5 : 3, 6 : 2, 7 : 2, 4 : 2, 9 : 2])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find the closest smaller number than n.\nfunc closest_num(N: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(closest_num(N: 11) == 10)\nassert(closest_num(N: 7) == 6)\nassert(closest_num(N: 12) == 11)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find squares of individual elements in an array.\nfunc square_nums(nums: [Int]) -> [Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(square_nums(nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) == [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\nassert(square_nums(nums: [10, 20, 30]) == [100, 400, 900])\nassert(square_nums(nums: [12, 15]) == [144, 225])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the length of the longest word.\nfunc len_log(list1: [String]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(len_log(list1: [\"python\", \"PHP\", \"bigdata\"]) == 7)\nassert(len_log(list1: [\"a\", \"ab\", \"abc\"]) == 3)\nassert(len_log(list1: [\"small\", \"big\", \"tall\"]) == 5)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check if a string is present as a substring in a given array of string values.\nfunc find_substring(str1: [String], sub_str: String) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ack\") == true)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"abc\") == false)\nassert(find_substring(str1: [\"red\", \"black\", \"white\", \"green\", \"orange\"], sub_str: \"ange\") == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "swift",
+    "prompt": "\n/// Write a function to check whether the given number is undulating or not.\nfunc is_undulating(n: Int) -> Bool {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(is_undulating(n: 1212121) == true)\nassert(is_undulating(n: 1991) == false)\nassert(is_undulating(n: 121) == true)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "swift",
+    "prompt": "\n/// Write a function to calculate the value of 'a' to the power 'b'.\nfunc power(a: Int, b: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(power(a: 3, b: 4) == 81)\nassert(power(a: 2, b: 3) == 8)\nassert(power(a: 5, b: 5) == 3125)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "swift",
+    "prompt": "\n/// Given an array of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunc index_minimum(test_list: [(String, Int)]) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(index_minimum(test_list: [(\"Rash\", 143), (\"Manjeet\", 200), (\"Varsha\", 100)]) == \"Varsha\")\nassert(index_minimum(test_list: [(\"Yash\", 185), (\"Dawood\", 125), (\"Sanya\", 175)]) == \"Dawood\")\nassert(index_minimum(test_list: [(\"Sai\", 345), (\"Salman\", 145), (\"Ayesha\", 96)]) == \"Ayesha\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the length of the smallest array in an array of arrays.\nfunc Find_Min_Length(lst: [[Int]]) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(Find_Min_Length(lst: [[1], [1, 2]]) == 1)\nassert(Find_Min_Length(lst: [[1, 2], [1, 2, 3], [1, 2, 3, 4]]) == 2)\nassert(Find_Min_Length(lst: [[3, 3, 3], [4, 4, 4, 4]]) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the number of divisors of a given integer.\nfunc divisor(n: Int) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(divisor(n: 15) == 4)\nassert(divisor(n: 12) == 6)\nassert(divisor(n: 9) == 3)",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "swift",
+    "prompt": "\n/// Write a function to find frequency of each element in a flattened array of arrays, returned in a dictionary.\nfunc frequency_lists(list1: [[Int]]) -> [Int : Int] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(frequency_lists(list1: [[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]) == [1 : 1, 2 : 3, 3 : 1, 4 : 1, 5 : 2, 6 : 1, 7 : 1, 8 : 1, 9 : 1])\nassert(frequency_lists(list1: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]) == [1 : 1, 2 : 1, 3 : 1, 4 : 1, 5 : 1, 6 : 1, 7 : 1, 8 : 1, 9 : 1, 10 : 1, 11 : 1, 12 : 1])\nassert(frequency_lists(list1: [[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]) == [20 : 2, 30 : 2, 40 : 2, 17 : 1, 18 : 1, 16 : 1, 14 : 1, 13 : 1, 10 : 1])",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "swift",
+    "prompt": "\n/// Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunc decimal_to_binary(n: Int) -> String {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(decimal_to_binary(n: 8) == \"1000\")\nassert(decimal_to_binary(n: 18) == \"10010\")\nassert(decimal_to_binary(n: 7) == \"111\")",
+    "stop_tokens": [
+      "\n}"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "swift",
+    "prompt": "\n/// Write a swiftthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunc find_Rotations(str: String) -> Int {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "}\n\n\nfunc ==(left: [(Int, Int)], right: [(Int, Int)]) -> Bool {\n    if left.count != right.count {\n        return false\n    }\n    for (l, r) in zip(left, right) {\n        if l != r {\n            return false\n        }\n    }\n    return true\n}\n            \nassert(find_Rotations(str: \"aaaa\") == 1)\nassert(find_Rotations(str: \"ab\") == 2)\nassert(find_Rotations(str: \"abc\") == 3)",
     "stop_tokens": [
       "\n}"
     ]

--- a/prompts/mbpp-ts-keep.json
+++ b/prompts/mbpp-ts-keep.json
@@ -1,4317 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "ts",
-    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "ts",
-    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "ts",
-    "prompt": "//Write a function to check whether a specified list is sorted or not.\nfunction issort_list(list1: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "ts",
-    "prompt": "//Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional(test_list: [number, number][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "ts",
-    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "ts",
     "prompt": "//Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome(num: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest_palindrome;\n  assert.deepEqual(candidate(99),101);\n  assert.deepEqual(candidate(1221),1331);\n  assert.deepEqual(candidate(120),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum(arr: number[], n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "ts",
-    "prompt": "//Write a python function to find the first digit of a given number.\nfunction first_Digit(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "ts",
-    "prompt": "//Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1: string): string | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "ts",
-    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "ts",
-    "prompt": "//Write a python function to find smallest number in a list.\nfunction smallest_num(xs: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "ts",
-    "prompt": "//Write a python function to find nth bell number.\nfunction bell_Number(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "ts",
-    "prompt": "//Write a function to find cubes of individual elements in a list.\nfunction cube_nums(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "ts",
-    "prompt": "//Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "ts",
-    "prompt": "//Write a python function to find even numbers from a list of numbers.\nfunction Split(list: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples(test_list: [number, number, number][], K: number): [number, number, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "ts",
-    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given number is even or not.\nfunction is_Even(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of positive numbers in a list.\nfunction pos_count(list: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "ts",
-    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "ts",
-    "prompt": "//Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "ts",
-    "prompt": "//Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input: number[], k: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "ts",
-    "prompt": "//Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks(subjectmarks: [string, number][]): [string, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "ts",
-    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string: string, second_string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "ts",
-    "prompt": "//Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum(list1: number| number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "ts",
-    "prompt": "//Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "ts",
-    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter(dict: {[key: string]: number}, n: number): {[key: string]: number} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum(a: number[], size: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "ts",
-    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1: number[], array_nums2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts(list1: any[], L: number): any {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "ts",
-    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text: string, pattern: string): [string, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "ts",
-    "prompt": "//Write a python function to find the volume of a triangular prism.\nfunction find_Volume(l: number, b: number, h: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v: number, t: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "ts",
-    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same(s: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "ts",
-    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the length of the word is odd or not.\nfunction word_len(s: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element(list: string[], element: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "ts",
-    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "ts",
-    "prompt": "//Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear(test_tuple: [string, string, string]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given tuples contain the k or not.\nfunction check_K(test_tup: number[], K: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "ts",
-    "prompt": "//Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists(list1: number[], list2: number[], list3: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "ts",
-    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x: number, y: number, z: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "ts",
-    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "ts",
-    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "ts",
-    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number: number): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "ts",
-    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "ts",
-    "prompt": "//Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum(test_list: [string, number][]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "ts",
-    "prompt": "//Write a function to divide two lists element wise.\nfunction div_list(nums1: number[], nums2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "ts",
-    "prompt": "//Write a function to find the list with maximum length.\nfunction max_length_list(input_list: number[][]): [number, number[]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "ts",
-    "prompt": "//Write a python function to return the negative numbers in a list.\nfunction neg_nos(list1: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "ts",
-    "prompt": "//Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "ts",
-    "prompt": "//Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist(l: number[], s: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "ts",
-    "prompt": "//Write a function to subtract two lists element-wise.\nfunction sub_list(nums1: number[], nums2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x: number, y: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "ts",
-    "prompt": "//Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "ts",
-    "prompt": "//Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd(list1: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "ts",
-    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(list1: string[][]): string[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "ts",
-    "prompt": "//Write a python function to find the last digit of a given number.\nfunction last_Digit(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "ts",
-    "prompt": "//Write a function to convert a list to a string.\nfunction tup_string(tup1: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "ts",
-    "prompt": "//Write a function to remove all elements from a given list present in another list.\nfunction remove_elements(list1: number[], list2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1: number[], list2: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "ts",
-    "prompt": "//Write a python function to identify non-prime numbers.\nfunction is_not_prime(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val(listval: string| number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "ts",
-    "prompt": "//Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "ts",
-    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "ts",
-    "prompt": "//Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split(list: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "ts",
-    "prompt": "//Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product(nums1: number[], nums2: number[], N: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum(test_list: number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "ts",
-    "prompt": "//Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr: number[], n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "ts",
-    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n: number, d: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "ts",
-    "prompt": "//Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char(str1: string): string | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "ts",
-    "prompt": "//Write a python function to count inversions in an array.\nfunction get_Inv_Count(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "ts",
-    "prompt": "//Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "ts",
-    "prompt": "//Write a function to find whether all the given lists have equal length or not.\nfunction get_equal(Input: number[][]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "ts",
-    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "ts",
-    "prompt": "//Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list: string[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "ts",
-    "prompt": "//Write a python function to move all zeroes to the end of the given list.\nfunction move_zero(num_list: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "ts",
-    "prompt": "//Write a function to check if given list contains no duplicates.\nfunction check_distinct(test_tup: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost: number, sale_amount: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "ts",
-    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str: string, K: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "ts",
-    "prompt": "//Write a python function to count number of digits in a given string.\nfunction number_ctr(str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "ts",
-    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "ts",
-    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m: number, n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "ts",
-    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion(a: number[], x: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers(a: number, b: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr: number[], n: number, x: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements(test_tup1: [number, number, number], test_tup2: [number, number, number]): [number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "ts",
-    "prompt": "//Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "ts",
-    "prompt": "//Write a function to check if all values are same in a dictionary.\nfunction check_value(dict: {[key: string]: number}, n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "ts",
-    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix: number[][]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "ts",
-    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "ts",
-    "prompt": "//Write a function to check whether an element exists within a tuple.\nfunction check_tuplex(tuplex: string| number[], tuple1: any): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "ts",
-    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "ts",
-    "prompt": "//Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "ts",
-    "prompt": "//Write a python function to convert a given string to uppercase.\nfunction is_upper(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "ts",
-    "prompt": "//Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s: string, n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr: number[], n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element(arr: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "ts",
-    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "ts",
-    "prompt": "//Write a python function to count true booleans in the given list.\nfunction count(lst: boolean[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "ts",
-    "prompt": "//Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair(A: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "ts",
-    "prompt": "//Write a python function to count the upper case characters in a given string.\nfunction upper_ctr(str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "ts",
-    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors: string[], patterns: string[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of lists in a given number of lists.\nfunction count_list(input_list: number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "ts",
-    "prompt": "//Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple(nums: number[][]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "ts",
-    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X: string, Y: string, Z: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of an array.\nfunction _sum(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive(l: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "ts",
-    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text: string): [number, number, string] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "ts",
-    "prompt": "//Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right(list: number[], m: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split(S: any[], step: number): any[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "ts",
-    "prompt": "//Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique(test_list: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "ts",
-    "prompt": "//Write a python function to convert complex numbers to polar coordinates.\nfunction convert(numbers: number): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "ts",
-    "prompt": "//Write a python function to convert the given string to lower case.\nfunction is_lower(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "ts",
-    "prompt": "//Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "ts",
-    "prompt": "//Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring(str1: string[], sub_str: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "ts",
-    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1: string, ch: string, newch: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "ts",
-    "prompt": "//Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd(list1: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to convert a list to a tuple.\nfunction list_tuple(listx: number[]): any {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "ts",
-    "prompt": "//Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "ts",
-    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array(A: number[], B: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "ts",
-    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a: number[], n: number, k: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple(list1: [number, number][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "ts",
-    "prompt": "//Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r: number): number | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to convert a given string to a list of characters.\nfunction string_to_tuple(str1: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "ts",
-    "prompt": "//Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate(stdata: [string, number][]): [string, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "ts",
-    "prompt": "//Write a function to sort a list of elements.\nfunction comb_sort(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "ts",
-    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "ts",
-    "prompt": "//Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1: number[], lst2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "ts",
-    "prompt": "//Write a function to apply a given format string to all of the elements in a list.\nfunction add_string(list_: any[], string: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "ts",
-    "prompt": "//Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area(b: number, s: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "ts",
-    "prompt": "//Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length(lst: number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "ts",
-    "prompt": "//Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "ts",
-    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "ts",
-    "prompt": "//Write a python function to get the difference between two lists.\nfunction Diff(li1: number[], li2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "ts",
-    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1: string): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "ts",
-    "prompt": "//Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum(data_list: number| number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a: number, b: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "ts",
-    "prompt": "//Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr(l: number[], n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "ts",
-    "prompt": "//Write a python function to find the number of divisors of a given integer.\nfunction divisor(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "ts",
-    "prompt": "//Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "ts",
-    "prompt": "//Write a function to find squares of individual elements in a list.\nfunction square_nums(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given tuple has any none value or not.\nfunction check_none(test_tup: any): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of common divisors of two given numbers.\nfunction sum(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "ts",
-    "prompt": "//Write a function to find the list of maximum length in a list of lists.\nfunction max_length(list1: number[][]): [number, number[]] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "ts",
-    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a: number, b: number, c: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "ts",
-    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring(text: string, pattern: string): [string, number, number] | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "ts",
-    "prompt": "//Write a function to remove tuples from the given tuple.\nfunction remove_nested(test_tup: any): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "ts",
-    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(input_list: string[][]): string[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "ts",
-    "prompt": "//Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1: number[], L: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple(test_tup: [number, number, number], test_dict: {[key: string]: number}): [number, number, number, {[key: string]: number}] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "ts",
-    "prompt": "//Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n: number, m: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "ts",
-    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "ts",
-    "prompt": "//Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence(tup: any, lst: any[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "ts",
-    "prompt": "//Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair(list1: number[], list2: number[], list3: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "ts",
-    "prompt": "//Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "ts",
-    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "ts",
-    "prompt": "//Write a python function to find the element of a list having maximum length.\nfunction Find_Max(lst: any[][]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n: number, m: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of occurrences of a number in a given list.\nfunction frequency(a: number[], x: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "ts",
-    "prompt": "//Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings(nums_str: string[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "ts",
-    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits(startnum: number, endnum: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "ts",
-    "prompt": "//Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product(list_data: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "ts",
-    "prompt": "//Write a python function to find the largest negative number from the given list.\nfunction largest_neg(list1: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "ts",
-    "prompt": "//Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates(nums: any[]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "ts",
-    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps: [number, number], d: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "ts",
-    "prompt": "//Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr: number[]): [number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "ts",
-    "prompt": "//Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element(list1: [string, number, number][], n: number): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "ts",
-    "prompt": "//Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "ts",
-    "prompt": "//Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates(list1: any[]): any[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "ts",
-    "prompt": "//Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "ts",
-    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1: number[], arr2: number[], k: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "ts",
-    "prompt": "//Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists(list1: number[][]): {[key: number]: number} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "ts",
-    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a: number, b: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "ts",
-    "prompt": "//Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "ts",
-    "prompt": "//Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "ts",
-    "prompt": "//Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge(lst: any[][]): any[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "ts",
-    "prompt": "//Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller(test_tup1: [number, number, number], test_tup2: [number, number, number]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "ts",
-    "prompt": "//Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count(list1: number[]): {[key: number]: number} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "ts",
-    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r: number, g: number, b: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "ts",
-    "prompt": "//Write a function to flatten a given nested list structure.\nfunction flatten_list(list1: number| number[][]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "ts",
-    "prompt": "//Write a function to sort the given list.\nfunction heap_sort(iterable: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "ts",
-    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1: number[], nums2: number[], k: number): number[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "ts",
-    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution(a: number, b: number, n: number): [number, number] | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "ts",
-    "prompt": "//Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "ts",
-    "prompt": "//Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list(lists: number[][]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "ts",
-    "prompt": "//Write a python function to interchange the first and last elements in a list.\nfunction swap_List(newList: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "ts",
-    "prompt": "//Write a function to find the median of two sorted lists of same size.\nfunction get_median(arr1: number[], arr2: number[], n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "ts",
-    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1: number, num2: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "ts",
-    "prompt": "//Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list(stringlist: string[]): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "ts",
-    "prompt": "//Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits(nums: any[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "ts",
-    "prompt": "//Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest(nums: number[], n: number): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "ts",
-    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost: number, sale_amount: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "ts",
-    "prompt": "//Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements(test_tup1: number[], test_tup2: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "ts",
-    "prompt": "//Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length(lst: number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "ts",
-    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items: string[]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "ts",
-    "prompt": "//Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity(x: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "ts",
-    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1: number, base2: number, height: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "ts",
-    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "ts",
-    "prompt": "//Write a function to find number of lists present in the given list.\nfunction find_lists(Input: any[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "ts",
-    "prompt": "//Write a python function to find the length of the longest word.\nfunction len_log(list1: string[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "ts",
-    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area(r: number, a: number): number | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position(nums: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "ts",
-    "prompt": "//Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single(L: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "ts",
-    "prompt": "//Write a python function to find whether a number is divisible by 11.\nfunction is_Diff(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "ts",
-    "prompt": "//Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "ts",
-    "prompt": "//Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int(test_str: string): [number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "ts",
-    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "ts",
-    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup: number[]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "ts",
-    "prompt": "//Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq(test_list: [number, number][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "ts",
-    "prompt": "//The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair(nums1: number[], nums2: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "ts",
-    "prompt": "//Write function to find the sum of all items in the given dictionary.\nfunction return_sum(dict: {[key: string]: number}): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "ts",
-    "prompt": "//Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise(l1: number[]): [number, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "ts",
-    "prompt": "//Write a python function to split a string into characters.\nfunction split(word: string): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "ts",
-    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a: number, b: number, c: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "ts",
-    "prompt": "//Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "ts",
-    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "ts",
-    "prompt": "//Write a python function that returns the number of integer elements in a given list.\nfunction count_integer(list1: number| string| number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "ts",
-    "prompt": "//Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "ts",
-    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "ts",
-    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "ts",
-    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base: number, power: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list(list1: any[], list2: any[]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1: string, char: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "ts",
-    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "ts",
-    "prompt": "//Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int(nums: [number, number, number]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "ts",
-    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w: number, h: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1: number, n2: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "ts",
-    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "ts",
-    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list(list1: any[][], x: any): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "ts",
-    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x: number, y: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "ts",
-    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise(test_tup: [number, number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple(list1: [number, number][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4324,7 +19,7 @@
     "language": "ts",
     "prompt": "//Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element(arr: number[], k: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = kth_element;\n  assert.deepEqual(candidate([12, 3, 5, 7, 19], 2),3);\n  assert.deepEqual(candidate([17, 24, 8, 23], 3),8);\n  assert.deepEqual(candidate([16, 21, 25, 36, 4], 4),36);\n}\n\ntest();",
     "stop_tokens": [
@@ -4335,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "ts",
-    "prompt": "//Write a python function to interchange the first and last element in a given list.\nfunction swap_List(newList: number[]): number[] {\n",
+    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4350,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "ts",
-    "prompt": "//Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements(test_tup: number| [number, number][]): number {\n",
+    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n: number, m: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4365,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "ts",
-    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a: number[], x: number): number {\n",
+    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(input_list: string[][]): string[][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4380,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "ts",
-    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x: number): boolean {\n",
+    "prompt": "//Write a python function to count true booleans in the given list.\nfunction count(lst: boolean[]): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4395,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "ts",
-    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list: number[]): number[] {\n",
+    "prompt": "//Write a function to append the given list to the given tuples.\nfunction add_lists(test_list: number[], test_tup: [number, number]): [number, number, number, number, number] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4410,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "ts",
-    "prompt": "//Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A: number[], N: number): number {\n",
+    "prompt": "//Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list(num1: number[], num2: number[], num3: number[]): number[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4425,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "ts",
-    "prompt": "//Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l: number, r: number): number {\n",
+    "prompt": "//Write a python function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s: string, n: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4440,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "ts",
-    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a: number): number {\n",
+    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text: string): boolean {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4455,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "ts",
-    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n: number): number {\n",
+    "prompt": "//Write a function to convert a given tuple of positive integers into a single integer.\nfunction tuple_to_int(nums: [number, number, number]): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "ts",
-    "prompt": "//Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "ts",
-    "prompt": "//Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp(words: string[]): [string, string] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "ts",
-    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "ts",
-    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "ts",
-    "prompt": "//Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n: number, l: number, r: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "ts",
-    "prompt": "//Write a python function to get the first element of each sublist.\nfunction Extract(lst: number[][]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "ts",
-    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r: number, h: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "ts",
-    "prompt": "//Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names: string[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "ts",
-    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n: number): any {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "ts",
-    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "ts",
-    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "ts",
-    "prompt": "//Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even(test_tuple: [number, number, [number, number, [number, number]], number, number]): any {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4684,249 +169,9 @@
     "language": "ts",
     "prompt": "//Write a function to convert all possible convertible elements in a list of lists to floats.\nfunction list_to_float(test_list: [string, string][]): [number, number][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_to_float;\n  assert.deepEqual(candidate([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]]);\n  assert.deepEqual(candidate([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]]);\n  assert.deepEqual(candidate([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "ts",
-    "prompt": "//Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count(arr: number[], sum: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "ts",
-    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n: number, k: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "ts",
-    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "ts",
-    "prompt": "//Write a python function to check if a given number is one less than twice its reverse.\nfunction checks(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "ts",
-    "prompt": "//Write a python function to find the last position of an element in a sorted array.\nfunction last(arr: number[], x: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "ts",
-    "prompt": "//Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X(tup: number[], x: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "ts",
-    "prompt": "//We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list(l1: number[], l2: number[], l3: number[]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "ts",
-    "prompt": "//Write a function to find the second smallest number in a list.\nfunction second_smallest(numbers: number| number[]): number | undefined {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple(test_tup: [string, string, number, string]): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "ts",
-    "prompt": "//Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list(list1: number[], m: number, n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "ts",
-    "prompt": "//Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three(dict1: {[key: string]: string}, dict2: {[key: string]: string}, dict3: {[key: string]: string}): {[key: string]: string} {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the minimum of two numbers.\nfunction minimum(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference(test_list: [number, number][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "ts",
-    "prompt": "//Write a python function to find element at a given index after number of rotations.\nfunction find_Element(arr: number[], ranges: number[][], rotations: number, index: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4939,7 +184,7 @@
     "language": "ts",
     "prompt": "//Write a function to convert a string to a list of strings split on the space character.\nfunction string_to_list(string: string): string[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_list;\n  assert.deepEqual(candidate(\"python programming\"),[\"python\", \"programming\"]);\n  assert.deepEqual(candidate(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"]);\n  assert.deepEqual(candidate(\"write a program\"),[\"write\", \"a\", \"program\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -4954,24 +199,9 @@
     "language": "ts",
     "prompt": "//Write a python function to find the element that appears only once in a sorted array.\nfunction search(arr: number[]): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([1, 1, 2, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4, 4]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "ts",
-    "prompt": "//Write a function to sort a dictionary by value.\nfunction sort_counter(dict1: {[key: string]: number}): [string, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4984,7 +214,7 @@
     "language": "ts",
     "prompt": "//Write a python function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ(s: string, ch: string): string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_Occ;\n  assert.deepEqual(candidate(\"hello\", \"l\"),\"heo\");\n  assert.deepEqual(candidate(\"abcda\", \"a\"),\"bcd\");\n  assert.deepEqual(candidate(\"PHP\", \"P\"),\"H\");\n}\n\ntest();",
     "stop_tokens": [
@@ -4995,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "ts",
-    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l: number): number {\n",
+    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of tuples within a given list.\nfunction max_product_tuple(list1: [number, number][]): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5010,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "ts",
-    "prompt": "//Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element(list1: any[], list2: any[]): boolean | undefined {\n",
+    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5025,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "ts",
-    "prompt": "//Write a function to append the given list to the given tuples.\nfunction add_lists(test_list: number[], test_tup: [number, number]): [number, number, number, number, number] {\n",
+    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string: string): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5040,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "ts",
-    "prompt": "//Write a function to compute the n-th power of each number in a list.\nfunction nth_nums(nums: number[], n: number): number[] {\n",
+    "prompt": "//Write a python function to find the sum of common divisors of two given numbers.\nfunction sum(a: number, b: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5055,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "ts",
-    "prompt": "//Write a function to sort a list of elements.\nfunction pancake_sort(nums: number[]): number[] {\n",
+    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x: number, y: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "ts",
-    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a: number, b: number, c: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr: number[], number: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element(list: any[], element: any): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "ts",
-    "prompt": "//Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string(str: string[], l: number): string[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "ts",
-    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text: string): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to trim each list by k in the given lists.\nfunction trim_tuple(test_list: number[][], K: number): number[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "ts",
-    "prompt": "//Write a python function to find the sublist having minimum length.\nfunction Find_Min(lst: any[][]): any[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "ts",
-    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "ts",
-    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "ts",
-    "prompt": "//Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth(test_list: number[][], N: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n: number): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors(l: string[], n: number): string[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text: string): string {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "ts",
-    "prompt": "//Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1: string, str2: string): any {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to create a new tuple from the given string and list.\nfunction new_tuple(test_list: string[], test_str: string): [string, string, string] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "ts",
-    "prompt": "//Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr: number[], n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "ts",
-    "prompt": "//Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val(listval: string| number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "ts",
-    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to add the given tuple to the given list.\nfunction add_tuple(test_list: number[], test_tup: [number, number]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "ts",
-    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "ts",
-    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M: number[][]): number[][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "ts",
-    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a: number[], n: number, index: number, k: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5419,7 +304,7 @@
     "language": "ts",
     "prompt": "//Write a function to find words that are longer than n characters from a given list of words.\nfunction long_words(n: number, str: string): string[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = long_words;\n  assert.deepEqual(candidate(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"]);\n  assert.deepEqual(candidate(2, \"writing a program\"),[\"writing\", \"program\"]);\n  assert.deepEqual(candidate(5, \"sorting list\"),[\"sorting\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5430,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "ts",
-    "prompt": "//Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum(arr: number[]): number {\n",
+    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix: number[][]): boolean {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5445,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "ts",
-    "prompt": "//Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict(test_tup: [number, number, number, number, number, number]): {[key: number]: number} {\n",
+    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M: number[][]): number[][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5460,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "ts",
-    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates(test_tup: [number, number]): number[][] {\n",
+    "prompt": "//Write a function to find the item with maximum frequency in a given list.\nfunction max_occurrences(nums: number[]): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "ts",
-    "prompt": "//Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type(test_tuple: any): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "ts",
-    "prompt": "//Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing(array: number[]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n: number): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "ts",
-    "prompt": "//Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k(test_list: [string, number][], K: number): [string, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "ts",
-    "prompt": "//Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s: string): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract(test_list: [number, string, number][]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "ts",
-    "prompt": "//Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations(test_list: [number, number][]): [number, number][] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "ts",
-    "prompt": "//Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost: number[][]): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist: number[], item: number): [boolean, number] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "ts",
-    "prompt": "//Write a python function to remove odd numbers from a given list.\nfunction remove_odd(l: number[]): number[] {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even(arr: number[]): boolean {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "ts",
-    "prompt": "//Write a python function to find the maximum of two numbers.\nfunction maximum(a: number, b: number): number {\n",
-    "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5689,9 +364,744 @@
     "language": "ts",
     "prompt": "//Write a python function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels(str1: string): string {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_vowels;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"USA\"),\"ASU\");\n  assert.deepEqual(candidate(\"ab\"),\"ab\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "ts",
+    "prompt": "//Write a function to convert a list to a string.\nfunction tup_string(tup1: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum of the negative numbers of a given list of numbers.\nfunction sum_negativenum(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort a list of elements.\nfunction pancake_sort(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "ts",
+    "prompt": "//Write a function to count number items that are identical in the same position of three given lists.\nfunction count_samepair(list1: number[], list2: number[], list3: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "ts",
+    "prompt": "//Write a function to find number of lists present in the given list.\nfunction find_lists(Input: any[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "ts",
+    "prompt": "//Write a python function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "ts",
+    "prompt": "//Write a python function to find the volume of a triangular prism.\nfunction find_Volume(l: number, b: number, h: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "ts",
+    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as a tuple, or return None if no solution exists.\nfunction find_solution(a: number, b: number, n: number): [number, number] | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "ts",
+    "prompt": "//Write a function to remove all elements from a given list present in another list.\nfunction remove_elements(list1: number[], list2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "ts",
+    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1: number, num2: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "ts",
+    "prompt": "//Write a function that counts the number of pairs of integers in a list that xor to an even number.\nfunction find_even_pair(A: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "ts",
+    "prompt": "//Write a python function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of occurrences of a number in a given list.\nfunction frequency(a: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "ts",
+    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "ts",
+    "prompt": "//Write a function to find the sum of numbers in a list within a range specified by two indices.\nfunction sum_range_list(list1: number[], m: number, n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "ts",
+    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "ts",
+    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "ts",
+    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string: string, second_string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "ts",
+    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "ts",
+    "prompt": "//Write a function to check if all the elements in tuple have same data type or not.\nfunction check_type(test_tuple: any): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr: number[], n: number, x: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "ts",
+    "prompt": "//Write a python function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "ts",
+    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a: number, b: number, c: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n: number, l: number, r: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr: number[], n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1: string, char: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "ts",
+    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "ts",
+    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m: number, n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two lists and replaces the last element of the first list with the elements of the second list.\nfunction replace_list(list1: any[], list2: any[]): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "ts",
+    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "ts",
+    "prompt": "//Write a python function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "ts",
+    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "ts",
+    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "ts",
+    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1: number[], array_nums2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "ts",
+    "prompt": "//Write a python function that takes in a tuple and an element and counts the occcurences of the element in the list.\nfunction count_X(tup: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a list and an element and inserts the element before each element in the list, and returns the resulting list.\nfunction insert_element(list: string[], element: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "ts",
+    "prompt": "//Write a python function to convert complex numbers to polar coordinates.\nfunction convert(numbers: number): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "ts",
+    "prompt": "//Write a python function that returns the number of integer elements in a given list.\nfunction count_integer(list1: number| string| number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a list and length n, and generates all combinations (with repetition) of the elements of the list and returns a list with a list for each combination.\nfunction combinations_colors(l: string[], n: number): string[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "ts",
+    "prompt": "//Write a python function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two numbers and returns a list with the second number and then the first number.\nfunction swap_numbers(a: number, b: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5704,7 +1114,7 @@
     "language": "ts",
     "prompt": "//Write a function to maximize the given two lists.\nfunction maximize_elements(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximize_elements;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5715,13 +1125,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "ts",
-    "prompt": "//Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position(nums: number[]): boolean {\n",
+    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5730,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "ts",
-    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string: string): string {\n",
+    "prompt": "//Write a function that takes in two tuples and performs mathematical division operation element-wise across the given tuples.\nfunction division_elements(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5745,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "ts",
-    "prompt": "//Write a python function to find the sum of even factors of a number.\nfunction sumofFactors(n: number): number {\n",
+    "prompt": "//Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.\nfunction split_two_parts(list1: any[], L: number): any {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5760,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "ts",
-    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r: number, h: number): number {\n",
+    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5775,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "ts",
-    "prompt": "//Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr: number[], n: number): number {\n",
+    "prompt": "//Write a function that takes in a list and an integer n and splits a list for every nth element, returning a list of the resulting lists.\nfunction list_split(S: any[], step: number): any[][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5790,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "ts",
-    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A: number[], x: number): number {\n",
+    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5809,9 +1219,894 @@
     "language": "ts",
     "prompt": "//Write a python function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum(n: number): number {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),10);\n  assert.deepEqual(candidate(3),35);\n  assert.deepEqual(candidate(4),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "ts",
+    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of even numbers at even positions of a list.\nfunction sum_even_and_even_index(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "ts",
+    "prompt": "//Write a python function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a list of tuples and returns a list containing the rear element of each tuple.\nfunction rear_extract(test_list: [number, string, number][]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two tuples and subtracts the elements of the first tuple by the elements of the second tuple with the same index.\nfunction substract_elements(test_tup1: [number, number, number], test_tup2: [number, number, number]): [number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "ts",
+    "prompt": "//Write a python function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a dictionary and integer n and filters the dictionary to only include entries with values greater than or equal to n.\nfunction dict_filter(dict: {[key: string]: number}, n: number): {[key: string]: number} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "ts",
+    "prompt": "//Write a function to find the number of elements that occurs before the list element in the given tuple.\nfunction count_first_elements(test_tup: number| [number, number][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and element and returns a tuple containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist: number[], item: number): [boolean, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "ts",
+    "prompt": "//Write a python function to check if the elements of a given list are unique or not.\nfunction all_unique(test_list: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "ts",
+    "prompt": "//Write a function to subtract two lists element-wise.\nfunction sub_list(nums1: number[], nums2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "ts",
+    "prompt": "//Write a python function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a list and element and checks whether all items in the list are equal to the given element.\nfunction check_element(list: any[], element: any): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "ts",
+    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "ts",
+    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a: number[], n: number, k: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "ts",
+    "prompt": "//Write a python function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "ts",
+    "prompt": "//Write a function to find the list of maximum length in a list of lists.\nfunction max_length(list1: number[][]): [number, number[]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "ts",
+    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n: number, k: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "ts",
+    "prompt": "//Write a python function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n: number, m: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "ts",
+    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w: number, h: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum value in a given heterogeneous list.\nfunction max_val(listval: string| number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "ts",
+    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "ts",
+    "prompt": "//Write a python function to count inversions in an array.\nfunction get_Inv_Count(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "ts",
+    "prompt": "//Write a function to flatten a given nested list structure.\nfunction flatten_list(list1: number| number[][]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the maximum aggregate from the list of tuples.\nfunction max_aggregate(stdata: [string, number][]): [string, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "ts",
+    "prompt": "//Write a python function to find element at a given index after number of rotations.\nfunction find_Element(arr: number[], ranges: number[][], rotations: number, index: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "ts",
+    "prompt": "//Write a function to return two words from a list of words starting with letter 'p'.\nfunction start_withp(words: string[]): [string, string] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a: number[], n: number, index: number, k: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the specified number of largest products from two given lists, selecting one factor from each list.\nfunction large_product(nums1: number[], nums2: number[], N: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the maximum of two numbers.\nfunction maximum(a: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to convert a given string to a list of characters.\nfunction string_to_tuple(str1: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "ts",
+    "prompt": "//Write a python function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "ts",
+    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "ts",
+    "prompt": "//Write a function to apply a given format string to all of the elements in a list.\nfunction add_string(list_: any[], string: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "ts",
+    "prompt": "//Write a function to find the list with maximum length.\nfunction max_length_list(input_list: number[][]): [number, number[]] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "ts",
+    "prompt": "//Write a function to check if given list contains no duplicates.\nfunction check_distinct(test_tup: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "ts",
+    "prompt": "//Write a python function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1: string): string | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "ts",
+    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a: number, b: number, c: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "ts",
+    "prompt": "//Write a function to compute the sum of digits of each number of a given list.\nfunction sum_of_digits(nums: any[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "ts",
+    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given tuples.\nfunction bitwise_xor(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "ts",
+    "prompt": "//Write a python function to identify non-prime numbers.\nfunction is_not_prime(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "ts",
+    "prompt": "//Write a function to extract the number of unique tuples in the given list.\nfunction extract_freq(test_list: [number, number][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to perform index wise addition of list elements in the given two nested lists.\nfunction add_nested_tuples(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the minimum of two numbers.\nfunction minimum(a: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "ts",
+    "prompt": "//Write a function to check whether an element exists within a tuple.\nfunction check_tuplex(tuplex: string| number[], tuple1: any): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "ts",
+    "prompt": "//Write a python function to find whether the parity of a given number is odd.\nfunction find_Parity(x: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "ts",
+    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n: number): any {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "ts",
+    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1: number[], nums2: number[], k: number): number[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to find the minimum product from the pairs of tuples within a given list.\nfunction min_product_tuple(list1: [number, number][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "ts",
+    "prompt": "//Write a function to find the minimum value in a given heterogeneous list.\nfunction min_val(listval: string| number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "ts",
+    "prompt": "//Write a python function to remove odd numbers from a given list.\nfunction remove_odd(l: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "ts",
+    "prompt": "//Write a function to extract the nth element from a given list of tuples.\nfunction extract_nth_element(list1: [string, number, number][], n: number): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1: number[], list2: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "ts",
+    "prompt": "//Write a python function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr: number[]): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5824,7 +2119,7 @@
     "language": "ts",
     "prompt": "//Write a function to find common first element in given list of lists.\nfunction group_tuples(Input: string[][]): string[][] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "verbatim",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = group_tuples;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n  assert.deepEqual(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5835,13 +2130,3718 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "ts",
-    "prompt": "//Write a function to merge three lists into a single sorted list.\nfunction merge_sorted_list(num1: number[], num2: number[], num3: number[]): number[] {\n",
+    "prompt": "//Write a python function to find the element of a list having maximum length.\nfunction Find_Max(lst: any[][]): any[] {\n",
     "doctests": "keep",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "verbatim",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "ts",
+    "prompt": "//Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nfunction round_and_sum(list1: number| number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to concatenate each element of tuple by the delimiter.\nfunction concatenate_tuple(test_tup: [string, string, number, string]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "ts",
+    "prompt": "//Write a python function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "ts",
+    "prompt": "//Write a function to extract only the rear index element of each string in the given tuple.\nfunction extract_rear(test_tuple: [string, string, string]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of sublists containing a particular element.\nfunction count_element_in_list(list1: any[][], x: any): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "ts",
+    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "ts",
+    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to extract the elementwise and tuples from the given two tuples.\nfunction and_tuples(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "ts",
+    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a: number, b: number, c: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes two lists and returns true if they have at least one common element.\nfunction common_element(list1: any[], list2: any[]): boolean | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "ts",
+    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1: number, base2: number, height: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr: number[], number: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "ts",
+    "prompt": "//Write a python function to find the last digit of a given number.\nfunction last_Digit(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "ts",
+    "prompt": "//Write a python function to return the negative numbers in a list.\nfunction neg_nos(list1: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "ts",
+    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "ts",
+    "prompt": "//Write a function to count bidirectional tuple pairs.\nfunction count_bidirectional(test_list: [number, number][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "ts",
+    "prompt": "//Write a function to join a list of multiple integers into a single integer.\nfunction multiple_to_single(L: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "ts",
+    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text: string): [number, number, string] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "ts",
+    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "ts",
+    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "ts",
+    "prompt": "//Write a python function to find the largest negative number from the given list.\nfunction largest_neg(list1: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to trim each list by k in the given lists.\nfunction trim_tuple(test_list: number[][], K: number): number[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "ts",
+    "prompt": "//Write a function to perform index wise multiplication of list elements in the given two lists.\nfunction index_multiplication(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "ts",
+    "prompt": "//Write a python function to count the occurence of all elements of list in a tuple.\nfunction count_Occurrence(tup: any, lst: any[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "ts",
+    "prompt": "//Write a function to find cubes of individual elements in a list.\nfunction cube_nums(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "ts",
+    "prompt": "//Write a function to extract specified size of strings from a given list of string values.\nfunction extract_string(str: string[], l: number): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "ts",
+    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "ts",
+    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost: number, sale_amount: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of even factors of a number.\nfunction sumofFactors(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "ts",
+    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "ts",
+    "prompt": "//Write a function to reverse each string in a given list of string values.\nfunction reverse_string_list(stringlist: string[]): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sublist having minimum length.\nfunction Find_Min(lst: any[][]): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "ts",
+    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "ts",
+    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "ts",
+    "prompt": "//Write a python function to get the first element of each sublist.\nfunction Extract(lst: number[][]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "ts",
+    "prompt": "//Write a python function to count the upper case characters in a given string.\nfunction upper_ctr(str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "ts",
+    "prompt": "//Write a function to check if all values are same in a dictionary.\nfunction check_value(dict: {[key: string]: number}, n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "ts",
+    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given tuple.\nfunction add_pairwise(test_tup: [number, number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "ts",
+    "prompt": "//Write a python function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr: number[], n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given list contains consecutive numbers or not.\nfunction check_Consecutive(l: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "ts",
+    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1: string, ch: string, newch: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "ts",
+    "prompt": "//Write a function to sort a dictionary by value.\nfunction sort_counter(dict1: {[key: string]: number}): [string, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "ts",
+    "prompt": "//Write a python function to convert the given string to lower case.\nfunction is_lower(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "ts",
+    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "ts",
+    "prompt": "//Write a python function to find the first digit of a given number.\nfunction first_Digit(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "ts",
+    "prompt": "//Write a function to find the n largest integers from a given list of numbers, returned in descending order.\nfunction heap_queue_largest(nums: number[], n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "ts",
+    "prompt": "//Write a python function which takes a list of integers and only returns the odd ones.\nfunction Split(list: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "ts",
+    "prompt": "//Write a python function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A: number[], N: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "ts",
+    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1: number, n2: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the sum of the largest contiguous sublist in the given list.\nfunction max_sub_array_sum(a: number[], size: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "ts",
+    "prompt": "//Write a function to find the union of the elements of two given lists and output them in sorted order.\nfunction union_elements(test_tup1: number[], test_tup2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "ts",
+    "prompt": "//Write a python function to find the length of the longest sublists.\nfunction Find_Max_Length(lst: number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "ts",
+    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "ts",
+    "prompt": "//Write a python function which takes a list of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr: number[], n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "ts",
+    "prompt": "//Write a python function to split a string into characters.\nfunction split(word: string): string[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "ts",
+    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "ts",
+    "prompt": "//Write a function to check whether a specified list is sorted or not.\nfunction issort_list(list1: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "ts",
+    "prompt": "//Write a function to sort each sublist of strings in a given list of lists.\nfunction sort_sublists(list1: string[][]): string[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "ts",
+    "prompt": "//Write a python function to check if a given number is one less than twice its reverse.\nfunction checks(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "ts",
+    "prompt": "//Write a python function to remove duplicate numbers from a given number of lists.\nfunction two_unique_nums(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "ts",
+    "prompt": "//Write a python function to calculate the product of the unique numbers in a given list.\nfunction unique_product(list_data: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "ts",
+    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r: number, h: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether a list is sublist of another or not.\nfunction is_Sub_Array(A: number[], B: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "ts",
+    "prompt": "//Write a python function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "ts",
+    "prompt": "//Write a function to interleave 3 lists of the same length into a single flat list.\nfunction interleave_lists(list1: number[], list2: number[], list3: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "ts",
+    "prompt": "//Write a function to find the dissimilar elements in the given two tuples.\nfunction find_dissimilar(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "ts",
+    "prompt": "//Write a python function to find the largest number that can be formed with the given list of digits.\nfunction find_Max_Num(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "ts",
+    "prompt": "//Write a function to remove uneven elements in the nested mixed tuple.\nfunction extract_even(test_tuple: [number, number, [number, number, [number, number]], number, number]): any {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "ts",
+    "prompt": "//Write a python function to find the surface area of a square pyramid with a given base edge and height.\nfunction surface_Area(b: number, s: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "ts",
+    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "ts",
+    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "ts",
+    "prompt": "//Write a python function to split a list at the nth eelment and add the first part to the end.\nfunction split_Arr(l: number[], n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to convert a list to a tuple.\nfunction list_tuple(listx: number[]): any {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "ts",
+    "prompt": "//Write a python function to find the difference between largest and smallest value in a given list.\nfunction big_diff(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "ts",
+    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a: number, b: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x: number, y: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "ts",
+    "prompt": "//Write a python function to interchange the first and last elements in a list.\nfunction swap_List(newList: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "ts",
+    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "ts",
+    "prompt": "//Write a function to find the difference of the first even and first odd number of a given list.\nfunction diff_even_odd(list1: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "ts",
+    "prompt": "//Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1: string, str2: string): any {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "ts",
+    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1: number[], arr2: number[], k: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "ts",
+    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number: number): [number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given number is even or not.\nfunction is_Even(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "ts",
+    "prompt": "//Write a python function to find the first repeated character in a given string.\nfunction first_repeated_char(str1: string): string | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "ts",
+    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "ts",
+    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "ts",
+    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "ts",
+    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text: string, pattern: string): [string, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "ts",
+    "prompt": "//Write a python function to find nth bell number.\nfunction bell_Number(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "ts",
+    "prompt": "//Write a python function which takes a list and returns a list with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1: number[], L: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "ts",
+    "prompt": "//Write a function which given a matrix represented as a list of lists returns the max of the n'th column.\nfunction max_of_nth(test_list: number[][], N: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "ts",
+    "prompt": "//Write a python function which takes a list of lists, where each sublist has two elements, and returns a list of two lists where the first list has the first element of each sublist and the second one has the second.\nfunction merge(lst: any[][]): any[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given list of lists.\nfunction cummulative_sum(test_list: number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "ts",
+    "prompt": "//Write a function which takes a lists of lists and returns the average value for each sublist as a list.\nfunction average_tuple(nums: number[][]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "ts",
+    "prompt": "//Write a function which takes two tuples of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "ts",
+    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps: [number, number], d: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "ts",
+    "prompt": "//Write a function to divide two lists element wise.\nfunction div_list(nums1: number[], nums2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "ts",
+    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "ts",
+    "prompt": "//Write a function to find the median of two sorted lists of same size.\nfunction get_median(arr1: number[], arr2: number[], n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "ts",
+    "prompt": "//Write a function to compute the n-th power of each number in a list.\nfunction nth_nums(nums: number[], n: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "ts",
+    "prompt": "//Write a python function to convert a given string to uppercase.\nfunction is_upper(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "ts",
+    "prompt": "//Write a python function to interchange the first and last element in a given list.\nfunction swap_List(newList: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "ts",
+    "prompt": "//Write a python function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r: number): number | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "ts",
+    "prompt": "//Write a python function to find the smallest missing number from a sorted list of natural numbers.\nfunction find_First_Missing(array: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "ts",
+    "prompt": "//Write a python function to find even numbers from a list of numbers.\nfunction Split(list: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "ts",
+    "prompt": "//Write a python function to find smallest number in a list.\nfunction smallest_num(xs: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "ts",
+    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nfunction get_coordinates(test_tup: [number, number]): number[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "ts",
+    "prompt": "//Write a python function to move all zeroes to the end of the given list.\nfunction move_zero(num_list: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of xor of all pairs of numbers in the given list.\nfunction pair_xor_Sum(arr: number[], n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort the given list.\nfunction heap_sort(iterable: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost: number, sale_amount: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v: number, t: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "ts",
+    "prompt": "//Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names: string[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum difference between available pairs in the given tuple list.\nfunction max_difference(test_list: [number, number][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "ts",
+    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items: string[]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "ts",
+    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "ts",
+    "prompt": "//Write a python function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input: number[], k: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "ts",
+    "prompt": "//Write a function to sort a list of tuples using the second value of each tuple.\nfunction subject_marks(subjectmarks: [string, number][]): [string, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "ts",
+    "prompt": "//Write a function to flatten a list and sum all of its elements.\nfunction recursive_list_sum(data_list: number| number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of positive numbers in a list.\nfunction pos_count(list: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "ts",
+    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "ts",
+    "prompt": "//Write a function to check whether a list contains the given sublist or not.\nfunction is_sublist(l: number[], s: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a: number, b: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "ts",
+    "prompt": "//Write a function to find whether all the given lists have equal length or not.\nfunction get_equal(Input: number[][]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort a list of elements.\nfunction comb_sort(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to add a dictionary to the tuple. The output should be a tuple.\nfunction add_dict_to_tuple(test_tup: [number, number, number], test_dict: {[key: string]: number}): [number, number, number, {[key: string]: number}] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "ts",
+    "prompt": "//Given a square matrix of size N*N given as a list of lists, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost: number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "ts",
+    "prompt": "//The input is defined as two lists of the same length. Write a function to count indices where the lists have the same values.\nfunction count_same_pair(nums1: number[], nums2: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "ts",
+    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base: number, power: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "ts",
+    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1: string): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "ts",
+    "prompt": "//Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup: number[]): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "ts",
+    "prompt": "//Write a function takes as input two lists [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1: number[], lst2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "ts",
+    "prompt": "//Write a function to remove consecutive duplicates of a given list.\nfunction consecutive_duplicates(nums: any[]): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "ts",
+    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r: number, h: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "ts",
+    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "ts",
+    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "ts",
+    "prompt": "//Write a python function to find sum of products of all possible sublists of a given list. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "ts",
+    "prompt": "//Write a python function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "ts",
+    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-data-structure-exercise-24.php\nfunction left_insertion(a: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/python-exercises/data-structures-and-algorithms/python-recursion-exercise-9.php\nfunction geometric_sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "ts",
+    "prompt": "//Write a python function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given tuple to a key-value dictionary using adjacent elements. https://www.geeksforgeeks.org/python-convert-tuple-to-adjacent-pair-dictionary/\nfunction tuple_to_dict(test_tup: [number, number, number, number, number, number]): {[key: number]: number} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether all the characters are same or not.\nfunction all_Characters_Same(s: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "ts",
+    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "ts",
+    "prompt": "//Write a function to rotate a given list by specified number of items to the right direction. https://www.geeksforgeeks.org/python-program-right-rotate-list-n/\nfunction rotate_right(list: number[], m: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given tuple has any none value or not.\nfunction check_none(test_tup: any): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "ts",
+    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/python-exercises/lambda/python-lambda-exercise-24.php\nfunction divisible_by_digits(startnum: number, endnum: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "ts",
+    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return None if the angle is larger than 360 degrees.\nfunction sector_area(r: number, a: number): number | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "ts",
+    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X: string, Y: string, Z: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "ts",
+    "prompt": "//Write a function to sort a given list of strings of numbers numerically. https://www.geeksforgeeks.org/python-sort-numeric-strings-in-a-list/\nfunction sort_numeric_strings(nums_str: string[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "ts",
+    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors: string[], patterns: string[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to add the given tuple to the given list.\nfunction add_tuple(test_list: number[], test_tup: [number, number]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "ts",
+    "prompt": "//Write a function to find minimum k records from tuple list. https://www.geeksforgeeks.org/python-find-minimum-k-records-from-tuple-list/ - in this case a verbatim copy of test cases\nfunction min_k(test_list: [string, number][], K: number): [string, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "ts",
+    "prompt": "//We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.\nfunction extract_index_list(l1: number[], l2: number[], l3: number[]): any[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "ts",
+    "prompt": "//Write a function to find the second smallest number in a list.\nfunction second_smallest(numbers: number| number[]): number | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/python-exercises/re/python-re-exercise-3.php\nfunction text_match_zero_one(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "ts",
+    "prompt": "//Write a function to count the pairs of reverse strings in the given string list. https://www.geeksforgeeks.org/python-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list: string[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "ts",
+    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nfunction find_tuples(test_list: [number, number, number][], K: number): [number, number, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether a list of numbers contains only one distinct element or not.\nfunction unique_Element(arr: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "ts",
+    "prompt": "//Write a python function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr: number[], n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "ts",
+    "prompt": "//Write a python function to count number of digits in a given string.\nfunction number_ctr(str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "ts",
+    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "ts",
+    "prompt": "//Write a function to return a list of all pairs of consecutive items in a given list.\nfunction pair_wise(l1: number[]): [number, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input a list of numbers and the sum,\nfunction get_pairs_count(arr: number[], sum: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "ts",
+    "prompt": "//Write a python function to get the difference between two lists.\nfunction Diff(li1: number[], li2: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "ts",
+    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str: string, K: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "ts",
+    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return None if there is no match.\nfunction occurance_substring(text: string, pattern: string): [string, number, number] | undefined {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether every odd index contains odd numbers of a given list.\nfunction odd_position(nums: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "ts",
+    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of non-repeated elements in a given list.\nfunction find_sum(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "ts",
+    "prompt": "//Write a function to pack consecutive duplicates of a given list elements into sublists.\nfunction pack_consecutive_duplicates(list1: any[]): any[][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "ts",
+    "prompt": "//Write a python function to find whether a number is divisible by 11.\nfunction is_Diff(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "ts",
+    "prompt": "//Write a function to find the combinations of sums with tuples in the given tuple list. https://www.geeksforgeeks.org/python-combinations-of-sum-with-tuples-in-tuple-list/\nfunction find_combinations(test_list: [number, number][]): [number, number][] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the count of divisors is even. https://www.w3resource.com/python-exercises/basic/python-basic-1-exercise-24.php\nfunction count_divisors(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "ts",
+    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r: number, g: number, b: number): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "ts",
+    "prompt": "//Write a function to find the product of first even and odd number of a given list.\nfunction mul_even_odd(list1: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "ts",
+    "prompt": "//Write a function to convert tuple string to integer tuple.\nfunction tuple_str_int(test_str: string): [number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "ts",
+    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to create a new tuple from the given string and list.\nfunction new_tuple(test_list: string[], test_str: string): [string, string, string] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether every even index contains even numbers of a given list.\nfunction even_position(nums: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "ts",
+    "prompt": "//Write a function to remove tuples from the given tuple.\nfunction remove_nested(test_tup: any): [number, number, number, number] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of lists in a given number of lists.\nfunction count_list(input_list: number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "ts",
+    "prompt": "//Write a python function to find the last position of an element in a sorted array.\nfunction last(arr: number[], x: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "ts",
+    "prompt": "//Write function to find the sum of all items in the given dictionary.\nfunction return_sum(dict: {[key: string]: number}): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l: number, r: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "ts",
+    "prompt": "//Write a python function to find the sum of an array.\nfunction _sum(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "ts",
+    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n: number, d: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "ts",
+    "prompt": "//Write a python function to check whether the length of the word is odd or not.\nfunction word_len(s: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x: number, y: number, z: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "ts",
+    "prompt": "//Write a python function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the product of numbers in a list is even or not.\nfunction is_product_even(arr: number[]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "ts",
+    "prompt": "//Write a function that returns the list in a list of lists whose sum of elements is the highest.\nfunction max_sum_list(lists: number[][]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "ts",
+    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "ts",
+    "prompt": "//Write a python function to find the first odd number in a given list of numbers.\nfunction first_odd(nums: number[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given tuples contain the k or not.\nfunction check_K(test_tup: number[], K: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "ts",
+    "prompt": "//Write a function to check if each element of second tuple is smaller than its corresponding element in the first tuple.\nfunction check_smaller(test_tup1: [number, number, number], test_tup2: [number, number, number]): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "ts",
+    "prompt": "//Write a python function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr: string): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "ts",
+    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "ts",
+    "prompt": "//Write a function to merge three dictionaries into a single dictionary.\nfunction merge_dictionaries_three(dict1: {[key: string]: string}, dict2: {[key: string]: string}, dict3: {[key: string]: string}): {[key: string]: string} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "ts",
+    "prompt": "//Write a function to get the frequency of all the elements in a list, returned as a dictionary.\nfunction freq_count(list1: number[]): {[key: number]: number} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "ts",
+    "prompt": "//Write a function to find squares of individual elements in a list.\nfunction square_nums(nums: number[]): number[] {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "ts",
+    "prompt": "//Write a python function to find the length of the longest word.\nfunction len_log(list1: string[]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "ts",
+    "prompt": "//Write a function to check if a string is present as a substring in a given list of string values.\nfunction find_substring(str1: string[], sub_str: string): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n: number): boolean {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a: number, b: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "ts",
+    "prompt": "//Given a list of tuples, write a function that returns the first value of the tuple with the smallest second value.\nfunction index_minimum(test_list: [string, number][]): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "ts",
+    "prompt": "//Write a python function to find the length of the smallest list in a list of lists.\nfunction Find_Min_Length(lst: number[][]): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "ts",
+    "prompt": "//Write a python function to find the number of divisors of a given integer.\nfunction divisor(n: number): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "ts",
+    "prompt": "//Write a function to find frequency of each element in a flattened list of lists, returned in a dictionary.\nfunction frequency_lists(list1: number[][]): {[key: number]: number} {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n: number): string {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "ts",
+    "prompt": "//Write a python function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str: string): number {\n",
+    "doctests": "keep",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "verbatim",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",

--- a/prompts/mbpp-ts-reworded.json
+++ b/prompts/mbpp-ts-reworded.json
@@ -1,4317 +1,12 @@
 [
   {
-    "name": "mbpp_247_lps",
-    "language": "ts",
-    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_451_remove_whitespaces",
-    "language": "ts",
-    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_567_issort_list",
-    "language": "ts",
-    "prompt": "//Write a function to check whether a specified array is sorted or not.\nfunction issort_list(list1: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_438_count_bidirectional",
-    "language": "ts",
-    "prompt": "//Write a function to count bidirectional array pairs.\nfunction count_bidirectional(test_list: [number, number][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_441_surfacearea_cube",
-    "language": "ts",
-    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
     "name": "mbpp_100_next_smallest_palindrome",
     "language": "ts",
     "prompt": "//Write a function to find the next smallest palindrome of a specified integer, returned as an integer.\nfunction next_smallest_palindrome(num: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_100_next_smallest_palindrome.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_smallest_palindrome;\n  assert.deepEqual(candidate(99),101);\n  assert.deepEqual(candidate(1221),1331);\n  assert.deepEqual(candidate(120),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_420_cube_Sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_633_pair_xor_Sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum(arr: number[], n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_751_check_min_heap",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_479_first_Digit",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the first digit of a given number.\nfunction first_Digit(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_395_first_non_repeating_character",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1: string): string | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_606_radian_degree",
-    "language": "ts",
-    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_463_max_subarray_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_62_smallest_num",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find smallest number in an array.\nfunction smallest_num(xs: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_756_text_match_zero_one",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/tsthon-exercises/re/tsthon-re-exercise-3.php\nfunction text_match_zero_one(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_608_bell_Number",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find nth bell number.\nfunction bell_Number(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_447_cube_nums",
-    "language": "ts",
-    "prompt": "//Write a function to find cubes of individual elements in an array.\nfunction cube_nums(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_577_last_Digit_Factorial",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_629_Split",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find even numbers from an array of numbers.\nfunction Split(list: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_605_prime_num",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_75_find_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples(test_list: [number, number, number][], K: number): [number, number, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_742_area_tetrahedron",
-    "language": "ts",
-    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_600_is_Even",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given number is even or not.\nfunction is_Even(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_66_pos_count",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of positive numbers in an array.\nfunction pos_count(list: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_603_get_ludic",
-    "language": "ts",
-    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_739_find_Index",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_644_reverse_Array_Upto_K",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input: number[], k: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_64_subject_marks",
-    "language": "ts",
-    "prompt": "//Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks(subjectmarks: [string, number][]): [string, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_18_remove_dirty_chars",
-    "language": "ts",
-    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string: string, second_string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_419_round_and_sum",
-    "language": "ts",
-    "prompt": "//Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum(list1: number| number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_130_max_occurrences",
-    "language": "ts",
-    "prompt": "//Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_759_is_decimal",
-    "language": "ts",
-    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_277_dict_filter",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an object and integer n and filters the object to only include entries with values greater than or equal to n.\nfunction dict_filter(dict: {[key: string]: number}, n: number): {[key: string]: number} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_270_sum_even_and_even_index",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_559_max_sub_array_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum(a: number[], size: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_249_intersection_array",
-    "language": "ts",
-    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1: number[], array_nums2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_262_split_two_parts",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts(list1: any[], L: number): any {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_607_find_literals",
-    "language": "ts",
-    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text: string, pattern: string): [string, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_14_find_Volume",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the volume of a triangular prism.\nfunction find_Volume(l: number, b: number, h: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_638_wind_chill",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v: number, t: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_269_ascii_value",
-    "language": "ts",
-    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_741_all_Characters_Same",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether all the characters are same or not.\nfunction all_Characters_Same(s: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_619_move_num",
-    "language": "ts",
-    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_79_word_len",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the length of the word is odd or not.\nfunction word_len(s: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_251_insert_element",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element(list: string[], element: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_478_remove_lowercase",
-    "language": "ts",
-    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_224_count_Set_Bits",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_424_extract_rear",
-    "language": "ts",
-    "prompt": "//Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear(test_tuple: [string, string, string]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_172_count_occurance",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_808_check_K",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given arrays contain the k or not.\nfunction check_K(test_tup: number[], K: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_578_interleave_lists",
-    "language": "ts",
-    "prompt": "//Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists(list1: number[], list2: number[], list3: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_102_snake_to_camel",
-    "language": "ts",
-    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_801_test_three_equal",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x: number, y: number, z: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_782_odd_length_sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_67_bell_number",
-    "language": "ts",
-    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_458_rectangle_area",
-    "language": "ts",
-    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_599_sum_average",
-    "language": "ts",
-    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_261_division_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_566_sum_digits",
-    "language": "ts",
-    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_94_index_minimum",
-    "language": "ts",
-    "prompt": "//Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum(test_list: [string, number][]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_618_div_list",
-    "language": "ts",
-    "prompt": "//Write a function to divide two arrays element wise.\nfunction div_list(nums1: number[], nums2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_393_max_length_list",
-    "language": "ts",
-    "prompt": "//Write a function to find the array with maximum length.\nfunction max_length_list(input_list: number[][]): [number, number[]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_476_big_sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_436_neg_nos",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to return the negative numbers in an array.\nfunction neg_nos(list1: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_388_highest_Power_of_2",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_69_is_sublist",
-    "language": "ts",
-    "prompt": "//Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist(l: number[], s: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_282_sub_list",
-    "language": "ts",
-    "prompt": "//Write a function to subtract two arrays element-wise.\nfunction sub_list(nums1: number[], nums2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_58_opposite_Signs",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x: number, y: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_616_tuple_modulo",
-    "language": "ts",
-    "prompt": "//Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_594_diff_even_odd",
-    "language": "ts",
-    "prompt": "//Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd(list1: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_569_sort_sublists",
-    "language": "ts",
-    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(list1: string[][]): string[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_435_last_Digit",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the last digit of a given number.\nfunction last_Digit(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_770_odd_num_sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_132_tup_string",
-    "language": "ts",
-    "prompt": "//Write a function to convert an array to a string.\nfunction tup_string(tup1: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_161_remove_elements",
-    "language": "ts",
-    "prompt": "//Write a function to remove all elements from a given array present in another array.\nfunction remove_elements(list1: number[], list2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_414_overlapping",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1: number[], list2: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_3_is_not_prime",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to identify non-prime numbers.\nfunction is_not_prime(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_294_max_val",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val(listval: string| number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_133_sum_negativenum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_9_find_Rotations",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_427_change_date_format",
-    "language": "ts",
-    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_554_Split",
-    "language": "ts",
-    "prompt": "//Write a tsthon function which takes an array of integers and only returns the odd ones.\nfunction Split(list: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_735_toggle_middle_bits",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_165_count_char_position",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_308_large_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product(nums1: number[], nums2: number[], N: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_614_cummulative_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum(test_list: number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_763_find_min_diff",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr: number[], n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_794_text_starta_endb",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_799_left_rotate",
-    "language": "ts",
-    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n: number, d: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_602_first_repeated_char",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the first repeated character in a given string.\nfunction first_repeated_char(str1: string): string | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_296_get_Inv_Count",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count inversions in an array.\nfunction get_Inv_Count(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_271_even_Power_Sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_70_get_equal",
-    "language": "ts",
-    "prompt": "//Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal(Input: number[][]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_113_check_integer",
-    "language": "ts",
-    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_757_count_reverse_pairs",
-    "language": "ts",
-    "prompt": "//Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/tsthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list: string[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_632_move_zero",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to move all zeroes to the end of the given array.\nfunction move_zero(num_list: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_394_check_distinct",
-    "language": "ts",
-    "prompt": "//Write a function to check if given array contains no duplicates.\nfunction check_distinct(test_tup: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_637_noprofit_noloss",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost: number, sale_amount: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_772_remove_length",
-    "language": "ts",
-    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str: string, K: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_764_number_ctr",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count number of digits in a given string.\nfunction number_ctr(str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_242_count_charac",
-    "language": "ts",
-    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_239_get_total_number_of_sequences",
-    "language": "ts",
-    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m: number, n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_736_left_insertion",
-    "language": "ts",
-    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/tsthon-exercises/data-structures-and-algorithms/tsthon-data-structure-exercise-24.php\nfunction left_insertion(a: number[], x: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_257_swap_numbers",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers(a: number, b: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_223_is_majority",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr: number[], n: number, x: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_273_substract_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements(test_tup1: [number, number, number], test_tup2: [number, number, number]): [number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_748_capital_words_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_422_find_Average_Of_Cube",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_464_check_value",
-    "language": "ts",
-    "prompt": "//Write a function to check if all values are same in an object.\nfunction check_value(dict: {[key: string]: number}, n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_80_tetrahedral_number",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_129_magic_square_test",
-    "language": "ts",
-    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix: number[][]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_459_remove_uppercase",
-    "language": "ts",
-    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_405_check_tuplex",
-    "language": "ts",
-    "prompt": "//Write a function to check whether an element exists within an array.\nfunction check_tuplex(tuplex: string| number[], tuple1: any): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_264_dog_age",
-    "language": "ts",
-    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_244_next_Perfect_Square",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_624_is_upper",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to convert a given string to uppercase.\nfunction is_upper(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_109_odd_Equivalent",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s: string, n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_229_re_arrange_array",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr: number[], n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_760_unique_Element",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element(arr: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_563_extract_values",
-    "language": "ts",
-    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_105_count",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count true booleans in the given array.\nfunction count(lst: boolean[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_166_find_even_pair",
-    "language": "ts",
-    "prompt": "//Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair(A: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_598_armstrong_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_461_upper_ctr",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the upper case characters in a given string.\nfunction upper_ctr(str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_429_and_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_74_is_samepatterns",
-    "language": "ts",
-    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors: string[], patterns: string[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_792_count_list",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of arrays in a given number of arrays.\nfunction count_list(input_list: number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_615_average_tuple",
-    "language": "ts",
-    "prompt": "//Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple(nums: number[][]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_747_lcs_of_three",
-    "language": "ts",
-    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X: string, Y: string, Z: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_268_find_star_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_798__sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of an array.\nfunction _sum(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_472_check_Consecutive",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive(l: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_440_find_adverb_position",
-    "language": "ts",
-    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text: string): [number, number, string] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_743_rotate_right",
-    "language": "ts",
-    "prompt": "//Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/tsthon-program-right-rotate-array-n/\nfunction rotate_right(list: number[], m: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_238_number_of_substrings",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_265_list_split",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split(S: any[], step: number): any[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_281_all_unique",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check if the elements of a given array are unique or not.\nfunction all_unique(test_list: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_252_convert",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to convert complex numbers to polar coordinates.\nfunction convert(numbers: number): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_477_is_lower",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to convert the given string to lower case.\nfunction is_lower(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_167_next_power_of_2",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_91_find_substring",
-    "language": "ts",
-    "prompt": "//Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring(str1: string[], sub_str: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_474_replace_char",
-    "language": "ts",
-    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1: string, ch: string, newch: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_784_mul_even_odd",
-    "language": "ts",
-    "prompt": "//Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd(list1: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_587_list_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to convert an array to an array.\nfunction list_tuple(listx: number[]): any {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_274_even_binomial_Coeff_Sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_399_bitwise_xor",
-    "language": "ts",
-    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_576_is_Sub_Array",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array(A: number[], B: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_286_max_sub_array_sum_repeated",
-    "language": "ts",
-    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a: number[], n: number, k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_409_min_product_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple(list1: [number, number][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_781_count_divisors",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the count of divisors is even. https://www.w3resource.com/tsthon-exercises/basic/tsthon-basic-1-exercise-24.php\nfunction count_divisors(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_626_triangle_area",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r: number): number | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_310_string_to_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to convert a given string to an array of characters.\nfunction string_to_tuple(str1: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_125_find_length",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_256_count_Primes_nums",
-    "language": "ts",
-    "prompt": "//Write a tsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_592_sum_Of_product",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_299_max_aggregate",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate(stdata: [string, number][]): [string, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_71_comb_sort",
-    "language": "ts",
-    "prompt": "//Write a function to sort an array of elements.\nfunction comb_sort(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_771_check_expression",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_454_text_match_wordz",
-    "language": "ts",
-    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_728_sum_list",
-    "language": "ts",
-    "prompt": "//Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1: number[], lst2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_260_newman_prime",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_390_add_string",
-    "language": "ts",
-    "prompt": "//Write a function to apply a given format string to all of the elements in an array.\nfunction add_string(list_: any[], string: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_581_surface_Area",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the surface area of a square tsramid with a given base edge and height.\nfunction surface_Area(b: number, s: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_95_Find_Min_Length",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length(lst: number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_283_validate",
-    "language": "ts",
-    "prompt": "//Write a tsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_135_hexagonal_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_389_find_lucas",
-    "language": "ts",
-    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_769_Diff",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to get the difference between two arrays.\nfunction Diff(li1: number[], li2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_725_extract_quotation",
-    "language": "ts",
-    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1: string): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_65_recursive_list_sum",
-    "language": "ts",
-    "prompt": "//Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum(data_list: number| number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_6_differ_At_One_Bit_Pos",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a: number, b: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_787_text_match_three",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_468_max_product",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_586_split_Arr",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr(l: number[], n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_96_divisor",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the number of divisors of a given integer.\nfunction divisor(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_588_big_diff",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_8_square_nums",
-    "language": "ts",
-    "prompt": "//Write a function to find squares of individual elements in an array.\nfunction square_nums(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_744_check_none",
-    "language": "ts",
-    "prompt": "//Write a function to check if the given array has any none value or not.\nfunction check_none(test_tup: any): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_68_is_Monotonic",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_803_is_perfect_square",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_126_sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of common divisors of two given numbers.\nfunction sum(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_290_max_length",
-    "language": "ts",
-    "prompt": "//Write a function to find the array of maximum length in an array of arrays.\nfunction max_length(list1: number[][]): [number, number[]] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_430_parabola_directrix",
-    "language": "ts",
-    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a: number, b: number, c: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_773_occurance_substring",
-    "language": "ts",
-    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return undefined if there is no match.\nfunction occurance_substring(text: string, pattern: string): [string, number, number] | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_791_remove_nested",
-    "language": "ts",
-    "prompt": "//Write a function to remove arrays from the given array.\nfunction remove_nested(test_tup: any): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_104_sort_sublists",
-    "language": "ts",
-    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(input_list: string[][]): string[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_610_remove_kth_element",
-    "language": "ts",
-    "prompt": "//Write a tsthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1: number[], L: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_720_add_dict_to_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to add an object to the array. The output should be an array.\nfunction add_dict_to_tuple(test_tup: [number, number, number], test_dict: {[key: string]: number}): [number, number, number, {[key: string]: number}] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_292_find",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n: number, m: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_285_text_match_two_three",
-    "language": "ts",
-    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_446_count_Occurrence",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence(tup: any, lst: any[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_142_count_samepair",
-    "language": "ts",
-    "prompt": "//Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair(list1: number[], list2: number[], list3: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_434_text_match_one",
-    "language": "ts",
-    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_555_difference",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_557_toggle_string",
-    "language": "ts",
-    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_418_Find_Max",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the element of an array having maximum length.\nfunction Find_Max(lst: any[][]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_103_eulerian_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n: number, m: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_168_frequency",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of occurrences of a number in a given array.\nfunction frequency(a: number[], x: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_749_sort_numeric_strings",
-    "language": "ts",
-    "prompt": "//Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/tsthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings(nums_str: string[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_738_geometric_sum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/tsthon-exercises/data-structures-and-algorithms/tsthon-recursion-exercise-9.php\nfunction geometric_sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_745_divisible_by_digits",
-    "language": "ts",
-    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/tsthon-exercises/lambda/tsthon-lambda-exercise-24.php\nfunction divisible_by_digits(startnum: number, endnum: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_573_unique_product",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product(list_data: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_443_largest_neg",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the largest negative number from the given array.\nfunction largest_neg(list1: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_730_consecutive_duplicates",
-    "language": "ts",
-    "prompt": "//Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates(nums: any[]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_617_min_Jumps",
-    "language": "ts",
-    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps: [number, number], d: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_415_max_Product",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr: number[]): [number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_413_extract_nth_element",
-    "language": "ts",
-    "prompt": "//Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element(list1: [string, number, number][], n: number): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_641_is_nonagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_145_max_Abs_Diff",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_778_pack_consecutive_duplicates",
-    "language": "ts",
-    "prompt": "//Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates(list1: any[]): any[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_448_cal_sum",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_226_odd_values_string",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_597_find_kth",
-    "language": "ts",
-    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1: number[], arr2: number[], k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_752_jacobsthal_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_97_frequency_lists",
-    "language": "ts",
-    "prompt": "//Write a function to find frequency of each element in a flattened array of arrays, returned in an object.\nfunction frequency_lists(list1: number[][]): {[key: number]: number} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_589_perfect_squares",
-    "language": "ts",
-    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a: number, b: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_734_sum_Of_Subarray_Prod",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_807_first_odd",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the first odd number in a given array of numbers.\nfunction first_odd(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_401_add_nested_tuples",
-    "language": "ts",
-    "prompt": "//Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_612_merge",
-    "language": "ts",
-    "prompt": "//Write a tsthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge(lst: any[][]): any[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_72_dif_Square",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_809_check_smaller",
-    "language": "ts",
-    "prompt": "//Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller(test_tup1: [number, number, number], test_tup2: [number, number, number]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_88_freq_count",
-    "language": "ts",
-    "prompt": "//Write a function to get the frequency of all the elements in an array, returned as an object.\nfunction freq_count(list1: number[]): {[key: number]: number} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_783_rgb_to_hsv",
-    "language": "ts",
-    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r: number, g: number, b: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_297_flatten_list",
-    "language": "ts",
-    "prompt": "//Write a function to flatten a given nested array structure.\nfunction flatten_list(list1: number| number[][]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_737_check_str",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_762_check_monthnumber_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_635_heap_sort",
-    "language": "ts",
-    "prompt": "//Write a function to sort the given array.\nfunction heap_sort(iterable: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_408_k_smallest_pairs",
-    "language": "ts",
-    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1: number[], nums2: number[], k: number): number[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_160_find_solution",
-    "language": "ts",
-    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undefined if no solution exists.\nfunction find_solution(a: number, b: number, n: number): [number, number] | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_57_find_Max_Num",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_805_max_sum_list",
-    "language": "ts",
-    "prompt": "//Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list(lists: number[][]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_591_swap_List",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to interchange the first and last elements in an array.\nfunction swap_List(newList: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_622_get_median",
-    "language": "ts",
-    "prompt": "//Write a function to find the median of two sorted arrays of same size.\nfunction get_median(arr1: number[], arr2: number[], n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_631_replace_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_164_are_equivalent",
-    "language": "ts",
-    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1: number, num2: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_456_reverse_string_list",
-    "language": "ts",
-    "prompt": "//Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list(stringlist: string[]): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_398_sum_of_digits",
-    "language": "ts",
-    "prompt": "//Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits(nums: any[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_84_sequence",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_4_heap_queue_largest",
-    "language": "ts",
-    "prompt": "//Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest(nums: number[], n: number): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_452_loss_amount",
-    "language": "ts",
-    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost: number, sale_amount: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_560_union_elements",
-    "language": "ts",
-    "prompt": "//Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements(test_tup1: number[], test_tup2: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_562_Find_Max_Length",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the length of the longest subarrays.\nfunction Find_Max_Length(lst: number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_640_remove_parenthesis",
-    "language": "ts",
-    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items: string[]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_406_find_Parity",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find whether the parity of a given number is odd.\nfunction find_Parity(x: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_432_median_trapezium",
-    "language": "ts",
-    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1: number, base2: number, height: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_86_centered_hexagonal_number",
-    "language": "ts",
-    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_143_find_lists",
-    "language": "ts",
-    "prompt": "//Write a function to find number of arrays present in the given array.\nfunction find_lists(Input: any[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_392_get_max_sum",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_90_len_log",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the length of the longest word.\nfunction len_log(list1: string[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_746_sector_area",
-    "language": "ts",
-    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undefined if the angle is larger than 360 degrees.\nfunction sector_area(r: number, a: number): number | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_775_odd_position",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position(nums: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_439_multiple_to_single",
-    "language": "ts",
-    "prompt": "//Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single(L: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_77_is_Diff",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find whether a number is divisible by 11.\nfunction is_Diff(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_445_index_multiplication",
-    "language": "ts",
-    "prompt": "//Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_785_tuple_str_int",
-    "language": "ts",
-    "prompt": "//Write a function to convert array string to integer array.\nfunction tuple_str_int(test_str: string): [number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_123_amicable_numbers_sum",
-    "language": "ts",
-    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_437_remove_odd",
-    "language": "ts",
-    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_726_multiply_elements",
-    "language": "ts",
-    "prompt": "//Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup: number[]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_802_count_rotation",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_400_extract_freq",
-    "language": "ts",
-    "prompt": "//Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq(test_list: [number, number][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_723_count_same_pair",
-    "language": "ts",
-    "prompt": "//The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair(nums1: number[], nums2: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_93_power",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_796_return_sum",
-    "language": "ts",
-    "prompt": "//Write function to find the sum of all items in the given object.\nfunction return_sum(dict: {[key: string]: number}): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_766_pair_wise",
-    "language": "ts",
-    "prompt": "//Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise(l1: number[]): [number, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_565_split",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to split a string into characters.\nfunction split(word: string): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_227_min_of_three",
-    "language": "ts",
-    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a: number, b: number, c: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_83_get_Char",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_295_sum_div",
-    "language": "ts",
-    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_253_count_integer",
-    "language": "ts",
-    "prompt": "//Write a tsthon function that returns the number of integer elements in a given array.\nfunction count_integer(list1: number| string| number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_572_two_unique_nums",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_19_test_duplicate",
-    "language": "ts",
-    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_583_catalan_number",
-    "language": "ts",
-    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_724_power_base_sum",
-    "language": "ts",
-    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base: number, power: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_240_replace_list",
-    "language": "ts",
-    "prompt": "//Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list(list1: any[], list2: any[]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_59_is_octagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_230_replace_blank",
-    "language": "ts",
-    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1: string, char: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_732_replace_specialchar",
-    "language": "ts",
-    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_116_tuple_to_int",
-    "language": "ts",
-    "prompt": "//Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int(nums: [number, number, number]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_293_otherside_rightangle",
-    "language": "ts",
-    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w: number, h: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_558_digit_distance_nums",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1: number, n2: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_643_text_match_wordz_middle",
-    "language": "ts",
-    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_593_removezero_ip",
-    "language": "ts",
-    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_425_count_element_in_list",
-    "language": "ts",
-    "prompt": "//Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list(list1: any[][], x: any): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_127_multiply_int",
-    "language": "ts",
-    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x: number, y: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_470_add_pairwise",
-    "language": "ts",
-    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise(test_tup: [number, number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_120_max_product_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple(list1: [number, number][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4324,7 +19,7 @@
     "language": "ts",
     "prompt": "//Write a function to find the kth element in the given array using 1-based indexing.\nfunction kth_element(arr: number[], k: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_101_kth_element.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = kth_element;\n  assert.deepEqual(candidate([12, 3, 5, 7, 19], 2),3);\n  assert.deepEqual(candidate([17, 24, 8, 23], 3),8);\n  assert.deepEqual(candidate([16, 21, 25, 36, 4], 4),36);\n}\n\ntest();",
     "stop_tokens": [
@@ -4335,13 +30,13 @@
     ]
   },
   {
-    "name": "mbpp_625_swap_List",
+    "name": "mbpp_102_snake_to_camel",
     "language": "ts",
-    "prompt": "//Write a tsthon function to interchange the first and last element in a given array.\nfunction swap_List(newList: number[]): number[] {\n",
+    "prompt": "//Write a function to convert a snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_102_snake_to_camel.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"python_program\"),\"PythonProgram\");\n  assert.deepEqual(candidate(\"python_language\"),\"PythonLanguage\");\n  assert.deepEqual(candidate(\"programming_language\"),\"ProgrammingLanguage\");\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4350,13 +45,13 @@
     ]
   },
   {
-    "name": "mbpp_278_count_first_elements",
+    "name": "mbpp_103_eulerian_num",
     "language": "ts",
-    "prompt": "//Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements(test_tup: number| [number, number][]): number {\n",
+    "prompt": "//Write a function to find the Eulerian number a(n, m).\nfunction eulerian_num(n: number, m: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_103_eulerian_num.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = eulerian_num;\n  assert.deepEqual(candidate(3, 1),4);\n  assert.deepEqual(candidate(4, 1),11);\n  assert.deepEqual(candidate(5, 3),26);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4365,13 +60,13 @@
     ]
   },
   {
-    "name": "mbpp_786_right_insertion",
+    "name": "mbpp_104_sort_sublists",
     "language": "ts",
-    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a: number[], x: number): number {\n",
+    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(input_list: string[][]): string[][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_104_sort_sublists.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\" red \", \"green\"], [\"blue \", \" black\"], [\" orange\", \"brown\"]]),[[\" red \", \"green\"], [\" black\", \"blue \"], [\" orange\", \"brown\"]]);\n  assert.deepEqual(candidate([[\"zilver\", \"gold\"], [\"magnesium\", \"aluminium\"], [\"steel\", \"bronze\"]]),[[\"gold\", \"zilver\"], [\"aluminium\", \"magnesium\"], [\"bronze\", \"steel\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4380,13 +75,13 @@
     ]
   },
   {
-    "name": "mbpp_20_is_woodall",
+    "name": "mbpp_105_count",
     "language": "ts",
-    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x: number): boolean {\n",
+    "prompt": "//Write a tsthon function to count true booleans in the given array.\nfunction count(lst: boolean[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_105_count.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count;\n  assert.deepEqual(candidate([true, false, true]),2);\n  assert.deepEqual(candidate([false, false]),0);\n  assert.deepEqual(candidate([true, true, true]),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4395,13 +90,13 @@
     ]
   },
   {
-    "name": "mbpp_428_shell_sort",
+    "name": "mbpp_106_add_lists",
     "language": "ts",
-    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list: number[]): number[] {\n",
+    "prompt": "//Write a function to append the given array to the given arrays.\nfunction add_lists(test_list: number[], test_tup: [number, number]): [number, number, number, number, number] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4410,13 +105,13 @@
     ]
   },
   {
-    "name": "mbpp_556_find_Odd_Pair",
+    "name": "mbpp_108_merge_sorted_list",
     "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A: number[], N: number): number {\n",
+    "prompt": "//Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list(num1: number[], num2: number[], num3: number[]): number[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4425,13 +120,13 @@
     ]
   },
   {
-    "name": "mbpp_797_sum_in_range",
+    "name": "mbpp_109_odd_Equivalent",
     "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l: number, r: number): number {\n",
+    "prompt": "//Write a tsthon function to find the number of numbers with an odd value when rotating a binary string the given number of times.\nfunction odd_Equivalent(s: string, n: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_109_odd_Equivalent.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_Equivalent;\n  assert.deepEqual(candidate(\"011001\", 6),3);\n  assert.deepEqual(candidate(\"11011\", 5),4);\n  assert.deepEqual(candidate(\"1010\", 4),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4440,13 +135,13 @@
     ]
   },
   {
-    "name": "mbpp_17_square_perimeter",
+    "name": "mbpp_113_check_integer",
     "language": "ts",
-    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a: number): number {\n",
+    "prompt": "//Write a function to check if a string represents an integer or not.\nfunction check_integer(text: string): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_113_check_integer.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_integer;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"1\"),true);\n  assert.deepEqual(candidate(\"12345\"),true);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4455,223 +150,13 @@
     ]
   },
   {
-    "name": "mbpp_765_is_polite",
+    "name": "mbpp_116_tuple_to_int",
     "language": "ts",
-    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n: number): number {\n",
+    "prompt": "//Write a function to convert a given array of positive integers into a single integer.\nfunction tuple_to_int(nums: [number, number, number]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_116_tuple_to_int.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_162_sum_series",
-    "language": "ts",
-    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_579_find_dissimilar",
-    "language": "ts",
-    "prompt": "//Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_305_start_withp",
-    "language": "ts",
-    "prompt": "//Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp(words: string[]): [string, string] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_411_snake_to_camel",
-    "language": "ts",
-    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_234_volume_cube",
-    "language": "ts",
-    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_455_check_monthnumb_number",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n: number, l: number, r: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_460_Extract",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to get the first element of each subarray.\nfunction Extract(lst: number[][]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_574_surfacearea_cylinder",
-    "language": "ts",
-    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r: number, h: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_639_sample_nam",
-    "language": "ts",
-    "prompt": "//Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names: string[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_407_rearrange_bigger",
-    "language": "ts",
-    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n: number): any {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_171_perimeter_pentagon",
-    "language": "ts",
-    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_245_max_sum",
-    "language": "ts",
-    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_580_extract_even",
-    "language": "ts",
-    "prompt": "//Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even(test_tuple: [number, number, [number, number, [number, number]], number, number]): any {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_int;\n  assert.deepEqual(candidate([1, 2, 3]),123);\n  assert.deepEqual(candidate([4, 5, 6]),456);\n  assert.deepEqual(candidate([5, 6, 7]),567);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4684,249 +169,9 @@
     "language": "ts",
     "prompt": "//Write a function to convert all possible convertible elements in an array of arrays to floats.\nfunction list_to_float(test_list: [string, string][]): [number, number][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_117_list_to_float.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_to_float;\n  assert.deepEqual(candidate([[\"3\", \"4\"], [\"1\", \"26.45\"], [\"7.32\", \"8\"], [\"4\", \"8\"]]),[[3.0, 4.0], [1.0, 26.45], [7.32, 8.0], [4.0, 8.0]]);\n  assert.deepEqual(candidate([[\"4\", \"4\"], [\"2\", \"27\"], [\"4.12\", \"9\"], [\"7\", \"11\"]]),[[4.0, 4.0], [2.0, 27.0], [4.12, 9.0], [7.0, 11.0]]);\n  assert.deepEqual(candidate([[\"6\", \"78\"], [\"5\", \"26.45\"], [\"1.33\", \"4\"], [\"82\", \"13\"]]),[[6.0, 78.0], [5.0, 26.45], [1.33, 4.0], [82.0, 13.0]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_287_square_Sum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_767_get_pairs_count",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count(arr: number[], sum: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_291_count_no_of_ways",
-    "language": "ts",
-    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n: number, k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_604_reverse_words",
-    "language": "ts",
-    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_56_checks",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to check if a given number is one less than twice its reverse.\nfunction checks(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_793_last",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the last position of an element in a sorted array.\nfunction last(arr: number[], x: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_250_count_X",
-    "language": "ts",
-    "prompt": "//Write a tsthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X(tup: number[], x: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_754_extract_index_list",
-    "language": "ts",
-    "prompt": "//We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list(l1: number[], l2: number[], l3: number[]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_755_second_smallest",
-    "language": "ts",
-    "prompt": "//Write a function to find the second smallest number in an array.\nfunction second_smallest(numbers: number| number[]): number | undefined {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_421_concatenate_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple(test_tup: [string, string, number, string]): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_628_replace_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_170_sum_range_list",
-    "language": "ts",
-    "prompt": "//Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list(list1: number[], m: number, n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_87_merge_dictionaries_three",
-    "language": "ts",
-    "prompt": "//Write a function to merge three dictionaries into a single object.\nfunction merge_dictionaries_three(dict1: {[key: string]: string}, dict2: {[key: string]: string}, dict3: {[key: string]: string}): {[key: string]: string} {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_404_minimum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the minimum of two numbers.\nfunction minimum(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_63_max_difference",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference(test_list: [number, number][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_304_find_Element",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find element at a given index after number of rotations.\nfunction find_Element(arr: number[], ranges: number[][], rotations: number, index: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4939,7 +184,7 @@
     "language": "ts",
     "prompt": "//Write a function to convert a string to an array of strings split on the space character.\nfunction string_to_list(string: string): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_118_string_to_list.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_list;\n  assert.deepEqual(candidate(\"python programming\"),[\"python\", \"programming\"]);\n  assert.deepEqual(candidate(\"lists tuples strings\"),[\"lists\", \"tuples\", \"strings\"]);\n  assert.deepEqual(candidate(\"write a program\"),[\"write\", \"a\", \"program\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -4954,24 +199,9 @@
     "language": "ts",
     "prompt": "//Write a tsthon function to find the element that appears only once in a sorted array.\nfunction search(arr: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_119_search.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = search;\n  assert.deepEqual(candidate([1, 1, 2, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1, 3, 3, 4, 4, 5, 5, 7, 7, 8]),8);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 4, 4]),1);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_475_sort_counter",
-    "language": "ts",
-    "prompt": "//Write a function to sort an object by value.\nfunction sort_counter(dict1: {[key: string]: number}): [string, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -4984,7 +214,7 @@
     "language": "ts",
     "prompt": "//Write a tsthon function to remove first and last occurrence of a given character from the string.\nfunction remove_Occ(s: string, ch: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_11_remove_Occ.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_Occ;\n  assert.deepEqual(candidate(\"hello\", \"l\"),\"heo\");\n  assert.deepEqual(candidate(\"abcda\", \"a\"),\"bcd\");\n  assert.deepEqual(candidate(\"PHP\", \"P\"),\"H\");\n}\n\ntest();",
     "stop_tokens": [
@@ -4995,13 +225,13 @@
     ]
   },
   {
-    "name": "mbpp_266_lateralsurface_cube",
+    "name": "mbpp_120_max_product_tuple",
     "language": "ts",
-    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l: number): number {\n",
+    "prompt": "//Write a function to find the maximum absolute product between numbers in pairs of arrays within a given array.\nfunction max_product_tuple(list1: [number, number][]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_120_max_product_tuple.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),36);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),200);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),484);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5010,13 +240,13 @@
     ]
   },
   {
-    "name": "mbpp_431_common_element",
+    "name": "mbpp_123_amicable_numbers_sum",
     "language": "ts",
-    "prompt": "//Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element(list1: any[], list2: any[]): boolean | undefined {\n",
+    "prompt": "//Write a function to sum all amicable numbers from 1 to a specified number.\nfunction amicable_numbers_sum(limit: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_123_amicable_numbers_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = amicable_numbers_sum;\n  assert.deepEqual(candidate(999),504);\n  assert.deepEqual(candidate(9999),31626);\n  assert.deepEqual(candidate(99),0);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5025,13 +255,13 @@
     ]
   },
   {
-    "name": "mbpp_106_add_lists",
+    "name": "mbpp_125_find_length",
     "language": "ts",
-    "prompt": "//Write a function to append the given array to the given arrays.\nfunction add_lists(test_list: number[], test_tup: [number, number]): [number, number, number, number, number] {\n",
+    "prompt": "//Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nfunction find_length(string: string): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_106_add_lists.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_125_find_length.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_lists;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[9, 10, 5, 6, 7]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[10, 11, 6, 7, 8]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_length;\n  assert.deepEqual(candidate(\"11000010001\"),6);\n  assert.deepEqual(candidate(\"10111\"),1);\n  assert.deepEqual(candidate(\"11011101100101\"),2);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5040,13 +270,13 @@
     ]
   },
   {
-    "name": "mbpp_623_nth_nums",
+    "name": "mbpp_126_sum",
     "language": "ts",
-    "prompt": "//Write a function to compute the n-th power of each number in an array.\nfunction nth_nums(nums: number[], n: number): number[] {\n",
+    "prompt": "//Write a tsthon function to find the sum of common divisors of two given numbers.\nfunction sum(a: number, b: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_126_sum.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum;\n  assert.deepEqual(candidate(10, 15),6);\n  assert.deepEqual(candidate(100, 150),93);\n  assert.deepEqual(candidate(4, 6),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5055,358 +285,13 @@
     ]
   },
   {
-    "name": "mbpp_141_pancake_sort",
+    "name": "mbpp_127_multiply_int",
     "language": "ts",
-    "prompt": "//Write a function to sort an array of elements.\nfunction pancake_sort(nums: number[]): number[] {\n",
+    "prompt": "//Write a function to multiply two integers.\nfunction multiply_int(x: number, y: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_127_multiply_int.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_397_median_numbers",
-    "language": "ts",
-    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a: number, b: number, c: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_433_check_greater",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr: number[], number: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_284_check_element",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element(list: any[], element: any): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_450_extract_string",
-    "language": "ts",
-    "prompt": "//Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string(str: string[], l: number): string[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_16_text_lowercase_underscore",
-    "language": "ts",
-    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text: string): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_444_trim_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to trim each array by k in the given arrays.\nfunction trim_tuple(test_list: number[][], K: number): number[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_457_Find_Min",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the subarray having minimum length.\nfunction Find_Min(lst: any[][]): any[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_426_filter_oddnumbers",
-    "language": "ts",
-    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_584_find_adverbs",
-    "language": "ts",
-    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_611_max_of_nth",
-    "language": "ts",
-    "prompt": "//Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth(test_list: number[][], N: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_99_decimal_to_binary",
-    "language": "ts",
-    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n: number): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_255_combinations_colors",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors(l: string[], n: number): string[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_800_remove_all_spaces",
-    "language": "ts",
-    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text: string): string {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_595_min_Swaps",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1: string, str2: string): any {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_788_new_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to create a new array from the given string and array.\nfunction new_tuple(test_list: string[], test_str: string): [string, string, string] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_471_find_remainder",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr: number[], n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_410_min_val",
-    "language": "ts",
-    "prompt": "//Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val(listval: string| number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_442_positive_count",
-    "language": "ts",
-    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_750_add_tuple",
-    "language": "ts",
-    "prompt": "//Write a function to add the given array to the given array.\nfunction add_tuple(test_list: number[], test_tup: [number, number]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_806_max_run_uppercase",
-    "language": "ts",
-    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_12_sort_matrix",
-    "language": "ts",
-    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M: number[][]): number[][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_776_count_vowels",
-    "language": "ts",
-    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_306_max_sum_increasing_subseq",
-    "language": "ts",
-    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a: number[], n: number, index: number, k: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_int;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(5, 10),50);\n  assert.deepEqual(candidate(4, 8),32);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5419,7 +304,7 @@
     "language": "ts",
     "prompt": "//Write a function to find words that are longer than n characters from a given array of words.\nfunction long_words(n: number, str: string): string[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_128_long_words.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = long_words;\n  assert.deepEqual(candidate(3, \"python is a programming language\"),[\"python\", \"programming\", \"language\"]);\n  assert.deepEqual(candidate(2, \"writing a program\"),[\"writing\", \"program\"]);\n  assert.deepEqual(candidate(5, \"sorting list\"),[\"sorting\"]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5430,13 +315,13 @@
     ]
   },
   {
-    "name": "mbpp_777_find_sum",
+    "name": "mbpp_129_magic_square_test",
     "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum(arr: number[]): number {\n",
+    "prompt": "//Write a function to calculate whether the matrix is a magic square.\nfunction magic_square_test(my_matrix: number[][]): boolean {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_129_magic_square_test.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = magic_square_test;\n  assert.deepEqual(candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]]),true);\n  assert.deepEqual(candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]]),false);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5445,13 +330,13 @@
     ]
   },
   {
-    "name": "mbpp_740_tuple_to_dict",
+    "name": "mbpp_12_sort_matrix",
     "language": "ts",
-    "prompt": "//Write a function to convert the given array to a key-value object using adjacent elements. https://www.geeksforgeeks.org/tsthon-convert-array-to-adjacent-pair-object/\nfunction tuple_to_dict(test_tup: [number, number, number, number, number, number]): {[key: number]: number} {\n",
+    "prompt": "//Write a function to sort a given matrix in ascending order according to the sum of its rows.\nfunction sort_matrix(M: number[][]): number[][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_12_sort_matrix.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_matrix;\n  assert.deepEqual(candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]]),[[1, 1, 1], [1, 2, 3], [2, 4, 5]]);\n  assert.deepEqual(candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]]),[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]);\n  assert.deepEqual(candidate([[5, 8, 9], [6, 4, 3], [2, 1, 4]]),[[2, 1, 4], [6, 4, 3], [5, 8, 9]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5460,223 +345,13 @@
     ]
   },
   {
-    "name": "mbpp_630_get_coordinates",
+    "name": "mbpp_130_max_occurrences",
     "language": "ts",
-    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates(test_tup: [number, number]): number[][] {\n",
+    "prompt": "//Write a function to find the item with maximum frequency in a given array.\nfunction max_occurrences(nums: number[]): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_130_max_occurrences.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_222_check_type",
-    "language": "ts",
-    "prompt": "//Write a function to check if all the elements in array have same data type or not.\nfunction check_type(test_tuple: any): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_627_find_First_Missing",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing(array: number[]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_92_is_undulating",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n: number): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_753_min_k",
-    "language": "ts",
-    "prompt": "//Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/tsthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cots of test cases\nfunction min_k(test_list: [string, number][], K: number): [string, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_61_count_Substrings",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s: string): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_279_is_num_decagonal",
-    "language": "ts",
-    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_272_rear_extract",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract(test_list: [number, string, number][]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_89_closest_num",
-    "language": "ts",
-    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_780_find_combinations",
-    "language": "ts",
-    "prompt": "//Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/tsthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations(test_list: [number, number][]): [number, number][] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_721_maxAverageOfPath",
-    "language": "ts",
-    "prompt": "//Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost: number[][]): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_280_sequential_search",
-    "language": "ts",
-    "prompt": "//Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist: number[], item: number): [boolean, number] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_412_remove_odd",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to remove odd numbers from a given array.\nfunction remove_odd(l: number[]): number[] {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_804_is_product_even",
-    "language": "ts",
-    "prompt": "//Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even(arr: number[]): boolean {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
-    "stop_tokens": [
-      "\nfunction ",
-      "\n/*",
-      "\n//",
-      "\nclass"
-    ]
-  },
-  {
-    "name": "mbpp_309_maximum",
-    "language": "ts",
-    "prompt": "//Write a tsthon function to find the maximum of two numbers.\nfunction maximum(a: number, b: number): number {\n",
-    "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
-    "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_occurrences;\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 2, 6, 5, 1, 6, 1, 2, 3, 2, 4, 6, 9, 1, 2]),2);\n  assert.deepEqual(candidate([2, 3, 8, 4, 7, 9, 8, 7, 9, 15, 14, 10, 12, 13, 16, 18]),8);\n  assert.deepEqual(candidate([10, 20, 20, 30, 40, 90, 80, 50, 30, 20, 50, 10]),20);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5689,9 +364,744 @@
     "language": "ts",
     "prompt": "//Write a tsthon function to reverse only the vowels of a given string (where y is not a vowel).\nfunction reverse_vowels(str1: string): string {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_131_reverse_vowels.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_vowels;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"USA\"),\"ASU\");\n  assert.deepEqual(candidate(\"ab\"),\"ab\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_132_tup_string",
+    "language": "ts",
+    "prompt": "//Write a function to convert an array to a string.\nfunction tup_string(tup1: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_132_tup_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tup_string;\n  assert.deepEqual(candidate([\"e\", \"x\", \"e\", \"r\", \"c\", \"i\", \"s\", \"e\", \"s\"]),\"exercises\");\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]),\"python\");\n  assert.deepEqual(candidate([\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]),\"program\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_133_sum_negativenum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum of the negative numbers of a given array of numbers.\nfunction sum_negativenum(nums: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_133_sum_negativenum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_negativenum;\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),-32);\n  assert.deepEqual(candidate([10, 15, -14, 13, -18, 12, -20]),-52);\n  assert.deepEqual(candidate([19, -65, 57, 39, 152, -639, 121, 44, 90, -190]),-894);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_135_hexagonal_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth hexagonal number.\nfunction hexagonal_num(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_135_hexagonal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = hexagonal_num;\n  assert.deepEqual(candidate(10),190);\n  assert.deepEqual(candidate(5),45);\n  assert.deepEqual(candidate(7),91);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_138_is_Sum_Of_Powers_Of_Two",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nfunction is_Sum_Of_Powers_Of_Two(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_138_is_Sum_Of_Powers_Of_Two.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sum_Of_Powers_Of_Two;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(7),false);\n  assert.deepEqual(candidate(14),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_141_pancake_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort an array of elements.\nfunction pancake_sort(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_141_pancake_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pancake_sort;\n  assert.deepEqual(candidate([15, 79, 25, 38, 69]),[15, 25, 38, 69, 79]);\n  assert.deepEqual(candidate([98, 12, 54, 36, 85]),[12, 36, 54, 85, 98]);\n  assert.deepEqual(candidate([41, 42, 32, 12, 23]),[12, 23, 32, 41, 42]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_142_count_samepair",
+    "language": "ts",
+    "prompt": "//Write a function to count number items that are identical in the same position of three given arrays.\nfunction count_samepair(list1: number[], list2: number[], list3: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_142_count_samepair.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_samepair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9], [2, 1, 3, 1, 2, 6, 7, 9]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 2, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 8], [2, 1, 3, 1, 2, 6, 7, 8]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_143_find_lists",
+    "language": "ts",
+    "prompt": "//Write a function to find number of arrays present in the given array.\nfunction find_lists(Input: any[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_143_find_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8]]),2);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6]]),3);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5, 4, 3, 2, 1]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_145_max_Abs_Diff",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the maximum difference between any two elements in a given array.\nfunction max_Abs_Diff(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_145_max_Abs_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Abs_Diff;\n  assert.deepEqual(candidate([2, 1, 5, 3]),4);\n  assert.deepEqual(candidate([9, 3, 2, 5, 1]),8);\n  assert.deepEqual(candidate([3, 2, 1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_14_find_Volume",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the volume of a triangular prism.\nfunction find_Volume(l: number, b: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_14_find_Volume.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Volume;\n  assert.deepEqual(candidate(10, 8, 6),240);\n  assert.deepEqual(candidate(3, 2, 2),6);\n  assert.deepEqual(candidate(1, 2, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_160_find_solution",
+    "language": "ts",
+    "prompt": "//Write a function that returns integers x and y that satisfy ax + by = n as an array, or return undefined if no solution exists.\nfunction find_solution(a: number, b: number, n: number): [number, number] | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_160_find_solution.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_solution;\n  assert.deepEqual(candidate(2, 3, 7),[2, 1]);\n  assert.deepEqual(candidate(4, 2, 7),undefined);\n  assert.deepEqual(candidate(1, 13, 17),[4, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_161_remove_elements",
+    "language": "ts",
+    "prompt": "//Write a function to remove all elements from a given array present in another array.\nfunction remove_elements(list1: number[], list2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_161_remove_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_elements;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7]),[2, 4, 6, 8, 9, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [5, 7]),[1, 2, 3, 4, 6, 8, 9, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_162_sum_series",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum (n - 2*i) from i=0 to n // 2, for instance n + (n-2) + (n-4)... (until n-x =< 0).\nfunction sum_series(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_162_sum_series.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_series;\n  assert.deepEqual(candidate(6),12);\n  assert.deepEqual(candidate(10),30);\n  assert.deepEqual(candidate(9),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_164_are_equivalent",
+    "language": "ts",
+    "prompt": "//Write a function to determine if the sum of the divisors of two integers are the same.\nfunction are_equivalent(num1: number, num2: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_164_are_equivalent.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = are_equivalent;\n  assert.deepEqual(candidate(36, 57),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(23, 47),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_165_count_char_position",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of characters in a string that occur at the same position in the string as in the English alphabet (case insensitive).\nfunction count_char_position(str1: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_165_count_char_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_char_position;\n  assert.deepEqual(candidate(\"xbcefg\"),2);\n  assert.deepEqual(candidate(\"ABcED\"),3);\n  assert.deepEqual(candidate(\"AbgdeF\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_166_find_even_pair",
+    "language": "ts",
+    "prompt": "//Write a function that counts the number of pairs of integers in an array that xor to an even number.\nfunction find_even_pair(A: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_166_find_even_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_even_pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1]),4);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11]),9);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_167_next_power_of_2",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the smallest power of 2 greater than or equal to n.\nfunction next_power_of_2(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_167_next_power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_power_of_2;\n  assert.deepEqual(candidate(0),1);\n  assert.deepEqual(candidate(5),8);\n  assert.deepEqual(candidate(17),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_168_frequency",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of occurrences of a number in a given array.\nfunction frequency(a: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_168_frequency.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency;\n  assert.deepEqual(candidate([1, 2, 3], 4),0);\n  assert.deepEqual(candidate([1, 2, 2, 3, 3, 3, 4], 3),3);\n  assert.deepEqual(candidate([0, 1, 2, 3, 1, 2], 1),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_16_text_lowercase_underscore",
+    "language": "ts",
+    "prompt": "//Write a function to that returns true if the input string contains sequences of lowercase letters joined with an underscore and false otherwise.\nfunction text_lowercase_underscore(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_16_text_lowercase_underscore.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_lowercase_underscore;\n  assert.deepEqual(candidate(\"aab_cbbbc\"),true);\n  assert.deepEqual(candidate(\"aab_Abbbc\"),false);\n  assert.deepEqual(candidate(\"Aaab_abbbc\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_170_sum_range_list",
+    "language": "ts",
+    "prompt": "//Write a function to find the sum of numbers in an array within a range specified by two indices.\nfunction sum_range_list(list1: number[], m: number, n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_170_sum_range_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_range_list;\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 8, 10),29);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 5, 7),16);\n  assert.deepEqual(candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], 7, 10),38);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_171_perimeter_pentagon",
+    "language": "ts",
+    "prompt": "//Write a function to find the perimeter of a regular pentagon from the length of its sides.\nfunction perimeter_pentagon(a: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_171_perimeter_pentagon.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perimeter_pentagon;\n  assert.deepEqual(candidate(5),25);\n  assert.deepEqual(candidate(10),50);\n  assert.deepEqual(candidate(15),75);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_172_count_occurance",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of occurence of the string 'std' in a given string.\nfunction count_occurance(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_172_count_occurance.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_occurance;\n  assert.deepEqual(candidate(\"letstdlenstdporstd\"),3);\n  assert.deepEqual(candidate(\"truststdsolensporsd\"),1);\n  assert.deepEqual(candidate(\"makestdsostdworthit\"),2);\n  assert.deepEqual(candidate(\"stds\"),1);\n  assert.deepEqual(candidate(\"\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_17_square_perimeter",
+    "language": "ts",
+    "prompt": "//Write a function that returns the perimeter of a square given its side length as input.\nfunction square_perimeter(a: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_17_square_perimeter.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_perimeter;\n  assert.deepEqual(candidate(10),40);\n  assert.deepEqual(candidate(5),20);\n  assert.deepEqual(candidate(4),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_18_remove_dirty_chars",
+    "language": "ts",
+    "prompt": "//Write a function to remove characters from the first string which are present in the second string.\nfunction remove_dirty_chars(string: string, second_string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_18_remove_dirty_chars.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_dirty_chars;\n  assert.deepEqual(candidate(\"probasscurve\", \"pros\"),\"bacuve\");\n  assert.deepEqual(candidate(\"digitalindia\", \"talent\"),\"digiidi\");\n  assert.deepEqual(candidate(\"exoticmiles\", \"toxic\"),\"emles\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_19_test_duplicate",
+    "language": "ts",
+    "prompt": "//Write a function to find whether a given array of integers contains any duplicate element.\nfunction test_duplicate(arraynums: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_19_test_duplicate.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_duplicate;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),true);\n  assert.deepEqual(candidate([1, 1, 2, 2, 3, 3, 4, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_20_is_woodall",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given number is woodball or not.\nfunction is_woodall(x: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_20_is_woodall.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_woodall;\n  assert.deepEqual(candidate(383),true);\n  assert.deepEqual(candidate(254),false);\n  assert.deepEqual(candidate(200),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_222_check_type",
+    "language": "ts",
+    "prompt": "//Write a function to check if all the elements in array have same data type or not.\nfunction check_type(test_tuple: any): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_222_check_type.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_type;\n  assert.deepEqual(candidate([5, 6, 7, 3, 5, 6]),true);\n  assert.deepEqual(candidate([1, 2, \"4\"]),false);\n  assert.deepEqual(candidate([3, 2, 1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_223_is_majority",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a sorted array, its length (n), and an element and returns whether the element is the majority element in the given sorted array. (The majority element is the element that occurs more than n/2 times.)\nfunction is_majority(arr: number[], n: number, x: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_223_is_majority.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_majority;\n  assert.deepEqual(candidate([1, 2, 3, 3, 3, 3, 10], 7, 3),true);\n  assert.deepEqual(candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4),false);\n  assert.deepEqual(candidate([1, 1, 1, 2, 2], 5, 1),true);\n  assert.deepEqual(candidate([1, 1, 2, 2], 5, 1),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_224_count_Set_Bits",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of set bits (binary digits with value 1) in a given number.\nfunction count_Set_Bits(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_224_count_Set_Bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Set_Bits;\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),1);\n  assert.deepEqual(candidate(6),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_226_odd_values_string",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to remove the characters which have odd index values of a given string.\nfunction odd_values_string(str: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_226_odd_values_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_values_string;\n  assert.deepEqual(candidate(\"abcdef\"),\"ace\");\n  assert.deepEqual(candidate(\"python\"),\"pto\");\n  assert.deepEqual(candidate(\"data\"),\"dt\");\n  assert.deepEqual(candidate(\"lambs\"),\"lms\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_227_min_of_three",
+    "language": "ts",
+    "prompt": "//Write a function to find minimum of three numbers.\nfunction min_of_three(a: number, b: number, c: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_227_min_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_of_three;\n  assert.deepEqual(candidate(10, 20, 0),0);\n  assert.deepEqual(candidate(19, 15, 18),15);\n  assert.deepEqual(candidate(-10, -20, -30),-30);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_228_all_Bits_Set_In_The_Given_Range",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether all the bits are unset in the given range or not.\nfunction all_Bits_Set_In_The_Given_Range(n: number, l: number, r: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_228_all_Bits_Set_In_The_Given_Range.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Bits_Set_In_The_Given_Range;\n  assert.deepEqual(candidate(4, 1, 2),true);\n  assert.deepEqual(candidate(17, 2, 4),true);\n  assert.deepEqual(candidate(39, 4, 6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_229_re_arrange_array",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and an integer n, and re-arranges the first n elements of the given array so that all negative elements appear before positive ones, and where the relative order among negative and positive elements is preserved.\nfunction re_arrange_array(arr: number[], n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_229_re_arrange_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = re_arrange_array;\n  assert.deepEqual(candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9),[-1, -3, -7, 4, 5, 6, 2, 8, 9]);\n  assert.deepEqual(candidate([12, -14, -26, 13, 15], 5),[-14, -26, 12, 13, 15]);\n  assert.deepEqual(candidate([10, 24, 36, -42, -39, -78, 85], 7),[-42, -39, -78, 10, 24, 36, 85]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_230_replace_blank",
+    "language": "ts",
+    "prompt": "//Write a function that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.\nfunction replace_blank(str1: string, char: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_230_replace_blank.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_blank;\n  assert.deepEqual(candidate(\"hello people\", \"@\"),\"hello@people\");\n  assert.deepEqual(candidate(\"python program language\", \"$\"),\"python$program$language\");\n  assert.deepEqual(candidate(\"blank space\", \"-\"),\"blank-space\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_234_volume_cube",
+    "language": "ts",
+    "prompt": "//Write a function to find the volume of a cube given its side length.\nfunction volume_cube(l: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_234_volume_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = volume_cube;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(2),8);\n  assert.deepEqual(candidate(5),125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_238_number_of_substrings",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of non-empty substrings of a given string.\nfunction number_of_substrings(str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_238_number_of_substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_of_substrings;\n  assert.deepEqual(candidate(\"abc\"),6);\n  assert.deepEqual(candidate(\"abcd\"),10);\n  assert.deepEqual(candidate(\"abcde\"),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_239_get_total_number_of_sequences",
+    "language": "ts",
+    "prompt": "//Write a function that takes in positive integers m and n and finds the number of possible sequences of length n, such that each element is a positive integer and is greater than or equal to twice the previous element but less than or equal to m.\nfunction get_total_number_of_sequences(m: number, n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_239_get_total_number_of_sequences.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_total_number_of_sequences;\n  assert.deepEqual(candidate(10, 4),4);\n  assert.deepEqual(candidate(5, 2),6);\n  assert.deepEqual(candidate(16, 3),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_240_replace_list",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two arrays and replaces the last element of the first array with the elements of the second array.\nfunction replace_list(list1: any[], list2: any[]): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_240_replace_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_list;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 10], [2, 4, 6, 8]),[1, 3, 5, 7, 9, 2, 4, 6, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8]),[1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([\"red\", \"blue\", \"green\"], [\"yellow\"]),[\"red\", \"blue\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_242_count_charac",
+    "language": "ts",
+    "prompt": "//Write a function to count the total number of characters in a string.\nfunction count_charac(str1: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_242_count_charac.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_charac;\n  assert.deepEqual(candidate(\"python programming\"),18);\n  assert.deepEqual(candidate(\"language\"),8);\n  assert.deepEqual(candidate(\"words\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_244_next_Perfect_Square",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the next perfect square greater than a given number.\nfunction next_Perfect_Square(N: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_244_next_Perfect_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = next_Perfect_Square;\n  assert.deepEqual(candidate(35),36);\n  assert.deepEqual(candidate(6),9);\n  assert.deepEqual(candidate(9),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_245_max_sum",
+    "language": "ts",
+    "prompt": "//Write a function that takes an array and finds the maximum sum of a bitonic subsequence for the given array, where a sequence is bitonic if it is first increasing and then decreasing.\nfunction max_sum(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_245_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum;\n  assert.deepEqual(candidate([1, 15, 51, 45, 33, 100, 12, 18, 9]),194);\n  assert.deepEqual(candidate([80, 60, 30, 40, 20, 10]),210);\n  assert.deepEqual(candidate([2, 3, 14, 16, 21, 23, 29, 30]),138);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_247_lps",
+    "language": "ts",
+    "prompt": "//Write a function to find the length of the longest palindromic subsequence in the given string.\nfunction lps(str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_247_lps.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lps;\n  assert.deepEqual(candidate(\"TENS FOR TENS\"),5);\n  assert.deepEqual(candidate(\"CARDIO FOR CARDS\"),7);\n  assert.deepEqual(candidate(\"PART OF THE JOURNEY IS PART\"),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_249_intersection_array",
+    "language": "ts",
+    "prompt": "//Write a function to find the intersection of two arrays.\nfunction intersection_array(array_nums1: number[], array_nums2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_249_intersection_array.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = intersection_array;\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [1, 2, 4, 8, 9]),[1, 2, 8, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [3, 5, 7, 9]),[3, 5, 7, 9]);\n  assert.deepEqual(candidate([1, 2, 3, 5, 7, 8, 9, 10], [10, 20, 30, 40]),[10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_250_count_X",
+    "language": "ts",
+    "prompt": "//Write a tsthon function that takes in an array and an element and counts the occcurences of the element in the array.\nfunction count_X(tup: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_250_count_X.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_X;\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 4),0);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 10),3);\n  assert.deepEqual(candidate([10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2], 8),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_251_insert_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and an element and inserts the element before each element in the array, and returns the resulting array.\nfunction insert_element(list: string[], element: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_251_insert_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = insert_element;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Black\"], \"c\"),[\"c\", \"Red\", \"c\", \"Green\", \"c\", \"Black\"]);\n  assert.deepEqual(candidate([\"python\", \"java\"], \"program\"),[\"program\", \"python\", \"program\", \"java\"]);\n  assert.deepEqual(candidate([\"happy\", \"sad\"], \"laugh\"),[\"laugh\", \"happy\", \"laugh\", \"sad\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_252_convert",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to convert complex numbers to polar coordinates.\nfunction convert(numbers: number): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_252_convert.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = convert;\n  assert.deepEqual(candidate(1),[1.0, 0.0]);\n  assert.deepEqual(candidate(4),[4.0, 0.0]);\n  assert.deepEqual(candidate(5),[5.0, 0.0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_253_count_integer",
+    "language": "ts",
+    "prompt": "//Write a tsthon function that returns the number of integer elements in a given array.\nfunction count_integer(list1: number| string| number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_253_count_integer.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_integer;\n  assert.deepEqual(candidate([1, 2, \"abc\", 1.2]),2);\n  assert.deepEqual(candidate([1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 1.2, 4, 5.1]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_255_combinations_colors",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and length n, and generates all combinations (with repetition) of the elements of the array and returns an array with an array for each combination.\nfunction combinations_colors(l: string[], n: number): string[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_255_combinations_colors.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = combinations_colors;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 1),[[\"Red\"], [\"Green\"], [\"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 2),[[\"Red\", \"Red\"], [\"Red\", \"Green\"], [\"Red\", \"Blue\"], [\"Green\", \"Green\"], [\"Green\", \"Blue\"], [\"Blue\", \"Blue\"]]);\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\"], 3),[[\"Red\", \"Red\", \"Red\"], [\"Red\", \"Red\", \"Green\"], [\"Red\", \"Red\", \"Blue\"], [\"Red\", \"Green\", \"Green\"], [\"Red\", \"Green\", \"Blue\"], [\"Red\", \"Blue\", \"Blue\"], [\"Green\", \"Green\", \"Green\"], [\"Green\", \"Green\", \"Blue\"], [\"Green\", \"Blue\", \"Blue\"], [\"Blue\", \"Blue\", \"Blue\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_256_count_Primes_nums",
+    "language": "ts",
+    "prompt": "//Write a tsthon function that takes in a non-negative number and returns the number of prime numbers less than the given non-negative number.\nfunction count_Primes_nums(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_256_count_Primes_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Primes_nums;\n  assert.deepEqual(candidate(5),2);\n  assert.deepEqual(candidate(10),4);\n  assert.deepEqual(candidate(100),25);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_257_swap_numbers",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two numbers and returns an array with the second number and then the first number.\nfunction swap_numbers(a: number, b: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_257_swap_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_numbers;\n  assert.deepEqual(candidate(10, 20),[20, 10]);\n  assert.deepEqual(candidate(15, 17),[17, 15]);\n  assert.deepEqual(candidate(100, 200),[200, 100]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5704,7 +1114,7 @@
     "language": "ts",
     "prompt": "//Write a function to maximize the given two arrays.\nfunction maximize_elements(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_259_maximize_elements.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximize_elements;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 7], [4, 9], [2, 9], [7, 10]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[7, 8], [5, 10], [3, 10], [8, 11]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[8, 9], [6, 11], [4, 11], [9, 12]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5715,13 +1125,13 @@
     ]
   },
   {
-    "name": "mbpp_790_even_position",
+    "name": "mbpp_260_newman_prime",
     "language": "ts",
-    "prompt": "//Write a tsthon function to check whether every even index contains even numbers of a given array.\nfunction even_position(nums: number[]): boolean {\n",
+    "prompt": "//Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nfunction newman_prime(n: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_260_newman_prime.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = newman_prime;\n  assert.deepEqual(candidate(3),7);\n  assert.deepEqual(candidate(4),17);\n  assert.deepEqual(candidate(5),41);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5730,13 +1140,13 @@
     ]
   },
   {
-    "name": "mbpp_396_check_char",
+    "name": "mbpp_261_division_elements",
     "language": "ts",
-    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string: string): string {\n",
+    "prompt": "//Write a function that takes in two arrays and performs mathematical division operation element-wise across the given arrays.\nfunction division_elements(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_261_division_elements.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = division_elements;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[2, 2, 2, 3]);\n  assert.deepEqual(candidate([12, 6, 8, 16], [6, 3, 4, 4]),[2, 2, 2, 4]);\n  assert.deepEqual(candidate([20, 14, 36, 18], [5, 7, 6, 9]),[4, 2, 6, 2]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5745,13 +1155,13 @@
     ]
   },
   {
-    "name": "mbpp_453_sumofFactors",
+    "name": "mbpp_262_split_two_parts",
     "language": "ts",
-    "prompt": "//Write a tsthon function to find the sum of even factors of a number.\nfunction sumofFactors(n: number): number {\n",
+    "prompt": "//Write a function that takes in an array and an integer L and splits the given array into two parts where the length of the first part of the array is L, and returns the resulting arrays in an array.\nfunction split_two_parts(list1: any[], L: number): any {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_262_split_two_parts.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_two_parts;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[[1, 1, 2], [3, 4, 4, 5, 1]]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], 2),[[\"a\", \"b\"], [\"c\", \"d\"]]);\n  assert.deepEqual(candidate([\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"], 4),[[\"p\", \"y\", \"t\", \"h\"], [\"o\", \"n\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5760,13 +1170,13 @@
     ]
   },
   {
-    "name": "mbpp_731_lateralsurface_cone",
+    "name": "mbpp_264_dog_age",
     "language": "ts",
-    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r: number, h: number): number {\n",
+    "prompt": "//Write a function to calculate a dog's age in dog's years.\nfunction dog_age(h_age: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_264_dog_age.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dog_age;\n  assert.deepEqual(candidate(12),61);\n  assert.deepEqual(candidate(15),73);\n  assert.deepEqual(candidate(24),109);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5775,13 +1185,13 @@
     ]
   },
   {
-    "name": "mbpp_564_count_Pairs",
+    "name": "mbpp_265_list_split",
     "language": "ts",
-    "prompt": "//Write a tsthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr: number[], n: number): number {\n",
+    "prompt": "//Write a function that takes in an array and an integer n and splits an array for every nth element, returning an array of the resulting arrays.\nfunction list_split(S: any[], step: number): any[][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_265_list_split.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_split;\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\"], 3),[[\"a\", \"d\", \"g\", \"j\", \"m\"], [\"b\", \"e\", \"h\", \"k\", \"n\"], [\"c\", \"f\", \"i\", \"l\"]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 3),[[1, 4, 7, 10, 13], [2, 5, 8, 11, 14], [3, 6, 9, 12]]);\n  assert.deepEqual(candidate([\"python\", \"java\", \"C\", \"C++\", \"DBMS\", \"SQL\"], 2),[[\"python\", \"C\", \"DBMS\"], [\"java\", \"C++\", \"SQL\"]]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5790,13 +1200,13 @@
     ]
   },
   {
-    "name": "mbpp_733_find_first_occurrence",
+    "name": "mbpp_266_lateralsurface_cube",
     "language": "ts",
-    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A: number[], x: number): number {\n",
+    "prompt": "//Write a function to find the lateral surface area of a cube given its side length.\nfunction lateralsurface_cube(l: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_266_lateralsurface_cube.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cube;\n  assert.deepEqual(candidate(5),100);\n  assert.deepEqual(candidate(9),324);\n  assert.deepEqual(candidate(10),400);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5809,9 +1219,894 @@
     "language": "ts",
     "prompt": "//Write a tsthon function that takes in an integer n and returns the sum of the squares of the first n odd natural numbers.\nfunction square_Sum(n: number): number {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_267_square_Sum.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),10);\n  assert.deepEqual(candidate(3),35);\n  assert.deepEqual(candidate(4),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_268_find_star_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the n'th star number.\nfunction find_star_num(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_268_find_star_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_star_num;\n  assert.deepEqual(candidate(3),37);\n  assert.deepEqual(candidate(4),73);\n  assert.deepEqual(candidate(5),121);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_269_ascii_value",
+    "language": "ts",
+    "prompt": "//Write a function to find the ascii value of a character.\nfunction ascii_value(k: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_269_ascii_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = ascii_value;\n  assert.deepEqual(candidate(\"A\"),65);\n  assert.deepEqual(candidate(\"R\"),82);\n  assert.deepEqual(candidate(\"S\"),83);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_270_sum_even_and_even_index",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of even numbers at even positions of an array.\nfunction sum_even_and_even_index(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_270_sum_even_and_even_index.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_even_and_even_index;\n  assert.deepEqual(candidate([5, 6, 12, 1, 18, 8]),30);\n  assert.deepEqual(candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18]),26);\n  assert.deepEqual(candidate([5, 6, 12, 1]),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_271_even_Power_Sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function that takes in an integer n and finds the sum of the first n even natural numbers that are raised to the fifth power.\nfunction even_Power_Sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_271_even_Power_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_Power_Sum;\n  assert.deepEqual(candidate(2),1056);\n  assert.deepEqual(candidate(3),8832);\n  assert.deepEqual(candidate(1),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_272_rear_extract",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array of arrays and returns an array containing the rear element of each array.\nfunction rear_extract(test_list: [number, string, number][]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_272_rear_extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rear_extract;\n  assert.deepEqual(candidate([[1, \"Rash\", 21], [2, \"Varsha\", 20], [3, \"Kil\", 19]]),[21, 20, 19]);\n  assert.deepEqual(candidate([[1, \"Sai\", 36], [2, \"Ayesha\", 25], [3, \"Salman\", 45]]),[36, 25, 45]);\n  assert.deepEqual(candidate([[1, \"Sudeep\", 14], [2, \"Vandana\", 36], [3, \"Dawood\", 56]]),[14, 36, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_273_substract_elements",
+    "language": "ts",
+    "prompt": "//Write a function that takes in two arrays and subtracts the elements of the first array by the elements of the second array with the same index.\nfunction substract_elements(test_tup1: [number, number, number], test_tup2: [number, number, number]): [number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_273_substract_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = substract_elements;\n  assert.deepEqual(candidate([10, 4, 5], [2, 5, 18]),[8, -1, -13]);\n  assert.deepEqual(candidate([11, 2, 3], [24, 45, 16]),[-13, -43, -13]);\n  assert.deepEqual(candidate([7, 18, 9], [10, 11, 12]),[-3, 7, -3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_274_even_binomial_Coeff_Sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function that takes in a positive integer n and finds the sum of even index binomial coefficients.\nfunction even_binomial_Coeff_Sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_274_even_binomial_Coeff_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_binomial_Coeff_Sum;\n  assert.deepEqual(candidate(4),8);\n  assert.deepEqual(candidate(6),32);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_277_dict_filter",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an object and integer n and filters the object to only include entries with values greater than or equal to n.\nfunction dict_filter(dict: {[key: string]: number}, n: number): {[key: string]: number} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_277_dict_filter.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dict_filter;\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 170),{\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 180),{\"Alden Cantrell\": 180, \"Pierre Cox\": 190});\n  assert.deepEqual(candidate({\"Cierra Vega\": 175, \"Alden Cantrell\": 180, \"Kierra Gentry\": 165, \"Pierre Cox\": 190}, 190),{\"Pierre Cox\": 190});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_278_count_first_elements",
+    "language": "ts",
+    "prompt": "//Write a function to find the number of elements that occurs before the array element in the given array.\nfunction count_first_elements(test_tup: number| [number, number][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_278_count_first_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_first_elements;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),3);\n  assert.deepEqual(candidate([2, 9, [5, 7], 11]),2);\n  assert.deepEqual(candidate([11, 15, 5, 8, [2, 3], 8]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_279_is_num_decagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth decagonal number.\nfunction is_num_decagonal(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_279_is_num_decagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_num_decagonal;\n  assert.deepEqual(candidate(3),27);\n  assert.deepEqual(candidate(7),175);\n  assert.deepEqual(candidate(10),370);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_280_sequential_search",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and element and returns an array containing a boolean that indicates if the element is in the array and the index position of the element (or -1 if the element is not found).\nfunction sequential_search(dlist: number[], item: number): [boolean, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_280_sequential_search.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequential_search;\n  assert.deepEqual(candidate([11, 23, 58, 31, 56, 77, 43, 12, 65, 19], 31),[true, 3]);\n  assert.deepEqual(candidate([12, 32, 45, 62, 35, 47, 44, 61], 61),[true, 7]);\n  assert.deepEqual(candidate([9, 10, 17, 19, 22, 39, 48, 56], 48),[true, 6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_281_all_unique",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check if the elements of a given array are unique or not.\nfunction all_unique(test_list: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_281_all_unique.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_unique;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_282_sub_list",
+    "language": "ts",
+    "prompt": "//Write a function to subtract two arrays element-wise.\nfunction sub_list(nums1: number[], nums2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_282_sub_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sub_list;\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),[-3, -3, -3]);\n  assert.deepEqual(candidate([1, 2], [3, 4]),[-2, -2]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[40, 50]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_283_validate",
+    "language": "ts",
+    "prompt": "//Write a tsthon function takes in an integer and check whether the frequency of each digit in the integer is less than or equal to the digit itself.\nfunction validate(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_283_validate.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = validate;\n  assert.deepEqual(candidate(1234),true);\n  assert.deepEqual(candidate(51241),false);\n  assert.deepEqual(candidate(321),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_284_check_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes in an array and element and checks whether all items in the array are equal to the given element.\nfunction check_element(list: any[], element: any): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_284_check_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_element;\n  assert.deepEqual(candidate([\"green\", \"orange\", \"black\", \"white\"], \"blue\"),false);\n  assert.deepEqual(candidate([1, 2, 3, 4], 7),false);\n  assert.deepEqual(candidate([\"green\", \"green\", \"green\", \"green\"], \"green\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_285_text_match_two_three",
+    "language": "ts",
+    "prompt": "//Write a function that checks whether a string contains the 'a' character followed by two or three 'b' characters.\nfunction text_match_two_three(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_285_text_match_two_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_two_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_286_max_sub_array_sum_repeated",
+    "language": "ts",
+    "prompt": "//Write a function to find the largest sum of a contiguous array in the modified array which is formed by repeating the given array k times.\nfunction max_sub_array_sum_repeated(a: number[], n: number, k: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_286_max_sub_array_sum_repeated.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum_repeated;\n  assert.deepEqual(candidate([10, 20, -30, -1], 4, 3),30);\n  assert.deepEqual(candidate([-1, 10, 20], 3, 2),59);\n  assert.deepEqual(candidate([-1, -2, -3], 3, 3),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_287_square_Sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function takes in an integer n and returns the sum of squares of first n even natural numbers.\nfunction square_Sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_287_square_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_Sum;\n  assert.deepEqual(candidate(2),20);\n  assert.deepEqual(candidate(3),56);\n  assert.deepEqual(candidate(4),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_290_max_length",
+    "language": "ts",
+    "prompt": "//Write a function to find the array of maximum length in an array of arrays.\nfunction max_length(list1: number[][]): [number, number[]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_290_max_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1], [5, 7], [10, 12, 14, 15]]),[4, [10, 12, 14, 15]]);\n  assert.deepEqual(candidate([[5], [15, 20, 25]]),[3, [15, 20, 25]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_291_count_no_of_ways",
+    "language": "ts",
+    "prompt": "//Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nfunction count_no_of_ways(n: number, k: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_291_count_no_of_ways.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_no_of_ways;\n  assert.deepEqual(candidate(2, 4),16);\n  assert.deepEqual(candidate(3, 2),6);\n  assert.deepEqual(candidate(4, 4),228);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_292_find",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find quotient of two numbers (rounded down to the nearest integer).\nfunction find(n: number, m: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_292_find.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find;\n  assert.deepEqual(candidate(10, 3),3);\n  assert.deepEqual(candidate(4, 2),2);\n  assert.deepEqual(candidate(20, 5),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_293_otherside_rightangle",
+    "language": "ts",
+    "prompt": "//Write a function to find the third side of a right angled triangle.\nfunction otherside_rightangle(w: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_293_otherside_rightangle.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = otherside_rightangle;\n  assert.deepEqual(candidate(7, 8),10.63014581273465);\n  assert.deepEqual(candidate(3, 4),5);\n  assert.deepEqual(candidate(7, 15),16.55294535724685);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_294_max_val",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum value in a given heterogeneous array.\nfunction max_val(listval: string| number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_294_max_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),5);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),25);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),50);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_295_sum_div",
+    "language": "ts",
+    "prompt": "//Write a function to return the sum of all divisors of a number.\nfunction sum_div(number: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_295_sum_div.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_div;\n  assert.deepEqual(candidate(8),7);\n  assert.deepEqual(candidate(12),16);\n  assert.deepEqual(candidate(7),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_296_get_Inv_Count",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count inversions in an array.\nfunction get_Inv_Count(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_296_get_Inv_Count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Inv_Count;\n  assert.deepEqual(candidate([1, 20, 6, 4, 5]),5);\n  assert.deepEqual(candidate([1, 2, 1]),1);\n  assert.deepEqual(candidate([1, 2, 5, 6, 1]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_297_flatten_list",
+    "language": "ts",
+    "prompt": "//Write a function to flatten a given nested array structure.\nfunction flatten_list(list1: number| number[][]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_297_flatten_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = flatten_list;\n  assert.deepEqual(candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]]),[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);\n  assert.deepEqual(candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]]),[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_299_max_aggregate",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the maximum aggregate from the array of arrays.\nfunction max_aggregate(stdata: [string, number][]): [string, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_299_max_aggregate.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_aggregate;\n  assert.deepEqual(candidate([[\"Juan Whelan\", 90], [\"Sabah Colley\", 88], [\"Peter Nichols\", 7], [\"Juan Whelan\", 122], [\"Sabah Colley\", 84]]),[\"Juan Whelan\", 212]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 50], [\"Sabah Colley\", 48], [\"Peter Nichols\", 37], [\"Juan Whelan\", 22], [\"Sabah Colley\", 14]]),[\"Juan Whelan\", 72]);\n  assert.deepEqual(candidate([[\"Juan Whelan\", 10], [\"Sabah Colley\", 20], [\"Peter Nichols\", 30], [\"Juan Whelan\", 40], [\"Sabah Colley\", 50]]),[\"Sabah Colley\", 70]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_304_find_Element",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find element at a given index after number of rotations.\nfunction find_Element(arr: number[], ranges: number[][], rotations: number, index: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_304_find_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [[0, 2], [0, 3]], 2, 1),3);\n  assert.deepEqual(candidate([1, 2, 3, 4], [[0, 1], [0, 2]], 1, 2),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [[0, 1], [0, 2]], 1, 1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_305_start_withp",
+    "language": "ts",
+    "prompt": "//Write a function to return two words from an array of words starting with letter 'p'.\nfunction start_withp(words: string[]): [string, string] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_305_start_withp.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = start_withp;\n  assert.deepEqual(candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"]),[\"Python\", \"PHP\"]);\n  assert.deepEqual(candidate([\"Python Programming\", \"Java Programming\"]),[\"Python\", \"Programming\"]);\n  assert.deepEqual(candidate([\"Pqrst Pqr\", \"qrstuv\"]),[\"Pqrst\", \"Pqr\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_306_max_sum_increasing_subseq",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum sum of increasing subsequence from prefix until ith index and also including a given kth element which is after i, i.e., k > i .\nfunction max_sum_increasing_subseq(a: number[], n: number, index: number, k: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_306_max_sum_increasing_subseq.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_increasing_subseq;\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 4, 6),11);\n  assert.deepEqual(candidate([1, 101, 2, 3, 100, 4, 5], 7, 2, 5),7);\n  assert.deepEqual(candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4),71);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_308_large_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the specified number of largest products from two given arrays, selecting one factor from each array.\nfunction large_product(nums1: number[], nums2: number[], N: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_308_large_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = large_product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 3),[60, 54, 50]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 4),[60, 54, 50, 48]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [3, 6, 8, 9, 10, 6], 5),[60, 54, 50, 48, 45]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_309_maximum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the maximum of two numbers.\nfunction maximum(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_309_maximum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maximum;\n  assert.deepEqual(candidate(5, 10),10);\n  assert.deepEqual(candidate(-1, -2),-1);\n  assert.deepEqual(candidate(9, 7),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_310_string_to_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to convert a given string to an array of characters.\nfunction string_to_tuple(str1: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_310_string_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = string_to_tuple;\n  assert.deepEqual(candidate(\"python 3.0\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\", \"3\", \".\", \"0\"]);\n  assert.deepEqual(candidate(\"item1\"),[\"i\", \"t\", \"e\", \"m\", \"1\"]);\n  assert.deepEqual(candidate(\"15.10\"),[\"1\", \"5\", \".\", \"1\", \"0\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_388_highest_Power_of_2",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the highest power of 2 that is less than or equal to n.\nfunction highest_Power_of_2(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_388_highest_Power_of_2.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = highest_Power_of_2;\n  assert.deepEqual(candidate(10),8);\n  assert.deepEqual(candidate(19),16);\n  assert.deepEqual(candidate(32),32);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_389_find_lucas",
+    "language": "ts",
+    "prompt": "//Write a function to find the n'th lucas number.\nfunction find_lucas(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_389_find_lucas.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_lucas;\n  assert.deepEqual(candidate(9),76);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(3),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_390_add_string",
+    "language": "ts",
+    "prompt": "//Write a function to apply a given format string to all of the elements in an array.\nfunction add_string(list_: any[], string: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_390_add_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_string;\n  assert.deepEqual(candidate([1, 2, 3, 4], \"temp{0}\"),[\"temp1\", \"temp2\", \"temp3\", \"temp4\"]);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\", \"d\"], \"python{0}\"),[\"pythona\", \"pythonb\", \"pythonc\", \"pythond\"]);\n  assert.deepEqual(candidate([5, 6, 7, 8], \"string{0}\"),[\"string5\", \"string6\", \"string7\", \"string8\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_392_get_max_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nfunction get_max_sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_392_get_max_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_max_sum;\n  assert.deepEqual(candidate(60),106);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_393_max_length_list",
+    "language": "ts",
+    "prompt": "//Write a function to find the array with maximum length.\nfunction max_length_list(input_list: number[][]): [number, number[]] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_393_max_length_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_length_list;\n  assert.deepEqual(candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]]),[3, [13, 15, 17]]);\n  assert.deepEqual(candidate([[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3], [1, 2], [1]]),[5, [1, 2, 3, 4, 5]]);\n  assert.deepEqual(candidate([[3, 4, 5], [6, 7, 8, 9], [10, 11, 12]]),[4, [6, 7, 8, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_394_check_distinct",
+    "language": "ts",
+    "prompt": "//Write a function to check if given array contains no duplicates.\nfunction check_distinct(test_tup: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_394_check_distinct.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_distinct;\n  assert.deepEqual(candidate([1, 4, 5, 6, 1, 4]),false);\n  assert.deepEqual(candidate([1, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_395_first_non_repeating_character",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the first non-repeated character in a given string.\nfunction first_non_repeating_character(str1: string): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_395_first_non_repeating_character.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_non_repeating_character;\n  assert.deepEqual(candidate(\"abcabc\"),undefined);\n  assert.deepEqual(candidate(\"abc\"),\"a\");\n  assert.deepEqual(candidate(\"ababc\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_396_check_char",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given string starts and ends with the same character or not.\nfunction check_char(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_396_check_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_char;\n  assert.deepEqual(candidate(\"abba\"),\"Valid\");\n  assert.deepEqual(candidate(\"a\"),\"Valid\");\n  assert.deepEqual(candidate(\"abcd\"),\"Invalid\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_397_median_numbers",
+    "language": "ts",
+    "prompt": "//Write a function to find the median of three numbers.\nfunction median_numbers(a: number, b: number, c: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_397_median_numbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_numbers;\n  assert.deepEqual(candidate(25, 55, 65),55.0);\n  assert.deepEqual(candidate(20, 10, 30),20.0);\n  assert.deepEqual(candidate(15, 45, 75),45.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_398_sum_of_digits",
+    "language": "ts",
+    "prompt": "//Write a function to compute the sum of digits of each number of a given array.\nfunction sum_of_digits(nums: any[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_398_sum_of_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_of_digits;\n  assert.deepEqual(candidate([10, 2, 56]),14);\n  assert.deepEqual(candidate([[10, 20, 4, 5, \"b\", 70, \"a\"]]),19);\n  assert.deepEqual(candidate([10, 20, -4, 5, -70]),19);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_399_bitwise_xor",
+    "language": "ts",
+    "prompt": "//Write a function to perform the mathematical bitwise xor operation across the given arrays.\nfunction bitwise_xor(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_399_bitwise_xor.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bitwise_xor;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[15, 6, 5, 10]);\n  assert.deepEqual(candidate([11, 5, 7, 10], [6, 3, 4, 4]),[13, 6, 3, 14]);\n  assert.deepEqual(candidate([12, 6, 8, 11], [7, 4, 5, 6]),[11, 2, 13, 13]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_3_is_not_prime",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to identify non-prime numbers.\nfunction is_not_prime(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_3_is_not_prime.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_not_prime;\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(35),true);\n  assert.deepEqual(candidate(37),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_400_extract_freq",
+    "language": "ts",
+    "prompt": "//Write a function to extract the number of unique arrays in the given array.\nfunction extract_freq(test_list: [number, number][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_400_extract_freq.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_freq;\n  assert.deepEqual(candidate([[3, 4], [1, 2], [4, 3], [5, 6]]),3);\n  assert.deepEqual(candidate([[4, 15], [2, 3], [5, 4], [6, 7]]),4);\n  assert.deepEqual(candidate([[5, 16], [2, 3], [6, 5], [6, 9]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_401_add_nested_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to perform index wise addition of array elements in the given two nested arrays.\nfunction add_nested_tuples(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_401_add_nested_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_nested_tuples;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[7, 10], [7, 14], [3, 10], [8, 13]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[9, 12], [9, 16], [5, 12], [10, 15]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[11, 14], [11, 18], [7, 14], [12, 17]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_404_minimum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the minimum of two numbers.\nfunction minimum(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_404_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = minimum;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(-5, -4),-5);\n  assert.deepEqual(candidate(0, 0),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_405_check_tuplex",
+    "language": "ts",
+    "prompt": "//Write a function to check whether an element exists within an array.\nfunction check_tuplex(tuplex: string| number[], tuple1: any): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_405_check_tuplex.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_tuplex;\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"r\"),true);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], \"5\"),false);\n  assert.deepEqual(candidate([\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"], 3),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_406_find_Parity",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find whether the parity of a given number is odd.\nfunction find_Parity(x: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_406_find_Parity.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Parity;\n  assert.deepEqual(candidate(12),false);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(10),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_407_rearrange_bigger",
+    "language": "ts",
+    "prompt": "//Write a function to create the next bigger number by rearranging the digits of a given number.\nfunction rearrange_bigger(n: number): any {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_407_rearrange_bigger.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rearrange_bigger;\n  assert.deepEqual(candidate(12),21);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(102),120);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_408_k_smallest_pairs",
+    "language": "ts",
+    "prompt": "//Write a function to find k number of smallest pairs which consist of one element from the first array and one element from the second array.\nfunction k_smallest_pairs(nums1: number[], nums2: number[], k: number): number[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_408_k_smallest_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = k_smallest_pairs;\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 2),[[1, 2], [1, 4]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 1),[[1, 2]]);\n  assert.deepEqual(candidate([1, 3, 7], [2, 4, 6], 7),[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_409_min_product_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to find the minimum product from the pairs of arrays within a given array.\nfunction min_product_tuple(list1: [number, number][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_409_min_product_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_product_tuple;\n  assert.deepEqual(candidate([[2, 7], [2, 6], [1, 8], [4, 9]]),8);\n  assert.deepEqual(candidate([[10, 20], [15, 2], [5, 10]]),30);\n  assert.deepEqual(candidate([[11, 44], [10, 15], [20, 5], [12, 9]]),100);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_410_min_val",
+    "language": "ts",
+    "prompt": "//Write a function to find the minimum value in a given heterogeneous array.\nfunction min_val(listval: string| number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_410_min_val.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_val;\n  assert.deepEqual(candidate([\"Python\", 3, 2, 4, 5, \"version\"]),2);\n  assert.deepEqual(candidate([\"Python\", 15, 20, 25]),15);\n  assert.deepEqual(candidate([\"Python\", 30, 20, 40, 50, \"version\"]),20);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_411_snake_to_camel",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given snake case string to camel case string.\nfunction snake_to_camel(word: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_411_snake_to_camel.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = snake_to_camel;\n  assert.deepEqual(candidate(\"android_tv\"),\"AndroidTv\");\n  assert.deepEqual(candidate(\"google_pixel\"),\"GooglePixel\");\n  assert.deepEqual(candidate(\"apple_watch\"),\"AppleWatch\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_412_remove_odd",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to remove odd numbers from a given array.\nfunction remove_odd(l: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_412_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate([1, 2, 3]),[2]);\n  assert.deepEqual(candidate([2, 4, 6]),[2, 4, 6]);\n  assert.deepEqual(candidate([10, 20, 3]),[10, 20]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_413_extract_nth_element",
+    "language": "ts",
+    "prompt": "//Write a function to extract the nth element from a given array of arrays.\nfunction extract_nth_element(list1: [string, number, number][], n: number): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_413_extract_nth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_nth_element;\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 0),[\"Greyson Fulton\", \"Brady Kent\", \"Wyatt Knott\", \"Beau Turnbull\"]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 2),[99, 96, 94, 98]);\n  assert.deepEqual(candidate([[\"Greyson Fulton\", 98, 99], [\"Brady Kent\", 97, 96], [\"Wyatt Knott\", 91, 94], [\"Beau Turnbull\", 94, 98]], 1),[98, 97, 91, 94]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_414_overlapping",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether any value in a sequence exists in a sequence or not.\nfunction overlapping(list1: number[], list2: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_414_overlapping.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = overlapping;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),false);\n  assert.deepEqual(candidate([1, 2, 3], [4, 5, 6]),false);\n  assert.deepEqual(candidate([1, 4, 5], [1, 4, 5]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_415_max_Product",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find a pair with highest product from a given array of integers.\nfunction max_Product(arr: number[]): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_415_max_Product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_Product;\n  assert.deepEqual(candidate([1, 2, 3, 4, 7, 0, 8, 4]),[7, 8]);\n  assert.deepEqual(candidate([0, -1, -2, -4, 5, 0, -6]),[-4, -6]);\n  assert.deepEqual(candidate([1, 2, 3]),[2, 3]);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",
@@ -5824,7 +2119,7 @@
     "language": "ts",
     "prompt": "//Write a function to find common first element in given array of arrays.\nfunction group_tuples(Input: string[][]): string[][] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_417_group_tuples.py",
     "prompt_terminology": "reworded",
     "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = group_tuples;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"x\", \"z\"], [\"w\", \"t\"]]),[[\"x\", \"y\", \"z\"], [\"w\", \"t\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"a\", \"c\"], [\"d\", \"e\"]]),[[\"a\", \"b\", \"c\"], [\"d\", \"e\"]]);\n  assert.deepEqual(candidate([[\"f\", \"g\"], [\"f\", \"g\"], [\"h\", \"i\"]]),[[\"f\", \"g\", \"g\"], [\"h\", \"i\"]]);\n}\n\ntest();",
     "stop_tokens": [
@@ -5835,13 +2130,3718 @@
     ]
   },
   {
-    "name": "mbpp_108_merge_sorted_list",
+    "name": "mbpp_418_Find_Max",
     "language": "ts",
-    "prompt": "//Write a function to merge three arrays into a single sorted array.\nfunction merge_sorted_list(num1: number[], num2: number[], num3: number[]): number[] {\n",
+    "prompt": "//Write a tsthon function to find the element of an array having maximum length.\nfunction Find_Max(lst: any[][]): any[] {\n",
     "doctests": "transform",
-    "original": "/home/arjun/repos/nuprl/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_108_merge_sorted_list.py",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_418_Find_Max.py",
     "prompt_terminology": "reworded",
-    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_sorted_list;\n  assert.deepEqual(candidate([25, 24, 15, 4, 5, 29, 110], [19, 20, 11, 56, 25, 233, 154], [24, 26, 54, 48]),[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]);\n  assert.deepEqual(candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]),[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]);\n  assert.deepEqual(candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1], [25, 35, 22, 85, 14, 65, 75, 25, 58], [12, 74, 9, 50, 61, 41]),[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]);\n}\n\ntest();",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max;\n  assert.deepEqual(candidate([[\"A\"], [\"A\", \"B\"], [\"A\", \"B\", \"C\"]]),[\"A\", \"B\", \"C\"]);\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1, 2, 3]);\n  assert.deepEqual(candidate([[1, 1], [1, 2, 3], [1, 5, 6, 1]]),[1, 5, 6, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_419_round_and_sum",
+    "language": "ts",
+    "prompt": "//Write a function to round every number of a given array of numbers and print the total sum multiplied by the length of the array.\nfunction round_and_sum(list1: number| number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_419_round_and_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = round_and_sum;\n  assert.deepEqual(candidate([22.4, 4.0, -16.22, -9.1, 11.0, -12.22, 14.2, -5.2, 17.5]),243);\n  assert.deepEqual(candidate([5, 2, 9, 24.3, 29]),345);\n  assert.deepEqual(candidate([25.0, 56.7, 89.2]),513);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_420_cube_Sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the cube sum of first n even natural numbers.\nfunction cube_Sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_420_cube_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_Sum;\n  assert.deepEqual(candidate(2),72);\n  assert.deepEqual(candidate(3),288);\n  assert.deepEqual(candidate(4),800);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_421_concatenate_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to concatenate each element of array by the delimiter.\nfunction concatenate_tuple(test_tup: [string, string, number, string]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_421_concatenate_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = concatenate_tuple;\n  assert.deepEqual(candidate([\"ID\", \"is\", 4, \"UTS\"]),\"ID-is-4-UTS\");\n  assert.deepEqual(candidate([\"QWE\", \"is\", 4, \"RTY\"]),\"QWE-is-4-RTY\");\n  assert.deepEqual(candidate([\"ZEN\", \"is\", 4, \"OP\"]),\"ZEN-is-4-OP\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_422_find_Average_Of_Cube",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the average of cubes of first n natural numbers.\nfunction find_Average_Of_Cube(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_422_find_Average_Of_Cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Average_Of_Cube;\n  assert.deepEqual(candidate(2),4.5);\n  assert.deepEqual(candidate(3),12);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_424_extract_rear",
+    "language": "ts",
+    "prompt": "//Write a function to extract only the rear index element of each string in the given array.\nfunction extract_rear(test_tuple: [string, string, string]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_424_extract_rear.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_rear;\n  assert.deepEqual(candidate([\"Mers\", \"for\", \"Vers\"]),[\"s\", \"r\", \"s\"]);\n  assert.deepEqual(candidate([\"Avenge\", \"for\", \"People\"]),[\"e\", \"r\", \"e\"]);\n  assert.deepEqual(candidate([\"Gotta\", \"get\", \"go\"]),[\"a\", \"t\", \"o\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_425_count_element_in_list",
+    "language": "ts",
+    "prompt": "//Write a function to count the number of subarrays containing a particular element.\nfunction count_element_in_list(list1: any[][], x: any): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_425_count_element_in_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_element_in_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]], 1),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"A\"),3);\n  assert.deepEqual(candidate([[\"A\", \"B\"], [\"A\", \"C\"], [\"A\", \"D\", \"E\"], [\"B\", \"C\", \"D\"]], \"E\"),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_426_filter_oddnumbers",
+    "language": "ts",
+    "prompt": "//Write a function to filter odd numbers.\nfunction filter_oddnumbers(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_426_filter_oddnumbers.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = filter_oddnumbers;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 3, 5, 7, 9]);\n  assert.deepEqual(candidate([10, 20, 45, 67, 84, 93]),[45, 67, 93]);\n  assert.deepEqual(candidate([5, 7, 9, 8, 6, 4, 3]),[5, 7, 9, 3]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_427_change_date_format",
+    "language": "ts",
+    "prompt": "//Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nfunction change_date_format(dt: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_427_change_date_format.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = change_date_format;\n  assert.deepEqual(candidate(\"2026-01-02\"),\"02-01-2026\");\n  assert.deepEqual(candidate(\"2020-11-13\"),\"13-11-2020\");\n  assert.deepEqual(candidate(\"2021-04-26\"),\"26-04-2021\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_428_shell_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort the given array by using shell sort.\nfunction shell_sort(my_list: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_428_shell_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = shell_sort;\n  assert.deepEqual(candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]),[2, 3, 4, 5, 12, 12, 23, 56, 81, 95]);\n  assert.deepEqual(candidate([24, 22, 39, 34, 87, 73, 68]),[22, 24, 34, 39, 68, 73, 87]);\n  assert.deepEqual(candidate([32, 30, 16, 96, 82, 83, 74]),[16, 30, 32, 74, 82, 83, 96]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_429_and_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to extract the elementwise and arrays from the given two arrays.\nfunction and_tuples(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_429_and_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = and_tuples;\n  assert.deepEqual(candidate([10, 4, 6, 9], [5, 2, 3, 3]),[0, 0, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [5, 6, 7, 8]),[1, 2, 3, 0]);\n  assert.deepEqual(candidate([8, 9, 11, 12], [7, 13, 14, 17]),[0, 9, 10, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_430_parabola_directrix",
+    "language": "ts",
+    "prompt": "//Write a function to find the directrix of a parabola.\nfunction parabola_directrix(a: number, b: number, c: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_430_parabola_directrix.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = parabola_directrix;\n  assert.deepEqual(candidate(5, 3, 2),-198);\n  assert.deepEqual(candidate(9, 8, 4),-2336);\n  assert.deepEqual(candidate(2, 4, 6),-130);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_431_common_element",
+    "language": "ts",
+    "prompt": "//Write a function that takes two arrays and returns true if they have at least one common element.\nfunction common_element(list1: any[], list2: any[]): boolean | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_431_common_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = common_element;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [5, 6, 7, 8, 9]),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 8, 9]),undefined);\n  assert.deepEqual(candidate([\"a\", \"b\", \"c\"], [\"d\", \"b\", \"e\"]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_432_median_trapezium",
+    "language": "ts",
+    "prompt": "//Write a function to find the median length of a trapezium.\nfunction median_trapezium(base1: number, base2: number, height: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_432_median_trapezium.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = median_trapezium;\n  assert.deepEqual(candidate(15, 25, 35),20);\n  assert.deepEqual(candidate(10, 20, 30),15);\n  assert.deepEqual(candidate(6, 9, 4),7.5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_433_check_greater",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the entered number is greater than the elements of the given array.\nfunction check_greater(arr: number[], number: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_433_check_greater.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_greater;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 4),false);\n  assert.deepEqual(candidate([2, 3, 4, 5, 6], 8),true);\n  assert.deepEqual(candidate([9, 7, 4, 8, 6, 1], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_434_text_match_one",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an a followed by one or more b's.\nfunction text_match_one(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_434_text_match_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_435_last_Digit",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the last digit of a given number.\nfunction last_Digit(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_435_last_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit;\n  assert.deepEqual(candidate(123),3);\n  assert.deepEqual(candidate(25),5);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_436_neg_nos",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to return the negative numbers in an array.\nfunction neg_nos(list1: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_436_neg_nos.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = neg_nos;\n  assert.deepEqual(candidate([-1, 4, 5, -6]),[-1, -6]);\n  assert.deepEqual(candidate([-1, -2, 3, 4]),[-1, -2]);\n  assert.deepEqual(candidate([-7, -6, 8, 9]),[-7, -6]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_437_remove_odd",
+    "language": "ts",
+    "prompt": "//Write a function to remove odd characters in a string.\nfunction remove_odd(str1: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_437_remove_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_odd;\n  assert.deepEqual(candidate(\"python\"),\"yhn\");\n  assert.deepEqual(candidate(\"program\"),\"rga\");\n  assert.deepEqual(candidate(\"language\"),\"agae\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_438_count_bidirectional",
+    "language": "ts",
+    "prompt": "//Write a function to count bidirectional array pairs.\nfunction count_bidirectional(test_list: [number, number][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_438_count_bidirectional.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_bidirectional;\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 1], [6, 5], [2, 1]]),3);\n  assert.deepEqual(candidate([[5, 6], [1, 3], [6, 5], [9, 1], [6, 5], [2, 1]]),2);\n  assert.deepEqual(candidate([[5, 6], [1, 2], [6, 5], [9, 2], [6, 5], [2, 1]]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_439_multiple_to_single",
+    "language": "ts",
+    "prompt": "//Write a function to join an array of multiple integers into a single integer.\nfunction multiple_to_single(L: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_439_multiple_to_single.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiple_to_single;\n  assert.deepEqual(candidate([11, 33, 50]),113350);\n  assert.deepEqual(candidate([-1, 2, 3, 4, 5, 6]),-123456);\n  assert.deepEqual(candidate([10, 15, 20, 25]),10152025);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_440_find_adverb_position",
+    "language": "ts",
+    "prompt": "//Write a function to find the first adverb and their positions in a given sentence.\nfunction find_adverb_position(text: string): [number, number, string] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_440_find_adverb_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverb_position;\n  assert.deepEqual(candidate(\"clearly!! we can see the sky\"),[0, 7, \"clearly\"]);\n  assert.deepEqual(candidate(\"seriously!! there are many roses\"),[0, 9, \"seriously\"]);\n  assert.deepEqual(candidate(\"unfortunately!! sita is going to home\"),[0, 13, \"unfortunately\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_441_surfacearea_cube",
+    "language": "ts",
+    "prompt": "//Write a function to find the surface area of a cube of a given size.\nfunction surfacearea_cube(l: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_441_surfacearea_cube.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cube;\n  assert.deepEqual(candidate(5),150);\n  assert.deepEqual(candidate(3),54);\n  assert.deepEqual(candidate(10),600);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_442_positive_count",
+    "language": "ts",
+    "prompt": "//Write a function to find the ration of positive numbers in an array of integers.\nfunction positive_count(nums: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_442_positive_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = positive_count;\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8]),0.54);\n  assert.deepEqual(candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),0.69);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17]),0.56);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_443_largest_neg",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the largest negative number from the given array.\nfunction largest_neg(list1: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_443_largest_neg.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = largest_neg;\n  assert.deepEqual(candidate([1, 2, 3, -4, -6]),-6);\n  assert.deepEqual(candidate([1, 2, 3, -8, -9]),-9);\n  assert.deepEqual(candidate([1, 2, 3, 4, -1]),-1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_444_trim_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to trim each array by k in the given arrays.\nfunction trim_tuple(test_list: number[][], K: number): number[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_444_trim_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = trim_tuple;\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 2),[[2], [9], [2], [2]]);\n  assert.deepEqual(candidate([[5, 3, 2, 1, 4], [3, 4, 9, 2, 1], [9, 1, 2, 3, 5], [4, 8, 2, 1, 7]], 1),[[3, 2, 1], [4, 9, 2], [1, 2, 3], [8, 2, 1]]);\n  assert.deepEqual(candidate([[7, 8, 4, 9], [11, 8, 12, 4], [4, 1, 7, 8], [3, 6, 9, 7]], 1),[[8, 4], [8, 12], [1, 7], [6, 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_445_index_multiplication",
+    "language": "ts",
+    "prompt": "//Write a function to perform index wise multiplication of array elements in the given two arrays.\nfunction index_multiplication(test_tup1: number[][], test_tup2: number[][]): number[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_445_index_multiplication.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_multiplication;\n  assert.deepEqual(candidate([[1, 3], [4, 5], [2, 9], [1, 10]], [[6, 7], [3, 9], [1, 1], [7, 3]]),[[6, 21], [12, 45], [2, 9], [7, 30]]);\n  assert.deepEqual(candidate([[2, 4], [5, 6], [3, 10], [2, 11]], [[7, 8], [4, 10], [2, 2], [8, 4]]),[[14, 32], [20, 60], [6, 20], [16, 44]]);\n  assert.deepEqual(candidate([[3, 5], [6, 7], [4, 11], [3, 12]], [[8, 9], [5, 11], [3, 3], [9, 5]]),[[24, 45], [30, 77], [12, 33], [27, 60]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_446_count_Occurrence",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the occurence of all elements of array in an array.\nfunction count_Occurrence(tup: any, lst: any[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_446_count_Occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Occurrence;\n  assert.deepEqual(candidate([\"a\", \"a\", \"c\", \"b\", \"d\"], [\"a\", \"b\"]),3);\n  assert.deepEqual(candidate([1, 2, 3, 1, 4, 6, 7, 1, 4], [1, 4, 7]),6);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], [1, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_447_cube_nums",
+    "language": "ts",
+    "prompt": "//Write a function to find cubes of individual elements in an array.\nfunction cube_nums(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_447_cube_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cube_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]);\n  assert.deepEqual(candidate([10, 20, 30]),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15]),[1728, 3375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_448_cal_sum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the sum of perrin numbers.\nfunction cal_sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_448_cal_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cal_sum;\n  assert.deepEqual(candidate(9),49);\n  assert.deepEqual(candidate(10),66);\n  assert.deepEqual(candidate(11),88);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_450_extract_string",
+    "language": "ts",
+    "prompt": "//Write a function to extract specified size of strings from a given array of string values.\nfunction extract_string(str: string[], l: number): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_450_extract_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_string;\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 8),[\"practice\", \"solution\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 6),[\"Python\"]);\n  assert.deepEqual(candidate([\"Python\", \"list\", \"exercises\", \"practice\", \"solution\"], 9),[\"exercises\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_451_remove_whitespaces",
+    "language": "ts",
+    "prompt": "//Write a function to remove all whitespaces from the given string.\nfunction remove_whitespaces(text1: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_451_remove_whitespaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_whitespaces;\n  assert.deepEqual(candidate(\" Google    Flutter \"),\"GoogleFlutter\");\n  assert.deepEqual(candidate(\" Google    Dart \"),\"GoogleDart\");\n  assert.deepEqual(candidate(\" iOS    Swift \"),\"iOSSwift\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_452_loss_amount",
+    "language": "ts",
+    "prompt": "//Write a function that gives loss amount on a sale if the given amount has loss else return 0.\nfunction loss_amount(actual_cost: number, sale_amount: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_452_loss_amount.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = loss_amount;\n  assert.deepEqual(candidate(1500, 1200),0);\n  assert.deepEqual(candidate(100, 200),100);\n  assert.deepEqual(candidate(2000, 5000),3000);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_453_sumofFactors",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of even factors of a number.\nfunction sumofFactors(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_453_sumofFactors.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sumofFactors;\n  assert.deepEqual(candidate(18),26);\n  assert.deepEqual(candidate(30),48);\n  assert.deepEqual(candidate(6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_454_text_match_wordz",
+    "language": "ts",
+    "prompt": "//Write a function that matches a word containing 'z'.\nfunction text_match_wordz(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_454_text_match_wordz.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz;\n  assert.deepEqual(candidate(\"pythonz.\"),true);\n  assert.deepEqual(candidate(\"xyz.\"),true);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_455_check_monthnumb_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given month number contains 31 days or not.\nfunction check_monthnumb_number(monthnum2: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_455_check_monthnumb_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumb_number;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(6),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_456_reverse_string_list",
+    "language": "ts",
+    "prompt": "//Write a function to reverse each string in a given array of string values.\nfunction reverse_string_list(stringlist: string[]): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_456_reverse_string_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_string_list;\n  assert.deepEqual(candidate([\"Red\", \"Green\", \"Blue\", \"White\", \"Black\"]),[\"deR\", \"neerG\", \"eulB\", \"etihW\", \"kcalB\"]);\n  assert.deepEqual(candidate([\"john\", \"amal\", \"joel\", \"george\"]),[\"nhoj\", \"lama\", \"leoj\", \"egroeg\"]);\n  assert.deepEqual(candidate([\"jack\", \"john\", \"mary\"]),[\"kcaj\", \"nhoj\", \"yram\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_457_Find_Min",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the subarray having minimum length.\nfunction Find_Min(lst: any[][]): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_457_Find_Min.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min;\n  assert.deepEqual(candidate([[1], [1, 2], [1, 2, 3]]),[1]);\n  assert.deepEqual(candidate([[1, 1], [1, 1, 1], [1, 2, 7, 8]]),[1, 1]);\n  assert.deepEqual(candidate([[\"x\"], [\"x\", \"y\"], [\"x\", \"y\", \"z\"]]),[\"x\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_458_rectangle_area",
+    "language": "ts",
+    "prompt": "//Write a function to find the area of a rectangle.\nfunction rectangle_area(l: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_458_rectangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rectangle_area;\n  assert.deepEqual(candidate(10, 20),200);\n  assert.deepEqual(candidate(10, 5),50);\n  assert.deepEqual(candidate(4, 2),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_459_remove_uppercase",
+    "language": "ts",
+    "prompt": "//Write a function to remove uppercase substrings from a given string.\nfunction remove_uppercase(str1: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_459_remove_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_uppercase;\n  assert.deepEqual(candidate(\"cAstyoUrFavoRitETVshoWs\"),\"cstyoravoitshos\");\n  assert.deepEqual(candidate(\"wAtchTheinTernEtrAdIo\"),\"wtchheinerntrdo\");\n  assert.deepEqual(candidate(\"VoicESeaRchAndreComMendaTionS\"),\"oiceachndreomendaion\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_460_Extract",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to get the first element of each subarray.\nfunction Extract(lst: number[][]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_460_Extract.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Extract;\n  assert.deepEqual(candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]),[1, 3, 6]);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5]]),[1, 4]);\n  assert.deepEqual(candidate([[9, 8, 1], [1, 2]]),[9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_461_upper_ctr",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the upper case characters in a given string.\nfunction upper_ctr(str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_461_upper_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = upper_ctr;\n  assert.deepEqual(candidate(\"PYthon\"),1);\n  assert.deepEqual(candidate(\"BigData\"),1);\n  assert.deepEqual(candidate(\"program\"),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_463_max_subarray_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum product subarray of the given array.\nfunction max_subarray_product(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_463_max_subarray_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_subarray_product;\n  assert.deepEqual(candidate([1, -2, -3, 0, 7, -8, -2]),112);\n  assert.deepEqual(candidate([6, -3, -10, 0, 2]),180);\n  assert.deepEqual(candidate([-2, -40, 0, -2, -3]),80);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_464_check_value",
+    "language": "ts",
+    "prompt": "//Write a function to check if all values are same in an object.\nfunction check_value(dict: {[key: string]: number}, n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_464_check_value.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_value;\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 10),false);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 12),true);\n  assert.deepEqual(candidate({\"Cierra Vega\": 12, \"Alden Cantrell\": 12, \"Kierra Gentry\": 12, \"Pierre Cox\": 12}, 5),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_468_max_product",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nfunction max_product(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_468_max_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_product;\n  assert.deepEqual(candidate([3, 100, 4, 5, 150, 6]),3000);\n  assert.deepEqual(candidate([4, 42, 55, 68, 80]),50265600);\n  assert.deepEqual(candidate([10, 22, 9, 33, 21, 50, 41, 60]),2460);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_470_add_pairwise",
+    "language": "ts",
+    "prompt": "//Write a function to find the pairwise addition of the neighboring elements of the given array.\nfunction add_pairwise(test_tup: [number, number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_470_add_pairwise.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_pairwise;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[6, 12, 15, 18]);\n  assert.deepEqual(candidate([2, 6, 8, 9, 11]),[8, 14, 17, 20]);\n  assert.deepEqual(candidate([3, 7, 9, 10, 12]),[10, 16, 19, 22]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_471_find_remainder",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the product of the array multiplication modulo n.\nfunction find_remainder(arr: number[], n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_471_find_remainder.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_remainder;\n  assert.deepEqual(candidate([100, 10, 5, 25, 35, 14], 11),9);\n  assert.deepEqual(candidate([1, 1, 1], 1),0);\n  assert.deepEqual(candidate([1, 2, 1], 2),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_472_check_Consecutive",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given array contains consecutive numbers or not.\nfunction check_Consecutive(l: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_472_check_Consecutive.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_Consecutive;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),true);\n  assert.deepEqual(candidate([1, 2, 3, 5, 6]),false);\n  assert.deepEqual(candidate([1, 2, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_474_replace_char",
+    "language": "ts",
+    "prompt": "//Write a function to replace characters in a string.\nfunction replace_char(str1: string, ch: string, newch: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_474_replace_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_char;\n  assert.deepEqual(candidate(\"polygon\", \"y\", \"l\"),\"pollgon\");\n  assert.deepEqual(candidate(\"character\", \"c\", \"a\"),\"aharaater\");\n  assert.deepEqual(candidate(\"python\", \"l\", \"a\"),\"python\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_475_sort_counter",
+    "language": "ts",
+    "prompt": "//Write a function to sort an object by value.\nfunction sort_counter(dict1: {[key: string]: number}): [string, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_475_sort_counter.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_counter;\n  assert.deepEqual(candidate({\"Math\": 81, \"Physics\": 83, \"Chemistry\": 87}),[[\"Chemistry\", 87], [\"Physics\", 83], [\"Math\", 81]]);\n  assert.deepEqual(candidate({\"Math\": 400, \"Physics\": 300, \"Chemistry\": 250}),[[\"Math\", 400], [\"Physics\", 300], [\"Chemistry\", 250]]);\n  assert.deepEqual(candidate({\"Math\": 900, \"Physics\": 1000, \"Chemistry\": 1250}),[[\"Chemistry\", 1250], [\"Physics\", 1000], [\"Math\", 900]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_476_big_sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of the largest and smallest value in a given array.\nfunction big_sum(nums: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_476_big_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_sum;\n  assert.deepEqual(candidate([1, 2, 3]),4);\n  assert.deepEqual(candidate([-1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([2, 3, 6]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_477_is_lower",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to convert the given string to lower case.\nfunction is_lower(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_477_is_lower.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_lower;\n  assert.deepEqual(candidate(\"InValid\"),\"invalid\");\n  assert.deepEqual(candidate(\"TruE\"),\"true\");\n  assert.deepEqual(candidate(\"SenTenCE\"),\"sentence\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_478_remove_lowercase",
+    "language": "ts",
+    "prompt": "//Write a function to remove lowercase substrings from a given string.\nfunction remove_lowercase(str1: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_478_remove_lowercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_lowercase;\n  assert.deepEqual(candidate(\"PYTHon\"),\"PYTH\");\n  assert.deepEqual(candidate(\"FInD\"),\"FID\");\n  assert.deepEqual(candidate(\"STRinG\"),\"STRG\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_479_first_Digit",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the first digit of a given number.\nfunction first_Digit(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_479_first_Digit.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_Digit;\n  assert.deepEqual(candidate(123),1);\n  assert.deepEqual(candidate(456),4);\n  assert.deepEqual(candidate(12),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_4_heap_queue_largest",
+    "language": "ts",
+    "prompt": "//Write a function to find the n largest integers from a given array of numbers, returned in descending order.\nfunction heap_queue_largest(nums: number[], n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_4_heap_queue_largest.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_queue_largest;\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 3),[85, 75, 65]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 2),[85, 75]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 22, 58], 5),[85, 75, 65, 58, 35]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_554_Split",
+    "language": "ts",
+    "prompt": "//Write a tsthon function which takes an array of integers and only returns the odd ones.\nfunction Split(list: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_554_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),[1, 3, 5]);\n  assert.deepEqual(candidate([10, 11, 12, 13]),[11, 13]);\n  assert.deepEqual(candidate([7, 8, 9, 1]),[7, 9, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_555_difference",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the difference between the sum of cubes of the first n natural numbers and the sum of the first n natural numbers.\nfunction difference(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_555_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = difference;\n  assert.deepEqual(candidate(3),30);\n  assert.deepEqual(candidate(5),210);\n  assert.deepEqual(candidate(2),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_556_find_Odd_Pair",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of pairs whose xor value is odd.\nfunction find_Odd_Pair(A: number[], N: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_556_find_Odd_Pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Odd_Pair;\n  assert.deepEqual(candidate([5, 4, 7, 2, 1], 5),6);\n  assert.deepEqual(candidate([7, 2, 8, 1, 0, 5, 11], 7),12);\n  assert.deepEqual(candidate([1, 2, 3], 3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_557_toggle_string",
+    "language": "ts",
+    "prompt": "//Write a function to toggle the case of all characters in a string.\nfunction toggle_string(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_557_toggle_string.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_string;\n  assert.deepEqual(candidate(\"Python\"),\"pYTHON\");\n  assert.deepEqual(candidate(\"Pangram\"),\"pANGRAM\");\n  assert.deepEqual(candidate(\"LIttLE\"),\"liTTle\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_558_digit_distance_nums",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of the per-digit difference between two integers.\nfunction digit_distance_nums(n1: number, n2: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_558_digit_distance_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = digit_distance_nums;\n  assert.deepEqual(candidate(1, 2),1);\n  assert.deepEqual(candidate(23, 56),6);\n  assert.deepEqual(candidate(123, 256),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_559_max_sub_array_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the sum of the largest contiguous subarray in the given array.\nfunction max_sub_array_sum(a: number[], size: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_559_max_sub_array_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sub_array_sum;\n  assert.deepEqual(candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8),7);\n  assert.deepEqual(candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8),8);\n  assert.deepEqual(candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_560_union_elements",
+    "language": "ts",
+    "prompt": "//Write a function to find the union of the elements of two given arrays and output them in sorted order.\nfunction union_elements(test_tup1: number[], test_tup2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_560_union_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = union_elements;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 4, 5, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [3, 4, 5, 6]),[1, 2, 3, 4, 5, 6]);\n  assert.deepEqual(candidate([11, 12, 13, 14], [13, 15, 16, 17]),[11, 12, 13, 14, 15, 16, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_562_Find_Max_Length",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the length of the longest subarrays.\nfunction Find_Max_Length(lst: number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_562_Find_Max_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Max_Length;\n  assert.deepEqual(candidate([[1], [1, 4], [5, 6, 7, 8]]),4);\n  assert.deepEqual(candidate([[0, 1], [2, 2], [3, 2, 1]]),3);\n  assert.deepEqual(candidate([[7], [22, 23], [13, 14, 15], [10, 20, 30, 40, 50]]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_563_extract_values",
+    "language": "ts",
+    "prompt": "//Write a function to extract values between quotation marks from a string.\nfunction extract_values(text: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_563_extract_values.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_values;\n  assert.deepEqual(candidate(\"\"Python\", \"PHP\", \"Java\"\"),[\"Python\", \"PHP\", \"Java\"]);\n  assert.deepEqual(candidate(\"\"python\",\"program\",\"language\"\"),[\"python\", \"program\", \"language\"]);\n  assert.deepEqual(candidate(\"\"red\",\"blue\",\"green\",\"yellow\"\"),[\"red\", \"blue\", \"green\", \"yellow\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_564_count_Pairs",
+    "language": "ts",
+    "prompt": "//Write a tsthon function which takes an array of integers and counts the number of possible unordered pairs where both elements are unequal.\nfunction count_Pairs(arr: number[], n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_564_count_Pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Pairs;\n  assert.deepEqual(candidate([1, 2, 1], 3),2);\n  assert.deepEqual(candidate([1, 1, 1, 1], 4),0);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], 5),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_565_split",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to split a string into characters.\nfunction split(word: string): string[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_565_split.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split;\n  assert.deepEqual(candidate(\"python\"),[\"p\", \"y\", \"t\", \"h\", \"o\", \"n\"]);\n  assert.deepEqual(candidate(\"Name\"),[\"N\", \"a\", \"m\", \"e\"]);\n  assert.deepEqual(candidate(\"program\"),[\"p\", \"r\", \"o\", \"g\", \"r\", \"a\", \"m\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_566_sum_digits",
+    "language": "ts",
+    "prompt": "//Write a function to get the sum of the digits of a non-negative integer.\nfunction sum_digits(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_566_sum_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_digits;\n  assert.deepEqual(candidate(345),12);\n  assert.deepEqual(candidate(12),3);\n  assert.deepEqual(candidate(97),16);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_567_issort_list",
+    "language": "ts",
+    "prompt": "//Write a function to check whether a specified array is sorted or not.\nfunction issort_list(list1: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_567_issort_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = issort_list;\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 16, 17]),true);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17]),false);\n  assert.deepEqual(candidate([1, 2, 4, 6, 8, 10, 15, 14, 20]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_569_sort_sublists",
+    "language": "ts",
+    "prompt": "//Write a function to sort each subarray of strings in a given array of arrays.\nfunction sort_sublists(list1: string[][]): string[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_569_sort_sublists.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_sublists;\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]]),[[\"green\", \"orange\"], [\"black\", \"white\"], [\"black\", \"orange\", \"white\"]]);\n  assert.deepEqual(candidate([[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]),[[\"green\", \"orange\"], [\"black\"], [\"green\", \"orange\"], [\"white\"]]);\n  assert.deepEqual(candidate([[\"a\", \"b\"], [\"d\", \"c\"], [\"g\", \"h\"], [\"f\", \"e\"]]),[[\"a\", \"b\"], [\"c\", \"d\"], [\"g\", \"h\"], [\"e\", \"f\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_56_checks",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check if a given number is one less than twice its reverse.\nfunction checks(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_56_checks.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = checks;\n  assert.deepEqual(candidate(70),false);\n  assert.deepEqual(candidate(23),false);\n  assert.deepEqual(candidate(73),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_572_two_unique_nums",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to remove duplicate numbers from a given number of arrays.\nfunction two_unique_nums(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_572_two_unique_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = two_unique_nums;\n  assert.deepEqual(candidate([1, 2, 3, 2, 3, 4, 5]),[1, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 2, 4, 5]),[1, 3, 4, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_573_unique_product",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to calculate the product of the unique numbers in a given array.\nfunction unique_product(list_data: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_573_unique_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_product;\n  assert.deepEqual(candidate([10, 20, 30, 40, 20, 50, 60, 40]),720000000);\n  assert.deepEqual(candidate([1, 2, 3, 1]),6);\n  assert.deepEqual(candidate([7, 8, 9, 0, 1, 1]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_574_surfacearea_cylinder",
+    "language": "ts",
+    "prompt": "//Write a function to find the surface area of a cylinder.\nfunction surfacearea_cylinder(r: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_574_surfacearea_cylinder.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surfacearea_cylinder;\n  assert.deepEqual(candidate(10, 5),942.45);\n  assert.deepEqual(candidate(4, 5),226.18800000000002);\n  assert.deepEqual(candidate(4, 10),351.848);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_576_is_Sub_Array",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether an array is subarray of another or not.\nfunction is_Sub_Array(A: number[], B: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_576_is_Sub_Array.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Sub_Array;\n  assert.deepEqual(candidate([1, 4, 3, 5], [1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 1], [1, 2, 1]),true);\n  assert.deepEqual(candidate([1, 0, 2, 2], [2, 2, 0]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_577_last_Digit_Factorial",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the last digit in factorial of a given number.\nfunction last_Digit_Factorial(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_577_last_Digit_Factorial.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last_Digit_Factorial;\n  assert.deepEqual(candidate(4),4);\n  assert.deepEqual(candidate(21),0);\n  assert.deepEqual(candidate(30),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_578_interleave_lists",
+    "language": "ts",
+    "prompt": "//Write a function to interleave 3 arrays of the same length into a single flat array.\nfunction interleave_lists(list1: number[], list2: number[], list3: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_578_interleave_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = interleave_lists;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], [100, 200, 300, 400, 500, 600, 700]),[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]);\n  assert.deepEqual(candidate([10, 20], [15, 2], [5, 10]),[10, 15, 5, 20, 2, 10]);\n  assert.deepEqual(candidate([11, 44], [10, 15], [20, 5]),[11, 10, 20, 44, 15, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_579_find_dissimilar",
+    "language": "ts",
+    "prompt": "//Write a function to find the dissimilar elements in the given two arrays.\nfunction find_dissimilar(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_579_find_dissimilar.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_dissimilar;\n  assert.deepEqual(candidate([3, 4, 5, 6], [5, 7, 4, 10]),[3, 6, 7, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], [7, 2, 3, 9]),[1, 4, 7, 9]);\n  assert.deepEqual(candidate([21, 11, 25, 26], [26, 34, 21, 36]),[34, 36, 11, 25]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_57_find_Max_Num",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the largest number that can be formed with the given array of digits.\nfunction find_Max_Num(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_57_find_Max_Num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Max_Num;\n  assert.deepEqual(candidate([1, 2, 3]),321);\n  assert.deepEqual(candidate([4, 5, 6, 1]),6541);\n  assert.deepEqual(candidate([1, 2, 3, 9]),9321);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_580_extract_even",
+    "language": "ts",
+    "prompt": "//Write a function to remove uneven elements in the nested mixed array.\nfunction extract_even(test_tuple: [number, number, [number, number, [number, number]], number, number]): any {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_580_extract_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_even;\n  assert.deepEqual(candidate([4, 5, [7, 6, [2, 4]], 6, 8]),[4, [6, [2, 4]], 6, 8]);\n  assert.deepEqual(candidate([5, 6, [8, 7, [4, 8]], 7, 9]),[6, [8, [4, 8]]]);\n  assert.deepEqual(candidate([5, 6, [9, 8, [4, 6]], 8, 10]),[6, [8, [4, 6]], 8, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_581_surface_Area",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the surface area of a square tsramid with a given base edge and height.\nfunction surface_Area(b: number, s: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_581_surface_Area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = surface_Area;\n  assert.deepEqual(candidate(3, 4),33);\n  assert.deepEqual(candidate(4, 5),56);\n  assert.deepEqual(candidate(1, 2),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_583_catalan_number",
+    "language": "ts",
+    "prompt": "//Write a function which returns nth catalan number.\nfunction catalan_number(num: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_583_catalan_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = catalan_number;\n  assert.deepEqual(candidate(10),16796);\n  assert.deepEqual(candidate(9),4862);\n  assert.deepEqual(candidate(7),429);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_584_find_adverbs",
+    "language": "ts",
+    "prompt": "//Write a function to find the first adverb ending with ly and its positions in a given string.\nfunction find_adverbs(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_584_find_adverbs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_adverbs;\n  assert.deepEqual(candidate(\"Clearly, he has no excuse for such behavior.\"),\"0-7: Clearly\");\n  assert.deepEqual(candidate(\"Please handle the situation carefuly\"),\"28-36: carefuly\");\n  assert.deepEqual(candidate(\"Complete the task quickly\"),\"18-25: quickly\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_586_split_Arr",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to split an array at the nth eelment and add the first part to the end.\nfunction split_Arr(l: number[], n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_586_split_Arr.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = split_Arr;\n  assert.deepEqual(candidate([12, 10, 5, 6, 52, 36], 2),[5, 6, 52, 36, 12, 10]);\n  assert.deepEqual(candidate([1, 2, 3, 4], 1),[2, 3, 4, 1]);\n  assert.deepEqual(candidate([0, 1, 2, 3, 4, 5, 6, 7], 3),[3, 4, 5, 6, 7, 0, 1, 2]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_587_list_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to convert an array to an array.\nfunction list_tuple(listx: number[]): any {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_587_list_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = list_tuple;\n  assert.deepEqual(candidate([5, 10, 7, 4, 15, 3]),[5, 10, 7, 4, 15, 3]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 2, 3, 4, 4, 7]),[2, 4, 5, 6, 2, 3, 4, 4, 7]);\n  assert.deepEqual(candidate([58, 44, 56]),[58, 44, 56]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_588_big_diff",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the difference between largest and smallest value in a given array.\nfunction big_diff(nums: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_588_big_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = big_diff;\n  assert.deepEqual(candidate([1, 2, 3, 4]),3);\n  assert.deepEqual(candidate([4, 5, 12]),8);\n  assert.deepEqual(candidate([9, 2, 3]),7);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_589_perfect_squares",
+    "language": "ts",
+    "prompt": "//Write a function to find perfect squares between two given numbers.\nfunction perfect_squares(a: number, b: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_589_perfect_squares.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = perfect_squares;\n  assert.deepEqual(candidate(1, 30),[1, 4, 9, 16, 25]);\n  assert.deepEqual(candidate(50, 100),[64, 81, 100]);\n  assert.deepEqual(candidate(100, 200),[100, 121, 144, 169, 196]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_58_opposite_Signs",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given two integers have opposite sign or not.\nfunction opposite_Signs(x: number, y: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_58_opposite_Signs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = opposite_Signs;\n  assert.deepEqual(candidate(1, -2),true);\n  assert.deepEqual(candidate(3, 2),false);\n  assert.deepEqual(candidate(-10, -10),false);\n  assert.deepEqual(candidate(-2, 2),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_591_swap_List",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to interchange the first and last elements in an array.\nfunction swap_List(newList: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_591_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([12, 35, 9, 56, 24]),[24, 35, 9, 56, 12]);\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_592_sum_Of_product",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of the product of consecutive binomial co-efficients.\nfunction sum_Of_product(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_592_sum_Of_product.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_product;\n  assert.deepEqual(candidate(3),15);\n  assert.deepEqual(candidate(4),56);\n  assert.deepEqual(candidate(1),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_593_removezero_ip",
+    "language": "ts",
+    "prompt": "//Write a function to remove leading zeroes from an ip address.\nfunction removezero_ip(ip: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_593_removezero_ip.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = removezero_ip;\n  assert.deepEqual(candidate(\"216.08.094.196\"),\"216.8.94.196\");\n  assert.deepEqual(candidate(\"12.01.024\"),\"12.1.24\");\n  assert.deepEqual(candidate(\"216.08.094.0196\"),\"216.8.94.196\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_594_diff_even_odd",
+    "language": "ts",
+    "prompt": "//Write a function to find the difference of the first even and first odd number of a given array.\nfunction diff_even_odd(list1: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_594_diff_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = diff_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),1);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_595_min_Swaps",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count minimum number of swaps required to convert one binary number represented as a string to another.\nfunction min_Swaps(str1: string, str2: string): any {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_595_min_Swaps.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Swaps;\n  assert.deepEqual(candidate(\"1101\", \"1110\"),1);\n  assert.deepEqual(candidate(\"111\", \"000\"),\"Not Possible\");\n  assert.deepEqual(candidate(\"111\", \"110\"),\"Not Possible\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_597_find_kth",
+    "language": "ts",
+    "prompt": "//Write a function to find kth element from the given two sorted arrays.\nfunction find_kth(arr1: number[], arr2: number[], k: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_597_find_kth.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_kth;\n  assert.deepEqual(candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5),6);\n  assert.deepEqual(candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 7),256);\n  assert.deepEqual(candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 6),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_598_armstrong_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is armstrong or not.\nfunction armstrong_number(number: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_598_armstrong_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = armstrong_number;\n  assert.deepEqual(candidate(153),true);\n  assert.deepEqual(candidate(259),false);\n  assert.deepEqual(candidate(4458),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_599_sum_average",
+    "language": "ts",
+    "prompt": "//Write a function to find sum and average of first n natural numbers.\nfunction sum_average(number: number): [number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_599_sum_average.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_average;\n  assert.deepEqual(candidate(10),[55, 5.5]);\n  assert.deepEqual(candidate(15),[120, 8.0]);\n  assert.deepEqual(candidate(20),[210, 10.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_59_is_octagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth octagonal number.\nfunction is_octagonal(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_59_is_octagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_octagonal;\n  assert.deepEqual(candidate(5),65);\n  assert.deepEqual(candidate(10),280);\n  assert.deepEqual(candidate(15),645);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_600_is_Even",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given number is even or not.\nfunction is_Even(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_600_is_Even.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Even;\n  assert.deepEqual(candidate(1),false);\n  assert.deepEqual(candidate(2),true);\n  assert.deepEqual(candidate(3),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_602_first_repeated_char",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the first repeated character in a given string.\nfunction first_repeated_char(str1: string): string | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_602_first_repeated_char.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_repeated_char;\n  assert.deepEqual(candidate(\"abcabc\"),\"a\");\n  assert.deepEqual(candidate(\"abc\"),undefined);\n  assert.deepEqual(candidate(\"123123\"),\"1\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_603_get_ludic",
+    "language": "ts",
+    "prompt": "//Write a function to get all lucid numbers smaller than or equal to a given integer.\nfunction get_ludic(n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_603_get_ludic.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_ludic;\n  assert.deepEqual(candidate(10),[1, 2, 3, 5, 7]);\n  assert.deepEqual(candidate(25),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25]);\n  assert.deepEqual(candidate(45),[1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_604_reverse_words",
+    "language": "ts",
+    "prompt": "//Write a function to reverse words seperated by spaces in a given string.\nfunction reverse_words(s: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_604_reverse_words.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_words;\n  assert.deepEqual(candidate(\"python program\"),\"program python\");\n  assert.deepEqual(candidate(\"java language\"),\"language java\");\n  assert.deepEqual(candidate(\"indian man\"),\"man indian\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_605_prime_num",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given integer is a prime number.\nfunction prime_num(num: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_605_prime_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = prime_num;\n  assert.deepEqual(candidate(13),true);\n  assert.deepEqual(candidate(7),true);\n  assert.deepEqual(candidate(-1010),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_606_radian_degree",
+    "language": "ts",
+    "prompt": "//Write a function to convert degrees to radians.\nfunction radian_degree(degree: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_606_radian_degree.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = radian_degree;\n  assert.deepEqual(candidate(90),1.5707963267948966);\n  assert.deepEqual(candidate(60),1.0471975511965976);\n  assert.deepEqual(candidate(120),2.0943951023931953);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_607_find_literals",
+    "language": "ts",
+    "prompt": "//Write a function to search a string for a regex pattern. The function should return the matching subtring, a start index and an end index.\nfunction find_literals(text: string, pattern: string): [string, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_607_find_literals.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_literals;\n  assert.deepEqual(candidate(\"The quick brown fox jumps over the lazy dog.\", \"fox\"),[\"fox\", 16, 19]);\n  assert.deepEqual(candidate(\"Its been a very crazy procedure right\", \"crazy\"),[\"crazy\", 16, 21]);\n  assert.deepEqual(candidate(\"Hardest choices required strongest will\", \"will\"),[\"will\", 35, 39]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_608_bell_Number",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find nth bell number.\nfunction bell_Number(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_608_bell_Number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_Number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(3),5);\n  assert.deepEqual(candidate(4),15);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_610_remove_kth_element",
+    "language": "ts",
+    "prompt": "//Write a tsthon function which takes an array and returns an array with the same elements, but the k'th element removed.\nfunction remove_kth_element(list1: number[], L: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_610_remove_kth_element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_kth_element;\n  assert.deepEqual(candidate([1, 1, 2, 3, 4, 4, 5, 1], 3),[1, 1, 3, 4, 4, 5, 1]);\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4], 4),[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10], 5),[10, 10, 15, 19, 18, 17, 26, 26, 17, 18, 10]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_611_max_of_nth",
+    "language": "ts",
+    "prompt": "//Write a function which given a matrix represented as an array of arrays returns the max of the n'th column.\nfunction max_of_nth(test_list: number[][], N: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_611_max_of_nth.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_of_nth;\n  assert.deepEqual(candidate([[5, 6, 7], [1, 3, 5], [8, 9, 19]], 2),19);\n  assert.deepEqual(candidate([[6, 7, 8], [2, 4, 6], [9, 10, 20]], 1),10);\n  assert.deepEqual(candidate([[7, 8, 9], [3, 5, 7], [10, 11, 21]], 1),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_612_merge",
+    "language": "ts",
+    "prompt": "//Write a tsthon function which takes an array of arrays, where each subarray has two elements, and returns an array of two arrays where the first array has the first element of each subarray and the second one has the second.\nfunction merge(lst: any[][]): any[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_612_merge.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge;\n  assert.deepEqual(candidate([[\"x\", \"y\"], [\"a\", \"b\"], [\"m\", \"n\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"]]);\n  assert.deepEqual(candidate([[1, 2], [3, 4], [5, 6], [7, 8]]),[[1, 3, 5, 7], [2, 4, 6, 8]]);\n  assert.deepEqual(candidate([[\"x\", \"y\", \"z\"], [\"a\", \"b\", \"c\"], [\"m\", \"n\", \"o\"]]),[[\"x\", \"a\", \"m\"], [\"y\", \"b\", \"n\"], [\"z\", \"c\", \"o\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_614_cummulative_sum",
+    "language": "ts",
+    "prompt": "//Write a function to find the cumulative sum of all the values that are present in the given array of arrays.\nfunction cummulative_sum(test_list: number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_614_cummulative_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = cummulative_sum;\n  assert.deepEqual(candidate([[1, 3], [5, 6, 7], [2, 6]]),30);\n  assert.deepEqual(candidate([[2, 4], [6, 7, 8], [3, 7]]),37);\n  assert.deepEqual(candidate([[3, 5], [7, 8, 9], [4, 8]]),44);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_615_average_tuple",
+    "language": "ts",
+    "prompt": "//Write a function which takes an arrays of arrays and returns the average value for each subarray as an array.\nfunction average_tuple(nums: number[][]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_615_average_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = average_tuple;\n  assert.deepEqual(candidate([[10, 10, 10, 12], [30, 45, 56, 45], [81, 80, 39, 32], [1, 2, 3, 4]]),[30.5, 34.25, 27.0, 23.25]);\n  assert.deepEqual(candidate([[1, 1, -5], [30, -15, 56], [81, -60, -39], [-10, 2, 3]]),[25.5, -18.0, 3.75]);\n  assert.deepEqual(candidate([[100, 100, 100, 120], [300, 450, 560, 450], [810, 800, 390, 320], [10, 20, 30, 40]]),[305.0, 342.5, 270.0, 232.5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_616_tuple_modulo",
+    "language": "ts",
+    "prompt": "//Write a function which takes two arrays of the same length and performs the element wise modulo.\nfunction tuple_modulo(test_tup1: [number, number, number, number], test_tup2: [number, number, number, number]): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_616_tuple_modulo.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_modulo;\n  assert.deepEqual(candidate([10, 4, 5, 6], [5, 6, 7, 5]),[0, 4, 5, 1]);\n  assert.deepEqual(candidate([11, 5, 6, 7], [6, 7, 8, 6]),[5, 5, 6, 1]);\n  assert.deepEqual(candidate([12, 6, 7, 8], [7, 8, 9, 7]),[5, 6, 7, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_617_min_Jumps",
+    "language": "ts",
+    "prompt": "//Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nfunction min_Jumps(steps: [number, number], d: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_617_min_Jumps.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_Jumps;\n  assert.deepEqual(candidate([3, 4], 11),3.5);\n  assert.deepEqual(candidate([3, 4], 0),0);\n  assert.deepEqual(candidate([11, 14], 11),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_618_div_list",
+    "language": "ts",
+    "prompt": "//Write a function to divide two arrays element wise.\nfunction div_list(nums1: number[], nums2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_618_div_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = div_list;\n  assert.deepEqual(candidate([4, 5, 6], [1, 2, 3]),[4.0, 2.5, 2.0]);\n  assert.deepEqual(candidate([3, 2], [1, 4]),[3.0, 0.5]);\n  assert.deepEqual(candidate([90, 120], [50, 70]),[1.8, 1.7142857142857142]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_619_move_num",
+    "language": "ts",
+    "prompt": "//Write a function to move all the numbers to the end of the given string.\nfunction move_num(test_str: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_619_move_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_num;\n  assert.deepEqual(candidate(\"I1love143you55three3000thousand\"),\"Iloveyouthreethousand1143553000\");\n  assert.deepEqual(candidate(\"Avengers124Assemble\"),\"AvengersAssemble124\");\n  assert.deepEqual(candidate(\"Its11our12path13to14see15things16do17things\"),\"Itsourpathtoseethingsdothings11121314151617\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_61_count_Substrings",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of substrings with the sum of digits equal to their length.\nfunction count_Substrings(s: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_61_count_Substrings.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_Substrings;\n  assert.deepEqual(candidate(\"112112\"),6);\n  assert.deepEqual(candidate(\"111\"),6);\n  assert.deepEqual(candidate(\"1101112\"),12);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_622_get_median",
+    "language": "ts",
+    "prompt": "//Write a function to find the median of two sorted arrays of same size.\nfunction get_median(arr1: number[], arr2: number[], n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_622_get_median.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_median;\n  assert.deepEqual(candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5),16.0);\n  assert.deepEqual(candidate([2, 4, 8, 9], [7, 13, 19, 28], 4),8.5);\n  assert.deepEqual(candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6),25.0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_623_nth_nums",
+    "language": "ts",
+    "prompt": "//Write a function to compute the n-th power of each number in an array.\nfunction nth_nums(nums: number[], n: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_623_nth_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = nth_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30], 3),[1000, 8000, 27000]);\n  assert.deepEqual(candidate([12, 15], 5),[248832, 759375]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_624_is_upper",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to convert a given string to uppercase.\nfunction is_upper(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_624_is_upper.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_upper;\n  assert.deepEqual(candidate(\"person\"),\"PERSON\");\n  assert.deepEqual(candidate(\"final\"),\"FINAL\");\n  assert.deepEqual(candidate(\"Valid\"),\"VALID\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_625_swap_List",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to interchange the first and last element in a given array.\nfunction swap_List(newList: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_625_swap_List.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = swap_List;\n  assert.deepEqual(candidate([1, 2, 3]),[3, 2, 1]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 4]),[4, 2, 3, 4, 1]);\n  assert.deepEqual(candidate([4, 5, 6]),[6, 5, 4]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_626_triangle_area",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the area of the largest triangle that can be inscribed in a semicircle with a given radius.\nfunction triangle_area(r: number): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_626_triangle_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = triangle_area;\n  assert.deepEqual(candidate(-1),undefined);\n  assert.deepEqual(candidate(0),0);\n  assert.deepEqual(candidate(2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_627_find_First_Missing",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the smallest missing number from a sorted array of natural numbers.\nfunction find_First_Missing(array: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_627_find_First_Missing.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_First_Missing;\n  assert.deepEqual(candidate([0, 1, 2, 3]),4);\n  assert.deepEqual(candidate([0, 1, 2, 6, 9]),3);\n  assert.deepEqual(candidate([2, 3, 5, 8, 9]),0);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_628_replace_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to replace all spaces in the given string with '%20'.\nfunction replace_spaces(string: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_628_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"My Name is Dawood\"),\"My%20Name%20is%20Dawood\");\n  assert.deepEqual(candidate(\"I am a Programmer\"),\"I%20am%20a%20Programmer\");\n  assert.deepEqual(candidate(\"I love Coding\"),\"I%20love%20Coding\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_629_Split",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find even numbers from an array of numbers.\nfunction Split(list: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_629_Split.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Split;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),[2, 4]);\n  assert.deepEqual(candidate([4, 5, 6, 7, 8, 0, 1]),[4, 6, 8, 0]);\n  assert.deepEqual(candidate([8, 12, 15, 19]),[8, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_62_smallest_num",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find smallest number in an array.\nfunction smallest_num(xs: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_62_smallest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = smallest_num;\n  assert.deepEqual(candidate([10, 20, 1, 45, 99]),1);\n  assert.deepEqual(candidate([1, 2, 3]),1);\n  assert.deepEqual(candidate([45, 46, 50, 60]),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_630_get_coordinates",
+    "language": "ts",
+    "prompt": "//Write a function to extract all the adjacent coordinates of the given coordinate array.\nfunction get_coordinates(test_tup: [number, number]): number[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_630_get_coordinates.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_coordinates;\n  assert.deepEqual(candidate([3, 4]),[[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([4, 5]),[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]);\n  assert.deepEqual(candidate([5, 6]),[[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_631_replace_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to replace whitespaces with an underscore and vice versa in a given string.\nfunction replace_spaces(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_631_replace_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_spaces;\n  assert.deepEqual(candidate(\"Jumanji The Jungle\"),\"Jumanji_The_Jungle\");\n  assert.deepEqual(candidate(\"The_Avengers\"),\"The Avengers\");\n  assert.deepEqual(candidate(\"Fast and Furious\"),\"Fast_and_Furious\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_632_move_zero",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to move all zeroes to the end of the given array.\nfunction move_zero(num_list: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_632_move_zero.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = move_zero;\n  assert.deepEqual(candidate([1, 0, 2, 0, 3, 4]),[1, 2, 3, 4, 0, 0]);\n  assert.deepEqual(candidate([2, 3, 2, 0, 0, 4, 0, 5, 0]),[2, 3, 2, 4, 5, 0, 0, 0, 0]);\n  assert.deepEqual(candidate([0, 1, 0, 1, 1]),[1, 1, 1, 0, 0]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_633_pair_xor_Sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of xor of all pairs of numbers in the given array.\nfunction pair_xor_Sum(arr: number[], n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_633_pair_xor_Sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_xor_Sum;\n  assert.deepEqual(candidate([5, 9, 7, 6], 4),47);\n  assert.deepEqual(candidate([7, 3, 5], 3),12);\n  assert.deepEqual(candidate([7, 3], 2),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_635_heap_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort the given array.\nfunction heap_sort(iterable: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_635_heap_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = heap_sort;\n  assert.deepEqual(candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);\n  assert.deepEqual(candidate([25, 35, 22, 85, 14, 65, 75, 25, 58]),[14, 22, 25, 25, 35, 58, 65, 75, 85]);\n  assert.deepEqual(candidate([7, 1, 9, 5]),[1, 5, 7, 9]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_637_noprofit_noloss",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given amount has no profit and no loss\nfunction noprofit_noloss(actual_cost: number, sale_amount: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_637_noprofit_noloss.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = noprofit_noloss;\n  assert.deepEqual(candidate(1500, 1200),false);\n  assert.deepEqual(candidate(100, 100),true);\n  assert.deepEqual(candidate(2000, 5000),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_638_wind_chill",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the wind chill index rounded to the next integer given the wind velocity in km/h and a temperature in celsius.\nfunction wind_chill(v: number, t: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_638_wind_chill.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = wind_chill;\n  assert.deepEqual(candidate(120, 35),40);\n  assert.deepEqual(candidate(40, 20),19);\n  assert.deepEqual(candidate(10, 8),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_639_sample_nam",
+    "language": "ts",
+    "prompt": "//Write a function to sum the length of the names of a given array of names after removing the names that start with a lowercase letter.\nfunction sample_nam(sample_names: string[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_639_sample_nam.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sample_nam;\n  assert.deepEqual(candidate([\"sally\", \"Dylan\", \"rebecca\", \"Diana\", \"Joanne\", \"keith\"]),16);\n  assert.deepEqual(candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"]),10);\n  assert.deepEqual(candidate([\"abcd\", \"Python\", \"abba\", \"aba\"]),6);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_63_max_difference",
+    "language": "ts",
+    "prompt": "//Write a function to find the maximum difference between available pairs in the given array array.\nfunction max_difference(test_list: [number, number][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_63_max_difference.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_difference;\n  assert.deepEqual(candidate([[3, 5], [1, 7], [10, 3], [1, 2]]),7);\n  assert.deepEqual(candidate([[4, 6], [2, 17], [9, 13], [11, 12]]),15);\n  assert.deepEqual(candidate([[12, 35], [21, 27], [13, 23], [41, 22]]),23);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_640_remove_parenthesis",
+    "language": "ts",
+    "prompt": "//Write a function to remove the parenthesis and what is inbetween them from a string.\nfunction remove_parenthesis(items: string[]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_640_remove_parenthesis.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_parenthesis;\n  assert.deepEqual(candidate([\"python (chrome)\"]),\"python\");\n  assert.deepEqual(candidate([\"string(.abc)\"]),\"string\");\n  assert.deepEqual(candidate([\"alpha(num)\"]),\"alpha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_641_is_nonagonal",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth nonagonal number.\nfunction is_nonagonal(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_641_is_nonagonal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_nonagonal;\n  assert.deepEqual(candidate(10),325);\n  assert.deepEqual(candidate(15),750);\n  assert.deepEqual(candidate(18),1089);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_643_text_match_wordz_middle",
+    "language": "ts",
+    "prompt": "//Write a function that checks if a strings contains 'z', except at the start and end of the word.\nfunction text_match_wordz_middle(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_643_text_match_wordz_middle.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_wordz_middle;\n  assert.deepEqual(candidate(\"pythonzabc.\"),true);\n  assert.deepEqual(candidate(\"zxyabc.\"),false);\n  assert.deepEqual(candidate(\"  lang  .\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_644_reverse_Array_Upto_K",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to reverse an array upto a given position.\nfunction reverse_Array_Upto_K(input: number[], k: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_644_reverse_Array_Upto_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = reverse_Array_Upto_K;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 4),[4, 3, 2, 1, 5, 6]);\n  assert.deepEqual(candidate([4, 5, 6, 7], 2),[5, 4, 6, 7]);\n  assert.deepEqual(candidate([9, 8, 7, 6, 5], 3),[7, 8, 9, 6, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_64_subject_marks",
+    "language": "ts",
+    "prompt": "//Write a function to sort an array of arrays using the second value of each array.\nfunction subject_marks(subjectmarks: [string, number][]): [string, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_64_subject_marks.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = subject_marks;\n  assert.deepEqual(candidate([[\"English\", 88], [\"Science\", 90], [\"Maths\", 97], [\"Social sciences\", 82]]),[[\"Social sciences\", 82], [\"English\", 88], [\"Science\", 90], [\"Maths\", 97]]);\n  assert.deepEqual(candidate([[\"Telugu\", 49], [\"Hindhi\", 54], [\"Social\", 33]]),[[\"Social\", 33], [\"Telugu\", 49], [\"Hindhi\", 54]]);\n  assert.deepEqual(candidate([[\"Physics\", 96], [\"Chemistry\", 97], [\"Biology\", 45]]),[[\"Biology\", 45], [\"Physics\", 96], [\"Chemistry\", 97]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_65_recursive_list_sum",
+    "language": "ts",
+    "prompt": "//Write a function to flatten an array and sum all of its elements.\nfunction recursive_list_sum(data_list: number| number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_65_recursive_list_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = recursive_list_sum;\n  assert.deepEqual(candidate([1, 2, [3, 4], [5, 6]]),21);\n  assert.deepEqual(candidate([7, 10, [15, 14], [19, 41]]),106);\n  assert.deepEqual(candidate([10, 20, [30, 40], [50, 60]]),210);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_66_pos_count",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of positive numbers in an array.\nfunction pos_count(list: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_66_pos_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pos_count;\n  assert.deepEqual(candidate([1, -2, 3, -4]),2);\n  assert.deepEqual(candidate([3, 4, 5, -1]),3);\n  assert.deepEqual(candidate([1, 2, 3, 4]),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_67_bell_number",
+    "language": "ts",
+    "prompt": "//Write a function to find the number of ways to partition a set of Bell numbers.\nfunction bell_number(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_67_bell_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = bell_number;\n  assert.deepEqual(candidate(2),2);\n  assert.deepEqual(candidate(10),115975);\n  assert.deepEqual(candidate(56),6775685320645824322581483068371419745979053216268760300);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_68_is_Monotonic",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given array is monotonic or not.\nfunction is_Monotonic(A: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_68_is_Monotonic.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Monotonic;\n  assert.deepEqual(candidate([6, 5, 4, 4]),true);\n  assert.deepEqual(candidate([1, 2, 2, 3]),true);\n  assert.deepEqual(candidate([1, 3, 2]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_69_is_sublist",
+    "language": "ts",
+    "prompt": "//Write a function to check whether an array contains the given subarray or not.\nfunction is_sublist(l: number[], s: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_69_is_sublist.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_sublist;\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [3, 7]),false);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [4, 3]),true);\n  assert.deepEqual(candidate([2, 4, 3, 5, 7], [1, 6]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_6_differ_At_One_Bit_Pos",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the two numbers differ at one bit position only or not.\nfunction differ_At_One_Bit_Pos(a: number, b: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_6_differ_At_One_Bit_Pos.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = differ_At_One_Bit_Pos;\n  assert.deepEqual(candidate(13, 9),true);\n  assert.deepEqual(candidate(15, 8),false);\n  assert.deepEqual(candidate(2, 4),false);\n  assert.deepEqual(candidate(2, 3),true);\n  assert.deepEqual(candidate(5, 1),true);\n  assert.deepEqual(candidate(1, 5),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_70_get_equal",
+    "language": "ts",
+    "prompt": "//Write a function to find whether all the given arrays have equal length or not.\nfunction get_equal(Input: number[][]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_70_get_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_equal;\n  assert.deepEqual(candidate([[11, 22, 33], [44, 55, 66]]),true);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6, 7]]),false);\n  assert.deepEqual(candidate([[1, 2], [3, 4]]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_71_comb_sort",
+    "language": "ts",
+    "prompt": "//Write a function to sort an array of elements.\nfunction comb_sort(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_71_comb_sort.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = comb_sort;\n  assert.deepEqual(candidate([5, 15, 37, 25, 79]),[5, 15, 25, 37, 79]);\n  assert.deepEqual(candidate([41, 32, 15, 19, 22]),[15, 19, 22, 32, 41]);\n  assert.deepEqual(candidate([99, 15, 13, 47]),[13, 15, 47, 99]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_720_add_dict_to_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to add an object to the array. The output should be an array.\nfunction add_dict_to_tuple(test_tup: [number, number, number], test_dict: {[key: string]: number}): [number, number, number, {[key: string]: number}] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_720_add_dict_to_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_dict_to_tuple;\n  assert.deepEqual(candidate([4, 5, 6], {\"MSAM\": 1, \"is\": 2, \"best\": 3}),[4, 5, 6, {\"MSAM\": 1, \"is\": 2, \"best\": 3}]);\n  assert.deepEqual(candidate([1, 2, 3], {\"UTS\": 2, \"is\": 3, \"Worst\": 4}),[1, 2, 3, {\"UTS\": 2, \"is\": 3, \"Worst\": 4}]);\n  assert.deepEqual(candidate([8, 9, 10], {\"POS\": 3, \"is\": 4, \"Okay\": 5}),[8, 9, 10, {\"POS\": 3, \"is\": 4, \"Okay\": 5}]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_721_maxAverageOfPath",
+    "language": "ts",
+    "prompt": "//Given a square matrix of size N*N given as an array of arrays, where each cell is associated with a specific cost. A path is defined as a specific sequence of cells that starts from the top-left cell move only right or down and ends on bottom right cell. We want to find a path with the maximum average over all existing paths. Average is computed as total cost divided by the number of cells visited in the path.\nfunction maxAverageOfPath(cost: number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_721_maxAverageOfPath.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = maxAverageOfPath;\n  assert.deepEqual(candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]]),5.2);\n  assert.deepEqual(candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]]),6.2);\n  assert.deepEqual(candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]]),7.2);\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),5.8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_723_count_same_pair",
+    "language": "ts",
+    "prompt": "//The input is defined as two arrays of the same length. Write a function to count indices where the arrays have the same values.\nfunction count_same_pair(nums1: number[], nums2: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_723_count_same_pair.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_same_pair;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 3, 1, 2, 6, 7, 9]),4);\n  assert.deepEqual(candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),11);\n  assert.deepEqual(candidate([2, 4, -6, -9, 11, -12, 14, -5, 17], [2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8]),1);\n  assert.deepEqual(candidate([0, 1, 1, 2], [0, 1, 2, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_724_power_base_sum",
+    "language": "ts",
+    "prompt": "//Write a function that takes base and power as arguments and calculate the sum of all digits of the base to the specified power.\nfunction power_base_sum(base: number, power: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_724_power_base_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power_base_sum;\n  assert.deepEqual(candidate(2, 100),115);\n  assert.deepEqual(candidate(8, 10),37);\n  assert.deepEqual(candidate(8, 15),62);\n  assert.deepEqual(candidate(3, 3),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_725_extract_quotation",
+    "language": "ts",
+    "prompt": "//Write a function to extract values between quotation marks \" \" of the given string.\nfunction extract_quotation(text1: string): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_725_extract_quotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_quotation;\n  assert.deepEqual(candidate(\"Cortex \"A53\" Based \"multi\" tasking \"Processor\"\"),[\"A53\", \"multi\", \"Processor\"]);\n  assert.deepEqual(candidate(\"Cast your \"favorite\" entertainment \"apps\"\"),[\"favorite\", \"apps\"]);\n  assert.deepEqual(candidate(\"Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support\"),[\"4k Ultra HD\", \"HDR 10\"]);\n  assert.deepEqual(candidate(\"Watch content '4k Ultra HD' resolution with 'HDR 10' Support\"),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_726_multiply_elements",
+    "language": "ts",
+    "prompt": "//Write a function that takes as input an array of numbers (t_1,...,t_{N+1}) and returns an array of length N where the i-th element of the array is equal to t_i * t_{i+1}.\nfunction multiply_elements(test_tup: number[]): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_726_multiply_elements.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = multiply_elements;\n  assert.deepEqual(candidate([1, 5, 7, 8, 10]),[5, 35, 56, 80]);\n  assert.deepEqual(candidate([2, 4, 5, 6, 7]),[8, 20, 30, 42]);\n  assert.deepEqual(candidate([12, 13, 14, 9, 15]),[156, 182, 126, 135]);\n  assert.deepEqual(candidate([12]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_728_sum_list",
+    "language": "ts",
+    "prompt": "//Write a function takes as input two arrays [a_1,...,a_n], [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n].\nfunction sum_list(lst1: number[], lst2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_728_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_list;\n  assert.deepEqual(candidate([10, 20, 30], [15, 25, 35]),[25, 45, 65]);\n  assert.deepEqual(candidate([1, 2, 3], [5, 6, 7]),[6, 8, 10]);\n  assert.deepEqual(candidate([15, 20, 30], [15, 45, 75]),[30, 65, 105]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_72_dif_Square",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the given number can be represented as the difference of two squares or not.\nfunction dif_Square(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_72_dif_Square.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = dif_Square;\n  assert.deepEqual(candidate(5),true);\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(15),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_730_consecutive_duplicates",
+    "language": "ts",
+    "prompt": "//Write a function to remove consecutive duplicates of a given array.\nfunction consecutive_duplicates(nums: any[]): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_730_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[10, 15, 19, 18, 17, 26, 17, 18, 10]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[\"a\", \"b\", \"c\", \"d\"]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\", \"a\", \"a\"]),[\"a\", \"b\", \"c\", \"d\", \"a\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_731_lateralsurface_cone",
+    "language": "ts",
+    "prompt": "//Write a function to find the lateral surface area of a cone given radius r and the height h.\nfunction lateralsurface_cone(r: number, h: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_731_lateralsurface_cone.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lateralsurface_cone;\n  assert.deepEqual(candidate(5, 12),204.20352248333654);\n  assert.deepEqual(candidate(10, 15),566.3586699569488);\n  assert.deepEqual(candidate(19, 17),1521.8090132193388);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_732_replace_specialchar",
+    "language": "ts",
+    "prompt": "//Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nfunction replace_specialchar(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_732_replace_specialchar.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = replace_specialchar;\n  assert.deepEqual(candidate(\"Python language, Programming language.\"),\"Python:language::Programming:language:\");\n  assert.deepEqual(candidate(\"a b c,d e f\"),\"a:b:c:d:e:f\");\n  assert.deepEqual(candidate(\"ram reshma,ram rahim\"),\"ram:reshma:ram:rahim\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_733_find_first_occurrence",
+    "language": "ts",
+    "prompt": "//Write a function to find the index of the first occurrence of a given number in a sorted array.\nfunction find_first_occurrence(A: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_733_find_first_occurrence.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_first_occurrence;\n  assert.deepEqual(candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5),1);\n  assert.deepEqual(candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5),2);\n  assert.deepEqual(candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_734_sum_Of_Subarray_Prod",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find sum of products of all possible subarrays of a given array. https://www.geeksforgeeks.org/sum-of-products-of-all-possible-subarrays/\nfunction sum_Of_Subarray_Prod(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_734_sum_Of_Subarray_Prod.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_Of_Subarray_Prod;\n  assert.deepEqual(candidate([1, 2, 3]),20);\n  assert.deepEqual(candidate([1, 2]),5);\n  assert.deepEqual(candidate([1, 2, 3, 4]),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_735_toggle_middle_bits",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to toggle bits of the number except the first and the last bit. https://www.geeksforgeeks.org/toggle-bits-number-expect-first-last-bits/\nfunction toggle_middle_bits(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_735_toggle_middle_bits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = toggle_middle_bits;\n  assert.deepEqual(candidate(9),15);\n  assert.deepEqual(candidate(10),12);\n  assert.deepEqual(candidate(11),13);\n  assert.deepEqual(candidate(65),127);\n  assert.deepEqual(candidate(77),115);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_736_left_insertion",
+    "language": "ts",
+    "prompt": "//Write a function to locate the left insertion point for a specified value in sorted order. https://www.w3resource.com/tsthon-exercises/data-structures-and-algorithms/tsthon-data-structure-exercise-24.php\nfunction left_insertion(a: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_736_left_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_737_check_str",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given string is starting with a vowel or not using regex.\nfunction check_str(string: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_737_check_str.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_str;\n  assert.deepEqual(candidate(\"annie\"),true);\n  assert.deepEqual(candidate(\"dawood\"),false);\n  assert.deepEqual(candidate(\"Else\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_738_geometric_sum",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the geometric sum of n-1. https://www.w3resource.com/tsthon-exercises/data-structures-and-algorithms/tsthon-recursion-exercise-9.php\nfunction geometric_sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_738_geometric_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = geometric_sum;\n  assert.deepEqual(candidate(7),1.9921875);\n  assert.deepEqual(candidate(4),1.9375);\n  assert.deepEqual(candidate(8),1.99609375);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_739_find_Index",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the index of smallest triangular number with n digits. https://www.geeksforgeeks.org/index-of-smallest-triangular-number-with-n-digits/\nfunction find_Index(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_739_find_Index.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Index;\n  assert.deepEqual(candidate(2),4);\n  assert.deepEqual(candidate(3),14);\n  assert.deepEqual(candidate(4),45);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_740_tuple_to_dict",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given array to a key-value object using adjacent elements. https://www.geeksforgeeks.org/tsthon-convert-array-to-adjacent-pair-object/\nfunction tuple_to_dict(test_tup: [number, number, number, number, number, number]): {[key: number]: number} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_740_tuple_to_dict.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_to_dict;\n  assert.deepEqual(candidate([1, 5, 7, 10, 13, 5]),{1: 5, 7: 10, 13: 5});\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),{1: 2, 3: 4, 5: 6});\n  assert.deepEqual(candidate([7, 8, 9, 10, 11, 12]),{7: 8, 9: 10, 11: 12});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_741_all_Characters_Same",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether all the characters are same or not.\nfunction all_Characters_Same(s: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_741_all_Characters_Same.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = all_Characters_Same;\n  assert.deepEqual(candidate(\"python\"),false);\n  assert.deepEqual(candidate(\"aaa\"),true);\n  assert.deepEqual(candidate(\"data\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_742_area_tetrahedron",
+    "language": "ts",
+    "prompt": "//Write a function to caluclate the area of a tetrahedron.\nfunction area_tetrahedron(side: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_742_area_tetrahedron.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = area_tetrahedron;\n  assert.deepEqual(candidate(3),15.588457268119894);\n  assert.deepEqual(candidate(20),692.8203230275509);\n  assert.deepEqual(candidate(10),173.20508075688772);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_743_rotate_right",
+    "language": "ts",
+    "prompt": "//Write a function to rotate a given array by specified number of items to the right direction. https://www.geeksforgeeks.org/tsthon-program-right-rotate-array-n/\nfunction rotate_right(list: number[], m: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_743_rotate_right.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rotate_right;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3),[8, 9, 10, 1, 2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2),[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5),[6, 7, 8, 9, 10, 1, 2, 3, 4, 5]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_744_check_none",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given array has any none value or not.\nfunction check_none(test_tup: any): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_744_check_none.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_none;\n  assert.deepEqual(candidate([10, 4, 5, 6, undefined]),true);\n  assert.deepEqual(candidate([7, 8, 9, 11, 14]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, undefined]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_745_divisible_by_digits",
+    "language": "ts",
+    "prompt": "//Write a function to find numbers within a given range from startnum ti endnum where every number is divisible by every digit it contains. https://www.w3resource.com/tsthon-exercises/lambda/tsthon-lambda-exercise-24.php\nfunction divisible_by_digits(startnum: number, endnum: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_745_divisible_by_digits.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisible_by_digits;\n  assert.deepEqual(candidate(1, 22),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]);\n  assert.deepEqual(candidate(1, 15),[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]);\n  assert.deepEqual(candidate(20, 25),[22, 24]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_746_sector_area",
+    "language": "ts",
+    "prompt": "//Write a function to find area of a sector. The function takes the radius and angle as inputs. Function should return undefined if the angle is larger than 360 degrees.\nfunction sector_area(r: number, a: number): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_746_sector_area.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sector_area;\n  assert.deepEqual(candidate(4, 45),6.283185307179586);\n  assert.deepEqual(candidate(9, 45),31.808625617596654);\n  assert.deepEqual(candidate(9, 361),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_747_lcs_of_three",
+    "language": "ts",
+    "prompt": "//Write a function to find the longest common subsequence for the given three string sequence. https://www.geeksforgeeks.org/lcs-longest-common-subsequence-three-strings/\nfunction lcs_of_three(X: string, Y: string, Z: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_747_lcs_of_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = lcs_of_three;\n  assert.deepEqual(candidate(\"AGGT12\", \"12TXAYB\", \"12XBA\"),2);\n  assert.deepEqual(candidate(\"Reels\", \"Reelsfor\", \"ReelsforReels\"),5);\n  assert.deepEqual(candidate(\"abcd1e2\", \"bc12ea\", \"bd1ea\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_748_capital_words_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to put spaces between words starting with capital letters in a given string.\nfunction capital_words_spaces(str1: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_748_capital_words_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = capital_words_spaces;\n  assert.deepEqual(candidate(\"Python\"),\"Python\");\n  assert.deepEqual(candidate(\"PythonProgrammingExamples\"),\"Python Programming Examples\");\n  assert.deepEqual(candidate(\"GetReadyToBeCodingFreak\"),\"Get Ready To Be Coding Freak\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_749_sort_numeric_strings",
+    "language": "ts",
+    "prompt": "//Write a function to sort a given array of strings of numbers numerically. https://www.geeksforgeeks.org/tsthon-sort-numeric-strings-in-a-array/\nfunction sort_numeric_strings(nums_str: string[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_749_sort_numeric_strings.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sort_numeric_strings;\n  assert.deepEqual(candidate([\"4\", \"12\", \"45\", \"7\", \"0\", \"100\", \"200\", \"-12\", \"-500\"]),[-500, -12, 0, 4, 7, 12, 45, 100, 200]);\n  assert.deepEqual(candidate([\"2\", \"3\", \"8\", \"4\", \"7\", \"9\", \"8\", \"2\", \"6\", \"5\", \"1\", \"6\", \"1\", \"2\", \"3\", \"4\", \"6\", \"9\", \"1\", \"2\"]),[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]);\n  assert.deepEqual(candidate([\"1\", \"3\", \"5\", \"7\", \"1\", \"3\", \"13\", \"15\", \"17\", \"5\", \"7 \", \"9\", \"1\", \"11\"]),[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_74_is_samepatterns",
+    "language": "ts",
+    "prompt": "//Write a function to check whether it follows the sequence given in the patterns array.\nfunction is_samepatterns(colors: string[], patterns: string[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_74_is_samepatterns.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_samepatterns;\n  assert.deepEqual(candidate([\"red\", \"green\", \"green\"], [\"a\", \"b\", \"b\"]),true);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\", \"b\"]),false);\n  assert.deepEqual(candidate([\"red\", \"green\", \"greenn\"], [\"a\", \"b\"]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_750_add_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to add the given array to the given array.\nfunction add_tuple(test_list: number[], test_tup: [number, number]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_750_add_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = add_tuple;\n  assert.deepEqual(candidate([5, 6, 7], [9, 10]),[5, 6, 7, 9, 10]);\n  assert.deepEqual(candidate([6, 7, 8], [10, 11]),[6, 7, 8, 10, 11]);\n  assert.deepEqual(candidate([7, 8, 9], [11, 12]),[7, 8, 9, 11, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_751_check_min_heap",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given array represents min heap or not. https://www.geeksforgeeks.org/how-to-check-if-a-given-array-represents-a-binary-heap/\nfunction check_min_heap(arr: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_751_check_min_heap.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_min_heap;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6]),true);\n  assert.deepEqual(candidate([2, 3, 4, 5, 10, 15]),true);\n  assert.deepEqual(candidate([2, 10, 4, 5, 3, 15]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_752_jacobsthal_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth jacobsthal number. https://www.geeksforgeeks.org/jacobsthal-and-jacobsthal-lucas-numbers/ 0, 1, 1, 3, 5, 11, 21, 43, 85, 171, 341, 683, 1365, 2731, ...\nfunction jacobsthal_num(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_752_jacobsthal_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = jacobsthal_num;\n  assert.deepEqual(candidate(5),11);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(4),5);\n  assert.deepEqual(candidate(13),2731);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_753_min_k",
+    "language": "ts",
+    "prompt": "//Write a function to find minimum k records from array array. https://www.geeksforgeeks.org/tsthon-find-minimum-k-records-from-array-array/ - in this case a verbatim cots of test cases\nfunction min_k(test_list: [string, number][], K: number): [string, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_753_min_k.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = min_k;\n  assert.deepEqual(candidate([[\"Manjeet\", 10], [\"Akshat\", 4], [\"Akash\", 2], [\"Nikhil\", 8]], 2),[[\"Akash\", 2], [\"Akshat\", 4]]);\n  assert.deepEqual(candidate([[\"Sanjeev\", 11], [\"Angat\", 5], [\"Akash\", 3], [\"Nepin\", 9]], 3),[[\"Akash\", 3], [\"Angat\", 5], [\"Nepin\", 9]]);\n  assert.deepEqual(candidate([[\"tanmay\", 14], [\"Amer\", 11], [\"Ayesha\", 9], [\"SKD\", 16]], 1),[[\"Ayesha\", 9]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_754_extract_index_list",
+    "language": "ts",
+    "prompt": "//We say that an element is common for arrays l1, l2, l3 if it appears in all three arrays under the same index. Write a function to find common elements from three arrays. The function should return an array.\nfunction extract_index_list(l1: number[], l2: number[], l3: number[]): any[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_754_extract_index_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = extract_index_list;\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 7]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 6, 5], [0, 1, 2, 3, 4, 6, 7]),[1, 6]);\n  assert.deepEqual(candidate([1, 1, 3, 4, 6, 5, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[1, 5]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 6, 6, 6], [0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4, 5, 7]),[]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_755_second_smallest",
+    "language": "ts",
+    "prompt": "//Write a function to find the second smallest number in an array.\nfunction second_smallest(numbers: number| number[]): number | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_755_second_smallest.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = second_smallest;\n  assert.deepEqual(candidate([1, 2, -8, -2, 0, -2]),-2);\n  assert.deepEqual(candidate([1, 1, -0.5, 0, 2, -2, -2]),-0.5);\n  assert.deepEqual(candidate([2, 2]),undefined);\n  assert.deepEqual(candidate([2, 2, 2]),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_756_text_match_zero_one",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by one or more 'b's. https://www.w3resource.com/tsthon-exercises/re/tsthon-re-exercise-3.php\nfunction text_match_zero_one(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_756_text_match_zero_one.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_zero_one;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"dsabbbba\"),true);\n  assert.deepEqual(candidate(\"asbbbba\"),false);\n  assert.deepEqual(candidate(\"abaaa\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_757_count_reverse_pairs",
+    "language": "ts",
+    "prompt": "//Write a function to count the pairs of reverse strings in the given string array. https://www.geeksforgeeks.org/tsthon-program-to-count-the-pairs-of-reverse-strings/\nfunction count_reverse_pairs(test_list: string[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_757_count_reverse_pairs.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_reverse_pairs;\n  assert.deepEqual(candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"]),2);\n  assert.deepEqual(candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]),1);\n  assert.deepEqual(candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_759_is_decimal",
+    "language": "ts",
+    "prompt": "//Write a function to check whether a given string is a decimal number with a precision of 2.\nfunction is_decimal(num: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_759_is_decimal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_decimal;\n  assert.deepEqual(candidate(\"123.11\"),true);\n  assert.deepEqual(candidate(\"e666.86\"),false);\n  assert.deepEqual(candidate(\"3.124587\"),false);\n  assert.deepEqual(candidate(\"1.11\"),true);\n  assert.deepEqual(candidate(\"1.1.11\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_75_find_tuples",
+    "language": "ts",
+    "prompt": "//Write a function to find arrays which have all elements divisible by k from the given array of arrays.\nfunction find_tuples(test_list: [number, number, number][], K: number): [number, number, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_75_find_tuples.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_tuples;\n  assert.deepEqual(candidate([[6, 24, 12], [7, 9, 6], [12, 18, 21]], 6),[[6, 24, 12]]);\n  assert.deepEqual(candidate([[5, 25, 30], [4, 2, 3], [7, 8, 9]], 5),[[5, 25, 30]]);\n  assert.deepEqual(candidate([[7, 9, 16], [8, 16, 4], [19, 17, 18]], 4),[[8, 16, 4]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_760_unique_Element",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether an array of numbers contains only one distinct element or not.\nfunction unique_Element(arr: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_760_unique_Element.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = unique_Element;\n  assert.deepEqual(candidate([1, 1, 1]),true);\n  assert.deepEqual(candidate([1, 2, 1, 2]),false);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_762_check_monthnumber_number",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given month number contains 30 days or not. Months are given as number from 1 to 12.\nfunction check_monthnumber_number(monthnum3: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_762_check_monthnumber_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_monthnumber_number;\n  assert.deepEqual(candidate(6),true);\n  assert.deepEqual(candidate(2),false);\n  assert.deepEqual(candidate(12),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_763_find_min_diff",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the minimum difference between any two elements in a given array. https://www.geeksforgeeks.org/find-minimum-difference-pair/\nfunction find_min_diff(arr: number[], n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_763_find_min_diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_min_diff;\n  assert.deepEqual(candidate([1, 5, 3, 19, 18, 25], 6),1);\n  assert.deepEqual(candidate([4, 3, 2, 6], 4),1);\n  assert.deepEqual(candidate([30, 5, 20, 9], 4),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_764_number_ctr",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count number of digits in a given string.\nfunction number_ctr(str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_764_number_ctr.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = number_ctr;\n  assert.deepEqual(candidate(\"program2bedone\"),1);\n  assert.deepEqual(candidate(\"3wonders\"),1);\n  assert.deepEqual(candidate(\"123\"),3);\n  assert.deepEqual(candidate(\"3wond-1ers2\"),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_765_is_polite",
+    "language": "ts",
+    "prompt": "//Write a function to find nth polite number. geeksforgeeks.org/n-th-polite-number/\nfunction is_polite(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_765_is_polite.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_polite;\n  assert.deepEqual(candidate(7),11);\n  assert.deepEqual(candidate(4),7);\n  assert.deepEqual(candidate(9),13);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_766_pair_wise",
+    "language": "ts",
+    "prompt": "//Write a function to return an array of all pairs of consecutive items in a given array.\nfunction pair_wise(l1: number[]): [number, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_766_pair_wise.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pair_wise;\n  assert.deepEqual(candidate([1, 1, 2, 3, 3, 4, 4, 5]),[[1, 1], [1, 2], [2, 3], [3, 3], [3, 4], [4, 4], [4, 5]]);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),[[1, 5], [5, 7], [7, 9], [9, 10]]);\n  assert.deepEqual(candidate([5, 1, 9, 7, 10]),[[5, 1], [1, 9], [9, 7], [7, 10]]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 10]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_767_get_pairs_count",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of pairs whose sum is equal to \u2018sum\u2019. The funtion gets as input an array of numbers and the sum,\nfunction get_pairs_count(arr: number[], sum: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_767_get_pairs_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_pairs_count;\n  assert.deepEqual(candidate([1, 1, 1, 1], 2),6);\n  assert.deepEqual(candidate([1, 5, 7, -1, 5], 6),3);\n  assert.deepEqual(candidate([1, -2, 3], 1),1);\n  assert.deepEqual(candidate([-1, -2, 3], -3),1);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_769_Diff",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to get the difference between two arrays.\nfunction Diff(li1: number[], li2: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_769_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Diff;\n  assert.deepEqual(candidate([10, 15, 20, 25, 30, 35, 40], [25, 40, 35]),[10, 20, 30, 15]);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5], [6, 7, 1]),[2, 3, 4, 5, 6, 7]);\n  assert.deepEqual(candidate([1, 2, 3], [6, 7, 1]),[2, 3, 6, 7]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_770_odd_num_sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of fourth power of first n odd natural numbers.\nfunction odd_num_sum(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_770_odd_num_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_num_sum;\n  assert.deepEqual(candidate(2),82);\n  assert.deepEqual(candidate(3),707);\n  assert.deepEqual(candidate(4),3108);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_771_check_expression",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given expression is balanced or not. https://www.geeksforgeeks.org/check-for-balanced-parentheses-in-an-expression/\nfunction check_expression(exp: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_771_check_expression.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_expression;\n  assert.deepEqual(candidate(\"{()}[{}]\"),true);\n  assert.deepEqual(candidate(\"{()}[{]\"),false);\n  assert.deepEqual(candidate(\"{()}[{}][]({})\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_772_remove_length",
+    "language": "ts",
+    "prompt": "//Write a function to remove all the words with k length in the given string.\nfunction remove_length(test_str: string, K: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_772_remove_length.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_length;\n  assert.deepEqual(candidate(\"The person is most value tet\", 3),\"person is most value\");\n  assert.deepEqual(candidate(\"If you told me about this ok\", 4),\"If you me about ok\");\n  assert.deepEqual(candidate(\"Forces of darkeness is come into the play\", 4),\"Forces of darkeness is the\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_773_occurance_substring",
+    "language": "ts",
+    "prompt": "//Write a function to find the occurrence and position of the substrings within a string. Return undefined if there is no match.\nfunction occurance_substring(text: string, pattern: string): [string, number, number] | undefined {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_773_occurance_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = occurance_substring;\n  assert.deepEqual(candidate(\"python programming, python language\", \"python\"),[\"python\", 0, 6]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"programming\"),[\"programming\", 7, 18]);\n  assert.deepEqual(candidate(\"python programming,programming language\", \"language\"),[\"language\", 31, 39]);\n  assert.deepEqual(candidate(\"c++ programming, c++ language\", \"python\"),undefined);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_775_odd_position",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether every odd index contains odd numbers of a given array.\nfunction odd_position(nums: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_775_odd_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_position;\n  assert.deepEqual(candidate([2, 1, 4, 3, 6, 7, 6, 3]),true);\n  assert.deepEqual(candidate([4, 1, 2]),true);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_776_count_vowels",
+    "language": "ts",
+    "prompt": "//Write a function to count those characters which have vowels as their neighbors in the given string.\nfunction count_vowels(test_str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_776_count_vowels.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_vowels;\n  assert.deepEqual(candidate(\"bestinstareels\"),7);\n  assert.deepEqual(candidate(\"partofthejourneyistheend\"),12);\n  assert.deepEqual(candidate(\"amazonprime\"),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_777_find_sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of non-repeated elements in a given array.\nfunction find_sum(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_777_find_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_sum;\n  assert.deepEqual(candidate([1, 2, 3, 1, 1, 4, 5, 6]),21);\n  assert.deepEqual(candidate([1, 10, 9, 4, 2, 10, 10, 45, 4]),71);\n  assert.deepEqual(candidate([12, 10, 9, 45, 2, 10, 10, 45, 10]),78);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_778_pack_consecutive_duplicates",
+    "language": "ts",
+    "prompt": "//Write a function to pack consecutive duplicates of a given array elements into subarrays.\nfunction pack_consecutive_duplicates(list1: any[]): any[][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_778_pack_consecutive_duplicates.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = pack_consecutive_duplicates;\n  assert.deepEqual(candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]),[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]);\n  assert.deepEqual(candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10]),[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]);\n  assert.deepEqual(candidate([\"a\", \"a\", \"b\", \"c\", \"d\", \"d\"]),[[\"a\", \"a\"], [\"b\"], [\"c\"], [\"d\", \"d\"]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_77_is_Diff",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find whether a number is divisible by 11.\nfunction is_Diff(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_77_is_Diff.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_Diff;\n  assert.deepEqual(candidate(12345),false);\n  assert.deepEqual(candidate(1212112),true);\n  assert.deepEqual(candidate(1212),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_780_find_combinations",
+    "language": "ts",
+    "prompt": "//Write a function to find the combinations of sums with arrays in the given array array. https://www.geeksforgeeks.org/tsthon-combinations-of-sum-with-arrays-in-array-array/\nfunction find_combinations(test_list: [number, number][]): [number, number][] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_780_find_combinations.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_combinations;\n  assert.deepEqual(candidate([[2, 4], [6, 7], [5, 1], [6, 10]]),[[8, 11], [7, 5], [8, 14], [11, 8], [12, 17], [11, 11]]);\n  assert.deepEqual(candidate([[3, 5], [7, 8], [6, 2], [7, 11]]),[[10, 13], [9, 7], [10, 16], [13, 10], [14, 19], [13, 13]]);\n  assert.deepEqual(candidate([[4, 6], [8, 9], [7, 3], [8, 12]]),[[12, 15], [11, 9], [12, 18], [15, 12], [16, 21], [15, 15]]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_781_count_divisors",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the count of divisors is even. https://www.w3resource.com/tsthon-exercises/basic/tsthon-basic-1-exercise-24.php\nfunction count_divisors(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_781_count_divisors.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_divisors;\n  assert.deepEqual(candidate(10),true);\n  assert.deepEqual(candidate(100),false);\n  assert.deepEqual(candidate(125),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_782_odd_length_sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of all odd length subarrays. https://www.geeksforgeeks.org/sum-of-all-odd-length-subarrays/\nfunction odd_length_sum(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_782_odd_length_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = odd_length_sum;\n  assert.deepEqual(candidate([1, 2, 4]),14);\n  assert.deepEqual(candidate([1, 2, 1, 2]),15);\n  assert.deepEqual(candidate([1, 7]),8);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_783_rgb_to_hsv",
+    "language": "ts",
+    "prompt": "//Write a function to convert rgb color to hsv color. https://www.geeksforgeeks.org/program-change-rgb-color-model-hsv-color-model/\nfunction rgb_to_hsv(r: number, g: number, b: number): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_783_rgb_to_hsv.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = rgb_to_hsv;\n  assert.deepEqual(candidate(255, 255, 255),[0.0, 0.0, 100.0]);\n  assert.deepEqual(candidate(0, 215, 0),[120.0, 100.0, 84.31372549019608]);\n  assert.deepEqual(candidate(10, 215, 110),[149.26829268292684, 95.34883720930233, 84.31372549019608]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_784_mul_even_odd",
+    "language": "ts",
+    "prompt": "//Write a function to find the product of first even and odd number of a given array.\nfunction mul_even_odd(list1: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_784_mul_even_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = mul_even_odd;\n  assert.deepEqual(candidate([1, 3, 5, 7, 4, 1, 6, 8]),4);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),2);\n  assert.deepEqual(candidate([1, 5, 7, 9, 10]),10);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_785_tuple_str_int",
+    "language": "ts",
+    "prompt": "//Write a function to convert array string to integer array.\nfunction tuple_str_int(test_str: string): [number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_785_tuple_str_int.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tuple_str_int;\n  assert.deepEqual(candidate(\"(7, 8, 9)\"),[7, 8, 9]);\n  assert.deepEqual(candidate(\"(1, 2, 3)\"),[1, 2, 3]);\n  assert.deepEqual(candidate(\"(4, 5, 6)\"),[4, 5, 6]);\n  assert.deepEqual(candidate(\"(7, 81, 19)\"),[7, 81, 19]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_786_right_insertion",
+    "language": "ts",
+    "prompt": "//Write a function to locate the right insertion point for a specified value in sorted order.\nfunction right_insertion(a: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_786_right_insertion.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = right_insertion;\n  assert.deepEqual(candidate([1, 2, 4, 5], 6),4);\n  assert.deepEqual(candidate([1, 2, 4, 5], 3),2);\n  assert.deepEqual(candidate([1, 2, 4, 5], 7),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_787_text_match_three",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an a followed by three 'b'.\nfunction text_match_three(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_787_text_match_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_match_three;\n  assert.deepEqual(candidate(\"ac\"),false);\n  assert.deepEqual(candidate(\"dc\"),false);\n  assert.deepEqual(candidate(\"abbbba\"),true);\n  assert.deepEqual(candidate(\"caacabbbba\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_788_new_tuple",
+    "language": "ts",
+    "prompt": "//Write a function to create a new array from the given string and array.\nfunction new_tuple(test_list: string[], test_str: string): [string, string, string] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_788_new_tuple.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = new_tuple;\n  assert.deepEqual(candidate([\"WEB\", \"is\"], \"best\"),[\"WEB\", \"is\", \"best\"]);\n  assert.deepEqual(candidate([\"We\", \"are\"], \"Developers\"),[\"We\", \"are\", \"Developers\"]);\n  assert.deepEqual(candidate([\"Part\", \"is\"], \"Wrong\"),[\"Part\", \"is\", \"Wrong\"]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_790_even_position",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether every even index contains even numbers of a given array.\nfunction even_position(nums: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_790_even_position.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = even_position;\n  assert.deepEqual(candidate([3, 2, 1]),false);\n  assert.deepEqual(candidate([1, 2, 3]),false);\n  assert.deepEqual(candidate([2, 1, 4]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_791_remove_nested",
+    "language": "ts",
+    "prompt": "//Write a function to remove arrays from the given array.\nfunction remove_nested(test_tup: any): [number, number, number, number] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_791_remove_nested.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_nested;\n  assert.deepEqual(candidate([1, 5, 7, [4, 6], 10]),[1, 5, 7, 10]);\n  assert.deepEqual(candidate([2, 6, 8, [5, 7], 11]),[2, 6, 8, 11]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], 12]),[3, 7, 9, 12]);\n  assert.deepEqual(candidate([3, 7, 9, [6, 8], [5, 12], 12]),[3, 7, 9, 12]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_792_count_list",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of arrays in a given number of arrays.\nfunction count_list(input_list: number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_792_count_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_list;\n  assert.deepEqual(candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]),4);\n  assert.deepEqual(candidate([[1, 2], [2, 3], [4, 5]]),3);\n  assert.deepEqual(candidate([[1, 0], [2, 0]]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_793_last",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the last position of an element in a sorted array.\nfunction last(arr: number[], x: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_793_last.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = last;\n  assert.deepEqual(candidate([1, 2, 3], 1),0);\n  assert.deepEqual(candidate([1, 1, 1, 2, 3, 4], 1),2);\n  assert.deepEqual(candidate([2, 3, 2, 3, 6, 8, 9], 3),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_794_text_starta_endb",
+    "language": "ts",
+    "prompt": "//Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nfunction text_starta_endb(text: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_794_text_starta_endb.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = text_starta_endb;\n  assert.deepEqual(candidate(\"aabbbb\"),true);\n  assert.deepEqual(candidate(\"aabAbbbc\"),false);\n  assert.deepEqual(candidate(\"accddbbjjj\"),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_796_return_sum",
+    "language": "ts",
+    "prompt": "//Write function to find the sum of all items in the given object.\nfunction return_sum(dict: {[key: string]: number}): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_796_return_sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = return_sum;\n  assert.deepEqual(candidate({\"a\": 100, \"b\": 200, \"c\": 300}),600);\n  assert.deepEqual(candidate({\"a\": 25, \"b\": 18, \"c\": 45}),88);\n  assert.deepEqual(candidate({\"a\": 36, \"b\": 39, \"c\": 49}),124);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_797_sum_in_range",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of all odd natural numbers within the range l and r.\nfunction sum_in_range(l: number, r: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_797_sum_in_range.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sum_in_range;\n  assert.deepEqual(candidate(2, 5),8);\n  assert.deepEqual(candidate(5, 7),12);\n  assert.deepEqual(candidate(7, 13),40);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_798__sum",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the sum of an array.\nfunction _sum(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_798__sum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = _sum;\n  assert.deepEqual(candidate([1, 2, 3]),6);\n  assert.deepEqual(candidate([15, 12, 13, 10]),50);\n  assert.deepEqual(candidate([0, 1, 2]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_799_left_rotate",
+    "language": "ts",
+    "prompt": "//Write a function to that rotate left bits by d bits a given number. We assume that the number is 32 bit.\nfunction left_rotate(n: number, d: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_799_left_rotate.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = left_rotate;\n  assert.deepEqual(candidate(16, 2),64);\n  assert.deepEqual(candidate(10, 2),40);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(99, 3),792);\n  assert.deepEqual(candidate(1, 3),8);\n  assert.deepEqual(candidate(5, 3),40);\n  assert.deepEqual(candidate(29, 3),232);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_79_word_len",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to check whether the length of the word is odd or not.\nfunction word_len(s: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_79_word_len.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = word_len;\n  assert.deepEqual(candidate(\"Hadoop\"),false);\n  assert.deepEqual(candidate(\"great\"),true);\n  assert.deepEqual(candidate(\"structure\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_800_remove_all_spaces",
+    "language": "ts",
+    "prompt": "//Write a function to remove all whitespaces from a string.\nfunction remove_all_spaces(text: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_800_remove_all_spaces.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = remove_all_spaces;\n  assert.deepEqual(candidate(\"python  program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"python   programming    language\"),\"pythonprogramminglanguage\");\n  assert.deepEqual(candidate(\"python                     program\"),\"pythonprogram\");\n  assert.deepEqual(candidate(\"   python                     program\"),\"pythonprogram\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_801_test_three_equal",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of equal numbers from three given integers.\nfunction test_three_equal(x: number, y: number, z: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_801_test_three_equal.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = test_three_equal;\n  assert.deepEqual(candidate(1, 1, 1),3);\n  assert.deepEqual(candidate(-1, -2, -3),0);\n  assert.deepEqual(candidate(1, 2, 2),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_802_count_rotation",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to count the number of rotations required to generate a sorted array. https://www.geeksforgeeks.org/count-of-rotations-required-to-generate-a-sorted-array/\nfunction count_rotation(arr: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_802_count_rotation.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = count_rotation;\n  assert.deepEqual(candidate([3, 2, 1]),1);\n  assert.deepEqual(candidate([4, 5, 1, 2, 3]),2);\n  assert.deepEqual(candidate([7, 8, 9, 1, 2, 3]),3);\n  assert.deepEqual(candidate([1, 2, 3]),0);\n  assert.deepEqual(candidate([1, 3, 2]),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_803_is_perfect_square",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is a perfect square or not. https://www.geeksforgeeks.org/check-if-given-number-is-perfect-square-in-cpp/\nfunction is_perfect_square(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_803_is_perfect_square.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_perfect_square;\n  assert.deepEqual(candidate(10),false);\n  assert.deepEqual(candidate(36),true);\n  assert.deepEqual(candidate(14),false);\n  assert.deepEqual(candidate(196),true);\n  assert.deepEqual(candidate(125),false);\n  assert.deepEqual(candidate(15625),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_804_is_product_even",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the product of numbers in an array is even or not.\nfunction is_product_even(arr: number[]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_804_is_product_even.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_product_even;\n  assert.deepEqual(candidate([1, 2, 3]),true);\n  assert.deepEqual(candidate([1, 2, 1, 4]),true);\n  assert.deepEqual(candidate([1, 1]),false);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_805_max_sum_list",
+    "language": "ts",
+    "prompt": "//Write a function that returns the array in an array of arrays whose sum of elements is the highest.\nfunction max_sum_list(lists: number[][]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_805_max_sum_list.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_sum_list;\n  assert.deepEqual(candidate([[1, 2, 3], [4, 5, 6], [10, 11, 12], [7, 8, 9]]),[10, 11, 12]);\n  assert.deepEqual(candidate([[3, 2, 1], [6, 5, 4], [12, 11, 10]]),[12, 11, 10]);\n  assert.deepEqual(candidate([[2, 3, 1]]),[2, 3, 1]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_806_max_run_uppercase",
+    "language": "ts",
+    "prompt": "//Write a function to find maximum run of uppercase characters in the given string.\nfunction max_run_uppercase(test_str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_806_max_run_uppercase.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = max_run_uppercase;\n  assert.deepEqual(candidate(\"GeMKSForGERksISBESt\"),5);\n  assert.deepEqual(candidate(\"PrECIOusMOVemENTSYT\"),6);\n  assert.deepEqual(candidate(\"GooGLEFluTTER\"),4);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_807_first_odd",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the first odd number in a given array of numbers.\nfunction first_odd(nums: number[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_807_first_odd.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = first_odd;\n  assert.deepEqual(candidate([1, 3, 5]),1);\n  assert.deepEqual(candidate([2, 4, 1, 3]),1);\n  assert.deepEqual(candidate([8, 9, 1]),9);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_808_check_K",
+    "language": "ts",
+    "prompt": "//Write a function to check if the given arrays contain the k or not.\nfunction check_K(test_tup: number[], K: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_808_check_K.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_K;\n  assert.deepEqual(candidate([10, 4, 5, 6, 8], 6),true);\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6], 7),false);\n  assert.deepEqual(candidate([7, 8, 9, 44, 11, 12], 11),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_809_check_smaller",
+    "language": "ts",
+    "prompt": "//Write a function to check if each element of second array is smaller than its corresponding element in the first array.\nfunction check_smaller(test_tup1: [number, number, number], test_tup2: [number, number, number]): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_809_check_smaller.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = check_smaller;\n  assert.deepEqual(candidate([1, 2, 3], [2, 3, 4]),false);\n  assert.deepEqual(candidate([4, 5, 6], [3, 4, 5]),true);\n  assert.deepEqual(candidate([11, 12, 13], [10, 11, 12]),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_80_tetrahedral_number",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth tetrahedral number.\nfunction tetrahedral_number(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_80_tetrahedral_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = tetrahedral_number;\n  assert.deepEqual(candidate(5),35);\n  assert.deepEqual(candidate(6),56);\n  assert.deepEqual(candidate(7),84);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_83_get_Char",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the character made by adding the ASCII value of all the characters of the given string modulo 26.\nfunction get_Char(strr: string): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_83_get_Char.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = get_Char;\n  assert.deepEqual(candidate(\"abc\"),\"f\");\n  assert.deepEqual(candidate(\"gfg\"),\"t\");\n  assert.deepEqual(candidate(\"ab\"),\"c\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_84_sequence",
+    "language": "ts",
+    "prompt": "//Write a function to find the nth number in the newman conway sequence.\nfunction sequence(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_84_sequence.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = sequence;\n  assert.deepEqual(candidate(10),6);\n  assert.deepEqual(candidate(2),1);\n  assert.deepEqual(candidate(3),2);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_86_centered_hexagonal_number",
+    "language": "ts",
+    "prompt": "//Write a function to find nth centered hexagonal number.\nfunction centered_hexagonal_number(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_86_centered_hexagonal_number.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = centered_hexagonal_number;\n  assert.deepEqual(candidate(10),271);\n  assert.deepEqual(candidate(2),7);\n  assert.deepEqual(candidate(9),217);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_87_merge_dictionaries_three",
+    "language": "ts",
+    "prompt": "//Write a function to merge three dictionaries into a single object.\nfunction merge_dictionaries_three(dict1: {[key: string]: string}, dict2: {[key: string]: string}, dict3: {[key: string]: string}): {[key: string]: string} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_87_merge_dictionaries_three.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = merge_dictionaries_three;\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\"}),{\"B\": \"Black\", \"R\": \"Red\", \"P\": \"Pink\", \"G\": \"Green\", \"W\": \"White\", \"O\": \"Orange\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"G\": \"Green\", \"W\": \"White\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}),{\"W\": \"White\", \"P\": \"Pink\", \"B\": \"Black\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\"});\n  assert.deepEqual(candidate({\"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\"}, {\"L\": \"lavender\", \"B\": \"Blue\"}, {\"G\": \"Green\", \"W\": \"White\"}),{\"B\": \"Black\", \"P\": \"Pink\", \"R\": \"Red\", \"G\": \"Green\", \"L\": \"lavender\", \"W\": \"White\"});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_88_freq_count",
+    "language": "ts",
+    "prompt": "//Write a function to get the frequency of all the elements in an array, returned as an object.\nfunction freq_count(list1: number[]): {[key: number]: number} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_88_freq_count.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = freq_count;\n  assert.deepEqual(candidate([10, 10, 10, 10, 20, 20, 20, 20, 40, 40, 50, 50, 30]),{10: 4, 20: 4, 40: 2, 50: 2, 30: 1});\n  assert.deepEqual(candidate([1, 2, 3, 4, 3, 2, 4, 1, 3, 1, 4]),{1: 3, 2: 2, 3: 3, 4: 3});\n  assert.deepEqual(candidate([5, 6, 7, 4, 9, 10, 4, 5, 6, 7, 9, 5]),{10: 1, 5: 3, 6: 2, 7: 2, 4: 2, 9: 2});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_89_closest_num",
+    "language": "ts",
+    "prompt": "//Write a function to find the closest smaller number than n.\nfunction closest_num(N: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_89_closest_num.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = closest_num;\n  assert.deepEqual(candidate(11),10);\n  assert.deepEqual(candidate(7),6);\n  assert.deepEqual(candidate(12),11);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_8_square_nums",
+    "language": "ts",
+    "prompt": "//Write a function to find squares of individual elements in an array.\nfunction square_nums(nums: number[]): number[] {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_8_square_nums.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = square_nums;\n  assert.deepEqual(candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]);\n  assert.deepEqual(candidate([10, 20, 30]),[100, 400, 900]);\n  assert.deepEqual(candidate([12, 15]),[144, 225]);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_90_len_log",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the length of the longest word.\nfunction len_log(list1: string[]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_90_len_log.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = len_log;\n  assert.deepEqual(candidate([\"python\", \"PHP\", \"bigdata\"]),7);\n  assert.deepEqual(candidate([\"a\", \"ab\", \"abc\"]),3);\n  assert.deepEqual(candidate([\"small\", \"big\", \"tall\"]),5);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_91_find_substring",
+    "language": "ts",
+    "prompt": "//Write a function to check if a string is present as a substring in a given array of string values.\nfunction find_substring(str1: string[], sub_str: string): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_91_find_substring.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_substring;\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ack\"),true);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"abc\"),false);\n  assert.deepEqual(candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"], \"ange\"),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_92_is_undulating",
+    "language": "ts",
+    "prompt": "//Write a function to check whether the given number is undulating or not.\nfunction is_undulating(n: number): boolean {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_92_is_undulating.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = is_undulating;\n  assert.deepEqual(candidate(1212121),true);\n  assert.deepEqual(candidate(1991),false);\n  assert.deepEqual(candidate(121),true);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_93_power",
+    "language": "ts",
+    "prompt": "//Write a function to calculate the value of 'a' to the power 'b'.\nfunction power(a: number, b: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_93_power.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = power;\n  assert.deepEqual(candidate(3, 4),81);\n  assert.deepEqual(candidate(2, 3),8);\n  assert.deepEqual(candidate(5, 5),3125);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_94_index_minimum",
+    "language": "ts",
+    "prompt": "//Given an array of arrays, write a function that returns the first value of the array with the smallest second value.\nfunction index_minimum(test_list: [string, number][]): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_94_index_minimum.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = index_minimum;\n  assert.deepEqual(candidate([[\"Rash\", 143], [\"Manjeet\", 200], [\"Varsha\", 100]]),\"Varsha\");\n  assert.deepEqual(candidate([[\"Yash\", 185], [\"Dawood\", 125], [\"Sanya\", 175]]),\"Dawood\");\n  assert.deepEqual(candidate([[\"Sai\", 345], [\"Salman\", 145], [\"Ayesha\", 96]]),\"Ayesha\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_95_Find_Min_Length",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the length of the smallest array in an array of arrays.\nfunction Find_Min_Length(lst: number[][]): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_95_Find_Min_Length.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = Find_Min_Length;\n  assert.deepEqual(candidate([[1], [1, 2]]),1);\n  assert.deepEqual(candidate([[1, 2], [1, 2, 3], [1, 2, 3, 4]]),2);\n  assert.deepEqual(candidate([[3, 3, 3], [4, 4, 4, 4]]),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_96_divisor",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the number of divisors of a given integer.\nfunction divisor(n: number): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_96_divisor.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = divisor;\n  assert.deepEqual(candidate(15),4);\n  assert.deepEqual(candidate(12),6);\n  assert.deepEqual(candidate(9),3);\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_97_frequency_lists",
+    "language": "ts",
+    "prompt": "//Write a function to find frequency of each element in a flattened array of arrays, returned in an object.\nfunction frequency_lists(list1: number[][]): {[key: number]: number} {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_97_frequency_lists.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = frequency_lists;\n  assert.deepEqual(candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]]),{1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1});\n  assert.deepEqual(candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]),{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1});\n  assert.deepEqual(candidate([[20, 30, 40, 17], [18, 16, 14, 13], [10, 20, 30, 40]]),{20: 2, 30: 2, 40: 2, 17: 1, 18: 1, 16: 1, 14: 1, 13: 1, 10: 1});\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_99_decimal_to_binary",
+    "language": "ts",
+    "prompt": "//Write a function to convert the given decimal number to its binary equivalent, represented as a string with no leading zeros.\nfunction decimal_to_binary(n: number): string {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_99_decimal_to_binary.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = decimal_to_binary;\n  assert.deepEqual(candidate(8),\"1000\");\n  assert.deepEqual(candidate(18),\"10010\");\n  assert.deepEqual(candidate(7),\"111\");\n}\n\ntest();",
+    "stop_tokens": [
+      "\nfunction ",
+      "\n/*",
+      "\n//",
+      "\nclass"
+    ]
+  },
+  {
+    "name": "mbpp_9_find_Rotations",
+    "language": "ts",
+    "prompt": "//Write a tsthon function to find the minimum number of rotations (greater than 0) required to get the same string.\nfunction find_Rotations(str: string): number {\n",
+    "doctests": "transform",
+    "original": "/Users/evgeniizh/PycharmProjects/MultiPL-E/datasets/../datasets/mbpp-typed/mbpp_9_find_Rotations.py",
+    "prompt_terminology": "reworded",
+    "tests": "declare var require: any;\nconst assert = require('node:assert');\n\n\nfunction test() {\n  let candidate = find_Rotations;\n  assert.deepEqual(candidate(\"aaaa\"),1);\n  assert.deepEqual(candidate(\"ab\"),2);\n  assert.deepEqual(candidate(\"abc\"),3);\n}\n\ntest();",
     "stop_tokens": [
       "\nfunction ",
       "\n/*",


### PR DESCRIPTION
Currently, there is some non-determinism in prompt preparation due to the use of unsorted containers. This generates large diffs for no reason. This PR sorts all such places (that I could find), resulting in deterministic generation (i.e., running `all_prepare_prompts` twice results in no diff).